### PR TITLE
Add a Levanter serving backend to marin-serve

### DIFF
--- a/lib/levanter/src/levanter/data/passthrough_tokenizer.py
+++ b/lib/levanter/src/levanter/data/passthrough_tokenizer.py
@@ -77,6 +77,9 @@ class PassthroughTokenizer:
     def chat_template(self) -> str | None:
         return None
 
+    def with_chat_template(self, chat_template: str) -> "PassthroughTokenizer":
+        raise ValueError("PassthroughTokenizer does not support chat templates")
+
     def apply_chat_template(
         self,
         conversation: list[dict[str, str]],

--- a/lib/levanter/src/levanter/inference/openai.py
+++ b/lib/levanter/src/levanter/inference/openai.py
@@ -26,10 +26,14 @@ import jax.random as jrandom
 import numpy as np
 import uvicorn
 from fastapi import FastAPI, HTTPException
-from openai.types import Completion, CompletionUsage
-from openai.types.chat import ChatCompletion
+from fastapi.responses import StreamingResponse
+from openai.types import Completion, CompletionUsage, Model
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from openai.types.chat.chat_completion import Choice as ChatCompletionChoice
 from openai.types.chat.chat_completion import ChoiceLogprobs
+from openai.types.chat.chat_completion_chunk import Choice as ChatCompletionChunkChoice
+from openai.types.chat.chat_completion_chunk import ChoiceDelta
+from openai.types.chat.chat_completion_chunk import ChoiceLogprobs as ChunkChoiceLogprobs
 from openai.types.chat.chat_completion_message import ChatCompletionMessage
 from openai.types.chat.chat_completion_token_logprob import ChatCompletionTokenLogprob
 from openai.types.completion_choice import CompletionChoice, Logprobs
@@ -55,6 +59,9 @@ from levanter.trainer import TrainerConfig
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_MODEL_NAME = "levanter"
+
+
 @dataclass
 class InferenceServerConfig:
     """Configuration for OpenAI-compatible inference server."""
@@ -64,6 +71,9 @@ class InferenceServerConfig:
 
     # Inference service/memory layout configuration
     service: InferenceEngineConfig = field(default_factory=lambda: InferenceEngineConfig(4096))
+
+    model_name: str = DEFAULT_MODEL_NAME
+    """Model id this server advertises from ``/v1/models``."""
 
     # Default generation parameters for API
     temperature: float = 0.7
@@ -417,6 +427,59 @@ def _health_check() -> dict:
     return {"status": "healthy", "service": "levanter-inference"}
 
 
+def _sse_event(payload: str) -> str:
+    return f"data: {payload}\n\n"
+
+
+def _chat_completion_events(completion: ChatCompletion) -> collections.abc.Iterator[str]:
+    """Render a finished chat completion as an OpenAI server-sent-event stream.
+
+    The engine returns each generation whole, so a choice is delivered as one content chunk
+    followed by a chunk carrying its finish reason: the events are well-formed but not
+    incremental, and a client sees the whole completion in the first delta it receives.
+    """
+    for choice in completion.choices:
+        logprobs = (
+            ChunkChoiceLogprobs(content=choice.logprobs.content, refusal=choice.logprobs.refusal)
+            if choice.logprobs is not None
+            else None
+        )
+        content = ChatCompletionChunkChoice(
+            index=choice.index,
+            delta=ChoiceDelta(role="assistant", content=choice.message.content),
+            logprobs=logprobs,
+        )
+        finish = ChatCompletionChunkChoice(index=choice.index, delta=ChoiceDelta(), finish_reason=choice.finish_reason)
+        for chunk_choice in (content, finish):
+            chunk = ChatCompletionChunk(
+                id=completion.id,
+                object="chat.completion.chunk",
+                created=completion.created,
+                model=completion.model,
+                choices=[chunk_choice],
+            )
+            yield _sse_event(chunk.model_dump_json())
+    yield _sse_event("[DONE]")
+
+
+def _completion_events(completion: Completion) -> collections.abc.Iterator[str]:
+    """Render a finished text completion as an OpenAI server-sent-event stream.
+
+    The streaming and non-streaming completion payloads share a shape, so each choice rides
+    its own event. As with chat, the events are well-formed but not incremental.
+    """
+    for choice in completion.choices:
+        chunk = Completion(
+            id=completion.id,
+            object="text_completion",
+            created=completion.created,
+            model=completion.model,
+            choices=[choice],
+        )
+        yield _sse_event(chunk.model_dump_json())
+    yield _sse_event("[DONE]")
+
+
 def _decoded_token_pieces(tokenizer: MarinTokenizer, token_ids: List[int]) -> List[str]:
     return [tokenizer.decode([token_id], skip_special_tokens=False) for token_id in token_ids]
 
@@ -596,16 +659,23 @@ async def _create_completion(ctx: InferenceContext, request: CompletionRequest) 
 
 
 def _compute_tokens(messages: list[ChatMessage], tokenizer: MarinTokenizer) -> List[int]:
-    try:
-        dict_messages = [msg.model_dump(exclude_none=True) for msg in messages]
-        result = tokenizer.apply_chat_template(dict_messages, tokenize=True, add_generation_prompt=True)
-        assert isinstance(result, list)
-        return result
-    except Exception as e:
-        # Fallback: simple concatenation if template fails
-        logger.warning(f"Chat template failed, using fallback: {e}", exc_info=True)
-        prompt_text = "\n".join([f"{msg.role}: {msg.content}" for msg in messages])
-        return tokenizer.encode(prompt_text, add_special_tokens=True)
+    """Encode a conversation with the tokenizer's chat template.
+
+    A model with no chat template cannot represent a conversation, so a chat request against one
+    is rejected rather than rendered into some invented format the model never saw. Base and
+    midtrained checkpoints are served through ``/v1/completions`` instead.
+    """
+    if tokenizer.chat_template is None:
+        raise HTTPException(
+            status_code=400,
+            detail="This model has no chat template; use /v1/completions, or serve it with a chat template.",
+        )
+    dict_messages = [msg.model_dump(exclude_none=True) for msg in messages]
+    # return_dict=False pins the token ids to a flat list; tokenizers otherwise hand back a
+    # BatchEncoding here, which is the shape the rest of this module cannot use.
+    result = tokenizer.apply_chat_template(dict_messages, tokenize=True, add_generation_prompt=True, return_dict=False)
+    assert isinstance(result, list)
+    return result
 
 
 async def _fetch_tokens(ctx: InferenceContext, request: TokensRequest) -> TokensResponse:
@@ -618,6 +688,8 @@ async def _fetch_tokens(ctx: InferenceContext, request: TokensRequest) -> Tokens
 
         return TokensResponse(results=results)
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("Error in tokenization.", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
@@ -699,6 +771,8 @@ async def _create_chat_completion(ctx: InferenceContext, request: ChatCompletion
         )
         return response
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error in chat completion: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
@@ -751,19 +825,33 @@ class InferenceServer:
     def _create_app(inference_context: InferenceContext) -> FastAPI:
         """Create and configure the FastAPI application."""
         app = FastAPI(title="Levanter Inference Service", version="1.0.0")
+        model_name = inference_context.config.model_name
 
         # Register routes with thin wrappers that call helper functions
         @app.get("/health")
         async def health_check():
             return _health_check()
 
+        @app.get("/v1/models")
+        async def list_models() -> dict:
+            model = Model(id=model_name, object="model", created=int(time.time()), owned_by="levanter")
+            return {"object": "list", "data": [model.model_dump(mode="json")]}
+
+        # A streaming request returns a StreamingResponse, which FastAPI passes through
+        # untouched; `response_model` still describes the non-streaming body.
         @app.post("/v1/chat/completions", response_model=ChatCompletion)
-        async def create_chat_completion(request: ChatCompletionRequest) -> ChatCompletion:
-            return await _create_chat_completion(inference_context, request)
+        async def create_chat_completion(request: ChatCompletionRequest):
+            completion = await _create_chat_completion(inference_context, request)
+            if not request.stream:
+                return completion
+            return StreamingResponse(_chat_completion_events(completion), media_type="text/event-stream")
 
         @app.post("/v1/completions", response_model=Completion)
-        async def create_completion(request: CompletionRequest) -> Completion:
-            return await _create_completion(inference_context, request)
+        async def create_completion(request: CompletionRequest):
+            completion = await _create_completion(inference_context, request)
+            if not request.stream:
+                return completion
+            return StreamingResponse(_completion_events(completion), media_type="text/event-stream")
 
         @app.post("/v1/tokens", response_model=TokensResponse)
         async def fetch_tokens(request: TokensRequest) -> TokensResponse:

--- a/lib/levanter/src/levanter/tokenizers.py
+++ b/lib/levanter/src/levanter/tokenizers.py
@@ -118,6 +118,10 @@ class MarinTokenizer(Protocol):
     @property
     def chat_template(self) -> str | None: ...
 
+    def with_chat_template(self, chat_template: str) -> "MarinTokenizer":
+        """Return a copy of this tokenizer that renders ``chat_template``."""
+        ...
+
     def apply_chat_template(
         self,
         conversation: list[dict[str, str]],
@@ -572,6 +576,9 @@ class HfMarinTokenizer:
     @property
     def all_special_ids(self) -> list[int]:
         return self._all_special_ids
+
+    def with_chat_template(self, chat_template: str) -> "HfMarinTokenizer":
+        return dataclasses.replace(self, _chat_template=chat_template)
 
     def apply_chat_template(
         self,

--- a/lib/levanter/tests/inference/test_inference_server.py
+++ b/lib/levanter/tests/inference/test_inference_server.py
@@ -1,6 +1,7 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -53,9 +54,18 @@ def baby_llama_config():
             max_queued_tokens=32,
             hbm_utilization=0.1,
         ),
+        model_name="timinar/baby-llama-58m",
         temperature=0.7,
         seed=42,
     )
+
+
+# baby-llama is a base checkpoint and ships no chat template, so the chat tests below bring one:
+# the server refuses to invent a conversation format a model was never trained on.
+BABY_LLAMA_CHAT_TEMPLATE = (
+    "{% for message in messages %}{{ message['role'] }}: {{ message['content'] }}\n{% endfor %}"
+    "{% if add_generation_prompt %}assistant: {% endif %}"
+)
 
 
 @pytest.fixture(scope="module")
@@ -64,6 +74,7 @@ def loaded_model(trainer_config):
     hf_checkpoint = "timinar/baby-llama-58m"
     model_config = LlamaConfig()
     tokenizer = load_tokenizer(hf_checkpoint)
+    tokenizer.chat_template = BABY_LLAMA_CHAT_TEMPLATE
 
     with trainer_config.use_device_mesh(), hax.axis_mapping(trainer_config.compute_axis_mapping):
         converter = HFCheckpointConverter(
@@ -178,8 +189,103 @@ def test_endpoints_exist(test_client):
     _, server = test_client
     routes = [route.path for route in server.app.routes]
     assert "/health" in routes
+    assert "/v1/models" in routes
     assert "/v1/completions" in routes
     assert "/v1/chat/completions" in routes
+
+
+def test_models_endpoint_reports_the_configured_model(test_client):
+    """A client discovering the server (OpenAI SDK, dashboards) reads the id it should send back."""
+    client, server = test_client
+
+    response = client.get("/v1/models")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["object"] == "list"
+    assert [model["id"] for model in payload["data"]] == [server.config.model_name]
+
+
+def test_chat_completion_without_a_chat_template_is_rejected(test_client, monkeypatch):
+    """A model with no chat template cannot represent a conversation, so chat requests are refused.
+
+    Rendering one anyway would feed the model a prompt format it was never trained on and return
+    it as a normal completion, leaving callers unable to tell a chat model from a base one.
+    """
+    client, server = test_client
+    monkeypatch.setattr(server.inference_context.tokenizer, "chat_template", None)
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={"model": "timinar/baby-llama-58m", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 4},
+    )
+
+    assert response.status_code == 400
+    assert "no chat template" in response.json()["detail"]
+
+
+def _sse_payloads(body: str) -> list[str]:
+    """The `data:` payloads of an SSE body, in order."""
+    return [line[len("data:") :].strip() for line in body.splitlines() if line.startswith("data:")]
+
+
+@pytest.mark.slow
+def test_streaming_chat_completion_carries_the_same_content(test_client):
+    """`stream: true` must produce a parseable SSE stream, not a bare JSON body.
+
+    The engine generates whole completions, so the deltas are not incremental; what a client
+    needs is that the events are well-formed, terminated by [DONE], and add up to the content the
+    non-streaming call returns for the same request.
+    """
+    client, _ = test_client
+    request = {
+        "model": "timinar/baby-llama-58m",
+        "messages": [{"role": "user", "content": "The quick brown fox"}],
+        "max_tokens": 8,
+        "temperature": 0.0,
+        "seed": 42,
+    }
+
+    streamed = client.post("/v1/chat/completions", json={**request, "stream": True})
+    assert streamed.status_code == 200
+    assert streamed.headers["content-type"].startswith("text/event-stream")
+
+    payloads = _sse_payloads(streamed.text)
+    assert payloads[-1] == "[DONE]"
+    chunks = [json.loads(payload) for payload in payloads[:-1]]
+    assert all(chunk["object"] == "chat.completion.chunk" for chunk in chunks)
+    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+    content = "".join(chunk["choices"][0]["delta"].get("content") or "" for chunk in chunks)
+
+    blocking = client.post("/v1/chat/completions", json=request)
+    assert blocking.status_code == 200
+    assert content == ChatCompletion.model_validate(blocking.json()).choices[0].message.content
+
+
+@pytest.mark.slow
+def test_streaming_completion_carries_the_same_text(test_client):
+    client, _ = test_client
+    request = {
+        "model": "timinar/baby-llama-58m",
+        "prompt": "The quick brown fox",
+        "max_tokens": 8,
+        "temperature": 0.0,
+        "seed": 42,
+    }
+
+    streamed = client.post("/v1/completions", json={**request, "stream": True})
+    assert streamed.status_code == 200
+    assert streamed.headers["content-type"].startswith("text/event-stream")
+
+    payloads = _sse_payloads(streamed.text)
+    assert payloads[-1] == "[DONE]"
+    chunks = [json.loads(payload) for payload in payloads[:-1]]
+    assert all(chunk["object"] == "text_completion" for chunk in chunks)
+    text = "".join(chunk["choices"][0]["text"] for chunk in chunks)
+
+    blocking = client.post("/v1/completions", json=request)
+    assert blocking.status_code == 200
+    assert text == Completion.model_validate(blocking.json()).choices[0].text
 
 
 class _OpenAITestTokenizer:

--- a/lib/marin/src/marin/inference/quick_serve.py
+++ b/lib/marin/src/marin/inference/quick_serve.py
@@ -1,27 +1,22 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Quick single-model vLLM inference server for an Iris TPU or GPU slice.
+"""Quick single-model inference server for an Iris TPU or GPU slice.
 
-A quick-serve job boots one native vLLM server on a single-host slice, fronts it
-with a browser dashboard + OpenAI-compatible reverse proxy, and registers the
-dashboard as an Iris endpoint so it is reachable through the controller proxy. The
-job shuts itself down after a wall-clock timeout so a forgotten server does not sit
-on a slice indefinitely.
+A quick-serve job boots one serving backend on a single-host slice, fronts it with a browser
+dashboard + OpenAI-compatible reverse proxy, and registers the dashboard as an Iris endpoint so it
+is reachable through the controller proxy. The job shuts itself down after a wall-clock timeout so
+a forgotten server does not sit on a slice indefinitely.
 
-On the TPU path vLLM is the TPU-vLLM stack installed in the workspace venv; on the
-GPU path stock CUDA vLLM is provisioned in an isolated uv-tool env (see
-:func:`select_vllm_launcher`). This module holds the serving config and the in-job
-entrypoint that boots vLLM on the slice; the ``marin-serve`` launcher CLI is a
-separate module.
+Which stack answers requests is the backend's business (:mod:`marin.inference.serving_backend`):
+vLLM as a subprocess, or Levanter's inference engine in-process. This module holds the serving
+config and the in-job entrypoint; the ``marin-serve`` launcher CLI is a separate module.
 """
 
 import json
 import logging
-import socket
-import tempfile
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import requests
 from iris.client import iris_ctx
@@ -34,27 +29,17 @@ from rigging.filesystem import StoragePath
 from rigging.log_setup import configure_logging
 from transformers import AutoConfig
 
-from marin.evaluation.evaluators.evaluator import ModelConfig
 from marin.inference.quick_serve_dashboard import (
     ServingInfo,
     bind_serving_socket,
     build_dashboard_app,
     serve_app_background,
 )
-from marin.inference.vllm_server import (
-    IsolatedCudaVllm,
-    IsolatedTpuVllm,
-    VllmEnvironment,
-    VllmLauncher,
-    WorkspaceVllm,
-    _is_object_store_path,
-)
+from marin.inference.serving_backend import OPENAI_API_SUFFIX, ModelSpec, ServedModel, ServingBackend
+from marin.inference.vllm_server import _is_object_store_path
 
 logger = logging.getLogger(__name__)
 
-# vLLM's OpenAI server mounts its routes under /v1; the dashboard reverse-proxy
-# forwards verbatim paths, so we keep the upstream root separately.
-_VLLM_API_SUFFIX = "/v1"
 # Cadence of the wall-clock timeout / liveness loop.
 _TIMEOUT_POLL_SECONDS = 30
 # GCS prefix (under the region-local TTL temp bucket) for mirrored HF snapshots.
@@ -72,6 +57,9 @@ class QuickServeConfig:
     """HF model id (e.g. ``Qwen/Qwen3-0.6B``) or object-store path (``gs://...``)."""
     endpoint_name: str
     """Iris endpoint name registered for the dashboard (a leading ``/`` is verbatim)."""
+    backend: ServingBackend
+    """The stack that serves the model: :class:`~marin.inference.serving_backend.VllmBackend` or
+    :class:`~marin.inference.serving_backend.LevanterBackend`, carrying its own knobs."""
     tpu_type: str | None = None
     """Single-host TPU slice type, e.g. ``v6e-8`` or ``v5litepod-8``. Set on the TPU path;
     ``None`` on the GPU path, where ``gpu_type``/``gpu_count`` describe the slice instead."""
@@ -80,39 +68,24 @@ class QuickServeConfig:
     gpu_count: int | None = None
     """GPU count per node when serving on a GPU slice. Its presence selects the GPU path:
     ``num_chips`` is taken directly from it rather than a TPU topology lookup."""
-    vllm_version: str | None = None
-    """When set, provision stock CUDA vLLM at this exact version in an isolated uv-tool
-    env (see :class:`IsolatedCudaVllm`) — the GPU serving path. ``None`` serves from the
-    vLLM already on the venv/image ``PATH``: the workspace TPU-vLLM stack, or a prebuilt
-    ``--task-image``."""
-    tpu_vllm_ref: str | None = None
-    """When set (with ``tpu_inference_ref``), provision Marin's forked TPU vLLM in an
-    isolated uv-tool env (see :class:`IsolatedTpuVllm`) — the checkout-free TPU serving
-    path. ``None`` serves the TPU vLLM from the workspace venv (the in-checkout path)."""
-    tpu_inference_ref: str | None = None
-    """``uvx --with`` requirement for the tpu-inference fork; paired with ``tpu_vllm_ref``."""
     access: int = EndpointAccess.ENDPOINT_ACCESS_PRIVATE
     """Proxy access mode. PRIVATE (cluster identity only) or LINK (a scoped capability
     URL, minted CLI-side, that anyone holding the link can call off-cluster)."""
     port_name: str = "http"
     dtype: str = "bfloat16"
     max_model_len: int | None = None
-    """vLLM max sequence length. ``None`` lets vLLM derive it from the model config,
-    which keeps models with a clamped RoPE window (e.g. Delphi's 4k) bootable."""
+    """Maximum sequence length. ``None`` lets vLLM derive it from the model config, which keeps
+    models with a clamped RoPE window (e.g. Delphi's 4k) bootable; the Levanter backend, which
+    must size its KV cache up front, falls back to its own default window."""
     tensor_parallel_size: int | None = None
     """``None`` auto-selects the largest power-of-two TP that divides the model's
     attention-head count and fits the slice's chip count."""
-    max_num_batched_tokens: int = 512
-    """Prefill batch size. Kept modest because the TPU paged-attention kernel's
-    on-chip (VMEM) scratch grows with this; large values overflow VMEM at compile."""
     chat_template_content: str | None = None
-    """Inline Jinja chat template forwarded to vLLM; resolved from a path/URL by the CLI."""
+    """Inline Jinja chat template; resolved from a path/URL by the CLI."""
     cache_ttl_days: int = 14
     """Mirror HF models to a region-local GCS cache with this lifecycle TTL so repeat
     serves skip the HuggingFace download. ``0`` disables caching; ignored for gs:// paths."""
     timeout_hours: float = 24.0
-    vllm_startup_timeout_seconds: int = 1800
-    extra_vllm_args: tuple[str, ...] = field(default_factory=tuple)
 
     @property
     def accelerator_label(self) -> str:
@@ -125,23 +98,14 @@ class QuickServeConfig:
             return f"{self.gpu_type}x{self.gpu_count}" if self.gpu_type else f"gpux{self.gpu_count}"
         return self.tpu_type or "unknown"
 
-
-def select_vllm_launcher(config: QuickServeConfig) -> VllmLauncher:
-    """Pick how to launch vLLM: an isolated CUDA/TPU vLLM, or the workspace ``vllm``.
-
-    - ``vllm_version`` set → stock CUDA vLLM in a throwaway uv-tool env (GPU path).
-    - ``tpu_vllm_ref`` set → Marin's forked TPU vLLM in a throwaway uv-tool env
-      (checkout-free TPU path).
-    - neither → the vLLM already on the active venv/image ``PATH``: the workspace
-      TPU-vLLM stack, or a prebuilt ``--task-image`` that ships its own vLLM.
-    """
-    if config.vllm_version:
-        return IsolatedCudaVllm(version=config.vllm_version)
-    if config.tpu_vllm_ref:
-        if not config.tpu_inference_ref:
-            raise ValueError("tpu_vllm_ref requires tpu_inference_ref (the tpu-inference fork).")
-        return IsolatedTpuVllm(vllm_ref=config.tpu_vllm_ref, tpu_inference_ref=config.tpu_inference_ref)
-    return WorkspaceVllm()
+    @property
+    def num_chips(self) -> int:
+        """Chips on this slice: the GPU count, or the TPU type's per-VM chip count."""
+        if self.gpu_count is not None:
+            return self.gpu_count
+        if self.tpu_type is None:
+            raise ValueError("QuickServeConfig requires tpu_type on the TPU path (or gpu_count on the GPU path).")
+        return get_tpu_topology(self.tpu_type).chips_per_vm
 
 
 def select_tensor_parallel_size(
@@ -152,9 +116,10 @@ def select_tensor_parallel_size(
     """Pick the largest power-of-two tensor-parallel size valid for this model+slice.
 
     vLLM requires ``num_attention_heads`` to be divisible by the TP size and the
-    KV-head count to be compatible (divides TP or is divisible by it). TPU slices
-    expose power-of-two chip counts, so we search powers of two up to ``num_chips``.
-    Models with odd or prime head counts fall back to TP 1.
+    KV-head count to be compatible (divides TP or is divisible by it); Levanter shards the
+    same head axis across its model mesh axis. TPU slices expose power-of-two chip counts, so we
+    search powers of two up to ``num_chips``. Models with odd or prime head counts fall back to
+    TP 1.
     """
     if num_chips < 1:
         return 1
@@ -194,7 +159,7 @@ def _read_model_config_dict(model: str) -> dict:
 
 
 def resolve_model_path(model: str, cache_ttl_days: int) -> str:
-    """Resolve ``model`` to a path vLLM can load, mirroring HF repos to a TTL'd GCS cache.
+    """Resolve ``model`` to a path the backend can load, mirroring HF repos to a TTL'd GCS cache.
 
     HuggingFace repo ids are mirrored once to a region-local GCS cache under a distributed
     lock, so a later serve of the same model reads the snapshot from same-region GCS instead
@@ -203,15 +168,15 @@ def resolve_model_path(model: str, cache_ttl_days: int) -> str:
     return resolve_cached_model_path(model, cache_ttl_days=cache_ttl_days, cache_prefix=_MODEL_CACHE_PREFIX)
 
 
-def detect_chat_support(vllm_base_url: str, model_id: str) -> bool:
+def detect_chat_support(base_url: str, model_id: str) -> bool:
     """Probe whether the served model accepts ``/v1/chat/completions``.
 
-    Base/midtrained checkpoints ship no chat template, so vLLM rejects chat
+    Base/midtrained checkpoints ship no chat template, so the backend rejects chat
     requests; the dashboard defaults such models to completion mode.
     """
     try:
         response = requests.post(
-            f"{vllm_base_url}{_VLLM_API_SUFFIX}/chat/completions",
+            f"{base_url}{OPENAI_API_SUFFIX}/chat/completions",
             json={"model": model_id, "messages": [{"role": "user", "content": "ping"}], "max_tokens": 1},
             timeout=60,
         )
@@ -221,52 +186,52 @@ def detect_chat_support(vllm_base_url: str, model_id: str) -> bool:
     return response.status_code == 200
 
 
-def _write_chat_template(content: str | None) -> str | None:
-    if content is None:
-        return None
-    with tempfile.NamedTemporaryFile("w", suffix=".jinja", prefix="quick_serve_chat_", delete=False) as handle:
-        handle.write(content)
-        return handle.name
+def build_model_spec(config: QuickServeConfig, model_path: str) -> ModelSpec:
+    """Resolve the slice-and-model inputs the backend needs, inferring TP when unset."""
+    num_chips = config.num_chips
+    if config.tensor_parallel_size is not None:
+        tensor_parallel_size = config.tensor_parallel_size
+        logger.info(
+            "quick-serve model=%s accelerator=%s chips=%d tensor_parallel_size=%d (user-specified)",
+            config.model,
+            config.accelerator_label,
+            num_chips,
+            tensor_parallel_size,
+        )
+    else:
+        num_attention_heads, num_key_value_heads = read_attention_heads(model_path)
+        tensor_parallel_size = select_tensor_parallel_size(num_attention_heads, num_chips, num_key_value_heads)
+        logger.info(
+            "quick-serve model=%s accelerator=%s chips=%d heads=%d kv_heads=%s -> tensor_parallel_size=%d",
+            config.model,
+            config.accelerator_label,
+            num_chips,
+            num_attention_heads,
+            num_key_value_heads,
+            tensor_parallel_size,
+        )
+    return ModelSpec(
+        model=config.model,
+        model_path=model_path,
+        num_chips=num_chips,
+        tensor_parallel_size=tensor_parallel_size,
+        dtype=config.dtype,
+        max_model_len=config.max_model_len,
+        chat_template_content=config.chat_template_content,
+    )
 
 
-def _reserve_localhost_port() -> int:
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
-
-
-def _build_vllm_extra_args(
-    config: QuickServeConfig, tensor_parallel_size: int, chat_template_path: str | None
-) -> list[str]:
-    # Pin the served model name to the requested model so the OpenAI API id stays
-    # the friendly HF id regardless of whether the backing path is local or gs://.
-    args = [
-        "--tensor-parallel-size",
-        str(tensor_parallel_size),
-        "--dtype",
-        config.dtype,
-        "--served-model-name",
-        config.model,
-    ]
-    if chat_template_path is not None:
-        args += ["--chat-template", chat_template_path]
-    args += list(config.extra_vllm_args)
-    return args
-
-
-def _block_until_timeout(env: VllmEnvironment, timeout_hours: float) -> None:
-    """Block until the timeout elapses, failing early if vLLM dies."""
+def _block_until_timeout(served: ServedModel, timeout_hours: float) -> None:
+    """Block until the timeout elapses, failing early if the backend dies."""
     deadline = time.monotonic() + timeout_hours * 3600
     while time.monotonic() < deadline:
-        server = env.vllm_server
-        if server is not None and server.process.poll() is not None:
-            raise RuntimeError(f"vLLM server exited unexpectedly with code {server.process.returncode}.")
+        served.check_alive()
         time.sleep(_TIMEOUT_POLL_SECONDS)
     logger.info("quick-serve reached its %.1fh timeout; shutting down.", timeout_hours)
 
 
 def serve_in_job(config: QuickServeConfig) -> None:
-    """Iris job entrypoint: boot vLLM, serve the dashboard, register the endpoint, block."""
+    """Iris job entrypoint: boot the backend, serve the dashboard, register the endpoint, block."""
     configure_logging()
     job_info = get_job_info()
     if job_info is None:
@@ -274,8 +239,8 @@ def serve_in_job(config: QuickServeConfig) -> None:
     ctx = iris_ctx()
     port = ctx.get_port(config.port_name)
     advertise_host = job_info.advertise_host
-    # Claim the dashboard's port now, before vLLM launches: Iris' named-port range
-    # overlaps the OS ephemeral range, so vLLM's internal sockets could otherwise
+    # Claim the dashboard's port now, before the backend launches: Iris' named-port range
+    # overlaps the OS ephemeral range, so the backend's internal sockets could otherwise
     # squat it. Binding here reserves it for us until uvicorn takes over. Bind only
     # the advertised interface (the address the controller proxy connects to), not
     # all interfaces.
@@ -286,85 +251,44 @@ def serve_in_job(config: QuickServeConfig) -> None:
     serving_port = serving_socket.getsockname()[1]
 
     model_path = resolve_model_path(config.model, config.cache_ttl_days)
+    spec = build_model_spec(config, model_path)
     accelerator = config.accelerator_label
-    if config.gpu_count is not None:
-        # GPU slices expose their chip count directly; vLLM auto-detects CUDA.
-        num_chips = config.gpu_count
-    else:
-        if config.tpu_type is None:
-            raise ValueError("QuickServeConfig requires tpu_type on the TPU path (or gpu_count on the GPU path).")
-        num_chips = get_tpu_topology(config.tpu_type).chips_per_vm
-    if config.tensor_parallel_size is not None:
-        tensor_parallel_size = config.tensor_parallel_size
-        logger.info(
-            "quick-serve model=%s accelerator=%s chips=%d tensor_parallel_size=%d (user-specified)",
-            config.model,
-            accelerator,
-            num_chips,
-            tensor_parallel_size,
-        )
-    else:
-        num_attention_heads, num_key_value_heads = read_attention_heads(model_path)
-        tensor_parallel_size = select_tensor_parallel_size(num_attention_heads, num_chips, num_key_value_heads)
-        logger.info(
-            "quick-serve model=%s accelerator=%s chips=%d heads=%d kv_heads=%s -> tensor_parallel_size=%d",
-            config.model,
-            accelerator,
-            num_chips,
-            num_attention_heads,
-            num_key_value_heads,
-            tensor_parallel_size,
-        )
 
-    chat_template_path = _write_chat_template(config.chat_template_content)
-    engine_kwargs: dict[str, object] = {"max_num_batched_tokens": config.max_num_batched_tokens}
-    if config.max_model_len is not None:
-        engine_kwargs["max_model_len"] = config.max_model_len
-    vllm_model = ModelConfig(name="quick-serve", path=model_path, engine_kwargs=engine_kwargs)
-    extra_args = _build_vllm_extra_args(config, tensor_parallel_size, chat_template_path)
-    internal_port = _reserve_localhost_port()
-
-    with VllmEnvironment(
-        vllm_model,
-        host="127.0.0.1",
-        port=internal_port,
-        timeout_seconds=config.vllm_startup_timeout_seconds,
-        extra_args=extra_args,
-        launcher=select_vllm_launcher(config),
-    ) as env:
-        if env.model_id is None:
-            raise RuntimeError("vLLM server did not report a model id.")
-        model_id = env.model_id
-        upstream_base_url = env.server_url.removesuffix(_VLLM_API_SUFFIX)
-        has_chat_template = config.chat_template_content is not None or detect_chat_support(upstream_base_url, model_id)
+    with config.backend.serve(spec) as served:
+        has_chat_template = config.chat_template_content is not None or detect_chat_support(
+            served.base_url, served.model_id
+        )
         info = ServingInfo(
-            model=model_id,
-            tensor_parallel_size=tensor_parallel_size,
+            model=served.model_id,
+            backend=config.backend.name,
+            tensor_parallel_size=spec.tensor_parallel_size,
             max_model_len=config.max_model_len,
             dtype=config.dtype,
             has_chat_template=has_chat_template,
             tpu_type=accelerator,
             endpoint=config.endpoint_name,
         )
-        app = build_dashboard_app(upstream_base_url=upstream_base_url, model_id=model_id, info=info)
+        app = build_dashboard_app(upstream_base_url=served.base_url, model_id=served.model_id, info=info)
         with serve_app_background(app, serving_socket):
             address = f"http://{advertise_host}:{serving_port}"
             metadata = {
-                "model": str(model_id),
+                "model": str(served.model_id),
                 "kind": "quick-serve",
+                "backend": config.backend.name,
                 "accelerator": accelerator,
-                "tensor_parallel_size": str(tensor_parallel_size),
+                "tensor_parallel_size": str(spec.tensor_parallel_size),
             }
             endpoint_id = ctx.registry.register(config.endpoint_name, address, metadata, access=config.access)
             logger.info(
-                "Registered quick-serve endpoint name=%s address=%s id=%s proxy_path=%s",
+                "Registered quick-serve endpoint name=%s backend=%s address=%s id=%s proxy_path=%s",
                 config.endpoint_name,
+                config.backend.name,
                 address,
                 endpoint_id,
                 proxy_path(config.endpoint_name),
             )
             try:
-                _block_until_timeout(env, config.timeout_hours)
+                _block_until_timeout(served, config.timeout_hours)
             finally:
                 try:
                     ctx.registry.unregister(endpoint_id)

--- a/lib/marin/src/marin/inference/quick_serve_cli.py
+++ b/lib/marin/src/marin/inference/quick_serve_cli.py
@@ -3,28 +3,31 @@
 
 """``marin-serve`` — one-liner to serve an HF model on an Iris TPU or GPU slice.
 
-Submits a single Iris job that boots vLLM on a single-host TPU or GPU slice and
-registers a browser dashboard + OpenAI-compatible endpoint through the controller
-proxy. The job stops itself after ``--timeout-hours`` so a forgotten server frees
-its slice.
+Submits a single Iris job that boots a serving backend on a single-host TPU or GPU slice and
+registers a browser dashboard + OpenAI-compatible endpoint through the controller proxy. The job
+stops itself after ``--timeout-hours`` so a forgotten server frees its slice.
 
 Examples::
 
     marin-serve Qwen/Qwen3-0.6B --cluster marin --tpu v6e-8
+    marin-serve Qwen/Qwen3-0.6B --cluster marin --tpu v6e-8 --backend levanter
     marin-serve gs://my-bucket/ckpt --tpu v5litepod-8 --chat-template delphi_v0.jinja2
     marin-serve Qwen/Qwen3-0.6B --cluster marin --gpu H100x8 --target-cluster cw-rno2a
 
-``--gpu`` and ``--tpu`` are mutually exclusive (the default is TPU ``v6e-8``). The GPU
-path provisions stock CUDA vLLM in an isolated ``uv`` tool env at ``--vllm-version``.
+``--backend`` picks the stack that answers requests: ``vllm`` (default) runs vLLM as a
+subprocess, ``levanter`` runs Levanter's inference engine in-process on the slice's chips. Both
+expose the same OpenAI API through the same dashboard, so serving one model under each and
+pointing one client at both endpoints compares them directly.
 
-Inside a marin checkout the TPU path serves vLLM from the workspace lock. Outside one it
-serves from an isolated ``uv`` tool env: ``marin-core`` installed from PyPI plus Marin's
-forked TPU vLLM. ``--isolated-vllm`` selects that env inside a checkout too.
+``--gpu`` and ``--tpu`` are mutually exclusive (the default is TPU ``v6e-8``). On the vLLM GPU
+path stock CUDA vLLM is provisioned in an isolated ``uv`` tool env at ``--vllm-version``; on the
+vLLM TPU path, a marin checkout serves vLLM from the workspace lock, and outside a checkout (or
+with ``--isolated-vllm``) from an isolated ``uv`` tool env holding Marin's forked TPU vLLM. The
+Levanter backend needs no vLLM at all: it serves from the worker venv's JAX.
 
-``--cluster`` selects the controller to submit to; ``--target-cluster`` federates the job
-to a named peer. The slice's tensor-parallel size and (for clamped-RoPE models) max
-sequence length are inferred automatically; override with ``--tensor-parallel-size`` /
-``--max-model-len``.
+``--cluster`` selects the controller to submit to; ``--target-cluster`` federates the job to a
+named peer. The slice's tensor-parallel size and (for clamped-RoPE models) max sequence length are
+inferred automatically; override with ``--tensor-parallel-size`` / ``--max-model-len``.
 """
 
 import contextlib
@@ -34,6 +37,7 @@ import re
 import shlex
 import time
 import uuid
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 import click
@@ -53,11 +57,13 @@ from iris.cluster.types import (
     is_job_finished,
     tpu_device,
 )
+from iris.rpc import job_pb2
 from rigging.config_discovery import find_project_root
 from rigging.connect import capability_path, proxy_path
 from rigging.timing import Duration
 
 from marin.inference.quick_serve import QuickServeConfig, serve_in_job
+from marin.inference.serving_backend import LevanterBackend, ServingBackend, VllmBackend
 from marin.inference.tpu_vllm_pins import tpu_inference_fork_ref, vllm_fork_ref
 from marin.inference.vllm_server import WORKER_PYTHON_VERSION
 
@@ -67,11 +73,110 @@ _WORKER_EXTRAS = ("tpu", "vllm")
 # subprocess; CUDA vLLM is provisioned in an isolated uv-tool env (not the workspace
 # lock), so the worker venv needs no accelerator extra at all — base Marin suffices.
 _GPU_WORKER_EXTRAS: tuple[str, ...] = ()
+# Levanter serves in-process, so the worker venv needs the accelerator's JAX and nothing else:
+# marin-core already depends on marin-levanter[serve] for the FastAPI/uvicorn surface.
+_LEVANTER_TPU_EXTRAS = ("tpu",)
+_LEVANTER_GPU_EXTRAS = ("gpu",)
 # Pinned CUDA vLLM for the GPU path, overridable with --vllm-version. Stock PyPI vLLM
 # (>=0.25) targets torch 2.11 / CUDA 13; provisioned per-job via uvx, so a bump is just
 # this string with no workspace re-lock.
 DEFAULT_CUDA_VLLM_VERSION = "0.25.0"
 _ENDPOINT_READY_POLL_SECONDS = 5.0
+
+# Options that only mean something to one backend, by Click parameter name. Passing one to the
+# other backend is a mistake worth failing on, but several carry non-None defaults, so only a
+# value the user actually typed counts (hence the ParameterSource check in _reject_foreign_flags).
+_VLLM_ONLY_OPTIONS = {
+    "vllm_version": "--vllm-version",
+    "vllm_args": "--vllm-arg",
+    "isolated_vllm": "--isolated-vllm",
+    "max_num_batched_tokens": "--max-num-batched-tokens",
+}
+_LEVANTER_ONLY_OPTIONS = {
+    "max_seqs": "--max-seqs",
+    "page_size": "--page-size",
+    "hbm_utilization": "--hbm-utilization",
+}
+
+
+def _reject_foreign_flags(backend: str, options: dict[str, str]) -> None:
+    """Fail if the user typed an option belonging to a backend they did not select."""
+    ctx = click.get_current_context()
+    typed = [flag for name, flag in options.items() if ctx.get_parameter_source(name) == ParameterSource.COMMANDLINE]
+    if typed:
+        raise click.ClickException(f"{', '.join(typed)} cannot be used with --backend {backend}.")
+
+
+@dataclass(frozen=True)
+class ServingPlan:
+    """How to serve on this slice: which backend, on what device, in which worker environment."""
+
+    backend: ServingBackend
+    device: job_pb2.DeviceConfig
+    worker_extras: tuple[str, ...]
+    tpu_type: str | None = None
+    gpu_type: str | None = None
+    gpu_count: int | None = None
+
+
+def _resolve_serving_plan(
+    *,
+    backend: str,
+    tpu: str,
+    gpu: str | None,
+    in_checkout: bool,
+    isolated_vllm: bool,
+    task_image: str | None,
+    cuda_vllm_version: str,
+    vllm: VllmBackend,
+    levanter: LevanterBackend,
+    extras: tuple[str, ...],
+) -> ServingPlan:
+    """Pick the backend, the slice's device, and the extras the worker venv needs to run it.
+
+    ``vllm`` and ``levanter`` arrive carrying the knobs the user set; what is decided here is which
+    of them serves, and where its runtime comes from. Levanter computes in the worker venv, so that
+    venv carries the accelerator's JAX and nothing else; vLLM runs as a subprocess, either from the
+    workspace lock or from an isolated uv-tool env.
+    """
+    if gpu is not None:
+        if not in_checkout:
+            raise click.ClickException(
+                "marin-serve --gpu serves from a marin checkout (the worker runs marin-core from "
+                "it); none was found. Run marin-serve from inside a marin checkout."
+            )
+        try:
+            gpu_type, gpu_count = parse_gpu_spec(gpu)
+        except ValueError as exc:
+            raise click.ClickException(str(exc)) from exc
+        device = gpu_device(gpu_type, gpu_count)
+        if backend == "levanter":
+            return ServingPlan(
+                levanter, device, (*_LEVANTER_GPU_EXTRAS, *extras), gpu_type=gpu_type, gpu_count=gpu_count
+            )
+        # Provision CUDA vLLM in an isolated uv-tool env unless the operator brought a prebuilt
+        # --task-image, which is expected to ship its own vLLM on PATH.
+        if task_image is None:
+            vllm = replace(vllm, vllm_version=cuda_vllm_version)
+        return ServingPlan(vllm, device, (*_GPU_WORKER_EXTRAS, *extras), gpu_type=gpu_type, gpu_count=gpu_count)
+
+    topology = get_tpu_topology(tpu)
+    if topology.vm_count != 1:
+        raise click.ClickException(
+            f"{tpu!r} is a multi-host slice (vm_count={topology.vm_count}); quick-serve supports "
+            f"single-host slices only (e.g. v6e-8, v5litepod-8)."
+        )
+    device = tpu_device(tpu)
+    if backend == "levanter":
+        return ServingPlan(levanter, device, (*_LEVANTER_TPU_EXTRAS, *extras), tpu_type=tpu)
+    if isolated_vllm or not in_checkout:
+        # Provision the forked TPU vLLM from an isolated uvx env when there is no checkout to build
+        # it from (or when explicitly requested); otherwise serve the workspace TPU-vLLM from the
+        # lock. The worker venv always needs the `tpu` extra for the serving glue's jax/libtpu; the
+        # `vllm` extra is only for the in-workspace build.
+        vllm = replace(vllm, tpu_vllm_ref=vllm_fork_ref(), tpu_inference_ref=tpu_inference_fork_ref())
+        return ServingPlan(vllm, device, ("tpu", *extras), tpu_type=tpu)
+    return ServingPlan(vllm, device, (*_WORKER_EXTRAS, *extras), tpu_type=tpu)
 
 
 def _default_job_name(model: str) -> str:
@@ -130,7 +235,7 @@ def _wait_for_endpoint(client: IrisClient, job: Job, endpoint_name: str, timeout
         time.sleep(_ENDPOINT_READY_POLL_SECONDS)
     raise click.ClickException(
         f"Timed out after {timeout_seconds:.0f}s waiting for {endpoint_name!r}. "
-        "The job is still booting vLLM; re-check later via the Iris dashboard."
+        "The job is still booting the model; re-check later via the Iris dashboard."
     )
 
 
@@ -164,6 +269,12 @@ def _mint_and_print_capability_url(
 
 @click.command(context_settings={"show_default": True})
 @click.argument("model")
+@click.option(
+    "--backend",
+    type=click.Choice(["vllm", "levanter"]),
+    default="vllm",
+    help="Serving stack: vllm (subprocess) or levanter (in-process JAX inference engine).",
+)
 @click.option("--cluster", default="marin", envvar="IRIS_CLUSTER", help="Named iris cluster to submit to.")
 @click.option(
     "--controller", default=None, envvar="IRIS_CONTROLLER", help="Pre-tunneled controller URL (overrides --cluster)."
@@ -189,12 +300,28 @@ def _mint_and_print_capability_url(
 @click.option("--name", default=None, help="Iris job name (default: derived from the model).")
 @click.option("--endpoint-name", default=None, help="Endpoint name to register (default: /serve/<job-name>).")
 @click.option("--chat-template", default=None, help="Jinja chat template: local file path or http(s) URL.")
-@click.option("--max-model-len", type=int, default=None, help="vLLM max sequence length (default: derived from model).")
 @click.option(
-    "--max-num-batched-tokens", type=int, default=512, help="Prefill batch size; small values avoid TPU VMEM overflow."
+    "--max-model-len",
+    type=int,
+    default=None,
+    help="Max sequence length (vLLM derives it from the model when unset; levanter serves a 4k window).",
+)
+@click.option(
+    "--max-num-batched-tokens",
+    type=int,
+    default=512,
+    help="vLLM backend: prefill batch size; small values avoid TPU VMEM overflow.",
+)
+@click.option("--max-seqs", type=int, default=16, help="Levanter backend: concurrent sequence slots.")
+@click.option("--page-size", type=int, default=128, help="Levanter backend: tokens per KV-cache page.")
+@click.option(
+    "--hbm-utilization",
+    type=float,
+    default=0.8,
+    help="Levanter backend: fraction of device HBM the KV cache may claim.",
 )
 @click.option("--tensor-parallel-size", type=int, default=None, help="TP size (default: auto from heads + chips).")
-@click.option("--dtype", default="bfloat16", help="vLLM dtype.")
+@click.option("--dtype", default="bfloat16", help="Weight/compute dtype.")
 @click.option("--cache-ttl-days", type=int, default=14, help="Mirror HF models to a TTL'd GCS cache (0 disables).")
 @click.option(
     "--no-cache", is_flag=True, default=False, help="Skip the GCS model cache; always download from HuggingFace."
@@ -205,7 +332,7 @@ def _mint_and_print_capability_url(
     type=click.Choice(["private", "link"]),
     default="private",
     help="Proxy access. private: cluster identity only. link: mints a scoped capability "
-    "URL anyone with the link can call off-cluster (printed once vLLM is ready).",
+    "URL anyone with the link can call off-cluster (printed once the model is ready).",
 )
 @click.option("--region", default=None, help="Comma-separated region(s) to pin the slice to.")
 @click.option("--cpu", type=float, default=8.0)
@@ -236,10 +363,12 @@ def _mint_and_print_capability_url(
     "--wait-timeout",
     type=float,
     default=1800.0,
-    help="Seconds allowed for vLLM to boot; bounds both the client wait and the in-job startup.",
+    help="Seconds the client waits for the endpoint to register; on --backend vllm it also bounds "
+    "the in-job server boot.",
 )
 def main(
     model: str,
+    backend: str,
     cluster: str | None,
     controller: str | None,
     tpu: str,
@@ -251,6 +380,9 @@ def main(
     chat_template: str | None,
     max_model_len: int | None,
     max_num_batched_tokens: int,
+    max_seqs: int,
+    page_size: int,
+    hbm_utilization: float,
     tensor_parallel_size: int | None,
     dtype: str,
     cache_ttl_days: int,
@@ -278,6 +410,7 @@ def main(
     tpu_from_cli = click.get_current_context().get_parameter_source("tpu") == ParameterSource.COMMANDLINE
     if gpu is not None and tpu_from_cli:
         raise click.ClickException("--gpu and --tpu are mutually exclusive; pass only one.")
+    _reject_foreign_flags(backend, _VLLM_ONLY_OPTIONS if backend == "levanter" else _LEVANTER_ONLY_OPTIONS)
 
     job_name = name or _default_job_name(model)
     if "/" in job_name:
@@ -293,75 +426,49 @@ def main(
 
     endpoint_access = EndpointAccess.Value(f"ENDPOINT_ACCESS_{access.upper()}")
 
-    tpu_vllm_ref: str | None = None
-    tpu_inference_ref: str | None = None
-    if gpu is not None:
-        if workspace_dir is None:
-            raise click.ClickException(
-                "marin-serve --gpu serves from a marin checkout (the worker runs marin-core from "
-                "it); none was found. Run marin-serve from inside a marin checkout."
-            )
-        try:
-            gpu_variant, gpu_count = parse_gpu_spec(gpu)
-        except ValueError as exc:
-            raise click.ClickException(str(exc)) from exc
-        tpu_type: str | None = None
-        device = gpu_device(gpu_variant, gpu_count)
-        worker_extras = (*_GPU_WORKER_EXTRAS, *extras)
-        # Provision CUDA vLLM in an isolated uv-tool env unless the operator brought a
-        # prebuilt --task-image, which is expected to ship its own vLLM on PATH.
-        cuda_vllm_version = None if task_image is not None else vllm_version
-    else:
-        topology = get_tpu_topology(tpu)
-        if topology.vm_count != 1:
-            raise click.ClickException(
-                f"{tpu!r} is a multi-host slice (vm_count={topology.vm_count}); quick-serve supports "
-                f"single-host slices only (e.g. v6e-8, v5litepod-8)."
-            )
-        gpu_variant, gpu_count = None, None
-        tpu_type = tpu
-        device = tpu_device(tpu)
-        cuda_vllm_version = None
-        # Provision the forked TPU vLLM from an isolated uvx env when there is no checkout
-        # to build it from (or when explicitly requested); otherwise serve the workspace
-        # TPU-vLLM from the lock. The worker venv always needs the `tpu` extra for the
-        # serving glue's jax/libtpu; the `vllm` extra is only for the in-workspace build.
-        if isolated_vllm or workspace_dir is None:
-            tpu_vllm_ref = vllm_fork_ref()
-            tpu_inference_ref = tpu_inference_fork_ref()
-            worker_extras = ("tpu", *extras)
-        else:
-            worker_extras = (*_WORKER_EXTRAS, *extras)
+    plan = _resolve_serving_plan(
+        backend=backend,
+        tpu=tpu,
+        gpu=gpu,
+        in_checkout=workspace_dir is not None,
+        isolated_vllm=isolated_vllm,
+        task_image=task_image,
+        cuda_vllm_version=vllm_version,
+        vllm=VllmBackend(
+            max_num_batched_tokens=max_num_batched_tokens,
+            # The in-job vLLM boot budget must cover the same window the client waits, so raising
+            # --wait-timeout for a slow-booting model actually takes effect.
+            startup_timeout_seconds=int(wait_timeout),
+            extra_args=tuple(vllm_args),
+        ),
+        levanter=LevanterBackend(max_seqs=max_seqs, page_size=page_size, hbm_utilization=hbm_utilization),
+        extras=extras,
+    )
 
     config = QuickServeConfig(
         model=model,
         endpoint_name=endpoint,
-        tpu_type=tpu_type,
-        gpu_type=gpu_variant,
-        gpu_count=gpu_count,
+        backend=plan.backend,
+        tpu_type=plan.tpu_type,
+        gpu_type=plan.gpu_type,
+        gpu_count=plan.gpu_count,
         access=endpoint_access,
         dtype=dtype,
         max_model_len=max_model_len,
-        max_num_batched_tokens=max_num_batched_tokens,
         tensor_parallel_size=tensor_parallel_size,
         chat_template_content=_resolve_chat_template(chat_template),
         cache_ttl_days=0 if no_cache else cache_ttl_days,
         timeout_hours=timeout_hours,
-        # The in-job vLLM startup budget must cover the same window the client waits,
-        # so raising --wait-timeout for a slow-booting model actually takes effect.
-        vllm_startup_timeout_seconds=int(wait_timeout),
-        extra_vllm_args=tuple(vllm_args),
-        vllm_version=cuda_vllm_version,
-        tpu_vllm_ref=tpu_vllm_ref,
-        tpu_inference_ref=tpu_inference_ref,
     )
 
     # No checkout to bundle → install marin-core from PyPI on the worker (checkout-free
     # TPU path); otherwise sync the bundled workspace with the resolved extras.
     if workspace_dir is None:
-        environment = EnvironmentSpec(setup_scripts=[_checkout_free_setup_script(_marin_core_version(), worker_extras)])
+        environment = EnvironmentSpec(
+            setup_scripts=[_checkout_free_setup_script(_marin_core_version(), plan.worker_extras)]
+        )
     else:
-        environment = EnvironmentSpec(extras=worker_extras)
+        environment = EnvironmentSpec(extras=plan.worker_extras)
 
     constraints: list[Constraint] = []
     if region:
@@ -380,7 +487,7 @@ def main(
             job = client.submit(
                 entrypoint=Entrypoint.from_callable(serve_in_job, config),
                 name=job_name,
-                resources=ResourceSpec(cpu=cpu, memory=memory, disk=disk, device=device),
+                resources=ResourceSpec(cpu=cpu, memory=memory, disk=disk, device=plan.device),
                 environment=environment,
                 ports=["http"],
                 constraints=constraints or None,
@@ -392,6 +499,7 @@ def main(
             click.echo("")
             click.echo(f"  job          {job}")
             click.echo(f"  model        {model}")
+            click.echo(f"  backend      {backend}")
             if gpu is not None:
                 click.echo(f"  gpu          {config.accelerator_label}")
             else:
@@ -411,12 +519,12 @@ def main(
             click.echo("")
 
             if not wait:
-                click.echo("Submitted. Open the dashboard from the Iris UI once vLLM has booted.")
+                click.echo("Submitted. Open the dashboard from the Iris UI once the model has booted.")
                 if endpoint_access == EndpointAccess.ENDPOINT_ACCESS_LINK:
-                    click.echo("Re-run with --wait once vLLM registers to mint the off-cluster capability URL.")
+                    click.echo("Re-run with --wait once the server registers to mint the off-cluster capability URL.")
                 return
 
-            click.echo("Waiting for vLLM to boot and register (Ctrl-C to detach; the job keeps running) …")
+            click.echo("Waiting for the model to load and register (Ctrl-C to detach; the job keeps running) …")
             _wait_for_endpoint(client, job, endpoint, wait_timeout)
             click.echo("")
             click.echo(f"READY — dashboard: {proxy_url}/")

--- a/lib/marin/src/marin/inference/quick_serve_dashboard.py
+++ b/lib/marin/src/marin/inference/quick_serve_dashboard.py
@@ -1,7 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Browser dashboard and OpenAI-compatible reverse proxy for a quick-serve vLLM job.
+"""Browser dashboard and OpenAI-compatible reverse proxy for a quick-serve job.
 
 The dashboard is a single self-contained Vue page served at ``/``. It and every
 ``/v1/*`` request resolve through the Iris controller proxy's
@@ -9,8 +9,9 @@ The dashboard is a single self-contained Vue page served at ``/``. It and every
 (``new URL(path, location.href)``) — the proxy does not rewrite HTML bodies, so an
 absolute path like ``/v1/chat/completions`` would escape the prefix.
 
-``/v1/*`` requests are reverse-proxied to the local vLLM server with the response
-streamed back verbatim, so server-sent-event token streaming works end to end.
+``/v1/*`` requests are reverse-proxied to whichever serving backend runs on the
+slice (see :mod:`marin.inference.serving_backend`) with the response streamed back
+verbatim, so server-sent-event token streaming works end to end.
 """
 
 import dataclasses
@@ -32,7 +33,7 @@ from starlette.routing import Route
 
 logger = logging.getLogger(__name__)
 
-# Request headers that must not be forwarded to the upstream vLLM server; httpx
+# Request headers that must not be forwarded to the upstream backend server; httpx
 # recomputes Host/Content-Length, and the rest are hop-by-hop per RFC 7230.
 _REQUEST_DROP_HEADERS = frozenset(
     {
@@ -58,6 +59,7 @@ class ServingInfo:
     """Static serving metadata surfaced at ``/info`` and rendered by the dashboard."""
 
     model: str
+    backend: str
     tensor_parallel_size: int
     max_model_len: int | None
     dtype: str
@@ -73,11 +75,11 @@ def build_dashboard_app(
     info: ServingInfo,
     request_timeout_seconds: float = 600.0,
 ) -> Starlette:
-    """Build the Starlette app fronting a local vLLM server.
+    """Build the Starlette app fronting a local serving backend.
 
     Args:
-        upstream_base_url: Root URL of the local vLLM server (without ``/v1``).
-        model_id: The model id vLLM reports; surfaced to the dashboard.
+        upstream_base_url: Root URL of the backend's OpenAI server (without ``/v1``).
+        model_id: The model id the backend reports; surfaced to the dashboard.
         info: Static serving metadata returned from ``/info``.
         request_timeout_seconds: Per-request timeout for upstream proxying.
     """
@@ -126,7 +128,7 @@ def build_dashboard_app(
         try:
             upstream_response = await client.send(upstream_request, stream=True)
         except httpx.HTTPError as exc:
-            return JSONResponse({"error": f"upstream vLLM request failed: {exc}"}, status_code=502)
+            return JSONResponse({"error": f"upstream request failed: {exc}"}, status_code=502)
 
         resp_headers = {k: v for k, v in upstream_response.headers.items() if k.lower() not in _RESPONSE_DROP_HEADERS}
 
@@ -161,8 +163,8 @@ def bind_serving_socket(host: str, port: int) -> socket.socket:
 
     Iris allocates the task's named port from a range (30000-40000) that overlaps
     the OS ephemeral range, so any ephemeral socket the task later opens — notably
-    vLLM's many internal sockets — can squat the port we need. Binding here, before
-    vLLM starts, removes the port from the ephemeral pool and reserves it for us.
+    vLLM's many internal sockets — can squat the port we need. Binding here, before the
+    backend starts, removes the port from the ephemeral pool and reserves it for us.
     """
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -170,8 +172,24 @@ def bind_serving_socket(host: str, port: int) -> socket.socket:
     return sock
 
 
+@dataclass(frozen=True)
+class BackgroundServer:
+    """A uvicorn server running on a daemon thread, for as long as the thread is up."""
+
+    thread: threading.Thread
+
+    def is_alive(self) -> bool:
+        return self.thread.is_alive()
+
+
 @contextmanager
-def serve_app_background(app: Starlette, sock: socket.socket, *, start_timeout_seconds: float = 30.0) -> Iterator[None]:
+def serve_app_background(
+    app: Starlette,
+    sock: socket.socket,
+    *,
+    name: str = "quick-serve-dashboard",
+    start_timeout_seconds: float = 30.0,
+) -> Iterator[BackgroundServer]:
     """Run ``app`` under uvicorn on an already-bound ``sock`` in a daemon thread.
 
     The caller owns the listening socket (see :func:`bind_serving_socket`) so it can
@@ -180,8 +198,8 @@ def serve_app_background(app: Starlette, sock: socket.socket, *, start_timeout_s
     host, port = sock.getsockname()[:2]
     config = uvicorn.Config(app, log_level="info", log_config=None, workers=1)
     server = uvicorn.Server(config)
-    thread = threading.Thread(target=server.run, kwargs={"sockets": [sock]}, name="quick-serve-dashboard", daemon=True)
-    logger.info("Starting quick-serve dashboard on %s:%d", host, port)
+    thread = threading.Thread(target=server.run, kwargs={"sockets": [sock]}, name=name, daemon=True)
+    logger.info("Starting %s on %s:%d", name, host, port)
     thread.start()
     started = ExponentialBackoff(initial=0.02, maximum=1, jitter=0).wait_until(
         lambda: server.started or not thread.is_alive(),
@@ -190,11 +208,11 @@ def serve_app_background(app: Starlette, sock: socket.socket, *, start_timeout_s
     if not started or not server.started:
         server.should_exit = True
         thread.join()
-        raise RuntimeError("quick-serve dashboard failed to start")
+        raise RuntimeError(f"{name} failed to start")
     try:
-        yield
+        yield BackgroundServer(thread=thread)
     finally:
-        logger.info("Stopping quick-serve dashboard on %s:%d", host, port)
+        logger.info("Stopping %s on %s:%d", name, host, port)
         server.should_exit = True
         thread.join()
 

--- a/lib/marin/src/marin/inference/serving_backend.py
+++ b/lib/marin/src/marin/inference/serving_backend.py
@@ -1,0 +1,346 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Serving backends for quick-serve: the stack that actually answers OpenAI requests.
+
+A backend boots one OpenAI-compatible HTTP server for one model on the local slice and hands
+back the URL it listens on. vLLM runs as a subprocess; Levanter's inference engine runs
+in-process under uvicorn. Both speak OpenAI over localhost HTTP, so the quick-serve dashboard
+and its ``/v1`` reverse proxy front either one without knowing which is behind it — which is what
+makes the two stacks comparable on the same model, the same slice, and the same API.
+
+A backend *is* its config: :class:`VllmBackend` and :class:`LevanterBackend` are frozen
+dataclasses carrying their own knobs and their own ``serve()``, and the launcher cloudpickles the
+chosen one into the Iris job.
+"""
+
+import logging
+import socket
+import tempfile
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass, field
+from typing import Protocol
+
+import jax
+import jax.numpy as jnp
+import jmp
+from levanter.compat.hf_checkpoints import HFCheckpointConverter, load_tokenizer
+from levanter.inference.engine import InferenceEngineConfig
+from levanter.inference.openai import InferenceServer, InferenceServerConfig
+from levanter.trainer import TrainerConfig
+from levanter.utils.mesh import MeshConfig
+
+from marin.evaluation.evaluators.evaluator import ModelConfig
+from marin.inference.quick_serve_dashboard import BackgroundServer, bind_serving_socket, serve_app_background
+from marin.inference.vllm_server import (
+    JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECONDS,
+    JAX_PERSISTENT_CACHE_MIN_ENTRY_SIZE_BYTES,
+    IsolatedCudaVllm,
+    IsolatedTpuVllm,
+    VllmEnvironment,
+    VllmLauncher,
+    WorkspaceVllm,
+    default_jax_compilation_cache_dir,
+)
+
+logger = logging.getLogger(__name__)
+
+# Every OpenAI-compatible server mounts its routes under /v1; a backend reports the root above it.
+OPENAI_API_SUFFIX = "/v1"
+# Levanter sizes its KV page table from max_seq_len, so — unlike vLLM, which derives the window
+# from the model — it needs a concrete number. Serve a modest window by default and let
+# --max-model-len raise it, rather than reserving a KV cache for a model's full 128k claim.
+DEFAULT_LEVANTER_MAX_SEQ_LEN = 4096
+# The engine requires max_queued_tokens >= max_seqs (and >= the prefill/decode pack sizes).
+_MIN_QUEUED_TOKENS = 512
+# Levanter loads weights at one dtype; vLLM's `auto`/`half`/`float` aliases have no meaning here.
+LEVANTER_DTYPES = ("bfloat16", "float16", "float32")
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """What to serve, and on what slice: the inputs every backend needs."""
+
+    model: str
+    """Friendly model id (HF repo id or object-store path); the id the OpenAI API reports."""
+    model_path: str
+    """Resolved path the weights load from: an HF repo id, or an HF-format snapshot directory."""
+    num_chips: int
+    tensor_parallel_size: int
+    dtype: str
+    max_model_len: int | None
+    chat_template_content: str | None
+
+
+class ServedModel(Protocol):
+    """A running OpenAI-compatible server for one model on this slice."""
+
+    @property
+    def base_url(self) -> str:
+        """Root URL of the local server, without the ``/v1`` suffix."""
+        ...
+
+    @property
+    def model_id(self) -> str:
+        """Model id the server reports over the OpenAI API."""
+        ...
+
+    def check_alive(self) -> None:
+        """Raise if the server has died."""
+        ...
+
+
+class ServingBackend(Protocol):
+    """Boots an OpenAI-compatible server for one model on the local slice."""
+
+    @property
+    def name(self) -> str:
+        """Backend id, surfaced on the dashboard and in the endpoint's metadata."""
+        ...
+
+    def serve(self, spec: ModelSpec) -> AbstractContextManager[ServedModel]:
+        """Serve ``spec`` for the duration of the context, yielding the running server."""
+        ...
+
+
+@dataclass(frozen=True)
+class VllmServedModel:
+    """A ``vllm serve`` subprocess."""
+
+    base_url: str
+    model_id: str
+    environment: VllmEnvironment
+
+    def check_alive(self) -> None:
+        server = self.environment.vllm_server
+        if server is not None and server.process.poll() is not None:
+            raise RuntimeError(f"vLLM server exited unexpectedly with code {server.process.returncode}.")
+
+
+@dataclass(frozen=True)
+class VllmBackend:
+    """Serve the model with vLLM, launched as a subprocess.
+
+    The launcher decides which vLLM runs: the one already on the venv/image ``PATH``, or a stock
+    CUDA / Marin-forked TPU vLLM provisioned in a throwaway uv-tool env (see
+    :meth:`select_launcher`).
+    """
+
+    name: str = "vllm"
+    vllm_version: str | None = None
+    """When set, provision stock CUDA vLLM at this exact version in an isolated uv-tool env — the
+    GPU serving path. ``None`` serves from the vLLM already on the venv/image ``PATH``: the
+    workspace TPU-vLLM stack, or a prebuilt ``--task-image``."""
+    tpu_vllm_ref: str | None = None
+    """When set (with ``tpu_inference_ref``), provision Marin's forked TPU vLLM in an isolated
+    uv-tool env — the checkout-free TPU serving path."""
+    tpu_inference_ref: str | None = None
+    """``uvx --with`` requirement for the tpu-inference fork; paired with ``tpu_vllm_ref``."""
+    max_num_batched_tokens: int = 512
+    """Prefill batch size. Kept modest because the TPU paged-attention kernel's on-chip (VMEM)
+    scratch grows with this; large values overflow VMEM at compile."""
+    startup_timeout_seconds: int = 1800
+    """How long ``vllm serve`` may take to answer ``/v1/models`` before the job gives up."""
+    extra_args: tuple[str, ...] = field(default_factory=tuple)
+    """Raw flags forwarded verbatim to ``vllm serve``."""
+
+    def select_launcher(self) -> VllmLauncher:
+        if self.vllm_version:
+            return IsolatedCudaVllm(version=self.vllm_version)
+        if self.tpu_vllm_ref:
+            if not self.tpu_inference_ref:
+                raise ValueError("tpu_vllm_ref requires tpu_inference_ref (the tpu-inference fork).")
+            return IsolatedTpuVllm(vllm_ref=self.tpu_vllm_ref, tpu_inference_ref=self.tpu_inference_ref)
+        return WorkspaceVllm()
+
+    @contextmanager
+    def serve(self, spec: ModelSpec) -> Iterator[VllmServedModel]:
+        engine_kwargs: dict[str, object] = {"max_num_batched_tokens": self.max_num_batched_tokens}
+        if spec.max_model_len is not None:
+            engine_kwargs["max_model_len"] = spec.max_model_len
+        model = ModelConfig(name="quick-serve", path=spec.model_path, engine_kwargs=engine_kwargs)
+
+        with VllmEnvironment(
+            model,
+            host="127.0.0.1",
+            port=_reserve_localhost_port(),
+            timeout_seconds=self.startup_timeout_seconds,
+            extra_args=self._cli_args(spec),
+            launcher=self.select_launcher(),
+        ) as environment:
+            if environment.model_id is None:
+                raise RuntimeError("vLLM server did not report a model id.")
+            yield VllmServedModel(
+                base_url=environment.server_url.removesuffix(OPENAI_API_SUFFIX),
+                model_id=environment.model_id,
+                environment=environment,
+            )
+
+    def _cli_args(self, spec: ModelSpec) -> list[str]:
+        # Pin the served model name to the requested model so the OpenAI API id stays the friendly
+        # HF id regardless of whether the backing path is local or gs://.
+        args = [
+            "--tensor-parallel-size",
+            str(spec.tensor_parallel_size),
+            "--dtype",
+            spec.dtype,
+            "--served-model-name",
+            spec.model,
+        ]
+        chat_template_path = _write_chat_template(spec.chat_template_content)
+        if chat_template_path is not None:
+            args += ["--chat-template", chat_template_path]
+        return args + list(self.extra_args)
+
+
+@dataclass(frozen=True)
+class LevanterServedModel:
+    """Levanter's inference engine, serving in-process under uvicorn."""
+
+    base_url: str
+    model_id: str
+    uvicorn: BackgroundServer
+
+    def check_alive(self) -> None:
+        if not self.uvicorn.is_alive():
+            raise RuntimeError("The Levanter inference server stopped serving.")
+
+
+@dataclass(frozen=True)
+class LevanterBackend:
+    """Serve the model with Levanter's inference engine, in-process on the slice's chips.
+
+    Weights load through :class:`~levanter.compat.hf_checkpoints.HFCheckpointConverter`, which
+    infers the Levanter model class from the checkpoint's HF architecture and reads config and
+    weights over fsspec, so an HF repo id and an object-store HF-format snapshot both work. A
+    native Levanter checkpoint tree (not an HF export) is not servable this way.
+    """
+
+    name: str = "levanter"
+    max_seqs: int = 16
+    """Concurrent sequences the engine holds slots for."""
+    page_size: int = 128
+    """Tokens per KV-cache page."""
+    hbm_utilization: float = 0.8
+    """Fraction of device HBM the KV cache may claim."""
+
+    @contextmanager
+    def serve(self, spec: ModelSpec) -> Iterator[LevanterServedModel]:
+        # Levanter compiles on the first request; write to the cache the vLLM path already uses so
+        # a re-serve of the same model on the same slice skips the compile.
+        jax.config.update("jax_compilation_cache_dir", default_jax_compilation_cache_dir())
+        jax.config.update("jax_persistent_cache_min_entry_size_bytes", JAX_PERSISTENT_CACHE_MIN_ENTRY_SIZE_BYTES)
+        jax.config.update("jax_persistent_cache_min_compile_time_secs", JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECONDS)
+
+        dtype = validate_levanter_dtype(spec.dtype)
+        trainer = TrainerConfig(
+            mp=jmp.get_policy(f"p={dtype},c={dtype}"),
+            mesh=inference_mesh(spec.num_chips, spec.tensor_parallel_size),
+        )
+        tokenizer = load_tokenizer(spec.model_path)
+        if spec.chat_template_content is not None:
+            tokenizer.chat_template = spec.chat_template_content
+
+        converter = HFCheckpointConverter.from_hf(spec.model_path)
+        model_config = converter.default_config
+        max_seq_len = levanter_max_seq_len(spec.max_model_len, model_config.max_seq_len)
+        logger.info(
+            "Loading %s into Levanter (%s, dtype=%s, max_seq_len=%d, chips=%d, model_axis=%d)",
+            spec.model_path,
+            type(model_config).__name__,
+            dtype,
+            max_seq_len,
+            spec.num_chips,
+            spec.tensor_parallel_size,
+        )
+
+        with trainer.use_device_mesh():
+            model = converter.load_pretrained(
+                model_config.model_type,
+                ref=spec.model_path,
+                dtype=trainer.mp.compute_dtype,
+                axis_mapping=trainer.parameter_axis_mapping,
+            )
+            server = InferenceServer.create(
+                InferenceServerConfig(
+                    trainer=trainer,
+                    tokenizer=spec.model_path,
+                    model_name=spec.model,
+                    service=InferenceEngineConfig(
+                        max_seq_len=max_seq_len,
+                        max_seqs=self.max_seqs,
+                        page_size=self.page_size,
+                        hbm_utilization=self.hbm_utilization,
+                        max_queued_tokens=max(_MIN_QUEUED_TOKENS, self.max_seqs),
+                        compute_dtype=jnp.dtype(dtype),
+                    ),
+                ),
+                model=model,
+                tokenizer=tokenizer,
+            )
+
+        # Levanter's own InferenceServer.serve() owns a uvicorn it never signals to stop, so serve
+        # its app under the same helper the dashboard uses and keep teardown in our hands.
+        sock = bind_serving_socket("127.0.0.1", 0)
+        port = sock.getsockname()[1]
+        try:
+            with serve_app_background(server.app, sock, name="levanter-inference") as background:
+                yield LevanterServedModel(base_url=f"http://127.0.0.1:{port}", model_id=spec.model, uvicorn=background)
+        finally:
+            server.shutdown()
+
+
+def inference_mesh(num_chips: int, tensor_parallel_size: int) -> MeshConfig:
+    """Build the serving mesh: ``model`` shards the model, ``data`` absorbs the rest of the slice.
+
+    A mesh must cover every chip, and Levanter shards attention heads and MLPs across the ``model``
+    axis, so the model axis is the tensor-parallel width and whatever chips remain land on
+    ``data``. When the chip count divides the model's head count the whole slice goes on the model
+    axis (``data`` is 1); a head count the slice cannot divide leaves chips over, and they
+    replicate the model rather than shard it — correct, but duplicated work.
+    """
+    data, remainder = divmod(num_chips, tensor_parallel_size)
+    if remainder:
+        raise ValueError(f"tensor_parallel_size={tensor_parallel_size} does not divide the {num_chips}-chip slice.")
+    if data > 1:
+        logger.warning(
+            "tensor_parallel_size=%d does not span all %d chips; the model replicates %d ways.",
+            tensor_parallel_size,
+            num_chips,
+            data,
+        )
+    return MeshConfig(axes={"replica": 1, "data": data, "model": tensor_parallel_size})
+
+
+def validate_levanter_dtype(dtype: str) -> str:
+    """Check a quick-serve ``--dtype`` names a dtype Levanter can load weights at."""
+    if dtype not in LEVANTER_DTYPES:
+        raise ValueError(f"--dtype {dtype!r} is not supported by the levanter backend; use one of {LEVANTER_DTYPES}.")
+    return dtype
+
+
+def levanter_max_seq_len(max_model_len: int | None, model_max_seq_len: int) -> int:
+    """Pick the KV-cache window: the requested length, or a default clamped to the model's."""
+    if max_model_len is None:
+        return min(DEFAULT_LEVANTER_MAX_SEQ_LEN, model_max_seq_len)
+    if max_model_len > model_max_seq_len:
+        raise ValueError(
+            f"--max-model-len {max_model_len} exceeds the model's maximum sequence length {model_max_seq_len}."
+        )
+    return max_model_len
+
+
+def _reserve_localhost_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _write_chat_template(content: str | None) -> str | None:
+    """Write an inline chat template to a file, for backends that take one by path."""
+    if content is None:
+        return None
+    with tempfile.NamedTemporaryFile("w", suffix=".jinja", prefix="quick_serve_chat_", delete=False) as handle:
+        handle.write(content)
+        return handle.name

--- a/lib/marin/src/marin/inference/vllm_server.py
+++ b/lib/marin/src/marin/inference/vllm_server.py
@@ -411,7 +411,15 @@ class VllmEnvironment:
         return _native_diagnostics(self.vllm_server, max_lines=max_lines)
 
 
-def _default_jax_compilation_cache_dir() -> str:
+# Cache aggressively for iterative bring-up workflows: every compilation is worth keeping, and
+# a serve of the same model on the same slice should not pay for the compile twice. Both serving
+# backends key off these — vLLM through its subprocess environment, Levanter through jax.config.
+JAX_PERSISTENT_CACHE_MIN_ENTRY_SIZE_BYTES = -1
+JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECONDS = 2
+
+
+def default_jax_compilation_cache_dir() -> str:
+    """Persistent XLA/JAX compilation cache shared by every serving backend on this slice."""
     return f"{marin_prefix()}/compilation-cache"
 
 
@@ -434,14 +442,13 @@ def _vllm_env() -> dict[str, str]:
     Starts from ``os.environ`` and applies the canonical defaults.
     """
     env = dict(os.environ)
-    cache_dir = env.get("JAX_COMPILATION_CACHE_DIR", _default_jax_compilation_cache_dir())
+    cache_dir = env.get("JAX_COMPILATION_CACHE_DIR", default_jax_compilation_cache_dir())
     env.setdefault("TOKENIZERS_PARALLELISM", "false")
     env.setdefault("JAX_COMPILATION_CACHE_DIR", cache_dir)
     # TPU vLLM uses XLA compilation caches; this env var is the one it keys off.
     env.setdefault("VLLM_XLA_CACHE_PATH", cache_dir)
-    # Cache aggressively for iterative bring-up workflows.
-    env.setdefault("JAX_PERSISTENT_CACHE_MIN_ENTRY_SIZE_BYTES", "-1")
-    env.setdefault("JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECS", "2")
+    env.setdefault("JAX_PERSISTENT_CACHE_MIN_ENTRY_SIZE_BYTES", str(JAX_PERSISTENT_CACHE_MIN_ENTRY_SIZE_BYTES))
+    env.setdefault("JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECS", str(JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECONDS))
     for key, default in _VLLM_ENV_DEFAULTS:
         env.setdefault(key, default)
     return env

--- a/lib/marin/src/marin/rl/environments/inference_ctx/levanter.py
+++ b/lib/marin/src/marin/rl/environments/inference_ctx/levanter.py
@@ -157,7 +157,7 @@ class LevanterInferenceContext(BaseInferenceContext):
             # `request_kwargs` never sets `stream`, so spreading it as untyped kwargs prevents
             # the non-streaming overload from being selected; the result is always a ChatCompletion.
             completion = await client.chat.completions.create(
-                model=getattr(self._inference_server.config, "model_name", "test-model"),
+                model=self._inference_server.config.model_name,
                 messages=[{"role": "user", "content": prompt}],
                 **request_kwargs,
                 timeout=30,

--- a/lib/marin/src/marin/rl/environments/inference_ctx/levanter.py
+++ b/lib/marin/src/marin/rl/environments/inference_ctx/levanter.py
@@ -29,6 +29,15 @@ from openai.types.chat import ChatCompletion
 
 logger = logging.getLogger(__name__)
 
+# Base and midtrained checkpoints ship no chat template, but rollouts go through
+# /v1/chat/completions. This renders the plain "role: content" transcript that
+# `BaseInferenceContext.tokenize_prompt` falls back to, so the prompt the server generates from and
+# the prompt tokens recorded in the rollout stay identical.
+FALLBACK_CHAT_TEMPLATE = (
+    "{% for message in messages %}{{ message['role'] }}: {{ message['content'] }}"
+    "{% if not loop.last %}\n{% endif %}{% endfor %}"
+)
+
 UNSUPPORTED_LEVANTER_DECODING_FIELDS = (
     "top_k",
     "min_p",
@@ -61,7 +70,14 @@ class LevanterInferenceContext(BaseInferenceContext):
         inference_config: LevanterInferenceContextConfig,
     ):
         self.inference_server_config = inference_config.inference_server_config
-        self.tokenizer = inference_config.tokenizer
+        tokenizer = inference_config.tokenizer
+        if tokenizer.chat_template is None:
+            logger.warning(
+                "Tokenizer %s has no chat template; rendering rollout prompts as a plain 'role: content' transcript.",
+                tokenizer.name_or_path,
+            )
+            tokenizer = tokenizer.with_chat_template(FALLBACK_CHAT_TEMPLATE)
+        self.tokenizer = tokenizer
         self._stop_tokens = inference_config.stop_tokens
         self.max_tokens = inference_config.max_tokens
         self.mesh = inference_config.mesh

--- a/tests/inference/test_quick_serve.py
+++ b/tests/inference/test_quick_serve.py
@@ -9,25 +9,35 @@ import socket
 import time
 from unittest.mock import MagicMock
 
+import click
 import pytest
 import requests
+from click.testing import CliRunner
 from iris.rpc import controller_pb2
 from iris.time_proto import timestamp_to_proto
 from marin.inference.quick_serve import (
-    QuickServeConfig,
     resolve_model_path,
     select_tensor_parallel_size,
-    select_vllm_launcher,
 )
 from marin.inference.quick_serve_cli import (
     _checkout_free_setup_script,
     _mint_and_print_capability_url,
+    _resolve_serving_plan,
+    main,
 )
 from marin.inference.quick_serve_dashboard import (
     ServingInfo,
     bind_serving_socket,
     build_dashboard_app,
     serve_app_background,
+)
+from marin.inference.serving_backend import (
+    DEFAULT_LEVANTER_MAX_SEQ_LEN,
+    LevanterBackend,
+    VllmBackend,
+    inference_mesh,
+    levanter_max_seq_len,
+    validate_levanter_dtype,
 )
 from marin.inference.vllm_server import IsolatedCudaVllm, IsolatedTpuVllm, WorkspaceVllm
 from rigging.timing import Timestamp
@@ -79,44 +89,155 @@ def test_checkout_free_setup_script_pins_marin_core_with_extras():
     assert "vllm" not in script
 
 
-def test_select_vllm_launcher_gpu_provisions_isolated_cuda_vllm():
-    config = QuickServeConfig(
-        model="Qwen/Qwen3-0.6B", endpoint_name="/serve/x", gpu_type="H100", gpu_count=8, vllm_version="0.25.0"
-    )
-    assert select_vllm_launcher(config) == IsolatedCudaVllm(version="0.25.0")
+def test_vllm_backend_gpu_provisions_isolated_cuda_vllm():
+    assert VllmBackend(vllm_version="0.25.0").select_launcher() == IsolatedCudaVllm(version="0.25.0")
 
 
-def test_select_vllm_launcher_falls_back_to_workspace_without_version():
+def test_vllm_backend_falls_back_to_workspace_without_version():
     # The TPU path (no version) and a --task-image GPU path (image ships its own vLLM)
     # both serve from the vLLM already on PATH.
-    tpu = QuickServeConfig(model="m", endpoint_name="/serve/x", tpu_type="v6e-8")
-    gpu_with_image = QuickServeConfig(
-        model="m", endpoint_name="/serve/x", gpu_type="H100", gpu_count=8, vllm_version=None
-    )
-    assert select_vllm_launcher(tpu) == WorkspaceVllm()
-    assert select_vllm_launcher(gpu_with_image) == WorkspaceVllm()
+    assert VllmBackend().select_launcher() == WorkspaceVllm()
 
 
-def test_select_vllm_launcher_tpu_isolated_from_refs():
-    config = QuickServeConfig(
-        model="Qwen/Qwen3-0.6B",
-        endpoint_name="/serve/x",
-        tpu_type="v6e-8",
+def test_vllm_backend_tpu_isolated_from_refs():
+    backend = VllmBackend(
         tpu_vllm_ref="vllm @ git+https://github.com/marin-community/vllm.git@abc",
         tpu_inference_ref="tpu-inference @ git+https://github.com/marin-community/tpu-inference.git@def",
     )
-    assert select_vllm_launcher(config) == IsolatedTpuVllm(
+    assert backend.select_launcher() == IsolatedTpuVllm(
         vllm_ref="vllm @ git+https://github.com/marin-community/vllm.git@abc",
         tpu_inference_ref="tpu-inference @ git+https://github.com/marin-community/tpu-inference.git@def",
     )
 
 
-def test_select_vllm_launcher_tpu_ref_requires_tpu_inference():
+def test_vllm_backend_tpu_ref_requires_tpu_inference():
     # A vLLM fork without its tpu-inference runtime would boot a broken TPU server; fail
-    # at config time instead.
-    config = QuickServeConfig(model="m", endpoint_name="/serve/x", tpu_type="v6e-8", tpu_vllm_ref="vllm @ git+...@abc")
+    # at launch-selection time instead.
     with pytest.raises(ValueError, match="tpu_inference_ref"):
-        select_vllm_launcher(config)
+        VllmBackend(tpu_vllm_ref="vllm @ git+...@abc").select_launcher()
+
+
+def test_levanter_max_seq_len_defaults_within_the_models_window():
+    # A model advertising a huge window still serves a modest KV cache by default...
+    assert levanter_max_seq_len(None, 131072) == DEFAULT_LEVANTER_MAX_SEQ_LEN
+    # ...and a model with a smaller window than the default clamps down to it.
+    assert levanter_max_seq_len(None, 2048) == 2048
+    # An explicit request is honored up to the model's window, and rejected past it.
+    assert levanter_max_seq_len(8192, 131072) == 8192
+    with pytest.raises(ValueError, match="exceeds the model"):
+        levanter_max_seq_len(8192, 4096)
+
+
+def test_validate_levanter_dtype_rejects_vllm_aliases():
+    assert validate_levanter_dtype("bfloat16") == "bfloat16"
+    # vLLM accepts these; Levanter loads weights at a concrete dtype, so they are errors here.
+    for alias in ("auto", "half", "float"):
+        with pytest.raises(ValueError, match="not supported by the levanter backend"):
+            validate_levanter_dtype(alias)
+
+
+@pytest.mark.parametrize(
+    ("num_chips", "tensor_parallel_size", "expected"),
+    [
+        (8, 8, {"replica": 1, "data": 1, "model": 8}),  # the slice divides the head count: shard across it
+        (8, 2, {"replica": 1, "data": 4, "model": 2}),  # it does not: the leftover chips replicate
+    ],
+)
+def test_inference_mesh_covers_every_chip(num_chips, tensor_parallel_size, expected):
+    assert dict(inference_mesh(num_chips, tensor_parallel_size).axes) == expected
+
+
+def test_inference_mesh_rejects_a_tp_that_does_not_divide_the_slice():
+    with pytest.raises(ValueError, match="does not divide"):
+        inference_mesh(8, 3)
+
+
+def test_cli_rejects_vllm_flags_under_the_levanter_backend():
+    result = CliRunner().invoke(main, ["Qwen/Qwen3-0.6B", "--backend", "levanter", "--vllm-arg", "--enforce-eager"])
+    assert result.exit_code != 0
+    assert "--vllm-arg cannot be used with --backend levanter" in result.output
+
+
+def test_cli_defaulted_vllm_options_do_not_trip_the_levanter_backend(monkeypatch):
+    """--vllm-version and --max-num-batched-tokens have non-None defaults.
+
+    Rejecting a vLLM-only option by its *value* rather than by "the user typed it" would fail
+    every levanter serve, so reaching the controller is the assertion.
+    """
+    reached_controller = RuntimeError("reached the controller")
+
+    def _fail_at_controller(*_args, **_kwargs):
+        raise reached_controller
+
+    monkeypatch.setattr("marin.inference.quick_serve_cli.open_controller_endpoint", _fail_at_controller)
+    result = CliRunner().invoke(main, ["Qwen/Qwen3-0.6B", "--backend", "levanter", "--max-seqs", "4"])
+    assert result.exception is reached_controller
+
+
+def test_cli_rejects_levanter_flags_under_the_vllm_backend():
+    result = CliRunner().invoke(main, ["Qwen/Qwen3-0.6B", "--page-size", "64"])
+    assert result.exit_code != 0
+    assert "--page-size cannot be used with --backend vllm" in result.output
+
+
+def _plan(**overrides):
+    args = {
+        "backend": "vllm",
+        "tpu": "v6e-8",
+        "gpu": None,
+        "in_checkout": True,
+        "isolated_vllm": False,
+        "task_image": None,
+        "cuda_vllm_version": "0.25.0",
+        "vllm": VllmBackend(),
+        "levanter": LevanterBackend(),
+        "extras": (),
+    }
+    return _resolve_serving_plan(**{**args, **overrides})
+
+
+@pytest.mark.parametrize(
+    ("overrides", "backend_type", "worker_extras"),
+    [
+        # vLLM in a checkout builds from the workspace lock, so the venv needs both TPU extras.
+        ({}, VllmBackend, ("tpu", "vllm")),
+        # Outside a checkout (or with --isolated-vllm) vLLM comes from uvx: no `vllm` extra.
+        ({"in_checkout": False}, VllmBackend, ("tpu",)),
+        ({"isolated_vllm": True}, VllmBackend, ("tpu",)),
+        # CUDA vLLM is provisioned by uvx, so the GPU worker venv needs no accelerator extra.
+        ({"gpu": "H100x8"}, VllmBackend, ()),
+        # Levanter computes in the worker venv, so that venv carries the accelerator's JAX itself.
+        ({"backend": "levanter"}, LevanterBackend, ("tpu",)),
+        ({"backend": "levanter", "gpu": "H100x8"}, LevanterBackend, ("gpu",)),
+    ],
+)
+def test_resolve_serving_plan_picks_the_worker_extras_the_backend_needs(overrides, backend_type, worker_extras):
+    plan = _plan(**overrides)
+    assert isinstance(plan.backend, backend_type)
+    assert plan.worker_extras == worker_extras
+
+
+def test_resolve_serving_plan_pins_cuda_vllm_only_on_the_gpu_path():
+    # A CUDA version on the TPU path would launch CUDA vLLM on a TPU slice.
+    gpu = _plan(gpu="H100x8").backend
+    assert gpu.select_launcher() == IsolatedCudaVllm(version="0.25.0")
+    assert _plan().backend.select_launcher() == WorkspaceVllm()
+    # A prebuilt --task-image is expected to ship its own vLLM, so nothing is provisioned.
+    assert _plan(gpu="H100x8", task_image="img").backend.select_launcher() == WorkspaceVllm()
+
+
+def test_resolve_serving_plan_isolates_vllm_outside_a_checkout():
+    # No checkout to build the TPU-vLLM fork from, so it has to come from a pinned uvx env.
+    backend = _plan(in_checkout=False).backend
+    assert isinstance(backend, VllmBackend)
+    assert backend.tpu_vllm_ref and backend.tpu_inference_ref
+    # In a checkout it serves the workspace vLLM instead.
+    assert _plan().backend.tpu_vllm_ref is None
+
+
+def test_resolve_serving_plan_rejects_multihost_slices():
+    with pytest.raises(click.ClickException, match="multi-host"):
+        _plan(tpu="v6e-16")
 
 
 def _mint_response(token: str, ttl_hours: float) -> controller_pb2.Controller.MintEndpointTokenResponse:
@@ -196,6 +317,7 @@ def test_dashboard_serves_ui_and_reverse_proxies_streaming():
     dashboard_port = dashboard_sock.getsockname()[1]
     info = ServingInfo(
         model="fake-model",
+        backend="vllm",
         tensor_parallel_size=2,
         max_model_len=4096,
         dtype="bfloat16",
@@ -241,6 +363,7 @@ def test_dashboard_health_reports_loading_when_upstream_down():
     dashboard_port = dashboard_sock.getsockname()[1]
     info = ServingInfo(
         model="fake-model",
+        backend="vllm",
         tensor_parallel_size=1,
         max_model_len=None,
         dtype="bfloat16",

--- a/tests/rl/test_inference_ctx.py
+++ b/tests/rl/test_inference_ctx.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock
 
 import numpy as np
 import pytest
-from levanter.inference.openai import ChatMessage
+from levanter.inference.openai import ChatMessage, _compute_tokens
 from marin.rl.decoding import DecodingConfig
 from marin.rl.environments.inference_ctx import (
     MODEL_MAPPINGS,
@@ -149,7 +149,7 @@ def test_tokenize_prompt_adds_special_tokens(inference_ctx, llama3_tokenizer):
 
 
 def test_tokenize_prompt_fallback_no_template(gpt2_tokenizer, dummy_server):
-    """Test fallback when tokenizer has no chat template."""
+    """A tokenizer with no chat template gets the plain 'role: content' transcript."""
     ctx = LevanterInferenceContext(
         LevanterInferenceContextConfig(
             inference_server_config=None,
@@ -164,10 +164,31 @@ def test_tokenize_prompt_fallback_no_template(gpt2_tokenizer, dummy_server):
     prompt = "Test prompt"
     tokens = ctx.tokenize_prompt(prompt)
 
-    # Should fallback to "user: Test prompt" format
     decoded = gpt2_tokenizer.decode(tokens)
-    assert "user:" in decoded
-    assert prompt in decoded
+    assert decoded == "user: Test prompt"
+
+
+def test_prompt_tokens_match_what_the_server_builds(gpt2_tokenizer, dummy_server):
+    """Rollout prompt tokens must equal the ones the Levanter server generates from.
+
+    The context and the server share a tokenizer, so a base checkpoint's missing chat template has to
+    be filled in on both sides or the recorded prompt drifts from the generated one.
+    """
+    ctx = LevanterInferenceContext(
+        LevanterInferenceContextConfig(
+            inference_server_config=None,
+            tokenizer=gpt2_tokenizer,
+            stop_tokens=None,
+            max_tokens=100,
+            mesh=None,
+            axis_mapping={},
+        )
+    )
+
+    prompt = "Test prompt"
+    server_tokens = _compute_tokens([ChatMessage(role="user", content=prompt)], ctx.tokenizer)
+
+    assert list(ctx.tokenize_prompt(prompt)) == server_tokens
 
 
 def test_response_tokens_from_choice(inference_ctx, llama3_tokenizer):


### PR DESCRIPTION
`marin-serve` grows `--backend {vllm,levanter}`: the same one-liner can now serve a model through Levanter's inference engine instead of vLLM, so the two stacks can be compared on the same model, the same slice, and the same OpenAI API.

```
marin-serve Qwen/Qwen3-0.6B --tpu v6e-8                     # vLLM (default; unchanged)
marin-serve Qwen/Qwen3-0.6B --tpu v6e-8 --backend levanter  # same model, Levanter engine
```

Both backends are OpenAI-compatible servers on localhost — vLLM as a subprocess, Levanter as a FastAPI app under uvicorn in-process — which keeps the seam small. A backend hands `serve_in_job` a base URL and a model id (`ServingBackend` / `ServedModel` in the new `marin/inference/serving_backend.py`); the dashboard, the `/v1` reverse proxy, endpoint registration, capability-URL minting and the self-stop loop are untouched and backend-blind. The backend *is* its config: `VllmBackend` and `LevanterBackend` are frozen dataclasses carrying their own knobs and their own `serve()`, and the CLI cloudpickles the chosen one into the Iris job — no registry, no dispatch table, no boolean flag. The Levanter path needs no vLLM at all, so its worker venv is just the accelerator's JAX (`tpu` or `gpu` extra).

The Levanter backend loads weights through `HFCheckpointConverter.from_hf`, which infers the model class from the checkpoint's HF architecture and reads over fsspec, so HF repo ids and `gs://` HF-format snapshots both work — the same model contract vLLM already has. Unlike vLLM it must size its KV page table up front, so `max_seq_len` comes from `--max-model-len` or a 4k default clamped to the model's window rather than the model's full (possibly 128k) claim.

Two gaps in Levanter's OpenAI surface had to close for one client to work against both backends:

- **`GET /v1/models` did not exist.** Added, backed by a new `InferenceServerConfig.model_name` — which also retires the `getattr(config, "model_name", "test-model")` hack in the RL inference context.
- **`stream: true` was accepted and silently ignored** on both completion routes, handing a non-SSE body to a client waiting for events (and breaking the marin-serve dashboard, which streams both). The routes now emit a well-formed SSE sequence. Levanter's engine generates whole completions, so the events are *not* incremental — a client sees the completion in its first delta. Real token streaming needs the decode loop and is left alone.

## The chat-template bug

Driving the backend end to end turned up a latent correctness bug worth calling out, because it changes RL rollouts.

Levanter's chat encoder asserted `apply_chat_template(tokenize=True)` returned a `list[int]`, wrapped in a blanket `except Exception` that fell back to concatenating `"role: content"`. But transformers 5.x defaults `return_dict=True` and returns a `BatchEncoding` — so the assert **always** failed and was **always** swallowed. Every Levanter chat completion on this pin has been built from an invented prompt format rather than the model's own chat template, including the RL rollout path (`LevanterInferenceContext.batch_completions`) and `/v1/tokens`.

The encoding is now pinned to a flat token list (`return_dict=False`), and a model with no chat template is refused with a 400 the way vLLM refuses it, rather than having a format invented for it. Chat requests now use the real template; the two backends agree on which models can chat.

Fixes #7172