### PR TITLE
[RL] Keep BOS in the fallback chat template

### DIFF
--- a/lib/marin/src/marin/rl/environments/inference_ctx/levanter.py
+++ b/lib/marin/src/marin/rl/environments/inference_ctx/levanter.py
@@ -33,8 +33,10 @@ logger = logging.getLogger(__name__)
 # /v1/chat/completions. This renders the plain "role: content" transcript that
 # `BaseInferenceContext.tokenize_prompt` falls back to, so the prompt the server generates from and
 # the prompt tokens recorded in the rollout stay identical.
+# A rendered template is tokenized without special tokens, so it opens with the BOS token the way
+# real chat templates do.
 FALLBACK_CHAT_TEMPLATE = (
-    "{% for message in messages %}{{ message['role'] }}: {{ message['content'] }}"
+    "{{ bos_token }}{% for message in messages %}{{ message['role'] }}: {{ message['content'] }}"
     "{% if not loop.last %}\n{% endif %}{% endfor %}"
 )
 

--- a/tests/rl/test_inference_ctx.py
+++ b/tests/rl/test_inference_ctx.py
@@ -165,7 +165,7 @@ def test_tokenize_prompt_fallback_no_template(gpt2_tokenizer, dummy_server):
     tokens = ctx.tokenize_prompt(prompt)
 
     decoded = gpt2_tokenizer.decode(tokens)
-    assert decoded == "user: Test prompt"
+    assert decoded == f"{gpt2_tokenizer.bos_token}user: Test prompt"
 
 
 def test_prompt_tokens_match_what_the_server_builds(gpt2_tokenizer, dummy_server):

--- a/tests/rl/test_inference_ctx.py
+++ b/tests/rl/test_inference_ctx.py
@@ -149,7 +149,7 @@ def test_tokenize_prompt_adds_special_tokens(inference_ctx, llama3_tokenizer):
 
 
 def test_tokenize_prompt_fallback_no_template(gpt2_tokenizer, dummy_server):
-    """A tokenizer with no chat template gets the plain 'role: content' transcript."""
+    """A tokenizer with no chat template gets a BOS token and the plain 'role: content' transcript."""
     ctx = LevanterInferenceContext(
         LevanterInferenceContextConfig(
             inference_server_config=None,


### PR DESCRIPTION
The fallback chat template that #7178 installs for template-less checkpoints rendered the "role: content" transcript with no BOS token. A rendered chat template is tokenized with add_special_tokens=False, so rollout prompts for base and midtrained checkpoints came out one BOS token short of what they were on main, where the transcript was encoded directly with add_special_tokens=True.

Open the template with bos_token, the way real chat templates do (Llama-3's starts with <|begin_of_text|>). Tokenizers with no BOS token render it as the empty string, so they are unaffected.

Follow-up to #7178.