### PR TITLE
[iris] Add copy-logs-as-JSON button to dashboard log viewer

### DIFF
--- a/lib/iris/dashboard/src/components/controller/JobDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/JobDetail.vue
@@ -5,6 +5,7 @@ import { controllerRpcCall, useLogServerStatsRpc } from '@/composables/useRpc'
 import { useAutoRefresh } from '@/composables/useAutoRefresh'
 import { stateToName, stateDisplayName } from '@/types/status'
 import { useBackends } from '@/composables/useBackends'
+import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
 import {
   LOCAL_CLUSTER, isFederated,
   type JobStatus, type TaskStatus, type LaunchJobRequest, type JobQuery,
@@ -55,7 +56,7 @@ const loadingChildJobs = ref<Set<string>>(new Set())
 const loading = ref(true)
 const error = ref<string | null>(null)
 const profilingTaskId = ref<string | null>(null)
-const copiedName = ref(false)
+const { copied: copiedName, copy: copyToClipboard } = useCopyToClipboard()
 const taskSearch = ref('')
 const stateFilter = ref('')
 
@@ -89,12 +90,10 @@ function toggleChildSort(col: ChildSortColumn) {
   }
 }
 
-async function copyJobName() {
+function copyJobName() {
   const name = job.value?.name
   if (!name) return
-  await navigator.clipboard.writeText(name)
-  copiedName.value = true
-  setTimeout(() => { copiedName.value = false }, 1500)
+  copyToClipboard(name)
 }
 
 // -- Fetch --

--- a/lib/iris/dashboard/src/components/shared/CopyButton.vue
+++ b/lib/iris/dashboard/src/components/shared/CopyButton.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
 
 const props = defineProps<{
   /** The raw value to copy (e.g. "https://10.0.0.1:8080"). Protocol and port are stripped before copying. */
@@ -8,13 +8,11 @@ const props = defineProps<{
   title?: string
 }>()
 
-const copied = ref(false)
+const { copied, copy: copyToClipboard } = useCopyToClipboard()
 
-async function copy() {
+function copy() {
   const ip = props.value.replace(/^https?:\/\//, '').replace(/:\d+$/, '')
-  await navigator.clipboard.writeText(ip)
-  copied.value = true
-  setTimeout(() => { copied.value = false }, 1500)
+  copyToClipboard(ip)
 }
 </script>
 

--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -548,11 +548,14 @@ function isoTimestamp(entry: LogEntry): string {
 // Serialize the currently loaded lines (respecting the active server-side
 // filter and any expanded context) as a JSON array, one object per line.
 function logsAsJson(): string {
+  // In EXACT scope the backend omits per-row keys (they all equal the queried
+  // source), so fall back to the query source for those rows.
+  const exactSource = matchScope.value === 'EXACT' ? sourceInput.value : ''
   const rows = logRows.value.map((row) => ({
     seq: row.seq,
     timestamp: isoTimestamp(row.entry),
     level: logLevelName(row.entry.level),
-    source: row.entry.key ?? '',
+    source: row.entry.key || exactSource,
     message: row.entry.data ?? '',
   }))
   return JSON.stringify(rows, null, 2)

--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -544,6 +544,34 @@ function isoTimestamp(entry: LogEntry): string {
   return ms ? new Date(ms).toISOString() : ''
 }
 
+// Serialize the currently loaded lines (respecting the active server-side
+// filter and any expanded context) as a JSON array, one object per line.
+function logsAsJson(): string {
+  const rows = logRows.value.map((row) => ({
+    seq: row.seq,
+    timestamp: isoTimestamp(row.entry),
+    level: logLevelName(row.entry.level),
+    source: row.entry.key ?? '',
+    message: row.entry.data ?? '',
+  }))
+  return JSON.stringify(rows, null, 2)
+}
+
+const copied = ref(false)
+const copyError = ref(false)
+
+async function copyLogs() {
+  copyError.value = false
+  try {
+    await navigator.clipboard.writeText(logsAsJson())
+    copied.value = true
+    setTimeout(() => { copied.value = false }, 1500)
+  } catch {
+    copyError.value = true
+    setTimeout(() => { copyError.value = false }, 1500)
+  }
+}
+
 function onKeydown(e: KeyboardEvent) {
   // Only the visible viewer responds; a hidden tab keeps its handler inert.
   if (!scrollBox.value?.offsetParent) return
@@ -774,6 +802,13 @@ defineExpose({ selectedAttemptId })
           :disabled="!exceptionIndices.length"
           @click="gotoException(-1)"
         >↑</button>
+        <button
+          class="px-2 py-0.5 border border-surface-border rounded text-xs hover:bg-surface-sunken"
+          :class="copied ? 'text-status-success' : copyError ? 'text-status-danger' : 'text-text-muted'"
+          :disabled="!logRows.length"
+          title="Copy the loaded lines to the clipboard as JSON"
+          @click="copyLogs"
+        >{{ copied ? 'Copied' : copyError ? 'Failed' : 'Copy JSON' }}</button>
         <button
           class="px-2 py-0.5 border border-surface-border rounded text-xs hover:bg-surface-sunken"
           :class="wrap ? 'text-accent' : 'text-text-muted'"

--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -5,6 +5,7 @@ import { logServiceRpcCall } from '@/composables/useRpc'
 import { useAutoRefresh } from '@/composables/useAutoRefresh'
 import { useIndexCursor } from '@/composables/useIndexCursor'
 import { useLogSearch } from '@/composables/useLogSearch'
+import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
 import { CUSTOM_PRESET, SINCE_PRESETS, type TimeZoneName, useTimeWindow } from '@/composables/useTimeWindow'
 import { isFederated, type FetchLogsResponse, type LogEntry, type TaskAttempt } from '@/types/rpc'
 import { timestampMs, logLevelName, formatLogTime } from '@/utils/formatting'
@@ -557,19 +558,10 @@ function logsAsJson(): string {
   return JSON.stringify(rows, null, 2)
 }
 
-const copied = ref(false)
-const copyError = ref(false)
+const { copied, error: copyError, copy } = useCopyToClipboard()
 
-async function copyLogs() {
-  copyError.value = false
-  try {
-    await navigator.clipboard.writeText(logsAsJson())
-    copied.value = true
-    setTimeout(() => { copied.value = false }, 1500)
-  } catch {
-    copyError.value = true
-    setTimeout(() => { copyError.value = false }, 1500)
-  }
+function copyLogs() {
+  copy(logsAsJson())
 }
 
 function onKeydown(e: KeyboardEvent) {

--- a/lib/iris/dashboard/src/composables/useCopyToClipboard.ts
+++ b/lib/iris/dashboard/src/composables/useCopyToClipboard.ts
@@ -1,0 +1,30 @@
+import { ref } from 'vue'
+
+// How long the `copied`/`error` flags stay set before reverting, so a button can
+// flash "Copied" and settle back to its idle label.
+const RESET_DELAY_MS = 1500
+
+/**
+ * Write text to the clipboard and expose transient `copied`/`error` flags that
+ * auto-reset, for the common "flash a confirmation on a button" pattern.
+ */
+export function useCopyToClipboard() {
+  const copied = ref(false)
+  const error = ref(false)
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  async function copy(text: string): Promise<boolean> {
+    error.value = false
+    try {
+      await navigator.clipboard.writeText(text)
+      copied.value = true
+    } catch {
+      error.value = true
+    }
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(() => { copied.value = false; error.value = false }, RESET_DELAY_MS)
+    return copied.value
+  }
+
+  return { copied, error, copy }
+}

--- a/lib/iris/dashboard/src/composables/useCopyToClipboard.ts
+++ b/lib/iris/dashboard/src/composables/useCopyToClipboard.ts
@@ -13,7 +13,7 @@ export function useCopyToClipboard() {
   const error = ref(false)
   let timer: ReturnType<typeof setTimeout> | undefined
 
-  async function copy(text: string): Promise<boolean> {
+  async function copy(text: string): Promise<void> {
     error.value = false
     try {
       await navigator.clipboard.writeText(text)
@@ -23,7 +23,6 @@ export function useCopyToClipboard() {
     }
     if (timer) clearTimeout(timer)
     timer = setTimeout(() => { copied.value = false; error.value = false }, RESET_DELAY_MS)
-    return copied.value
   }
 
   return { copied, error, copy }


### PR DESCRIPTION
* adds a `Copy JSON` button to the log viewer toolbar (next to `Wrap`/`Follow`), available everywhere the shared `LogViewer` renders — task detail, worker detail, job detail, and the standalone Logs tab
* copies the currently loaded lines to the clipboard as a pretty-printed JSON array, one object per line with `seq`, ISO `timestamp`, `level`, `source` (stream key), and `message`
  * exports exactly what's on screen — respects the active server-side filter, level, time window, and any expanded context rows
  * flashes `Copied` (green) / `Failed` (red) and is disabled when no lines are loaded
* extracts a `useCopyToClipboard` composable and adopts it here, in `CopyButton`, and in `JobDetail`'s copy-name button, deduping the clipboard-write + transient-flag + timeout-reset pattern that was copy-pasted across those sites[^1]

[^1]: `JobsTab` keeps its own copy handler — it tracks *which* row was copied via a keyed string flag rather than a boolean, a different shape than the composable models