### PR TITLE
[datakit] Benchmark fast-transformer quality classifier on v6e TPU

### DIFF
--- a/experiments/datakit/cluster/quality/fast_transformer/data.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/data.py
@@ -14,9 +14,15 @@ from collections import Counter
 from dataclasses import dataclass
 
 import numpy as np
+import tiktoken
 from transformers import AutoTokenizer
 
 logger = logging.getLogger(__name__)
+
+# A tokenizer name with this prefix (e.g. "tiktoken:o200k_base") selects a tiktoken BPE
+# encoder instead of a HuggingFace tokenizer. tiktoken tokenizes several times faster than
+# the HF SentencePiece path.
+TIKTOKEN_PREFIX = "tiktoken:"
 
 
 @functools.lru_cache(maxsize=8)
@@ -28,6 +34,11 @@ def load_tokenizer(tokenizer_name: str):
     without the cache a many-batch shard reloads the tokenizer hundreds of times.
     """
     return AutoTokenizer.from_pretrained(tokenizer_name)
+
+
+@functools.lru_cache(maxsize=4)
+def _load_tiktoken(encoding_name: str):
+    return tiktoken.get_encoding(encoding_name)
 
 
 # Reserved compact ids. Real tokens are remapped to dense ids starting at 2.
@@ -102,7 +113,17 @@ def _pack(raw_ids: list[list[int]], remap: dict[int, int], scores: np.ndarray, m
 
 
 def encode_texts(tokenizer_name: str, texts: list[str], max_tokens: int) -> list[list[int]]:
-    """Tokenize raw in-memory texts (no parquet read), truncating to ``max_tokens``."""
+    """Tokenize raw in-memory texts (no parquet read), truncating to ``max_tokens``.
+
+    A ``tiktoken:<encoding>`` name selects a tiktoken BPE encoder; any other name is a
+    HuggingFace tokenizer.
+    """
+    if tokenizer_name.startswith(TIKTOKEN_PREFIX):
+        encoding = _load_tiktoken(tokenizer_name.removeprefix(TIKTOKEN_PREFIX))
+        # Pre-cap by characters like the HF path: bounds tokenizer work and defuses
+        # tiktoken's O(n^2) worst case on pathological (repeated-char) input.
+        capped = [t[: max_tokens * 8] for t in texts]
+        return [row[:max_tokens] for row in encoding.encode_ordinary_batch(capped, num_threads=1)]
     return _encode(load_tokenizer(tokenizer_name), texts, max_tokens)
 
 

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/README.md
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/README.md
@@ -9,18 +9,32 @@ pipeline and compares it to the fasttext baseline it replaced.
 ## Finding
 
 The v6e forward is essentially free (~1% MXU; ~670 M window-tok/s per v6e-4). Throughput
-is **host-bound**: first by tokenization, then — once that is parallelized across the
-host with a fork process pool — by the **GCS parquet data path** (reading/decoding the
-input, writing the output), which is ~65% of a warm shard while the chips sit ~97% idle.
+is **host-bound**, so the pipeline is built around the host, not the chips: a warm
+190K-doc shard takes **~10.5s (~18,000 docs/s)** on a v6e-4, split read 2.7s + tokenize/
+forward/reduce 4.7s + write 3.1s.
 
 | path | hardware | warm docs/s | note |
 |---|---|---|---|
-| fast, fork pool | 1× v6e-4 | ~8,800 | `--tok-procs 48` |
-| fast, fork pool ×4 | 4× v6e-4 (16 chips) | 8,345/VM → 33,380 agg | ~94% scaling |
-| fast, CPU-only | 32 vCPU | ~1,608 | forward-bound (the "before") |
+| fast (fork pool + parallel read + stager) | 1× v6e-4 | ~18,000 | `--tok-procs 96 --device-batch 4096` |
+| fast, 4 workers | 4× v6e-4 (16 chips) | ~18,000/VM → ~72,000 agg | linear (per-VM independent) |
 | fasttext (baseline) | 32 vCPU | ~6,122 | quality Spearman 0.44 vs 0.69 |
 
-A 10T-token corpus (~11 B docs) is ~6 h on 64 v6e-4 (~1.4 h on 256).
+A 10T-token corpus (~11 B docs) is **~2.7 h on 64 v6e-4** (~0.7 h on 256), on preemptible TPU.
+
+## How it's built
+
+The three host costs each get the right tool:
+
+- **Read** — each parquet file's ~11 row groups are read concurrently by a thread pool
+  (`id`/`text` columns only, arrow-native; the read + decode release the GIL), so the
+  ~400 MB text download runs row-group-parallel instead of as one serial stream.
+- **Tokenize** — CPU-heavy Python-and-Rust glue that only scales ~4x across threads (the
+  GIL), so it runs in a *fork* process pool (true multi-core); each child packs a block and
+  hands it back through `shared_memory`, avoiding a ~750 MB/shard pickle.
+- **Forward / stage** — a stager thread copies each packed block out of shared memory and
+  ships it to the chips (`device_put`), so the H2D transfer of upcoming blocks overlaps the
+  current block's forward + reduce; the forward thread only touches pre-staged device arrays.
+  The forward itself is ~free (~0.5s/shard).
 
 ## Layout
 
@@ -29,24 +43,24 @@ A 10T-token corpus (~11 B docs) is ~6 h on 64 v6e-4 (~1.4 h on 256).
 - `build_scorer.py` — build a config-faithful scorer dir (real vocab remap from a corpus
   slice, random weights, percentile calibration). Throughput is weight-independent, so
   this needs no trained checkpoint.
-- `fast_stage.py` — the headline pipeline: a per-worker fork tokenizer pool feeds the
-  device forward; `--cpu-only` runs the same path with no TPU (the CPU baseline).
-- `tokenize_worker.py` — jax-free child module for the fork pool (children never touch
-  the TPU).
+- `fast_stage.py` — the headline pipeline: parallel row-group reads + a fork tokenizer pool
+  feeding the device forward through a stager thread.
+- `tokenize_worker.py` — fork-pool child: tokenizes a block off the GIL and returns it
+  through shared memory (children never touch the TPU).
 - `fasttext_stage.py` — the deployed fasttext baseline on the identical doc set.
-- `common.py` — shared windowing / tokenize-pack / timing helpers.
-- `run_bench.py` — launcher; dispatches to a stage's `run()` (keeps closures importable
-  by path for cloudpickle, and forces `TOKENIZERS_PARALLELISM=true`).
+- `common.py` — shared windowing / tokenize-pack / tokenizer-loading helpers.
+- `run_bench.py` — launcher; dispatches to a stage's `run()` (keeps closures importable by
+  path for cloudpickle).
 
 ## Run
 
 Build the scorer once, then launch a stage as an Iris job (v6e-4 in `europe-west4-a`,
 marin cluster). `run_bench.py` is the entry point; `fast` needs a TPU
-(`--enable-extra-resources --extra tpu`), `fasttext` and `--cpu-only` are CPU jobs.
+(`--enable-extra-resources --extra tpu`), `fasttext` is a CPU job.
 
 ```bash
 python -m experiments.datakit.cluster.quality.fast_transformer.tpu_bench.run_bench \
     fast --corpus 'gs://.../outputs/main/*.parquet' \
     --model-dir gs://.../ft-tpu-bench --out-dir gs://.../out \
-    --max-files 24 --max-workers 4 --device-batch 4096 --tok-procs 48
+    --max-files 24 --max-workers 4 --device-batch 4096 --tok-procs 96 --read-threads 12
 ```

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/README.md
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/README.md
@@ -1,0 +1,52 @@
+# TPU throughput benchmark (issue #7187)
+
+How fast can the pooled fast-transformer quality classifier score a corpus on a v6e
+TPU, how does it scale, and what would a ~10T-token pass cost? The deployed
+[`score.py`](../score.py) path runs the forward on CPU under `InlineRunner(cpu=2)` — too
+slow to use in practice. This harness measures the TPU path on the real Zephyr-on-Iris
+pipeline and compares it to the fasttext baseline it replaced.
+
+## Finding
+
+The v6e forward is essentially free (~1% MXU; ~670 M window-tok/s per v6e-4). Throughput
+is **host-bound**: first by tokenization, then — once that is parallelized across the
+host with a fork process pool — by the **GCS parquet data path** (reading/decoding the
+input, writing the output), which is ~65% of a warm shard while the chips sit ~97% idle.
+
+| path | hardware | warm docs/s | note |
+|---|---|---|---|
+| fast, fork pool | 1× v6e-4 | ~8,800 | `--tok-procs 48` |
+| fast, fork pool ×4 | 4× v6e-4 (16 chips) | 8,345/VM → 33,380 agg | ~94% scaling |
+| fast, CPU-only | 32 vCPU | ~1,608 | forward-bound (the "before") |
+| fasttext (baseline) | 32 vCPU | ~6,122 | quality Spearman 0.44 vs 0.69 |
+
+A 10T-token corpus (~11 B docs) is ~6 h on 64 v6e-4 (~1.4 h on 256).
+
+## Layout
+
+- `microbench.py` — forward-only device ceiling (pre-tokenized resident batches, async
+  launches). Establishes the ~670 M window-tok/s upper bound.
+- `build_scorer.py` — build a config-faithful scorer dir (real vocab remap from a corpus
+  slice, random weights, percentile calibration). Throughput is weight-independent, so
+  this needs no trained checkpoint.
+- `fast_stage.py` — the headline pipeline: a per-worker fork tokenizer pool feeds the
+  device forward; `--cpu-only` runs the same path with no TPU (the CPU baseline).
+- `tokenize_worker.py` — jax-free child module for the fork pool (children never touch
+  the TPU).
+- `fasttext_stage.py` — the deployed fasttext baseline on the identical doc set.
+- `common.py` — shared windowing / tokenize-pack / timing helpers.
+- `run_bench.py` — launcher; dispatches to a stage's `run()` (keeps closures importable
+  by path for cloudpickle, and forces `TOKENIZERS_PARALLELISM=true`).
+
+## Run
+
+Build the scorer once, then launch a stage as an Iris job (v6e-4 in `europe-west4-a`,
+marin cluster). `run_bench.py` is the entry point; `fast` needs a TPU
+(`--enable-extra-resources --extra tpu`), `fasttext` and `--cpu-only` are CPU jobs.
+
+```bash
+python -m experiments.datakit.cluster.quality.fast_transformer.tpu_bench.run_bench \
+    fast --corpus 'gs://.../outputs/main/*.parquet' \
+    --model-dir gs://.../ft-tpu-bench --out-dir gs://.../out \
+    --max-files 24 --max-workers 4 --device-batch 4096 --tok-procs 48
+```

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/README.md
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/README.md
@@ -16,11 +16,18 @@ forward/reduce 4.7s + write 3.1s.
 | path | hardware | warm docs/s | note |
 |---|---|---|---|
 | fast (fork pool + parallel read + stager) | 1× v6e-4 | ~18,000 | `--tok-procs 96 --device-batch 4096` |
+| fast, tiktoken | 1× v6e-4 | ~26,600 | `--tokenizer tiktoken:o200k_base`; read+write-bound |
 | fast, 4 workers | 4× v6e-4 (16 chips) | ~18,000/VM → ~72,000 agg | linear (per-VM independent) |
 | fast, GPU | CoreWeave 8× H100 | ~22,700 | `--accelerator H100x8`; faster S3 writes |
 | fasttext (baseline) | 32 vCPU | ~6,122 | quality Spearman 0.44 vs 0.69 |
 
 A 10T-token corpus (~11 B docs) is **~2.7 h on 64 v6e-4** (~0.7 h on 256), on preemptible TPU.
+
+Tokenization is the largest host cost, so the tokenizer is the main throughput lever. A
+tiktoken BPE (`tiktoken:o200k_base`) tokenizes ~6× faster per core than the deployed
+SentencePiece tokenizer and halves the compute phase, leaving the shard read+write-bound at
+~26,600 docs/s; a controlled retrain matches classifier quality (held-out Spearman 0.70 vs
+0.695). `build_scorer.py`, `run_bench.py`, and `train.py` all take `--tokenizer`.
 
 The harness is accelerator- and cluster-agnostic: `--accelerator` selects a TPU type
 (`v6e-4`) or a `VARIANTxCOUNT` GPU request (`H100x8`), and relative `--corpus` / `--model-dir`

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/README.md
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/README.md
@@ -17,9 +17,15 @@ forward/reduce 4.7s + write 3.1s.
 |---|---|---|---|
 | fast (fork pool + parallel read + stager) | 1× v6e-4 | ~18,000 | `--tok-procs 96 --device-batch 4096` |
 | fast, 4 workers | 4× v6e-4 (16 chips) | ~18,000/VM → ~72,000 agg | linear (per-VM independent) |
+| fast, GPU | CoreWeave 8× H100 | ~22,700 | `--accelerator H100x8`; faster S3 writes |
 | fasttext (baseline) | 32 vCPU | ~6,122 | quality Spearman 0.44 vs 0.69 |
 
 A 10T-token corpus (~11 B docs) is **~2.7 h on 64 v6e-4** (~0.7 h on 256), on preemptible TPU.
+
+The harness is accelerator- and cluster-agnostic: `--accelerator` selects a TPU type
+(`v6e-4`) or a `VARIANTxCOUNT` GPU request (`H100x8`), and relative `--corpus` / `--model-dir`
+paths root at `marin_prefix()`, so the same command reads the datakit corpus from GCS on the
+marin cluster or from S3 on CoreWeave.
 
 ## How it's built
 
@@ -55,12 +61,14 @@ The three host costs each get the right tool:
 ## Run
 
 Build the scorer once, then launch a stage as an Iris job (v6e-4 in `europe-west4-a`,
-marin cluster). `run_bench.py` is the entry point; `fast` needs a TPU
-(`--enable-extra-resources --extra tpu`), `fasttext` is a CPU job.
+marin cluster). `run_bench.py` is the entry point; `fast` needs an accelerator
+(`--enable-extra-resources --extra tpu`, or `--extra gpu` for the GPU path), `fasttext` is a
+CPU job. Relative `--corpus` / `--model-dir` / `--out-dir` paths root at `marin_prefix()`;
+omit `--corpus` to use the default datakit corpus slice.
 
 ```bash
 python -m experiments.datakit.cluster.quality.fast_transformer.tpu_bench.run_bench \
-    fast --corpus 'gs://.../outputs/main/*.parquet' \
-    --model-dir gs://.../ft-tpu-bench --out-dir gs://.../out \
-    --max-files 24 --max-workers 4 --device-batch 4096 --tok-procs 96 --read-threads 12
+    fast --model-dir datakit/quality/ft-tpu-bench --out-dir datakit/quality/ft-tpu-bench-out \
+    --accelerator v6e-4 --max-files 24 --max-workers 4 \
+    --device-batch 4096 --tok-procs 96 --read-threads 12
 ```

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/__init__.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/build_scorer.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/build_scorer.py
@@ -4,7 +4,7 @@
 """Build a *config-faithful* fast-transformer scorer for the TPU throughput benchmark.
 
 The deployed ``.eqx`` lives in the CoreWeave object store (no creds from a GCP box), so
-this reconstructs an equivalent scorer in a GCS model dir: the deployed architecture +
+this reconstructs an equivalent scorer in a model dir: the deployed architecture +
 tokenizer, a vocab remap built from a **real** corpus slice (``min_count=2``, exactly as
 training does), and a monotonic calibration fit to this model's own raw-score
 distribution. Weights are random -- throughput depends only on config + vocab size +
@@ -12,11 +12,12 @@ token-length distribution, all of which this preserves -- so the benchmark numbe
 faithful. Quality is NOT faithful (that comes from the recorded Spearman 0.69 vs 0.44),
 and the calibration only guarantees non-degenerate buckets, not oracle agreement.
 
-Run once (CPU is fine) before the scoring pipelines:
+Corpus/out-dir take absolute URLs or paths relative to ``marin_prefix()`` (the local object
+store on each cluster). Run once (CPU is fine) before the scoring pipelines:
 
     python -m ...tpu_bench.build_scorer \
-        --corpus 'gs://marin-eu-west4/.../data-*.parquet' \
-        --out-dir gs://marin-eu-west4/user/rav/quality/ft-tpu-bench
+        --corpus 'normalized/nemotron_cc_v2/high_quality_.../outputs/main/part-*.parquet' \
+        --out-dir datakit/quality/ft-tpu-bench
 """
 
 import argparse
@@ -35,6 +36,7 @@ from experiments.datakit.cluster.quality.fast_transformer.model import (
     count_params,
 )
 from experiments.datakit.cluster.quality.fast_transformer.scorer import load_pooled_scorer, score_bme
+from experiments.datakit.cluster.quality.fast_transformer.tpu_bench.common import MODEL_CALIB, resolve_dataset_path
 from experiments.datakit.cluster.quality.fast_transformer.train import DEPLOY_CONFIG, MAX_TOKENS, TOKENIZER, _save_scorer
 
 logger = logging.getLogger(__name__)
@@ -70,15 +72,17 @@ def fit_calibration(scorer, texts: list[str]) -> dict:
 
 def main() -> None:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--corpus", required=True, help="glob of text parquet files for vocab + calibration")
-    p.add_argument("--out-dir", required=True, help="GCS model dir to write scorer + calib_bme.json")
+    p.add_argument("--corpus", required=True, help="text parquet glob; relative paths root at marin_prefix()")
+    p.add_argument("--out-dir", required=True, help="model dir for scorer + calib; relative roots at marin_prefix()")
     p.add_argument("--text-col", default="text")
     p.add_argument("--vocab-docs", type=int, default=50000, help="docs used to build the vocab remap")
     p.add_argument("--calib-docs", type=int, default=3000, help="docs used to fit the calibration")
     args = p.parse_args()
     logging.basicConfig(level=logging.INFO)
 
-    texts = read_texts(args.corpus, args.vocab_docs, args.text_col)
+    corpus = resolve_dataset_path(args.corpus)
+    out_dir = resolve_dataset_path(args.out_dir)
+    texts = read_texts(corpus, args.vocab_docs, args.text_col)
     logger.info("building vocab from %d docs with tokenizer %s", len(texts), TOKENIZER)
     raw_ids = encode_texts(TOKENIZER, texts, MAX_TOKENS)
     remap = build_remap(raw_ids, min_count=2)
@@ -91,13 +95,13 @@ def main() -> None:
         "model: vocab=%d params=%.2fM flops/token=%.0f", vocab, count_params(model) / 1e6, config.flops_per_token()
     )
 
-    _save_scorer(model, remap, TOKENIZER, config, args.out_dir, name="pooled_junkgate2")
+    _save_scorer(model, remap, TOKENIZER, config, out_dir, name="pooled_junkgate2")
 
-    scorer = load_pooled_scorer(args.out_dir)
+    scorer = load_pooled_scorer(out_dir)
     calib = fit_calibration(scorer, texts[: args.calib_docs])
-    with open_url(f"{args.out_dir.rstrip('/')}/calib_bme.json", "w") as fh:
+    with open_url(str(StoragePath(out_dir) / MODEL_CALIB), "w") as fh:
         fh.write(json.dumps(calib))
-    logger.info("wrote scorer + calib_bme.json to %s (vocab=%d)", args.out_dir, vocab)
+    logger.info("wrote scorer + %s to %s (vocab=%d)", MODEL_CALIB, out_dir, vocab)
 
 
 if __name__ == "__main__":

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/build_scorer.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/build_scorer.py
@@ -1,0 +1,104 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build a *config-faithful* fast-transformer scorer for the TPU throughput benchmark.
+
+The deployed ``.eqx`` lives in the CoreWeave object store (no creds from a GCP box), so
+this reconstructs an equivalent scorer in a GCS model dir: the deployed architecture +
+tokenizer, a vocab remap built from a **real** corpus slice (``min_count=2``, exactly as
+training does), and a monotonic calibration fit to this model's own raw-score
+distribution. Weights are random -- throughput depends only on config + vocab size +
+token-length distribution, all of which this preserves -- so the benchmark numbers are
+faithful. Quality is NOT faithful (that comes from the recorded Spearman 0.69 vs 0.44),
+and the calibration only guarantees non-degenerate buckets, not oracle agreement.
+
+Run once (CPU is fine) before the scoring pipelines:
+
+    python -m ...tpu_bench.build_scorer \
+        --corpus 'gs://marin-eu-west4/.../data-*.parquet' \
+        --out-dir gs://marin-eu-west4/user/rav/quality/ft-tpu-bench
+"""
+
+import argparse
+import json
+import logging
+
+import jax
+import numpy as np
+import pyarrow.parquet as pq
+from rigging.filesystem import StoragePath, open_url
+
+from experiments.datakit.cluster.quality.fast_transformer.data import build_remap, encode_texts
+from experiments.datakit.cluster.quality.fast_transformer.model import (
+    FastTransformer,
+    FastTransformerConfig,
+    count_params,
+)
+from experiments.datakit.cluster.quality.fast_transformer.scorer import load_pooled_scorer, score_bme
+from experiments.datakit.cluster.quality.fast_transformer.train import DEPLOY_CONFIG, MAX_TOKENS, TOKENIZER, _save_scorer
+
+logger = logging.getLogger(__name__)
+
+
+def read_texts(corpus_glob: str, n_docs: int, text_col: str) -> list[str]:
+    """Read up to ``n_docs`` document texts from the corpus glob (in listing order)."""
+    files = sorted(str(m) for m in StoragePath(corpus_glob).glob())
+    if not files:
+        raise ValueError(f"no files matched {corpus_glob}")
+    texts: list[str] = []
+    for f in files:
+        with StoragePath(f).open("rb") as fh:
+            table = pq.read_table(fh, columns=[text_col])
+        texts.extend(t or "" for t in table.column(text_col).to_pylist())
+        logger.info("read %d docs (%s)", len(texts), f)
+        if len(texts) >= n_docs:
+            break
+    return texts[:n_docs]
+
+
+def fit_calibration(scorer, texts: list[str]) -> dict:
+    """Percentile calibration: map this model's raw bme scores monotonically onto [0,1] so
+    the fixed bucket cutpoints land on a spread distribution (not oracle-calibrated)."""
+    raw = score_bme(scorer, texts)
+    qs = np.linspace(0.0, 1.0, 11)
+    xk = np.quantile(raw, qs)
+    xk = np.maximum.accumulate(xk)
+    xk[0] -= 1e-6
+    xk[-1] += 1e-6
+    return {"xk": [float(x) for x in xk], "yk": [float(q) for q in qs]}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--corpus", required=True, help="glob of text parquet files for vocab + calibration")
+    p.add_argument("--out-dir", required=True, help="GCS model dir to write scorer + calib_bme.json")
+    p.add_argument("--text-col", default="text")
+    p.add_argument("--vocab-docs", type=int, default=50000, help="docs used to build the vocab remap")
+    p.add_argument("--calib-docs", type=int, default=3000, help="docs used to fit the calibration")
+    args = p.parse_args()
+    logging.basicConfig(level=logging.INFO)
+
+    texts = read_texts(args.corpus, args.vocab_docs, args.text_col)
+    logger.info("building vocab from %d docs with tokenizer %s", len(texts), TOKENIZER)
+    raw_ids = encode_texts(TOKENIZER, texts, MAX_TOKENS)
+    remap = build_remap(raw_ids, min_count=2)
+    vocab = len(remap) + 2
+    config = FastTransformerConfig(
+        vocab_size=vocab, max_tokens=MAX_TOKENS, dropout=0.0, final_pool="mean", **DEPLOY_CONFIG
+    )
+    model = FastTransformer(config, key=jax.random.PRNGKey(0))
+    logger.info(
+        "model: vocab=%d params=%.2fM flops/token=%.0f", vocab, count_params(model) / 1e6, config.flops_per_token()
+    )
+
+    _save_scorer(model, remap, TOKENIZER, config, args.out_dir, name="pooled_junkgate2")
+
+    scorer = load_pooled_scorer(args.out_dir)
+    calib = fit_calibration(scorer, texts[: args.calib_docs])
+    with open_url(f"{args.out_dir.rstrip('/')}/calib_bme.json", "w") as fh:
+        fh.write(json.dumps(calib))
+    logger.info("wrote scorer + calib_bme.json to %s (vocab=%d)", args.out_dir, vocab)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/build_scorer.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/build_scorer.py
@@ -77,14 +77,20 @@ def main() -> None:
     p.add_argument("--text-col", default="text")
     p.add_argument("--vocab-docs", type=int, default=50000, help="docs used to build the vocab remap")
     p.add_argument("--calib-docs", type=int, default=3000, help="docs used to fit the calibration")
+    p.add_argument(
+        "--tokenizer",
+        default=TOKENIZER,
+        help="HF tokenizer name, or tiktoken:<encoding> for a tiktoken BPE (e.g. tiktoken:o200k_base)",
+    )
     args = p.parse_args()
     logging.basicConfig(level=logging.INFO)
 
     corpus = resolve_dataset_path(args.corpus)
     out_dir = resolve_dataset_path(args.out_dir)
+    tokenizer = args.tokenizer
     texts = read_texts(corpus, args.vocab_docs, args.text_col)
-    logger.info("building vocab from %d docs with tokenizer %s", len(texts), TOKENIZER)
-    raw_ids = encode_texts(TOKENIZER, texts, MAX_TOKENS)
+    logger.info("building vocab from %d docs with tokenizer %s", len(texts), tokenizer)
+    raw_ids = encode_texts(tokenizer, texts, MAX_TOKENS)
     remap = build_remap(raw_ids, min_count=2)
     vocab = len(remap) + 2
     config = FastTransformerConfig(
@@ -95,7 +101,7 @@ def main() -> None:
         "model: vocab=%d params=%.2fM flops/token=%.0f", vocab, count_params(model) / 1e6, config.flops_per_token()
     )
 
-    _save_scorer(model, remap, TOKENIZER, config, out_dir, name="pooled_junkgate2")
+    _save_scorer(model, remap, tokenizer, config, out_dir, name="pooled_junkgate2")
 
     scorer = load_pooled_scorer(out_dir)
     calib = fit_calibration(scorer, texts[: args.calib_docs])

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/common.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/common.py
@@ -15,7 +15,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 
 import numpy as np
-from rigging.filesystem import open_url
+from rigging.filesystem import marin_prefix, open_url, prefix_join
 
 # Disable the tokenizers-lib internal rayon parallelism: this pipeline drives its own thread
 # pool over row groups, so each thread's ``encode_batch`` runs single-threaded (the Rust encode
@@ -29,6 +29,23 @@ from experiments.datakit.cluster.quality.fast_transformer.scorer import CHUNK_CH
 
 # Calibration json name in a scorer dir.
 MODEL_CALIB = "calib_bme.json"
+
+# Datakit assets, relative to marin_prefix() so one path resolves to the region-appropriate copy
+# on each cluster -- GCS on marin, S3 on CoreWeave.
+DEFAULT_CORPUS = "normalized/nemotron_cc_v2/high_quality_b451aefe/outputs/main/part-*-of-04136.parquet"
+FASTTEXT_MODEL = "datakit/llm-quality-classifier/model/sonnet46-thr05/model.bin"
+
+
+def resolve_dataset_path(path: str) -> str:
+    """Root a cluster-relative datakit path at ``marin_prefix()``; pass absolute URLs through.
+
+    Resolve on the driver, where the cluster config has injected ``MARIN_PREFIX``, so a relative
+    corpus/model path picks up the local object store (GCS on marin, S3 on CoreWeave) with no
+    cross-region read.
+    """
+    if "://" in path or path.startswith("/"):
+        return path
+    return prefix_join(marin_prefix(), path)
 
 
 def doc_windows(text: str) -> list[str]:

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/common.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/common.py
@@ -1,0 +1,87 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for the TPU throughput benchmark (issue #7187).
+
+Kept separate from the production ``score.py`` so the benchmark's instrumentation and
+window-carrying schema don't leak into the deployed path. Everything here reuses the
+production model / tokenizer / windowing so the numbers reflect the real code.
+"""
+
+import json
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import numpy as np
+from rigging.filesystem import open_url
+
+from experiments.datakit.cluster.quality.fast_transformer.data import PAD_ID, UNK_ID, encode_texts
+from experiments.datakit.cluster.quality.fast_transformer.scorer import CHUNK_CHARS, MODEL_META, MODEL_REMAP
+
+# Peak bf16 FLOP/s per v6e chip (fray/device_flops.py: v6e bf16 = 918e12).
+V6E_BF16_PEAK_FLOPS = 918e12
+
+# Calibration json name in a scorer dir (matches score.py's MODEL_CALIB).
+MODEL_CALIB = "calib_bme.json"
+
+
+def doc_windows(text: str) -> list[str]:
+    """The begin/middle/end ~512-token windows of a doc (mirrors ``score_bme``)."""
+    if len(text) <= CHUNK_CHARS:
+        return [text]
+    m = len(text) // 2
+    return [text[:CHUNK_CHARS], text[max(0, m - CHUNK_CHARS // 2) : m + CHUNK_CHARS // 2], text[-CHUNK_CHARS:]]
+
+
+def load_remap_meta(model_dir: str) -> tuple[dict[int, int], str, int]:
+    """Load (remap, tokenizer_name, max_tokens) from a scorer dir -- no ``.eqx`` needed."""
+    model_dir = model_dir.rstrip("/")
+    with open_url(f"{model_dir}/{MODEL_META}", "r") as fh:
+        meta = json.loads(fh.read())
+    with open_url(f"{model_dir}/{MODEL_REMAP}", "r") as fh:
+        remap = {int(k): int(v) for k, v in json.loads(fh.read()).items()}
+    return remap, meta["tokenizer"], int(meta["max_tokens"])
+
+
+def remap_to_array(remap: dict[int, int], vocab_size: int) -> np.ndarray:
+    """Dense lookup table: raw HF token id -> compact id (UNK for pruned). Vectorizes the
+    per-token ``remap.get`` loop so packing is a gather, not a Python dict loop."""
+    hi = max(remap) + 1
+    lut = np.full(max(hi, 1), UNK_ID, dtype=np.int32)
+    for raw, compact in remap.items():
+        lut[raw] = compact
+    return lut
+
+
+def pack_windows(texts: list[str], tokenizer_name: str, lut: np.ndarray, max_tokens: int) -> np.ndarray:
+    """Tokenize + remap + right-pad a list of window texts to ``[N, max_tokens]`` int32.
+
+    Uses the dense ``lut`` (vectorized gather) instead of the production per-token dict
+    loop; the benchmark reports both so we can attribute the pack cost.
+    """
+    encoded = encode_texts(tokenizer_name, texts, max_tokens)
+    ids = np.full((len(texts), max_tokens), PAD_ID, dtype=np.int32)
+    lut_n = lut.shape[0]
+    for i, row in enumerate(encoded):
+        if not row:
+            continue
+        raw = np.asarray(row[:max_tokens], dtype=np.int64)
+        raw = np.where(raw < lut_n, raw, 0)  # out-of-lut -> UNK via lut[0] path below
+        ids[i, : raw.shape[0]] = lut[raw]
+    return ids
+
+
+@contextmanager
+def accumulate(store: dict, key: str) -> Iterator[None]:
+    """Accumulate elapsed wall-seconds into ``store[key]`` (per-worker timing breakdown)."""
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        store[key] = store.get(key, 0.0) + (time.perf_counter() - t0)
+
+
+def write_result_json(path: str, payload: dict) -> None:
+    with open_url(path, "w") as fh:
+        fh.write(json.dumps(payload, indent=2))

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/common.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/common.py
@@ -13,8 +13,10 @@ import os
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Protocol
 
 import numpy as np
+import tiktoken
 from rigging.filesystem import marin_prefix, open_url, prefix_join
 
 # Disable the tokenizers-lib internal rayon parallelism: this pipeline drives its own thread
@@ -22,9 +24,9 @@ from rigging.filesystem import marin_prefix, open_url, prefix_join
 # still releases the GIL) rather than contending over one shared process-wide rayon pool.
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
-from levanter.tokenizers import MarinTokenizer, load_tokenizer
+from levanter.tokenizers import load_tokenizer
 
-from experiments.datakit.cluster.quality.fast_transformer.data import PAD_ID, UNK_ID
+from experiments.datakit.cluster.quality.fast_transformer.data import PAD_ID, TIKTOKEN_PREFIX, UNK_ID
 from experiments.datakit.cluster.quality.fast_transformer.scorer import CHUNK_CHARS, MODEL_META, MODEL_REMAP
 
 # Calibration json name in a scorer dir.
@@ -77,18 +79,42 @@ def remap_to_array(remap: dict[int, int]) -> np.ndarray:
     return lut
 
 
-def load_shared_tokenizer(tokenizer_name: str) -> MarinTokenizer:
-    """Load the tokenizer once via levanter (mirror-staged, no repeated HF Hub calls).
+class BatchTokenizer(Protocol):
+    """A tokenizer that encodes a batch of texts to raw id lists off the GIL."""
 
-    The returned wrapper's ``encode_batch`` calls the raw ``tokenizers`` Rust encoder with an
-    immutable ``&self`` (unlike HF's ``PreTrainedTokenizerFast``, which rewrites truncation
-    state per call), so a single instance is shared across all worker threads -- concurrent
-    ``encode_batch`` is safe and, with rayon disabled, each call runs on one core.
+    def encode_batch(self, texts: list[str]) -> list[list[int]]: ...
+
+
+class TiktokenBatchTokenizer:
+    """Adapt a tiktoken encoding to the ``encode_batch`` interface the pipeline expects.
+
+    ``num_threads=1`` because the pipeline already fans tokenization across a fork pool and a
+    read-thread pool; tiktoken's own batch threads would oversubscribe the host.
     """
+
+    def __init__(self, encoding_name: str):
+        self._encoding = tiktoken.get_encoding(encoding_name)
+
+    def encode_batch(self, texts: list[str]) -> list[list[int]]:
+        return self._encoding.encode_ordinary_batch(texts, num_threads=1)
+
+
+def load_shared_tokenizer(tokenizer_name: str) -> BatchTokenizer:
+    """Load a thread-shareable batch tokenizer by name.
+
+    A ``tiktoken:<encoding>`` name (e.g. ``tiktoken:o200k_base``) loads a tiktoken BPE
+    encoder; any other name loads the levanter HF tokenizer. Both are safe to share across
+    the pipeline's read/fork workers: the levanter wrapper calls the Rust ``tokenizers``
+    encoder with an immutable ``&self`` (unlike HF's ``PreTrainedTokenizerFast``, which
+    rewrites truncation state per call), and tiktoken's encoder is likewise stateless per
+    call, so concurrent ``encode_batch`` is safe and each call runs on one core.
+    """
+    if tokenizer_name.startswith(TIKTOKEN_PREFIX):
+        return TiktokenBatchTokenizer(tokenizer_name.removeprefix(TIKTOKEN_PREFIX))
     return load_tokenizer(tokenizer_name)
 
 
-def pack_windows(texts: list[str], tokenizer: MarinTokenizer, lut: np.ndarray, max_tokens: int) -> np.ndarray:
+def pack_windows(texts: list[str], tokenizer: BatchTokenizer, lut: np.ndarray, max_tokens: int) -> np.ndarray:
     """Tokenize (shared wrapper) + remap + right-pad window texts to ``[N, max_tokens]`` int32.
 
     ``encode_batch`` does not truncate, so ids are cut to ``max_tokens`` here.

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/common.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/common.py
@@ -9,6 +9,7 @@ windowing so the numbers reflect the real code.
 """
 
 import json
+import os
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -16,7 +17,14 @@ from contextlib import contextmanager
 import numpy as np
 from rigging.filesystem import open_url
 
-from experiments.datakit.cluster.quality.fast_transformer.data import PAD_ID, UNK_ID, encode_texts
+# Disable the tokenizers-lib internal rayon parallelism: this pipeline drives its own thread
+# pool over row groups, so each thread's ``encode_batch`` runs single-threaded (the Rust encode
+# still releases the GIL) rather than contending over one shared process-wide rayon pool.
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+from levanter.tokenizers import MarinTokenizer, load_tokenizer
+
+from experiments.datakit.cluster.quality.fast_transformer.data import PAD_ID, UNK_ID
 from experiments.datakit.cluster.quality.fast_transformer.scorer import CHUNK_CHARS, MODEL_META, MODEL_REMAP
 
 # Calibration json name in a scorer dir.
@@ -53,9 +61,23 @@ def remap_to_array(remap: dict[int, int]) -> np.ndarray:
     return lut
 
 
-def pack_windows(texts: list[str], tokenizer_name: str, lut: np.ndarray, max_tokens: int) -> np.ndarray:
-    """Tokenize + remap + right-pad a list of window texts to ``[N, max_tokens]`` int32."""
-    encoded = encode_texts(tokenizer_name, texts, max_tokens)
+def load_shared_tokenizer(tokenizer_name: str) -> MarinTokenizer:
+    """Load the tokenizer once via levanter (mirror-staged, no repeated HF Hub calls).
+
+    The returned wrapper's ``encode_batch`` calls the raw ``tokenizers`` Rust encoder with an
+    immutable ``&self`` (unlike HF's ``PreTrainedTokenizerFast``, which rewrites truncation
+    state per call), so a single instance is shared across all worker threads -- concurrent
+    ``encode_batch`` is safe and, with rayon disabled, each call runs on one core.
+    """
+    return load_tokenizer(tokenizer_name)
+
+
+def pack_windows(texts: list[str], tokenizer: MarinTokenizer, lut: np.ndarray, max_tokens: int) -> np.ndarray:
+    """Tokenize (shared wrapper) + remap + right-pad window texts to ``[N, max_tokens]`` int32.
+
+    ``encode_batch`` does not truncate, so ids are cut to ``max_tokens`` here.
+    """
+    encoded = tokenizer.encode_batch(texts)
     ids = np.full((len(texts), max_tokens), PAD_ID, dtype=np.int32)
     lut_n = lut.shape[0]
     for i, row in enumerate(encoded):

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/common.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/common.py
@@ -59,10 +59,9 @@ def doc_windows(text: str) -> list[str]:
 
 def load_remap_meta(model_dir: str) -> tuple[dict[int, int], str, int]:
     """Load (remap, tokenizer_name, max_tokens) from a scorer dir -- no ``.eqx`` needed."""
-    model_dir = model_dir.rstrip("/")
-    with open_url(f"{model_dir}/{MODEL_META}", "r") as fh:
+    with open_url(prefix_join(model_dir, MODEL_META), "r") as fh:
         meta = json.loads(fh.read())
-    with open_url(f"{model_dir}/{MODEL_REMAP}", "r") as fh:
+    with open_url(prefix_join(model_dir, MODEL_REMAP), "r") as fh:
         remap = {int(k): int(v) for k, v in json.loads(fh.read()).items()}
     return remap, meta["tokenizer"], int(meta["max_tokens"])
 

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/common.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/common.py
@@ -1,11 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared helpers for the TPU throughput benchmark (issue #7187).
+"""Shared helpers for the TPU throughput benchmark.
 
-Kept separate from the production ``score.py`` so the benchmark's instrumentation and
-window-carrying schema don't leak into the deployed path. Everything here reuses the
-production model / tokenizer / windowing so the numbers reflect the real code.
+Kept separate from the production ``score.py`` so the benchmark's instrumentation doesn't
+leak into the deployed path. Everything here reuses the production model / tokenizer /
+windowing so the numbers reflect the real code.
 """
 
 import json
@@ -19,15 +19,13 @@ from rigging.filesystem import open_url
 from experiments.datakit.cluster.quality.fast_transformer.data import PAD_ID, UNK_ID, encode_texts
 from experiments.datakit.cluster.quality.fast_transformer.scorer import CHUNK_CHARS, MODEL_META, MODEL_REMAP
 
-# Peak bf16 FLOP/s per v6e chip (fray/device_flops.py: v6e bf16 = 918e12).
-V6E_BF16_PEAK_FLOPS = 918e12
-
-# Calibration json name in a scorer dir (matches score.py's MODEL_CALIB).
+# Calibration json name in a scorer dir.
 MODEL_CALIB = "calib_bme.json"
 
 
 def doc_windows(text: str) -> list[str]:
-    """The begin/middle/end ~512-token windows of a doc (mirrors ``score_bme``)."""
+    """The begin/middle/end ~512-token windows of a doc: the whole text if short, else the
+    first, middle, and last ``CHUNK_CHARS``-char slices."""
     if len(text) <= CHUNK_CHARS:
         return [text]
     m = len(text) // 2
@@ -44,22 +42,19 @@ def load_remap_meta(model_dir: str) -> tuple[dict[int, int], str, int]:
     return remap, meta["tokenizer"], int(meta["max_tokens"])
 
 
-def remap_to_array(remap: dict[int, int], vocab_size: int) -> np.ndarray:
-    """Dense lookup table: raw HF token id -> compact id (UNK for pruned). Vectorizes the
-    per-token ``remap.get`` loop so packing is a gather, not a Python dict loop."""
-    hi = max(remap) + 1
-    lut = np.full(max(hi, 1), UNK_ID, dtype=np.int32)
+def remap_to_array(remap: dict[int, int]) -> np.ndarray:
+    """Dense lookup table indexed by raw HF token id -> compact id (UNK for pruned ids).
+
+    Sized to ``max(remap) + 1``; callers guard raw ids beyond that range before indexing.
+    """
+    lut = np.full(max(max(remap) + 1, 1), UNK_ID, dtype=np.int32)
     for raw, compact in remap.items():
         lut[raw] = compact
     return lut
 
 
 def pack_windows(texts: list[str], tokenizer_name: str, lut: np.ndarray, max_tokens: int) -> np.ndarray:
-    """Tokenize + remap + right-pad a list of window texts to ``[N, max_tokens]`` int32.
-
-    Uses the dense ``lut`` (vectorized gather) instead of the production per-token dict
-    loop; the benchmark reports both so we can attribute the pack cost.
-    """
+    """Tokenize + remap + right-pad a list of window texts to ``[N, max_tokens]`` int32."""
     encoded = encode_texts(tokenizer_name, texts, max_tokens)
     ids = np.full((len(texts), max_tokens), PAD_ID, dtype=np.int32)
     lut_n = lut.shape[0]

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fast_stage.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fast_stage.py
@@ -1,23 +1,25 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""The fast scoring pipeline: parallel-tokenize on the v6e host, forward on the chips.
+"""The fast scoring pipeline: read + tokenize on the v6e host threads, forward on the chips.
 
 A v6e-4 VM has 4 chips *and* a 180-vCPU host. The forward is dispatch-bound (~1% MXU) and
-scoring a shard's windows on-device costs a few seconds, so throughput is host-bound. This
-stage keeps everything on one Zephyr worker (one shard per worker) and parallelizes the
-tokenization across the host cores:
+scoring a shard's windows on-device costs a few seconds, so throughput is host-bound -- by
+the GCS parquet read/decode and by tokenization, not the model. Both parallelize across the
+host cores with an ordinary thread pool (the arrow read and the Rust tokenizer both release
+the GIL), so this stage keeps one shard on one Zephyr worker and drives its own pool:
 
-  - ``--tok-procs 0``: tokenize on the main thread. The HF fast tokenizer is Rust/rayon
-    multi-core, but ONLY when called from the main thread -- calling it from a worker
-    thread silently drops to single-core.
-  - ``--tok-procs N``: a fork process pool (``tokenize_worker``, jax-free so children never
-    touch the TPU) tokenizes window batches across N cores; the main process pulls packed
-    batches in order and runs the forward, so tokenization overlaps the forward.
+  - Each parquet row group is read (``id`` + ``text`` columns only, arrow-native, no per-row
+    dict materialization) and windowed by a pool thread, so the ~400 MB text download and
+    decode run row-group-parallel instead of as one serial stream.
+  - As each row group lands, its docs are cut into ``device_batch``-window blocks and each
+    block is submitted as its own tokenize task -- so tokenization fans out across the whole
+    pool (not just the ~11 row groups), each thread tokenizing single-threaded with the HF
+    rayon pool disabled.
+  - A stager thread pulls finished blocks and ships them to the chips (``device_put``); the
+    main thread only forwards the staged device arrays and reduces windows -> per-doc scores.
+    Reads, tokenization, the H2D transfer, and the forward all overlap.
 
-With tokenization parallel, the per-shard wall is dominated by the GCS parquet data path
-(read/decode the input, write the output), not by tokenize/forward/reduce. ``--cpu-only``
-runs the same path with no TPU (the forward on the host CPUs) for the CPU baseline.
 Weights/vocab come from the config-faithful scorer dir.
 """
 
@@ -27,23 +29,26 @@ import logging
 import multiprocessing as mp
 import os
 import posixpath
+import queue
+import threading
 import time
 from collections.abc import Iterator
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from multiprocessing import shared_memory
 
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pyarrow.parquet as pq
 from fray.cluster import ResourceConfig
 from rigging.filesystem import StoragePath, open_url
 from zephyr import counters
 from zephyr.dataset import Dataset, ShardInfo
 from zephyr.execution import ZephyrContext
-from zephyr.readers import DEFAULT_FILE_PATH_COLUMN, load_file
 from zephyr.runners import InlineRunner
 from zephyr.writers import ThreadedBatchWriter, write_parquet_file
 
-os.environ["TOKENIZERS_PARALLELISM"] = "true"
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 from experiments.datakit.cluster.quality.fast_transformer.artifact import BUCKET_EDGES
 from experiments.datakit.cluster.quality.fast_transformer.inference import (
@@ -55,18 +60,26 @@ from experiments.datakit.cluster.quality.fast_transformer.tpu_bench import token
 from experiments.datakit.cluster.quality.fast_transformer.tpu_bench.common import (
     doc_windows,
     load_remap_meta,
-    pack_windows,
+    load_shared_tokenizer,
     remap_to_array,
+    write_result_json,
 )
 
 logger = logging.getLogger(__name__)
 
+READ_COLUMNS = ["id", "text"]
+# vCPUs requested per v6e-4 worker (of the host's 180) -- see the ResourceConfig note in run().
+TPU_HOST_CPU = 128
+# How many staged (H2D'd) blocks the stager thread may run ahead of the forward. Bounds the
+# resident device memory while keeping the chips fed; the forward is never blocked on H2D.
+STAGE_QUEUE_DEPTH = 8
+
 
 @functools.cache
 def _load_worker(model_dir: str, device_batch: int, max_tokens: int, calib_file: str):
+    """Parent-side warm: scorer + calibration + compiled forward. Tokenization lives in the
+    fork children, so the parent never loads the tokenizer or remap."""
     scorer = load_pooled_scorer(model_dir)
-    remap, tokenizer_name, _ = load_remap_meta(model_dir)
-    lut = remap_to_array(remap)
     with open_url(f"{model_dir.rstrip('/')}/{calib_file}", "r") as fh:
         calib = json.loads(fh.read())
     xk = np.asarray(calib["xk"], dtype=np.float64)
@@ -75,130 +88,204 @@ def _load_worker(model_dir: str, device_batch: int, max_tokens: int, calib_file:
     # Warm the compile for the padded launch shape.
     warm = jax.device_put(jnp.zeros((device_batch, max_tokens), dtype=jnp.int32), batch_shard)
     jax.block_until_ready(_predict_batch(scorer.model, warm))
-    logger.info(
-        "fast worker warm: %d chips, device_batch=%d tok=%d tokenizer=%s", ndev, device_batch, max_tokens, tokenizer_name
-    )
-    return scorer, lut, tokenizer_name, xk, yk, batch_shard
+    logger.info("fast worker warm: %d chips, device_batch=%d tok=%d", ndev, device_batch, max_tokens)
+    return scorer, xk, yk, batch_shard
 
 
 @functools.cache
-def _get_pool(model_dir: str, tok_procs: int) -> ProcessPoolExecutor:
-    """One tokenizer pool per worker (children are jax-free, load the tokenizer once).
+def _get_read_pool(read_threads: int) -> ThreadPoolExecutor:
+    """Thread pool for the row-group arrow reads (the read + parquet decode release the GIL)."""
+    return ThreadPoolExecutor(max_workers=read_threads, thread_name_prefix="rg-read")
 
-    Uses ``fork``, not ``spawn``: the Zephyr worker's ``__main__`` is the (unguarded) iris
-    actor bootstrap, so spawn's ``_check_not_importing_main`` aborts. Fork is safe here only
-    because this is called BEFORE the parent initializes JAX (``_load_worker``) -- the child
-    inherits a pre-TPU process image and never touches jax.
+
+@functools.cache
+def _get_fork_pool(model_dir: str, tok_procs: int) -> ProcessPoolExecutor:
+    """Fork tokenizer pool -- true multi-core tokenization off the GIL.
+
+    ``fork`` (not ``spawn``): the Zephyr worker's ``__main__`` is the unguarded iris actor
+    bootstrap, so spawn's ``_check_not_importing_main`` aborts. Fork is safe only because this
+    runs BEFORE the parent initializes JAX (``_load_worker``) -- children inherit a pre-TPU
+    image and never touch the chips. The tokenizer + remap are warmed here first so forked
+    children inherit them copy-on-write instead of re-staging.
     """
+    remap, tokenizer_name, _ = load_remap_meta(model_dir)
+    load_shared_tokenizer(tokenizer_name)
+    remap_to_array(remap)
     ctx = mp.get_context("fork")
     pool = ProcessPoolExecutor(
         max_workers=tok_procs, mp_context=ctx, initializer=tokenize_worker.child_init, initargs=(model_dir,)
     )
-    # Force children to spin up (and load the tokenizer) now, still before JAX init.
+    # Force children to spin up (and bind the tokenizer) now, still before JAX init.
     list(pool.map(tokenize_worker.child_warm, range(tok_procs)))
-    logger.info("tokenizer pool: %d fork procs", tok_procs)
+    logger.info("tokenizer fork pool: %d procs", tok_procs)
     return pool
 
 
-def _stage_to_device(model, ids: np.ndarray, batch_shard, device_batch: int):
-    """Pad ``ids`` to ``device_batch`` rows, ship H2D, launch forward -> (jax_out, n_real)."""
-    n = ids.shape[0]
-    if n < device_batch:
-        ids = np.concatenate([ids, np.zeros((device_batch - n, ids.shape[1]), dtype=ids.dtype)], axis=0)
-    dev = jax.device_put(jnp.asarray(ids), batch_shard)
-    return _predict_batch(model, dev), n
+def _num_row_groups(path: str) -> int:
+    with open_url(path, "rb") as f:
+        return pq.ParquetFile(f).metadata.num_row_groups
 
 
-def _score_shard(records, model_dir, device_batch, calib_file, tok_procs):
-    """Score one shard's docs; returns (rows, stats). Tokenizes across ``tok_procs`` cores."""
-    # Build the fork pool BEFORE JAX inits (children must inherit a pre-TPU process image).
-    pool = _get_pool(model_dir, tok_procs) if tok_procs and tok_procs > 1 else None
-    scorer, lut, tokenizer_name, xk, yk, batch_shard = _load_worker(model_dir, device_batch, 512, calib_file)
-    max_tokens = scorer.max_tokens
+def _read_and_window_rg(path: str, rg_index: int) -> tuple[list, list[list[str]]]:
+    """Read one row group's ``id``/``text`` columns and window each doc (runs on a read thread)."""
+    with open_url(path, "rb") as f:
+        table = pq.ParquetFile(f).read_row_group(rg_index, columns=READ_COLUMNS)
+    ids = table.column("id").to_pylist()
+    texts = table.column("text").to_pylist()
+    return ids, [doc_windows(t or "") for t in texts]
 
-    # Materialize the shard's window texts in order (a shard is ~one file). ``doc_windows``
-    # always yields >=1 window, so ``ids_out`` (one id per input doc) preserves the exact
-    # input row count, and ``doc_pos_of_win`` maps each window back to its doc for the reduce.
-    stats = {"tokenize_s": 0.0, "forward_s": 0.0, "window_s": 0.0, "reduce_s": 0.0, "n_tokens": 0}
-    t_win = time.perf_counter()
+
+def _iter_blocks(doc_ids: list, doc_win: list[list[str]], device_batch: int):
+    """Cut a row group's docs into blocks of <= ``device_batch`` windows, at doc boundaries.
+
+    Yields ``(block_ids, win_texts, win_doc)`` where ``win_doc[i]`` is the block-local doc
+    index of window ``i`` -- everything a block needs to reduce its windows back to docs.
+    """
+    block_ids: list = []
     win_texts: list[str] = []
-    doc_pos_of_win: list[int] = []
-    ids_out: list[object] = []
-    for doc_pos, r in enumerate(records):
-        ids_out.append(r["id"])
-        for w in doc_windows(r.get("text") or ""):
-            win_texts.append(w)
-            doc_pos_of_win.append(doc_pos)
-    stats["window_s"] = time.perf_counter() - t_win
+    win_doc: list[int] = []
+    for doc_id, windows in zip(doc_ids, doc_win, strict=True):
+        if win_texts and len(win_texts) + len(windows) > device_batch:
+            yield block_ids, win_texts, np.asarray(win_doc, dtype=np.int64)
+            block_ids, win_texts, win_doc = [], [], []
+        local = len(block_ids)
+        block_ids.append(doc_id)
+        win_texts.extend(windows)
+        win_doc.extend([local] * len(windows))
+    if win_texts:
+        yield block_ids, win_texts, np.asarray(win_doc, dtype=np.int64)
 
-    n_windows = len(win_texts)
-    win_scores = np.empty(n_windows, dtype=np.float32)
-    # One tokenize batch == one device launch. A large batch lets the tokenizer's rayon
-    # pool fill the host cores on the main thread (its parallelism only engages there).
-    starts = list(range(0, n_windows, device_batch))
-    batches = [win_texts[s : s + device_batch] for s in starts]
 
-    def forward(start: int, ids: np.ndarray):
-        stats["n_tokens"] += int((ids != 0).sum())
-        t1 = time.perf_counter()
-        out, n = _stage_to_device(scorer.model, ids, batch_shard, device_batch)
-        win_scores[start : start + n] = np.asarray(out)[:n]
-        stats["forward_s"] += time.perf_counter() - t1
+def _read_and_put(shm_name: str, shape: tuple[int, int], batch_shard, device_batch: int):
+    """Copy a child's packed block out of shared memory, pad to ``device_batch``, ship H2D.
 
-    t0 = time.perf_counter()
-    if pool is not None:
-        # Children tokenize in parallel; results stream back in submission order and are
-        # forwarded on-device by the parent -> tokenization overlaps forward + reduce.
-        for start, ids in zip(starts, pool.map(tokenize_worker.child_tokenize, batches), strict=True):
-            forward(start, ids)
-    else:
-        for start, texts in zip(starts, batches, strict=True):
-            forward(start, pack_windows(texts, tokenizer_name, lut, max_tokens))
-    stats["tokenize_s"] = time.perf_counter() - t0 - stats["forward_s"]
+    The copy lets us ``unlink`` the segment immediately; ``device_put`` then owns the data.
+    """
+    shm = shared_memory.SharedMemory(name=shm_name)
+    try:
+        packed = np.ndarray(shape, dtype=np.int32, buffer=shm.buf)
+        n = shape[0]
+        out = np.zeros((device_batch, shape[1]), dtype=np.int32)
+        out[:n] = packed
+    finally:
+        shm.close()
+        shm.unlink()
+    return jax.device_put(out, batch_shard), n
 
-    # Reduce windows -> doc (mean) with a vectorized scatter-add (np.add.at), in doc order.
-    t_red = time.perf_counter()
-    n_docs = len(ids_out)
-    pos = np.asarray(doc_pos_of_win, dtype=np.int64)
+
+def _forward_and_reduce(model, block_ids, win_doc, dev, n_real, xk, yk, stats) -> list[dict]:
+    """Forward a staged device block and reduce its windows to per-doc score rows."""
+    t1 = time.perf_counter()
+    win_scores = np.asarray(_predict_batch(model, dev))[:n_real]  # launch forward + D2H
+    stats["forward_s"] += time.perf_counter() - t1
+    stats["n_windows"] += n_real
+
+    n_docs = len(block_ids)
     sums = np.zeros(n_docs, dtype=np.float64)
     cnts = np.zeros(n_docs, dtype=np.int64)
-    np.add.at(sums, pos, win_scores)
-    np.add.at(cnts, pos, 1)
+    np.add.at(sums, win_doc, win_scores)
+    np.add.at(cnts, win_doc, 1)
     raw = sums / np.maximum(cnts, 1)
     cal = np.interp(raw, xk, yk)
     buckets = np.digitize(cal, BUCKET_EDGES)
-    rows = [{"id": ids_out[i], "score": float(cal[i]), "quality_bucket": int(buckets[i])} for i in range(n_docs)]
-    stats["reduce_s"] = time.perf_counter() - t_red
-    stats["n_docs"] = n_docs
-    stats["n_windows"] = n_windows
+    return [{"id": block_ids[i], "score": float(cal[i]), "quality_bucket": int(buckets[i])} for i in range(n_docs)]
+
+
+def _score_file(path, model_dir, device_batch, tok_procs, read_threads, calib_file):
+    """Score one parquet file's docs; returns ``(rows, stats)``.
+
+    ``rows`` are per-doc ``{id, score, quality_bucket}``; ``stats`` carries the read/forward/
+    compute timings and the token/window/doc counts.
+    """
+    # Fork pool BEFORE JAX init (children must inherit a pre-TPU image).
+    fork_pool = _get_fork_pool(model_dir, tok_procs)
+    read_pool = _get_read_pool(read_threads)
+    scorer, xk, yk, batch_shard = _load_worker(model_dir, device_batch, 512, calib_file)
+    stats = {"read_s": 0.0, "forward_s": 0.0, "compute_s": 0.0, "n_tokens": 0, "n_windows": 0}
+
+    n_rg = _num_row_groups(path)
+    read_futs = [read_pool.submit(_read_and_window_rg, path, i) for i in range(n_rg)]
+    tok_futs: dict = {}
+    t_read = time.perf_counter()
+    for rf in as_completed(read_futs):
+        doc_ids, doc_win = rf.result()
+        for block_ids, win_texts, win_doc in _iter_blocks(doc_ids, doc_win, device_batch):
+            tok_futs[fork_pool.submit(tokenize_worker.child_pack, win_texts)] = (block_ids, win_doc)
+    stats["read_s"] = time.perf_counter() - t_read
+
+    # Stage (shm copy + H2D) on a helper thread so the forward thread never waits on the transfer.
+    staged: queue.Queue = queue.Queue(maxsize=STAGE_QUEUE_DEPTH)
+    stage_err: list[Exception] = []
+
+    def _stage() -> None:
+        try:
+            for tf in as_completed(tok_futs):
+                block_ids, win_doc = tok_futs[tf]
+                shm_name, shape, n_tokens = tf.result()
+                dev, n_real = _read_and_put(shm_name, shape, batch_shard, device_batch)
+                staged.put((block_ids, win_doc, dev, n_real, n_tokens))
+        except Exception as e:  # surface to the main thread instead of wedging its get()
+            stage_err.append(e)
+        finally:
+            staged.put(None)
+
+    rows: list[dict] = []
+    t_compute = time.perf_counter()
+    stager = threading.Thread(target=_stage, name="stage-h2d")
+    stager.start()
+    while (item := staged.get()) is not None:
+        block_ids, win_doc, dev, n_real, n_tokens = item
+        stats["n_tokens"] += n_tokens
+        rows.extend(_forward_and_reduce(scorer.model, block_ids, win_doc, dev, n_real, xk, yk, stats))
+    stager.join()
+    if stage_err:
+        raise stage_err[0]
+    stats["compute_s"] = time.perf_counter() - t_compute
+    stats["n_docs"] = len(rows)
     return rows, stats
 
 
-def _writer(output_path, model_dir, device_batch, calib_file, tok_procs):
-    def writer(records: Iterator[dict], shard: ShardInfo) -> Iterator[dict]:
-        records = iter(records)
-        first = next(records, None)
-        if first is None:
-            return
-        shard_file = posixpath.basename(first[DEFAULT_FILE_PATH_COLUMN])
-        rows, stats = _score_shard([first, *records], model_dir, device_batch, calib_file, tok_procs)
-        out_file = f"{output_path.rstrip('/')}/outputs/main/{shard_file}"
-        result: dict = {}
+def _write_rows(rows: list[dict], out_file: str) -> dict:
+    result: dict = {}
 
-        def _sink(items):
-            result.update(write_parquet_file(items, output_path=out_file))
+    def _sink(items):
+        result.update(write_parquet_file(items, output_path=out_file))
 
-        with ThreadedBatchWriter(_sink) as w:
-            for row in rows:
-                w.submit(row)
-        counters.pipeline.update_counter("fast/docs", stats["n_docs"])
-        counters.pipeline.update_counter("fast/windows", stats["n_windows"])
-        counters.pipeline.update_counter("fast/tokens", stats["n_tokens"])
-        counters.pipeline.update_counter("fast/tokenize_ms", int(stats["tokenize_s"] * 1000))
-        counters.pipeline.update_counter("fast/forward_ms", int(stats["forward_s"] * 1000))
-        counters.pipeline.update_counter("fast/window_ms", int(stats["window_s"] * 1000))
-        counters.pipeline.update_counter("fast/reduce_ms", int(stats["reduce_s"] * 1000))
-        yield {"shard_file": shard_file, "docs": stats["n_docs"], **result}
+    with ThreadedBatchWriter(_sink) as w:
+        for row in rows:
+            w.submit(row)
+    return result
+
+
+def _writer(output_path, model_dir, device_batch, calib_file, tok_procs, read_threads):
+    def writer(paths: Iterator[str], shard: ShardInfo) -> Iterator[dict]:
+        for path in paths:
+            t0 = time.perf_counter()
+            rows, stats = _score_file(path, model_dir, device_batch, tok_procs, read_threads, calib_file)
+            out_file = f"{output_path.rstrip('/')}/outputs/main/{posixpath.basename(path)}"
+            t_write = time.perf_counter()
+            result = _write_rows(rows, out_file)
+            write_s = time.perf_counter() - t_write
+            shard_s = time.perf_counter() - t0
+            logger.info(
+                "shard %s: %.1fs (read %.1f, compute %.1f, write %.1f) -> %d docs, %.0f docs/s",
+                posixpath.basename(path),
+                shard_s,
+                stats["read_s"],
+                stats["compute_s"],
+                write_s,
+                stats["n_docs"],
+                stats["n_docs"] / shard_s if shard_s else 0,
+            )
+            counters.pipeline.update_counter("fast/docs", stats["n_docs"])
+            counters.pipeline.update_counter("fast/windows", stats["n_windows"])
+            counters.pipeline.update_counter("fast/tokens", stats["n_tokens"])
+            counters.pipeline.update_counter("fast/read_ms", int(stats["read_s"] * 1000))
+            counters.pipeline.update_counter("fast/forward_ms", int(stats["forward_s"] * 1000))
+            counters.pipeline.update_counter("fast/compute_ms", int(stats["compute_s"] * 1000))
+            counters.pipeline.update_counter("fast/write_ms", int(write_s * 1000))
+            counters.pipeline.update_counter("fast/shard_ms", int(shard_s * 1000))
+            yield {"shard_file": posixpath.basename(path), "docs": stats["n_docs"], **result}
 
     return writer
 
@@ -212,35 +299,30 @@ def run(
     max_workers,
     device_batch,
     tok_procs,
+    read_threads,
     calib_file,
     result_json,
-    cpu_only=False,
-    cpu=180,
 ):
     files = sorted(str(m) for m in StoragePath(corpus_glob).glob())[:max_files]
     if not files:
         raise ValueError(f"no files matched {corpus_glob}")
     logger.info(
-        "fast: %d files, %d workers, device_batch=%d tok_procs=%d cpu_only=%s",
+        "fast: %d files, %d workers, device_batch=%d tok_procs=%d read_threads=%d",
         len(files),
         max_workers,
         device_batch,
         tok_procs,
-        cpu_only,
+        read_threads,
     )
-    pipeline = (
-        Dataset.from_list(files)
-        .flat_map(functools.partial(load_file, include_file_paths=True))
-        .map_shard(_writer(output_path, model_dir, device_batch, calib_file, tok_procs))
+    pipeline = Dataset.from_list(files).map_shard(
+        _writer(output_path, model_dir, device_batch, calib_file, tok_procs, read_threads)
     )
-    # cpu_only measures the "before" baseline the issue describes: the same forward + tokenize
-    # path with no TPU, so JAX runs the forward on the host CPUs where it competes with
-    # tokenization for cores (on a v6e the forward instead offloads to otherwise-idle chips).
-    resources = (
-        ResourceConfig(cpu=cpu, ram=f"{cpu * 3}g") if cpu_only else ResourceConfig.with_tpu("v6e-4", cpu=180, ram="600g")
-    )
+    # Request 128 of the host's 180 vCPUs (not the whole host): the pipeline uses ~tok_procs
+    # tokenizer cores plus the read threads and JAX dispatch, and leaving headroom lets the
+    # worker co-schedule onto a host other tenants already partially occupy vs forcing a fresh slice.
+    resources = ResourceConfig.with_tpu("v6e-4", cpu=TPU_HOST_CPU, ram="400g")
     ctx = ZephyrContext(
-        name="ft-fast-cpu" if cpu_only else "ft-fast",
+        name="ft-fast",
         resources=resources,
         max_workers=max_workers,
         stage_runner_factory=InlineRunner,
@@ -251,12 +333,12 @@ def run(
     wall = time.time() - t0
     docs = agg.get("fast/docs", 0)
     tokens = agg.get("fast/tokens", 0)
-    n_chips = 0 if cpu_only else 4 * max_workers
+    n_chips = 4 * max_workers
     payload = {
-        "stage": "fast_cpu" if cpu_only else "fast",
-        "cpu_only": cpu_only,
-        "cpu_per_worker": cpu if cpu_only else 180,
+        "stage": "fast",
+        "cpu_per_worker": TPU_HOST_CPU,
         "tok_procs": tok_procs,
+        "read_threads": read_threads,
         "files": len(files),
         "workers_v6e4": max_workers,
         "n_chips": n_chips,
@@ -268,14 +350,14 @@ def run(
         "docs_per_s": round(docs / wall, 1) if wall else 0,
         "tokens_per_s": round(tokens / wall, 1) if wall else 0,
         "tokens_per_s_per_chip": round(tokens / wall / n_chips, 1) if wall and n_chips else 0,
-        "tokenize_worker_s": round(agg.get("fast/tokenize_ms", 0) / 1000, 1),
+        "read_worker_s": round(agg.get("fast/read_ms", 0) / 1000, 1),
         "forward_worker_s": round(agg.get("fast/forward_ms", 0) / 1000, 1),
-        "window_worker_s": round(agg.get("fast/window_ms", 0) / 1000, 1),
-        "reduce_worker_s": round(agg.get("fast/reduce_ms", 0) / 1000, 1),
+        "compute_worker_s": round(agg.get("fast/compute_ms", 0) / 1000, 1),
+        "write_worker_s": round(agg.get("fast/write_ms", 0) / 1000, 1),
+        "shard_worker_s": round(agg.get("fast/shard_ms", 0) / 1000, 1),
         "counters": agg,
     }
     print("BENCH " + json.dumps(payload), flush=True)
     if result_json:
-        with open_url(result_json, "w") as fh:
-            fh.write(json.dumps(payload, indent=2))
+        write_result_json(result_json, payload)
     return payload

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fast_stage.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fast_stage.py
@@ -66,7 +66,7 @@ logger = logging.getLogger(__name__)
 def _load_worker(model_dir: str, device_batch: int, max_tokens: int, calib_file: str):
     scorer = load_pooled_scorer(model_dir)
     remap, tokenizer_name, _ = load_remap_meta(model_dir)
-    lut = remap_to_array(remap, len(remap) + 2)
+    lut = remap_to_array(remap)
     with open_url(f"{model_dir.rstrip('/')}/{calib_file}", "r") as fh:
         calib = json.loads(fh.read())
     xk = np.asarray(calib["xk"], dtype=np.float64)

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fast_stage.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fast_stage.py
@@ -18,7 +18,7 @@ the GIL), so this stage keeps one shard on one Zephyr worker and drives its own 
     rayon pool disabled.
   - A stager thread pulls finished blocks and ships them to the chips (``device_put``); the
     main thread only forwards the staged device arrays and reduces windows -> per-doc scores.
-    Reads, tokenization, the H2D transfer, and the forward all overlap.
+    Reads overlap tokenization; the stager's H2D transfers then overlap the forward and reduce.
 
 Weights/vocab come from the config-faithful scorer dir.
 """
@@ -85,7 +85,7 @@ def _load_worker(model_dir: str, device_batch: int, max_tokens: int, calib_file:
     """Parent-side warm: scorer + calibration + compiled forward. Tokenization lives in the
     fork children, so the parent never loads the tokenizer or remap."""
     scorer = load_pooled_scorer(model_dir)
-    with open_url(f"{model_dir.rstrip('/')}/{calib_file}", "r") as fh:
+    with open_url(str(StoragePath(model_dir) / calib_file), "r") as fh:
         calib = json.loads(fh.read())
     xk = np.asarray(calib["xk"], dtype=np.float64)
     yk = np.asarray(calib["yk"], dtype=np.float64)
@@ -267,7 +267,7 @@ def _writer(output_path, model_dir, device_batch, calib_file, tok_procs, read_th
         for path in paths:
             t0 = time.perf_counter()
             rows, stats = _score_file(path, model_dir, device_batch, tok_procs, read_threads, calib_file)
-            out_file = f"{output_path.rstrip('/')}/outputs/main/{posixpath.basename(path)}"
+            out_file = str(StoragePath(output_path) / "outputs" / "main" / posixpath.basename(path))
             t_write = time.perf_counter()
             result = _write_rows(rows, out_file)
             write_s = time.perf_counter() - t_write
@@ -362,7 +362,7 @@ def run(
         "tok_procs": tok_procs,
         "read_threads": read_threads,
         "files": len(files),
-        "workers_v6e4": max_workers,
+        "workers": max_workers,
         "n_chips": n_chips,
         "device_batch": device_batch,
         "wall_s": round(wall, 1),

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fast_stage.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fast_stage.py
@@ -58,18 +58,23 @@ from experiments.datakit.cluster.quality.fast_transformer.inference import (
 from experiments.datakit.cluster.quality.fast_transformer.scorer import load_pooled_scorer
 from experiments.datakit.cluster.quality.fast_transformer.tpu_bench import tokenize_worker
 from experiments.datakit.cluster.quality.fast_transformer.tpu_bench.common import (
+    DEFAULT_CORPUS,
     doc_windows,
     load_remap_meta,
     load_shared_tokenizer,
     remap_to_array,
+    resolve_dataset_path,
     write_result_json,
 )
 
 logger = logging.getLogger(__name__)
 
 READ_COLUMNS = ["id", "text"]
-# vCPUs requested per v6e-4 worker (of the host's 180) -- see the ResourceConfig note in run().
+# Default vCPUs requested per worker of the accelerator host. TPU: 128 of a v6e-4's 180 (leave
+# headroom so the worker co-schedules with other tenants vs forcing a fresh slice). GPU: a
+# smaller share of an 8x-GPU node's host, still plenty for the tokenizer fork pool.
 TPU_HOST_CPU = 128
+GPU_HOST_CPU = 96
 # How many staged (H2D'd) blocks the stager thread may run ahead of the forward. Bounds the
 # resident device memory while keeping the chips fed; the forward is never blocked on H2D.
 STAGE_QUEUE_DEPTH = 8
@@ -290,6 +295,20 @@ def _writer(output_path, model_dir, device_batch, calib_file, tok_procs, read_th
     return writer
 
 
+def _resolve_resources(accelerator: str, worker_cpu: int | None) -> tuple[ResourceConfig, int]:
+    """Resolve an accelerator request to ``(ResourceConfig, chips_per_worker)``.
+
+    ``accelerator`` is a TPU type (``"v6e-4"``, ``"v5litepod-16"``) or a GPU ``VARIANTxCOUNT``
+    (``"H100x8"``). The forward runs data-parallel across the worker's chips either way.
+    """
+    if "x" in accelerator:  # GPU, e.g. "H100x8"
+        variant, _, count = accelerator.partition("x")
+        cpu = worker_cpu if worker_cpu is not None else GPU_HOST_CPU
+        return ResourceConfig.with_gpu(variant, count=int(count), cpu=cpu, ram=f"{cpu * 4}g"), int(count)
+    cpu = worker_cpu if worker_cpu is not None else TPU_HOST_CPU
+    return ResourceConfig.with_tpu(accelerator, cpu=cpu, ram="400g"), int(accelerator.rsplit("-", 1)[1])
+
+
 def run(
     *,
     corpus_glob,
@@ -302,14 +321,20 @@ def run(
     read_threads,
     calib_file,
     result_json,
+    accelerator="v6e-4",
+    worker_cpu=None,
 ):
+    corpus_glob = resolve_dataset_path(corpus_glob or DEFAULT_CORPUS)
+    model_dir = resolve_dataset_path(model_dir)
     files = sorted(str(m) for m in StoragePath(corpus_glob).glob())[:max_files]
     if not files:
         raise ValueError(f"no files matched {corpus_glob}")
+    resources, chips_per_worker = _resolve_resources(accelerator, worker_cpu)
     logger.info(
-        "fast: %d files, %d workers, device_batch=%d tok_procs=%d read_threads=%d",
+        "fast: %d files, %d %s workers, device_batch=%d tok_procs=%d read_threads=%d",
         len(files),
         max_workers,
+        accelerator,
         device_batch,
         tok_procs,
         read_threads,
@@ -317,10 +342,6 @@ def run(
     pipeline = Dataset.from_list(files).map_shard(
         _writer(output_path, model_dir, device_batch, calib_file, tok_procs, read_threads)
     )
-    # Request 128 of the host's 180 vCPUs (not the whole host): the pipeline uses ~tok_procs
-    # tokenizer cores plus the read threads and JAX dispatch, and leaving headroom lets the
-    # worker co-schedule onto a host other tenants already partially occupy vs forcing a fresh slice.
-    resources = ResourceConfig.with_tpu("v6e-4", cpu=TPU_HOST_CPU, ram="400g")
     ctx = ZephyrContext(
         name="ft-fast",
         resources=resources,
@@ -333,10 +354,11 @@ def run(
     wall = time.time() - t0
     docs = agg.get("fast/docs", 0)
     tokens = agg.get("fast/tokens", 0)
-    n_chips = 4 * max_workers
+    n_chips = chips_per_worker * max_workers
     payload = {
         "stage": "fast",
-        "cpu_per_worker": TPU_HOST_CPU,
+        "accelerator": accelerator,
+        "cpu_per_worker": resources.cpu,
         "tok_procs": tok_procs,
         "read_threads": read_threads,
         "files": len(files),

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fast_stage.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fast_stage.py
@@ -1,0 +1,281 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The fast scoring pipeline: parallel-tokenize on the v6e host, forward on the chips.
+
+A v6e-4 VM has 4 chips *and* a 180-vCPU host. The forward is dispatch-bound (~1% MXU) and
+scoring a shard's windows on-device costs a few seconds, so throughput is host-bound. This
+stage keeps everything on one Zephyr worker (one shard per worker) and parallelizes the
+tokenization across the host cores:
+
+  - ``--tok-procs 0``: tokenize on the main thread. The HF fast tokenizer is Rust/rayon
+    multi-core, but ONLY when called from the main thread -- calling it from a worker
+    thread silently drops to single-core.
+  - ``--tok-procs N``: a fork process pool (``tokenize_worker``, jax-free so children never
+    touch the TPU) tokenizes window batches across N cores; the main process pulls packed
+    batches in order and runs the forward, so tokenization overlaps the forward.
+
+With tokenization parallel, the per-shard wall is dominated by the GCS parquet data path
+(read/decode the input, write the output), not by tokenize/forward/reduce. ``--cpu-only``
+runs the same path with no TPU (the forward on the host CPUs) for the CPU baseline.
+Weights/vocab come from the config-faithful scorer dir.
+"""
+
+import functools
+import json
+import logging
+import multiprocessing as mp
+import os
+import posixpath
+import time
+from collections.abc import Iterator
+from concurrent.futures import ProcessPoolExecutor
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from fray.cluster import ResourceConfig
+from rigging.filesystem import StoragePath, open_url
+from zephyr import counters
+from zephyr.dataset import Dataset, ShardInfo
+from zephyr.execution import ZephyrContext
+from zephyr.readers import DEFAULT_FILE_PATH_COLUMN, load_file
+from zephyr.runners import InlineRunner
+from zephyr.writers import ThreadedBatchWriter, write_parquet_file
+
+os.environ["TOKENIZERS_PARALLELISM"] = "true"
+
+from experiments.datakit.cluster.quality.fast_transformer.artifact import BUCKET_EDGES
+from experiments.datakit.cluster.quality.fast_transformer.inference import (
+    _predict_batch,
+    data_parallel_shardings,
+)
+from experiments.datakit.cluster.quality.fast_transformer.scorer import load_pooled_scorer
+from experiments.datakit.cluster.quality.fast_transformer.tpu_bench import tokenize_worker
+from experiments.datakit.cluster.quality.fast_transformer.tpu_bench.common import (
+    doc_windows,
+    load_remap_meta,
+    pack_windows,
+    remap_to_array,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@functools.cache
+def _load_worker(model_dir: str, device_batch: int, max_tokens: int, calib_file: str):
+    scorer = load_pooled_scorer(model_dir)
+    remap, tokenizer_name, _ = load_remap_meta(model_dir)
+    lut = remap_to_array(remap, len(remap) + 2)
+    with open_url(f"{model_dir.rstrip('/')}/{calib_file}", "r") as fh:
+        calib = json.loads(fh.read())
+    xk = np.asarray(calib["xk"], dtype=np.float64)
+    yk = np.asarray(calib["yk"], dtype=np.float64)
+    ndev, _, batch_shard = data_parallel_shardings()
+    # Warm the compile for the padded launch shape.
+    warm = jax.device_put(jnp.zeros((device_batch, max_tokens), dtype=jnp.int32), batch_shard)
+    jax.block_until_ready(_predict_batch(scorer.model, warm))
+    logger.info(
+        "fast worker warm: %d chips, device_batch=%d tok=%d tokenizer=%s", ndev, device_batch, max_tokens, tokenizer_name
+    )
+    return scorer, lut, tokenizer_name, xk, yk, batch_shard
+
+
+@functools.cache
+def _get_pool(model_dir: str, tok_procs: int) -> ProcessPoolExecutor:
+    """One tokenizer pool per worker (children are jax-free, load the tokenizer once).
+
+    Uses ``fork``, not ``spawn``: the Zephyr worker's ``__main__`` is the (unguarded) iris
+    actor bootstrap, so spawn's ``_check_not_importing_main`` aborts. Fork is safe here only
+    because this is called BEFORE the parent initializes JAX (``_load_worker``) -- the child
+    inherits a pre-TPU process image and never touches jax.
+    """
+    ctx = mp.get_context("fork")
+    pool = ProcessPoolExecutor(
+        max_workers=tok_procs, mp_context=ctx, initializer=tokenize_worker.child_init, initargs=(model_dir,)
+    )
+    # Force children to spin up (and load the tokenizer) now, still before JAX init.
+    list(pool.map(tokenize_worker.child_warm, range(tok_procs)))
+    logger.info("tokenizer pool: %d fork procs", tok_procs)
+    return pool
+
+
+def _stage_to_device(model, ids: np.ndarray, batch_shard, device_batch: int):
+    """Pad ``ids`` to ``device_batch`` rows, ship H2D, launch forward -> (jax_out, n_real)."""
+    n = ids.shape[0]
+    if n < device_batch:
+        ids = np.concatenate([ids, np.zeros((device_batch - n, ids.shape[1]), dtype=ids.dtype)], axis=0)
+    dev = jax.device_put(jnp.asarray(ids), batch_shard)
+    return _predict_batch(model, dev), n
+
+
+def _score_shard(records, model_dir, device_batch, calib_file, tok_procs):
+    """Score one shard's docs; returns (rows, stats). Tokenizes across ``tok_procs`` cores."""
+    # Build the fork pool BEFORE JAX inits (children must inherit a pre-TPU process image).
+    pool = _get_pool(model_dir, tok_procs) if tok_procs and tok_procs > 1 else None
+    scorer, lut, tokenizer_name, xk, yk, batch_shard = _load_worker(model_dir, device_batch, 512, calib_file)
+    max_tokens = scorer.max_tokens
+
+    # Materialize the shard's window texts in order (a shard is ~one file). ``doc_windows``
+    # always yields >=1 window, so ``ids_out`` (one id per input doc) preserves the exact
+    # input row count, and ``doc_pos_of_win`` maps each window back to its doc for the reduce.
+    stats = {"tokenize_s": 0.0, "forward_s": 0.0, "window_s": 0.0, "reduce_s": 0.0, "n_tokens": 0}
+    t_win = time.perf_counter()
+    win_texts: list[str] = []
+    doc_pos_of_win: list[int] = []
+    ids_out: list[object] = []
+    for doc_pos, r in enumerate(records):
+        ids_out.append(r["id"])
+        for w in doc_windows(r.get("text") or ""):
+            win_texts.append(w)
+            doc_pos_of_win.append(doc_pos)
+    stats["window_s"] = time.perf_counter() - t_win
+
+    n_windows = len(win_texts)
+    win_scores = np.empty(n_windows, dtype=np.float32)
+    # One tokenize batch == one device launch. A large batch lets the tokenizer's rayon
+    # pool fill the host cores on the main thread (its parallelism only engages there).
+    starts = list(range(0, n_windows, device_batch))
+    batches = [win_texts[s : s + device_batch] for s in starts]
+
+    def forward(start: int, ids: np.ndarray):
+        stats["n_tokens"] += int((ids != 0).sum())
+        t1 = time.perf_counter()
+        out, n = _stage_to_device(scorer.model, ids, batch_shard, device_batch)
+        win_scores[start : start + n] = np.asarray(out)[:n]
+        stats["forward_s"] += time.perf_counter() - t1
+
+    t0 = time.perf_counter()
+    if pool is not None:
+        # Children tokenize in parallel; results stream back in submission order and are
+        # forwarded on-device by the parent -> tokenization overlaps forward + reduce.
+        for start, ids in zip(starts, pool.map(tokenize_worker.child_tokenize, batches), strict=True):
+            forward(start, ids)
+    else:
+        for start, texts in zip(starts, batches, strict=True):
+            forward(start, pack_windows(texts, tokenizer_name, lut, max_tokens))
+    stats["tokenize_s"] = time.perf_counter() - t0 - stats["forward_s"]
+
+    # Reduce windows -> doc (mean) with a vectorized scatter-add (np.add.at), in doc order.
+    t_red = time.perf_counter()
+    n_docs = len(ids_out)
+    pos = np.asarray(doc_pos_of_win, dtype=np.int64)
+    sums = np.zeros(n_docs, dtype=np.float64)
+    cnts = np.zeros(n_docs, dtype=np.int64)
+    np.add.at(sums, pos, win_scores)
+    np.add.at(cnts, pos, 1)
+    raw = sums / np.maximum(cnts, 1)
+    cal = np.interp(raw, xk, yk)
+    buckets = np.digitize(cal, BUCKET_EDGES)
+    rows = [{"id": ids_out[i], "score": float(cal[i]), "quality_bucket": int(buckets[i])} for i in range(n_docs)]
+    stats["reduce_s"] = time.perf_counter() - t_red
+    stats["n_docs"] = n_docs
+    stats["n_windows"] = n_windows
+    return rows, stats
+
+
+def _writer(output_path, model_dir, device_batch, calib_file, tok_procs):
+    def writer(records: Iterator[dict], shard: ShardInfo) -> Iterator[dict]:
+        records = iter(records)
+        first = next(records, None)
+        if first is None:
+            return
+        shard_file = posixpath.basename(first[DEFAULT_FILE_PATH_COLUMN])
+        rows, stats = _score_shard([first, *records], model_dir, device_batch, calib_file, tok_procs)
+        out_file = f"{output_path.rstrip('/')}/outputs/main/{shard_file}"
+        result: dict = {}
+
+        def _sink(items):
+            result.update(write_parquet_file(items, output_path=out_file))
+
+        with ThreadedBatchWriter(_sink) as w:
+            for row in rows:
+                w.submit(row)
+        counters.pipeline.update_counter("fast/docs", stats["n_docs"])
+        counters.pipeline.update_counter("fast/windows", stats["n_windows"])
+        counters.pipeline.update_counter("fast/tokens", stats["n_tokens"])
+        counters.pipeline.update_counter("fast/tokenize_ms", int(stats["tokenize_s"] * 1000))
+        counters.pipeline.update_counter("fast/forward_ms", int(stats["forward_s"] * 1000))
+        counters.pipeline.update_counter("fast/window_ms", int(stats["window_s"] * 1000))
+        counters.pipeline.update_counter("fast/reduce_ms", int(stats["reduce_s"] * 1000))
+        yield {"shard_file": shard_file, "docs": stats["n_docs"], **result}
+
+    return writer
+
+
+def run(
+    *,
+    corpus_glob,
+    model_dir,
+    output_path,
+    max_files,
+    max_workers,
+    device_batch,
+    tok_procs,
+    calib_file,
+    result_json,
+    cpu_only=False,
+    cpu=180,
+):
+    files = sorted(str(m) for m in StoragePath(corpus_glob).glob())[:max_files]
+    if not files:
+        raise ValueError(f"no files matched {corpus_glob}")
+    logger.info(
+        "fast: %d files, %d workers, device_batch=%d tok_procs=%d cpu_only=%s",
+        len(files),
+        max_workers,
+        device_batch,
+        tok_procs,
+        cpu_only,
+    )
+    pipeline = (
+        Dataset.from_list(files)
+        .flat_map(functools.partial(load_file, include_file_paths=True))
+        .map_shard(_writer(output_path, model_dir, device_batch, calib_file, tok_procs))
+    )
+    # cpu_only measures the "before" baseline the issue describes: the same forward + tokenize
+    # path with no TPU, so JAX runs the forward on the host CPUs where it competes with
+    # tokenization for cores (on a v6e the forward instead offloads to otherwise-idle chips).
+    resources = (
+        ResourceConfig(cpu=cpu, ram=f"{cpu * 3}g") if cpu_only else ResourceConfig.with_tpu("v6e-4", cpu=180, ram="600g")
+    )
+    ctx = ZephyrContext(
+        name="ft-fast-cpu" if cpu_only else "ft-fast",
+        resources=resources,
+        max_workers=max_workers,
+        stage_runner_factory=InlineRunner,
+        heartbeat_timeout=1800,
+    )
+    t0 = time.time()
+    agg = dict(ctx.execute(pipeline).counters)
+    wall = time.time() - t0
+    docs = agg.get("fast/docs", 0)
+    tokens = agg.get("fast/tokens", 0)
+    n_chips = 0 if cpu_only else 4 * max_workers
+    payload = {
+        "stage": "fast_cpu" if cpu_only else "fast",
+        "cpu_only": cpu_only,
+        "cpu_per_worker": cpu if cpu_only else 180,
+        "tok_procs": tok_procs,
+        "files": len(files),
+        "workers_v6e4": max_workers,
+        "n_chips": n_chips,
+        "device_batch": device_batch,
+        "wall_s": round(wall, 1),
+        "docs": docs,
+        "windows": agg.get("fast/windows", 0),
+        "tokens": tokens,
+        "docs_per_s": round(docs / wall, 1) if wall else 0,
+        "tokens_per_s": round(tokens / wall, 1) if wall else 0,
+        "tokens_per_s_per_chip": round(tokens / wall / n_chips, 1) if wall and n_chips else 0,
+        "tokenize_worker_s": round(agg.get("fast/tokenize_ms", 0) / 1000, 1),
+        "forward_worker_s": round(agg.get("fast/forward_ms", 0) / 1000, 1),
+        "window_worker_s": round(agg.get("fast/window_ms", 0) / 1000, 1),
+        "reduce_worker_s": round(agg.get("fast/reduce_ms", 0) / 1000, 1),
+        "counters": agg,
+    }
+    print("BENCH " + json.dumps(payload), flush=True)
+    if result_json:
+        with open_url(result_json, "w") as fh:
+            fh.write(json.dumps(payload, indent=2))
+    return payload

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fasttext_stage.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fasttext_stage.py
@@ -10,6 +10,7 @@ identical sharding. Reports docs/sec and chars/sec (fasttext's natural units).
 
 import argparse
 import functools
+import itertools
 import json
 import logging
 import os
@@ -64,7 +65,7 @@ def _writer(output_path: str, model_path: str):
         if first is None:
             return
         shard_file = posixpath.basename(first[DEFAULT_FILE_PATH_COLUMN])
-        out_file = f"{output_path.rstrip('/')}/outputs/main/{shard_file}"
+        out_file = str(StoragePath(output_path) / "outputs" / "main" / shard_file)
         timing: dict[str, float] = {}
         result: dict = {}
         n_docs = n_chars = 0
@@ -87,7 +88,7 @@ def _writer(output_path: str, model_path: str):
                 n_docs += len(batch)
                 n_chars += sum(len(t) for t in texts)
 
-            for r in (first, *records):
+            for r in itertools.chain([first], records):
                 batch.append(r)
                 if len(batch) >= PREDICT_BATCH:
                     flush(batch)

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fasttext_stage.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fasttext_stage.py
@@ -28,7 +28,13 @@ from zephyr.readers import DEFAULT_FILE_PATH_COLUMN, load_file
 from zephyr.runners import InlineRunner
 from zephyr.writers import ThreadedBatchWriter, write_parquet_file
 
-from experiments.datakit.cluster.quality.fast_transformer.tpu_bench.common import accumulate, write_result_json
+from experiments.datakit.cluster.quality.fast_transformer.tpu_bench.common import (
+    DEFAULT_CORPUS,
+    FASTTEXT_MODEL,
+    accumulate,
+    resolve_dataset_path,
+    write_result_json,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -98,14 +104,16 @@ def _writer(output_path: str, model_path: str):
 
 def run(
     *,
-    corpus_glob: str,
-    model_path: str,
+    corpus_glob: str | None,
+    model_path: str | None,
     output_path: str,
     max_files: int,
     max_workers: int,
     cpu: int,
     result_json: str | None,
 ):
+    corpus_glob = resolve_dataset_path(corpus_glob or DEFAULT_CORPUS)
+    model_path = resolve_dataset_path(model_path or FASTTEXT_MODEL)
     files = sorted(str(m) for m in StoragePath(corpus_glob).glob())[:max_files]
     if not files:
         raise ValueError(f"no files matched {corpus_glob}")
@@ -148,10 +156,8 @@ def run(
 
 def main() -> None:
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--corpus", required=True)
-    p.add_argument(
-        "--model-path", default="gs://marin-eu-west4/datakit/llm-quality-classifier/model/sonnet46-thr05/model.bin"
-    )
+    p.add_argument("--corpus", default=None, help="text parquet glob; relative paths root at marin_prefix()")
+    p.add_argument("--model-path", default=None, help="fasttext .bin; relative paths root at marin_prefix()")
     p.add_argument("--out-dir", required=True)
     p.add_argument("--max-files", type=int, default=64)
     p.add_argument("--max-workers", type=int, default=32)

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fasttext_stage.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fasttext_stage.py
@@ -1,13 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Pipeline C: fasttext quality-classifier baseline on the SAME corpus slice.
+"""fasttext quality-classifier baseline on the same corpus slice.
 
 Runs the deployed-style fasttext inference (the path the fast-transformer replaced) on a
 CPU Zephyr fleet so the throughput / $ comparison is apples-to-apples: identical doc set,
-identical sharding. fasttext's natural unit is docs/sec (and chars/sec); corpus-token
-throughput is derived from the shared reference-tokenizer count (from the B1 run), so both
-classifiers are compared on the same corpus tokens.
+identical sharding. Reports docs/sec and chars/sec (fasttext's natural units).
 """
 
 import argparse

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fasttext_stage.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/fasttext_stage.py
@@ -1,0 +1,176 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pipeline C: fasttext quality-classifier baseline on the SAME corpus slice.
+
+Runs the deployed-style fasttext inference (the path the fast-transformer replaced) on a
+CPU Zephyr fleet so the throughput / $ comparison is apples-to-apples: identical doc set,
+identical sharding. fasttext's natural unit is docs/sec (and chars/sec); corpus-token
+throughput is derived from the shared reference-tokenizer count (from the B1 run), so both
+classifiers are compared on the same corpus tokens.
+"""
+
+import argparse
+import functools
+import json
+import logging
+import os
+import posixpath
+import tempfile
+import time
+from collections.abc import Iterator
+
+import fasttext
+from fray.cluster import ResourceConfig
+from rigging.filesystem import StoragePath, open_url
+from zephyr import counters
+from zephyr.dataset import Dataset, ShardInfo
+from zephyr.execution import ZephyrContext
+from zephyr.readers import DEFAULT_FILE_PATH_COLUMN, load_file
+from zephyr.runners import InlineRunner
+from zephyr.writers import ThreadedBatchWriter, write_parquet_file
+
+from experiments.datakit.cluster.quality.fast_transformer.tpu_bench.common import accumulate, write_result_json
+
+logger = logging.getLogger(__name__)
+
+PREDICT_BATCH = 1000
+MAX_TEXT_CHARS = 4000  # the deployed v0 fasttext cap (~1k tokens)
+
+
+@functools.cache
+def _load_model(model_path: str):
+    fd, local = tempfile.mkstemp(suffix=".bin")
+    with os.fdopen(fd, "wb") as out, open_url(model_path, "rb") as fh:
+        out.write(fh.read())
+    logger.info("loaded fasttext model from %s", model_path)
+    return fasttext.load_model(local)
+
+
+def _normalize(text: str) -> str:
+    """fasttext.predict rejects literal newlines; strip + cap like the deployed path."""
+    return (text or "")[:MAX_TEXT_CHARS].replace("\n", " ").replace("\r", " ")
+
+
+def _writer(output_path: str, model_path: str):
+    def writer(records: Iterator[dict], shard: ShardInfo) -> Iterator[dict]:
+        model = _load_model(model_path)
+        records = iter(records)
+        first = next(records, None)
+        if first is None:
+            return
+        shard_file = posixpath.basename(first[DEFAULT_FILE_PATH_COLUMN])
+        out_file = f"{output_path.rstrip('/')}/outputs/main/{shard_file}"
+        timing: dict[str, float] = {}
+        result: dict = {}
+        n_docs = n_chars = 0
+
+        def _sink(items):
+            result.update(write_parquet_file(items, output_path=out_file))
+
+        with ThreadedBatchWriter(_sink) as w:
+            batch: list[dict] = []
+
+            def flush(batch):
+                nonlocal n_docs, n_chars
+                if not batch:
+                    return
+                texts = [_normalize(r.get("text") or "") for r in batch]
+                with accumulate(timing, "predict"):
+                    labels, probs = model.predict(texts, k=1)
+                for r, lab, pr in zip(batch, labels, probs, strict=True):
+                    w.submit({"id": r["id"], "score": float(pr[0]), "label": lab[0]})
+                n_docs += len(batch)
+                n_chars += sum(len(t) for t in texts)
+
+            for r in (first, *records):
+                batch.append(r)
+                if len(batch) >= PREDICT_BATCH:
+                    flush(batch)
+                    batch = []
+            flush(batch)
+
+        counters.pipeline.update_counter("ft2/docs", n_docs)
+        counters.pipeline.update_counter("ft2/chars", n_chars)
+        counters.pipeline.update_counter("ft2/predict_ms", int(timing.get("predict", 0.0) * 1000))
+        yield {"shard_file": shard_file, "docs": n_docs, **result}
+
+    return writer
+
+
+def run(
+    *,
+    corpus_glob: str,
+    model_path: str,
+    output_path: str,
+    max_files: int,
+    max_workers: int,
+    cpu: int,
+    result_json: str | None,
+):
+    files = sorted(str(m) for m in StoragePath(corpus_glob).glob())[:max_files]
+    if not files:
+        raise ValueError(f"no files matched {corpus_glob}")
+    logger.info("C fasttext: %d files, %d workers, cpu=%d/worker", len(files), max_workers, cpu)
+    pipeline = (
+        Dataset.from_list(files)
+        .flat_map(functools.partial(load_file, include_file_paths=True))
+        .map_shard(_writer(output_path, model_path))
+    )
+    ctx = ZephyrContext(
+        name="ft-c-fasttext",
+        resources=ResourceConfig(cpu=cpu, ram=f"{cpu * 2}g"),
+        max_workers=max_workers,
+        stage_runner_factory=InlineRunner,
+        heartbeat_timeout=1200,
+    )
+    t0 = time.time()
+    agg = dict(ctx.execute(pipeline).counters)
+    wall = time.time() - t0
+    docs = agg.get("ft2/docs", 0)
+    chars = agg.get("ft2/chars", 0)
+    payload = {
+        "stage": "C_fasttext",
+        "files": len(files),
+        "max_workers": max_workers,
+        "cpu_per_worker": cpu,
+        "wall_s": round(wall, 1),
+        "docs": docs,
+        "chars": chars,
+        "docs_per_s": round(docs / wall, 1) if wall else 0,
+        "mb_per_s": round(chars / 1e6 / wall, 2) if wall else 0,
+        "predict_worker_s": round(agg.get("ft2/predict_ms", 0) / 1000, 1),
+        "counters": agg,
+    }
+    print("BENCH " + json.dumps(payload), flush=True)
+    if result_json:
+        write_result_json(result_json, payload)
+    return payload
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--corpus", required=True)
+    p.add_argument(
+        "--model-path", default="gs://marin-eu-west4/datakit/llm-quality-classifier/model/sonnet46-thr05/model.bin"
+    )
+    p.add_argument("--out-dir", required=True)
+    p.add_argument("--max-files", type=int, default=64)
+    p.add_argument("--max-workers", type=int, default=32)
+    p.add_argument("--cpu", type=int, default=8)
+    p.add_argument("--result-json", default=None)
+    args = p.parse_args()
+    logging.basicConfig(level=logging.INFO)
+    run(
+        corpus_glob=args.corpus,
+        model_path=args.model_path,
+        output_path=args.out_dir,
+        max_files=args.max_files,
+        max_workers=args.max_workers,
+        cpu=args.cpu,
+        result_json=args.result_json,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/microbench.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/microbench.py
@@ -1,0 +1,126 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Forward-only device-ceiling microbenchmark for the pooled fast-transformer.
+
+Measures the *device upper bound*: pre-tokenized ``[B, T]`` ids resident on the TPU,
+warm (compiled) forward, several async launches queued before a single
+``block_until_ready``. This is deliberately NOT the achievable pipeline throughput
+(the real pipeline is host-bound by tokenization) -- it answers "how little of the
+v6e does the forward pass actually use?" and bounds the device side of the scaling
+projection.
+
+Weights are random and the vocab is a placeholder: forward FLOPs and array shapes are
+config-dependent only, so throughput is weight-independent. Run on a v6e via an Iris
+job; prints one JSON line per (config, batch) measurement to stdout.
+"""
+
+import argparse
+import json
+import logging
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from experiments.datakit.cluster.quality.fast_transformer.inference import (
+    _predict_batch,
+    data_parallel_shardings,
+)
+from experiments.datakit.cluster.quality.fast_transformer.model import (
+    FastTransformer,
+    FastTransformerConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+# Peak bf16 FLOP/s per v6e chip (fray/device_flops.py).
+V6E_BF16_PEAK_FLOPS = 918e12
+
+# The deployed scorer's architecture (train.py DEPLOY_CONFIG + MAX_TOKENS).
+DEPLOYED = dict(embed_dim=256, hidden_dim=256, num_layers=2, num_heads=4, pool_window=64, pool_kind="meanmaxmin")
+# A 4x-larger variant: still under the 1M FLOPs/token budget (~420K), to show device headroom.
+BIG = dict(embed_dim=512, hidden_dim=512, num_layers=4, num_heads=8, pool_window=64, pool_kind="meanmaxmin")
+
+
+def make_model(cfg_kwargs: dict, vocab_size: int, max_tokens: int) -> tuple[FastTransformer, FastTransformerConfig]:
+    config = FastTransformerConfig(vocab_size=vocab_size, max_tokens=max_tokens, final_pool="mean", **cfg_kwargs)
+    model = FastTransformer(config, key=jax.random.PRNGKey(0))
+    return model, config
+
+
+def bench_one(
+    model: FastTransformer,
+    config: FastTransformerConfig,
+    *,
+    batch: int,
+    launches: int,
+    repeats: int,
+) -> dict:
+    """Time ``launches`` async forwards on a resident ``[batch, T]`` batch, ``repeats`` times.
+
+    Returns the best (max-throughput) repeat to reject scheduler noise. The batch is
+    sharded data-parallel across all chips exactly as ``predict`` shards it.
+    """
+    t = config.max_tokens
+    ndev, replicated, batch_shard = data_parallel_shardings()
+    batch = max(ndev, (batch // ndev) * ndev)
+    model = jax.device_put(model, replicated)
+    # Resident ids: real token range so the embedding gather is representative.
+    ids_host = np.random.default_rng(0).integers(1, config.vocab_size, size=(batch, t), dtype=np.int32)
+    ids = jax.device_put(jnp.asarray(ids_host), batch_shard)
+
+    # Warmup: force compile for this shape, then block.
+    jax.block_until_ready(_predict_batch(model, ids))
+
+    best_tok_s = 0.0
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        outs = [_predict_batch(model, ids) for _ in range(launches)]  # queued async
+        jax.block_until_ready(outs)
+        dt = time.perf_counter() - t0
+        tok_s = batch * t * launches / dt
+        best_tok_s = max(best_tok_s, tok_s)
+
+    flops_per_token = config.flops_per_token()
+    mxu_util = best_tok_s * flops_per_token / (ndev * V6E_BF16_PEAK_FLOPS)
+    return {
+        "kind": "microbench",
+        "n_chips": ndev,
+        "batch_global": batch,
+        "max_tokens": t,
+        "launches": launches,
+        "flops_per_token": round(flops_per_token),
+        "tokens_per_s": round(best_tok_s),
+        "tokens_per_s_per_chip": round(best_tok_s / ndev),
+        "docs_per_s_approx": round(best_tok_s / t),  # 1 window == 1 "doc" here
+        "mxu_util_frac": round(mxu_util, 5),
+    }
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--model", choices=["deployed", "big"], default="deployed")
+    p.add_argument("--vocab-size", type=int, default=48000)
+    p.add_argument("--max-tokens", type=int, default=512)
+    p.add_argument("--batches", type=int, nargs="+", default=[512, 2048, 8192, 32768, 65536])
+    p.add_argument("--launches", type=int, default=32, help="async forwards queued before one sync")
+    p.add_argument("--repeats", type=int, default=5)
+    args = p.parse_args()
+    logging.basicConfig(level=logging.INFO)
+
+    cfg_kwargs = DEPLOYED if args.model == "deployed" else BIG
+    logger.info("devices: %s", jax.devices())
+    for batch in args.batches:
+        model, config = make_model(cfg_kwargs, args.vocab_size, args.max_tokens)
+        try:
+            row = bench_one(model, config, batch=batch, launches=args.launches, repeats=args.repeats)
+        except Exception as e:  # OOM at large batch: record and continue the sweep
+            row = {"kind": "microbench", "batch_global": batch, "max_tokens": args.max_tokens, "error": repr(e)[:200]}
+        row["model"] = args.model
+        print("BENCH " + json.dumps(row), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/microbench.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/microbench.py
@@ -23,6 +23,7 @@ import time
 import jax
 import jax.numpy as jnp
 import numpy as np
+from fray.device_flops import device_flops
 
 from experiments.datakit.cluster.quality.fast_transformer.inference import (
     _predict_batch,
@@ -35,8 +36,8 @@ from experiments.datakit.cluster.quality.fast_transformer.model import (
 
 logger = logging.getLogger(__name__)
 
-# Peak bf16 FLOP/s per v6e chip (fray/device_flops.py).
-V6E_BF16_PEAK_FLOPS = 918e12
+# Peak bf16 FLOP/s per v6e chip.
+V6E_BF16_PEAK_FLOPS = device_flops("v6e", "bf16")
 
 # The deployed scorer's architecture (train.py DEPLOY_CONFIG + MAX_TOKENS).
 DEPLOYED = dict(embed_dim=256, hidden_dim=256, num_layers=2, num_heads=4, pool_window=64, pool_kind="meanmaxmin")

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/run_bench.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/run_bench.py
@@ -15,10 +15,10 @@ import argparse
 import logging
 import os
 
-# The marin worker image ships TOKENIZERS_PARALLELISM=false, which pins the HF fast
-# tokenizer to a single core -- fatal here, since tokenization is the throughput bound.
-# Force it on before any transformers import so the tokenizer's rayon pool uses the host.
-os.environ["TOKENIZERS_PARALLELISM"] = "true"
+# The fast stage tokenizes in a fork process pool (one core per proc), so the tokenizers-lib
+# internal rayon parallelism is disabled to avoid oversubscription. Set it before any import
+# that pulls the tokenizers lib.
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
 
 from experiments.datakit.cluster.quality.fast_transformer.tpu_bench import fast_stage, fasttext_stage
 from experiments.datakit.cluster.quality.fast_transformer.tpu_bench.common import MODEL_CALIB
@@ -33,13 +33,9 @@ def main() -> None:
     p.add_argument("--max-files", type=int, default=24)
     p.add_argument("--max-workers", type=int, default=1)
     p.add_argument("--device-batch", type=int, default=4096)
-    p.add_argument(
-        "--tok-procs", type=int, default=0, help="tokenizer processes on the v6e host (0/1 = main-thread rayon)"
-    )
-    p.add_argument("--cpu", type=int, default=8)
-    p.add_argument(
-        "--cpu-only", action="store_true", help="fast stage: no TPU, forward on host CPUs (the 'before' baseline)"
-    )
+    p.add_argument("--tok-procs", type=int, default=96, help="fork processes for tokenization (off the GIL)")
+    p.add_argument("--read-threads", type=int, default=12, help="host threads for row-group parquet reads")
+    p.add_argument("--cpu", type=int, default=8, help="vCPUs per worker for the fasttext stage")
     p.add_argument("--calib-file", default=MODEL_CALIB)
     p.add_argument(
         "--fasttext-model", default="gs://marin-eu-west4/datakit/llm-quality-classifier/model/sonnet46-thr05/model.bin"
@@ -57,10 +53,9 @@ def main() -> None:
             max_workers=args.max_workers,
             device_batch=args.device_batch,
             tok_procs=args.tok_procs,
+            read_threads=args.read_threads,
             calib_file=args.calib_file,
             result_json=args.result_json,
-            cpu_only=args.cpu_only,
-            cpu=args.cpu,
         )
     elif args.stage == "fasttext":
         fasttext_stage.run(

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/run_bench.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/run_bench.py
@@ -27,19 +27,19 @@ from experiments.datakit.cluster.quality.fast_transformer.tpu_bench.common impor
 def main() -> None:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("stage", choices=["fast", "fasttext"])
-    p.add_argument("--corpus", default=None, help="text parquet glob")
-    p.add_argument("--model-dir", required=True)
+    p.add_argument("--corpus", default=None, help="text parquet glob; relative paths root at marin_prefix()")
+    p.add_argument("--model-dir", required=True, help="scorer dir; relative paths root at marin_prefix()")
     p.add_argument("--out-dir", required=True)
     p.add_argument("--max-files", type=int, default=24)
     p.add_argument("--max-workers", type=int, default=1)
     p.add_argument("--device-batch", type=int, default=4096)
+    p.add_argument("--accelerator", default="v6e-4", help="TPU type (v6e-4) or GPU VARIANTxCOUNT (H100x8)")
+    p.add_argument("--worker-cpu", type=int, default=None, help="vCPUs per accelerator worker (default per host)")
     p.add_argument("--tok-procs", type=int, default=96, help="fork processes for tokenization (off the GIL)")
     p.add_argument("--read-threads", type=int, default=12, help="host threads for row-group parquet reads")
     p.add_argument("--cpu", type=int, default=8, help="vCPUs per worker for the fasttext stage")
     p.add_argument("--calib-file", default=MODEL_CALIB)
-    p.add_argument(
-        "--fasttext-model", default="gs://marin-eu-west4/datakit/llm-quality-classifier/model/sonnet46-thr05/model.bin"
-    )
+    p.add_argument("--fasttext-model", default=None, help="fasttext .bin; relative paths root at marin_prefix()")
     p.add_argument("--result-json", default=None)
     args = p.parse_args()
     logging.basicConfig(level=logging.INFO)
@@ -56,6 +56,8 @@ def main() -> None:
             read_threads=args.read_threads,
             calib_file=args.calib_file,
             result_json=args.result_json,
+            accelerator=args.accelerator,
+            worker_cpu=args.worker_cpu,
         )
     elif args.stage == "fasttext":
         fasttext_stage.run(

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/run_bench.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/run_bench.py
@@ -28,7 +28,7 @@ def main() -> None:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("stage", choices=["fast", "fasttext"])
     p.add_argument("--corpus", default=None, help="text parquet glob; relative paths root at marin_prefix()")
-    p.add_argument("--model-dir", required=True, help="scorer dir; relative paths root at marin_prefix()")
+    p.add_argument("--model-dir", default=None, help="fast scorer dir; relative paths root at marin_prefix()")
     p.add_argument("--out-dir", required=True)
     p.add_argument("--max-files", type=int, default=24)
     p.add_argument("--max-workers", type=int, default=1)
@@ -45,6 +45,8 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO)
 
     if args.stage == "fast":
+        if not args.model_dir:
+            p.error("--model-dir is required for the fast stage")
         fast_stage.run(
             corpus_glob=args.corpus,
             model_dir=args.model_dir,

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/run_bench.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/run_bench.py
@@ -1,0 +1,78 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Launcher for the TPU throughput benchmark stages.
+
+Runs as ``__main__`` and dispatches into a stage module's ``run()``. This indirection
+matters: the Zephyr pipeline closures (map_shard writers) are cloudpickled to the
+coordinator job, and cloudpickle references module-level functions *by import path*. If a
+stage were launched with ``python -m ...fast_stage`` it would be ``__main__`` and its
+functions would pickle as ``__main__.<name>`` -- unimportable on the coordinator. Importing
+the stage module here keeps every referenced function under its real module path.
+"""
+
+import argparse
+import logging
+import os
+
+# The marin worker image ships TOKENIZERS_PARALLELISM=false, which pins the HF fast
+# tokenizer to a single core -- fatal here, since tokenization is the throughput bound.
+# Force it on before any transformers import so the tokenizer's rayon pool uses the host.
+os.environ["TOKENIZERS_PARALLELISM"] = "true"
+
+from experiments.datakit.cluster.quality.fast_transformer.tpu_bench import fast_stage, fasttext_stage
+from experiments.datakit.cluster.quality.fast_transformer.tpu_bench.common import MODEL_CALIB
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("stage", choices=["fast", "fasttext"])
+    p.add_argument("--corpus", default=None, help="text parquet glob")
+    p.add_argument("--model-dir", required=True)
+    p.add_argument("--out-dir", required=True)
+    p.add_argument("--max-files", type=int, default=24)
+    p.add_argument("--max-workers", type=int, default=1)
+    p.add_argument("--device-batch", type=int, default=4096)
+    p.add_argument(
+        "--tok-procs", type=int, default=0, help="tokenizer processes on the v6e host (0/1 = main-thread rayon)"
+    )
+    p.add_argument("--cpu", type=int, default=8)
+    p.add_argument(
+        "--cpu-only", action="store_true", help="fast stage: no TPU, forward on host CPUs (the 'before' baseline)"
+    )
+    p.add_argument("--calib-file", default=MODEL_CALIB)
+    p.add_argument(
+        "--fasttext-model", default="gs://marin-eu-west4/datakit/llm-quality-classifier/model/sonnet46-thr05/model.bin"
+    )
+    p.add_argument("--result-json", default=None)
+    args = p.parse_args()
+    logging.basicConfig(level=logging.INFO)
+
+    if args.stage == "fast":
+        fast_stage.run(
+            corpus_glob=args.corpus,
+            model_dir=args.model_dir,
+            output_path=args.out_dir,
+            max_files=args.max_files,
+            max_workers=args.max_workers,
+            device_batch=args.device_batch,
+            tok_procs=args.tok_procs,
+            calib_file=args.calib_file,
+            result_json=args.result_json,
+            cpu_only=args.cpu_only,
+            cpu=args.cpu,
+        )
+    elif args.stage == "fasttext":
+        fasttext_stage.run(
+            corpus_glob=args.corpus,
+            model_path=args.fasttext_model,
+            output_path=args.out_dir,
+            max_files=args.max_files,
+            max_workers=args.max_workers,
+            cpu=args.cpu,
+            result_json=args.result_json,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/tokenize_worker.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/tokenize_worker.py
@@ -1,20 +1,30 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Child-process tokenization worker for the fast scoring pipeline.
+"""Fork-pool tokenization worker for the fast scoring pipeline.
 
-The fast stage forks a process pool to tokenize across the v6e host's many cores. A child
-runs no jax *device* ops -- it only tokenizes -- so it never initializes the TPU runtime
-(the parent process owns the 4 chips). Each child loads the tokenizer + vocab lookup once
-via ``child_init`` and then packs window-text batches to ``[N, max_tokens]`` int32.
+Tokenization is CPU-heavy Python-and-Rust glue: the Rust ``encode_batch`` releases the GIL,
+but the surrounding Python caps thread scaling to ~4x, so this pipeline tokenizes in a *fork*
+process pool (true multi-core, no GIL) instead. A child runs no jax device ops -- it only
+tokenizes -- so it never initializes the TPU runtime (the parent owns the chips), which is
+safe only because the pool is forked BEFORE the parent initializes JAX.
+
+Each child packs a block of window texts to ``[W, max_tokens]`` int32 and hands it back through
+a ``shared_memory`` segment (the parent unlinks it), so a shard's ~750 MB of packed ids never
+travels as a pickle over the pool's pipes.
 """
 
 import os
+from multiprocessing import resource_tracker, shared_memory
 
-os.environ["TOKENIZERS_PARALLELISM"] = "true"
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+import numpy as np
 
 from experiments.datakit.cluster.quality.fast_transformer.tpu_bench.common import (
+    PAD_ID,
     load_remap_meta,
+    load_shared_tokenizer,
     pack_windows,
     remap_to_array,
 )
@@ -23,19 +33,34 @@ _STATE: dict = {}
 
 
 def child_init(model_dir: str) -> None:
-    """Pool initializer: load tokenizer + dense remap once per child process."""
+    """Pool initializer: bind the shared tokenizer + dense remap once per child process.
+
+    Forked after the parent warmed both, so ``load_shared_tokenizer``/``remap_to_array`` hit
+    the inherited caches (copy-on-write) rather than re-staging or re-downloading.
+    """
     remap, tokenizer_name, max_tokens = load_remap_meta(model_dir)
+    _STATE["tokenizer"] = load_shared_tokenizer(tokenizer_name)
     _STATE["lut"] = remap_to_array(remap)
-    _STATE["tokenizer_name"] = tokenizer_name
     _STATE["max_tokens"] = max_tokens
 
 
 def child_warm(_i: int = 0) -> int:
-    """Force the tokenizer to load in this child (called once per proc at pool startup)."""
-    pack_windows(["warm up the tokenizer"], _STATE["tokenizer_name"], _STATE["lut"], _STATE["max_tokens"])
+    """Force the tokenizer to bind in this child (called once per proc at pool startup)."""
+    pack_windows(["warm up the tokenizer"], _STATE["tokenizer"], _STATE["lut"], _STATE["max_tokens"])
     return _i
 
 
-def child_tokenize(texts: list[str]):
-    """Tokenize + pack a batch of window texts -> ``[len(texts), max_tokens]`` int32."""
-    return pack_windows(texts, _STATE["tokenizer_name"], _STATE["lut"], _STATE["max_tokens"])
+def child_pack(win_texts: list[str]) -> tuple[str, tuple[int, int], int]:
+    """Tokenize + pack a block to shared memory -> (shm_name, shape, n_real_tokens).
+
+    The parent reads the segment by name and is responsible for ``unlink``-ing it.
+    """
+    packed = pack_windows(win_texts, _STATE["tokenizer"], _STATE["lut"], _STATE["max_tokens"])
+    n_tokens = int((packed != PAD_ID).sum())
+    shm = shared_memory.SharedMemory(create=True, size=packed.nbytes)
+    np.ndarray(packed.shape, dtype=packed.dtype, buffer=shm.buf)[:] = packed
+    # The parent unlinks the segment, so drop this child's resource_tracker registration --
+    # otherwise the tracker double-frees at child exit and spams "leaked shared_memory" warnings.
+    resource_tracker.unregister(shm._name, "shared_memory")
+    shm.close()
+    return shm.name, packed.shape, n_tokens

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/tokenize_worker.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/tokenize_worker.py
@@ -3,10 +3,10 @@
 
 """Child-process tokenization worker for the fast scoring pipeline.
 
-Deliberately imports NO jax: the fast stage spawns a process pool to tokenize across the
-v6e host's many cores, and a spawned child must not import the TPU runtime (only the
-parent process owns the 4 chips). Each child loads the tokenizer + vocab lookup once via
-``child_init`` and then packs window-text batches to ``[N, max_tokens]`` int32.
+The fast stage forks a process pool to tokenize across the v6e host's many cores. A child
+runs no jax *device* ops -- it only tokenizes -- so it never initializes the TPU runtime
+(the parent process owns the 4 chips). Each child loads the tokenizer + vocab lookup once
+via ``child_init`` and then packs window-text batches to ``[N, max_tokens]`` int32.
 """
 
 import os
@@ -25,7 +25,7 @@ _STATE: dict = {}
 def child_init(model_dir: str) -> None:
     """Pool initializer: load tokenizer + dense remap once per child process."""
     remap, tokenizer_name, max_tokens = load_remap_meta(model_dir)
-    _STATE["lut"] = remap_to_array(remap, len(remap) + 2)
+    _STATE["lut"] = remap_to_array(remap)
     _STATE["tokenizer_name"] = tokenizer_name
     _STATE["max_tokens"] = max_tokens
 

--- a/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/tokenize_worker.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/tpu_bench/tokenize_worker.py
@@ -1,0 +1,41 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Child-process tokenization worker for the fast scoring pipeline.
+
+Deliberately imports NO jax: the fast stage spawns a process pool to tokenize across the
+v6e host's many cores, and a spawned child must not import the TPU runtime (only the
+parent process owns the 4 chips). Each child loads the tokenizer + vocab lookup once via
+``child_init`` and then packs window-text batches to ``[N, max_tokens]`` int32.
+"""
+
+import os
+
+os.environ["TOKENIZERS_PARALLELISM"] = "true"
+
+from experiments.datakit.cluster.quality.fast_transformer.tpu_bench.common import (
+    load_remap_meta,
+    pack_windows,
+    remap_to_array,
+)
+
+_STATE: dict = {}
+
+
+def child_init(model_dir: str) -> None:
+    """Pool initializer: load tokenizer + dense remap once per child process."""
+    remap, tokenizer_name, max_tokens = load_remap_meta(model_dir)
+    _STATE["lut"] = remap_to_array(remap, len(remap) + 2)
+    _STATE["tokenizer_name"] = tokenizer_name
+    _STATE["max_tokens"] = max_tokens
+
+
+def child_warm(_i: int = 0) -> int:
+    """Force the tokenizer to load in this child (called once per proc at pool startup)."""
+    pack_windows(["warm up the tokenizer"], _STATE["tokenizer_name"], _STATE["lut"], _STATE["max_tokens"])
+    return _i
+
+
+def child_tokenize(texts: list[str]):
+    """Tokenize + pack a batch of window texts -> ``[len(texts), max_tokens]`` int32."""
+    return pack_windows(texts, _STATE["tokenizer_name"], _STATE["lut"], _STATE["max_tokens"])

--- a/experiments/datakit/cluster/quality/fast_transformer/train.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/train.py
@@ -340,9 +340,14 @@ def main() -> None:
     p.add_argument("--labels", default=DEFAULT_LABELS, help="merged oracle-label parquet")
     p.add_argument("--out-dir", required=True, help="dir to write <name>.eqx + _remap.json + _meta.json")
     p.add_argument("--name", default=MODEL_STEM)
+    p.add_argument(
+        "--tokenizer",
+        default=TOKENIZER,
+        help="HF tokenizer name, or tiktoken:<encoding> for a tiktoken BPE (e.g. tiktoken:o200k_base)",
+    )
     args = p.parse_args()
     configure_logging(logging.INFO)
-    train_from_labels(labels_path=args.labels, out_dir=args.out_dir, name=args.name)
+    train_from_labels(labels_path=args.labels, out_dir=args.out_dir, name=args.name, tokenizer=args.tokenizer)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,10 @@ dependencies = [
     "marin-ducky",
     # top level deps. try to keep these small.
     "watchdog",
+    # Fast BPE tokenizer for the datakit fast-transformer quality-classifier benchmark
+    # (experiments/datakit/.../tpu_bench). Already resolved transitively; pinned here so
+    # the worker's base `uv sync` installs it without the heavy evalchemy extra.
+    "tiktoken>=0.12.0",
     # marin-dupekit is a native (maturin) package shipped as pre-built platform
     # wheels (built by dupekit-release-wheels.yaml) rather than a workspace
     # member. A `>= X.Y.Z.dev0` floor opts uv into the daily nightly wheels

--- a/uv.lock
+++ b/uv.lock
@@ -5460,6 +5460,7 @@ dependencies = [
     { name = "marin-levanter" },
     { name = "marin-rigging", extra = ["secrets"] },
     { name = "marin-zephyr" },
+    { name = "tiktoken" },
     { name = "watchdog" },
 ]
 
@@ -5475,6 +5476,7 @@ requires-dist = [
     { name = "marin-levanter", editable = "lib/levanter" },
     { name = "marin-rigging", extras = ["secrets"], editable = "lib/rigging" },
     { name = "marin-zephyr", editable = "lib/zephyr" },
+    { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "watchdog" },
 ]
 


### PR DESCRIPTION
A throughput benchmark for the pooled fast-transformer quality classifier on v6e TPUs, answering #7187: how fast can it score a corpus, how does it scale across VMs, and what would a ~10T-token pass take.

The v6e forward is essentially free (~1% MXU), so the pipeline is host-bound and built around the host, not the chips: parallel row-group parquet reads (arrow-native, `id`/`text` only), a fork process pool for tokenization (true multi-core, off the GIL) that hands each packed block back through shared memory, and a stager thread that ships blocks to the chips (`device_put`) so the H2D transfer overlaps the forward. A warm 190K-doc shard scores in ~10.5s (**~18,000 docs/s per v6e-4**) and scales linearly across VMs; a 10T-token corpus is **~2.7 h on 64 v6e-4** (~0.7 h on 256), on preemptible TPU. That is ~3× fasttext's throughput at 0.69 vs 0.44 quality.

The harness is accelerator- and cluster-agnostic: `--accelerator` takes a TPU type (`v6e-4`) or a `VARIANTxCOUNT` GPU request (`H100x8`), and relative `--corpus` / `--model-dir` paths root at `marin_prefix()`. The same command runs unchanged on CoreWeave 8× H100 reading the corpus and scorer from S3, at ~22,700 docs/s (host-bound there too, with faster object-store writes).

Harness under `experiments/datakit/cluster/quality/fast_transformer/tpu_bench/`:

- `microbench.py` — forward-only device ceiling (~670 M window-tok/s, ~1% MXU).
- `build_scorer.py` — a config-faithful scorer dir (real vocab remap, random weights; throughput is weight-independent).
- `fast_stage.py` — the pipeline: parallel reads + fork tokenizer pool + stager thread feeding the device forward.
- `tokenize_worker.py` — fork-pool child (tokenizes off the GIL, returns through shared memory).
- `fasttext_stage.py` — the deployed fasttext baseline on the identical doc set.
- `common.py` / `run_bench.py` — shared helpers and the launcher.
