### PR TITLE
quiet aiobotocore credential-log bursts on s3 tasks

### DIFF
--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -687,6 +687,10 @@ _root.addHandler(_handler)
 _root.setLevel(logging.INFO)
 logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
+# botocore/aiobotocore log credential discovery + retry chatter at INFO once per
+# fresh S3 session; pure noise on S3-backed tasks (mirror of rigging.log_setup).
+logging.getLogger("botocore").setLevel(logging.WARNING)
+logging.getLogger("aiobotocore").setLevel(logging.WARNING)
 
 workdir = os.environ["IRIS_WORKDIR"]
 

--- a/lib/rigging/src/rigging/log_setup.py
+++ b/lib/rigging/src/rigging/log_setup.py
@@ -249,5 +249,10 @@ def configure_logging(level: int = logging.INFO) -> LogRingBuffer:
     logging.getLogger("httpcore").setLevel(logging.WARNING)
     logging.getLogger("fsspec").setLevel(logging.WARNING)
     logging.getLogger("fsspec.caching").setLevel(logging.WARNING)
+    # botocore/aiobotocore log credential discovery ("Found credentials in
+    # environment variables.") and retry chatter at INFO, once per fresh S3
+    # session -- pure noise on every S3-backed task (e.g. CoreWeave object store).
+    logging.getLogger("botocore").setLevel(logging.WARNING)
+    logging.getLogger("aiobotocore").setLevel(logging.WARNING)
 
     return _global_buffer

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -188,8 +188,14 @@ class _SidecarSlice:
     avg_item_bytes: float
 
 
-def _read_sidecar_slice(path: str, shard_key: str) -> _SidecarSlice | None:
+def _read_sidecar_slice(fs: Any, fs_path: str, path: str, shard_key: str) -> _SidecarSlice | None:
     """Read one sidecar and extract only the fields for ``shard_key``.
+
+    ``fs``/``fs_path`` are the pre-resolved filesystem and native path for
+    ``path``'s sidecar. The caller resolves them once on the submitting thread
+    so every worker shares one ``S3FileSystem`` — fsspec keys its instance cache
+    on the thread id, so resolving inside each worker would build (and leak, via
+    fsspec's strong-ref cache) a separate ~12MB botocore client per thread.
 
     Returns ``None`` if the sidecar has no ranges for this shard. The parsed
     dict is released when this function returns. Once we confirm this shard
@@ -204,7 +210,6 @@ def _read_sidecar_slice(path: str, shard_key: str) -> _SidecarSlice | None:
     for small sidecars, and msgpack decodes bytes directly.
     """
     meta_path = _scatter_meta_path(path)
-    fs, fs_path = url_to_fs(meta_path)
     meta = _sidecar_decoder().decode(fs.cat_file(fs_path))
     ranges_raw = meta.get("shards", {}).get(shard_key)
     if not ranges_raw:
@@ -237,8 +242,18 @@ def _read_sidecar_slices_parallel(scatter_paths: list[str], target_shard: int) -
     """
     shard_key = str(target_shard)
     ordered: list[_SidecarSlice | None] = [None] * len(scatter_paths)
+    # Resolve the filesystem on this thread so all workers share one instance.
+    # fsspec caches filesystem instances per thread id, so calling url_to_fs
+    # inside each worker would build a separate botocore client per thread
+    # (~12MB each, kept alive by fsspec's strong-ref cache) and log a
+    # "Found credentials" line per thread. Every sidecar shares one endpoint,
+    # so one filesystem serves them all; only the stripped path differs.
+    resolved = [url_to_fs(_scatter_meta_path(p)) for p in scatter_paths]
     with concurrent.futures.ThreadPoolExecutor(max_workers=_SIDECAR_READ_CONCURRENCY) as pool:
-        futures = {pool.submit(_read_sidecar_slice, p, shard_key): i for i, p in enumerate(scatter_paths)}
+        futures = {
+            pool.submit(_read_sidecar_slice, fs, fs_path, p, shard_key): i
+            for i, (p, (fs, fs_path)) in enumerate(zip(scatter_paths, resolved, strict=True))
+        }
         for fut in concurrent.futures.as_completed(futures):
             idx = futures[fut]
             ordered[idx] = fut.result()

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -192,10 +192,7 @@ def _read_sidecar_slice(fs: Any, fs_path: str, path: str, shard_key: str) -> _Si
     """Read one sidecar and extract only the fields for ``shard_key``.
 
     ``fs``/``fs_path`` are the pre-resolved filesystem and native path for
-    ``path``'s sidecar. The caller resolves them once on the submitting thread
-    so every worker shares one ``S3FileSystem`` — fsspec keys its instance cache
-    on the thread id, so resolving inside each worker would build (and leak, via
-    fsspec's strong-ref cache) a separate ~12MB botocore client per thread.
+    ``path``'s sidecar, shared across workers (see the caller).
 
     Returns ``None`` if the sidecar has no ranges for this shard. The parsed
     dict is released when this function returns. Once we confirm this shard


### PR DESCRIPTION
* down-level `botocore`/`aiobotocore` loggers to `WARNING` and share one `S3FileSystem` across zephyr's sidecar read pool, killing the repeated `aiobotocore.credentials Found credentials in environment variables.` INFO bursts — and the redundant S3 clients behind them — on CoreWeave/S3 tasks
* the line fires once per fresh aiobotocore session; fsspec keys its filesystem instance cache on `threading.get_ident()`, so a `ThreadPoolExecutor` doing S3 I/O builds one `S3FileSystem` per worker thread, each with its own credential resolution (one log line) and its own ~12MB botocore client kept alive for the process lifetime by fsspec's strong-ref cache [^1]
* silence the noise: set `botocore`/`aiobotocore` to `WARNING` in `rigging.log_setup.configure_logging` and the duplicated `CALLABLE_RUNNER` bootstrap in `iris` (mirrors the existing `httpx`/`httpcore`/`fsspec` suppression)
* fix the churn at the source in `zephyr.shuffle._read_sidecar_slices_parallel`: resolve the filesystem once on the submitting thread and pass `(fs, fs_path)` into each worker, so all up-to-32 sidecar readers share one client instead of one-per-thread
  * sharing a sync fsspec instance across threads is safe — every op marshals onto fsspec's single shared IO loop
* `execution.py`'s flatten pool has the same per-thread duplication but resolves its fs via `open_url` deep inside chunk-read types (`PickleDiskChunk.read`), so collapsing it needs a factory-level process-wide memo — left as a follow-up

[^1]: measured ~12MB RSS per redundant client; a 32-worker pool holds ~370MB of redundant clients, and entries accumulate as fresh pools rotate thread idents
