### PR TITLE
[datakit] Retain a per-source canonical in fuzzy dedup

### DIFF
--- a/experiments/datakit/reference_pipeline.py
+++ b/experiments/datakit/reference_pipeline.py
@@ -640,13 +640,16 @@ def reference_datakit_steps(
         }
 
     # ---- Cross-source dedup ----------------------------------------------------
-    # No content params of its own -- the MinHash params live in the minhash deps
-    # (so a param change re-keys minhash, then dedup via dep names); connected
-    # components is deterministic given those inputs. ``v`` is a manual salt.
+    # The MinHash params live in the minhash deps (so a param change re-keys
+    # minhash, then dedup via dep names); connected components is deterministic
+    # given those inputs. ``canonical_scope`` is the one content param the fn
+    # reads that is not carried by a dep, so it must be in the hash: a scope
+    # flip has to land in a fresh artifact, never reuse a prior GLOBAL dedup at
+    # the same path. ``v`` is a manual salt.
     dedup = StepSpec(
         name="datakit/dedup",
         deps=minhash_steps,
-        hash_attrs={"v": 1},
+        hash_attrs={"canonical_scope": CanonicalScope.PER_SOURCE.value, "v": 1},
         fn=lambda op: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(s.output_path, MinHashAttrData) for s in minhash_steps],
             output_path=op,
@@ -655,10 +658,6 @@ def reference_datakit_steps(
             cc_resume=True,
             worker_resources=scale.pool.worker,
         ),
-        # canonical_scope changes which docs survive, so bind it into the step
-        # hash: a scope flip must land in a fresh artifact, never reuse a
-        # previously-computed GLOBAL dedup at the same path.
-        hash_attrs={"canonical_scope": CanonicalScope.PER_SOURCE.value},
     )
 
     # ---- Final store: 5-way join + per-bucket Levanter cache ------------------

--- a/experiments/datakit/reference_pipeline.py
+++ b/experiments/datakit/reference_pipeline.py
@@ -97,6 +97,7 @@ from marin.execution.remote import remote
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.deduplication.fuzzy_dups import (
+    CanonicalScope,
     FuzzyDupsAttrData,
     compute_fuzzy_dups_attrs,
 )
@@ -649,10 +650,15 @@ def reference_datakit_steps(
         fn=lambda op: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(s.output_path, MinHashAttrData) for s in minhash_steps],
             output_path=op,
+            canonical_scope=CanonicalScope.PER_SOURCE,
             max_parallelism=scale.dedup_max_parallelism,
             cc_resume=True,
             worker_resources=scale.pool.worker,
         ),
+        # canonical_scope changes which docs survive, so bind it into the step
+        # hash: a scope flip must land in a fresh artifact, never reuse a
+        # previously-computed GLOBAL dedup at the same path.
+        hash_attrs={"canonical_scope": CanonicalScope.PER_SOURCE.value},
     )
 
     # ---- Final store: 5-way join + per-bucket Levanter cache ------------------

--- a/experiments/datakit/testbed/variants.py
+++ b/experiments/datakit/testbed/variants.py
@@ -27,7 +27,11 @@ from marin.execution.lazy import ArtifactStep
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.consolidate import FilterConfig, FilterType, consolidate
-from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData, compute_fuzzy_dups_attrs
+from marin.processing.classification.deduplication.fuzzy_dups import (
+    CanonicalScope,
+    FuzzyDupsAttrData,
+    compute_fuzzy_dups_attrs,
+)
 from marin.processing.classification.deduplication.fuzzy_minhash import MinHashAttrData, compute_minhash_attrs
 from marin.processing.tokenize.tokenize import TokenizedCache
 from rigging.log_setup import configure_logging
@@ -84,6 +88,7 @@ def _fuzzy_dups_step(minhash_steps: list[StepSpec], cc_max_iterations: int) -> S
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(mh.output_path, MinHashAttrData) for mh in minhash_steps],
             output_path=output_path,
+            canonical_scope=CanonicalScope.PER_SOURCE,
             cc_max_iterations=cc_max_iterations,
             max_parallelism=_FUZZY_DUPS_MAX_PARALLELISM,
             worker_resources=_FUZZY_DUPS_WORKER_RESOURCES,

--- a/experiments/datakit/testbed/variants.py
+++ b/experiments/datakit/testbed/variants.py
@@ -84,7 +84,9 @@ def _fuzzy_dups_step(minhash_steps: list[StepSpec], cc_max_iterations: int) -> S
     return StepSpec(
         name="data/datakit/fuzzy_dups",
         deps=list(minhash_steps),
-        hash_attrs={"cc_max_iterations": cc_max_iterations},
+        # Bind canonical_scope into the hash so a scope flip lands in a fresh
+        # artifact instead of reusing a previously-computed GLOBAL dedup.
+        hash_attrs={"cc_max_iterations": cc_max_iterations, "canonical_scope": CanonicalScope.PER_SOURCE.value},
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(mh.output_path, MinHashAttrData) for mh in minhash_steps],
             output_path=output_path,

--- a/experiments/ferries/datakit_ferry.py
+++ b/experiments/ferries/datakit_ferry.py
@@ -23,6 +23,7 @@ from marin.processing.classification.consolidate import (
     consolidate,
 )
 from marin.processing.classification.deduplication.fuzzy_dups import (
+    CanonicalScope,
     FuzzyDupsAttrData,
     compute_fuzzy_dups_attrs,
 )
@@ -84,6 +85,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(minhash.output_path, MinHashAttrData)],
             output_path=output_path,
+            canonical_scope=CanonicalScope.PER_SOURCE,
             max_parallelism=128,
             cc_max_iterations=3,
             worker_resources=ResourceConfig(cpu=1, ram="16g", disk="30g"),

--- a/experiments/ferries/datakit_nemotron_ferry.py
+++ b/experiments/ferries/datakit_nemotron_ferry.py
@@ -27,6 +27,7 @@ from marin.processing.classification.consolidate import (
     consolidate,
 )
 from marin.processing.classification.deduplication.fuzzy_dups import (
+    CanonicalScope,
     FuzzyDupsAttrData,
     compute_fuzzy_dups_attrs,
 )
@@ -122,6 +123,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(minhash.output_path, MinHashAttrData)],
             output_path=output_path,
+            canonical_scope=CanonicalScope.PER_SOURCE,
             cc_max_iterations=3,
             worker_resources=(resources := ResourceConfig(cpu=16, ram="160g", disk="32g")),
             map_task_resources=resources.scale(1 / 16),

--- a/experiments/ferries/datakit_tier2_skewed_ferry.py
+++ b/experiments/ferries/datakit_tier2_skewed_ferry.py
@@ -33,6 +33,7 @@ from marin.processing.classification.consolidate import (
     consolidate,
 )
 from marin.processing.classification.deduplication.fuzzy_dups import (
+    CanonicalScope,
     FuzzyDupsAttrData,
     compute_fuzzy_dups_attrs,
 )
@@ -93,6 +94,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(minhash.output_path, MinHashAttrData)],
             output_path=output_path,
+            canonical_scope=CanonicalScope.PER_SOURCE,
             max_parallelism=64,
             cc_max_iterations=3,
         ),

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
@@ -14,8 +14,8 @@ Per-document attr rows have schema::
     {
       id: str,
       attributes: {
-        dup_cluster_id: str,         # CC component id — shared by all cluster members
-        is_cluster_canonical: bool,  # True for exactly one member per cluster
+        dup_cluster_id: str,         # global CC component id — shared by all cluster members
+        is_cluster_canonical: bool,  # True for the canonical member(s); see canonical_scope
       }
     }
 
@@ -24,7 +24,10 @@ non-canonicals). Singletons get no row, preserving the
 ``consolidate(..., keep_if_missing=True)`` pattern. This shape lets the
 canonical-selection policy live in consolidate (e.g. the default
 ``keep is_cluster_canonical=True``, or any custom per-cluster reducer) rather
-than being baked in here.
+than being baked in here. ``canonical_scope`` decides how many members are
+flagged canonical: one per cluster (``GLOBAL``) or one per ``(source, cluster)``
+(``PER_SOURCE``, which prevents cross-source dedup from wiping out whole
+sources) — ``dup_cluster_id`` stays the global component id either way.
 
 Combining multiple ``MinHashAttrData`` inputs is the foundation for iterative
 global dedup: re-running this job over the union of all per-dataset MinHash
@@ -34,6 +37,7 @@ artifacts produces fresh markers without re-reading any source text.
 import logging
 import os
 from collections.abc import Iterator
+from enum import StrEnum
 from typing import Any
 
 from fray.types import ResourceConfig
@@ -52,6 +56,29 @@ from marin.processing.classification.deduplication.dedup_commons import _load_ba
 from marin.processing.classification.deduplication.fuzzy_minhash import MinHashAttrData, MinHashParams
 
 logger = logging.getLogger(__name__)
+
+
+class CanonicalScope(StrEnum):
+    """Which members of a duplicate cluster are marked ``is_cluster_canonical``.
+
+    Connected components always run globally across every input, so
+    ``dup_cluster_id`` identifies a cross-source cluster regardless of scope.
+    This only controls *which* members of that cluster survive the default
+    keep-canonical policy:
+
+    - ``GLOBAL``: exactly one member per cluster (the min-``id_norm`` node),
+      regardless of source. Cross-source near-duplicates collapse to a single
+      surviving copy — appropriate when source boundaries are irrelevant (e.g.
+      deduping one logical corpus).
+    - ``PER_SOURCE``: one member per ``(source, cluster)`` — the min-``id_norm``
+      node *within each source*. Every source that participates in a cluster
+      keeps a representative, so no source can be wiped out just because its
+      content near-duplicates content in another source. Genuine *intra*-source
+      near-duplicates are still collapsed to one.
+    """
+
+    GLOBAL = "global"
+    PER_SOURCE = "per_source"
 
 
 class FuzzyDupsPerSource(BaseModel):
@@ -159,15 +186,16 @@ def _cc_id(source_tag: str, doc_id: str) -> str:
     inputs can carry byte-identical normalized ids (e.g. exact text overlap
     across datasets), and without this prefix they collapse to a single
     node — under-reporting dups and potentially clobbering co-partitioned
-    attr files. The prefix is stripped in :func:`_strip_cc_prefix` before
+    attr files. The prefix is split back off in :func:`_split_cc_id` before
     the final attr parquet is written.
     """
     return f"{source_tag}{_CC_ID_SEP}{doc_id}"
 
 
-def _strip_cc_prefix(record_id: str) -> str:
-    """Reverse :func:`_cc_id`, returning the original ``doc_id``."""
-    return record_id.split(_CC_ID_SEP, 1)[1]
+def _split_cc_id(record_id: str) -> tuple[str, str]:
+    """Reverse :func:`_cc_id`, returning ``(source_tag, doc_id)``."""
+    source_tag, doc_id = record_id.split(_CC_ID_SEP, 1)
+    return source_tag, doc_id
 
 
 def _emit_bucket_records(entries: list[dict[str, Any]]) -> Iterator[dict]:
@@ -244,10 +272,48 @@ def _make_per_shard_writer(output_path: str, counter_prefix: str):
     return aggregate
 
 
+def _to_cc_member(record: dict) -> dict:
+    """Project one raw ``CCNode`` parquet row into a cluster-member record.
+
+    Returns ``{id, id_norm, source_tag, component_id, file_idx, is_singleton}``:
+    the source-stripped doc ``id``, the orderable ``id_norm``, its
+    ``source_tag``, the global ``component_id`` (the ``dup_cluster_id``), the
+    ``file_idx`` write shard, and whether the node is a singleton.
+    """
+    source_tag, doc_id = _split_cc_id(record["record_id"])
+    adjacency = record["adjacency_list"]
+    return {
+        "id": doc_id,
+        "id_norm": record["id_norm"],
+        "source_tag": source_tag,
+        "component_id": record["component_id"],
+        "file_idx": record["file_idx"],
+        # preserve_singletons wires singletons as a self-link, so a node is a
+        # singleton iff its adjacency is exactly [id_norm] — no cluster peers.
+        "is_singleton": len(adjacency) == 1 and adjacency[0] == record["id_norm"],
+    }
+
+
+def _mark_source_canonicals(key: tuple[str, str], members: Iterator[dict]) -> Iterator[dict]:
+    """Flag the min-``id_norm`` member of one ``(source_tag, component_id)`` group as canonical.
+
+    Relies on the upstream ``group_by(sort_by=id_norm)`` delivering members in
+    ascending ``id_norm`` order, so the first member is the per-source minimum
+    and the rest are non-canonical. Streaming (O(1) memory) — a single cluster
+    within one over-merged source can hold millions of members. ``id_norm`` is
+    unique per node within a source, so the minimum is unambiguous.
+    """
+    is_first = True
+    for member in members:
+        yield {**member, "is_canonical": is_first}
+        is_first = False
+
+
 def compute_fuzzy_dups_attrs(
     *,
     inputs: list[MinHashAttrData],
     output_path: str,
+    canonical_scope: CanonicalScope,
     cc_max_iterations: int = 10,
     cc_resume: bool = False,
     max_parallelism: int = MAX_WORKERS_PER_JOB,
@@ -266,15 +332,29 @@ def compute_fuzzy_dups_attrs(
     cluster member with ``{id: str, attributes: {dup_cluster_id: str,
     is_cluster_canonical: bool}}``; singletons are omitted.
 
-    Exactly one member per cluster has ``is_cluster_canonical=True`` — the
-    one CC's Hash-to-Min picked as the natural canonical (min ``id_norm``).
-    Consolidate may honor that flag (default policy) or ignore it and apply
-    a custom per-``dup_cluster_id`` policy.
+    ``dup_cluster_id`` is always the global connected-component id, so it
+    identifies a cross-source cluster regardless of ``canonical_scope``.
+    ``canonical_scope`` controls how many members are flagged
+    ``is_cluster_canonical=True`` (the members the default keep-canonical
+    policy retains):
+
+    - :attr:`CanonicalScope.GLOBAL`: exactly one per cluster (the min-``id_norm``
+      node). Cross-source near-duplicates collapse to a single surviving copy.
+    - :attr:`CanonicalScope.PER_SOURCE`: one per ``(source, cluster)`` — the
+      min-``id_norm`` node within each source. Prevents whole-source wipeouts
+      when a source's content near-duplicates content in other sources, while
+      still collapsing genuine intra-source near-duplicates.
+
+    Consolidate may honor the flag (default policy) or ignore it and apply a
+    custom per-``dup_cluster_id`` policy.
 
     Args:
         inputs: ``MinHashAttrData`` artifacts to fuzzy-dedup together.
         output_path: Output root. Per-source attr trees land under
             ``<output_path>/outputs/source_NNN/``.
+        canonical_scope: Whether ``is_cluster_canonical`` marks one member per
+            cluster (:attr:`CanonicalScope.GLOBAL`) or one per ``(source,
+            cluster)`` (:attr:`CanonicalScope.PER_SOURCE`).
         cc_max_iterations: Max iterations for connected components.
         max_parallelism: Worker count for the ZephyrContext.
         worker_resources: Per-worker resource request. Required when
@@ -357,27 +437,29 @@ def compute_fuzzy_dups_attrs(
     ctx.put(_SHARED_ENTRIES_KEY, entries)
     aggregator = _make_per_shard_writer(output_path, counter_prefix="dedup/fuzzy/document")
 
-    # CC's Hash-to-Min guarantees component_id == min(id_norm) across a cluster,
-    # so `component_id == id_norm` cheaply identifies the natural canonical.
-    # `preserve_singletons=True` wires singletons as self-links, so a node is a
-    # singleton iff its adjacency_list is exactly [id_norm] — no cluster peers.
-    shard_pipeline = (
-        Dataset.from_list(cc_files)
-        .load_parquet()
-        .map(
-            lambda r: {
-                "id": _strip_cc_prefix(r["record_id"]),
-                "component_id": r["component_id"],
-                "is_canonical": r["component_id"] == r["id_norm"],
-                "is_singleton": len(r["adjacency_list"]) == 1 and r["adjacency_list"][0] == r["id_norm"],
-                "file_idx": r["file_idx"],
-            }
+    members = Dataset.from_list(cc_files).load_parquet().map(_to_cc_member)
+    if canonical_scope is CanonicalScope.GLOBAL:
+        # CC's Hash-to-Min guarantees component_id == min(id_norm) across a
+        # cluster, so `component_id == id_norm` cheaply identifies the single
+        # global canonical — no extra shuffle.
+        labeled = members.map(lambda m: {**m, "is_canonical": m["component_id"] == m["id_norm"]})
+    else:
+        # Per-source canonical: regroup members by (source_tag, component_id)
+        # sorted by id_norm and flag the per-source minimum. One extra shuffle
+        # over the cluster members (marginal vs CC's iterations), gated behind
+        # PER_SOURCE so global callers keep the single-shuffle fast path.
+        labeled = members.group_by(
+            lambda m: (m["source_tag"], m["component_id"]),
+            sort_by=lambda m: m["id_norm"],
+            reducer=_mark_source_canonicals,
         )
-        .group_by(
-            lambda r: r["file_idx"],
-            sort_by=lambda r: r["id"],
-            reducer=aggregator,
-        )
+
+    # Co-partition annotations with their source shard for the writer. Rows are
+    # sorted by id so the per-shard attr parquet mirrors its NormalizedData shard.
+    shard_pipeline = labeled.group_by(
+        lambda r: r["file_idx"],
+        sort_by=lambda r: r["id"],
+        reducer=aggregator,
     )
 
     outcome = ctx.execute(shard_pipeline, verbose=True)
@@ -389,12 +471,14 @@ def compute_fuzzy_dups_attrs(
     }
 
     cluster_members = sum(r["cluster_members"] for r in shard_results)
-    clusters = sum(r["canonicals"] for r in shard_results)  # one canonical per cluster
+    # One canonical per cluster (GLOBAL) or per (source, cluster) (PER_SOURCE).
+    canonicals = sum(r["canonicals"] for r in shard_results)
     logger.info(
-        "Fuzzy dups: %d cluster members across %d clusters (non-canonicals to drop by default: %d)",
+        "Fuzzy dups (%s): %d cluster members, %d canonical survivors (non-canonicals to drop by default: %d)",
+        canonical_scope.value,
         cluster_members,
-        clusters,
-        cluster_members - clusters,
+        canonicals,
+        cluster_members - canonicals,
     )
 
     return FuzzyDupsAttrData(
@@ -408,6 +492,7 @@ def compute_fuzzy_dups_attrs_step(
     *,
     name: str,
     minhash_steps: list[StepSpec],
+    canonical_scope: CanonicalScope,
     cc_max_iterations: int = 10,
     max_parallelism: int,
     worker_resources: ResourceConfig | None = None,
@@ -421,11 +506,12 @@ def compute_fuzzy_dups_attrs_step(
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(s.output_path, MinHashAttrData) for s in minhash_steps],
             output_path=output_path,
+            canonical_scope=canonical_scope,
             cc_max_iterations=cc_max_iterations,
             max_parallelism=max_parallelism,
             worker_resources=worker_resources,
             coordinator_resources=coordinator_resources,
         ),
-        hash_attrs={"cc_max_iterations": cc_max_iterations},
+        hash_attrs={"cc_max_iterations": cc_max_iterations, "canonical_scope": canonical_scope.value},
         override_output_path=override_output_path,
     )

--- a/tests/processing/classification/deduplication/test_fuzzy.py
+++ b/tests/processing/classification/deduplication/test_fuzzy.py
@@ -296,7 +296,12 @@ def test_fuzzy_dups_rejects_duplicate_source(fox_corpus):
 def _canonical_assignment(source: NormalizedData, output_path: str) -> dict[str, tuple[str, bool]]:
     """Run minhash + fuzzy_dups for *source* and return ``{id -> (dup_cluster_id, is_canonical)}``."""
     minhash = compute_minhash_attrs(source=source, output_path=os.path.join(output_path, "minhash"))
-    dups = compute_fuzzy_dups_attrs(inputs=[minhash], output_path=os.path.join(output_path, "dups"), max_parallelism=4)
+    dups = compute_fuzzy_dups_attrs(
+        inputs=[minhash],
+        output_path=os.path.join(output_path, "dups"),
+        canonical_scope=CanonicalScope.PER_SOURCE,
+        max_parallelism=4,
+    )
     rows = _read_cluster_attrs(dups.sources[source.main_output_dir].attr_dir)
     return {r["id"]: (r["attributes"]["dup_cluster_id"], r["attributes"]["is_cluster_canonical"]) for r in rows}
 
@@ -359,6 +364,7 @@ def test_fuzzy_dups_capped_does_not_raise_and_emits(fox_corpus):
     dups = compute_fuzzy_dups_attrs(
         inputs=[mh],
         output_path=os.path.join(fox_corpus["output_dir"], "fuzzy_dups_path"),
+        canonical_scope=CanonicalScope.PER_SOURCE,
         cc_max_iterations=1,
         max_parallelism=4,
     )

--- a/tests/processing/classification/deduplication/test_fuzzy.py
+++ b/tests/processing/classification/deduplication/test_fuzzy.py
@@ -13,7 +13,7 @@ import pytest
 from fray.current_client import set_current_client
 from fray.local_backend import LocalClient
 from marin.datakit.normalize import NormalizedData, generate_id, normalize_to_parquet
-from marin.processing.classification.deduplication.fuzzy_dups import compute_fuzzy_dups_attrs
+from marin.processing.classification.deduplication.fuzzy_dups import CanonicalScope, compute_fuzzy_dups_attrs
 from marin.processing.classification.deduplication.fuzzy_minhash import (
     MinHashAttrData,
     MinHashParams,
@@ -121,7 +121,11 @@ def test_fuzzy_dups_single_source_schema_and_pair(fox_corpus):
 
     source = _normalize(fox_corpus["test_dir"], norm_dir)
     minhash = compute_minhash_attrs(source=source, output_path=minhash_dir)
-    dups = compute_fuzzy_dups_attrs(inputs=[minhash], output_path=dups_dir, max_parallelism=4)
+    # Single source: PER_SOURCE and GLOBAL coincide (one canonical per cluster,
+    # all in the one source), so this pins the shared invariant.
+    dups = compute_fuzzy_dups_attrs(
+        inputs=[minhash], output_path=dups_dir, canonical_scope=CanonicalScope.PER_SOURCE, max_parallelism=4
+    )
 
     assert dups.params == minhash.params
     per_source = dups.sources[source.main_output_dir]
@@ -144,15 +148,22 @@ def test_fuzzy_dups_single_source_schema_and_pair(fox_corpus):
     assert "test_unique_2" not in by_source_id
 
 
-def test_fuzzy_dups_multi_source_per_source_attr_trees(fox_corpus):
+@pytest.mark.parametrize("scope", [CanonicalScope.GLOBAL, CanonicalScope.PER_SOURCE])
+def test_fuzzy_dups_multi_source_per_source_attr_trees(fox_corpus, scope):
     """Two MinHashAttrData inputs produce two per-source attr trees.
 
     Cross-source exact-text duplicates (e.g. ``train_arctic_1`` ==
     ``test_contaminated_1`` byte-identical → same normalized id in both
     datasets) must be detected as a 2-member cluster rather than collapsing
     into a single node. Each side independently carries its own attr row for
-    the shared content hash, with a shared ``dup_cluster_id`` and exactly one
-    canonical across the pair.
+    the shared content hash and a shared ``dup_cluster_id``.
+
+    The number of canonicals across the pair depends on ``canonical_scope``:
+
+    - ``GLOBAL``: exactly one canonical across both sources (the other copy is
+      dropped — the whole-source-wipeout hazard of issue #6854).
+    - ``PER_SOURCE``: both sources keep their copy (both canonical), so neither
+      source loses its content to cross-source dedup. This is the #6854 fix.
 
     This test targets multi-source fuzzy dedup behavior directly. Normalization
     and MinHash generation already have separate coverage above.
@@ -198,7 +209,8 @@ def test_fuzzy_dups_multi_source_per_source_attr_trees(fox_corpus):
 
     dups = compute_fuzzy_dups_attrs(
         inputs=[train_mh, test_mh],
-        output_path=os.path.join(fox_corpus["output_dir"], "fuzzy_dups"),
+        output_path=os.path.join(fox_corpus["output_dir"], f"fuzzy_dups_{scope.value}"),
+        canonical_scope=scope,
         max_parallelism=1,
     )
 
@@ -214,8 +226,8 @@ def test_fuzzy_dups_multi_source_per_source_attr_trees(fox_corpus):
     test_rows = rows_by_id(test_main_dir)
 
     # Each cross-source byte-identical text must appear as an attr row on both
-    # sides (keyed by the same content hash), share a dup_cluster_id, and have
-    # exactly one canonical across the pair.
+    # sides (keyed by the same content hash) and share the global dup_cluster_id.
+    # How many are canonical depends on canonical_scope (see docstring).
     for shared_text in (
         "Arctic predators have superior auditory capabilities for hunting beneath snow.",
         "Red canids inhabit northern territories worldwide.",
@@ -225,9 +237,26 @@ def test_fuzzy_dups_multi_source_per_source_attr_trees(fox_corpus):
         assert content_id in test_rows, f"missing test attr row for {shared_text!r}"
         a, b = train_rows[content_id]["attributes"], test_rows[content_id]["attributes"]
         assert a["dup_cluster_id"] == b["dup_cluster_id"], f"{shared_text!r}: dup_cluster_id mismatch"
-        assert (
-            a["is_cluster_canonical"] != b["is_cluster_canonical"]
-        ), f"{shared_text!r}: exactly one canonical expected across pair"
+        if scope is CanonicalScope.PER_SOURCE:
+            assert (
+                a["is_cluster_canonical"] and b["is_cluster_canonical"]
+            ), f"{shared_text!r}: both sources must keep a canonical under PER_SOURCE (issue #6854)"
+        else:
+            assert (
+                a["is_cluster_canonical"] != b["is_cluster_canonical"]
+            ), f"{shared_text!r}: exactly one canonical expected across pair under GLOBAL"
+
+    # Aggregate no-wipeout property. Each source's only cluster members are the
+    # two cross-source shared texts (the unique docs are singletons with no
+    # attr row). Under PER_SOURCE every source keeps a canonical for each shared
+    # cluster (2 + 2), so neither source is dropped; under GLOBAL there is one
+    # canonical per cluster total (2), which is what lets a source be wiped out.
+    train_canon = sum(r["attributes"]["is_cluster_canonical"] for r in train_rows.values())
+    test_canon = sum(r["attributes"]["is_cluster_canonical"] for r in test_rows.values())
+    if scope is CanonicalScope.PER_SOURCE:
+        assert train_canon == 2 and test_canon == 2, f"per-source canonicals: train={train_canon}, test={test_canon}"
+    else:
+        assert train_canon + test_canon == 2, f"global canonicals across pair: {train_canon + test_canon}"
 
 
 def test_fuzzy_dups_rejects_param_mismatch(fox_corpus):
@@ -245,6 +274,7 @@ def test_fuzzy_dups_rejects_param_mismatch(fox_corpus):
         compute_fuzzy_dups_attrs(
             inputs=[a, b],
             output_path=os.path.join(fox_corpus["output_dir"], "fuzzy_dups"),
+            canonical_scope=CanonicalScope.PER_SOURCE,
             max_parallelism=4,
         )
 
@@ -258,6 +288,7 @@ def test_fuzzy_dups_rejects_duplicate_source(fox_corpus):
         compute_fuzzy_dups_attrs(
             inputs=[mh, mh],
             output_path=os.path.join(fox_corpus["output_dir"], "fuzzy_dups"),
+            canonical_scope=CanonicalScope.PER_SOURCE,
             max_parallelism=4,
         )
 
@@ -535,7 +566,12 @@ def _run_dedup_on_corpus(tmp_path: Path, docs: list[dict]) -> dict[str, dict]:
 
     source = _normalize(str(src_dir), str(tmp_path / "norm"))
     minhash = compute_minhash_attrs(source=source, output_path=str(tmp_path / "minhash"))
-    dups = compute_fuzzy_dups_attrs(inputs=[minhash], output_path=str(tmp_path / "dups"), max_parallelism=1)
+    dups = compute_fuzzy_dups_attrs(
+        inputs=[minhash],
+        output_path=str(tmp_path / "dups"),
+        canonical_scope=CanonicalScope.PER_SOURCE,
+        max_parallelism=1,
+    )
 
     by_id = _read_main_records(source)
     rows = _read_cluster_attrs(dups.sources[source.main_output_dir].attr_dir)


### PR DESCRIPTION
Fuzzy dedup marked exactly one canonical per connected component — the global min-`id_norm` member — and both consumers (the consolidate filter and the datakit store) drop every non-canonical. So when a source's docs near-duplicate docs in other sources, the single canonical lands in whichever source holds the min hash and the current source loses its entire portion of every such cluster. That wiped whole sources: public-domain book/record collections that overlap each other (Gutenberg, Library of Congress, uk_hansard) and structurally near-identical code (LLVM IR across languages), with `massive_function_calling` at exactly 100% removed.

Add a `CanonicalScope` to `compute_fuzzy_dups_attrs`. `PER_SOURCE` marks one canonical per `(source, cluster)` — the min-`id_norm` member within each source — so every source that participates in a cluster keeps a representative and no source can be wiped out by cross-source overlap, while genuine intra-source near-duplicates are still collapsed to one. Connected components still run globally, so `dup_cluster_id` stays the global cluster id and both consumers read the `is_cluster_canonical` bool unchanged. `GLOBAL` preserves the original one-per-cluster behavior for single-corpus callers.

The `PER_SOURCE` path regroups CC members by `(source_tag, component_id)` sorted by `id_norm` and flags the first; `source_tag` is recovered from the existing `_cc_id` prefix, so the one extra shuffle is gated behind `PER_SOURCE` and global callers keep the single-shuffle fast path. All datakit call sites pass `PER_SOURCE`.

This targets the cross-source failure mode. The within-source over-merge of templated/synthetic data (#6851) is a separate preprocessing/threshold problem and is out of scope here. Adjacent to #7177 (dedup determinism for #6798), which touches the same files but is complementary — it makes the global canonical reproducible, this changes which members are canonical.

Fixes #6854