### PR TITLE
[evals] Add tagged MRCR context perplexity evaluation

### DIFF
--- a/experiments/datasets/mrcr.py
+++ b/experiments/datasets/mrcr.py
@@ -1,0 +1,192 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenAI MRCR long-context perplexity datasets for tagged evaluation."""
+
+import gzip
+import io
+import json
+from contextlib import ExitStack
+from dataclasses import dataclass
+from typing import TextIO, TypedDict
+
+import pyarrow.parquet as pq
+from levanter.data.text.formats import ChatLmDatasetFormat
+from marin.execution.artifact import Artifact
+from marin.execution.lazy import ArtifactStep, StepContext
+from marin.experiment.data import dataset_main, hf_download
+from marin.processing.tokenize.tokenize import TokenizeConfig, TokenizedCache, tokenize
+from rigging.filesystem import StoragePath, prefix_join
+
+from experiments.llama import llama3_tokenizer
+
+_HF_REVISION = "f4c69fae7cf81f7ca26b9fee34b392a50f6b8a1d"
+_VERSION = "2026.07.14.1"
+MRCR_NEEDLE_COUNTS = (2, 4, 8)
+_FULL_CONTEXT = "full_context"
+_FINAL_USER_ONLY = "final_user_only"
+MRCR_CONDITIONS = (_FULL_CONTEXT, _FINAL_USER_ONLY)
+_MRCR_CHAT_TEMPLATE = (
+    "{{ messages[0]['content'] }}" "{% generation %}{{ messages[1]['content'] + ' ' + eos_token }}{% endgeneration %}"
+)
+
+
+class _MrcrMessage(TypedDict):
+    role: str
+    content: str
+
+
+@dataclass(frozen=True)
+class MrcrTransformConfig:
+    """Paths for converting MRCR parquet files to paired chat records."""
+
+    input_path: str
+    output_path: str
+
+
+class MrcrTokenizedCache(TokenizedCache):
+    """MRCR cache consumed as packed, right-sliced tagged-eval examples."""
+
+    @property
+    def format(self) -> ChatLmDatasetFormat:
+        return ChatLmDatasetFormat(chat_template=_MRCR_CHAT_TEMPLATE, pack=True, slice_strategy="right")
+
+
+def _render_prompt(messages: list[_MrcrMessage]) -> str:
+    turns = "".join(f"{message['role'].capitalize()}: {message['content']}\n" for message in messages)
+    return f"{turns}Assistant: "
+
+
+def _writer(
+    stack: ExitStack,
+    writers: dict[tuple[int, str], TextIO],
+    output_path: str,
+    needles: int,
+    condition: str,
+) -> TextIO:
+    key = (needles, condition)
+    if key not in writers:
+        path = prefix_join(output_path, f"{needles}needle/{condition}.jsonl.gz")
+        StoragePath(path).parent.mkdirs(exist_ok=True)
+        raw = stack.enter_context(StoragePath(path).open("wb"))
+        compressed = stack.enter_context(gzip.GzipFile(fileobj=raw, mode="wb", mtime=0))
+        writers[key] = stack.enter_context(io.TextIOWrapper(compressed, encoding="utf-8"))
+    return writers[key]
+
+
+def transform_mrcr(config: MrcrTransformConfig) -> None:
+    """Convert MRCR into full-context and final-user-only chat pairs."""
+
+    input_files = sorted(str(path) for path in StoragePath(prefix_join(config.input_path, "**/*.parquet")).glob())
+    if not input_files:
+        raise FileNotFoundError(f"No MRCR parquet files found under {config.input_path}")
+
+    with ExitStack() as stack:
+        writers: dict[tuple[int, str], TextIO] = {}
+        for input_file in input_files:
+            with StoragePath(input_file).open("rb") as source:
+                parquet = pq.ParquetFile(source)
+                for batch in parquet.iter_batches(batch_size=1, columns=["prompt", "answer", "n_needles"]):
+                    row = batch.to_pylist()[0]
+                    messages: list[_MrcrMessage] = json.loads(row["prompt"])
+                    answer = row["answer"]
+                    needles = row["n_needles"]
+                    prompts = {
+                        _FULL_CONTEXT: _render_prompt(messages),
+                        _FINAL_USER_ONLY: _render_prompt(messages[-1:]),
+                    }
+
+                    for condition, prompt in prompts.items():
+                        output = _writer(
+                            stack,
+                            writers,
+                            config.output_path,
+                            needles,
+                            condition,
+                        )
+                        output.write(
+                            json.dumps(
+                                {
+                                    "messages": [
+                                        {"role": "user", "content": prompt},
+                                        {"role": "assistant", "content": answer},
+                                    ]
+                                },
+                                ensure_ascii=False,
+                            )
+                            + "\n"
+                        )
+
+
+def _mrcr_tags(needles: int, condition: str) -> tuple[str, ...]:
+    needle = f"{needles}needle"
+    return (
+        f"mrcr/{condition}",
+        f"mrcr/{needle}/{condition}",
+    )
+
+
+def _tokenized_mrcr(
+    *,
+    name: str,
+    tokenizer: str,
+    raw: ArtifactStep[Artifact],
+    glob: str,
+    tags: tuple[str, ...],
+) -> ArtifactStep[TokenizedCache]:
+    def build_config(ctx: StepContext) -> TokenizeConfig:
+        return TokenizeConfig(
+            train_paths=[],
+            validation_paths=[prefix_join(ctx.artifact_path(raw), glob)],
+            cache_path=ctx.output_path,
+            tokenizer=tokenizer,
+            format=ChatLmDatasetFormat(chat_template=_MRCR_CHAT_TEMPLATE, pack=True, slice_strategy="right"),
+            tags=list(tags),
+        )
+
+    return ArtifactStep(
+        name=name,
+        version=_VERSION,
+        artifact_type=MrcrTokenizedCache,
+        run=tokenize,
+        build_config=build_config,
+        deps=(raw,),
+    )
+
+
+def mrcr_datasets(*, tokenizer: str = llama3_tokenizer) -> dict[str, ArtifactStep[TokenizedCache]]:
+    """Return paired MRCR validation datasets keyed by needle count and condition."""
+
+    raw = hf_download(
+        "raw/openai/mrcr",
+        hf_id="openai/mrcr",
+        revision=_HF_REVISION,
+        urls_glob=["*needle/*.parquet"],
+        version=_VERSION,
+    )
+    processed = ArtifactStep(
+        name="processed/openai/mrcr",
+        version=_VERSION,
+        artifact_type=Artifact,
+        run=transform_mrcr,
+        build_config=lambda ctx: MrcrTransformConfig(
+            input_path=ctx.artifact_path(raw),
+            output_path=ctx.output_path,
+        ),
+        deps=(raw,),
+    )
+    return {
+        f"{needles}needle/{condition}": _tokenized_mrcr(
+            name=f"mrcr/{needles}needle/{condition}-llama3",
+            tokenizer=tokenizer,
+            raw=processed,
+            glob=f"{needles}needle/{condition}.jsonl.gz",
+            tags=_mrcr_tags(needles, condition),
+        )
+        for needles in MRCR_NEEDLE_COUNTS
+        for condition in MRCR_CONDITIONS
+    }
+
+
+if __name__ == "__main__":
+    dataset_main(mrcr_datasets())

--- a/experiments/datasets/mrcr.py
+++ b/experiments/datasets/mrcr.py
@@ -44,12 +44,16 @@ class MrcrTransformConfig:
     output_path: str
 
 
+def _mrcr_format() -> ChatLmDatasetFormat:
+    return ChatLmDatasetFormat(chat_template=_MRCR_CHAT_TEMPLATE, pack=True, slice_strategy="right")
+
+
 class MrcrTokenizedCache(TokenizedCache):
     """MRCR cache consumed as packed, right-sliced tagged-eval examples."""
 
     @property
     def format(self) -> ChatLmDatasetFormat:
-        return ChatLmDatasetFormat(chat_template=_MRCR_CHAT_TEMPLATE, pack=True, slice_strategy="right")
+        return _mrcr_format()
 
 
 def _render_prompt(messages: list[_MrcrMessage]) -> str:
@@ -140,7 +144,7 @@ def _tokenized_mrcr(
             validation_paths=[prefix_join(ctx.artifact_path(raw), glob)],
             cache_path=ctx.output_path,
             tokenizer=tokenizer,
-            format=ChatLmDatasetFormat(chat_template=_MRCR_CHAT_TEMPLATE, pack=True, slice_strategy="right"),
+            format=_mrcr_format(),
             tags=list(tags),
         )
 

--- a/experiments/grug/moe/launch.py
+++ b/experiments/grug/moe/launch.py
@@ -37,6 +37,7 @@ from marin.experiment.namespacing import user_namespaced_name
 from marin.processing.tokenize.tokenize import TokenizedCache
 from marin.training.training import LevanterCheckpoint, resolve_checkpointer_output_path
 
+from experiments.datasets.mrcr import mrcr_datasets
 from experiments.datasets.nemotron import nemotron_datasets
 from experiments.datasets.paloma import paloma_datasets
 from experiments.datasets.proofpile import proofpile_dataset
@@ -209,7 +210,7 @@ def grug_moe_baseline(*, version: str | None = None) -> ArtifactStep[LevanterChe
 
     Every component is a :class:`Dataset` handle, so the whole graph lowers via
     :func:`~marin.execution.lazy.lower`. Pinned components never re-tokenize; the
-    paloma/uncheatable suites are validation (weight 0).
+    Paloma, Uncheatable, and MRCR suites are validation (weight 0).
     """
     name = "grug/4_10_baseline_moe"
     version = resolve_version(name, version)
@@ -217,9 +218,11 @@ def grug_moe_baseline(*, version: str | None = None) -> ArtifactStep[LevanterChe
     train = {nem[split]: weight for split, weight in _NEMOTRON_WEIGHTS.items()}
     train[starcoder_dataset(tokenizer=llama3_tokenizer)] = _STARCODER_WEIGHT
     train[proofpile_dataset(tokenizer=llama3_tokenizer)] = _PROOFPILE_WEIGHT
+    mrcr = mrcr_datasets(tokenizer=llama3_tokenizer)
     validation = [
         *paloma_datasets(tokenizer=llama3_tokenizer).values(),
         *uncheatable_datasets(tokenizer=llama3_tokenizer).values(),
+        *mrcr.values(),
     ]
 
     def build_config(ctx: StepContext) -> GrugMoeLaunchConfig:

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -529,7 +529,7 @@ def dataset_for_component(
         )
     elif isinstance(fmt, ChatLmDatasetFormat):
         # Chat has no continuous-stream mode: a falsy pack means one conversation per example.
-        max_segments, slice_strategy = _resolve_pack_config(pack)
+        max_segments, slice_strategy = _resolve_pack_config(pack, packed_slice_strategy=fmt.slice_strategy)
         return ChatDataset(
             cache,
             Pos,

--- a/lib/levanter/src/levanter/data/text/formats.py
+++ b/lib/levanter/src/levanter/data/text/formats.py
@@ -3,7 +3,7 @@
 
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, TypedDict
+from typing import Any, Literal, TypedDict
 
 import numpy as np
 from draccus import PluginRegistry
@@ -55,6 +55,7 @@ class ChatLmDatasetFormat(LmDatasetFormatBase):
     system_prompt: str | None = None
     chat_template_kwargs: str | None = "chat_template_kwargs"
     pack: bool | int | None = None  # None => default pack behavior (currently pack)
+    slice_strategy: Literal["left", "right", "raise"] = "left"
     mask_user_turns: bool = True
 
     def build_preprocessor(

--- a/lib/levanter/tests/test_text.py
+++ b/lib/levanter/tests/test_text.py
@@ -718,6 +718,39 @@ def test_chat_dataset_build_and_pack(dummy_chat_data):
             assert_loss_weight_matches_all_assistants(ex, tokenizer)
 
 
+def test_dataset_for_component_chat_right_slice_retains_assistant_tokens(tmp_path):
+    data_path = tmp_path / "chat.jsonl"
+    data_path.write_text(
+        json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "long context " * 100},
+                    {"role": "assistant", "content": "remembered answer"},
+                ]
+            }
+        )
+        + "\n"
+    )
+    tokenizer = load_tokenizer("marin-community/marin-tokenizer")
+    component = DatasetComponent(
+        source=UrlDatasetSourceConfig(train_urls=[str(data_path)]),
+        format=ChatLmDatasetFormat(messages_field="messages", pack=True, slice_strategy="right"),
+        cache_dir=str(tmp_path / "cache"),
+    )
+    cache = _build_train_cache(component, tokenizer)
+    Pos = hax.Axis("position", 32)
+
+    example = dataset_for_component(
+        component,
+        Pos,
+        cache,
+        eos_id=None,
+        block_cross_document_attention=True,
+    ).as_sync_dataset()[0]
+
+    assert np.asarray(example.loss_weight).sum() > 0
+
+
 # --- one example per document ----------------------------------------------
 #
 # A falsy pack (for chat/trace) and pack=1 select one document per example, padded to

--- a/tests/test_mrcr_dataset.py
+++ b/tests/test_mrcr_dataset.py
@@ -1,0 +1,70 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import gzip
+import json
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from levanter.data.text.formats import ChatLmDatasetFormat
+from marin.execution.artifact import ArtifactRecord, write_record
+
+from experiments.datasets.mrcr import MrcrTokenizedCache, MrcrTransformConfig, transform_mrcr
+
+
+def test_transform_mrcr_builds_paired_prompts_with_identical_targets(tmp_path):
+    input_path = tmp_path / "input" / "2needle"
+    input_path.mkdir(parents=True)
+    messages = [
+        {"role": "user", "content": "old context " * 2_100},
+        {"role": "assistant", "content": "old answer"},
+        {"role": "user", "content": "return the remembered answer"},
+    ]
+    pq.write_table(
+        pa.Table.from_pylist(
+            [
+                {
+                    "prompt": json.dumps(messages),
+                    "answer": "prefix-old answer",
+                    "n_needles": 2,
+                }
+            ]
+        ),
+        input_path / "2needle_0.parquet",
+    )
+
+    output_path = tmp_path / "output"
+    transform_mrcr(MrcrTransformConfig(input_path=str(tmp_path / "input"), output_path=str(output_path)))
+
+    def read(condition: str) -> dict[str, list[dict[str, str]]]:
+        with gzip.open(output_path / "2needle" / f"{condition}.jsonl.gz", "rt") as f:
+            return json.loads(f.read())
+
+    full_context = read("full_context")
+    final_user_only = read("final_user_only")
+
+    full_messages = full_context["messages"]
+    final_messages = final_user_only["messages"]
+    assert full_messages[0]["content"].startswith("User: old context")
+    assert full_messages[0]["content"].endswith(final_messages[0]["content"])
+    assert final_messages[0] == {
+        "role": "user",
+        "content": "User: return the remembered answer\nAssistant: ",
+    }
+    assert full_messages[1] == final_messages[1] == {"role": "assistant", "content": "prefix-old answer"}
+
+
+def test_mrcr_cache_uses_packed_right_sliced_chat_examples(tmp_path):
+    write_record(
+        ArtifactRecord(
+            output_path=str(tmp_path),
+            config={"tokenizer": "passthrough", "tags": ["mrcr/full_context"]},
+        )
+    )
+
+    component = MrcrTokenizedCache.raw_load(str(tmp_path)).as_component()
+
+    assert isinstance(component.format, ChatLmDatasetFormat)
+    assert component.format.pack is True
+    assert component.format.slice_strategy == "right"
+    assert component.tags == ["mrcr/full_context"]


### PR DESCRIPTION
Add a pinned OpenAI MRCR validation suite to the default Grug MoE recipe. Each example scores the same final assistant answer under full-context and final-user-only prompts. Chat-formatted caches preserve target-only loss, retain the rightmost model-length window for overlength examples, and emit aggregate and per-needle losses through the existing TaggedEvaluator.

The d512 validation run in us-east5-a reduced final-turn PPL from 21.0855 without context to 10.4012 with context, a 0.7067 nat/token loss reduction. The 2-, 4-, and 8-needle subsets each showed approximately a 2x PPL ratio.

Fixes #7181