### PR TITLE
[coral] Add batch calibration utilities

### DIFF
--- a/experiments/coral/__init__.py
+++ b/experiments/coral/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/experiments/coral/batch_calibration.py
+++ b/experiments/coral/batch_calibration.py
@@ -1,0 +1,217 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Estimate dense-transformer HBM and select a TPU batch configuration."""
+
+import math
+
+from fray.types import get_tpu_topology, tpu_family
+
+BYTES_PER_GIB = 1024**3
+
+_TPU_HBM_BYTES_PER_CHIP: dict[str, int] = {
+    "v4": 32 * BYTES_PER_GIB,
+    "v5e": 16 * BYTES_PER_GIB,
+    "v5p": 95 * BYTES_PER_GIB,
+    "v6e": 32 * BYTES_PER_GIB,
+}
+
+
+def adam_optimizer_bytes(
+    parameter_count: int,
+    *,
+    first_moment_dtype_bytes: int = 4,
+    second_moment_dtype_bytes: int = 4,
+) -> int:
+    """Adam-family optimizer-state bytes: the first- and second-moment buffers."""
+    first_moment_bytes = parameter_count * first_moment_dtype_bytes
+    second_moment_bytes = parameter_count * second_moment_dtype_bytes
+    return first_moment_bytes + second_moment_bytes
+
+
+def dense_transformer_bytes(
+    *,
+    parameter_count: int,
+    batch_size: int,
+    seq_len: int,
+    hidden_dim: int,
+    intermediate_dim: int,
+    num_layers: int,
+    parameter_dtype_bytes: int = 4,
+    activation_dtype_bytes: int = 2,
+    activation_layer_fraction: float = 0.75,
+    activation_layer_floor: int = 4,
+) -> tuple[int, int]:
+    """Estimate parameter and activation bytes for a dense transformer.
+
+    Args:
+        parameter_count: Number of trainable model parameters.
+        batch_size: Global training batch size.
+        seq_len: Tokens per training example.
+        hidden_dim: Transformer hidden dimension.
+        intermediate_dim: MLP intermediate dimension.
+        num_layers: Number of transformer layers.
+        parameter_dtype_bytes: Bytes used by each model parameter.
+        activation_dtype_bytes: Bytes used by each activation element.
+        activation_layer_fraction: Fraction of layers whose activations are resident simultaneously.
+        activation_layer_floor: Minimum number of layers whose activations are resident simultaneously.
+
+    Returns:
+        A ``(parameter_bytes, activation_bytes)`` tuple.
+
+    Raises:
+        ValueError: If ``activation_layer_fraction`` is outside ``[0, 1]``.
+    """
+    _validate_activation_layer_fraction(activation_layer_fraction)
+
+    hidden_activation_bytes = batch_size * seq_len * hidden_dim * activation_dtype_bytes
+    attention_activation_bytes = batch_size * seq_len * hidden_dim * 4 * activation_dtype_bytes
+    mlp_activation_bytes = batch_size * seq_len * intermediate_dim * activation_dtype_bytes
+    per_layer_activation_bytes = hidden_activation_bytes + attention_activation_bytes + mlp_activation_bytes
+    # With gradient checkpointing, only a fraction of layer activations are resident at once;
+    # the explicit floor keeps the estimate useful for shallow models.
+    saved_activation_layers = max(
+        math.floor(num_layers * activation_layer_fraction),
+        activation_layer_floor,
+    )
+    parameter_bytes = parameter_count * parameter_dtype_bytes
+    activation_bytes = per_layer_activation_bytes * saved_activation_layers
+    return parameter_bytes, activation_bytes
+
+
+def batch_memory_bytes(
+    *,
+    parameter_bytes: int,
+    optimizer_bytes: int,
+    activation_bytes: int,
+    correction_factor: float = 1.0,
+) -> int:
+    """Return total HBM bytes for a global batch.
+
+    Args:
+        parameter_bytes: Model parameter memory.
+        optimizer_bytes: Optimizer-state memory.
+        activation_bytes: Activation memory for the global batch.
+        correction_factor: Empirical scale factor for the raw bucket sum. The default ``1.0`` means no
+            ad hoc correction is applied.
+
+    Returns:
+        The corrected global-batch memory estimate in bytes.
+
+    Raises:
+        ValueError: If a byte bucket is negative or ``correction_factor`` is not positive.
+    """
+    if min(parameter_bytes, optimizer_bytes, activation_bytes) < 0:
+        raise ValueError("Memory byte counts must be non-negative.")
+    if correction_factor <= 0:
+        raise ValueError(f"correction_factor must be positive, got {correction_factor}")
+    return math.ceil((parameter_bytes + optimizer_bytes + activation_bytes) * correction_factor)
+
+
+def tpu_batch_config(
+    tpu: str,
+    batch_size: int,
+    batch_bytes: int,
+    *,
+    data_axis_size: int | None = None,
+) -> tuple[int, int]:
+    """Select Levanter batch settings that fit a global batch on a TPU slice.
+
+    Args:
+        tpu: TPU topology name accepted by Fray, such as ``"v5litepod-8"``.
+        batch_size: Global training batch size.
+        batch_bytes: HBM needed for the full global batch. When it does not fit, memory is assumed to
+            scale linearly with microbatch size.
+        data_axis_size: Chips assigned to Levanter's batch axis. Defaults to the slice chip count. For
+            example, ``"v5p-32"`` has 16 chips, so tensor parallelism of two uses ``data_axis_size=8``.
+
+    Returns:
+        A ``(per_device_parallelism, gradient_accumulation)`` tuple. ``per_device_parallelism`` is ``-1``
+        when the full batch fits without microbatching.
+
+    Raises:
+        ValueError: If the inputs are invalid or no microbatch fits the slice.
+    """
+    topology = get_tpu_topology(tpu)
+    data_axis_size = _resolve_data_axis_size(topology.chip_count, data_axis_size)
+    _validate_batch_divisible_by_data_axis(batch_size, data_axis_size)
+    if batch_bytes <= 0:
+        raise ValueError(f"batch_bytes must be positive, got {batch_bytes}")
+
+    capacity_bytes = tpu_hbm_capacity_bytes(tpu)
+    if batch_bytes <= capacity_bytes:
+        return -1, 1
+
+    full_per_device_batch = batch_size // data_axis_size
+    for per_device_parallelism in range(full_per_device_batch, 0, -1):
+        if full_per_device_batch % per_device_parallelism != 0:
+            continue
+        microbatch_size = per_device_parallelism * data_axis_size
+        if _batch_bytes_for_microbatch(batch_bytes, full_batch_size=batch_size, microbatch_size=microbatch_size) <= (
+            capacity_bytes
+        ):
+            return per_device_parallelism, batch_size // microbatch_size
+
+    minimum_microbatch_bytes = _batch_bytes_for_microbatch(
+        batch_bytes,
+        full_batch_size=batch_size,
+        microbatch_size=data_axis_size,
+    )
+    raise ValueError(
+        f"Batch does not fit on {tpu}: even per_device_parallelism=1 "
+        f"(microbatch_size={data_axis_size}) needs {_format_gib(minimum_microbatch_bytes)}, "
+        f"but target HBM capacity is {_format_gib(capacity_bytes)}. Use a larger TPU slice, "
+        "reduce model/sequence size, or use more model/context parallelism and pass the resulting data_axis_size."
+    )
+
+
+def tpu_hbm_capacity_bytes(tpu: str) -> int:
+    """Return the aggregate HBM capacity of a TPU slice in bytes."""
+    topology = get_tpu_topology(tpu)
+    family = tpu_family(tpu)
+    hbm_bytes_per_chip = _TPU_HBM_BYTES_PER_CHIP.get(family)
+    if hbm_bytes_per_chip is None:
+        raise ValueError(
+            f"No HBM memory spec for TPU family {family!r}. Known families: {sorted(_TPU_HBM_BYTES_PER_CHIP)}"
+        )
+    return topology.chip_count * hbm_bytes_per_chip
+
+
+def _batch_bytes_for_microbatch(batch_bytes: int, *, full_batch_size: int, microbatch_size: int) -> int:
+    return math.ceil(batch_bytes * microbatch_size / full_batch_size)
+
+
+def _resolve_data_axis_size(chip_count: int, data_axis_size: int | None) -> int:
+    if data_axis_size is None:
+        return chip_count
+    if data_axis_size <= 0:
+        raise ValueError(f"data_axis_size must be positive, got {data_axis_size}")
+    if chip_count % data_axis_size != 0:
+        raise ValueError(
+            f"data_axis_size ({data_axis_size}) must divide TPU chip count ({chip_count}). "
+            "For tensor/model/context parallelism, pass the number of chips left on Levanter's batch axis."
+        )
+    return data_axis_size
+
+
+def _validate_batch_divisible_by_data_axis(batch_size: int, data_axis_size: int) -> None:
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be positive, got {batch_size}")
+    if batch_size % data_axis_size == 0:
+        return
+    next_valid = math.ceil(batch_size / data_axis_size) * data_axis_size
+    raise ValueError(
+        f"batch_size ({batch_size}) must be divisible by data_axis_size ({data_axis_size}) for Levanter "
+        f"microbatching. Use batch_size={next_valid}, choose another batch size, or pass the correct data_axis_size."
+    )
+
+
+def _validate_activation_layer_fraction(activation_layer_fraction: float) -> None:
+    if not (0.0 <= activation_layer_fraction <= 1.0):
+        raise ValueError(
+            f"activation_layer_fraction must be in the interval [0.0, 1.0], got {activation_layer_fraction}"
+        )
+
+
+def _format_gib(num_bytes: int) -> str:
+    return f"{num_bytes / BYTES_PER_GIB:.2f} GiB"

--- a/tests/experiment/coral/test_batch_calibration.py
+++ b/tests/experiment/coral/test_batch_calibration.py
@@ -1,0 +1,139 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from experiments.coral.batch_calibration import (
+    BYTES_PER_GIB,
+    adam_optimizer_bytes,
+    batch_memory_bytes,
+    dense_transformer_bytes,
+    tpu_batch_config,
+)
+
+
+def test_example_usage():
+    batch_size = 128
+    parameter_count = 100_000_000
+    parameter_bytes, activation_bytes = dense_transformer_bytes(
+        parameter_count=parameter_count,
+        batch_size=batch_size,
+        seq_len=2048,
+        hidden_dim=1024,
+        intermediate_dim=4096,
+        num_layers=12,
+    )
+    optimizer_bytes = adam_optimizer_bytes(parameter_count)
+    batch_bytes = batch_memory_bytes(
+        parameter_bytes=parameter_bytes,
+        optimizer_bytes=optimizer_bytes,
+        activation_bytes=activation_bytes,
+    )
+
+    batch_config = tpu_batch_config(
+        "v5litepod-4",
+        batch_size,
+        batch_bytes,
+    )
+
+    assert parameter_bytes == 400_000_000
+    assert optimizer_bytes == 800_000_000
+    assert activation_bytes == 43_486_543_872
+    assert batch_bytes == 44_686_543_872
+    assert batch_config == (-1, 1)
+
+
+def test_adam_optimizer_bytes():
+    assert (
+        adam_optimizer_bytes(
+            10,
+            first_moment_dtype_bytes=2,
+            second_moment_dtype_bytes=8,
+        )
+        == 100
+    )
+
+
+def test_dense_transformer_bytes():
+    parameter_bytes, activation_bytes = dense_transformer_bytes(
+        parameter_count=3,
+        batch_size=2,
+        seq_len=4,
+        hidden_dim=5,
+        intermediate_dim=7,
+        num_layers=8,
+        parameter_dtype_bytes=2,
+        activation_dtype_bytes=4,
+        activation_layer_fraction=0.5,
+        activation_layer_floor=6,
+    )
+
+    assert parameter_bytes == 6
+    assert activation_bytes == 6144
+
+
+def test_batch_memory_bytes():
+    assert (
+        batch_memory_bytes(
+            parameter_bytes=1,
+            optimizer_bytes=2,
+            activation_bytes=2,
+            correction_factor=0.5,
+        )
+        == 3
+    )
+
+
+@pytest.mark.parametrize(
+    ("batch_bytes", "expected_config"),
+    [
+        (64 * BYTES_PER_GIB, (-1, 1)),
+        (128 * BYTES_PER_GIB, (16, 2)),
+        (160 * BYTES_PER_GIB, (8, 4)),
+    ],
+)
+def test_tpu_batch_config(batch_bytes, expected_config):
+    assert (
+        tpu_batch_config(
+            "v5litepod-4",
+            batch_size=128,
+            batch_bytes=batch_bytes,
+        )
+        == expected_config
+    )
+
+
+def test_data_axis_size():
+    batch_config = tpu_batch_config(
+        "v5litepod-4",
+        batch_size=128,
+        batch_bytes=128 * BYTES_PER_GIB,
+        data_axis_size=2,
+    )
+
+    assert batch_config == (32, 2)
+
+
+def test_nondivisible_batch():
+    with pytest.raises(
+        ValueError,
+        match=r"batch_size \(130\) must be divisible by data_axis_size \(4\)",
+    ):
+        tpu_batch_config(
+            "v5litepod-4",
+            batch_size=130,
+            batch_bytes=1,
+            data_axis_size=4,
+        )
+
+
+def test_minimum_microbatch_too_large():
+    with pytest.raises(
+        ValueError,
+        match=r"Batch does not fit on v5litepod-4: even per_device_parallelism=1",
+    ):
+        tpu_batch_config(
+            "v5litepod-4",
+            batch_size=4,
+            batch_bytes=128 * BYTES_PER_GIB,
+        )


### PR DESCRIPTION
This PR is trying to accomplish two things:

1. Carve out a tiny bit of space somewhere upstream in Marin for generic utilities more specific to Coral projects
2. Make it easier to size device parallelism and gradient accumulation for any TPU

The ideal workflow I have in mind to help training (dense) Coral models is:

1. Assume a target global batch size
2. Have something that can estimate peak HBM utilization for a training configuration
3. Use that something to configure gradient accumulation

The only code I'm aware of like this is in different forms of [estimate_memory_bytes](https://github.com/marin-community/marin/blob/b35bfb32a9d4fa5586f6873c9bb0c258a7ffce0f/experiments/references/completed_adamh.py#L229).  That has a `fudge_factor` and some other heuristics baked into it that wouldn't necessarily align very well to all the details of a "training configuration".  All the same, I find it pretty useful especially if adapted to a more experiment-specific context.  I also find that it's not as far off as I would have guessed to measured HBM utilization from W&B for small models in short training runs:

<img width="896" alt="batch_calibration_results" src="https://github.com/user-attachments/assets/64c233bc-c189-47dd-9e97-0153871db3c9" />


It undershoots heavily in many cases, but that's still useful as a bound or for seeding better estimates.  E.g. I typically start a lot of sweeps by brute forcing binary searches for per-chip max microbatch sizes by TPU family ([skills/size-tpu-train-config.md](https://github.com/eric-czech/marin-agent-kb/blob/main/skills/size-tpu-train-config.md)).  An alternative is to treat an estimation method like this as parameterized.  If it has a single knob to turn and calibrating that value results in the same gradient accumulation, then it's equivalent to a brute-force search.  The advantage would be that with time and some more iterations, this estimation for common Coral training configs could be reliable enough to avoid the extra training runs.

So this PR starts from `estimate_memory_bytes` and generalizes it slightly to separate parameter, optimizer and activation memory usage.  It rebrands `fudge_factor` as `correction_factor` and that's the knob I am tuning for experiments I want to run on any TPU.  E.g. [MarinFold #117 Batch Calibration](https://github.com/Open-Athena/MarinFold/issues/117#issuecomment-4981872673) compares this to a brute-force search.  Ideally this factor goes away entirely for sufficiently similar experiments.  For now, I wanted to start with recognizable estimation code and go from there.

This is the way I'm currently using it:

https://github.com/marin-community/marin/blob/284ad563a4cffe565c987ce1a9e9c0efd208aac5/tests/experiment/coral/test_batch_calibration.py#L15-L37

Is there a better way to solve for this kind of problem?

Also, making space for Coral work in some way is an assumption I welcome thoughts on.
