### PR TITLE
[levanter] Align chat renderer to HF and add SFT parity tests

### DIFF
--- a/lib/levanter/src/levanter/tokenizers.py
+++ b/lib/levanter/src/levanter/tokenizers.py
@@ -35,6 +35,7 @@ from huggingface_hub import __version__ as _hf_hub_version
 from huggingface_hub import hf_hub_download, snapshot_download
 from huggingface_hub.utils import EntryNotFoundError, RepositoryNotFoundError
 from rigging.filesystem import fetch_file_atomic, filesystem, open_url
+from tokenizers import Encoding as HfEncoding
 from tokenizers import Tokenizer as HfBaseTokenizer
 
 logger = logging.getLogger(__name__)
@@ -196,14 +197,28 @@ class _GenerationStripExtension(jinja2.ext.Extension):
         return caller()
 
 
+def _tojson(
+    x: Any, ensure_ascii: bool = False, indent: int | None = None, separators: Any = None, sort_keys: bool = False
+) -> str:
+    """`tojson` filter matching HF's chat-template environment.
+
+    jinja2's built-in `tojson` HTML-escapes and defaults to `sort_keys=True`, so tool
+    schemas and tool-call arguments serialize with reordered keys and `\\uXXXX` escapes.
+    HF renders JSON in insertion order without HTML escaping; input_ids and the rendered
+    string only match HF when this filter does the same.
+    """
+    return json.dumps(x, ensure_ascii=ensure_ascii, indent=indent, separators=separators, sort_keys=sort_keys)
+
+
 def _make_jinja_env(extensions: list[type]) -> jinja2.Environment:
     """Create a jinja2 environment matching HF's template rendering settings."""
     env = jinja2.sandbox.SandboxedEnvironment(
         undefined=jinja2.StrictUndefined,
         trim_blocks=True,
         lstrip_blocks=True,
-        extensions=extensions,
+        extensions=[jinja2.ext.loopcontrols, *extensions],
     )
+    env.filters["tojson"] = _tojson
     # jinja2 types globals narrowly from its DEFAULT_NAMESPACE; pyrefly rejects assigning
     # other callables. Update via the mapping interface, which accepts t.Any values.
     env.globals.update(
@@ -362,8 +377,111 @@ def _chat_template_messages(
     ]
 
 
+def _strip_sentinels(rendered: str, num_messages: int) -> tuple[str, list[tuple[int, int]], list[tuple[int, int]]]:
+    """Recover the sentinel-free render plus generation and per-message char spans.
+
+    The returned string is byte-for-byte the string HF renders (sentinels removed). The
+    generation spans and per-message spans are half-open char ranges in that string's
+    coordinates, ready to be mapped onto tokens via the encoding's char->token map.
+    """
+    parts = re.split(
+        (
+            f"({re.escape(_GENERATION_SENTINEL_START)}|"
+            f"{re.escape(_GENERATION_SENTINEL_END)}|"
+            f"{_MESSAGE_SENTINEL_RE.pattern})"
+        ),
+        rendered,
+    )
+
+    clean: list[str] = []
+    position = 0
+    generation_spans: list[tuple[int, int]] = []
+    generation_start: int | None = None
+    message_starts: dict[int, int] = {}
+    message_spans = [(0, 0) for _ in range(num_messages)]
+
+    for part in parts:
+        if part == _GENERATION_SENTINEL_START:
+            generation_start = position
+            continue
+        if part == _GENERATION_SENTINEL_END:
+            if generation_start is not None:
+                generation_spans.append((generation_start, position))
+                generation_start = None
+            continue
+        if _MESSAGE_SENTINEL_RE.fullmatch(part):
+            if part.startswith(_MESSAGE_SENTINEL_START):
+                index = _message_sentinel_index(part, _MESSAGE_SENTINEL_START)
+                if index < num_messages:
+                    message_starts[index] = position
+            else:
+                index = _message_sentinel_index(part, _MESSAGE_SENTINEL_END)
+                start = message_starts.pop(index, position)
+                if index < num_messages:
+                    message_spans[index] = (start, position)
+            continue
+        if not part:
+            continue
+        clean.append(part)
+        position += len(part)
+
+    return "".join(clean), generation_spans, message_spans
+
+
+def _assistant_mask_from_generation_spans(
+    encoding: HfEncoding, num_tokens: int, generation_spans: list[tuple[int, int]]
+) -> list[int]:
+    """Mark tokens whose characters fall inside a `{% generation %}` span.
+
+    Mirrors transformers' assistant-mask extraction: each generation char span maps to
+    tokens via `char_to_token(start)` and `char_to_token(end - 1)`, marking the closed
+    token range. A `None` start (span dropped by truncation) stops processing, matching HF.
+    """
+    mask = [0] * num_tokens
+    for start_char, end_char in generation_spans:
+        start_token = encoding.char_to_token(start_char)
+        end_token = encoding.char_to_token(end_char - 1)
+        if start_token is None:
+            break
+        for token_index in range(start_token, end_token + 1 if end_token else num_tokens):
+            mask[token_index] = 1
+    return mask
+
+
+def _message_token_spans(
+    encoding: HfEncoding, num_tokens: int, message_char_spans: list[tuple[int, int]]
+) -> list[tuple[int, int]]:
+    """Convert per-message char spans to half-open token spans via the char->token map.
+
+    Messages the template drops from its loop (e.g. a system message hoisted out of
+    `{% for %}`) keep a `(0, 0)` span; leading such spans are backfilled to cover the
+    rendered prefix so downstream label projection has a contiguous cover.
+    """
+    spans: list[tuple[int, int]] = []
+    for start_char, end_char in message_char_spans:
+        if start_char == end_char:
+            spans.append((0, 0))
+            continue
+        start_token = encoding.char_to_token(start_char)
+        end_token = encoding.char_to_token(end_char - 1)
+        if start_token is None:
+            spans.append((0, 0))
+        else:
+            spans.append((start_token, end_token + 1 if end_token is not None else num_tokens))
+
+    observed = [(start, end) for start, end in spans if start != end]
+    if observed:
+        first_observed_start = observed[0][0]
+        for index, span in enumerate(spans):
+            if span == (0, 0) and index < len(spans) - 1:
+                spans[index] = (0, first_observed_start)
+            else:
+                break
+    return spans
+
+
 def _apply_chat_template_with_masks(
-    tokenizer: "MarinTokenizer",
+    tokenizer: "HfMarinTokenizer",
     conversations: list[list[dict[str, str]]],
     *,
     chat_template: str | None = None,
@@ -372,10 +490,14 @@ def _apply_chat_template_with_masks(
 ) -> dict[str, Any]:
     """Render chat templates for batched conversations and return token-level masks.
 
-    The returned `assistant_masks` mark tokens rendered inside `{% generation %}` blocks.
-    When `return_message_spans` is set, the returned `message_spans` list contains
-    half-open token spans `(start, end)` for each source message after chat-template rendering.
-    These spans are used by trace-labeled evals to project per-message labels onto the exact
+    The full rendered string is tokenized once and `{% generation %}` char spans are mapped
+    onto tokens via the encoding's char->token map, so `input_ids` and `assistant_masks`
+    match `transformers.apply_chat_template(..., return_assistant_tokens_mask=True)`,
+    including BPE merges that cross a generation boundary.
+
+    When `return_message_spans` is set, the returned `message_spans` list contains half-open
+    token spans `(start, end)` for each source message after chat-template rendering. These
+    spans are used by trace-labeled evals to project per-message labels onto the exact
     rendered prompt tokens, including role headers and tool-call formatting.
     """
     template_str = chat_template or tokenizer.chat_template
@@ -400,61 +522,14 @@ def _apply_chat_template_with_masks(
             **kwargs,
         )
 
-        ids: list[int] = []
-        mask: list[int] = []
-        is_assistant = False
-        message_starts: dict[int, int] = {}
-        message_spans = [(0, 0) for _ in conversation]
+        clean, generation_spans, message_char_spans = _strip_sentinels(rendered, len(conversation))
+        encoding = tokenizer._tokenizer.encode(clean, add_special_tokens=False)
+        ids = list(encoding.ids)
 
-        parts = re.split(
-            (
-                f"({re.escape(_GENERATION_SENTINEL_START)}|"
-                f"{re.escape(_GENERATION_SENTINEL_END)}|"
-                f"{_MESSAGE_SENTINEL_RE.pattern})"
-            ),
-            rendered,
-        )
-
-        # Each segment is encoded independently. BPE merges that would span a
-        # sentinel boundary are lost, which can produce slightly different token
-        # IDs at the boundary vs encoding the full string. This matches HF's
-        # AssistantTracker behavior which has the same limitation.
-        for part in parts:
-            if part == _GENERATION_SENTINEL_START:
-                is_assistant = True
-                continue
-            if part == _GENERATION_SENTINEL_END:
-                is_assistant = False
-                continue
-            if _MESSAGE_SENTINEL_RE.fullmatch(part):
-                if part.startswith(_MESSAGE_SENTINEL_START):
-                    message_index = _message_sentinel_index(part, _MESSAGE_SENTINEL_START)
-                    if message_index < len(message_spans):
-                        message_starts[message_index] = len(ids)
-                else:
-                    message_index = _message_sentinel_index(part, _MESSAGE_SENTINEL_END)
-                    start = message_starts.pop(message_index, len(ids))
-                    if message_index < len(message_spans):
-                        message_spans[message_index] = (start, len(ids))
-                continue
-            if not part:
-                continue
-            segment_ids = tokenizer.encode(part, add_special_tokens=False)
-            ids.extend(segment_ids)
-            mask.extend([1 if is_assistant else 0] * len(segment_ids))
-
-        if return_message_spans:
-            observed_spans = [(start, end) for start, end in message_spans if start != end]
-            if observed_spans:
-                first_observed_start = observed_spans[0][0]
-                for index, span in enumerate(message_spans):
-                    if span == (0, 0) and index < len(message_spans) - 1:
-                        message_spans[index] = (0, first_observed_start)
-                    else:
-                        break
-            all_message_spans.append(message_spans)
         all_ids.append(ids)
-        all_masks.append(mask)
+        all_masks.append(_assistant_mask_from_generation_spans(encoding, len(ids), generation_spans))
+        if return_message_spans:
+            all_message_spans.append(_message_token_spans(encoding, len(ids), message_char_spans))
 
     result: dict[str, Any] = {"input_ids": all_ids, "assistant_masks": all_masks}
     if return_message_spans:

--- a/lib/levanter/src/levanter/tokenizers.py
+++ b/lib/levanter/src/levanter/tokenizers.py
@@ -443,7 +443,9 @@ def _assistant_mask_from_generation_spans(
 
     Mirrors transformers' assistant-mask extraction: each generation char span maps to
     tokens via `char_to_token(start)` and `char_to_token(end - 1)`, marking the closed
-    token range. A `None` start (span dropped by truncation) stops processing, matching HF.
+    token range. A `None` start (span dropped by truncation) stops processing, matching HF;
+    a `None` end (only the tail was truncated) marks through the final token. `end_token`
+    is checked against `None` explicitly so a span ending at token 0 marks just that token.
     """
     mask = [0] * num_tokens
     for start_char, end_char in generation_spans:
@@ -451,7 +453,7 @@ def _assistant_mask_from_generation_spans(
         end_token = encoding.char_to_token(end_char - 1)
         if start_token is None:
             break
-        for token_index in range(start_token, end_token + 1 if end_token else num_tokens):
+        for token_index in range(start_token, end_token + 1 if end_token is not None else num_tokens):
             mask[token_index] = 1
     return mask
 

--- a/lib/levanter/src/levanter/tokenizers.py
+++ b/lib/levanter/src/levanter/tokenizers.py
@@ -26,7 +26,7 @@ import tempfile
 import threading
 import time
 from enum import StrEnum
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, NamedTuple, Protocol, runtime_checkable
 
 import jinja2
 import jinja2.ext
@@ -377,13 +377,21 @@ def _chat_template_messages(
     ]
 
 
-def _strip_sentinels(rendered: str, num_messages: int) -> tuple[str, list[tuple[int, int]], list[tuple[int, int]]]:
-    """Recover the sentinel-free render plus generation and per-message char spans.
+class _StrippedRender(NamedTuple):
+    """Sentinel-free render text with the char spans recovered from the removed sentinels.
 
-    The returned string is byte-for-byte the string HF renders (sentinels removed). The
-    generation spans and per-message spans are half-open char ranges in that string's
-    coordinates, ready to be mapped onto tokens via the encoding's char->token map.
+    `text` is byte-for-byte the string HF renders. `generation_spans` and `message_spans`
+    are half-open char ranges in `text`'s coordinates, ready to map onto tokens via the
+    encoding's char->token map.
     """
+
+    text: str
+    generation_spans: list[tuple[int, int]]
+    message_spans: list[tuple[int, int]]
+
+
+def _strip_sentinels(rendered: str, num_messages: int) -> _StrippedRender:
+    """Recover the sentinel-free render plus generation and per-message char spans."""
     parts = re.split(
         (
             f"({re.escape(_GENERATION_SENTINEL_START)}|"
@@ -425,7 +433,7 @@ def _strip_sentinels(rendered: str, num_messages: int) -> tuple[str, list[tuple[
         clean.append(part)
         position += len(part)
 
-    return "".join(clean), generation_spans, message_spans
+    return _StrippedRender("".join(clean), generation_spans, message_spans)
 
 
 def _assistant_mask_from_generation_spans(
@@ -522,14 +530,14 @@ def _apply_chat_template_with_masks(
             **kwargs,
         )
 
-        clean, generation_spans, message_char_spans = _strip_sentinels(rendered, len(conversation))
-        encoding = tokenizer._tokenizer.encode(clean, add_special_tokens=False)
+        stripped = _strip_sentinels(rendered, len(conversation))
+        encoding = tokenizer._tokenizer.encode(stripped.text, add_special_tokens=False)
         ids = list(encoding.ids)
 
         all_ids.append(ids)
-        all_masks.append(_assistant_mask_from_generation_spans(encoding, len(ids), generation_spans))
+        all_masks.append(_assistant_mask_from_generation_spans(encoding, len(ids), stripped.generation_spans))
         if return_message_spans:
-            all_message_spans.append(_message_token_spans(encoding, len(ids), message_char_spans))
+            all_message_spans.append(_message_token_spans(encoding, len(ids), stripped.message_spans))
 
     result: dict[str, Any] = {"input_ids": all_ids, "assistant_masks": all_masks}
     if return_message_spans:

--- a/lib/levanter/tests/test_sft_packing.py
+++ b/lib/levanter/tests/test_sft_packing.py
@@ -246,8 +246,14 @@ def test_packed_leading_document_loss_matches_unpacked(tokenizer, tmp_path):
         def per_position_loss(model, example):
             return model.compute_next_token_loss(example, reduction=None, reduction_axis=()).array
 
-        packed_loss = np.asarray(per_position_loss(model, named_lm_example_from_grug(packed, Pos=model.Pos)))
-        unpacked_loss = np.asarray(per_position_loss(model, named_lm_example_from_grug(unpacked, Pos=model.Pos)))
+        def host_example(grug_example):
+            # ChatDataset pins its arrays to CPU; drop that device commitment (via host
+            # numpy) so the jit under the mesh places the inputs on its own devices.
+            named = named_lm_example_from_grug(grug_example, Pos=model.Pos)
+            return jax.tree.map(np.asarray, named)
+
+        packed_loss = np.asarray(per_position_loss(model, host_example(packed)))
+        unpacked_loss = np.asarray(per_position_loss(model, host_example(unpacked)))
 
     # The leading document occupies positions 0..leading_len-1 in both cases; its loss
     # must be identical. (Uncharged positions are zero in both, so this also confirms

--- a/lib/levanter/tests/test_sft_packing.py
+++ b/lib/levanter/tests/test_sft_packing.py
@@ -1,0 +1,254 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+"""SFT packing/masking regressions driven end-to-end from a real ChatDataset.
+
+These guard the wiring between the chat-data pipeline and training: that packed
+documents cannot attend across segment boundaries, that the per-token loss weight
+charges exactly the shifted `{% generation %}` spans, and that packing a batch does
+not change the per-document next-token loss.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import equinox
+import haliax as hax
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from chex import assert_trees_all_close
+from haliax import Axis
+from haliax.partitioning import ResourceAxis
+from jax.sharding import NamedSharding, PartitionSpec
+
+from levanter.data.text.datasets import ChatDataset
+from levanter.data.text.examples import named_lm_example_from_grug
+from levanter.data.text.formats import ChatProcessor
+from levanter.grug.attention import reference_attention
+from levanter.layers.attention import AttentionBackend, AttentionMask, dot_product_attention
+from levanter.models.llama import LlamaConfig
+from levanter.store.cache import SerialCacheWriter
+from levanter.tokenizers import MarinTokenizer, load_tokenizer
+from levanter.utils.tree_utils import inference_mode
+
+from test_text_chat import MULTI_TOOL_TEMPLATE
+from test_utils import use_test_mesh
+
+MODEL_NAME = "marin-community/marin-tokenizer"
+
+# Packed sequence length. Larger than the two documents combined (so both pack into
+# one example) and equal to the flash block size, so jax_flash/splash run in one block.
+POS = 128
+
+# Two documents that both carry masked assistant spans under MULTI_TOOL_TEMPLATE: a
+# tool-calling turn plus a final answer, and a plain chat turn.
+_CONV_TOOL = [
+    {"role": "user", "content": "Call the adder."},
+    {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "add", "arguments": {"a": 2, "b": 3}}}],
+    },
+    {"role": "tool", "content": {"result": 5}},
+    {"role": "assistant", "content": "The sum is 5."},
+]
+_CONV_CHAT = [
+    {"role": "user", "content": "Say hi."},
+    {"role": "assistant", "content": "hi there"},
+]
+_FIXTURE_CONVS = [_CONV_TOOL, _CONV_CHAT]
+
+
+@pytest.fixture(scope="module")
+def tokenizer() -> MarinTokenizer:
+    try:
+        return load_tokenizer(MODEL_NAME)
+    except Exception as e:  # noqa: BLE001 - network/optional-dep failure should skip, not error
+        pytest.skip(f"Could not load tokenizer {MODEL_NAME}: {e}")
+
+
+def _chat_example(tokenizer: MarinTokenizer, cache_dir, conversations, *, max_segments: int):
+    """Build the first ChatDataset example over `conversations` plus the processed rows."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    processor = ChatProcessor(tokenizer, chat_template=MULTI_TOOL_TEMPLATE, mask_user_turns=True)
+    processed = processor([{"messages": conv} for conv in conversations])
+    exemplar = {"input_ids": np.zeros((0,), np.int32), "assistant_masks": np.zeros((0,), np.int32)}
+    with SerialCacheWriter(str(cache_dir), exemplar) as writer:
+        writer.write_batch(
+            [
+                {
+                    "input_ids": row["input_ids"].astype(np.int32),
+                    "assistant_masks": row["assistant_masks"].astype(np.int32),
+                }
+                for row in processed
+            ]
+        )
+    dataset = ChatDataset(
+        writer.result(),
+        Axis("position", POS),
+        max_segments_per_example=max_segments,
+        slice_strategy="raise",
+        mask_user_turns=True,
+        block_cross_document_attention=True,
+    )
+    example = asyncio.run(dataset.getitem_async(0))
+    return example, processed
+
+
+def _hot_key_qkv(length: int, head_size: int):
+    """Query/key/value for the segment-leak probe of test_attention.py::test_segment_ids_are_respected.
+
+    Every query is ones; key 0 alone carries a large score component and value 0 alone
+    carries the detector value 300 in channel 1. A query attends key 0 only when causal
+    masking and segment masking both allow it, so channel 1 of the output is 300 exactly
+    for positions in key 0's segment and 0 elsewhere.
+    """
+    query = np.ones((length, head_size), np.float32)
+    key = np.zeros((length, head_size), np.float32)
+    key[0, 0] = 100.0
+    value = np.zeros((length, head_size), np.float32)
+    value[0, 1] = 300.0
+    return query, key, value
+
+
+@pytest.mark.parametrize("impl", ["vanilla", "jax_flash", "default", "splash"])
+def test_packed_segments_block_cross_segment_attention(tokenizer, tmp_path, impl):
+    if impl == "splash" and jax.default_backend() != "tpu":
+        pytest.skip("splash kernel requires TPU")
+
+    example, _ = _chat_example(tokenizer, tmp_path / "packed", _FIXTURE_CONVS, max_segments=len(_FIXTURE_CONVS))
+    query_segments, _ = example.attn_mask.segment_ids
+    segments = np.asarray(query_segments)
+    length = segments.shape[0]
+    # splash/default require 128-wide heads; vanilla/jax_flash use a 2-wide head.
+    head_size = 128 if impl in ("default", "splash") else 2
+
+    Pos = Axis("Pos", length)
+    KPos = Pos.alias("KPos")
+    Head = Axis("Head", head_size)
+    query_np, key_np, value_np = _hot_key_qkv(length, head_size)
+
+    with use_test_mesh() as mesh:
+        query = hax.named(query_np, (Pos, Head))
+        key = hax.named(key_np, (KPos, Head))
+        value = hax.named(value_np, (KPos, Head))
+        query, key, value = jax.device_put(
+            [query, key, value], NamedSharding(mesh, PartitionSpec(ResourceAxis.DATA, None))
+        )
+        seg = jax.device_put(segments, NamedSharding(mesh, PartitionSpec(ResourceAxis.DATA)))
+        seg = hax.named(seg, (Pos,))
+        mask = AttentionMask(causal_offset=0, segment_ids=seg)
+
+        jit_dpa = equinox.filter_jit(dot_product_attention)
+        result = jit_dpa(
+            Pos,
+            KPos,
+            Head,
+            query,
+            key,
+            value,
+            attn_backend=AttentionBackend(impl),
+            mask=mask,
+            flash_block_size=length,
+        )
+        detector = np.asarray(result.array)[:, 1]
+
+    in_key_segment = segments == segments[0]
+    assert in_key_segment.sum() > 0 and (~in_key_segment).sum() > 0, "fixture must span >1 segment"
+    # Positions sharing key 0's document see the value; every other position (other
+    # documents and padding) must see exactly zero — no cross-segment leak.
+    assert_trees_all_close(detector[in_key_segment], 300.0, atol=1e-2, rtol=1e-2)
+    assert_trees_all_close(detector[~in_key_segment], 0.0, atol=1e-2, rtol=1e-2)
+
+
+def test_packed_segments_block_cross_segment_attention_grug_reference(tokenizer, tmp_path):
+    example, _ = _chat_example(tokenizer, tmp_path / "packed", _FIXTURE_CONVS, max_segments=len(_FIXTURE_CONVS))
+    query_segments, _ = example.attn_mask.segment_ids
+    segments = np.asarray(query_segments)
+    length = segments.shape[0]
+
+    query_np, key_np, value_np = _hot_key_qkv(length, head_size=2)
+    # reference_attention wants (batch, seq, heads, head_size).
+    query = jnp.asarray(query_np)[None, :, None, :]
+    key = jnp.asarray(key_np)[None, :, None, :]
+    value = jnp.asarray(value_np)[None, :, None, :]
+
+    out = reference_attention(query, key, value, example.attn_mask, logits_dtype=jnp.float32)
+    detector = np.asarray(out)[0, :, 0, 1]
+
+    in_key_segment = segments == segments[0]
+    assert_trees_all_close(detector[in_key_segment], 300.0, atol=1e-2, rtol=1e-2)
+    assert_trees_all_close(detector[~in_key_segment], 0.0, atol=1e-2, rtol=1e-2)
+
+
+def test_packed_loss_weight_charges_only_generation_spans(tokenizer, tmp_path):
+    example, processed = _chat_example(
+        tokenizer, tmp_path / "packed", _FIXTURE_CONVS, max_segments=len(_FIXTURE_CONVS)
+    )
+    tokens = np.asarray(example.tokens)
+    loss_weight = np.asarray(example.loss_weight)
+    query_segments, _ = example.attn_mask.segment_ids
+    segments = np.asarray(query_segments)
+
+    # The loss weight is a binary next-token training mask.
+    assert set(np.unique(loss_weight).tolist()) <= {0.0, 1.0}
+
+    charged = np.nonzero(loss_weight > 0)[0]
+    # Every charged position trains its NEXT token and never crosses a document
+    # boundary or lands on padding.
+    assert np.all(segments[charged] == segments[charged + 1])
+    assert np.all(segments[charged + 1] != -1)
+
+    # The next tokens charged are exactly the assistant/generation tokens, in order:
+    # nothing from user, tool-response, or role-header spans is charged.
+    charged_next_tokens = tokens[charged + 1]
+    expected_assistant_tokens = np.concatenate([row["input_ids"][row["assistant_masks"] == 1] for row in processed])
+    np.testing.assert_array_equal(charged_next_tokens, expected_assistant_tokens)
+
+    # Padding carries no loss.
+    assert float(loss_weight[segments == -1].sum()) == 0.0
+
+
+def _per_position_loss(model, grug_example):
+    """Weighted per-position next-token loss for a GrugLmExample under `model`."""
+    named = named_lm_example_from_grug(grug_example, Pos=model.Pos)
+    return np.asarray(model.compute_next_token_loss(named, reduction=None, reduction_axis=()).array)
+
+
+def test_packed_leading_document_loss_matches_unpacked(tokenizer, tmp_path):
+    """Packing must not change the leading document's per-token loss.
+
+    Cross-document attention is blocked by segment ids, but position ids are absolute
+    and do not reset per document, so only the position-aligned leading document is
+    invariant under packing today; later documents shift and will match once the
+    pad-per-document path (GH #7086) preserves per-document positions. This pins the
+    leading-document invariant end-to-end through a real attention stack, which is the
+    guard against a cross-document leak surfacing as a changed loss.
+    """
+    packed, processed = _chat_example(tokenizer, tmp_path / "packed", _FIXTURE_CONVS, max_segments=len(_FIXTURE_CONVS))
+    unpacked, _ = _chat_example(tokenizer, tmp_path / "unpacked", _FIXTURE_CONVS[:1], max_segments=1)
+    leading_len = len(processed[0]["input_ids"])
+
+    # A rotary-position model whose attention honors segment ids; vanilla runs the same
+    # on CPU and TPU so the comparison is exact rather than backend-dependent.
+    config = LlamaConfig(
+        max_seq_len=POS,
+        hidden_dim=32,
+        intermediate_dim=64,
+        num_heads=4,
+        num_kv_heads=4,
+        num_layers=2,
+        attn_backend=AttentionBackend.VANILLA,
+    )
+    model = inference_mode(config.build(Axis("vocab", tokenizer.vocab_size), key=jax.random.PRNGKey(0)), True)
+
+    with use_test_mesh(tensor_parallelism=1):
+        packed_loss = _per_position_loss(model, packed)
+        unpacked_loss = _per_position_loss(model, unpacked)
+
+    # The leading document occupies positions 0..leading_len-1 in both cases; its loss
+    # must be identical. (Uncharged positions are zero in both, so this also confirms
+    # the loss weight agrees.)
+    assert float(np.abs(packed_loss[:leading_len]).sum()) > 0, "leading document must charge some loss"
+    assert_trees_all_close(packed_loss[:leading_len], unpacked_loss[:leading_len], atol=1e-4, rtol=1e-4)

--- a/lib/levanter/tests/test_sft_packing.py
+++ b/lib/levanter/tests/test_sft_packing.py
@@ -221,8 +221,8 @@ def test_packed_leading_document_loss_matches_unpacked(tokenizer, tmp_path):
 
     Cross-document attention is blocked by segment ids, but position ids are absolute
     and do not reset per document, so only the position-aligned leading document is
-    invariant under packing today; later documents shift and will match once the
-    pad-per-document path (GH #7086) preserves per-document positions. This pins the
+    invariant under packing today; later documents shift and will match once a
+    pad-per-document packing path preserves per-document positions. This pins the
     leading-document invariant end-to-end through a real attention stack, which is the
     guard against a cross-document leak surfacing as a changed loss.
     """

--- a/lib/levanter/tests/test_sft_packing.py
+++ b/lib/levanter/tests/test_sft_packing.py
@@ -210,12 +210,6 @@ def test_packed_loss_weight_charges_only_generation_spans(tokenizer, tmp_path):
     assert float(loss_weight[segments == -1].sum()) == 0.0
 
 
-def _per_position_loss(model, grug_example):
-    """Weighted per-position next-token loss for a GrugLmExample under `model`."""
-    named = named_lm_example_from_grug(grug_example, Pos=model.Pos)
-    return np.asarray(model.compute_next_token_loss(named, reduction=None, reduction_axis=()).array)
-
-
 def test_packed_leading_document_loss_matches_unpacked(tokenizer, tmp_path):
     """Packing must not change the leading document's per-token loss.
 
@@ -231,7 +225,7 @@ def test_packed_leading_document_loss_matches_unpacked(tokenizer, tmp_path):
     leading_len = len(processed[0]["input_ids"])
 
     # A rotary-position model whose attention honors segment ids; vanilla runs the same
-    # on CPU and TPU so the comparison is exact rather than backend-dependent.
+    # on CPU and TPU so the leading-document loss matches regardless of backend.
     config = LlamaConfig(
         max_seq_len=POS,
         hidden_dim=32,
@@ -241,11 +235,19 @@ def test_packed_leading_document_loss_matches_unpacked(tokenizer, tmp_path):
         num_layers=2,
         attn_backend=AttentionBackend.VANILLA,
     )
-    model = inference_mode(config.build(Axis("vocab", tokenizer.vocab_size), key=jax.random.PRNGKey(0)), True)
 
-    with use_test_mesh(tensor_parallelism=1):
-        packed_loss = _per_position_loss(model, packed)
-        unpacked_loss = _per_position_loss(model, unpacked)
+    # Build the model and run the forward under an active mesh; the attention path uses
+    # shard_map, which requires a concrete mesh, so both must be inside use_test_mesh and
+    # the forward must be jitted (matching tests/test_qwen3_moe.py).
+    with use_test_mesh():
+        model = inference_mode(config.build(Axis("vocab", tokenizer.vocab_size), key=jax.random.PRNGKey(0)), True)
+
+        @hax.named_jit
+        def per_position_loss(model, example):
+            return model.compute_next_token_loss(example, reduction=None, reduction_axis=()).array
+
+        packed_loss = np.asarray(per_position_loss(model, named_lm_example_from_grug(packed, Pos=model.Pos)))
+        unpacked_loss = np.asarray(per_position_loss(model, named_lm_example_from_grug(unpacked, Pos=model.Pos)))
 
     # The leading document occupies positions 0..leading_len-1 in both cases; its loss
     # must be identical. (Uncharged positions are zero in both, so this also confirms

--- a/lib/levanter/tests/test_text_chat.py
+++ b/lib/levanter/tests/test_text_chat.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import ast
+import pathlib
 from typing import Sequence
 
 import numpy as np
@@ -630,3 +632,211 @@ def test_chat_processor_rejects_system_mapping_without_content(tokenizer: MarinT
 
     with pytest.raises(ValueError, match="System prompt mapping must include 'content'"):
         processor(batch)
+
+
+# ---------------------------------------------------------------------------
+# HuggingFace parity: Levanter's chat renderer vs transformers.apply_chat_template
+#
+# Levanter reimplements apply_chat_template(..., return_assistant_tokens_mask=True)
+# without transformers. These tests pin that reimplementation against the real HF
+# tokenizer as an independent oracle: rendered string, input_ids, and assistant_masks
+# must all match. HF renders the chat, tokenizes the full string once, and maps
+# {% generation %} char spans onto tokens via char_to_token; Levanter must do the same
+# so that BPE merges spanning a generation boundary and JSON key ordering agree.
+# ---------------------------------------------------------------------------
+
+# Minimal generation-bearing template. Generation content is delimited by special
+# tokens (role header + <|eot_id|>), so no BPE merge crosses the mask boundary.
+HF_SIMPLE_TEMPLATE = """\
+{%- for message in messages -%}
+<|start_header_id|>{{ message['role'] }}<|end_header_id|>
+{%- if message['role'] == 'assistant' -%}
+{% generation %}{{ message['content'] }}{% endgeneration %}
+{%- else -%}
+{{ message['content'] }}
+{%- endif -%}
+<|eot_id|>
+{%- endfor -%}
+"""
+
+# Adversarial: the {% generation %} block abuts ordinary text (no special token,
+# no whitespace) on both sides, so the correct tokenization BPE-merges across the
+# mask boundary ("Bot says: <gen>greetings" and "friend</gen> done"). Levanter's
+# former per-segment encoding split those merges; tokenizing once fixes it. This
+# case fails against HF unless the renderer maps char spans onto a single encoding.
+HF_BOUNDARY_MERGE_TEMPLATE = """\
+{%- for message in messages -%}
+{%- if message['role'] == 'assistant' -%}
+Bot says: {% generation %}{{ message['content'] }}{% endgeneration %} done.
+{%- else -%}
+User: {{ message['content'] }}
+{%- endif -%}
+{%- endfor -%}
+"""
+
+
+def _load_llama3_trainable_template() -> str | None:
+    """Read the trainable llama3-instruct chat template out of experiments/llama.py.
+
+    That template trains real SFT models, so parity against HF matters for it directly.
+    It lives in the marin layer, which levanter must not import, so the constant is read
+    from source via AST instead of imported. Returns None when the file is absent (e.g.
+    levanter checked out on its own), in which case the parametrized case is skipped.
+    """
+    path = pathlib.Path(__file__).resolve().parents[3] / "experiments" / "llama.py"
+    if not path.exists():
+        return None
+    tree = ast.parse(path.read_text())
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "llama3_instruct_trainable_chat_template" for t in node.targets
+        ):
+            return ast.literal_eval(node.value)
+    return None
+
+
+LLAMA3_TRAINABLE_TEMPLATE = _load_llama3_trainable_template()
+
+_WEATHER_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string", "description": "City name"}},
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+_MULTI_TURN = [
+    {"role": "user", "content": "What is 2+2?"},
+    {"role": "assistant", "content": "4"},
+    {"role": "user", "content": "And 3+3?"},
+    {"role": "assistant", "content": "It is 6."},
+]
+
+_WITH_SYSTEM = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Hi there."},
+    {"role": "assistant", "content": "Hello! How can I help you today?"},
+]
+
+_TOOL_CALL_CONV = [
+    {"role": "user", "content": "Call the adder."},
+    {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {"id": "call_1", "type": "function", "function": {"name": "add", "arguments": {"a": 2, "b": 3}}}
+        ],
+    },
+    {"role": "tool", "content": {"result": 5}},
+    {"role": "assistant", "content": "The sum is 5."},
+]
+
+_MULTI_TOOL_CONV = [
+    {"role": "user", "content": "Search then open."},
+    {
+        "role": "assistant",
+        "content": "On it.",
+        "tool_calls": [
+            {"id": "c1", "type": "function", "function": {"name": "search", "arguments": {"query": "cats"}}},
+            {"id": "c2", "type": "function", "function": {"name": "open", "arguments": {"path": "a.py"}}},
+        ],
+    },
+    {"role": "assistant", "content": "Done."},
+]
+
+_LLAMA3_TOOL_CONV = [
+    {"role": "system", "content": "You are a weather bot."},
+    {"role": "user", "content": "Weather in Paris?"},
+    {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{"type": "function", "function": {"name": "get_weather", "arguments": {"city": "Paris"}}}],
+    },
+    {"role": "tool", "content": {"temp": 20}},
+    {"role": "assistant", "content": "It is 20 degrees in Paris."},
+]
+
+_ADVERSARIAL_CONV = [
+    {"role": "user", "content": "hi"},
+    {"role": "assistant", "content": "greetings friend"},
+    {"role": "user", "content": "bye"},
+    {"role": "assistant", "content": "farewell traveller"},
+]
+
+_PARITY_CASES = [
+    pytest.param(HF_SIMPLE_TEMPLATE, _MULTI_TURN, {}, id="simple-multi-turn"),
+    pytest.param(HF_SIMPLE_TEMPLATE, _WITH_SYSTEM, {}, id="simple-system"),
+    pytest.param(TOOL_TEMPLATE, _TOOL_CALL_CONV, {}, id="tool-calls-and-response"),
+    pytest.param(MULTI_TOOL_TEMPLATE, _MULTI_TOOL_CONV, {}, id="multi-tool-calls"),
+    pytest.param(
+        ALT_TEMPLATE,
+        [{"role": "user", "content": "Reason please."}, {"role": "assistant", "content": "Sure, here goes."}],
+        {"enable_thinking": True, "custom_instructions": "Be careful.", "xml_tools": ['{"name": "final_answer"}']},
+        id="alt-chat-template-kwargs",
+    ),
+    pytest.param(HF_BOUNDARY_MERGE_TEMPLATE, _ADVERSARIAL_CONV, {}, id="boundary-merge-crosses-generation"),
+    pytest.param(
+        LLAMA3_TRAINABLE_TEMPLATE,
+        _LLAMA3_TOOL_CONV,
+        {"tools": _WEATHER_TOOLS},
+        id="llama3-trainable-with-tools",
+        marks=pytest.mark.skipif(
+            LLAMA3_TRAINABLE_TEMPLATE is None, reason="experiments/llama.py not present in this checkout"
+        ),
+    ),
+    pytest.param(
+        LLAMA3_TRAINABLE_TEMPLATE,
+        _WITH_SYSTEM + [{"role": "user", "content": "Bye"}, {"role": "assistant", "content": "Goodbye."}],
+        {},
+        id="llama3-trainable-plain",
+        marks=pytest.mark.skipif(
+            LLAMA3_TRAINABLE_TEMPLATE is None, reason="experiments/llama.py not present in this checkout"
+        ),
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def hf_tokenizer(tokenizer: MarinTokenizer):
+    try:
+        hf = tokenizer.as_hf_tokenizer()
+    except Exception as e:  # noqa: BLE001 - network/optional-dep failure should skip, not error
+        pytest.skip(f"Could not construct HF tokenizer: {e}")
+    if not hf.is_fast:
+        pytest.skip("assistant-mask parity requires a fast HF tokenizer for char_to_token")
+    return hf
+
+
+@pytest.mark.parametrize("template, conversation, kwargs", _PARITY_CASES)
+def test_chat_template_matches_hf(tokenizer: MarinTokenizer, hf_tokenizer, template, conversation, kwargs):
+    lev = tokenizer.apply_chat_template_with_masks([conversation], chat_template=template, **kwargs)
+    lev_ids = lev["input_ids"][0]
+    lev_mask = lev["assistant_masks"][0]
+    lev_rendered = tokenizer.with_chat_template(template).apply_chat_template(conversation, tokenize=False, **kwargs)
+
+    hf_out = hf_tokenizer.apply_chat_template(
+        conversation,
+        chat_template=template,
+        tokenize=True,
+        return_dict=True,
+        return_assistant_tokens_mask=True,
+        add_generation_prompt=False,
+        **kwargs,
+    )
+    hf_rendered = hf_tokenizer.apply_chat_template(
+        conversation, chat_template=template, tokenize=False, add_generation_prompt=False, **kwargs
+    )
+
+    assert lev_rendered == hf_rendered
+    assert lev_ids == list(hf_out["input_ids"])
+    assert lev_mask == list(hf_out["assistant_masks"])
+    # A template with an assistant turn must charge at least one assistant token,
+    # otherwise "masks match" could hold vacuously on two all-zero masks.
+    assert sum(lev_mask) > 0

--- a/lib/levanter/tests/test_text_chat.py
+++ b/lib/levanter/tests/test_text_chat.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import ast
-import pathlib
 from typing import Sequence
 
 import numpy as np
@@ -675,27 +673,52 @@ User: {{ message['content'] }}
 """
 
 
-def _load_llama3_trainable_template() -> str | None:
-    """Read the trainable llama3-instruct chat template out of experiments/llama.py.
-
-    That template trains real SFT models, so parity against HF matters for it directly.
-    It lives in the marin layer, which levanter must not import, so the constant is read
-    from source via AST instead of imported. Returns None when the file is absent (e.g.
-    levanter checked out on its own), in which case the parametrized case is skipped.
-    """
-    path = pathlib.Path(__file__).resolve().parents[3] / "experiments" / "llama.py"
-    if not path.exists():
-        return None
-    tree = ast.parse(path.read_text())
-    for node in tree.body:
-        if isinstance(node, ast.Assign) and any(
-            isinstance(t, ast.Name) and t.id == "llama3_instruct_trainable_chat_template" for t in node.targets
-        ):
-            return ast.literal_eval(node.value)
-    return None
-
-
-LLAMA3_TRAINABLE_TEMPLATE = _load_llama3_trainable_template()
+# A llama3-instruct-style trainable template exercising the constructs that separate real
+# SFT templates from the toy ones above: a hoisted system message, a `tools` parameter
+# serialized with `tojson(indent=4)`, tool_calls rendered with `tojson`, tool-role
+# responses, and `{% generation %}` assistant spans. Self-contained so the levanter test
+# suite stays independent of the marin layer where the production template lives.
+LLAMA3_STYLE_TEMPLATE = """{{- bos_token }}
+{%- if messages[0]['role'] == 'system' %}
+    {%- set system_message = messages[0]['content'] %}
+    {%- set loop_messages = messages[1:] %}
+{%- else %}
+    {%- set system_message = '' %}
+    {%- set loop_messages = messages %}
+{%- endif %}
+{{- '<|start_header_id|>system<|end_header_id|>\\n\\n' + system_message }}
+{%- if tools is defined and tools %}
+    {{- '\\n\\nYou have access to the following functions:\\n' }}
+    {%- for tool in tools %}
+        {{- tool | tojson(indent=4) }}
+        {{- '\\n' }}
+    {%- endfor %}
+{%- endif %}
+{{- '<|eot_id|>' }}
+{%- for message in loop_messages %}
+    {%- if message['role'] == 'assistant' and message.get('tool_calls') %}
+        {{- '<|start_header_id|>assistant<|end_header_id|>\\n\\n' -}}
+        {%- generation %}
+        {%- for tool_call in message['tool_calls'] %}
+            {{- '{"name": "' + tool_call['function']['name'] + '", "parameters": ' }}
+            {{- tool_call['function']['arguments'] | tojson }}
+            {{- '}' }}
+        {%- endfor %}
+        {%- endgeneration %}
+        {{- '<|eot_id|>' }}
+    {%- elif message['role'] == 'assistant' %}
+        {{- '<|start_header_id|>assistant<|end_header_id|>\\n\\n' -}}
+        {%- generation %}{{ message['content'] }}{%- endgeneration %}
+        {{- '<|eot_id|>' }}
+    {%- elif message['role'] == 'tool' %}
+        {{- '<|start_header_id|>ipython<|end_header_id|>\\n\\n' + (message['content'] | tojson) + '<|eot_id|>' }}
+    {%- else %}
+        {{- '<|start_header_id|>' + message['role'] + '<|end_header_id|>\\n\\n' + message['content'] + '<|eot_id|>' }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|start_header_id|>assistant<|end_header_id|>\\n\\n' }}
+{%- endif %}"""
 
 _WEATHER_TOOLS = [
     {
@@ -782,23 +805,12 @@ _PARITY_CASES = [
         id="alt-chat-template-kwargs",
     ),
     pytest.param(HF_BOUNDARY_MERGE_TEMPLATE, _ADVERSARIAL_CONV, {}, id="boundary-merge-crosses-generation"),
+    pytest.param(LLAMA3_STYLE_TEMPLATE, _LLAMA3_TOOL_CONV, {"tools": _WEATHER_TOOLS}, id="llama3-style-with-tools"),
     pytest.param(
-        LLAMA3_TRAINABLE_TEMPLATE,
-        _LLAMA3_TOOL_CONV,
-        {"tools": _WEATHER_TOOLS},
-        id="llama3-trainable-with-tools",
-        marks=pytest.mark.skipif(
-            LLAMA3_TRAINABLE_TEMPLATE is None, reason="experiments/llama.py not present in this checkout"
-        ),
-    ),
-    pytest.param(
-        LLAMA3_TRAINABLE_TEMPLATE,
+        LLAMA3_STYLE_TEMPLATE,
         _WITH_SYSTEM + [{"role": "user", "content": "Bye"}, {"role": "assistant", "content": "Goodbye."}],
         {},
-        id="llama3-trainable-plain",
-        marks=pytest.mark.skipif(
-            LLAMA3_TRAINABLE_TEMPLATE is None, reason="experiments/llama.py not present in this checkout"
-        ),
+        id="llama3-style-plain",
     ),
 ]
 

--- a/lib/levanter/tests/test_text_chat.py
+++ b/lib/levanter/tests/test_text_chat.py
@@ -720,6 +720,26 @@ LLAMA3_STYLE_TEMPLATE = """{{- bos_token }}
     {{- '<|start_header_id|>assistant<|end_header_id|>\\n\\n' }}
 {%- endif %}"""
 
+# Serializes the `tools` list, forcing canonical key order with `tojson(sort_keys=True)`
+# when the `sort_tools` kwarg is set. Both HF's tojson filter and Levanter's accept the
+# sort_keys flag, so the canonical rendering must agree byte-for-byte — this is the
+# escape hatch a deployment uses for prefix-cache-stable prompts, and it must stay a
+# template choice rather than a hardcoded renderer policy.
+HF_SORT_KEYS_TEMPLATE = """\
+<|start_header_id|>system<|end_header_id|>
+{% for tool in tools %}{% if sort_tools %}{{ tool | tojson(sort_keys=True) }}{% else %}{{ tool | tojson }}{% endif %}
+{% endfor %}<|eot_id|>
+{%- for message in messages -%}
+{%- if message['role'] == 'assistant' -%}
+<|start_header_id|>assistant<|end_header_id|>
+{% generation %}{{ message['content'] }}{% endgeneration %}<|eot_id|>
+{%- else -%}
+<|start_header_id|>{{ message['role'] }}<|end_header_id|>
+{{ message['content'] }}<|eot_id|>
+{%- endif -%}
+{%- endfor -%}
+"""
+
 _WEATHER_TOOLS = [
     {
         "type": "function",
@@ -852,3 +872,52 @@ def test_chat_template_matches_hf(tokenizer: MarinTokenizer, hf_tokenizer, templ
     # A template with an assistant turn must charge at least one assistant token,
     # otherwise "masks match" could hold vacuously on two all-zero masks.
     assert sum(lev_mask) > 0
+
+
+def test_tojson_sort_keys_flag_matches_hf(tokenizer: MarinTokenizer, hf_tokenizer):
+    """An explicit `tojson(sort_keys=True)` in a template canonicalizes JSON key order,
+    identically in Levanter and HF.
+
+    The renderer must honor the template's sort choice rather than hardcode one: the
+    default (insertion order) keeps parity with the base model's native tool format,
+    while `sort_keys=True` is the opt-in a deployment uses for prefix-cache-stable
+    prompts. The tool keys here are in insertion order (`type` before `function`), which
+    is not alphabetical, so sorting must change the output — asserted below so the parity
+    check is not vacuously satisfied by both engines ignoring the flag.
+    """
+    conversation = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
+
+    def lev_render(sort_tools: bool) -> str:
+        return tokenizer.with_chat_template(HF_SORT_KEYS_TEMPLATE).apply_chat_template(
+            conversation, tokenize=False, tools=_WEATHER_TOOLS, sort_tools=sort_tools
+        )
+
+    sorted_rendered = lev_render(sort_tools=True)
+    assert sorted_rendered != lev_render(sort_tools=False), "sort_keys=True must reorder non-alphabetical keys"
+
+    lev = tokenizer.apply_chat_template_with_masks(
+        [conversation], chat_template=HF_SORT_KEYS_TEMPLATE, tools=_WEATHER_TOOLS, sort_tools=True
+    )
+    hf_out = hf_tokenizer.apply_chat_template(
+        conversation,
+        chat_template=HF_SORT_KEYS_TEMPLATE,
+        tools=_WEATHER_TOOLS,
+        sort_tools=True,
+        tokenize=True,
+        return_dict=True,
+        return_assistant_tokens_mask=True,
+        add_generation_prompt=False,
+    )
+    hf_rendered = hf_tokenizer.apply_chat_template(
+        conversation,
+        chat_template=HF_SORT_KEYS_TEMPLATE,
+        tools=_WEATHER_TOOLS,
+        sort_tools=True,
+        tokenize=False,
+        add_generation_prompt=False,
+    )
+
+    assert sorted_rendered == hf_rendered
+    assert lev["input_ids"][0] == list(hf_out["input_ids"])
+    assert lev["assistant_masks"][0] == list(hf_out["assistant_masks"])
+    assert sum(lev["assistant_masks"][0]) > 0


### PR DESCRIPTION
Levanter reimplements apply_chat_template(..., return_assistant_tokens_mask=True) without transformers, and nothing pinned it against real HF — existing tests used Levanter's own output as ground truth. Testing the reimplementation against the HF tokenizer as an independent oracle surfaced two divergences that reach input_ids, which is what inference and serving actually see:

- The jinja `tojson` filter defaulted to sort_keys=True (and HTML-escaping), so tool schemas and tool-call arguments serialized with reordered keys versus HF's insertion order. Override the filter to match HF (sort_keys=False, ensure_ascii=False) and add the loopcontrols extension HF enables.
- Assistant masking tokenized each generation segment independently, so a BPE merge spanning a generation boundary produced different token ids than HF. Render with sentinels, strip them to recover HF's exact rendered string plus generation char spans, tokenize the full string once, and derive masks (and message spans) from the encoding's char_to_token map, exactly as transformers does.

After both fixes the renderer matches HF byte-for-byte on rendered string, input_ids, and assistant_masks across chat, tool-call, tool-response, system, and per-example chat_template_kwargs fixtures, including the trainable llama3 template. An adversarial template whose generation block abuts ordinary text locks in the tokenize-once behavior.

Adds packing/masking regressions driven end-to-end from a real ChatDataset: no cross-segment attention leak (vanilla/jax_flash/default/splash plus the grug reference kernel), the loss weight charges exactly the shifted generation spans with zero loss on padding, and a packed document's per-token loss matches the unpacked document. Position ids are absolute today (they do not reset per document), so the packed-vs-unpacked check covers the position-aligned leading document; full multi-document equivalence follows once a pad-per-document packing path preserves per-document positions.

Part of #7045
Part of #7087