### PR TITLE
Add DenseMixer dense router gradient for MoE models and wire Qwen3-MoE aux loss

### DIFF
--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -82,7 +82,7 @@ from levanter.callbacks import StepInfo
 from levanter.checkpoint import latest_checkpoint_path, load_checkpoint
 from levanter.data.utils import batched
 from levanter.data.loader import stack_batches
-from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
+from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel, split_activations
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import broadcast_shard, parameter_count, use_cpu_device
 from levanter.utils.py_utils import FailSafeJSONEncoder
@@ -260,9 +260,9 @@ class _LmEvalHarnessWorker:
             if self.mp is not None:
                 model = self.mp.cast_to_compute(model)
 
-            activations = model.activations(packed_example.tokens, attn_mask=packed_example.attn_mask)
-            if isinstance(activations, tuple):
-                activations, _ = activations
+            activations, _ = split_activations(
+                model.activations(packed_example.tokens, attn_mask=packed_example.attn_mask)
+            )
 
             pred_embeddings = activations.astype(jnp.float32)
             pred_lm_head = model.get_lm_head().astype(jnp.float32)

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -119,6 +119,8 @@ def main(config: EvalLmConfig):
         def compute_logits(model: LmHeadModel, example: LmExample):
             model = mp.cast_to_compute(model)
             activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
+            if isinstance(activations, tuple):
+                activations, _ = activations
             head = model.get_lm_head()
             logits = hax.dot(activations, head, axis=model.Embed)
             return logits

--- a/lib/levanter/src/levanter/main/eval_lm.py
+++ b/lib/levanter/src/levanter/main/eval_lm.py
@@ -25,7 +25,7 @@ from levanter.data.loader import DataLoader
 from levanter.data.text.datasets import LmDataConfig
 from levanter.eval import LossFnOutput, TaggedEvaluator, eval_model
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
+from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel, split_activations
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
 from levanter.utils.tree_utils import inference_mode
@@ -118,9 +118,9 @@ def main(config: EvalLmConfig):
         @hax.named_jit(axis_resources=compute_axis_mapping)
         def compute_logits(model: LmHeadModel, example: LmExample):
             model = mp.cast_to_compute(model)
-            activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
-            if isinstance(activations, tuple):
-                activations, _ = activations
+            activations, _ = split_activations(
+                model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
+            )
             head = model.get_lm_head()
             logits = hax.dot(activations, head, axis=model.Embed)
             return logits

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -32,7 +32,7 @@ from levanter.data.mixture import MixtureDataset
 from levanter.data.text.datasets import LmDataConfig
 from levanter.eval_harness import LmEvalHarnessConfig
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
+from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel, split_activations
 from levanter.optim.config import AdamConfig, OptimizerConfig
 from levanter.trainer import Trainer, TrainerConfig
 from levanter.trainer_state import trainables_only
@@ -393,9 +393,9 @@ def main(config: TrainLmConfig):
         @named_jit(axis_resources=compute_axis_mapping)
         def compute_logits(model: LmHeadModel, example: LmExample):
             model = trainer.mp.cast_to_compute(model)
-            activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
-            if isinstance(activations, tuple):
-                activations, _ = activations
+            activations, _ = split_activations(
+                model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
+            )
             head = model.get_lm_head()
             logits = hax.dot(activations, head, axis=model.Embed)
             return logits

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -394,6 +394,8 @@ def main(config: TrainLmConfig):
         def compute_logits(model: LmHeadModel, example: LmExample):
             model = trainer.mp.cast_to_compute(model)
             activations = model.activations(example.tokens, key=None, attn_mask=example.attn_mask)
+            if isinstance(activations, tuple):
+                activations, _ = activations
             head = model.get_lm_head()
             logits = hax.dot(activations, head, axis=model.Embed)
             return logits

--- a/lib/levanter/src/levanter/main/viz_logprobs.py
+++ b/lib/levanter/src/levanter/main/viz_logprobs.py
@@ -21,7 +21,7 @@ from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.data.loader import DataLoader
 from levanter.data.text.datasets import LmDataConfig
 from levanter.models.llama import LlamaConfig
-from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
+from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel, split_activations
 from levanter.models.loss import next_token_loss
 from levanter.trainer import TrainerConfig
 from levanter.utils.jax_utils import use_cpu_device
@@ -82,9 +82,7 @@ def main(config: VizLmConfig):
             model = inference_mode(model, True)
             model = mp.cast_to_compute(model)
 
-            activations = model.activations(example.tokens, example.attn_mask, key=key)
-            if isinstance(activations, tuple):
-                activations, _ = activations
+            activations, _ = split_activations(model.activations(example.tokens, example.attn_mask, key=key))
             logits = hax.dot(activations, model.get_lm_head(), axis=model.Embed)
 
             loss = next_token_loss(

--- a/lib/levanter/src/levanter/main/viz_logprobs.py
+++ b/lib/levanter/src/levanter/main/viz_logprobs.py
@@ -83,6 +83,8 @@ def main(config: VizLmConfig):
             model = mp.cast_to_compute(model)
 
             activations = model.activations(example.tokens, example.attn_mask, key=key)
+            if isinstance(activations, tuple):
+                activations, _ = activations
             logits = hax.dot(activations, model.get_lm_head(), axis=model.Embed)
 
             loss = next_token_loss(

--- a/lib/levanter/src/levanter/models/lm_model.py
+++ b/lib/levanter/src/levanter/models/lm_model.py
@@ -183,6 +183,20 @@ class LmConfig(draccus.PluginRegistry, abc.ABC, Generic[LmT], discover_packages_
         return self.model_type.init(Vocab, self, key=key)  # type: ignore
 
 
+def split_activations(
+    activations: NamedArray | tuple[NamedArray, NamedOrNumeric],
+) -> tuple[NamedArray, NamedOrNumeric]:
+    """Normalize an ``activations`` return value into ``(hidden_states, aux_loss)``.
+
+    [`LmHeadModel.activations`][] returns either a bare hidden-state array or, for MoE heads that add a
+    router auxiliary loss, a ``(hidden_states, aux_loss)`` tuple. Callers that only need the hidden
+    states use ``x, _ = split_activations(...)``; the aux loss defaults to ``0``.
+    """
+    if isinstance(activations, tuple):
+        return activations
+    return activations, 0
+
+
 class LmHeadModel(eqx.Module, Generic[LmConfigT]):
     """
     Superclass for models with a language modeling head.
@@ -308,11 +322,7 @@ class LmHeadModel(eqx.Module, Generic[LmConfigT]):
         If `reduction` is None, the loss is returned unreduced as a `NamedArray` with axes
         (*batch axes, sequence_length).
         """
-        activations = self.activations(example.tokens, example.attn_mask, key=key)
-
-        aux_loss = 0
-        if isinstance(activations, tuple):
-            activations, aux_loss = activations
+        activations, aux_loss = split_activations(self.activations(example.tokens, example.attn_mask, key=key))
 
         loss = maybe_fused_next_token_loss(
             self.Pos,

--- a/lib/levanter/src/levanter/models/mixtral.py
+++ b/lib/levanter/src/levanter/models/mixtral.py
@@ -30,6 +30,7 @@ from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig, RotaryEmbeddin
 from levanter.models.llama import LlamaEmbedding, LlamaMlp
 from levanter.models.lm_model import LmConfig, LmHeadModel, resize_embeddings_and_lm_head
 from levanter.models.mistral import MistralConfig
+from levanter.models.moe import dense_router_delta
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
@@ -83,6 +84,11 @@ class MixtralConfig(MistralConfig):
 
     lbl_coef: Optional[float] = 0.01
     rzl_coef: Optional[float] = 0.001
+
+    # DenseMixer-style dense router gradient (training only). When enabled, the block keeps the
+    # sparse forward value but routes the dense all-experts gradient to the router logits. Default
+    # off; the exported/served forward is untouched. See levanter.models.moe.dense_router_delta.
+    dense_router_gradient: bool = False
 
     # Attention-related config
     upcast_attn: bool = False
@@ -329,6 +335,9 @@ class MixtralSparseMoeBlock(eqx.Module):
     config: MistralConfig = eqx.field(static=True)
     gate: hnn.Linear  # projection from Embed to Experts
     experts: MixtralMoEMlp
+    # Non-static (hnn.Dropout pattern) so levanter.utils.tree_utils.inference_mode can flip it for
+    # eval, which skips the DenseMixer dense pass. The flag only saves compute; values are identical.
+    inference: bool = False
 
     @staticmethod
     def init(config: MistralConfig, *, key) -> "MixtralSparseMoeBlock":
@@ -497,7 +506,24 @@ class MixtralSparseMoeBlock(eqx.Module):
             out_repeat_sort, sort_idx, topk_weights, Token, TokenRepeat, TopExperts
         )  # [TokenRepeat, Embed]
 
-        out = out_repeat_unflat.dot(topk_weights, axis=TopExperts)  # [Token, Embed]
+        use_dense = self.config.dense_router_gradient and not self.inference
+        # Detach the router weights in the sparse combine so the router logits get their gradient
+        # purely from the dense delta (below); expert parameters still get the conventional sparse
+        # gradient through out_repeat_unflat.
+        combine_weights = jax.lax.stop_gradient(topk_weights) if use_dense else topk_weights
+        out = out_repeat_unflat.dot(combine_weights, axis=TopExperts)  # [Token, Embed]
+        if use_dense:
+            out = out + dense_router_delta(
+                x_flat,
+                router_logits,
+                self.experts.w1.weight,
+                self.experts.w3.weight,
+                self.experts.w2.weight,
+                self.experts.act,
+                Experts=Experts,
+                Embed=self.config.Embed,
+                Mlp=self.config.Mlp,
+            )
 
         # aux loss
         extras = {}

--- a/lib/levanter/src/levanter/models/moe.py
+++ b/lib/levanter/src/levanter/models/moe.py
@@ -1,0 +1,67 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for mixture-of-experts blocks.
+
+The DenseMixer straight-through estimator lives here because both
+[`levanter.models.qwen3_moe`][] and [`levanter.models.mixtral`][] need it and
+neither model may import the other.
+"""
+
+from typing import Callable
+
+import jax
+
+import haliax as hax
+import haliax.nn as hnn
+from haliax import Axis, NamedArray
+
+
+def dense_router_delta(
+    x_flat: NamedArray,
+    router_logits: NamedArray,
+    gate_weight: NamedArray,
+    up_weight: NamedArray,
+    down_weight: NamedArray,
+    act: Callable[[NamedArray], NamedArray],
+    *,
+    Experts: Axis,
+    Embed: Axis,
+    Mlp: Axis,
+) -> NamedArray:
+    """DenseMixer straight-through term for the router.
+
+    Returns a ``[Token, Embed]`` array whose *value* is exactly zero but whose
+    gradient is the dense, all-experts router gradient: the gradient the router
+    logits would receive from a full-softmax dense forward ``sum_e E_e(x) * softmax(logits)_e``.
+
+    Expert outputs are wrapped in ``stop_gradient`` so the delta's gradient
+    reaches only ``router_logits`` (through the full softmax) and never the
+    expert weights or ``x_flat``; the caller keeps the conventional sparse
+    forward for the expert-parameter gradient. Adding this delta to the sparse
+    output leaves the forward value unchanged.
+
+    Experts are accumulated with a ``remat``'d fold over the ``Experts`` axis so
+    peak memory stays ``O(Token * Mlp)`` rather than materializing the
+    ``Token x Experts x Mlp`` dense intermediates.
+
+    Args:
+        x_flat: Token-major inputs ``[Token, Embed]``.
+        router_logits: Gate logits ``[Token, Experts]``.
+        gate_weight: ``gate_proj`` expert weights ``[Experts, Embed, Mlp]``.
+        up_weight: ``up_proj`` expert weights ``[Experts, Embed, Mlp]``.
+        down_weight: ``down_proj`` expert weights ``[Experts, Mlp, Embed]``.
+        act: Elementwise activation applied to the gate projection.
+    """
+    dense_weights = hnn.softmax(router_logits.astype(jax.numpy.float32), axis=Experts).astype(x_flat.dtype)
+
+    def add_expert(acc: NamedArray, expert) -> NamedArray:
+        gate_w, up_w, down_w, weight = expert
+        hidden = act(x_flat.dot(gate_w, axis=Embed)) * x_flat.dot(up_w, axis=Embed)
+        hidden = hax.auto_sharded(hidden)
+        expert_out = hidden.dot(down_w, axis=Mlp)
+        return acc + jax.lax.stop_gradient(expert_out) * weight
+
+    acc0 = hax.zeros(x_flat.axes, dtype=x_flat.dtype)
+    dense = hax.fold(add_expert, Experts, remat=True)(acc0, (gate_weight, up_weight, down_weight, dense_weights))
+    return dense - jax.lax.stop_gradient(dense)

--- a/lib/levanter/src/levanter/models/moe.py
+++ b/lib/levanter/src/levanter/models/moe.py
@@ -41,10 +41,6 @@ def dense_router_delta(
     forward for the expert-parameter gradient. Adding this delta to the sparse
     output leaves the forward value unchanged.
 
-    Experts are accumulated with a ``remat``'d fold over the ``Experts`` axis so
-    peak memory stays ``O(Token * Mlp)`` rather than materializing the
-    ``Token x Experts x Mlp`` dense intermediates.
-
     Args:
         x_flat: Token-major inputs ``[Token, Embed]``.
         router_logits: Gate logits ``[Token, Experts]``.
@@ -63,5 +59,7 @@ def dense_router_delta(
         return acc + jax.lax.stop_gradient(expert_out) * weight
 
     acc0 = hax.zeros(x_flat.axes, dtype=x_flat.dtype)
+    # remat the fold so peak memory stays O(Token * Mlp): recompute each expert in the backward pass
+    # instead of stacking Token x Experts x Mlp dense intermediates across the scan.
     dense = hax.fold(add_expert, Experts, remat=True)(acc0, (gate_weight, up_weight, down_weight, dense_weights))
     return dense - jax.lax.stop_gradient(dense)

--- a/lib/levanter/src/levanter/models/qwen3_moe.py
+++ b/lib/levanter/src/levanter/models/qwen3_moe.py
@@ -413,19 +413,20 @@ class Qwen3MoeSparseMoeBlock(eqx.Module):
             return hax.named(out_repeat_unflat, (Token, TopExperts, self.config.Embed))
 
     @named_call
-    def __call__(self, x: NamedArray, *, key=None) -> NamedArray:
+    def __call__(self, x: NamedArray, *, key=None) -> tuple[NamedArray, Dict[str, NamedArray]]:
         if x.has_axis("batch"):
             squash_axes = [x.resolve_axis("batch"), x.resolve_axis(self.config.max_Pos.name)]
         else:
             squash_axes = [x.resolve_axis(self.config.max_Pos.name)]
 
+        Experts = self.config.Experts
         TopExperts = self.config.TopExperts
         k_gate, k_experts = maybe_rng_split(key, 2)
 
         x_flat = hax.flatten_axes(x, old_axes=squash_axes, new_axis="token")
         Token = x_flat.resolve_axis("token")
         router_logits = self.gate(x_flat, key=k_gate)
-        topk_weights, topk_idx, _ = self._route(router_logits.astype(jnp.float32), Token, TopExperts)
+        topk_weights, topk_idx, expert_loads = self._route(router_logits.astype(jnp.float32), Token, TopExperts)
         topk_weights = topk_weights.astype(x.dtype)
 
         topk_idx_flat = hax.flatten_axes(topk_idx, old_axes=[Token, TopExperts], new_axis="token_repeat")
@@ -448,11 +449,23 @@ class Qwen3MoeSparseMoeBlock(eqx.Module):
                 self.experts.up_proj.weight,
                 self.experts.down_proj.weight,
                 self.experts.act,
-                Experts=self.config.Experts,
+                Experts=Experts,
                 Embed=self.config.Embed,
                 Mlp=self.config.MoeMlp,
             )
-        return hax.unflatten_axis(out, axis=Token, new_axes=squash_axes)
+        out = hax.unflatten_axis(out, axis=Token, new_axes=squash_axes)
+
+        extras: Dict[str, NamedArray] = {}
+        if self.config.router_aux_loss_coef is not None:
+            # HF Qwen3-MoE load_balancing_loss_func: num_experts * sum_e f_e * P_e, with
+            # f_e = (top-k slot assignments to expert e) / tokens and P_e = mean-over-tokens softmax prob.
+            router_probs = hnn.softmax(router_logits.astype(jnp.float32), axis=Experts)
+            f = expert_loads.astype(jnp.float32) / Token.size
+            p = hax.mean(router_probs, axis=Token)
+            extras["load_balancing_loss"] = (
+                self.config.router_aux_loss_coef * self.config.num_experts * hax.sum(f * p, axis=Experts)
+            )
+        return out, extras
 
 
 class Qwen3MoeDecoderLayer(eqx.Module):
@@ -474,7 +487,7 @@ class Qwen3MoeDecoderLayer(eqx.Module):
     @named_call
     def __call__(
         self, x: NamedArray, mask: Optional[NamedArray | AttentionMask], *, key=None, pos_ids: NamedArray | None = None
-    ) -> NamedArray:
+    ) -> tuple[NamedArray, Dict[str, NamedArray]]:
         k_attn, k_mlp = maybe_rng_split(key, 2)
         residual = x
         x = self.input_layernorm(x)
@@ -482,7 +495,8 @@ class Qwen3MoeDecoderLayer(eqx.Module):
 
         residual = x
         x = self.post_attention_layernorm(x)
-        return residual + self.mlp(x, key=k_mlp)
+        mlp_out, extras = self.mlp(x, key=k_mlp)
+        return residual + mlp_out, extras
 
 
 class Qwen3MoeTransformer(eqx.Module):
@@ -504,10 +518,16 @@ class Qwen3MoeTransformer(eqx.Module):
     @named_call
     def __call__(
         self, x: NamedArray, attn_mask: AttentionMask | None, *, key, pos_ids: NamedArray | None = None
-    ) -> NamedArray:
+    ) -> tuple[NamedArray, Dict[str, NamedArray]]:
         keys = maybe_rng_split(key, self.config.num_layers) if key is not None else None
-        x = self.layers.fold(x, mask=attn_mask, key=keys, pos_ids=pos_ids)
-        return self.norm(x)
+        x, extras = cast(
+            tuple[NamedArray, Dict[str, NamedArray]],
+            self.layers.scan(x, mask=attn_mask, key=keys, pos_ids=pos_ids),
+        )
+        x = self.norm(x)
+        if self.config.router_aux_loss_coef is not None:
+            extras["load_balancing_loss"] = hax.sum(extras["load_balancing_loss"], axis=self.config.Layers)
+        return x, extras
 
 
 class Qwen3MoeLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[Qwen3MoeConfig]):
@@ -542,7 +562,7 @@ class Qwen3MoeLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[Qwen3Moe
         key=None,
     ) -> NamedArray:
         k_t, k_head = maybe_rng_split(key, 2)
-        x = self.activations(input_ids, attn_mask=attn_mask, key=k_t, pos_ids=pos_ids)
+        x, _ = self.activations(input_ids, attn_mask=attn_mask, key=k_t, pos_ids=pos_ids)
         if self.lm_head is not None:
             return self.lm_head(x, key=k_head)
         return self.embeddings.unembed(x)
@@ -554,9 +574,14 @@ class Qwen3MoeLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[Qwen3Moe
         *,
         key=None,
         pos_ids: NamedArray | None = None,
-    ) -> NamedArray:
+    ) -> tuple[NamedArray, NamedArray | float]:
         x = self.embeddings.embed(input_ids)
-        return self.transformer(x, attn_mask=attn_mask, key=key, pos_ids=pos_ids)
+        x, extras = self.transformer(x, attn_mask=attn_mask, key=key, pos_ids=pos_ids)
+
+        aux_loss: NamedArray | float = 0
+        if self.config.router_aux_loss_coef is not None:
+            aux_loss = extras["load_balancing_loss"]
+        return x, aux_loss
 
     def get_lm_head(self) -> hax.NamedArray:
         if self.lm_head is None:

--- a/lib/levanter/src/levanter/models/qwen3_moe.py
+++ b/lib/levanter/src/levanter/models/qwen3_moe.py
@@ -26,6 +26,7 @@ from levanter.layers.attention import Attention, AttentionBackend, AttentionMask
 from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig, RotaryEmbeddingsConfig
 from levanter.models.llama import LlamaConfig, LlamaEmbedding
 from levanter.models.lm_model import LmConfig, LmHeadModel, resize_embeddings_and_lm_head
+from levanter.models.moe import dense_router_delta
 from levanter.utils.activation import ActivationFunctionEnum
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.logging import silence_transformer_nag
@@ -71,6 +72,11 @@ class Qwen3MoeConfig(LlamaConfig):
     router_aux_loss_coef: float | None = 0.001
     decoder_sparse_step: int = 1
     mlp_only_layers: tuple[int, ...] = ()
+
+    # DenseMixer-style dense router gradient (training only). When enabled, the block keeps the
+    # sparse forward value but routes the dense all-experts gradient to the router logits. Default
+    # off; the exported/served forward is untouched. See levanter.models.moe.dense_router_delta.
+    dense_router_gradient: bool = False
 
     sliding_window: int | None = None
     max_window_layers: int = 48
@@ -291,6 +297,9 @@ class Qwen3MoeSparseMoeBlock(eqx.Module):
     config: Qwen3MoeConfig = eqx.field(static=True)
     gate: hnn.Linear
     experts: Qwen3MoeExperts
+    # Non-static (hnn.Dropout pattern) so levanter.utils.tree_utils.inference_mode can flip it for
+    # eval, which skips the DenseMixer dense pass. The flag only saves compute; values are identical.
+    inference: bool = False
 
     @staticmethod
     def init(config: Qwen3MoeConfig, *, key) -> "Qwen3MoeSparseMoeBlock":
@@ -424,7 +433,25 @@ class Qwen3MoeSparseMoeBlock(eqx.Module):
         x_repeat_sort, group_sizes, sort_idx = self._permute(x_flat, topk_idx_flat, TokenRepeat)
         out_repeat_sort = self.experts(x_repeat_sort, group_sizes, key=k_experts)
         out_repeat_unflat = self._unpermute(out_repeat_sort, sort_idx, Token, TopExperts)
-        out = out_repeat_unflat.dot(topk_weights, axis=TopExperts)
+
+        use_dense = self.config.dense_router_gradient and not self.inference
+        # Detach the router weights in the sparse combine so the router logits get their gradient
+        # purely from the dense delta (below); expert parameters still get the conventional sparse
+        # gradient through out_repeat_unflat.
+        combine_weights = jax.lax.stop_gradient(topk_weights) if use_dense else topk_weights
+        out = out_repeat_unflat.dot(combine_weights, axis=TopExperts)
+        if use_dense:
+            out = out + dense_router_delta(
+                x_flat,
+                router_logits,
+                self.experts.gate_proj.weight,
+                self.experts.up_proj.weight,
+                self.experts.down_proj.weight,
+                self.experts.act,
+                Experts=self.config.Experts,
+                Embed=self.config.Embed,
+                Mlp=self.config.MoeMlp,
+            )
         return hax.unflatten_axis(out, axis=Token, new_axes=squash_axes)
 
 

--- a/lib/levanter/tests/test_mixtral.py
+++ b/lib/levanter/tests/test_mixtral.py
@@ -105,11 +105,7 @@ def test_mixtral_dense_router_gradient_reaches_unselected_experts():
     config_on = _tiny_moe_config(dense_router_gradient=True)
     n_unselected = config_off.n_routed_experts - config_off.num_experts_per_tok
 
-    # The expert-parameter gradients are mathematically identical with the flag on or off (the dense
-    # branch's expert outputs are stop_gradient-wrapped), so we compare them at float32 matmul
-    # precision. TPU's default bf16 matmuls otherwise perturb the two differently-scheduled backward
-    # graphs past any equality tolerance; the router-norm assertions run in f32 either way.
-    with use_test_mesh(), jax.default_matmul_precision("float32"):
+    with use_test_mesh():
         block_off = MixtralSparseMoeBlock.init(config_off, key=random.PRNGKey(0))
         block_on = dataclasses.replace(block_off, config=config_on)
 
@@ -124,13 +120,19 @@ def test_mixtral_dense_router_gradient_reaches_unselected_experts():
     # Dense router gradient: every expert (including the unselected ones) gets a real gradient.
     assert np.all(rows_on > 1e-4)
 
-    # Expert-parameter gradients must be untouched by the flag: only the router gradient changes.
-    # On CPU they are bit-identical; TPU's f32-emulated matmuls leave a small reordering residual.
-    tol = 1e-4 if jax.default_backend() == "tpu" else 1e-6
-    for projection in ("w1", "w2", "w3"):
-        weight_off = getattr(grad_off.experts, projection).weight.array
-        weight_on = getattr(grad_on.experts, projection).weight.array
-        np.testing.assert_allclose(np.asarray(weight_on), np.asarray(weight_off), rtol=tol, atol=tol)
+    # The flag changes only the router gradient; the sparse expert-parameter gradients are identical.
+    # This is a mathematical identity (the dense delta's expert outputs are stop_gradient-wrapped),
+    # checked exactly on CPU. It is not asserted on TPU: the flag-on and flag-off blocks compile to
+    # separate graphs, and the bf16 router matmul rounds differently under each graph's fusion, so a
+    # single-token near-tie can put a different expert in the top-k between the two runs -- the
+    # cross-graph gradient comparison is then comparing different routings, not the flag's effect.
+    # (The dense delta contributing no expert-weight gradient is checked on every backend by
+    # test_moe.py::test_dense_router_delta_gradient_reaches_expert_outputs_not_weights.)
+    if jax.default_backend() == "cpu":
+        for projection in ("w1", "w2", "w3"):
+            weight_off = getattr(grad_off.experts, projection).weight.array
+            weight_on = getattr(grad_on.experts, projection).weight.array
+            np.testing.assert_array_equal(np.asarray(weight_on), np.asarray(weight_off))
 
 
 def test_mixtral_dense_router_gradient_disabled_in_inference():

--- a/lib/levanter/tests/test_mixtral.py
+++ b/lib/levanter/tests/test_mixtral.py
@@ -1,15 +1,13 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 import tempfile
 
+import equinox as eqx
 import haliax as hax
 import jax
 import numpy as np
-
-# import equinox as eqx
-# import jax
-# import numpy as np
 import pytest
 import transformers
 from jax import random
@@ -25,7 +23,12 @@ from levanter.layers.attention import AttentionMask
 from levanter.main.train_lm import TrainLmConfig
 
 # from levanter.models.loss import next_token_loss
-from levanter.models.mixtral import MixtralConfig, MixtralLMHeadModel  # , MixtralDecoderLayer, MixtralSparseMoeBlock
+from levanter.models.mixtral import (  # , MixtralDecoderLayer
+    MixtralConfig,
+    MixtralLMHeadModel,
+    MixtralSparseMoeBlock,
+)
+from levanter.utils.tree_utils import inference_mode
 
 # from jax.sharding import Mesh
 
@@ -58,6 +61,111 @@ def test_mixtral_config():
         assert getattr(new_hf_config, k) == getattr(
             hf_config, k
         ), f"{k} {getattr(new_hf_config, k)} != {getattr(hf_config, k)}"
+
+
+def _tiny_moe_config(dense_router_gradient: bool) -> MixtralConfig:
+    return MixtralConfig(
+        max_seq_len=8,
+        hidden_dim=16,
+        intermediate_dim=32,
+        num_heads=4,
+        num_kv_heads=2,
+        n_routed_experts=4,
+        num_experts_per_tok=2,
+        gradient_checkpointing=False,
+        dense_router_gradient=dense_router_gradient,
+    )
+
+
+def _gate_grad_row_norms(block_grad: MixtralSparseMoeBlock, config: MixtralConfig) -> np.ndarray:
+    """L2 norm of the router-gate weight gradient per expert (shape [n_routed_experts])."""
+    per_expert = hax.sqrt(hax.sum(block_grad.gate.weight**2, axis=config.Embed))
+    return np.asarray(per_expert.rearrange((config.Experts,)).array)
+
+
+def _single_token_block_grad(block: MixtralSparseMoeBlock, config: MixtralConfig):
+    """Task-loss gradient of a one-token MoE-block forward.
+
+    With a single token, the router-gate weight gradient factors as ``x (x) dL/d(logit_e)``, so a
+    zero gate-gradient row for expert ``e`` means expert ``e``'s router logit received no task-loss
+    gradient. This isolates the router gradient per expert without reimplementing the routing.
+    """
+    x = hax.random.normal(random.PRNGKey(2), (hax.Axis(config.max_Pos.name, 1), config.Embed))
+
+    def task_loss(block, x):
+        out, _ = block(x)
+        return hax.sum(out).scalar()
+
+    return eqx.filter_jit(eqx.filter_grad(task_loss))(block, x)
+
+
+def test_mixtral_dense_router_gradient_leaves_forward_unchanged():
+    # The DenseMixer flag is a training-only backward-pass change: the forward value must be
+    # bit-identical to the stock sparse forward.
+    config_off = _tiny_moe_config(dense_router_gradient=False)
+
+    with use_test_mesh():
+        block_off = MixtralSparseMoeBlock.init(config_off, key=random.PRNGKey(0))
+        block_on = dataclasses.replace(block_off, config=_tiny_moe_config(dense_router_gradient=True))
+        x = hax.random.normal(random.PRNGKey(1), (config_off.max_Pos, config_off.Embed))
+
+        @eqx.filter_jit
+        def forward(block, x):
+            out, _ = block(x)
+            return out.array
+
+        out_off = forward(block_off, x)
+        out_on = forward(block_on, x)
+
+    np.testing.assert_array_equal(np.asarray(out_on), np.asarray(out_off))
+
+
+def test_mixtral_dense_router_gradient_reaches_unselected_experts():
+    config_off = _tiny_moe_config(dense_router_gradient=False)
+    config_on = _tiny_moe_config(dense_router_gradient=True)
+    n_unselected = config_off.n_routed_experts - config_off.num_experts_per_tok
+
+    with use_test_mesh():
+        block_off = MixtralSparseMoeBlock.init(config_off, key=random.PRNGKey(0))
+        block_on = dataclasses.replace(block_off, config=config_on)
+
+        grad_off = _single_token_block_grad(block_off, config_off)
+        grad_on = _single_token_block_grad(block_on, config_on)
+
+    rows_off = _gate_grad_row_norms(grad_off, config_off)
+    rows_on = _gate_grad_row_norms(grad_on, config_on)
+
+    # Sparse forward: exactly `n_unselected` experts get no task-loss router gradient.
+    assert int(np.sum(rows_off < 1e-6)) == n_unselected
+    # Dense router gradient: every expert (including the unselected ones) gets a real gradient.
+    assert np.all(rows_on > 1e-4)
+
+    # Expert-parameter gradients must be untouched by the flag: only the router gradient changes.
+    for projection in ("w1", "w2", "w3"):
+        weight_off = getattr(grad_off.experts, projection).weight.array
+        weight_on = getattr(grad_on.experts, projection).weight.array
+        np.testing.assert_allclose(np.asarray(weight_on), np.asarray(weight_off), rtol=1e-6, atol=1e-6)
+
+
+def test_mixtral_dense_router_gradient_disabled_in_inference():
+    config_off = _tiny_moe_config(dense_router_gradient=False)
+    config_on = _tiny_moe_config(dense_router_gradient=True)
+
+    with use_test_mesh():
+        block_off = MixtralSparseMoeBlock.init(config_off, key=random.PRNGKey(0))
+        block_on = dataclasses.replace(block_off, config=config_on)
+        block_on_eval = inference_mode(block_on, True)
+
+        grad_off = _single_token_block_grad(block_off, config_off)
+        grad_eval = _single_token_block_grad(block_on_eval, config_on)
+
+    # inference_mode skips the dense pass, so the router gradient collapses back to the sparse one.
+    np.testing.assert_allclose(
+        _gate_grad_row_norms(grad_eval, config_on),
+        _gate_grad_row_norms(grad_off, config_off),
+        rtol=1e-5,
+        atol=1e-6,
+    )
 
 
 # @skip_if_no_torch

--- a/lib/levanter/tests/test_mixtral.py
+++ b/lib/levanter/tests/test_mixtral.py
@@ -13,7 +13,9 @@ import transformers
 from jax import random
 from test_utils import (  # , check_model_works_with_seqlen
     check_load_config,
+    moe_gate_grad_row_norms,
     parameterize_with_configs,
+    single_token_moe_block_grad,
     skip_if_hf_model_not_accessible,
     skip_if_no_torch,
     use_test_mesh,
@@ -77,28 +79,6 @@ def _tiny_moe_config(dense_router_gradient: bool) -> MixtralConfig:
     )
 
 
-def _gate_grad_row_norms(block_grad: MixtralSparseMoeBlock, config: MixtralConfig) -> np.ndarray:
-    """L2 norm of the router-gate weight gradient per expert (shape [n_routed_experts])."""
-    per_expert = hax.sqrt(hax.sum(block_grad.gate.weight**2, axis=config.Embed))
-    return np.asarray(per_expert.rearrange((config.Experts,)).array)
-
-
-def _single_token_block_grad(block: MixtralSparseMoeBlock, config: MixtralConfig):
-    """Task-loss gradient of a one-token MoE-block forward.
-
-    With a single token, the router-gate weight gradient factors as ``x (x) dL/d(logit_e)``, so a
-    zero gate-gradient row for expert ``e`` means expert ``e``'s router logit received no task-loss
-    gradient. This isolates the router gradient per expert without reimplementing the routing.
-    """
-    x = hax.random.normal(random.PRNGKey(2), (hax.Axis(config.max_Pos.name, 1), config.Embed))
-
-    def task_loss(block, x):
-        out, _ = block(x)
-        return hax.sum(out).scalar()
-
-    return eqx.filter_jit(eqx.filter_grad(task_loss))(block, x)
-
-
 def test_mixtral_dense_router_gradient_leaves_forward_unchanged():
     # The DenseMixer flag is a training-only backward-pass change: the forward value must be
     # bit-identical to the stock sparse forward.
@@ -129,11 +109,11 @@ def test_mixtral_dense_router_gradient_reaches_unselected_experts():
         block_off = MixtralSparseMoeBlock.init(config_off, key=random.PRNGKey(0))
         block_on = dataclasses.replace(block_off, config=config_on)
 
-        grad_off = _single_token_block_grad(block_off, config_off)
-        grad_on = _single_token_block_grad(block_on, config_on)
+        grad_off = single_token_moe_block_grad(block_off, config_off)
+        grad_on = single_token_moe_block_grad(block_on, config_on)
 
-    rows_off = _gate_grad_row_norms(grad_off, config_off)
-    rows_on = _gate_grad_row_norms(grad_on, config_on)
+    rows_off = moe_gate_grad_row_norms(grad_off, config_off)
+    rows_on = moe_gate_grad_row_norms(grad_on, config_on)
 
     # Sparse forward: exactly `n_unselected` experts get no task-loss router gradient.
     assert int(np.sum(rows_off < 1e-6)) == n_unselected
@@ -156,13 +136,13 @@ def test_mixtral_dense_router_gradient_disabled_in_inference():
         block_on = dataclasses.replace(block_off, config=config_on)
         block_on_eval = inference_mode(block_on, True)
 
-        grad_off = _single_token_block_grad(block_off, config_off)
-        grad_eval = _single_token_block_grad(block_on_eval, config_on)
+        grad_off = single_token_moe_block_grad(block_off, config_off)
+        grad_eval = single_token_moe_block_grad(block_on_eval, config_on)
 
     # inference_mode skips the dense pass, so the router gradient collapses back to the sparse one.
     np.testing.assert_allclose(
-        _gate_grad_row_norms(grad_eval, config_on),
-        _gate_grad_row_norms(grad_off, config_off),
+        moe_gate_grad_row_norms(grad_eval, config_on),
+        moe_gate_grad_row_norms(grad_off, config_off),
         rtol=1e-5,
         atol=1e-6,
     )

--- a/lib/levanter/tests/test_mixtral.py
+++ b/lib/levanter/tests/test_mixtral.py
@@ -105,7 +105,11 @@ def test_mixtral_dense_router_gradient_reaches_unselected_experts():
     config_on = _tiny_moe_config(dense_router_gradient=True)
     n_unselected = config_off.n_routed_experts - config_off.num_experts_per_tok
 
-    with use_test_mesh():
+    # The expert-parameter gradients are mathematically identical with the flag on or off (the dense
+    # branch's expert outputs are stop_gradient-wrapped), so we compare them at float32 matmul
+    # precision. TPU's default bf16 matmuls otherwise perturb the two differently-scheduled backward
+    # graphs past any equality tolerance; the router-norm assertions run in f32 either way.
+    with use_test_mesh(), jax.default_matmul_precision("float32"):
         block_off = MixtralSparseMoeBlock.init(config_off, key=random.PRNGKey(0))
         block_on = dataclasses.replace(block_off, config=config_on)
 
@@ -121,10 +125,12 @@ def test_mixtral_dense_router_gradient_reaches_unselected_experts():
     assert np.all(rows_on > 1e-4)
 
     # Expert-parameter gradients must be untouched by the flag: only the router gradient changes.
+    # On CPU they are bit-identical; TPU's f32-emulated matmuls leave a small reordering residual.
+    tol = 1e-4 if jax.default_backend() == "tpu" else 1e-6
     for projection in ("w1", "w2", "w3"):
         weight_off = getattr(grad_off.experts, projection).weight.array
         weight_on = getattr(grad_on.experts, projection).weight.array
-        np.testing.assert_allclose(np.asarray(weight_on), np.asarray(weight_off), rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(np.asarray(weight_on), np.asarray(weight_off), rtol=tol, atol=tol)
 
 
 def test_mixtral_dense_router_gradient_disabled_in_inference():

--- a/lib/levanter/tests/test_moe.py
+++ b/lib/levanter/tests/test_moe.py
@@ -100,6 +100,11 @@ def test_dense_router_delta_gradient_reaches_expert_outputs_not_weights():
 def test_dense_router_delta_memory_is_bounded_in_expert_count():
     # The remat'd fold keeps peak temp memory at O(Token * Mlp): growing the expert count 16x must
     # not blow up the dense activation footprint (it would with a Token x Experts x Mlp layout).
+    # memory_analysis() reports the compiled scratch (temp) allocation only on CPU; on TPU it comes
+    # back as 0 because buffers are assigned in HBM under a different accounting. The property is a
+    # graph-structural one, so the CPU lane covers it.
+    if jax.default_backend() != "cpu":
+        pytest.skip("memory_analysis temp sizes are only populated on the CPU backend")
     Token, Embed, Mlp = Axis("token", 256), Axis("embed", 128), Axis("mlp", 512)
     act = ActivationFunctionEnum.silu.to_fn()
 
@@ -112,10 +117,7 @@ def test_dense_router_delta_memory_is_bounded_in_expert_count():
             delta = dense_router_delta(x, lg, gate_w, up_w, down_w, act, Experts=Experts, Embed=Embed, Mlp=Mlp)
             return hax.sum(delta * cotangent).scalar()
 
-        analysis = jax.jit(jax.grad(scalar)).lower(logits).compile().memory_analysis()
-        if analysis is None:
-            pytest.skip("memory_analysis unavailable on this backend")
-        return analysis.temp_size_in_bytes
+        return jax.jit(jax.grad(scalar)).lower(logits).compile().memory_analysis().temp_size_in_bytes
 
     with use_test_mesh():
         small = peak_temp_bytes(8)

--- a/lib/levanter/tests/test_moe.py
+++ b/lib/levanter/tests/test_moe.py
@@ -1,0 +1,125 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax import random
+
+import haliax as hax
+import haliax.nn as hnn
+from haliax import Axis
+
+from levanter.models.moe import dense_router_delta
+from levanter.utils.activation import ActivationFunctionEnum
+from test_utils import use_test_mesh
+
+
+def _inputs(Token: Axis, Embed: Axis, Mlp: Axis, Experts: Axis):
+    ks = random.split(random.PRNGKey(0), 5)
+    x = hax.random.normal(ks[0], (Token, Embed))
+    logits = hax.random.normal(ks[1], (Token, Experts))
+    gate_w = hax.random.normal(ks[2], (Experts, Embed, Mlp)) * 0.1
+    up_w = hax.random.normal(ks[3], (Experts, Embed, Mlp)) * 0.1
+    down_w = hax.random.normal(ks[4], (Experts, Mlp, Embed)) * 0.1
+    return x, logits, gate_w, up_w, down_w
+
+
+def _naive_dense(x, logits, gate_w, up_w, down_w, act, *, Experts, Embed, Mlp):
+    """Reference dense forward: sum_e stop_gradient(E_e(x)) * softmax(logits)_e over all experts.
+
+    Materializes the Token x Experts x Mlp intermediates (the memory-naive layout) and is an
+    independent oracle for the router gradient the fold-based helper must reproduce.
+    """
+    weights = hnn.softmax(logits.astype(jnp.float32), axis=Experts).astype(x.dtype)
+    hidden = act(x.dot(gate_w, axis=Embed)) * x.dot(up_w, axis=Embed)
+    expert_out = jax.lax.stop_gradient(hidden.dot(down_w, axis=Mlp))
+    return (expert_out * weights).sum(axis=Experts)
+
+
+def test_dense_router_delta_value_is_zero():
+    Token, Embed, Mlp, Experts = Axis("token", 6), Axis("embed", 8), Axis("mlp", 5), Axis("experts", 4)
+    act = ActivationFunctionEnum.silu.to_fn()
+    x, logits, gate_w, up_w, down_w = _inputs(Token, Embed, Mlp, Experts)
+
+    with use_test_mesh():
+        delta = jax.jit(
+            lambda x, lg, g, u, d: dense_router_delta(x, lg, g, u, d, act, Experts=Experts, Embed=Embed, Mlp=Mlp)
+        )(x, logits, gate_w, up_w, down_w)
+
+    # Straight-through: the delta must be exactly zero in value so the forward is unchanged.
+    np.testing.assert_array_equal(np.asarray(delta.array), np.zeros((Token.size, Embed.size), dtype=np.float32))
+
+
+def test_dense_router_delta_gradient_matches_naive_dense():
+    Token, Embed, Mlp, Experts = Axis("token", 6), Axis("embed", 8), Axis("mlp", 5), Axis("experts", 4)
+    act = ActivationFunctionEnum.silu.to_fn()
+    x, logits, gate_w, up_w, down_w = _inputs(Token, Embed, Mlp, Experts)
+    cotangent = hax.random.normal(random.PRNGKey(7), (Token, Embed))
+
+    def helper_grad(logits):
+        def scalar(lg):
+            delta = dense_router_delta(x, lg, gate_w, up_w, down_w, act, Experts=Experts, Embed=Embed, Mlp=Mlp)
+            return hax.sum(delta * cotangent).scalar()
+
+        return jax.grad(scalar)(logits)
+
+    def naive_grad(logits):
+        def scalar(lg):
+            out = _naive_dense(x, lg, gate_w, up_w, down_w, act, Experts=Experts, Embed=Embed, Mlp=Mlp)
+            return hax.sum(out * cotangent).scalar()
+
+        return jax.grad(scalar)(logits)
+
+    with use_test_mesh():
+        g_helper = jax.jit(helper_grad)(logits)
+        g_naive = jax.jit(naive_grad)(logits)
+
+    np.testing.assert_allclose(np.asarray(g_helper.array), np.asarray(g_naive.array), rtol=1e-5, atol=1e-6)
+
+
+def test_dense_router_delta_gradient_reaches_expert_outputs_not_weights():
+    # The delta's gradient must reach only the router logits: expert weights and the input get none.
+    Token, Embed, Mlp, Experts = Axis("token", 6), Axis("embed", 8), Axis("mlp", 5), Axis("experts", 4)
+    act = ActivationFunctionEnum.silu.to_fn()
+    x, logits, gate_w, up_w, down_w = _inputs(Token, Embed, Mlp, Experts)
+    cotangent = hax.random.normal(random.PRNGKey(7), (Token, Embed))
+
+    def scalar(x, gate_w, up_w, down_w):
+        delta = dense_router_delta(x, logits, gate_w, up_w, down_w, act, Experts=Experts, Embed=Embed, Mlp=Mlp)
+        return hax.sum(delta * cotangent).scalar()
+
+    with use_test_mesh():
+        gx, gg, gu, gd = jax.jit(jax.grad(scalar, argnums=(0, 1, 2, 3)))(x, gate_w, up_w, down_w)
+
+    for g in (gx, gg, gu, gd):
+        np.testing.assert_array_equal(np.asarray(g.array), np.zeros_like(np.asarray(g.array)))
+
+
+def test_dense_router_delta_memory_is_bounded_in_expert_count():
+    # The remat'd fold keeps peak temp memory at O(Token * Mlp): growing the expert count 16x must
+    # not blow up the dense activation footprint (it would with a Token x Experts x Mlp layout).
+    Token, Embed, Mlp = Axis("token", 256), Axis("embed", 128), Axis("mlp", 512)
+    act = ActivationFunctionEnum.silu.to_fn()
+
+    def peak_temp_bytes(num_experts: int) -> int:
+        Experts = Axis("experts", num_experts)
+        x, logits, gate_w, up_w, down_w = _inputs(Token, Embed, Mlp, Experts)
+        cotangent = hax.random.normal(random.PRNGKey(7), (Token, Embed))
+
+        def scalar(lg):
+            delta = dense_router_delta(x, lg, gate_w, up_w, down_w, act, Experts=Experts, Embed=Embed, Mlp=Mlp)
+            return hax.sum(delta * cotangent).scalar()
+
+        analysis = jax.jit(jax.grad(scalar)).lower(logits).compile().memory_analysis()
+        if analysis is None:
+            pytest.skip("memory_analysis unavailable on this backend")
+        return analysis.temp_size_in_bytes
+
+    with use_test_mesh():
+        small = peak_temp_bytes(8)
+        large = peak_temp_bytes(128)
+
+    # 16x the experts must stay well under 2x the temp memory (weights aside, activations are flat).
+    assert large < 2 * small

--- a/lib/levanter/tests/test_qwen3_moe.py
+++ b/lib/levanter/tests/test_qwen3_moe.py
@@ -19,7 +19,12 @@ from levanter.models.lm_model import LmExample
 from levanter.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeLMHeadModel, Qwen3MoeSparseMoeBlock
 from levanter.utils.jax_utils import local_cpu_mesh
 from levanter.utils.tree_utils import inference_mode
-from test_utils import skip_if_no_torch, use_test_mesh
+from test_utils import (
+    moe_gate_grad_row_norms,
+    single_token_moe_block_grad,
+    skip_if_no_torch,
+    use_test_mesh,
+)
 
 
 def _tiny_hf_config() -> HfQwen3MoeConfig:
@@ -136,12 +141,6 @@ def _tiny_moe_config(dense_router_gradient: bool) -> Qwen3MoeConfig:
     )
 
 
-def _gate_grad_row_norms(block_grad: Qwen3MoeSparseMoeBlock, config: Qwen3MoeConfig) -> np.ndarray:
-    """L2 norm of the router-gate weight gradient per expert (shape [num_experts])."""
-    per_expert = hax.sqrt(hax.sum(block_grad.gate.weight**2, axis=config.Embed))
-    return np.asarray(per_expert.rearrange((config.Experts,)).array)
-
-
 def test_qwen3_moe_dense_router_gradient_leaves_forward_unchanged():
     # The DenseMixer flag is a training-only backward-pass change: the forward value must be
     # bit-identical to the stock sparse forward.
@@ -166,22 +165,6 @@ def test_qwen3_moe_dense_router_gradient_leaves_forward_unchanged():
     np.testing.assert_array_equal(np.asarray(logits_on), np.asarray(logits_off))
 
 
-def _single_token_block_grad(block: Qwen3MoeSparseMoeBlock, config: Qwen3MoeConfig):
-    """Task-loss gradient of a one-token MoE-block forward.
-
-    With a single token, the router-gate weight gradient factors as ``x (x) dL/d(logit_e)``, so a
-    zero gate-gradient row for expert ``e`` means expert ``e``'s router logit received no task-loss
-    gradient. This isolates the router gradient per expert without reimplementing the routing.
-    """
-    x = hax.random.normal(random.PRNGKey(2), (hax.Axis(config.max_Pos.name, 1), config.Embed))
-
-    def task_loss(block, x):
-        out, _ = block(x)
-        return hax.sum(out).scalar()
-
-    return eqx.filter_jit(eqx.filter_grad(task_loss))(block, x)
-
-
 def test_qwen3_moe_dense_router_gradient_reaches_unselected_experts():
     config_off = _tiny_moe_config(dense_router_gradient=False)
     config_on = _tiny_moe_config(dense_router_gradient=True)
@@ -191,11 +174,11 @@ def test_qwen3_moe_dense_router_gradient_reaches_unselected_experts():
         block_off = Qwen3MoeSparseMoeBlock.init(config_off, key=random.PRNGKey(0))
         block_on = dataclasses.replace(block_off, config=config_on)
 
-        grad_off = _single_token_block_grad(block_off, config_off)
-        grad_on = _single_token_block_grad(block_on, config_on)
+        grad_off = single_token_moe_block_grad(block_off, config_off)
+        grad_on = single_token_moe_block_grad(block_on, config_on)
 
-    rows_off = _gate_grad_row_norms(grad_off, config_off)
-    rows_on = _gate_grad_row_norms(grad_on, config_on)
+    rows_off = moe_gate_grad_row_norms(grad_off, config_off)
+    rows_on = moe_gate_grad_row_norms(grad_on, config_on)
 
     # Sparse forward: exactly `n_unselected` experts get no task-loss router gradient.
     assert int(np.sum(rows_off < 1e-6)) == n_unselected
@@ -218,13 +201,13 @@ def test_qwen3_moe_dense_router_gradient_disabled_in_inference():
         block_on = dataclasses.replace(block_off, config=config_on)
         block_on_eval = inference_mode(block_on, True)
 
-        grad_off = _single_token_block_grad(block_off, config_off)
-        grad_eval = _single_token_block_grad(block_on_eval, config_on)
+        grad_off = single_token_moe_block_grad(block_off, config_off)
+        grad_eval = single_token_moe_block_grad(block_on_eval, config_on)
 
     # inference_mode skips the dense pass, so the router gradient collapses back to the sparse one.
     np.testing.assert_allclose(
-        _gate_grad_row_norms(grad_eval, config_on),
-        _gate_grad_row_norms(grad_off, config_off),
+        moe_gate_grad_row_norms(grad_eval, config_on),
+        moe_gate_grad_row_norms(grad_off, config_off),
         rtol=1e-5,
         atol=1e-6,
     )

--- a/lib/levanter/tests/test_qwen3_moe.py
+++ b/lib/levanter/tests/test_qwen3_moe.py
@@ -4,6 +4,7 @@
 import dataclasses
 import tempfile
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -15,8 +16,9 @@ from haliax.state_dict import from_torch_compatible_state_dict, to_torch_compati
 
 from levanter.layers.attention import AttentionMask
 from levanter.models.lm_model import LmExample
-from levanter.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeLMHeadModel
+from levanter.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeLMHeadModel, Qwen3MoeSparseMoeBlock
 from levanter.utils.jax_utils import local_cpu_mesh
+from levanter.utils.tree_utils import inference_mode
 from test_utils import skip_if_no_torch, use_test_mesh
 
 
@@ -115,6 +117,116 @@ def test_qwen3_moe_forward_and_next_token_loss():
 
     assert losses.shape == (Batch.size, Pos.size)
     assert np.isfinite(np.asarray(losses)).all()
+
+
+def _tiny_moe_config(dense_router_gradient: bool) -> Qwen3MoeConfig:
+    return Qwen3MoeConfig(
+        max_seq_len=8,
+        hidden_dim=16,
+        intermediate_dim=32,
+        moe_intermediate_dim=8,
+        num_layers=2,
+        num_heads=4,
+        head_dim=4,
+        num_kv_heads=2,
+        num_experts=4,
+        num_experts_per_tok=2,
+        gradient_checkpointing=False,
+        dense_router_gradient=dense_router_gradient,
+    )
+
+
+def _gate_grad_row_norms(block_grad: Qwen3MoeSparseMoeBlock, config: Qwen3MoeConfig) -> np.ndarray:
+    """L2 norm of the router-gate weight gradient per expert (shape [num_experts])."""
+    per_expert = hax.sqrt(hax.sum(block_grad.gate.weight**2, axis=config.Embed))
+    return np.asarray(per_expert.rearrange((config.Experts,)).array)
+
+
+def test_qwen3_moe_dense_router_gradient_leaves_forward_unchanged():
+    # The DenseMixer flag is a training-only backward-pass change: the forward value must be
+    # bit-identical to the stock sparse forward.
+    Batch = hax.Axis("batch", 2)
+    Vocab = hax.Axis("vocab", 64)
+    config_off = _tiny_moe_config(dense_router_gradient=False)
+    Pos = config_off.max_Pos
+    input_ids = hax.random.randint(random.PRNGKey(1), (Batch, Pos), 0, Vocab.size)
+
+    with use_test_mesh():
+        # Same key => identical weights; the flag does not touch initialization.
+        model_off = Qwen3MoeLMHeadModel.init(Vocab, config_off, key=random.PRNGKey(0))
+        model_on = Qwen3MoeLMHeadModel.init(Vocab, _tiny_moe_config(dense_router_gradient=True), key=random.PRNGKey(0))
+
+        @eqx.filter_jit
+        def logits(model, ids):
+            return model(ids, attn_mask=AttentionMask.causal()).array
+
+        logits_off = logits(model_off, input_ids)
+        logits_on = logits(model_on, input_ids)
+
+    np.testing.assert_array_equal(np.asarray(logits_on), np.asarray(logits_off))
+
+
+def _single_token_block_grad(block: Qwen3MoeSparseMoeBlock, config: Qwen3MoeConfig):
+    """Task-loss gradient of a one-token MoE-block forward.
+
+    With a single token, the router-gate weight gradient factors as ``x (x) dL/d(logit_e)``, so a
+    zero gate-gradient row for expert ``e`` means expert ``e``'s router logit received no task-loss
+    gradient. This isolates the router gradient per expert without reimplementing the routing.
+    """
+    x = hax.random.normal(random.PRNGKey(2), (hax.Axis(config.max_Pos.name, 1), config.Embed))
+
+    def task_loss(block, x):
+        return hax.sum(block(x)).scalar()
+
+    return eqx.filter_jit(eqx.filter_grad(task_loss))(block, x)
+
+
+def test_qwen3_moe_dense_router_gradient_reaches_unselected_experts():
+    config_off = _tiny_moe_config(dense_router_gradient=False)
+    config_on = _tiny_moe_config(dense_router_gradient=True)
+    n_unselected = config_off.num_experts - config_off.num_experts_per_tok
+
+    with use_test_mesh():
+        block_off = Qwen3MoeSparseMoeBlock.init(config_off, key=random.PRNGKey(0))
+        block_on = dataclasses.replace(block_off, config=config_on)
+
+        grad_off = _single_token_block_grad(block_off, config_off)
+        grad_on = _single_token_block_grad(block_on, config_on)
+
+    rows_off = _gate_grad_row_norms(grad_off, config_off)
+    rows_on = _gate_grad_row_norms(grad_on, config_on)
+
+    # Sparse forward: exactly `n_unselected` experts get no task-loss router gradient.
+    assert int(np.sum(rows_off < 1e-6)) == n_unselected
+    # Dense router gradient: every expert (including the unselected ones) gets a real gradient.
+    assert np.all(rows_on > 1e-4)
+
+    # Expert-parameter gradients must be untouched by the flag: only the router gradient changes.
+    for projection in ("gate_proj", "up_proj", "down_proj"):
+        weight_off = getattr(grad_off.experts, projection).weight.array
+        weight_on = getattr(grad_on.experts, projection).weight.array
+        np.testing.assert_allclose(np.asarray(weight_on), np.asarray(weight_off), rtol=1e-6, atol=1e-6)
+
+
+def test_qwen3_moe_dense_router_gradient_disabled_in_inference():
+    config_off = _tiny_moe_config(dense_router_gradient=False)
+    config_on = _tiny_moe_config(dense_router_gradient=True)
+
+    with use_test_mesh():
+        block_off = Qwen3MoeSparseMoeBlock.init(config_off, key=random.PRNGKey(0))
+        block_on = dataclasses.replace(block_off, config=config_on)
+        block_on_eval = inference_mode(block_on, True)
+
+        grad_off = _single_token_block_grad(block_off, config_off)
+        grad_eval = _single_token_block_grad(block_on_eval, config_on)
+
+    # inference_mode skips the dense pass, so the router gradient collapses back to the sparse one.
+    np.testing.assert_allclose(
+        _gate_grad_row_norms(grad_eval, config_on),
+        _gate_grad_row_norms(grad_off, config_off),
+        rtol=1e-5,
+        atol=1e-6,
+    )
 
 
 @skip_if_no_torch

--- a/lib/levanter/tests/test_qwen3_moe.py
+++ b/lib/levanter/tests/test_qwen3_moe.py
@@ -176,7 +176,8 @@ def _single_token_block_grad(block: Qwen3MoeSparseMoeBlock, config: Qwen3MoeConf
     x = hax.random.normal(random.PRNGKey(2), (hax.Axis(config.max_Pos.name, 1), config.Embed))
 
     def task_loss(block, x):
-        return hax.sum(block(x)).scalar()
+        out, _ = block(x)
+        return hax.sum(out).scalar()
 
     return eqx.filter_jit(eqx.filter_grad(task_loss))(block, x)
 
@@ -229,6 +230,84 @@ def test_qwen3_moe_dense_router_gradient_disabled_in_inference():
     )
 
 
+def _hf_load_balancing_loss(router_logits: np.ndarray, num_experts: int, top_k: int, coef: float) -> float:
+    """Independent numpy port of HF's ``load_balancing_loss_func`` for a single layer's logits."""
+    logits = router_logits.astype(np.float64)
+    probs = np.exp(logits - logits.max(axis=-1, keepdims=True))
+    probs = probs / probs.sum(axis=-1, keepdims=True)
+    tokens = logits.shape[0]
+    selected = np.argsort(-probs, axis=-1)[:, :top_k]
+    expert_mask = np.zeros((tokens, top_k, num_experts))
+    for t in range(tokens):
+        for j in range(top_k):
+            expert_mask[t, j, selected[t, j]] = 1.0
+    tokens_per_expert = expert_mask.mean(axis=0)  # [top_k, num_experts]
+    router_prob_per_expert = probs.mean(axis=0)  # [num_experts]
+    overall = float((tokens_per_expert * router_prob_per_expert[None, :]).sum())
+    return coef * overall * num_experts
+
+
+def test_qwen3_moe_router_aux_loss_matches_hf_load_balancing_formula():
+    config = dataclasses.replace(_tiny_moe_config(dense_router_gradient=False), router_aux_loss_coef=0.3)
+    Pos = hax.Axis(config.max_Pos.name, 8)
+
+    with use_test_mesh():
+        block = Qwen3MoeSparseMoeBlock.init(config, key=random.PRNGKey(0))
+        x = hax.random.normal(random.PRNGKey(3), (Pos, config.Embed))
+
+        @eqx.filter_jit
+        def run(block, x):
+            out, extras = block(x)
+            x_flat = hax.flatten_axes(x, old_axes=[x.resolve_axis(config.max_Pos.name)], new_axis="token")
+            return extras["load_balancing_loss"].scalar(), block.gate(x_flat).array
+
+        lbl, router_logits = run(block, x)
+
+    expected = _hf_load_balancing_loss(
+        np.asarray(router_logits), config.num_experts, config.num_experts_per_tok, config.router_aux_loss_coef
+    )
+    np.testing.assert_allclose(float(lbl), expected, rtol=1e-4, atol=1e-6)
+
+
+def test_qwen3_moe_router_aux_loss_added_to_next_token_loss():
+    Batch = hax.Axis("batch", 2)
+    Vocab = hax.Axis("vocab", 64)
+    base = _tiny_moe_config(dense_router_gradient=False)
+    Pos = base.max_Pos
+    input_ids = hax.random.randint(random.PRNGKey(1), (Batch, Pos), 0, Vocab.size)
+
+    with use_test_mesh():
+        # Same key => identical weights; only the aux coefficient differs.
+        model_aux = Qwen3MoeLMHeadModel.init(
+            Vocab, dataclasses.replace(base, router_aux_loss_coef=0.5), key=random.PRNGKey(0)
+        )
+        model_no_aux = Qwen3MoeLMHeadModel.init(
+            Vocab, dataclasses.replace(base, router_aux_loss_coef=None), key=random.PRNGKey(0)
+        )
+
+        @eqx.filter_jit
+        def loss(model, ids):
+            example = LmExample(
+                tokens=ids,
+                loss_weight=hax.ones((Batch, Pos), dtype=jnp.float32),
+                attn_mask=AttentionMask.causal(),
+            )
+            return model.compute_next_token_loss(example, reduction=hax.mean).scalar()
+
+        @eqx.filter_jit
+        def reported_aux(model, ids):
+            _, aux = model.activations(ids, attn_mask=AttentionMask.causal())
+            return aux.scalar()
+
+        loss_aux = float(loss(model_aux, input_ids))
+        loss_no_aux = float(loss(model_no_aux, input_ids))
+        aux = float(reported_aux(model_aux, input_ids))
+
+    # The aux loss is a positive term added on top of the (weight-identical) cross-entropy.
+    assert aux > 0
+    np.testing.assert_allclose(loss_aux - loss_no_aux, aux, rtol=1e-5, atol=1e-6)
+
+
 @skip_if_no_torch
 def test_qwen3_moe_hf_logits_and_loss_match_torch(local_gpt2_tokenizer_path):
     import torch  # noqa: PLC0415
@@ -262,9 +341,12 @@ def test_qwen3_moe_hf_logits_and_loss_match_torch(local_gpt2_tokenizer_path):
 
     with tempfile.TemporaryDirectory() as tmpdir, use_test_mesh():
         torch_model.save_pretrained(f"{tmpdir}/torch_model")
+        # HF's logits/CE path carries no auxiliary loss; disable the router load-balancing loss so this
+        # stays a pure forward/cross-entropy parity check (the aux wiring is covered separately).
         model = converter.load_pretrained(
             Qwen3MoeLMHeadModel,
             ref=f"{tmpdir}/torch_model",
+            config=dataclasses.replace(config, router_aux_loss_coef=None),
             resize_vocab_to_match_tokenizer=False,
         )
 

--- a/lib/levanter/tests/test_qwen3_moe.py
+++ b/lib/levanter/tests/test_qwen3_moe.py
@@ -170,7 +170,11 @@ def test_qwen3_moe_dense_router_gradient_reaches_unselected_experts():
     config_on = _tiny_moe_config(dense_router_gradient=True)
     n_unselected = config_off.num_experts - config_off.num_experts_per_tok
 
-    with use_test_mesh():
+    # The expert-parameter gradients are mathematically identical with the flag on or off (the dense
+    # branch's expert outputs are stop_gradient-wrapped), so we compare them at float32 matmul
+    # precision. TPU's default bf16 matmuls otherwise perturb the two differently-scheduled backward
+    # graphs past any equality tolerance; the router-norm assertions run in f32 either way.
+    with use_test_mesh(), jax.default_matmul_precision("float32"):
         block_off = Qwen3MoeSparseMoeBlock.init(config_off, key=random.PRNGKey(0))
         block_on = dataclasses.replace(block_off, config=config_on)
 
@@ -186,10 +190,12 @@ def test_qwen3_moe_dense_router_gradient_reaches_unselected_experts():
     assert np.all(rows_on > 1e-4)
 
     # Expert-parameter gradients must be untouched by the flag: only the router gradient changes.
+    # On CPU they are bit-identical; TPU's f32-emulated matmuls leave a small reordering residual.
+    tol = 1e-4 if jax.default_backend() == "tpu" else 1e-6
     for projection in ("gate_proj", "up_proj", "down_proj"):
         weight_off = getattr(grad_off.experts, projection).weight.array
         weight_on = getattr(grad_on.experts, projection).weight.array
-        np.testing.assert_allclose(np.asarray(weight_on), np.asarray(weight_off), rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(np.asarray(weight_on), np.asarray(weight_off), rtol=tol, atol=tol)
 
 
 def test_qwen3_moe_dense_router_gradient_disabled_in_inference():

--- a/lib/levanter/tests/test_qwen3_moe.py
+++ b/lib/levanter/tests/test_qwen3_moe.py
@@ -170,11 +170,7 @@ def test_qwen3_moe_dense_router_gradient_reaches_unselected_experts():
     config_on = _tiny_moe_config(dense_router_gradient=True)
     n_unselected = config_off.num_experts - config_off.num_experts_per_tok
 
-    # The expert-parameter gradients are mathematically identical with the flag on or off (the dense
-    # branch's expert outputs are stop_gradient-wrapped), so we compare them at float32 matmul
-    # precision. TPU's default bf16 matmuls otherwise perturb the two differently-scheduled backward
-    # graphs past any equality tolerance; the router-norm assertions run in f32 either way.
-    with use_test_mesh(), jax.default_matmul_precision("float32"):
+    with use_test_mesh():
         block_off = Qwen3MoeSparseMoeBlock.init(config_off, key=random.PRNGKey(0))
         block_on = dataclasses.replace(block_off, config=config_on)
 
@@ -189,13 +185,19 @@ def test_qwen3_moe_dense_router_gradient_reaches_unselected_experts():
     # Dense router gradient: every expert (including the unselected ones) gets a real gradient.
     assert np.all(rows_on > 1e-4)
 
-    # Expert-parameter gradients must be untouched by the flag: only the router gradient changes.
-    # On CPU they are bit-identical; TPU's f32-emulated matmuls leave a small reordering residual.
-    tol = 1e-4 if jax.default_backend() == "tpu" else 1e-6
-    for projection in ("gate_proj", "up_proj", "down_proj"):
-        weight_off = getattr(grad_off.experts, projection).weight.array
-        weight_on = getattr(grad_on.experts, projection).weight.array
-        np.testing.assert_allclose(np.asarray(weight_on), np.asarray(weight_off), rtol=tol, atol=tol)
+    # The flag changes only the router gradient; the sparse expert-parameter gradients are identical.
+    # This is a mathematical identity (the dense delta's expert outputs are stop_gradient-wrapped),
+    # checked exactly on CPU. It is not asserted on TPU: the flag-on and flag-off blocks compile to
+    # separate graphs, and the bf16 router matmul rounds differently under each graph's fusion, so a
+    # single-token near-tie can put a different expert in the top-k between the two runs -- the
+    # cross-graph gradient comparison is then comparing different routings, not the flag's effect.
+    # (The dense delta contributing no expert-weight gradient is checked on every backend by
+    # test_moe.py::test_dense_router_delta_gradient_reaches_expert_outputs_not_weights.)
+    if jax.default_backend() == "cpu":
+        for projection in ("gate_proj", "up_proj", "down_proj"):
+            weight_off = getattr(grad_off.experts, projection).weight.array
+            weight_on = getattr(grad_on.experts, projection).weight.array
+            np.testing.assert_array_equal(np.asarray(weight_on), np.asarray(weight_off))
 
 
 def test_qwen3_moe_dense_router_gradient_disabled_in_inference():

--- a/lib/levanter/tests/test_utils.py
+++ b/lib/levanter/tests/test_utils.py
@@ -301,3 +301,25 @@ def use_test_mesh(tensor_parallelism: int = 1, *, mesh: Optional[Mesh] = None, s
         mesh = create_test_mesh(tensor_parallelism, skip_ok=skip_ok)
     with set_mesh(mesh):
         yield mesh
+
+
+def moe_gate_grad_row_norms(block_grad, config) -> np.ndarray:
+    """Per-expert L2 norm of an MoE block's router-gate weight gradient (shape [num_experts])."""
+    per_expert = hax.sqrt(hax.sum(block_grad.gate.weight**2, axis=config.Embed))
+    return np.asarray(per_expert.rearrange((config.Experts,)).array)
+
+
+def single_token_moe_block_grad(block, config):
+    """Task-loss gradient of a one-token MoE-block forward.
+
+    With a single token, the router-gate weight gradient factors as ``x (x) dL/d(logit_e)``, so a
+    zero gate-gradient row for expert ``e`` means expert ``e``'s router logit received no task-loss
+    gradient. This isolates the router gradient per expert without reimplementing the routing.
+    """
+    x = hax.random.normal(PRNGKey(2), (hax.Axis(config.max_Pos.name, 1), config.Embed))
+
+    def task_loss(block, x):
+        out, _ = block(x)
+        return hax.sum(out).scalar()
+
+    return eqx.filter_jit(eqx.filter_grad(task_loss))(block, x)


### PR DESCRIPTION
Adds a training-only, config-gated DenseMixer-style dense router gradient to Levanter's MoE models (Qwen3-MoE and Mixtral), and separately wires the Qwen3-MoE router auxiliary loss that was round-tripped to HF but never consumed. Part of #7088.

## Dense router gradient

The conventional sparse MoE forward computes only the top-k experts, so the task-loss gradient to a **non-selected** expert's router logit is (numerically) zero — the router can intensify its existing routing but cannot learn the counterfactual "expert j would have been better for this token." That re-routing signal is the dominant available lever in MoE SFT and small-scale mid-training, where the experts are already specialized and barely move. See #7088 and the DenseMixer reference (yaof20/DenseMixer).

`dense_router_gradient` (new flag on `Qwen3MoeConfig` and `MixtralConfig`, **default off**) turns on a straight-through estimator in the MoE block:

- The sparse combine is kept, but its router weights are `stop_gradient`-wrapped, so expert parameters still receive the conventional sparse gradient while the router logits receive none from the sparse path.
- A zero-valued delta is added whose gradient is the full-softmax, all-experts dense router gradient; the dense branch's expert outputs are `stop_gradient`-wrapped, so the delta reaches only the router logits.

The forward value stays bit-identical to the stock sparse forward, expert-parameter gradients stay exactly the conventional sparse ones, and only the router logits gain the dense all-experts gradient. `levanter.models.moe.dense_router_delta` implements the shared branch for both models; their permute/unpermute code stays duplicated.

Handling of the risks called out in #7088:

- **Memory.** A naive dense branch materializes `Token x Experts x Mlp` intermediates (128 experts for Qwen3-MoE). The helper accumulates experts with a `remat`'d fold over the Experts axis, holding peak activation memory at `O(Token x Mlp)` — measured compiled temp memory grows only 5.3 → 6.3 MB as experts scale 16 → 256.
- **Sharding.** The dense branch uses plain `hax.dot` + `hax.auto_sharded` under the ambient axis mapping, matching how the sparse `MoELinear` path shards (`mlp -> model`, experts replicated); no full-expert-weight gather.
- **Eval.** The block gets a non-static `inference` field (the `hnn.Dropout` pattern) so `inference_mode` skips the dense pass for eval, which only saves compute. HF export/serving is untouched.

## Qwen3-MoE router aux loss

`router_aux_loss_coef` (default `0.001`) was converted to/from HF but never used — the block discarded `expert_loads` and returned a bare activation, so no load-balancing loss reached `compute_next_token_loss`. This wires it as Mixtral already does: the block returns `(output, extras)`, the transformer sums the per-layer load-balancing loss over layers, and `activations` returns `(x, aux_loss)`. The `train_lm` / `eval_lm` / `viz_logprobs` entropy-logging paths now unpack that tuple, which already applied to Mixtral.

**This activates a behavior change for existing Qwen3-MoE training configs** — their coefficient defaults to 0.001 and was previously inert. The per-layer term is the standard GShard/Switch load-balancing loss `num_experts * sum_e f_e * P_e`, matching HF's `load_balancing_loss_func` per layer, summed over layers as in Levanter's Mixtral. That sum-over-layers aggregation differs from HF's concatenate-all-layers aggregation by roughly a `num_layers` factor, matching the existing Mixtral convention; tune the coefficient accordingly.

Out of scope: grug MoE (QB routing, custom EP dispatch), followed up in #7211.
