### PR TITLE
[iris] Balanced multi-rack GB200 placement: schedulable-rack cutoff + Kueue PodSet slices

### DIFF
--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -441,6 +441,33 @@ gangs), so `iris-cq` carries two flavors in one resourceGroup:
   instead of being fenced onto CPU-only capacity. Pass `--cpu-flavor-node-label
   KEY=VALUE` to pin `cw-cpu` to specific CPU nodes instead.
 
+**GB200 NVLink-domain placement.** NVL72 nodes (GB200/GB300, `gb200-4x` — 4
+Blackwell GPUs each) carry `ds.coreweave.com/nvlink.domain`; one NVL72 rack is one
+NVLink domain of 18 physical nodes, of which CoreWeave keeps only **16 schedulable
+at once** (the rest absorb host failures and maintenance — a floor, not a cap).
+Iris picks a placement level per multi-node GB200 gang from its replica count:
+
+- **≤ 16 nodes** bind **hard** to a single `nvlink.domain`
+  (`podset-required-topology`) — the whole gang shares one rack's NVLink fabric.
+  16 is the largest hard single-domain gang; binding a 17–18-node gang hard would
+  demand a fully-healthy rack and could sit unschedulable whenever one is short a
+  node.
+- **> 16 nodes** use Kueue **PodSet slices** (`podset-slice-required-topology:
+  nvlink.domain` + a computed `podset-slice-size`). The gang is split evenly over
+  the fewest racks that hold ≤ 16 nodes each, and each slice is hard-bound to its
+  own NVLink domain, so it lands as an exact **balanced N-rack layout**: 24 → 12+12,
+  32 → 16+16, 48 → 16+16+16. Because two slices always exceed a rack (each is more
+  than half of 18), no two share a rack. A soft `leafgroup` preference is paired so
+  the racks also cluster on one IB leaf group.
+
+The sliced level requires **node-saturating pods** (one pod = one whole `gb200-4x`
+node = 4 GPUs) so a slice fills whole nodes, and a gang size that splits into equal,
+more-than-half-a-rack slices — sizes that cannot (e.g. 17, 18, 40) are rejected at
+submit. PodSet slices need **Kueue ≥ 0.13**; use **0.18+** for the `IsTAS()`
+recognition fix for slice-only pod groups (upstream #10282). On an older Kueue the
+slice annotations are silently ignored and a multi-rack gang degrades to a soft
+leafgroup gang with no per-rack NVLink guarantee.
+
 **Never install Kueue with unscoped admission webhooks on a CoreWeave cluster.**
 The script scopes them to the `iris` namespace (`--pod-namespace`); the chart
 default intercepts pod CREATEs in every namespace fail-closed, including the
@@ -746,6 +773,18 @@ kci delete nodepool -l iris-<label_prefix>-managed=true
 - **`NCCL_SOCKET_IFNAME` is per-region.** The same GPU SKU exposes different PCI
   interface names in different regions; verify on a live node (see "Bringing up
   a new cluster").
+- **A controller restart can CrashLoop on a stale node-local state DB.** The
+  controller keeps its SQLite state on node-local NVMe (`storage.local_state_dir`,
+  a hostPath), and `cluster controller restart` may reschedule the new pod onto a
+  different CPU node. If that node holds a corrupt leftover state DB from an earlier
+  stint whose mtime is at least as fresh as the latest remote checkpoint, startup
+  trusts it (skips the checkpoint restore) and crashes with `database disk image is
+  malformed`. The deploy's post-restart health check catches the CrashLoopBackOff
+  and **auto-rolls-back** to the previous image + pre-deploy checkpoint, so the
+  cluster stays healthy. Recovery: just re-run the restart — a fresher pre-deploy
+  checkpoint makes a stale node restore the clean checkpoint, and landing back on
+  the current controller node reuses its good DB. A persistently bad node needs its
+  `local_state_dir/db` wiped so startup falls back to the checkpoint.
 
 Cold-start timings:
 

--- a/lib/iris/scripts/install_kueue.py
+++ b/lib/iris/scripts/install_kueue.py
@@ -426,7 +426,11 @@ def _parse_node_label(spec: str) -> tuple[str, str]:
 )
 @click.option("--kubeconfig", default=None, help="kubeconfig to use (else $KUBECONFIG / ~/.kube/config).")
 @click.option("--context", default=None, help="kube context to target.")
-@click.option("--chart-version", default=None, help="Pin the chart version (upstream default: 0.11.0; cw: latest).")
+@click.option(
+    "--chart-version",
+    default=None,
+    help=f"Pin the chart version (upstream default: {UPSTREAM_DEFAULT_VERSION}; cw: latest).",
+)
 @click.option("--release", default=RELEASE_DEFAULT, help="helm release name (default: kueue).")
 @click.option(
     "--with-queues/--no-with-queues",

--- a/lib/iris/scripts/install_kueue.py
+++ b/lib/iris/scripts/install_kueue.py
@@ -116,9 +116,11 @@ from iris.cluster.platforms.k8s.types import IRIS_PRIORITY_CLASS_SYSTEM, iris_pr
 _WEBHOOK_WARMUP_RETRIES = 6
 _WEBHOOK_WARMUP_DELAY = 5.0
 
-# Upstream Kueue OCI helm chart (kind / generic clusters).
+# Upstream Kueue OCI helm chart (kind / generic clusters). Pinned >= 0.13 for the PodSet-slice
+# TAS feature (multi-rack GB200 nvlink.domain.sliced placement); 0.18 also carries the
+# IsTAS()-recognition fix for slice-only pod groups (upstream #10282, patched in 0.16/0.17).
 UPSTREAM_CHART = "oci://registry.k8s.io/kueue/charts/kueue"
-UPSTREAM_DEFAULT_VERSION = "0.11.0"
+UPSTREAM_DEFAULT_VERSION = "0.18.0"
 
 
 # --------------------------------------------------------------------------

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -493,9 +493,10 @@ def resolve_multinode_defaults(
     coscheduling by ``tpu-name`` so that all tasks land on workers in the same
     TPU slice. For GPUs with replicas > 1, the coscheduling level is derived from
     the GPU variant: NVL72 (GB200/GB300) gangs that fit a rack's guaranteed-schedulable
-    node slice bind HARD to ``nvlink.domain``; larger NVL72 gangs bind SOFT to the same
-    level (``nvlink.domain.preferred``) so Kueue packs them into whole racks; H100 and
-    other GPUs coschedule on the soft ``leafgroup`` IB level.
+    node slice bind HARD to ``nvlink.domain``; larger NVL72 gangs bind to
+    ``nvlink.domain.sliced``, which partitions them into rack-sized slices placed one per
+    NVLink domain (balanced N racks x 16); H100 and other GPUs coschedule on the soft
+    ``leafgroup`` IB level.
 
     Args:
         tpu: TPU type string (e.g. ``"v6e-32"``), or ``None``.

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -39,7 +39,12 @@ from iris.cluster.constraints import (
     region_constraint,
     zone_constraint,
 )
-from iris.cluster.platforms.k8s.coreweave_topology import gpu_gang_coscheduling_level
+from iris.cluster.platforms.k8s.coreweave_topology import (
+    COSCHEDULE_NVLINK_DOMAIN_SLICED,
+    NVL72_GPUS_PER_NODE,
+    balanced_rack_slice_size,
+    gpu_gang_coscheduling_level,
+)
 from iris.cluster.redaction import redact_submit_argv
 from iris.cluster.tpu_topology import get_tpu_topology
 from iris.cluster.types import (
@@ -496,7 +501,9 @@ def resolve_multinode_defaults(
     node slice bind HARD to ``nvlink.domain``; larger NVL72 gangs bind to
     ``nvlink.domain.sliced``, which partitions them into rack-sized slices placed one per
     NVLink domain (balanced N racks x 16); H100 and other GPUs coschedule on the soft
-    ``leafgroup`` IB level.
+    ``leafgroup`` IB level. A sliced gang whose size cannot split into equal, more-than-half-a-rack
+    slices, or whose pods are not node-saturating, is rejected here with a ``click.UsageError``
+    rather than deferred to a controller-side failure.
 
     Args:
         tpu: TPU type string (e.g. ``"v6e-32"``), or ``None``.
@@ -510,8 +517,21 @@ def resolve_multinode_defaults(
     """
     if not tpu:
         if gpu and replicas is not None and replicas > 1:
-            variant, _ = parse_gpu_spec(gpu)
+            variant, gpu_count = parse_gpu_spec(gpu)
             level = gpu_gang_coscheduling_level(variant, replicas)
+            if level == COSCHEDULE_NVLINK_DOMAIN_SLICED:
+                # Reject a knowably-unplaceable sliced gang at submit rather than let the
+                # controller terminal-fail it a round-trip later. Only the sliced level constrains
+                # size and per-node GPU count; smaller gangs and other GPUs are always placeable.
+                if gpu_count != NVL72_GPUS_PER_NODE:
+                    raise click.UsageError(
+                        f"A sliced multi-rack {variant} gang needs node-saturating pods "
+                        f"({NVL72_GPUS_PER_NODE} GPUs each so one slice fills whole nodes); got {gpu_count}."
+                    )
+                try:
+                    balanced_rack_slice_size(replicas)
+                except ValueError as e:
+                    raise click.UsageError(f"--replicas {replicas} for {variant}: {e}") from e
             return replicas, CoschedulingConfig(group_by=level)
         return replicas or 1, None
 

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -492,9 +492,9 @@ def resolve_multinode_defaults(
     For TPUs with vm_count > 1, infers replicas from the topology and enables
     coscheduling by ``tpu-name`` so that all tasks land on workers in the same
     TPU slice. For GPUs with replicas > 1, the coscheduling level is derived from
-    the GPU variant: NVL72 (GB200/GB300) gangs that fit one rack bind HARD to
-    ``nvlink.domain``; larger NVL72 gangs bind SOFT to the same level
-    (``nvlink.domain.preferred``) so Kueue packs them into whole racks; H100 and
+    the GPU variant: NVL72 (GB200/GB300) gangs that fit a rack's guaranteed-schedulable
+    node slice bind HARD to ``nvlink.domain``; larger NVL72 gangs bind SOFT to the same
+    level (``nvlink.domain.preferred``) so Kueue packs them into whole racks; H100 and
     other GPUs coschedule on the soft ``leafgroup`` IB level.
 
     Args:

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -54,6 +54,7 @@ from iris.cluster.platforms.k8s.coreweave_topology import (
     CW_LABEL_NVLINK_DOMAIN,
     NVL72_GPUS_PER_NODE,
     RACK_SIZE,
+    SCHEDULABLE_RACK_NODES,
     KueueTopologyBinding,
     TopologyMode,
     balanced_rack_slice_size,
@@ -98,7 +99,7 @@ class PodManifestError(ValueError):
 
     Raised for request-level validation failures in manifest construction: an
     unsupported container profile, a coscheduling group_by with no topology
-    mapping, an NVLink-domain gang larger than one rack, or an unsupported
+    mapping, an NVLink-domain gang larger than a rack's schedulable slice, or an unsupported
     constraint op. These are permanent — the identical request fails the same
     way on every retry — so ``sync`` fails the task terminally instead of
     treating it as a retryable worker loss and re-applying it every tick.
@@ -650,8 +651,9 @@ def _topology_request_annotations(
     """Kueue topology-request annotations for a coscheduled gang, per the binding's mode.
 
     PREFERRED/REQUIRED bind the whole gang to one ``node_label`` domain (soft/hard). For a hard
-    nvlink.domain gang that exceeds one rack — which can never be placed and would hang forever —
-    this raises instead (the CLI never emits it; the guard catches a programmatic client).
+    nvlink.domain gang that exceeds a rack's guaranteed-schedulable slice — which could sit
+    unschedulable whenever a rack is short a node — this raises instead (the CLI never emits it;
+    the guard catches a programmatic or stale client).
     SLICE_REQUIRED partitions the gang into balanced per-rack slices (size from
     ``balanced_rack_slice_size``), each hard-bound to one nvlink.domain, and pairs a soft coarse
     preference so the racks cluster on the IB fabric. The one-slice-per-rack guarantee holds only
@@ -677,11 +679,12 @@ def _topology_request_annotations(
             annotations[_KUEUE_PREFERRED_TOPOLOGY] = binding.coarse_preferred_label
         return annotations
     if binding.mode is TopologyMode.REQUIRED:
-        if node_label == CW_LABEL_NVLINK_DOMAIN and num_tasks > RACK_SIZE:
+        if node_label == CW_LABEL_NVLINK_DOMAIN and num_tasks > SCHEDULABLE_RACK_NODES:
             raise PodManifestError(
                 f"Coscheduled task {task_ref!r} requires a single {group_by!r} domain but num_tasks={num_tasks} "
-                f"exceeds the NVLink domain size ({RACK_SIZE} nodes, one NVL72 rack). A hard NVLink-domain gang "
-                f"cannot cross racks; request <= {RACK_SIZE} replicas or coschedule on a coarser level (e.g. leafgroup)."
+                f"exceeds the guaranteed-schedulable rack slice ({SCHEDULABLE_RACK_NODES} of an {RACK_SIZE}-node "
+                f"NVL72 rack). A hard NVLink-domain gang can hang if a rack is short a node; request "
+                f"<= {SCHEDULABLE_RACK_NODES} replicas, or use the sliced level for a larger balanced gang."
             )
         return {_KUEUE_REQUIRED_TOPOLOGY: node_label}
     return {_KUEUE_PREFERRED_TOPOLOGY: node_label}

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -54,9 +54,9 @@ from iris.cluster.platforms.k8s.coreweave_topology import (
     CW_LABEL_NVLINK_DOMAIN,
     NVL72_GPUS_PER_NODE,
     RACK_SIZE,
-    SCHEDULABLE_RACK_NODES,
     KueueTopologyBinding,
     TopologyMode,
+    balanced_rack_slice_size,
 )
 from iris.cluster.platforms.k8s.service import K8sService
 from iris.cluster.platforms.k8s.types import (
@@ -211,9 +211,9 @@ _KUEUE_MANAGED_FINALIZER = "kueue.x-k8s.io/managed"
 #                 nvlink.domain label, so this only binds on GB200 capacity).
 #   nvlink.domain.preferred  soft (preferred) on the SAME nvlink.domain label: pack into as few
 #                 whole NVLink domains as possible. Reachable only via explicit config/group_by.
-#   nvlink.domain.sliced  PodSet-slice: partition a multi-rack GB200 gang into
-#                 SCHEDULABLE_RACK_NODES-node slices, each hard-bound to its own nvlink.domain,
-#                 with a soft leafgroup preference so the racks cluster on one IB leaf group.
+#   nvlink.domain.sliced  PodSet-slice: partition a multi-rack GB200 gang into balanced per-rack
+#                 slices, each hard-bound to its own nvlink.domain, with a soft leafgroup
+#                 preference so the racks cluster on one IB leaf group.
 # A cluster whose Topology uses different levels overrides this via
 # kubernetes_provider.kueue.topologies. Priority classes have NO default: Iris
 # never invents WorkloadPriorityClass names (a missing one is rejected by
@@ -223,7 +223,7 @@ _CW_DEFAULT_TOPOLOGIES: dict[str, KueueTopologyBinding] = {
     COSCHEDULE_NVLINK_DOMAIN: KueueTopologyBinding(CW_LABEL_NVLINK_DOMAIN, TopologyMode.REQUIRED),
     COSCHEDULE_NVLINK_DOMAIN_PREFERRED: KueueTopologyBinding(CW_LABEL_NVLINK_DOMAIN, TopologyMode.PREFERRED),
     COSCHEDULE_NVLINK_DOMAIN_SLICED: KueueTopologyBinding(
-        CW_LABEL_NVLINK_DOMAIN, TopologyMode.SLICE_REQUIRED, SCHEDULABLE_RACK_NODES, CW_LABEL_LEAFGROUP
+        CW_LABEL_NVLINK_DOMAIN, TopologyMode.SLICE_REQUIRED, coarse_preferred_label=CW_LABEL_LEAFGROUP
     ),
 }
 
@@ -652,30 +652,26 @@ def _topology_request_annotations(
     PREFERRED/REQUIRED bind the whole gang to one ``node_label`` domain (soft/hard). For a hard
     nvlink.domain gang that exceeds one rack — which can never be placed and would hang forever —
     this raises instead (the CLI never emits it; the guard catches a programmatic client).
-    SLICE_REQUIRED partitions the gang into ``slice_size`` rack slices, each hard-bound to one
-    nvlink.domain, and pairs a soft coarse preference so the racks cluster on the IB fabric. The
-    one-slice-per-rack guarantee holds only for node-saturating pods and a slice size that two
-    of cannot fit one rack; both are validated here, along with a whole-number-of-slices count.
+    SLICE_REQUIRED partitions the gang into balanced per-rack slices (size from
+    ``balanced_rack_slice_size``), each hard-bound to one nvlink.domain, and pairs a soft coarse
+    preference so the racks cluster on the IB fabric. The one-slice-per-rack guarantee holds only
+    for node-saturating pods and a gang that splits into equal, more-than-half-a-rack slices;
+    both are validated here.
     """
     node_label = binding.node_label
     if binding.mode is TopologyMode.SLICE_REQUIRED:
-        slice_size = binding.slice_size
-        if slice_size is None or 2 * slice_size <= RACK_SIZE or slice_size > SCHEDULABLE_RACK_NODES:
-            raise PodManifestError(
-                f"Sliced topology {group_by!r} needs a slice size in ({RACK_SIZE // 2}, {SCHEDULABLE_RACK_NODES}] "
-                f"so two slices cannot share one {RACK_SIZE}-node rack; got {slice_size}."
-            )
         if gpu_count != NVL72_GPUS_PER_NODE:
             raise PodManifestError(
                 f"Coscheduled task {task_ref!r} uses sliced level {group_by!r}, which requires node-saturating "
                 f"NVL72 pods ({NVL72_GPUS_PER_NODE} GPUs each) so one slice fills whole nodes; got gpu_count={gpu_count}"
             )
-        if num_tasks % slice_size != 0:
+        try:
+            slice_size = balanced_rack_slice_size(num_tasks)
+        except ValueError as e:
             raise PodManifestError(
-                f"Coscheduled task {task_ref!r} uses sliced level {group_by!r}: num_tasks={num_tasks} must be a whole "
-                f"number of {slice_size}-node rack slices. Round to a multiple of {slice_size}, or set "
+                f"Coscheduled task {task_ref!r} on sliced level {group_by!r}: {e}. Round the gang size, or set "
                 f"group_by={COSCHEDULE_NVLINK_DOMAIN_PREFERRED!r} for loose (unbalanced) packing."
-            )
+            ) from e
         annotations = {_KUEUE_SLICE_REQUIRED_TOPOLOGY: node_label, _KUEUE_SLICE_SIZE: str(slice_size)}
         if binding.coarse_preferred_label:
             annotations[_KUEUE_PREFERRED_TOPOLOGY] = binding.coarse_preferred_label

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -49,9 +49,14 @@ from iris.cluster.platforms.k8s.coreweave_topology import (
     COSCHEDULE_LEAFGROUP,
     COSCHEDULE_NVLINK_DOMAIN,
     COSCHEDULE_NVLINK_DOMAIN_PREFERRED,
+    COSCHEDULE_NVLINK_DOMAIN_SLICED,
     CW_LABEL_LEAFGROUP,
     CW_LABEL_NVLINK_DOMAIN,
+    NVL72_GPUS_PER_NODE,
     RACK_SIZE,
+    SCHEDULABLE_RACK_NODES,
+    KueueTopologyBinding,
+    TopologyMode,
 )
 from iris.cluster.platforms.k8s.service import K8sService
 from iris.cluster.platforms.k8s.types import (
@@ -179,10 +184,15 @@ _KUEUE_QUEUE_NAME = "kueue.x-k8s.io/queue-name"
 _KUEUE_PRIORITY_CLASS = "kueue.x-k8s.io/priority-class"
 _KUEUE_REQUIRED_TOPOLOGY = "kueue.x-k8s.io/podset-required-topology"
 _KUEUE_PREFERRED_TOPOLOGY = "kueue.x-k8s.io/podset-preferred-topology"
+# PodSet-slice request: partition the pod group into podset-slice-size chunks, each hard-bound
+# to one domain of the named level. Kueue >= 0.13 (feature under TopologyAwareScheduling).
+_KUEUE_SLICE_REQUIRED_TOPOLOGY = "kueue.x-k8s.io/podset-slice-required-topology"
+_KUEUE_SLICE_SIZE = "kueue.x-k8s.io/podset-slice-size"
 # Per-pod ordinal within the gang. Kueue's TAS plain-pod-group path uses it to
 # assign each pod a topology domain rank; basic gang admission does not need it,
-# but stamping it is harmless and required once a podset-topology annotation is
-# present. Sourced from the task ordinal (JobName.task_index).
+# but stamping it is required for slice membership to be rank-contiguous (slice k = pod indices
+# [k*size, (k+1)*size)); without it the ungater assigns domains arbitrarily. Sourced from the
+# task ordinal (JobName.task_index).
 _KUEUE_POD_GROUP_POD_INDEX = "kueue.x-k8s.io/pod-group-pod-index"
 # Pod finalizer Kueue's webhook stamps on admitted gang pods. Kueue only
 # strips it for pods it considers accounted for; on teardown Iris removes it
@@ -190,26 +200,31 @@ _KUEUE_POD_GROUP_POD_INDEX = "kueue.x-k8s.io/pod-group-pod-index"
 # pod-group Workload (Kueue rebuilds it from surviving labeled pods).
 _KUEUE_MANAGED_FINALIZER = "kueue.x-k8s.io/managed"
 
-# CoreWeave-convention fallback for KueueConfig.topologies: group_by -> (node
-# label, required?). Used only when the cluster config leaves topologies unset.
-# group_by names the ACTUAL topology level the gang runs against (a convention,
-# not a portable abstraction — CoreWeave names leak by design). The keys are the
-# levels in CoreWeave's Kueue Topology CRs (see scripts/install_kueue.py):
+# CoreWeave-convention fallback for KueueConfig.topologies: group_by -> KueueTopologyBinding.
+# Used only when the cluster config leaves topologies unset. group_by names the ACTUAL topology
+# level the gang runs against (a convention, not a portable abstraction — CoreWeave names leak
+# by design). The keys are the levels in CoreWeave's Kueue Topology CRs (see
+# scripts/install_kueue.py):
 #   leafgroup     soft (preferred): multi-node IB colocation on one leaf group
 #                 (H100 InfiniBand deployments).
 #   nvlink.domain hard (required): one GB200 NVLink domain (H100 has no
 #                 nvlink.domain label, so this only binds on GB200 capacity).
-#   nvlink.domain.preferred  soft (preferred) on the SAME nvlink.domain label: a GB200 gang
-#                 too large for one rack, so Kueue packs it into as few whole NVLink domains
-#                 as possible instead of demanding a single (impossible) domain.
+#   nvlink.domain.preferred  soft (preferred) on the SAME nvlink.domain label: pack into as few
+#                 whole NVLink domains as possible. Reachable only via explicit config/group_by.
+#   nvlink.domain.sliced  PodSet-slice: partition a multi-rack GB200 gang into
+#                 SCHEDULABLE_RACK_NODES-node slices, each hard-bound to its own nvlink.domain,
+#                 with a soft leafgroup preference so the racks cluster on one IB leaf group.
 # A cluster whose Topology uses different levels overrides this via
 # kubernetes_provider.kueue.topologies. Priority classes have NO default: Iris
 # never invents WorkloadPriorityClass names (a missing one is rejected by
 # Kueue), so a band is stamped only when the config maps it explicitly.
-_CW_DEFAULT_TOPOLOGIES: dict[str, tuple[str, bool]] = {
-    COSCHEDULE_LEAFGROUP: (CW_LABEL_LEAFGROUP, False),
-    COSCHEDULE_NVLINK_DOMAIN: (CW_LABEL_NVLINK_DOMAIN, True),
-    COSCHEDULE_NVLINK_DOMAIN_PREFERRED: (CW_LABEL_NVLINK_DOMAIN, False),
+_CW_DEFAULT_TOPOLOGIES: dict[str, KueueTopologyBinding] = {
+    COSCHEDULE_LEAFGROUP: KueueTopologyBinding(CW_LABEL_LEAFGROUP, TopologyMode.PREFERRED),
+    COSCHEDULE_NVLINK_DOMAIN: KueueTopologyBinding(CW_LABEL_NVLINK_DOMAIN, TopologyMode.REQUIRED),
+    COSCHEDULE_NVLINK_DOMAIN_PREFERRED: KueueTopologyBinding(CW_LABEL_NVLINK_DOMAIN, TopologyMode.PREFERRED),
+    COSCHEDULE_NVLINK_DOMAIN_SLICED: KueueTopologyBinding(
+        CW_LABEL_NVLINK_DOMAIN, TopologyMode.SLICE_REQUIRED, SCHEDULABLE_RACK_NODES, CW_LABEL_LEAFGROUP
+    ),
 }
 
 # Finest topology level (one node), the last level in both CoreWeave Topology CRs. The
@@ -411,9 +426,9 @@ class PodConfig:
     # PriorityBand -> WorkloadPriorityClass name. A band with no entry is not
     # stamped (Kueue uses its default priority); Iris never invents class names.
     kueue_priority_classes: dict[int, str] = field(default_factory=dict)
-    # coscheduling group_by -> (node label, required?). Defaults to CoreWeave
+    # coscheduling group_by -> KueueTopologyBinding. Defaults to CoreWeave
     # conventions; a group_by with no entry carries no topology annotation.
-    kueue_topologies: dict[str, tuple[str, bool]] = field(default_factory=lambda: dict(_CW_DEFAULT_TOPOLOGIES))
+    kueue_topologies: dict[str, KueueTopologyBinding] = field(default_factory=lambda: dict(_CW_DEFAULT_TOPOLOGIES))
     # PriorityBand -> Kubernetes PriorityClass name. Sets spec.priorityClassName.
     # UNSPECIFIED is treated as INTERACTIVE. Defaults to the iris-{band} classes
     # Iris creates at startup; override via kubernetes_provider.priority_classes.
@@ -629,6 +644,53 @@ def _security_context(profile: int, has_tpu: bool) -> dict:
     return ctx
 
 
+def _topology_request_annotations(
+    binding: KueueTopologyBinding, *, group_by: str, num_tasks: int, gpu_count: int, task_ref: str
+) -> dict[str, str]:
+    """Kueue topology-request annotations for a coscheduled gang, per the binding's mode.
+
+    PREFERRED/REQUIRED bind the whole gang to one ``node_label`` domain (soft/hard). For a hard
+    nvlink.domain gang that exceeds one rack — which can never be placed and would hang forever —
+    this raises instead (the CLI never emits it; the guard catches a programmatic client).
+    SLICE_REQUIRED partitions the gang into ``slice_size`` rack slices, each hard-bound to one
+    nvlink.domain, and pairs a soft coarse preference so the racks cluster on the IB fabric. The
+    one-slice-per-rack guarantee holds only for node-saturating pods and a slice size that two
+    of cannot fit one rack; both are validated here, along with a whole-number-of-slices count.
+    """
+    node_label = binding.node_label
+    if binding.mode is TopologyMode.SLICE_REQUIRED:
+        slice_size = binding.slice_size
+        if slice_size is None or 2 * slice_size <= RACK_SIZE or slice_size > SCHEDULABLE_RACK_NODES:
+            raise PodManifestError(
+                f"Sliced topology {group_by!r} needs a slice size in ({RACK_SIZE // 2}, {SCHEDULABLE_RACK_NODES}] "
+                f"so two slices cannot share one {RACK_SIZE}-node rack; got {slice_size}."
+            )
+        if gpu_count != NVL72_GPUS_PER_NODE:
+            raise PodManifestError(
+                f"Coscheduled task {task_ref!r} uses sliced level {group_by!r}, which requires node-saturating "
+                f"NVL72 pods ({NVL72_GPUS_PER_NODE} GPUs each) so one slice fills whole nodes; got gpu_count={gpu_count}"
+            )
+        if num_tasks % slice_size != 0:
+            raise PodManifestError(
+                f"Coscheduled task {task_ref!r} uses sliced level {group_by!r}: num_tasks={num_tasks} must be a whole "
+                f"number of {slice_size}-node rack slices. Round to a multiple of {slice_size}, or set "
+                f"group_by={COSCHEDULE_NVLINK_DOMAIN_PREFERRED!r} for loose (unbalanced) packing."
+            )
+        annotations = {_KUEUE_SLICE_REQUIRED_TOPOLOGY: node_label, _KUEUE_SLICE_SIZE: str(slice_size)}
+        if binding.coarse_preferred_label:
+            annotations[_KUEUE_PREFERRED_TOPOLOGY] = binding.coarse_preferred_label
+        return annotations
+    if binding.mode is TopologyMode.REQUIRED:
+        if node_label == CW_LABEL_NVLINK_DOMAIN and num_tasks > RACK_SIZE:
+            raise PodManifestError(
+                f"Coscheduled task {task_ref!r} requires a single {group_by!r} domain but num_tasks={num_tasks} "
+                f"exceeds the NVLink domain size ({RACK_SIZE} nodes, one NVL72 rack). A hard NVLink-domain gang "
+                f"cannot cross racks; request <= {RACK_SIZE} replicas or coschedule on a coarser level (e.g. leafgroup)."
+            )
+        return {_KUEUE_REQUIRED_TOPOLOGY: node_label}
+    return {_KUEUE_PREFERRED_TOPOLOGY: node_label}
+
+
 def _build_pod_manifest(
     run_req: job_pb2.RunTaskRequest,
     config: PodConfig,
@@ -785,26 +847,14 @@ def _build_pod_manifest(
                 "kubernetes_provider.kueue.topologies or use a known level."
             )
         labels[_KUEUE_POD_GROUP_NAME] = _pod_group_name(task_id, attempt_id)
-        # Per-pod ordinal within the gang (0..total-1) for Kueue TAS rank assignment.
+        # Per-pod ordinal within the gang (0..total-1). Kueue's TAS assigns each pod a domain
+        # rank from it; for the sliced level it makes slice membership rank-contiguous.
         labels[_KUEUE_POD_GROUP_POD_INDEX] = str(task_id.task_index)
-        node_label, required = topo
-        # A hard single-NVLink-domain gang cannot span racks: one NVL72 rack is one NVLink
-        # domain of RACK_SIZE nodes, so a required nvlink.domain gang larger than that can
-        # never be placed and would sit unschedulable forever. Reject it at build time with a
-        # clear message instead. The CLI never emits this — a multi-rack GB200 gang gets the
-        # soft nvlink.domain.preferred level — so this guards a programmatic client that stamps
-        # the hard nvlink.domain level directly for more than one rack.
-        if required and node_label == CW_LABEL_NVLINK_DOMAIN and run_req.num_tasks > RACK_SIZE:
-            raise PodManifestError(
-                f"Coscheduled task {run_req.task_id!r} requires a single {group_by!r} domain but "
-                f"num_tasks={run_req.num_tasks} exceeds the NVLink domain size ({RACK_SIZE} nodes, "
-                "one NVL72 rack). A hard NVLink-domain gang cannot cross racks; request "
-                f"<= {RACK_SIZE} replicas or coschedule on a coarser level (e.g. leafgroup)."
-            )
-        anno_key = _KUEUE_REQUIRED_TOPOLOGY if required else _KUEUE_PREFERRED_TOPOLOGY
         metadata["annotations"] = {
             _KUEUE_POD_GROUP_TOTAL: str(run_req.num_tasks),
-            anno_key: node_label,
+            **_topology_request_annotations(
+                topo, group_by=group_by, num_tasks=run_req.num_tasks, gpu_count=gpu_count, task_ref=run_req.task_id
+            ),
         }
     elif gpu_count > 0:
         # A non-coscheduled GPU pod still lands on the topology-aware cw-ib flavor, which
@@ -1541,7 +1591,7 @@ class K8sTaskProvider:
     env_secret_name: str = ""
     local_queue: str = ""
     kueue_priority_classes: dict[int, str] = field(default_factory=dict)
-    kueue_topologies: dict[str, tuple[str, bool]] = field(default_factory=lambda: dict(_CW_DEFAULT_TOPOLOGIES))
+    kueue_topologies: dict[str, KueueTopologyBinding] = field(default_factory=lambda: dict(_CW_DEFAULT_TOPOLOGIES))
     priority_class_names: dict[int, str] = field(default_factory=lambda: dict(_DEFAULT_PRIORITY_CLASS_NAMES))
     # Namespaces whose preemptible (negative-priority) GPU pods Iris evicts
     # when it has gang work for Kueue. Empty disables the feature; see

--- a/lib/iris/src/iris/cluster/composer.py
+++ b/lib/iris/src/iris/cluster/composer.py
@@ -38,6 +38,7 @@ from iris.cluster.controller.reconcile.loader import TransitionReader
 from iris.cluster.controller.transition_reader import DbTransitionReader
 from iris.cluster.inject_env import TASK_ENV_SECRET_NAME, projects_task_env_secret
 from iris.cluster.platforms.factory import ProviderBundle, create_provider_bundle
+from iris.cluster.platforms.k8s.coreweave_topology import KueueTopologyBinding
 from iris.cluster.platforms.k8s.service import CloudK8sService
 from iris.cluster.platforms.types import local_queue_name
 from iris.rpc import job_pb2
@@ -111,7 +112,12 @@ def make_task_backend(
             pod_priority_classes[band] = pc_name
 
         # Empty topologies falls back to the CoreWeave-convention defaults.
-        topologies = {group_by: (topo.node_label, topo.required) for group_by, topo in kp.kueue.topologies.items()}
+        topologies = {
+            group_by: KueueTopologyBinding(
+                topo.node_label, topo.mode, topo.slice_size, topo.coarse_preferred_label or None
+            )
+            for group_by, topo in kp.kueue.topologies.items()
+        }
         # The LocalQueue name is derived from label_prefix, not configured; Kueue is
         # mandatory (checked above), so it is always set.
         local_queue = local_queue_name(label_prefix)

--- a/lib/iris/src/iris/cluster/composer.py
+++ b/lib/iris/src/iris/cluster/composer.py
@@ -113,9 +113,7 @@ def make_task_backend(
 
         # Empty topologies falls back to the CoreWeave-convention defaults.
         topologies = {
-            group_by: KueueTopologyBinding(
-                topo.node_label, topo.mode, topo.slice_size, topo.coarse_preferred_label or None
-            )
+            group_by: KueueTopologyBinding(topo.node_label, topo.mode, topo.coarse_preferred_label or None)
             for group_by, topo in kp.kueue.topologies.items()
         }
         # The LocalQueue name is derived from label_prefix, not configured; Kueue is

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -595,7 +595,6 @@ class WorkerProviderConfig(_Config):
 class KueueTopology(_Config):
     node_label: str = ""
     mode: TopologyMode = TopologyMode.PREFERRED  # preferred (soft) / required (hard) / slice
-    slice_size: int | None = None  # pods per rack slice; required iff mode is SLICE_REQUIRED
     coarse_preferred_label: str = ""  # optional soft coarse pairing for a sliced binding
 
 

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -31,6 +31,7 @@ from rigging.filesystem import StoragePath
 from rigging.secrets import as_secret_spec, is_secret_reference, resolve_secret_spec
 from rigging.timing import Duration
 
+from iris.cluster.platforms.k8s.coreweave_topology import TopologyMode
 from iris.cluster.tpu_topology import TPU_FAMILY_VARIANT_PREFIX, get_tpu_topology, tpu_variant_name
 from iris.cluster.types import (
     AUTO_DEVICE_VARIANT,
@@ -593,7 +594,9 @@ class WorkerProviderConfig(_Config):
 
 class KueueTopology(_Config):
     node_label: str = ""
-    required: bool = False  # True => required-topology (hard); False => preferred
+    mode: TopologyMode = TopologyMode.PREFERRED  # preferred (soft) / required (hard) / slice
+    slice_size: int | None = None  # pods per rack slice; required iff mode is SLICE_REQUIRED
+    coarse_preferred_label: str = ""  # optional soft coarse pairing for a sliced binding
 
 
 class KueueConfig(_Config):

--- a/lib/iris/src/iris/cluster/platforms/k8s/coreweave_topology.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/coreweave_topology.py
@@ -116,26 +116,32 @@ class KueueTopologyBinding:
     coarse_preferred_label: str | None = None
 
 
-def balanced_rack_slice_size(num_tasks: int, cap: int = SCHEDULABLE_RACK_NODES) -> int:
+def balanced_rack_slice_size(num_tasks: int) -> int:
     """Nodes per rack slice for a multi-rack NVL72 gang, balanced across the fewest racks.
 
-    Places the gang on ``ceil(num_tasks / cap)`` NVLink domains — the fewest that hold at most
-    ``cap`` nodes each — and splits it evenly, so every rack runs the same node count. Returns
-    that per-rack size (also Kueue's ``podset-slice-size``). Raises ``ValueError`` when the gang
-    cannot split into equal slices that each exceed half a rack, the condition under which two
-    slices could share one rack and the one-slice-per-rack guarantee would break.
+    Places the gang on ``ceil(num_tasks / SCHEDULABLE_RACK_NODES)`` NVLink domains — the fewest
+    that hold at most ``SCHEDULABLE_RACK_NODES`` nodes each — and splits it evenly, so every rack
+    runs the same node count. Returns that per-rack size (also Kueue's ``podset-slice-size``).
+    Raises ``ValueError`` when the gang cannot split into equal slices that each exceed half a
+    rack, the condition under which two slices could share one rack and the one-slice-per-rack
+    guarantee would break.
     """
-    num_racks = -(-num_tasks // cap)  # ceil
+    if num_tasks <= 0:
+        raise ValueError(f"gang size must be positive, got {num_tasks}")
+    num_racks = -(-num_tasks // SCHEDULABLE_RACK_NODES)  # ceil
+    min_rack_slice = RACK_SIZE // 2 + 1  # more than half a rack, so two slices can't share one
     if num_tasks % num_racks:
         raise ValueError(
-            f"{num_tasks} nodes do not divide evenly across {num_racks} racks (<= {cap} nodes each); "
-            f"use a gang size that is a multiple of {num_racks}"
+            f"{num_tasks} nodes do not divide evenly across {num_racks} racks "
+            f"(<= {SCHEDULABLE_RACK_NODES} nodes each); a multi-rack NVL72 gang must split into equal "
+            f"{min_rack_slice}-{SCHEDULABLE_RACK_NODES} node rack slices (e.g. 20, 24, 32, 48)"
         )
     slice_size = num_tasks // num_racks
-    if 2 * slice_size <= RACK_SIZE:
+    if slice_size < min_rack_slice:
         raise ValueError(
-            f"{num_tasks} nodes would place {num_racks} racks of {slice_size}, but two {slice_size}-node "
-            f"slices fit one {RACK_SIZE}-node rack, breaking one-slice-per-rack; use a larger gang"
+            f"{num_tasks} nodes would place {num_racks} racks of {slice_size}, but a rack slice must "
+            f"exceed half a rack ({min_rack_slice}+ of {RACK_SIZE} nodes) to keep one slice per rack; "
+            f"use a larger gang (e.g. 20, 24, 32, 48)"
         )
     return slice_size
 

--- a/lib/iris/src/iris/cluster/platforms/k8s/coreweave_topology.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/coreweave_topology.py
@@ -80,10 +80,11 @@ COSCHEDULE_NVLINK_DOMAIN = "nvlink.domain"
 # gang spills across racks over InfiniBand. Reachable only via explicit config/group_by; the
 # CLI routes multi-rack GB200 to the sliced level below instead.
 COSCHEDULE_NVLINK_DOMAIN_PREFERRED = "nvlink.domain.preferred"
-# Multi-rack GB200: partition the gang into whole-rack slices, each slice hard-bound to one
-# nvlink.domain (Kueue's PodSet-slice feature). With slice size SCHEDULABLE_RACK_NODES and
-# 2*size > RACK_SIZE, two slices cannot share a rack, so the gang lands as an exact N racks x
-# SCHEDULABLE_RACK_NODES balanced layout instead of the unbalanced fill preferred would give.
+# Multi-rack GB200: partition the gang into per-rack slices, each slice hard-bound to one
+# nvlink.domain (Kueue's PodSet-slice feature). The slice size is computed per gang to spread it
+# evenly over the fewest racks (see balanced_rack_slice_size); because two slices exceed a rack,
+# each lands on its own nvlink.domain, giving an exact balanced layout instead of the unbalanced
+# fill preferred would give.
 COSCHEDULE_NVLINK_DOMAIN_SLICED = "nvlink.domain.sliced"
 
 
@@ -91,8 +92,8 @@ class TopologyMode(StrEnum):
     """How a coscheduling level's node label constrains Kueue placement.
 
     PREFERRED/REQUIRED bind the whole PodSet to one domain of the label as a soft hint or a
-    hard requirement. SLICE_REQUIRED instead partitions the PodSet into ``slice_size`` chunks
-    and hard-binds each chunk to one domain of the label (Kueue's PodSet-slice feature).
+    hard requirement. SLICE_REQUIRED instead partitions the PodSet into balanced per-rack slices
+    and hard-binds each slice to one domain of the label (Kueue's PodSet-slice feature).
     """
 
     PREFERRED = "preferred"
@@ -104,16 +105,39 @@ class TopologyMode(StrEnum):
 class KueueTopologyBinding:
     """The Kueue topology request a coscheduling ``group_by`` level maps to.
 
-    ``node_label`` is the Topology-CR level the constraint binds. For SLICE_REQUIRED,
-    ``slice_size`` is the pods-per-slice (each slice hard-bound to one ``node_label`` domain)
-    and ``coarse_preferred_label`` optionally adds a soft whole-PodSet preference at a coarser
-    level, so the slices also cluster near each other on the IB fabric.
+    ``node_label`` is the Topology-CR level the constraint binds. ``coarse_preferred_label``
+    optionally adds a soft whole-PodSet preference at a coarser level (used by SLICE_REQUIRED so
+    the per-rack slices also cluster near each other on the IB fabric). The SLICE_REQUIRED slice
+    size is not stored here — it is computed per gang from its node count (balanced_rack_slice_size).
     """
 
     node_label: str
     mode: TopologyMode
-    slice_size: int | None = None
     coarse_preferred_label: str | None = None
+
+
+def balanced_rack_slice_size(num_tasks: int, cap: int = SCHEDULABLE_RACK_NODES) -> int:
+    """Nodes per rack slice for a multi-rack NVL72 gang, balanced across the fewest racks.
+
+    Places the gang on ``ceil(num_tasks / cap)`` NVLink domains — the fewest that hold at most
+    ``cap`` nodes each — and splits it evenly, so every rack runs the same node count. Returns
+    that per-rack size (also Kueue's ``podset-slice-size``). Raises ``ValueError`` when the gang
+    cannot split into equal slices that each exceed half a rack, the condition under which two
+    slices could share one rack and the one-slice-per-rack guarantee would break.
+    """
+    num_racks = -(-num_tasks // cap)  # ceil
+    if num_tasks % num_racks:
+        raise ValueError(
+            f"{num_tasks} nodes do not divide evenly across {num_racks} racks (<= {cap} nodes each); "
+            f"use a gang size that is a multiple of {num_racks}"
+        )
+    slice_size = num_tasks // num_racks
+    if 2 * slice_size <= RACK_SIZE:
+        raise ValueError(
+            f"{num_tasks} nodes would place {num_racks} racks of {slice_size}, but two {slice_size}-node "
+            f"slices fit one {RACK_SIZE}-node rack, breaking one-slice-per-rack; use a larger gang"
+        )
+    return slice_size
 
 
 def gpu_gang_coscheduling_level(gpu_variant: str, replicas: int) -> str:

--- a/lib/iris/src/iris/cluster/platforms/k8s/coreweave_topology.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/coreweave_topology.py
@@ -37,10 +37,19 @@ CW_LABEL_NVLINK_DOMAIN = "ds.coreweave.com/nvlink.domain"
 # declared by rack count (spec.targetRacks) and do NOT autoscale — CoreWeave rejects both a
 # partial rack and the autoscaler on rack-based instances. Every other instance type is
 # node-based (spec.targetNodes + autoscaling). See docs.coreweave.com nvl72 instance docs.
-# One NVL72 rack is also exactly one NVLink domain (RACK_SIZE nodes share the rack's NVLink
-# switch), so RACK_SIZE doubles as the hard upper bound on a single-nvlink.domain gang.
+# One NVL72 rack is also exactly one NVLink domain: RACK_SIZE nodes share the rack's NVLink
+# switch, so RACK_SIZE is the physical size of a single nvlink.domain and the unit racks are
+# provisioned in.
 RACK_SIZE = 18
 NVL72_INSTANCE_PREFIXES = ("gb200", "gb300")
+
+# CoreWeave keeps only this many of a rack's RACK_SIZE nodes schedulable at once; the rest
+# absorb host failures and maintenance. A hard single-nvlink.domain gang can therefore only be
+# guaranteed placement up to this size. A larger gang would need every node in one rack healthy
+# at the same moment, so binding it hard could leave it unschedulable indefinitely — above this
+# size a gang binds the nvlink.domain label softly instead. This is the hard upper bound on a
+# single-nvlink.domain gang, distinct from the physical RACK_SIZE.
+SCHEDULABLE_RACK_NODES = 16
 
 
 def is_rack_based(instance_type: str) -> bool:
@@ -66,19 +75,20 @@ def gpu_gang_coscheduling_level(gpu_variant: str, replicas: int) -> str:
     """The Kueue topology level a multi-node GPU gang of ``replicas`` nodes should bind to.
 
     NVL72 (GB200/GB300) nodes carry ``ds.coreweave.com/nvlink.domain`` and one rack is a
-    single NVLink domain of ``RACK_SIZE`` nodes. A gang that fits inside one rack binds HARD
-    to ``nvlink.domain`` (``podset-required-topology``) so every replica shares the rack's
-    NVLink fabric — the reason NVL72 exists. A gang larger than one rack cannot fit a single
-    NVLink domain (NVLink does not cross racks), so it binds SOFT to the same level
-    (``nvlink.domain.preferred`` -> ``podset-preferred-topology``): Kueue packs the replicas
-    into as few whole NVLink domains as possible, keeping NVLink within each rack while the
-    gang spills across racks over InfiniBand.
+    single NVLink domain of ``RACK_SIZE`` nodes, of which CoreWeave keeps only
+    ``SCHEDULABLE_RACK_NODES`` schedulable at once. A gang that fits the guaranteed-schedulable
+    slice of one rack binds HARD to ``nvlink.domain`` (``podset-required-topology``) so every
+    replica shares the rack's NVLink fabric — the reason NVL72 exists. A larger gang binds SOFT
+    to the same level (``nvlink.domain.preferred`` -> ``podset-preferred-topology``): Kueue
+    packs the replicas into as few whole NVLink domains as possible, keeping NVLink within each
+    rack while the gang spills across racks over InfiniBand. Binding a larger gang hard would
+    demand a fully healthy rack and could leave it unschedulable whenever a rack is down a node.
 
     H100 and every non-NVL72 GPU carry no ``nvlink.domain`` label, so they always coschedule
     on ``leafgroup`` (soft IB colocation), which is the behavior this preserves for them.
     """
     if is_rack_based(gpu_variant):
-        if replicas <= RACK_SIZE:
+        if replicas <= SCHEDULABLE_RACK_NODES:
             return COSCHEDULE_NVLINK_DOMAIN
         return COSCHEDULE_NVLINK_DOMAIN_PREFERRED
     return COSCHEDULE_LEAFGROUP

--- a/lib/iris/src/iris/cluster/platforms/k8s/coreweave_topology.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/coreweave_topology.py
@@ -5,7 +5,7 @@
 
 These keys are the levels in CoreWeave's Kueue Topology CRs and the node
 selectors that three sites must agree on: the K8s task provider stamps
-``podset-{required,preferred}-topology`` annotations naming them
+``podset-{required,preferred,slice-required}-topology`` annotations naming them
 (``providers/k8s/tasks.py``), the install script declares them as Topology
 levels + ResourceFlavor selectors (``scripts/install_kueue.py``), and the kind
 smoke stamps them onto synthetic nodes so TAS resolves the same layout it would
@@ -15,6 +15,9 @@ those three sites cannot drift.
 Names leak CoreWeave conventions by design: ``group_by`` reflects the actual
 topology the gang runs against, it is not a portable abstraction.
 """
+
+from dataclasses import dataclass
+from enum import StrEnum
 
 # InfiniBand fabric hierarchy, coarse -> fine. A leafgroup is one IB
 # leaf-switch group (soft/preferred multi-node colocation); superpod and fabric
@@ -43,6 +46,13 @@ CW_LABEL_NVLINK_DOMAIN = "ds.coreweave.com/nvlink.domain"
 RACK_SIZE = 18
 NVL72_INSTANCE_PREFIXES = ("gb200", "gb300")
 
+# GPUs on one NVL72 compute tray (gb200-4x / gb300-4x). A gang whose pods each request this
+# many GPUs is node-saturating: one pod per node, so pod count == node count and the rack-slice
+# capacity arithmetic (a 16-pod slice fills 16 whole nodes) holds. A sub-node NVL72 pod would
+# let multiple slices share a rack, silently voiding one-slice-per-rack; the sliced level
+# rejects it.
+NVL72_GPUS_PER_NODE = 4
+
 # CoreWeave keeps only this many of a rack's RACK_SIZE nodes schedulable at once; the rest
 # absorb host failures and maintenance. A hard single-nvlink.domain gang can therefore only be
 # guaranteed placement up to this size. A larger gang would need every node in one rack healthy
@@ -67,8 +77,43 @@ COSCHEDULE_NVLINK_DOMAIN = "nvlink.domain"
 # Soft variant that binds the SAME nvlink.domain label as a preference rather than a hard
 # requirement, for a GB200 gang too large to fit one rack. Kueue packs the replicas into as
 # few whole NVLink domains (racks) as possible, so GPUs within a rack keep NVLink while the
-# gang spills across racks over InfiniBand.
+# gang spills across racks over InfiniBand. Reachable only via explicit config/group_by; the
+# CLI routes multi-rack GB200 to the sliced level below instead.
 COSCHEDULE_NVLINK_DOMAIN_PREFERRED = "nvlink.domain.preferred"
+# Multi-rack GB200: partition the gang into whole-rack slices, each slice hard-bound to one
+# nvlink.domain (Kueue's PodSet-slice feature). With slice size SCHEDULABLE_RACK_NODES and
+# 2*size > RACK_SIZE, two slices cannot share a rack, so the gang lands as an exact N racks x
+# SCHEDULABLE_RACK_NODES balanced layout instead of the unbalanced fill preferred would give.
+COSCHEDULE_NVLINK_DOMAIN_SLICED = "nvlink.domain.sliced"
+
+
+class TopologyMode(StrEnum):
+    """How a coscheduling level's node label constrains Kueue placement.
+
+    PREFERRED/REQUIRED bind the whole PodSet to one domain of the label as a soft hint or a
+    hard requirement. SLICE_REQUIRED instead partitions the PodSet into ``slice_size`` chunks
+    and hard-binds each chunk to one domain of the label (Kueue's PodSet-slice feature).
+    """
+
+    PREFERRED = "preferred"
+    REQUIRED = "required"
+    SLICE_REQUIRED = "slice"
+
+
+@dataclass(frozen=True)
+class KueueTopologyBinding:
+    """The Kueue topology request a coscheduling ``group_by`` level maps to.
+
+    ``node_label`` is the Topology-CR level the constraint binds. For SLICE_REQUIRED,
+    ``slice_size`` is the pods-per-slice (each slice hard-bound to one ``node_label`` domain)
+    and ``coarse_preferred_label`` optionally adds a soft whole-PodSet preference at a coarser
+    level, so the slices also cluster near each other on the IB fabric.
+    """
+
+    node_label: str
+    mode: TopologyMode
+    slice_size: int | None = None
+    coarse_preferred_label: str | None = None
 
 
 def gpu_gang_coscheduling_level(gpu_variant: str, replicas: int) -> str:
@@ -78,11 +123,13 @@ def gpu_gang_coscheduling_level(gpu_variant: str, replicas: int) -> str:
     single NVLink domain of ``RACK_SIZE`` nodes, of which CoreWeave keeps only
     ``SCHEDULABLE_RACK_NODES`` schedulable at once. A gang that fits the guaranteed-schedulable
     slice of one rack binds HARD to ``nvlink.domain`` (``podset-required-topology``) so every
-    replica shares the rack's NVLink fabric — the reason NVL72 exists. A larger gang binds SOFT
-    to the same level (``nvlink.domain.preferred`` -> ``podset-preferred-topology``): Kueue
-    packs the replicas into as few whole NVLink domains as possible, keeping NVLink within each
-    rack while the gang spills across racks over InfiniBand. Binding a larger gang hard would
-    demand a fully healthy rack and could leave it unschedulable whenever a rack is down a node.
+    replica shares the rack's NVLink fabric — the reason NVL72 exists. Binding a rack-sized gang
+    hard would demand a fully healthy rack and could leave it unschedulable whenever a rack is
+    down a node, so that is the largest hard single-domain gang.
+
+    A larger gang binds to ``nvlink.domain.sliced``: the gang is partitioned into
+    ``SCHEDULABLE_RACK_NODES``-node slices, each hard-bound to its own nvlink.domain, so it lands
+    as an exact N racks x SCHEDULABLE_RACK_NODES balanced layout (see ``COSCHEDULE_NVLINK_DOMAIN_SLICED``).
 
     H100 and every non-NVL72 GPU carry no ``nvlink.domain`` label, so they always coschedule
     on ``leafgroup`` (soft IB colocation), which is the behavior this preserves for them.
@@ -90,5 +137,5 @@ def gpu_gang_coscheduling_level(gpu_variant: str, replicas: int) -> str:
     if is_rack_based(gpu_variant):
         if replicas <= SCHEDULABLE_RACK_NODES:
             return COSCHEDULE_NVLINK_DOMAIN
-        return COSCHEDULE_NVLINK_DOMAIN_PREFERRED
+        return COSCHEDULE_NVLINK_DOMAIN_SLICED
     return COSCHEDULE_LEAFGROUP

--- a/lib/iris/tests/cli/test_job_multinode.py
+++ b/lib/iris/tests/cli/test_job_multinode.py
@@ -3,7 +3,7 @@
 
 import pytest
 from iris.cli.job import resolve_multinode_defaults
-from iris.cluster.platforms.k8s.coreweave_topology import gpu_gang_coscheduling_level
+from iris.cluster.platforms.k8s.coreweave_topology import balanced_rack_slice_size, gpu_gang_coscheduling_level
 
 
 @pytest.mark.parametrize(
@@ -54,3 +54,24 @@ def test_resolve_multinode_defaults_gpu(tpu, gpu, replicas, expected_replicas, e
 )
 def test_gpu_gang_coscheduling_level(variant, replicas, expected):
     assert gpu_gang_coscheduling_level(variant, replicas) == expected
+
+
+@pytest.mark.parametrize(
+    "num_tasks,slice_size",
+    [
+        # Spread evenly over the fewest racks (<= 16 nodes each): 24 -> 12+12, 48 -> 16+16+16.
+        (17, None),  # ceil(17/16)=2 racks, does not divide evenly -> rejected
+        (18, None),  # 2 racks of 9, but two 9-node slices fit one 18-node rack -> rejected
+        (20, 10),
+        (24, 12),
+        (32, 16),
+        (48, 16),
+        (64, 16),
+    ],
+)
+def test_balanced_rack_slice_size(num_tasks, slice_size):
+    if slice_size is None:
+        with pytest.raises(ValueError):
+            balanced_rack_slice_size(num_tasks)
+    else:
+        assert balanced_rack_slice_size(num_tasks) == slice_size

--- a/lib/iris/tests/cli/test_job_multinode.py
+++ b/lib/iris/tests/cli/test_job_multinode.py
@@ -3,7 +3,7 @@
 
 import pytest
 from iris.cli.job import resolve_multinode_defaults
-from iris.cluster.platforms.k8s.coreweave_topology import RACK_SIZE, gpu_gang_coscheduling_level
+from iris.cluster.platforms.k8s.coreweave_topology import SCHEDULABLE_RACK_NODES, gpu_gang_coscheduling_level
 
 
 @pytest.mark.parametrize(
@@ -13,12 +13,12 @@ from iris.cluster.platforms.k8s.coreweave_topology import RACK_SIZE, gpu_gang_co
         (None, "H100x8", 2, 2, "leafgroup"),
         (None, "H100x8", 1, 1, None),
         (None, "H100x8", None, 1, None),
-        # GB200 NVL72: a multi-node gang that fits one rack binds hard to nvlink.domain,
-        # a gang larger than a rack binds soft to nvlink.domain.preferred (pack into whole
+        # GB200 NVL72: a gang within the guaranteed-schedulable slice of a rack binds hard to
+        # nvlink.domain, a larger gang binds soft to nvlink.domain.preferred (pack into whole
         # racks), and a single node is not a gang.
         (None, "GB200x4", 2, 2, "nvlink.domain"),
-        (None, "GB200x4", RACK_SIZE, RACK_SIZE, "nvlink.domain"),
-        (None, "GB200x4", RACK_SIZE + 1, RACK_SIZE + 1, "nvlink.domain.preferred"),
+        (None, "GB200x4", SCHEDULABLE_RACK_NODES, SCHEDULABLE_RACK_NODES, "nvlink.domain"),
+        (None, "GB200x4", SCHEDULABLE_RACK_NODES + 1, SCHEDULABLE_RACK_NODES + 1, "nvlink.domain.preferred"),
         (None, "GB200x4", 1, 1, None),
         (None, "GB200", None, 1, None),
         (None, None, 2, 2, None),
@@ -37,12 +37,13 @@ def test_resolve_multinode_defaults_gpu(tpu, gpu, replicas, expected_replicas, e
 @pytest.mark.parametrize(
     "variant,replicas,expected",
     [
-        # NVL72 GPUs: hard nvlink.domain up to one rack, soft nvlink.domain.preferred beyond it.
+        # NVL72 GPUs: hard nvlink.domain up to the guaranteed-schedulable rack slice, soft
+        # nvlink.domain.preferred beyond it (a full rack is not guaranteed all-healthy).
         ("GB200", 2, "nvlink.domain"),
-        ("GB200", RACK_SIZE, "nvlink.domain"),
-        ("GB200", RACK_SIZE + 1, "nvlink.domain.preferred"),
+        ("GB200", SCHEDULABLE_RACK_NODES, "nvlink.domain"),
+        ("GB200", SCHEDULABLE_RACK_NODES + 1, "nvlink.domain.preferred"),
         ("GB300", 4, "nvlink.domain"),
-        ("GB300", RACK_SIZE + 1, "nvlink.domain.preferred"),
+        ("GB300", SCHEDULABLE_RACK_NODES + 1, "nvlink.domain.preferred"),
         # H100 (and any non-NVL72 GPU) has no nvlink.domain label -> always leafgroup.
         ("H100", 2, "leafgroup"),
         ("H100", 64, "leafgroup"),

--- a/lib/iris/tests/cli/test_job_multinode.py
+++ b/lib/iris/tests/cli/test_job_multinode.py
@@ -14,11 +14,11 @@ from iris.cluster.platforms.k8s.coreweave_topology import gpu_gang_coscheduling_
         (None, "H100x8", 1, 1, None),
         (None, "H100x8", None, 1, None),
         # GB200 NVL72: 16 nodes (the guaranteed-schedulable slice of a rack) is the largest
-        # hard nvlink.domain gang; 17 spills to the soft nvlink.domain.preferred level; a
+        # hard single-domain gang; 17 spills to the sliced level (one rack slice per domain); a
         # single node is not a gang.
         (None, "GB200x4", 2, 2, "nvlink.domain"),
         (None, "GB200x4", 16, 16, "nvlink.domain"),
-        (None, "GB200x4", 17, 17, "nvlink.domain.preferred"),
+        (None, "GB200x4", 17, 17, "nvlink.domain.sliced"),
         (None, "GB200x4", 1, 1, None),
         (None, "GB200", None, 1, None),
         (None, None, 2, 2, None),
@@ -38,12 +38,13 @@ def test_resolve_multinode_defaults_gpu(tpu, gpu, replicas, expected_replicas, e
     "variant,replicas,expected",
     [
         # NVL72 GPUs: hard nvlink.domain up to 16 (the guaranteed-schedulable rack slice),
-        # soft nvlink.domain.preferred at 17+ (a full rack is not guaranteed all-healthy).
+        # sliced (rack-sized slices, one per NVLink domain) at 17+ where a single hard domain
+        # is not guaranteed all-healthy.
         ("GB200", 2, "nvlink.domain"),
         ("GB200", 16, "nvlink.domain"),
-        ("GB200", 17, "nvlink.domain.preferred"),
+        ("GB200", 17, "nvlink.domain.sliced"),
         ("GB300", 4, "nvlink.domain"),
-        ("GB300", 17, "nvlink.domain.preferred"),
+        ("GB300", 17, "nvlink.domain.sliced"),
         # H100 (and any non-NVL72 GPU) has no nvlink.domain label -> always leafgroup.
         ("H100", 2, "leafgroup"),
         ("H100", 64, "leafgroup"),

--- a/lib/iris/tests/cli/test_job_multinode.py
+++ b/lib/iris/tests/cli/test_job_multinode.py
@@ -3,7 +3,7 @@
 
 import pytest
 from iris.cli.job import resolve_multinode_defaults
-from iris.cluster.platforms.k8s.coreweave_topology import SCHEDULABLE_RACK_NODES, gpu_gang_coscheduling_level
+from iris.cluster.platforms.k8s.coreweave_topology import gpu_gang_coscheduling_level
 
 
 @pytest.mark.parametrize(
@@ -13,12 +13,12 @@ from iris.cluster.platforms.k8s.coreweave_topology import SCHEDULABLE_RACK_NODES
         (None, "H100x8", 2, 2, "leafgroup"),
         (None, "H100x8", 1, 1, None),
         (None, "H100x8", None, 1, None),
-        # GB200 NVL72: a gang within the guaranteed-schedulable slice of a rack binds hard to
-        # nvlink.domain, a larger gang binds soft to nvlink.domain.preferred (pack into whole
-        # racks), and a single node is not a gang.
+        # GB200 NVL72: 16 nodes (the guaranteed-schedulable slice of a rack) is the largest
+        # hard nvlink.domain gang; 17 spills to the soft nvlink.domain.preferred level; a
+        # single node is not a gang.
         (None, "GB200x4", 2, 2, "nvlink.domain"),
-        (None, "GB200x4", SCHEDULABLE_RACK_NODES, SCHEDULABLE_RACK_NODES, "nvlink.domain"),
-        (None, "GB200x4", SCHEDULABLE_RACK_NODES + 1, SCHEDULABLE_RACK_NODES + 1, "nvlink.domain.preferred"),
+        (None, "GB200x4", 16, 16, "nvlink.domain"),
+        (None, "GB200x4", 17, 17, "nvlink.domain.preferred"),
         (None, "GB200x4", 1, 1, None),
         (None, "GB200", None, 1, None),
         (None, None, 2, 2, None),
@@ -37,13 +37,13 @@ def test_resolve_multinode_defaults_gpu(tpu, gpu, replicas, expected_replicas, e
 @pytest.mark.parametrize(
     "variant,replicas,expected",
     [
-        # NVL72 GPUs: hard nvlink.domain up to the guaranteed-schedulable rack slice, soft
-        # nvlink.domain.preferred beyond it (a full rack is not guaranteed all-healthy).
+        # NVL72 GPUs: hard nvlink.domain up to 16 (the guaranteed-schedulable rack slice),
+        # soft nvlink.domain.preferred at 17+ (a full rack is not guaranteed all-healthy).
         ("GB200", 2, "nvlink.domain"),
-        ("GB200", SCHEDULABLE_RACK_NODES, "nvlink.domain"),
-        ("GB200", SCHEDULABLE_RACK_NODES + 1, "nvlink.domain.preferred"),
+        ("GB200", 16, "nvlink.domain"),
+        ("GB200", 17, "nvlink.domain.preferred"),
         ("GB300", 4, "nvlink.domain"),
-        ("GB300", SCHEDULABLE_RACK_NODES + 1, "nvlink.domain.preferred"),
+        ("GB300", 17, "nvlink.domain.preferred"),
         # H100 (and any non-NVL72 GPU) has no nvlink.domain label -> always leafgroup.
         ("H100", 2, "leafgroup"),
         ("H100", 64, "leafgroup"),

--- a/lib/iris/tests/cli/test_job_multinode.py
+++ b/lib/iris/tests/cli/test_job_multinode.py
@@ -1,6 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import click
 import pytest
 from iris.cli.job import resolve_multinode_defaults
 from iris.cluster.platforms.k8s.coreweave_topology import balanced_rack_slice_size, gpu_gang_coscheduling_level
@@ -14,11 +15,11 @@ from iris.cluster.platforms.k8s.coreweave_topology import balanced_rack_slice_si
         (None, "H100x8", 1, 1, None),
         (None, "H100x8", None, 1, None),
         # GB200 NVL72: 16 nodes (the guaranteed-schedulable slice of a rack) is the largest
-        # hard single-domain gang; 17 spills to the sliced level (one rack slice per domain); a
-        # single node is not a gang.
+        # hard single-domain gang; a valid multi-rack size spills to the sliced level (one rack
+        # slice per domain); a single node is not a gang.
         (None, "GB200x4", 2, 2, "nvlink.domain"),
         (None, "GB200x4", 16, 16, "nvlink.domain"),
-        (None, "GB200x4", 17, 17, "nvlink.domain.sliced"),
+        (None, "GB200x4", 32, 32, "nvlink.domain.sliced"),
         (None, "GB200x4", 1, 1, None),
         (None, "GB200", None, 1, None),
         (None, None, 2, 2, None),
@@ -60,8 +61,10 @@ def test_gpu_gang_coscheduling_level(variant, replicas, expected):
     "num_tasks,slice_size",
     [
         # Spread evenly over the fewest racks (<= 16 nodes each): 24 -> 12+12, 48 -> 16+16+16.
+        (0, None),  # non-positive -> rejected (not ZeroDivisionError)
         (17, None),  # ceil(17/16)=2 racks, does not divide evenly -> rejected
         (18, None),  # 2 racks of 9, but two 9-node slices fit one 18-node rack -> rejected
+        (216, None),  # ceil(216/16)=14 racks, 216 % 14 != 0 -> rejected (fewest-racks split only)
         (20, 10),
         (24, 12),
         (32, 16),
@@ -75,3 +78,18 @@ def test_balanced_rack_slice_size(num_tasks, slice_size):
             balanced_rack_slice_size(num_tasks)
     else:
         assert balanced_rack_slice_size(num_tasks) == slice_size
+
+
+@pytest.mark.parametrize(
+    "gpu,replicas",
+    [
+        ("GB200x4", 17),  # sliced level, but 17 does not split evenly across racks
+        ("GB200x4", 18),  # sliced level, but two 9-node slices would share a rack
+        ("GB200", 32),  # sliced size is valid but pods are not node-saturating (1 GPU, not 4)
+    ],
+)
+def test_resolve_multinode_defaults_rejects_bad_sliced_gang(gpu, replicas):
+    """The CLI rejects a knowably-unplaceable multi-rack NVL72 gang at submit rather than letting
+    the controller terminal-fail it after a round-trip."""
+    with pytest.raises(click.UsageError):
+        resolve_multinode_defaults(None, gpu, replicas)

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -15,6 +15,8 @@ from iris.cluster.backends.k8s.tasks import (
     _KUEUE_PRIORITY_CLASS,
     _KUEUE_QUEUE_NAME,
     _KUEUE_REQUIRED_TOPOLOGY,
+    _KUEUE_SLICE_REQUIRED_TOPOLOGY,
+    _KUEUE_SLICE_SIZE,
     _LABEL_JOB_ID,
     _LABEL_TASK_HASH,
     _build_init_container_spec,
@@ -34,7 +36,13 @@ from iris.cluster.backends.k8s.tasks import (
     _task_update_from_pod,
 )
 from iris.cluster.controller.task_state import RunningTaskEntry
-from iris.cluster.platforms.k8s.coreweave_topology import RACK_SIZE
+from iris.cluster.platforms.k8s.coreweave_topology import (
+    NVL72_GPUS_PER_NODE,
+    RACK_SIZE,
+    SCHEDULABLE_RACK_NODES,
+    KueueTopologyBinding,
+    TopologyMode,
+)
 from iris.cluster.platforms.k8s.types import parse_k8s_quantity
 from iris.cluster.types import JobName
 from iris.rpc import job_pb2
@@ -1122,6 +1130,68 @@ def test_kueue_preferred_nvlink_gang_packs_multi_rack():
     assert _KUEUE_REQUIRED_TOPOLOGY not in annotations
 
 
+def _sliced_req(
+    task_id: str, num_tasks: int, *, gpu_count: int = NVL72_GPUS_PER_NODE, group_by: str = "nvlink.domain.sliced"
+):
+    """A coscheduled request on the sliced level with a GB200 GPU device (node-saturating by default)."""
+    req = _cosched_req(task_id, num_tasks=num_tasks, group_by=group_by)
+    req.resources.device.gpu.CopyFrom(job_pb2.GpuDevice(variant="GB200", count=gpu_count))
+    return req
+
+
+def test_kueue_sliced_nvlink_gang_stamps_slice_annotations():
+    """A multi-rack GB200 gang on the sliced level partitions into rack-sized slices: it binds
+    podset-slice-required-topology to nvlink.domain with podset-slice-size = SCHEDULABLE_RACK_NODES,
+    pairs a soft coarse leafgroup preference, and stamps the per-pod index that makes slice
+    membership rank-contiguous. It carries neither the whole-podset required nor a preferred
+    nvlink.domain request."""
+    manifest = _build_pod_manifest(
+        _sliced_req("/job/task/0", num_tasks=2 * SCHEDULABLE_RACK_NODES), pod_config(local_queue="iris-lq")
+    )
+    annotations = manifest["metadata"]["annotations"]
+    assert annotations[_KUEUE_SLICE_REQUIRED_TOPOLOGY] == "ds.coreweave.com/nvlink.domain"
+    assert annotations[_KUEUE_SLICE_SIZE] == str(SCHEDULABLE_RACK_NODES)
+    assert annotations[_KUEUE_PREFERRED_TOPOLOGY] == "backend.coreweave.cloud/leafgroup"
+    assert _KUEUE_REQUIRED_TOPOLOGY not in annotations
+    assert manifest["metadata"]["labels"][_KUEUE_POD_GROUP_POD_INDEX] == "0"
+
+
+def test_kueue_sliced_gang_requires_whole_number_of_slices():
+    """A sliced gang whose size is not a whole number of rack slices can't place as a balanced
+    layout, so it is rejected at build time (Kueue would silently drop the remainder)."""
+    with pytest.raises(ValueError, match="whole number"):
+        _build_pod_manifest(
+            _sliced_req("/job/task/0", num_tasks=2 * SCHEDULABLE_RACK_NODES + 1), pod_config(local_queue="iris-lq")
+        )
+
+
+def test_kueue_sliced_gang_requires_node_saturating_pods():
+    """The one-slice-per-rack guarantee holds only if each pod fills a whole node; a sub-node
+    GB200 pod would let two slices share a rack, so the sliced level rejects it."""
+    with pytest.raises(ValueError, match="node-saturating"):
+        _build_pod_manifest(
+            _sliced_req("/job/task/0", num_tasks=2 * SCHEDULABLE_RACK_NODES, gpu_count=1),
+            pod_config(local_queue="iris-lq"),
+        )
+
+
+def test_kueue_sliced_gang_rejects_slice_size_that_two_fit_one_rack():
+    """A slice size small enough that two slices fit one rack breaks rack exclusivity; a
+    programmatic binding that configures one is rejected."""
+    with pytest.raises(ValueError, match="slice size"):
+        _build_pod_manifest(
+            _sliced_req("/job/task/0", num_tasks=RACK_SIZE // 2 * 2, group_by="sliced-too-small"),
+            pod_config(
+                local_queue="iris-lq",
+                kueue_topologies={
+                    "sliced-too-small": KueueTopologyBinding(
+                        "ds.coreweave.com/nvlink.domain", TopologyMode.SLICE_REQUIRED, RACK_SIZE // 2
+                    )
+                },
+            ),
+        )
+
+
 def test_kueue_preferred_topology_for_leafgroup():
     """group_by=leafgroup -> preferred (soft) leafgroup topology."""
     manifest = _build_pod_manifest(_cosched_req("/job/task/0", group_by="leafgroup"), pod_config(local_queue="iris-lq"))
@@ -1224,7 +1294,10 @@ def test_kueue_topologies_override_config():
     """A configured topologies mapping overrides the CoreWeave defaults for a group_by."""
     manifest = _build_pod_manifest(
         _cosched_req("/job/task/0", group_by="leafgroup"),
-        pod_config(local_queue="iris-lq", kueue_topologies={"leafgroup": ("rack.example.com/pod", True)}),
+        pod_config(
+            local_queue="iris-lq",
+            kueue_topologies={"leafgroup": KueueTopologyBinding("rack.example.com/pod", TopologyMode.REQUIRED)},
+        ),
     )
     annotations = manifest["metadata"]["annotations"]
     assert annotations[_KUEUE_REQUIRED_TOPOLOGY] == "rack.example.com/pod"

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -1090,7 +1090,8 @@ def test_kueue_required_topology_for_nvlink_domain():
 def test_kueue_required_nvlink_gang_rejects_more_than_one_rack():
     """A hard nvlink.domain gang cannot span racks: one NVL72 rack is one NVLink domain of
     RACK_SIZE nodes, so a required gang larger than that is unschedulable and must fail fast
-    (the guard for the programmatic client; the CLI already caps NVLink gangs at RACK_SIZE)."""
+    (the guard for the programmatic client; the CLI degrades hard NVLink gangs to soft below
+    RACK_SIZE, so it never emits one this large)."""
     with pytest.raises(ValueError, match="NVLink domain size"):
         _build_pod_manifest(
             _cosched_req("/job/task/0", num_tasks=RACK_SIZE + 1, group_by="nvlink.domain"),

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -39,6 +39,7 @@ from iris.cluster.controller.task_state import RunningTaskEntry
 from iris.cluster.platforms.k8s.coreweave_topology import (
     NVL72_GPUS_PER_NODE,
     RACK_SIZE,
+    SCHEDULABLE_RACK_NODES,
     KueueTopologyBinding,
     TopologyMode,
 )
@@ -1094,22 +1095,23 @@ def test_kueue_required_topology_for_nvlink_domain():
     assert _KUEUE_PREFERRED_TOPOLOGY not in annotations
 
 
-def test_kueue_required_nvlink_gang_rejects_more_than_one_rack():
-    """A hard nvlink.domain gang cannot span racks: one NVL72 rack is one NVLink domain of
-    RACK_SIZE nodes, so a required gang larger than that is unschedulable and must fail fast
-    (the guard for the programmatic client; the CLI degrades hard NVLink gangs to soft below
-    RACK_SIZE, so it never emits one this large)."""
-    with pytest.raises(ValueError, match="NVLink domain size"):
+def test_kueue_required_nvlink_gang_rejects_above_schedulable_slice():
+    """A hard nvlink.domain gang larger than a rack's guaranteed-schedulable slice can hang
+    whenever the rack is short a node, so it must fail fast (the guard for a programmatic or
+    stale client; the CLI routes 17+ NVL72 replicas to the sliced level, never to a hard gang
+    this large)."""
+    with pytest.raises(ValueError, match="guaranteed-schedulable rack slice"):
         _build_pod_manifest(
-            _cosched_req("/job/task/0", num_tasks=RACK_SIZE + 1, group_by="nvlink.domain"),
+            _cosched_req("/job/task/0", num_tasks=SCHEDULABLE_RACK_NODES + 1, group_by="nvlink.domain"),
             pod_config(local_queue="iris-lq"),
         )
 
 
-def test_kueue_required_nvlink_gang_allows_full_rack():
-    """A hard nvlink.domain gang of exactly one full rack (RACK_SIZE nodes) is valid."""
+def test_kueue_required_nvlink_gang_allows_schedulable_slice():
+    """A hard nvlink.domain gang of exactly the guaranteed-schedulable rack slice
+    (SCHEDULABLE_RACK_NODES nodes) is the largest hard single-domain gang and is valid."""
     manifest = _build_pod_manifest(
-        _cosched_req("/job/task/0", num_tasks=RACK_SIZE, group_by="nvlink.domain"),
+        _cosched_req("/job/task/0", num_tasks=SCHEDULABLE_RACK_NODES, group_by="nvlink.domain"),
         pod_config(local_queue="iris-lq"),
     )
     assert manifest["metadata"]["annotations"][_KUEUE_REQUIRED_TOPOLOGY] == "ds.coreweave.com/nvlink.domain"
@@ -1163,8 +1165,8 @@ def test_kueue_sliced_gang_rejects_uneven_split():
 
 def test_kueue_sliced_gang_rejects_slice_too_small():
     """A gang whose balanced slices would each be <= half a rack (18 -> two 9-node slices) lets
-    two slices share one rack, breaking one-slice-per-rack, so it is rejected."""
-    with pytest.raises(ValueError, match="one-slice-per-rack"):
+    two slices share one rack, breaking one slice per rack, so it is rejected."""
+    with pytest.raises(ValueError, match="must exceed half a rack"):
         _build_pod_manifest(_sliced_req("/job/task/0", num_tasks=18), pod_config(local_queue="iris-lq"))
 
 
@@ -1176,6 +1178,26 @@ def test_kueue_sliced_gang_requires_node_saturating_pods():
             _sliced_req("/job/task/0", num_tasks=32, gpu_count=1),
             pod_config(local_queue="iris-lq"),
         )
+
+
+def test_kueue_sliced_gang_without_coarse_preferred_omits_preferred_annotation():
+    """A sliced binding whose coarse_preferred_label is unset stamps only the slice request, no
+    whole-podset preferred topology."""
+    manifest = _build_pod_manifest(
+        _sliced_req("/job/task/0", num_tasks=32),
+        pod_config(
+            local_queue="iris-lq",
+            kueue_topologies={
+                "nvlink.domain.sliced": KueueTopologyBinding(
+                    "ds.coreweave.com/nvlink.domain", TopologyMode.SLICE_REQUIRED
+                )
+            },
+        ),
+    )
+    annotations = manifest["metadata"]["annotations"]
+    assert annotations[_KUEUE_SLICE_REQUIRED_TOPOLOGY] == "ds.coreweave.com/nvlink.domain"
+    assert annotations[_KUEUE_SLICE_SIZE] == "16"
+    assert _KUEUE_PREFERRED_TOPOLOGY not in annotations
 
 
 def test_kueue_preferred_topology_for_leafgroup():

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -39,7 +39,6 @@ from iris.cluster.controller.task_state import RunningTaskEntry
 from iris.cluster.platforms.k8s.coreweave_topology import (
     NVL72_GPUS_PER_NODE,
     RACK_SIZE,
-    SCHEDULABLE_RACK_NODES,
     KueueTopologyBinding,
     TopologyMode,
 )
@@ -1139,30 +1138,34 @@ def _sliced_req(
     return req
 
 
-def test_kueue_sliced_nvlink_gang_stamps_slice_annotations():
-    """A multi-rack GB200 gang on the sliced level partitions into rack-sized slices: it binds
-    podset-slice-required-topology to nvlink.domain with podset-slice-size = SCHEDULABLE_RACK_NODES,
-    pairs a soft coarse leafgroup preference, and stamps the per-pod index that makes slice
-    membership rank-contiguous. It carries neither the whole-podset required nor a preferred
-    nvlink.domain request."""
-    manifest = _build_pod_manifest(
-        _sliced_req("/job/task/0", num_tasks=2 * SCHEDULABLE_RACK_NODES), pod_config(local_queue="iris-lq")
-    )
+@pytest.mark.parametrize("num_tasks,slice_size", [(24, 12), (32, 16), (48, 16), (20, 10), (64, 16)])
+def test_kueue_sliced_nvlink_gang_stamps_balanced_slice_size(num_tasks, slice_size):
+    """A multi-rack GB200 gang on the sliced level binds podset-slice-required-topology to
+    nvlink.domain with a podset-slice-size that spreads it evenly over the fewest racks (24->12,
+    32->16, 48->16), pairs a soft coarse leafgroup preference, and stamps the per-pod index that
+    makes slice membership rank-contiguous. It carries neither the whole-podset required nor a
+    preferred nvlink.domain request."""
+    manifest = _build_pod_manifest(_sliced_req("/job/task/0", num_tasks=num_tasks), pod_config(local_queue="iris-lq"))
     annotations = manifest["metadata"]["annotations"]
     assert annotations[_KUEUE_SLICE_REQUIRED_TOPOLOGY] == "ds.coreweave.com/nvlink.domain"
-    assert annotations[_KUEUE_SLICE_SIZE] == str(SCHEDULABLE_RACK_NODES)
+    assert annotations[_KUEUE_SLICE_SIZE] == str(slice_size)
     assert annotations[_KUEUE_PREFERRED_TOPOLOGY] == "backend.coreweave.cloud/leafgroup"
     assert _KUEUE_REQUIRED_TOPOLOGY not in annotations
     assert manifest["metadata"]["labels"][_KUEUE_POD_GROUP_POD_INDEX] == "0"
 
 
-def test_kueue_sliced_gang_requires_whole_number_of_slices():
-    """A sliced gang whose size is not a whole number of rack slices can't place as a balanced
-    layout, so it is rejected at build time (Kueue would silently drop the remainder)."""
-    with pytest.raises(ValueError, match="whole number"):
-        _build_pod_manifest(
-            _sliced_req("/job/task/0", num_tasks=2 * SCHEDULABLE_RACK_NODES + 1), pod_config(local_queue="iris-lq")
-        )
+def test_kueue_sliced_gang_rejects_uneven_split():
+    """A sliced gang that cannot split into equal per-rack slices (17 over ceil(17/16)=2 racks)
+    can't place as a balanced layout, so it is rejected at build time."""
+    with pytest.raises(ValueError, match="do not divide evenly"):
+        _build_pod_manifest(_sliced_req("/job/task/0", num_tasks=17), pod_config(local_queue="iris-lq"))
+
+
+def test_kueue_sliced_gang_rejects_slice_too_small():
+    """A gang whose balanced slices would each be <= half a rack (18 -> two 9-node slices) lets
+    two slices share one rack, breaking one-slice-per-rack, so it is rejected."""
+    with pytest.raises(ValueError, match="one-slice-per-rack"):
+        _build_pod_manifest(_sliced_req("/job/task/0", num_tasks=18), pod_config(local_queue="iris-lq"))
 
 
 def test_kueue_sliced_gang_requires_node_saturating_pods():
@@ -1170,25 +1173,8 @@ def test_kueue_sliced_gang_requires_node_saturating_pods():
     GB200 pod would let two slices share a rack, so the sliced level rejects it."""
     with pytest.raises(ValueError, match="node-saturating"):
         _build_pod_manifest(
-            _sliced_req("/job/task/0", num_tasks=2 * SCHEDULABLE_RACK_NODES, gpu_count=1),
+            _sliced_req("/job/task/0", num_tasks=32, gpu_count=1),
             pod_config(local_queue="iris-lq"),
-        )
-
-
-def test_kueue_sliced_gang_rejects_slice_size_that_two_fit_one_rack():
-    """A slice size small enough that two slices fit one rack breaks rack exclusivity; a
-    programmatic binding that configures one is rejected."""
-    with pytest.raises(ValueError, match="slice size"):
-        _build_pod_manifest(
-            _sliced_req("/job/task/0", num_tasks=RACK_SIZE // 2 * 2, group_by="sliced-too-small"),
-            pod_config(
-                local_queue="iris-lq",
-                kueue_topologies={
-                    "sliced-too-small": KueueTopologyBinding(
-                        "ds.coreweave.com/nvlink.domain", TopologyMode.SLICE_REQUIRED, RACK_SIZE // 2
-                    )
-                },
-            ),
         )
 
 

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -88,10 +88,11 @@ def test_sync_apply_error_yields_worker_failed(provider, k8s):
 def test_sync_invalid_manifest_fails_task_terminally(provider, k8s):
     """An unbuildable manifest -> terminal FAILED, not retryable WORKER_FAILED.
 
-    A programmatic client can stamp a required nvlink.domain gang larger than one
-    rack (the CLI caps it, direct RunTaskRequests do not). The manifest can never
-    be built, so retrying would rebuild the same broken request every tick and
-    wedge the reconcile loop. sync must fail the task terminally and keep going.
+    A programmatic client can stamp a required nvlink.domain gang larger than a rack's
+    guaranteed-schedulable slice (the CLI routes those to the sliced level, direct
+    RunTaskRequests do not). The manifest can never be built, so retrying would rebuild the
+    same broken request every tick and wedge the reconcile loop. sync must fail the task
+    terminally and keep going.
     """
     req = make_run_req("/test-job/0", num_tasks=RACK_SIZE + 1, coscheduling_group_by="nvlink.domain")
     batch = make_batch(tasks_to_run=[req])
@@ -100,7 +101,7 @@ def test_sync_invalid_manifest_fails_task_terminally(provider, k8s):
 
     assert len(result) == 1
     assert result[0].new_state == job_pb2.TASK_STATE_FAILED
-    assert "NVLink domain size" in result[0].error
+    assert "guaranteed-schedulable rack slice" in result[0].error
     # Nothing was created, and the tick was not aborted by the escaping error.
     assert k8s.list_json(K8sResource.PODS, labels={_LABEL_MANAGED: "true"}) == []
 

--- a/lib/iris/tests/e2e/gpu_gang_smoke.py
+++ b/lib/iris/tests/e2e/gpu_gang_smoke.py
@@ -318,7 +318,7 @@ class KindTarget(ControllerTarget):
         install_kueue.run_install(
             variant=install_kueue.VARIANT_UPSTREAM,
             kubeconfig=self.kubeconfig,
-            chart_version="0.11.0",
+            chart_version=install_kueue.UPSTREAM_DEFAULT_VERSION,
             with_queues=True,
             cluster_queue=cfg.kubernetes_provider.kueue.cluster_queue,
             flavor_topology=install_kueue.MULTINODE_TOPOLOGY_NAME,


### PR DESCRIPTION
CoreWeave guarantees only 16 of an NVL72 rack's 18 nodes are schedulable at once. This reshapes how iris places GB200 gangs on Kueue, in two steps.

First, cap the hard single-NVLink-domain gang at the guaranteed-schedulable slice: add `SCHEDULABLE_RACK_NODES = 16` and use it (not the physical `RACK_SIZE = 18`) as the hard/soft threshold, at both the CLI (which level a gang gets) and the manifest builder (which terminal-fails a hard `nvlink.domain` gang above 16). A 17–18 node gang bound hard to `nvlink.domain` would demand a fully-healthy rack and could sit unschedulable whenever a rack is down a node.

Second, place multi-rack GB200 gangs as balanced rack slices. The old path used the soft `nvlink.domain.preferred` level, which only hints Kueue to minimize domains and greedily fills each rack to whatever is free (16/18 is a floor, not a cap) — so 128 nodes could land `7×18 + 2`, destroying the per-rack NVLink collective geometry. Route multi-rack gangs to a new `nvlink.domain.sliced` level that stamps Kueue's PodSet-slice annotations (`podset-slice-required-topology: nvlink.domain`, `podset-slice-size: <computed>`). The slice size is computed per gang to spread it evenly over the fewest racks (≤16 nodes each): 24→12+12, 32→16+16, 48→16+16+16. Kueue hard-binds each slice to one NVLink domain; since two slices always exceed a rack (each is more than half of 18) two slices cannot share a rack, so the gang lands as an exact balanced N-rack layout. A soft `leafgroup` preference is paired so the racks also cluster on one IB leaf group.

The three placement modes are now a `TopologyMode` enum + `KueueTopologyBinding` (replacing the `(label, required: bool)` tuple) across the provider, config, and composer. The sliced path validates what Kueue itself does not — node-saturating pods (4 GPUs/node), a whole number of equal rack slices, and a slice size two of which cannot fit one rack — and the CLI rejects a knowably-unplaceable sliced gang (uneven split, sub-half-rack slices, or non-node-saturating pods) at submit with a `UsageError`, rather than deferring to a controller-side terminal failure a round-trip later.

PodSet slices need Kueue ≥ 0.13, and 0.18 carries the `IsTAS()`-recognition fix for slice-only pod groups (upstream #10282); the kind Kueue pin moves 0.11.0 → 0.18.0. The live cluster's Kueue must likewise support slices — on an older Kueue the slice annotations are silently ignored and a multi-rack gang degrades to a soft leafgroup gang with no per-rack NVLink guarantee, so the CW GB200 cluster's Kueue version is verified out of band before this is relied on.

Follow-ups, not in this PR: a post-admission placement audit (count pods per `nvlink.domain`, alert on skew), and a live preemption canary on the CW GB200 cluster before the first production run — TAS/slice preemption has open upstream issues, one filed on GB200 racks.
