### PR TITLE
[experiments] Add grug value-embedding (VE) variant with three-arm ablation

### DIFF
--- a/docs/reports/grug-archive.md
+++ b/docs/reports/grug-archive.md
@@ -23,6 +23,16 @@ This file is the paper trail for grug experiments.
 
 ## Experiments
 
+### grug-ve-value-embeddings
+- Path: `experiments/grug/ve/`
+- Origin: `experiments/grug/base/`
+- Introduced: TBD
+- Last known-good: TBD
+- Status: active
+- Purpose: value embeddings — a layer-shared, token-indexed table blended into the attention
+  value path under a learnable per-layer gate, buying parameters at zero added matmul FLOPs.
+  Paired A/B (`--arm ve` vs `--arm base`) at 130M, confirming at 1.3B, on a single H200.
+
 ### grug-base-template
 - Path: `experiments/grug/base/`
 - Introduced: TBD

--- a/experiments/grug/variants.md
+++ b/experiments/grug/variants.md
@@ -1,3 +1,42 @@
 # Grug Variant Notes
 
 Use this file for variant-specific guidance and examples.
+
+## `ve` — value embeddings
+
+A second token-indexed embedding table, shared across all layers, blended into each layer's
+attention value path under a learnable per-layer gate:
+
+```text
+v = (1 - lambda_i) * v + lambda_i * value_embed[token_ids]
+```
+
+Queries and keys never see the table, so the attention pattern is the base model's exactly; only
+the payload a token delivers when attended to carries the extra signal. The table is read once
+per forward pass and handed to every block, so it costs `vocab_size x kv_width` parameters and
+one embedding lookup — no added matmul FLOPs. Indexing by raw token id rather than by the hidden
+state is the point: the signal never travels the residual stream, so it cannot be degraded by the
+layers in between, which is why it is worth the most where the stream is furthest from token space.
+
+The table is sized to the KV width (`num_kv_heads * head_dim`), not `hidden_dim`. Under grouped-
+query attention those differ, and `v` carries KV heads.
+
+`value_emb_lambda_init` is the only knob: a float turns the gate on at that init, `None` turns the
+whole mechanism off and recovers the base model exactly. The ablation's control arm is therefore
+the same code path with the knob set to `None`, which is what makes the two arms comparable.
+
+Diagnostics to watch: `ve/lambda/layer_<i>` against depth is the model's own report of where a
+token-identity side channel earns its keep, and `throughput/mfu` should be unchanged against the
+control — if it moved, the lookup was not free.
+
+The gates are exempt from weight decay: the launch optimizer decays via an explicit inclusion
+list rather than levanter's default mask, which would decay them. A decayed gate is pulled toward
+zero every step regardless of gradient, so "dialed away" and "nothing opposed the decay" would be
+indistinguishable in the lambda readout.
+
+Do not match parameter counts across the arms. The claim is capacity-per-FLOP, and equalizing
+parameters erases the effect being measured; compare loss at equal FLOPs (equal tokens) instead.
+
+If this is ever ported onto Muon, the table belongs in the optimizer's embedding partition, not
+with the matrices: a lookup table's per-row gradients are sparse, and Muon's orthogonalized update
+assumes the dense statistics of a matmul weight.

--- a/experiments/grug/ve/__init__.py
+++ b/experiments/grug/ve/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/experiments/grug/ve/launch.py
+++ b/experiments/grug/ve/launch.py
@@ -138,38 +138,55 @@ _OPTIMIZER = AdamConfig(
     warmup=1000,
 )
 
+
+@dataclass(frozen=True)
+class _Rung:
+    """One scale point of the ablation: the model and the budget it trains under.
+
+    Batch sizes are sized for one 141GB H200 with the template's per-block activation
+    checkpointing. On smaller devices override with --batch-size: batch 128 at the 130m
+    rung OOMs on a 95GB H100 (the train step allocates ~78GiB). Halving the batch halves
+    the token budget rather than doubling the steps -- all arms of a comparison must share
+    whatever value is used, and the A/B stays valid at any batch size.
+    """
+
+    model: GrugModelConfig
+    batch_size: int
+    steps: int
+
+
 # Two rungs. 130M is the iteration rung -- it turns around fast enough to iterate on, and it is
 # where a speedrun-scale result would show up if it transfers at all. 1.3B is the confirmation
 # rung: the VE table costs a fixed vocab x kv_width, so it shrinks as a fraction of the model as
 # the model grows, and the question worth the GPU-hours is whether the win shrinks with it.
-_MODELS = {
-    "130m": GrugModelConfig(
-        vocab_size=128_256,
-        hidden_dim=512,
-        intermediate_dim=1792,
-        num_layers=6,
-        num_heads=8,
-        num_kv_heads=8,
-        max_seq_len=_SEQ_LEN,
+_RUNGS = {
+    "130m": _Rung(
+        model=GrugModelConfig(
+            vocab_size=128_256,
+            hidden_dim=512,
+            intermediate_dim=1792,
+            num_layers=6,
+            num_heads=8,
+            num_kv_heads=8,
+            max_seq_len=_SEQ_LEN,
+        ),
+        batch_size=128,
+        steps=8_000,
     ),
-    "1.3b": GrugModelConfig(
-        vocab_size=128_256,
-        hidden_dim=2048,
-        intermediate_dim=5632,
-        num_layers=24,
-        num_heads=16,
-        num_kv_heads=16,
-        max_seq_len=_SEQ_LEN,
+    "1.3b": _Rung(
+        model=GrugModelConfig(
+            vocab_size=128_256,
+            hidden_dim=2048,
+            intermediate_dim=5632,
+            num_layers=24,
+            num_heads=16,
+            num_kv_heads=16,
+            max_seq_len=_SEQ_LEN,
+        ),
+        batch_size=32,
+        steps=12_000,
     ),
 }
-
-# Batch size and token budget per rung, sized for one 141GB H200 with the template's per-block
-# activation checkpointing. On smaller devices override with --batch-size: batch 128 at the 130m
-# rung OOMs on a 95GB H100 (the train step allocates ~78GiB). Halving the batch halves the token
-# budget rather than doubling the steps -- both arms must share whatever value is used, and the
-# A/B stays valid at any batch size.
-_BATCH_SIZE = {"130m": 128, "1.3b": 32}
-_STEPS = {"130m": 8_000, "1.3b": 12_000}
 
 
 @dataclass(frozen=True)
@@ -275,7 +292,6 @@ def build_grug_run_config(launch: GrugVeLaunchConfig) -> GrugRunConfig:
 
 
 def run_grug_ve_trial(config: GrugVeLaunchConfig) -> None:
-    """Build the full grug run config and dispatch the training job to Fray."""
     run_grug(build_grug_run_config(config))
 
 
@@ -298,17 +314,18 @@ def grug_ve_trial(
     """
     if arm not in ("ve", "base", "wide"):
         raise ValueError(f"arm must be 've', 'base', or 'wide', got {arm!r}")
-    if size not in _MODELS:
-        raise ValueError(f"size must be one of {tuple(_MODELS)}, got {size!r}")
+    if size not in _RUNGS:
+        raise ValueError(f"size must be one of {tuple(_RUNGS)}, got {size!r}")
 
-    model = _MODELS[size]
+    rung = _RUNGS[size]
+    model = rung.model
     if arm == "ve":
         model = dataclasses.replace(model, value_emb_lambda_init=_LAMBDA_INIT)
     elif arm == "wide":
         model = dataclasses.replace(model, intermediate_dim=_wide_intermediate_dim(model))
     train_data = fineweb_edu_10B_dataset()
     run_id = _resolve_run_id(f"grug-ve-{size}-{arm}")
-    resolved_batch_size = batch_size if batch_size is not None else _BATCH_SIZE[size]
+    resolved_batch_size = batch_size if batch_size is not None else rung.batch_size
     resolved_eval_batch_size = eval_batch_size if eval_batch_size is not None else resolved_batch_size
 
     def build_config(ctx: StepContext) -> GrugVeLaunchConfig:
@@ -318,7 +335,7 @@ def grug_ve_trial(
             output_path=ctx.output_path,
             run_id=run_id,
             resources=ctx.runtime_arg("train_resources"),
-            steps=_STEPS[size],
+            steps=rung.steps,
             batch_size=resolved_batch_size,
             # The same seed in both arms: control and treatment see the same data in the same
             # order and start from the same draw, so what separates them is not a seed.
@@ -358,7 +375,7 @@ def grug_ve_trial(
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--arm", choices=("ve", "base", "wide"), default="ve")
-    parser.add_argument("--size", choices=tuple(_MODELS), default="130m")
+    parser.add_argument("--size", choices=tuple(_RUNGS), default="130m")
     parser.add_argument("--version", default="dev")
     parser.add_argument(
         "--batch-size",

--- a/experiments/grug/ve/launch.py
+++ b/experiments/grug/ve/launch.py
@@ -326,7 +326,6 @@ def grug_ve_trial(
     train_data = fineweb_edu_10B_dataset()
     run_id = _resolve_run_id(f"grug-ve-{size}-{arm}")
     resolved_batch_size = batch_size if batch_size is not None else rung.batch_size
-    resolved_eval_batch_size = eval_batch_size if eval_batch_size is not None else resolved_batch_size
 
     def build_config(ctx: StepContext) -> GrugVeLaunchConfig:
         return GrugVeLaunchConfig(
@@ -352,9 +351,13 @@ def grug_ve_trial(
             z_loss_weight=1e-4,
             ema_beta=None,
             log_every=10,
-            # Eval follows the train batch: eval is forward-only, so anything that fits a train
-            # step fits eval at the same batch, and no separate memory budget is needed.
-            eval_batch_size=resolved_eval_batch_size,
+            # Eval is explicitly off (unless the caller opts in): the prebuilt fineweb-edu-10B
+            # cache carries no validation split, so a configured perplexity eval would silently
+            # never fire. The experiment's readout is the paired train loss instead -- every arm
+            # sees the same never-repeated batches in the same order, so train loss at matched
+            # steps is itself a held-out comparison. Pass eval_batch_size only when pointing at
+            # a cache that actually has a validation split.
+            eval_batch_size=eval_batch_size,
             steps_per_eval=500,
             max_eval_batches=8,
             eval_current=True,

--- a/experiments/grug/ve/launch.py
+++ b/experiments/grug/ve/launch.py
@@ -1,0 +1,372 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""grug value-embedding (VE) ablation, sized for a single H200.
+
+A second token-indexed embedding table, shared across all layers, blended into each layer's
+attention value path under a learnable per-layer gate. Queries and keys are untouched, so the
+attention pattern is the base model's exactly; only the payload a token delivers when attended
+to carries the extra signal. It buys ``vocab_size x kv_width`` parameters at the cost of one
+embedding lookup -- no added matmul FLOPs.
+
+The experiment is a paired A/B: the same model, data, seed, and token budget, run with the
+value-embedding gate on and off. Both arms are the same code path -- ``value_emb_lambda_init``
+is None in the control -- so the difference between them is the intervention and nothing else.
+
+    # the pair, at 130M, on one H200
+    python -m experiments.grug.ve.launch --arm ve
+    python -m experiments.grug.ve.launch --arm base
+
+    # the parameter-matched dumb control (wider MLP; see _wide_intermediate_dim)
+    python -m experiments.grug.ve.launch --arm wide
+
+    # the same pair at 1.3B once 130M says it is worth the tokens
+    python -m experiments.grug.ve.launch --arm ve --size 1.3b
+
+Parameter counts are not matched across arms, and deliberately so: the whole claim is
+capacity-per-FLOP, and matching parameters would erase the effect being measured. The
+comparison that settles it is loss at equal FLOPs (equivalently, equal tokens), which is what
+these two arms hold fixed. ``throughput/mfu`` and ``ve/lambda/layer_<i>`` are the diagnostics
+to watch: the first says the lookup stayed free, the second is the model's own report of where
+in depth a token-identity side channel is worth having.
+
+Know what the table costs before reading a win off it. Against a 128k Llama vocab it is not a
+rounding error:
+
+    130m:  148.6M -> 214.3M params  (+65.7M, +44%)
+    1.3b: 1481.7M -> 1744.4M params (+262.7M, +18%)
+
+Zero added matmul FLOPs, but 44% more parameters at the small rung -- the speedrun lineage this
+comes from runs a ~50k vocab, and the cost here scales with vocab. Two consequences. First, the
+optimizer state and HBM for that table are real even though the FLOPs are not, which is what the
+batch sizes above leave room for. Second, if the VE arm wins at 130M, "value embeddings help" and
+"44% more parameters help, wherever you put them" both explain it, and the run cannot tell them
+apart; the ``wide`` arm separates those by spending the same budget somewhere dumb (a wider
+MLP), and it is worth running before believing the mechanism.
+
+The lever on that cost is ``num_kv_heads``. The table is sized to the KV width, so grouped-query
+attention shrinks it directly -- at 130M, ``num_kv_heads=2`` takes it from 65.7M to 16.4M (+11%)
+and makes the parameter-matching objection much smaller, at the price of changing the attention
+config in both arms. Left at MHA here so the base rung matches the base template.
+"""
+
+import argparse
+import dataclasses
+import os
+from dataclasses import dataclass
+from datetime import timedelta
+
+import jmp
+from fray.types import ANY_REGION, ResourceConfig
+from levanter.analysis.backward_flow import BackwardFlowConfig
+from levanter.callbacks.profiler import ProfilerConfig
+from levanter.checkpoint import CheckpointerConfig
+from levanter.data.text.datasets import LmDataConfig
+from levanter.optim.config import AdamConfig, OptimizerConfig
+from levanter.tracker import TrackerConfig
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
+from marin.execution.lazy import ArtifactStep, StepContext
+from marin.execution.step_runner import StepRunner
+from marin.experiment.data import mixture
+from marin.experiment.namespacing import user_namespaced_name
+from marin.training.training import LevanterCheckpoint, resolve_checkpointer_output_path
+
+from experiments.datasets.prebuilt_caches import fineweb_edu_10B_dataset
+from experiments.grug.ve.model import GrugModelConfig
+from experiments.grug.ve.train import GrugEvalConfig, GrugRunConfig, GrugTrainerConfig, run_grug
+
+# One H200. `regions=[ANY_REGION]` keeps the job schedulable on a GPU host that advertises no
+# region, which is what a personal box looks like to the scheduler.
+_TRAIN_RESOURCES = ResourceConfig.with_gpu("H200", count=1, cpu=16, disk="256G", ram="128G", regions=[ANY_REGION])
+
+# The gate's init: 0.5 is "trust the computed value and the stored value equally", and lets the
+# model move in either direction from the start. It is not a claim that half is right -- the
+# per-layer gates are free to go anywhere, and where they land is the experiment's readout.
+_LAMBDA_INIT = 0.5
+
+
+def _wide_intermediate_dim(model: GrugModelConfig) -> int:
+    """MLP width for the parameter-matched dumb control.
+
+    The ``wide`` arm answers "is the VE win just 44% more parameters, wherever you put
+    them?" by spending the VE table's exact parameter count on wider MLPs instead: the
+    table costs ``vocab x kv_width`` and each unit of intermediate_dim costs
+    ``2 x hidden x num_layers``, so the quotient is the width increase. Note this control
+    is params-matched but NOT FLOPs-matched -- the wider MLP does real matmul work, so at
+    equal tokens the wide arm gets strictly more compute than the ve arm. If ve still wins,
+    the mechanism claim survives its strongest form.
+    """
+    table_params = model.vocab_size * model.value_emb_dim
+    params_per_unit_width = 2 * model.hidden_dim * model.num_layers
+    return model.intermediate_dim + round(table_params / params_per_unit_width)
+
+
+# Sequence length is 2048 rather than the base template's 4096: at these model sizes attention is
+# a small share of FLOPs, and the shorter context buys batch size on a single device.
+_SEQ_LEN = 2048
+
+# Adam for everything, including the value-embedding table. If this is ever ported onto Muon, the
+# table belongs in the embedding partition, not with the matrices: a lookup table's per-row
+# gradients are sparse, and Muon's orthogonalized update assumes the dense statistics of a matmul
+# weight.
+#
+# `weight_decay_modules` is an explicit inclusion list because the default mask would decay the
+# `lambda_ve` gates (it only exempts norms, biases, and `*Embedding*` class names, and grug's
+# parameters are raw arrays). A decayed gate is pulled toward zero at every step regardless of
+# gradient, which both suppresses the mechanism and confounds the lambda-vs-depth readout -- a
+# layer at lambda~0 could mean "dialed away" or just "nothing opposed the decay". The list keeps
+# decay on exactly the parameters the default decays today, minus the gates; norm weights stay
+# undecayed as before.
+_OPTIMIZER = AdamConfig(
+    learning_rate=3e-3,
+    weight_decay=0.1,
+    weight_decay_modules=[
+        "w_q",
+        "w_k",
+        "w_v",
+        "w_o",
+        "mlp_up",
+        "mlp_down",
+        "token_embed",
+        "value_embed",
+        "output_proj",
+    ],
+    lr_schedule="cosine",
+    decay=0.2,
+    min_lr_ratio=0.1,
+    warmup=1000,
+)
+
+# Two rungs. 130M is the iteration rung -- it turns around fast enough to iterate on, and it is
+# where a speedrun-scale result would show up if it transfers at all. 1.3B is the confirmation
+# rung: the VE table costs a fixed vocab x kv_width, so it shrinks as a fraction of the model as
+# the model grows, and the question worth the GPU-hours is whether the win shrinks with it.
+_MODELS = {
+    "130m": GrugModelConfig(
+        vocab_size=128_256,
+        hidden_dim=512,
+        intermediate_dim=1792,
+        num_layers=6,
+        num_heads=8,
+        num_kv_heads=8,
+        max_seq_len=_SEQ_LEN,
+    ),
+    "1.3b": GrugModelConfig(
+        vocab_size=128_256,
+        hidden_dim=2048,
+        intermediate_dim=5632,
+        num_layers=24,
+        num_heads=16,
+        num_kv_heads=16,
+        max_seq_len=_SEQ_LEN,
+    ),
+}
+
+# Batch size and token budget per rung, sized for one 141GB H200 with the template's per-block
+# activation checkpointing. On smaller devices override with --batch-size: batch 128 at the 130m
+# rung OOMs on a 95GB H100 (the train step allocates ~78GiB). Halving the batch halves the token
+# budget rather than doubling the steps -- both arms must share whatever value is used, and the
+# A/B stays valid at any batch size.
+_BATCH_SIZE = {"130m": 128, "1.3b": 32}
+_STEPS = {"130m": 8_000, "1.3b": 12_000}
+
+
+@dataclass(frozen=True)
+class GrugVeLaunchConfig:
+    """Last-mile run config for the value-embedding variant.
+
+    Flat scalars rather than nested trainer/eval configs: those carry
+    ``jax.sharding.PartitionSpec`` defaults the artifact fingerprint cannot serialize.
+    ``build_grug_run_config`` reconstitutes them at run time.
+    """
+
+    model: GrugModelConfig
+    data: LmDataConfig
+    output_path: str
+    run_id: str
+    resources: ResourceConfig
+    steps: int
+    batch_size: int
+    seed: int
+    mp: str  # jmp policy string, e.g. "params=float32,compute=bfloat16,output=bfloat16".
+    tracker: TrackerConfig
+    optimizer: OptimizerConfig
+    z_loss_weight: float = 1e-4
+    ema_beta: float | None = None  # EMA coefficient for eval/checkpoint model; None disables EMA.
+    log_every: int = 10
+    loss_implementation: str | tuple[str, ...] | None = None  # cross-entropy kernel; None uses the trainer default.
+    eval_batch_size: int | None = 128  # None disables perplexity eval.
+    steps_per_eval: int = 500
+    max_eval_batches: int = 8
+    eval_current: bool = True
+    eval_ema: bool = False
+
+
+def _resolve_run_id(default_run_id: str) -> str:
+    """Resolve run id and append `FERRY_DATE` when launching from ferry workflows."""
+    run_id = os.environ.get("GRUG_RUN_ID", default_run_id)
+    ferry_date = os.environ.get("FERRY_DATE")
+    if ferry_date:
+        run_id = f"{run_id}-{ferry_date}"
+    return run_id
+
+
+def _resolve_tracker(tracker: TrackerConfig, run_id: str) -> TrackerConfig:
+    if isinstance(tracker, WandbConfig):
+        return dataclasses.replace(tracker, name=run_id)
+    return tracker
+
+
+def build_grug_run_config(launch: GrugVeLaunchConfig) -> GrugRunConfig:
+    """Map launch knobs onto the trainer's full ``GrugRunConfig``."""
+    output_path = launch.output_path
+    trainer = TrainerConfig(
+        id=launch.run_id,
+        seed=launch.seed,
+        train_batch_size=launch.batch_size,
+        num_train_steps=launch.steps,
+        profiler=ProfilerConfig(enabled=False, start_step=5, num_steps=100, perfetto_link=False),
+        mp=jmp.get_policy(launch.mp),
+        tracker=_resolve_tracker(launch.tracker, launch.run_id),
+        use_explicit_mesh_axes=True,
+        require_accelerator=True,
+        allow_nondivisible_batch_size=False,
+        checkpointer=resolve_checkpointer_output_path(
+            CheckpointerConfig(save_interval=timedelta(minutes=30), keep=None),
+            output_path,
+        ),
+    )
+
+    grug_trainer = GrugTrainerConfig(
+        trainer=trainer,
+        z_loss_weight=launch.z_loss_weight,
+        ema_beta=launch.ema_beta,
+        log_every=launch.log_every,
+        loss_implementation=launch.loss_implementation,
+        # Backward-flow tracing OFF: traced steps run without per-block activation
+        # checkpointing (see model.py Block dispatch), which needs tens of GiB more than a
+        # normal step -- it is what OOMed this config on a 95GB H100 at step 0. The
+        # diagnostic is not part of this experiment; re-enable deliberately if needed.
+        backward_flow=BackwardFlowConfig(interval=0),
+    )
+
+    eval_config = (
+        GrugEvalConfig(
+            eval_batch_size=launch.eval_batch_size,
+            steps_per_eval=launch.steps_per_eval,
+            max_eval_batches=launch.max_eval_batches,
+            eval_current=launch.eval_current,
+            eval_ema=launch.eval_ema,
+        )
+        if launch.eval_batch_size is not None
+        else None
+    )
+
+    return GrugRunConfig(
+        model=launch.model,
+        data=launch.data,
+        resources=launch.resources,
+        output_path=output_path,
+        optimizer=launch.optimizer,
+        trainer=grug_trainer,
+        eval=eval_config,
+    )
+
+
+def run_grug_ve_trial(config: GrugVeLaunchConfig) -> None:
+    """Build the full grug run config and dispatch the training job to Fray."""
+    run_grug(build_grug_run_config(config))
+
+
+def grug_ve_trial(
+    *,
+    arm: str,
+    size: str = "130m",
+    version: str = "dev",
+    batch_size: int | None = None,
+    eval_batch_size: int | None = None,
+) -> ArtifactStep[LevanterCheckpoint]:
+    """One arm of the value-embedding ablation as a lazy checkpoint.
+
+    ``arm="ve"`` turns the value-embedding gate on; ``arm="base"`` is the control, identical in
+    every other respect; ``arm="wide"`` is the parameter-matched dumb control -- no value
+    embeddings, the same parameter budget spent on wider MLPs instead. All arms train on
+    fineweb-edu at the same seed, batch size, and token budget, so loss gaps between them are
+    the interventions. Keep --batch-size identical across every arm you intend to compare:
+    it fixes the data order.
+    """
+    if arm not in ("ve", "base", "wide"):
+        raise ValueError(f"arm must be 've', 'base', or 'wide', got {arm!r}")
+    if size not in _MODELS:
+        raise ValueError(f"size must be one of {tuple(_MODELS)}, got {size!r}")
+
+    model = _MODELS[size]
+    if arm == "ve":
+        model = dataclasses.replace(model, value_emb_lambda_init=_LAMBDA_INIT)
+    elif arm == "wide":
+        model = dataclasses.replace(model, intermediate_dim=_wide_intermediate_dim(model))
+    train_data = fineweb_edu_10B_dataset()
+    run_id = _resolve_run_id(f"grug-ve-{size}-{arm}")
+    resolved_batch_size = batch_size if batch_size is not None else _BATCH_SIZE[size]
+    resolved_eval_batch_size = eval_batch_size if eval_batch_size is not None else resolved_batch_size
+
+    def build_config(ctx: StepContext) -> GrugVeLaunchConfig:
+        return GrugVeLaunchConfig(
+            model=model,
+            data=mixture(ctx, {train_data: 1.0}),
+            output_path=ctx.output_path,
+            run_id=run_id,
+            resources=ctx.runtime_arg("train_resources"),
+            steps=_STEPS[size],
+            batch_size=resolved_batch_size,
+            # The same seed in both arms: control and treatment see the same data in the same
+            # order and start from the same draw, so what separates them is not a seed.
+            seed=0,
+            mp="params=float32,compute=bfloat16,output=bfloat16",
+            tracker=WandbConfig(
+                project="marin",
+                tags=["grug", "value-embeddings", size, arm],
+                group=f"grug-ve-{size}",
+                name=None,  # filled from run_id in _resolve_tracker
+                replicate_path=ctx.output_path,
+            ),
+            optimizer=_OPTIMIZER,
+            z_loss_weight=1e-4,
+            ema_beta=None,
+            log_every=10,
+            # Eval follows the train batch: eval is forward-only, so anything that fits a train
+            # step fits eval at the same batch, and no separate memory budget is needed.
+            eval_batch_size=resolved_eval_batch_size,
+            steps_per_eval=500,
+            max_eval_batches=8,
+            eval_current=True,
+            eval_ema=False,
+        )
+
+    return ArtifactStep(
+        name=user_namespaced_name(f"grug/ve-{size}-{arm}", version),
+        version=version,
+        artifact_type=LevanterCheckpoint,
+        run=run_grug_ve_trial,
+        build_config=build_config,
+        deps=(train_data,),
+        runtime_args={"train_resources": _TRAIN_RESOURCES},
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--arm", choices=("ve", "base", "wide"), default="ve")
+    parser.add_argument("--size", choices=tuple(_MODELS), default="130m")
+    parser.add_argument("--version", default="dev")
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=None,
+        help="Override the per-size default batch size; both arms of a comparison must use the same value.",
+    )
+    args = parser.parse_args()
+    StepRunner().run(
+        [grug_ve_trial(arm=args.arm, size=args.size, version=args.version, batch_size=args.batch_size).lower()]
+    )

--- a/experiments/grug/ve/model.py
+++ b/experiments/grug/ve/model.py
@@ -1,0 +1,347 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+from dataclasses import dataclass
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from einops import rearrange
+from haliax.jax_utils import named_call
+from jax import random
+from jax.sharding import PartitionSpec as P
+from jax.sharding import reshard
+from jaxtyping import Array, Float, Int, PRNGKeyArray
+from levanter.analysis.backward_flow import (
+    is_backward_flow_active,
+    log_backward_activation,
+    trace_backward_activation,
+    trace_grads,
+)
+from levanter.grug.attention import AttentionMask, RotaryConfig, apply_rotary_embedding, attention
+from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
+from levanter.grug.sharding import Pbatch, Pembed_vocab, Plm_head, Plogits, unshard
+
+
+@dataclass(frozen=True)
+class GrugModelConfig:
+    """Hyperparameters for the Grug Llama-style transformer with value embeddings.
+
+    ``value_emb_lambda_init`` is the one knob this variant adds. When it is None the model
+    is the base grug transformer exactly; when it is a float, a second token-indexed
+    embedding table is blended into every layer's attention value path, gated by a learnable
+    per-layer scalar initialized to this value. The A/B arm of the ablation is therefore the
+    same code path with the knob set to None -- not a different file.
+    """
+
+    vocab_size: int
+    hidden_dim: int = 2048
+    intermediate_dim: int = 5632
+    num_layers: int = 24
+    num_heads: int = 16
+    num_kv_heads: int = 16
+    head_dim: int | None = None
+    max_seq_len: int = 4096
+    layer_norm_eps: float = 1e-5
+    initializer_std: float = 0.02
+    rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
+    value_emb_lambda_init: float | None = None  # None disables value embeddings.
+
+    def __post_init__(self) -> None:
+        _ = self.inferred_head_dim
+        if self.num_heads % self.num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads for grouped-query attention")
+        if self.vocab_size <= 0:
+            raise ValueError("vocab_size must be positive")
+        if self.max_seq_len <= 0:
+            raise ValueError("max_seq_len must be positive")
+
+    @property
+    def inferred_head_dim(self) -> int:
+        if self.head_dim is not None:
+            return self.head_dim
+        if self.hidden_dim % self.num_heads != 0:
+            raise ValueError(
+                f"hidden_dim={self.hidden_dim} is not divisible by num_heads={self.num_heads}; set head_dim explicitly"
+            )
+        return self.hidden_dim // self.num_heads
+
+    @property
+    def value_emb_dim(self) -> int:
+        """Width of a value-embedding row: it is blended into ``v``, so it matches the KV width.
+
+        Under grouped-query attention ``v`` carries ``num_kv_heads`` heads, not ``num_heads``,
+        so sizing the table to the KV width (rather than ``hidden_dim``) both makes the blend
+        shape-correct and keeps the table as small as GQA already makes the value path.
+        """
+        return self.num_kv_heads * self.inferred_head_dim
+
+
+class CausalSelfAttention(eqx.Module):
+    w_q: jax.Array
+    w_k: jax.Array
+    w_v: jax.Array
+    w_o: jax.Array
+    # Blend coefficient between the context-computed value and the per-token stored value
+    # embedding. One learnable scalar per layer: each depth finds its own mix, and a layer
+    # that wants no stored memory can drive it to zero. None when value embeddings are off.
+    lambda_ve: jax.Array | None
+    cfg: GrugModelConfig = eqx.field(static=True)
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "CausalSelfAttention":
+        k_q, k_k, k_v, k_o = random.split(key, 4)
+        d_model, n_heads, n_kv_heads, head_dim = cfg.hidden_dim, cfg.num_heads, cfg.num_kv_heads, cfg.inferred_head_dim
+        lambda_init = cfg.value_emb_lambda_init
+        return CausalSelfAttention(
+            w_q=reshard(_init_weight(k_q, (d_model, n_heads * head_dim), cfg.initializer_std), P("data", "model")),
+            w_k=reshard(_init_weight(k_k, (d_model, n_kv_heads * head_dim), cfg.initializer_std), P("data", "model")),
+            w_v=reshard(_init_weight(k_v, (d_model, n_kv_heads * head_dim), cfg.initializer_std), P("data", "model")),
+            w_o=reshard(_init_weight(k_o, (n_heads * head_dim, d_model), cfg.initializer_std), P("model", "data")),
+            lambda_ve=None if lambda_init is None else jnp.array(lambda_init, dtype=jnp.float32),
+            cfg=cfg,
+        )
+
+    @trace_grads
+    @named_call
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+        mask: AttentionMask | jax.Array,
+        ve: Float[Array, "B S Dkv"] | None = None,
+    ) -> Float[Array, "B S D"]:
+        head_dim = self.cfg.inferred_head_dim
+        seq_len = x.shape[1]
+
+        q = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_q), "... (n d) -> ... n d", d=head_dim)
+        k = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_k), "... (m d) -> ... m d", d=head_dim)
+        v = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_v), "... (m d) -> ... m d", d=head_dim)
+        q, k = apply_rotary_embedding(q, k, seq_len=seq_len, head_dim=head_dim, rope=self.cfg.rope)
+
+        # Blend the stored per-token memory into the value path only. q and k are untouched,
+        # so the attention pattern -- who attends to whom -- is exactly the base model's; only
+        # the payload a token delivers when attended to carries the token-identity side channel.
+        if ve is not None:
+            if self.lambda_ve is None:
+                raise ValueError("value embeddings were passed to a layer with no lambda_ve gate")
+            lam = unshard(self.lambda_ve).astype(v.dtype)
+            ve_heads = rearrange(ve, "... (m d) -> ... m d", d=head_dim)
+            v = (1.0 - lam) * v + lam * ve_heads.astype(v.dtype)
+
+        attn_out = attention(q, k, v, mask)
+        attn_out = rearrange(attn_out, "... n d -> ... (n d)")
+        return jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=Pbatch)
+
+
+class MLP(eqx.Module):
+    mlp_up: jax.Array
+    mlp_down: jax.Array
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "MLP":
+        k_up, k_down = random.split(key, 2)
+        d_model, d_ff = cfg.hidden_dim, cfg.intermediate_dim
+        return MLP(
+            mlp_up=reshard(_init_weight(k_up, (d_model, d_ff), cfg.initializer_std), P("data", "model")),
+            mlp_down=reshard(_init_weight(k_down, (d_ff, d_model), cfg.initializer_std), P("model", "data")),
+        )
+
+    @trace_grads
+    @named_call
+    def __call__(self, x: Float[Array, "B S D"]) -> Float[Array, "B S D"]:
+        up = jnp.einsum("bsh,hm->bsm", x, self.mlp_up)
+        activated = jax.nn.relu(up)
+        return jnp.einsum("bsm,mh->bsh", activated, self.mlp_down, out_sharding=Pbatch)
+
+
+class RMSNorm(eqx.Module):
+    weight: jax.Array
+    eps: float = eqx.field(static=True)
+
+    @staticmethod
+    def init(dim: int, eps: float) -> "RMSNorm":
+        return RMSNorm(weight=jnp.ones((dim,), dtype=jnp.float32), eps=eps)
+
+    @named_call
+    def __call__(self, x: Float[Array, "... D"]) -> Float[Array, "... D"]:
+        weight = unshard(self.weight)
+        dtype = x.dtype
+        x = x.astype(jnp.float32)
+        variance = jnp.mean(jnp.square(x), axis=-1, keepdims=True)
+        normed = x * jax.lax.rsqrt(variance + self.eps)
+        return (normed * weight).astype(dtype)
+
+
+class Block(eqx.Module):
+    rms_attn: RMSNorm
+    attn: CausalSelfAttention
+    rms_mlp: RMSNorm
+    mlp: MLP
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "Block":
+        attn_key, mlp_key = random.split(key, 2)
+        return Block(
+            rms_attn=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            attn=CausalSelfAttention.init(cfg, key=attn_key),
+            rms_mlp=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            mlp=MLP.init(cfg, key=mlp_key),
+        )
+
+    @named_call
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+        mask: AttentionMask | jax.Array,
+        ve: Float[Array, "B S Dkv"] | None = None,
+    ) -> Float[Array, "B S D"]:
+        x = trace_backward_activation(x, "resid_in")
+        x = x + self.attn(self.rms_attn(x), mask, ve)
+        x = trace_backward_activation(x, "resid_post_attn")
+        x = x + self.mlp(self.rms_mlp(x))
+        return trace_backward_activation(x, "resid_out")
+
+
+class Transformer(eqx.Module):
+    token_embed: jax.Array
+    # The value-embedding table: a second vector per vocabulary entry, read at every layer.
+    # One table serves all depths, so its parameter cost is paid once, and it is indexed by
+    # the raw token ids rather than the hidden state -- the signal never travels the residual
+    # stream and so cannot be degraded by the layers in between. A lookup, not a matmul: it
+    # buys parameters at zero added FLOPs. None when value embeddings are off.
+    value_embed: jax.Array | None
+    output_proj: jax.Array
+    blocks: tuple[Block, ...]
+    final_norm: RMSNorm
+    config: GrugModelConfig = eqx.field(static=True)
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "Transformer":
+        embed_key, ve_key, out_key, *block_keys = random.split(key, cfg.num_layers + 3)
+        token_embed = reshard(
+            _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), cfg.initializer_std), Pembed_vocab
+        )
+        value_embed = None
+        if cfg.value_emb_lambda_init is not None:
+            value_embed = reshard(
+                _init_weight(ve_key, (cfg.vocab_size, cfg.value_emb_dim), cfg.initializer_std), Pembed_vocab
+            )
+        output_proj = reshard(_init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head)
+        blocks = tuple(Block.init(cfg, key=layer_key) for layer_key in block_keys)
+        final_norm = RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps)
+        return Transformer(
+            token_embed=token_embed,
+            value_embed=value_embed,
+            output_proj=output_proj,
+            blocks=blocks,
+            final_norm=final_norm,
+            config=cfg,
+        )
+
+    @named_call
+    def __call__(
+        self,
+        token_ids: Int[Array, "B S"],
+        mask: AttentionMask | jax.Array | None = None,
+    ) -> Float[Array, "B S D"]:
+        if mask is None:
+            mask = AttentionMask.causal()
+
+        with jax.named_scope("token_embed"):
+            hidden = self.token_embed.at[token_ids].get(out_sharding=Pbatch)
+            hidden = log_backward_activation(hidden)
+
+        # One lookup for the whole network: every block is handed the same `ve` tensor.
+        ve = None
+        if self.value_embed is not None:
+            with jax.named_scope("value_embed"):
+                ve = self.value_embed.at[token_ids].get(out_sharding=Pbatch)
+
+        for i, block in enumerate(self.blocks):
+            with jax.named_scope(f"block_{i}"):
+                block_fn = block if is_backward_flow_active() else eqx.filter_checkpoint(block)
+                hidden = block_fn(hidden, mask, ve)
+        with jax.named_scope("final_norm"):
+            hidden = self.final_norm(hidden)
+            return log_backward_activation(hidden)
+
+    def value_emb_lambdas(self) -> tuple[jax.Array, ...]:
+        """The learned per-layer blend coefficients, shallow to deep.
+
+        The headline diagnostic: plotted against depth, this is the model's own answer to
+        where a token-identity side channel is worth having. Empty when the model has none.
+        """
+        return tuple(block.attn.lambda_ve for block in self.blocks if block.attn.lambda_ve is not None)
+
+    @named_call
+    def logits(
+        self,
+        token_ids: Int[Array, "B S"],
+        mask: AttentionMask | jax.Array | None = None,
+    ) -> Float[Array, "B S V"]:
+        hidden = self(token_ids, mask=mask)
+        return jnp.einsum("bsh,hd->bsd", hidden, self.output_proj, out_sharding=Plogits)
+
+    def next_token_loss(
+        self,
+        token_ids: Int[Array, "B S"],
+        loss_weight: Float[Array, "B S"],
+        *,
+        mask: AttentionMask | jax.Array | None = None,
+        reduction: str = "mean",
+        logsumexp_weight: float | None = None,
+        loss_dtype: jnp.dtype = jnp.float32,
+        loss_implementation: str | tuple[str, ...] | None = None,
+    ) -> jax.Array:
+        """Compute next-token cross-entropy loss for a batch."""
+        hidden = self(token_ids, mask=mask)
+        labels = jnp.concatenate([token_ids[:, 1:], token_ids[:, :1] * 0], axis=1).astype(jnp.int32)
+        loss_weight = loss_weight.astype(loss_dtype)
+
+        return fused_linear_softmax_cross_entropy_loss(
+            hidden,
+            self.output_proj,
+            labels,
+            weight=loss_weight,
+            reduction=reduction,
+            logsumexp_weight=logsumexp_weight,
+            dtype=loss_dtype,
+            implementation=loss_implementation,
+        )
+
+
+def _init_weight(key: PRNGKeyArray, shape: tuple[int, ...], std: float) -> Float[Array, "..."]:
+    return std * random.truncated_normal(key, -3, 3, shape)
+
+
+def debug_mesh_and_token_pspec(num_devices: int, model_axis_size: int = 1) -> tuple[jax.sharding.AbstractMesh, P]:
+    """Return a small abstract mesh and token sharding for lowering contract tests."""
+    if num_devices <= 0:
+        raise ValueError(f"num_devices must be positive, got {num_devices}")
+    if model_axis_size <= 0:
+        raise ValueError(f"model_axis_size must be positive, got {model_axis_size}")
+    if num_devices % model_axis_size != 0:
+        raise ValueError(f"num_devices ({num_devices}) must be divisible by model_axis_size ({model_axis_size})")
+    data_axis_size = num_devices // model_axis_size
+    mesh = jax.sharding.AbstractMesh(
+        axis_sizes=(1, data_axis_size, model_axis_size),
+        axis_names=("replica_dcn", "data", "model"),
+        axis_types=(
+            jax.sharding.AxisType.Explicit,
+            jax.sharding.AxisType.Explicit,
+            jax.sharding.AxisType.Explicit,
+        ),
+    )
+    return mesh, P(("replica_dcn", "data"), None)
+
+
+__all__ = [
+    "MLP",
+    "Block",
+    "CausalSelfAttention",
+    "GrugModelConfig",
+    "RMSNorm",
+    "Transformer",
+    "debug_mesh_and_token_pspec",
+]

--- a/experiments/grug/ve/train.py
+++ b/experiments/grug/ve/train.py
@@ -1,0 +1,679 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+import functools
+import logging
+import time
+from dataclasses import dataclass, field
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jmp
+import levanter.callbacks as callbacks
+import levanter.tracker
+import optax
+from fray.cluster import ResourceConfig
+from haliax import Axis
+from haliax.partitioning import set_mesh
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+from jax.tree_util import register_dataclass
+from jaxtyping import PRNGKeyArray
+from levanter.analysis.backward_flow import (
+    BackwardFlowConfig,
+    BackwardFlowGraph,
+    backward_flow_graph_from_jaxpr,
+    backward_flow_node_stats,
+    capture_backward_flow,
+    collapse_backward_flow_graph,
+    infer_backward_flow_render_hints,
+    render_backward_flow_html,
+)
+from levanter.callbacks.state_adapter import StateCallbackRunner
+from levanter.callbacks.watch import WatchConfig, compute_watch_stats
+from levanter.data.dataset import AsyncDataset
+from levanter.data.loader import DataLoader
+from levanter.data.mixture import MixtureDataset, rescale_mixture_schedule_for_batch_schedule
+from levanter.data.text.datasets import LmDataConfig
+from levanter.data.text.examples import GrugLmExample, grug_lm_example_from_named
+from levanter.eval import TaggedEvaluator, cb_tagged_evaluate
+from levanter.grug.sharding import compact_grug_mesh
+from levanter.models.lm_model import LmExample
+from levanter.optim.config import AdamConfig, OptimizerConfig
+from levanter.schedule import BatchSchedule
+from levanter.trainer import TrainerConfig
+from levanter.utils.flop_utils import lm_flops_per_token
+from levanter.utils.jax_utils import parameter_count
+from levanter.utils.logging import LoadingTimeTrackerIterator
+
+from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
+from experiments.grug.dispatch import dispatch_grug_training_run
+from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
+from experiments.grug.ve.model import GrugModelConfig, Transformer
+
+logger = logging.getLogger(__name__)
+_BACKWARD_FLOW_METRICS_KEY = "_backward_flow"
+_BACKWARD_FLOW_DEFAULT_INTERVAL = 50
+
+
+@dataclass(frozen=True)
+class GrugTrainerConfig:
+    """Runtime knobs for grug training."""
+
+    trainer: TrainerConfig = field(default_factory=lambda: TrainerConfig(use_explicit_mesh_axes=True))
+    train_batch_pspec: P = field(default_factory=lambda: P(("replica_dcn", "data")))
+    data_seed: int | None = None
+    log_every: int = 1
+    ema_beta: float | None = None  # EMA coefficient for eval/checkpoint model; None disables EMA.
+    z_loss_weight: float = 0.0  # Weight on logsumexp (z-loss) stabilization term.
+    backward_flow: BackwardFlowConfig = field(
+        default_factory=lambda: BackwardFlowConfig(interval=_BACKWARD_FLOW_DEFAULT_INTERVAL)
+    )
+    loss_implementation: str | tuple[str, ...] | None = None
+    sharding_dump_path: str | None = None
+
+
+@dataclass(frozen=True)
+class GrugEvalConfig:
+    """Perplexity eval settings for grug training."""
+
+    eval_batch_size: int = 512
+    eval_batch_pspec: P = field(default_factory=lambda: P(("replica_dcn", "data")))
+    steps_per_eval: int | None = 1000
+    max_eval_batches: int | None = None
+    prefix: str = "eval"
+    eval_current: bool = True
+    eval_ema: bool = True
+    compute_bpb: bool = True
+
+
+@dataclass(frozen=True)
+class GrugRunConfig:
+    """Top-level config for grug training."""
+
+    model: GrugModelConfig
+    data: LmDataConfig
+    resources: ResourceConfig
+    output_path: str = ""
+    optimizer: OptimizerConfig = field(default_factory=AdamConfig)
+    trainer: GrugTrainerConfig = field(default_factory=GrugTrainerConfig)
+    eval: GrugEvalConfig | None = field(default_factory=GrugEvalConfig)
+
+
+def build_train_dataset(
+    data_config: LmDataConfig,
+    *,
+    max_seq_len: int,
+    batch_schedule: BatchSchedule,
+    key: PRNGKeyArray,
+) -> MixtureDataset[GrugLmExample]:
+    pos = Axis("position", max_seq_len)
+    mix_key, shuffle_key = jax.random.split(key)
+    weights = data_config.train_weights
+    if isinstance(weights, list):
+        weights = rescale_mixture_schedule_for_batch_schedule(weights, batch_schedule)
+
+    initial_batch_size = batch_schedule.batch_size_at_step(0)
+    datasets = data_config.train_sets(pos, key=shuffle_key, initial_batch_size=initial_batch_size)
+    return MixtureDataset(
+        datasets=datasets,
+        weights=weights,
+        stop_strategy=data_config.stop_strategy,
+        key=mix_key,
+        block_size=data_config.mixture_block_size,
+    )
+
+
+def build_train_loader(
+    dataset: AsyncDataset[GrugLmExample],
+    *,
+    batch_schedule: BatchSchedule,
+    mesh: Mesh,
+    batch_pspec: P = P(("replica_dcn", "data")),
+) -> DataLoader[GrugLmExample]:
+    # DataLoader uses this batch axis mapping to shard batches across the distributed mesh.
+    axis_resource = batch_pspec[0]
+    return DataLoader(
+        dataset,
+        batch_schedule.schedule,
+        mesh=mesh,
+        axis_resources={"__BATCH__": axis_resource},
+        batch_axis_name="__BATCH__",
+        allow_nondivisible_batch_size=False,
+    )
+
+
+def build_tagged_evaluator(
+    *,
+    data_config: LmDataConfig,
+    max_seq_len: int,
+    mesh: Mesh,
+    eval_cfg: GrugEvalConfig,
+) -> TaggedEvaluator[LmExample | GrugLmExample, Transformer] | None:
+    pos = Axis("position", max_seq_len)
+    tagged_eval_sets = data_config.tagged_eval_sets(pos)
+    if len(tagged_eval_sets) == 0:
+        logger.warning("No evaluation datasets provided.")
+        return None
+
+    max_examples_per_dataset = None
+    if eval_cfg.max_eval_batches is not None:
+        max_examples_per_dataset = eval_cfg.max_eval_batches * eval_cfg.eval_batch_size
+
+    tokenizer = data_config.the_tokenizer if eval_cfg.compute_bpb else None
+    batch_axis_resource = eval_cfg.eval_batch_pspec[0]
+    eval_axis_mapping = {"batch": batch_axis_resource}
+    eval_batch = Axis("batch", eval_cfg.eval_batch_size)
+    eval_array_sharding = NamedSharding(mesh, P(batch_axis_resource, None))
+
+    def eval_loss_fn(model: Transformer, batch: LmExample | GrugLmExample) -> tuple[jax.Array, jax.Array, jax.Array]:
+        if isinstance(batch, LmExample):
+            batch = grug_lm_example_from_named(batch)
+        per_pos_loss = model.next_token_loss(
+            batch.tokens,
+            batch.loss_weight,
+            mask=batch.attn_mask,
+            reduction="none",
+            logsumexp_weight=None,
+        )
+        per_pos_loss = jax.sharding.reshard(per_pos_loss, eval_array_sharding)
+        per_pos_weight = jax.sharding.reshard(batch.loss_weight, eval_array_sharding)
+        per_pos_token_id = jnp.roll(batch.tokens, -1, axis=-1)
+        return per_pos_loss, per_pos_weight, per_pos_token_id
+
+    return TaggedEvaluator(
+        EvalBatch=eval_batch,
+        tagged_eval_sets=tagged_eval_sets,
+        loss_fn=eval_loss_fn,
+        tokenizer=tokenizer,
+        device_mesh=mesh,
+        axis_mapping=eval_axis_mapping,
+        max_examples_per_dataset=max_examples_per_dataset,
+    )
+
+
+def _compute_flops(
+    *,
+    model_config: GrugModelConfig,
+) -> tuple[float, dict[str, float]]:
+    flops_per_token = lm_flops_per_token(
+        hidden_dim=model_config.hidden_dim,
+        intermediate_dim=model_config.intermediate_dim,
+        num_layers=model_config.num_layers,
+        num_kv_heads=model_config.num_kv_heads,
+        num_heads=model_config.num_heads,
+        seq_len=model_config.max_seq_len,
+        vocab_size=model_config.vocab_size,
+        glu=False,
+    )
+    flops_per_example = 3 * flops_per_token * model_config.max_seq_len
+
+    flops_summary: dict[str, float] = {
+        "throughput/flops_per_token_analytic": flops_per_token,
+        "throughput/flops_per_example_analytic": flops_per_example,
+    }
+
+    return flops_per_example, flops_summary
+
+
+def log_value_emb_lambdas(step_info) -> None:
+    """Log each layer's value-embedding blend coefficient.
+
+    ``ve/lambda/layer_<i>`` against depth is what this variant exists to measure: the
+    speedrun lineage reports value embeddings paying off at the shallowest and deepest
+    layers and being dialed away in the middle, and a learnable per-layer gate lets the
+    model report that profile itself instead of us imposing it. ``ve/lambda/mean`` is the
+    one-number summary of how much stored memory the model is using overall. A no-op on a
+    model with no value embeddings, which is the control arm of the ablation.
+    """
+    lambdas = step_info.model.value_emb_lambdas()
+    if not lambdas:
+        return
+    metrics: dict[str, jax.Array] = {f"ve/lambda/layer_{i}": lam for i, lam in enumerate(lambdas)}
+    metrics["ve/lambda/mean"] = jnp.mean(jnp.stack(lambdas))
+    levanter.tracker.log(metrics, step=step_info.step)
+
+
+def _make_mixture_stage_callback(train_dataset: MixtureDataset, batch_schedule: BatchSchedule):
+    last_mixture_stage = -1
+
+    def log_mixture_stage(step_info):
+        nonlocal last_mixture_stage
+        seq_index = batch_schedule.global_data_offset_by_step(step_info.step)
+        block_id = seq_index // train_dataset.block_size
+        stage = train_dataset._get_stage_for_block(block_id)
+        if stage == last_mixture_stage:
+            return
+
+        weights = train_dataset.weight_stages[stage][1]
+        mixture_log = {f"mixture/weight/{name}": weight for name, weight in weights.items()}
+        mixture_log["mixture/stage"] = stage
+        levanter.tracker.log(mixture_log, step=step_info.step)
+        last_mixture_stage = stage
+
+    return log_mixture_stage
+
+
+def _build_backward_flow_graph(
+    *,
+    params: Transformer,
+    batch: GrugLmExample,
+    mp: jmp.Policy,
+    z_loss_weight: float,
+) -> BackwardFlowGraph:
+    z_loss = z_loss_weight if z_loss_weight > 0 else None
+
+    def loss_fn(model: Transformer) -> jax.Array:
+        compute_params = mp.cast_to_compute(model)
+        return compute_params.next_token_loss(
+            batch.tokens,
+            batch.loss_weight,
+            mask=batch.attn_mask,
+            reduction="mean",
+            logsumexp_weight=z_loss,
+        )
+
+    with capture_backward_flow(BackwardFlowConfig(interval=1)):
+        closed_jaxpr, _, _ = eqx.filter_make_jaxpr(jax.grad(loss_fn))(params)
+    return backward_flow_graph_from_jaxpr(closed_jaxpr)
+
+
+def _write_backward_flow_artifact(
+    *,
+    graph: BackwardFlowGraph,
+    backward_flow_metrics: dict[str, jax.Array],
+    log_dir,
+    run_id: str,
+    step: int,
+) -> None:
+    node_stats = backward_flow_node_stats(backward_flow_metrics)
+    collapsed_graph = collapse_backward_flow_graph(graph, node_stats)
+    if not collapsed_graph.nodes:
+        return
+
+    render_hints = infer_backward_flow_render_hints(collapsed_graph)
+    html = render_backward_flow_html(
+        collapsed_graph,
+        node_stats,
+        node_lanes=render_hints.node_lanes,
+        display_edges=render_hints.display_edges,
+        plates=render_hints.plates,
+        title=f"Backward Flow Step {step}",
+    )
+    artifact_dir = log_dir / run_id / "artifacts" / "backward_flow"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = artifact_dir / f"step_{step:07d}.html"
+    artifact_path.write_text(html)
+    tracker = levanter.tracker.current_tracker()
+    tracker.log_html("backward_flow/dag", artifact_path, step=step, commit=False)
+    tracker.log_artifact(
+        artifact_path,
+        name=f"backward_flow_step_{step:07d}",
+        type="backward_flow",
+    )
+
+
+@register_dataclass
+@dataclass(frozen=True)
+class GrugTrainState:
+    step: jax.Array
+    params: Transformer
+    opt_state: optax.OptState
+    ema_params: Transformer | None
+
+
+def initial_state(
+    model_config: GrugModelConfig,
+    *,
+    optimizer: optax.GradientTransformation,
+    mp: jmp.Policy,
+    key: PRNGKeyArray,
+    ema_beta: float | None,
+) -> GrugTrainState:
+    params = mp.cast_to_param(Transformer.init(model_config, key=key))
+    return GrugTrainState(
+        step=jnp.array(0, dtype=jnp.int32),
+        params=params,
+        opt_state=optimizer.init(params),
+        ema_params=params if ema_beta is not None else None,
+    )
+
+
+def _make_train_step(
+    optimizer: optax.GradientTransformation,
+    mp: jmp.Policy,
+    *,
+    z_loss_weight: float,
+    loss_implementation: str | tuple[str, ...] | None = None,
+    ema_beta: float | None,
+    watch_config: WatchConfig | None = None,
+    backward_flow_config: BackwardFlowConfig | None = None,
+):
+    one = jnp.array(1, dtype=jnp.int32)
+    z_loss = z_loss_weight if z_loss_weight > 0 else None
+    if watch_config is not None:
+        if isinstance(watch_config.watch_targets, str):
+            watch_targets = tuple(t.strip() for t in watch_config.watch_targets.split(","))
+        else:
+            watch_targets = tuple(watch_config.watch_targets)
+    else:
+        watch_targets = ()
+
+    @functools.partial(jax.jit, donate_argnums=(0,), static_argnames=("compute_backward_flow", "compute_watch"))
+    def train_step(
+        state: GrugTrainState,
+        batch,
+        *,
+        compute_watch: bool = False,
+        compute_backward_flow: bool = False,
+    ):
+        def loss_fn(params):
+            compute_params = mp.cast_to_compute(params)
+            return compute_params.next_token_loss(
+                batch.tokens,
+                batch.loss_weight,
+                mask=batch.attn_mask,
+                reduction="mean",
+                logsumexp_weight=z_loss,
+                loss_implementation=loss_implementation,
+            )
+
+        backward_flow_stats = None
+        if backward_flow_config is not None and compute_backward_flow:
+            gradient_scale = jnp.sum(jnp.asarray(batch.loss_weight, dtype=jnp.float32))
+            with capture_backward_flow(backward_flow_config, gradient_scale=gradient_scale):
+                with levanter.tracker.defer_tracker_for_jit() as backward_flow_stats:
+                    loss, grads = jax.value_and_grad(loss_fn)(state.params)
+        else:
+            loss, grads = jax.value_and_grad(loss_fn)(state.params)
+        updates, opt_state = optimizer.update(grads, state.opt_state, state.params)
+        params = optax.apply_updates(state.params, updates)
+
+        if ema_beta is None:
+            ema_params = None
+        else:
+            if state.ema_params is None:
+                raise ValueError("ema_params must be initialized when ema_beta is set.")
+            ema_params = jax.tree_util.tree_map(
+                lambda old, new: ema_beta * old + (1.0 - ema_beta) * new,
+                state.ema_params,
+                params,
+            )
+
+        watch_stats = None
+        if watch_config is not None and compute_watch:
+            watch_stats = compute_watch_stats(
+                watch_targets=watch_targets,
+                include_norms=watch_config.include_norms,
+                include_per_parameter_norms=watch_config.include_per_parameter_norms,
+                include_histogram=watch_config.include_histograms,
+                split_scan_layers=watch_config.split_scan_layers,
+                params=state.params,
+                grads=grads,
+                updates=updates,
+                opt_state=state.opt_state,
+                model_tree_type=type(state.params),
+            )
+
+        next_state = dataclasses.replace(
+            state,
+            step=state.step + one,
+            params=params,
+            opt_state=opt_state,
+            ema_params=ema_params,
+        )
+
+        metrics = {"train/loss": loss}
+        if backward_flow_stats is not None:
+            metrics[_BACKWARD_FLOW_METRICS_KEY] = backward_flow_stats
+
+        return next_state, metrics, watch_stats
+
+    return train_step
+
+
+def _run_grug_local(config: GrugRunConfig) -> None:
+    """Entry point for the grug template training loop."""
+    trainer = config.trainer.trainer
+    trainer.initialize()
+    levanter.tracker.log_configuration(config)
+
+    run_id = trainer.id
+    if run_id is None:
+        raise ValueError("trainer.id was not initialized")
+
+    optimizer = config.optimizer.build(trainer.num_train_steps)
+    watch_config = trainer.watch
+    backward_flow_config = config.trainer.backward_flow if config.trainer.backward_flow.is_enabled else None
+    train_step = _make_train_step(
+        optimizer,
+        trainer.mp,
+        z_loss_weight=config.trainer.z_loss_weight,
+        loss_implementation=config.trainer.loss_implementation,
+        ema_beta=config.trainer.ema_beta,
+        watch_config=watch_config if watch_config.is_enabled else None,
+        backward_flow_config=backward_flow_config,
+    )
+
+    data_key, model_key = jax.random.split(jax.random.PRNGKey(trainer.seed), 2)
+    if config.trainer.data_seed is not None:
+        data_key = jax.random.PRNGKey(config.trainer.data_seed)
+
+    # Grug uses raw PartitionSpecs rather than Trainer's logical axis mapping.
+    # Keep the mesh compact so P(("replica_dcn", "data")) spans slices directly.
+    mesh = compact_grug_mesh()
+    with set_mesh(mesh):
+        batch_schedule = trainer.batch_schedule
+
+        train_dataset = build_train_dataset(
+            config.data,
+            max_seq_len=config.model.max_seq_len,
+            batch_schedule=batch_schedule,
+            key=data_key,
+        )
+        train_loader = build_train_loader(
+            train_dataset,
+            batch_schedule=batch_schedule,
+            mesh=mesh,
+            batch_pspec=config.trainer.train_batch_pspec,
+        )
+
+        @jax.jit
+        def _init_state(model_rng):
+            return initial_state(
+                config.model,
+                optimizer=optimizer,
+                mp=trainer.mp,
+                key=model_rng,
+                ema_beta=config.trainer.ema_beta,
+            )
+
+        state = _init_state(model_key)
+
+        checkpointer = trainer.checkpointer.create(run_id)
+        state = restore_grug_state_from_checkpoint(
+            state,
+            checkpoint_search_paths=trainer.checkpoint_search_paths(run_id),
+            load_checkpoint_setting=trainer.load_checkpoint,
+            mesh=mesh,
+            allow_partial=trainer.allow_partial_checkpoint,
+        )
+        dump_grug_state_sharding_run_artifact(
+            state,
+            log_dir=trainer.log_dir,
+            run_id=run_id,
+            path_override=config.trainer.sharding_dump_path,
+        )
+
+        levanter.tracker.log_summary({"parameter_count": parameter_count(state.params)})
+
+        flops_per_example, flops_summary = _compute_flops(model_config=config.model)
+        levanter.tracker.log_summary(flops_summary)
+
+        eval_cfg = config.eval
+        evaluator = None
+        if eval_cfg is not None:
+            evaluator = build_tagged_evaluator(
+                data_config=config.data,
+                max_seq_len=config.model.max_seq_len,
+                mesh=mesh,
+                eval_cfg=eval_cfg,
+            )
+
+        profiler_cfg = trainer.profiler
+        profiler_num_steps = profiler_cfg.resolve_num_profile_steps(num_train_steps=trainer.num_train_steps)
+        profiler_enabled = profiler_cfg.is_enabled and profiler_num_steps > 0
+
+        log_every = max(1, config.trainer.log_every)
+        iterator = LoadingTimeTrackerIterator(train_loader.iter_from_step(int(state.step)))
+
+        state_callbacks = StateCallbackRunner[GrugTrainState](
+            step_getter=lambda s: s.step,
+            model_getter=lambda s: s.params,
+            eval_model_getter=lambda s: s.ema_params if s.ema_params is not None else s.params,
+            opt_state_getter=lambda s: s.opt_state,
+        )
+        state_callbacks.add_hook(
+            callbacks.log_performance_stats(config.model.max_seq_len, batch_schedule, flops_per_example),
+            every=log_every,
+        )
+        state_callbacks.add_hook(callbacks.pbar_logger(total=trainer.num_train_steps), every=log_every)
+        state_callbacks.add_hook(callbacks.log_step_info(trainer.num_train_steps), every=log_every)
+        if profiler_enabled:
+            state_callbacks.add_hook(
+                callbacks.profile(
+                    str(trainer.log_dir / run_id / "profiler"),
+                    profiler_cfg.start_step,
+                    profiler_num_steps,
+                    profiler_cfg.perfetto_link,
+                ),
+                every=1,
+            )
+        state_callbacks.add_hook(_make_mixture_stage_callback(train_dataset, batch_schedule), every=1)
+        state_callbacks.add_hook(log_value_emb_lambdas, every=log_every)
+        if evaluator is not None and eval_cfg is not None:
+            interval = eval_cfg.steps_per_eval
+            eval_ema = eval_cfg.eval_ema and config.trainer.ema_beta is not None
+            if interval is not None and interval > 0 and (eval_cfg.eval_current or eval_ema):
+                state_callbacks.add_hook(
+                    cb_tagged_evaluate(
+                        evaluator,
+                        prefix=eval_cfg.prefix,
+                        eval_current=eval_cfg.eval_current,
+                        eval_ema=eval_ema,
+                    ),
+                    every=interval,
+                )
+
+        last_loss: float | jax.Array = 0.0
+        last_step_duration = 0.0
+        backward_flow_graph: BackwardFlowGraph | None = None
+
+        # Main optimization loop.
+        try:
+            while int(state.step) < trainer.num_train_steps:
+                with jax.profiler.TraceAnnotation("load_batch"):
+                    batch = next(iterator)
+                step_start = time.perf_counter()
+                current_step = int(state.step)
+                # grad_watch runs only on its configured interval.
+                compute_watch = (
+                    watch_config.is_enabled and watch_config.interval > 0 and current_step % watch_config.interval == 0
+                )
+                compute_backward_flow = (
+                    backward_flow_config is not None
+                    and backward_flow_config.interval > 0
+                    and current_step % backward_flow_config.interval == 0
+                )
+                state, metrics, watch_stats = train_step(
+                    state,
+                    batch,
+                    compute_watch=compute_watch,
+                    compute_backward_flow=compute_backward_flow,
+                )
+                backward_flow_stats = metrics.get(_BACKWARD_FLOW_METRICS_KEY)
+                if backward_flow_stats is not None:
+                    metrics = {key: value for key, value in metrics.items() if key != _BACKWARD_FLOW_METRICS_KEY}
+                step = int(state.step) - 1
+
+                jax.block_until_ready(metrics["train/loss"])
+                duration = time.perf_counter() - step_start
+                backward_flow_timing_metrics = None
+                if compute_backward_flow:
+                    backward_flow_timing_metrics = {"backward_flow/compute_step_duration": duration}
+
+                hook_start = time.perf_counter()
+                with jax.profiler.TraceAnnotation("callbacks"):
+                    state_callbacks.run(state, loss=metrics["train/loss"], step_duration=duration)
+                    last_loss = metrics["train/loss"]
+                    last_step_duration = duration
+                    levanter.tracker.log({"throughput/hook_time": time.perf_counter() - hook_start}, step=step)
+                    levanter.tracker.log({"throughput/loading_time": iterator.this_load_time}, step=step)
+
+                    if watch_stats is not None:
+                        levanter.tracker.log(watch_stats, step=step)
+                    if backward_flow_timing_metrics is not None:
+                        levanter.tracker.log(backward_flow_timing_metrics, step=step)
+                    if backward_flow_stats:
+                        levanter.tracker.log(backward_flow_stats, step=step)
+                        if backward_flow_graph is None:
+                            backward_flow_graph = _build_backward_flow_graph(
+                                params=state.params,
+                                batch=batch,
+                                mp=trainer.mp,
+                                z_loss_weight=config.trainer.z_loss_weight,
+                            )
+                        artifact_start = time.perf_counter()
+                        _write_backward_flow_artifact(
+                            graph=backward_flow_graph,
+                            backward_flow_metrics=backward_flow_stats,
+                            log_dir=trainer.log_dir,
+                            run_id=run_id,
+                            step=step,
+                        )
+                        levanter.tracker.log(
+                            {"backward_flow/artifact_write_duration": time.perf_counter() - artifact_start},
+                            step=step,
+                        )
+
+                if checkpointer is not None:
+                    checkpointer.on_step(tree=state, step=int(state.step))
+        except BaseException:
+            logger.exception(
+                "Fatal error in grug training loop; skipping final callbacks/checkpoint to preserve root cause"
+            )
+            raise
+        else:
+            # Mirror classic trainer behavior: force callbacks on the last completed step.
+            state_callbacks.run(state, loss=last_loss, step_duration=last_step_duration, force=True)
+            if checkpointer is not None:
+                checkpointer.on_step(tree=state, step=int(state.step), force=True)
+                checkpointer.wait_until_finished()
+
+    levanter.tracker.current_tracker().finish()
+
+
+def run_grug(config: GrugRunConfig) -> None:
+    """Dispatch grug training through Fray jobs."""
+    trainer = config.trainer.trainer
+    if trainer.id is None:
+        raise ValueError("trainer.id must be set before dispatching grug training.")
+
+    dispatch_grug_training_run(
+        run_id=trainer.id,
+        config=config,
+        local_entrypoint=_run_grug_local,
+        resources=config.resources,
+    )
+
+
+__all__ = [
+    "GrugEvalConfig",
+    "GrugRunConfig",
+    "GrugTrainState",
+    "GrugTrainerConfig",
+    "initial_state",
+    "run_grug",
+]

--- a/tests/test_grug_ve.py
+++ b/tests/test_grug_ve.py
@@ -1,0 +1,287 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavior tests for the grug value-embedding variant.
+
+The variant's claims are that the value-embedding table enters the model only through the
+attention value path -- leaving the attention pattern identical to the base model's -- and that
+the table and its per-layer gates actually learn. These tests pin both.
+"""
+
+import dataclasses
+import json
+import logging
+import uuid
+from io import StringIO
+from pathlib import Path
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+import pytest
+from fray.cluster import ResourceConfig
+from jax.sharding import AxisType
+from levanter.analysis.backward_flow import BackwardFlowConfig
+from levanter.checkpoint import CheckpointerConfig
+from levanter.data.dataset import ListAsyncDataset
+from levanter.data.text.datasets import DirectDatasetComponent, LmDataConfig
+from levanter.data.text.examples import GrugLmExample
+from levanter.distributed import DistributedConfig
+from levanter.tracker.json_logger import JsonLoggerConfig
+from levanter.trainer import TrainerConfig
+
+from experiments.grug.ve.launch import _OPTIMIZER
+from experiments.grug.ve.model import GrugModelConfig, Transformer
+from experiments.grug.ve.train import GrugRunConfig, GrugTrainerConfig, run_grug
+
+# Grouped-query attention on purpose: v carries num_kv_heads heads, not num_heads, so a value
+# table sized to hidden_dim would be shape-wrong here while passing under a MHA config.
+GQA_CONFIG = GrugModelConfig(
+    vocab_size=64,
+    hidden_dim=32,
+    intermediate_dim=64,
+    num_layers=3,
+    num_heads=8,
+    num_kv_heads=2,
+    max_seq_len=16,
+    value_emb_lambda_init=0.5,
+)
+
+TOKENS = jnp.asarray([[3, 1, 4, 1, 5, 9, 2, 6]], dtype=jnp.int32)
+
+
+@pytest.fixture
+def mesh():
+    """The model's ``reshard`` calls need a mesh; one device is enough to check numerics.
+
+    Not autouse: the training loop enters its own mesh, and nesting the two would not reflect
+    how the model is actually constructed at run time.
+    """
+    device_mesh = jax.make_mesh(
+        (1, 1, 1),
+        ("replica_dcn", "data", "model"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit, AxisType.Explicit),
+    )
+    with jax.set_mesh(device_mesh):
+        yield device_mesh
+
+
+def _drop_value_embeddings(model: Transformer) -> Transformer:
+    """The control twin: the same weights, with the value-embedding table removed.
+
+    Every other parameter is shared with ``model``, so a difference in output between the two
+    is attributable to the value embeddings and to nothing else -- not to a different init draw.
+    """
+    return eqx.tree_at(lambda m: m.value_embed, model, None, is_leaf=lambda x: x is None)
+
+
+def _with_lambdas(model: Transformer, value: float) -> Transformer:
+    return eqx.tree_at(
+        lambda m: [block.attn.lambda_ve for block in m.blocks],
+        model,
+        [jnp.asarray(value, dtype=jnp.float32)] * len(model.blocks),
+    )
+
+
+def test_zero_lambda_is_exactly_the_base_model(mesh):
+    """At lambda=0 the blend contributes nothing, so the model must reduce to the base model.
+
+    This is the claim that the value embeddings touch only ``v``: if the table leaked into q, k,
+    or the residual stream, zeroing the value-path gate would not recover the base model's
+    logits bit-for-bit.
+    """
+    model = Transformer.init(GQA_CONFIG, key=jax.random.PRNGKey(0))
+    control = _drop_value_embeddings(model)
+
+    gated_off = _with_lambdas(model, 0.0).logits(TOKENS)
+    baseline = control.logits(TOKENS)
+
+    np.testing.assert_array_equal(np.asarray(gated_off), np.asarray(baseline))
+
+
+def test_open_gate_changes_the_output(mesh):
+    """A nonzero gate must actually route the stored memory into the output.
+
+    The companion to the test above: without this, a model that silently ignored ``ve``
+    entirely would still pass the lambda=0 equivalence check.
+    """
+    model = Transformer.init(GQA_CONFIG, key=jax.random.PRNGKey(0))
+    control = _drop_value_embeddings(model)
+
+    gated_on = _with_lambdas(model, 0.5).logits(TOKENS)
+    baseline = control.logits(TOKENS)
+
+    assert not np.allclose(np.asarray(gated_on), np.asarray(baseline))
+
+
+def test_value_table_is_sized_to_the_kv_width(mesh):
+    """The table is blended into ``v``, so a row must be exactly one value vector wide."""
+    model = Transformer.init(GQA_CONFIG, key=jax.random.PRNGKey(0))
+    head_dim = GQA_CONFIG.inferred_head_dim
+
+    assert model.value_embed is not None
+    assert model.value_embed.shape == (GQA_CONFIG.vocab_size, GQA_CONFIG.num_kv_heads * head_dim)
+
+
+def test_disabled_variant_carries_no_value_embedding_parameters(mesh):
+    """The control arm of the ablation must not pay for a table it does not use."""
+    config = dataclasses.replace(GQA_CONFIG, value_emb_lambda_init=None)
+    model = Transformer.init(config, key=jax.random.PRNGKey(0))
+
+    assert model.value_embed is None
+    assert model.value_emb_lambdas() == ()
+
+
+def test_training_moves_the_table_and_the_gates(mesh):
+    """The table and the per-layer gates must both receive gradient and move under an update.
+
+    A gate stuck at its init, or a table that never updates, would make the whole experiment
+    measure nothing -- and both are silent failures rather than crashes.
+    """
+    model = Transformer.init(GQA_CONFIG, key=jax.random.PRNGKey(0))
+    loss_weight = jnp.ones_like(TOKENS, dtype=jnp.float32)
+
+    def loss_fn(m: Transformer) -> jax.Array:
+        return m.next_token_loss(TOKENS, loss_weight)
+
+    grads = eqx.filter_grad(loss_fn)(model)
+
+    assert grads.value_embed is not None
+    assert jnp.any(grads.value_embed != 0), "value-embedding table received no gradient"
+    for i, lam_grad in enumerate(grads.value_emb_lambdas()):
+        assert lam_grad != 0, f"lambda gate at layer {i} received no gradient"
+
+    optimizer = optax.adam(1e-2)
+    params = eqx.filter(model, eqx.is_inexact_array)
+    updates, _ = optimizer.update(eqx.filter(grads, eqx.is_inexact_array), optimizer.init(params), params)
+    updated = eqx.apply_updates(model, updates)
+
+    for i, (before, after) in enumerate(zip(model.value_emb_lambdas(), updated.value_emb_lambdas(), strict=True)):
+        assert not jnp.allclose(before, after), f"lambda gate at layer {i} did not move under an update"
+
+
+@pytest.mark.parametrize("lambda_init", [0.0, 0.5, 1.0])
+def test_forward_pass_runs_across_the_gate_range(mesh, lambda_init: float):
+    """The blend must be well-formed at both ends of its range, not just in the middle.
+
+    lambda=1 is the degenerate 'stored memory only' case: the value path stops depending on the
+    hidden state at all, and it must still produce finite logits rather than NaNs.
+    """
+    config = dataclasses.replace(GQA_CONFIG, value_emb_lambda_init=lambda_init)
+    model = Transformer.init(config, key=jax.random.PRNGKey(0))
+
+    logits = model.logits(TOKENS)
+
+    assert logits.shape == (*TOKENS.shape, config.vocab_size)
+    assert jnp.all(jnp.isfinite(logits))
+
+
+def test_lambda_gates_are_exempt_from_weight_decay(mesh):
+    """The launch optimizer must not decay the per-layer gates.
+
+    Levanter's default mask decays them (it only exempts norms, biases, and ``*Embedding*``
+    class names, and grug's parameters are raw arrays). A decayed gate is pulled toward zero
+    every step regardless of gradient, which confounds the lambda-vs-depth readout the
+    experiment exists to produce. The matrices and both embedding tables must keep their decay:
+    the exemption is for the gates, not a change to the rest of the recipe.
+    """
+    model = Transformer.init(GQA_CONFIG, key=jax.random.PRNGKey(0))
+    mask = _OPTIMIZER.build_weight_decay_mask()(model)
+
+    for i, block_mask in enumerate(mask.blocks):
+        assert block_mask.attn.lambda_ve is False, f"lambda gate at layer {i} would be decayed"
+        assert block_mask.attn.w_q is True
+        assert block_mask.rms_attn.weight is False
+    assert mask.token_embed is True
+    assert mask.value_embed is True
+    assert mask.output_proj is True
+
+
+def _run_one_step(tmp_path: Path, *, logger_name: str, value_emb_lambda_init: float | None) -> dict:
+    """Train the variant for one step against an in-memory dataset; return the run's summary."""
+    vocab_size, seq_len = 128, 32
+    examples = [GrugLmExample.causal((jnp.arange(seq_len, dtype=jnp.int32) + i) % vocab_size) for i in range(8)]
+    eval_examples = [GrugLmExample.causal((jnp.arange(seq_len, dtype=jnp.int32) + 100) % vocab_size)]
+    data_config = LmDataConfig(
+        components={
+            "direct": DirectDatasetComponent(
+                datasets={"train": ListAsyncDataset(examples), "validation": ListAsyncDataset(eval_examples)}
+            )
+        },
+        vocab_size=vocab_size,
+        tokenizer="passthrough",
+    )
+
+    stream = StringIO()
+    handler = logging.StreamHandler(stream)
+    logger = logging.getLogger(logger_name)
+    logger.handlers.clear()
+    logger.propagate = False
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+    try:
+        run_grug(
+            GrugRunConfig(
+                model=GrugModelConfig(
+                    vocab_size=vocab_size,
+                    hidden_dim=32,
+                    intermediate_dim=64,
+                    num_layers=2,
+                    num_heads=2,
+                    num_kv_heads=2,
+                    max_seq_len=seq_len,
+                    value_emb_lambda_init=value_emb_lambda_init,
+                ),
+                data=data_config,
+                resources=ResourceConfig.with_cpu(),
+                trainer=GrugTrainerConfig(
+                    trainer=TrainerConfig(
+                        id=f"test-{logger_name}",
+                        num_train_steps=1,
+                        train_batch_size=max(1, len(jax.devices())),
+                        tracker=JsonLoggerConfig(logger_name=logger_name),
+                        require_accelerator=False,
+                        use_explicit_mesh_axes=True,
+                        distributed=DistributedConfig(initialize_jax_distributed=False),
+                        log_dir=tmp_path / "logs",
+                        checkpointer=CheckpointerConfig(base_path=str(tmp_path / "checkpoints")),
+                    ),
+                    log_every=1,
+                    backward_flow=BackwardFlowConfig(interval=0),
+                ),
+                eval=None,
+            )
+        )
+    finally:
+        logger.removeHandler(handler)
+
+    records = [json.loads(line) for line in stream.getvalue().splitlines() if line.strip()]
+    finish = [record for record in records if record.get("event") == "finish"]
+    assert len(finish) == 1
+    return finish[0]["summary"]
+
+
+def test_training_run_reports_a_lambda_per_layer(tmp_path: Path):
+    """The per-layer gates must reach the tracker: they are the experiment's readout.
+
+    Drives the real training loop rather than the callback in isolation, so a gate that is never
+    logged -- the failure that would leave the run un-analyzable after the GPU time is spent --
+    is caught here.
+    """
+    summary = _run_one_step(tmp_path, logger_name=f"grug_ve_{uuid.uuid4().hex}", value_emb_lambda_init=0.5)
+
+    assert summary["ve/lambda/layer_0"] == pytest.approx(0.5, abs=0.1)
+    assert summary["ve/lambda/layer_1"] == pytest.approx(0.5, abs=0.1)
+    assert "ve/lambda/mean" in summary
+    assert "train/loss" in summary
+
+
+def test_control_arm_trains_and_reports_no_lambdas(tmp_path: Path):
+    """The control arm must run the same loop and simply have no gates to report."""
+    summary = _run_one_step(tmp_path, logger_name=f"grug_base_{uuid.uuid4().hex}", value_emb_lambda_init=None)
+
+    assert "train/loss" in summary
+    assert not [key for key in summary if key.startswith("ve/lambda")]


### PR DESCRIPTION
Add a grug variant implementing value embeddings from the modded-nanogpt lineage: a second token-indexed embedding table, shared across all layers, blended into each layer's attention value path under a learnable per-layer scalar gate. Queries and keys are untouched, so the attention pattern is the base model's exactly; the table costs vocab x kv_width parameters and one lookup per forward pass, with no added matmul FLOPs. The table is sized to the KV width so the blend stays shape-correct under grouped-query attention.

The launch is a three-arm experiment at 130M on fineweb-edu (single GPU): ve (gate on), base (same code path with the knob None), and wide (parameter-matched control that spends the VE table's exact parameter count on MLP width instead — params-matched but FLOPs-over-matched, so a ve win over wide is the strongest form of the mechanism claim). A 1.3B confirmation rung is configured but not yet run.

Two defaults are deliberately overridden. The lambda gates are exempted from weight decay via an explicit inclusion list: the default mask decays them, pulling every gate toward zero regardless of gradient, which both suppresses the mechanism and makes the lambda-vs-depth readout unreadable. Backward-flow tracing is off: traced steps run without per-block activation checkpointing and OOM a 95GB device at this size.

First paired run (130M, batch 64, 1.05B tokens, one H100): ve beats base by 0.034 nats at equal tokens, stable from step 2k. The learned gate profile is monotone in depth — lambda ~1.0 at layer 0 falling to ~-1.8 at the last layer, i.e. late layers subtract token identity rather than reading it out — which differs from the speedrun's early-and-late placement. VE steps ran ~10% slower than base on that card. The wide control is queued; tests pin the value path (lambda=0 recovers base logits bit-for-bit against a weight-shared control), GQA table sizing, gradient flow, the weight-decay exemption, and per-layer lambda logging through the real training loop.