### PR TITLE
[iris] Raise jax.distributed.initialize timeout to 1800s for large-gang cold restarts

### DIFF
--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -225,13 +225,19 @@ def _initialize_supervised_jax(
         device_ids,
         coordinator,
     )
-    jax.distributed.initialize(coordinator, proc_count, proc_index, local_device_ids=device_ids)
+    jax.distributed.initialize(
+        coordinator,
+        proc_count,
+        proc_index,
+        local_device_ids=device_ids,
+        initialization_timeout=_JAX_DIST_INIT_TIMEOUT,
+    )
 
 
 def initialize_jax(
     port: int = 8476,
     endpoint_name: str = "jax_coordinator",
-    poll_timeout: float = 300.0,
+    poll_timeout: float = _JAX_DIST_INIT_TIMEOUT,
     poll_interval: float = 2.0,
 ) -> None:
     """Initialize JAX distributed runtime using Iris endpoint discovery.
@@ -252,7 +258,10 @@ def initialize_jax(
             An explicit port is required because JAX's gRPC coordinator binds
             internally and does not expose the actual bound port.
         endpoint_name: Name under which the coordinator registers.
-        poll_timeout: Maximum seconds for non-coordinator tasks to wait.
+        poll_timeout: Maximum seconds for non-coordinator tasks to wait for the
+            coordinator endpoint to register. Defaults to ``_JAX_DIST_INIT_TIMEOUT``
+            so a slow coordinator host on a large-gang cold restart does not abort
+            the pollers before the JAX barrier itself gets its longer timeout.
         poll_interval: Initial backoff delay for polling (seconds).
     """
     import jax  # noqa: PLC0415  # optional dep: jax (iris does not depend on jax)

--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -32,6 +32,12 @@ from iris.runtime.multigpu import (
 logger = logging.getLogger(__name__)
 
 _COMPILATION_CACHE_SUBDIR = "compilation-cache"
+# JAX's RegisterTask barrier defaults to 300s. On a large gang (e.g. v5p-64 = 8 hosts) a
+# preemption-driven cold restart can have a random subset of hosts still doing uv-sync/import/
+# GCS-read setup past 300s, so the already-registered hosts hit DEADLINE_EXCEEDED and abort the
+# whole gang. Give cold gang-init more slack; a longer timeout only affects how long a
+# genuinely-stuck init waits.
+_JAX_DIST_INIT_TIMEOUT = 1800
 
 _JAX_ENV_KEYS = (
     "IRIS_TASK_ID",
@@ -311,7 +317,11 @@ def initialize_jax(
         # Best-effort cleanup: if the process crashes, the controller's
         # cascade delete on task cleanup handles endpoint removal.
         atexit.register(ctx.registry.unregister, endpoint_id)
-        jax.distributed.initialize(coordinator, job_info.num_tasks, task_index)
+        jax.distributed.initialize(
+            coordinator, job_info.num_tasks, task_index, initialization_timeout=_JAX_DIST_INIT_TIMEOUT
+        )
     else:
         coordinator = _poll_for_coordinator(ctx.resolver, endpoint_name, poll_timeout, poll_interval)
-        jax.distributed.initialize(coordinator, job_info.num_tasks, task_index)
+        jax.distributed.initialize(
+            coordinator, job_info.num_tasks, task_index, initialization_timeout=_JAX_DIST_INIT_TIMEOUT
+        )


### PR DESCRIPTION
JAX's `RegisterTask` barrier defaults to 300s. On a large gang (e.g. v5p-64 = 8 hosts) a preemption-driven cold restart can leave a random subset of hosts still doing uv-sync / import / GCS-read setup past 300s, so the already-registered hosts hit `DEADLINE_EXCEEDED` and abort the whole gang.

This passes `initialization_timeout=1800` on both the coordinator and worker `jax.distributed.initialize` calls in `iris.runtime.jax_init`. A longer timeout only affects how long a genuinely-stuck init waits before failing.
