### PR TITLE
[levanter] Use the padded tokenizer's vocab for the Vocab axis under pad_tokenizer_to_match_model

### DIFF
--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -152,6 +152,8 @@ def main(config: TrainLmConfig):
 
         if config.pad_tokenizer_to_match_model:
             converter = converter.with_tokenizer_padded_to_match_model()
+            # Rebind so the Vocab axis below (built from ``len(tokenizer)``) reflects the padded vocab.
+            tokenizer = converter.tokenizer
 
         if config.use_hf_model_config:
             # TODO: log diff of old and new config
@@ -162,6 +164,8 @@ def main(config: TrainLmConfig):
         converter = converter.replaced(tokenizer=tokenizer)
         if config.pad_tokenizer_to_match_model:
             converter = converter.with_tokenizer_padded_to_match_model()
+            # Rebind so the Vocab axis below (built from ``len(tokenizer)``) reflects the padded vocab.
+            tokenizer = converter.tokenizer
     else:
         converter = None
 


### PR DESCRIPTION
`with_tokenizer_padded_to_match_model()` returns a converter whose tokenizer is padded up to the model's vocab, but `train_lm.main` kept its local `tokenizer` variable pointing at the original unpadded tokenizer. The `Vocab` axis is built later from `len(tokenizer)`, so under `pad_tokenizer_to_match_model=True` it was still sized to the unpadded vocab while the checkpoint being loaded has the larger, padded embedding.

For a model whose embedding is padded past its tokenizer (e.g. Qwen3: model 151936 vs tokenizer 151669) this produced a Vocab-size pytree mismatch at `train_step` tracing — and, for tied embeddings, at `optimizer.update` where the opt-state `Vocab` disagreed with the loaded params.

Rebind `tokenizer` to the padded converter tokenizer at both pad sites so the `Vocab` axis matches the model's embedding. No effect when the flag is off (the default).
