### PR TITLE
grug(june 67B-A2B): tensor-parallel-safe attention QKV head split/merge (explicit out_sharding)

### DIFF
--- a/experiments/june_tpu_67b_a2b/moe/model.py
+++ b/experiments/june_tpu_67b_a2b/moe/model.py
@@ -248,9 +248,21 @@ class CausalSelfAttention(eqx.Module):
         seq_len = x.shape[1]
         batch_spec = _batch_spec()
 
-        q = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_q), "... (n d) -> ... n d", d=head_dim)
-        k = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_k), "... (m d) -> ... m d", d=head_dim)
-        v = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_v), "... (m d) -> ... m d", d=head_dim)
+        # Split the flattened head dim (num_heads * head_dim) into (heads, head_dim).
+        # Under tensor/model parallelism the projection output's last dim is sharded over the
+        # ``model`` axis, and JAX's explicit-mesh reshape cannot infer which output axis carries
+        # that sharding on a split -> pass out_sharding explicitly (model on the head axis,
+        # head_dim replicated). At model_axis==1 this is byte-identical to the old einops rearrange.
+        _qkv_head_spec = P(_BATCH_AXES, None, "model", None)
+        q = jnp.einsum("bsh,hd->bsd", x, self.w_q).reshape(
+            (x.shape[0], seq_len, -1, head_dim), out_sharding=_qkv_head_spec
+        )
+        k = jnp.einsum("bsh,hd->bsd", x, self.w_k).reshape(
+            (x.shape[0], seq_len, -1, head_dim), out_sharding=_qkv_head_spec
+        )
+        v = jnp.einsum("bsh,hd->bsd", x, self.w_v).reshape(
+            (x.shape[0], seq_len, -1, head_dim), out_sharding=_qkv_head_spec
+        )
 
         # Shift the second half of K's head_dim back by one position so the
         # query at position i sees K[i] on head_dim[:half] but K[i-1] on
@@ -311,7 +323,12 @@ class CausalSelfAttention(eqx.Module):
         # Headwise gating: sigmoid(x @ attn_gate) produces one scalar per head.
         gate = 2 * jax.nn.sigmoid(jnp.einsum("bsd,dn->bsn", x, self.attn_gate))[..., None]
         attn_out = gate * attn_out
-        attn_out = rearrange(attn_out, "... n d -> ... (n d)")
+        # Merge (heads, head_dim) back to a flat head dim. The head axis is sharded over ``model``
+        # (tensor parallel), so pin the merged dim's sharding explicitly rather than relying on
+        # explicit-mesh reshape inference. At model_axis==1 this equals the old einops rearrange.
+        attn_out = attn_out.reshape(
+            (attn_out.shape[0], attn_out.shape[1], -1), out_sharding=P(_BATCH_AXES, None, "model")
+        )
         return jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=batch_spec)
 
 


### PR DESCRIPTION
## What

The attention QKV head split/merge in `experiments/june_tpu_67b_a2b/moe/model.py` reshapes a dimension that, under model/tensor parallelism (`model_axis > 1`), is sharded over the `model` axis. JAX's explicit-mesh reshape cannot infer the output sharding when splitting that dim into `(heads, head_dim)` (or merging it back), so `train_step` fails at **trace time**:

```
jax._src.core.ShardingTypeError: This reshape is not supported. Please specify the sharding
of the output via the out_sharding argument of jax.lax.reshape.
Got operand type: bfloat16[8@(replica_dcn,data,expert),32768,640@model], new sizes: (8,32768,5,128)
```

This PR passes `out_sharding` explicitly:
- split (`w_q/w_k/w_v` → `(B,S,heads,head_dim)`): `P(_BATCH_AXES, None, "model", None)` — `model` on the head axis, `head_dim` replicated.
- merge (back to a flat head dim before `w_o`): `P(_BATCH_AXES, None, "model")`.

## Safety

**Byte-identical at `model_axis == 1`** (the only configuration exercised today) — with a size-1 `model` axis the `out_sharding` is a no-op relative to the previous einops `rearrange`. Verified the change traces cleanly *past* the attention stage on a `model_axis=5` run (the original `ShardingTypeError` is gone). `rearrange` remains imported/used elsewhere. ruff clean.

## Known follow-up — why full TP still can't run for this 67B-A2B config

This unblocks the **attention** stage, but full tensor parallelism for this specific model is still blocked downstream by a coprimality constraint (documented here so the next person doesn't rediscover it): `model_axis > 1` must divide **both**
- `num_kv_heads = 5` (prime → valid widths `{1, 5}`) for the GQA head split, **and**
- `vocab_size = 128256` for the vocab-parallel `embed`/`lm_head` (`Pembed_vocab`/`Plm_head` shard vocab over `model`),

but `128256 % 5 != 0`, so no `model_axis > 1` satisfies both (the `model=5` run fails next at the embed/lm_head vocab shard). Enabling full TP additionally requires either padding `vocab_size` to a multiple of the TP width or re-sharding `embed`/`lm_head` on `hidden` (2560, divisible by 5) instead of `vocab`. Out of scope for this PR.