### PR TITLE
[iris] cw-us-east-08a: admit wg0420@princeton.edu as federated submitter

### DIFF
--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -114,7 +114,7 @@ auth:
       -----BEGIN PUBLIC KEY-----
       MCowBQYDK2VwAyEA42ziFTlGKgaA/fQ1wJCONKOml7rx5Y8UAQqVLTCtrCo=
       -----END PUBLIC KEY-----
-  allowed_submitters: ["*@openathena.ai"]
+  allowed_submitters: ["*@openathena.ai", "wg0420@princeton.edu"]
 
 kubernetes_provider:
   namespace: iris


### PR DESCRIPTION
Add `wg0420@princeton.edu` to `allowed_submitters` on cw-us-east-08a so jobs this user submits to marin federate onto the GB200 cluster. The peer checks the asserted `submitting_user` against this allowlist at the federation handoff; it previously admitted only `*@openathena.ai`, so a princeton.edu submitter was rejected.

Takes effect once the cw-us-east-08a controller is reloaded/redeployed (config is rebuilt on start).

Companion change (not in this repo): the user was granted `roles/iap.httpsResourceAccessor` on the `iris-marin-be` backend service in `hai-gcp-models`, which is what lets them reach the marin controller in the first place.