### PR TITLE
[finelog] Budget compaction merges by measured Arrow bytes, not parquet footer size

### DIFF
--- a/lib/finelog/rust/src/store/compaction/config.rs
+++ b/lib/finelog/rust/src/store/compaction/config.rs
@@ -24,19 +24,28 @@ pub struct CompactionConfig {
     /// Per-level fanout cap. Promotes a non-terminal level once its contiguous
     /// run reaches this many segments, even if the byte target isn't met.
     pub max_segments_per_level: usize,
-    /// Ceiling on the summed UNCOMPRESSED size of a merge job's inputs.
+    /// Ceiling on the summed ARROW-MATERIALIZED size of a merge job's inputs.
     ///
     /// `level_targets` bound a job's COMPRESSED input size, but the merge decodes
     /// every input into Arrow arrays and the k-way merge builds the whole merged
-    /// copy before either is freed. Peak RSS is therefore about twice this
-    /// ceiling, plus the merge's sort-key row encodings — not the compressed
-    /// size, which log text undershoots by 10-20x. This is the knob that bounds
-    /// merge memory.
+    /// copy before either is freed, so peak RSS is about twice this ceiling plus
+    /// the sort-key row encodings.
     ///
-    /// A run whose first segment alone exceeds the ceiling yields a single-input
-    /// job, which the executor promotes by rename instead of merging, so an
-    /// oversized segment never wedges its level.
-    pub max_merge_uncompressed_bytes: i64,
+    /// The ceiling is denominated in Arrow bytes and enforced by the executor
+    /// against `RecordBatch::get_array_memory_size` as it reads, because no
+    /// cheaper proxy tracks it. Both parquet sizes in a segment's footer
+    /// understate a decoded log-text column by ~7-20x: the compressed size
+    /// because zstd folds repeated lines away, and `total_byte_size` — despite
+    /// naming itself uncompressed — because it measures DICTIONARY-ENCODED
+    /// pages, where a repeated log line costs one 4-byte index rather than its
+    /// full text. Budgeting against either one is what OOM-killed the `log`
+    /// namespace: a job the footer called 1.9 GiB materialized ~15 GiB.
+    ///
+    /// The executor merges the longest prefix of the job's inputs that fits and
+    /// leaves the rest for the next tick; a single input over the ceiling is
+    /// promoted by rename instead of merged, so an oversized segment costs no
+    /// merge memory and never wedges its level.
+    pub max_merge_arrow_bytes: i64,
     /// Whole-namespace segment cap (eviction trigger).
     pub max_segments_per_namespace: usize,
     /// Whole-namespace byte cap on locally-retained segments (eviction trigger).
@@ -54,7 +63,9 @@ impl Default for CompactionConfig {
         CompactionConfig {
             level_targets: vec![64 * MIB, 256 * MIB, 256 * MIB],
             max_segments_per_level: 32,
-            max_merge_uncompressed_bytes: 4 * GIB,
+            // ~2x this in peak merge RSS. Sized for the 32 GiB hub box, whose
+            // query pool may hold 21 GiB concurrently.
+            max_merge_arrow_bytes: 4 * GIB,
             max_segments_per_namespace: 1000,
             max_bytes_per_namespace: 15 * 1024 * 1024 * 1024,
             check_interval: Duration::from_secs(30),

--- a/lib/finelog/rust/src/store/compaction/config.rs
+++ b/lib/finelog/rust/src/store/compaction/config.rs
@@ -81,10 +81,13 @@ impl CompactionConfig {
 }
 
 /// One pending merge: `inputs.len()` segments -> one `output_level` segment.
+///
+/// `output_min_seq` names the output file. There is no `output_max_seq`: the
+/// executor may consume only a prefix of `inputs`, so the output's upper bound
+/// is whatever that prefix spans and is folded there, not predicted here.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompactionJob {
     pub inputs: Vec<SegmentRow>,
     pub output_level: i32,
     pub output_min_seq: i64,
-    pub output_max_seq: i64,
 }

--- a/lib/finelog/rust/src/store/compaction/executor.rs
+++ b/lib/finelog/rust/src/store/compaction/executor.rs
@@ -36,7 +36,7 @@ use crate::store::compaction::merge::{
 };
 use crate::store::compaction::planner::aggregate_key_bounds;
 use crate::store::segment::{segment_bounds, segment_writer_properties};
-use crate::store::types::{seg_filename, LocalSegment, SegmentLocation};
+use crate::store::types::{seg_filename, LocalSegment, SegmentLocation, SegmentRow};
 
 fn now_ms() -> i64 {
     SystemTime::now()
@@ -48,24 +48,33 @@ fn now_ms() -> i64 {
 /// The deque/catalog mutation a `CompactionJob` resolves to, ready for the
 /// caller to commit under the query-visibility write lock.
 ///
-/// `removed` are the input segment paths to splice out. `added` is the single
-/// output segment (its file already exists for a merge; for a bump the file
-/// appears only after `bump_rename` runs in the commit). `unlink_removed` is
-/// `false` for a level bump (the input file was renamed, so its old path is
-/// already gone after `bump_rename`) and `true` for a merge (the inputs are
-/// still on disk). `bump_rename`, when `Some((from, to))`, is the in-place
-/// promotion rename the commit performs first.
+/// `removed` are the input segment paths to splice out — the prefix of the job's
+/// inputs that fit the merge memory ceiling, which may be shorter than the job.
+/// `added` is the single output segment (its file already exists for a merge;
+/// for a bump the file appears only after `bump_rename` runs in the commit).
+/// `unlink_removed` is `false` for a level bump (the input file was renamed, so
+/// its old path is already gone after `bump_rename`) and `true` for a merge (the
+/// inputs are still on disk). `bump_rename`, when `Some((from, to))`, is the
+/// in-place promotion rename the commit performs first. `input_arrow_bytes` is
+/// the measured decoded size of the consumed inputs (0 for a bump, which decodes
+/// nothing) — the quantity the ceiling bounds, logged so merge memory is visible
+/// in production.
 #[derive(Debug, Clone)]
 pub struct PlannedSwap {
     pub removed: Vec<String>,
     pub added: LocalSegment,
     pub unlink_removed: bool,
     pub bump_rename: Option<(PathBuf, PathBuf)>,
+    pub input_arrow_bytes: i64,
 }
 
 /// Resolve `job` into a `PlannedSwap`, performing the heavy read/merge/write for
 /// a multi-input job. `dir` is the namespace directory; `arrow_schema` is the
 /// store-form schema (with `seq`); `key_column` is the namespace's ordering key.
+///
+/// `max_merge_arrow_bytes` caps the decoded size the merge holds: inputs are
+/// read in order and the merge takes the longest prefix that fits, leaving the
+/// rest of the run for the next tick.
 ///
 /// `inputs_by_path` lets the caller supply the typed in-memory key bounds for
 /// each input (the catalog round-trip stringifies them, losing numeric
@@ -78,10 +87,11 @@ pub fn run_job(
     arrow_schema: &SchemaRef,
     key_column: Option<&str>,
     indexed_columns: &[&str],
+    max_merge_arrow_bytes: i64,
     input_key_bounds: impl Fn(&str) -> (Option<i64>, Option<i64>),
 ) -> Result<PlannedSwap, StatsError> {
     if job.inputs.len() == 1 {
-        apply_level_bump(job, dir, &input_key_bounds)
+        apply_level_bump(&job.inputs[0], job.output_level, dir, &input_key_bounds)
     } else {
         apply_merge(
             job,
@@ -89,6 +99,7 @@ pub fn run_job(
             arrow_schema,
             key_column,
             indexed_columns,
+            max_merge_arrow_bytes,
             &input_key_bounds,
         )
     }
@@ -99,18 +110,18 @@ pub fn run_job(
 /// row_count, seq window, and typed key bounds. The rename itself is deferred to
 /// the commit via `PlannedSwap::bump_rename`.
 fn apply_level_bump(
-    job: &CompactionJob,
+    old: &SegmentRow,
+    output_level: i32,
     dir: &Path,
     input_key_bounds: &impl Fn(&str) -> (Option<i64>, Option<i64>),
 ) -> Result<PlannedSwap, StatsError> {
-    let old = &job.inputs[0];
-    let new_filename = seg_filename(job.output_level, old.min_seq);
+    let new_filename = seg_filename(output_level, old.min_seq);
     let new_path = dir.join(&new_filename);
     let (min_key, max_key) = input_key_bounds(&old.path);
     let bumped = LocalSegment {
         path: new_path.to_string_lossy().into_owned(),
         size_bytes: old.byte_size,
-        level: job.output_level,
+        level: output_level,
         min_seq: old.min_seq,
         max_seq: old.max_seq,
         row_count: old.row_count,
@@ -124,17 +135,26 @@ fn apply_level_bump(
         added: bumped,
         unlink_removed: false,
         bump_rename: Some((PathBuf::from(&old.path), new_path)),
+        input_arrow_bytes: 0,
     })
 }
 
 /// Multi-input merge: read inputs, project, k-way merge, write the output file,
 /// rename `.tmp` -> final. Returns the swap with `unlink_removed = true`.
+///
+/// Merges the longest prefix of `job.inputs` whose measured Arrow size fits
+/// `max_merge_arrow_bytes`; the remaining inputs stay at their level for the
+/// next tick, which replans them as a shorter run. A prefix of a contiguous run
+/// is itself contiguous, so the output's seq window stays gap-free and the
+/// commit's deque splice is unaffected. Truncating to a single input degenerates
+/// to a level bump — a rename, no rewrite.
 fn apply_merge(
     job: &CompactionJob,
     dir: &Path,
     arrow_schema: &SchemaRef,
     key_column: Option<&str>,
     indexed_columns: &[&str],
+    max_merge_arrow_bytes: i64,
     input_key_bounds: &impl Fn(&str) -> (Option<i64>, Option<i64>),
 ) -> Result<PlannedSwap, StatsError> {
     let merged_filename = seg_filename(job.output_level, job.output_min_seq);
@@ -156,15 +176,47 @@ fn apply_merge(
     // ~256 MiB compressed `log` segment past 2 GiB), and that concat overflowed
     // and wedged the `log` namespace's compaction indefinitely. Each reader batch
     // is row-group-bounded, so sorting it in isolation never overflows.
+    //
+    // Inputs are taken ONE AT A TIME and measured against the memory ceiling
+    // before the merge commits to them, because a segment's decoded size is only
+    // knowable by decoding it: every size in its footer counts encoded bytes,
+    // where a repeated log line costs one dictionary index rather than its text.
+    // An input that does not fit is therefore read, measured, and dropped again —
+    // one input of transient RAM over the ceiling, the price of measuring instead
+    // of guessing.
     let mut projected: Vec<RecordBatch> = Vec::new();
+    let mut consumed: Vec<&SegmentRow> = Vec::new();
+    let mut input_arrow_bytes: i64 = 0;
     for inp in &job.inputs {
+        let mut batches: Vec<RecordBatch> = Vec::new();
+        let mut batch_bytes: i64 = 0;
         for b in read_segment_batches(Path::new(&inp.path))? {
             let projected_batch = project_to_schema(&b, arrow_schema)
                 .map_err(|e| StatsError::Internal(format!("project merge input: {e}")))?;
             let sorted = sort_batch_by(&projected_batch, &sort_cols)
                 .map_err(|e| StatsError::Internal(format!("sort merge input: {e}")))?;
-            projected.push(sorted);
+            batch_bytes = batch_bytes.saturating_add(sorted.get_array_memory_size() as i64);
+            batches.push(sorted);
         }
+        if !consumed.is_empty()
+            && input_arrow_bytes.saturating_add(batch_bytes) > max_merge_arrow_bytes
+        {
+            break;
+        }
+        input_arrow_bytes = input_arrow_bytes.saturating_add(batch_bytes);
+        projected.extend(batches);
+        consumed.push(inp);
+        if input_arrow_bytes > max_merge_arrow_bytes {
+            break;
+        }
+    }
+
+    // A lone input that busts the ceiling has nothing to merge with: promote it
+    // by rename instead, so an oversized segment costs no merge memory and does
+    // not wedge its level.
+    if consumed.len() == 1 {
+        drop(projected);
+        return apply_level_bump(consumed[0], job.output_level, dir, input_key_bounds);
     }
 
     let merged = kway_merge(&projected, &sort_cols)
@@ -207,16 +259,17 @@ fn apply_merge(
     let size = std::fs::metadata(&merged_path)
         .map_err(|e| StatsError::Internal(format!("stat {}: {e}", merged_path.display())))?
         .len() as i64;
-    // row_count = sum of inputs.
-    let row_count: i64 = job.inputs.iter().map(|s| s.row_count).sum();
+    // Bounds and counts fold over the CONSUMED prefix, not the planned job: the
+    // inputs left behind are still live segments at their own level.
+    let row_count: i64 = consumed.iter().map(|s| s.row_count).sum();
     let (merged_min_key, merged_max_key) =
-        aggregate_key_bounds(job.inputs.iter().map(|s| input_key_bounds(&s.path)));
+        aggregate_key_bounds(consumed.iter().map(|s| input_key_bounds(&s.path)));
     let merged_seg = LocalSegment {
         path: merged_path.to_string_lossy().into_owned(),
         size_bytes: size,
         level: job.output_level,
-        min_seq: job.output_min_seq,
-        max_seq: job.output_max_seq,
+        min_seq: consumed.iter().map(|s| s.min_seq).min().expect("non-empty"),
+        max_seq: consumed.iter().map(|s| s.max_seq).max().expect("non-empty"),
         row_count,
         created_at_ms: now_ms(),
         min_key_value: merged_min_key,
@@ -224,10 +277,11 @@ fn apply_merge(
         location: SegmentLocation::Local,
     };
     Ok(PlannedSwap {
-        removed: job.inputs.iter().map(|s| s.path.clone()).collect(),
+        removed: consumed.iter().map(|s| s.path.clone()).collect(),
         added: merged_seg,
         unlink_removed: true,
         bump_rename: None,
+        input_arrow_bytes,
     })
 }
 
@@ -287,11 +341,7 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
 
     use super::*;
-    use crate::store::compaction::config::CompactionConfig;
-    use crate::store::compaction::planner::plan;
-    use crate::store::segment::{
-        read_segment_footer, segment_uncompressed_bytes, write_segment_to_dir,
-    };
+    use crate::store::segment::{read_segment_footer, write_segment_to_dir};
     use crate::store::types::{seg_filename, SegmentRow};
 
     fn tempdir(tag: &str) -> PathBuf {
@@ -375,7 +425,7 @@ mod tests {
                 _ => (None, None),
             }
         };
-        let swap = run_job(&job, &dir, &schema(), Some("key"), &[], bounds).unwrap();
+        let swap = run_job(&job, &dir, &schema(), Some("key"), &[], i64::MAX, bounds).unwrap();
         assert!(swap.bump_rename.is_none());
         assert!(swap.unlink_removed);
         assert_eq!(swap.removed.len(), 3);
@@ -409,55 +459,122 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    /// The compaction memory ceiling, driven by real parquet footers rather than
-    /// the on-disk (compressed) size: a segment that alone decodes past
-    /// `max_merge_uncompressed_bytes` is isolated into a one-input job, which
-    /// `run_job` resolves to a rename — no read, no merge, no memory. Merging it
-    /// instead is what OOM-killed the `log` namespace's container. Raising the
-    /// ceiling over the pair's combined size must merge them as usual, so the
-    /// ceiling (not an off-by-one) is what decides.
-    #[test]
-    fn segment_over_memory_ceiling_is_promoted_by_rename_not_merged() {
-        let dir = tempdir("ceiling");
-        let big: Vec<(i64, i64, &str)> = (1..=20_000)
-            .map(|s| (s, 20_001 - s, "a-log-line-wide-enough-to-decode"))
+    /// A segment of `n` rows all repeating the same wide log line — the shape
+    /// that makes parquet sizes useless as a memory proxy. Both the compressed
+    /// and the footer's `total_byte_size` collapse to near nothing (one
+    /// dictionary entry plus run-length-encoded indices) while the decode
+    /// materializes every row's text in full.
+    fn repeated_line_segment(dir: &Path, first_seq: i64, n: i64) -> (PathBuf, i64, i64) {
+        let rows: Vec<(i64, i64, &str)> = (0..n)
+            .map(|i| {
+                (
+                    first_seq + i,
+                    first_seq + i,
+                    "a-log-line-repeated-verbatim-across-every-row",
+                )
+            })
             .collect();
-        let (p_big, _) = write_segment_to_dir(&dir, 0, 1, &batch(&big)).unwrap();
-        let (p_small, _) =
-            write_segment_to_dir(&dir, 0, 20_001, &batch(&[(20_001, 7, "s")])).unwrap();
+        let (path, _) = write_segment_to_dir(dir, 0, first_seq, &batch(&rows)).unwrap();
+        (path, first_seq, first_seq + n - 1)
+    }
 
-        let big_decoded = segment_uncompressed_bytes(&p_big).unwrap();
-        let small_decoded = segment_uncompressed_bytes(&p_small).unwrap();
+    fn decoded_bytes(path: &Path) -> i64 {
+        read_segment_batches(path)
+            .unwrap()
+            .iter()
+            .map(|b| b.get_array_memory_size() as i64)
+            .sum()
+    }
+
+    /// A ceiling that admits only part of a planned job merges the prefix that
+    /// fits and leaves the rest at their level for the next tick, so a backlog
+    /// drains in bounded chunks instead of one unbounded merge.
+    ///
+    /// The ceiling here sits ABOVE the inputs' combined parquet size and below
+    /// their combined decode, so it also pins the denomination: a budget counting
+    /// stored bytes would wave this whole run through. That is precisely how the
+    /// `log` namespace OOM-killed its container — a 4 GiB budget admitted a job
+    /// whose footer read 1.9 GiB and whose decode reached ~15 GiB.
+    #[test]
+    fn merge_takes_the_prefix_that_fits_and_leaves_the_rest() {
+        let dir = tempdir("prefix");
+        let (p0, min0, max0) = repeated_line_segment(&dir, 1, 20_000);
+        let (p1, min1, max1) = repeated_line_segment(&dir, 20_001, 20_000);
+        let (p2, min2, max2) = repeated_line_segment(&dir, 40_001, 20_000);
+        let one = decoded_bytes(&p0);
+        let stored: i64 = [&p0, &p1, &p2]
+            .iter()
+            .map(|p| std::fs::metadata(p).unwrap().len() as i64)
+            .sum();
         assert!(
-            big_decoded > small_decoded,
-            "footer must report the decoded size, not the compressed one"
+            one * 2 + 1 > stored,
+            "the ceiling must exceed every input's combined STORED size ({stored}), \
+             else this cannot distinguish a decoded budget from a parquet-sized one"
         );
 
-        let rows = vec![
-            row_for(&p_big.to_string_lossy(), 0, 1, 20_000, 100),
-            row_for(&p_small.to_string_lossy(), 0, 20_001, 20_001, 100),
-        ];
-        let footer_size = |r: &SegmentRow| {
-            segment_uncompressed_bytes(Path::new(&r.path)).expect("readable footer")
-        };
-        // Count-promote the run so the compressed target never decides the prefix.
-        let config = |ceiling: i64| CompactionConfig {
-            level_targets: vec![i64::MAX],
-            max_segments_per_level: 2,
-            max_merge_uncompressed_bytes: ceiling,
-            ..Default::default()
+        let job = CompactionJob {
+            inputs: vec![
+                row_for(&p0.to_string_lossy(), 0, min0, max0, 100),
+                row_for(&p1.to_string_lossy(), 0, min1, max1, 100),
+                row_for(&p2.to_string_lossy(), 0, min2, max2, 100),
+            ],
+            output_level: 1,
+            output_min_seq: min0,
+            output_max_seq: max2,
         };
 
-        // Ceiling below the big segment alone: isolated, and promoted by rename.
-        let job = plan(&config(big_decoded - 1), &rows, footer_size).unwrap();
-        assert_eq!(job.inputs.len(), 1, "oversized segment must be isolated");
-        let swap = run_job(&job, &dir, &schema(), Some("key"), &[], |_| (None, None)).unwrap();
-        assert!(swap.bump_rename.is_some(), "single-input job is a rename");
+        // A ceiling holding two of the three segments.
+        let swap = run_job(&job, &dir, &schema(), Some("key"), &[], one * 2 + 1, |_| {
+            (None, None)
+        })
+        .unwrap();
+        assert_eq!(swap.removed.len(), 2, "only the fitting prefix is consumed");
+        assert_eq!(
+            swap.added.max_seq, max1,
+            "the output spans the consumed prefix, not the planned job"
+        );
+        assert_eq!(swap.added.row_count, 40_000);
+        assert!(
+            swap.input_arrow_bytes <= one * 2 + 1,
+            "the measured decode must respect the ceiling"
+        );
+        assert!(
+            Path::new(&p2).exists(),
+            "the untaken input stays live for the next tick"
+        );
+
+        // A ceiling over the whole job merges it whole, as if uncapped.
+        let swap = run_job(&job, &dir, &schema(), Some("key"), &[], i64::MAX, |_| {
+            (None, None)
+        })
+        .unwrap();
+        assert_eq!(swap.removed.len(), 3);
+        assert_eq!(swap.added.max_seq, max2);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A lone input over the ceiling has nothing to merge with, so it is
+    /// promoted by rename — no rewrite, no memory — rather than wedging its
+    /// level forever behind a merge that can never fit.
+    #[test]
+    fn input_alone_over_ceiling_is_promoted_by_rename() {
+        let dir = tempdir("lone_over");
+        let (p0, min0, max0) = repeated_line_segment(&dir, 1, 20_000);
+        let (p1, min1, max1) = repeated_line_segment(&dir, 20_001, 20_000);
+        let job = CompactionJob {
+            inputs: vec![
+                row_for(&p0.to_string_lossy(), 0, min0, max0, 100),
+                row_for(&p1.to_string_lossy(), 0, min1, max1, 100),
+            ],
+            output_level: 1,
+            output_min_seq: min0,
+            output_max_seq: max1,
+        };
+        let swap = run_job(&job, &dir, &schema(), Some("key"), &[], 1, |_| (None, None)).unwrap();
+        assert!(swap.bump_rename.is_some(), "must degenerate to a rename");
         assert!(!swap.unlink_removed, "a rename leaves nothing to unlink");
-
-        // Ceiling above the pair: both merge, exactly as before the ceiling existed.
-        let job = plan(&config(big_decoded + small_decoded), &rows, footer_size).unwrap();
-        assert_eq!(job.inputs.len(), 2);
+        assert_eq!(swap.removed, vec![p0.to_string_lossy().to_string()]);
+        assert_eq!(swap.added.max_seq, max0, "the bump carries its own span");
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -499,7 +616,7 @@ mod tests {
             output_max_seq: n + 1,
         };
         let bounds = |_: &str| (Some(1), Some(n));
-        let swap = run_job(&job, &dir, &schema(), Some("key"), &[], bounds).unwrap();
+        let swap = run_job(&job, &dir, &schema(), Some("key"), &[], i64::MAX, bounds).unwrap();
 
         assert_eq!(swap.added.row_count, n + 1, "no row loss");
         let out = PathBuf::from(&swap.added.path);
@@ -535,7 +652,7 @@ mod tests {
             output_max_seq: 2,
         };
         let bounds = |_: &str| (Some(10), Some(20));
-        let swap = run_job(&job, &dir, &schema(), Some("key"), &[], bounds).unwrap();
+        let swap = run_job(&job, &dir, &schema(), Some("key"), &[], i64::MAX, bounds).unwrap();
 
         // It's a bump: a deferred rename, not a rewrite.
         let (from, to) = swap.bump_rename.clone().unwrap();
@@ -600,7 +717,10 @@ mod tests {
             output_min_seq: 1,
             output_max_seq: 2,
         };
-        let swap = run_job(&job, &dir, &log, Some("key"), &["data"], |_| (None, None)).unwrap();
+        let swap = run_job(&job, &dir, &log, Some("key"), &["data"], i64::MAX, |_| {
+            (None, None)
+        })
+        .unwrap();
 
         // The merged output carries a sidecar whose mask prunes correctly.
         let out = PathBuf::from(&swap.added.path);
@@ -711,7 +831,10 @@ mod tests {
             output_min_seq: 1,
             output_max_seq: 2,
         };
-        let swap = run_job(&job, &dir, &wide, Some("key"), &[], |_| (None, None)).unwrap();
+        let swap = run_job(&job, &dir, &wide, Some("key"), &[], i64::MAX, |_| {
+            (None, None)
+        })
+        .unwrap();
         let batches = read_segment_batches(Path::new(&swap.added.path)).unwrap();
         let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total_rows, 2);

--- a/lib/finelog/rust/src/store/compaction/executor.rs
+++ b/lib/finelog/rust/src/store/compaction/executor.rs
@@ -211,9 +211,9 @@ fn apply_merge(
         }
     }
 
-    // A lone input that busts the ceiling has nothing to merge with: promote it
-    // by rename instead, so an oversized segment costs no merge memory and does
-    // not wedge its level.
+    // One input has nothing to merge with — whether it busted the ceiling alone
+    // or merely left no room for the next input. Promote it by rename instead,
+    // so it costs no merge memory and its level still advances.
     if consumed.len() == 1 {
         drop(projected);
         return apply_level_bump(consumed[0], job.output_level, dir, input_key_bounds);
@@ -414,7 +414,6 @@ mod tests {
             ],
             output_level: 1,
             output_min_seq: 1,
-            output_max_seq: 6,
         };
         // typed key bounds per input.
         let bounds = |path: &str| -> (Option<i64>, Option<i64>) {
@@ -520,7 +519,6 @@ mod tests {
             ],
             output_level: 1,
             output_min_seq: min0,
-            output_max_seq: max2,
         };
 
         // A ceiling holding two of the three segments.
@@ -568,7 +566,6 @@ mod tests {
             ],
             output_level: 1,
             output_min_seq: min0,
-            output_max_seq: max1,
         };
         let swap = run_job(&job, &dir, &schema(), Some("key"), &[], 1, |_| (None, None)).unwrap();
         assert!(swap.bump_rename.is_some(), "must degenerate to a rename");
@@ -613,7 +610,6 @@ mod tests {
             ],
             output_level: 1,
             output_min_seq: 1,
-            output_max_seq: n + 1,
         };
         let bounds = |_: &str| (Some(1), Some(n));
         let swap = run_job(&job, &dir, &schema(), Some("key"), &[], i64::MAX, bounds).unwrap();
@@ -649,7 +645,6 @@ mod tests {
             inputs: vec![input],
             output_level: 3,
             output_min_seq: 1,
-            output_max_seq: 2,
         };
         let bounds = |_: &str| (Some(10), Some(20));
         let swap = run_job(&job, &dir, &schema(), Some("key"), &[], i64::MAX, bounds).unwrap();
@@ -715,7 +710,6 @@ mod tests {
             ],
             output_level: 1,
             output_min_seq: 1,
-            output_max_seq: 2,
         };
         let swap = run_job(&job, &dir, &log, Some("key"), &["data"], i64::MAX, |_| {
             (None, None)
@@ -829,7 +823,6 @@ mod tests {
             ],
             output_level: 1,
             output_min_seq: 1,
-            output_max_seq: 2,
         };
         let swap = run_job(&job, &dir, &wide, Some("key"), &[], i64::MAX, |_| {
             (None, None)

--- a/lib/finelog/rust/src/store/compaction/executor.rs
+++ b/lib/finelog/rust/src/store/compaction/executor.rs
@@ -188,9 +188,30 @@ fn apply_merge(
     let mut consumed: Vec<&SegmentRow> = Vec::new();
     let mut input_arrow_bytes: i64 = 0;
     for inp in &job.inputs {
+        // An input we cannot read is one we can never merge, and failing the tick
+        // would replan the identical job every check_interval and wedge the level
+        // for good. Route around it instead: as the run's head it is promoted by
+        // rename (the branch below), and otherwise it ends the prefix and becomes
+        // the next tick's head. Either way it moves and compaction stays live.
+        // Only the READ is forgiven — a projection or sort failure is a schema bug
+        // and still propagates.
+        let raw = match read_segment_batches(Path::new(&inp.path)) {
+            Ok(raw) => raw,
+            Err(e) => {
+                tracing::warn!(
+                    path = %inp.path,
+                    error = %e,
+                    "unreadable merge input; promoting it past the merge"
+                );
+                if consumed.is_empty() {
+                    return apply_level_bump(inp, job.output_level, dir, input_key_bounds);
+                }
+                break;
+            }
+        };
         let mut batches: Vec<RecordBatch> = Vec::new();
         let mut batch_bytes: i64 = 0;
-        for b in read_segment_batches(Path::new(&inp.path))? {
+        for b in raw {
             let projected_batch = project_to_schema(&b, arrow_schema)
                 .map_err(|e| StatsError::Internal(format!("project merge input: {e}")))?;
             let sorted = sort_batch_by(&projected_batch, &sort_cols)
@@ -548,6 +569,42 @@ mod tests {
         .unwrap();
         assert_eq!(swap.removed.len(), 3);
         assert_eq!(swap.added.max_seq, max2);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// An unreadable input must not fail the tick. The planner would hand back
+    /// the identical job every `check_interval`, so propagating the read error
+    /// would wedge the level permanently on one corrupt file — the very failure
+    /// the memory ceiling exists to prevent. It is promoted past the merge
+    /// instead, and its readable neighbours still compact.
+    #[test]
+    fn unreadable_input_is_promoted_past_the_merge_not_propagated() {
+        let dir = tempdir("unreadable");
+        let (p_bad, min_bad, max_bad) = repeated_line_segment(&dir, 1, 100);
+        let (p_good, min_good, max_good) = repeated_line_segment(&dir, 101, 100);
+        std::fs::write(&p_bad, b"this is not a parquet file").unwrap();
+
+        let job = CompactionJob {
+            inputs: vec![
+                row_for(&p_bad.to_string_lossy(), 0, min_bad, max_bad, 100),
+                row_for(&p_good.to_string_lossy(), 0, min_good, max_good, 100),
+            ],
+            output_level: 1,
+            output_min_seq: min_bad,
+        };
+        let swap = run_job(&job, &dir, &schema(), Some("key"), &[], i64::MAX, |_| {
+            (None, None)
+        })
+        .expect("an unreadable input must not fail the tick");
+        assert!(
+            swap.bump_rename.is_some(),
+            "the unreadable head is renamed past, not merged"
+        );
+        assert_eq!(swap.removed, vec![p_bad.to_string_lossy().to_string()]);
+        assert!(
+            Path::new(&p_good).exists(),
+            "its readable neighbour stays live to compact next tick"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/lib/finelog/rust/src/store/compaction/planner.rs
+++ b/lib/finelog/rust/src/store/compaction/planner.rs
@@ -26,19 +26,15 @@ pub fn compaction_sort_keys(schema: &Schema) -> Vec<String> {
 
 /// Return the next merge job, or `None` if nothing is due.
 ///
-/// Walks tiers from L0 upward and returns the first promotable run. The selected
-/// run prefix is capped both at the level's compressed byte target and at
-/// `config.max_merge_uncompressed_bytes` (`take_until_limits`), so a large
-/// backlog drains one bounded chunk per tick rather than OOMing a single merge.
+/// Walks tiers from L0 upward and returns the first promotable run, capping the
+/// selected prefix at the level's compressed byte target.
 ///
-/// `uncompressed_bytes` reports a segment's decoded size; the caller reads it
-/// from the parquet footer. It is consulted only for the prefix of the one run
-/// this call promotes.
-pub fn plan(
-    config: &CompactionConfig,
-    segments: &[SegmentRow],
-    uncompressed_bytes: impl Fn(&SegmentRow) -> i64,
-) -> Option<CompactionJob> {
+/// The job's MEMORY cost is not decided here: a segment's decoded Arrow size
+/// cannot be read off its footer (see `max_merge_arrow_bytes`), so the executor
+/// measures it while reading and merges only the prefix of `inputs` that fits.
+/// A job this planner returns is therefore an upper bound on what one tick
+/// merges, not a promise.
+pub fn plan(config: &CompactionConfig, segments: &[SegmentRow]) -> Option<CompactionJob> {
     for (n, &target) in config.level_targets.iter().enumerate() {
         let level = n as i32;
         let mut at_level: Vec<&SegmentRow> = segments.iter().filter(|s| s.level == level).collect();
@@ -48,13 +44,7 @@ pub fn plan(
         at_level.sort_by_key(|s| s.min_seq);
         for run in contiguous_runs(&at_level) {
             if run_bytes(&run) >= target || run.len() >= config.max_segments_per_level {
-                let prefix = take_until_limits(
-                    &run,
-                    target,
-                    config.max_merge_uncompressed_bytes,
-                    &uncompressed_bytes,
-                );
-                return Some(build_job(prefix, level + 1));
+                return Some(build_job(take_until_target(&run, target), level + 1));
             }
         }
     }
@@ -83,30 +73,14 @@ fn run_bytes(run: &[&SegmentRow]) -> i64 {
     run.iter().map(|s| s.byte_size).sum()
 }
 
-/// Take the shortest prefix of `run` whose compressed byte sum hits `target`,
-/// stopping before any segment that would push the prefix's uncompressed size
-/// past `max_uncompressed`.
-///
-/// Always returns at least one segment: a lone segment over the ceiling becomes
-/// a single-input job, which the executor promotes by rename rather than
-/// merging, so it costs no memory and cannot wedge its level.
-fn take_until_limits<'a>(
-    run: &[&'a SegmentRow],
-    target: i64,
-    max_uncompressed: i64,
-    uncompressed_bytes: &impl Fn(&SegmentRow) -> i64,
-) -> Vec<&'a SegmentRow> {
+/// Take the shortest prefix of `run` whose compressed byte sum hits `target`.
+/// Always returns at least one segment.
+fn take_until_target<'a>(run: &[&'a SegmentRow], target: i64) -> Vec<&'a SegmentRow> {
     let mut out: Vec<&SegmentRow> = Vec::new();
     let mut compressed: i64 = 0;
-    let mut uncompressed: i64 = 0;
     for &seg in run {
-        let seg_uncompressed = uncompressed_bytes(seg);
-        if !out.is_empty() && uncompressed.saturating_add(seg_uncompressed) > max_uncompressed {
-            break;
-        }
         out.push(seg);
         compressed += seg.byte_size;
-        uncompressed = uncompressed.saturating_add(seg_uncompressed);
         if compressed >= target {
             break;
         }
@@ -178,32 +152,20 @@ mod tests {
         }
     }
 
-    /// Report every segment as decoding to nothing, so the uncompressed ceiling
-    /// never binds and the compressed target alone decides the prefix.
-    fn ignore_uncompressed(_: &SegmentRow) -> i64 {
-        0
-    }
-
-    /// Decoded size as a fixed multiple of the on-disk size — the shape of real
-    /// log segments, which compress 10-20x.
-    fn ratio_uncompressed(ratio: i64) -> impl Fn(&SegmentRow) -> i64 {
-        move |s: &SegmentRow| s.byte_size * ratio
-    }
-
     // --- the 6 planner cases ---------------------
 
     #[test]
     fn plan_returns_none_when_under_target() {
         let cfg = config(vec![1024], 1024);
         let rows = vec![row(0, 1, 1, 128)];
-        assert_eq!(plan(&cfg, &rows, ignore_uncompressed), None);
+        assert_eq!(plan(&cfg, &rows), None);
     }
 
     #[test]
     fn plan_promotes_when_byte_target_reached() {
         let cfg = config(vec![1024], 1024);
         let rows = vec![row(0, 1, 1, 512), row(0, 2, 2, 512)];
-        let job = plan(&cfg, &rows, ignore_uncompressed).unwrap();
+        let job = plan(&cfg, &rows).unwrap();
         assert_eq!(job.output_level, 1);
         let mins: Vec<i64> = job.inputs.iter().map(|r| r.min_seq).collect();
         assert_eq!(mins, vec![1, 2]);
@@ -213,7 +175,7 @@ mod tests {
     fn plan_promotes_at_segment_count_below_byte_target() {
         let cfg = config(vec![1 << 30], 3);
         let rows = vec![row(0, 1, 1, 128), row(0, 2, 2, 128), row(0, 3, 3, 128)];
-        let job = plan(&cfg, &rows, ignore_uncompressed).unwrap();
+        let job = plan(&cfg, &rows).unwrap();
         assert_eq!(job.output_level, 1);
         let mins: Vec<i64> = job.inputs.iter().map(|r| r.min_seq).collect();
         assert_eq!(mins, vec![1, 2, 3]);
@@ -224,7 +186,7 @@ mod tests {
         // terminal level == len(level_targets) == 1; L1 is terminal here.
         let cfg = config(vec![1024], 2);
         let rows = vec![row(1, 1, 1, 128), row(1, 2, 2, 128), row(1, 3, 3, 128)];
-        assert_eq!(plan(&cfg, &rows, ignore_uncompressed), None);
+        assert_eq!(plan(&cfg, &rows), None);
     }
 
     #[test]
@@ -232,7 +194,7 @@ mod tests {
         // L2 is non-terminal (len == 2), so L1 count-promotes.
         let cfg = config(vec![64, 1 << 30], 2);
         let rows = vec![row(1, 1, 1, 8), row(1, 2, 2, 8)];
-        let job = plan(&cfg, &rows, ignore_uncompressed).unwrap();
+        let job = plan(&cfg, &rows).unwrap();
         assert_eq!(job.output_level, 2);
         let mins: Vec<i64> = job.inputs.iter().map(|r| r.min_seq).collect();
         assert_eq!(mins, vec![1, 2]);
@@ -242,7 +204,7 @@ mod tests {
     fn plan_single_l2_segment_at_l3_target_emits_single_input_job() {
         let cfg = config(vec![64, 256, 256], 32);
         let rows = vec![row(2, 1, 100, 256)];
-        let job = plan(&cfg, &rows, ignore_uncompressed).unwrap();
+        let job = plan(&cfg, &rows).unwrap();
         assert_eq!(job.output_level, 3);
         assert_eq!(job.inputs.len(), 1);
         assert_eq!(job.inputs[0].min_seq, 1);
@@ -251,78 +213,19 @@ mod tests {
     // --- take_until_target / contiguous_runs ----------------------------
 
     #[test]
-    fn take_until_limits_shortest_prefix_at_least_one() {
+    fn take_until_target_shortest_prefix_at_least_one() {
         let r0 = row(0, 1, 1, 30);
         let r1 = row(0, 2, 2, 40);
         let r2 = row(0, 3, 3, 50);
         let run = vec![&r0, &r1, &r2];
         // 30 + 40 >= 64 stops at 2.
-        let taken = take_until_limits(&run, 64, i64::MAX, &ignore_uncompressed);
+        let taken = take_until_target(&run, 64);
         let mins: Vec<i64> = taken.iter().map(|s| s.min_seq).collect();
         assert_eq!(mins, vec![1, 2]);
         // sub-target run still makes forward progress with >=1 input.
-        let taken = take_until_limits(&run, 1_000_000, i64::MAX, &ignore_uncompressed);
-        assert_eq!(taken.len(), 3);
+        assert_eq!(take_until_target(&run, 1_000_000).len(), 3);
         let single = vec![&r0];
-        assert_eq!(
-            take_until_limits(&single, 1_000_000, i64::MAX, &ignore_uncompressed).len(),
-            1
-        );
-    }
-
-    /// The compressed target alone would pull the whole run into one merge; the
-    /// uncompressed ceiling is what keeps the job's decoded inputs — and so the
-    /// executor's peak RSS — bounded.
-    #[test]
-    fn take_until_limits_stops_before_exceeding_uncompressed_ceiling() {
-        let r0 = row(0, 1, 1, 100);
-        let r1 = row(0, 2, 2, 100);
-        let r2 = row(0, 3, 3, 100);
-        let run = vec![&r0, &r1, &r2];
-        // Each segment decodes to 100 * 10 = 1000; a 2500 ceiling admits two.
-        let taken = take_until_limits(&run, i64::MAX, 2500, &ratio_uncompressed(10));
-        let mins: Vec<i64> = taken.iter().map(|s| s.min_seq).collect();
-        assert_eq!(mins, vec![1, 2]);
-    }
-
-    /// A segment that alone decodes past the ceiling must still make progress:
-    /// it becomes a single-input job, which the executor promotes by rename
-    /// rather than merging. Otherwise its level wedges forever.
-    #[test]
-    fn take_until_limits_isolates_a_segment_larger_than_the_ceiling() {
-        let big = row(2, 1, 100, 256);
-        let next = row(2, 101, 200, 16);
-        let run = vec![&big, &next];
-        let taken = take_until_limits(&run, i64::MAX, 1000, &ratio_uncompressed(20));
-        assert_eq!(taken.len(), 1);
-        assert_eq!(taken[0].min_seq, 1);
-    }
-
-    /// An unreadable footer reports `i64::MAX`; the running total must saturate
-    /// rather than overflow into a negative sum that admits the segment.
-    #[test]
-    fn take_until_limits_saturates_on_unmeasurable_segment() {
-        let r0 = row(0, 1, 1, 10);
-        let r1 = row(0, 2, 2, 10);
-        let run = vec![&r0, &r1];
-        let taken = take_until_limits(&run, i64::MAX, 1000, &|_| i64::MAX);
-        assert_eq!(taken.len(), 1);
-    }
-
-    /// End-to-end through `plan`: a promotable L2 run whose segments each decode
-    /// past the ceiling yields a one-input job (a rename), not a merge.
-    #[test]
-    fn plan_isolates_oversized_segment_into_single_input_job() {
-        let cfg = CompactionConfig {
-            level_targets: vec![64, 256, 256],
-            max_merge_uncompressed_bytes: 1000,
-            ..Default::default()
-        };
-        let rows = vec![row(2, 1, 100, 200), row(2, 101, 200, 200)];
-        let job = plan(&cfg, &rows, ratio_uncompressed(20)).unwrap();
-        assert_eq!(job.output_level, 3);
-        assert_eq!(job.inputs.len(), 1);
-        assert_eq!(job.output_max_seq, 100);
+        assert_eq!(take_until_target(&single, 1_000_000).len(), 1);
     }
 
     #[test]
@@ -349,7 +252,7 @@ mod tests {
         // Two runs at L0: [1..1] (tiny) and [10..10],[11..11] (count-promotes).
         let cfg = config(vec![1 << 30], 2);
         let rows = vec![row(0, 1, 1, 8), row(0, 10, 10, 8), row(0, 11, 11, 8)];
-        let job = plan(&cfg, &rows, ignore_uncompressed).unwrap();
+        let job = plan(&cfg, &rows).unwrap();
         let mins: Vec<i64> = job.inputs.iter().map(|r| r.min_seq).collect();
         assert_eq!(mins, vec![10, 11]);
     }

--- a/lib/finelog/rust/src/store/compaction/planner.rs
+++ b/lib/finelog/rust/src/store/compaction/planner.rs
@@ -90,12 +90,10 @@ fn take_until_target<'a>(run: &[&'a SegmentRow], target: i64) -> Vec<&'a Segment
 
 fn build_job(run: Vec<&SegmentRow>, output_level: i32) -> CompactionJob {
     let output_min_seq = run.iter().map(|s| s.min_seq).min().expect("run non-empty");
-    let output_max_seq = run.iter().map(|s| s.max_seq).max().expect("run non-empty");
     CompactionJob {
         inputs: run.into_iter().cloned().collect(),
         output_level,
         output_min_seq,
-        output_max_seq,
     }
 }
 

--- a/lib/finelog/rust/src/store/namespace.rs
+++ b/lib/finelog/rust/src/store/namespace.rs
@@ -20,8 +20,6 @@
 //! persisted: it stamps into a RAM buffer, advances `persisted_seq` to the
 //! freshly allocated seq under the lock, and never writes parquet.
 
-use std::cell::RefCell;
-use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -44,8 +42,7 @@ use crate::store::reconcile::reconcile_remote_segments;
 use crate::store::remote::{build_remote_store, RemoteStore};
 use crate::store::schema::{schema_to_arrow, AlignedBatch, Schema};
 use crate::store::segment::{
-    discover_segments, read_segment_footer, recover_next_seq, segment_uncompressed_bytes,
-    write_segment_to_dir,
+    discover_segments, read_segment_footer, recover_next_seq, write_segment_to_dir,
 };
 use crate::store::trigram::{sidecar_path, write_sidecar};
 use crate::store::types::{LocalSegment, NamespaceStats, SegmentLocation, SegmentRow};
@@ -647,50 +644,15 @@ impl Namespace {
                 .map(|s| segment_to_row(&self.name, s))
                 .collect::<Vec<_>>()
         };
-        // The planner's only I/O is the per-segment footer read behind this
-        // closure. Memoize it so the chosen job's uncompressed size can be
-        // logged without re-parsing the same footers.
-        let uncompressed: RefCell<HashMap<String, i64>> = RefCell::new(HashMap::new());
-        let planned = plan(&self.compaction_config, &rows, |row| {
-            *uncompressed
-                .borrow_mut()
-                .entry(row.path.clone())
-                .or_insert_with(|| self.segment_uncompressed(&row.path))
-        });
-        let Some(job) = planned else {
+        let Some(job) = plan(&self.compaction_config, &rows) else {
             return Ok(false);
         };
-        let memo = uncompressed.borrow();
-        let job_uncompressed = job
-            .inputs
-            .iter()
-            .filter_map(|s| memo.get(&s.path).copied())
-            .fold(0i64, i64::saturating_add);
-        drop(memo);
-        self.run_one_job(&dir, &job, job_uncompressed)?;
+        self.run_one_job(&dir, &job)?;
         Ok(true)
     }
 
-    /// Decoded size of the segment at `path`, for the compaction memory budget.
-    ///
-    /// An unreadable footer reports `i64::MAX` so the planner isolates the
-    /// segment into a single-input job — promoted by rename — rather than
-    /// pulling an unmeasurable input into a merge.
-    fn segment_uncompressed(&self, path: &str) -> i64 {
-        match segment_uncompressed_bytes(std::path::Path::new(path)) {
-            Some(bytes) => bytes,
-            None => {
-                tracing::warn!(
-                    namespace = %self.name,
-                    path = %path,
-                    "unreadable segment footer; treating as over the merge memory budget"
-                );
-                i64::MAX
-            }
-        }
-    }
-
-    /// Synthesize and apply a single L0->L1 merge of ALL L0 segments.
+    /// Synthesize and apply a single L0->L1 merge of every L0 segment that fits
+    /// `max_merge_arrow_bytes` (all of them, at test data sizes).
     ///
     /// Tests use this to land L1 state without configuring tiny `level_targets`.
     /// Production never calls it. No-op when there are no L0 segments (or in
@@ -715,46 +677,28 @@ impl Namespace {
         }
         let output_min_seq = l0.iter().map(|r| r.min_seq).min().expect("non-empty");
         let output_max_seq = l0.iter().map(|r| r.max_seq).max().expect("non-empty");
-        let uncompressed = l0
-            .iter()
-            .map(|r| self.segment_uncompressed(&r.path))
-            .fold(0i64, i64::saturating_add);
         let job = CompactionJob {
             inputs: l0,
             output_level: 1,
             output_min_seq,
             output_max_seq,
         };
-        self.run_one_job(&dir, &job, uncompressed)
+        self.run_one_job(&dir, &job)
     }
 
     /// Execute `job` (read+merge+write or rename) then commit the resulting swap.
     ///
-    /// `input_uncompressed_bytes` is the decoded size the planner budgeted the
-    /// job against; it is logged so the compressed-to-decoded ratio driving
-    /// merge memory is visible in production.
-    fn run_one_job(
-        &self,
-        dir: &std::path::Path,
-        job: &CompactionJob,
-        input_uncompressed_bytes: i64,
-    ) -> Result<(), StatsError> {
+    /// The executor may consume only a prefix of `job.inputs` — as much as
+    /// `max_merge_arrow_bytes` admits — so the committed span comes from the
+    /// swap, not the job, and both counts are logged.
+    fn run_one_job(&self, dir: &std::path::Path, job: &CompactionJob) -> Result<(), StatsError> {
         let indexed = self.indexed_columns();
         let started = Instant::now();
-        // A single-input job is a rename; a multi-input job reads every input
-        // into RAM. The distinction is the whole memory story, so name it.
-        let kind = if job.inputs.len() == 1 {
-            "bump"
-        } else {
-            "merge"
-        };
         tracing::info!(
             namespace = %self.name,
-            kind,
-            inputs = job.inputs.len(),
+            planned_inputs = job.inputs.len(),
             output_level = job.output_level,
             input_bytes = job.inputs.iter().map(|s| s.byte_size).sum::<i64>(),
-            input_uncompressed_bytes,
             input_rows = job.inputs.iter().map(|s| s.row_count).sum::<i64>(),
             "compaction job starting"
         );
@@ -764,11 +708,23 @@ impl Namespace {
             &self.arrow_schema,
             self.key_column.as_deref(),
             &indexed,
+            self.compaction_config.max_merge_arrow_bytes,
             |path| self.input_key_bounds(path),
         )?;
         let output_path = swap.added.path.clone();
         let output_bytes = swap.added.size_bytes;
         let output_rows = swap.added.row_count;
+        // A bump is a rename; a merge decodes its inputs into RAM. The
+        // distinction is the whole memory story, so name it — along with the
+        // decoded size the ceiling actually bounds, and how much of the planned
+        // job that ceiling let this tick take.
+        let kind = if swap.bump_rename.is_some() {
+            "bump"
+        } else {
+            "merge"
+        };
+        let merged_inputs = swap.removed.len();
+        let input_arrow_bytes = swap.input_arrow_bytes;
         self.commit_swap(swap)?;
         tracing::info!(
             namespace = %self.name,
@@ -777,6 +733,9 @@ impl Namespace {
             output_path = %output_path,
             output_bytes,
             output_rows,
+            merged_inputs,
+            planned_inputs = job.inputs.len(),
+            input_arrow_bytes,
             elapsed_ms = started.elapsed().as_millis() as u64,
             "compaction job committed"
         );

--- a/lib/finelog/rust/src/store/namespace.rs
+++ b/lib/finelog/rust/src/store/namespace.rs
@@ -676,12 +676,10 @@ impl Namespace {
             return Ok(());
         }
         let output_min_seq = l0.iter().map(|r| r.min_seq).min().expect("non-empty");
-        let output_max_seq = l0.iter().map(|r| r.max_seq).max().expect("non-empty");
         let job = CompactionJob {
             inputs: l0,
             output_level: 1,
             output_min_seq,
-            output_max_seq,
         };
         self.run_one_job(&dir, &job)
     }

--- a/lib/finelog/rust/src/store/segment.rs
+++ b/lib/finelog/rust/src/store/segment.rs
@@ -189,26 +189,6 @@ pub fn segment_bounds(
     Some((num_rows, lo, hi))
 }
 
-/// Footer-only sum of each row group's uncompressed byte size, or `None` on an
-/// unreadable footer.
-///
-/// This is the size of the segment's decoded column data — the scale of the
-/// Arrow arrays a merge materializes in RAM. The on-disk (compressed) size
-/// understates it by the compression ratio, which reaches 10-20x on log text,
-/// so the compaction planner budgets merge memory against this instead.
-pub fn segment_uncompressed_bytes(path: &Path) -> Option<i64> {
-    let file = std::fs::File::open(path).ok()?;
-    let reader = SerializedFileReader::new(file).ok()?;
-    Some(
-        reader
-            .metadata()
-            .row_groups()
-            .iter()
-            .map(|rg| rg.total_byte_size())
-            .sum(),
-    )
-}
-
 /// Footer-only row-group count for the parquet file at `path`, or `None` on an
 /// unreadable footer. Used by the trigram prune to confirm a sidecar's
 /// per-row-group entries align with the segment before attaching an access plan.


### PR DESCRIPTION
The marin finelog hub has been crash-looping since roughly 2026-07-15 — 630 restarts by the time this was diagnosed. Every boot replans the same `log` L2->L3 merge, decodes it to ~31 GB RSS, and gets OOM-killed by the container cgroup about 80s in. The same job replans on the next boot, so it never drains and never commits.

The merge memory ceiling was denominated in the wrong unit. `max_merge_uncompressed_bytes` was enforced against `total_byte_size()` from the parquet footer, which — despite calling itself uncompressed — measures dictionary-encoded pages, where a repeated log line costs one 4-byte index rather than its full text. The merge then decodes those pages into Arrow, where every row carries its text in full, and holds the inputs and the merged copy at once. The poison job measured 1.9 GiB by the footer and materialized roughly 15 GiB, twice over — far past the 4 GiB ceiling that admitted it. Halving that ceiling would not have helped: at 2 GiB the same 1.9 GiB job still fits.

No size in a parquet footer tracks the decoded size, so the ceiling moves to the executor, the only layer that can measure it. Inputs are now read one at a time and summed by `RecordBatch::get_array_memory_size`; the merge takes the longest prefix that fits `max_merge_arrow_bytes` and leaves the rest of the run for the next tick. An input that alone busts the ceiling degenerates to a level bump — a rename, no rewrite — so an oversized segment costs no merge memory and cannot wedge its level. Measuring costs one input of transient RAM over the ceiling, since a segment is only measurable by decoding it. The planner returns to pure policy on compressed bytes and no longer reads footers at all, which drops `segment_uncompressed_bytes` and its per-tick footer reads.

The committed-job log line now carries the measured decode, the consumed input count, and the planned count, so the ratio that made the footer unusable is visible in production instead of inferred from an OOM.

Two limits worth knowing. The ceiling is per-job and namespaces compact concurrently, so the process total is still unbounded across namespaces — only `log` is large enough to matter today, and a global budget is filed as follow-up work. And terminal-level segments will now land smaller than the 256 MiB `level_targets` tier implies, because the decoded ceiling binds first on log text; that is the correct trade against OOM-killing the hub.

This is a recurrence: an earlier OOM of this same namespace was fixed by introducing the footer-based ceiling, whose proxy is the bug here. The regression test now pins the denomination — its ceiling sits above the inputs combined stored size and below their combined decode, so a parquet-sized budget of the same number would wave the whole run through.