### PR TITLE
iris: cw-us-east-08a admit ravwojdyla service account as federated submitter

### DIFF
--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -114,7 +114,7 @@ auth:
       -----BEGIN PUBLIC KEY-----
       MCowBQYDK2VwAyEA42ziFTlGKgaA/fQ1wJCONKOml7rx5Y8UAQqVLTCtrCo=
       -----END PUBLIC KEY-----
-  allowed_submitters: ["*@openathena.ai", "wg0420@princeton.edu"]
+  allowed_submitters: ["*@openathena.ai", "wg0420@princeton.edu", "ravwojdyla@rav-openathena.iam.gserviceaccount.com"]
 
 kubernetes_provider:
   namespace: iris


### PR DESCRIPTION
* admit `ravwojdyla@rav-openathena.iam.gserviceaccount.com` in `cw-us-east-08a`'s `auth.allowed_submitters`
* the agent VM's only credential is this GCP service account; the marin hub (IAP) attributes its federated handoffs to that email, and 08a's allowlist (`*@openathena.ai` + one exact entry) rejects it at admission — `user_admitted` matches wildcard entries on the exact domain only
* same shape as #7260 (exact-entry admit for a non-domain submitter)
* blocks the mve seed-repeat panel retarget onto 08a GB200s (10 runs; TPU panel stopped per rav)