### PR TITLE
[iris] Mirror a federated child's job_config so it renders on the parent

### DIFF
--- a/lib/iris/src/iris/cluster/controller/federation_store.py
+++ b/lib/iris/src/iris/cluster/controller/federation_store.py
@@ -27,6 +27,7 @@ from iris.cluster.controller.codec import reconstruct_launch_job_request
 from iris.cluster.controller.db import ControllerDB, Tx
 from iris.cluster.controller.projections.attempt_counts import AttemptCountsProjection
 from iris.cluster.controller.projections.endpoints import EndpointRow, EndpointsProjection
+from iris.cluster.controller.projections.run_templates import RunTemplatesProjection
 from iris.cluster.federation.availability import QueuedCandidate
 from iris.cluster.federation.store import (
     CancelTarget,
@@ -339,7 +340,7 @@ class ControllerFederationStore:
             cur.caches[AttemptCountsProjection].invalidate_for_tasks(cur, [local_task_id])
 
     def _insert_child_mirror(self, cur: Tx, peer_id: str, local_job_id: JobName, summary) -> bool:
-        """Create the local mirror row for a child a peer spawned under a received root.
+        """Create the local mirror rows for a child a peer spawned under a received root.
 
         The whole federated subtree shares the root's submitter and root submit time,
         read from the (already-present) parent; the row is stamped with the peer
@@ -347,6 +348,11 @@ class ControllerFederationStore:
         ``False`` (and skips) if the parent is not mirrored yet — deltas arrive in
         changelog order, so the parent's creation precedes the child's and this is
         only a defensive guard; the child is re-created on its next delta.
+
+        Writes the ``job_config`` companion the dashboard reads join against, so the
+        child renders like any other job. Only the peer-reported resources are known
+        here — the parent never authored a request for this job and never runs it —
+        so the rest of the config keeps its column defaults.
         """
         parent = local_job_id.parent
         if parent is None:
@@ -365,7 +371,7 @@ class ControllerFederationStore:
             root_job_id=local_job_id.root_job.to_wire(),
             depth=local_job_id.depth,
             state=summary.state,
-            submitted_at_ms=root_submitted_ms,
+            submitted_at_ms=_proto_ms(summary.HasField("submitted_at"), summary.submitted_at) or root_submitted_ms,
             root_submitted_at_ms=root_submitted_ms,
             started_at_ms=_proto_ms(summary.HasField("started_at"), summary.started_at),
             finished_at_ms=_proto_ms(summary.HasField("finished_at"), summary.finished_at),
@@ -376,6 +382,15 @@ class ControllerFederationStore:
             name=local_job_id.name,
             cluster=peer_id,
         )
+        writes.insert_mirrored_job_config(
+            cur,
+            job_id=local_job_id,
+            name=local_job_id.name,
+            resources=summary.resources,
+        )
+        # job_config backs RunTemplatesProjection; invalidate post-commit per its
+        # watch contract, as ops.job.submit does for a locally-submitted job.
+        cur.caches[RunTemplatesProjection].invalidate_for_job(cur, local_job_id)
         return True
 
     def _set_replace(self, cur: Tx, peer_id: str, deltas) -> None:

--- a/lib/iris/src/iris/cluster/controller/migrations/0046_mirrored_job_config_backfill.py
+++ b/lib/iris/src/iris/cluster/controller/migrations/0046_mirrored_job_config_backfill.py
@@ -1,0 +1,25 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backfill the ``job_config`` companion for jobs mirrored from a federation peer.
+
+``job_config`` is a 1:1 extension of ``jobs``, and every dashboard read joins the two.
+The federation sync used to mirror a child a peer spawned under a received root as a
+``jobs`` row alone, so those children were dropped by the join: absent from ListJobs
+and not addressable by id, on the one cluster a user watches the whole federation from.
+
+The mirror now writes both rows. This repairs the rows it already created: the peer
+reports resources only for jobs it mirrors from here on, so a backfilled row keeps the
+column defaults and renders with no resource figures — enough to make a job that ran
+visible again, which is the whole of what was lost.
+"""
+
+
+def migrate(raw_conn) -> None:
+    raw_conn.execute(
+        """
+        INSERT INTO job_config (job_id, name)
+        SELECT jobs.job_id, jobs.name FROM jobs
+        WHERE NOT EXISTS (SELECT 1 FROM job_config WHERE job_config.job_id = jobs.job_id)
+        """
+    )

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -2093,15 +2093,21 @@ def changelog_min_seq(tx: Tx) -> int:
 
 
 def received_jobs_for_requester(tx: Tx, requester_id: str) -> list[JobName]:
-    """Every still-present job this peer received from ``requester_id`` (the full set
-    a stale/first-contact requester is resynced with)."""
+    """Every still-present job under a root this peer received from ``requester_id``
+    (the full set a stale/first-contact requester is resynced with).
+
+    Covers the whole subtree, not just the handed-off roots: a job the root spawns
+    runs locally on this peer and is reported to the same requester, so it is matched
+    through ``root_job_id``. Ordered by depth, so a parent precedes its children.
+    """
     rows = tx.execute(
-        select(federated_jobs_table.c.job_id)
-        .select_from(federated_jobs_table.join(jobs_table, jobs_table.c.job_id == federated_jobs_table.c.job_id))
+        select(jobs_table.c.job_id)
+        .select_from(jobs_table.join(federated_jobs_table, federated_jobs_table.c.job_id == jobs_table.c.root_job_id))
         .where(
             federated_jobs_table.c.direction == int(FederationDirection.RECEIVED),
             federated_jobs_table.c.peer_id == requester_id,
         )
+        .order_by(jobs_table.c.depth)
     ).all()
     return [r.job_id for r in rows]
 

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -3266,7 +3266,10 @@ class ControllerServiceImpl:
         return controller_pb2.Controller.ListPeersResponse(peers=self._controller.federation.peer_summaries())
 
     def _federated_job_summary(self, q: Tx, job) -> job_pb2.JobStatus:
-        """A ``JobStatus`` for a handed-off job as this peer holds it (sync summary)."""
+        """A ``JobStatus`` for a handed-off job as this peer holds it (sync summary).
+
+        Carries the job's resource spec, which the requester mirrors onto its config.
+        """
         summaries = reads.task_summaries_for_jobs(
             q, {job.job_id}, attempt_counts=q.caches[AttemptCountsProjection].get_jobs(q, [job.job_id])
         )
@@ -3278,6 +3281,7 @@ class ControllerServiceImpl:
             name=job.name,
             backend_id=job.backend_id or "",
             cluster=job.cluster,
+            resources=resource_spec_from_job_row(job),
             **_job_status_counts(summaries.get(job.job_id), job.job_id),
         )
         if job.started_at_ms:

--- a/lib/iris/src/iris/cluster/controller/writes.py
+++ b/lib/iris/src/iris/cluster/controller/writes.py
@@ -28,6 +28,7 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
 
 from iris.cluster.controller.caches import CacheRegistry
+from iris.cluster.controller.codec import proto_to_json
 from iris.cluster.controller.db import Tx
 from iris.cluster.controller.projections.attempt_counts import AttemptCountsProjection
 from iris.cluster.controller.projections.run_templates import RunTemplatesProjection
@@ -866,6 +867,32 @@ def mark_federated_job_unschedulable(tx: Tx, job_id: JobName, *, now_ms: int, er
         update(jobs_table)
         .where(jobs_table.c.job_id == job_id)
         .values(state=job_pb2.JOB_STATE_UNSCHEDULABLE, finished_at_ms=now_ms, error=error)
+    )
+
+
+@writes_to(job_config_table)
+def insert_mirrored_job_config(
+    tx: Tx,
+    *,
+    job_id: JobName,
+    name: str,
+    resources: job_pb2.ResourceSpecProto,
+) -> None:
+    """Insert the ``job_config`` companion for a job mirrored from a peer.
+
+    Sets the name and the resources the peer reports; the columns describing how to
+    run the job (entrypoint, bundle, retries, timeouts) keep their defaults, since
+    the peer runs it and the parent only renders it.
+    """
+    tx.execute(
+        insert(job_config_table).values(
+            job_id=job_id,
+            name=name,
+            res_cpu_millicores=int(resources.cpu_millicores),
+            res_memory_bytes=int(resources.memory_bytes),
+            res_disk_bytes=int(resources.disk_bytes),
+            res_device_json=proto_to_json(resources.device),
+        )
     )
 
 

--- a/lib/iris/tests/cluster/controller/test_federation_handoff.py
+++ b/lib/iris/tests/cluster/controller/test_federation_handoff.py
@@ -1287,3 +1287,127 @@ def test_incremental_sync_delivers_a_tombstone_and_drops_the_handle(tmp_path, lo
 
         assert _handle(parent_state, parent_job_id) is None
         assert query_job(parent_state, parent_job_id) is None
+
+
+def _spawn_child_on_peer(peer_service: ControllerServiceImpl, root: JobName, name: str) -> JobName:
+    """Submit ``name`` as a child of a received root, the way a coordinator job on
+    the peer spawns its trainer sub-job against its own local controller."""
+    request = make_direct_job_request(name, replicas=1)
+    request.name = root.child(name).to_wire()
+    response = peer_service.launch_job(request, None)
+    return JobName.from_wire(response.job_id)
+
+
+def test_sync_mirrors_a_child_the_peer_spawned_under_a_received_root(tmp_path, log_client):
+    """A child a peer spawns under a received root reaches the parent's dashboard.
+
+    The peer runs the child as an ordinary local job, so nothing hands it off; it is
+    reported because its *root* was received. The parent must mirror it as a job a
+    dashboard read can actually return — ListJobs and GetJobStatus, not just a raw
+    ``jobs`` row — else a coordinator's real work is invisible on the parent.
+    """
+    with ExitStack() as stack:
+        parent_service, parent_state = _make_service(stack, "parent", tmp_path, log_client)
+        peer_service, _ = _make_service(stack, "peer", tmp_path, log_client)
+        manager = _attach_federation(parent_service, _InProcessPeerConnection(peer_service))
+
+        response = parent_service.launch_job(_cluster_pinned_request("coord"), None)
+        root = JobName.from_wire(response.job_id)
+        promote_queued_federation(manager, parent_state)
+
+        child = _spawn_child_on_peer(peer_service, root, "trainer")
+        manager.sync_once()
+
+        # The mirrored child is a complete job row: stamped with the owning peer and
+        # hung under its parent, so the dashboard renders it in the root's subtree.
+        mirrored = query_job(parent_state, child)
+        assert mirrored is not None, "peer-spawned child never mirrored onto the parent"
+        assert mirrored.cluster == "cw"
+        assert mirrored.parent_job_id == root
+
+        # ListJobs is the dashboard's job feed: the child must appear both unfiltered
+        # and under the peer's cluster filter.
+        def _list(**query) -> set[str]:
+            resp = parent_service.list_jobs(
+                controller_pb2.Controller.ListJobsRequest(query=controller_pb2.Controller.JobQuery(**query)),
+                None,
+            )
+            return {j.job_id for j in resp.jobs}
+
+        assert child.to_wire() in _list()
+        assert child.to_wire() in _list(cluster="cw")
+
+        # The dashboard drills into a root by listing its children; the reported
+        # total must match the rows actually returned, or the page under-fills.
+        children = parent_service.list_jobs(
+            controller_pb2.Controller.ListJobsRequest(
+                query=controller_pb2.Controller.JobQuery(
+                    scope=controller_pb2.Controller.JOB_QUERY_SCOPE_CHILDREN,
+                    parent_job_id=root.to_wire(),
+                )
+            ),
+            None,
+        )
+        assert {j.job_id for j in children.jobs} == {child.to_wire()}
+        assert children.total_count == 1
+
+        # And it must be addressable by id, not just visible in a list.
+        status = parent_service.get_job_status(
+            controller_pb2.Controller.GetJobStatusRequest(job_id=child.to_wire()), None
+        ).job
+        assert status.cluster == "cw"
+
+
+def test_sync_mirrors_a_childs_resources_from_the_peer(tmp_path, log_client):
+    """The parent authored no request for a peer-spawned child, so the sync summary is
+    the only place its resource spec can come from. Without it the child renders as a
+    job asking for nothing.
+    """
+    with ExitStack() as stack:
+        parent_service, parent_state = _make_service(stack, "parent", tmp_path, log_client)
+        peer_service, _ = _make_service(stack, "peer", tmp_path, log_client)
+        manager = _attach_federation(parent_service, _InProcessPeerConnection(peer_service))
+
+        response = parent_service.launch_job(_cluster_pinned_request("coord"), None)
+        root = JobName.from_wire(response.job_id)
+        promote_queued_federation(manager, parent_state)
+
+        request = make_direct_job_request("trainer", replicas=1)
+        request.name = root.child("trainer").to_wire()
+        request.resources.CopyFrom(job_pb2.ResourceSpecProto(cpu_millicores=8000, memory_bytes=64 * 1024**3))
+        child = JobName.from_wire(peer_service.launch_job(request, None).job_id)
+        manager.sync_once()
+
+        mirrored = query_job(parent_state, child)
+        assert mirrored.res_cpu_millicores == 8000
+        assert mirrored.res_memory_bytes == 64 * 1024**3
+
+
+def test_full_resync_reports_the_whole_subtree_under_a_received_root(tmp_path, log_client):
+    """A stale cursor resyncs from the peer's full active set, which must include the
+    children under a received root — not just the roots.
+
+    The resync advances the parent's cursor to the peer's max seq, so a child left out
+    of that set is not merely late: its creation event is consumed and it never appears
+    unless it happens to change again.
+    """
+    with ExitStack() as stack:
+        parent_service, parent_state = _make_service(stack, "parent", tmp_path, log_client)
+        peer_service, peer_state = _make_service(stack, "peer", tmp_path, log_client)
+        manager = _attach_federation(parent_service, _InProcessPeerConnection(peer_service))
+
+        response = parent_service.launch_job(_cluster_pinned_request("coord"), None)
+        root = JobName.from_wire(response.job_id)
+        promote_queued_federation(manager, parent_state)
+
+        # The child is born and reaches its terminal state entirely inside the window
+        # the parent's cursor skips, so only the full set can carry it across.
+        child = _spawn_child_on_peer(peer_service, root, "trainer")
+        _run_peer_task_to_success(peer_state, child)
+        with parent_state._db.transaction() as cur:
+            writes.upsert_sync_cursor(cur, "cw", "")
+        manager.sync_once()
+
+        mirrored = query_job(parent_state, child)
+        assert mirrored is not None, "full resync dropped the child under a received root"
+        assert mirrored.state == job_pb2.JOB_STATE_SUCCEEDED


### PR DESCRIPTION
A child a peer spawns under a received root was mirrored onto the parent as a `jobs` row alone. `job_config` is a 1:1 extension of `jobs` that `list_jobs` and `get_job_detail` both inner-join, so every such child was dropped by the join: absent from the dashboard's job feed and not addressable by id, on the very cluster a user watches the whole federation from. A coordinator federated out to a peer showed up with none of the work it spawned.

Reported against `/larry/gb200-512gpu-r8-fa4fix-coord` on cw-us-east-08a, which rendered on marin with no children. The sync was working the whole time — the peer emitted changelog rows for the child (attributed to `marin` via the received root), marin consumed them and wrote the child's `jobs` and `tasks` rows. Only the read dropped it. Live on marin before this change: 82 of 82 federated children across three peers had no config; 6083 of 6083 local children had one.

The mirror now writes the config companion alongside the job row. The parent authored no request for a peer-spawned job, so the peer reports the resource spec on the sync summary (`JobStatus.resources`, already on the wire and until now never set on this path) and the remaining columns keep their defaults — a federated job folds out of the local control plane on its `cluster` stamp, not on a missing config, so the row is inert for scheduling (`test_federation_fold_exclusion.py` pins this: it drives a federated job that *has* a config, with a 1s timeout, through every control-plane reader).

Two adjacent defects on the same path:

- The full-resync set was roots-only, so a stale cursor resynced a requester without the children under its received roots while advancing that requester's cursor past their changelog events — stranding any child that did not happen to change again. It now enumerates the subtree through `root_job_id`, the way the endpoint snapshot already scopes a received root's children. On cw-us-east-08a: 57 children under marin-received roots, 52 mirrored.
- A mirrored child was stamped with the root's submit time rather than its own, which the sync summary already carries, so date-sorted listings pinned every child to its root's timestamp.

Migration 0046 backfills the config for rows the mirror already created. The peer reports resources only for jobs mirrored from here on, so a backfilled row renders without resource figures — enough to make a job that ran visible again.

`_insert_child_mirror` had no test at all, which is how this held: every sync assertion goes through `query_job` → `get_job_detail` → the inner join, and passes for roots because a root always has a config from its handoff request. The three new tests each fail on the unfixed tree.

Rolled to marin-dev and marin (410/410 workers retained, no federation errors, migration cleared all 87 config-less rows). `/larry/gb200-512gpu-r8-fa4fix-coord` now lists with its child and the child resolves by id with its 128 tasks.

The peer-side halves — resources on the sync summary, and the subtree resync — take effect for a peer once that peer's controller rolls; the CoreWeave peers have not been rolled.
