### PR TITLE
[rigging] Match sensitive key names on word boundaries, not substrings

### DIFF
--- a/lib/iris/dashboard/src/components/controller/RpcStatsPanel.vue
+++ b/lib/iris/dashboard/src/components/controller/RpcStatsPanel.vue
@@ -236,8 +236,10 @@ function currentSamples(method: string, tab: 'recent' | 'slow'): RpcCallSample[]
       <p class="text-xs text-text-muted mb-3">
         Per-method counters, latency percentiles, and an inline histogram on a log scale
         (3 buckets per octave, ≈1 ms → 60 s). Click a row to expand samples.
-        Request previews are redacted server-side for keys matching
-        <code class="font-mono">KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL</code>.
+        Request previews are redacted server-side for keys naming a secret, such as
+        <code class="font-mono">API_KEY</code>, <code class="font-mono">TOKEN</code>,
+        <code class="font-mono">SECRET</code>, <code class="font-mono">PASSWORD</code> or
+        <code class="font-mono">CREDENTIAL</code>.
       </p>
 
       <!-- Header -->

--- a/lib/rigging/src/rigging/redaction.py
+++ b/lib/rigging/src/rigging/redaction.py
@@ -3,6 +3,7 @@
 
 """Shared secret redaction helpers."""
 
+import itertools
 import json
 import math
 import re
@@ -23,10 +24,72 @@ PREFIXED_SECRET_RE = re.compile(
     r"|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"
     r")(?![A-Za-z0-9_-])"
 )
-SENSITIVE_KEY_RE = re.compile(
-    r"api[_-]?key|secret|token|password|passwd|pwd|auth|credential|private[_-]?key|access[_-]?key|bearer|session",
-    re.IGNORECASE,
+# Words that mark a key as secret-bearing, matched against the key's words
+# rather than as raw substrings. A substring match is wrong in both directions
+# for real env var names: "token" appears inside ``TOKENIZERS_PARALLELISM`` and
+# ``TOKENIZER_PATH``, and "auth" inside ``AUTHOR``, none of which are secrets.
+_SENSITIVE_WORDS = frozenset(
+    {
+        "apikey",
+        "auth",
+        "authentication",
+        "authorization",
+        "bearer",
+        "credential",
+        "credentials",
+        "passphrase",
+        "passwd",
+        "password",
+        "passwords",
+        "pwd",
+        "secret",
+        "secrets",
+        "session",
+        "sessions",
+        "token",
+        "tokens",
+    }
 )
+
+# Sensitive only as an adjacent word pair. "key" on its own is too common in
+# non-secret names (``cache_key``, ``sort_key``, ``key_name``) to redact.
+_SENSITIVE_PHRASES = frozenset(
+    {
+        ("api", "key"),
+        ("access", "key"),
+        ("private", "key"),
+    }
+)
+
+# "token" is a credential in ``HF_TOKEN`` but a sequence length in
+# ``max_tokens`` / ``token_count``. When a counting word sits alongside it and
+# nothing else in the key is sensitive, read it as the length sense.
+_TOKEN_WORDS = frozenset({"token", "tokens"})
+_COUNT_WORDS = frozenset(
+    {
+        "avg",
+        "budget",
+        "count",
+        "len",
+        "length",
+        "limit",
+        "max",
+        "mean",
+        "min",
+        "num",
+        "per",
+        "size",
+        "sum",
+        "total",
+        "window",
+    }
+)
+
+# Splits an identifier into words on separator characters and camelCase humps,
+# so ``WANDB_API_KEY``, ``wandbApiKey`` and ``wandb-api-key`` all yield
+# ``["wandb", "api", "key"]``. An all-caps run stays one word, which is what
+# keeps ``TOKENIZERS`` from reading as ``TOKEN``.
+_KEY_WORD_RE = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z]+|[a-z]+|[0-9]+")
 
 # Keys whose values are known to be identifiers (job/task/worker IDs, names,
 # zones, hostnames, etc.) rather than secrets. Values under safe keys skip
@@ -35,8 +98,8 @@ SENSITIVE_KEY_RE = re.compile(
 # (``sk-...``, ``ghp_...``, AKIA, JWTs, PEM blocks) still applies, so a real
 # secret accidentally placed in a safe field is still caught.
 #
-# Sensitive-key detection runs first, so a key matching both ``SENSITIVE_KEY_RE``
-# and ``SAFE_KEY_RE`` (e.g., ``auth_id``) is still redacted as sensitive.
+# Sensitive-key detection runs first, so a key that is both sensitive and safe
+# (e.g., ``auth_id``) is still redacted as sensitive.
 SAFE_KEY_RE = re.compile(
     # Generic identifier suffixes: foo_id, foo_ids, foo_name, foo_index, foo_no, foo_num
     r".*_(id|name|index|idx|no|num)s?$"
@@ -68,8 +131,26 @@ def looks_like_key(value: str, min_len: int = 24, min_entropy: float = _MIN_KEY_
     return len(value) >= min_len and _KEY_CHARS_RE.fullmatch(value) is not None and shannon_entropy(value) >= min_entropy
 
 
+def key_words(name: str) -> list[str]:
+    """Split *name* into its lowercased words on separators and camelCase humps."""
+    return [word.lower() for word in _KEY_WORD_RE.findall(name)]
+
+
 def is_sensitive_key_name(name: str) -> bool:
-    return SENSITIVE_KEY_RE.search(name) is not None
+    """Return True if *name* names a secret-bearing field.
+
+    Matches whole words, not substrings, so ``HF_TOKEN`` is sensitive while
+    ``TOKENIZERS_PARALLELISM`` is not. "token" alongside a counting word and no
+    other sensitive word reads as a length, so ``max_tokens`` is not sensitive
+    either, while ``session_token_count`` still is.
+    """
+    words = key_words(name)
+    hits = {word for word in words if word in _SENSITIVE_WORDS}
+    if hits <= _TOKEN_WORDS and any(word in _COUNT_WORDS for word in words):
+        hits = set()
+    if hits:
+        return True
+    return any(pair in _SENSITIVE_PHRASES for pair in itertools.pairwise(words))
 
 
 def is_safe_key_name(name: str) -> bool:

--- a/lib/rigging/tests/test_redaction.py
+++ b/lib/rigging/tests/test_redaction.py
@@ -34,6 +34,69 @@ def test_redact_value_redacts_sensitive_key_names():
     }
 
 
+def test_is_sensitive_key_name_matches_whole_words_not_substrings():
+    # Regression: the matcher used a bare substring search, so every name
+    # merely *containing* "token" or "auth" was treated as a secret.
+    for name in [
+        "TOKENIZERS_PARALLELISM",
+        "TOKENIZER_PATH",
+        "HF_TOKENIZER",
+        "tokenizer",
+        "AUTHOR",
+        "author_name",
+        "AUTHORIZED_USERS",
+        "AUTHORITY",
+    ]:
+        assert not is_sensitive_key_name(name), name
+
+
+def test_is_sensitive_key_name_matches_real_secret_names():
+    for name in [
+        "HF_TOKEN",
+        "token",
+        "access-token",
+        "refresh_token",
+        "api_key",
+        "apiKey",
+        "x-api-key",
+        "WANDB_API_KEY",
+        "wandbApiKey",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "Authorization",
+        "AUTHORIZATION",
+        "PRIVATE_KEY",
+        "password",
+        "passphrase",
+        "bearer_token",
+        "client_secret",
+    ]:
+        assert is_sensitive_key_name(name), name
+
+
+def test_is_sensitive_key_name_reads_token_counts_as_lengths():
+    # "token" is a sequence length here, not a credential.
+    for name in ["max_tokens", "num_tokens", "token_count", "max_new_tokens", "tokens_per_second"]:
+        assert not is_sensitive_key_name(name), name
+
+
+def test_counting_word_does_not_launder_a_real_secret():
+    # A counting word only reinterprets "token" when nothing else in the key is
+    # sensitive; it must not unmask a key that names a credential outright.
+    assert is_sensitive_key_name("session_token_count")
+    assert is_sensitive_key_name("max_auth_tokens")
+    assert is_sensitive_key_name("secret_token_limit")
+
+
+def test_redact_value_preserves_tokenizers_parallelism():
+    # Iris injects TOKENIZERS_PARALLELISM into every job's env; it must survive
+    # redaction so the dashboard shows it beside a genuinely redacted API key.
+    value = {"WANDB_API_KEY": "local-4f8ac21e9b3d5c760a1e2f3b4c5d6e7f8a9b0c1d", "TOKENIZERS_PARALLELISM": "false"}
+
+    assert redact_value(value) == {"WANDB_API_KEY": REDACTED_VALUE, "TOKENIZERS_PARALLELISM": "false"}
+
+
 def test_redact_string_redacts_prefixed_tokens():
     slack_token = "xox" + "b-1234567890-abcdefghijklmnopqrstuvwxyz"
     raw = (


### PR DESCRIPTION
`is_sensitive_key_name` ran an unanchored substring search, so any key merely containing "token", "auth", or "secret" was treated as secret-bearing. Iris injects `TOKENIZERS_PARALLELISM` into every job environment, and it contains "TOKEN" — so the dashboard's Environment Variables panel rendered it as `TOKENIZERS_PARALLELISM=[REDACTED]` next to the legitimately redacted `WANDB_API_KEY`, hiding a value that is only ever `false` or `0`. The same substring match swallowed `TOKENIZER_PATH`, `HF_TOKENIZER`, and `AUTHOR`.

Key names are now split into words on separators and camelCase humps and matched a word at a time, so `HF_TOKEN` stays sensitive while `TOKENIZERS` reads as one word. "key" alone is too common to redact on (`cache_key`, `sort_key`), so it only counts in the pairs `api key`, `access key`, and `private key` — matching what the previous regex spelled out. `auth` no longer matches by substring, so `authorization` and `authentication` are now listed explicitly to keep `Authorization` headers redacted.

"token" also names a sequence length across levanter and marin (`max_tokens`, `token_count`, 300+ call sites). Where a counting word sits alongside it and nothing else in the key is sensitive, it reads as the length sense; a key that names a credential outright still redacts, so `session_token_count` and `max_auth_tokens` do not slip through.

The entropy heuristic is not involved in any of this — it only applies to values of 24+ characters, and a value of `0` scores 0.0. The substring match on the *key name* was doing all the damage.

Before / after, through the real `GetJobStatus` path:

```
  HF_TOKEN=[REDACTED]                     HF_TOKEN=[REDACTED]
  JAX_PLATFORMS=tpu                       JAX_PLATFORMS=tpu
  TOKENIZERS_PARALLELISM=[REDACTED]  ->   TOKENIZERS_PARALLELISM=0
  WANDB_API_KEY=[REDACTED]                WANDB_API_KEY=[REDACTED]
```

The RPC stats panel advertised redaction of keys "matching `KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL`", a whole-word framing the regex never enforced; it now describes what the redactor actually does.

Existing redaction tests pass unchanged (`lib/rigging`, `tests/ci/test_iris_monitor.py`, `lib/iris` cluster + controller service), which pins that no previously-redacted secret name regressed.