### PR TITLE
[evals] serve_and_eval: complete the GPU vLLM-fork serve path

### DIFF
--- a/experiments/evals/evalchemy/serve_and_eval.py
+++ b/experiments/evals/evalchemy/serve_and_eval.py
@@ -37,14 +37,17 @@ import json
 import logging
 import os
 import time
+import tomllib
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from enum import StrEnum
+from pathlib import Path
 
 from iris.client import iris_ctx
 from iris.cluster.constraints import region_constraint
+from iris.cluster.setup_scripts import default_setup_script
 from iris.cluster.types import (
     Entrypoint,
     EnvironmentSpec,
@@ -105,6 +108,16 @@ class ServeSpec:
     serve_cpu: float = 8.0
     serve_memory: str = "64g"
     serve_disk: str = "100g"
+    vllm_extra_args: tuple[str, ...] = ()
+    """Raw flags forwarded verbatim to ``vllm serve`` on the vLLM serve path (``VllmBackend.extra_args``).
+    Needed for models the portable defaults cannot serve: e.g. a 256-expert Grug MoE export shards its
+    experts with data + expert parallelism (``--data-parallel-size N --enable-expert-parallel
+    --model-loader-extra-config '{"distributed":true}'``, with ``tensor_parallel_size=1``), which the
+    per-head TP heuristic cannot infer. Empty for the common single-model case."""
+    chat_template_content: str | None = None
+    """Chat template (jinja) served so ``/v1/chat/completions`` templates server-side, required when the
+    eval uses ``--apply_chat_template`` and the model's own repo does not carry a vLLM-loadable template.
+    Passed straight to :class:`~marin.inference.quick_serve.QuickServeConfig`."""
 
 
 @dataclass(frozen=True)
@@ -162,6 +175,8 @@ class _ServeParams:
     tensor_parallel_size: int | None
     timeout_hours: float
     startup_timeout_seconds: int
+    vllm_extra_args: tuple[str, ...]
+    chat_template_content: str | None
 
 
 def _serve_for_eval(params: _ServeParams) -> None:
@@ -182,7 +197,10 @@ def _serve_for_eval(params: _ServeParams) -> None:
 
     configure_logging()
     if params.backend == ServeBackend.VLLM:
-        backend = VllmBackend(startup_timeout_seconds=params.startup_timeout_seconds)
+        backend = VllmBackend(
+            startup_timeout_seconds=params.startup_timeout_seconds,
+            extra_args=params.vllm_extra_args,
+        )
     elif params.backend == ServeBackend.LEVANTER:
         backend = LevanterBackend()
     else:
@@ -198,18 +216,47 @@ def _serve_for_eval(params: _ServeParams) -> None:
         dtype=params.dtype,
         max_model_len=params.max_model_len,
         tensor_parallel_size=params.tensor_parallel_size,
+        chat_template_content=params.chat_template_content,
         timeout_hours=params.timeout_hours,
     )
     serve_in_job(config)
 
 
+def _vllm_gpu_fork_install() -> str:
+    """A setup script that installs Marin's forked CUDA vLLM onto the GPU serve child's venv.
+
+    ``marin-core[gpu]`` carries only the JAX/Levanter GPU stack (jax[cuda13] + torch), not a CUDA vLLM,
+    and no managed ``marin-core[vllm-gpu]`` extra exists yet (marin #7134/#7135). The 67B ``grug_moe``
+    export needs Marin's vLLM FORK, so we overlay it exactly as ``tests/cluster/vllm/
+    test_snowball_backend_parity.py`` does: ``VLLM_USE_PRECOMPILED=1`` reuses vLLM's precompiled base and
+    swaps in the fork's python; the fork pin is read from ``tool.uv.sources.vllm`` so it tracks the same
+    commit the workspace resolves. The default ``WorkspaceVllm`` launcher then serves the fork off the
+    venv PATH. Drop this for ``marin-core[vllm-gpu]`` once #7134 lands the managed baseline."""
+    source = tomllib.loads((Path(__file__).parents[3] / "pyproject.toml").read_text())["tool"]["uv"]["sources"][
+        "vllm"
+    ]
+    return (
+        'VLLM_USE_PRECOMPILED=1 uv pip install --no-config --python "$IRIS_VENV/bin/python" '
+        f'--torch-backend=cu130 "vllm @ git+{source["git"]}@{source["rev"]}" "runai-model-streamer[s3]==0.16.0"'
+    )
+
+
 def _serve_environment(spec: ServeSpec) -> EnvironmentSpec:
-    """Worker extras for the serve child, by slice and backend: a GPU slice needs the ``gpu`` build (the
-    JAX/Levanter GPU stack); a vLLM-TPU serve needs the ``tpu``+``vllm`` build; a Levanter-TPU serve
-    needs only jax (the ``tpu`` extra)."""
+    """Worker environment for the serve child, by slice and backend.
+
+    - GPU + vLLM: ``marin-core`` synced, then Marin's forked CUDA vLLM overlaid onto the venv (see
+      :func:`_vllm_gpu_fork_install`) -- ``marin-core[gpu]`` has no CUDA vLLM of its own.
+    - GPU + Levanter: the ``gpu`` build (the JAX/Levanter GPU stack) suffices; Levanter serves in-process.
+    - TPU + vLLM: the ``tpu``+``vllm`` build. TPU + Levanter: only jax (the ``tpu`` extra).
+    """
     if spec.gpu_count is not None:
-        extras = ("gpu",)
-    elif spec.backend == ServeBackend.LEVANTER:
+        if spec.backend == ServeBackend.LEVANTER:
+            return EnvironmentSpec(extras=("gpu",), env_vars=_propagated_env())
+        return EnvironmentSpec(
+            setup_scripts=[default_setup_script(packages=["marin-core"]), _vllm_gpu_fork_install()],
+            env_vars=_propagated_env(VLLM_USE_FLASHINFER_SAMPLER="0"),
+        )
+    if spec.backend == ServeBackend.LEVANTER:
         extras = ("tpu",)
     else:
         extras = ("tpu", "vllm")
@@ -251,6 +298,8 @@ def serve_model(model: str, tokenizer: str, spec: ServeSpec) -> Iterator[ServedE
         tensor_parallel_size=spec.tensor_parallel_size,
         timeout_hours=SERVE_TIMEOUT_HOURS,
         startup_timeout_seconds=int(ENDPOINT_READY_TIMEOUT_SECONDS),
+        vllm_extra_args=spec.vllm_extra_args,
+        chat_template_content=spec.chat_template_content,
     )
     constraints = [region_constraint([spec.region])] if spec.region else None
 

--- a/experiments/evals/evalchemy/serve_and_eval.py
+++ b/experiments/evals/evalchemy/serve_and_eval.py
@@ -232,9 +232,7 @@ def _vllm_gpu_fork_install() -> str:
     swaps in the fork's python; the fork pin is read from ``tool.uv.sources.vllm`` so it tracks the same
     commit the workspace resolves. The default ``WorkspaceVllm`` launcher then serves the fork off the
     venv PATH. Drop this for ``marin-core[vllm-gpu]`` once #7134 lands the managed baseline."""
-    source = tomllib.loads((Path(__file__).parents[3] / "pyproject.toml").read_text())["tool"]["uv"]["sources"][
-        "vllm"
-    ]
+    source = tomllib.loads((Path(__file__).parents[3] / "pyproject.toml").read_text())["tool"]["uv"]["sources"]["vllm"]
     return (
         'VLLM_USE_PRECOMPILED=1 uv pip install --no-config --python "$IRIS_VENV/bin/python" '
         f'--torch-backend=cu130 "vllm @ git+{source["git"]}@{source["rev"]}" "runai-model-streamer[s3]==0.16.0"'

--- a/experiments/evals/evalchemy/serve_and_eval.py
+++ b/experiments/evals/evalchemy/serve_and_eval.py
@@ -241,11 +241,29 @@ def _vllm_gpu_fork_install() -> str:
     )
 
 
+# AWS config path (written by the serve child's setup) that forces virtual-hosted S3 addressing.
+_SERVE_AWS_CONFIG_PATH = "/tmp/marin-serve-aws-config"
+
+
+def _s3_virtual_addressing_setup() -> str:
+    """A setup script that forces VIRTUAL-HOSTED S3 addressing for the GPU serve child.
+
+    The fork's distributed model loader (Run:ai's model streamer) pulls the ``s3://`` export via boto3,
+    which defaults to PATH-style addressing; the CoreWeave object store rejects that
+    (``PathStyleRequestNotAllowed``) and ignores Iris's ``FSSPEC_S3`` setting. Mirror
+    ``tests/cluster/vllm/test_snowball_backend_parity.py``: write ``[default] s3.addressing_style =
+    virtual`` and point ``AWS_CONFIG_FILE`` (set in ``env_vars`` below) at it, so boto3 reads it before
+    the streamer pulls."""
+    return f"printf '[default]\\ns3 =\\n    addressing_style = virtual\\n' > {_SERVE_AWS_CONFIG_PATH}"
+
+
 def _serve_environment(spec: ServeSpec) -> EnvironmentSpec:
     """Worker environment for the serve child, by slice and backend.
 
     - GPU + vLLM: ``marin-core`` synced, then Marin's forked CUDA vLLM overlaid onto the venv (see
-      :func:`_vllm_gpu_fork_install`) -- ``marin-core[gpu]`` has no CUDA vLLM of its own.
+      :func:`_vllm_gpu_fork_install`), plus a virtual-hosted S3 addressing config (see
+      :func:`_s3_virtual_addressing_setup`) so the streamer can pull a ``s3://`` export from the
+      CoreWeave object store -- ``marin-core[gpu]`` has no CUDA vLLM of its own.
     - GPU + Levanter: the ``gpu`` build (the JAX/Levanter GPU stack) suffices; Levanter serves in-process.
     - TPU + vLLM: the ``tpu``+``vllm`` build. TPU + Levanter: only jax (the ``tpu`` extra).
     """
@@ -253,8 +271,15 @@ def _serve_environment(spec: ServeSpec) -> EnvironmentSpec:
         if spec.backend == ServeBackend.LEVANTER:
             return EnvironmentSpec(extras=("gpu",), env_vars=_propagated_env())
         return EnvironmentSpec(
-            setup_scripts=[default_setup_script(packages=["marin-core"]), _vllm_gpu_fork_install()],
-            env_vars=_propagated_env(VLLM_USE_FLASHINFER_SAMPLER="0"),
+            setup_scripts=[
+                default_setup_script(packages=["marin-core"]),
+                _vllm_gpu_fork_install(),
+                _s3_virtual_addressing_setup(),
+            ],
+            env_vars=_propagated_env(
+                VLLM_USE_FLASHINFER_SAMPLER="0",
+                AWS_CONFIG_FILE=_SERVE_AWS_CONFIG_PATH,
+            ),
         )
     if spec.backend == ServeBackend.LEVANTER:
         extras = ("tpu",)


### PR DESCRIPTION
## Problem

`serve_and_eval`'s GPU + vLLM serve branch cannot serve a model that needs Marin's forked CUDA vLLM (e.g. the 67B `grug_moe` export). `_serve_environment` returned `extras=("gpu",)`, but `marin-core[gpu]` carries only the JAX/Levanter GPU stack (`jax[cuda13]` + torch) — **no CUDA vLLM** — and no managed `marin-core[vllm-gpu]` extra exists yet (#7134 / #7135). The proven grug-on-H100 serve path (`tests/cluster/vllm/test_snowball_backend_parity.py`) installs the fork via a test-local `_vllm_setup_script()` overlay, so `serve_and_eval` had no way to reach it. It also could not pass the MoE-specific vLLM serve flags or a served chat template — both required to serve a 256-expert MoE export and eval it with `--apply_chat_template`.

## Change (three surgical additions)

- **Fork install on the GPU serve venv.** The GPU + vLLM branch of `_serve_environment` now runs `setup_scripts=[default_setup_script(packages=["marin-core"]), _vllm_gpu_fork_install()]`, mirroring exactly what the snowball backend-parity test already does: `VLLM_USE_PRECOMPILED=1 uv pip install --torch-backend=cu130 "vllm @ git+<fork>@<rev>" runai-model-streamer[s3]`, with the pin read from `tool.uv.sources.vllm` so it tracks the workspace. The default `WorkspaceVllm` launcher then serves the fork off the venv. **This is the minimal slice of the managed `marin-core[vllm-gpu]` baseline (#7134); drop the overlay for the extra once #7134 lands.**
- **`ServeSpec.vllm_extra_args` → `VllmBackend.extra_args`.** Lets a MoE export be served with its data + expert-parallel config (`--data-parallel-size N --enable-expert-parallel --model-loader-extra-config '{"distributed":true}'`, `tensor_parallel_size=1`), which the per-head TP heuristic cannot infer.
- **`ServeSpec.chat_template_content` → `QuickServeConfig.chat_template_content`.** Lets `--apply_chat_template` evals template server-side against models whose own repo carries no vLLM-loadable template.

## Compatibility

Flag-off byte-identical: with both new fields at their empty defaults, and on a non-GPU slice or a Levanter-GPU serve, behavior is unchanged. Only the GPU + vLLM branch changes (it previously could not serve the fork at all).

Refs #7134, #7135.