### PR TITLE
[finelog] Add an implicit origin-cluster column to every registered table

### DIFF
--- a/lib/finelog/rust/src/server/forwarding.rs
+++ b/lib/finelog/rust/src/server/forwarding.rs
@@ -64,7 +64,9 @@ use crate::query::{make_ctx, run_query_over, QueryResult, RegisteredProvider};
 use crate::server::auth::FINELOG_AUDIENCE;
 use crate::server::MAX_MESSAGE_BYTES;
 use crate::store::ipc::encode_ipc;
-use crate::store::schema::{schema_to_proto_owned, Schema, IMPLICIT_SEQ_COLUMN};
+use crate::store::schema::{
+    schema_to_proto_owned, Schema, IMPLICIT_CLUSTER_COLUMN, IMPLICIT_SEQ_COLUMN,
+};
 use crate::store::store::LOG_NAMESPACE_NAME;
 use crate::store::Store;
 
@@ -101,11 +103,6 @@ const BACKOFF_MAX: Duration = Duration::from_secs(60);
 /// Emit a progress line at most this often, so a healthy forwarder is observable
 /// without flooding the logs it forwards.
 const PROGRESS_INTERVAL: Duration = Duration::from_secs(300);
-
-/// The column, when a table has one, that names a row's origin cluster. The forwarder
-/// stamps it with its own cluster on the way out and forwards only rows that do not
-/// already carry a foreign origin, so a hub's own relayed rows never loop back.
-const ORIGIN_COLUMN: &str = "cluster";
 
 /// Where this store forwards, and as whom. Parsed from the `FINELOG_FORWARDING` JSON;
 /// the Ed25519 private key arrives separately (`FINELOG_SIGNING_KEY`) so it never rides
@@ -361,7 +358,13 @@ where
             }
         };
         cursor = self.cap_lag(name, cursor, persisted, progress);
-        let has_origin = schema.column(ORIGIN_COLUMN).is_some();
+        // The forwarder stamps this column with its own cluster on the way out and
+        // forwards only rows that do not already carry a foreign origin, so a hub's
+        // own relayed rows never loop back. A registered table always has it (added
+        // implicitly at registration); a legacy namespace adopted from disk before
+        // the column existed does not, and forwards unstamped until it is
+        // re-registered.
+        let has_origin = schema.column(IMPLICIT_CLUSTER_COLUMN).is_some();
 
         while cursor < persisted && !*stop.borrow() {
             let batch = match self.read_batch(name, cursor, persisted, has_origin).await {
@@ -596,7 +599,7 @@ where
                 continue;
             }
             fields.push(field.as_ref().clone());
-            if field.name() == ORIGIN_COLUMN {
+            if field.name() == IMPLICIT_CLUSTER_COLUMN {
                 columns.push(Arc::clone(&origin));
             } else {
                 columns.push(Arc::clone(batch.column(i)));

--- a/lib/finelog/rust/src/server/forwarding_tests.rs
+++ b/lib/finelog/rust/src/server/forwarding_tests.rs
@@ -180,6 +180,23 @@ async fn push(client: &LogServiceClient<TestTransport>, key: &str, lines: &[&str
     client.push_logs(request).await.unwrap();
 }
 
+/// Every value of `column` the hub holds for `namespace`, read straight off the hub
+/// store. Lets a test assert on a column a log reader never surfaces — notably the
+/// stamped origin `cluster` on a generic stat table. Holds the query-visibility read
+/// guard across the scan, exactly as the server does.
+async fn hub_column(store: &Store, namespace: &str, column: &str) -> Vec<Option<String>> {
+    let _guard = store.query_visibility().read().await;
+    let providers = store.query_providers().unwrap();
+    let sql = format!("SELECT {column} FROM \"{namespace}\" ORDER BY seq");
+    let result = run_query_over(&make_ctx(), providers, &sql).await.unwrap();
+    let mut values = Vec::new();
+    for batch in &result.batches {
+        let col = batch.column(0).as_string::<i32>();
+        values.extend(col.iter().map(|v| v.map(str::to_string)));
+    }
+    values
+}
+
 /// Every log row the server behind `client` holds, newest last, as `(key, data)` — read
 /// back over the wire so the assertion sees exactly what a log reader would.
 async fn read_all(client: &LogServiceClient<TestTransport>) -> Vec<(String, String)> {
@@ -625,12 +642,15 @@ async fn a_backlog_beyond_the_lag_cap_is_skipped_rather_than_drained() {
 // Integration test: a non-log table forwards generically.
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn a_non_log_table_is_registered_on_the_hub_and_forwarded() {
+async fn a_non_log_table_is_registered_on_the_hub_and_stamped_with_its_origin() {
     // Forwarding is table-generic: a table the hub has never seen is created there with
-    // RegisterTable, then its rows arrive through the same WriteRows path as logs. The
-    // table has no origin column, so nothing is stamped -- it forwards verbatim.
+    // RegisterTable, then its rows arrive through the same WriteRows path as logs. Every
+    // registered table carries the implicit origin `cluster` column, so a generic stat
+    // table's rows land on the hub stamped with the cluster that produced them — the
+    // producer writes only its own columns and never has to know the column exists.
     let fx = Fixture::new("generic").await;
 
+    // The producer declares `id` only; `cluster` is added implicitly at registration.
     let schema = Schema::new(
         vec![Column::new("id", ColumnType::COLUMN_TYPE_STRING, false)],
         "id",
@@ -664,4 +684,13 @@ async fn a_non_log_table_is_registered_on_the_hub_and_forwarded() {
         .find(|(name, _, _, _)| name == "events")
         .expect("the hub created the events namespace from RegisterTable");
     assert_eq!(events.2.row_count, 2, "both rows landed on the hub");
+
+    assert_eq!(
+        hub_column(fx.target_store(), "events", "cluster").await,
+        vec![
+            Some(SOURCE_CLUSTER.to_string()),
+            Some(SOURCE_CLUSTER.to_string())
+        ],
+        "the forwarder stamps the origin cluster onto a table that never declared it"
+    );
 }

--- a/lib/finelog/rust/src/store/schema.rs
+++ b/lib/finelog/rust/src/store/schema.rs
@@ -331,11 +331,6 @@ pub fn with_implicit_seq(schema: Schema) -> Schema {
 
 /// Return `schema` with the implicit nullable STRING `cluster` column appended.
 /// No-op if a `cluster` column is already declared.
-///
-/// Nullable and appended so it evolves an already-registered namespace additively:
-/// [`merge_schemas`] admits a new nullable column, and segments written before the
-/// column existed null-fill it on read. Local writers leave it empty; the
-/// cross-cluster forwarder fills it (see [`IMPLICIT_CLUSTER_COLUMN`]).
 pub fn with_implicit_cluster(schema: Schema) -> Schema {
     if schema
         .columns

--- a/lib/finelog/rust/src/store/schema.rs
+++ b/lib/finelog/rust/src/store/schema.rs
@@ -27,6 +27,13 @@ pub const IMPLICIT_KEY_COLUMN: &str = "timestamp_ms";
 /// transmitted on the wire and never declared by callers.
 pub const IMPLICIT_SEQ_COLUMN: &str = "seq";
 
+/// Origin-cluster column, added to every registered table that does not declare
+/// one (see [`with_implicit_cluster`]). Local writers leave it empty; the
+/// cross-cluster forwarder stamps it with the origin cluster on the way to a hub
+/// finelog, so a hub that collects rows from many federated clusters can filter or
+/// group them by the cluster that produced them.
+pub const IMPLICIT_CLUSTER_COLUMN: &str = "cluster";
+
 /// Max bytes per WriteRows request body.
 pub const MAX_WRITE_ROWS_BYTES: usize = 16 * 1024 * 1024;
 
@@ -320,6 +327,33 @@ pub fn with_implicit_seq(schema: Schema) -> Schema {
     ));
     columns.extend(schema.columns);
     Schema::new(columns, schema.key_column)
+}
+
+/// Return `schema` with the implicit nullable STRING `cluster` column appended.
+/// No-op if a `cluster` column is already declared.
+///
+/// Nullable and appended so it evolves an already-registered namespace additively:
+/// [`merge_schemas`] admits a new nullable column, and segments written before the
+/// column existed null-fill it on read. Local writers leave it empty; the
+/// cross-cluster forwarder fills it (see [`IMPLICIT_CLUSTER_COLUMN`]).
+pub fn with_implicit_cluster(schema: Schema) -> Schema {
+    if schema
+        .columns
+        .iter()
+        .any(|c| c.name == IMPLICIT_CLUSTER_COLUMN)
+    {
+        return schema;
+    }
+    let Schema {
+        mut columns,
+        key_column,
+    } = schema;
+    columns.push(Column::new(
+        IMPLICIT_CLUSTER_COLUMN,
+        ColumnType::COLUMN_TYPE_STRING,
+        true,
+    ));
+    Schema::new(columns, key_column)
 }
 
 /// Resolve the ordering key column name (presence-only), raising if invalid.
@@ -703,6 +737,37 @@ mod tests {
         assert!(!stored.columns[0].nullable);
         let again = with_implicit_seq(stored.clone());
         assert_eq!(again, stored);
+    }
+
+    #[test]
+    fn with_implicit_cluster_appends_nullable_string_cluster_and_is_idempotent() {
+        let stored = with_implicit_cluster(worker_schema());
+        let last = stored.columns.last().unwrap();
+        assert_eq!(last.name, "cluster");
+        assert_eq!(last.r#type, ColumnType::COLUMN_TYPE_STRING);
+        assert!(last.nullable, "the implicit cluster column is nullable");
+        // The rest of the schema is untouched, and the key column is preserved.
+        assert_eq!(
+            stored.column_names(),
+            vec!["worker_id", "mem_bytes", "timestamp_ms", "cluster"]
+        );
+        let again = with_implicit_cluster(stored.clone());
+        assert_eq!(again, stored, "re-applying it does not add a second column");
+    }
+
+    #[test]
+    fn with_implicit_cluster_keeps_a_declared_cluster_column_as_is() {
+        // A schema that already declares `cluster` (e.g. the privileged `log`
+        // namespace, whose writer supplies it) is left exactly as it is — the
+        // column is not moved, duplicated, or re-typed.
+        let declared = Schema::new(
+            vec![
+                col("cluster", ColumnType::COLUMN_TYPE_STRING, false),
+                col("timestamp_ms", ColumnType::COLUMN_TYPE_INT64, false),
+            ],
+            "",
+        );
+        assert_eq!(with_implicit_cluster(declared.clone()), declared);
     }
 
     #[test]

--- a/lib/finelog/rust/src/store/store.rs
+++ b/lib/finelog/rust/src/store/store.rs
@@ -26,7 +26,8 @@ use crate::store::namespace::Namespace;
 use crate::store::namespace_name::validate_namespace_name;
 use crate::store::policy::StoragePolicy;
 use crate::store::schema::{
-    merge_schemas, resolve_key_column, with_implicit_seq, AlignedBatch, Column, Schema,
+    merge_schemas, resolve_key_column, with_implicit_cluster, with_implicit_seq, AlignedBatch,
+    Column, Schema,
 };
 use crate::store::types::NamespaceStats;
 
@@ -317,7 +318,13 @@ impl Store {
     }
 
     /// Register or evolve `name` to `schema`; return the EFFECTIVE store-form
-    /// schema (WITH implicit `seq`). On re-register an empty policy is kept.
+    /// schema (WITH implicit `seq` and `cluster`). On re-register an empty policy
+    /// is kept.
+    ///
+    /// Every registered table gains the implicit `cluster` origin column when it
+    /// does not declare one, so a table's rows become attributable to their origin
+    /// cluster on a hub finelog uniformly — the forwarder stamps that column, and a
+    /// producer need not know the column exists.
     pub fn register_table(
         &self,
         name: &str,
@@ -327,7 +334,7 @@ impl Store {
         // Validate the name (and fence the `log` dir special-case) first.
         self.namespace_dir(name)?;
         resolve_key_column(&schema)?;
-        let stored = with_implicit_seq(schema);
+        let stored = with_implicit_seq(with_implicit_cluster(schema));
 
         // `merge_schemas` (pure) raises SchemaConflict on a non-additive change.
         // The catalog applies the empty-policy-keeps-existing rule and persists
@@ -671,13 +678,23 @@ mod tests {
     }
 
     #[test]
-    fn register_returns_store_form_with_seq() {
+    fn register_returns_store_form_with_seq_and_cluster() {
         let store = mem_store();
         let effective = store
             .register_table("iris.worker", worker_schema(), StoragePolicy::default())
             .unwrap();
-        assert_eq!(effective, with_implicit_seq(worker_schema()));
+        // The store form prepends the implicit `seq` and appends the implicit
+        // origin `cluster` column, so a producer's plain schema becomes
+        // cluster-attributable without declaring the column.
+        assert_eq!(
+            effective,
+            with_implicit_seq(with_implicit_cluster(worker_schema()))
+        );
         assert_eq!(effective.columns[0].name, "seq");
+        let cluster = effective
+            .column("cluster")
+            .expect("implicit cluster column");
+        assert!(cluster.nullable);
     }
 
     #[test]
@@ -773,7 +790,7 @@ mod tests {
         let eff = store
             .register_table("iris.worker", subset, StoragePolicy::default())
             .unwrap();
-        assert_eq!(eff, with_implicit_seq(full));
+        assert_eq!(eff, with_implicit_seq(with_implicit_cluster(full)));
     }
 
     #[test]
@@ -791,9 +808,18 @@ mod tests {
                 StoragePolicy::default(),
             )
             .unwrap();
+        // `cluster` was added implicitly at the first registration, so it precedes
+        // `note`, which this re-register adds as the new additive column.
         assert_eq!(
             eff.column_names(),
-            vec!["seq", "worker_id", "mem_bytes", "timestamp_ms", "note"]
+            vec![
+                "seq",
+                "worker_id",
+                "mem_bytes",
+                "timestamp_ms",
+                "cluster",
+                "note"
+            ]
         );
     }
 


### PR DESCRIPTION
Make the origin-cluster column implicit, so every forwarded table is cluster-attributable on a hub finelog.

The cross-cluster forwarder stamps a row's origin cluster only onto tables that already declare a `cluster` column. The `log` namespace declares one, but the typed stat tables (`iris.task`, `iris.worker`, and the forthcoming `iris.telltale`) do not, so once forwarded to the marin hub the CoreWeave rows and the marin-local rows interleave indistinguishably — the hub's `iris.task` cannot be filtered or grouped by cluster.

Add an implicit `cluster` column to every registered table that does not declare one, mirroring the existing implicit `seq` column: `with_implicit_cluster` appends a nullable STRING `cluster` at registration, and `register_table` now applies it alongside `with_implicit_seq`. Local writers leave it empty (missing nullable column → null-filled at write), and the forwarder's existing stamp path — which fills `cluster` where it `IS NULL OR = ''` — then applies uniformly to every table. Producers need no change: a table becomes cluster-attributable on the hub without ever declaring the column.

The `log` namespace keeps its explicit, writer-supplied `cluster` (its push path builds the column by position, so the explicit declaration documents that coupling); `with_implicit_cluster` is a no-op there. The forwarder's duplicate `ORIGIN_COLUMN` magic string is folded into the shared `IMPLICIT_CLUSTER_COLUMN` constant.

Fixes #7307.
