### PR TITLE
[evals] serve_and_eval: route eval artifacts to durable object storage

### DIFF
--- a/experiments/evals/evalchemy/run_evalchemy_client.py
+++ b/experiments/evals/evalchemy/run_evalchemy_client.py
@@ -5,17 +5,19 @@
 
 The eval child runs this as a plain command under the image's own interpreter
 (``/opt/openthoughts/.venv/bin/python``) -- the only interpreter in that image with ``eval``,
-``lm_eval``, ``fsspec`` and ``gcsfs`` installed. It is deliberately a *command* entrypoint, not an
-Iris ``from_callable`` one: the image's default/synced interpreter is a bare python with no
-cloudpickle, so a cloudpickled callable cannot be deserialized there (issue #7267). Keeping this
-script to the standard library plus ``fsspec`` lets that interpreter run it directly.
+``lm_eval`` and ``fsspec`` (plus the ``s3fs``/``gcsfs`` backends) installed. It is a command
+entrypoint, not an Iris ``from_callable`` one: the image's default/synced interpreter is a bare
+python with no cloudpickle, so a cloudpickled callable cannot be deserialized there (issue #7267).
+Keeping this script to the standard library plus ``fsspec`` lets that interpreter run it directly.
 
 Config arrives as JSON in ``$EVALCHEMY_CLIENT_CONFIG`` (the parent builds it in
 :mod:`experiments.evals.evalchemy.serve_and_eval`), so nothing marin-side needs to import here.
 Each task runs through the evalchemy fork's ``eval.eval`` once (one invocation per task so each
 carries its own ``num_fewshot``) with lm-eval's ``local-completions`` (or ``local-chat-completions``)
-API model pointed at the served URL, and its native ``results_*.json`` tree is uploaded to
-``out_path/<dir>/`` for :class:`~marin.evaluation.eval_result.EvalchemyResult` to read back.
+API model pointed at the served URL. Its ``results_*.json`` tree is uploaded to ``out_path/<dir>/``
+for :class:`~marin.evaluation.eval_result.EvalchemyResult` to read back. ``out_path`` is an
+object-store URL the parent resolved under ``marin_prefix()``; for an ``s3://`` destination the pod's
+injected ``FSSPEC_S3`` (endpoint + virtual-host addressing) is applied by fsspec automatically.
 """
 
 from __future__ import annotations
@@ -86,18 +88,33 @@ def main() -> None:
         raise SystemExit("run_evalchemy_client requires at least one task")
 
     out_path = config["out_path"].rstrip("/")
-    # Raw fsspec, not rigging's StoragePath: the eval image carries only fsspec/gcsfs, not rigging.
-    # out_path is region-local (the eval child is pinned to the serve region), so no cross-region copy.
+    # Raw fsspec, not rigging's StoragePath: the eval image carries fsspec + s3fs/gcsfs, not rigging.
+    # For an s3:// destination the pod's injected FSSPEC_S3 (endpoint + virtual-host addressing) is
+    # applied by fsspec, so url_to_fs needs no extra config. out_path is region-local (the eval child
+    # is pinned to the serve region), so no cross-region copy.
     out_fs, _ = fsspec.core.url_to_fs(out_path)
+    failures: list[str] = []
     for task in tasks:
+        dest = f"{out_path}/{task['dir']}"
         with tempfile.TemporaryDirectory() as local_out:
             # sys.executable is the evalchemy image's interpreter, so ``-m eval.eval`` resolves the
             # fork + lm-eval baked into its venv.
             cmd = build_command(config, task, local_out, sys.executable)
             print(f"running evalchemy: {' '.join(cmd)}", flush=True)
-            subprocess.run(cmd, check=True)
-            out_fs.put(local_out, f"{out_path}/{task['dir']}", recursive=True)
+            # Upload whatever the task produced before reacting to its exit code, so one task's failure
+            # does not discard another task's already-scored output.
+            result = subprocess.run(cmd)
+            produced = os.listdir(local_out)
+            if produced:
+                out_fs.put(local_out, dest, recursive=True)
+                print(f"uploaded {len(produced)} path(s) to {dest}", flush=True)
+        if result.returncode != 0:
+            failures.append(f"{task['name']}: eval.eval exited {result.returncode}")
+        elif not produced:
+            failures.append(f"{task['name']}: produced no artifacts")
     print(f"evalchemy client wrote results for {len(tasks)} task(s) to {out_path}", flush=True)
+    if failures:
+        raise SystemExit("evalchemy task failures: " + "; ".join(failures))
 
 
 if __name__ == "__main__":

--- a/experiments/evals/evalchemy/serve_and_eval.py
+++ b/experiments/evals/evalchemy/serve_and_eval.py
@@ -19,14 +19,14 @@ that address straight over the same-cluster VPC -- no controller proxy or capabi
 auto-cleans child jobs when the parent ends, so leaving the ``with`` block (or the parent exiting)
 tears the server down; the context manager also stops it eagerly for promptness.
 
-The two children take different entrypoints for a reason. The serve child runs in the marin image,
-whose synced venv can deserialize a cloudpickled callable, so it uses ``Entrypoint.from_callable``.
-The eval child runs in the ``:evalchemy-tpu`` image, whose default interpreter is a bare python with
-no cloudpickle -- only ``/opt/openthoughts/.venv`` carries ``eval``/``lm_eval``/``fsspec`` -- so it
-runs :mod:`experiments.evals.evalchemy.run_evalchemy_client` as a plain *command* under that
-interpreter, with its config passed as JSON in an env var.
+The two children take different entrypoints. The serve child runs in the marin image, whose synced
+venv can deserialize a cloudpickled callable, so it uses ``Entrypoint.from_callable``. The eval child
+runs in the ``:evalchemy-tpu`` image, whose default interpreter is a bare python with no cloudpickle
+-- only ``/opt/openthoughts/.venv`` carries ``eval``/``lm_eval``/``fsspec`` -- so it runs
+:mod:`experiments.evals.evalchemy.run_evalchemy_client` as a plain command under that interpreter,
+with its config passed as JSON in an env var.
 
-Top-level imports are kept light on purpose: the serve child's ``VllmBackend``/``LevanterBackend``
+Top-level imports are kept light: the serve child's ``VllmBackend``/``LevanterBackend``
 construction (which pulls levanter + vLLM) happens lazily inside :func:`_serve_for_eval`, so the CPU
 parent that references it for cloudpickling never imports the serving stack.
 """
@@ -40,7 +40,7 @@ import time
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager, suppress
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import StrEnum
 
 from iris.client import iris_ctx
@@ -137,7 +137,11 @@ class EvalchemyEvalConfig:
     model: str
     """HF repo id or object-store (``gs://``) path of the model to serve and eval."""
     tasks: tuple[EvalTaskConfig, ...]
-    out_path: str
+    out_path: str | None = None
+    """Object-store destination for the eval child's ``results_*.json`` tree, read back by
+    :class:`~marin.evaluation.eval_result.EvalchemyResult`. Resolved by
+    :func:`_resolve_durable_out_path`: an object-store path is used verbatim; ``None`` or a pod-local
+    path is routed under the cluster's ``marin_prefix()`` so results survive pod teardown."""
     serve: ServeSpec = field(default_factory=ServeSpec)
     tokenizer: str | None = None
     """HF tokenizer id the eval client loads to build prompts; defaults to ``model``. Set it when
@@ -379,11 +383,53 @@ def _client_config_json(config: EvalchemyEvalConfig, endpoint: ServedEndpoint) -
 # --------------------------------------------------------------------------------------------------
 
 
+def _resolve_durable_out_path(out_path: str | None, run_id: str) -> str:
+    """Resolve the object-store destination for the eval child's artifacts.
+
+    An object-store path (contains ``://``) is returned verbatim. Anything else -- ``None`` or a
+    pod-local path, which is garbage-collected when the eval pod ends -- is routed under the active
+    cluster's ``marin_prefix()``, keyed by ``run_id``. ``marin_prefix()`` resolves the region-local
+    store, so no bucket is hardcoded.
+    """
+    if out_path and "://" in out_path:
+        return out_path.rstrip("/")
+    from rigging.filesystem import marin_prefix, prefix_join  # noqa: PLC0415  # lazy: keep rigging out of the parent
+
+    durable = prefix_join(marin_prefix(), f"eval/evalchemy/{run_id}")
+    if out_path:
+        logger.warning(
+            "out_path %r is not an object-store path; routing eval artifacts to durable storage %r.",
+            out_path,
+            durable,
+        )
+    return durable
+
+
+def _verify_durable_artifacts(out_path: str) -> None:
+    """Raise if no ``results_*.json`` reached ``out_path``.
+
+    Runs in the parent (marin image, which carries rigging + s3fs) after the eval child finishes, so a
+    succeeded child cannot report success over an empty prefix.
+    """
+    from rigging.filesystem import url_to_fs  # noqa: PLC0415  # lazy: keep rigging out of the CPU parent's import
+
+    fs, path = url_to_fs(out_path)
+    objects = fs.find(path)
+    results = [p for p in objects if p.rsplit("/", 1)[-1].startswith("results_") and p.endswith(".json")]
+    logger.info(
+        "Durable evalchemy artifacts under %s: %d object(s), %d results_*.json", out_path, len(objects), len(results)
+    )
+    if not results:
+        raise RuntimeError(f"no evalchemy results_*.json landed under {out_path!r}; eval artifacts were lost")
+
+
 def serve_and_eval(config: EvalchemyEvalConfig) -> None:
     """Parent entrypoint: serve the model, run evalchemy against its OpenAI URL, tear the server down.
 
     Runs as a CPU orchestrator job. Serving and eval are separate child jobs (different container
-    images), tied together by the served OpenAI URL and by Iris's parent/child auto-cleanup.
+    images), tied together by the served OpenAI URL and by Iris's parent/child auto-cleanup. The eval
+    child's artifacts are routed to durable object storage (:func:`_resolve_durable_out_path`) and
+    verified back before the parent returns.
     """
     if not config.tasks:
         raise ValueError("serve_and_eval requires at least one task")
@@ -395,8 +441,14 @@ def serve_and_eval(config: EvalchemyEvalConfig) -> None:
             f"model {config.model!r} is an object-store path the eval image cannot load a tokenizer "
             "from; set EvalchemyEvalConfig.tokenizer (EvalGroup.tokenizer) to the base model's HF id."
         )
+    run_id = uuid.uuid4().hex[:8]
+    durable_out_path = _resolve_durable_out_path(config.out_path, run_id)
+    config = replace(config, out_path=durable_out_path)
+    logger.info("evalchemy artifacts for this run route to durable storage %s", durable_out_path)
     with serve_model(config.model, config.tokenizer or config.model, config.serve) as endpoint:
         _submit_eval_child(config, endpoint)
+    # The eval child uploaded per task; confirm from the parent that the results landed.
+    _verify_durable_artifacts(durable_out_path)
 
 
 def _submit_eval_child(config: EvalchemyEvalConfig, endpoint: ServedEndpoint) -> None:


### PR DESCRIPTION
A succeeded evalchemy eval could still lose its numbers: the eval child uploaded its results tree to whatever `out_path` the caller passed, and a pod-local path (used because the eval image had no s3fs) is garbage-collected when the pod ends. A recent grug-B′ run went to SUCCEEDED with its gsm8k + MATH500 numbers written only to `/tmp/...` and unrecoverable.

- `serve_and_eval` resolves `out_path` through `marin_prefix()` keyed by a run id: an object-store path is honored verbatim; `None` or a pod-local path is routed to the region-local marin store so results survive pod teardown. No bucket is hardcoded.
- The eval child uploads each task's output before reacting to its exit code, so one task's failure does not discard another task's scored results; per-task failures surface after every task's artifacts are banked.
- After the child finishes, the parent lists the destination back and raises if no `results_*.json` landed, so a succeeded run cannot sit over an empty prefix.

Requires the eval image to carry an fsspec `s3://` backend (`s3fs`), added in marin-community/evalchemy#20; point `EVALCHEMY_TPU_IMAGE` at the rebuilt digest.

Rebased onto main now that #7303 has merged, so the diff is just the durable-routing change.
