### PR TITLE
iris: dev_gpu support H100 and GB200

### DIFF
--- a/scripts/iris/dev_gpu.py
+++ b/scripts/iris/dev_gpu.py
@@ -2,7 +2,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Allocate and use development GPU (CoreWeave H100) pods on Iris-managed clusters."""
+"""Allocate and use development GPU (CoreWeave) pods on Iris-managed clusters."""
 
 import getpass
 import json
@@ -21,6 +21,7 @@ from iris.client import IrisClient, JobAlreadyExists
 from iris.cluster.backends.k8s.tasks import _LABEL_TASK_ID, _sanitize_label_value
 from iris.cluster.composer import provider_bundle
 from iris.cluster.config import IrisClusterConfig, load_config
+from iris.cluster.platforms.k8s.coreweave_topology import NVL72_GPUS_PER_NODE
 from iris.cluster.types import Entrypoint, JobName, ResourceSpec, gpu_device
 from iris.rpc import job_pb2
 
@@ -35,9 +36,17 @@ HOLDER_COMMAND = (
 )
 
 STATE_DIR = Path.home() / ".cache" / "marin" / "dev_gpu_iris"
-DEFAULT_GPU_COUNT = 8
 TASK_CONTAINER = "task"
-GPU_VARIANT = "H100"
+DEFAULT_GPU_VARIANT = "H100"
+
+# GPUs on one whole node of a given variant, used as the default --gpu-count so a dev
+# session grabs exactly one node. An H100 node is an 8-GPU DGX box; a GB200 node is a
+# 4-GPU NVL72 compute tray (a rack/NVLink domain is 18 of them = 72 GPUs). These are the
+# only variants the clusters we have access to expose.
+GPUS_PER_NODE = {
+    "H100": 8,
+    "GB200": NVL72_GPUS_PER_NODE,
+}
 
 DEFAULT_CPU = 8.0
 DEFAULT_MEMORY = "64GB"
@@ -79,6 +88,7 @@ class DevGpuState:
     config_file: str
     job_id: str
     gpu_count: int
+    gpu_variant: str
     target: CoreweaveTarget
     pod: PodRef
 
@@ -93,6 +103,9 @@ class DevGpuState:
             config_file=data["config_file"],
             job_id=data["job_id"],
             gpu_count=data["gpu_count"],
+            # Sessions allocated before the variant was configurable were all H100;
+            # default so they still load for status/connect/release after an upgrade.
+            gpu_variant=data.get("gpu_variant", DEFAULT_GPU_VARIANT),
             target=CoreweaveTarget(**data["target"]),
             pod=PodRef(**data["pod"]),
         )
@@ -256,7 +269,7 @@ class Context:
 @click.option("--verbose", is_flag=True, help="Enable verbose logging.")
 @click.pass_context
 def cli(ctx, config: str | None, session_name: str | None, verbose: bool) -> None:
-    """Development GPU (CoreWeave H100) pod management for Iris clusters."""
+    """Development GPU (CoreWeave) pod management for Iris clusters."""
     ctx.ensure_object(Context)
     ctx.obj.config_file = str(Path(config).resolve()) if config else None
     ctx.obj.session_name = session_name or getpass.getuser()
@@ -268,12 +281,19 @@ def cli(ctx, config: str | None, session_name: str | None, verbose: bool) -> Non
 
 @cli.command("allocate")
 @click.option(
+    "--gpu-variant",
+    type=click.Choice(sorted(GPUS_PER_NODE), case_sensitive=False),
+    default=DEFAULT_GPU_VARIANT,
+    show_default=True,
+    help="GPU variant to reserve. Passed through to Iris, which schedules onto the matching node pool.",
+)
+@click.option(
     "--gpu-count",
     type=click.IntRange(min=1),
-    default=DEFAULT_GPU_COUNT,
-    show_default=True,
-    help="H100 GPUs to reserve. Only 8 (a whole h100-8x node) is validated; "
-    "smaller values may not schedule on the bare-metal pool.",
+    default=None,
+    help="GPUs to reserve. Defaults to one whole node of the chosen --gpu-variant "
+    "(H100: 8, GB200: 4). Whole-node counts are what the bare-metal pools validate; "
+    "smaller values may not schedule.",
 )
 @click.option(
     "--cpu",
@@ -297,10 +317,17 @@ def cli(ctx, config: str | None, session_name: str | None, verbose: bool) -> Non
 @click.option("--timeout", default=900, show_default=True, help="Seconds to wait for the task to run.")
 @click.option("--pod-timeout", default=120, show_default=True, help="Seconds to wait for the pod to run.")
 @click.pass_context
-def allocate(ctx, gpu_count: int, cpu: float, memory: str, disk: str, timeout: int, pod_timeout: int) -> None:
-    """Allocate a dev GPU H100 pod and hold it until Ctrl-C."""
+def allocate(
+    ctx, gpu_variant: str, gpu_count: int | None, cpu: float, memory: str, disk: str, timeout: int, pod_timeout: int
+) -> None:
+    """Allocate a dev GPU pod and hold it until Ctrl-C."""
     if not ctx.obj.config_file:
         raise click.ClickException("--config is required")
+
+    # click.Choice(case_sensitive=False) already normalized gpu_variant to a canonical
+    # key of GPUS_PER_NODE, so a bare --gpu-count defaults to that variant's whole node.
+    if gpu_count is None:
+        gpu_count = GPUS_PER_NODE[gpu_variant]
 
     session_name = ctx.obj.session_name
     state_file = state_path(ctx.obj.state_dir, session_name)
@@ -313,7 +340,7 @@ def allocate(ctx, gpu_count: int, cpu: float, memory: str, disk: str, timeout: i
 
     state: DevGpuState | None = None
     with controller_client(ctx.obj.config_file) as client:
-        resources = ResourceSpec(cpu=cpu, memory=memory, disk=disk, device=gpu_device(GPU_VARIANT, gpu_count))
+        resources = ResourceSpec(cpu=cpu, memory=memory, disk=disk, device=gpu_device(gpu_variant, gpu_count))
         try:
             job = client.submit(
                 entrypoint=Entrypoint.from_command("python", "-c", HOLDER_COMMAND),
@@ -331,6 +358,7 @@ def allocate(ctx, gpu_count: int, cpu: float, memory: str, disk: str, timeout: i
                 config_file=ctx.obj.config_file,
                 job_id=str(job.job_id),
                 gpu_count=gpu_count,
+                gpu_variant=gpu_variant,
                 target=target,
                 pod=pod,
             )
@@ -338,7 +366,7 @@ def allocate(ctx, gpu_count: int, cpu: float, memory: str, disk: str, timeout: i
 
             print(f"Session: {session_name}")
             print(f"Job: {job.job_id}")
-            print(f"GPUs: {gpu_count} x {GPU_VARIANT}")
+            print(f"GPUs: {gpu_count} x {gpu_variant}")
             print(f"Pod: {pod.pod_name} (namespace={pod.namespace})")
             print("\nAllocation is active. Press Ctrl-C to release.")
 
@@ -355,7 +383,7 @@ def allocate(ctx, gpu_count: int, cpu: float, memory: str, disk: str, timeout: i
                 terminated = True
             except Exception:
                 logger.warning(
-                    "Failed to terminate holder job %s; the H100 pod may still be running. "
+                    "Failed to terminate holder job %s; the GPU pod may still be running. "
                     "Keeping local session state — run `release` to retry cleanup.",
                     job.job_id,
                     exc_info=True,
@@ -401,7 +429,7 @@ def status(ctx) -> None:
     print(f"Session: {state.session_name}")
     print(f"Job: {state.job_id}")
     print(f"Config: {state.config_file}")
-    print(f"GPUs: {state.gpu_count} x {GPU_VARIANT}")
+    print(f"GPUs: {state.gpu_count} x {state.gpu_variant}")
     print(f"Pod: {state.pod.pod_name} (namespace={state.pod.namespace})")
 
 
@@ -420,7 +448,7 @@ def release(ctx, force: bool) -> None:
         # still be running; --force is the escape hatch for already-dead jobs.
         if not force:
             raise click.ClickException(
-                f"Failed to terminate holder job {state.job_id}; the H100 pod may still be running. "
+                f"Failed to terminate holder job {state.job_id}; the GPU pod may still be running. "
                 f"Retry `release`, or pass --force to drop local state anyway (then confirm the job is gone "
                 f"with `iris job list`). Error: {exc}"
             ) from exc


### PR DESCRIPTION
* make `scripts/iris/dev_gpu.py` variant-aware instead of hard-coded to H100
* add `--gpu-variant` (a case-insensitive `click.Choice` of `H100` / `GB200`, default `H100`) — the variant is passed straight through `gpu_device()` to Iris, which schedules onto the matching node pool
  * scoped to the two variants the clusters we have access to actually expose; other names are rejected at parse time
* `--gpu-count` now defaults to one whole node of the chosen variant (`H100`: 8, `GB200`: 4 — a GB200 node is one NVL72 4-GPU compute tray[^1]); pass an explicit count to override
* persist `gpu_variant` in the session state so `status` / `connect` / `release` report the right accelerator; pre-existing H100 session files still load

[^1]: an NVL72 rack / NVLink domain is 18 such nodes = 72 GPUs, sourced from `NVL72_GPUS_PER_NODE` so the number stays in sync with the Iris scheduler