### PR TITLE
[fray] Use GB200 NVL72 per-GPU peaks for the b200 FLOPS spec

### DIFF
--- a/lib/fray/src/fray/device_flops.py
+++ b/lib/fray/src/fray/device_flops.py
@@ -106,16 +106,21 @@ DEVICE_FLOPS: dict[str, dict[str, float]] = {
         "fp8": 3.958e15 / 2,
         "int8": 3.958e15 / 2,
     },
-    # B200 / GB200 - per-GPU Blackwell peaks
+    # B200 / GB200 - per-GPU GB200 NVL72 peaks (Grace Blackwell, liquid-cooled)
+    # Rack totals from Table 2 of the Blackwell Architecture Technical Brief (V2.1),
+    # divided by 72 GPUs. Stored value is the dense peak (fray's sparse/2 convention).
+    # JAX reports "NVIDIA GB200" on this hardware, so use the GB200 NVL72 column, not
+    # the lower-clocked HGX B200 (1000W) numbers.
     # source: https://resources.nvidia.com/en-us-blackwell-architecture
     "b200": {
-        "fp64": 40e12,
-        "fp32": 40e12,
-        "tf32": 2.2e15 / 2,
-        "fp16": 4.5e15 / 2,
-        "bf16": 4.5e15 / 2,
-        "fp8": 9e15 / 2,
-        "int8": 9e15 / 2,
+        "fp64": 40e12,  # 2880 TFLOPS / 72
+        "fp32": 80e12,  # 5760 TFLOPS / 72
+        "tf32": 2.5e15 / 2,  # 180 PFLOPS / 72 sparse -> 1.25 dense
+        "fp16": 5e15 / 2,  # 360 PFLOPS / 72 sparse -> 2.5 dense
+        "bf16": 5e15 / 2,  # 360 PFLOPS / 72 sparse -> 2.5 dense
+        "fp8": 10e15 / 2,  # 720 PFLOPS / 72 sparse -> 5 dense
+        "int8": 10e15 / 2,  # 720 POPS / 72 sparse -> 5 dense
+        "fp4": 20e15 / 2,  # 1440 PFLOPS / 72 sparse -> 10 dense
     },
     # source: https://images.nvidia.com/content/technologies/volta/pdf/volta-v100-datasheet-update-us-1165301-r5.pdf
     "v100": {


### PR DESCRIPTION
The b200 entry added in #7328 used the HGX B200 (1000W air-cooled) per-GPU peaks, but JAX reports "NVIDIA GB200" on our hardware, which is the higher-clocked GB200 NVL72 SKU. Its per-GPU tensor peaks are ~11% higher, so the old numbers understated the theoretical peak and overstated MFU by ~11% on every Blackwell run.

Rederive every value from Table 2 of the NVIDIA Blackwell Architecture Technical Brief (V2.1), dividing the 72-GPU rack totals by 72 (fray stores the dense peak as sparse/2):

| format | old (dense) | new (dense) | GB200 NVL72 rack ÷ 72 |
|---|---|---|---|
| bf16 / fp16 | 2.25 PF | 2.5 PF | 180 PF / 72 |
| fp8 / int8 | 4.5 PF | 5 PF | 360 PF / 72 |
| tf32 | 1.1 PF | 1.25 PF | 90 PF / 72 |
| fp32 | 40 TF | 80 TF | 5760 TF / 72 |
| fp64 | 40 TF | 40 TF | 2880 TF / 72 |
| fp4 | *(absent)* | 10 PF | 720 PF / 72 |

Two separate issues in the old entry: the tensor formats were the HGX B200 column while `fp64=40` was the GB200 value (HGX B200 is 37), so the spec mixed two SKUs; and `fp32=40` matched neither table (likely copied from fp64). The entry is now internally consistent with the single GB200 NVL72 SKU that JAX actually reports, plus the previously missing fp4 format.

The number that matters for training MFU is bf16: 2.25 → 2.5 drops reported MFU by ~11% across Blackwell runs.