### PR TITLE
[ci] Hand canary triage to weaver sessions via @weaverbot

### DIFF
--- a/.github/workflows/marin-canary-datakit-tier1.yaml
+++ b/.github/workflows/marin-canary-datakit-tier1.yaml
@@ -255,3 +255,31 @@ jobs:
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           fallback-text: ":red_circle: *Datakit Smoke failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+  # Hand triage to a weaver session: comment @weaverbot on the [canary-datakit-smoke] issue
+  # the in-job Claude triage filed (or file a bare tracking issue when triage died
+  # before filing). Slack notification stays with the notify-slack job.
+  weaver-triage:
+    needs: [datakit-smoke]
+    # cancelled matters: a job that hits its timeout-minutes reports cancelled, not failure
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      (contains(needs.datakit-smoke.result, 'failure') || contains(needs.datakit-smoke.result, 'cancelled'))
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write    # comment on / file the tracking issue
+      actions: read    # pull failed-job logs for the excerpt
+      contents: read
+    steps:
+      - uses: marin-community/marin-style/actions/report-failure@4e5736a7054318af49b0245fadee197f534519d7
+        with:
+          lane: datakit-smoke
+          issue-title-prefix: "[canary-datakit-smoke]"
+          issue-labels: bug,agent-generated,canary
+          trigger-token: ${{ secrets.WEAVERBOT_GH_TOKEN }}
+          triage-notes: >-
+            An in-runner Claude triage may already have posted its diagnosis on this
+            issue — read it first, then verify or correct it (lib/iris/OPS.md and
+            lib/zephyr/OPS.md cover the live-infrastructure debugging commands) and
+            drive the outcome: a fix PR in this repo, or a crisp handoff comment with
+            the blocking question.

--- a/.github/workflows/marin-canary-datakit-tier2.yaml
+++ b/.github/workflows/marin-canary-datakit-tier2.yaml
@@ -198,3 +198,31 @@ jobs:
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           fallback-text: ":red_circle: *Datakit Tier 2 Ferry failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+  # Hand triage to a weaver session: comment @weaverbot on the [canary-datakit-tier2] issue
+  # the in-job Claude triage filed (or file a bare tracking issue when triage died
+  # before filing). Slack notification stays with the notify-slack job.
+  weaver-triage:
+    needs: [datakit-tier2-ferry]
+    # cancelled matters: a job that hits its timeout-minutes reports cancelled, not failure
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      (contains(needs.datakit-tier2-ferry.result, 'failure') || contains(needs.datakit-tier2-ferry.result, 'cancelled'))
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write    # comment on / file the tracking issue
+      actions: read    # pull failed-job logs for the excerpt
+      contents: read
+    steps:
+      - uses: marin-community/marin-style/actions/report-failure@4e5736a7054318af49b0245fadee197f534519d7
+        with:
+          lane: datakit-tier2
+          issue-title-prefix: "[canary-datakit-tier2]"
+          issue-labels: bug,agent-generated,canary
+          trigger-token: ${{ secrets.WEAVERBOT_GH_TOKEN }}
+          triage-notes: >-
+            An in-runner Claude triage may already have posted its diagnosis on this
+            issue — read it first, then verify or correct it (lib/iris/OPS.md and
+            lib/zephyr/OPS.md cover the live-infrastructure debugging commands) and
+            drive the outcome: a fix PR in this repo, or a crisp handoff comment with
+            the blocking question.

--- a/.github/workflows/marin-canary-datakit-tier3.yaml
+++ b/.github/workflows/marin-canary-datakit-tier3.yaml
@@ -168,3 +168,30 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           fallback-text: ":red_circle: *Datakit Nemotron Ferry failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           message-artifact: ''
+
+  # Hand triage to a weaver session: file or update the [canary-datakit-tier3]
+  # tracking issue and comment @weaverbot on it. This lane has no in-job Claude
+  # triage, so the weaver session is the whole triage story here.
+  weaver-triage:
+    needs: [datakit-nemotron-ferry]
+    # cancelled matters: a job that hits its timeout-minutes reports cancelled, not failure
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      (contains(needs.datakit-nemotron-ferry.result, 'failure') || contains(needs.datakit-nemotron-ferry.result, 'cancelled'))
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write    # comment on / file the tracking issue
+      actions: read    # pull failed-job logs for the excerpt
+      contents: read
+    steps:
+      - uses: marin-community/marin-style/actions/report-failure@4e5736a7054318af49b0245fadee197f534519d7
+        with:
+          lane: datakit-tier3
+          issue-title-prefix: "[canary-datakit-tier3]"
+          issue-labels: bug,agent-generated,canary
+          trigger-token: ${{ secrets.WEAVERBOT_GH_TOKEN }}
+          triage-notes: >-
+            Diagnose from the run's diagnostics artifact and the Iris job state
+            (lib/iris/OPS.md and lib/zephyr/OPS.md cover the live-infrastructure
+            debugging commands), then drive the outcome: a fix PR in this repo, or a
+            crisp handoff comment with the blocking question.

--- a/.github/workflows/marin-canary-ferry-coreweave.yaml
+++ b/.github/workflows/marin-canary-ferry-coreweave.yaml
@@ -287,3 +287,31 @@ jobs:
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           fallback-text: ":red_circle: *GPU Canary failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+  # Hand triage to a weaver session: comment @weaverbot on the [canary-gpu] issue
+  # the in-job Claude triage filed (or file a bare tracking issue when triage died
+  # before filing). Slack notification stays with the notify-slack job.
+  weaver-triage:
+    needs: [canary-ferry-cw]
+    # cancelled matters: a job that hits its timeout-minutes reports cancelled, not failure
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      (contains(needs.canary-ferry-cw.result, 'failure') || contains(needs.canary-ferry-cw.result, 'cancelled'))
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write    # comment on / file the tracking issue
+      actions: read    # pull failed-job logs for the excerpt
+      contents: read
+    steps:
+      - uses: marin-community/marin-style/actions/report-failure@4e5736a7054318af49b0245fadee197f534519d7
+        with:
+          lane: gpu
+          issue-title-prefix: "[canary-gpu]"
+          issue-labels: bug,agent-generated,canary
+          trigger-token: ${{ secrets.WEAVERBOT_GH_TOKEN }}
+          triage-notes: >-
+            An in-runner Claude triage may already have posted its diagnosis on this
+            issue — read it first, then verify or correct it (lib/iris/OPS.md and
+            lib/zephyr/OPS.md cover the live-infrastructure debugging commands) and
+            drive the outcome: a fix PR in this repo, or a crisp handoff comment with
+            the blocking question.

--- a/.github/workflows/marin-canary-ferry.yaml
+++ b/.github/workflows/marin-canary-ferry.yaml
@@ -225,3 +225,31 @@ jobs:
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           fallback-text: ":red_circle: *TPU Canary failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+  # Hand triage to a weaver session: comment @weaverbot on the [canary-tpu] issue
+  # the in-job Claude triage filed (or file a bare tracking issue when triage died
+  # before filing). Slack notification stays with the notify-slack job.
+  weaver-triage:
+    needs: [canary-ferry]
+    # cancelled matters: a job that hits its timeout-minutes reports cancelled, not failure
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      (contains(needs.canary-ferry.result, 'failure') || contains(needs.canary-ferry.result, 'cancelled'))
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write    # comment on / file the tracking issue
+      actions: read    # pull failed-job logs for the excerpt
+      contents: read
+    steps:
+      - uses: marin-community/marin-style/actions/report-failure@4e5736a7054318af49b0245fadee197f534519d7
+        with:
+          lane: tpu
+          issue-title-prefix: "[canary-tpu]"
+          issue-labels: bug,agent-generated,canary
+          trigger-token: ${{ secrets.WEAVERBOT_GH_TOKEN }}
+          triage-notes: >-
+            An in-runner Claude triage may already have posted its diagnosis on this
+            issue — read it first, then verify or correct it (lib/iris/OPS.md and
+            lib/zephyr/OPS.md cover the live-infrastructure debugging commands) and
+            drive the outcome: a fix PR in this repo, or a crisp handoff comment with
+            the blocking question.

--- a/.github/workflows/marin-canary-grug-multislice.yaml
+++ b/.github/workflows/marin-canary-grug-multislice.yaml
@@ -197,3 +197,31 @@ jobs:
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           fallback-text: ":red_circle: *Grug multislice smoke failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+  # Hand triage to a weaver session: comment @weaverbot on the [canary-grug-multislice] issue
+  # the in-job Claude triage filed (or file a bare tracking issue when triage died
+  # before filing). Slack notification stays with the notify-slack job.
+  weaver-triage:
+    needs: [grug-multislice-smoke]
+    # cancelled matters: a job that hits its timeout-minutes reports cancelled, not failure
+    if: >-
+      always() && github.event_name == 'schedule' &&
+      (contains(needs.grug-multislice-smoke.result, 'failure') || contains(needs.grug-multislice-smoke.result, 'cancelled'))
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write    # comment on / file the tracking issue
+      actions: read    # pull failed-job logs for the excerpt
+      contents: read
+    steps:
+      - uses: marin-community/marin-style/actions/report-failure@4e5736a7054318af49b0245fadee197f534519d7
+        with:
+          lane: grug-multislice
+          issue-title-prefix: "[canary-grug-multislice]"
+          issue-labels: bug,agent-generated,canary
+          trigger-token: ${{ secrets.WEAVERBOT_GH_TOKEN }}
+          triage-notes: >-
+            An in-runner Claude triage may already have posted its diagnosis on this
+            issue — read it first, then verify or correct it (lib/iris/OPS.md and
+            lib/zephyr/OPS.md cover the live-infrastructure debugging commands) and
+            drive the outcome: a fix PR in this repo, or a crisp handoff comment with
+            the blocking question.


### PR DESCRIPTION
Each canary lane gains a `weaver-triage` job that runs when the scheduled lane fails or is timeout-cancelled: it comments `@weaverbot` on the lane's `[canary-<lane>]` issue — the one the in-job Claude triage already files, found by title prefix, so no duplicate issues — which launches a weaver session against the repo (or nudges the one already working the issue) to verify the diagnosis and drive a fix. Tier 3, which has no in-job triage, gets the full file-and-ask flow.

Uses the shared `report-failure` composite action from [marin-community/marin-style#2](https://github.com/marin-community/marin-style/pull/2) (pinned by SHA; the pin moves to the v0.2.0 tag once that PR merges). Slack notification stays with the existing notify-slack jobs (`slack-webhook-url` is left empty, which skips that step). The `@weaverbot` ask is skipped with a workflow notice until the `WEAVERBOT_GH_TOKEN` secret is provisioned, so this is safe to merge first.

Part of the failure-reporting rollout across the fork repos (evalchemy#21, harbor#9, MarinSkyRL#30, vllm#16, tpu-inference#10), which use the same action for issue + weaverbot + Slack.