### PR TITLE
[iris] Capture periodic thread dumps from k8s task pods

### DIFF
--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -370,13 +370,13 @@ Namespaces:
 
 - `iris.worker` — per-tick host utilization (cpu, mem, disk, running task count, net bps), keyed by `ts`.
 - `iris.task` — per-attempt task resource snapshots, keyed by `ts`.
-- `iris.profile` — per-capture profile blobs (cpu/memory/thread, periodic or on-demand), keyed by `source` so the dashboard's per-source list query prunes via parquet row-group min/max. Filter on `source` (a task path like `/user/job/.../<index>`, `/system/worker/<id>`, or `/system/controller`) and `type` (`cpu`/`memory`/`thread`). `format` is the blob encoding — periodic CPU captures are py-spy **speedscope** JSON. `vm_id` is the writer VM (worker id, `controller-self`, or `k8s/<node-or-pod>`).
+- `iris.profile` — per-capture profile blobs (cpu/memory/thread, periodic or on-demand), keyed by `source` so the dashboard's per-source list query prunes via parquet row-group min/max. Filter on `source` (a task path like `/user/job/.../<index>`, `/system/worker/<id>`, or `/system/controller`) and `type` (`cpu`/`memory`/`thread`). `format` is the blob encoding — the GCE/TPU worker's periodic CPU captures are py-spy **speedscope** JSON; the k8s backend's periodic captures are py-spy **thread dumps** (`type=thread`), since a hung collective samples no CPU but a thread dump pinpoints where every rank is blocked. `vm_id` is the writer VM (worker id, `controller-self`, or `k8s/<node-or-pod>`). To find a hang, read the last periodic `thread` capture per `source` before the freeze.
 
 Retention is finelog segment-based. Target for `iris.profile` is 7 days.
 
 Get a profile for a task — open the dashboard task page and use the "Profile history" panel; rows are CPU captures from the worker's 10-minute periodic loop plus any on-demand captures, click to download. To capture on demand, hit the "Profile now" button on the task page, the worker page (`/system/worker/<id>`), or the controller status page (`/system/controller`).
 
-Profiles are written by the worker (periodic CPU + on-demand all types), by `K8sTaskProvider` (on-demand only), and by the controller for `/system/controller` self-captures.
+Profiles are written by the worker (periodic CPU + on-demand all types), by `K8sTaskProvider` (periodic thread dumps of every running pod + on-demand all types), and by the controller for `/system/controller` self-captures. The k8s backend has no per-node worker daemon, so its `PeriodicProfiler` runs the equivalent 10-minute loop controller-side (`profile_poll_interval`), dumping each running pod's threads off the reconcile path.
 
 Query the namespace directly with the finelog CLI (opens a tunnel to the cluster's finelog deployment named by `finelog.config`):
 

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -1787,9 +1787,7 @@ class ResourceCollector:
         self._thread.join(timeout=5)
 
 
-# Periodic thread-dump cadence, matching the GCE/TPU worker's profile loop
-# (Worker._profile_interval, 10 minutes). The k8s runtime has no per-node worker
-# daemon to run that loop, so PeriodicProfiler reproduces it controller-side.
+# Periodic thread-dump cadence, 10 minutes to match the GCE/TPU worker cadence.
 DEFAULT_PROFILE_POLL_INTERVAL = 600.0
 # Cap on concurrent kubectl exec streams a single capture cycle opens, so a large
 # gang is dumped near-simultaneously without exhausting the controller's k8s
@@ -1810,23 +1808,14 @@ class _ProfileTarget:
 
 
 class PeriodicProfiler:
-    """Background thread that dumps each running task pod's threads every
-    ``poll_interval`` and appends a ``trigger="periodic"`` ``iris.profile`` row.
+    """Dumps each running task pod's threads every ``poll_interval`` and appends
+    one ``trigger="periodic"`` ``iris.profile`` row per pod.
 
-    The GCE/TPU runtime profiles each running attempt from its per-node worker
-    daemon (``Worker._run_profile_loop``). The k8s runtime has no worker daemon,
-    so without this the only profiles a k8s job ever gets are the on-demand
-    captures an operator triggers by hand — a silently wedged collective (every
-    rank blocked, no error, no process exit) then leaves no stack-trace history
-    to diagnose after the fact. This reproduces the worker loop controller-side:
-    unattended thread dumps land in the profile timeline so a hang is caught.
-
-    Thread dumps (not CPU samples) are captured because they are instantaneous
-    and pinpoint where each rank is blocked; a CPU profile of a hung process
-    samples nothing. Captures run on a bounded thread pool so a whole gang is
-    dumped near-simultaneously. The reconcile loop declares the authoritative
-    running-pod set via ``set_pods()`` once per cycle, and all kubectl exec I/O
-    stays off the reconcile thread.
+    The reconcile loop declares the running-pod set via ``set_pods()``; captures
+    then run on a background thread, off the reconcile path, on a bounded pool so
+    a whole gang is dumped near-simultaneously. Thread dumps rather than CPU
+    samples: a hung process samples no CPU, but a thread dump shows where each
+    rank is blocked.
     """
 
     def __init__(
@@ -2080,11 +2069,9 @@ class K8sTaskProvider:
     # resolution (15s) — sampling faster only re-reads the same value. One bulk
     # metrics list per tick covers every managed pod (see ResourceCollector).
     resource_poll_interval: float = 15.0
-    # Periodic thread-dump cadence. The k8s runtime has no per-node worker daemon
-    # to run the GCE worker's profile loop, so PeriodicProfiler reproduces it here:
-    # every profile_poll_interval it dumps each running pod's threads to
-    # iris.profile (trigger=periodic) so a silently hung collective is caught in
-    # the profile timeline. Matches the worker loop's 10-minute cadence.
+    # Cadence at which PeriodicProfiler dumps each running pod's threads to
+    # iris.profile (trigger=periodic), so a silently hung collective is caught in
+    # the profile timeline even though nothing polls a k8s pod otherwise.
     profile_poll_interval: float = DEFAULT_PROFILE_POLL_INTERVAL
     # Cluster-wide kubectl scans (pod list, stray-pod GC, pod poll, node refresh)
     # are coarse-grained: the controller ticks reconcile at poll_interval (1s),

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -16,6 +16,7 @@ import shlex
 import threading
 import time
 from collections.abc import Iterator, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -88,6 +89,8 @@ from iris.cluster.runtime.env import (
 from iris.cluster.runtime.profile import (
     PROFILER_WATCHDOG_GRACE_SECONDS,
     ExecResult,
+    IrisProfile,
+    ProfileTrigger,
     build_profile_row,
     capture_cpu,
     capture_memory_attach,
@@ -1784,6 +1787,127 @@ class ResourceCollector:
         self._thread.join(timeout=5)
 
 
+# Periodic thread-dump cadence, matching the GCE/TPU worker's profile loop
+# (Worker._profile_interval, 10 minutes). The k8s runtime has no per-node worker
+# daemon to run that loop, so PeriodicProfiler reproduces it controller-side.
+DEFAULT_PROFILE_POLL_INTERVAL = 600.0
+# Cap on concurrent kubectl exec streams a single capture cycle opens, so a large
+# gang is dumped near-simultaneously without exhausting the controller's k8s
+# connection pool.
+DEFAULT_PROFILE_MAX_CONCURRENCY = 8
+
+
+@dataclass(frozen=True)
+class _ProfileTarget:
+    """Identity one periodic thread dump needs: the task/attempt the row is
+    attributed to, the pod to exec into, and the node for the ``k8s/<node>``
+    vm_id (falling back to the pod name when the pod is not yet scheduled)."""
+
+    task_id: str
+    attempt_id: int
+    pod_name: str
+    node_name: str
+
+
+class PeriodicProfiler:
+    """Background thread that dumps each running task pod's threads every
+    ``poll_interval`` and appends a ``trigger="periodic"`` ``iris.profile`` row.
+
+    The GCE/TPU runtime profiles each running attempt from its per-node worker
+    daemon (``Worker._run_profile_loop``). The k8s runtime has no worker daemon,
+    so without this the only profiles a k8s job ever gets are the on-demand
+    captures an operator triggers by hand — a silently wedged collective (every
+    rank blocked, no error, no process exit) then leaves no stack-trace history
+    to diagnose after the fact. This reproduces the worker loop controller-side:
+    unattended thread dumps land in the profile timeline so a hang is caught.
+
+    Thread dumps (not CPU samples) are captured because they are instantaneous
+    and pinpoint where each rank is blocked; a CPU profile of a hung process
+    samples nothing. Captures run on a bounded thread pool so a whole gang is
+    dumped near-simultaneously. The reconcile loop declares the authoritative
+    running-pod set via ``set_pods()`` once per cycle, and all kubectl exec I/O
+    stays off the reconcile thread.
+    """
+
+    def __init__(
+        self,
+        kubectl: K8sService,
+        profile_table: Table,
+        *,
+        poll_interval: float = DEFAULT_PROFILE_POLL_INTERVAL,
+        max_concurrency: int = DEFAULT_PROFILE_MAX_CONCURRENCY,
+    ):
+        self._kubectl = kubectl
+        self._table = profile_table
+        self._poll_interval = poll_interval
+        self._max_concurrency = max(1, max_concurrency)
+        self._targets: dict[tuple[str, int], _ProfileTarget] = {}
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True, name="periodic-profiler")
+        self._thread.start()
+
+    def set_pods(self, targets: dict[tuple[str, int], _ProfileTarget]) -> None:
+        """Declare the authoritative set of running pods to profile."""
+        with self._lock:
+            self._targets = dict(targets)
+
+    def _run(self) -> None:
+        # Wait one interval before the first pass so freshly-started pods have
+        # begun running (and py-spy is importable in the task venv) before the
+        # first attach; wait() returns True only when close() sets the event.
+        while not self._stop.wait(timeout=self._poll_interval):
+            self.collect_once()
+
+    def collect_once(self) -> None:
+        """Dump every tracked pod once and append one profile row per pod.
+
+        Runs each ``poll_interval`` on the background thread; also the unit of
+        collection tests drive directly.
+        """
+        with self._lock:
+            snapshot = list(self._targets.values())
+        if not snapshot:
+            return
+        workers = min(self._max_concurrency, len(snapshot))
+        with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="k8s-profile") as pool:
+            rows = [row for row in pool.map(self._capture, snapshot) if row is not None]
+        if not rows:
+            return
+        try:
+            self._table.write(rows)
+        except Exception:
+            logger.debug("PeriodicProfiler: write to iris.profile failed", exc_info=True)
+
+    def _capture(self, target: _ProfileTarget) -> IrisProfile | None:
+        """Dump one pod's threads; returns the row, or None on any failure.
+
+        A pod whose venv lacks py-spy, or that vanished between reconcile and
+        capture, fails here and is skipped rather than aborting the cycle.
+        """
+        dispatch = _K8sProfileDispatch(self._kubectl, target.pod_name)
+        try:
+            data = capture_threads(dispatch, pid="1")
+        except Exception as e:
+            logger.debug("PeriodicProfiler: thread dump failed for pod %s: %s", target.pod_name, e)
+            return None
+        if not data:
+            return None
+        return build_profile_row(
+            source=target.task_id,
+            attempt_id=target.attempt_id,
+            vm_id=f"k8s/{target.node_name or target.pod_name}",
+            duration_seconds=0,
+            profile_type=job_pb2.ProfileType(threads=job_pb2.ThreadsProfile(locals=False)),
+            profile_data=data,
+            trigger=ProfileTrigger.PERIODIC,
+        )
+
+    def close(self) -> None:
+        self._stop.set()
+        self._thread.join(timeout=5)
+
+
 class TaskEventLog:
     """Appends scheduling/admission events to the ``iris.task_event`` namespace.
 
@@ -1956,6 +2080,12 @@ class K8sTaskProvider:
     # resolution (15s) — sampling faster only re-reads the same value. One bulk
     # metrics list per tick covers every managed pod (see ResourceCollector).
     resource_poll_interval: float = 15.0
+    # Periodic thread-dump cadence. The k8s runtime has no per-node worker daemon
+    # to run the GCE worker's profile loop, so PeriodicProfiler reproduces it here:
+    # every profile_poll_interval it dumps each running pod's threads to
+    # iris.profile (trigger=periodic) so a silently hung collective is caught in
+    # the profile timeline. Matches the worker loop's 10-minute cadence.
+    profile_poll_interval: float = DEFAULT_PROFILE_POLL_INTERVAL
     # Cluster-wide kubectl scans (pod list, stray-pod GC, pod poll, node refresh)
     # are coarse-grained: the controller ticks reconcile at poll_interval (1s),
     # but these LISTs run at most once per cluster_scan_interval to bound kubectl
@@ -1976,6 +2106,7 @@ class K8sTaskProvider:
     transition_reader: TransitionReader | None = field(default=None, repr=False)
     _pod_not_found_counts: dict[str, int] = field(default_factory=dict, init=False, repr=False)
     _resource_collector: ResourceCollector | None = field(default=None, init=False, repr=False)
+    _periodic_profiler: PeriodicProfiler | None = field(default=None, init=False, repr=False)
     _node_stats_collector: NodeStatsCollector | None = field(default=None, init=False, repr=False)
     _task_event_log: TaskEventLog | None = field(default=None, init=False, repr=False)
     _cluster_state: ClusterState = field(default_factory=ClusterState, init=False, repr=False)
@@ -1995,6 +2126,17 @@ class K8sTaskProvider:
                 poll_interval=self.resource_poll_interval,
             )
         return self._resource_collector
+
+    def _ensure_periodic_profiler(self) -> PeriodicProfiler | None:
+        if self.profile_table is None:
+            return None
+        if self._periodic_profiler is None:
+            self._periodic_profiler = PeriodicProfiler(
+                self.kubectl,
+                self.profile_table,
+                poll_interval=self.profile_poll_interval,
+            )
+        return self._periodic_profiler
 
     def _ensure_node_stats_collector(self) -> NodeStatsCollector | None:
         if self.worker_stats_table is None:
@@ -2266,6 +2408,8 @@ class K8sTaskProvider:
     def close(self) -> None:
         if self._resource_collector is not None:
             self._resource_collector.close()
+        if self._periodic_profiler is not None:
+            self._periodic_profiler.close()
         if self._node_stats_collector is not None:
             self._node_stats_collector.close()
 
@@ -2665,6 +2809,8 @@ class K8sTaskProvider:
         if not running:
             if self._resource_collector is not None:
                 self._resource_collector.set_pods({})
+            if self._periodic_profiler is not None:
+                self._periodic_profiler.set_pods({})
             if self._task_event_log is not None:
                 self._task_event_log.retain(set())
             return []
@@ -2686,6 +2832,9 @@ class K8sTaskProvider:
         # appended directly to iris.task by the collector; the controller no
         # longer multiplexes them through TaskUpdate.
         resource_pods: dict[tuple[str, int], str] = {}
+        # Same running set, carrying the node name so the periodic profiler can
+        # stamp the k8s/<node> vm_id without a per-pod GET.
+        profile_targets: dict[tuple[str, int], _ProfileTarget] = {}
         event_log = self._ensure_task_event_log()
 
         for entry in running:
@@ -2730,6 +2879,12 @@ class K8sTaskProvider:
             phase = pod.get("status", {}).get("phase", "")
             if phase == "Running":
                 resource_pods[event_key] = pod_name
+                profile_targets[event_key] = _ProfileTarget(
+                    task_id=entry.task_id.to_wire(),
+                    attempt_id=entry.attempt_id,
+                    pod_name=pod_name,
+                    node_name=pod.get("spec", {}).get("nodeName", "") or "",
+                )
             if event_log is not None:
                 event_log.observe(event_key, _pod_event(pod, workload))
 
@@ -2738,6 +2893,9 @@ class K8sTaskProvider:
         resource_collector = self._ensure_resource_collector()
         if resource_collector is not None:
             resource_collector.set_pods(resource_pods)
+        periodic_profiler = self._ensure_periodic_profiler()
+        if periodic_profiler is not None:
+            periodic_profiler.set_pods(profile_targets)
         if event_log is not None:
             event_log.retain({(entry.task_id.to_wire(), entry.attempt_id) for entry in running})
 

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -743,9 +743,9 @@ def test_periodic_profiler_no_targets_writes_nothing(k8s):
     assert profile_table.writes == []
 
 
-def test_reconcile_registers_running_pods_for_periodic_profiler(k8s):
-    """reconcile hands the profiler exactly the running pods (not terminal ones),
-    so a driven cycle dumps only those."""
+def test_reconcile_dumps_only_running_pods_via_periodic_profiler(k8s):
+    """After reconcile registers the running set, the background profiler loop
+    dumps only the running pod (not the terminal one) into iris.profile."""
     profile_table = FakeStatsTable()
     provider = K8sTaskProvider(
         kubectl=k8s,
@@ -754,7 +754,7 @@ def test_reconcile_registers_running_pods_for_periodic_profiler(k8s):
         cache_dir="/cache",
         local_queue="iris-lq",
         profile_table=profile_table,
-        profile_poll_interval=60.0,
+        profile_poll_interval=0.05,
         cluster_scan_interval=0.0,
     )
     try:
@@ -767,25 +767,15 @@ def test_reconcile_registers_running_pods_for_periodic_profiler(k8s):
         k8s.set_exec_response(running_pod, _success_cp(stdout="Thread 0x1\n  train.py:1"))
 
         provider.sync(make_batch(running_tasks=[running, terminal]))
+        # The loop samples every registered pod each cycle, so once a row lands a
+        # full cycle has run — the terminal pod's absence is real, not a race.
+        wait_for_condition(lambda: bool(profile_table.writes), timeout=Duration.from_seconds(5.0))
 
-        # Stop the background loop so the cycle is deterministic, then drive it once.
-        assert provider._periodic_profiler is not None
-        provider._periodic_profiler.close()
-        provider._periodic_profiler.collect_once()
-
-        rows = [row for batch in profile_table.writes for row in batch]
+        rows = [row for batch in list(profile_table.writes) for row in batch]
         assert {row.source for row in rows} == {"/job/run"}, "only the running pod should be dumped"
-        assert rows[0].trigger == ProfileTrigger.PERIODIC.value
+        assert all(row.trigger == ProfileTrigger.PERIODIC.value for row in rows)
     finally:
         provider.close()
-
-
-def test_provider_without_profile_table_has_no_periodic_profiler(provider, k8s):
-    """The profiler is inert when no profile table is configured (test/local mode)."""
-    populate_pod(k8s, _pod_name(JobName.from_wire("/job/run"), 0), "Running")
-    provider.sync(make_batch(running_tasks=[RunningTaskEntry(task_id=JobName.from_wire("/job/run"), attempt_id=0)]))
-
-    assert provider._periodic_profiler is None
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -22,8 +22,10 @@ from iris.cluster.backends.k8s.tasks import (
     _POD_NOT_FOUND_GRACE_CYCLES,
     _RUNTIME_LABEL_VALUE,
     K8sTaskProvider,
+    PeriodicProfiler,
     ResourceCollector,
     _pod_name,
+    _ProfileTarget,
     _sanitize_label_value,
     _task_hash,
 )
@@ -31,13 +33,14 @@ from iris.cluster.controller.backend import TaskTarget
 from iris.cluster.controller.task_state import RunningTaskEntry
 from iris.cluster.platforms.k8s.coreweave_topology import RACK_SIZE
 from iris.cluster.platforms.k8s.types import ExecResult, K8sResource, KubectlError, PodResourceUsage
+from iris.cluster.runtime.profile import ProfileTrigger
 from iris.cluster.types import JobName
 from iris.cluster.worker.stats import IrisTaskStat
 from iris.rpc import job_pb2
 from iris.test_util import wait_for_condition
 from rigging.timing import Duration
 
-from .conftest import make_batch, make_kueue_provider, make_run_req, populate_node, populate_pod
+from .conftest import FakeStatsTable, make_batch, make_kueue_provider, make_run_req, populate_node, populate_pod
 
 # ---------------------------------------------------------------------------
 # sync(): tasks_to_run
@@ -654,6 +657,135 @@ def test_profile_kubectl_exec_failure_returns_error(provider, k8s):
 
     assert resp.error
     assert "container not running" in resp.error
+
+
+# ---------------------------------------------------------------------------
+# Periodic thread-dump profiling (k8s has no worker daemon to run the GCE loop)
+# ---------------------------------------------------------------------------
+
+
+def _stopped_profiler(k8s, profile_table) -> PeriodicProfiler:
+    """A PeriodicProfiler with its background loop stopped, so tests can drive
+    collect_once() synchronously (the ResourceCollector unit-test pattern)."""
+    profiler = PeriodicProfiler(k8s, profile_table, poll_interval=60.0)
+    profiler.close()
+    return profiler
+
+
+def test_periodic_profiler_writes_thread_dump_rows(k8s):
+    """A tracked running pod is dumped and recorded as a periodic thread profile."""
+    profile_table = FakeStatsTable()
+    pod_name = _pod_name(JobName.from_wire("/job/0"), 0)
+    populate_pod(k8s, pod_name, "Running")
+    k8s.set_exec_response(pod_name, _success_cp(stdout="Thread 0x1 (active+gil)\n  train.py:99 all_to_all"))
+
+    profiler = _stopped_profiler(k8s, profile_table)
+    profiler.set_pods({("/job/0", 0): _ProfileTarget("/job/0", 0, pod_name, "node-a")})
+    profiler.collect_once()
+
+    rows = [row for batch in profile_table.writes for row in batch]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.source == "/job/0"
+    assert row.attempt_id == 0
+    assert row.trigger == ProfileTrigger.PERIODIC.value
+    assert row.type == "thread"
+    assert row.vm_id == "k8s/node-a"
+    assert b"all_to_all" in row.profile_data
+
+
+def test_periodic_profiler_vm_id_falls_back_to_pod_name(k8s):
+    """An unscheduled pod (no nodeName) still gets a k8s/ vm_id from its pod name."""
+    profile_table = FakeStatsTable()
+    pod_name = _pod_name(JobName.from_wire("/job/0"), 0)
+    populate_pod(k8s, pod_name, "Running")
+    k8s.set_exec_response(pod_name, _success_cp(stdout="Thread 0x1\n  main.py:1"))
+
+    profiler = _stopped_profiler(k8s, profile_table)
+    profiler.set_pods({("/job/0", 0): _ProfileTarget("/job/0", 0, pod_name, "")})
+    profiler.collect_once()
+
+    rows = [row for batch in profile_table.writes for row in batch]
+    assert rows[0].vm_id == f"k8s/{pod_name}"
+
+
+def test_periodic_profiler_skips_pods_whose_dump_fails(k8s):
+    """A pod whose py-spy dump fails is skipped, not written, and does not abort
+    the cycle for its siblings."""
+    profile_table = FakeStatsTable()
+    good_pod = _pod_name(JobName.from_wire("/job/0"), 0)
+    bad_pod = _pod_name(JobName.from_wire("/job/1"), 0)
+    populate_pod(k8s, good_pod, "Running")
+    populate_pod(k8s, bad_pod, "Running")
+    k8s.set_exec_response(good_pod, _success_cp(stdout="Thread 0x1\n  main.py:1"))
+    k8s.set_exec_response(bad_pod, _failure_cp(stderr="py-spy: No such process (os error 3)"))
+
+    profiler = _stopped_profiler(k8s, profile_table)
+    profiler.set_pods(
+        {
+            ("/job/0", 0): _ProfileTarget("/job/0", 0, good_pod, "node-a"),
+            ("/job/1", 0): _ProfileTarget("/job/1", 0, bad_pod, "node-b"),
+        }
+    )
+    profiler.collect_once()
+
+    rows = [row for batch in profile_table.writes for row in batch]
+    assert {row.source for row in rows} == {"/job/0"}, "only the pod that dumped cleanly is recorded"
+
+
+def test_periodic_profiler_no_targets_writes_nothing(k8s):
+    """With no running pods declared, a cycle is a no-op."""
+    profile_table = FakeStatsTable()
+    profiler = _stopped_profiler(k8s, profile_table)
+    profiler.set_pods({})
+    profiler.collect_once()
+
+    assert profile_table.writes == []
+
+
+def test_reconcile_registers_running_pods_for_periodic_profiler(k8s):
+    """reconcile hands the profiler exactly the running pods (not terminal ones),
+    so a driven cycle dumps only those."""
+    profile_table = FakeStatsTable()
+    provider = K8sTaskProvider(
+        kubectl=k8s,
+        namespace="iris",
+        default_image="myrepo/iris:latest",
+        cache_dir="/cache",
+        local_queue="iris-lq",
+        profile_table=profile_table,
+        profile_poll_interval=60.0,
+        cluster_scan_interval=0.0,
+    )
+    try:
+        running = RunningTaskEntry(task_id=JobName.from_wire("/job/run"), attempt_id=0)
+        terminal = RunningTaskEntry(task_id=JobName.from_wire("/job/done"), attempt_id=0)
+        running_pod = _pod_name(running.task_id, running.attempt_id)
+        terminal_pod = _pod_name(terminal.task_id, terminal.attempt_id)
+        populate_pod(k8s, running_pod, "Running")
+        populate_pod(k8s, terminal_pod, "Succeeded")
+        k8s.set_exec_response(running_pod, _success_cp(stdout="Thread 0x1\n  train.py:1"))
+
+        provider.sync(make_batch(running_tasks=[running, terminal]))
+
+        # Stop the background loop so the cycle is deterministic, then drive it once.
+        assert provider._periodic_profiler is not None
+        provider._periodic_profiler.close()
+        provider._periodic_profiler.collect_once()
+
+        rows = [row for batch in profile_table.writes for row in batch]
+        assert {row.source for row in rows} == {"/job/run"}, "only the running pod should be dumped"
+        assert rows[0].trigger == ProfileTrigger.PERIODIC.value
+    finally:
+        provider.close()
+
+
+def test_provider_without_profile_table_has_no_periodic_profiler(provider, k8s):
+    """The profiler is inert when no profile table is configured (test/local mode)."""
+    populate_pod(k8s, _pod_name(JobName.from_wire("/job/run"), 0), "Running")
+    provider.sync(make_batch(running_tasks=[RunningTaskEntry(task_id=JobName.from_wire("/job/run"), attempt_id=0)]))
+
+    assert provider._periodic_profiler is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The GCE/TPU runtime profiles each running attempt every 10 minutes from its per-node worker daemon, so a training hang leaves a stack-trace trail in `iris.profile`. The k8s backend has no worker daemon, so until now the only profiles a k8s job ever got were the on-demand captures an operator triggers by hand. A silently wedged collective — every rank blocked, no error, no process exit, so `max_retries_failure` never fires — therefore left zero forensic data. Confirmed against the live cluster: `iris.profile` holds 3.29M periodic CPU captures, all written by GCE workers, and not one periodic capture from any k8s pod; the 512-GPU GB200 job in #7344 that hung mid-training has zero profiles of any kind.

Add `PeriodicProfiler`, a background thread on `K8sTaskProvider` that dumps every running pod's threads on the same 10-minute cadence and writes them to `iris.profile` with `trigger=periodic`. It mirrors `ResourceCollector`: the reconcile loop hands it the authoritative running-pod set via `set_pods()`, and all `kubectl exec` I/O runs on a bounded pool off the reconcile thread. Captures are thread dumps rather than CPU samples because a hung process samples no CPU, whereas a thread dump pinpoints where each rank is blocked. The collector is inert unless a finelog profile table is configured, so the change is a no-op for local/test providers.

`profile_poll_interval` (default 600s) is the tuning lever if a large CPU job's pod count makes the volume undesirable.

Part of #7344