### PR TITLE
[iris] Proxy federated on-demand debug RPCs through one seam; add K8s process status

### DIFF
--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -39,7 +39,7 @@ from iris.cluster.controller.backend import (
     BackendCapability,
     BackendRuntime,
     DeviceCapacity,
-    ProviderUnsupportedError,
+    ProviderError,
     ReconcileRequest,
     ReconcileResult,
     ScheduleRequest,
@@ -1892,6 +1892,121 @@ class _K8sProfileDispatch:
             logger.warning("SIGCONT sweep failed for pod %s: %s", self.pod_name, e)
 
 
+# Reads the task pod's PID-1 vitals from /proc in one exec, mirroring how profiling
+# reaches the pod (kubectl exec into the ``task`` container). Emits marker-delimited
+# raw file contents; parsing (including the two CPU samples) happens controller-side
+# in ``_parse_pod_proc_status``. The 0.5s gap between the two /proc/1/stat reads is the
+# CPU sampling interval; a container whose sleep rejects fractions just yields ~0 cpu.
+_POD_PROC_STATUS_SCRIPT = r"""
+echo "@@hostname"; cat /proc/sys/kernel/hostname 2>/dev/null
+echo "@@uptime1"; cat /proc/uptime 2>/dev/null
+echo "@@stat1"; cat /proc/1/stat 2>/dev/null
+sleep 0.5 2>/dev/null || sleep 1
+echo "@@uptime2"; cat /proc/uptime 2>/dev/null
+echo "@@stat2"; cat /proc/1/stat 2>/dev/null
+echo "@@statm"; cat /proc/1/statm 2>/dev/null
+echo "@@threads"; grep -i '^Threads:' /proc/1/status 2>/dev/null
+echo "@@fds"; ls /proc/1/fd 2>/dev/null | wc -l
+echo "@@memtotal"; grep -i '^MemTotal:' /proc/meminfo 2>/dev/null
+echo "@@nproc"; nproc 2>/dev/null
+echo "@@clktck"; getconf CLK_TCK 2>/dev/null
+echo "@@pagesize"; getconf PAGE_SIZE 2>/dev/null
+"""
+# kubectl-exec overhead plus the in-pod sampling sleep; a task-pod /proc read is quick.
+_POD_PROC_STATUS_TIMEOUT = 15
+
+
+def _proc_int(text: str, default: int = 0) -> int:
+    try:
+        return int(text.strip())
+    except (ValueError, AttributeError):
+        return default
+
+
+def _stat_fields_after_comm(raw: str) -> list[str]:
+    """Fields of ``/proc/PID/stat`` starting at ``state`` (field 3).
+
+    The ``comm`` field (2) is parenthesized and may itself contain spaces or
+    parens, so index from the last ``)`` rather than splitting the whole line.
+    Returned index ``i`` is stat field ``i + 3``.
+    """
+    rclose = raw.rfind(")")
+    return raw[rclose + 2 :].split() if rclose != -1 else []
+
+
+def _parse_pod_proc_status(output: str) -> job_pb2.ProcessInfo:
+    """Parse ``_POD_PROC_STATUS_SCRIPT`` output into a ``ProcessInfo`` for PID 1.
+
+    Reports the OS-level vitals of the pod's main process (the task command).
+    Daemon-specific fields the worker path fills from its own interpreter
+    (``python_version``, build ``provenance``) have no pod equivalent and are left
+    unset. ``cpu_millicores`` is the instantaneous rate across the two samples;
+    ``thread_count`` is the kernel task count, not a Python-level count.
+    """
+    sections: dict[str, str] = {}
+    key: str | None = None
+    buf: list[str] = []
+    for line in output.splitlines():
+        if line.startswith("@@"):
+            if key is not None:
+                sections[key] = "\n".join(buf).strip()
+            key, buf = line[2:], []
+        else:
+            buf.append(line)
+    if key is not None:
+        sections[key] = "\n".join(buf).strip()
+
+    clk_tck = _proc_int(sections.get("clktck", ""), 100) or 100
+    page_size = _proc_int(sections.get("pagesize", ""), 4096) or 4096
+
+    def _uptime(section: str) -> float:
+        try:
+            return float(sections.get(section, "").split()[0])
+        except (ValueError, IndexError):
+            return 0.0
+
+    def _cpu_ticks(fields: list[str]) -> int:
+        # utime (field 14) + stime (field 15) => indices 11, 12 after comm.
+        return _proc_int(fields[11]) + _proc_int(fields[12]) if len(fields) >= 13 else 0
+
+    stat1 = _stat_fields_after_comm(sections.get("stat1", ""))
+    stat2 = _stat_fields_after_comm(sections.get("stat2", ""))
+    uptime1, uptime2 = _uptime("uptime1"), _uptime("uptime2")
+
+    interval = uptime2 - uptime1
+    cpu_millicores = 0
+    if interval > 0 and stat1 and stat2:
+        cpu_millicores = max(0, round((_cpu_ticks(stat2) - _cpu_ticks(stat1)) / clk_tck / interval * 1000))
+
+    uptime_ms = 0
+    if len(stat1) >= 20 and uptime1 > 0:
+        # starttime is field 22 => index 19 after comm.
+        uptime_ms = max(0, round((uptime1 - _proc_int(stat1[19]) / clk_tck) * 1000))
+
+    statm = sections.get("statm", "").split()
+    vms = _proc_int(statm[0]) * page_size if len(statm) >= 1 else 0
+    rss = _proc_int(statm[1]) * page_size if len(statm) >= 2 else 0
+
+    threads_line = sections.get("threads", "")
+    thread_count = _proc_int(threads_line.split(":")[-1]) if ":" in threads_line else 0
+
+    mem_parts = sections.get("memtotal", "").split()  # "MemTotal:  N kB"
+    mem_total = _proc_int(mem_parts[1]) * 1024 if len(mem_parts) >= 2 else 0
+
+    return job_pb2.ProcessInfo(
+        hostname=sections.get("hostname", ""),
+        pid=1,
+        uptime_ms=uptime_ms,
+        memory_rss_bytes=rss,
+        memory_vms_bytes=vms,
+        cpu_millicores=cpu_millicores,
+        thread_count=thread_count,
+        open_fd_count=_proc_int(sections.get("fds", "")),
+        memory_total_bytes=mem_total,
+        cpu_count=_proc_int(sections.get("nproc", "")),
+    )
+
+
 @dataclass
 class K8sTaskProvider:
     """Executes tasks as Kubernetes Pods without worker daemons.
@@ -2261,7 +2376,20 @@ class K8sTaskProvider:
         target: TaskTarget,
         request: job_pb2.GetProcessStatusRequest,
     ) -> job_pb2.GetProcessStatusResponse:
-        raise ProviderUnsupportedError("K8s backend does not support per-process status")
+        """Report the task pod's PID-1 vitals, collected via ``kubectl exec``.
+
+        There is no worker daemon in the pod, so — like profiling — this reaches
+        the task container directly and reads ``/proc`` for the main process's
+        memory, cpu, thread, and fd counters. Logs are served separately via
+        FetchLogs, so ``log_entries`` stays empty.
+        """
+        pod_name = _pod_name(JobName.from_wire(target.task_id), target.attempt_id)
+        result = self.kubectl.exec(
+            pod_name, ["sh", "-c", _POD_PROC_STATUS_SCRIPT], container="task", timeout=_POD_PROC_STATUS_TIMEOUT
+        )
+        if result.returncode != 0:
+            raise ProviderError(f"process status exec in pod {pod_name} failed: {result.stderr.strip() or 'no output'}")
+        return job_pb2.GetProcessStatusResponse(process_info=_parse_pod_proc_status(result.stdout or ""))
 
     def close(self) -> None:
         if self._resource_collector is not None:

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -11,10 +11,10 @@ aggregated from task states.
 import json
 import logging
 import secrets
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import date, timedelta
-from typing import Any, Protocol
+from typing import Any, Protocol, TypeVar
 
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
@@ -74,6 +74,7 @@ from iris.cluster.controller.schema import (
 from iris.cluster.controller.task_state import ACTIVE_TASK_STATES, task_row_can_be_scheduled
 from iris.cluster.controller.worker_health import WorkerLiveness
 from iris.cluster.federation.manager import FederationManager
+from iris.cluster.federation.peer import FederationPeer
 from iris.cluster.federation.router import RoutingRequest, SubmitDisposition, SubmitPlan
 from iris.cluster.federation.store import HandoffState
 from iris.cluster.log_highlights import extract_failure_highlights
@@ -108,6 +109,9 @@ from iris.rpc.proto_display import (
 from iris.time_proto import duration_from_proto, duration_to_proto, timestamp_to_proto
 
 logger = logging.getLogger(__name__)
+
+# Return type of a proxied on-demand RPC (a unary controller response).
+_T = TypeVar("_T")
 
 
 def submitting_user_for_root(
@@ -2419,6 +2423,20 @@ class ControllerServiceImpl:
         with self._db.read_snapshot() as snap:
             return reads.federated_handle(snap, task_id.root_job)
 
+    def _proxy_if_federated(self, task_id: JobName, call: Callable[[FederationPeer], _T]) -> _T | None:
+        """Forward an on-demand RPC to its owning peer if ``task_id`` is federated.
+
+        ``call`` invokes the matching typed method on the peer connection; the peer is
+        authoritative, so its ``NOT_FOUND`` for a moved or finished task propagates
+        back. Returns the peer's response, or ``None`` when the root job runs locally —
+        the caller then resolves it against the local backend. The proxied responses
+        are unary messages, never ``None``, so callers dispatch on ``is not None``.
+        """
+        handle = self._federated_handle_for_task(task_id)
+        if handle is None:
+            return None
+        return self._controller.federation.proxy_to_peer(handle.peer_id, call)
+
     def _resolve_task_target(self, task: TaskWithAttempts, attempt_id: int, *, wire_name: str) -> TaskTarget:
         """Resolve a running task to a :class:`TaskTarget` for on-demand worker RPCs.
 
@@ -2637,12 +2655,9 @@ class ControllerServiceImpl:
         # attempt rows. Proxy the profile through the peer controller (which does
         # its own task->worker resolution) before the local resolution below, so
         # it is never dispatched to _backend_for_id's local fallback.
-        handle = self._federated_handle_for_task(target.task_id)
-        if handle is not None:
-            return self._controller.federation.proxy_profile(
-                peer_id=handle.peer_id,
-                request=request,
-            )
+        proxied = self._proxy_if_federated(target.task_id, lambda peer: peer.profile_task(request))
+        if proxied is not None:
+            return proxied
 
         attempt_id = target.attempt_id if target.attempt_id is not None else task.current_attempt_id
         task_target = self._resolve_task_target(task, attempt_id, wire_name=request.target)
@@ -2763,6 +2778,8 @@ class ControllerServiceImpl:
         Target routing (same convention as ProfileTask):
         - empty or /system/process: the controller process itself
         - /system/worker/<worker_id>: proxy to a specific worker
+        - /job/.../task/N: the process serving that task — proxied to the owning
+          peer for a federated task, else resolved against the local backend.
         """
         target = request.target
         if not target or target == "/system/process":
@@ -2771,7 +2788,7 @@ class ControllerServiceImpl:
         # Parse /system/worker/<worker_id>
         worker_id = _parse_worker_target(target)
         if worker_id is None:
-            raise ConnectError(Code.INVALID_ARGUMENT, f"Invalid target: {target}")
+            return self._task_process_status(target, request)
 
         worker = _read_worker(self._db, WorkerId(worker_id))
         if not worker:
@@ -2790,6 +2807,36 @@ class ControllerServiceImpl:
                 self._controller.backend_id_for_scale_group(str(worker.scale_group or ""))
             )
             return worker_backend.get_process_status(process_target, request)
+        except ProviderError as exc:
+            raise ConnectError(Code.UNAVAILABLE, str(exc)) from exc
+
+    def _task_process_status(
+        self, target: str, request: job_pb2.GetProcessStatusRequest
+    ) -> job_pb2.GetProcessStatusResponse:
+        """Process status for a ``/job/.../task/N`` target.
+
+        A federated task's subtree runs on a peer, so the request is proxied through
+        the peer controller before any local resolution. Otherwise the owning backend
+        reports it: a worker-daemon backend returns the worker hosting the task; the
+        K8s backend reads the task pod's PID 1.
+        """
+        try:
+            task_id = JobName.from_wire(target)
+            task_id.require_task()
+        except ValueError as exc:
+            raise ConnectError(Code.INVALID_ARGUMENT, f"Invalid target: {target}") from exc
+
+        task = _read_task_with_attempts(self._db, task_id)
+        if not task:
+            raise ConnectError(Code.NOT_FOUND, f"Task {target} not found")
+
+        proxied = self._proxy_if_federated(task_id, lambda peer: peer.get_process_status(request))
+        if proxied is not None:
+            return proxied
+
+        task_target = self._resolve_task_target(task, task.current_attempt_id, wire_name=target)
+        try:
+            return self._backend_for_id(str(task.backend_id or "")).get_process_status(task_target, request)
         except ProviderError as exc:
             raise ConnectError(Code.UNAVAILABLE, str(exc)) from exc
 
@@ -2870,12 +2917,9 @@ class ControllerServiceImpl:
         # attempt rows. Proxy the exec through the peer controller (which does its
         # own task->worker resolution) before the local resolution below, so it is
         # never dispatched to _backend_for_id's local fallback.
-        handle = self._federated_handle_for_task(task_id)
-        if handle is not None:
-            return self._controller.federation.proxy_exec(
-                peer_id=handle.peer_id,
-                request=request,
-            )
+        proxied = self._proxy_if_federated(task_id, lambda peer: peer.exec_in_container(request))
+        if proxied is not None:
+            return proxied
 
         worker_request = worker_pb2.Worker.ExecInContainerRequest(
             task_id=request.task_id,

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -1218,6 +1218,27 @@ class ControllerServiceImpl:
             raise ConnectError(Code.PERMISSION_DENIED, f"Peer {identity.user_id!r} did not federate job {job_id}")
         authorize_resource_owner(job_id.user)
 
+    def _authorize_federated_debug_target(self, root_job: JobName) -> None:
+        """Scope a federation peer's on-demand debug RPC to a job it federated here.
+
+        ``authorize_method`` admits ProfileTask/ExecInContainer/GetProcessStatus for a
+        ``FEDERATION_PEER_ROLE`` identity; this confirms ``root_job`` is one the peer
+        actually handed off (matching its received handle), so a peer cannot profile,
+        exec into, or inspect this cluster's own tasks. Non-peer callers pass through
+        untouched — their access stays governed by ``authorize_method``'s role
+        allowlist, so the read-only dashboard keeps reading any task's process status.
+        """
+        if not self._auth.provider:
+            return
+        identity = get_verified_identity()
+        if identity is None or identity.role != FEDERATION_PEER_ROLE:
+            return
+        with self._db.read_snapshot() as snap:
+            handoff = reads.received_handoff(snap, root_job)
+            if handoff is not None and handoff.requester_id == identity.user_id:
+                return
+        raise ConnectError(Code.PERMISSION_DENIED, f"Peer {identity.user_id!r} did not federate job {root_job}")
+
     def _wait_until_job_drained(self, job_id: JobName, wait: Duration) -> bool:
         """Wait up to ``wait`` for ``job_id`` to have no unfinished worker-bound
         attempts. Returns ``True`` if drained, ``False`` if the wait elapsed.
@@ -2647,6 +2668,7 @@ class ControllerServiceImpl:
             target.task_id.require_task()
         except ValueError as exc:
             raise ConnectError(Code.INVALID_ARGUMENT, str(exc)) from exc
+        self._authorize_federated_debug_target(target.task_id.root_job)
         task = _read_task_with_attempts(self._db, target.task_id)
         if not task:
             raise ConnectError(Code.NOT_FOUND, f"Task {request.target} not found")
@@ -2826,6 +2848,7 @@ class ControllerServiceImpl:
         except ValueError as exc:
             raise ConnectError(Code.INVALID_ARGUMENT, f"Invalid target: {target}") from exc
 
+        self._authorize_federated_debug_target(task_id.root_job)
         task = _read_task_with_attempts(self._db, task_id)
         if not task:
             raise ConnectError(Code.NOT_FOUND, f"Task {target} not found")
@@ -2909,6 +2932,7 @@ class ControllerServiceImpl:
         except ValueError as exc:
             raise ConnectError(Code.INVALID_ARGUMENT, str(exc)) from exc
 
+        self._authorize_federated_debug_target(task_id.root_job)
         task = _read_task_with_attempts(self._db, task_id)
         if not task:
             raise ConnectError(Code.NOT_FOUND, f"Task {request.task_id} not found")

--- a/lib/iris/src/iris/cluster/federation/manager.py
+++ b/lib/iris/src/iris/cluster/federation/manager.py
@@ -19,6 +19,7 @@ to hand a job off or run the sync loop; the observability slice (heartbeat,
 import logging
 import threading
 from collections.abc import Callable, Sequence
+from typing import TypeVar
 
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
@@ -43,9 +44,12 @@ from iris.cluster.federation.store import (
 )
 from iris.cluster.types import JobName
 from iris.managed_thread import ManagedThread, ThreadContainer
-from iris.rpc import controller_pb2, job_pb2
+from iris.rpc import controller_pb2
 
 logger = logging.getLogger(__name__)
+
+# Return type of a proxied on-demand RPC (a unary controller response).
+_T = TypeVar("_T")
 
 DEFAULT_HEARTBEAT_INTERVAL = Duration.from_seconds(30)
 DEFAULT_SYNC_INTERVAL = Duration.from_seconds(3)
@@ -284,37 +288,16 @@ class FederationManager:
 
     # -- on-demand proxy (parent side) ---------------------------------------
 
-    def proxy_profile(
-        self,
-        *,
-        peer_id: str,
-        request: job_pb2.ProfileTaskRequest,
-    ) -> job_pb2.ProfileTaskResponse:
-        """Forward a profile RPC for a federated task to its peer controller.
+    def proxy_to_peer(self, peer_id: str, call: Callable[[FederationPeer], _T]) -> _T:
+        """Forward an on-demand RPC for a federated task to its owning peer controller.
 
-        Job ids are cluster-invariant, so the request's target names the same task
-        on the peer — it is proxied verbatim to the peer's ``ProfileTask``. The peer
-        is authoritative: its answer — including a ``NOT_FOUND`` for a task it has
-        since moved or finished — propagates back.
+        Job ids are cluster-invariant, so a task's request names the same task on the
+        peer; ``call`` invokes the matching typed method on the peer connection (e.g.
+        ``lambda peer: peer.profile_task(request)``). The peer is authoritative — its
+        answer, including a ``NOT_FOUND`` for a task it has since moved or finished,
+        propagates back verbatim.
         """
-        peer = self._require_peer(peer_id)
-        return peer.profile_task(request)
-
-    def proxy_exec(
-        self,
-        *,
-        peer_id: str,
-        request: controller_pb2.Controller.ExecInContainerRequest,
-    ) -> controller_pb2.Controller.ExecInContainerResponse:
-        """Forward an exec RPC for a federated task to its peer controller.
-
-        Job ids are cluster-invariant, so the request's task id names the same task
-        on the peer — it is proxied verbatim to the peer's ``ExecInContainer``. The
-        peer is authoritative: its answer — including a ``NOT_FOUND`` — propagates
-        back.
-        """
-        peer = self._require_peer(peer_id)
-        return peer.exec_in_container(request)
+        return call(self._require_peer(peer_id))
 
     # -- background loops ----------------------------------------------------
 

--- a/lib/iris/src/iris/cluster/federation/peer.py
+++ b/lib/iris/src/iris/cluster/federation/peer.py
@@ -42,6 +42,10 @@ _PROFILE_PROXY_TIMEOUT_MARGIN_MS = 60_000
 _EXEC_PROXY_TIMEOUT_MARGIN_MS = 60_000
 _DEFAULT_PROFILE_DURATION = 10
 _DEFAULT_EXEC_TIMEOUT = 60
+# Process status has no duration; the peer's own worker/pod hop is bounded (a worker
+# forward caps at ~10s, a kubectl-exec /proc read is quick), so give the parent->peer
+# hop that budget plus margin to outlast the peer rather than time out first.
+_PROCESS_STATUS_PROXY_TIMEOUT_MS = 30_000
 
 logger = logging.getLogger(__name__)
 
@@ -51,8 +55,8 @@ class PeerConnection(Protocol):
 
     ``list_backends`` is the capability heartbeat; ``launch_job`` delivers a handoff;
     ``terminate_job`` routes a cancel; ``federation_sync`` runs one delta-sync round;
-    ``profile_task``/``exec_in_container`` proxy an on-demand RPC against a handed-off
-    task, which the peer resolves to its own worker.
+    ``profile_task``/``exec_in_container``/``get_process_status`` proxy an on-demand RPC
+    against a handed-off task, which the peer resolves to its own worker or pod.
     """
 
     def list_backends(self) -> list[controller_pb2.Controller.BackendSummary]: ...
@@ -72,6 +76,8 @@ class PeerConnection(Protocol):
     def exec_in_container(
         self, request: controller_pb2.Controller.ExecInContainerRequest
     ) -> controller_pb2.Controller.ExecInContainerResponse: ...
+
+    def get_process_status(self, request: job_pb2.GetProcessStatusRequest) -> job_pb2.GetProcessStatusResponse: ...
 
     def shutdown(self) -> None: ...
 
@@ -151,6 +157,9 @@ class _PeerRpcConnection:
         else:
             budget_ms = (request.timeout_seconds or _DEFAULT_EXEC_TIMEOUT) * 1000
         return self._client.exec_in_container(request, timeout_ms=budget_ms + _EXEC_PROXY_TIMEOUT_MARGIN_MS)
+
+    def get_process_status(self, request: job_pb2.GetProcessStatusRequest) -> job_pb2.GetProcessStatusResponse:
+        return self._client.get_process_status(request, timeout_ms=_PROCESS_STATUS_PROXY_TIMEOUT_MS)
 
     def shutdown(self) -> None:
         self._client.close()
@@ -234,6 +243,10 @@ class FederationPeer:
     ) -> controller_pb2.Controller.ExecInContainerResponse:
         """Proxy an exec RPC for a handed-off task to the peer (reuses its ``ExecInContainer``)."""
         return self._connection.exec_in_container(request)
+
+    def get_process_status(self, request: job_pb2.GetProcessStatusRequest) -> job_pb2.GetProcessStatusResponse:
+        """Proxy a process-status RPC for a handed-off task to the peer (reuses its ``GetProcessStatus``)."""
+        return self._connection.get_process_status(request)
 
     def close(self) -> None:
         """Release the peer connection."""

--- a/lib/iris/src/iris/rpc/auth.py
+++ b/lib/iris/src/iris/rpc/auth.py
@@ -29,18 +29,23 @@ SESSION_COOKIE = "iris_session"
 DASHBOARD_ROLE = "dashboard"
 
 # Role carried by a verified federation token — a trusted peer handing a job off or
-# driving its sync/cancel/proxy. Method-scoped to FEDERATION_RPCS below, never a
-# general identity: a federation bearer the composite verifier accepts cannot reach
-# any other RPC even though it authenticated.
+# driving its sync/cancel/proxy. Method-scoped to FEDERATION_RPCS and the
+# target-scoped FEDERATION_SCOPED_RPCS below, never a general identity: a federation
+# bearer the composite verifier accepts cannot reach any other RPC even though it
+# authenticated.
 FEDERATION_PEER_ROLE = "federation-peer"
 
-# The only RPCs a federation-peer identity may call: whole-job handoff, routed
+# RPCs a federation-peer identity may call unconditionally: whole-job handoff, routed
 # cancel, delta-sync, and the capability heartbeat. A default-deny allowlist, like
-# DASHBOARD_READABLE_RPCS. The on-demand exec/profile proxies (ProfileTask,
-# ExecInContainer) are deliberately excluded until their handlers scope a peer to
-# the jobs it federated per target — a peer must not exec into the receiving
-# cluster's own tasks or profile its controller.
+# DASHBOARD_READABLE_RPCS.
 FEDERATION_RPCS: frozenset[str] = frozenset({"LaunchJob", "TerminateJob", "FederationSync", "ListBackends"})
+
+# On-demand debug proxies a federation-peer identity may call, but only after the
+# handler confirms the target task belongs to a job that peer federated here (its
+# RECEIVED handle) — a peer must not profile/exec/inspect the receiving cluster's own
+# tasks or its controller. authorize_method admits these; the controller service's
+# _authorize_federated_debug_target enforces the per-target ownership.
+FEDERATION_SCOPED_RPCS: frozenset[str] = frozenset({"ProfileTask", "ExecInContainer", "GetProcessStatus"})
 
 
 class AuthzAction(StrEnum):
@@ -120,7 +125,11 @@ def authorize_method(identity: VerifiedIdentity, method_name: str) -> None:
             f"Read-only dashboard access cannot call {method_name}; "
             "this identity is not provisioned for write access",
         )
-    if identity.role == FEDERATION_PEER_ROLE and method_name not in FEDERATION_RPCS:
+    if (
+        identity.role == FEDERATION_PEER_ROLE
+        and method_name not in FEDERATION_RPCS
+        and method_name not in FEDERATION_SCOPED_RPCS
+    ):
         raise ConnectError(
             Code.PERMISSION_DENIED,
             f"Federation-peer identity cannot call {method_name}; it is scoped to the federation RPC subset",

--- a/lib/iris/tests/cluster/backends/k8s/test_k8s_parsers.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_k8s_parsers.py
@@ -6,7 +6,62 @@
 from datetime import UTC, datetime
 
 import pytest
+from iris.cluster.backends.k8s.tasks import _parse_pod_proc_status
 from iris.cluster.platforms.k8s.types import parse_k8s_cpu, parse_k8s_quantity, parse_k8s_timestamp
+
+# One capture of the in-pod /proc reader. comm carries a space to exercise the
+# "index from the last ')'" parse; CLK_TCK=100, PAGE_SIZE=4096. Between the two
+# stat samples utime+stime advances 15 ticks over a 0.5s uptime gap => 300 mcores.
+# starttime 6000 ticks at 1000.5s uptime => 940.5s process uptime.
+_POD_PROC_STATUS_SAMPLE = """@@hostname
+task-pod-abc
+@@uptime1
+1000.50 900.00
+@@stat1
+1 (python 3.11) S 0 1 1 0 -1 4194560 12345 0 0 0 5000 2000 0 0 20 0 8 0 6000 0 0 0
+@@uptime2
+1001.00 900.40
+@@stat2
+1 (python 3.11) S 0 1 1 0 -1 4194560 12400 0 0 0 5010 2005 0 0 20 0 8 0 6000 0 0 0
+@@statm
+100000 25000 5000 1 0 90000 0
+@@threads
+Threads:\t8
+@@fds
+42
+@@memtotal
+MemTotal:       16000000 kB
+@@nproc
+8
+@@clktck
+100
+@@pagesize
+4096
+"""
+
+
+def test_parse_pod_proc_status():
+    info = _parse_pod_proc_status(_POD_PROC_STATUS_SAMPLE)
+    assert info.hostname == "task-pod-abc"
+    assert info.pid == 1
+    assert info.thread_count == 8
+    assert info.open_fd_count == 42
+    assert info.cpu_count == 8
+    assert info.cpu_millicores == 300
+    assert info.uptime_ms == 940500
+    assert info.memory_rss_bytes == 25000 * 4096
+    assert info.memory_vms_bytes == 100000 * 4096
+    assert info.memory_total_bytes == 16000000 * 1024
+
+
+def test_parse_pod_proc_status_tolerates_empty_capture():
+    # A stripped-down container may lack some /proc entries; parsing must not raise
+    # and unknown counters fall back to zero rather than a bogus value.
+    info = _parse_pod_proc_status("@@hostname\npod-x\n@@clktck\n100\n@@pagesize\n4096\n")
+    assert info.hostname == "pod-x"
+    assert info.cpu_millicores == 0
+    assert info.uptime_ms == 0
+    assert info.thread_count == 0
 
 
 @pytest.mark.parametrize(

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -27,7 +27,7 @@ from iris.cluster.backends.k8s.tasks import (
     _sanitize_label_value,
     _task_hash,
 )
-from iris.cluster.controller.backend import TaskTarget
+from iris.cluster.controller.backend import ProviderError, TaskTarget
 from iris.cluster.controller.task_state import RunningTaskEntry
 from iris.cluster.platforms.k8s.coreweave_topology import RACK_SIZE
 from iris.cluster.platforms.k8s.types import ExecResult, K8sResource, KubectlError, PodResourceUsage
@@ -526,6 +526,43 @@ def test_profile_threads_via_kubectl_exec(provider, k8s):
 
     assert not resp.error
     assert b"Thread 0x7f00" in resp.profile_data
+
+
+def test_get_process_status_reads_pod_proc_via_kubectl_exec(provider, k8s):
+    """get_process_status execs the /proc reader into the task pod and parses vitals."""
+    pod_name = _pod_name(JobName.from_wire("/job/0"), 0)
+    populate_pod(k8s, pod_name, "Running")
+    stdout = (
+        "@@hostname\ntask-0\n@@uptime1\n500.0 0\n"
+        "@@stat1\n1 (python) S 0 1 1 0 -1 0 0 0 0 0 100 50 0 0 20 0 5 0 1000 0\n"
+        "@@uptime2\n500.5 0\n"
+        "@@stat2\n1 (python) S 0 1 1 0 -1 0 0 0 0 0 100 50 0 0 20 0 5 0 1000 0\n"
+        "@@statm\n0 0\n@@threads\nThreads:\t5\n@@fds\n9\n"
+        "@@memtotal\nMemTotal: 0 kB\n@@nproc\n4\n@@clktck\n100\n@@pagesize\n4096\n"
+    )
+    k8s.set_exec_response(pod_name, _success_cp(stdout=stdout))
+
+    resp = provider.get_process_status(
+        TaskTarget(task_id="/job/0", attempt_id=0, worker_id=None, address=None),
+        job_pb2.GetProcessStatusRequest(target="/job/0"),
+    )
+
+    assert resp.process_info.thread_count == 5
+    assert resp.process_info.open_fd_count == 9
+    assert resp.process_info.cpu_count == 4
+
+
+def test_get_process_status_raises_on_exec_failure(provider, k8s):
+    """A failed kubectl exec surfaces as ProviderError (mapped to UNAVAILABLE upstream)."""
+    pod_name = _pod_name(JobName.from_wire("/job/0"), 0)
+    populate_pod(k8s, pod_name, "Running")
+    k8s.set_exec_response(pod_name, _failure_cp(stderr="container not running"))
+
+    with pytest.raises(ProviderError, match="process status exec"):
+        provider.get_process_status(
+            TaskTarget(task_id="/job/0", attempt_id=0, worker_id=None, address=None),
+            job_pb2.GetProcessStatusRequest(target="/job/0"),
+        )
 
 
 def test_profile_threads_with_locals(provider, k8s):

--- a/lib/iris/tests/cluster/controller/test_federation_exec_proxy.py
+++ b/lib/iris/tests/cluster/controller/test_federation_exec_proxy.py
@@ -61,6 +61,7 @@ class _ProxyPeerConnection:
         self._service = service
         self.profile_calls = 0
         self.exec_calls = 0
+        self.status_calls = 0
 
     def list_backends(self) -> list[controller_pb2.Controller.BackendSummary]:
         return []
@@ -95,6 +96,11 @@ class _ProxyPeerConnection:
         self.exec_calls += 1
         with identity_scope(_PEER_IDENTITY):
             return self._service.exec_in_container(request, None)
+
+    def get_process_status(self, request: job_pb2.GetProcessStatusRequest) -> job_pb2.GetProcessStatusResponse:
+        self.status_calls += 1
+        with identity_scope(_PEER_IDENTITY):
+            return self._service.get_process_status(request, None)
 
 
 def _make_service(
@@ -239,6 +245,30 @@ def test_exec_against_a_federated_task_runs_on_the_peer(tmp_path, log_client):
         (call,) = peer_service._controller.provider.exec_in_container.call_args_list
         assert call.args[0].task_id == job_id.task(0).to_wire()
         assert call.args[1].task_id == job_id.task(0).to_wire()
+
+
+def test_process_status_against_a_federated_task_runs_on_the_peer(tmp_path, log_client):
+    with ExitStack() as stack:
+        parent_service, parent_state = _make_service(stack, "parent", tmp_path, log_client)
+        peer_service, peer_state = _make_service(stack, "peer", tmp_path, log_client)
+        manager = _attach_federation(parent_service, _ProxyPeerConnection(peer_service))
+        job_id = _handoff_and_mirror_running_task(parent_service, parent_state, peer_state, manager)
+
+        peer_service._controller.provider.get_process_status.return_value = job_pb2.GetProcessStatusResponse(
+            process_info=job_pb2.ProcessInfo(pid=1, thread_count=7)
+        )
+        resp = parent_service.get_process_status(
+            job_pb2.GetProcessStatusRequest(target=job_id.task(0).to_wire()),
+            None,
+        )
+
+        # The status could only have come from the peer's backend.
+        assert resp.process_info.thread_count == 7
+        # The federated task was never dispatched to the parent's local fallback backend.
+        parent_service._controller.provider.get_process_status.assert_not_called()
+        # The peer resolved the task under the same, cluster-invariant job id.
+        (call,) = peer_service._controller.provider.get_process_status.call_args_list
+        assert call.args[0].task_id == job_id.task(0).to_wire()
 
 
 def test_exec_forwards_a_task_id_whose_job_name_contains_a_colon(tmp_path, log_client):

--- a/lib/iris/tests/cluster/controller/test_federation_exec_proxy.py
+++ b/lib/iris/tests/cluster/controller/test_federation_exec_proxy.py
@@ -22,6 +22,7 @@ from iris.cluster.bundle import BundleStore
 from iris.cluster.config import PeerConfig
 from iris.cluster.constraints import CLUSTER_CONSTRAINT_KEY, Constraint, ConstraintOp
 from iris.cluster.controller import reads, writes
+from iris.cluster.controller.auth import ControllerAuth
 from iris.cluster.controller.endpoint_service import EndpointServiceImpl
 from iris.cluster.controller.federation_store import ControllerFederationStore
 from iris.cluster.controller.service import ControllerServiceImpl
@@ -30,6 +31,7 @@ from iris.cluster.federation.peer import FederationPeer
 from iris.cluster.types import JobName
 from iris.managed_thread import get_thread_container
 from iris.rpc import controller_pb2, job_pb2, worker_pb2
+from iris.rpc.auth import FEDERATION_PEER_ROLE
 from rigging.server_auth import VerifiedIdentity, identity_scope
 
 from ._test_support import ControllerTestState
@@ -269,6 +271,46 @@ def test_process_status_against_a_federated_task_runs_on_the_peer(tmp_path, log_
         # The peer resolved the task under the same, cluster-invariant job id.
         (call,) = peer_service._controller.provider.get_process_status.call_args_list
         assert call.args[0].task_id == job_id.task(0).to_wire()
+
+
+def test_process_status_scopes_a_federated_peer_to_the_jobs_it_handed_off(tmp_path, log_client):
+    """Under enforced federation auth, the proxied debug RPC lands on the peer carrying a
+    federation-peer bearer — not the admin identity the other tests assert under. The peer
+    runs it only for a job that peer actually federated here (its received handle); a peer
+    that never handed the job off is denied before any backend call."""
+    with ExitStack() as stack:
+        parent_service, parent_state = _make_service(stack, "parent", tmp_path, log_client)
+        peer_service, peer_state = _make_service(stack, "peer", tmp_path, log_client)
+        manager = _attach_federation(parent_service, _ProxyPeerConnection(peer_service))
+        job_id = _handoff_and_mirror_running_task(parent_service, parent_state, peer_state, manager)
+
+        # An auth-enforcing view of the peer over the same state. The handoff above ran
+        # through the null-auth service (scoping skipped); this one activates it.
+        enforcing_peer = ControllerServiceImpl(
+            controller=peer_service._controller,
+            bundle_store=BundleStore(storage_dir=str(tmp_path / "peer" / "bundles")),
+            log_client=log_client,
+            db=peer_state._db,
+            endpoint_service=peer_service._endpoint_service,
+            auth=ControllerAuth(provider="iap"),
+        )
+        peer_service._controller.provider.get_process_status.return_value = job_pb2.GetProcessStatusResponse(
+            process_info=job_pb2.ProcessInfo(pid=1, thread_count=7)
+        )
+        request = job_pb2.GetProcessStatusRequest(target=job_id.task(0).to_wire())
+
+        # "parent" is the requester on the received handle — it may read the task.
+        with identity_scope(VerifiedIdentity(user_id="parent", role=FEDERATION_PEER_ROLE)):
+            resp = enforcing_peer.get_process_status(request, None)
+        assert resp.process_info.thread_count == 7
+
+        # A different peer never federated this job here — PERMISSION_DENIED, no backend call.
+        peer_service._controller.provider.get_process_status.reset_mock()
+        with identity_scope(VerifiedIdentity(user_id="intruder", role=FEDERATION_PEER_ROLE)):
+            with pytest.raises(ConnectError) as exc:
+                enforcing_peer.get_process_status(request, None)
+        assert exc.value.code == Code.PERMISSION_DENIED
+        peer_service._controller.provider.get_process_status.assert_not_called()
 
 
 def test_exec_forwards_a_task_id_whose_job_name_contains_a_colon(tmp_path, log_client):

--- a/lib/iris/tests/rpc/test_auth.py
+++ b/lib/iris/tests/rpc/test_auth.py
@@ -16,6 +16,7 @@ from iris.rpc.auth import (
     DASHBOARD_ROLE,
     FEDERATION_PEER_ROLE,
     FEDERATION_RPCS,
+    FEDERATION_SCOPED_RPCS,
     AuthzAction,
     authorize,
     authorize_method,
@@ -78,11 +79,20 @@ def test_authorize_method_allows_federation_rpcs_for_a_peer(method):
     authorize_method(VerifiedIdentity("peer-cluster", FEDERATION_PEER_ROLE), method)
 
 
-@pytest.mark.parametrize("method", ["ProfileTask", "ExecInContainer", "SetUserBudget", "ListJobs", "GetJobStatus"])
+@pytest.mark.parametrize("method", sorted(FEDERATION_SCOPED_RPCS))
+def test_authorize_method_allows_scoped_debug_rpcs_for_a_peer(method):
+    # The on-demand debug proxies are admitted at the method gate; the handler then
+    # scopes each to a job the peer federated here (see the controller service's
+    # _authorize_federated_debug_target). Without this, a proxied stack/exec/status
+    # for a federated task is rejected before the peer can route it.
+    authorize_method(VerifiedIdentity("peer-cluster", FEDERATION_PEER_ROLE), method)
+
+
+@pytest.mark.parametrize("method", ["SetUserBudget", "ListJobs", "GetJobStatus", "ExecuteRawQuery"])
 def test_authorize_method_denies_non_federation_rpcs_for_a_peer(method):
     # A federation bearer accepted by the composite verifier cannot reach any RPC
-    # outside the federation subset — including the exec/profile proxies deferred
-    # from v1 and every read the dashboard role would be allowed.
+    # outside the federation subset and the scoped debug proxies — including every
+    # read the dashboard role would be allowed.
     with pytest.raises(ConnectError) as exc:
         authorize_method(VerifiedIdentity("peer-cluster", FEDERATION_PEER_ROLE), method)
     assert exc.value.code == Code.PERMISSION_DENIED


### PR DESCRIPTION
Debugging a job that runs entirely on a federated peer (CoreWeave/K8s) should not
require SSHing into the peer's worker. ProfileTask and ExecInContainer already
forwarded to the owning peer, but each was hand-wired through four passthrough
layers, and GetProcessStatus had no federated or task path and was unsupported on
the K8s backend.

Collapse the per-RPC boilerplate into one seam. `FederationManager.proxy_to_peer`
forwards a call to the owning peer, and `ControllerServiceImpl._proxy_if_federated`
resolves the federated handle and dispatches, or returns None for a local task.
ProfileTask and ExecInContainer move onto it with no behavior change. A new proxied
debug RPC is now one typed `FederationPeer` method plus a three-line guard in the
handler.

Give GetProcessStatus a `/job/.../task/N` target routed through the same seam, and
implement it on the K8s backend the way profiling reaches the pod: kubectl exec into
the task container and read PID 1's /proc vitals (rss/vms, thread and fd counts, cpu
millicores from two samples, uptime) into ProcessInfo. Daemon-only fields
(python_version, build provenance) have no pod equivalent and stay unset. So
`iris process status -t /job/.../task/N` now works for local and federated K8s
tasks. Stacks remain a ProfileTask(threads) dump, which already proxies.

Cross-cluster profile-history relay is deliberately left out: periodic profile blobs
on the peer's finelog are large and relaying them would run continuously across
regions. The on-demand proxy fetches only when a human asks.

Part of #7344.