### PR TITLE
[grafana] Note the retained github-token secret after status-page teardown

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -140,8 +140,10 @@ i.e. reachable by nobody until the first grant.
 
 The ferry and build panels read the GitHub API; `GITHUB_TOKEN` comes from the
 `marin-status-page-github-token` Secret Manager secret, mounted by the CloudRunService
-`secrets` field (the value never enters Pulumi). Create it once if it does not exist — a
-classic token with no scopes or a fine-grained PAT scoped to public-repo read is enough:
+`secrets` field (the value never enters Pulumi). The name is a holdover from the retired
+`marin-infra-dashboard` status page; Grafana is now its only consumer, so keep it despite
+the name. Create it once if it does not exist — a classic token with no scopes or a
+fine-grained PAT scoped to public-repo read is enough:
 
 ```bash
 echo -n "<paste-github-token>" | gcloud secrets create marin-status-page-github-token \


### PR DESCRIPTION
infra/status-page was replaced by the Grafana Cloud Run service and removed in #7341. That page was deployed with plain `gcloud run deploy --source`, not Pulumi, so its live GCP resources had no stack to destroy and were torn down by hand in `hai-gcp-models`: the `marin-infra-dashboard` Cloud Run service (us-central1), the `marin-status-page@` service account together with its two project IAM bindings (`roles/compute.viewer`, `roles/secretmanager.secretAccessor`), and the retired `marin-infra-dashboard`/`marin-status-page` images in the `cloud-run-source-deploy` Artifact Registry repo.

The `marin-status-page-github-token` secret is deliberately left in place because Grafana mounts it as `GITHUB_TOKEN`. This adds a one-line README note recording that, so its legacy name does not later invite deletion.