### PR TITLE
[iac] Gate pulumi behind a marin-iac[deploy] extra

### DIFF
--- a/.github/actions/pulumi-deploy/action.yaml
+++ b/.github/actions/pulumi-deploy/action.yaml
@@ -42,7 +42,7 @@ runs:
 
     - name: Sync the iac venv
       shell: bash
-      run: uv sync --package marin-iac --frozen
+      run: uv sync --package marin-iac --extra deploy --frozen
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -110,7 +110,7 @@ and its image build come from the reusable `iac.gcp.cloud_run.CloudRunService` c
 and shares `infra/iac`'s state backend.
 
 ```bash
-uv sync --all-packages                                    # once: iac + Pulumi providers on the venv
+uv sync --all-packages --extra deploy                     # once: iac + Pulumi providers on the venv (pulumi lives behind marin-iac[deploy])
 gcloud auth configure-docker us-central1-docker.pkg.dev   # once: let buildx push to Artifact Registry
 
 cd infra/grafana

--- a/infra/iac/README.md
+++ b/infra/iac/README.md
@@ -35,10 +35,11 @@ new `provisioning:` section in that same file. Iris carries `provisioning:` as a
 - The [Pulumi CLI](https://www.pulumi.com/docs/install/) (`brew install pulumi/tap/pulumi`).
 - The repo's uv venv, synced so `iris`, `rigging`, `pulumi`, `pulumi_kubernetes` all import.
 `marin-iac` is a member of the root uv workspace, so its deps live in the shared repo
-`.venv`. Sync the **whole** workspace — a bare `uv sync` from a member dir prunes the venv
-to just that member, so use `--all-packages`:
+`.venv`. The pulumi SDK sits behind the package's `deploy` extra (it is deploy-only
+tooling, kept out of the plain workspace sync so Iris job venvs don't pull the pulumi
+providers), so pass `--extra deploy` when preparing a preview/up:
   ```bash
-  uv sync --all-packages    # run from the repo root or anywhere in the tree
+  uv sync --all-packages --extra deploy    # run from the repo root or anywhere in the tree
   ```
 - For the k8s dry-run: the CoreWeave kubeconfig at the path in the cluster's
 `platform.coreweave.kubeconfig_path` (read access to the live cluster).

--- a/infra/iac/pyproject.toml
+++ b/infra/iac/pyproject.toml
@@ -8,13 +8,22 @@ version = "0.0.0"
 description = "Infrastructure-as-code for Marin clusters."
 requires-python = ">=3.12"
 dependencies = [
+    "marin-iris",
+    "marin-rigging",
+]
+
+# The pulumi SDK is only imported when running the IaC program itself (pulumi
+# preview/up, the grafana Cloud Run deploy, and the iac tests); no Iris/Marin
+# runtime code touches it. Gating it behind the `deploy` extra keeps the
+# workspace-wide `uv sync --all-packages` that provisions every Iris job venv
+# from pulling the pulumi providers into jobs that never deploy.
+[project.optional-dependencies]
+deploy = [
     "pulumi>=3.140,<4",
     "pulumi-kubernetes>=4.18,<5",
     "pulumi-gcp>=9,<10",
     "pulumi-docker-build>=0.0.8,<1",
     "pulumi-cloudflare>=6,<7",
-    "marin-iris",
-    "marin-rigging",
 ]
 
 # marin-iris / marin-rigging resolve via the root workspace [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -4908,6 +4908,10 @@ source = { editable = "infra/iac" }
 dependencies = [
     { name = "marin-iris" },
     { name = "marin-rigging" },
+]
+
+[package.optional-dependencies]
+deploy = [
     { name = "pulumi" },
     { name = "pulumi-cloudflare" },
     { name = "pulumi-docker-build" },
@@ -4919,12 +4923,13 @@ dependencies = [
 requires-dist = [
     { name = "marin-iris", editable = "lib/iris" },
     { name = "marin-rigging", editable = "lib/rigging" },
-    { name = "pulumi", specifier = ">=3.140,<4" },
-    { name = "pulumi-cloudflare", specifier = ">=6,<7" },
-    { name = "pulumi-docker-build", specifier = ">=0.0.8,<1" },
-    { name = "pulumi-gcp", specifier = ">=9,<10" },
-    { name = "pulumi-kubernetes", specifier = ">=4.18,<5" },
+    { name = "pulumi", marker = "extra == 'deploy'", specifier = ">=3.140,<4" },
+    { name = "pulumi-cloudflare", marker = "extra == 'deploy'", specifier = ">=6,<7" },
+    { name = "pulumi-docker-build", marker = "extra == 'deploy'", specifier = ">=0.0.8,<1" },
+    { name = "pulumi-gcp", marker = "extra == 'deploy'", specifier = ">=9,<10" },
+    { name = "pulumi-kubernetes", marker = "extra == 'deploy'", specifier = ">=4.18,<5" },
 ]
+provides-extras = ["deploy"]
 
 [[package]]
 name = "marin-iris"


### PR DESCRIPTION
Every Iris job venv is provisioned with `uv sync --all-packages`, which builds every workspace member — including marin-iac, whose pulumi provider SDKs (pulumi, pulumi-gcp, pulumi-kubernetes, pulumi-cloudflare, pulumi-docker-build) were base dependencies. That dragged the whole pulumi stack into unrelated jobs such as model training, where nothing needs it.

No Iris/Marin runtime code imports pulumi — it is touched only by the IaC program itself (`infra/iac/__main__.py`), the grafana Cloud Run deploy (`infra/grafana/__main__.py`), and the iac tests. Move the pulumi dependencies into a `deploy` extra so the workspace-wide sync installs a trivial marin-iac and skips pulumi, while deploy paths request `--extra deploy`.

The shared `pulumi-deploy` action now syncs `--package marin-iac --extra deploy` (used by grafana), and the iac README documents the extra. With the change, `uv sync --all-packages --extra tpu` resolves zero pulumi packages; `uv sync --package marin-iac --extra deploy` restores all five providers.