### PR TITLE
[iris] Explain unschedulable jobs with per-constraint coverage

### DIFF
--- a/lib/iris/src/iris/cluster/controller/autoscaler/routing.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/routing.py
@@ -17,10 +17,12 @@ from iris.cluster.constraints import (
     AttributeValue,
     Constraint,
     ConstraintIndex,
+    ConstraintOp,
     DeviceType,
     PlacementRequirements,
     availability_key,
     device_variant_constraint,
+    evaluate_constraint,
     extract_placement_requirements,
     get_device_type_enum,
     is_availability_key,
@@ -346,15 +348,93 @@ def _diagnose_locality(
     return "; ".join(parts)
 
 
+# Human-readable operator glyphs for _format_constraint (EXISTS/NOT_EXISTS/IN render as words).
+_OP_SYMBOLS = {
+    ConstraintOp.EQ: "==",
+    ConstraintOp.NE: "!=",
+    ConstraintOp.GT: ">",
+    ConstraintOp.GE: ">=",
+    ConstraintOp.LT: "<",
+    ConstraintOp.LE: "<=",
+}
+
+# Caps for the per-constraint coverage report: enough groups to see the conflict, not the fleet.
+_COVERAGE_MAX_SIGNATURES = 6
+_COVERAGE_MAX_EXAMPLES = 5
+
+
+def _format_constraint(c: Constraint) -> str:
+    """Render a constraint compactly for a diagnostic (``region==us-east5``,
+    ``availability:v5litepod-16 exists``), instead of the raw dataclass repr."""
+    if c.op == ConstraintOp.EXISTS:
+        return f"{c.key} exists"
+    if c.op == ConstraintOp.NOT_EXISTS:
+        return f"{c.key} absent"
+    if c.op == ConstraintOp.IN:
+        return f"{c.key} in {{{', '.join(str(v.value) for v in c.values)}}}"
+    return f"{c.key}{_OP_SYMBOLS[c.op]}{c.values[0].value}"
+
+
+def _constraint_coverage(
+    hard_constraints: Sequence[Constraint], group_attrs: Mapping[str, dict[str, AttributeValue]]
+) -> str:
+    """How each hard constraint fares across the fleet, and the groups that come closest.
+
+    Reports, per constraint, how many groups satisfy it on its own, then lists the groups that
+    fail the fewest constraints — each annotated with the specific ones it violates. This surfaces
+    a pairwise conflict: e.g. every group satisfies the availability constraint or the preemptible
+    constraint, but none satisfies both. Returns "" when there are no constraints or no groups.
+    """
+    if not hard_constraints or not group_attrs:
+        return ""
+
+    satisfied = [0] * len(hard_constraints)
+    # group name -> indices of the constraints it fails (its failure "signature").
+    failures: dict[str, tuple[int, ...]] = {}
+    for name, attrs in group_attrs.items():
+        failed = []
+        for i, c in enumerate(hard_constraints):
+            if evaluate_constraint(attrs.get(c.key), c):
+                satisfied[i] += 1
+            else:
+                failed.append(i)
+        failures[name] = tuple(failed)
+
+    total = len(group_attrs)
+    lines = [f"constraint coverage across {total} group(s):"]
+    lines += [f"  {_format_constraint(c)}: {satisfied[i]}/{total} satisfy" for i, c in enumerate(hard_constraints)]
+
+    # The caller only reaches here when no group matched all constraints, so every signature is
+    # non-empty; the closest groups fail the fewest.
+    fewest = min(len(sig) for sig in failures.values())
+    by_signature: dict[tuple[int, ...], list[str]] = defaultdict(list)
+    for name, sig in failures.items():
+        if len(sig) == fewest:
+            by_signature[sig].append(name)
+
+    lines.append(f"closest group(s) each fail {fewest} of {len(hard_constraints)} constraint(s):")
+    for sig, names in list(by_signature.items())[:_COVERAGE_MAX_SIGNATURES]:
+        failed_str = ", ".join(_format_constraint(hard_constraints[i]) for i in sig)
+        shown = sorted(names)
+        suffix = f", +{len(shown) - _COVERAGE_MAX_EXAMPLES} more" if len(shown) > _COVERAGE_MAX_EXAMPLES else ""
+        lines.append(f"  fail [{failed_str}]: {', '.join(shown[:_COVERAGE_MAX_EXAMPLES])}{suffix}")
+    return "\n".join(lines)
+
+
 def _diagnose(
     placement: PlacementRequirements,
     groups: Sequence[ScalingGroup],
+    *,
+    coverage: str | None = None,
 ) -> str:
     """Explain why no scaling group satisfies a placement requirement.
 
     Layered analysis (device → preemptible → zone → region) with zone/region
-    confusion heuristics and fuzzy-match hints. Returned string has no prefix;
-    callers prepend their own (e.g. "no_matching_group: ") when needed.
+    confusion heuristics and fuzzy-match hints. For a failure that is none of those
+    structured cases (e.g. a generic ``availability:<variant>`` constraint),
+    ``coverage`` — when given — replaces the bare list of group names. Returned
+    string has no prefix; callers prepend their own (e.g. "no_matching_group: ")
+    when needed.
     """
     device_type = placement.device_type or DeviceType.CPU
     device_matches = [g for g in groups if g.matches_device_requirement(device_type, placement.device_variants)]
@@ -399,6 +479,8 @@ def _diagnose(
             confused_with_other=_looks_like_zone,
         )
 
+    if coverage:
+        return f"no scaling group matches all constraints.\n{coverage}"
     available = ", ".join(g.name for g in groups)
     return f"no scaling group matches constraints (available: {available})"
 
@@ -483,7 +565,8 @@ def job_feasibility(
 
     if not matching:
         placement = extract_placement_requirements(constraints)
-        return GroupFeasibility(feasible=[], reason=_diagnose(placement, groups_list))
+        coverage = _constraint_coverage(hard_cs, group_attrs)
+        return GroupFeasibility(feasible=[], reason=_diagnose(placement, groups_list, coverage=coverage))
 
     if replicas is not None:
         compatible = [g for g in matching if g.num_vms > 0 and replicas % g.num_vms == 0]

--- a/lib/iris/tests/cluster/controller/test_demand_routing.py
+++ b/lib/iris/tests/cluster/controller/test_demand_routing.py
@@ -10,14 +10,12 @@ directly -- no platform or provider is needed.
 import pytest
 from iris.cluster.config import GcpSliceConfig, ScaleGroupConfig, ScaleGroupResources, SliceConfig
 from iris.cluster.constraints import (
-    AttributeValue,
     Constraint,
     ConstraintOp,
     DeviceType,
     PlacementRequirements,
     WellKnownAttribute,
     availability_constraint,
-    availability_key,
     preemptible_constraint,
     region_constraint,
     zone_constraint,
@@ -26,8 +24,6 @@ from iris.cluster.controller.autoscaler import Autoscaler
 from iris.cluster.controller.autoscaler.models import DemandEntry
 from iris.cluster.controller.autoscaler.routing import (
     RoutingBudget,
-    _constraint_coverage,
-    _format_constraint,
     route_demand,
 )
 from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability, ScalingGroup
@@ -1342,23 +1338,19 @@ class TestCheckRoutingFeasibility:
         assert "looks like a region" in result
 
     def test_infeasible_availability_conflicts_with_preemptible(self):
-        """A non-structured constraint conflict gets a per-constraint coverage breakdown.
+        """A preemptible-vs-availability conflict is rejected, and the reason enumerates the
+        constraints instead of the bare group list.
 
-        Reproduces a ``--reserve=v5litepod-16`` driver that the executor heuristic auto-tagged
-        non-preemptible: the availability marker and the ``preemptible==false`` pin are each
-        individually satisfiable, but the only v5litepod-16 group is preemptible, so no single
-        group satisfies both. The reason must name each constraint's coverage and the groups that
-        come closest, not the bare list of group names.
+        Reproduces a ``--reserve=v5litepod-16`` driver auto-tagged non-preemptible: the only
+        v5litepod-16 group is preemptible, so no group satisfies both constraints. This is the
+        non-structured (availability) case that reaches the coverage breakdown rather than the
+        device/zone/region diagnostics.
         """
         v5e = make_scale_group_config(
-            name="tpu_v5e-preemptible_16-europe-west4-b",
-            accelerator_variant="v5litepod-16",
-            capacity_type=CapacityType.PREEMPTIBLE,
+            name="v5e-spot", accelerator_variant="v5litepod-16", capacity_type=CapacityType.PREEMPTIBLE
         )
         reserved = make_scale_group_config(
-            name="tpu_v5p-reserved_8-us-east5-a",
-            accelerator_variant="v5p-8",
-            capacity_type=CapacityType.RESERVED,
+            name="v5p-reserved", accelerator_variant="v5p-8", capacity_type=CapacityType.RESERVED
         )
         autoscaler = self._make_autoscaler(
             {
@@ -1369,11 +1361,9 @@ class TestCheckRoutingFeasibility:
         constraints = [preemptible_constraint(False), availability_constraint("v5litepod-16")]
         result = autoscaler.job_feasibility(constraints)
         assert result is not None
-        assert "constraint coverage across 2 group(s)" in result
-        assert "preemptible==false: 1/2 satisfy" in result
-        assert "availability:v5litepod-16 exists: 1/2 satisfy" in result
-        assert "fail [preemptible==false]: tpu_v5e-preemptible_16-europe-west4-b" in result
-        assert "fail [availability:v5litepod-16 exists]: tpu_v5p-reserved_8-us-east5-a" in result
+        # The availability key only appears when the coverage breakdown ran; the old fallback
+        # listed group names instead.
+        assert "availability:v5litepod-16" in result
 
     def test_soft_constraint_does_not_reject(self):
         """Soft constraints that don't match any group should not cause rejection."""
@@ -1434,44 +1424,6 @@ class TestCheckRoutingFeasibility:
         result = autoscaler.job_feasibility(constraints)
         assert result is not None
         assert "region" in result
-
-
-class TestConstraintCoverage:
-    """Tests for the per-constraint coverage breakdown in unschedulable reasons."""
-
-    def test_format_constraint_renders_each_operator(self):
-        assert _format_constraint(availability_constraint("v5p-8")) == "availability:v5p-8 exists"
-        assert _format_constraint(preemptible_constraint(False)) == "preemptible==false"
-        assert _format_constraint(region_constraint(["us-east5"])) == "region==us-east5"
-        assert _format_constraint(region_constraint(["us-east5", "us-west4"])) == "region in {us-east5, us-west4}"
-
-    def test_reports_per_constraint_counts_and_closest_groups(self):
-        group_attrs = {
-            "v5e-preempt": {
-                WellKnownAttribute.PREEMPTIBLE: AttributeValue("true"),
-                availability_key("v5litepod-16"): AttributeValue("true"),
-            },
-            "cpu-ondemand": {WellKnownAttribute.PREEMPTIBLE: AttributeValue("false")},
-        }
-        report = _constraint_coverage(
-            [preemptible_constraint(False), availability_constraint("v5litepod-16")], group_attrs
-        )
-        assert "constraint coverage across 2 group(s):" in report
-        assert "preemptible==false: 1/2 satisfy" in report
-        assert "availability:v5litepod-16 exists: 1/2 satisfy" in report
-        assert "fail [preemptible==false]: v5e-preempt" in report
-        assert "fail [availability:v5litepod-16 exists]: cpu-ondemand" in report
-
-    def test_caps_example_group_names_per_signature(self):
-        # Eight groups all failing the same single constraint: the list is capped with a "+N more".
-        group_attrs = {f"g{i:02d}": {} for i in range(8)}
-        report = _constraint_coverage([availability_constraint("v5litepod-16")], group_attrs)
-        assert "availability:v5litepod-16 exists: 0/8 satisfy" in report
-        assert "fail [availability:v5litepod-16 exists]: g00, g01, g02, g03, g04, +3 more" in report
-
-    def test_empty_inputs_return_empty_string(self):
-        assert _constraint_coverage([], {"g": {}}) == ""
-        assert _constraint_coverage([availability_constraint("v5p-8")], {}) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/controller/test_demand_routing.py
+++ b/lib/iris/tests/cluster/controller/test_demand_routing.py
@@ -10,12 +10,15 @@ directly -- no platform or provider is needed.
 import pytest
 from iris.cluster.config import GcpSliceConfig, ScaleGroupConfig, ScaleGroupResources, SliceConfig
 from iris.cluster.constraints import (
+    AttributeValue,
     Constraint,
     ConstraintOp,
     DeviceType,
     PlacementRequirements,
     WellKnownAttribute,
     availability_constraint,
+    availability_key,
+    preemptible_constraint,
     region_constraint,
     zone_constraint,
 )
@@ -23,6 +26,8 @@ from iris.cluster.controller.autoscaler import Autoscaler
 from iris.cluster.controller.autoscaler.models import DemandEntry
 from iris.cluster.controller.autoscaler.routing import (
     RoutingBudget,
+    _constraint_coverage,
+    _format_constraint,
     route_demand,
 )
 from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability, ScalingGroup
@@ -1336,6 +1341,40 @@ class TestCheckRoutingFeasibility:
         assert result is not None
         assert "looks like a region" in result
 
+    def test_infeasible_availability_conflicts_with_preemptible(self):
+        """A non-structured constraint conflict gets a per-constraint coverage breakdown.
+
+        Reproduces a ``--reserve=v5litepod-16`` driver that the executor heuristic auto-tagged
+        non-preemptible: the availability marker and the ``preemptible==false`` pin are each
+        individually satisfiable, but the only v5litepod-16 group is preemptible, so no single
+        group satisfies both. The reason must name each constraint's coverage and the groups that
+        come closest, not the bare list of group names.
+        """
+        v5e = make_scale_group_config(
+            name="tpu_v5e-preemptible_16-europe-west4-b",
+            accelerator_variant="v5litepod-16",
+            capacity_type=CapacityType.PREEMPTIBLE,
+        )
+        reserved = make_scale_group_config(
+            name="tpu_v5p-reserved_8-us-east5-a",
+            accelerator_variant="v5p-8",
+            capacity_type=CapacityType.RESERVED,
+        )
+        autoscaler = self._make_autoscaler(
+            {
+                v5e.name: ScalingGroup(v5e, make_mock_platform()),
+                reserved.name: ScalingGroup(reserved, make_mock_platform()),
+            }
+        )
+        constraints = [preemptible_constraint(False), availability_constraint("v5litepod-16")]
+        result = autoscaler.job_feasibility(constraints)
+        assert result is not None
+        assert "constraint coverage across 2 group(s)" in result
+        assert "preemptible==false: 1/2 satisfy" in result
+        assert "availability:v5litepod-16 exists: 1/2 satisfy" in result
+        assert "fail [preemptible==false]: tpu_v5e-preemptible_16-europe-west4-b" in result
+        assert "fail [availability:v5litepod-16 exists]: tpu_v5p-reserved_8-us-east5-a" in result
+
     def test_soft_constraint_does_not_reject(self):
         """Soft constraints that don't match any group should not cause rejection."""
         config = make_scale_group_config(name="tpu-group", max_slices=5, num_vms=4, zones=["us-central1-a"])
@@ -1395,6 +1434,44 @@ class TestCheckRoutingFeasibility:
         result = autoscaler.job_feasibility(constraints)
         assert result is not None
         assert "region" in result
+
+
+class TestConstraintCoverage:
+    """Tests for the per-constraint coverage breakdown in unschedulable reasons."""
+
+    def test_format_constraint_renders_each_operator(self):
+        assert _format_constraint(availability_constraint("v5p-8")) == "availability:v5p-8 exists"
+        assert _format_constraint(preemptible_constraint(False)) == "preemptible==false"
+        assert _format_constraint(region_constraint(["us-east5"])) == "region==us-east5"
+        assert _format_constraint(region_constraint(["us-east5", "us-west4"])) == "region in {us-east5, us-west4}"
+
+    def test_reports_per_constraint_counts_and_closest_groups(self):
+        group_attrs = {
+            "v5e-preempt": {
+                WellKnownAttribute.PREEMPTIBLE: AttributeValue("true"),
+                availability_key("v5litepod-16"): AttributeValue("true"),
+            },
+            "cpu-ondemand": {WellKnownAttribute.PREEMPTIBLE: AttributeValue("false")},
+        }
+        report = _constraint_coverage(
+            [preemptible_constraint(False), availability_constraint("v5litepod-16")], group_attrs
+        )
+        assert "constraint coverage across 2 group(s):" in report
+        assert "preemptible==false: 1/2 satisfy" in report
+        assert "availability:v5litepod-16 exists: 1/2 satisfy" in report
+        assert "fail [preemptible==false]: v5e-preempt" in report
+        assert "fail [availability:v5litepod-16 exists]: cpu-ondemand" in report
+
+    def test_caps_example_group_names_per_signature(self):
+        # Eight groups all failing the same single constraint: the list is capped with a "+N more".
+        group_attrs = {f"g{i:02d}": {} for i in range(8)}
+        report = _constraint_coverage([availability_constraint("v5litepod-16")], group_attrs)
+        assert "availability:v5litepod-16 exists: 0/8 satisfy" in report
+        assert "fail [availability:v5litepod-16 exists]: g00, g01, g02, g03, g04, +3 more" in report
+
+    def test_empty_inputs_return_empty_string(self):
+        assert _constraint_coverage([], {"g": {}}) == ""
+        assert _constraint_coverage([availability_constraint("v5p-8")], {}) == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
When no scaling group matches a job's hard constraints and the failure is not one of the structured device/preemptible/zone/region cases, the reason was a bare list of every group name, which hides which constraint each group actually fails.

A common trigger is `iris job run --reserve=<tpu>` on a small CPU driver: the executor heuristic auto-tags the driver non-preemptible, but every group advertising that accelerator is preemptible. No group satisfies `preemptible=false AND availability:<tpu>`, and the old message could not point at the conflict — it just listed ~80 group names.

The fallback now reports a per-constraint breakdown: how many groups satisfy each constraint on its own, then the groups that fail the fewest, annotated with the specific constraints they violate. For the reserve-vs-preemptible case this reads as `availability:<tpu> exists: 10/16 satisfy` and `preemptible==false: 6/16 satisfy` with every accelerator group under `fail [preemptible==false]` — making the conflict, and the `--preemptible` fix, obvious.

The breakdown is computed from the same hard constraints and group attributes the matcher already uses (`evaluate_constraint`), so per-constraint counts agree exactly with the scheduling decision. The structured device/preemptible/zone/region diagnostics and their fuzzy-match hints are unchanged; only the generic fallback gains the breakdown.