### PR TITLE
[finelog] Drop a missing compaction input instead of wedging on rename

### DIFF
--- a/lib/finelog/rust/src/store/compaction/executor.rs
+++ b/lib/finelog/rust/src/store/compaction/executor.rs
@@ -51,7 +51,9 @@ fn now_ms() -> i64 {
 /// `removed` are the input segment paths to splice out — the prefix of the job's
 /// inputs that fit the merge memory ceiling, which may be shorter than the job.
 /// `added` is the single output segment (its file already exists for a merge;
-/// for a bump the file appears only after `bump_rename` runs in the commit).
+/// for a bump the file appears only after `bump_rename` runs in the commit). It
+/// is `None` only when the job's head input file is gone, so the swap drops that
+/// dangling reference and produces no replacement.
 /// `unlink_removed` is `false` for a level bump (the input file was renamed, so
 /// its old path is already gone after `bump_rename`) and `true` for a merge (the
 /// inputs are still on disk). `bump_rename`, when `Some((from, to))`, is the
@@ -62,7 +64,7 @@ fn now_ms() -> i64 {
 #[derive(Debug, Clone)]
 pub struct PlannedSwap {
     pub removed: Vec<String>,
-    pub added: LocalSegment,
+    pub added: Option<LocalSegment>,
     pub unlink_removed: bool,
     pub bump_rename: Option<(PathBuf, PathBuf)>,
     pub input_arrow_bytes: i64,
@@ -132,11 +134,30 @@ fn apply_level_bump(
     };
     Ok(PlannedSwap {
         removed: vec![old.path.clone()],
-        added: bumped,
+        added: Some(bumped),
         unlink_removed: false,
         bump_rename: Some((PathBuf::from(&old.path), new_path)),
         input_arrow_bytes: 0,
     })
+}
+
+/// Drop a dangling input whose file has vanished: splice its stale reference out
+/// of the deque + catalog and produce no replacement.
+///
+/// A missing file carries no recoverable rows and cannot be renamed, so promoting
+/// it past the merge (`apply_level_bump`) would emit a rename that fails on the
+/// absent source every tick, wedging the level for good. The rows are either
+/// already durable in the output of an earlier merge that unlinked this input, or
+/// were lost with the file itself — dropping the reference loses nothing either
+/// way and lets compaction resume.
+fn drop_missing_input(missing: &SegmentRow) -> PlannedSwap {
+    PlannedSwap {
+        removed: vec![missing.path.clone()],
+        added: None,
+        unlink_removed: false,
+        bump_rename: None,
+        input_arrow_bytes: 0,
+    }
 }
 
 /// Multi-input merge: read inputs, project, k-way merge, write the output file,
@@ -190,22 +211,39 @@ fn apply_merge(
     for inp in &job.inputs {
         // An input we cannot read is one we can never merge, and failing the tick
         // would replan the identical job every check_interval and wedge the level
-        // for good. Route around it instead: as the run's head it is promoted by
-        // rename (the branch below), and otherwise it ends the prefix and becomes
-        // the next tick's head. Either way it moves and compaction stays live.
-        // Only the READ is forgiven — a projection or sort failure is a schema bug
-        // and still propagates.
+        // for good. Route around it instead so compaction stays live. As a non-head
+        // input it ends the prefix and becomes the next tick's head. As the run's
+        // head, the recovery depends on WHY the read failed: a file that is present
+        // but corrupt still has a real path to rename, so it is promoted past the
+        // merge by level bump; a file that is simply gone (a dangling deque/catalog
+        // reference to a segment an earlier merge already consumed and unlinked) has
+        // nothing to rename, so a bump would fail on the absent source every tick —
+        // its stale reference is dropped instead. Only the READ is forgiven — a
+        // projection or sort failure is a schema bug and still propagates.
         let raw = match read_segment_batches(Path::new(&inp.path)) {
             Ok(raw) => raw,
             Err(e) => {
+                if consumed.is_empty() {
+                    if Path::new(&inp.path).exists() {
+                        tracing::warn!(
+                            path = %inp.path,
+                            error = %e,
+                            "unreadable merge input; promoting it past the merge"
+                        );
+                        return apply_level_bump(inp, job.output_level, dir, input_key_bounds);
+                    }
+                    tracing::warn!(
+                        path = %inp.path,
+                        error = %e,
+                        "merge input file missing; dropping the stale segment reference"
+                    );
+                    return Ok(drop_missing_input(inp));
+                }
                 tracing::warn!(
                     path = %inp.path,
                     error = %e,
-                    "unreadable merge input; promoting it past the merge"
+                    "unreadable merge input; deferring it to the next tick"
                 );
-                if consumed.is_empty() {
-                    return apply_level_bump(inp, job.output_level, dir, input_key_bounds);
-                }
                 break;
             }
         };
@@ -299,7 +337,7 @@ fn apply_merge(
     };
     Ok(PlannedSwap {
         removed: consumed.iter().map(|s| s.path.clone()).collect(),
-        added: merged_seg,
+        added: Some(merged_seg),
         unlink_removed: true,
         bump_rename: None,
         input_arrow_bytes,
@@ -400,6 +438,14 @@ mod tests {
         .unwrap()
     }
 
+    /// Unwrap the output segment of a swap that is expected to produce one (every
+    /// merge/bump; a drop returns `None`).
+    fn added_seg(swap: &PlannedSwap) -> &LocalSegment {
+        swap.added
+            .as_ref()
+            .expect("swap produced an output segment")
+    }
+
     fn row_for(path: &str, level: i32, min_seq: i64, max_seq: i64, byte_size: i64) -> SegmentRow {
         SegmentRow {
             namespace: "ns".to_string(),
@@ -449,16 +495,16 @@ mod tests {
         assert!(swap.bump_rename.is_none());
         assert!(swap.unlink_removed);
         assert_eq!(swap.removed.len(), 3);
-        assert_eq!(swap.added.level, 1);
-        assert_eq!(swap.added.row_count, 6);
-        assert_eq!(swap.added.min_seq, 1);
-        assert_eq!(swap.added.max_seq, 6);
+        assert_eq!(added_seg(&swap).level, 1);
+        assert_eq!(added_seg(&swap).row_count, 6);
+        assert_eq!(added_seg(&swap).min_seq, 1);
+        assert_eq!(added_seg(&swap).max_seq, 6);
         // folded key bounds preserve numeric ordering.
-        assert_eq!(swap.added.min_key_value, Some(5));
-        assert_eq!(swap.added.max_key_value, Some(40));
+        assert_eq!(added_seg(&swap).min_key_value, Some(5));
+        assert_eq!(added_seg(&swap).max_key_value, Some(40));
 
         // the output file exists with the expected name and is (key,seq)-sorted.
-        let out = PathBuf::from(&swap.added.path);
+        let out = PathBuf::from(&added_seg(&swap).path);
         assert_eq!(
             out.file_name().unwrap().to_str().unwrap(),
             seg_filename(1, 1)
@@ -549,10 +595,11 @@ mod tests {
         .unwrap();
         assert_eq!(swap.removed.len(), 2, "only the fitting prefix is consumed");
         assert_eq!(
-            swap.added.max_seq, max1,
+            added_seg(&swap).max_seq,
+            max1,
             "the output spans the consumed prefix, not the planned job"
         );
-        assert_eq!(swap.added.row_count, 40_000);
+        assert_eq!(added_seg(&swap).row_count, 40_000);
         assert!(
             swap.input_arrow_bytes <= one * 2 + 1,
             "the measured decode must respect the ceiling"
@@ -568,7 +615,7 @@ mod tests {
         })
         .unwrap();
         assert_eq!(swap.removed.len(), 3);
-        assert_eq!(swap.added.max_seq, max2);
+        assert_eq!(added_seg(&swap).max_seq, max2);
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -608,6 +655,55 @@ mod tests {
         std::fs::remove_dir_all(&dir).ok();
     }
 
+    /// A head input whose FILE IS GONE (not merely corrupt) must be dropped, not
+    /// promoted. A merge that consumed and unlinked this segment can leave a stale
+    /// deque/catalog reference behind; the planner then hands back the identical
+    /// job every `check_interval`, and promoting-by-rename fails on the absent
+    /// source forever — the exact wedge that stalled `iris.task` in production.
+    /// The swap must drop the reference (no rename, no output) so compaction
+    /// resumes, and its readable neighbour stays live for the next tick.
+    #[test]
+    fn missing_head_input_is_dropped_not_promoted() {
+        let dir = tempdir("missing_head");
+        let (p_gone, min_gone, max_gone) = repeated_line_segment(&dir, 1, 100);
+        let (p_good, min_good, max_good) = repeated_line_segment(&dir, 101, 100);
+        // The file is gone from disk while its row still names it — the dangling
+        // reference an already-consumed-and-unlinked segment leaves behind.
+        std::fs::remove_file(&p_gone).unwrap();
+
+        let job = CompactionJob {
+            inputs: vec![
+                row_for(&p_gone.to_string_lossy(), 0, min_gone, max_gone, 100),
+                row_for(&p_good.to_string_lossy(), 0, min_good, max_good, 100),
+            ],
+            output_level: 1,
+            output_min_seq: min_gone,
+        };
+        let swap = run_job(&job, &dir, &schema(), Some("key"), &[], i64::MAX, |_| {
+            (None, None)
+        })
+        .expect("a missing input must not fail the tick");
+        assert!(
+            swap.added.is_none(),
+            "a missing head produces no output segment"
+        );
+        assert!(
+            swap.bump_rename.is_none(),
+            "a missing head is dropped, never renamed"
+        );
+        assert!(!swap.unlink_removed, "nothing on disk to unlink");
+        assert_eq!(
+            swap.removed,
+            vec![p_gone.to_string_lossy().to_string()],
+            "only the dangling reference is spliced out"
+        );
+        assert!(
+            Path::new(&p_good).exists(),
+            "its readable neighbour stays live to compact next tick"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
     /// A lone input over the ceiling has nothing to merge with, so it is
     /// promoted by rename — no rewrite, no memory — rather than wedging its
     /// level forever behind a merge that can never fit.
@@ -628,7 +724,11 @@ mod tests {
         assert!(swap.bump_rename.is_some(), "must degenerate to a rename");
         assert!(!swap.unlink_removed, "a rename leaves nothing to unlink");
         assert_eq!(swap.removed, vec![p0.to_string_lossy().to_string()]);
-        assert_eq!(swap.added.max_seq, max0, "the bump carries its own span");
+        assert_eq!(
+            added_seg(&swap).max_seq,
+            max0,
+            "the bump carries its own span"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 
@@ -671,8 +771,8 @@ mod tests {
         let bounds = |_: &str| (Some(1), Some(n));
         let swap = run_job(&job, &dir, &schema(), Some("key"), &[], i64::MAX, bounds).unwrap();
 
-        assert_eq!(swap.added.row_count, n + 1, "no row loss");
-        let out = PathBuf::from(&swap.added.path);
+        assert_eq!(added_seg(&swap).row_count, n + 1, "no row loss");
+        let out = PathBuf::from(&added_seg(&swap).path);
         let mut keyed: Vec<(i64, i64)> = Vec::new();
         for b in &read_segment_batches(&out).unwrap() {
             let seqs = b.column(0).as_any().downcast_ref::<Int64Array>().unwrap();
@@ -714,11 +814,15 @@ mod tests {
             seg_filename(3, 1)
         );
         assert!(!swap.unlink_removed);
-        assert_eq!(swap.added.level, 3);
-        assert_eq!(swap.added.created_at_ms, 9999, "birth time preserved");
-        assert_eq!(swap.added.size_bytes, size, "no rewrite -> same bytes");
-        assert_eq!(swap.added.min_key_value, Some(10));
-        assert_eq!(swap.added.max_key_value, Some(20));
+        assert_eq!(added_seg(&swap).level, 3);
+        assert_eq!(added_seg(&swap).created_at_ms, 9999, "birth time preserved");
+        assert_eq!(
+            added_seg(&swap).size_bytes,
+            size,
+            "no rewrite -> same bytes"
+        );
+        assert_eq!(added_seg(&swap).min_key_value, Some(10));
+        assert_eq!(added_seg(&swap).max_key_value, Some(20));
 
         // The executor itself does NOT rename (deferred to commit); the old file
         // is still present and the new one absent.
@@ -774,7 +878,7 @@ mod tests {
         .unwrap();
 
         // The merged output carries a sidecar whose mask prunes correctly.
-        let out = PathBuf::from(&swap.added.path);
+        let out = PathBuf::from(&added_seg(&swap).path);
         let sc = sidecar_path(&out);
         assert!(sc.exists(), "merge output must have a trigram sidecar");
         let index = read_column_from_bytes(&std::fs::read(&sc).unwrap(), "data").unwrap();
@@ -885,7 +989,7 @@ mod tests {
             (None, None)
         })
         .unwrap();
-        let batches = read_segment_batches(Path::new(&swap.added.path)).unwrap();
+        let batches = read_segment_batches(Path::new(&added_seg(&swap).path)).unwrap();
         let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total_rows, 2);
         // note column exists and the first (old) row is null.

--- a/lib/finelog/rust/src/store/compaction/executor.rs
+++ b/lib/finelog/rust/src/store/compaction/executor.rs
@@ -111,12 +111,28 @@ pub fn run_job(
 /// carries the new level + path but PRESERVES the input's `created_at_ms`,
 /// row_count, seq window, and typed key bounds. The rename itself is deferred to
 /// the commit via `PlannedSwap::bump_rename`.
+///
+/// A bump can only rename a file that exists. When the input's file is gone — a
+/// dangling deque/catalog reference to a segment an earlier merge already
+/// consumed and unlinked — there is nothing to rename and no recoverable rows, so
+/// the stale reference is dropped instead. This guards BOTH callers: the
+/// single-input dispatch in `run_job` (a lone planner run over a missing segment)
+/// and `apply_merge`'s head-of-run recovery. Without it a single-input job over a
+/// missing file would emit a `bump_rename` that fails on the absent source every
+/// `check_interval`, wedging the level exactly as the merge path once did.
 fn apply_level_bump(
     old: &SegmentRow,
     output_level: i32,
     dir: &Path,
     input_key_bounds: &impl Fn(&str) -> (Option<i64>, Option<i64>),
 ) -> Result<PlannedSwap, StatsError> {
+    if !Path::new(&old.path).exists() {
+        tracing::warn!(
+            path = %old.path,
+            "level-bump input file missing; dropping the stale segment reference"
+        );
+        return Ok(drop_missing_input(old));
+    }
     let new_filename = seg_filename(output_level, old.min_seq);
     let new_path = dir.join(&new_filename);
     let (min_key, max_key) = input_key_bounds(&old.path);
@@ -144,12 +160,10 @@ fn apply_level_bump(
 /// Drop a dangling input whose file has vanished: splice its stale reference out
 /// of the deque + catalog and produce no replacement.
 ///
-/// A missing file carries no recoverable rows and cannot be renamed, so promoting
-/// it past the merge (`apply_level_bump`) would emit a rename that fails on the
-/// absent source every tick, wedging the level for good. The rows are either
-/// already durable in the output of an earlier merge that unlinked this input, or
-/// were lost with the file itself — dropping the reference loses nothing either
-/// way and lets compaction resume.
+/// A missing file carries no recoverable rows and cannot be renamed. Its rows are
+/// either already durable in the output of an earlier merge that unlinked this
+/// input, or were lost with the file itself — dropping the reference loses nothing
+/// either way and lets compaction resume instead of retrying a doomed rename.
 fn drop_missing_input(missing: &SegmentRow) -> PlannedSwap {
     PlannedSwap {
         removed: vec![missing.path.clone()],
@@ -213,31 +227,20 @@ fn apply_merge(
         // would replan the identical job every check_interval and wedge the level
         // for good. Route around it instead so compaction stays live. As a non-head
         // input it ends the prefix and becomes the next tick's head. As the run's
-        // head, the recovery depends on WHY the read failed: a file that is present
-        // but corrupt still has a real path to rename, so it is promoted past the
-        // merge by level bump; a file that is simply gone (a dangling deque/catalog
-        // reference to a segment an earlier merge already consumed and unlinked) has
-        // nothing to rename, so a bump would fail on the absent source every tick —
-        // its stale reference is dropped instead. Only the READ is forgiven — a
-        // projection or sort failure is a schema bug and still propagates.
+        // head it is handed to `apply_level_bump`, which promotes a present-but-
+        // corrupt file past the merge by rename and drops a missing one. Only the
+        // READ is forgiven — a projection or sort failure is a schema bug and still
+        // propagates.
         let raw = match read_segment_batches(Path::new(&inp.path)) {
             Ok(raw) => raw,
             Err(e) => {
                 if consumed.is_empty() {
-                    if Path::new(&inp.path).exists() {
-                        tracing::warn!(
-                            path = %inp.path,
-                            error = %e,
-                            "unreadable merge input; promoting it past the merge"
-                        );
-                        return apply_level_bump(inp, job.output_level, dir, input_key_bounds);
-                    }
                     tracing::warn!(
                         path = %inp.path,
                         error = %e,
-                        "merge input file missing; dropping the stale segment reference"
+                        "unreadable merge input at run head; promoting or dropping it"
                     );
-                    return Ok(drop_missing_input(inp));
+                    return apply_level_bump(inp, job.output_level, dir, input_key_bounds);
                 }
                 tracing::warn!(
                     path = %inp.path,
@@ -701,6 +704,43 @@ mod tests {
             Path::new(&p_good).exists(),
             "its readable neighbour stays live to compact next tick"
         );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// A SINGLE-input planned job (the planner emits these for an isolated
+    /// promotable segment) dispatches straight to `apply_level_bump`, never
+    /// through the merge read loop. If that lone input is a dangling reference
+    /// (file gone), the bump must still drop it rather than emit a rename that
+    /// fails on the absent source every tick — the same wedge, reached by the
+    /// single-input path.
+    #[test]
+    fn single_missing_input_is_dropped_not_bumped() {
+        let dir = tempdir("single_missing");
+        let (p_gone, min_gone, max_gone) = repeated_line_segment(&dir, 1, 100);
+        std::fs::remove_file(&p_gone).unwrap();
+
+        let job = CompactionJob {
+            inputs: vec![row_for(
+                &p_gone.to_string_lossy(),
+                2,
+                min_gone,
+                max_gone,
+                100,
+            )],
+            output_level: 3,
+            output_min_seq: min_gone,
+        };
+        let swap = run_job(&job, &dir, &schema(), Some("key"), &[], i64::MAX, |_| {
+            (None, None)
+        })
+        .expect("a missing single input must not fail the tick");
+        assert!(swap.added.is_none(), "a missing input produces no output");
+        assert!(
+            swap.bump_rename.is_none(),
+            "a missing single input is dropped, never renamed"
+        );
+        assert!(!swap.unlink_removed, "nothing on disk to unlink");
+        assert_eq!(swap.removed, vec![p_gone.to_string_lossy().to_string()]);
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/lib/finelog/rust/src/store/namespace.rs
+++ b/lib/finelog/rust/src/store/namespace.rs
@@ -709,9 +709,29 @@ impl Namespace {
             self.compaction_config.max_merge_arrow_bytes,
             |path| self.input_key_bounds(path),
         )?;
-        let output_path = swap.added.path.clone();
-        let output_bytes = swap.added.size_bytes;
-        let output_rows = swap.added.row_count;
+        let merged_inputs = swap.removed.len();
+        let input_arrow_bytes = swap.input_arrow_bytes;
+        // A missing head input produces no output — the swap only names the stale
+        // reference to drop. Route it through `evict_segment`, which is
+        // location-aware (a BOTH segment collapses to REMOTE, preserving its
+        // durable archive; a LOCAL-only row is removed) and tolerates the already
+        // absent file. This unwedges compaction without deleting a segment that
+        // still has a remote copy.
+        let Some(added) = swap.added.clone() else {
+            for path in &swap.removed {
+                self.evict_segment(path);
+            }
+            tracing::warn!(
+                namespace = %self.name,
+                dropped = ?swap.removed,
+                elapsed_ms = started.elapsed().as_millis() as u64,
+                "dropped stale segment reference with no local file; compaction resumed"
+            );
+            return Ok(());
+        };
+        let output_path = added.path.clone();
+        let output_bytes = added.size_bytes;
+        let output_rows = added.row_count;
         // A bump is a rename; a merge decodes its inputs into RAM. The
         // distinction is the whole memory story, so name it — along with the
         // decoded size the ceiling actually bounds, and how much of the planned
@@ -721,8 +741,6 @@ impl Namespace {
         } else {
             "merge"
         };
-        let merged_inputs = swap.removed.len();
-        let input_arrow_bytes = swap.input_arrow_bytes;
         self.commit_swap(swap)?;
         tracing::info!(
             namespace = %self.name,
@@ -809,7 +827,14 @@ impl Namespace {
         }
         let removed_set: std::collections::HashSet<&str> =
             swap.removed.iter().map(|s| s.as_str()).collect();
-        let added_row = segment_to_row(&self.name, &swap.added);
+        // A drop (missing head input) never reaches `commit_swap` — `run_one_job`
+        // routes it through `evict_segment`. Every committed swap therefore
+        // replaces its inputs with a real output segment.
+        let added = swap
+            .added
+            .as_ref()
+            .expect("commit_swap requires an output segment; drops are handled by run_one_job");
+        let added_row = segment_to_row(&self.name, added);
         {
             let mut inner = self.inner.lock().unwrap();
             let mut new_segments: VecDeque<LocalSegment> =
@@ -818,7 +843,7 @@ impl Namespace {
             for s in inner.local_segments.drain(..) {
                 if removed_set.contains(s.path.as_str()) {
                     if !inserted {
-                        new_segments.push_back(swap.added.clone());
+                        new_segments.push_back(added.clone());
                         inserted = true;
                     }
                 } else {
@@ -826,7 +851,7 @@ impl Namespace {
                 }
             }
             if !inserted {
-                new_segments.push_back(swap.added.clone());
+                new_segments.push_back(added.clone());
             }
             inner.local_segments = new_segments;
             // Atomic catalog splice. Propagate on failure: the
@@ -1847,6 +1872,63 @@ mod tests {
         ns.run_maintenance(true).await.unwrap();
 
         assert_eq!(ns.backfill_missing_sidecars(10), 0);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn maintenance_drops_dangling_segment_reference_instead_of_wedging() {
+        // Regression for the `iris.task` compaction wedge. A merge that consumed
+        // and unlinked a segment can leave its deque/catalog reference behind (a
+        // duplicate entry the splice missed). The planner then hands back a job
+        // whose head input file is gone; the old recovery tried to promote it by
+        // rename, which failed on the absent source every `check_interval` and
+        // wedged the namespace's compaction for good (14k L0 files and growing in
+        // production). Maintenance must instead DROP the dangling reference and
+        // keep compacting.
+        let dir = tempdir();
+        let ns_dir = dir.join("iris.worker");
+        let catalog = Arc::new(Catalog::open(Some(&dir)).unwrap());
+        let ns = open_ns(
+            "iris.worker",
+            worker_schema(),
+            Some(ns_dir.clone()),
+            catalog,
+        );
+
+        // Three L0 segments (seq 1, 2, 3), each its own flush.
+        write_one(&ns).await;
+        write_one(&ns).await;
+        write_one(&ns).await;
+        let before = discover_segments(&ns_dir);
+        assert_eq!(before.len(), 3, "three L0 segments on disk");
+
+        // Delete the lowest-min_seq file while its deque + catalog rows survive —
+        // the dangling reference an already-consumed-and-unlinked input leaves,
+        // and the head of the next planned run.
+        let head = before.iter().min().unwrap().clone();
+        std::fs::remove_file(&head).unwrap();
+
+        // Before the fix this returned Err (rename of the absent head failed) and
+        // every later tick replanned the identical doomed job.
+        ns.run_maintenance(true)
+            .await
+            .expect("a dangling reference must not wedge maintenance");
+
+        // The stale reference is gone from the catalog, and the two intact rows
+        // survive (compacted forward, none lost).
+        let rows = ns.catalog.list_segments("iris.worker").unwrap();
+        let head_str = head.to_string_lossy().to_string();
+        assert!(
+            rows.iter().all(|r| r.path != head_str),
+            "the dangling reference was dropped from the catalog"
+        );
+        let total_rows: i64 = rows.iter().map(|r| r.row_count).sum();
+        assert_eq!(total_rows, 2, "the two intact segments' rows survive");
+
+        // Compaction is live again: a further tick runs without error.
+        ns.run_maintenance(true)
+            .await
+            .expect("compaction stays live after the drop");
         std::fs::remove_dir_all(&dir).ok();
     }
 


### PR DESCRIPTION
When a planned compaction input's file is gone — a dangling deque/catalog reference to a segment an earlier merge already consumed and unlinked — the executor forgave the read error and promoted the head past the merge by level bump. That bump's rename has no source file, so it failed every `check_interval`, `run_maintenance` errored before it could mutate the deque, and the planner handed back the identical doomed job on the next tick. The namespace's compaction wedged permanently.

This is not hypothetical: production `iris.task` stalled at 22:16 on one such phantom L0 reference and has logged the same failed cycle every 30s since, while ~14k L0 segments piled up unmerged — so every query over the namespace now opens them all.

The fix distinguishes *why* the read failed:

- present but corrupt — still a real path to rename, so keep promoting it past the merge by level bump (unchanged).
- simply gone — nothing to rename, and no recoverable rows behind it. Drop the stale reference.

The drop routes through `evict_segment`, which is already the store's location-aware removal primitive: a `BOTH` segment collapses to `REMOTE` and keeps its durable archive, a `LOCAL`-only row is removed, and an already-absent file is tolerated. Compaction resumes on the same tick instead of wedging. `PlannedSwap.added` becomes `Option` to model a swap that removes an input without producing a replacement.

This makes compaction self-heal from a dangling reference regardless of how it arose. How the duplicate deque entry appears in the first place is a separate correctness question tracked as a follow-up.