### PR TITLE
[levanter] Forward training metrics to finelog by default via telltale

### DIFF
--- a/lib/finelog/dashboard/src/utils/arrow.ts
+++ b/lib/finelog/dashboard/src/utils/arrow.ts
@@ -42,5 +42,19 @@ function normalize(v: unknown): unknown {
   if (typeof v === 'bigint') return Number(v)
   if (v instanceof Uint8Array) return `<bytes ${v.byteLength}>`
   if (v instanceof Date) return v.toISOString()
+  // Nested columns (a native Map<Utf8,Utf8> `labels`, a struct, a list) arrive
+  // as arrow MapRow/StructRow/sub-Vector objects. DataTable renders cells as
+  // text, so flatten them to compact JSON — coercing any nested bigint the way
+  // scalar cells are — rather than handing it an arrow object it can't stringify.
+  if (typeof v === 'object') {
+    // A cell decoded as a JS Map (rather than an arrow MapRow) stringifies to
+    // "{}" unless entries are lifted out first.
+    const plain = v instanceof Map ? Object.fromEntries(v) : v
+    try {
+      return JSON.stringify(plain, (_key, val) => (typeof val === 'bigint' ? Number(val) : val))
+    } catch {
+      return String(v)
+    }
+  }
   return v
 }

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -784,13 +784,7 @@ class Trainer:
 
 
 def _compose_with_telltale(config: TrackerConfig | Sequence[TrackerConfig]) -> list[TrackerConfig]:
-    """The configured tracker(s) plus the always-on telltale mirror.
-
-    The telltale tracker publishes training metrics onto the process's telltale
-    page, which the iris runtime forwards to finelog so a run's series outlive
-    the job and drive dashboards. It is process-local and cheap, so it rides on
-    every run unless the config already names one.
-    """
+    """The configured tracker(s), with a ``TelltaleConfig`` appended unless one is already present."""
     configs = list(config) if isinstance(config, Sequence) else [config]
     if not any(isinstance(c, TelltaleConfig) for c in configs):
         configs = [*configs, TelltaleConfig()]

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -67,6 +67,7 @@ from levanter.metrics import Metric, auto_metric_from_name, unwrap_metrics
 from levanter.optim.model_averaging import ModelAveragingConfig
 from levanter.schedule import BatchSchedule, IntSchedule, ScheduleStep, distinct_values, value_at_step
 from levanter.tracker import TrackerConfig, capture_time
+from levanter.tracker.telltale import TelltaleConfig
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer_state import InsideJitInfo, TrainerState, saveable_training_mask
 from levanter.utils import cloud_utils
@@ -287,10 +288,9 @@ class Trainer:
             self.tracker = levanter.tracker.current_tracker()
         except RuntimeError:
             # No global tracker set, create one
-            if isinstance(config.tracker, Sequence):
-                self.tracker = levanter.tracker.CompositeTracker([c.init(self.run_id) for c in config.tracker])
-            else:
-                self.tracker = config.tracker.init(self.run_id)
+            self.tracker = levanter.tracker.CompositeTracker(
+                [c.init(self.run_id) for c in _compose_with_telltale(config.tracker)]
+            )
 
         if add_default_hooks:
             self._add_default_hooks()
@@ -783,12 +783,22 @@ class Trainer:
         return fn(*args, **kwargs)
 
 
-def _initialize_global_tracker(config, run_id):
-    if isinstance(config, Sequence):
-        tracker = levanter.tracker.CompositeTracker([c.init(run_id) for c in config])
-    else:
-        tracker = config.init(run_id)
+def _compose_with_telltale(config: TrackerConfig | Sequence[TrackerConfig]) -> list[TrackerConfig]:
+    """The configured tracker(s) plus the always-on telltale mirror.
 
+    The telltale tracker publishes training metrics onto the process's telltale
+    page, which the iris runtime forwards to finelog so a run's series outlive
+    the job and drive dashboards. It is process-local and cheap, so it rides on
+    every run unless the config already names one.
+    """
+    configs = list(config) if isinstance(config, Sequence) else [config]
+    if not any(isinstance(c, TelltaleConfig) for c in configs):
+        configs = [*configs, TelltaleConfig()]
+    return configs
+
+
+def _initialize_global_tracker(config, run_id):
+    tracker = levanter.tracker.CompositeTracker([c.init(run_id) for c in _compose_with_telltale(config)])
     levanter.tracker.set_global_tracker(tracker)
 
 


### PR DESCRIPTION
Compose a telltale tracker onto every levanter run so training metrics reach finelog by default.

Levanter's telltale tracker mirrors training metrics onto the process's telltale page, which the iris runtime forwards to finelog so a run's series outlive the job and drive dashboards. It was opt-in, and neither the levanter default (`WandbConfig`) nor marin's explicit `tracker=WandbConfig(...)` ever named it — so training runs forwarded only the default prometheus process/gc collectors, and the finelog training dashboard stayed empty. `_compose_with_telltale` now appends a `TelltaleConfig` (deduped) at both tracker-build sites, so it rides on every run even when the config sets an explicit tracker. The telltale tracker is process-local and cheap; finelog forwarding only fires inside an iris job.

Also fixes the finelog dashboard query view: a native `Map<Utf8,Utf8>` cell — the telltale `labels` column — arrives as an arrow `MapRow` that `DataTable` can't render as text, so query results came back blank. `normalize` now flattens object cells to compact JSON (bigint-coerced, JS-`Map` entries lifted, `String()` fallback).

The `Map` column itself round-trips through compaction correctly (verified: 40 flushed segments merge into one, rows and `json_get(labels,...)` intact), so no finelog server change is needed.