### PR TITLE
[datakit] Add trillionlabs/TheBioCollection source

### DIFF
--- a/lib/marin/src/marin/datakit/download/biocollection.py
+++ b/lib/marin/src/marin/datakit/download/biocollection.py
@@ -1,0 +1,57 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""trillionlabs/TheBioCollection download + normalize helpers.
+
+Two synthetic biology/chemistry pretraining streams built from molecular and
+reaction data:
+
+- ``free_text_stream``: free-text renderings of molecules (SMILES/IUPAC/InChI
+  plus physicochemical and graph descriptors).
+- ``instruction_stream``: instruction/response pairs (e.g. reaction-product
+  prediction).
+
+Each stream is a directory of zstd-compressed JSONL shards
+(``data/<stream>/*.jsonl.zst``) whose ``text`` field already holds the document
+content (the only other column, ``record_type``, is dropped by normalize). The
+two streams share one HF repo, so each is staged under its own
+``raw/biocollection/<stream>`` path and downloaded via a per-stream glob.
+"""
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "trillionlabs/TheBioCollection"
+HF_REVISION = "c4593c2"
+
+STREAMS = ("free_text_stream", "instruction_stream")
+
+
+def download_biocollection_step(stream: str) -> StepSpec:
+    """Download a single TheBioCollection stream's zstd-JSONL shards."""
+    return download_hf_step(
+        f"raw/biocollection/{stream}",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=[f"data/{stream}/*.jsonl.zst"],
+    )
+
+
+def biocollection_normalize_steps() -> dict[str, tuple[StepSpec, ...]]:
+    """Return ``(download, normalize)`` chains for both TheBioCollection streams.
+
+    Keyed by the registry name convention ``"biocollection/<stream>"``.
+    """
+    chains: dict[str, tuple[StepSpec, ...]] = {}
+    for stream in STREAMS:
+        marin_name = f"biocollection/{stream}"
+        download = download_biocollection_step(stream)
+        normalize = normalize_step(
+            name=f"normalized/{marin_name}",
+            download=download,
+            text_field="text",
+            file_extensions=(".jsonl.zst",),
+        )
+        chains[marin_name] = (download, normalize)
+    return chains

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from functools import cache
 
 from marin.datakit.canonical.safety_pretraining import safety_pretraining_normalize_steps
+from marin.datakit.download.biocollection import biocollection_normalize_steps
 from marin.datakit.download.biodiversity import biodiversity_normalize_steps
 from marin.datakit.download.climblab_ja import climblab_ja_normalize_steps
 from marin.datakit.download.coderforge import coderforge_normalize_steps
@@ -186,6 +187,18 @@ def all_sources() -> dict[str, DatakitSource]:
             "starcoder2/ir_python": 4.64,
             "starcoder2/ir_rust": 1.84,
             "starcoder2/kaggle": 1.38,
+        },
+    )
+
+    # TheBioCollection: two synthetic bio/chem streams from one HF repo, each
+    # staged and downloaded per-stream (see biocollection.py). Token counts are
+    # the exact Marin-tokenizer (Llama-3) totals from each stream's tokenized
+    # cache .stats.json.
+    biocollection = _rows_flat(
+        biocollection_normalize_steps,
+        {
+            "biocollection/free_text_stream": 33.186704843,
+            "biocollection/instruction_stream": 18.123700603,
         },
     )
 
@@ -390,6 +403,7 @@ def all_sources() -> dict[str, DatakitSource]:
     all_rows: tuple[_SourceRow, ...] = (
         *single_sources,
         *starcoder2_extras,
+        *biocollection,
         *common_pile,
         *finepdfs,
         *nemotron_cc_v2,


### PR DESCRIPTION
Register TheBioCollection as two mixture components, biocollection/free_text_stream and biocollection/instruction_stream.

Each stream is a per-stream directory of zstd-compressed JSONL shards (data/<stream>/*.jsonl.zst) sharing one HF repo, so each is staged under its own raw/biocollection/<stream> path and downloaded via a per-stream glob, then normalized off the text field (the only other column, record_type, is dropped).

rough_token_count_b is the exact Marin-tokenizer (Llama-3) total for each stream, read from the tokenized cache .stats.json: 33.186704843B free-text and 18.123700603B instruction. Both streams are already staged and normalized in us-central1.