### PR TITLE
[levanter] Fix multi-host HF export crash and async checkpoint shutdown race

### DIFF
--- a/lib/levanter/src/levanter/compat/hf_checkpoints.py
+++ b/lib/levanter/src/levanter/compat/hf_checkpoints.py
@@ -44,6 +44,7 @@ from huggingface_hub.utils import EntryNotFoundError, GatedRepoError, HFValidati
 from jax import ShapeDtypeStruct
 from jax._src.mesh import get_concrete_mesh
 from jax._src.partition_spec import PartitionSpec
+from jax.experimental import multihost_utils
 from jax.random import PRNGKey
 from jaxtyping import Array, PRNGKeyArray
 from rigging.filesystem import StoragePath, fetch_file_atomic, url_to_fs
@@ -425,6 +426,18 @@ def _to_state_dict_with_dtype(
     state_dict = jax.tree.map(lambda value: jax.sharding.reshard(value, PartitionSpec()), state_dict)
 
     return state_dict
+
+
+def _gather_to_host_numpy(array) -> np.ndarray:
+    """Gather a (possibly globally-sharded) array to a full, host-local numpy array.
+
+    On a multi-host run a parameter's shards live on devices that are not all local to
+    this process, so ``np.asarray`` raises ``RuntimeError: Fetching value for jax.Array
+    that spans non-addressable ... devices``. ``process_allgather`` is a collective — every
+    process must call it in lockstep — that returns the complete array as a host-local
+    numpy array on every process, which the safetensors writer requires.
+    """
+    return np.asarray(multihost_utils.process_allgather(array, tiled=True))
 
 
 @dataclass_with_default_init(frozen=True)
@@ -1150,7 +1163,9 @@ class HFCheckpointConverter(Generic[LevConfig]):
                     subset_arg = subset_keys
 
                 shard_weights = _to_state_dict_with_dtype(model, dtype, subset_arg)
-                shard_numpy = {k: np.asarray(v) for k, v in shard_weights.items()}
+                # Gather each parameter across processes: on multi-host, shards span
+                # non-addressable devices, so a bare np.asarray would raise.
+                shard_numpy = {k: _gather_to_host_numpy(v) for k, v in shard_weights.items()}
                 bytes_this_time = sum(v.nbytes for v in shard_numpy.values())
                 logger.info(
                     "Saving shard %s (%s, %.2f%% of model)",

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -56,7 +56,7 @@ import levanter.utils.logging
 from levanter.callbacks import Callback, CBInfo, JitCallback, LambdaCallback, StepInfo
 from levanter.callbacks.profiler import ProfilerConfig
 from levanter.callbacks.watch import WatchConfig
-from levanter.checkpoint import CheckpointerConfig, is_checkpoint_path, load_checkpoint_or_initialize
+from levanter.checkpoint import Checkpointer, CheckpointerConfig, is_checkpoint_path, load_checkpoint_or_initialize
 from levanter.config import JsonAtom
 from levanter.data.dataset import AsyncDataset
 from levanter.data.loader import DataLoader
@@ -280,6 +280,7 @@ class Trainer:
         self.config = config
         self.optimizer = optimizer
         self._raw_loss_function = loss_fn
+        self._checkpointer: Optional[Checkpointer] = None
 
         # Use existing global tracker if available (e.g., from levanter.initialize()),
         # otherwise create a new one. This avoids calling wandb.init() twice.
@@ -380,6 +381,17 @@ class Trainer:
 
     def __exit__(self, *args):
         problems = []
+
+        # Block on any in-flight async checkpoint serialization before tearing down the tracker
+        # and mesh. A run that has returned must have durably written its final checkpoint, and
+        # letting the background commit thread finish here also avoids it logging into the
+        # already-closed tracker/stdout during teardown.
+        if self._checkpointer is not None:
+            try:
+                self._checkpointer.wait_until_finished()
+            except Exception as e:
+                problems.append(e)
+
         for cmanager in reversed(self._cmanagers):
             try:
                 cmanager.__exit__(*args)
@@ -583,6 +595,7 @@ class Trainer:
         )
         # engine.add_hook(callbacks.log_memory_usage(), every=1)
         checkpointer = self.config.checkpointer.create(self.run_id)
+        self._checkpointer = checkpointer
 
         def checkpoint_hook(info, force=False):
             checkpointer.on_step(tree=info.state.saveable_state, step=info.step, force=force)


### PR DESCRIPTION
Two independent, pre-existing multi-host bugs in levanter, found while debugging a v5litepod-16 (4-host) run of `experiments/tutorials/train_tiny_model.py`.

**HF safetensors export crashed on multi-host.** `save_pretrained` called `np.asarray` on globally-sharded parameters whose shards span non-addressable devices, raising `RuntimeError: Fetching value for jax.Array that spans non-addressable (non process local) devices`. The `reshard(PartitionSpec())` in `_to_state_dict_with_dtype` sets a replicated spec but the concrete array still spans the global mesh, so the numpy conversion fails on every host. Each parameter is now gathered with `process_allgather` — a lockstep collective every process runs — so the safetensors writer sees a complete host-local array. The export callback already runs on all processes, and only process 0 writes the shard/metadata files through the existing `temp_dir_before_upload` and `save_state_dict` guards.

**Trainer returned before its final checkpoint was durable.** The `Checkpointer` serializes the final checkpoint on a background thread, and that async commit is what writes the metadata `latest_checkpoint_path` discovers. The trainer returned before the commit finished, so a run that had returned could still have no discoverable checkpoint, and the commit thread outlived teardown and logged into already-closed tracker/stdout handles (`I/O operation on closed file`). `Trainer.__exit__` now awaits the checkpointer before tearing down the tracker and mesh, so a returned run has durably written its final checkpoint.

Tracks weaver #495.