### PR TITLE
[inference] Add GPU backend to brokered vLLM

### DIFF
--- a/.agents/skills/refresh-tpu-vllm-forks/SKILL.md
+++ b/.agents/skills/refresh-tpu-vllm-forks/SKILL.md
@@ -225,7 +225,7 @@ Run the brokered suite with a bounded sample by composing its existing pieces:
 uv run iris --config lib/iris/config/marin.yaml job run \
   --job-name served-qwen3-<run-id> --cpu 1 --memory 2G --extra cpu \
   --priority interactive --no-wait -- python -c \
-  "from dataclasses import replace; from fray.types import ResourceConfig; from marin.execution.lazy import lower; from marin.execution.step_runner import StepRunner; from experiments.evals.brokered_eval_suite import brokered_eval_suite; from experiments.evals.served_qwen3 import QWEN3_INFERENCE; inference = replace(QWEN3_INFERENCE, worker_resources=ResourceConfig.with_tpu('v6e-4', ram='96g', regions=['europe-west4'])); StepRunner().run([lower(brokered_eval_suite(inference, model_name='qwen3-0.6b-refresh-smoke', version='<run-id>-dev', limit=8))])"
+  "from dataclasses import replace; from fray.types import ResourceConfig; from marin.execution.lazy import lower; from marin.execution.step_runner import StepRunner; from experiments.evals.brokered_eval_suite import brokered_eval_suite; from experiments.evals.served_qwen3 import QWEN3_TPU_INFERENCE; inference = replace(QWEN3_TPU_INFERENCE, worker_resources=ResourceConfig.with_tpu('v6e-4', ram='96g', regions=['europe-west4'])); StepRunner().run([lower(brokered_eval_suite(inference, model_name='qwen3-0.6b-refresh-smoke', version='<run-id>-dev', limit=8))])"
 ```
 
 Inspect the Iris parent, broker, and worker logs; confirm the proxy served

--- a/experiments/evals/served_qwen3.py
+++ b/experiments/evals/served_qwen3.py
@@ -15,7 +15,6 @@ Examples:
 """
 
 import argparse
-from collections.abc import Mapping
 from enum import StrEnum
 from types import MappingProxyType
 
@@ -35,12 +34,13 @@ from experiments.evals.brokered_eval_suite import brokered_eval_suite
 
 QWEN3_EVAL_VERSION = "2026.07.17"
 _VLLM_TIMEOUT = 1800
-_TPU_VLLM_WORKER_ENV_VARS = {
-    "VLLM_ENABLE_V1_MULTIPROCESSING": "0",
-    "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
-    "VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION": "1",
-    "VLLM_TPU_SKIP_PRECOMPILE": "1",
-}
+_TPU_VLLM_WORKER_ENV_VARS = (
+    ("VLLM_ENABLE_V1_MULTIPROCESSING", "0"),
+    ("VLLM_ALLOW_LONG_MAX_MODEL_LEN", "1"),
+    ("VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION", "1"),
+    ("VLLM_TPU_SKIP_PRECOMPILE", "1"),
+)
+_GPU_VLLM_WORKER_ENV_VARS: tuple[tuple[str, str], ...] = ()
 
 
 class Accelerator(StrEnum):
@@ -52,7 +52,7 @@ def qwen3_inference(
     *,
     backend: BrokeredVllmBackend,
     worker_resources: ResourceConfig,
-    worker_env_vars: Mapping[str, str],
+    worker_env_vars: tuple[tuple[str, str], ...],
 ) -> BrokeredVllmSystemConfig:
     """Compose Qwen3 model policy with an accelerator-specific serving backend."""
     return BrokeredVllmSystemConfig(
@@ -96,7 +96,7 @@ QWEN3_GPU_INFERENCE = qwen3_inference(
         disk="100g",
         regions=[ANY_REGION],
     ),
-    worker_env_vars={},
+    worker_env_vars=_GPU_VLLM_WORKER_ENV_VARS,
 )
 
 QWEN3_GPU_EVAL_RESULTS = brokered_eval_suite(

--- a/experiments/evals/served_qwen3.py
+++ b/experiments/evals/served_qwen3.py
@@ -40,7 +40,6 @@ _TPU_VLLM_WORKER_ENV_VARS = (
     ("VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION", "1"),
     ("VLLM_TPU_SKIP_PRECOMPILE", "1"),
 )
-_GPU_VLLM_WORKER_ENV_VARS: tuple[tuple[str, str], ...] = ()
 
 
 class Accelerator(StrEnum):
@@ -96,7 +95,7 @@ QWEN3_GPU_INFERENCE = qwen3_inference_config(
         disk="100g",
         regions=[ANY_REGION],
     ),
-    worker_env_vars=_GPU_VLLM_WORKER_ENV_VARS,
+    worker_env_vars=(),
 )
 
 QWEN3_GPU_EVAL_RESULTS = brokered_eval_suite(

--- a/experiments/evals/served_qwen3.py
+++ b/experiments/evals/served_qwen3.py
@@ -8,45 +8,118 @@ Examples:
   uv run iris --cluster=marin job run --job-name qwen3-evals --cpu 1 --memory 2G \
     --extra cpu --priority interactive --no-wait \
     -- python -m experiments.evals.served_qwen3
+
+  uv run iris --config lib/iris/config/marin.yaml job run --target-cluster cw-us-east-02a \
+    --job-name qwen3-gpu-evals --cpu 1 --memory 2G --extra cpu --priority interactive --no-wait \
+    -- python -m experiments.evals.served_qwen3 --accelerator gpu
 """
+
+import argparse
+from collections.abc import Mapping
+from enum import StrEnum
 
 from fray.types import ANY_REGION, ResourceConfig
 from marin.execution.lazy import lower
 from marin.execution.step_runner import StepRunner
-from marin.inference.vllm import BrokeredVllmSystemConfig, VllmProxyConfig, VllmServerConfig
+from marin.inference.vllm import (
+    BrokeredVllmBackend,
+    BrokeredVllmSystemConfig,
+    GpuVllmBackend,
+    TpuVllmBackend,
+    VllmProxyConfig,
+    VllmServerConfig,
+)
 
 from experiments.evals.brokered_eval_suite import brokered_eval_suite
 
+QWEN3_EVAL_VERSION = "2026.07.17"
 _VLLM_TIMEOUT = 1800
-_VLLM_WORKER_ENV_VARS = {
+_TPU_VLLM_WORKER_ENV_VARS = {
     "VLLM_ENABLE_V1_MULTIPROCESSING": "0",
     "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
     "VLLM_TPU_DISABLE_TOPK_TOPP_OPTIMIZATION": "1",
     "VLLM_TPU_SKIP_PRECOMPILE": "1",
 }
 
-QWEN3_INFERENCE = BrokeredVllmSystemConfig(
-    model="Qwen/Qwen3-0.6B-Base",
-    tokenizer="Qwen/Qwen3-0.6B",
+
+class Accelerator(StrEnum):
+    TPU = "tpu"
+    GPU = "gpu"
+
+
+def qwen3_inference(
+    *,
+    backend: BrokeredVllmBackend,
+    worker_resources: ResourceConfig,
+    worker_env_vars: Mapping[str, str],
+) -> BrokeredVllmSystemConfig:
+    """Compose Qwen3 model policy with an accelerator-specific serving backend."""
+    return BrokeredVllmSystemConfig(
+        model="Qwen/Qwen3-0.6B-Base",
+        tokenizer="Qwen/Qwen3-0.6B",
+        backend=backend,
+        worker_resources=worker_resources,
+        worker_env_vars=worker_env_vars,
+        server=VllmServerConfig(timeout_seconds=_VLLM_TIMEOUT),
+        proxy=VllmProxyConfig(
+            request_timeout_seconds=_VLLM_TIMEOUT,
+            readiness_timeout_seconds=_VLLM_TIMEOUT,
+            ignored_request_fields=("seed",),
+        ),
+    )
+
+
+QWEN3_TPU_INFERENCE = qwen3_inference(
+    backend=TpuVllmBackend(),
     worker_resources=ResourceConfig.with_tpu(
         ["v5litepod-4", "v4-8", "v5p-8", "v6e-4"],
         ram="96g",
         regions=[ANY_REGION],
     ),
-    worker_env_vars=_VLLM_WORKER_ENV_VARS,
-    server=VllmServerConfig(timeout_seconds=_VLLM_TIMEOUT),
-    proxy=VllmProxyConfig(
-        request_timeout_seconds=_VLLM_TIMEOUT,
-        readiness_timeout_seconds=_VLLM_TIMEOUT,
-        ignored_request_fields=("seed",),
-    ),
+    worker_env_vars=_TPU_VLLM_WORKER_ENV_VARS,
 )
 
-QWEN3_EVAL_RESULTS = brokered_eval_suite(
-    QWEN3_INFERENCE,
+QWEN3_TPU_EVAL_RESULTS = brokered_eval_suite(
+    QWEN3_TPU_INFERENCE,
     model_name="qwen3-0.6b",
-    version="2026.07.17",
+    version=QWEN3_EVAL_VERSION,
 )
+
+QWEN3_GPU_INFERENCE = qwen3_inference(
+    backend=GpuVllmBackend(),
+    worker_resources=ResourceConfig.with_gpu(
+        "H100",
+        count=1,
+        cpu=8,
+        ram="64g",
+        disk="100g",
+        regions=[ANY_REGION],
+    ),
+    worker_env_vars={},
+)
+
+QWEN3_GPU_EVAL_RESULTS = brokered_eval_suite(
+    QWEN3_GPU_INFERENCE,
+    model_name="qwen3-0.6b-gpu",
+    version=QWEN3_EVAL_VERSION,
+)
+
+QWEN3_EVALS_BY_ACCELERATOR = {
+    Accelerator.TPU: QWEN3_TPU_EVAL_RESULTS,
+    Accelerator.GPU: QWEN3_GPU_EVAL_RESULTS,
+}
+
+
+def _parse_accelerator() -> Accelerator:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--accelerator",
+        type=Accelerator,
+        choices=tuple(Accelerator),
+        default=Accelerator.TPU,
+    )
+    return parser.parse_args().accelerator
+
 
 if __name__ == "__main__":
-    StepRunner().run([lower(QWEN3_EVAL_RESULTS)])
+    StepRunner().run([lower(QWEN3_EVALS_BY_ACCELERATOR[_parse_accelerator()])])

--- a/experiments/evals/served_qwen3.py
+++ b/experiments/evals/served_qwen3.py
@@ -48,7 +48,7 @@ class Accelerator(StrEnum):
     GPU = "gpu"
 
 
-def qwen3_inference(
+def qwen3_inference_config(
     *,
     backend: BrokeredVllmBackend,
     worker_resources: ResourceConfig,
@@ -70,7 +70,7 @@ def qwen3_inference(
     )
 
 
-QWEN3_TPU_INFERENCE = qwen3_inference(
+QWEN3_TPU_INFERENCE = qwen3_inference_config(
     backend=TpuVllmBackend(),
     worker_resources=ResourceConfig.with_tpu(
         ["v5litepod-4", "v4-8", "v5p-8", "v6e-4"],
@@ -86,7 +86,7 @@ QWEN3_TPU_EVAL_RESULTS = brokered_eval_suite(
     version=QWEN3_EVAL_VERSION,
 )
 
-QWEN3_GPU_INFERENCE = qwen3_inference(
+QWEN3_GPU_INFERENCE = qwen3_inference_config(
     backend=GpuVllmBackend(),
     worker_resources=ResourceConfig.with_gpu(
         "H100",

--- a/experiments/evals/served_qwen3.py
+++ b/experiments/evals/served_qwen3.py
@@ -17,6 +17,7 @@ Examples:
 import argparse
 from collections.abc import Mapping
 from enum import StrEnum
+from types import MappingProxyType
 
 from fray.types import ANY_REGION, ResourceConfig
 from marin.execution.lazy import lower
@@ -104,10 +105,12 @@ QWEN3_GPU_EVAL_RESULTS = brokered_eval_suite(
     version=QWEN3_EVAL_VERSION,
 )
 
-QWEN3_EVALS_BY_ACCELERATOR = {
-    Accelerator.TPU: QWEN3_TPU_EVAL_RESULTS,
-    Accelerator.GPU: QWEN3_GPU_EVAL_RESULTS,
-}
+QWEN3_EVALS_BY_ACCELERATOR = MappingProxyType(
+    {
+        Accelerator.TPU: QWEN3_TPU_EVAL_RESULTS,
+        Accelerator.GPU: QWEN3_GPU_EVAL_RESULTS,
+    }
+)
 
 
 def _parse_accelerator() -> Accelerator:

--- a/lib/marin/src/marin/inference/quick_serve_cli.py
+++ b/lib/marin/src/marin/inference/quick_serve_cli.py
@@ -68,14 +68,13 @@ from marin.inference.serving_backend import LevanterBackend, ServingBackend, Vll
 from marin.inference.tpu_vllm_pins import tpu_inference_fork_ref, vllm_fork_ref
 from marin.inference.vllm_server import (
     DEFAULT_CUDA_VLLM_VERSION,
+    TPU_VLLM_WORKER_EXTRAS,
     WORKER_PYTHON_VERSION,
     IsolatedCudaVllm,
     IsolatedTpuVllm,
     VllmType,
 )
 
-# vLLM and the dashboard need the generic TPU stack plus the TPU-vLLM runtime.
-_WORKER_EXTRAS = ("tpu", "vllm")
 # The GPU serve worker only runs the dashboard/registry glue plus a `vllm serve`
 # subprocess; CUDA vLLM is provisioned in an isolated uv-tool env (not the workspace
 # lock), so the worker venv needs no accelerator extra at all — base Marin suffices.
@@ -189,7 +188,7 @@ def _resolve_serving_plan(
             vllm, launcher=IsolatedTpuVllm(vllm_ref=vllm_fork_ref(), tpu_inference_ref=tpu_inference_fork_ref())
         )
         return ServingPlan(vllm, device, ("tpu", *extras), tpu_type=tpu)
-    return ServingPlan(vllm, device, (*_WORKER_EXTRAS, *extras), tpu_type=tpu)
+    return ServingPlan(vllm, device, (*TPU_VLLM_WORKER_EXTRAS, *extras), tpu_type=tpu)
 
 
 def _default_job_name(model: str) -> str:

--- a/lib/marin/src/marin/inference/quick_serve_cli.py
+++ b/lib/marin/src/marin/inference/quick_serve_cli.py
@@ -67,6 +67,7 @@ from marin.inference.quick_serve import QuickServeConfig, serve_in_job
 from marin.inference.serving_backend import LevanterBackend, ServingBackend, VllmBackend
 from marin.inference.tpu_vllm_pins import tpu_inference_fork_ref, vllm_fork_ref
 from marin.inference.vllm_server import (
+    DEFAULT_CUDA_VLLM_VERSION,
     WORKER_PYTHON_VERSION,
     IsolatedCudaVllm,
     IsolatedTpuVllm,
@@ -83,10 +84,6 @@ _GPU_WORKER_EXTRAS: tuple[str, ...] = ()
 # marin-core already depends on marin-levanter[serve] for the FastAPI/uvicorn surface.
 _LEVANTER_TPU_EXTRAS = ("tpu",)
 _LEVANTER_GPU_EXTRAS = ("gpu",)
-# Pinned CUDA vLLM for the GPU path, overridable with --vllm-version. Stock PyPI vLLM
-# (>=0.25) targets torch 2.11 / CUDA 13; provisioned per-job via uvx, so a bump is just
-# this string with no workspace re-lock.
-DEFAULT_CUDA_VLLM_VERSION = "0.25.0"
 _ENDPOINT_READY_POLL_SECONDS = 5.0
 
 # Options that only mean something to one backend, by Click parameter name. Passing one to the

--- a/lib/marin/src/marin/inference/vllm.py
+++ b/lib/marin/src/marin/inference/vllm.py
@@ -7,12 +7,12 @@ import uuid
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import cast
+from typing import Protocol, cast
 
 import requests
 from fray.client import JobHandle
 from fray.current_client import current_client
-from fray.types import ActorConfig, Entrypoint, JobRequest, ResourceConfig, create_environment
+from fray.types import ActorConfig, Entrypoint, GpuConfig, JobRequest, ResourceConfig, TpuConfig, create_environment
 from iris.cluster.client.job_info import get_job_info
 from rigging.log_setup import configure_logging
 
@@ -20,7 +20,14 @@ from marin.evaluation.evaluators.evaluator import ModelConfig
 from marin.inference.broker import InferenceBroker
 from marin.inference.proxy import serve_inference_proxy
 from marin.inference.types import InferenceRequestProvider, InferenceResponseProvider, OpenAIEndpoint, RunningModel
-from marin.inference.vllm_server import VllmEnvironment
+from marin.inference.vllm_server import (
+    DEFAULT_CUDA_VLLM_VERSION,
+    IsolatedCudaVllm,
+    VllmEnvironment,
+    VllmLauncher,
+    VllmType,
+    WorkspaceVllm,
+)
 from marin.inference.worker import (
     InferenceWorker,
     run_inference_worker,
@@ -41,15 +48,97 @@ DEFAULT_BROKERED_PROXY_START_TIMEOUT = timedelta(seconds=10)
 DEFAULT_BROKERED_MAX_IN_FLIGHT_PER_WORKER = 16
 
 
+class BrokeredVllmBackend(Protocol):
+    """Accelerator-specific vLLM worker configuration."""
+
+    def validate_worker_resources(self, resources: ResourceConfig) -> None:
+        """Validate that ``resources`` can run this backend."""
+        ...
+
+    def worker_environment_extras(self) -> tuple[str, ...]:
+        """Return Marin dependency extras installed in each worker environment."""
+        ...
+
+    def vllm_launcher(self) -> VllmLauncher:
+        """Return the launcher for the worker's vLLM subprocess."""
+        ...
+
+    def server_args(self, resources: ResourceConfig | None) -> list[str]:
+        """Return accelerator-specific arguments passed to ``vllm serve``."""
+        ...
+
+
+@dataclass(frozen=True)
+class TpuVllmBackend:
+    """Run the workspace TPU-vLLM stack in brokered workers."""
+
+    def validate_worker_resources(self, resources: ResourceConfig) -> None:
+        if not isinstance(resources.device, TpuConfig):
+            raise ValueError("TpuVllmBackend requires TPU worker_resources.")
+
+    def worker_environment_extras(self) -> tuple[str, ...]:
+        return ("tpu", "vllm")
+
+    def vllm_launcher(self) -> VllmLauncher:
+        return WorkspaceVllm()
+
+    def server_args(self, resources: ResourceConfig | None) -> list[str]:
+        return []
+
+
+@dataclass(frozen=True)
+class GpuVllmBackend:
+    """Run isolated CUDA vLLM in brokered GPU workers.
+
+    CUDA vLLM stays outside Marin's workspace environment so its torch/CUDA dependency tree does
+    not conflict with the TPU-oriented ``vllm`` extra. By default one vLLM process tensor-parallels
+    across every GPU requested by the worker's :class:`ResourceConfig`.
+    """
+
+    source: VllmType = VllmType.UPSTREAM
+    version: str | None = DEFAULT_CUDA_VLLM_VERSION
+    tensor_parallel_size: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.source is VllmType.UPSTREAM and not self.version:
+            raise ValueError("GpuVllmBackend with the upstream source requires a vLLM version.")
+        if self.tensor_parallel_size is not None and self.tensor_parallel_size <= 0:
+            raise ValueError("GpuVllmBackend.tensor_parallel_size must be positive.")
+
+    def validate_worker_resources(self, resources: ResourceConfig) -> None:
+        if not isinstance(resources.device, GpuConfig):
+            raise ValueError("GpuVllmBackend requires GPU worker_resources.")
+        if resources.replicas != 1:
+            raise ValueError("GpuVllmBackend supports one CoreWeave node per brokered worker.")
+        if self.tensor_parallel_size is not None and self.tensor_parallel_size > resources.device.count:
+            raise ValueError("GpuVllmBackend.tensor_parallel_size cannot exceed the number of requested worker GPUs.")
+
+    def worker_environment_extras(self) -> tuple[str, ...]:
+        # IsolatedCudaVllm provisions CUDA vLLM; the worker only needs base Marin.
+        return ()
+
+    def vllm_launcher(self) -> VllmLauncher:
+        return IsolatedCudaVllm(source=self.source, version=self.version)
+
+    def server_args(self, resources: ResourceConfig | None) -> list[str]:
+        tensor_parallel_size = self.tensor_parallel_size
+        if tensor_parallel_size is None and resources is not None:
+            assert isinstance(resources.device, GpuConfig)
+            tensor_parallel_size = resources.device.count
+        if tensor_parallel_size is None:
+            return []
+        return ["--tensor-parallel-size", str(tensor_parallel_size)]
+
+
 @dataclass(frozen=True)
 class VllmServerConfig:
     # Local port for `vllm serve` inside each worker process.
     port: int = 8000
-    # vLLM TPU startup can include model download and compile work.
+    # vLLM startup can include model download and compile work.
     timeout_seconds: int = 1800
     # Default vLLM maximum sequence length, including prompt and generated tokens.
     max_model_len: int = 4096
-    # Keep prefill modest on v5p-8 while still exercising vLLM's internal batching.
+    # Keep prefill modest while still exercising vLLM's internal batching.
     max_num_batched_tokens: int = 1024
 
 
@@ -87,24 +176,23 @@ class InferenceWorkerConfig:
 class BrokeredVllmSystemConfig:
     model: str
     tokenizer: str | None = None
+    backend: BrokeredVllmBackend = field(default_factory=TpuVllmBackend)
     # Recovery timeout for work fetched by a worker but not answered.
     request_lease_timeout_seconds: float = DEFAULT_BROKERED_REQUEST_LEASE_TIMEOUT.total_seconds()
     server: VllmServerConfig = field(default_factory=VllmServerConfig)
     proxy: VllmProxyConfig = field(default_factory=VllmProxyConfig)
     workers: InferenceWorkerConfig = field(default_factory=InferenceWorkerConfig)
-    # Required when running worker jobs through Iris; ignored by local mode.
+    # Required in Iris mode. GPU local mode also uses it to infer tensor parallelism.
     worker_resources: ResourceConfig | None = None
-    # Broker is CPU-only; TPU work happens in worker jobs.
+    # Broker is CPU-only; accelerator work happens in worker jobs.
     broker_resources: ResourceConfig = field(
         default_factory=lambda: ResourceConfig.with_cpu(cpu=2, ram="8g", disk="20g")
     )
-    # Worker jobs need the generic TPU stack plus the TPU-vLLM runtime stack; the CPU parent only needs base Marin.
-    worker_environment_extras: tuple[str, ...] = ("tpu", "vllm")
-    # TPU/vLLM-specific env vars stay explicit at the entrypoint.
+    # Accelerator/vLLM-specific env vars stay explicit at the entrypoint.
     worker_env_vars: Mapping[str, str] = field(default_factory=dict)
     # Actor startup waits on Iris endpoint registration.
     broker_ready_timeout_seconds: float = 900.0
-    # Applied to broker actor and TPU worker child jobs.
+    # Applied to the broker actor and accelerator worker child jobs.
     priority: int = 0
 
     def __post_init__(self) -> None:
@@ -140,6 +228,7 @@ def start_iris_brokered_vllm(config: BrokeredVllmSystemConfig) -> Iterator[Runni
 
     if config.worker_resources is None:
         raise ValueError("worker_resources must be set for Iris brokered vLLM mode.")
+    config.backend.validate_worker_resources(config.worker_resources)
 
     client = current_client()
     job_info = get_job_info()
@@ -162,7 +251,7 @@ def start_iris_brokered_vllm(config: BrokeredVllmSystemConfig) -> Iterator[Runni
         broker_handle = broker_group.wait_ready(count=1, timeout=config.broker_ready_timeout_seconds)[0]
         request_provider = cast(InferenceRequestProvider, broker_handle)
         response_provider = cast(InferenceResponseProvider, broker_handle)
-        worker_extras = list(config.worker_environment_extras)
+        worker_extras = list(config.backend.worker_environment_extras())
         worker_environment = create_environment(
             extras=worker_extras,
             env_vars=env_vars_for_dependency_groups(
@@ -195,6 +284,8 @@ def start_iris_brokered_vllm(config: BrokeredVllmSystemConfig) -> Iterator[Runni
 
 @contextlib.contextmanager
 def start_local_vllm_server(config: BrokeredVllmSystemConfig) -> Iterator[RunningModel]:
+    if config.worker_resources is not None:
+        config.backend.validate_worker_resources(config.worker_resources)
     server_config = config.server
     vllm_model = ModelConfig(
         name="brokered-vllm",
@@ -212,7 +303,11 @@ def start_local_vllm_server(config: BrokeredVllmSystemConfig) -> Iterator[Runnin
         server_config.max_num_batched_tokens,
     )
     with VllmEnvironment(
-        model=vllm_model, port=server_config.port, timeout_seconds=server_config.timeout_seconds
+        model=vllm_model,
+        port=server_config.port,
+        timeout_seconds=server_config.timeout_seconds,
+        extra_args=config.backend.server_args(config.worker_resources),
+        launcher=config.backend.vllm_launcher(),
     ) as env:
         if env.model_id is None:
             raise RuntimeError("Expected vLLM server to expose a model id.")

--- a/lib/marin/src/marin/inference/vllm.py
+++ b/lib/marin/src/marin/inference/vllm.py
@@ -63,7 +63,7 @@ class BrokeredVllmBackend(Protocol):
         """Return the launcher for the worker's vLLM subprocess."""
         ...
 
-    def server_args(self, resources: ResourceConfig | None) -> list[str]:
+    def server_args(self, _resources: ResourceConfig | None) -> list[str]:
         """Return accelerator-specific arguments passed to ``vllm serve``."""
         ...
 
@@ -82,17 +82,15 @@ class TpuVllmBackend:
     def vllm_launcher(self) -> VllmLauncher:
         return WorkspaceVllm()
 
-    def server_args(self, resources: ResourceConfig | None) -> list[str]:
+    def server_args(self, _resources: ResourceConfig | None) -> list[str]:
         return []
 
 
 @dataclass(frozen=True)
 class GpuVllmBackend:
-    """Run isolated CUDA vLLM in brokered GPU workers.
+    """Serve brokered requests with CUDA vLLM on one GPU node.
 
-    CUDA vLLM stays outside Marin's workspace environment so its torch/CUDA dependency tree does
-    not conflict with the TPU-oriented ``vllm`` extra. By default one vLLM process tensor-parallels
-    across every GPU requested by the worker's :class:`ResourceConfig`.
+    ``tensor_parallel_size`` defaults to every GPU requested by the worker resources.
     """
 
     source: VllmType = VllmType.UPSTREAM
@@ -120,11 +118,11 @@ class GpuVllmBackend:
     def vllm_launcher(self) -> VllmLauncher:
         return IsolatedCudaVllm(source=self.source, version=self.version)
 
-    def server_args(self, resources: ResourceConfig | None) -> list[str]:
+    def server_args(self, _resources: ResourceConfig | None) -> list[str]:
         tensor_parallel_size = self.tensor_parallel_size
-        if tensor_parallel_size is None and resources is not None:
-            assert isinstance(resources.device, GpuConfig)
-            tensor_parallel_size = resources.device.count
+        if tensor_parallel_size is None and _resources is not None:
+            assert isinstance(_resources.device, GpuConfig)
+            tensor_parallel_size = _resources.device.count
         if tensor_parallel_size is None:
             return []
         return ["--tensor-parallel-size", str(tensor_parallel_size)]

--- a/lib/marin/src/marin/inference/vllm.py
+++ b/lib/marin/src/marin/inference/vllm.py
@@ -22,6 +22,7 @@ from marin.inference.proxy import serve_inference_proxy
 from marin.inference.types import InferenceRequestProvider, InferenceResponseProvider, OpenAIEndpoint, RunningModel
 from marin.inference.vllm_server import (
     DEFAULT_CUDA_VLLM_VERSION,
+    TPU_VLLM_WORKER_EXTRAS,
     IsolatedCudaVllm,
     VllmEnvironment,
     VllmLauncher,
@@ -51,21 +52,13 @@ DEFAULT_BROKERED_MAX_IN_FLIGHT_PER_WORKER = 16
 class BrokeredVllmBackend(Protocol):
     """Accelerator-specific vLLM worker configuration."""
 
-    def validate_worker_resources(self, resources: ResourceConfig) -> None:
-        """Validate that ``resources`` can run this backend."""
-        ...
+    def validate_worker_resources(self, resources: ResourceConfig) -> None: ...
 
-    def worker_environment_extras(self) -> tuple[str, ...]:
-        """Return Marin dependency extras installed in each worker environment."""
-        ...
+    def worker_environment_extras(self) -> tuple[str, ...]: ...
 
-    def vllm_launcher(self) -> VllmLauncher:
-        """Return the launcher for the worker's vLLM subprocess."""
-        ...
+    def vllm_launcher(self) -> VllmLauncher: ...
 
-    def server_args(self, resources: ResourceConfig | None, /) -> list[str]:
-        """Return accelerator-specific arguments passed to ``vllm serve``."""
-        ...
+    def server_args(self, resources: ResourceConfig | None, /) -> list[str]: ...
 
 
 @dataclass(frozen=True)
@@ -77,7 +70,7 @@ class TpuVllmBackend:
             raise ValueError("TpuVllmBackend requires TPU worker_resources.")
 
     def worker_environment_extras(self) -> tuple[str, ...]:
-        return ("tpu", "vllm")
+        return TPU_VLLM_WORKER_EXTRAS
 
     def vllm_launcher(self) -> VllmLauncher:
         return WorkspaceVllm()

--- a/lib/marin/src/marin/inference/vllm.py
+++ b/lib/marin/src/marin/inference/vllm.py
@@ -4,7 +4,7 @@
 import contextlib
 import logging
 import uuid
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Protocol, cast
@@ -180,7 +180,7 @@ class BrokeredVllmSystemConfig:
         default_factory=lambda: ResourceConfig.with_cpu(cpu=2, ram="8g", disk="20g")
     )
     # Accelerator/vLLM-specific env vars stay explicit at the entrypoint.
-    worker_env_vars: Mapping[str, str] = field(default_factory=dict)
+    worker_env_vars: tuple[tuple[str, str], ...] = ()
     # Actor startup waits on Iris endpoint registration.
     broker_ready_timeout_seconds: float = 900.0
     # Applied to the broker actor and accelerator worker child jobs.

--- a/lib/marin/src/marin/inference/vllm.py
+++ b/lib/marin/src/marin/inference/vllm.py
@@ -63,7 +63,7 @@ class BrokeredVllmBackend(Protocol):
         """Return the launcher for the worker's vLLM subprocess."""
         ...
 
-    def server_args(self, _resources: ResourceConfig | None) -> list[str]:
+    def server_args(self, resources: ResourceConfig | None, /) -> list[str]:
         """Return accelerator-specific arguments passed to ``vllm serve``."""
         ...
 
@@ -82,7 +82,7 @@ class TpuVllmBackend:
     def vllm_launcher(self) -> VllmLauncher:
         return WorkspaceVllm()
 
-    def server_args(self, _resources: ResourceConfig | None) -> list[str]:
+    def server_args(self, _resources: ResourceConfig | None, /) -> list[str]:
         return []
 
 
@@ -118,11 +118,11 @@ class GpuVllmBackend:
     def vllm_launcher(self) -> VllmLauncher:
         return IsolatedCudaVllm(source=self.source, version=self.version)
 
-    def server_args(self, _resources: ResourceConfig | None) -> list[str]:
+    def server_args(self, resources: ResourceConfig | None, /) -> list[str]:
         tensor_parallel_size = self.tensor_parallel_size
-        if tensor_parallel_size is None and _resources is not None:
-            assert isinstance(_resources.device, GpuConfig)
-            tensor_parallel_size = _resources.device.count
+        if tensor_parallel_size is None and resources is not None:
+            assert isinstance(resources.device, GpuConfig)
+            tensor_parallel_size = resources.device.count
         if tensor_parallel_size is None:
             return []
         return ["--tensor-parallel-size", str(tensor_parallel_size)]

--- a/lib/marin/src/marin/inference/vllm_server.py
+++ b/lib/marin/src/marin/inference/vllm_server.py
@@ -39,6 +39,7 @@ WORKER_PYTHON_VERSION = "3.12"
 # Stock CUDA vLLM used by GPU serving. It runs in an isolated uv-tool environment, so it does not
 # participate in Marin's workspace dependency resolution.
 DEFAULT_CUDA_VLLM_VERSION = "0.25.1"
+TPU_VLLM_WORKER_EXTRAS = ("tpu", "vllm")
 # Pinned Run:ai model streamer for the fork's distributed s3:// checkpoint loader. The upstream
 # vllm[runai] extra bundles this; the git fork does not, so MARIN_FORK adds it explicitly.
 _RUNAI_STREAMER_REQUIREMENT = "runai-model-streamer[s3]==0.16.0"

--- a/lib/marin/src/marin/inference/vllm_server.py
+++ b/lib/marin/src/marin/inference/vllm_server.py
@@ -42,7 +42,8 @@ DEFAULT_CUDA_VLLM_VERSION = "0.25.1"
 # Pinned Run:ai model streamer for the fork's distributed s3:// checkpoint loader. The upstream
 # vllm[runai] extra bundles this; the git fork does not, so MARIN_FORK adds it explicitly.
 _RUNAI_STREAMER_REQUIREMENT = "runai-model-streamer[s3]==0.16.0"
-_DISABLE_FLASHINFER_SAMPLER_ENV = {"VLLM_USE_FLASHINFER_SAMPLER": "0"}
+_CUDA_TORCH_BACKEND = "cu130"
+_FLASHINFER_SAMPLER_ENV_VAR = "VLLM_USE_FLASHINFER_SAMPLER"
 
 
 class VllmLauncher(Protocol):
@@ -80,22 +81,10 @@ class VllmType(StrEnum):
 
 @dataclass(frozen=True)
 class IsolatedCudaVllm:
-    """Run CUDA vLLM from a throwaway uv-managed environment via ``uvx``.
+    """Provide an isolated CUDA vLLM command and environment.
 
-    One launcher, two sources (see :class:`VllmType`):
-
-    - ``UPSTREAM`` — stock ``vllm[runai]==<version>`` on the cu130 torch backend. Serves any
-      architecture upstream vLLM knows; this is the ``marin-serve --gpu`` default.
-    - ``MARIN_FORK`` — Marin's vLLM fork (pinned by ``tool.uv.sources.vllm`` via
-      :func:`~marin.inference.tpu_vllm_pins.vllm_fork_ref`), needed to serve Marin-custom
-      architectures upstream cannot load (e.g. ``grug_moe``). Built with ``VLLM_USE_PRECOMPILED``
-      on the cu130 backend, with the Run:ai streamer added and virtual-hosted S3 addressing set
-      for the CoreWeave object store.
-
-    GPU serving pins CUDA vLLM here instead of the workspace lockfile: vLLM is only ever a
-    ``vllm serve`` subprocess, so ``uvx`` provisions it — and its torch/CUDA wheel tree — in a
-    cached, isolated env that never enters Marin's resolution. Bumping upstream is just the
-    version string; bumping the fork is a one-line ``tool.uv.sources.vllm`` edit.
+    Upstream serves standard vLLM architectures. The Marin fork additionally serves Marin-specific
+    architectures and streams checkpoints from the CoreWeave object store.
     """
 
     source: VllmType = VllmType.UPSTREAM
@@ -111,9 +100,9 @@ class IsolatedCudaVllm:
 
     def command(self) -> list[str]:
         if self.source is VllmType.MARIN_FORK:
-            from_spec, torch_backend, extra = vllm_fork_ref(), "cu130", ["--with", _RUNAI_STREAMER_REQUIREMENT]
+            from_spec, extra = vllm_fork_ref(), ["--with", _RUNAI_STREAMER_REQUIREMENT]
         else:
-            from_spec, torch_backend, extra = f"vllm[runai]=={self.version}", "cu130", []
+            from_spec, extra = f"vllm[runai]=={self.version}", []
         return [
             "uvx",
             "--from",
@@ -122,14 +111,14 @@ class IsolatedCudaVllm:
             "--python",
             self.python_version,
             "--torch-backend",
-            torch_backend,
+            _CUDA_TORCH_BACKEND,
             "vllm",
         ]
 
     def env(self) -> dict[str, str]:
         # CoreWeave runtime images provide CUDA libraries but not nvcc. FlashInfer may otherwise
         # JIT-compile its sampling kernel; vLLM's native/Triton sampler needs no CUDA toolkit.
-        environment = dict(_DISABLE_FLASHINFER_SAMPLER_ENV)
+        environment = {_FLASHINFER_SAMPLER_ENV_VAR: "0"}
         if self.source is VllmType.MARIN_FORK:
             environment.update(
                 {

--- a/lib/marin/src/marin/inference/vllm_server.py
+++ b/lib/marin/src/marin/inference/vllm_server.py
@@ -36,9 +36,13 @@ _REMOVED_VLLM_MODE_MESSAGE = (
 # venv and the isolated uvx vLLM envs. Kept single so they cannot drift — cloudpickle needs the
 # worker venv to match the launching CLI, and the uvx env to match the venv. Marin pins 3.12.
 WORKER_PYTHON_VERSION = "3.12"
+# Stock CUDA vLLM used by GPU serving. It runs in an isolated uv-tool environment, so it does not
+# participate in Marin's workspace dependency resolution.
+DEFAULT_CUDA_VLLM_VERSION = "0.25.1"
 # Pinned Run:ai model streamer for the fork's distributed s3:// checkpoint loader. The upstream
 # vllm[runai] extra bundles this; the git fork does not, so MARIN_FORK adds it explicitly.
 _RUNAI_STREAMER_REQUIREMENT = "runai-model-streamer[s3]==0.16.0"
+_DISABLE_FLASHINFER_SAMPLER_ENV = {"VLLM_USE_FLASHINFER_SAMPLER": "0"}
 
 
 class VllmLauncher(Protocol):
@@ -80,7 +84,7 @@ class IsolatedCudaVllm:
 
     One launcher, two sources (see :class:`VllmType`):
 
-    - ``UPSTREAM`` — stock ``vllm[runai]==<version>`` on the cu128 torch backend. Serves any
+    - ``UPSTREAM`` — stock ``vllm[runai]==<version>`` on the cu130 torch backend. Serves any
       architecture upstream vLLM knows; this is the ``marin-serve --gpu`` default.
     - ``MARIN_FORK`` — Marin's vLLM fork (pinned by ``tool.uv.sources.vllm`` via
       :func:`~marin.inference.tpu_vllm_pins.vllm_fork_ref`), needed to serve Marin-custom
@@ -109,7 +113,7 @@ class IsolatedCudaVllm:
         if self.source is VllmType.MARIN_FORK:
             from_spec, torch_backend, extra = vllm_fork_ref(), "cu130", ["--with", _RUNAI_STREAMER_REQUIREMENT]
         else:
-            from_spec, torch_backend, extra = f"vllm[runai]=={self.version}", "cu128", []
+            from_spec, torch_backend, extra = f"vllm[runai]=={self.version}", "cu130", []
         return [
             "uvx",
             "--from",
@@ -123,13 +127,17 @@ class IsolatedCudaVllm:
         ]
 
     def env(self) -> dict[str, str]:
+        # CoreWeave runtime images provide CUDA libraries but not nvcc. FlashInfer may otherwise
+        # JIT-compile its sampling kernel; vLLM's native/Triton sampler needs no CUDA toolkit.
+        environment = dict(_DISABLE_FLASHINFER_SAMPLER_ENV)
         if self.source is VllmType.MARIN_FORK:
-            return {
-                "VLLM_USE_PRECOMPILED": "1",
-                "VLLM_USE_FLASHINFER_SAMPLER": "0",
-                "AWS_CONFIG_FILE": _write_virtual_hosted_s3_config(),
-            }
-        return {}
+            environment.update(
+                {
+                    "VLLM_USE_PRECOMPILED": "1",
+                    "AWS_CONFIG_FILE": _write_virtual_hosted_s3_config(),
+                }
+            )
+        return environment
 
 
 def _write_virtual_hosted_s3_config() -> str:

--- a/tests/evals/test_inference_proxy.py
+++ b/tests/evals/test_inference_proxy.py
@@ -40,7 +40,7 @@ from marin.inference.vllm import (
     start_local_brokered_vllm,
     start_local_vllm_server,
 )
-from marin.inference.vllm_server import IsolatedCudaVllm, VllmType
+from marin.inference.vllm_server import DEFAULT_CUDA_VLLM_VERSION, IsolatedCudaVllm, VllmType
 from marin.inference.worker import InferenceWorker, run_inference_worker
 from rigging.timing import ExponentialBackoff
 
@@ -64,7 +64,7 @@ def test_brokered_gpu_eval_lowers_with_symbolic_worker_resources() -> None:
     assert fingerprint["inference"]["backend"] == {
         "source": "upstream",
         "tensor_parallel_size": None,
-        "version": "0.25.1",
+        "version": DEFAULT_CUDA_VLLM_VERSION,
     }
 
 
@@ -242,13 +242,10 @@ def test_iris_brokered_vllm_worker_environment_matches_backend(
 
 def test_gpu_backend_uses_isolated_cuda() -> None:
     backend = GpuVllmBackend()
-    resources = ResourceConfig.with_gpu("H100", count=8)
-
-    backend.validate_worker_resources(resources)
 
     assert backend.vllm_launcher() == IsolatedCudaVllm(
         source=VllmType.UPSTREAM,
-        version="0.25.1",
+        version=DEFAULT_CUDA_VLLM_VERSION,
     )
 
 

--- a/tests/evals/test_inference_proxy.py
+++ b/tests/evals/test_inference_proxy.py
@@ -228,7 +228,7 @@ def test_iris_brokered_vllm_worker_environment_matches_backend(
         model="gpt2",
         backend=backend,
         worker_resources=worker_resources,
-        worker_env_vars={"VLLM_ENABLE_V1_MULTIPROCESSING": "0"},
+        worker_env_vars=(("VLLM_ENABLE_V1_MULTIPROCESSING", "0"),),
     )
 
     with start_iris_brokered_vllm(config):

--- a/tests/evals/test_inference_proxy.py
+++ b/tests/evals/test_inference_proxy.py
@@ -15,6 +15,7 @@ import httpx
 import marin.inference.vllm as vllm_module
 import pytest
 from fray.types import ResourceConfig
+from marin.execution.lazy import lower
 from marin.inference.broker import InferenceBroker
 from marin.inference.proxy import InferenceProxy, serve_inference_proxy
 from marin.inference.types import (
@@ -30,14 +31,19 @@ from marin.inference.types import (
 from marin.inference.vllm import (
     DEFAULT_BROKERED_MAX_IN_FLIGHT_PER_WORKER,
     BrokeredVllmSystemConfig,
+    GpuVllmBackend,
     InferenceWorkerConfig,
+    TpuVllmBackend,
     VllmProxyConfig,
     start_iris_brokered_vllm,
     start_local_brokered_vllm,
+    start_local_vllm_server,
 )
+from marin.inference.vllm_server import IsolatedCudaVllm, VllmType
 from marin.inference.worker import InferenceWorker, run_inference_worker
 from rigging.timing import ExponentialBackoff
 
+from experiments.evals.served_qwen3 import QWEN3_GPU_EVAL_RESULTS
 from tests.evals.openai_stub import (
     DeterministicOpenAIStub,
     assert_completions_scoring_contract,
@@ -45,6 +51,12 @@ from tests.evals.openai_stub import (
 )
 
 BROKER_LEASE_TIMEOUT_SECONDS = 300.0
+
+
+def test_brokered_gpu_eval_lowers_with_symbolic_worker_resources() -> None:
+    step = lower(QWEN3_GPU_EVAL_RESULTS)
+
+    assert step.name == "evals/qwen3-0.6b-gpu/suite"
 
 
 @dataclass
@@ -153,7 +165,20 @@ def test_local_brokered_vllm_rejects_multiple_workers() -> None:
             pass
 
 
-def test_iris_brokered_vllm_worker_env_defaults_tpu_build_settings(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("backend", "worker_resources", "expected_extras", "expected_target_device"),
+    [
+        (TpuVllmBackend(), ResourceConfig.with_tpu("v6e-4"), ["tpu", "vllm"], "tpu"),
+        (GpuVllmBackend(), ResourceConfig.with_gpu("H100", count=8), [], None),
+    ],
+)
+def test_iris_brokered_vllm_worker_environment_matches_backend(
+    monkeypatch,
+    backend,
+    worker_resources,
+    expected_extras,
+    expected_target_device,
+) -> None:
     class _FakeJob:
         job_id = "worker-0"
 
@@ -192,7 +217,8 @@ def test_iris_brokered_vllm_worker_env_defaults_tpu_build_settings(monkeypatch) 
 
     config = BrokeredVllmSystemConfig(
         model="gpt2",
-        worker_resources=ResourceConfig.with_tpu("v6e-4"),
+        backend=backend,
+        worker_resources=worker_resources,
         worker_env_vars={"VLLM_ENABLE_V1_MULTIPROCESSING": "0"},
     )
 
@@ -200,9 +226,58 @@ def test_iris_brokered_vllm_worker_env_defaults_tpu_build_settings(monkeypatch) 
         pass
 
     [worker_request] = client.submissions
-    assert worker_request.environment.extras == ["tpu", "vllm"]
+    assert worker_request.environment.extras == expected_extras
     assert worker_request.environment.env_vars["VLLM_ENABLE_V1_MULTIPROCESSING"] == "0"
-    assert worker_request.environment.env_vars["VLLM_TARGET_DEVICE"] == "tpu"
+    assert worker_request.environment.env_vars.get("VLLM_TARGET_DEVICE") == expected_target_device
+
+
+def test_gpu_brokered_vllm_uses_isolated_cuda_and_all_requested_gpus(monkeypatch) -> None:
+    captured = SimpleNamespace()
+
+    class _FakeVllmEnvironment:
+        server_url = "http://127.0.0.1:8000/v1"
+        model_id = "gpt2"
+
+        def __init__(self, model, **kwargs) -> None:
+            captured.model = model
+            captured.kwargs = kwargs
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback) -> None:
+            pass
+
+    monkeypatch.setattr(vllm_module, "VllmEnvironment", _FakeVllmEnvironment)
+    config = BrokeredVllmSystemConfig(
+        model="gpt2",
+        backend=GpuVllmBackend(),
+        worker_resources=ResourceConfig.with_gpu("H100", count=8),
+    )
+
+    with start_local_vllm_server(config) as model:
+        assert model.endpoint.model == "gpt2"
+
+    assert captured.kwargs["launcher"] == IsolatedCudaVllm(
+        source=VllmType.UPSTREAM,
+        version="0.25.1",
+    )
+    assert captured.kwargs["extra_args"] == ["--tensor-parallel-size", "8"]
+
+
+@pytest.mark.parametrize(
+    ("backend", "worker_resources"),
+    [
+        (TpuVllmBackend(), ResourceConfig.with_gpu("H100")),
+        (GpuVllmBackend(), ResourceConfig.with_tpu("v6e-4")),
+    ],
+)
+def test_brokered_vllm_rejects_resources_for_the_wrong_backend(backend, worker_resources) -> None:
+    config = BrokeredVllmSystemConfig(model="gpt2", backend=backend, worker_resources=worker_resources)
+
+    with pytest.raises(ValueError, match=r"Backend requires .* worker_resources"):
+        with start_local_vllm_server(config):
+            pass
 
 
 def test_inference_proxy_forwards_completions_to_running_model(mock_cluster: MockInferenceCluster) -> None:

--- a/tests/evals/test_inference_proxy.py
+++ b/tests/evals/test_inference_proxy.py
@@ -240,7 +240,7 @@ def test_iris_brokered_vllm_worker_environment_matches_backend(
     assert worker_request.environment.env_vars.get("VLLM_TARGET_DEVICE") == expected_target_device
 
 
-def test_gpu_backend_uses_isolated_cuda_and_all_requested_gpus() -> None:
+def test_gpu_backend_uses_isolated_cuda() -> None:
     backend = GpuVllmBackend()
     resources = ResourceConfig.with_gpu("H100", count=8)
 
@@ -250,7 +250,6 @@ def test_gpu_backend_uses_isolated_cuda_and_all_requested_gpus() -> None:
         source=VllmType.UPSTREAM,
         version="0.25.1",
     )
-    assert backend.server_args(resources) == ["--tensor-parallel-size", "8"]
 
 
 @pytest.mark.parametrize(

--- a/tests/evals/test_inference_proxy.py
+++ b/tests/evals/test_inference_proxy.py
@@ -40,7 +40,7 @@ from marin.inference.vllm import (
     start_local_brokered_vllm,
     start_local_vllm_server,
 )
-from marin.inference.vllm_server import DEFAULT_CUDA_VLLM_VERSION, IsolatedCudaVllm, VllmType
+from marin.inference.vllm_server import DEFAULT_CUDA_VLLM_VERSION
 from marin.inference.worker import InferenceWorker, run_inference_worker
 from rigging.timing import ExponentialBackoff
 
@@ -238,15 +238,6 @@ def test_iris_brokered_vllm_worker_environment_matches_backend(
     assert worker_request.environment.extras == expected_extras
     assert worker_request.environment.env_vars["VLLM_ENABLE_V1_MULTIPROCESSING"] == "0"
     assert worker_request.environment.env_vars.get("VLLM_TARGET_DEVICE") == expected_target_device
-
-
-def test_gpu_backend_uses_isolated_cuda() -> None:
-    backend = GpuVllmBackend()
-
-    assert backend.vllm_launcher() == IsolatedCudaVllm(
-        source=VllmType.UPSTREAM,
-        version=DEFAULT_CUDA_VLLM_VERSION,
-    )
 
 
 @pytest.mark.parametrize(

--- a/tests/evals/test_inference_proxy.py
+++ b/tests/evals/test_inference_proxy.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import json
 import socket
 import threading
 from collections.abc import Iterator
@@ -55,8 +56,16 @@ BROKER_LEASE_TIMEOUT_SECONDS = 300.0
 
 def test_brokered_gpu_eval_lowers_with_symbolic_worker_resources() -> None:
     step = lower(QWEN3_GPU_EVAL_RESULTS)
+    fingerprint = json.loads(step.fingerprint_payload)
 
-    assert step.name == "evals/qwen3-0.6b-gpu/suite"
+    # Artifact lowering replaces runtime resources with a symbolic value. Backend validation must
+    # remain at the serving boundary, where the concrete ResourceConfig is available.
+    assert fingerprint["inference"]["worker_resources"] == "<worker_resources>"
+    assert fingerprint["inference"]["backend"] == {
+        "source": "upstream",
+        "tensor_parallel_size": None,
+        "version": "0.25.1",
+    }
 
 
 @dataclass
@@ -231,38 +240,17 @@ def test_iris_brokered_vllm_worker_environment_matches_backend(
     assert worker_request.environment.env_vars.get("VLLM_TARGET_DEVICE") == expected_target_device
 
 
-def test_gpu_brokered_vllm_uses_isolated_cuda_and_all_requested_gpus(monkeypatch) -> None:
-    captured = SimpleNamespace()
+def test_gpu_backend_uses_isolated_cuda_and_all_requested_gpus() -> None:
+    backend = GpuVllmBackend()
+    resources = ResourceConfig.with_gpu("H100", count=8)
 
-    class _FakeVllmEnvironment:
-        server_url = "http://127.0.0.1:8000/v1"
-        model_id = "gpt2"
+    backend.validate_worker_resources(resources)
 
-        def __init__(self, model, **kwargs) -> None:
-            captured.model = model
-            captured.kwargs = kwargs
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type, exc, traceback) -> None:
-            pass
-
-    monkeypatch.setattr(vllm_module, "VllmEnvironment", _FakeVllmEnvironment)
-    config = BrokeredVllmSystemConfig(
-        model="gpt2",
-        backend=GpuVllmBackend(),
-        worker_resources=ResourceConfig.with_gpu("H100", count=8),
-    )
-
-    with start_local_vllm_server(config) as model:
-        assert model.endpoint.model == "gpt2"
-
-    assert captured.kwargs["launcher"] == IsolatedCudaVllm(
+    assert backend.vllm_launcher() == IsolatedCudaVllm(
         source=VllmType.UPSTREAM,
         version="0.25.1",
     )
-    assert captured.kwargs["extra_args"] == ["--tensor-parallel-size", "8"]
+    assert backend.server_args(resources) == ["--tensor-parallel-size", "8"]
 
 
 @pytest.mark.parametrize(

--- a/tests/inference/test_quick_serve.py
+++ b/tests/inference/test_quick_serve.py
@@ -41,6 +41,7 @@ from marin.inference.serving_backend import (
 )
 from marin.inference.tpu_vllm_pins import vllm_fork_ref
 from marin.inference.vllm_server import (
+    DEFAULT_CUDA_VLLM_VERSION,
     WORKER_PYTHON_VERSION,
     IsolatedCudaVllm,
     IsolatedTpuVllm,
@@ -97,18 +98,18 @@ def test_checkout_free_setup_script_pins_marin_core_with_extras():
 
 
 def test_isolated_cuda_vllm_upstream_command_and_env():
-    launcher = IsolatedCudaVllm(source=VllmType.UPSTREAM, version="0.25.0")
+    launcher = IsolatedCudaVllm(source=VllmType.UPSTREAM, version="0.25.1")
     assert launcher.command() == [
         "uvx",
         "--from",
-        "vllm[runai]==0.25.0",
+        "vllm[runai]==0.25.1",
         "--python",
         WORKER_PYTHON_VERSION,
         "--torch-backend",
-        "cu128",
+        "cu130",
         "vllm",
     ]
-    assert launcher.env() == {}
+    assert launcher.env() == {"VLLM_USE_FLASHINFER_SAMPLER": "0"}
 
 
 def test_isolated_cuda_vllm_marin_fork_command_and_env():
@@ -210,7 +211,7 @@ def _plan(**overrides):
         "in_checkout": True,
         "isolated_vllm": False,
         "task_image": None,
-        "cuda_vllm_version": "0.25.0",
+        "cuda_vllm_version": DEFAULT_CUDA_VLLM_VERSION,
         "vllm_source": VllmType.UPSTREAM,
         "vllm": VllmBackend(),
         "levanter": LevanterBackend(),
@@ -242,7 +243,7 @@ def test_resolve_serving_plan_picks_the_worker_extras_the_backend_needs(override
 
 def test_gpu_plan_defaults_to_upstream_launcher():
     plan = _plan(gpu="H100x8")
-    assert plan.backend.launcher == IsolatedCudaVllm(source=VllmType.UPSTREAM, version="0.25.0")
+    assert plan.backend.launcher == IsolatedCudaVllm(source=VllmType.UPSTREAM, version="0.25.1")
 
 
 def test_gpu_plan_marin_fork_selects_fork_launcher():

--- a/tests/inference/test_quick_serve.py
+++ b/tests/inference/test_quick_serve.py
@@ -42,7 +42,6 @@ from marin.inference.serving_backend import (
 from marin.inference.tpu_vllm_pins import vllm_fork_ref
 from marin.inference.vllm_server import (
     DEFAULT_CUDA_VLLM_VERSION,
-    WORKER_PYTHON_VERSION,
     IsolatedCudaVllm,
     IsolatedTpuVllm,
     VllmType,
@@ -98,17 +97,11 @@ def test_checkout_free_setup_script_pins_marin_core_with_extras():
 
 
 def test_isolated_cuda_vllm_upstream_command_and_env():
-    launcher = IsolatedCudaVllm(source=VllmType.UPSTREAM, version="0.25.1")
-    assert launcher.command() == [
-        "uvx",
-        "--from",
-        "vllm[runai]==0.25.1",
-        "--python",
-        WORKER_PYTHON_VERSION,
-        "--torch-backend",
-        "cu130",
-        "vllm",
-    ]
+    launcher = IsolatedCudaVllm(source=VllmType.UPSTREAM, version=DEFAULT_CUDA_VLLM_VERSION)
+    command = launcher.command()
+
+    assert f"vllm[runai]=={DEFAULT_CUDA_VLLM_VERSION}" in command
+    assert command[command.index("--torch-backend") + 1] == "cu130"
     assert launcher.env() == {"VLLM_USE_FLASHINFER_SAMPLER": "0"}
 
 

--- a/tests/inference/test_quick_serve.py
+++ b/tests/inference/test_quick_serve.py
@@ -100,7 +100,7 @@ def test_isolated_cuda_vllm_upstream_command_and_env():
     launcher = IsolatedCudaVllm(source=VllmType.UPSTREAM, version=DEFAULT_CUDA_VLLM_VERSION)
     command = launcher.command()
 
-    assert f"vllm[runai]=={DEFAULT_CUDA_VLLM_VERSION}" in command
+    assert command[command.index("--from") + 1] == f"vllm[runai]=={DEFAULT_CUDA_VLLM_VERSION}"
     assert command[command.index("--torch-backend") + 1] == "cu130"
     assert launcher.env() == {"VLLM_USE_FLASHINFER_SAMPLER": "0"}
 

--- a/tests/inference/test_quick_serve.py
+++ b/tests/inference/test_quick_serve.py
@@ -96,12 +96,8 @@ def test_checkout_free_setup_script_pins_marin_core_with_extras():
     assert "vllm" not in script
 
 
-def test_isolated_cuda_vllm_upstream_command_and_env():
+def test_isolated_cuda_vllm_upstream_disables_flashinfer_sampler():
     launcher = IsolatedCudaVllm(source=VllmType.UPSTREAM, version=DEFAULT_CUDA_VLLM_VERSION)
-    command = launcher.command()
-
-    assert command[command.index("--from") + 1] == f"vllm[runai]=={DEFAULT_CUDA_VLLM_VERSION}"
-    assert command[command.index("--torch-backend") + 1] == "cu130"
     assert launcher.env() == {"VLLM_USE_FLASHINFER_SAMPLER": "0"}
 
 

--- a/tests/inference/test_quick_serve.py
+++ b/tests/inference/test_quick_serve.py
@@ -232,7 +232,10 @@ def test_resolve_serving_plan_picks_the_worker_extras_the_backend_needs(override
 
 def test_gpu_plan_defaults_to_upstream_launcher():
     plan = _plan(gpu="H100x8")
-    assert plan.backend.launcher == IsolatedCudaVllm(source=VllmType.UPSTREAM, version="0.25.1")
+    assert plan.backend.launcher == IsolatedCudaVllm(
+        source=VllmType.UPSTREAM,
+        version=DEFAULT_CUDA_VLLM_VERSION,
+    )
 
 
 def test_gpu_plan_marin_fork_selects_fork_launcher():


### PR DESCRIPTION
Add accelerator-specific brokered vLLM backends so the existing inference broker can launch either TPU workers or isolated CUDA workers on CoreWeave. GPU workers validate their resource shape, infer tensor parallelism from the requested GPUs, and share the pinned CUDA vLLM launcher used by quick serving.

Keep Qwen3 evaluation in one script with declarative TPU and GPU configurations selected by `--accelerator`. The CUDA launcher uses vLLM 0.25.1 on CUDA 13 and selects the native/Triton sampler so CoreWeave runtime images do not require nvcc.

The full GPU suite completed on CoreWeave with 16,165 matched requests and no drops, timeouts, or rejections. Results are stored at `s3://marin-us-east-02a/marin/evals/qwen3-0.6b-gpu/suite/2026.07.17`.