### PR TITLE
[coral] Generalize TPU batch calibration for tensor parallelism

### DIFF
--- a/experiments/coral/batch_calibration.py
+++ b/experiments/coral/batch_calibration.py
@@ -4,10 +4,21 @@
 """Estimate dense-transformer HBM and select a TPU batch configuration."""
 
 import math
+from dataclasses import dataclass
 
 from fray.types import get_tpu_topology, tpu_hbm_capacity_bytes
 
 BYTES_PER_GIB = 1024**3
+
+
+@dataclass(frozen=True)
+class TpuBatchConfig:
+    """Parallelism settings selected for a TPU training batch."""
+
+    data_parallelism: int
+    tensor_parallelism: int
+    per_device_parallelism: int
+    gradient_accumulation: int
 
 
 def adam_optimizer_bytes(
@@ -106,55 +117,77 @@ def tpu_batch_config(
     batch_size: int,
     batch_bytes: int,
     *,
-    data_axis_size: int | None = None,
-) -> tuple[int, int]:
-    """Select Levanter batch settings that fit a global batch on a TPU slice.
+    context_parallelism: int = 1,
+    slice_count: int = 1,
+) -> TpuBatchConfig:
+    """Select Levanter parallelism settings that fit a global batch on TPUs.
 
     Args:
         tpu: TPU topology name accepted by Fray, such as ``"v5litepod-8"``.
         batch_size: Global training batch size.
         batch_bytes: HBM needed for the full global batch. When it does not fit, memory is assumed to
             scale linearly with microbatch size.
-        data_axis_size: Chips assigned to Levanter's batch axis. Defaults to the slice chip count. For
-            example, ``"v5p-32"`` has 16 chips, so tensor parallelism of two uses ``data_axis_size=8``.
+        context_parallelism: Number of chips that split each example's sequence positions within a slice.
+        slice_count: Number of identical TPU slices used by the training job.
 
     Returns:
-        A ``(per_device_parallelism, gradient_accumulation)`` tuple. ``per_device_parallelism`` is ``-1``
-        when the full batch fits without microbatching.
+        The effective data, tensor, per-device, and gradient-accumulation parallelism. Tensor parallelism
+        uses the chips not assigned to data or context parallelism. All returned values are positive and
+        explicit, including when the full batch fits in one microstep.
 
     Raises:
-        ValueError: If the inputs are invalid or no microbatch fits the slice.
+        ValueError: If the inputs are invalid or no microbatch fits the requested slices.
     """
     topology = get_tpu_topology(tpu)
-    data_axis_size = _resolve_data_axis_size(topology.chip_count, data_axis_size)
-    _validate_batch_divisible_by_data_axis(batch_size, data_axis_size)
+    _validate_parallelism_inputs(
+        batch_size=batch_size,
+        chips_per_slice=topology.chip_count,
+        context_parallelism=context_parallelism,
+        slice_count=slice_count,
+    )
     if batch_bytes <= 0:
         raise ValueError(f"batch_bytes must be positive, got {batch_bytes}")
 
-    capacity_bytes = tpu_hbm_capacity_bytes(tpu)
-    if batch_bytes <= capacity_bytes:
-        return -1, 1
+    examples_per_slice = batch_size // slice_count
+    parallel_capacity_per_slice = topology.chip_count // context_parallelism
+    data_parallelism_per_slice = math.gcd(examples_per_slice, parallel_capacity_per_slice)
+    data_parallelism = slice_count * data_parallelism_per_slice
+    tensor_parallelism = parallel_capacity_per_slice // data_parallelism_per_slice
 
-    full_per_device_batch = batch_size // data_axis_size
+    capacity_bytes = tpu_hbm_capacity_bytes(tpu) * slice_count
+    if batch_bytes <= capacity_bytes:
+        return TpuBatchConfig(
+            data_parallelism=data_parallelism,
+            tensor_parallelism=tensor_parallelism,
+            per_device_parallelism=batch_size // data_parallelism,
+            gradient_accumulation=1,
+        )
+
+    full_per_device_batch = batch_size // data_parallelism
     for per_device_parallelism in range(full_per_device_batch, 0, -1):
         if full_per_device_batch % per_device_parallelism != 0:
             continue
-        microbatch_size = per_device_parallelism * data_axis_size
+        microbatch_size = per_device_parallelism * data_parallelism
         if _batch_bytes_for_microbatch(batch_bytes, full_batch_size=batch_size, microbatch_size=microbatch_size) <= (
             capacity_bytes
         ):
-            return per_device_parallelism, batch_size // microbatch_size
+            return TpuBatchConfig(
+                data_parallelism=data_parallelism,
+                tensor_parallelism=tensor_parallelism,
+                per_device_parallelism=per_device_parallelism,
+                gradient_accumulation=batch_size // microbatch_size,
+            )
 
     minimum_microbatch_bytes = _batch_bytes_for_microbatch(
         batch_bytes,
         full_batch_size=batch_size,
-        microbatch_size=data_axis_size,
+        microbatch_size=data_parallelism,
     )
     raise ValueError(
         f"Batch does not fit on {tpu}: even per_device_parallelism=1 "
-        f"(microbatch_size={data_axis_size}) needs {_format_gib(minimum_microbatch_bytes)}, "
+        f"(microbatch_size={data_parallelism}) needs {_format_gib(minimum_microbatch_bytes)}, "
         f"but target HBM capacity is {_format_gib(capacity_bytes)}. Use a larger TPU slice, "
-        "reduce model/sequence size, or use more model/context parallelism and pass the resulting data_axis_size."
+        "more slices, a larger batch size, or more model/context parallelism."
     )
 
 
@@ -162,29 +195,23 @@ def _batch_bytes_for_microbatch(batch_bytes: int, *, full_batch_size: int, micro
     return math.ceil(batch_bytes * microbatch_size / full_batch_size)
 
 
-def _resolve_data_axis_size(chip_count: int, data_axis_size: int | None) -> int:
-    if data_axis_size is None:
-        return chip_count
-    if data_axis_size <= 0:
-        raise ValueError(f"data_axis_size must be positive, got {data_axis_size}")
-    if chip_count % data_axis_size != 0:
-        raise ValueError(
-            f"data_axis_size ({data_axis_size}) must divide TPU chip count ({chip_count}). "
-            "For tensor/model/context parallelism, pass the number of chips left on Levanter's batch axis."
-        )
-    return data_axis_size
-
-
-def _validate_batch_divisible_by_data_axis(batch_size: int, data_axis_size: int) -> None:
+def _validate_parallelism_inputs(
+    *,
+    batch_size: int,
+    chips_per_slice: int,
+    context_parallelism: int,
+    slice_count: int,
+) -> None:
     if batch_size <= 0:
         raise ValueError(f"batch_size must be positive, got {batch_size}")
-    if batch_size % data_axis_size == 0:
-        return
-    next_valid = math.ceil(batch_size / data_axis_size) * data_axis_size
-    raise ValueError(
-        f"batch_size ({batch_size}) must be divisible by data_axis_size ({data_axis_size}) for Levanter "
-        f"microbatching. Use batch_size={next_valid}, choose another batch size, or pass the correct data_axis_size."
-    )
+    if context_parallelism <= 0:
+        raise ValueError(f"context_parallelism must be positive, got {context_parallelism}")
+    if slice_count <= 0:
+        raise ValueError(f"slice_count must be positive, got {slice_count}")
+    if chips_per_slice % context_parallelism != 0:
+        raise ValueError(f"context_parallelism ({context_parallelism}) must divide chips per slice ({chips_per_slice})")
+    if batch_size % slice_count != 0:
+        raise ValueError(f"batch_size ({batch_size}) must be divisible by slice_count ({slice_count})")
 
 
 def _validate_activation_layer_fraction(activation_layer_fraction: float) -> None:

--- a/tests/experiment/coral/test_batch_calibration.py
+++ b/tests/experiment/coral/test_batch_calibration.py
@@ -5,6 +5,7 @@ import pytest
 
 from experiments.coral.batch_calibration import (
     BYTES_PER_GIB,
+    TpuBatchConfig,
     adam_optimizer_bytes,
     batch_memory_bytes,
     dense_transformer_bytes,
@@ -40,7 +41,12 @@ def test_example_usage():
     assert optimizer_bytes == 800_000_000
     assert activation_bytes == 43_486_543_872
     assert batch_bytes == 44_686_543_872
-    assert batch_config == (-1, 1)
+    assert batch_config == TpuBatchConfig(
+        data_parallelism=4,
+        tensor_parallelism=1,
+        per_device_parallelism=32,
+        gradient_accumulation=1,
+    )
 
 
 def test_adam_optimizer_bytes():
@@ -87,9 +93,9 @@ def test_batch_memory_bytes():
 @pytest.mark.parametrize(
     ("batch_bytes", "expected_config"),
     [
-        (64 * BYTES_PER_GIB, (-1, 1)),
-        (128 * BYTES_PER_GIB, (16, 2)),
-        (160 * BYTES_PER_GIB, (8, 4)),
+        (64 * BYTES_PER_GIB, TpuBatchConfig(4, 1, 32, 1)),
+        (128 * BYTES_PER_GIB, TpuBatchConfig(4, 1, 16, 2)),
+        (160 * BYTES_PER_GIB, TpuBatchConfig(4, 1, 8, 4)),
     ],
 )
 def test_tpu_batch_config(batch_bytes, expected_config):
@@ -103,28 +109,64 @@ def test_tpu_batch_config(batch_bytes, expected_config):
     )
 
 
-def test_data_axis_size():
-    batch_config = tpu_batch_config(
-        "v5litepod-4",
-        batch_size=128,
-        batch_bytes=128 * BYTES_PER_GIB,
-        data_axis_size=2,
+@pytest.mark.parametrize(
+    ("tpu", "batch_size", "context_parallelism", "slice_count", "expected"),
+    [
+        ("v5litepod-8", 4, 1, 1, TpuBatchConfig(4, 2, 1, 1)),
+        ("v5litepod-8", 6, 1, 1, TpuBatchConfig(2, 4, 3, 1)),
+        ("v5p-32", 6, 1, 1, TpuBatchConfig(2, 8, 3, 1)),
+        ("v5litepod-8", 4, 2, 1, TpuBatchConfig(4, 1, 1, 1)),
+        ("v5litepod-8", 12, 1, 2, TpuBatchConfig(4, 4, 3, 1)),
+        ("v5litepod-8", 16, 2, 2, TpuBatchConfig(8, 1, 2, 1)),
+    ],
+)
+def test_tpu_batch_config_uses_all_chips_for_single_and_multiple_slices(
+    tpu,
+    batch_size,
+    context_parallelism,
+    slice_count,
+    expected,
+):
+    assert (
+        tpu_batch_config(
+            tpu,
+            batch_size=batch_size,
+            batch_bytes=1,
+            context_parallelism=context_parallelism,
+            slice_count=slice_count,
+        )
+        == expected
     )
 
-    assert batch_config == (32, 2)
+
+def test_tpu_batch_config_multislice_gradient_accumulation():
+    assert tpu_batch_config(
+        "v5litepod-4",
+        batch_size=128,
+        batch_bytes=256 * BYTES_PER_GIB,
+        slice_count=2,
+    ) == TpuBatchConfig(
+        data_parallelism=8,
+        tensor_parallelism=1,
+        per_device_parallelism=8,
+        gradient_accumulation=2,
+    )
 
 
-def test_nondivisible_batch():
-    with pytest.raises(
-        ValueError,
-        match=r"batch_size \(130\) must be divisible by data_axis_size \(4\)",
-    ):
-        tpu_batch_config(
-            "v5litepod-4",
-            batch_size=130,
-            batch_bytes=1,
-            data_axis_size=4,
-        )
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"batch_size": 0}, "batch_size must be positive"),
+        ({"context_parallelism": 0}, "context_parallelism must be positive"),
+        ({"context_parallelism": 3}, "must divide chips per slice"),
+        ({"slice_count": 0}, "slice_count must be positive"),
+        ({"batch_size": 5, "slice_count": 2}, "must be divisible by slice_count"),
+    ],
+)
+def test_tpu_batch_config_rejects_incompatible_parallelism(kwargs, match):
+    args = {"batch_size": 4, "batch_bytes": 1, **kwargs}
+    with pytest.raises(ValueError, match=match):
+        tpu_batch_config("v5litepod-4", **args)
 
 
 def test_minimum_microbatch_too_large():

--- a/tests/experiment/coral/test_batch_calibration.py
+++ b/tests/experiment/coral/test_batch_calibration.py
@@ -98,7 +98,7 @@ def test_batch_memory_bytes():
         (160 * BYTES_PER_GIB, TpuBatchConfig(4, 1, 8, 4)),
     ],
 )
-def test_tpu_batch_config(batch_bytes, expected_config):
+def test_batch_config_for_memory(batch_bytes, expected_config):
     assert (
         tpu_batch_config(
             "v5litepod-4",
@@ -120,7 +120,7 @@ def test_tpu_batch_config(batch_bytes, expected_config):
         ("v5litepod-8", 16, 2, 2, TpuBatchConfig(8, 1, 2, 1)),
     ],
 )
-def test_tpu_batch_config_uses_all_chips_for_single_and_multiple_slices(
+def test_batch_config_parallelism(
     tpu,
     batch_size,
     context_parallelism,
@@ -139,7 +139,7 @@ def test_tpu_batch_config_uses_all_chips_for_single_and_multiple_slices(
     )
 
 
-def test_tpu_batch_config_multislice_gradient_accumulation():
+def test_multislice_accumulation():
     assert tpu_batch_config(
         "v5litepod-4",
         batch_size=128,
@@ -154,26 +154,23 @@ def test_tpu_batch_config_multislice_gradient_accumulation():
 
 
 @pytest.mark.parametrize(
-    ("kwargs", "match"),
+    "kwargs",
     [
-        ({"batch_size": 0}, "batch_size must be positive"),
-        ({"context_parallelism": 0}, "context_parallelism must be positive"),
-        ({"context_parallelism": 3}, "must divide chips per slice"),
-        ({"slice_count": 0}, "slice_count must be positive"),
-        ({"batch_size": 5, "slice_count": 2}, "must be divisible by slice_count"),
+        {"batch_size": 0},
+        {"context_parallelism": 0},
+        {"context_parallelism": 3},
+        {"slice_count": 0},
+        {"batch_size": 5, "slice_count": 2},
     ],
 )
-def test_tpu_batch_config_rejects_incompatible_parallelism(kwargs, match):
+def test_incompatible_parallelism(kwargs):
     args = {"batch_size": 4, "batch_bytes": 1, **kwargs}
-    with pytest.raises(ValueError, match=match):
+    with pytest.raises(ValueError):
         tpu_batch_config("v5litepod-4", **args)
 
 
-def test_minimum_microbatch_too_large():
-    with pytest.raises(
-        ValueError,
-        match=r"Batch does not fit on v5litepod-4: even per_device_parallelism=1",
-    ):
+def test_minimum_microbatch_does_not_fit():
+    with pytest.raises(ValueError):
         tpu_batch_config(
             "v5litepod-4",
             batch_size=4,


### PR DESCRIPTION
Generalize the batch calibration utilities added in [#7204](https://github.com/marin-community/marin/pull/7204) to match Levanter’s data, tensor, and context parallelism model. An experiment supplies the TPU topology and slice count, global batch size, and context parallelism; the memory estimator supplies the expected full-batch HBM usage. `tpu_batch_config` derives DP, TP, PDP, and GA from those inputs.

<details>
<summary><strong>Selection policy: maximize DP, minimize TP</strong></summary>

Topology selection is deliberately DP-first. The helper chooses the largest data-parallel axis that divides both the batch and the chip capacity remaining after CP, thereby maximizing DP and minimizing TP. TP is used only to occupy chips that cannot participate in an exact data-parallel partition—for example, when the global batch is smaller than the available chip capacity or does not divide it evenly.

DP and TP are fixed before the HBM estimate is considered. To fit memory, the helper only lowers PDP, which reduces the microbatch size and increases GA. It does not trade DP for additional TP as a memory strategy. A lower-DP, higher-TP decomposition may perform better for a particular model or topology, but choosing one requires model-specific compatibility and performance decisions. This automatic policy is intended for experiment sweeps across many runs, not for optimizing the parallelism of one large training job.

</details>

The [reference card](https://gist.github.com/eric-czech/77b4026b4eeff6bb6224ff5ba557e69d) below provides a compact view of the parallelism model behind this policy, including its Levanter/JAX mesh correspondence and the single-slice-to-multislice extension.

<img width="1024" alt="marin_parallelisms" src="https://github.com/user-attachments/assets/5bfff72e-0ac4-4f9e-8d81-667c7c3f94d7" />

For a single slice:

```python
parallel_capacity = chip_count // context_parallelism
data_parallelism = math.gcd(batch_size, parallel_capacity)
tensor_parallelism = parallel_capacity // data_parallelism
per_device_parallelism = largest_fitting_divisor(batch_size // data_parallelism)
microbatch_size = data_parallelism * per_device_parallelism
gradient_accumulation = batch_size // microbatch_size
```

This preserves Levanter’s mesh invariant:

```python
chip_count == data_parallelism * tensor_parallelism * context_parallelism
```

For `train_lm`, the derived TP configures the `model` mesh axis and PDP controls the microbatch size. Levanter derives the effective DP and GA from those values, the device mesh, and the global batch size. The helper returns DP and GA as well so the complete configuration remains explicit.

<details>
<summary><strong>Multislice extension: solve per slice, combine DP across slices</strong></summary>

For multiple slices, chip allocation is solved per slice and the resulting data-parallel replicas are combined across slices:

```python
examples_per_slice = batch_size // slice_count
parallel_capacity_per_slice = chips_per_slice // context_parallelism
data_parallelism_per_slice = math.gcd(examples_per_slice, parallel_capacity_per_slice)
tensor_parallelism = parallel_capacity_per_slice // data_parallelism_per_slice
data_parallelism = slice_count * data_parallelism_per_slice
```

`per_device_parallelism` (PDP), `microbatch_size` (MB), and `gradient_accumulation` (GA) retain their single-slice definitions using the resulting total `data_parallelism` (DP). Setting `slice_count=1` reduces directly to the single-slice case.

</details>