### PR TITLE
Register Focus Crawl artifact

### DIFF
--- a/lib/marin/src/marin/datakit/download/common_crawl_focus.py
+++ b/lib/marin/src/marin/datakit/download/common_crawl_focus.py
@@ -9,11 +9,11 @@ from marin.execution.step_spec import StepSpec
 # WARCs with XenonMolecule/jusText@20d27c00ebfbe927f86281933da687d3e636cba3,
 # using its sklearn model and English stoplist. experiments/datakit/focus_crawl.py
 # wrote the resulting text and WARC provenance as normalized Parquet.
-_FOCUS_CRAWL_ARTIFACT = "gs://marin-us-central1/data/datakit/normalized/common_crawl_focus_2026_22_ed4b8bc9"
+_FOCUS_CRAWL_ARTIFACT = "s3://marin-us-east-02a/marin/data/datakit/normalized/common_crawl_focus_2026_22_ed4b8bc9"
 
 
 def common_crawl_focus_normalize_steps() -> tuple[StepSpec, ...]:
-    """Return the existing Focus Crawl normalized artifact."""
+    """Return steps that read the existing Focus Crawl normalized artifact."""
     return (
         StepSpec(
             name="normalized/common-crawl-focus-2026-22",

--- a/lib/marin/src/marin/datakit/download/common_crawl_focus.py
+++ b/lib/marin/src/marin/datakit/download/common_crawl_focus.py
@@ -1,0 +1,23 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from marin.datakit.normalize import NormalizedData
+from marin.execution.artifact import read_artifact
+from marin.execution.step_spec import StepSpec
+
+# Extracted indexed HTML response byte ranges from all 4,573 CC-SUPPLEMENTAL-2026-22
+# WARCs with XenonMolecule/jusText@20d27c00ebfbe927f86281933da687d3e636cba3,
+# using its sklearn model and English stoplist. experiments/datakit/focus_crawl.py
+# wrote the resulting text and WARC provenance as normalized Parquet.
+_FOCUS_CRAWL_ARTIFACT = "gs://marin-us-central1/data/datakit/normalized/common_crawl_focus_2026_22_ed4b8bc9"
+
+
+def common_crawl_focus_normalize_steps() -> tuple[StepSpec, ...]:
+    """Return the existing Focus Crawl normalized artifact."""
+    return (
+        StepSpec(
+            name="normalized/common-crawl-focus-2026-22",
+            hash_attrs={"artifact": _FOCUS_CRAWL_ARTIFACT},
+            fn=lambda _output_path: read_artifact(_FOCUS_CRAWL_ARTIFACT, NormalizedData),
+        ),
+    )

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -54,7 +54,11 @@ from marin.datakit.download.swe_rebench_contree import swe_rebench_contree_norma
 from marin.datakit.download.swe_rebench_openhands import swe_rebench_openhands_normalize_steps
 from marin.datakit.download.swe_zero_12m import swe_zero_12m_normalize_steps
 from marin.datakit.download.synthetic1 import synthetic1_normalize_steps
+from marin.datakit.normalize import NormalizedData
+from marin.execution.artifact import read_artifact
 from marin.execution.step_spec import StepSpec
+
+_FOCUS_CRAWL_ARTIFACT = "gs://marin-us-central1/data/datakit/normalized/common_crawl_focus_2026_22_ed4b8bc9"
 
 
 @dataclass(frozen=True)
@@ -85,6 +89,16 @@ class DatakitSource:
 # triple. The chain factory, called with no args, returns the ordered
 # ``(download, ..., normalize)`` StepSpec tuple for that source.
 _SourceRow = tuple[str, Callable[[], tuple[StepSpec, ...]], float]
+
+
+def _focus_crawl_normalize_steps() -> tuple[StepSpec, ...]:
+    return (
+        StepSpec(
+            name="normalized/common-crawl-focus-2026-22",
+            hash_attrs={"artifact": _FOCUS_CRAWL_ARTIFACT},
+            fn=lambda _output_path: read_artifact(_FOCUS_CRAWL_ARTIFACT, NormalizedData),
+        ),
+    )
 
 
 def _rows_flat(
@@ -149,6 +163,7 @@ def all_sources() -> dict[str, DatakitSource]:
         ("cp/biodiversity", biodiversity_normalize_steps, 8.60),
         ("climblab-ja", climblab_ja_normalize_steps, 371.92),
         ("coderforge", coderforge_normalize_steps, 10.29),
+        ("common-crawl-focus-2026-22", _focus_crawl_normalize_steps, 47.5),
         ("davinci-dev/ctx-native", davinci_dev_ctx_native_normalize_steps, 57.57),
         ("davinci-dev/env-native", davinci_dev_env_native_normalize_steps, 2.58),
         ("eai-taxonomy-code-w-dclm", eai_taxonomy_code_normalize_steps, 591.90),

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -22,6 +22,7 @@ from marin.datakit.download.biocollection import biocollection_normalize_steps
 from marin.datakit.download.biodiversity import biodiversity_normalize_steps
 from marin.datakit.download.climblab_ja import climblab_ja_normalize_steps
 from marin.datakit.download.coderforge import coderforge_normalize_steps
+from marin.datakit.download.common_crawl_focus import common_crawl_focus_normalize_steps
 from marin.datakit.download.common_pile import common_pile_normalize_steps
 from marin.datakit.download.davinci_dev import (
     davinci_dev_ctx_native_normalize_steps,
@@ -54,11 +55,7 @@ from marin.datakit.download.swe_rebench_contree import swe_rebench_contree_norma
 from marin.datakit.download.swe_rebench_openhands import swe_rebench_openhands_normalize_steps
 from marin.datakit.download.swe_zero_12m import swe_zero_12m_normalize_steps
 from marin.datakit.download.synthetic1 import synthetic1_normalize_steps
-from marin.datakit.normalize import NormalizedData
-from marin.execution.artifact import read_artifact
 from marin.execution.step_spec import StepSpec
-
-_FOCUS_CRAWL_ARTIFACT = "gs://marin-us-central1/data/datakit/normalized/common_crawl_focus_2026_22_ed4b8bc9"
 
 
 @dataclass(frozen=True)
@@ -89,16 +86,6 @@ class DatakitSource:
 # triple. The chain factory, called with no args, returns the ordered
 # ``(download, ..., normalize)`` StepSpec tuple for that source.
 _SourceRow = tuple[str, Callable[[], tuple[StepSpec, ...]], float]
-
-
-def _focus_crawl_normalize_steps() -> tuple[StepSpec, ...]:
-    return (
-        StepSpec(
-            name="normalized/common-crawl-focus-2026-22",
-            hash_attrs={"artifact": _FOCUS_CRAWL_ARTIFACT},
-            fn=lambda _output_path: read_artifact(_FOCUS_CRAWL_ARTIFACT, NormalizedData),
-        ),
-    )
 
 
 def _rows_flat(
@@ -163,7 +150,7 @@ def all_sources() -> dict[str, DatakitSource]:
         ("cp/biodiversity", biodiversity_normalize_steps, 8.60),
         ("climblab-ja", climblab_ja_normalize_steps, 371.92),
         ("coderforge", coderforge_normalize_steps, 10.29),
-        ("common-crawl-focus-2026-22", _focus_crawl_normalize_steps, 47.5),
+        ("common-crawl-focus-2026-22", common_crawl_focus_normalize_steps, 49.702569456),
         ("davinci-dev/ctx-native", davinci_dev_ctx_native_normalize_steps, 57.57),
         ("davinci-dev/env-native", davinci_dev_env_native_normalize_steps, 2.58),
         ("eai-taxonomy-code-w-dclm", eai_taxonomy_code_normalize_steps, 591.90),


### PR DESCRIPTION
Register the Common Crawl Focus Crawl 2026-22 jusText extraction as a Datakit source. The source materializes a local NormalizedData pointer by reading the existing CoreWeave S3 artifact, without adding another download or normalization pipeline.