### PR TITLE
[evals] Allow text-only prompt_logprobs on multimodal models (TPU vLLM)

### DIFF
--- a/lib/marin/src/marin/inference/tpu_vllm_pins.py
+++ b/lib/marin/src/marin/inference/tpu_vllm_pins.py
@@ -16,7 +16,7 @@ pins from the workspace lock the in-checkout path uses.
 VLLM_FORK_URL = "https://github.com/marin-community/vllm.git"
 VLLM_FORK_REV = "afb26719464d5957e695bde478ae93a160b11d14"
 TPU_INFERENCE_FORK_URL = "https://github.com/marin-community/tpu-inference.git"
-TPU_INFERENCE_FORK_REV = "734d2842aa883c8f7bcff87a4b437a366f3adbc0"
+TPU_INFERENCE_FORK_REV = "235c5e2dc8f7aa7766ce63d145a3e50499539b3a"
 
 
 def vllm_fork_ref() -> str:

--- a/lib/marin/src/marin/inference/tpu_vllm_pins.py
+++ b/lib/marin/src/marin/inference/tpu_vllm_pins.py
@@ -16,7 +16,7 @@ pins from the workspace lock the in-checkout path uses.
 VLLM_FORK_URL = "https://github.com/marin-community/vllm.git"
 VLLM_FORK_REV = "afb26719464d5957e695bde478ae93a160b11d14"
 TPU_INFERENCE_FORK_URL = "https://github.com/marin-community/tpu-inference.git"
-TPU_INFERENCE_FORK_REV = "235c5e2dc8f7aa7766ce63d145a3e50499539b3a"
+TPU_INFERENCE_FORK_REV = "35cdb53ddf6e79dae951fca82c82f1d0e47d7e44"
 
 
 def vllm_fork_ref() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,8 +179,8 @@ harbor = { git = "https://github.com/marin-community/harbor.git", rev = "0d0dbe8
 # temporary and must be replaced by the landed fork main SHA.
 # https://github.com/marin-community/vllm/compare/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c...afb26719464d5957e695bde478ae93a160b11d14
 vllm = { git = "https://github.com/marin-community/vllm.git", rev = "afb26719464d5957e695bde478ae93a160b11d14" }
-# https://github.com/marin-community/tpu-inference/compare/23d17a8120d9cc34890135599f42e1db4f947c10...235c5e2dc8f7aa7766ce63d145a3e50499539b3a
-tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "235c5e2dc8f7aa7766ce63d145a3e50499539b3a" }
+# https://github.com/marin-community/tpu-inference/compare/23d17a8120d9cc34890135599f42e1db4f947c10...35cdb53ddf6e79dae951fca82c82f1d0e47d7e44
+tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "35cdb53ddf6e79dae951fca82c82f1d0e47d7e44" }
 # ### BEGIN RUST-DEV SOURCES ###
 # ### END RUST-DEV SOURCES ###
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,8 +179,8 @@ harbor = { git = "https://github.com/marin-community/harbor.git", rev = "0d0dbe8
 # temporary and must be replaced by the landed fork main SHA.
 # https://github.com/marin-community/vllm/compare/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c...afb26719464d5957e695bde478ae93a160b11d14
 vllm = { git = "https://github.com/marin-community/vllm.git", rev = "afb26719464d5957e695bde478ae93a160b11d14" }
-# https://github.com/marin-community/tpu-inference/compare/23d17a8120d9cc34890135599f42e1db4f947c10...734d2842aa883c8f7bcff87a4b437a366f3adbc0
-tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "734d2842aa883c8f7bcff87a4b437a366f3adbc0" }
+# https://github.com/marin-community/tpu-inference/compare/23d17a8120d9cc34890135599f42e1db4f947c10...235c5e2dc8f7aa7766ce63d145a3e50499539b3a
+tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "235c5e2dc8f7aa7766ce63d145a3e50499539b3a" }
 # ### BEGIN RUST-DEV SOURCES ###
 # ### END RUST-DEV SOURCES ###
 

--- a/uv.lock
+++ b/uv.lock
@@ -4359,7 +4359,7 @@ requires-dist = [
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'cpu'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "cpu" } },
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'tpu'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "tpu" } },
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'vllm'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "vllm" } },
-    { name = "tpu-inference", marker = "extra == 'vllm'", git = "https://github.com/marin-community/tpu-inference.git?rev=734d2842aa883c8f7bcff87a4b437a366f3adbc0" },
+    { name = "tpu-inference", marker = "extra == 'vllm'", git = "https://github.com/marin-community/tpu-inference.git?rev=235c5e2dc8f7aa7766ce63d145a3e50499539b3a" },
     { name = "tqdm" },
     { name = "tqdm-loggable" },
     { name = "transformers", specifier = ">=5.5.3,<6.0" },
@@ -10524,7 +10524,7 @@ wheels = [
 [[package]]
 name = "tpu-inference"
 version = "0.23.0"
-source = { git = "https://github.com/marin-community/tpu-inference.git?rev=734d2842aa883c8f7bcff87a4b437a366f3adbc0#734d2842aa883c8f7bcff87a4b437a366f3adbc0" }
+source = { git = "https://github.com/marin-community/tpu-inference.git?rev=235c5e2dc8f7aa7766ce63d145a3e50499539b3a#235c5e2dc8f7aa7766ce63d145a3e50499539b3a" }
 dependencies = [
     { name = "absl-py" },
     { name = "fastapi", extra = ["standard"], marker = "extra == 'extra-10-marin-core-vllm' or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-10-marin-core-gpu') or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-10-marin-core-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'group-10-marin-fray-fray-tpu-test') or (extra == 'extra-10-marin-core-tpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'group-10-marin-fray-fray-tpu-test')" },

--- a/uv.lock
+++ b/uv.lock
@@ -4359,7 +4359,7 @@ requires-dist = [
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'cpu'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "cpu" } },
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'tpu'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "tpu" } },
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'vllm'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "vllm" } },
-    { name = "tpu-inference", marker = "extra == 'vllm'", git = "https://github.com/marin-community/tpu-inference.git?rev=235c5e2dc8f7aa7766ce63d145a3e50499539b3a" },
+    { name = "tpu-inference", marker = "extra == 'vllm'", git = "https://github.com/marin-community/tpu-inference.git?rev=35cdb53ddf6e79dae951fca82c82f1d0e47d7e44" },
     { name = "tqdm" },
     { name = "tqdm-loggable" },
     { name = "transformers", specifier = ">=5.5.3,<6.0" },
@@ -10524,7 +10524,7 @@ wheels = [
 [[package]]
 name = "tpu-inference"
 version = "0.23.0"
-source = { git = "https://github.com/marin-community/tpu-inference.git?rev=235c5e2dc8f7aa7766ce63d145a3e50499539b3a#235c5e2dc8f7aa7766ce63d145a3e50499539b3a" }
+source = { git = "https://github.com/marin-community/tpu-inference.git?rev=35cdb53ddf6e79dae951fca82c82f1d0e47d7e44#35cdb53ddf6e79dae951fca82c82f1d0e47d7e44" }
 dependencies = [
     { name = "absl-py" },
     { name = "fastapi", extra = ["standard"], marker = "extra == 'extra-10-marin-core-vllm' or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-10-marin-core-gpu') or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-10-marin-core-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'group-10-marin-fray-fray-tpu-test') or (extra == 'extra-10-marin-core-tpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'group-10-marin-fray-fray-tpu-test')" },


### PR DESCRIPTION
Serving a vision-language model (Qwen3.5-9B, `Qwen3_5ForConditionalGeneration`) for text-only lm-eval loglikelihood tasks killed the TPU vLLM `EngineCore`. The tpu-inference model runner raised `ValueError("prompt_logprobs is not supported for multimodal models.")` inside the engine step loop for every `echo`/`prompt_logprobs` request, so the first burst of MMLU/ARC/HellaSwag scoring crashed the engine (`EngineDeadError`) and every in-flight request saw `ServerDisconnectedError`. Generation tasks (gsm8k) succeeded on the same slice, and text-only models (Qwen3-8B, Llama-3.1-8B-Instruct) were unaffected because they never set `is_multimodal_model`.

The guard was over-broad: it blocked `prompt_logprobs` for any multimodal-*capable* model, even for a pure-text batch with no image inputs. This bumps the `tpu-inference` fork pin (`pyproject.toml`, `tpu_vllm_pins.py`, `uv.lock`) to [marin-community/tpu-inference#11](https://github.com/marin-community/tpu-inference/pull/11), which narrows the guard to fire only when the batch actually carries multimodal inputs (`mm_embeds is not None`), so text-only requests — including those to a VL model — compute prompt logprobs, while genuine multimodal `prompt_logprobs` requests still raise.

The pin is the landed fork `main` SHA `35cdb53d` (#11 squash-merged).

Fixes #7390