### PR TITLE
[iris] Disable Kueue TASBalancedPlacement gate that wedges pod admission

### DIFF
--- a/lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py
@@ -36,6 +36,24 @@ CW_CHART = f"{CW_REPO_NAME}/cks-kueue"
 RELEASE_DEFAULT = "kueue"
 OPERATOR_NS = "kueue-system"
 
+# Controller-manager feature gates for the cks-kueue chart. Helm replaces list values
+# wholesale, so this enumerates the full set the chart ships with, changing one entry:
+# TASBalancedPlacement stays OFF. That Alpha gate's balanced-placement scheduler divides
+# the pod-slice count by the number of selected topology domains and panics (integer
+# divide by zero) when that count is zero, crashing the controller-manager process — which
+# drops the admission-webhook endpoints and fail-closes every pod CREATE in the Iris
+# namespace. Iris requests explicit per-rack slice sizes for balanced multi-rack placement
+# (podset-slice-size, under TopologyAwareScheduling), so it never relies on this heuristic;
+# every other gate stays at the chart default.
+CKS_KUEUE_FEATURE_GATES = [
+    {"name": "VisibilityOnDemand", "enabled": True},
+    {"name": "LendingLimit", "enabled": True},
+    {"name": "ObjectRetentionPolicies", "enabled": True},
+    {"name": "TopologyAwareScheduling", "enabled": True},
+    {"name": "TASBalancedPlacement", "enabled": False},
+    {"name": "TASMultiLayerTopology", "enabled": True},
+]
+
 # Namespace(s) Iris submits gang pods into (the k8s provider namespace, default
 # "iris"). Kueue's admission webhooks are scoped to ONLY these — see
 # build_controller_manager_config for why a broad selector is dangerous.
@@ -177,10 +195,10 @@ def build_cks_values(pod_namespaces: Sequence[str] = DEFAULT_POD_NAMESPACES) -> 
     apiVersion the CRD no longer serves (see module docstring); the Topology CRs
     are kubectl-applied after install instead.
 
-    NB: the chart already enables ``--feature-gates=TopologyAwareScheduling=true``
-    by default (its ``controllerManager.featureGates`` value is a *list*), so we
-    deliberately do NOT set ``featureGates`` — overriding it (especially as a map)
-    breaks the chart's ``kueue.featureGates`` template.
+    ``controllerManager.featureGates`` is CKS_KUEUE_FEATURE_GATES — the chart's own
+    list shape with the crash-prone TASBalancedPlacement gate turned off. The chart
+    takes this value as a *list*; overriding it as a map breaks the chart's
+    ``kueue.featureGates`` template.
     """
     config_yaml = yaml.safe_dump(
         build_controller_manager_config(pod_namespaces), default_flow_style=False, sort_keys=False
@@ -188,6 +206,7 @@ def build_cks_values(pod_namespaces: Sequence[str] = DEFAULT_POD_NAMESPACES) -> 
     return {
         "kueue": {
             "enableKueueViz": False,
+            "controllerManager": {"featureGates": CKS_KUEUE_FEATURE_GATES},
             "managerConfig": {"controllerManagerConfigYaml": config_yaml},
         },
     }

--- a/lib/iris/tests/cluster/backends/k8s/test_kueue_manifests.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_kueue_manifests.py
@@ -1,0 +1,35 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression guards for the Kueue helm values Iris renders."""
+
+from iris.cluster.platforms.k8s.kueue_manifests import build_cks_values, build_upstream_values
+
+
+def _gate(gates: list[dict], name: str) -> bool | None:
+    for gate in gates:
+        if gate["name"] == name:
+            return gate["enabled"]
+    return None
+
+
+def test_cks_values_disable_tas_balanced_placement():
+    # The cks-kueue chart default enables the Alpha TASBalancedPlacement gate, whose
+    # balanced-placement scheduler divides by the selected-domain count and panics
+    # (integer divide by zero) at zero domains, crashing the controller-manager and
+    # dropping the admission-webhook endpoints — which fail-closes every pod CREATE in
+    # the Iris namespace. Iris pins the gate OFF.
+    gates = build_cks_values(["iris"])["kueue"]["controllerManager"]["featureGates"]
+    assert _gate(gates, "TASBalancedPlacement") is False
+    # TAS itself, and the multi-layer topology the sliced multi-rack placement rides on,
+    # stay ON.
+    assert _gate(gates, "TopologyAwareScheduling") is True
+    assert _gate(gates, "TASMultiLayerTopology") is True
+
+
+def test_upstream_values_never_enable_tas_balanced_placement():
+    # Upstream Kueue defaults TASBalancedPlacement off; the upstream variant must not turn
+    # it on (leaving it unset keeps the safe default).
+    gates = build_upstream_values(["iris"])["controllerManager"]["featureGates"]
+    assert _gate(gates, "TASBalancedPlacement") in (None, False)
+    assert _gate(gates, "TopologyAwareScheduling") is True


### PR DESCRIPTION
The cks-kueue chart Iris installs enables the Alpha `TASBalancedPlacement` feature gate by default. Its balanced-placement scheduler computes `sliceCount / selectedDomainsCount` and panics with an integer divide-by-zero when the selected-domain count is zero (`pkg/cache/scheduler/tas_balanced_placement.go`). That panic crashes the whole `kueue-controller-manager` process, so the `kueue-webhook-service` loses its endpoints and the fail-closed `mpod.kb.io` mutating webhook rejects every pod CREATE in the Iris namespace with a 500. Every new task then hangs in BUILDING and nothing schedules, while already-admitted pods keep running — which masks the outage.

`build_cks_values` now pins `controllerManager.featureGates` to the chart's own list shape with `TASBalancedPlacement` disabled and every other gate left at its chart default. Helm replaces list values wholesale, so the full set is enumerated.

Iris does not need this heuristic. It produces balanced multi-rack GB200 layouts (e.g. 16/16/16/16 rather than 17/15/16/16) from its own `podset-slice-size` request — an exact per-rack slice count from `balanced_rack_slice_size`, hard-bound one slice per `nvlink.domain`. That rides on `TopologyAwareScheduling` (and `TASMultiLayerTopology`, both kept on), not on `TASBalancedPlacement`.

Observed on `cw-us-east-08a` (GB200): the controller-manager had CrashLoopBackOff'd ~100 times and jobs sat unscheduled for ~7h. The live cluster was recovered by disabling the gate on the running deployment (webhook endpoints returned, ~48 SchedulingGated pods admitted, stuck tasks moved BUILDING→RUNNING); this change makes that the rendered default so a future helm/IaC reconcile cannot re-enable it.