### PR TITLE
[iris] Re-auth via reload on an IAP 401 instead of the bearer-token login page

### DIFF
--- a/lib/iris/dashboard/src/App.vue
+++ b/lib/iris/dashboard/src/App.vue
@@ -19,7 +19,19 @@ const { capabilities, backends, peers, fetchConfig, ensurePeers } = useBackends(
 const showScope = computed(() => backends.value.length + peers.value.length > 1)
 
 const authEnabled = ref(false)
+// Login provider from /auth/config. On an IAP cluster a 401 is an edge-session
+// lapse, recovered by reloading (not by the bearer-token page); see onAuthRequired.
+const authProvider = ref<string | null>(null)
 const legendOpen = ref(false)
+
+// sessionStorage key holding the epoch-ms of the last IAP re-auth reload, so a
+// genuinely persistent 401 falls through to /login instead of reload-looping.
+const IAP_REAUTH_RELOAD_KEY = 'iris-iap-reauth-reload-ms'
+// A second 401 within this window of a reload means the reload did not re-auth.
+const IAP_REAUTH_RELOAD_WINDOW_MS = 15_000
+// Set once we schedule a reload, so concurrent 401s (many polls in flight) don't
+// briefly route to /login before the reload navigation replaces the document.
+let reloadingForAuth = false
 
 // Tabs always shown have no `requires`; conditional tabs name the capability
 // the backend must advertise (see backend_descriptor in backend.py). The
@@ -67,6 +79,24 @@ const isDetailPage = computed(() => {
 const isLoginPage = computed(() => route.path === '/login')
 
 function onAuthRequired() {
+  // A 401 reached the SPA. On an IAP-fronted cluster this is almost always the
+  // browser's IAP EDGE session lapsing: IAP answers a background XHR/POST (the
+  // RPC polls, the 30s log-viewer FetchLogs) with 401 rather than the 302 it gives
+  // a GET navigation, so iris never sees the request. The remedy is a full-page
+  // reload — a GET that IAP redirects through its edge re-auth — not the
+  // bearer-token LoginPage, which does not apply to IAP. Reload at most once per
+  // window so a persistent 401 (revoked access, or a genuine iris challenge) still
+  // lands on /login instead of looping.
+  if (reloadingForAuth) return
+  if (authProvider.value === 'iap') {
+    const last = Number(sessionStorage.getItem(IAP_REAUTH_RELOAD_KEY) ?? '0')
+    if (!Number.isFinite(last) || Date.now() - last > IAP_REAUTH_RELOAD_WINDOW_MS) {
+      reloadingForAuth = true
+      sessionStorage.setItem(IAP_REAUTH_RELOAD_KEY, String(Date.now()))
+      window.location.reload()
+      return
+    }
+  }
   router.push('/login')
 }
 
@@ -81,8 +111,13 @@ onMounted(async () => {
   try {
     // fetchConfig fetches /auth/config once, populates capabilities + backends,
     // and returns auth-related fields for login redirection.
-    const { authEnabled: ae, authenticated, authOptional } = await fetchConfig()
+    const { authEnabled: ae, authenticated, authOptional, provider } = await fetchConfig()
     authEnabled.value = ae
+    authProvider.value = provider
+    // This config load reached us authenticated (a GET, which IAP re-auths at the
+    // edge), so the session is healthy again — clear the reload guard so a later,
+    // unrelated lapse can reload once more.
+    if (authenticated) sessionStorage.removeItem(IAP_REAUTH_RELOAD_KEY)
     // Only send the browser to the login page when auth is required and this
     // request is not already authenticated. Behind IAP the caller is
     // authenticated at the edge (no session cookie), so `authenticated` is true

--- a/lib/iris/dashboard/src/composables/useBackends.ts
+++ b/lib/iris/dashboard/src/composables/useBackends.ts
@@ -46,6 +46,10 @@ export interface AuthConfig {
   authEnabled: boolean
   authenticated: boolean
   authOptional: boolean
+  // The login provider ('iap', 'cidr', or null for null-auth). Drives 401 recovery:
+  // an IAP cluster re-authenticates at the edge on reload, so a 401 must not route to
+  // the bearer-token login page (see App.vue onAuthRequired).
+  provider: string | null
 }
 
 export function useBackends() {
@@ -58,7 +62,7 @@ export function useBackends() {
    * without a second fetch.
    */
   async function fetchConfig(): Promise<AuthConfig> {
-    const authDefaults: AuthConfig = { authEnabled: false, authenticated: false, authOptional: false }
+    const authDefaults: AuthConfig = { authEnabled: false, authenticated: false, authOptional: false, provider: null }
     if (_configFetched) return authDefaults
     _configFetched = true
     try {
@@ -68,6 +72,7 @@ export function useBackends() {
         auth_enabled?: boolean
         authenticated?: boolean
         optional?: boolean
+        provider?: string | null
         capabilities?: string[]
         backends?: Array<{ id: string; name?: string; capabilities?: string[] }>
         backend?: { capabilities?: string[] }
@@ -87,6 +92,7 @@ export function useBackends() {
         authEnabled: config.auth_enabled ?? false,
         authenticated: config.authenticated ?? false,
         authOptional: config.optional ?? false,
+        provider: config.provider ?? null,
       }
     } catch {
       // Endpoint unavailable — leave capabilities/backends empty.


### PR DESCRIPTION
On an IAP-fronted cluster (iris.oa.dev) the dashboard sometimes drops to its
"This cluster requires authentication. Paste a bearer token to continue." login
page while a job is open — most visibly on a long-running federated job whose
logs auto-refresh — even though /auth/config reports authenticated: true.

The cause is the IAP edge, not iris auth and not finelog. When the browser's IAP
session lapses, IAP answers a background XHR/POST (the ControllerService polls and
the LogViewer's 30s FetchLogs poll are all POSTs) with HTTP 401, whereas a GET
navigation still gets a 302 redirect. Verified directly against iris.oa.dev: with
no IAP credential a GET returns 302, a POST returns `401 Invalid IAP credentials:
empty token` (IAP's own body, text/html — iris never sees the request). The SPA's
`handleUnauthorized` treats any 401 as an iris auth challenge and routes to
LoginPage, which does not apply to an IAP cluster: the correct recovery is a
full-page reload so IAP re-authenticates at its edge. It looks federation-specific
only because a long-open federated-job page is where the background polls most
often outlive the IAP session; `system.log-server` is a local endpoint and every
finelog/peer/upstream 401 already folds to 502, so the log path is identical for
local and federated jobs.

Branch the 401 handler on the auth provider: for an IAP cluster, reload once —
guarded by a sessionStorage timestamp so a genuinely persistent 401 (revoked
access, or a real iris challenge) still falls through to /login instead of
looping, and cleared once a config load confirms the session is healthy again.
Other providers keep the bearer-token page unchanged. /auth/config already
returns `provider`; it is now threaded to the frontend to drive this.

Investigation notes and the live-cluster evidence: https://loom.rjp.io/s/w7odymnt