### PR TITLE
Fix bursty TPU prompt-logprobs KeyError 500s (bump tpu-inference fork)

### DIFF
--- a/lib/marin/src/marin/inference/tpu_vllm_pins.py
+++ b/lib/marin/src/marin/inference/tpu_vllm_pins.py
@@ -16,7 +16,7 @@ pins from the workspace lock the in-checkout path uses.
 VLLM_FORK_URL = "https://github.com/marin-community/vllm.git"
 VLLM_FORK_REV = "afb26719464d5957e695bde478ae93a160b11d14"
 TPU_INFERENCE_FORK_URL = "https://github.com/marin-community/tpu-inference.git"
-TPU_INFERENCE_FORK_REV = "734d2842aa883c8f7bcff87a4b437a366f3adbc0"
+TPU_INFERENCE_FORK_REV = "e8809d492d5d6c7008369919a00384eb1c4de969"
 
 
 def vllm_fork_ref() -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,8 +179,8 @@ harbor = { git = "https://github.com/marin-community/harbor.git", rev = "0d0dbe8
 # temporary and must be replaced by the landed fork main SHA.
 # https://github.com/marin-community/vllm/compare/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c...afb26719464d5957e695bde478ae93a160b11d14
 vllm = { git = "https://github.com/marin-community/vllm.git", rev = "afb26719464d5957e695bde478ae93a160b11d14" }
-# https://github.com/marin-community/tpu-inference/compare/23d17a8120d9cc34890135599f42e1db4f947c10...734d2842aa883c8f7bcff87a4b437a366f3adbc0
-tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "734d2842aa883c8f7bcff87a4b437a366f3adbc0" }
+# https://github.com/marin-community/tpu-inference/compare/23d17a8120d9cc34890135599f42e1db4f947c10...e8809d492d5d6c7008369919a00384eb1c4de969
+tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "e8809d492d5d6c7008369919a00384eb1c4de969" }
 # ### BEGIN RUST-DEV SOURCES ###
 # ### END RUST-DEV SOURCES ###
 

--- a/uv.lock
+++ b/uv.lock
@@ -4359,7 +4359,7 @@ requires-dist = [
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'cpu'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "cpu" } },
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'tpu'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "tpu" } },
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'vllm'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "vllm" } },
-    { name = "tpu-inference", marker = "extra == 'vllm'", git = "https://github.com/marin-community/tpu-inference.git?rev=734d2842aa883c8f7bcff87a4b437a366f3adbc0" },
+    { name = "tpu-inference", marker = "extra == 'vllm'", git = "https://github.com/marin-community/tpu-inference.git?rev=e8809d492d5d6c7008369919a00384eb1c4de969" },
     { name = "tqdm" },
     { name = "tqdm-loggable" },
     { name = "transformers", specifier = ">=5.5.3,<6.0" },
@@ -10524,7 +10524,7 @@ wheels = [
 [[package]]
 name = "tpu-inference"
 version = "0.23.0"
-source = { git = "https://github.com/marin-community/tpu-inference.git?rev=734d2842aa883c8f7bcff87a4b437a366f3adbc0#734d2842aa883c8f7bcff87a4b437a366f3adbc0" }
+source = { git = "https://github.com/marin-community/tpu-inference.git?rev=e8809d492d5d6c7008369919a00384eb1c4de969#e8809d492d5d6c7008369919a00384eb1c4de969" }
 dependencies = [
     { name = "absl-py" },
     { name = "fastapi", extra = ["standard"], marker = "extra == 'extra-10-marin-core-vllm' or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-10-marin-core-gpu') or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-10-marin-core-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'group-10-marin-fray-fray-tpu-test') or (extra == 'extra-10-marin-core-tpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'group-10-marin-fray-fray-tpu-test')" },


### PR DESCRIPTION
Bump the tpu-inference fork pin to marin-community/tpu-inference#12, fixing the bursty whole-batch `KeyError: <token id>` 500s that lm-eval MCQ suites hit against marin-serve on TPU (echo + prompt_logprobs over `/v1/completions`). For some prompt positions the TPU engine returned a top-logprobs dict that omitted the actual prompt token, so vLLM's `_create_completion_logprobs` (`step_top_logprobs[token_id]`) raised and 500'd every in-flight request at once.

The fork PR fixes two independent bugs that both drop the actual prompt token:

- **Chunk-boundary target gather.** The prompt-logprob target was `jnp.roll(input_ids, -1)`, which at a chunked-prefill boundary wraps to the neighbouring request's token instead of the request's true next prompt token (which lives in a later chunk). Aggravated by small `max_num_batched_tokens` (more chunking).
- **Accumulator wiped on mid-prefill re-add.** The per-request CPU logprobs accumulator was reallocated (`np.empty`) on every `add_request`; a running multi-chunk prefill request skipped for a step under token-budget contention is evicted and re-added, wiping rows already filled by earlier chunks and emitting uninitialized token ids. `np.empty` heap recycling makes the corruption persist across the serve process — the "once a serve storms it keeps storming, a fresh serve is clean" behaviour. Removing the per-step realloc also lifts a serial bottleneck.

This pin also carries the already-landed text-only multimodal `prompt_logprobs` guard fix (fork #11, `35cdb53d`), superseding the pending pin bump in #7398.

Pins the fork PR head `e8809d49`; will be repinned to the landed fork `main` SHA once tpu-inference#12 is approved and squash-merged (do not merge this PR before then).

Fixes #7390.