### PR TITLE
[grafana] K8s control-plane observability: bridge source, dashboard, alerting

### DIFF
--- a/infra/grafana/Dockerfile
+++ b/infra/grafana/Dockerfile
@@ -9,6 +9,8 @@
 #
 # The Infinity plugin is installed at build time rather than through
 # GF_INSTALL_PLUGINS, so a cold start never depends on grafana.com being reachable.
+# The version is pinned: the provisioned alert rules evaluate through this plugin,
+# so an untested plugin build must never arrive as a side effect of an image build.
 FROM grafana/grafana:13.1.0-ubuntu
 
 USER root
@@ -17,7 +19,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends python3 python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
-RUN grafana cli --pluginsDir /var/lib/grafana/plugins plugins install yesoreyeram-infinity-datasource
+RUN grafana cli --pluginsDir /var/lib/grafana/plugins plugins install yesoreyeram-infinity-datasource 3.10.1
 
 # The bridge lives in its own venv; nothing else in the image is Python.
 #
@@ -52,6 +54,17 @@ USER grafana
 # service agent, so every request has already passed through IAP, which sets the
 # header itself. Anonymous stays enabled as a fallback: a request without the
 # header (a health check, a misconfig) degrades to read-only rather than 401.
+#
+# SMTP: the Google Workspace relay, STARTTLS on 587. The user doubles as the from
+# address; the password (a Workspace app password) arrives as GF_SMTP_PASSWORD from
+# Secret Manager. Until that secret holds a real credential, email notifications
+# fail while Slack still delivers.
+ENV GF_SMTP_ENABLED=true \
+    GF_SMTP_HOST=smtp-relay.gmail.com:587 \
+    GF_SMTP_FROM_ADDRESS=grafana@openathena.ai \
+    GF_SMTP_USER=grafana@openathena.ai \
+    GF_SMTP_STARTTLS_POLICY=MandatoryStartTLS
+
 ENV GF_PATHS_PROVISIONING=/etc/grafana/provisioning \
     GF_AUTH_ANONYMOUS_ENABLED=true \
     GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer \

--- a/infra/grafana/Dockerfile
+++ b/infra/grafana/Dockerfile
@@ -55,12 +55,13 @@ USER grafana
 # header itself. Anonymous stays enabled as a fallback: a request without the
 # header (a health check, a misconfig) degrades to read-only rather than 401.
 #
-# SMTP: the Google Workspace relay, STARTTLS on 587. The user doubles as the from
-# address; the password (a Workspace app password) arrives as GF_SMTP_PASSWORD from
-# Secret Manager. Without a valid credential there, email notification delivery
-# fails while Slack still delivers.
-ENV GF_SMTP_ENABLED=true \
-    GF_SMTP_HOST=smtp-relay.gmail.com:587 \
+# SMTP: plain Gmail submission (smtp.gmail.com:587, STARTTLS), authenticated as
+# grafana@openathena.ai with an app password (GF_SMTP_PASSWORD from Secret Manager).
+# The app sends mail itself — no Workspace relay, so deliverability rests on the
+# sending account alone. GF_SMTP_ENABLED is deliberately absent here: the deploy sets
+# it only when the credentials secret exists, so an image without credentials runs
+# with SMTP off and alerts reach Slack only.
+ENV GF_SMTP_HOST=smtp.gmail.com:587 \
     GF_SMTP_FROM_ADDRESS=grafana@openathena.ai \
     GF_SMTP_USER=grafana@openathena.ai \
     GF_SMTP_STARTTLS_POLICY=MandatoryStartTLS

--- a/infra/grafana/Dockerfile
+++ b/infra/grafana/Dockerfile
@@ -57,8 +57,8 @@ USER grafana
 #
 # SMTP: the Google Workspace relay, STARTTLS on 587. The user doubles as the from
 # address; the password (a Workspace app password) arrives as GF_SMTP_PASSWORD from
-# Secret Manager. Until that secret holds a real credential, email notifications
-# fail while Slack still delivers.
+# Secret Manager. Without a valid credential there, email notification delivery
+# fails while Slack still delivers.
 ENV GF_SMTP_ENABLED=true \
     GF_SMTP_HOST=smtp-relay.gmail.com:587 \
     GF_SMTP_FROM_ADDRESS=grafana@openathena.ai \

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -1,12 +1,13 @@
 # grafana
 
 The Marin infra dashboard, as an IAP-gated Cloud Run service: Grafana plus a bridge
-that fronts three sources for its Infinity datasource — finelog SQL, the live Iris
-controller, and the GitHub API. One instance serves both clusters, reaching
-`finelog-marin` / `finelog-marin-dev` and each cluster's Iris controller on their
-internal IPs over Direct VPC egress. `marin` is the federation hub (the CoreWeave
-clusters forward their rows to it), so its finelog datasource sees the whole fleet;
-`marin-dev` sees only itself.
+that fronts four sources for its Infinity datasource — finelog SQL, the live Iris
+controller, the GitHub API, and the CoreWeave k8s API servers. One instance serves
+both GCE clusters, reaching `finelog-marin` / `finelog-marin-dev` and each cluster's
+Iris controller on their internal IPs over Direct VPC egress, and polls the public
+CKS API servers of the CW clusters read-only. `marin` is the federation hub (the
+CoreWeave clusters forward their rows to it), so its finelog datasource sees the
+whole fleet; `marin-dev` sees only itself.
 
 Dashboards and datasources are provisioned from the files in this directory.
 Grafana's SQLite is ephemeral on Cloud Run, so UI edits do not persist: change the
@@ -30,6 +31,10 @@ GET /finelog/{cluster}/query?sql=&from=&to=      finelog SQL
 GET /iris/{cluster}/jobs | workers | health      live controller RPCs
 GET /iris/{cluster}/query?sql=                    ad-hoc SELECT (admin/null-auth)
 GET /github/ferries | builds | nightlies          GitHub REST / GraphQL
+GET /k8s/control_plane | crashloops | pending     CW control-plane state, all clusters
+GET /k8s/kueue | events | health                  ... one response, `cluster` column
+GET /k8s/alerts/{unreachable,crashloops,          alert rows: string labels + one
+     webhook_ready,degraded}                      numeric, >=1 row per cluster
 GET /health                                       bridge liveness
 ```
 
@@ -57,6 +62,30 @@ repos), classifies each (lane, day) cell server-side — health, overdue, and du
 and serves the result as a wide matrix: one row per day, a per-lane status code keyed by lane
 id, which the state-timeline panel renders as one row per lane over the trailing week.
 
+k8s: the bridge polls the three CoreWeave clusters' public CKS API servers with plain
+httpx GETs (paginated LISTs, bounded timeouts, one 429 retry) and a single org-wide CW
+read-role bearer token from `CW_READ_TOKEN` — genuine read-only kubectl, no Secrets, no
+writes. Each response aggregates every cluster with a `cluster` column: watched
+control-plane components (a config constant: kueue-controller-manager, iris-controller,
+traefik, cert-manager) with ready/desired/restarts/waiting state, admission-webhook
+ready-endpoint counts from `discovery.k8s.io` EndpointSlices, backoff pods, pending and
+scheduling-gated pods, the unadmitted Kueue backlog per queue, and recent Warning
+events. The pod-level scans skip provider-managed namespaces (`cw-*`, `kube-*`):
+CoreWeave's per-node daemons are thousands of pods of someone else's infrastructure,
+while the namespaces we operate hold about a hundred. These are current-state reads —
+the bridge stores no history; trends come from the finelog-backed rows.
+
+The `/k8s/alerts/*` routes exist for Grafana's table-alert contract: string label
+columns plus exactly one numeric column, and always at least one row per cluster — an
+explicit zero when healthy — so an alert rule can never enter NoData. A cluster the
+bridge cannot read becomes labeled rows (its error class: auth, network, timeout, http)
+rather than an empty result: `unreachable` reports 1, the count-style routes report
+zero (the unreachable rule pages instead of fabricating counts), and `webhook_ready`
+reports 0 ready endpoints — which also fires the webhook rule, deliberately, since
+unknown admission state is the failure class it watches. A missing `CW_READ_TOKEN`
+reads as an auth failure on every cluster rather than failing the boot, which would
+take Grafana down with it.
+
 The controller and finelog IPs are resolved from GCE labels and refreshed after a
 connection failure. A dead controller or GitHub returns 5xx (not empty rows) and the
 failure is not cached, so a panel shows an error rather than blank data; `iris/.../health`
@@ -65,15 +94,16 @@ is the exception — it returns `reachable=false` so the panel can render the ou
 ## Layout
 
 ```
-src/server.py          the bridge routes (Starlette): finelog SQL, Iris, GitHub
+src/server.py          the bridge routes (Starlette): finelog SQL, Iris, GitHub, k8s
 src/finelog_source.py  finelog query over its internal IP (LogClient)
 src/iris_source.py     live controller RPCs: jobs, workers, health, ad-hoc query
 src/github_source.py   ferry runs and CI build rollup, precomputed
+src/k8s_source.py      CW k8s API reads + the per-cluster fan-out and alert rows
 src/discovery.py       GCE label -> internal IP
-src/config.py          cluster targets, ferry config, and bridge settings
+src/config.py          cluster targets, watched components, and bridge settings
 src/cache.py           TTL cache with in-flight coalescing
 src/errors.py          UpstreamError -> 5xx
-provisioning/          datasources (finelog, iris, github) + dashboard provider
+provisioning/          datasources (finelog, iris, github, k8s), dashboards, alerting
 dashboards/            dashboard JSON — reviewed like code
 Dockerfile             grafana:13.1.0-ubuntu + the bridge venv + the Infinity plugin
 entrypoint.sh          runs both; if either dies the container dies
@@ -86,7 +116,68 @@ plane, probes, 24h history, and the nightly regression matrix), `fleet.json` (ca
 worker health), `iris.json`
 (per-task and per-worker resource usage), `pipelines.json` (Zephyr throughput and shard
 memory), `training.json` (levanter training metrics from the `telltale` namespace,
-grouped by run).
+grouped by run), `k8s.json` (current CW control-plane state from the k8s source).
+
+## Alerting
+
+Grafana unified alerting, provisioned entirely from the files under
+`provisioning/alerting/` — contact points, the notification policy tree, and the rules.
+File provisioning owns that tree: UI edits to alerting do not persist (ephemeral
+SQLite) and would be overwritten by the files anyway. Change the YAML and redeploy.
+
+The v1 catalog pages only on near-certain incidents: an unreachable cluster, a
+crash-looping watched component, an admission webhook with no ready endpoints, a
+degraded component, and a dead Iris controller. Workload-tier signals (gated pods,
+Kueue backlog, workload crashloops) are dashboard-only until their expected cases can
+be suppressed. `severity=critical` routes to `ops-critical` (email ops@openathena.ai +
+Slack); `severity=warning` routes to `ops-slack` (Slack only). Every rule sets
+`noDataState: Alerting` and `execErrState: Alerting`, and the alert endpoints return
+explicit zeros when healthy, so silence anywhere in the pipeline pages rather than
+resolving.
+
+Alert state is ephemeral: Cloud Run's SQLite means a deploy resets pending (`for`)
+timers, notification dedup, and silences — worst case a re-notification after a deploy
+and a lost silence. Rule definitions are files, so nothing else is lost. Accepted for
+now (deploys are infrequent; `min=max=1` keeps a single evaluator); the hardening path
+if it ever matters is a small Cloud SQL Postgres for Grafana state.
+
+SMTP is the Google Workspace relay (`smtp-relay.gmail.com:587`, STARTTLS), sending as
+grafana@openathena.ai; `GF_SMTP_PASSWORD` comes from Secret Manager. Until a Workspace
+admin fills that secret with a real app password, email notifications fail while Slack
+still delivers. After changing contact points or their credentials, send a test
+notification to both receivers (Alerting → Contact points → Test) rather than trusting
+config presence.
+
+## Secrets and rotation
+
+All four secrets live in Secret Manager and reach the container as env vars via the
+`CloudRunService` `secrets` field; values never enter Pulumi or git.
+
+| Env var | Secret | Feeds |
+|---|---|---|
+| `GITHUB_TOKEN` | `marin-status-page-github-token` | ferry/build/nightly panels |
+| `CW_READ_TOKEN` | `marin-grafana-cw-read-token` | k8s source (all CW clusters) |
+| `SLACK_ALERTS_WEBHOOK` | `marin-grafana-slack-webhook` | alert contact points |
+| `GF_SMTP_PASSWORD` | `marin-grafana-smtp-credentials` | Grafana SMTP (email alerts) |
+
+`CW_READ_TOKEN` is an org-wide CoreWeave API token minted with only the `read` role
+(CKS binds it to the built-in `view` ClusterRole): read-only kubectl across every
+cluster in the org, no Secrets, no writes. Rotation is overlap-safe: mint a second
+read-role token in the CW console, `gcloud secrets versions add` it, redeploy, then
+revoke the old token. The same applies to the Slack webhook and SMTP password — add a
+version, redeploy, retire the old credential.
+
+Human setup, once, before the first deploy of this configuration (Cloud Run fails to
+start on a missing secret — create all three even if a value is a placeholder):
+
+1. CoreWeave console → API access → new token (e.g. `grafana-observer`) with only the
+   `read` role, then
+   `echo -n "<token>" | gcloud secrets create marin-grafana-cw-read-token --project=hai-gcp-models --data-file=-`
+2. Slack → incoming webhook for `#marin-eng`, then
+   `echo -n "https://hooks.slack.com/..." | gcloud secrets create marin-grafana-slack-webhook --project=hai-gcp-models --data-file=-`
+3. Workspace admin → app password for grafana@openathena.ai on the SMTP relay, then
+   `echo -n "<app-password>" | gcloud secrets create marin-grafana-smtp-credentials --project=hai-gcp-models --data-file=-`
+4. Send a test notification to both `ops-critical` receivers and confirm delivery.
 
 ## Develop
 

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -125,11 +125,11 @@ Grafana unified alerting, provisioned entirely from the files under
 File provisioning owns that tree: UI edits to alerting do not persist (ephemeral
 SQLite) and would be overwritten by the files anyway. Change the YAML and redeploy.
 
-The v1 catalog pages only on near-certain incidents: an unreachable cluster, a
+Rules page only on near-certain incidents: an unreachable cluster, a
 crash-looping watched component, an admission webhook with no ready endpoints, a
 degraded component, and a dead Iris controller. Workload-tier signals (gated pods,
-Kueue backlog, workload crashloops) are dashboard-only until their expected cases can
-be suppressed. `severity=critical` routes to `ops-critical` (email ops@openathena.ai +
+Kueue backlog, workload crashloops) are dashboard-only — they have expected benign
+causes, so paging on them would be noise. `severity=critical` routes to `ops-critical` (email ops@openathena.ai +
 Slack); `severity=warning` routes to `ops-slack` (Slack only). Every rule sets
 `noDataState: Alerting` and `execErrState: Alerting`, and the alert endpoints return
 explicit zeros when healthy, so silence anywhere in the pipeline pages rather than

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -142,11 +142,10 @@ now (deploys are infrequent; `min=max=1` keeps a single evaluator); the hardenin
 if it ever matters is a small Cloud SQL Postgres for Grafana state.
 
 SMTP is the Google Workspace relay (`smtp-relay.gmail.com:587`, STARTTLS), sending as
-grafana@openathena.ai; `GF_SMTP_PASSWORD` comes from Secret Manager. Until a Workspace
-admin fills that secret with a real app password, email notifications fail while Slack
-still delivers. After changing contact points or their credentials, send a test
-notification to both receivers (Alerting → Contact points → Test) rather than trusting
-config presence.
+grafana@openathena.ai; `GF_SMTP_PASSWORD` comes from Secret Manager. Without a valid
+app password in that secret, email delivery fails while Slack still delivers. After
+changing contact points or their credentials, send a test notification to both
+receivers (Alerting → Contact points → Test) rather than trusting config presence.
 
 ## Secrets and rotation
 
@@ -167,8 +166,8 @@ read-role token in the CW console, `gcloud secrets versions add` it, redeploy, t
 revoke the old token. The same applies to the Slack webhook and SMTP password — add a
 version, redeploy, retire the old credential.
 
-Human setup, once, before the first deploy of this configuration (Cloud Run fails to
-start on a missing secret — create all three even if a value is a placeholder):
+Creating the secrets (Cloud Run fails to start on a missing secret, so each must
+exist even if its value is a placeholder):
 
 1. CoreWeave console → API access → new token (e.g. `grafana-observer`) with only the
    `read` role, then

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -213,6 +213,10 @@ cd infra/grafana
 pulumi login gs://marin-iac-state
 export PULUMI_CONFIG_PASSPHRASE="$(gcloud secrets versions access latest \
   --secret=pulumi-iac-passphrase --project=hai-gcp-models)"
+# The grafana.oa.dev DNS record lives in the oa.dev Cloudflare zone; the provider
+# reads this token from the environment.
+export CLOUDFLARE_API_TOKEN="$(gcloud secrets versions access latest \
+  --secret=cloudflare-oa-dns-token --project=hai-gcp-models)"
 pulumi stack select marin-grafana                         # first time: pulumi stack init marin-grafana
 
 # Who gets in — a bare email, a *@domain wildcard, or a qualified IAM member. Editing this

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -141,15 +141,18 @@ and a lost silence. Rule definitions are files, so nothing else is lost. Accepte
 now (deploys are infrequent; `min=max=1` keeps a single evaluator); the hardening path
 if it ever matters is a small Cloud SQL Postgres for Grafana state.
 
-SMTP is the Google Workspace relay (`smtp-relay.gmail.com:587`, STARTTLS), sending as
-grafana@openathena.ai; `GF_SMTP_PASSWORD` comes from Secret Manager. Without a valid
-app password in that secret, email delivery fails while Slack still delivers. After
-changing contact points or their credentials, send a test notification to both
-receivers (Alerting → Contact points → Test) rather than trusting config presence.
+Email is optional. SMTP is plain Gmail submission (`smtp.gmail.com:587`, STARTTLS),
+sending as grafana@openathena.ai with an app password from Secret Manager; the app
+sends mail itself, so deliverability (SPF, spam filtering) rests on the sending
+account. The deploy enables SMTP only when the `marin-grafana-smtp-credentials`
+secret exists — without it the service still deploys, the email receiver fails
+silently, and critical alerts reach Slack only. After changing contact points or
+their credentials, send a test notification to both receivers (Alerting → Contact
+points → Test) rather than trusting config presence.
 
 ## Secrets and rotation
 
-All four secrets live in Secret Manager and reach the container as env vars via the
+All secrets live in Secret Manager and reach the container as env vars via the
 `CloudRunService` `secrets` field; values never enter Pulumi or git.
 
 | Env var | Secret | Feeds |
@@ -157,7 +160,11 @@ All four secrets live in Secret Manager and reach the container as env vars via 
 | `GITHUB_TOKEN` | `marin-status-page-github-token` | ferry/build/nightly panels |
 | `CW_READ_TOKEN` | `marin-grafana-cw-read-token` | k8s source (all CW clusters) |
 | `SLACK_ALERTS_WEBHOOK` | `marin-grafana-slack-webhook` | alert contact points |
-| `GF_SMTP_PASSWORD` | `marin-grafana-smtp-credentials` | Grafana SMTP (email alerts) |
+| `GF_SMTP_PASSWORD` | `marin-grafana-smtp-credentials` | Grafana SMTP (email alerts, optional) |
+
+The first three must exist before a deploy — Cloud Run fails to start a revision
+that references a missing secret. `GF_SMTP_PASSWORD` is optional: `__main__.py`
+probes for the secret and only wires it (and enables SMTP) when it exists.
 
 `CW_READ_TOKEN` is an org-wide CoreWeave API token minted with only the `read` role
 (CKS binds it to the built-in `view` ClusterRole): read-only kubectl across every
@@ -166,15 +173,14 @@ read-role token in the CW console, `gcloud secrets versions add` it, redeploy, t
 revoke the old token. The same applies to the Slack webhook and SMTP password — add a
 version, redeploy, retire the old credential.
 
-Creating the secrets (Cloud Run fails to start on a missing secret, so each must
-exist even if its value is a placeholder):
+Creating the secrets:
 
 1. CoreWeave console → API access → new token (e.g. `grafana-observer`) with only the
    `read` role, then
    `echo -n "<token>" | gcloud secrets create marin-grafana-cw-read-token --project=hai-gcp-models --data-file=-`
 2. Slack → incoming webhook for `#marin-eng`, then
    `echo -n "https://hooks.slack.com/..." | gcloud secrets create marin-grafana-slack-webhook --project=hai-gcp-models --data-file=-`
-3. Workspace admin → app password for grafana@openathena.ai on the SMTP relay, then
+3. (optional, enables email) Gmail app password for grafana@openathena.ai, then
    `echo -n "<app-password>" | gcloud secrets create marin-grafana-smtp-credentials --project=hai-gcp-models --data-file=-`
 4. Send a test notification to both `ops-critical` receivers and confirm delivery.
 

--- a/infra/grafana/__main__.py
+++ b/infra/grafana/__main__.py
@@ -53,9 +53,16 @@ def main() -> None:
             cpu_always_allocated=True,
             # The bridge lists finelog and controller VM internal IPs through the Compute API.
             service_account_roles=("roles/compute.viewer",),
-            # The ferry/build panels call the GitHub API; the token lifts the REST rate limit
-            # and is required for the GraphQL build query. Value stays in Secret Manager.
-            secrets=(SecretEnv(name="GITHUB_TOKEN", secret="marin-status-page-github-token"),),
+            # Values stay in Secret Manager; the component only grants the runtime service
+            # account access. GITHUB_TOKEN feeds the ferry/build panels; CW_READ_TOKEN is the
+            # CoreWeave read-role token behind the k8s source; SLACK_ALERTS_WEBHOOK and
+            # GF_SMTP_PASSWORD feed the provisioned alerting contact points.
+            secrets=(
+                SecretEnv(name="GITHUB_TOKEN", secret="marin-status-page-github-token"),
+                SecretEnv(name="CW_READ_TOKEN", secret="marin-grafana-cw-read-token"),
+                SecretEnv(name="SLACK_ALERTS_WEBHOOK", secret="marin-grafana-slack-webhook"),
+                SecretEnv(name="GF_SMTP_PASSWORD", secret="marin-grafana-smtp-credentials"),
+            ),
             iap_members=tuple(viewers),
         ),
         gcp_provider=provider,

--- a/infra/grafana/__main__.py
+++ b/infra/grafana/__main__.py
@@ -33,6 +33,20 @@ SERVICE = "marin-grafana"
 # is the image build context.
 BUILD_CONTEXT = os.path.dirname(os.path.abspath(__file__))
 
+# Email delivery is optional: the deploy wires Grafana's SMTP password only when this
+# secret exists, so a project without it still deploys — critical alerts then reach
+# Slack only.
+SMTP_SECRET = "marin-grafana-smtp-credentials"
+
+
+def smtp_secret_exists(provider: gcp.Provider) -> bool:
+    found = gcp.secretmanager.get_secrets(
+        project=PROJECT,
+        filter=f"name:{SMTP_SECRET}",
+        opts=pulumi.InvokeOptions(provider=provider),
+    )
+    return any(secret.secret_id == SMTP_SECRET for secret in found.secrets)
+
 
 def main() -> None:
     config = pulumi.Config()
@@ -41,6 +55,21 @@ def main() -> None:
     viewers = config.get_object("viewers") or []
 
     provider = gcp.Provider("gcp", project=PROJECT)
+
+    # Values stay in Secret Manager; the component only grants the runtime service
+    # account access. GITHUB_TOKEN feeds the ferry/build panels; CW_READ_TOKEN is the
+    # CoreWeave read-role token behind the k8s source; SLACK_ALERTS_WEBHOOK and
+    # GF_SMTP_PASSWORD feed the provisioned alerting contact points.
+    secrets = [
+        SecretEnv(name="GITHUB_TOKEN", secret="marin-status-page-github-token"),
+        SecretEnv(name="CW_READ_TOKEN", secret="marin-grafana-cw-read-token"),
+        SecretEnv(name="SLACK_ALERTS_WEBHOOK", secret="marin-grafana-slack-webhook"),
+    ]
+    env = {}
+    if smtp_secret_exists(provider):
+        secrets.append(SecretEnv(name="GF_SMTP_PASSWORD", secret=SMTP_SECRET))
+        env["GF_SMTP_ENABLED"] = "true"
+
     service = CloudRunService(
         "grafana",
         CloudRunServiceArgs(
@@ -53,16 +82,8 @@ def main() -> None:
             cpu_always_allocated=True,
             # The bridge lists finelog and controller VM internal IPs through the Compute API.
             service_account_roles=("roles/compute.viewer",),
-            # Values stay in Secret Manager; the component only grants the runtime service
-            # account access. GITHUB_TOKEN feeds the ferry/build panels; CW_READ_TOKEN is the
-            # CoreWeave read-role token behind the k8s source; SLACK_ALERTS_WEBHOOK and
-            # GF_SMTP_PASSWORD feed the provisioned alerting contact points.
-            secrets=(
-                SecretEnv(name="GITHUB_TOKEN", secret="marin-status-page-github-token"),
-                SecretEnv(name="CW_READ_TOKEN", secret="marin-grafana-cw-read-token"),
-                SecretEnv(name="SLACK_ALERTS_WEBHOOK", secret="marin-grafana-slack-webhook"),
-                SecretEnv(name="GF_SMTP_PASSWORD", secret="marin-grafana-smtp-credentials"),
-            ),
+            env=env,
+            secrets=tuple(secrets),
             iap_members=tuple(viewers),
         ),
         gcp_provider=provider,

--- a/infra/grafana/dashboards/k8s.json
+++ b/infra/grafana/dashboards/k8s.json
@@ -1,0 +1,567 @@
+{
+  "uid": "marin-k8s",
+  "title": "K8s control plane",
+  "description": "Current control-plane state of the CoreWeave clusters, read straight from their k8s API servers by the bridge's k8s source: watched components, webhook endpoints, backoff pods, pending/gated pods, Kueue admission backlog, and Warning events. Every table carries a cluster column; a cluster the bridge cannot read shows up in the Cluster health panel with its error class. These panels are current-state only — the bridge stores no history; trends live in the finelog-backed dashboards.",
+  "tags": [
+    "marin",
+    "generated"
+  ],
+  "timezone": "utc",
+  "editable": false,
+  "schemaVersion": 39,
+  "refresh": "1m",
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "table",
+      "title": "Cluster health",
+      "description": "Whether each cluster's k8s API server answers the bridge, with the error class (auth, network, timeout, http) when it does not.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "k8s"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "latency_ms"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/health",
+          "url_options": {
+            "method": "GET"
+          },
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "reachable",
+              "text": "reachable",
+              "type": "boolean"
+            },
+            {
+              "selector": "error_class",
+              "text": "error_class",
+              "type": "string"
+            },
+            {
+              "selector": "error",
+              "text": "error",
+              "type": "string"
+            },
+            {
+              "selector": "latency_ms",
+              "text": "latency_ms",
+              "type": "number"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "table",
+      "title": "Webhook endpoints",
+      "description": "Ready endpoints behind each watched admission-webhook service, from discovery.k8s.io EndpointSlices. Zero means fail-closed admission is rejecting pod CREATE.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "k8s"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "ready_endpoints"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "green",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/control_plane",
+          "url_options": {
+            "method": "GET"
+          },
+          "filterExpression": "kind == 'webhook'",
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "component",
+              "text": "webhook",
+              "type": "string"
+            },
+            {
+              "selector": "ready_endpoints",
+              "text": "ready_endpoints",
+              "type": "number"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "table",
+      "title": "Kueue admission backlog",
+      "description": "Unadmitted, unfinished Kueue Workloads per local queue, with the age of the oldest. A backlog is normal under capacity pressure; it is a dashboard signal, not an alert.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "k8s"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "oldest_age_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/kueue",
+          "url_options": {
+            "method": "GET"
+          },
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "queue",
+              "text": "queue",
+              "type": "string"
+            },
+            {
+              "selector": "unadmitted",
+              "text": "unadmitted",
+              "type": "number"
+            },
+            {
+              "selector": "oldest_age_seconds",
+              "text": "oldest_age_seconds",
+              "type": "number"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "table",
+      "title": "Control-plane components",
+      "description": "Ready vs desired replicas, cumulative container restarts, and any waiting reason for each watched component. Missing means the Deployment does not exist.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "k8s"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "waiting_reason"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "": {
+                        "color": "green",
+                        "index": 0
+                      },
+                      "CrashLoopBackOff": {
+                        "color": "red",
+                        "index": 1
+                      },
+                      "ImagePullBackOff": {
+                        "color": "red",
+                        "index": 2
+                      },
+                      "Missing": {
+                        "color": "red",
+                        "index": 3
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/control_plane",
+          "url_options": {
+            "method": "GET"
+          },
+          "filterExpression": "kind == 'component'",
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "component",
+              "text": "component",
+              "type": "string"
+            },
+            {
+              "selector": "ready",
+              "text": "ready",
+              "type": "number"
+            },
+            {
+              "selector": "desired",
+              "text": "desired",
+              "type": "number"
+            },
+            {
+              "selector": "restarts",
+              "text": "restarts",
+              "type": "number"
+            },
+            {
+              "selector": "waiting_reason",
+              "text": "waiting_reason",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "table",
+      "title": "Crash-looping pods",
+      "description": "Containers sitting in CrashLoopBackOff or ImagePullBackOff, across every namespace except CoreWeave-managed ones (cw-*, kube-*). scope=control-plane means the pod belongs to a watched component; workload backoffs are informational.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "k8s"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/crashloops",
+          "url_options": {
+            "method": "GET"
+          },
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "namespace",
+              "text": "namespace",
+              "type": "string"
+            },
+            {
+              "selector": "pod",
+              "text": "pod",
+              "type": "string"
+            },
+            {
+              "selector": "container",
+              "text": "container",
+              "type": "string"
+            },
+            {
+              "selector": "reason",
+              "text": "reason",
+              "type": "string"
+            },
+            {
+              "selector": "restarts",
+              "text": "restarts",
+              "type": "number"
+            },
+            {
+              "selector": "scope",
+              "text": "scope",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "table",
+      "title": "Pending / gated pods",
+      "description": "Pods in phase Pending, oldest first: scheduling_gated means a scheduling gate (e.g. Kueue admission) is holding the pod; pending means the scheduler has it but has not placed it.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "k8s"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "age_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/pending",
+          "url_options": {
+            "method": "GET"
+          },
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "namespace",
+              "text": "namespace",
+              "type": "string"
+            },
+            {
+              "selector": "pod",
+              "text": "pod",
+              "type": "string"
+            },
+            {
+              "selector": "state",
+              "text": "state",
+              "type": "string"
+            },
+            {
+              "selector": "reason",
+              "text": "reason",
+              "type": "string"
+            },
+            {
+              "selector": "age_seconds",
+              "text": "age_seconds",
+              "type": "number"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "table",
+      "title": "Warning events",
+      "description": "The most recent Warning events per cluster (fieldSelector type=Warning), newest first. Event retention on the API server is about an hour.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "k8s"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/events",
+          "url_options": {
+            "method": "GET"
+          },
+          "columns": [
+            {
+              "selector": "last_seen",
+              "text": "last_seen",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "namespace",
+              "text": "namespace",
+              "type": "string"
+            },
+            {
+              "selector": "object",
+              "text": "object",
+              "type": "string"
+            },
+            {
+              "selector": "reason",
+              "text": "reason",
+              "type": "string"
+            },
+            {
+              "selector": "count",
+              "text": "count",
+              "type": "number"
+            },
+            {
+              "selector": "message",
+              "text": "message",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/k8s.json
+++ b/infra/grafana/dashboards/k8s.json
@@ -135,6 +135,18 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "kind"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
           }
         ]
       },
@@ -151,6 +163,11 @@
           },
           "filterExpression": "kind == 'webhook'",
           "columns": [
+            {
+              "selector": "kind",
+              "text": "kind",
+              "type": "string"
+            },
             {
               "selector": "cluster",
               "text": "cluster",
@@ -295,6 +312,18 @@
                 ]
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "kind"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
           }
         ]
       },
@@ -311,6 +340,11 @@
           },
           "filterExpression": "kind == 'component'",
           "columns": [
+            {
+              "selector": "kind",
+              "text": "kind",
+              "type": "string"
+            },
             {
               "selector": "cluster",
               "text": "cluster",

--- a/infra/grafana/provisioning/alerting/contact-points.yaml
+++ b/infra/grafana/provisioning/alerting/contact-points.yaml
@@ -1,0 +1,35 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Contact points, provisioned from files like the rest of the alerting tree: UI
+# edits do not persist (Grafana's SQLite is ephemeral on Cloud Run) and would be
+# overwritten by these files anyway.
+#
+# ops-critical carries two receivers so a critical alert reaches email and Slack
+# without relying on routing-tree subtleties; ops-slack is the warning tier.
+# $SLACK_ALERTS_WEBHOOK is expanded from the container environment (Secret
+# Manager: marin-grafana-slack-webhook). Email delivery additionally needs the
+# SMTP credentials secret — until a Workspace admin fills it, email is inert
+# while Slack still delivers.
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: ops-critical
+    receivers:
+      - uid: ops-critical-email
+        type: email
+        settings:
+          addresses: ops@openathena.ai
+      - uid: ops-critical-slack
+        type: slack
+        settings:
+          url: $SLACK_ALERTS_WEBHOOK
+
+  - orgId: 1
+    name: ops-slack
+    receivers:
+      - uid: ops-slack-webhook
+        type: slack
+        settings:
+          url: $SLACK_ALERTS_WEBHOOK

--- a/infra/grafana/provisioning/alerting/contact-points.yaml
+++ b/infra/grafana/provisioning/alerting/contact-points.yaml
@@ -8,9 +8,8 @@
 # ops-critical carries two receivers so a critical alert reaches email and Slack
 # without relying on routing-tree subtleties; ops-slack is the warning tier.
 # $SLACK_ALERTS_WEBHOOK is expanded from the container environment (Secret
-# Manager: marin-grafana-slack-webhook). Email delivery additionally needs the
-# SMTP credentials secret — until a Workspace admin fills it, email is inert
-# while Slack still delivers.
+# Manager: marin-grafana-slack-webhook). Email delivery additionally needs valid
+# SMTP credentials — without them email is inert while Slack still delivers.
 apiVersion: 1
 
 contactPoints:

--- a/infra/grafana/provisioning/alerting/policies.yaml
+++ b/infra/grafana/provisioning/alerting/policies.yaml
@@ -1,0 +1,23 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The notification policy tree. severity=critical routes to ops-critical (email +
+# Slack); severity=warning routes to ops-slack, which is also the root receiver
+# so an unlabeled alert still lands somewhere visible. Instances group by
+# (alertname, cluster) and re-notify every 4h while firing.
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    receiver: ops-slack
+    group_by: ["alertname", "cluster"]
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h
+    routes:
+      - receiver: ops-critical
+        object_matchers:
+          - ["severity", "=", "critical"]
+      - receiver: ops-slack
+        object_matchers:
+          - ["severity", "=", "warning"]

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -1,0 +1,260 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The v1 alert catalog: only conditions that are near-certainly an incident. The
+# k8s rules read the bridge's /k8s/alerts/* endpoints, which return string label
+# columns plus exactly one numeric column and always at least one row per cluster
+# (explicit zeros when healthy) — so a rule's NoData state is unreachable by
+# construction, and every rule still sets noDataState/execErrState to Alerting so
+# a broken datasource pages with the rule's own labels rather than going quiet.
+#
+# Workload-tier noise (gated pods, kueue backlog, workload crashloops) stays
+# dashboard-only: observe first, promote to rules once the expected cases can be
+# suppressed.
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: k8s-control-plane
+    folder: Alerts
+    interval: 1m
+    rules:
+      - uid: k8s-cluster-unreachable
+        title: K8sClusterUnreachable
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.cluster }}: k8s API server unreachable ({{ $labels.error_class }})"
+          runbook_url: https://github.com/marin-community/marin/blob/main/lib/iris/OPS.md
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: k8s
+            model:
+              refId: A
+              datasource: { type: yesoreyeram-infinity-datasource, uid: k8s }
+              type: json
+              source: url
+              parser: backend
+              format: table
+              url: /alerts/unreachable
+              url_options: { method: GET }
+              columns:
+                - { selector: cluster, text: cluster, type: string }
+                - { selector: error_class, text: error_class, type: string }
+                - { selector: value, text: value, type: number }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
+      - uid: k8s-control-plane-crashloop
+        title: ControlPlaneCrashLooping
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.cluster }}: a watched control-plane component is in backoff"
+          runbook_url: https://github.com/marin-community/marin/blob/main/lib/iris/OPS.md
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: k8s
+            model:
+              refId: A
+              datasource: { type: yesoreyeram-infinity-datasource, uid: k8s }
+              type: json
+              source: url
+              parser: backend
+              format: table
+              url: /alerts/crashloops
+              url_options:
+                method: GET
+                params:
+                  - { key: scope, value: control-plane }
+              columns:
+                - { selector: cluster, text: cluster, type: string }
+                - { selector: scope, text: scope, type: string }
+                - { selector: value, text: value, type: number }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
+      - uid: k8s-webhook-endpoints-empty
+        title: WebhookEndpointsEmpty
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.cluster }}: {{ $labels.webhook }} has no ready endpoints — fail-closed admission will reject pod CREATE"
+          runbook_url: https://github.com/marin-community/marin/blob/main/lib/iris/OPS.md
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: k8s
+            model:
+              refId: A
+              datasource: { type: yesoreyeram-infinity-datasource, uid: k8s }
+              type: json
+              source: url
+              parser: backend
+              format: table
+              url: /alerts/webhook_ready
+              url_options: { method: GET }
+              columns:
+                - { selector: cluster, text: cluster, type: string }
+                - { selector: webhook, text: webhook, type: string }
+                - { selector: value, text: value, type: number }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [1] }
+
+      - uid: k8s-control-plane-degraded
+        title: ControlPlaneDegraded
+        condition: C
+        for: 15m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.cluster }}: {{ $labels.component }} has fewer ready replicas than desired"
+          runbook_url: https://github.com/marin-community/marin/blob/main/lib/iris/OPS.md
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: k8s
+            model:
+              refId: A
+              datasource: { type: yesoreyeram-infinity-datasource, uid: k8s }
+              type: json
+              source: url
+              parser: backend
+              format: table
+              url: /alerts/degraded
+              url_options: { method: GET }
+              columns:
+                - { selector: cluster, text: cluster, type: string }
+                - { selector: component, text: component, type: string }
+                - { selector: value, text: value, type: number }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
+  # The GCE controllers are not in K8S_CLUSTERS; their liveness comes from the
+  # existing per-cluster iris datasources. The health row always exists (the
+  # bridge answers reachable=false rather than erroring), and `up` is its 0/1
+  # numeric mirror. The rule carries the cluster label itself since the endpoint
+  # is already cluster-scoped. marin-dev is warning: its controller matters to
+  # dev work, not to production paging.
+  - orgId: 1
+    name: iris-control-plane
+    folder: Alerts
+    interval: 1m
+    rules:
+      - uid: iris-controller-down-marin
+        title: IrisControllerDown
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: critical
+          cluster: marin
+        annotations:
+          summary: "marin: Iris controller /health is unreachable"
+          runbook_url: https://github.com/marin-community/marin/blob/main/lib/iris/OPS.md
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: iris-marin
+            model:
+              refId: A
+              datasource: { type: yesoreyeram-infinity-datasource, uid: iris-marin }
+              type: json
+              source: url
+              parser: backend
+              format: table
+              url: /health
+              url_options: { method: GET }
+              columns:
+                - { selector: up, text: up, type: number }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [1] }
+
+      - uid: iris-controller-down-marin-dev
+        title: IrisControllerDown
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: warning
+          cluster: marin-dev
+        annotations:
+          summary: "marin-dev: Iris controller /health is unreachable"
+          runbook_url: https://github.com/marin-community/marin/blob/main/lib/iris/OPS.md
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: iris-marin-dev
+            model:
+              refId: A
+              datasource: { type: yesoreyeram-infinity-datasource, uid: iris-marin-dev }
+              type: json
+              source: url
+              parser: backend
+              format: table
+              url: /health
+              url_options: { method: GET }
+              columns:
+                - { selector: up, text: up, type: number }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [1] }

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -1,16 +1,16 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 #
-# The v1 alert catalog: only conditions that are near-certainly an incident. The
+# Alert rules cover only conditions that are near-certainly an incident. The
 # k8s rules read the bridge's /k8s/alerts/* endpoints, which return string label
 # columns plus exactly one numeric column and always at least one row per cluster
 # (explicit zeros when healthy) — so a rule's NoData state is unreachable by
 # construction, and every rule still sets noDataState/execErrState to Alerting so
 # a broken datasource pages with the rule's own labels rather than going quiet.
 #
-# Workload-tier noise (gated pods, kueue backlog, workload crashloops) stays
-# dashboard-only: observe first, promote to rules once the expected cases can be
-# suppressed.
+# Workload-tier signals (gated pods, kueue backlog, workload crashloops) are
+# dashboard-only: they have expected benign causes (capacity pressure, user
+# error), so paging on them would be noise.
 apiVersion: 1
 
 groups:

--- a/infra/grafana/provisioning/datasources/k8s.yaml
+++ b/infra/grafana/provisioning/datasources/k8s.yaml
@@ -1,0 +1,23 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The k8s datasource, pointed at the bridge's /k8s path on loopback. Panels append
+# a fixed endpoint (`/control_plane`, `/crashloops`, ...) and the alert rules in
+# provisioning/alerting/rules.yaml append `/alerts/...`; the bridge queries every
+# CoreWeave API server with the CW read-role token and returns flat JSON rows with
+# a `cluster` column, so one datasource covers the fleet. The token lives in the
+# bridge, never in datasource config.
+#
+# allowedHosts pins the datasource to the bridge; port 8081 is config.BRIDGE_PORT.
+apiVersion: 1
+
+datasources:
+  - name: k8s
+    uid: k8s
+    type: yesoreyeram-infinity-datasource
+    access: proxy
+    editable: false
+    jsonData:
+      auth_method: none
+      allowedHosts: ["http://127.0.0.1:8081"]
+    url: http://127.0.0.1:8081/k8s

--- a/infra/grafana/pyproject.toml
+++ b/infra/grafana/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 grafana-bridge = "server:main"
 
 [dependency-groups]
-dev = ["pytest >= 8.4"]
+dev = ["pytest >= 8.4", "pyyaml >= 6"]
 
 [tool.uv]
 # if-necessary (not allow): take prereleases only for packages with no stable

--- a/infra/grafana/src/config.py
+++ b/infra/grafana/src/config.py
@@ -61,6 +61,64 @@ CLUSTERS: tuple[ClusterTarget, ...] = (
 
 
 @dataclasses.dataclass(frozen=True)
+class K8sClusterTarget:
+    """A CoreWeave cluster whose k8s API server the bridge polls read-only."""
+
+    name: str  # iris cluster name, e.g. "cw-us-east-08a"
+    api_server: str  # public CKS API server URL
+
+
+# All requests authenticate with the single org-wide CW read-role token from the
+# CW_READ_TOKEN env var (Secret Manager: marin-grafana-cw-read-token).
+K8S_CLUSTERS: tuple[K8sClusterTarget, ...] = (
+    K8sClusterTarget("cw-us-east-02a", "https://208261-34513e48.k8s.us-east-02a.coreweave.com"),
+    K8sClusterTarget("cw-us-east-08a", "https://208261-d2cd61ed.k8s.us-east-08a.coreweave.com"),
+    K8sClusterTarget("cw-rno2a", "https://208261-6670debc.k8s.rno2a.coreweave.com"),
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class WatchedComponent:
+    """A control-plane Deployment the k8s source reports on and alerts over."""
+
+    namespace: str
+    deployment: str
+
+    @property
+    def key(self) -> str:
+        return f"{self.namespace}/{self.deployment}"
+
+
+WATCHED_COMPONENTS: tuple[WatchedComponent, ...] = (
+    WatchedComponent("kueue-system", "kueue-controller-manager"),
+    WatchedComponent("iris", "iris-controller"),
+    WatchedComponent("traefik", "traefik"),
+    WatchedComponent("cert-manager", "cert-manager"),
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class WatchedWebhook:
+    """An admission-webhook Service whose ready-endpoint count the bridge watches."""
+
+    namespace: str
+    service: str
+
+    @property
+    def key(self) -> str:
+        return f"{self.namespace}/{self.service}"
+
+
+WATCHED_WEBHOOKS: tuple[WatchedWebhook, ...] = (WatchedWebhook("kueue-system", "kueue-webhook-service"),)
+
+# Namespaces the pod-level scans (crashloops, pending) skip, by prefix. CoreWeave's
+# per-node daemons dominate the pod count on large clusters (thousands of pods,
+# ~20KB of JSON each) and are CoreWeave's to operate; the namespaces we own hold
+# on the order of a hundred pods.
+PROVIDER_NAMESPACE_PREFIXES: tuple[str, ...] = ("cw-", "kube-")
+
+
+@dataclasses.dataclass(frozen=True)
 class FerryTier:
     """One workflow file backing a ferry card. label captions a multi-tier strip."""
 
@@ -100,13 +158,18 @@ class BridgeConfig:
     # finelog result cache TTL, seconds.
     cache_ttl: float
     query_timeout_ms: int
-    # Cache TTLs for the live Iris and GitHub endpoints, seconds.
+    # Cache TTLs for the live Iris, GitHub, and k8s endpoints, seconds.
     iris_cache_ttl: float
     github_cache_ttl: float
-    # HTTP timeout for the controller RPC and GitHub calls, seconds.
+    k8s_cache_ttl: float
+    # HTTP timeout for the controller RPC, GitHub, and k8s API calls, seconds.
     http_timeout: float
     # GitHub token; lifts the REST rate limit and is required for the GraphQL build panel.
     github_token: str | None
+    # CW read-role bearer token for the k8s API servers. None does not fail the boot
+    # (that would take Grafana down with it); the k8s routes serve auth error rows
+    # and unreachable=1 alert rows instead.
+    cw_read_token: str | None
 
     @staticmethod
     def from_environment() -> "BridgeConfig":
@@ -117,6 +180,8 @@ class BridgeConfig:
             query_timeout_ms=int(os.environ.get("GRAFANA_BRIDGE_QUERY_TIMEOUT_MS", "20000")),
             iris_cache_ttl=float(os.environ.get("GRAFANA_BRIDGE_IRIS_CACHE_TTL", "15")),
             github_cache_ttl=float(os.environ.get("GRAFANA_BRIDGE_GITHUB_CACHE_TTL", "60")),
+            k8s_cache_ttl=float(os.environ.get("GRAFANA_BRIDGE_K8S_CACHE_TTL", "30")),
             http_timeout=float(os.environ.get("GRAFANA_BRIDGE_HTTP_TIMEOUT", "10")),
             github_token=os.environ.get("GITHUB_TOKEN") or None,
+            cw_read_token=os.environ.get("CW_READ_TOKEN") or None,
         )

--- a/infra/grafana/src/iris_source.py
+++ b/infra/grafana/src/iris_source.py
@@ -140,8 +140,7 @@ class IrisSource:
 
         Returns 200 with reachable=false on failure — reachability is the signal, so the
         panel threshold renders it, rather than the endpoint erroring. ``up`` mirrors
-        ``reachable`` as 0/1 for the IrisControllerDown alert rule, which needs a
-        numeric column to threshold on.
+        ``reachable`` as 0/1 so a threshold can evaluate it numerically.
         """
         base = self._base()
         started = time.monotonic()

--- a/infra/grafana/src/iris_source.py
+++ b/infra/grafana/src/iris_source.py
@@ -139,7 +139,9 @@ class IrisSource:
         """One row: whether the controller /health answers, and the round-trip latency.
 
         Returns 200 with reachable=false on failure — reachability is the signal, so the
-        panel threshold renders it, rather than the endpoint erroring.
+        panel threshold renders it, rather than the endpoint erroring. ``up`` mirrors
+        ``reachable`` as 0/1 for the IrisControllerDown alert rule, which needs a
+        numeric column to threshold on.
         """
         base = self._base()
         started = time.monotonic()
@@ -147,10 +149,10 @@ class IrisSource:
             response = self._client.get(f"{base}/health")
             latency_ms = round((time.monotonic() - started) * 1000)
             reachable = response.status_code == 200
-            return [{"reachable": reachable, "latency_ms": latency_ms if reachable else None}]
+            return [{"reachable": reachable, "up": int(reachable), "latency_ms": latency_ms if reachable else None}]
         except httpx.TransportError as err:
             self._base_url = None
-            return [{"reachable": False, "latency_ms": None, "error": str(err)}]
+            return [{"reachable": False, "up": 0, "latency_ms": None, "error": str(err)}]
 
     def raw_query(self, sql: str) -> list[dict]:
         """Run an ad-hoc SELECT via ExecuteRawQuery, zipping columns to values."""

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -54,6 +54,11 @@ _EVENT_MESSAGE_LIMIT = 200
 # Container waiting reasons the crashloop rows report.
 BACKOFF_REASONS = ("CrashLoopBackOff", "ImagePullBackOff")
 
+# Crashloop scope labels: pods of a watched component vs everything else. The alert
+# rules filter on these values (the crashloops rule pages only on SCOPE_CONTROL_PLANE).
+SCOPE_CONTROL_PLANE = "control-plane"
+SCOPE_WORKLOAD = "workload"
+
 
 class K8sErrorClass(StrEnum):
     """Why a cluster query failed, coarse enough to be an alert label."""
@@ -334,12 +339,12 @@ def _pod_condition(pod: dict, condition_type: str) -> dict:
 
 
 def _pod_scope(metadata: dict) -> str:
-    """control-plane if the pod belongs to a watched Deployment, else workload."""
+    """SCOPE_CONTROL_PLANE if the pod belongs to a watched Deployment, else SCOPE_WORKLOAD."""
     namespace, name = metadata.get("namespace"), metadata.get("name") or ""
     for component in WATCHED_COMPONENTS:
         if namespace == component.namespace and name.startswith(f"{component.deployment}-"):
-            return "control-plane"
-    return "workload"
+            return SCOPE_CONTROL_PLANE
+    return SCOPE_WORKLOAD
 
 
 class K8sFleet:
@@ -408,12 +413,14 @@ class K8sFleet:
         """Per cluster: backoff container counts for both scopes, zero rows included."""
 
         def counts(source: K8sSource) -> list[dict]:
-            by_scope = {"control-plane": 0, "workload": 0}
+            by_scope = {SCOPE_CONTROL_PLANE: 0, SCOPE_WORKLOAD: 0}
             for row in source.crashloops():
                 by_scope[row["scope"]] += 1
             return [{"scope": scope, "value": count} for scope, count in by_scope.items()]
 
-        return self._fan_out(counts, lambda err: [{"scope": s, "value": 0} for s in ("control-plane", "workload")])
+        return self._fan_out(
+            counts, lambda err: [{"scope": s, "value": 0} for s in (SCOPE_CONTROL_PLANE, SCOPE_WORKLOAD)]
+        )
 
     def alert_webhook_ready(self) -> list[dict]:
         """Per cluster and watched webhook: the ready-endpoint count (0 when unreachable)."""

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -1,0 +1,436 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read-only CoreWeave k8s control-plane state, as flat JSON rows.
+
+One K8sSource per cluster speaks to the public CKS API server with plain httpx
+GETs and the CW read-role bearer token — no kubernetes client. K8sFleet fans a
+query out across every cluster and stamps a ``cluster`` column, so one response
+covers the fleet.
+
+The pod-level scans (crashloops, pending) cover every namespace except the
+provider-managed prefixes in PROVIDER_NAMESPACE_PREFIXES: CoreWeave's per-node
+daemons are thousands of pods of someone else's infrastructure, while the
+namespaces we operate hold about a hundred.
+
+Failure semantics: a cluster that cannot be queried becomes labeled rows inside
+the aggregate response — never an empty result — so healthy clusters keep
+rendering and alert rules keep one row per cluster. Errors are classified
+(auth / network / timeout / http) so a revoked token reads differently from a
+dead API server. On the alert routes every numeric falls back to zero for an
+unreachable cluster: for the crashloop and degraded rules zero means "no
+evidence, no page" (the unreachable rule pages instead), while for
+webhook_ready zero means "no ready endpoints", so unreachability also fires the
+webhook rule — deliberate, because unknown admission state is exactly the
+failure class it watches.
+"""
+
+import logging
+import time
+from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from enum import StrEnum
+
+import httpx
+from config import (
+    PROVIDER_NAMESPACE_PREFIXES,
+    WATCHED_COMPONENTS,
+    WATCHED_WEBHOOKS,
+    K8sClusterTarget,
+    WatchedComponent,
+    WatchedWebhook,
+)
+
+logger = logging.getLogger(__name__)
+
+_LIST_PAGE = 500
+_MAX_LIST_PAGES = 10
+_MAX_RETRY_AFTER = 3.0
+# Warning events returned per cluster, most recent first.
+_EVENT_LIMIT = 100
+_EVENT_MESSAGE_LIMIT = 200
+
+# Container waiting reasons the crashloop rows report.
+BACKOFF_REASONS = ("CrashLoopBackOff", "ImagePullBackOff")
+
+
+class K8sErrorClass(StrEnum):
+    """Why a cluster query failed, coarse enough to be an alert label."""
+
+    AUTH = "auth"  # 401/403: token missing, revoked, or under-privileged
+    NETWORK = "network"  # connect/TLS failure
+    TIMEOUT = "timeout"
+    HTTP = "http"  # any other non-200
+
+
+class K8sError(Exception):
+    """A per-cluster query failure, carrying its class for error rows."""
+
+    def __init__(self, error_class: K8sErrorClass, message: str) -> None:
+        self.error_class = error_class
+        super().__init__(message)
+
+
+def _age_seconds(timestamp: str | None) -> int | None:
+    if not timestamp:
+        return None
+    created = datetime.fromisoformat(timestamp)
+    return max(int((datetime.now(UTC) - created).total_seconds()), 0)
+
+
+def _epoch_ms(timestamp: str | None) -> int | None:
+    if not timestamp:
+        return None
+    return round(datetime.fromisoformat(timestamp).timestamp() * 1000)
+
+
+def _retry_after(response: httpx.Response) -> float:
+    try:
+        return min(float(response.headers.get("retry-after", "1")), _MAX_RETRY_AFTER)
+    except ValueError:
+        return 1.0
+
+
+class K8sSource:
+    """A query handle for one cluster's k8s API server.
+
+    Every method raises K8sError on failure; K8sFleet turns that into labeled
+    rows. Rows carry no cluster column — the fleet stamps it.
+    """
+
+    def __init__(self, target: K8sClusterTarget, *, token: str | None, timeout: float) -> None:
+        self._target = target
+        self._token = token
+        headers = {"authorization": f"Bearer {token}"} if token else {}
+        self._client = httpx.Client(base_url=target.api_server, timeout=timeout, headers=headers)
+
+    @property
+    def target(self) -> K8sClusterTarget:
+        return self._target
+
+    def _get(self, path: str, params: dict | None = None, *, none_on_404: bool = False) -> dict | None:
+        """GET one API path as JSON, retrying a 429 once after its Retry-After."""
+        if self._token is None:
+            raise K8sError(K8sErrorClass.AUTH, "CW_READ_TOKEN is not set")
+        for attempt in (1, 2):
+            try:
+                response = self._client.get(path, params=params)
+            except httpx.TimeoutException as err:
+                raise K8sError(K8sErrorClass.TIMEOUT, f"{path}: {err}") from err
+            except httpx.TransportError as err:
+                raise K8sError(K8sErrorClass.NETWORK, f"{path}: {err}") from err
+            if response.status_code == 429 and attempt == 1:
+                time.sleep(_retry_after(response))
+                continue
+            if response.status_code == 404 and none_on_404:
+                return None
+            if response.status_code in (401, 403):
+                raise K8sError(K8sErrorClass.AUTH, f"{path}: HTTP {response.status_code}")
+            if response.status_code != 200:
+                raise K8sError(K8sErrorClass.HTTP, f"{path}: HTTP {response.status_code}")
+            return response.json()
+        raise AssertionError("unreachable")
+
+    def _list(self, path: str, params: dict | None = None) -> list[dict]:
+        """LIST with limit/continue pagination, concatenating the pages' items."""
+        params = dict(params or {})
+        params["limit"] = _LIST_PAGE
+        items: list[dict] = []
+        for _ in range(_MAX_LIST_PAGES):
+            page = self._get(path, params)
+            assert page is not None
+            items.extend(page.get("items", []))
+            cont = (page.get("metadata") or {}).get("continue")
+            if not cont:
+                return items
+            params["continue"] = cont
+        logger.warning("%s: %s pagination stopped after %d pages", self._target.name, path, _MAX_LIST_PAGES)
+        return items
+
+    def probe(self) -> int:
+        """Round-trip /version (cheap, still authenticated) and return the latency in ms."""
+        started = time.monotonic()
+        self._get("/version")
+        return round((time.monotonic() - started) * 1000)
+
+    def _deployment(self, component: WatchedComponent) -> dict | None:
+        path = f"/apis/apps/v1/namespaces/{component.namespace}/deployments/{component.deployment}"
+        return self._get(path, none_on_404=True)
+
+    def _deployment_pods(self, component: WatchedComponent, deployment: dict) -> list[dict]:
+        match_labels = ((deployment.get("spec") or {}).get("selector") or {}).get("matchLabels") or {}
+        if not match_labels:
+            return []
+        selector = ",".join(f"{key}={value}" for key, value in sorted(match_labels.items()))
+        return self._list(f"/api/v1/namespaces/{component.namespace}/pods", {"labelSelector": selector})
+
+    def component_status(self, component: WatchedComponent) -> dict:
+        """Ready/desired replicas plus restart and waiting state from the pods behind one Deployment.
+
+        A missing Deployment reports desired=1, ready=0 with waiting_reason=Missing, so
+        a deleted control-plane component reads as degraded rather than healthy.
+        """
+        deployment = self._deployment(component)
+        if deployment is None:
+            return {
+                "kind": "component",
+                "component": component.key,
+                "ready": 0,
+                "desired": 1,
+                "restarts": 0,
+                "waiting_reason": "Missing",
+            }
+        desired = (deployment.get("spec") or {}).get("replicas")
+        desired = 1 if desired is None else desired
+        ready = (deployment.get("status") or {}).get("readyReplicas") or 0
+        restarts = 0
+        waiting_reason = ""
+        for pod in self._deployment_pods(component, deployment):
+            for status in _container_statuses(pod):
+                restarts += status.get("restartCount") or 0
+                reason = ((status.get("state") or {}).get("waiting") or {}).get("reason")
+                if reason and not waiting_reason:
+                    waiting_reason = reason
+        return {
+            "kind": "component",
+            "component": component.key,
+            "ready": ready,
+            "desired": desired,
+            "restarts": restarts,
+            "waiting_reason": waiting_reason,
+        }
+
+    def webhook_ready_endpoints(self, webhook: WatchedWebhook) -> int:
+        """Count ready endpoints across the service's EndpointSlices (nil ready counts as ready)."""
+        slices = self._list(
+            f"/apis/discovery.k8s.io/v1/namespaces/{webhook.namespace}/endpointslices",
+            {"labelSelector": f"kubernetes.io/service-name={webhook.service}"},
+        )
+        ready = 0
+        for slice_ in slices:
+            for endpoint in slice_.get("endpoints") or []:
+                if (endpoint.get("conditions") or {}).get("ready") is not False:
+                    ready += 1
+        return ready
+
+    def control_plane(self) -> list[dict]:
+        """One row per watched component, then one per watched webhook service."""
+        rows = [self.component_status(component) for component in WATCHED_COMPONENTS]
+        for webhook in WATCHED_WEBHOOKS:
+            rows.append(
+                {
+                    "kind": "webhook",
+                    "component": webhook.key,
+                    "ready_endpoints": self.webhook_ready_endpoints(webhook),
+                }
+            )
+        return rows
+
+    def _scanned_namespaces(self) -> list[str]:
+        """Namespaces the pod scans cover: everything not provider-managed by prefix."""
+        namespaces = self._list("/api/v1/namespaces")
+        names = [(ns.get("metadata") or {}).get("name") or "" for ns in namespaces]
+        return [name for name in names if name and not name.startswith(PROVIDER_NAMESPACE_PREFIXES)]
+
+    def _scan_pods(self, field_selector: str) -> list[dict]:
+        pods: list[dict] = []
+        for namespace in self._scanned_namespaces():
+            pods.extend(self._list(f"/api/v1/namespaces/{namespace}/pods", {"fieldSelector": field_selector}))
+        return pods
+
+    def crashloops(self) -> list[dict]:
+        """One row per container sitting in a backoff waiting state, across the scanned namespaces."""
+        pods = self._scan_pods("status.phase!=Succeeded,status.phase!=Failed")
+        rows = []
+        for pod in pods:
+            for status in _container_statuses(pod):
+                reason = ((status.get("state") or {}).get("waiting") or {}).get("reason")
+                if reason not in BACKOFF_REASONS:
+                    continue
+                metadata = pod.get("metadata") or {}
+                rows.append(
+                    {
+                        "namespace": metadata.get("namespace"),
+                        "pod": metadata.get("name"),
+                        "container": status.get("name"),
+                        "reason": reason,
+                        "restarts": status.get("restartCount") or 0,
+                        "scope": _pod_scope(metadata),
+                    }
+                )
+        return rows
+
+    def pending(self) -> list[dict]:
+        """One row per Pending pod in the scanned namespaces, split into scheduling_gated vs pending, oldest first."""
+        pods = self._scan_pods("status.phase=Pending")
+        rows = []
+        for pod in pods:
+            metadata = pod.get("metadata") or {}
+            scheduled = _pod_condition(pod, "PodScheduled")
+            gated = bool((pod.get("spec") or {}).get("schedulingGates")) or scheduled.get("reason") == "SchedulingGated"
+            rows.append(
+                {
+                    "namespace": metadata.get("namespace"),
+                    "pod": metadata.get("name"),
+                    "state": "scheduling_gated" if gated else "pending",
+                    "reason": scheduled.get("reason") or "",
+                    "age_seconds": _age_seconds(metadata.get("creationTimestamp")),
+                }
+            )
+        rows.sort(key=lambda row: row["age_seconds"] or 0, reverse=True)
+        return rows
+
+    def kueue(self) -> list[dict]:
+        """Unadmitted, unfinished Kueue Workloads aggregated per local queue."""
+        workloads = self._list("/apis/kueue.x-k8s.io/v1beta2/workloads")
+        queues: dict[str, dict] = {}
+        for workload in workloads:
+            conditions = {c.get("type"): c.get("status") for c in (workload.get("status") or {}).get("conditions") or []}
+            if conditions.get("Admitted") == "True" or conditions.get("Finished") == "True":
+                continue
+            queue = (workload.get("spec") or {}).get("queueName") or "unknown"
+            age = _age_seconds((workload.get("metadata") or {}).get("creationTimestamp")) or 0
+            bucket = queues.setdefault(queue, {"queue": queue, "unadmitted": 0, "oldest_age_seconds": 0})
+            bucket["unadmitted"] += 1
+            bucket["oldest_age_seconds"] = max(bucket["oldest_age_seconds"], age)
+        return [queues[queue] for queue in sorted(queues)]
+
+    def warning_events(self) -> list[dict]:
+        """The most recent Warning events, newest first."""
+        events = self._list("/api/v1/events", {"fieldSelector": "type=Warning"})
+        rows = []
+        for event in events:
+            involved = event.get("involvedObject") or {}
+            last_seen = (
+                event.get("lastTimestamp")
+                or event.get("eventTime")
+                or (event.get("metadata") or {}).get("creationTimestamp")
+            )
+            rows.append(
+                {
+                    "namespace": involved.get("namespace"),
+                    "object": f"{involved.get('kind', '?')}/{involved.get('name', '?')}",
+                    "reason": event.get("reason"),
+                    "message": (event.get("message") or "")[:_EVENT_MESSAGE_LIMIT],
+                    "count": event.get("count") or 1,
+                    "last_seen": _epoch_ms(last_seen),
+                }
+            )
+        rows.sort(key=lambda row: row["last_seen"] or 0, reverse=True)
+        return rows[:_EVENT_LIMIT]
+
+
+def _container_statuses(pod: dict) -> list[dict]:
+    status = pod.get("status") or {}
+    return list(status.get("initContainerStatuses") or []) + list(status.get("containerStatuses") or [])
+
+
+def _pod_condition(pod: dict, condition_type: str) -> dict:
+    for condition in (pod.get("status") or {}).get("conditions") or []:
+        if condition.get("type") == condition_type:
+            return condition
+    return {}
+
+
+def _pod_scope(metadata: dict) -> str:
+    """control-plane if the pod belongs to a watched Deployment, else workload."""
+    namespace, name = metadata.get("namespace"), metadata.get("name") or ""
+    for component in WATCHED_COMPONENTS:
+        if namespace == component.namespace and name.startswith(f"{component.deployment}-"):
+            return "control-plane"
+    return "workload"
+
+
+class K8sFleet:
+    """Fans one query out across every cluster, one thread each, stamping ``cluster``."""
+
+    def __init__(self, sources: Sequence[K8sSource]) -> None:
+        self._sources = tuple(sources)
+        self._executor = ThreadPoolExecutor(max_workers=max(len(self._sources), 1), thread_name_prefix="k8s")
+
+    def _fan_out(
+        self,
+        fn: Callable[[K8sSource], list[dict]],
+        on_error: Callable[[K8sError], list[dict]],
+    ) -> list[dict]:
+        futures = [(source, self._executor.submit(fn, source)) for source in self._sources]
+        rows: list[dict] = []
+        for source, future in futures:
+            try:
+                cluster_rows = future.result()
+            except K8sError as err:
+                logger.warning("k8s query failed for %s: %s", source.target.name, err)
+                cluster_rows = on_error(err)
+            rows.extend({"cluster": source.target.name, **row} for row in cluster_rows)
+        return rows
+
+    @staticmethod
+    def _error_row(err: K8sError) -> list[dict]:
+        return [{"error_class": str(err.error_class), "error": str(err)}]
+
+    def control_plane(self) -> list[dict]:
+        return self._fan_out(lambda s: s.control_plane(), self._error_row)
+
+    def crashloops(self) -> list[dict]:
+        return self._fan_out(lambda s: s.crashloops(), self._error_row)
+
+    def pending(self) -> list[dict]:
+        return self._fan_out(lambda s: s.pending(), self._error_row)
+
+    def kueue(self) -> list[dict]:
+        return self._fan_out(lambda s: s.kueue(), self._error_row)
+
+    def warning_events(self) -> list[dict]:
+        return self._fan_out(lambda s: s.warning_events(), self._error_row)
+
+    def health(self) -> list[dict]:
+        """One row per cluster: reachable, error class, and API server latency."""
+
+        def probe(source: K8sSource) -> list[dict]:
+            return [{"reachable": True, "error_class": "", "error": "", "latency_ms": source.probe()}]
+
+        def on_error(err: K8sError) -> list[dict]:
+            return [{"reachable": False, "error_class": str(err.error_class), "error": str(err), "latency_ms": None}]
+
+        return self._fan_out(probe, on_error)
+
+    def alert_unreachable(self) -> list[dict]:
+        """Per cluster: value=1 with its error class when the API server cannot be read."""
+
+        def probe(source: K8sSource) -> list[dict]:
+            source.probe()
+            return [{"error_class": "none", "value": 0}]
+
+        return self._fan_out(probe, lambda err: [{"error_class": str(err.error_class), "value": 1}])
+
+    def alert_crashloops(self) -> list[dict]:
+        """Per cluster: backoff container counts for both scopes, zero rows included."""
+
+        def counts(source: K8sSource) -> list[dict]:
+            by_scope = {"control-plane": 0, "workload": 0}
+            for row in source.crashloops():
+                by_scope[row["scope"]] += 1
+            return [{"scope": scope, "value": count} for scope, count in by_scope.items()]
+
+        return self._fan_out(counts, lambda err: [{"scope": s, "value": 0} for s in ("control-plane", "workload")])
+
+    def alert_webhook_ready(self) -> list[dict]:
+        """Per cluster and watched webhook: the ready-endpoint count (0 when unreachable)."""
+
+        def counts(source: K8sSource) -> list[dict]:
+            return [{"webhook": w.key, "value": source.webhook_ready_endpoints(w)} for w in WATCHED_WEBHOOKS]
+
+        return self._fan_out(counts, lambda err: [{"webhook": w.key, "value": 0} for w in WATCHED_WEBHOOKS])
+
+    def alert_degraded(self) -> list[dict]:
+        """Per cluster and watched component: desired minus ready replicas."""
+
+        def gaps(source: K8sSource) -> list[dict]:
+            rows = []
+            for component in WATCHED_COMPONENTS:
+                status = source.component_status(component)
+                rows.append({"component": component.key, "value": max(status["desired"] - status["ready"], 0)})
+            return rows
+
+        return self._fan_out(gaps, lambda err: [{"component": c.key, "value": 0} for c in WATCHED_COMPONENTS])

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -19,10 +19,24 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /github/ferries                          recent ferry runs per tier, with success rate
     GET /github/builds                           recent main commits with CI rollup state
     GET /github/nightlies                        7-day nightly-lane matrix (one row per lane/day)
+    GET /k8s/control_plane                       watched components + webhook endpoints, all clusters
+    GET /k8s/crashloops                          containers in backoff waiting states
+    GET /k8s/pending                             Pending / SchedulingGated pods with age
+    GET /k8s/kueue                               unadmitted Kueue workloads per queue
+    GET /k8s/events                              recent Warning events
+    GET /k8s/health                              per-cluster API server reachability + latency
+    GET /k8s/alerts/unreachable                  alert rows: cluster, error_class, value(0|1)
+    GET /k8s/alerts/crashloops?scope=            alert rows: cluster, scope, value(count)
+    GET /k8s/alerts/webhook_ready                alert rows: cluster, webhook, value(ready count)
+    GET /k8s/alerts/degraded                     alert rows: cluster, component, value(desired-ready)
     GET /health                                  bridge liveness
 
 A dead controller or GitHub returns 5xx (not empty rows), and the failure is not
-cached. Handlers are sync defs; Starlette runs them in a threadpool.
+cached. The k8s routes aggregate every CW cluster into one response, so a dead
+cluster becomes labeled error rows while the rest render; the alert routes always
+return at least one row per cluster (explicit zeros when healthy) so Grafana
+rules never hit NoData. Handlers are sync defs; Starlette runs them in a
+threadpool.
 """
 
 import json
@@ -33,12 +47,13 @@ from datetime import UTC, datetime
 import pyarrow as pa
 import uvicorn
 from cache import TtlCache
-from config import BRIDGE_PORT, CLUSTERS, BridgeConfig, ClusterTarget
+from config import BRIDGE_PORT, CLUSTERS, K8S_CLUSTERS, BridgeConfig, ClusterTarget
 from errors import UpstreamError
 from finelog.errors import QueryResultTooLargeError
 from finelog_source import FinelogSource, MetricSource
 from github_source import GithubSource
 from iris_source import IrisSource
+from k8s_source import K8sFleet, K8sSource
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -223,11 +238,13 @@ def create_app(
     finelog_sources: Mapping[str, MetricSource],
     iris_sources: Mapping[str, IrisSource],
     github_source: GithubSource,
+    k8s_fleet: K8sFleet,
 ) -> Starlette:
-    """Build the ASGI app serving finelog, Iris, and GitHub for the configured clusters."""
+    """Build the ASGI app serving finelog, Iris, GitHub, and k8s for the configured clusters."""
     finelog_cache: TtlCache = TtlCache(config.cache_ttl)
     iris_cache: TtlCache = TtlCache(config.iris_cache_ttl)
     github_cache: TtlCache = TtlCache(config.github_cache_ttl)
+    k8s_cache: TtlCache = TtlCache(config.k8s_cache_ttl)
 
     def query(request: Request) -> JSONResponse:
         try:
@@ -281,6 +298,47 @@ def create_app(
     def github_nightlies(_: Request) -> JSONResponse:
         return github_endpoint("nightlies", github_source.nightlies)
 
+    def k8s_endpoint(key: str, run) -> JSONResponse:
+        # Per-cluster failures are labeled rows inside the response; only a bridge
+        # bug raises here, and Starlette turns that into a 500.
+        return JSONResponse(k8s_cache.get_or_compute(key, run))
+
+    def k8s_control_plane(_: Request) -> JSONResponse:
+        return k8s_endpoint("control_plane", k8s_fleet.control_plane)
+
+    def k8s_crashloops(_: Request) -> JSONResponse:
+        return k8s_endpoint("crashloops", k8s_fleet.crashloops)
+
+    def k8s_pending(_: Request) -> JSONResponse:
+        return k8s_endpoint("pending", k8s_fleet.pending)
+
+    def k8s_kueue(_: Request) -> JSONResponse:
+        return k8s_endpoint("kueue", k8s_fleet.kueue)
+
+    def k8s_events(_: Request) -> JSONResponse:
+        return k8s_endpoint("events", k8s_fleet.warning_events)
+
+    def k8s_health(_: Request) -> JSONResponse:
+        return k8s_endpoint("health", k8s_fleet.health)
+
+    def k8s_alerts_unreachable(_: Request) -> JSONResponse:
+        return k8s_endpoint("alerts_unreachable", k8s_fleet.alert_unreachable)
+
+    def k8s_alerts_crashloops(request: Request) -> JSONResponse:
+        # The paging rule asks for scope=control-plane; workload backoffs stay
+        # observe-only. Filtering after the cache keeps one scan per TTL.
+        response = k8s_cache.get_or_compute("alerts_crashloops", k8s_fleet.alert_crashloops)
+        scope = request.query_params.get("scope")
+        if scope:
+            response = [row for row in response if row["scope"] == scope]
+        return JSONResponse(response)
+
+    def k8s_alerts_webhook_ready(_: Request) -> JSONResponse:
+        return k8s_endpoint("alerts_webhook_ready", k8s_fleet.alert_webhook_ready)
+
+    def k8s_alerts_degraded(_: Request) -> JSONResponse:
+        return k8s_endpoint("alerts_degraded", k8s_fleet.alert_degraded)
+
     def health(_: Request) -> JSONResponse:
         return JSONResponse({"status": "ok", "clusters": sorted(finelog_sources)})
 
@@ -295,6 +353,16 @@ def create_app(
             Route("/iris/{cluster}/workers", iris_workers),
             Route("/iris/{cluster}/health", iris_health),
             Route("/iris/{cluster}/query", iris_query),
+            Route("/k8s/control_plane", k8s_control_plane),
+            Route("/k8s/crashloops", k8s_crashloops),
+            Route("/k8s/pending", k8s_pending),
+            Route("/k8s/kueue", k8s_kueue),
+            Route("/k8s/events", k8s_events),
+            Route("/k8s/health", k8s_health),
+            Route("/k8s/alerts/unreachable", k8s_alerts_unreachable),
+            Route("/k8s/alerts/crashloops", k8s_alerts_crashloops),
+            Route("/k8s/alerts/webhook_ready", k8s_alerts_webhook_ready),
+            Route("/k8s/alerts/degraded", k8s_alerts_degraded),
         ]
     )
 
@@ -305,10 +373,11 @@ def main() -> None:
     finelog_sources = {c.name: FinelogSource(c, timeout_ms=config.query_timeout_ms) for c in CLUSTERS}
     iris_sources = {c.name: IrisSource(c, timeout=config.http_timeout) for c in CLUSTERS}
     github_source = GithubSource(token=config.github_token, timeout=config.http_timeout)
+    k8s_fleet = K8sFleet([K8sSource(c, token=config.cw_read_token, timeout=config.http_timeout) for c in K8S_CLUSTERS])
     logger.info("grafana bridge serving %s on :%d", sorted(finelog_sources), BRIDGE_PORT)
     # Loopback only: Grafana fetches from the same container.
     uvicorn.run(
-        create_app(config, finelog_sources, iris_sources, github_source),
+        create_app(config, finelog_sources, iris_sources, github_source, k8s_fleet),
         host="127.0.0.1",
         port=BRIDGE_PORT,
         access_log=False,

--- a/infra/grafana/tests/conftest.py
+++ b/infra/grafana/tests/conftest.py
@@ -1,0 +1,20 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared test helpers."""
+
+from config import BridgeConfig
+
+
+def bridge_config(cache_ttl: float = 20.0) -> BridgeConfig:
+    return BridgeConfig(
+        max_rows=1000,
+        cache_ttl=cache_ttl,
+        query_timeout_ms=5000,
+        iris_cache_ttl=15.0,
+        github_cache_ttl=60.0,
+        k8s_cache_ttl=30.0,
+        http_timeout=5.0,
+        github_token=None,
+        cw_read_token=None,
+    )

--- a/infra/grafana/tests/conftest.py
+++ b/infra/grafana/tests/conftest.py
@@ -1,9 +1,17 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared test helpers."""
+"""Shared test helpers: the bridge config and a canned k8s API server."""
 
-from config import BridgeConfig
+import httpx
+from config import BridgeConfig, K8sClusterTarget
+from k8s_source import K8sSource
+
+KUEUE_DEPLOY = "/apis/apps/v1/namespaces/kueue-system/deployments/kueue-controller-manager"
+IRIS_DEPLOY = "/apis/apps/v1/namespaces/iris/deployments/iris-controller"
+TRAEFIK_DEPLOY = "/apis/apps/v1/namespaces/traefik/deployments/traefik"
+CERT_DEPLOY = "/apis/apps/v1/namespaces/cert-manager/deployments/cert-manager"
+KUEUE_SLICES = "/apis/discovery.k8s.io/v1/namespaces/kueue-system/endpointslices"
 
 
 def bridge_config(cache_ttl: float = 20.0) -> BridgeConfig:
@@ -18,3 +26,79 @@ def bridge_config(cache_ttl: float = 20.0) -> BridgeConfig:
         github_token=None,
         cw_read_token=None,
     )
+
+
+def deployment(namespace: str, name: str, *, ready: int = 1, desired: int = 1) -> dict:
+    return {
+        "metadata": {"namespace": namespace, "name": name},
+        "spec": {"replicas": desired, "selector": {"matchLabels": {"app": name}}},
+        "status": {"readyReplicas": ready},
+    }
+
+
+def pod(
+    namespace: str,
+    name: str,
+    *,
+    waiting: str | None = None,
+    restarts: int = 0,
+    created: str = "2026-07-19T00:00:00Z",
+    gates: list | None = None,
+    conditions: list | None = None,
+) -> dict:
+    state = {"waiting": {"reason": waiting}} if waiting else {"running": {}}
+    return {
+        "metadata": {"namespace": namespace, "name": name, "creationTimestamp": created},
+        "spec": {"schedulingGates": gates or []},
+        "status": {
+            "conditions": conditions or [],
+            "containerStatuses": [{"name": "main", "restartCount": restarts, "state": state}],
+        },
+    }
+
+
+def k8s_api(routes: dict):
+    """A MockTransport handler serving canned bodies by path.
+
+    A list value becomes a one-page LIST response; a callable runs per request;
+    anything else is returned as the JSON body. Unknown paths 404.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = routes.get(request.url.path)
+        if body is None:
+            return httpx.Response(404, json={})
+        if callable(body):
+            return body(request)
+        if isinstance(body, list):
+            return httpx.Response(200, json={"items": body, "metadata": {}})
+        return httpx.Response(200, json=body)
+
+    return handler
+
+
+def make_k8s_source(handler, name: str = "cw-a", token: str | None = "secret") -> K8sSource:
+    source = K8sSource(K8sClusterTarget(name, "https://api.example"), token=token, timeout=5.0)
+    source._client = httpx.Client(
+        transport=httpx.MockTransport(handler), base_url="https://api.example", headers=source._client.headers
+    )
+    return source
+
+
+def healthy_k8s_routes() -> dict:
+    """A cluster where every watched component is up and the webhook has one endpoint."""
+    return {
+        "/version": {"gitVersion": "v1.32.0"},
+        KUEUE_DEPLOY: deployment("kueue-system", "kueue-controller-manager"),
+        IRIS_DEPLOY: deployment("iris", "iris-controller"),
+        TRAEFIK_DEPLOY: deployment("traefik", "traefik"),
+        CERT_DEPLOY: deployment("cert-manager", "cert-manager"),
+        "/api/v1/namespaces/kueue-system/pods": [pod("kueue-system", "kueue-controller-manager-abc")],
+        "/api/v1/namespaces/iris/pods": [pod("iris", "iris-controller-abc")],
+        "/api/v1/namespaces/traefik/pods": [pod("traefik", "traefik-abc")],
+        "/api/v1/namespaces/cert-manager/pods": [pod("cert-manager", "cert-manager-abc")],
+        KUEUE_SLICES: [{"endpoints": [{"conditions": {"ready": True}}]}],
+        "/api/v1/namespaces": [],
+        "/apis/kueue.x-k8s.io/v1beta2/workloads": [],
+        "/api/v1/events": [],
+    }

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -9,7 +9,8 @@ from datetime import UTC, datetime
 
 import pyarrow as pa
 from cache import TtlCache
-from config import BridgeConfig, ClusterTarget
+from config import ClusterTarget
+from conftest import bridge_config
 from finelog.errors import QueryResultTooLargeError
 from github_source import GithubSource
 from k8s_source import K8sFleet
@@ -22,20 +23,6 @@ TO_MS = FROM_MS + 3_600_000
 MARIN = ClusterTarget(
     name="marin", project="p", zone="z", instance_filter="name = finelog-marin", controller_filter="labels.x=true"
 )
-
-
-def bridge_config(cache_ttl: float = 20.0) -> BridgeConfig:
-    return BridgeConfig(
-        max_rows=1000,
-        cache_ttl=cache_ttl,
-        query_timeout_ms=5000,
-        iris_cache_ttl=15.0,
-        github_cache_ttl=60.0,
-        k8s_cache_ttl=30.0,
-        http_timeout=5.0,
-        github_token=None,
-        cw_read_token=None,
-    )
 
 
 def finelog_result(**columns: list) -> pa.Table:

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -12,6 +12,7 @@ from cache import TtlCache
 from config import BridgeConfig, ClusterTarget
 from finelog.errors import QueryResultTooLargeError
 from github_source import GithubSource
+from k8s_source import K8sFleet
 from server import create_app
 from starlette.testclient import TestClient
 
@@ -30,8 +31,10 @@ def bridge_config(cache_ttl: float = 20.0) -> BridgeConfig:
         query_timeout_ms=5000,
         iris_cache_ttl=15.0,
         github_cache_ttl=60.0,
+        k8s_cache_ttl=30.0,
         http_timeout=5.0,
         github_token=None,
+        cw_read_token=None,
     )
 
 
@@ -64,7 +67,7 @@ class FakeSource:
 
 def _client(source: FakeSource, cache_ttl: float = 20.0) -> TestClient:
     github = GithubSource(token=None, timeout=5.0)
-    return TestClient(create_app(bridge_config(cache_ttl), {"marin": source}, {}, github))
+    return TestClient(create_app(bridge_config(cache_ttl), {"marin": source}, {}, github, K8sFleet(())))
 
 
 def _get(client: TestClient, sql: str, **params):

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -1,0 +1,386 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the k8s source: flattening of canned API-server JSON, pagination,
+error classification, and the fleet's always-one-row-per-cluster alert contract."""
+
+import httpx
+import pytest
+from config import BridgeConfig, K8sClusterTarget
+from github_source import GithubSource
+from k8s_source import K8sError, K8sErrorClass, K8sFleet, K8sSource
+from server import create_app
+from starlette.testclient import TestClient
+
+KUEUE_DEPLOY = "/apis/apps/v1/namespaces/kueue-system/deployments/kueue-controller-manager"
+IRIS_DEPLOY = "/apis/apps/v1/namespaces/iris/deployments/iris-controller"
+TRAEFIK_DEPLOY = "/apis/apps/v1/namespaces/traefik/deployments/traefik"
+CERT_DEPLOY = "/apis/apps/v1/namespaces/cert-manager/deployments/cert-manager"
+KUEUE_SLICES = "/apis/discovery.k8s.io/v1/namespaces/kueue-system/endpointslices"
+
+
+def _deployment(namespace: str, name: str, *, ready: int = 1, desired: int = 1) -> dict:
+    return {
+        "metadata": {"namespace": namespace, "name": name},
+        "spec": {"replicas": desired, "selector": {"matchLabels": {"app": name}}},
+        "status": {"readyReplicas": ready},
+    }
+
+
+def _pod(
+    namespace: str,
+    name: str,
+    *,
+    waiting: str | None = None,
+    restarts: int = 0,
+    created: str = "2026-07-19T00:00:00Z",
+    gates: list | None = None,
+    conditions: list | None = None,
+) -> dict:
+    state = {"waiting": {"reason": waiting}} if waiting else {"running": {}}
+    return {
+        "metadata": {"namespace": namespace, "name": name, "creationTimestamp": created},
+        "spec": {"schedulingGates": gates or []},
+        "status": {
+            "conditions": conditions or [],
+            "containerStatuses": [{"name": "main", "restartCount": restarts, "state": state}],
+        },
+    }
+
+
+def _workload(name: str, queue: str, *, conditions: list | None = None, created: str = "2026-07-19T00:00:00Z") -> dict:
+    return {
+        "metadata": {"namespace": "iris", "name": name, "creationTimestamp": created},
+        "spec": {"queueName": queue},
+        "status": {"conditions": conditions or []},
+    }
+
+
+def _namespace(name: str) -> dict:
+    return {"metadata": {"name": name}}
+
+
+def _api(routes: dict):
+    """A MockTransport handler serving canned bodies by path.
+
+    A list value becomes a one-page LIST response; a callable runs per request;
+    anything else is returned as the JSON body. Unknown paths 404. Requests are
+    recorded on ``handler.calls``.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        handler.calls.append(request)
+        body = routes.get(request.url.path)
+        if body is None:
+            return httpx.Response(404, json={})
+        if callable(body):
+            return body(request)
+        if isinstance(body, list):
+            return httpx.Response(200, json={"items": body, "metadata": {}})
+        return httpx.Response(200, json=body)
+
+    handler.calls = []
+    return handler
+
+
+def _source(handler, name: str = "cw-a", token: str | None = "secret") -> K8sSource:
+    source = K8sSource(K8sClusterTarget(name, "https://api.example"), token=token, timeout=5.0)
+    source._client = httpx.Client(
+        transport=httpx.MockTransport(handler), base_url="https://api.example", headers=source._client.headers
+    )
+    return source
+
+
+def _healthy_routes() -> dict:
+    """A cluster where every watched component is up and the webhook has one endpoint."""
+    return {
+        "/version": {"gitVersion": "v1.32.0"},
+        KUEUE_DEPLOY: _deployment("kueue-system", "kueue-controller-manager"),
+        IRIS_DEPLOY: _deployment("iris", "iris-controller"),
+        TRAEFIK_DEPLOY: _deployment("traefik", "traefik"),
+        CERT_DEPLOY: _deployment("cert-manager", "cert-manager"),
+        "/api/v1/namespaces/kueue-system/pods": [_pod("kueue-system", "kueue-controller-manager-abc")],
+        "/api/v1/namespaces/iris/pods": [_pod("iris", "iris-controller-abc")],
+        "/api/v1/namespaces/traefik/pods": [_pod("traefik", "traefik-abc")],
+        "/api/v1/namespaces/cert-manager/pods": [_pod("cert-manager", "cert-manager-abc")],
+        KUEUE_SLICES: [{"endpoints": [{"conditions": {"ready": True}}]}],
+        "/api/v1/namespaces": [],
+        "/apis/kueue.x-k8s.io/v1beta2/workloads": [],
+        "/api/v1/events": [],
+    }
+
+
+# --- K8sSource --------------------------------------------------------------
+
+
+def test_control_plane_flattens_components_and_webhooks():
+    routes = _healthy_routes()
+    routes[KUEUE_DEPLOY] = _deployment("kueue-system", "kueue-controller-manager", ready=0)
+    routes["/api/v1/namespaces/kueue-system/pods"] = [
+        _pod("kueue-system", "kueue-controller-manager-abc", waiting="CrashLoopBackOff", restarts=7)
+    ]
+    routes[KUEUE_SLICES] = [
+        # nil ready counts as ready per the EndpointSlice contract; False does not.
+        {"endpoints": [{"conditions": {"ready": True}}, {"conditions": {}}]},
+        {"endpoints": [{"conditions": {"ready": False}}]},
+    ]
+    rows = _source(_api(routes)).control_plane()
+
+    kueue = rows[0]
+    assert kueue == {
+        "kind": "component",
+        "component": "kueue-system/kueue-controller-manager",
+        "ready": 0,
+        "desired": 1,
+        "restarts": 7,
+        "waiting_reason": "CrashLoopBackOff",
+    }
+    assert rows[-1] == {"kind": "webhook", "component": "kueue-system/kueue-webhook-service", "ready_endpoints": 2}
+
+
+def test_missing_deployment_reads_as_degraded_not_healthy():
+    routes = _healthy_routes()
+    del routes[IRIS_DEPLOY]
+    rows = _source(_api(routes)).control_plane()
+    iris = next(row for row in rows if row["component"] == "iris/iris-controller")
+    assert iris["ready"] == 0 and iris["desired"] == 1 and iris["waiting_reason"] == "Missing"
+
+
+def test_list_follows_continue_pagination():
+    pages = [
+        {"items": [_pod("iris", "task-1", waiting="CrashLoopBackOff")], "metadata": {"continue": "tok"}},
+        {"items": [_pod("iris", "task-2", waiting="ImagePullBackOff")], "metadata": {}},
+    ]
+    seen_continues = []
+
+    def pods(request: httpx.Request) -> httpx.Response:
+        seen_continues.append(request.url.params.get("continue"))
+        return httpx.Response(200, json=pages[len(seen_continues) - 1])
+
+    routes = {"/api/v1/namespaces": [_namespace("iris")], "/api/v1/namespaces/iris/pods": pods}
+    rows = _source(_api(routes)).crashloops()
+    assert [row["pod"] for row in rows] == ["task-1", "task-2"]
+    assert seen_continues == [None, "tok"]
+
+
+def test_429_is_retried_once_after_retry_after():
+    responses = [httpx.Response(429, headers={"retry-after": "0"}), httpx.Response(200, json={"gitVersion": "v1"})]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return responses.pop(0)
+
+    source = _source(handler)
+    assert isinstance(source.probe(), int)
+    assert not responses
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected_class"),
+    [
+        (lambda request: httpx.Response(401, json={}), K8sErrorClass.AUTH),
+        (lambda request: httpx.Response(403, json={}), K8sErrorClass.AUTH),
+        (lambda request: httpx.Response(500, json={}), K8sErrorClass.HTTP),
+        (lambda request: (_ for _ in ()).throw(httpx.ConnectError("refused", request=request)), K8sErrorClass.NETWORK),
+        (lambda request: (_ for _ in ()).throw(httpx.ReadTimeout("slow", request=request)), K8sErrorClass.TIMEOUT),
+    ],
+)
+def test_failures_are_classified(failure, expected_class):
+    with pytest.raises(K8sError) as excinfo:
+        _source(failure).probe()
+    assert excinfo.value.error_class == expected_class
+
+
+def test_missing_token_is_an_auth_error_without_a_network_call():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("no request should be sent without a token")
+
+    with pytest.raises(K8sError) as excinfo:
+        _source(handler, token=None).probe()
+    assert excinfo.value.error_class == K8sErrorClass.AUTH
+
+
+def test_crashloop_scope_separates_watched_components_from_workloads():
+    routes = {
+        "/api/v1/namespaces": [_namespace("iris")],
+        "/api/v1/namespaces/iris/pods": [
+            _pod("iris", "iris-controller-7f9-x2", waiting="CrashLoopBackOff", restarts=3),
+            _pod("iris", "some-user-task-0", waiting="ImagePullBackOff"),
+            _pod("iris", "healthy-task-0"),
+        ],
+    }
+    rows = _source(_api(routes)).crashloops()
+    assert [(row["pod"], row["scope"], row["reason"]) for row in rows] == [
+        ("iris-controller-7f9-x2", "control-plane", "CrashLoopBackOff"),
+        ("some-user-task-0", "workload", "ImagePullBackOff"),
+    ]
+
+
+def test_provider_namespaces_are_excluded_from_pod_scans():
+    # Only the iris pods route exists: a scan reaching cw-* or kube-* would 404
+    # and raise, so a passing scan proves the exclusion.
+    routes = {
+        "/api/v1/namespaces": [_namespace("cw-exporters"), _namespace("kube-system"), _namespace("iris")],
+        "/api/v1/namespaces/iris/pods": [_pod("iris", "task-0", waiting="CrashLoopBackOff")],
+    }
+    assert [row["pod"] for row in _source(_api(routes)).crashloops()] == ["task-0"]
+
+
+def test_pending_splits_gated_from_pending_and_sorts_oldest_first():
+    unschedulable = [{"type": "PodScheduled", "status": "False", "reason": "Unschedulable"}]
+    gated = [{"type": "PodScheduled", "status": "False", "reason": "SchedulingGated"}]
+    routes = {
+        "/api/v1/namespaces": [_namespace("iris")],
+        "/api/v1/namespaces/iris/pods": [
+            _pod("iris", "young-gated", created="2026-07-19T12:00:00Z", conditions=gated),
+            _pod("iris", "old-stuck", created="2026-07-01T00:00:00Z", conditions=unschedulable),
+        ],
+    }
+    rows = _source(_api(routes)).pending()
+    assert [(row["pod"], row["state"]) for row in rows] == [
+        ("old-stuck", "pending"),
+        ("young-gated", "scheduling_gated"),
+    ]
+    assert rows[0]["reason"] == "Unschedulable"
+    assert rows[0]["age_seconds"] > rows[1]["age_seconds"]
+
+
+def test_kueue_counts_unadmitted_per_queue_skipping_admitted_and_finished():
+    admitted = [{"type": "Admitted", "status": "True"}]
+    finished = [{"type": "Finished", "status": "True"}]
+    routes = {
+        "/apis/kueue.x-k8s.io/v1beta2/workloads": [
+            _workload("running", "q1", conditions=admitted),
+            _workload("done", "q1", conditions=finished),
+            _workload("waiting-old", "q1", created="2026-07-01T00:00:00Z"),
+            _workload("waiting-new", "q1", created="2026-07-19T00:00:00Z"),
+            _workload("waiting-other", "q2"),
+        ]
+    }
+    rows = _source(_api(routes)).kueue()
+    assert [(row["queue"], row["unadmitted"]) for row in rows] == [("q1", 2), ("q2", 1)]
+    assert rows[0]["oldest_age_seconds"] > rows[1]["oldest_age_seconds"]
+
+
+def test_warning_events_flatten_newest_first():
+    routes = {
+        "/api/v1/events": [
+            {
+                "involvedObject": {"kind": "Pod", "name": "task-0", "namespace": "iris"},
+                "reason": "FailedScheduling",
+                "message": "0/5 nodes are available",
+                "count": 4,
+                "lastTimestamp": "2026-07-19T10:00:00Z",
+            },
+            {
+                "involvedObject": {
+                    "kind": "Deployment",
+                    "name": "kueue-controller-manager",
+                    "namespace": "kueue-system",
+                },
+                "reason": "BackOff",
+                "message": "x" * 500,
+                "lastTimestamp": "2026-07-19T11:00:00Z",
+            },
+        ]
+    }
+    rows = _source(_api(routes)).warning_events()
+    assert [row["object"] for row in rows] == ["Deployment/kueue-controller-manager", "Pod/task-0"]
+    assert rows[1]["count"] == 4
+    assert len(rows[0]["message"]) == 200
+
+
+# --- K8sFleet ---------------------------------------------------------------
+
+
+def _fleet(*handlers_by_name: tuple[str, object]) -> K8sFleet:
+    return K8sFleet([_source(handler, name=name) for name, handler in handlers_by_name])
+
+
+def _forbidden(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(403, json={})
+
+
+def test_fleet_stamps_cluster_and_keeps_healthy_clusters_on_partial_failure():
+    fleet = _fleet(("cw-a", _api(_healthy_routes())), ("cw-b", _forbidden))
+    rows = fleet.control_plane()
+    healthy = [row for row in rows if row["cluster"] == "cw-a"]
+    assert len(healthy) == 5  # 4 components + 1 webhook
+    (error_row,) = [row for row in rows if row["cluster"] == "cw-b"]
+    assert error_row["error_class"] == "auth"
+    assert "403" in error_row["error"]
+
+
+def test_alert_routes_return_explicit_zeros_when_healthy():
+    fleet = _fleet(("cw-a", _api(_healthy_routes())))
+    assert fleet.alert_unreachable() == [{"cluster": "cw-a", "error_class": "none", "value": 0}]
+    assert fleet.alert_crashloops() == [
+        {"cluster": "cw-a", "scope": "control-plane", "value": 0},
+        {"cluster": "cw-a", "scope": "workload", "value": 0},
+    ]
+    assert fleet.alert_webhook_ready() == [
+        {"cluster": "cw-a", "webhook": "kueue-system/kueue-webhook-service", "value": 1}
+    ]
+    assert fleet.alert_degraded() == [
+        {"cluster": "cw-a", "component": "kueue-system/kueue-controller-manager", "value": 0},
+        {"cluster": "cw-a", "component": "iris/iris-controller", "value": 0},
+        {"cluster": "cw-a", "component": "traefik/traefik", "value": 0},
+        {"cluster": "cw-a", "component": "cert-manager/cert-manager", "value": 0},
+    ]
+
+
+def test_alert_routes_keep_one_row_per_cluster_when_unreachable():
+    # Zeros everywhere except unreachable: no fabricated health evidence, and only
+    # webhook_ready (where zero means empty) also fires alongside unreachable.
+    fleet = _fleet(("cw-a", _forbidden))
+    assert fleet.alert_unreachable() == [{"cluster": "cw-a", "error_class": "auth", "value": 1}]
+    assert {row["value"] for row in fleet.alert_crashloops()} == {0}
+    assert fleet.alert_webhook_ready() == [
+        {"cluster": "cw-a", "webhook": "kueue-system/kueue-webhook-service", "value": 0}
+    ]
+    assert {row["value"] for row in fleet.alert_degraded()} == {0}
+
+
+def test_crashloop_alert_counts_by_scope():
+    routes = _healthy_routes()
+    routes["/api/v1/namespaces"] = [_namespace("iris")]
+    routes["/api/v1/namespaces/iris/pods"] = [
+        _pod("iris", "iris-controller-7f9-x2", waiting="CrashLoopBackOff"),
+        _pod("iris", "task-a-0", waiting="CrashLoopBackOff"),
+        _pod("iris", "task-b-0", waiting="ImagePullBackOff"),
+    ]
+    assert _fleet(("cw-a", _api(routes))).alert_crashloops() == [
+        {"cluster": "cw-a", "scope": "control-plane", "value": 1},
+        {"cluster": "cw-a", "scope": "workload", "value": 2},
+    ]
+
+
+# --- endpoints --------------------------------------------------------------
+
+
+def _client(fleet: K8sFleet) -> TestClient:
+    config = BridgeConfig(
+        max_rows=1000,
+        cache_ttl=20,
+        query_timeout_ms=5000,
+        iris_cache_ttl=15,
+        github_cache_ttl=60,
+        k8s_cache_ttl=30,
+        http_timeout=5,
+        github_token=None,
+        cw_read_token=None,
+    )
+    return TestClient(create_app(config, {}, {}, GithubSource(token=None, timeout=5.0), fleet))
+
+
+def test_k8s_routes_serve_fleet_rows():
+    client = _client(_fleet(("cw-a", _api(_healthy_routes()))))
+    for path in ("/k8s/control_plane", "/k8s/crashloops", "/k8s/pending", "/k8s/kueue", "/k8s/events"):
+        assert client.get(path).status_code == 200
+    health = client.get("/k8s/health").json()
+    assert health[0]["cluster"] == "cw-a" and health[0]["reachable"] is True
+
+
+def test_alerts_crashloops_scope_param_filters_rows():
+    client = _client(_fleet(("cw-a", _api(_healthy_routes()))))
+    rows = client.get("/k8s/alerts/crashloops", params={"scope": "control-plane"}).json()
+    assert rows == [{"cluster": "cw-a", "scope": "control-plane", "value": 0}]

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -6,47 +6,21 @@ error classification, and the fleet's always-one-row-per-cluster alert contract.
 
 import httpx
 import pytest
-from config import K8sClusterTarget
-from conftest import bridge_config
+from conftest import (
+    IRIS_DEPLOY,
+    KUEUE_DEPLOY,
+    KUEUE_SLICES,
+    bridge_config,
+    deployment,
+    healthy_k8s_routes,
+    k8s_api,
+    make_k8s_source,
+    pod,
+)
 from github_source import GithubSource
-from k8s_source import K8sError, K8sErrorClass, K8sFleet, K8sSource
+from k8s_source import K8sError, K8sErrorClass, K8sFleet
 from server import create_app
 from starlette.testclient import TestClient
-
-KUEUE_DEPLOY = "/apis/apps/v1/namespaces/kueue-system/deployments/kueue-controller-manager"
-IRIS_DEPLOY = "/apis/apps/v1/namespaces/iris/deployments/iris-controller"
-TRAEFIK_DEPLOY = "/apis/apps/v1/namespaces/traefik/deployments/traefik"
-CERT_DEPLOY = "/apis/apps/v1/namespaces/cert-manager/deployments/cert-manager"
-KUEUE_SLICES = "/apis/discovery.k8s.io/v1/namespaces/kueue-system/endpointslices"
-
-
-def _deployment(namespace: str, name: str, *, ready: int = 1, desired: int = 1) -> dict:
-    return {
-        "metadata": {"namespace": namespace, "name": name},
-        "spec": {"replicas": desired, "selector": {"matchLabels": {"app": name}}},
-        "status": {"readyReplicas": ready},
-    }
-
-
-def _pod(
-    namespace: str,
-    name: str,
-    *,
-    waiting: str | None = None,
-    restarts: int = 0,
-    created: str = "2026-07-19T00:00:00Z",
-    gates: list | None = None,
-    conditions: list | None = None,
-) -> dict:
-    state = {"waiting": {"reason": waiting}} if waiting else {"running": {}}
-    return {
-        "metadata": {"namespace": namespace, "name": name, "creationTimestamp": created},
-        "spec": {"schedulingGates": gates or []},
-        "status": {
-            "conditions": conditions or [],
-            "containerStatuses": [{"name": "main", "restartCount": restarts, "state": state}],
-        },
-    }
 
 
 def _workload(name: str, queue: str, *, conditions: list | None = None, created: str = "2026-07-19T00:00:00Z") -> dict:
@@ -61,68 +35,21 @@ def _namespace(name: str) -> dict:
     return {"metadata": {"name": name}}
 
 
-def _api(routes: dict):
-    """A MockTransport handler serving canned bodies by path.
-
-    A list value becomes a one-page LIST response; a callable runs per request;
-    anything else is returned as the JSON body. Unknown paths 404.
-    """
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        body = routes.get(request.url.path)
-        if body is None:
-            return httpx.Response(404, json={})
-        if callable(body):
-            return body(request)
-        if isinstance(body, list):
-            return httpx.Response(200, json={"items": body, "metadata": {}})
-        return httpx.Response(200, json=body)
-
-    return handler
-
-
-def _source(handler, name: str = "cw-a", token: str | None = "secret") -> K8sSource:
-    source = K8sSource(K8sClusterTarget(name, "https://api.example"), token=token, timeout=5.0)
-    source._client = httpx.Client(
-        transport=httpx.MockTransport(handler), base_url="https://api.example", headers=source._client.headers
-    )
-    return source
-
-
-def _healthy_routes() -> dict:
-    """A cluster where every watched component is up and the webhook has one endpoint."""
-    return {
-        "/version": {"gitVersion": "v1.32.0"},
-        KUEUE_DEPLOY: _deployment("kueue-system", "kueue-controller-manager"),
-        IRIS_DEPLOY: _deployment("iris", "iris-controller"),
-        TRAEFIK_DEPLOY: _deployment("traefik", "traefik"),
-        CERT_DEPLOY: _deployment("cert-manager", "cert-manager"),
-        "/api/v1/namespaces/kueue-system/pods": [_pod("kueue-system", "kueue-controller-manager-abc")],
-        "/api/v1/namespaces/iris/pods": [_pod("iris", "iris-controller-abc")],
-        "/api/v1/namespaces/traefik/pods": [_pod("traefik", "traefik-abc")],
-        "/api/v1/namespaces/cert-manager/pods": [_pod("cert-manager", "cert-manager-abc")],
-        KUEUE_SLICES: [{"endpoints": [{"conditions": {"ready": True}}]}],
-        "/api/v1/namespaces": [],
-        "/apis/kueue.x-k8s.io/v1beta2/workloads": [],
-        "/api/v1/events": [],
-    }
-
-
 # --- K8sSource --------------------------------------------------------------
 
 
 def test_control_plane_flattens_components_and_webhooks():
-    routes = _healthy_routes()
-    routes[KUEUE_DEPLOY] = _deployment("kueue-system", "kueue-controller-manager", ready=0)
+    routes = healthy_k8s_routes()
+    routes[KUEUE_DEPLOY] = deployment("kueue-system", "kueue-controller-manager", ready=0)
     routes["/api/v1/namespaces/kueue-system/pods"] = [
-        _pod("kueue-system", "kueue-controller-manager-abc", waiting="CrashLoopBackOff", restarts=7)
+        pod("kueue-system", "kueue-controller-manager-abc", waiting="CrashLoopBackOff", restarts=7)
     ]
     routes[KUEUE_SLICES] = [
         # nil ready counts as ready per the EndpointSlice contract; False does not.
         {"endpoints": [{"conditions": {"ready": True}}, {"conditions": {}}]},
         {"endpoints": [{"conditions": {"ready": False}}]},
     ]
-    rows = _source(_api(routes)).control_plane()
+    rows = make_k8s_source(k8s_api(routes)).control_plane()
 
     kueue = rows[0]
     assert kueue == {
@@ -137,17 +64,17 @@ def test_control_plane_flattens_components_and_webhooks():
 
 
 def test_missing_deployment_reads_as_degraded_not_healthy():
-    routes = _healthy_routes()
+    routes = healthy_k8s_routes()
     del routes[IRIS_DEPLOY]
-    rows = _source(_api(routes)).control_plane()
+    rows = make_k8s_source(k8s_api(routes)).control_plane()
     iris = next(row for row in rows if row["component"] == "iris/iris-controller")
     assert iris["ready"] == 0 and iris["desired"] == 1 and iris["waiting_reason"] == "Missing"
 
 
 def test_list_follows_continue_pagination():
     pages = [
-        {"items": [_pod("iris", "task-1", waiting="CrashLoopBackOff")], "metadata": {"continue": "tok"}},
-        {"items": [_pod("iris", "task-2", waiting="ImagePullBackOff")], "metadata": {}},
+        {"items": [pod("iris", "task-1", waiting="CrashLoopBackOff")], "metadata": {"continue": "tok"}},
+        {"items": [pod("iris", "task-2", waiting="ImagePullBackOff")], "metadata": {}},
     ]
     seen_continues = []
 
@@ -156,7 +83,7 @@ def test_list_follows_continue_pagination():
         return httpx.Response(200, json=pages[len(seen_continues) - 1])
 
     routes = {"/api/v1/namespaces": [_namespace("iris")], "/api/v1/namespaces/iris/pods": pods}
-    rows = _source(_api(routes)).crashloops()
+    rows = make_k8s_source(k8s_api(routes)).crashloops()
     assert [row["pod"] for row in rows] == ["task-1", "task-2"]
     assert seen_continues == [None, "tok"]
 
@@ -167,7 +94,7 @@ def test_429_is_retried_once_after_retry_after():
     def handler(request: httpx.Request) -> httpx.Response:
         return responses.pop(0)
 
-    source = _source(handler)
+    source = make_k8s_source(handler)
     assert isinstance(source.probe(), int)
     assert not responses
 
@@ -184,7 +111,7 @@ def test_429_is_retried_once_after_retry_after():
 )
 def test_failures_are_classified(failure, expected_class):
     with pytest.raises(K8sError) as excinfo:
-        _source(failure).probe()
+        make_k8s_source(failure).probe()
     assert excinfo.value.error_class == expected_class
 
 
@@ -193,7 +120,7 @@ def test_missing_token_is_an_auth_error_without_a_network_call():
         raise AssertionError("no request should be sent without a token")
 
     with pytest.raises(K8sError) as excinfo:
-        _source(handler, token=None).probe()
+        make_k8s_source(handler, token=None).probe()
     assert excinfo.value.error_class == K8sErrorClass.AUTH
 
 
@@ -201,12 +128,12 @@ def test_crashloop_scope_separates_watched_components_from_workloads():
     routes = {
         "/api/v1/namespaces": [_namespace("iris")],
         "/api/v1/namespaces/iris/pods": [
-            _pod("iris", "iris-controller-7f9-x2", waiting="CrashLoopBackOff", restarts=3),
-            _pod("iris", "some-user-task-0", waiting="ImagePullBackOff"),
-            _pod("iris", "healthy-task-0"),
+            pod("iris", "iris-controller-7f9-x2", waiting="CrashLoopBackOff", restarts=3),
+            pod("iris", "some-user-task-0", waiting="ImagePullBackOff"),
+            pod("iris", "healthy-task-0"),
         ],
     }
-    rows = _source(_api(routes)).crashloops()
+    rows = make_k8s_source(k8s_api(routes)).crashloops()
     assert [(row["pod"], row["scope"], row["reason"]) for row in rows] == [
         ("iris-controller-7f9-x2", "control-plane", "CrashLoopBackOff"),
         ("some-user-task-0", "workload", "ImagePullBackOff"),
@@ -218,9 +145,9 @@ def test_provider_namespaces_are_excluded_from_pod_scans():
     # and raise, so a passing scan proves the exclusion.
     routes = {
         "/api/v1/namespaces": [_namespace("cw-exporters"), _namespace("kube-system"), _namespace("iris")],
-        "/api/v1/namespaces/iris/pods": [_pod("iris", "task-0", waiting="CrashLoopBackOff")],
+        "/api/v1/namespaces/iris/pods": [pod("iris", "task-0", waiting="CrashLoopBackOff")],
     }
-    assert [row["pod"] for row in _source(_api(routes)).crashloops()] == ["task-0"]
+    assert [row["pod"] for row in make_k8s_source(k8s_api(routes)).crashloops()] == ["task-0"]
 
 
 def test_pending_splits_gated_from_pending_and_sorts_oldest_first():
@@ -229,11 +156,11 @@ def test_pending_splits_gated_from_pending_and_sorts_oldest_first():
     routes = {
         "/api/v1/namespaces": [_namespace("iris")],
         "/api/v1/namespaces/iris/pods": [
-            _pod("iris", "young-gated", created="2026-07-19T12:00:00Z", conditions=gated),
-            _pod("iris", "old-stuck", created="2026-07-01T00:00:00Z", conditions=unschedulable),
+            pod("iris", "young-gated", created="2026-07-19T12:00:00Z", conditions=gated),
+            pod("iris", "old-stuck", created="2026-07-01T00:00:00Z", conditions=unschedulable),
         ],
     }
-    rows = _source(_api(routes)).pending()
+    rows = make_k8s_source(k8s_api(routes)).pending()
     assert [(row["pod"], row["state"]) for row in rows] == [
         ("old-stuck", "pending"),
         ("young-gated", "scheduling_gated"),
@@ -254,7 +181,7 @@ def test_kueue_counts_unadmitted_per_queue_skipping_admitted_and_finished():
             _workload("waiting-other", "q2"),
         ]
     }
-    rows = _source(_api(routes)).kueue()
+    rows = make_k8s_source(k8s_api(routes)).kueue()
     assert [(row["queue"], row["unadmitted"]) for row in rows] == [("q1", 2), ("q2", 1)]
     assert rows[0]["oldest_age_seconds"] > rows[1]["oldest_age_seconds"]
 
@@ -281,7 +208,7 @@ def test_warning_events_flatten_newest_first():
             },
         ]
     }
-    rows = _source(_api(routes)).warning_events()
+    rows = make_k8s_source(k8s_api(routes)).warning_events()
     assert [row["object"] for row in rows] == ["Deployment/kueue-controller-manager", "Pod/task-0"]
     assert rows[1]["count"] == 4
     assert len(rows[0]["message"]) == 200
@@ -291,7 +218,7 @@ def test_warning_events_flatten_newest_first():
 
 
 def _fleet(*handlers_by_name: tuple[str, object]) -> K8sFleet:
-    return K8sFleet([_source(handler, name=name) for name, handler in handlers_by_name])
+    return K8sFleet([make_k8s_source(handler, name=name) for name, handler in handlers_by_name])
 
 
 def _forbidden(request: httpx.Request) -> httpx.Response:
@@ -299,7 +226,7 @@ def _forbidden(request: httpx.Request) -> httpx.Response:
 
 
 def test_fleet_stamps_cluster_and_keeps_healthy_clusters_on_partial_failure():
-    fleet = _fleet(("cw-a", _api(_healthy_routes())), ("cw-b", _forbidden))
+    fleet = _fleet(("cw-a", k8s_api(healthy_k8s_routes())), ("cw-b", _forbidden))
     rows = fleet.control_plane()
     healthy = [row for row in rows if row["cluster"] == "cw-a"]
     assert len(healthy) == 5  # 4 components + 1 webhook
@@ -309,7 +236,7 @@ def test_fleet_stamps_cluster_and_keeps_healthy_clusters_on_partial_failure():
 
 
 def test_alert_routes_return_explicit_zeros_when_healthy():
-    fleet = _fleet(("cw-a", _api(_healthy_routes())))
+    fleet = _fleet(("cw-a", k8s_api(healthy_k8s_routes())))
     assert fleet.alert_unreachable() == [{"cluster": "cw-a", "error_class": "none", "value": 0}]
     assert fleet.alert_crashloops() == [
         {"cluster": "cw-a", "scope": "control-plane", "value": 0},
@@ -339,14 +266,14 @@ def test_alert_routes_keep_one_row_per_cluster_when_unreachable():
 
 
 def test_crashloop_alert_counts_by_scope():
-    routes = _healthy_routes()
+    routes = healthy_k8s_routes()
     routes["/api/v1/namespaces"] = [_namespace("iris")]
     routes["/api/v1/namespaces/iris/pods"] = [
-        _pod("iris", "iris-controller-7f9-x2", waiting="CrashLoopBackOff"),
-        _pod("iris", "task-a-0", waiting="CrashLoopBackOff"),
-        _pod("iris", "task-b-0", waiting="ImagePullBackOff"),
+        pod("iris", "iris-controller-7f9-x2", waiting="CrashLoopBackOff"),
+        pod("iris", "task-a-0", waiting="CrashLoopBackOff"),
+        pod("iris", "task-b-0", waiting="ImagePullBackOff"),
     ]
-    assert _fleet(("cw-a", _api(routes))).alert_crashloops() == [
+    assert _fleet(("cw-a", k8s_api(routes))).alert_crashloops() == [
         {"cluster": "cw-a", "scope": "control-plane", "value": 1},
         {"cluster": "cw-a", "scope": "workload", "value": 2},
     ]
@@ -360,7 +287,7 @@ def _client(fleet: K8sFleet) -> TestClient:
 
 
 def test_k8s_routes_serve_fleet_rows():
-    client = _client(_fleet(("cw-a", _api(_healthy_routes()))))
+    client = _client(_fleet(("cw-a", k8s_api(healthy_k8s_routes()))))
     for path in ("/k8s/control_plane", "/k8s/crashloops", "/k8s/pending", "/k8s/kueue", "/k8s/events"):
         assert client.get(path).status_code == 200
     health = client.get("/k8s/health").json()
@@ -368,6 +295,6 @@ def test_k8s_routes_serve_fleet_rows():
 
 
 def test_alerts_crashloops_scope_param_filters_rows():
-    client = _client(_fleet(("cw-a", _api(_healthy_routes()))))
+    client = _client(_fleet(("cw-a", k8s_api(healthy_k8s_routes()))))
     rows = client.get("/k8s/alerts/crashloops", params={"scope": "control-plane"}).json()
     assert rows == [{"cluster": "cw-a", "scope": "control-plane", "value": 0}]

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -6,7 +6,8 @@ error classification, and the fleet's always-one-row-per-cluster alert contract.
 
 import httpx
 import pytest
-from config import BridgeConfig, K8sClusterTarget
+from config import K8sClusterTarget
+from conftest import bridge_config
 from github_source import GithubSource
 from k8s_source import K8sError, K8sErrorClass, K8sFleet, K8sSource
 from server import create_app
@@ -64,12 +65,10 @@ def _api(routes: dict):
     """A MockTransport handler serving canned bodies by path.
 
     A list value becomes a one-page LIST response; a callable runs per request;
-    anything else is returned as the JSON body. Unknown paths 404. Requests are
-    recorded on ``handler.calls``.
+    anything else is returned as the JSON body. Unknown paths 404.
     """
 
     def handler(request: httpx.Request) -> httpx.Response:
-        handler.calls.append(request)
         body = routes.get(request.url.path)
         if body is None:
             return httpx.Response(404, json={})
@@ -79,7 +78,6 @@ def _api(routes: dict):
             return httpx.Response(200, json={"items": body, "metadata": {}})
         return httpx.Response(200, json=body)
 
-    handler.calls = []
     return handler
 
 
@@ -358,18 +356,7 @@ def test_crashloop_alert_counts_by_scope():
 
 
 def _client(fleet: K8sFleet) -> TestClient:
-    config = BridgeConfig(
-        max_rows=1000,
-        cache_ttl=20,
-        query_timeout_ms=5000,
-        iris_cache_ttl=15,
-        github_cache_ttl=60,
-        k8s_cache_ttl=30,
-        http_timeout=5,
-        github_token=None,
-        cw_read_token=None,
-    )
-    return TestClient(create_app(config, {}, {}, GithubSource(token=None, timeout=5.0), fleet))
+    return TestClient(create_app(bridge_config(), {}, {}, GithubSource(token=None, timeout=5.0), fleet))
 
 
 def test_k8s_routes_serve_fleet_rows():

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -11,12 +11,11 @@ import re
 from pathlib import Path
 from urllib.parse import urlsplit
 
-import httpx
 import yaml
-from config import ClusterTarget, K8sClusterTarget
-from conftest import bridge_config
+from config import ClusterTarget
+from conftest import bridge_config, healthy_k8s_routes, k8s_api, make_k8s_source
 from github_source import GithubSource
-from k8s_source import K8sFleet, K8sSource
+from k8s_source import K8sFleet
 from server import create_app
 from starlette.testclient import TestClient
 
@@ -65,21 +64,6 @@ def test_every_rule_alerts_on_nodata_and_error():
         assert rule["labels"]["severity"] in VALID_SEVERITIES, rule["uid"]
 
 
-def _healthy_k8s_source() -> K8sSource:
-    def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path.endswith("/pods") or "workloads" in request.url.path or "endpointslices" in request.url.path:
-            return httpx.Response(200, json={"items": [], "metadata": {}})
-        if "/deployments/" in request.url.path:
-            return httpx.Response(
-                200, json={"spec": {"replicas": 1, "selector": {"matchLabels": {}}}, "status": {"readyReplicas": 1}}
-            )
-        return httpx.Response(200, json={})
-
-    source = K8sSource(K8sClusterTarget("cw-a", "https://api.example"), token="t", timeout=5.0)
-    source._client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.example")
-    return source
-
-
 class _FakeIris:
     def __init__(self, name: str) -> None:
         self.target = ClusterTarget(name=name, project="p", zone="z", instance_filter="f", controller_filter="c")
@@ -91,7 +75,7 @@ class _FakeIris:
 def test_every_rule_query_url_answers_on_the_bridge():
     """Join each rule's datasource base path with its query URL and GET it for real."""
     iris_sources = {name: _FakeIris(name) for name in ("marin", "marin-dev")}
-    fleet = K8sFleet([_healthy_k8s_source()])
+    fleet = K8sFleet([make_k8s_source(k8s_api(healthy_k8s_routes()))])
     client = TestClient(create_app(bridge_config(), {}, iris_sources, GithubSource(token=None, timeout=5.0), fleet))
 
     base_paths = _datasources()

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -7,6 +7,7 @@ dashboard datasources exist. These files only otherwise fail inside a deployed
 Grafana, which is the most expensive place to find out."""
 
 import json
+import re
 from pathlib import Path
 from urllib.parse import urlsplit
 
@@ -133,6 +134,24 @@ def test_critical_contact_point_reaches_email_and_slack():
         for receiver in point["receivers"]:
             if receiver["type"] == "slack":
                 assert receiver["settings"]["url"] == "$SLACK_ALERTS_WEBHOOK"
+
+
+def test_dashboard_filter_expressions_reference_selected_columns():
+    # Infinity's backend parser applies filterExpression to the frame built from
+    # `columns`, so every field a filter references must also be selected.
+    literals = {"true", "false", "null"}
+    for path in (ROOT / "dashboards").glob("*.json"):
+        dashboard = json.loads(path.read_text())
+        for panel in dashboard["panels"]:
+            for target in panel.get("targets", []):
+                expression = target.get("filterExpression")
+                if not expression:
+                    continue
+                columns = target.get("columns", [])
+                selected = {c["text"] for c in columns} | {c["selector"] for c in columns}
+                fields = set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", re.sub(r"'[^']*'", "", expression))) - literals
+                missing = fields - selected
+                assert not missing, f"{path.name} panel {panel.get('id')}: filter references unselected {missing}"
 
 
 def test_dashboard_datasource_uids_are_provisioned():

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -1,0 +1,156 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests over the provisioning tree: the alerting YAML parses with resolvable
+datasource UIDs and refIds, every rule's query URL answers on the bridge, and
+dashboard datasources exist. These files only otherwise fail inside a deployed
+Grafana, which is the most expensive place to find out."""
+
+import json
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import httpx
+import yaml
+from config import BridgeConfig, ClusterTarget, K8sClusterTarget
+from github_source import GithubSource
+from k8s_source import K8sFleet, K8sSource
+from server import create_app
+from starlette.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parent.parent
+ALERTING = ROOT / "provisioning" / "alerting"
+
+EXPRESSION_UID = "__expr__"
+VALID_SEVERITIES = {"critical", "warning"}
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text())
+
+
+def _datasources() -> dict[str, str]:
+    """Provisioned datasource uid -> bridge base path (from its loopback URL)."""
+    uids = {}
+    for path in (ROOT / "provisioning" / "datasources").glob("*.yaml"):
+        for datasource in _load(path)["datasources"]:
+            uids[datasource["uid"]] = urlsplit(datasource["url"]).path
+    return uids
+
+
+def _rules() -> list[dict]:
+    return [rule for group in _load(ALERTING / "rules.yaml")["groups"] for rule in group["rules"]]
+
+
+def test_alert_rules_have_resolvable_datasources_and_refids():
+    datasource_uids = set(_datasources())
+    for rule in _rules():
+        ref_ids = [node["refId"] for node in rule["data"]]
+        assert len(ref_ids) == len(set(ref_ids)), f"{rule['uid']}: duplicate refIds"
+        assert rule["condition"] in ref_ids, f"{rule['uid']}: condition points at a missing refId"
+        for node in rule["data"]:
+            assert node["model"]["refId"] == node["refId"], f"{rule['uid']}: model refId mismatch"
+            uid = node["datasourceUid"]
+            assert uid == EXPRESSION_UID or uid in datasource_uids, f"{rule['uid']}: unknown datasource {uid!r}"
+
+
+def test_every_rule_alerts_on_nodata_and_error():
+    # The alert endpoints return explicit zeros when healthy, so NoData/exec
+    # errors can only mean the pipeline itself broke — which must page too.
+    for rule in _rules():
+        assert rule["noDataState"] == "Alerting", rule["uid"]
+        assert rule["execErrState"] == "Alerting", rule["uid"]
+        assert rule["labels"]["severity"] in VALID_SEVERITIES, rule["uid"]
+
+
+def _healthy_k8s_source() -> K8sSource:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/pods") or "workloads" in request.url.path or "endpointslices" in request.url.path:
+            return httpx.Response(200, json={"items": [], "metadata": {}})
+        if "/deployments/" in request.url.path:
+            return httpx.Response(
+                200, json={"spec": {"replicas": 1, "selector": {"matchLabels": {}}}, "status": {"readyReplicas": 1}}
+            )
+        return httpx.Response(200, json={})
+
+    source = K8sSource(K8sClusterTarget("cw-a", "https://api.example"), token="t", timeout=5.0)
+    source._client = httpx.Client(transport=httpx.MockTransport(handler), base_url="https://api.example")
+    return source
+
+
+class _FakeIris:
+    def __init__(self, name: str) -> None:
+        self.target = ClusterTarget(name=name, project="p", zone="z", instance_filter="f", controller_filter="c")
+
+    def health(self) -> list[dict]:
+        return [{"reachable": True, "up": 1, "latency_ms": 3}]
+
+
+def test_every_rule_query_url_answers_on_the_bridge():
+    """Join each rule's datasource base path with its query URL and GET it for real."""
+    config = BridgeConfig(
+        max_rows=1000,
+        cache_ttl=20,
+        query_timeout_ms=5000,
+        iris_cache_ttl=15,
+        github_cache_ttl=60,
+        k8s_cache_ttl=30,
+        http_timeout=5,
+        github_token=None,
+        cw_read_token=None,
+    )
+    iris_sources = {name: _FakeIris(name) for name in ("marin", "marin-dev")}
+    fleet = K8sFleet([_healthy_k8s_source()])
+    client = TestClient(create_app(config, {}, iris_sources, GithubSource(token=None, timeout=5.0), fleet))
+
+    base_paths = _datasources()
+    for rule in _rules():
+        for node in rule["data"]:
+            if node["datasourceUid"] == EXPRESSION_UID:
+                continue
+            model = node["model"]
+            params = {p["key"]: p["value"] for p in model.get("url_options", {}).get("params", [])}
+            url = base_paths[node["datasourceUid"]] + model["url"]
+            response = client.get(url, params=params)
+            assert response.status_code == 200, f"{rule['uid']}: GET {url} -> {response.status_code}"
+            assert response.json(), f"{rule['uid']}: GET {url} returned no rows"
+
+
+def test_alert_queries_select_exactly_one_numeric_column():
+    # Grafana's table-alert contract: string columns become labels; the single
+    # numeric column is what the threshold expression evaluates.
+    for rule in _rules():
+        for node in rule["data"]:
+            if node["datasourceUid"] == EXPRESSION_UID:
+                continue
+            numeric = [c for c in node["model"]["columns"] if c["type"] == "number"]
+            assert len(numeric) == 1, f"{rule['uid']}: expected exactly one numeric column"
+
+
+def test_policies_reference_provisioned_contact_points():
+    contact_points = {point["name"] for point in _load(ALERTING / "contact-points.yaml")["contactPoints"]}
+    for policy in _load(ALERTING / "policies.yaml")["policies"]:
+        assert policy["receiver"] in contact_points
+        for route in policy.get("routes", []):
+            assert route["receiver"] in contact_points
+
+
+def test_critical_contact_point_reaches_email_and_slack():
+    points = {point["name"]: point for point in _load(ALERTING / "contact-points.yaml")["contactPoints"]}
+    critical_types = {receiver["type"] for receiver in points["ops-critical"]["receivers"]}
+    assert critical_types == {"email", "slack"}
+    for point in points.values():
+        for receiver in point["receivers"]:
+            if receiver["type"] == "slack":
+                assert receiver["settings"]["url"] == "$SLACK_ALERTS_WEBHOOK"
+
+
+def test_dashboard_datasource_uids_are_provisioned():
+    uids = set(_datasources())
+    for path in (ROOT / "dashboards").glob("*.json"):
+        dashboard = json.loads(path.read_text())
+        for panel in dashboard["panels"]:
+            uid = (panel.get("datasource") or {}).get("uid")
+            if uid is None or uid.startswith("${"):  # row panels / template variables
+                continue
+            assert uid in uids, f"{path.name} panel {panel.get('id')}: unknown datasource {uid!r}"

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -12,7 +12,8 @@ from urllib.parse import urlsplit
 
 import httpx
 import yaml
-from config import BridgeConfig, ClusterTarget, K8sClusterTarget
+from config import ClusterTarget, K8sClusterTarget
+from conftest import bridge_config
 from github_source import GithubSource
 from k8s_source import K8sFleet, K8sSource
 from server import create_app
@@ -88,20 +89,9 @@ class _FakeIris:
 
 def test_every_rule_query_url_answers_on_the_bridge():
     """Join each rule's datasource base path with its query URL and GET it for real."""
-    config = BridgeConfig(
-        max_rows=1000,
-        cache_ttl=20,
-        query_timeout_ms=5000,
-        iris_cache_ttl=15,
-        github_cache_ttl=60,
-        k8s_cache_ttl=30,
-        http_timeout=5,
-        github_token=None,
-        cw_read_token=None,
-    )
     iris_sources = {name: _FakeIris(name) for name in ("marin", "marin-dev")}
     fleet = K8sFleet([_healthy_k8s_source()])
-    client = TestClient(create_app(config, {}, iris_sources, GithubSource(token=None, timeout=5.0), fleet))
+    client = TestClient(create_app(bridge_config(), {}, iris_sources, GithubSource(token=None, timeout=5.0), fleet))
 
     base_paths = _datasources()
     for rule in _rules():

--- a/infra/grafana/tests/test_sources.py
+++ b/infra/grafana/tests/test_sources.py
@@ -15,6 +15,7 @@ from config import BridgeConfig, ClusterTarget
 from errors import UpstreamError
 from github_source import GithubSource
 from iris_source import IrisSource
+from k8s_source import K8sFleet
 from nightly_config import NIGHTLY_LANES
 from server import create_app
 from starlette.testclient import TestClient
@@ -108,6 +109,7 @@ def test_workers_follows_pagination():
 def test_health_reports_reachable_with_latency():
     result = _iris(lambda request: httpx.Response(200, json={})).health()
     assert result[0]["reachable"] is True
+    assert result[0]["up"] == 1
     assert isinstance(result[0]["latency_ms"], int)
 
 
@@ -115,7 +117,7 @@ def test_health_reports_unreachable_without_raising():
     def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("down", request=request)
 
-    assert _iris(handler).health() == [{"reachable": False, "latency_ms": None, "error": "down"}]
+    assert _iris(handler).health() == [{"reachable": False, "up": 0, "latency_ms": None, "error": "down"}]
 
 
 def test_controller_non_200_raises_upstream_error():
@@ -230,12 +232,13 @@ def _app(iris_source, github_source: GithubSource | None = None) -> TestClient:
         query_timeout_ms=5000,
         iris_cache_ttl=15,
         github_cache_ttl=60,
+        k8s_cache_ttl=30,
         http_timeout=5,
         github_token=None,
+        cw_read_token=None,
     )
-    return TestClient(
-        create_app(config, {}, {"marin": iris_source}, github_source or GithubSource(token=None, timeout=5.0))
-    )
+    github = github_source or GithubSource(token=None, timeout=5.0)
+    return TestClient(create_app(config, {}, {"marin": iris_source}, github, K8sFleet(())))
 
 
 def test_iris_endpoint_returns_rows():

--- a/infra/grafana/tests/test_sources.py
+++ b/infra/grafana/tests/test_sources.py
@@ -11,7 +11,8 @@ import json
 
 import httpx
 import pytest
-from config import BridgeConfig, ClusterTarget
+from config import ClusterTarget
+from conftest import bridge_config
 from errors import UpstreamError
 from github_source import GithubSource
 from iris_source import IrisSource
@@ -226,19 +227,8 @@ class _FakeIris:
 
 
 def _app(iris_source, github_source: GithubSource | None = None) -> TestClient:
-    config = BridgeConfig(
-        max_rows=1000,
-        cache_ttl=20,
-        query_timeout_ms=5000,
-        iris_cache_ttl=15,
-        github_cache_ttl=60,
-        k8s_cache_ttl=30,
-        http_timeout=5,
-        github_token=None,
-        cw_read_token=None,
-    )
     github = github_source or GithubSource(token=None, timeout=5.0)
-    return TestClient(create_app(config, {}, {"marin": iris_source}, github, K8sFleet(())))
+    return TestClient(create_app(bridge_config(), {}, {"marin": iris_source}, github, K8sFleet(())))
 
 
 def test_iris_endpoint_returns_rows():

--- a/infra/grafana/uv.lock
+++ b/infra/grafana/uv.lock
@@ -747,6 +747,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
@@ -759,7 +760,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8.4" }]
+dev = [
+    { name = "pytest", specifier = ">=8.4" },
+    { name = "pyyaml", specifier = ">=6" },
+]
 
 [[package]]
 name = "marin-rigging"


### PR DESCRIPTION
Add a read-only k8s path into the Grafana bridge, a "K8s control plane" dashboard, and file-provisioned alerting, so a CoreWeave control-plane failure (the July 18 kueue wedge: a crash-looping kueue-controller-manager whose fail-closed webhook silently rejected every pod CREATE for hours) pages ops instead of waiting to be noticed.

The bridge polls the three CW CKS API servers (cw-us-east-02a, cw-us-east-08a, cw-rno2a) with plain httpx and one org-wide CW read-role token: watched components (kueue-controller-manager, iris-controller, traefik, cert-manager) with ready/desired/restarts/waiting state, webhook ready-endpoint counts from discovery.k8s.io EndpointSlices, backoff pods, pending/gated pods, unadmitted Kueue workloads (v1beta2, verified against the live clusters), and Warning events. Pod-level scans skip provider-managed namespaces (cw-*, kube-*): CoreWeave's per-node daemons are ~5,000 pods of ~19KB JSON each on cw-us-east-08a, while the namespaces we operate hold about a hundred.

The /k8s/alerts/* routes implement Grafana's table-alert contract: string label columns plus exactly one numeric column, always at least one row per cluster with explicit zeros when healthy, so a rule can never enter NoData. An unreachable cluster becomes labeled error rows (auth vs network vs timeout) while the other clusters keep rendering.

Alerting is provisioned from files: ops-critical (email ops@openathena.ai + Slack #marin-eng) for critical, ops-slack for warnings, grouped by alertname+cluster, 4h repeat. v1 rules: K8sClusterUnreachable, ControlPlaneCrashLooping, WebhookEndpointsEmpty (5m, critical), ControlPlaneDegraded (15m, warning), and IrisControllerDown via the existing /iris/{cluster}/health (marin critical, marin-dev warning; the health row gained a numeric `up` column to threshold on). Every rule sets noDataState/execErrState: Alerting. Workload-tier signals (gated pods, kueue backlog, workload crashloops) stay dashboard-only for now.

The Infinity plugin is now pinned (3.10.1) so alert evaluation never rides an untested plugin build. Email is optional: Grafana sends via plain Gmail submission (smtp.gmail.com:587, app password for grafana@openathena.ai) rather than the Workspace relay, and the deploy probes Secret Manager for `marin-grafana-smtp-credentials` — when it is absent the service still deploys with SMTP disabled and critical alerts page Slack only.

Every secret the deploy requires now exists: `marin-status-page-github-token` (pre-existing), `marin-grafana-slack-webhook` (v1, 2026-07-19), and `marin-grafana-cw-read-token` (v1, 2026-07-19). The CW token currently holds the token from the iris kubeconfig as a temporary stand-in; swap it for a proper CW read-role token via the overlap-safe rotation in the README (`gcloud secrets versions add`, redeploy, revoke the old token). To turn on email later:

    echo -n "<gmail-app-password>" | gcloud secrets create marin-grafana-smtp-credentials \
      --project=hai-gcp-models --data-file=-

Phases 1-3 of the k8s observability plan; the iris.task_state / iris.admission_probe emitters (phase 4) are a separate workstream.
