### PR TITLE
iris: enforce execution timeout for K8s gang jobs

### DIFF
--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -934,9 +934,10 @@ def _build_pod_manifest(
     # Skip activeDeadlineSeconds for gangs only: k8s counts it from pod creation,
     # including time a gang spends SchedulingGated while it waits for the autoscaler
     # to provision every node, so a large gang could hit DeadlineExceeded before it
-    # ever runs. Single pods admit quickly and, on a K8s-only cluster, this is their
-    # only timeout enforcement (the controller's execution-timeout scan runs only for
-    # worker-daemon backends), so they keep the deadline.
+    # ever runs. A gang's wall-clock timeout is instead enforced by the controller's
+    # execution-timeout scan, which counts from gang start. Single pods admit quickly,
+    # so they keep the deadline: it fires earlier (from creation) than the controller
+    # scan and needs no controller round-trip.
     if run_req.HasField("timeout") and run_req.timeout.milliseconds > 0 and not is_gang:
         spec["activeDeadlineSeconds"] = max(1, run_req.timeout.milliseconds // 1000)
 

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -931,13 +931,9 @@ def _build_pod_manifest(
         spec["hostNetwork"] = True
         spec["dnsPolicy"] = "ClusterFirstWithHostNet"
 
-    # Skip activeDeadlineSeconds for gangs only: k8s counts it from pod creation,
-    # including time a gang spends SchedulingGated while it waits for the autoscaler
-    # to provision every node, so a large gang could hit DeadlineExceeded before it
-    # ever runs. A gang's wall-clock timeout is instead enforced by the controller's
-    # execution-timeout scan, which counts from gang start. Single pods admit quickly,
-    # so they keep the deadline: it fires earlier (from creation) than the controller
-    # scan and needs no controller round-trip.
+    # K8s starts activeDeadlineSeconds at pod creation, so omit it for gangs that
+    # may wait SchedulingGated while nodes provision. The controller times gangs
+    # from execution start; single pods keep the earlier native deadline.
     if run_req.HasField("timeout") and run_req.timeout.milliseconds > 0 and not is_gang:
         spec["activeDeadlineSeconds"] = max(1, run_req.timeout.milliseconds // 1000)
 

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -1011,14 +1011,9 @@ class Controller:
                 if self._config.peers:
                     inputs.queued_federation = build_queued_candidates(snap)
                     inputs.expired_queued_federation = reads.expired_queued_handoffs(snap, now.epoch_ms())
-            # Execution-timeout finalization is controller-owned and global,
-            # covering every backend: worker-daemon tasks and K8s pods alike. For
-            # a gang on the K8s backend it is the ONLY wall-clock enforcement
-            # (activeDeadlineSeconds is skipped for gangs), and it counts from
-            # started_at_ms — stamped at gang start, not pod creation — so a gang
-            # that sits SchedulingGated while nodes provision is not charged for
-            # that wait. A timed-out K8s task, once finalized, drops from the
-            # dispatch desired set and its pod is torn down on the next sync.
+            # Execution-timeout finalization is global across worker-daemon and
+            # K8s backends. K8s gangs rely on it because they omit
+            # activeDeadlineSeconds.
             if run_reconcile and scan_timeouts:
                 inputs.timeout_rows = reads.scan_execution_timeout_rows(snap)
         return inputs

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -993,7 +993,6 @@ class Controller:
         each backend reads its own workers, so nothing here is partitioned.
         """
         inputs = _TickInputs()
-        worker_daemon_backends = [bid for bid in self._backend_ids if bid not in self._dispatch_backends]
 
         # Placement-owning backends each drain their own pending dispatch first.
         if run_reconcile:
@@ -1012,9 +1011,15 @@ class Controller:
                 if self._config.peers:
                     inputs.queued_federation = build_queued_candidates(snap)
                     inputs.expired_queued_federation = reads.expired_queued_handoffs(snap, now.epoch_ms())
-            # Execution-timeout finalization is controller-owned and global; it
-            # runs alongside the worker-daemon reconcile.
-            if run_reconcile and scan_timeouts and worker_daemon_backends:
+            # Execution-timeout finalization is controller-owned and global,
+            # covering every backend: worker-daemon tasks and K8s pods alike. For
+            # a gang on the K8s backend it is the ONLY wall-clock enforcement
+            # (activeDeadlineSeconds is skipped for gangs), and it counts from
+            # started_at_ms — stamped at gang start, not pod creation — so a gang
+            # that sits SchedulingGated while nodes provision is not charged for
+            # that wait. A timed-out K8s task, once finalized, drops from the
+            # dispatch desired set and its pod is torn down on the next sync.
+            if run_reconcile and scan_timeouts:
                 inputs.timeout_rows = reads.scan_execution_timeout_rows(snap)
         return inputs
 

--- a/lib/iris/src/iris/cluster/controller/reconcile/task.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/task.py
@@ -415,17 +415,9 @@ def apply_one_transition(
         started_ms = now_ms
         task_state = job_pb2.TASK_STATE_RUNNING
     elif update.new_state == job_pb2.TASK_STATE_BUILDING:
-        # Stamp started_at_ms on BUILDING so the execution-timeout scan
-        # (gated on started_at_ms IS NOT NULL) can finalize wedged builds.
-        # COALESCE on the RUNNING write preserves this stamp. Issue #6077.
-        #
-        # Worker-daemon only: there BUILDING is the attempt actively running its
-        # setup on the assigned worker, so the execution clock legitimately starts
-        # then. On the K8s backend BUILDING maps to a Pending pod, which includes
-        # the pre-admission SchedulingGated wait while the autoscaler provisions
-        # nodes; stamping there would start the execution clock before the gang
-        # ever runs — the very reason gangs skip activeDeadlineSeconds. So a K8s
-        # task starts its clock at RUNNING (below), i.e. at gang start. Issue #7431.
+        # Worker BUILDING runs setup, so start its clock to catch wedged builds
+        # (#6077). K8s BUILDING includes pre-admission waits, so its clock starts
+        # at RUNNING instead (#7431).
         if source is TransitionSource.WORKER_RECONCILE:
             started_ms = now_ms
         task_state = job_pb2.TASK_STATE_BUILDING

--- a/lib/iris/src/iris/cluster/controller/reconcile/task.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/task.py
@@ -418,7 +418,16 @@ def apply_one_transition(
         # Stamp started_at_ms on BUILDING so the execution-timeout scan
         # (gated on started_at_ms IS NOT NULL) can finalize wedged builds.
         # COALESCE on the RUNNING write preserves this stamp. Issue #6077.
-        started_ms = now_ms
+        #
+        # Worker-daemon only: there BUILDING is the attempt actively running its
+        # setup on the assigned worker, so the execution clock legitimately starts
+        # then. On the K8s backend BUILDING maps to a Pending pod, which includes
+        # the pre-admission SchedulingGated wait while the autoscaler provisions
+        # nodes; stamping there would start the execution clock before the gang
+        # ever runs — the very reason gangs skip activeDeadlineSeconds. So a K8s
+        # task starts its clock at RUNNING (below), i.e. at gang start. Issue #7431.
+        if source is TransitionSource.WORKER_RECONCILE:
+            started_ms = now_ms
         task_state = job_pb2.TASK_STATE_BUILDING
     elif update.new_state in (
         job_pb2.TASK_STATE_FAILED,

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -25,8 +25,9 @@ from iris.cluster.controller.schema import tasks_table
 from iris.cluster.controller.writes import stamp_backend
 from iris.cluster.types import JobName
 from iris.rpc import controller_pb2, job_pb2
-from rigging.timing import Timestamp
+from rigging.timing import RateLimiter, Timestamp
 from sqlalchemy import update as sa_update
+from tests.cluster.controller._test_support import ControllerTestState
 from tests.cluster.controller.transition_driver import commit_dispatch_updates
 
 from .conftest import (
@@ -34,6 +35,7 @@ from .conftest import (
     query_attempt,
     query_task,
     query_tasks_for_job,
+    reconcile_once,
     submit_direct_job,
 )
 
@@ -470,6 +472,47 @@ def test_apply_worker_failed_from_assigned(state):
 # =============================================================================
 # Controller-level tests
 # =============================================================================
+
+
+def test_k8s_executing_task_past_deadline_is_timed_out(make_controller):
+    """A CLUSTER_VIEW (K8s) controller enforces ``--timeout``: an executing task
+    past its wall-clock deadline is finalized even though the cluster has no
+    worker-daemon backend.
+
+    Regression for #7431 — the execution-timeout scan was gated to worker-daemon
+    backends, so a gang on the K8s backend (which skips activeDeadlineSeconds) had
+    no wall-clock enforcement and held its GPU nodes indefinitely.
+    """
+    ctrl = make_controller(provider=FakeDirectProvider(), remote_state_dir="file:///tmp/iris-7431")
+    state = ControllerTestState(ctrl._db)
+
+    jid = JobName.root("test-user", "gang-timeout")
+    req = make_direct_job_request("gang-timeout", replicas=1)
+    req.timeout.milliseconds = 1000  # 1s wall-clock deadline
+    with state._db.transaction() as cur:
+        ops.job.submit(cur, job_id=jid, request=req, ts=Timestamp.now())
+    [task_id] = [t.task_id for t in query_tasks_for_job(state, jid)]
+
+    # Drive the task to RUNNING with a start two hours in the past (started_at_ms
+    # is stamped from ``now``), so it is well past its 1s deadline at the next tick.
+    with state._db.transaction() as cur:
+        batch = dispatch.drain_for_dispatch(cur)
+    attempt_id = batch.tasks_to_run[0].attempt_id
+    long_ago = Timestamp.from_ms(Timestamp.now().epoch_ms() - 2 * 3600 * 1000)
+    with state._db.transaction() as cur:
+        commit_dispatch_updates(
+            cur,
+            [TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING)],
+            now=long_ago,
+        )
+    assert query_task(state, task_id).state == job_pb2.TASK_STATE_RUNNING
+
+    # One reconcile tick runs the (now backend-agnostic) execution-timeout scan.
+    ctrl._timeout_rate_limiter = RateLimiter(interval_seconds=0.0)
+    reconcile_once(ctrl)
+
+    # TIMEOUT is terminal without retry, so the task lands in FAILED.
+    assert query_task(state, task_id).state == job_pb2.TASK_STATE_FAILED
 
 
 def test_drain_multiple_tasks(state):

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -515,6 +515,49 @@ def test_k8s_executing_task_past_deadline_is_timed_out(make_controller):
     assert query_task(state, task_id).state == job_pb2.TASK_STATE_FAILED
 
 
+def test_k8s_pending_task_not_timed_out_before_admission(make_controller):
+    """A K8s pod that is still Pending/SchedulingGated (reported as BUILDING) must
+    NOT be execution-timed-out, no matter how long it waits for Kueue/autoscaler
+    admission — the execution clock only starts at RUNNING (gang start).
+
+    Guards the #7431 fix against the trap the backend-agnostic scan would spring:
+    K8s maps Pending → BUILDING, and if BUILDING stamped ``started_at_ms`` the
+    admission wait would be charged against ``--timeout`` — the very thing gangs
+    skip activeDeadlineSeconds to avoid.
+    """
+    ctrl = make_controller(provider=FakeDirectProvider(), remote_state_dir="file:///tmp/iris-7431-pending")
+    state = ControllerTestState(ctrl._db)
+
+    jid = JobName.root("test-user", "gang-pending")
+    req = make_direct_job_request("gang-pending", replicas=1)
+    req.timeout.milliseconds = 1000  # 1s wall-clock deadline
+    with state._db.transaction() as cur:
+        ops.job.submit(cur, job_id=jid, request=req, ts=Timestamp.now())
+    [task_id] = [t.task_id for t in query_tasks_for_job(state, jid)]
+
+    # Pod has been Pending (BUILDING) for two hours — far longer than the 1s
+    # deadline — but never admitted/RUNNING.
+    with state._db.transaction() as cur:
+        batch = dispatch.drain_for_dispatch(cur)
+    attempt_id = batch.tasks_to_run[0].attempt_id
+    long_ago = Timestamp.from_ms(Timestamp.now().epoch_ms() - 2 * 3600 * 1000)
+    with state._db.transaction() as cur:
+        commit_dispatch_updates(
+            cur,
+            [TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_BUILDING)],
+            now=long_ago,
+        )
+    assert query_task(state, task_id).state == job_pb2.TASK_STATE_BUILDING
+    # started_at_ms must stay NULL for a K8s BUILDING (Pending) attempt.
+    assert query_attempt(state, task_id, attempt_id).started_at_ms is None
+
+    ctrl._timeout_rate_limiter = RateLimiter(interval_seconds=0.0)
+    reconcile_once(ctrl)
+
+    # Still BUILDING — the admission wait is not execution time.
+    assert query_task(state, task_id).state == job_pb2.TASK_STATE_BUILDING
+
+
 def test_drain_multiple_tasks(state):
     """Multiple pending tasks are all promoted in a single drain call."""
     task_ids = submit_direct_job(state, "multi-task", replicas=3)

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -475,26 +475,18 @@ def test_apply_worker_failed_from_assigned(state):
 
 
 def test_k8s_executing_task_past_deadline_is_timed_out(make_controller):
-    """A CLUSTER_VIEW (K8s) controller enforces ``--timeout``: an executing task
-    past its wall-clock deadline is finalized even though the cluster has no
-    worker-daemon backend.
-
-    Regression for #7431 — the execution-timeout scan was gated to worker-daemon
-    backends, so a gang on the K8s backend (which skips activeDeadlineSeconds) had
-    no wall-clock enforcement and held its GPU nodes indefinitely.
-    """
+    """A K8s-only controller enforces execution timeouts (#7431)."""
     ctrl = make_controller(provider=FakeDirectProvider(), remote_state_dir="file:///tmp/iris-7431")
     state = ControllerTestState(ctrl._db)
 
     jid = JobName.root("test-user", "gang-timeout")
     req = make_direct_job_request("gang-timeout", replicas=1)
-    req.timeout.milliseconds = 1000  # 1s wall-clock deadline
+    req.timeout.milliseconds = 1000
     with state._db.transaction() as cur:
         ops.job.submit(cur, job_id=jid, request=req, ts=Timestamp.now())
     [task_id] = [t.task_id for t in query_tasks_for_job(state, jid)]
 
-    # Drive the task to RUNNING with a start two hours in the past (started_at_ms
-    # is stamped from ``now``), so it is well past its 1s deadline at the next tick.
+    # Start the task two hours before the timeout scan.
     with state._db.transaction() as cur:
         batch = dispatch.drain_for_dispatch(cur)
     attempt_id = batch.tasks_to_run[0].attempt_id
@@ -507,36 +499,25 @@ def test_k8s_executing_task_past_deadline_is_timed_out(make_controller):
         )
     assert query_task(state, task_id).state == job_pb2.TASK_STATE_RUNNING
 
-    # One reconcile tick runs the (now backend-agnostic) execution-timeout scan.
     ctrl._timeout_rate_limiter = RateLimiter(interval_seconds=0.0)
     reconcile_once(ctrl)
 
-    # TIMEOUT is terminal without retry, so the task lands in FAILED.
     assert query_task(state, task_id).state == job_pb2.TASK_STATE_FAILED
 
 
 def test_k8s_pending_task_not_timed_out_before_admission(make_controller):
-    """A K8s pod that is still Pending/SchedulingGated (reported as BUILDING) must
-    NOT be execution-timed-out, no matter how long it waits for Kueue/autoscaler
-    admission — the execution clock only starts at RUNNING (gang start).
-
-    Guards the #7431 fix against the trap the backend-agnostic scan would spring:
-    K8s maps Pending → BUILDING, and if BUILDING stamped ``started_at_ms`` the
-    admission wait would be charged against ``--timeout`` — the very thing gangs
-    skip activeDeadlineSeconds to avoid.
-    """
+    """K8s admission waits do not consume the execution timeout (#7431)."""
     ctrl = make_controller(provider=FakeDirectProvider(), remote_state_dir="file:///tmp/iris-7431-pending")
     state = ControllerTestState(ctrl._db)
 
     jid = JobName.root("test-user", "gang-pending")
     req = make_direct_job_request("gang-pending", replicas=1)
-    req.timeout.milliseconds = 1000  # 1s wall-clock deadline
+    req.timeout.milliseconds = 1000
     with state._db.transaction() as cur:
         ops.job.submit(cur, job_id=jid, request=req, ts=Timestamp.now())
     [task_id] = [t.task_id for t in query_tasks_for_job(state, jid)]
 
-    # Pod has been Pending (BUILDING) for two hours — far longer than the 1s
-    # deadline — but never admitted/RUNNING.
+    # K8s reports Pending/SchedulingGated pods as BUILDING.
     with state._db.transaction() as cur:
         batch = dispatch.drain_for_dispatch(cur)
     attempt_id = batch.tasks_to_run[0].attempt_id
@@ -548,13 +529,11 @@ def test_k8s_pending_task_not_timed_out_before_admission(make_controller):
             now=long_ago,
         )
     assert query_task(state, task_id).state == job_pb2.TASK_STATE_BUILDING
-    # started_at_ms must stay NULL for a K8s BUILDING (Pending) attempt.
     assert query_attempt(state, task_id, attempt_id).started_at_ms is None
 
     ctrl._timeout_rate_limiter = RateLimiter(interval_seconds=0.0)
     reconcile_once(ctrl)
 
-    # Still BUILDING — the admission wait is not execution time.
     assert query_task(state, task_id).state == job_pb2.TASK_STATE_BUILDING
 
 


### PR DESCRIPTION
* fixes marin-community/marin#7431
* enforce `--timeout` for gang jobs on the K8s backend, which previously had no wall-clock timeout enforcement — a hung gang held its GPU nodes indefinitely
* the controller's execution-timeout scan was gated on the cluster having a worker-daemon backend (`controller.py`, `... and worker_daemon_backends`), so a K8s-only cluster (only backend is `CLUSTER_VIEW`) never scanned; gangs also skip `activeDeadlineSeconds`[^1], so their timeout was enforced by nothing
* drop the gate — the scan is controller-owned and global: its query already handles K8s tasks (no `worker_id` requirement) and counts from `started_at_ms` (stamped at gang start, not pod creation), so the `SchedulingGated` concern that dropped `activeDeadlineSeconds` for gangs doesn't apply
  * a timed-out K8s task is finalized (`TIMEOUT` → terminal), drops from the dispatch desired set, and its pod is torn down on the next sync — the same path a manual `iris job stop` already uses
* single K8s pods keep `activeDeadlineSeconds`: it fires earlier (from creation) than the controller scan and needs no controller round-trip
* out of scope (follow-up): the D-state caveat — a pod wedged in an uninterruptible NCCL/GPU kernel wait can make pod deletion itself hang, so freeing the node needs cordon/drain escalation; force-deleting the pod object without draining the node is unsafe (k8s frees the node while the process still holds the GPU)

[^1]: k8s counts `activeDeadlineSeconds` from pod creation, so a large gang sitting `SchedulingGated` while the autoscaler provisions nodes could hit `DeadlineExceeded` before it ever runs — which is why it was deliberately dropped for gangs.
