### PR TITLE
[grafana] Grant dashboard TV IAP access

### DIFF
--- a/infra/grafana/Pulumi.marin-grafana.yaml
+++ b/infra/grafana/Pulumi.marin-grafana.yaml
@@ -8,7 +8,7 @@ config:
   #     - alice@example.com
   #     - "*@openathena.ai"
   #     - group:marin-eng@example.com
-  marin-grafana:viewers: [russell.power@gmail.com, '*@openathena.ai']
+  marin-grafana:viewers: [russell.power@gmail.com, sf.office.shared.openathena@gmail.com, '*@openathena.ai']
   # Vanity host for the service. The DNS CNAME (grafana -> ghs.googlehosted.com) is created
   # in the oa.dev Cloudflare zone; unset custom_domain to serve only the run.app URL.
   marin-grafana:custom_domain: grafana.oa.dev


### PR DESCRIPTION
Add sf.office.shared.openathena@gmail.com to the Grafana IAP viewer allowlist so the San Francisco office dashboard TV can reach grafana.oa.dev. The existing individual and openathena.ai domain grants remain unchanged.

Session: https://loom.rjp.io/s/zurltagy