### PR TITLE
[grafana] Monitor stuck GPU pod terminations

### DIFF
--- a/.agents/skills/recover-stuck-k8s-pod/SKILL.md
+++ b/.agents/skills/recover-stuck-k8s-pod/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: recover-stuck-k8s-pod
+description: Diagnose and safely recover stuck terminating Kubernetes pods on Marin CoreWeave clusters, especially node-bound GPU pods. Use for deletion hangs, suspected uninterruptible GPU/NCCL waits, node cordoning or reboot decisions, and force-deletion requests.
+---
+
+# Recover a stuck Kubernetes pod
+
+Treat a pod that remains beyond its deletion deadline as a stuck Kubernetes
+object. Determine whether the node still owns live work before changing it.
+Force deletion removes the API object; it does not prove that the process or
+GPU allocation is gone.
+
+## Guardrails
+
+- Start with read-only inspection. Get explicit operator approval before
+  cordoning, deleting workloads, rebooting a node, or changing Iris state.
+- Never force-delete a node-bound GPU pod while its process might still be
+  running. Cordon the node, quiesce Iris retries, and obtain provider-level
+  proof of reboot completion first.
+- Extract the canonical Iris attempt from the `task` container's
+  `IRIS_TASK_ID`. Labels are sanitized or truncated display identifiers; never
+  use them as targets for `iris job kick`.
+- Do not use a broad `kubectl drain --force`. Inventory sibling pods, owners,
+  disruption budgets, volumes, and local storage before approving collateral.
+- Record whether the node was already cordoned. Uncordon only a node this
+  procedure cordoned, and only after health checks pass.
+- Do not restart an Iris cluster as part of pod recovery.
+
+Read `platform.coreweave.kubeconfig_path` and `kube_context` from the canonical
+`lib/iris/config/<cluster>.yaml` before operating. Do not copy those values from
+an alert, an old incident, or this skill:
+
+```bash
+rg -n 'kubeconfig_path|kube_context' lib/iris/config/<cluster>.yaml
+```
+
+Set `<kubeconfig>`, `<context>`, `<namespace>`, `<pod>`, and `<node>` explicitly
+in every command. Do not rely on the current kubectl context.
+
+## Classify the object
+
+Inspect the pod and its events:
+
+```bash
+kubectl --kubeconfig <kubeconfig> --context <context> \
+  -n <namespace> get pod <pod> -o yaml
+kubectl --kubeconfig <kubeconfig> --context <context> \
+  -n <namespace> get events --field-selector involvedObject.name=<pod> \
+  --sort-by=.lastTimestamp
+```
+
+The Grafana `classification` column chooses the first applicable case:
+
+- `finalizer`: investigate and repair the owning controller. Do not reboot a
+  node solely because an object has a finalizer.
+- `terminal`: the workload finished; investigate API or runtime cleanup.
+- `unbound`: no node owns the pod; investigate API or scheduler cleanup.
+- `invalid_timestamp`: repair or escalate the malformed object metadata.
+- `node_cleanup`: the nonterminal object is bound to a node with no finalizer.
+  Continue with node-level recovery only for this case.
+
+`FailedKillPod` or `ExceededGracePeriod` events strengthen the diagnosis, but
+events can expire. Missing logs do not identify a stuck termination, and
+Kubernetes/DCGM metrics do not reliably identify an NCCL collective. A process
+in `D` state or a kernel stack involving GPU/NCCL code is supporting evidence,
+not the alert condition.
+
+## Identify the Iris attempt and blast radius
+
+Extract the exact attempt and inspect all workloads on the node:
+
+```bash
+kubectl --kubeconfig <kubeconfig> --context <context> \
+  -n <namespace> get pod <pod> \
+  -o jsonpath='{.spec.containers[?(@.name=="task")].env[?(@.name=="IRIS_TASK_ID")].value}{"\n"}'
+kubectl --kubeconfig <kubeconfig> --context <context> \
+  get pods --all-namespaces --field-selector spec.nodeName=<node> -o wide
+kubectl --kubeconfig <kubeconfig> --context <context> \
+  get node <node> -o jsonpath='{.spec.unschedulable}{"\n"}'
+```
+
+Also inspect owner references, pod disruption budgets, PVCs, `emptyDir`, and
+unmanaged pods. Split `<attempt>` (for example `/user/job/0:3`) at the task
+suffix and check current Iris state:
+
+```bash
+uv run iris --cluster=<cluster> job summary <job>
+```
+
+Before node recovery, choose an explicit retry policy with the operator:
+
+- Stop the parent job with `iris job stop <job>` when all work must remain
+  quiescent.
+- Mark only the canonical attempt failed with
+  `iris job kick <attempt> --state failed` when the operator accepts Iris
+  scheduling its retry.
+
+Do not kick by pod label, and do not permit an immediate retry onto a node that
+has not yet been cordoned.
+
+## Isolate and try graceful cleanup
+
+With approval, cordon first and then request an ordinary deletion:
+
+```bash
+kubectl --kubeconfig <kubeconfig> --context <context> cordon <node>
+kubectl --kubeconfig <kubeconfig> --context <context> \
+  -n <namespace> delete pod <pod> --wait=false
+```
+
+Wait for kubelet cleanup and inspect fresh events. If the object disappears,
+verify the process and GPU allocation are gone before considering the node
+healthy. If it remains and node cleanup is implicated, continue to reboot.
+
+For additional evidence, an approved privileged node debug session can inspect
+the host under `/host`:
+
+```bash
+kubectl --kubeconfig <kubeconfig> --context <context> \
+  debug node/<node> -it --image=ubuntu --profile=sysadmin
+```
+
+Do not kill arbitrary PIDs from the debug shell.
+
+## Reboot the node before force deletion
+
+CoreWeave `cwic` is a prerequisite. If it is unavailable or authentication
+fails, stop and use the CoreWeave console or support; do not substitute force
+deletion.
+
+```bash
+command -v cwic
+cwic auth login
+cwic node get <node>
+cwic node describe <node>
+cwic node reboot --force --message "stuck terminating GPU pod <namespace>/<pod>" <node>
+```
+
+Use `--force` only when the graceful path has failed and the collateral impact
+is approved. A Kubernetes `NotReady`/`Ready` transition alone is not proof of a
+physical reboot. Wait for `cwic node describe` to show the provider operation
+completed and the node returned through self-test to production. Record the
+provider operation, boot identity when available, and affected sibling pods.
+
+Use the Kubernetes `node.kubernetes.io/out-of-service` taint only when the node
+is confirmed powered off and the storage implications are understood. It can
+force detach volumes and carries data-corruption risk; it is not the normal
+path for a wedged GPU pod.
+
+## Remove stale state and restore service
+
+Only after provider-confirmed reboot completion may the remaining API object be
+force-deleted:
+
+```bash
+kubectl --kubeconfig <kubeconfig> --context <context> \
+  -n <namespace> delete pod <pod> --grace-period=0 --force
+```
+
+Verify that the original pod UID is gone, no duplicate Iris attempt is active,
+GPU allocatable capacity is restored, required daemonsets are healthy, and the
+node has passed its workload health checks. If this procedure cordoned a node
+that was initially schedulable, uncordon it only after those checks:
+
+```bash
+kubectl --kubeconfig <kubeconfig> --context <context> uncordon <node>
+```
+
+Record the timeline, commands, canonical attempt, node, provider operation,
+collateral workloads, and verification evidence in the incident or task log.
+
+## References
+
+- [Kubernetes pod termination](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination)
+- [kubectl delete force-deletion warning](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_delete/)
+- [CoreWeave node reboot](https://docs.coreweave.com/docs/products/cks/nodes/reboot-a-node)
+- [CoreWeave node status and self-test](https://docs.coreweave.com/docs/products/cks/nodes/node-status)
+- [Kubernetes non-graceful node shutdown](https://kubernetes.io/docs/concepts/cluster-administration/node-shutdown/#non-graceful-node-shutdown)

--- a/.agents/skills/recover-stuck-k8s-pod/SKILL.md
+++ b/.agents/skills/recover-stuck-k8s-pod/SKILL.md
@@ -51,11 +51,11 @@ kubectl --kubeconfig <kubeconfig> --context <context> \
 
 The Grafana `classification` column chooses the first applicable case:
 
+- `invalid_timestamp`: repair or escalate the malformed object metadata.
 - `finalizer`: investigate and repair the owning controller. Do not reboot a
   node solely because an object has a finalizer.
 - `terminal`: the workload finished; investigate API or runtime cleanup.
 - `unbound`: no node owns the pod; investigate API or scheduler cleanup.
-- `invalid_timestamp`: repair or escalate the malformed object metadata.
 - `node_cleanup`: the nonterminal object is bound to a node with no finalizer.
   Continue with node-level recovery only for this case.
 

--- a/.agents/skills/recover-stuck-k8s-pod/SKILL.md
+++ b/.agents/skills/recover-stuck-k8s-pod/SKILL.md
@@ -91,9 +91,9 @@ Before node recovery, choose an explicit retry policy with the operator:
 
 - Stop the parent job with `iris job stop <job>` when all work must remain
   quiescent.
-- Mark only the canonical attempt failed with
-  `iris job kick <attempt> --state failed` when the operator accepts Iris
-  scheduling its retry.
+- Mark only the canonical attempt preempted with
+  `iris job kick <attempt> --state preempted` when the operator accepts Iris
+  scheduling its retry within the job's preemption budget.
 
 Do not kick by pod label, and do not permit an immediate retry onto a node that
 has not yet been cordoned.

--- a/.agents/skills/recover-stuck-k8s-pod/agents/openai.yaml
+++ b/.agents/skills/recover-stuck-k8s-pod/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Recover Stuck K8s Pod"
+  short_description: "Safely recover stuck CoreWeave GPU pods"
+  default_prompt: "Use $recover-stuck-k8s-pod to diagnose and safely recover this stuck CoreWeave Kubernetes pod."

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -34,9 +34,10 @@ GET /iris/{cluster}/jobs | workers | health      live controller RPCs
 GET /iris/{cluster}/query?sql=                    ad-hoc SELECT (admin/null-auth)
 GET /github/ferries | builds | nightlies          GitHub REST / GraphQL
 GET /k8s/control_plane | crashloops | pending     CW control-plane state, all clusters
-GET /k8s/kueue | events | health                  ... one response, `cluster` column
+GET /k8s/termination_candidates | kueue | events | health
+                                                    ... one response, `cluster` column
 GET /k8s/alerts/{unreachable,crashloops,          alert rows: string labels + one
-     webhook_ready,degraded}                      numeric, >=1 row per cluster
+     webhook_ready,degraded,stuck_gpu_pods}       numeric, >=1 row per cluster
 GET /health                                       bridge liveness
 ```
 
@@ -72,7 +73,11 @@ control-plane components (a config constant: kueue-controller-manager, iris-cont
 traefik, cert-manager) with ready/desired/restarts/waiting state, admission-webhook
 ready-endpoint counts from `discovery.k8s.io` EndpointSlices, backoff pods, pending and
 scheduling-gated pods, the unadmitted Kueue backlog per queue, and recent Warning
-events. The pod-level scans skip provider-managed namespaces (`cw-*`, `kube-*`):
+events. It also reports pods still present at least two minutes after their API
+deletion deadline, classified as node cleanup, finalizer cleanup, terminal cleanup,
+unbound cleanup, or invalid timestamp. Those rows include the assigned node, GPU
+request, canonical Iris task-attempt id from `IRIS_TASK_ID`, priority class, and
+finalizers. The pod-level scans skip provider-managed namespaces (`cw-*`, `kube-*`):
 CoreWeave's per-node daemons are thousands of pods of someone else's infrastructure,
 while the namespaces we operate hold about a hundred. These are current-state reads —
 the bridge stores no history; trends come from the finelog-backed rows.
@@ -130,9 +135,12 @@ redeploy.
 
 Rules page only on near-certain incidents: an unreachable cluster, a
 crash-looping watched component, an admission webhook with no ready endpoints, a
-degraded component, and a dead Iris controller. Workload-tier signals (gated pods,
-Kueue backlog, workload crashloops) are dashboard-only — they have expected benign
-causes, so paging on them would be noise. `severity=critical` routes to `ops-critical` (email ops@openathena.ai +
+degraded component, a dead Iris controller, and a GPU pod that stays node-bound and
+nonterminal without finalizers for five minutes after the bridge's two-minute
+overdue threshold. The stuck-pod rule groups by node and links the cordon-first
+recovery skill; terminal, unbound, and finalizer-held pods stay dashboard-only.
+Other workload-tier signals (gated pods, Kueue backlog, workload crashloops) are
+dashboard-only because they have expected benign causes. `severity=critical` routes to `ops-critical` (email ops@openathena.ai +
 Slack); `severity=warning` routes to `ops-slack` (Slack only). Every rule sets
 `noDataState: Alerting` and `execErrState: Alerting`, and the alert endpoints return
 explicit zeros when healthy, so silence anywhere in the pipeline pages rather than

--- a/infra/grafana/dashboards/k8s.json
+++ b/infra/grafana/dashboards/k8s.json
@@ -380,6 +380,126 @@
       ]
     },
     {
+      "id": 8,
+      "type": "table",
+      "title": "Stuck terminating pods",
+      "description": "Pods still present at least two minutes after metadata.deletionTimestamp. Only node_cleanup rows that request GPUs page; finalizer, terminal, unbound, and invalid_timestamp rows need API/controller cleanup rather than an automatic node reboot.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "k8s"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "overdue_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "deletion_grace_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/termination_candidates",
+          "url_options": {
+            "method": "GET"
+          },
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "namespace",
+              "text": "namespace",
+              "type": "string"
+            },
+            {
+              "selector": "pod",
+              "text": "pod",
+              "type": "string"
+            },
+            {
+              "selector": "node",
+              "text": "node",
+              "type": "string"
+            },
+            {
+              "selector": "phase",
+              "text": "phase",
+              "type": "string"
+            },
+            {
+              "selector": "classification",
+              "text": "classification",
+              "type": "string"
+            },
+            {
+              "selector": "gpu_count",
+              "text": "gpu_count",
+              "type": "number"
+            },
+            {
+              "selector": "task_attempt",
+              "text": "task_attempt",
+              "type": "string"
+            },
+            {
+              "selector": "priority_class",
+              "text": "priority_class",
+              "type": "string"
+            },
+            {
+              "selector": "overdue_seconds",
+              "text": "overdue_seconds",
+              "type": "number"
+            },
+            {
+              "selector": "deletion_grace_seconds",
+              "text": "deletion_grace_seconds",
+              "type": "number"
+            },
+            {
+              "selector": "finalizers",
+              "text": "finalizers",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": 5,
       "type": "table",
       "title": "Crash-looping pods",
@@ -392,7 +512,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 15
+        "y": 23
       },
       "fieldConfig": {
         "defaults": {},
@@ -462,7 +582,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 15
+        "y": 23
       },
       "fieldConfig": {
         "defaults": {},
@@ -540,7 +660,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 31
       },
       "fieldConfig": {
         "defaults": {},

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -183,7 +183,7 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: "{{ $labels.cluster }}: GPU pod termination stuck on {{ $labels.node }} ({{ $labels.pods }})"
+          summary: "{{ $labels.cluster }}: GPU pod termination stuck on {{ $labels.node }}"
           runbook_url: https://github.com/marin-community/marin/blob/main/.agents/skills/recover-stuck-k8s-pod/SKILL.md
         data:
           - refId: A
@@ -201,9 +201,6 @@ groups:
               columns:
                 - { selector: cluster, text: cluster, type: string }
                 - { selector: node, text: node, type: string }
-                - { selector: pods, text: pods, type: string }
-                - { selector: task_attempts, text: task_attempts, type: string }
-                - { selector: gpus, text: gpus, type: string }
                 - { selector: value, text: value, type: number }
           - refId: C
             datasourceUid: __expr__

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -174,6 +174,47 @@ groups:
               conditions:
                 - evaluator: { type: gt, params: [0] }
 
+      - uid: k8s-gpu-pod-termination-stuck
+        title: GpuPodTerminationStuck
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.cluster }}: GPU pod termination stuck on {{ $labels.node }} ({{ $labels.pods }})"
+          runbook_url: https://github.com/marin-community/marin/blob/main/.agents/skills/recover-stuck-k8s-pod/SKILL.md
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: k8s
+            model:
+              refId: A
+              datasource: { type: yesoreyeram-infinity-datasource, uid: k8s }
+              type: json
+              source: url
+              parser: backend
+              format: table
+              url: /alerts/stuck_gpu_pods
+              url_options: { method: GET }
+              columns:
+                - { selector: cluster, text: cluster, type: string }
+                - { selector: node, text: node, type: string }
+                - { selector: pods, text: pods, type: string }
+                - { selector: task_attempts, text: task_attempts, type: string }
+                - { selector: gpus, text: gpus, type: string }
+                - { selector: value, text: value, type: number }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
   # The GCE controllers are not in K8S_CLUSTERS; their liveness comes from the
   # existing per-cluster iris datasources. The health row always exists (the
   # bridge answers reachable=false rather than erroring), and `up` is its 0/1

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -618,27 +618,24 @@ class K8sFleet:
     def alert_stuck_gpu_pods(self, candidates: Sequence[TerminatingPodResult] | None = None) -> list[dict]:
         """Return node-grouped counts plus zero rows where no qualifying evidence exists."""
         rows = list(candidates) if candidates is not None else self.termination_candidates()
-        by_node: dict[tuple[str, str], list[TerminatingPod]] = {}
+        by_node: dict[tuple[str, str], int] = {}
         for row in rows:
             if not isinstance(row, TerminatingPod):
                 continue
             if row.classification != TerminationClass.NODE_CLEANUP or row.gpu_count <= 0:
                 continue
             key = (row.cluster, row.node)
-            by_node.setdefault(key, []).append(row)
+            by_node[key] = by_node.get(key, 0) + 1
 
         alert_rows = []
         affected_clusters = set()
-        for (cluster, node), node_rows in sorted(by_node.items()):
+        for (cluster, node), count in sorted(by_node.items()):
             affected_clusters.add(cluster)
             alert_rows.append(
                 {
                     "cluster": cluster,
                     "node": node,
-                    "pods": ",".join(sorted(row.pod for row in node_rows)),
-                    "task_attempts": ",".join(sorted(row.task_attempt for row in node_rows if row.task_attempt)),
-                    "gpus": str(sum(row.gpu_count for row in node_rows)),
-                    "value": len(node_rows),
+                    "value": count,
                 }
             )
         for source in self._sources:
@@ -647,9 +644,6 @@ class K8sFleet:
                     {
                         "cluster": source.target.name,
                         "node": "",
-                        "pods": "",
-                        "task_attempts": "",
-                        "gpus": "0",
                         "value": 0,
                     }
                 )

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -8,7 +8,7 @@ GETs and the CW read-role bearer token — no kubernetes client. K8sFleet fans a
 query out across every cluster and stamps a ``cluster`` column, so one response
 covers the fleet.
 
-The pod-level scans (crashloops, pending) cover every namespace except the
+The pod-level scans (crashloops, pending, termination candidates) cover every namespace except the
 provider-managed prefixes in PROVIDER_NAMESPACE_PREFIXES: CoreWeave's per-node
 daemons are thousands of pods of someone else's infrastructure, while the
 namespaces we operate hold about a hundred.
@@ -29,8 +29,10 @@ import logging
 import time
 from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
+from typing import TypeVar
 
 import httpx
 from config import (
@@ -51,6 +53,14 @@ _MAX_RETRY_AFTER = 3.0
 _EVENT_LIMIT = 100
 _EVENT_MESSAGE_LIMIT = 200
 
+# A pod is a stuck-termination candidate only after its API deletion deadline has
+# been expired for this long. Grafana holds the alert for another five minutes.
+STUCK_TERMINATION_OVERDUE_SECONDS = 120
+
+_GPU_RESOURCE = "nvidia.com/gpu"
+_IRIS_TASK_ID_ENV = "IRIS_TASK_ID"
+_TERMINAL_POD_PHASES = frozenset(("Succeeded", "Failed"))
+
 # Container waiting reasons the crashloop rows report.
 BACKOFF_REASONS = ("CrashLoopBackOff", "ImagePullBackOff")
 
@@ -69,6 +79,50 @@ class K8sErrorClass(StrEnum):
     HTTP = "http"  # any other non-200
 
 
+class TerminationClass(StrEnum):
+    """Operator action implied by an overdue terminating pod."""
+
+    INVALID_TIMESTAMP = "invalid_timestamp"
+    FINALIZER = "finalizer"
+    TERMINAL = "terminal"
+    UNBOUND = "unbound"
+    NODE_CLEANUP = "node_cleanup"
+
+
+@dataclass(frozen=True)
+class TerminatingPod:
+    """A pod termination record that requires operator visibility."""
+
+    cluster: str
+    namespace: str
+    pod: str
+    node: str
+    phase: str
+    deletion_timestamp: str
+    deletion_grace_seconds: int | None
+    overdue_seconds: int | None
+    gpu_count: int
+    task_attempt: str
+    task_label: str
+    job_label: str
+    priority_class: str
+    finalizers: str
+    classification: TerminationClass
+
+
+@dataclass(frozen=True)
+class TerminatingPodError:
+    """A cluster query failure returned beside healthy clusters' pod records."""
+
+    cluster: str
+    error_class: str
+    error: str
+
+
+TerminatingPodResult = TerminatingPod | TerminatingPodError
+_Row = TypeVar("_Row")
+
+
 class K8sError(Exception):
     """A per-cluster query failure, carrying its class for error rows."""
 
@@ -82,6 +136,14 @@ def _age_seconds(timestamp: str | None) -> int | None:
         return None
     created = datetime.fromisoformat(timestamp)
     return max(int((datetime.now(UTC) - created).total_seconds()), 0)
+
+
+def _deletion_overdue_seconds(timestamp: str) -> int | None:
+    """Return age past a deletion deadline, or None for an invalid deadline."""
+    try:
+        return _age_seconds(timestamp)
+    except (TypeError, ValueError):
+        return None
 
 
 def _epoch_ms(timestamp: str | None) -> int | None:
@@ -238,10 +300,11 @@ class K8sSource:
         names = [(ns.get("metadata") or {}).get("name") or "" for ns in namespaces]
         return [name for name in names if name and not name.startswith(PROVIDER_NAMESPACE_PREFIXES)]
 
-    def _scan_pods(self, field_selector: str) -> list[dict]:
+    def _scan_pods(self, field_selector: str | None) -> list[dict]:
         pods: list[dict] = []
+        params = {"fieldSelector": field_selector} if field_selector else None
         for namespace in self._scanned_namespaces():
-            pods.extend(self._list(f"/api/v1/namespaces/{namespace}/pods", {"fieldSelector": field_selector}))
+            pods.extend(self._list(f"/api/v1/namespaces/{namespace}/pods", params))
         return pods
 
     def crashloops(self) -> list[dict]:
@@ -284,6 +347,47 @@ class K8sSource:
                 }
             )
         rows.sort(key=lambda row: row["age_seconds"] or 0, reverse=True)
+        return rows
+
+    def termination_candidates(self) -> list[TerminatingPod]:
+        """Return overdue terminating pods and invalid deletion timestamps.
+
+        Raises:
+            ValueError: A candidate has a malformed GPU resource quantity.
+        """
+        rows = []
+        for pod in self._scan_pods(None):
+            metadata = pod.get("metadata") or {}
+            deletion_timestamp = metadata.get("deletionTimestamp")
+            if not deletion_timestamp:
+                continue
+            overdue_seconds = _deletion_overdue_seconds(deletion_timestamp)
+            if overdue_seconds is not None and overdue_seconds < STUCK_TERMINATION_OVERDUE_SECONDS:
+                continue
+            spec = pod.get("spec") or {}
+            status = pod.get("status") or {}
+            labels = metadata.get("labels") or {}
+            finalizers = sorted(metadata.get("finalizers") or [])
+            rows.append(
+                TerminatingPod(
+                    cluster=self._target.name,
+                    namespace=metadata.get("namespace") or "",
+                    pod=metadata.get("name") or "",
+                    node=spec.get("nodeName") or "",
+                    phase=status.get("phase") or "",
+                    deletion_timestamp=deletion_timestamp,
+                    deletion_grace_seconds=metadata.get("deletionGracePeriodSeconds"),
+                    overdue_seconds=overdue_seconds,
+                    gpu_count=_pod_gpu_count(pod),
+                    task_attempt=_iris_task_attempt(pod),
+                    task_label=labels.get("iris.task_id") or "",
+                    job_label=labels.get("iris.job_id") or "",
+                    priority_class=spec.get("priorityClassName") or "",
+                    finalizers=",".join(finalizers),
+                    classification=_termination_class(pod, overdue_seconds),
+                )
+            )
+        rows.sort(key=lambda row: row.overdue_seconds if row.overdue_seconds is not None else -1, reverse=True)
         return rows
 
     def kueue(self) -> list[dict]:
@@ -347,6 +451,57 @@ def _pod_scope(metadata: dict) -> str:
     return SCOPE_WORKLOAD
 
 
+def _resource_gpu_count(resources: dict | None) -> int:
+    resources = resources or {}
+    values = []
+    for field in ("requests", "limits"):
+        raw = (resources.get(field) or {}).get(_GPU_RESOURCE, 0)
+        try:
+            values.append(int(raw))
+        except (TypeError, ValueError) as err:
+            raise ValueError(f"invalid {_GPU_RESOURCE} {field} quantity: {raw!r}") from err
+    return max(values, default=0)
+
+
+def _pod_gpu_count(pod: dict) -> int:
+    """Return the effective GPU request Kubernetes uses to schedule the pod."""
+    spec = pod.get("spec") or {}
+    app_total = sum(_resource_gpu_count(c.get("resources")) for c in spec.get("containers") or [])
+    restartable_total = 0
+    init_peak = 0
+    for container in spec.get("initContainers") or []:
+        count = _resource_gpu_count(container.get("resources"))
+        if container.get("restartPolicy") == "Always":
+            restartable_total += count
+        else:
+            init_peak = max(init_peak, restartable_total + count)
+    return max(app_total + restartable_total, init_peak)
+
+
+def _iris_task_attempt(pod: dict) -> str:
+    for container in (pod.get("spec") or {}).get("containers") or []:
+        if container.get("name") != "task":
+            continue
+        for item in container.get("env") or []:
+            if item.get("name") == _IRIS_TASK_ID_ENV:
+                return item.get("value") or ""
+    return ""
+
+
+def _termination_class(pod: dict, overdue_seconds: int | None) -> TerminationClass:
+    metadata = pod.get("metadata") or {}
+    if overdue_seconds is None:
+        return TerminationClass.INVALID_TIMESTAMP
+    if metadata.get("finalizers"):
+        return TerminationClass.FINALIZER
+    status = pod.get("status") or {}
+    if status.get("phase") in _TERMINAL_POD_PHASES:
+        return TerminationClass.TERMINAL
+    if not (pod.get("spec") or {}).get("nodeName"):
+        return TerminationClass.UNBOUND
+    return TerminationClass.NODE_CLEANUP
+
+
 class K8sFleet:
     """Fans one query out across every cluster, one thread each, stamping ``cluster``."""
 
@@ -354,21 +509,33 @@ class K8sFleet:
         self._sources = tuple(sources)
         self._executor = ThreadPoolExecutor(max_workers=max(len(self._sources), 1), thread_name_prefix="k8s")
 
+    def _collect(
+        self,
+        fn: Callable[[K8sSource], list[_Row]],
+        on_error: Callable[[K8sSource, K8sError], list[_Row]],
+    ) -> list[_Row]:
+        futures = [(source, self._executor.submit(fn, source)) for source in self._sources]
+        rows: list[_Row] = []
+        for source, future in futures:
+            try:
+                rows.extend(future.result())
+            except K8sError as err:
+                logger.warning("k8s query failed for %s: %s", source.target.name, err)
+                rows.extend(on_error(source, err))
+        return rows
+
     def _fan_out(
         self,
         fn: Callable[[K8sSource], list[dict]],
         on_error: Callable[[K8sError], list[dict]],
     ) -> list[dict]:
-        futures = [(source, self._executor.submit(fn, source)) for source in self._sources]
-        rows: list[dict] = []
-        for source, future in futures:
-            try:
-                cluster_rows = future.result()
-            except K8sError as err:
-                logger.warning("k8s query failed for %s: %s", source.target.name, err)
-                cluster_rows = on_error(err)
-            rows.extend({"cluster": source.target.name, **row} for row in cluster_rows)
-        return rows
+        def stamped(source: K8sSource) -> list[dict]:
+            return [{"cluster": source.target.name, **row} for row in fn(source)]
+
+        def stamped_error(source: K8sSource, err: K8sError) -> list[dict]:
+            return [{"cluster": source.target.name, **row} for row in on_error(err)]
+
+        return self._collect(stamped, stamped_error)
 
     @staticmethod
     def _error_row(err: K8sError) -> list[dict]:
@@ -382,6 +549,12 @@ class K8sFleet:
 
     def pending(self) -> list[dict]:
         return self._fan_out(lambda s: s.pending(), self._error_row)
+
+    def termination_candidates(self) -> list[TerminatingPodResult]:
+        return self._collect(
+            lambda source: source.termination_candidates(),
+            lambda source, err: [TerminatingPodError(source.target.name, str(err.error_class), str(err))],
+        )
 
     def kueue(self) -> list[dict]:
         return self._fan_out(lambda s: s.kueue(), self._error_row)
@@ -441,3 +614,43 @@ class K8sFleet:
             return rows
 
         return self._fan_out(gaps, lambda err: [{"component": c.key, "value": 0} for c in WATCHED_COMPONENTS])
+
+    def alert_stuck_gpu_pods(self, candidates: Sequence[TerminatingPodResult] | None = None) -> list[dict]:
+        """Return node-grouped counts plus zero rows where no qualifying evidence exists."""
+        rows = list(candidates) if candidates is not None else self.termination_candidates()
+        by_node: dict[tuple[str, str], list[TerminatingPod]] = {}
+        for row in rows:
+            if not isinstance(row, TerminatingPod):
+                continue
+            if row.classification != TerminationClass.NODE_CLEANUP or row.gpu_count <= 0:
+                continue
+            key = (row.cluster, row.node)
+            by_node.setdefault(key, []).append(row)
+
+        alert_rows = []
+        affected_clusters = set()
+        for (cluster, node), node_rows in sorted(by_node.items()):
+            affected_clusters.add(cluster)
+            alert_rows.append(
+                {
+                    "cluster": cluster,
+                    "node": node,
+                    "pods": ",".join(sorted(row.pod for row in node_rows)),
+                    "task_attempts": ",".join(sorted(row.task_attempt for row in node_rows if row.task_attempt)),
+                    "gpus": str(sum(row.gpu_count for row in node_rows)),
+                    "value": len(node_rows),
+                }
+            )
+        for source in self._sources:
+            if source.target.name not in affected_clusters:
+                alert_rows.append(
+                    {
+                        "cluster": source.target.name,
+                        "node": "",
+                        "pods": "",
+                        "task_attempts": "",
+                        "gpus": "0",
+                        "value": 0,
+                    }
+                )
+        return alert_rows

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -30,7 +30,7 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /k8s/alerts/crashloops?scope=            alert rows: cluster, scope, value(count)
     GET /k8s/alerts/webhook_ready                alert rows: cluster, webhook, value(ready count)
     GET /k8s/alerts/degraded                     alert rows: cluster, component, value(desired-ready)
-    GET /k8s/alerts/stuck_gpu_pods                alert rows: cluster, node, pod labels, value(count)
+    GET /k8s/alerts/stuck_gpu_pods                alert rows: cluster, node, value(count)
     GET /health                                  bridge liveness
 
 A dead controller or GitHub returns 5xx (not empty rows), and the failure is not

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -22,6 +22,7 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /k8s/control_plane                       watched components + webhook endpoints, all clusters
     GET /k8s/crashloops                          containers in backoff waiting states
     GET /k8s/pending                             Pending / SchedulingGated pods with age
+    GET /k8s/termination_candidates             pods overdue past their deletion deadline
     GET /k8s/kueue                               unadmitted Kueue workloads per queue
     GET /k8s/events                              recent Warning events
     GET /k8s/health                              per-cluster API server reachability + latency
@@ -29,6 +30,7 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /k8s/alerts/crashloops?scope=            alert rows: cluster, scope, value(count)
     GET /k8s/alerts/webhook_ready                alert rows: cluster, webhook, value(ready count)
     GET /k8s/alerts/degraded                     alert rows: cluster, component, value(desired-ready)
+    GET /k8s/alerts/stuck_gpu_pods                alert rows: cluster, node, pod labels, value(count)
     GET /health                                  bridge liveness
 
 A dead controller or GitHub returns 5xx (not empty rows), and the failure is not
@@ -42,6 +44,7 @@ threadpool.
 import json
 import logging
 from collections.abc import Mapping
+from dataclasses import asdict
 from datetime import UTC, datetime
 
 import pyarrow as pa
@@ -70,6 +73,7 @@ TO_MACRO = "{{to}}"
 # it into columns under this prefix so a panel can select one as a series.
 LABELS_COLUMN = "labels"
 LABEL_PREFIX = "label_"
+_K8S_TERMINATION_CANDIDATES_CACHE_KEY = "termination_candidates"
 
 
 def _sql_timestamp(at: datetime) -> str:
@@ -312,6 +316,10 @@ def create_app(
     def k8s_pending(_: Request) -> JSONResponse:
         return k8s_endpoint("pending", k8s_fleet.pending)
 
+    def k8s_termination_candidates(_: Request) -> JSONResponse:
+        rows = k8s_cache.get_or_compute(_K8S_TERMINATION_CANDIDATES_CACHE_KEY, k8s_fleet.termination_candidates)
+        return JSONResponse([asdict(row) for row in rows])
+
     def k8s_kueue(_: Request) -> JSONResponse:
         return k8s_endpoint("kueue", k8s_fleet.kueue)
 
@@ -339,6 +347,11 @@ def create_app(
     def k8s_alerts_degraded(_: Request) -> JSONResponse:
         return k8s_endpoint("alerts_degraded", k8s_fleet.alert_degraded)
 
+    def k8s_alerts_stuck_gpu_pods(_: Request) -> JSONResponse:
+        # The dashboard and alert projection share one fleet LIST per cache TTL.
+        rows = k8s_cache.get_or_compute(_K8S_TERMINATION_CANDIDATES_CACHE_KEY, k8s_fleet.termination_candidates)
+        return JSONResponse(k8s_fleet.alert_stuck_gpu_pods(rows))
+
     def health(_: Request) -> JSONResponse:
         return JSONResponse({"status": "ok", "clusters": sorted(finelog_sources)})
 
@@ -356,6 +369,7 @@ def create_app(
             Route("/k8s/control_plane", k8s_control_plane),
             Route("/k8s/crashloops", k8s_crashloops),
             Route("/k8s/pending", k8s_pending),
+            Route("/k8s/termination_candidates", k8s_termination_candidates),
             Route("/k8s/kueue", k8s_kueue),
             Route("/k8s/events", k8s_events),
             Route("/k8s/health", k8s_health),
@@ -363,6 +377,7 @@ def create_app(
             Route("/k8s/alerts/crashloops", k8s_alerts_crashloops),
             Route("/k8s/alerts/webhook_ready", k8s_alerts_webhook_ready),
             Route("/k8s/alerts/degraded", k8s_alerts_degraded),
+            Route("/k8s/alerts/stuck_gpu_pods", k8s_alerts_stuck_gpu_pods),
         ]
     )
 

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -4,6 +4,9 @@
 """Tests for the k8s source: flattening of canned API-server JSON, pagination,
 error classification, and the fleet's always-one-row-per-cluster alert contract."""
 
+from dataclasses import asdict
+from datetime import UTC, datetime
+
 import httpx
 import pytest
 from conftest import (
@@ -22,6 +25,9 @@ from k8s_source import K8sError, K8sErrorClass, K8sFleet
 from server import create_app
 from starlette.testclient import TestClient
 
+GPU_RESOURCE = "nvidia.com/gpu"
+STALE_DELETION_TIMESTAMP = "2000-01-01T00:00:00Z"
+
 
 def _workload(name: str, queue: str, *, conditions: list | None = None, created: str = "2026-07-19T00:00:00Z") -> dict:
     return {
@@ -33,6 +39,35 @@ def _workload(name: str, queue: str, *, conditions: list | None = None, created:
 
 def _namespace(name: str) -> dict:
     return {"metadata": {"name": name}}
+
+
+def _termination_candidate(
+    name: str,
+    *,
+    node: str | None = None,
+    timestamp: str = STALE_DELETION_TIMESTAMP,
+    phase: str = "Running",
+    finalizers: list[str] | None = None,
+) -> dict:
+    manifest = pod("iris", name)
+    manifest["metadata"]["deletionTimestamp"] = timestamp
+    if finalizers:
+        manifest["metadata"]["finalizers"] = finalizers
+    manifest["spec"]["containers"] = [{"name": "task", "resources": {}}]
+    if node is not None:
+        manifest["spec"]["nodeName"] = node
+    manifest["status"]["phase"] = phase
+    return manifest
+
+
+def _with_gpu(manifest: dict, quantity: str) -> dict:
+    manifest["spec"]["containers"][0]["resources"]["limits"] = {GPU_RESOURCE: quantity}
+    return manifest
+
+
+def _with_task_attempt(manifest: dict, task_attempt: str) -> dict:
+    manifest["spec"]["containers"][0]["env"] = [{"name": "IRIS_TASK_ID", "value": task_attempt}]
+    return manifest
 
 
 # --- K8sSource --------------------------------------------------------------
@@ -214,6 +249,84 @@ def test_warning_events_flatten_newest_first():
     assert len(rows[0]["message"]) == 200
 
 
+def test_terminating_classifies_node_and_api_cleanup_cases():
+    recent = datetime.now(UTC).isoformat()
+    labels = {"iris.task_id": "sanitized.task", "iris.job_id": "sanitized.job"}
+    stuck_gpu = _with_task_attempt(
+        _with_gpu(_termination_candidate("stuck-gpu", node="node-a"), "4"), "/user/full-job/0:3"
+    )
+    stuck_gpu["metadata"].update({"deletionGracePeriodSeconds": 30, "labels": labels})
+    routes = {
+        "/api/v1/namespaces": [_namespace("iris")],
+        "/api/v1/namespaces/iris/pods": [
+            stuck_gpu,
+            _termination_candidate("finalizer", node="node-b", finalizers=["z", "a"]),
+            _termination_candidate("terminal", node="node-c", phase="Succeeded"),
+            _termination_candidate("unbound"),
+            _with_gpu(_termination_candidate("invalid", node="node-d", timestamp="not-a-time"), "1"),
+            _termination_candidate("within-threshold", node="node-e", timestamp=recent),
+        ],
+    }
+    rows = make_k8s_source(k8s_api(routes)).termination_candidates()
+    by_name = {row.pod: row for row in rows}
+
+    assert set(by_name) == {"stuck-gpu", "finalizer", "terminal", "unbound", "invalid"}
+    stuck_gpu = asdict(by_name["stuck-gpu"])
+    assert stuck_gpu.pop("cluster") == "cw-a"
+    overdue_seconds = stuck_gpu.pop("overdue_seconds")
+    assert stuck_gpu == {
+        "namespace": "iris",
+        "pod": "stuck-gpu",
+        "node": "node-a",
+        "phase": "Running",
+        "deletion_timestamp": STALE_DELETION_TIMESTAMP,
+        "deletion_grace_seconds": 30,
+        "gpu_count": 4,
+        "task_attempt": "/user/full-job/0:3",
+        "task_label": "sanitized.task",
+        "job_label": "sanitized.job",
+        "priority_class": "",
+        "finalizers": "",
+        "classification": "node_cleanup",
+    }
+    assert overdue_seconds > 0
+    assert by_name["finalizer"].classification == "finalizer"
+    assert by_name["finalizer"].finalizers == "a,z"
+    assert by_name["terminal"].classification == "terminal"
+    assert by_name["unbound"].classification == "unbound"
+    assert by_name["invalid"].classification == "invalid_timestamp"
+    assert by_name["invalid"].overdue_seconds is None
+
+
+def test_terminating_gpu_count_uses_requests_limits_and_init_peak():
+    manifest = _with_gpu(_termination_candidate("mixed-resources", node="node-a"), "2")
+    manifest["spec"]["containers"][0]["resources"]["requests"] = {GPU_RESOURCE: "1"}
+    manifest["spec"]["containers"].append({"name": "sidecar", "resources": {"requests": {GPU_RESOURCE: "1"}}})
+    manifest["spec"]["initContainers"] = [
+        {"name": "setup", "resources": {"limits": {GPU_RESOURCE: "4"}}},
+        {
+            "name": "restartable",
+            "restartPolicy": "Always",
+            "resources": {"limits": {GPU_RESOURCE: "1"}},
+        },
+    ]
+    routes = {
+        "/api/v1/namespaces": [_namespace("iris")],
+        "/api/v1/namespaces/iris/pods": [manifest],
+    }
+    (row,) = make_k8s_source(k8s_api(routes)).termination_candidates()
+    assert row.gpu_count == 4
+
+
+def test_terminating_rejects_an_invalid_gpu_quantity():
+    routes = {
+        "/api/v1/namespaces": [_namespace("iris")],
+        "/api/v1/namespaces/iris/pods": [_with_gpu(_termination_candidate("invalid-gpu", node="node-a"), "many")],
+    }
+    with pytest.raises(ValueError):
+        make_k8s_source(k8s_api(routes)).termination_candidates()
+
+
 # --- K8sFleet ---------------------------------------------------------------
 
 
@@ -251,6 +364,9 @@ def test_alert_routes_return_explicit_zeros_when_healthy():
         {"cluster": "cw-a", "component": "traefik/traefik", "value": 0},
         {"cluster": "cw-a", "component": "cert-manager/cert-manager", "value": 0},
     ]
+    assert fleet.alert_stuck_gpu_pods() == [
+        {"cluster": "cw-a", "node": "", "pods": "", "task_attempts": "", "gpus": "0", "value": 0}
+    ]
 
 
 def test_alert_routes_keep_one_row_per_cluster_when_unreachable():
@@ -263,6 +379,33 @@ def test_alert_routes_keep_one_row_per_cluster_when_unreachable():
         {"cluster": "cw-a", "webhook": "kueue-system/kueue-webhook-service", "value": 0}
     ]
     assert {row["value"] for row in fleet.alert_degraded()} == {0}
+    assert {row["value"] for row in fleet.alert_stuck_gpu_pods()} == {0}
+
+
+def test_stuck_gpu_alert_groups_only_node_cleanup_rows_by_node():
+    routes_a = healthy_k8s_routes()
+    routes_a["/api/v1/namespaces"] = [_namespace("iris")]
+    routes_a["/api/v1/namespaces/iris/pods"] = [
+        _with_task_attempt(_with_gpu(_termination_candidate("task-b", node="node-a"), "2"), "/u/job/1:2"),
+        _with_task_attempt(_with_gpu(_termination_candidate("task-a", node="node-a"), "1"), "/u/job/0:2"),
+        _with_gpu(_termination_candidate("terminal", node="node-b", phase="Failed"), "4"),
+        _with_gpu(_termination_candidate("finalizer", node="node-c", finalizers=["x"]), "4"),
+        _with_gpu(_termination_candidate("unbound"), "4"),
+        _termination_candidate("cpu-only", node="node-d"),
+    ]
+    fleet = _fleet(("cw-a", k8s_api(routes_a)), ("cw-b", k8s_api(healthy_k8s_routes())))
+    rows = fleet.alert_stuck_gpu_pods(fleet.termination_candidates())
+    assert rows == [
+        {
+            "cluster": "cw-a",
+            "node": "node-a",
+            "pods": "task-a,task-b",
+            "task_attempts": "/u/job/0:2,/u/job/1:2",
+            "gpus": "3",
+            "value": 2,
+        },
+        {"cluster": "cw-b", "node": "", "pods": "", "task_attempts": "", "gpus": "0", "value": 0},
+    ]
 
 
 def test_crashloop_alert_counts_by_scope():
@@ -288,10 +431,40 @@ def _client(fleet: K8sFleet) -> TestClient:
 
 def test_k8s_routes_serve_fleet_rows():
     client = _client(_fleet(("cw-a", k8s_api(healthy_k8s_routes()))))
-    for path in ("/k8s/control_plane", "/k8s/crashloops", "/k8s/pending", "/k8s/kueue", "/k8s/events"):
+    for path in (
+        "/k8s/control_plane",
+        "/k8s/crashloops",
+        "/k8s/pending",
+        "/k8s/kueue",
+        "/k8s/events",
+    ):
         assert client.get(path).status_code == 200
     health = client.get("/k8s/health").json()
     assert health[0]["cluster"] == "cw-a" and health[0]["reachable"] is True
+
+
+def test_stuck_termination_routes_return_classification_and_alert_projection():
+    routes = healthy_k8s_routes()
+    routes["/api/v1/namespaces"] = [_namespace("iris")]
+    routes["/api/v1/namespaces/iris/pods"] = [
+        _with_task_attempt(_with_gpu(_termination_candidate("task-0", node="gpu-node"), "4"), "/user/job/0:1")
+    ]
+    client = _client(_fleet(("cw-a", k8s_api(routes))))
+
+    (terminating,) = client.get("/k8s/termination_candidates").json()
+    assert terminating["cluster"] == "cw-a"
+    assert terminating["pod"] == "task-0"
+    assert terminating["classification"] == "node_cleanup"
+    assert client.get("/k8s/alerts/stuck_gpu_pods").json() == [
+        {
+            "cluster": "cw-a",
+            "node": "gpu-node",
+            "pods": "task-0",
+            "task_attempts": "/user/job/0:1",
+            "gpus": "4",
+            "value": 1,
+        }
+    ]
 
 
 def test_alerts_crashloops_scope_param_filters_rows():

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -364,9 +364,7 @@ def test_alert_routes_return_explicit_zeros_when_healthy():
         {"cluster": "cw-a", "component": "traefik/traefik", "value": 0},
         {"cluster": "cw-a", "component": "cert-manager/cert-manager", "value": 0},
     ]
-    assert fleet.alert_stuck_gpu_pods() == [
-        {"cluster": "cw-a", "node": "", "pods": "", "task_attempts": "", "gpus": "0", "value": 0}
-    ]
+    assert fleet.alert_stuck_gpu_pods() == [{"cluster": "cw-a", "node": "", "value": 0}]
 
 
 def test_alert_routes_keep_one_row_per_cluster_when_unreachable():
@@ -399,12 +397,9 @@ def test_stuck_gpu_alert_groups_only_node_cleanup_rows_by_node():
         {
             "cluster": "cw-a",
             "node": "node-a",
-            "pods": "task-a,task-b",
-            "task_attempts": "/u/job/0:2,/u/job/1:2",
-            "gpus": "3",
             "value": 2,
         },
-        {"cluster": "cw-b", "node": "", "pods": "", "task_attempts": "", "gpus": "0", "value": 0},
+        {"cluster": "cw-b", "node": "", "value": 0},
     ]
 
 
@@ -459,9 +454,6 @@ def test_stuck_termination_routes_return_classification_and_alert_projection():
         {
             "cluster": "cw-a",
             "node": "gpu-node",
-            "pods": "task-0",
-            "task_attempts": "/user/job/0:1",
-            "gpus": "4",
             "value": 1,
         }
     ]

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -202,6 +202,21 @@ preemption budget; `failed` is terminal with no retry.
 `-` target) and take `--dry-run`. This is the query→act bridge: select the
 targets with SQL, preview, then fire. See "Bulk actions: query → act" below.
 
+### Recovering a stuck terminating Kubernetes pod
+
+Use [the `recover-stuck-k8s-pod` skill](../../.agents/skills/recover-stuck-k8s-pod/SKILL.md)
+when a CoreWeave pod remains after its Kubernetes deletion deadline. The Grafana
+**K8s control plane** dashboard classifies overdue pods; its alert fires only for
+node-bound, nonterminal GPU pods without finalizers.
+
+The recovery order is safety-critical: record the node's existing cordon state,
+cordon it, quiesce the exact Iris attempt and every sibling workload, then use a
+CoreWeave force reboot if targeted graceful deletion still cannot stop the pod.
+Never force-delete the pod object while the old process may still be running.
+Kubernetes does not wait for kubelet confirmation, so replacement work can start
+while the old process still owns the GPU. Force-delete a stale object only after
+CoreWeave confirms the reboot completed (or process death is otherwise proven).
+
 ## Process Inspection & Profiling
 
 ```bash


### PR DESCRIPTION
Detect CoreWeave pods that remain past their Kubernetes deletion deadline and expose classified termination candidates in the Kubernetes Grafana dashboard. A warning alert selects only node-bound, nonterminal GPU pods without finalizers, groups them by node, and includes the canonical Iris attempt extracted from the task container environment. Invalid timestamps and finalizer, terminal, or unbound cleanup cases remain visible without triggering node-recovery alerts.

Add a recovery skill and Iris operations link for the cordon-first process. It treats missing logs and collective detection as supporting evidence rather than alert conditions, quiesces the exact Iris attempt before recovery, requires provider-confirmed reboot completion before force-deleting a stale pod object, and restores scheduling only after node health checks pass.