### PR TITLE
[iac] Use WIF and KMS for service deploys

### DIFF
--- a/.github/actions/pulumi-deploy/action.yaml
+++ b/.github/actions/pulumi-deploy/action.yaml
@@ -8,9 +8,12 @@ inputs:
   work-dir:
     description: "Directory holding the Pulumi.yaml (e.g. infra/grafana)."
     required: true
-  gcp-credentials:
-    description: "Service-account key JSON for the deploy account."
+  service-account:
+    description: "GCP service account impersonated through Workload Identity Federation."
     required: true
+  workload-identity-provider:
+    description: "GCP workload identity provider resource name."
+    default: "projects/748532799086/locations/global/workloadIdentityPools/github-pool/providers/github-oidc"
   gcp-project-id:
     description: "GCP project id."
     required: true
@@ -27,21 +30,18 @@ runs:
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v3
       with:
-        credentials_json: ${{ inputs.gcp-credentials }}
+        project_id: ${{ inputs.gcp-project-id }}
+        workload_identity_provider: ${{ inputs.workload-identity-provider }}
+        service_account: ${{ inputs.service-account }}
 
     - name: Set up Google Cloud SDK
       uses: google-github-actions/setup-gcloud@v3
       with:
         project_id: ${{ inputs.gcp-project-id }}
 
-    - name: Configure Pulumi backend and registry auth
+    - name: Configure registry auth
       shell: bash
-      run: |
-        passphrase="$(gcloud secrets versions access latest \
-          --secret=pulumi-iac-passphrase --project=hai-gcp-models)"
-        echo "::add-mask::$passphrase"
-        echo "PULUMI_CONFIG_PASSPHRASE=$passphrase" >> "$GITHUB_ENV"
-        gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+      run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v7

--- a/.github/workflows/ops-ducky.yaml
+++ b/.github/workflows/ops-ducky.yaml
@@ -32,8 +32,12 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -52,8 +56,9 @@ jobs:
         with:
           stack: ducky-marin
           work-dir: infra/ducky
-          gcp-credentials: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
-          gcp-project-id: ${{ secrets.GCP_PROJECT_ID }}
+          service-account: iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com
+          gcp-project-id: hai-gcp-models
           # The program imports ducky + iris, so sync the whole workspace.
           uv-sync-args: "--all-packages --extra deploy --frozen"
-          config-map: ${{ inputs.deploy_generation && format('{{"ducky:deploy_generation": {{"value": "{0}"}}}}', inputs.deploy_generation) || '' }}
+          config-map: >-
+            ${{ inputs.deploy_generation && format('{{"ducky:deploy_generation": {{"value": "{0}"}}}}', inputs.deploy_generation) || '' }}

--- a/.github/workflows/ops-grafana.yaml
+++ b/.github/workflows/ops-grafana.yaml
@@ -38,9 +38,12 @@ jobs:
 
   deploy:
     needs: test
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
     concurrency:
       group: marin-grafana-deploy
       cancel-in-progress: false
@@ -53,5 +56,5 @@ jobs:
         with:
           stack: marin-grafana
           work-dir: infra/grafana
-          gcp-credentials: ${{ secrets.MARIN_CD_CLOUD_RUN_SA_KEY }}
-          gcp-project-id: ${{ secrets.GCP_PROJECT_ID }}
+          service-account: marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com
+          gcp-project-id: hai-gcp-models

--- a/infra/cloudsql/Pulumi.marin-cloudsql.yaml
+++ b/infra/cloudsql/Pulumi.marin-cloudsql.yaml
@@ -1,1 +1,2 @@
-encryptionsalt: v1:uNRpnaR/2DY=:v1:15putJq1VQi9MCER:PK9QNpcru7nqSbaxOCq6bY+cOS5DnA==
+secretsprovider: gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
+encryptedkey: CiQAKk3j6YA/XAGlhj7JJNRafiajGAk+3H3kRAnSH7XVr2O6LzESSQCdtF6iwZ8tr2HVyOhyHQ7eteEamJqBGzZOorPzjIUprg6+/dntFzIo0iSTzyK0JO5xALvdLaBQOG/dVii4gzMk811tAFBhIvY=

--- a/infra/cloudsql/Pulumi.yaml
+++ b/infra/cloudsql/Pulumi.yaml
@@ -10,4 +10,4 @@ description: Shared Cloud SQL (Postgres) metadata instance + eval-records bucket
 # State backend and secrets provider come from the operator/CI environment, shared with
 # infra/iac (see README.md):
 #   pulumi login gs://marin-iac-state
-#   PULUMI_CONFIG_PASSPHRASE from Secret Manager (pulumi-iac-passphrase)
+# The production stack records the shared GCP KMS provider in Pulumi.marin-cloudsql.yaml.

--- a/infra/cloudsql/Pulumi.yaml
+++ b/infra/cloudsql/Pulumi.yaml
@@ -7,7 +7,7 @@ runtime:
   options:
     virtualenv: ../../.venv
 description: Shared Cloud SQL (Postgres) metadata instance + eval-records bucket.
-# State backend and secrets provider come from the operator/CI environment, shared with
-# infra/iac (see README.md):
+# The state backend is selected by the operator/CI environment and shared with infra/iac
+# (see README.md):
 #   pulumi login gs://marin-iac-state
-# The production stack records the shared GCP KMS provider in Pulumi.marin-cloudsql.yaml.
+# Pulumi.marin-cloudsql.yaml records the production stack's shared GCP KMS provider.

--- a/infra/cloudsql/README.md
+++ b/infra/cloudsql/README.md
@@ -21,13 +21,16 @@ uv sync --all-packages --extra deploy                     # once: iac + Pulumi p
 
 cd infra/cloudsql
 pulumi login gs://marin-iac-state
-export PULUMI_CONFIG_PASSPHRASE="$(gcloud secrets versions access latest \
-  --secret=pulumi-iac-passphrase --project=hai-gcp-models)"
-pulumi stack select marin-cloudsql                        # first time: pulumi stack init marin-cloudsql
+pulumi stack select marin-cloudsql
 
 pulumi preview                                            # plan; then, once it looks right:
 pulumi up
 ```
+
+The stack uses the shared `marin-iac-key` KMS secrets provider. The operator needs
+`roles/cloudkms.cryptoKeyEncrypterDecrypter` on that key; no passphrase is used. Grafana reads
+this stack through a `StackReference`, so both stacks must remain on providers its deploy
+identity can decrypt.
 
 `pulumi up` creates the instance, the `grafana` and `evals` databases, the
 `cloudsql-grafana-password` and `cloudsql-evals-password` secret shells, and the

--- a/infra/ducky/Pulumi.ducky-marin.yaml
+++ b/infra/ducky/Pulumi.ducky-marin.yaml
@@ -31,3 +31,5 @@ config:
     DUCKY_R2_ACCESS_KEY: gcp-secret://projects/hai-gcp-models/secrets/marin-r2-access-key-id/versions/1
     DUCKY_R2_SECRET_KEY: gcp-secret://projects/hai-gcp-models/secrets/marin-r2-secret-key/versions/1
     DUCKY_CW_SECRET_KEY: gcp-secret://projects/hai-gcp-models/secrets/ducky-cw-secret-key/versions/1
+secretsprovider: gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
+encryptedkey: CiQAKk3j6aRDsYQ2FS3VJ7N/qENL4tQrvNlhqlCaoVXini2vOpQSSACdtF6iP6ajZwMv19he+MWpHMqfWQ1fP3JPQh2oux4p+QxrtbKeTwhC5bKFZWhFl/2ByVgcBSYdqcixKp19YM17xuE31qiiSQ==

--- a/infra/ducky/Pulumi.yaml
+++ b/infra/ducky/Pulumi.yaml
@@ -11,4 +11,4 @@ description: ducky (ad-hoc DuckDB SQL service) as an always-on Iris job.
 # State backend and secrets provider come from the operator/CI environment, shared with
 # infra/iac (see infra/iac/README.md):
 #   pulumi login gs://marin-iac-state
-#   PULUMI_CONFIG_PASSPHRASE from Secret Manager (pulumi-iac-passphrase)
+# The production stack records the shared GCP KMS provider in Pulumi.ducky-marin.yaml.

--- a/infra/ducky/Pulumi.yaml
+++ b/infra/ducky/Pulumi.yaml
@@ -8,7 +8,7 @@ runtime:
   options:
     virtualenv: ../../.venv
 description: ducky (ad-hoc DuckDB SQL service) as an always-on Iris job.
-# State backend and secrets provider come from the operator/CI environment, shared with
-# infra/iac (see infra/iac/README.md):
+# The state backend is selected by the operator/CI environment and shared with infra/iac
+# (see infra/iac/README.md):
 #   pulumi login gs://marin-iac-state
-# The production stack records the shared GCP KMS provider in Pulumi.ducky-marin.yaml.
+# Pulumi.ducky-marin.yaml records the production stack's shared GCP KMS provider.

--- a/infra/ducky/__main__.py
+++ b/infra/ducky/__main__.py
@@ -14,7 +14,7 @@ The Vue dashboard is built by the deploy itself (``build_commands`` runs on ever
 needs node/npm on the deploying machine.
 
 Runs on the shared repo venv; ``uv sync --all-packages --extra deploy`` first. See
-infra/iac/README.md for the state backend and passphrase.
+infra/iac/README.md for the state backend and KMS provider.
 """
 
 import pulumi

--- a/infra/grafana/Pulumi.marin-grafana.yaml
+++ b/infra/grafana/Pulumi.marin-grafana.yaml
@@ -13,4 +13,5 @@ config:
   # in the oa.dev Cloudflare zone; unset custom_domain to serve only the run.app URL.
   marin-grafana:custom_domain: grafana.oa.dev
   marin-grafana:dns_zone_id: 169959d6aafcbfd77764b8efafa3a509
-encryptionsalt: v1:l4cpXo+O0AQ=:v1:eyZFohyodD1XPLAl:MQudWu5IcpxOK62NyqAUU5cCP8FYBw==
+secretsprovider: gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
+encryptedkey: CiQAKk3j6Q+ANb/lWOlKPlnYfjnVwqsddavq2mCxtpbL2qM4LDkSSQCdtF6i23aOY/4tztuXbQxjEf7zLiHzOSRS37IKAQ0lwPtGPtsU+eHwrNMTw6rqY4wLRoKzPpdTOWDtzYkIgSixmuEPz14nxCE=

--- a/infra/grafana/Pulumi.yaml
+++ b/infra/grafana/Pulumi.yaml
@@ -10,4 +10,4 @@ description: Grafana + the finelog bridge as an IAP-gated Cloud Run service.
 # State backend and secrets provider come from the operator/CI environment, shared with
 # infra/iac (see README.md):
 #   pulumi login gs://marin-iac-state
-#   PULUMI_CONFIG_PASSPHRASE from Secret Manager (pulumi-iac-passphrase)
+# The production stack records the shared GCP KMS provider in Pulumi.marin-grafana.yaml.

--- a/infra/grafana/Pulumi.yaml
+++ b/infra/grafana/Pulumi.yaml
@@ -7,7 +7,7 @@ runtime:
   options:
     virtualenv: ../../.venv
 description: Grafana + the finelog bridge as an IAP-gated Cloud Run service.
-# State backend and secrets provider come from the operator/CI environment, shared with
-# infra/iac (see README.md):
+# The state backend is selected by the operator/CI environment and shared with infra/iac
+# (see README.md):
 #   pulumi login gs://marin-iac-state
-# The production stack records the shared GCP KMS provider in Pulumi.marin-grafana.yaml.
+# Pulumi.marin-grafana.yaml records the production stack's shared GCP KMS provider.

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -213,13 +213,11 @@ gcloud auth configure-docker us-central1-docker.pkg.dev   # once: let buildx pus
 
 cd infra/grafana
 pulumi login gs://marin-iac-state
-export PULUMI_CONFIG_PASSPHRASE="$(gcloud secrets versions access latest \
-  --secret=pulumi-iac-passphrase --project=hai-gcp-models)"
 # The grafana.oa.dev DNS record lives in the oa.dev Cloudflare zone; the provider
 # reads this token from the environment.
 export CLOUDFLARE_API_TOKEN="$(gcloud secrets versions access latest \
   --secret=cloudflare-oa-dns-token --project=hai-gcp-models)"
-pulumi stack select marin-grafana                         # first time: pulumi stack init marin-grafana
+pulumi stack select marin-grafana
 
 # Who gets in — a bare email, a *@domain wildcard, or a qualified IAM member. Editing this
 # and re-running updates only the grant, never the service.
@@ -228,6 +226,9 @@ pulumi config set --path 'viewers[0]' you@example.com
 pulumi preview                                            # plan; then, once it looks right:
 pulumi up
 ```
+
+The stack uses the shared `marin-iac-key` KMS secrets provider. The operator needs
+`roles/cloudkms.cryptoKeyEncrypterDecrypter` on that key; no passphrase is used.
 
 `pulumi up` builds the Dockerfile with buildx, pushes it digest-pinned to Artifact
 Registry, and rolls the service to that digest. `min` and `max` instances are both 1: one

--- a/infra/iac/README.md
+++ b/infra/iac/README.md
@@ -165,10 +165,10 @@ The shared backend is a GCS bucket + a GCP KMS secrets provider, both in `hai-gc
 - **State bucket** `gs://marin-iac-state` (us-central1, uniform bucket-level access, versioned).
 - **Secrets provider: a GCP KMS key**,
 `gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key`.
-Unlike a passphrase, KMS access is asymmetric: CI holds only
-`roles/cloudkms.cryptoKeyDecrypter` (can decrypt to compute a preview diff, cannot write new
-secrets), operators hold `roles/cloudkms.cryptoKeyEncrypterDecrypter` (can `pulumi up`) — see
-`spec.md §9`. No `PULUMI_CONFIG_PASSPHRASE` is set against this backend; decryption is
+Unlike a passphrase, KMS access is asymmetric: preview-only CI holds
+`roles/cloudkms.cryptoKeyDecrypter`, while deployment workflows and operators that run
+`pulumi up` hold `roles/cloudkms.cryptoKeyEncrypterDecrypter` — see `spec.md §9` and
+[`infra/permissions`](../permissions/README.md). No `PULUMI_CONFIG_PASSPHRASE` is set against this backend; decryption is
 authorized by each caller's own GCP credentials (`gcloud auth application-default login`
 locally, WIF in CI), so IAM on the key is the only access control. Each stack's
 `secretsprovider` URI is recorded in its committed `Pulumi.<stack>.yaml` at `stack init`.

--- a/infra/iac/src/iac/gcp/permissions.py
+++ b/infra/iac/src/iac/gcp/permissions.py
@@ -1,0 +1,126 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Additive GCP permissions for keyless GitHub service deployments."""
+
+from dataclasses import dataclass
+
+import pulumi
+import pulumi_gcp as gcp
+
+WORKLOAD_IDENTITY_USER = "roles/iam.workloadIdentityUser"
+STATE_WRITER = "roles/storage.objectAdmin"
+KMS_ENCRYPTER_DECRYPTER = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+SERVICE_ACCOUNT_TOKEN_CREATOR = "roles/iam.serviceAccountTokenCreator"
+
+
+@dataclass(frozen=True)
+class GcpDeployPermissionsArgs:
+    project: str
+    project_number: str
+    workload_identity_pool: str
+    github_subject: str
+    state_bucket: str
+    kms_location: str
+    kms_key_ring: str
+    kms_key: str
+    service_accounts: tuple[str, ...]
+    id_token_service_accounts: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class GcpDeployPermissionSet:
+    account_id: str
+    service_account_id: str
+    service_account_member: str
+    github_principal: str
+    state_bucket: str
+    crypto_key_id: str
+    mint_id_tokens: bool
+
+
+def _account_id(project: str, email: str) -> str:
+    suffix = f"@{project}.iam.gserviceaccount.com"
+    if not email.endswith(suffix):
+        raise ValueError(f"service account {email!r} is not in project {project!r}")
+    return email.removesuffix(suffix)
+
+
+def deploy_permission_sets(args: GcpDeployPermissionsArgs) -> tuple[GcpDeployPermissionSet, ...]:
+    """Resolve stable IAM members and resource IDs for each deployment account."""
+    unknown_id_token_accounts = args.id_token_service_accounts - set(args.service_accounts)
+    if unknown_id_token_accounts:
+        raise ValueError(
+            f"id_token_service_accounts contains undeclared deploy accounts: {sorted(unknown_id_token_accounts)!r}"
+        )
+    github_principal = (
+        f"principal://iam.googleapis.com/projects/{args.project_number}/locations/global/"
+        f"workloadIdentityPools/{args.workload_identity_pool}/subject/{args.github_subject}"
+    )
+    crypto_key_id = (
+        f"projects/{args.project}/locations/{args.kms_location}/keyRings/{args.kms_key_ring}/"
+        f"cryptoKeys/{args.kms_key}"
+    )
+    return tuple(
+        GcpDeployPermissionSet(
+            account_id=_account_id(args.project, email),
+            service_account_id=f"projects/{args.project}/serviceAccounts/{email}",
+            service_account_member=f"serviceAccount:{email}",
+            github_principal=github_principal,
+            state_bucket=args.state_bucket,
+            crypto_key_id=crypto_key_id,
+            mint_id_tokens=email in args.id_token_service_accounts,
+        )
+        for email in args.service_accounts
+    )
+
+
+class GcpDeployPermissions(pulumi.ComponentResource):
+    """Grant main-branch GitHub workflows access to deploy through existing accounts.
+
+    The component owns only non-authoritative IAM members. The service accounts, workload
+    identity pool/provider, state bucket, and KMS key are existing shared resources.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        args: GcpDeployPermissionsArgs,
+        *,
+        gcp_provider: pulumi.ProviderResource,
+        opts: pulumi.ResourceOptions | None = None,
+    ) -> None:
+        super().__init__("marin:gcp:GcpDeployPermissions", name, None, opts)
+        child = pulumi.ResourceOptions(parent=self, provider=gcp_provider, protect=True)
+        for permission_set in deploy_permission_sets(args):
+            gcp.serviceaccount.IAMMember(
+                f"{permission_set.account_id}-github-main",
+                service_account_id=permission_set.service_account_id,
+                role=WORKLOAD_IDENTITY_USER,
+                member=permission_set.github_principal,
+                opts=child,
+            )
+            if permission_set.mint_id_tokens:
+                gcp.serviceaccount.IAMMember(
+                    f"{permission_set.account_id}-github-main-id-token",
+                    service_account_id=permission_set.service_account_id,
+                    role=SERVICE_ACCOUNT_TOKEN_CREATOR,
+                    member=permission_set.github_principal,
+                    opts=child,
+                )
+            gcp.storage.BucketIAMMember(
+                f"{permission_set.account_id}-pulumi-state",
+                bucket=permission_set.state_bucket,
+                role=STATE_WRITER,
+                member=permission_set.service_account_member,
+                opts=child,
+            )
+            gcp.kms.CryptoKeyIAMMember(
+                f"{permission_set.account_id}-pulumi-kms",
+                crypto_key_id=permission_set.crypto_key_id,
+                role=KMS_ENCRYPTER_DECRYPTER,
+                member=permission_set.service_account_member,
+                opts=child,
+            )
+
+        self.register_outputs({})

--- a/infra/iac/tests/test_permissions.py
+++ b/infra/iac/tests/test_permissions.py
@@ -60,13 +60,20 @@ def _workflow(name: str) -> dict:
 
 def test_deploy_workflows_use_main_branch_wif_service_accounts():
     expected = {
-        "ops-ducky.yaml": "iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com",
-        "ops-grafana.yaml": "marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com",
+        "ops-ducky.yaml": (
+            "github.ref == 'refs/heads/main'",
+            "iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com",
+        ),
+        "ops-grafana.yaml": (
+            "github.ref == 'refs/heads/main' && (github.event_name == 'push' || "
+            "github.event_name == 'workflow_dispatch')",
+            "marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com",
+        ),
     }
-    for workflow_name, service_account in expected.items():
+    for workflow_name, (condition, service_account) in expected.items():
         deploy = _workflow(workflow_name)["jobs"]["deploy"]
         assert deploy["permissions"] == {"contents": "read", "id-token": "write"}
-        assert "github.ref == 'refs/heads/main'" in deploy["if"]
+        assert deploy["if"] == condition
         step = next(step for step in deploy["steps"] if step.get("uses") == "./.github/actions/pulumi-deploy")
         assert step["with"]["service-account"] == service_account
 
@@ -77,9 +84,9 @@ def test_pulumi_deploy_action_uses_wif_without_passphrase_or_key_json():
     auth = next(step for step in action["runs"]["steps"] if step.get("uses") == "google-github-actions/auth@v3")
     assert auth["with"]["workload_identity_provider"] == "${{ inputs.workload-identity-provider }}"
     assert auth["with"]["service_account"] == "${{ inputs.service-account }}"
-    serialized = yaml.safe_dump(action)
-    assert "credentials_json" not in serialized
-    assert "pulumi-iac-passphrase" not in serialized
+    assert "credentials_json" not in auth["with"]
+    registry_auth = next(step for step in action["runs"]["steps"] if step.get("name") == "Configure registry auth")
+    assert registry_auth["run"] == "gcloud auth configure-docker us-central1-docker.pkg.dev --quiet"
 
 
 def test_service_stacks_use_shared_kms_provider():

--- a/infra/iac/tests/test_permissions.py
+++ b/infra/iac/tests/test_permissions.py
@@ -1,0 +1,94 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import yaml
+from iac.gcp.permissions import GcpDeployPermissionsArgs, deploy_permission_sets
+
+REPO_ROOT = Path(__file__).parents[3]
+PROJECT = "hai-gcp-models"
+PROJECT_NUMBER = "748532799086"
+POOL = "github-pool"
+GITHUB_SUBJECT = "repo:marin-community/marin:ref:refs/heads/main"
+SERVICE_ACCOUNTS = (
+    "iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com",
+    "marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com",
+)
+WIF_PROVIDER = "projects/748532799086/locations/global/workloadIdentityPools/github-pool/providers/github-oidc"
+KMS_PROVIDER = (
+    "gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/" "marin-iac-keyring/cryptoKeys/marin-iac-key"
+)
+
+
+def test_deploy_permission_sets_resolve_scoped_members_and_resources():
+    permission_sets = deploy_permission_sets(
+        GcpDeployPermissionsArgs(
+            project=PROJECT,
+            project_number=PROJECT_NUMBER,
+            workload_identity_pool=POOL,
+            github_subject=GITHUB_SUBJECT,
+            state_bucket="marin-iac-state",
+            kms_location="us-central1",
+            kms_key_ring="marin-iac-keyring",
+            kms_key="marin-iac-key",
+            service_accounts=SERVICE_ACCOUNTS,
+            id_token_service_accounts=frozenset({SERVICE_ACCOUNTS[0]}),
+        )
+    )
+    assert {permission_set.account_id for permission_set in permission_sets} == {
+        "iris-ci-smoke",
+        "marin-cd-cloud-run-deploy",
+    }
+    for permission_set, email in zip(permission_sets, SERVICE_ACCOUNTS, strict=True):
+        assert permission_set.service_account_id == f"projects/{PROJECT}/serviceAccounts/{email}"
+        assert permission_set.service_account_member == f"serviceAccount:{email}"
+        assert permission_set.github_principal == (
+            "principal://iam.googleapis.com/projects/748532799086/locations/global/"
+            f"workloadIdentityPools/github-pool/subject/{GITHUB_SUBJECT}"
+        )
+        assert permission_set.state_bucket == "marin-iac-state"
+        assert permission_set.crypto_key_id == (
+            "projects/hai-gcp-models/locations/us-central1/keyRings/" "marin-iac-keyring/cryptoKeys/marin-iac-key"
+        )
+    assert [permission_set.mint_id_tokens for permission_set in permission_sets] == [True, False]
+
+
+def _workflow(name: str) -> dict:
+    return yaml.safe_load((REPO_ROOT / ".github" / "workflows" / name).read_text())
+
+
+def test_deploy_workflows_use_main_branch_wif_service_accounts():
+    expected = {
+        "ops-ducky.yaml": "iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com",
+        "ops-grafana.yaml": "marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com",
+    }
+    for workflow_name, service_account in expected.items():
+        deploy = _workflow(workflow_name)["jobs"]["deploy"]
+        assert deploy["permissions"] == {"contents": "read", "id-token": "write"}
+        assert "github.ref == 'refs/heads/main'" in deploy["if"]
+        step = next(step for step in deploy["steps"] if step.get("uses") == "./.github/actions/pulumi-deploy")
+        assert step["with"]["service-account"] == service_account
+
+
+def test_pulumi_deploy_action_uses_wif_without_passphrase_or_key_json():
+    action = yaml.safe_load((REPO_ROOT / ".github" / "actions" / "pulumi-deploy" / "action.yaml").read_text())
+    assert "gcp-credentials" not in action["inputs"]
+    auth = next(step for step in action["runs"]["steps"] if step.get("uses") == "google-github-actions/auth@v3")
+    assert auth["with"]["workload_identity_provider"] == "${{ inputs.workload-identity-provider }}"
+    assert auth["with"]["service_account"] == "${{ inputs.service-account }}"
+    serialized = yaml.safe_dump(action)
+    assert "credentials_json" not in serialized
+    assert "pulumi-iac-passphrase" not in serialized
+
+
+def test_service_stacks_use_shared_kms_provider():
+    for stack_file in (
+        REPO_ROOT / "infra" / "cloudsql" / "Pulumi.marin-cloudsql.yaml",
+        REPO_ROOT / "infra" / "ducky" / "Pulumi.ducky-marin.yaml",
+        REPO_ROOT / "infra" / "grafana" / "Pulumi.marin-grafana.yaml",
+    ):
+        stack = yaml.safe_load(stack_file.read_text())
+        assert stack["secretsprovider"] == KMS_PROVIDER
+        assert stack["encryptedkey"]
+        assert "encryptionsalt" not in stack

--- a/infra/iac/tests/test_permissions.py
+++ b/infra/iac/tests/test_permissions.py
@@ -1,98 +1,44 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
+from dataclasses import replace
 
-import yaml
+import pytest
 from iac.gcp.permissions import GcpDeployPermissionsArgs, deploy_permission_sets
 
-REPO_ROOT = Path(__file__).parents[3]
 PROJECT = "hai-gcp-models"
-PROJECT_NUMBER = "748532799086"
-POOL = "github-pool"
-GITHUB_SUBJECT = "repo:marin-community/marin:ref:refs/heads/main"
-SERVICE_ACCOUNTS = (
-    "iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com",
-    "marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com",
-)
-KMS_PROVIDER = (
-    "gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/" "marin-iac-keyring/cryptoKeys/marin-iac-key"
-)
+DEPLOY_ACCOUNT = "iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com"
 
 
-def test_deploy_permission_sets_resolve_scoped_members_and_resources():
-    permission_sets = deploy_permission_sets(
-        GcpDeployPermissionsArgs(
-            project=PROJECT,
-            project_number=PROJECT_NUMBER,
-            workload_identity_pool=POOL,
-            github_subject=GITHUB_SUBJECT,
-            state_bucket="marin-iac-state",
-            kms_location="us-central1",
-            kms_key_ring="marin-iac-keyring",
-            kms_key="marin-iac-key",
-            service_accounts=SERVICE_ACCOUNTS,
-            id_token_service_accounts=frozenset({SERVICE_ACCOUNTS[0]}),
-        )
+def _permissions_args() -> GcpDeployPermissionsArgs:
+    return GcpDeployPermissionsArgs(
+        project=PROJECT,
+        project_number="748532799086",
+        workload_identity_pool="github-pool",
+        github_subject="repo:marin-community/marin:ref:refs/heads/main",
+        state_bucket="marin-iac-state",
+        kms_location="us-central1",
+        kms_key_ring="marin-iac-keyring",
+        kms_key="marin-iac-key",
+        service_accounts=(DEPLOY_ACCOUNT,),
     )
-    assert {permission_set.account_id for permission_set in permission_sets} == {
-        "iris-ci-smoke",
-        "marin-cd-cloud-run-deploy",
-    }
-    for permission_set, email in zip(permission_sets, SERVICE_ACCOUNTS, strict=True):
-        assert permission_set.service_account_id == f"projects/{PROJECT}/serviceAccounts/{email}"
-        assert permission_set.service_account_member == f"serviceAccount:{email}"
-        assert permission_set.github_principal == (
-            "principal://iam.googleapis.com/projects/748532799086/locations/global/"
-            f"workloadIdentityPools/github-pool/subject/{GITHUB_SUBJECT}"
-        )
-        assert permission_set.state_bucket == "marin-iac-state"
-        assert permission_set.crypto_key_id == (
-            "projects/hai-gcp-models/locations/us-central1/keyRings/" "marin-iac-keyring/cryptoKeys/marin-iac-key"
-        )
-    assert [permission_set.mint_id_tokens for permission_set in permission_sets] == [True, False]
 
 
-def _workflow(name: str) -> dict:
-    return yaml.safe_load((REPO_ROOT / ".github" / "workflows" / name).read_text())
+def test_deploy_permission_sets_rejects_id_token_account_without_deploy_access():
+    args = replace(
+        _permissions_args(),
+        id_token_service_accounts=frozenset({"undeclared@hai-gcp-models.iam.gserviceaccount.com"}),
+    )
+
+    with pytest.raises(ValueError):
+        deploy_permission_sets(args)
 
 
-def test_deploy_workflows_use_main_branch_wif_service_accounts():
-    expected = {
-        "ops-ducky.yaml": (
-            "github.ref == 'refs/heads/main'",
-            "iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com",
-        ),
-        "ops-grafana.yaml": (
-            "github.ref == 'refs/heads/main' && (github.event_name == 'push' || "
-            "github.event_name == 'workflow_dispatch')",
-            "marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com",
-        ),
-    }
-    for workflow_name, (condition, service_account) in expected.items():
-        deploy = _workflow(workflow_name)["jobs"]["deploy"]
-        assert deploy["permissions"] == {"contents": "read", "id-token": "write"}
-        assert deploy["if"] == condition
-        step = next(step for step in deploy["steps"] if step.get("uses") == "./.github/actions/pulumi-deploy")
-        assert step["with"]["service-account"] == service_account
+def test_deploy_permission_sets_rejects_service_account_from_another_project():
+    args = replace(
+        _permissions_args(),
+        service_accounts=("deploy@another-project.iam.gserviceaccount.com",),
+    )
 
-
-def test_pulumi_deploy_action_uses_wif_without_key_json():
-    action = yaml.safe_load((REPO_ROOT / ".github" / "actions" / "pulumi-deploy" / "action.yaml").read_text())
-    assert "gcp-credentials" not in action["inputs"]
-    auth = next(step for step in action["runs"]["steps"] if step.get("uses") == "google-github-actions/auth@v3")
-    assert auth["with"]["workload_identity_provider"] == "${{ inputs.workload-identity-provider }}"
-    assert auth["with"]["service_account"] == "${{ inputs.service-account }}"
-    assert "credentials_json" not in auth["with"]
-
-
-def test_service_stacks_use_shared_kms_provider():
-    for stack_file in (
-        REPO_ROOT / "infra" / "cloudsql" / "Pulumi.marin-cloudsql.yaml",
-        REPO_ROOT / "infra" / "ducky" / "Pulumi.ducky-marin.yaml",
-        REPO_ROOT / "infra" / "grafana" / "Pulumi.marin-grafana.yaml",
-    ):
-        stack = yaml.safe_load(stack_file.read_text())
-        assert stack["secretsprovider"] == KMS_PROVIDER
-        assert stack["encryptedkey"]
-        assert "encryptionsalt" not in stack
+    with pytest.raises(ValueError):
+        deploy_permission_sets(args)

--- a/infra/iac/tests/test_permissions.py
+++ b/infra/iac/tests/test_permissions.py
@@ -15,7 +15,6 @@ SERVICE_ACCOUNTS = (
     "iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com",
     "marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com",
 )
-WIF_PROVIDER = "projects/748532799086/locations/global/workloadIdentityPools/github-pool/providers/github-oidc"
 KMS_PROVIDER = (
     "gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/" "marin-iac-keyring/cryptoKeys/marin-iac-key"
 )

--- a/infra/iac/tests/test_permissions.py
+++ b/infra/iac/tests/test_permissions.py
@@ -78,15 +78,13 @@ def test_deploy_workflows_use_main_branch_wif_service_accounts():
         assert step["with"]["service-account"] == service_account
 
 
-def test_pulumi_deploy_action_uses_wif_without_passphrase_or_key_json():
+def test_pulumi_deploy_action_uses_wif_without_key_json():
     action = yaml.safe_load((REPO_ROOT / ".github" / "actions" / "pulumi-deploy" / "action.yaml").read_text())
     assert "gcp-credentials" not in action["inputs"]
     auth = next(step for step in action["runs"]["steps"] if step.get("uses") == "google-github-actions/auth@v3")
     assert auth["with"]["workload_identity_provider"] == "${{ inputs.workload-identity-provider }}"
     assert auth["with"]["service_account"] == "${{ inputs.service-account }}"
     assert "credentials_json" not in auth["with"]
-    registry_auth = next(step for step in action["runs"]["steps"] if step.get("name") == "Configure registry auth")
-    assert registry_auth["run"] == "gcloud auth configure-docker us-central1-docker.pkg.dev --quiet"
 
 
 def test_service_stacks_use_shared_kms_provider():

--- a/infra/permissions/Pulumi.hai-gcp-models.yaml
+++ b/infra/permissions/Pulumi.hai-gcp-models.yaml
@@ -1,0 +1,16 @@
+config:
+  marin-permissions:project: hai-gcp-models
+  marin-permissions:project_number: "748532799086"
+  marin-permissions:workload_identity_pool: github-pool
+  marin-permissions:github_subject: repo:marin-community/marin:ref:refs/heads/main
+  marin-permissions:state_bucket: marin-iac-state
+  marin-permissions:kms_location: us-central1
+  marin-permissions:kms_key_ring: marin-iac-keyring
+  marin-permissions:kms_key: marin-iac-key
+  marin-permissions:deploy_service_accounts:
+    - iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com
+    - marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com
+  marin-permissions:id_token_service_accounts:
+    - iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com
+secretsprovider: gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
+encryptedkey: CiQAKk3j6QvsjVzr0PISU10T8p7CBI0p31YV97owWqgbmeAU4wUSSQCdtF6ivDSFDEI7pl9JQ4dMHYbmdE2rjMYZjjF9S6S3BiIx2j9acg0JGF88fZT8lDPrScl/KjBkTV76oECYPg18C/ry5YsXaAE=

--- a/infra/permissions/Pulumi.yaml
+++ b/infra/permissions/Pulumi.yaml
@@ -1,0 +1,6 @@
+name: marin-permissions
+runtime:
+  name: python
+  options:
+    virtualenv: ../../.venv
+description: Shared IAM grants for Marin deployment automation.

--- a/infra/permissions/README.md
+++ b/infra/permissions/README.md
@@ -1,0 +1,51 @@
+# Marin permissions
+
+This Pulumi project owns additive IAM grants shared by deployment workflows. It does not own
+the existing GitHub workload identity pool, service accounts, state bucket, or KMS key.
+
+The `hai-gcp-models` stack lets GitHub OIDC tokens for the `main` branch impersonate the Ducky
+and Grafana deployment accounts. Each account can update the shared Pulumi state bucket and
+encrypt or decrypt stack secrets with `marin-iac-key`. The IAM resources are protected, so a
+stack destroy fails instead of removing workflow authentication.
+
+The Ducky account also receives `roles/iam.serviceAccountTokenCreator` from the same exact
+GitHub subject. Rigging needs it to mint the service-account ID token accepted by Iris's IAP
+edge; Grafana does not mint IAP tokens and does not receive that role.
+
+## Apply
+
+Select the existing stack and review its plan before applying changes:
+
+```bash
+uv sync --package marin-iac --extra deploy
+cd infra/permissions
+pulumi login gs://marin-iac-state
+pulumi stack select hai-gcp-models
+pulumi preview
+pulumi up
+```
+
+The stack was bootstrapped directly with the shared `marin-iac-key` KMS provider. If the
+backend metadata must be recreated, initialize it with:
+
+```bash
+pulumi stack init hai-gcp-models \
+  --secrets-provider=gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
+```
+
+The first preview should contain seven IAM creates: WIF impersonation, state-bucket object
+admin, and KMS encrypt/decrypt for each deployment account, plus ID-token minting for Ducky.
+Any other IAM change is unexpected.
+
+The shared bucket and key are a deliberate trust boundary: either deploy account can access
+state from other projects in the backend. Splitting state prefixes and keys requires a separate
+backend migration; Grafana also reads the Cloud SQL stack through a stack reference.
+
+## Human access inventory
+
+[`user-access-inventory.yaml`](user-access-inventory.yaml) records the requested initial,
+read-only pull of Compute Admin and KMS access. It has no effect on GCP. Human access can be
+managed here later with non-authoritative `gcp.projects.IAMMember` and
+`gcp.kms.CryptoKeyIAMMember` resources after the entries have been reviewed. Do not use an
+authoritative project or role binding: the live project contains unrelated members that such a
+binding would remove.

--- a/infra/permissions/README.md
+++ b/infra/permissions/README.md
@@ -33,9 +33,9 @@ pulumi stack init hai-gcp-models \
   --secrets-provider=gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
 ```
 
-The first preview should contain seven IAM creates: WIF impersonation, state-bucket object
-admin, and KMS encrypt/decrypt for each deployment account, plus ID-token minting for Ducky.
-Any other IAM change is unexpected.
+A normal preview is a no-op. Recreating the stack should produce exactly seven IAM members:
+WIF impersonation, state-bucket object admin, and KMS encrypt/decrypt for each deployment
+account, plus ID-token minting for Ducky. Any other IAM change is unexpected.
 
 The shared bucket and key are a deliberate trust boundary: either deploy account can access
 state from other projects in the backend. Splitting state prefixes and keys requires a separate
@@ -43,8 +43,8 @@ backend migration; Grafana also reads the Cloud SQL stack through a stack refere
 
 ## Human access inventory
 
-[`user-access-inventory.yaml`](user-access-inventory.yaml) records the requested initial,
-read-only pull of Compute Admin and KMS access. It has no effect on GCP. Human access can be
+[`user-access-inventory.yaml`](user-access-inventory.yaml) records a read-only snapshot of
+Compute Admin and KMS access. It has no effect on GCP. Human access can be
 managed here later with non-authoritative `gcp.projects.IAMMember` and
 `gcp.kms.CryptoKeyIAMMember` resources after the entries have been reviewed. Do not use an
 authoritative project or role binding: the live project contains unrelated members that such a

--- a/infra/permissions/__main__.py
+++ b/infra/permissions/__main__.py
@@ -1,0 +1,33 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pulumi entry point for shared deployment IAM grants."""
+
+import pulumi
+import pulumi_gcp as gcp
+from iac.gcp.permissions import GcpDeployPermissions, GcpDeployPermissionsArgs
+
+
+def main() -> None:
+    config = pulumi.Config()
+    project = config.require("project")
+    provider = gcp.Provider("gcp", project=project)
+    GcpDeployPermissions(
+        "deploy",
+        GcpDeployPermissionsArgs(
+            project=project,
+            project_number=config.require("project_number"),
+            workload_identity_pool=config.require("workload_identity_pool"),
+            github_subject=config.require("github_subject"),
+            state_bucket=config.require("state_bucket"),
+            kms_location=config.require("kms_location"),
+            kms_key_ring=config.require("kms_key_ring"),
+            kms_key=config.require("kms_key"),
+            service_accounts=tuple(config.require_object("deploy_service_accounts")),
+            id_token_service_accounts=frozenset(config.get_object("id_token_service_accounts") or []),
+        ),
+        gcp_provider=provider,
+    )
+
+
+main()

--- a/infra/permissions/user-access-inventory.yaml
+++ b/infra/permissions/user-access-inventory.yaml
@@ -1,0 +1,11 @@
+# Read-only snapshot from GCP IAM on 2026-07-20. The Pulumi program does not read this file.
+# Move a reviewed entry into typed stack config before making Pulumi authoritative for it.
+project_roles:
+  roles/compute.admin:
+    - user:held@stanford.edu
+  roles/cloudkms.admin:
+    - user:wbmoss@gmail.com
+kms_key_roles:
+  projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key:
+    roles/cloudkms.cryptoKeyEncrypterDecrypter:
+      - user:wbmoss@gmail.com

--- a/lib/ducky/README.md
+++ b/lib/ducky/README.md
@@ -184,11 +184,12 @@ manual roll:
 uv sync --all-packages --extra deploy
 cd infra/ducky
 pulumi login gs://marin-iac-state
-export PULUMI_CONFIG_PASSPHRASE="$(gcloud secrets versions access latest \
-  --secret=pulumi-iac-passphrase --project=hai-gcp-models)"
 pulumi stack select ducky-marin
 pulumi up
 ```
+
+The stack uses the shared `marin-iac-key` KMS secrets provider. The operator needs
+`roles/cloudkms.cryptoKeyEncrypterDecrypter` on that key; no passphrase is used.
 
 Runtime config still arrives as `DUCKY_*` env vars — see `config.py`; the stack yaml is
 where the values are set.


### PR DESCRIPTION
Move Ducky and Grafana deployment authentication from repository service-account keys and the Secret Manager Pulumi passphrase to exact-main-branch Workload Identity Federation and KMS-backed Pulumi stack secrets.

Add a dedicated `marin-permissions` stack that owns only protected, additive IAM members for the existing deployment accounts: WIF impersonation, Pulumi state-bucket writes, KMS encrypt/decrypt, and Ducky's Iris/IAP ID-token minting. The stack is bootstrapped in `hai-gcp-models`; its current preview is a clean 10 unchanged resources.

Migrate the Ducky, Grafana, and Grafana-referenced Cloud SQL stack metadata to the shared KMS key. The composite deploy action no longer accepts `credentials_json` or fetches `PULUMI_CONFIG_PASSPHRASE`. Existing long-lived keys remain in place for separately coordinated cleanup after the WIF workflows run successfully.

Record the selected live Compute Admin and KMS human grants as an inert, read-only configuration snapshot, with guidance for adopting reviewed entries later through non-authoritative IAM member resources.

Session: https://loom.rjp.io/s/ivm5n3xa
