### PR TITLE
Fix two flaky-test races surfaced while testing #5963

### DIFF
--- a/lib/finelog/src/finelog/client/log_client.py
+++ b/lib/finelog/src/finelog/client/log_client.py
@@ -343,6 +343,12 @@ class Table:
             self._cond.notify_all()
         self._thread.join(timeout=max(self._flush_interval * 2, 10.0))
         with self._cond:
+            if self._processed_seq < self._pushed_seq:
+                logger.warning(
+                    "Table(%s) close() timed out before draining %d pending row(s); they were not sent",
+                    self._namespace,
+                    self._pushed_seq - self._processed_seq,
+                )
             self._closed = True
             self._cond.notify_all()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,10 +12,20 @@ DEFAULT_DOCUMENT_PATH = "documents/test-document-path"
 
 
 @pytest.fixture(autouse=True)
-def fray_client():
-    """Set up a v2 LocalClient for all tests."""
-    with set_current_client(LocalClient()) as client:
+def fray_client(_configure_marin_prefix):
+    """Set up a v2 LocalClient for all tests.
+
+    Depends on ``_configure_marin_prefix`` so it tears down first: shutting
+    down the client joins every local-backend worker thread before that
+    fixture removes the MARIN_PREFIX temp directory. Without this ordering, a
+    straggler task can still be writing under MARIN_PREFIX when the temp
+    directory is removed, raising ``OSError: Directory not empty`` at
+    teardown.
+    """
+    client = LocalClient()
+    with set_current_client(client):
         yield client
+    client.shutdown()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Two small, independent fixes to shared test/CI infrastructure, found while chasing CI flakiness on #5963. Neither touches anything specific to that PR — pulling them out here so they can land on their own.

**`tests/conftest.py`**: the `fray_client` autouse fixture created a fresh `LocalClient` per test but never called `shutdown()`, so its `ThreadPoolExecutor` threads could still be alive when a sibling autouse fixture ran its own teardown. `_configure_marin_prefix` tears down before `fray_client` (reverse of setup order), so it could remove the `MARIN_PREFIX` temp directory while a straggler worker thread from the just-finished pipeline was still writing under it — raising `OSError: Directory not empty` at teardown. `fray_client` now depends on `_configure_marin_prefix` (forcing it to tear down first) and shuts the client down, joining in-flight threads before the temp directory is removed.

**`finelog`'s `Table.close()`**: does a "best-effort drain" — it wakes the background flush thread and joins it with a generous timeout, then marks itself closed regardless of whether the drain actually finished. On a CPU-starved CI runner the flush thread can fail to get scheduled in time, silently dropping pending rows with nothing in the logs to explain it. `close()` now logs a warning naming the table and the number of undelivered rows when this happens, so the failure mode is observable instead of silent.