### PR TITLE
[marin] Build Harbor Dockerfile tasks on Iris sandboxes; add OT TB Lite eval

### DIFF
--- a/experiments/evals/served_lm_eval.py
+++ b/experiments/evals/served_lm_eval.py
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import tempfile
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field, replace
 from typing import Any
 
 from fray.types import ResourceConfig
+from marin.evaluation.harbor_eval import HarborEvalResults, HarborEvalRun, run_harbor_eval
 from marin.evaluation.lm_eval import LM_EVAL_UV_PACKAGES, LmEvalResults, LmEvalRun, run_lm_eval
 from marin.execution.lazy import ArtifactStep, StepContext
 from marin.execution.remote import remote
@@ -17,6 +18,7 @@ from marin.inference.config import (
     VllmEngineConfig,
 )
 from marin.inference.iris import remote_inference
+from marin.inference.types import RunningModel
 from rigging.filesystem import StoragePath
 
 _EVAL_PARENT_RESOURCES = ResourceConfig.with_cpu(
@@ -24,6 +26,22 @@ _EVAL_PARENT_RESOURCES = ResourceConfig.with_cpu(
     ram="6g",
     disk="16g",
     preemptible=False,
+)
+
+# The harbor parent runs the agent LLM loops in-process, one per concurrent trial.
+_HARBOR_EVAL_PARENT_RESOURCES = ResourceConfig.with_cpu(
+    cpu=2,
+    ram="8g",
+    disk="32g",
+    preemptible=False,
+)
+_HARBOR_EVAL_PARENT_DEPENDENCY_GROUPS = ["harbor"]
+
+OT_TB_LITE_DATASET = "openthoughts-tblite"
+OT_TB_LITE_VERSION = "2.0"
+# The registry of the marin-community harbor fork, pinned to the workspace harbor rev.
+MARIN_HARBOR_REGISTRY_URL = (
+    "https://raw.githubusercontent.com/marin-community/harbor/0d0dbe8904ed984137a0dfa764583f1508cf3274/registry.json"
 )
 
 
@@ -36,10 +54,11 @@ class BrokeredEvalInference:
     broker: BrokerConfig = field(default_factory=BrokerConfig)
 
 
-def _run_brokered_lm_eval_artifact(
+def _run_brokered_eval_artifact[RunT](
     inference: BrokeredEvalInference,
-    eval_run: LmEvalRun,
+    eval_run: RunT,
     output_path: str,
+    run_eval: Callable[[RunningModel, RunT, str], None],
 ) -> None:
     with tempfile.TemporaryDirectory() as local_output:
         with remote_inference(
@@ -49,8 +68,71 @@ def _run_brokered_lm_eval_artifact(
             instances=inference.instances,
             broker=inference.broker,
         ) as session:
-            run_lm_eval(session.model, eval_run, local_output)
+            run_eval(session.model, eval_run, local_output)
         StoragePath(output_path).upload_from(local_output + "/", recursive=True)
+
+
+def _require_pinned_lm_eval_packages(config: Mapping[str, Any]) -> None:
+    if config["lm_eval_uv_packages"] != LM_EVAL_UV_PACKAGES:
+        raise ValueError("artifact lm-eval packages must match the pinned runtime packages")
+
+
+def _brokered_eval_step[ResultsT, RunT](
+    inference: BrokeredEvalInference,
+    eval_run: RunT,
+    *,
+    name: str,
+    version: str,
+    artifact_type: type[ResultsT],
+    run_eval: Callable[[RunningModel, RunT, str], None],
+    parent_resources: ResourceConfig,
+    parent_env_vars: Mapping[str, str] | None = None,
+    parent_dependency_groups: list[str] | None = None,
+    config_extras: Mapping[str, Any] | None = None,
+    check_config: Callable[[Mapping[str, Any]], None] | None = None,
+) -> ArtifactStep[ResultsT]:
+    """Shared scaffold: serve the model brokered, run one eval against it, keep the results.
+
+    ``config_extras`` ride in the artifact config so pin changes invalidate it;
+    ``check_config`` re-validates a stored config against the current runtime.
+    """
+    worker_resources = inference.iris.worker_resources
+    results_path = str(StoragePath("mirror://") / name / version)
+
+    def build_config(context: StepContext) -> dict[str, Any]:
+        return {
+            "inference": replace(
+                inference,
+                iris=replace(inference.iris, worker_resources=context.runtime_arg("worker_resources")),
+            ),
+            "eval_run": eval_run,
+            "results_path": results_path,
+            **(config_extras or {}),
+        }
+
+    def run_step(config: dict[str, Any]) -> ResultsT:
+        if check_config is not None:
+            check_config(config)
+        remote(
+            _run_brokered_eval_artifact,
+            name=name,
+            resources=parent_resources,
+            env_vars=dict(parent_env_vars or {}),
+            pip_dependency_groups=parent_dependency_groups,
+        )(config["inference"], config["eval_run"], config["results_path"], run_eval)
+        return artifact_type(results_path=config["results_path"])
+
+    return ArtifactStep(
+        name=name,
+        version=version,
+        artifact_type=artifact_type,
+        run=run_step,
+        build_config=build_config,
+        deps=(),
+        runtime_args={
+            "worker_resources": worker_resources,
+        },
+    )
 
 
 def brokered_lm_eval_step(
@@ -62,7 +144,6 @@ def brokered_lm_eval_step(
     parent_env_vars: Mapping[str, str],
 ) -> ArtifactStep[LmEvalResults]:
     """Build a lazy artifact containing lm-eval metrics and samples."""
-    worker_resources = inference.iris.worker_resources
     eval_run = replace(
         eval_run,
         extra_model_args={
@@ -71,38 +152,61 @@ def brokered_lm_eval_step(
             **eval_run.extra_model_args,
         },
     )
-    results_path = str(StoragePath("mirror://") / name / version)
-
-    def build_config(context: StepContext) -> dict[str, Any]:
-        return {
-            "inference": replace(
-                inference,
-                iris=replace(inference.iris, worker_resources=context.runtime_arg("worker_resources")),
-            ),
-            "lm_eval_uv_packages": LM_EVAL_UV_PACKAGES,
-            "eval_run": eval_run,
-            "results_path": results_path,
-        }
-
-    def run_step(config: dict[str, Any]) -> LmEvalResults:
-        if config["lm_eval_uv_packages"] != LM_EVAL_UV_PACKAGES:
-            raise ValueError("artifact lm-eval packages must match the pinned runtime packages")
-        remote(
-            _run_brokered_lm_eval_artifact,
-            name=name,
-            resources=_EVAL_PARENT_RESOURCES,
-            env_vars=dict(parent_env_vars),
-        )(config["inference"], config["eval_run"], config["results_path"])
-        return LmEvalResults(results_path=config["results_path"])
-
-    return ArtifactStep(
+    return _brokered_eval_step(
+        inference,
+        eval_run,
         name=name,
         version=version,
         artifact_type=LmEvalResults,
-        run=run_step,
-        build_config=build_config,
-        deps=(),
-        runtime_args={
-            "worker_resources": worker_resources,
-        },
+        run_eval=run_lm_eval,
+        parent_resources=_EVAL_PARENT_RESOURCES,
+        parent_env_vars=parent_env_vars,
+        config_extras={"lm_eval_uv_packages": LM_EVAL_UV_PACKAGES},
+        check_config=_require_pinned_lm_eval_packages,
+    )
+
+
+def brokered_harbor_eval_step(
+    inference: BrokeredEvalInference,
+    eval_run: HarborEvalRun,
+    *,
+    name: str,
+    version: str,
+) -> ArtifactStep[HarborEvalResults]:
+    """Build a lazy artifact containing a Harbor dataset's trial results."""
+    return _brokered_eval_step(
+        inference,
+        eval_run,
+        name=name,
+        version=version,
+        artifact_type=HarborEvalResults,
+        run_eval=run_harbor_eval,
+        parent_resources=_HARBOR_EVAL_PARENT_RESOURCES,
+        parent_dependency_groups=_HARBOR_EVAL_PARENT_DEPENDENCY_GROUPS,
+    )
+
+
+def brokered_ot_tb_lite_step(
+    inference: BrokeredEvalInference,
+    *,
+    model_name: str,
+    version: str,
+    container_profile: str,
+    n_tasks: int | None = None,
+    n_concurrent_trials: int = 4,
+) -> ArtifactStep[HarborEvalResults]:
+    """OpenThoughts-TBLite from the marin-community harbor fork, on Iris sandboxes."""
+    eval_run = HarborEvalRun(
+        dataset=OT_TB_LITE_DATASET,
+        dataset_version=OT_TB_LITE_VERSION,
+        registry_url=MARIN_HARBOR_REGISTRY_URL,
+        n_tasks=n_tasks,
+        n_concurrent_trials=n_concurrent_trials,
+        container_profile=container_profile,
+    )
+    return brokered_harbor_eval_step(
+        inference,
+        eval_run,
+        name=f"evals/{model_name}/ot-tb-lite",
+        version=version,
     )

--- a/experiments/evals/served_qwen3.py
+++ b/experiments/evals/served_qwen3.py
@@ -32,9 +32,16 @@ from marin.inference.config import (
 from marin.training.run_environment import env_vars_for_dependency_groups
 
 from experiments.evals.brokered_eval_suite import brokered_eval_suite
-from experiments.evals.served_lm_eval import BrokeredEvalInference
+from experiments.evals.served_lm_eval import BrokeredEvalInference, brokered_ot_tb_lite_step
 
 QWEN3_EVAL_VERSION = "2026.07.17"
+QWEN3_OT_TB_LITE_VERSION = "2026.07.21"
+# ~53 agent-hours if every trial runs out its clock; 16 concurrent sandboxes
+# keeps the full 97-task dataset under ~5h wall.
+_OT_TB_LITE_N_CONCURRENT_TRIALS = 16
+# Flip to "gvisor" (IrisEnvironment's default, un-gated) once the fleet's
+# workers carry runsc; until then sandboxes need the admin-gated profile.
+_OT_TB_LITE_CONTAINER_PROFILE = "privileged"
 _VLLM_TIMEOUT = 1800
 _TPU_VLLM_WORKER_ENV_VARS = (
     ("VLLM_ENABLE_V1_MULTIPROCESSING", "0"),
@@ -98,6 +105,14 @@ QWEN3_TPU_EVAL_RESULTS = brokered_eval_suite(
     version=QWEN3_EVAL_VERSION,
 )
 
+QWEN3_TPU_OT_TB_LITE_RESULTS = brokered_ot_tb_lite_step(
+    QWEN3_TPU_INFERENCE,
+    model_name="qwen3-0.6b",
+    version=QWEN3_OT_TB_LITE_VERSION,
+    container_profile=_OT_TB_LITE_CONTAINER_PROFILE,
+    n_concurrent_trials=_OT_TB_LITE_N_CONCURRENT_TRIALS,
+)
+
 QWEN3_GPU_INFERENCE = qwen3_inference_config(
     engine=VllmEngineConfig(
         launcher=VllmLauncherType.CUDA,
@@ -121,10 +136,12 @@ QWEN3_GPU_EVAL_RESULTS = brokered_eval_suite(
     version=QWEN3_EVAL_VERSION,
 )
 
+# No GPU OT TB Lite step: Dockerfile-task sandboxes need a docker-worker
+# cluster, and the GPU evals run on CoreWeave's k8s backend.
 QWEN3_EVALS_BY_ACCELERATOR = MappingProxyType(
     {
-        Accelerator.TPU: QWEN3_TPU_EVAL_RESULTS,
-        Accelerator.GPU: QWEN3_GPU_EVAL_RESULTS,
+        Accelerator.TPU: (QWEN3_TPU_EVAL_RESULTS, QWEN3_TPU_OT_TB_LITE_RESULTS),
+        Accelerator.GPU: (QWEN3_GPU_EVAL_RESULTS,),
     }
 )
 
@@ -141,4 +158,4 @@ def _parse_accelerator() -> Accelerator:
 
 
 if __name__ == "__main__":
-    StepRunner().run([lower(QWEN3_EVALS_BY_ACCELERATOR[_parse_accelerator()])])
+    StepRunner().run([lower(step) for step in QWEN3_EVALS_BY_ACCELERATOR[_parse_accelerator()]])

--- a/lib/iris/src/iris/cluster/runtime/docker.py
+++ b/lib/iris/src/iris/cluster/runtime/docker.py
@@ -248,7 +248,7 @@ def _build_device_flags(config: ContainerConfig) -> list[str]:
     return flags
 
 
-def _security_flags(profile: int, is_tpu_run: bool) -> list[str]:
+def security_flags(profile: int, is_tpu_run: bool) -> list[str]:
     """Docker security flags (privilege, capabilities, docker-socket mount).
 
     A TPU run requires ``--privileged`` for device access regardless of profile,
@@ -676,7 +676,7 @@ exec {quoted_cmd}
         ]
         is_tpu_run = include_devices and _has_tpu_device(config)
 
-        cmd.extend(_security_flags(config.container_profile, is_tpu_run))
+        cmd.extend(security_flags(config.container_profile, is_tpu_run))
         logger.info(
             "Container security profile %s (tpu_run=%s) for task %s",
             job_pb2.ContainerProfile.Name(resolve_container_profile(config.container_profile)),

--- a/lib/iris/tests/cluster/runtime/test_docker_runtime.py
+++ b/lib/iris/tests/cluster/runtime/test_docker_runtime.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock
 
 import pytest
 from iris.cluster.bundle import BundleStore
-from iris.cluster.runtime.docker import DockerRuntime, _security_flags
+from iris.cluster.runtime.docker import DockerRuntime, security_flags
 from iris.cluster.runtime.types import MountKind, MountSpec
 from iris.rpc import job_pb2
 
@@ -111,33 +111,33 @@ def test_stage_bundle(monkeypatch, tmp_path, runtime, mock_bundle_store):
 
 def test_security_flags_default_cpu():
     """UNSPECIFIED resolves to DEFAULT: hardened CPU defaults with SYS_PTRACE."""
-    flags = _security_flags(job_pb2.CONTAINER_PROFILE_UNSPECIFIED, is_tpu_run=False)
+    flags = security_flags(job_pb2.CONTAINER_PROFILE_UNSPECIFIED, is_tpu_run=False)
     assert flags == ["--security-opt", "no-new-privileges", "--cap-drop", "ALL", "--cap-add", "SYS_PTRACE"]
 
 
 def test_security_flags_default_tpu_is_privileged():
     """A TPU run is privileged for device access even under DEFAULT."""
-    flags = _security_flags(job_pb2.CONTAINER_PROFILE_DEFAULT, is_tpu_run=True)
+    flags = security_flags(job_pb2.CONTAINER_PROFILE_DEFAULT, is_tpu_run=True)
     assert "--privileged" in flags
     assert "no-new-privileges" not in flags
     assert "SYS_PTRACE" in flags
 
 
 def test_security_flags_restricted_omits_ptrace():
-    flags = _security_flags(job_pb2.CONTAINER_PROFILE_RESTRICTED, is_tpu_run=False)
+    flags = security_flags(job_pb2.CONTAINER_PROFILE_RESTRICTED, is_tpu_run=False)
     assert flags == ["--security-opt", "no-new-privileges", "--cap-drop", "ALL"]
     assert "SYS_PTRACE" not in flags
 
 
 def test_security_flags_privileged_cpu():
-    flags = _security_flags(job_pb2.CONTAINER_PROFILE_PRIVILEGED, is_tpu_run=False)
+    flags = security_flags(job_pb2.CONTAINER_PROFILE_PRIVILEGED, is_tpu_run=False)
     assert "--privileged" in flags
     assert "--cap-drop" not in flags
     assert "SYS_PTRACE" in flags
 
 
 def test_security_flags_docker_access_mounts_socket():
-    flags = _security_flags(job_pb2.CONTAINER_PROFILE_DOCKER_ACCESS, is_tpu_run=False)
+    flags = security_flags(job_pb2.CONTAINER_PROFILE_DOCKER_ACCESS, is_tpu_run=False)
     assert "-v" in flags
     assert "/var/run/docker.sock:/var/run/docker.sock" in flags
     # Still hardened like DEFAULT otherwise.
@@ -146,7 +146,7 @@ def test_security_flags_docker_access_mounts_socket():
 
 def test_security_flags_gvisor_uses_runsc_runtime_and_default_caps():
     """gVisor selects the runsc runtime and keeps docker's default caps (no cap-drop)."""
-    flags = _security_flags(job_pb2.CONTAINER_PROFILE_GVISOR, is_tpu_run=False)
+    flags = security_flags(job_pb2.CONTAINER_PROFILE_GVISOR, is_tpu_run=False)
     assert flags == ["--runtime", "runsc"]
     # in-guest root needs the default cap set, so the container is NOT cap-dropped
     # or privileged — gVisor provides the host isolation instead.

--- a/lib/marin/src/marin/evaluation/harbor_eval.py
+++ b/lib/marin/src/marin/evaluation/harbor_eval.py
@@ -1,0 +1,152 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run a Harbor registry dataset against an already served model.
+
+The served-model analog of ``marin.evaluation.lm_eval``: the agent (an LLM
+loop such as terminus-2) runs in this process and talks to the model's
+OpenAI-compatible endpoint, while each trial's sandbox runs as an Iris job via
+``marin.harbor.iris_environment.IrisEnvironment``. Must run inside an Iris job
+so sandboxes can reach the controller directly.
+"""
+
+import asyncio
+import dataclasses
+import json
+import statistics
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from iris.cluster.client.job_info import get_job_info
+
+from marin.execution.artifact import Artifact
+from marin.inference.types import RunningModel
+
+IRIS_ENVIRONMENT_IMPORT_PATH = "marin.harbor.iris_environment:IrisEnvironment"
+HARBOR_JOB_NAME = "harbor"
+
+# hosted_vllm agents require token limits and (free) serving costs up front.
+DEFAULT_HOSTED_VLLM_MODEL_INFO: Mapping[str, int | float] = {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.0,
+    "output_cost_per_token": 0.0,
+}
+
+
+class HarborEvalResults(Artifact):
+    """A lazy reference to a Harbor job's results and trial artifacts."""
+
+    results_path: str
+
+
+@dataclass(frozen=True)
+class HarborEvalRun:
+    """A single Harbor dataset run against an already served model."""
+
+    dataset: str
+    dataset_version: str
+    registry_url: str
+    # Sandbox security profile; see marin.harbor.iris_environment.IrisEnvironment.
+    container_profile: str
+    agent_name: str = "terminus-2"
+    n_tasks: int | None = None
+    n_concurrent_trials: int = 4
+    model_info: Mapping[str, int | float] = field(default_factory=lambda: dict(DEFAULT_HOSTED_VLLM_MODEL_INFO))
+
+
+def run_harbor_eval(model: RunningModel, run: HarborEvalRun, output_path: str):
+    """Run the dataset's trials against the served model and persist results.
+
+    Harbor writes its full job output (per-trial logs, ``result.json``) under
+    ``output_path``; a flat ``results.json`` summary is added at the root.
+    Returns the harbor ``JobResult``.
+    """
+    from harbor.job import Job  # noqa: PLC0415  # optional dep: harbor
+    from harbor.models.job.config import DatasetConfig, JobConfig  # noqa: PLC0415  # optional dep: harbor
+    from harbor.models.trial.config import AgentConfig, EnvironmentConfig  # noqa: PLC0415  # optional dep: harbor
+
+    job_info = get_job_info()
+    if job_info is None:
+        raise RuntimeError("run_harbor_eval must run inside an Iris job.")
+
+    config = JobConfig(
+        job_name=HARBOR_JOB_NAME,
+        jobs_dir=Path(output_path),
+        datasets=[
+            DatasetConfig(
+                name=run.dataset,
+                version=run.dataset_version,
+                registry_url=run.registry_url,
+                n_tasks=run.n_tasks,
+            )
+        ],
+        agents=[
+            AgentConfig(
+                name=run.agent_name,
+                model_name=f"hosted_vllm/{model.endpoint.model}",
+                kwargs={
+                    "api_base": model.endpoint.base_url,
+                    "model_info": dict(run.model_info),
+                },
+            )
+        ],
+        environment=EnvironmentConfig(
+            import_path=IRIS_ENVIRONMENT_IMPORT_PATH,
+            kwargs={
+                "controller_url": job_info.controller_address,
+                "container_profile": run.container_profile,
+            },
+        ),
+        n_concurrent_trials=run.n_concurrent_trials,
+        quiet=True,
+    )
+
+    async def create_and_run():
+        job = await Job.create(config)
+        return await job.run()
+
+    result = asyncio.run(create_and_run())
+    summary_path = Path(output_path) / "results.json"
+    summary_path.write_text(json.dumps(dataclasses.asdict(summarize_job_result(result)), indent=2))
+    return result
+
+
+@dataclass(frozen=True)
+class TrialSummary:
+    task_name: str
+    # None when the verifier produced no reward (counted as 0.0 in the mean).
+    reward: float | None
+    exception: str | None
+
+
+@dataclass(frozen=True)
+class HarborEvalSummary:
+    n_total_trials: int
+    n_errored_trials: int
+    mean_reward: float | None
+    trials: dict[str, TrialSummary]
+
+
+def summarize_job_result(result) -> HarborEvalSummary:
+    """Flatten a Harbor ``JobResult`` into per-trial rewards and a mean."""
+    trials = {}
+    rewards = []
+    for trial in result.trial_results:
+        reward = None
+        if trial.verifier_result is not None and trial.verifier_result.rewards:
+            reward = trial.verifier_result.rewards.get("reward")
+        reward = float(reward) if isinstance(reward, int | float) else None
+        rewards.append(reward if reward is not None else 0.0)
+        trials[trial.trial_name] = TrialSummary(
+            task_name=trial.task_name,
+            reward=reward,
+            exception=trial.exception_info.exception_type if trial.exception_info else None,
+        )
+    return HarborEvalSummary(
+        n_total_trials=result.n_total_trials,
+        n_errored_trials=result.stats.n_errored_trials,
+        mean_reward=statistics.mean(rewards) if rewards else None,
+        trials=trials,
+    )

--- a/lib/marin/src/marin/harbor/iris_environment.py
+++ b/lib/marin/src/marin/harbor/iris_environment.py
@@ -4,17 +4,23 @@
 """Harbor environment backend that runs each sandbox as an Iris job.
 
 Each sandbox runs as its own CPU-only Iris job on cluster workers (bin-packed
-onto spare host CPU, TPU hosts included). Only prebuilt-image tasks
-(``[environment] docker_image = ...``) are supported; Dockerfile/compose
-builds are not.
+onto spare host CPU, TPU hosts included). Prebuilt-image tasks
+(``[environment] docker_image = ...``) run the image directly. Dockerfile
+tasks submit the admin-gated DOCKER_ACCESS profile and drive the worker's own
+docker daemon: a real ``docker build`` of the task's environment dir under a
+content-keyed tag (identical environments reuse the built image and its layer
+cache across trials), then the task runs as a sibling container that execs
+are routed into. ``container_profile`` describes the task container's
+security posture in both shapes; siblings get it as the equivalent docker-run
+flags. Dockerfile tasks need a docker-worker cluster (the k8s backend rejects
+DOCKER_ACCESS at submission). Compose tasks are not supported.
 
 The default ``gvisor`` profile submits CONTAINER_PROFILE_GVISOR: the whole
 task container runs under the gVisor runtime (docker --runtime=runsc), so
 untrusted agent code gets full in-container root (apt/setuid work) behind
-gVisor's intercepted guest kernel instead of the host kernel, with no admin
-gate. Requires runsc on the worker — installed by the GCP worker bootstrap on
-workers booted with post-#7339 code; on older workers GVISOR jobs fail at
-container creation.
+gVisor's intercepted guest kernel, with no admin gate. Requires runsc on the
+worker (the GCP worker bootstrap installs it); workers without it fail GVISOR
+jobs at container creation.
 
 Usage:
     harbor trials start -p <task-dir> -a oracle \\
@@ -24,6 +30,7 @@ Usage:
 
 import asyncio
 import base64
+import hashlib
 import re
 import shlex
 import tarfile
@@ -36,6 +43,7 @@ from harbor.environments.capabilities import EnvironmentCapabilities, Environmen
 from harbor.trial.errors import EnvironmentStartTimeoutError
 from iris.cli.connect import ControllerEndpoint, connect_controller
 from iris.client import IrisClient, Job
+from iris.cluster.runtime.docker import security_flags
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec
 from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.compression import IRIS_RPC_COMPRESSIONS
@@ -46,7 +54,12 @@ from upath import UPath
 
 ENVIRONMENT_TYPE = "iris"
 
-UPLOAD_CHUNK_BYTES = 256 * 1024
+DOCKERFILE_NAME = "Dockerfile"
+
+# Chunks ride inside a single `sh -c` argument; base64 inflates 4/3, and Linux
+# caps one argv string at MAX_ARG_STRLEN (128 KiB) — 256 KiB chunks fail with
+# "Argument list too long" on any file bigger than one chunk.
+UPLOAD_CHUNK_BYTES = 64 * 1024
 DOWNLOAD_CHUNK_BYTES = 1024 * 1024
 DEFAULT_SCHEDULING_TIMEOUT = 600
 # Hard job TTL so a sandbox whose harness died without stop() cannot reserve
@@ -68,6 +81,21 @@ _CONTAINER_PROFILES = {
     "privileged": job_pb2.CONTAINER_PROFILE_PRIVILEGED,
     GVISOR_PROFILE: job_pb2.CONTAINER_PROFILE_GVISOR,
 }
+
+
+# Dockerfile-task job image: needs the bash Iris's docker runtime requires plus
+# curl — DOCKER_ACCESS drops all capabilities, so apt (which setuids to _apt)
+# cannot install anything; the docker client is fetched as static binaries.
+BUILD_JOB_IMAGE = "buildpack-deps:bookworm-curl"
+DOCKER_CLI_VERSION = "28.1.1"
+BUILDX_VERSION = "0.21.2"
+# uname -m (x86_64/aarch64) → the goarch names buildx releases use.
+_BUILDX_ARCHES = {"x86_64": "amd64", "aarch64": "arm64"}
+BUILD_CONTEXT_DIR = "/harbor-build"
+# Content-keyed image tags on the worker's daemon: identical environment dirs
+# reuse the already-built image (and its layer cache) across trials.
+BUILD_IMAGE_REPO = "harbor-env"
+DOCKER_CLI_INSTALL_TIMEOUT = 300
 
 _LOCAL_PROTOCOLS = ("", "file", "local")
 
@@ -135,15 +163,18 @@ class IrisEnvironment(BaseEnvironment):
             scheduling_timeout: Seconds to wait for the sandbox task to be
                 scheduled and reach RUNNING. Accepts str because harbor's
                 --environment-kwarg values arrive as strings.
-            container_profile: "gvisor" (default) runs the task container
-                under the gVisor runtime — full in-container root (apt/setuid)
-                isolated from the host kernel, no admin gate, but the worker
-                must carry runsc (post-#7339 boots). "default" drops all
+            container_profile: The task container's security posture. "gvisor"
+                (default) runs it under the gVisor runtime — full in-container
+                root (apt/setuid) isolated from the host kernel, no admin
+                gate; requires runsc on the worker. "default" drops all
                 capabilities, so setuid commands fail there; "privileged" is
-                admin-gated.
+                admin-gated. Dockerfile tasks submit the admin-gated
+                DOCKER_ACCESS profile for the job and apply this posture to
+                the sibling task container.
             sandbox_ttl: Hard job TTL in seconds after which Iris kills the
                 sandbox even if stop() is never called (leaked-harness safety
-                net). Accepts str like scheduling_timeout.
+                net). Accepts str like scheduling_timeout. Sibling containers
+                get the same TTL via a `timeout` entrypoint.
         """
         super().__init__(*args, **kwargs)
         if (cluster is None) == (controller_url is None):
@@ -158,6 +189,9 @@ class IrisEnvironment(BaseEnvironment):
         self._rpc: ControllerServiceClientSync | None = None
         self._job: Job | None = None
         self._task_id: str | None = None
+        # Name of the started sibling task container (Dockerfile tasks);
+        # execs are routed into it once set.
+        self._sibling: str | None = None
 
     @staticmethod
     def type() -> str:
@@ -173,23 +207,40 @@ class IrisEnvironment(BaseEnvironment):
         return EnvironmentResourceCapabilities(cpu_request=True, memory_request=True)
 
     def _validate_definition(self):
-        if not self.task_env_config.docker_image:
-            raise ValueError(
-                "IrisEnvironment only supports prebuilt-image tasks "
-                "([environment] docker_image = ...); Dockerfile builds are not supported."
-            )
+        if not self.task_env_config.docker_image and not (self.environment_dir / DOCKERFILE_NAME).exists():
+            raise ValueError("IrisEnvironment requires [environment] docker_image = ... or an environment/Dockerfile.")
+
+    @property
+    def _builds_sibling(self) -> bool:
+        """True when this task's Dockerfile is built on the worker's daemon."""
+        return not self.task_env_config.docker_image
+
+    def _task_image(self) -> str:
+        if self._builds_sibling:
+            return BUILD_JOB_IMAGE
+        assert self.task_env_config.docker_image is not None
+        return self.task_env_config.docker_image
+
+    def _job_container_profile(self) -> int:
+        # Sibling builds need the host docker socket regardless of the sandbox
+        # posture, which is applied to the sibling instead.
+        if self._builds_sibling:
+            return job_pb2.CONTAINER_PROFILE_DOCKER_ACCESS
+        return self._container_profile
 
     def _job_name(self) -> str:
         sanitized = re.sub(r"[^a-zA-Z0-9_.-]", "-", self.session_id).strip("-")
         return f"harbor-{sanitized}"[:120]
 
     async def start(self, force_build: bool) -> None:
-        del force_build  # Prebuilt images only; nothing to build.
+        del force_build  # Dockerfile-task images are content-keyed on the worker's daemon.
         await asyncio.to_thread(self._start_sync)
         # From here the job is live: tear it down if the rest of start fails
         # (or is cancelled), so a failed start cannot leak a sandbox until
         # the TTL fires.
         try:
+            if self._builds_sibling:
+                await self._start_sibling()
             # Non-mounting environments use the trial's mount targets as mkdir
             # hints (e.g. /logs/agent, /logs/verifier); see BaseEnvironment.mounts.
             dirs = self._mount_targets(writable_only=True)
@@ -241,8 +292,8 @@ class IrisEnvironment(BaseEnvironment):
                     memory=(self.task_env_config.memory_mb or DEFAULT_MEMORY_MB) * 1024 * 1024,
                     disk=(self.task_env_config.storage_mb or DEFAULT_STORAGE_MB) * 1024 * 1024,
                 ),
-                task_image=self.task_env_config.docker_image,
-                container_profile=self._container_profile,
+                task_image=self._task_image(),
+                container_profile=self._job_container_profile(),
                 scheduling_timeout=Duration.from_seconds(self._scheduling_timeout),
                 timeout=Duration.from_seconds(self._sandbox_ttl),
                 # A restarted sandbox is a fresh container with all trial state lost,
@@ -284,18 +335,31 @@ class IrisEnvironment(BaseEnvironment):
         await asyncio.to_thread(self._stop_sync)
 
     def _stop_sync(self) -> None:
-        if self._job is not None:
-            self._job.terminate()
-            self._job = None
-        self._task_id = None
-        self._rpc = None
-        if self._iris is not None:
-            self._iris.shutdown()
-            self._iris = None
-        # Close the tunnel last: the client above reaches the controller through it.
-        if self._endpoint is not None:
-            self._endpoint.close()
-            self._endpoint = None
+        try:
+            if self._job is not None and self._sibling is not None:
+                # The sibling outlives the job unless removed; its `timeout`
+                # entrypoint is only the leaked-harness backstop. A failure
+                # here still propagates (as IrisSandboxError) after the rest
+                # of the teardown runs, so a leaked sibling is never silent.
+                _require_success(
+                    self._exec_sync(f"docker rm -f {shlex.quote(self._sibling)}", timeout_sec=60),
+                    f"failed to remove sibling container {self._sibling}",
+                    IrisSandboxError,
+                )
+        finally:
+            self._sibling = None
+            if self._job is not None:
+                self._job.terminate()
+                self._job = None
+            self._task_id = None
+            self._rpc = None
+            if self._iris is not None:
+                self._iris.shutdown()
+                self._iris = None
+            # Close the tunnel last: the client above reaches the controller through it.
+            if self._endpoint is not None:
+                self._endpoint.close()
+                self._endpoint = None
 
     async def exec(
         self,
@@ -305,9 +369,84 @@ class IrisEnvironment(BaseEnvironment):
         timeout_sec: int | None = None,
         user: str | int | None = None,
     ) -> ExecResult:
-        effective_cwd = cwd or self.task_env_config.workdir
+        if self._builds_sibling and self._sibling is None:
+            # Sibling not up yet: this exec is build plumbing in the job
+            # container, where the task's workdir does not exist.
+            effective_cwd = cwd
+        else:
+            effective_cwd = cwd or self.task_env_config.workdir
         script = self._build_script(command, cwd=effective_cwd, env=env, user=user)
+        if self._sibling is not None:
+            # docker exec applies the image's ENV/WORKDIR; -u 0 matches the
+            # container-root default of the direct exec path, with user
+            # switching handled by _build_script's su wrapping.
+            script = f"docker exec -u 0 {shlex.quote(self._sibling)} sh -c {shlex.quote(script)}"
         return await asyncio.to_thread(self._exec_sync, script, timeout_sec)
+
+    async def _start_sibling(self) -> None:
+        """Build the task's Dockerfile on the worker's daemon and start the task container.
+
+        The job container is trusted plumbing holding the docker socket; the
+        built image — where untrusted agent code runs — executes as a sibling
+        container, under runsc when the gvisor profile is selected.
+        """
+        arch = (await self._plumbing_exec("uname -m", error="failed to probe arch")).stdout.strip()
+        buildx_arch = _BUILDX_ARCHES[arch]
+        await self._plumbing_exec(
+            f"curl -fsSL https://download.docker.com/linux/static/stable/{arch}/docker-{DOCKER_CLI_VERSION}.tgz"
+            # --no-same-owner: restoring the archive's uids needs CAP_CHOWN,
+            # which the capability-dropped DOCKER_ACCESS job does not have.
+            " | tar -xz --no-same-owner -C /usr/local/bin --strip-components=1 docker/docker"
+            " && mkdir -p /usr/local/lib/docker/cli-plugins"
+            " && curl -fsSL https://github.com/docker/buildx/releases/download/"
+            f"v{BUILDX_VERSION}/buildx-v{BUILDX_VERSION}.linux-{buildx_arch}"
+            " -o /usr/local/lib/docker/cli-plugins/docker-buildx"
+            " && chmod 0755 /usr/local/lib/docker/cli-plugins/docker-buildx",
+            timeout_sec=DOCKER_CLI_INSTALL_TIMEOUT,
+            error="failed to install the docker client",
+        )
+        await self.upload_dir(self.environment_dir, BUILD_CONTEXT_DIR)
+        image = f"{BUILD_IMAGE_REPO}:{self._environment_content_hash()}"
+        build_timeout = int(self.task_env_config.build_timeout_sec)
+        await self._plumbing_exec(
+            f"docker image inspect {image} > /dev/null 2>&1"
+            f" || DOCKER_BUILDKIT=1 docker build -t {image} {BUILD_CONTEXT_DIR}",
+            timeout_sec=build_timeout,
+            error=f"docker build failed for {self.environment_dir}",
+        )
+        sibling = self._job_name()
+        cpus = self.task_env_config.cpus or DEFAULT_CPUS
+        memory_mb = self.task_env_config.memory_mb or DEFAULT_MEMORY_MB
+        # No disk bound on the sibling: docker's --storage-opt size= needs
+        # pquota-backed overlay2, which the fleet's workers do not run. The
+        # job's storage_mb reservation still covers bin-packing accounting.
+        # The sibling gets the same posture flags iris applies for the profile,
+        # so container_profile means the task container's posture in both modes.
+        posture = " ".join(security_flags(self._container_profile, is_tpu_run=False))
+        await self._plumbing_exec(
+            f"docker run -d --rm --name {shlex.quote(sibling)} {posture}"
+            f" --cpus {cpus} --memory {memory_mb}m"
+            f" --entrypoint timeout {image} {self._sandbox_ttl} sleep infinity",
+            error=f"failed to start sibling container from {image}",
+        )
+        self._sibling = sibling
+        self.logger.info(f"Sibling container {sibling} running image {image}")
+
+    async def _plumbing_exec(self, command: str, timeout_sec: int | None = None, error: str | None = None) -> ExecResult:
+        """Run a command in the job container (docker plumbing, never the sandbox)."""
+        result = await asyncio.to_thread(self._exec_sync, command, timeout_sec)
+        return _require_success(result, error or f"command failed: {command}", IrisSandboxError)
+
+    def _environment_content_hash(self) -> str:
+        digest = hashlib.sha256()
+        for file in sorted(self.environment_dir.rglob("*")):
+            if file.is_file():
+                digest.update(file.relative_to(self.environment_dir).as_posix().encode())
+                # Permission bits change the built image (COPY preserves them),
+                # so they must change the tag too.
+                digest.update(f"\0{file.stat().st_mode & 0o777:o}\0".encode())
+                digest.update(file.read_bytes())
+        return digest.hexdigest()[:16]
 
     def _build_script(
         self,


### PR DESCRIPTION
My initial Harbor Iris sandbox backend only ran prebuilt images, but most benchmark tasks (OpenThoughts-TBLite included) define their environment as a Dockerfile without pointing to a pre-built image. So we need a registry pipeline of some sort! This is that.

Dockerfile tasks now submit the DOCKER_ACCESS profile and drive the worker's own docker daemon: a real docker build of the environment dir under a content-keyed tag (repeat trials reuse the built image and layer cache), with the task running as a sibling container that execs route into. 

This is in service of a smaller change here: marin.evaluation.harbor_eval runs a Harbor registry dataset against an already served model and served_qwen3 gains an OT TB Lite step.

Open Issue reserved for later: Dockerfile tasks therefore need a docker-worker cluster; the k8s backend rejects DOCKER_ACCESS at submission so this only works on TPU cluster rn.