### PR TITLE
feat(transform/conversation): tool-calling passthrough + reusable tools->chat_template_kwargs for agentic SFT

### DIFF
--- a/lib/marin/src/marin/transform/conversation/adapters.py
+++ b/lib/marin/src/marin/transform/conversation/adapters.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
+import json
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
@@ -128,7 +129,22 @@ class TransformAdapter:
             conversation = row[self.conversation_column]
             for conv in conversation:
                 role = role_to_openai_role[conv[self.role_key]]
-                messages.append(OpenAIChatMessage(role=role, content=conv[self.content_key]))
+                message = OpenAIChatMessage(role=role, content=conv[self.content_key])
+                # Preserve structured tool-calling fields when present (agentic / tool-calling SFT):
+                # the plain role/content mapping otherwise drops assistant ``tool_calls`` and the
+                # ``tool_call_id``/``name`` that carry the <tool_call>/<tool_response> structure a
+                # tools-aware chat template renders. No-op for conversations without these keys, so it
+                # is backward-compatible for plain chat datasets.
+                tool_calls = conv.get("tool_calls")
+                if tool_calls:
+                    message.tool_calls = tool_calls
+                tool_call_id = conv.get("tool_call_id")
+                if tool_call_id is not None:
+                    message.tool_call_id = tool_call_id
+                name = conv.get("name")
+                if name is not None:
+                    message.name = name
+                messages.append(message)
             return messages
         elif self.dataset_format == InputDatasetFormat.INSTRUCT_COLUMN_RESPONSE:
             messages = []
@@ -164,3 +180,38 @@ class TransformAdapter:
 
     def copy(self) -> "TransformAdapter":
         return dataclasses.replace(self)
+
+
+def tools_column_to_chat_template_kwargs(row: dict[str, Any], *, tools_column: str = "tools") -> dict[str, Any]:
+    """Relocate a per-row ``tools`` column into a ``chat_template_kwargs`` column.
+
+    Intended as a ``TransformAdapter.extra_metadata_fn`` for tool-calling / agentic SFT datasets
+    (e.g. the opencode serve-parity data) whose rows carry the callable function schemas in a
+    ``tools`` column. Levanter's ``ChatLmDatasetFormat`` has no ``tools`` column wiring: it renders
+    the template with ``apply_chat_template(..., **chat_template_kwargs)`` and, by default, reads
+    those kwargs from a ``chat_template_kwargs`` column. Emitting ``{"chat_template_kwargs":
+    {"tools": [...]}}`` here makes the template's ``{% if tools %}`` / ``<tools>`` system block
+    render per row, byte-for-byte matching a HuggingFace ``apply_chat_template(tools=...)`` render.
+
+    ``tools`` may be a JSON string (Arrow-safe datasets store the schema list as a string) or an
+    already-parsed list; both are handled. Returns ``{}`` (no extra column) when ``tools`` is
+    missing, empty, or an unparseable string, so rows without tools are unaffected. Mirrors the
+    ``chat_template_kwargs``-emitting pattern of ``ReasoningToChatKwargs`` in
+    ``experiments/datasets/instruction.py``.
+
+    Assistant ``tool_calls.function.arguments`` JSON-string parsing is handled separately by
+    ``transform_conversation._normalize_tool_structures`` (already applied by ``transform_row``),
+    and empty ``tool_calls`` lists are dropped by the ``SINGLE_COLUMN_MULTI_TURN`` adapter's
+    truthiness guard, so this function only concerns the ``tools`` schema relocation.
+    """
+    tools = row.get(tools_column)
+    if tools is None:
+        return {}
+    if isinstance(tools, str):
+        try:
+            tools = json.loads(tools)
+        except json.JSONDecodeError:
+            return {}
+    if not tools:
+        return {}
+    return {"chat_template_kwargs": {"tools": tools}}

--- a/tests/transform/test_conversation.py
+++ b/tests/transform/test_conversation.py
@@ -3,9 +3,15 @@
 
 """Tests for conversation data transformation scripts."""
 
+import json
 from pathlib import Path
+from typing import ClassVar
 
-from marin.transform.conversation.adapters import InputDatasetFormat, TransformAdapter
+from marin.transform.conversation.adapters import (
+    InputDatasetFormat,
+    TransformAdapter,
+    tools_column_to_chat_template_kwargs,
+)
 from marin.transform.conversation.conversation_to_dolma import transform_conversation_to_dolma
 from marin.transform.conversation.preference_data_adapters import PreferenceTransformAdapter
 from marin.transform.conversation.transform_conversation import (
@@ -101,6 +107,44 @@ class TestTransformAdapters:
         assert messages[0].content == "What is the capital of France?"
         assert messages[1].role == "assistant"
         assert messages[1].content == "The capital of France is Paris."
+
+    def test_multi_turn_preserves_tool_calling_fields(self):
+        """SINGLE_COLUMN_MULTI_TURN passes through assistant tool_calls + tool_call_id/name."""
+        adapter = TransformAdapter(
+            dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
+            conversation_column="messages",
+        )
+        row = {
+            "messages": [
+                {"role": "user", "content": "List the files."},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{"type": "function", "function": {"name": "bash", "arguments": '{"command": "ls"}'}}],
+                },
+                {"role": "tool", "content": "a.py\nb.py", "tool_call_id": "call_1", "name": "bash"},
+            ]
+        }
+
+        messages = adapter.transform_conversation_to_openai_format(row)
+
+        assert messages[1].tool_calls == row["messages"][1]["tool_calls"]
+        assert messages[2].role == "tool"
+        assert messages[2].tool_call_id == "call_1"
+        assert messages[2].name == "bash"
+        # A plain user turn carries none of the tool fields.
+        assert messages[0].tool_calls is None
+        assert messages[0].tool_call_id is None
+
+    def test_multi_turn_empty_tool_calls_dropped(self):
+        """An empty tool_calls list is not attached (truthiness guard), matching template semantics."""
+        adapter = TransformAdapter(
+            dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
+            conversation_column="messages",
+        )
+        row = {"messages": [{"role": "assistant", "content": "hi", "tool_calls": []}]}
+        messages = adapter.transform_conversation_to_openai_format(row)
+        assert messages[0].tool_calls is None
 
     def test_sharegpt_format_adapter(self):
         """Test ShareGPT format adapter."""
@@ -243,6 +287,54 @@ class TestTransformRow:
         }
 
         assert transform_row(row, cfg, adapter) is None
+
+
+class TestToolsColumnToChatTemplateKwargs:
+    """Test the reusable ``tools`` -> ``chat_template_kwargs`` extra_metadata_fn."""
+
+    TOOLS: ClassVar = [{"type": "function", "function": {"name": "bash", "parameters": {}}}]
+
+    def test_tools_json_string_relocated(self):
+        row = {"messages": [], "tools": json.dumps(self.TOOLS)}
+        assert tools_column_to_chat_template_kwargs(row) == {"chat_template_kwargs": {"tools": self.TOOLS}}
+
+    def test_tools_already_parsed_list(self):
+        row = {"messages": [], "tools": self.TOOLS}
+        assert tools_column_to_chat_template_kwargs(row) == {"chat_template_kwargs": {"tools": self.TOOLS}}
+
+    def test_missing_tools_returns_empty(self):
+        assert tools_column_to_chat_template_kwargs({"messages": []}) == {}
+
+    def test_empty_and_unparseable_return_empty(self):
+        assert tools_column_to_chat_template_kwargs({"tools": "[]"}) == {}
+        assert tools_column_to_chat_template_kwargs({"tools": []}) == {}
+        assert tools_column_to_chat_template_kwargs({"tools": "{not json"}) == {}
+
+    def test_flows_through_transform_row_as_extra_column(self):
+        """End-to-end: the emitted chat_template_kwargs lands as a top-level extra column."""
+        adapter = TransformAdapter(
+            dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
+            conversation_column="messages",
+            replacements={},
+            extra_metadata_fn=tools_column_to_chat_template_kwargs,
+        )
+        cfg = TransformSFTDatasetConfig(
+            source="test/tools",
+            revision="main",
+            output_path="/tmp/output",
+            metadata_columns=[],
+            adapter=adapter,
+        )
+        row = {
+            "messages": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ],
+            "tools": json.dumps(self.TOOLS),
+        }
+        result = transform_row(row, cfg, adapter)
+        assert result is not None
+        assert result.model_dump()["chat_template_kwargs"] == {"tools": self.TOOLS}
 
 
 class TestPreferenceDataTransform:


### PR DESCRIPTION
## What

Reusable **conversation-preprocessing** for tool-calling / agentic (opencode-style) SFT — the marin-core half of the Levanter⇄Axolotl opencode-SFT tokenization-parity path. It makes a tools-aware chat template render byte-for-byte the same tokenization it will see at serve time.

**`lib/marin/src/marin/transform/conversation/adapters.py`**
- `SINGLE_COLUMN_MULTI_TURN` adapter now **passes through** assistant `tool_calls` and the `tool_call_id`/`name` on tool turns. The plain role/content mapping otherwise drops the structured fields that carry the `<tool_call>`/`<tool_response>` structure. Backward-compatible no-op for plain chat datasets; an empty `tool_calls` list is not attached (truthiness guard).
- New reusable, documented **`tools_column_to_chat_template_kwargs(row)`** `extra_metadata_fn`: relocate a per-row `tools` column (JSON string or list) into a `chat_template_kwargs` column so Levanter's `ChatLmDatasetFormat` renders the `<tools>` system block (Levanter has no `tools` column wiring). Generalized out of a run-specific config; mirrors the `chat_template_kwargs`-emitting pattern of `ReasoningToChatKwargs`.

Assistant tool-call `arguments` JSON-string→dict parsing is **already** handled upstream by `transform_conversation._normalize_tool_structures` (no change needed here).

**`tests/transform/test_conversation.py`** — tool-field passthrough, empty-`tool_calls` dropped, the reusable fn (json-string / list / missing / empty / unparseable), and an end-to-end `transform_row` check that tools land as a top-level column and arguments parse to a dict.

## Parity verdict (why this is correct)

Validated by a byte-exact harness that runs **each framework's own tokenization code** on `Qwen/Qwen3-30B-A3B-Thinking-2507` over 60 real rows of the densemoe SFT set `laion/nemotron-code-oracle-opencode-sft-serveparity`:

- **`input_ids` BYTE-EXACT 60/60** — incl. tool-schema `| tojson`, tool-call-`arguments` serialization, `role: tool`/`<tool_response>` framing, `<think>`, special tokens, BOS/EOS (both `add_special_tokens=False`; no double BOS).
- loss mask is not bit-identical, but that residual is an **Axolotl `find_turn` runtime-diff artifact** (0.38% turn-boundary jitter), not anything this PR affects.

**Reproduce it:**
- Harness (re-runnable): https://gist.github.com/penfever/7ccfe7762926e1a33df1bc004bd4ce96
- Artifacts (templates, 60 sample rows, both frameworks' tokens, reports + verdict): https://gist.github.com/penfever/ac54b452fef28b0e449f55f4f4379435

## Paired with

PR that lands the `{% generation %}`-annotated tools-aware chat-template resource + the `ChatLmDatasetFormat` wiring the transformed data plugs into: #7455

Part of the opencode-SFT data-preprocessing path for #7098.
