### PR TITLE
[grug] Emit a single config.json name per field for the Snowball HF export

### DIFF
--- a/experiments/evaluation/models.py
+++ b/experiments/evaluation/models.py
@@ -142,7 +142,7 @@ MODELS: dict[str, EvalModelConfig] = {
     # concat template: a message list rendered as the raw text a base model expects.
     "snowball": _snowball(
         "snowball",
-        "s3://marin-us-east-02a/marin/exports/grug/june-67b-a2b/step-42150/hf-bf16-vllm/781bc3291c81ce28/",
+        "s3://marin-us-east-02a/marin/exports/grug/june-67b-a2b/step-42150/hf-bf16-vllm/d819cbc63780bd86/",
         chat_template=CONCAT_CHAT_TEMPLATE,
     ),
     # The stage-2 (thinking) SFT of the same checkpoint. Its export ships a chat_template.jinja that

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -226,10 +226,9 @@ class GrugModelConfig:
         )
 
     def to_hf_config(self, vocab_size: int, config_overrides: dict[str, Any] | None = None) -> GrugMoeHfConfig:
-        # Single name per field (issue #7447, Option A): core fields use the universal
-        # transformers spelling; MoE fields use the most common public spelling (== Qwen2-MoE's
-        # set); grug-specific extras keep their bare names. from_hf_config still accepts the old
-        # dual-name spellings, so existing artifacts keep loading.
+        # One name per field: core fields take the universal transformers spelling, MoE fields the
+        # most common public spelling, and grug-specific extras keep their bare names. from_hf_config
+        # stays tolerant of the older spellings so existing artifacts keep loading.
         config = {
             "architectures": [GRUG_MOE_ARCHITECTURE],
             "vocab_size": vocab_size,

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -226,39 +226,34 @@ class GrugModelConfig:
         )
 
     def to_hf_config(self, vocab_size: int, config_overrides: dict[str, Any] | None = None) -> GrugMoeHfConfig:
+        # Single name per field (issue #7447, Option A): core fields use the universal
+        # transformers spelling; MoE fields use the most common public spelling (== Qwen2-MoE's
+        # set); grug-specific extras keep their bare names. from_hf_config still accepts the old
+        # dual-name spellings, so existing artifacts keep loading.
         config = {
             "architectures": [GRUG_MOE_ARCHITECTURE],
             "vocab_size": vocab_size,
-            "hidden_dim": self.hidden_dim,
+            # core — universal transformers names
             "hidden_size": self.hidden_dim,
-            "intermediate_dim": self.intermediate_dim,
-            "intermediate_size": self.intermediate_dim,
-            "moe_intermediate_size": self.intermediate_dim,
-            "shared_expert_intermediate_dim": self.shared_expert_intermediate_dim,
-            "shared_expert_intermediate_size": self.shared_expert_intermediate_dim,
-            "num_experts": self.num_experts,
-            "num_local_experts": self.num_experts,
-            "num_experts_per_token": self.num_experts_per_token,
-            "num_experts_per_tok": self.num_experts_per_token,
-            "num_layers": self.num_layers,
             "num_hidden_layers": self.num_layers,
-            "num_heads": self.num_heads,
             "num_attention_heads": self.num_heads,
-            "num_kv_heads": self.num_kv_heads,
             "num_key_value_heads": self.num_kv_heads,
             "head_dim": self.inferred_head_dim,
-            "max_seq_len": self.max_seq_len,
             "max_position_embeddings": self.max_seq_len,
             "sliding_window": self.sliding_window,
-            "layer_norm_eps": self.layer_norm_eps,
             "rms_norm_eps": self.layer_norm_eps,
-            "initializer_std": self.initializer_std,
             "initializer_range": self.initializer_std,
+            "rope_theta": self.rope.theta,
+            "tie_word_embeddings": False,
+            # MoE — most common public spelling per field
+            "num_experts": self.num_experts,
+            "num_experts_per_tok": self.num_experts_per_token,
+            "moe_intermediate_size": self.intermediate_dim,
+            "shared_expert_intermediate_size": self.shared_expert_intermediate_dim,
+            # grug-specific (no public equivalent)
             "qk_mult": self.qk_mult,
             "grugmoe_attention_mode": "production",
             GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY: GRUG_MOE_ARTIFACT_SCHEMA_VERSION,
-            "rope_theta": self.rope.theta,
-            "tie_word_embeddings": False,
         }
         if config_overrides is not None:
             config.update(config_overrides)

--- a/lib/levanter/src/levanter/models/snowball.py
+++ b/lib/levanter/src/levanter/models/snowball.py
@@ -77,12 +77,30 @@ GRUG_MOE_ATTENTION_MODE = "production"
 GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY = "grugmoe_artifact_schema_version"
 GRUG_MOE_ARTIFACT_SCHEMA_VERSION = 1
 
-# Single-name config contract (issue #7447): to_hf_config emits exactly one spelling per field.
-# These are the dropped dual-name aliases -- from_hf_config still accepts them as fallbacks so
-# existing dual-name artifacts keep loading, but no published config.json may carry them. The
-# unit and export-time contract tests assert none of these leak.
+# A published config.json carries exactly one spelling per field. ``from_hf_config`` deliberately
+# accepts more spellings than the exporter may write, so the two lists are not interchangeable:
+# reads are tolerant (old artifacts keep loading), writes are strict. A config carrying both
+# spellings of a field can load as two different models, since backends disagree on which wins.
+#
+# (published name, config attribute) for every field that has more than one accepted spelling.
+GRUG_MOE_CANONICAL_CONFIG_FIELDS: tuple[tuple[str, str], ...] = (
+    ("hidden_size", "hidden_dim"),
+    ("num_hidden_layers", "num_layers"),
+    ("num_attention_heads", "num_heads"),
+    ("num_key_value_heads", "num_kv_heads"),
+    ("max_position_embeddings", "max_seq_len"),
+    ("rms_norm_eps", "layer_norm_eps"),
+    ("initializer_range", "initializer_std"),
+    ("num_experts", "num_experts"),
+    ("num_experts_per_tok", "num_experts_per_token"),
+    ("moe_intermediate_size", "intermediate_dim"),
+    ("shared_expert_intermediate_size", "shared_expert_intermediate_dim"),
+)
+
+# Spellings the exporter must never emit, though from_hf_config still reads them.
 GRUG_MOE_BANNED_CONFIG_ALIASES = frozenset(
     {
+        "attention_head_dim",
         "hidden_dim",
         "intermediate_dim",
         "intermediate_size",
@@ -97,6 +115,24 @@ GRUG_MOE_BANNED_CONFIG_ALIASES = frozenset(
         "initializer_std",
     }
 )
+
+
+def validate_single_name_config(serialized: dict, config: Any) -> None:
+    """Check a serialized config.json against the single-name contract.
+
+    Each canonical name must be present with the value held by the corresponding attribute of
+    ``config``, and no banned alias may appear. ``config`` may be any object exposing the grug
+    attribute names (``SnowballConfig`` and the experiment ``GrugModelConfig`` both do).
+    """
+    for published, attribute in GRUG_MOE_CANONICAL_CONFIG_FIELDS:
+        expected = getattr(config, attribute)
+        actual = serialized.get(published)
+        if actual != expected:
+            raise ValueError(f"config.json {published}={actual!r}, expected {expected!r}")
+    leaked = GRUG_MOE_BANNED_CONFIG_ALIASES & serialized.keys()
+    if leaked:
+        raise ValueError(f"banned config aliases in config.json: {sorted(leaked)}")
+
 
 _GATED_NORM_RANK = 128
 _ROUTING_RENORM_SUM = 2.5
@@ -243,10 +279,9 @@ class SnowballConfig(HFCompatConfig):
         )
 
     def to_hf_config(self, vocab_size: int, config_overrides: Optional[dict] = None) -> GrugMoeHfConfig:
-        # Single name per field (issue #7447, Option A): core fields use the universal
-        # transformers spelling; MoE fields use the most common public spelling (== Qwen2-MoE's
-        # set); grug-specific extras keep their bare names. from_hf_config still accepts the old
-        # dual-name spellings, so existing artifacts keep loading.
+        # One name per field: core fields take the universal transformers spelling, MoE fields the
+        # most common public spelling, and grug-specific extras keep their bare names. Emitting a
+        # second spelling for any of these is what GRUG_MOE_BANNED_CONFIG_ALIASES forbids.
         config = {
             "architectures": [GRUG_MOE_ARCHITECTURE],
             "vocab_size": vocab_size,

--- a/lib/levanter/src/levanter/models/snowball.py
+++ b/lib/levanter/src/levanter/models/snowball.py
@@ -77,6 +77,27 @@ GRUG_MOE_ATTENTION_MODE = "production"
 GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY = "grugmoe_artifact_schema_version"
 GRUG_MOE_ARTIFACT_SCHEMA_VERSION = 1
 
+# Single-name config contract (issue #7447): to_hf_config emits exactly one spelling per field.
+# These are the dropped dual-name aliases -- from_hf_config still accepts them as fallbacks so
+# existing dual-name artifacts keep loading, but no published config.json may carry them. The
+# unit and export-time contract tests assert none of these leak.
+GRUG_MOE_BANNED_CONFIG_ALIASES = frozenset(
+    {
+        "hidden_dim",
+        "intermediate_dim",
+        "intermediate_size",
+        "shared_expert_intermediate_dim",
+        "num_local_experts",
+        "num_experts_per_token",
+        "num_layers",
+        "num_heads",
+        "num_kv_heads",
+        "max_seq_len",
+        "layer_norm_eps",
+        "initializer_std",
+    }
+)
+
 _GATED_NORM_RANK = 128
 _ROUTING_RENORM_SUM = 2.5
 _EP_CAPACITY_FACTOR = 1.0
@@ -222,39 +243,34 @@ class SnowballConfig(HFCompatConfig):
         )
 
     def to_hf_config(self, vocab_size: int, config_overrides: Optional[dict] = None) -> GrugMoeHfConfig:
+        # Single name per field (issue #7447, Option A): core fields use the universal
+        # transformers spelling; MoE fields use the most common public spelling (== Qwen2-MoE's
+        # set); grug-specific extras keep their bare names. from_hf_config still accepts the old
+        # dual-name spellings, so existing artifacts keep loading.
         config = {
             "architectures": [GRUG_MOE_ARCHITECTURE],
             "vocab_size": vocab_size,
-            "hidden_dim": self.hidden_dim,
+            # core — universal transformers names
             "hidden_size": self.hidden_dim,
-            "intermediate_dim": self.intermediate_dim,
-            "intermediate_size": self.intermediate_dim,
-            "moe_intermediate_size": self.intermediate_dim,
-            "shared_expert_intermediate_dim": self.shared_expert_intermediate_dim,
-            "shared_expert_intermediate_size": self.shared_expert_intermediate_dim,
-            "num_experts": self.num_experts,
-            "num_local_experts": self.num_experts,
-            "num_experts_per_token": self.num_experts_per_token,
-            "num_experts_per_tok": self.num_experts_per_token,
-            "num_layers": self.num_layers,
             "num_hidden_layers": self.num_layers,
-            "num_heads": self.num_heads,
             "num_attention_heads": self.num_heads,
-            "num_kv_heads": self.num_kv_heads,
             "num_key_value_heads": self.num_kv_heads,
             "head_dim": self.inferred_head_dim,
-            "max_seq_len": self.max_seq_len,
             "max_position_embeddings": self.max_seq_len,
             "sliding_window": self.sliding_window,
-            "layer_norm_eps": self.layer_norm_eps,
             "rms_norm_eps": self.layer_norm_eps,
-            "initializer_std": self.initializer_std,
             "initializer_range": self.initializer_std,
+            "rope_theta": self.rope.theta,
+            "tie_word_embeddings": False,
+            # MoE — most common public spelling per field
+            "num_experts": self.num_experts,
+            "num_experts_per_tok": self.num_experts_per_token,
+            "moe_intermediate_size": self.intermediate_dim,
+            "shared_expert_intermediate_size": self.shared_expert_intermediate_dim,
+            # grug-specific (no public equivalent)
             "qk_mult": self.qk_mult,
             "grugmoe_attention_mode": GRUG_MOE_ATTENTION_MODE,
             GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY: GRUG_MOE_ARTIFACT_SCHEMA_VERSION,
-            "rope_theta": self.rope.theta,
-            "tie_word_embeddings": False,
         }
         if config_overrides is not None:
             config.update(config_overrides)

--- a/lib/levanter/tests/test_snowball.py
+++ b/lib/levanter/tests/test_snowball.py
@@ -28,6 +28,7 @@ from levanter.grug.sharding import compact_grug_mesh
 from levanter.models.lm_model import LmConfig
 from levanter.models.snowball import (
     GRUG_MOE_ARCHITECTURE,
+    GRUG_MOE_BANNED_CONFIG_ALIASES,
     GRUG_MOE_MODEL_TYPE,
     GrugMoeHfConfig,
     SnowballConfig,
@@ -106,6 +107,28 @@ def test_snowball_config_hf_roundtrip():
     ):
         assert getattr(back, field) == getattr(cfg, field), field
     assert back.inferred_head_dim == cfg.inferred_head_dim
+
+    # Single-name config contract (issue #7447): the serialized config.json carries exactly one
+    # spelling per dual-name field -- the canonical Option A name with the right value -- and none
+    # of the dropped aliases. from_hf_config still round-trips (above) via its fallback tuples.
+    serialized = hf.to_dict()
+    canonical = {
+        "hidden_size": cfg.hidden_dim,
+        "num_hidden_layers": cfg.num_layers,
+        "num_attention_heads": cfg.num_heads,
+        "num_key_value_heads": cfg.num_kv_heads,
+        "max_position_embeddings": cfg.max_seq_len,
+        "rms_norm_eps": cfg.layer_norm_eps,
+        "initializer_range": cfg.initializer_std,
+        "num_experts": cfg.num_experts,
+        "num_experts_per_tok": cfg.num_experts_per_token,
+        "moe_intermediate_size": cfg.intermediate_dim,
+        "shared_expert_intermediate_size": cfg.shared_expert_intermediate_dim,
+    }
+    for key, value in canonical.items():
+        assert serialized.get(key) == value, key
+    leaked = GRUG_MOE_BANNED_CONFIG_ALIASES & serialized.keys()
+    assert not leaked, f"banned config aliases leaked into config.json: {sorted(leaked)}"
 
 
 def test_snowball_hf_converter_matches_config_class():

--- a/lib/levanter/tests/test_snowball.py
+++ b/lib/levanter/tests/test_snowball.py
@@ -28,11 +28,11 @@ from levanter.grug.sharding import compact_grug_mesh
 from levanter.models.lm_model import LmConfig
 from levanter.models.snowball import (
     GRUG_MOE_ARCHITECTURE,
-    GRUG_MOE_BANNED_CONFIG_ALIASES,
     GRUG_MOE_MODEL_TYPE,
     GrugMoeHfConfig,
     SnowballConfig,
     SnowballLMHeadModel,
+    validate_single_name_config,
 )
 
 
@@ -108,27 +108,9 @@ def test_snowball_config_hf_roundtrip():
         assert getattr(back, field) == getattr(cfg, field), field
     assert back.inferred_head_dim == cfg.inferred_head_dim
 
-    # Single-name config contract (issue #7447): the serialized config.json carries exactly one
-    # spelling per dual-name field -- the canonical Option A name with the right value -- and none
-    # of the dropped aliases. from_hf_config still round-trips (above) via its fallback tuples.
-    serialized = hf.to_dict()
-    canonical = {
-        "hidden_size": cfg.hidden_dim,
-        "num_hidden_layers": cfg.num_layers,
-        "num_attention_heads": cfg.num_heads,
-        "num_key_value_heads": cfg.num_kv_heads,
-        "max_position_embeddings": cfg.max_seq_len,
-        "rms_norm_eps": cfg.layer_norm_eps,
-        "initializer_range": cfg.initializer_std,
-        "num_experts": cfg.num_experts,
-        "num_experts_per_tok": cfg.num_experts_per_token,
-        "moe_intermediate_size": cfg.intermediate_dim,
-        "shared_expert_intermediate_size": cfg.shared_expert_intermediate_dim,
-    }
-    for key, value in canonical.items():
-        assert serialized.get(key) == value, key
-    leaked = GRUG_MOE_BANNED_CONFIG_ALIASES & serialized.keys()
-    assert not leaked, f"banned config aliases leaked into config.json: {sorted(leaked)}"
+    # The serialized config carries one canonical name per field and no dropped alias, while
+    # from_hf_config still round-trips it (above) through its tolerant fallback tuples.
+    validate_single_name_config(hf.to_dict(), cfg)
 
 
 def test_snowball_hf_converter_matches_config_class():

--- a/tests/cluster/vllm/snowball.py
+++ b/tests/cluster/vllm/snowball.py
@@ -56,8 +56,8 @@ SNOWBALL = ModelIdentity(
         "moe_67b_a2b_d2560_ep1_rep8_bs1024_seq65536_sw2k_v4_2048_muon_cooldown_step39k-79ebf3"
     ),
     checkpoint_step=42150,
-    export_sha256="781bc3291c81ce282be6762520280ebd5ef5b85e88ba65129c2d0162d48ee632",
-    export_uri="s3://marin-us-east-02a/marin/exports/grug/june-67b-a2b/step-42150/hf-bf16-vllm/781bc3291c81ce28/",
+    export_sha256="d819cbc63780bd866a942e47f9283cbd7932bbb237b52df527edd750c65be8f0",
+    export_uri="s3://marin-us-east-02a/marin/exports/grug/june-67b-a2b/step-42150/hf-bf16-vllm/d819cbc63780bd86/",
 )
 
 

--- a/tests/cluster/vllm/test_snowball_hf_bf16_export.py
+++ b/tests/cluster/vllm/test_snowball_hf_bf16_export.py
@@ -13,7 +13,6 @@ Run from the repository root:
 import dataclasses
 import hashlib
 import json
-import os
 import sys
 import tempfile
 import uuid
@@ -22,7 +21,6 @@ from typing import Any, cast
 
 import draccus
 import equinox as eqx
-import fsspec
 import jax
 import jax.numpy as jnp
 import pytest
@@ -32,8 +30,9 @@ from haliax.partitioning import set_mesh
 from iris.client import IrisClient
 from iris.rpc import job_pb2
 from levanter.grug.sharding import compact_grug_mesh
-from levanter.models.snowball import GRUG_MOE_BANNED_CONFIG_ALIASES
+from levanter.models.snowball import validate_single_name_config
 from levanter.tokenizers import load_tokenizer
+from rigging.filesystem import StoragePath
 
 from experiments.grug.moe.model import GrugModelConfig, Transformer
 from tests.cluster.vllm.snowball import SNOWBALL
@@ -73,38 +72,13 @@ def _to_main_model(params: VendoredTransformer, config: GrugModelConfig) -> Tran
     )
 
 
-def _assert_single_name_config_contract(exported_config: dict[str, Any], config: GrugModelConfig) -> None:
-    """Issue #7447: the published config.json carries exactly one spelling per dual-name field.
-
-    Assert the canonical Option A name is present with the right value and that none of the dropped
-    aliases leak. This runs against the real, ``config_overrides``-merged artifact (which could
-    otherwise sneak an alias back in), and complements the Levanter-side from_hf_config round-trip.
-    """
-    canonical = {
-        "hidden_size": config.hidden_dim,
-        "num_hidden_layers": config.num_layers,
-        "num_attention_heads": config.num_heads,
-        "num_key_value_heads": config.num_kv_heads,
-        "max_position_embeddings": config.max_seq_len,
-        "rms_norm_eps": config.layer_norm_eps,
-        "initializer_range": config.initializer_std,
-        "num_experts": config.num_experts,
-        "num_experts_per_tok": config.num_experts_per_token,
-        "moe_intermediate_size": config.intermediate_dim,
-        "shared_expert_intermediate_size": config.shared_expert_intermediate_dim,
-    }
-    for key, value in canonical.items():
-        assert exported_config.get(key) == value, key
-    leaked = GRUG_MOE_BANNED_CONFIG_ALIASES & exported_config.keys()
-    assert not leaked, f"banned config aliases leaked into config.json: {sorted(leaked)}"
-
-
 def _assert_vllm_bf16(export_dir: Path, config: GrugModelConfig) -> None:
     exported_config = json.loads((export_dir / "config.json").read_text())
     assert exported_config["architectures"] == ["GrugMoeForCausalLM"]
     assert exported_config["model_type"] == "grug_moe"
     assert exported_config["dtype"] == "bfloat16"
-    _assert_single_name_config_contract(exported_config, config)
+    # Checked on the real config_overrides-merged artifact, which could otherwise reintroduce an alias.
+    validate_single_name_config(exported_config, config)
 
     tensor_dtypes: set[str] = set()
     for shard_path in export_dir.glob("model-*.safetensors"):
@@ -126,9 +100,7 @@ def _tree_sha256(export_dir: Path) -> str:
 def _export_snowball_bf16(export_dir: Path) -> None:
     """Load the pinned checkpoint and write the bf16 HF export into ``export_dir``.
 
-    Shared by the reproduction test (which asserts the persisted digest) and the re-cut/publish
-    entrypoint (which uploads the tree), so both exercise byte-identical export logic. Validates the
-    single-name config contract on the produced ``config.json`` before returning.
+    Validates the single-name config contract on the produced ``config.json`` before returning.
     """
     executor_info = read_executor_info()
     model_config = executor_info["config"]["model"]
@@ -181,19 +153,19 @@ def recut_and_publish_snowball_bf16(export_base_uri: str) -> tuple[str, str]:
         export_dir = Path(export_dir_str)
         _export_snowball_bf16(export_dir)
         export_sha256 = _tree_sha256(export_dir)
-        export_uri = f"{export_base_uri.rstrip('/')}/{export_sha256[:16]}/"
-        fs = fsspec.core.get_fs_token_paths(export_uri, mode="wb")[0]
-        fs.put(os.path.join(export_dir_str, "*"), export_uri, recursive=True)
+        destination = StoragePath(export_base_uri) / export_sha256[:16]
+        # Glob the directory's entries so the tree lands directly under the digest prefix.
+        destination.upload_from(str(export_dir / "*"), recursive=True)
+        export_uri = f"{destination}/"
         print(f"export_sha256={export_sha256}")
         print(f"export_uri={export_uri}")
         return export_sha256, export_uri
 
 
 if __name__ == "__main__":
-    # Operator entrypoint for the re-cut (issue #7447 / #7366): re-export and upload a fresh tree,
-    # then paste the printed export_sha256/export_uri into ModelIdentity.SNOWBALL. Base URI defaults
-    # to the current export's parent (strips the content-addressed <digest[:16]>/ segment).
-    base_uri = sys.argv[1] if len(sys.argv) > 1 else SNOWBALL.export_uri.rstrip("/").rsplit("/", 1)[0]
+    # Re-export and upload a fresh tree, then paste the printed values into ModelIdentity.SNOWBALL.
+    # Defaults to the parent of the current content-addressed export directory.
+    base_uri = sys.argv[1] if len(sys.argv) > 1 else str(StoragePath(SNOWBALL.export_uri).parent)
     recut_and_publish_snowball_bf16(base_uri)
 
 

--- a/tests/cluster/vllm/test_snowball_hf_bf16_export.py
+++ b/tests/cluster/vllm/test_snowball_hf_bf16_export.py
@@ -13,7 +13,6 @@ Run from the repository root:
 import dataclasses
 import hashlib
 import json
-import sys
 import tempfile
 import uuid
 from pathlib import Path
@@ -32,7 +31,6 @@ from iris.rpc import job_pb2
 from levanter.grug.sharding import compact_grug_mesh
 from levanter.models.snowball import validate_single_name_config
 from levanter.tokenizers import load_tokenizer
-from rigging.filesystem import StoragePath
 
 from experiments.grug.moe.model import GrugModelConfig, Transformer
 from tests.cluster.vllm.snowball import SNOWBALL
@@ -97,11 +95,7 @@ def _tree_sha256(export_dir: Path) -> str:
     return digest.hexdigest()
 
 
-def _export_snowball_bf16(export_dir: Path) -> None:
-    """Load the pinned checkpoint and write the bf16 HF export into ``export_dir``.
-
-    Validates the single-name config contract on the produced ``config.json`` before returning.
-    """
+def assert_checkpoint_reproduces_bf16_export() -> None:
     executor_info = read_executor_info()
     model_config = executor_info["config"]["model"]
     vendored_config = decode_vendored_config(executor_info)
@@ -128,45 +122,17 @@ def _export_snowball_bf16(export_dir: Path) -> None:
             .with_config_overrides({"dtype": "bfloat16"})
         )
         export_model = _to_main_model(params, main_config)
-        converter.save_pretrained(export_model, str(export_dir), dtype=jnp.bfloat16)
 
-    _assert_vllm_bf16(export_dir, main_config)
-
-
-def assert_checkpoint_reproduces_bf16_export() -> None:
-    with tempfile.TemporaryDirectory(prefix="snowball-bf16-export-") as export_dir_str:
-        export_dir = Path(export_dir_str)
-        _export_snowball_bf16(export_dir)
-        actual_sha256 = _tree_sha256(export_dir)
-        assert actual_sha256 == SNOWBALL.export_sha256, actual_sha256
-
-
-def recut_and_publish_snowball_bf16(export_base_uri: str) -> tuple[str, str]:
-    """Re-cut the bf16 export from the pinned checkpoint and upload it to a content-addressed URI.
-
-    Writes the export locally, computes its whole-tree digest, uploads the tree to
-    ``<export_base_uri>/<digest[:16]>/`` (content-addressed -- a new config.json yields a new
-    directory and never overwrites an existing cut), and returns ``(export_sha256, export_uri)`` to
-    paste into ``ModelIdentity.SNOWBALL``. Must run on an 8xH100 node with object-store write access.
-    """
-    with tempfile.TemporaryDirectory(prefix="snowball-bf16-export-") as export_dir_str:
-        export_dir = Path(export_dir_str)
-        _export_snowball_bf16(export_dir)
-        export_sha256 = _tree_sha256(export_dir)
-        destination = StoragePath(export_base_uri) / export_sha256[:16]
-        # Glob the directory's entries so the tree lands directly under the digest prefix.
-        destination.upload_from(str(export_dir / "*"), recursive=True)
-        export_uri = f"{destination}/"
-        print(f"export_sha256={export_sha256}")
-        print(f"export_uri={export_uri}")
-        return export_sha256, export_uri
-
-
-if __name__ == "__main__":
-    # Re-export and upload a fresh tree, then paste the printed values into ModelIdentity.SNOWBALL.
-    # Defaults to the parent of the current content-addressed export directory.
-    base_uri = sys.argv[1] if len(sys.argv) > 1 else str(StoragePath(SNOWBALL.export_uri).parent)
-    recut_and_publish_snowball_bf16(base_uri)
+        with tempfile.TemporaryDirectory(prefix="snowball-bf16-export-") as export_dir_str:
+            export_dir = Path(export_dir_str)
+            converter.save_pretrained(
+                export_model,
+                export_dir_str,
+                dtype=jnp.bfloat16,
+            )
+            _assert_vllm_bf16(export_dir, main_config)
+            actual_sha256 = _tree_sha256(export_dir)
+            assert actual_sha256 == SNOWBALL.export_sha256, actual_sha256
 
 
 def test_snowball_checkpoint_reproduces_persisted_vllm_bf16_export(marin_gpu_client: IrisClient, run_test_job) -> None:

--- a/tests/cluster/vllm/test_snowball_hf_bf16_export.py
+++ b/tests/cluster/vllm/test_snowball_hf_bf16_export.py
@@ -29,6 +29,7 @@ from haliax.partitioning import set_mesh
 from iris.client import IrisClient
 from iris.rpc import job_pb2
 from levanter.grug.sharding import compact_grug_mesh
+from levanter.models.snowball import GRUG_MOE_BANNED_CONFIG_ALIASES
 from levanter.tokenizers import load_tokenizer
 
 from experiments.grug.moe.model import GrugModelConfig, Transformer
@@ -69,11 +70,38 @@ def _to_main_model(params: VendoredTransformer, config: GrugModelConfig) -> Tran
     )
 
 
-def _assert_vllm_bf16(export_dir: Path) -> None:
+def _assert_single_name_config_contract(exported_config: dict[str, Any], config: GrugModelConfig) -> None:
+    """Issue #7447: the published config.json carries exactly one spelling per dual-name field.
+
+    Assert the canonical Option A name is present with the right value and that none of the dropped
+    aliases leak. This runs against the real, ``config_overrides``-merged artifact (which could
+    otherwise sneak an alias back in), and complements the Levanter-side from_hf_config round-trip.
+    """
+    canonical = {
+        "hidden_size": config.hidden_dim,
+        "num_hidden_layers": config.num_layers,
+        "num_attention_heads": config.num_heads,
+        "num_key_value_heads": config.num_kv_heads,
+        "max_position_embeddings": config.max_seq_len,
+        "rms_norm_eps": config.layer_norm_eps,
+        "initializer_range": config.initializer_std,
+        "num_experts": config.num_experts,
+        "num_experts_per_tok": config.num_experts_per_token,
+        "moe_intermediate_size": config.intermediate_dim,
+        "shared_expert_intermediate_size": config.shared_expert_intermediate_dim,
+    }
+    for key, value in canonical.items():
+        assert exported_config.get(key) == value, key
+    leaked = GRUG_MOE_BANNED_CONFIG_ALIASES & exported_config.keys()
+    assert not leaked, f"banned config aliases leaked into config.json: {sorted(leaked)}"
+
+
+def _assert_vllm_bf16(export_dir: Path, config: GrugModelConfig) -> None:
     exported_config = json.loads((export_dir / "config.json").read_text())
     assert exported_config["architectures"] == ["GrugMoeForCausalLM"]
     assert exported_config["model_type"] == "grug_moe"
     assert exported_config["dtype"] == "bfloat16"
+    _assert_single_name_config_contract(exported_config, config)
 
     tensor_dtypes: set[str] = set()
     for shard_path in export_dir.glob("model-*.safetensors"):
@@ -127,7 +155,7 @@ def assert_checkpoint_reproduces_bf16_export() -> None:
                 export_dir_str,
                 dtype=jnp.bfloat16,
             )
-            _assert_vllm_bf16(export_dir)
+            _assert_vllm_bf16(export_dir, main_config)
             actual_sha256 = _tree_sha256(export_dir)
             assert actual_sha256 == SNOWBALL.export_sha256, actual_sha256
 

--- a/tests/cluster/vllm/test_snowball_hf_bf16_export.py
+++ b/tests/cluster/vllm/test_snowball_hf_bf16_export.py
@@ -13,6 +13,8 @@ Run from the repository root:
 import dataclasses
 import hashlib
 import json
+import os
+import sys
 import tempfile
 import uuid
 from pathlib import Path
@@ -20,6 +22,7 @@ from typing import Any, cast
 
 import draccus
 import equinox as eqx
+import fsspec
 import jax
 import jax.numpy as jnp
 import pytest
@@ -120,7 +123,13 @@ def _tree_sha256(export_dir: Path) -> str:
     return digest.hexdigest()
 
 
-def assert_checkpoint_reproduces_bf16_export() -> None:
+def _export_snowball_bf16(export_dir: Path) -> None:
+    """Load the pinned checkpoint and write the bf16 HF export into ``export_dir``.
+
+    Shared by the reproduction test (which asserts the persisted digest) and the re-cut/publish
+    entrypoint (which uploads the tree), so both exercise byte-identical export logic. Validates the
+    single-name config contract on the produced ``config.json`` before returning.
+    """
     executor_info = read_executor_info()
     model_config = executor_info["config"]["model"]
     vendored_config = decode_vendored_config(executor_info)
@@ -147,17 +156,45 @@ def assert_checkpoint_reproduces_bf16_export() -> None:
             .with_config_overrides({"dtype": "bfloat16"})
         )
         export_model = _to_main_model(params, main_config)
+        converter.save_pretrained(export_model, str(export_dir), dtype=jnp.bfloat16)
 
-        with tempfile.TemporaryDirectory(prefix="snowball-bf16-export-") as export_dir_str:
-            export_dir = Path(export_dir_str)
-            converter.save_pretrained(
-                export_model,
-                export_dir_str,
-                dtype=jnp.bfloat16,
-            )
-            _assert_vllm_bf16(export_dir, main_config)
-            actual_sha256 = _tree_sha256(export_dir)
-            assert actual_sha256 == SNOWBALL.export_sha256, actual_sha256
+    _assert_vllm_bf16(export_dir, main_config)
+
+
+def assert_checkpoint_reproduces_bf16_export() -> None:
+    with tempfile.TemporaryDirectory(prefix="snowball-bf16-export-") as export_dir_str:
+        export_dir = Path(export_dir_str)
+        _export_snowball_bf16(export_dir)
+        actual_sha256 = _tree_sha256(export_dir)
+        assert actual_sha256 == SNOWBALL.export_sha256, actual_sha256
+
+
+def recut_and_publish_snowball_bf16(export_base_uri: str) -> tuple[str, str]:
+    """Re-cut the bf16 export from the pinned checkpoint and upload it to a content-addressed URI.
+
+    Writes the export locally, computes its whole-tree digest, uploads the tree to
+    ``<export_base_uri>/<digest[:16]>/`` (content-addressed -- a new config.json yields a new
+    directory and never overwrites an existing cut), and returns ``(export_sha256, export_uri)`` to
+    paste into ``ModelIdentity.SNOWBALL``. Must run on an 8xH100 node with object-store write access.
+    """
+    with tempfile.TemporaryDirectory(prefix="snowball-bf16-export-") as export_dir_str:
+        export_dir = Path(export_dir_str)
+        _export_snowball_bf16(export_dir)
+        export_sha256 = _tree_sha256(export_dir)
+        export_uri = f"{export_base_uri.rstrip('/')}/{export_sha256[:16]}/"
+        fs = fsspec.core.get_fs_token_paths(export_uri, mode="wb")[0]
+        fs.put(os.path.join(export_dir_str, "*"), export_uri, recursive=True)
+        print(f"export_sha256={export_sha256}")
+        print(f"export_uri={export_uri}")
+        return export_sha256, export_uri
+
+
+if __name__ == "__main__":
+    # Operator entrypoint for the re-cut (issue #7447 / #7366): re-export and upload a fresh tree,
+    # then paste the printed export_sha256/export_uri into ModelIdentity.SNOWBALL. Base URI defaults
+    # to the current export's parent (strips the content-addressed <digest[:16]>/ segment).
+    base_uri = sys.argv[1] if len(sys.argv) > 1 else SNOWBALL.export_uri.rstrip("/").rsplit("/", 1)[0]
+    recut_and_publish_snowball_bf16(base_uri)
 
 
 def test_snowball_checkpoint_reproduces_persisted_vllm_bf16_export(marin_gpu_client: IrisClient, run_test_job) -> None:


### PR DESCRIPTION
`to_hf_config` wrote two spellings for 11 fields, so a published `config.json` said most things twice. The backends disagree on which name wins, and once an artifact is on the Hub, keys can be added but never removed. It now emits one name per field: universal transformers spellings for core fields, the most common public spelling for MoE fields, bare names for the grug-specific extras.

`from_hf_config` keeps its fallbacks deliberately — reads stay tolerant so existing artifacts still load, writes become strict. `validate_single_name_config` holds that contract in one place; the Levanter round-trip test and the export-time check both call it.

Re-cut the step-42150 bf16 export and re-pinned `SNOWBALL` and the eval registry to `d819cbc63780bd86`. The re-cut was a one-off; `test_snowball_checkpoint_reproduces_persisted_vllm_bf16_export` is what pins the result.

- Old and new trees differ in **exactly one file**: `config.json`, 1368 → 1059 bytes. All 39 weight shards are byte-identical, so the logprob goldens are untouched.
- Reproduction gate and `levanter-gpu` parity pass on `cw-us-east-02a`.
- `vllm-gpu` parity is red for a **pre-existing** reason: it fails the same way on the old, untouched export. The failing case is the rank sentinel that #7354 measured at 2 of 5 runs and explicitly recommended against using as a blocking gate — byte-identical inputs gave 0.0925 and 0.0964 across two runs.

Delete the old `781bc329` tree once this merges.
