### PR TITLE
[levanter] Size the test KV cache to the device count

### DIFF
--- a/lib/levanter/tests/inference/test_engine.py
+++ b/lib/levanter/tests/inference/test_engine.py
@@ -29,8 +29,10 @@ class DummyModel(eqx.Module):
         self.eos = eos_id
 
     def initial_cache(self, spec: PageTableSpec, *, dtype):
-        # Use trivial cache dimensions; the cache is unused by this dummy model
-        kv_heads = Axis("kv_head", 1)
+        # The cache contents are unused by this dummy model, so only its shardability matters.
+        # `KvPageCache.init` packs K and V into a single `2 * kv_heads` axis, so one kv head per
+        # device keeps that axis divisible by a `model` mesh axis sized to the device count.
+        kv_heads = Axis("kv_head", jax.device_count())
         head_size = Axis("embed", 1)
         return KvPageCache.init(spec, kv_heads, head_size, dtype=dtype)
 


### PR DESCRIPTION
test_auto_page_sizing_uses_explicit_axis_resources builds a mesh of
jax.device_count() and shards the cache kv_head axis over it, while
DummyModel.initial_cache asked for a fixed Axis("kv_head", 1). KvPageCache.init
packs K and V into a single 2 * kv_heads axis, so the materialized axis was
always 2 and sharding it raised IndivisibleError on any host with more than two
accelerators. The test passed on 1- and 2-device workstations and failed on the
4-device levanter-tpu runner, where it has never passed.

Sizing the stub to one kv head per device keeps the packed axis divisible for
any device count, including odd ones. Reproduced on CPU with
XLA_FLAGS=--xla_force_host_platform_device_count=N: the test now passes at
N = 1, 2, 3, 4, 8 and 16, and the cache shards four ways at N = 4.

Shrinking the mesh instead does not work: create_mesh_from_axis_specs forwards
to mesh_utils.create_device_mesh, which requires the mesh to cover every device,
so ici_axes={"model": 2} on a 4-device host raises ValueError.

levanter-tpu is path-gated on lib/levanter/**, so it is skipped on main and the
breakage surfaced only as a red required check on PRs touching levanter.

Fixes #7467
