### PR TITLE
[draft] Extract SM100 QuACK expert backend from #7012 PoC

### DIFF
--- a/experiments/grug/moe/launch.py
+++ b/experiments/grug/moe/launch.py
@@ -168,9 +168,11 @@ def run_grug_moe_trial(config: GrugMoeLaunchConfig) -> None:
         require_accelerator=True,
         allow_nondivisible_batch_size=False,
         initialize_from=initialize_from,
+        # Rolling temporary checkpoint every hour (preemption recovery); keep=None means no
+        # periodic permanent checkpoints -- only the trainer's forced final save at num_train_steps.
         checkpointer=config.checkpointer
         or resolve_checkpointer_output_path(
-            CheckpointerConfig(save_interval=timedelta(minutes=10), keep=None),
+            CheckpointerConfig(save_interval=timedelta(hours=1), keep=None),
             config.output_path,
         ),
     )

--- a/experiments/grug/moe/launch.py
+++ b/experiments/grug/moe/launch.py
@@ -23,6 +23,7 @@ from datetime import timedelta
 import jmp
 from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfilerConfig
+from levanter.callbacks.watch import WatchConfig
 from levanter.checkpoint import CheckpointerConfig, latest_checkpoint_path
 from levanter.data.text import LmDataConfig
 from levanter.optim import OptimizerConfig
@@ -149,6 +150,11 @@ def run_grug_moe_trial(config: GrugMoeLaunchConfig) -> None:
     blocks until it completes.
     """
     initialize_from = latest_checkpoint_path(config.init_from) if config.init_from is not None else None
+    # SCALE_WATCH=0 disables the grad/param watch callback. It fires every
+    # WatchConfig.interval steps and (with split_scan_layers) unstacks all layers to
+    # compute per-parameter norms -- a memory spike (e.g. at step 10) that OOMs a model
+    # sitting near the HBM limit even though the plain train step fits.
+    watch = WatchConfig(watch_targets=[]) if os.environ.get("SCALE_WATCH") == "0" else WatchConfig()
     trainer = TrainerConfig(
         id=config.run_id,
         seed=config.seed,
@@ -157,6 +163,7 @@ def run_grug_moe_trial(config: GrugMoeLaunchConfig) -> None:
         profiler=config.profiler,
         mp=jmp.get_policy(config.mp),
         tracker=_resolve_tracker(config.tracker, config.run_id),
+        watch=watch,
         use_explicit_mesh_axes=True,
         require_accelerator=True,
         allow_nondivisible_batch_size=False,

--- a/experiments/grug/moe/launch_cw_basic.py
+++ b/experiments/grug/moe/launch_cw_basic.py
@@ -56,6 +56,7 @@ from experiments.grug.moe.launch_cw_scale import (
 from experiments.grug.moe.model import GrugModelConfig, RematMode
 from experiments.grug.moe.train import GrugRunConfig, GrugTrainerConfig
 from experiments.grug.moe.train_basic import run_grug_basic
+from experiments.grug.moe.train_mid import run_grug_mid
 
 _SLIMPAJAMA_SHUFFLE = BlockShuffleConfig(io_block_size=256, window_blocks=256, perm_type="feistel")
 
@@ -127,7 +128,10 @@ def run_grug_basic_trial(config: GrugMoeLaunchConfig) -> None:
         or resolve_checkpointer_output_path(CheckpointerConfig(save_interval=None, keep=None), config.output_path),
     )
     grug_trainer = dataclasses.replace(config.grug_trainer, trainer=trainer)
-    run_grug_basic(
+    # SCALE_MODEL selects the model/training variant: "basic" (dense / leading- or
+    # interleaved-MoE model_basic) or "mid" (every layer = shared expert + routed MoE).
+    run_fn = run_grug_mid if os.environ.get("SCALE_MODEL", "basic").lower() == "mid" else run_grug_basic
+    run_fn(
         GrugRunConfig(
             model=config.model,
             data=config.data,
@@ -170,7 +174,9 @@ def build_basic_checkpoint(*, version: str = "dev") -> ArtifactStep[LevanterChec
         optimizer = dataclasses.replace(SCALE_OPTIMIZER, learning_rate=lr)
 
     checkpoint_mode = os.environ.get("SCALE_CHECKPOINTS", "s3").lower()
-    if checkpoint_mode == "local":
+    if checkpoint_mode in ("local", "none"):
+        # "none" carries the same cheap /tmp config, but train_basic skips every save
+        # (see SCALE_CHECKPOINTS handling there) so the probe writes no checkpoint.
         checkpointer = CheckpointerConfig(
             base_path=f"/tmp/grug-basic-ckpt/{run_id}",
             append_run_id_to_base_path=False,
@@ -180,7 +186,7 @@ def build_basic_checkpoint(*, version: str = "dev") -> ArtifactStep[LevanterChec
     elif checkpoint_mode == "s3":
         checkpointer = None
     else:
-        raise ValueError(f"SCALE_CHECKPOINTS={checkpoint_mode!r} must be 's3' or 'local'")
+        raise ValueError(f"SCALE_CHECKPOINTS={checkpoint_mode!r} must be 's3', 'local', or 'none'")
 
     model = build_basic_model()
 

--- a/experiments/grug/moe/launch_cw_basic.py
+++ b/experiments/grug/moe/launch_cw_basic.py
@@ -32,7 +32,7 @@ from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfilerConfig
 from levanter.checkpoint import CheckpointerConfig, latest_checkpoint_path
 from levanter.data.text import BlockShuffleConfig
-from levanter.optim import AdamConfig
+from levanter.optim import GrugMuonConfig, OptimizerConfig
 from levanter.tracker.json_logger import JsonLoggerConfig
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
@@ -74,6 +74,12 @@ def build_basic_model() -> GrugModelConfig:
     attn_impl = os.environ.get("SCALE_ATTN_IMPL") or None
     if attn_impl not in (None, "reference", "gpu_fa4_cute", "gpu_fa4_thd", "tpu_splash"):
         raise ValueError(f"SCALE_ATTN_IMPL={attn_impl!r} is not a known GrugAttentionImplementation")
+    # MoE dispatch backend for the leading MoE layers; None -> grug default ("ring").
+    # On single-node GPU (no expert parallelism) the local backends are the right choice:
+    # "scatter" (grouped GMM + scatter-add) or "sonic" (Triton gather/combine).
+    moe_impl = os.environ.get("SCALE_MOE_IMPL") or None
+    if moe_impl not in (None, "ring", "ragged_all_to_all", "deepep", "scatter", "sonic"):
+        raise ValueError(f"SCALE_MOE_IMPL={moe_impl!r} is not a known MoeImplementation")
     # SCALE_ZERO_INIT zeros every weight (std=0): keeps the norm-free deep model finite
     # for throughput probes where we only measure fit/MFU, not learning.
     initializer_std = 0.0 if os.environ.get("SCALE_ZERO_INIT") == "1" else 0.02
@@ -87,8 +93,10 @@ def build_basic_model() -> GrugModelConfig:
         head_dim=HEAD_DIM,
         intermediate_dim=intermediate_dim,
         shared_expert_intermediate_dim=0,  # dense model: no shared expert
-        num_experts=1,  # unused by model_basic; kept for config/FLOP compatibility
-        num_experts_per_token=1,
+        # MoE knobs used only by the leading SCALE_NUM_MOE_LAYERS layers; 1/1 keeps dense.
+        num_experts=env_int("SCALE_NUM_EXPERTS", 1),
+        num_experts_per_token=env_int("SCALE_EXPERTS_PER_TOKEN", 1),
+        moe_implementation=moe_impl,
         max_seq_len=seq_len,
         sliding_window=seq_len,
         remat_mode=cast(RematMode, remat_mode),
@@ -153,7 +161,13 @@ def build_basic_checkpoint(*, version: str = "dev") -> ArtifactStep[LevanterChec
     # LR override for the throughput/profile run (the no-norm model needs a tiny LR
     # to stay finite long enough to reach the profiler window).
     lr = float(os.environ.get("SCALE_LR") or SCALE_OPTIMIZER.learning_rate)
-    optimizer = dataclasses.replace(SCALE_OPTIMIZER, learning_rate=lr)
+    optimizer: OptimizerConfig
+    if os.environ.get("SCALE_OPTIMIZER", "adam").lower() in ("muon", "grug_muon"):
+        # Muon (one momentum buffer) for matrix/expert weights + AdamW for embed/head:
+        # ~8 B/param vs Adam's 12, the memory lever for large-expert-count MoE.
+        optimizer = GrugMuonConfig(learning_rate=lr, adam_lr=lr)
+    else:
+        optimizer = dataclasses.replace(SCALE_OPTIMIZER, learning_rate=lr)
 
     checkpoint_mode = os.environ.get("SCALE_CHECKPOINTS", "s3").lower()
     if checkpoint_mode == "local":
@@ -216,7 +230,7 @@ def build_basic_checkpoint(*, version: str = "dev") -> ArtifactStep[LevanterChec
             seed=0,
             mp=mp,
             tracker=tracker,
-            optimizer=cast(AdamConfig, optimizer),
+            optimizer=optimizer,
             grug_trainer=grug_trainer,
             processes_per_task=processes_per_task,
             eval=None,

--- a/experiments/grug/moe/launch_cw_basic.py
+++ b/experiments/grug/moe/launch_cw_basic.py
@@ -1,0 +1,239 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimalist dense-transformer scale/smoke run for the CoreWeave H100 cluster.
+
+Same CoreWeave plumbing as ``launch_cw_scale.py`` (SCALE_* env knobs, FSDP mesh,
+SlimPajama block-shuffle), but trains the bare ``model_basic`` dense transformer
+via ``train_basic`` instead of the MoE model. Full multi-head attention
+(``num_kv_heads == num_heads``), a plain GELU MLP, and no norms.
+
+Env knobs (all optional):
+
+    SCALE_GPU_REPLICAS   number of 8xH100 nodes (default 1 -> 8 GPUs)
+    SCALE_EXPERT_AXIS    intra-node shard axis (default 8; dense model shards
+                         batch, not experts, over it)
+    SCALE_REPLICA_AXIS   cross-node replication; 1 = pure FSDP (default 1)
+    SCALE_HIDDEN_DIM / SCALE_NUM_LAYERS / SCALE_NUM_HEADS / SCALE_INTERMEDIATE_DIM
+    SCALE_BATCH / SCALE_SEQ_LEN / SCALE_STEPS
+    SCALE_TRACKER        wandb | json_logger (default json_logger)
+    SCALE_PROFILER_STEPS / SCALE_PROFILER_START
+    SCALE_CHECKPOINTS    s3 (default) | local
+    RUN_ID               unique run identifier
+"""
+
+import dataclasses
+import datetime
+import os
+from typing import cast
+
+import jmp
+from fray.cluster import ResourceConfig
+from levanter.callbacks.profiler import ProfilerConfig
+from levanter.checkpoint import CheckpointerConfig, latest_checkpoint_path
+from levanter.data.text import BlockShuffleConfig
+from levanter.optim import AdamConfig
+from levanter.tracker.json_logger import JsonLoggerConfig
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
+from marin.execution.lazy import ArtifactStep, StepContext
+from marin.execution.step_runner import StepRunner
+from marin.experiment.data import mixture
+from marin.experiment.namespacing import user_namespaced_name
+from marin.training.training import LevanterCheckpoint, resolve_checkpointer_output_path
+
+from experiments.grug.moe.launch import GrugMoeLaunchConfig, env_int, slimpajama_6b_dataset
+from experiments.grug.moe.launch_cw_scale import (
+    DEFAULT_BATCH,
+    DEFAULT_SEQ_LEN,
+    GPUS_PER_NODE,
+    HEAD_DIM,
+    OUTPUT_SUBDIR,
+    SCALE_OPTIMIZER,
+    SCALE_TRAINER_DEFAULTS,
+    VOCAB_SIZE,
+)
+from experiments.grug.moe.model import GrugModelConfig, RematMode
+from experiments.grug.moe.train import GrugRunConfig, GrugTrainerConfig
+from experiments.grug.moe.train_basic import run_grug_basic
+
+_SLIMPAJAMA_SHUFFLE = BlockShuffleConfig(io_block_size=256, window_blocks=256, perm_type="feistel")
+
+
+def build_basic_model() -> GrugModelConfig:
+    """Minimalist dense transformer (overridable via SCALE_* env vars). Full MHA."""
+    hidden_dim = env_int("SCALE_HIDDEN_DIM", 768)
+    if hidden_dim % HEAD_DIM != 0:
+        raise ValueError(f"SCALE_HIDDEN_DIM={hidden_dim} must be a multiple of head_dim={HEAD_DIM}")
+    num_heads = env_int("SCALE_NUM_HEADS", hidden_dim // HEAD_DIM)
+    intermediate_dim = env_int("SCALE_INTERMEDIATE_DIM", hidden_dim * 4)
+    seq_len = env_int("SCALE_SEQ_LEN", DEFAULT_SEQ_LEN)
+    remat_mode = os.environ.get("SCALE_REMAT", "recompute_all")
+    if remat_mode not in ("recompute_all", "save_moe", "none"):
+        raise ValueError(f"SCALE_REMAT={remat_mode!r} must be 'recompute_all', 'save_moe', or 'none'")
+    attn_impl = os.environ.get("SCALE_ATTN_IMPL") or None
+    if attn_impl not in (None, "reference", "gpu_fa4_cute", "gpu_fa4_thd", "tpu_splash"):
+        raise ValueError(f"SCALE_ATTN_IMPL={attn_impl!r} is not a known GrugAttentionImplementation")
+    # SCALE_ZERO_INIT zeros every weight (std=0): keeps the norm-free deep model finite
+    # for throughput probes where we only measure fit/MFU, not learning.
+    initializer_std = 0.0 if os.environ.get("SCALE_ZERO_INIT") == "1" else 0.02
+    return GrugModelConfig(
+        initializer_std=initializer_std,
+        vocab_size=VOCAB_SIZE,
+        hidden_dim=hidden_dim,
+        num_layers=env_int("SCALE_NUM_LAYERS", 12),
+        num_heads=num_heads,
+        num_kv_heads=num_heads,  # full multi-head attention
+        head_dim=HEAD_DIM,
+        intermediate_dim=intermediate_dim,
+        shared_expert_intermediate_dim=0,  # dense model: no shared expert
+        num_experts=1,  # unused by model_basic; kept for config/FLOP compatibility
+        num_experts_per_token=1,
+        max_seq_len=seq_len,
+        sliding_window=seq_len,
+        remat_mode=cast(RematMode, remat_mode),
+        attention_implementation=attn_impl,
+    )
+
+
+def run_grug_basic_trial(config: GrugMoeLaunchConfig) -> None:
+    """Map launch knobs onto a Levanter trainer and dispatch the dense run."""
+    initialize_from = latest_checkpoint_path(config.init_from) if config.init_from is not None else None
+    trainer = TrainerConfig(
+        id=config.run_id,
+        seed=config.seed,
+        train_batch_size=config.batch_size,
+        num_train_steps=config.steps,
+        profiler=config.profiler,
+        mp=jmp.get_policy(config.mp),
+        tracker=(
+            dataclasses.replace(config.tracker, name=config.run_id)
+            if isinstance(config.tracker, WandbConfig)
+            else config.tracker
+        ),
+        use_explicit_mesh_axes=True,
+        require_accelerator=True,
+        allow_nondivisible_batch_size=False,
+        initialize_from=initialize_from,
+        checkpointer=config.checkpointer
+        or resolve_checkpointer_output_path(CheckpointerConfig(save_interval=None, keep=None), config.output_path),
+    )
+    grug_trainer = dataclasses.replace(config.grug_trainer, trainer=trainer)
+    run_grug_basic(
+        GrugRunConfig(
+            model=config.model,
+            data=config.data,
+            resources=config.resources,
+            optimizer=config.optimizer,
+            trainer=grug_trainer,
+            eval=config.eval,
+            processes_per_task=config.processes_per_task,
+        )
+    )
+
+
+def build_basic_checkpoint(*, version: str = "dev") -> ArtifactStep[LevanterCheckpoint]:
+    """Assemble the CoreWeave dense-transformer run as a lazy checkpoint from SCALE_* env."""
+    run_id = os.environ.get("RUN_ID") or datetime.datetime.now(datetime.UTC).strftime("%Y%m%d-%H%M%S")
+
+    replicas = env_int("SCALE_GPU_REPLICAS", 1)
+    expert_axis = env_int("SCALE_EXPERT_AXIS", 8)
+    replica_axis = env_int("SCALE_REPLICA_AXIS", 1)
+    batch_size = env_int("SCALE_BATCH", DEFAULT_BATCH)
+    steps = env_int("SCALE_STEPS", 50)
+    processes_per_task = env_int("SCALE_PROCESSES_PER_TASK", 1)
+    profiler_steps = env_int("SCALE_PROFILER_STEPS", 0)
+    profiler = ProfilerConfig(
+        enabled=profiler_steps > 0,
+        start_step=env_int("SCALE_PROFILER_START", 8),
+        num_steps=profiler_steps,
+        perfetto_link=os.environ.get("SCALE_PROFILER_LINK", "") == "1",
+    )
+
+    # LR override for the throughput/profile run (the no-norm model needs a tiny LR
+    # to stay finite long enough to reach the profiler window).
+    lr = float(os.environ.get("SCALE_LR") or SCALE_OPTIMIZER.learning_rate)
+    optimizer = dataclasses.replace(SCALE_OPTIMIZER, learning_rate=lr)
+
+    checkpoint_mode = os.environ.get("SCALE_CHECKPOINTS", "s3").lower()
+    if checkpoint_mode == "local":
+        checkpointer = CheckpointerConfig(
+            base_path=f"/tmp/grug-basic-ckpt/{run_id}",
+            append_run_id_to_base_path=False,
+            save_interval=None,
+            keep=None,
+        )
+    elif checkpoint_mode == "s3":
+        checkpointer = None
+    else:
+        raise ValueError(f"SCALE_CHECKPOINTS={checkpoint_mode!r} must be 's3' or 'local'")
+
+    model = build_basic_model()
+
+    # Batch is sharded over (replica_dcn, data, expert); data absorbs the rest.
+    data_axis = (replicas * GPUS_PER_NODE) // (replica_axis * expert_axis)
+    batch_shards = replica_axis * data_axis * expert_axis
+    if batch_size % batch_shards != 0:
+        raise ValueError(f"SCALE_BATCH={batch_size} must be divisible by batch shards={batch_shards}")
+
+    resources = ResourceConfig.with_gpu("H100", count=GPUS_PER_NODE, cpu=32, ram="256g", disk="256g", replicas=replicas)
+
+    use_wandb = os.environ.get("SCALE_TRACKER", "json_logger").lower() == "wandb"
+    json_logger_name = os.environ.get("SCALE_JSON_LOGGER", "grug_basic_scale.metrics")
+    wandb_entity = os.environ.get("WANDB_ENTITY") or None
+    wandb_project = os.environ.get("WANDB_PROJECT", "marin_moe")
+
+    grug_trainer = GrugTrainerConfig(
+        expert_axis_size=expert_axis,
+        replica_axis_size=replica_axis,
+        **SCALE_TRAINER_DEFAULTS,
+    )
+
+    mp = os.environ.get("SCALE_MP", "params=float32,compute=bfloat16,output=bfloat16")
+    name = f"grug-basic-cw-d{model.hidden_dim}-L{model.num_layers}-r{replicas}"
+    slim = slimpajama_6b_dataset()
+
+    def build_config(ctx: StepContext) -> GrugMoeLaunchConfig:
+        if use_wandb:
+            tracker = WandbConfig(
+                entity=wandb_entity,
+                project=wandb_project,
+                tags=["grug", "basic", "cw", "h100", "scale"],
+                group="grug-basic-cw-scale",
+                name=None,
+                replicate_path=ctx.output_path,
+            )
+        else:
+            tracker = JsonLoggerConfig(logger_name=json_logger_name)
+        return GrugMoeLaunchConfig(
+            model=model,
+            data=mixture(ctx, {slim: 1.0}, shuffle=_SLIMPAJAMA_SHUFFLE),
+            output_path=ctx.output_path,
+            run_id=run_id,
+            resources=ctx.runtime_arg("train_resources"),
+            steps=steps,
+            batch_size=batch_size,
+            seed=0,
+            mp=mp,
+            tracker=tracker,
+            optimizer=cast(AdamConfig, optimizer),
+            grug_trainer=grug_trainer,
+            processes_per_task=processes_per_task,
+            eval=None,
+            profiler=profiler,
+            checkpointer=checkpointer,
+        )
+
+    return ArtifactStep(
+        name=user_namespaced_name(f"{OUTPUT_SUBDIR}/{name}-{run_id}", version),
+        version=version,
+        artifact_type=LevanterCheckpoint,
+        run=run_grug_basic_trial,
+        build_config=build_config,
+        deps=(slim,),
+        runtime_args={"train_resources": resources},
+    )
+
+
+if __name__ == "__main__":
+    StepRunner().run([build_basic_checkpoint().lower()])

--- a/experiments/grug/moe/launch_cw_basic.py
+++ b/experiments/grug/moe/launch_cw_basic.py
@@ -54,6 +54,7 @@ from experiments.grug.moe.launch_cw_scale import (
     VOCAB_SIZE,
 )
 from experiments.grug.moe.model import GrugModelConfig, RematMode
+from experiments.grug.moe.optimizer import GrugMoeAdamHConfig, GrugMoeMuonHConfig
 from experiments.grug.moe.train import GrugRunConfig, GrugTrainerConfig
 from experiments.grug.moe.train_basic import run_grug_basic
 from experiments.grug.moe.train_mid import run_grug_mid
@@ -166,10 +167,17 @@ def build_basic_checkpoint(*, version: str = "dev") -> ArtifactStep[LevanterChec
     # to stay finite long enough to reach the profiler window).
     lr = float(os.environ.get("SCALE_LR") or SCALE_OPTIMIZER.learning_rate)
     optimizer: OptimizerConfig
-    if os.environ.get("SCALE_OPTIMIZER", "adam").lower() in ("muon", "grug_muon"):
+    opt_name = os.environ.get("SCALE_OPTIMIZER", "adam").lower()
+    if opt_name in ("muon", "grug_muon"):
         # Muon (one momentum buffer) for matrix/expert weights + AdamW for embed/head:
         # ~8 B/param vs Adam's 12, the memory lever for large-expert-count MoE.
         optimizer = GrugMuonConfig(learning_rate=lr, adam_lr=lr)
+    elif opt_name in ("muonh", "grug_moe_muonh"):
+        # May Recipe MuonH: Newton-Schulz + norm-preserving ("H") step on the matrix
+        # groups (attn / experts / shared / gated), AdamH on lm_head, Adam on the rest.
+        optimizer = GrugMoeMuonHConfig(learning_rate=lr, adam_lr=lr)
+    elif opt_name in ("adamh", "grug_moe_adamh"):
+        optimizer = GrugMoeAdamHConfig(learning_rate=lr, adam_lr=lr)
     else:
         optimizer = dataclasses.replace(SCALE_OPTIMIZER, learning_rate=lr)
 

--- a/experiments/grug/moe/launch_cw_basic.py
+++ b/experiments/grug/moe/launch_cw_basic.py
@@ -82,9 +82,16 @@ def build_basic_model() -> GrugModelConfig:
     moe_impl = os.environ.get("SCALE_MOE_IMPL") or None
     if moe_impl not in (None, "ring", "ragged_all_to_all", "deepep", "scatter", "sonic"):
         raise ValueError(f"SCALE_MOE_IMPL={moe_impl!r} is not a known MoeImplementation")
-    # SCALE_ZERO_INIT zeros every weight (std=0): keeps the norm-free deep model finite
-    # for throughput probes where we only measure fit/MFU, not learning.
-    initializer_std = 0.0 if os.environ.get("SCALE_ZERO_INIT") == "1" else 0.02
+    # SCALE_INIT_STD sets the weight init std directly (used for every weight, incl. embed
+    # and router via embed_router_std); else SCALE_ZERO_INIT zeros every weight (std=0) for
+    # throughput probes; else the 0.02 default.
+    init_std_env = os.environ.get("SCALE_INIT_STD")
+    if init_std_env is not None:
+        initializer_std = float(init_std_env)
+    elif os.environ.get("SCALE_ZERO_INIT") == "1":
+        initializer_std = 0.0
+    else:
+        initializer_std = 0.02
     return GrugModelConfig(
         initializer_std=initializer_std,
         vocab_size=VOCAB_SIZE,

--- a/experiments/grug/moe/launch_cw_scale.py
+++ b/experiments/grug/moe/launch_cw_scale.py
@@ -59,6 +59,7 @@ from marin.experiment.data import mixture
 from marin.experiment.namespacing import user_namespaced_name
 from marin.training.training import LevanterCheckpoint
 
+from experiments.grug.moe.heuristic import MoeHeuristic
 from experiments.grug.moe.launch import GrugMoeLaunchConfig, env_int, run_grug_moe_trial, slimpajama_6b_dataset
 from experiments.grug.moe.model import GrugModelConfig, RematMode
 from experiments.grug.moe.optimizer import GrugMoeAdamHConfig, GrugMoeMuonHConfig
@@ -214,6 +215,13 @@ def build_scale_checkpoint(*, version: str = "dev") -> ArtifactStep[LevanterChec
     optimizer: OptimizerConfig
     if opt_name in ("muon", "grug_muon"):
         optimizer = GrugMuonConfig(learning_rate=lr, adam_lr=lr)
+    elif opt_name in ("muonh_heuristic", "muonh_heur"):
+        # May Recipe compute-scaling heuristic sets LR/beta/epsilon from tokens & dim,
+        # with warmup=0.01 (1pct) and min_lr_ratio=0.05, noclip.
+        total_tokens = float(steps * batch_size * model.max_seq_len)
+        optimizer = MoeHeuristic(min_lr_ratio=0.05).build_optimizer_config(
+            batch_size=batch_size, tokens=total_tokens, hidden_dim=model.hidden_dim, seq_len=model.max_seq_len
+        )
     elif opt_name in ("muonh", "grug_moe_muonh"):
         optimizer = GrugMoeMuonHConfig(learning_rate=lr, adam_lr=lr)
     elif opt_name in ("adamh", "grug_moe_adamh"):

--- a/experiments/grug/moe/launch_cw_scale.py
+++ b/experiments/grug/moe/launch_cw_scale.py
@@ -125,6 +125,9 @@ def build_scale_model() -> GrugModelConfig:
         raise ValueError(f"SCALE_MOE_IMPL={moe_impl!r} is not a known MoeImplementation")
     attn_impl = os.environ.get("SCALE_ATTN_IMPL") or None
     initializer_std = float(os.environ.get("SCALE_INIT_STD", "0.02"))
+    # SCALE_SCAN_LAYERS=1 stacks the blocks and runs them under one lax.scan (needs the
+    # homogeneous body -> requires disable_pko, which is the model default).
+    use_stacked_blocks = os.environ.get("SCALE_SCAN_LAYERS") == "1"
     return GrugModelConfig(
         vocab_size=VOCAB_SIZE,
         hidden_dim=hidden_dim,
@@ -142,6 +145,7 @@ def build_scale_model() -> GrugModelConfig:
         moe_implementation=moe_impl,
         attention_implementation=attn_impl,
         initializer_std=initializer_std,
+        use_array_stacked_blocks=use_stacked_blocks,
     )
 
 

--- a/experiments/grug/moe/launch_cw_scale.py
+++ b/experiments/grug/moe/launch_cw_scale.py
@@ -103,10 +103,18 @@ def build_scale_model() -> GrugModelConfig:
     if hidden_dim % HEAD_DIM != 0:
         raise ValueError(f"SCALE_HIDDEN_DIM={hidden_dim} must be a multiple of head_dim={HEAD_DIM}")
     num_heads = hidden_dim // HEAD_DIM
-    # ~4:1 grouped-query attention; back off to the nearest divisor of num_heads.
-    num_kv_heads = max(1, num_heads // 4)
-    while num_heads % num_kv_heads != 0:
-        num_kv_heads -= 1
+    # SCALE_NUM_KV_HEADS overrides the KV-head count (set == num_heads for full MHA, which
+    # the gpu_fa4_cute flash kernel supports; GQA needs the THD kernel, which requires
+    # packed segment metadata the JAX path doesn't provide). Default ~4:1 GQA.
+    kv_env = os.environ.get("SCALE_NUM_KV_HEADS")
+    if kv_env is not None:
+        num_kv_heads = int(kv_env)
+        if num_kv_heads <= 0 or num_heads % num_kv_heads != 0:
+            raise ValueError(f"SCALE_NUM_KV_HEADS={num_kv_heads} must be a positive divisor of num_heads={num_heads}")
+    else:
+        num_kv_heads = max(1, num_heads // 4)
+        while num_heads % num_kv_heads != 0:
+            num_kv_heads -= 1
     intermediate_dim = hidden_dim // 2  # expert FFN inner width (~d/2)
     seq_len = env_int("SCALE_SEQ_LEN", DEFAULT_SEQ_LEN)
     remat_mode = os.environ.get("SCALE_REMAT", "recompute_all")

--- a/experiments/grug/moe/launch_cw_scale.py
+++ b/experiments/grug/moe/launch_cw_scale.py
@@ -41,6 +41,7 @@ Env knobs (all optional; defaults give the full 90B run on 256 H100):
     RUN_ID              unique run identifier
 """
 
+import dataclasses
 import datetime
 import os
 from typing import cast
@@ -49,7 +50,7 @@ from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfilerConfig
 from levanter.checkpoint import CheckpointerConfig
 from levanter.data.text import BlockShuffleConfig
-from levanter.optim import AdamConfig
+from levanter.optim import AdamConfig, GrugMuonConfig, OptimizerConfig
 from levanter.tracker.json_logger import JsonLoggerConfig
 from levanter.tracker.wandb import WandbConfig
 from marin.execution.lazy import ArtifactStep, StepContext
@@ -60,6 +61,7 @@ from marin.training.training import LevanterCheckpoint
 
 from experiments.grug.moe.launch import GrugMoeLaunchConfig, env_int, run_grug_moe_trial, slimpajama_6b_dataset
 from experiments.grug.moe.model import GrugModelConfig, RematMode
+from experiments.grug.moe.optimizer import GrugMoeAdamHConfig, GrugMoeMuonHConfig
 from experiments.grug.moe.train import GrugTrainerConfig
 from experiments.llama import llama3_tokenizer_vocab_size
 
@@ -110,6 +112,11 @@ def build_scale_model() -> GrugModelConfig:
     remat_mode = os.environ.get("SCALE_REMAT", "recompute_all")
     if remat_mode not in ("recompute_all", "save_moe"):
         raise ValueError(f"SCALE_REMAT={remat_mode!r} must be 'recompute_all' or 'save_moe'")
+    moe_impl = os.environ.get("SCALE_MOE_IMPL") or None
+    if moe_impl not in (None, "ring", "ragged_all_to_all", "deepep", "scatter", "sonic"):
+        raise ValueError(f"SCALE_MOE_IMPL={moe_impl!r} is not a known MoeImplementation")
+    attn_impl = os.environ.get("SCALE_ATTN_IMPL") or None
+    initializer_std = float(os.environ.get("SCALE_INIT_STD", "0.02"))
     return GrugModelConfig(
         vocab_size=VOCAB_SIZE,
         hidden_dim=hidden_dim,
@@ -124,6 +131,9 @@ def build_scale_model() -> GrugModelConfig:
         max_seq_len=seq_len,
         sliding_window=seq_len,
         remat_mode=cast(RematMode, remat_mode),
+        moe_implementation=moe_impl,
+        attention_implementation=attn_impl,
+        initializer_std=initializer_std,
     )
 
 
@@ -186,6 +196,19 @@ def build_scale_checkpoint(*, version: str = "dev") -> ArtifactStep[LevanterChec
     )
 
     mp = os.environ.get("SCALE_MP", "params=float32,compute=bfloat16,output=bfloat16")
+
+    lr = float(os.environ.get("SCALE_LR") or SCALE_OPTIMIZER.learning_rate)
+    opt_name = os.environ.get("SCALE_OPTIMIZER", "adam").lower()
+    optimizer: OptimizerConfig
+    if opt_name in ("muon", "grug_muon"):
+        optimizer = GrugMuonConfig(learning_rate=lr, adam_lr=lr)
+    elif opt_name in ("muonh", "grug_moe_muonh"):
+        optimizer = GrugMoeMuonHConfig(learning_rate=lr, adam_lr=lr)
+    elif opt_name in ("adamh", "grug_moe_adamh"):
+        optimizer = GrugMoeAdamHConfig(learning_rate=lr, adam_lr=lr)
+    else:
+        optimizer = dataclasses.replace(SCALE_OPTIMIZER, learning_rate=lr)
+
     name = f"grug-moe-cw-d{model.hidden_dim}-L{model.num_layers}-e{model.num_experts}-r{replicas}"
     slim = slimpajama_6b_dataset()
 
@@ -212,7 +235,7 @@ def build_scale_checkpoint(*, version: str = "dev") -> ArtifactStep[LevanterChec
             seed=0,
             mp=mp,
             tracker=tracker,
-            optimizer=SCALE_OPTIMIZER,
+            optimizer=optimizer,
             grug_trainer=grug_trainer,
             processes_per_task=processes_per_task,
             eval=None,

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -71,7 +71,7 @@ def _mesh_axis_size(mesh: jax.sharding.AbstractMesh | None, axis_name: str) -> i
     return int(mesh.shape[axis_name])
 
 
-RematMode = Literal["recompute_all", "save_moe"]
+RematMode = Literal["recompute_all", "save_moe", "none"]
 
 
 def _batch_spec() -> P:

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -18,6 +18,7 @@ import jax.scipy as jsp
 from einops import rearrange
 from haliax import Axis
 from haliax.jax_utils import named_call
+from haliax.nn import ArrayStacked
 from jax import random
 from jax.sharding import PartitionSpec as P
 from jax.sharding import get_abstract_mesh, reshard
@@ -26,7 +27,7 @@ try:
     from jax.shard_map import shard_map
 except ModuleNotFoundError:
     from jax.experimental.shard_map import shard_map
-from jaxtyping import Array, Float, Int, PRNGKeyArray
+from jaxtyping import Array, Bool, Float, Int, PRNGKeyArray
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.grug.attention import (
     AttentionMask,
@@ -131,6 +132,12 @@ class GrugModelConfig:
     still apply half-RoPE. Set to False to keep RoPE on long layers."""
     attention_implementation: GrugAttentionImplementation | None = None
     moe_implementation: MoeImplementation | None = None
+    use_array_stacked_blocks: bool = False
+    """Stack all transformer blocks into a single ``ArrayStacked[Block]`` and run them
+    through one ``jax.lax.scan``. Collapses N per-layer subgraphs into one scan body so
+    XLA only plans HBM for one iteration's intermediates -- needed at scale where the
+    unrolled program OOMs. Requires ``disable_pko=True`` (PKO reads a per-layer flag at
+    trace time, which the homogeneous scan body cannot express)."""
     remat_mode: RematMode = "recompute_all"
     """Per-block gradient checkpointing. "recompute_all" reruns the whole block in
     backward (lowest memory); "save_moe" keeps the tagged MoE dispatch tensors so
@@ -624,6 +631,13 @@ class MoEMLP(eqx.Module):
         return routed, router_stats
 
 
+def _long_layer_schedule(num_layers: int) -> jax.Array:
+    """Bool[num_layers] = True for every 4th layer and the last layer (the full-causal
+    "long" layers); False elsewhere (sliding-window "short" layers)."""
+    idx = jnp.arange(num_layers)
+    return ((idx % 4) == 3) | (idx == num_layers - 1)
+
+
 class Block(eqx.Module):
     rms_attn: RMSNorm
     attn_gated_norm: GatedNorm
@@ -655,12 +669,23 @@ class Block(eqx.Module):
     def __call__(
         self,
         x: Float[Array, "B S D"],
-        mask: AttentionMask | jax.Array,
+        short_mask: AttentionMask | jax.Array,
+        long_mask: AttentionMask | jax.Array,
+        use_long_mask: Bool[Array, ""] | bool,
         use_pko: bool = False,
-        disable_rope: bool = False,
+        disable_long_rope: bool = False,
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
         attn_in = self.attn_gated_norm(self.rms_attn(x))
-        x = x + self.attn(attn_in, mask, use_pko=use_pko, disable_rope=disable_rope)
+        # lax.cond so the body has a uniform shape across scan iterations: long layers use
+        # the full causal mask (and may PKO / drop RoPE); short layers use the sliding-window
+        # mask, never PKO, and always RoPE.
+        attn_out = jax.lax.cond(
+            jnp.asarray(use_long_mask, dtype=jnp.bool_),
+            lambda _: self.attn(attn_in, long_mask, use_pko=use_pko, disable_rope=disable_long_rope),
+            lambda _: self.attn(attn_in, short_mask, use_pko=False, disable_rope=False),
+            operand=None,
+        )
+        x = x + attn_out
         mlp_in = self.mlp_gated_norm(self.rms_mlp(x))
         mlp_out, router_stats = self.mlp(mlp_in)
         if self.shared is not None:
@@ -674,7 +699,10 @@ class Transformer(eqx.Module):
     embed_norm: RMSNorm
     embed_gated_norm: GatedNorm
     output_proj: jax.Array
-    blocks: tuple[Block, ...]
+    # Exactly one is populated: ``blocks`` (unrolled per-layer) or ``stacked_blocks``
+    # (homogeneous lax.scan), selected by ``cfg.use_array_stacked_blocks``.
+    blocks: tuple[Block, ...] | None
+    stacked_blocks: ArrayStacked[Block] | None
     final_norm: RMSNorm
     final_gated_norm: GatedNorm
     config: GrugModelConfig = eqx.field(static=True)
@@ -699,18 +727,36 @@ class Transformer(eqx.Module):
                 raise ValueError("config must not be provided when initializing directly from GrugModelConfig")
             cfg = cfg_or_vocab
 
-        embed_key, out_key, embed_gn_key, final_gn_key, *block_keys = random.split(key, cfg.num_layers + 4)
+        if cfg.use_array_stacked_blocks and not cfg.disable_pko:
+            raise ValueError(
+                "use_array_stacked_blocks=True requires disable_pko=True because "
+                "CausalSelfAttention reads use_pko at trace time (not scan-expressible)."
+            )
+
+        keys = random.split(key, cfg.num_layers + 4)
+        embed_key, out_key, embed_gn_key, final_gn_key = keys[:4]
+        block_keys = keys[4:]
         token_embed = reshard(
             _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), cfg.initializer_std), Pembed_vocab
         )
         output_proj = reshard(_init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head)
-        blocks = tuple(Block.init(cfg, key=block_keys[i]) for i in range(cfg.num_layers))
+
+        blocks: tuple[Block, ...] | None
+        stacked_blocks: ArrayStacked[Block] | None
+        if cfg.use_array_stacked_blocks:
+            blocks = None
+            stacked_blocks = ArrayStacked.init(cfg.num_layers, Block)(cfg=cfg, key=block_keys)
+        else:
+            blocks = tuple(Block.init(cfg, key=block_keys[i]) for i in range(cfg.num_layers))
+            stacked_blocks = None
+
         return Transformer(
             token_embed=token_embed,
             embed_norm=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
             embed_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=embed_gn_key),
             output_proj=output_proj,
             blocks=blocks,
+            stacked_blocks=stacked_blocks,
             final_norm=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
             final_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=final_gn_key),
             config=cfg,
@@ -744,27 +790,51 @@ class Transformer(eqx.Module):
         else:
             remat_policy = None
 
-        num_blocks = len(self.blocks)
-        moe_router_stats: list[dict[str, jax.Array]] = []
-        for i, block in enumerate(self.blocks):
-            is_last = i == num_blocks - 1
-            is_long = i % 4 == 3 or is_last
-            layer_mask = long_mask if is_long else short_mask
-            use_pko = is_long and not cfg.disable_pko
-            disable_rope = is_long and cfg.disable_long_rope
-            hidden, router_stats = eqx.filter_checkpoint(block, policy=remat_policy)(
-                hidden, layer_mask, use_pko, disable_rope
-            )
-            moe_router_stats.append(router_stats)
+        if self.blocks is not None:
+            num_blocks = len(self.blocks)
+            moe_router_stats: list[dict[str, jax.Array]] = []
+            for i, block in enumerate(self.blocks):
+                is_last = i == num_blocks - 1
+                is_long = i % 4 == 3 or is_last
+                use_pko = is_long and not cfg.disable_pko
+                hidden, router_stats = eqx.filter_checkpoint(block, policy=remat_policy)(
+                    hidden, short_mask, long_mask, is_long, use_pko, cfg.disable_long_rope
+                )
+                moe_router_stats.append(router_stats)
+            router_metrics = {
+                "routing_entropy_per_layer": jnp.stack([s["routing_entropy"] for s in moe_router_stats], axis=0),
+                "routing_counts_per_layer": jnp.stack([s["routing_counts"] for s in moe_router_stats], axis=0),
+                "load_balancing_loss_per_layer": jnp.stack([s["load_balancing_loss"] for s in moe_router_stats], axis=0),
+                "router_z_loss_per_layer": jnp.stack([s["router_z_loss"] for s in moe_router_stats], axis=0),
+                "qb_beta_per_layer": jnp.stack([s["qb_beta"] for s in moe_router_stats], axis=0),
+                "capacity_overflow_per_layer": jnp.stack([s["capacity_overflow"] for s in moe_router_stats], axis=0),
+            }
+        else:
+            assert self.stacked_blocks is not None
+            # Homogeneous scan: one compiled Block body over the stacked layers; the per-layer
+            # short/long mask choice rides in as a Bool[num_layers] scan input.
+            mask_schedule = _long_layer_schedule(cfg.num_layers)
 
-        router_metrics = {
-            "routing_entropy_per_layer": jnp.stack([s["routing_entropy"] for s in moe_router_stats], axis=0),
-            "routing_counts_per_layer": jnp.stack([s["routing_counts"] for s in moe_router_stats], axis=0),
-            "load_balancing_loss_per_layer": jnp.stack([s["load_balancing_loss"] for s in moe_router_stats], axis=0),
-            "router_z_loss_per_layer": jnp.stack([s["router_z_loss"] for s in moe_router_stats], axis=0),
-            "qb_beta_per_layer": jnp.stack([s["qb_beta"] for s in moe_router_stats], axis=0),
-            "capacity_overflow_per_layer": jnp.stack([s["capacity_overflow"] for s in moe_router_stats], axis=0),
-        }
+            def _scan_layers(
+                carry_hidden: Float[Array, "B S D"],
+                scan_inputs: tuple[Block, Bool[Array, ""]],
+            ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+                layer, layer_use_long_mask = scan_inputs
+                return eqx.filter_checkpoint(layer, policy=remat_policy)(
+                    carry_hidden, short_mask, long_mask, layer_use_long_mask, False, cfg.disable_long_rope
+                )
+
+            hidden, stacked_router_stats = jax.lax.scan(
+                _scan_layers, hidden, xs=(self.stacked_blocks.stacked, mask_schedule)
+            )
+            router_metrics = {
+                "routing_entropy_per_layer": stacked_router_stats["routing_entropy"],
+                "routing_counts_per_layer": stacked_router_stats["routing_counts"],
+                "load_balancing_loss_per_layer": stacked_router_stats["load_balancing_loss"],
+                "router_z_loss_per_layer": stacked_router_stats["router_z_loss"],
+                "qb_beta_per_layer": stacked_router_stats["qb_beta"],
+                "capacity_overflow_per_layer": stacked_router_stats["capacity_overflow"],
+            }
         hidden = self.final_gated_norm(self.final_norm(hidden))
         return hidden, router_metrics
 

--- a/experiments/grug/moe/model_basic.py
+++ b/experiments/grug/moe/model_basic.py
@@ -36,6 +36,7 @@ from experiments.grug.moe.model import (
     MoEMLP,
     _batch_spec,
     _init_weight,
+    rms_norm,
 )
 
 # FSDP axes for the non-expert params (attention, dense MLP, embed, lm_head): shard over
@@ -76,6 +77,11 @@ class BasicAttention(eqx.Module):
         q = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_q), "... (n d) -> ... n d", d=head_dim)
         k = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_k), "... (n d) -> ... n d", d=head_dim)
         v = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_v), "... (n d) -> ... n d", d=head_dim)
+
+        # Non-parametric QK norm (RMS over head_dim) before RoPE, matching model.py.
+        if qk_norm_enabled():
+            q = rms_norm(q)
+            k = rms_norm(k)
 
         if not no_rope_enabled():
             q, k = apply_rotary_embedding(q, k, seq_len=seq_len, head_dim=head_dim, rope=self.cfg.rope)
@@ -242,6 +248,11 @@ def moe_expert_intermediate(cfg: GrugModelConfig) -> int:
 def no_rope_enabled() -> bool:
     """Env toggle (SCALE_NO_ROPE=1): skip rotary position embedding (NoPE attention)."""
     return os.environ.get("SCALE_NO_ROPE") == "1"
+
+
+def qk_norm_enabled() -> bool:
+    """Env toggle (SCALE_QK_NORM=1): non-parametric RMS norm on Q and K before RoPE."""
+    return os.environ.get("SCALE_QK_NORM") == "1"
 
 
 def remat_every_k() -> int:

--- a/experiments/grug/moe/model_basic.py
+++ b/experiments/grug/moe/model_basic.py
@@ -27,15 +27,22 @@ from jax.sharding import PartitionSpec as P
 from jax.sharding import reshard
 from jaxtyping import Array, Float, Int, PRNGKeyArray
 from levanter.grug.attention import AttentionMask, apply_rotary_embedding, attention
+from levanter.grug.grug_moe import MOE_REMAT_SAVE_NAMES
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
-from levanter.grug.sharding import Pembed_vocab, Plm_head
 
 from experiments.grug.moe.model import (
     _BATCH_AXES,
     GrugModelConfig,
+    MoEMLP,
     _batch_spec,
     _init_weight,
 )
+
+# FSDP axes for the non-expert params (attention, dense MLP, embed, lm_head): shard over
+# the full batch-axis set so they use every GPU regardless of the data/expert split. Under
+# pure FSDP this is just "data"; under expert parallelism it keeps them sharded over all
+# devices (via the expert axis) instead of collapsing to the shrunken data axis.
+_FSDP_AXES = _BATCH_AXES
 
 
 class BasicAttention(eqx.Module):
@@ -54,10 +61,10 @@ class BasicAttention(eqx.Module):
         k_q, k_k, k_v, k_o = random.split(key, 4)
         d, n, h = cfg.hidden_dim, cfg.num_heads, cfg.inferred_head_dim
         return BasicAttention(
-            w_q=reshard(_init_weight(k_q, (d, n * h), cfg.initializer_std), P("data", "model")),
-            w_k=reshard(_init_weight(k_k, (d, n * h), cfg.initializer_std), P("data", "model")),
-            w_v=reshard(_init_weight(k_v, (d, n * h), cfg.initializer_std), P("data", "model")),
-            w_o=reshard(_init_weight(k_o, (n * h, d), cfg.initializer_std), P("model", "data")),
+            w_q=reshard(_init_weight(k_q, (d, n * h), cfg.initializer_std), P(_FSDP_AXES, "model")),
+            w_k=reshard(_init_weight(k_k, (d, n * h), cfg.initializer_std), P(_FSDP_AXES, "model")),
+            w_v=reshard(_init_weight(k_v, (d, n * h), cfg.initializer_std), P(_FSDP_AXES, "model")),
+            w_o=reshard(_init_weight(k_o, (n * h, d), cfg.initializer_std), P("model", _FSDP_AXES)),
             cfg=cfg,
         )
 
@@ -91,8 +98,10 @@ class BasicMLP(eqx.Module):
     def init(hidden_dim: int, intermediate_dim: int, initializer_std: float, *, key: PRNGKeyArray) -> "BasicMLP":
         k_up, k_down = random.split(key)
         return BasicMLP(
-            w_up=reshard(_init_weight(k_up, (hidden_dim, intermediate_dim), initializer_std), P("data", "model")),
-            w_down=reshard(_init_weight(k_down, (intermediate_dim, hidden_dim), initializer_std), P("model", "data")),
+            w_up=reshard(_init_weight(k_up, (hidden_dim, intermediate_dim), initializer_std), P(_FSDP_AXES, "model")),
+            w_down=reshard(
+                _init_weight(k_down, (intermediate_dim, hidden_dim), initializer_std), P("model", _FSDP_AXES)
+            ),
         )
 
     @named_call
@@ -141,9 +150,93 @@ class BasicMLPBlock(eqx.Module):
         return x + self.mlp(x)
 
 
+class MoEBasicBlock(eqx.Module):
+    """Residual attention + grug QB-routed MoE MLP, no norms.
+
+    Reuses grug's :class:`MoEMLP` (router, QB top-(K+1) gating, ragged-dot expert
+    dispatch). Forward-only QB: the router bias stays zero and the returned router
+    stats are discarded (no stateful per-step beta update).
+    """
+
+    attn: BasicAttention
+    mlp: MoEMLP
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "MoEBasicBlock":
+        attn_key, mlp_key, router_key = random.split(key, 3)
+        # MoEMLP reads cfg.intermediate_dim as the *expert* width; the dense layers use
+        # the config's own intermediate_dim, so swap in the (narrower) expert width here.
+        moe_cfg = dataclasses.replace(cfg, intermediate_dim=moe_expert_intermediate(cfg))
+        mlp = MoEMLP.init(moe_cfg, key=mlp_key)
+        # Give the router a nonzero init even under zero-init so routing spreads across
+        # experts (experts stay zero for stability, but the dispatch load is realistic).
+        router = reshard(_init_weight(router_key, mlp.router.shape, embed_router_std(cfg)), P(None, None))
+        mlp = eqx.tree_at(lambda m: m.router, mlp, router)
+        return MoEBasicBlock(attn=BasicAttention.init(cfg, key=attn_key), mlp=mlp)
+
+    @named_call
+    def __call__(self, x: Float[Array, "B S D"], mask: AttentionMask | jax.Array) -> Float[Array, "B S D"]:
+        x = x + self.attn(x, mask)
+        moe_out, _router_stats = self.mlp(x)  # forward-only QB routing; stats unused
+        return x + moe_out
+
+
 def mlp_only_enabled() -> bool:
     """Env toggle (SCALE_MLP_ONLY=1) selecting attention-free MLP blocks."""
     return os.environ.get("SCALE_MLP_ONLY") == "1"
+
+
+def num_moe_layers() -> int:
+    """Number of leading layers that use a grug MoE MLP (SCALE_NUM_MOE_LAYERS, default 0)."""
+    return int(os.environ.get("SCALE_NUM_MOE_LAYERS", "0"))
+
+
+def moe_stride() -> int:
+    """SCALE_MOE_STRIDE: if >0, interleave MoE layers at every ``stride``-th index
+    (starting at SCALE_MOE_START). 0 (default) uses SCALE_NUM_MOE_LAYERS leading layers."""
+    return int(os.environ.get("SCALE_MOE_STRIDE", "0"))
+
+
+def moe_start() -> int:
+    """First layer index eligible to be MoE under SCALE_MOE_STRIDE (SCALE_MOE_START, default 0)."""
+    return int(os.environ.get("SCALE_MOE_START", "0"))
+
+
+def moe_scan_save() -> bool:
+    """SCALE_MOE_SCAN_SAVE=1: in the pair-scan, save the MoE dispatch tensors instead of
+    recomputing them. Only fits at small batch — under scan the saved tensors stack across
+    every period, so this memory scales with batch (tokens/GPU)."""
+    return os.environ.get("SCALE_MOE_SCAN_SAVE") == "1"
+
+
+def is_moe_layer(i: int) -> bool:
+    """Whether layer ``i`` is a MoE layer, per the interleave (stride) or leading config."""
+    stride = moe_stride()
+    if stride > 0:
+        return i >= moe_start() and (i - moe_start()) % stride == 0
+    return i < num_moe_layers()
+
+
+def moe_layer_count(num_layers: int) -> int:
+    """Number of MoE layers in a model of ``num_layers`` layers."""
+    return sum(1 for i in range(num_layers) if is_moe_layer(i))
+
+
+def embed_router_std(cfg: GrugModelConfig) -> float:
+    """Init std for the token embedding and MoE router.
+
+    These stay nonzero even under zero-init (SCALE_EMBED_ROUTER_STD, default 0.02) so
+    the residual stream is nonzero and MoE routing spreads across experts, while other
+    weights follow cfg.initializer_std (0 under zero-init keeps the deep stack stable).
+    """
+    if cfg.initializer_std != 0.0:
+        return cfg.initializer_std
+    return float(os.environ.get("SCALE_EMBED_ROUTER_STD", "0.02"))
+
+
+def moe_expert_intermediate(cfg: GrugModelConfig) -> int:
+    """Per-expert MLP width for MoE layers (SCALE_MOE_EXPERT_INTERMEDIATE; default half hidden_dim)."""
+    return int(os.environ.get("SCALE_MOE_EXPERT_INTERMEDIATE", str(cfg.hidden_dim // 2)))
 
 
 def no_rope_enabled() -> bool:
@@ -204,35 +297,84 @@ def remat_policy():
     return policies[name]
 
 
+def moe_remat_policy():
+    """Checkpoint policy for MoE blocks: keep the tagged dispatch tensors (grug
+    ``save_moe``) so the backward reuses them instead of re-running the expensive
+    expert dispatch (sort/gather/scatter, collectives) and grouped GEMMs.
+    """
+    return jax.checkpoint_policies.save_only_these_names(*MOE_REMAT_SAVE_NAMES)
+
+
 class Transformer(eqx.Module):
     """Minimalist dense transformer: embed -> blocks -> lm head, no norms.
 
-    ``blocks`` is a tuple of per-layer modules in the default (unrolled) path; under
-    ``SCALE_SCAN_LAYERS`` it is a single block whose leaves carry a leading layer axis.
+    The first ``num_moe_layers()`` blocks are grug MoE layers (``moe_blocks``, always
+    unrolled); the remaining dense ``blocks`` are a tuple in the default path, or under
+    ``SCALE_SCAN_LAYERS`` a single block whose leaves carry a leading layer axis.
     """
 
     token_embed: Float[Array, "V D"]
     output_proj: Float[Array, "D V"]
-    blocks: tuple[BasicBlock | BasicMLPBlock, ...] | BasicBlock | BasicMLPBlock
+    moe_blocks: tuple[MoEBasicBlock, ...]
+    blocks: tuple[BasicBlock | BasicMLPBlock | MoEBasicBlock, ...] | BasicBlock | BasicMLPBlock
     config: GrugModelConfig = eqx.field(static=True)
 
     @staticmethod
     def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "Transformer":
         embed_key, out_key, *block_keys = random.split(key, cfg.num_layers + 2)
         token_embed = reshard(
-            _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), cfg.initializer_std), Pembed_vocab
+            _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), embed_router_std(cfg)), P("model", _FSDP_AXES)
         )
-        output_proj = reshard(_init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head)
+        output_proj = reshard(
+            _init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), P(_FSDP_AXES, "model")
+        )
         block_cls: type[BasicBlock] | type[BasicMLPBlock] = BasicMLPBlock if mlp_only_enabled() else BasicBlock
-        block_list = [block_cls.init(cfg, key=block_keys[i]) for i in range(cfg.num_layers)]
-        blocks: tuple[BasicBlock | BasicMLPBlock, ...] | BasicBlock | BasicMLPBlock
-        if scan_layers_enabled() and block_list:
+        blocks: tuple[BasicBlock | BasicMLPBlock | MoEBasicBlock, ...] | BasicBlock | BasicMLPBlock
+
+        if moe_stride() > 0:
+            stride = moe_stride()
+
+            def _init_layer(i: int) -> BasicBlock | BasicMLPBlock | MoEBasicBlock:
+                if is_moe_layer(i):
+                    return MoEBasicBlock.init(cfg, key=block_keys[i])
+                return block_cls.init(cfg, key=block_keys[i])
+
+            if scan_layers_enabled() and cfg.num_layers % stride == 0:
+                # Periodic pair-scan: one stack per within-period position (all layers at a
+                # position share a type, so each stack is homogeneous). scan runs the `stride`
+                # positions in order per period -> dense-led (dense, MoE) pairs for stride=2.
+                position_stacks = [
+                    jax.tree_util.tree_map(
+                        lambda *leaves: jnp.stack(leaves), *[_init_layer(i) for i in range(p, cfg.num_layers, stride)]
+                    )
+                    for p in range(stride)
+                ]
+                return Transformer(
+                    token_embed=token_embed,
+                    output_proj=output_proj,
+                    moe_blocks=(),
+                    blocks=tuple(position_stacks),
+                    config=cfg,
+                )
+            # Fallback: unrolled heterogeneous tuple (no scan / non-divisible).
+            mixed = [_init_layer(i) for i in range(cfg.num_layers)]
+            return Transformer(
+                token_embed=token_embed, output_proj=output_proj, moe_blocks=(), blocks=tuple(mixed), config=cfg
+            )
+
+        # Leading MoE layers (unrolled) followed by a homogeneous, scannable dense tail.
+        n_moe = min(num_moe_layers(), cfg.num_layers)
+        moe_blocks = tuple(MoEBasicBlock.init(cfg, key=block_keys[i]) for i in range(n_moe))
+        dense_list = [block_cls.init(cfg, key=block_keys[i]) for i in range(n_moe, cfg.num_layers)]
+        if scan_layers_enabled() and dense_list:
             # Stack homogeneous per-layer weights along a new leading layer axis so the
             # forward can scan over them. Static (config) fields are shared, not stacked.
-            blocks = jax.tree_util.tree_map(lambda *leaves: jnp.stack(leaves), *block_list)
+            blocks = jax.tree_util.tree_map(lambda *leaves: jnp.stack(leaves), *dense_list)
         else:
-            blocks = tuple(block_list)
-        return Transformer(token_embed=token_embed, output_proj=output_proj, blocks=blocks, config=cfg)
+            blocks = tuple(dense_list)
+        return Transformer(
+            token_embed=token_embed, output_proj=output_proj, moe_blocks=moe_blocks, blocks=blocks, config=cfg
+        )
 
     @property
     def Vocab(self) -> Axis:
@@ -258,8 +400,49 @@ class Transformer(eqx.Module):
         base_remat = self.config.remat_mode != "none"
         policy = remat_policy()
 
-        if scan_layers_enabled() and self.config.num_layers > 0:
-            # Scan the stacked blocks: one compiled body, sequential schedule.
+        moe_policy = moe_remat_policy()
+
+        if moe_stride() > 0:
+            stride = moe_stride()
+            if scan_layers_enabled() and self.config.num_layers % stride == 0:
+                # Periodic pair-scan: self.blocks is one stack per within-period position.
+                # Each period is checkpointed under the MoE policy so the MoE block's dispatch
+                # tensors are saved while the (cheap) dense block recomputes.
+                partitioned = [eqx.partition(stack, eqx.is_array) for stack in self.blocks]
+                statics = [static for _, static in partitioned]
+
+                def run_period(carry, period_params):
+                    for pos_params, static in zip(period_params, statics, strict=True):
+                        carry = eqx.combine(pos_params, static)(carry, mask)
+                    return carry, None
+
+                xs = tuple(params for params, _ in partitioned)
+                # Under scan, save_only_these_names stacks the saved dispatch tensors across
+                # all periods (memory ~ batch), so full remat (recompute) is the default and
+                # save_moe (SCALE_MOE_SCAN_SAVE) is only viable at small batch.
+                scan_policy = moe_policy if moe_scan_save() else policy
+                step = eqx.filter_checkpoint(run_period, policy=scan_policy) if base_remat else run_period
+                hidden, _ = jax.lax.scan(step, hidden, xs)
+                return hidden
+
+            # Fallback: unrolled heterogeneous stack, each block under its own policy.
+            for block in self.blocks:
+                block_policy = moe_policy if isinstance(block, MoEBasicBlock) else policy
+                hidden = (eqx.filter_checkpoint(block, policy=block_policy) if base_remat else block)(hidden, mask)
+            return hidden
+
+        # Leading MoE layers run unrolled (heterogeneous, can't join the dense scan).
+        # They checkpoint under the MoE policy: save the dispatch tensors so the backward
+        # doesn't re-run the expensive expert dispatch/GEMMs.
+        for block in self.moe_blocks:
+            hidden = (eqx.filter_checkpoint(block, policy=moe_policy) if base_remat else block)(hidden, mask)
+
+        n_dense = self.config.num_layers - len(self.moe_blocks)
+        if n_dense == 0:
+            return hidden
+
+        if scan_layers_enabled():
+            # Scan the stacked dense blocks: one compiled body, sequential schedule.
             block_params, block_static = eqx.partition(self.blocks, eqx.is_array)
 
             def run_layer(carry, layer_params):
@@ -276,10 +459,9 @@ class Transformer(eqx.Module):
             # Nested scan: checkpoint every `group` layers. Inner scan runs the group
             # (activations kept within it); the outer body is checkpointed so only the
             # group input is stacked -> fewer recomputes than per-layer full remat.
-            num_layers = self.config.num_layers
-            if num_layers % group != 0:
-                raise ValueError(f"SCALE_SCAN_CHUNK={group} must divide num_layers={num_layers}")
-            grouped = jax.tree_util.tree_map(lambda x: x.reshape(num_layers // group, group, *x.shape[1:]), block_params)
+            if n_dense % group != 0:
+                raise ValueError(f"SCALE_SCAN_CHUNK={group} must divide dense layer count={n_dense}")
+            grouped = jax.tree_util.tree_map(lambda x: x.reshape(n_dense // group, group, *x.shape[1:]), block_params)
 
             def run_group(carry, group_params):
                 out, _ = jax.lax.scan(run_layer, carry, group_params)

--- a/experiments/grug/moe/model_basic.py
+++ b/experiments/grug/moe/model_basic.py
@@ -1,0 +1,344 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimalist dense transformer for smoke/throughput experiments.
+
+Deliberately stripped to the bare skeleton: token embedding, a stack of
+``(basic multi-head attention + dense MLP)`` residual blocks with *no*
+normalization layers, and an untied LM head. None of the grug MoE machinery
+(routing, QB betas, GatedNorm, XSA, PKO, half-RoPE, sliding windows) is present.
+
+It reuses :class:`~experiments.grug.moe.model.GrugModelConfig` for shape knobs so
+the FLOP/launch plumbing is shared; the MoE-only config fields (``num_experts`` &c)
+are ignored here. Attention is full multi-head (``num_kv_heads == num_heads``).
+"""
+
+import dataclasses
+import os
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from einops import rearrange
+from haliax import Axis
+from haliax.jax_utils import named_call
+from jax import random
+from jax.sharding import PartitionSpec as P
+from jax.sharding import reshard
+from jaxtyping import Array, Float, Int, PRNGKeyArray
+from levanter.grug.attention import AttentionMask, apply_rotary_embedding, attention
+from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
+from levanter.grug.sharding import Pembed_vocab, Plm_head
+
+from experiments.grug.moe.model import (
+    _BATCH_AXES,
+    GrugModelConfig,
+    _batch_spec,
+    _init_weight,
+)
+
+
+class BasicAttention(eqx.Module):
+    """Full multi-head causal self-attention with RoPE. No GQA, gating, or XSA."""
+
+    w_q: Float[Array, "D NH"]
+    w_k: Float[Array, "D NH"]
+    w_v: Float[Array, "D NH"]
+    w_o: Float[Array, "NH D"]
+    cfg: GrugModelConfig = eqx.field(static=True)
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "BasicAttention":
+        if cfg.num_heads != cfg.num_kv_heads:
+            raise ValueError("model_basic uses full multi-head attention; set num_kv_heads == num_heads")
+        k_q, k_k, k_v, k_o = random.split(key, 4)
+        d, n, h = cfg.hidden_dim, cfg.num_heads, cfg.inferred_head_dim
+        return BasicAttention(
+            w_q=reshard(_init_weight(k_q, (d, n * h), cfg.initializer_std), P("data", "model")),
+            w_k=reshard(_init_weight(k_k, (d, n * h), cfg.initializer_std), P("data", "model")),
+            w_v=reshard(_init_weight(k_v, (d, n * h), cfg.initializer_std), P("data", "model")),
+            w_o=reshard(_init_weight(k_o, (n * h, d), cfg.initializer_std), P("model", "data")),
+            cfg=cfg,
+        )
+
+    @named_call
+    def __call__(self, x: Float[Array, "B S D"], mask: AttentionMask | jax.Array) -> Float[Array, "B S D"]:
+        head_dim = self.cfg.inferred_head_dim
+        seq_len = x.shape[1]
+
+        q = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_q), "... (n d) -> ... n d", d=head_dim)
+        k = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_k), "... (n d) -> ... n d", d=head_dim)
+        v = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_v), "... (n d) -> ... n d", d=head_dim)
+
+        if not no_rope_enabled():
+            q, k = apply_rotary_embedding(q, k, seq_len=seq_len, head_dim=head_dim, rope=self.cfg.rope)
+        attn_out = attention(q, k, v, mask, implementation=self.cfg.attention_implementation)
+        # Tag the flash-attention output so a remat policy can save it (expensive to
+        # recompute — a real kernel — but cheap to store: [B,S,n,h]).
+        attn_out = jax.ad_checkpoint.checkpoint_name(attn_out, "attn_out")
+        attn_out = reshard(attn_out, P(_BATCH_AXES, None, "model", None))
+        attn_out = rearrange(attn_out, "... n d -> ... (n d)")
+        return jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=_batch_spec())
+
+
+class BasicMLP(eqx.Module):
+    """Plain two-matrix MLP with GELU. No gated/GLU path."""
+
+    w_up: Float[Array, "D I"]
+    w_down: Float[Array, "I D"]
+
+    @staticmethod
+    def init(hidden_dim: int, intermediate_dim: int, initializer_std: float, *, key: PRNGKeyArray) -> "BasicMLP":
+        k_up, k_down = random.split(key)
+        return BasicMLP(
+            w_up=reshard(_init_weight(k_up, (hidden_dim, intermediate_dim), initializer_std), P("data", "model")),
+            w_down=reshard(_init_weight(k_down, (intermediate_dim, hidden_dim), initializer_std), P("model", "data")),
+        )
+
+    @named_call
+    def __call__(self, x: Float[Array, "B S D"]) -> Float[Array, "B S D"]:
+        b, s, _ = x.shape
+        x_flat = rearrange(x, "b s d -> (b s) d")
+        hidden = jax.nn.gelu(jnp.einsum("td,di->ti", x_flat, self.w_up))
+        out_flat = jnp.einsum("ti,id->td", hidden, self.w_down, out_sharding=_batch_spec())
+        # out_flat already carries _batch_spec(); the rearrange is a free bitcast, so no
+        # trailing reshard is needed (dropping the redundant round-trip).
+        return rearrange(out_flat, "(b s) d -> b s d", b=b, s=s)
+
+
+class BasicBlock(eqx.Module):
+    """Residual attention + MLP. No pre/post normalization."""
+
+    attn: BasicAttention
+    mlp: BasicMLP
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "BasicBlock":
+        attn_key, mlp_key = random.split(key)
+        return BasicBlock(
+            attn=BasicAttention.init(cfg, key=attn_key),
+            mlp=BasicMLP.init(cfg.hidden_dim, cfg.intermediate_dim, cfg.initializer_std, key=mlp_key),
+        )
+
+    @named_call
+    def __call__(self, x: Float[Array, "B S D"], mask: AttentionMask | jax.Array) -> Float[Array, "B S D"]:
+        x = x + self.attn(x, mask)
+        x = x + self.mlp(x)
+        return x
+
+
+class BasicMLPBlock(eqx.Module):
+    """Residual MLP only, no attention. For isolating MLP + CE throughput."""
+
+    mlp: BasicMLP
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "BasicMLPBlock":
+        return BasicMLPBlock(mlp=BasicMLP.init(cfg.hidden_dim, cfg.intermediate_dim, cfg.initializer_std, key=key))
+
+    @named_call
+    def __call__(self, x: Float[Array, "B S D"], mask: AttentionMask | jax.Array) -> Float[Array, "B S D"]:
+        return x + self.mlp(x)
+
+
+def mlp_only_enabled() -> bool:
+    """Env toggle (SCALE_MLP_ONLY=1) selecting attention-free MLP blocks."""
+    return os.environ.get("SCALE_MLP_ONLY") == "1"
+
+
+def no_rope_enabled() -> bool:
+    """Env toggle (SCALE_NO_ROPE=1): skip rotary position embedding (NoPE attention)."""
+    return os.environ.get("SCALE_NO_ROPE") == "1"
+
+
+def remat_every_k() -> int:
+    """Selective remat stride (SCALE_REMAT_EVERY_K): checkpoint block ``i`` iff ``i % K == 0``.
+
+    K=1 checkpoints every block (equivalent to full remat); larger K checkpoints
+    fewer blocks -> more activation memory but less recompute. 0 (default) disables
+    this and falls back to the binary ``remat_mode``.
+    """
+    return int(os.environ.get("SCALE_REMAT_EVERY_K", "0"))
+
+
+def scan_layers_enabled() -> bool:
+    """Env toggle (SCALE_SCAN_LAYERS=1): run the (homogeneous) blocks under a single
+    ``jax.lax.scan`` instead of a Python for-loop. One compiled layer body + a clean
+    sequential memory schedule, vs. an unrolled 26-layer graph that XLA over-allocates.
+    """
+    return os.environ.get("SCALE_SCAN_LAYERS") == "1"
+
+
+def scan_chunk_size() -> int:
+    """SCALE_SCAN_CHUNK=G: under scan, checkpoint every G layers (nested scan).
+
+    G=1 (default) checkpoints every layer = full remat (min memory, max recompute);
+    larger G checkpoints fewer boundaries -> more activation memory, less recompute
+    (recovers MFU). Must divide num_layers.
+    """
+    return int(os.environ.get("SCALE_SCAN_CHUNK", "1"))
+
+
+def remat_policy():
+    """SCALE_REMAT_POLICY selects the checkpoint policy for the rematerialized body.
+
+    '' / 'none' -> default (nothing saved: recompute everything, incl. matmuls).
+    'dots' -> save all matmul outputs, recompute only cheap elementwise (GELU/residual/RoPE):
+              eliminates the GEMM recompute at the cost of storing matmul outputs.
+    'dots_nobatch' -> save only batch-dim-free dots (cheaper memory, less recompute saved).
+    'everything' -> save all intermediates (equivalent to no remat).
+    """
+    name = os.environ.get("SCALE_REMAT_POLICY", "").lower()
+    if name in ("", "none"):
+        return None
+    policies = {
+        "dots": jax.checkpoint_policies.dots_saveable,
+        "dots_nobatch": jax.checkpoint_policies.dots_with_no_batch_dims_saveable,
+        "everything": jax.checkpoint_policies.everything_saveable,
+        # Save only the flash-attention output: recover its recompute (a real kernel)
+        # for [T,d] storage, while still recomputing the cheap-to-redo matmuls.
+        "attn": jax.checkpoint_policies.save_only_these_names("attn_out"),
+    }
+    if name not in policies:
+        raise ValueError(f"SCALE_REMAT_POLICY={name!r} must be one of {sorted(policies)} or none")
+    return policies[name]
+
+
+class Transformer(eqx.Module):
+    """Minimalist dense transformer: embed -> blocks -> lm head, no norms.
+
+    ``blocks`` is a tuple of per-layer modules in the default (unrolled) path; under
+    ``SCALE_SCAN_LAYERS`` it is a single block whose leaves carry a leading layer axis.
+    """
+
+    token_embed: Float[Array, "V D"]
+    output_proj: Float[Array, "D V"]
+    blocks: tuple[BasicBlock | BasicMLPBlock, ...] | BasicBlock | BasicMLPBlock
+    config: GrugModelConfig = eqx.field(static=True)
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "Transformer":
+        embed_key, out_key, *block_keys = random.split(key, cfg.num_layers + 2)
+        token_embed = reshard(
+            _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), cfg.initializer_std), Pembed_vocab
+        )
+        output_proj = reshard(_init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head)
+        block_cls: type[BasicBlock] | type[BasicMLPBlock] = BasicMLPBlock if mlp_only_enabled() else BasicBlock
+        block_list = [block_cls.init(cfg, key=block_keys[i]) for i in range(cfg.num_layers)]
+        blocks: tuple[BasicBlock | BasicMLPBlock, ...] | BasicBlock | BasicMLPBlock
+        if scan_layers_enabled() and block_list:
+            # Stack homogeneous per-layer weights along a new leading layer axis so the
+            # forward can scan over them. Static (config) fields are shared, not stacked.
+            blocks = jax.tree_util.tree_map(lambda *leaves: jnp.stack(leaves), *block_list)
+        else:
+            blocks = tuple(block_list)
+        return Transformer(token_embed=token_embed, output_proj=output_proj, blocks=blocks, config=cfg)
+
+    @property
+    def Vocab(self) -> Axis:
+        return Axis("vocab", self.config.vocab_size)
+
+    def build(self, Vocab: Axis, *, key: PRNGKeyArray) -> "Transformer":
+        cfg = (
+            self.config
+            if Vocab.size == self.config.vocab_size
+            else dataclasses.replace(self.config, vocab_size=Vocab.size)
+        )
+        return Transformer.init(cfg, key=key)
+
+    @named_call
+    def __call__(
+        self,
+        token_ids: Int[Array, "B S"],
+        mask: AttentionMask | jax.Array | None = None,
+    ) -> Float[Array, "B S D"]:
+        if mask is None:
+            mask = AttentionMask.causal()
+        hidden = self.token_embed.at[token_ids].get(out_sharding=_batch_spec())
+        base_remat = self.config.remat_mode != "none"
+        policy = remat_policy()
+
+        if scan_layers_enabled() and self.config.num_layers > 0:
+            # Scan the stacked blocks: one compiled body, sequential schedule.
+            block_params, block_static = eqx.partition(self.blocks, eqx.is_array)
+
+            def run_layer(carry, layer_params):
+                block = eqx.combine(layer_params, block_static)
+                return block(carry, mask), None
+
+            group = scan_chunk_size()
+            if group <= 1:
+                # Checkpoint every layer (full remat) — the safe minimum-memory path.
+                step = eqx.filter_checkpoint(run_layer, policy=policy) if base_remat else run_layer
+                hidden, _ = jax.lax.scan(step, hidden, block_params)
+                return hidden
+
+            # Nested scan: checkpoint every `group` layers. Inner scan runs the group
+            # (activations kept within it); the outer body is checkpointed so only the
+            # group input is stacked -> fewer recomputes than per-layer full remat.
+            num_layers = self.config.num_layers
+            if num_layers % group != 0:
+                raise ValueError(f"SCALE_SCAN_CHUNK={group} must divide num_layers={num_layers}")
+            grouped = jax.tree_util.tree_map(lambda x: x.reshape(num_layers // group, group, *x.shape[1:]), block_params)
+
+            def run_group(carry, group_params):
+                out, _ = jax.lax.scan(run_layer, carry, group_params)
+                return out, None
+
+            step = eqx.filter_checkpoint(run_group, policy=policy) if base_remat else run_group
+            hidden, _ = jax.lax.scan(step, hidden, grouped)
+            return hidden
+
+        every_k = remat_every_k()
+        for i, block in enumerate(self.blocks):
+            do_remat = (i % every_k == 0) if every_k > 0 else base_remat
+            hidden = (eqx.filter_checkpoint(block, policy=policy) if do_remat else block)(hidden, mask)
+        return hidden
+
+    @named_call
+    def logits(
+        self,
+        token_ids: Int[Array, "B S"],
+        mask: AttentionMask | jax.Array | None = None,
+    ) -> Float[Array, "B S V"]:
+        hidden = self(token_ids, mask=mask)
+        return jnp.einsum("bsh,hd->bsd", hidden, self.output_proj, out_sharding=_batch_spec())
+
+    def next_token_loss(
+        self,
+        token_ids: Int[Array, "B S"],
+        loss_weight: Float[Array, "B S"],
+        *,
+        mask: AttentionMask | jax.Array | None = None,
+        reduction: str = "mean",
+        logsumexp_weight: float | None = None,
+        loss_dtype: jnp.dtype = jnp.float32,
+    ) -> jax.Array:
+        hidden = self(token_ids, mask=mask)
+        labels = jnp.concatenate([token_ids[:, 1:], token_ids[:, :1] * 0], axis=1).astype(jnp.int32)
+        return fused_linear_softmax_cross_entropy_loss(
+            hidden,
+            self.output_proj,
+            labels,
+            weight=loss_weight.astype(loss_dtype),
+            reduction=reduction,
+            logsumexp_weight=logsumexp_weight,
+            dtype=loss_dtype,
+        )
+
+
+def build(cfg: GrugModelConfig, Vocab: Axis, *, key: PRNGKeyArray) -> Transformer:
+    """Build a minimalist transformer, matching Vocab size to the tokenizer."""
+    resolved = cfg if Vocab.size == cfg.vocab_size else dataclasses.replace(cfg, vocab_size=Vocab.size)
+    return Transformer.init(resolved, key=key)
+
+
+__all__ = [
+    "BasicAttention",
+    "BasicBlock",
+    "BasicMLP",
+    "BasicMLPBlock",
+    "Transformer",
+    "build",
+    "mlp_only_enabled",
+]

--- a/experiments/grug/moe/model_mid.py
+++ b/experiments/grug/moe/model_mid.py
@@ -6,10 +6,11 @@
 A mid-point between ``model_basic`` (dense / a few MoE layers) and the full
 ``model.py`` (RMSNorm + GatedNorm + PKO/XSA/half-RoPE). *Every* layer here is::
 
-    x = x + attn(x)
-    x = x + routed_moe(x) + shared_expert(x)
+    x = x + attn(norm_attn(x))
+    x = x + routed_moe(norm_mlp(x)) + shared_expert(norm_mlp(x))
 
-with **no normalization**. The shared expert is a SwiGLU FFN at width
+with learnable-gain :class:`RMSNorm` pre-attention and pre-MLP, plus an input norm
+(after the embedding) and an output norm (before the LM head). The shared expert is a SwiGLU FFN at width
 ``hidden_dim`` (grug's :class:`~experiments.grug.moe.model.DenseMLP`); the routed
 component is grug's QB-routed :class:`~experiments.grug.moe.model.MoEMLP` picking
 ``num_experts_per_token`` of ``num_experts`` (e.g. 4 of 64). Shared and routed
@@ -42,6 +43,7 @@ from experiments.grug.moe.model import (
     DenseMLP,
     GrugModelConfig,
     MoEMLP,
+    RMSNorm,
     _batch_spec,
     _init_weight,
 )
@@ -68,15 +70,18 @@ def shared_expert_intermediate(cfg: GrugModelConfig) -> int:
 
 
 class MoeMidBlock(eqx.Module):
-    """Residual attention + (routed MoE + shared SwiGLU expert), no norms.
+    """Residual (pre-norm attention) + (pre-norm routed MoE + shared SwiGLU expert).
 
     Reuses ``model_basic``'s :class:`BasicAttention`, grug's :class:`MoEMLP` (routed,
-    top-(K+1) QB gating, ragged-dot dispatch), and grug's :class:`DenseMLP` (SwiGLU
-    shared expert). Forward-only QB: the router bias stays zero and the returned
-    router stats are discarded.
+    top-(K+1) QB gating, ragged-dot dispatch), grug's :class:`DenseMLP` (SwiGLU shared
+    expert), and grug's learnable-gain :class:`RMSNorm` applied pre-attention and
+    pre-MLP. Forward-only QB: the router bias stays zero and the returned router stats
+    are discarded.
     """
 
     attn: BasicAttention
+    norm_attn: RMSNorm
+    norm_mlp: RMSNorm
     shared: DenseMLP
     moe: MoEMLP
 
@@ -92,13 +97,20 @@ class MoeMidBlock(eqx.Module):
         router = reshard(_init_weight(router_key, moe.router.shape, embed_router_std(cfg)), P(None, None))
         moe = eqx.tree_at(lambda m: m.router, moe, router)
         shared = DenseMLP.init(cfg.hidden_dim, shared_expert_intermediate(cfg), cfg.initializer_std, key=shared_key)
-        return MoeMidBlock(attn=BasicAttention.init(cfg, key=attn_key), shared=shared, moe=moe)
+        return MoeMidBlock(
+            attn=BasicAttention.init(cfg, key=attn_key),
+            norm_attn=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            norm_mlp=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            shared=shared,
+            moe=moe,
+        )
 
     @named_call
     def __call__(self, x: Float[Array, "B S D"], mask: AttentionMask | jax.Array) -> Float[Array, "B S D"]:
-        x = x + self.attn(x, mask)
-        moe_out, _router_stats = self.moe(x)  # forward-only QB routing; stats unused
-        shared_out = self.shared(x, activation=ActivationFunctionEnum.silu)
+        x = x + self.attn(self.norm_attn(x), mask)
+        mlp_in = self.norm_mlp(x)
+        moe_out, _router_stats = self.moe(mlp_in)  # forward-only QB routing; stats unused
+        shared_out = self.shared(mlp_in, activation=ActivationFunctionEnum.silu)
         return x + moe_out + shared_out
 
 
@@ -112,6 +124,8 @@ class Transformer(eqx.Module):
 
     token_embed: Float[Array, "V D"]
     output_proj: Float[Array, "D V"]
+    norm_input: RMSNorm
+    norm_output: RMSNorm
     blocks: tuple[MoeMidBlock, ...] | MoeMidBlock
     config: GrugModelConfig = eqx.field(static=True)
 
@@ -132,7 +146,14 @@ class Transformer(eqx.Module):
             blocks = jax.tree_util.tree_map(lambda *leaves: jnp.stack(leaves), *block_list)
         else:
             blocks = tuple(block_list)
-        return Transformer(token_embed=token_embed, output_proj=output_proj, blocks=blocks, config=cfg)
+        return Transformer(
+            token_embed=token_embed,
+            output_proj=output_proj,
+            norm_input=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            norm_output=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            blocks=blocks,
+            config=cfg,
+        )
 
     @property
     def Vocab(self) -> Axis:
@@ -154,7 +175,7 @@ class Transformer(eqx.Module):
     ) -> Float[Array, "B S D"]:
         if mask is None:
             mask = AttentionMask.causal()
-        hidden = self.token_embed.at[token_ids].get(out_sharding=_batch_spec())
+        hidden = self.norm_input(self.token_embed.at[token_ids].get(out_sharding=_batch_spec()))
         base_remat = self.config.remat_mode != "none"
         policy = remat_policy()
         # Every block is MoE: save the tagged dispatch tensors (save_moe) only when asked,
@@ -174,30 +195,29 @@ class Transformer(eqx.Module):
                 # Checkpoint every layer (full remat) — the safe minimum-memory path.
                 step = eqx.filter_checkpoint(run_layer, policy=block_policy) if base_remat else run_layer
                 hidden, _ = jax.lax.scan(step, hidden, block_params)
-                return hidden
+            else:
+                # Nested scan: checkpoint every `group` layers. The inner scan runs the group
+                # (activations kept within it); the outer body is checkpointed so only the
+                # group input is stacked -> fewer recomputes than per-layer full remat.
+                if self.config.num_layers % group != 0:
+                    raise ValueError(f"SCALE_SCAN_CHUNK={group} must divide num_layers={self.config.num_layers}")
+                grouped = jax.tree_util.tree_map(
+                    lambda x: x.reshape(self.config.num_layers // group, group, *x.shape[1:]), block_params
+                )
 
-            # Nested scan: checkpoint every `group` layers. The inner scan runs the group
-            # (activations kept within it); the outer body is checkpointed so only the
-            # group input is stacked -> fewer recomputes than per-layer full remat.
-            if self.config.num_layers % group != 0:
-                raise ValueError(f"SCALE_SCAN_CHUNK={group} must divide num_layers={self.config.num_layers}")
-            grouped = jax.tree_util.tree_map(
-                lambda x: x.reshape(self.config.num_layers // group, group, *x.shape[1:]), block_params
-            )
+                def run_group(carry, group_params):
+                    out, _ = jax.lax.scan(run_layer, carry, group_params)
+                    return out, None
 
-            def run_group(carry, group_params):
-                out, _ = jax.lax.scan(run_layer, carry, group_params)
-                return out, None
+                step = eqx.filter_checkpoint(run_group, policy=block_policy) if base_remat else run_group
+                hidden, _ = jax.lax.scan(step, hidden, grouped)
+        else:
+            every_k = remat_every_k()
+            for i, block in enumerate(self.blocks):
+                do_remat = (i % every_k == 0) if every_k > 0 else base_remat
+                hidden = (eqx.filter_checkpoint(block, policy=block_policy) if do_remat else block)(hidden, mask)
 
-            step = eqx.filter_checkpoint(run_group, policy=block_policy) if base_remat else run_group
-            hidden, _ = jax.lax.scan(step, hidden, grouped)
-            return hidden
-
-        every_k = remat_every_k()
-        for i, block in enumerate(self.blocks):
-            do_remat = (i % every_k == 0) if every_k > 0 else base_remat
-            hidden = (eqx.filter_checkpoint(block, policy=block_policy) if do_remat else block)(hidden, mask)
-        return hidden
+        return self.norm_output(hidden)
 
     @named_call
     def logits(

--- a/experiments/grug/moe/model_mid.py
+++ b/experiments/grug/moe/model_mid.py
@@ -41,6 +41,7 @@ from levanter.utils.activation import ActivationFunctionEnum
 
 from experiments.grug.moe.model import (
     DenseMLP,
+    GatedNorm,
     GrugModelConfig,
     MoEMLP,
     RMSNorm,
@@ -69,6 +70,12 @@ def shared_expert_intermediate(cfg: GrugModelConfig) -> int:
     return int(os.environ.get("SCALE_SHARED_EXPERT_INTERMEDIATE", str(cfg.hidden_dim)))
 
 
+def gated_norm_enabled() -> bool:
+    """Env toggle (SCALE_GATED_NORM=1): apply grug's learnable GatedNorm (rank 128) after
+    the pre-attn and pre-MLP RMSNorm, matching model.py."""
+    return os.environ.get("SCALE_GATED_NORM") == "1"
+
+
 class MoeMidBlock(eqx.Module):
     """Residual (pre-norm attention) + (pre-norm routed MoE + shared SwiGLU expert).
 
@@ -81,13 +88,15 @@ class MoeMidBlock(eqx.Module):
 
     attn: BasicAttention
     norm_attn: RMSNorm
+    gated_attn: GatedNorm | None
     norm_mlp: RMSNorm
+    gated_mlp: GatedNorm | None
     shared: DenseMLP
     moe: MoEMLP
 
     @staticmethod
     def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "MoeMidBlock":
-        attn_key, shared_key, moe_key, router_key = random.split(key, 4)
+        attn_key, shared_key, moe_key, router_key, ga_key, gm_key = random.split(key, 6)
         # MoEMLP reads cfg.intermediate_dim as the *expert* width; swap in the (narrower)
         # routed-expert width so the config's own intermediate_dim is untouched.
         moe_cfg = dataclasses.replace(cfg, intermediate_dim=moe_expert_intermediate(cfg))
@@ -97,18 +106,26 @@ class MoeMidBlock(eqx.Module):
         router = reshard(_init_weight(router_key, moe.router.shape, embed_router_std(cfg)), P(None, None))
         moe = eqx.tree_at(lambda m: m.router, moe, router)
         shared = DenseMLP.init(cfg.hidden_dim, shared_expert_intermediate(cfg), cfg.initializer_std, key=shared_key)
+        gated = gated_norm_enabled()
         return MoeMidBlock(
             attn=BasicAttention.init(cfg, key=attn_key),
             norm_attn=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            gated_attn=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=ga_key) if gated else None,
             norm_mlp=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            gated_mlp=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=gm_key) if gated else None,
             shared=shared,
             moe=moe,
         )
 
     @named_call
     def __call__(self, x: Float[Array, "B S D"], mask: AttentionMask | jax.Array) -> Float[Array, "B S D"]:
-        x = x + self.attn(self.norm_attn(x), mask)
+        attn_in = self.norm_attn(x)
+        if self.gated_attn is not None:
+            attn_in = self.gated_attn(attn_in)
+        x = x + self.attn(attn_in, mask)
         mlp_in = self.norm_mlp(x)
+        if self.gated_mlp is not None:
+            mlp_in = self.gated_mlp(mlp_in)
         moe_out, _router_stats = self.moe(mlp_in)  # forward-only QB routing; stats unused
         shared_out = self.shared(mlp_in, activation=ActivationFunctionEnum.silu)
         return x + moe_out + shared_out

--- a/experiments/grug/moe/model_mid.py
+++ b/experiments/grug/moe/model_mid.py
@@ -1,0 +1,245 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimalist shared-expert + routed-MoE transformer for throughput experiments.
+
+A mid-point between ``model_basic`` (dense / a few MoE layers) and the full
+``model.py`` (RMSNorm + GatedNorm + PKO/XSA/half-RoPE). *Every* layer here is::
+
+    x = x + attn(x)
+    x = x + routed_moe(x) + shared_expert(x)
+
+with **no normalization**. The shared expert is a SwiGLU FFN at width
+``hidden_dim`` (grug's :class:`~experiments.grug.moe.model.DenseMLP`); the routed
+component is grug's QB-routed :class:`~experiments.grug.moe.model.MoEMLP` picking
+``num_experts_per_token`` of ``num_experts`` (e.g. 4 of 64). Shared and routed
+both read the post-attention hidden and their sum feeds a single residual add,
+matching ``model.py``'s block minus the norms.
+
+Attention is full multi-head (``num_kv_heads == num_heads``) and reuses
+``model_basic``'s no-norm :class:`BasicAttention`. The stack is homogeneous, so
+the blocks are an unrolled tuple or, under ``SCALE_SCAN_LAYERS``, a single block
+whose leaves carry a leading layer axis for ``jax.lax.scan``.
+"""
+
+import dataclasses
+import os
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from haliax import Axis
+from haliax.jax_utils import named_call
+from jax import random
+from jax.sharding import PartitionSpec as P
+from jax.sharding import reshard
+from jaxtyping import Array, Float, Int, PRNGKeyArray
+from levanter.grug.attention import AttentionMask
+from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
+from levanter.utils.activation import ActivationFunctionEnum
+
+from experiments.grug.moe.model import (
+    DenseMLP,
+    GrugModelConfig,
+    MoEMLP,
+    _batch_spec,
+    _init_weight,
+)
+from experiments.grug.moe.model_basic import (
+    _FSDP_AXES,
+    BasicAttention,
+    embed_router_std,
+    moe_expert_intermediate,
+    moe_remat_policy,
+    moe_scan_save,
+    remat_every_k,
+    remat_policy,
+    scan_chunk_size,
+    scan_layers_enabled,
+)
+
+
+def shared_expert_intermediate(cfg: GrugModelConfig) -> int:
+    """Width of the per-layer shared SwiGLU expert (SCALE_SHARED_EXPERT_INTERMEDIATE).
+
+    Defaults to ``hidden_dim`` (a full-width dense SwiGLU alongside the routed experts).
+    """
+    return int(os.environ.get("SCALE_SHARED_EXPERT_INTERMEDIATE", str(cfg.hidden_dim)))
+
+
+class MoeMidBlock(eqx.Module):
+    """Residual attention + (routed MoE + shared SwiGLU expert), no norms.
+
+    Reuses ``model_basic``'s :class:`BasicAttention`, grug's :class:`MoEMLP` (routed,
+    top-(K+1) QB gating, ragged-dot dispatch), and grug's :class:`DenseMLP` (SwiGLU
+    shared expert). Forward-only QB: the router bias stays zero and the returned
+    router stats are discarded.
+    """
+
+    attn: BasicAttention
+    shared: DenseMLP
+    moe: MoEMLP
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "MoeMidBlock":
+        attn_key, shared_key, moe_key, router_key = random.split(key, 4)
+        # MoEMLP reads cfg.intermediate_dim as the *expert* width; swap in the (narrower)
+        # routed-expert width so the config's own intermediate_dim is untouched.
+        moe_cfg = dataclasses.replace(cfg, intermediate_dim=moe_expert_intermediate(cfg))
+        moe = MoEMLP.init(moe_cfg, key=moe_key)
+        # Nonzero router init even under zero-init so routing spreads across experts
+        # (experts stay zero for stability, but the dispatch load is realistic).
+        router = reshard(_init_weight(router_key, moe.router.shape, embed_router_std(cfg)), P(None, None))
+        moe = eqx.tree_at(lambda m: m.router, moe, router)
+        shared = DenseMLP.init(cfg.hidden_dim, shared_expert_intermediate(cfg), cfg.initializer_std, key=shared_key)
+        return MoeMidBlock(attn=BasicAttention.init(cfg, key=attn_key), shared=shared, moe=moe)
+
+    @named_call
+    def __call__(self, x: Float[Array, "B S D"], mask: AttentionMask | jax.Array) -> Float[Array, "B S D"]:
+        x = x + self.attn(x, mask)
+        moe_out, _router_stats = self.moe(x)  # forward-only QB routing; stats unused
+        shared_out = self.shared(x, activation=ActivationFunctionEnum.silu)
+        return x + moe_out + shared_out
+
+
+class Transformer(eqx.Module):
+    """Minimalist all-MoE transformer: embed -> shared+routed MoE blocks -> lm head.
+
+    The stack is homogeneous (every layer is a :class:`MoeMidBlock`), so ``blocks`` is
+    an unrolled tuple in the default path, or under ``SCALE_SCAN_LAYERS`` a single block
+    whose leaves carry a leading layer axis.
+    """
+
+    token_embed: Float[Array, "V D"]
+    output_proj: Float[Array, "D V"]
+    blocks: tuple[MoeMidBlock, ...] | MoeMidBlock
+    config: GrugModelConfig = eqx.field(static=True)
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "Transformer":
+        embed_key, out_key, *block_keys = random.split(key, cfg.num_layers + 2)
+        token_embed = reshard(
+            _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), embed_router_std(cfg)), P("model", _FSDP_AXES)
+        )
+        output_proj = reshard(
+            _init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), P(_FSDP_AXES, "model")
+        )
+        block_list = [MoeMidBlock.init(cfg, key=block_keys[i]) for i in range(cfg.num_layers)]
+        blocks: tuple[MoeMidBlock, ...] | MoeMidBlock
+        if scan_layers_enabled():
+            # Stack homogeneous per-layer weights along a new leading layer axis so the
+            # forward can scan over them. Static (config) fields are shared, not stacked.
+            blocks = jax.tree_util.tree_map(lambda *leaves: jnp.stack(leaves), *block_list)
+        else:
+            blocks = tuple(block_list)
+        return Transformer(token_embed=token_embed, output_proj=output_proj, blocks=blocks, config=cfg)
+
+    @property
+    def Vocab(self) -> Axis:
+        return Axis("vocab", self.config.vocab_size)
+
+    def build(self, Vocab: Axis, *, key: PRNGKeyArray) -> "Transformer":
+        cfg = (
+            self.config
+            if Vocab.size == self.config.vocab_size
+            else dataclasses.replace(self.config, vocab_size=Vocab.size)
+        )
+        return Transformer.init(cfg, key=key)
+
+    @named_call
+    def __call__(
+        self,
+        token_ids: Int[Array, "B S"],
+        mask: AttentionMask | jax.Array | None = None,
+    ) -> Float[Array, "B S D"]:
+        if mask is None:
+            mask = AttentionMask.causal()
+        hidden = self.token_embed.at[token_ids].get(out_sharding=_batch_spec())
+        base_remat = self.config.remat_mode != "none"
+        policy = remat_policy()
+        # Every block is MoE: save the tagged dispatch tensors (save_moe) only when asked,
+        # else full remat. Under scan save_moe stacks the saved tensors across all layers
+        # (memory ~ batch), so recompute is the safe default.
+        block_policy = moe_remat_policy() if moe_scan_save() else policy
+
+        if scan_layers_enabled():
+            block_params, block_static = eqx.partition(self.blocks, eqx.is_array)
+
+            def run_layer(carry, layer_params):
+                block = eqx.combine(layer_params, block_static)
+                return block(carry, mask), None
+
+            group = scan_chunk_size()
+            if group <= 1:
+                # Checkpoint every layer (full remat) — the safe minimum-memory path.
+                step = eqx.filter_checkpoint(run_layer, policy=block_policy) if base_remat else run_layer
+                hidden, _ = jax.lax.scan(step, hidden, block_params)
+                return hidden
+
+            # Nested scan: checkpoint every `group` layers. The inner scan runs the group
+            # (activations kept within it); the outer body is checkpointed so only the
+            # group input is stacked -> fewer recomputes than per-layer full remat.
+            if self.config.num_layers % group != 0:
+                raise ValueError(f"SCALE_SCAN_CHUNK={group} must divide num_layers={self.config.num_layers}")
+            grouped = jax.tree_util.tree_map(
+                lambda x: x.reshape(self.config.num_layers // group, group, *x.shape[1:]), block_params
+            )
+
+            def run_group(carry, group_params):
+                out, _ = jax.lax.scan(run_layer, carry, group_params)
+                return out, None
+
+            step = eqx.filter_checkpoint(run_group, policy=block_policy) if base_remat else run_group
+            hidden, _ = jax.lax.scan(step, hidden, grouped)
+            return hidden
+
+        every_k = remat_every_k()
+        for i, block in enumerate(self.blocks):
+            do_remat = (i % every_k == 0) if every_k > 0 else base_remat
+            hidden = (eqx.filter_checkpoint(block, policy=block_policy) if do_remat else block)(hidden, mask)
+        return hidden
+
+    @named_call
+    def logits(
+        self,
+        token_ids: Int[Array, "B S"],
+        mask: AttentionMask | jax.Array | None = None,
+    ) -> Float[Array, "B S V"]:
+        hidden = self(token_ids, mask=mask)
+        return jnp.einsum("bsh,hd->bsd", hidden, self.output_proj, out_sharding=_batch_spec())
+
+    def next_token_loss(
+        self,
+        token_ids: Int[Array, "B S"],
+        loss_weight: Float[Array, "B S"],
+        *,
+        mask: AttentionMask | jax.Array | None = None,
+        reduction: str = "mean",
+        logsumexp_weight: float | None = None,
+        loss_dtype: jnp.dtype = jnp.float32,
+    ) -> jax.Array:
+        hidden = self(token_ids, mask=mask)
+        labels = jnp.concatenate([token_ids[:, 1:], token_ids[:, :1] * 0], axis=1).astype(jnp.int32)
+        return fused_linear_softmax_cross_entropy_loss(
+            hidden,
+            self.output_proj,
+            labels,
+            weight=loss_weight.astype(loss_dtype),
+            reduction=reduction,
+            logsumexp_weight=logsumexp_weight,
+            dtype=loss_dtype,
+        )
+
+
+def build(cfg: GrugModelConfig, Vocab: Axis, *, key: PRNGKeyArray) -> Transformer:
+    """Build a minimalist shared-expert + routed-MoE transformer, matching Vocab size."""
+    resolved = cfg if Vocab.size == cfg.vocab_size else dataclasses.replace(cfg, vocab_size=Vocab.size)
+    return Transformer.init(resolved, key=key)
+
+
+__all__ = [
+    "MoeMidBlock",
+    "Transformer",
+    "build",
+    "shared_expert_intermediate",
+]

--- a/experiments/grug/moe/optimizer.py
+++ b/experiments/grug/moe/optimizer.py
@@ -197,8 +197,12 @@ class GrugMoeAdamHConfig(OptimizerConfig):
                 return "adam"
             if "router_bias" in path_lower or "attn_gate" in path_lower or ".router" in path_lower:
                 return "adam"
-            # RMSNorm/LayerNorm gains -> plain Adam.
-            if "norm" in path_lower:
+            # GatedNorm projections are matrices -> adamh; checked before the rms/norm test
+            # (model.py names them *_gated_norm).
+            if "gated" in path_lower:
+                return "adamh"
+            # RMSNorm/LayerNorm gains -> plain Adam (model.py rms_*, model_mid norm_*).
+            if "rms" in path_lower or "norm" in path_lower:
                 return "adam"
             if "expert_mlp.w_" in path_lower or ".shared.w_" in path_lower:
                 return "adamh_expert"
@@ -300,12 +304,17 @@ class GrugMoeMuonHConfig(OptimizerConfig):
                 return "adam"
             if "output_proj" in path_lower or "lm_head" in path_lower:
                 return "adamh"
-            # RMSNorm/LayerNorm gains are per-dimension scales (stack to 2D under scan),
-            # not orthogonalizable matrices -> plain Adam.
-            if "norm" in path_lower:
+            # GatedNorm low-rank projections are real matrices -> MuonH. Checked before the
+            # norm test since model.py names them *_gated_norm (contains "norm"); model_mid
+            # names them gated_*.
+            if "gated" in path_lower:
+                return "muonh"
+            # RMSNorm/LayerNorm gains are per-dimension scales (stack to 2D under scan), not
+            # orthogonalizable matrices -> plain Adam. Handles model.py's rms_attn/rms_mlp
+            # and model_mid's norm_* naming.
+            if "rms" in path_lower or "norm" in path_lower:
                 return "adam"
-            # Matrices -> MuonH: attention, MoE experts (4D when stacked under scan), shared
-            # expert, and GatedNorm low-rank projections.
+            # Matrices -> MuonH: attention, MoE experts (4D when stacked under scan), shared.
             if hasattr(param, "ndim") and param.ndim in (2, 3, 4):
                 return "muonh"
             return "adam"

--- a/experiments/grug/moe/optimizer.py
+++ b/experiments/grug/moe/optimizer.py
@@ -197,7 +197,10 @@ class GrugMoeAdamHConfig(OptimizerConfig):
                 return "adam"
             if "router_bias" in path_lower or "attn_gate" in path_lower or ".router" in path_lower:
                 return "adam"
-            if ".mlp.expert_mlp.w_" in path_lower or ".mlp.w_" in path_lower or ".shared.w_" in path_lower:
+            # RMSNorm/LayerNorm gains -> plain Adam.
+            if "norm" in path_lower:
+                return "adam"
+            if "expert_mlp.w_" in path_lower or ".shared.w_" in path_lower:
                 return "adamh_expert"
             if hasattr(param, "ndim") and param.ndim >= 2:
                 return "adamh"
@@ -297,10 +300,13 @@ class GrugMoeMuonHConfig(OptimizerConfig):
                 return "adam"
             if "output_proj" in path_lower or "lm_head" in path_lower:
                 return "adamh"
-            # GatedNorms route to muonh (NS + Frobenius hyperball), same as matrices.
-            if "gated_norm" in path_lower:
-                return "muonh"
-            if hasattr(param, "ndim") and param.ndim in (2, 3):
+            # RMSNorm/LayerNorm gains are per-dimension scales (stack to 2D under scan),
+            # not orthogonalizable matrices -> plain Adam.
+            if "norm" in path_lower:
+                return "adam"
+            # Matrices -> MuonH: attention, MoE experts (4D when stacked under scan), shared
+            # expert, and GatedNorm low-rank projections.
+            if hasattr(param, "ndim") and param.ndim in (2, 3, 4):
                 return "muonh"
             return "adam"
 

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -255,16 +255,18 @@ class GrugTrainState:
 
 def _apply_qb_betas(model: Transformer, qb_betas: jax.Array) -> Transformer:
     """Set router biases from QB betas (computed on previous step)."""
+    new_biases = -qb_betas
+    new_biases = new_biases - jnp.mean(new_biases, axis=-1, keepdims=True)
+    if model.stacked_blocks is not None:
+        # Stacked path: router_bias is a single [num_layers, num_experts] leaf.
+        return eqx.tree_at(lambda t: t.stacked_blocks.stacked.mlp.router_bias, model, new_biases)
+    assert model.blocks is not None
     new_blocks = list(model.blocks)
-    moe_idx = 0
     for i, block in enumerate(model.blocks):
         if block.mlp is None:
             continue
-        new_bias = -qb_betas[moe_idx]
-        new_bias = new_bias - jnp.mean(new_bias)
-        new_mlp = eqx.tree_at(lambda m: m.router_bias, block.mlp, new_bias)
+        new_mlp = eqx.tree_at(lambda m: m.router_bias, block.mlp, new_biases[i])
         new_blocks[i] = eqx.tree_at(lambda b: b.mlp, block, new_mlp)
-        moe_idx += 1
     return eqx.tree_at(lambda t: t.blocks, model, tuple(new_blocks))
 
 
@@ -277,7 +279,10 @@ def initial_state(
     ema_beta: float | None,
 ) -> GrugTrainState:
     params = mp.cast_to_param(Transformer.init(model_config, key=key))
-    num_moe_layers = sum(1 for b in params.blocks if b.mlp is not None)
+    if params.blocks is not None:
+        num_moe_layers = sum(1 for b in params.blocks if b.mlp is not None)
+    else:
+        num_moe_layers = model_config.num_layers
     return GrugTrainState(
         step=jnp.array(0, dtype=jnp.int32),
         params=params,

--- a/experiments/grug/moe/train_basic.py
+++ b/experiments/grug/moe/train_basic.py
@@ -1,0 +1,465 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Training loop for the minimalist dense transformer (``model_basic``).
+
+Mirrors ``experiments/grug/moe/train.py`` but stripped of all MoE machinery:
+no QB router biases, no router z-loss / capacity metrics, no ``pending_qb_betas``
+in the train state. Data/mesh/eval/flop plumbing is reused from ``train.py`` since
+it is model-agnostic.
+"""
+
+import dataclasses
+import functools
+import logging
+import os
+import time
+
+import fsspec
+import jax
+import jax.numpy as jnp
+import jmp
+import levanter.callbacks as callbacks
+import levanter.tracker
+import optax
+from haliax.partitioning import set_mesh
+from jax.sharding import PartitionSpec as P
+from jax.sharding import get_abstract_mesh, reshard
+from jax.tree_util import register_dataclass
+from jaxtyping import PRNGKeyArray
+from levanter.callbacks.state_adapter import StateCallbackRunner
+from levanter.callbacks.watch import WatchConfig, compute_watch_stats
+from levanter.eval import cb_tagged_evaluate
+from levanter.grug.sharding import compact_grug_mesh
+from levanter.utils.jax_utils import parameter_count
+from levanter.utils.logging import LoadingTimeTrackerIterator
+
+from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
+from experiments.grug.dispatch import dispatch_grug_training_run
+from experiments.grug.moe import model_basic
+from experiments.grug.moe.model import GrugModelConfig
+from experiments.grug.moe.model_basic import Transformer
+from experiments.grug.moe.train import (
+    GrugEvalConfig,
+    GrugRunConfig,
+    GrugTrainerConfig,
+    _make_mixture_stage_callback,
+    build_tagged_evaluator,
+    build_train_dataset,
+    build_train_loader,
+)
+from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
+
+logger = logging.getLogger(__name__)
+
+
+def _basic_compute_flops(model_config: GrugModelConfig) -> tuple[float, dict[str, float]]:
+    """Analytic FLOPs for the basic dense transformer.
+
+    Differs from the MoE ``_compute_flops``: the MLP is a plain two-matrix GELU
+    block (no GLU gate, so 2 matmuls not 3), and attention is dropped entirely
+    when ``SCALE_MLP_ONLY`` selects attention-free blocks.
+    """
+    h = model_config.hidden_dim
+    inter = model_config.intermediate_dim
+    seq = model_config.max_seq_len
+    per_layer = 2 * 2 * h * inter  # up + down projections, 2 FLOPs each, no gate
+    if not model_basic.mlp_only_enabled():
+        head_dim = h / model_config.num_heads
+        qkv_proj = 2 * h * (model_config.num_heads * head_dim + 2 * model_config.num_kv_heads * head_dim)
+        dense_proj = 2 * h * h
+        seq_flops = 2 * seq**2 * model_config.num_heads * head_dim
+        seq_flops += 3 * seq * seq * model_config.num_heads
+        seq_flops += 2 * seq * seq * head_dim * model_config.num_heads
+        per_layer += qkv_proj + dense_proj + seq_flops / seq
+    lm_head = 2 * h * model_config.vocab_size
+    flops_per_token = model_config.num_layers * per_layer + lm_head
+    flops_per_example = 3 * flops_per_token * seq
+    return flops_per_example, {
+        "throughput/flops_per_token_analytic": flops_per_token,
+        "throughput/flops_per_example_analytic": flops_per_example,
+    }
+
+
+@register_dataclass
+@dataclasses.dataclass(frozen=True)
+class BasicTrainState:
+    step: jax.Array
+    params: Transformer
+    opt_state: optax.OptState
+    ema_params: Transformer | None
+
+
+def _zero1_shard_leaf(x):
+    """Shard one array's leading axis over the 'expert' (data-parallel) axis.
+
+    Replicated -> expert-sharded is a local slice (no communication) since the
+    replicated value already lives on every device. Scalars and leaves whose
+    leading axis isn't divisible by the expert size are left as-is.
+    """
+    if not isinstance(x, jax.Array) or x.ndim == 0:
+        return x
+    mesh = get_abstract_mesh()
+    expert_size = mesh.shape["expert"] if "expert" in mesh.axis_names else 1
+    if expert_size <= 1 or x.shape[0] % expert_size != 0:
+        return x
+    return reshard(x, P("expert", *([None] * (x.ndim - 1))))
+
+
+def _zero1_shard_tree(tree):
+    """ZeRO-1: shard a params-shaped pytree's leaves over the 'expert' axis."""
+    return jax.tree_util.tree_map(_zero1_shard_leaf, tree)
+
+
+def initial_state(
+    model_config: GrugModelConfig,
+    *,
+    optimizer: optax.GradientTransformation,
+    mp: jmp.Policy,
+    key: PRNGKeyArray,
+    ema_beta: float | None,
+    zero1: bool = False,
+) -> BasicTrainState:
+    params = mp.cast_to_param(model_basic.Transformer.init(model_config, key=key))
+    opt_state = optimizer.init(params)
+    if zero1:
+        opt_state = _zero1_shard_tree(opt_state)
+    return BasicTrainState(
+        step=jnp.array(0, dtype=jnp.int32),
+        params=params,
+        opt_state=opt_state,
+        ema_params=params if ema_beta is not None else None,
+    )
+
+
+def _make_train_step(
+    optimizer: optax.GradientTransformation,
+    mp: jmp.Policy,
+    *,
+    z_loss_weight: float,
+    ema_beta: float | None,
+    watch_config: WatchConfig | None = None,
+    zero1: bool = False,
+):
+    one = jnp.array(1, dtype=jnp.int32)
+    z_loss = z_loss_weight if z_loss_weight > 0 else None
+    if watch_config is not None:
+        if isinstance(watch_config.watch_targets, str):
+            watch_targets = tuple(t.strip() for t in watch_config.watch_targets.split(","))
+        else:
+            watch_targets = tuple(watch_config.watch_targets)
+    else:
+        watch_targets = ()
+
+    @functools.partial(jax.jit, donate_argnums=(0,), static_argnames=("compute_watch",))
+    def train_step(state: BasicTrainState, batch, *, compute_watch: bool = False):
+        def loss_fn(params):
+            compute_params = mp.cast_to_compute(params)
+            return compute_params.next_token_loss(
+                batch.tokens,
+                batch.loss_weight,
+                mask=batch.attn_mask,
+                reduction="mean",
+                logsumexp_weight=z_loss,
+            )
+
+        loss, grads = jax.value_and_grad(loss_fn)(state.params)
+        metrics = {"train/loss": loss}
+        if zero1:
+            # ZeRO-1: run the whole Adam update in expert-sharded space. Resharding
+            # grads/params from replicated -> expert-shard is a local slice (no comm);
+            # the update keeps mu/nu/updates expert-sharded; then all-gather the updates
+            # back to the replicated param layout — the single collective per step.
+            sharded_grads = _zero1_shard_tree(grads)
+            sharded_params = _zero1_shard_tree(state.params)
+            updates, opt_state = optimizer.update(sharded_grads, state.opt_state, sharded_params)
+            # all-gather updates from expert-shard back to the replicated param layout.
+            # Under an explicit mesh with_sharding_constraint only asserts, so reshard.
+            updates = jax.tree_util.tree_map(
+                lambda u, ref: reshard(u, jax.typeof(ref).sharding.spec),
+                updates,
+                state.params,
+            )
+        else:
+            updates, opt_state = optimizer.update(grads, state.opt_state, state.params)
+        params = optax.apply_updates(state.params, updates)
+
+        if ema_beta is None:
+            ema_params = None
+        else:
+            if state.ema_params is None:
+                raise ValueError("ema_params must be initialized when ema_beta is set.")
+            ema_params = jax.tree_util.tree_map(
+                lambda old, new: ema_beta * old + (1.0 - ema_beta) * new,
+                state.ema_params,
+                params,
+            )
+
+        watch_stats = None
+        if watch_config is not None and compute_watch:
+            watch_stats = compute_watch_stats(
+                watch_targets=watch_targets,
+                include_norms=watch_config.include_norms,
+                include_per_parameter_norms=watch_config.include_per_parameter_norms,
+                include_histogram=watch_config.include_histograms,
+                split_scan_layers=watch_config.split_scan_layers,
+                params=state.params,
+                grads=grads,
+                updates=updates,
+                opt_state=state.opt_state,
+                model_tree_type=type(state.params),
+            )
+
+        next_state = dataclasses.replace(
+            state,
+            step=state.step + one,
+            params=params,
+            opt_state=opt_state,
+            ema_params=ema_params,
+        )
+        return next_state, metrics, watch_stats
+
+    return train_step
+
+
+def _run_grug_basic_local(config: GrugRunConfig) -> None:
+    """Entry point for the minimalist dense training loop."""
+    trainer = config.trainer.trainer
+    trainer.initialize()
+    levanter.tracker.log_configuration(config)
+
+    run_id = trainer.id
+    if run_id is None:
+        raise ValueError("trainer.id was not initialized")
+
+    optimizer = config.optimizer.build(trainer.num_train_steps)
+    watch_config = trainer.watch
+    zero1 = os.environ.get("SCALE_ZERO1") == "1"
+    train_step = _make_train_step(
+        optimizer,
+        trainer.mp,
+        z_loss_weight=config.trainer.z_loss_weight,
+        ema_beta=config.trainer.ema_beta,
+        watch_config=watch_config if watch_config.is_enabled else None,
+        zero1=zero1,
+    )
+
+    data_key, model_key = jax.random.split(jax.random.PRNGKey(trainer.seed), 2)
+    if config.trainer.data_seed is not None:
+        data_key = jax.random.PRNGKey(config.trainer.data_seed)
+
+    mesh = compact_grug_mesh(
+        expert_axis_size=config.trainer.expert_axis_size,
+        replica_axis_size=config.trainer.replica_axis_size,
+    )
+    with set_mesh(mesh):
+        batch_schedule = trainer.batch_schedule
+
+        train_dataset = build_train_dataset(
+            config.data,
+            max_seq_len=config.model.max_seq_len,
+            batch_schedule=batch_schedule,
+            key=data_key,
+        )
+        train_loader = build_train_loader(train_dataset, batch_schedule=batch_schedule, mesh=mesh)
+
+        @jax.jit
+        def _init_state(model_rng):
+            return initial_state(
+                config.model,
+                optimizer=optimizer,
+                mp=trainer.mp,
+                key=model_rng,
+                ema_beta=config.trainer.ema_beta,
+                zero1=zero1,
+            )
+
+        state = _init_state(model_key)
+
+        checkpointer = trainer.checkpointer.create(run_id)
+        state = restore_grug_state_from_checkpoint(
+            state,
+            checkpoint_search_paths=trainer.checkpoint_search_paths(run_id),
+            load_checkpoint_setting=trainer.load_checkpoint,
+            mesh=mesh,
+            allow_partial=trainer.allow_partial_checkpoint,
+        )
+        dump_grug_state_sharding_run_artifact(
+            state,
+            log_dir=trainer.log_dir,
+            run_id=run_id,
+            path_override=config.trainer.sharding_dump_path,
+        )
+
+        levanter.tracker.log_summary({"parameter_count": parameter_count(state.params)})
+
+        flops_per_example, flops_summary = _basic_compute_flops(config.model)
+        levanter.tracker.log_summary(flops_summary)
+
+        eval_cfg = config.eval
+        evaluator = None
+        if eval_cfg is not None:
+            evaluator = build_tagged_evaluator(
+                data_config=config.data,
+                max_seq_len=config.model.max_seq_len,
+                mesh=mesh,
+                eval_cfg=eval_cfg,
+            )
+
+        profiler_cfg = trainer.profiler
+        profiler_num_steps = profiler_cfg.resolve_num_profile_steps(num_train_steps=trainer.num_train_steps)
+        profiler_enabled = profiler_cfg.is_enabled and profiler_num_steps > 0
+
+        log_every = max(1, config.trainer.log_every)
+        iterator = LoadingTimeTrackerIterator(train_loader.iter_from_step(int(state.step)))
+
+        state_callbacks = StateCallbackRunner[BasicTrainState](
+            step_getter=lambda s: s.step,
+            model_getter=lambda s: s.params,
+            eval_model_getter=lambda s: s.ema_params if s.ema_params is not None else s.params,
+            opt_state_getter=lambda s: s.opt_state,
+        )
+        state_callbacks.add_hook(
+            callbacks.log_performance_stats(config.model.max_seq_len, batch_schedule, flops_per_example),
+            every=log_every,
+        )
+        state_callbacks.add_hook(callbacks.pbar_logger(total=trainer.num_train_steps), every=log_every)
+        state_callbacks.add_hook(callbacks.log_step_info(trainer.num_train_steps), every=log_every)
+        if profiler_enabled:
+            state_callbacks.add_hook(
+                callbacks.profile(
+                    str(trainer.log_dir / run_id / "profiler"),
+                    profiler_cfg.start_step,
+                    profiler_num_steps,
+                    profiler_cfg.perfetto_link,
+                ),
+                every=1,
+            )
+        state_callbacks.add_hook(_make_mixture_stage_callback(train_dataset, batch_schedule), every=1)
+        if evaluator is not None and eval_cfg is not None:
+            interval = eval_cfg.steps_per_eval
+            eval_ema = eval_cfg.eval_ema and config.trainer.ema_beta is not None
+            if interval is not None and interval > 0 and (eval_cfg.eval_current or eval_ema):
+                state_callbacks.add_hook(
+                    cb_tagged_evaluate(
+                        evaluator,
+                        prefix=eval_cfg.prefix,
+                        eval_current=eval_cfg.eval_current,
+                        eval_ema=eval_ema,
+                    ),
+                    every=interval,
+                )
+
+        # Sync/NaN-check/log only every SCALE_SYNC_EVERY steps so the host can dispatch
+        # steps ahead and keep the GPU fed (removes the per-step block_until_ready stall).
+        # A host-side step counter avoids the per-iteration int(state.step) device syncs.
+        sync_every = max(1, int(os.environ.get("SCALE_SYNC_EVERY", "1")))
+        # SCALE_TIME_EXCL_LOAD=1 subtracts data-loading wall time from the step timer
+        # (the old measurement boundary, which started timing after next(iterator)).
+        excl_load = os.environ.get("SCALE_TIME_EXCL_LOAD") == "1"
+        last_loss: float | jax.Array = 0.0
+        last_step_duration = 0.0
+        local_step = int(state.step)
+        window_start = time.perf_counter()
+        window_steps = 0
+        window_load = 0.0
+
+        try:
+            while local_step < trainer.num_train_steps:
+                with jax.profiler.TraceAnnotation("load_batch"):
+                    batch = next(iterator)
+                window_load += iterator.this_load_time
+                compute_watch = (
+                    watch_config.is_enabled and watch_config.interval > 0 and local_step % watch_config.interval == 0
+                )
+                state, metrics, watch_stats = train_step(state, batch, compute_watch=compute_watch)
+                local_step += 1
+                window_steps += 1
+
+                if local_step % sync_every != 0 and local_step < trainer.num_train_steps:
+                    continue
+
+                jax.block_until_ready(metrics["train/loss"])
+                if jnp.isnan(metrics["train/loss"]):
+                    logger.error(f"NaN loss at step {local_step}. Stopping training.")
+                    break
+                window_wall = time.perf_counter() - window_start
+                duration = (window_wall - (window_load if excl_load else 0.0)) / window_steps
+                step = local_step - 1
+                hook_start = time.perf_counter()
+                with jax.profiler.TraceAnnotation("callbacks"):
+                    state_callbacks.run(state, loss=metrics["train/loss"], step_duration=duration)
+                    last_loss = metrics["train/loss"]
+                    last_step_duration = duration
+                    levanter.tracker.log({"throughput/hook_time": time.perf_counter() - hook_start}, step=step)
+                    levanter.tracker.log({"throughput/loading_time": iterator.this_load_time}, step=step)
+                    if watch_stats is not None:
+                        levanter.tracker.log(watch_stats, step=step)
+                window_start = time.perf_counter()
+                window_steps = 0
+                window_load = 0.0
+
+                if checkpointer is not None:
+                    checkpointer.on_step(tree=state, step=local_step)
+        except BaseException:
+            logger.exception(
+                "Fatal error in grug training loop; skipping final callbacks/checkpoint to preserve root cause"
+            )
+            raise
+        else:
+            state_callbacks.run(state, loss=last_loss, step_duration=last_step_duration, force=True)
+            if checkpointer is not None:
+                checkpointer.on_step(tree=state, step=local_step, force=True)
+                checkpointer.wait_until_finished()
+            _upload_profiler_trace(trainer, run_id)
+
+    levanter.tracker.current_tracker().finish()
+
+
+def _upload_profiler_trace(trainer, run_id: str) -> None:
+    """Copy the node-local profiler trace to ``PROFILE_UPLOAD_URI`` (durable object store).
+
+    CoreWeave pods write the JAX profiler trace to local disk and have no outbound
+    internet for the perfetto link, so we push the trace to R2/S3 ourselves. No-op
+    unless ``PROFILE_UPLOAD_URI`` is set; only process 0 uploads.
+    """
+    uri = os.environ.get("PROFILE_UPLOAD_URI")
+    if not uri or jax.process_index() != 0:
+        return
+    local_dir = str(trainer.log_dir / run_id / "profiler")
+    local_fs = fsspec.filesystem("file")
+    if not local_fs.exists(local_dir):
+        logger.warning("No profiler trace at %s; nothing to upload.", local_dir)
+        return
+    dest_fs, dest_root = fsspec.core.url_to_fs(uri)
+    files = local_fs.find(local_dir)
+    logger.info("Uploading %d profiler file(s) to %s", len(files), uri)
+    for f in files:
+        rel = os.path.relpath(f, local_dir)
+        dest_fs.put_file(f, f"{dest_root.rstrip('/')}/{rel}")
+    logger.info("Profiler trace uploaded to %s", uri)
+
+
+def run_grug_basic(config: GrugRunConfig) -> None:
+    """Dispatch minimalist dense training through Fray jobs."""
+    trainer = config.trainer.trainer
+    if trainer.id is None:
+        raise ValueError("trainer.id must be set before dispatching grug training.")
+
+    dispatch_grug_training_run(
+        run_id=trainer.id,
+        config=config,
+        local_entrypoint=_run_grug_basic_local,
+        resources=config.resources,
+        processes_per_task=config.processes_per_task,
+    )
+
+
+__all__ = [
+    "BasicTrainState",
+    "GrugEvalConfig",
+    "GrugRunConfig",
+    "GrugTrainerConfig",
+    "initial_state",
+    "run_grug_basic",
+]

--- a/experiments/grug/moe/train_basic.py
+++ b/experiments/grug/moe/train_basic.py
@@ -54,26 +54,36 @@ logger = logging.getLogger(__name__)
 
 
 def _basic_compute_flops(model_config: GrugModelConfig) -> tuple[float, dict[str, float]]:
-    """Analytic FLOPs for the basic dense transformer.
+    """Analytic FLOPs for the basic transformer.
 
-    Differs from the MoE ``_compute_flops``: the MLP is a plain two-matrix GELU
-    block (no GLU gate, so 2 matmuls not 3), and attention is dropped entirely
-    when ``SCALE_MLP_ONLY`` selects attention-free blocks.
+    Differs from the MoE ``_compute_flops``: the dense MLP is a plain two-matrix
+    GELU block (no GLU gate, so 2 matmuls not 3), attention is dropped entirely
+    when ``SCALE_MLP_ONLY`` selects attention-free blocks, and the leading
+    ``SCALE_NUM_MOE_LAYERS`` layers use routed-expert (top-k) MLP FLOPs.
     """
     h = model_config.hidden_dim
-    inter = model_config.intermediate_dim
     seq = model_config.max_seq_len
-    per_layer = 2 * 2 * h * inter  # up + down projections, 2 FLOPs each, no gate
-    if not model_basic.mlp_only_enabled():
+
+    def attn_flops() -> float:
         head_dim = h / model_config.num_heads
         qkv_proj = 2 * h * (model_config.num_heads * head_dim + 2 * model_config.num_kv_heads * head_dim)
         dense_proj = 2 * h * h
         seq_flops = 2 * seq**2 * model_config.num_heads * head_dim
         seq_flops += 3 * seq * seq * model_config.num_heads
         seq_flops += 2 * seq * seq * head_dim * model_config.num_heads
-        per_layer += qkv_proj + dense_proj + seq_flops / seq
+        return qkv_proj + dense_proj + seq_flops / seq
+
+    dense_mlp = 2 * 2 * h * model_config.intermediate_dim  # up + down, 2 FLOPs each
+    # Each active expert is a SwiGLU FFN: gate + up + down = 3 matmuls = 6*H*I; plus the
+    # dense router projection. Only the top-k experts run per token.
+    expert_inter = model_basic.moe_expert_intermediate(model_config)
+    moe_mlp = model_config.num_experts_per_token * 2 * 3 * h * expert_inter + 2 * h * model_config.num_experts
+
+    n_moe = model_basic.moe_layer_count(model_config.num_layers)
+    per_dense = dense_mlp + (0.0 if model_basic.mlp_only_enabled() else attn_flops())
+    per_moe = moe_mlp + attn_flops()  # MoE blocks always have attention
     lm_head = 2 * h * model_config.vocab_size
-    flops_per_token = model_config.num_layers * per_layer + lm_head
+    flops_per_token = n_moe * per_moe + (model_config.num_layers - n_moe) * per_dense + lm_head
     flops_per_example = 3 * flops_per_token * seq
     return flops_per_example, {
         "throughput/flops_per_token_analytic": flops_per_token,

--- a/experiments/grug/moe/train_basic.py
+++ b/experiments/grug/moe/train_basic.py
@@ -14,6 +14,7 @@ import functools
 import logging
 import os
 import time
+from collections.abc import Callable
 
 import fsspec
 import jax
@@ -232,8 +233,20 @@ def _make_train_step(
     return train_step
 
 
-def _run_grug_basic_local(config: GrugRunConfig) -> None:
-    """Entry point for the minimalist dense training loop."""
+def _run_grug_local(
+    config: GrugRunConfig,
+    *,
+    init_state_fn: Callable[..., BasicTrainState],
+    compute_flops_fn: Callable[[GrugModelConfig], tuple[float, dict[str, float]]],
+) -> None:
+    """Generic minimalist training loop shared by the dense (``model_basic``) and
+    shared-expert-MoE (``model_mid``) variants.
+
+    ``init_state_fn`` builds the initial :class:`BasicTrainState` for the chosen model
+    (same signature as :func:`initial_state`); ``compute_flops_fn`` returns the analytic
+    per-example FLOPs and summary dict for that model. Everything else — mesh, data,
+    optimizer, ZeRO-1, callbacks, sync/timing knobs, checkpointing — is model-agnostic.
+    """
     trainer = config.trainer.trainer
     trainer.initialize()
     levanter.tracker.log_configuration(config)
@@ -275,7 +288,7 @@ def _run_grug_basic_local(config: GrugRunConfig) -> None:
 
         @jax.jit
         def _init_state(model_rng):
-            return initial_state(
+            return init_state_fn(
                 config.model,
                 optimizer=optimizer,
                 mp=trainer.mp,
@@ -286,7 +299,11 @@ def _run_grug_basic_local(config: GrugRunConfig) -> None:
 
         state = _init_state(model_key)
 
-        checkpointer = trainer.checkpointer.create(run_id)
+        # SCALE_CHECKPOINTS=none disables all checkpoint writes. The final save is
+        # otherwise forced regardless of save_interval, and the throughput probes have
+        # no use for a multi-billion-param checkpoint.
+        checkpoints_enabled = os.environ.get("SCALE_CHECKPOINTS", "s3").lower() != "none"
+        checkpointer = trainer.checkpointer.create(run_id) if checkpoints_enabled else None
         state = restore_grug_state_from_checkpoint(
             state,
             checkpoint_search_paths=trainer.checkpoint_search_paths(run_id),
@@ -303,7 +320,7 @@ def _run_grug_basic_local(config: GrugRunConfig) -> None:
 
         levanter.tracker.log_summary({"parameter_count": parameter_count(state.params)})
 
-        flops_per_example, flops_summary = _basic_compute_flops(config.model)
+        flops_per_example, flops_summary = compute_flops_fn(config.model)
         levanter.tracker.log_summary(flops_summary)
 
         eval_cfg = config.eval
@@ -424,6 +441,11 @@ def _run_grug_basic_local(config: GrugRunConfig) -> None:
             _upload_profiler_trace(trainer, run_id)
 
     levanter.tracker.current_tracker().finish()
+
+
+def _run_grug_basic_local(config: GrugRunConfig) -> None:
+    """Entry point for the minimalist dense (``model_basic``) training loop."""
+    _run_grug_local(config, init_state_fn=initial_state, compute_flops_fn=_basic_compute_flops)
 
 
 def _upload_profiler_trace(trainer, run_id: str) -> None:

--- a/experiments/grug/moe/train_mid.py
+++ b/experiments/grug/moe/train_mid.py
@@ -1,0 +1,108 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Training loop for the shared-expert + routed-MoE transformer (``model_mid``).
+
+Thin wrapper over ``train_basic``: every layer is (no-norm attention) + (SwiGLU
+shared expert at width ``hidden_dim``) + (QB-routed MoE, top-k of E), so only the
+model constructor and the analytic FLOP count differ from the dense path. The
+mesh/data/optimizer/ZeRO-1/callback/checkpoint machinery is reused verbatim via
+:func:`experiments.grug.moe.train_basic._run_grug_local`.
+"""
+
+import jax.numpy as jnp
+import jmp
+import optax
+from jaxtyping import PRNGKeyArray
+
+from experiments.grug.dispatch import dispatch_grug_training_run
+from experiments.grug.moe import model_basic, model_mid
+from experiments.grug.moe.model import GrugModelConfig
+from experiments.grug.moe.train import GrugRunConfig
+from experiments.grug.moe.train_basic import BasicTrainState, _run_grug_local, _zero1_shard_tree
+
+
+def _mid_compute_flops(model_config: GrugModelConfig) -> tuple[float, dict[str, float]]:
+    """Analytic FLOPs for the shared-expert + routed-MoE transformer.
+
+    Every layer contributes attention + a full-width shared SwiGLU expert
+    (``6*H*I_shared``) + the routed top-k experts (``k*6*H*I_exp``) + the router
+    projection (``2*H*E``). There are no dense or MLP-only layers.
+    """
+    h = model_config.hidden_dim
+    seq = model_config.max_seq_len
+
+    def attn_flops() -> float:
+        head_dim = h / model_config.num_heads
+        qkv_proj = 2 * h * (model_config.num_heads * head_dim + 2 * model_config.num_kv_heads * head_dim)
+        dense_proj = 2 * h * h
+        seq_flops = 2 * seq**2 * model_config.num_heads * head_dim
+        seq_flops += 3 * seq * seq * model_config.num_heads
+        seq_flops += 2 * seq * seq * head_dim * model_config.num_heads
+        return qkv_proj + dense_proj + seq_flops / seq
+
+    # Shared expert is a SwiGLU FFN (gate + up + down = 3 matmuls = 6*H*I_shared), run for
+    # every token (no routing).
+    shared_inter = model_mid.shared_expert_intermediate(model_config)
+    shared_mlp = 2 * 3 * h * shared_inter
+    # Routed experts: each active expert is a SwiGLU FFN (6*H*I_exp); only the top-k run per
+    # token. Plus the dense router projection (2*H*E).
+    expert_inter = model_basic.moe_expert_intermediate(model_config)
+    routed_mlp = model_config.num_experts_per_token * 2 * 3 * h * expert_inter + 2 * h * model_config.num_experts
+
+    per_layer = attn_flops() + shared_mlp + routed_mlp  # every layer is shared + routed MoE
+    lm_head = 2 * h * model_config.vocab_size
+    flops_per_token = model_config.num_layers * per_layer + lm_head
+    flops_per_example = 3 * flops_per_token * seq
+    return flops_per_example, {
+        "throughput/flops_per_token_analytic": flops_per_token,
+        "throughput/flops_per_example_analytic": flops_per_example,
+    }
+
+
+def initial_state(
+    model_config: GrugModelConfig,
+    *,
+    optimizer: optax.GradientTransformation,
+    mp: jmp.Policy,
+    key: PRNGKeyArray,
+    ema_beta: float | None,
+    zero1: bool = False,
+) -> BasicTrainState:
+    """Build the initial train state for the ``model_mid`` transformer."""
+    params = mp.cast_to_param(model_mid.Transformer.init(model_config, key=key))
+    opt_state = optimizer.init(params)
+    if zero1:
+        opt_state = _zero1_shard_tree(opt_state)
+    return BasicTrainState(
+        step=jnp.array(0, dtype=jnp.int32),
+        params=params,
+        opt_state=opt_state,
+        ema_params=params if ema_beta is not None else None,
+    )
+
+
+def _run_grug_mid_local(config: GrugRunConfig) -> None:
+    """Entry point for the shared-expert + routed-MoE (``model_mid``) training loop."""
+    _run_grug_local(config, init_state_fn=initial_state, compute_flops_fn=_mid_compute_flops)
+
+
+def run_grug_mid(config: GrugRunConfig) -> None:
+    """Dispatch shared-expert + routed-MoE training through Fray jobs."""
+    trainer = config.trainer.trainer
+    if trainer.id is None:
+        raise ValueError("trainer.id must be set before dispatching grug training.")
+
+    dispatch_grug_training_run(
+        run_id=trainer.id,
+        config=config,
+        local_entrypoint=_run_grug_mid_local,
+        resources=config.resources,
+        processes_per_task=config.processes_per_task,
+    )
+
+
+__all__ = [
+    "initial_state",
+    "run_grug_mid",
+]

--- a/lib/levanter/src/levanter/grug/_moe/common.py
+++ b/lib/levanter/src/levanter/grug/_moe/common.py
@@ -26,6 +26,7 @@ MoeImplementation: TypeAlias = Literal[
     "deepep",  # Expert-parallel DeepEP intranode dispatch/combine backend.
     "scatter",  # Single-process grouped GMM with scatter-add combine.
     "sonic",  # Single-process raw Sonic Triton gather/combine backend.
+    "sonic_cute",  # Single-process QuACK SM100 gated GEMM (SonicMoE) via cutlass_call.
 ]
 _VALID_MOE_IMPLEMENTATIONS = get_args(MoeImplementation)
 _EP_MOE_IMPLEMENTATIONS = ("ring", "ragged_all_to_all", "deepep")
@@ -34,6 +35,7 @@ _EP_MOE_IMPLEMENTATIONS = ("ring", "ragged_all_to_all", "deepep")
 _LOCAL_MOE_IMPLEMENTATIONS = (
     "scatter",
     "sonic",
+    "sonic_cute",
 )
 
 _CHECKPOINT_DISPATCH_INPUT = "grug_moe_dispatch_input"

--- a/lib/levanter/src/levanter/grug/_moe/local.py
+++ b/lib/levanter/src/levanter/grug/_moe/local.py
@@ -11,10 +11,12 @@ from jaxtyping import Array, Float, Int
 from levanter.grug._moe.common import _LOCAL_MOE_IMPLEMENTATIONS, MoeImplementation
 from levanter.grug._moe.scatter import _moe_mlp_local_scatter
 from levanter.grug._moe.sonic import _moe_mlp_local_sonic
+from levanter.grug._moe.sonic_cute import _moe_mlp_local_sonic_cute
 
 _MOE_LOCAL_FNS = {
     "scatter": _moe_mlp_local_scatter,
     "sonic": _moe_mlp_local_sonic,
+    "sonic_cute": _moe_mlp_local_sonic_cute,
 }
 
 

--- a/lib/levanter/src/levanter/grug/_moe/quack_moe_cute.py
+++ b/lib/levanter/src/levanter/grug/_moe/quack_moe_cute.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Vendored CuTeDSL→JAX shim for QuACK's SM100 gated grouped GEMM (SonicMoE kernel).
+
+Mirrors David's `_fa4_cute_backend.py` pattern: build a thin ``@cute.jit`` launcher
+with the JAX ``cutlass_call`` signature ``(stream, *inputs, *outputs, **scalars)``
+that reuses QuACK's ``GemmGatedSm100`` kernel, then wrap it with
+``cutlass.jax.cutlass_call``. Forward-only for now (grouped SwiGLU): tokens are
+pre-sorted by expert (varlen_m via ``cu_seqlens_m``; no A_idx gather).
+
+A[M,K] @ B[E,K,2N]  -> (per expert group) -> SwiGLU -> PostAct[M,N]
+"""
+from __future__ import annotations
+
+import importlib
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.jax as cjax
+from quack.gemm_act import GemmActMixin, GemmGatedSm100, act_fn_map, gate_fn_map
+from quack.gemm_act import get_max_active_clusters
+from quack.gemm_tvm_ffi_utils import make_scheduler_args, make_varlen_args
+
+_ACC = cutlass.Float32
+_JAX_TO_CUTE = {
+    jnp.dtype(jnp.bfloat16): cutlass.BFloat16,
+    jnp.dtype(jnp.float16): cutlass.Float16,
+    jnp.dtype(jnp.float32): cutlass.Float32,
+}
+
+
+def _cute_dtype(dt):
+    return _JAX_TO_CUTE[jnp.dtype(dt)]
+
+
+def _build_launcher(*, a_dtype, tile_mn, cluster_mnk, activation, max_active_clusters, max_swizzle):
+    """Return a ``@cute.jit`` launcher with the cutlass_call signature.
+
+    Signature: (stream, mA, mB, mCuSeqlens, mD, mPostAct)
+      mA:[M,K] tokens (k-major)  mB:[E,K,2N] weights  mCuSeqlens:[E+1] int32
+      mD:[M,2N] preact out (n-major)  mPostAct:[M,N] swiglu out (n-major)
+    """
+    act = gate_fn_map[activation] if activation in gate_fn_map else act_fn_map[activation]
+
+    @cute.jit
+    def launcher(stream, mA, mB, mCuSeqlens, mD, mPostAct):
+        gemm = GemmGatedSm100(
+            _ACC,
+            a_dtype,
+            tile_mn,
+            cluster_mnk,
+            gather_A=False,
+            use_clc_persistence=False,
+        )
+        epi_args = GemmActMixin.EpilogueArguments(
+            mPostAct,
+            act,  # SwiGLU activation function (Constexpr)
+            mRowVecBroadcast=None,
+            mColVecBroadcast=None,
+        )
+        scheduler_args = make_scheduler_args(max_active_clusters, max_swizzle, None)
+        varlen_args = make_varlen_args(mCuSeqlens, None, None)
+        gemm(mA, mB, mD, None, epi_args, scheduler_args, varlen_args, stream)
+
+    return launcher
+
+
+def quack_gated_grouped_gemm(x_sort, w_gate_up, cu_seqlens, *, activation="swiglu",
+                             tile_mn=(256, 128), cluster_mnk=(2, 1, 1), max_swizzle=8, return_preact=False):
+    """Grouped SwiGLU expert GEMM via QuACK's SM100 kernel.
+
+    x_sort: [M, K] tokens sorted by expert. w_gate_up: [E, K, 2N]. cu_seqlens: [E+1] int32.
+    Returns postact [M, N].
+    """
+    M, K = x_sort.shape
+    E = w_gate_up.shape[0]
+    N2 = w_gate_up.shape[2]
+    N = N2 // 2
+    a_dtype = _cute_dtype(x_sort.dtype)
+    try:
+        max_active_clusters = get_max_active_clusters(cluster_mnk[0] * cluster_mnk[1])
+    except Exception:
+        max_active_clusters = 148  # B200 SM-count fallback for host-side lowering tests
+    launcher = _build_launcher(
+        a_dtype=a_dtype, tile_mn=tile_mn, cluster_mnk=cluster_mnk,
+        activation=activation, max_active_clusters=max_active_clusters, max_swizzle=max_swizzle,
+    )
+    ts = cjax.TensorSpec
+    # divisibility is in physical-dim order (contiguous dim gets the vector width).
+    # B is physically [E,K,2N] but the kernel wants it as [K,2N,E] (expert = trailing
+    # batch/L mode); express that with mode=(1,2,0) rather than a physical transpose.
+    a_spec = ts(divisibility=(1, 8), static=False)              # [M,K] k-major
+    # B is physically [E,K,2N]; kernel wants n-major logical [2N,K,E] (leading_dim 0).
+    b_spec = ts(mode=(2, 1, 0), divisibility=(1, 1, 8), static=False)
+    cu_spec = ts(static=False)                                  # [E+1] int32
+    d_spec = ts(divisibility=(1, 8), static=False)              # [M,2N] n-major
+    p_spec = ts(divisibility=(1, 8), static=False)              # [M,N]  n-major
+    call = cjax.cutlass_call(
+        launcher,
+        output_shape_dtype=(
+            jax.ShapeDtypeStruct((M, N2), x_sort.dtype),
+            jax.ShapeDtypeStruct((M, N), x_sort.dtype),
+        ),
+        input_spec=(a_spec, b_spec, cu_spec),
+        output_spec=(d_spec, p_spec),
+        use_static_tensors=False,
+    )
+    preact, postact = call(x_sort, w_gate_up, cu_seqlens.astype(jnp.int32))
+    return (preact, postact) if return_preact else postact
+
+
+# ---- plain grouped GEMM (non-gated), for down projection + backward matmuls ----
+from quack.gemm_default_epi import GemmDefaultSm100, GemmDefaultEpiMixin  # noqa: E402
+
+
+def _build_plain_launcher(*, a_dtype, tile_mn, cluster_mnk, max_active_clusters, max_swizzle):
+    @cute.jit
+    def launcher(stream, mA, mB, mCuSeqlens, mD):
+        gemm = GemmDefaultSm100(_ACC, a_dtype, tile_mn, cluster_mnk,
+                                gather_A=False, use_clc_persistence=False)
+        epi_args = GemmDefaultEpiMixin.EpilogueArguments()
+        scheduler_args = make_scheduler_args(max_active_clusters, max_swizzle, None)
+        varlen_args = make_varlen_args(mCuSeqlens, None, None)
+        gemm(mA, mB, mD, None, epi_args, scheduler_args, varlen_args, stream)
+    return launcher
+
+
+def quack_grouped_gemm(a, w, cu_seqlens, *, b_major="n", tile_mn=(256, 128), cluster_mnk=(2, 1, 1), max_swizzle=8):
+    """Plain grouped GEMM a[M,K] @ w -> [M,N], grouped by cu_seqlens (varlen_m).
+
+    b_major='n': w is [E,K,N] (n-major, mode (2,1,0)).  b_major='k': w is [E,N,K]
+    (k-major, mode (1,2,0)) for transposed/backward contractions."""
+    M, K = a.shape
+    N = w.shape[2] if b_major == "n" else w.shape[1]
+    _bmode = (2, 1, 0) if b_major == "n" else (1, 2, 0)
+    a_dtype = _cute_dtype(a.dtype)
+    try:
+        mac = get_max_active_clusters(cluster_mnk[0] * cluster_mnk[1])
+    except Exception:
+        mac = 148
+    launcher = _build_plain_launcher(a_dtype=a_dtype, tile_mn=tile_mn, cluster_mnk=cluster_mnk,
+                                     max_active_clusters=mac, max_swizzle=max_swizzle)
+    ts = cjax.TensorSpec
+    a_spec = ts(divisibility=(1, 8), static=False)
+    b_spec = ts(mode=_bmode, divisibility=(1, 1, 8), static=False)
+    cu_spec = ts(static=False)
+    d_spec = ts(divisibility=(1, 8), static=False)
+    call = cjax.cutlass_call(
+        launcher,
+        output_shape_dtype=jax.ShapeDtypeStruct((M, N), a.dtype),
+        input_spec=(a_spec, b_spec, cu_spec),
+        output_spec=(d_spec,),
+        use_static_tensors=False,
+    )
+    return call(a, w, cu_seqlens.astype(jnp.int32))

--- a/lib/levanter/src/levanter/grug/_moe/sonic_cute.py
+++ b/lib/levanter/src/levanter/grug/_moe/sonic_cute.py
@@ -1,0 +1,107 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Local Grug MoE backend using Tri Dao's QuACK SM100 kernels (SonicMoE) on B200.
+
+Dispatch/combine as in ``scatter``, but the expert MLP GEMMs run on QuACK's
+``GemmGatedSm100`` / ``GemmDefaultSm100`` via the vendored ``cutlass.jax.cutlass_call``
+shim. QuACK does all four activation-path grouped GEMMs (gate/up fwd fused with
+SwiGLU, down fwd, and the ``dh``/``dx`` backward matmuls); the SwiGLU backward is
+elementwise in JAX; the two weight-gradient GEMMs (``dw13``/``dw2``) stay on XLA
+``ragged_dot`` (a different varlen-k grouping). QuACK covers ~2/3 of the MoE FLOPs.
+"""
+
+from collections.abc import Callable
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from haliax.jax_utils import tree_checkpoint_name
+from haliax.nn.ragged_dot import ragged_dot
+from jaxtyping import Array, Float, Int
+
+from levanter.grug._moe.common import (
+    _CHECKPOINT_DISPATCH_INPUT,
+    _CHECKPOINT_DISPATCH_OUTPUT,
+    _CHECKPOINT_EXPERT_HIDDEN,
+    _prepare_moe_dispatch,
+    _zero_dropped_assignments,
+)
+from levanter.grug._moe.quack_moe_cute import quack_gated_grouped_gemm, quack_grouped_gemm
+
+
+def _interleave_gate_up(moe_w13: jax.Array, moe_dim: int) -> jax.Array:
+    """grug w13 [E,H,2I] gate=[:I], up=[I:] -> interleaved [g0,u0,g1,u1,...] (QuACK layout)."""
+    gate = moe_w13[..., :moe_dim]
+    up = moe_w13[..., moe_dim:]
+    return jnp.stack([gate, up], axis=-1).reshape(moe_w13.shape)
+
+
+@jax.custom_vjp
+def _expert_mlp(x_dispatch, w13_il, moe_w2, group_sizes, cu):
+    """y = down( swiglu( x @ w13_il ) ), grouped by experts. Activation-path GEMMs on QuACK.
+
+    ``group_sizes``/``cu`` are traced int arrays passed as explicit args (not closed
+    over — that leaks under shard_map; not nondiff_argnums — that rejects tracers).
+    """
+    _gu, h = quack_gated_grouped_gemm(x_dispatch, w13_il, cu, return_preact=True)
+    return quack_grouped_gemm(h, moe_w2, cu, b_major="n")
+
+
+def _expert_mlp_fwd(x_dispatch, w13_il, moe_w2, group_sizes, cu):
+    gu, h = quack_gated_grouped_gemm(x_dispatch, w13_il, cu, return_preact=True)
+    y = quack_grouped_gemm(h, moe_w2, cu, b_major="n")
+    return y, (x_dispatch, w13_il, moe_w2, gu, h, group_sizes, cu)
+
+
+def _expert_mlp_bwd(res, dy):
+    x_dispatch, w13_il, moe_w2, gu, h, group_sizes, cu = res
+    # down backward: dh via QuACK (transposed contraction), dw2 via XLA weight-grad
+    dh = quack_grouped_gemm(dy, moe_w2, cu, b_major="k")
+    (dw2,) = jax.vjp(lambda w: ragged_dot(h, w, group_sizes), moe_w2)[1](dy)
+    # SwiGLU backward (interleaved gate/up), elementwise
+    gate, up = gu[:, 0::2], gu[:, 1::2]
+    sg = jax.nn.sigmoid(gate)
+    silu = gate * sg
+    dgate = dh * up * (sg + silu * (1.0 - sg))
+    dup = dh * silu
+    d_gu = jnp.stack([dgate, dup], axis=-1).reshape(gu.shape)
+    # gate/up backward: dx via QuACK, dw13 via XLA weight-grad
+    dx = quack_grouped_gemm(d_gu, w13_il, cu, b_major="k")
+    (dw13_il,) = jax.vjp(lambda w: ragged_dot(x_dispatch, w, group_sizes), w13_il)[1](d_gu)
+    # int-typed routing args get float0 zero cotangents
+    gs_ct = np.zeros(group_sizes.shape, dtype=jax.dtypes.float0)
+    cu_ct = np.zeros(cu.shape, dtype=jax.dtypes.float0)
+    return dx, dw13_il, dw2, gs_ct, cu_ct
+
+
+_expert_mlp.defvjp(_expert_mlp_fwd, _expert_mlp_bwd)
+
+
+def _moe_mlp_local_sonic_cute(
+    x: Float[Array, "T H"],
+    selected_experts: Int[Array, "T K"],
+    combine_weights: Float[Array, "T K"],
+    moe_w13: Float[Array, "E H I2"],
+    moe_w2: Float[Array, "E I H"],
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+) -> tuple[Float[Array, "T H"], Int[Array, ""]]:
+    x_dispatch, w_dispatch, token_dispatch, group_sizes = _prepare_moe_dispatch(
+        x, selected_experts, combine_weights, num_experts=num_experts
+    )
+    x_dispatch = tree_checkpoint_name(x_dispatch, _CHECKPOINT_DISPATCH_INPUT)
+    moe_dim = moe_w2.shape[1]
+    w13_il = _interleave_gate_up(moe_w13, moe_dim)
+    cu = jnp.concatenate([jnp.zeros((1,), jnp.int32), jnp.cumsum(group_sizes).astype(jnp.int32)])
+
+    with jax.named_scope("moe_up_down_quack"):
+        out_dispatch = tree_checkpoint_name(
+            _expert_mlp(x_dispatch, w13_il, moe_w2, group_sizes, cu), _CHECKPOINT_DISPATCH_OUTPUT
+        )
+
+    with jax.named_scope("scatter"):
+        out = jnp.zeros_like(x).at[token_dispatch].add(out_dispatch * w_dispatch[:, None], mode="drop")
+    return out, _zero_dropped_assignments()

--- a/lib/levanter/src/levanter/grug/loss.py
+++ b/lib/levanter/src/levanter/grug/loss.py
@@ -213,13 +213,17 @@ def fused_linear_softmax_cross_entropy_loss(
         flat_weight = shard_weight.reshape((-1,))
 
         if os.environ.get("CE_IMPL") == "liger":
+            ce_chunk = int(os.environ.get("CE_LIGER_CHUNK", "8192"))
+            if ce_chunk <= 0:
+                # 0 -> one chunk per shard: a single CE iteration per device (max MFU).
+                ce_chunk = flat_hidden.shape[0]
             loss = _liger_weighted_ce(
                 flat_hidden,
                 shard_lm_head,
                 flat_labels,
                 flat_weight.astype(dtype),
                 float(logsumexp_weight or 0.0),
-                int(os.environ.get("CE_LIGER_CHUNK", "8192")),
+                ce_chunk,
             )
         else:
             loss = fused_cross_entropy_loss_and_logsumexp_penalty(

--- a/lib/levanter/src/levanter/grug/loss.py
+++ b/lib/levanter/src/levanter/grug/loss.py
@@ -7,6 +7,9 @@ This wraps the shared fused kernel API for TPU and falls back to a full-logits
 reference implementation on non-TPU backends.
 """
 
+import functools
+import os
+
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding, PartitionSpec as P, get_abstract_mesh, get_mesh, reshard
@@ -15,6 +18,89 @@ from haliax.jax_utils import named_call
 from levanter.kernels.pallas.fused_cross_entropy_loss import (
     fused_cross_entropy_loss_and_logsumexp_penalty,
 )
+
+
+# Liger-style CE: chunk the tokens, do all matmuls with cuBLAS, no custom kernel.
+# Peak memory is bounded by one [chunk, V] logit tile; backward recomputes logits.
+# Enabled per-shard via CE_IMPL=liger (chunk from CE_LIGER_CHUNK, default 8192).
+
+
+def _liger_ce_forward(hidden, lm_head, labels, weight, logsumexp_weight, chunk_size):
+    n, h = hidden.shape
+    npad = -(-n // chunk_size) * chunk_size
+    hp = jnp.pad(hidden, ((0, npad - n), (0, 0)))
+    lp = jnp.pad(labels.astype(jnp.int32), (0, npad - n))
+    wp = jnp.pad(weight, (0, npad - n))
+    nc = npad // chunk_size
+
+    def chunk_loss(a):
+        h_c, l_c, w_c = a
+        logits = (h_c @ lm_head).astype(jnp.float32)
+        lse = jax.scipy.special.logsumexp(logits, axis=-1)
+        tgt = jnp.take_along_axis(logits, l_c[:, None], axis=1)[:, 0]
+        loss = lse - tgt
+        if logsumexp_weight:
+            loss = loss + logsumexp_weight * lse * lse
+        return w_c * loss
+
+    out = jax.lax.map(
+        chunk_loss, (hp.reshape(nc, chunk_size, h), lp.reshape(nc, chunk_size), wp.reshape(nc, chunk_size))
+    )
+    return out.reshape(npad)[:n]
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=(4, 5))
+def _liger_weighted_ce(hidden, lm_head, labels, weight, logsumexp_weight, chunk_size):
+    """Per-token weight*(CE + z-loss), Liger-chunked. custom_vjp over (hidden, lm_head)."""
+    return _liger_ce_forward(hidden, lm_head, labels, weight, logsumexp_weight, chunk_size)
+
+
+def _liger_ce_vjp_fwd(hidden, lm_head, labels, weight, logsumexp_weight, chunk_size):
+    out = _liger_ce_forward(hidden, lm_head, labels, weight, logsumexp_weight, chunk_size)
+    return out, (hidden, lm_head, labels, weight)
+
+
+def _liger_ce_vjp_bwd(logsumexp_weight, chunk_size, residual, g):
+    hidden, lm_head, labels, weight = residual
+    n, h = hidden.shape
+    v = lm_head.shape[1]
+    npad = -(-n // chunk_size) * chunk_size
+    hp = jnp.pad(hidden, ((0, npad - n), (0, 0)))
+    lp = jnp.pad(labels.astype(jnp.int32), (0, npad - n))
+    wp = jnp.pad(weight, (0, npad - n))
+    gp = jnp.pad(g.astype(jnp.float32), (0, npad - n))
+    nc = npad // chunk_size
+
+    def body(dw, a):
+        h_c, l_c, w_c, g_c = a
+        logits = (h_c @ lm_head).astype(jnp.float32)
+        lse = jax.scipy.special.logsumexp(logits, axis=-1)
+        probs = jnp.exp(logits - lse[:, None])
+        onehot = jax.nn.one_hot(l_c, v, dtype=jnp.float32)
+        coef = (1.0 + 2.0 * logsumexp_weight * lse)[:, None] if logsumexp_weight else 1.0
+        scale = (w_c * g_c)[:, None]  # weight (inside loss) * incoming cotangent
+        d_logits = (scale * (probs * coef - onehot)).astype(hidden.dtype)
+        dh_c = d_logits @ lm_head.T
+        dw_c = (h_c.T @ d_logits).astype(jnp.float32)
+        return dw + dw_c, dh_c
+
+    unroll = int(os.environ.get("CE_LIGER_UNROLL", "1"))
+    dw, dh = jax.lax.scan(
+        body,
+        jnp.zeros((h, v), jnp.float32),
+        (
+            hp.reshape(nc, chunk_size, h),
+            lp.reshape(nc, chunk_size),
+            wp.reshape(nc, chunk_size),
+            gp.reshape(nc, chunk_size),
+        ),
+        unroll=unroll,
+    )
+    # cotangents for (hidden, lm_head, labels, weight); labels/weight are not differentiated.
+    return dh.reshape(npad, h)[:n].astype(hidden.dtype), dw.astype(lm_head.dtype), None, None
+
+
+_liger_weighted_ce.defvjp(_liger_ce_vjp_fwd, _liger_ce_vjp_bwd)
 
 
 def _batch_axis_spec(x: jax.Array):
@@ -126,18 +212,28 @@ def fused_linear_softmax_cross_entropy_loss(
         flat_labels = shard_labels.reshape((-1,)).astype(jnp.int32)
         flat_weight = shard_weight.reshape((-1,))
 
-        loss = fused_cross_entropy_loss_and_logsumexp_penalty(
-            flat_hidden,
-            flat_labels,
-            shard_lm_head,
-            reduction=None,
-            weight=flat_weight,
-            logsumexp_weight=logsumexp_weight,
-            dtype=dtype,
-            logit_soft_cap=None,
-            precision=precision,
-            implementation=implementation,
-        )
+        if os.environ.get("CE_IMPL") == "liger":
+            loss = _liger_weighted_ce(
+                flat_hidden,
+                shard_lm_head,
+                flat_labels,
+                flat_weight.astype(dtype),
+                float(logsumexp_weight or 0.0),
+                int(os.environ.get("CE_LIGER_CHUNK", "8192")),
+            )
+        else:
+            loss = fused_cross_entropy_loss_and_logsumexp_penalty(
+                flat_hidden,
+                flat_labels,
+                shard_lm_head,
+                reduction=None,
+                weight=flat_weight,
+                logsumexp_weight=logsumexp_weight,
+                dtype=dtype,
+                logit_soft_cap=None,
+                precision=precision,
+                implementation=implementation,
+            )
 
         if reduction_mode is None:
             return loss.reshape(shard_labels.shape)

--- a/lib/levanter/src/levanter/grug/sharding.py
+++ b/lib/levanter/src/levanter/grug/sharding.py
@@ -9,9 +9,12 @@ from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec, get_abstr
 # Convenience shorthand for batch sharding. Keep this aligned with Levanter's
 # default distributed batch mapping, which includes the cross-slice axis.
 Pbatch = P(("replica_dcn", "data"))
-Pembed_vocab = P("model", Pbatch[0])
-Plm_head = P(Pbatch[0], "model")
-Plogits = P(Pbatch[0], None, "model")
+# Params drop ``replica_dcn`` (shard over ``data`` only) so they *replicate* across the
+# cross-node replica axis, while ``Pbatch`` keeps it for the batch/activation split (each
+# replica processes a different data slice). At replica_axis_size=1 this is a no-op.
+Pembed_vocab = P("model", "data")
+Plm_head = P("data", "model")
+Plogits = P("data", None, "model")
 
 
 def unshard(x: jax.Array) -> jax.Array:

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/batched_xla.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/batched_xla.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from functools import partial
 from typing import NamedTuple, Optional
 
@@ -386,6 +387,10 @@ def _h100_full_vocab_b_tiled_block_size(
         return None
     if w.shape[1] < _LARGE_VOCAB_THRESHOLD:
         return None
+    # CE_B_BLOCK env override lets us sweep the full-vocab batch tile for profiling.
+    override = os.environ.get("CE_B_BLOCK")
+    if override:
+        return int(override)
     return _H100_FULL_VOCAB_B_TILED_BLOCK_SIZE
 
 

--- a/lib/levanter/src/levanter/optim/grugmuon.py
+++ b/lib/levanter/src/levanter/optim/grugmuon.py
@@ -10,6 +10,7 @@ All 2D arrays are routed to Muon, except those whose path contains
 """
 
 import math
+import os
 from dataclasses import dataclass
 from functools import partial
 
@@ -133,8 +134,9 @@ class GrugMuonConfig(MuonConfig):
             elif (
                 hasattr(param, "ndim")
                 and param.ndim == 3
-                and ("w_up_gate" in path_lower or "w_gate_up" in path_lower or "w_down" in path_lower)
+                and any(k in path_lower for k in ("w_up_gate", "w_gate_up", "w_gate", "w_up", "w_down"))
             ):
+                # 3D stacked MoE expert weights (combined w_gate_up or separate w_gate/w_up/w_down).
                 return "muon"
             else:
                 return "adamw"
@@ -183,6 +185,10 @@ def _grug_scale_with_muon(
 
         def transform_array(x, param):
             if not hasattr(x, "ndim") or x.ndim not in (2, 3):
+                return x
+            if os.environ.get("SCALE_MUON_NO_NS") == "1":
+                # No-op the Newton-Schulz orthogonalization (momentum-only update): skips
+                # the all-gather/reshard transient. Not real Muon; for memory/fit probes.
                 return x
             if x.ndim == 2:
                 updated = _zeropower_via_newtonschulz_replicated(

--- a/lib/levanter/src/levanter/optim/grugmuon.py
+++ b/lib/levanter/src/levanter/optim/grugmuon.py
@@ -134,7 +134,9 @@ class GrugMuonConfig(MuonConfig):
             # bias/scalar (<2D) use AdamW.
             if not hasattr(param, "ndim") or param.ndim < 2:
                 return "adamw"
-            if any(k in path_lower for k in ("embed", "lm_head", "output", "router")):
+            # RMSNorm/LayerNorm gains are per-dimension scales, not orthogonalizable matrices
+            # (they stack to 2D under scan), so keep them on AdamW alongside embed/head/router.
+            if any(k in path_lower for k in ("embed", "lm_head", "output", "router", "norm")):
                 return "adamw"
             return "muon"
 

--- a/lib/levanter/src/levanter/optim/grugmuon.py
+++ b/lib/levanter/src/levanter/optim/grugmuon.py
@@ -127,19 +127,16 @@ class GrugMuonConfig(MuonConfig):
         def mask_fn(param, path):
             path_str = ".".join(path) if isinstance(path, (list, tuple)) else str(path)
             path_lower = path_str.lower()
-            if "embed" in path_lower or "lm_head" in path_lower or "output" in path_lower:
+            # Route by role, not raw ndim: stacked-block scanning prepends a layer axis
+            # (attn/MLP 2D->3D, MoE experts 3D->4D), so an ndim test would misroute the
+            # scanned weights. Muon gets the weight matrices (whose orthogonalizable matrix
+            # is the trailing two dims); the embedding, LM head, router gate, and any
+            # bias/scalar (<2D) use AdamW.
+            if not hasattr(param, "ndim") or param.ndim < 2:
                 return "adamw"
-            elif hasattr(param, "ndim") and param.ndim == 2:
-                return "muon"
-            elif (
-                hasattr(param, "ndim")
-                and param.ndim == 3
-                and any(k in path_lower for k in ("w_up_gate", "w_gate_up", "w_gate", "w_up", "w_down"))
-            ):
-                # 3D stacked MoE expert weights (combined w_gate_up or separate w_gate/w_up/w_down).
-                return "muon"
-            else:
+            if any(k in path_lower for k in ("embed", "lm_head", "output", "router")):
                 return "adamw"
+            return "muon"
 
         return jax.tree.map(mask_fn, params, paths)
 
@@ -183,8 +180,8 @@ def _grug_scale_with_muon(
         else:
             updates = buf
 
-        def transform_array(x, param):
-            if not hasattr(x, "ndim") or x.ndim not in (2, 3):
+        def transform_array(path, x, param):
+            if not hasattr(x, "ndim") or x.ndim not in (2, 3, 4):
                 return x
             if os.environ.get("SCALE_MUON_NO_NS") == "1":
                 # No-op the Newton-Schulz orthogonalization (momentum-only update): skips
@@ -198,6 +195,11 @@ def _grug_scale_with_muon(
                     coefficient_type,
                     None,
                 )
+            elif x.ndim == 4:
+                # Stacked MoE expert leaf (L, E, D, I) / (L, E, I, D): distribute whole
+                # matrices across chips (data-parallel over L*E) and run NS locally, never
+                # gathering D/I to full-replicated.
+                updated = _newtonschulz_4d_distributed(path, x, steps, muon_eps, coefficient_type)
             else:
                 if orthogonalization_layout == VMAP_REPLICATED:
                     updated = jax.vmap(
@@ -239,9 +241,9 @@ def _grug_scale_with_muon(
             return updated
 
         if params is None:
-            updates = jax.tree.map(lambda x: transform_array(x, None), updates)
+            updates = jax.tree_util.tree_map_with_path(lambda path, x: transform_array(path, x, None), updates)
         else:
-            updates = jax.tree.map(transform_array, updates, params)
+            updates = jax.tree_util.tree_map_with_path(transform_array, updates, params)
 
         return updates, ScaleByMuonState(momentum_buffer=buf)
 
@@ -271,6 +273,109 @@ def _match_update_sharding():
         return updates, state
 
     return optax.GradientTransformation(init_fn, update_fn)
+
+
+def _zeropower_via_newtonschulz_local(
+    X: jax.Array,
+    steps: int = 5,
+    eps: float = 1e-7,
+    coefficient_type: CoefficientType = "quintic",
+) -> jax.Array:
+    """Newton-Schulz that assumes ``X`` is already fully local to one device.
+
+    Unlike :func:`_zeropower_via_newtonschulz_replicated`, this does NOT reshard ``X`` to
+    ``P(None, None)`` to gather it across devices. The caller must arrange sharding so each
+    device already holds the matrices it processes locally (e.g. vmapped over a leading axis
+    that is sharded on the batch/data axis).
+    """
+    assert X.ndim == 2
+    orig_dtype = X.dtype
+    X = X.astype(jnp.bfloat16)
+
+    coeffs = NEWTON_SCHULZ_COEFFICIENTS[coefficient_type]
+    X = X / (jnp.linalg.norm(X) + eps)
+
+    transpose = False
+    if X.shape[0] > X.shape[1]:
+        X = X.T
+        transpose = True
+
+    for i in range(steps):
+        a, b, c = coeffs[i % len(coeffs)]
+        A = jnp.einsum("ik,jk->ij", X, X)
+        B = b * A + c * jnp.einsum("ik,kj->ij", A, A)
+        X = a * X + jnp.einsum("ik,kj->ij", B, X)
+
+    if transpose:
+        X = X.T
+
+    return X.astype(orig_dtype)
+
+
+def _newtonschulz_4d_distributed(
+    path,
+    x: jax.Array,
+    steps: int,
+    eps: float,
+    coefficient_type: CoefficientType,
+) -> jax.Array:
+    """Newton-Schulz on a stacked 4D MoE expert leaf without gathering D/I to replicated.
+
+    The leaf is ``(L, E, D, I)`` for ``w_gate``/``w_up`` or ``(L, E, I, D)`` for ``w_down``,
+    sharded ``P(None, "expert", "data", "model")``. The "one matrix per chip" plan: bf16
+    cast, free-merge ``(L, E) -> LE`` keeping the sharding on the ``data`` axis, an explicit
+    all-to-all reshard to move ``LE`` onto the batch axis (each chip ends up owning
+    ``LE / shards`` *full* matrices), local NS, then reverse. Splitting the axis merge from
+    the cross-axis migration lets XLA do each cheaply instead of materializing the full stack.
+    """
+    mesh = jax.sharding.get_abstract_mesh()
+    if mesh.empty:
+        return x
+    mesh_shape_items = [(name, size) for name, size in mesh.shape.items() if size > 1]
+    if not mesh_shape_items:
+        return x
+
+    layers, expert_count, d, last = x.shape
+    merged = layers * expert_count
+
+    # Largest subset of batch mesh axes whose product divides ``merged``; NS replicates
+    # across any axes that don't divide it rather than silently skipping orthogonalization.
+    best_axes: tuple[str, ...] = ()
+    best_shards = 0
+    for mask in range(1, 1 << len(mesh_shape_items)):
+        subset = [mesh_shape_items[i] for i in range(len(mesh_shape_items)) if mask & (1 << i)]
+        prod = 1
+        for _, size in subset:
+            prod *= size
+        if merged % prod == 0 and prod > best_shards:
+            best_axes = tuple(name for name, _ in subset)
+            best_shards = prod
+    if not best_axes:
+        raise ValueError(
+            f"4D NS: no subset of batch mesh axes {dict(mesh.shape)} divides "
+            f"merged={merged} (layers={layers} * experts={expert_count}) for "
+            f"{jax.tree_util.keystr(path)}."
+        )
+
+    is_w_down = any(getattr(entry, "name", None) == "w_down" for entry in path)
+    if is_w_down:
+        intermediate_3d_spec = PartitionSpec(None, "model", "data")
+        orig_4d_spec = PartitionSpec(None, "expert", "model", "data")
+    else:
+        intermediate_3d_spec = PartitionSpec(None, "data", "model")
+        orig_4d_spec = PartitionSpec(None, "expert", "data", "model")
+    target_3d_spec = (
+        PartitionSpec(best_axes[0], None, None) if len(best_axes) == 1 else PartitionSpec(best_axes, None, None)
+    )
+
+    x_bf16 = x.astype(jnp.bfloat16)
+    x_flat = jax.lax.reshape(x_bf16, (merged, d, last), out_sharding=intermediate_3d_spec)
+    x_distributed = reshard(x_flat, target_3d_spec)
+    local_ns = lambda matrix: _zeropower_via_newtonschulz_local(matrix, steps, eps, coefficient_type)
+    updated_distributed = jax.vmap(local_ns)(x_distributed)
+    updated_flat = reshard(updated_distributed, intermediate_3d_spec)
+    updated_bf16 = jax.lax.reshape(updated_flat, (layers, expert_count, d, last), out_sharding=orig_4d_spec)
+    return updated_bf16.astype(x.dtype)
 
 
 def _zeropower_via_newtonschulz_replicated(


### PR DESCRIPTION
## Status

Draft extraction marker. The source branch is research-quality and must be reduced to the backend, focused parity tests, and dependency changes before merge.

## Validated result

The SM100 QuACK grouped-GEMM backend improved matched B200 whole-model MFU while preserving loss and gradient parity.

- PoC implementation: [`a3b19c5ff`](https://github.com/marin-community/marin/commit/a3b19c5ff0351a2b6d59f2a130a67be50d99d488)
- Validation: [#7012 result](https://github.com/marin-community/marin/issues/7012#issuecomment-4919640071)
- Independent reproduction: [#7012 follow-up](https://github.com/marin-community/marin/issues/7012#issuecomment-4960848663)

## Before review

- extract only the reusable backend and configuration surface;
- retain ragged/empty-expert and end-to-end gradient parity coverage;
- separate experimental launchers and logbooks from the implementation.

Part of #6710. Related to #7012.