### PR TITLE
[draft] Extract slim Sonic CuTe residuals and MoE-aware rematerialization

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -72,7 +72,7 @@ def _mesh_axis_size(mesh: jax.sharding.AbstractMesh | None, axis_name: str) -> i
     return int(mesh.shape[axis_name])
 
 
-RematMode = Literal["recompute_all", "save_moe", "none"]
+RematMode = Literal["recompute_all", "save_moe", "attn_only", "none"]
 
 
 def _batch_spec() -> P:
@@ -141,7 +141,10 @@ class GrugModelConfig:
     remat_mode: RematMode = "recompute_all"
     """Per-block gradient checkpointing. "recompute_all" reruns the whole block in
     backward (lowest memory); "save_moe" keeps the tagged MoE dispatch tensors so
-    backward skips re-running expert dispatch and its EP collectives."""
+    backward skips re-running expert dispatch and its EP collectives; "attn_only"
+    checkpoints just the attention sub-block, so the MoE forward — including its
+    custom_vjp residuals, which name-based save policies cannot reach — is never
+    re-executed in backward; "none" disables checkpointing entirely."""
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
 
     def __post_init__(self) -> None:
@@ -674,17 +677,28 @@ class Block(eqx.Module):
         use_long_mask: Bool[Array, ""] | bool,
         use_pko: bool = False,
         disable_long_rope: bool = False,
+        remat_attention: bool = False,
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
-        attn_in = self.attn_gated_norm(self.rms_attn(x))
-        # lax.cond so the body has a uniform shape across scan iterations: long layers use
-        # the full causal mask (and may PKO / drop RoPE); short layers use the sliding-window
-        # mask, never PKO, and always RoPE.
-        attn_out = jax.lax.cond(
-            jnp.asarray(use_long_mask, dtype=jnp.bool_),
-            lambda _: self.attn(attn_in, long_mask, use_pko=use_pko, disable_rope=disable_long_rope),
-            lambda _: self.attn(attn_in, short_mask, use_pko=False, disable_rope=False),
-            operand=None,
-        )
+        def _attn_block(attn_mods, h, use_long, s_mask, l_mask):
+            rms_attn, attn_gated_norm, attn = attn_mods
+            attn_in = attn_gated_norm(rms_attn(h))
+            # lax.cond so the body has a uniform shape across scan iterations: long layers use
+            # the full causal mask (and may PKO / drop RoPE); short layers use the sliding-window
+            # mask, never PKO, and always RoPE.
+            return jax.lax.cond(
+                jnp.asarray(use_long, dtype=jnp.bool_),
+                lambda _: attn(attn_in, l_mask, use_pko=use_pko, disable_rope=disable_long_rope),
+                lambda _: attn(attn_in, s_mask, use_pko=False, disable_rope=False),
+                operand=None,
+            )
+
+        # Modules and traced values enter _attn_block as explicit arguments (not via
+        # closure) so eqx.filter_checkpoint sees them as differentiable/dynamic inputs.
+        attn_mods = (self.rms_attn, self.attn_gated_norm, self.attn)
+        if remat_attention:
+            attn_out = eqx.filter_checkpoint(_attn_block)(attn_mods, x, use_long_mask, short_mask, long_mask)
+        else:
+            attn_out = _attn_block(attn_mods, x, use_long_mask, short_mask, long_mask)
         x = x + attn_out
         mlp_in = self.mlp_gated_norm(self.rms_mlp(x))
         mlp_out, router_stats = self.mlp(mlp_in)
@@ -790,6 +804,15 @@ class Transformer(eqx.Module):
         else:
             remat_policy = None
 
+        def _apply_block(block: Block, *args) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+            if cfg.remat_mode == "none":
+                return block(*args)
+            if cfg.remat_mode == "attn_only":
+                # Checkpoint only the attention sub-block; the MoE forward and its
+                # residuals stay live so backward never re-executes expert dispatch.
+                return block(*args, remat_attention=True)
+            return eqx.filter_checkpoint(block, policy=remat_policy)(*args)
+
         if self.blocks is not None:
             num_blocks = len(self.blocks)
             moe_router_stats: list[dict[str, jax.Array]] = []
@@ -797,8 +820,8 @@ class Transformer(eqx.Module):
                 is_last = i == num_blocks - 1
                 is_long = i % 4 == 3 or is_last
                 use_pko = is_long and not cfg.disable_pko
-                hidden, router_stats = eqx.filter_checkpoint(block, policy=remat_policy)(
-                    hidden, short_mask, long_mask, is_long, use_pko, cfg.disable_long_rope
+                hidden, router_stats = _apply_block(
+                    block, hidden, short_mask, long_mask, is_long, use_pko, cfg.disable_long_rope
                 )
                 moe_router_stats.append(router_stats)
             router_metrics = {
@@ -820,8 +843,8 @@ class Transformer(eqx.Module):
                 scan_inputs: tuple[Block, Bool[Array, ""]],
             ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
                 layer, layer_use_long_mask = scan_inputs
-                return eqx.filter_checkpoint(layer, policy=remat_policy)(
-                    carry_hidden, short_mask, long_mask, layer_use_long_mask, False, cfg.disable_long_rope
+                return _apply_block(
+                    layer, carry_hidden, short_mask, long_mask, layer_use_long_mask, False, cfg.disable_long_rope
                 )
 
             hidden, stacked_router_stats = jax.lax.scan(

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -72,7 +72,7 @@ def _mesh_axis_size(mesh: jax.sharding.AbstractMesh | None, axis_name: str) -> i
     return int(mesh.shape[axis_name])
 
 
-RematMode = Literal["recompute_all", "save_moe", "attn_only", "moe_only", "none"]
+RematMode = Literal["recompute_all", "save_moe", "attn_only", "moe_only", "all_but_moe", "none"]
 
 
 def _batch_spec() -> P:
@@ -146,7 +146,11 @@ class GrugModelConfig:
     custom_vjp residuals, which name-based save policies cannot reach — is never
     re-executed in backward (memory-heavy: the custom_vjp pins dispatch tensors
     and gathered expert weights per layer); "moe_only" is the inverse — only the
-    MoE sub-block is checkpointed, so attention and the norms are never re-run;
+    MoE sub-block is checkpointed, so attention and the norms are never re-run
+    (memory-heavy: live-side norm/rope intermediates are saved in fp32);
+    "all_but_moe" checkpoints attention *and* all norms, leaving only the MoE
+    (router → dispatch → expert GEMMs → combine) and shared expert live — with
+    the slim sonic_cute residuals this is the split that fits in HBM;
     "none" disables checkpointing entirely."""
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
 
@@ -680,8 +684,7 @@ class Block(eqx.Module):
         use_long_mask: Bool[Array, ""] | bool,
         use_pko: bool = False,
         disable_long_rope: bool = False,
-        remat_attention: bool = False,
-        remat_moe: bool = False,
+        sub_remat: Literal["none", "attention", "moe", "all_but_moe"] = "none",
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
         def _attn_block(attn_mods, h, use_long, s_mask, l_mask):
             rms_attn, attn_gated_norm, attn = attn_mods
@@ -696,15 +699,6 @@ class Block(eqx.Module):
                 operand=None,
             )
 
-        # Modules and traced values enter _attn_block as explicit arguments (not via
-        # closure) so eqx.filter_checkpoint sees them as differentiable/dynamic inputs.
-        attn_mods = (self.rms_attn, self.attn_gated_norm, self.attn)
-        if remat_attention:
-            attn_out = eqx.filter_checkpoint(_attn_block)(attn_mods, x, use_long_mask, short_mask, long_mask)
-        else:
-            attn_out = _attn_block(attn_mods, x, use_long_mask, short_mask, long_mask)
-        x = x + attn_out
-
         def _mlp_block(mlp_mods, h):
             rms_mlp, mlp_gated_norm, mlp, shared = mlp_mods
             mlp_in = mlp_gated_norm(rms_mlp(h))
@@ -713,8 +707,36 @@ class Block(eqx.Module):
                 mlp_out = mlp_out + shared(mlp_in, activation=ActivationFunctionEnum.silu)
             return mlp_out, router_stats
 
+        # Modules and traced values enter the checkpointed sub-functions as explicit
+        # arguments (not via closure) so eqx.filter_checkpoint sees them as
+        # differentiable/dynamic inputs.
+        attn_mods = (self.rms_attn, self.attn_gated_norm, self.attn)
         mlp_mods = (self.rms_mlp, self.mlp_gated_norm, self.mlp, self.shared)
-        if remat_moe:
+
+        if sub_remat == "all_but_moe":
+            # Checkpoint attention *and* the mlp-side norms — everything whose live
+            # residuals would otherwise be saved as fp32 by autodiff — leaving only
+            # the MoE (router, dispatch, expert GEMMs, combine) and shared expert
+            # live so backward never re-runs the expert forward.
+            def _pre_moe(mods, h, use_long, s_mask, l_mask):
+                a_mods, rms_mlp, mlp_gated_norm = mods
+                h2 = h + _attn_block(a_mods, h, use_long, s_mask, l_mask)
+                return h2, mlp_gated_norm(rms_mlp(h2))
+
+            pre_mods = (attn_mods, self.rms_mlp, self.mlp_gated_norm)
+            x, mlp_in = eqx.filter_checkpoint(_pre_moe)(pre_mods, x, use_long_mask, short_mask, long_mask)
+            mlp_out, router_stats = self.mlp(mlp_in)
+            if self.shared is not None:
+                mlp_out = mlp_out + self.shared(mlp_in, activation=ActivationFunctionEnum.silu)
+            return x + mlp_out, router_stats
+
+        if sub_remat == "attention":
+            attn_out = eqx.filter_checkpoint(_attn_block)(attn_mods, x, use_long_mask, short_mask, long_mask)
+        else:
+            attn_out = _attn_block(attn_mods, x, use_long_mask, short_mask, long_mask)
+        x = x + attn_out
+
+        if sub_remat == "moe":
             mlp_out, router_stats = eqx.filter_checkpoint(_mlp_block)(mlp_mods, x)
         else:
             mlp_out, router_stats = _mlp_block(mlp_mods, x)
@@ -818,17 +840,13 @@ class Transformer(eqx.Module):
         else:
             remat_policy = None
 
+        _SUB_REMAT = {"attn_only": "attention", "moe_only": "moe", "all_but_moe": "all_but_moe"}
+
         def _apply_block(block: Block, *args) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
             if cfg.remat_mode == "none":
                 return block(*args)
-            if cfg.remat_mode == "attn_only":
-                # Checkpoint only the attention sub-block; the MoE forward and its
-                # residuals stay live so backward never re-executes expert dispatch.
-                return block(*args, remat_attention=True)
-            if cfg.remat_mode == "moe_only":
-                # Inverse split: only the MoE sub-block reruns in backward; attention
-                # residuals (FA4 q/k/v/o + lse, small) stay live.
-                return block(*args, remat_moe=True)
+            if cfg.remat_mode in _SUB_REMAT:
+                return block(*args, sub_remat=_SUB_REMAT[cfg.remat_mode])
             return eqx.filter_checkpoint(block, policy=remat_policy)(*args)
 
         if self.blocks is not None:

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -72,7 +72,7 @@ def _mesh_axis_size(mesh: jax.sharding.AbstractMesh | None, axis_name: str) -> i
     return int(mesh.shape[axis_name])
 
 
-RematMode = Literal["recompute_all", "save_moe", "attn_only", "none"]
+RematMode = Literal["recompute_all", "save_moe", "attn_only", "moe_only", "none"]
 
 
 def _batch_spec() -> P:
@@ -144,7 +144,10 @@ class GrugModelConfig:
     backward skips re-running expert dispatch and its EP collectives; "attn_only"
     checkpoints just the attention sub-block, so the MoE forward — including its
     custom_vjp residuals, which name-based save policies cannot reach — is never
-    re-executed in backward; "none" disables checkpointing entirely."""
+    re-executed in backward (memory-heavy: the custom_vjp pins dispatch tensors
+    and gathered expert weights per layer); "moe_only" is the inverse — only the
+    MoE sub-block is checkpointed, so attention and the norms are never re-run;
+    "none" disables checkpointing entirely."""
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
 
     def __post_init__(self) -> None:
@@ -678,6 +681,7 @@ class Block(eqx.Module):
         use_pko: bool = False,
         disable_long_rope: bool = False,
         remat_attention: bool = False,
+        remat_moe: bool = False,
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
         def _attn_block(attn_mods, h, use_long, s_mask, l_mask):
             rms_attn, attn_gated_norm, attn = attn_mods
@@ -700,10 +704,20 @@ class Block(eqx.Module):
         else:
             attn_out = _attn_block(attn_mods, x, use_long_mask, short_mask, long_mask)
         x = x + attn_out
-        mlp_in = self.mlp_gated_norm(self.rms_mlp(x))
-        mlp_out, router_stats = self.mlp(mlp_in)
-        if self.shared is not None:
-            mlp_out = mlp_out + self.shared(mlp_in, activation=ActivationFunctionEnum.silu)
+
+        def _mlp_block(mlp_mods, h):
+            rms_mlp, mlp_gated_norm, mlp, shared = mlp_mods
+            mlp_in = mlp_gated_norm(rms_mlp(h))
+            mlp_out, router_stats = mlp(mlp_in)
+            if shared is not None:
+                mlp_out = mlp_out + shared(mlp_in, activation=ActivationFunctionEnum.silu)
+            return mlp_out, router_stats
+
+        mlp_mods = (self.rms_mlp, self.mlp_gated_norm, self.mlp, self.shared)
+        if remat_moe:
+            mlp_out, router_stats = eqx.filter_checkpoint(_mlp_block)(mlp_mods, x)
+        else:
+            mlp_out, router_stats = _mlp_block(mlp_mods, x)
         x = x + mlp_out
         return x, router_stats
 
@@ -811,6 +825,10 @@ class Transformer(eqx.Module):
                 # Checkpoint only the attention sub-block; the MoE forward and its
                 # residuals stay live so backward never re-executes expert dispatch.
                 return block(*args, remat_attention=True)
+            if cfg.remat_mode == "moe_only":
+                # Inverse split: only the MoE sub-block reruns in backward; attention
+                # residuals (FA4 q/k/v/o + lse, small) stay live.
+                return block(*args, remat_moe=True)
             return eqx.filter_checkpoint(block, policy=remat_policy)(*args)
 
         if self.blocks is not None:

--- a/grug_moe_row13.py
+++ b/grug_moe_row13.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import time
 from pathlib import Path
 
@@ -80,7 +81,7 @@ def build_model(args) -> GrugModelConfig:
         moe_implementation=args.moe_implementation,
         use_array_stacked_blocks=True,  # stacked-blocks lax.scan (needs disable_pko)
         disable_pko=True,
-        remat_mode="recompute_all",
+        remat_mode=os.environ.get("REMAT_MODE", "recompute_all"),
     )
 
 
@@ -129,13 +130,18 @@ def main() -> None:
 
         state = init(jax.random.PRNGKey(args.seed))
 
+        profile_dir = os.environ.get("PROFILE_DIR")
         loss = jnp.array(0.0)
-        for _ in range(args.steps):
+        for i in range(args.steps):
+            if profile_dir and i == args.warmup_steps + 2:
+                jax.profiler.start_trace(profile_dir)
             t0 = time.perf_counter()
             state, step_metrics, _w = train_step(state, batch, compute_watch=False)
             loss = step_metrics["train/loss"]
             jax.block_until_ready(loss)
             dur = time.perf_counter() - t0
+            if profile_dir and i == args.warmup_steps + 4:
+                jax.profiler.stop_trace()
             step = int(state.step) - 1
             eps = args.batch_size / dur
             achieved = flops_per_example * eps

--- a/grug_moe_row13.py
+++ b/grug_moe_row13.py
@@ -1,0 +1,198 @@
+# Copied from Will's harness (delphi-rl/grugmoe/marin/grug_moe_row13.py, 2026-07-07) for a comparable baseline.
+#!/usr/bin/env python3
+"""Replicate row 13 of issue #6979 (full model.py) on B200.
+
+Row 13: d2560 / 26 layers / 64 experts (top-4) / MHA / sonic dispatch / EP1 (FSDP
+over data) / MuonH / stacked-scan blocks / b128 / seq4k. On 8xH100 this measured
+26.7% MFU. Here we run the identical model config on 8xB200 (single node) and
+report MFU vs the B200 bf16 dense peak plus absolute throughput (comparable
+across hardware). A single random batch is reused each step (throughput probe).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import jmp
+from haliax.partitioning import set_mesh
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+from levanter.data.text import GrugLmExample
+from levanter.grug.attention import AttentionMask
+from levanter.grug.sharding import compact_grug_mesh
+
+from experiments.grug.moe.model import GrugModelConfig
+from experiments.grug.moe.optimizer import GrugMoeMuonHConfig
+from experiments.grug.moe.train import _compute_flops, _make_train_step, initial_state
+
+# B200 SXM bf16 dense (non-sparse) peak per GPU, FLOP/s. H100 SXM bf16 dense is ~9.89e14
+# for reference (what row 13's 26.7% is measured against).
+_B200_BF16_PEAK_FLOPS = 2.25e15
+_H100_BF16_PEAK_FLOPS = 9.89e14
+
+_BATCH_AXES = ("replica_dcn", "data", "expert")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser()
+    p.add_argument("--run-id", required=True)
+    p.add_argument("--output-dir", required=True)
+    p.add_argument("--steps", type=int, default=20)
+    p.add_argument("--warmup-steps", type=int, default=8)
+    p.add_argument("--batch-size", type=int, default=128)
+    p.add_argument("--seq-len", type=int, default=4096)
+    p.add_argument("--hidden-dim", type=int, default=2560)
+    p.add_argument("--num-layers", type=int, default=26)
+    p.add_argument("--num-experts", type=int, default=64)
+    p.add_argument("--num-experts-per-token", type=int, default=4)
+    p.add_argument("--head-dim", type=int, default=128)
+    p.add_argument("--num-gpus", type=int, default=8)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--moe-implementation", default="sonic")
+    p.add_argument("--attention-implementation", default="gpu_fa4_cute")
+    return p.parse_args()
+
+
+def build_model(args) -> GrugModelConfig:
+    num_heads = args.hidden_dim // args.head_dim
+    intermediate = args.hidden_dim // 2
+    return GrugModelConfig(
+        vocab_size=128256,
+        hidden_dim=args.hidden_dim,
+        num_layers=args.num_layers,
+        num_heads=num_heads,
+        num_kv_heads=num_heads,  # full multi-head attention (MHA)
+        head_dim=args.head_dim,
+        intermediate_dim=intermediate,
+        shared_expert_intermediate_dim=intermediate,
+        num_experts=args.num_experts,
+        num_experts_per_token=args.num_experts_per_token,
+        max_seq_len=args.seq_len,
+        sliding_window=2048,
+        initializer_std=0.5 / (args.hidden_dim**0.5),
+        qk_mult=1.3,
+        attention_implementation=args.attention_implementation,
+        moe_implementation=args.moe_implementation,
+        use_array_stacked_blocks=True,  # stacked-blocks lax.scan (needs disable_pko)
+        disable_pko=True,
+        remat_mode="recompute_all",
+    )
+
+
+def make_batch(batch_size: int, seq_len: int, vocab_size: int, seed: int, mesh) -> GrugLmExample:
+    key = jax.random.PRNGKey(seed)
+    tokens = jax.random.randint(key, (batch_size, seq_len), 0, vocab_size, dtype=jnp.int32)
+    loss_weight = jnp.broadcast_to(
+        GrugLmExample.causal_loss_mask(seq_len).astype(jnp.float32), (batch_size, seq_len)
+    )
+    sharding = NamedSharding(mesh, P(_BATCH_AXES, None))
+    segment_ids = jax.device_put(jnp.zeros((batch_size, seq_len), dtype=jnp.int32), sharding)
+    return GrugLmExample(
+        tokens=jax.device_put(tokens, sharding),
+        loss_weight=jax.device_put(loss_weight, sharding),
+        attn_mask=AttentionMask.causal(sliding_window=seq_len).with_segment_ids(segment_ids),
+    )
+
+
+def main() -> None:
+    jax.config.update("jax_threefry_partitionable", True)
+    args = parse_args()
+    out = Path(args.output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    model = build_model(args)
+    # MuonH (May Recipe): LR values don't affect throughput; keep them small/stable.
+    optimizer = GrugMoeMuonHConfig(learning_rate=1e-3, adam_lr=1e-4, min_lr_ratio=0.0, warmup=0.1)
+    mp = jmp.get_policy("params=float32,compute=bfloat16,output=bfloat16")
+
+    opt = optimizer.build(args.steps)
+    train_step = _make_train_step(opt, mp, z_loss_weight=1e-4, ema_beta=None, watch_config=None)
+    flops_per_example, flops_summary = _compute_flops(model_config=model)
+    peak = args.num_gpus * _B200_BF16_PEAK_FLOPS
+
+    # EP1 + FSDP: experts are NOT expert-parallel; params/opt shard over the data axis.
+    mesh = compact_grug_mesh(expert_axis_size=1, replica_axis_size=1)
+    metrics: list[dict] = []
+    tokens_per_step = args.batch_size * args.seq_len
+
+    with set_mesh(mesh):
+        batch = make_batch(args.batch_size, args.seq_len, model.vocab_size, args.seed, mesh)
+
+        @jax.jit
+        def init(rng):
+            return initial_state(model, optimizer=opt, mp=mp, key=rng, ema_beta=None)
+
+        state = init(jax.random.PRNGKey(args.seed))
+
+        loss = jnp.array(0.0)
+        for _ in range(args.steps):
+            t0 = time.perf_counter()
+            state, step_metrics, _w = train_step(state, batch, compute_watch=False)
+            loss = step_metrics["train/loss"]
+            jax.block_until_ready(loss)
+            dur = time.perf_counter() - t0
+            step = int(state.step) - 1
+            eps = args.batch_size / dur
+            achieved = flops_per_example * eps
+            m = {
+                "step": step,
+                "duration": dur,
+                "tokens_per_second": tokens_per_step / dur,
+                "achieved_flops_per_second": achieved,
+                "mfu_b200": achieved / peak,
+                "mfu_h100_equiv": achieved / (args.num_gpus * _H100_BF16_PEAK_FLOPS),
+                "loss": float(loss),
+            }
+            metrics.append(m)
+            print(json.dumps(m, sort_keys=True), flush=True)
+
+        try:
+            ms = jax.local_devices()[0].memory_stats() or {}
+            peak_gib = ms.get("peak_bytes_in_use", 0) / 1024**3
+        except Exception:
+            peak_gib = None
+
+    steady = [m for m in metrics if m["step"] >= args.warmup_steps]
+
+    def med(xs):
+        return None if not xs else sorted(xs)[len(xs) // 2]
+
+    summary = {
+        "args": vars(args),
+        "config": {
+            "hidden_dim": model.hidden_dim,
+            "num_layers": model.num_layers,
+            "num_heads": model.num_heads,
+            "num_kv_heads": model.num_kv_heads,
+            "intermediate_dim": model.intermediate_dim,
+            "shared_expert_intermediate_dim": model.shared_expert_intermediate_dim,
+            "num_experts": model.num_experts,
+            "num_experts_per_token": model.num_experts_per_token,
+            "moe_implementation": model.moe_implementation,
+            "attention_implementation": model.attention_implementation,
+            "use_array_stacked_blocks": model.use_array_stacked_blocks,
+            "batch_size": args.batch_size,
+            "seq_len": args.seq_len,
+            "ep": 1,
+            "tokens_per_step": tokens_per_step,
+            **flops_summary,
+            "peak_gib_per_gpu": peak_gib,
+        },
+        "metrics": metrics,
+        "steady_median_mfu_b200": med([m["mfu_b200"] for m in steady]),
+        "steady_median_mfu_h100_equiv": med([m["mfu_h100_equiv"] for m in steady]),
+        "steady_median_tokens_per_second": med([m["tokens_per_second"] for m in steady]),
+        "steady_median_achieved_tflops": None if not steady else med([m["achieved_flops_per_second"] for m in steady]) / 1e12,
+        "steady_median_duration": med([m["duration"] for m in steady]),
+    }
+    (out / "metrics_summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True))
+    print("SUMMARY " + json.dumps({k: v for k, v in summary.items() if k != "metrics"}, sort_keys=True), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/levanter/src/levanter/grug/_moe/local.py
+++ b/lib/levanter/src/levanter/grug/_moe/local.py
@@ -11,7 +11,16 @@ from jaxtyping import Array, Float, Int
 from levanter.grug._moe.common import _LOCAL_MOE_IMPLEMENTATIONS, MoeImplementation
 from levanter.grug._moe.scatter import _moe_mlp_local_scatter
 from levanter.grug._moe.sonic import _moe_mlp_local_sonic
-from levanter.grug._moe.sonic_cute import _moe_mlp_local_sonic_cute
+try:
+    from levanter.grug._moe.sonic_cute import _moe_mlp_local_sonic_cute
+except ModuleNotFoundError as _e:  # quack-kernels (and its torch dep) are optional
+    _sonic_cute_error = _e
+
+    def _moe_mlp_local_sonic_cute(*args, **kwargs):
+        raise ModuleNotFoundError(
+            "moe_implementation='sonic_cute' requires quack-kernels and torch: "
+            f"{_sonic_cute_error}"
+        ) from _sonic_cute_error
 
 _MOE_LOCAL_FNS = {
     "scatter": _moe_mlp_local_scatter,

--- a/lib/levanter/src/levanter/grug/_moe/quack_moe_cute.py
+++ b/lib/levanter/src/levanter/grug/_moe/quack_moe_cute.py
@@ -12,6 +12,7 @@ A[M,K] @ B[E,K,2N]  -> (per expert group) -> SwiGLU -> PostAct[M,N]
 from __future__ import annotations
 
 import importlib
+import os
 from functools import partial
 
 import jax
@@ -34,6 +35,22 @@ _JAX_TO_CUTE = {
 
 def _cute_dtype(dt):
     return _JAX_TO_CUTE[jnp.dtype(dt)]
+
+
+# SMs reserved for concurrent comm kernels (SM specialization): size the persistent
+# schedulers' grids to (SM count - carveout) so GEMM waves stay exact while NCCL
+# holds a fixed CTA budget (pin the comm side with NCCL_MIN_CTAS=NCCL_MAX_CTAS).
+_SM_CARVEOUT = int(os.environ.get("SONIC_CUTE_SM_CARVEOUT", "0"))
+
+
+def _max_active_clusters(cluster_size: int) -> int:
+    try:
+        mac = get_max_active_clusters(cluster_size)
+    except Exception:
+        mac = 148  # B200 SM-count fallback for host-side lowering tests
+    if _SM_CARVEOUT:
+        mac = max(1, mac - -(-_SM_CARVEOUT // cluster_size))
+    return mac
 
 
 def _build_launcher(*, a_dtype, tile_mn, cluster_mnk, activation, max_active_clusters, max_swizzle):
@@ -80,10 +97,7 @@ def quack_gated_grouped_gemm(x_sort, w_gate_up, cu_seqlens, *, activation="swigl
     N2 = w_gate_up.shape[2]
     N = N2 // 2
     a_dtype = _cute_dtype(x_sort.dtype)
-    try:
-        max_active_clusters = get_max_active_clusters(cluster_mnk[0] * cluster_mnk[1])
-    except Exception:
-        max_active_clusters = 148  # B200 SM-count fallback for host-side lowering tests
+    max_active_clusters = _max_active_clusters(cluster_mnk[0] * cluster_mnk[1])
     launcher = _build_launcher(
         a_dtype=a_dtype, tile_mn=tile_mn, cluster_mnk=cluster_mnk,
         activation=activation, max_active_clusters=max_active_clusters, max_swizzle=max_swizzle,
@@ -137,10 +151,7 @@ def quack_grouped_gemm(a, w, cu_seqlens, *, b_major="n", tile_mn=(256, 256), clu
     N = w.shape[2] if b_major == "n" else w.shape[1]
     _bmode = (2, 1, 0) if b_major == "n" else (1, 2, 0)
     a_dtype = _cute_dtype(a.dtype)
-    try:
-        mac = get_max_active_clusters(cluster_mnk[0] * cluster_mnk[1])
-    except Exception:
-        mac = 148
+    mac = _max_active_clusters(cluster_mnk[0] * cluster_mnk[1])
     launcher = _build_plain_launcher(a_dtype=a_dtype, tile_mn=tile_mn, cluster_mnk=cluster_mnk,
                                      max_active_clusters=mac, max_swizzle=max_swizzle)
     ts = cjax.TensorSpec
@@ -205,10 +216,7 @@ def quack_grouped_wgrad_gemm(acts, grads, cu_seqlens, num_experts, *,
     M = acts.shape[1]
     N = grads.shape[1]
     a_dtype = _cute_dtype(acts.dtype)
-    try:
-        mac = get_max_active_clusters(cluster_mnk[0] * cluster_mnk[1])
-    except Exception:
-        mac = 148  # B200 SM-count fallback for host-side lowering tests
+    mac = _max_active_clusters(cluster_mnk[0] * cluster_mnk[1])
     launcher = _build_wgrad_launcher(
         a_dtype=a_dtype, tile_mn=tile_mn, cluster_mnk=cluster_mnk,
         max_active_clusters=mac, max_swizzle=max_swizzle,

--- a/lib/levanter/src/levanter/grug/_moe/quack_moe_cute.py
+++ b/lib/levanter/src/levanter/grug/_moe/quack_moe_cute.py
@@ -156,3 +156,76 @@ def quack_grouped_gemm(a, w, cu_seqlens, *, b_major="n", tile_mn=(256, 128), clu
         use_static_tensors=False,
     )
     return call(a, w, cu_seqlens.astype(jnp.int32))
+
+
+# ---- varlen-k grouped GEMM (weight gradients dw13/dw2) ----
+
+
+def _build_wgrad_launcher(*, a_dtype, tile_mn, cluster_mnk, max_active_clusters, max_swizzle):
+    """Launcher for dw[e] = acts_e^T @ grads_e: ragged contraction over tokens (varlen_k).
+
+    Signature: (stream, mA, mB, mCuSeqlensK, mD)
+      mA:[M,total_K] m-major (transposed view of acts [total_K,M])
+      mB:[N,total_K] n-major (transposed view of grads [total_K,N])
+      mCuSeqlensK:[E+1] int32
+      mD:[M,N,E] n-major (expert = trailing batch/L mode)
+    """
+
+    @cute.jit
+    def launcher(stream, mA, mB, mCuSeqlensK, mD):
+        gemm = GemmDefaultSm100(
+            _ACC,
+            a_dtype,
+            tile_mn,
+            cluster_mnk,
+            gather_A=False,
+            use_clc_persistence=False,
+        )
+        epi_args = GemmDefaultEpiMixin.EpilogueArguments()
+        scheduler_args = make_scheduler_args(max_active_clusters, max_swizzle, None)
+        varlen_args = make_varlen_args(None, mCuSeqlensK, None)
+        gemm(mA, mB, mD, None, epi_args, scheduler_args, varlen_args, stream)
+
+    return launcher
+
+
+def quack_grouped_wgrad_gemm(acts, grads, cu_seqlens, num_experts, *,
+                             tile_mn=(256, 128), cluster_mnk=(2, 1, 1), max_swizzle=8):
+    """dw[e] = acts_e^T @ grads_e with ragged token contraction (QuACK varlen_k).
+
+    acts: [total_K, M] tokens sorted by expert (x_dispatch for dw13, h for dw2).
+    grads: [total_K, N] matching cotangents (d_gu for dw13, dy for dw2).
+    cu_seqlens: [E+1] int32 cumulative expert token counts.
+    Returns dw [E, M, N]. Empty experts yield zero slices (kernel clears acc at k_len==0).
+
+    Both transposed operand views are zero-copy: the row-major [total_K, M] activations
+    ARE m-major when read as logical [M, total_K] (quack asserts A m-major / B n-major
+    for varlen_k; cf. sonic-moe's dw1/dw2 calls in functional/__init__.py).
+    """
+    M = acts.shape[1]
+    N = grads.shape[1]
+    a_dtype = _cute_dtype(acts.dtype)
+    try:
+        mac = get_max_active_clusters(cluster_mnk[0] * cluster_mnk[1])
+    except Exception:
+        mac = 148  # B200 SM-count fallback for host-side lowering tests
+    launcher = _build_wgrad_launcher(
+        a_dtype=a_dtype, tile_mn=tile_mn, cluster_mnk=cluster_mnk,
+        max_active_clusters=mac, max_swizzle=max_swizzle,
+    )
+    ts = cjax.TensorSpec
+    # acts physically [total_K, M] row-major; logical [M, total_K] via mode=(1,0) — m-major.
+    a_spec = ts(mode=(1, 0), divisibility=(1, 8), static=False)
+    # grads physically [total_K, N] row-major; logical [N, total_K] via mode=(1,0) — n-major.
+    b_spec = ts(mode=(1, 0), divisibility=(1, 8), static=False)
+    cu_spec = ts(static=False)  # [E+1] int32
+    # dw physically [E, M, N]; kernel wants n-major logical [M, N, E] (expert trailing).
+    d_spec = ts(mode=(1, 2, 0), divisibility=(1, 1, 8), static=False)
+    call = cjax.cutlass_call(
+        launcher,
+        output_shape_dtype=jax.ShapeDtypeStruct((num_experts, M, N), acts.dtype),
+        input_spec=(a_spec, b_spec, cu_spec),
+        output_spec=(d_spec,),
+        use_static_tensors=False,
+    )
+    return call(acts, grads, cu_seqlens.astype(jnp.int32))

--- a/lib/levanter/src/levanter/grug/_moe/quack_moe_cute.py
+++ b/lib/levanter/src/levanter/grug/_moe/quack_moe_cute.py
@@ -69,7 +69,7 @@ def _build_launcher(*, a_dtype, tile_mn, cluster_mnk, activation, max_active_clu
 
 
 def quack_gated_grouped_gemm(x_sort, w_gate_up, cu_seqlens, *, activation="swiglu",
-                             tile_mn=(256, 128), cluster_mnk=(2, 1, 1), max_swizzle=8, return_preact=False):
+                             tile_mn=(256, 256), cluster_mnk=(2, 1, 1), max_swizzle=8, return_preact=False):
     """Grouped SwiGLU expert GEMM via QuACK's SM100 kernel.
 
     x_sort: [M, K] tokens sorted by expert. w_gate_up: [E, K, 2N]. cu_seqlens: [E+1] int32.
@@ -128,7 +128,7 @@ def _build_plain_launcher(*, a_dtype, tile_mn, cluster_mnk, max_active_clusters,
     return launcher
 
 
-def quack_grouped_gemm(a, w, cu_seqlens, *, b_major="n", tile_mn=(256, 128), cluster_mnk=(2, 1, 1), max_swizzle=8):
+def quack_grouped_gemm(a, w, cu_seqlens, *, b_major="n", tile_mn=(256, 256), cluster_mnk=(2, 1, 1), max_swizzle=8):
     """Plain grouped GEMM a[M,K] @ w -> [M,N], grouped by cu_seqlens (varlen_m).
 
     b_major='n': w is [E,K,N] (n-major, mode (2,1,0)).  b_major='k': w is [E,N,K]
@@ -190,7 +190,7 @@ def _build_wgrad_launcher(*, a_dtype, tile_mn, cluster_mnk, max_active_clusters,
 
 
 def quack_grouped_wgrad_gemm(acts, grads, cu_seqlens, num_experts, *,
-                             tile_mn=(256, 128), cluster_mnk=(2, 1, 1), max_swizzle=8):
+                             tile_mn=(256, 256), cluster_mnk=(2, 1, 1), max_swizzle=8):
     """dw[e] = acts_e^T @ grads_e with ragged token contraction (QuACK varlen_k).
 
     acts: [total_K, M] tokens sorted by expert (x_dispatch for dw13, h for dw2).

--- a/lib/levanter/src/levanter/grug/_moe/sonic_cute.py
+++ b/lib/levanter/src/levanter/grug/_moe/sonic_cute.py
@@ -22,7 +22,7 @@ import numpy as np
 from haliax.jax_utils import tree_checkpoint_name
 from haliax.nn.ragged_dot import ragged_dot
 from jax import P
-from jax.sharding import get_abstract_mesh, reshard
+from jax.sharding import AxisType, get_abstract_mesh, reshard
 from jaxtyping import Array, Float, Int
 
 from levanter.grug._moe.common import (
@@ -51,37 +51,49 @@ def _interleave_gate_up(moe_w13: jax.Array, moe_dim: int) -> jax.Array:
     return jnp.stack([gate, up], axis=-1).reshape(moe_w13.shape)
 
 
-def _fsdp_spec(spec: P) -> P | None:
-    """Return ``spec`` if every named axis exists in the current mesh, else None."""
+# Residual storage for the expert weights: shard the hidden dim over the FSDP axis
+# (mirroring the param layout) and re-gather in backward — the same all-gather
+# whole-block remat pays — so a remat split that leaves the MoE live does not pin
+# 26 layers of gathered expert weights. The local MoE usually runs inside a
+# shard_map (the FSDP axis is Manual there → slice/all_gather); under explicit
+# GSPMD sharding use reshard; with no mesh (unit tests) store the full weight.
+_FSDP_AXIS = "data"
+
+
+def _fsdp_axis_kind() -> tuple[AxisType | None, int]:
     mesh = get_abstract_mesh()
-    if mesh is None or mesh.empty:
-        return None
-    for entry in spec:
-        names = entry if isinstance(entry, tuple) else (entry,)
-        for name in names:
-            if name is not None and name not in mesh.shape:
-                return None
-    return spec
+    if mesh is None or mesh.empty or _FSDP_AXIS not in mesh.shape:
+        return None, 1
+    kinds = dict(zip(mesh.axis_names, mesh.axis_types))
+    return kinds[_FSDP_AXIS], int(mesh.shape[_FSDP_AXIS])
 
 
-def _store_sharded(w: jax.Array, spec: P) -> jax.Array:
-    """Reshard a (gathered) weight back to its FSDP layout for residual storage."""
-    resolved = _fsdp_spec(spec)
-    return w if resolved is None else reshard(w, resolved)
+def _store_sharded(w: jax.Array, dim: int) -> jax.Array:
+    """Store a (gathered) weight residual sharded along ``dim`` over the FSDP axis."""
+    kind, n = _fsdp_axis_kind()
+    if n <= 1 or w.shape[dim] % n != 0:
+        return w
+    if kind == AxisType.Explicit:
+        spec = [None] * w.ndim
+        spec[dim] = _FSDP_AXIS
+        return reshard(w, P(*spec))
+    if kind == AxisType.Manual:
+        shard = w.shape[dim] // n
+        start = jax.lax.axis_index(_FSDP_AXIS) * shard
+        return jax.lax.dynamic_slice_in_dim(w, start, shard, axis=dim)
+    return w
 
 
-def _restore_full(w: jax.Array, spec: P) -> jax.Array:
-    """All-gather a residual weight stored in FSDP layout."""
-    resolved = _fsdp_spec(spec)
-    return w if resolved is None else reshard(w, P(*(None for _ in w.shape)))
-
-
-# Residual-storage layouts for the expert weights (mirror the FSDP param sharding:
-# hidden dim over "data"). Residuals are stored sharded and re-gathered in backward —
-# the same all-gather whole-block remat pays — so a remat split that leaves the MoE
-# live does not pin 26 layers of gathered expert weights.
-_W13_STORE_SPEC = P(None, "data", None)
-_W2_STORE_SPEC = P(None, None, "data")
+def _restore_full(w: jax.Array, dim: int, full_size: int) -> jax.Array:
+    """Re-gather a weight residual stored by ``_store_sharded``."""
+    if w.shape[dim] == full_size:
+        return w
+    kind, _ = _fsdp_axis_kind()
+    if kind == AxisType.Explicit:
+        return reshard(w, P(*(None for _ in w.shape)))
+    if kind == AxisType.Manual:
+        return jax.lax.all_gather(w, _FSDP_AXIS, axis=dim, tiled=True)
+    raise AssertionError(f"weight residual sharded along dim {dim} but FSDP axis kind is {kind}")
 
 
 @jax.custom_vjp
@@ -107,8 +119,8 @@ def _expert_mlp_fwd(x_dispatch, w13_il, moe_w2, group_sizes, cu, x, token_dispat
     res = (
         x,
         token_dispatch,
-        _store_sharded(w13_il, _W13_STORE_SPEC),
-        _store_sharded(moe_w2, _W2_STORE_SPEC),
+        _store_sharded(w13_il, 1),  # [E, H, 2I] sharded along H
+        _store_sharded(moe_w2, 2),  # [E, I, H] sharded along H
         gu,
         group_sizes,
         cu,
@@ -118,9 +130,10 @@ def _expert_mlp_fwd(x_dispatch, w13_il, moe_w2, group_sizes, cu, x, token_dispat
 
 def _expert_mlp_bwd(res, dy):
     x, token_dispatch, w13_stored, w2_stored, gu, group_sizes, cu = res
+    hidden = x.shape[-1]
     x_dispatch = x[token_dispatch]
-    w13_il = _restore_full(w13_stored, _W13_STORE_SPEC)
-    moe_w2 = _restore_full(w2_stored, _W2_STORE_SPEC)
+    w13_il = _restore_full(w13_stored, 1, hidden)
+    moe_w2 = _restore_full(w2_stored, 2, hidden)
     # h = swiglu(gu), recomputed elementwise (fp32 internally, matching kernel accum)
     gate32 = gu[:, 0::2].astype(jnp.float32)
     up32 = gu[:, 1::2].astype(jnp.float32)

--- a/lib/levanter/src/levanter/grug/_moe/sonic_cute.py
+++ b/lib/levanter/src/levanter/grug/_moe/sonic_cute.py
@@ -6,11 +6,13 @@
 Dispatch/combine as in ``scatter``, but the expert MLP GEMMs run on QuACK's
 ``GemmGatedSm100`` / ``GemmDefaultSm100`` via the vendored ``cutlass.jax.cutlass_call``
 shim. QuACK does all four activation-path grouped GEMMs (gate/up fwd fused with
-SwiGLU, down fwd, and the ``dh``/``dx`` backward matmuls); the SwiGLU backward is
-elementwise in JAX; the two weight-gradient GEMMs (``dw13``/``dw2``) stay on XLA
-``ragged_dot`` (a different varlen-k grouping). QuACK covers ~2/3 of the MoE FLOPs.
+SwiGLU, down fwd, and the ``dh``/``dx`` backward matmuls, and — via the varlen-k
+mode — the two weight-gradient GEMMs ``dw13``/``dw2``); the SwiGLU backward is
+elementwise in JAX. Set ``SONIC_CUTE_WGRAD=xla`` to fall back to the XLA
+``ragged_dot`` weight grads for A/B comparison.
 """
 
+import os
 from collections.abc import Callable
 from functools import partial
 
@@ -28,7 +30,16 @@ from levanter.grug._moe.common import (
     _prepare_moe_dispatch,
     _zero_dropped_assignments,
 )
-from levanter.grug._moe.quack_moe_cute import quack_gated_grouped_gemm, quack_grouped_gemm
+from levanter.grug._moe.quack_moe_cute import (
+    quack_gated_grouped_gemm,
+    quack_grouped_gemm,
+    quack_grouped_wgrad_gemm,
+)
+
+# Weight-grad GEMM backend: "quack" (varlen-k grouped GEMM on SM100) or "xla" (ragged_dot).
+_WGRAD_IMPL = os.environ.get("SONIC_CUTE_WGRAD", "quack")
+if _WGRAD_IMPL not in ("quack", "xla"):
+    raise ValueError(f"SONIC_CUTE_WGRAD={_WGRAD_IMPL!r} must be 'quack' or 'xla'")
 
 
 def _interleave_gate_up(moe_w13: jax.Array, moe_dim: int) -> jax.Array:
@@ -59,7 +70,11 @@ def _expert_mlp_bwd(res, dy):
     x_dispatch, w13_il, moe_w2, gu, h, group_sizes, cu = res
     # down backward: dh via QuACK (transposed contraction), dw2 via XLA weight-grad
     dh = quack_grouped_gemm(dy, moe_w2, cu, b_major="k")
-    (dw2,) = jax.vjp(lambda w: ragged_dot(h, w, group_sizes), moe_w2)[1](dy)
+    num_experts = moe_w2.shape[0]
+    if _WGRAD_IMPL == "quack":
+        dw2 = quack_grouped_wgrad_gemm(h, dy, cu, num_experts)
+    else:
+        (dw2,) = jax.vjp(lambda w: ragged_dot(h, w, group_sizes), moe_w2)[1](dy)
     # SwiGLU backward (interleaved gate/up), elementwise
     gate, up = gu[:, 0::2], gu[:, 1::2]
     sg = jax.nn.sigmoid(gate)
@@ -69,7 +84,10 @@ def _expert_mlp_bwd(res, dy):
     d_gu = jnp.stack([dgate, dup], axis=-1).reshape(gu.shape)
     # gate/up backward: dx via QuACK, dw13 via XLA weight-grad
     dx = quack_grouped_gemm(d_gu, w13_il, cu, b_major="k")
-    (dw13_il,) = jax.vjp(lambda w: ragged_dot(x_dispatch, w, group_sizes), w13_il)[1](d_gu)
+    if _WGRAD_IMPL == "quack":
+        dw13_il = quack_grouped_wgrad_gemm(x_dispatch, d_gu, cu, num_experts)
+    else:
+        (dw13_il,) = jax.vjp(lambda w: ragged_dot(x_dispatch, w, group_sizes), w13_il)[1](d_gu)
     # int-typed routing args get float0 zero cotangents
     gs_ct = np.zeros(group_sizes.shape, dtype=jax.dtypes.float0)
     cu_ct = np.zeros(cu.shape, dtype=jax.dtypes.float0)

--- a/lib/levanter/src/levanter/grug/_moe/sonic_cute.py
+++ b/lib/levanter/src/levanter/grug/_moe/sonic_cute.py
@@ -21,6 +21,8 @@ import jax.numpy as jnp
 import numpy as np
 from haliax.jax_utils import tree_checkpoint_name
 from haliax.nn.ragged_dot import ragged_dot
+from jax import P
+from jax.sharding import get_abstract_mesh, reshard
 from jaxtyping import Array, Float, Int
 
 from levanter.grug._moe.common import (
@@ -49,25 +51,80 @@ def _interleave_gate_up(moe_w13: jax.Array, moe_dim: int) -> jax.Array:
     return jnp.stack([gate, up], axis=-1).reshape(moe_w13.shape)
 
 
+def _fsdp_spec(spec: P) -> P | None:
+    """Return ``spec`` if every named axis exists in the current mesh, else None."""
+    mesh = get_abstract_mesh()
+    if mesh is None or mesh.empty:
+        return None
+    for entry in spec:
+        names = entry if isinstance(entry, tuple) else (entry,)
+        for name in names:
+            if name is not None and name not in mesh.shape:
+                return None
+    return spec
+
+
+def _store_sharded(w: jax.Array, spec: P) -> jax.Array:
+    """Reshard a (gathered) weight back to its FSDP layout for residual storage."""
+    resolved = _fsdp_spec(spec)
+    return w if resolved is None else reshard(w, resolved)
+
+
+def _restore_full(w: jax.Array, spec: P) -> jax.Array:
+    """All-gather a residual weight stored in FSDP layout."""
+    resolved = _fsdp_spec(spec)
+    return w if resolved is None else reshard(w, P(*(None for _ in w.shape)))
+
+
+# Residual-storage layouts for the expert weights (mirror the FSDP param sharding:
+# hidden dim over "data"). Residuals are stored sharded and re-gathered in backward —
+# the same all-gather whole-block remat pays — so a remat split that leaves the MoE
+# live does not pin 26 layers of gathered expert weights.
+_W13_STORE_SPEC = P(None, "data", None)
+_W2_STORE_SPEC = P(None, None, "data")
+
+
 @jax.custom_vjp
-def _expert_mlp(x_dispatch, w13_il, moe_w2, group_sizes, cu):
+def _expert_mlp(x_dispatch, w13_il, moe_w2, group_sizes, cu, x, token_dispatch):
     """y = down( swiglu( x @ w13_il ) ), grouped by experts. Activation-path GEMMs on QuACK.
 
     ``group_sizes``/``cu`` are traced int arrays passed as explicit args (not closed
     over — that leaks under shard_map; not nondiff_argnums — that rejects tracers).
+    ``x``/``token_dispatch`` are backward hints: ``x_dispatch`` must equal
+    ``x[token_dispatch]``, so backward re-gathers it instead of pinning the [T*K, H]
+    dispatch tensor as a residual. ``x`` gets a zero cotangent — the real gradient
+    flows through ``x_dispatch`` into the caller's gather transpose.
     """
     _gu, h = quack_gated_grouped_gemm(x_dispatch, w13_il, cu, return_preact=True)
     return quack_grouped_gemm(h, moe_w2, cu, b_major="n")
 
 
-def _expert_mlp_fwd(x_dispatch, w13_il, moe_w2, group_sizes, cu):
+def _expert_mlp_fwd(x_dispatch, w13_il, moe_w2, group_sizes, cu, x, token_dispatch):
     gu, h = quack_gated_grouped_gemm(x_dispatch, w13_il, cu, return_preact=True)
     y = quack_grouped_gemm(h, moe_w2, cu, b_major="n")
-    return y, (x_dispatch, w13_il, moe_w2, gu, h, group_sizes, cu)
+    # Slim residuals: backward re-gathers x_dispatch from (x, token_dispatch) and
+    # recomputes h elementwise from gu; weights are stored FSDP-sharded.
+    res = (
+        x,
+        token_dispatch,
+        _store_sharded(w13_il, _W13_STORE_SPEC),
+        _store_sharded(moe_w2, _W2_STORE_SPEC),
+        gu,
+        group_sizes,
+        cu,
+    )
+    return y, res
 
 
 def _expert_mlp_bwd(res, dy):
-    x_dispatch, w13_il, moe_w2, gu, h, group_sizes, cu = res
+    x, token_dispatch, w13_stored, w2_stored, gu, group_sizes, cu = res
+    x_dispatch = x[token_dispatch]
+    w13_il = _restore_full(w13_stored, _W13_STORE_SPEC)
+    moe_w2 = _restore_full(w2_stored, _W2_STORE_SPEC)
+    # h = swiglu(gu), recomputed elementwise (fp32 internally, matching kernel accum)
+    gate32 = gu[:, 0::2].astype(jnp.float32)
+    up32 = gu[:, 1::2].astype(jnp.float32)
+    h = (gate32 * jax.nn.sigmoid(gate32) * up32).astype(gu.dtype)
     # down backward: dh via QuACK (transposed contraction), dw2 via XLA weight-grad
     dh = quack_grouped_gemm(dy, moe_w2, cu, b_major="k")
     num_experts = moe_w2.shape[0]
@@ -91,7 +148,10 @@ def _expert_mlp_bwd(res, dy):
     # int-typed routing args get float0 zero cotangents
     gs_ct = np.zeros(group_sizes.shape, dtype=jax.dtypes.float0)
     cu_ct = np.zeros(cu.shape, dtype=jax.dtypes.float0)
-    return dx, dw13_il, dw2, gs_ct, cu_ct
+    td_ct = np.zeros(token_dispatch.shape, dtype=jax.dtypes.float0)
+    # x is a backward hint only; its gradient flows through x_dispatch (see _expert_mlp)
+    x_ct = jnp.zeros_like(x)
+    return dx, dw13_il, dw2, gs_ct, cu_ct, x_ct, td_ct
 
 
 _expert_mlp.defvjp(_expert_mlp_fwd, _expert_mlp_bwd)
@@ -117,7 +177,8 @@ def _moe_mlp_local_sonic_cute(
 
     with jax.named_scope("moe_up_down_quack"):
         out_dispatch = tree_checkpoint_name(
-            _expert_mlp(x_dispatch, w13_il, moe_w2, group_sizes, cu), _CHECKPOINT_DISPATCH_OUTPUT
+            _expert_mlp(x_dispatch, w13_il, moe_w2, group_sizes, cu, x, token_dispatch),
+            _CHECKPOINT_DISPATCH_OUTPUT,
         )
 
     with jax.named_scope("scatter"):

--- a/test_sonic_slim_parity.py
+++ b/test_sonic_slim_parity.py
@@ -1,0 +1,60 @@
+"""Parity: sonic_cute full fwd+bwd (slim custom_vjp residuals) vs the scatter reference.
+
+Run on 1 B200. Validates the residual-slimming rewrite: backward re-gathers
+x_dispatch from (x, token_dispatch), recomputes h = swiglu(gu) elementwise, and
+(under a mesh) stores expert weights FSDP-sharded.
+"""
+import traceback
+
+import jax
+import jax.numpy as jnp
+
+from levanter.grug._moe.scatter import _moe_mlp_local_scatter
+from levanter.grug._moe.sonic_cute import _moe_mlp_local_sonic_cute
+
+T, H, I, E, K = 32768, 2560, 1280, 64, 4
+
+k = jax.random.PRNGKey(0)
+kx, ks, kw, k13, k2 = jax.random.split(k, 5)
+x = (jax.random.normal(kx, (T, H)) * 0.1).astype(jnp.bfloat16)
+selected = jax.random.randint(ks, (T, K), 0, E, dtype=jnp.int32)
+combine = jax.nn.sigmoid(jax.random.normal(kw, (T, K))).astype(jnp.float32)
+w13 = (jax.random.normal(k13, (E, H, 2 * I)) * 0.02).astype(jnp.bfloat16)
+w2 = (jax.random.normal(k2, (E, I, H)) * 0.02).astype(jnp.bfloat16)
+
+
+def make_loss(impl):
+    def loss(x, combine, w13, w2):
+        out, _ = impl(
+            x, selected, combine, w13, w2, activation_fn=jax.nn.silu, num_experts=E
+        )
+        return jnp.sum(out.astype(jnp.float32) ** 2)
+
+    return loss
+
+
+failures = 0
+try:
+    ref_fn = jax.jit(jax.value_and_grad(make_loss(_moe_mlp_local_scatter), argnums=(0, 1, 2, 3)))
+    got_fn = jax.jit(jax.value_and_grad(make_loss(_moe_mlp_local_sonic_cute), argnums=(0, 1, 2, 3)))
+    ref_loss, ref_grads = ref_fn(x, combine, w13, w2)
+    got_loss, got_grads = got_fn(x, combine, w13, w2)
+    jax.block_until_ready((ref_loss, got_loss, ref_grads, got_grads))
+    lrel = abs(float(got_loss) - float(ref_loss)) / (abs(float(ref_loss)) + 1e-6)
+    print(f"loss ref={float(ref_loss):.4f} got={float(got_loss):.4f} rel={lrel:.5f} "
+          f"{'ok' if lrel < 0.01 else 'FAIL'}", flush=True)
+    if lrel >= 0.01:
+        failures += 1
+    for name, rg, gg in zip(("dx", "d_combine", "dw13", "dw2"), ref_grads, got_grads):
+        rg32, gg32 = rg.astype(jnp.float32), gg.astype(jnp.float32)
+        err = float(jnp.abs(gg32 - rg32).max())
+        rel = err / (float(jnp.abs(rg32).max()) + 1e-6)
+        status = "ok" if rel < 0.02 else "FAIL"
+        if status == "FAIL":
+            failures += 1
+        print(f"{name}: max_abs {err:.6f} rel {rel:.5f} {status}", flush=True)
+except Exception:
+    traceback.print_exc()
+    failures += 1
+
+print("SLIM_PARITY_OK" if failures == 0 else f"SLIM_PARITY_FAIL ({failures})", flush=True)

--- a/test_wgrad_parity.py
+++ b/test_wgrad_parity.py
@@ -1,0 +1,59 @@
+"""Parity: quack_grouped_wgrad_gemm vs the XLA ragged_dot weight-grad it replaces.
+
+Run on 1 B200. Covers even groups, heavily ragged groups (odd sizes incl. 1),
+and empty experts (kernel must clear the accumulator, cf. gemm_sm100 clear_acc).
+"""
+import traceback
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from haliax.nn.ragged_dot import ragged_dot
+
+from levanter.grug._moe.quack_moe_cute import quack_grouped_wgrad_gemm
+
+
+def xla_ref(acts, grads, group_sizes, E, M, N):
+    """The exact XLA weight-grad this replaces: vjp of ragged_dot w.r.t. w."""
+    w0 = jnp.zeros((E, M, N), acts.dtype)
+    (dw,) = jax.vjp(lambda w: ragged_dot(acts, w, group_sizes), w0)[1](grads)
+    return dw
+
+
+CASES = [
+    ("even/dw13-shape", [2048] * 8, 2560, 5120),
+    ("ragged", [1, 8191, 777, 4096, 33, 3000, 190, 96], 2560, 5120),
+    ("empty-experts/dw2-shape", [4096, 0, 2048, 0, 8192, 512, 1024, 512], 1280, 2560),
+]
+
+failures = 0
+for name, gs, M, N in CASES:
+    TK, E = sum(gs), len(gs)
+    k1, k2 = jax.random.split(jax.random.PRNGKey(abs(hash(name)) % 2**31))
+    acts = (jax.random.normal(k1, (TK, M)) * 0.1).astype(jnp.bfloat16)
+    grads = (jax.random.normal(k2, (TK, N)) * 0.1).astype(jnp.bfloat16)
+    group_sizes = jnp.asarray(gs, jnp.int32)
+    cu = jnp.asarray(np.concatenate([[0], np.cumsum(gs)]), jnp.int32)
+    try:
+        dw = quack_grouped_wgrad_gemm(acts, grads, cu, E)
+        ref = xla_ref(acts, grads, group_sizes, E, M, N)
+        jax.block_until_ready((dw, ref))
+        err = float(jnp.abs(dw.astype(jnp.float32) - ref.astype(jnp.float32)).max())
+        rel = err / (float(jnp.abs(ref).max()) + 1e-6)
+        status = "ok" if rel < 0.02 else "FAIL"
+        if status == "FAIL":
+            failures += 1
+        print(f"{name}: max_abs {err:.5f} rel {rel:.5f} {status}", flush=True)
+        # empty experts must be exactly zero
+        for e, g in enumerate(gs):
+            if g == 0:
+                z = float(jnp.abs(dw[e]).max())
+                print(f"  expert {e} empty: max|dw|={z} {'ok' if z == 0.0 else 'FAIL'}", flush=True)
+                if z != 0.0:
+                    failures += 1
+    except Exception:
+        traceback.print_exc()
+        failures += 1
+        print(f"{name}: EXCEPTION", flush=True)
+
+print("WGRAD_PARITY_OK" if failures == 0 else f"WGRAD_PARITY_FAIL ({failures})", flush=True)


### PR DESCRIPTION
## Status

Draft extraction marker stacked on the QuACK backend branch. Do not merge this research branch as-is: the weight-gradient and SM-carveout experiments are intentionally out of scope.

## Validated result

Slim custom-VJP residuals combined with `all_but_moe` rematerialization reduced recomputation and produced a measured whole-model improvement with matching loss trajectories.

- In-scope PoC: [`01b8e7c92`](https://github.com/marin-community/marin/commit/01b8e7c92f22faf486bf66a4d3e4b6d1aa7f0236)
- Validation: [#7012 result](https://github.com/marin-community/marin/issues/7012#issuecomment-4984144891)

## Before review

- extract the slim-residual VJP and rematerialization mode into a focused change;
- add value/gradient coverage for the residual reconstruction path;
- keep performance-null experiments out of the final PR.

Part of #6710. Related to #7012.