### PR TITLE
[draft] Guard against the slow XLA ragged-all-to-all one-shot path

### DIFF
--- a/lib/levanter/docs/Getting-Started-GPU.md
+++ b/lib/levanter/docs/Getting-Started-GPU.md
@@ -7,6 +7,17 @@
 !!! tip "Deterministic Training"
     If you want fully deterministic results when training on GPU, set `XLA_FLAGS="--xla_gpu_deterministic_ops=true"` in your environment before launching Levanter.
 
+!!! tip "MoE with the `ragged_all_to_all` backend"
+    XLA lowers `ragged_all_to_all` to a "one-shot" device kernel by default, which runs far below
+    NVLink bandwidth at MoE dispatch sizes. If you use the grug MoE `ragged_all_to_all`
+    expert-parallel backend on GPU, set
+    `XLA_FLAGS="--xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel=false"` so the
+    collective routes through NCCL. Measured on the grug MoE layer (d2560, top-4 of 256 experts,
+    16k tokens/device, fwd+bwd): 96 → 27 ms/step on one 8xH100 node (EP4). The one-shot kernel is
+    only used for single-host cliques, so multi-node runs are unaffected — but the flag still
+    matters there whenever the expert mesh fits within a node. Levanter warns when this backend
+    runs on GPU without the flag.
+
 We have two installation options for Levanter:
 
 1. [Using `uv` Virtual Environments](#using-uv-virtual-environments): This is the simplest way if you don't have root access to your machine (and don't have rootless docker installed).

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -4,6 +4,8 @@
 """Ragged all-to-all expert-parallel Grug MoE backend."""
 
 import math
+import os
+import warnings
 from collections.abc import Callable
 
 import jax
@@ -23,6 +25,29 @@ from levanter.grug._moe.ep_common import (
     _unpermute_from_global_expert,
 )
 from levanter.grug.sharding import _batch_axes
+
+_ONE_SHOT_RAGGED_A2A_FLAG = "--xla_gpu_unsupported_use_ragged_all_to_all_one_shot_kernel=false"
+
+
+def warn_if_slow_ragged_a2a_kernel() -> None:
+    """Warn when XLA's one-shot ragged-all-to-all kernel is not disabled on GPU.
+
+    XLA lowers ``ragged_all_to_all`` to a one-shot device kernel by default,
+    which runs ~30x below NVLink bandwidth at grug MoE sizes: measured 96 vs
+    27 ms/step for the layer fwd+bwd on 8xH100 (d2560, EP4). Disabling it via
+    ``XLA_FLAGS='... {flag}'`` routes the collective through NCCL instead.
+    XLA flags are read at backend initialization, so this must come from the
+    launch environment; warn rather than set it here.
+    """
+    if jax.default_backend() != "gpu":
+        return
+    if _ONE_SHOT_RAGGED_A2A_FLAG in os.environ.get("XLA_FLAGS", ""):
+        return
+    warnings.warn(
+        "The ragged_all_to_all MoE backend is ~4x slower with XLA's default one-shot ragged-all-to-all kernel. "
+        f"Add '{_ONE_SHOT_RAGGED_A2A_FLAG}' to XLA_FLAGS before launch.",
+        stacklevel=3,
+    )
 
 
 def _moe_mlp_ep_ragged_a2a_local(

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -44,7 +44,7 @@ from levanter.grug._moe.ep_common import (
     _shard_a2a_params as _shard_a2a_params,
 )
 from levanter.grug._moe.ep_deepep import _moe_mlp_ep_deepep_local
-from levanter.grug._moe.ep_ragged_all_to_all import _moe_mlp_ep_ragged_a2a_local
+from levanter.grug._moe.ep_ragged_all_to_all import _moe_mlp_ep_ragged_a2a_local, warn_if_slow_ragged_a2a_kernel
 from levanter.grug._moe.ep_ring import _moe_mlp_ep_ring_local
 from levanter.grug._moe.local import _moe_mlp_local
 from levanter.grug.sharding import (
@@ -209,6 +209,7 @@ def moe_mlp(
         if resolved_implementation == "ring":
             shard_local_fn = _moe_mlp_ep_ring_local
         elif resolved_implementation == "ragged_all_to_all":
+            warn_if_slow_ragged_a2a_kernel()
             shard_local_fn = _moe_mlp_ep_ragged_a2a_local
         elif resolved_implementation == "deepep":
             shard_local_fn = _moe_mlp_ep_deepep_local


### PR DESCRIPTION
## Status

Draft placeholder for the focused flag-and-warning treatment demonstrated in the B200 MoE experiments.

## Validated result

Selecting XLA's send/receive path avoids the pathological default one-shot ragged-all-to-all behavior. The branch exposes the choice explicitly and warns when the known-slow path is selected.

- PoC implementation: [`41ce33431`](https://github.com/marin-community/marin/commit/41ce3343150d2e73eb9d6c1f8935091962e00031)
- Validation and backend comparison: [#7012](https://github.com/marin-community/marin/issues/7012#issuecomment-4995418725)

## Before review

Add a focused configuration test, keep the treatment opt-in, and document that backend selection remains workload-dependent.

Part of #6710. Related to #7012 and #7279.