### PR TITLE
[telltale] Let a metric's own labels win inside its label map

### DIFF
--- a/lib/rigging/src/rigging/telltale.py
+++ b/lib/rigging/src/rigging/telltale.py
@@ -168,11 +168,7 @@ def get_global_labels() -> dict[str, str]:
 #: (the default Prometheus process/platform collectors).
 _KNOWN_SOURCES = frozenset({"levanter", "zephyr", "iris"})
 
-#: The global labels that become typed columns on a forwarded row. Read from the
-#: process globals only and never merged into a row's label map, so a metric's
-#: own label of either name keeps both its key and its value (see
-#: ``scrape_metrics``). The ``MetricIdentity`` fields are columns too, but they
-#: never travel as labels, so they need no exclusion here.
+#: Global labels stored as row columns instead of in the label map.
 _GLOBAL_LABEL_COLUMNS = frozenset({"source", "run"})
 
 #: Seconds between registry snapshots. A durable sink typically seals at most one
@@ -250,14 +246,9 @@ def _source_from_name(name: str) -> str:
 def scrape_metrics(identity: MetricIdentity, ts: datetime) -> list[TelltaleMetric]:
     """Snapshot the registry into rows, stamping ``identity`` onto each. Pure; no I/O.
 
-    One rule settles every name collision: the producer owns the columns, and the
-    metric owns its label map. ``source`` and ``run`` come from the process-global
-    labels and the job ``identity`` is set on the row directly, so a metric's own
-    labels can never spoof either. The remaining globals are merged into ``labels``
-    only as defaults for keys the metric does not use — a metric that labels its
-    series ``source=local_cache_hit`` keeps that, and stays distinguishable from its
-    siblings. Prometheus ``_created`` series (a counter's start time, not a metric)
-    are dropped.
+    Process-global ``source`` and ``run`` labels populate row columns. Other global
+    labels fill missing keys in each metric's label map; metric labels take
+    precedence. Prometheus ``_created`` series are dropped.
     """
     global_labels = get_global_labels()
     global_source = global_labels.get("source")

--- a/lib/rigging/src/rigging/telltale.py
+++ b/lib/rigging/src/rigging/telltale.py
@@ -168,6 +168,13 @@ def get_global_labels() -> dict[str, str]:
 #: (the default Prometheus process/platform collectors).
 _KNOWN_SOURCES = frozenset({"levanter", "zephyr", "iris"})
 
+#: The global labels that become typed columns on a forwarded row. Read from the
+#: process globals only and never merged into a row's label map, so a metric's
+#: own label of either name keeps both its key and its value (see
+#: ``scrape_metrics``). The ``MetricIdentity`` fields are columns too, but they
+#: never travel as labels, so they need no exclusion here.
+_GLOBAL_LABEL_COLUMNS = frozenset({"source", "run"})
+
 #: Seconds between registry snapshots. A durable sink typically seals at most one
 #: segment per second, so this stays clear of that while keeping dashboards live.
 DEFAULT_FORWARD_INTERVAL = 15.0
@@ -234,10 +241,8 @@ class MetricSink(Protocol):
     def close(self) -> None: ...
 
 
-def _source_for(name: str, source_label: str | None) -> str:
-    """Resolve a row's ``source``: an explicit label wins, else the name prefix."""
-    if source_label:
-        return source_label
+def _source_from_name(name: str) -> str:
+    """The producer a metric name implies; ``"process"`` for the stdlib collectors."""
     head = name.split("_", 1)[0]
     return head if head in _KNOWN_SOURCES else "process"
 
@@ -245,20 +250,26 @@ def _source_for(name: str, source_label: str | None) -> str:
 def scrape_metrics(identity: MetricIdentity, ts: datetime) -> list[TelltaleMetric]:
     """Snapshot the registry into rows, stamping ``identity`` onto each. Pure; no I/O.
 
-    ``source`` and ``run`` are lifted from the process-global labels into columns;
-    the job ``identity`` is set on the row directly, so a metric's own labels can
-    never spoof it. Everything else stays in ``labels``. Prometheus ``_created``
-    series (a counter's start time, not a metric) are dropped.
+    One rule settles every name collision: the producer owns the columns, and the
+    metric owns its label map. ``source`` and ``run`` come from the process-global
+    labels and the job ``identity`` is set on the row directly, so a metric's own
+    labels can never spoof either. The remaining globals are merged into ``labels``
+    only as defaults for keys the metric does not use — a metric that labels its
+    series ``source=local_cache_hit`` keeps that, and stays distinguishable from its
+    siblings. Prometheus ``_created`` series (a counter's start time, not a metric)
+    are dropped.
     """
     global_labels = get_global_labels()
+    global_source = global_labels.get("source")
+    run = global_labels.get("run")
+    carried_labels = {k: v for k, v in global_labels.items() if k not in _GLOBAL_LABEL_COLUMNS}
     rows: list[TelltaleMetric] = []
     for family in samples():
         sample = family.sample
         if sample.name.endswith("_created"):
             continue
-        labels = {**sample.labels, **global_labels}
-        source = _source_for(sample.name, labels.pop("source", None))
-        run = labels.pop("run", None)
+        labels = {**carried_labels, **sample.labels}
+        source = global_source or _source_from_name(sample.name)
         rows.append(
             TelltaleMetric(
                 name=sample.name,

--- a/lib/rigging/tests/test_telltale.py
+++ b/lib/rigging/tests/test_telltale.py
@@ -221,17 +221,22 @@ def test_status_survives_a_scrape_and_is_replaced_not_appended(client):
 
 
 @pytest.mark.parametrize(
-    ("metric_name", "expected"),
+    ("metric_prefix", "expected"),
     [
-        ("levanter_train_loss", "levanter"),
-        ("zephyr_item_count", "zephyr"),
-        ("iris_task_reconciles", "iris"),
-        ("process_cpu_seconds_total", "process"),
-        ("vllm:prompt_tokens_total", "process"),
+        ("levanter_", "levanter"),
+        ("zephyr_", "zephyr"),
+        ("iris_", "iris"),
+        ("process_", "process"),
+        ("vllm:", "process"),
     ],
 )
-def test_source_falls_back_to_the_name_prefix(metric_name, expected):
-    assert telltale._source_from_name(metric_name) == expected
+def test_scrape_source_falls_back_to_metric_name_prefix(name, clean_global_labels, metric_prefix, expected):
+    metric_name = f"{metric_prefix}{name}"
+    telltale.gauge(metric_name, "d").set(1)
+
+    row = _one(metric_name, telltale.scrape_metrics(telltale.MetricIdentity(), _TS))
+
+    assert row.source == expected
 
 
 def test_scrape_flattens_identity_and_run_source_into_columns(name, clean_global_labels):
@@ -246,8 +251,6 @@ def test_scrape_flattens_identity_and_run_source_into_columns(name, clean_global
     assert row.source == "levanter"
     assert row.run == "r1"
     assert row.job_id == "/a/b" and row.task_index == 3 and row.attempt == 1
-    # run/source are lifted out of the label map and identity is set on the row;
-    # every other global still rides along in the map.
     assert row.labels == {"cluster": "us-central2"}
 
 
@@ -261,11 +264,7 @@ def test_scrape_identity_is_authoritative_over_a_colliding_metric_label(name):
     assert row.labels["worker"] == "evil"  # the raw label survives; the column is authoritative
 
 
-def test_scrape_keeps_a_metrics_own_source_and_run_labels(name, clean_global_labels):
-    # Same guarantee as the identity columns above: the producer's globals own the
-    # `source`/`run` columns, and the metric's own labels of those names survive in
-    # the map. vLLM's `prompt_tokens_by_source` breaks down by a `source` label; if
-    # the globals clobbered it, its series would be indistinguishable once stored.
+def test_scrape_keeps_metric_source_and_run_labels(name, clean_global_labels):
     telltale.counter(name, "d", ["source", "run"]).labels("local_cache_hit", "leg-3").inc(9)
     telltale.set_global_labels(source="vllm", run="serve-1")
 
@@ -275,7 +274,7 @@ def test_scrape_keeps_a_metrics_own_source_and_run_labels(name, clean_global_lab
     assert row.labels == {"source": "local_cache_hit", "run": "leg-3"}
 
 
-def test_scrape_keeps_sibling_series_distinguishable_by_their_own_source_label(name, clean_global_labels):
+def test_scrape_keeps_sibling_series_distinct_by_metric_source(name, clean_global_labels):
     counter = telltale.counter(name, "d", ["source"])
     counter.labels("local_compute").inc(9)
     counter.labels("local_cache_hit").inc(4)
@@ -284,13 +283,10 @@ def test_scrape_keeps_sibling_series_distinguishable_by_their_own_source_label(n
     rows = [r for r in telltale.scrape_metrics(telltale.MetricIdentity(), _TS) if r.name == f"{name}_total"]
 
     assert {r.labels["source"]: r.value for r in rows} == {"local_compute": 9.0, "local_cache_hit": 4.0}
-    assert all(r.source == "vllm" for r in rows)  # the label never reaches the column
+    assert all(r.source == "vllm" for r in rows)
 
 
-def test_scrape_ignores_a_metrics_own_source_and_run_when_the_producer_set_no_globals(clean_global_labels):
-    # The producer names itself; a metric labelling its own series cannot stand in
-    # for that. With no globals set, `source` falls back to the name prefix and
-    # `run` stays empty — both raw labels survive in the map regardless.
+def test_scrape_ignores_metric_source_and_run_without_globals(clean_global_labels):
     telltale.counter("levanter_test_own_identity", "d", ["source", "run"]).labels("evil", "spoofed").inc()
 
     row = _one("levanter_test_own_identity_total", telltale.scrape_metrics(telltale.MetricIdentity(), _TS))
@@ -300,7 +296,7 @@ def test_scrape_ignores_a_metrics_own_source_and_run_when_the_producer_set_no_gl
     assert row.labels == {"source": "evil", "run": "spoofed"}
 
 
-def test_scrape_lets_a_metrics_own_label_win_over_a_global_of_the_same_name(name, clean_global_labels):
+def test_scrape_metric_label_wins_over_global_label(name, clean_global_labels):
     telltale.counter(name, "d", ["cluster"]).labels("us-east-02a").inc()
     telltale.set_global_labels(cluster="us-central2")
 

--- a/lib/rigging/tests/test_telltale.py
+++ b/lib/rigging/tests/test_telltale.py
@@ -221,22 +221,22 @@ def test_status_survives_a_scrape_and_is_replaced_not_appended(client):
 
 
 @pytest.mark.parametrize(
-    ("metric_name", "source_label", "expected"),
+    ("metric_name", "expected"),
     [
-        ("levanter_train_loss", None, "levanter"),
-        ("zephyr_item_count", None, "zephyr"),
-        ("iris_task_reconciles", None, "iris"),
-        ("process_cpu_seconds_total", None, "process"),
-        ("levanter_train_loss", "custom", "custom"),
+        ("levanter_train_loss", "levanter"),
+        ("zephyr_item_count", "zephyr"),
+        ("iris_task_reconciles", "iris"),
+        ("process_cpu_seconds_total", "process"),
+        ("vllm:prompt_tokens_total", "process"),
     ],
 )
-def test_source_prefers_explicit_label_then_name_prefix(metric_name, source_label, expected):
-    assert telltale._source_for(metric_name, source_label) == expected
+def test_source_falls_back_to_the_name_prefix(metric_name, expected):
+    assert telltale._source_from_name(metric_name) == expected
 
 
 def test_scrape_flattens_identity_and_run_source_into_columns(name, clean_global_labels):
     telltale.gauge(name, "d").set(2.0)
-    telltale.set_global_labels(run="r1", source="levanter")
+    telltale.set_global_labels(run="r1", source="levanter", cluster="us-central2")
 
     identity = telltale.MetricIdentity(job_id="/a/b", task_index=3, attempt=1)
     row = _one(name, telltale.scrape_metrics(identity, _TS))
@@ -246,8 +246,9 @@ def test_scrape_flattens_identity_and_run_source_into_columns(name, clean_global
     assert row.source == "levanter"
     assert row.run == "r1"
     assert row.job_id == "/a/b" and row.task_index == 3 and row.attempt == 1
-    # run/source are lifted out of the label map; identity is set on the row.
-    assert row.labels == {}
+    # run/source are lifted out of the label map and identity is set on the row;
+    # every other global still rides along in the map.
+    assert row.labels == {"cluster": "us-central2"}
 
 
 def test_scrape_identity_is_authoritative_over_a_colliding_metric_label(name):
@@ -258,6 +259,54 @@ def test_scrape_identity_is_authoritative_over_a_colliding_metric_label(name):
 
     assert row.worker == "real"
     assert row.labels["worker"] == "evil"  # the raw label survives; the column is authoritative
+
+
+def test_scrape_keeps_a_metrics_own_source_and_run_labels(name, clean_global_labels):
+    # Same guarantee as the identity columns above: the producer's globals own the
+    # `source`/`run` columns, and the metric's own labels of those names survive in
+    # the map. vLLM's `prompt_tokens_by_source` breaks down by a `source` label; if
+    # the globals clobbered it, its series would be indistinguishable once stored.
+    telltale.counter(name, "d", ["source", "run"]).labels("local_cache_hit", "leg-3").inc(9)
+    telltale.set_global_labels(source="vllm", run="serve-1")
+
+    row = _one(f"{name}_total", telltale.scrape_metrics(telltale.MetricIdentity(), _TS))
+
+    assert row.source == "vllm" and row.run == "serve-1"
+    assert row.labels == {"source": "local_cache_hit", "run": "leg-3"}
+
+
+def test_scrape_keeps_sibling_series_distinguishable_by_their_own_source_label(name, clean_global_labels):
+    counter = telltale.counter(name, "d", ["source"])
+    counter.labels("local_compute").inc(9)
+    counter.labels("local_cache_hit").inc(4)
+    telltale.set_global_labels(source="vllm")
+
+    rows = [r for r in telltale.scrape_metrics(telltale.MetricIdentity(), _TS) if r.name == f"{name}_total"]
+
+    assert {r.labels["source"]: r.value for r in rows} == {"local_compute": 9.0, "local_cache_hit": 4.0}
+    assert all(r.source == "vllm" for r in rows)  # the label never reaches the column
+
+
+def test_scrape_ignores_a_metrics_own_source_and_run_when_the_producer_set_no_globals(clean_global_labels):
+    # The producer names itself; a metric labelling its own series cannot stand in
+    # for that. With no globals set, `source` falls back to the name prefix and
+    # `run` stays empty — both raw labels survive in the map regardless.
+    telltale.counter("levanter_test_own_identity", "d", ["source", "run"]).labels("evil", "spoofed").inc()
+
+    row = _one("levanter_test_own_identity_total", telltale.scrape_metrics(telltale.MetricIdentity(), _TS))
+
+    assert row.source == "levanter"
+    assert row.run is None
+    assert row.labels == {"source": "evil", "run": "spoofed"}
+
+
+def test_scrape_lets_a_metrics_own_label_win_over_a_global_of_the_same_name(name, clean_global_labels):
+    telltale.counter(name, "d", ["cluster"]).labels("us-east-02a").inc()
+    telltale.set_global_labels(cluster="us-central2")
+
+    row = _one(f"{name}_total", telltale.scrape_metrics(telltale.MetricIdentity(), _TS))
+
+    assert row.labels == {"cluster": "us-east-02a"}
 
 
 def test_scrape_drops_created_and_keeps_histogram_le_in_the_map(name):


### PR DESCRIPTION
Global labels merged *over* each metric's own labels, so a metric labelling its own
series `source=...` lost that label — twice, since `source`/`run` were then popped into
their typed columns. A colliding global of any other name overwrote it once.

One rule now settles collisions: the producer owns the columns, the metric owns its
label map. `source` and `run` are read from the globals directly and never merged in;
other globals fill only keys the metric does not use.

So a metric's own `source`/`run` no longer fills the column when the producer set no
global one — `source` falls back to the metric-name prefix, `run` stays empty. That
closes a spoofing hole: a scrape landing before a producer set its globals used to stamp
the `source` column from the metric's own label, hiding the row from every
`WHERE source = 'vllm'` query. No in-tree producer declares either label, so nothing
else changes.

The metric affected today is `vllm:prompt_tokens_by_source_total`, whose
`local_compute`/`local_cache_hit`/`external_kv_transfer` split reached finelog as three
rows with identical labels. Sums were always correct, and the historical split stays
derivable from `vllm:prompt_tokens_cached_total` and `vllm:prompt_tokens_total`.

Fixes #7497
