### PR TITLE
[datakit] Write SEC-EDGAR shards through a virtual-host S3 filesystem

### DIFF
--- a/lib/marin/src/marin/datakit/download/sec_edgar.py
+++ b/lib/marin/src/marin/datakit/download/sec_edgar.py
@@ -18,7 +18,7 @@ from rigging.timing import ExponentialBackoff, retry_with_backoff
 from zephyr import counters
 from zephyr.dataset import Dataset
 from zephyr.execution import ZephyrContext
-from zephyr.writers import atomic_rename, ensure_parent_dir
+from zephyr.writers import atomic_rename, ensure_parent_dir, parquet_sink
 
 from marin.datakit.normalize import normalize_step
 from marin.execution.step_spec import StepSpec
@@ -84,12 +84,17 @@ def _download_once(task: _DownloadTask) -> _DownloadResult:
         counters.pipeline.update_counter("sec_edgar/empty_input", 1)
         return _DownloadResult(hf_path=task.hf_path, destination_path=task.destination_path, rows=0)
     with atomic_rename(task.destination_path) as temporary_path:
-        with pq.ParquetWriter(temporary_path, first.schema) as writer:
-            writer.write_batch(first)
-            count += first.num_rows
-            for batch in batches:
-                writer.write_batch(batch)
-                count += batch.num_rows
+        # Route the write through zephyr's sink so the parquet stream reaches a
+        # pyarrow filesystem carrying the S3 endpoint's virtual-host addressing.
+        # A bare s3:// string builds a default path-style client, which CoreWeave
+        # object storage rejects on multipart upload (PathStyleRequestNotAllowed).
+        with parquet_sink(temporary_path) as (where_fd, native_fs):
+            with pq.ParquetWriter(where_fd, first.schema, filesystem=native_fs) as writer:
+                writer.write_batch(first)
+                count += first.num_rows
+                for batch in batches:
+                    writer.write_batch(batch)
+                    count += batch.num_rows
     counters.pipeline.update_counter("sec_edgar/rows_downloaded", count)
     return _DownloadResult(hf_path=task.hf_path, destination_path=task.destination_path, rows=count)
 

--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -260,12 +260,14 @@ def _pyarrow_filesystem(path: str) -> tuple[pa_fs.FileSystem, str] | None:
 
 
 @contextmanager
-def _parquet_sink(temp_path: str):
+def parquet_sink(temp_path: str):
     """Yield ``(where_fd, native_fs)`` for ``pq.ParquetWriter``/``pq.write_table``.
 
     Prefers a native pyarrow filesystem for flat-memory streaming; falls back
     to a buffered fsspec handle (``filesystem=None``) for protocols pyarrow
-    cannot address.
+    cannot address. The native filesystem carries the S3-compatible endpoint's
+    virtual-host addressing (``force_virtual_addressing``), which pyarrow cannot
+    infer from a bare ``s3://`` URI — required for CoreWeave object storage.
     """
     native = _pyarrow_filesystem(temp_path)
     if native is not None:
@@ -299,7 +301,7 @@ def write_parquet_file(
     count = 0
 
     with atomic_rename(output_path) as temp_path:
-        with _parquet_sink(temp_path) as (where_fd, native_fs):
+        with parquet_sink(temp_path) as (where_fd, native_fs):
             writer: pq.ParquetWriter | None = None
             try:
                 for table in _accumulate_tables(records, schema=schema, target_bytes=target_buffer_bytes):


### PR DESCRIPTION
The SEC-EDGAR downloader passed a bare `s3://` string to `pq.ParquetWriter`, so pyarrow built a default S3 client using path-style addressing. CoreWeave object storage only accepts virtual-hosted requests and rejects the multipart upload that large shards trigger (`CreateMultipartUpload` -> HTTP 400 `PathStyleRequestNotAllowed`). The write worked on GCS, where path-style is accepted, so this only surfaced when staging raw datakit sources on CoreWeave S3.

Route the write through zephyr's `parquet_sink`, which resolves a native pyarrow filesystem carrying the endpoint's `force_virtual_addressing`. Promote the helper from `_parquet_sink` to `parquet_sink` for reuse outside the module. Verified against `s3://marin-us-east-02a` on cw-rno2a: the path-style rejection is gone and shards upload.
