### PR TITLE
Disable automated prose cleanup

### DIFF
--- a/.github/workflows/ops-agent-prose-cleanup.yaml
+++ b/.github/workflows/ops-agent-prose-cleanup.yaml
@@ -1,4 +1,4 @@
-name: "Ops - Agent Prose Cleanup"
+name: "Ops - Agent Prose Cleanup (disabled)"
 
 on:
   issues:
@@ -12,9 +12,7 @@ concurrency:
 
 jobs:
   rewrite:
-    if: >-
-      (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'agent-generated')) ||
-      (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'agent-generated'))
+    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/ops-agent-prose-cleanup.yaml
+++ b/.github/workflows/ops-agent-prose-cleanup.yaml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   rewrite:
+    # Re-enable only after the marin-style cleanup action is reviewed. Owner: Marin maintainers.
     if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
Disable Marin's legacy prose-cleanup workflow. Its automated edits to agent-generated issue and pull request descriptions are causing unwanted changes. The workflow stays in place so it can be re-enabled later, and will not run until the marin-style cleanup action is reviewed.

---
[Original description](https://github.com/marin-community/marin/pull/7509#issuecomment-5049558378) <!-- marin-prose-cleanup -->