### PR TITLE
[iris] Add portable diagnostic metadata

### DIFF
--- a/.agents/projects/iris_scripts_port_scope.md
+++ b/.agents/projects/iris_scripts_port_scope.md
@@ -1,0 +1,247 @@
+# Iris operational scripts port scope
+
+## Decision
+
+Port the functionality, not the current script boundary. The OpenThoughts-Agent
+directory contains 14 in-scope executable files. `launch_external_opencode_eval.py`
+is deferred pending a native Marin Harbor evaluation configuration, and
+`patch_tpu_inference.py` must be solved in an upstream or pinned fork. The 14
+remaining scripts combine three layers
+that should not remain coupled:
+
+1. generic Iris lifecycle, Finelog, bundle, and CoreWeave-pod collection;
+2. Marin-owned RL and Harbor result semantics; and
+3. OpenThoughts launch conventions, hard-coded model locations, and secret files.
+
+The first layer belongs in `marin-iris`; the second belongs in `marin-core`;
+the third must be replaced by explicit Marin configuration or retired. No ported
+module may depend on `/Users/benjaminfeuer/...`, invoke a second `iris` binary,
+read a kubeconfig selected by `KUBECONFIG`, or decode `iris-task-env` from
+Kubernetes.
+
+## Base and target layout
+
+This scope was prepared from Marin `main` at
+`b22baf7b5bd5298faa2e944d8072ffed260f4561`.
+
+```text
+lib/iris/src/iris/
+  diagnostics/
+    __init__.py
+    bundles.py             # stable local evidence bundle format
+    jobs.py                # typed job inventory, lifecycle, retry policy
+    finelog.py             # complete log acquisition and coverage checks
+    coreweave.py           # configured K8s/S3 artifact collection
+  cli/
+    job.py                 # `iris job list`, `summary`, and new `watch` surface
+    diagnostics.py         # `iris diagnostics ...` commands
+
+lib/marin/src/marin/
+  rl/iris_diagnostics.py             # RL progress and completed-run analysis
+  evaluation/harbor_diagnostics.py   # Harbor/datagen/eval progress and analysis
+  model_mirror.py                    # portable object-store mirror library
+  cli/diagnostics.py                 # Marin-owned CLI wiring, if a top-level
+                                     # `marin` command is introduced
+```
+
+`iris.diagnostics` is deliberately a client-side package: it reads existing
+controller, Finelog, Kubernetes, and object-store state. It is not controller
+logic, does not add schema columns, and does not alter task lifecycle.
+
+## Inventory and exact disposition
+
+| OpenThoughts source | Current responsibility | Marin destination | Disposition |
+|---|---|---|---|
+| `scripts/iris/iris_ops.py` | shell-based lifecycle polling; DNS retry; local manifest location | `iris.diagnostics.jobs`, `iris.diagnostics.bundles`, `iris.cli.job` | Port the typed state/bundle contract; replace subprocess calls with `connect_controller()` and `IrisClient`; add `iris job watch`. |
+| `scripts/iris/list_iris_jobs.py` | one-user recent-job table; job-name heuristic | `iris.cli.job:list_jobs` | Extend the existing native command with `--user`, `--since`, JSON/CSV output and a stable table. Do not preserve the workload-type name heuristic in Iris. |
+| `scripts/iris/coreweave_ops.py` | pod discovery, task/Ray/vLLM log capture, S3 trial copy, transient kubectl retry | `iris.diagnostics.coreweave` | Port as a configured collector built on `CloudK8sService`; use the cluster's pinned `kubeconfig_path`/context and a caller-provided object-store client. Delete secret decoding from `iris-task-env`. |
+| `scripts/iris/watch_coreweave_rl.py` | active CoreWeave RL discovery, Finelog/pod/Ray sync, newest-500 `trace_jobs`, RL metrics table | `marin.rl.iris_diagnostics` using `iris.diagnostics.*` | Port as `marin rl iris-watch` or `iris diagnostics rl`; preserve the fleet-wide recent-trace policy and manifest. Move SkyRL/Harbor parsing out of Iris. |
+| `scripts/iris/analyze_coreweave_rl_job.py` | resync/read shared RL evidence bundle and summarize it | `marin.rl.iris_diagnostics` | Fold into the same module as a completed-run subcommand. It must work from an existing bundle when a remote resync is unavailable. |
+| `scripts/iris/analyze_coreweave_rl_job_live.sh` | 559-line live `kubectl` inspection shell | `marin.rl.iris_diagnostics` | Replace with explicit Python subcommands over the collector: summary, list, show trial, grep artifacts, pull selected trial, and flight-recorder capture. Retire the shell script after parity tests. |
+| `scripts/iris/watch_iris_harbor.py` | active Harbor datagen/eval discovery across TPU and CoreWeave; results, mean, error count, Finelog and Ray/vLLM sync | `marin.evaluation.harbor_diagnostics` using `iris.diagnostics.*` | Port. It understands `run_tracegen.py`, `result.json`, and `exception.txt`, so it belongs with Marin's existing Harbor evaluator, not Iris. |
+| `scripts/iris/analyze_iris_harbor_job.py` | complete Finelog acquisition through compaction; throughput/preemption/stage analysis; Harbor trial analysis | `iris.diagnostics.finelog` plus `marin.evaluation.harbor_diagnostics` | Split. Generic Finelog paging, deduplication and coverage become Iris code; Harbor line parsing, output layout, result and exception analysis remain Marin evaluation code. |
+| `scripts/iris/analyze_iris_harbor_job_live.sh` | thin live watcher wrapper | command alias only | Delete after the Harbor watcher command exists. No separate implementation. |
+| `scripts/iris/mirror_models.py` | route dispatch for HF→GCS, GCS→S3, HF→S3 | `marin.model_mirror` | Port as library routing plus a typed CLI. |
+| `scripts/iris/mirror_hf_to_gcs.py` | resumable Hub model fan-out to GCS | `marin.model_mirror` | Port algorithm after making destination prefixes explicit configuration. Reuse `gcsfs`/`huggingface_hub`; centralize the include manifest. |
+| `scripts/iris/mirror_gcs_to_s3.py` | resumable GCS→S3 transfer | `marin.model_mirror` | Port behind configured source/destination clients. Retain one-file-at-a-time transfer and terminal manifest. |
+| `scripts/iris/mirror_hf_to_s3.py` | resumable in-cluster Hub→CoreWeave S3 transfer | `marin.model_mirror` | Port with the same configured S3 client. Keep it runnable in a CoreWeave task; do not infer credentials from an operator laptop. |
+| `scripts/iris/launch_mirror.py` | OpenThoughts `IrisLauncher` submission wrappers for the two GCS routes | `marin.model_mirror` plus an Iris submit helper | Replace rather than copy. The implementation must build an `IrisClient.submit` request and use config-defined resources/images; it cannot import OpenThoughts `hpc.iris_launch_utils`. |
+
+## Existing Marin capabilities to reuse
+
+| Need | Existing capability | Required change |
+|---|---|---|
+| Controller access and credentials | `iris.cli.connect.connect_controller`, `IrisClient`, `iris job list/summary/logs` | Diagnostics calls these APIs directly instead of launching a second `iris` executable. |
+| CoreWeave cluster selection | `IrisClusterConfig`, `CloudK8sService`, `lib/iris/config/*.yaml` | Read `kubeconfig_path` and `kube_context` from the selected cluster config. This fixes the stale `KUBECONFIG` class of failure centrally. |
+| Kubernetes reads/exec/logs | `K8sService` protocol and `CloudK8sService` | Add only the read-only artifact operations the collector needs; preserve fakes at this protocol boundary. |
+| Object-store configuration | `configure_client_s3`, `s3fs`, `gcsfs` | Create a single explicit diagnostic storage factory. It receives operator credentials from normal configuration; it must not read Kubernetes Secrets. |
+| Finelog | `marin-finelog`, `LogClient`, deploy config utilities | Extract complete log acquisition into `iris.diagnostics.finelog`; keep compaction-race retries bounded and observable. |
+| Harbor result semantics | `marin.evaluation.evaluators.harbor_evaluator` | Reuse its `result.json` conventions and make shared result/error parsing a public small helper. |
+| Object-store evaluation records | `marin.evaluation.records` | Write a portable terminal summary record for successful and failed Harbor analysis instead of only a local report. |
+
+## Dependencies that must move or disappear
+
+### Direct OpenThoughts imports
+
+`analyze_iris_harbor_job.py` imports
+`hpc.iris.job_output_resolver.resolve_job_output_dir`. Its GCS-only output
+resolver is a Harbor launch convention. Recreate it as a narrow
+`marin.evaluation.harbor_diagnostics.resolve_output_uri()` that first consumes
+the Iris job's recorded entrypoint/environment and then accepts an explicit
+override. It must support both `gs://` and `s3://` through fsspec and never
+consult an OpenThoughts local SQLite registry.
+
+`launch_mirror.py` imports OpenThoughts `IrisLauncher` and `PROJECT_ROOT`.
+Replace it with `connect_controller()` plus `IrisClient.submit`; resources,
+image, destinations and target cluster become typed command/config options.
+
+`hpc.iris.precache` dynamically imports `mirror_hf_to_gcs` and documents the
+old command. It is a caller that must migrate to `marin.model_mirror`, then
+be removed from the OpenThoughts dependency graph once its launchers have
+moved. `hpc.model_mirror_registry` is likewise an application-local catalog;
+do not copy it until Marin decides whether its object manifests belong in a
+registry or are queried directly.
+
+### Third-party dependencies
+
+`marin-iris` already owns `marin-finelog`, `fsspec`, `gcsfs`, `s3fs`,
+Kubernetes support, and `tabulate`. `marin-core` already owns the Harbor
+extra and Hugging Face Hub through its existing extras. Avoid a new `boto3`
+dependency unless an S3 operation cannot be expressed through the existing
+configured filesystem; the current scripts use boto3 chiefly because they
+manually recover task credentials.
+
+`duckdb` is already a Finelog dependency. Keep it inside the Finelog-specific
+module rather than making it an Iris controller dependency.
+
+## Unsafe assumptions to remove before any port
+
+- `/Users/benjaminfeuer/Documents/...` for Marin source, evidence bundles,
+  config paths, task images and the `iris` executable.
+- Fixed user `benjaminfeuer`, fixed CoreWeave buckets, and two historical
+  kubeconfig paths. Cluster config is the source of truth.
+- `KUBECONFIG` inheritance. CoreWeave operations must bind the selected
+  cluster's configured path and context.
+- Reading the `iris-task-env` Secret with `kubectl`, base64-decoding AWS
+  credentials, and writing/using them on the launch host. This violates the
+  task-secret boundary. Operator-side collection requires explicitly provided
+  operator credentials, or an in-cluster collector task with a constrained
+  output contract.
+- `--secrets-env` and plaintext secret-file parsing. Secret values should use
+  `EnvironmentSpec.env_vars` or cluster `inject_env`; token-bearing URLs must
+  never appear in argv, manifests, logs, or reports.
+- Parsing arbitrary shell entrypoints as the primary interface. Keep a
+  bounded legacy parser for historical runs, but new Marin Harbor/RL launch
+  records must write typed diagnostic metadata (dataset, output URI, trial
+  count, serving endpoint, and workload kind) at submission.
+- The runtime file-rewrite patch for `tpu-inference`, including its broad
+  `except Exception`. The real fix is a versioned upstream dependency.
+
+## Phased implementation plan
+
+### Phase 1: typed Iris diagnostic substrate
+
+Add `iris.diagnostics.bundles` and `iris.diagnostics.jobs` with a versioned
+manifest schema and a `JobRef(cluster, JobName)` key. The default root is a
+user cache directory (for example `~/.cache/marin/iris/jobs`), while every
+command accepts `--bundle-root`. Preserve the current stable layout:
+
+```text
+<root>/jobs/<cluster>/<user>/<job>/manifest.json
+```
+
+Implement controller operations through `connect_controller`/`IrisClient`:
+job list, summary, task log fetch, lifecycle polling, and retry classification.
+Use `rigging.timing.Deadline`/`ExponentialBackoff`; distinguish a retry-exhausted
+transport error from a terminal job state. Add `iris job watch <job>` and extend
+`iris job list` rather than add a second inventory script.
+
+Tests in `lib/iris/tests/cli/test_job.py` and a new
+`lib/iris/tests/diagnostics/test_bundles.py` should cover canonical bundle
+paths, invalid non-root IDs, listing filters, terminal state transitions, and
+retry exhaustion with fake controller transport.
+
+### Phase 2: read-only CoreWeave artifact collector
+
+Add `iris.diagnostics.coreweave` on top of `K8sService`. It finds a task pod by
+Iris labels/job metadata rather than substring matching, gets task and Ray/vLLM
+logs, safely extracts a streamed tar archive, and records collection failures
+without inserting HTML proxy pages into the status table. Keep the 100 MiB log
+and 20 MiB non-log bounds configurable.
+
+Add configured S3/GCS artifact listing and selected-trial copying. The collector
+must take a filesystem/client provided by a storage factory; it cannot obtain
+credentials from a pod secret. Define a clear unavailable-artifacts outcome
+when the invoking principal lacks object-store credentials.
+
+Tests in `lib/iris/tests/diagnostics/test_coreweave.py` should use a fake
+`K8sService`, in-memory tar streams, and a fake filesystem. Cover an empty tar,
+one retryable transport failure, safe relative paths, no token/secret output,
+and the most-recent-N selection by object modification time.
+
+### Phase 3: Marin RL and Harbor analyzers
+
+Move the RL watcher and both RL analyzers into
+`marin.rl.iris_diagnostics`. It owns RL command/metric patterns and
+`trace_jobs`; it consumes only typed bundles and the Phase 2 collector. Its
+default must retain the fleet-wide most-recent 500 traces and emit selected,
+available, completed, and omitted counts in the bundle manifest.
+
+Split `analyze_iris_harbor_job.py` before moving it:
+
+- Finelog segment pagination, live/GCS merge, de-duplication, and coverage
+  checks move to `iris.diagnostics.finelog`.
+- Harbor trial discovery, `result.json` mean/error extraction,
+  `exception.txt` frequency, task totals, stage quantiles, throughput, and
+  preemption report move to `marin.evaluation.harbor_diagnostics`.
+
+`watch_iris_harbor.py` becomes the active-job mode of that same Harbor module.
+It must report dataset, completed/total/remaining, mean for direct results,
+error counts from both `result.json` and `exception.txt`, Finelog state, Ray/vLLM
+state, and trend. It must route controller requests through the Phase 1 retry
+policy.
+
+Port behavior tests from OpenThoughts into focused tests under
+`lib/marin/tests/rl/` and `lib/marin/tests/evaluation/`, using fixture bundles
+and fake filesystems. Do not retain tests that assert command-string assembly.
+
+### Phase 4: mirror launch behavior
+
+Implement `marin.model_mirror` with a typed `MirrorRoute` and a shared file
+selection/manifest implementation. Destination URIs are explicit CLI/config
+values; the two historical multi-region GCS defaults are not library defaults.
+Add an optional `marin[mirror]` extra only if `huggingface-hub` cannot be made
+available from an already-selected Marin extra. Submit mirror work via a small
+Iris-client launcher, with an in-cluster route for CoreWeave S3.
+
+Tests verify resumability using a fake Hub/filesystems, manifest-last behavior,
+and route validation.
+
+### Phase 5: cutover and deletion
+
+Update launcher call sites and operational docs first. Run the new diagnostics
+alongside the existing OpenThoughts watchers for one active CoreWeave RL job and
+one Harbor TPU job, compare counts/means/error totals/artifact manifests, then
+switch cron/monitor invocations.
+
+After parity is demonstrated, remove all 14 in-scope OpenThoughts scripts, their Iris
+tests, references in `scripts/README.md`, `.agents/ops/iris/ops.md`, and
+OpenThoughts `hpc.iris.precache` imports. Delete the two shell wrappers rather
+than retaining compatibility aliases. The excluded external-endpoint launcher
+and TPU patch follow separate native-eval and upstream/fork workstreams.
+
+## Acceptance criteria
+
+- `iris job list` and `iris job watch` function from any supported local host
+  without `IRIS_BIN`, `MARIN_MAIN_ROOT`, or `KUBECONFIG` overrides.
+- Every monitor/analyzer addresses the same bundle for `(cluster, full root
+  job id)` and can analyze an existing bundle when remote collection is absent.
+- A CoreWeave bundle records Finelog, pod/Ray/vLLM collection outcomes and a
+bounded, provenance-bearing trace selection without exposing object-store
+credentials.
+- Harbor reports agree with direct `result.json` and `exception.txt` fixtures,
+including completed/remaining counts, mean reward, and grouped errors.
+- Controller and Kubernetes transport retries are bounded, surfaced as
+collection errors after exhaustion, and never mistaken for a job failure.
+- No OpenThoughts import, absolute user path, user-specific bucket default,
+secret-file parser, or runtime third-party source patch remains in Marin.

--- a/lib/iris/src/iris/client/client.py
+++ b/lib/iris/src/iris/client/client.py
@@ -58,6 +58,7 @@ from iris.cluster.types import (
     adjust_tpu_replicas,
     is_job_finished,
 )
+from iris.diagnostics.metadata import DiagnosticJobMetadata, attach_diagnostic_metadata
 from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.proto_display import job_state_friendly
 from iris.time_proto import timestamp_from_proto
@@ -629,6 +630,7 @@ class IrisClient:
         priority_band: job_pb2.PriorityBand = job_pb2.PRIORITY_BAND_UNSPECIFIED,
         container_profile: job_pb2.ContainerProfile = job_pb2.CONTAINER_PROFILE_UNSPECIFIED,
         submit_argv: list[str] | None = None,
+        diagnostic_metadata: DiagnosticJobMetadata | None = None,
     ) -> Job:
         """Submit a job with automatic job_id hierarchy.
 
@@ -658,6 +660,8 @@ class IrisClient:
             container_profile: Container security profile. UNSPECIFIED resolves to
                 DEFAULT. Elevated profiles (DOCKER_ACCESS, PRIVILEGED) require the
                 admin role at submission when auth is enabled.
+            diagnostic_metadata: Typed workload metadata persisted with the job's
+                explicit environment for portable diagnostic tooling.
 
         Returns:
             Job handle for the submitted job
@@ -744,6 +748,9 @@ class IrisClient:
         # attribute. Stripping here keeps the controller's matching paths unaware of it.
         if constraints:
             constraints = [c for c in constraints if not is_any_region_marker(c)]
+
+        if diagnostic_metadata is not None:
+            environment = attach_diagnostic_metadata(environment, diagnostic_metadata)
 
         # Convert to wire format
         resources_proto = resources.to_proto()

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -462,6 +462,16 @@ class StorageConfig(_Config):
     remote_state_dir: str = ""  # remote URI for checkpoints + worker profiles
 
 
+class DiagnosticsConfig(_Config):
+    """Remote evidence storage for client-side job diagnostics.
+
+    An empty value disables automatic evidence-location construction. Workloads
+    still carry their own typed artifact URI in diagnostic metadata.
+    """
+
+    evidence_root: str = ""
+
+
 class GcpControllerConfig(_Config):
     zone: str = ""
     machine_type: str = ""  # default: "n2-standard-4"
@@ -755,6 +765,7 @@ class IrisClusterConfig(_OneofConfig):
     platform: PlatformConfig = Field(default_factory=PlatformConfig)
     defaults: DefaultsConfig = Field(default_factory=DefaultsConfig)
     storage: StorageConfig = Field(default_factory=StorageConfig)
+    diagnostics: DiagnosticsConfig = Field(default_factory=DiagnosticsConfig)
     controller: ControllerVmConfig = Field(default_factory=ControllerVmConfig)
     scale_groups: dict[str, ScaleGroupConfig] = Field(default_factory=dict)
     auth: AuthConfig | None = None

--- a/lib/iris/src/iris/diagnostics/__init__.py
+++ b/lib/iris/src/iris/diagnostics/__init__.py
@@ -1,0 +1,7 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed client-side contracts for Iris job diagnostics."""
+
+from iris.diagnostics.metadata import DiagnosticJobMetadata, DiagnosticWorkloadKind
+from iris.diagnostics.resolution import DiagnosticCluster, resolve_diagnostic_artifact

--- a/lib/iris/src/iris/diagnostics/metadata.py
+++ b/lib/iris/src/iris/diagnostics/metadata.py
@@ -1,0 +1,159 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Versioned job metadata for portable diagnostic tooling."""
+
+import json
+from dataclasses import asdict, dataclass, replace
+from enum import StrEnum
+from urllib.parse import urlparse
+
+from iris.cluster.types import EnvironmentSpec
+
+DIAGNOSTIC_METADATA_ENV = "IRIS_DIAGNOSTIC_METADATA"
+DIAGNOSTIC_METADATA_VERSION = 1
+_ARTIFACT_SCHEMES = frozenset(("gs", "s3"))
+
+
+class DiagnosticWorkloadKind(StrEnum):
+    """Workload families supported by the diagnostic clients."""
+
+    DATAGEN = "datagen"
+    EVAL = "eval"
+    MIRROR = "mirror"
+    RL = "rl"
+    SERVE = "serve"
+    OTHER = "other"
+
+
+def validate_artifact_uri(value: str) -> str:
+    """Validate and normalize an object-store artifact URI."""
+    uri = value.strip().rstrip("/")
+    parsed = urlparse(uri)
+    if parsed.scheme not in _ARTIFACT_SCHEMES or not parsed.netloc:
+        schemes = ", ".join(sorted(_ARTIFACT_SCHEMES))
+        raise ValueError(f"Artifact URI must use one of {schemes}: {value!r}")
+    return uri
+
+
+def _optional_text(name: str, value: str | None) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string when provided")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{name} must be non-empty when provided")
+    return normalized
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosticJobMetadata:
+    """Stable metadata emitted with a newly submitted diagnosable job.
+
+    The JSON representation is stored in the submitted job's explicit
+    environment configuration. Iris persists that configuration with the job,
+    and the task receives the same value without relying on a launch-host path
+    or secret file.
+    """
+
+    workload_kind: DiagnosticWorkloadKind
+    dataset: str | None = None
+    artifact_uri: str | None = None
+    total_trials: int | None = None
+    serving_endpoint: str | None = None
+    model_identifier: str | None = None
+    schema_version: int = DIAGNOSTIC_METADATA_VERSION
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.workload_kind, DiagnosticWorkloadKind):
+            raise ValueError("workload_kind must be a DiagnosticWorkloadKind")
+        if self.schema_version != DIAGNOSTIC_METADATA_VERSION:
+            raise ValueError(
+                f"Unsupported diagnostic metadata schema version {self.schema_version}; "
+                f"expected {DIAGNOSTIC_METADATA_VERSION}"
+            )
+        object.__setattr__(self, "dataset", _optional_text("dataset", self.dataset))
+        object.__setattr__(self, "serving_endpoint", _optional_text("serving_endpoint", self.serving_endpoint))
+        object.__setattr__(self, "model_identifier", _optional_text("model_identifier", self.model_identifier))
+        if self.artifact_uri is not None:
+            object.__setattr__(self, "artifact_uri", validate_artifact_uri(self.artifact_uri))
+        if self.total_trials is not None and (
+            isinstance(self.total_trials, bool) or not isinstance(self.total_trials, int) or self.total_trials < 0
+        ):
+            raise ValueError("total_trials must be a non-negative integer when provided")
+
+    def to_json(self) -> str:
+        """Encode the contract as canonical JSON for the submitted environment."""
+        payload = asdict(self)
+        payload["workload_kind"] = self.workload_kind.value
+        return json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+    @classmethod
+    def from_json(cls, value: str) -> "DiagnosticJobMetadata":
+        """Decode one metadata value, rejecting unknown or malformed fields."""
+        try:
+            payload = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Diagnostic metadata is not valid JSON") from exc
+        if not isinstance(payload, dict):
+            raise ValueError("Diagnostic metadata must be a JSON object")
+        expected = {
+            "artifact_uri",
+            "dataset",
+            "model_identifier",
+            "schema_version",
+            "serving_endpoint",
+            "total_trials",
+            "workload_kind",
+        }
+        unknown = set(payload) - expected
+        if unknown:
+            raise ValueError(f"Diagnostic metadata has unknown fields: {', '.join(sorted(unknown))}")
+        try:
+            workload_kind = DiagnosticWorkloadKind(payload["workload_kind"])
+        except KeyError as exc:
+            raise ValueError("Diagnostic metadata is missing workload_kind") from exc
+        except ValueError as exc:
+            raise ValueError(f"Unknown diagnostic workload kind {payload.get('workload_kind')!r}") from exc
+        total_trials = payload.get("total_trials")
+        if total_trials is not None and (isinstance(total_trials, bool) or not isinstance(total_trials, int)):
+            raise ValueError("total_trials must be an integer when provided")
+        schema_version = payload.get("schema_version")
+        if isinstance(schema_version, bool) or not isinstance(schema_version, int):
+            raise ValueError("schema_version must be an integer")
+        return cls(
+            workload_kind=workload_kind,
+            dataset=payload.get("dataset"),
+            artifact_uri=payload.get("artifact_uri"),
+            total_trials=total_trials,
+            serving_endpoint=payload.get("serving_endpoint"),
+            model_identifier=payload.get("model_identifier"),
+            schema_version=schema_version,
+        )
+
+
+def attach_diagnostic_metadata(
+    environment: EnvironmentSpec | None,
+    metadata: DiagnosticJobMetadata,
+) -> EnvironmentSpec:
+    """Return an environment that persists one diagnostic metadata contract."""
+    env_vars = dict(environment.env_vars) if environment and environment.env_vars else {}
+    encoded = metadata.to_json()
+    existing = env_vars.get(DIAGNOSTIC_METADATA_ENV)
+    if existing is not None and existing != encoded:
+        raise ValueError(f"{DIAGNOSTIC_METADATA_ENV} is already set to different metadata")
+    env_vars[DIAGNOSTIC_METADATA_ENV] = encoded
+    if environment is None:
+        return EnvironmentSpec(env_vars=env_vars)
+    return replace(environment, env_vars=env_vars)
+
+
+def metadata_from_environment(environment: dict[str, str] | None) -> DiagnosticJobMetadata | None:
+    """Read typed diagnostic metadata from persisted explicit environment variables."""
+    if environment is None:
+        return None
+    value = environment.get(DIAGNOSTIC_METADATA_ENV)
+    if value is None:
+        return None
+    return DiagnosticJobMetadata.from_json(value)

--- a/lib/iris/src/iris/diagnostics/resolution.py
+++ b/lib/iris/src/iris/diagnostics/resolution.py
@@ -1,0 +1,111 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve diagnostic storage and legacy artifact locations from cluster configuration."""
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from iris.cluster.config import IrisClusterConfig
+from iris.cluster.types import JobName
+from iris.diagnostics.metadata import DiagnosticJobMetadata, validate_artifact_uri
+
+
+class DiagnosticArtifactSource(StrEnum):
+    """How an artifact URI was determined."""
+
+    EXPLICIT = "explicit"
+    METADATA = "metadata"
+    LEGACY = "legacy"
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosticCluster:
+    """The diagnostic-relevant, configuration-derived cluster settings."""
+
+    name: str
+    evidence_root: str | None
+    namespace: str | None
+    kubeconfig_path: Path | None
+    kube_context: str | None
+
+    @classmethod
+    def from_config(cls, config: IrisClusterConfig) -> "DiagnosticCluster":
+        evidence_root = config.diagnostics.evidence_root or None
+        if evidence_root is not None:
+            evidence_root = validate_artifact_uri(evidence_root)
+        coreweave = config.platform.coreweave
+        if coreweave is None:
+            return cls(config.name, evidence_root, None, None, None)
+        kubeconfig_path = Path(coreweave.kubeconfig_path).expanduser() if coreweave.kubeconfig_path else None
+        namespace = coreweave.namespace or None
+        kube_context = coreweave.kube_context or None
+        return cls(config.name, evidence_root, namespace, kubeconfig_path, kube_context)
+
+    def evidence_uri(self, job_id: JobName) -> str | None:
+        """Return this root job's configured remote evidence location, if any."""
+        if self.evidence_root is None:
+            return None
+        if not job_id.is_root:
+            raise ValueError(f"Diagnostic evidence is keyed by root jobs, got {job_id}")
+        return f"{self.evidence_root}/jobs/{self.name}/{job_id.user}/{job_id.name}"
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedDiagnosticArtifact:
+    """One resolved artifact URI and the authority that supplied it."""
+
+    uri: str
+    source: DiagnosticArtifactSource
+
+
+_LEGACY_ARTIFACT_PATTERNS = (
+    re.compile(r"(?:--harbor_extra_arg=)?--jobs-dir(?:=|\s+)(?P<uri>(?:s3|gs)://[^\s'\"\\]+)"),
+    re.compile(r"(?:--trials-dir|--experiments_dir|--gcs-output-dir)(?:=|\s+)(?P<uri>(?:s3|gs)://[^\s'\"\\]+)"),
+)
+
+
+def infer_legacy_artifact_uri(entrypoint: str) -> str | None:
+    """Infer an OpenThoughts-era artifact URI from a historical command string.
+
+    This parser is intentionally isolated from normal resolution. New
+    submissions must provide :class:`DiagnosticJobMetadata` instead.
+    """
+    for pattern in _LEGACY_ARTIFACT_PATTERNS:
+        match = pattern.search(entrypoint)
+        if match is not None:
+            return validate_artifact_uri(match.group("uri"))
+    return None
+
+
+def resolve_diagnostic_artifact(
+    metadata: DiagnosticJobMetadata | None,
+    *,
+    artifact_uri_override: str | None = None,
+    legacy_entrypoint: str | None = None,
+    allow_legacy: bool = False,
+) -> ResolvedDiagnosticArtifact:
+    """Resolve an artifact URI with explicit input, typed metadata, then opt-in legacy parsing.
+
+    Legacy command parsing is unavailable when typed metadata exists, even if
+    that metadata has no artifact URI. This prevents historical heuristics from
+    overriding an intentional modern submission contract.
+    """
+    if artifact_uri_override is not None:
+        return ResolvedDiagnosticArtifact(
+            validate_artifact_uri(artifact_uri_override), DiagnosticArtifactSource.EXPLICIT
+        )
+    if metadata is not None:
+        if metadata.artifact_uri is None:
+            raise LookupError("Diagnostic metadata has no artifact_uri; pass an explicit artifact URI override")
+        return ResolvedDiagnosticArtifact(metadata.artifact_uri, DiagnosticArtifactSource.METADATA)
+    if allow_legacy and legacy_entrypoint is not None:
+        uri = infer_legacy_artifact_uri(legacy_entrypoint)
+        if uri is not None:
+            return ResolvedDiagnosticArtifact(uri, DiagnosticArtifactSource.LEGACY)
+    raise LookupError(
+        "No diagnostic artifact URI is available. Submit typed metadata, pass an explicit artifact URI override, "
+        "or opt into legacy entrypoint parsing for a historical OpenThoughts job."
+    )

--- a/lib/iris/tests/cluster/test_env_propagation.py
+++ b/lib/iris/tests/cluster/test_env_propagation.py
@@ -18,6 +18,7 @@ from iris.client import IrisClient, IrisContext, iris_ctx_scope
 from iris.cluster.client.job_info import JobInfo
 from iris.cluster.constraints import Constraint, ConstraintOp, WellKnownAttribute, any_region_constraint
 from iris.cluster.types import Entrypoint, EnvironmentSpec, JobName, ResourceSpec
+from iris.diagnostics.metadata import DiagnosticJobMetadata, DiagnosticWorkloadKind, metadata_from_environment
 
 
 def dummy_entrypoint():
@@ -120,6 +121,23 @@ def test_no_env_inheritance_without_parent_context(capturing_client):
     client.submit(entrypoint, "no-parent-test", resources)
 
     assert stub.captured_env == {}
+
+
+def test_submit_persists_diagnostic_metadata_in_explicit_environment(capturing_client):
+    client, stub = capturing_client
+    metadata = DiagnosticJobMetadata(
+        workload_kind=DiagnosticWorkloadKind.RL,
+        artifact_uri="s3://marin-us-east-02a/rl/run-1",
+    )
+
+    client.submit(
+        Entrypoint.from_callable(dummy_entrypoint),
+        "diagnostic-metadata",
+        ResourceSpec(cpu=1, memory="1g"),
+        diagnostic_metadata=metadata,
+    )
+
+    assert metadata_from_environment(stub.captured_env) == metadata
 
 
 def test_child_job_inherits_parent_constraints(capturing_client, parent_context):

--- a/lib/iris/tests/diagnostics/test_metadata.py
+++ b/lib/iris/tests/diagnostics/test_metadata.py
@@ -1,0 +1,96 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavioral tests for the portable diagnostic metadata boundary."""
+
+import pytest
+from iris.cluster.config import CoreweavePlatformConfig, DiagnosticsConfig, IrisClusterConfig, PlatformConfig
+from iris.cluster.types import EnvironmentSpec, JobName
+from iris.diagnostics.metadata import (
+    DiagnosticJobMetadata,
+    DiagnosticWorkloadKind,
+    attach_diagnostic_metadata,
+    metadata_from_environment,
+)
+from iris.diagnostics.resolution import DiagnosticArtifactSource, DiagnosticCluster, resolve_diagnostic_artifact
+
+
+def test_diagnostic_metadata_round_trips_through_explicit_environment():
+    """Metadata uses the submit environment rather than local launch-host state."""
+    metadata = DiagnosticJobMetadata(
+        workload_kind=DiagnosticWorkloadKind.DATAGEN,
+        dataset="DCAgent/code-contests-noblock",
+        artifact_uri="s3://marin-us-east-02a/harbor/glm52-r10",
+        total_trials=8728,
+        serving_endpoint="/benjaminfeuer/glm52",
+        model_identifier="vllm/laion/glm-5.2-awq",
+    )
+
+    environment = attach_diagnostic_metadata(EnvironmentSpec(env_vars={"UNCHANGED": "yes"}), metadata)
+
+    assert environment.env_vars["UNCHANGED"] == "yes"
+    assert metadata_from_environment(environment.env_vars) == metadata
+
+
+def test_diagnostic_cluster_uses_configured_coreweave_context_not_kubeconfig_environment(monkeypatch):
+    monkeypatch.setenv("KUBECONFIG", "/stale/kubeconfig")
+    config = IrisClusterConfig(
+        name="cw-rno2a",
+        diagnostics=DiagnosticsConfig(evidence_root="s3://diagnostics/evidence"),
+        platform=PlatformConfig(
+            coreweave=CoreweavePlatformConfig(
+                namespace="iris",
+                kubeconfig_path="~/configured-kubeconfig",
+                kube_context="marin-rn02a_RNO2A",
+            )
+        ),
+    )
+
+    cluster = DiagnosticCluster.from_config(config)
+
+    assert cluster.namespace == "iris"
+    assert cluster.kubeconfig_path is not None
+    assert cluster.kubeconfig_path.name == "configured-kubeconfig"
+    assert cluster.kube_context == "marin-rn02a_RNO2A"
+    assert cluster.evidence_uri(JobName.root("alice", "run-1")) == "s3://diagnostics/evidence/jobs/cw-rno2a/alice/run-1"
+
+
+def test_artifact_resolution_prefers_explicit_uri_and_gates_legacy_inference():
+    legacy_entrypoint = "python run_tracegen.py --jobs-dir gs://legacy-bucket/jobs/run-1"
+    metadata = DiagnosticJobMetadata(
+        workload_kind=DiagnosticWorkloadKind.EVAL,
+        artifact_uri="gs://typed-bucket/jobs/run-1",
+    )
+
+    explicit = resolve_diagnostic_artifact(
+        metadata,
+        artifact_uri_override="s3://override-bucket/results/run-1",
+        legacy_entrypoint=legacy_entrypoint,
+        allow_legacy=True,
+    )
+    typed = resolve_diagnostic_artifact(metadata, legacy_entrypoint=legacy_entrypoint, allow_legacy=True)
+    legacy = resolve_diagnostic_artifact(None, legacy_entrypoint=legacy_entrypoint, allow_legacy=True)
+
+    assert explicit.source == DiagnosticArtifactSource.EXPLICIT
+    assert explicit.uri == "s3://override-bucket/results/run-1"
+    assert typed.source == DiagnosticArtifactSource.METADATA
+    assert typed.uri == "gs://typed-bucket/jobs/run-1"
+    assert legacy.source == DiagnosticArtifactSource.LEGACY
+    assert legacy.uri == "gs://legacy-bucket/jobs/run-1"
+
+
+def test_artifact_resolution_refuses_legacy_layout_without_explicit_opt_in():
+    with pytest.raises(LookupError, match="opt into legacy"):
+        resolve_diagnostic_artifact(
+            None,
+            legacy_entrypoint="python run_tracegen.py --jobs-dir gs://legacy-bucket/jobs/run-1",
+        )
+
+
+def test_artifact_resolution_does_not_infer_legacy_for_typed_metadata_without_uri():
+    with pytest.raises(LookupError, match="metadata has no artifact_uri"):
+        resolve_diagnostic_artifact(
+            DiagnosticJobMetadata(workload_kind=DiagnosticWorkloadKind.DATAGEN),
+            legacy_entrypoint="python run_tracegen.py --jobs-dir gs://legacy-bucket/jobs/run-1",
+            allow_legacy=True,
+        )


### PR DESCRIPTION
Persist typed diagnostic metadata with Iris job submissions and resolve artifacts from explicit input or job metadata. CoreWeave diagnostic locations now come from cluster configuration, and legacy OpenThoughts command parsing is opt-in.

This foundation deliberately excludes the watcher, collector, analyzer, and mirror ports. The 14-script migration plan is included in `.agents/projects/iris_scripts_port_scope.md`.

Part of #7098
