### PR TITLE
[pulumi] Move everything to KMS

### DIFF
--- a/infra/evaldash/Pulumi.marin-evaldash.yaml
+++ b/infra/evaldash/Pulumi.marin-evaldash.yaml
@@ -13,4 +13,5 @@ config:
   # in the oa.dev Cloudflare zone; unset custom_domain to serve only the run.app URL.
   marin-evaldash:custom_domain: evaldash.oa.dev
   marin-evaldash:dns_zone_id: 169959d6aafcbfd77764b8efafa3a509
-encryptionsalt: v1:AONWc+XQ/do=:v1:RRUP8bNePz9TVCoI:Aoz4KiiUDpsxnBGLgCjduulTE0kevA==
+secretsprovider: gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
+encryptedkey: CiQAKk3j6alqF2aXPeik2V9Y87N0Vt4yJbJ0Kt9y5Kqtt29xg4cSSQCdtF6iA67MRjUX4DFR6u8/bus3nzUsa9UUqSt7ViMi4UHjk0UtyF7yTBRJQeDN5dL8B5PPt9z1Hbv1gYUHIZQxPmk39h514Ac=

--- a/infra/evaldash/Pulumi.yaml
+++ b/infra/evaldash/Pulumi.yaml
@@ -7,7 +7,7 @@ runtime:
   options:
     virtualenv: ../../.venv
 description: The Marin eval-results dashboard as an IAP-gated Cloud Run service.
-# State backend and secrets provider come from the operator/CI environment, shared with
-# infra/pulumi (see README.md):
+# The state backend is selected by the operator/CI environment and shared with infra/pulumi
+# (see README.md):
 #   pulumi login gs://marin-iac-state
-#   PULUMI_CONFIG_PASSPHRASE from Secret Manager (pulumi-iac-passphrase)
+# Pulumi.marin-evaldash.yaml records the production stack's shared GCP KMS provider.

--- a/infra/evaldash/README.md
+++ b/infra/evaldash/README.md
@@ -109,3 +109,6 @@ own Pulumi project (stack `marin-evaldash`), sharing `infra/pulumi`'s state back
 on the `hai-gcp-models:us-central1:marin-metadata` Cloud SQL instance and the
 `cloudsql-evals-password` secret from `infra/cloudsql` — see that project's README for
 provisioning them.
+
+The stack uses the shared `marin-iac-key` KMS secrets provider. The operator needs
+`roles/cloudkms.cryptoKeyEncrypterDecrypter` on that key; no passphrase is used.

--- a/infra/pulumi/Pulumi.marin.yaml
+++ b/infra/pulumi/Pulumi.marin.yaml
@@ -1,3 +1,4 @@
 config:
   marin-iac:cluster: marin
-encryptionsalt: v1:DllYXY6TjoI=:v1:bUzjcglbcOPfMjlm:SArcHQUd8X4RyFqteNWDEmDvY58Iew==
+secretsprovider: gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
+encryptedkey: CiQAKk3j6WdPIcnb9BTMvTFi33Ul9bDA89H3owKefrxog4tbpWoSSQCdtF6iH5aRd5NJkng98KEkevQprE6799I0MRgoNS8OYkDqy0L5TX5J/nilfCLWa/h/8rRj3EwSvvLDl8DQyHh6XrHURw1yadA=

--- a/infra/pulumi/github/Pulumi.marin-community.yaml
+++ b/infra/pulumi/github/Pulumi.marin-community.yaml
@@ -295,4 +295,5 @@ config:
       source_ref: env:OPENAI_ADMIN_KEY
       disposition: review
       note: Optional cost-report provider credential.
-encryptionsalt: v1:DFMrtZjMAAg=:v1:8LS1krCS1f9qTzOA:jbdoeGkDIOvOTJg3CKKKeobJyGGGgQ==
+secretsprovider: gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
+encryptedkey: CiQAKk3j6XZs8zGfSYvujFXIFZheWMPjbPdDOV7JJodZEXp2kRkSSQCdtF6ipwmQbLzrT+vTDynD/SCx5yrJeXJ4b2hDtiqNsXV8wjjzqePjSvwlLP4lQZ9EWt2ow0DiAiWCqkg6c4Md9mRI8TY0fPE=


### PR DESCRIPTION
`evaldash` was the only one with state in `gs://marin-iac-state`, which was migrated. The other two had no state, so they were just init'd with kms.

Fixes #7459