### PR TITLE
[iris] Replace stale terminal pod on job resubmit

### DIFF
--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -72,7 +72,6 @@ from iris.cluster.platforms.k8s.types import (
     IRIS_PRIORITY_CLASS_BATCH,
     IRIS_PRIORITY_CLASS_INTERACTIVE,
     IRIS_PRIORITY_CLASS_PRODUCTION,
-    POD_ATTEMPT_UID_LABEL,
     K8sResource,
     KubectlError,
     parse_k8s_quantity,
@@ -346,24 +345,31 @@ def _job_id_from_task(task_id: JobName) -> str:
     return _sanitize_label_value(_job_path(task_id))
 
 
-def _pod_name(task_id: JobName, attempt_id: int) -> str:
-    """Build a DNS-label-safe pod name from task_id and attempt_id.
+def _pod_name(task_id: JobName, attempt_id: int, attempt_uid: str = "") -> str:
+    """Build a DNS-label-safe pod name from task_id, attempt_id, and attempt_uid.
 
     k8s pod names must match [a-z0-9][a-z0-9-]* and be at most 253 chars.
     We lowercase and replace non-alphanumeric chars with hyphens, then truncate.
 
-    Both a 8-char task hash and the attempt_id are reserved before truncating
-    the readable prefix, so:
+    A 8-char task hash, the attempt_id, and the attempt_uid are reserved before
+    truncating the readable prefix, so:
     - Different task IDs with the same long prefix cannot share a pod name
       (the task hash distinguishes them).
     - Different retry attempts of the same task cannot share a pod name
       (the attempt_id distinguishes them).
+    - Different incarnations of the same (task, attempt) — a resubmit reuses the
+      task name and resets attempt_id to 0 — cannot share a pod name (the
+      per-attempt uid distinguishes them). This is what lets ``create`` always
+      succeed for a fresh attempt instead of colliding with a previous run's
+      leftover pod. ``attempt_uid`` is empty only off the direct-dispatch path
+      (older controllers, tests), which keeps the pre-uid name.
     """
     task_id_wire = task_id.to_wire()
     # 8-char hash ensures different task IDs produce different pod names
     # even after prefix truncation.
     hash8 = hashlib.sha256(task_id_wire.encode()).hexdigest()[:8]
-    suffix = f"-{hash8}-{attempt_id}"
+    uid_part = f"-{attempt_uid}" if attempt_uid else ""
+    suffix = f"-{hash8}-{attempt_id}{uid_part}"
     prefix_raw = f"iris-{task_id_wire}"
     prefix = re.sub(r"[^a-z0-9-]", "-", prefix_raw.lower())
     prefix = re.sub(r"-{2,}", "-", prefix).strip("-")
@@ -717,7 +723,7 @@ def _build_pod_manifest(
     """Build a Pod manifest dict from a RunTaskRequest and cluster config."""
     task_id = JobName.from_wire(run_req.task_id)
     attempt_id = run_req.attempt_id
-    pod_name = _pod_name(task_id, attempt_id)
+    pod_name = _pod_name(task_id, attempt_id, run_req.attempt_uid)
 
     namespace = config.namespace
     # Per-task image override (RunTaskRequest.task_image) wins; otherwise the
@@ -826,11 +832,6 @@ def _build_pod_manifest(
         _LABEL_TASK_HASH: _task_hash(run_req.task_id),
         _LABEL_JOB_ID: job_id,
     }
-    # attempt_uid distinguishes this attempt's pod from a stale one a previous job
-    # left at the same (task_hash, attempt_id) name; see CloudK8sService._apply_pod.
-    # Omitted when unset (older controllers, tests) — apply then stays create-if-absent.
-    if run_req.attempt_uid:
-        labels[POD_ATTEMPT_UID_LABEL] = run_req.attempt_uid
     if managed_label:
         labels[managed_label] = "true"
     metadata: dict = {
@@ -2430,7 +2431,7 @@ class K8sTaskProvider:
         the profile duration itself.
         """
         attempt_id = target.attempt_id
-        pod_name = _pod_name(JobName.from_wire(target.task_id), attempt_id)
+        pod_name = _pod_name(JobName.from_wire(target.task_id), attempt_id, target.attempt_uid)
         duration = request.duration_seconds or 10
         profile_type = request.profile_type
         dispatch = _K8sProfileDispatch(self.kubectl, pod_name)
@@ -2471,7 +2472,7 @@ class K8sTaskProvider:
     ) -> worker_pb2.Worker.ExecInContainerResponse:
         """Execute a command in a running task pod via kubectl exec."""
         command = list(request.command)
-        pod_name = _pod_name(JobName.from_wire(target.task_id), target.attempt_id)
+        pod_name = _pod_name(JobName.from_wire(target.task_id), target.attempt_id, target.attempt_uid)
         effective_timeout: float | None = timeout_seconds if timeout_seconds >= 0 else None
         try:
             result = self.kubectl.exec(pod_name, command, container="task", timeout=effective_timeout)
@@ -2495,7 +2496,7 @@ class K8sTaskProvider:
         memory, cpu, thread, and fd counters. Logs are served separately via
         FetchLogs, so ``log_entries`` stays empty.
         """
-        pod_name = _pod_name(JobName.from_wire(target.task_id), target.attempt_id)
+        pod_name = _pod_name(JobName.from_wire(target.task_id), target.attempt_id, target.attempt_uid)
         result = self.kubectl.exec(
             pod_name, ["sh", "-c", _POD_PROC_STATUS_SCRIPT], container="task", timeout=_POD_PROC_STATUS_TIMEOUT
         )
@@ -2552,7 +2553,7 @@ class K8sTaskProvider:
         manifest = _build_pod_manifest(run_req, self.pod_config)
 
         task_id_name = JobName.from_wire(run_req.task_id)
-        pod_name = _pod_name(task_id_name, run_req.attempt_id)
+        pod_name = _pod_name(task_id_name, run_req.attempt_id, run_req.attempt_uid)
 
         init_containers, extra_volumes, configmap_name = _build_init_container_spec(
             run_req,
@@ -2922,7 +2923,7 @@ class K8sTaskProvider:
         # each. Lazy: only fetched on cycles where at least one pod is missing,
         # so steady-state cycles add no call. setdefault keeps the active entry
         # if a name somehow appears in both.
-        if any(_pod_name(entry.task_id, entry.attempt_id) not in pods_by_name for entry in running):
+        if any(_pod_name(entry.task_id, entry.attempt_id, entry.attempt_uid) not in pods_by_name for entry in running):
             for pod in self._list_terminal_pods():
                 pods_by_name.setdefault(pod.get("metadata", {}).get("name", ""), pod)
 
@@ -2936,7 +2937,7 @@ class K8sTaskProvider:
         event_log = self._ensure_task_event_log()
 
         for entry in running:
-            pod_name = _pod_name(entry.task_id, entry.attempt_id)
+            pod_name = _pod_name(entry.task_id, entry.attempt_id, entry.attempt_uid)
             cursor_key = f"{entry.task_id.to_wire()}:{entry.attempt_id}"
             event_key = (entry.task_id.to_wire(), entry.attempt_id)
             pod = pods_by_name.get(pod_name)

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -72,6 +72,7 @@ from iris.cluster.platforms.k8s.types import (
     IRIS_PRIORITY_CLASS_BATCH,
     IRIS_PRIORITY_CLASS_INTERACTIVE,
     IRIS_PRIORITY_CLASS_PRODUCTION,
+    POD_ATTEMPT_UID_LABEL,
     K8sResource,
     KubectlError,
     parse_k8s_quantity,
@@ -825,6 +826,11 @@ def _build_pod_manifest(
         _LABEL_TASK_HASH: _task_hash(run_req.task_id),
         _LABEL_JOB_ID: job_id,
     }
+    # attempt_uid distinguishes this attempt's pod from a stale one a previous job
+    # left at the same (task_hash, attempt_id) name; see CloudK8sService._apply_pod.
+    # Omitted when unset (older controllers, tests) — apply then stays create-if-absent.
+    if run_req.attempt_uid:
+        labels[POD_ATTEMPT_UID_LABEL] = run_req.attempt_uid
     if managed_label:
         labels[managed_label] = "true"
     metadata: dict = {

--- a/lib/iris/src/iris/cluster/controller/backend.py
+++ b/lib/iris/src/iris/cluster/controller/backend.py
@@ -154,14 +154,17 @@ class TaskTarget:
     """Addresses one task attempt for on-demand RPCs (status / profile / exec).
 
     Worker-daemon backends route by :attr:`address`; direct backends route by
-    :attr:`task_id` / :attr:`attempt_id`. Each backend reads the fields it needs;
-    the controller fills them from the DB once at the RPC boundary.
+    :attr:`task_id` / :attr:`attempt_id` / :attr:`attempt_uid`. Each backend reads
+    the fields it needs; the controller fills them from the DB once at the RPC
+    boundary. ``attempt_uid`` is the incarnation key the K8s backend needs to
+    rebuild the pod name (which embeds it); empty for worker-daemon targets.
     """
 
     task_id: str
     attempt_id: int
     worker_id: WorkerId | None
     address: str | None
+    attempt_uid: str = ""
 
 
 @dataclass(frozen=True)

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -1155,6 +1155,30 @@ def attempt_uid_for(tx: Tx, task_id: JobName, attempt_id: int) -> AttemptUid | N
     return AttemptUid(row.attempt_uid) if row is not None else None
 
 
+def attempt_uids_for(tx: Tx, keys: Sequence[tuple[JobName, int]]) -> dict[tuple[JobName, int], AttemptUid]:
+    """Bulk ``(task_id, attempt_id) -> attempt_uid`` over the task_attempts PK.
+
+    Chunked to bound the IN-list size. Missing keys are silently absent — a
+    caller treats their uid as empty (pre-uid name).
+    """
+    if not keys:
+        return {}
+    unique = list(dict.fromkeys(keys))
+    result: dict[tuple[JobName, int], AttemptUid] = {}
+    for chunk_start in range(0, len(unique), _BULK_GET_CHUNK_SIZE):
+        chunk = unique[chunk_start : chunk_start + _BULK_GET_CHUNK_SIZE]
+        rows = tx.execute(
+            select(
+                task_attempts_table.c.task_id,
+                task_attempts_table.c.attempt_id,
+                task_attempts_table.c.attempt_uid,
+            ).where(tuple_(task_attempts_table.c.task_id, task_attempts_table.c.attempt_id).in_(chunk))
+        ).all()
+        for row in rows:
+            result[(row.task_id, int(row.attempt_id))] = AttemptUid(row.attempt_uid)
+    return result
+
+
 def resolve_attempt_uids(
     tx: Tx,
     uids: Sequence[AttemptUid],

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -1139,6 +1139,22 @@ _RESOLVE_ATTEMPT_UIDS_STMT = (
 )
 
 
+def attempt_uid_for(tx: Tx, task_id: JobName, attempt_id: int) -> AttemptUid | None:
+    """Return the controller-minted ``attempt_uid`` for ``(task_id, attempt_id)``.
+
+    Point-read over the ``task_attempts`` primary key. ``None`` when the attempt
+    row does not exist — e.g. a never-run PENDING task whose ``current_attempt_id``
+    is still ``-1``.
+    """
+    row = tx.execute(
+        select(task_attempts_table.c.attempt_uid).where(
+            task_attempts_table.c.task_id == task_id,
+            task_attempts_table.c.attempt_id == attempt_id,
+        )
+    ).first()
+    return AttemptUid(row.attempt_uid) if row is not None else None
+
+
 def resolve_attempt_uids(
     tx: Tx,
     uids: Sequence[AttemptUid],

--- a/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
@@ -82,6 +82,13 @@ def build_run_request(
     # Coscheduling drives Kueue gang admission on the direct path.
     if row.has_coscheduling:
         run_req.coscheduling.group_by = row.coscheduling_group_by
+    # Stamp the attempt's uid so the K8s backend can label the pod with it and
+    # tell this attempt's own pod apart from a stale pod a previous job left at
+    # the same (task_hash, attempt_id) name. Visible in this tx for both paths:
+    # promote inserted the attempt row above, redrive reads the current one.
+    uid = reads.attempt_uid_for(cur, row.task_id, attempt_id)
+    if uid is not None:
+        run_req.attempt_uid = uid
     return run_req
 
 

--- a/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
@@ -235,11 +235,15 @@ def drain_for_dispatch(
         order_by_task_id=True,
         backend_id=backend_id,
     )
+    # The K8s provider rebuilds each pod name from (task_id, attempt_id, uid), so
+    # poll must carry the current attempt's uid to target the right incarnation.
+    uids = reads.attempt_uids_for(cur, [(row.task_id, row.current_attempt_id) for row in running_rows])
     running_tasks = [
         RunningTaskEntry(
             task_id=row.task_id,
             attempt_id=row.current_attempt_id,
             coscheduled=row.has_coscheduling,
+            attempt_uid=uids.get((row.task_id, row.current_attempt_id), ""),
         )
         for row in running_rows
     ]

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -2479,11 +2479,20 @@ class ControllerServiceImpl:
         its worker is gone or unhealthy. Shared by ``profile_task`` and
         ``exec_in_container``.
         """
+        # The K8s backend rebuilds the pod name from (task_id, attempt_id, uid);
+        # the uid rides on the attempt rows already attached to ``task``.
+        attempt_uid = next((a.attempt_uid for a in task.attempts if a.attempt_id == attempt_id), "")
         task_worker_id = _task_worker_id(task)
         if not task_worker_id:
             if BackendCapability.CLUSTER_VIEW not in self._controller.capabilities:
                 raise ConnectError(Code.FAILED_PRECONDITION, f"Task {wire_name} not yet assigned to a worker")
-            return TaskTarget(task_id=task.task_id.to_wire(), attempt_id=attempt_id, worker_id=None, address=None)
+            return TaskTarget(
+                task_id=task.task_id.to_wire(),
+                attempt_id=attempt_id,
+                worker_id=None,
+                address=None,
+                attempt_uid=attempt_uid,
+            )
         worker = _read_worker(self._db, task_worker_id)
         if not worker or not self._controller.liveness_for_worker(task_worker_id).healthy:
             raise ConnectError(Code.UNAVAILABLE, f"Worker {task_worker_id} is unavailable")
@@ -2492,6 +2501,7 @@ class ControllerServiceImpl:
             attempt_id=attempt_id,
             worker_id=task_worker_id,
             address=worker.address,
+            attempt_uid=attempt_uid,
         )
 
     @property

--- a/lib/iris/src/iris/cluster/controller/task_state.py
+++ b/lib/iris/src/iris/cluster/controller/task_state.py
@@ -45,11 +45,17 @@ class RunningTaskEntry(NamedTuple):
     a gang preemption (WORKER_FAILED) rather than an application failure: when
     Kueue preempts a pod group it deletes every pod, leaving no terminal pod
     status to read — only the absence. See K8sTaskProvider._poll_pods.
+
+    ``attempt_uid`` is the incarnation key the K8s provider needs to rebuild the
+    pod name (which embeds it): a resubmit reuses (task_id, attempt_id) but mints
+    a new uid, so poll must target this attempt's pod, not a stale one. Empty off
+    the direct-dispatch path.
     """
 
     task_id: JobName
     attempt_id: int
     coscheduled: bool = False
+    attempt_uid: str = ""
 
 
 def task_is_finished(

--- a/lib/iris/src/iris/cluster/platforms/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/fake.py
@@ -658,7 +658,7 @@ class InMemoryK8sService:
             terminating = bool(existing.get("metadata", {}).get("deletionTimestamp"))
             if phase in ("Succeeded", "Failed") and not terminating:
                 self.delete(resource, name)
-                raise KubectlError(f"stale terminal pod {name} (phase={phase}) deleted; will recreate")
+                raise KubectlError("stale terminal pod deleted; will recreate on next dispatch")
             return
 
         self._resources[(resource.plural, name)] = manifest

--- a/lib/iris/src/iris/cluster/platforms/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/fake.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
 from iris.cluster.platforms.k8s.types import (
+    POD_ATTEMPT_UID_LABEL,
     ExecResult,
     K8sResource,
     KubectlError,
@@ -647,18 +648,21 @@ class InMemoryK8sService:
         resource = K8sResource.from_kind(manifest["kind"])
         name = manifest["metadata"]["name"]
 
-        # Pods are create-if-live-absent (mirrors K8sService._apply_pod): a live
-        # pod already holding this name is the attempt we want, so re-applying it
-        # on a redrive is a no-op (overwriting would reset a running pod). A
-        # terminal pod is a leftover from a previous job that reused this name;
-        # delete it and fail the apply so a fresh pod replaces it on retry.
+        # Pods are create-if-absent (mirrors K8sService._apply_pod): an existing pod
+        # is normally our own attempt, so re-applying on a redrive is a no-op
+        # (overwriting would reset a running pod). The exception is a pod whose
+        # attempt_uid label differs from ours — a leftover from a previous job that
+        # reused this (task_hash, attempt_id) name — which we delete and fail the
+        # apply so a fresh pod replaces it on retry.
         if resource is K8sResource.PODS and (resource.plural, name) in self._resources:
             existing = self._resources[(resource.plural, name)]
-            phase = existing.get("status", {}).get("phase")
+            existing_uid = existing.get("metadata", {}).get("labels", {}).get(POD_ATTEMPT_UID_LABEL)
+            our_uid = manifest.get("metadata", {}).get("labels", {}).get(POD_ATTEMPT_UID_LABEL)
             terminating = bool(existing.get("metadata", {}).get("deletionTimestamp"))
-            if phase in ("Succeeded", "Failed") and not terminating:
-                self.delete(resource, name)
-                raise KubectlError("stale terminal pod deleted; will recreate on next dispatch")
+            if existing_uid and our_uid and existing_uid != our_uid:
+                if not terminating:
+                    self.delete(resource, name)
+                raise KubectlError("stale pod from a prior attempt deleted; will recreate on next dispatch")
             return
 
         self._resources[(resource.plural, name)] = manifest

--- a/lib/iris/src/iris/cluster/platforms/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/fake.py
@@ -21,7 +21,6 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
 from iris.cluster.platforms.k8s.types import (
-    POD_ATTEMPT_UID_LABEL,
     ExecResult,
     K8sResource,
     KubectlError,
@@ -648,21 +647,11 @@ class InMemoryK8sService:
         resource = K8sResource.from_kind(manifest["kind"])
         name = manifest["metadata"]["name"]
 
-        # Pods are create-if-absent (mirrors K8sService._apply_pod): an existing pod
-        # is normally our own attempt, so re-applying on a redrive is a no-op
-        # (overwriting would reset a running pod). The exception is a pod whose
-        # attempt_uid label differs from ours — a leftover from a previous job that
-        # reused this (task_hash, attempt_id) name — which we delete and fail the
-        # apply so a fresh pod replaces it on retry.
+        # Pods are create-if-absent (mirrors K8sService._apply_pod): the pod name
+        # embeds the attempt uid, so a fresh incarnation never collides — an
+        # existing pod is our own attempt, and re-applying on a redrive is a no-op
+        # (overwriting would reset a running pod).
         if resource is K8sResource.PODS and (resource.plural, name) in self._resources:
-            existing = self._resources[(resource.plural, name)]
-            existing_uid = existing.get("metadata", {}).get("labels", {}).get(POD_ATTEMPT_UID_LABEL)
-            our_uid = manifest.get("metadata", {}).get("labels", {}).get(POD_ATTEMPT_UID_LABEL)
-            terminating = bool(existing.get("metadata", {}).get("deletionTimestamp"))
-            if existing_uid and our_uid and existing_uid != our_uid:
-                if not terminating:
-                    self.delete(resource, name)
-                raise KubectlError("stale pod from a prior attempt deleted; will recreate on next dispatch")
             return
 
         self._resources[(resource.plural, name)] = manifest

--- a/lib/iris/src/iris/cluster/platforms/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/fake.py
@@ -647,10 +647,18 @@ class InMemoryK8sService:
         resource = K8sResource.from_kind(manifest["kind"])
         name = manifest["metadata"]["name"]
 
-        # Pods are create-if-absent (mirrors K8sService._apply_pod): an existing
-        # pod — in any phase — is the one we want, so re-applying it on a redrive
-        # is a no-op. Overwriting and rescheduling would reset a running pod.
+        # Pods are create-if-live-absent (mirrors K8sService._apply_pod): a live
+        # pod already holding this name is the attempt we want, so re-applying it
+        # on a redrive is a no-op (overwriting would reset a running pod). A
+        # terminal pod is a leftover from a previous job that reused this name;
+        # delete it and fail the apply so a fresh pod replaces it on retry.
         if resource is K8sResource.PODS and (resource.plural, name) in self._resources:
+            existing = self._resources[(resource.plural, name)]
+            phase = existing.get("status", {}).get("phase")
+            terminating = bool(existing.get("metadata", {}).get("deletionTimestamp"))
+            if phase in ("Succeeded", "Failed") and not terminating:
+                self.delete(resource, name)
+                raise KubectlError(f"stale terminal pod {name} (phase={phase}) deleted; will recreate")
             return
 
         self._resources[(resource.plural, name)] = manifest

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -311,9 +311,12 @@ class CloudK8sService:
             phase = existing.get("status", {}).get("phase")
             terminating = bool(existing.get("metadata", {}).get("deletionTimestamp"))
             if phase in ("Succeeded", "Failed") and not terminating:
-                logger.info("k8s: deleting stale terminal pod %s (phase=%s) before recreate", name, phase)
+                # Do not interpolate the manifest-derived name/phase into the log
+                # or error: a pod manifest carries secret env, so a data-flow
+                # scanner treats anything read from it as sensitive. The provider
+                # already logs the failing task id alongside this error.
                 self.delete(res, name, wait=False)
-                raise KubectlError(f"stale terminal pod {name} (phase={phase}) deleted; will recreate") from None
+                raise KubectlError("stale terminal pod deleted; will recreate on next dispatch") from None
             # Live pod, or a prior generation still terminating; leave it. A later
             # reconcile re-applies once any deletion lands.
 

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -279,17 +279,22 @@ class CloudK8sService:
                 ) from e
 
     def _apply_pod(self, res: K8sResource, name: str, ns: str | None, manifest: dict) -> None:
-        """Create the Pod if it is not already present (create-if-absent).
+        """Create the Pod if no live pod already holds its name (create-if-live-absent).
 
         A task attempt's pod name is stable and its manifest deterministic, so a
-        pod that already exists — in any phase — is the one we want; we must NOT
-        delete and recreate it. Delete-then-create would destroy a running task
-        on every redrive and, because the delete and the create race, fail with
-        409 AlreadyExists ("object is being deleted") while the prior pod is
-        still Terminating — which the dispatch loop then mistakes for worker loss
-        and retries, churning the task through attempts until it fails. A pod
-        that genuinely needs to change comes from a new attempt (new name); one
-        that should go away is removed by stray-pod GC.
+        live pod (Pending/Running) that already holds this name is the attempt we
+        want; we must NOT delete and recreate it. Delete-then-create would destroy
+        a running task on every redrive and, because the delete and the create
+        race, fail with 409 AlreadyExists ("object is being deleted") while the
+        prior pod is still Terminating — which the dispatch loop then mistakes for
+        worker loss and retries, churning the task through attempts until it fails.
+
+        A *terminal* pod (Succeeded/Failed) is different: pod names are deterministic
+        in (task_hash, attempt_id) and attempt_id resets to 0 on a job resubmit, so
+        a resubmitted job's fresh attempt collides with the previous run's terminal
+        pod. Keeping it would report that dead attempt's verdict against the fresh
+        one. Delete the stale pod and fail the apply; the provider maps the error to
+        WORKER_FAILED and the next dispatch recreates a fresh pod once it is gone.
         """
         api = self._resource_api(res)
         ns_kw = {"namespace": ns} if ns else {}
@@ -297,11 +302,20 @@ class CloudK8sService:
         try:
             api.create(body=manifest, **timeout_kw, **ns_kw)
         except ApiException as e:
-            if e.status == 409:
-                # Pod already present (or a prior generation still terminating);
-                # leave it. A later reconcile re-applies once any deletion lands.
+            if e.status != 409:
+                raise
+            existing = self.get_json(res, name)
+            if existing is None:
+                # Vanished between create and get; a later reconcile re-applies.
                 return
-            raise
+            phase = existing.get("status", {}).get("phase")
+            terminating = bool(existing.get("metadata", {}).get("deletionTimestamp"))
+            if phase in ("Succeeded", "Failed") and not terminating:
+                logger.info("k8s: deleting stale terminal pod %s (phase=%s) before recreate", name, phase)
+                self.delete(res, name, wait=False)
+                raise KubectlError(f"stale terminal pod {name} (phase={phase}) deleted; will recreate") from None
+            # Live pod, or a prior generation still terminating; leave it. A later
+            # reconcile re-applies once any deletion lands.
 
     # -- get -----------------------------------------------------------------
 

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -34,6 +34,7 @@ from rigging.log_setup import slow_log
 from rigging.timing import Deadline, ExponentialBackoff
 
 from iris.cluster.platforms.k8s.types import (
+    POD_ATTEMPT_UID_LABEL,
     ExecResult,
     K8sResource,
     KubectlError,
@@ -279,22 +280,24 @@ class CloudK8sService:
                 ) from e
 
     def _apply_pod(self, res: K8sResource, name: str, ns: str | None, manifest: dict) -> None:
-        """Create the Pod if no live pod already holds its name (create-if-live-absent).
+        """Create the Pod unless our own attempt already holds its name (create-if-absent).
 
-        A task attempt's pod name is stable and its manifest deterministic, so a
-        live pod (Pending/Running) that already holds this name is the attempt we
-        want; we must NOT delete and recreate it. Delete-then-create would destroy
-        a running task on every redrive and, because the delete and the create
-        race, fail with 409 AlreadyExists ("object is being deleted") while the
-        prior pod is still Terminating — which the dispatch loop then mistakes for
-        worker loss and retries, churning the task through attempts until it fails.
+        A task attempt's pod name is stable and its manifest deterministic, so on a
+        409 an existing pod is normally the attempt we want — in any phase. It must
+        NOT be deleted and recreated: a redrive fires every reconcile tick until a
+        (slower) poll observes the pod, and delete-then-create would destroy a
+        running task and race its own deletion (409 AlreadyExists while the prior
+        pod is still Terminating), churning the task through attempts until it fails.
 
-        A *terminal* pod (Succeeded/Failed) is different: pod names are deterministic
-        in (task_hash, attempt_id) and attempt_id resets to 0 on a job resubmit, so
-        a resubmitted job's fresh attempt collides with the previous run's terminal
-        pod. Keeping it would report that dead attempt's verdict against the fresh
-        one. Delete the stale pod and fail the apply; the provider maps the error to
-        WORKER_FAILED and the next dispatch recreates a fresh pod once it is gone.
+        The exception is a resubmit: pod names are deterministic in (task_hash,
+        attempt_id) and attempt_id resets to 0 on a job resubmit, so a resubmitted
+        job's fresh attempt collides with the previous run's leftover pod. The
+        controller stamps each pod with its attempt's uid (POD_ATTEMPT_UID_LABEL),
+        unique per incarnation, so a 409 pod whose uid differs from ours is that
+        stale pod — not our own fast-finishing attempt. Delete it and fail the
+        apply; the provider maps the error to WORKER_FAILED and the next dispatch
+        recreates a fresh pod once it is gone. A pod with no uid label (older
+        controller) or a matching uid is left untouched (create-if-absent).
         """
         api = self._resource_api(res)
         ns_kw = {"namespace": ns} if ns else {}
@@ -308,16 +311,19 @@ class CloudK8sService:
             if existing is None:
                 # Vanished between create and get; a later reconcile re-applies.
                 return
-            phase = existing.get("status", {}).get("phase")
-            terminating = bool(existing.get("metadata", {}).get("deletionTimestamp"))
-            if phase in ("Succeeded", "Failed") and not terminating:
-                # Do not interpolate the manifest-derived name/phase into the log
-                # or error: a pod manifest carries secret env, so a data-flow
-                # scanner treats anything read from it as sensitive. The provider
-                # already logs the failing task id alongside this error.
-                self.delete(res, name, wait=False)
-                raise KubectlError("stale terminal pod deleted; will recreate on next dispatch") from None
-            # Live pod, or a prior generation still terminating; leave it. A later
+            existing_uid = existing.get("metadata", {}).get("labels", {}).get(POD_ATTEMPT_UID_LABEL)
+            our_uid = manifest.get("metadata", {}).get("labels", {}).get(POD_ATTEMPT_UID_LABEL)
+            if existing_uid and our_uid and existing_uid != our_uid:
+                # A different attempt incarnation holds our name: a stale pod from a
+                # previous job that reused it. Delete it (unless already going) and
+                # fail the apply so the retry creates a fresh pod. The message omits
+                # the manifest-derived name/phase — a pod manifest carries secret
+                # env, so a data-flow scanner flags logging anything read from it;
+                # the provider already logs the failing task id alongside this error.
+                if not existing.get("metadata", {}).get("deletionTimestamp"):
+                    self.delete(res, name, wait=False)
+                raise KubectlError("stale pod from a prior attempt deleted; will recreate on next dispatch") from None
+            # Our own pod (matching or absent uid), in any phase; leave it. A later
             # reconcile re-applies once any deletion lands.
 
     # -- get -----------------------------------------------------------------

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -34,7 +34,6 @@ from rigging.log_setup import slow_log
 from rigging.timing import Deadline, ExponentialBackoff
 
 from iris.cluster.platforms.k8s.types import (
-    POD_ATTEMPT_UID_LABEL,
     ExecResult,
     K8sResource,
     KubectlError,
@@ -280,24 +279,17 @@ class CloudK8sService:
                 ) from e
 
     def _apply_pod(self, res: K8sResource, name: str, ns: str | None, manifest: dict) -> None:
-        """Create the Pod unless our own attempt already holds its name (create-if-absent).
+        """Create the Pod if it is not already present (create-if-absent).
 
-        A task attempt's pod name is stable and its manifest deterministic, so on a
-        409 an existing pod is normally the attempt we want — in any phase. It must
-        NOT be deleted and recreated: a redrive fires every reconcile tick until a
-        (slower) poll observes the pod, and delete-then-create would destroy a
-        running task and race its own deletion (409 AlreadyExists while the prior
-        pod is still Terminating), churning the task through attempts until it fails.
-
-        The exception is a resubmit: pod names are deterministic in (task_hash,
-        attempt_id) and attempt_id resets to 0 on a job resubmit, so a resubmitted
-        job's fresh attempt collides with the previous run's leftover pod. The
-        controller stamps each pod with its attempt's uid (POD_ATTEMPT_UID_LABEL),
-        unique per incarnation, so a 409 pod whose uid differs from ours is that
-        stale pod — not our own fast-finishing attempt. Delete it and fail the
-        apply; the provider maps the error to WORKER_FAILED and the next dispatch
-        recreates a fresh pod once it is gone. A pod with no uid label (older
-        controller) or a matching uid is left untouched (create-if-absent).
+        The pod name embeds the attempt's uid (see K8s backend ``_pod_name``), so a
+        fresh incarnation — a resubmit that reuses (task_id, attempt_id) but mints a
+        new uid — never collides with a previous run's leftover pod: ``create`` just
+        succeeds. A 409 therefore means our own attempt's pod already exists, in any
+        phase; a redrive fires every reconcile tick until a (slower) poll observes
+        it, and it must be left untouched. Deleting and recreating would destroy a
+        running task and race its own deletion (409 AlreadyExists while the prior pod
+        is still Terminating). The stale pod from a superseded incarnation carries a
+        different name and is reaped by the age-based terminal GC.
         """
         api = self._resource_api(res)
         ns_kw = {"namespace": ns} if ns else {}
@@ -305,26 +297,11 @@ class CloudK8sService:
         try:
             api.create(body=manifest, **timeout_kw, **ns_kw)
         except ApiException as e:
-            if e.status != 409:
-                raise
-            existing = self.get_json(res, name)
-            if existing is None:
-                # Vanished between create and get; a later reconcile re-applies.
+            if e.status == 409:
+                # Pod already present (or a prior generation still terminating);
+                # leave it. A later reconcile re-applies once any deletion lands.
                 return
-            existing_uid = existing.get("metadata", {}).get("labels", {}).get(POD_ATTEMPT_UID_LABEL)
-            our_uid = manifest.get("metadata", {}).get("labels", {}).get(POD_ATTEMPT_UID_LABEL)
-            if existing_uid and our_uid and existing_uid != our_uid:
-                # A different attempt incarnation holds our name: a stale pod from a
-                # previous job that reused it. Delete it (unless already going) and
-                # fail the apply so the retry creates a fresh pod. The message omits
-                # the manifest-derived name/phase — a pod manifest carries secret
-                # env, so a data-flow scanner flags logging anything read from it;
-                # the provider already logs the failing task id alongside this error.
-                if not existing.get("metadata", {}).get("deletionTimestamp"):
-                    self.delete(res, name, wait=False)
-                raise KubectlError("stale pod from a prior attempt deleted; will recreate on next dispatch") from None
-            # Our own pod (matching or absent uid), in any phase; leave it. A later
-            # reconcile re-applies once any deletion lands.
+            raise
 
     # -- get -----------------------------------------------------------------
 

--- a/lib/iris/src/iris/cluster/platforms/k8s/types.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/types.py
@@ -33,6 +33,15 @@ IRIS_PRIORITY_CLASSES: tuple[tuple[str, int, str], ...] = (
     (IRIS_PRIORITY_CLASS_BATCH, 0, "Never"),
 )
 
+# Pod label carrying the controller-minted attempt_uid (16 hex chars). It is
+# unique per attempt incarnation — a redrive of the same attempt keeps it, a
+# resubmit under the same name mints a new one — so a pod's attempt_uid tells the
+# current attempt's own pod apart from a stale pod left by a previous job that
+# reused the deterministic (task_hash, attempt_id) name. Shared here because both
+# the backend (which stamps it) and the platform service (which reads it in
+# _apply_pod to decide whether a 409 pod is ours) depend on the same key.
+POD_ATTEMPT_UID_LABEL = "iris.attempt_uid"
+
 
 def build_priority_class_manifest(name: str, value: int, preemption_policy: str) -> dict:
     """Build a cluster-scoped PriorityClass manifest dict."""

--- a/lib/iris/src/iris/cluster/platforms/k8s/types.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/types.py
@@ -33,15 +33,6 @@ IRIS_PRIORITY_CLASSES: tuple[tuple[str, int, str], ...] = (
     (IRIS_PRIORITY_CLASS_BATCH, 0, "Never"),
 )
 
-# Pod label carrying the controller-minted attempt_uid (16 hex chars). It is
-# unique per attempt incarnation — a redrive of the same attempt keeps it, a
-# resubmit under the same name mints a new one — so a pod's attempt_uid tells the
-# current attempt's own pod apart from a stale pod left by a previous job that
-# reused the deterministic (task_hash, attempt_id) name. Shared here because both
-# the backend (which stamps it) and the platform service (which reads it in
-# _apply_pod to decide whether a 409 pod is ours) depend on the same key.
-POD_ATTEMPT_UID_LABEL = "iris.attempt_uid"
-
 
 def build_priority_class_manifest(name: str, value: int, preemption_policy: str) -> dict:
     """Build a cluster-scoped PriorityClass manifest dict."""

--- a/lib/iris/tests/cluster/backends/k8s/conftest.py
+++ b/lib/iris/tests/cluster/backends/k8s/conftest.py
@@ -71,10 +71,12 @@ def make_run_req(
     num_tasks: int = 0,
     coscheduling_group_by: str = "",
     priority: int = job_pb2.PRIORITY_BAND_UNSPECIFIED,
+    attempt_uid: str = "",
 ) -> job_pb2.RunTaskRequest:
     req = job_pb2.RunTaskRequest()
     req.task_id = task_id
     req.attempt_id = attempt_id
+    req.attempt_uid = attempt_uid
     req.num_tasks = num_tasks
     req.entrypoint.run_command.argv.extend(["python", "train.py"])
     req.environment.env_vars["IRIS_JOB_ID"] = "test-job"

--- a/lib/iris/tests/cluster/backends/k8s/test_k8s_service.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_k8s_service.py
@@ -198,7 +198,7 @@ def test_delete_nonexistent_is_idempotent(svc: InMemoryK8sService):
 
 
 def test_apply_pod_is_create_if_absent(svc: InMemoryK8sService):
-    """Re-applying an existing pod is a no-op: the live pod is never overwritten.
+    """Re-applying an existing live pod is a no-op: it is never overwritten.
 
     A task attempt's pod name is stable, so a redrive re-applies the same name
     every tick. Overwriting (delete-then-create) would destroy a running pod and
@@ -213,6 +213,31 @@ def test_apply_pod_is_create_if_absent(svc: InMemoryK8sService):
     assert result is not None
     # Second apply was a no-op — the original pod (no version label) survives.
     assert result["metadata"].get("labels", {}).get("version") is None
+
+
+def test_apply_pod_replaces_stale_terminal_pod(svc: InMemoryK8sService):
+    """A resubmit whose name collides with a previous run's terminal pod gets a
+    fresh pod, not the dead attempt's verdict.
+
+    Pod names are deterministic in (task_hash, attempt_id) and attempt_id resets
+    to 0 on resubmit, so a fresh attempt collides with the prior run's Failed
+    pod. Apply must delete the stale pod and raise (mapped to WORKER_FAILED),
+    then the retry recreates a fresh pod.
+    """
+    svc.apply_json(_pod_manifest("p1", labels={"run": "old"}))
+    svc.transition_pod("p1", "Failed", exit_code=137, reason="OOMKilled")
+
+    with pytest.raises(KubectlError, match="stale terminal pod"):
+        svc.apply_json(_pod_manifest("p1", labels={"run": "new"}))
+    # The stale pod is gone, so the retry's create cannot adopt it.
+    assert svc.get_json(K8sResource.PODS, "p1") is None
+
+    svc.apply_json(_pod_manifest("p1", labels={"run": "new"}))
+    result = svc.get_json(K8sResource.PODS, "p1")
+    assert result is not None
+    # The recreated pod is the fresh manifest, not the dead attempt's Failed pod.
+    assert result["metadata"]["labels"]["run"] == "new"
+    assert result.get("status", {}).get("phase") != "Failed"
 
 
 # ========================================================================

--- a/lib/iris/tests/cluster/backends/k8s/test_k8s_service.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_k8s_service.py
@@ -9,7 +9,7 @@ that matters to K8sTaskProvider and CoreWeave controller consumers.
 
 import pytest
 from iris.cluster.platforms.k8s.fake import FakeNodeResources, InMemoryK8sService
-from iris.cluster.platforms.k8s.types import K8sResource, KubectlError
+from iris.cluster.platforms.k8s.types import POD_ATTEMPT_UID_LABEL, K8sResource, KubectlError
 
 
 def _get_pod_phase(svc: InMemoryK8sService, name: str) -> str:
@@ -215,29 +215,48 @@ def test_apply_pod_is_create_if_absent(svc: InMemoryK8sService):
     assert result["metadata"].get("labels", {}).get("version") is None
 
 
-def test_apply_pod_replaces_stale_terminal_pod(svc: InMemoryK8sService):
-    """A resubmit whose name collides with a previous run's terminal pod gets a
-    fresh pod, not the dead attempt's verdict.
+def test_apply_pod_replaces_stale_pod_from_prior_attempt(svc: InMemoryK8sService):
+    """A resubmit whose name collides with a prior incarnation's pod gets a fresh
+    pod, not the dead attempt's verdict.
 
     Pod names are deterministic in (task_hash, attempt_id) and attempt_id resets
-    to 0 on resubmit, so a fresh attempt collides with the prior run's Failed
-    pod. Apply must delete the stale pod and raise (mapped to WORKER_FAILED),
-    then the retry recreates a fresh pod.
+    to 0 on resubmit, so a fresh attempt collides with the prior run's pod. The
+    two are told apart by attempt_uid: the leftover pod carries the old uid, so
+    apply deletes it and raises (mapped to WORKER_FAILED), then the retry (same
+    new uid, no pod present) recreates a fresh pod.
     """
-    svc.apply_json(_pod_manifest("p1", labels={"run": "old"}))
+    svc.apply_json(_pod_manifest("p1", labels={POD_ATTEMPT_UID_LABEL: "olduid0000000000"}))
     svc.transition_pod("p1", "Failed", exit_code=137, reason="OOMKilled")
 
-    with pytest.raises(KubectlError, match="stale terminal pod"):
-        svc.apply_json(_pod_manifest("p1", labels={"run": "new"}))
+    with pytest.raises(KubectlError, match="stale pod from a prior attempt"):
+        svc.apply_json(_pod_manifest("p1", labels={POD_ATTEMPT_UID_LABEL: "newuid1111111111"}))
     # The stale pod is gone, so the retry's create cannot adopt it.
     assert svc.get_json(K8sResource.PODS, "p1") is None
 
-    svc.apply_json(_pod_manifest("p1", labels={"run": "new"}))
+    svc.apply_json(_pod_manifest("p1", labels={POD_ATTEMPT_UID_LABEL: "newuid1111111111"}))
     result = svc.get_json(K8sResource.PODS, "p1")
     assert result is not None
-    # The recreated pod is the fresh manifest, not the dead attempt's Failed pod.
-    assert result["metadata"]["labels"]["run"] == "new"
+    # The recreated pod is the fresh attempt, not the dead one's Failed pod.
+    assert result["metadata"]["labels"][POD_ATTEMPT_UID_LABEL] == "newuid1111111111"
     assert result.get("status", {}).get("phase") != "Failed"
+
+
+def test_apply_pod_keeps_own_terminal_pod(svc: InMemoryK8sService):
+    """A redrive of the same attempt over its own just-finished pod is a no-op.
+
+    A task stays ASSIGNED and is redriven every tick until poll observes it, so a
+    fast-finishing attempt's own terminal pod is re-applied with the SAME
+    attempt_uid. That pod must be kept (not deleted) so poll can read its verdict;
+    deleting it would destroy a real result and misreport it as infra loss.
+    """
+    svc.apply_json(_pod_manifest("p1", labels={POD_ATTEMPT_UID_LABEL: "sameuid000000000"}))
+    svc.transition_pod("p1", "Succeeded")
+
+    # Redrive with the same uid — no raise, pod untouched.
+    svc.apply_json(_pod_manifest("p1", labels={POD_ATTEMPT_UID_LABEL: "sameuid000000000"}))
+    result = svc.get_json(K8sResource.PODS, "p1")
+    assert result is not None
+    assert result["status"]["phase"] == "Succeeded"
 
 
 # ========================================================================

--- a/lib/iris/tests/cluster/backends/k8s/test_k8s_service.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_k8s_service.py
@@ -9,7 +9,7 @@ that matters to K8sTaskProvider and CoreWeave controller consumers.
 
 import pytest
 from iris.cluster.platforms.k8s.fake import FakeNodeResources, InMemoryK8sService
-from iris.cluster.platforms.k8s.types import POD_ATTEMPT_UID_LABEL, K8sResource, KubectlError
+from iris.cluster.platforms.k8s.types import K8sResource, KubectlError
 
 
 def _get_pod_phase(svc: InMemoryK8sService, name: str) -> str:
@@ -215,45 +215,18 @@ def test_apply_pod_is_create_if_absent(svc: InMemoryK8sService):
     assert result["metadata"].get("labels", {}).get("version") is None
 
 
-def test_apply_pod_replaces_stale_pod_from_prior_attempt(svc: InMemoryK8sService):
-    """A resubmit whose name collides with a prior incarnation's pod gets a fresh
-    pod, not the dead attempt's verdict.
-
-    Pod names are deterministic in (task_hash, attempt_id) and attempt_id resets
-    to 0 on resubmit, so a fresh attempt collides with the prior run's pod. The
-    two are told apart by attempt_uid: the leftover pod carries the old uid, so
-    apply deletes it and raises (mapped to WORKER_FAILED), then the retry (same
-    new uid, no pod present) recreates a fresh pod.
-    """
-    svc.apply_json(_pod_manifest("p1", labels={POD_ATTEMPT_UID_LABEL: "olduid0000000000"}))
-    svc.transition_pod("p1", "Failed", exit_code=137, reason="OOMKilled")
-
-    with pytest.raises(KubectlError, match="stale pod from a prior attempt"):
-        svc.apply_json(_pod_manifest("p1", labels={POD_ATTEMPT_UID_LABEL: "newuid1111111111"}))
-    # The stale pod is gone, so the retry's create cannot adopt it.
-    assert svc.get_json(K8sResource.PODS, "p1") is None
-
-    svc.apply_json(_pod_manifest("p1", labels={POD_ATTEMPT_UID_LABEL: "newuid1111111111"}))
-    result = svc.get_json(K8sResource.PODS, "p1")
-    assert result is not None
-    # The recreated pod is the fresh attempt, not the dead one's Failed pod.
-    assert result["metadata"]["labels"][POD_ATTEMPT_UID_LABEL] == "newuid1111111111"
-    assert result.get("status", {}).get("phase") != "Failed"
-
-
 def test_apply_pod_keeps_own_terminal_pod(svc: InMemoryK8sService):
-    """A redrive of the same attempt over its own just-finished pod is a no-op.
+    """Re-applying the same pod name over its own finished pod is a no-op.
 
-    A task stays ASSIGNED and is redriven every tick until poll observes it, so a
-    fast-finishing attempt's own terminal pod is re-applied with the SAME
-    attempt_uid. That pod must be kept (not deleted) so poll can read its verdict;
-    deleting it would destroy a real result and misreport it as infra loss.
+    A fast-finishing attempt is redriven every tick until poll observes it, so its
+    own terminal pod is re-applied under the same name (the uid is baked into the
+    name upstream). That pod must be kept so poll can read its verdict — deleting
+    it would destroy a real result and misreport it as infra loss.
     """
-    svc.apply_json(_pod_manifest("p1", labels={POD_ATTEMPT_UID_LABEL: "sameuid000000000"}))
+    svc.apply_json(_pod_manifest("p1"))
     svc.transition_pod("p1", "Succeeded")
 
-    # Redrive with the same uid — no raise, pod untouched.
-    svc.apply_json(_pod_manifest("p1", labels={POD_ATTEMPT_UID_LABEL: "sameuid000000000"}))
+    svc.apply_json(_pod_manifest("p1"))
     result = svc.get_json(K8sResource.PODS, "p1")
     assert result is not None
     assert result["status"]["phase"] == "Succeeded"

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -43,7 +43,7 @@ from iris.cluster.platforms.k8s.coreweave_topology import (
     KueueTopologyBinding,
     TopologyMode,
 )
-from iris.cluster.platforms.k8s.types import POD_ATTEMPT_UID_LABEL, parse_k8s_quantity
+from iris.cluster.platforms.k8s.types import parse_k8s_quantity
 from iris.cluster.runtime.env import STANDARD_MOUNTS
 from iris.cluster.runtime.types import MountKind
 from iris.cluster.types import JobName
@@ -210,16 +210,21 @@ def test_build_pod_manifest_task_hash_label():
     assert labels[_LABEL_TASK_HASH].isalnum()
 
 
-def test_build_pod_manifest_attempt_uid_label():
+def test_pod_name_embeds_attempt_uid():
+    """The uid is part of the pod name, so two incarnations of the same
+    (task, attempt) get distinct names and never collide on create. An empty uid
+    keeps the pre-uid name for back-compat."""
+    task = JobName.from_wire("/test-job/0")
+    with_old = _pod_name(task, 0, "olduid0000000000")
+    with_new = _pod_name(task, 0, "newuid1111111111")
+    assert with_old != with_new
+    assert with_old.endswith("-olduid0000000000")
+    assert _pod_name(task, 0, "") == _pod_name(task, 0)
+
+
+def test_build_pod_manifest_pod_name_carries_uid():
     manifest = _build_pod_manifest(make_run_req("/test-job/0", attempt_uid="abcd1234abcd1234"), pod_config())
-    assert manifest["metadata"]["labels"][POD_ATTEMPT_UID_LABEL] == "abcd1234abcd1234"
-
-
-def test_build_pod_manifest_omits_attempt_uid_label_when_unset():
-    """No uid (older controller / non-dispatch path) => no label, so apply stays
-    create-if-absent instead of treating every pod as a mismatch."""
-    labels = _build_pod_manifest(make_run_req("/test-job/0"), pod_config())["metadata"]["labels"]
-    assert POD_ATTEMPT_UID_LABEL not in labels
+    assert manifest["metadata"]["name"] == _pod_name(JobName.from_wire("/test-job/0"), 0, "abcd1234abcd1234")
 
 
 def test_task_hash_distinct_for_sanitization_collisions():

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -43,7 +43,7 @@ from iris.cluster.platforms.k8s.coreweave_topology import (
     KueueTopologyBinding,
     TopologyMode,
 )
-from iris.cluster.platforms.k8s.types import parse_k8s_quantity
+from iris.cluster.platforms.k8s.types import POD_ATTEMPT_UID_LABEL, parse_k8s_quantity
 from iris.cluster.runtime.env import STANDARD_MOUNTS
 from iris.cluster.runtime.types import MountKind
 from iris.cluster.types import JobName
@@ -208,6 +208,18 @@ def test_build_pod_manifest_task_hash_label():
     assert labels[_LABEL_TASK_HASH] == _task_hash("/test-job/0")
     assert len(labels[_LABEL_TASK_HASH]) <= 63
     assert labels[_LABEL_TASK_HASH].isalnum()
+
+
+def test_build_pod_manifest_attempt_uid_label():
+    manifest = _build_pod_manifest(make_run_req("/test-job/0", attempt_uid="abcd1234abcd1234"), pod_config())
+    assert manifest["metadata"]["labels"][POD_ATTEMPT_UID_LABEL] == "abcd1234abcd1234"
+
+
+def test_build_pod_manifest_omits_attempt_uid_label_when_unset():
+    """No uid (older controller / non-dispatch path) => no label, so apply stays
+    create-if-absent instead of treating every pod as a mismatch."""
+    labels = _build_pod_manifest(make_run_req("/test-job/0"), pod_config())["metadata"]["labels"]
+    assert POD_ATTEMPT_UID_LABEL not in labels
 
 
 def test_task_hash_distinct_for_sanitization_collisions():

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -135,31 +135,55 @@ def test_redrive_does_not_recreate_running_pod(provider, k8s):
     assert all(u.new_state != job_pb2.TASK_STATE_WORKER_FAILED for u in result)
 
 
-def test_resubmit_replaces_stale_terminal_pod(provider, k8s):
-    """A resubmit inheriting a previous run's Failed pod recreates a fresh pod.
+def test_resubmit_replaces_stale_pod_from_prior_attempt(provider, k8s):
+    """A resubmit inheriting a previous run's pod recreates a fresh pod.
 
     Pod names are deterministic in (task_hash, attempt_id) and attempt_id resets
     to 0 on resubmit, so a fresh attempt collides with the prior run's terminal
-    pod. Adopting it reported the dead attempt's verdict against the fresh one.
-    The apply must delete the stale pod and fail as WORKER_FAILED (retryable),
-    then the next tick recreates a fresh pod.
+    pod. The stale pod carries the old attempt_uid; the resubmit's differs, so the
+    apply deletes it and fails as WORKER_FAILED (retryable), then the next tick
+    recreates a fresh pod.
     """
-    req = make_run_req("/test-job/0")
     pod_name = _pod_name(JobName.from_wire("/test-job/0"), 0)
+    old = make_run_req("/test-job/0", attempt_uid="olduid0000000000")
+    new = make_run_req("/test-job/0", attempt_uid="newuid1111111111")
 
-    provider.sync(make_batch(tasks_to_run=[req]))
+    provider.sync(make_batch(tasks_to_run=[old]))
     k8s.transition_pod(pod_name, "Failed", exit_code=137, reason="OOMKilled")
 
-    # Resubmit: the same attempt-0 name now collides with the stale Failed pod.
-    result = provider.sync(make_batch(tasks_to_run=[req]))
+    # Resubmit: same attempt-0 name, new uid — the stale Failed pod is not ours.
+    result = provider.sync(make_batch(tasks_to_run=[new]))
     assert [u.new_state for u in result] == [job_pb2.TASK_STATE_WORKER_FAILED]
     assert k8s.get_json(K8sResource.PODS, pod_name) is None
 
     # Retry recreates a fresh pod that no longer carries the Failed verdict.
-    provider.sync(make_batch(tasks_to_run=[req]))
+    provider.sync(make_batch(tasks_to_run=[new]))
     pod_after = k8s.get_json(K8sResource.PODS, pod_name)
     assert pod_after is not None
     assert pod_after.get("status", {}).get("phase") != "Failed"
+
+
+def test_redrive_keeps_own_fast_finished_pod(provider, k8s):
+    """A redrive over the same attempt's just-finished pod keeps the verdict.
+
+    A task stays ASSIGNED (redriven in tasks_to_run) and also sits in
+    running_tasks until poll observes it, so an attempt that finishes before the
+    next scan is re-applied with its OWN attempt_uid. That terminal pod must be
+    left in place — deleting it would destroy a real result and misreport it as
+    WORKER_FAILED infra loss instead of the task's own verdict.
+    """
+    pod_name = _pod_name(JobName.from_wire("/test-job/0"), 0)
+    req = make_run_req("/test-job/0", attempt_uid="sameuid000000000")
+
+    provider.sync(make_batch(tasks_to_run=[req]))
+    k8s.transition_pod(pod_name, "Failed", exit_code=1, reason="Error")
+
+    # Redrive with the same uid: not treated as stale, pod kept for poll to read.
+    result = provider.sync(make_batch(tasks_to_run=[req]))
+    assert all(u.new_state != job_pb2.TASK_STATE_WORKER_FAILED for u in result)
+    pod_after = k8s.get_json(K8sResource.PODS, pod_name)
+    assert pod_after is not None
+    assert pod_after["status"]["phase"] == "Failed"
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -135,50 +135,48 @@ def test_redrive_does_not_recreate_running_pod(provider, k8s):
     assert all(u.new_state != job_pb2.TASK_STATE_WORKER_FAILED for u in result)
 
 
-def test_resubmit_replaces_stale_pod_from_prior_attempt(provider, k8s):
-    """A resubmit inheriting a previous run's pod recreates a fresh pod.
+def test_resubmit_gets_fresh_pod_not_prior_incarnation(provider, k8s):
+    """A resubmit gets its own pod instead of adopting the prior run's verdict.
 
-    Pod names are deterministic in (task_hash, attempt_id) and attempt_id resets
-    to 0 on resubmit, so a fresh attempt collides with the prior run's terminal
-    pod. The stale pod carries the old attempt_uid; the resubmit's differs, so the
-    apply deletes it and fails as WORKER_FAILED (retryable), then the next tick
-    recreates a fresh pod.
+    A resubmit reuses (task_id, attempt_id) but mints a new attempt_uid, and the
+    uid is part of the pod name, so the two incarnations have distinct names. The
+    fresh attempt's create just succeeds; the previous run's Failed pod is left
+    untouched under its own name (reaped later by terminal GC), never adopted.
     """
-    pod_name = _pod_name(JobName.from_wire("/test-job/0"), 0)
+    task = JobName.from_wire("/test-job/0")
     old = make_run_req("/test-job/0", attempt_uid="olduid0000000000")
     new = make_run_req("/test-job/0", attempt_uid="newuid1111111111")
+    old_pod = _pod_name(task, 0, "olduid0000000000")
+    new_pod = _pod_name(task, 0, "newuid1111111111")
+    assert old_pod != new_pod
 
     provider.sync(make_batch(tasks_to_run=[old]))
-    k8s.transition_pod(pod_name, "Failed", exit_code=137, reason="OOMKilled")
+    k8s.transition_pod(old_pod, "Failed", exit_code=137, reason="OOMKilled")
 
-    # Resubmit: same attempt-0 name, new uid — the stale Failed pod is not ours.
+    # Resubmit: no collision, no WORKER_FAILED — a fresh pod is created.
     result = provider.sync(make_batch(tasks_to_run=[new]))
-    assert [u.new_state for u in result] == [job_pb2.TASK_STATE_WORKER_FAILED]
-    assert k8s.get_json(K8sResource.PODS, pod_name) is None
-
-    # Retry recreates a fresh pod that no longer carries the Failed verdict.
-    provider.sync(make_batch(tasks_to_run=[new]))
-    pod_after = k8s.get_json(K8sResource.PODS, pod_name)
-    assert pod_after is not None
-    assert pod_after.get("status", {}).get("phase") != "Failed"
+    assert all(u.new_state != job_pb2.TASK_STATE_WORKER_FAILED for u in result)
+    fresh = k8s.get_json(K8sResource.PODS, new_pod)
+    assert fresh is not None
+    assert fresh.get("status", {}).get("phase") != "Failed"
+    # The stale pod is not touched by apply; terminal GC reaps it by age.
+    assert k8s.get_json(K8sResource.PODS, old_pod) is not None
 
 
 def test_redrive_keeps_own_fast_finished_pod(provider, k8s):
     """A redrive over the same attempt's just-finished pod keeps the verdict.
 
-    A task stays ASSIGNED (redriven in tasks_to_run) and also sits in
-    running_tasks until poll observes it, so an attempt that finishes before the
-    next scan is re-applied with its OWN attempt_uid. That terminal pod must be
-    left in place — deleting it would destroy a real result and misreport it as
-    WORKER_FAILED infra loss instead of the task's own verdict.
+    A task stays ASSIGNED (redriven in tasks_to_run) until poll observes it, so an
+    attempt that finishes before the next scan is re-applied under its OWN name
+    (same uid). Create-if-absent leaves that terminal pod in place so poll reads
+    its verdict, instead of resetting it.
     """
-    pod_name = _pod_name(JobName.from_wire("/test-job/0"), 0)
     req = make_run_req("/test-job/0", attempt_uid="sameuid000000000")
+    pod_name = _pod_name(JobName.from_wire("/test-job/0"), 0, "sameuid000000000")
 
     provider.sync(make_batch(tasks_to_run=[req]))
     k8s.transition_pod(pod_name, "Failed", exit_code=1, reason="Error")
 
-    # Redrive with the same uid: not treated as stale, pod kept for poll to read.
     result = provider.sync(make_batch(tasks_to_run=[req]))
     assert all(u.new_state != job_pb2.TASK_STATE_WORKER_FAILED for u in result)
     pod_after = k8s.get_json(K8sResource.PODS, pod_name)

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -135,6 +135,33 @@ def test_redrive_does_not_recreate_running_pod(provider, k8s):
     assert all(u.new_state != job_pb2.TASK_STATE_WORKER_FAILED for u in result)
 
 
+def test_resubmit_replaces_stale_terminal_pod(provider, k8s):
+    """A resubmit inheriting a previous run's Failed pod recreates a fresh pod.
+
+    Pod names are deterministic in (task_hash, attempt_id) and attempt_id resets
+    to 0 on resubmit, so a fresh attempt collides with the prior run's terminal
+    pod. Adopting it reported the dead attempt's verdict against the fresh one.
+    The apply must delete the stale pod and fail as WORKER_FAILED (retryable),
+    then the next tick recreates a fresh pod.
+    """
+    req = make_run_req("/test-job/0")
+    pod_name = _pod_name(JobName.from_wire("/test-job/0"), 0)
+
+    provider.sync(make_batch(tasks_to_run=[req]))
+    k8s.transition_pod(pod_name, "Failed", exit_code=137, reason="OOMKilled")
+
+    # Resubmit: the same attempt-0 name now collides with the stale Failed pod.
+    result = provider.sync(make_batch(tasks_to_run=[req]))
+    assert [u.new_state for u in result] == [job_pb2.TASK_STATE_WORKER_FAILED]
+    assert k8s.get_json(K8sResource.PODS, pod_name) is None
+
+    # Retry recreates a fresh pod that no longer carries the Failed verdict.
+    provider.sync(make_batch(tasks_to_run=[req]))
+    pod_after = k8s.get_json(K8sResource.PODS, pod_name)
+    assert pod_after is not None
+    assert pod_after.get("status", {}).get("phase") != "Failed"
+
+
 # ---------------------------------------------------------------------------
 # sync(): stray pod deletion (kill via desired-set diff)
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -130,6 +130,24 @@ def test_drain_pending_creates_attempt_rows(state):
     assert attempt.worker_id is None
 
 
+def test_drain_stamps_attempt_uid(state):
+    """The dispatched RunTaskRequest carries the attempt's minted uid, and a
+    redrive of the same attempt keeps it — so the K8s backend can label the pod
+    and tell this attempt's pod apart from a stale resubmit pod."""
+    [task_id] = submit_direct_job(state, "drain-uid")
+
+    with state._db.transaction() as cur:
+        batch = dispatch.drain_for_dispatch(cur)
+    uid = batch.tasks_to_run[0].attempt_uid
+    assert uid
+    assert uid == query_attempt(state, task_id, 0).attempt_uid
+
+    # Redrive (still ASSIGNED+null-worker) rebuilds the request with the same uid.
+    with state._db.transaction() as cur:
+        redriven = dispatch.drain_for_dispatch(cur)
+    assert redriven.tasks_to_run[0].attempt_uid == uid
+
+
 def test_drain_propagates_task_image(state):
     """task_image set on the LaunchJobRequest is copied into RunTaskRequest."""
     [task_id] = submit_direct_job(state, "drain-task-image", task_image="custom/swetrace:dev")


### PR DESCRIPTION
Resubmitting a job whose previous run left a pod behind failed instantly with the previous attempt's log tail. Pod names were deterministic in (task_hash, attempt_id), and attempt_id resets to 0 on resubmit, so the fresh attempt collided with the stale pod; pod apply was create-if-absent, so it kept the stale pod and poll reported that dead attempt's verdict. Observed on cw-us-east-08a: six consecutive allocate runs failed after an OOMKilled holder pod lingered; a manual kubectl delete pod restored allocation.

Fix the collision at the source: make the pod name incarnation-unique. Pods are immutable and a terminated pod cannot be revived, so no apply/patch/replace policy turns the leftover pod into the fresh attempt — the leverage is the name. _pod_name now embeds attempt_uid (minted per attempt), so a resubmit that reuses (task_id, attempt_id) but mints a new uid gets a distinct name and plain create always succeeds; the stale pod keeps its own name and is reaped by the age-based terminal GC. _apply_pod stays plain create-if-absent — no 409 handling, no delete.

attempt_uid threads into the k8s RunTaskRequest (build_run_request), onto RunningTaskEntry (bulk reads.attempt_uids_for) and TaskTarget so poll/profile/exec rebuild the name. Empty uid keeps the pre-uid name for non-dispatch paths.

Fixes #7516
