### PR TITLE
[datakit] Read SEC-EDGAR shards with DuckDB for giant page headers

### DIFF
--- a/lib/marin/pyproject.toml
+++ b/lib/marin/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "braceexpand",
     "datasets<5.0.0",
     "draccus>=0.11.6",
+    "duckdb>=1.0.0",
     "fasttext-wheel>=0.9.2",
     "marin-fray",
     "marin-iris",

--- a/lib/marin/src/marin/datakit/download/sec_edgar.py
+++ b/lib/marin/src/marin/datakit/download/sec_edgar.py
@@ -6,13 +6,16 @@
 from __future__ import annotations
 
 import logging
+import tempfile
 from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 
+import duckdb
 import pyarrow as pa
 import pyarrow.parquet as pq
 from fray.types import ResourceConfig
-from huggingface_hub import HfFileSystem
+from huggingface_hub import HfFileSystem, hf_hub_download
 from rigging.filesystem import StoragePath, prefix_join
 from rigging.timing import ExponentialBackoff, retry_with_backoff
 from zephyr import counters
@@ -33,16 +36,9 @@ _HF_URL_ROOT = StoragePath("hf://datasets") / HF_DATASET_ID
 
 FILING_TYPES = ("10-K", "10-Q", "8-K", "20-F", "S-1", "S-8", "144", "3", "4", "5")
 
-# HF rate-limits aggressively; a small batch reader keeps memory bounded
-# while one big SEC row group (~700 MB decompressed) is in flight.
+# A small batch reader keeps memory bounded while one big SEC row group
+# (~700 MB decompressed) is in flight.
 _ROWS_PER_BATCH = 8
-
-# Lift PyArrow's Thrift decoder caps so page headers carrying multi-MB
-# string statistics (apache/arrow#46404) decode without "Couldn't
-# deserialize thrift" errors. 1 GiB is well above any plausible single
-# page header in SEC's content column (~tens of MB worst case) while
-# still bounded.
-_THRIFT_DECODE_LIMIT_BYTES = 1024 * 1024 * 1024
 
 # Per-file retry policy for HF rate limits and transient network failures.
 _MAX_RETRIES = 20
@@ -62,39 +58,70 @@ class _DownloadResult:
     rows: int
 
 
-def _iter_parquet_batches(hf_path: str, *, revision: str = HF_REVISION) -> Iterator[pa.RecordBatch]:
-    """Yield record batches from one revision-pinned SEC-EDGAR shard."""
-    with StoragePath(hf_path).open("rb", revision=revision) as source:
-        # SEC's multi-MB content values can produce page headers above PyArrow's
-        # default Thrift limits. See https://github.com/marin-community/marin/issues/5334.
-        parquet_file = pq.ParquetFile(
-            source,
-            thrift_string_size_limit=_THRIFT_DECODE_LIMIT_BYTES,
-            thrift_container_size_limit=_THRIFT_DECODE_LIMIT_BYTES,
+def _path_in_repo(hf_path: str) -> str:
+    """Return a shard URL's in-repo path (e.g. ``10-K/<uuid>-<n>.parquet``)."""
+    return str(StoragePath(hf_path).relative_to(_HF_URL_ROOT))
+
+
+@contextmanager
+def _fetch_shard(hf_path: str, *, revision: str = HF_REVISION) -> Iterator[str]:
+    """Download one shard to a local temp file and yield its path.
+
+    DuckDB (the reader in :func:`_iter_parquet_batches`) needs a local file, and
+    ``hf_hub_download`` provides one with a resumable, integrity-checked,
+    revision-pinned transfer.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        yield hf_hub_download(
+            repo_id=HF_DATASET_ID,
+            filename=_path_in_repo(hf_path),
+            revision=revision,
+            repo_type="dataset",
+            local_dir=tmp_dir,
         )
-        yield from parquet_file.iter_batches(batch_size=_ROWS_PER_BATCH)
+
+
+def _iter_parquet_batches(local_path: str) -> Iterator[pa.RecordBatch]:
+    """Yield record batches from a locally-downloaded SEC-EDGAR shard.
+
+    Read with DuckDB rather than PyArrow. SEC's multi-MB ``content`` values
+    produce parquet page-header statistics that PyArrow's Thrift decoder cannot
+    deserialize -- ``Couldn't deserialize thrift: No more data to read``
+    (apache/arrow#46404) -- even with raised decoder limits, while DuckDB reads
+    them without issue. The re-encode in :func:`_download_once` then emits
+    pyarrow-readable shards for downstream normalize.
+    """
+    connection = duckdb.connect()
+    try:
+        reader = connection.execute("SELECT * FROM read_parquet($shard)", {"shard": local_path}).to_arrow_reader(
+            _ROWS_PER_BATCH
+        )
+        yield from reader
+    finally:
+        connection.close()
 
 
 def _download_once(task: _DownloadTask) -> _DownloadResult:
     ensure_parent_dir(task.destination_path)
     count = 0
-    batches = _iter_parquet_batches(task.hf_path)
-    first = next(batches, None)
-    if first is None:
-        counters.pipeline.update_counter("sec_edgar/empty_input", 1)
-        return _DownloadResult(hf_path=task.hf_path, destination_path=task.destination_path, rows=0)
-    with atomic_rename(task.destination_path) as temporary_path:
-        # Route the write through zephyr's sink so the parquet stream reaches a
-        # pyarrow filesystem carrying the S3 endpoint's virtual-host addressing.
-        # A bare s3:// string builds a default path-style client, which CoreWeave
-        # object storage rejects on multipart upload (PathStyleRequestNotAllowed).
-        with parquet_sink(temporary_path) as (where_fd, native_fs):
-            with pq.ParquetWriter(where_fd, first.schema, filesystem=native_fs) as writer:
-                writer.write_batch(first)
-                count += first.num_rows
-                for batch in batches:
-                    writer.write_batch(batch)
-                    count += batch.num_rows
+    with _fetch_shard(task.hf_path) as local_shard:
+        batches = _iter_parquet_batches(local_shard)
+        first = next(batches, None)
+        if first is None:
+            counters.pipeline.update_counter("sec_edgar/empty_input", 1)
+            return _DownloadResult(hf_path=task.hf_path, destination_path=task.destination_path, rows=0)
+        with atomic_rename(task.destination_path) as temporary_path:
+            # Route the write through zephyr's sink so the parquet stream reaches a
+            # pyarrow filesystem carrying the S3 endpoint's virtual-host addressing.
+            # A bare s3:// string builds a default path-style client, which CoreWeave
+            # object storage rejects on multipart upload (PathStyleRequestNotAllowed).
+            with parquet_sink(temporary_path) as (where_fd, native_fs):
+                with pq.ParquetWriter(where_fd, first.schema, filesystem=native_fs) as writer:
+                    writer.write_batch(first)
+                    count += first.num_rows
+                    for batch in batches:
+                        writer.write_batch(batch)
+                        count += batch.num_rows
     counters.pipeline.update_counter("sec_edgar/rows_downloaded", count)
     return _DownloadResult(hf_path=task.hf_path, destination_path=task.destination_path, rows=count)
 
@@ -119,7 +146,7 @@ def _list_hf_parquets() -> list[str]:
             # glob(..., revision=...) embeds the pin in the repo segment
             # (``datasets/<repo>@<rev>/...``); resolve_path recovers the clean
             # in-repo path so the emitted hf:// URL stays revision-free (the pin
-            # is reapplied at open time in _iter_parquet_batches).
+            # is reapplied when the shard is fetched in _fetch_shard).
             relative_path = filesystem.resolve_path(parquet_path).path_in_repo
             paths.append(str(_HF_URL_ROOT / relative_path))
     paths.sort()
@@ -149,7 +176,9 @@ def download_sec_edgar(output_path: str) -> None:
             skip_existing=True,
         )
     )
-    context = ZephyrContext(name="download-sec-edgar", resources=ResourceConfig(cpu=1, ram="16g"))
+    # disk headroom: each shard is now staged to a local temp file for the DuckDB
+    # read + re-encode, so a worker holds one full shard on disk at a time.
+    context = ZephyrContext(name="download-sec-edgar", resources=ResourceConfig(cpu=1, ram="16g", disk="10g"))
     context.execute(pipeline)
 
     write_provenance_json(

--- a/lib/marin/src/marin/datakit/download/sec_edgar.py
+++ b/lib/marin/src/marin/datakit/download/sec_edgar.py
@@ -82,15 +82,12 @@ def _fetch_shard(hf_path: str, *, revision: str = HF_REVISION) -> Iterator[str]:
 
 
 def _iter_parquet_batches(local_path: str) -> Iterator[pa.RecordBatch]:
-    """Yield record batches from a locally-downloaded SEC-EDGAR shard.
-
-    Read with DuckDB rather than PyArrow. SEC's multi-MB ``content`` values
-    produce parquet page-header statistics that PyArrow's Thrift decoder cannot
-    deserialize -- ``Couldn't deserialize thrift: No more data to read``
-    (apache/arrow#46404) -- even with raised decoder limits, while DuckDB reads
-    them without issue. The re-encode in :func:`_download_once` then emits
-    pyarrow-readable shards for downstream normalize.
-    """
+    """Yield record batches from a locally-downloaded SEC-EDGAR shard."""
+    # Read with DuckDB, not PyArrow: SEC's multi-MB `content` values produce
+    # parquet page-header statistics that PyArrow 23's Thrift decoder cannot
+    # deserialize ("Couldn't deserialize thrift: No more data to read",
+    # apache/arrow#46404), even with raised decoder limits, while DuckDB reads
+    # them. _download_once re-encodes the batches into pyarrow-readable shards.
     connection = duckdb.connect()
     try:
         reader = connection.execute("SELECT * FROM read_parquet($shard)", {"shard": local_path}).to_arrow_reader(

--- a/lib/marin/src/marin/datakit/download/sec_edgar.py
+++ b/lib/marin/src/marin/datakit/download/sec_edgar.py
@@ -6,16 +6,15 @@
 from __future__ import annotations
 
 import logging
-import tempfile
 from collections.abc import Iterator
-from contextlib import contextmanager
 from dataclasses import dataclass
 
 import duckdb
+import fsspec
 import pyarrow as pa
 import pyarrow.parquet as pq
 from fray.types import ResourceConfig
-from huggingface_hub import HfFileSystem, hf_hub_download
+from huggingface_hub import HfFileSystem
 from rigging.filesystem import StoragePath, prefix_join
 from rigging.timing import ExponentialBackoff, retry_with_backoff
 from zephyr import counters
@@ -58,41 +57,26 @@ class _DownloadResult:
     rows: int
 
 
-def _path_in_repo(hf_path: str) -> str:
-    """Return a shard URL's in-repo path (e.g. ``10-K/<uuid>-<n>.parquet``)."""
-    return str(StoragePath(hf_path).relative_to(_HF_URL_ROOT))
+def _revision_pinned_url(hf_path: str, revision: str) -> str:
+    """Insert the revision pin into a shard URL: ``hf://datasets/<repo>@<rev>/<in-repo>``."""
+    in_repo = StoragePath(hf_path).relative_to(_HF_URL_ROOT)
+    return str(StoragePath(f"hf://datasets/{HF_DATASET_ID}@{revision}") / in_repo)
 
 
-@contextmanager
-def _fetch_shard(hf_path: str, *, revision: str = HF_REVISION) -> Iterator[str]:
-    """Download one shard to a local temp file and yield its path.
-
-    DuckDB (the reader in :func:`_iter_parquet_batches`) needs a local file, and
-    ``hf_hub_download`` provides one with a resumable, integrity-checked,
-    revision-pinned transfer.
-    """
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        yield hf_hub_download(
-            repo_id=HF_DATASET_ID,
-            filename=_path_in_repo(hf_path),
-            revision=revision,
-            repo_type="dataset",
-            local_dir=tmp_dir,
-        )
-
-
-def _iter_parquet_batches(local_path: str) -> Iterator[pa.RecordBatch]:
-    """Yield record batches from a locally-downloaded SEC-EDGAR shard."""
+def _iter_parquet_batches(hf_path: str, *, revision: str = HF_REVISION) -> Iterator[pa.RecordBatch]:
+    """Yield record batches from one revision-pinned SEC-EDGAR shard."""
     # Read with DuckDB, not PyArrow: SEC's multi-MB `content` values produce
     # parquet page-header statistics that PyArrow 23's Thrift decoder cannot
     # deserialize ("Couldn't deserialize thrift: No more data to read",
     # apache/arrow#46404), even with raised decoder limits, while DuckDB reads
     # them. _download_once re-encodes the batches into pyarrow-readable shards.
+    # DuckDB reads the shard over the fsspec HfFileSystem (no local staging).
     connection = duckdb.connect()
     try:
-        reader = connection.execute("SELECT * FROM read_parquet($shard)", {"shard": local_path}).to_arrow_reader(
-            _ROWS_PER_BATCH
-        )
+        connection.register_filesystem(fsspec.filesystem("hf"))
+        reader = connection.execute(
+            "SELECT * FROM read_parquet($shard)", {"shard": _revision_pinned_url(hf_path, revision)}
+        ).to_arrow_reader(_ROWS_PER_BATCH)
         yield from reader
     finally:
         connection.close()
@@ -101,24 +85,23 @@ def _iter_parquet_batches(local_path: str) -> Iterator[pa.RecordBatch]:
 def _download_once(task: _DownloadTask) -> _DownloadResult:
     ensure_parent_dir(task.destination_path)
     count = 0
-    with _fetch_shard(task.hf_path) as local_shard:
-        batches = _iter_parquet_batches(local_shard)
-        first = next(batches, None)
-        if first is None:
-            counters.pipeline.update_counter("sec_edgar/empty_input", 1)
-            return _DownloadResult(hf_path=task.hf_path, destination_path=task.destination_path, rows=0)
-        with atomic_rename(task.destination_path) as temporary_path:
-            # Route the write through zephyr's sink so the parquet stream reaches a
-            # pyarrow filesystem carrying the S3 endpoint's virtual-host addressing.
-            # A bare s3:// string builds a default path-style client, which CoreWeave
-            # object storage rejects on multipart upload (PathStyleRequestNotAllowed).
-            with parquet_sink(temporary_path) as (where_fd, native_fs):
-                with pq.ParquetWriter(where_fd, first.schema, filesystem=native_fs) as writer:
-                    writer.write_batch(first)
-                    count += first.num_rows
-                    for batch in batches:
-                        writer.write_batch(batch)
-                        count += batch.num_rows
+    batches = _iter_parquet_batches(task.hf_path)
+    first = next(batches, None)
+    if first is None:
+        counters.pipeline.update_counter("sec_edgar/empty_input", 1)
+        return _DownloadResult(hf_path=task.hf_path, destination_path=task.destination_path, rows=0)
+    with atomic_rename(task.destination_path) as temporary_path:
+        # Route the write through zephyr's sink so the parquet stream reaches a
+        # pyarrow filesystem carrying the S3 endpoint's virtual-host addressing.
+        # A bare s3:// string builds a default path-style client, which CoreWeave
+        # object storage rejects on multipart upload (PathStyleRequestNotAllowed).
+        with parquet_sink(temporary_path) as (where_fd, native_fs):
+            with pq.ParquetWriter(where_fd, first.schema, filesystem=native_fs) as writer:
+                writer.write_batch(first)
+                count += first.num_rows
+                for batch in batches:
+                    writer.write_batch(batch)
+                    count += batch.num_rows
     counters.pipeline.update_counter("sec_edgar/rows_downloaded", count)
     return _DownloadResult(hf_path=task.hf_path, destination_path=task.destination_path, rows=count)
 
@@ -143,7 +126,7 @@ def _list_hf_parquets() -> list[str]:
             # glob(..., revision=...) embeds the pin in the repo segment
             # (``datasets/<repo>@<rev>/...``); resolve_path recovers the clean
             # in-repo path so the emitted hf:// URL stays revision-free (the pin
-            # is reapplied when the shard is fetched in _fetch_shard).
+            # is reapplied when the shard is read in _iter_parquet_batches).
             relative_path = filesystem.resolve_path(parquet_path).path_in_repo
             paths.append(str(_HF_URL_ROOT / relative_path))
     paths.sort()
@@ -173,9 +156,7 @@ def download_sec_edgar(output_path: str) -> None:
             skip_existing=True,
         )
     )
-    # disk headroom: each shard is now staged to a local temp file for the DuckDB
-    # read + re-encode, so a worker holds one full shard on disk at a time.
-    context = ZephyrContext(name="download-sec-edgar", resources=ResourceConfig(cpu=1, ram="16g", disk="10g"))
+    context = ZephyrContext(name="download-sec-edgar", resources=ResourceConfig(cpu=1, ram="16g"))
     context.execute(pipeline)
 
     write_provenance_json(

--- a/uv.lock
+++ b/uv.lock
@@ -4133,6 +4133,7 @@ dependencies = [
     { name = "braceexpand" },
     { name = "datasets" },
     { name = "draccus" },
+    { name = "duckdb" },
     { name = "fasttext-wheel" },
     { name = "fsspec" },
     { name = "gcsfs" },
@@ -4294,6 +4295,7 @@ requires-dist = [
     { name = "braceexpand" },
     { name = "datasets", specifier = "<5.0.0" },
     { name = "draccus", specifier = ">=0.11.6" },
+    { name = "duckdb", specifier = ">=1.0.0" },
     { name = "faiss-cpu", marker = "extra == 'datakit'" },
     { name = "fasttext-wheel", specifier = ">=0.9.2" },
     { name = "flash-attn-4", extras = ["cu13"], marker = "sys_platform == 'linux' and extra == 'gpu'", specifier = ">=4.0.0b16,<4.1" },
@@ -10945,7 +10947,7 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.20.1rc1.dev1465+gafb267194.tpu"
+version = "1+tpu"
 source = { git = "https://github.com/marin-community/vllm.git?rev=afb26719464d5957e695bde478ae93a160b11d14#afb26719464d5957e695bde478ae93a160b11d14" }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
SEC-EDGAR shards store multi-MB documents in the `content` column, whose per-page parquet statistics produce page headers that PyArrow 23's Thrift decoder cannot deserialize -- `Couldn't deserialize thrift: No more data to read` (apache/arrow#46404) -- even with the string and container size limits raised to 1 GiB. The failure is in the reader, not the transport: a fully downloaded local shard fails the same way, on the row groups holding the largest documents (a single 22 MB document is enough), and no read option, buffering setting, or scanner variant gets past it.

Read each shard with DuckDB, which decodes these headers without issue, over the fsspec HfFileSystem registered on the DuckDB connection -- so access stays on fsspec and no shard is staged to worker disk. Re-encode through the existing virtual-host `parquet_sink`; the re-encoded shard carries ordinary PyArrow-written page headers, so downstream normalize reads it.

Verified on `10-K/bc44a4a5-...-12.parquet` (1335 rows; two of its five row groups are unreadable by PyArrow): the shard reads fully via DuckDB and re-encodes to a pyarrow-readable file with the schema preserved. Adds `duckdb` as a marin dependency.
