### PR TITLE
[grafana] Add rack alerting, home dashboard, and dedupe drifted panels

### DIFF
--- a/infra/grafana/Dockerfile
+++ b/infra/grafana/Dockerfile
@@ -47,7 +47,14 @@ RUN cd /opt/bridge \
     && UV_PROJECT_ENVIRONMENT=/opt/bridge/venv uv sync --frozen --no-dev --compile-bytecode
 
 COPY provisioning /etc/grafana/provisioning
-COPY dashboards /etc/grafana/dashboards
+# dashboards/*.json holds panelRef markers for panels shared across dashboards
+# (see src/dashboard_stitch.py); this resolves them into the full panel bodies
+# Grafana actually loads, the same way the infra-panel build above resolves
+# TSX into JS. The source stays git-reviewable; only the resolved output ships.
+COPY dashboards /tmp/dashboards-src
+RUN /opt/bridge/venv/bin/python -m dashboard_stitch \
+    --src-dir /tmp/dashboards-src --panels-dir /tmp/dashboards-src/panels --out-dir /etc/grafana/dashboards \
+    && rm -rf /tmp/dashboards-src
 COPY entrypoint.sh /opt/entrypoint.sh
 RUN chmod +x /opt/entrypoint.sh && chown -R grafana:root /opt/bridge /etc/grafana/dashboards
 

--- a/infra/grafana/Dockerfile
+++ b/infra/grafana/Dockerfile
@@ -86,6 +86,7 @@ ENV GF_SMTP_HOST=smtp.gmail.com:587 \
     GF_SMTP_STARTTLS_POLICY=MandatoryStartTLS
 
 ENV GF_PATHS_PROVISIONING=/etc/grafana/provisioning \
+    GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/dashboards/home.json \
     GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=marin-infra-panel \
     GF_AUTH_ANONYMOUS_ENABLED=true \
     GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer \

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -127,8 +127,10 @@ src/discovery.py       GCE label -> internal IP
 src/config.py          cluster targets, watched components, and bridge settings
 src/cache.py           TTL cache with in-flight coalescing
 src/errors.py          UpstreamError -> 5xx
+src/dashboard_stitch.py  resolves dashboards/*.json panelRef markers into full panel bodies
 provisioning/          datasources (finelog, iris, github, k8s), dashboards, alerting
-dashboards/            dashboard JSON — reviewed like code
+dashboards/            dashboard JSON source — reviewed like code; see "Adding a dashboard"
+dashboards/panels/     panel bodies shared across dashboards, referenced by panelRef
 marin-infra-panel/     internal React panel for the matrix, CI strip, and W&B charts
 Dockerfile             Grafana + bridge venv + pinned Infinity and internal panel plugins
 entrypoint.sh          runs both; if either dies the container dies
@@ -302,3 +304,33 @@ Write the window into the SQL as `{{from}}` / `{{to}}`, and bin the time axis wi
 `date_bin(INTERVAL '${__interval_ms} milliseconds', ts)` so Grafana sizes the
 buckets to the panel — see `dashboards/iris.json`. All dashboards use the
 `${cluster}` datasource variable so one serves marin and marin-dev.
+
+## Sharing a panel across dashboards
+
+A panel that belongs on more than one dashboard (e.g. the k8s workload-issue
+tables that also appear on the `infra.json` cockpit) is a single fragment file
+under `dashboards/panels/<name>.json` — the panel's full body (type, title,
+description, datasource, fieldConfig, options, targets) with `id` and `gridPos`
+omitted, since those two fields are the only ones that legitimately vary by
+placement. Each dashboard references it with a stitch marker instead of the full
+body:
+
+```json
+{ "id": 4, "gridPos": { "h": 8, "w": 24, "x": 0, "y": 7 }, "panelRef": "control_plane_components" }
+```
+
+`src/dashboard_stitch.py` resolves every `panelRef` marker into its fragment body
+at image build time (Dockerfile), the same way the `marin-infra-panel` build above
+resolves TSX into JS — the fragment is the reviewed source, the merged dashboard
+JSON `/etc/grafana/dashboards` ships to the container is derived, not committed.
+`uv run pytest` runs the same resolution before asserting datasource UIDs, filter
+expressions, and stat-panel schemas, so a stitching mistake fails locally, not
+after a deploy. This was the fix for `infra.json`'s k8s panels drifting from the
+bridge's actual field names (`phase`/`count`/`involved_object` that the routes no
+longer return) — a panel shared this way can only go stale in one place.
+
+Deliberately not a Grafana library panel: those live in Grafana's Postgres state,
+not git, and only sync through the Library Elements HTTP API — no file-based
+provisioning exists for them as of Grafana 13.x. A `panelRef` fragment stays
+100% file-provisioned like everything else here, at the cost of only resolving
+at build time rather than being editable through the Grafana UI.

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -38,6 +38,7 @@ GET /k8s/control_plane | crashloops | pending     CW control-plane state, all cl
 GET /k8s/termination_candidates | kueue | events | health
                                                     ... one response, `cluster` column
 GET /k8s/overview                                 explicit pending/crashloop counts
+GET /k8s/gpu_racks                                GPU nodes grouped by physical rack: trays total/ready
 GET /k8s/alerts/{unreachable,crashloops,          alert rows: string labels + one
      webhook_ready,degraded,stuck_gpu_pods}       numeric, >=1 row per cluster
 GET /health                                       bridge liveness
@@ -87,6 +88,14 @@ finalizers. The pod-level scans skip provider-managed namespaces (`cw-*`, `kube-
 CoreWeave's per-node daemons are thousands of pods of someone else's infrastructure,
 while the namespaces we operate hold about a hundred. These are current-state reads —
 the bridge stores no history; trends come from the finelog-backed rows.
+
+`gpu_racks` lists every node with `nvidia.com/gpu` capacity, grouped by its
+CoreWeave `node.coreweave.cloud/rack` label, with the rack's full name
+(`ds.coreweave.com/physical-topology.rack-name`), instance type, and how many of
+its trays are registered vs. Ready. A tray that never re-registers with the k8s
+API — the common failure mode after hardware maintenance — is invisible here, so
+a rack short of its physical capacity (18 trays for a GB200 NVL72 rack, one CoreWeave
+rack) is a floor on what's down, not a guarantee.
 
 The `/k8s/alerts/*` routes exist for Grafana's table-alert contract: string label
 columns plus exactly one numeric column, and always at least one row per cluster — an

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -143,12 +143,23 @@ __main__.py            Pulumi entry point — the Cloud Run service (iac.gcp.clo
 Pulumi.yaml            Pulumi project, run on the shared repo venv
 ```
 
-Dashboards: `infra.json` (the compact cockpit — nightlies, CI and ferries, Iris capacity,
-provisioning, control-plane health, Kubernetes workload state, and hero training), `fleet.json` (canary +
+Dashboards: `home.json` (the landing page — see below), `infra.json` (the compact
+cockpit — nightlies, CI and ferries, Iris capacity, provisioning, control-plane
+health, Kubernetes workload state, and hero training), `fleet.json` (canary +
 worker health), `iris.json`
 (per-task and per-worker resource usage), `pipelines.json` (Zephyr throughput and shard
 memory), `training.json` (levanter training metrics from the `telltale` namespace,
 grouped by run), `k8s.json` (current CW control-plane state from the k8s source).
+
+`home.json` is provisioned as the default home dashboard
+(`GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/dashboards/home.json`,
+the stitcher's output path) — everyone who opens grafana.oa.dev without a
+specific dashboard in mind lands here instead of Grafana's stock welcome page.
+It leads with a native `alertlist` panel (every rule currently Alerting or
+Pending, across every group), then a row of the same GCP/Iris and CoreWeave
+k8s health stats as `infra.json`'s cockpit, the control-plane components
+table, and the GB200 rack tray inventory — all shared `panelRef` fragments, so
+none of it drifts independently of the dashboards those fragments also serve.
 
 ## Alerting
 
@@ -162,9 +173,9 @@ Rules page only on near-certain incidents: an unreachable cluster, a
 crash-looping watched component, an admission webhook with no ready endpoints, a
 degraded component, a dead Iris controller, a GPU pod that stays node-bound and
 nonterminal without finalizers for five minutes after the bridge's two-minute
-overdue threshold, and a GPU rack with fewer than 16 trays Ready for 15 minutes
-(the GB200 NVL72 rack spec is 18; a floor rather than an outright outage — see
-`gpu_racks` above). The stuck-pod rule groups by node and links the cordon-first
+overdue threshold, and a GB200 rack with fewer than 16 trays Ready for five
+minutes (the NVL72 rack spec is 18; a floor rather than an outright outage —
+see `gpu_racks` above). The stuck-pod rule groups by node and links the cordon-first
 recovery skill; terminal, unbound, and finalizer-held pods stay dashboard-only.
 Other workload-tier signals (gated pods, Kueue backlog, workload crashloops) are
 dashboard-only because they have expected benign causes. `severity=critical` routes to `ops-critical` (email ops@openathena.ai +

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -90,13 +90,18 @@ CoreWeave's per-node daemons are thousands of pods of someone else's infrastruct
 while the namespaces we operate hold about a hundred. These are current-state reads —
 the bridge stores no history; trends come from the finelog-backed rows.
 
-`gpu_racks` lists every node with `nvidia.com/gpu` capacity, grouped by its
-CoreWeave `node.coreweave.cloud/rack` label, with the rack's full name
+`gpu_racks` lists every GB200 NVL72 node (`nvidia.com/gpu` capacity present and
+`node.kubernetes.io/instance-type` containing `gb200`), grouped by its CoreWeave
+`node.coreweave.cloud/rack` label, with the rack's full name
 (`ds.coreweave.com/physical-topology.rack-name`), instance type, and how many of
-its trays are registered vs. Ready. A tray that never re-registers with the k8s
-API — the common failure mode after hardware maintenance — is invisible here, so
-a rack short of its physical capacity (18 trays for a GB200 NVL72 rack, one CoreWeave
-rack) is a floor on what's down, not a guarantee.
+its trays are registered vs. Ready. The instance-type filter matters: other GPU
+node pools carry a CoreWeave rack label too, but not the 18-node shared-rack
+topology the 16/18 thresholds assume — `cw-us-east-02a`'s H100 fleet
+(`gd-8xh100ib-i128`) has 29 racks, 26 of them a single standalone node, and
+without the filter every one read as "1 of 18 trays." A tray that never
+re-registers with the k8s API — the common failure mode after hardware
+maintenance — is invisible here, so a GB200 rack short of 18 trays is a floor
+on what's down, not a guarantee.
 
 The `/k8s/alerts/*` routes exist for Grafana's table-alert contract: string label
 columns plus exactly one numeric column, and always at least one row per cluster — an

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -40,7 +40,8 @@ GET /k8s/termination_candidates | kueue | events | health
 GET /k8s/overview                                 explicit pending/crashloop counts
 GET /k8s/gpu_racks                                GPU nodes grouped by physical rack: trays total/ready
 GET /k8s/alerts/{unreachable,crashloops,          alert rows: string labels + one
-     webhook_ready,degraded,stuck_gpu_pods}       numeric, >=1 row per cluster
+     webhook_ready,degraded,stuck_gpu_pods,        numeric; gpu_rack_trays omits rows for
+     gpu_rack_trays}                               a cluster it cannot reach, others zero
 GET /health                                       bridge liveness
 ```
 
@@ -152,9 +153,11 @@ redeploy.
 
 Rules page only on near-certain incidents: an unreachable cluster, a
 crash-looping watched component, an admission webhook with no ready endpoints, a
-degraded component, a dead Iris controller, and a GPU pod that stays node-bound and
+degraded component, a dead Iris controller, a GPU pod that stays node-bound and
 nonterminal without finalizers for five minutes after the bridge's two-minute
-overdue threshold. The stuck-pod rule groups by node and links the cordon-first
+overdue threshold, and a GPU rack with fewer than 16 trays Ready for 15 minutes
+(the GB200 NVL72 rack spec is 18; a floor rather than an outright outage — see
+`gpu_racks` above). The stuck-pod rule groups by node and links the cordon-first
 recovery skill; terminal, unbound, and finalizer-held pods stay dashboard-only.
 Other workload-tier signals (gated pods, Kueue backlog, workload crashloops) are
 dashboard-only because they have expected benign causes. `severity=critical` routes to `ops-critical` (email ops@openathena.ai +

--- a/infra/grafana/dashboards/home.json
+++ b/infra/grafana/dashboards/home.json
@@ -1,0 +1,200 @@
+{
+  "uid": "marin-home",
+  "title": "Home",
+  "description": "Landing page for grafana.oa.dev: currently firing/pending Grafana alerts, GCP (Iris) and CoreWeave k8s health at a glance, and links to the per-domain dashboards. Provisioned as the default home dashboard (GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH) — everyone who opens the site without a specific dashboard in mind lands here first.",
+  "tags": [
+    "marin",
+    "generated"
+  ],
+  "timezone": "utc",
+  "editable": false,
+  "schemaVersion": 42,
+  "refresh": "1m",
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Infra",
+      "type": "link",
+      "url": "/d/infra"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Fleet",
+      "type": "link",
+      "url": "/d/marin-fleet"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Iris",
+      "type": "link",
+      "url": "/d/marin-iris"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "K8s",
+      "type": "link",
+      "url": "/d/marin-k8s"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Pipelines",
+      "type": "link",
+      "url": "/d/marin-pipelines"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Training",
+      "type": "link",
+      "url": "/d/marin-training"
+    },
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "targetBlank": true,
+      "title": "GitHub Actions",
+      "type": "link",
+      "url": "https://github.com/marin-community/marin/actions"
+    }
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "type": "alertlist",
+      "title": "Firing / pending alerts",
+      "description": "Every Grafana alert rule currently Alerting or Pending, across every rule group. Empty means nothing is currently paging.",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "viewMode": "list",
+        "groupMode": "default",
+        "groupBy": [],
+        "maxItems": 20,
+        "sortOrder": 3,
+        "dashboardAlerts": false,
+        "alertName": "",
+        "alertInstanceLabelFilter": "",
+        "stateFilter": {
+          "alerting": true,
+          "pending": true,
+          "noData": false,
+          "normal": false,
+          "error": true
+        }
+      }
+    },
+    {
+      "id": 2,
+      "panelRef": "iris_controller_up",
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 0,
+        "y": 8
+      }
+    },
+    {
+      "id": 3,
+      "panelRef": "k8s_apis_unreachable",
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 4,
+        "y": 8
+      }
+    },
+    {
+      "id": 4,
+      "panelRef": "healthy_workers_count",
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 8
+      }
+    },
+    {
+      "id": 5,
+      "panelRef": "tpu_chips_count",
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 8
+      }
+    },
+    {
+      "id": 6,
+      "panelRef": "pending_pods_count",
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 8
+      }
+    },
+    {
+      "id": 7,
+      "panelRef": "crashloops_count",
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 8
+      }
+    },
+    {
+      "id": 8,
+      "panelRef": "control_plane_components",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      }
+    },
+    {
+      "id": 9,
+      "panelRef": "gpu_rack_tray_inventory",
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      }
+    }
+  ]
+}

--- a/infra/grafana/dashboards/infra.json
+++ b/infra/grafana/dashboards/infra.json
@@ -284,162 +284,23 @@
     },
     {
       "id": 3,
-      "type": "stat",
-      "title": "Iris controller",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "iris-marin"
-      },
+      "panelRef": "iris_controller_up",
       "gridPos": {
         "h": 3,
         "w": 4,
         "x": 0,
         "y": 12
-      },
-      "fieldConfig": {
-        "defaults": {
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          },
-          "max": 1,
-          "mappings": [
-            {
-              "type": "value",
-              "options": {
-                "0": {
-                  "text": "DOWN",
-                  "color": "red",
-                  "index": 1
-                },
-                "1": {
-                  "text": "UP",
-                  "color": "green",
-                  "index": 0
-                }
-              }
-            }
-          ]
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "background",
-        "graphMode": "none",
-        "textMode": "auto",
-        "orientation": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/health",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "up",
-              "text": "up",
-              "type": "number"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 4,
-      "type": "stat",
-      "title": "K8s APIs reachable",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "k8s"
-      },
+      "panelRef": "k8s_apis_unreachable",
       "gridPos": {
         "h": 3,
         "w": 4,
         "x": 4,
         "y": 12
-      },
-      "fieldConfig": {
-        "defaults": {
-          "min": 0,
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 5
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "sum"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "none",
-        "textMode": "auto",
-        "orientation": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/health",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "up",
-              "text": "up",
-              "type": "number"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 5,
@@ -587,204 +448,33 @@
     },
     {
       "id": 7,
-      "type": "stat",
-      "title": "Pending pods",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "k8s"
-      },
+      "panelRef": "pending_pods_count",
       "gridPos": {
         "h": 3,
         "w": 4,
         "x": 16,
         "y": 12
-      },
-      "fieldConfig": {
-        "defaults": {
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "count"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "none",
-        "textMode": "auto",
-        "orientation": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/overview",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "pending_pods",
-              "text": "pending_pods",
-              "type": "number"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 8,
-      "type": "stat",
-      "title": "Crashloops",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "k8s"
-      },
+      "panelRef": "crashloops_count",
       "gridPos": {
         "h": 3,
         "w": 4,
         "x": 20,
         "y": 12
-      },
-      "fieldConfig": {
-        "defaults": {
-          "min": 0,
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "yellow",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 5
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "count"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "none",
-        "textMode": "auto",
-        "orientation": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/overview",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "crashlooping_containers",
-              "text": "crashlooping_containers",
-              "type": "number"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 9,
-      "type": "stat",
-      "title": "Healthy workers",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "iris-marin"
-      },
+      "panelRef": "healthy_workers_count",
       "gridPos": {
         "h": 3,
         "w": 6,
         "x": 0,
         "y": 15
-      },
-      "fieldConfig": {
-        "defaults": {
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "sum"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "none",
-        "textMode": "auto",
-        "orientation": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/workers",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "healthy",
-              "text": "healthy",
-              "type": "number"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 10,
@@ -918,67 +608,13 @@
     },
     {
       "id": 12,
-      "type": "stat",
-      "title": "TPU chips",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "iris-marin"
-      },
+      "panelRef": "tpu_chips_count",
       "gridPos": {
         "h": 3,
         "w": 6,
         "x": 18,
         "y": 15
-      },
-      "fieldConfig": {
-        "defaults": {
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "sum"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "none",
-        "textMode": "auto",
-        "orientation": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/workers",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "tpu_chips",
-              "text": "tpu_chips",
-              "type": "number"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 20,

--- a/infra/grafana/dashboards/infra.json
+++ b/infra/grafana/dashboards/infra.json
@@ -1550,87 +1550,13 @@
     },
     {
       "id": 33,
-      "type": "table",
-      "title": "Kubernetes control plane",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "k8s"
-      },
+      "panelRef": "control_plane_components",
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 16,
         "y": 35
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "filterable": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/control_plane",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "cluster",
-              "text": "cluster",
-              "type": "string"
-            },
-            {
-              "selector": "kind",
-              "text": "kind",
-              "type": "string"
-            },
-            {
-              "selector": "namespace",
-              "text": "namespace",
-              "type": "string"
-            },
-            {
-              "selector": "name",
-              "text": "name",
-              "type": "string"
-            },
-            {
-              "selector": "desired",
-              "text": "desired",
-              "type": "number"
-            },
-            {
-              "selector": "ready",
-              "text": "ready",
-              "type": "number"
-            },
-            {
-              "selector": "up",
-              "text": "up",
-              "type": "number"
-            },
-            {
-              "selector": "error_class",
-              "text": "error_class",
-              "type": "string"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 40,
@@ -1882,171 +1808,23 @@
     },
     {
       "id": 51,
-      "type": "table",
-      "title": "Pending and gated pods",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "k8s"
-      },
+      "panelRef": "pending_gated_pods",
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 0,
         "y": 53
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "filterable": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/pending",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "cluster",
-              "text": "cluster",
-              "type": "string"
-            },
-            {
-              "selector": "namespace",
-              "text": "namespace",
-              "type": "string"
-            },
-            {
-              "selector": "pod",
-              "text": "pod",
-              "type": "string"
-            },
-            {
-              "selector": "phase",
-              "text": "phase",
-              "type": "string"
-            },
-            {
-              "selector": "reason",
-              "text": "reason",
-              "type": "string"
-            },
-            {
-              "selector": "age_seconds",
-              "text": "age_seconds",
-              "type": "number"
-            },
-            {
-              "selector": "scope",
-              "text": "scope",
-              "type": "string"
-            },
-            {
-              "selector": "error_class",
-              "text": "error_class",
-              "type": "string"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 52,
-      "type": "table",
-      "title": "Crashlooping containers",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "k8s"
-      },
+      "panelRef": "crashlooping_pods",
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 8,
         "y": 53
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "filterable": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/crashloops",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "cluster",
-              "text": "cluster",
-              "type": "string"
-            },
-            {
-              "selector": "namespace",
-              "text": "namespace",
-              "type": "string"
-            },
-            {
-              "selector": "pod",
-              "text": "pod",
-              "type": "string"
-            },
-            {
-              "selector": "container",
-              "text": "container",
-              "type": "string"
-            },
-            {
-              "selector": "reason",
-              "text": "reason",
-              "type": "string"
-            },
-            {
-              "selector": "restarts",
-              "text": "restarts",
-              "type": "number"
-            },
-            {
-              "selector": "scope",
-              "text": "scope",
-              "type": "string"
-            },
-            {
-              "selector": "error_class",
-              "text": "error_class",
-              "type": "string"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 53,
@@ -2129,156 +1907,23 @@
     },
     {
       "id": 54,
-      "type": "table",
-      "title": "Kueue backlog",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "k8s"
-      },
+      "panelRef": "kueue_admission_backlog",
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 0,
         "y": 60
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "filterable": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/kueue",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "cluster",
-              "text": "cluster",
-              "type": "string"
-            },
-            {
-              "selector": "queue",
-              "text": "queue",
-              "type": "string"
-            },
-            {
-              "selector": "count",
-              "text": "count",
-              "type": "number"
-            },
-            {
-              "selector": "oldest_age_seconds",
-              "text": "oldest_age_seconds",
-              "type": "number"
-            },
-            {
-              "selector": "error_class",
-              "text": "error_class",
-              "type": "string"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 55,
-      "type": "table",
-      "title": "Warning events",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "k8s"
-      },
+      "panelRef": "warning_events",
       "gridPos": {
         "h": 7,
         "w": 16,
         "x": 8,
         "y": 60
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "filterable": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/events",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "cluster",
-              "text": "cluster",
-              "type": "string"
-            },
-            {
-              "selector": "namespace",
-              "text": "namespace",
-              "type": "string"
-            },
-            {
-              "selector": "involved_object",
-              "text": "involved_object",
-              "type": "string"
-            },
-            {
-              "selector": "reason",
-              "text": "reason",
-              "type": "string"
-            },
-            {
-              "selector": "message",
-              "text": "message",
-              "type": "string"
-            },
-            {
-              "selector": "count",
-              "text": "count",
-              "type": "number"
-            },
-            {
-              "selector": "last_seen",
-              "text": "last_seen",
-              "type": "timestamp_epoch"
-            },
-            {
-              "selector": "error_class",
-              "text": "error_class",
-              "type": "string"
-            }
-          ]
-        }
-      ]
+      }
     }
   ]
 }

--- a/infra/grafana/dashboards/k8s.json
+++ b/infra/grafana/dashboards/k8s.json
@@ -189,195 +189,23 @@
     },
     {
       "id": 3,
-      "type": "table",
-      "title": "Kueue admission backlog",
-      "description": "Unadmitted, unfinished Kueue Workloads per local queue, with the age of the oldest. A backlog is normal under capacity pressure; it is a dashboard signal, not an alert.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "k8s"
-      },
+      "panelRef": "kueue_admission_backlog",
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 16,
         "y": 0
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "oldest_age_seconds"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              }
-            ]
-          }
-        ]
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/kueue",
-          "url_options": {
-            "method": "GET"
-          },
-          "columns": [
-            {
-              "selector": "cluster",
-              "text": "cluster",
-              "type": "string"
-            },
-            {
-              "selector": "queue",
-              "text": "queue",
-              "type": "string"
-            },
-            {
-              "selector": "unadmitted",
-              "text": "unadmitted",
-              "type": "number"
-            },
-            {
-              "selector": "oldest_age_seconds",
-              "text": "oldest_age_seconds",
-              "type": "number"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 4,
-      "type": "table",
-      "title": "Control-plane components",
-      "description": "Ready vs desired replicas, cumulative container restarts, and any waiting reason for each watched component. Missing means the Deployment does not exist.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "k8s"
-      },
+      "panelRef": "control_plane_components",
       "gridPos": {
         "h": 8,
         "w": 24,
         "x": 0,
         "y": 7
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "waiting_reason"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-text"
-                }
-              },
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "type": "value",
-                    "options": {
-                      "": {
-                        "color": "green",
-                        "index": 0
-                      },
-                      "CrashLoopBackOff": {
-                        "color": "red",
-                        "index": 1
-                      },
-                      "ImagePullBackOff": {
-                        "color": "red",
-                        "index": 2
-                      },
-                      "Missing": {
-                        "color": "red",
-                        "index": 3
-                      }
-                    }
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "kind"
-            },
-            "properties": [
-              {
-                "id": "custom.hidden",
-                "value": true
-              }
-            ]
-          }
-        ]
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/control_plane",
-          "url_options": {
-            "method": "GET"
-          },
-          "filterExpression": "kind == 'component'",
-          "columns": [
-            {
-              "selector": "kind",
-              "text": "kind",
-              "type": "string"
-            },
-            {
-              "selector": "cluster",
-              "text": "cluster",
-              "type": "string"
-            },
-            {
-              "selector": "component",
-              "text": "component",
-              "type": "string"
-            },
-            {
-              "selector": "ready",
-              "text": "ready",
-              "type": "number"
-            },
-            {
-              "selector": "desired",
-              "text": "desired",
-              "type": "number"
-            },
-            {
-              "selector": "restarts",
-              "text": "restarts",
-              "type": "number"
-            },
-            {
-              "selector": "waiting_reason",
-              "text": "waiting_reason",
-              "type": "string"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 8,
@@ -501,221 +329,33 @@
     },
     {
       "id": 5,
-      "type": "table",
-      "title": "Crash-looping pods",
-      "description": "Containers sitting in CrashLoopBackOff or ImagePullBackOff, across every namespace except CoreWeave-managed ones (cw-*, kube-*). scope=control-plane means the pod belongs to a watched component; workload backoffs are informational.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "k8s"
-      },
+      "panelRef": "crashlooping_pods",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
         "y": 23
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/crashloops",
-          "url_options": {
-            "method": "GET"
-          },
-          "columns": [
-            {
-              "selector": "cluster",
-              "text": "cluster",
-              "type": "string"
-            },
-            {
-              "selector": "namespace",
-              "text": "namespace",
-              "type": "string"
-            },
-            {
-              "selector": "pod",
-              "text": "pod",
-              "type": "string"
-            },
-            {
-              "selector": "container",
-              "text": "container",
-              "type": "string"
-            },
-            {
-              "selector": "reason",
-              "text": "reason",
-              "type": "string"
-            },
-            {
-              "selector": "restarts",
-              "text": "restarts",
-              "type": "number"
-            },
-            {
-              "selector": "scope",
-              "text": "scope",
-              "type": "string"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 6,
-      "type": "table",
-      "title": "Pending / gated pods",
-      "description": "Pods in phase Pending, oldest first: scheduling_gated means a scheduling gate (e.g. Kueue admission) is holding the pod; pending means the scheduler has it but has not placed it.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "k8s"
-      },
+      "panelRef": "pending_gated_pods",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
         "y": 23
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "age_seconds"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              }
-            ]
-          }
-        ]
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/pending",
-          "url_options": {
-            "method": "GET"
-          },
-          "columns": [
-            {
-              "selector": "cluster",
-              "text": "cluster",
-              "type": "string"
-            },
-            {
-              "selector": "namespace",
-              "text": "namespace",
-              "type": "string"
-            },
-            {
-              "selector": "pod",
-              "text": "pod",
-              "type": "string"
-            },
-            {
-              "selector": "state",
-              "text": "state",
-              "type": "string"
-            },
-            {
-              "selector": "reason",
-              "text": "reason",
-              "type": "string"
-            },
-            {
-              "selector": "age_seconds",
-              "text": "age_seconds",
-              "type": "number"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 7,
-      "type": "table",
-      "title": "Warning events",
-      "description": "The most recent Warning events per cluster (fieldSelector type=Warning), newest first. Event retention on the API server is about an hour.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "k8s"
-      },
+      "panelRef": "warning_events",
       "gridPos": {
         "h": 9,
         "w": 24,
         "x": 0,
         "y": 31
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/events",
-          "url_options": {
-            "method": "GET"
-          },
-          "columns": [
-            {
-              "selector": "last_seen",
-              "text": "last_seen",
-              "type": "timestamp_epoch"
-            },
-            {
-              "selector": "cluster",
-              "text": "cluster",
-              "type": "string"
-            },
-            {
-              "selector": "namespace",
-              "text": "namespace",
-              "type": "string"
-            },
-            {
-              "selector": "object",
-              "text": "object",
-              "type": "string"
-            },
-            {
-              "selector": "reason",
-              "text": "reason",
-              "type": "string"
-            },
-            {
-              "selector": "count",
-              "text": "count",
-              "type": "number"
-            },
-            {
-              "selector": "message",
-              "text": "message",
-              "type": "string"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 9,

--- a/infra/grafana/dashboards/k8s.json
+++ b/infra/grafana/dashboards/k8s.json
@@ -361,7 +361,7 @@
       "id": 9,
       "type": "table",
       "title": "GPU rack tray inventory",
-      "description": "GPU nodes (nvidia.com/gpu capacity present) grouped by CoreWeave physical rack: trays currently registered with the k8s API vs. Ready. Thresholds on trays_ready assume the GB200 NVL72 rack spec (18 trays full, 16 minimum) and will misclassify racks of a different instance type. A rack below 16, or with a gap between trays_total and its expected full count, needs a CoreWeave ticket citing rack_name — a tray that never re-registers is invisible here, so this is a floor on down trays, not a guarantee.",
+      "description": "GB200 NVL72 nodes only (instance type contains 'gb200') grouped by CoreWeave physical rack: trays currently registered with the k8s API vs. Ready, against the 18-tray-full/16-minimum rack spec. Other GPU instance types (e.g. standalone H100 servers) carry a CoreWeave rack label too but with a different physical-rack topology — mostly one node per rack — so they're excluded rather than misread against a threshold that isn't about them. A rack below 16, or with a gap between trays_total and its expected full count, needs a CoreWeave ticket citing rack_name — a tray that never re-registers is invisible here, so this is a floor on down trays, not a guarantee.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "k8s"
@@ -461,7 +461,7 @@
       "id": 10,
       "type": "barchart",
       "title": "GPU racks — trays ready",
-      "description": "Trays Ready per physical rack (bar height), colored by the same GB200 NVL72 thresholds as the inventory table above: red under 16, orange 16-17, green at the 18-tray full spec. One bar per rack_name, so a rack short of trays reads at a glance without scanning the table.",
+      "description": "GB200 NVL72 racks only, same scope as the inventory table above. Trays Ready per physical rack (bar height), colored by the same thresholds: red under 16, orange 16-17, green at the 18-tray full spec. One bar per rack_name, so a rack short of trays reads at a glance without scanning the table.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "k8s"

--- a/infra/grafana/dashboards/k8s.json
+++ b/infra/grafana/dashboards/k8s.json
@@ -359,103 +359,13 @@
     },
     {
       "id": 9,
-      "type": "table",
-      "title": "GPU rack tray inventory",
-      "description": "GB200 NVL72 nodes only (instance type contains 'gb200') grouped by CoreWeave physical rack: trays currently registered with the k8s API vs. Ready, against the 18-tray-full/16-minimum rack spec. Other GPU instance types (e.g. standalone H100 servers) carry a CoreWeave rack label too but with a different physical-rack topology — mostly one node per rack — so they're excluded rather than misread against a threshold that isn't about them. A rack below 16, or with a gap between trays_total and its expected full count, needs a CoreWeave ticket citing rack_name — a tray that never re-registers is invisible here, so this is a floor on down trays, not a guarantee.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "k8s"
-      },
+      "panelRef": "gpu_rack_tray_inventory",
       "gridPos": {
         "h": 9,
         "w": 24,
         "x": 0,
         "y": 40
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "trays_ready"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "red",
-                      "value": null
-                    },
-                    {
-                      "color": "orange",
-                      "value": 16
-                    },
-                    {
-                      "color": "green",
-                      "value": 18
-                    }
-                  ]
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/gpu_racks",
-          "url_options": {
-            "method": "GET"
-          },
-          "columns": [
-            {
-              "selector": "cluster",
-              "text": "cluster",
-              "type": "string"
-            },
-            {
-              "selector": "rack",
-              "text": "rack",
-              "type": "string"
-            },
-            {
-              "selector": "rack_name",
-              "text": "rack_name",
-              "type": "string"
-            },
-            {
-              "selector": "instance_type",
-              "text": "instance_type",
-              "type": "string"
-            },
-            {
-              "selector": "trays_ready",
-              "text": "trays_ready",
-              "type": "number"
-            },
-            {
-              "selector": "trays_total",
-              "text": "trays_total",
-              "type": "number"
-            }
-          ]
-        }
-      ]
+      }
     },
     {
       "id": 10,

--- a/infra/grafana/dashboards/k8s.json
+++ b/infra/grafana/dashboards/k8s.json
@@ -1,7 +1,7 @@
 {
   "uid": "marin-k8s",
   "title": "K8s control plane",
-  "description": "Current control-plane state of the CoreWeave clusters, read straight from their k8s API servers by the bridge's k8s source: watched components, webhook endpoints, backoff pods, pending/gated pods, Kueue admission backlog, and Warning events. Every table carries a cluster column; a cluster the bridge cannot read shows up in the Cluster health panel with its error class. These panels are current-state only — the bridge stores no history; trends live in the finelog-backed dashboards.",
+  "description": "Current control-plane state of the CoreWeave clusters, read straight from their k8s API servers by the bridge's k8s source: watched components, webhook endpoints, backoff pods, pending/gated pods, Kueue admission backlog, Warning events, and GPU rack tray inventory. Every table carries a cluster column; a cluster the bridge cannot read shows up in the Cluster health panel with its error class. These panels are current-state only — the bridge stores no history; trends live in the finelog-backed dashboards.",
   "tags": [
     "marin",
     "generated"
@@ -712,6 +712,189 @@
               "selector": "message",
               "text": "message",
               "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "table",
+      "title": "GPU rack tray inventory",
+      "description": "GPU nodes (nvidia.com/gpu capacity present) grouped by CoreWeave physical rack: trays currently registered with the k8s API vs. Ready. Thresholds on trays_ready assume the GB200 NVL72 rack spec (18 trays full, 16 minimum) and will misclassify racks of a different instance type. A rack below 16, or with a gap between trays_total and its expected full count, needs a CoreWeave ticket citing rack_name — a tray that never re-registers is invisible here, so this is a floor on down trays, not a guarantee.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "k8s"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trays_ready"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "red",
+                      "value": null
+                    },
+                    {
+                      "color": "orange",
+                      "value": 16
+                    },
+                    {
+                      "color": "green",
+                      "value": 18
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/gpu_racks",
+          "url_options": {
+            "method": "GET"
+          },
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "rack",
+              "text": "rack",
+              "type": "string"
+            },
+            {
+              "selector": "rack_name",
+              "text": "rack_name",
+              "type": "string"
+            },
+            {
+              "selector": "instance_type",
+              "text": "instance_type",
+              "type": "string"
+            },
+            {
+              "selector": "trays_ready",
+              "text": "trays_ready",
+              "type": "number"
+            },
+            {
+              "selector": "trays_total",
+              "text": "trays_total",
+              "type": "number"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "barchart",
+      "title": "GPU racks — trays ready",
+      "description": "Trays Ready per physical rack (bar height), colored by the same GB200 NVL72 thresholds as the inventory table above: red under 16, orange 16-17, green at the 18-tray full spec. One bar per rack_name, so a rack short of trays reads at a glance without scanning the table.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "k8s"
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 18,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 16
+              },
+              {
+                "color": "green",
+                "value": 18
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "xField": "rack_name",
+        "barWidth": 0.8,
+        "groupWidth": 0.7,
+        "showValue": "always",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/gpu_racks",
+          "url_options": {
+            "method": "GET"
+          },
+          "columns": [
+            {
+              "selector": "rack_name",
+              "text": "rack_name",
+              "type": "string"
+            },
+            {
+              "selector": "trays_ready",
+              "text": "trays_ready",
+              "type": "number"
             }
           ]
         }

--- a/infra/grafana/dashboards/panels/control_plane_components.json
+++ b/infra/grafana/dashboards/panels/control_plane_components.json
@@ -1,0 +1,117 @@
+{
+  "type": "table",
+  "title": "Control-plane components",
+  "description": "Ready vs desired replicas, cumulative container restarts, and any waiting reason for each watched component. Missing means the Deployment does not exist.",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "k8s"
+  },
+  "fieldConfig": {
+    "defaults": {},
+    "overrides": [
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "waiting_reason"
+        },
+        "properties": [
+          {
+            "id": "custom.cellOptions",
+            "value": {
+              "type": "color-text"
+            }
+          },
+          {
+            "id": "mappings",
+            "value": [
+              {
+                "type": "value",
+                "options": {
+                  "": {
+                    "color": "green",
+                    "index": 0
+                  },
+                  "CrashLoopBackOff": {
+                    "color": "red",
+                    "index": 1
+                  },
+                  "ImagePullBackOff": {
+                    "color": "red",
+                    "index": 2
+                  },
+                  "Missing": {
+                    "color": "red",
+                    "index": 3
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "kind"
+        },
+        "properties": [
+          {
+            "id": "custom.hidden",
+            "value": true
+          }
+        ]
+      }
+    ]
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/control_plane",
+      "url_options": {
+        "method": "GET"
+      },
+      "filterExpression": "kind == 'component'",
+      "columns": [
+        {
+          "selector": "kind",
+          "text": "kind",
+          "type": "string"
+        },
+        {
+          "selector": "cluster",
+          "text": "cluster",
+          "type": "string"
+        },
+        {
+          "selector": "component",
+          "text": "component",
+          "type": "string"
+        },
+        {
+          "selector": "ready",
+          "text": "ready",
+          "type": "number"
+        },
+        {
+          "selector": "desired",
+          "text": "desired",
+          "type": "number"
+        },
+        {
+          "selector": "restarts",
+          "text": "restarts",
+          "type": "number"
+        },
+        {
+          "selector": "waiting_reason",
+          "text": "waiting_reason",
+          "type": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/crashlooping_pods.json
+++ b/infra/grafana/dashboards/panels/crashlooping_pods.json
@@ -1,0 +1,63 @@
+{
+  "type": "table",
+  "title": "Crash-looping pods",
+  "description": "Containers sitting in CrashLoopBackOff or ImagePullBackOff, across every namespace except CoreWeave-managed ones (cw-*, kube-*). scope=control-plane means the pod belongs to a watched component; workload backoffs are informational.",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "k8s"
+  },
+  "fieldConfig": {
+    "defaults": {},
+    "overrides": []
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/crashloops",
+      "url_options": {
+        "method": "GET"
+      },
+      "columns": [
+        {
+          "selector": "cluster",
+          "text": "cluster",
+          "type": "string"
+        },
+        {
+          "selector": "namespace",
+          "text": "namespace",
+          "type": "string"
+        },
+        {
+          "selector": "pod",
+          "text": "pod",
+          "type": "string"
+        },
+        {
+          "selector": "container",
+          "text": "container",
+          "type": "string"
+        },
+        {
+          "selector": "reason",
+          "text": "reason",
+          "type": "string"
+        },
+        {
+          "selector": "restarts",
+          "text": "restarts",
+          "type": "number"
+        },
+        {
+          "selector": "scope",
+          "text": "scope",
+          "type": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/crashloops_count.json
+++ b/infra/grafana/dashboards/panels/crashloops_count.json
@@ -1,0 +1,66 @@
+{
+  "type": "stat",
+  "title": "Crashloops",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "k8s"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "min": 0,
+      "noValue": "0",
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          },
+          {
+            "color": "yellow",
+            "value": 1
+          },
+          {
+            "color": "red",
+            "value": 5
+          }
+        ]
+      }
+    },
+    "overrides": []
+  },
+  "options": {
+    "reduceOptions": {
+      "calcs": [
+        "lastNotNull"
+      ],
+      "fields": "",
+      "values": false
+    },
+    "colorMode": "value",
+    "graphMode": "none",
+    "textMode": "auto",
+    "orientation": "auto"
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/overview",
+      "url_options": {
+        "method": "GET",
+        "params": []
+      },
+      "columns": [
+        {
+          "selector": "crashlooping_containers",
+          "text": "crashlooping_containers",
+          "type": "number"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/gpu_rack_tray_inventory.json
+++ b/infra/grafana/dashboards/panels/gpu_rack_tray_inventory.json
@@ -1,0 +1,93 @@
+{
+  "type": "table",
+  "title": "GPU rack tray inventory",
+  "description": "GB200 NVL72 nodes only (instance type contains 'gb200') grouped by CoreWeave physical rack: trays currently registered with the k8s API vs. Ready, against the 18-tray-full/16-minimum rack spec. Other GPU instance types (e.g. standalone H100 servers) carry a CoreWeave rack label too but with a different physical-rack topology — mostly one node per rack — so they're excluded rather than misread against a threshold that isn't about them. A rack below 16, or with a gap between trays_total and its expected full count, needs a CoreWeave ticket citing rack_name — a tray that never re-registers is invisible here, so this is a floor on down trays, not a guarantee.",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "k8s"
+  },
+  "fieldConfig": {
+    "defaults": {},
+    "overrides": [
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "trays_ready"
+        },
+        "properties": [
+          {
+            "id": "custom.cellOptions",
+            "value": {
+              "type": "color-background"
+            }
+          },
+          {
+            "id": "thresholds",
+            "value": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red",
+                  "value": null
+                },
+                {
+                  "color": "orange",
+                  "value": 16
+                },
+                {
+                  "color": "green",
+                  "value": 18
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/gpu_racks",
+      "url_options": {
+        "method": "GET"
+      },
+      "columns": [
+        {
+          "selector": "cluster",
+          "text": "cluster",
+          "type": "string"
+        },
+        {
+          "selector": "rack",
+          "text": "rack",
+          "type": "string"
+        },
+        {
+          "selector": "rack_name",
+          "text": "rack_name",
+          "type": "string"
+        },
+        {
+          "selector": "instance_type",
+          "text": "instance_type",
+          "type": "string"
+        },
+        {
+          "selector": "trays_ready",
+          "text": "trays_ready",
+          "type": "number"
+        },
+        {
+          "selector": "trays_total",
+          "text": "trays_total",
+          "type": "number"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/healthy_workers_count.json
+++ b/infra/grafana/dashboards/panels/healthy_workers_count.json
@@ -1,0 +1,57 @@
+{
+  "type": "stat",
+  "title": "Healthy workers",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "iris-marin"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "min": 0,
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      }
+    },
+    "overrides": []
+  },
+  "options": {
+    "reduceOptions": {
+      "calcs": [
+        "sum"
+      ],
+      "fields": "",
+      "values": false
+    },
+    "colorMode": "value",
+    "graphMode": "none",
+    "textMode": "auto",
+    "orientation": "auto"
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/workers",
+      "url_options": {
+        "method": "GET",
+        "params": []
+      },
+      "columns": [
+        {
+          "selector": "healthy",
+          "text": "healthy",
+          "type": "number"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/iris_controller_up.json
+++ b/infra/grafana/dashboards/panels/iris_controller_up.json
@@ -1,0 +1,79 @@
+{
+  "type": "stat",
+  "title": "Iris controller",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "iris-marin"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "min": 0,
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "red",
+            "value": null
+          },
+          {
+            "color": "green",
+            "value": 1
+          }
+        ]
+      },
+      "max": 1,
+      "mappings": [
+        {
+          "type": "value",
+          "options": {
+            "0": {
+              "text": "DOWN",
+              "color": "red",
+              "index": 1
+            },
+            "1": {
+              "text": "UP",
+              "color": "green",
+              "index": 0
+            }
+          }
+        }
+      ]
+    },
+    "overrides": []
+  },
+  "options": {
+    "reduceOptions": {
+      "calcs": [
+        "lastNotNull"
+      ],
+      "fields": "",
+      "values": false
+    },
+    "colorMode": "background",
+    "graphMode": "none",
+    "textMode": "auto",
+    "orientation": "auto"
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/health",
+      "url_options": {
+        "method": "GET",
+        "params": []
+      },
+      "columns": [
+        {
+          "selector": "up",
+          "text": "up",
+          "type": "number"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/k8s_apis_unreachable.json
+++ b/infra/grafana/dashboards/panels/k8s_apis_unreachable.json
@@ -1,0 +1,66 @@
+{
+  "type": "stat",
+  "title": "K8s APIs unreachable",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "k8s"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "min": 0,
+      "noValue": "0",
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          },
+          {
+            "color": "yellow",
+            "value": 1
+          },
+          {
+            "color": "red",
+            "value": 5
+          }
+        ]
+      }
+    },
+    "overrides": []
+  },
+  "options": {
+    "reduceOptions": {
+      "calcs": [
+        "sum"
+      ],
+      "fields": "",
+      "values": false
+    },
+    "colorMode": "value",
+    "graphMode": "none",
+    "textMode": "auto",
+    "orientation": "auto"
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/alerts/unreachable",
+      "url_options": {
+        "method": "GET",
+        "params": []
+      },
+      "columns": [
+        {
+          "selector": "value",
+          "text": "value",
+          "type": "number"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/kueue_admission_backlog.json
+++ b/infra/grafana/dashboards/panels/kueue_admission_backlog.json
@@ -1,0 +1,61 @@
+{
+  "type": "table",
+  "title": "Kueue admission backlog",
+  "description": "Unadmitted, unfinished Kueue Workloads per local queue, with the age of the oldest. A backlog is normal under capacity pressure; it is a dashboard signal, not an alert.",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "k8s"
+  },
+  "fieldConfig": {
+    "defaults": {},
+    "overrides": [
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "oldest_age_seconds"
+        },
+        "properties": [
+          {
+            "id": "unit",
+            "value": "s"
+          }
+        ]
+      }
+    ]
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/kueue",
+      "url_options": {
+        "method": "GET"
+      },
+      "columns": [
+        {
+          "selector": "cluster",
+          "text": "cluster",
+          "type": "string"
+        },
+        {
+          "selector": "queue",
+          "text": "queue",
+          "type": "string"
+        },
+        {
+          "selector": "unadmitted",
+          "text": "unadmitted",
+          "type": "number"
+        },
+        {
+          "selector": "oldest_age_seconds",
+          "text": "oldest_age_seconds",
+          "type": "number"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/pending_gated_pods.json
+++ b/infra/grafana/dashboards/panels/pending_gated_pods.json
@@ -1,0 +1,71 @@
+{
+  "type": "table",
+  "title": "Pending / gated pods",
+  "description": "Pods in phase Pending, oldest first: scheduling_gated means a scheduling gate (e.g. Kueue admission) is holding the pod; pending means the scheduler has it but has not placed it.",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "k8s"
+  },
+  "fieldConfig": {
+    "defaults": {},
+    "overrides": [
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "age_seconds"
+        },
+        "properties": [
+          {
+            "id": "unit",
+            "value": "s"
+          }
+        ]
+      }
+    ]
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/pending",
+      "url_options": {
+        "method": "GET"
+      },
+      "columns": [
+        {
+          "selector": "cluster",
+          "text": "cluster",
+          "type": "string"
+        },
+        {
+          "selector": "namespace",
+          "text": "namespace",
+          "type": "string"
+        },
+        {
+          "selector": "pod",
+          "text": "pod",
+          "type": "string"
+        },
+        {
+          "selector": "state",
+          "text": "state",
+          "type": "string"
+        },
+        {
+          "selector": "reason",
+          "text": "reason",
+          "type": "string"
+        },
+        {
+          "selector": "age_seconds",
+          "text": "age_seconds",
+          "type": "number"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/pending_pods_count.json
+++ b/infra/grafana/dashboards/panels/pending_pods_count.json
@@ -1,0 +1,57 @@
+{
+  "type": "stat",
+  "title": "Pending pods",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "k8s"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "min": 0,
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      }
+    },
+    "overrides": []
+  },
+  "options": {
+    "reduceOptions": {
+      "calcs": [
+        "lastNotNull"
+      ],
+      "fields": "",
+      "values": false
+    },
+    "colorMode": "value",
+    "graphMode": "none",
+    "textMode": "auto",
+    "orientation": "auto"
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/overview",
+      "url_options": {
+        "method": "GET",
+        "params": []
+      },
+      "columns": [
+        {
+          "selector": "pending_pods",
+          "text": "pending_pods",
+          "type": "number"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/tpu_chips_count.json
+++ b/infra/grafana/dashboards/panels/tpu_chips_count.json
@@ -1,0 +1,57 @@
+{
+  "type": "stat",
+  "title": "TPU chips",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "iris-marin"
+  },
+  "fieldConfig": {
+    "defaults": {
+      "min": 0,
+      "thresholds": {
+        "mode": "absolute",
+        "steps": [
+          {
+            "color": "green",
+            "value": null
+          }
+        ]
+      }
+    },
+    "overrides": []
+  },
+  "options": {
+    "reduceOptions": {
+      "calcs": [
+        "sum"
+      ],
+      "fields": "",
+      "values": false
+    },
+    "colorMode": "value",
+    "graphMode": "none",
+    "textMode": "auto",
+    "orientation": "auto"
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/workers",
+      "url_options": {
+        "method": "GET",
+        "params": []
+      },
+      "columns": [
+        {
+          "selector": "tpu_chips",
+          "text": "tpu_chips",
+          "type": "number"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/panels/warning_events.json
+++ b/infra/grafana/dashboards/panels/warning_events.json
@@ -1,0 +1,63 @@
+{
+  "type": "table",
+  "title": "Warning events",
+  "description": "The most recent Warning events per cluster (fieldSelector type=Warning), newest first. Event retention on the API server is about an hour.",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "k8s"
+  },
+  "fieldConfig": {
+    "defaults": {},
+    "overrides": []
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/events",
+      "url_options": {
+        "method": "GET"
+      },
+      "columns": [
+        {
+          "selector": "last_seen",
+          "text": "last_seen",
+          "type": "timestamp_epoch"
+        },
+        {
+          "selector": "cluster",
+          "text": "cluster",
+          "type": "string"
+        },
+        {
+          "selector": "namespace",
+          "text": "namespace",
+          "type": "string"
+        },
+        {
+          "selector": "object",
+          "text": "object",
+          "type": "string"
+        },
+        {
+          "selector": "reason",
+          "text": "reason",
+          "type": "string"
+        },
+        {
+          "selector": "count",
+          "text": "count",
+          "type": "number"
+        },
+        {
+          "selector": "message",
+          "text": "message",
+          "type": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -3,10 +3,13 @@
 #
 # Alert rules cover only conditions that are near-certainly an incident. The
 # k8s rules read the bridge's /k8s/alerts/* endpoints, which return string label
-# columns plus exactly one numeric column and always at least one row per cluster
-# (explicit zeros when healthy) — so a rule's NoData state is unreachable by
-# construction, and every rule still sets noDataState/execErrState to Alerting so
-# a broken datasource pages with the rule's own labels rather than going quiet.
+# columns plus exactly one numeric column. Most also always emit at least one row
+# per cluster (explicit zeros when healthy), making their NoData state unreachable
+# by construction; gpu_rack_trays is the exception — an unreachable cluster
+# contributes no rows for it rather than a fabricated safe value, since
+# K8sClusterUnreachable already covers that failure mode. Every rule still sets
+# noDataState/execErrState to Alerting, so a broken datasource or an all-clusters
+# NoData still pages with the rule's own labels rather than going quiet.
 #
 # Workload-tier signals (gated pods, kueue backlog, workload crashloops) are
 # dashboard-only: they have expected benign causes (capacity pressure, user
@@ -211,6 +214,44 @@ groups:
               expression: A
               conditions:
                 - evaluator: { type: gt, params: [0] }
+
+      - uid: k8s-gpu-rack-trays-low
+        title: GpuRackTraysBelowMinimum
+        condition: C
+        for: 15m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.cluster }}: rack {{ $labels.rack_name }} has fewer than 16 trays Ready"
+          runbook_url: https://github.com/marin-community/marin/blob/main/lib/iris/OPS.md
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: k8s
+            model:
+              refId: A
+              datasource: { type: yesoreyeram-infinity-datasource, uid: k8s }
+              type: json
+              source: url
+              parser: backend
+              format: table
+              url: /alerts/gpu_rack_trays
+              url_options: { method: GET }
+              columns:
+                - { selector: cluster, text: cluster, type: string }
+                - { selector: rack_name, text: rack_name, type: string }
+                - { selector: value, text: value, type: number }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [16] }
 
   # The GCE controllers are not in K8S_CLUSTERS; their liveness comes from the
   # existing per-cluster iris datasources. The health row always exists (the

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -218,7 +218,7 @@ groups:
       - uid: k8s-gpu-rack-trays-low
         title: GpuRackTraysBelowMinimum
         condition: C
-        for: 15m
+        for: 5m
         noDataState: Alerting
         execErrState: Alerting
         labels:

--- a/infra/grafana/src/dashboard_stitch.py
+++ b/infra/grafana/src/dashboard_stitch.py
@@ -1,0 +1,67 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stitch shared panel fragments into dashboard JSON at image build time.
+
+A dashboard's ``panels`` array can hold a stitch marker instead of a full panel
+body: ``{"id": N, "gridPos": {...}, "panelRef": "<fragment-name>"}``. Every other
+field of the rendered panel — type, title, description, datasource, fieldConfig,
+options, targets — comes from ``panels/<fragment-name>.json``, the single source of
+truth for a panel shared across dashboards. ``id`` and ``gridPos`` stay
+dashboard-local: they are the only two things that legitimately vary by placement.
+
+This keeps ``dashboards/*.json`` file-provisioned and git-reviewable end to end —
+no Grafana library-panel API, no runtime sync, no new credential — while killing
+copy-pasted panel bodies that drift out of sync with the bridge's actual schema.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+PANEL_REF_KEY = "panelRef"
+
+
+def load_panel_fragments(panels_dir: Path) -> dict[str, dict]:
+    """Read every panels/<name>.json fragment, keyed by its filename stem."""
+    return {path.stem: json.loads(path.read_text()) for path in panels_dir.glob("*.json")}
+
+
+def stitch_dashboard(source: dict, fragments: dict[str, dict]) -> dict:
+    """Replace every panelRef marker in source's panels with its fragment body.
+
+    Raises:
+        KeyError: A panel references a fragment name missing from ``fragments``.
+    """
+    panels = []
+    for panel in source["panels"]:
+        ref = panel.get(PANEL_REF_KEY)
+        if ref is None:
+            panels.append(panel)
+            continue
+        if ref not in fragments:
+            raise KeyError(f"panel {panel.get('id')} references unknown panel fragment {ref!r}")
+        panels.append({**fragments[ref], "id": panel["id"], "gridPos": panel["gridPos"]})
+    return {**source, "panels": panels}
+
+
+def stitch_all(src_dir: Path, panels_dir: Path) -> dict[str, dict]:
+    """Stitch every dashboard JSON file in src_dir, keyed by filename."""
+    fragments = load_panel_fragments(panels_dir)
+    return {path.name: stitch_dashboard(json.loads(path.read_text()), fragments) for path in src_dir.glob("*.json")}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--src-dir", type=Path, required=True, help="Directory of dashboard JSON with panelRef markers.")
+    parser.add_argument("--panels-dir", type=Path, required=True, help="Directory of shared panel fragment JSON.")
+    parser.add_argument("--out-dir", type=Path, required=True, help="Directory to write stitched dashboard JSON to.")
+    args = parser.parse_args()
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    for name, dashboard in stitch_all(args.src_dir, args.panels_dir).items():
+        (args.out_dir / name).write_text(json.dumps(dashboard, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -61,6 +61,12 @@ _GPU_RESOURCE = "nvidia.com/gpu"
 _IRIS_TASK_ID_ENV = "IRIS_TASK_ID"
 _TERMINAL_POD_PHASES = frozenset(("Succeeded", "Failed"))
 
+# CoreWeave physical-topology labels a GPU node carries: which rack it lives in,
+# the rack's full CoreWeave-assigned name, and its instance type.
+_RACK_LABEL = "node.coreweave.cloud/rack"
+_RACK_NAME_LABEL = "ds.coreweave.com/physical-topology.rack-name"
+_INSTANCE_TYPE_LABEL = "node.kubernetes.io/instance-type"
+
 # Container waiting reasons the crashloop rows report.
 BACKOFF_REASONS = ("CrashLoopBackOff", "ImagePullBackOff")
 
@@ -429,6 +435,48 @@ class K8sSource:
         rows.sort(key=lambda row: row["last_seen"] or 0, reverse=True)
         return rows[:_EVENT_LIMIT]
 
+    def gpu_racks(self) -> list[dict]:
+        """One row per physical rack of GPU nodes: trays registered vs. Ready.
+
+        Only nodes advertising nvidia.com/gpu capacity carry the CoreWeave rack
+        topology labels that map to a physical tray; CPU/storage nodes are excluded.
+        """
+        racks: dict[str, dict] = {}
+        for node in self._list("/api/v1/nodes"):
+            if _node_gpu_capacity(node) <= 0:
+                continue
+            labels = (node.get("metadata") or {}).get("labels") or {}
+            rack = labels.get(_RACK_LABEL)
+            if rack is None:
+                continue
+            bucket = racks.setdefault(
+                rack,
+                {
+                    "rack": rack,
+                    "rack_name": labels.get(_RACK_NAME_LABEL, ""),
+                    "instance_type": labels.get(_INSTANCE_TYPE_LABEL, ""),
+                    "trays_total": 0,
+                    "trays_ready": 0,
+                },
+            )
+            bucket["trays_total"] += 1
+            if _node_ready(node):
+                bucket["trays_ready"] += 1
+        return [racks[rack] for rack in sorted(racks, key=int)]
+
+
+def _node_gpu_capacity(node: dict) -> int:
+    raw = ((node.get("status") or {}).get("capacity") or {}).get(_GPU_RESOURCE, 0)
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _node_ready(node: dict) -> bool:
+    conditions = (node.get("status") or {}).get("conditions") or []
+    return any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions)
+
 
 def _container_statuses(pod: dict) -> list[dict]:
     status = pod.get("status") or {}
@@ -561,6 +609,9 @@ class K8sFleet:
 
     def warning_events(self) -> list[dict]:
         return self._fan_out(lambda s: s.warning_events(), self._error_row)
+
+    def gpu_racks(self) -> list[dict]:
+        return self._fan_out(lambda s: s.gpu_racks(), self._error_row)
 
     def health(self) -> list[dict]:
         """One row per cluster: reachable, error class, and API server latency."""

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -67,6 +67,14 @@ _RACK_LABEL = "node.coreweave.cloud/rack"
 _RACK_NAME_LABEL = "ds.coreweave.com/physical-topology.rack-name"
 _INSTANCE_TYPE_LABEL = "node.kubernetes.io/instance-type"
 
+# gpu_racks' tray/rack concept — many nodes sharing one liquid-cooled rack, with a
+# fleet-wide expected tray count — is specific to GB200 NVL72. Other instance types
+# (e.g. gd-8xh100ib-i128, a standalone 8-GPU H100 server) get their own CoreWeave
+# rack label too, but mostly 1 node per rack: cw-us-east-02a has 29 racks, 26 of them
+# with exactly one node. Grouping those in made every one read as "1 of 18 trays" and
+# fired the below-16 alert on hardware the threshold was never about.
+_GB200_INSTANCE_TYPE_SUBSTRING = "gb200"
+
 # Container waiting reasons the crashloop rows report.
 BACKOFF_REASONS = ("CrashLoopBackOff", "ImagePullBackOff")
 
@@ -436,10 +444,11 @@ class K8sSource:
         return rows[:_EVENT_LIMIT]
 
     def gpu_racks(self) -> list[dict]:
-        """One row per physical rack of GPU nodes: trays registered vs. Ready.
+        """One row per physical rack of GB200 nodes: trays registered vs. Ready.
 
-        Only nodes advertising nvidia.com/gpu capacity carry the CoreWeave rack
-        topology labels that map to a physical tray; CPU/storage nodes are excluded.
+        Scoped to GB200 NVL72 instance types (see _GB200_INSTANCE_TYPE_SUBSTRING):
+        other GPU instance types carry a CoreWeave rack label too, but with a
+        different physical-rack topology the 16/18-tray expectation doesn't apply to.
 
         Raises:
             ValueError: A node has a malformed nvidia.com/gpu capacity quantity.
@@ -449,6 +458,9 @@ class K8sSource:
             if _node_gpu_capacity(node) <= 0:
                 continue
             labels = (node.get("metadata") or {}).get("labels") or {}
+            instance_type = labels.get(_INSTANCE_TYPE_LABEL, "")
+            if _GB200_INSTANCE_TYPE_SUBSTRING not in instance_type:
+                continue
             rack = labels.get(_RACK_LABEL)
             if rack is None:
                 continue
@@ -457,7 +469,7 @@ class K8sSource:
                 {
                     "rack": rack,
                     "rack_name": labels.get(_RACK_NAME_LABEL, ""),
-                    "instance_type": labels.get(_INSTANCE_TYPE_LABEL, ""),
+                    "instance_type": instance_type,
                     "trays_total": 0,
                     "trays_ready": 0,
                 },

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -440,6 +440,9 @@ class K8sSource:
 
         Only nodes advertising nvidia.com/gpu capacity carry the CoreWeave rack
         topology labels that map to a physical tray; CPU/storage nodes are excluded.
+
+        Raises:
+            ValueError: A node has a malformed nvidia.com/gpu capacity quantity.
         """
         racks: dict[str, dict] = {}
         for node in self._list("/api/v1/nodes"):
@@ -469,8 +472,8 @@ def _node_gpu_capacity(node: dict) -> int:
     raw = ((node.get("status") or {}).get("capacity") or {}).get(_GPU_RESOURCE, 0)
     try:
         return int(raw)
-    except (TypeError, ValueError):
-        return 0
+    except (TypeError, ValueError) as err:
+        raise ValueError(f"invalid {_GPU_RESOURCE} capacity quantity: {raw!r}") from err
 
 
 def _node_ready(node: dict) -> bool:

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -613,6 +613,24 @@ class K8sFleet:
     def gpu_racks(self) -> list[dict]:
         return self._fan_out(lambda s: s.gpu_racks(), self._error_row)
 
+    def alert_gpu_rack_trays(self) -> list[dict]:
+        """Per rack: trays_ready as ``value``, for the below-minimum-trays alert.
+
+        Unlike the other alert routes, an unreachable cluster contributes no rows
+        here rather than an explicit safe value: we don't know its rack set to fill
+        in placeholders for, and a fabricated value below the threshold would
+        double-page alongside K8sClusterUnreachable, which already covers that
+        failure mode. noDataState=Alerting still pages if the whole fleet drops out.
+        """
+
+        def counts(source: K8sSource) -> list[dict]:
+            return [
+                {"rack": row["rack"], "rack_name": row["rack_name"], "value": row["trays_ready"]}
+                for row in source.gpu_racks()
+            ]
+
+        return self._fan_out(counts, lambda err: [])
+
     def health(self) -> list[dict]:
         """One row per cluster: reachable, error class, and API server latency."""
 

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -34,6 +34,7 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /k8s/alerts/webhook_ready                alert rows: cluster, webhook, value(ready count)
     GET /k8s/alerts/degraded                     alert rows: cluster, component, value(desired-ready)
     GET /k8s/alerts/stuck_gpu_pods                alert rows: cluster, node, value(count)
+    GET /k8s/alerts/gpu_rack_trays                alert rows: cluster, rack_name, value(trays_ready)
     GET /health                                  bridge liveness
 
 A dead controller or GitHub returns 5xx (not empty rows), and the failure is not
@@ -383,6 +384,9 @@ def create_app(
     def k8s_alerts_degraded(_: Request) -> JSONResponse:
         return k8s_endpoint("alerts_degraded", k8s_fleet.alert_degraded)
 
+    def k8s_alerts_gpu_rack_trays(_: Request) -> JSONResponse:
+        return k8s_endpoint("alerts_gpu_rack_trays", k8s_fleet.alert_gpu_rack_trays)
+
     def k8s_alerts_stuck_gpu_pods(_: Request) -> JSONResponse:
         # The dashboard and alert projection share one fleet LIST per cache TTL.
         rows = k8s_cache.get_or_compute(_K8S_TERMINATION_CANDIDATES_CACHE_KEY, k8s_fleet.termination_candidates)
@@ -416,6 +420,7 @@ def create_app(
             Route("/k8s/alerts/crashloops", k8s_alerts_crashloops),
             Route("/k8s/alerts/webhook_ready", k8s_alerts_webhook_ready),
             Route("/k8s/alerts/degraded", k8s_alerts_degraded),
+            Route("/k8s/alerts/gpu_rack_trays", k8s_alerts_gpu_rack_trays),
             Route("/k8s/alerts/stuck_gpu_pods", k8s_alerts_stuck_gpu_pods),
         ]
     )

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -28,6 +28,7 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /k8s/events                              recent Warning events
     GET /k8s/health                              per-cluster API server reachability + latency
     GET /k8s/overview                            explicit workload issue counts (zeros included)
+    GET /k8s/gpu_racks                           GPU nodes grouped by physical rack: trays total/ready
     GET /k8s/alerts/unreachable                  alert rows: cluster, error_class, value(0|1)
     GET /k8s/alerts/crashloops?scope=            alert rows: cluster, scope, value(count)
     GET /k8s/alerts/webhook_ready                alert rows: cluster, webhook, value(ready count)
@@ -361,6 +362,9 @@ def create_app(
 
         return k8s_endpoint("overview", compute)
 
+    def k8s_gpu_racks(_: Request) -> JSONResponse:
+        return k8s_endpoint("gpu_racks", k8s_fleet.gpu_racks)
+
     def k8s_alerts_unreachable(_: Request) -> JSONResponse:
         return k8s_endpoint("alerts_unreachable", k8s_fleet.alert_unreachable)
 
@@ -407,6 +411,7 @@ def create_app(
             Route("/k8s/events", k8s_events),
             Route("/k8s/health", k8s_health),
             Route("/k8s/overview", k8s_overview),
+            Route("/k8s/gpu_racks", k8s_gpu_racks),
             Route("/k8s/alerts/unreachable", k8s_alerts_unreachable),
             Route("/k8s/alerts/crashloops", k8s_alerts_crashloops),
             Route("/k8s/alerts/webhook_ready", k8s_alerts_webhook_ready),

--- a/infra/grafana/tests/conftest.py
+++ b/infra/grafana/tests/conftest.py
@@ -57,6 +57,30 @@ def pod(
     }
 
 
+def node(
+    name: str,
+    *,
+    rack: str | None = None,
+    rack_name: str = "",
+    instance_type: str = "",
+    gpu_capacity: int = 0,
+    ready: bool = True,
+) -> dict:
+    labels = {}
+    if rack is not None:
+        labels["node.coreweave.cloud/rack"] = rack
+        labels["ds.coreweave.com/physical-topology.rack-name"] = rack_name
+    if instance_type:
+        labels["node.kubernetes.io/instance-type"] = instance_type
+    return {
+        "metadata": {"name": name, "labels": labels},
+        "status": {
+            "capacity": {"nvidia.com/gpu": str(gpu_capacity)},
+            "conditions": [{"type": "Ready", "status": "True" if ready else "False"}],
+        },
+    }
+
+
 def k8s_api(routes: dict):
     """A MockTransport handler serving canned bodies by path.
 

--- a/infra/grafana/tests/conftest.py
+++ b/infra/grafana/tests/conftest.py
@@ -110,7 +110,7 @@ def make_k8s_source(handler, name: str = "cw-a", token: str | None = "secret") -
 
 
 def healthy_k8s_routes() -> dict:
-    """A cluster where every watched component is up and the webhook has one endpoint."""
+    """A cluster where every watched component is up, the webhook has one endpoint, and one GPU rack is full."""
     return {
         "/version": {"gitVersion": "v1.32.0"},
         KUEUE_DEPLOY: deployment("kueue-system", "kueue-controller-manager"),
@@ -125,4 +125,7 @@ def healthy_k8s_routes() -> dict:
         "/api/v1/namespaces": [],
         "/apis/kueue.x-k8s.io/v1beta2/workloads": [],
         "/api/v1/events": [],
+        "/api/v1/nodes": [
+            node("g1", rack="169", rack_name="dh1-r169-us-east-08a", instance_type="gb200-4x", gpu_capacity=4)
+        ],
     }

--- a/infra/grafana/tests/fixture_bridge.py
+++ b/infra/grafana/tests/fixture_bridge.py
@@ -199,16 +199,15 @@ def _rows(path: str, query: str) -> list[dict] | dict:
         return [
             {
                 "cluster": cluster,
-                "kind": "deployment",
-                "namespace": namespace,
-                "name": name,
-                "desired": 1,
+                "kind": "component",
+                "component": component,
                 "ready": 1,
-                "up": 1,
-                "error_class": "",
+                "desired": 1,
+                "restarts": 0,
+                "waiting_reason": "",
             }
             for cluster in ("cw-us-east-02a", "cw-us-east-08a", "cw-rno2a")
-            for namespace, name in (("iris", "iris-controller"), ("kueue-system", "kueue-controller-manager"))
+            for component in ("iris/iris-controller", "kueue-system/kueue-controller-manager")
         ]
     if path == "/k8s/pending":
         return [
@@ -216,11 +215,9 @@ def _rows(path: str, query: str) -> list[dict] | dict:
                 "cluster": "cw-us-east-08a",
                 "namespace": "iris",
                 "pod": "trainer-queued",
-                "phase": "Pending",
+                "state": "pending",
                 "reason": "Unschedulable",
                 "age_seconds": 420,
-                "scope": "workload",
-                "error_class": "",
             }
         ]
     if path == "/k8s/crashloops":
@@ -249,9 +246,7 @@ def _rows(path: str, query: str) -> list[dict] | dict:
             }
         ]
     if path == "/k8s/kueue":
-        return [
-            {"cluster": "cw-us-east-08a", "queue": "training", "count": 6, "oldest_age_seconds": 540, "error_class": ""}
-        ]
+        return [{"cluster": "cw-us-east-08a", "queue": "training", "unadmitted": 6, "oldest_age_seconds": 540}]
     if path == "/k8s/gpu_racks":
         return [
             {
@@ -282,12 +277,11 @@ def _rows(path: str, query: str) -> list[dict] | dict:
             {
                 "cluster": "cw-us-east-08a",
                 "namespace": "training",
-                "involved_object": "trainer-queued",
+                "object": "Pod/trainer-queued",
                 "reason": "FailedScheduling",
                 "message": "waiting for H100 capacity",
                 "count": 2,
                 "last_seen": round(_NOW.timestamp() * 1000),
-                "error_class": "",
             }
         ]
     if path.startswith("/wandb/"):

--- a/infra/grafana/tests/fixture_bridge.py
+++ b/infra/grafana/tests/fixture_bridge.py
@@ -252,6 +252,31 @@ def _rows(path: str, query: str) -> list[dict] | dict:
         return [
             {"cluster": "cw-us-east-08a", "queue": "training", "count": 6, "oldest_age_seconds": 540, "error_class": ""}
         ]
+    if path == "/k8s/gpu_racks":
+        return [
+            {
+                "cluster": "cw-us-east-08a",
+                "rack": rack,
+                "rack_name": f"dh1-r{rack}-us-east-08a",
+                "instance_type": "gb200-4x",
+                "trays_total": total,
+                "trays_ready": ready,
+            }
+            for rack, total, ready in (
+                ("122", 17, 17),
+                ("124", 17, 17),
+                ("125", 17, 17),
+                ("126", 18, 18),
+                ("128", 16, 16),
+                ("129", 18, 18),
+                ("136", 17, 17),
+                ("137", 16, 16),
+                ("392", 16, 16),
+                ("393", 16, 16),
+                ("394", 16, 16),
+                ("397", 15, 15),
+            )
+        ]
     if path == "/k8s/events":
         return [
             {

--- a/infra/grafana/tests/fixture_bridge.py
+++ b/infra/grafana/tests/fixture_bridge.py
@@ -193,6 +193,11 @@ def _rows(path: str, query: str) -> list[dict] | dict:
             {"cluster": cluster, "reachable": True, "up": 1, "latency_ms": 31, "error_class": ""}
             for cluster in ("cw-us-east-02a", "cw-us-east-08a", "cw-rno2a")
         ]
+    if path == "/k8s/alerts/unreachable":
+        return [
+            {"cluster": cluster, "error_class": "none", "value": 0}
+            for cluster in ("cw-us-east-02a", "cw-us-east-08a", "cw-rno2a")
+        ]
     if path == "/k8s/overview":
         return [{"pending_pods": 1, "crashlooping_containers": 1}]
     if path == "/k8s/control_plane":

--- a/infra/grafana/tests/test_dashboard_stitch.py
+++ b/infra/grafana/tests/test_dashboard_stitch.py
@@ -1,0 +1,52 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for stitching shared panel fragments into dashboard JSON."""
+
+import json
+
+import pytest
+from dashboard_stitch import load_panel_fragments, stitch_all, stitch_dashboard
+
+FRAGMENT = {"type": "table", "title": "Shared panel", "targets": [{"refId": "A"}]}
+
+
+def test_stitch_dashboard_merges_fragment_with_local_id_and_grid_pos():
+    source = {
+        "panels": [
+            {"id": 7, "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0}, "panelRef": "shared"},
+        ]
+    }
+    (panel,) = stitch_dashboard(source, {"shared": FRAGMENT})["panels"]
+    assert panel == {**FRAGMENT, "id": 7, "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0}}
+
+
+def test_stitch_dashboard_leaves_non_ref_panels_untouched():
+    inline_panel = {"id": 1, "type": "row", "title": "Section"}
+    source = {"panels": [inline_panel]}
+    assert stitch_dashboard(source, {})["panels"] == [inline_panel]
+
+
+def test_stitch_dashboard_rejects_an_unknown_fragment_name():
+    source = {"panels": [{"id": 7, "gridPos": {}, "panelRef": "missing"}]}
+    with pytest.raises(KeyError, match="missing"):
+        stitch_dashboard(source, {})
+
+
+def test_load_panel_fragments_keys_by_filename_stem(tmp_path):
+    (tmp_path / "control_plane_components.json").write_text(json.dumps(FRAGMENT))
+    assert load_panel_fragments(tmp_path) == {"control_plane_components": FRAGMENT}
+
+
+def test_stitch_all_processes_every_dashboard_in_a_directory(tmp_path):
+    panels_dir = tmp_path / "panels"
+    panels_dir.mkdir()
+    (panels_dir / "shared.json").write_text(json.dumps(FRAGMENT))
+    (tmp_path / "a.json").write_text(json.dumps({"panels": [{"id": 1, "gridPos": {"h": 1}, "panelRef": "shared"}]}))
+    (tmp_path / "b.json").write_text(json.dumps({"panels": []}))
+
+    dashboards = stitch_all(tmp_path, panels_dir)
+
+    assert set(dashboards) == {"a.json", "b.json"}
+    assert dashboards["a.json"]["panels"][0]["title"] == "Shared panel"
+    assert dashboards["b.json"]["panels"] == []

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -18,6 +18,7 @@ from conftest import (
     healthy_k8s_routes,
     k8s_api,
     make_k8s_source,
+    node,
     pod,
 )
 from github_source import GithubSource
@@ -328,6 +329,58 @@ def test_terminating_rejects_an_invalid_gpu_quantity():
         make_k8s_source(k8s_api(routes)).termination_candidates()
 
 
+def test_gpu_racks_groups_by_rack_and_counts_ready():
+    routes = {
+        "/api/v1/nodes": [
+            node("g1", rack="169", rack_name="dh1-r169-us-east-08a", instance_type="gb200-4x", gpu_capacity=4),
+            node("g2", rack="169", rack_name="dh1-r169-us-east-08a", instance_type="gb200-4x", gpu_capacity=4),
+            node(
+                "g3", rack="397", rack_name="dh1-r397-us-east-08a", instance_type="gb200-4x", gpu_capacity=4, ready=False
+            ),
+        ]
+    }
+    rows = make_k8s_source(k8s_api(routes)).gpu_racks()
+    assert rows == [
+        {
+            "rack": "169",
+            "rack_name": "dh1-r169-us-east-08a",
+            "instance_type": "gb200-4x",
+            "trays_total": 2,
+            "trays_ready": 2,
+        },
+        {
+            "rack": "397",
+            "rack_name": "dh1-r397-us-east-08a",
+            "instance_type": "gb200-4x",
+            "trays_total": 1,
+            "trays_ready": 0,
+        },
+    ]
+
+
+def test_gpu_racks_excludes_non_gpu_and_unlabeled_nodes():
+    routes = {
+        "/api/v1/nodes": [
+            node("cpu-1", rack="122", gpu_capacity=0),
+            node("no-rack-label", gpu_capacity=4),
+            node("g1", rack="169", gpu_capacity=4),
+        ]
+    }
+    rows = make_k8s_source(k8s_api(routes)).gpu_racks()
+    assert [row["rack"] for row in rows] == ["169"]
+
+
+def test_gpu_racks_sorts_numerically_not_lexically():
+    routes = {
+        "/api/v1/nodes": [
+            node("g1", rack="10", gpu_capacity=4),
+            node("g2", rack="9", gpu_capacity=4),
+        ]
+    }
+    rows = make_k8s_source(k8s_api(routes)).gpu_racks()
+    assert [row["rack"] for row in rows] == ["9", "10"]
+
+
 # --- K8sFleet ---------------------------------------------------------------
 
 
@@ -428,17 +481,30 @@ def _client(fleet: K8sFleet) -> TestClient:
 
 
 def test_k8s_routes_serve_fleet_rows():
-    client = _client(_fleet(("cw-a", k8s_api(healthy_k8s_routes()))))
+    routes = healthy_k8s_routes()
+    routes["/api/v1/nodes"] = [node("g1", rack="169", instance_type="gb200-4x", gpu_capacity=4)]
+    client = _client(_fleet(("cw-a", k8s_api(routes))))
     for path in (
         "/k8s/control_plane",
         "/k8s/crashloops",
         "/k8s/pending",
         "/k8s/kueue",
         "/k8s/events",
+        "/k8s/gpu_racks",
     ):
         assert client.get(path).status_code == 200
     health = client.get("/k8s/health").json()
     assert health[0]["cluster"] == "cw-a" and health[0]["reachable"] is True
+
+    (rack,) = client.get("/k8s/gpu_racks").json()
+    assert rack == {
+        "cluster": "cw-a",
+        "rack": "169",
+        "rack_name": "",
+        "instance_type": "gb200-4x",
+        "trays_total": 1,
+        "trays_ready": 1,
+    }
 
 
 def test_stuck_termination_routes_return_classification_and_alert_projection():

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -402,6 +402,21 @@ def test_fleet_stamps_cluster_and_keeps_healthy_clusters_on_partial_failure():
     assert "403" in error_row["error"]
 
 
+def test_alert_gpu_rack_trays_maps_trays_ready_to_value():
+    fleet = _fleet(("cw-a", k8s_api(healthy_k8s_routes())))
+    assert fleet.alert_gpu_rack_trays() == [
+        {"cluster": "cw-a", "rack": "169", "rack_name": "dh1-r169-us-east-08a", "value": 1}
+    ]
+
+
+def test_alert_gpu_rack_trays_omits_rows_for_an_unreachable_cluster():
+    # Unlike the other alert routes, an unreachable cluster contributes no rows: we
+    # don't know its rack set, and a fabricated below-threshold value would double-page
+    # alongside K8sClusterUnreachable.
+    fleet = _fleet(("cw-a", k8s_api(healthy_k8s_routes())), ("cw-b", _forbidden))
+    assert [row["cluster"] for row in fleet.alert_gpu_rack_trays()] == ["cw-a"]
+
+
 def test_alert_routes_return_explicit_zeros_when_healthy():
     fleet = _fleet(("cw-a", k8s_api(healthy_k8s_routes())))
     assert fleet.alert_unreachable() == [{"cluster": "cw-a", "error_class": "none", "value": 0}]
@@ -481,9 +496,7 @@ def _client(fleet: K8sFleet) -> TestClient:
 
 
 def test_k8s_routes_serve_fleet_rows():
-    routes = healthy_k8s_routes()
-    routes["/api/v1/nodes"] = [node("g1", rack="169", instance_type="gb200-4x", gpu_capacity=4)]
-    client = _client(_fleet(("cw-a", k8s_api(routes))))
+    client = _client(_fleet(("cw-a", k8s_api(healthy_k8s_routes()))))
     for path in (
         "/k8s/control_plane",
         "/k8s/crashloops",
@@ -500,7 +513,7 @@ def test_k8s_routes_serve_fleet_rows():
     assert rack == {
         "cluster": "cw-a",
         "rack": "169",
-        "rack_name": "",
+        "rack_name": "dh1-r169-us-east-08a",
         "instance_type": "gb200-4x",
         "trays_total": 1,
         "trays_ready": 1,

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -361,9 +361,23 @@ def test_gpu_racks_groups_by_rack_and_counts_ready():
 def test_gpu_racks_excludes_non_gpu_and_unlabeled_nodes():
     routes = {
         "/api/v1/nodes": [
-            node("cpu-1", rack="122", gpu_capacity=0),
-            node("no-rack-label", gpu_capacity=4),
-            node("g1", rack="169", gpu_capacity=4),
+            node("cpu-1", rack="122", instance_type="gb200-4x", gpu_capacity=0),
+            node("no-rack-label", instance_type="gb200-4x", gpu_capacity=4),
+            node("g1", rack="169", instance_type="gb200-4x", gpu_capacity=4),
+        ]
+    }
+    rows = make_k8s_source(k8s_api(routes)).gpu_racks()
+    assert [row["rack"] for row in rows] == ["169"]
+
+
+def test_gpu_racks_excludes_non_gb200_instance_types():
+    # cw-us-east-02a's H100 fleet (gd-8xh100ib-i128) carries a CoreWeave rack label
+    # too, but mostly one node per rack — grouping it in misapplies the GB200
+    # 16/18-tray thresholds to hardware they were never about.
+    routes = {
+        "/api/v1/nodes": [
+            node("h100-1", rack="2", instance_type="gd-8xh100ib-i128", gpu_capacity=8),
+            node("g1", rack="169", instance_type="gb200-4x", gpu_capacity=4),
         ]
     }
     rows = make_k8s_source(k8s_api(routes)).gpu_racks()
@@ -373,8 +387,8 @@ def test_gpu_racks_excludes_non_gpu_and_unlabeled_nodes():
 def test_gpu_racks_sorts_numerically_not_lexically():
     routes = {
         "/api/v1/nodes": [
-            node("g1", rack="10", gpu_capacity=4),
-            node("g2", rack="9", gpu_capacity=4),
+            node("g1", rack="10", instance_type="gb200-4x", gpu_capacity=4),
+            node("g2", rack="9", instance_type="gb200-4x", gpu_capacity=4),
         ]
     }
     rows = make_k8s_source(k8s_api(routes)).gpu_racks()
@@ -382,7 +396,7 @@ def test_gpu_racks_sorts_numerically_not_lexically():
 
 
 def test_gpu_racks_rejects_an_invalid_gpu_capacity_quantity():
-    bad_node = node("g1", rack="169", gpu_capacity=4)
+    bad_node = node("g1", rack="169", instance_type="gb200-4x", gpu_capacity=4)
     bad_node["status"]["capacity"][GPU_RESOURCE] = "many"
     with pytest.raises(ValueError):
         make_k8s_source(k8s_api({"/api/v1/nodes": [bad_node]})).gpu_racks()

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -381,6 +381,13 @@ def test_gpu_racks_sorts_numerically_not_lexically():
     assert [row["rack"] for row in rows] == ["9", "10"]
 
 
+def test_gpu_racks_rejects_an_invalid_gpu_capacity_quantity():
+    bad_node = node("g1", rack="169", gpu_capacity=4)
+    bad_node["status"]["capacity"][GPU_RESOURCE] = "many"
+    with pytest.raises(ValueError):
+        make_k8s_source(k8s_api({"/api/v1/nodes": [bad_node]})).gpu_racks()
+
+
 # --- K8sFleet ---------------------------------------------------------------
 
 

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -6,7 +6,6 @@ datasource UIDs and refIds, every rule's query URL answers on the bridge, and
 dashboard datasources exist. These files only otherwise fail inside a deployed
 Grafana, which is the most expensive place to find out."""
 
-import json
 import re
 from pathlib import Path
 from urllib.parse import urlsplit
@@ -14,6 +13,7 @@ from urllib.parse import urlsplit
 import yaml
 from config import ClusterTarget
 from conftest import bridge_config, healthy_k8s_routes, k8s_api, make_k8s_source
+from dashboard_stitch import stitch_all
 from github_source import GithubSource
 from k8s_source import K8sFleet
 from server import create_app
@@ -22,9 +22,20 @@ from wandb_source import WandbSource
 
 ROOT = Path(__file__).resolve().parent.parent
 ALERTING = ROOT / "provisioning" / "alerting"
+DASHBOARDS = ROOT / "dashboards"
 
 EXPRESSION_UID = "__expr__"
 VALID_SEVERITIES = {"critical", "warning"}
+
+
+def _stitched_dashboards() -> dict[str, dict]:
+    """Every dashboard as Grafana actually renders it: panelRef markers resolved.
+
+    The checks below assert on the deployed shape, not the templated source —
+    a panel's real datasource/columns/thresholds live in its fragment file once
+    it's been extracted behind a panelRef.
+    """
+    return stitch_all(DASHBOARDS, DASHBOARDS / "panels")
 
 
 def _load(path: Path) -> dict:
@@ -133,8 +144,7 @@ def test_dashboard_filter_expressions_reference_selected_columns():
     # Infinity's backend parser applies filterExpression to the frame built from
     # `columns`, so every field a filter references must also be selected.
     literals = {"true", "false", "null"}
-    for path in (ROOT / "dashboards").glob("*.json"):
-        dashboard = json.loads(path.read_text())
+    for name, dashboard in _stitched_dashboards().items():
         for panel in dashboard["panels"]:
             for target in panel.get("targets", []):
                 expression = target.get("filterExpression")
@@ -144,26 +154,24 @@ def test_dashboard_filter_expressions_reference_selected_columns():
                 selected = {c["text"] for c in columns} | {c["selector"] for c in columns}
                 fields = set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", re.sub(r"'[^']*'", "", expression))) - literals
                 missing = fields - selected
-                assert not missing, f"{path.name} panel {panel.get('id')}: filter references unselected {missing}"
+                assert not missing, f"{name} panel {panel.get('id')}: filter references unselected {missing}"
 
 
 def test_dashboard_datasource_uids_are_provisioned():
     uids = set(_datasources())
-    for path in (ROOT / "dashboards").glob("*.json"):
-        dashboard = json.loads(path.read_text())
+    for name, dashboard in _stitched_dashboards().items():
         for panel in dashboard["panels"]:
             uid = (panel.get("datasource") or {}).get("uid")
             if uid is None or uid.startswith("${"):  # row panels / template variables
                 continue
-            assert uid in uids, f"{path.name} panel {panel.get('id')}: unknown datasource {uid!r}"
+            assert uid in uids, f"{name} panel {panel.get('id')}: unknown datasource {uid!r}"
 
 
 def test_stat_panels_use_grafana_reduce_options_schema():
-    for path in (ROOT / "dashboards").glob("*.json"):
-        dashboard = json.loads(path.read_text())
+    for name, dashboard in _stitched_dashboards().items():
         for panel in dashboard["panels"]:
             if panel.get("type") != "stat":
                 continue
             reduce_options = panel.get("options", {}).get("reduceOptions", {})
-            assert "calc" not in reduce_options, f"{path.name} panel {panel['id']}: use calcs, not calc"
-            assert reduce_options.get("calcs"), f"{path.name} panel {panel['id']}: missing reduction"
+            assert "calc" not in reduce_options, f"{name} panel {panel['id']}: use calcs, not calc"
+            assert reduce_options.get("calcs"), f"{name} panel {panel['id']}: missing reduction"


### PR DESCRIPTION
Add a "GPU rack tray inventory" table and horizontal bar chart to k8s.json,
fed by a new /k8s/gpu_racks bridge route that groups GB200 NVL72 nodes
(nvidia.com/gpu capacity, instance type containing "gb200") by their
CoreWeave physical rack, reporting trays registered vs. Ready per rack.
Other GPU instance types carry a CoreWeave rack label too but with a
different physical topology — cw-us-east-02a's H100 fleet
(gd-8xh100ib-i128) has 29 racks, 26 of them a single standalone node — so
they're excluded rather than misread against the GB200-specific 16/18-tray
thresholds, a bug caught after the first deploy.

Add a GpuRackTraysBelowMinimum alert (severity=warning, 5m for-duration,
routes to Slack via ops-slack) so a GB200 rack short of 16 trays pages
instead of only showing up on the dashboard.

Add dashboards/home.json as the default landing page
(GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH), replacing Grafana's stock
welcome screen: a native alertlist panel (every rule currently Alerting or
Pending) leads, followed by GCP/Iris and CoreWeave k8s health stats, the
control-plane components table, and the GB200 rack tray inventory, plus
the same per-dashboard nav links infra.json already had.

Extract eleven panels duplicated or now shared across k8s.json, infra.json,
and home.json into dashboards/panels/<name>.json, each referenced by a
"panelRef" marker resolved by a new src/dashboard_stitch.py at Docker build
time — id and gridPos stay dashboard-local, everything else lives once.
Several of infra.json's originals were quietly broken: /pending selected
"phase" (the route returns "state"), /kueue selected "count" (the route
returns "unadmitted"), /events selected "involved_object" (the route
returns "object"), "K8s APIs reachable" selected an "up" field /k8s/health
doesn't return, and "Pending pods"/"Crashloops" used a "count" reducer
against a single pre-aggregated row (which counts rows, always 1, rather
than reading the row's value). All rendered wrong or blank in production;
stitching from the correct source fixes them as a side effect.

Deliberately not Grafana's native library-panel feature: those live in
Grafana's Postgres state, not git, and only sync through the Library
Elements HTTP API — no file-based provisioning exists for them as of
Grafana 13.x, and Cloud Run's native IAP integration (this service's
iap_enabled=True) has no documented service-account auth story for a
Pulumi-driven sync step. Fragment files stay 100% file-provisioned and
git-reviewable, at the cost of only resolving at build time.

Verified locally throughout: built the real image, ran it standalone and
against the fixture bridge, and rendered every affected dashboard to
confirm panels resolve and previously-blank or wrong columns show correct
data.
