### PR TITLE
[iac] Manage the oa.dev federation CNAME with Pulumi

### DIFF
--- a/infra/pulumi/README.md
+++ b/infra/pulumi/README.md
@@ -1,11 +1,12 @@
 # Pulumi infrastructure
 
 Infrastructure-as-code for the static substrate of Marin clusters, per the design in
-[`.agents/projects/iac/`](../../.agents/projects/iac/). Pulumi (Python). **CoreWeave first.**
+[`.agents/projects/iac/`](../../.agents/projects/iac/). Pulumi (Python).
 
-This is the **minimal cut**: it provisions RBAC, reserved NodePools, Kueue objects, and the
-Traefik/cert-manager/federation-ingress stack for a CoreWeave cluster, and is the sole owner of
-all of it — Iris no longer provisions any of these itself (`verify_prerequisites()` in
+Currently just **CoreWeave**: it provisions RBAC, reserved NodePools, Kueue objects, the
+Traefik/cert-manager/federation-ingress stack, and the `oa.dev` CNAME pointing at it, for a
+CoreWeave cluster, and is the sole owner of all of it — Iris no longer provisions any of these
+itself (`verify_prerequisites()` in
 [`k8s/controller.py`](../../lib/iris/src/iris/cluster/platforms/k8s/controller.py) only checks
 presence and fails with a `pulumi up` remediation if something is missing). The CKS cluster
 object itself is not yet managed by Pulumi (see `coreweave/cluster.py` and "Future work" below).
@@ -64,7 +65,10 @@ Everything comes from the per-cluster Iris config (`lib/iris/config/<cluster>.ya
   per-machine and per-CI-runner (runners are ephemeral).
 - **GCP credentials**: `gcloud auth application-default login`. Decrypting stack secrets is
   authorized by your own GCP credentials against the shared KMS key — see "Backend" below for
-  getting the IAM role granted.
+  getting the IAM role granted. `FederationDns` (the `oa.dev` CNAME) reads its Cloudflare API
+  token straight from Secret Manager (`cloudflare-oa-dns-token` in `hai-gcp-models`, the same
+  one `infra/grafana` uses) under these same credentials — no separate export needed, just
+  `roles/secretmanager.secretAccessor` on that secret.
 - **Backend login**: `pulumi login gs://marin-iac-state`.
 - **Cluster access** (for the k8s dry-run): the CoreWeave kubeconfig at the path in the
   cluster's `platform.coreweave.kubeconfig_path` (typically `~/.kube/coreweave-iris`).
@@ -123,6 +127,27 @@ pulumi config rm marin-iac:import
 pulumi up       # normal run, adopt=false now — creates the remaining components fresh
 ```
 
+### Adopting the DNS record
+
+`FederationDns` computes its CNAME target directly (`iac.coreweave.dns.federation_dns_target`)
+rather than reading it live, so it doesn't need `marin-iac:import` — but Cloudflare identifies a
+`DnsRecord` by its own generated `<zone_id>/<dns_record_id>`, which nothing in our config
+derives, so an already-existing record still needs a one-time import with a separately looked-up
+ID:
+
+```bash
+# Look up the live record's ID (zone_id is the constant OA_DEV_ZONE_ID in dns.py):
+token="$(gcloud secrets versions access latest --secret=cloudflare-oa-dns-token --project=hai-gcp-models)"
+curl -s -H "Authorization: Bearer $token" \
+  "https://api.cloudflare.com/client/v4/zones/169959d6aafcbfd77764b8efafa3a509/dns_records?type=CNAME&name=iris-cw-<cluster>.oa.dev" \
+  | jq -r '.result[0].id'
+
+pulumi config set marin-iac:dns_record_import_id '169959d6aafcbfd77764b8efafa3a509/<record_id>'
+pulumi preview   # gate: `import` on the DnsRecord, no diff in content/ttl/proxied
+pulumi up
+pulumi config rm marin-iac:dns_record_import_id   # one-shot, same discipline as marin-iac:import
+```
+
 ### Backend
 
 The shared backend is a GCS bucket + a GCP KMS secrets provider, both in `hai-gcp-models`,
@@ -159,10 +184,6 @@ already provisioned:
   (`cw-rno2a`/`cw-us-east-08a` both read/write `marin-us-east-02a`'s bucket) — undecided whether
   Pulumi should provision a bucket per cluster or this reuse is the standing choice.
 - **finelog server Deployment**: a planned `FinelogServer` component, not yet built.
-- **DNS CNAME** (`iris-cw-<cluster>.oa.dev` → the Traefik LoadBalancer's CoreWeave-allocated
-  hostname): manual (Cloudflare) today. CoreWeave allocates the hostname asynchronously after
-  Traefik comes up, which needs a custom Dynamic Provider to express declaratively, and no
-  Cloudflare credential exists in this repo yet.
 - **Federation peers**: `lib/iris/config/marin.yaml`/`marin-dev.yaml`'s `peers:` entries are
   hand-edited per cluster; generate or CI-validate the peer set from the cluster configs so a
   cluster can't be reachable-but-unregistered or registered-but-missing.
@@ -173,4 +194,5 @@ already provisioned:
   `install_cw_network.py` directly for this.
 
 Everything else in the original design (RBAC, NodePools, Kueue, Traefik/cert-manager, the
-federation ingress, the GCP static IPs and Artifact Registry mirrors) is landed.
+federation ingress, the `oa.dev` CNAME, the GCP static IPs and Artifact Registry mirrors) is
+landed.

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -27,6 +27,7 @@ import pulumi_gcp as gcp
 import pulumi_kubernetes as k8s
 from iac.config import Provider, load_iris_config, load_provisioning
 from iac.coreweave.cluster import CoreweaveCluster, CoreweaveClusterArgs
+from iac.coreweave.dns import FederationDns, FederationDnsArgs
 from iac.coreweave.kueue import KueueAddon, KueueAddonArgs
 from iac.coreweave.rbac import IrisRbac, IrisRbacArgs
 from iac.coreweave.traefik import TraefikAddon, TraefikAddonArgs
@@ -63,7 +64,7 @@ def _warn_if_no_persistent_signing_key(cluster: str, iris_config) -> None:
     )
 
 
-def _build_coreweave(cluster: str, *, adopt: bool) -> None:
+def _build_coreweave(cluster: str, *, adopt: bool, dns_record_import_id: str | None) -> None:
     provisioning = load_provisioning(cluster)
     assert provisioning.coreweave is not None  # guaranteed by load_provisioning
     coreweave_provisioning = provisioning.coreweave
@@ -149,6 +150,14 @@ def _build_coreweave(cluster: str, *, adopt: bool) -> None:
         ),
         k8s_provider=k8s_provider,
     )
+    FederationDns(
+        "dns",
+        FederationDnsArgs(
+            cluster=cluster,
+            cks_cluster=coreweave_provisioning.cluster,
+            import_id=dns_record_import_id,
+        ),
+    )
 
 
 def _build_gcp(cluster: str, *, adopt: bool) -> None:
@@ -184,9 +193,12 @@ def main() -> None:
     # resource so `pulumi preview` shows the real adoption diff (provider- and parent-correct)
     # instead of planning creates. Never run `pulumi up` through a destructive NodePool diff.
     adopt = config.get_bool("import") or False
+    # Same one-shot pattern as `import`, but scoped to just the DNS record (see
+    # FederationDnsArgs.import_id): Cloudflare's own record ID, not derivable from our config.
+    dns_record_import_id = config.get("dns_record_import_id")
     provider = load_provisioning(cluster).provider
     if provider is Provider.COREWEAVE:
-        _build_coreweave(cluster, adopt=adopt)
+        _build_coreweave(cluster, adopt=adopt, dns_record_import_id=dns_record_import_id)
     elif provider is Provider.GCP:
         _build_gcp(cluster, adopt=adopt)
     else:

--- a/infra/pulumi/src/iac/coreweave/dns.py
+++ b/infra/pulumi/src/iac/coreweave/dns.py
@@ -1,0 +1,102 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""FederationDns — the oa.dev CNAME pointing a cluster's federation host at CoreWeave's LB.
+
+CoreWeave's External Hostname Controller allocates a wildcard record under
+`<tenant>-<cks-cluster-name>.coreweave.app` once TraefikAddon's LoadBalancer comes up, resolving
+any label under it to that LoadBalancer. Rather than polling the live Service for that
+asynchronously-allocated value (the approach install_cw_network.py's read_traefik_fqdn takes),
+the CNAME target is computed directly: it always follows
+`<federation-host-label>.<tenant>-<cks-cluster-name>.coreweave.app`, confirmed byte-for-byte
+against every live CoreWeave record in the oa.dev zone (2026-07-22) — see
+`federation_dns_target`'s docstring for the four checked values.
+"""
+
+from dataclasses import dataclass
+
+import pulumi
+import pulumi_cloudflare as cloudflare
+from iris.cluster.platforms.k8s.network_manifests import default_federation_host
+from rigging.secrets import resolve_secret_spec
+
+from iac.config import CksClusterSpec
+
+# CoreWeave account/tenant ID for this org. Stable across every cluster on the account, not
+# derived from anything cluster-specific; also hardcoded in infra/grafana/src/config.py and
+# lib/iris/docs/coreweave.md's Grafana dashboard link.
+COREWEAVE_TENANT_ID = "208261"
+
+# oa.dev's Cloudflare zone ID. Same value as infra/grafana/Pulumi.marin-grafana.yaml's
+# dns_zone_id; not secret (zone IDs aren't credentials, only the API token is), so it's a plain
+# constant here rather than duplicated stack config across every CoreWeave cluster.
+OA_DEV_ZONE_ID = "169959d6aafcbfd77764b8efafa3a509"
+
+# Same token infra/grafana's DnsRecord uses (see its README's "one-time" setup step) — a plain
+# constant, not per-cluster config, since every CoreWeave cluster's federation CNAME lives in
+# the same oa.dev zone. "latest" (not a pinned version) matches how it's rotated today; a
+# malformed/absent secret raises SecretResolutionError rather than falling back silently.
+CLOUDFLARE_TOKEN_SECRET = "gcp-secret://projects/hai-gcp-models/secrets/cloudflare-oa-dns-token/versions/latest"
+
+
+def federation_dns_target(cluster: str, cks_cluster_name: str) -> str:
+    """The CNAME target CoreWeave allocates for `cluster`'s federation host.
+
+    Checked against every live oa.dev record as of 2026-07-22:
+        cw-rno2a        (marin-rn02a)      -> iris-cw-rno2a.208261-marin-rn02a.coreweave.app
+        cw-us-east-02a  (marin-gpu)        -> iris-cw-us-east-02a.208261-marin-gpu.coreweave.app
+        cw-us-east-08a  (marin-us-east-08a)-> iris-cw-us-east-08a.208261-marin-us-east-08a.coreweave.app
+        cw-us-west-04a  (marin)            -> iris-cw-us-west-04a.208261-marin.coreweave.app
+    """
+    host_label = default_federation_host(cluster).split(".", 1)[0]
+    return f"{host_label}.{COREWEAVE_TENANT_ID}-{cks_cluster_name}.coreweave.app"
+
+
+@dataclass(frozen=True)
+class FederationDnsArgs:
+    cluster: str  # Iris cluster name; derives the record name (iris-cw-<cluster>.oa.dev)
+    cks_cluster: CksClusterSpec  # .name feeds the CNAME target
+    # One-shot adoption: the live record's Cloudflare-generated `<zone_id>/<dns_record_id>`.
+    # Unlike the K8s resources' `marin-iac:import` flow, Cloudflare's ID isn't derivable from our
+    # own config — look it up via the API or dashboard and set it via
+    # `marin-iac:dns_record_import_id` for exactly one `up`, same one-shot discipline as
+    # `marin-iac:import` elsewhere (see README.md's "Adopting a new cluster").
+    import_id: str | None = None
+
+
+class FederationDns(pulumi.ComponentResource):
+    """The oa.dev CNAME pointing this cluster's federation host at its Traefik LoadBalancer."""
+
+    def __init__(
+        self,
+        name: str,
+        args: FederationDnsArgs,
+        *,
+        opts: pulumi.ResourceOptions | None = None,
+    ) -> None:
+        super().__init__("marin:coreweave:FederationDns", name, None, opts)
+
+        # Fetched directly from Secret Manager rather than the CLOUDFLARE_API_TOKEN env var, so
+        # `pulumi preview`/`up` need no manual export step. pulumi.Output.secret marks it so the
+        # CLI and state file never render it in plaintext (the provider's own schema already
+        # treats api_token as sensitive; this is belt-and-suspenders for the raw string in between).
+        token = resolve_secret_spec(CLOUDFLARE_TOKEN_SECRET).value
+        cloudflare_provider = cloudflare.Provider(
+            "cloudflare",
+            api_token=pulumi.Output.secret(token),
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+
+        host = default_federation_host(args.cluster)
+        target = federation_dns_target(args.cluster, args.cks_cluster.name)
+        self.record = cloudflare.DnsRecord(
+            "federation-cname",
+            zone_id=OA_DEV_ZONE_ID,
+            name=host,
+            type="CNAME",
+            content=target,
+            ttl=300,
+            proxied=False,
+            opts=pulumi.ResourceOptions(parent=self, provider=cloudflare_provider, import_=args.import_id),
+        )
+        self.register_outputs({})

--- a/infra/pulumi/tests/test_dns.py
+++ b/infra/pulumi/tests/test_dns.py
@@ -1,0 +1,29 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""federation_dns_target — the computed CoreWeave CNAME target for a cluster's federation host.
+
+Guards the assumption FederationDns is built on: CoreWeave's allocated hostname always follows
+`<host-label>.<tenant>-<cks-cluster-name>.coreweave.app`. If CoreWeave ever changes that naming
+scheme, this test — not a live cluster — is where it should first show up as a failure.
+"""
+
+import pytest
+from iac.coreweave.dns import federation_dns_target
+
+
+@pytest.mark.parametrize(
+    "cluster, cks_cluster_name, expected",
+    [
+        ("cw-rno2a", "marin-rn02a", "iris-cw-rno2a.208261-marin-rn02a.coreweave.app"),
+        ("cw-us-east-02a", "marin-gpu", "iris-cw-us-east-02a.208261-marin-gpu.coreweave.app"),
+        (
+            "cw-us-east-08a",
+            "marin-us-east-08a",
+            "iris-cw-us-east-08a.208261-marin-us-east-08a.coreweave.app",
+        ),
+        ("cw-us-west-04a", "marin", "iris-cw-us-west-04a.208261-marin.coreweave.app"),
+    ],
+)
+def test_federation_dns_target_matches_the_live_oa_dev_zone(cluster, cks_cluster_name, expected):
+    assert federation_dns_target(cluster, cks_cluster_name) == expected


### PR DESCRIPTION
Adds a FederationDns component so Pulumi owns the oa.dev CNAME that points each CoreWeave cluster's federation host at its Traefik LoadBalancer, instead of that record being a manual, out-of-band step.

CoreWeave's allocated LoadBalancer hostname turned out to be fully deterministic (`<host-label>.<tenant>-<cks-cluster-name>.coreweave.app`, confirmed byte-for-byte against all four live oa.dev records), so the CNAME target is computed directly rather than needing a custom Dynamic Provider to poll the live Service for it, which is what an earlier version of this doc assumed was required.

- Adds `FederationDns` (`infra/pulumi/src/iac/coreweave/dns.py`), a `pulumi_cloudflare.DnsRecord` wired into `_build_coreweave` in `__main__.py`. The `pulumi_cloudflare` provider and the Cloudflare API token it needs already exist via `infra/grafana`'s precedent (`cloudflare-oa-dns-token` in `hai-gcp-models`).
- The component resolves that token directly from Secret Manager (`rigging.secrets.resolve_secret_spec`) rather than requiring a manually exported `CLOUDFLARE_API_TOKEN`, matching how secret resolution works elsewhere in this codebase.
- Adds a regression test (`infra/pulumi/tests/test_dns.py`) pinning the computed CNAME target against the four live records, so a change to CoreWeave's naming scheme shows up there first.
- Updates `infra/pulumi/README.md`'s "First-time setup" and adds an "Adopting the DNS record" section covering the one-time `pulumi import` a pre-existing record needs (Cloudflare identifies records by its own generated ID, not derivable from our config).

The four pre-existing live records have already been imported and `pulumi up` has run clean on every cluster.