### PR TITLE
[iac] Post Pulumi previews for infrastructure changes

### DIFF
--- a/.github/actions/pulumi-preview/action.yaml
+++ b/.github/actions/pulumi-preview/action.yaml
@@ -26,6 +26,9 @@ inputs:
   comment-on-pr:
     description: "Post/update the preview as a PR comment. Set false for non-PR triggers (e.g. workflow_dispatch), which have no PR to comment on."
     default: "true"
+  cloudflare-secret-name:
+    description: "GCP Secret Manager secret to export as CLOUDFLARE_API_TOKEN before preview (e.g. cloudflare-oa-dns-token, for stacks with provisioning.coreweave.federation_dns). Leave empty to skip."
+    default: ""
 
 runs:
   using: composite
@@ -41,6 +44,15 @@ runs:
       uses: google-github-actions/setup-gcloud@v3
       with:
         project_id: ${{ inputs.gcp-project-id }}
+
+    - name: Fetch Cloudflare DNS token
+      if: inputs.cloudflare-secret-name != ''
+      shell: bash
+      run: |
+        TOKEN="$(gcloud secrets versions access latest \
+          --secret="${{ inputs.cloudflare-secret-name }}" --project="${{ inputs.gcp-project-id }}")"
+        echo "::add-mask::$TOKEN"
+        echo "CLOUDFLARE_API_TOKEN=$TOKEN" >> "$GITHUB_ENV"
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v7

--- a/.github/actions/pulumi-preview/action.yaml
+++ b/.github/actions/pulumi-preview/action.yaml
@@ -26,6 +26,9 @@ inputs:
   comment-on-pr:
     description: "Post/update the preview as a PR comment. Set false for non-PR triggers (e.g. workflow_dispatch), which have no PR to comment on."
     default: "true"
+  config-map:
+    description: "Optional pulumi/actions config-map JSON applied before preview."
+    default: ""
 
 runs:
   using: composite
@@ -36,11 +39,6 @@ runs:
         project_id: ${{ inputs.gcp-project-id }}
         workload_identity_provider: ${{ inputs.workload-identity-provider }}
         service_account: ${{ inputs.service-account }}
-
-    - name: Set up Google Cloud SDK
-      uses: google-github-actions/setup-gcloud@v3
-      with:
-        project_id: ${{ inputs.gcp-project-id }}
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v7
@@ -63,5 +61,6 @@ runs:
         work-dir: ${{ inputs.work-dir }}
         cloud-url: gs://marin-iac-state
         diff: true
+        config-map: ${{ inputs.config-map }}
         comment-on-pr: ${{ inputs.comment-on-pr }}
         github-token: ${{ inputs.github-token }}

--- a/.github/actions/pulumi-preview/action.yaml
+++ b/.github/actions/pulumi-preview/action.yaml
@@ -26,9 +26,6 @@ inputs:
   comment-on-pr:
     description: "Post/update the preview as a PR comment. Set false for non-PR triggers (e.g. workflow_dispatch), which have no PR to comment on."
     default: "true"
-  cloudflare-secret-name:
-    description: "GCP Secret Manager secret to export as CLOUDFLARE_API_TOKEN before preview (e.g. cloudflare-oa-dns-token, for stacks with provisioning.coreweave.federation_dns). Leave empty to skip."
-    default: ""
 
 runs:
   using: composite
@@ -44,15 +41,6 @@ runs:
       uses: google-github-actions/setup-gcloud@v3
       with:
         project_id: ${{ inputs.gcp-project-id }}
-
-    - name: Fetch Cloudflare DNS token
-      if: inputs.cloudflare-secret-name != ''
-      shell: bash
-      run: |
-        TOKEN="$(gcloud secrets versions access latest \
-          --secret="${{ inputs.cloudflare-secret-name }}" --project="${{ inputs.gcp-project-id }}")"
-        echo "::add-mask::$TOKEN"
-        echo "CLOUDFLARE_API_TOKEN=$TOKEN" >> "$GITHUB_ENV"
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v7

--- a/.github/actions/pulumi-preview/action.yaml
+++ b/.github/actions/pulumi-preview/action.yaml
@@ -1,0 +1,61 @@
+name: "Pulumi preview"
+description: "Preview a stack against the shared iac backend and post the plan as a PR comment: GCP auth, then pulumi preview."
+
+inputs:
+  stack:
+    description: "Pulumi stack name (e.g. cw-us-east-02a, marin-grafana)."
+    required: true
+  work-dir:
+    description: "Directory holding the Pulumi.yaml (e.g. infra/pulumi)."
+    required: true
+  service-account:
+    description: "GCP service account impersonated through Workload Identity Federation."
+    required: true
+  workload-identity-provider:
+    description: "GCP workload identity provider resource name."
+    default: "projects/748532799086/locations/global/workloadIdentityPools/github-pool/providers/github-oidc"
+  gcp-project-id:
+    description: "GCP project id."
+    required: true
+  github-token:
+    description: "Token used to post/update the preview comment on the PR (needs pull-requests: write)."
+    required: true
+  uv-sync-args:
+    description: "Arguments for the venv sync (stacks whose program imports more than iac widen this)."
+    default: "--package marin-iac --extra deploy --frozen"
+  comment-on-pr:
+    description: "Post/update the preview as a PR comment. Set false for non-PR triggers (e.g. workflow_dispatch), which have no PR to comment on."
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v3
+      with:
+        project_id: ${{ inputs.gcp-project-id }}
+        workload_identity_provider: ${{ inputs.workload-identity-provider }}
+        service_account: ${{ inputs.service-account }}
+
+    - name: Set up Google Cloud SDK
+      uses: google-github-actions/setup-gcloud@v3
+      with:
+        project_id: ${{ inputs.gcp-project-id }}
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v7
+
+    - name: Sync the iac venv
+      shell: bash
+      run: uv sync ${{ inputs.uv-sync-args }}
+
+    - name: Preview the stack
+      uses: pulumi/actions@v6
+      with:
+        command: preview
+        stack-name: ${{ inputs.stack }}
+        work-dir: ${{ inputs.work-dir }}
+        cloud-url: gs://marin-iac-state
+        diff: true
+        comment-on-pr: ${{ inputs.comment-on-pr }}
+        github-token: ${{ inputs.github-token }}

--- a/.github/actions/pulumi-preview/action.yaml
+++ b/.github/actions/pulumi-preview/action.yaml
@@ -51,6 +51,12 @@ runs:
 
     - name: Preview the stack
       uses: pulumi/actions@v6
+      env:
+        # infra/pulumi's plain `runtime: python` (no `virtualenv:` option) resolves `python3`
+        # from PATH, which `uv sync` above does not add to this step's PATH — without this,
+        # Pulumi runs the program under the runner's system Python and fails with
+        # `ModuleNotFoundError: No module named 'pulumi'` instead of previewing.
+        PULUMI_PYTHON_CMD: ${{ github.workspace }}/.venv/bin/python
       with:
         command: preview
         stack-name: ${{ inputs.stack }}

--- a/.github/workflows/ops-iac-preview.yaml
+++ b/.github/workflows/ops-iac-preview.yaml
@@ -67,8 +67,6 @@ jobs:
           gcp-project-id: ${{ env.PULUMI_CI_PROJECT }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-pr: ${{ github.event_name == 'pull_request' }}
-          # Every CoreWeave cluster declares provisioning.coreweave.federation_dns.
-          cloudflare-secret-name: cloudflare-oa-dns-token
 
   preview-gcp:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/ops-iac-preview.yaml
+++ b/.github/workflows/ops-iac-preview.yaml
@@ -92,3 +92,7 @@ jobs:
           gcp-project-id: ${{ env.PULUMI_CI_PROJECT }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-pr: ${{ github.event_name == 'pull_request' }}
+          # The live GCP resources predate this empty stack. Show their adoption diff instead
+          # of reporting creates that would fail because the names already exist. Remove this
+          # after the first successful `pulumi up` adopts the six resources into the marin stack.
+          config-map: '{"marin-iac:import": {"value": "true"}}'

--- a/.github/workflows/ops-iac-preview.yaml
+++ b/.github/workflows/ops-iac-preview.yaml
@@ -1,0 +1,90 @@
+name: "Ops - IaC preview"
+
+# Posts `pulumi preview` for each affected infra/pulumi (marin-iac) stack as a PR comment.
+# Also runnable via workflow_dispatch (e.g. to check for drift outside a PR)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "infra/pulumi/**"
+      - "lib/iris/config/**"
+      - ".github/workflows/ops-iac-preview.yaml"
+      - ".github/actions/pulumi-preview/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  preview-coreweave:
+    # Fork PRs can't reach repo secrets (WIF, kubeconfig); skip rather than fail.
+    # Manual dispatch has no PR to check and is already gated to repo collaborators by GitHub.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    concurrency:
+      group: iac-preview-${{ matrix.stack }}-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        stack: [cw-rno2a, cw-us-east-02a, cw-us-east-08a, cw-us-west-04a]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Write kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          echo "${{ secrets.CW_KUBECONFIG }}" > ~/.kube/coreweave-iris
+          chmod 600 ~/.kube/coreweave-iris
+
+      # Required for TraefikAddon's Traefik/cert-manager Releases to resolve their charts
+      # during `pulumi preview` — see infra/pulumi/README.md's Prerequisites.
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Add CoreWeave Helm repo
+        run: |
+          helm repo add coreweave https://charts.core-services.ingress.coreweave.com
+          helm repo update coreweave
+
+      - name: Preview ${{ matrix.stack }}
+        uses: ./.github/actions/pulumi-preview
+        with:
+          stack: ${{ matrix.stack }}
+          work-dir: infra/pulumi
+          service-account: pulumi-ci@hai-gcp-models.iam.gserviceaccount.com
+          gcp-project-id: hai-gcp-models
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-on-pr: ${{ github.event_name == 'pull_request' }}
+
+  preview-gcp:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    concurrency:
+      group: iac-preview-marin-${{ github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Preview marin
+        uses: ./.github/actions/pulumi-preview
+        with:
+          stack: marin
+          work-dir: infra/pulumi
+          service-account: pulumi-ci@hai-gcp-models.iam.gserviceaccount.com
+          gcp-project-id: hai-gcp-models
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-on-pr: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ops-iac-preview.yaml
+++ b/.github/workflows/ops-iac-preview.yaml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+env:
+  PULUMI_CI_SERVICE_ACCOUNT: pulumi-ci@hai-gcp-models.iam.gserviceaccount.com
+  PULUMI_CI_PROJECT: hai-gcp-models
+
 jobs:
   preview-coreweave:
     # Fork PRs can't reach repo secrets (WIF, kubeconfig); skip rather than fail.
@@ -59,8 +63,8 @@ jobs:
         with:
           stack: ${{ matrix.stack }}
           work-dir: infra/pulumi
-          service-account: pulumi-ci@hai-gcp-models.iam.gserviceaccount.com
-          gcp-project-id: hai-gcp-models
+          service-account: ${{ env.PULUMI_CI_SERVICE_ACCOUNT }}
+          gcp-project-id: ${{ env.PULUMI_CI_PROJECT }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-pr: ${{ github.event_name == 'pull_request' }}
 
@@ -84,7 +88,7 @@ jobs:
         with:
           stack: marin
           work-dir: infra/pulumi
-          service-account: pulumi-ci@hai-gcp-models.iam.gserviceaccount.com
-          gcp-project-id: hai-gcp-models
+          service-account: ${{ env.PULUMI_CI_SERVICE_ACCOUNT }}
+          gcp-project-id: ${{ env.PULUMI_CI_PROJECT }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-pr: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ops-iac-preview.yaml
+++ b/.github/workflows/ops-iac-preview.yaml
@@ -67,6 +67,8 @@ jobs:
           gcp-project-id: ${{ env.PULUMI_CI_PROJECT }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-pr: ${{ github.event_name == 'pull_request' }}
+          # Every CoreWeave cluster declares provisioning.coreweave.federation_dns.
+          cloudflare-secret-name: cloudflare-oa-dns-token
 
   preview-gcp:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository

--- a/infra/permissions/Pulumi.hai-gcp-models.yaml
+++ b/infra/permissions/Pulumi.hai-gcp-models.yaml
@@ -36,6 +36,7 @@ config:
         - *main_subject
       kms_access: decrypt_only
       state_access: preview
+      gcp_resource_previewer: true
       create_account: true
       display_name: "Pulumi CI preview (read-only)"
       # CoreWeave stacks with provisioning.coreweave.federation_dns read this at preview time

--- a/infra/permissions/Pulumi.hai-gcp-models.yaml
+++ b/infra/permissions/Pulumi.hai-gcp-models.yaml
@@ -2,17 +2,18 @@ config:
   marin-permissions:project: hai-gcp-models
   marin-permissions:project_number: "748532799086"
   marin-permissions:workload_identity_pool: github-pool
-  marin-permissions:github_subject: repo:marin-community/marin:ref:refs/heads/main
   marin-permissions:state_bucket: marin-iac-state
   marin-permissions:kms_location: us-central1
   marin-permissions:kms_key_ring: marin-iac-keyring
   marin-permissions:kms_key: marin-iac-key
   marin-permissions:deploy_accounts:
     - service_account: iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com
+      github_subject: repo:marin-community/marin:ref:refs/heads/main
       mint_id_tokens: true
       secret_access_secrets:
         - iris-cw-us-west-04a-signing-key
     - service_account: marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com
+      github_subject: repo:marin-community/marin:ref:refs/heads/main
       secret_metadata_viewer: true
       # Keep this permission allowlist explicit: a new runtime secret should fail closed
       # until its deploy-account IAM management is reviewed here.
@@ -26,5 +27,12 @@ config:
           repositories:
             - marin-grafana
       iap_iam_manager: true
+    # Used for posting `pulumi preview` as a PR comment
+    - service_account: pulumi-ci@hai-gcp-models.iam.gserviceaccount.com
+      github_subject: repo:marin-community/marin:pull_request
+      kms_access: decrypt_only
+      state_access: preview
+      create_account: true
+      display_name: "Pulumi CI preview (read-only)"
 secretsprovider: gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
 encryptedkey: CiQAKk3j6QvsjVzr0PISU10T8p7CBI0p31YV97owWqgbmeAU4wUSSQCdtF6ivDSFDEI7pl9JQ4dMHYbmdE2rjMYZjjF9S6S3BiIx2j9acg0JGF88fZT8lDPrScl/KjBkTV76oECYPg18C/ry5YsXaAE=

--- a/infra/permissions/Pulumi.hai-gcp-models.yaml
+++ b/infra/permissions/Pulumi.hai-gcp-models.yaml
@@ -29,9 +29,7 @@ config:
           repositories:
             - marin-grafana
       iap_iam_manager: true
-    # Used for posting `pulumi preview` as a PR comment. Two subjects: `pull_request` covers
-    # the PR trigger; `*main_subject` covers `workflow_dispatch`, whose OIDC subject follows
-    # the dispatching ref rather than the event name — manual runs only authenticate from main.
+    # Used for posting `pulumi preview` as a PR comment.
     - service_account: pulumi-ci@hai-gcp-models.iam.gserviceaccount.com
       github_subjects:
         - repo:marin-community/marin:pull_request

--- a/infra/permissions/Pulumi.hai-gcp-models.yaml
+++ b/infra/permissions/Pulumi.hai-gcp-models.yaml
@@ -8,12 +8,12 @@ config:
   marin-permissions:kms_key: marin-iac-key
   marin-permissions:deploy_accounts:
     - service_account: iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com
-      github_subject: repo:marin-community/marin:ref:refs/heads/main
+      github_subject: &main_subject repo:marin-community/marin:ref:refs/heads/main
       mint_id_tokens: true
       secret_access_secrets:
         - iris-cw-us-west-04a-signing-key
     - service_account: marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com
-      github_subject: repo:marin-community/marin:ref:refs/heads/main
+      github_subject: *main_subject
       secret_metadata_viewer: true
       # Keep this permission allowlist explicit: a new runtime secret should fail closed
       # until its deploy-account IAM management is reviewed here.

--- a/infra/permissions/Pulumi.hai-gcp-models.yaml
+++ b/infra/permissions/Pulumi.hai-gcp-models.yaml
@@ -40,5 +40,9 @@ config:
       state_access: preview
       create_account: true
       display_name: "Pulumi CI preview (read-only)"
+      # CoreWeave stacks with provisioning.coreweave.federation_dns read this at preview time
+      # (infra/pulumi/README.md's Cloudflare credential prerequisite).
+      secret_access_secrets:
+        - cloudflare-oa-dns-token
 secretsprovider: gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
 encryptedkey: CiQAKk3j6QvsjVzr0PISU10T8p7CBI0p31YV97owWqgbmeAU4wUSSQCdtF6ivDSFDEI7pl9JQ4dMHYbmdE2rjMYZjjF9S6S3BiIx2j9acg0JGF88fZT8lDPrScl/KjBkTV76oECYPg18C/ry5YsXaAE=

--- a/infra/permissions/Pulumi.hai-gcp-models.yaml
+++ b/infra/permissions/Pulumi.hai-gcp-models.yaml
@@ -8,12 +8,14 @@ config:
   marin-permissions:kms_key: marin-iac-key
   marin-permissions:deploy_accounts:
     - service_account: iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com
-      github_subject: &main_subject repo:marin-community/marin:ref:refs/heads/main
+      github_subjects:
+        - &main_subject repo:marin-community/marin:ref:refs/heads/main
       mint_id_tokens: true
       secret_access_secrets:
         - iris-cw-us-west-04a-signing-key
     - service_account: marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com
-      github_subject: *main_subject
+      github_subjects:
+        - *main_subject
       secret_metadata_viewer: true
       # Keep this permission allowlist explicit: a new runtime secret should fail closed
       # until its deploy-account IAM management is reviewed here.
@@ -27,9 +29,13 @@ config:
           repositories:
             - marin-grafana
       iap_iam_manager: true
-    # Used for posting `pulumi preview` as a PR comment
+    # Used for posting `pulumi preview` as a PR comment. Two subjects: `pull_request` covers
+    # the PR trigger; `*main_subject` covers `workflow_dispatch`, whose OIDC subject follows
+    # the dispatching ref rather than the event name — manual runs only authenticate from main.
     - service_account: pulumi-ci@hai-gcp-models.iam.gserviceaccount.com
-      github_subject: repo:marin-community/marin:pull_request
+      github_subjects:
+        - repo:marin-community/marin:pull_request
+        - *main_subject
       kms_access: decrypt_only
       state_access: preview
       create_account: true

--- a/infra/permissions/README.md
+++ b/infra/permissions/README.md
@@ -24,9 +24,11 @@ is created by this stack (`create_account: true`) rather than pre-existing. It b
 `workflow_dispatch` — whose OIDC subject follows the dispatching ref, not the event name, so a
 manual run only authenticates when dispatched from `main`. Its grants are preview-only:
 `kms_access: decrypt_only` (never encrypt/write secrets) and `state_access: preview` (read
-state, write only the `.pulumi/locks/` prefix — never state content). Every other account
-defaults to `kms_access: encrypt_decrypt` / `state_access: apply`, matching `pulumi up`, and
-`github_subjects` normally holds just the one main-branch subject.
+state, write only the `.pulumi/locks/` prefix — never state content). Its custom
+`marinGcpResourcePreviewer` role can read only the Artifact Registry repositories and reserved
+addresses declared by the GCP stack, including the location metadata those reads require. Every
+other account defaults to `kms_access: encrypt_decrypt` / `state_access: apply`, matching
+`pulumi up`, and `github_subjects` normally holds just the one main-branch subject.
 
 The Grafana deploy account can list Secret Manager metadata for its optional-secret probe. A
 custom role lets it manage IAM policies on the four secrets wired into Cloud Run without

--- a/infra/permissions/README.md
+++ b/infra/permissions/README.md
@@ -19,11 +19,14 @@ GitHub subject. Rigging needs it to mint the service-account ID token accepted b
 edge; Grafana does not mint IAP tokens and does not receive that role.
 
 The `pulumi-ci` account backs `ops-iac-preview.yaml` (`infra/pulumi/README.md`'s CI preview) and
-is created by this stack (`create_account: true`) rather than pre-existing. It binds to the
-`pull_request` OIDC subject rather than main-branch push, and its grants are preview-only:
+is created by this stack (`create_account: true`) rather than pre-existing. It binds two
+`github_subjects`: `pull_request` for the PR trigger, and `*main_subject` for
+`workflow_dispatch` — whose OIDC subject follows the dispatching ref, not the event name, so a
+manual run only authenticates when dispatched from `main`. Its grants are preview-only:
 `kms_access: decrypt_only` (never encrypt/write secrets) and `state_access: preview` (read
 state, write only the `.pulumi/locks/` prefix — never state content). Every other account
-defaults to `kms_access: encrypt_decrypt` / `state_access: apply`, matching `pulumi up`.
+defaults to `kms_access: encrypt_decrypt` / `state_access: apply`, matching `pulumi up`, and
+`github_subjects` normally holds just the one main-branch subject.
 
 The Grafana deploy account can list Secret Manager metadata for its optional-secret probe. A
 custom role lets it manage IAM policies on the four secrets wired into Cloud Run without

--- a/infra/permissions/README.md
+++ b/infra/permissions/README.md
@@ -1,7 +1,10 @@
 # Marin permissions
 
 This Pulumi project owns additive IAM grants shared by deployment workflows. It does not own
-the existing GitHub workload identity pool, service accounts, state bucket, or KMS key.
+the workload identity pool, state bucket, or KMS key — those are existing shared resources. Most
+deploy accounts are existing too (created out-of-band; this stack only grants IAM on them). An
+account with `create_account: true` is the exception: this stack owns it end-to-end, creating the
+`google_service_account` alongside its grants.
 
 The `hai-gcp-models` stack lets GitHub OIDC tokens for the `main` branch impersonate deployment
 accounts. Each account can update the shared Pulumi state bucket and encrypt or decrypt stack
@@ -14,6 +17,13 @@ the CoreWeave smoke-test controller.
 The Ducky account also receives `roles/iam.serviceAccountTokenCreator` from the same exact
 GitHub subject. Rigging needs it to mint the service-account ID token accepted by Iris's IAP
 edge; Grafana does not mint IAP tokens and does not receive that role.
+
+The `pulumi-ci` account backs `ops-iac-preview.yaml` (`infra/pulumi/README.md`'s CI preview) and
+is created by this stack (`create_account: true`) rather than pre-existing. It binds to the
+`pull_request` OIDC subject rather than main-branch push, and its grants are preview-only:
+`kms_access: decrypt_only` (never encrypt/write secrets) and `state_access: preview` (read
+state, write only the `.pulumi/locks/` prefix — never state content). Every other account
+defaults to `kms_access: encrypt_decrypt` / `state_access: apply`, matching `pulumi up`.
 
 The Grafana deploy account can list Secret Manager metadata for its optional-secret probe. A
 custom role lets it manage IAM policies on the four secrets wired into Cloud Run without

--- a/infra/permissions/__main__.py
+++ b/infra/permissions/__main__.py
@@ -7,7 +7,7 @@ import pulumi
 import pulumi_gcp as gcp
 from iac.gcp.permissions import (
     GcpArtifactRegistryGrant,
-    GcpDeployAccount,
+    GcpAutomationAccount,
     GcpDeployPermissions,
     GcpDeployPermissionsArgs,
     GcpKmsAccess,
@@ -31,7 +31,7 @@ def main() -> None:
             kms_key_ring=config.require("kms_key_ring"),
             kms_key=config.require("kms_key"),
             accounts=tuple(
-                GcpDeployAccount(
+                GcpAutomationAccount(
                     service_account=account["service_account"],
                     github_subjects=tuple(account["github_subjects"]),
                     mint_id_tokens=account.get("mint_id_tokens", False),
@@ -47,6 +47,7 @@ def main() -> None:
                         )
                         for grant in account.get("artifact_registry_grants", [])
                     ),
+                    gcp_resource_previewer=account.get("gcp_resource_previewer", False),
                     iap_iam_manager=account.get("iap_iam_manager", False),
                     create_account=account.get("create_account", False),
                     display_name=account.get("display_name", ""),

--- a/infra/permissions/__main__.py
+++ b/infra/permissions/__main__.py
@@ -33,7 +33,7 @@ def main() -> None:
             accounts=tuple(
                 GcpDeployAccount(
                     service_account=account["service_account"],
-                    github_subject=account["github_subject"],
+                    github_subjects=tuple(account["github_subjects"]),
                     mint_id_tokens=account.get("mint_id_tokens", False),
                     kms_access=GcpKmsAccess(account.get("kms_access", GcpKmsAccess.ENCRYPT_DECRYPT.value)),
                     state_access=GcpStateAccess(account.get("state_access", GcpStateAccess.APPLY.value)),

--- a/infra/permissions/__main__.py
+++ b/infra/permissions/__main__.py
@@ -10,6 +10,8 @@ from iac.gcp.permissions import (
     GcpDeployAccount,
     GcpDeployPermissions,
     GcpDeployPermissionsArgs,
+    GcpKmsAccess,
+    GcpStateAccess,
 )
 
 
@@ -24,7 +26,6 @@ def main() -> None:
             project=project,
             project_number=config.require("project_number"),
             workload_identity_pool=config.require("workload_identity_pool"),
-            github_subject=config.require("github_subject"),
             state_bucket=config.require("state_bucket"),
             kms_location=config.require("kms_location"),
             kms_key_ring=config.require("kms_key_ring"),
@@ -32,7 +33,10 @@ def main() -> None:
             accounts=tuple(
                 GcpDeployAccount(
                     service_account=account["service_account"],
+                    github_subject=account["github_subject"],
                     mint_id_tokens=account.get("mint_id_tokens", False),
+                    kms_access=GcpKmsAccess(account.get("kms_access", GcpKmsAccess.ENCRYPT_DECRYPT.value)),
+                    state_access=GcpStateAccess(account.get("state_access", GcpStateAccess.APPLY.value)),
                     secret_metadata_viewer=account.get("secret_metadata_viewer", False),
                     secret_access_secrets=tuple(account.get("secret_access_secrets", [])),
                     secret_iam_secrets=tuple(account.get("secret_iam_secrets", [])),
@@ -44,6 +48,8 @@ def main() -> None:
                         for grant in account.get("artifact_registry_grants", [])
                     ),
                     iap_iam_manager=account.get("iap_iam_manager", False),
+                    create_account=account.get("create_account", False),
+                    display_name=account.get("display_name", ""),
                 )
                 for account in deploy_accounts
             ),

--- a/infra/pulumi/README.md
+++ b/infra/pulumi/README.md
@@ -148,6 +148,32 @@ already provisioned:
     --role="roles/cloudkms.cryptoKeyEncrypterDecrypter"
   ```
 
+## CI preview
+
+`.github/workflows/ops-iac-preview.yaml` runs `pulumi preview` for every stack (CoreWeave and
+`marin`) on PRs that touch `infra/pulumi/**` or `lib/iris/config/**`, and posts each stack's plan
+as a PR comment via `./.github/actions/pulumi-preview`. It's also runnable via
+`workflow_dispatch` (e.g. to check for drift outside a PR); those runs skip the comment, since
+there's no PR to post to, and print the plan to the job logs instead. **CI never runs `pulumi
+up`** — see `spec.md §9`.
+
+It authenticates as `pulumi-ci@hai-gcp-models.iam.gserviceaccount.com` over Workload Identity
+Federation, bound to the `pull_request` OIDC subject (not main-branch push). Both the account and
+its IAM are declared in [`infra/permissions`](../permissions/README.md), deliberately narrower
+than the deploy accounts: `roles/cloudkms.cryptoKeyDecrypter` (read stack secrets, never write
+them) and `roles/storage.objectViewer` plus a `.pulumi/locks/`-scoped `roles/storage.objectUser`
+(read state, take/release the stack lock, never write state content). A compromised preview run
+on a PR cannot mutate state or re-encrypt secrets.
+
+CoreWeave stacks also need a live k8s connection for the Server-Side Apply dry-run — the
+workflow writes the shared `CW_KUBECONFIG` repo secret to `~/.kube/coreweave-iris` before
+calling the action, matching every cluster's `platform.coreweave.kubeconfig_path`.
+
+Adapting this to another Pulumi project (e.g. `infra/grafana`) means a new thin workflow that
+triggers on that project's paths and calls `./.github/actions/pulumi-preview` with its own
+`stack`/`work-dir` — plus, if that stack also needs preview-only access, a `state_access: preview`
+/ `kms_access: decrypt_only` account in `infra/permissions`.
+
 ## Unsupported
 
 - **Signing keys** (`iris-<cluster>-signing-key`, `finelog-<cluster>-signing-key`) stay manual,

--- a/infra/pulumi/README.md
+++ b/infra/pulumi/README.md
@@ -150,29 +150,13 @@ already provisioned:
 
 ## CI preview
 
-`.github/workflows/ops-iac-preview.yaml` runs `pulumi preview` for every stack (CoreWeave and
-`marin`) on PRs that touch `infra/pulumi/**` or `lib/iris/config/**`, and posts each stack's plan
-as a PR comment via `./.github/actions/pulumi-preview`. It's also runnable via
-`workflow_dispatch` (e.g. to check for drift outside a PR); those runs skip the comment, since
-there's no PR to post to, and print the plan to the job logs instead. **CI never runs `pulumi
-up`** — see `spec.md §9`.
+`.github/workflows/ops-iac-preview.yaml` posts `pulumi preview` for every stack as a PR comment.
+**CI never runs `pulumi up`** — see `spec.md §9`. It authenticates as
+`pulumi-ci@hai-gcp-models.iam.gserviceaccount.com`, granted preview-only (decrypt/read, never
+write) access in [`infra/permissions`](../permissions/README.md).
 
-It authenticates as `pulumi-ci@hai-gcp-models.iam.gserviceaccount.com` over Workload Identity
-Federation, bound to the `pull_request` OIDC subject (not main-branch push). Both the account and
-its IAM are declared in [`infra/permissions`](../permissions/README.md), deliberately narrower
-than the deploy accounts: `roles/cloudkms.cryptoKeyDecrypter` (read stack secrets, never write
-them) and `roles/storage.objectViewer` plus a `.pulumi/locks/`-scoped `roles/storage.objectUser`
-(read state, take/release the stack lock, never write state content). A compromised preview run
-on a PR cannot mutate state or re-encrypt secrets.
-
-CoreWeave stacks also need a live k8s connection for the Server-Side Apply dry-run — the
-workflow writes the shared `CW_KUBECONFIG` repo secret to `~/.kube/coreweave-iris` before
-calling the action, matching every cluster's `platform.coreweave.kubeconfig_path`.
-
-Adapting this to another Pulumi project (e.g. `infra/grafana`) means a new thin workflow that
-triggers on that project's paths and calls `./.github/actions/pulumi-preview` with its own
-`stack`/`work-dir` — plus, if that stack also needs preview-only access, a `state_access: preview`
-/ `kms_access: decrypt_only` account in `infra/permissions`.
+Adapting this to another Pulumi project means a new thin workflow that triggers on that
+project's paths and calls `./.github/actions/pulumi-preview` with its own `stack`/`work-dir`.
 
 ## Unsupported
 

--- a/infra/pulumi/src/iac/gcp/permissions.py
+++ b/infra/pulumi/src/iac/gcp/permissions.py
@@ -172,70 +172,82 @@ def _create_service_accounts(
     return tuple(created)
 
 
+def _grant_workload_identity(permission_set: GcpDeployPermissionSet, opts: pulumi.ResourceOptions) -> None:
+    # Suffix only when an account has more than one subject: the unsuffixed "-github-main" name
+    # is the pre-existing resource name for the accounts already live in state, and renaming it
+    # would make Pulumi delete-then-recreate a protected resource.
+    multiple = len(permission_set.github_principals) > 1
+    for i, principal in enumerate(permission_set.github_principals):
+        suffix = f"-{i}" if multiple else ""
+        gcp.serviceaccount.IAMMember(
+            f"{permission_set.account_id}-github-main{suffix}",
+            service_account_id=permission_set.service_account_id,
+            role=WORKLOAD_IDENTITY_USER,
+            member=principal,
+            opts=opts,
+        )
+        if permission_set.mint_id_tokens:
+            gcp.serviceaccount.IAMMember(
+                f"{permission_set.account_id}-github-main-id-token{suffix}",
+                service_account_id=permission_set.service_account_id,
+                role=SERVICE_ACCOUNT_TOKEN_CREATOR,
+                member=principal,
+                opts=opts,
+            )
+
+
+def _grant_state_access(permission_set: GcpDeployPermissionSet, opts: pulumi.ResourceOptions) -> None:
+    if permission_set.state_access is GcpStateAccess.APPLY:
+        gcp.storage.BucketIAMMember(
+            f"{permission_set.account_id}-pulumi-state",
+            bucket=permission_set.state_bucket,
+            role=STATE_WRITER,
+            member=permission_set.service_account_member,
+            opts=opts,
+        )
+        return
+    gcp.storage.BucketIAMMember(
+        f"{permission_set.account_id}-pulumi-state-read",
+        bucket=permission_set.state_bucket,
+        role=STATE_READER,
+        member=permission_set.service_account_member,
+        opts=opts,
+    )
+    gcp.storage.BucketIAMMember(
+        f"{permission_set.account_id}-pulumi-state-locks",
+        bucket=permission_set.state_bucket,
+        role=STATE_LOCK_WRITER,
+        member=permission_set.service_account_member,
+        condition=gcp.storage.BucketIAMMemberConditionArgs(
+            title=f"{permission_set.account_id}-pulumi-locks",
+            description="Create/delete stack lock objects only; no access to state content.",
+            expression=(
+                f'resource.name.startsWith("projects/_/buckets/{permission_set.state_bucket}'
+                f'/objects/{STATE_LOCKS_PREFIX}")'
+            ),
+        ),
+        opts=opts,
+    )
+
+
+def _grant_kms_access(permission_set: GcpDeployPermissionSet, opts: pulumi.ResourceOptions) -> None:
+    gcp.kms.CryptoKeyIAMMember(
+        f"{permission_set.account_id}-pulumi-kms",
+        crypto_key_id=permission_set.crypto_key_id,
+        role=_KMS_ROLES[permission_set.kms_access],
+        member=permission_set.service_account_member,
+        opts=opts,
+    )
+
+
 def _create_base_permissions(
     permission_sets: tuple[GcpDeployPermissionSet, ...],
     opts: pulumi.ResourceOptions,
 ) -> None:
     for permission_set in permission_sets:
-        # Suffix only when an account has more than one subject: the unsuffixed "-github-main"
-        # name is the pre-existing resource name for the accounts already live in state, and
-        # renaming it would make Pulumi delete-then-recreate a protected resource.
-        multiple = len(permission_set.github_principals) > 1
-        for i, principal in enumerate(permission_set.github_principals):
-            suffix = f"-{i}" if multiple else ""
-            gcp.serviceaccount.IAMMember(
-                f"{permission_set.account_id}-github-main{suffix}",
-                service_account_id=permission_set.service_account_id,
-                role=WORKLOAD_IDENTITY_USER,
-                member=principal,
-                opts=opts,
-            )
-            if permission_set.mint_id_tokens:
-                gcp.serviceaccount.IAMMember(
-                    f"{permission_set.account_id}-github-main-id-token{suffix}",
-                    service_account_id=permission_set.service_account_id,
-                    role=SERVICE_ACCOUNT_TOKEN_CREATOR,
-                    member=principal,
-                    opts=opts,
-                )
-        if permission_set.state_access is GcpStateAccess.APPLY:
-            gcp.storage.BucketIAMMember(
-                f"{permission_set.account_id}-pulumi-state",
-                bucket=permission_set.state_bucket,
-                role=STATE_WRITER,
-                member=permission_set.service_account_member,
-                opts=opts,
-            )
-        else:
-            gcp.storage.BucketIAMMember(
-                f"{permission_set.account_id}-pulumi-state-read",
-                bucket=permission_set.state_bucket,
-                role=STATE_READER,
-                member=permission_set.service_account_member,
-                opts=opts,
-            )
-            gcp.storage.BucketIAMMember(
-                f"{permission_set.account_id}-pulumi-state-locks",
-                bucket=permission_set.state_bucket,
-                role=STATE_LOCK_WRITER,
-                member=permission_set.service_account_member,
-                condition=gcp.storage.BucketIAMMemberConditionArgs(
-                    title=f"{permission_set.account_id}-pulumi-locks",
-                    description="Create/delete stack lock objects only; no access to state content.",
-                    expression=(
-                        f'resource.name.startsWith("projects/_/buckets/{permission_set.state_bucket}'
-                        f'/objects/{STATE_LOCKS_PREFIX}")'
-                    ),
-                ),
-                opts=opts,
-            )
-        gcp.kms.CryptoKeyIAMMember(
-            f"{permission_set.account_id}-pulumi-kms",
-            crypto_key_id=permission_set.crypto_key_id,
-            role=_KMS_ROLES[permission_set.kms_access],
-            member=permission_set.service_account_member,
-            opts=opts,
-        )
+        _grant_workload_identity(permission_set, opts)
+        _grant_state_access(permission_set, opts)
+        _grant_kms_access(permission_set, opts)
 
 
 def _create_secret_permissions(args: GcpDeployPermissionsArgs, opts: pulumi.ResourceOptions) -> None:
@@ -327,13 +339,14 @@ def _create_iap_permissions(args: GcpDeployPermissionsArgs, opts: pulumi.Resourc
 
 
 class GcpDeployPermissions(pulumi.ComponentResource):
-    """Grant GitHub workflows access to deploy or preview through existing accounts.
+    """Grant GitHub workflows access to deploy or preview through deploy accounts.
 
-    Each account binds to its own GitHub OIDC subject (e.g. a main-branch push for `pulumi up`,
-    or a `pull_request` event for `pulumi preview`), scoped by `kms_access`/`state_access` to
-    what that trigger needs. The component owns custom roles and non-authoritative IAM members.
-    The service accounts, workload identity pool/provider, state bucket, and KMS key are
-    existing shared resources.
+    Each account binds to its own GitHub OIDC subject(s) (e.g. a main-branch push for
+    `pulumi up`, or a `pull_request` event for `pulumi preview`), scoped by
+    `kms_access`/`state_access` to what that trigger needs. Most accounts are existing —
+    this component only grants IAM on them — but one with `create_account=True` is owned
+    end-to-end, including the `gcp.serviceaccount.Account` itself. The workload identity
+    pool/provider, state bucket, and KMS key are always existing shared resources.
     """
 
     def __init__(

--- a/infra/pulumi/src/iac/gcp/permissions.py
+++ b/infra/pulumi/src/iac/gcp/permissions.py
@@ -62,7 +62,10 @@ class GcpArtifactRegistryGrant:
 @dataclass(frozen=True)
 class GcpDeployAccount:
     service_account: str
-    github_subject: str
+    # One GitHub OIDC subject per trigger this account must authenticate from (e.g. a
+    # `pull_request` subject for preview plus a main-branch `ref:refs/heads/main` subject for
+    # `workflow_dispatch`, whose subject follows the dispatching ref rather than the event name).
+    github_subjects: tuple[str, ...]
     mint_id_tokens: bool = False
     kms_access: GcpKmsAccess = GcpKmsAccess.ENCRYPT_DECRYPT
     state_access: GcpStateAccess = GcpStateAccess.APPLY
@@ -95,7 +98,7 @@ class GcpDeployPermissionSet:
     account_id: str
     service_account_id: str
     service_account_member: str
-    github_principal: str
+    github_principals: tuple[str, ...]
     state_bucket: str
     crypto_key_id: str
     mint_id_tokens: bool
@@ -114,10 +117,13 @@ def _service_account_member(email: str) -> str:
     return f"serviceAccount:{email}"
 
 
-def _github_principal(project_number: str, workload_identity_pool: str, github_subject: str) -> str:
-    return (
+def _github_principals(
+    project_number: str, workload_identity_pool: str, github_subjects: tuple[str, ...]
+) -> tuple[str, ...]:
+    return tuple(
         f"principal://iam.googleapis.com/projects/{project_number}/locations/global/"
-        f"workloadIdentityPools/{workload_identity_pool}/subject/{github_subject}"
+        f"workloadIdentityPools/{workload_identity_pool}/subject/{subject}"
+        for subject in github_subjects
     )
 
 
@@ -132,7 +138,9 @@ def deploy_permission_sets(args: GcpDeployPermissionsArgs) -> tuple[GcpDeployPer
             account_id=_account_id(args.project, account.service_account),
             service_account_id=f"projects/{args.project}/serviceAccounts/{account.service_account}",
             service_account_member=_service_account_member(account.service_account),
-            github_principal=_github_principal(args.project_number, args.workload_identity_pool, account.github_subject),
+            github_principals=_github_principals(
+                args.project_number, args.workload_identity_pool, account.github_subjects
+            ),
             state_bucket=args.state_bucket,
             crypto_key_id=crypto_key_id,
             mint_id_tokens=account.mint_id_tokens,
@@ -169,21 +177,27 @@ def _create_base_permissions(
     opts: pulumi.ResourceOptions,
 ) -> None:
     for permission_set in permission_sets:
-        gcp.serviceaccount.IAMMember(
-            f"{permission_set.account_id}-github-main",
-            service_account_id=permission_set.service_account_id,
-            role=WORKLOAD_IDENTITY_USER,
-            member=permission_set.github_principal,
-            opts=opts,
-        )
-        if permission_set.mint_id_tokens:
+        # Suffix only when an account has more than one subject: the unsuffixed "-github-main"
+        # name is the pre-existing resource name for the accounts already live in state, and
+        # renaming it would make Pulumi delete-then-recreate a protected resource.
+        multiple = len(permission_set.github_principals) > 1
+        for i, principal in enumerate(permission_set.github_principals):
+            suffix = f"-{i}" if multiple else ""
             gcp.serviceaccount.IAMMember(
-                f"{permission_set.account_id}-github-main-id-token",
+                f"{permission_set.account_id}-github-main{suffix}",
                 service_account_id=permission_set.service_account_id,
-                role=SERVICE_ACCOUNT_TOKEN_CREATOR,
-                member=permission_set.github_principal,
+                role=WORKLOAD_IDENTITY_USER,
+                member=principal,
                 opts=opts,
             )
+            if permission_set.mint_id_tokens:
+                gcp.serviceaccount.IAMMember(
+                    f"{permission_set.account_id}-github-main-id-token{suffix}",
+                    service_account_id=permission_set.service_account_id,
+                    role=SERVICE_ACCOUNT_TOKEN_CREATOR,
+                    member=principal,
+                    opts=opts,
+                )
         if permission_set.state_access is GcpStateAccess.APPLY:
             gcp.storage.BucketIAMMember(
                 f"{permission_set.account_id}-pulumi-state",

--- a/infra/pulumi/src/iac/gcp/permissions.py
+++ b/infra/pulumi/src/iac/gcp/permissions.py
@@ -26,6 +26,13 @@ SECRET_IAM_PERMISSIONS = (
     "secretmanager.secrets.setIamPolicy",
 )
 ARTIFACT_REGISTRY_WRITER = "roles/artifactregistry.writer"
+GCP_RESOURCE_PREVIEWER_ROLE_ID = "marinGcpResourcePreviewer"
+GCP_RESOURCE_PREVIEWER_PERMISSIONS = (
+    "artifactregistry.locations.get",
+    "artifactregistry.repositories.get",
+    "compute.addresses.get",
+    "compute.regions.get",
+)
 IAP_IAM_ROLE_ID = "marinIapIamManager"
 IAP_IAM_PERMISSIONS = (
     "iap.webServices.getIamPolicy",
@@ -47,12 +54,6 @@ class GcpStateAccess(StrEnum):
     PREVIEW = "preview"  # `pulumi preview` — read state, write only the per-stack lock prefix.
 
 
-_KMS_ROLES = {
-    GcpKmsAccess.ENCRYPT_DECRYPT: KMS_ENCRYPTER_DECRYPTER,
-    GcpKmsAccess.DECRYPT_ONLY: KMS_DECRYPTER,
-}
-
-
 @dataclass(frozen=True)
 class GcpArtifactRegistryGrant:
     location: str
@@ -60,7 +61,7 @@ class GcpArtifactRegistryGrant:
 
 
 @dataclass(frozen=True)
-class GcpDeployAccount:
+class GcpAutomationAccount:
     service_account: str
     # One GitHub OIDC subject per trigger this account must authenticate from (e.g. a
     # `pull_request` subject for preview plus a main-branch `ref:refs/heads/main` subject for
@@ -73,6 +74,7 @@ class GcpDeployAccount:
     secret_access_secrets: tuple[str, ...] = ()
     secret_iam_secrets: tuple[str, ...] = ()
     artifact_registry_grants: tuple[GcpArtifactRegistryGrant, ...] = ()
+    gcp_resource_previewer: bool = False
     iap_iam_manager: bool = False
     # True for accounts this stack owns end-to-end (net-new, deploy-only identities). False
     # (default) for accounts that predate this stack and were created out-of-band — this
@@ -90,7 +92,7 @@ class GcpDeployPermissionsArgs:
     kms_location: str
     kms_key_ring: str
     kms_key: str
-    accounts: tuple[GcpDeployAccount, ...]
+    accounts: tuple[GcpAutomationAccount, ...]
 
 
 @dataclass(frozen=True)
@@ -149,6 +151,12 @@ def deploy_permission_sets(args: GcpDeployPermissionsArgs) -> tuple[GcpDeployPer
         )
         for account in args.accounts
     )
+
+
+def _kms_role(access: GcpKmsAccess) -> str:
+    if access is GcpKmsAccess.DECRYPT_ONLY:
+        return KMS_DECRYPTER
+    return KMS_ENCRYPTER_DECRYPTER
 
 
 def _create_service_accounts(
@@ -234,7 +242,7 @@ def _grant_kms_access(permission_set: GcpDeployPermissionSet, opts: pulumi.Resou
     gcp.kms.CryptoKeyIAMMember(
         f"{permission_set.account_id}-pulumi-kms",
         crypto_key_id=permission_set.crypto_key_id,
-        role=_KMS_ROLES[permission_set.kms_access],
+        role=_kms_role(permission_set.kms_access),
         member=permission_set.service_account_member,
         opts=opts,
     )
@@ -314,6 +322,30 @@ def _create_artifact_registry_permissions(args: GcpDeployPermissionsArgs, opts: 
                 )
 
 
+def _create_gcp_resource_preview_permissions(args: GcpDeployPermissionsArgs, opts: pulumi.ResourceOptions) -> None:
+    preview_accounts = tuple(account for account in args.accounts if account.gcp_resource_previewer)
+    if not preview_accounts:
+        return
+
+    preview_role = gcp.projects.IAMCustomRole(
+        "gcp-resource-previewer",
+        project=args.project,
+        role_id=GCP_RESOURCE_PREVIEWER_ROLE_ID,
+        title="Marin GCP Resource Previewer",
+        description="Read the GCP resources declared by the marin-iac preview stack.",
+        permissions=list(GCP_RESOURCE_PREVIEWER_PERMISSIONS),
+        opts=opts,
+    )
+    for account in preview_accounts:
+        gcp.projects.IAMMember(
+            f"{_account_id(args.project, account.service_account)}-gcp-resource-previewer",
+            project=args.project,
+            role=preview_role.name,
+            member=_service_account_member(account.service_account),
+            opts=opts,
+        )
+
+
 def _create_iap_permissions(args: GcpDeployPermissionsArgs, opts: pulumi.ResourceOptions) -> None:
     iap_iam_accounts = tuple(account for account in args.accounts if account.iap_iam_manager)
     if not iap_iam_accounts:
@@ -369,6 +401,7 @@ class GcpDeployPermissions(pulumi.ComponentResource):
         _create_base_permissions(deploy_permission_sets(args), grant_opts)
         _create_secret_permissions(args, grant_opts)
         _create_artifact_registry_permissions(args, grant_opts)
+        _create_gcp_resource_preview_permissions(args, grant_opts)
         _create_iap_permissions(args, grant_opts)
 
         self.register_outputs({})

--- a/infra/pulumi/src/iac/gcp/permissions.py
+++ b/infra/pulumi/src/iac/gcp/permissions.py
@@ -4,13 +4,18 @@
 """Additive GCP permissions for keyless GitHub service deployments."""
 
 from dataclasses import dataclass
+from enum import StrEnum
 
 import pulumi
 import pulumi_gcp as gcp
 
 WORKLOAD_IDENTITY_USER = "roles/iam.workloadIdentityUser"
 STATE_WRITER = "roles/storage.objectAdmin"
+STATE_READER = "roles/storage.objectViewer"
+STATE_LOCK_WRITER = "roles/storage.objectUser"
+STATE_LOCKS_PREFIX = ".pulumi/locks/"
 KMS_ENCRYPTER_DECRYPTER = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+KMS_DECRYPTER = "roles/cloudkms.cryptoKeyDecrypter"
 SERVICE_ACCOUNT_TOKEN_CREATOR = "roles/iam.serviceAccountTokenCreator"
 SECRET_METADATA_VIEWER = "roles/secretmanager.viewer"
 SECRET_ACCESSOR = "roles/secretmanager.secretAccessor"
@@ -28,6 +33,26 @@ IAP_IAM_PERMISSIONS = (
 )
 
 
+class GcpKmsAccess(StrEnum):
+    """How far a deploy account's KMS grant reaches on the shared state key."""
+
+    ENCRYPT_DECRYPT = "encrypt_decrypt"  # `pulumi up` — reads and writes stack secrets.
+    DECRYPT_ONLY = "decrypt_only"  # `pulumi preview` — reads stack secrets, never writes them.
+
+
+class GcpStateAccess(StrEnum):
+    """How far a deploy account's grant reaches on the shared state bucket."""
+
+    APPLY = "apply"  # `pulumi up` — full read/write on state objects.
+    PREVIEW = "preview"  # `pulumi preview` — read state, write only the per-stack lock prefix.
+
+
+_KMS_ROLES = {
+    GcpKmsAccess.ENCRYPT_DECRYPT: KMS_ENCRYPTER_DECRYPTER,
+    GcpKmsAccess.DECRYPT_ONLY: KMS_DECRYPTER,
+}
+
+
 @dataclass(frozen=True)
 class GcpArtifactRegistryGrant:
     location: str
@@ -37,12 +62,20 @@ class GcpArtifactRegistryGrant:
 @dataclass(frozen=True)
 class GcpDeployAccount:
     service_account: str
+    github_subject: str
     mint_id_tokens: bool = False
+    kms_access: GcpKmsAccess = GcpKmsAccess.ENCRYPT_DECRYPT
+    state_access: GcpStateAccess = GcpStateAccess.APPLY
     secret_metadata_viewer: bool = False
     secret_access_secrets: tuple[str, ...] = ()
     secret_iam_secrets: tuple[str, ...] = ()
     artifact_registry_grants: tuple[GcpArtifactRegistryGrant, ...] = ()
     iap_iam_manager: bool = False
+    # True for accounts this stack owns end-to-end (net-new, deploy-only identities). False
+    # (default) for accounts that predate this stack and were created out-of-band — this
+    # component only grants IAM on those, per the project README.
+    create_account: bool = False
+    display_name: str = ""
 
 
 @dataclass(frozen=True)
@@ -50,7 +83,6 @@ class GcpDeployPermissionsArgs:
     project: str
     project_number: str
     workload_identity_pool: str
-    github_subject: str
     state_bucket: str
     kms_location: str
     kms_key_ring: str
@@ -67,6 +99,8 @@ class GcpDeployPermissionSet:
     state_bucket: str
     crypto_key_id: str
     mint_id_tokens: bool
+    kms_access: GcpKmsAccess
+    state_access: GcpStateAccess
 
 
 def _account_id(project: str, email: str) -> str:
@@ -80,12 +114,15 @@ def _service_account_member(email: str) -> str:
     return f"serviceAccount:{email}"
 
 
+def _github_principal(project_number: str, workload_identity_pool: str, github_subject: str) -> str:
+    return (
+        f"principal://iam.googleapis.com/projects/{project_number}/locations/global/"
+        f"workloadIdentityPools/{workload_identity_pool}/subject/{github_subject}"
+    )
+
+
 def deploy_permission_sets(args: GcpDeployPermissionsArgs) -> tuple[GcpDeployPermissionSet, ...]:
     """Resolve stable IAM members and resource IDs for each deployment account."""
-    github_principal = (
-        f"principal://iam.googleapis.com/projects/{args.project_number}/locations/global/"
-        f"workloadIdentityPools/{args.workload_identity_pool}/subject/{args.github_subject}"
-    )
     crypto_key_id = (
         f"projects/{args.project}/locations/{args.kms_location}/keyRings/{args.kms_key_ring}/"
         f"cryptoKeys/{args.kms_key}"
@@ -95,13 +132,36 @@ def deploy_permission_sets(args: GcpDeployPermissionsArgs) -> tuple[GcpDeployPer
             account_id=_account_id(args.project, account.service_account),
             service_account_id=f"projects/{args.project}/serviceAccounts/{account.service_account}",
             service_account_member=_service_account_member(account.service_account),
-            github_principal=github_principal,
+            github_principal=_github_principal(args.project_number, args.workload_identity_pool, account.github_subject),
             state_bucket=args.state_bucket,
             crypto_key_id=crypto_key_id,
             mint_id_tokens=account.mint_id_tokens,
+            kms_access=account.kms_access,
+            state_access=account.state_access,
         )
         for account in args.accounts
     )
+
+
+def _create_service_accounts(
+    args: GcpDeployPermissionsArgs, opts: pulumi.ResourceOptions
+) -> tuple[gcp.serviceaccount.Account, ...]:
+    """Create the accounts this stack owns end-to-end (`create_account=True`)."""
+    created = []
+    for account in args.accounts:
+        if not account.create_account:
+            continue
+        account_id = _account_id(args.project, account.service_account)
+        created.append(
+            gcp.serviceaccount.Account(
+                f"{account_id}-account",
+                account_id=account_id,
+                project=args.project,
+                display_name=account.display_name or account_id,
+                opts=opts,
+            )
+        )
+    return tuple(created)
 
 
 def _create_base_permissions(
@@ -124,17 +184,41 @@ def _create_base_permissions(
                 member=permission_set.github_principal,
                 opts=opts,
             )
-        gcp.storage.BucketIAMMember(
-            f"{permission_set.account_id}-pulumi-state",
-            bucket=permission_set.state_bucket,
-            role=STATE_WRITER,
-            member=permission_set.service_account_member,
-            opts=opts,
-        )
+        if permission_set.state_access is GcpStateAccess.APPLY:
+            gcp.storage.BucketIAMMember(
+                f"{permission_set.account_id}-pulumi-state",
+                bucket=permission_set.state_bucket,
+                role=STATE_WRITER,
+                member=permission_set.service_account_member,
+                opts=opts,
+            )
+        else:
+            gcp.storage.BucketIAMMember(
+                f"{permission_set.account_id}-pulumi-state-read",
+                bucket=permission_set.state_bucket,
+                role=STATE_READER,
+                member=permission_set.service_account_member,
+                opts=opts,
+            )
+            gcp.storage.BucketIAMMember(
+                f"{permission_set.account_id}-pulumi-state-locks",
+                bucket=permission_set.state_bucket,
+                role=STATE_LOCK_WRITER,
+                member=permission_set.service_account_member,
+                condition=gcp.storage.BucketIAMMemberConditionArgs(
+                    title=f"{permission_set.account_id}-pulumi-locks",
+                    description="Create/delete stack lock objects only; no access to state content.",
+                    expression=(
+                        f'resource.name.startsWith("projects/_/buckets/{permission_set.state_bucket}'
+                        f'/objects/{STATE_LOCKS_PREFIX}")'
+                    ),
+                ),
+                opts=opts,
+            )
         gcp.kms.CryptoKeyIAMMember(
             f"{permission_set.account_id}-pulumi-kms",
             crypto_key_id=permission_set.crypto_key_id,
-            role=KMS_ENCRYPTER_DECRYPTER,
+            role=_KMS_ROLES[permission_set.kms_access],
             member=permission_set.service_account_member,
             opts=opts,
         )
@@ -229,10 +313,13 @@ def _create_iap_permissions(args: GcpDeployPermissionsArgs, opts: pulumi.Resourc
 
 
 class GcpDeployPermissions(pulumi.ComponentResource):
-    """Grant main-branch GitHub workflows access to deploy through existing accounts.
+    """Grant GitHub workflows access to deploy or preview through existing accounts.
 
-    The component owns custom roles and non-authoritative IAM members. The service accounts,
-    workload identity pool/provider, state bucket, and KMS key are existing shared resources.
+    Each account binds to its own GitHub OIDC subject (e.g. a main-branch push for `pulumi up`,
+    or a `pull_request` event for `pulumi preview`), scoped by `kms_access`/`state_access` to
+    what that trigger needs. The component owns custom roles and non-authoritative IAM members.
+    The service accounts, workload identity pool/provider, state bucket, and KMS key are
+    existing shared resources.
     """
 
     def __init__(
@@ -245,9 +332,16 @@ class GcpDeployPermissions(pulumi.ComponentResource):
     ) -> None:
         super().__init__("marin:gcp:GcpDeployPermissions", name, None, opts)
         child = pulumi.ResourceOptions(parent=self, provider=gcp_provider, protect=True)
-        _create_base_permissions(deploy_permission_sets(args), child)
-        _create_secret_permissions(args, child)
-        _create_artifact_registry_permissions(args, child)
-        _create_iap_permissions(args, child)
+        created_accounts = _create_service_accounts(args, child)
+        # Grants on a just-created account must wait for the Account resource itself
+        grant_opts = (
+            pulumi.ResourceOptions(parent=self, provider=gcp_provider, protect=True, depends_on=list(created_accounts))
+            if created_accounts
+            else child
+        )
+        _create_base_permissions(deploy_permission_sets(args), grant_opts)
+        _create_secret_permissions(args, grant_opts)
+        _create_artifact_registry_permissions(args, grant_opts)
+        _create_iap_permissions(args, grant_opts)
 
         self.register_outputs({})

--- a/infra/pulumi/src/iac/gcp/registries.py
+++ b/infra/pulumi/src/iac/gcp/registries.py
@@ -23,6 +23,8 @@ from iac.config import (
     GcpRemoteRepositorySpec,
 )
 
+DOCKER_HUB_URI = "https://registry-1.docker.io"
+
 
 @dataclass(frozen=True)
 class GcpArtifactRegistriesArgs:
@@ -38,20 +40,12 @@ def _import_id(project: str, location: str, repo_name: str) -> str:
     return f"projects/{project}/locations/{location}/repositories/{repo_name}"
 
 
-def _remote_config(spec: GcpRemoteRepositorySpec) -> gcp.artifactregistry.RepositoryRemoteRepositoryConfigArgs:
-    """Build the Docker upstream config: GCP's predefined Docker Hub, or a custom registry URI."""
-    if spec.docker_upstream == DOCKER_HUB_UPSTREAM:
-        docker = gcp.artifactregistry.RepositoryRemoteRepositoryConfigDockerRepositoryArgs(
-            public_repository="DOCKER_HUB"
-        )
-    else:
-        docker = gcp.artifactregistry.RepositoryRemoteRepositoryConfigDockerRepositoryArgs(
-            custom_repository=gcp.artifactregistry.RepositoryRemoteRepositoryConfigDockerRepositoryCustomRepositoryArgs(
-                uri=spec.docker_upstream
-            )
-        )
+def remote_repository_config(
+    spec: GcpRemoteRepositorySpec,
+) -> gcp.artifactregistry.RepositoryRemoteRepositoryConfigArgs:
+    upstream_uri = DOCKER_HUB_URI if spec.docker_upstream == DOCKER_HUB_UPSTREAM else spec.docker_upstream
     return gcp.artifactregistry.RepositoryRemoteRepositoryConfigArgs(
-        description=spec.description or None, docker_repository=docker
+        common_repository=gcp.artifactregistry.RepositoryRemoteRepositoryConfigCommonRepositoryArgs(uri=upstream_uri)
     )
 
 
@@ -92,7 +86,7 @@ class GcpArtifactRegistries(pulumi.ComponentResource):
                     format="DOCKER",
                     mode="REMOTE_REPOSITORY",
                     description=spec.description or None,
-                    remote_repository_config=_remote_config(spec),
+                    remote_repository_config=remote_repository_config(spec),
                     cleanup_policies=[_cleanup_policy(p) for p in spec.cleanup_policies],
                     # Enforce the policies (actually delete), not just report a dry-run plan.
                     cleanup_policy_dry_run=False,

--- a/infra/pulumi/tests/test_permissions.py
+++ b/infra/pulumi/tests/test_permissions.py
@@ -22,7 +22,7 @@ def _permissions_args() -> GcpDeployPermissionsArgs:
         kms_location="us-central1",
         kms_key_ring="marin-iac-keyring",
         kms_key="marin-iac-key",
-        accounts=(GcpDeployAccount(service_account=DEPLOY_ACCOUNT, github_subject=GITHUB_SUBJECT),),
+        accounts=(GcpDeployAccount(service_account=DEPLOY_ACCOUNT, github_subjects=(GITHUB_SUBJECT,)),),
     )
 
 
@@ -32,7 +32,7 @@ def test_deploy_permission_sets_rejects_service_account_from_another_project():
         accounts=(
             GcpDeployAccount(
                 service_account="deploy@another-project.iam.gserviceaccount.com",
-                github_subject=GITHUB_SUBJECT,
+                github_subjects=(GITHUB_SUBJECT,),
             ),
         ),
     )

--- a/infra/pulumi/tests/test_permissions.py
+++ b/infra/pulumi/tests/test_permissions.py
@@ -10,24 +10,31 @@ PROJECT = "hai-gcp-models"
 DEPLOY_ACCOUNT = "iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com"
 
 
+GITHUB_SUBJECT = "repo:marin-community/marin:ref:refs/heads/main"
+
+
 def _permissions_args() -> GcpDeployPermissionsArgs:
     return GcpDeployPermissionsArgs(
         project=PROJECT,
         project_number="748532799086",
         workload_identity_pool="github-pool",
-        github_subject="repo:marin-community/marin:ref:refs/heads/main",
         state_bucket="marin-iac-state",
         kms_location="us-central1",
         kms_key_ring="marin-iac-keyring",
         kms_key="marin-iac-key",
-        accounts=(GcpDeployAccount(service_account=DEPLOY_ACCOUNT),),
+        accounts=(GcpDeployAccount(service_account=DEPLOY_ACCOUNT, github_subject=GITHUB_SUBJECT),),
     )
 
 
 def test_deploy_permission_sets_rejects_service_account_from_another_project():
     args = replace(
         _permissions_args(),
-        accounts=(GcpDeployAccount(service_account="deploy@another-project.iam.gserviceaccount.com"),),
+        accounts=(
+            GcpDeployAccount(
+                service_account="deploy@another-project.iam.gserviceaccount.com",
+                github_subject=GITHUB_SUBJECT,
+            ),
+        ),
     )
 
     with pytest.raises(ValueError):

--- a/infra/pulumi/tests/test_permissions.py
+++ b/infra/pulumi/tests/test_permissions.py
@@ -4,7 +4,7 @@
 from dataclasses import replace
 
 import pytest
-from iac.gcp.permissions import GcpDeployAccount, GcpDeployPermissionsArgs, deploy_permission_sets
+from iac.gcp.permissions import GcpAutomationAccount, GcpDeployPermissionsArgs, deploy_permission_sets
 
 PROJECT = "hai-gcp-models"
 DEPLOY_ACCOUNT = "iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com"
@@ -22,7 +22,7 @@ def _permissions_args() -> GcpDeployPermissionsArgs:
         kms_location="us-central1",
         kms_key_ring="marin-iac-keyring",
         kms_key="marin-iac-key",
-        accounts=(GcpDeployAccount(service_account=DEPLOY_ACCOUNT, github_subjects=(GITHUB_SUBJECT,)),),
+        accounts=(GcpAutomationAccount(service_account=DEPLOY_ACCOUNT, github_subjects=(GITHUB_SUBJECT,)),),
     )
 
 
@@ -30,7 +30,7 @@ def test_deploy_permission_sets_rejects_service_account_from_another_project():
     args = replace(
         _permissions_args(),
         accounts=(
-            GcpDeployAccount(
+            GcpAutomationAccount(
                 service_account="deploy@another-project.iam.gserviceaccount.com",
                 github_subjects=(GITHUB_SUBJECT,),
             ),

--- a/infra/pulumi/tests/test_registries.py
+++ b/infra/pulumi/tests/test_registries.py
@@ -1,0 +1,23 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from iac.config import DOCKER_HUB_UPSTREAM, GcpRemoteRepositorySpec
+from iac.gcp.registries import remote_repository_config
+
+
+@pytest.mark.parametrize(
+    ("upstream", "expected_uri"),
+    [
+        ("https://ghcr.io", "https://ghcr.io"),
+        (DOCKER_HUB_UPSTREAM, "https://registry-1.docker.io"),
+    ],
+)
+def test_remote_repository_config_uses_canonical_common_repository(upstream: str, expected_uri: str) -> None:
+    spec = GcpRemoteRepositorySpec(name="mirror", docker_upstream=upstream, locations=["us"])
+
+    config = remote_repository_config(spec)
+
+    assert config.common_repository is not None
+    assert config.common_repository.uri == expected_uri
+    assert config.docker_repository is None

--- a/lib/iris/config/marin.yaml
+++ b/lib/iris/config/marin.yaml
@@ -39,14 +39,13 @@ provisioning:
       - name: docker-mirror
         docker_upstream: DOCKER_HUB
         locations: [us, europe]
-        description: "Pull-through cache for Docker Hub (harbor sandbox base images)"
         # Base-image packages hold a handful of mutable tags, so the default keep-16 floor
-        # would protect every version indefinitely. Plain 7-day TTL instead: an evicted image
-        # is re-cached on its next pull, and a mutable tag is never more than a week stale.
+        # would protect every version indefinitely. Match the live repositories' plain
+        # 30-day TTL; an evicted image is re-cached on its next pull.
         cleanup_policies:
-          - id: delete-older-than-7d
+          - id: delete-old
             action: DELETE
-            older_than: 604800s
+            older_than: 2592000s
 
 platform:
   label_prefix: marin


### PR DESCRIPTION
Run `pulumi preview` for every `infra/pulumi` stack when a pull request changes the Pulumi program or Iris cluster configuration, and post each plan to the pull request. Manual dispatch from `main` runs the same checks without posting a comment. CI never runs `pulumi up`.

Authenticate same-repository pull requests with a dedicated `pulumi-ci` workload identity. It can decrypt stack secrets, read state, write only the lock prefix, read the Cloudflare DNS token needed by CoreWeave previews, and inspect only the Artifact Registry repositories and static addresses declared by the GCP stack. It cannot write Pulumi state or encrypt stack secrets. The identity and grants are applied in `hai-gcp-models`.

The six live GCP resources predate the empty `marin` stack, so its preview uses import mode until the first adoption. Artifact Registry upstreams use the canonical `commonRepository` schema, avoiding replacements during import. The Docker mirrors retain their live 30-day cleanup policy. The verified adoption plan imports four repositories and two addresses, updates two descriptions and one cleanup-policy identifier in place, and has no replacements or deletes.
