### PR TITLE
[infra] Stabilize CoreWeave control planes

### DIFF
--- a/.agents/ops/2026-07-22-coreweave-kueue-leader-loss.md
+++ b/.agents/ops/2026-07-22-coreweave-kueue-leader-loss.md
@@ -60,7 +60,7 @@ clientConnection:
 
 `infra/pulumi/src/iac/config.py` exposes the pair as a typed provisioning block with the same shared defaults, while retaining per-cluster overrides. Pulumi applied only the `cw-rno2a` Kueue Helm release during recovery; other clusters will receive the defaults through their normal Pulumi updates.
 
-`infra/pulumi/src/iac/coreweave/dns.py` also declares each existing DNS-only Cloudflare record with deletion protection. Every CoreWeave config carries its zone, hostname, and allocated LoadBalancer target. Operators load `cloudflare-oa-dns-token` into `CLOUDFLARE_API_TOKEN` for previews and updates.
+`infra/pulumi/src/iac/coreweave/dns.py` also declares each existing DNS-only Cloudflare record with deletion protection. The typed schema owns the shared `oa.dev` zone ID, while every CoreWeave config carries its hostname and allocated LoadBalancer target. Operators load `cloudflare-oa-dns-token` into `CLOUDFLARE_API_TOKEN` for previews and updates.
 
 ## How OPS.md could have shortened this
 

--- a/.agents/ops/2026-07-22-coreweave-kueue-leader-loss.md
+++ b/.agents/ops/2026-07-22-coreweave-kueue-leader-loss.md
@@ -1,0 +1,76 @@
+---
+date: 2026-07-22
+system: coreweave
+severity: outage
+resolution: fixed
+pr: none
+issue: none
+---
+
+## TL;DR
+
+- `cw-rno2a` lost the `kueue-webhook-service` endpoint while `kueue-controller-manager` entered `CrashLoopBackOff`.
+- The observed restarts were not OOM kills. They exited with code 1 after the Kubernetes API client rate limiter delayed event writes past Kueue's 10-second leader-election renewal deadline.
+- The failure appeared during a resync with approximately 4,843 Pods and 3,080 Kueue Workloads. Kueue was using its 20-QPS, 30-request burst defaults.
+- `provisioning.coreweave.kueue.client_connection` now sets 100 QPS and a 200-request burst for `cw-rno2a`. A targeted Pulumi update rolled the controller; the replacement Pod became ready with zero restarts and restored the webhook endpoint.
+- The full preview also found an existing Cloudflare federation CNAME orphaned from the Pulumi program. The CNAME is declared and protected again, and an untargeted preview reports 29 unchanged resources.
+
+## Original problem report
+
+Grafana fired `WebhookEndpointsEmpty cw-rno2a` for `kueue-system/kueue-webhook-service`, followed by `ControlPlaneCrashLooping cw-rno2a`. A previous Kueue failure had been caused by an OOM, so the operator asked whether memory pressure had returned and requested a Pulumi correction plus reload.
+
+## Investigation path
+
+1. The live Deployment requested and limited Kueue to 2 GiB. Its only Pod, `kueue-controller-manager-78558f65f7-q92qg`, was unready with 21 restarts, and the webhook Endpoint contained only a not-ready address.
+
+2. Kubernetes recorded the latest termination as `Reason: Error`, `Exit Code: 1`, not `OOMKilled`. The Pod ran on a healthy node with approximately 1.5 TiB of allocatable memory. The cluster did not expose the Metrics API, so no historical working-set measurement was available.
+
+3. Previous-container logs ended with `client rate limiter Wait returned an error: context deadline exceeded`, `Failed to renew lease`, and `Could not run manager` with `error: leader election lost`. A second restart at 22:54 UTC ended the same way.
+
+4. The manager ConfigMap had no `clientConnection` block, leaving Kueue v0.18.0 at its 20-QPS and 30-request burst defaults. The cluster held approximately 4,843 Pods and 3,080 Kueue Workloads. Restart resyncs produced event POST delays above 11 seconds, longer than the 10-second leader renewal deadline.
+
+5. `lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py:138` gained an optional `clientConnection` renderer. `lib/iris/config/cw-rno2a.yaml:41` set 100 QPS and a 200-request burst while retaining the existing 2 GiB memory limit.
+
+6. An untargeted Pulumi preview proposed deleting `iris-cw-rno2a.oa.dev`, an unrelated Cloudflare CNAME still present in stack state. The Kueue recovery used a target restricted to the Helm release; no DNS or NodePool resource changed.
+
+7. The targeted update completed in 43 seconds. Deployment revision 6 created `kueue-controller-manager-77cbc9bcd7-d5hcb`, and `kueue-webhook-service` published its ready endpoint at `10.0.1.139`.
+
+8. `infra/pulumi/src/iac/coreweave/dns.py` restored the exact Cloudflare component, provider, and record URNs already in state. The live CNAME still resolved to `iris-cw-rno2a.208261-marin-rn02a.coreweave.app`, and the final untargeted preview reported all 29 resources unchanged.
+
+## User course corrections
+
+- After the targeted Kueue rollout succeeded, the operator asked for the orphaned Cloudflare CNAME to be fixed before finishing. This converted a one-off targeted-update workaround into a clean, non-destructive full-stack preview.
+
+## Root cause
+
+Kueue's controller, event recorder, and leader-election operations shared the configured Kubernetes client rate limiter. At 20 QPS with a burst of 30, the `cw-rno2a` restart resync queued enough event writes to delay lease renewal beyond 10 seconds. Kueue exited on `leader election lost`, Kubernetes restarted it, and the fail-closed admission webhook temporarily had no ready endpoint.
+
+The prior 2 GiB memory correction remained active. The sampled failures had explicit exit-code-1 leader-election logs and no `OOMKilled` termination reason. Kubernetes retains only the most recent terminated-container status, so terminations older than the two captured log samples were not independently classified.
+
+## Fix
+
+`lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py` now renders explicit client rate limits when both values are configured:
+
+```yaml
+clientConnection:
+  qps: 100
+  burst: 200
+```
+
+`infra/pulumi/src/iac/config.py` exposes the pair as a typed provisioning block, and `lib/iris/config/cw-rno2a.yaml` supplies the large-cluster override. Pulumi applied only the Kueue Helm release during recovery.
+
+`infra/pulumi/src/iac/coreweave/dns.py` also declares the existing DNS-only Cloudflare record with deletion protection. The CoreWeave config carries its zone, hostname, and allocated LoadBalancer target. Operators load `cloudflare-oa-dns-token` into `CLOUDFLARE_API_TOKEN` for previews and updates.
+
+## How OPS.md could have shortened this
+
+- Add a CoreWeave control-plane subsection under `lib/iris/OPS.md` "Troubleshooting" with these first checks: `kubectl describe pod`, `.status.containerStatuses[*].lastState`, and `kubectl logs --previous`. The termination reason distinguishes an OOM from a controller exit before resource changes are considered.
+- Add `client rate limiter` plus `leader election lost` as a generic controller-runtime diagnostic. The runbook should direct the operator to compare API request delay with `leaderElection.renewDeadline`, count watched objects, and inspect the component's `clientConnection.qps` and `burst` configuration.
+- Extend the Pulumi warning to reject any unexpected deletion, not only NodePool replacement or deletion. A targeted update is appropriate only after its preview names the exact recovery resource; the program and state drift still need reconciliation afterward.
+
+## Artifacts
+
+- `.agents/ops/2026-07-22-coreweave-kueue-leader-loss.md`
+- `lib/iris/config/cw-rno2a.yaml`
+- `lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py`
+- `infra/pulumi/src/iac/coreweave/dns.py`
+- Grafana alert: https://grafana.oa.dev/alerting/grafana/k8s-control-plane-crashloop/view?orgId=1

--- a/.agents/ops/2026-07-22-coreweave-kueue-leader-loss.md
+++ b/.agents/ops/2026-07-22-coreweave-kueue-leader-loss.md
@@ -3,7 +3,7 @@ date: 2026-07-22
 system: coreweave
 severity: outage
 resolution: fixed
-pr: none
+pr: https://github.com/marin-community/marin/pull/7533
 issue: none
 ---
 
@@ -12,8 +12,8 @@ issue: none
 - `cw-rno2a` lost the `kueue-webhook-service` endpoint while `kueue-controller-manager` entered `CrashLoopBackOff`.
 - The observed restarts were not OOM kills. They exited with code 1 after the Kubernetes API client rate limiter delayed event writes past Kueue's 10-second leader-election renewal deadline.
 - The failure appeared during a resync with approximately 4,843 Pods and 3,080 Kueue Workloads. Kueue was using its 20-QPS, 30-request burst defaults.
-- `provisioning.coreweave.kueue.client_connection` now sets 100 QPS and a 200-request burst for `cw-rno2a`. A targeted Pulumi update rolled the controller; the replacement Pod became ready with zero restarts and restored the webhook endpoint.
-- The full preview also found an existing Cloudflare federation CNAME orphaned from the Pulumi program. The CNAME is declared and protected again, and an untargeted preview reports 29 unchanged resources.
+- Iris now renders 100 QPS and a 200-request burst by default for every Kueue installation. A targeted Pulumi update applied those values to `cw-rno2a`; the replacement Pod became ready with zero restarts and restored the webhook endpoint.
+- Full previews also found the existing Cloudflare federation CNAME in every CoreWeave stack orphaned from the Pulumi program. All four records are declared and protected again.
 
 ## Original problem report
 
@@ -29,17 +29,18 @@ Grafana fired `WebhookEndpointsEmpty cw-rno2a` for `kueue-system/kueue-webhook-s
 
 4. The manager ConfigMap had no `clientConnection` block, leaving Kueue v0.18.0 at its 20-QPS and 30-request burst defaults. The cluster held approximately 4,843 Pods and 3,080 Kueue Workloads. Restart resyncs produced event POST delays above 11 seconds, longer than the 10-second leader renewal deadline.
 
-5. `lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py:138` gained an optional `clientConnection` renderer. `lib/iris/config/cw-rno2a.yaml:41` set 100 QPS and a 200-request burst while retaining the existing 2 GiB memory limit.
+5. `lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py` gained a `clientConnection` renderer. The first recovery applied 100 QPS and a 200-request burst through `cw-rno2a`'s provisioning config while retaining the existing 2 GiB memory limit.
 
-6. An untargeted Pulumi preview proposed deleting `iris-cw-rno2a.oa.dev`, an unrelated Cloudflare CNAME still present in stack state. The Kueue recovery used a target restricted to the Helm release; no DNS or NodePool resource changed.
+6. An untargeted Pulumi preview proposed deleting `iris-cw-rno2a.oa.dev`, an unrelated Cloudflare CNAME still present in stack state. The Kueue recovery used a target restricted to the Helm release; no DNS or NodePool resource changed. Later previews found the same drift in the other three CoreWeave stacks.
 
 7. The targeted update completed in 43 seconds. Deployment revision 6 created `kueue-controller-manager-77cbc9bcd7-d5hcb`, and `kueue-webhook-service` published its ready endpoint at `10.0.1.139`.
 
-8. `infra/pulumi/src/iac/coreweave/dns.py` restored the exact Cloudflare component, provider, and record URNs already in state. The live CNAME still resolved to `iris-cw-rno2a.208261-marin-rn02a.coreweave.app`, and the final untargeted preview reported all 29 resources unchanged.
+8. `infra/pulumi/src/iac/coreweave/dns.py` restored the exact Cloudflare component, provider, and record URNs already in state. Each cluster config now declares the hostname and live target already recorded in its Pulumi state.
 
 ## User course corrections
 
-- After the targeted Kueue rollout succeeded, the operator asked for the orphaned Cloudflare CNAME to be fixed before finishing. This converted a one-off targeted-update workaround into a clean, non-destructive full-stack preview.
+- After the targeted Kueue rollout succeeded, the operator asked for the orphaned Cloudflare CNAME to be fixed before finishing. Full-stack previews showed that the same correction was required for all four existing CoreWeave records.
+- Because Iris control-plane load is similar across clusters, the operator asked to make 100 QPS and a 200-request burst the shared default rather than a `cw-rno2a` override.
 
 ## Root cause
 
@@ -49,7 +50,7 @@ The prior 2 GiB memory correction remained active. The sampled failures had expl
 
 ## Fix
 
-`lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py` now renders explicit client rate limits when both values are configured:
+`lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py` now renders these client rate limits by default for both CKS and upstream Kueue charts:
 
 ```yaml
 clientConnection:
@@ -57,9 +58,9 @@ clientConnection:
   burst: 200
 ```
 
-`infra/pulumi/src/iac/config.py` exposes the pair as a typed provisioning block, and `lib/iris/config/cw-rno2a.yaml` supplies the large-cluster override. Pulumi applied only the Kueue Helm release during recovery.
+`infra/pulumi/src/iac/config.py` exposes the pair as a typed provisioning block with the same shared defaults, while retaining per-cluster overrides. Pulumi applied only the `cw-rno2a` Kueue Helm release during recovery; other clusters will receive the defaults through their normal Pulumi updates.
 
-`infra/pulumi/src/iac/coreweave/dns.py` also declares the existing DNS-only Cloudflare record with deletion protection. The CoreWeave config carries its zone, hostname, and allocated LoadBalancer target. Operators load `cloudflare-oa-dns-token` into `CLOUDFLARE_API_TOKEN` for previews and updates.
+`infra/pulumi/src/iac/coreweave/dns.py` also declares each existing DNS-only Cloudflare record with deletion protection. Every CoreWeave config carries its zone, hostname, and allocated LoadBalancer target. Operators load `cloudflare-oa-dns-token` into `CLOUDFLARE_API_TOKEN` for previews and updates.
 
 ## How OPS.md could have shortened this
 
@@ -70,7 +71,6 @@ clientConnection:
 ## Artifacts
 
 - `.agents/ops/2026-07-22-coreweave-kueue-leader-loss.md`
-- `lib/iris/config/cw-rno2a.yaml`
 - `lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py`
 - `infra/pulumi/src/iac/coreweave/dns.py`
 - Grafana alert: https://grafana.oa.dev/alerting/grafana/k8s-control-plane-crashloop/view?orgId=1

--- a/.agents/ops/2026-07-22-iris-proxy-health-stalls.md
+++ b/.agents/ops/2026-07-22-iris-proxy-health-stalls.md
@@ -1,0 +1,87 @@
+---
+date: 2026-07-22
+system: iris
+severity: degraded
+resolution: mitigated
+pr: none
+issue: none
+---
+
+## TL;DR
+
+- `cw-us-east-02a` emitted repeated readiness and liveness probe timeouts for its live, ready Iris controller Pod. The Pod was not stale and never restarted.
+- The controller was proxying approximately 180 long-lived inference streams while its control loop repeatedly listed and decoded more than 1,500 Pods. The proxy event loop intermittently stopped answering `/health` for more than 10 seconds.
+- The controller image included `uvloop`, but Iris's custom RPC-executor launcher constructed an asyncio selector loop directly and bypassed Uvicorn's `loop=auto` factory.
+- The launcher now preserves Uvicorn's loop factory while retaining the 64-thread RPC executor. A local 1,600-stream benchmark improved median completion throughput from 74.1 to 96.9 streams per second and reduced median per-trial health p99 from 8.85 to 2.19 seconds, with no stream or probe errors.
+- The Kubernetes probe remains at its existing 10-second timeout. Increasing it would hide genuine controller unresponsiveness; separating the proxy data plane remains the scaling path beyond this event-loop correction.
+
+## Original problem report
+
+Grafana showed this warning for `cw-us-east-02a`:
+
+```text
+Readiness probe failed: Get "http://10.0.5.136:10000/health": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+iris
+Pod/iris-controller-555c688864-fz6mm
+Unhealthy
+```
+
+The operator asked whether the event was a false alarm or stale Pod, what caused it, how to adjust the probe, and how Iris could support as many as 1,600 concurrent proxied connections.
+
+## Investigation path
+
+1. `iris-controller-555c688864-fz6mm` was the current Deployment Pod and EndpointSlice target at `10.0.5.136`. It had been running since July 21 with zero restarts. Readiness and liveness failure event counts continued increasing during the investigation, while intermittent successes kept the Pod ready.
+
+2. A loopback request to `/health` from inside the controller container also timed out. This ruled out a stale Grafana row and isolated the failure from Traefik and external routing. Grafana's warning-events panel retains raw Kubernetes events, but these events described a real transient stall.
+
+3. The controller used approximately 3.1 GiB of its 64 GiB limit, the node reported no pressure, and sampled CPU throttling was absent. The event was not an OOM or CPU-quota failure.
+
+4. The controller held approximately 421 inbound connections on port 10000. Of these, 180 arrived from Traefik and matched 180 outbound connections to one inference endpoint. The same interval contained 668 proxied completion requests and 1,094 Kubernetes exec requests.
+
+5. The cluster held approximately 1,541 Pods and 537 Kueue Workloads. Kubernetes Pod and Workload LIST decoding took roughly 2.8 to 3.0 seconds on average and reached 6.1 seconds. This control-loop work contended for the Python GIL with the proxy server.
+
+6. `py-spy` captured the controller-server thread in Starlette `StreamingResponse`, Uvicorn's `send`, and asyncio selector-transport writes. Logs emitted thousands of `asyncio socket.send() raised exception` messages per minute while clients disconnected under load.
+
+7. The running image contained `uvloop 0.22.1` and `httptools`, and Uvicorn was configured with `loop=auto`. `_install_rpc_executor`, however, called `asyncio.new_event_loop()` and therefore always created `_UnixSelectorEventLoop`.
+
+8. A regression test installed a marked Uvicorn loop factory and failed against the old launcher. Replacing the manual lifecycle with `asyncio.Runner(loop_factory=server.config.get_loop_factory())` selected the marked loop and retained the named `rpc-handler` executor.
+
+9. A local benchmark drove real HTTP requests through Uvicorn, Starlette, `EndpointProxy`, HTTPX, and a streaming Uvicorn upstream. It alternated selector-loop and auto-loop trials at 200, 800, and 1,600 concurrent streams and issued health requests on the same proxy event loop.
+
+10. At the 1,600-stream target, three production-parity trials completed with zero stream or health errors. The auto-selected uvloop improved median throughput by 30.8% and reduced median per-trial health p99 by 75.3%. Lower-load results were variable: the 200-stream run improved both measures, while a separate 800-stream run was flat on health and 13.4% slower on throughput.
+
+## User course corrections
+
+- The operator expanded the initial warning-event check into controller-load analysis, then asked about Python threading, subprocess proxying, and the knobs needed for 1,600 streams.
+- After the event-loop defect was identified, the operator requested the best safe performance from the current single-process configuration, a reproducible local benchmark, a PR with measured results, and authorization to roll `cw-rno2a` after local validation.
+
+## Root cause
+
+The probe timeouts were genuine transient event-loop stalls, not stale monitoring state. Long-lived proxy streams and disconnect handling shared one Python process with a control loop that performs expensive Kubernetes object decoding. Under that load, the selector event loop could not schedule `/health` within the 10-second probe timeout.
+
+Iris unintentionally disabled an optimization already present in its image. `_install_rpc_executor` replaced Uvicorn's server runner so synchronous Connect handlers used a 64-thread executor, but its manual `asyncio.new_event_loop()` also bypassed Uvicorn's configured loop factory. Uvicorn's `auto` setting therefore never selected the installed uvloop implementation.
+
+Threads are appropriate for synchronous RPC handlers but do not move async HTTP forwarding or Python decoding off the GIL. Running multiple Uvicorn workers inside the existing controller would duplicate control loops and state ownership. A separate, horizontally scaled proxy Deployment is the correct future process boundary if one controller must sustain this load continuously.
+
+## Fix
+
+`_install_rpc_executor` now creates an `asyncio.Runner` with `server.config.get_loop_factory()`, sets the existing 64-thread default executor on that loop, and passes any pre-bound sockets through to `server.serve`. This restores Uvicorn's installed `uvloop` and `httptools` fast path without changing controller ownership or request semantics.
+
+`benchmark_controller.py proxy` provides the local comparison. Its default scenario runs three balanced trials at 200, 800, and 1,600 streams, uses an uncapped HTTPX load client like the production proxy, matches the controller's 120-second keepalive, records the actual loop class, and reports throughput plus health latency and errors.
+
+No probe timeout was increased. The 10-second timeout exposed a real data-plane/control-plane coupling problem, and the existing failure threshold prevented an unnecessary restart while the controller recovered between stalls.
+
+## How OPS.md could have shortened this
+
+- Distinguish the Grafana warning-events table from stateful alerts: verify the event's last timestamp and count, then inspect the owning Deployment, Pod UID, restart count, and EndpointSlice before treating a row as stale.
+- For controller health timeouts, test `/health` from inside the Pod before changing ingress or probe settings. A loopback timeout identifies application-loop starvation.
+- Record the controller's socket fan-out with `ss` or `/proc/<pid>/net/tcp`, correlate inbound ingress connections with outbound endpoint connections, and sample individual Python threads with `py-spy`.
+- Confirm the actual event-loop implementation, not only the Uvicorn configuration. A custom runner can bypass `loop=auto` even when `uvloop` is installed.
+
+## Artifacts
+
+- `.agents/ops/2026-07-22-iris-proxy-health-stalls.md`
+- `lib/iris/src/iris/cluster/controller/controller.py`
+- `lib/iris/tests/cluster/controller/test_controller_server.py`
+- `lib/iris/scripts/benchmark_controller.py`
+- Kubernetes Pod: `iris/iris-controller-555c688864-fz6mm`

--- a/infra/pulumi/README.md
+++ b/infra/pulumi/README.md
@@ -3,9 +3,10 @@
 Infrastructure-as-code for the static substrate of Marin clusters, per the design in
 [`.agents/projects/iac/`](../../.agents/projects/iac/). Pulumi (Python). **CoreWeave first.**
 
-This is the **minimal cut**: it provisions RBAC, reserved NodePools, Kueue objects, and the
-Traefik/cert-manager/federation-ingress stack for a CoreWeave cluster, and is the sole owner of
-all of it — Iris no longer provisions any of these itself (`verify_prerequisites()` in
+This is the **minimal cut**: it provisions RBAC, reserved NodePools, Kueue objects, the
+Traefik/cert-manager/federation-ingress stack, and configured Cloudflare CNAMEs for a CoreWeave
+cluster. It is the sole owner of these resources — Iris no longer provisions any of them
+(`verify_prerequisites()` in
 [`k8s/controller.py`](../../lib/iris/src/iris/cluster/platforms/k8s/controller.py) only checks
 presence and fails with a `pulumi up` remediation if something is missing). The CKS cluster
 object itself is not yet managed by Pulumi (see `coreweave/cluster.py` and "Future work" below).
@@ -33,8 +34,9 @@ Everything comes from the per-cluster Iris config (`lib/iris/config/<cluster>.ya
 - NodePools derive from `scale_groups` (`iac.nodepools.derive_nodepools`).
 - Namespace from `kubernetes_provider.namespace`; ClusterQueue name from
   `kubernetes_provider.kueue.cluster_queue`.
-- The residual cluster facts (CKS cluster name, ResourceFlavor, ACME issuers) from the
-  `provisioning:` section in that same file. Iris carries `provisioning:` as an opaque dict;
+- The residual cluster facts (CKS cluster name, ResourceFlavor, ACME issuers, and optional
+  federation CNAME) from the `provisioning:` section in that same file. Iris carries
+  `provisioning:` as an opaque dict;
   `iac.config` owns the typed schema. (The package is `infra/pulumi/src/iac/`, imported as
   `iac` — a `src/<pkg>` layout mirroring `lib/*/src/<pkg>`.)
 
@@ -65,6 +67,12 @@ Everything comes from the per-cluster Iris config (`lib/iris/config/<cluster>.ya
 - **GCP credentials**: `gcloud auth application-default login`. Decrypting stack secrets is
   authorized by your own GCP credentials against the shared KMS key — see "Backend" below for
   getting the IAM role granted.
+- **Cloudflare credential**: stacks with `provisioning.coreweave.federation_dns` read
+  `CLOUDFLARE_API_TOKEN`. Load the DNS-only token without copying it into stack config:
+  ```bash
+  export CLOUDFLARE_API_TOKEN="$(gcloud secrets versions access latest \
+    --secret=cloudflare-oa-dns-token --project=hai-gcp-models)"
+  ```
 - **Backend login**: `pulumi login gs://marin-iac-state`.
 - **Cluster access** (for the k8s dry-run): the CoreWeave kubeconfig at the path in the
   cluster's `platform.coreweave.kubeconfig_path` (typically `~/.kube/coreweave-iris`).
@@ -159,10 +167,6 @@ already provisioned:
   (`cw-rno2a`/`cw-us-east-08a` both read/write `marin-us-east-02a`'s bucket) — undecided whether
   Pulumi should provision a bucket per cluster or this reuse is the standing choice.
 - **finelog server Deployment**: a planned `FinelogServer` component, not yet built.
-- **DNS CNAME** (`iris-cw-<cluster>.oa.dev` → the Traefik LoadBalancer's CoreWeave-allocated
-  hostname): manual (Cloudflare) today. CoreWeave allocates the hostname asynchronously after
-  Traefik comes up, which needs a custom Dynamic Provider to express declaratively, and no
-  Cloudflare credential exists in this repo yet.
 - **Federation peers**: `lib/iris/config/marin.yaml`/`marin-dev.yaml`'s `peers:` entries are
   hand-edited per cluster; generate or CI-validate the peer set from the cluster configs so a
   cluster can't be reachable-but-unregistered or registered-but-missing.
@@ -173,4 +177,4 @@ already provisioned:
   `install_cw_network.py` directly for this.
 
 Everything else in the original design (RBAC, NodePools, Kueue, Traefik/cert-manager, the
-federation ingress, the GCP static IPs and Artifact Registry mirrors) is landed.
+federation ingress and DNS, the GCP static IPs, and Artifact Registry mirrors) is landed.

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -6,9 +6,9 @@
 Reads the target cluster from stack config (`marin-iac:cluster`), loads its Iris config +
 typed `provisioning:` section, and declares that cluster's resources. One stack per cluster;
 `pulumi up` provisions all of a stack's declared resources together. The provider decides
-which resources: CoreWeave declares the controller RBAC, reserved NodePools, Kueue objects, and
-the Traefik/cert-manager/federation-ingress stack; GCP declares the reserved federation-egress
-static IPs and the Artifact Registry pull-through mirrors. Components not yet implemented
+which resources: CoreWeave declares the controller RBAC, reserved NodePools, Kueue objects,
+the Traefik/cert-manager/federation-ingress stack, and configured Cloudflare CNAMEs; GCP declares
+the reserved federation-egress static IPs and the Artifact Registry pull-through mirrors. Components not yet implemented
 (object storage, the CKS cluster object itself; GCP IAM/GCLB+IAP/buckets) are tracked in
 README.md's "Future work".
 """

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -27,6 +27,7 @@ import pulumi_gcp as gcp
 import pulumi_kubernetes as k8s
 from iac.config import Provider, load_iris_config, load_provisioning
 from iac.coreweave.cluster import CoreweaveCluster, CoreweaveClusterArgs
+from iac.coreweave.dns import FederationDns, FederationDnsArgs
 from iac.coreweave.kueue import KueueAddon, KueueAddonArgs
 from iac.coreweave.rbac import IrisRbac, IrisRbacArgs
 from iac.coreweave.traefik import TraefikAddon, TraefikAddonArgs
@@ -149,6 +150,22 @@ def _build_coreweave(cluster: str, *, adopt: bool) -> None:
         ),
         k8s_provider=k8s_provider,
     )
+
+    federation_dns = coreweave_provisioning.federation_dns
+    if federation_dns is not None:
+        cloudflare_api_token = os.environ.get("CLOUDFLARE_API_TOKEN")
+        if not cloudflare_api_token:
+            raise ValueError(
+                "CLOUDFLARE_API_TOKEN is required when provisioning.coreweave.federation_dns is set; "
+                "load cloudflare-oa-dns-token from GCP Secret Manager"
+            )
+        FederationDns(
+            "dns",
+            FederationDnsArgs(
+                spec=federation_dns,
+                api_token=pulumi.Output.secret(cloudflare_api_token),
+            ),
+        )
 
 
 def _build_gcp(cluster: str, *, adopt: bool) -> None:

--- a/infra/pulumi/src/iac/config.py
+++ b/infra/pulumi/src/iac/config.py
@@ -19,6 +19,10 @@ from enum import StrEnum
 from typing import Annotated, Literal
 
 from iris.cluster.config import IrisClusterConfig, load_config
+from iris.cluster.platforms.k8s.kueue_manifests import (
+    DEFAULT_CLIENT_CONNECTION_BURST,
+    DEFAULT_CLIENT_CONNECTION_QPS,
+)
 from iris.cluster.platforms.k8s.network_manifests import DEFAULT_CLUSTER_ISSUER
 from pydantic import BaseModel, Field
 from rigging.config_discovery import resolve_cluster_config
@@ -47,8 +51,8 @@ class CksClusterSpec(BaseModel):
 class KueueClientConnectionSpec(BaseModel):
     """Kubernetes API client rate limit for the Kueue controller-manager."""
 
-    qps: float = Field(gt=0)
-    burst: int = Field(gt=0)
+    qps: float = Field(default=DEFAULT_CLIENT_CONNECTION_QPS, gt=0)
+    burst: int = Field(default=DEFAULT_CLIENT_CONNECTION_BURST, gt=0)
 
 
 class KueueProvisioningSpec(BaseModel):
@@ -66,9 +70,8 @@ class KueueProvisioningSpec(BaseModel):
     flavor_topology: str = "infiniband"
     # Override controllerManager.manager.resources' memory (requests == limits)
     manager_memory_limit: str | None = None
-    # Override Kueue's default client-side API rate limit. Large clusters can otherwise build
-    # enough reconciliation requests to starve the controller's shared leader-election client.
-    client_connection: KueueClientConnectionSpec | None = None
+    # Override Iris's shared Kueue client-side API rate limit.
+    client_connection: KueueClientConnectionSpec = Field(default_factory=KueueClientConnectionSpec)
 
 
 # Egress addresses of the marin-side controllers that federate into every CoreWeave cluster

--- a/infra/pulumi/src/iac/config.py
+++ b/infra/pulumi/src/iac/config.py
@@ -82,6 +82,7 @@ class KueueProvisioningSpec(BaseModel):
 # lib/iris/scripts/install_cw_network.py — keep the two in sync until that script's own copy is
 # deleted (see README.md's "Future work").
 MARIN_FEDERATION_EGRESS_SOURCES = ["34.27.183.11", "35.254.13.19"]
+CLOUDFLARE_OA_DEV_ZONE_ID = "169959d6aafcbfd77764b8efafa3a509"
 
 
 class IngressSpec(BaseModel):
@@ -103,7 +104,7 @@ class IngressSpec(BaseModel):
 class FederationDnsSpec(BaseModel):
     """Cloudflare CNAME for the CoreWeave federation ingress."""
 
-    zone_id: str
+    zone_id: str = CLOUDFLARE_OA_DEV_ZONE_ID
     hostname: str
     target: str
 

--- a/infra/pulumi/src/iac/config.py
+++ b/infra/pulumi/src/iac/config.py
@@ -44,14 +44,21 @@ class CksClusterSpec(BaseModel):
     zone: str
 
 
+class KueueClientConnectionSpec(BaseModel):
+    """Kubernetes API client rate limit for the Kueue controller-manager."""
+
+    qps: float = Field(gt=0)
+    burst: int = Field(gt=0)
+
+
 class KueueProvisioningSpec(BaseModel):
     """Cluster-scoped Kueue objects owned by IaC (KueueAddon).
 
     The ResourceFlavor name and the Topology set are canonical constants in
     iris.cluster.platforms.k8s.kueue_manifests (shared with install_kueue.py so IaC and the
     script render identically), not per-cluster knobs. cluster_queue derives from the Iris
-    config. The flavor→topology binding and the controller-manager memory override are the
-    two things that vary per cluster and live here.
+    config. The flavor→topology binding and controller-manager resource overrides are the
+    cluster-specific values that live here.
     """
 
     # Which topology the ResourceFlavor binds (spec.topologyName). NVL72 clusters bind
@@ -59,6 +66,9 @@ class KueueProvisioningSpec(BaseModel):
     flavor_topology: str = "infiniband"
     # Override controllerManager.manager.resources' memory (requests == limits)
     manager_memory_limit: str | None = None
+    # Override Kueue's default client-side API rate limit. Large clusters can otherwise build
+    # enough reconciliation requests to starve the controller's shared leader-election client.
+    client_connection: KueueClientConnectionSpec | None = None
 
 
 # Egress addresses of the marin-side controllers that federate into every CoreWeave cluster
@@ -87,6 +97,14 @@ class IngressSpec(BaseModel):
     federation_allow_sources: list[str] = Field(default_factory=lambda: list(MARIN_FEDERATION_EGRESS_SOURCES))
 
 
+class FederationDnsSpec(BaseModel):
+    """Cloudflare CNAME for the CoreWeave federation ingress."""
+
+    zone_id: str
+    hostname: str
+    target: str
+
+
 class RbacSpec(BaseModel):
     """Controller RBAC ceded from ensure_rbac(). namespace derives from the Iris config."""
 
@@ -97,6 +115,7 @@ class CoreweaveProvisioning(BaseModel):
     cluster: CksClusterSpec
     kueue: KueueProvisioningSpec
     ingress: IngressSpec
+    federation_dns: FederationDnsSpec | None = None
     rbac: RbacSpec = RbacSpec()
 
 

--- a/infra/pulumi/src/iac/coreweave/dns.py
+++ b/infra/pulumi/src/iac/coreweave/dns.py
@@ -1,0 +1,47 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cloudflare DNS for a CoreWeave federation ingress."""
+
+from dataclasses import dataclass
+
+import pulumi
+import pulumi_cloudflare as cloudflare
+
+from iac.config import FederationDnsSpec
+
+
+@dataclass(frozen=True)
+class FederationDnsArgs:
+    spec: FederationDnsSpec
+    api_token: pulumi.Input[str]
+
+
+class FederationDns(pulumi.ComponentResource):
+    """A protected, DNS-only CNAME for the CoreWeave controller ingress."""
+
+    def __init__(
+        self,
+        name: str,
+        args: FederationDnsArgs,
+        *,
+        opts: pulumi.ResourceOptions | None = None,
+    ) -> None:
+        super().__init__("marin:coreweave:FederationDns", name, None, opts)
+
+        provider = cloudflare.Provider(
+            "cloudflare",
+            api_token=args.api_token,
+            opts=pulumi.ResourceOptions(parent=self),
+        )
+        record = cloudflare.DnsRecord(
+            "federation-cname",
+            zone_id=args.spec.zone_id,
+            name=args.spec.hostname,
+            type="CNAME",
+            content=args.spec.target,
+            ttl=300,
+            proxied=False,
+            opts=pulumi.ResourceOptions(parent=self, provider=provider, protect=True),
+        )
+        self.register_outputs({"hostname": record.name})

--- a/infra/pulumi/src/iac/coreweave/kueue.py
+++ b/infra/pulumi/src/iac/coreweave/kueue.py
@@ -83,8 +83,8 @@ class KueueAddon(pulumi.ComponentResource):
         helm_values = build_cks_values(
             [args.namespace],
             manager_memory_limit=args.spec.manager_memory_limit,
-            client_connection_qps=None if client_connection is None else client_connection.qps,
-            client_connection_burst=None if client_connection is None else client_connection.burst,
+            client_connection_qps=client_connection.qps,
+            client_connection_burst=client_connection.burst,
         )
 
         # The cks-kueue Helm release. Webhooks scoped to args.namespace via the manager config.

--- a/infra/pulumi/src/iac/coreweave/kueue.py
+++ b/infra/pulumi/src/iac/coreweave/kueue.py
@@ -79,6 +79,14 @@ class KueueAddon(pulumi.ComponentResource):
                 import_=import_id if (args.adopt and import_id) else None,
             )
 
+        client_connection = args.spec.client_connection
+        helm_values = build_cks_values(
+            [args.namespace],
+            manager_memory_limit=args.spec.manager_memory_limit,
+            client_connection_qps=None if client_connection is None else client_connection.qps,
+            client_connection_burst=None if client_connection is None else client_connection.burst,
+        )
+
         # The cks-kueue Helm release. Webhooks scoped to args.namespace via the manager config.
         release = k8s.helm.v3.Release(
             "kueue",
@@ -88,7 +96,7 @@ class KueueAddon(pulumi.ComponentResource):
             namespace=OPERATOR_NS,
             create_namespace=True,
             repository_opts=k8s.helm.v3.RepositoryOptsArgs(repo=CW_REPO_URL),
-            values=build_cks_values([args.namespace], manager_memory_limit=args.spec.manager_memory_limit),
+            values=helm_values,
             # helm Release import id is "<namespace>/<release-name>".
             opts=child_opts(f"{OPERATOR_NS}/{RELEASE_DEFAULT}"),
         )

--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -47,7 +47,6 @@ provisioning:
       cluster_issuers: [letsencrypt-http01-staging, letsencrypt-http01-prod]
       active_cluster_issuer: letsencrypt-http01-prod
     federation_dns:
-      zone_id: 169959d6aafcbfd77764b8efafa3a509
       hostname: iris-cw-rno2a.oa.dev
       target: iris-cw-rno2a.208261-marin-rn02a.coreweave.app
     rbac: { service_account: iris-controller }

--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -41,11 +41,18 @@ provisioning:
     kueue:
       flavor_topology: infiniband  # H100 IB cluster: bind the flavor to the infiniband topology
       manager_memory_limit: 2Gi
+      # Kueue's 20-QPS/30-burst defaults starve its 10-second leader lease when this
+      # cluster's thousands of Pods and Workloads resync after a controller restart.
+      client_connection: { qps: 100, burst: 200 }
     ingress:
       ingress_class: traefik
       acme_email: ops@openathena.ai
       cluster_issuers: [letsencrypt-http01-staging, letsencrypt-http01-prod]
       active_cluster_issuer: letsencrypt-http01-prod
+    federation_dns:
+      zone_id: 169959d6aafcbfd77764b8efafa3a509
+      hostname: iris-cw-rno2a.oa.dev
+      target: iris-cw-rno2a.208261-marin-rn02a.coreweave.app
     rbac: { service_account: iris-controller }
 
 platform:

--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -41,9 +41,6 @@ provisioning:
     kueue:
       flavor_topology: infiniband  # H100 IB cluster: bind the flavor to the infiniband topology
       manager_memory_limit: 2Gi
-      # Kueue's 20-QPS/30-burst defaults starve its 10-second leader lease when this
-      # cluster's thousands of Pods and Workloads resync after a controller restart.
-      client_connection: { qps: 100, burst: 200 }
     ingress:
       ingress_class: traefik
       acme_email: ops@openathena.ai

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -50,6 +50,10 @@ provisioning:
       acme_email: ops@openathena.ai
       cluster_issuers: [letsencrypt-http01-staging, letsencrypt-http01-prod]
       active_cluster_issuer: letsencrypt-http01-prod
+    federation_dns:
+      zone_id: 169959d6aafcbfd77764b8efafa3a509
+      hostname: iris-cw-us-east-02a.oa.dev
+      target: iris-cw-us-east-02a.208261-marin-gpu.coreweave.app
     rbac: { service_account: iris-controller }
 
 platform:

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -51,7 +51,6 @@ provisioning:
       cluster_issuers: [letsencrypt-http01-staging, letsencrypt-http01-prod]
       active_cluster_issuer: letsencrypt-http01-prod
     federation_dns:
-      zone_id: 169959d6aafcbfd77764b8efafa3a509
       hostname: iris-cw-us-east-02a.oa.dev
       target: iris-cw-us-east-02a.208261-marin-gpu.coreweave.app
     rbac: { service_account: iris-controller }

--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -57,7 +57,6 @@ provisioning:
       cluster_issuers: [letsencrypt-http01-staging, letsencrypt-http01-prod]
       active_cluster_issuer: letsencrypt-http01-prod
     federation_dns:
-      zone_id: 169959d6aafcbfd77764b8efafa3a509
       hostname: iris-cw-us-east-08a.oa.dev
       target: iris-cw-us-east-08a.208261-marin-us-east-08a.coreweave.app
     rbac: { service_account: iris-controller }

--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -56,6 +56,10 @@ provisioning:
       acme_email: ops@oa.dev
       cluster_issuers: [letsencrypt-http01-staging, letsencrypt-http01-prod]
       active_cluster_issuer: letsencrypt-http01-prod
+    federation_dns:
+      zone_id: 169959d6aafcbfd77764b8efafa3a509
+      hostname: iris-cw-us-east-08a.oa.dev
+      target: iris-cw-us-east-08a.208261-marin-us-east-08a.coreweave.app
     rbac: { service_account: iris-controller }
 
 platform:

--- a/lib/iris/config/cw-us-west-04a.yaml
+++ b/lib/iris/config/cw-us-west-04a.yaml
@@ -25,6 +25,10 @@ provisioning:
       cluster_issuers: [letsencrypt-http01-staging, letsencrypt-http01-prod]
       # Flipped from the default staging issuer once the staging cert validated (2026-07-17).
       active_cluster_issuer: letsencrypt-http01-prod
+    federation_dns:
+      zone_id: 169959d6aafcbfd77764b8efafa3a509
+      hostname: iris-cw-us-west-04a.oa.dev
+      target: iris-cw-us-west-04a.208261-marin.coreweave.app
     rbac: { service_account: iris-controller }
 
 # Request auth. Identity is by network location: in-cluster peers (RFC1918 pods/nodes,

--- a/lib/iris/config/cw-us-west-04a.yaml
+++ b/lib/iris/config/cw-us-west-04a.yaml
@@ -26,7 +26,6 @@ provisioning:
       # Flipped from the default staging issuer once the staging cert validated (2026-07-17).
       active_cluster_issuer: letsencrypt-http01-prod
     federation_dns:
-      zone_id: 169959d6aafcbfd77764b8efafa3a509
       hostname: iris-cw-us-west-04a.oa.dev
       target: iris-cw-us-west-04a.208261-marin.coreweave.app
     rbac: { service_account: iris-controller }

--- a/lib/iris/scripts/benchmark_controller.py
+++ b/lib/iris/scripts/benchmark_controller.py
@@ -129,7 +129,7 @@ from iris.rpc.compression import IRIS_RPC_COMPRESSIONS
 from iris.rpc.controller_connect import ControllerServiceClientSync
 from iris.rpc.worker_connect import WorkerService, WorkerServiceASGIApplication
 from iris.version import client_revision_date
-from rigging.timing import Duration, Timestamp
+from rigging.timing import Duration, ExponentialBackoff, Timestamp
 from sqlalchemy import func, select, text, update
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -478,15 +478,15 @@ class ScenarioRunner:
                     "max": 0.0,
                 }
             else:
-                p50, p95, p99, _p999, mx = _percentiles_ms(all_latencies)
+                percentiles = _percentiles_ms(all_latencies)
                 results[load.name] = {
                     "n": n,
                     "errors": len(all_errors),
                     "actual_rps": n / elapsed,
-                    "p50": p50,
-                    "p95": p95,
-                    "p99": p99,
-                    "max": mx,
+                    "p50": percentiles.p50,
+                    "p95": percentiles.p95,
+                    "p99": percentiles.p99,
+                    "max": percentiles.maximum,
                 }
         return results
 
@@ -2063,15 +2063,24 @@ def benchmark_control_isolation(db: ControllerDB) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _percentiles_ms(latencies: list[float]) -> tuple[float, float, float, float, float]:
+@dataclasses.dataclass(frozen=True)
+class LatencyPercentiles:
+    p50: float
+    p95: float
+    p99: float
+    p999: float
+    maximum: float
+
+
+def _percentiles_ms(latencies: list[float]) -> LatencyPercentiles:
     latencies.sort()
     n = len(latencies)
-    return (
-        latencies[n // 2],
-        latencies[int(n * 0.95)],
-        latencies[int(n * 0.99)],
-        latencies[min(int(n * 0.999), n - 1)],
-        latencies[-1],
+    return LatencyPercentiles(
+        p50=latencies[n // 2],
+        p95=latencies[int(n * 0.95)],
+        p99=latencies[int(n * 0.99)],
+        p999=latencies[min(int(n * 0.999), n - 1)],
+        maximum=latencies[-1],
     )
 
 
@@ -2408,9 +2417,10 @@ class ProxyBenchmarkResult:
         return self.bytes_transferred / self.elapsed / 1024**2
 
     @property
-    def health_percentiles_ms(self) -> tuple[float, float, float, float, float]:
+    def health_percentiles_ms(self) -> LatencyPercentiles:
         if not self.health_latencies_ms:
-            return (float("nan"),) * 5
+            nan = float("nan")
+            return LatencyPercentiles(p50=nan, p95=nan, p99=nan, p999=nan, maximum=nan)
         return _percentiles_ms(list(self.health_latencies_ms))
 
 
@@ -2426,15 +2436,15 @@ class ProxyExerciseResult:
 _PROXY_ASYNCIO_LOOP = "asyncio"
 _PROXY_AUTO_LOOP = "auto"
 _PROXY_LOOPS = (_PROXY_ASYNCIO_LOOP, _PROXY_AUTO_LOOP)
+_PROXY_BENCHMARK_BACKLOG = 2048
+_PROXY_BENCHMARK_KEEPALIVE = 120
 
 
 def _wait_for_uvicorn(server: uvicorn.Server) -> None:
-    deadline = time.monotonic() + 10
-    while time.monotonic() < deadline:
-        if server.started:
-            return
-        time.sleep(0.01)
-    raise RuntimeError("benchmark server did not start within 10 seconds")
+    ExponentialBackoff(initial=0.01, maximum=0.1).wait_until(
+        lambda: server.started,
+        timeout=Duration.from_seconds(10),
+    )
 
 
 def _proxy_benchmark_upstream(*, chunks: int, chunk_bytes: int, chunk_interval: float) -> Starlette:
@@ -2550,8 +2560,8 @@ def _run_proxy_trial(
             http="httptools",
             log_level="error",
             log_config=None,
-            backlog=2048,
-            timeout_keep_alive=120,
+            backlog=_PROXY_BENCHMARK_BACKLOG,
+            timeout_keep_alive=_PROXY_BENCHMARK_KEEPALIVE,
         )
     )
     proxy = uvicorn.Server(
@@ -2563,8 +2573,8 @@ def _run_proxy_trial(
             http="httptools",
             log_level="error",
             log_config=None,
-            backlog=2048,
-            timeout_keep_alive=120,
+            backlog=_PROXY_BENCHMARK_BACKLOG,
+            timeout_keep_alive=_PROXY_BENCHMARK_KEEPALIVE,
         )
     )
     _install_rpc_executor(proxy, max_workers=_RPC_HANDLER_THREADS)
@@ -2630,12 +2640,13 @@ def proxy_cmd(
                     trial=trial,
                 )
                 results.append(result)
-                p50, _, p99, _, maximum = result.health_percentiles_ms
+                percentiles = result.health_percentiles_ms
                 print(
                     f"{connection_count:5d}  {loop:>7}  {result.loop_class:>10}  {trial:5d}  "
                     f"{result.elapsed:7.3f}s  {result.streams_per_second:9.1f}  "
-                    f"{result.mebibytes_per_second:8.1f}  {p50:9.1f}ms  {p99:7.1f}ms  "
-                    f"{maximum:7.1f}ms  {len(result.health_latencies_ms):6d}  {len(result.health_errors):4d}"
+                    f"{result.mebibytes_per_second:8.1f}  {percentiles.p50:9.1f}ms  {percentiles.p99:7.1f}ms  "
+                    f"{percentiles.maximum:7.1f}ms  {len(result.health_latencies_ms):6d}  "
+                    f"{len(result.health_errors):4d}"
                 )
                 for error in result.health_errors:
                     print(f"         health error: {error}")
@@ -2647,8 +2658,8 @@ def proxy_cmd(
         }
         baseline = statistics.median(r.streams_per_second for r in by_loop[_PROXY_ASYNCIO_LOOP])
         treatment = statistics.median(r.streams_per_second for r in by_loop[_PROXY_AUTO_LOOP])
-        baseline_p99 = statistics.median(r.health_percentiles_ms[2] for r in by_loop[_PROXY_ASYNCIO_LOOP])
-        treatment_p99 = statistics.median(r.health_percentiles_ms[2] for r in by_loop[_PROXY_AUTO_LOOP])
+        baseline_p99 = statistics.median(r.health_percentiles_ms.p99 for r in by_loop[_PROXY_ASYNCIO_LOOP])
+        treatment_p99 = statistics.median(r.health_percentiles_ms.p99 for r in by_loop[_PROXY_AUTO_LOOP])
         baseline_errors = sum(len(r.health_errors) for r in by_loop[_PROXY_ASYNCIO_LOOP])
         treatment_errors = sum(len(r.health_errors) for r in by_loop[_PROXY_AUTO_LOOP])
         print(

--- a/lib/iris/scripts/benchmark_controller.py
+++ b/lib/iris/scripts/benchmark_controller.py
@@ -77,6 +77,7 @@ from iris.cluster.controller.backend import (
 from iris.cluster.controller.backend_store import BackendWorkerStore, DbBackendWorkerStore
 from iris.cluster.controller.checkpoint import download_checkpoint_to_local
 from iris.cluster.controller.controller import (
+    _CONTROLLER_KEEPALIVE,
     _RPC_HANDLER_THREADS,
     Controller,
     ControllerConfig,
@@ -2444,7 +2445,8 @@ _PROXY_ASYNCIO_LOOP = "asyncio"
 _PROXY_AUTO_LOOP = "auto"
 _PROXY_LOOPS = (_PROXY_ASYNCIO_LOOP, _PROXY_AUTO_LOOP)
 _PROXY_BENCHMARK_BACKLOG = 2048
-_PROXY_BENCHMARK_KEEPALIVE = 120
+_PROXY_BENCHMARK_HEALTH_ROUTE = "/health"
+_PROXY_BENCHMARK_HOST = "127.0.0.1"
 
 
 def _wait_for_uvicorn(server: uvicorn.Server) -> None:
@@ -2485,7 +2487,7 @@ def _proxy_benchmark_app(upstream_address: str) -> Starlette:
 
     return Starlette(
         routes=[
-            Route("/health", health),
+            Route(_PROXY_BENCHMARK_HEALTH_ROUTE, health),
             Route(PROXY_ROUTE, proxy_route, methods=list(ALLOWED_METHODS)),
         ],
         lifespan=on_shutdown(proxy.close),
@@ -2504,7 +2506,7 @@ async def _exercise_proxy(base_url: str, *, connections: int) -> ProxyExerciseRe
         httpx.AsyncClient(limits=limits, timeout=timeout) as stream_client,
         httpx.AsyncClient(limits=httpx.Limits(max_connections=4), timeout=timeout) as health_client,
     ):
-        health_response = await health_client.get(f"{base_url}/health")
+        health_response = await health_client.get(f"{base_url}{_PROXY_BENCHMARK_HEALTH_ROUTE}")
         health_response.raise_for_status()
         loop_class = str(health_response.json()["loop"])
 
@@ -2521,7 +2523,7 @@ async def _exercise_proxy(base_url: str, *, connections: int) -> ProxyExerciseRe
             while not streams_done.is_set():
                 probe_started = time.perf_counter()
                 try:
-                    response = await health_client.get(f"{base_url}/health")
+                    response = await health_client.get(f"{base_url}{_PROXY_BENCHMARK_HEALTH_ROUTE}")
                     response.raise_for_status()
                     health_latencies.append((time.perf_counter() - probe_started) * 1000)
                 except httpx.HTTPError as exc:
@@ -2559,27 +2561,27 @@ def _run_proxy_trial(
     upstream = uvicorn.Server(
         uvicorn.Config(
             _proxy_benchmark_upstream(stream_spec),
-            host="127.0.0.1",
+            host=_PROXY_BENCHMARK_HOST,
             port=upstream_port,
             loop="uvloop",
             http="httptools",
             log_level="error",
             log_config=None,
             backlog=_PROXY_BENCHMARK_BACKLOG,
-            timeout_keep_alive=_PROXY_BENCHMARK_KEEPALIVE,
+            timeout_keep_alive=_CONTROLLER_KEEPALIVE,
         )
     )
     proxy = uvicorn.Server(
         uvicorn.Config(
-            _proxy_benchmark_app(f"127.0.0.1:{upstream_port}"),
-            host="127.0.0.1",
+            _proxy_benchmark_app(f"{_PROXY_BENCHMARK_HOST}:{upstream_port}"),
+            host=_PROXY_BENCHMARK_HOST,
             port=proxy_port,
             loop=loop,
             http="httptools",
             log_level="error",
             log_config=None,
             backlog=_PROXY_BENCHMARK_BACKLOG,
-            timeout_keep_alive=_PROXY_BENCHMARK_KEEPALIVE,
+            timeout_keep_alive=_CONTROLLER_KEEPALIVE,
         )
     )
     _install_rpc_executor(proxy, max_workers=_RPC_HANDLER_THREADS)
@@ -2588,7 +2590,7 @@ def _run_proxy_trial(
         _wait_for_uvicorn(upstream)
         threads.spawn_server(proxy, name="proxy-benchmark-proxy")
         _wait_for_uvicorn(proxy)
-        exercise = asyncio.run(_exercise_proxy(f"http://127.0.0.1:{proxy_port}", connections=connections))
+        exercise = asyncio.run(_exercise_proxy(f"http://{_PROXY_BENCHMARK_HOST}:{proxy_port}", connections=connections))
     finally:
         threads.stop(timeout=Duration.from_seconds(30))
 
@@ -2908,7 +2910,14 @@ def _serve_fake_worker():
         cast(WorkerService, _EchoWorker()),
         compressions=IRIS_RPC_COMPRESSIONS,
     )
-    config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="error", log_config=None, timeout_keep_alive=120)
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=0,
+        log_level="error",
+        log_config=None,
+        timeout_keep_alive=_CONTROLLER_KEEPALIVE,
+    )
     server = uvicorn.Server(config)
 
     def _run():

--- a/lib/iris/scripts/benchmark_controller.py
+++ b/lib/iris/scripts/benchmark_controller.py
@@ -2459,6 +2459,7 @@ _PROXY_BENCHMARK_BACKLOG = 2048
 _PROXY_BENCHMARK_HEALTH_ROUTE = "/health"
 _PROXY_BENCHMARK_HOST = "127.0.0.1"
 _PROXY_BENCHMARK_HTTP = "httptools"
+_PROXY_BENCHMARK_REQUEST_TIMEOUT = 30.0
 
 
 def _proxy_benchmark_upstream(stream_spec: ProxyStreamSpec) -> Starlette:
@@ -2476,7 +2477,10 @@ def _proxy_benchmark_upstream(stream_spec: ProxyStreamSpec) -> Starlette:
 
 
 def _proxy_benchmark_app(upstream_address: str) -> Starlette:
-    proxy = EndpointProxy({"/bench/stream": upstream_address}.get, timeout_seconds=30)
+    proxy = EndpointProxy(
+        {"/bench/stream": upstream_address}.get,
+        timeout_seconds=_PROXY_BENCHMARK_REQUEST_TIMEOUT,
+    )
 
     async def health(_request: Request) -> JSONResponse:
         return JSONResponse({"loop": type(asyncio.get_running_loop()).__name__})
@@ -2501,7 +2505,7 @@ def _proxy_benchmark_app(upstream_address: str) -> Starlette:
 
 async def _exercise_proxy(base_url: str, *, connections: int) -> ProxyExerciseResult:
     limits = httpx.Limits(max_connections=None, max_keepalive_connections=0)
-    timeout = httpx.Timeout(30)
+    timeout = httpx.Timeout(_PROXY_BENCHMARK_REQUEST_TIMEOUT)
     started = asyncio.Event()
     streams_done = asyncio.Event()
     health_latencies: list[float] = []

--- a/lib/iris/scripts/benchmark_controller.py
+++ b/lib/iris/scripts/benchmark_controller.py
@@ -2321,6 +2321,17 @@ def run_cmd(db_path: Path | None, only_group: str | None, scenario_scale: float,
     db.close()
 
 
+_SERVER_START_TIMEOUT = Duration.from_seconds(10)
+
+
+def _wait_for_server_start(condition: Callable[[], bool], error_message: str) -> None:
+    ExponentialBackoff(initial=0.01, maximum=0.1).wait_until_or_raise(
+        condition,
+        timeout=_SERVER_START_TIMEOUT,
+        error_message=error_message,
+    )
+
+
 @main.command("serve")
 @click.option(
     "--db-path",
@@ -2370,14 +2381,14 @@ def serve_cmd(db_path: Path, state_dir: Path) -> None:
         threads=threads,
     )
     controller.start()
-    deadline = time.time() + 10.0
-    while time.time() < deadline:
-        if controller._server is not None and controller._server.started:
-            break
-        time.sleep(0.02)
-    else:
+    try:
+        _wait_for_server_start(
+            lambda: controller._server is not None and controller._server.started,
+            "Controller server did not start within 10s",
+        )
+    except TimeoutError as exc:
         controller.stop()
-        raise click.ClickException("Controller server did not start within 10s")
+        raise click.ClickException(str(exc)) from exc
 
     print(f"READY port={controller.port}", flush=True)
 
@@ -2447,13 +2458,7 @@ _PROXY_LOOPS = (_PROXY_ASYNCIO_LOOP, _PROXY_AUTO_LOOP)
 _PROXY_BENCHMARK_BACKLOG = 2048
 _PROXY_BENCHMARK_HEALTH_ROUTE = "/health"
 _PROXY_BENCHMARK_HOST = "127.0.0.1"
-
-
-def _wait_for_uvicorn(server: uvicorn.Server) -> None:
-    ExponentialBackoff(initial=0.01, maximum=0.1).wait_until(
-        lambda: server.started,
-        timeout=Duration.from_seconds(10),
-    )
+_PROXY_BENCHMARK_HTTP = "httptools"
 
 
 def _proxy_benchmark_upstream(stream_spec: ProxyStreamSpec) -> Starlette:
@@ -2564,7 +2569,7 @@ def _run_proxy_trial(
             host=_PROXY_BENCHMARK_HOST,
             port=upstream_port,
             loop="uvloop",
-            http="httptools",
+            http=_PROXY_BENCHMARK_HTTP,
             log_level="error",
             log_config=None,
             backlog=_PROXY_BENCHMARK_BACKLOG,
@@ -2577,7 +2582,7 @@ def _run_proxy_trial(
             host=_PROXY_BENCHMARK_HOST,
             port=proxy_port,
             loop=loop,
-            http="httptools",
+            http=_PROXY_BENCHMARK_HTTP,
             log_level="error",
             log_config=None,
             backlog=_PROXY_BENCHMARK_BACKLOG,
@@ -2587,9 +2592,9 @@ def _run_proxy_trial(
     _install_rpc_executor(proxy, max_workers=_RPC_HANDLER_THREADS)
     try:
         threads.spawn_server(upstream, name="proxy-benchmark-upstream")
-        _wait_for_uvicorn(upstream)
+        _wait_for_server_start(lambda: upstream.started, "benchmark upstream did not start within 10s")
         threads.spawn_server(proxy, name="proxy-benchmark-proxy")
-        _wait_for_uvicorn(proxy)
+        _wait_for_server_start(lambda: proxy.started, "benchmark proxy did not start within 10s")
         exercise = asyncio.run(_exercise_proxy(f"http://{_PROXY_BENCHMARK_HOST}:{proxy_port}", connections=connections))
     finally:
         threads.stop(timeout=Duration.from_seconds(30))
@@ -2933,13 +2938,7 @@ def _serve_fake_worker():
     thread = threading.Thread(target=_run, name="fake-worker", daemon=True)
     thread.start()
 
-    deadline = time.time() + 10
-    while time.time() < deadline:
-        if server.started:
-            break
-        time.sleep(0.02)
-    else:
-        raise RuntimeError("fake worker did not start in 10s")
+    _wait_for_server_start(lambda: server.started, "fake worker did not start within 10s")
 
     port = None
     for sock in server.servers or []:

--- a/lib/iris/scripts/benchmark_controller.py
+++ b/lib/iris/scripts/benchmark_controller.py
@@ -24,6 +24,9 @@ Usage:
     # (independent of the checkpoint-driven groups above).
     uv run python lib/iris/scripts/benchmark_controller.py reconcile \\
         --num-tasks 5000 --tasks-per-worker 64 --payload-bytes 100000
+
+    # Compare proxy throughput and health latency at up to 1,600 streams.
+    uv run --isolated --directory lib/iris python -m scripts.benchmark_controller proxy
 """
 
 import asyncio
@@ -32,6 +35,7 @@ import math
 import os
 import shutil
 import signal
+import socket
 import sqlite3
 import statistics
 import subprocess
@@ -46,6 +50,7 @@ from pathlib import Path
 from typing import Any, NotRequired, TypedDict, cast
 
 import click
+import httpx
 import uvicorn
 import yaml
 from connectrpc.request import RequestContext
@@ -75,8 +80,10 @@ from iris.cluster.controller.checkpoint import download_checkpoint_to_local
 from iris.cluster.controller.controller import (
     Controller,
     ControllerConfig,
+    _install_rpc_executor,
 )
 from iris.cluster.controller.db import ControllerDB
+from iris.cluster.controller.endpoint_proxy import ALLOWED_METHODS, PROXY_ROUTE, EndpointProxy
 from iris.cluster.controller.log_stack import build_log_stack
 from iris.cluster.controller.ops.task import Assignment
 from iris.cluster.controller.ops.worker import apply_reconcile
@@ -113,6 +120,7 @@ from iris.cluster.controller.service import (
 )
 from iris.cluster.controller.task_state import ACTIVE_TASK_STATES
 from iris.cluster.controller.worker_health import WorkerHealthEvent, WorkerHealthEventKind, WorkerHealthTracker
+from iris.cluster.dashboard_common import on_shutdown
 from iris.cluster.types import DEFAULT_BACKEND_ID, AttemptUid, JobName, UserBudgetDefaults, WorkerId
 from iris.managed_thread import ThreadContainer
 from iris.rpc import controller_pb2, job_pb2, query_pb2, worker_pb2
@@ -120,8 +128,12 @@ from iris.rpc.compression import IRIS_RPC_COMPRESSIONS
 from iris.rpc.controller_connect import ControllerServiceClientSync
 from iris.rpc.worker_connect import WorkerService, WorkerServiceASGIApplication
 from iris.version import client_revision_date
-from rigging.timing import Timestamp
+from rigging.timing import Duration, Timestamp
 from sqlalchemy import func, select, text, update
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.routing import Route
 from tests.cluster.controller._test_support import ControllerTestState
 from tests.cluster.controller.transition_driver import CursorTransitionReader
 
@@ -2368,6 +2380,275 @@ def serve_cmd(db_path: Path, state_dir: Path) -> None:
     stop.wait()
     controller.stop()
     db.close()
+
+
+# ---------------------------------------------------------------------------
+# Endpoint proxy benchmark (real Uvicorn -> Starlette -> HTTPX -> Uvicorn)
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class ProxyBenchmarkResult:
+    loop: str
+    loop_class: str
+    connections: int
+    trial: int
+    elapsed: float
+    bytes_transferred: int
+    health_latencies_ms: tuple[float, ...]
+    health_errors: tuple[str, ...]
+
+    @property
+    def streams_per_second(self) -> float:
+        return self.connections / self.elapsed
+
+    @property
+    def mebibytes_per_second(self) -> float:
+        return self.bytes_transferred / self.elapsed / 1024**2
+
+
+def _unused_local_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_uvicorn(server: uvicorn.Server) -> None:
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        if server.started:
+            return
+        time.sleep(0.01)
+    raise RuntimeError("benchmark server did not start within 10 seconds")
+
+
+def _proxy_benchmark_upstream(*, chunks: int, chunk_bytes: int, chunk_interval: float) -> Starlette:
+    payload = b"x" * chunk_bytes
+
+    async def stream(_request: Request) -> StreamingResponse:
+        async def body():
+            for _ in range(chunks):
+                yield payload
+                await asyncio.sleep(chunk_interval)
+
+        return StreamingResponse(body(), media_type="application/octet-stream")
+
+    return Starlette(routes=[Route("/stream", stream)])
+
+
+def _proxy_benchmark_app(upstream_address: str) -> Starlette:
+    proxy = EndpointProxy({"/bench/stream": upstream_address}.get, timeout_seconds=30)
+
+    async def health(_request: Request) -> JSONResponse:
+        return JSONResponse({"loop": type(asyncio.get_running_loop()).__name__})
+
+    async def proxy_route(request: Request) -> Response:
+        name = request.path_params["endpoint_name"]
+        return await proxy.dispatch(
+            request,
+            encoded_name=name,
+            sub_path=request.path_params["sub_path"],
+            proxy_prefix=f"/proxy/{name}",
+        )
+
+    return Starlette(
+        routes=[
+            Route("/health", health),
+            Route(PROXY_ROUTE, proxy_route, methods=list(ALLOWED_METHODS)),
+        ],
+        lifespan=on_shutdown(proxy.close),
+    )
+
+
+async def _exercise_proxy(
+    base_url: str, *, connections: int
+) -> tuple[int, float, str, tuple[float, ...], tuple[str, ...]]:
+    limits = httpx.Limits(max_connections=None, max_keepalive_connections=0)
+    timeout = httpx.Timeout(30)
+    started = asyncio.Event()
+    streams_done = asyncio.Event()
+    health_latencies: list[float] = []
+    health_errors: list[str] = []
+
+    async with (
+        httpx.AsyncClient(limits=limits, timeout=timeout) as stream_client,
+        httpx.AsyncClient(limits=httpx.Limits(max_connections=4), timeout=timeout) as health_client,
+    ):
+        health_response = await health_client.get(f"{base_url}/health")
+        health_response.raise_for_status()
+        loop_class = str(health_response.json()["loop"])
+
+        async def read_stream() -> int:
+            await started.wait()
+            received = 0
+            async with stream_client.stream("GET", f"{base_url}/proxy/bench.stream/stream") as response:
+                response.raise_for_status()
+                async for chunk in response.aiter_bytes():
+                    received += len(chunk)
+            return received
+
+        async def probe_health() -> None:
+            while not streams_done.is_set():
+                probe_started = time.perf_counter()
+                try:
+                    response = await health_client.get(f"{base_url}/health")
+                    response.raise_for_status()
+                    health_latencies.append((time.perf_counter() - probe_started) * 1000)
+                except httpx.HTTPError as exc:
+                    health_errors.append(f"{type(exc).__name__}: {exc}")
+                await asyncio.sleep(0.01)
+
+        stream_tasks = [asyncio.create_task(read_stream()) for _ in range(connections)]
+        health_task = asyncio.create_task(probe_health())
+        benchmark_started = time.perf_counter()
+        started.set()
+        byte_counts = await asyncio.gather(*stream_tasks)
+        elapsed = time.perf_counter() - benchmark_started
+        streams_done.set()
+        await health_task
+
+    return sum(byte_counts), elapsed, loop_class, tuple(health_latencies), tuple(health_errors)
+
+
+def _run_proxy_trial(
+    *,
+    loop: str,
+    connections: int,
+    chunks: int,
+    chunk_bytes: int,
+    chunk_interval: float,
+    trial: int,
+) -> ProxyBenchmarkResult:
+    threads = ThreadContainer(f"proxy-benchmark-{loop}-{trial}")
+    upstream_port = _unused_local_port()
+    proxy_port = _unused_local_port()
+    upstream = uvicorn.Server(
+        uvicorn.Config(
+            _proxy_benchmark_upstream(chunks=chunks, chunk_bytes=chunk_bytes, chunk_interval=chunk_interval),
+            host="127.0.0.1",
+            port=upstream_port,
+            loop="uvloop",
+            http="httptools",
+            log_level="error",
+            log_config=None,
+            backlog=2048,
+            timeout_keep_alive=120,
+        )
+    )
+    proxy = uvicorn.Server(
+        uvicorn.Config(
+            _proxy_benchmark_app(f"127.0.0.1:{upstream_port}"),
+            host="127.0.0.1",
+            port=proxy_port,
+            loop=loop,
+            http="httptools",
+            log_level="error",
+            log_config=None,
+            backlog=2048,
+            timeout_keep_alive=120,
+        )
+    )
+    _install_rpc_executor(proxy, max_workers=64)
+    try:
+        threads.spawn_server(upstream, name="proxy-benchmark-upstream")
+        _wait_for_uvicorn(upstream)
+        threads.spawn_server(proxy, name="proxy-benchmark-proxy")
+        _wait_for_uvicorn(proxy)
+        transferred, elapsed, loop_class, health_latencies, health_errors = asyncio.run(
+            _exercise_proxy(f"http://127.0.0.1:{proxy_port}", connections=connections)
+        )
+    finally:
+        threads.stop(timeout=Duration.from_seconds(30))
+
+    return ProxyBenchmarkResult(
+        loop=loop,
+        loop_class=loop_class,
+        connections=connections,
+        trial=trial,
+        elapsed=elapsed,
+        bytes_transferred=transferred,
+        health_latencies_ms=health_latencies,
+        health_errors=health_errors,
+    )
+
+
+def _proxy_percentile(values: tuple[float, ...], percentile: float) -> float:
+    if not values:
+        return float("nan")
+    ordered = sorted(values)
+    return ordered[min(math.ceil(len(ordered) * percentile) - 1, len(ordered) - 1)]
+
+
+@main.command("proxy")
+@click.option("--connections", type=int, multiple=True, default=(200, 800, 1600), show_default=True)
+@click.option("--trials", type=int, default=3, show_default=True)
+@click.option("--chunks", type=int, default=64, show_default=True)
+@click.option("--chunk-bytes", type=int, default=1024, show_default=True)
+@click.option("--chunk-interval-ms", type=float, default=10.0, show_default=True)
+def proxy_cmd(
+    connections: tuple[int, ...], trials: int, chunks: int, chunk_bytes: int, chunk_interval_ms: float
+) -> None:
+    """Compare the old asyncio controller loop with Uvicorn's auto-selected loop.
+
+    Each request crosses a real Uvicorn/Starlette endpoint proxy and a real
+    HTTPX upstream stream. Health requests share the proxy event loop so their
+    tail latency exposes starvation under concurrent streaming load.
+    """
+    if min((*connections, trials, chunks, chunk_bytes)) <= 0 or chunk_interval_ms < 0:
+        raise click.BadParameter("connections, trials, chunks, and chunk-bytes must be positive")
+
+    print(
+        f"Proxy benchmark: connections={list(connections)} trials={trials} "
+        f"body={chunks}x{chunk_bytes}B interval={chunk_interval_ms:g}ms"
+    )
+    print(
+        f"{'conn':>5}  {'loop':>7}  {'runtime':>10}  {'trial':>5}  {'elapsed':>8}  "
+        f"{'streams/s':>9}  {'MiB/s':>8}  {'health p50':>10}  {'p99':>8}  {'max':>8}  "
+        f"{'probes':>6}  {'errs':>4}"
+    )
+    results: list[ProxyBenchmarkResult] = []
+    for connection_count in connections:
+        for trial in range(1, trials + 1):
+            loop_order = ("asyncio", "auto") if trial % 2 else ("auto", "asyncio")
+            for loop in loop_order:
+                result = _run_proxy_trial(
+                    loop=loop,
+                    connections=connection_count,
+                    chunks=chunks,
+                    chunk_bytes=chunk_bytes,
+                    chunk_interval=chunk_interval_ms / 1000,
+                    trial=trial,
+                )
+                results.append(result)
+                p50 = _proxy_percentile(result.health_latencies_ms, 0.5)
+                p99 = _proxy_percentile(result.health_latencies_ms, 0.99)
+                maximum = max(result.health_latencies_ms, default=float("nan"))
+                print(
+                    f"{connection_count:5d}  {loop:>7}  {result.loop_class:>10}  {trial:5d}  "
+                    f"{result.elapsed:7.3f}s  {result.streams_per_second:9.1f}  "
+                    f"{result.mebibytes_per_second:8.1f}  {p50:9.1f}ms  {p99:7.1f}ms  "
+                    f"{maximum:7.1f}ms  {len(result.health_latencies_ms):6d}  {len(result.health_errors):4d}"
+                )
+                for error in result.health_errors:
+                    print(f"         health error: {error}")
+
+    print("\nMedian comparison (auto relative to asyncio):")
+    for connection_count in connections:
+        by_loop = {
+            loop: [r for r in results if r.connections == connection_count and r.loop == loop]
+            for loop in ("asyncio", "auto")
+        }
+        baseline = statistics.median(r.streams_per_second for r in by_loop["asyncio"])
+        treatment = statistics.median(r.streams_per_second for r in by_loop["auto"])
+        baseline_p99 = statistics.median(_proxy_percentile(r.health_latencies_ms, 0.99) for r in by_loop["asyncio"])
+        treatment_p99 = statistics.median(_proxy_percentile(r.health_latencies_ms, 0.99) for r in by_loop["auto"])
+        baseline_errors = sum(len(r.health_errors) for r in by_loop["asyncio"])
+        treatment_errors = sum(len(r.health_errors) for r in by_loop["auto"])
+        print(
+            f"  {connection_count:5d} connections: throughput {baseline:.1f} -> {treatment:.1f} streams/s "
+            f"({(treatment / baseline - 1) * 100:+.1f}%); health p99 {baseline_p99:.1f} -> {treatment_p99:.1f} ms "
+            f"({(treatment_p99 / baseline_p99 - 1) * 100:+.1f}%); errors {baseline_errors} -> {treatment_errors}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/scripts/benchmark_controller.py
+++ b/lib/iris/scripts/benchmark_controller.py
@@ -35,7 +35,6 @@ import math
 import os
 import shutil
 import signal
-import socket
 import sqlite3
 import statistics
 import subprocess
@@ -78,6 +77,7 @@ from iris.cluster.controller.backend import (
 from iris.cluster.controller.backend_store import BackendWorkerStore, DbBackendWorkerStore
 from iris.cluster.controller.checkpoint import download_checkpoint_to_local
 from iris.cluster.controller.controller import (
+    _RPC_HANDLER_THREADS,
     Controller,
     ControllerConfig,
     _install_rpc_executor,
@@ -121,6 +121,7 @@ from iris.cluster.controller.service import (
 from iris.cluster.controller.task_state import ACTIVE_TASK_STATES
 from iris.cluster.controller.worker_health import WorkerHealthEvent, WorkerHealthEventKind, WorkerHealthTracker
 from iris.cluster.dashboard_common import on_shutdown
+from iris.cluster.platforms.types import find_free_port
 from iris.cluster.types import DEFAULT_BACKEND_ID, AttemptUid, JobName, UserBudgetDefaults, WorkerId
 from iris.managed_thread import ThreadContainer
 from iris.rpc import controller_pb2, job_pb2, query_pb2, worker_pb2
@@ -2406,11 +2407,25 @@ class ProxyBenchmarkResult:
     def mebibytes_per_second(self) -> float:
         return self.bytes_transferred / self.elapsed / 1024**2
 
+    @property
+    def health_percentiles_ms(self) -> tuple[float, float, float, float, float]:
+        if not self.health_latencies_ms:
+            return (float("nan"),) * 5
+        return _percentiles_ms(list(self.health_latencies_ms))
 
-def _unused_local_port() -> int:
-    with socket.socket() as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
+
+@dataclasses.dataclass(frozen=True)
+class ProxyExerciseResult:
+    bytes_transferred: int
+    elapsed: float
+    loop_class: str
+    health_latencies_ms: tuple[float, ...]
+    health_errors: tuple[str, ...]
+
+
+_PROXY_ASYNCIO_LOOP = "asyncio"
+_PROXY_AUTO_LOOP = "auto"
+_PROXY_LOOPS = (_PROXY_ASYNCIO_LOOP, _PROXY_AUTO_LOOP)
 
 
 def _wait_for_uvicorn(server: uvicorn.Server) -> None:
@@ -2460,9 +2475,7 @@ def _proxy_benchmark_app(upstream_address: str) -> Starlette:
     )
 
 
-async def _exercise_proxy(
-    base_url: str, *, connections: int
-) -> tuple[int, float, str, tuple[float, ...], tuple[str, ...]]:
+async def _exercise_proxy(base_url: str, *, connections: int) -> ProxyExerciseResult:
     limits = httpx.Limits(max_connections=None, max_keepalive_connections=0)
     timeout = httpx.Timeout(30)
     started = asyncio.Event()
@@ -2507,7 +2520,13 @@ async def _exercise_proxy(
         streams_done.set()
         await health_task
 
-    return sum(byte_counts), elapsed, loop_class, tuple(health_latencies), tuple(health_errors)
+    return ProxyExerciseResult(
+        bytes_transferred=sum(byte_counts),
+        elapsed=elapsed,
+        loop_class=loop_class,
+        health_latencies_ms=tuple(health_latencies),
+        health_errors=tuple(health_errors),
+    )
 
 
 def _run_proxy_trial(
@@ -2520,8 +2539,8 @@ def _run_proxy_trial(
     trial: int,
 ) -> ProxyBenchmarkResult:
     threads = ThreadContainer(f"proxy-benchmark-{loop}-{trial}")
-    upstream_port = _unused_local_port()
-    proxy_port = _unused_local_port()
+    upstream_port = find_free_port()
+    proxy_port = find_free_port()
     upstream = uvicorn.Server(
         uvicorn.Config(
             _proxy_benchmark_upstream(chunks=chunks, chunk_bytes=chunk_bytes, chunk_interval=chunk_interval),
@@ -2548,35 +2567,26 @@ def _run_proxy_trial(
             timeout_keep_alive=120,
         )
     )
-    _install_rpc_executor(proxy, max_workers=64)
+    _install_rpc_executor(proxy, max_workers=_RPC_HANDLER_THREADS)
     try:
         threads.spawn_server(upstream, name="proxy-benchmark-upstream")
         _wait_for_uvicorn(upstream)
         threads.spawn_server(proxy, name="proxy-benchmark-proxy")
         _wait_for_uvicorn(proxy)
-        transferred, elapsed, loop_class, health_latencies, health_errors = asyncio.run(
-            _exercise_proxy(f"http://127.0.0.1:{proxy_port}", connections=connections)
-        )
+        exercise = asyncio.run(_exercise_proxy(f"http://127.0.0.1:{proxy_port}", connections=connections))
     finally:
         threads.stop(timeout=Duration.from_seconds(30))
 
     return ProxyBenchmarkResult(
         loop=loop,
-        loop_class=loop_class,
+        loop_class=exercise.loop_class,
         connections=connections,
         trial=trial,
-        elapsed=elapsed,
-        bytes_transferred=transferred,
-        health_latencies_ms=health_latencies,
-        health_errors=health_errors,
+        elapsed=exercise.elapsed,
+        bytes_transferred=exercise.bytes_transferred,
+        health_latencies_ms=exercise.health_latencies_ms,
+        health_errors=exercise.health_errors,
     )
-
-
-def _proxy_percentile(values: tuple[float, ...], percentile: float) -> float:
-    if not values:
-        return float("nan")
-    ordered = sorted(values)
-    return ordered[min(math.ceil(len(ordered) * percentile) - 1, len(ordered) - 1)]
 
 
 @main.command("proxy")
@@ -2609,7 +2619,7 @@ def proxy_cmd(
     results: list[ProxyBenchmarkResult] = []
     for connection_count in connections:
         for trial in range(1, trials + 1):
-            loop_order = ("asyncio", "auto") if trial % 2 else ("auto", "asyncio")
+            loop_order = _PROXY_LOOPS if trial % 2 else tuple(reversed(_PROXY_LOOPS))
             for loop in loop_order:
                 result = _run_proxy_trial(
                     loop=loop,
@@ -2620,9 +2630,7 @@ def proxy_cmd(
                     trial=trial,
                 )
                 results.append(result)
-                p50 = _proxy_percentile(result.health_latencies_ms, 0.5)
-                p99 = _proxy_percentile(result.health_latencies_ms, 0.99)
-                maximum = max(result.health_latencies_ms, default=float("nan"))
+                p50, _, p99, _, maximum = result.health_percentiles_ms
                 print(
                     f"{connection_count:5d}  {loop:>7}  {result.loop_class:>10}  {trial:5d}  "
                     f"{result.elapsed:7.3f}s  {result.streams_per_second:9.1f}  "
@@ -2635,15 +2643,14 @@ def proxy_cmd(
     print("\nMedian comparison (auto relative to asyncio):")
     for connection_count in connections:
         by_loop = {
-            loop: [r for r in results if r.connections == connection_count and r.loop == loop]
-            for loop in ("asyncio", "auto")
+            loop: [r for r in results if r.connections == connection_count and r.loop == loop] for loop in _PROXY_LOOPS
         }
-        baseline = statistics.median(r.streams_per_second for r in by_loop["asyncio"])
-        treatment = statistics.median(r.streams_per_second for r in by_loop["auto"])
-        baseline_p99 = statistics.median(_proxy_percentile(r.health_latencies_ms, 0.99) for r in by_loop["asyncio"])
-        treatment_p99 = statistics.median(_proxy_percentile(r.health_latencies_ms, 0.99) for r in by_loop["auto"])
-        baseline_errors = sum(len(r.health_errors) for r in by_loop["asyncio"])
-        treatment_errors = sum(len(r.health_errors) for r in by_loop["auto"])
+        baseline = statistics.median(r.streams_per_second for r in by_loop[_PROXY_ASYNCIO_LOOP])
+        treatment = statistics.median(r.streams_per_second for r in by_loop[_PROXY_AUTO_LOOP])
+        baseline_p99 = statistics.median(r.health_percentiles_ms[2] for r in by_loop[_PROXY_ASYNCIO_LOOP])
+        treatment_p99 = statistics.median(r.health_percentiles_ms[2] for r in by_loop[_PROXY_AUTO_LOOP])
+        baseline_errors = sum(len(r.health_errors) for r in by_loop[_PROXY_ASYNCIO_LOOP])
+        treatment_errors = sum(len(r.health_errors) for r in by_loop[_PROXY_AUTO_LOOP])
         print(
             f"  {connection_count:5d} connections: throughput {baseline:.1f} -> {treatment:.1f} streams/s "
             f"({(treatment / baseline - 1) * 100:+.1f}%); health p99 {baseline_p99:.1f} -> {treatment_p99:.1f} ms "

--- a/lib/iris/scripts/benchmark_controller.py
+++ b/lib/iris/scripts/benchmark_controller.py
@@ -43,7 +43,7 @@ import tempfile
 import threading
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, NotRequired, TypedDict, cast
@@ -2433,6 +2433,13 @@ class ProxyExerciseResult:
     health_errors: tuple[str, ...]
 
 
+@dataclasses.dataclass(frozen=True)
+class ProxyStreamSpec:
+    chunks: int
+    chunk_bytes: int
+    chunk_interval: float
+
+
 _PROXY_ASYNCIO_LOOP = "asyncio"
 _PROXY_AUTO_LOOP = "auto"
 _PROXY_LOOPS = (_PROXY_ASYNCIO_LOOP, _PROXY_AUTO_LOOP)
@@ -2447,14 +2454,14 @@ def _wait_for_uvicorn(server: uvicorn.Server) -> None:
     )
 
 
-def _proxy_benchmark_upstream(*, chunks: int, chunk_bytes: int, chunk_interval: float) -> Starlette:
-    payload = b"x" * chunk_bytes
+def _proxy_benchmark_upstream(stream_spec: ProxyStreamSpec) -> Starlette:
+    payload = b"x" * stream_spec.chunk_bytes
 
     async def stream(_request: Request) -> StreamingResponse:
         async def body():
-            for _ in range(chunks):
+            for _ in range(stream_spec.chunks):
                 yield payload
-                await asyncio.sleep(chunk_interval)
+                await asyncio.sleep(stream_spec.chunk_interval)
 
         return StreamingResponse(body(), media_type="application/octet-stream")
 
@@ -2543,9 +2550,7 @@ def _run_proxy_trial(
     *,
     loop: str,
     connections: int,
-    chunks: int,
-    chunk_bytes: int,
-    chunk_interval: float,
+    stream_spec: ProxyStreamSpec,
     trial: int,
 ) -> ProxyBenchmarkResult:
     threads = ThreadContainer(f"proxy-benchmark-{loop}-{trial}")
@@ -2553,7 +2558,7 @@ def _run_proxy_trial(
     proxy_port = find_free_port()
     upstream = uvicorn.Server(
         uvicorn.Config(
-            _proxy_benchmark_upstream(chunks=chunks, chunk_bytes=chunk_bytes, chunk_interval=chunk_interval),
+            _proxy_benchmark_upstream(stream_spec),
             host="127.0.0.1",
             port=upstream_port,
             loop="uvloop",
@@ -2599,6 +2604,52 @@ def _run_proxy_trial(
     )
 
 
+def _proxy_trials(
+    *, connections: tuple[int, ...], trials: int, stream_spec: ProxyStreamSpec
+) -> Iterator[ProxyBenchmarkResult]:
+    for connection_count in connections:
+        for trial in range(1, trials + 1):
+            loop_order = _PROXY_LOOPS if trial % 2 else tuple(reversed(_PROXY_LOOPS))
+            for loop in loop_order:
+                yield _run_proxy_trial(
+                    loop=loop,
+                    connections=connection_count,
+                    stream_spec=stream_spec,
+                    trial=trial,
+                )
+
+
+def _print_proxy_result(result: ProxyBenchmarkResult) -> None:
+    percentiles = result.health_percentiles_ms
+    print(
+        f"{result.connections:5d}  {result.loop:>7}  {result.loop_class:>10}  {result.trial:5d}  "
+        f"{result.elapsed:7.3f}s  {result.streams_per_second:9.1f}  "
+        f"{result.mebibytes_per_second:8.1f}  {percentiles.p50:9.1f}ms  {percentiles.p99:7.1f}ms  "
+        f"{percentiles.maximum:7.1f}ms  {len(result.health_latencies_ms):6d}  {len(result.health_errors):4d}"
+    )
+    for error in result.health_errors:
+        print(f"         health error: {error}")
+
+
+def _print_proxy_comparison(results: list[ProxyBenchmarkResult], connections: tuple[int, ...]) -> None:
+    print("\nMedian comparison (auto relative to asyncio):")
+    for connection_count in connections:
+        by_loop = {
+            loop: [r for r in results if r.connections == connection_count and r.loop == loop] for loop in _PROXY_LOOPS
+        }
+        baseline = statistics.median(r.streams_per_second for r in by_loop[_PROXY_ASYNCIO_LOOP])
+        treatment = statistics.median(r.streams_per_second for r in by_loop[_PROXY_AUTO_LOOP])
+        baseline_p99 = statistics.median(r.health_percentiles_ms.p99 for r in by_loop[_PROXY_ASYNCIO_LOOP])
+        treatment_p99 = statistics.median(r.health_percentiles_ms.p99 for r in by_loop[_PROXY_AUTO_LOOP])
+        baseline_errors = sum(len(r.health_errors) for r in by_loop[_PROXY_ASYNCIO_LOOP])
+        treatment_errors = sum(len(r.health_errors) for r in by_loop[_PROXY_AUTO_LOOP])
+        print(
+            f"  {connection_count:5d} connections: throughput {baseline:.1f} -> {treatment:.1f} streams/s "
+            f"({(treatment / baseline - 1) * 100:+.1f}%); health p99 {baseline_p99:.1f} -> {treatment_p99:.1f} ms "
+            f"({(treatment_p99 / baseline_p99 - 1) * 100:+.1f}%); errors {baseline_errors} -> {treatment_errors}"
+        )
+
+
 @main.command("proxy")
 @click.option("--connections", type=int, multiple=True, default=(200, 800, 1600), show_default=True)
 @click.option("--trials", type=int, default=3, show_default=True)
@@ -2617,6 +2668,11 @@ def proxy_cmd(
     if min((*connections, trials, chunks, chunk_bytes)) <= 0 or chunk_interval_ms < 0:
         raise click.BadParameter("connections, trials, chunks, and chunk-bytes must be positive")
 
+    stream_spec = ProxyStreamSpec(
+        chunks=chunks,
+        chunk_bytes=chunk_bytes,
+        chunk_interval=chunk_interval_ms / 1000,
+    )
     print(
         f"Proxy benchmark: connections={list(connections)} trials={trials} "
         f"body={chunks}x{chunk_bytes}B interval={chunk_interval_ms:g}ms"
@@ -2627,46 +2683,10 @@ def proxy_cmd(
         f"{'probes':>6}  {'errs':>4}"
     )
     results: list[ProxyBenchmarkResult] = []
-    for connection_count in connections:
-        for trial in range(1, trials + 1):
-            loop_order = _PROXY_LOOPS if trial % 2 else tuple(reversed(_PROXY_LOOPS))
-            for loop in loop_order:
-                result = _run_proxy_trial(
-                    loop=loop,
-                    connections=connection_count,
-                    chunks=chunks,
-                    chunk_bytes=chunk_bytes,
-                    chunk_interval=chunk_interval_ms / 1000,
-                    trial=trial,
-                )
-                results.append(result)
-                percentiles = result.health_percentiles_ms
-                print(
-                    f"{connection_count:5d}  {loop:>7}  {result.loop_class:>10}  {trial:5d}  "
-                    f"{result.elapsed:7.3f}s  {result.streams_per_second:9.1f}  "
-                    f"{result.mebibytes_per_second:8.1f}  {percentiles.p50:9.1f}ms  {percentiles.p99:7.1f}ms  "
-                    f"{percentiles.maximum:7.1f}ms  {len(result.health_latencies_ms):6d}  "
-                    f"{len(result.health_errors):4d}"
-                )
-                for error in result.health_errors:
-                    print(f"         health error: {error}")
-
-    print("\nMedian comparison (auto relative to asyncio):")
-    for connection_count in connections:
-        by_loop = {
-            loop: [r for r in results if r.connections == connection_count and r.loop == loop] for loop in _PROXY_LOOPS
-        }
-        baseline = statistics.median(r.streams_per_second for r in by_loop[_PROXY_ASYNCIO_LOOP])
-        treatment = statistics.median(r.streams_per_second for r in by_loop[_PROXY_AUTO_LOOP])
-        baseline_p99 = statistics.median(r.health_percentiles_ms.p99 for r in by_loop[_PROXY_ASYNCIO_LOOP])
-        treatment_p99 = statistics.median(r.health_percentiles_ms.p99 for r in by_loop[_PROXY_AUTO_LOOP])
-        baseline_errors = sum(len(r.health_errors) for r in by_loop[_PROXY_ASYNCIO_LOOP])
-        treatment_errors = sum(len(r.health_errors) for r in by_loop[_PROXY_AUTO_LOOP])
-        print(
-            f"  {connection_count:5d} connections: throughput {baseline:.1f} -> {treatment:.1f} streams/s "
-            f"({(treatment / baseline - 1) * 100:+.1f}%); health p99 {baseline_p99:.1f} -> {treatment_p99:.1f} ms "
-            f"({(treatment_p99 / baseline_p99 - 1) * 100:+.1f}%); errors {baseline_errors} -> {treatment_errors}"
-        )
+    for result in _proxy_trials(connections=connections, trials=trials, stream_spec=stream_spec):
+        results.append(result)
+        _print_proxy_result(result)
+    _print_proxy_comparison(results, connections)
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -121,17 +121,13 @@ def _install_rpc_executor(server: uvicorn.Server, *, max_workers: int) -> None:
     """Replace ``server.run`` with a variant that pins a sized default executor."""
 
     def run_with_executor(sockets: list[socket.socket] | None = None) -> None:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.set_default_executor(ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="rpc-handler"))
-        try:
-            loop.run_until_complete(server.serve())
-        finally:
-            try:
-                loop.run_until_complete(loop.shutdown_asyncgens())
-            finally:
-                asyncio.set_event_loop(None)
-                loop.close()
+        # Preserve Uvicorn's configured loop factory. Constructing an asyncio
+        # loop directly bypasses ``loop=auto`` and silently disables uvloop.
+        with asyncio.Runner(loop_factory=server.config.get_loop_factory()) as runner:
+            runner.get_loop().set_default_executor(
+                ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="rpc-handler")
+            )
+            runner.run(server.serve(sockets=sockets))
 
     server.run = run_with_executor
 

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -115,6 +115,7 @@ logger = logging.getLogger(__name__)
 # drain. Install a wider, named pool so a burst of slow handlers cannot
 # starve the rest.
 _RPC_HANDLER_THREADS = 64
+_CONTROLLER_KEEPALIVE = 120
 
 
 def _install_rpc_executor(server: uvicorn.Server, *, max_workers: int) -> None:
@@ -662,7 +663,7 @@ class Controller:
             port=self._config.port,
             log_level="warning",
             log_config=None,
-            timeout_keep_alive=120,
+            timeout_keep_alive=_CONTROLLER_KEEPALIVE,
             proxy_headers=True,
             forwarded_allow_ips="*",
         )

--- a/lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py
@@ -59,6 +59,13 @@ CKS_KUEUE_FEATURE_GATES = [
 # build_controller_manager_config for why a broad selector is dangerous.
 DEFAULT_POD_NAMESPACES = ("iris",)
 
+# Kueue's Kubernetes API client is shared by reconcilers, event recording, and
+# leader election. Iris clusters routinely carry enough Pods and Workloads for
+# Kueue's upstream 20-QPS/30-burst defaults to delay a lease renewal during a
+# restart resync.
+DEFAULT_CLIENT_CONNECTION_QPS = 100.0
+DEFAULT_CLIENT_CONNECTION_BURST = 200
+
 # Standard k8s per-node label, the finest topology level.
 _K8S_HOSTNAME_LABEL = "kubernetes.io/hostname"
 
@@ -138,8 +145,8 @@ CPU_FLAVOR_QUOTA = {**NON_BINDING_QUOTA, "nvidia.com/gpu": "0", "rdma/ib": "0"}
 def build_controller_manager_config(
     pod_namespaces: Sequence[str] = DEFAULT_POD_NAMESPACES,
     *,
-    client_connection_qps: float | None = None,
-    client_connection_burst: int | None = None,
+    client_connection_qps: float = DEFAULT_CLIENT_CONNECTION_QPS,
+    client_connection_burst: int = DEFAULT_CLIENT_CONNECTION_BURST,
 ) -> dict:
     """Return the kueue ``Configuration`` (controller-manager config) as a dict.
 
@@ -164,9 +171,6 @@ def build_controller_manager_config(
     it can't reach (no network yet) → the pod is rejected → the node never goes
     Ready. Opt-in scoping keeps the webhooks off every namespace but our own.
     """
-    if (client_connection_qps is None) != (client_connection_burst is None):
-        raise ValueError("client connection QPS and burst must be set together")
-
     config: dict[str, object] = {
         "apiVersion": "config.kueue.x-k8s.io/v1beta1",
         "kind": "Configuration",
@@ -194,12 +198,11 @@ def build_controller_manager_config(
         "integrations": {
             "frameworks": ["batch/job", "pod"],
         },
-    }
-    if client_connection_qps is not None and client_connection_burst is not None:
-        config["clientConnection"] = {
+        "clientConnection": {
             "qps": client_connection_qps,
             "burst": client_connection_burst,
-        }
+        },
+    }
     return config
 
 
@@ -207,8 +210,8 @@ def build_cks_values(
     pod_namespaces: Sequence[str] = DEFAULT_POD_NAMESPACES,
     *,
     manager_memory_limit: str | None = None,
-    client_connection_qps: float | None = None,
-    client_connection_burst: int | None = None,
+    client_connection_qps: float = DEFAULT_CLIENT_CONNECTION_QPS,
+    client_connection_burst: int = DEFAULT_CLIENT_CONNECTION_BURST,
 ) -> dict:
     """Return the ``cks-kueue`` (CoreWeave) helm values (managerConfig only).
 

--- a/lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py
@@ -135,7 +135,12 @@ CPU_FLAVOR_QUOTA = {**NON_BINDING_QUOTA, "nvidia.com/gpu": "0", "rdma/ib": "0"}
 # --------------------------------------------------------------------------
 # Pure builders (return plain dicts; no I/O).
 # --------------------------------------------------------------------------
-def build_controller_manager_config(pod_namespaces: Sequence[str] = DEFAULT_POD_NAMESPACES) -> dict:
+def build_controller_manager_config(
+    pod_namespaces: Sequence[str] = DEFAULT_POD_NAMESPACES,
+    *,
+    client_connection_qps: float | None = None,
+    client_connection_burst: int | None = None,
+) -> dict:
     """Return the kueue ``Configuration`` (controller-manager config) as a dict.
 
     Serialized to YAML and embedded as the chart's ``controllerManagerConfigYaml``
@@ -159,7 +164,10 @@ def build_controller_manager_config(pod_namespaces: Sequence[str] = DEFAULT_POD_
     it can't reach (no network yet) → the pod is rejected → the node never goes
     Ready. Opt-in scoping keeps the webhooks off every namespace but our own.
     """
-    return {
+    if (client_connection_qps is None) != (client_connection_burst is None):
+        raise ValueError("client connection QPS and burst must be set together")
+
+    config: dict[str, object] = {
         "apiVersion": "config.kueue.x-k8s.io/v1beta1",
         "kind": "Configuration",
         "health": {"healthProbeBindAddress": ":8081"},
@@ -187,12 +195,20 @@ def build_controller_manager_config(pod_namespaces: Sequence[str] = DEFAULT_POD_
             "frameworks": ["batch/job", "pod"],
         },
     }
+    if client_connection_qps is not None and client_connection_burst is not None:
+        config["clientConnection"] = {
+            "qps": client_connection_qps,
+            "burst": client_connection_burst,
+        }
+    return config
 
 
 def build_cks_values(
     pod_namespaces: Sequence[str] = DEFAULT_POD_NAMESPACES,
     *,
     manager_memory_limit: str | None = None,
+    client_connection_qps: float | None = None,
+    client_connection_burst: int | None = None,
 ) -> dict:
     """Return the ``cks-kueue`` (CoreWeave) helm values (managerConfig only).
 
@@ -213,7 +229,13 @@ def build_cks_values(
     request/limit instead of duplicating it.
     """
     config_yaml = yaml.safe_dump(
-        build_controller_manager_config(pod_namespaces), default_flow_style=False, sort_keys=False
+        build_controller_manager_config(
+            pod_namespaces,
+            client_connection_qps=client_connection_qps,
+            client_connection_burst=client_connection_burst,
+        ),
+        default_flow_style=False,
+        sort_keys=False,
     )
     controller_manager: dict = {"featureGates": CKS_KUEUE_FEATURE_GATES}
     if manager_memory_limit is not None:

--- a/lib/iris/tests/cluster/backends/k8s/test_kueue_manifests.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_kueue_manifests.py
@@ -3,6 +3,7 @@
 
 """Regression guards for the Kueue helm values Iris renders."""
 
+import yaml
 from iris.cluster.platforms.k8s.kueue_manifests import build_cks_values, build_upstream_values
 
 
@@ -33,3 +34,12 @@ def test_upstream_values_never_enable_tas_balanced_placement():
     gates = build_upstream_values(["iris"])["controllerManager"]["featureGates"]
     assert _gate(gates, "TASBalancedPlacement") in (None, False)
     assert _gate(gates, "TopologyAwareScheduling") is True
+
+
+def test_cks_values_set_client_connection_rate_limit():
+    values = build_cks_values(["iris"], client_connection_qps=100, client_connection_burst=200)
+
+    config_yaml = values["kueue"]["managerConfig"]["controllerManagerConfigYaml"]
+    config = yaml.safe_load(config_yaml)
+
+    assert config["clientConnection"] == {"qps": 100, "burst": 200}

--- a/lib/iris/tests/cluster/backends/k8s/test_kueue_manifests.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_kueue_manifests.py
@@ -3,7 +3,6 @@
 
 """Regression guards for the Kueue helm values Iris renders."""
 
-import yaml
 from iris.cluster.platforms.k8s.kueue_manifests import build_cks_values, build_upstream_values
 
 
@@ -34,12 +33,3 @@ def test_upstream_values_never_enable_tas_balanced_placement():
     gates = build_upstream_values(["iris"])["controllerManager"]["featureGates"]
     assert _gate(gates, "TASBalancedPlacement") in (None, False)
     assert _gate(gates, "TopologyAwareScheduling") is True
-
-
-def test_cks_values_set_client_connection_rate_limit():
-    values = build_cks_values(["iris"], client_connection_qps=100, client_connection_burst=200)
-
-    config_yaml = values["kueue"]["managerConfig"]["controllerManagerConfigYaml"]
-    config = yaml.safe_load(config_yaml)
-
-    assert config["clientConnection"] == {"qps": 100, "burst": 200}

--- a/lib/iris/tests/cluster/controller/test_controller_server.py
+++ b/lib/iris/tests/cluster/controller/test_controller_server.py
@@ -1,0 +1,57 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import threading
+
+import uvicorn
+from iris.cluster.controller.controller import _install_rpc_executor
+from iris.managed_thread import ThreadContainer
+from rigging.timing import Duration, ExponentialBackoff
+from starlette.types import Receive, Scope, Send
+
+
+class _MarkedEventLoop(asyncio.SelectorEventLoop):
+    pass
+
+
+def _marked_loop_factory() -> asyncio.AbstractEventLoop:
+    return _MarkedEventLoop()
+
+
+def test_controller_server_honors_configured_loop_and_rpc_executor() -> None:
+    observed: list[tuple[str, str]] = []
+
+    async def app(scope: Scope, receive: Receive, send: Send) -> None:
+        assert scope["type"] == "lifespan"
+        while True:
+            message = await receive()
+            if message["type"] == "lifespan.startup":
+                executor_thread = await asyncio.to_thread(lambda: threading.current_thread().name)
+                observed.append((type(asyncio.get_running_loop()).__name__, executor_thread))
+                await send({"type": "lifespan.startup.complete"})
+                continue
+            await send({"type": "lifespan.shutdown.complete"})
+            return
+
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=0,
+        lifespan="on",
+        loop="tests.cluster.controller.test_controller_server:_marked_loop_factory",
+        log_config=None,
+    )
+    server = uvicorn.Server(config)
+    _install_rpc_executor(server, max_workers=2)
+    threads = ThreadContainer()
+    try:
+        threads.spawn_server(server, name="controller-server-test")
+        ExponentialBackoff(initial=0.01, maximum=0.1).wait_until(
+            lambda: bool(observed),
+            timeout=Duration.from_seconds(5),
+        )
+    finally:
+        threads.stop()
+
+    assert observed == [("_MarkedEventLoop", "rpc-handler_0")]


### PR DESCRIPTION
Raise Kueue's Kubernetes-client limit from its 20-QPS/30-burst defaults to an Iris-wide default of 100 QPS/200 burst, while retaining typed per-cluster overrides. The July 22 `cw-rno2a` outage was not an OOM: event writes waited more than 11 seconds during a roughly 4,843-Pod/3,080-Workload resync, Kueue missed its 10-second leader-renewal deadline, and the process exited with code 1 without an `OOMKilled` status. A targeted Pulumi update restored that controller; the replacement remains ready with zero restarts and a populated webhook endpoint. Read-only previews show the same in-place Kueue update for the other three CoreWeave stacks, but do not apply it.

Restore Pulumi ownership of all four existing DNS-only Cloudflare federation CNAMEs and protect them from deletion. The typed schema owns their shared `oa.dev` zone ID, and each cluster config declares its current hostname and target. Full previews show every CNAME unchanged and protected, with no deletes or replacements.

Preserve Uvicorn's configured loop factory when installing Iris's 64-thread RPC executor. The previous launcher created a selector loop directly, disabling the uvloop already installed in the controller image. The `cw-us-east-02a` probe warnings came from the live Pod rather than stale telemetry: roughly 180 long-lived inference streams shared the process with Kubernetes LIST decoding that reached 6.1 seconds, and loopback `/health` requests also timed out.

A local real-proxy benchmark at 1,600 concurrent streams improved median completion throughput from 74.1 to 96.9 streams/s (+30.8%) and health p99 from 8.85 to 2.19 seconds (-75.3%) across three balanced trials, with zero request or probe errors. At 200 streams, throughput improved 22.6% and health p99 fell 84.0%. A separate 800-stream run was noisy and did not improve, so these results show a substantial saturation-tail improvement rather than a universal throughput gain. The benchmark ran the Uvicorn proxy and upstream on the same 12-core Xeon E-2236 host, using 64 chunks of 1,024 bytes per stream at 10 ms intervals. Keep the 10-second Kubernetes probe timeout because it exposed genuine event-loop unresponsiveness.

The state-preserving `cw-rno2a` rollout restored 5,539 jobs from `s3://marin-us-east-02a/iris/cw-rno2a/state/controller-state/1784765370653` and deployed controller image `634bd5550c`. The controller reports version `e6898a8695`, is ready with zero restarts, and passed 30 post-cutover loopback health requests. The 59 focused tests, changed-file lint and type checks, local proxy smoke, Pulumi previews, and the agentic lint review pass.
