### PR TITLE
[grafana] Monitor finelog fleet health

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -30,6 +30,8 @@ fetch server-side, so nothing outside the container reaches it.
 
 ```
 GET /finelog/{cluster}/query?sql=&from=&to=      finelog SQL
+GET /finelog/marin/fleet_health                  main query probe + k8s mirror readiness
+GET /finelog/marin/alerts/fleet_health           alert rows: server labels + value(0|1)
 GET /iris/{cluster}/jobs | workers | health      live controller RPCs
 GET /iris/{cluster}/query?sql=                    ad-hoc SELECT (admin/null-auth)
 GET /github/ferries | builds | nightlies          GitHub REST / GraphQL
@@ -54,6 +56,10 @@ Timestamps come back as epoch milliseconds, so a panel selects a raw or `date_bi
 time column without casting. finelog has JSON SQL UDFs, so a panel groups by a label in SQL
 — `json_get(labels,'region')`; the bridge also flattens a `labels` column into
 `label_<key>` fields.
+
+`fleet_health` reads one row from `finelog-marin`'s `log` namespace and combines that
+result with the three CoreWeave mirror Deployments' HTTP-readiness state. A hub query
+at or above 5 seconds is slow.
 
 Iris: the bridge owns each query behind a fixed endpoint and returns flat rows, so the
 dashboard never sends raw admin SQL. `jobs` (root jobs by state — in-flight plus 24h
@@ -171,7 +177,8 @@ redeploy.
 
 Rules page only on near-certain incidents: an unreachable cluster, a
 crash-looping watched component, an admission webhook with no ready endpoints, a
-degraded component, a dead Iris controller, a GPU pod that stays node-bound and
+degraded component, a dead Iris controller, an unhealthy finelog hub or mirror, a GPU
+pod that stays node-bound and
 nonterminal without finalizers for five minutes after the bridge's two-minute
 overdue threshold, and a GB200 rack with fewer than 16 trays Ready for five
 minutes (the NVL72 rack spec is 18; a floor rather than an outright outage —

--- a/infra/grafana/dashboards/k8s.json
+++ b/infra/grafana/dashboards/k8s.json
@@ -449,6 +449,99 @@
           ]
         }
       ]
+    },
+    {
+      "id": 11,
+      "type": "table",
+      "title": "Finelog fleet health",
+      "description": "The marin hub reads one row from the log namespace and reports latency, exercising rotated segments. Each CoreWeave mirror reports its Kubernetes HTTP /health readiness.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 63
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "latency_ms"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/fleet_health",
+          "url_options": {
+            "method": "GET"
+          },
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "server",
+              "text": "server",
+              "type": "string"
+            },
+            {
+              "selector": "role",
+              "text": "role",
+              "type": "string"
+            },
+            {
+              "selector": "responsive",
+              "text": "responsive",
+              "type": "boolean"
+            },
+            {
+              "selector": "ready",
+              "text": "ready",
+              "type": "number"
+            },
+            {
+              "selector": "desired",
+              "text": "desired",
+              "type": "number"
+            },
+            {
+              "selector": "latency_ms",
+              "text": "latency_ms",
+              "type": "number"
+            },
+            {
+              "selector": "error_class",
+              "text": "error_class",
+              "type": "string"
+            },
+            {
+              "selector": "error",
+              "text": "error",
+              "type": "string"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -253,6 +253,57 @@ groups:
               conditions:
                 - evaluator: { type: lt, params: [16] }
 
+  # The marin datasource combines a query-path probe of the GCE hub with the
+  # HTTP-readiness state of each CoreWeave finelog Deployment. K8s marks a pod
+  # NotReady when /health misses its fifteen-second deadline; the hub reports its
+  # measured one-row log query latency. The alert projection returns an explicit zero for
+  # every healthy server, so NoData means the monitoring path itself failed.
+  - orgId: 1
+    name: finelog-health
+    folder: Alerts
+    interval: 1m
+    rules:
+      - uid: finelog-fleet-unhealthy
+        title: FinelogFleetUnhealthy
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.cluster }}: {{ $labels.server }} is {{ $labels.state }}"
+          runbook_url: https://github.com/marin-community/marin/blob/main/lib/finelog/OPS.md
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: finelog-marin
+            model:
+              refId: A
+              datasource: { type: yesoreyeram-infinity-datasource, uid: finelog-marin }
+              type: json
+              source: url
+              parser: backend
+              format: table
+              url: /alerts/fleet_health
+              url_options: { method: GET }
+              columns:
+                - { selector: cluster, text: cluster, type: string }
+                - { selector: server, text: server, type: string }
+                - { selector: role, text: role, type: string }
+                - { selector: state, text: state, type: string }
+                - { selector: error_class, text: error_class, type: string }
+                - { selector: value, text: value, type: number }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
   # The GCE controllers are not in K8S_CLUSTERS; their liveness comes from the
   # existing per-cluster iris datasources. The health row always exists (the
   # bridge answers reachable=false rather than erroring), and `up` is its 0/1

--- a/infra/grafana/src/config.py
+++ b/infra/grafana/src/config.py
@@ -20,6 +20,9 @@ CONTROLLER_PORT = 10000
 # (provisioning/datasources/finelog.yaml) use it.
 BRIDGE_PORT = 8081
 
+# A main-hub log query at or above this latency is unhealthy.
+FINELOG_SLOW_THRESHOLD_MS = 5_000
+
 # The GitHub repository the ferry and build panels read.
 GITHUB_REPO = "marin-community/marin"
 # Ferry runs fetched per tier; commits scanned for the build panel.

--- a/infra/grafana/src/discovery.py
+++ b/infra/grafana/src/discovery.py
@@ -11,10 +11,14 @@ monitored cluster's control plane is down.
 from google.cloud import compute_v1
 
 
+class InstanceResolutionError(RuntimeError):
+    """A configured VM filter did not resolve to an internal IP."""
+
+
 def resolve_internal_ip(project: str, zone: str, instance_filter: str) -> str:
     """Return the internal IP of the VM matching instance_filter in project/zone.
 
-    Raises RuntimeError if no matching instance has an internal IP.
+    Raises InstanceResolutionError if no matching instance has an internal IP.
     """
     # list() flattens only project/zone; the filter rides on the request.
     request = compute_v1.ListInstancesRequest(project=project, zone=zone, filter=instance_filter)
@@ -22,4 +26,4 @@ def resolve_internal_ip(project: str, zone: str, instance_filter: str) -> str:
         for interface in instance.network_interfaces:
             if interface.network_i_p:
                 return interface.network_i_p
-    raise RuntimeError(f"no VM with an internal IP for filter {instance_filter!r} in {zone}")
+    raise InstanceResolutionError(f"no VM with an internal IP for filter {instance_filter!r} in {zone}")

--- a/infra/grafana/src/finelog_health.py
+++ b/infra/grafana/src/finelog_health.py
@@ -1,0 +1,29 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared health model for the main finelog and its k8s mirrors."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class FinelogRole(StrEnum):
+    """A server's place in the finelog forwarding topology."""
+
+    HUB = "hub"
+    MIRROR = "mirror"
+
+
+@dataclass(frozen=True)
+class FinelogHealth:
+    """One finelog server's query or HTTP-readiness health."""
+
+    cluster: str
+    server: str
+    role: FinelogRole
+    responsive: bool
+    ready: int
+    desired: int
+    latency_ms: int | None
+    error_class: str
+    error: str

--- a/infra/grafana/src/finelog_source.py
+++ b/infra/grafana/src/finelog_source.py
@@ -9,12 +9,16 @@ cluster's controller is down.
 """
 
 import logging
+import time
 from typing import Protocol
 
 import pyarrow as pa
 from config import FINELOG_PORT, ClusterTarget
-from discovery import resolve_internal_ip
+from discovery import InstanceResolutionError, resolve_internal_ip
 from finelog.client.log_client import LogClient
+from finelog.errors import StatsError
+from finelog_health import FinelogHealth, FinelogRole
+from google.api_core.exceptions import GoogleAPIError
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +30,8 @@ class MetricSource(Protocol):
     def target(self) -> ClusterTarget: ...
 
     def query(self, sql: str, *, max_rows: int) -> pa.Table: ...
+
+    def health(self) -> FinelogHealth: ...
 
 
 class FinelogSource:
@@ -56,3 +62,33 @@ class FinelogSource:
     def query(self, sql: str, *, max_rows: int) -> pa.Table:
         """Run sql against this cluster's finelog. Raises QueryResultTooLargeError past max_rows."""
         return self._client.query(sql, max_rows=max_rows)
+
+    def health(self) -> FinelogHealth:
+        """Probe the query path and return a dashboard-safe health row."""
+        started = time.monotonic()
+        try:
+            self.query('SELECT * FROM "log" LIMIT 1', max_rows=1)
+        except (GoogleAPIError, InstanceResolutionError, OSError, StatsError) as err:
+            logger.warning("finelog health query failed for %s: %s", self._target.name, err)
+            return FinelogHealth(
+                cluster=self._target.name,
+                server=f"finelog-{self._target.name}",
+                role=FinelogRole.HUB,
+                responsive=False,
+                ready=0,
+                desired=1,
+                latency_ms=None,
+                error_class=type(err).__name__,
+                error=str(err),
+            )
+        return FinelogHealth(
+            cluster=self._target.name,
+            server=f"finelog-{self._target.name}",
+            role=FinelogRole.HUB,
+            responsive=True,
+            ready=1,
+            desired=1,
+            latency_ms=round((time.monotonic() - started) * 1000),
+            error_class="",
+            error="",
+        )

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -43,6 +43,7 @@ from config import (
     WatchedComponent,
     WatchedWebhook,
 )
+from finelog_health import FinelogHealth, FinelogRole
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +61,8 @@ STUCK_TERMINATION_OVERDUE_SECONDS = 120
 _GPU_RESOURCE = "nvidia.com/gpu"
 _IRIS_TASK_ID_ENV = "IRIS_TASK_ID"
 _TERMINAL_POD_PHASES = frozenset(("Succeeded", "Failed"))
+_FINELOG_CONTAINER = "finelog"
+_FINELOG_FALLBACK_SERVER = "finelog-mirror"
 
 # CoreWeave physical-topology labels a GPU node carries: which rack it lives in,
 # the rack's full CoreWeave-assigned name, and its instance type.
@@ -82,6 +85,11 @@ BACKOFF_REASONS = ("CrashLoopBackOff", "ImagePullBackOff")
 # rules filter on these values (the crashloops rule pages only on SCOPE_CONTROL_PLANE).
 SCOPE_CONTROL_PLANE = "control-plane"
 SCOPE_WORKLOAD = "workload"
+
+
+def _deployment_has_container(deployment: dict, container_name: str) -> bool:
+    pod_spec = ((deployment.get("spec") or {}).get("template") or {}).get("spec") or {}
+    return any(container.get("name") == container_name for container in pod_spec.get("containers") or [])
 
 
 class K8sErrorClass(StrEnum):
@@ -307,6 +315,43 @@ class K8sSource:
                 }
             )
         return rows
+
+    def finelog_health(self) -> FinelogHealth:
+        """Report the mirror's HTTP-probe readiness from its Deployment status."""
+        # Name and namespace belong to finelog's deploy config, which is not in this
+        # image; discover by the stable container name instead of mirroring config.
+        deployments = self._list("/apis/apps/v1/deployments")
+        deployments = [
+            deployment for deployment in deployments if _deployment_has_container(deployment, _FINELOG_CONTAINER)
+        ]
+        if len(deployments) != 1:
+            return FinelogHealth(
+                cluster=self._target.name,
+                server=_FINELOG_FALLBACK_SERVER,
+                role=FinelogRole.MIRROR,
+                responsive=False,
+                ready=0,
+                desired=1,
+                latency_ms=None,
+                error_class="discovery",
+                error=f"expected one finelog Deployment, found {len(deployments)}",
+            )
+        deployment = deployments[0]
+        server = (deployment.get("metadata") or {}).get("name") or _FINELOG_FALLBACK_SERVER
+        desired = (deployment.get("spec") or {}).get("replicas", 1)
+        ready = (deployment.get("status") or {}).get("readyReplicas") or 0
+        responsive = desired > 0 and ready >= desired
+        return FinelogHealth(
+            cluster=self._target.name,
+            server=server,
+            role=FinelogRole.MIRROR,
+            responsive=responsive,
+            ready=ready,
+            desired=desired,
+            latency_ms=None,
+            error_class="" if responsive else "readiness",
+            error="" if responsive else "HTTP /health probe is not Ready",
+        )
 
     def _scanned_namespaces(self) -> list[str]:
         """Namespaces the pod scans cover: everything not provider-managed by prefix."""
@@ -627,6 +672,26 @@ class K8sFleet:
 
     def gpu_racks(self) -> list[dict]:
         return self._fan_out(lambda s: s.gpu_racks(), self._error_row)
+
+    def finelog_health(self) -> list[FinelogHealth]:
+        """One health row per k8s finelog mirror, including API failures."""
+
+        def on_error(source: K8sSource, err: K8sError) -> list[FinelogHealth]:
+            return [
+                FinelogHealth(
+                    cluster=source.target.name,
+                    server=_FINELOG_FALLBACK_SERVER,
+                    role=FinelogRole.MIRROR,
+                    responsive=False,
+                    ready=0,
+                    desired=1,
+                    latency_ms=None,
+                    error_class=str(err.error_class),
+                    error=str(err),
+                )
+            ]
+
+        return self._collect(lambda source: [source.finelog_health()], on_error)
 
     def alert_gpu_rack_trays(self) -> list[dict]:
         """Per rack: trays_ready as ``value``, for the below-minimum-trays alert.

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -12,6 +12,8 @@ dashboard never sends admin RPC SQL, and every route feeds Infinity's backend pa
 Routes, grouped by source (cluster is a path segment where it applies):
 
     GET /finelog/{cluster}/query?sql=&from=&to=  finelog SQL (window macros, cached per bucket)
+    GET /finelog/marin/fleet_health              hub query health + k8s mirror readiness
+    GET /finelog/marin/alerts/fleet_health       alert rows: server labels + value(0|1)
     GET /iris/{cluster}/jobs                     root-job counts by state (in-flight + 24h terminal)
     GET /iris/{cluster}/workers                  healthy worker counts + resource totals per region
     GET /iris/{cluster}/health                   controller reachability + latency
@@ -54,9 +56,10 @@ from datetime import UTC, datetime
 import pyarrow as pa
 import uvicorn
 from cache import TtlCache
-from config import BRIDGE_PORT, CLUSTERS, K8S_CLUSTERS, BridgeConfig, ClusterTarget
+from config import BRIDGE_PORT, CLUSTERS, FINELOG_SLOW_THRESHOLD_MS, K8S_CLUSTERS, BridgeConfig, ClusterTarget
 from errors import UpstreamError
 from finelog.errors import QueryResultTooLargeError
+from finelog_health import FinelogHealth
 from finelog_source import FinelogSource, MetricSource
 from github_source import GithubSource
 from iris_source import IrisSource
@@ -79,6 +82,7 @@ TO_MACRO = "{{to}}"
 LABELS_COLUMN = "labels"
 LABEL_PREFIX = "label_"
 _K8S_TERMINATION_CANDIDATES_CACHE_KEY = "termination_candidates"
+_FINELOG_HUB_CLUSTER = "marin"
 
 
 def workload_overview(pending_rows: list[dict], crashloop_rows: list[dict]) -> list[dict]:
@@ -89,6 +93,29 @@ def workload_overview(pending_rows: list[dict], crashloop_rows: list[dict]) -> l
             "crashlooping_containers": sum("container" in row for row in crashloop_rows),
         }
     ]
+
+
+def finelog_alert_rows(health_rows: list[FinelogHealth]) -> list[dict]:
+    """Project fleet health into Grafana's one-numeric-column alert contract."""
+    alerts = []
+    for row in health_rows:
+        if not row.responsive:
+            state = "unresponsive"
+        elif row.latency_ms is not None and row.latency_ms >= FINELOG_SLOW_THRESHOLD_MS:
+            state = "slow"
+        else:
+            state = "healthy"
+        alerts.append(
+            {
+                "cluster": row.cluster,
+                "server": row.server,
+                "role": row.role,
+                "state": state,
+                "error_class": row.error_class,
+                "value": 0 if state == "healthy" else 1,
+            }
+        )
+    return alerts
 
 
 def _sql_timestamp(at: datetime) -> str:
@@ -262,6 +289,7 @@ def create_app(
 ) -> Starlette:
     """Build the ASGI app serving finelog, Iris, GitHub, W&B, and k8s sources."""
     finelog_cache: TtlCache = TtlCache(config.cache_ttl)
+    finelog_health_cache: TtlCache = TtlCache(config.k8s_cache_ttl)
     iris_cache: TtlCache = TtlCache(config.iris_cache_ttl)
     github_cache: TtlCache = TtlCache(config.github_cache_ttl)
     k8s_cache: TtlCache = TtlCache(config.k8s_cache_ttl)
@@ -274,6 +302,25 @@ def create_app(
             return JSONResponse({"error": str(err)}, status_code=400)
         except QueryResultTooLargeError as err:
             return JSONResponse({"error": f"{err}; narrow the time range or aggregate"}, status_code=400)
+
+    def fleet_health_rows() -> list[FinelogHealth]:
+        _target_for(_FINELOG_HUB_CLUSTER, finelog_sources)
+        return finelog_health_cache.get_or_compute(
+            "fleet_health",
+            lambda: [finelog_sources[_FINELOG_HUB_CLUSTER].health(), *k8s_fleet.finelog_health()],
+        )
+
+    def finelog_fleet_health(_: Request) -> JSONResponse:
+        try:
+            return JSONResponse([asdict(row) for row in fleet_health_rows()])
+        except _BadRequest as err:
+            return JSONResponse({"error": str(err)}, status_code=400)
+
+    def finelog_alerts_fleet_health(_: Request) -> JSONResponse:
+        try:
+            return JSONResponse(finelog_alert_rows(fleet_health_rows()))
+        except _BadRequest as err:
+            return JSONResponse({"error": str(err)}, status_code=400)
 
     def iris_endpoint(request: Request, endpoint: str, run) -> JSONResponse:
         try:
@@ -403,6 +450,8 @@ def create_app(
             Route("/github/nightlies", github_nightlies),
             Route("/wandb/{chart}", wandb_chart),
             Route("/finelog/{cluster}/query", query),
+            Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/fleet_health", finelog_fleet_health),
+            Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/fleet_health", finelog_alerts_fleet_health),
             Route("/iris/{cluster}/jobs", iris_jobs),
             Route("/iris/{cluster}/workers", iris_workers),
             Route("/iris/{cluster}/health", iris_health),

--- a/infra/grafana/tests/conftest.py
+++ b/infra/grafana/tests/conftest.py
@@ -11,6 +11,7 @@ KUEUE_DEPLOY = "/apis/apps/v1/namespaces/kueue-system/deployments/kueue-controll
 IRIS_DEPLOY = "/apis/apps/v1/namespaces/iris/deployments/iris-controller"
 TRAEFIK_DEPLOY = "/apis/apps/v1/namespaces/traefik/deployments/traefik"
 CERT_DEPLOY = "/apis/apps/v1/namespaces/cert-manager/deployments/cert-manager"
+FINELOG_DEPLOYMENTS_PATH = "/apis/apps/v1/deployments"
 KUEUE_SLICES = "/apis/discovery.k8s.io/v1/namespaces/kueue-system/endpointslices"
 
 
@@ -28,10 +29,21 @@ def bridge_config(cache_ttl: float = 20.0) -> BridgeConfig:
     )
 
 
-def deployment(namespace: str, name: str, *, ready: int = 1, desired: int = 1) -> dict:
+def deployment(
+    namespace: str,
+    name: str,
+    *,
+    ready: int = 1,
+    desired: int = 1,
+    containers: tuple[str, ...] = (),
+) -> dict:
     return {
         "metadata": {"namespace": namespace, "name": name},
-        "spec": {"replicas": desired, "selector": {"matchLabels": {"app": name}}},
+        "spec": {
+            "replicas": desired,
+            "selector": {"matchLabels": {"app": name}},
+            "template": {"spec": {"containers": [{"name": container} for container in containers]}},
+        },
         "status": {"readyReplicas": ready},
     }
 
@@ -117,6 +129,7 @@ def healthy_k8s_routes() -> dict:
         IRIS_DEPLOY: deployment("iris", "iris-controller"),
         TRAEFIK_DEPLOY: deployment("traefik", "traefik"),
         CERT_DEPLOY: deployment("cert-manager", "cert-manager"),
+        FINELOG_DEPLOYMENTS_PATH: [deployment("iris", "finelog-cw-a", containers=("finelog",))],
         "/api/v1/namespaces/kueue-system/pods": [pod("kueue-system", "kueue-controller-manager-abc")],
         "/api/v1/namespaces/iris/pods": [pod("iris", "iris-controller-abc")],
         "/api/v1/namespaces/traefik/pods": [pod("traefik", "traefik-abc")],

--- a/infra/grafana/tests/fixture_bridge.py
+++ b/infra/grafana/tests/fixture_bridge.py
@@ -188,6 +188,26 @@ def _rows(path: str, query: str) -> list[dict] | dict:
             {"bucket": "last24h", "state": "succeeded", "count": 318},
             {"bucket": "last24h", "state": "failed", "count": 9},
         ]
+    if path == "/finelog/marin/fleet_health":
+        return [
+            {
+                "cluster": cluster,
+                "server": server,
+                "role": role,
+                "responsive": True,
+                "ready": 1,
+                "desired": 1,
+                "latency_ms": 22 if role == "hub" else None,
+                "error_class": "",
+                "error": "",
+            }
+            for cluster, server, role in (
+                ("marin", "finelog-marin", "hub"),
+                ("cw-us-east-02a", "finelog-cw-use02a", "mirror"),
+                ("cw-us-east-08a", "finelog-cw-use08a", "mirror"),
+                ("cw-rno2a", "finelog-cw-rno2a", "mirror"),
+            )
+        ]
     if path == "/k8s/health":
         return [
             {"cluster": cluster, "reachable": True, "up": 1, "latency_ms": 31, "error_class": ""}

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -10,8 +10,9 @@ from datetime import UTC, datetime
 import pyarrow as pa
 from cache import TtlCache
 from config import ClusterTarget
-from conftest import bridge_config
+from conftest import FINELOG_DEPLOYMENTS_PATH, bridge_config, deployment, healthy_k8s_routes, k8s_api, make_k8s_source
 from finelog.errors import QueryResultTooLargeError
+from finelog_health import FinelogHealth, FinelogRole
 from github_source import GithubSource
 from k8s_source import K8sFleet
 from server import create_app, workload_overview
@@ -37,9 +38,25 @@ _ONE_ROW = finelog_result(t=[datetime(2026, 7, 17, 3, 0, tzinfo=UTC)], value=[1.
 class FakeSource:
     """A MetricSource that records the SQL it is handed and replays a canned table."""
 
-    def __init__(self, table: pa.Table | None = None, raises: Exception | None = None) -> None:
+    def __init__(
+        self,
+        table: pa.Table | None = None,
+        raises: Exception | None = None,
+        health: FinelogHealth | None = None,
+    ) -> None:
         self._table = table if table is not None else pa.table({})
         self._raises = raises
+        self._health = health or FinelogHealth(
+            cluster="marin",
+            server="finelog-marin",
+            role=FinelogRole.HUB,
+            responsive=True,
+            ready=1,
+            desired=1,
+            latency_ms=12,
+            error_class="",
+            error="",
+        )
         self.queries: list[str] = []
 
     @property
@@ -52,11 +69,21 @@ class FakeSource:
             raise self._raises
         return self._table
 
+    def health(self) -> FinelogHealth:
+        return self._health
 
-def _client(source: FakeSource, cache_ttl: float = 20.0) -> TestClient:
+
+def _client(source: FakeSource, cache_ttl: float = 20.0, k8s_fleet: K8sFleet | None = None) -> TestClient:
     github = GithubSource(token=None, timeout=5.0)
     return TestClient(
-        create_app(bridge_config(cache_ttl), {"marin": source}, {}, github, K8sFleet(()), WandbSource(timeout=5.0))
+        create_app(
+            bridge_config(cache_ttl),
+            {"marin": source},
+            {},
+            github,
+            k8s_fleet or K8sFleet(()),
+            WandbSource(timeout=5.0),
+        )
     )
 
 
@@ -157,6 +184,55 @@ def test_unparseable_labels_cell_keeps_the_row():
 
 def test_health_lists_configured_clusters():
     assert _client(FakeSource()).get("/health").json() == {"status": "ok", "clusters": ["marin"]}
+
+
+def test_finelog_fleet_health_combines_the_main_hub_and_k8s_mirrors():
+    fleet = K8sFleet([make_k8s_source(k8s_api(healthy_k8s_routes()))])
+
+    rows = _client(FakeSource(), k8s_fleet=fleet).get("/finelog/marin/fleet_health").json()
+
+    assert [(row["cluster"], row["server"], row["role"], row["responsive"]) for row in rows] == [
+        ("marin", "finelog-marin", "hub", True),
+        ("cw-a", "finelog-cw-a", "mirror", True),
+    ]
+
+
+def test_finelog_fleet_alert_marks_slow_and_unresponsive_servers():
+    slow_hub = FakeSource(
+        health=FinelogHealth(
+            cluster="marin",
+            server="finelog-marin",
+            role=FinelogRole.HUB,
+            responsive=True,
+            ready=1,
+            desired=1,
+            latency_ms=5000,
+            error_class="",
+            error="",
+        )
+    )
+    routes = healthy_k8s_routes()
+    routes[FINELOG_DEPLOYMENTS_PATH] = [deployment("iris", "finelog-cw-a", ready=0, containers=("finelog",))]
+    fleet = K8sFleet([make_k8s_source(k8s_api(routes))])
+
+    assert _client(slow_hub, k8s_fleet=fleet).get("/finelog/marin/alerts/fleet_health").json() == [
+        {
+            "cluster": "marin",
+            "server": "finelog-marin",
+            "role": "hub",
+            "state": "slow",
+            "error_class": "",
+            "value": 1,
+        },
+        {
+            "cluster": "cw-a",
+            "server": "finelog-cw-a",
+            "role": "mirror",
+            "state": "unresponsive",
+            "error_class": "readiness",
+            "value": 1,
+        },
+    ]
 
 
 def test_workload_overview_counts_issue_rows_and_keeps_explicit_zeros():

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 import httpx
 import pytest
 from conftest import (
+    FINELOG_DEPLOYMENTS_PATH,
     IRIS_DEPLOY,
     KUEUE_DEPLOY,
     KUEUE_SLICES,
@@ -21,6 +22,7 @@ from conftest import (
     node,
     pod,
 )
+from finelog_health import FinelogRole
 from github_source import GithubSource
 from k8s_source import K8sError, K8sErrorClass, K8sFleet
 from server import create_app
@@ -421,6 +423,40 @@ def test_fleet_stamps_cluster_and_keeps_healthy_clusters_on_partial_failure():
     (error_row,) = [row for row in rows if row["cluster"] == "cw-b"]
     assert error_row["error_class"] == "auth"
     assert "403" in error_row["error"]
+
+
+def test_finelog_health_reports_http_probe_readiness_for_each_mirror():
+    fleet = _fleet(("cw-a", k8s_api(healthy_k8s_routes())))
+
+    (health,) = fleet.finelog_health()
+    assert (health.cluster, health.server, health.role) == ("cw-a", "finelog-cw-a", FinelogRole.MIRROR)
+    assert health.responsive is True
+    assert (health.ready, health.desired, health.error_class) == (1, 1, "")
+
+
+def test_finelog_health_reports_not_ready_and_k8s_api_failures():
+    routes = healthy_k8s_routes()
+    routes[FINELOG_DEPLOYMENTS_PATH] = [deployment("iris", "finelog-cw-a", ready=0, containers=("finelog",))]
+    fleet = _fleet(("cw-a", k8s_api(routes)), ("cw-b", _forbidden))
+
+    health = fleet.finelog_health()
+    assert [(row.cluster, row.server, row.responsive, row.error_class) for row in health] == [
+        ("cw-a", "finelog-cw-a", False, "readiness"),
+        ("cw-b", "finelog-mirror", False, "auth"),
+    ]
+
+
+def test_finelog_health_reports_missing_deployment():
+    routes = healthy_k8s_routes()
+    routes[FINELOG_DEPLOYMENTS_PATH] = []
+
+    (health,) = _fleet(("cw-a", k8s_api(routes))).finelog_health()
+    assert (health.cluster, health.server, health.responsive, health.error_class) == (
+        "cw-a",
+        "finelog-mirror",
+        False,
+        "discovery",
+    )
 
 
 def test_alert_gpu_rack_trays_maps_trays_ready_to_value():

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -14,6 +14,7 @@ import yaml
 from config import ClusterTarget
 from conftest import bridge_config, healthy_k8s_routes, k8s_api, make_k8s_source
 from dashboard_stitch import stitch_all
+from finelog_health import FinelogHealth, FinelogRole
 from github_source import GithubSource
 from k8s_source import K8sFleet
 from server import create_app
@@ -84,14 +85,33 @@ class _FakeIris:
         return [{"reachable": True, "up": 1, "latency_ms": 3}]
 
 
+class _FakeFinelog:
+    def __init__(self, name: str) -> None:
+        self.target = ClusterTarget(name=name, project="p", zone="z", instance_filter="f", controller_filter="c")
+
+    def health(self) -> FinelogHealth:
+        return FinelogHealth(
+            cluster=self.target.name,
+            server=f"finelog-{self.target.name}",
+            role=FinelogRole.HUB,
+            responsive=True,
+            ready=1,
+            desired=1,
+            latency_ms=3,
+            error_class="",
+            error="",
+        )
+
+
 def test_every_rule_query_url_answers_on_the_bridge():
     """Join each rule's datasource base path with its query URL and GET it for real."""
     iris_sources = {name: _FakeIris(name) for name in ("marin", "marin-dev")}
+    finelog_sources = {"marin": _FakeFinelog("marin")}
     fleet = K8sFleet([make_k8s_source(k8s_api(healthy_k8s_routes()))])
     client = TestClient(
         create_app(
             bridge_config(),
-            {},
+            finelog_sources,
             iris_sources,
             GithubSource(token=None, timeout=5.0),
             fleet,
@@ -138,6 +158,26 @@ def test_critical_contact_point_reaches_email_and_slack():
         for receiver in point["receivers"]:
             if receiver["type"] == "slack":
                 assert receiver["settings"]["url"] == "$SLACK_ALERTS_WEBHOOK"
+
+
+def test_finelog_health_alert_pages_critical_after_five_minutes():
+    (rule,) = [rule for rule in _rules() if rule["uid"] == "finelog-fleet-unhealthy"]
+    assert rule["for"] == "5m"
+    assert rule["labels"]["severity"] == "critical"
+    assert rule["data"][0]["datasourceUid"] == "finelog-marin"
+    assert rule["data"][0]["model"]["url"] == "/alerts/fleet_health"
+
+
+def test_k8s_dashboard_shows_finelog_fleet_health():
+    dashboard = _stitched_dashboards()["k8s.json"]
+    (panel,) = [
+        panel
+        for panel in dashboard["panels"]
+        if any(target.get("url") == "/fleet_health" for target in panel.get("targets", []))
+    ]
+    assert panel["datasource"]["uid"] == "finelog-marin"
+    selectors = {column["selector"] for column in panel["targets"][0]["columns"]}
+    assert {"cluster", "server", "responsive", "ready", "desired", "latency_ms"} <= selectors
 
 
 def test_dashboard_filter_expressions_reference_selected_columns():

--- a/infra/grafana/tests/test_sources.py
+++ b/infra/grafana/tests/test_sources.py
@@ -1,19 +1,18 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the live Iris and GitHub sources and their bridge endpoints.
-
-The sources are driven over an httpx MockTransport so the real RPC/REST parsing,
-aggregation, and error mapping run without a controller or GitHub.
-"""
+"""Behavioral tests for live finelog, Iris, GitHub, and W&B bridge sources."""
 
 import json
 
 import httpx
+import pyarrow as pa
 import pytest
 from config import ClusterTarget
 from conftest import bridge_config
 from errors import UpstreamError
+from finelog_health import FinelogRole
+from finelog_source import FinelogSource
 from github_source import GithubSource
 from iris_source import IrisSource
 from k8s_source import K8sFleet
@@ -42,6 +41,44 @@ def _wandb(handler) -> WandbSource:
     source = WandbSource(timeout=5.0)
     source._client = httpx.Client(transport=httpx.MockTransport(handler), headers=source._client.headers)
     return source
+
+
+class _FakeLogClient:
+    def __init__(self, raises: Exception | None = None) -> None:
+        self._raises = raises
+
+    def query(self, sql: str, *, max_rows: int) -> pa.Table:
+        assert sql == 'SELECT * FROM "log" LIMIT 1'
+        assert max_rows == 1
+        if self._raises is not None:
+            raise self._raises
+        return pa.table({"1": [1]})
+
+
+def _finelog(raises: Exception | None = None) -> FinelogSource:
+    source = FinelogSource(TARGET, timeout_ms=5_000)
+    source._client = _FakeLogClient(raises)
+    return source
+
+
+def test_finelog_health_probes_the_log_query_path():
+    row = _finelog().health()
+    assert isinstance(row.latency_ms, int)
+    assert (row.cluster, row.server, row.role) == ("marin", "finelog-marin", FinelogRole.HUB)
+    assert row.responsive is True
+    assert (row.ready, row.desired, row.error_class) == (1, 1, "")
+
+
+def test_finelog_health_reports_query_failures_without_raising():
+    row = _finelog(TimeoutError("slow")).health()
+    assert (row.cluster, row.server, row.role) == ("marin", "finelog-marin", FinelogRole.HUB)
+    assert row.responsive is False
+    assert (row.ready, row.desired, row.latency_ms, row.error_class) == (0, 1, None, "TimeoutError")
+
+
+def test_finelog_health_does_not_mask_programming_errors():
+    with pytest.raises(ValueError, match="bug"):
+        _finelog(ValueError("bug")).health()
 
 
 # --- IrisSource ------------------------------------------------------------

--- a/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
+++ b/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
@@ -80,18 +80,20 @@ spec:
               cpu: "2"
               memory: "32Gi"
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /health
               port: {{ port }}
             initialDelaySeconds: 15
             periodSeconds: 30
-            timeoutSeconds: 5
+            timeoutSeconds: 15
             failureThreshold: 3
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /health
               port: {{ port }}
             initialDelaySeconds: 5
             periodSeconds: 10
-            timeoutSeconds: 5
+            timeoutSeconds: 15
             failureThreshold: 3
       volumes:
         - name: cache

--- a/lib/finelog/tests/test_deploy_k8s.py
+++ b/lib/finelog/tests/test_deploy_k8s.py
@@ -10,6 +10,7 @@ from dataclasses import replace
 
 import click
 import pytest
+import yaml
 from finelog.deploy._k8s import (
     _K8S_MANIFEST_DIR,
     _MANIFESTS,
@@ -128,6 +129,26 @@ def test_forwarding_signing_key_never_leaves_the_secret(monkeypatch: pytest.Monk
 
     for manifest_name in _MANIFESTS:
         assert "SEKRIT" not in _render_manifest(_K8S_MANIFEST_DIR / manifest_name, cfg)
+
+
+def test_deployment_probes_the_http_health_endpoint() -> None:
+    deployment = yaml.safe_load(_render_manifest(_K8S_MANIFEST_DIR / "02-deployment.yaml.tmpl", _forwarding_cfg()))
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+
+    assert container["readinessProbe"] == {
+        "httpGet": {"path": "/health", "port": 10001},
+        "initialDelaySeconds": 5,
+        "periodSeconds": 10,
+        "timeoutSeconds": 15,
+        "failureThreshold": 3,
+    }
+    assert container["livenessProbe"] == {
+        "httpGet": {"path": "/health", "port": 10001},
+        "initialDelaySeconds": 15,
+        "periodSeconds": 30,
+        "timeoutSeconds": 15,
+        "failureThreshold": 3,
+    }
 
 
 def test_env_secret_carries_both_s3_credentials_and_signing_key(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Read one row from the marin finelog `log` namespace to exercise the rotated-log query path, and expose CoreWeave mirror readiness on the K8s dashboard. Kubernetes calls `/health` for finelog readiness and liveness; the Grafana bridge discovers each mirror through the read-only Kubernetes API without service-proxy access.

Alert after five minutes when the hub query fails or takes at least five seconds, a mirror stays NotReady, mirror discovery fails, or the health datasource fails. The critical route uses the existing Slack and email contact point.
