### PR TITLE
[finelog] Stabilize Kubernetes mirrors under ingest bursts

### DIFF
--- a/.agents/ops/2026-07-23-finelog-rno2a-readiness-loop.md
+++ b/.agents/ops/2026-07-23-finelog-rno2a-readiness-loop.md
@@ -1,0 +1,63 @@
+---
+date: 2026-07-23
+system: finelog
+severity: degraded
+resolution: mitigated
+pr: https://github.com/marin-community/marin/pull/7540
+issue: none
+---
+
+## TL;DR
+
+- RNO2A recorded six liveness restarts and 79 readiness failures in roughly three hours during concurrent ingest and large compactions.
+- Exit 137 came from kubelet liveness termination, not an OOM: cgroup counters showed zero OOM kills and memory peaked at 12.4 GB under a 32 GiB limit.
+- The 250 GiB PVC was 1% full. More disk capacity would not address the failure.
+- A live patch raised reserved compute, added a five-minute startup probe, and moved all probes to HTTP `/health`; the replacement pod remained Ready with zero restarts.
+- Global Kubernetes defaults, a dedicated Grafana dashboard, the readiness runbook, and a startup/PVC research brief were proposed in PR #7540.
+
+## Original problem report
+
+The RNO2A finelog mirror intermittently reported `HTTP /health probe is not Ready`. The request was to determine whether the server was overloaded, apply a targeted live fix, raise global Kubernetes provisioning where justified, investigate CoreWeave PVC and startup performance, add a Grafana debugging view, and open a pull request.
+
+## Investigation path
+
+1. The live Deployment and pod were inspected with the explicit RNO2A kubeconfig and context. The old pod had restarted nine times and retained TCP liveness and readiness probes with a 500m CPU request, 2 CPU limit, 4 GiB memory request, and 32 GiB memory limit.
+2. Pod events showed six liveness kills and 79 readiness failures over roughly three hours. Previous logs showed concurrent `WriteRows` calls taking 8–24 seconds while multi-million-row compactions ran.
+3. Exit 137 was compared with kubelet events and `/sys/fs/cgroup/memory.events`. The kubelet explicitly killed the container after failed liveness probes; `oom` and `oom_kill` were both zero.
+4. Current and peak memory, filesystem use, and node capacity were measured. Memory peaked at 12.4 GB, the PVC used 2.5 of 250 GiB, and the 192-CPU control node had substantial unreserved compute and memory.
+5. Earlier restart logs showed 85–95 seconds before the listener bound, while liveness began after 15 seconds. The probe policy amplified a transient stall into repeated cold starts.
+6. The Deployment was patched in place to request 2 CPUs and 16 GiB, allow 8 CPUs and 32 GiB, add a five-minute HTTP startup probe, and use HTTP `/health` for liveness and readiness. The rollout completed without changing the PVC or Secret.
+7. The replacement pod started at 02:20:49 UTC and logged its listener at 02:21:17.415 UTC, about 28.4 seconds later. It remained Ready with zero restarts through the final check.
+8. The mounted VAST/NFS volume and finelog startup code were inspected. Warm metadata and small-read probes were much shorter than startup, while `Namespace::open` performed a standalone SQLite catalog upsert for every adopted segment. Batching those writes became the highest-priority follow-up experiment.
+
+## User course corrections
+
+- The user asked for a targeted server patch before the configuration change, so the safe probe and resource patch was applied and verified live first.
+- The user broadened the provisioning change from RNO2A to global Kubernetes finelog defaults, so no cluster-specific override was added.
+- The user requested an investigation rather than an immediate storage migration, so PVC options and falsifiable experiments were recorded without changing durability or storage products.
+- The user added a dedicated Grafana dashboard requirement, so pod, resource, probe, PVC, fleet-health, and warning-event diagnostics were included in the same pull request.
+
+## Root cause
+
+Concurrent ingest and large compactions intermittently delayed the health endpoint long enough to fail readiness and liveness. The liveness policy then killed the process during both overload and slow store reopening, creating a restart loop. Memory exhaustion, PVC capacity, and node capacity were excluded.
+
+The remaining 28–95 second startup time was not fully isolated. The leading hypothesis was hundreds of implicit SQLite catalog transactions over the shared VAST/NFS volume, based on the startup code path and live file count. Phase timers and a batched transaction experiment were still required to confirm it.
+
+## Fix
+
+The live RNO2A Deployment was patched to request 2 CPUs and 16 GiB of memory, allow 8 CPUs and 32 GiB, and defer liveness and readiness until a five-minute HTTP startup probe succeeded. PR #7540 applied those values as the global Kubernetes finelog defaults, kept per-cluster overrides available, added the dedicated Grafana dashboard, and documented the diagnostic procedure.
+
+## How OPS.md could have shortened this
+
+The previous runbook did not explain that exit 137 could be a liveness kill, nor did it list cgroup OOM counters, peak memory, PVC use, and previous logs as the first decision points. The added readiness section now provides those commands and directs operators to compare ingest/compaction stalls with probe events before increasing memory or storage.
+
+Startup phase timing was still absent from the server. Timers around catalog open, local segment adoption, catalog refresh, and engine rehydration would have separated storage latency from SQLite transaction overhead without inferring from aggregate startup time.
+
+## Artifacts
+
+- Pull request: https://github.com/marin-community/marin/pull/7540
+- Session: https://loom.rjp.io/s/cy3crgzz
+- Startup and PVC research: `.agents/projects/finelog-pvc-startup/research.md`
+- Updated runbook: `lib/finelog/OPS.md`
+- Grafana dashboard: `infra/grafana/dashboards/finelog.json`
+- Final live pod: `finelog-cw-rno2a-5d99f7b464-x956q`, Ready with zero restarts

--- a/.agents/ops/2026-07-23-finelog-rno2a-readiness-loop.md
+++ b/.agents/ops/2026-07-23-finelog-rno2a-readiness-loop.md
@@ -13,7 +13,7 @@ issue: none
 - Exit 137 came from kubelet liveness termination, not an OOM: cgroup counters showed zero OOM kills and memory peaked at 12.4 GB under a 32 GiB limit.
 - The 250 GiB PVC was 1% full. More disk capacity would not address the failure.
 - A live patch raised reserved compute, added a five-minute startup probe, and moved all probes to HTTP `/health`; the replacement pod remained Ready with zero restarts.
-- Global Kubernetes defaults, a dedicated Grafana dashboard, the readiness runbook, and a startup/PVC research brief were proposed in PR #7540.
+- Global Kubernetes defaults, startup phase logging and batching, a dedicated Grafana dashboard, the readiness runbook, and a startup/PVC research brief were proposed in PR #7540.
 
 ## Original problem report
 
@@ -41,17 +41,17 @@ The RNO2A finelog mirror intermittently reported `HTTP /health probe is not Read
 
 Concurrent ingest and large compactions intermittently delayed the health endpoint long enough to fail readiness and liveness. The liveness policy then killed the process during both overload and slow store reopening, creating a restart loop. Memory exhaustion, PVC capacity, and node capacity were excluded.
 
-The remaining 28–95 second startup time was not fully isolated. The leading hypothesis was hundreds of implicit SQLite catalog transactions over the shared VAST/NFS volume, based on the startup code path and live file count. Phase timers and a batched transaction experiment were still required to confirm it.
+The remaining 28–95 second startup time was not fully isolated. The leading hypothesis was hundreds of implicit SQLite catalog transactions over the shared VAST/NFS volume, based on the startup code path and live file count. PR #7540 added phase timers, batched those writes, and removed a duplicate footer scan so the next deployment could confirm or falsify it.
 
 ## Fix
 
-The live RNO2A Deployment was patched to request 2 CPUs and 16 GiB of memory, allow 8 CPUs and 32 GiB, and defer liveness and readiness until a five-minute HTTP startup probe succeeded. PR #7540 applied those values as the global Kubernetes finelog defaults, kept per-cluster overrides available, added the dedicated Grafana dashboard, and documented the diagnostic procedure.
+The live RNO2A Deployment was patched to request 2 CPUs and 16 GiB of memory, allow 8 CPUs and 32 GiB, and defer liveness and readiness until a five-minute HTTP startup probe succeeded. PR #7540 applied those values as the global Kubernetes finelog defaults, kept per-cluster overrides available, batched startup catalog writes, removed a duplicate footer scan, selected network-safe persistent rollback journaling, added structured startup timings and the dedicated Grafana dashboard, and documented the diagnostic procedure.
 
 ## How OPS.md could have shortened this
 
 The previous runbook did not explain that exit 137 could be a liveness kill, nor did it list cgroup OOM counters, peak memory, PVC use, and previous logs as the first decision points. The added readiness section now provides those commands and directs operators to compare ingest/compaction stalls with probe events before increasing memory or storage.
 
-Startup phase timing was still absent from the server. Timers around catalog open, local segment adoption, catalog refresh, and engine rehydration would have separated storage latency from SQLite transaction overhead without inferring from aggregate startup time.
+Startup phase timing had been absent from the server. PR #7540 added timers around catalog open, local segment adoption, footer reconciliation, catalog refresh, engine rehydration, and remote reconcile so subsequent incidents could separate storage latency from SQLite transaction overhead.
 
 ## Artifacts
 

--- a/.agents/projects/finelog-pvc-startup/research.md
+++ b/.agents/projects/finelog-pvc-startup/research.md
@@ -16,7 +16,9 @@ The live resource patch restarted RNO2A at 02:20:49 UTC. The server logged `fine
 
 ## Internal Prior Work
 
-`lib/finelog/rust/src/store/namespace.rs` adopts local segments during `Namespace::open`, then calls `catalog.upsert_segment` once for every adopted segment. `lib/finelog/rust/src/store/catalog.rs` executes each upsert as a standalone SQLite statement. On an NFS-backed SQLite database, routine startup can therefore issue hundreds of implicit commits and synchronous filesystem operations before the listener binds.
+Before PR #7540, `lib/finelog/rust/src/store/namespace.rs` adopted local segments during `Namespace::open`, then called `catalog.upsert_segment` once for every adopted segment. `lib/finelog/rust/src/store/catalog.rs` executed each upsert as a standalone SQLite statement. On an NFS-backed SQLite database, routine startup could therefore issue hundreds of implicit commits and synchronous filesystem operations before the listener bound.
+
+PR #7540 changes that path to one transaction per namespace, eliminates a second full Parquet-footer scan that only recomputed `next_seq`, selects SQLite's rollback-journal `PERSIST` mode with `synchronous=FULL`, and emits structured phase timings. WAL remains disabled because SQLite requires WAL clients to share a memory index and explicitly does not support WAL over network filesystems.
 
 Iris already keeps its CoreWeave controller SQLite state on node-local NVMe through `storage.local_state_dir`; `lib/iris/docs/coreweave.md` documents that `/mnt/local` is the bare-metal node's NVMe RAID. Finelog differs because its PVC provides node-independent persistence for active segments that have not yet reached object storage.
 
@@ -49,7 +51,7 @@ CoreWeave recommends larger object-store requests and notes that LOTA caches obj
   - No phase timers or syscall trace yet prove how much time is spent in catalog commits.
 - Directness to Marin: exact live dataset, deployment, PVC, and startup code path.
 - Confidence: high inference, not yet experimentally isolated.
-- Action: add phase timing and batch catalog refresh in one transaction.
+- Action: deploy PR #7540 and compare its new phase timings with the 28.4-second baseline.
 
 ### Claim: a larger PVC will not make this deployment faster
 
@@ -64,10 +66,10 @@ CoreWeave recommends larger object-store requests and notes that LOTA caches obj
 
 ## Recommended Next Experiments
 
-### 1. Batch startup catalog refresh
+### 1. Measure the batched startup path
 
-- Minimum experiment: add timers for catalog open, local adoption, catalog refresh, and engine rehydration; refresh all adopted segment rows in one SQLite transaction.
-- Baseline/control: five cold restarts from identical copied stores on `shared-vast`, current build versus batched build.
+- Minimum experiment: run five controlled restarts of PR #7540 and record catalog open, local adoption, footer reconciliation, catalog refresh, namespace rehydration, and total store timings.
+- Baseline/control: the observed 28.4-second restart and five restarts from an identical copied store on `shared-vast` using the prior build.
 - Expected signal: at least 50% lower container-start-to-listener-bind time and one catalog commit per startup or namespace instead of one per segment.
 - Falsifier: startup improves less than 20% and the footer/adoption phase remains dominant.
 - Cost/risk: low implementation cost; preserve FULL durability and crash-safe transaction semantics.
@@ -106,7 +108,7 @@ CoreWeave recommends larger object-store requests and notes that LOTA caches obj
 - Add: intermittent VAST metadata contention explains the 28-95 second spread after transaction count is controlled.
 - Add: remote small-object layout limits LOTA during cold recovery.
 - Falsify / stop: increasing PVC capacity as a performance fix.
-- Promote: batched catalog refresh and phase timing.
+- Promote: deploy and measure the batched catalog refresh, single footer pass, and phase timing in PR #7540.
 
 ## Source Ledger
 
@@ -127,6 +129,6 @@ CoreWeave recommends larger object-store requests and notes that LOTA caches obj
 
 ## Handoff
 
-- Suggested issue title: `[finelog] Batch startup catalog refresh on network filesystems`
-- Open questions: exact phase timing; number of SQLite syncs; VAST `qos_wait`; remote object-size distribution; acceptable durability model for a local-NVMe active cache.
+- Suggested issue title: `[finelog] Benchmark startup catalog refresh on shared VAST`
+- Open questions: measured phase timing after PR #7540; VAST `qos_wait`; remote object-size distribution; acceptable durability model for a local-NVMe active cache.
 - Stop reason: internal code, live measurements, installed StorageClasses, and primary external sources converge on a falsifiable first experiment.

--- a/.agents/projects/finelog-pvc-startup/research.md
+++ b/.agents/projects/finelog-pvc-startup/research.md
@@ -1,0 +1,132 @@
+# Background Research Brief
+
+- Effort: medium
+- Stop rule: stop after the live measurements, Marin code, available cluster storage classes, and primary storage documentation converge on a ranked experiment.
+- Date: 2026-07-23
+
+## Question
+
+Why does a CoreWeave finelog mirror need 28-95 seconds to bind its listener after a restart, and which storage or finelog changes can reduce that recovery time?
+
+## Current Marin Context
+
+RNO2A stores the finelog cache on a 250 GiB `shared-vast` PVC. The volume held 2.5 GiB across 315 segment files and was 1% full during the incident. The PV is NFSv3 with `nconnect=32`, multiple VAST remote ports, `lookupcache=pos`, `noatime`, and `noacl`. All three Marin CoreWeave clusters expose only the `shared-vast` StorageClass; no persistent SSD or block class is selectable today.
+
+The live resource patch restarted RNO2A at 02:20:49 UTC. The server logged `finelog-server listening` at 02:21:17.415 UTC, about 28.4 seconds later. Warm read-only probes took 0.244 seconds to `stat` every local file and 1.30 seconds to read 8 KiB from every file. Earlier liveness-driven restarts took 85-95 seconds before bind.
+
+## Internal Prior Work
+
+`lib/finelog/rust/src/store/namespace.rs` adopts local segments during `Namespace::open`, then calls `catalog.upsert_segment` once for every adopted segment. `lib/finelog/rust/src/store/catalog.rs` executes each upsert as a standalone SQLite statement. On an NFS-backed SQLite database, routine startup can therefore issue hundreds of implicit commits and synchronous filesystem operations before the listener binds.
+
+Iris already keeps its CoreWeave controller SQLite state on node-local NVMe through `storage.local_state_dir`; `lib/iris/docs/coreweave.md` documents that `/mnt/local` is the bare-metal node's NVMe RAID. Finelog differs because its PVC provides node-independent persistence for active segments that have not yet reached object storage.
+
+## External Prior Art
+
+CoreWeave documents `emptyDir` and `hostPath` as node-local NVMe options. `emptyDir` is erased with the pod; `hostPath` survives pod replacement on the same node but couples data to that node. CoreWeave's distributed file storage documentation identifies `shared-vast` as the general PVC path. Dedicated VAST storage can provide block access and custom QoS, but it is a separately provisioned product rather than a StorageClass currently present in these clusters.
+
+VAST QoS can prioritize metadata operations and define minimum, maximum, or burst throughput. The live PV has no attached QoS policy. Increasing a PVC's requested capacity has no established performance effect without a capacity-based QoS policy.
+
+CoreWeave recommends larger object-store requests and notes that LOTA caches objects above 4 MiB. Remote recovery that touches many small segment objects will not benefit fully from LOTA. SQLite's documentation warns that WAL is unsuitable on general network filesystems; batching rollback-journal transactions is the safer first change.
+
+## Negative / Failed Leads
+
+- The PVC is 99% free, so capacity exhaustion is excluded.
+- The container recorded zero cgroup OOM kills and peaked below its 32 GiB limit. More memory does not address pre-bind filesystem work.
+- Warm metadata and small-read probes are much shorter than startup. Raw footer reads alone do not explain the 28.4-second interval.
+- The current NFS mount already uses connection spreading and metadata-friendly options. Mount tuning has little obvious headroom and cannot remove SQLite commit round trips.
+- Switching SQLite to WAL is not a valid general NFS optimization.
+
+## Evidence Map
+
+### Claim: standalone startup catalog upserts are the leading bottleneck
+
+- Support:
+  - Marin code: one `catalog.upsert_segment` call per adopted segment in `Namespace::open`.
+  - Live RNO2A: about 315 local segment files and 28.4 seconds before bind.
+  - Warm storage probes: 0.244 seconds for metadata and 1.30 seconds for 8 KiB per file.
+  - SQLite: a standalone write statement opens an implicit transaction; default synchronous rollback-journal behavior can require filesystem synchronization.
+- Contradictions:
+  - No phase timers or syscall trace yet prove how much time is spent in catalog commits.
+- Directness to Marin: exact live dataset, deployment, PVC, and startup code path.
+- Confidence: high inference, not yet experimentally isolated.
+- Action: add phase timing and batch catalog refresh in one transaction.
+
+### Claim: a larger PVC will not make this deployment faster
+
+- Support:
+  - The PVC is 1% full.
+  - The PV has no QoS policy; VAST documents capacity-based performance only when that QoS mode is configured.
+- Contradictions:
+  - CoreWeave could apply undocumented tenant-level policies outside the PV manifest.
+- Directness to Marin: exact live PV and StorageClass.
+- Confidence: high.
+- Action: request view-level latency and `qos_wait` data from CoreWeave before changing storage size.
+
+## Recommended Next Experiments
+
+### 1. Batch startup catalog refresh
+
+- Minimum experiment: add timers for catalog open, local adoption, catalog refresh, and engine rehydration; refresh all adopted segment rows in one SQLite transaction.
+- Baseline/control: five cold restarts from identical copied stores on `shared-vast`, current build versus batched build.
+- Expected signal: at least 50% lower container-start-to-listener-bind time and one catalog commit per startup or namespace instead of one per segment.
+- Falsifier: startup improves less than 20% and the footer/adoption phase remains dominant.
+- Cost/risk: low implementation cost; preserve FULL durability and crash-safe transaction semantics.
+- Sources: Marin `namespace.rs` and `catalog.rs`; SQLite transaction and pragma documentation.
+
+### 2. Compare shared VAST with node-local NVMe
+
+- Minimum experiment: mount an `emptyDir` on the same CPU node, copy the same store, and run repeated startup probes without production traffic.
+- Baseline/control: identical image, CPU limit, store contents, and node; only filesystem differs.
+- Expected signal: NVMe isolates the filesystem contribution to startup.
+- Falsifier: NVMe startup is within 20% of VAST after catalog batching.
+- Cost/risk: diagnostic only. Do not cut production to `emptyDir`; it loses data on pod or node replacement.
+- Sources: CoreWeave local storage documentation; Marin CoreWeave runbook.
+
+### 3. Measure and prioritize the VAST view
+
+- Minimum experiment: ask CoreWeave for metadata latency, IOPS, and `qos_wait` for VAST view `110833` / quota `110935` during restart windows; request a trial prioritized view if contention appears.
+- Baseline/control: restart latency and VAST counters before and during the trial.
+- Expected signal: lower tail startup time when `qos_wait` or metadata latency was previously elevated.
+- Falsifier: `qos_wait` remains near zero and storage latency does not correlate with slow boots.
+- Cost/risk: provider coordination and possible storage cost.
+- Sources: VAST QoS and connection-balancing documentation.
+
+### 4. Increase remote segment size
+
+- Minimum experiment: inventory remote object sizes and count footer/object requests during reconcile; compact objects toward at least 15 MiB where retention/query behavior permits.
+- Baseline/control: reconcile request count, bytes, and elapsed time before and after compaction tuning.
+- Expected signal: fewer requests and higher LOTA hit usefulness for objects above 4 MiB.
+- Falsifier: remote reconcile is already background-only and contributes no readiness delay, or objects already exceed the thresholds.
+- Cost/risk: compaction CPU and altered query granularity.
+- Sources: CoreWeave object-storage best practices.
+
+## Hypothesis Queue Update
+
+- Add: implicit SQLite transaction count dominates routine NFS startup.
+- Add: intermittent VAST metadata contention explains the 28-95 second spread after transaction count is controlled.
+- Add: remote small-object layout limits LOTA during cold recovery.
+- Falsify / stop: increasing PVC capacity as a performance fix.
+- Promote: batched catalog refresh and phase timing.
+
+## Source Ledger
+
+| Source | Type | Location | Claim used for | Confidence | Notes |
+|---|---|---|---|---|---|
+| Finelog namespace startup | Marin code | `lib/finelog/rust/src/store/namespace.rs` | one catalog upsert per adopted segment | high | exact current code |
+| Finelog catalog | Marin code | `lib/finelog/rust/src/store/catalog.rs` | standalone SQLite writes | high | exact current code |
+| CoreWeave local storage | official docs | https://docs.coreweave.com/products/storage/local-storage | NVMe `emptyDir` and `hostPath` lifecycle | high | current product docs |
+| CoreWeave storage overview | official docs | https://docs.coreweave.com/products/storage | available storage families | high | current product docs |
+| Distributed file storage | official docs | https://docs.coreweave.com/products/storage/distributed-file-storage/create-volumes | `shared-vast` PVC behavior | high | current product docs |
+| Object storage performance | official docs | https://docs.coreweave.com/products/storage/object-storage/improving-performance/best-practices | small-object and LOTA thresholds | high | current product docs |
+| Dedicated VAST release | official docs | https://docs.coreweave.com/changelog/release-notes/dedicated-vast-storage | block access and custom QoS option | medium | separate product availability requires provider confirmation |
+| VAST QoS overview | vendor docs | https://kb.vastdata.com/documentation/docs/qos-overview-3 | metadata QoS and capacity-based policies | high | live PV has no policy in its manifest |
+| VAST client balancing | vendor docs | https://kb.vastdata.com/docs/client-to-protocol-server-cnode-balancing | connection/VIP tuning | high | live mount already uses multiple remote ports |
+| SQLite over networks | official docs | https://www.sqlite.org/useovernet.html | WAL/network-filesystem caveat | high | rules out a tempting shortcut |
+| SQLite pragmas | official docs | https://sqlite.org/pragma.html | journal and synchronous defaults | high | behavior should be confirmed against runtime connection settings |
+| SQLite transactions | official docs | https://www.sqlite.org/lang_transaction.html | implicit transaction per standalone statement | high | explains commit count |
+
+## Handoff
+
+- Suggested issue title: `[finelog] Batch startup catalog refresh on network filesystems`
+- Open questions: exact phase timing; number of SQLite syncs; VAST `qos_wait`; remote object-size distribution; acceptable durability model for a local-NVMe active cache.
+- Stop reason: internal code, live measurements, installed StorageClasses, and primary external sources converge on a falsifiable first experiment.

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -39,6 +39,7 @@ GET /wandb/{train-loss,paloma-macro-loss,mfu}      public report runset and samp
 GET /k8s/control_plane | crashloops | pending     CW control-plane state, all clusters
 GET /k8s/termination_candidates | kueue | events | health
                                                     ... one response, `cluster` column
+GET /k8s/finelog | finelog_events                 mirror pods/PVCs and matching warnings
 GET /k8s/overview                                 explicit pending/crashloop counts
 GET /k8s/gpu_racks                                GPU nodes grouped by physical rack: trays total/ready
 GET /k8s/alerts/{unreachable,crashloops,          alert rows: string labels + one
@@ -59,7 +60,9 @@ time column without casting. finelog has JSON SQL UDFs, so a panel groups by a l
 
 `fleet_health` reads one row from `finelog-marin`'s `log` namespace and combines that
 result with the three CoreWeave mirror Deployments' HTTP-readiness state. A hub query
-at or above 5 seconds is slow.
+at or above 5 seconds is slow. The dedicated finelog dashboard adds effective pod
+resources, restart history, probe presence, node placement, PVC class/capacity, and
+recent matching Kubernetes Warning events.
 
 Iris: the bridge owns each query behind a fixed endpoint and returns flat rows, so the
 dashboard never sends raw admin SQL. `jobs` (root jobs by state — in-flight plus 24h
@@ -155,7 +158,8 @@ health, Kubernetes workload state, and hero training), `fleet.json` (canary +
 worker health), `iris.json`
 (per-task and per-worker resource usage), `pipelines.json` (Zephyr throughput and shard
 memory), `training.json` (levanter training metrics from the `telltale` namespace,
-grouped by run), `k8s.json` (current CW control-plane state from the k8s source).
+grouped by run), `k8s.json` (current CW control-plane state from the k8s source), and
+`finelog.json` (fleet readiness plus mirror pod, probe, resource, and PVC details).
 
 `home.json` is provisioned as the default home dashboard
 (`GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/dashboards/home.json`,

--- a/infra/grafana/dashboards/finelog.json
+++ b/infra/grafana/dashboards/finelog.json
@@ -1,0 +1,352 @@
+{
+  "uid": "marin-finelog",
+  "title": "Finelog",
+  "description": "Finelog fleet health, Kubernetes pod provisioning, restart history, probes, and persistent storage. The fleet table includes the GCE hub and every CoreWeave mirror; pod and PVC details come from the read-only Kubernetes API.",
+  "tags": [
+    "marin",
+    "generated",
+    "finelog"
+  ],
+  "timezone": "utc",
+  "editable": false,
+  "schemaVersion": 42,
+  "refresh": "1m",
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "targetBlank": true,
+      "title": "Finelog runbook",
+      "type": "link",
+      "url": "https://github.com/marin-community/marin/blob/main/lib/finelog/OPS.md"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "K8s",
+      "type": "link",
+      "url": "/d/marin-k8s"
+    }
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "type": "table",
+      "title": "Fleet health",
+      "description": "The hub runs a one-row rotated-log query. Each CoreWeave mirror reports its Deployment readiness, which is driven by HTTP /health probes.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/fleet_health",
+          "url_options": {
+            "method": "GET"
+          },
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "server",
+              "text": "server",
+              "type": "string"
+            },
+            {
+              "selector": "role",
+              "text": "role",
+              "type": "string"
+            },
+            {
+              "selector": "responsive",
+              "text": "responsive",
+              "type": "boolean"
+            },
+            {
+              "selector": "ready",
+              "text": "ready",
+              "type": "number"
+            },
+            {
+              "selector": "desired",
+              "text": "desired",
+              "type": "number"
+            },
+            {
+              "selector": "latency_ms",
+              "text": "latency_ms",
+              "type": "number"
+            },
+            {
+              "selector": "error_class",
+              "text": "error_class",
+              "type": "string"
+            },
+            {
+              "selector": "error",
+              "text": "error",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "table",
+      "title": "Kubernetes pods and storage",
+      "description": "Effective pod placement, restart history, resource requests and limits, probe presence, and PVC provisioning for every CoreWeave finelog mirror.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "k8s"
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/finelog",
+          "url_options": {
+            "method": "GET"
+          },
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "namespace",
+              "text": "namespace",
+              "type": "string"
+            },
+            {
+              "selector": "deployment",
+              "text": "deployment",
+              "type": "string"
+            },
+            {
+              "selector": "pod",
+              "text": "pod",
+              "type": "string"
+            },
+            {
+              "selector": "node",
+              "text": "node",
+              "type": "string"
+            },
+            {
+              "selector": "phase",
+              "text": "phase",
+              "type": "string"
+            },
+            {
+              "selector": "ready",
+              "text": "ready",
+              "type": "boolean"
+            },
+            {
+              "selector": "restarts",
+              "text": "restarts",
+              "type": "number"
+            },
+            {
+              "selector": "last_exit_code",
+              "text": "last_exit_code",
+              "type": "number"
+            },
+            {
+              "selector": "last_exit_reason",
+              "text": "last_exit_reason",
+              "type": "string"
+            },
+            {
+              "selector": "cpu_request",
+              "text": "cpu_request",
+              "type": "string"
+            },
+            {
+              "selector": "cpu_limit",
+              "text": "cpu_limit",
+              "type": "string"
+            },
+            {
+              "selector": "memory_request",
+              "text": "memory_request",
+              "type": "string"
+            },
+            {
+              "selector": "memory_limit",
+              "text": "memory_limit",
+              "type": "string"
+            },
+            {
+              "selector": "startup_probe",
+              "text": "startup_probe",
+              "type": "boolean"
+            },
+            {
+              "selector": "readiness_probe",
+              "text": "readiness_probe",
+              "type": "boolean"
+            },
+            {
+              "selector": "liveness_probe",
+              "text": "liveness_probe",
+              "type": "boolean"
+            },
+            {
+              "selector": "pvc",
+              "text": "pvc",
+              "type": "string"
+            },
+            {
+              "selector": "storage_class",
+              "text": "storage_class",
+              "type": "string"
+            },
+            {
+              "selector": "storage_capacity",
+              "text": "storage_capacity",
+              "type": "string"
+            },
+            {
+              "selector": "image",
+              "text": "image",
+              "type": "string"
+            },
+            {
+              "selector": "error_class",
+              "text": "error_class",
+              "type": "string"
+            },
+            {
+              "selector": "error",
+              "text": "error",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "table",
+      "title": "Recent finelog warning events",
+      "description": "Kubernetes Warning events whose object name or message mentions finelog, newest first. Empty means no matching retained events.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "k8s"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/finelog_events",
+          "url_options": {
+            "method": "GET"
+          },
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "last_seen",
+              "text": "last_seen",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "namespace",
+              "text": "namespace",
+              "type": "string"
+            },
+            {
+              "selector": "object",
+              "text": "object",
+              "type": "string"
+            },
+            {
+              "selector": "reason",
+              "text": "reason",
+              "type": "string"
+            },
+            {
+              "selector": "count",
+              "text": "count",
+              "type": "number"
+            },
+            {
+              "selector": "message",
+              "text": "message",
+              "type": "string"
+            },
+            {
+              "selector": "error_class",
+              "text": "error_class",
+              "type": "string"
+            },
+            {
+              "selector": "error",
+              "text": "error",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/finelog.json
+++ b/infra/grafana/dashboards/finelog.json
@@ -40,83 +40,13 @@
   "panels": [
     {
       "id": 1,
-      "type": "table",
-      "title": "Fleet health",
-      "description": "The hub runs a one-row rotated-log query. Each CoreWeave mirror reports its Deployment readiness, which is driven by HTTP /health probes.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
         "y": 0
       },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/fleet_health",
-          "url_options": {
-            "method": "GET"
-          },
-          "columns": [
-            {
-              "selector": "cluster",
-              "text": "cluster",
-              "type": "string"
-            },
-            {
-              "selector": "server",
-              "text": "server",
-              "type": "string"
-            },
-            {
-              "selector": "role",
-              "text": "role",
-              "type": "string"
-            },
-            {
-              "selector": "responsive",
-              "text": "responsive",
-              "type": "boolean"
-            },
-            {
-              "selector": "ready",
-              "text": "ready",
-              "type": "number"
-            },
-            {
-              "selector": "desired",
-              "text": "desired",
-              "type": "number"
-            },
-            {
-              "selector": "latency_ms",
-              "text": "latency_ms",
-              "type": "number"
-            },
-            {
-              "selector": "error_class",
-              "text": "error_class",
-              "type": "string"
-            },
-            {
-              "selector": "error",
-              "text": "error",
-              "type": "string"
-            }
-          ]
-        }
-      ]
+      "panelRef": "finelog_fleet_health"
     },
     {
       "id": 2,

--- a/infra/grafana/dashboards/home.json
+++ b/infra/grafana/dashboards/home.json
@@ -51,6 +51,16 @@
       "includeVars": false,
       "keepTime": true,
       "targetBlank": false,
+      "title": "Finelog",
+      "type": "link",
+      "url": "/d/marin-finelog"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
       "title": "K8s",
       "type": "link",
       "url": "/d/marin-k8s"

--- a/infra/grafana/dashboards/k8s.json
+++ b/infra/grafana/dashboards/k8s.json
@@ -452,96 +452,13 @@
     },
     {
       "id": 11,
-      "type": "table",
-      "title": "Finelog fleet health",
-      "description": "The marin hub reads one row from the log namespace and reports latency, exercising rotated segments. Each CoreWeave mirror reports its Kubernetes HTTP /health readiness.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
         "y": 63
       },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "latency_ms"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "ms"
-              }
-            ]
-          }
-        ]
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/fleet_health",
-          "url_options": {
-            "method": "GET"
-          },
-          "columns": [
-            {
-              "selector": "cluster",
-              "text": "cluster",
-              "type": "string"
-            },
-            {
-              "selector": "server",
-              "text": "server",
-              "type": "string"
-            },
-            {
-              "selector": "role",
-              "text": "role",
-              "type": "string"
-            },
-            {
-              "selector": "responsive",
-              "text": "responsive",
-              "type": "boolean"
-            },
-            {
-              "selector": "ready",
-              "text": "ready",
-              "type": "number"
-            },
-            {
-              "selector": "desired",
-              "text": "desired",
-              "type": "number"
-            },
-            {
-              "selector": "latency_ms",
-              "text": "latency_ms",
-              "type": "number"
-            },
-            {
-              "selector": "error_class",
-              "text": "error_class",
-              "type": "string"
-            },
-            {
-              "selector": "error",
-              "text": "error",
-              "type": "string"
-            }
-          ]
-        }
-      ]
+      "panelRef": "finelog_fleet_health"
     }
   ]
 }

--- a/infra/grafana/dashboards/panels/finelog_fleet_health.json
+++ b/infra/grafana/dashboards/panels/finelog_fleet_health.json
@@ -1,0 +1,86 @@
+{
+  "type": "table",
+  "title": "Finelog fleet health",
+  "description": "The marin hub reads one row from the log namespace and reports latency, exercising rotated segments. Each CoreWeave mirror reports its Kubernetes HTTP /health readiness.",
+  "datasource": {
+    "type": "yesoreyeram-infinity-datasource",
+    "uid": "finelog-marin"
+  },
+  "fieldConfig": {
+    "defaults": {},
+    "overrides": [
+      {
+        "matcher": {
+          "id": "byName",
+          "options": "latency_ms"
+        },
+        "properties": [
+          {
+            "id": "unit",
+            "value": "ms"
+          }
+        ]
+      }
+    ]
+  },
+  "targets": [
+    {
+      "refId": "A",
+      "type": "json",
+      "source": "url",
+      "format": "table",
+      "parser": "backend",
+      "url": "/fleet_health",
+      "url_options": {
+        "method": "GET"
+      },
+      "columns": [
+        {
+          "selector": "cluster",
+          "text": "cluster",
+          "type": "string"
+        },
+        {
+          "selector": "server",
+          "text": "server",
+          "type": "string"
+        },
+        {
+          "selector": "role",
+          "text": "role",
+          "type": "string"
+        },
+        {
+          "selector": "responsive",
+          "text": "responsive",
+          "type": "boolean"
+        },
+        {
+          "selector": "ready",
+          "text": "ready",
+          "type": "number"
+        },
+        {
+          "selector": "desired",
+          "text": "desired",
+          "type": "number"
+        },
+        {
+          "selector": "latency_ms",
+          "text": "latency_ms",
+          "type": "number"
+        },
+        {
+          "selector": "error_class",
+          "text": "error_class",
+          "type": "string"
+        },
+        {
+          "selector": "error",
+          "text": "error",
+          "type": "string"
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -247,12 +247,12 @@ class K8sSource:
         path = f"/apis/apps/v1/namespaces/{component.namespace}/deployments/{component.deployment}"
         return self._get(path, none_on_404=True)
 
-    def _deployment_pods(self, component: WatchedComponent, deployment: dict) -> list[dict]:
+    def _deployment_pods(self, namespace: str, deployment: dict) -> list[dict]:
         match_labels = ((deployment.get("spec") or {}).get("selector") or {}).get("matchLabels") or {}
         if not match_labels:
             return []
         selector = ",".join(f"{key}={value}" for key, value in sorted(match_labels.items()))
-        return self._list(f"/api/v1/namespaces/{component.namespace}/pods", {"labelSelector": selector})
+        return self._list(f"/api/v1/namespaces/{namespace}/pods", {"labelSelector": selector})
 
     def component_status(self, component: WatchedComponent) -> dict:
         """Ready/desired replicas plus restart and waiting state from the pods behind one Deployment.
@@ -275,7 +275,7 @@ class K8sSource:
         ready = (deployment.get("status") or {}).get("readyReplicas") or 0
         restarts = 0
         waiting_reason = ""
-        for pod in self._deployment_pods(component, deployment):
+        for pod in self._deployment_pods(component.namespace, deployment):
             for status in _container_statuses(pod):
                 restarts += status.get("restartCount") or 0
                 reason = ((status.get("state") or {}).get("waiting") or {}).get("reason")
@@ -352,6 +352,84 @@ class K8sSource:
             error_class="" if responsive else "readiness",
             error="" if responsive else "HTTP /health probe is not Ready",
         )
+
+    def finelog_pods(self) -> list[dict]:
+        """Runtime and provisioning details for every finelog pod in this cluster."""
+        deployments = [
+            deployment
+            for deployment in self._list("/apis/apps/v1/deployments")
+            if _deployment_has_container(deployment, _FINELOG_CONTAINER)
+        ]
+        rows = []
+        for deployment in deployments:
+            metadata = deployment.get("metadata") or {}
+            namespace = metadata.get("namespace") or "default"
+            deployment_name = metadata.get("name") or _FINELOG_FALLBACK_SERVER
+            pod_spec = ((deployment.get("spec") or {}).get("template") or {}).get("spec") or {}
+            container = next(
+                (item for item in pod_spec.get("containers") or [] if item.get("name") == _FINELOG_CONTAINER),
+                {},
+            )
+            resources = container.get("resources") or {}
+            requests = resources.get("requests") or {}
+            limits = resources.get("limits") or {}
+            pvc_name = next(
+                (
+                    (volume.get("persistentVolumeClaim") or {}).get("claimName")
+                    for volume in pod_spec.get("volumes") or []
+                    if (volume.get("persistentVolumeClaim") or {}).get("claimName")
+                ),
+                "",
+            )
+            pvc = None
+            if pvc_name:
+                pvc = self._get(
+                    f"/api/v1/namespaces/{namespace}/persistentvolumeclaims/{pvc_name}",
+                    none_on_404=True,
+                )
+            pvc_spec = (pvc or {}).get("spec") or {}
+            pvc_status = (pvc or {}).get("status") or {}
+            storage_capacity = (pvc_status.get("capacity") or {}).get("storage")
+            if storage_capacity is None:
+                storage_capacity = ((pvc_spec.get("resources") or {}).get("requests") or {}).get("storage", "")
+
+            pods = self._deployment_pods(namespace, deployment)
+            if not pods:
+                pods = [{"metadata": {}, "spec": {}, "status": {}}]
+            for pod in pods:
+                pod_metadata = pod.get("metadata") or {}
+                runtime_spec = pod.get("spec") or {}
+                status = pod.get("status") or {}
+                container_status = next(
+                    (item for item in status.get("containerStatuses") or [] if item.get("name") == _FINELOG_CONTAINER),
+                    {},
+                )
+                last_terminated = (container_status.get("lastState") or {}).get("terminated") or {}
+                rows.append(
+                    {
+                        "namespace": namespace,
+                        "deployment": deployment_name,
+                        "pod": pod_metadata.get("name") or "",
+                        "node": runtime_spec.get("nodeName") or "",
+                        "phase": status.get("phase") or "Missing",
+                        "ready": bool(container_status.get("ready")),
+                        "restarts": container_status.get("restartCount") or 0,
+                        "last_exit_code": last_terminated.get("exitCode"),
+                        "last_exit_reason": last_terminated.get("reason") or "",
+                        "image": container.get("image") or "",
+                        "cpu_request": str(requests.get("cpu", "")),
+                        "cpu_limit": str(limits.get("cpu", "")),
+                        "memory_request": str(requests.get("memory", "")),
+                        "memory_limit": str(limits.get("memory", "")),
+                        "startup_probe": bool(container.get("startupProbe")),
+                        "readiness_probe": bool(container.get("readinessProbe")),
+                        "liveness_probe": bool(container.get("livenessProbe")),
+                        "pvc": pvc_name,
+                        "storage_class": pvc_spec.get("storageClassName") or "",
+                        "storage_capacity": str(storage_capacity),
+                    }
+                )
+        return rows
 
     def _scanned_namespaces(self) -> list[str]:
         """Namespaces the pod scans cover: everything not provider-managed by prefix."""
@@ -692,6 +770,9 @@ class K8sFleet:
             ]
 
         return self._collect(lambda source: [source.finelog_health()], on_error)
+
+    def finelog_pods(self) -> list[dict]:
+        return self._fan_out(lambda source: source.finelog_pods(), self._error_row)
 
     def alert_gpu_rack_trays(self) -> list[dict]:
         """Per rack: trays_ready as ``value``, for the below-minimum-trays alert.

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -142,6 +142,45 @@ class TerminatingPodError:
 
 
 TerminatingPodResult = TerminatingPod | TerminatingPodError
+
+
+@dataclass(frozen=True)
+class FinelogPod:
+    """Runtime and provisioning details for one Kubernetes finelog pod."""
+
+    cluster: str
+    namespace: str
+    deployment: str
+    pod: str
+    node: str
+    phase: str
+    ready: bool
+    restarts: int
+    last_exit_code: int | None
+    last_exit_reason: str
+    image: str
+    cpu_request: str
+    cpu_limit: str
+    memory_request: str
+    memory_limit: str
+    startup_probe: bool
+    readiness_probe: bool
+    liveness_probe: bool
+    pvc: str
+    storage_class: str
+    storage_capacity: str
+
+
+@dataclass(frozen=True)
+class FinelogPodError:
+    """A cluster query failure returned beside healthy finelog pod records."""
+
+    cluster: str
+    error_class: str
+    error: str
+
+
+FinelogPodResult = FinelogPod | FinelogPodError
 _Row = TypeVar("_Row")
 
 
@@ -320,10 +359,7 @@ class K8sSource:
         """Report the mirror's HTTP-probe readiness from its Deployment status."""
         # Name and namespace belong to finelog's deploy config, which is not in this
         # image; discover by the stable container name instead of mirroring config.
-        deployments = self._list("/apis/apps/v1/deployments")
-        deployments = [
-            deployment for deployment in deployments if _deployment_has_container(deployment, _FINELOG_CONTAINER)
-        ]
+        deployments = self._finelog_deployments()
         if len(deployments) != 1:
             return FinelogHealth(
                 cluster=self._target.name,
@@ -353,15 +389,17 @@ class K8sSource:
             error="" if responsive else "HTTP /health probe is not Ready",
         )
 
-    def finelog_pods(self) -> list[dict]:
-        """Runtime and provisioning details for every finelog pod in this cluster."""
-        deployments = [
+    def _finelog_deployments(self) -> list[dict]:
+        return [
             deployment
             for deployment in self._list("/apis/apps/v1/deployments")
             if _deployment_has_container(deployment, _FINELOG_CONTAINER)
         ]
+
+    def finelog_pods(self) -> list[FinelogPod]:
+        """Runtime and provisioning details for every finelog pod in this cluster."""
         rows = []
-        for deployment in deployments:
+        for deployment in self._finelog_deployments():
             metadata = deployment.get("metadata") or {}
             namespace = metadata.get("namespace") or "default"
             deployment_name = metadata.get("name") or _FINELOG_FALLBACK_SERVER
@@ -406,28 +444,29 @@ class K8sSource:
                 )
                 last_terminated = (container_status.get("lastState") or {}).get("terminated") or {}
                 rows.append(
-                    {
-                        "namespace": namespace,
-                        "deployment": deployment_name,
-                        "pod": pod_metadata.get("name") or "",
-                        "node": runtime_spec.get("nodeName") or "",
-                        "phase": status.get("phase") or "Missing",
-                        "ready": bool(container_status.get("ready")),
-                        "restarts": container_status.get("restartCount") or 0,
-                        "last_exit_code": last_terminated.get("exitCode"),
-                        "last_exit_reason": last_terminated.get("reason") or "",
-                        "image": container.get("image") or "",
-                        "cpu_request": str(requests.get("cpu", "")),
-                        "cpu_limit": str(limits.get("cpu", "")),
-                        "memory_request": str(requests.get("memory", "")),
-                        "memory_limit": str(limits.get("memory", "")),
-                        "startup_probe": bool(container.get("startupProbe")),
-                        "readiness_probe": bool(container.get("readinessProbe")),
-                        "liveness_probe": bool(container.get("livenessProbe")),
-                        "pvc": pvc_name,
-                        "storage_class": pvc_spec.get("storageClassName") or "",
-                        "storage_capacity": str(storage_capacity),
-                    }
+                    FinelogPod(
+                        cluster=self._target.name,
+                        namespace=namespace,
+                        deployment=deployment_name,
+                        pod=pod_metadata.get("name") or "",
+                        node=runtime_spec.get("nodeName") or "",
+                        phase=status.get("phase") or "Missing",
+                        ready=bool(container_status.get("ready")),
+                        restarts=container_status.get("restartCount") or 0,
+                        last_exit_code=last_terminated.get("exitCode"),
+                        last_exit_reason=last_terminated.get("reason") or "",
+                        image=container.get("image") or "",
+                        cpu_request=str(requests.get("cpu", "")),
+                        cpu_limit=str(limits.get("cpu", "")),
+                        memory_request=str(requests.get("memory", "")),
+                        memory_limit=str(limits.get("memory", "")),
+                        startup_probe=bool(container.get("startupProbe")),
+                        readiness_probe=bool(container.get("readinessProbe")),
+                        liveness_probe=bool(container.get("livenessProbe")),
+                        pvc=pvc_name,
+                        storage_class=pvc_spec.get("storageClassName") or "",
+                        storage_capacity=str(storage_capacity),
+                    )
                 )
         return rows
 
@@ -771,8 +810,11 @@ class K8sFleet:
 
         return self._collect(lambda source: [source.finelog_health()], on_error)
 
-    def finelog_pods(self) -> list[dict]:
-        return self._fan_out(lambda source: source.finelog_pods(), self._error_row)
+    def finelog_pods(self) -> list[FinelogPodResult]:
+        return self._collect(
+            lambda source: source.finelog_pods(),
+            lambda source, err: [FinelogPodError(source.target.name, str(err.error_class), str(err))],
+        )
 
     def alert_gpu_rack_trays(self) -> list[dict]:
         """Per rack: trays_ready as ``value``, for the below-minimum-trays alert.

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -397,7 +397,7 @@ class K8sSource:
         ]
 
     def finelog_pods(self) -> list[FinelogPod]:
-        """Runtime and provisioning details for every finelog pod in this cluster."""
+        """Report each finelog Deployment, including a Missing row when it has no pod."""
         rows = []
         for deployment in self._finelog_deployments():
             metadata = deployment.get("metadata") or {}

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -84,6 +84,9 @@ TO_MACRO = "{{to}}"
 LABELS_COLUMN = "labels"
 LABEL_PREFIX = "label_"
 _K8S_TERMINATION_CANDIDATES_CACHE_KEY = "termination_candidates"
+_K8S_EVENTS_CACHE_KEY = "events"
+_K8S_FINELOG_CACHE_KEY = "finelog"
+_FINELOG_FILTER_TOKEN = "finelog"
 _FINELOG_HUB_CLUSTER = "marin"
 
 
@@ -399,18 +402,20 @@ def create_app(
         return k8s_endpoint("kueue", k8s_fleet.kueue)
 
     def k8s_events(_: Request) -> JSONResponse:
-        return k8s_endpoint("events", k8s_fleet.warning_events)
+        return k8s_endpoint(_K8S_EVENTS_CACHE_KEY, k8s_fleet.warning_events)
 
     def k8s_finelog(_: Request) -> JSONResponse:
-        return k8s_endpoint("finelog", k8s_fleet.finelog_pods)
+        rows = k8s_cache.get_or_compute(_K8S_FINELOG_CACHE_KEY, k8s_fleet.finelog_pods)
+        return JSONResponse([asdict(row) for row in rows])
 
     def k8s_finelog_events(_: Request) -> JSONResponse:
-        events = k8s_cache.get_or_compute("events", k8s_fleet.warning_events)
+        events = k8s_cache.get_or_compute(_K8S_EVENTS_CACHE_KEY, k8s_fleet.warning_events)
         return JSONResponse(
             [
                 row
                 for row in events
-                if "finelog" in (row.get("object") or "").lower() or "finelog" in (row.get("message") or "").lower()
+                if _FINELOG_FILTER_TOKEN in (row.get("object") or "").lower()
+                or _FINELOG_FILTER_TOKEN in (row.get("message") or "").lower()
             ]
         )
 

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -28,6 +28,8 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /k8s/termination_candidates             pods overdue past their deletion deadline
     GET /k8s/kueue                               unadmitted Kueue workloads per queue
     GET /k8s/events                              recent Warning events
+    GET /k8s/finelog                             finelog pod, probe, resource, and PVC details
+    GET /k8s/finelog_events                      recent Warning events involving finelog
     GET /k8s/health                              per-cluster API server reachability + latency
     GET /k8s/overview                            explicit workload issue counts (zeros included)
     GET /k8s/gpu_racks                           GPU nodes grouped by physical rack: trays total/ready
@@ -399,6 +401,19 @@ def create_app(
     def k8s_events(_: Request) -> JSONResponse:
         return k8s_endpoint("events", k8s_fleet.warning_events)
 
+    def k8s_finelog(_: Request) -> JSONResponse:
+        return k8s_endpoint("finelog", k8s_fleet.finelog_pods)
+
+    def k8s_finelog_events(_: Request) -> JSONResponse:
+        events = k8s_cache.get_or_compute("events", k8s_fleet.warning_events)
+        return JSONResponse(
+            [
+                row
+                for row in events
+                if "finelog" in (row.get("object") or "").lower() or "finelog" in (row.get("message") or "").lower()
+            ]
+        )
+
     def k8s_health(_: Request) -> JSONResponse:
         return k8s_endpoint("health", k8s_fleet.health)
 
@@ -462,6 +477,8 @@ def create_app(
             Route("/k8s/termination_candidates", k8s_termination_candidates),
             Route("/k8s/kueue", k8s_kueue),
             Route("/k8s/events", k8s_events),
+            Route("/k8s/finelog", k8s_finelog),
+            Route("/k8s/finelog_events", k8s_finelog_events),
             Route("/k8s/health", k8s_health),
             Route("/k8s/overview", k8s_overview),
             Route("/k8s/gpu_racks", k8s_gpu_racks),

--- a/infra/grafana/tests/fixture_bridge.py
+++ b/infra/grafana/tests/fixture_bridge.py
@@ -140,7 +140,59 @@ def _finelog(query: str) -> list[dict]:
     return []
 
 
+def _finelog_k8s_rows(path: str) -> list[dict] | None:
+    if path == "/k8s/finelog":
+        return [
+            {
+                "cluster": cluster,
+                "namespace": "iris",
+                "deployment": server,
+                "pod": f"{server}-abc",
+                "node": "cpu-node-1",
+                "phase": "Running",
+                "ready": True,
+                "restarts": 0,
+                "last_exit_code": None,
+                "last_exit_reason": "",
+                "cpu_request": "2",
+                "cpu_limit": "8",
+                "memory_request": "16Gi",
+                "memory_limit": "32Gi",
+                "startup_probe": True,
+                "readiness_probe": True,
+                "liveness_probe": True,
+                "pvc": f"{server}-cache",
+                "storage_class": "shared-vast",
+                "storage_capacity": "250Gi",
+                "image": "ghcr.io/marin-community/finelog@sha256:abc",
+                "error_class": "",
+                "error": "",
+            }
+            for cluster, server in (
+                ("cw-us-east-02a", "finelog-cw-use02a"),
+                ("cw-us-east-08a", "finelog-cw-use08a"),
+                ("cw-rno2a", "finelog-cw-rno2a"),
+            )
+        ]
+    if path == "/k8s/finelog_events":
+        return [
+            {
+                "cluster": "cw-rno2a",
+                "namespace": "iris",
+                "object": "Pod/finelog-cw-rno2a-abc",
+                "reason": "Unhealthy",
+                "message": "Readiness probe failed",
+                "count": 3,
+                "last_seen": round(_NOW.timestamp() * 1000),
+            }
+        ]
+    return None
+
+
 def _rows(path: str, query: str) -> list[dict] | dict:
+    finelog_rows = _finelog_k8s_rows(path)
+    if finelog_rows is not None:
+        return finelog_rows
     if path == "/github/nightlies":
         return _nightlies()
     if path == "/github/builds":
@@ -306,51 +358,6 @@ def _rows(path: str, query: str) -> list[dict] | dict:
                 "reason": "FailedScheduling",
                 "message": "waiting for H100 capacity",
                 "count": 2,
-                "last_seen": round(_NOW.timestamp() * 1000),
-            }
-        ]
-    if path == "/k8s/finelog":
-        return [
-            {
-                "cluster": cluster,
-                "namespace": "iris",
-                "deployment": server,
-                "pod": f"{server}-abc",
-                "node": "cpu-node-1",
-                "phase": "Running",
-                "ready": True,
-                "restarts": 0,
-                "last_exit_code": None,
-                "last_exit_reason": "",
-                "cpu_request": "2",
-                "cpu_limit": "8",
-                "memory_request": "16Gi",
-                "memory_limit": "32Gi",
-                "startup_probe": True,
-                "readiness_probe": True,
-                "liveness_probe": True,
-                "pvc": f"{server}-cache",
-                "storage_class": "shared-vast",
-                "storage_capacity": "250Gi",
-                "image": "ghcr.io/marin-community/finelog@sha256:abc",
-                "error_class": "",
-                "error": "",
-            }
-            for cluster, server in (
-                ("cw-us-east-02a", "finelog-cw-use02a"),
-                ("cw-us-east-08a", "finelog-cw-use08a"),
-                ("cw-rno2a", "finelog-cw-rno2a"),
-            )
-        ]
-    if path == "/k8s/finelog_events":
-        return [
-            {
-                "cluster": "cw-rno2a",
-                "namespace": "iris",
-                "object": "Pod/finelog-cw-rno2a-abc",
-                "reason": "Unhealthy",
-                "message": "Readiness probe failed",
-                "count": 3,
                 "last_seen": round(_NOW.timestamp() * 1000),
             }
         ]

--- a/infra/grafana/tests/fixture_bridge.py
+++ b/infra/grafana/tests/fixture_bridge.py
@@ -309,6 +309,51 @@ def _rows(path: str, query: str) -> list[dict] | dict:
                 "last_seen": round(_NOW.timestamp() * 1000),
             }
         ]
+    if path == "/k8s/finelog":
+        return [
+            {
+                "cluster": cluster,
+                "namespace": "iris",
+                "deployment": server,
+                "pod": f"{server}-abc",
+                "node": "cpu-node-1",
+                "phase": "Running",
+                "ready": True,
+                "restarts": 0,
+                "last_exit_code": None,
+                "last_exit_reason": "",
+                "cpu_request": "2",
+                "cpu_limit": "8",
+                "memory_request": "16Gi",
+                "memory_limit": "32Gi",
+                "startup_probe": True,
+                "readiness_probe": True,
+                "liveness_probe": True,
+                "pvc": f"{server}-cache",
+                "storage_class": "shared-vast",
+                "storage_capacity": "250Gi",
+                "image": "ghcr.io/marin-community/finelog@sha256:abc",
+                "error_class": "",
+                "error": "",
+            }
+            for cluster, server in (
+                ("cw-us-east-02a", "finelog-cw-use02a"),
+                ("cw-us-east-08a", "finelog-cw-use08a"),
+                ("cw-rno2a", "finelog-cw-rno2a"),
+            )
+        ]
+    if path == "/k8s/finelog_events":
+        return [
+            {
+                "cluster": "cw-rno2a",
+                "namespace": "iris",
+                "object": "Pod/finelog-cw-rno2a-abc",
+                "reason": "Unhealthy",
+                "message": "Readiness probe failed",
+                "count": 3,
+                "last_seen": round(_NOW.timestamp() * 1000),
+            }
+        ]
     if path.startswith("/wandb/"):
         return _wandb(path.rsplit("/", 1)[-1])
     if path == "/finelog/marin/query":

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -504,7 +504,8 @@ def test_finelog_pods_reports_runtime_resources_probes_and_pvc():
 
     (row,) = make_k8s_source(k8s_api(routes)).finelog_pods()
 
-    assert row == {
+    assert asdict(row) == {
+        "cluster": "cw-a",
         "namespace": "iris",
         "deployment": "finelog-cw-a",
         "pod": "finelog-cw-a-abc",
@@ -646,6 +647,35 @@ def test_k8s_routes_serve_fleet_rows():
         "trays_total": 1,
         "trays_ready": 1,
     }
+
+
+def test_finelog_events_route_filters_kubernetes_warnings():
+    routes = healthy_k8s_routes()
+    routes["/api/v1/events"] = [
+        {
+            "involvedObject": {"kind": "Pod", "name": "finelog-cw-a-abc", "namespace": "iris"},
+            "reason": "Unhealthy",
+            "message": "Readiness probe failed",
+            "lastTimestamp": "2026-07-23T02:00:00Z",
+        },
+        {
+            "involvedObject": {"kind": "PersistentVolumeClaim", "name": "cache", "namespace": "iris"},
+            "reason": "ProvisioningFailed",
+            "message": "finelog volume could not be mounted",
+            "lastTimestamp": "2026-07-23T01:59:00Z",
+        },
+        {
+            "involvedObject": {"kind": "Pod", "name": "trainer-0", "namespace": "training"},
+            "reason": "FailedScheduling",
+            "message": "no GPU nodes available",
+            "lastTimestamp": "2026-07-23T01:58:00Z",
+        },
+    ]
+
+    response = _client(_fleet(("cw-a", k8s_api(routes)))).get("/k8s/finelog_events")
+
+    assert response.status_code == 200
+    assert [row["object"] for row in response.json()] == ["Pod/finelog-cw-a-abc", "PersistentVolumeClaim/cache"]
 
 
 def test_stuck_termination_routes_return_classification_and_alert_projection():

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -459,6 +459,75 @@ def test_finelog_health_reports_missing_deployment():
     )
 
 
+def test_finelog_pods_reports_runtime_resources_probes_and_pvc():
+    manifest = deployment("iris", "finelog-cw-a", containers=("finelog",))
+    container = manifest["spec"]["template"]["spec"]["containers"][0]
+    container.update(
+        {
+            "image": "ghcr.io/marin-community/finelog@sha256:abc",
+            "resources": {
+                "requests": {"cpu": "2", "memory": "16Gi"},
+                "limits": {"cpu": "8", "memory": "32Gi"},
+            },
+            "startupProbe": {"httpGet": {"path": "/health", "port": 10001}},
+            "readinessProbe": {"httpGet": {"path": "/health", "port": 10001}},
+            "livenessProbe": {"httpGet": {"path": "/health", "port": 10001}},
+        }
+    )
+    manifest["spec"]["template"]["spec"]["volumes"] = [
+        {"name": "cache", "persistentVolumeClaim": {"claimName": "finelog-cw-a-cache"}}
+    ]
+    finelog_pod = pod("iris", "finelog-cw-a-abc", restarts=9)
+    finelog_pod["spec"].update({"nodeName": "cpu-1", "containers": [container]})
+    finelog_pod["status"].update(
+        {
+            "phase": "Running",
+            "containerStatuses": [
+                {
+                    "name": "finelog",
+                    "ready": True,
+                    "restartCount": 9,
+                    "state": {"running": {}},
+                    "lastState": {"terminated": {"reason": "Error", "exitCode": 137}},
+                }
+            ],
+        }
+    )
+    routes = {
+        FINELOG_DEPLOYMENTS_PATH: [manifest],
+        "/api/v1/namespaces/iris/pods": [finelog_pod],
+        "/api/v1/namespaces/iris/persistentvolumeclaims/finelog-cw-a-cache": {
+            "spec": {"storageClassName": "shared-vast", "resources": {"requests": {"storage": "250Gi"}}},
+            "status": {"capacity": {"storage": "250Gi"}},
+        },
+    }
+
+    (row,) = make_k8s_source(k8s_api(routes)).finelog_pods()
+
+    assert row == {
+        "namespace": "iris",
+        "deployment": "finelog-cw-a",
+        "pod": "finelog-cw-a-abc",
+        "node": "cpu-1",
+        "phase": "Running",
+        "ready": True,
+        "restarts": 9,
+        "last_exit_code": 137,
+        "last_exit_reason": "Error",
+        "image": "ghcr.io/marin-community/finelog@sha256:abc",
+        "cpu_request": "2",
+        "cpu_limit": "8",
+        "memory_request": "16Gi",
+        "memory_limit": "32Gi",
+        "startup_probe": True,
+        "readiness_probe": True,
+        "liveness_probe": True,
+        "pvc": "finelog-cw-a-cache",
+        "storage_class": "shared-vast",
+        "storage_capacity": "250Gi",
+    }
+
+
 def test_alert_gpu_rack_trays_maps_trays_ready_to_value():
     fleet = _fleet(("cw-a", k8s_api(healthy_k8s_routes())))
     assert fleet.alert_gpu_rack_trays() == [
@@ -560,6 +629,8 @@ def test_k8s_routes_serve_fleet_rows():
         "/k8s/pending",
         "/k8s/kueue",
         "/k8s/events",
+        "/k8s/finelog",
+        "/k8s/finelog_events",
         "/k8s/gpu_racks",
     ):
         assert client.get(path).status_code == 200

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -630,8 +630,6 @@ def test_k8s_routes_serve_fleet_rows():
         "/k8s/pending",
         "/k8s/kueue",
         "/k8s/events",
-        "/k8s/finelog",
-        "/k8s/finelog_events",
         "/k8s/gpu_racks",
     ):
         assert client.get(path).status_code == 200
@@ -646,6 +644,47 @@ def test_k8s_routes_serve_fleet_rows():
         "instance_type": "gb200-4x",
         "trays_total": 1,
         "trays_ready": 1,
+    }
+
+
+def test_finelog_route_serializes_pod_diagnostics():
+    routes = healthy_k8s_routes()
+    finelog_pod = pod("iris", "finelog-cw-a-abc", restarts=2)
+    finelog_pod["spec"]["nodeName"] = "cpu-1"
+    finelog_pod["status"]["phase"] = "Running"
+    finelog_pod["status"]["containerStatuses"] = [
+        {
+            "name": "finelog",
+            "ready": True,
+            "restartCount": 2,
+            "state": {"running": {}},
+            "lastState": {"terminated": {"reason": "Error", "exitCode": 137}},
+        }
+    ]
+    routes["/api/v1/namespaces/iris/pods"] = [finelog_pod]
+
+    response = _client(_fleet(("cw-a", k8s_api(routes)))).get("/k8s/finelog")
+
+    assert response.status_code == 200
+    (row,) = response.json()
+    assert {
+        "cluster": row["cluster"],
+        "deployment": row["deployment"],
+        "pod": row["pod"],
+        "node": row["node"],
+        "phase": row["phase"],
+        "ready": row["ready"],
+        "restarts": row["restarts"],
+        "last_exit_code": row["last_exit_code"],
+    } == {
+        "cluster": "cw-a",
+        "deployment": "finelog-cw-a",
+        "pod": "finelog-cw-a-abc",
+        "node": "cpu-1",
+        "phase": "Running",
+        "ready": True,
+        "restarts": 2,
+        "last_exit_code": 137,
     }
 
 

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -180,6 +180,34 @@ def test_k8s_dashboard_shows_finelog_fleet_health():
     assert {"cluster", "server", "responsive", "ready", "desired", "latency_ms"} <= selectors
 
 
+def test_finelog_dashboard_shows_health_pods_storage_and_events():
+    dashboard = _stitched_dashboards()["finelog.json"]
+    targets = [target for panel in dashboard["panels"] for target in panel.get("targets", [])]
+
+    assert {(target["url"], target.get("parser")) for target in targets} == {
+        ("/fleet_health", "backend"),
+        ("/finelog", "backend"),
+        ("/finelog_events", "backend"),
+    }
+    pod_target = next(target for target in targets if target["url"] == "/finelog")
+    selectors = {column["selector"] for column in pod_target["columns"]}
+    assert {
+        "cluster",
+        "namespace",
+        "pod",
+        "node",
+        "restarts",
+        "cpu_request",
+        "cpu_limit",
+        "memory_request",
+        "memory_limit",
+        "startup_probe",
+        "pvc",
+        "storage_class",
+        "storage_capacity",
+    } <= selectors
+
+
 def test_dashboard_filter_expressions_reference_selected_columns():
     # Infinity's backend parser applies filterExpression to the frame built from
     # `columns`, so every field a filter references must also be selected.

--- a/lib/finelog/OPS.md
+++ b/lib/finelog/OPS.md
@@ -124,6 +124,9 @@ kubectl --kubeconfig ~/.kube/coreweave-iris --context <context> -n iris \
   exec deployment/finelog-<cluster> -- cat /sys/fs/cgroup/memory.events
 kubectl --kubeconfig ~/.kube/coreweave-iris --context <context> -n iris \
   exec deployment/finelog-<cluster> -- df -h /var/cache/finelog
+kubectl --kubeconfig ~/.kube/coreweave-iris --context <context> -n iris \
+  logs deployment/finelog-<cluster> --timestamps=true | \
+  rg 'finelog (catalog sqlite ready|local segment adoption complete|namespace startup complete|store startup complete|remote reconcile complete)'
 ```
 
 Exit 137 is ambiguous by itself. A nearby `Killing ... failed liveness probe`
@@ -135,3 +138,11 @@ compactions indicate ingest pressure; tune `cpu_request`, `cpu_limit`,
 `memory_request`, and `memory_limit` in the cluster's finelog config. Every
 Kubernetes deployment also has a five-minute startup probe so reopening an
 existing network-backed store does not feed a liveness restart loop.
+
+The startup events carry millisecond timings for SQLite open, one-time catalog
+adoption, local directory discovery, catalog reads, Parquet footer reconciliation,
+batched catalog refresh, namespace rehydration, and total store open. The catalog
+event also reports the effective SQLite journal and synchronous modes. Remote
+reconcile runs after the listener binds and reports object listing, footer fetch,
+catalog update, and delete timings separately; a slow remote phase cannot explain
+pre-bind readiness delay.

--- a/lib/finelog/OPS.md
+++ b/lib/finelog/OPS.md
@@ -108,3 +108,30 @@ To rotate a key, add the new Secret Manager version, add its public key alongsid
 the old one under the same `keys[].cluster` (the hub accepts either), roll the
 hub, re-pin the sender's `signing_key` to the new version, roll the sender, then
 drop the old public key and roll the hub again.
+
+## Diagnosing Kubernetes mirror readiness
+
+Use the kubeconfig and context from `config/<cluster>.yaml`; do not rely on the
+file's current context. Inspect the deployment, termination reason, probe events,
+and persistent cache before changing resources:
+
+```bash
+kubectl --kubeconfig ~/.kube/coreweave-iris --context <context> -n iris \
+  describe pod -l app=finelog-<cluster>
+kubectl --kubeconfig ~/.kube/coreweave-iris --context <context> -n iris \
+  logs deployment/finelog-<cluster> --previous --tail=300 --timestamps=true
+kubectl --kubeconfig ~/.kube/coreweave-iris --context <context> -n iris \
+  exec deployment/finelog-<cluster> -- cat /sys/fs/cgroup/memory.events
+kubectl --kubeconfig ~/.kube/coreweave-iris --context <context> -n iris \
+  exec deployment/finelog-<cluster> -- df -h /var/cache/finelog
+```
+
+Exit 137 is ambiguous by itself. A nearby `Killing ... failed liveness probe`
+event with zero `oom_kill` events means kubelet terminated an unresponsive
+process; it was not a memory-limit OOM. Compare `memory.current` and
+`memory.peak` with the configured limit, and compare cache use with the PVC
+capacity before raising either. Slow `WriteRows` calls coincident with large
+compactions indicate ingest pressure; tune `cpu_request`, `cpu_limit`,
+`memory_request`, and `memory_limit` in the cluster's finelog config. Every
+Kubernetes deployment also has a five-minute startup probe so reopening an
+existing network-backed store does not feed a liveness restart loop.

--- a/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
+++ b/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
@@ -74,11 +74,21 @@ spec:
               mountPath: /var/cache/finelog
           resources:
             requests:
-              cpu: "500m"
-              memory: "4Gi"
+              cpu: "{{ cpu_request }}"
+              memory: "{{ memory_request }}"
             limits:
-              cpu: "2"
-              memory: "32Gi"
+              cpu: "{{ cpu_limit }}"
+              memory: "{{ memory_limit }}"
+          # Opening an existing store can take over a minute on a network-backed
+          # PVC. Gate liveness and readiness until startup succeeds so recovery
+          # work cannot trigger a self-sustaining liveness restart loop.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: {{ port }}
+            periodSeconds: 10
+            timeoutSeconds: 15
+            failureThreshold: 30
           livenessProbe:
             httpGet:
               path: /health

--- a/lib/finelog/rust/src/store/adopt.rs
+++ b/lib/finelog/rust/src/store/adopt.rs
@@ -481,9 +481,7 @@ fn adopt_one_namespace_dir(
     // canonical key is "key" (a STRING column carrying no Int64 stats, so key
     // bounds stay None), which the heuristic schema also resolves to.
     let rows = adopt_namespace_from_disk(ns_dir, namespace, &schema);
-    for row in &rows {
-        catalog.upsert_segment(row)?;
-    }
+    catalog.upsert_segments(&rows)?;
 
     tracing::info!(
         namespace,

--- a/lib/finelog/rust/src/store/catalog.rs
+++ b/lib/finelog/rust/src/store/catalog.rs
@@ -118,6 +118,21 @@ fn upsert_segment_in(conn: &Connection, row: &SegmentRow) -> Result<(), StatsErr
     Ok(())
 }
 
+fn remove_segments_in(
+    conn: &Connection,
+    namespace: &str,
+    paths: &[String],
+) -> Result<(), StatsError> {
+    for path in paths {
+        conn.execute(
+            "DELETE FROM segments WHERE namespace = ?1 AND path = ?2",
+            rusqlite::params![namespace, path],
+        )
+        .map_err(sqlite_err)?;
+    }
+    Ok(())
+}
+
 impl Catalog {
     /// Open the catalog. `data_dir = None` -> in-memory; otherwise the sidecar
     /// lives at `{data_dir}/_finelog_catalog.sqlite`. Creates the three tables
@@ -127,7 +142,28 @@ impl Catalog {
             None => Connection::open_in_memory().map_err(sqlite_err)?,
             Some(dir) => Connection::open(dir.join(CATALOG_DB_FILENAME)).map_err(sqlite_err)?,
         };
+        let journal_mode: String = if data_dir.is_some() {
+            // WAL requires shared memory and is not safe on the network-backed
+            // filesystems used by Kubernetes finelog. PERSIST keeps rollback
+            // journaling while avoiding a journal-file delete on every commit.
+            conn.query_row("PRAGMA journal_mode = PERSIST", [], |row| row.get(0))
+                .map_err(sqlite_err)?
+        } else {
+            conn.query_row("PRAGMA journal_mode", [], |row| row.get(0))
+                .map_err(sqlite_err)?
+        };
+        conn.execute_batch("PRAGMA synchronous = FULL;")
+            .map_err(sqlite_err)?;
+        let synchronous: i64 = conn
+            .query_row("PRAGMA synchronous", [], |row| row.get(0))
+            .map_err(sqlite_err)?;
         Self::create_tables(&conn)?;
+        tracing::info!(
+            persistent = data_dir.is_some(),
+            journal_mode,
+            synchronous,
+            "finelog catalog sqlite ready"
+        );
         Ok(Catalog {
             inner: Mutex::new(CatalogInner {
                 conn,
@@ -528,6 +564,30 @@ impl Catalog {
         upsert_segment_in(&inner.conn, row)
     }
 
+    /// Insert or replace a set of segment rows in one durable transaction.
+    pub fn upsert_segments(&self, rows: &[SegmentRow]) -> Result<(), StatsError> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        let mut inner = self.inner.lock().unwrap();
+        let tx = inner.conn.transaction().map_err(sqlite_err)?;
+        for row in rows {
+            upsert_segment_in(&tx, row)?;
+        }
+        tx.commit().map_err(sqlite_err)
+    }
+
+    /// Remove a set of namespace segment rows in one durable transaction.
+    pub fn remove_segments(&self, namespace: &str, paths: &[String]) -> Result<(), StatsError> {
+        if paths.is_empty() {
+            return Ok(());
+        }
+        let mut inner = self.inner.lock().unwrap();
+        let tx = inner.conn.transaction().map_err(sqlite_err)?;
+        remove_segments_in(&tx, namespace, paths)?;
+        tx.commit().map_err(sqlite_err)
+    }
+
     /// Atomically swap `removed_paths` for `added` rows in one transaction.
     ///
     /// Compaction collapses N inputs at level n into one level-(n+1) output. The
@@ -541,13 +601,7 @@ impl Catalog {
     ) -> Result<(), StatsError> {
         let mut inner = self.inner.lock().unwrap();
         let tx = inner.conn.transaction().map_err(sqlite_err)?;
-        for path in removed_paths {
-            tx.execute(
-                "DELETE FROM segments WHERE namespace = ?1 AND path = ?2",
-                rusqlite::params![namespace, path],
-            )
-            .map_err(sqlite_err)?;
-        }
+        remove_segments_in(&tx, namespace, removed_paths)?;
         for seg in added {
             upsert_segment_in(&tx, seg)?;
         }

--- a/lib/finelog/rust/src/store/namespace.rs
+++ b/lib/finelog/rust/src/store/namespace.rs
@@ -41,9 +41,7 @@ use crate::store::ram_buffer::{stamp_seq_and_build, RamBuffers, SealedBuffer};
 use crate::store::reconcile::reconcile_remote_segments;
 use crate::store::remote::{build_remote_store, RemoteStore};
 use crate::store::schema::{schema_to_arrow, AlignedBatch, Schema};
-use crate::store::segment::{
-    discover_segments, read_segment_footer, recover_next_seq, write_segment_to_dir,
-};
+use crate::store::segment::{discover_segments, read_segment_footer, write_segment_to_dir};
 use crate::store::trigram::{sidecar_path, write_sidecar};
 use crate::store::types::{LocalSegment, NamespaceStats, SegmentLocation, SegmentRow};
 
@@ -196,6 +194,7 @@ impl Namespace {
         remote_log_dir: &str,
         storage_policy: StoragePolicy,
     ) -> Result<Arc<Namespace>, StatsError> {
+        let startup_started = Instant::now();
         let arrow_schema = schema_to_arrow(&schema);
         let key_column = if schema.key_column.is_empty() {
             None
@@ -203,6 +202,7 @@ impl Namespace {
             Some(schema.key_column.clone())
         };
 
+        let local_recovery_started = Instant::now();
         let (next_seq, adopted, init_persisted) = match &data_dir {
             None => (1_i64, VecDeque::new(), -1_i64),
             Some(dir) => {
@@ -215,7 +215,16 @@ impl Namespace {
                 // parquet unlinked, so a footer-only scan under-counts and would
                 // reuse live seqs (silent overwrite). Union the footer scan with
                 // the full catalog (LOCAL, REMOTE, and BOTH rows).
-                let next_seq = recover_next_seq(dir).max(crate::store::adopt::recover_next_seq(
+                // `adopt_local_segments` has already read every healthy local
+                // footer. Reuse those max_seq values instead of scanning every
+                // Parquet footer a second time.
+                let local_next_seq = adopted
+                    .iter()
+                    .map(|segment| segment.max_seq + 1)
+                    .max()
+                    .unwrap_or(1)
+                    .max(1);
+                let next_seq = local_next_seq.max(crate::store::adopt::recover_next_seq(
                     &catalog.list_segments(name)?,
                 ));
                 let max_persisted = adopted
@@ -227,14 +236,17 @@ impl Namespace {
                 (next_seq, adopted, max_persisted)
             }
         };
+        let local_recovery_ms = local_recovery_started.elapsed().as_millis() as u64;
 
         // The RemoteStore is rooted at the remote dir and composes the
         // namespace prefix internally, so we only need the dir to be configured.
+        let remote_store_started = Instant::now();
         let remote = if data_dir.is_some() {
             build_remote_store(remote_log_dir)?
         } else {
             None
         };
+        let remote_store_ms = remote_store_started.elapsed().as_millis() as u64;
 
         let (tx, _rx) = watch::channel(init_persisted);
         let ns = Arc::new(Namespace {
@@ -264,14 +276,28 @@ impl Namespace {
 
         // Refresh the catalog from the adopted deque so the segments table
         // reflects on-disk reality after a fresh boot from a wiped catalog.
-        for seg in &adopted {
-            catalog.upsert_segment(&segment_to_row(name, seg))?;
-        }
+        let catalog_refresh_started = Instant::now();
+        let adopted_rows: Vec<SegmentRow> = adopted
+            .iter()
+            .map(|segment| segment_to_row(name, segment))
+            .collect();
+        catalog.upsert_segments(&adopted_rows)?;
+        let catalog_refresh_ms = catalog_refresh_started.elapsed().as_millis() as u64;
 
         if ns.data_dir.is_some() {
             let handle = spawn_flush_task(Arc::clone(&ns));
             ns.task_handles.lock().unwrap().push(handle);
         }
+        tracing::info!(
+            namespace = name,
+            segments = adopted.len(),
+            next_seq,
+            local_recovery_ms,
+            remote_store_ms,
+            catalog_refresh_ms,
+            total_ms = startup_started.elapsed().as_millis() as u64,
+            "finelog namespace startup complete"
+        );
         Ok(ns)
     }
 
@@ -1396,16 +1422,22 @@ fn adopt_local_segments(
     catalog: &Catalog,
     namespace: &str,
 ) -> VecDeque<LocalSegment> {
+    let started = Instant::now();
     let mut segs: Vec<LocalSegment> = Vec::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
 
+    let discover_started = Instant::now();
     let local_files: std::collections::HashMap<String, PathBuf> = discover_segments(dir)
         .into_iter()
         .map(|p| (p.to_string_lossy().into_owned(), p))
         .collect();
+    let discover_ms = discover_started.elapsed().as_millis() as u64;
 
     // Pass 1: catalog rows.
+    let catalog_started = Instant::now();
     let catalog_rows = catalog.list_segments(namespace).unwrap_or_default();
+    let catalog_read_ms = catalog_started.elapsed().as_millis() as u64;
+    let footer_reconcile_started = Instant::now();
     // Highest seq the catalog still ACCOUNTS FOR after reconciliation: a local
     // file past it is genuinely new (an uncataloged flush); a file at or below it
     // whose row is gone is a compaction input the catalog already superseded (the
@@ -1513,6 +1545,17 @@ fn adopt_local_segments(
     segs.sort_by_key(|s| s.min_seq);
     let deque: VecDeque<LocalSegment> = segs.into();
     debug_assert_unique_paths(&deque);
+    tracing::info!(
+        namespace,
+        local_files = local_files.len(),
+        catalog_rows = catalog_rows.len(),
+        adopted_segments = deque.len(),
+        discover_ms,
+        catalog_read_ms,
+        footer_reconcile_ms = footer_reconcile_started.elapsed().as_millis() as u64,
+        total_ms = started.elapsed().as_millis() as u64,
+        "finelog local segment adoption complete"
+    );
     deque
 }
 

--- a/lib/finelog/rust/src/store/reconcile.rs
+++ b/lib/finelog/rust/src/store/reconcile.rs
@@ -49,6 +49,8 @@ pub async fn reconcile_remote_segments(
     local_dir: &std::path::Path,
     key_column: Option<&str>,
 ) -> Result<(), StatsError> {
+    let started = std::time::Instant::now();
+    let list_started = std::time::Instant::now();
     let objects = match remote.list_segment_objects(namespace).await {
         Ok(o) => o,
         Err(e) => {
@@ -56,6 +58,7 @@ pub async fn reconcile_remote_segments(
             return Ok(());
         }
     };
+    let list_ms = list_started.elapsed().as_millis() as u64;
 
     // Catalog rows at L>=1 keyed by basename (the durable-archive pointers).
     let catalog_rows = catalog.list_segments_min_level(namespace, 1)?;
@@ -88,6 +91,7 @@ pub async fn reconcile_remote_segments(
     // trips, so a sequential await would cost O(N) RTTs. `buffer_unordered`
     // caps in-flight requests; `read_footer` is a single ranged GET (size is
     // already known, no `head`).
+    let footer_started = std::time::Instant::now();
     let footers: Vec<Footer> = futures::stream::iter(pending)
         .map(|(name, size, level, min_seq)| async move {
             let footer = remote.read_footer(namespace, &name, size, key_column).await;
@@ -112,6 +116,7 @@ pub async fn reconcile_remote_segments(
         })
         .collect()
         .await;
+    let footer_ms = footer_started.elapsed().as_millis() as u64;
 
     // Union catalog + remote-only seq ranges; mark any segment fully spanned by
     // a strictly-higher level as redundant (transitivity makes a single pass
@@ -147,18 +152,25 @@ pub async fn reconcile_remote_segments(
     }
 
     // Drop redundant catalog rows + delete their bucket files.
+    let catalog_update_started = std::time::Instant::now();
+    let removed_paths: Vec<String> = redundant
+        .iter()
+        .filter_map(|name| catalog_by_basename.get(name).map(|row| row.path.clone()))
+        .collect();
+    catalog.remove_segments(namespace, &removed_paths)?;
+    let catalog_remove_ms = catalog_update_started.elapsed().as_millis() as u64;
+
+    let remote_delete_started = std::time::Instant::now();
     let mut dropped = 0;
     for name in &redundant {
-        if let Some(row) = catalog_by_basename.get(name) {
-            catalog.remove_segment(namespace, &row.path)?;
-        }
         remote.delete(namespace, name).await;
         dropped += 1;
     }
+    let remote_delete_ms = remote_delete_started.elapsed().as_millis() as u64;
 
     // Adopt the surviving (non-redundant) remote-only footers as REMOTE rows.
     let now = now_ms();
-    let mut adopted = 0;
+    let mut adopted_rows = Vec::new();
     for f in &footers {
         if redundant.contains(&f.basename) {
             continue;
@@ -166,7 +178,7 @@ pub async fn reconcile_remote_segments(
         let local_path = local_dir.join(&f.basename);
         // Record the footer's actual num_rows, not a seq-span recomputation, so
         // an edge-case empty footer adopts row_count=0 rather than 1.
-        catalog.upsert_segment(&SegmentRow {
+        adopted_rows.push(SegmentRow {
             namespace: namespace.to_string(),
             path: local_path.to_string_lossy().into_owned(),
             level: f.level,
@@ -178,18 +190,28 @@ pub async fn reconcile_remote_segments(
             min_key_value: f.min_key.map(|v| v.to_string()),
             max_key_value: f.max_key.map(|v| v.to_string()),
             location: SegmentLocation::Remote,
-        })?;
-        adopted += 1;
+        });
     }
+    let catalog_upsert_started = std::time::Instant::now();
+    catalog.upsert_segments(&adopted_rows)?;
+    let catalog_upsert_ms = catalog_upsert_started.elapsed().as_millis() as u64;
+    let adopted = adopted_rows.len();
 
-    if adopted > 0 || dropped > 0 {
-        tracing::info!(
-            namespace,
-            adopted,
-            dropped_redundant = dropped,
-            "reconciled remote"
-        );
-    }
+    tracing::info!(
+        namespace,
+        remote_objects = objects.len(),
+        catalog_segments = catalog_by_basename.len(),
+        footer_reads = footers.len(),
+        adopted,
+        dropped_redundant = dropped,
+        list_ms,
+        footer_ms,
+        catalog_remove_ms,
+        remote_delete_ms,
+        catalog_upsert_ms,
+        total_ms = started.elapsed().as_millis() as u64,
+        "finelog remote reconcile complete"
+    );
     Ok(())
 }
 

--- a/lib/finelog/rust/src/store/segment.rs
+++ b/lib/finelog/rust/src/store/segment.rs
@@ -217,21 +217,6 @@ pub fn discover_segments(dir: &Path) -> Vec<PathBuf> {
     out
 }
 
-/// Recover the next seq to allocate by scanning `dir`'s segment footers.
-///
-/// Returns `max(max_seq over all segments) + 1`, or `1` when no segments exist.
-pub fn recover_next_seq(dir: &Path) -> i64 {
-    let mut next_seq = 1_i64;
-    for p in discover_segments(dir) {
-        if let Some(meta) = read_segment_footer(&p, None) {
-            if meta.max_seq + 1 > next_seq {
-                next_seq = meta.max_seq + 1;
-            }
-        }
-    }
-    next_seq
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -315,23 +300,6 @@ mod tests {
             .downcast_ref::<Int64Array>()
             .unwrap();
         assert_eq!(keys.values(), &[30_i64, 10, 20], "L0 must be UNSORTED");
-        std::fs::remove_dir_all(&dir).ok();
-    }
-
-    #[test]
-    fn recover_next_seq_over_two_segments() {
-        let dir = tempdir();
-        // segment 1: seqs 1..3 (min_seq 1); segment 2: seqs 4..5 (min_seq 4).
-        write_segment_to_dir(&dir, 0, 1, &batch_with_keys(1, vec![1, 2, 3])).unwrap();
-        write_segment_to_dir(&dir, 0, 4, &batch_with_keys(4, vec![4, 5])).unwrap();
-        assert_eq!(recover_next_seq(&dir), 6);
-        std::fs::remove_dir_all(&dir).ok();
-    }
-
-    #[test]
-    fn recover_next_seq_empty_dir_is_one() {
-        let dir = tempdir();
-        assert_eq!(recover_next_seq(&dir), 1);
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/lib/finelog/rust/src/store/store.rs
+++ b/lib/finelog/rust/src/store/store.rs
@@ -13,7 +13,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use arrow::datatypes::SchemaRef;
 
@@ -116,12 +116,15 @@ impl Store {
     /// `remote_log_dir` configures the per-namespace offload target (empty
     /// disables sync). Pass it through to each `Namespace`.
     pub fn new(data_dir: Option<PathBuf>, remote_log_dir: String) -> Result<Store, StatsError> {
+        let startup_started = Instant::now();
         if let Some(dir) = &data_dir {
             std::fs::create_dir_all(dir).map_err(|e| {
                 StatsError::Internal(format!("create data_dir {}: {e}", dir.display()))
             })?;
         }
+        let catalog_open_started = Instant::now();
         let catalog = Arc::new(Catalog::open(data_dir.as_deref())?);
+        let catalog_open_ms = catalog_open_started.elapsed().as_millis() as u64;
         // Rebuild-from-disk catalog adoption. On a fresh boot over a log_dir an
         // earlier server populated, the sqlite sidecar is empty, so the disk
         // parquet layout + footers are the only record of the namespaces +
@@ -131,7 +134,9 @@ impl Store {
         // sentinel (subsequent boots). REMOTE adoption is the engines'
         // `boot_reconcile`, run in the background by each namespace's
         // maintenance task (spawned by `bootstrap_maintenance`), not before bind.
+        let catalog_adoption_started = Instant::now();
         crate::store::adopt::ensure_catalog_adopted(data_dir.as_deref(), &catalog)?;
+        let catalog_adoption_ms = catalog_adoption_started.elapsed().as_millis() as u64;
         let store = Store {
             data_dir,
             remote_log_dir,
@@ -146,8 +151,22 @@ impl Store {
         // evolving after rehydrate would instead require rebuilding a live engine,
         // whose stop-and-join uses a runtime `block_on` that is illegal here (this
         // runs directly on the async `main` task, not a `spawn_blocking` worker).
+        let log_schema_started = Instant::now();
         store.ensure_log_namespace_schema()?;
+        let log_schema_ms = log_schema_started.elapsed().as_millis() as u64;
+        let rehydrate_started = Instant::now();
         store.rehydrate_from_catalog()?;
+        let rehydrate_ms = rehydrate_started.elapsed().as_millis() as u64;
+        let namespaces = store.engines.lock().unwrap().len();
+        tracing::info!(
+            namespaces,
+            catalog_open_ms,
+            catalog_adoption_ms,
+            log_schema_ms,
+            rehydrate_ms,
+            total_ms = startup_started.elapsed().as_millis() as u64,
+            "finelog store startup complete"
+        );
         Ok(store)
     }
 

--- a/lib/finelog/src/finelog/deploy/_k8s.py
+++ b/lib/finelog/src/finelog/deploy/_k8s.py
@@ -96,6 +96,10 @@ def _render_manifest(template_path: Path, cfg: FinelogConfig) -> str:
         "remote_log_dir": cfg.remote_log_dir,
         "storage_class_block": storage_class_block,
         "storage_gb": k8s.storage_gb,
+        "cpu_request": k8s.cpu_request,
+        "cpu_limit": k8s.cpu_limit,
+        "memory_request": k8s.memory_request,
+        "memory_limit": k8s.memory_limit,
         "inline_env_block": _inline_env_block(cfg),
         "priority_class_block": _priority_class_block(cfg),
     }

--- a/lib/finelog/src/finelog/deploy/config.py
+++ b/lib/finelog/src/finelog/deploy/config.py
@@ -69,6 +69,10 @@ class K8sDeployment:
     kube_context: str | None = None
     storage_class: str | None = None
     storage_gb: int = 200
+    cpu_request: str = "2"
+    cpu_limit: str = "8"
+    memory_request: str = "16Gi"
+    memory_limit: str = "32Gi"
     # S3-compatible endpoint (e.g. Cloudflare R2) for an `s3://` remote_log_dir.
     # Required there: `finelog deploy up` mints a Secret holding this endpoint
     # plus the operator's R2 creds, projected into the pod via envFrom so the
@@ -297,6 +301,10 @@ def _build_k8s(raw: dict) -> K8sDeployment:
         kube_context=raw.get("kube_context"),
         storage_class=raw.get("storage_class"),
         storage_gb=int(raw.get("storage_gb", 200)),
+        cpu_request=str(raw.get("cpu_request", "2")),
+        cpu_limit=str(raw.get("cpu_limit", "8")),
+        memory_request=str(raw.get("memory_request", "16Gi")),
+        memory_limit=str(raw.get("memory_limit", "32Gi")),
         object_storage_endpoint=raw.get("object_storage_endpoint"),
         priority_class_name=raw.get("priority_class_name"),
         priority_class_value=None if priority_class_value is None else int(priority_class_value),

--- a/lib/finelog/src/finelog/deploy/config.py
+++ b/lib/finelog/src/finelog/deploy/config.py
@@ -294,17 +294,18 @@ def _build_forwarding(raw: dict, path: Path) -> ForwardingConfig:
 
 
 def _build_k8s(raw: dict) -> K8sDeployment:
+    defaults = K8sDeployment(namespace=raw["namespace"])
     priority_class_value = raw.get("priority_class_value")
     return K8sDeployment(
         namespace=raw["namespace"],
         kubeconfig=raw.get("kubeconfig"),
         kube_context=raw.get("kube_context"),
         storage_class=raw.get("storage_class"),
-        storage_gb=int(raw.get("storage_gb", 200)),
-        cpu_request=str(raw.get("cpu_request", "2")),
-        cpu_limit=str(raw.get("cpu_limit", "8")),
-        memory_request=str(raw.get("memory_request", "16Gi")),
-        memory_limit=str(raw.get("memory_limit", "32Gi")),
+        storage_gb=int(raw.get("storage_gb", defaults.storage_gb)),
+        cpu_request=str(raw.get("cpu_request", defaults.cpu_request)),
+        cpu_limit=str(raw.get("cpu_limit", defaults.cpu_limit)),
+        memory_request=str(raw.get("memory_request", defaults.memory_request)),
+        memory_limit=str(raw.get("memory_limit", defaults.memory_limit)),
         object_storage_endpoint=raw.get("object_storage_endpoint"),
         priority_class_name=raw.get("priority_class_name"),
         priority_class_value=None if priority_class_value is None else int(priority_class_value),

--- a/lib/finelog/tests/test_deploy_k8s.py
+++ b/lib/finelog/tests/test_deploy_k8s.py
@@ -149,6 +149,22 @@ def test_deployment_probes_the_http_health_endpoint() -> None:
         "timeoutSeconds": 15,
         "failureThreshold": 3,
     }
+    assert container["startupProbe"] == {
+        "httpGet": {"path": "/health", "port": 10001},
+        "periodSeconds": 10,
+        "timeoutSeconds": 15,
+        "failureThreshold": 30,
+    }
+
+
+def test_k8s_deployment_reserves_burst_capacity_by_default() -> None:
+    deployment = yaml.safe_load(_render_manifest(_K8S_MANIFEST_DIR / "02-deployment.yaml.tmpl", _forwarding_cfg()))
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+
+    assert container["resources"] == {
+        "requests": {"cpu": "2", "memory": "16Gi"},
+        "limits": {"cpu": "8", "memory": "32Gi"},
+    }
 
 
 def test_env_secret_carries_both_s3_credentials_and_signing_key(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Kubernetes finelog mirrors could spend more than a minute reopening a network-backed store, while liveness began after 15 seconds. An ingest or compaction stall could therefore turn one slow recovery into a repeated restart loop.

Reserve 2 CPUs and 16 GiB of memory for every Kubernetes finelog deployment, allow bursts to 8 CPUs while preserving the 32 GiB memory limit, and gate liveness and readiness behind a five-minute HTTP startup probe. The resource values remain configurable per cluster.

RNO2A recorded six liveness restarts and 79 readiness failures in roughly three hours while `WriteRows` calls reached 8–24 seconds during multi-million-row compactions. The container peaked at 12.4 GB with zero cgroup OOM kills, and its PVC used 2.5 of 250 GiB. A live patch with these defaults rolled out successfully; the replacement pod became Ready without restarting.

Batch startup catalog refresh into one transaction per namespace, remove a duplicate full Parquet-footer scan, and use SQLite's `PERSIST` rollback journal with `synchronous=FULL`. WAL remains disabled because SQLite does not support its shared-memory coordination on network filesystems. Structured timings now separate catalog open, local discovery, catalog reads, footer reconciliation, catalog refresh, namespace rehydration, and background remote reconcile.

Add a dedicated Finelog Grafana dashboard with fleet health, pod placement, readiness, restarts, last termination, effective requests and limits, probe presence, PVC provisioning, and recent matching Kubernetes warnings. The runbook now distinguishes liveness-driven exit 137 from OOM and shows how to read the startup phase events.

The startup/PVC brief in `.agents/projects/finelog-pvc-startup/research.md` records the evidence and rollout experiment. All current CoreWeave clusters expose only `shared-vast`; enlarging this 1%-full PVC has no demonstrated performance benefit. A controlled VAST-versus-local-NVMe comparison and provider-side VAST latency and `qos_wait` data remain the next storage checks.

Validation covered 308 Rust library tests, a full Rust workspace check, 27 finelog deployment tests, 96 Grafana tests, changed-file lint and formatting, and the repository's agentic lint review. Local `pyrefly` was unavailable in this worktree, so type checking remains covered by CI.

Session: https://loom.rjp.io/s/cy3crgzz
