### PR TITLE
[iris] Find task pods named before the name embedded attempt_uid

### DIFF
--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -379,29 +379,36 @@ def _pod_name(task_id: JobName, attempt_id: int, attempt_uid: str = "") -> str:
     return (prefix + suffix) if prefix else f"iris-task{suffix}"
 
 
-def _pod_name_candidates(task_id: JobName, attempt_id: int, attempt_uid: str) -> list[str]:
+def _pod_name_candidates(task_id: JobName, attempt_id: int, attempt_uid: str, *, allow_legacy: bool) -> list[str]:
     """Pod names an attempt may be running under, current scheme first.
 
     Pods are created under the uid-embedded name; attempts dispatched before the
     name embedded ``attempt_uid`` run under the uid-less name, so lookups must
-    accept it too. It ranks last, so a fresh attempt — whose uid-named pod exists
-    before it is first polled — resolves to its own pod rather than a leftover
-    one. Drop the legacy candidate once no pre-uid attempt can still be running.
+    accept it too. It ranks last, so an attempt whose uid-named pod exists always
+    resolves to its own pod rather than a leftover one.
+
+    ``allow_legacy`` must be false for any attempt this process dispatched. Such
+    an attempt was created under the current name, and a resubmit reuses
+    ``(task_id, attempt_id)``, so a uid-less pod sharing those is a previous
+    incarnation's — adopting it is the collision #7518 removed. Drop the legacy
+    candidate entirely once no attempt predating that change can still be running.
     """
     current = _pod_name(task_id, attempt_id, attempt_uid)
+    if not allow_legacy:
+        return [current]
     legacy = _pod_name(task_id, attempt_id)
     return [current] if legacy == current else [current, legacy]
 
 
 def _lookup_pod(
-    pods_by_name: dict[str, dict], task_id: JobName, attempt_id: int, attempt_uid: str
+    pods_by_name: dict[str, dict], task_id: JobName, attempt_id: int, attempt_uid: str, *, allow_legacy: bool
 ) -> tuple[str, dict | None]:
     """Resolve an attempt to its pod in *pods_by_name*, tolerating the pre-uid name.
 
     Returns the matched name and pod, or the current-scheme name and ``None``
-    when the attempt has no pod under either name.
+    when the attempt has no pod under any candidate name.
     """
-    candidates = _pod_name_candidates(task_id, attempt_id, attempt_uid)
+    candidates = _pod_name_candidates(task_id, attempt_id, attempt_uid, allow_legacy=allow_legacy)
     for name in candidates:
         pod = pods_by_name.get(name)
         if pod is not None:
@@ -2221,6 +2228,10 @@ class K8sTaskProvider:
     # worker store, so it reads its dispatch drain through this).
     transition_reader: TransitionReader | None = field(default=None, repr=False)
     _pod_not_found_counts: dict[str, int] = field(default_factory=dict, init=False, repr=False)
+    # (task_id_wire, attempt_id) this process has dispatched a pod for. Those pods
+    # were created under the current name, so their lookups must never consider the
+    # pre-uid name — see _pod_name_candidates.
+    _dispatched_attempts: set[tuple[str, int]] = field(default_factory=set, init=False, repr=False)
     _resource_collector: ResourceCollector | None = field(default=None, init=False, repr=False)
     _periodic_profiler: PeriodicProfiler | None = field(default=None, init=False, repr=False)
     _node_stats_collector: NodeStatsCollector | None = field(default=None, init=False, repr=False)
@@ -2447,6 +2458,17 @@ class K8sTaskProvider:
 
         return updates
 
+    def _lookup_entry_pod(self, pods_by_name: dict[str, dict], entry: RunningTaskEntry) -> tuple[str, dict | None]:
+        """Resolve a running entry to its pod, allowing the pre-uid name only when this
+        process did not dispatch the attempt."""
+        return _lookup_pod(
+            pods_by_name,
+            entry.task_id,
+            entry.attempt_id,
+            entry.attempt_uid,
+            allow_legacy=(entry.task_id.to_wire(), entry.attempt_id) not in self._dispatched_attempts,
+        )
+
     def _live_pod_name(self, target: TaskTarget) -> str:
         """Pod name for *target*, preferring the current scheme over the pre-uid name.
 
@@ -2454,7 +2476,12 @@ class K8sTaskProvider:
         otherwise returns the pre-uid name unprobed — a target with no pod under
         either name still yields a name for the caller to fail against.
         """
-        candidates = _pod_name_candidates(JobName.from_wire(target.task_id), target.attempt_id, target.attempt_uid)
+        candidates = _pod_name_candidates(
+            JobName.from_wire(target.task_id),
+            target.attempt_id,
+            target.attempt_uid,
+            allow_legacy=(target.task_id, target.attempt_id) not in self._dispatched_attempts,
+        )
         for name in candidates[:-1]:
             if self.kubectl.get_json(K8sResource.PODS, name) is not None:
                 return name
@@ -2597,6 +2624,7 @@ class K8sTaskProvider:
 
         task_id_name = JobName.from_wire(run_req.task_id)
         pod_name = _pod_name(task_id_name, run_req.attempt_id, run_req.attempt_uid)
+        self._dispatched_attempts.add((run_req.task_id, run_req.attempt_id))
 
         init_containers, extra_volumes, configmap_name = _build_init_container_spec(
             run_req,
@@ -2966,9 +2994,7 @@ class K8sTaskProvider:
         # each. Lazy: only fetched on cycles where at least one pod is missing,
         # so steady-state cycles add no call. setdefault keeps the active entry
         # if a name somehow appears in both.
-        if any(
-            _lookup_pod(pods_by_name, entry.task_id, entry.attempt_id, entry.attempt_uid)[1] is None for entry in running
-        ):
+        if any(self._lookup_entry_pod(pods_by_name, entry)[1] is None for entry in running):
             for pod in self._list_terminal_pods():
                 pods_by_name.setdefault(pod.get("metadata", {}).get("name", ""), pod)
 
@@ -2982,7 +3008,7 @@ class K8sTaskProvider:
         event_log = self._ensure_task_event_log()
 
         for entry in running:
-            pod_name, pod = _lookup_pod(pods_by_name, entry.task_id, entry.attempt_id, entry.attempt_uid)
+            pod_name, pod = self._lookup_entry_pod(pods_by_name, entry)
             cursor_key = f"{entry.task_id.to_wire()}:{entry.attempt_id}"
             event_key = (entry.task_id.to_wire(), entry.attempt_id)
 

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -382,16 +382,11 @@ def _pod_name(task_id: JobName, attempt_id: int, attempt_uid: str = "") -> str:
 def _pod_name_candidates(task_id: JobName, attempt_id: int, attempt_uid: str) -> list[str]:
     """Pod names an attempt may be running under, current scheme first.
 
-    Pods are created under the uid-embedded name, but an attempt dispatched by a
-    controller predating that scheme is running under a name without the uid.
-    Those pods stay in flight across a controller upgrade, so every lookup that
-    resolves a live attempt to its pod has to accept the pre-uid name as well:
-    recomputing only the current name misses them, and the poll path reads that
-    miss as the pod having vanished.
-
-    The legacy name is consulted only when no uid-named pod exists. A freshly
-    dispatched attempt creates its uid-named pod before it is ever polled, so the
-    fallback cannot re-adopt the leftover pod that the uid exists to disambiguate.
+    Pods are created under the uid-embedded name; attempts dispatched before the
+    name embedded ``attempt_uid`` run under the uid-less name, so lookups must
+    accept it too. It ranks last, so a fresh attempt — whose uid-named pod exists
+    before it is first polled — resolves to its own pod rather than a leftover
+    one. Drop the legacy candidate once no pre-uid attempt can still be running.
     """
     current = _pod_name(task_id, attempt_id, attempt_uid)
     legacy = _pod_name(task_id, attempt_id)
@@ -2453,11 +2448,11 @@ class K8sTaskProvider:
         return updates
 
     def _live_pod_name(self, target: TaskTarget) -> str:
-        """Pod name for *target*, falling back to the pre-uid name when it is live.
+        """Pod name for *target*, preferring the current scheme over the pre-uid name.
 
-        Attempts dispatched before pod names embedded ``attempt_uid`` are still
-        reachable under their original name; probe the current name first and
-        only pay a GET when both schemes are possible.
+        Probes the uid-embedded name and returns it when that pod exists,
+        otherwise returns the pre-uid name unprobed — a target with no pod under
+        either name still yields a name for the caller to fail against.
         """
         candidates = _pod_name_candidates(JobName.from_wire(target.task_id), target.attempt_id, target.attempt_uid)
         for name in candidates[:-1]:

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -379,6 +379,41 @@ def _pod_name(task_id: JobName, attempt_id: int, attempt_uid: str = "") -> str:
     return (prefix + suffix) if prefix else f"iris-task{suffix}"
 
 
+def _pod_name_candidates(task_id: JobName, attempt_id: int, attempt_uid: str) -> list[str]:
+    """Pod names an attempt may be running under, current scheme first.
+
+    Pods are created under the uid-embedded name, but an attempt dispatched by a
+    controller predating that scheme is running under a name without the uid.
+    Those pods stay in flight across a controller upgrade, so every lookup that
+    resolves a live attempt to its pod has to accept the pre-uid name as well:
+    recomputing only the current name misses them, and the poll path reads that
+    miss as the pod having vanished.
+
+    The legacy name is consulted only when no uid-named pod exists. A freshly
+    dispatched attempt creates its uid-named pod before it is ever polled, so the
+    fallback cannot re-adopt the leftover pod that the uid exists to disambiguate.
+    """
+    current = _pod_name(task_id, attempt_id, attempt_uid)
+    legacy = _pod_name(task_id, attempt_id)
+    return [current] if legacy == current else [current, legacy]
+
+
+def _lookup_pod(
+    pods_by_name: dict[str, dict], task_id: JobName, attempt_id: int, attempt_uid: str
+) -> tuple[str, dict | None]:
+    """Resolve an attempt to its pod in *pods_by_name*, tolerating the pre-uid name.
+
+    Returns the matched name and pod, or the current-scheme name and ``None``
+    when the attempt has no pod under either name.
+    """
+    candidates = _pod_name_candidates(task_id, attempt_id, attempt_uid)
+    for name in candidates:
+        pod = pods_by_name.get(name)
+        if pod is not None:
+            return name, pod
+    return candidates[0], None
+
+
 def _build_volumes_and_mounts(
     cache_dir: str,
     has_accelerator: bool,
@@ -2417,6 +2452,19 @@ class K8sTaskProvider:
 
         return updates
 
+    def _live_pod_name(self, target: TaskTarget) -> str:
+        """Pod name for *target*, falling back to the pre-uid name when it is live.
+
+        Attempts dispatched before pod names embedded ``attempt_uid`` are still
+        reachable under their original name; probe the current name first and
+        only pay a GET when both schemes are possible.
+        """
+        candidates = _pod_name_candidates(JobName.from_wire(target.task_id), target.attempt_id, target.attempt_uid)
+        for name in candidates[:-1]:
+            if self.kubectl.get_json(K8sResource.PODS, name) is not None:
+                return name
+        return candidates[-1]
+
     def profile_task(
         self,
         target: TaskTarget,
@@ -2431,7 +2479,7 @@ class K8sTaskProvider:
         the profile duration itself.
         """
         attempt_id = target.attempt_id
-        pod_name = _pod_name(JobName.from_wire(target.task_id), attempt_id, target.attempt_uid)
+        pod_name = self._live_pod_name(target)
         duration = request.duration_seconds or 10
         profile_type = request.profile_type
         dispatch = _K8sProfileDispatch(self.kubectl, pod_name)
@@ -2472,7 +2520,7 @@ class K8sTaskProvider:
     ) -> worker_pb2.Worker.ExecInContainerResponse:
         """Execute a command in a running task pod via kubectl exec."""
         command = list(request.command)
-        pod_name = _pod_name(JobName.from_wire(target.task_id), target.attempt_id, target.attempt_uid)
+        pod_name = self._live_pod_name(target)
         effective_timeout: float | None = timeout_seconds if timeout_seconds >= 0 else None
         try:
             result = self.kubectl.exec(pod_name, command, container="task", timeout=effective_timeout)
@@ -2496,7 +2544,7 @@ class K8sTaskProvider:
         memory, cpu, thread, and fd counters. Logs are served separately via
         FetchLogs, so ``log_entries`` stays empty.
         """
-        pod_name = _pod_name(JobName.from_wire(target.task_id), target.attempt_id, target.attempt_uid)
+        pod_name = self._live_pod_name(target)
         result = self.kubectl.exec(
             pod_name, ["sh", "-c", _POD_PROC_STATUS_SCRIPT], container="task", timeout=_POD_PROC_STATUS_TIMEOUT
         )
@@ -2923,7 +2971,9 @@ class K8sTaskProvider:
         # each. Lazy: only fetched on cycles where at least one pod is missing,
         # so steady-state cycles add no call. setdefault keeps the active entry
         # if a name somehow appears in both.
-        if any(_pod_name(entry.task_id, entry.attempt_id, entry.attempt_uid) not in pods_by_name for entry in running):
+        if any(
+            _lookup_pod(pods_by_name, entry.task_id, entry.attempt_id, entry.attempt_uid)[1] is None for entry in running
+        ):
             for pod in self._list_terminal_pods():
                 pods_by_name.setdefault(pod.get("metadata", {}).get("name", ""), pod)
 
@@ -2937,10 +2987,9 @@ class K8sTaskProvider:
         event_log = self._ensure_task_event_log()
 
         for entry in running:
-            pod_name = _pod_name(entry.task_id, entry.attempt_id, entry.attempt_uid)
+            pod_name, pod = _lookup_pod(pods_by_name, entry.task_id, entry.attempt_id, entry.attempt_uid)
             cursor_key = f"{entry.task_id.to_wire()}:{entry.attempt_id}"
             event_key = (entry.task_id.to_wire(), entry.attempt_id)
-            pod = pods_by_name.get(pod_name)
 
             if pod is None:
                 count = self._pod_not_found_counts.get(cursor_key, 0) + 1

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -290,6 +290,45 @@ def test_sync_pod_not_found_marks_failed(provider, k8s):
     assert result[0].new_state == job_pb2.TASK_STATE_FAILED
 
 
+def test_sync_finds_pod_dispatched_before_pod_names_embedded_uid(provider, k8s):
+    """An in-flight attempt whose pod predates uid-embedded names stays RUNNING.
+
+    Pod names gained the attempt_uid while these pods were already running, and
+    attempt_uid is populated for every attempt, so recomputing only the current
+    name misses them. Reading that miss as a vanished pod fails live tasks on the
+    first controller restart after the upgrade.
+    """
+    task_id = JobName.from_wire("/job/preexisting")
+    entry = RunningTaskEntry(task_id=task_id, attempt_id=0, attempt_uid="a1b2c3d4e5f60718")
+
+    populate_pod(k8s, _pod_name(task_id, 0), "Running")
+
+    batch = make_batch(running_tasks=[entry])
+    for _ in range(_POD_NOT_FOUND_GRACE_CYCLES + 1):
+        result = provider.sync(batch)
+        assert len(result) == 1
+        assert result[0].new_state == job_pb2.TASK_STATE_RUNNING
+
+
+def test_sync_prefers_uid_pod_over_stale_legacy_pod(provider, k8s):
+    """The uid-named pod wins, so a resubmit never re-adopts the previous run's pod.
+
+    Both names can exist at once while pre-upgrade pods drain; the fallback must
+    not undo the incarnation-uniqueness that the uid in the name provides.
+    """
+    task_id = JobName.from_wire("/job/resubmitted")
+    uid = "0f1e2d3c4b5a6978"
+    entry = RunningTaskEntry(task_id=task_id, attempt_id=0, attempt_uid=uid)
+
+    populate_pod(k8s, _pod_name(task_id, 0), "Failed")
+    populate_pod(k8s, _pod_name(task_id, 0, uid), "Running")
+
+    result = provider.sync(make_batch(running_tasks=[entry]))
+
+    assert len(result) == 1
+    assert result[0].new_state == job_pb2.TASK_STATE_RUNNING
+
+
 def test_sync_coscheduled_pod_not_found_is_worker_failed(provider, k8s):
     """A vanished pod for a coscheduled task is billed as WORKER_FAILED (gang preemption),
     not FAILED — Kueue deletes every pod in a preempted group, leaving only the absence."""

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -24,6 +24,7 @@ from iris.cluster.backends.k8s.tasks import (
     K8sTaskProvider,
     PeriodicProfiler,
     ResourceCollector,
+    _lookup_pod,
     _pod_name,
     _ProfileTarget,
     _sanitize_label_value,
@@ -310,23 +311,47 @@ def test_sync_finds_pod_dispatched_before_pod_names_embedded_uid(provider, k8s):
         assert result[0].new_state == job_pb2.TASK_STATE_RUNNING
 
 
-def test_sync_prefers_uid_pod_over_stale_legacy_pod(provider, k8s):
-    """The uid-named pod wins, so a resubmit never re-adopts the previous run's pod.
+def test_lookup_pod_prefers_uid_name_when_both_are_present(provider, k8s):
+    """With both names in the pod set, the uid-named pod wins.
 
-    Both names can exist at once while pre-upgrade pods drain; the fallback must
-    not undo the incarnation-uniqueness that the uid in the name provides.
+    Both can be present at once while pre-upgrade pods drain, and only the
+    uid-named one belongs to this attempt.
     """
     task_id = JobName.from_wire("/job/resubmitted")
     uid = "0f1e2d3c4b5a6978"
+    legacy_name = _pod_name(task_id, 0)
+    uid_name = _pod_name(task_id, 0, uid)
+    pods = {legacy_name: {"metadata": {"name": legacy_name}}, uid_name: {"metadata": {"name": uid_name}}}
+
+    name, pod = _lookup_pod(pods, task_id, 0, uid, allow_legacy=True)
+
+    assert name == uid_name
+    assert pod is pods[uid_name]
+
+
+def test_sync_ignores_legacy_pod_for_an_attempt_this_process_dispatched(provider, k8s):
+    """A resubmit does not fall back onto the previous incarnation's uid-less pod.
+
+    A resubmit reuses (task_id, attempt_id) with a fresh uid, so a leftover
+    uid-less pod shares those and outlives the label-based stray reaper. Once
+    this process has dispatched the attempt its pod carries the uid, and treating
+    the leftover as this attempt's pod is the collision #7518 removed.
+    """
+    task_id = JobName.from_wire("/job/resubmitted-after-upgrade")
+    uid = "1122334455667788"
+    populate_pod(k8s, _pod_name(task_id, 0), "Running")  # previous incarnation, still up
+
+    provider.sync(make_batch(tasks_to_run=[make_run_req(task_id.to_wire(), attempt_id=0, attempt_uid=uid)]))
+    k8s.delete(K8sResource.PODS, _pod_name(task_id, 0, uid))  # this attempt's pod goes away
+
     entry = RunningTaskEntry(task_id=task_id, attempt_id=0, attempt_uid=uid)
+    batch = make_batch(running_tasks=[entry])
+    for _ in range(_POD_NOT_FOUND_GRACE_CYCLES - 1):
+        assert provider.sync(batch)[0].new_state == job_pb2.TASK_STATE_RUNNING
 
-    populate_pod(k8s, _pod_name(task_id, 0), "Failed")
-    populate_pod(k8s, _pod_name(task_id, 0, uid), "Running")
-
-    result = provider.sync(make_batch(running_tasks=[entry]))
-
-    assert len(result) == 1
-    assert result[0].new_state == job_pb2.TASK_STATE_RUNNING
+    result = provider.sync(batch)
+    assert result[0].new_state == job_pb2.TASK_STATE_FAILED
+    assert result[0].error == "Pod not found"
 
 
 def test_sync_coscheduled_pod_not_found_is_worker_failed(provider, k8s):


### PR DESCRIPTION
Resolve a running attempt's pod by trying the current uid-embedded name and falling back to the pre-uid name, instead of recomputing only the current name.

#7518 added `attempt_uid` to the pod name. Migration 0027 backfills `attempt_uid` for every attempt, so attempts dispatched before that deploy carry a uid while their pods are named without one. On the first controller restart after the upgrade, poll recomputed the uid name for each in-flight attempt, missed the live pod, exhausted the not-found grace and failed the task with "Pod not found". The terminal task then dropped out of the desired set, so the label-based stray reaper deleted the still-running pod. On cw-us-east-02a this ended 15 jobs at 02:39 UTC on 2026-07-23, including four grug training runs that had been up for nine days.

Pod creation still always mints the uid name, and lookup prefers it, so a resubmit cannot re-adopt the leftover pod that #7518 addressed; the pre-uid name is consulted only when no uid-named pod exists. The legacy candidate can be dropped once no attempt predating #7518 can still be running.

The same failure will recur for any future change to the pod-name derivation, since the name is recomputed at poll time rather than recorded at dispatch. Recording the name on the attempt row would remove that class of break; this change does not do that.
