### PR TITLE
[iris] Add job restore to relaunch a finished job from its stored config

### DIFF
--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -7,7 +7,6 @@ All cluster subcommands live here: lifecycle (start/stop/restart/status),
 controller VM management, VM operations via controller RPC, and the dashboard tunnel.
 """
 
-import json
 import signal
 import subprocess
 import threading
@@ -32,6 +31,7 @@ from iris.cli.build import (
     get_git_sha,
 )
 from iris.cli.connect import IRIS_CLUSTER_CONFIG_DIRS, require_controller_url, rpc_client_for_ctx
+from iris.cli.raw_query import query_dicts, sql_literal
 from iris.cluster.composer import provider_bundle
 from iris.cluster.config import clear_remote_state, make_local_config
 from iris.cluster.controller.autoscaler.scaling_group import (
@@ -55,7 +55,7 @@ from iris.cluster.platforms.gcp.worker_bootstrap import build_worker_bootstrap_s
 from iris.cluster.platforms.gcp.workers import GcpWorkerProvider
 from iris.cluster.platforms.types import Labels
 from iris.cluster.provenance import provenance_from_proto
-from iris.rpc import controller_pb2, job_pb2, query_pb2, vm_pb2
+from iris.rpc import controller_pb2, job_pb2, vm_pb2
 from iris.rpc.proto_display import format_accelerator_display, vm_state_name
 from iris.time_proto import timestamp_from_proto
 
@@ -80,18 +80,15 @@ def _fetch_worker_bootstrap_rows(client, worker_ids: list[str]) -> dict[str, Wor
     """
     if not worker_ids:
         return {}
-    quoted = ", ".join("'" + wid.replace("'", "''") + "'" for wid in worker_ids)
+    quoted = ", ".join(sql_literal(wid) for wid in worker_ids)
     sql = f"SELECT worker_id, slice_id, scale_group, md_gce_zone FROM workers WHERE worker_id IN ({quoted})"
-    response = client.execute_raw_query(query_pb2.RawQueryRequest(sql=sql))
-    column_index = {col.name: i for i, col in enumerate(response.columns)}
     rows: dict[str, WorkerBootstrapRow] = {}
-    for raw in response.rows:
-        decoded = json.loads(raw)
+    for decoded in query_dicts(client, sql):
         row = WorkerBootstrapRow(
-            worker_id=decoded[column_index["worker_id"]],
-            slice_id=decoded[column_index["slice_id"]],
-            scale_group=decoded[column_index["scale_group"]],
-            zone=decoded[column_index["md_gce_zone"]],
+            worker_id=decoded["worker_id"],
+            slice_id=decoded["slice_id"],
+            scale_group=decoded["scale_group"],
+            zone=decoded["md_gce_zone"],
         )
         rows[row.worker_id] = row
     return rows

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -18,7 +18,7 @@ import time
 from datetime import date
 from pathlib import Path
 from types import SimpleNamespace
-from typing import cast
+from typing import Protocol, cast
 
 import click
 import humanfriendly
@@ -1517,12 +1517,20 @@ def logs(
 _JSON_LIST_COLUMNS = frozenset(c.name for c in job_config_table.columns if isinstance(c.type, JSONList))
 
 
-def _stored_job_row(client: ControllerServiceClientSync, job_id: str) -> LaunchJobRow | None:
-    """Read the stored config of *job_id* in the shape the reconstructor expects.
+class StoredJobRow(LaunchJobRow, Protocol):
+    """A stored job row, plus the two columns a restore reads outside the reconstructor.
 
-    ``state`` rides along so the caller can report what it replaced; the rest of
-    the row is the ``LaunchJobRow`` read surface.
+    ``job_id`` carries the original case, which ``LaunchJobRow.name`` does not:
+    ``job_config.name`` is stored lowercased, so relaunching under it forks a
+    second job. ``state`` gates the relaunch on the job being terminal.
     """
+
+    job_id: str
+    state: int
+
+
+def _stored_job_row(client: ControllerServiceClientSync, job_id: str) -> StoredJobRow | None:
+    """Read the stored config of *job_id* in the shape the reconstructor expects."""
     rows = query_dicts(
         client,
         "SELECT c.*, j.num_tasks, j.state "
@@ -1537,8 +1545,8 @@ def _stored_job_row(client: ControllerServiceClientSync, job_id: str) -> LaunchJ
         row[column] = json.loads(value) if isinstance(value, str) else (value or [])
     row["has_coscheduling"] = bool(row.get("has_coscheduling"))
     # The field set comes from `SELECT c.*`, so the schema decides it; the cast
-    # records that this is the reconstructor's row shape without restating it.
-    return cast(LaunchJobRow, SimpleNamespace(**row))
+    # records the row shape without restating it.
+    return cast(StoredJobRow, SimpleNamespace(**row))
 
 
 def _stored_workdir_files(client: ControllerServiceClientSync, job_id: str) -> dict[str, bytes]:

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -10,11 +10,14 @@ Usage:
 
 import csv
 import difflib
+import json
 import logging
 import os
 import sys
 import time
+from datetime import date
 from pathlib import Path
+from types import SimpleNamespace
 
 import click
 import humanfriendly
@@ -25,7 +28,8 @@ from rigging.credentials import ClientCredentials
 from rigging.timing import Duration, Timestamp
 from tabulate import tabulate
 
-from iris.cli.connect import iris_client_for_ctx, require_controller_url
+from iris.cli.connect import iris_client_for_ctx, require_controller_url, rpc_client_for_ctx
+from iris.cli.raw_query import query_dicts, sql_literal
 from iris.client import IrisClient
 from iris.client.client import Job, JobFailedError
 from iris.cluster.constraints import (
@@ -41,6 +45,8 @@ from iris.cluster.constraints import (
     region_constraint,
     zone_constraint,
 )
+from iris.cluster.controller.codec import reconstruct_launch_job_request
+from iris.cluster.controller.schema import JSONList, job_config_table
 from iris.cluster.platforms.k8s.coreweave_topology import (
     COSCHEDULE_NVLINK_DOMAIN_SLICED,
     NVL72_GPUS_PER_NODE,
@@ -60,6 +66,7 @@ from iris.cluster.types import (
     tpu_device,
 )
 from iris.rpc import job_pb2
+from iris.rpc.controller_connect import ControllerServiceClientSync
 from iris.rpc.proto_display import (
     CONTAINER_PROFILE_NAMES,
     PRIORITY_BAND_NAMES,
@@ -1499,3 +1506,94 @@ def logs(
     for entry in entries:
         ts = entry.timestamp.as_short_time()
         click.echo(f"[{ts}] task={entry.task_id} | {entry.data}")
+
+
+# job_config columns the DB decodes from JSON text. The query RPC hands back the
+# raw column value, so a restore has to decode them itself; deriving the set from
+# the table keeps a newly added JSONList column from silently arriving as a string.
+_JSON_LIST_COLUMNS = frozenset(c.name for c in job_config_table.columns if isinstance(c.type, JSONList))
+
+
+def _stored_job_row(client: ControllerServiceClientSync, job_id: str) -> SimpleNamespace | None:
+    """Read the stored config of *job_id* in the shape the reconstructor expects."""
+    rows = query_dicts(
+        client,
+        "SELECT c.*, j.num_tasks, j.user_id, j.state "
+        "FROM job_config c JOIN jobs j ON j.job_id = c.job_id "
+        f"WHERE c.job_id = {sql_literal(job_id)}",
+    )
+    if not rows:
+        return None
+    row = rows[0]
+    for column in _JSON_LIST_COLUMNS:
+        value = row.get(column)
+        row[column] = json.loads(value) if isinstance(value, str) else (value or [])
+    row["has_coscheduling"] = bool(row.get("has_coscheduling"))
+    return SimpleNamespace(**row)
+
+
+def _stored_workdir_files(client: ControllerServiceClientSync, job_id: str) -> dict[str, bytes]:
+    """Read the job's workdir files, hex-encoded so they survive the query RPC."""
+    rows = query_dicts(
+        client,
+        f"SELECT filename, hex(data) AS data_hex FROM job_workdir_files WHERE job_id = {sql_literal(job_id)}",
+    )
+    return {row["filename"]: bytes.fromhex(row["data_hex"]) for row in rows}
+
+
+@job.command("restore")
+@click.argument("job_id", nargs=-1)
+@click.option("--stdin", is_flag=True, help="Read job IDs from stdin (first field of each line)")
+@click.option("--dry-run", is_flag=True, help="Show what would be relaunched without submitting")
+@click.pass_context
+def restore(ctx, job_id: tuple[str, ...], stdin: bool, dry_run: bool) -> None:
+    """Relaunch finished jobs from the config the controller already stores.
+
+    Every input a job was submitted with — entrypoint, environment, resources,
+    constraints, workdir files, and the workspace bundle id — is kept in the
+    controller database, so a job can be put back without the submitting client,
+    its workspace, or its original machine. Use this to restart work that a
+    control-plane fault ended rather than the job's own code.
+
+    The job keeps its id and owner, so this replaces the finished run in place
+    rather than creating a differently-named copy. Child jobs are not restored
+    directly: a parent recreates its own children when it runs again.
+    """
+    targets = _collect_targets(job_id, stdin)
+    if not targets:
+        raise click.UsageError("No job IDs provided")
+
+    controller_url = require_controller_url(ctx)
+    restored: list[str] = []
+    with rpc_client_for_ctx(ctx, url=controller_url) as client:
+        for target in targets:
+            row = _stored_job_row(client, target)
+            if row is None:
+                click.echo(f"skip {target}: no stored config")
+                continue
+
+            request = reconstruct_launch_job_request(row, workdir_files=_stored_workdir_files(client, target))
+            # The reconstructor names the job from the stored ``name`` column, which
+            # is lowercased; ``job_id`` keeps the case the job was submitted under.
+            # Launching under ``name`` would fork a second job at a different id and
+            # leave the one being restored untouched.
+            request.name = row.job_id
+            # The stored policy is the one that governed the original submission;
+            # a restore always means "this id should be running again".
+            request.existing_job_policy = job_pb2.EXISTING_JOB_POLICY_RECREATE
+            request.fail_if_exists = False
+            # Freshness is judged against the client submitting now, not the
+            # long-finished run being restored.
+            request.client_revision_date = date.today().isoformat()
+
+            state = job_state_friendly(row.state)
+            if dry_run:
+                click.echo(f"would restore {target} (state={state}, tasks={request.replicas})")
+                continue
+
+            client.launch_job(request)
+            restored.append(target)
+            click.echo(f"restored {target} (was {state})")
+
+    if restored and not dry_run:
+        click.echo(f"\nRestored {len(restored)} job(s).")

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -33,6 +33,7 @@ from iris.cli.connect import iris_client_for_ctx, require_controller_url, rpc_cl
 from iris.cli.raw_query import query_dicts, sql_literal
 from iris.client import IrisClient
 from iris.client.client import Job, JobFailedError
+from iris.cluster.client.remote_client import LAUNCH_JOB_TIMEOUT_FLOOR_MS
 from iris.cluster.constraints import (
     CLUSTER_CONSTRAINT_KEY,
     Constraint,
@@ -57,6 +58,7 @@ from iris.cluster.platforms.k8s.coreweave_topology import (
 from iris.cluster.redaction import redact_submit_argv
 from iris.cluster.tpu_topology import get_tpu_topology
 from iris.cluster.types import (
+    TERMINAL_JOB_STATES,
     TERMINAL_TASK_STATES,
     CoschedulingConfig,
     Entrypoint,
@@ -1582,6 +1584,12 @@ def restore(ctx, job_id: tuple[str, ...], stdin: bool, dry_run: bool) -> None:
             if row is None:
                 click.echo(f"skip {target}: no stored config")
                 continue
+            # RECREATE cancels a job that is still going, and targets often arrive
+            # from a piped query whose results have moved on. Stop it first if
+            # replacing live work is really the intent.
+            if row.state not in TERMINAL_JOB_STATES:
+                click.echo(f"skip {target}: still {job_state_friendly(row.state)}")
+                continue
 
             request = reconstruct_launch_job_request(row, workdir_files=_stored_workdir_files(client, target))
             # The reconstructor names the job from the stored ``name`` column, which
@@ -1602,7 +1610,9 @@ def restore(ctx, job_id: tuple[str, ...], stdin: bool, dry_run: bool) -> None:
                 click.echo(f"would restore {target} (state={state}, tasks={request.replicas})")
                 continue
 
-            client.launch_job(request)
+            # Replacing a finished job can block on its worker-bound attempts
+            # draining, which outlasts the default per-call deadline.
+            client.launch_job(request, timeout_ms=LAUNCH_JOB_TIMEOUT_FLOOR_MS)
             restored.append(target)
             click.echo(f"restored {target} (was {state})")
 

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -18,6 +18,7 @@ import time
 from datetime import date
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 
 import click
 import humanfriendly
@@ -45,7 +46,7 @@ from iris.cluster.constraints import (
     region_constraint,
     zone_constraint,
 )
-from iris.cluster.controller.codec import reconstruct_launch_job_request
+from iris.cluster.controller.codec import LaunchJobRow, reconstruct_launch_job_request
 from iris.cluster.controller.schema import JSONList, job_config_table
 from iris.cluster.platforms.k8s.coreweave_topology import (
     COSCHEDULE_NVLINK_DOMAIN_SLICED,
@@ -1514,11 +1515,15 @@ def logs(
 _JSON_LIST_COLUMNS = frozenset(c.name for c in job_config_table.columns if isinstance(c.type, JSONList))
 
 
-def _stored_job_row(client: ControllerServiceClientSync, job_id: str) -> SimpleNamespace | None:
-    """Read the stored config of *job_id* in the shape the reconstructor expects."""
+def _stored_job_row(client: ControllerServiceClientSync, job_id: str) -> LaunchJobRow | None:
+    """Read the stored config of *job_id* in the shape the reconstructor expects.
+
+    ``state`` rides along so the caller can report what it replaced; the rest of
+    the row is the ``LaunchJobRow`` read surface.
+    """
     rows = query_dicts(
         client,
-        "SELECT c.*, j.num_tasks, j.user_id, j.state "
+        "SELECT c.*, j.num_tasks, j.state "
         "FROM job_config c JOIN jobs j ON j.job_id = c.job_id "
         f"WHERE c.job_id = {sql_literal(job_id)}",
     )
@@ -1529,11 +1534,17 @@ def _stored_job_row(client: ControllerServiceClientSync, job_id: str) -> SimpleN
         value = row.get(column)
         row[column] = json.loads(value) if isinstance(value, str) else (value or [])
     row["has_coscheduling"] = bool(row.get("has_coscheduling"))
-    return SimpleNamespace(**row)
+    # The field set comes from `SELECT c.*`, so the schema decides it; the cast
+    # records that this is the reconstructor's row shape without restating it.
+    return cast(LaunchJobRow, SimpleNamespace(**row))
 
 
 def _stored_workdir_files(client: ControllerServiceClientSync, job_id: str) -> dict[str, bytes]:
-    """Read the job's workdir files, hex-encoded so they survive the query RPC."""
+    """Read the job's workdir files.
+
+    ``data`` is a BLOB and the query RPC carries JSON, so it crosses as hex and
+    is decoded back to bytes here.
+    """
     rows = query_dicts(
         client,
         f"SELECT filename, hex(data) AS data_hex FROM job_workdir_files WHERE job_id = {sql_literal(job_id)}",

--- a/lib/iris/src/iris/cli/query.py
+++ b/lib/iris/src/iris/cli/query.py
@@ -5,18 +5,13 @@
 
 import csv
 import io
-import json
 
 import click
 from tabulate import tabulate
 
 from iris.cli.connect import require_controller_url, rpc_client_for_ctx
+from iris.cli.raw_query import parse_rows
 from iris.rpc import query_pb2
-
-
-def _parse_rows(response_rows: list[str]) -> list[list[object]]:
-    """Decode JSON-encoded row arrays from the query response."""
-    return [json.loads(row) for row in response_rows]
 
 
 def _format_table(columns: list[query_pb2.ColumnMeta], rows: list[list[object]]) -> str:
@@ -66,7 +61,7 @@ def query_cmd(ctx: click.Context, sql: str, fmt: str) -> None:
         response = client.execute_raw_query(request)
 
     columns = list(response.columns)
-    rows = _parse_rows(list(response.rows))
+    rows = parse_rows(response)
     formatter = _FORMATTERS[fmt]
     output = formatter(columns, rows)
 

--- a/lib/iris/src/iris/cli/raw_query.py
+++ b/lib/iris/src/iris/cli/raw_query.py
@@ -1,0 +1,31 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for CLI commands that read the controller DB over ExecuteRawQuery.
+
+The RPC returns each row as a JSON-encoded array alongside a separate column
+list, so every caller has to decode and, usually, zip the two back together.
+"""
+
+import json
+
+from iris.rpc import query_pb2
+from iris.rpc.controller_connect import ControllerServiceClientSync
+
+
+def sql_literal(value: str) -> str:
+    """Quote *value* as a SQL string literal."""
+    escaped = value.replace("'", "''")
+    return f"'{escaped}'"
+
+
+def parse_rows(response: query_pb2.RawQueryResponse) -> list[list]:
+    """Decode a raw-query response into positional row values."""
+    return [json.loads(row) for row in response.rows]
+
+
+def query_dicts(client: ControllerServiceClientSync, sql: str) -> list[dict]:
+    """Run *sql* against the controller and return rows keyed by column name."""
+    response = client.execute_raw_query(query_pb2.RawQueryRequest(sql=sql))
+    names = [column.name for column in response.columns]
+    return [dict(zip(names, values, strict=True)) for values in parse_rows(response)]

--- a/lib/iris/src/iris/cluster/controller/codec.py
+++ b/lib/iris/src/iris/cluster/controller/codec.py
@@ -19,6 +19,42 @@ from iris.cluster.types import get_gpu_count, get_tpu_count
 from iris.rpc import controller_pb2, job_pb2
 
 
+class LaunchJobRow(Protocol):
+    """Structural shape of the joined ``jobs``/``job_config`` row a launch is rebuilt from.
+
+    Names the exact read surface of :func:`reconstruct_launch_job_request`, so a
+    caller assembling the row itself (a federated handoff, a restore from the CLI)
+    can tell what it has to supply. ``ports_json`` and ``submit_argv_json`` are
+    decoded lists, not the JSON text of the underlying column.
+    """
+
+    name: str
+    bundle_id: str
+    num_tasks: int
+    max_task_failures: int
+    max_retries_failure: int
+    max_retries_preemption: int
+    preemption_policy: int
+    existing_job_policy: int
+    priority_band: int
+    container_profile: int
+    task_image: str
+    fail_if_exists: bool
+    entrypoint_json: str
+    environment_json: str
+    res_cpu_millicores: int
+    res_memory_bytes: int
+    res_disk_bytes: int
+    res_device_json: str | None
+    constraints_json: str | None
+    ports_json: list
+    submit_argv_json: list
+    has_coscheduling: bool
+    coscheduling_group_by: str
+    scheduling_timeout_ms: int | None
+    timeout_ms: int | None
+
+
 class WorkerAttributeRow(Protocol):
     """Structural shape of a ``worker_attributes`` SA row read by the value decoders."""
 
@@ -151,7 +187,7 @@ def resource_spec_from_job_row(job: Any) -> job_pb2.ResourceSpecProto:
 
 
 def reconstruct_launch_job_request(
-    job, *, workdir_files: dict[str, bytes]
+    job: LaunchJobRow, *, workdir_files: dict[str, bytes]
 ) -> controller_pb2.Controller.LaunchJobRequest:
     """Reconstruct a LaunchJobRequest proto from native job columns.
 


### PR DESCRIPTION
`iris job restore <job_id>` rebuilds a job's LaunchJobRequest from the config the controller already holds — entrypoint, environment, resources, constraints, workdir files, and bundle id — and relaunches it under the same job id and owner. It takes `--stdin` and `--dry-run`, so an `iris query` selection pipes into it the way it does into `kick` and `stop`.

The point is that the submitting client is not needed. A control-plane fault can end jobs whose submitters were laptops that are long gone, and until now the only recovery was to ask each owner to resubmit. Restoring cw-us-east-02a after the pod-name incident (#7542) put 12 of 13 root jobs back from a single checkout with no access to any submitter's workspace, including four grug training runs that had been up for nine days. The one job that could not be restored had had its bundle garbage-collected after 20 days, which no amount of stored config recovers.

The relaunch is named from the job id, not `job_config.name`: `name` is stored lowercased, so launching from it forks a second job at a different id and leaves the one being restored untouched. That happened on the first pass of the recovery and cost three duplicate jobs. Child jobs are not restored directly, since a parent recreates its own children when it runs again.

`reconstruct_launch_job_request` gains a `LaunchJobRow` protocol naming the row it reads, declared beside the existing `WorkerAttributeRow`. Both callers assemble that row now — the federated handoff from an SA row, this command from a query result — and only the handoff previously had a typed object to lean on. Raw-query row decoding and SQL literal quoting move to `iris/cli/raw_query.py`; `query.py` and `cluster.py` each had their own copy.

`restore` is a stopgap for the missing `describe`/`events`/`spec` vocabulary discussed in #7543, not a replacement for it.
