### PR TITLE
[inference] Retry vLLM startup on transient streamer read faults

### DIFF
--- a/lib/marin/src/marin/inference/vllm_server.py
+++ b/lib/marin/src/marin/inference/vllm_server.py
@@ -19,6 +19,7 @@ from urllib.parse import urlparse
 
 import requests
 from rigging.filesystem import marin_prefix
+from rigging.timing import Deadline, ExponentialBackoff, retry_with_backoff
 
 from marin.inference.config import WORKER_PYTHON_VERSION, InferenceModelConfig, VllmCompilationCacheMode
 from marin.inference.tpu_vllm_pins import tpu_inference_fork_ref, vllm_fork_ref
@@ -39,6 +40,12 @@ _RUNAI_STREAMER_REQUIREMENT = "runai-model-streamer[s3]==0.16.0"
 _CUDA_TORCH_BACKEND = "cu130"
 _FLASHINFER_SAMPLER_ENV_VAR = "VLLM_USE_FLASHINFER_SAMPLER"
 _AWS_CONFIG_FILE_ENV_VAR = "AWS_CONFIG_FILE"
+# libstreamer's read-fault text: startup is retried on this, and permanently failed on anything else.
+_RUNAI_STREAMER_READ_MARKER = "could not receive runai_response"
+
+
+class TransientStartupError(RuntimeError):
+    """A vLLM startup failure whose child logs show a transient Run:ai streamer read fault."""
 
 
 class VllmLauncher(Protocol):
@@ -433,7 +440,7 @@ def _engine_kwargs_to_cli_args(engine_kwargs: dict) -> list[str]:
 def _poll_until_ready(
     server_url: str,
     *,
-    timeout_seconds: int,
+    timeout_seconds: float,
     poll_interval_seconds: float = 5,
     check_alive: Callable[[], None] | None = None,
 ) -> None:
@@ -684,26 +691,37 @@ def _launch_vllm_process(
     )
 
 
-def _wait_for_vllm_server(handle: VllmServerHandle, *, command: list[str], timeout_seconds: int) -> None:
+def _wait_for_vllm_server(
+    handle: VllmServerHandle,
+    *,
+    command: list[str],
+    timeout_seconds: float,
+    poll_interval_seconds: float = 5,
+) -> None:
     process = handle.process
     assert handle.log_pump is not None
 
     def _check_process_alive() -> None:
-        if process.poll() is not None:
-            # Child has exited; drain the readers before reading the tail so it has the final lines.
-            handle.log_pump.join(timeout=5)
-            logs = _native_logs_tail(handle.log_dir)
-            raise RuntimeError(
-                "vLLM server process exited before becoming ready.\n"
-                f"Command: {command}\n"
-                f"Exit code: {process.returncode}\n"
-                f"Logs: {handle.log_dir}\n"
-                f"{logs}"
-            )
+        if process.poll() is None:
+            return
+        # Child has exited; drain the readers before reading the tail so it has the final lines.
+        handle.log_pump.join(timeout=5)
+        message = (
+            "vLLM server process exited before becoming ready.\n"
+            f"Command: {command}\n"
+            f"Exit code: {process.returncode}\n"
+            f"Logs: {handle.log_dir}\n"
+            f"{_native_logs_tail(handle.log_dir)}"
+        )
+        # The fault is already in the tail carried by ``message``, so classify off that.
+        if _RUNAI_STREAMER_READ_MARKER in message.lower():
+            raise TransientStartupError(message)
+        raise RuntimeError(message)
 
     _poll_until_ready(
         handle.server_url,
         timeout_seconds=timeout_seconds,
+        poll_interval_seconds=poll_interval_seconds,
         check_alive=_check_process_alive,
     )
 
@@ -717,11 +735,20 @@ def _start_vllm_native_server(
     extra_cli_args: list[str] | None = None,
     launcher: VllmLauncher | None = None,
     compilation_cache_mode: VllmCompilationCacheMode = VllmCompilationCacheMode.MANAGED,
+    max_attempts: int = 3,
+    poll_interval_seconds: float = 5,
+    backoff: ExponentialBackoff | None = None,
 ) -> VllmServerHandle:
-    """Start `vllm serve` as a subprocess and wait until `/v1/models` responds."""
+    """Start `vllm serve` as a subprocess and wait until `/v1/models` responds.
+
+    Retries up to ``max_attempts`` times on a transient streamer read fault, with all attempts sharing
+    one ``timeout_seconds`` deadline. Any other startup failure is raised on the first attempt.
+    """
 
     resolved_port = port if port is not None else 8000
     launcher = launcher or WorkspaceVllm()
+    # Fresh per call (mutable counter); wide jitter de-correlates retriers hitting the fault together.
+    backoff = backoff or ExponentialBackoff(initial=20.0, maximum=120.0, factor=2.0, jitter=0.9)
 
     cmd: list[str] = [
         *launcher.command(),
@@ -737,35 +764,73 @@ def _start_vllm_native_server(
         *(extra_cli_args or []),
     ]
 
-    log_dir = tempfile.mkdtemp(prefix="vllm_server_")
-    cache, native_env = _prepare_vllm_compilation_cache(
-        model_name_or_path=model_name_or_path,
-        extra_cli_args=extra_cli_args,
-        launcher=launcher,
-        mode=compilation_cache_mode,
-    )
-    logger.info(
-        "Starting vLLM native server (output streams to the job log). "
-        f"TPU_MIN_LOG_LEVEL={native_env.get('TPU_MIN_LOG_LEVEL')} "
-        f"TPU_STDERR_LOG_LEVEL={native_env.get('TPU_STDERR_LOG_LEVEL')}"
-    )
     server_url: str = f"http://{host}:{resolved_port}/v1"
-    handle = _launch_vllm_process(
-        command=cmd,
-        environment=native_env,
-        server_url=server_url,
-        port=resolved_port,
-        log_dir=log_dir,
-        compilation_cache=cache,
-    )
+    deadline = Deadline.from_seconds(timeout_seconds)
+    stale_log_dir: str | None = None
+
+    def _attempt() -> VllmServerHandle:
+        nonlocal stale_log_dir
+        # Drop the previous attempt's logs; a failed cleanup only leaks a temp dir, so ignore it.
+        if stale_log_dir is not None:
+            shutil.rmtree(stale_log_dir, ignore_errors=True)
+            stale_log_dir = None
+
+        remaining = deadline.remaining_seconds()
+        if remaining <= 0:
+            raise TimeoutError(f"vLLM startup budget of {timeout_seconds}s exhausted before this attempt.")
+
+        log_dir = tempfile.mkdtemp(prefix="vllm_server_")
+        # Prepared per attempt: a failed attempt's stop() removes the cache workspace with the process.
+        cache, native_env = _prepare_vllm_compilation_cache(
+            model_name_or_path=model_name_or_path,
+            extra_cli_args=extra_cli_args,
+            launcher=launcher,
+            mode=compilation_cache_mode,
+        )
+        logger.info(
+            "Starting vLLM native server (output streams to the job log). "
+            f"TPU_MIN_LOG_LEVEL={native_env.get('TPU_MIN_LOG_LEVEL')} "
+            f"TPU_STDERR_LOG_LEVEL={native_env.get('TPU_STDERR_LOG_LEVEL')}"
+        )
+        handle = _launch_vllm_process(
+            command=cmd,
+            environment=native_env,
+            server_url=server_url,
+            port=resolved_port,
+            log_dir=log_dir,
+            compilation_cache=cache,
+        )
+        try:
+            _wait_for_vllm_server(
+                handle,
+                command=cmd,
+                timeout_seconds=remaining,
+                poll_interval_seconds=poll_interval_seconds,
+            )
+        except Exception:
+            try:
+                handle.stop()
+            except Exception:
+                # Don't let a stop() failure mask the startup failure the classifier needs.
+                logger.warning("vLLM teardown failed after a startup failure", exc_info=True)
+            stale_log_dir = log_dir
+            raise
+        return handle
 
     try:
-        _wait_for_vllm_server(handle, command=cmd, timeout_seconds=timeout_seconds)
-    except Exception:
-        handle.stop()
+        handle = retry_with_backoff(
+            _attempt,
+            retryable=lambda exc: isinstance(exc, TransientStartupError),
+            max_attempts=max_attempts,
+            max_elapsed=timeout_seconds,
+            backoff=backoff,
+            operation="vllm_startup",
+        )
+    except TransientStartupError as exc:
+        exc.add_note(f"vLLM startup failed after {max_attempts} attempts (each a transient Run:ai streamer read fault).")
         raise
 
-    cache.publish()
+    handle.compilation_cache.publish()
 
     # Now that the server answers, forward its /metrics (throughput, TTFT, queue depth) to
     # telltale so it reaches finelog. The metrics endpoint sits at the root, not under /v1.

--- a/tests/inference/fake_vllm_server.py
+++ b/tests/inference/fake_vllm_server.py
@@ -1,0 +1,66 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fake ``vllm serve`` child for test_vllm_server.py: exercises the startup-retry path with no GPU.
+
+``_start_vllm_native_server`` appends ``serve <model> ... --port <p>``, so ``--port`` is read from argv.
+
+Modes:
+  serve                          Answer /v1/models with 200.
+  hang <counter>                 Record the start, then sleep without becoming ready.
+  fail <counter> <n> [message]   Record the start; fail the first <n> starts (printing <message>,
+                                 default the libstreamer fault, to stderr), then serve.
+"""
+
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+STREAMER_FAULT = "ValueError: Could not receive runai_response from libstreamer due to: b'File access error'"
+
+
+def _record_start(counter: str) -> int:
+    path = Path(counter)
+    n = int(path.read_text()) + 1 if path.exists() else 1
+    path.write_text(str(n))
+    return n
+
+
+def _serve() -> None:
+    port = int(sys.argv[sys.argv.index("--port") + 1])
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'{"data": [{"id": "fake-model"}]}')
+
+        def log_message(self, *args) -> None:
+            pass
+
+    HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+
+
+def main() -> None:
+    mode = sys.argv[1]
+    if mode == "serve":
+        _serve()
+    elif mode == "hang":
+        _record_start(sys.argv[2])
+        time.sleep(30)
+    elif mode == "fail":
+        started = _record_start(sys.argv[2])
+        fail_until = int(sys.argv[3])
+        # A custom message is present only when arg 4 is not the appended ``serve`` subcommand.
+        message = sys.argv[4] if len(sys.argv) > 4 and sys.argv[4] != "serve" else STREAMER_FAULT
+        if started <= fail_until:
+            print(message, file=sys.stderr)
+            sys.exit(1)
+        _serve()
+    else:
+        raise SystemExit(f"unknown mode: {mode}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/inference/test_vllm_server.py
+++ b/tests/inference/test_vllm_server.py
@@ -1,21 +1,33 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for native vLLM server log routing.
+"""Tests for the native vLLM server subprocess: log routing and startup retry.
 
 ``_LogPump`` forwards the subprocess's stdout/stderr to the parent's fds and to the on-disk logs,
-routing by severity and flushing/draining on teardown; these exercise that.
+routing by severity and flushing/draining on teardown. A second group covers
+``_start_vllm_native_server``'s bounded retry around a transient Run:ai streamer read fault: it
+retries that fault, fails fast on anything else, and shares one deadline across all attempts.
 """
 
 import os
+import socket
 import subprocess
 import sys
 import time
 from pathlib import Path
 
+import pytest
 from marin.inference.config import VllmCompilationCacheMode
 from marin.inference.vllm_cache import VllmCompilationCache, VllmCompileIdentity
-from marin.inference.vllm_server import VllmServerHandle, _engine_kwargs_to_cli_args, _LogPump, _native_logs_tail
+from marin.inference.vllm_server import (
+    TransientStartupError,
+    VllmServerHandle,
+    _engine_kwargs_to_cli_args,
+    _LogPump,
+    _native_logs_tail,
+    _start_vllm_native_server,
+)
+from rigging.timing import ExponentialBackoff
 
 
 def test_engine_kwargs_forward_dtype_to_vllm_command() -> None:
@@ -141,3 +153,88 @@ def test_handle_stop_terminates_drains_and_is_idempotent(tmp_path, monkeypatch):
     assert not compilation_cache_root.exists()
 
     handle.stop(timeout_seconds=5)  # second call must not raise
+
+
+# --- bounded retry around a transient Run:ai streamer read fault during startup ---
+
+_FAKE_VLLM_SERVER = str(Path(__file__).parent / "fake_vllm_server.py")
+_FAST_BACKOFF = ExponentialBackoff(initial=0.001, maximum=0.01, factor=2.0, jitter=0.0)
+
+
+class _FakeLauncher:
+    """Runs fake_vllm_server.py (see its modes) in place of the real ``vllm serve`` child."""
+
+    def __init__(self, *mode_args: str) -> None:
+        self._mode_args = mode_args
+
+    def command(self) -> list[str]:
+        return [sys.executable, _FAKE_VLLM_SERVER, *self._mode_args]
+
+    def env(self) -> dict[str, str]:
+        return {}
+
+    def cache_identity(self) -> str:
+        return "fake"
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _start(launcher: _FakeLauncher, *, timeout_seconds: float = 30) -> VllmServerHandle:
+    return _start_vllm_native_server(
+        model_name_or_path="fake-model",
+        port=_free_port(),
+        timeout_seconds=timeout_seconds,
+        launcher=launcher,
+        # Managed mode would restore/publish a remote cache archive on every attempt.
+        compilation_cache_mode=VllmCompilationCacheMode.CALLER_MANAGED,
+        max_attempts=3,
+        poll_interval_seconds=0.05,
+        backoff=_FAST_BACKOFF,
+    )
+
+
+def test_serves_when_startup_succeeds():
+    # A returned handle means the fake server answered /v1/models with 200.
+    handle = _start(_FakeLauncher("serve"))
+    handle.stop()
+
+
+def test_retries_streamer_fault_then_serves(tmp_path):
+    counter = tmp_path / "starts"
+    handle = _start(_FakeLauncher("fail", str(counter), "2"))
+    try:
+        assert counter.read_text() == "3"  # two streamer faults, served on the third start
+    finally:
+        handle.stop()
+
+
+def test_fails_fast_on_non_streamer_error(tmp_path):
+    counter = tmp_path / "starts"
+    with pytest.raises(RuntimeError) as excinfo:
+        _start(_FakeLauncher("fail", str(counter), "99", "RuntimeError: CUDA out of memory"))
+    assert not isinstance(excinfo.value, TransientStartupError)
+    assert "CUDA out of memory" in str(excinfo.value)
+    assert counter.read_text() == "1"  # a non-streamer failure is not retried
+
+
+def test_exhausts_retries_then_raises_with_diagnostics(tmp_path):
+    counter = tmp_path / "starts"
+    with pytest.raises(TransientStartupError) as excinfo:
+        _start(_FakeLauncher("fail", str(counter), "99"))
+    assert counter.read_text() == "3"  # retried up to the attempt budget
+    err = excinfo.value
+    assert "Could not receive runai_response from libstreamer" in str(err)  # streamer fault preserved
+    assert "fake-model" in str(err)  # attempted command preserved
+    assert err.__notes__
+
+
+def test_hang_times_out_without_retry(tmp_path):
+    # A live-but-never-ready server raises TimeoutError, not a streamer fault, so it is not retried.
+    counter = tmp_path / "starts"
+    with pytest.raises(TimeoutError):
+        _start(_FakeLauncher("hang", str(counter)), timeout_seconds=0.5)
+    assert counter.read_text() == "1"


### PR DESCRIPTION
Concurrent CoreWeave evals load vLLM weights from an s3:// checkpoint through the
Run:ai model streamer. A transient read fails mid-load with "Could not receive
runai_response from libstreamer due to: File access error", the vLLM subprocess
exits, and the eval fails permanently even though the load usually succeeds on a
retry. This hit 41 distinct TP=8 loads on cw-us-east-02a between 2026-07-18 and 07-22.

Retry startup up to 3 times with jittered backoff when the child's logs show the
streamer read fault; anything else (hang, OOM, bad config) still fails on the first
attempt. libstreamer reports no status code, so a cause-agnostic retry is the fix.
All attempts share the existing startup_timeout_seconds budget, which is also the
parent's endpoint-ready deadline. The per-attempt failure rate measured 41/213 ~= 19%,
leaving under 1% residual after three attempts; verified on 8xH100 that an injected
streamer fault is retried and the next attempt completes a real TP=8 runai_streamer
load from s3.

Part of #7525
