### PR TITLE
[inference] Default GPU serves to local model storage

### DIFF
--- a/lib/marin/src/marin/inference/config.py
+++ b/lib/marin/src/marin/inference/config.py
@@ -19,6 +19,8 @@ WORKER_PYTHON_VERSION = "3.12"
 # participate in Marin's workspace dependency resolution.
 DEFAULT_CUDA_VLLM_VERSION = "0.25.1"
 TPU_VLLM_WORKER_EXTRAS = ("tpu", "vllm")
+TPU_MODEL_CACHE_TTL_DAYS = 14
+GPU_MODEL_CACHE_TTL_DAYS = 0
 
 
 class VllmLauncherType(StrEnum):
@@ -168,14 +170,26 @@ class IrisConfig:
 
     worker_resources: ResourceConfig
     worker_environment: EnvironmentConfig
-    cache_ttl_days: int = 14
+    cache_ttl_days: int | None = None
+    """TTL for the regional object-store model cache.
+
+    ``None`` resolves to 14 days on constrained TPU workers and zero on
+    CoreWeave GPUs.  GPU workers have sufficient local NVMe for normal Hugging
+    Face/vLLM materialization; avoiding the object-store path also avoids the
+    RunAI range-streamer as the default load mechanism.  Pass a nonzero value
+    explicitly to opt a GPU serve into the regional mirror.
+    """
     endpoint_ready_timeout_seconds: float = 1800.0
     priority: int = 0
     max_retries_failure: int = 1
     max_retries_preemption: int = 10
 
     def __post_init__(self) -> None:
-        if self.cache_ttl_days < 0:
+        if isinstance(self.worker_resources, ResourceConfig) and self.cache_ttl_days is None:
+            device = self.worker_resources.device
+            cache_ttl_days = GPU_MODEL_CACHE_TTL_DAYS if device.kind == "gpu" else TPU_MODEL_CACHE_TTL_DAYS
+            object.__setattr__(self, "cache_ttl_days", cache_ttl_days)
+        if self.cache_ttl_days is not None and self.cache_ttl_days < 0:
             raise ValueError("cache_ttl_days must not be negative")
         if self.endpoint_ready_timeout_seconds <= 0:
             raise ValueError("endpoint_ready_timeout_seconds must be positive")

--- a/lib/marin/src/marin/inference/iris.py
+++ b/lib/marin/src/marin/inference/iris.py
@@ -128,7 +128,10 @@ def _resolved_model(model: ServedModelConfig, iris: IrisConfig) -> tuple[ServedM
         select_tensor_parallel_size,
     )
 
-    model_path = model.model_path or resolve_model_path(model.model, iris.cache_ttl_days)
+    cache_ttl_days = iris.cache_ttl_days
+    if cache_ttl_days is None:
+        raise ValueError("IrisConfig must resolve cache_ttl_days before serving")
+    model_path = model.model_path or resolve_model_path(model.model, cache_ttl_days)
     num_chips = iris.worker_resources.device.chip_count()
     tensor_parallel_size = model.tensor_parallel_size
     if tensor_parallel_size is None:

--- a/lib/marin/src/marin/inference/iris_cli.py
+++ b/lib/marin/src/marin/inference/iris_cli.py
@@ -341,7 +341,12 @@ def _mint_and_print_capability_url(
 )
 @click.option("--tensor-parallel-size", type=int, default=None, help="TP size (default: auto from heads + chips).")
 @click.option("--dtype", default="bfloat16", help="Weight/compute dtype.")
-@click.option("--cache-ttl-days", type=int, default=14, help="Mirror HF models to a TTL'd GCS cache (0 disables).")
+@click.option(
+    "--cache-ttl-days",
+    type=click.IntRange(min=0),
+    default=None,
+    help="Mirror HF models to a TTL'd GCS cache. Default: 14 days on TPU, disabled on CoreWeave GPU.",
+)
 @click.option(
     "--no-cache", is_flag=True, default=False, help="Skip the GCS model cache; always download from HuggingFace."
 )
@@ -425,7 +430,7 @@ def main(
     hbm_utilization: float,
     tensor_parallel_size: int | None,
     dtype: str,
-    cache_ttl_days: int,
+    cache_ttl_days: int | None,
     no_cache: bool,
     timeout_hours: float,
     proxy_timeout: float,

--- a/lib/marin/src/marin/inference/vllm_server.py
+++ b/lib/marin/src/marin/inference/vllm_server.py
@@ -78,8 +78,9 @@ class VllmType(StrEnum):
 class IsolatedCudaVllm:
     """Provide an isolated CUDA vLLM command and environment.
 
-    Both variants stream checkpoints from the CoreWeave object store. The Marin fork additionally
-    serves Marin-specific architectures.
+    The Marin fork additionally serves Marin-specific architectures.  CoreWeave
+    serves normally materialize Hugging Face weights on local NVMe; the RunAI
+    streamer is selected only by an explicit object-store model path.
     """
 
     source: VllmType = VllmType.UPSTREAM

--- a/tests/inference/test_serve.py
+++ b/tests/inference/test_serve.py
@@ -17,11 +17,14 @@ import click
 import pytest
 import requests
 from click.testing import CliRunner
-from fray.types import ANY_REGION
+from fray.types import ANY_REGION, ResourceConfig, create_environment
 from iris.rpc import controller_pb2
 from iris.time_proto import timestamp_to_proto
 from marin.inference.config import (
     DEFAULT_CUDA_VLLM_VERSION,
+    GPU_MODEL_CACHE_TTL_DAYS,
+    TPU_MODEL_CACHE_TTL_DAYS,
+    IrisConfig,
     LevanterEngineConfig,
     VllmEngineConfig,
     VllmLauncherType,
@@ -98,6 +101,20 @@ def test_select_tensor_parallel_size(heads, chips, kv_heads, expected):
 def test_resolve_model_path_passthrough(model, ttl_days):
     # These paths must not touch the network or GCS; they return the input unchanged.
     assert resolve_model_path(model, ttl_days) == model
+
+
+def test_iris_config_uses_local_model_materialization_on_gpu_by_default():
+    gpu = IrisConfig(
+        worker_resources=ResourceConfig.with_gpu("H100", count=8),
+        worker_environment=create_environment(extras=["gpu"]),
+    )
+    tpu = IrisConfig(
+        worker_resources=ResourceConfig.with_tpu("v6e-4"),
+        worker_environment=create_environment(extras=["tpu", "vllm"]),
+    )
+
+    assert gpu.cache_ttl_days == GPU_MODEL_CACHE_TTL_DAYS == 0
+    assert tpu.cache_ttl_days == TPU_MODEL_CACHE_TTL_DAYS == 14
 
 
 def test_checkout_free_setup_script_pins_marin_core_with_extras():


### PR DESCRIPTION
CoreWeave GPU inference now leaves Hugging Face model IDs unmirrored by default, so vLLM materializes weights on pod-local NVMe. The previous 14-day object-store cache selected the RunAI S3 loader and produced `File access error` failures in Qwen3.5 and Ling eval serves.

TPU serves retain the 14-day regional cache. Pass `--cache-ttl-days` explicitly to opt a GPU serve into the regional mirror.
