### PR TITLE
fix(inference): materialize GPU weights locally by default

### DIFF
--- a/lib/marin/src/marin/inference/quick_serve.py
+++ b/lib/marin/src/marin/inference/quick_serve.py
@@ -82,9 +82,14 @@ class QuickServeConfig:
     attention-head count and fits the slice's chip count."""
     chat_template_content: str | None = None
     """Inline Jinja chat template; resolved from a path/URL by the CLI."""
-    cache_ttl_days: int = 14
-    """Mirror HF models to a region-local GCS cache with this lifecycle TTL so repeat
-    serves skip the HuggingFace download. ``0`` disables caching; ignored for gs:// paths."""
+    cache_ttl_days: int | None = None
+    """Optional HF mirror TTL; defaults to 14 days on TPU and disabled on GPU.
+
+    CoreWeave GPU workers have ample local NVMe. Mirroring a normal Hugging Face
+    model there first converts it into an object-store path and unnecessarily
+    selects vLLM's Run:ai streaming loader. An explicit non-zero TTL remains
+    available when a mirror is deliberately desired.
+    """
     timeout_hours: float = 24.0
     proxy_timeout_seconds: float = 600.0
     """Registered as endpoint metadata so the controller proxy waits this long for a
@@ -109,6 +114,13 @@ class QuickServeConfig:
         if self.tpu_type is None:
             raise ValueError("QuickServeConfig requires tpu_type on the TPU path (or gpu_count on the GPU path).")
         return get_tpu_topology(self.tpu_type).chips_per_vm
+
+    @property
+    def resolved_cache_ttl_days(self) -> int:
+        """Resolve the accelerator-specific default without overriding user intent."""
+        if self.cache_ttl_days is not None:
+            return self.cache_ttl_days
+        return 0 if self.gpu_count is not None else 14
 
 
 def select_tensor_parallel_size(
@@ -253,7 +265,7 @@ def serve_in_job(config: QuickServeConfig) -> None:
     # the actual bound port so the controller proxy can reach the endpoint.
     serving_port = serving_socket.getsockname()[1]
 
-    model_path = resolve_model_path(config.model, config.cache_ttl_days)
+    model_path = resolve_model_path(config.model, config.resolved_cache_ttl_days)
     spec = build_model_spec(config, model_path)
     accelerator = config.accelerator_label
 

--- a/lib/marin/src/marin/inference/quick_serve_cli.py
+++ b/lib/marin/src/marin/inference/quick_serve_cli.py
@@ -338,7 +338,12 @@ def _mint_and_print_capability_url(
 )
 @click.option("--tensor-parallel-size", type=int, default=None, help="TP size (default: auto from heads + chips).")
 @click.option("--dtype", default="bfloat16", help="Weight/compute dtype.")
-@click.option("--cache-ttl-days", type=int, default=14, help="Mirror HF models to a TTL'd GCS cache (0 disables).")
+@click.option(
+    "--cache-ttl-days",
+    type=click.IntRange(min=0),
+    default=None,
+    help="Mirror HF models to a TTL'd GCS cache. Default: 14 days on TPU; disabled on CoreWeave GPU.",
+)
 @click.option(
     "--no-cache", is_flag=True, default=False, help="Skip the GCS model cache; always download from HuggingFace."
 )
@@ -417,7 +422,7 @@ def main(
     hbm_utilization: float,
     tensor_parallel_size: int | None,
     dtype: str,
-    cache_ttl_days: int,
+    cache_ttl_days: int | None,
     no_cache: bool,
     timeout_hours: float,
     proxy_timeout: float,

--- a/tests/inference/test_quick_serve.py
+++ b/tests/inference/test_quick_serve.py
@@ -16,6 +16,7 @@ from click.testing import CliRunner
 from iris.rpc import controller_pb2
 from iris.time_proto import timestamp_to_proto
 from marin.inference.quick_serve import (
+    QuickServeConfig,
     resolve_model_path,
     select_tensor_parallel_size,
 )
@@ -86,6 +87,13 @@ def test_select_tensor_parallel_size(heads, chips, kv_heads, expected):
 def test_resolve_model_path_passthrough(model, ttl_days):
     # These paths must not touch the network or GCS; they return the input unchanged.
     assert resolve_model_path(model, ttl_days) == model
+
+
+def test_default_model_cache_is_disabled_on_gpu_but_kept_on_tpu():
+    common = {"model": "Qwen/Qwen3-0.6B", "endpoint_name": "/serve/test", "backend": VllmBackend()}
+    assert QuickServeConfig(**common, gpu_type="H100", gpu_count=8).resolved_cache_ttl_days == 0
+    assert QuickServeConfig(**common, tpu_type="v6e-4").resolved_cache_ttl_days == 14
+    assert QuickServeConfig(**common, gpu_type="H100", gpu_count=8, cache_ttl_days=7).resolved_cache_ttl_days == 7
 
 
 def test_checkout_free_setup_script_pins_marin_core_with_extras():


### PR DESCRIPTION
Carries the CoreWeave local-HF-weight default into the canonical Marin baseline-eval branch. GPU defaults to direct local materialization; TPU retains its 14-day mirror and an explicit non-zero TTL remains available. `uv run --package marin-core pytest tests/inference/test_quick_serve.py tests/inference/test_vllm_server.py -q` passes (46 tests).