### PR TITLE
evalchemy: unify CoreWeave GPU eval launcher with local weights

### DIFF
--- a/experiments/evals/evalchemy/marin_evalchemy_gpu.py
+++ b/experiments/evals/evalchemy/marin_evalchemy_gpu.py
@@ -1,0 +1,385 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+"""CoreWeave-GPU driver for the Marin canonical baseline evals (A3B MoEs).
+
+LOCAL / UNCOMMITTED (marin is upstream marin-community/marin — do NOT push/merge).
+GPU sibling of ``marin_evalchemy_tpu.py``, but built on the DECOUPLED ``serve_and_eval``
+path so the serve child runs the marin VllmBackend/vLLM-fork stack (MoE / exotic-arch
+support) and the eval child is a CPU-only ``eval.eval --model local-chat-completions``
+client against the served OpenAI URL (:evalchemy-gpu image, has fsspec/s3fs).
+
+Submits ONE parent CPU orchestrator to ``cw-us-east-02a``; serve_and_eval spawns:
+  * serve child  (8xH100)  — marin VllmBackend, TP=$TP, max_model_len=32768, bf16.
+  * eval  child  (CPU)     — one ``eval.eval`` per task (own num_fewshot), chat route,
+                             --apply_chat_template, --log_samples, --verbosity INFO.
+
+Run from the marin repo root with the marin .venv (kubernetes 35.0.0 present) + secrets
+sourced + the CoreWeave GPU kubeconfig:
+    export DC_AGENT_SECRET_ENV=/Users/benjaminfeuer/Documents/secrets.env
+    set -a; source "$DC_AGENT_SECRET_ENV"; set +a
+    export KUBECONFIG=~/.kube/coreweave-iris-gpu
+    ./.venv/bin/python experiments/evals/evalchemy/marin_evalchemy_gpu.py
+
+Env knobs (all optional; defaults = the Qwen3-30B-A3B-Thinking-2507 pathfinder, tier 1):
+    EVAL_MODEL        HF id to serve+eval          (default Qwen/Qwen3-30B-A3B-Thinking-2507)
+    EVAL_TOKENIZER    HF tokenizer id              (default = EVAL_MODEL)
+    EVAL_TP           tensor_parallel_size         (default 8; must divide num_attention_heads)
+    EVAL_TIER         1 | 2                         (default 1 = 14 lm-harness tasks)
+    EVAL_OUT_PATH     fsspec out_path              (default pod-local /tmp/<slug>-tier<N>out)
+    EVAL_MAX_MODEL_LEN                              (default 32768)
+    EVAL_MAX_GEN_TOKS                              (default 32768)
+    EVAL_NUM_CONCURRENT                            (default 16)
+    EVAL_TRUST_REMOTE_CODE  "1" to note it (serve child trust_remote_code — see NOTE below)
+    EVAL_JOB_SUFFIX   extra tag on the job name
+"""
+from __future__ import annotations
+
+import os
+import re
+import time
+import uuid
+from pathlib import Path
+
+from iris.cli.connect import open_iris_client
+from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec
+from iris.rpc import job_pb2
+
+from experiments.evals.evalchemy.serve_and_eval import (
+    EvalchemyEvalConfig,
+    ServeBackend,
+    ServeSpec,
+    serve_and_eval,
+)
+from marin.evaluation.evaluation_config import EvalTaskConfig
+
+CLUSTER = "cw-us-east-02a"
+# :evalchemy-gpu (built via evalchemy infra/docker/build_evalchemy_gpu_kaniko.sh, PR #18) — CPU-only eval
+# client; python at /opt/eval/evalchemy/.venv. Pinned to evalchemy main HEAD 676fb85f which carries #28
+# (per-sample records now persist for lm-eval-native tasks under --log_samples → offline rescore, e.g. drop).
+EVAL_IMAGE = os.environ.get(
+    "EVAL_IMAGE", "ghcr.io/open-thoughts/openthoughts-agent:evalchemy-gpu-676fb85f"
+)
+EVAL_PYTHON = os.environ.get("EVAL_PYTHON", "/opt/eval/evalchemy/.venv/bin/python")
+
+# --- Tier 1: 14 lm-eval-harness tasks (POLICY §3; per-task shots). 1 run, seed 42. ---
+TIER1_TASKS = (
+    EvalTaskConfig("gsm8k", 0),
+    EvalTaskConfig("mmlu", 5),
+    EvalTaskConfig("hellaswag", 10),
+    EvalTaskConfig("arc_challenge", 25),
+    EvalTaskConfig("arc_easy", 0),
+    EvalTaskConfig("piqa", 0),
+    EvalTaskConfig("winogrande", 5),
+    EvalTaskConfig("openbookqa", 0),
+    EvalTaskConfig("boolq", 0),
+    EvalTaskConfig("truthfulqa_mc2", 0),
+    EvalTaskConfig("lambada_openai", 0),
+    EvalTaskConfig("triviaqa", 5),
+    EvalTaskConfig("nq_open", 5),
+    EvalTaskConfig("drop", 3),
+)
+
+# --- Tier 2: evalchemy chat benchmarks (POLICY §3). Names VERIFIED against the evalchemy fork's
+#     eval/chat_benchmarks/ dirs (the authoritative registry). ⚠ OlympiadBench + FinanceBench are NOT
+#     in this fork → omitted (flagged to operator). IFBench→IFEval (the fork's constraint benchmark).
+#     AIME24 = 10-seed (42..51) via EVAL_TIER=2 seed handling in the driver/client. ---
+TIER2_TASKS = (
+    EvalTaskConfig("MATH500", 0),
+    # AIME24 is NOT here — it runs as a dedicated 10-seed μ±σ set (EVAL_TASK_SET=aime24_seeds).
+    EvalTaskConfig("HumanEvalPlus", 0),
+    EvalTaskConfig("MBPPPlus", 0),
+    # MMLUPro DEFERRED — fork construction load_dataset fails (not a clean pip dep); N/A in RESULTS.
+    EvalTaskConfig("GPQADiamond", 0),
+    # CruxEval DEFERRED — the fork's CruxEval does `from execution import ...` (local-module import,
+    # not a pip dep) → registration fails; not a clean install. Marked N/A in RESULTS.
+    EvalTaskConfig("IFEval", 0),
+)
+
+
+def _slug(model: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", model.lower()).strip("-")
+
+
+def _is_thinking(model: str) -> bool:
+    """Thinking/reasoning models emit long CoT under the chat template → they truncate tier-2
+    generative benchmarks at 20480 (MATH500/HumanEval → 0) and need the near-full window. The 3
+    thinking baselines: Qwen3-*-Thinking + Qwen3.5 (thinking-on default). Instruct/chat models don't."""
+    m = model.lower()
+    return "thinking" in m or "qwen3.5" in m or "qwen3-next" in m
+
+
+def _auto_serve_overrides(model: str, requested_max_model_len: int):
+    """Per-model serve mitigations derived from the model's config.json (durable + automatic, so both
+    tiers + every launch carry them identically). Returns (extra_args_tuple, effective_max_model_len).
+
+    - GDN hybrid (gated-delta-net linear attention: Qwen3-Next, Qwen3.5) → `--gdn-prefill-backend triton`.
+      Maintainer-blessed mitigation (marin #7373 — Romain: pass via ServeSpec.vllm_extra_args; the
+      FlashInfer GDN prefill kernel is JIT-compiled and needs nvcc, absent in the uvx serve env).
+    - Multimodal wrapper (vision tower / *ForConditionalGeneration: Qwen3.5) → `--limit-mm-per-prompt
+      {"image":0,"video":0}` for text-only serving.
+    - Cap max_model_len at the model's native context (Moonlight = 8192; else vLLM ValidationError).
+    """
+    extra: list[str] = []
+    mml = requested_max_model_len
+    cfg: dict = {}
+    try:
+        import json as _json
+        from huggingface_hub import hf_hub_download
+        cfg = _json.load(open(hf_hub_download(model, "config.json")))
+    except Exception as e:  # noqa: BLE001
+        print(f"[warn] config.json fetch failed for {model}: {e!r}; using request defaults")
+    txt = __import__("json").dumps(cfg).lower()
+    arch = " ".join(cfg.get("architectures") or []).lower()
+    tcfg = cfg.get("text_config", cfg) if isinstance(cfg.get("text_config", cfg), dict) else cfg
+    if ("gated_delta_net" in txt or "linear_attn" in txt or "qwen3next" in arch
+            or "qwen3_5" in arch or "qwen3.5" in model.lower() or "qwen3-next" in model.lower()):
+        extra += ["--gdn-prefill-backend", "triton"]
+    if cfg.get("vision_config") or "forconditionalgeneration" in arch:
+        extra += ["--limit-mm-per-prompt", '{"image":0,"video":0}']
+    # Reasoning parser for thinking models (POLICY §5): the model emits <think>…</think> then the
+    # answer; without a parser the chat endpoint returns empty `content` for evalchemy graders → 0.
+    # `qwen3` parser splits reasoning_content from content so the grader sees the post-</think> answer.
+    ml = model.lower()
+    if ("thinking" in ml or "qwen3.5" in ml or "qwen3-next" in ml) and "qwen" in ml:
+        extra += ["--reasoning-parser", "qwen3"]
+    mpe = tcfg.get("max_position_embeddings") or cfg.get("max_position_embeddings")
+    if isinstance(mpe, (int, float)) and int(mpe) < mml:
+        mml = int(mpe)
+    return tuple(extra), mml
+
+
+# ── Baked per-model eval defaults: the Delphi grug THINKING checkpoint ─────────────────────────────
+# A no-override launch (just EVAL_MODEL=<grug>) MUST produce valid MATH500/AIME: correct context/gen
+# split (the gen budget must NOT consume the whole context, or a long prompt overflows → vLLM 400s →
+# EMPTY results — the bug this bakes out), the atomic <|start_think|>/<|end_think|> delimiters intact,
+# the Delphi chat_template (NOT the generic `main` /think template), and the answer-channel loop curbed.
+# Every value below is a DEFAULT — the matching EVAL_* env var still overrides it.
+PROMPT_HEADROOM = 4096  # min context reserved for the prompt; default gen budget = max_model_len − this.
+GRUG_THINKING_MODELS = {"penfever/grug-67b-a2b-sft-s2-thinking-step630"}
+
+
+def _is_grug_thinking(model: str) -> bool:
+    m = model.lower()
+    return model in GRUG_THINKING_MODELS or ("grug" in m and "thinking" in m)
+
+
+def _grug_profile(model: str) -> dict:
+    """Baked eval defaults for the Delphi grug thinking checkpoint ({} for any other model)."""
+    if not _is_grug_thinking(model):
+        return {}
+    return {
+        "tp": 1,  # 256-expert MoE: experts shard via data + expert parallelism, NOT tensor parallelism
+        "revision": "delphi-v0-think",  # the checkpoint revision carrying the Delphi chat_template (NOT main)
+        "tokenizer": "penfever/grug-67b-a2b-sft-s2-thinking-step630-tok",
+        # grug MoE expert-parallel serve; --revision selects the Delphi-template checkpoint.
+        "vllm_extra_args": ("--data-parallel-size", "8", "--enable-expert-parallel",
+                            "--model-loader-extra-config", '{"distributed":true}',
+                            "--revision", "delphi-v0-think"),
+        # skip_special_tokens=false → PRESERVE the atomic 128002/128003 delimiters (default True strips
+        # them → model looks like it emits no CoT). repetition_penalty=1.1 → curb the answer-channel
+        # loops (marin #7321) so long-CoT MATH500/GPQA samples terminate + box within the gen budget.
+        "extra_gen_kwargs": {"skip_special_tokens": "false", "repetition_penalty": "1.1"},
+    }
+
+
+def _grug_chat_template(model: str, revision: str) -> str | None:
+    """Fetch the Delphi thinking chat_template.jinja from the model's revision (it carries the
+    <|start_think|>/<|end_think|> machinery). cw nodes have egress. Returns None on failure so the serve
+    degrades to the repo's own template rather than hard-failing the launch."""
+    try:
+        from huggingface_hub import hf_hub_download  # noqa: PLC0415
+        return Path(hf_hub_download(model, "chat_template.jinja", revision=revision)).read_text()
+    except Exception as e:  # noqa: BLE001
+        print(f"[warn] grug chat_template fetch failed (rev={revision}): {e!r}; using served repo template")
+        return None
+
+
+def build_config(model: str, tokenizer: str, tier: int) -> EvalchemyEvalConfig:
+    prof = _grug_profile(model)  # baked defaults for the Delphi grug thinking checkpoint ({} otherwise)
+    tp = int(os.environ.get("EVAL_TP", str(prof.get("tp", 8))))
+    max_model_len = int(os.environ.get("EVAL_MAX_MODEL_LEN", "32768"))
+    # ⚠ max_gen_toks MUST be < max_model_len (prompt + max_tokens ≤ context, else vLLM 400s every
+    # request). Default 20480 leaves ~12k for even 25-shot prompts. lm-harness loglikelihood/MC tasks
+    # ignore it (max_tokens=0); it only bounds the 4 generative tasks (gsm8k/triviaqa/nq_open/drop).
+    # Tier-2 budget is MODEL-CLASS-dependent: thinking/GDN models need ~30720 (near-full 32k) for
+    # their CoT + boxed answer under the chat template; instruct models finish at 20480. Tier-1 uses
+    # 20480 (completion-style, shorter). AIME already forces 30720 via EVAL_MAX_GEN_TOKS in the launcher.
+    # grug thinking: size the gen budget to LEAVE prompt headroom (max_model_len − PROMPT_HEADROOM =
+    # 28672 @ 32k) so the CoT budget can't starve a long prompt into a context overflow → EMPTY result
+    # (marin #7321). Other thinking/GDN models keep the historical near-full 30720; instruct 20480.
+    _default_gen = (max_model_len - PROMPT_HEADROOM) if prof else (30720 if (tier == 2 and _is_thinking(model)) else 20480)
+    max_gen_toks = int(os.environ.get("EVAL_MAX_GEN_TOKS", str(_default_gen)))
+    num_concurrent = int(os.environ.get("EVAL_NUM_CONCURRENT", "16"))
+    # Per-model serve mitigations (GDN triton / limit-mm / native-context cap) derived automatically
+    # from config.json — durable + identical across tiers, no hand-passed flags.
+    # grug thinking: default the serve args to the expert-parallel + delphi-v0-think-revision set (env wins).
+    env_extra = (tuple(os.environ["EVAL_VLLM_EXTRA_ARGS"].split()) if os.environ.get("EVAL_VLLM_EXTRA_ARGS")
+                 else tuple(prof.get("vllm_extra_args", ())))
+    auto_extra, max_model_len = _auto_serve_overrides(model, max_model_len)
+    # Merge: env-passed flags win; append an auto flag only if its flag-name isn't already present.
+    merged = list(env_extra)
+    i = 0
+    while i < len(auto_extra):
+        flag = auto_extra[i]
+        pair = auto_extra[i:i + 2] if (i + 1 < len(auto_extra) and not auto_extra[i + 1].startswith("--")) else auto_extra[i:i + 1]
+        if flag not in merged:
+            merged += list(pair)
+        i += len(pair)
+    vllm_extra_args = tuple(merged)
+    # max_gen_toks MUST stay < max_model_len (else vLLM 400s / decoder-prompt-empty). Cap with ~4k
+    # prompt headroom — critical for small-context models (Moonlight 8192 → 4096).
+    if max_gen_toks >= max_model_len:
+        max_gen_toks = max(1024, max_model_len - 4096)
+    # Tier 1 (lm-harness) → local-completions (/completions logprob endpoint, NO chat template): the
+    # 10 MC/loglikelihood tasks REQUIRE /completions (chat/completions can't score forced continuations),
+    # matching marin's canonical `marin/evaluation/lm_eval.py` default (LOCAL_COMPLETIONS, apply_chat_template=False).
+    # Tier 2 (evalchemy chat benchmarks) → chat template ON (generative graders). Override via EVAL_APPLY_CHAT_TEMPLATE.
+    _act_env = os.environ.get("EVAL_APPLY_CHAT_TEMPLATE")
+    apply_chat_template = (_act_env == "1") if _act_env is not None else (tier == 2)
+    tasks = TIER1_TASKS if tier == 1 else TIER2_TASKS
+    # Subset override (serial tier-2 rerun of only the un-banked benchmarks): EVAL_TIER2_TASKS as a
+    # comma list of benchmark names (e.g. "MATH500,MBPPPlus,GPQADiamond,IFEval" to skip an already-
+    # harvested HumanEvalPlus). Applies on the tier-2 path; num_fewshot 0 (tier-2 is all 0-shot chat).
+    if tier == 2 and os.environ.get("EVAL_TIER2_TASKS"):
+        tasks = tuple(EvalTaskConfig(n.strip(), 0) for n in os.environ["EVAL_TIER2_TASKS"].split(",") if n.strip())
+    # Fast diagnostic smoke: a generative task (gsm8k) + an MC/loglikelihood task (hellaswag), small
+    # --limit → proves BOTH request types score non-empty over local-completions before the full suite.
+    if os.environ.get("EVAL_SMOKE") == "1":
+        tasks = (EvalTaskConfig("gsm8k", 0), EvalTaskConfig("hellaswag", 10))
+    # AIME24 10-seed μ±σ (POLICY §3): one process per seed 42..51, distinct dir per seed (task_alias)
+    # so results don't overwrite. Harvest = mean±std over the 10 pass@1 values.
+    if os.environ.get("EVAL_TASK_SET") == "math500":  # one-benchmark chat smoke (reasoning-parser test)
+        tasks = (EvalTaskConfig("MATH500", 0),)
+        apply_chat_template = True
+    if os.environ.get("EVAL_TASK_SET") == "aime24_seeds":
+        # Seeds: EVAL_AIME_SEEDS as a comma list (e.g. "42,43,44") — MARIN_EVAL_POLICY is 3-seed
+        # (seeds 42,43,44; report the mean). Default = the historical 10-seed set (42..51) for back-compat.
+        _seed_env = os.environ.get("EVAL_AIME_SEEDS")
+        _seeds = [int(s) for s in _seed_env.split(",") if s.strip()] if _seed_env else list(range(42, 52))
+        tasks = tuple(
+            EvalTaskConfig("AIME24", 0, task_alias=f"AIME24_seed{s}", task_kwargs={"seed": s})
+            for s in _seeds
+        )
+        apply_chat_template = True
+    max_eval_instances = int(os.environ["EVAL_LIMIT"]) if os.environ.get("EVAL_LIMIT") else None
+    # LOCAL (grug thinking model): serve a chat template the model's repo does not carry a vLLM-loadable
+    # copy of (or override it). EVAL_CHAT_TEMPLATE_FILE → ServeSpec.chat_template_content (server renders
+    # /v1/chat/completions with it). For Delphi grug this is the delphi_v0_think jinja carrying the
+    # <|start_think|>/<|end_think|> machinery — the marin `/think` default in the repo would mis-structure
+    # the prompt and never cue the model's thinking protocol.
+    chat_template_content = None
+    ctf = os.environ.get("EVAL_CHAT_TEMPLATE_FILE")
+    if ctf:
+        chat_template_content = Path(ctf).read_text()
+    elif prof:  # grug thinking: default to the Delphi thinking template from the delphi-v0-think revision
+        chat_template_content = _grug_chat_template(model, prof["revision"])
+    # LOCAL (grug thinking model): extra --gen_kwargs (key=value, comma-separated) folded into every
+    # lm-eval request. THE crux for Delphi thinking models: EVAL_EXTRA_GEN_KWARGS="skip_special_tokens=false"
+    # PRESERVES the atomic 128002/128003 delimiters (vLLM's skip_special_tokens=True default STRIPS them,
+    # which made the model look like it emitted no CoT — the original serving bug).
+    # grug thinking default: {skip_special_tokens:false, repetition_penalty:1.1}; EVAL_EXTRA_GEN_KWARGS wins.
+    extra_gen_kwargs: dict[str, str] = dict(prof.get("extra_gen_kwargs", {}))
+    egk = os.environ.get("EVAL_EXTRA_GEN_KWARGS")
+    if egk:
+        extra_gen_kwargs = {}
+        for pair in egk.split(","):
+            pair = pair.strip()
+            if not pair:
+                continue
+            k, _, v = pair.partition("=")
+            extra_gen_kwargs[k.strip()] = v.strip()
+    # Durable CoreWeave LOTA object store (marin-us-east-02a): the eval child writes each task's
+    # results_*.json here (run_evalchemy_client passes the LOTA virtual-addressing storage_options).
+    # Unique per-run sub-path so re-runs don't collide. Mac can't read LOTA directly (in-cluster only) —
+    # harvest via the EVALCHEMY_RESULT log-print; the s3 JSONs are the durable deliverable/provenance.
+    run_id = os.environ.get("EVAL_RUN_ID", uuid.uuid4().hex[:6])
+    default_out = f"s3://marin-us-east-02a/iris/marinbase-eval/{_slug(model)}/tier{tier}-{run_id}"
+    out_path = os.environ.get("EVAL_OUT_PATH", default_out)
+    # extra_gen_kwargs only reaches EvalchemyEvalConfig if that field exists in the installed marin lib;
+    # pass it ONLY when non-empty so the common (empty) path stays compatible with libs predating the
+    # field. Non-empty (grug thinking skip_special_tokens=false) requires the field to be present.
+    _egk = {"extra_gen_kwargs": extra_gen_kwargs} if extra_gen_kwargs else {}
+    return EvalchemyEvalConfig(
+        model=model,
+        tokenizer=tokenizer,
+        tasks=tasks,
+        out_path=out_path,
+        serve=ServeSpec(
+            backend=ServeBackend.VLLM,
+            tpu_type=None,
+            gpu_type="H100",
+            gpu_count=8,
+            tensor_parallel_size=tp,
+            dtype="bfloat16",
+            max_model_len=max_model_len,
+            serve_cpu=48.0,
+            serve_memory="1400g",
+            serve_disk="200g",
+            # Auto-derived per-model serve args (GDN triton / limit-mm) merged with any EVAL_VLLM_EXTRA_ARGS;
+            # rides ServeSpec.vllm_extra_args — the maintainer-blessed surface (marin #7373).
+            vllm_extra_args=vllm_extra_args,
+            chat_template_content=chat_template_content,
+        ),
+        apply_chat_template=apply_chat_template,
+        max_gen_toks=max_gen_toks,
+        max_eval_instances=max_eval_instances,
+        num_concurrent=num_concurrent,
+        eval_image=EVAL_IMAGE,
+        eval_cpu=8.0,
+        eval_memory="32g",
+        eval_disk="50g",
+        **_egk,
+    )
+
+
+def main() -> None:
+    model = os.environ.get("EVAL_MODEL", "Qwen/Qwen3-30B-A3B-Thinking-2507")
+    # grug thinking: default to the sanitized -tok tokenizer (the model dir's own tokenizer also works,
+    # but the -tok repo is the proven sanitized PreTrainedTokenizerFast). EVAL_TOKENIZER overrides.
+    tokenizer = os.environ.get("EVAL_TOKENIZER") or _grug_profile(model).get("tokenizer") or model
+    tier = int(os.environ.get("EVAL_TIER", "1"))
+    suffix = os.environ.get("EVAL_JOB_SUFFIX", "")
+    config = build_config(model, tokenizer, tier)
+
+    # Priority: EVAL_PRIORITY (batch|interactive|production; default batch). Forwarded to the parent
+    # env as MARINBASE_EVAL_PRIORITY so serve_and_eval sets the serve+eval CHILDREN to match — bump to
+    # interactive for slow models that keep getting preempted mid-run (GDN 80B/35B).
+    priority = os.environ.get("EVAL_PRIORITY", "batch").strip().lower()
+    priority_band = {
+        "production": job_pb2.PRIORITY_BAND_PRODUCTION,
+        "interactive": job_pb2.PRIORITY_BAND_INTERACTIVE,
+        "batch": job_pb2.PRIORITY_BAND_BATCH,
+    }.get(priority, job_pb2.PRIORITY_BAND_BATCH)
+
+    env_vars = {"EVALCHEMY_PYTHON": EVAL_PYTHON, "MARINBASE_EVAL_PRIORITY": priority}
+    for k in ("HF_TOKEN", "WANDB_API_KEY", "WANDB_ENTITY", "WANDB_PROJECT", "EVAL_RAW_PROBE"):
+        if os.environ.get(k):
+            env_vars[k] = os.environ[k]
+
+    name = f"marinbase-eval-{_slug(model)}-t{tier}{('-' + suffix) if suffix else ''}-{uuid.uuid4().hex[:6]}"
+    print(f"MODEL={model}  TIER={tier}  TP={config.serve.tensor_parallel_size}  "
+          f"max_model_len={config.serve.max_model_len}  out_path={config.out_path}")
+    print(f"TASKS={[t.name + '@' + str(t.num_fewshot) for t in config.tasks]}")
+    print(f"EVAL_IMAGE={EVAL_IMAGE}")
+
+    with open_iris_client(cluster_name=CLUSTER, workspace=Path(__file__).resolve().parents[3]) as client:
+        submit_ms = int(time.time() * 1000)
+        job = client.submit(
+            entrypoint=Entrypoint.from_callable(serve_and_eval, config),
+            name=name,
+            resources=ResourceSpec(cpu=1.0, memory="8g", disk="20g"),
+            environment=EnvironmentSpec(env_vars=env_vars),
+            max_retries_failure=0,
+            priority_band=priority_band,
+        )
+        job_id = getattr(job, "job_id", None) or getattr(job, "name", None)
+        print("SUBMITTED_JOB_ID:", job_id)
+        print("JOB_NAME:", name)
+        print("SUBMIT_MS:", submit_ms)
+        print(f"LOG_CMD: KUBECONFIG=~/.kube/coreweave-iris-gpu "
+              f"/Users/benjaminfeuer/miniconda3/envs/otagent/bin/iris --cluster={CLUSTER} "
+              f"job logs {job_id} --since-ms {submit_ms} --max-lines 400 --no-tail")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/evals/evalchemy/marin_evalchemy_gpu.py
+++ b/experiments/evals/evalchemy/marin_evalchemy_gpu.py
@@ -158,6 +158,14 @@ def _auto_serve_overrides(model: str, requested_max_model_len: int):
 # Every value below is a DEFAULT — the matching EVAL_* env var still overrides it.
 PROMPT_HEADROOM = 4096  # min context reserved for the prompt; default gen budget = max_model_len − this.
 GRUG_THINKING_MODELS = {"penfever/grug-67b-a2b-sft-s2-thinking-step630"}
+CANONICAL_AIME_SEEDS = (42, 43, 44)
+
+
+def _aime_seeds(seed_spec: str | None) -> tuple[int, ...]:
+    """Return canonical AIME seeds unless a caller deliberately requests a sensitivity set."""
+    if not seed_spec:
+        return CANONICAL_AIME_SEEDS
+    return tuple(int(seed) for seed in seed_spec.split(",") if seed.strip())
 
 
 def _is_grug_thinking(model: str) -> bool:
@@ -251,16 +259,14 @@ def build_config(model: str, tokenizer: str, tier: int) -> EvalchemyEvalConfig:
     # --limit → proves BOTH request types score non-empty over local-completions before the full suite.
     if os.environ.get("EVAL_SMOKE") == "1":
         tasks = (EvalTaskConfig("gsm8k", 0), EvalTaskConfig("hellaswag", 10))
-    # AIME24 10-seed μ±σ (POLICY §3): one process per seed 42..51, distinct dir per seed (task_alias)
-    # so results don't overwrite. Harvest = mean±std over the 10 pass@1 values.
+    # AIME24 policy: one process per canonical seed 42..44, with distinct task aliases so results
+    # do not overwrite. Three valid paired samples are sufficient for the campaign statistic.
     if os.environ.get("EVAL_TASK_SET") == "math500":  # one-benchmark chat smoke (reasoning-parser test)
         tasks = (EvalTaskConfig("MATH500", 0),)
         apply_chat_template = True
     if os.environ.get("EVAL_TASK_SET") == "aime24_seeds":
-        # Seeds: EVAL_AIME_SEEDS as a comma list (e.g. "42,43,44") — MARIN_EVAL_POLICY is 3-seed
-        # (seeds 42,43,44; report the mean). Default = the historical 10-seed set (42..51) for back-compat.
-        _seed_env = os.environ.get("EVAL_AIME_SEEDS")
-        _seeds = [int(s) for s in _seed_env.split(",") if s.strip()] if _seed_env else list(range(42, 52))
+        # EVAL_AIME_SEEDS may override the canonical three seeds for a deliberate sensitivity study.
+        _seeds = _aime_seeds(os.environ.get("EVAL_AIME_SEEDS"))
         tasks = tuple(
             EvalTaskConfig("AIME24", 0, task_alias=f"AIME24_seed{s}", task_kwargs={"seed": s}, generation=True)
             for s in _seeds

--- a/experiments/evals/evalchemy/marin_evalchemy_gpu.py
+++ b/experiments/evals/evalchemy/marin_evalchemy_gpu.py
@@ -173,9 +173,10 @@ def _grug_profile(model: str) -> dict:
         "tp": 1,  # 256-expert MoE: experts shard via data + expert parallelism, NOT tensor parallelism
         "revision": "delphi-v0-think",  # the checkpoint revision carrying the Delphi chat_template (NOT main)
         "tokenizer": "penfever/grug-67b-a2b-sft-s2-thinking-step630-tok",
-        # grug MoE expert-parallel serve; --revision selects the Delphi-template checkpoint.
+        # Grug MoE expert-parallel serve; --revision selects the Delphi-template checkpoint.
+        # ``distributed`` was a RunAI-streamer loader option. The canonical local-weight path
+        # uses vLLM's ``auto`` loader, which rejects it as an unknown loader extra config.
         "vllm_extra_args": ("--data-parallel-size", "8", "--enable-expert-parallel",
-                            "--model-loader-extra-config", '{"distributed":true}',
                             "--revision", "delphi-v0-think"),
         # skip_special_tokens=false → PRESERVE the atomic 128002/128003 delimiters (default True strips
         # them → model looks like it emits no CoT). repetition_penalty=1.1 → curb the answer-channel

--- a/experiments/evals/evalchemy/marin_evalchemy_gpu.py
+++ b/experiments/evals/evalchemy/marin_evalchemy_gpu.py
@@ -8,7 +8,8 @@ path so the serve child runs the marin VllmBackend/vLLM-fork stack (MoE / exotic
 support) and the eval child is a CPU-only ``eval.eval --model local-chat-completions``
 client against the served OpenAI URL (:evalchemy-gpu image, has fsspec/s3fs).
 
-Submits ONE parent CPU orchestrator to ``cw-us-east-02a``; serve_and_eval spawns:
+Submits ONE parent CPU orchestrator to the selected CoreWeave H100 cluster; ``EVAL_CLUSTER``
+defaults to ``cw-us-east-02a`` and may be set to ``cw-rno2a``. ``serve_and_eval`` spawns:
   * serve child  (8xH100)  — marin VllmBackend, TP=$TP, max_model_len=32768, bf16.
   * eval  child  (CPU)     — one ``eval.eval`` per task (own num_fewshot), chat route,
                              --apply_chat_template, --log_samples, --verbosity INFO.
@@ -24,6 +25,7 @@ Env knobs (all optional; defaults = the Qwen3-30B-A3B-Thinking-2507 pathfinder, 
     EVAL_MODEL        HF id to serve+eval          (default Qwen/Qwen3-30B-A3B-Thinking-2507)
     EVAL_TOKENIZER    HF tokenizer id              (default = EVAL_MODEL)
     EVAL_TP           tensor_parallel_size         (default 8; must divide num_attention_heads)
+    EVAL_CLUSTER      Iris GPU cluster              (default cw-us-east-02a; e.g. cw-rno2a)
     EVAL_TIER         1 | 2                         (default 1 = 14 lm-harness tasks)
     EVAL_OUT_PATH     fsspec out_path              (default pod-local /tmp/<slug>-tier<N>out)
     EVAL_MAX_MODEL_LEN                              (default 32768)
@@ -52,7 +54,7 @@ from experiments.evals.evalchemy.serve_and_eval import (
 )
 from marin.evaluation.evaluation_config import EvalTaskConfig
 
-CLUSTER = "cw-us-east-02a"
+CLUSTER = os.environ.get("EVAL_CLUSTER", "cw-us-east-02a")
 # :evalchemy-gpu (built via evalchemy infra/docker/build_evalchemy_gpu_kaniko.sh, PR #18) — CPU-only eval
 # client; python at /opt/eval/evalchemy/.venv. Pinned to evalchemy main HEAD 676fb85f which carries #28
 # (per-sample records now persist for lm-eval-native tasks under --log_samples → offline rescore, e.g. drop).

--- a/experiments/evals/evalchemy/marin_evalchemy_gpu.py
+++ b/experiments/evals/evalchemy/marin_evalchemy_gpu.py
@@ -84,15 +84,15 @@ TIER1_TASKS = (
 #     in this fork → omitted (flagged to operator). IFBench→IFEval (the fork's constraint benchmark).
 #     AIME24 = 10-seed (42..51) via EVAL_TIER=2 seed handling in the driver/client. ---
 TIER2_TASKS = (
-    EvalTaskConfig("MATH500", 0),
+    EvalTaskConfig("MATH500", 0, generation=True),
     # AIME24 is NOT here — it runs as a dedicated 10-seed μ±σ set (EVAL_TASK_SET=aime24_seeds).
-    EvalTaskConfig("HumanEvalPlus", 0),
-    EvalTaskConfig("MBPPPlus", 0),
+    EvalTaskConfig("HumanEvalPlus", 0, generation=True, unsafe_code=True, completion_only=True),
+    EvalTaskConfig("MBPPPlus", 0, generation=True, unsafe_code=True, completion_only=True),
     # MMLUPro DEFERRED — fork construction load_dataset fails (not a clean pip dep); N/A in RESULTS.
-    EvalTaskConfig("GPQADiamond", 0),
+    EvalTaskConfig("GPQADiamond", 0, generation=True),
     # CruxEval DEFERRED — the fork's CruxEval does `from execution import ...` (local-module import,
     # not a pip dep) → registration fails; not a clean install. Marked N/A in RESULTS.
-    EvalTaskConfig("IFEval", 0),
+    EvalTaskConfig("IFEval", 0, generation=True),
 )
 
 
@@ -241,7 +241,9 @@ def build_config(model: str, tokenizer: str, tier: int) -> EvalchemyEvalConfig:
     # comma list of benchmark names (e.g. "MATH500,MBPPPlus,GPQADiamond,IFEval" to skip an already-
     # harvested HumanEvalPlus). Applies on the tier-2 path; num_fewshot 0 (tier-2 is all 0-shot chat).
     if tier == 2 and os.environ.get("EVAL_TIER2_TASKS"):
-        tasks = tuple(EvalTaskConfig(n.strip(), 0) for n in os.environ["EVAL_TIER2_TASKS"].split(",") if n.strip())
+        selected = {task.name: task for task in TIER2_TASKS}
+        tasks = tuple(selected.get(name.strip(), EvalTaskConfig(name.strip(), 0, generation=True))
+                      for name in os.environ["EVAL_TIER2_TASKS"].split(",") if name.strip())
     # Fast diagnostic smoke: a generative task (gsm8k) + an MC/loglikelihood task (hellaswag), small
     # --limit → proves BOTH request types score non-empty over local-completions before the full suite.
     if os.environ.get("EVAL_SMOKE") == "1":
@@ -257,7 +259,7 @@ def build_config(model: str, tokenizer: str, tier: int) -> EvalchemyEvalConfig:
         _seed_env = os.environ.get("EVAL_AIME_SEEDS")
         _seeds = [int(s) for s in _seed_env.split(",") if s.strip()] if _seed_env else list(range(42, 52))
         tasks = tuple(
-            EvalTaskConfig("AIME24", 0, task_alias=f"AIME24_seed{s}", task_kwargs={"seed": s})
+            EvalTaskConfig("AIME24", 0, task_alias=f"AIME24_seed{s}", task_kwargs={"seed": s}, generation=True)
             for s in _seeds
         )
         apply_chat_template = True

--- a/experiments/evals/evalchemy/marin_evalchemy_gpu.py
+++ b/experiments/evals/evalchemy/marin_evalchemy_gpu.py
@@ -36,15 +36,18 @@ Env knobs (all optional; defaults = the Qwen3-30B-A3B-Thinking-2507 pathfinder, 
 """
 from __future__ import annotations
 
+import json
 import os
 import re
 import time
 import uuid
 from pathlib import Path
 
+from huggingface_hub import hf_hub_download
 from iris.cli.connect import open_iris_client
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec
 from iris.rpc import job_pb2
+from marin.evaluation.evaluation_config import EvalTaskConfig
 
 from experiments.evals.evalchemy.serve_and_eval import (
     EvalchemyEvalConfig,
@@ -52,15 +55,12 @@ from experiments.evals.evalchemy.serve_and_eval import (
     ServeSpec,
     serve_and_eval,
 )
-from marin.evaluation.evaluation_config import EvalTaskConfig
 
 CLUSTER = os.environ.get("EVAL_CLUSTER", "cw-us-east-02a")
 # :evalchemy-gpu (built via evalchemy infra/docker/build_evalchemy_gpu_kaniko.sh, PR #18) — CPU-only eval
 # client; python at /opt/eval/evalchemy/.venv. Pinned to evalchemy main HEAD 676fb85f which carries #28
 # (per-sample records now persist for lm-eval-native tasks under --log_samples → offline rescore, e.g. drop).
-EVAL_IMAGE = os.environ.get(
-    "EVAL_IMAGE", "ghcr.io/open-thoughts/openthoughts-agent:evalchemy-gpu-676fb85f"
-)
+EVAL_IMAGE = os.environ.get("EVAL_IMAGE", "ghcr.io/open-thoughts/openthoughts-agent:evalchemy-gpu-676fb85f")
 EVAL_PYTHON = os.environ.get("EVAL_PYTHON", "/opt/eval/evalchemy/.venv/bin/python")
 
 # --- Tier 1: 14 lm-eval-harness tasks (POLICY §3; per-task shots). 1 run, seed 42. ---
@@ -87,7 +87,7 @@ TIER1_TASKS = (
 #     AIME24 = 10-seed (42..51) via EVAL_TIER=2 seed handling in the driver/client. ---
 TIER2_TASKS = (
     EvalTaskConfig("MATH500", 0, generation=True),
-    # AIME24 is NOT here — it runs as a dedicated 10-seed μ±σ set (EVAL_TASK_SET=aime24_seeds).
+    # AIME24 is NOT here; it runs as a dedicated 10-seed mean/stddev set (EVAL_TASK_SET=aime24_seeds).
     EvalTaskConfig("HumanEvalPlus", 0, generation=True, unsafe_code=True, completion_only=True),
     EvalTaskConfig("MBPPPlus", 0, generation=True, unsafe_code=True, completion_only=True),
     # MMLUPro DEFERRED — fork construction load_dataset fails (not a clean pip dep); N/A in RESULTS.
@@ -125,16 +125,21 @@ def _auto_serve_overrides(model: str, requested_max_model_len: int):
     mml = requested_max_model_len
     cfg: dict = {}
     try:
-        import json as _json
-        from huggingface_hub import hf_hub_download
-        cfg = _json.load(open(hf_hub_download(model, "config.json")))
-    except Exception as e:  # noqa: BLE001
+        with open(hf_hub_download(model, "config.json")) as config_file:
+            cfg = json.load(config_file)
+    except Exception as e:
         print(f"[warn] config.json fetch failed for {model}: {e!r}; using request defaults")
-    txt = __import__("json").dumps(cfg).lower()
+    txt = json.dumps(cfg).lower()
     arch = " ".join(cfg.get("architectures") or []).lower()
     tcfg = cfg.get("text_config", cfg) if isinstance(cfg.get("text_config", cfg), dict) else cfg
-    if ("gated_delta_net" in txt or "linear_attn" in txt or "qwen3next" in arch
-            or "qwen3_5" in arch or "qwen3.5" in model.lower() or "qwen3-next" in model.lower()):
+    if (
+        "gated_delta_net" in txt
+        or "linear_attn" in txt
+        or "qwen3next" in arch
+        or "qwen3_5" in arch
+        or "qwen3.5" in model.lower()
+        or "qwen3-next" in model.lower()
+    ):
         extra += ["--gdn-prefill-backend", "triton"]
     if cfg.get("vision_config") or "forconditionalgeneration" in arch:
         extra += ["--limit-mm-per-prompt", '{"image":0,"video":0}']
@@ -156,7 +161,7 @@ def _auto_serve_overrides(model: str, requested_max_model_len: int):
 # EMPTY results — the bug this bakes out), the atomic <|start_think|>/<|end_think|> delimiters intact,
 # the Delphi chat_template (NOT the generic `main` /think template), and the answer-channel loop curbed.
 # Every value below is a DEFAULT — the matching EVAL_* env var still overrides it.
-PROMPT_HEADROOM = 4096  # min context reserved for the prompt; default gen budget = max_model_len − this.
+PROMPT_HEADROOM = 4096  # Min context reserved for the prompt; default gen budget = max_model_len - this.
 GRUG_THINKING_MODELS = {"penfever/grug-67b-a2b-sft-s2-thinking-step630"}
 CANONICAL_AIME_SEEDS = (42, 43, 44)
 
@@ -184,8 +189,7 @@ def _grug_profile(model: str) -> dict:
         # Grug MoE expert-parallel serve; --revision selects the Delphi-template checkpoint.
         # ``distributed`` was a RunAI-streamer loader option. The canonical local-weight path
         # uses vLLM's ``auto`` loader, which rejects it as an unknown loader extra config.
-        "vllm_extra_args": ("--data-parallel-size", "8", "--enable-expert-parallel",
-                            "--revision", "delphi-v0-think"),
+        "vllm_extra_args": ("--data-parallel-size", "8", "--enable-expert-parallel", "--revision", "delphi-v0-think"),
         # skip_special_tokens=false → PRESERVE the atomic 128002/128003 delimiters (default True strips
         # them → model looks like it emits no CoT). repetition_penalty=1.1 → curb the answer-channel
         # loops (marin #7321) so long-CoT MATH500/GPQA samples terminate + box within the gen budget.
@@ -198,9 +202,8 @@ def _grug_chat_template(model: str, revision: str) -> str | None:
     <|start_think|>/<|end_think|> machinery). cw nodes have egress. Returns None on failure so the serve
     degrades to the repo's own template rather than hard-failing the launch."""
     try:
-        from huggingface_hub import hf_hub_download  # noqa: PLC0415
         return Path(hf_hub_download(model, "chat_template.jinja", revision=revision)).read_text()
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:
         print(f"[warn] grug chat_template fetch failed (rev={revision}): {e!r}; using served repo template")
         return None
 
@@ -215,24 +218,31 @@ def build_config(model: str, tokenizer: str, tier: int) -> EvalchemyEvalConfig:
     # Tier-2 budget is MODEL-CLASS-dependent: thinking/GDN models need ~30720 (near-full 32k) for
     # their CoT + boxed answer under the chat template; instruct models finish at 20480. Tier-1 uses
     # 20480 (completion-style, shorter). AIME already forces 30720 via EVAL_MAX_GEN_TOKS in the launcher.
-    # grug thinking: size the gen budget to LEAVE prompt headroom (max_model_len − PROMPT_HEADROOM =
+    # grug thinking: size the gen budget to LEAVE prompt headroom (max_model_len - PROMPT_HEADROOM =
     # 28672 @ 32k) so the CoT budget can't starve a long prompt into a context overflow → EMPTY result
     # (marin #7321). Other thinking/GDN models keep the historical near-full 30720; instruct 20480.
-    _default_gen = (max_model_len - PROMPT_HEADROOM) if prof else (30720 if (tier == 2 and _is_thinking(model)) else 20480)
+    _default_gen = max_model_len - PROMPT_HEADROOM if prof else 30720 if tier == 2 and _is_thinking(model) else 20480
     max_gen_toks = int(os.environ.get("EVAL_MAX_GEN_TOKS", str(_default_gen)))
     num_concurrent = int(os.environ.get("EVAL_NUM_CONCURRENT", "16"))
     # Per-model serve mitigations (GDN triton / limit-mm / native-context cap) derived automatically
     # from config.json — durable + identical across tiers, no hand-passed flags.
     # grug thinking: default the serve args to the expert-parallel + delphi-v0-think-revision set (env wins).
-    env_extra = (tuple(os.environ["EVAL_VLLM_EXTRA_ARGS"].split()) if os.environ.get("EVAL_VLLM_EXTRA_ARGS")
-                 else tuple(prof.get("vllm_extra_args", ())))
+    env_extra = (
+        tuple(os.environ["EVAL_VLLM_EXTRA_ARGS"].split())
+        if os.environ.get("EVAL_VLLM_EXTRA_ARGS")
+        else tuple(prof.get("vllm_extra_args", ()))
+    )
     auto_extra, max_model_len = _auto_serve_overrides(model, max_model_len)
     # Merge: env-passed flags win; append an auto flag only if its flag-name isn't already present.
     merged = list(env_extra)
     i = 0
     while i < len(auto_extra):
         flag = auto_extra[i]
-        pair = auto_extra[i:i + 2] if (i + 1 < len(auto_extra) and not auto_extra[i + 1].startswith("--")) else auto_extra[i:i + 1]
+        pair = (
+            auto_extra[i : i + 2]
+            if (i + 1 < len(auto_extra) and not auto_extra[i + 1].startswith("--"))
+            else auto_extra[i : i + 1]
+        )
         if flag not in merged:
             merged += list(pair)
         i += len(pair)
@@ -253,8 +263,11 @@ def build_config(model: str, tokenizer: str, tier: int) -> EvalchemyEvalConfig:
     # harvested HumanEvalPlus). Applies on the tier-2 path; num_fewshot 0 (tier-2 is all 0-shot chat).
     if tier == 2 and os.environ.get("EVAL_TIER2_TASKS"):
         selected = {task.name: task for task in TIER2_TASKS}
-        tasks = tuple(selected.get(name.strip(), EvalTaskConfig(name.strip(), 0, generation=True))
-                      for name in os.environ["EVAL_TIER2_TASKS"].split(",") if name.strip())
+        tasks = tuple(
+            selected.get(name.strip(), EvalTaskConfig(name.strip(), 0, generation=True))
+            for name in os.environ["EVAL_TIER2_TASKS"].split(",")
+            if name.strip()
+        )
     # Fast diagnostic smoke: a generative task (gsm8k) + an MC/loglikelihood task (hellaswag), small
     # --limit → proves BOTH request types score non-empty over local-completions before the full suite.
     if os.environ.get("EVAL_SMOKE") == "1":
@@ -368,8 +381,10 @@ def main() -> None:
             env_vars[k] = os.environ[k]
 
     name = f"marinbase-eval-{_slug(model)}-t{tier}{('-' + suffix) if suffix else ''}-{uuid.uuid4().hex[:6]}"
-    print(f"MODEL={model}  TIER={tier}  TP={config.serve.tensor_parallel_size}  "
-          f"max_model_len={config.serve.max_model_len}  out_path={config.out_path}")
+    print(
+        f"MODEL={model}  TIER={tier}  TP={config.serve.tensor_parallel_size}  "
+        f"max_model_len={config.serve.max_model_len}  out_path={config.out_path}"
+    )
     print(f"TASKS={[t.name + '@' + str(t.num_fewshot) for t in config.tasks]}")
     print(f"EVAL_IMAGE={EVAL_IMAGE}")
 
@@ -387,9 +402,11 @@ def main() -> None:
         print("SUBMITTED_JOB_ID:", job_id)
         print("JOB_NAME:", name)
         print("SUBMIT_MS:", submit_ms)
-        print(f"LOG_CMD: KUBECONFIG=~/.kube/coreweave-iris-gpu "
-              f"/Users/benjaminfeuer/miniconda3/envs/otagent/bin/iris --cluster={CLUSTER} "
-              f"job logs {job_id} --since-ms {submit_ms} --max-lines 400 --no-tail")
+        print(
+            f"LOG_CMD: KUBECONFIG=~/.kube/coreweave-iris-gpu "
+            f"/Users/benjaminfeuer/miniconda3/envs/otagent/bin/iris --cluster={CLUSTER} "
+            f"job logs {job_id} --since-ms {submit_ms} --max-lines 400 --no-tail"
+        )
 
 
 if __name__ == "__main__":

--- a/experiments/evals/evalchemy/run_evalchemy_client.py
+++ b/experiments/evals/evalchemy/run_evalchemy_client.py
@@ -75,7 +75,7 @@ def served_max_length(base_url: str) -> int | None:
     return None
 
 
-def build_model_args(config: dict, use_chat: bool, max_length: int | None) -> str:
+def build_model_args(config: dict, use_chat: bool) -> str:
     """lm-eval ``--model_args`` for the served OpenAI endpoint (comma-joined ``key=value`` list)."""
     endpoint_path = "chat/completions" if use_chat else "completions"
     args = [
@@ -95,8 +95,6 @@ def build_model_args(config: dict, use_chat: bool, max_length: int | None) -> st
         # the endpoint. 1800s covers a full max_gen_toks generation on a slow serve.
         "timeout=1800",
     ]
-    if max_length is not None:
-        args.append(f"max_length={max_length}")
     return ",".join(args)
 
 
@@ -131,7 +129,7 @@ def build_command(config: dict, task: dict, output_path: str, python: str, max_l
         "--model",
         model,
         "--model_args",
-        build_model_args(config, use_chat, max_length),
+        build_model_args(config, use_chat),
         "--tasks",
         task["name"],
         "--gen_kwargs",
@@ -148,6 +146,9 @@ def build_command(config: dict, task: dict, output_path: str, python: str, max_l
         "--verbosity",
         "INFO",
     ]
+    if max_length is not None:
+        # Evalchemy resolves this once for both native lm-eval and its custom benchmarks.
+        cmd += ["--max_length", str(max_length)]
     # Always pass --num_fewshot, including 0. evalchemy's parser defaults it to None, so omitting the
     # flag lets lm-eval fall back to the task YAML's own default (gsm8k defaults to 5-shot) and a
     # 0-shot request is silently ignored. Chat-native benchmarks record it in their config but do not

--- a/experiments/evals/evalchemy/run_evalchemy_client.py
+++ b/experiments/evals/evalchemy/run_evalchemy_client.py
@@ -83,6 +83,7 @@ def build_model_args(config: dict, use_chat: bool, max_length: int | None) -> st
         f"base_url={config['base_url'].rstrip('/')}/{endpoint_path}",
         f"tokenizer={config['tokenizer']}",
         "tokenizer_backend=huggingface",
+        "trust_remote_code=True",
         "tokenized_requests=False",
         f"num_concurrent={config['num_concurrent']}",
         # The TPU vLLM prompt-logprobs path 500s in whole-batch bursts (every in-flight request at
@@ -97,6 +98,13 @@ def build_model_args(config: dict, use_chat: bool, max_length: int | None) -> st
     if max_length is not None:
         args.append(f"max_length={max_length}")
     return ",".join(args)
+
+
+def generation_kwargs(config: dict, max_gen_toks: int) -> str:
+    """Serialize the explicit budget plus optional served-model generation overrides."""
+    parts = [f"max_gen_toks={max_gen_toks}"]
+    parts.extend(f"{key}={value}" for key, value in (config.get("extra_gen_kwargs") or {}).items())
+    return ",".join(parts)
 
 
 def build_command(config: dict, task: dict, output_path: str, python: str, max_length: int | None) -> list[str]:
@@ -127,7 +135,7 @@ def build_command(config: dict, task: dict, output_path: str, python: str, max_l
         "--tasks",
         task["name"],
         "--gen_kwargs",
-        f"max_gen_toks={gen_budget}",
+        generation_kwargs(config, gen_budget),
         # Chat-native benchmarks (MATH500-style) size their generations from --max_tokens, not
         # gen_kwargs; lm-eval-native tasks ignore it.
         "--max_tokens",
@@ -145,6 +153,8 @@ def build_command(config: dict, task: dict, output_path: str, python: str, max_l
     # 0-shot request is silently ignored. Chat-native benchmarks record it in their config but do not
     # few-shot on it, so an explicit 0 is harmless there.
     cmd += ["--num_fewshot", str(task["num_fewshot"])]
+    if task.get("seed") is not None:
+        cmd += ["--seed", str(task["seed"])]
     if task["unsafe_code"]:
         # code_eval tasks execute model-generated code; lm-eval refuses them without this opt-in.
         cmd.append("--confirm_run_unsafe_code")

--- a/experiments/evals/evalchemy/serve_and_eval.py
+++ b/experiments/evals/evalchemy/serve_and_eval.py
@@ -163,9 +163,10 @@ class ServeSpec:
     """Extra flags forwarded to ``vllm serve`` (``VllmEngineConfig.extra_args``); empty for the common case.
     Use it for models the portable defaults miss:
 
-    - 256-expert Grug MoE export: ``--data-parallel-size N --enable-expert-parallel
-      --model-loader-extra-config '{"distributed":true}'`` with ``tensor_parallel_size=1``; the per-head
-      TP heuristic cannot infer this.
+    - 256-expert Grug MoE export: ``--data-parallel-size N --enable-expert-parallel`` with
+      ``tensor_parallel_size=1``; the per-head TP heuristic cannot infer this. The old
+      ``distributed`` loader config was specific to RunAI streaming and is invalid for the
+      canonical local-weight loader.
     - Qwen gated-delta-net models (``qwen_gdn_linear_attn``: ``Qwen/Qwen3.5-35B-A3B``,
       ``Qwen/Qwen3-Next-80B-A3B``): ``--gdn-prefill-backend triton``. The GPU serve env runs without
       ``nvcc``, so the default FlashInfer GDN prefill kernel — JIT-compiled at warmup — fails; triton

--- a/experiments/evals/evalchemy/serve_and_eval.py
+++ b/experiments/evals/evalchemy/serve_and_eval.py
@@ -214,6 +214,8 @@ class EvalchemyEvalConfig:
     """HF tokenizer id the eval client loads to build prompts; defaults to ``model``. Set it when
     ``model`` is a path the eval image cannot load a tokenizer from (e.g. a ``gs://`` checkpoint)."""
     max_gen_toks: int = 2048
+    extra_gen_kwargs: dict[str, str] = field(default_factory=dict)
+    """Additional generation kwargs forwarded to every lm-eval request."""
     apply_chat_template: bool = False
     max_eval_instances: int | None = None
     num_concurrent: int = DEFAULT_NUM_CONCURRENT
@@ -392,12 +394,14 @@ def _client_config_json(session: EvalSession, unit: EvalUnit, endpoint: ServedEn
                     "generation": t.generation,
                     "unsafe_code": t.unsafe_code,
                     "completion_only": t.completion_only,
+                    "seed": (t.task_kwargs or {}).get("seed"),
                 }
                 for t in unit.tasks
             ],
             "out_path": unit.out_path,
             "apply_chat_template": session.apply_chat_template,
             "max_gen_toks": unit.max_gen_toks,
+            "extra_gen_kwargs": session.extra_gen_kwargs,
             "max_eval_instances": unit.max_eval_instances,
             "num_concurrent": session.num_concurrent,
         }
@@ -420,6 +424,8 @@ class EvalSession:
     """HF tokenizer id the eval client loads to build prompts; defaults to ``model``. Required when
     ``model`` is a path the eval image cannot load a tokenizer from (e.g. a ``gs://`` checkpoint)."""
     apply_chat_template: bool = False
+    extra_gen_kwargs: dict[str, str] = field(default_factory=dict)
+    """Additional generation kwargs forwarded to every eval client request."""
     num_concurrent: int = DEFAULT_NUM_CONCURRENT
     eval_image: str = EVALCHEMY_IMAGE
     eval_cpu: float = 8.0
@@ -693,6 +699,7 @@ def serve_and_eval(config: EvalchemyEvalConfig) -> ServeAndEvalRun:
         serve=config.serve,
         tokenizer=config.tokenizer,
         apply_chat_template=config.apply_chat_template,
+        extra_gen_kwargs=config.extra_gen_kwargs,
         num_concurrent=config.num_concurrent,
         eval_image=config.eval_image,
         eval_cpu=config.eval_cpu,

--- a/lib/marin/src/marin/inference/config.py
+++ b/lib/marin/src/marin/inference/config.py
@@ -19,6 +19,8 @@ WORKER_PYTHON_VERSION = "3.12"
 # participate in Marin's workspace dependency resolution.
 DEFAULT_CUDA_VLLM_VERSION = "0.25.1"
 TPU_VLLM_WORKER_EXTRAS = ("tpu", "vllm")
+TPU_MODEL_CACHE_TTL_DAYS = 14
+GPU_MODEL_CACHE_TTL_DAYS = 0
 
 
 class VllmLauncherType(StrEnum):
@@ -168,14 +170,26 @@ class IrisConfig:
 
     worker_resources: ResourceConfig
     worker_environment: EnvironmentConfig
-    cache_ttl_days: int = 14
+    cache_ttl_days: int | None = None
+    """TTL for the regional object-store model cache.
+
+    ``None`` resolves to 14 days on constrained TPU workers and zero on
+    CoreWeave GPUs.  GPU workers have sufficient local NVMe for normal Hugging
+    Face/vLLM materialization; avoiding the object-store path also avoids the
+    RunAI range-streamer as the default load mechanism.  Pass a nonzero value
+    explicitly to opt a GPU serve into the regional mirror.
+    """
     endpoint_ready_timeout_seconds: float = 1800.0
     priority: int = 0
     max_retries_failure: int = 1
     max_retries_preemption: int = 10
 
     def __post_init__(self) -> None:
-        if self.cache_ttl_days < 0:
+        if isinstance(self.worker_resources, ResourceConfig) and self.cache_ttl_days is None:
+            device = self.worker_resources.device
+            cache_ttl_days = GPU_MODEL_CACHE_TTL_DAYS if device.kind == "gpu" else TPU_MODEL_CACHE_TTL_DAYS
+            object.__setattr__(self, "cache_ttl_days", cache_ttl_days)
+        if self.cache_ttl_days is not None and self.cache_ttl_days < 0:
             raise ValueError("cache_ttl_days must not be negative")
         if self.endpoint_ready_timeout_seconds <= 0:
             raise ValueError("endpoint_ready_timeout_seconds must be positive")

--- a/lib/marin/src/marin/inference/iris.py
+++ b/lib/marin/src/marin/inference/iris.py
@@ -128,7 +128,10 @@ def _resolved_model(model: ServedModelConfig, iris: IrisConfig) -> tuple[ServedM
         select_tensor_parallel_size,
     )
 
-    model_path = model.model_path or resolve_model_path(model.model, iris.cache_ttl_days)
+    cache_ttl_days = iris.cache_ttl_days
+    if cache_ttl_days is None:
+        raise ValueError("IrisConfig must resolve cache_ttl_days before serving")
+    model_path = model.model_path or resolve_model_path(model.model, cache_ttl_days)
     num_chips = iris.worker_resources.device.chip_count()
     tensor_parallel_size = model.tensor_parallel_size
     if tensor_parallel_size is None:

--- a/lib/marin/src/marin/inference/iris_cli.py
+++ b/lib/marin/src/marin/inference/iris_cli.py
@@ -341,7 +341,12 @@ def _mint_and_print_capability_url(
 )
 @click.option("--tensor-parallel-size", type=int, default=None, help="TP size (default: auto from heads + chips).")
 @click.option("--dtype", default="bfloat16", help="Weight/compute dtype.")
-@click.option("--cache-ttl-days", type=int, default=14, help="Mirror HF models to a TTL'd GCS cache (0 disables).")
+@click.option(
+    "--cache-ttl-days",
+    type=click.IntRange(min=0),
+    default=None,
+    help="Mirror HF models to a TTL'd GCS cache. Default: 14 days on TPU, disabled on CoreWeave GPU.",
+)
 @click.option(
     "--no-cache", is_flag=True, default=False, help="Skip the GCS model cache; always download from HuggingFace."
 )
@@ -425,7 +430,7 @@ def main(
     hbm_utilization: float,
     tensor_parallel_size: int | None,
     dtype: str,
-    cache_ttl_days: int,
+    cache_ttl_days: int | None,
     no_cache: bool,
     timeout_hours: float,
     proxy_timeout: float,

--- a/lib/marin/src/marin/inference/vllm_server.py
+++ b/lib/marin/src/marin/inference/vllm_server.py
@@ -78,8 +78,9 @@ class VllmType(StrEnum):
 class IsolatedCudaVllm:
     """Provide an isolated CUDA vLLM command and environment.
 
-    Both variants stream checkpoints from the CoreWeave object store. The Marin fork additionally
-    serves Marin-specific architectures.
+    The Marin fork additionally serves Marin-specific architectures.  CoreWeave
+    serves normally materialize Hugging Face weights on local NVMe; the RunAI
+    streamer is selected only by an explicit object-store model path.
     """
 
     source: VllmType = VllmType.UPSTREAM

--- a/tests/evals/test_serve_and_eval_config.py
+++ b/tests/evals/test_serve_and_eval_config.py
@@ -73,6 +73,7 @@ def test_client_config_json_carries_endpoint_and_per_task_dirs():
             "generation": False,
             "unsafe_code": False,
             "completion_only": False,
+            "seed": None,
         },
         {
             "name": "gsm8k",
@@ -81,6 +82,7 @@ def test_client_config_json_carries_endpoint_and_per_task_dirs():
             "generation": True,
             "unsafe_code": False,
             "completion_only": False,
+            "seed": None,
         },
     ]
 
@@ -153,6 +155,15 @@ def test_completion_only_pins_completions_route_and_forwards_unsafe_code():
     assert cmd[cmd.index("--model") + 1] == "local-completions"
     assert "--apply_chat_template" not in cmd
     assert "--confirm_run_unsafe_code" in cmd
+
+
+def test_client_forwards_seed_and_extra_generation_kwargs():
+    unit = _unit(tasks=(EvalTaskConfig("AIME24", 0, task_kwargs={"seed": 43}, generation=True),))
+    config = _payload(session=_session(apply_chat_template=True, extra_gen_kwargs={"skip_special_tokens": "false"}), unit=unit)
+    cmd = build_command(config, config["tasks"][0], "/tmp/out", "/opt/py", None)
+
+    assert cmd[cmd.index("--seed") + 1] == "43"
+    assert cmd[cmd.index("--gen_kwargs") + 1] == "max_gen_toks=2048,skip_special_tokens=false"
 
 
 def test_model_args_carry_served_max_length():

--- a/tests/evals/test_serve_and_eval_config.py
+++ b/tests/evals/test_serve_and_eval_config.py
@@ -17,8 +17,8 @@ from typing import cast
 from iris.client import Job
 from marin.evaluation.evaluation_config import EvalTaskConfig
 
-from experiments.evals.evalchemy.run_evalchemy_client import build_command, build_model_args, scored_results
 from experiments.evals.evalchemy.marin_evalchemy_gpu import CANONICAL_AIME_SEEDS, _aime_seeds, _grug_profile
+from experiments.evals.evalchemy.run_evalchemy_client import build_command, build_model_args, scored_results
 from experiments.evals.evalchemy.serve_and_eval import (
     EvalSession,
     EvalUnit,
@@ -160,7 +160,9 @@ def test_completion_only_pins_completions_route_and_forwards_unsafe_code():
 
 def test_client_forwards_seed_and_extra_generation_kwargs():
     unit = _unit(tasks=(EvalTaskConfig("AIME24", 0, task_kwargs={"seed": 43}, generation=True),))
-    config = _payload(session=_session(apply_chat_template=True, extra_gen_kwargs={"skip_special_tokens": "false"}), unit=unit)
+    config = _payload(
+        session=_session(apply_chat_template=True, extra_gen_kwargs={"skip_special_tokens": "false"}), unit=unit
+    )
     cmd = build_command(config, config["tasks"][0], "/tmp/out", "/opt/py", None)
 
     assert cmd[cmd.index("--seed") + 1] == "43"

--- a/tests/evals/test_serve_and_eval_config.py
+++ b/tests/evals/test_serve_and_eval_config.py
@@ -18,6 +18,7 @@ from iris.client import Job
 from marin.evaluation.evaluation_config import EvalTaskConfig
 
 from experiments.evals.evalchemy.run_evalchemy_client import build_command, build_model_args, scored_results
+from experiments.evals.evalchemy.marin_evalchemy_gpu import _grug_profile
 from experiments.evals.evalchemy.serve_and_eval import (
     EvalSession,
     EvalUnit,
@@ -164,6 +165,20 @@ def test_client_forwards_seed_and_extra_generation_kwargs():
 
     assert cmd[cmd.index("--seed") + 1] == "43"
     assert cmd[cmd.index("--gen_kwargs") + 1] == "max_gen_toks=2048,skip_special_tokens=false"
+
+
+def test_grug_profile_uses_local_weight_loader_compatible_extra_args():
+    """Grug's old RunAI-only loader config must not leak into local-weight GPU serving."""
+    args = _grug_profile("penfever/grug-67b-a2b-sft-s2-thinking-step630")["vllm_extra_args"]
+
+    assert args == (
+        "--data-parallel-size",
+        "8",
+        "--enable-expert-parallel",
+        "--revision",
+        "delphi-v0-think",
+    )
+    assert "--model-loader-extra-config" not in args
 
 
 def test_model_args_carry_served_max_length():

--- a/tests/evals/test_serve_and_eval_config.py
+++ b/tests/evals/test_serve_and_eval_config.py
@@ -18,7 +18,7 @@ from iris.client import Job
 from marin.evaluation.evaluation_config import EvalTaskConfig
 
 from experiments.evals.evalchemy.run_evalchemy_client import build_command, build_model_args, scored_results
-from experiments.evals.evalchemy.marin_evalchemy_gpu import _grug_profile
+from experiments.evals.evalchemy.marin_evalchemy_gpu import CANONICAL_AIME_SEEDS, _aime_seeds, _grug_profile
 from experiments.evals.evalchemy.serve_and_eval import (
     EvalSession,
     EvalUnit,
@@ -179,6 +179,11 @@ def test_grug_profile_uses_local_weight_loader_compatible_extra_args():
         "delphi-v0-think",
     )
     assert "--model-loader-extra-config" not in args
+
+
+def test_aime_defaults_to_the_three_canonical_campaign_seeds():
+    assert _aime_seeds(None) == CANONICAL_AIME_SEEDS == (42, 43, 44)
+    assert _aime_seeds("42,44,99") == (42, 44, 99)
 
 
 def test_model_args_carry_served_max_length():

--- a/tests/evals/test_serve_and_eval_config.py
+++ b/tests/evals/test_serve_and_eval_config.py
@@ -131,7 +131,7 @@ def test_build_command_chat_route_needs_template_and_generation():
     cmd = build_command(config, generative, "/tmp/out", "/opt/py", None)
     assert cmd[cmd.index("--model") + 1] == "local-chat-completions"
     assert "--apply_chat_template" in cmd
-    assert "base_url=http://10.0.0.1:30000/v1/chat/completions" in build_model_args(config, True, None)
+    assert "base_url=http://10.0.0.1:30000/v1/chat/completions" in build_model_args(config, True)
 
     # ...but a loglikelihood (MCQ) task always uses completions: chat endpoints cannot echo prompt
     # logprobs, and lm-eval rejects loglikelihood over chat completions.
@@ -188,11 +188,13 @@ def test_aime_defaults_to_the_three_canonical_campaign_seeds():
     assert _aime_seeds("42,44,99") == (42, 44, 99)
 
 
-def test_model_args_carry_served_max_length():
-    # lm-eval assumes a 2048-token window unless told otherwise, silently left-truncating few-shot
-    # prompts; the client reads the served max_model_len and passes it through.
-    args = dict(pair.split("=", 1) for pair in build_model_args(_payload(), False, 4096).split(","))
-    assert args["max_length"] == "4096"
+def test_build_command_carries_served_max_length_via_evalchemy_flag():
+    # Evalchemy owns the canonical request limit.  Keeping this outside lm-eval model_args makes
+    # native and custom benchmarks consume exactly the same explicit --max_length contract.
+    cmd = build_command(_payload(), _payload()["tasks"][0], "/tmp/out", "/opt/py", 4096)
+    args = dict(pair.split("=", 1) for pair in build_model_args(_payload(), False).split(","))
+    assert cmd[cmd.index("--max_length") + 1] == "4096"
+    assert "max_length" not in args
     assert args["tokenized_requests"] == "False"
 
 

--- a/tests/inference/test_serve.py
+++ b/tests/inference/test_serve.py
@@ -17,11 +17,14 @@ import click
 import pytest
 import requests
 from click.testing import CliRunner
-from fray.types import ANY_REGION
+from fray.types import ANY_REGION, ResourceConfig, create_environment
 from iris.rpc import controller_pb2
 from iris.time_proto import timestamp_to_proto
 from marin.inference.config import (
     DEFAULT_CUDA_VLLM_VERSION,
+    GPU_MODEL_CACHE_TTL_DAYS,
+    TPU_MODEL_CACHE_TTL_DAYS,
+    IrisConfig,
     LevanterEngineConfig,
     VllmEngineConfig,
     VllmLauncherType,
@@ -98,6 +101,20 @@ def test_select_tensor_parallel_size(heads, chips, kv_heads, expected):
 def test_resolve_model_path_passthrough(model, ttl_days):
     # These paths must not touch the network or GCS; they return the input unchanged.
     assert resolve_model_path(model, ttl_days) == model
+
+
+def test_iris_config_uses_local_model_materialization_on_gpu_by_default():
+    gpu = IrisConfig(
+        worker_resources=ResourceConfig.with_gpu("H100", count=8),
+        worker_environment=create_environment(extras=["gpu"]),
+    )
+    tpu = IrisConfig(
+        worker_resources=ResourceConfig.with_tpu("v6e-4"),
+        worker_environment=create_environment(extras=["tpu", "vllm"]),
+    )
+
+    assert gpu.cache_ttl_days == GPU_MODEL_CACHE_TTL_DAYS == 0
+    assert tpu.cache_ttl_days == TPU_MODEL_CACHE_TTL_DAYS == 14
 
 
 def test_checkout_free_setup_script_pins_marin_core_with_extras():


### PR DESCRIPTION
Consolidates the prior CoreWeave eval-driver and local-weight branches onto current main.

Includes:
- current-main-compatible GPU eval driver and durable artifact path
- local GPU weight materialization (no RunAI streamer)
- correct chat benchmark budgets, AIME seed propagation, Grug generation kwargs, and tokenizer compatibility
- RNO2A cluster selection for the baseline launcher

Validation:
- tests/evals/test_serve_and_eval_config.py
- tests/inference/test_serve.py
- 56 passed