### PR TITLE
inference: expire idle Iris serving endpoints

### DIFF
--- a/lib/marin/src/marin/inference/dashboard_server.py
+++ b/lib/marin/src/marin/inference/dashboard_server.py
@@ -21,7 +21,7 @@ import importlib.resources
 import logging
 import socket
 import threading
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterator, Callable, Iterator
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 
@@ -59,6 +59,7 @@ def build_dashboard_app(
     model_id: str,
     info: ServingInfo,
     request_timeout_seconds: float = 600.0,
+    on_inference_request: Callable[[], None] | None = None,
 ) -> Starlette:
     """Build the Starlette app fronting a local serving backend.
 
@@ -67,6 +68,8 @@ def build_dashboard_app(
         model_id: The model id the backend reports; surfaced to the dashboard.
         info: Static serving metadata returned from ``/info``.
         request_timeout_seconds: Per-request timeout for upstream proxying.
+        on_inference_request: Called for a model-inference request, but not
+            readiness, health, or model-discovery probes.
     """
     state: dict[str, httpx.AsyncClient] = {}
 
@@ -100,6 +103,11 @@ def build_dashboard_app(
         )
 
     async def proxy(request: Request) -> Response:
+        # Do not let the launcher's readiness probe or a monitor's GET /models
+        # keep an otherwise unused accelerator alive.  Actual OpenAI inference
+        # calls are non-GET requests under /v1/.
+        if on_inference_request is not None and request.method not in {"GET", "HEAD", "OPTIONS"}:
+            on_inference_request()
         client = state["client"]
         body = await request.body()
         fwd_headers = forwardable_request_headers(request.headers)

--- a/lib/marin/src/marin/inference/iris.py
+++ b/lib/marin/src/marin/inference/iris.py
@@ -5,6 +5,7 @@
 
 import contextlib
 import logging
+import threading
 import time
 import uuid
 from collections.abc import Iterator
@@ -93,12 +94,34 @@ class IrisServiceConfig:
     broker: BrokerConfig | None = None
     access: int = EndpointAccess.ENDPOINT_ACCESS_PRIVATE
     timeout_hours: float = 24.0
+    idle_timeout_hours: float | None = None
     controller_proxy_timeout_seconds: float = 600.0
     port_name: str | None = "http"
 
     def __post_init__(self) -> None:
         if self.instances <= 0:
             raise ValueError("instances must be positive")
+        if self.timeout_hours <= 0:
+            raise ValueError("timeout_hours must be positive")
+        if self.idle_timeout_hours is not None and self.idle_timeout_hours <= 0:
+            raise ValueError("idle_timeout_hours must be positive when set")
+
+
+class EndpointActivity:
+    """Thread-safe model-request activity used for service idle expiry."""
+
+    def __init__(self, *, monotonic=time.monotonic) -> None:
+        self._monotonic = monotonic
+        self._lock = threading.Lock()
+        self._last_inference_request = monotonic()
+
+    def record_inference_request(self) -> None:
+        with self._lock:
+            self._last_inference_request = self._monotonic()
+
+    def idle_seconds(self) -> float:
+        with self._lock:
+            return self._monotonic() - self._last_inference_request
 
 
 def _broker_config(instances: int, broker: BrokerConfig | None) -> BrokerConfig | None:
@@ -173,7 +196,7 @@ def _register_dashboard(
     tensor_parallel_size: int,
     backend_name: str,
     streaming: bool,
-) -> Iterator[None]:
+) -> Iterator[EndpointActivity]:
     job_info = get_job_info()
     if job_info is None:
         raise RuntimeError("Iris service must run inside an Iris job")
@@ -193,11 +216,13 @@ def _register_dashboard(
         endpoint=service.endpoint_name,
         streaming=streaming,
     )
+    activity = EndpointActivity()
     app = build_dashboard_app(
         upstream_base_url=_server_root(model),
         model_id=model.endpoint.model,
         info=info,
         request_timeout_seconds=service.controller_proxy_timeout_seconds,
+        on_inference_request=activity.record_inference_request,
     )
     with serve_app_background(app, serving_socket):
         address = f"http://{job_info.advertise_host}:{serving_port}"
@@ -219,7 +244,7 @@ def _register_dashboard(
             proxy_path(service.endpoint_name),
         )
         try:
-            yield
+            yield activity
         finally:
             try:
                 ctx.registry.unregister(endpoint_id)
@@ -227,20 +252,36 @@ def _register_dashboard(
                 logger.warning("Failed to unregister inference endpoint id=%s", endpoint_id, exc_info=True)
 
 
-def _block_until_timeout(session: LocalInferenceSession, timeout_hours: float) -> None:
+def _block_until_timeout(
+    session: LocalInferenceSession,
+    timeout_hours: float,
+    idle_timeout_hours: float | None,
+    activity: EndpointActivity,
+) -> None:
     deadline = time.monotonic() + timeout_hours * 3600
     while time.monotonic() < deadline:
         session.check_alive()
+        if idle_timeout_hours is not None and activity.idle_seconds() >= idle_timeout_hours * 3600:
+            logger.info("Stopping inference service after %.1fh without a model request", idle_timeout_hours)
+            return
         time.sleep(_TIMEOUT_POLL_SECONDS)
 
 
-def _block_remote_until_timeout(session: RemoteInferenceSession, timeout_hours: float) -> None:
+def _block_remote_until_timeout(
+    session: RemoteInferenceSession,
+    timeout_hours: float,
+    idle_timeout_hours: float | None,
+    activity: EndpointActivity,
+) -> None:
     deadline = time.monotonic() + timeout_hours * 3600
     while time.monotonic() < deadline:
         for job in session.jobs:
             status = job.status()
             if JobStatus.finished(status):
                 raise RuntimeError(f"Inference job {job.job_id} finished unexpectedly with status {status}")
+        if idle_timeout_hours is not None and activity.idle_seconds() >= idle_timeout_hours * 3600:
+            logger.info("Stopping inference service after %.1fh without a model request", idle_timeout_hours)
+            return
         time.sleep(_TIMEOUT_POLL_SECONDS)
 
 
@@ -258,8 +299,10 @@ def run_iris_service(service: IrisServiceConfig) -> None:
                 tensor_parallel_size=tensor_parallel_size,
                 backend_name=local_session.backend_name,
                 streaming=True,
-            ):
-                _block_until_timeout(local_session, service.timeout_hours)
+            ) as activity:
+                _block_until_timeout(
+                    local_session, service.timeout_hours, service.idle_timeout_hours, activity
+                )
         return
 
     with remote_inference(
@@ -275,8 +318,10 @@ def run_iris_service(service: IrisServiceConfig) -> None:
             tensor_parallel_size=session.tensor_parallel_size,
             backend_name=session.backend_name,
             streaming=session.streaming,
-        ):
-            _block_remote_until_timeout(session, service.timeout_hours)
+        ) as activity:
+            _block_remote_until_timeout(
+                session, service.timeout_hours, service.idle_timeout_hours, activity
+            )
 
 
 def _wait_for_endpoint(job: JobHandle, endpoint_name: str, timeout_seconds: float) -> tuple[str, dict[str, str]]:

--- a/lib/marin/src/marin/inference/iris_cli.py
+++ b/lib/marin/src/marin/inference/iris_cli.py
@@ -347,6 +347,12 @@ def _mint_and_print_capability_url(
 )
 @click.option("--timeout-hours", type=float, default=24.0, help="Wall-clock lifetime before the server self-stops.")
 @click.option(
+    "--idle-timeout-hours",
+    type=float,
+    default=None,
+    help="Stop the server after this long without a model-inference request (health/readiness probes do not count).",
+)
+@click.option(
     "--proxy-timeout",
     type=float,
     default=600.0,
@@ -428,6 +434,7 @@ def main(
     cache_ttl_days: int,
     no_cache: bool,
     timeout_hours: float,
+    idle_timeout_hours: float | None,
     proxy_timeout: float,
     region: str | None,
     cpu: float,
@@ -468,6 +475,8 @@ def main(
         raise click.ClickException("--endpoint-name cannot contain '.' (it breaks controller proxy routing).")
     if proxy_timeout <= 0:
         raise click.ClickException("--proxy-timeout must be positive.")
+    if idle_timeout_hours is not None and idle_timeout_hours <= 0:
+        raise click.ClickException("--idle-timeout-hours must be positive when set.")
 
     vllm_source_enum = VllmSource.MARIN_FORK if vllm_source == "marin-fork" else VllmSource.UPSTREAM
     plan = _resolve_serving_plan(
@@ -554,6 +563,7 @@ def main(
         broker=broker_config,
         access=EndpointAccess.ENDPOINT_ACCESS_LINK,
         timeout_hours=timeout_hours,
+        idle_timeout_hours=idle_timeout_hours,
         controller_proxy_timeout_seconds=proxy_timeout,
     )
 
@@ -617,6 +627,8 @@ def main(
             else:
                 click.echo(f"  proxy path   {proxy_path(endpoint)}/")
             click.echo(f"  timeout      {timeout_hours:g}h")
+            if idle_timeout_hours is not None:
+                click.echo(f"  idle timeout {idle_timeout_hours:g}h (model requests only)")
             click.echo(f"  req timeout  {proxy_timeout:g}s  (per-request proxy budget)")
             if controller is None and cluster:
                 click.echo(f"  stop with    iris --cluster {cluster} job stop {job}")

--- a/tests/inference/test_serve.py
+++ b/tests/inference/test_serve.py
@@ -474,8 +474,12 @@ def test_dashboard_serves_ui_and_reverse_proxies_streaming():
     )
 
     with serve_app_background(_fake_vllm_app(), upstream_sock):
+        inference_requests: list[None] = []
         app = build_dashboard_app(
-            upstream_base_url=f"http://127.0.0.1:{upstream_port}", model_id="fake-model", info=info
+            upstream_base_url=f"http://127.0.0.1:{upstream_port}",
+            model_id="fake-model",
+            info=info,
+            on_inference_request=lambda: inference_requests.append(None),
         )
         with serve_app_background(app, dashboard_sock):
             base = f"http://127.0.0.1:{dashboard_port}"
@@ -487,6 +491,7 @@ def test_dashboard_serves_ui_and_reverse_proxies_streaming():
             assert requests.get(f"{base}/info", timeout=10).json() == dataclasses.asdict(info)
             assert requests.get(f"{base}/health", timeout=10).json() == {"status": "ok", "model": "fake-model"}
             assert requests.get(f"{base}/v1/models", timeout=10).json()["data"][0]["id"] == "fake-model"
+            assert inference_requests == []
 
             chat = requests.post(
                 f"{base}/v1/chat/completions",
@@ -495,6 +500,7 @@ def test_dashboard_serves_ui_and_reverse_proxies_streaming():
                 timeout=10,
             )
             assert _collect_sse_text(chat, "delta") == "Hello, world!"
+            assert len(inference_requests) == 1
 
             completion = requests.post(
                 f"{base}/v1/completions",
@@ -503,6 +509,7 @@ def test_dashboard_serves_ui_and_reverse_proxies_streaming():
                 timeout=10,
             )
             assert _collect_sse_text(completion, "text") == "123456"
+            assert len(inference_requests) == 2
 
 
 def test_dashboard_health_reports_loading_when_upstream_down():


### PR DESCRIPTION
Adds an optional `--idle-timeout-hours` to `marin-serve iris`.

- counts only non-GET OpenAI inference requests at the endpoint proxy; readiness, health, and `/v1/models` probes do not reset the timer
- preserves the existing wall-clock timeout as a separate safety bound
- applies to direct and brokered services

Validation: `pytest tests/inference/test_serve.py -q` (47 passed).