### PR TITLE
[iac] Resolve the Cloudflare API token from Secret Manager

### DIFF
--- a/infra/pulumi/README.md
+++ b/infra/pulumi/README.md
@@ -67,12 +67,10 @@ Everything comes from the per-cluster Iris config (`lib/iris/config/<cluster>.ya
 - **GCP credentials**: `gcloud auth application-default login`. Decrypting stack secrets is
   authorized by your own GCP credentials against the shared KMS key — see "Backend" below for
   getting the IAM role granted.
-- **Cloudflare credential**: stacks with `provisioning.coreweave.federation_dns` read
-  `CLOUDFLARE_API_TOKEN`. Load the DNS-only token without copying it into stack config:
-  ```bash
-  export CLOUDFLARE_API_TOKEN="$(gcloud secrets versions access latest \
-    --secret=cloudflare-oa-dns-token --project=hai-gcp-models)"
-  ```
+- **Cloudflare credential**: stacks with `provisioning.coreweave.federation_dns` read the
+  DNS-only Cloudflare token straight from Secret Manager (`cloudflare-oa-dns-token` in
+  `hai-gcp-models`, the same one `infra/grafana` uses) under your GCP credentials above — no
+  separate export needed, just `roles/secretmanager.secretAccessor` on that secret.
 - **Backend login**: `pulumi login gs://marin-iac-state`.
 - **Cluster access** (for the k8s dry-run): the CoreWeave kubeconfig at the path in the
   cluster's `platform.coreweave.kubeconfig_path` (typically `~/.kube/coreweave-iris`).

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
 import pulumi
 import pulumi_gcp as gcp
 import pulumi_kubernetes as k8s
-from iac.config import Provider, load_iris_config, load_provisioning
+from iac.config import CLOUDFLARE_TOKEN_SECRET, Provider, load_iris_config, load_provisioning
 from iac.coreweave.cluster import CoreweaveCluster, CoreweaveClusterArgs
 from iac.coreweave.dns import FederationDns, FederationDnsArgs
 from iac.coreweave.kueue import KueueAddon, KueueAddonArgs
@@ -34,6 +34,7 @@ from iac.coreweave.traefik import TraefikAddon, TraefikAddonArgs
 from iac.gcp.addresses import GcpStaticAddresses, GcpStaticAddressesArgs
 from iac.gcp.registries import GcpArtifactRegistries, GcpArtifactRegistriesArgs
 from iac.nodepools import derive_nodepools
+from rigging.secrets import resolve_secret_spec
 
 DEFAULT_NAMESPACE = "iris"
 
@@ -153,12 +154,7 @@ def _build_coreweave(cluster: str, *, adopt: bool) -> None:
 
     federation_dns = coreweave_provisioning.federation_dns
     if federation_dns is not None:
-        cloudflare_api_token = os.environ.get("CLOUDFLARE_API_TOKEN")
-        if not cloudflare_api_token:
-            raise ValueError(
-                "CLOUDFLARE_API_TOKEN is required when provisioning.coreweave.federation_dns is set; "
-                "load cloudflare-oa-dns-token from GCP Secret Manager"
-            )
+        cloudflare_api_token = resolve_secret_spec(CLOUDFLARE_TOKEN_SECRET).value
         FederationDns(
             "dns",
             FederationDnsArgs(

--- a/infra/pulumi/src/iac/config.py
+++ b/infra/pulumi/src/iac/config.py
@@ -84,6 +84,8 @@ class KueueProvisioningSpec(BaseModel):
 MARIN_FEDERATION_EGRESS_SOURCES = ["34.27.183.11", "35.254.13.19"]
 CLOUDFLARE_OA_DEV_ZONE_ID = "169959d6aafcbfd77764b8efafa3a509"
 
+CLOUDFLARE_TOKEN_SECRET = "gcp-secret://projects/hai-gcp-models/secrets/cloudflare-oa-dns-token/versions/latest"
+
 
 class IngressSpec(BaseModel):
     """Traefik + cert-manager + ACME issuers, and the IP-locked federation route (TraefikAddon)."""


### PR DESCRIPTION
Follow-up to #7533, which landed FederationDns but kept requiring a manually exported CLOUDFLARE_API_TOKEN. Replaces that with loading it from Secrets Manager.

Does not create a pulumi diff since I'd already done this in https://github.com/marin-community/marin/pull/7526