### PR TITLE
[infra] Deploy Loom repository HEAD by default

### DIFF
--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -31,21 +31,25 @@ The local Docker builder must support `linux/amd64`.
 
 ## Deploy
 
-Set `LOOM_SOURCE` to the Loom worktree to build. Pulumi builds that tree during
-preview to catch image failures without pushing it. `pulumi up` rebuilds and
-pushes the image, places the provider-produced digest in VM metadata, and waits
-for `https://loom.oa.dev/api/ready` after activation.
+By default, Pulumi builds the HEAD of Loom's default branch during preview to
+catch image failures without pushing it. `pulumi up` rebuilds and pushes the
+image, places the provider-produced digest in VM metadata, and waits for
+`https://loom.oa.dev/api/ready` after activation.
 
 ```sh
-cd /path/to/loom
-export LOOM_SOURCE="$(git rev-parse --show-toplevel)"
 pulumi preview --cwd /path/to/marin/infra/loom --stack marin-loom --diff
 pulumi up --cwd /path/to/marin/infra/loom --stack marin-loom
 curl -fsS https://loom.oa.dev/api/ready
 ```
 
-The build includes tracked and untracked files allowed by the Loom worktree's
-`.dockerignore`. Review the local diff before deployment.
+Set `LOOM_SOURCE` to a Loom worktree to deploy local changes instead. The local
+build includes tracked and untracked files allowed by that worktree's
+`.dockerignore`; review its diff before deployment.
+
+```sh
+export LOOM_SOURCE=/path/to/loom
+pulumi up --cwd /path/to/marin/infra/loom --stack marin-loom
+```
 
 Pulumi renders the Compose and Caddy configuration into VM metadata. The GCE
 startup unit mounts the persistent disk, reads one numbered `LOOM_DOTENV`

--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -42,13 +42,15 @@ pulumi up --cwd /path/to/marin/infra/loom --stack marin-loom
 curl -fsS https://loom.oa.dev/api/ready
 ```
 
-Set `LOOM_SOURCE` to a Loom worktree to deploy local changes instead. The local
+Set `buildContext` to a Loom worktree to deploy local changes instead. The local
 build includes tracked and untracked files allowed by that worktree's
-`.dockerignore`; review its diff before deployment.
+`.dockerignore`; review its diff before deployment. Pulumi saves `-c` values in
+the stack configuration, so remove the override to return to the remote HEAD.
 
 ```sh
-export LOOM_SOURCE=/path/to/loom
-pulumi up --cwd /path/to/marin/infra/loom --stack marin-loom
+pulumi up --cwd /path/to/marin/infra/loom --stack marin-loom \
+  -c buildContext=/path/to/loom
+pulumi config rm --cwd /path/to/marin/infra/loom --stack marin-loom buildContext
 ```
 
 Pulumi renders the Compose and Caddy configuration into VM metadata. The GCE

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -331,11 +331,12 @@ class DeploymentConfig:
         gcp_config = pulumi.Config("gcp")
         project = gcp_config.require("project")
         source_path = os.environ.get("LOOM_SOURCE")
-        if source_path is None:
-            raise ValueError("LOOM_SOURCE must point to the Loom worktree to build")
-        source = Path(source_path).expanduser().resolve()
-        if not (source / "Dockerfile").is_file():
-            raise ValueError(f"LOOM_SOURCE does not contain a Dockerfile: {source}")
+        source = REPOSITORY_URL
+        if source_path is not None:
+            local_source = Path(source_path).expanduser().resolve()
+            if not (local_source / "Dockerfile").is_file():
+                raise ValueError(f"LOOM_SOURCE does not contain a Dockerfile: {local_source}")
+            source = str(local_source)
         region = config.require("region")
         raw_profiles = config.get_object("profiles") or {}
         if not isinstance(raw_profiles, dict):
@@ -368,7 +369,7 @@ class DeploymentConfig:
             domain=config.require("domain"),
             operator_cidr=config.require("operatorCidr"),
             dns_zone_id=config.require("dnsZoneId"),
-            source_path=str(source),
+            source_path=source,
             network=config.require("network"),
             instance_name=config.require("instanceName"),
             vm_service_account_name=config.require("vmServiceAccountName"),

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -285,7 +285,7 @@ class DeploymentConfig:
     domain: str
     operator_cidr: str
     dns_zone_id: str
-    source_path: str
+    build_context: str
     network: str
     instance_name: str
     vm_service_account_name: str
@@ -369,7 +369,7 @@ class DeploymentConfig:
             domain=config.require("domain"),
             operator_cidr=config.require("operatorCidr"),
             dns_zone_id=config.require("dnsZoneId"),
-            source_path=source,
+            build_context=source,
             network=config.require("network"),
             instance_name=config.require("instanceName"),
             vm_service_account_name=config.require("vmServiceAccountName"),
@@ -555,7 +555,7 @@ def _create_image(
     image_tag = f"{_artifact_image_path(config.project, config.region)}:latest"
     image = docker_build.Image(
         "loom-release-image",
-        context=docker_build.BuildContextArgs(location=config.source_path),
+        context=docker_build.BuildContextArgs(location=config.build_context),
         build_args={"CARGO_PROFILE": "release"},
         labels={"org.opencontainers.image.source": REPOSITORY_URL},
         platforms=[docker_build.Platform.LINUX_AMD64],

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -330,12 +329,12 @@ class DeploymentConfig:
         config = pulumi.Config()
         gcp_config = pulumi.Config("gcp")
         project = gcp_config.require("project")
-        source_path = os.environ.get("LOOM_SOURCE")
+        source_path = config.get("buildContext")
         source = REPOSITORY_URL
         if source_path is not None:
             local_source = Path(source_path).expanduser().resolve()
             if not (local_source / "Dockerfile").is_file():
-                raise ValueError(f"LOOM_SOURCE does not contain a Dockerfile: {local_source}")
+                raise ValueError(f"buildContext does not contain a Dockerfile: {local_source}")
             source = str(local_source)
         region = config.require("region")
         raw_profiles = config.get_object("profiles") or {}

--- a/infra/loom/tests/test_infrastructure.py
+++ b/infra/loom/tests/test_infrastructure.py
@@ -11,6 +11,7 @@ import pytest
 from pulumi.runtime import MockCallArgs, MockResourceArgs, Mocks
 
 from infra.loom.infrastructure import (
+    REPOSITORY_URL,
     DeploymentConfig,
     GitHubFederationConfig,
     ProfileConfig,
@@ -104,6 +105,34 @@ def by_name(mocks: RecordingMocks, name: str) -> MockResourceArgs:
 
 def field(inputs: dict, snake: str, camel: str):
     return inputs.get(snake, inputs.get(camel))
+
+
+def test_pulumi_config_defaults_to_loom_repository_head(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LOOM_SOURCE", raising=False)
+    pulumi.runtime.set_mocks(RecordingMocks(), project="marin-loom", stack="test", preview=False)
+    pulumi.runtime.set_all_config(
+        {
+            "gcp:project": "example",
+            "marin-loom:region": "us-central1",
+            "marin-loom:zone": "us-central1-a",
+            "marin-loom:domain": "loom.example.com",
+            "marin-loom:operatorCidr": "203.0.113.7/32",
+            "marin-loom:dnsZoneId": "cloudflare-zone",
+            "marin-loom:network": "default",
+            "marin-loom:instanceName": "loom",
+            "marin-loom:vmServiceAccountName": "loom-vm",
+            "marin-loom:machineType": "e2-highmem-4",
+            "marin-loom:bootDiskGb": "100",
+            "marin-loom:dataDiskGb": "500",
+            "marin-loom:dotenvSecretVersion": "3",
+            "marin-loom:snapshotRetentionDays": "14",
+        }
+    )
+
+    try:
+        assert DeploymentConfig.from_pulumi().source_path == REPOSITORY_URL
+    finally:
+        pulumi.runtime.set_all_config({})
 
 
 def test_empty_runtime_policy_cannot_prune_existing_profiles() -> None:

--- a/infra/loom/tests/test_infrastructure.py
+++ b/infra/loom/tests/test_infrastructure.py
@@ -11,7 +11,6 @@ import pytest
 from pulumi.runtime import MockCallArgs, MockResourceArgs, Mocks
 
 from infra.loom.infrastructure import (
-    REPOSITORY_URL,
     DeploymentConfig,
     GitHubFederationConfig,
     ProfileConfig,
@@ -105,34 +104,6 @@ def by_name(mocks: RecordingMocks, name: str) -> MockResourceArgs:
 
 def field(inputs: dict, snake: str, camel: str):
     return inputs.get(snake, inputs.get(camel))
-
-
-def test_pulumi_config_defaults_to_loom_repository_head(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("LOOM_SOURCE", raising=False)
-    pulumi.runtime.set_mocks(RecordingMocks(), project="marin-loom", stack="test", preview=False)
-    pulumi.runtime.set_all_config(
-        {
-            "gcp:project": "example",
-            "marin-loom:region": "us-central1",
-            "marin-loom:zone": "us-central1-a",
-            "marin-loom:domain": "loom.example.com",
-            "marin-loom:operatorCidr": "203.0.113.7/32",
-            "marin-loom:dnsZoneId": "cloudflare-zone",
-            "marin-loom:network": "default",
-            "marin-loom:instanceName": "loom",
-            "marin-loom:vmServiceAccountName": "loom-vm",
-            "marin-loom:machineType": "e2-highmem-4",
-            "marin-loom:bootDiskGb": "100",
-            "marin-loom:dataDiskGb": "500",
-            "marin-loom:dotenvSecretVersion": "3",
-            "marin-loom:snapshotRetentionDays": "14",
-        }
-    )
-
-    try:
-        assert DeploymentConfig.from_pulumi().build_context == REPOSITORY_URL
-    finally:
-        pulumi.runtime.set_all_config({})
 
 
 def test_empty_runtime_policy_cannot_prune_existing_profiles() -> None:

--- a/infra/loom/tests/test_infrastructure.py
+++ b/infra/loom/tests/test_infrastructure.py
@@ -57,7 +57,7 @@ def deployment_config() -> DeploymentConfig:
         domain="loom.example.com",
         operator_cidr="203.0.113.7/32",
         dns_zone_id="cloudflare-zone",
-        source_path="/tmp/loom-source",
+        build_context="/tmp/loom-source",
         network="default",
         instance_name="loom",
         vm_service_account_name="loom-vm",
@@ -130,7 +130,7 @@ def test_pulumi_config_defaults_to_loom_repository_head(monkeypatch: pytest.Monk
     )
 
     try:
-        assert DeploymentConfig.from_pulumi().source_path == REPOSITORY_URL
+        assert DeploymentConfig.from_pulumi().build_context == REPOSITORY_URL
     finally:
         pulumi.runtime.set_all_config({})
 


### PR DESCRIPTION
Use Loom's remote Git repository as the Docker build context when
`buildContext` is unset. `pulumi up --cwd infra/loom` now builds the current
HEAD of Loom's default branch without requiring a local Loom checkout.

Use Pulumi's native `-c buildContext=/path/to/loom` option to deploy uncommitted
changes from a validated local worktree. Removing the setting restores the
remote repository HEAD default.
