### PR TITLE
[xprof] Raise /ops/xprof resources and proxy timeout for large profiles

### DIFF
--- a/infra/xprof/Pulumi.xprof-marin.yaml
+++ b/infra/xprof/Pulumi.xprof-marin.yaml
@@ -2,8 +2,8 @@ config:
   xprof:cluster: marin
   xprof:user: ops
   xprof:region: us-east5
-  xprof:cpu: "2"
-  xprof:memory: 12GB
+  xprof:cpu: "16"
+  xprof:memory: 64GB
   xprof:disk: 80GB
   xprof:deploy_generation: "0"
   xprof:env:

--- a/infra/xprof/config.py
+++ b/infra/xprof/config.py
@@ -8,3 +8,8 @@ PORT_NAME = "xprof"
 HEALTH_PATH = "/healthz"
 PUBLIC_PATH = proxy_path(ENDPOINT_NAME)
 XPROF_PACKAGE = "xprof==2.22.3"
+
+# XProf overview_page requests over ALL_HOSTS on large profiles routinely take
+# longer than the controller proxy's 120s default, so raise the per-endpoint
+# upstream timeout well above it.
+PROXY_TIMEOUT_SECONDS = 600

--- a/infra/xprof/server.py
+++ b/infra/xprof/server.py
@@ -10,11 +10,12 @@ from cheroot import wsgi
 from iris.client.client import iris_ctx
 from iris.cluster.client.job_info import get_job_info
 from iris.cluster.platforms.types import find_free_port
+from iris.cluster.types import PROXY_TIMEOUT_METADATA_KEY
 from rigging.filesystem.s3_compat import configure_coreweave_s3
 from xprof import server as xprof_server
 from xprof.convert import _pywrap_profiler_plugin
 
-from infra.xprof.config import ENDPOINT_NAME, PORT_NAME, PUBLIC_PATH
+from infra.xprof.config import ENDPOINT_NAME, PORT_NAME, PROXY_TIMEOUT_SECONDS, PUBLIC_PATH
 from infra.xprof.gateway import ProfileCache, ProfileStageManager, XprofGateway
 
 logger = logging.getLogger(__name__)
@@ -51,7 +52,11 @@ def main() -> None:
     if port == 0:
         port = find_free_port()
     address = f"http://{job_info.advertise_host}:{port}"
-    endpoint_id = ctx.registry.register(ENDPOINT_NAME, address, {"job_id": ctx.job_id.to_wire()})
+    endpoint_id = ctx.registry.register(
+        ENDPOINT_NAME,
+        address,
+        {"job_id": ctx.job_id.to_wire(), PROXY_TIMEOUT_METADATA_KEY: str(PROXY_TIMEOUT_SECONDS)},
+    )
     http_server = wsgi.Server((os.environ["IRIS_BIND_HOST"], port), app)
 
     def stop_server(_signum, _frame) -> None:


### PR DESCRIPTION
The always-on xprof service hit two walls processing large multi-host profiles, both from the same heavy overview_page work:

- The container OOM-killed (exit 137) while generating derived timelines, which orphaned its `/xprof` endpoint registration until the lease expired.
- `overview_page` fetches for `host=ALL_HOSTS` exceeded the controller proxy's 120s default upstream timeout, returning 504 to the xprof UI.

Changes:
- Bump the service to 16 CPU / 64 GB (from 2 CPU / 12 GB).
- Set the endpoint's per-request proxy timeout to 600s via the canonical `PROXY_TIMEOUT_METADATA_KEY`, hoisting the value to a named `PROXY_TIMEOUT_SECONDS` constant.

Already deployed to the marin cluster via `pulumi up` (stack `xprof-marin`); the live `/ops/xprof` job runs 16 CPU / 64 GB and registers `/xprof` with `proxy_timeout_seconds=600`. This PR brings `main` in line so the next `pulumi up` does not revert it.