### PR TITLE
[datakit] Verify fuzzy dedup candidates before removal

### DIFF
--- a/.github/workflows/marin-integration.yaml
+++ b/.github/workflows/marin-integration.yaml
@@ -38,6 +38,22 @@ jobs:
         with:
           enable-cache: true
 
+      # Integration tests exercise workspace Python packages in worker
+      # subprocesses. Build their companion native packages from the same
+      # checkout so a coordinated Python/Rust API change cannot load an older
+      # published wheel.
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
+        with:
+          workspaces: |
+            lib/dupekit/rust
+            lib/finelog/rust
+            lib/iris/rust
+      - name: Switch native packages to source build
+        run: python3 scripts/rust_mode.py dev
+
       - name: Install dependencies
         # `--no-default-groups` keeps uv from also installing every workspace package's
         # dev/docs/test groups (e.g. `levanter[docs,test,dev]`), which saves multiple

--- a/experiments/datakit/reference_pipeline.py
+++ b/experiments/datakit/reference_pipeline.py
@@ -99,13 +99,16 @@ from marin.execution.remote import remote
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.deduplication.fuzzy_dups import (
+    FUZZY_DUPS_CANDIDATE_SCOPE,
     FuzzyDupsAttrData,
     compute_fuzzy_dups_attrs,
 )
 from marin.processing.classification.deduplication.fuzzy_minhash import (
     MinHashAttrData,
+    NgramKind,
     compute_minhash_attrs,
 )
+from marin.processing.classification.deduplication.fuzzy_verification import FuzzyVerificationParams
 from marin.processing.tokenize.attributes import (
     TokenizedAttrData,
     tokenize_attributes_step,
@@ -235,16 +238,17 @@ class PoolConfig:
 
 @dataclass(frozen=True)
 class MinhashConfig:
-    """Content-determining MinHash / LSH knobs for the fuzzy-dedup stage.
+    """Content-determining MinHash / LSH candidate-retrieval knobs.
 
     Not scale-sensitive (a smoke and a full run must agree), but every field shapes
-    the emitted signatures and buckets, so all are hashed into the minhash step -- and
-    thereby, via the minhash deps, into dedup and the store.
+    the emitted signatures and buckets. All are hashed into the MinHash step and
+    thereby, through its dependencies, into exact verification and the store.
     """
 
     num_perms: int = 286
     num_bands: int = 26
     ngram_size: int = 5
+    ngram_kind: NgramKind = NgramKind.WORD
     text_cap_chars: int | None = 500_000
     seed: int = 42
 
@@ -665,6 +669,7 @@ def reference_datakit_steps(
                 "num_perms": mh.num_perms,
                 "num_bands": mh.num_bands,
                 "ngram_size": mh.ngram_size,
+                "ngram_kind": str(mh.ngram_kind),
                 "text_cap_chars": mh.text_cap_chars,
                 "seed": mh.seed,
                 "v": 1,
@@ -675,6 +680,7 @@ def reference_datakit_steps(
                 num_perms=mh.num_perms,
                 num_bands=mh.num_bands,
                 ngram_size=mh.ngram_size,
+                ngram_kind=mh.ngram_kind,
                 text_cap_chars=mh.text_cap_chars,
                 seed=mh.seed,
                 worker_resources=scale.pool.worker,
@@ -692,16 +698,21 @@ def reference_datakit_steps(
         }
 
     # ---- Cross-source dedup ----------------------------------------------------
-    # No content params of its own -- the MinHash params live in the minhash deps
-    # (so a param change re-keys minhash, then dedup via dep names); connected
-    # components is deterministic given those inputs. ``v`` is a manual salt.
+    verification = FuzzyVerificationParams()
+    # Candidate scope and exact-verifier thresholds determine which normalized
+    # rows survive, so both must rekey the persisted step.
     dedup = StepSpec(
         name="datakit/dedup",
         deps=minhash_steps,
-        hash_attrs={"v": 1},
+        hash_attrs={
+            "candidate_scope": FUZZY_DUPS_CANDIDATE_SCOPE,
+            "verification": verification.model_dump(),
+            "v": 2,
+        },
         fn=lambda op: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(s.output_path, MinHashAttrData) for s in minhash_steps],
             output_path=op,
+            verification_params=verification,
             max_parallelism=scale.dedup_max_parallelism,
             cc_resume=True,
             worker_resources=scale.pool.worker,

--- a/experiments/datakit/reports/dedup.py
+++ b/experiments/datakit/reports/dedup.py
@@ -1,73 +1,101 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Stage report for the cross-source fuzzy dedup step.
+"""Stage report for verified cross-source fuzzy deduplication."""
 
-Headline numbers come from the artifact's aggregated counters. The per-source
-table and the cluster-size histogram come from a bounded sample of each
-source's dup-marker parquet, which is sparse: only non-singleton cluster
-members get a row, and sources with zero non-singletons have empty shards.
-"""
-
-from collections import Counter
+from pathlib import PurePosixPath
 
 from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData
 
-from experiments.datakit.reports.common import StageReport, render_template, sample_rows, write_report
+from experiments.datakit.reports.common import StageReport, render_template, write_report
 
-SAMPLE_LIMIT = 1000
-COUNTER_PREFIX = "dedup/fuzzy/document"
+VERIFICATION_COUNTER = "dedup/fuzzy/verification"
 
 
 def _source_label(source_main_dir: str) -> str:
     return "/".join(source_main_dir.rstrip("/").split("/")[-3:])
 
 
-def dedup_report(output_path: str, dedup: FuzzyDupsAttrData) -> StageReport:
-    """Render the fuzzy-dedup stage report and return its path plus headline stats."""
-    cluster_members = int(dedup.counters.get(f"{COUNTER_PREFIX}/cluster_members", 0))
-    clusters = int(dedup.counters.get(f"{COUNTER_PREFIX}/canonicals", 0))
-    singletons_skipped = int(dedup.counters.get(f"{COUNTER_PREFIX}/singletons_skipped", 0))
-    duplicates_to_drop = cluster_members - clusters
-    total_docs = cluster_members + singletons_skipped
+def _counter_suffix(dedup: FuzzyDupsAttrData, prefix: str) -> dict[str, int]:
+    start = f"{prefix}/"
+    return {key[len(start) :]: int(value) for key, value in dedup.counters.items() if key.startswith(start)}
 
-    # dup_cluster_id is global across sources, so pooling the per-source
-    # samples yields cross-source cluster sizes (within the sample).
-    sampled_cluster_sizes: Counter[str] = Counter()
+
+def _histogram(dedup: FuzzyDupsAttrData, metric: str) -> list[dict[str, int | str]]:
+    counts = _counter_suffix(dedup, f"{VERIFICATION_COUNTER}/histogram/{metric}")
+    return [{"bin": key, "pairs": value} for key, value in sorted(counts.items(), key=lambda item: int(item[0]))]
+
+
+def _lsh_collision_curve(dedup: FuzzyDupsAttrData) -> dict:
+    bands = dedup.params.num_bands
+    rows_per_band = dedup.params.num_perms // bands
+
+    def collision_probability(similarity: float) -> float:
+        return 1 - (1 - similarity**rows_per_band) ** bands
+
+    return {
+        "bands": bands,
+        "rows_per_band": rows_per_band,
+        "midpoint": (1 - 0.5 ** (1 / bands)) ** (1 / rows_per_band),
+        "points": [
+            {
+                "similarity": similarity,
+                "collision_probability": collision_probability(similarity),
+            }
+            for similarity in (0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99)
+        ],
+    }
+
+
+def dedup_report(output_path: str, dedup: FuzzyDupsAttrData) -> StageReport:
+    """Render exact candidate, rejection, and score evidence."""
+    candidates = int(dedup.counters.get(f"{VERIFICATION_COUNTER}/candidates", 0))
+    verified = int(dedup.counters.get(f"{VERIFICATION_COUNTER}/decision/accepted", 0))
+    rejection_counts = _counter_suffix(dedup, f"{VERIFICATION_COUNTER}/decision")
+    rejection_counts.pop("accepted", None)
+    rejected = candidates - verified
+    transitive_kept = int(dedup.counters.get("dedup/fuzzy/document/transitive_members_kept", 0))
+
     per_source = []
     for source_main_dir, entry in dedup.sources.items():
-        rows = sample_rows(entry.attr_dir, ["id", "attributes"], SAMPLE_LIMIT)
-        source_clusters = {r["attributes"]["dup_cluster_id"] for r in rows}
-        sampled_cluster_sizes.update(r["attributes"]["dup_cluster_id"] for r in rows)
+        source_tag = PurePosixPath(entry.attr_dir).name
+        decisions = _counter_suffix(dedup, f"{VERIFICATION_COUNTER}/source/{source_tag}/decision")
+        source_candidates = sum(decisions.values())
+        source_verified = decisions.get("accepted", 0)
         per_source.append(
             {
                 "label": _source_label(source_main_dir),
                 "source_main_dir": source_main_dir,
-                "sampled_members": len(rows),
-                "sampled_clusters": len(source_clusters),
+                "candidates": source_candidates,
+                "verified": source_verified,
+                "rejected": source_candidates - source_verified,
+                "acceptance_rate": source_verified / source_candidates if source_candidates else 0.0,
             }
         )
 
     stats = {
-        "cluster_members": cluster_members,
-        "clusters": clusters,
-        "duplicates_to_drop": duplicates_to_drop,
-        "singletons_skipped": singletons_skipped,
-        "dup_rate": duplicates_to_drop / total_docs if total_docs else 0.0,
+        "candidates": candidates,
+        "verified_duplicates": verified,
+        "rejected_candidates": rejected,
+        "acceptance_rate": verified / candidates if candidates else 0.0,
+        "transitive_members_kept": transitive_kept,
         "n_sources": len(dedup.sources),
     }
     data = {
         "params": dedup.params.model_dump(),
+        "verification": dedup.verification.model_dump(),
+        "decisions_dir": dedup.decisions_dir,
+        "lsh_collision_curve": _lsh_collision_curve(dedup),
         "stats": stats,
-        "sources": per_source,
-        "cluster_size_hist": [
-            {"size": size, "clusters": count} for size, count in sorted(Counter(sampled_cluster_sizes.values()).items())
+        "rejections": [
+            {"reason": reason, "pairs": pairs}
+            for reason, pairs in sorted(rejection_counts.items(), key=lambda item: (-item[1], item[0]))
         ],
-        "sample_limit": SAMPLE_LIMIT,
-        "sampling": (
-            f"headline numbers from dedup counters (exact); per-source table + cluster-size histogram "
-            f"from the first {SAMPLE_LIMIT} non-singleton rows per source (file order)"
-        ),
+        "sources": sorted(per_source, key=lambda row: (-row["candidates"], row["label"])),
+        "histograms": {
+            metric: _histogram(dedup, metric)
+            for metric in ("member_containment", "jaccard", "member_unique", "shared_buckets")
+        },
     }
     page = render_template("dedup.html", title="Datakit dedup", data=data)
     return StageReport(html_path=write_report(output_path, page), stats=stats)

--- a/experiments/datakit/reports/store.py
+++ b/experiments/datakit/reports/store.py
@@ -35,7 +35,7 @@ def store_report(output_path: str, store: ClusteredStoreData) -> StageReport:
         "n_sources": len(store.source_names),
         "records_in": store.counters.get("datakit_store/records_in", 0),
         "contaminated_dropped": store.counters.get("datakit_store/contaminated_dropped", 0),
-        "dedup_noncanonical_dropped": store.counters.get("datakit_store/dedup_noncanonical_dropped", 0),
+        "dedup_verified_dropped": store.counters.get("datakit_store/dedup_verified_dropped", 0),
         "records_out": store.counters.get("datakit_store/records_out", 0),
     }
     data = {

--- a/experiments/datakit/reports/templates/dedup.html
+++ b/experiments/datakit/reports/templates/dedup.html
@@ -42,15 +42,19 @@ td.heat{font-family:var(--mono);font-variant-numeric:tabular-nums}
   <header>
     <h1>__TITLE__</h1>
     <div class="sub" id="meta"></div>
-    <div class="sub" id="sampling"></div>
+    <div class="sub" id="evidence"></div>
   </header>
   <div class="cards" id="cards"></div>
-  <h2>minhash params</h2>
+  <h2>candidate and verifier parameters</h2>
   <div class="panel mono" id="params" style="font-size:12px"></div>
-  <h2>per-source samples</h2>
+  <h2>LSH candidate collision curve</h2>
+  <div class="tablewrap"><table id="lsh"></table></div>
+  <h2>candidate rejection reasons</h2>
+  <div class="tablewrap"><table id="rejections"></table></div>
+  <h2>per-source exact decisions</h2>
   <div class="tablewrap"><table id="sources"></table></div>
-  <h2>cluster size distribution (sampled)</h2>
-  <div class="tablewrap"><table id="hist"></table></div>
+  <h2>exact-score histograms</h2>
+  <div class="tablewrap"><table id="histograms"></table></div>
 </div>
 <script>
 const D = __DATA__;
@@ -59,32 +63,49 @@ const fmt = n => n >= 1e12 ? (n/1e12).toFixed(2)+"T" : n >= 1e9 ? (n/1e9).toFixe
 const pct = x => (100*x).toFixed(2)+"%";
 const S = D.stats;
 document.getElementById("meta").textContent =
-  `${S.n_sources} sources · sampled ≤${D.sample_limit} cluster members/source`;
-document.getElementById("sampling").textContent = D.sampling;
+  `${S.n_sources} sources · ${fmt(S.candidates)} direct-canonical candidates`;
+document.getElementById("evidence").textContent = `candidate evidence: ${D.decisions_dir}`;
 const cards = [
-  ["cluster members", fmt(S.cluster_members), "non-singleton docs"],
-  ["clusters", fmt(S.clusters), "one canonical each"],
-  ["duplicates to drop", fmt(S.duplicates_to_drop), "members − canonicals"],
-  ["singletons skipped", fmt(S.singletons_skipped), "no duplicate found"],
-  ["dup rate", pct(S.dup_rate), "drop / all docs"],
+  ["LSH candidates", fmt(S.candidates), "direct canonical neighbors"],
+  ["verified drops", fmt(S.verified_duplicates), "exact rule passed"],
+  ["candidates kept", fmt(S.rejected_candidates), "exact rule rejected"],
+  ["acceptance rate", pct(S.acceptance_rate), "verified / candidate"],
+  ["transitive kept", fmt(S.transitive_members_kept), "never sent to verifier"],
 ];
 document.getElementById("cards").innerHTML = cards.map(([k,v,d]) =>
   `<div class="card"><div class="k">${k}</div><div class="v">${v}</div><div class="d">${d}</div></div>`).join("");
 document.getElementById("params").textContent =
-  Object.entries(D.params).map(([k,v]) => `${k}=${v === null ? "none" : v}`).join("  ·  ");
-let srows = `<tr><th>source</th><th>sampled members</th><th>distinct clusters</th></tr>`;
+  "candidate: " + Object.entries(D.params).map(([k,v]) => `${k}=${v === null ? "none" : v}`).join(" · ") +
+  "\nverifier: " + Object.entries(D.verification).map(([k,v]) => `${k}=${v === null ? "none" : v}`).join(" · ");
+const L = D.lsh_collision_curve;
+let lrows = `<tr><th>exact shingle Jaccard</th><th>P(any LSH collision)</th></tr>`;
+for (const point of L.points) {
+  lrows += `<tr><td class="num">${point.similarity.toFixed(2)}</td>` +
+    `<td class="num">${pct(point.collision_probability)}</td></tr>`;
+}
+lrows += `<tr><td>50% collision midpoint</td><td class="num">${L.midpoint.toFixed(4)}</td></tr>`;
+document.getElementById("lsh").innerHTML = lrows;
+let rrows = `<tr><th>reason</th><th>pairs</th><th>candidate share</th></tr>`;
+for (const row of D.rejections) {
+  rrows += `<tr><td>${row.reason}</td><td class="num">${row.pairs.toLocaleString()}</td>` +
+    `<td class="num">${pct(row.pairs / Math.max(1, S.candidates))}</td></tr>`;
+}
+document.getElementById("rejections").innerHTML = rrows;
+let srows = `<tr><th>source</th><th>candidates</th><th>verified</th><th>rejected</th><th>acceptance</th></tr>`;
 for (const s of D.sources) {
   srows += `<tr><td title="${s.source_main_dir}">${s.label}</td>` +
-    `<td class="num">${s.sampled_members.toLocaleString()}</td>` +
-    `<td class="num">${s.sampled_clusters.toLocaleString()}</td></tr>`;
+    `<td class="num">${s.candidates.toLocaleString()}</td>` +
+    `<td class="num">${s.verified.toLocaleString()}</td>` +
+    `<td class="num">${s.rejected.toLocaleString()}</td>` +
+    `<td class="num">${pct(s.acceptance_rate)}</td></tr>`;
 }
 document.getElementById("sources").innerHTML = srows;
-const maxClusters = Math.max(1, ...D.cluster_size_hist.map(h => h.clusters));
-let hrows = `<tr><th>cluster size</th><th>clusters</th><th style="text-align:left">share</th></tr>`;
-for (const h of D.cluster_size_hist) {
-  const w = Math.max(2, Math.round(100 * h.clusters / maxClusters));
-  hrows += `<tr><td class="num">${h.size}</td><td class="num">${h.clusters.toLocaleString()}</td>` +
-    `<td style="text-align:left;min-width:220px"><div style="height:10px;width:${w}%;background:var(--accent);border-radius:3px"></div></td></tr>`;
+let hrows = `<tr><th>metric</th><th>bin</th><th>pairs</th></tr>`;
+for (const [metric, bins] of Object.entries(D.histograms)) {
+  for (const bin of bins) {
+    hrows += `<tr><td>${metric}</td><td class="num">${bin.bin}</td>` +
+      `<td class="num">${bin.pairs.toLocaleString()}</td></tr>`;
+  }
 }
-document.getElementById("hist").innerHTML = hrows;
+document.getElementById("histograms").innerHTML = hrows;
 </script>

--- a/experiments/datakit/reports/templates/store.html
+++ b/experiments/datakit/reports/templates/store.html
@@ -63,7 +63,7 @@ const cards = [
   ["buckets", S.n_buckets, `${S.n_clusters} clusters × ${S.n_quality_buckets} quality`],
   ["sources", S.n_sources, M.tokenizer],
   ["contaminated", fmt(S.contaminated_dropped), `of ${fmt(S.records_in)} in`],
-  ["dedup dropped", fmt(S.dedup_noncanonical_dropped), "non-canonical members"],
+  ["dedup dropped", fmt(S.dedup_verified_dropped), "exactly verified members"],
 ];
 document.getElementById("cards").innerHTML = cards.map(([k,v,d]) =>
   `<div class="card"><div class="k">${k}</div><div class="v">${v}</div><div class="d">${d}</div></div>`).join("");

--- a/experiments/datakit/scripts/validate_ferry_outputs.py
+++ b/experiments/datakit/scripts/validate_ferry_outputs.py
@@ -10,8 +10,8 @@ Run after the iris job for the datakit smoke ferry has completed.
 Checks the persisted output invariants:
   download (14 files, ~9.7M rows)
   → normalize (106 files under outputs/main, ~9.3M rows)
-  → fuzzy_dups (106 cluster-member attr files per source)
-  → consolidate (106 files, normalize - non_canonical rows)
+  → fuzzy_dups (106 verified-marker attr files per source)
+  → consolidate (106 files, normalize - verified duplicate rows)
   → tokenize (cache ledger rows == consolidate rows)
 
 Successful ferry completion covers the minhash step, which has no additional
@@ -42,14 +42,16 @@ NORMALIZE_EXPECTED_FILES = 106
 NORMALIZE_MIN_ROWS = 8_000_000  # observed: 9,268,156
 NORMALIZE_REQUIRED_COLUMNS = {"id", "text", "url", "source_id", "token_count"}
 
-# --- Fuzzy dups: one cluster-member attr file per normalize shard per source ---
+# --- Fuzzy dups: one sparse verified-marker attr file per normalize shard per source ---
 # The smoke ferry runs fuzzy dedup over a single source (fineweb-edu sample/10BT).
 FUZZY_DUPS_EXPECTED_SOURCES = 1
 FUZZY_DUPS_EXPECTED_FILES_PER_SOURCE = 106
 FUZZY_DUPS_REQUIRED_COLUMNS = {"id", "attributes"}
-# Non-canonicals are the rows consolidate will drop. Should be a non-trivial
-# but bounded fraction. Reference (old exact-dedup pipeline): 286,263 / 9,268,156 = 3.1%.
-FUZZY_DUPS_DROP_MIN_FRACTION = 0.005  # at least 0.5% dropped
+FUZZY_DUPS_CANDIDATE_COUNTER = "dedup/fuzzy/verification/candidates"
+FUZZY_DUPS_ACCEPTED_COUNTER = "dedup/fuzzy/verification/decision/accepted"
+# Verified duplicates are the rows consolidate will drop. Exact verification is
+# intentionally conservative, so require activity without prescribing a rate.
+FUZZY_DUPS_DROP_MIN_COUNT = 1
 FUZZY_DUPS_DROP_MAX_FRACTION = 0.50  # at most 50% dropped
 
 # --- Consolidate: same file count, strictly fewer rows than normalize ---
@@ -123,27 +125,25 @@ def _validate_normalize(base: str, download_rows: int) -> int:
     return rows
 
 
-def _count_canonicals(files: list[str]) -> int:
-    """Sum is_cluster_canonical=True rows across fuzzy-dups attr files."""
+def _count_verified_duplicates(files: list[str]) -> int:
+    """Sum dup_doc=True rows across fuzzy-duplicate attribute files."""
     total = 0
     for path in files:
         with StoragePath(path).open("rb") as f:
             tbl = pq.ParquetFile(f).read(columns=["attributes"])
         if tbl.num_rows == 0:
             continue
-        canonical = tbl.column("attributes").combine_chunks().field("is_cluster_canonical")
-        total += int(pc.sum(canonical).as_py() or 0)
+        duplicate = tbl.column("attributes").combine_chunks().field("dup_doc")
+        total += int(pc.sum(duplicate).as_py() or 0)
     return total
 
 
 def _validate_fuzzy_dups(base: str, normalize_rows: int) -> int:
     """Validate the fuzzy-dups step and return the number of rows consolidate will drop.
 
-    Fuzzy dedup writes one cluster-member parquet per normalize shard, per source,
-    under ``<attr_dir>/*.parquet`` with schema ``{id, attributes: {dup_cluster_id,
-    is_cluster_canonical}}``. Singletons are omitted, and exactly one cluster
-    member is flagged ``is_cluster_canonical=True``. Consolidate's default policy
-    keeps canonicals and singletons, so non-canonicals == rows dropped.
+    Fuzzy dedup writes one sparse marker parquet per normalize shard and source.
+    ``dup_doc=True`` means the row passed direct full-text verification and is
+    the exact set consolidate removes.
     """
     dedup = read_artifact(f"{base}/fuzzy_dups", FuzzyDupsAttrData)
     if len(dedup.sources) != FUZZY_DUPS_EXPECTED_SOURCES:
@@ -155,32 +155,30 @@ def _validate_fuzzy_dups(base: str, normalize_rows: int) -> int:
 
     _check_schema(files[0], FUZZY_DUPS_REQUIRED_COLUMNS)
 
-    cluster_members = _count_parquet_rows(files)
-    canonicals = _count_canonicals(files)
-    if canonicals > cluster_members:
-        raise SystemExit(
-            f"Fuzzy dups: {canonicals} canonicals > {cluster_members} cluster members — "
-            "at most one canonical per cluster must hold"
-        )
-    dropped = cluster_members - canonicals
+    marker_rows = _count_parquet_rows(files)
+    dropped = _count_verified_duplicates(files)
+    candidates = int(dedup.counters.get(FUZZY_DUPS_CANDIDATE_COUNTER, 0))
+    accepted = int(dedup.counters.get(FUZZY_DUPS_ACCEPTED_COUNTER, 0))
+    if marker_rows != dropped:
+        raise SystemExit(f"Fuzzy dups: {marker_rows} marker rows != {dropped} dup_doc=True rows")
+    if dropped != accepted:
+        raise SystemExit(f"Fuzzy dups: {dropped} persisted verified duplicates != {accepted} accepted decisions")
+    if candidates < accepted:
+        raise SystemExit(f"Fuzzy dups: {accepted} accepted decisions > {candidates} candidates")
     fraction = dropped / normalize_rows if normalize_rows > 0 else 0
 
-    if fraction < FUZZY_DUPS_DROP_MIN_FRACTION:
-        raise SystemExit(
-            f"Fuzzy dups: only {dropped} non-canonicals ({fraction:.1%} of {normalize_rows}) — "
-            f"expected >= {FUZZY_DUPS_DROP_MIN_FRACTION:.1%}"
-        )
+    if dropped < FUZZY_DUPS_DROP_MIN_COUNT:
+        raise SystemExit(f"Fuzzy dups: no verified duplicates among {normalize_rows} normalized rows")
     if fraction > FUZZY_DUPS_DROP_MAX_FRACTION:
         raise SystemExit(
-            f"Fuzzy dups: {dropped} non-canonicals ({fraction:.1%} of {normalize_rows}) — "
+            f"Fuzzy dups: {dropped} verified duplicates ({fraction:.1%} of {normalize_rows}) — "
             f"expected <= {FUZZY_DUPS_DROP_MAX_FRACTION:.0%}, something is wrong"
         )
 
     logger.info(
-        "Fuzzy dups OK: %d files, %d cluster members, %d canonicals → %d non-canonicals (%.1f%% of %d docs)",
+        "Fuzzy dups OK: %d files, %d candidates, %d verified duplicates (%.1f%% of %d docs)",
         len(files),
-        cluster_members,
-        canonicals,
+        candidates,
         dropped,
         100 * fraction,
         normalize_rows,
@@ -201,8 +199,7 @@ def _validate_consolidate(base: str, normalize_rows: int, dropped_rows: int) -> 
             f"Consolidate: {rows} rows >= normalize {normalize_rows} rows — dedup removal did not reduce row count"
         )
 
-    # Exact expected count: consolidate drops non-canonical cluster members; all
-    # other normalize rows (canonicals + singletons) pass through.
+    # Exact expected count: consolidate drops only verified marker rows.
     expected = normalize_rows - dropped_rows
     if rows != expected:
         raise SystemExit(

--- a/experiments/datakit/store/datakit_store.py
+++ b/experiments/datakit/store/datakit_store.py
@@ -163,18 +163,18 @@ def _load_quality_table(path: str) -> tuple[pa.Array, np.ndarray]:
     return table.column("id").combine_chunks(), np.asarray(table.column("quality_bucket"), dtype=np.int32)
 
 
-def _load_dedup_canonical(path: str) -> dict[str, bool]:
-    """Return sparse canonical flags; missing IDs are singleton documents."""
+def _load_dedup_drops(path: str) -> set[str]:
+    """Return IDs that passed exact fuzzy-duplicate verification."""
     if not StoragePath(path).exists():
-        return {}
+        return set()
     with StoragePath(path).open("rb") as fh:
         parquet = pq.ParquetFile(fh)
         if parquet.metadata.num_rows == 0:
-            return {}
+            return set()
         table = parquet.read(columns=["id", "attributes"])
     ids = table.column("id").to_pylist()
-    canonical = table.column("attributes").combine_chunks().field("is_cluster_canonical").to_pylist()
-    return dict(zip(ids, canonical, strict=True))
+    duplicate = table.column("attributes").combine_chunks().field("dup_doc").to_pylist()
+    return {doc_id for doc_id, drop in zip(ids, duplicate, strict=True) if drop}
 
 
 def _validate_cluster_view(cluster_assign: dict[str, AssignmentAttrData], cluster_view: int) -> str:
@@ -243,8 +243,8 @@ def _iter_surviving_docs(spec: dict[str, str], cluster_col: str) -> Iterator[tup
     """Join one shard's five datasets; yield ``(cluster, quality_bucket, doc_id, input_ids)`` per surviving doc.
 
     Reads decon/cluster/quality densely, dedup sparsely, streams tokenize in
-    positional lockstep, and drops contaminated rows and dedup-cluster
-    non-canonicals. Fails loud on missing or misaligned inputs.
+    positional lockstep, and drops contaminated rows and exactly verified
+    fuzzy duplicates. Fails loud on missing or misaligned inputs.
     """
     decon_ids, contaminated = _load_decon_table(spec["decontam"])
     cluster_ids, cluster_vals = _load_cluster_table(spec["cluster"], cluster_col)
@@ -266,7 +266,7 @@ def _iter_surviving_docs(spec: dict[str, str], cluster_col: str) -> Iterator[tup
     if not pc.all(pc.equal(decon_ids, quality_ids)).as_py():
         raise RuntimeError(f"{where}: decon/quality id mismatch -- co-partitioning broken")
     del decon_ids, cluster_ids, quality_ids
-    dedup_canonical = _load_dedup_canonical(spec["dedup"])
+    dedup_drops = _load_dedup_drops(spec["dedup"])
 
     n_in = 0
     n_contaminated = 0
@@ -288,7 +288,7 @@ def _iter_surviving_docs(spec: dict[str, str], cluster_col: str) -> Iterator[tup
                 if contam_slice[i]:
                     n_contaminated += 1
                     continue
-                if dedup_canonical.get(doc_id) is False:
+                if doc_id in dedup_drops:
                     n_dedup_dropped += 1
                     continue
                 ids = tok_input_ids[i].values.to_numpy()
@@ -301,7 +301,7 @@ def _iter_surviving_docs(spec: dict[str, str], cluster_col: str) -> Iterator[tup
             )
     counters.pipeline.update_counter("datakit_store/records_in", n_in)
     counters.pipeline.update_counter("datakit_store/contaminated_dropped", n_contaminated)
-    counters.pipeline.update_counter("datakit_store/dedup_noncanonical_dropped", n_dedup_dropped)
+    counters.pipeline.update_counter("datakit_store/dedup_verified_dropped", n_dedup_dropped)
     counters.pipeline.update_counter("datakit_store/records_out", n_out)
 
 

--- a/experiments/datakit/testbed/variants.py
+++ b/experiments/datakit/testbed/variants.py
@@ -27,8 +27,17 @@ from marin.execution.lazy import ArtifactStep
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.consolidate import FilterConfig, FilterType, consolidate
-from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData, compute_fuzzy_dups_attrs
-from marin.processing.classification.deduplication.fuzzy_minhash import MinHashAttrData, compute_minhash_attrs
+from marin.processing.classification.deduplication.fuzzy_dups import (
+    FUZZY_DUPS_CANDIDATE_SCOPE,
+    FuzzyDupsAttrData,
+    compute_fuzzy_dups_attrs,
+)
+from marin.processing.classification.deduplication.fuzzy_minhash import (
+    MinHashAttrData,
+    NgramKind,
+    compute_minhash_attrs,
+)
+from marin.processing.classification.deduplication.fuzzy_verification import FuzzyVerificationParams
 from marin.processing.tokenize.tokenize import TokenizedCache
 from rigging.log_setup import configure_logging
 
@@ -52,35 +61,50 @@ _FUZZY_DUPS_WORKER_RESOURCES = ResourceConfig(cpu=2, ram="5g")
 _CONSOLIDATE_WORKER_RESOURCES = ResourceConfig(cpu=2, ram="5g")
 
 
-def _minhash_step(src_name: str, sampled: StepSpec, **params: int) -> StepSpec:
+def _minhash_step(
+    src_name: str,
+    sampled: StepSpec,
+    *,
+    num_perms: int,
+    num_bands: int,
+    ngram_size: int,
+    ngram_kind: NgramKind,
+    seed: int,
+) -> StepSpec:
     """MinHash bucket attrs for one sampled source."""
     return StepSpec(
         name=f"data/datakit/minhash/{src_name}",
         deps=[sampled],
         hash_attrs={
-            "num_perms": params["num_perms"],
-            "num_bands": params["num_bands"],
-            "ngram_size": params["ngram_size"],
-            "seed": params["seed"],
+            "num_perms": num_perms,
+            "num_bands": num_bands,
+            "ngram_size": ngram_size,
+            "ngram_kind": str(ngram_kind),
+            "seed": seed,
         },
         fn=lambda output_path, sampled=sampled: compute_minhash_attrs(
             source=read_artifact(sampled.output_path, NormalizedData),
             output_path=output_path,
-            num_perms=params["num_perms"],
-            num_bands=params["num_bands"],
-            ngram_size=params["ngram_size"],
-            seed=params["seed"],
+            num_perms=num_perms,
+            num_bands=num_bands,
+            ngram_size=ngram_size,
+            ngram_kind=ngram_kind,
+            seed=seed,
             worker_resources=_MINHASH_WORKER_RESOURCES,
         ),
     )
 
 
 def _fuzzy_dups_step(minhash_steps: list[StepSpec], cc_max_iterations: int) -> StepSpec:
-    """Global fuzzy-dup cluster attrs across every source's MinHash."""
+    """Verify direct MinHash candidates and emit sparse removal markers."""
     return StepSpec(
         name="data/datakit/fuzzy_dups",
         deps=list(minhash_steps),
-        hash_attrs={"cc_max_iterations": cc_max_iterations},
+        hash_attrs={
+            "candidate_scope": FUZZY_DUPS_CANDIDATE_SCOPE,
+            "verification": FuzzyVerificationParams().model_dump(),
+            "cc_max_iterations": cc_max_iterations,
+        },
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(mh.output_path, MinHashAttrData) for mh in minhash_steps],
             output_path=output_path,
@@ -92,7 +116,7 @@ def _fuzzy_dups_step(minhash_steps: list[StepSpec], cc_max_iterations: int) -> S
 
 
 def _deduped_step(src_name: str, sampled: StepSpec, fuzzy_dups: StepSpec) -> StepSpec:
-    """Per-source consolidate: keep the canonical cluster member, drop the rest.
+    """Per-source consolidate: remove exactly verified fuzzy duplicates.
 
     Writes to ``{output_path}/outputs/main/part-*.parquet`` so the downstream
     tokenize's ``outputs/main/*.parquet`` glob picks it up unchanged.
@@ -106,11 +130,11 @@ def _deduped_step(src_name: str, sampled: StepSpec, fuzzy_dups: StepSpec) -> Ste
             filetype="parquet",
             filters=[
                 FilterConfig(
-                    type=FilterType.KEEP_DOC,
+                    type=FilterType.REMOVE_DOC,
                     attribute_path=read_artifact(fuzzy_dups.output_path, FuzzyDupsAttrData)
                     .sources[read_artifact(sampled.output_path, NormalizedData).main_output_dir]
                     .attr_dir,
-                    name="is_cluster_canonical",
+                    name="dup_doc",
                     attribute_filetype="parquet",
                     keep_if_missing=True,
                 ),
@@ -129,6 +153,7 @@ def dedup(
     fuzzy_dedup_num_perms: int = 286,
     fuzzy_dedup_num_bands: int = 26,
     fuzzy_dedup_ngram_size: int = 5,
+    fuzzy_dedup_ngram_kind: NgramKind = NgramKind.WORD,
     fuzzy_dedup_seed: int = 42,
     fuzzy_dedup_cc_max_iterations: int = 10,
 ) -> StepSpec:
@@ -148,6 +173,7 @@ def dedup(
         "num_perms": fuzzy_dedup_num_perms,
         "num_bands": fuzzy_dedup_num_bands,
         "ngram_size": fuzzy_dedup_ngram_size,
+        "ngram_kind": fuzzy_dedup_ngram_kind,
         "seed": fuzzy_dedup_seed,
     }
     minhash_by_source = {

--- a/experiments/ferries/OPS.md
+++ b/experiments/ferries/OPS.md
@@ -48,4 +48,9 @@ SMOKE_RUN_ID=$SMOKE_RUN_ID \
   uv run python experiments/datakit/scripts/validate_ferry_outputs.py
 ```
 
-Confirms row counts and dedup fraction across stages.
+Confirms row counts across stages and checks that fuzzy dedup's sparse
+`dup_doc=True` markers exactly match its accepted-verification counter and the
+rows removed by consolidation. Candidate counts, rejection reasons, exact-score
+histograms, per-source acceptance rates, and the LSH collision curve are in the
+dedup stage report; the full accepted/rejected evidence is under
+`$MARIN_PREFIX/datakit-smoke/$SMOKE_RUN_ID/fuzzy_dups/metadata/decisions/`.

--- a/experiments/ferries/datakit_ferry.py
+++ b/experiments/ferries/datakit_ferry.py
@@ -23,6 +23,7 @@ from marin.processing.classification.consolidate import (
     consolidate,
 )
 from marin.processing.classification.deduplication.fuzzy_dups import (
+    FUZZY_DUPS_CANDIDATE_SCOPE,
     FuzzyDupsAttrData,
     compute_fuzzy_dups_attrs,
 )
@@ -30,6 +31,7 @@ from marin.processing.classification.deduplication.fuzzy_minhash import (
     MinHashAttrData,
     compute_minhash_attrs,
 )
+from marin.processing.classification.deduplication.fuzzy_verification import FuzzyVerificationParams
 from marin.processing.tokenize.tokenize import TokenizeConfig, tokenize
 from rigging.filesystem import StoragePath, marin_temp_bucket
 from rigging.log_setup import configure_logging
@@ -75,15 +77,22 @@ def build_steps(run_id: str) -> list[StepSpec]:
         override_output_path=f"{base}/minhash",
     )
 
-    # Fuzzy dups: connected components over the MinHash bucket graph.
+    # Fuzzy dups: connected components retrieve direct candidates; exact
+    # full-text verification decides which rows consolidation removes.
     # max_parallelism=128 mirrors the old dedup tuning for 10BT (~106 shards).
+    verification = FuzzyVerificationParams()
     deduped = StepSpec(
         name="datakit-smoke/fuzzy_dups",
         deps=[minhash],
-        hash_attrs={"cc_max_iterations": 3},
+        hash_attrs={
+            "candidate_scope": FUZZY_DUPS_CANDIDATE_SCOPE,
+            "verification": verification.model_dump(),
+            "cc_max_iterations": 3,
+        },
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(minhash.output_path, MinHashAttrData)],
             output_path=output_path,
+            verification_params=verification,
             max_parallelism=128,
             cc_max_iterations=3,
             worker_resources=ResourceConfig(cpu=1, ram="16g", disk="30g"),
@@ -99,15 +108,13 @@ def build_steps(run_id: str) -> list[StepSpec]:
             output_path=output_path,
             filetype="parquet",
             filters=[
-                # Default fuzzy-dedup policy: keep the CC-picked canonical of each
-                # cluster, drop the rest. Singletons have no attr row, so
-                # keep_if_missing=True passes them through.
+                # Fuzzy dedup marks only candidates that pass exact verification.
                 FilterConfig(
-                    type=FilterType.KEEP_DOC,
+                    type=FilterType.REMOVE_DOC,
                     attribute_path=read_artifact(deduped.output_path, FuzzyDupsAttrData)
                     .sources[read_artifact(normalized.output_path, NormalizedData).main_output_dir]
                     .attr_dir,
-                    name="is_cluster_canonical",
+                    name="dup_doc",
                     attribute_filetype="parquet",
                     keep_if_missing=True,
                 ),

--- a/experiments/ferries/datakit_nemotron_ferry.py
+++ b/experiments/ferries/datakit_nemotron_ferry.py
@@ -27,6 +27,7 @@ from marin.processing.classification.consolidate import (
     consolidate,
 )
 from marin.processing.classification.deduplication.fuzzy_dups import (
+    FUZZY_DUPS_CANDIDATE_SCOPE,
     FuzzyDupsAttrData,
     compute_fuzzy_dups_attrs,
 )
@@ -34,6 +35,7 @@ from marin.processing.classification.deduplication.fuzzy_minhash import (
     MinHashAttrData,
     compute_minhash_attrs,
 )
+from marin.processing.classification.deduplication.fuzzy_verification import FuzzyVerificationParams
 from marin.processing.tokenize.tokenize import TokenizeConfig, tokenize
 from rigging.filesystem import (
     StoragePath,
@@ -115,13 +117,19 @@ def build_steps(run_id: str) -> list[StepSpec]:
         override_output_path=f"{base}/minhash",
     )  # ~1,380 output shards
 
+    verification = FuzzyVerificationParams()
     deduped = StepSpec(
         name="datakit-nemotron-smoke/fuzzy_dups",
         deps=[minhash],
-        hash_attrs={"cc_max_iterations": 3},
+        hash_attrs={
+            "candidate_scope": FUZZY_DUPS_CANDIDATE_SCOPE,
+            "verification": verification.model_dump(),
+            "cc_max_iterations": 3,
+        },
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(minhash.output_path, MinHashAttrData)],
             output_path=output_path,
+            verification_params=verification,
             cc_max_iterations=3,
             worker_resources=(resources := ResourceConfig(cpu=16, ram="160g", disk="32g")),
             map_task_resources=resources.scale(1 / 16),
@@ -139,11 +147,11 @@ def build_steps(run_id: str) -> list[StepSpec]:
             filetype="parquet",
             filters=[
                 FilterConfig(
-                    type=FilterType.KEEP_DOC,
+                    type=FilterType.REMOVE_DOC,
                     attribute_path=read_artifact(deduped.output_path, FuzzyDupsAttrData)
                     .sources[read_artifact(normalized.output_path, NormalizedData).main_output_dir]
                     .attr_dir,
-                    name="is_cluster_canonical",
+                    name="dup_doc",
                     attribute_filetype="parquet",
                     keep_if_missing=True,
                 ),

--- a/experiments/ferries/datakit_tier2_skewed_ferry.py
+++ b/experiments/ferries/datakit_tier2_skewed_ferry.py
@@ -33,6 +33,7 @@ from marin.processing.classification.consolidate import (
     consolidate,
 )
 from marin.processing.classification.deduplication.fuzzy_dups import (
+    FUZZY_DUPS_CANDIDATE_SCOPE,
     FuzzyDupsAttrData,
     compute_fuzzy_dups_attrs,
 )
@@ -40,6 +41,7 @@ from marin.processing.classification.deduplication.fuzzy_minhash import (
     MinHashAttrData,
     compute_minhash_attrs,
 )
+from marin.processing.classification.deduplication.fuzzy_verification import FuzzyVerificationParams
 from marin.processing.tokenize.tokenize import TokenizeConfig, tokenize
 from rigging.filesystem import StoragePath, marin_prefix, marin_temp_bucket
 from rigging.log_setup import configure_logging
@@ -86,13 +88,19 @@ def build_steps(run_id: str) -> list[StepSpec]:
     )
 
     # ~98 source shards / ~46 GiB; modest fan-out for fuzzy_dups CC.
+    verification = FuzzyVerificationParams()
     deduped = StepSpec(
         name="datakit-tier2-skewed-smoke/fuzzy_dups",
         deps=[minhash],
-        hash_attrs={"cc_max_iterations": 3},
+        hash_attrs={
+            "candidate_scope": FUZZY_DUPS_CANDIDATE_SCOPE,
+            "verification": verification.model_dump(),
+            "cc_max_iterations": 3,
+        },
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(minhash.output_path, MinHashAttrData)],
             output_path=output_path,
+            verification_params=verification,
             max_parallelism=64,
             cc_max_iterations=3,
         ),
@@ -108,11 +116,11 @@ def build_steps(run_id: str) -> list[StepSpec]:
             filetype="parquet",
             filters=[
                 FilterConfig(
-                    type=FilterType.KEEP_DOC,
+                    type=FilterType.REMOVE_DOC,
                     attribute_path=read_artifact(deduped.output_path, FuzzyDupsAttrData)
                     .sources[read_artifact(normalized.output_path, NormalizedData).main_output_dir]
                     .attr_dir,
-                    name="is_cluster_canonical",
+                    name="dup_doc",
                     attribute_filetype="parquet",
                     keep_if_missing=True,
                 ),

--- a/infra/ci/select_tests.py
+++ b/infra/ci/select_tests.py
@@ -105,9 +105,9 @@ MIN_FILES_PER_SHARD = 15
 
 # Native (maturin) packages, keyed by their owning scope. A change under a crate's
 # rust/ tree is invisible to the Python import graph, so classify force-selects the
-# owning scope and builds it from source. Its own tests cover the extension;
-# downstream consumers are selected only by their Python-level changes and run
-# against the prebuilt wheel.
+# owning scope and builds it from source. When the same diff changes that package's
+# Python surface, selected consumers also need the source build because the published
+# wheel may implement the previous ABI.
 NATIVE_CRATE_DIR: dict[str, str] = {
     "dupekit": "lib/dupekit/rust",
     "finelog": "lib/finelog/rust",
@@ -433,6 +433,18 @@ def extra_suites(changed_files: list[str]) -> list[str]:
     )
 
 
+def required_source_build_scopes(classification: ClassifyResult) -> set[str]:
+    """Scopes whose selected test legs must use native packages from this checkout."""
+    coordinated_native_changes = {
+        scope
+        for scope in classification.native_changed
+        if any(module == scope or module.startswith(f"{scope}.") for module in classification.src_modules)
+    }
+    if coordinated_native_changes:
+        return set(SCOPES)
+    return set(classification.native_changed)
+
+
 # ---------------------------------------------------------------------------
 # Test selection
 # ---------------------------------------------------------------------------
@@ -597,11 +609,10 @@ def main() -> None:
     classification = classify(changed, repo_root)
     suites = extra_suites(changed)
 
-    # The scopes whose native extension's Rust changed build it from source; every other
-    # leg installs the prebuilt wheel. This is independent of full vs. diff-driven runs: a
-    # broad trigger (e.g. a uv.lock bump) runs the whole matrix but keeps every leg on the
-    # fast prebuilt-wheel path.
-    source_build_scopes = set(classification.native_changed)
+    # Rust-only changes source-build the owning scope. A coordinated native/Python API
+    # change source-builds every selected consumer because the published wheel may expose
+    # the previous ABI. This is independent of full vs. diff-driven selection.
+    source_build_scopes = required_source_build_scopes(classification)
 
     if args.run_all_tests:
         reason, matrix = "run-all-tests", full_matrix(repo_root, source_build_scopes)

--- a/lib/dupekit/rust/src/lib.rs
+++ b/lib/dupekit/rust/src/lib.rs
@@ -17,6 +17,7 @@ fn dupekit_native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("DEFAULT_HASH_ALGORITHM", hashing::DEFAULT_HASH_ALGO)?;
 
     // Composable Pipeline
+    m.add_class::<minhash_ops::NgramKind>()?;
     m.add_class::<pipeline::Transformation>()?;
     m.add_function(wrap_pyfunction!(pipeline::transform, m)?)?;
 

--- a/lib/dupekit/rust/src/minhash_ops.rs
+++ b/lib/dupekit/rust/src/minhash_ops.rs
@@ -7,6 +7,14 @@ use regex::Regex;
 use std::sync::Arc;
 use xxhash_rust::xxh3;
 
+/// Unit used to form MinHash shingles.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[pyclass(eq, eq_int, module = "dupekit")]
+pub enum NgramKind {
+    Char,
+    Word,
+}
+
 /// Clean text using the SlimPajama text cleaning process.
 /// 1. Lowercase
 /// 2. Remove punctuation
@@ -41,6 +49,7 @@ pub fn compute_minhash(
     arr: &StringArray,
     num_perms: usize,
     ngram_size: usize,
+    ngram_kind: NgramKind,
     seed: u64,
 ) -> PyResult<Arc<dyn Array>> {
     // Generate permutations using Duplodocus strategy (Single u128 coefficient)
@@ -66,17 +75,61 @@ pub fn compute_minhash(
         }
 
         let text = arr.value(i);
-        let chars: Vec<char> = text.chars().collect();
         let mut signature = vec![u64::MAX; num_perms];
 
-        if chars.len() < ngram_size {
-            let hash = xxh3::xxh3_64(text.as_bytes()) as u128;
-            update_signature(&mut signature, hash, &coeffs);
-        } else {
-            for window in chars.windows(ngram_size) {
-                let s: String = window.iter().collect();
-                let hash = xxh3::xxh3_64(s.as_bytes()) as u128;
-                update_signature(&mut signature, hash, &coeffs);
+        match ngram_kind {
+            NgramKind::Char => {
+                let chars: Vec<char> = text.chars().collect();
+                if chars.len() < ngram_size {
+                    update_signature(
+                        &mut signature,
+                        xxh3::xxh3_64(text.as_bytes()) as u128,
+                        &coeffs,
+                    );
+                } else {
+                    for window in chars.windows(ngram_size) {
+                        let shingle: String = window.iter().collect();
+                        update_signature(
+                            &mut signature,
+                            xxh3::xxh3_64(shingle.as_bytes()) as u128,
+                            &coeffs,
+                        );
+                    }
+                }
+            }
+            NgramKind::Word => {
+                let mut word_bounds = Vec::new();
+                let mut word_start = None;
+                for (offset, character) in text.char_indices() {
+                    if character.is_whitespace() {
+                        if let Some(start) = word_start.take() {
+                            word_bounds.push((start, offset));
+                        }
+                    } else if word_start.is_none() {
+                        word_start = Some(offset);
+                    }
+                }
+                if let Some(start) = word_start {
+                    word_bounds.push((start, text.len()));
+                }
+
+                if word_bounds.len() < ngram_size {
+                    update_signature(
+                        &mut signature,
+                        xxh3::xxh3_64(text.as_bytes()) as u128,
+                        &coeffs,
+                    );
+                } else {
+                    for window in word_bounds.windows(ngram_size) {
+                        let start = window[0].0;
+                        let end = window[ngram_size - 1].1;
+                        update_signature(
+                            &mut signature,
+                            xxh3::xxh3_64(&text.as_bytes()[start..end]) as u128,
+                            &coeffs,
+                        );
+                    }
+                }
             }
         }
         list_builder.values().append_slice(&signature);

--- a/lib/dupekit/rust/src/pipeline.rs
+++ b/lib/dupekit/rust/src/pipeline.rs
@@ -34,6 +34,7 @@ pub enum Transformation {
         output_col: String,
         num_perms: usize,
         ngram_size: usize,
+        ngram_kind: minhash_ops::NgramKind,
         seed: u64,
     },
     MinHashLSH {
@@ -83,6 +84,7 @@ impl Transformation {
         output_col: String,
         num_perms: usize,
         ngram_size: usize,
+        ngram_kind: minhash_ops::NgramKind,
         seed: u64,
     ) -> Transformation {
         Self::MinHash {
@@ -90,6 +92,7 @@ impl Transformation {
             output_col,
             num_perms,
             ngram_size,
+            ngram_kind,
             seed,
         }
     }
@@ -146,11 +149,17 @@ fn apply_transformation(batch: RecordBatch, step: &Transformation) -> PyResult<R
             output_col,
             num_perms,
             ngram_size,
+            ngram_kind,
             seed,
         } => {
             let input_arr = ops::get_string_array(&batch, input_col)?;
-            let signature_arr =
-                minhash_ops::compute_minhash(&input_arr, *num_perms, *ngram_size, *seed)?;
+            let signature_arr = minhash_ops::compute_minhash(
+                &input_arr,
+                *num_perms,
+                *ngram_size,
+                *ngram_kind,
+                *seed,
+            )?;
             ops::add_column(&batch, output_col, signature_arr)
         }
 

--- a/lib/dupekit/src/dupekit/__init__.py
+++ b/lib/dupekit/src/dupekit/__init__.py
@@ -22,6 +22,7 @@ try:
         Bloom,
         Document,
         HashAlgorithm,
+        NgramKind,
         Transformation,
     )
 except ImportError:

--- a/lib/dupekit/src/dupekit/__init__.pyi
+++ b/lib/dupekit/src/dupekit/__init__.pyi
@@ -106,6 +106,12 @@ class HashAlgorithm(Enum):
 
 DEFAULT_HASH_ALGORITHM: HashAlgorithm
 
+class NgramKind(Enum):
+    """Unit used to form MinHash shingles."""
+
+    Char = ...
+    Word = ...
+
 @final
 class Transformation:
     """Transformation steps for the deduplication pipeline.
@@ -138,14 +144,22 @@ class Transformation:
         ...
 
     @staticmethod
-    def MinHash(input_col: str, output_col: str, num_perms: int, ngram_size: int, seed: int) -> "Transformation":
+    def MinHash(
+        input_col: str,
+        output_col: str,
+        num_perms: int,
+        ngram_size: int,
+        ngram_kind: NgramKind,
+        seed: int,
+    ) -> "Transformation":
         """Computes MinHash signatures for the input text using fused shingling/hashing.
 
         Args:
             input_col: Column containing text.
             output_col: Column to store signature (List[uint64]).
             num_perms: Number of permutation functions (length of signature).
-            ngram_size: Size of char-ngrams for shingling.
+            ngram_size: Size of each n-gram window.
+            ngram_kind: Whether windows contain characters or words.
             seed: Random seed for permutation coefficients.
         """
         ...

--- a/lib/dupekit/tests/bench/test_minhash.py
+++ b/lib/dupekit/tests/bench/test_minhash.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import dupekit
 import pyarrow as pa
-from dupekit import Transformation
+from dupekit import NgramKind, Transformation
 
 # Python is slow, can't use too many rows
 BENCHMARK_ROWS = 1000
@@ -14,7 +14,14 @@ BENCHMARK_ROWS = 1000
 def rust_minhash_pipeline(batch: pa.RecordBatch) -> int:
     pipeline = [
         Transformation.CleanText(input_col="text", output_col="clean"),
-        Transformation.MinHash(input_col="clean", output_col="sig", num_perms=286, ngram_size=5, seed=42),
+        Transformation.MinHash(
+            input_col="clean",
+            output_col="sig",
+            num_perms=286,
+            ngram_size=5,
+            ngram_kind=NgramKind.Word,
+            seed=42,
+        ),
         Transformation.MinHashLSH(input_col="sig", output_col="buckets", num_bands=26),
     ]
     res = dupekit.transform(batch, pipeline)

--- a/lib/dupekit/tests/test_minhash.py
+++ b/lib/dupekit/tests/test_minhash.py
@@ -1,8 +1,32 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import random
+
 import pyarrow as pa
-from dupekit import Transformation, transform
+from dupekit import NgramKind, Transformation, transform
+
+
+def _signatures(texts: list[str], ngram_kind: NgramKind) -> list[list[int]]:
+    batch = pa.RecordBatch.from_pydict({"text": texts})
+    return transform(
+        batch,
+        [
+            Transformation.CleanText(input_col="text", output_col="clean"),
+            Transformation.MinHash(
+                input_col="clean",
+                output_col="signature",
+                num_perms=286,
+                ngram_size=5,
+                ngram_kind=ngram_kind,
+                seed=42,
+            ),
+        ],
+    )["signature"].to_pylist()
+
+
+def _estimated_jaccard(left: list[int], right: list[int]) -> float:
+    return sum(a == b for a, b in zip(left, right, strict=True)) / len(left)
 
 
 def test_clean_text():
@@ -22,7 +46,16 @@ def test_minhash_dimensions():
     texts = ["doc one", "doc two"]
     num_perms = 128
     batch = pa.RecordBatch.from_pydict({"text": texts})
-    pipeline = [Transformation.MinHash(input_col="text", output_col="sig", num_perms=num_perms, ngram_size=3, seed=42)]
+    pipeline = [
+        Transformation.MinHash(
+            input_col="text",
+            output_col="sig",
+            num_perms=num_perms,
+            ngram_size=3,
+            ngram_kind=NgramKind.Char,
+            seed=42,
+        )
+    ]
     sigs = transform(batch, pipeline)["sig"]
     for sig in sigs:
         assert len(sig.as_py()) == num_perms
@@ -48,10 +81,37 @@ def test_full_pipeline_determinism():
     batch = pa.RecordBatch.from_pydict({"text": [text, text]})
     pipeline = [
         Transformation.CleanText(input_col="text", output_col="clean"),
-        Transformation.MinHash(input_col="clean", output_col="sig", num_perms=20, ngram_size=5, seed=1),
+        Transformation.MinHash(
+            input_col="clean",
+            output_col="sig",
+            num_perms=20,
+            ngram_size=5,
+            ngram_kind=NgramKind.Char,
+            seed=1,
+        ),
         Transformation.MinHashLSH(input_col="sig", output_col="buckets", num_bands=4),
     ]
     res = transform(batch, pipeline)
     b0 = res["buckets"][0].as_py()
     b1 = res["buckets"][1].as_py()
     assert b0 == b1
+
+
+def test_word_ngrams_distinguish_long_documents_with_shared_vocabulary():
+    """Word shingles distinguish sequences that saturate character shingles."""
+    vocabulary = (
+        "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima mike november oscar papa quebec "
+        "romeo sierra tango uniform victor whiskey xray yankee zulu amber birch cedar dune ember frost grove harbor "
+        "ivory jasmine knoll lagoon meadow nectar olive prairie quartz ridge solar timber umber valley willow xenon "
+        "yarrow zenith"
+    ).split()
+    texts = []
+    for seed in (1, 2):
+        rng = random.Random(seed)
+        texts.append(" ".join(rng.choice(vocabulary) for _ in range(4_000)))
+
+    char_left, char_right = _signatures(texts, NgramKind.Char)
+    word_left, word_right = _signatures(texts, NgramKind.Word)
+
+    assert _estimated_jaccard(char_left, char_right) > 0.75
+    assert _estimated_jaccard(word_left, word_right) < 0.05

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
@@ -1,41 +1,22 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Compute fuzzy duplicate markers from one or more ``MinHashAttrData`` inputs.
+"""Compute verified fuzzy-duplicate markers from MinHash candidates.
 
-Loads MinHash bucket attrs from each input, runs LSH-graph connected
-components globally across all inputs, and writes per-source attribute trees
-annotating every non-singleton cluster member. Each source's attr tree is
-co-partitioned with its underlying ``NormalizedData``, so
-:mod:`marin.processing.classification.consolidate` can join them directly.
-
-Per-document attr rows have schema::
-
-    {
-      id: str,
-      attributes: {
-        dup_cluster_id: str,         # CC component id — shared by all cluster members
-        is_cluster_canonical: bool,  # True for exactly one member per cluster
-      }
-    }
-
-Rows are emitted for every member of a non-singleton cluster (canonical +
-non-canonicals). Singletons get no row, preserving the
-``consolidate(..., keep_if_missing=True)`` pattern. This shape lets the
-canonical-selection policy live in consolidate (e.g. the default
-``keep is_cluster_canonical=True``, or any custom per-cluster reducer) rather
-than being baked in here.
-
-Combining multiple ``MinHashAttrData`` inputs is the foundation for iterative
-global dedup: re-running this job over the union of all per-dataset MinHash
-artifacts produces fresh markers without re-reading any source text.
+MinHash LSH only retrieves candidates. A document is marked ``dup_doc=True``
+after an exact, full-text comparison to the connected component's canonical,
+and only when it shared an LSH bucket directly with that retained canonical.
+Rejected candidates and their exact scores are persisted for audit.
 """
 
 import logging
 import os
+from collections import Counter, defaultdict
 from collections.abc import Iterator
 from typing import Any
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 from fray.types import ResourceConfig
 from pydantic import BaseModel
 from rigging.filesystem import StoragePath
@@ -50,8 +31,18 @@ from marin.execution.step_spec import StepSpec
 from marin.processing.classification.deduplication.connected_components import connected_components
 from marin.processing.classification.deduplication.dedup_commons import _load_batches
 from marin.processing.classification.deduplication.fuzzy_minhash import MinHashAttrData, MinHashParams
+from marin.processing.classification.deduplication.fuzzy_verification import (
+    FuzzyVerificationParams,
+    VerificationResult,
+    verify_candidate,
+)
 
 logger = logging.getLogger(__name__)
+
+FUZZY_DUPS_CANDIDATE_SCOPE = "direct_canonical_exact_v1"
+_VERIFICATION_COUNTER = "dedup/fuzzy/verification"
+_SCORE_HISTOGRAM_MAX_PERCENT = 100
+_UNIQUE_NGRAM_HISTOGRAM_OVERFLOW_BIN = 33
 
 
 class FuzzyDupsPerSource(BaseModel):
@@ -67,7 +58,7 @@ class FuzzyDupsPerSource(BaseModel):
 
 
 class FuzzyDupsAttrData(BaseModel):
-    """Co-partitioned fuzzy-duplicate marker attrs for one or more sources.
+    """Co-partitioned verified-duplicate markers for one or more sources.
 
     Persisted as the step's ``.artifact``. Load via
     ``Artifact.from_path(step, FuzzyDupsAttrData)``.
@@ -75,13 +66,17 @@ class FuzzyDupsAttrData(BaseModel):
     Attributes:
         version: Schema version of this artifact.
         params: MinHash params; equal to every input's params.
+        verification: Exact verification thresholds.
+        decisions_dir: Parquet evidence for accepted and rejected candidates.
         sources: Mapping from each input's ``MinHashAttrData.source_main_dir``
             to its per-source attr output entry.
         counters: Aggregated zephyr counters across all sources.
     """
 
-    version: str = "v1"
+    version: str = "v2"
     params: MinHashParams
+    verification: FuzzyVerificationParams
+    decisions_dir: str
     sources: dict[str, FuzzyDupsPerSource]
     counters: dict[str, int | float]
 
@@ -134,13 +129,15 @@ def _build_shard_index(inputs: list[MinHashAttrData]) -> tuple[list[dict[str, An
         if not attr_shards:
             raise FileNotFoundError(f"No attr parquet shards under {m.attr_dir}")
         for attr_path in attr_shards:
+            basename = os.path.basename(attr_path)
             entries.append(
                 {
                     "file_idx": len(entries),
                     "attr_path": attr_path,
+                    "source_path": f"{m.source_main_dir.rstrip('/')}/{basename}",
                     "source_main_dir": m.source_main_dir,
                     "source_tag": source_tag[m.source_main_dir],
-                    "basename": os.path.basename(attr_path),
+                    "basename": basename,
                 }
             )
     return entries, source_tag
@@ -193,61 +190,270 @@ def _emit_bucket_records(entries: list[dict[str, Any]]) -> Iterator[dict]:
 _SHARED_ENTRIES_KEY = "fuzzy_dups_entries"
 
 
-def _make_per_shard_writer(output_path: str, counter_prefix: str):
-    """Return a group_by reducer that writes per-shard cluster-annotation parquet files.
+def _candidate_node(record: dict[str, Any]) -> dict[str, Any]:
+    """Reduce one CC node to the fields required for direct-canonical matching."""
+    id_norm = record["id_norm"]
+    component_id = record["component_id"]
+    adjacency = record["adjacency_list"]
+    is_canonical = component_id == id_norm
+    is_singleton = len(adjacency) == 1 and adjacency[0] == id_norm
+    is_direct_candidate = is_canonical or component_id in adjacency
+    if is_singleton:
+        counters.pipeline.update_counter("dedup/fuzzy/document/singletons_skipped", 1)
+    elif not is_direct_candidate:
+        counters.pipeline.update_counter("dedup/fuzzy/document/transitive_members_kept", 1)
+    return {
+        "doc_id": _strip_cc_prefix(record["record_id"]),
+        "id_norm": id_norm,
+        "component_id": component_id,
+        "file_idx": record["file_idx"],
+        "is_canonical": is_canonical,
+        "canonical_order": 0 if is_canonical else 1,
+        "emit": not is_singleton and is_direct_candidate,
+    }
 
-    Skips singletons entirely. For every non-singleton cluster member, writes
-    ``{id, attributes: {dup_cluster_id, is_cluster_canonical}}``. Rows are
-    already sorted by ``id`` thanks to the upstream ``group_by(sort_by=id)``.
 
-    The ``entries`` list is loaded via ``zephyr_worker_ctx().get_shared`` so it
-    is shipped to workers once (via Zephyr shared-data) rather than captured
-    in this closure and re-pickled per ``pull_task`` RPC.
-    """
-
-    def aggregate(file_idx: int, records: Iterator[dict]) -> dict:
-        entries = zephyr_worker_ctx().get_shared(_SHARED_ENTRIES_KEY)
-        entry = entries[file_idx]
-        out_path = f"{output_path}/outputs/{entry['source_tag']}/{entry['basename']}"
-
-        cluster_members = 0
-        canonicals = 0
-
-        def cluster_member_rows():
-            nonlocal cluster_members, canonicals
-            for record in records:
-                if record["is_singleton"]:
-                    counters.pipeline.update_counter(f"{counter_prefix}/singletons_skipped", 1)
-                    continue
-                cluster_members += 1
-                counters.pipeline.update_counter(f"{counter_prefix}/cluster_members", 1)
-                if record["is_canonical"]:
-                    canonicals += 1
-                    counters.pipeline.update_counter(f"{counter_prefix}/canonicals", 1)
-                yield {
-                    "id": record["id"],
-                    "attributes": {
-                        "dup_cluster_id": record["component_id"],
-                        "is_cluster_canonical": record["is_canonical"],
-                    },
-                }
-
-        result = write_parquet_file(cluster_member_rows(), out_path)
-        return {
-            **result,
-            "file_idx": file_idx,
-            "source_tag": entry["source_tag"],
-            "cluster_members": cluster_members,
-            "canonicals": canonicals,
+def _candidate_pairs(component_id: str, records: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+    """Pair every direct member with the component canonical."""
+    canonical = next(records)
+    if not canonical["is_canonical"] or canonical["id_norm"] != component_id:
+        raise AssertionError(f"Component {component_id} did not start with its canonical")
+    for member in records:
+        if member["is_canonical"]:
+            raise AssertionError(f"Component {component_id} has multiple canonicals")
+        yield {
+            "pair_id": member["id_norm"],
+            "component_id": component_id,
+            "member_id": member["doc_id"],
+            "member_file_idx": member["file_idx"],
+            "canonical_id": canonical["doc_id"],
+            "canonical_file_idx": canonical["file_idx"],
         }
 
+
+def _candidate_text_requests(pair: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    for role, role_order in (("canonical", 0), ("member", 1)):
+        yield {
+            **pair,
+            "role": role,
+            "role_order": role_order,
+            "file_idx": pair[f"{role}_file_idx"],
+            "document_id": pair[f"{role}_id"],
+        }
+
+
+def _rows(path: str, columns: list[str]) -> Iterator[dict[str, Any]]:
+    for batch in _load_batches(path, columns=columns):
+        yield from batch.to_pylist()
+
+
+def _requested_texts(file_idx: int, requests: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+    """Resolve requests against the MinHash shard's order-preserving source subsequence."""
+    entry = zephyr_worker_ctx().get_shared(_SHARED_ENTRIES_KEY)[file_idx]
+    requests_by_id: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for request in requests:
+        requests_by_id[request["document_id"]].append(request)
+
+    minhash_rows = iter(_rows(entry["attr_path"], ["id", "buckets"]))
+    minhash_row = next(minhash_rows, None)
+    for source_row in _rows(entry["source_path"], ["id", "text"]):
+        if minhash_row is None or source_row["id"] != minhash_row["id"]:
+            if source_row["id"] in requests_by_id:
+                raise AssertionError(f"Missing MinHash buckets for {source_row['id']} in {entry['attr_path']}")
+            continue
+
+        matching_requests = requests_by_id.pop(source_row["id"], ())
+        for request in matching_requests:
+            counters.pipeline.update_counter(f"{_VERIFICATION_COUNTER}/text_reads", 1)
+            counters.pipeline.update_counter(f"{_VERIFICATION_COUNTER}/text_chars", len(source_row["text"]))
+            yield {
+                **request,
+                "text": source_row["text"],
+                "buckets": minhash_row["buckets"],
+            }
+        minhash_row = next(minhash_rows, None)
+
+    if minhash_row is not None:
+        raise AssertionError(f"MinHash row {minhash_row['id']} is absent from {entry['source_path']}")
+
+    if requests_by_id:
+        missing_id = min(requests_by_id)
+        raise AssertionError(f"Missing source text and MinHash buckets for {missing_id} in {entry['source_path']}")
+
+
+def _result_fields(result: VerificationResult) -> dict[str, Any]:
+    return {
+        "accepted": result.accepted,
+        "rejection": result.rejection.value if result.rejection is not None else None,
+        "member_chars": result.member_chars,
+        "canonical_chars": result.canonical_chars,
+        "member_tokens": result.member_tokens,
+        "canonical_tokens": result.canonical_tokens,
+        "member_ngrams": result.member_ngrams,
+        "canonical_ngrams": result.canonical_ngrams,
+        "shared_ngrams": result.shared_ngrams,
+        "member_unique_ngrams": result.member_unique_ngrams,
+        "member_containment": result.member_containment,
+        "jaccard": result.jaccard,
+        "under_tokenized": result.under_tokenized,
+        "char_jaccard": result.char_jaccard,
+    }
+
+
+def _score_bin(score: float) -> str:
+    return f"{min(int(score * 100), _SCORE_HISTOGRAM_MAX_PERCENT):03d}"
+
+
+def _make_candidate_verifier(params: FuzzyVerificationParams):
+    def verify(pair_id: str, pieces: Iterator[dict[str, Any]]) -> dict[str, Any]:
+        canonical = next(pieces)
+        member = next(pieces)
+        if canonical["role"] != "canonical" or member["role"] != "member":
+            raise AssertionError(f"Candidate {pair_id} text pieces are out of order")
+        if next(pieces, None) is not None:
+            raise AssertionError(f"Candidate {pair_id} has more than two text pieces")
+
+        result = verify_candidate(member["text"], canonical["text"], params)
+        shared_buckets = len(set(member["buckets"]) & set(canonical["buckets"]))
+        if not shared_buckets:
+            raise AssertionError(f"Direct candidate {pair_id} has no shared LSH bucket")
+
+        entries = zephyr_worker_ctx().get_shared(_SHARED_ENTRIES_KEY)
+        member_entry = entries[member["member_file_idx"]]
+        canonical_entry = entries[canonical["canonical_file_idx"]]
+        rejection = result.rejection.value if result.rejection is not None else "accepted"
+        counters.pipeline.update_counter(f"{_VERIFICATION_COUNTER}/candidates", 1)
+        counters.pipeline.update_counter(f"{_VERIFICATION_COUNTER}/decision/{rejection}", 1)
+        counters.pipeline.update_counter(
+            f"{_VERIFICATION_COUNTER}/source/{member_entry['source_tag']}/decision/{rejection}",
+            1,
+        )
+        counters.pipeline.update_counter(
+            f"{_VERIFICATION_COUNTER}/histogram/member_containment/{_score_bin(result.member_containment)}",
+            1,
+        )
+        counters.pipeline.update_counter(
+            f"{_VERIFICATION_COUNTER}/histogram/jaccard/{_score_bin(result.jaccard)}",
+            1,
+        )
+        counters.pipeline.update_counter(
+            f"{_VERIFICATION_COUNTER}/histogram/member_unique/"
+            f"{min(result.member_unique_ngrams, _UNIQUE_NGRAM_HISTOGRAM_OVERFLOW_BIN)}",
+            1,
+        )
+        counters.pipeline.update_counter(
+            f"{_VERIFICATION_COUNTER}/histogram/shared_buckets/{shared_buckets}",
+            1,
+        )
+        return {
+            "pair_id": pair_id,
+            "component_id": member["component_id"],
+            "member_id": member["member_id"],
+            "member_file_idx": member["member_file_idx"],
+            "member_source_main_dir": member_entry["source_main_dir"],
+            "canonical_id": canonical["canonical_id"],
+            "canonical_file_idx": canonical["canonical_file_idx"],
+            "canonical_source_main_dir": canonical_entry["source_main_dir"],
+            "shared_buckets": shared_buckets,
+            "verification_rule": params.rule_version,
+            **_result_fields(result),
+        }
+
+    return verify
+
+
+def _marker_records(decision: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    yield {
+        "marker_id": decision["member_id"],
+        "marker_file_idx": decision["member_file_idx"],
+        "attributes": {
+            "dup_doc": True,
+            "dup_cluster_id": decision["component_id"],
+            "dup_representative_id": decision["canonical_id"],
+            "dup_verifier_version": decision["verification_rule"],
+            "dup_shared_buckets": decision["shared_buckets"],
+            "dup_member_containment": decision["member_containment"],
+            "dup_jaccard": decision["jaccard"],
+            "dup_member_unique_ngrams": decision["member_unique_ngrams"],
+            "dup_under_tokenized": decision["under_tokenized"],
+            "dup_char_jaccard": decision["char_jaccard"],
+        },
+    }
+
+
+def _make_marker_writer(output_path: str):
+    def aggregate(file_idx: int, markers: Iterator[dict[str, Any]]) -> dict[str, Any]:
+        entry = zephyr_worker_ctx().get_shared(_SHARED_ENTRIES_KEY)[file_idx]
+        out_path = f"{output_path}/outputs/{entry['source_tag']}/{entry['basename']}"
+        count = 0
+
+        def marker_rows() -> Iterator[dict[str, Any]]:
+            nonlocal count
+            previous_id = None
+            previous_attributes = None
+            for marker in markers:
+                if marker["marker_id"] == previous_id:
+                    if marker["attributes"] != previous_attributes:
+                        raise AssertionError(f"Conflicting verified markers for {previous_id}")
+                    continue
+                previous_id = marker["marker_id"]
+                previous_attributes = marker["attributes"]
+                if marker["attributes"]["dup_doc"]:
+                    count += 1
+                    counters.pipeline.update_counter("dedup/fuzzy/document/verified_duplicates", 1)
+                yield {"id": marker["marker_id"], "attributes": marker["attributes"]}
+
+        result = write_parquet_file(marker_rows(), out_path)
+        return {**result, "file_idx": file_idx, "verified_duplicates": count}
+
     return aggregate
+
+
+_MARKER_SCHEMA = pa.schema(
+    [
+        pa.field("id", pa.string()),
+        pa.field(
+            "attributes",
+            pa.struct(
+                [
+                    pa.field("dup_doc", pa.bool_()),
+                    pa.field("dup_cluster_id", pa.string()),
+                    pa.field("dup_representative_id", pa.string()),
+                    pa.field("dup_verifier_version", pa.string()),
+                    pa.field("dup_shared_buckets", pa.int64()),
+                    pa.field("dup_member_containment", pa.float64()),
+                    pa.field("dup_jaccard", pa.float64()),
+                    pa.field("dup_member_unique_ngrams", pa.int64()),
+                    pa.field("dup_under_tokenized", pa.bool_()),
+                    pa.field("dup_char_jaccard", pa.float64()),
+                ]
+            ),
+        ),
+    ]
+)
+
+
+def _make_empty_marker_writer(output_path: str):
+    def ensure_outputs(entries: list[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+        for entry in entries:
+            out_path = f"{output_path}/outputs/{entry['source_tag']}/{entry['basename']}"
+            if StoragePath(out_path).exists():
+                yield {"file_idx": entry["file_idx"], "created": False}
+                continue
+            StoragePath(os.path.dirname(out_path)).mkdirs(exist_ok=True)
+            with StoragePath(out_path).open("wb") as stream:
+                pq.write_table(pa.Table.from_pylist([], schema=_MARKER_SCHEMA), stream)
+            counters.pipeline.update_counter("dedup/fuzzy/document/empty_attr_files", 1)
+            yield {"file_idx": entry["file_idx"], "created": True}
+
+    return ensure_outputs
 
 
 def compute_fuzzy_dups_attrs(
     *,
     inputs: list[MinHashAttrData],
     output_path: str,
+    verification_params: FuzzyVerificationParams | None = None,
     cc_max_iterations: int = 10,
     cc_resume: bool = False,
     max_parallelism: int = MAX_WORKERS_PER_JOB,
@@ -256,25 +462,20 @@ def compute_fuzzy_dups_attrs(
     map_task_resources: ResourceConfig | None = None,
     reduce_task_resources: ResourceConfig | None = None,
 ) -> FuzzyDupsAttrData:
-    """Mark fuzzy-duplicate cluster membership across one or more ``MinHashAttrData`` inputs.
+    """Mark only direct candidates that pass exact full-text verification.
 
-    All inputs must share identical :class:`MinHashParams`. The job builds a
-    global LSH bucket graph across every input shard, runs connected
-    components, and emits a per-source attribute tree under
-    ``<output_path>/outputs/source_NNN/`` with one parquet file per source
-    shard (filenames preserved from the source). Each row annotates one
-    cluster member with ``{id: str, attributes: {dup_cluster_id: str,
-    is_cluster_canonical: bool}}``; singletons are omitted.
-
-    Exactly one member per cluster has ``is_cluster_canonical=True`` — the
-    one CC's Hash-to-Min picked as the natural canonical (min ``id_norm``).
-    Consolidate may honor that flag (default policy) or ignore it and apply
-    a custom per-``dup_cluster_id`` policy.
+    Connected components identify a deterministic retained canonical, but
+    transitive members are never deleted. Each direct canonical neighbor is
+    joined back to full normalized text and scored exactly. Accepted members
+    receive a sparse ``dup_doc=True`` marker with the representative ID and
+    scores; rejected decisions are retained under ``metadata/decisions``.
 
     Args:
         inputs: ``MinHashAttrData`` artifacts to fuzzy-dedup together.
         output_path: Output root. Per-source attr trees land under
             ``<output_path>/outputs/source_NNN/``.
+        verification_params: Exact verifier thresholds. Defaults to the
+            precision-first exact token-subset rule.
         cc_max_iterations: Max iterations for connected components.
         max_parallelism: Worker count for the ZephyrContext.
         worker_resources: Per-worker resource request. Required when
@@ -284,22 +485,12 @@ def compute_fuzzy_dups_attrs(
         reduce_task_resources: ResourceConfig for reduce-stage tasks (e.g.
             the per-shard ``group_by`` writer).
 
-    Returns:
-        :class:`FuzzyDupsAttrData` describing per-source attr directories,
-        the shared MinHash params, and aggregated counters.
-
-    Canonical selection is deterministic (the min content-hash per component) and
-    reproducible across executor counts: ``connected_components`` sorts each LSH
-    bucket by ``id_norm`` so the graph topology does not depend on shuffle order.
-    If CC does not converge within ``cc_max_iterations`` the result is still
-    deterministic but *incomplete* (some near-dup clusters stay split); a warning
-    is logged and the caller can raise ``cc_max_iterations`` for complete dedup.
-
     Raises:
         ValueError: If inputs is empty or input params disagree.
         FileNotFoundError: If any input ``attr_dir`` is missing parquet shards.
     """
     params = _validate_inputs(inputs)
+    verification = verification_params or FuzzyVerificationParams()
     entries, source_tag = _build_shard_index(inputs)
 
     logger.info(
@@ -355,52 +546,71 @@ def compute_fuzzy_dups_attrs(
         )
 
     ctx.put(_SHARED_ENTRIES_KEY, entries)
-    aggregator = _make_per_shard_writer(output_path, counter_prefix="dedup/fuzzy/document")
-
-    # CC's Hash-to-Min guarantees component_id == min(id_norm) across a cluster,
-    # so `component_id == id_norm` cheaply identifies the natural canonical.
-    # `preserve_singletons=True` wires singletons as self-links, so a node is a
-    # singleton iff its adjacency_list is exactly [id_norm] — no cluster peers.
-    shard_pipeline = (
+    decisions_dir = f"{output_path}/metadata/decisions"
+    verification_pipeline = (
         Dataset.from_list(cc_files)
         .load_parquet()
-        .map(
-            lambda r: {
-                "id": _strip_cc_prefix(r["record_id"]),
-                "component_id": r["component_id"],
-                "is_canonical": r["component_id"] == r["id_norm"],
-                "is_singleton": len(r["adjacency_list"]) == 1 and r["adjacency_list"][0] == r["id_norm"],
-                "file_idx": r["file_idx"],
-            }
+        .map(_candidate_node)
+        .filter(lambda record: record["emit"])
+        .group_by(
+            lambda record: record["component_id"],
+            sort_by=lambda record: (record["canonical_order"], record["id_norm"]),
+            reducer=_candidate_pairs,
+        )
+        .flat_map(_candidate_text_requests)
+        .group_by(
+            lambda request: request["file_idx"],
+            sort_by=lambda request: (request["document_id"], request["pair_id"], request["role_order"]),
+            reducer=_requested_texts,
         )
         .group_by(
-            lambda r: r["file_idx"],
-            sort_by=lambda r: r["id"],
-            reducer=aggregator,
+            lambda piece: piece["pair_id"],
+            sort_by=lambda piece: piece["role_order"],
+            reducer=_make_candidate_verifier(verification),
+        )
+        .write_parquet(f"{decisions_dir}/part-{{shard:05d}}-of-{{total:05d}}.parquet")
+    )
+    verification_outcome = ctx.execute(verification_pipeline, verbose=True)
+    decision_files = sorted(str(path) for path in StoragePath(f"{decisions_dir}/*.parquet").glob())
+
+    marker_pipeline = (
+        Dataset.from_list(decision_files)
+        .load_parquet()
+        .filter(lambda decision: decision["accepted"])
+        .flat_map(_marker_records)
+        .group_by(
+            lambda marker: marker["marker_file_idx"],
+            sort_by=lambda marker: marker["marker_id"],
+            reducer=_make_marker_writer(output_path),
         )
     )
+    marker_outcome = ctx.execute(marker_pipeline, verbose=True)
+    empty_outcome = ctx.execute(
+        Dataset.from_list(entry_groups).flat_map(_make_empty_marker_writer(output_path)),
+        verbose=True,
+    )
 
-    outcome = ctx.execute(shard_pipeline, verbose=True)
-    shard_results = outcome.results
-
-    # Aggregate per-source counters across shards for the final artifact.
     sources: dict[str, FuzzyDupsPerSource] = {
         src_dir: FuzzyDupsPerSource(attr_dir=f"{output_path}/outputs/{tag}") for src_dir, tag in source_tag.items()
     }
-
-    cluster_members = sum(r["cluster_members"] for r in shard_results)
-    clusters = sum(r["canonicals"] for r in shard_results)  # one canonical per cluster
+    combined_counters: Counter[str] = Counter()
+    for outcome in (verification_outcome, marker_outcome, empty_outcome):
+        combined_counters.update(outcome.counters)
+    candidates = int(combined_counters[f"{_VERIFICATION_COUNTER}/candidates"])
+    verified = int(combined_counters[f"{_VERIFICATION_COUNTER}/decision/accepted"])
     logger.info(
-        "Fuzzy dups: %d cluster members across %d clusters (non-canonicals to drop by default: %d)",
-        cluster_members,
-        clusters,
-        cluster_members - clusters,
+        "Fuzzy dups: verified %d/%d direct-canonical candidates; retained %d rejected candidates",
+        verified,
+        candidates,
+        candidates - verified,
     )
 
     return FuzzyDupsAttrData(
         params=params,
+        verification=verification,
+        decisions_dir=decisions_dir,
         sources=sources,
-        counters=dict(outcome.counters),
+        counters=dict(combined_counters),
     )
 
 
@@ -408,6 +618,7 @@ def compute_fuzzy_dups_attrs_step(
     *,
     name: str,
     minhash_steps: list[StepSpec],
+    verification_params: FuzzyVerificationParams | None = None,
     cc_max_iterations: int = 10,
     max_parallelism: int,
     worker_resources: ResourceConfig | None = None,
@@ -415,17 +626,23 @@ def compute_fuzzy_dups_attrs_step(
     override_output_path: str | None = None,
 ) -> StepSpec:
     """Create a StepSpec that computes fuzzy duplicate attrs from ``MinHashAttrData`` step outputs."""
+    verification = verification_params or FuzzyVerificationParams()
     return StepSpec(
         name=name,
         deps=list(minhash_steps),
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(s.output_path, MinHashAttrData) for s in minhash_steps],
             output_path=output_path,
+            verification_params=verification,
             cc_max_iterations=cc_max_iterations,
             max_parallelism=max_parallelism,
             worker_resources=worker_resources,
             coordinator_resources=coordinator_resources,
         ),
-        hash_attrs={"cc_max_iterations": cc_max_iterations},
+        hash_attrs={
+            "candidate_scope": FUZZY_DUPS_CANDIDATE_SCOPE,
+            "cc_max_iterations": cc_max_iterations,
+            "verification": verification.model_dump(),
+        },
         override_output_path=override_output_path,
     )

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
@@ -14,9 +14,12 @@ deduplication.fuzzy_dups.compute_fuzzy_dups_attrs` consumes one or more of
 these artifacts to produce duplicate markers.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 from collections.abc import Iterator
+from enum import StrEnum
 
 import dupekit
 import pyarrow as pa
@@ -35,13 +38,29 @@ from marin.processing.classification.deduplication.dedup_commons import _load_ba
 logger = logging.getLogger(__name__)
 
 
+class NgramKind(StrEnum):
+    """Unit used to form MinHash candidate shingles."""
+
+    CHAR = "char"
+    WORD = "word"
+
+
+def _native_ngram_kind(kind: NgramKind) -> dupekit.NgramKind:
+    return {
+        NgramKind.CHAR: dupekit.NgramKind.Char,
+        NgramKind.WORD: dupekit.NgramKind.Word,
+    }[kind]
+
+
 class MinHashParams(BaseModel):
     """MinHash + LSH parameters that downstream fuzzy-dup consumers must agree on.
 
     Two ``MinHashAttrData`` artifacts can only be combined in
     :func:`compute_fuzzy_dups_attrs` if their params are equal.
 
-    ``text_cap_chars`` (added v2) caps each document's character length
+    ``ngram_kind`` selects character or whitespace-delimited word shingles.
+
+    ``text_cap_chars`` caps each document's character length
     before shingling/MinHash. Documents with O(10M+) shingles produce
     saturated MinHash signatures that band-collide with arbitrary other
     documents, creating large CC false-positive clusters. Capping bounds
@@ -52,6 +71,7 @@ class MinHashParams(BaseModel):
     num_perms: int
     num_bands: int
     ngram_size: int
+    ngram_kind: NgramKind
     seed: int
     text_cap_chars: int | None = None
 
@@ -73,7 +93,7 @@ class MinHashAttrData(BaseModel):
         counters: Aggregated zephyr counters.
     """
 
-    version: str = "v2"
+    version: str = "v3"
     params: MinHashParams
     source_main_dir: str
     attr_dir: str
@@ -84,8 +104,8 @@ def _attr_records(batch: pa.RecordBatch, params: MinHashParams) -> list[dict]:
     """Run the dupekit MinHash+LSH pipeline on *batch* and yield attr records.
 
     Yields one ``{id, buckets}`` record per input document with at least one
-    bucket. Documents whose signature column is null (empty/whitespace text
-    after cleaning) are dropped and counted via ``minhash/empty_signatures``.
+    bucket. Documents whose signature column is null are dropped and counted
+    via ``minhash/empty_signatures``.
     """
     if params.text_cap_chars is not None:
         # Truncate the text column to cap shingle count per doc. Mega-docs
@@ -122,6 +142,7 @@ def _attr_records(batch: pa.RecordBatch, params: MinHashParams) -> list[dict]:
             output_col="signature",
             num_perms=params.num_perms,
             ngram_size=params.ngram_size,
+            ngram_kind=_native_ngram_kind(params.ngram_kind),
             seed=params.seed,
         ),
         dupekit.Transformation.MinHashLSH(input_col="signature", output_col="buckets", num_bands=params.num_bands),
@@ -156,6 +177,7 @@ def compute_minhash_attrs(
     num_perms: int = 286,
     num_bands: int = 26,
     ngram_size: int = 5,
+    ngram_kind: NgramKind = NgramKind.WORD,
     text_cap_chars: int | None = 500_000,
     seed: int = 42,
     worker_resources: ResourceConfig | None = None,
@@ -176,9 +198,9 @@ def compute_minhash_attrs(
         num_perms: Number of MinHash permutations. Must be divisible by
             ``num_bands``.
         num_bands: Number of LSH bands.
-        ngram_size: Character n-gram size for shingling. Applied to text
-            after dupekit's CleanText (lowercase, strip punctuation,
-            collapse whitespace).
+        ngram_size: Size of the n-gram window.
+        ngram_kind: Unit used in the candidate n-gram window. Word shingles
+            avoid character-vocabulary saturation in long prose and code.
         text_cap_chars: If set, truncate each document to this many chars
             before MinHash so mega-docs cannot saturate the signature
             space and cause LSH false-positive blobs. Default 500,000
@@ -203,6 +225,7 @@ def compute_minhash_attrs(
         num_perms=num_perms,
         num_bands=num_bands,
         ngram_size=ngram_size,
+        ngram_kind=ngram_kind,
         seed=seed,
         text_cap_chars=text_cap_chars,
     )
@@ -260,6 +283,7 @@ def compute_minhash_attrs_step(
     num_perms: int = 286,
     num_bands: int = 26,
     ngram_size: int = 5,
+    ngram_kind: NgramKind = NgramKind.WORD,
     text_cap_chars: int | None = 500_000,
     seed: int = 42,
     worker_resources: ResourceConfig | None = None,
@@ -276,6 +300,7 @@ def compute_minhash_attrs_step(
             num_perms=num_perms,
             num_bands=num_bands,
             ngram_size=ngram_size,
+            ngram_kind=ngram_kind,
             text_cap_chars=text_cap_chars,
             seed=seed,
             worker_resources=worker_resources,
@@ -285,6 +310,7 @@ def compute_minhash_attrs_step(
             "num_perms": num_perms,
             "num_bands": num_bands,
             "ngram_size": ngram_size,
+            "ngram_kind": str(ngram_kind),
             "text_cap_chars": text_cap_chars,
             "seed": seed,
         },

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_verification.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_verification.py
@@ -1,0 +1,133 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exact verification for MinHash candidate pairs."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class VerificationRejection(StrEnum):
+    """Reason a MinHash candidate was retained."""
+
+    MEMBER_LONGER = "member_longer"
+    CONTAINMENT = "containment_below_threshold"
+    MEMBER_UNIQUE = "too_many_member_unique"
+    UNDER_TOKENIZED = "under_tokenized_char_jaccard_below_threshold"
+
+
+class FuzzyVerificationParams(BaseModel):
+    """Thresholds for an information-preserving direct-candidate deletion.
+
+    The defaults require every case-folded whitespace token 3-gram in the
+    removed member to occur in a no-shorter retained canonical. Text with too
+    few whitespace tokens also needs full-text character-5 Jaccard of at least
+    0.90.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    rule_version: str = "whitespace_3gram_subset_v1"
+    ngram_size: int = Field(default=3, ge=1)
+    minimum_member_containment: float = Field(default=1.0, ge=0, le=1)
+    maximum_member_unique_ngrams: int = Field(default=0, ge=0)
+    maximum_chars_per_token: float = Field(default=10.0, gt=0)
+    under_tokenized_char_ngram_size: int = Field(default=5, ge=1)
+    under_tokenized_minimum_char_jaccard: float = Field(default=0.90, ge=0, le=1)
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """Exact scores and decision for one candidate member."""
+
+    accepted: bool
+    rejection: VerificationRejection | None
+    member_chars: int
+    canonical_chars: int
+    member_tokens: int
+    canonical_tokens: int
+    member_ngrams: int
+    canonical_ngrams: int
+    shared_ngrams: int
+    member_unique_ngrams: int
+    member_containment: float
+    jaccard: float
+    under_tokenized: bool
+    char_jaccard: float | None
+
+
+def _token_ngrams(text: str, size: int) -> tuple[int, set[tuple[str, ...]]]:
+    tokens = text.casefold().split()
+    if not tokens:
+        return 0, set()
+    if len(tokens) < size:
+        return len(tokens), {tuple(tokens)}
+    return len(tokens), {tuple(tokens[index : index + size]) for index in range(len(tokens) - size + 1)}
+
+
+def _char_ngrams(text: str, size: int) -> set[str]:
+    normalized = text.casefold()
+    if len(normalized) < size:
+        return {normalized}
+    return {normalized[index : index + size] for index in range(len(normalized) - size + 1)}
+
+
+def _jaccard(left: set[str], right: set[str]) -> float:
+    union = len(left) + len(right) - len(left & right)
+    return len(left & right) / union if union else 1.0
+
+
+def verify_candidate(
+    member_text: str,
+    canonical_text: str,
+    params: FuzzyVerificationParams,
+) -> VerificationResult:
+    """Verify that a direct LSH member is safely contained by its canonical."""
+    member_tokens, member_ngrams = _token_ngrams(member_text, params.ngram_size)
+    canonical_tokens, canonical_ngrams = _token_ngrams(canonical_text, params.ngram_size)
+    shared = len(member_ngrams & canonical_ngrams)
+    union = len(member_ngrams) + len(canonical_ngrams) - shared
+    member_containment = shared / len(member_ngrams) if member_ngrams else 1.0
+    jaccard = shared / union if union else 1.0
+    member_unique = len(member_ngrams) - shared
+    member_chars = len(member_text)
+    canonical_chars = len(canonical_text)
+    under_tokenized = (
+        member_chars / max(member_tokens, 1) > params.maximum_chars_per_token
+        or canonical_chars / max(canonical_tokens, 1) > params.maximum_chars_per_token
+    )
+
+    rejection = None
+    char_jaccard = None
+    if member_chars > canonical_chars:
+        rejection = VerificationRejection.MEMBER_LONGER
+    elif member_containment < params.minimum_member_containment:
+        rejection = VerificationRejection.CONTAINMENT
+    elif member_unique > params.maximum_member_unique_ngrams:
+        rejection = VerificationRejection.MEMBER_UNIQUE
+    elif under_tokenized:
+        char_jaccard = _jaccard(
+            _char_ngrams(member_text, params.under_tokenized_char_ngram_size),
+            _char_ngrams(canonical_text, params.under_tokenized_char_ngram_size),
+        )
+        if char_jaccard < params.under_tokenized_minimum_char_jaccard:
+            rejection = VerificationRejection.UNDER_TOKENIZED
+
+    return VerificationResult(
+        accepted=rejection is None,
+        rejection=rejection,
+        member_chars=member_chars,
+        canonical_chars=canonical_chars,
+        member_tokens=member_tokens,
+        canonical_tokens=canonical_tokens,
+        member_ngrams=len(member_ngrams),
+        canonical_ngrams=len(canonical_ngrams),
+        shared_ngrams=shared,
+        member_unique_ngrams=member_unique,
+        member_containment=member_containment,
+        jaccard=jaccard,
+        under_tokenized=under_tokenized,
+        char_jaccard=char_jaccard,
+    )

--- a/tests/datakit/test_datakit_store.py
+++ b/tests/datakit/test_datakit_store.py
@@ -20,7 +20,8 @@ import pyarrow.parquet as pq
 from levanter.store.cache import TreeCache
 from marin.datakit.decon import DeconAttributes
 from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData, FuzzyDupsPerSource
-from marin.processing.classification.deduplication.fuzzy_minhash import MinHashParams
+from marin.processing.classification.deduplication.fuzzy_minhash import MinHashParams, NgramKind
+from marin.processing.classification.deduplication.fuzzy_verification import FuzzyVerificationParams
 from marin.processing.tokenize.attributes import TokenizedAttrData
 from zephyr.shard_keys import deterministic_hash
 
@@ -32,10 +33,10 @@ CLUSTER_VIEW = 2  # cluster column "cluster_2", clusters {0, 1}
 SPLIT = "train"
 EXEMPLAR = {"input_ids": np.array([0], dtype=np.int32)}
 
-# One doc = (id, cluster, quality_bucket, contaminated, dedup-canonical, token value, length).
+# One doc = (id, cluster, quality_bucket, contaminated, verified duplicate, token value, length).
 # ``quality_bucket`` is the precomputed calibrated bucket the scorer writes as a
 # column (consumed as-is by the store -- no score->bucket mapping).
-# ``canonical``: None -> singleton (absent from dedup, kept); True -> kept; False -> dropped.
+# ``duplicate``: None -> absent from dedup and kept; True -> dropped.
 # Each surviving doc's tokens are a run of its unique ``token`` value so we can
 # recover identity from the cache and confirm dropped docs never appear.
 _Doc = tuple[str, int, int, bool, bool | None, int, int]
@@ -44,11 +45,11 @@ SHARD0: list[_Doc] = [
     ("d0", 0, 0, False, None, 100, 3),  # -> (0, 0)
     ("d1", 0, 4, False, None, 101, 5),  # -> (0, 4)
     ("d2", 1, 2, True, None, 902, 9),  # contaminated -> dropped
-    ("d3", 1, 2, False, True, 103, 2),  # canonical -> (1, 2)
+    ("d3", 1, 2, False, None, 103, 2),  # -> (1, 2)
 ]
 SHARD1: list[_Doc] = [
     ("d4", 0, 0, False, None, 104, 4),  # -> (0, 0)
-    ("d5", 1, 2, False, False, 905, 8),  # non-canonical -> dropped
+    ("d5", 1, 2, False, True, 905, 8),  # verified duplicate -> dropped
     ("d6", 1, 4, False, None, 106, 6),  # -> (1, 4)
     ("d7", 0, 4, False, None, 107, 7),  # -> (0, 4)
 ]
@@ -94,15 +95,15 @@ def _write_shard(dirs: dict[str, str], basename: str, docs: list[_Doc]) -> None:
             }
         ),
     )
-    # Dedup is sparse: only non-singleton docs (canonical True/False) appear.
-    marked = [(d[0], d[4]) for d in docs if d[4] is not None]
+    # Dedup is sparse: only verified duplicate documents appear.
+    marked = [d[0] for d in docs if d[4]]
     if marked:
         _write_parquet(
             f"{dirs['dedup']}/{basename}",
             pa.table(
                 {
-                    "id": [m[0] for m in marked],
-                    "attributes": pa.array([{"is_cluster_canonical": m[1]} for m in marked]),
+                    "id": marked,
+                    "attributes": pa.array([{"dup_doc": True} for _ in marked]),
                 }
             ),
         )
@@ -158,7 +159,15 @@ def _build_inputs(tmp_path):
         )
     }
     dedup = FuzzyDupsAttrData(
-        params=MinHashParams(num_perms=8, num_bands=4, ngram_size=5, seed=0),
+        params=MinHashParams(
+            num_perms=8,
+            num_bands=4,
+            ngram_size=5,
+            ngram_kind=NgramKind.WORD,
+            seed=0,
+        ),
+        verification=FuzzyVerificationParams(),
+        decisions_dir=str(tmp_path / "decisions"),
         sources={main_dir: FuzzyDupsPerSource(attr_dir=dirs["dedup"])},
         counters={},
     )
@@ -210,10 +219,10 @@ def test_store_filters_routes_and_roundtrips(tmp_path):
             assert len(set(arr.tolist())) == 1  # each doc is a run of its unique token value
             all_tokens.extend(arr.tolist())
 
-    assert DROPPED_TOKEN_VALUES.isdisjoint(all_tokens), "contaminated + non-canonical docs must be absent"
+    assert DROPPED_TOKEN_VALUES.isdisjoint(all_tokens), "contaminated + verified duplicate docs must be absent"
     assert artifact.counters["datakit_store/records_in"] == len(SHARD0) + len(SHARD1)
     assert artifact.counters["datakit_store/contaminated_dropped"] == 1
-    assert artifact.counters["datakit_store/dedup_noncanonical_dropped"] == 1
+    assert artifact.counters["datakit_store/dedup_verified_dropped"] == 1
     assert artifact.counters["datakit_store/records_out"] == sum(len(docs) for docs in EXPECTED.values())
     assert artifact.counters["datakit_store/tokens_out"] == sum(
         length for docs in EXPECTED.values() for length in docs.values()

--- a/tests/datakit/test_dedup_report.py
+++ b/tests/datakit/test_dedup_report.py
@@ -1,0 +1,62 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData, FuzzyDupsPerSource
+from marin.processing.classification.deduplication.fuzzy_minhash import MinHashParams, NgramKind
+from marin.processing.classification.deduplication.fuzzy_verification import FuzzyVerificationParams
+
+from experiments.datakit.reports.dedup import dedup_report
+
+
+def test_dedup_report_surfaces_exact_verification_evidence(tmp_path):
+    counter = "dedup/fuzzy/verification"
+    source_main_dir = "s3://bucket/corpus/source/outputs/main"
+    artifact = FuzzyDupsAttrData(
+        params=MinHashParams(
+            num_perms=286,
+            num_bands=26,
+            ngram_size=5,
+            ngram_kind=NgramKind.WORD,
+            seed=42,
+        ),
+        verification=FuzzyVerificationParams(),
+        decisions_dir="s3://bucket/dedup/metadata/decisions",
+        sources={
+            source_main_dir: FuzzyDupsPerSource(
+                attr_dir="s3://bucket/dedup/outputs/source_000",
+            )
+        },
+        counters={
+            f"{counter}/candidates": 100,
+            f"{counter}/decision/accepted": 20,
+            f"{counter}/decision/member_longer": 50,
+            f"{counter}/decision/containment_below_threshold": 30,
+            f"{counter}/source/source_000/decision/accepted": 20,
+            f"{counter}/source/source_000/decision/member_longer": 50,
+            f"{counter}/source/source_000/decision/containment_below_threshold": 30,
+            f"{counter}/histogram/member_containment/100": 20,
+            f"{counter}/histogram/jaccard/099": 20,
+            f"{counter}/histogram/member_unique/0": 20,
+            f"{counter}/histogram/shared_buckets/26": 20,
+            "dedup/fuzzy/document/transitive_members_kept": 12,
+        },
+    )
+
+    report = dedup_report(str(tmp_path), artifact)
+
+    assert report.stats == {
+        "candidates": 100,
+        "verified_duplicates": 20,
+        "rejected_candidates": 80,
+        "acceptance_rate": 0.2,
+        "transitive_members_kept": 12,
+        "n_sources": 1,
+    }
+    html = Path(report.html_path).read_text()
+    assert "candidate evidence:" in html
+    assert "s3://bucket/dedup/metadata/decisions" in html
+    assert "containment_below_threshold" in html
+    assert "0.7184" in html
+    assert "0.903206" in html

--- a/tests/datakit/test_reference_pipeline_hashing.py
+++ b/tests/datakit/test_reference_pipeline_hashing.py
@@ -14,6 +14,7 @@ import json
 
 import pytest
 from marin.execution.step_spec import StepSpec
+from marin.processing.classification.deduplication.fuzzy_minhash import NgramKind
 
 from experiments.datakit import reference_pipeline
 from experiments.datakit.reference_pipeline import SMOKE_SCALE, PoolConfig, StoreConfig, reference_datakit_steps
@@ -83,7 +84,14 @@ def test_minhash_params_rekey_minhash_and_dedup():
     mh = dataclasses.replace(SMOKE_SCALE.minhash, num_bands=13)
     changed = _steps_by_name(_build(scale=dataclasses.replace(SMOKE_SCALE, minhash=mh)))
     assert changed["datakit/minhash/a"].hash_id != base["datakit/minhash/a"].hash_id
-    # dedup has no params of its own; it must re-key via its minhash deps.
+    assert changed["datakit/dedup"].hash_id != base["datakit/dedup"].hash_id
+
+
+def test_ngram_kind_rekeys_minhash_and_dedup():
+    base = _steps_by_name(_build())
+    mh = dataclasses.replace(SMOKE_SCALE.minhash, ngram_kind=NgramKind.CHAR)
+    changed = _steps_by_name(_build(scale=dataclasses.replace(SMOKE_SCALE, minhash=mh)))
+    assert changed["datakit/minhash/a"].hash_id != base["datakit/minhash/a"].hash_id
     assert changed["datakit/dedup"].hash_id != base["datakit/dedup"].hash_id
 
 

--- a/tests/infra/ci/test_select_tests.py
+++ b/tests/infra/ci/test_select_tests.py
@@ -18,6 +18,7 @@ from infra.ci.select_tests import (
     full_matrix,
     is_test_module,
     matrix_leg,
+    required_source_build_scopes,
     scope_legs,
     shard_files,
 )
@@ -26,7 +27,7 @@ from infra.ci.select_tests import (
 def select_matrix(changed_files: list[str], repo_root: Path) -> list[dict[str, str | int]]:
     """Mirror the diff-driven branch of select_tests.main without git."""
     classification = classify(changed_files, repo_root)
-    source_build_scopes = set(classification.native_changed)
+    source_build_scopes = required_source_build_scopes(classification)
     if classification.broad:
         return full_matrix(repo_root, source_build_scopes)
     return compute_matrix(
@@ -369,6 +370,26 @@ def test_native_change_source_builds_only_the_owning_scope(tmp_path: Path) -> No
 
     assert _leg(matrix, "finelog")["setup"] == "rust"
     assert _leg(matrix, "iris")["setup"] == ""
+
+
+def test_coordinated_native_api_change_source_builds_selected_consumers(tmp_path: Path) -> None:
+    """A native crate and its Python surface can change ABI together, so selected
+    consumers must test against the source build instead of the published wheel."""
+    write(tmp_path, "lib/finelog/src/finelog/__init__.py", "from finelog import native\n")
+    write(tmp_path, "lib/finelog/src/finelog/native.py", "X = 1\n")
+    write(tmp_path, "lib/finelog/tests/test_native.py", "from finelog.native import X\n")
+    write(tmp_path, "lib/iris/src/iris/__init__.py")
+    write(tmp_path, "lib/iris/src/iris/log.py", "from finelog.native import X\n")
+    write(tmp_path, "lib/iris/tests/test_log.py", "from iris.log import X\n")
+
+    matrix = select_matrix(
+        ["lib/finelog/rust/pyext/src/lib.rs", "lib/finelog/src/finelog/native.py"],
+        tmp_path,
+    )
+
+    assert scopes_in(matrix) == {"finelog", "iris"}
+    assert _leg(matrix, "finelog")["setup"] == "rust"
+    assert _leg(matrix, "iris")["setup"] == "rust"
 
 
 def test_broad_trigger_does_not_source_build(tmp_path: Path) -> None:

--- a/tests/processing/classification/deduplication/test_fuzzy.py
+++ b/tests/processing/classification/deduplication/test_fuzzy.py
@@ -17,11 +17,20 @@ from marin.processing.classification.deduplication.fuzzy_dups import compute_fuz
 from marin.processing.classification.deduplication.fuzzy_minhash import (
     MinHashAttrData,
     MinHashParams,
+    NgramKind,
     compute_minhash_attrs,
 )
+from marin.processing.classification.deduplication.fuzzy_verification import FuzzyVerificationParams
 from zephyr.writers import write_jsonl_file, write_parquet_file
 
-TEST_MINHASH_PARAMS = MinHashParams(num_perms=286, num_bands=26, ngram_size=5, seed=42)
+TEST_MINHASH_PARAMS = MinHashParams(
+    num_perms=286,
+    num_bands=26,
+    ngram_size=5,
+    ngram_kind=NgramKind.WORD,
+    seed=42,
+)
+CHAR_MINHASH_PARAMS = TEST_MINHASH_PARAMS.model_copy(update={"ngram_kind": NgramKind.CHAR})
 
 
 @pytest.fixture(autouse=True)
@@ -45,7 +54,7 @@ def _read_main_records(source: NormalizedData) -> dict[str, dict]:
 
 
 def _read_cluster_attrs(attr_dir: str) -> list[dict]:
-    """Return every cluster-member row (flat list) under *attr_dir*."""
+    """Return every Parquet row under *attr_dir*."""
     rows: list[dict] = []
     for pf in sorted(Path(attr_dir).glob("*.parquet")):
         rows.extend(pq.read_table(str(pf)).to_pylist())
@@ -57,17 +66,37 @@ def _write_minhash_attr_dataset(
     output_dir: str,
     source_main_dir: str,
     rows: list[dict],
+    text_by_id: dict[str, str],
 ) -> MinHashAttrData:
     """Write a one-shard MinHash attr dataset for focused fuzzy-dup tests."""
     attr_dir = os.path.join(output_dir, "outputs")
     Path(attr_dir).mkdir(parents=True, exist_ok=True)
-    write_parquet_file(rows, os.path.join(attr_dir, "part-00000.parquet"))
+    basename = "part-00000.parquet"
+    write_parquet_file(rows, os.path.join(attr_dir, basename))
+    Path(source_main_dir).mkdir(parents=True, exist_ok=True)
+    write_parquet_file(
+        [{"id": row["id"], "text": text_by_id[row["id"]]} for row in rows],
+        os.path.join(source_main_dir, basename),
+    )
     return MinHashAttrData(
         params=TEST_MINHASH_PARAMS,
         source_main_dir=source_main_dir,
         attr_dir=attr_dir,
         counters={},
     )
+
+
+def _contained_candidate_pair() -> tuple[str, str, str, str]:
+    """Return member/canonical texts and IDs with the canonical ordered first by CC."""
+    member = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda"
+    member_id = generate_id(member)
+    member_order = dupekit.hash_xxh3_128(f"source_000|{member_id}".encode())
+    for suffix in range(1_000):
+        canonical = f"preface context {member} appendix context {suffix}"
+        canonical_id = generate_id(canonical)
+        if dupekit.hash_xxh3_128(f"source_000|{canonical_id}".encode()) < member_order:
+            return member, member_id, canonical, canonical_id
+    raise AssertionError("Could not construct a longer deterministic canonical")
 
 
 def test_minhash_attrs_co_partitioned_with_source(fox_corpus):
@@ -104,96 +133,94 @@ def test_minhash_attrs_co_partitioned_with_source(fox_corpus):
 
 
 def test_fuzzy_dups_single_source_schema_and_pair(fox_corpus):
-    """Attr rows cover every cluster member; singletons get no row.
+    """Only the verified member receives a removal marker.
 
-    Uses the test corpus's fuzzy pair (``test_contaminated_1`` ~
-    ``test_high_overlap``, one-word diff) to exercise a real cluster of 2
-    and verifies:
-    * both members get an attr row,
-    * rows carry ``dup_cluster_id`` and ``is_cluster_canonical``,
-    * all rows for one cluster share the same ``dup_cluster_id``,
-    * exactly one member per cluster is canonical,
+    Builds a direct candidate whose shorter member is an exact token-3 subset
+    of the deterministic canonical and verifies:
+    * exactly one member gets ``dup_doc=True``,
+    * the marker names the retained representative,
     * unique docs have no attr row.
     """
-    norm_dir = os.path.join(fox_corpus["output_dir"], "normalized")
-    minhash_dir = os.path.join(fox_corpus["output_dir"], "minhash")
-    dups_dir = os.path.join(fox_corpus["output_dir"], "fuzzy_dups")
+    output_dir = fox_corpus["output_dir"]
+    main_dir = os.path.join(output_dir, "single_source_main")
+    member, member_id, canonical, canonical_id = _contained_candidate_pair()
 
-    source = _normalize(fox_corpus["test_dir"], norm_dir)
-    minhash = compute_minhash_attrs(source=source, output_path=minhash_dir)
-    dups = compute_fuzzy_dups_attrs(inputs=[minhash], output_path=dups_dir, max_parallelism=4)
+    minhash = _write_minhash_attr_dataset(
+        output_dir=os.path.join(output_dir, "single_source_minhash"),
+        source_main_dir=main_dir,
+        rows=[
+            {"id": member_id, "buckets": ["shared"]},
+            {"id": canonical_id, "buckets": ["shared"]},
+        ],
+        text_by_id={member_id: member, canonical_id: canonical},
+    )
+    dups = compute_fuzzy_dups_attrs(
+        inputs=[minhash],
+        output_path=os.path.join(output_dir, "single_source_dups"),
+        max_parallelism=1,
+    )
 
-    assert dups.params == minhash.params
-    per_source = dups.sources[source.main_output_dir]
-
-    by_id = _read_main_records(source)
-    rows = _read_cluster_attrs(per_source.attr_dir)
-    by_source_id = {by_id[r["id"]]["source_id"]: r for r in rows if r["id"] in by_id}
-
-    # The fuzzy pair is a cluster of 2: both members must have an attr row,
-    # sharing one dup_cluster_id, with exactly one canonical.
-    pair = {"test_contaminated_1", "test_high_overlap"}
-    assert pair <= by_source_id.keys(), f"missing attr rows for pair: {pair - by_source_id.keys()}"
-    cluster_ids = {by_source_id[s]["attributes"]["dup_cluster_id"] for s in pair}
-    assert len(cluster_ids) == 1, f"pair should share a dup_cluster_id; got {cluster_ids}"
-    canonicals = [s for s in pair if by_source_id[s]["attributes"]["is_cluster_canonical"]]
-    assert len(canonicals) == 1, f"exactly one canonical expected; got {canonicals}"
-
-    # Unique docs never have attr rows (no cluster → no annotation).
-    assert "test_unique_1" not in by_source_id
-    assert "test_unique_2" not in by_source_id
+    rows = _read_cluster_attrs(dups.sources[main_dir].attr_dir)
+    assert len(rows) == 1
+    assert rows[0]["id"] == member_id
+    attributes = rows[0]["attributes"]
+    assert attributes["dup_doc"] is True
+    assert attributes["dup_representative_id"] == canonical_id
 
 
 def test_fuzzy_dups_multi_source_per_source_attr_trees(fox_corpus):
     """Two MinHashAttrData inputs produce two per-source attr trees.
 
-    Cross-source exact-text duplicates (e.g. ``train_arctic_1`` ==
-    ``test_contaminated_1`` byte-identical → same normalized id in both
-    datasets) must be detected as a 2-member cluster rather than collapsing
-    into a single node. Each side independently carries its own attr row for
-    the shared content hash, with a shared ``dup_cluster_id`` and exactly one
-    canonical across the pair.
+    Cross-source exact-text duplicates have the same normalized ID in both
+    datasets but remain distinct CC nodes. Exactly one side receives the
+    verified removal marker.
 
     This test targets multi-source fuzzy dedup behavior directly. Normalization
     and MinHash generation already have separate coverage above.
     """
     train_main_dir = os.path.join(fox_corpus["output_dir"], "train_main")
     test_main_dir = os.path.join(fox_corpus["output_dir"], "test_main")
+    arctic = "Arctic predators have superior auditory capabilities for hunting beneath snow."
+    red = "Red canids inhabit northern territories worldwide."
+    train_unique = "Newborn kits emerge sightless and vulnerable."
+    test_unique = "Rapid runners represent the most diminutive wild dogs."
     train_mh = _write_minhash_attr_dataset(
         output_dir=os.path.join(fox_corpus["output_dir"], "mh_train"),
         source_main_dir=train_main_dir,
         rows=[
             {
-                "id": generate_id("Arctic predators have superior auditory capabilities for hunting beneath snow."),
+                "id": generate_id(arctic),
                 "buckets": ["shared-arctic"],
             },
             {
-                "id": generate_id("Red canids inhabit northern territories worldwide."),
+                "id": generate_id(red),
                 "buckets": ["shared-red"],
             },
             {
-                "id": generate_id("Newborn kits emerge sightless and vulnerable."),
+                "id": generate_id(train_unique),
                 "buckets": ["train-unique"],
             },
         ],
+        text_by_id={generate_id(text): text for text in (arctic, red, train_unique)},
     )
     test_mh = _write_minhash_attr_dataset(
         output_dir=os.path.join(fox_corpus["output_dir"], "mh_test"),
         source_main_dir=test_main_dir,
         rows=[
             {
-                "id": generate_id("Arctic predators have superior auditory capabilities for hunting beneath snow."),
+                "id": generate_id(arctic),
                 "buckets": ["shared-arctic"],
             },
             {
-                "id": generate_id("Red canids inhabit northern territories worldwide."),
+                "id": generate_id(red),
                 "buckets": ["shared-red"],
             },
             {
-                "id": generate_id("Rapid runners represent the most diminutive wild dogs."),
+                "id": generate_id(test_unique),
                 "buckets": ["test-unique"],
             },
         ],
+        text_by_id={generate_id(text): text for text in (arctic, red, test_unique)},
     )
 
     dups = compute_fuzzy_dups_attrs(
@@ -213,21 +240,68 @@ def test_fuzzy_dups_multi_source_per_source_attr_trees(fox_corpus):
     train_rows = rows_by_id(train_main_dir)
     test_rows = rows_by_id(test_main_dir)
 
-    # Each cross-source byte-identical text must appear as an attr row on both
-    # sides (keyed by the same content hash), share a dup_cluster_id, and have
-    # exactly one canonical across the pair.
     for shared_text in (
         "Arctic predators have superior auditory capabilities for hunting beneath snow.",
         "Red canids inhabit northern territories worldwide.",
     ):
         content_id = generate_id(shared_text)
-        assert content_id in train_rows, f"missing train attr row for {shared_text!r}"
-        assert content_id in test_rows, f"missing test attr row for {shared_text!r}"
-        a, b = train_rows[content_id]["attributes"], test_rows[content_id]["attributes"]
-        assert a["dup_cluster_id"] == b["dup_cluster_id"], f"{shared_text!r}: dup_cluster_id mismatch"
-        assert (
-            a["is_cluster_canonical"] != b["is_cluster_canonical"]
-        ), f"{shared_text!r}: exactly one canonical expected across pair"
+        marked = [rows[content_id] for rows in (train_rows, test_rows) if content_id in rows]
+        assert len(marked) == 1, f"{shared_text!r}: exactly one verified removal marker expected"
+        assert marked[0]["attributes"]["dup_doc"] is True
+
+
+def test_fuzzy_dups_retains_candidate_rejected_by_exact_verifier(fox_corpus):
+    main_dir = os.path.join(fox_corpus["output_dir"], "rejected_main")
+    left = "astronomy describes distant stars and planetary systems"
+    right = "cooking combines seasonal produce with regional techniques"
+    minhash = _write_minhash_attr_dataset(
+        output_dir=os.path.join(fox_corpus["output_dir"], "rejected_minhash"),
+        source_main_dir=main_dir,
+        rows=[
+            {"id": generate_id(left), "buckets": ["forced-collision"]},
+            {"id": generate_id(right), "buckets": ["forced-collision"]},
+        ],
+        text_by_id={generate_id(left): left, generate_id(right): right},
+    )
+
+    dups = compute_fuzzy_dups_attrs(
+        inputs=[minhash],
+        output_path=os.path.join(fox_corpus["output_dir"], "rejected_dups"),
+        max_parallelism=1,
+    )
+
+    assert _read_cluster_attrs(dups.sources[main_dir].attr_dir) == []
+    decisions = _read_cluster_attrs(dups.decisions_dir)
+    assert len(decisions) == 1
+    assert decisions[0]["accepted"] is False
+    assert decisions[0]["rejection"] in {
+        "member_longer",
+        "containment_below_threshold",
+    }
+
+
+def test_fuzzy_dups_writes_typed_empty_markers_without_candidates(fox_corpus):
+    main_dir = os.path.join(fox_corpus["output_dir"], "singleton_main")
+    text = "one document with no shared minhash bucket"
+    minhash = _write_minhash_attr_dataset(
+        output_dir=os.path.join(fox_corpus["output_dir"], "singleton_minhash"),
+        source_main_dir=main_dir,
+        rows=[{"id": generate_id(text), "buckets": ["unique"]}],
+        text_by_id={generate_id(text): text},
+    )
+
+    dups = compute_fuzzy_dups_attrs(
+        inputs=[minhash],
+        output_path=os.path.join(fox_corpus["output_dir"], "singleton_dups"),
+        max_parallelism=1,
+    )
+
+    attr_files = list(Path(dups.sources[main_dir].attr_dir).glob("*.parquet"))
+    assert len(attr_files) == 1
+    table = pq.read_table(attr_files[0])
+    assert table.num_rows == 0
+    assert table.schema.field("attributes").type.field("dup_doc").type == pa.bool_()
+    assert dups.counters.get("dedup/fuzzy/verification/candidates", 0) == 0
 
 
 def test_fuzzy_dups_rejects_param_mismatch(fox_corpus):
@@ -262,32 +336,49 @@ def test_fuzzy_dups_rejects_duplicate_source(fox_corpus):
         )
 
 
-def _canonical_assignment(source: NormalizedData, output_path: str) -> dict[str, tuple[str, bool]]:
-    """Run minhash + fuzzy_dups for *source* and return ``{id -> (dup_cluster_id, is_canonical)}``."""
-    minhash = compute_minhash_attrs(source=source, output_path=os.path.join(output_path, "minhash"))
+def _canonical_assignment(minhash: MinHashAttrData, output_path: str) -> dict[str, tuple[str, bool]]:
+    """Run fuzzy-dups and return ``{id -> (dup_cluster_id, is_canonical)}``."""
     dups = compute_fuzzy_dups_attrs(inputs=[minhash], output_path=os.path.join(output_path, "dups"), max_parallelism=4)
-    rows = _read_cluster_attrs(dups.sources[source.main_output_dir].attr_dir)
-    return {r["id"]: (r["attributes"]["dup_cluster_id"], r["attributes"]["is_cluster_canonical"]) for r in rows}
+    assignments = {}
+    for decision in _read_cluster_attrs(dups.decisions_dir):
+        if not decision["accepted"]:
+            continue
+        assignment = (decision["component_id"], True)
+        previous = assignments.setdefault(decision["canonical_id"], assignment)
+        assert previous == assignment
+        assignments[decision["member_id"]] = (decision["component_id"], False)
+    return assignments
 
 
 def test_fuzzy_dups_canonical_selection_is_deterministic(fox_corpus):
     """Two independent runs over the same input select the same survivors (marin#6798).
 
     Canonical selection is the min content-hash per component, so it must not
-    depend on shard/link/reduce order or parallelism. Running the whole
-    minhash → fuzzy_dups path twice into separate output trees must yield a
-    byte-identical ``{id -> (dup_cluster_id, is_cluster_canonical)}`` map, with
+    depend on shard/link/reduce order or parallelism. Running fuzzy-dups twice
+    over the same prepared MinHash input into separate output trees must yield a
+    byte-identical ``{id -> (dup_cluster_id, is_canonical)}`` map, with
     exactly one canonical per cluster. A future canonical pick that leaked
     dict/set ordering or arrival order would break this.
     """
-    source = _normalize(fox_corpus["test_dir"], os.path.join(fox_corpus["output_dir"], "norm"))
+    output_dir = fox_corpus["output_dir"]
+    main_dir = os.path.join(output_dir, "deterministic_main")
+    member, member_id, canonical, canonical_id = _contained_candidate_pair()
+    minhash = _write_minhash_attr_dataset(
+        output_dir=os.path.join(output_dir, "deterministic_minhash"),
+        source_main_dir=main_dir,
+        rows=[
+            {"id": member_id, "buckets": ["shared"]},
+            {"id": canonical_id, "buckets": ["shared"]},
+        ],
+        text_by_id={member_id: member, canonical_id: canonical},
+    )
 
-    first = _canonical_assignment(source, os.path.join(fox_corpus["output_dir"], "run_a"))
-    second = _canonical_assignment(source, os.path.join(fox_corpus["output_dir"], "run_b"))
+    first = _canonical_assignment(minhash, os.path.join(output_dir, "run_a"))
+    second = _canonical_assignment(minhash, os.path.join(output_dir, "run_b"))
 
     assert first == second, "fuzzy-dup canonical assignment differs between two runs over identical input"
-    # The fox corpus has at least one real fuzzy cluster; guard against a
-    # vacuous all-empty comparison and pin the one-canonical-per-cluster rule.
+    # Guard against a vacuous all-empty comparison and pin the
+    # one-canonical-per-cluster rule.
     assert first, "expected at least one cluster member row"
     canonical_per_cluster: dict[str, int] = {}
     for cluster_id, is_canonical in first.values():
@@ -304,7 +395,8 @@ def test_fuzzy_dups_capped_does_not_raise_and_emits(fox_corpus):
     each) whose min component id needs >=2 iterations to reach both ends;
     ``cc_max_iterations=1`` cannot converge. The step must NOT raise -- with the
     id_norm-sorted bucket topology the capped result is deterministic (just
-    incomplete) -- and must still emit cluster-member attr rows.
+    incomplete) -- and must still emit verified marker rows under permissive
+    verification thresholds.
     """
     main_dir = os.path.join(fox_corpus["output_dir"], "path_main")
     texts = [f"path node number {i} with distinct filler content here" for i in range(5)]
@@ -323,16 +415,22 @@ def test_fuzzy_dups_capped_does_not_raise_and_emits(fox_corpus):
         output_dir=os.path.join(fox_corpus["output_dir"], "mh_path"),
         source_main_dir=main_dir,
         rows=rows,
+        text_by_id={generate_id(text): text for text in texts},
     )
 
     dups = compute_fuzzy_dups_attrs(
         inputs=[mh],
         output_path=os.path.join(fox_corpus["output_dir"], "fuzzy_dups_path"),
+        verification_params=FuzzyVerificationParams(
+            minimum_member_containment=0,
+            maximum_member_unique_ngrams=100,
+            maximum_chars_per_token=100,
+        ),
         cc_max_iterations=1,
         max_parallelism=4,
     )
     attr_rows = _read_cluster_attrs(dups.sources[main_dir].attr_dir)
-    assert attr_rows, "capped run should still emit cluster-member rows"
+    assert attr_rows, "capped run should still emit verified marker rows"
 
 
 def test_text_cap_chars_truncates_mega_docs_only(tmp_path):
@@ -400,7 +498,7 @@ def test_text_cap_chars_truncates_mega_docs_only(tmp_path):
     # Params + version metadata.
     assert cap_mh.params.text_cap_chars == cap_chars
     assert nocap_mh.params.text_cap_chars is None
-    assert cap_mh.version == "v2"
+    assert cap_mh.version == "v3"
 
 
 # ---------------------------------------------------------------------------
@@ -474,6 +572,10 @@ def _dupekit_pipeline(params: MinHashParams) -> list:
             output_col="signature",
             num_perms=params.num_perms,
             ngram_size=params.ngram_size,
+            ngram_kind={
+                NgramKind.CHAR: dupekit.NgramKind.Char,
+                NgramKind.WORD: dupekit.NgramKind.Word,
+            }[params.ngram_kind],
             seed=params.seed,
         ),
         dupekit.Transformation.MinHashLSH(input_col="signature", output_col="buckets", num_bands=params.num_bands),
@@ -484,7 +586,7 @@ def _dupekit_pipeline(params: MinHashParams) -> list:
 def _shared_lsh_bucket(text_a: str, text_b: str) -> bool:
     """Return True iff (a, b) share at least one MinHash-LSH bucket."""
     batch = pa.RecordBatch.from_pylist([{"id": "a", "text": text_a}, {"id": "b", "text": text_b}])
-    out = dupekit.transform(batch, _dupekit_pipeline(TEST_MINHASH_PARAMS))
+    out = dupekit.transform(batch, _dupekit_pipeline(CHAR_MINHASH_PARAMS))
     return bool(set(out["buckets"][0].as_py()) & set(out["buckets"][1].as_py()))
 
 
@@ -528,7 +630,7 @@ def test_low_char_5gram_jaccard_rarely_collides(target_j: float):
 
 
 def _run_dedup_on_corpus(tmp_path: Path, docs: list[dict]) -> dict[str, dict]:
-    """Run normalize -> minhash -> fuzzy_dups on a list of ``{id, text}`` docs."""
+    """Return accepted cluster assignments from normalize -> minhash -> fuzzy-dups."""
     src_dir = tmp_path / "src"
     src_dir.mkdir()
     write_jsonl_file(docs, str(src_dir / "shard_0.jsonl.gz"))
@@ -538,61 +640,51 @@ def _run_dedup_on_corpus(tmp_path: Path, docs: list[dict]) -> dict[str, dict]:
     dups = compute_fuzzy_dups_attrs(inputs=[minhash], output_path=str(tmp_path / "dups"), max_parallelism=1)
 
     by_id = _read_main_records(source)
-    rows = _read_cluster_attrs(dups.sources[source.main_output_dir].attr_dir)
-    return {by_id[r["id"]]["source_id"]: r for r in rows if r["id"] in by_id}
+    assignments: dict[str, dict] = {}
+    for decision in _read_cluster_attrs(dups.decisions_dir):
+        if not decision["accepted"]:
+            continue
+        attributes = {"dup_cluster_id": decision["component_id"]}
+        for document_id in (decision["canonical_id"], decision["member_id"]):
+            if document_id in by_id:
+                assignments[by_id[document_id]["source_id"]] = {"attributes": attributes}
+    return assignments
 
 
 def _cluster_id(by_source_id: dict[str, dict], source_id: str) -> str | None:
-    """Return the dup_cluster_id for *source_id*, or None if it has no attr row (singleton)."""
+    """Return the accepted dup cluster for *source_id*, or None if it was retained."""
     row = by_source_id.get(source_id)
     return row["attributes"]["dup_cluster_id"] if row else None
 
 
 @pytest.mark.data_integration
-def test_html_parser_variants_cluster_per_article(tmp_path: Path, parser_variants_docs, parser_variants_articles):
-    """Trafilatura and readability outputs of one Wikipedia article cluster.
+def test_html_parser_variants_do_not_cross_cluster_articles(
+    tmp_path: Path, parser_variants_docs, parser_variants_articles
+):
+    """Accepted parser-variant pairs never cross article boundaries.
 
-    Pinning current pipeline behavior on the HF-hosted fixtures: at the default
-    MinHash params (num_perms=286, num_bands=26), trafilatura and readability
-    extract sufficiently similar text from the same page (measured char-Jaccard
-    ~0.89 on these fixtures) to share an LSH bucket and end up in the same
-    dup_cluster_id. Cross-article pairs do not cluster (~0.22).
-
-    The html2text variant is intentionally NOT asserted here; see
-    ``test_html_parser_variants_all_three_cluster_per_article`` for the gap.
+    The exact verifier intentionally retains same-article parser variants when
+    each extraction carries unique token 3-grams. Any pair it does accept must
+    still consist only of renderings of the same article.
     """
     by_source_id = _run_dedup_on_corpus(tmp_path, parser_variants_docs)
     assert parser_variants_articles, "no parser-variant fixtures discovered"
 
-    article_to_cluster: dict[str, str] = {}
-    for article in parser_variants_articles:
-        traf_id = f"{article}__trafilatura"
-        read_id = f"{article}__readability"
-        traf_cluster = _cluster_id(by_source_id, traf_id)
-        read_cluster = _cluster_id(by_source_id, read_id)
-        assert traf_cluster is not None, f"{traf_id} has no attr row (unexpected singleton)"
-        assert read_cluster is not None, f"{read_id} has no attr row (unexpected singleton)"
-        assert (
-            traf_cluster == read_cluster
-        ), f"{article}: trafilatura ({traf_cluster!r}) and readability ({read_cluster!r}) did not cluster together"
-        article_to_cluster[article] = traf_cluster
-
-    cluster_ids = list(article_to_cluster.values())
-    assert len(set(cluster_ids)) == len(
-        cluster_ids
-    ), f"distinct articles ended up in the same cluster: {article_to_cluster}"
+    articles_by_cluster: dict[str, set[str]] = {}
+    for source_id, row in by_source_id.items():
+        article, _ = source_id.rsplit("__", 1)
+        cluster_id = row["attributes"]["dup_cluster_id"]
+        articles_by_cluster.setdefault(cluster_id, set()).add(article)
+    assert all(len(articles) == 1 for articles in articles_by_cluster.values()), articles_by_cluster
 
 
 @pytest.mark.data_integration
 @pytest.mark.xfail(
     strict=True,
     reason=(
-        "html2text preserves Wikipedia nav/sidebar/edit-links/citations as inline text. "
-        "The resulting char-Jaccard with trafilatura/readability is ~0.5, below the LSH "
-        "threshold at b=26, r=11, so the pipeline does not cluster these as duplicates "
-        "today. When boilerplate handling improves (pre-strip, threshold tune, or "
-        "extractor-specific cleanup), this xfail flips and the main parser-variant test "
-        "should be tightened to assert all three variants cluster."
+        "Parser outputs preserve different navigation, citation, and boundary text. "
+        "The precision-first exact verifier retains variants with any unique token "
+        "3-grams; a separately evaluated boilerplate policy is needed to merge all three."
     ),
 )
 def test_html_parser_variants_all_three_cluster_per_article(
@@ -627,47 +719,34 @@ def test_same_site_distinct_bodies_do_not_cluster(tmp_path: Path, same_site_dist
 
 
 @pytest.mark.data_integration
-def test_wikipedia_revisions_cluster_per_article(tmp_path: Path, wikipedia_revisions_docs, wikipedia_revisions_articles):
-    """Different temporal captures of one Wikipedia article must cluster.
+def test_wikipedia_revisions_do_not_cross_cluster_articles(
+    tmp_path: Path, wikipedia_revisions_docs, wikipedia_revisions_articles
+):
+    """Accepted temporal-revision pairs never cross article boundaries.
 
-    Recall regression on temporal drift: the dedup pipeline must recognise
-    snapshots of the same URL across years (paragraphs added, citations
-    refreshed) as the same logical document. All rows whose
-    ``article_slug`` matches must share one ``dup_cluster_id``, and rows
-    with different slugs must not cross-cluster.
-
-    Fixture char-Jaccard between same-article revisions measures around
-    0.76-0.85; cross-article around 0.21. The MinHash params keep the
-    same-article pairs reliably above the LSH collision threshold.
+    Revisions with refreshed text are deliberately retained by the
+    precision-first verifier. This regression ensures the verifier never
+    turns shared Wikipedia structure into a cross-article deletion.
     """
     by_source_id = _run_dedup_on_corpus(tmp_path, wikipedia_revisions_docs)
     assert wikipedia_revisions_articles, "no revision fixtures discovered"
 
-    article_to_cluster: dict[str, str] = {}
-    for article in wikipedia_revisions_articles:
-        variants = [sid for sid in by_source_id if sid.startswith(f"{article}__")]
-        assert variants, f"no attr rows for revisions of {article!r} (unexpected singletons)"
-        clusters = {by_source_id[sid]["attributes"]["dup_cluster_id"] for sid in variants}
-        assert len(clusters) == 1, f"{article}: revisions split across clusters: {clusters}"
-        article_to_cluster[article] = clusters.pop()
-
-    cluster_ids = list(article_to_cluster.values())
-    assert len(set(cluster_ids)) == len(cluster_ids), f"distinct articles clustered together: {article_to_cluster}"
+    articles_by_cluster: dict[str, set[str]] = {}
+    for source_id, row in by_source_id.items():
+        article, _ = source_id.rsplit("__", 1)
+        cluster_id = row["attributes"]["dup_cluster_id"]
+        articles_by_cluster.setdefault(cluster_id, set()).add(article)
+    assert all(len(articles) == 1 for articles in articles_by_cluster.values()), articles_by_cluster
 
 
 @pytest.mark.data_integration
-def test_quote_inclusion_clusters_with_host_not_quoted(tmp_path: Path, quote_inclusion_corpus):
-    """A host article with an inserted long quote of another must cluster with the host, not the source.
+def test_quote_inclusion_does_not_remove_quoted_source(tmp_path: Path, quote_inclusion_corpus):
+    """A host article containing a long quote must not remove the quoted source.
 
     Precision regression on citation patterns: a doc that quotes a chunk
-    of another doc should remain distinct from the source unless the
-    quote dominates. Construction at test time keeps the fixture minimal:
-    fetch two real articles A and B; build ``A_with_B_quote`` by
-    splicing ~1500 chars from the middle of B into the middle of A.
-
-    Expected:
-    * cluster(article_a, article_a_with_quote)  — host pair clusters
-    * article_b is a singleton — source not over-merged with the quoter
+    of another doc remains distinct from the source. The exact-subset rule may
+    also retain the host variant because inserting the quote creates boundary
+    token 3-grams; that conservative recall tradeoff is intentional.
     """
     by_doc_id = {r["doc_id"]: r["text"] for r in quote_inclusion_corpus}
     article_a = by_doc_id["article_a"]
@@ -686,15 +765,7 @@ def test_quote_inclusion_clusters_with_host_not_quoted(tmp_path: Path, quote_inc
     ]
     by_source_id = _run_dedup_on_corpus(tmp_path, docs)
 
-    a_cluster = _cluster_id(by_source_id, "article_a")
-    a_with_quote_cluster = _cluster_id(by_source_id, "article_a_with_quote")
     b_cluster = _cluster_id(by_source_id, "article_b")
-
-    assert a_cluster is not None, "article_a should not be a singleton"
-    assert a_with_quote_cluster is not None, "article_a_with_quote should not be a singleton"
-    assert (
-        a_cluster == a_with_quote_cluster
-    ), f"host A and A_with_quote did not cluster: {a_cluster!r} vs {a_with_quote_cluster!r}"
 
     assert b_cluster is None, (
         f"article_b clustered (over-merge with quoter): cluster={b_cluster!r}; "

--- a/tests/processing/classification/deduplication/test_fuzzy_verification.py
+++ b/tests/processing/classification/deduplication/test_fuzzy_verification.py
@@ -1,0 +1,104 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from marin.processing.classification.deduplication.fuzzy_verification import (
+    FuzzyVerificationParams,
+    VerificationRejection,
+    verify_candidate,
+)
+
+
+def test_shorter_contained_member_is_verified():
+    member = "alpha beta gamma delta epsilon zeta eta theta"
+    canonical = f"preface context {member} appendix context"
+
+    result = verify_candidate(member, canonical, FuzzyVerificationParams())
+
+    assert result.accepted
+    assert result.member_containment == 1.0
+    assert result.member_unique_ngrams == 0
+
+
+def test_richer_member_is_retained():
+    canonical = "alpha beta gamma delta epsilon zeta"
+    member = f"{canonical} unique appendix with additional facts"
+
+    result = verify_candidate(member, canonical, FuzzyVerificationParams())
+
+    assert not result.accepted
+    assert result.rejection == VerificationRejection.MEMBER_LONGER
+
+
+def test_default_subset_rule_rejects_templated_mutation():
+    canonical_tokens = [f"shared{index}" for index in range(2_000)]
+    member_tokens = canonical_tokens.copy()
+    for index in (50, 150, 250):
+        member_tokens[index] = f"change{index}"
+    canonical = " ".join(canonical_tokens)
+    member = " ".join(member_tokens)
+
+    result = verify_candidate(member, canonical, FuzzyVerificationParams())
+
+    assert not result.accepted
+    assert result.member_containment >= 0.99
+    assert result.member_unique_ngrams > 4
+    assert result.rejection == VerificationRejection.CONTAINMENT
+
+
+def test_inserted_section_does_not_relax_exact_subset_rule():
+    member = "alpha beta gamma delta epsilon zeta eta theta"
+    canonical = "alpha beta gamma inserted quoted section delta epsilon zeta eta theta"
+
+    result = verify_candidate(member, canonical, FuzzyVerificationParams())
+
+    assert not result.accepted
+    assert result.member_unique_ngrams > 0
+    assert result.rejection == VerificationRejection.CONTAINMENT
+
+
+def test_configurable_novelty_cap_rejects_templated_mutation():
+    canonical_tokens = [f"shared{index}" for index in range(2_000)]
+    member_tokens = canonical_tokens.copy()
+    for index in (50, 150, 250):
+        member_tokens[index] = f"change{index}"
+    params = FuzzyVerificationParams(
+        minimum_member_containment=0.99,
+        maximum_member_unique_ngrams=4,
+    )
+
+    result = verify_candidate(
+        " ".join(member_tokens),
+        " ".join(canonical_tokens),
+        params,
+    )
+
+    assert result.member_containment >= params.minimum_member_containment
+    assert result.member_unique_ngrams > params.maximum_member_unique_ngrams
+    assert result.rejection == VerificationRejection.MEMBER_UNIQUE
+
+
+def test_character_guard_rejects_non_whitespace_false_positive():
+    shared_footer = "共通の著作権表示とナビゲーション"
+    member = f"これは天文学についての異なる長い記事です。{shared_footer}"
+    canonical = f"これは料理と地域製品についての無関係な説明です。{shared_footer}"
+    permissive = FuzzyVerificationParams(
+        minimum_member_containment=0,
+        maximum_member_unique_ngrams=10,
+    )
+
+    result = verify_candidate(member, canonical, permissive)
+
+    assert result.under_tokenized
+    assert result.char_jaccard is not None
+    assert result.char_jaccard < permissive.under_tokenized_minimum_char_jaccard
+    assert result.rejection == VerificationRejection.UNDER_TOKENIZED
+
+
+def test_character_guard_keeps_exact_non_whitespace_copy():
+    text = "空白を含まない同一の日本語文書です。" * 20
+
+    result = verify_candidate(text, text, FuzzyVerificationParams())
+
+    assert result.accepted
+    assert result.under_tokenized
+    assert result.char_jaccard == 1.0


### PR DESCRIPTION
* fixes https://github.com/marin-community/marin/issues/6854
* fixes https://github.com/marin-community/marin/issues/6851
* use word 5-gram MinHash with `26 × 11` LSH only for candidate retrieval
* propose only direct canonical neighbors and retain transitive-only connected-component members
* remove a candidate only when it satisfies the information-preservation rule
  * the member is no longer than the retained canonical
  * every case-folded whitespace token 3-gram in the member occurs in the canonical
  * under-tokenized pairs pass exact full-text character-5 Jaccard at `0.90`
* persist accepted and rejected pair evidence, including exact scores, rejection reasons, source counts, shared buckets, and rule version
* report the effective LSH collision curve and exact-verifier acceptance instead of inferring deletion precision from cluster size
* include shingle kind in the native and artifact APIs, and build checked-out native packages in downstream unit and integration CI
* validate candidate generation on the immutable 115-source, 103,716,988-document DataKit 100B testbed
  * manual review of all 1,018 original evaluator disagreements gives semantic false-positive rates of `63.617%` for the baseline and `52.149%` for the unverified word-shingle treatment
  * MinHash worker CPU falls from `84,007.55` to `24,982.35` seconds on identical item and byte totals
  * original audit: https://github.com/marin-community/marin/issues/6854#issuecomment-5105195439
* select the exact rule on a frozen stratified sample and evaluate all 5,410 resolved treatment pairs
  * `689` true duplicates and one semantic-label false positive
  * `99.855%` precision with a `99.184%` Wilson lower bound and `27.527%` recall
  * the disagreement is an information-preserving exact token/line subset of a longer version of the same page
* score all 155,212 materialized treatment candidates
  * accept `23,362` candidates (`15.052%`)
  * accept `0/1,251` `massive_function_calling`, `0/116` `ir_python`, and `0/2` Project Gutenberg candidates observed in the wipeout sources
  * process 1.55 billion pair characters in `353.53` worker CPU-seconds with a `705 MB` peak worker footprint
* retain measured recall as the primary caveat
  * minimum-ID canonical selection rejects `77,972` candidates because the proposed member is longer
  * longest or highest-quality representative selection needs a separate measured change
  * a production-scale ferry remains the rollout gate
