### PR TITLE
[eval] Preserve Harbor configuration artifacts

### DIFF
--- a/.github/workflows/update-evaluation-config-artifacts.yaml
+++ b/.github/workflows/update-evaluation-config-artifacts.yaml
@@ -1,0 +1,64 @@
+name: Update evaluation configuration artifacts
+
+on:
+  schedule:
+    - cron: "23 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-evaluation-config-artifacts
+  cancel-in-progress: false
+
+jobs:
+  propose-update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v6
+      - name: Download discovery manifests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir artifacts
+          gh release download harbor-config-latest --repo marin-community/harbor \
+            --pattern harbor-config-manifest.json --dir artifacts/harbor
+          gh release download evalchemy-config-latest --repo marin-community/evalchemy \
+            --pattern evalchemy-config-manifest.json --dir artifacts/evalchemy
+      - name: Verify and apply immutable pins
+        run: >-
+          uv run --no-project python scripts/ci/update_evaluation_config_artifacts.py
+          --harbor-manifest artifacts/harbor/harbor-config-manifest.json
+          --evalchemy-manifest artifacts/evalchemy/evalchemy-config-manifest.json
+      - name: Refresh the lock and run the consumer contract
+        run: |
+          if git diff --quiet; then
+            exit 0
+          fi
+          uv lock
+          uv sync --locked --package marin-core
+          uv run --package marin-core pytest tests/evals/test_config_artifacts.py -q
+      - name: Propose the verified update
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if git diff --quiet; then
+            exit 0
+          fi
+          branch="automation/evaluation-config-artifacts-${GITHUB_RUN_ID}"
+          git switch -c "$branch"
+          git add lib/marin/src/marin/evaluation/config_artifacts.py lib/marin/pyproject.toml pyproject.toml uv.lock
+          git commit -m "deps: update evaluation config artifacts"
+          git push --set-upstream origin "$branch"
+          gh pr create \
+            --title "deps: update evaluation config artifacts" \
+            --body "Pins Harbor and Evalchemy configuration resolvers to verified immutable release manifests. The runtime Harbor revision and lockfile are updated together." \
+            --label agent-generated \
+            --base main \
+            --head "$branch"

--- a/experiments/evals/evalchemy/serve_and_eval.py
+++ b/experiments/evals/evalchemy/serve_and_eval.py
@@ -157,6 +157,11 @@ class ServeSpec:
     serve_cpu: float = 8.0
     serve_memory: str = "64g"
     serve_disk: str = "100g"
+    priority: int = 0
+    """Iris priority band for the serving child. ``0`` preserves Iris's normal default for direct
+    callers; the canonical evaluation launcher resolves this explicitly from its launch policy."""
+    max_retries_failure: int = 1
+    """How many Iris worker failures the serving child retries before the eval group gives up."""
     max_num_batched_tokens: int = EVAL_SERVE_MAX_NUM_BATCHED_TOKENS
     """vLLM prefill budget per engine step. The 512 default is conservative: 2048 boots on the current
     TPU stack but prompt-logprobs traffic then kills the engine within minutes."""
@@ -369,6 +374,8 @@ def _shared_inference_config(model: str, tokenizer: str, spec: ServeSpec) -> _In
             worker_resources=resources,
             worker_environment=environment,
             endpoint_ready_timeout_seconds=ENDPOINT_READY_TIMEOUT_SECONDS,
+            priority=spec.priority,
+            max_retries_failure=spec.max_retries_failure,
         ),
         instances=spec.instances,
         broker=spec.broker,

--- a/experiments/evaluation/README.md
+++ b/experiments/evaluation/README.md
@@ -40,6 +40,30 @@ Key options: `--evals` takes a suite name (`smoke`, `core`) or comma-separated e
 sizing heuristic with an exact slice (`v6e-8` or `H100x8`); `--limit` caps eval instances;
 `--records-prefix` and `--cluster` override where records land and which iris cluster to submit to.
 
+## Harbor configuration and override policy
+
+Harbor evals use the same command, selecting a Harbor suite such as `aime-harbor`. The common path
+needs no Harbor file: the suite's named preset supplies conservative defaults. Operators who need a
+different retry policy, Daytona resources, agent harness, timeout, verifier setting, or generation
+budget can pass a complete Harbor YAML/JSON document with `--harbor-config`, then optionally apply a
+structured JSON object with `--harbor-patch`. Both are loaded and validated by the immutable
+`harbor-config` artifact produced from the exact Harbor revision the isolated trial driver executes.
+
+The precedence is deliberate, from lowest to highest:
+
+1. The selected suite's named Harbor preset and its default agent/output settings.
+2. `--harbor-config`, if supplied, replaces that preset with any valid Harbor document.
+3. `--harbor-patch` recursively overlays that document using Harbor's documented semantics (mappings
+   merge; lists replace), so it can override every Harbor policy field.
+4. Explicit launcher selections that define the evaluation itself: `--model`, `--evals`, and `--limit`.
+5. Runtime values that can only be discovered after serving: the generated Harbor job name, durable
+   jobs directory, served model name, and minted endpoint capability URL.
+
+The final layer is intentionally narrow. It does **not** overwrite agent choice, environment,
+resources, attempts, retries, timeouts, verifier policy, task filtering (unless `--limit` is passed),
+or `model_info.max_output_tokens`. A resolved, credential-redacted config plus its Harbor revision,
+schema fingerprint, resolver fingerprint, and SHA-256 is saved beside each run's results.
+
 Suites: `smoke` is a fast cluster check (capped mmlu cut + capped gsm8k). `core` is the comprehensive
 per-model benchmark set (`CORE_EVALS` in `evals.py`: mmlu, gsm8k, arc-challenge, hellaswag,
 winogrande, truthfulqa, boolq, piqa, openbookqa at OpenLLM-v1 shot counts, plus humaneval and

--- a/experiments/evaluation/cli.py
+++ b/experiments/evaluation/cli.py
@@ -10,7 +10,11 @@ rewrites every run's per-sample parquet exports from its kept ``samples_*.jsonl`
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import click
+from harbor_config import load_config_path
 from iris.cli.connect import open_iris_client
 from marin.evaluation.records import CW_RECORDS_PREFIX, DEFAULT_RECORDS_PREFIX, list_records
 from marin.evaluation.samples import export_lm_eval_samples
@@ -45,6 +49,26 @@ def _print_plan(spec: LaunchSpec) -> None:
         )
 
 
+def _load_harbor_document(path: Path | None) -> dict | None:
+    """Read a Harbor YAML/JSON document through the pinned Harbor resolver wheel."""
+    if path is None:
+        return None
+    return load_config_path(path).model_dump(mode="json")
+
+
+def _parse_harbor_patch(value: str | None) -> dict | None:
+    """Require an explicit JSON object so structured launch overrides remain auditable."""
+    if value is None:
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise click.BadParameter(f"--harbor-patch must be JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise click.BadParameter("--harbor-patch must be a JSON object")
+    return parsed
+
+
 @click.group()
 def cli() -> None:
     """Launch and track model evaluations."""
@@ -68,6 +92,17 @@ def cli() -> None:
     help="Human version label for this launch, e.g. '2026.07.20' or 'rl-fix-sweep'.",
 )
 @click.option("--description", default=None, help="Free-text note on why this launch was run.")
+@click.option(
+    "--harbor-config",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="Advanced Harbor YAML/JSON policy; Marin still owns model, dataset, job name, and durable root.",
+)
+@click.option(
+    "--harbor-patch",
+    default=None,
+    help="Advanced JSON object overlaid onto the Harbor policy before Marin's protected runtime wiring.",
+)
 @click.option("--no-wait", is_flag=True, help="Submit and return without waiting for results.")
 @click.option("--dry-run", is_flag=True, help="Print the resolved plan without submitting.")
 @click.option(
@@ -84,6 +119,8 @@ def launch(
     limit: int | None,
     version: str | None,
     description: str | None,
+    harbor_config: Path | None,
+    harbor_patch: str | None,
     no_wait: bool,
     dry_run: bool,
     records_prefix: str | None,
@@ -104,6 +141,8 @@ def launch(
         cluster=cluster,
         version=version,
         description=description,
+        harbor_config_document=_load_harbor_document(harbor_config),
+        harbor_config_patch=_parse_harbor_patch(harbor_patch),
     )
     if dry_run:
         _print_plan(spec)

--- a/experiments/evaluation/cli.py
+++ b/experiments/evaluation/cli.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import click
 from harbor_config import load_config_path
 from iris.cli.connect import open_iris_client
+from iris.rpc.proto_display import PRIORITY_BAND_NAMES, priority_band_value
 from marin.evaluation.records import CW_RECORDS_PREFIX, DEFAULT_RECORDS_PREFIX, list_records
 from marin.evaluation.samples import export_lm_eval_samples
 from rigging.config_discovery import find_project_root
@@ -111,6 +112,21 @@ def cli() -> None:
     help="Object-store prefix for run records; defaults to GCS, or CW S3 for CoreWeave-routed runs.",
 )
 @click.option("--cluster", default="marin", envvar="IRIS_CLUSTER", help="Named iris cluster to submit to.")
+@click.option(
+    "--priority",
+    type=click.Choice(PRIORITY_BAND_NAMES),
+    default="interactive",
+    show_default=True,
+    help="Iris scheduling band applied to the orchestrator and serving child.",
+)
+@click.option(
+    "--max-retries",
+    "max_retries_failure",
+    type=click.IntRange(min=0),
+    default=6,
+    show_default=True,
+    help="Iris failure retries for the orchestrator and serving child.",
+)
 def launch(
     model: str,
     evals_arg: str,
@@ -125,6 +141,8 @@ def launch(
     dry_run: bool,
     records_prefix: str | None,
     cluster: str,
+    priority: str,
+    max_retries_failure: int,
 ) -> None:
     """Submit one serve group for MODEL: serve once, run every selected eval, record each one."""
     if model not in MODELS:
@@ -139,6 +157,8 @@ def launch(
         limit=limit,
         records_prefix=records_prefix,
         cluster=cluster,
+        priority=priority_band_value(priority),
+        max_retries_failure=max_retries_failure,
         version=version,
         description=description,
         harbor_config_document=_load_harbor_document(harbor_config),

--- a/experiments/evaluation/evals.py
+++ b/experiments/evaluation/evals.py
@@ -41,6 +41,8 @@ class HarborSpec:
     n_concurrent: int = 4
     max_output_tokens: int = 8192
     agent_kwargs: dict = field(default_factory=dict)
+    preset: str = "standard"
+    """Named Marin policy preset. Advanced Harbor policy is supplied at launch, not copied here."""
 
 
 @dataclass(frozen=True)

--- a/experiments/evaluation/evals.py
+++ b/experiments/evaluation/evals.py
@@ -189,6 +189,19 @@ EVALS: dict[str, EvalSuiteConfig] = {
         harbor=HarborSpec(dataset="aime", version="1.0", n_concurrent=2),
         max_eval_instances=2,
     ),
+    "grug-opencode-id": EvalSuiteConfig(
+        name="grug-opencode-id",
+        mechanism=EvalMechanism.HARBOR,
+        harbor=HarborSpec(
+            dataset="DCAgent/dev_set_v2",
+            version="1.0",
+            agent="opencode",
+            env="daytona",
+            n_concurrent=256,
+            max_output_tokens=16384,
+            preset="grug-opencode-id",
+        ),
+    ),
 }
 
 # A fast cluster smoke: one small MCQ cut plus a capped gsm8k generation task.

--- a/experiments/evaluation/launch.py
+++ b/experiments/evaluation/launch.py
@@ -31,7 +31,8 @@ from iris.cluster.constraints import CLUSTER_CONSTRAINT_KEY, Constraint, Constra
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec
 from marin.evaluation.eval_env import EVAL_ENV_KEYS, daytona_sdk_env, env_vars_from_keys
 from marin.evaluation.eval_result import EvalchemyResult
-from marin.evaluation.harbor_runner import HarborRunConfig, canonical_served_name, run_harbor_eval
+from marin.evaluation.harbor_config import HarborPolicyDefaults, ResolvedHarborPolicy, resolve_harbor_policy
+from marin.evaluation.harbor_runner import HarborEndpoint, canonical_served_name, run_harbor_eval
 from marin.evaluation.records import (
     CW_RECORDS_PREFIX,
     DEFAULT_RECORDS_PREFIX,
@@ -62,7 +63,7 @@ from experiments.evals.evalchemy.serve_and_eval import (
     run_eval_units,
     serve_model,
 )
-from experiments.evaluation.evals import EVALS, EvalMechanism, EvalSuiteConfig, HarborSpec
+from experiments.evaluation.evals import EVALS, EvalMechanism, EvalSuiteConfig
 from experiments.evaluation.hardware import AcceleratorChoice, Platform, select_accelerator
 from experiments.evaluation.models import MODELS, EvalModelConfig
 
@@ -84,8 +85,8 @@ _ORCHESTRATOR_DISK = "16g"
 class EvalRunParams:
     """One recorded eval within a group: its identity, its durable results path, and its mechanism.
 
-    Exactly one of ``unit`` (evalchemy) or ``harbor`` (Harbor) is set; ``limit`` caps the run's
-    instances for either mechanism.
+    Exactly one of ``unit`` (evalchemy) or ``harbor_policy`` (Harbor) is set. Each mechanism carries
+    its own resolved policy instead of reconstructing a third copy of its schema in this launcher.
     """
 
     run_id: str
@@ -93,10 +94,7 @@ class EvalRunParams:
     out_path: str
     eval_ref: EvalRef
     unit: EvalUnit | None = None
-    harbor: HarborSpec | None = None
-    limit: int | None = None
-    harbor_config_document: dict | None = None
-    harbor_config_patch: dict | None = None
+    harbor_policy: ResolvedHarborPolicy | None = None
 
 
 @dataclass(frozen=True)
@@ -169,7 +167,7 @@ def run_eval_group(params: EvalGroupParams) -> list[str]:
     orchestrator job itself fails at the end if any eval failed.
     """
     configure_coreweave_s3()
-    if any(run.harbor is not None for run in params.runs):
+    if any(run.harbor_policy is not None for run in params.runs):
         return _run_harbor_group(params)
     base_jobs = {"orchestrator": str(iris_ctx().job_id)}
     units = [run.unit for run in params.runs if run.unit is not None]
@@ -248,26 +246,16 @@ def _run_harbor_group(params: EvalGroupParams) -> list[str]:
             api_base = _harbor_api_base(endpoint, params.mint_origin)
             serve_jobs = {"serve": endpoint.job}
             for run in params.runs:
-                assert run.harbor is not None
+                assert run.harbor_policy is not None
                 status = RunStatus.SUCCEEDED
                 error: str | None = None
                 metrics: dict[str, dict[str, float]] = {}
                 try:
                     result = run_harbor_eval(
-                        HarborRunConfig(
-                            dataset=run.harbor.dataset,
-                            version=run.harbor.version,
-                            agent=run.harbor.agent,
+                        run.harbor_policy,
+                        HarborEndpoint(
                             served_model_name=served_name,
                             api_base=api_base,
-                            env=run.harbor.env,
-                            n_concurrent=run.harbor.n_concurrent,
-                            max_output_tokens=run.harbor.max_output_tokens,
-                            task_limit=run.limit,
-                            agent_kwargs=dict(run.harbor.agent_kwargs),
-                            preset=run.harbor.preset,
-                            config_document=run.harbor_config_document,
-                            config_patch=run.harbor_config_patch,
                         ),
                         run.out_path,
                     )
@@ -479,19 +467,44 @@ def _group_params(plans: list[RunPlan], spec: LaunchSpec, provenance: Provenance
         run_id = _run_id(plan.model_key, plan.eval_key)
         out_path = f"{records_prefix.rstrip('/')}/{run_id}/results"
         harbor = plan.suite.harbor
+        harbor_policy = (
+            resolve_harbor_policy(
+                HarborPolicyDefaults(
+                    dataset=harbor.dataset,
+                    version=harbor.version,
+                    agent=harbor.agent,
+                    environment=harbor.env,
+                    n_concurrent_trials=harbor.n_concurrent,
+                    max_output_tokens=harbor.max_output_tokens,
+                    agent_kwargs=harbor.agent_kwargs,
+                    task_limit=plan.suite.max_eval_instances,
+                    preset=harbor.preset,
+                ),
+                document=spec.harbor_config_document,
+                patch=spec.harbor_config_patch,
+                task_limit_override=spec.limit,
+            )
+            if harbor is not None
+            else None
+        )
         eval_ref = EvalRef(
             name=plan.suite.name,
             mechanism=plan.suite.mechanism.value,
             tasks=tuple(EvalTaskRef(name=t.name, num_fewshot=t.num_fewshot) for t in plan.suite.tasks),
             harbor=(
-                HarborRef(dataset=harbor.dataset, version=harbor.version, agent=harbor.agent, env=harbor.env)
-                if harbor is not None
+                HarborRef(
+                    dataset=harbor_policy.dataset,
+                    version=harbor_policy.version,
+                    agent=harbor_policy.agent,
+                    env=harbor_policy.environment,
+                )
+                if harbor_policy is not None
                 else None
             ),
         )
         unit = (
             None
-            if harbor is not None
+            if harbor_policy is not None
             else EvalUnit(
                 name=plan.eval_key,
                 tasks=plan.suite.tasks,
@@ -507,10 +520,7 @@ def _group_params(plans: list[RunPlan], spec: LaunchSpec, provenance: Provenance
                 out_path=out_path,
                 eval_ref=eval_ref,
                 unit=unit,
-                harbor=harbor,
-                limit=plan.limit,
-                harbor_config_document=spec.harbor_config_document,
-                harbor_config_patch=spec.harbor_config_patch,
+                harbor_policy=harbor_policy,
             )
         )
     if len({run.eval_ref.name for run in runs}) != len(runs):

--- a/experiments/evaluation/launch.py
+++ b/experiments/evaluation/launch.py
@@ -95,6 +95,8 @@ class EvalRunParams:
     unit: EvalUnit | None = None
     harbor: HarborSpec | None = None
     limit: int | None = None
+    harbor_config_document: dict | None = None
+    harbor_config_patch: dict | None = None
 
 
 @dataclass(frozen=True)
@@ -263,6 +265,9 @@ def _run_harbor_group(params: EvalGroupParams) -> list[str]:
                             max_output_tokens=run.harbor.max_output_tokens,
                             task_limit=run.limit,
                             agent_kwargs=dict(run.harbor.agent_kwargs),
+                            preset=run.harbor.preset,
+                            config_document=run.harbor_config_document,
+                            config_patch=run.harbor_config_patch,
                         ),
                         run.out_path,
                     )
@@ -327,6 +332,8 @@ class LaunchSpec:
     cluster: str
     version: str | None = None
     description: str | None = None
+    harbor_config_document: dict | None = None
+    harbor_config_patch: dict | None = None
 
 
 @dataclass(frozen=True)
@@ -399,6 +406,10 @@ def plan_runs(spec: LaunchSpec) -> list[RunPlan]:
     mechanisms = {EVALS[eval_key].mechanism for eval_key in spec.evals}
     if len(mechanisms) > 1:
         raise ValueError(f"a launch group must be one mechanism, got {sorted(m.value for m in mechanisms)}")
+    if (spec.harbor_config_document is not None or spec.harbor_config_patch is not None) and mechanisms != {
+        EvalMechanism.HARBOR
+    }:
+        raise ValueError("--harbor-config/--harbor-patch require a Harbor eval suite")
     plans: list[RunPlan] = []
     for eval_key in spec.evals:
         suite = EVALS[eval_key]
@@ -498,6 +509,8 @@ def _group_params(plans: list[RunPlan], spec: LaunchSpec, provenance: Provenance
                 unit=unit,
                 harbor=harbor,
                 limit=plan.limit,
+                harbor_config_document=spec.harbor_config_document,
+                harbor_config_patch=spec.harbor_config_patch,
             )
         )
     if len({run.eval_ref.name for run in runs}) != len(runs):

--- a/experiments/evaluation/launch.py
+++ b/experiments/evaluation/launch.py
@@ -29,6 +29,7 @@ from iris.client import IrisClient, Job, iris_ctx
 from iris.cluster.config import load_config
 from iris.cluster.constraints import CLUSTER_CONSTRAINT_KEY, Constraint, ConstraintOp
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec
+from iris.rpc.proto_display import priority_band_value
 from marin.evaluation.eval_env import EVAL_ENV_KEYS, daytona_sdk_env, env_vars_from_keys
 from marin.evaluation.eval_result import EvalchemyResult
 from marin.evaluation.harbor_config import HarborPolicyDefaults, ResolvedHarborPolicy, resolve_harbor_policy
@@ -318,6 +319,11 @@ class LaunchSpec:
     limit: int | None
     records_prefix: str | None
     cluster: str
+    priority: int = priority_band_value("interactive")
+    """Iris priority band for the orchestrator and its serving child. Explicitly interactive by
+    default, rather than relying on Iris's controller-side default."""
+    max_retries_failure: int = 6
+    """Iris retry budget for both the orchestrator and serving child."""
     version: str | None = None
     description: str | None = None
     harbor_config_document: dict | None = None
@@ -356,7 +362,9 @@ class SubmittedGroup:
     runs: tuple[GroupRunRef, ...]
 
 
-def _serve_spec(model: EvalModelConfig, accel: AcceleratorChoice) -> ServeSpec:
+def _serve_spec(
+    model: EvalModelConfig, accel: AcceleratorChoice, *, priority: int, max_retries_failure: int
+) -> ServeSpec:
     if accel.platform == Platform.GPU:
         spec = ServeSpec(
             backend=model.backend,
@@ -367,6 +375,8 @@ def _serve_spec(model: EvalModelConfig, accel: AcceleratorChoice) -> ServeSpec:
             region=accel.region,
             vllm_extra_args=model.vllm_extra_args,
             chat_template_content=model.chat_template,
+            priority=priority,
+            max_retries_failure=max_retries_failure,
         )
     else:
         spec = ServeSpec(
@@ -378,6 +388,8 @@ def _serve_spec(model: EvalModelConfig, accel: AcceleratorChoice) -> ServeSpec:
             region=accel.region,
             vllm_extra_args=model.vllm_extra_args,
             chat_template_content=model.chat_template,
+            priority=priority,
+            max_retries_failure=max_retries_failure,
         )
     if model.serve_memory is not None:
         spec = replace(spec, serve_memory=model.serve_memory)
@@ -410,7 +422,12 @@ def plan_runs(spec: LaunchSpec) -> list[RunPlan]:
                 model=model,
                 suite=suite,
                 accel=accel,
-                serve=_serve_spec(model, accel),
+                serve=_serve_spec(
+                    model,
+                    accel,
+                    priority=spec.priority,
+                    max_retries_failure=spec.max_retries_failure,
+                ),
                 limit=limit,
             )
         )
@@ -592,7 +609,8 @@ def launch_group(spec: LaunchSpec, client: IrisClient) -> SubmittedGroup:
         ),
         environment=EnvironmentSpec(env_vars=env_vars_from_keys(EVAL_ENV_KEYS) | daytona_sdk_env()),
         constraints=constraints,
-        max_retries_failure=0,
+        max_retries_failure=spec.max_retries_failure,
+        priority_band=spec.priority,
     )
     logger.info("submitted eval group %s (%d evals) as job %s", params.group_id, len(params.runs), job)
     return SubmittedGroup(

--- a/lib/marin/pyproject.toml
+++ b/lib/marin/pyproject.toml
@@ -9,6 +9,10 @@ version = "0.2.0"
 
 requires-python = ">=3.12"
 dependencies = [
+    # BEGIN GENERATED CONFIG ARTIFACT DEPENDENCIES
+    "harbor-config @ https://github.com/marin-community/harbor/releases/download/harbor-config-95dcdfd3f1f2fdc745b15f9ca411755abc6734c5/harbor_config-0.1.0-py3-none-any.whl#sha256=eebfe87f7a0408c0540f0e633822158b45a2f95933fa1e19cf13b41c498777f9",
+    "evalchemy-config @ https://github.com/marin-community/evalchemy/releases/download/evalchemy-config-12a73251f540428e8ea01cdeefa2611d2344a8f266b4c2c38a181de5106c3b24/evalchemy_config-0.1.0-py3-none-any.whl#sha256=ef95d211e9f4bf5a6b8dec7bd3436b3cda88e685096587b9ae7cd06e59dfae00",
+    # END GENERATED CONFIG ARTIFACT DEPENDENCIES
     # Provides the compression.zstd module that fsspec imports to register its
     # zstd codec on Python < 3.14; required for reading/writing zstd via fsspec.
     "backports-zstd>=1.0.0; python_version < '3.14'",

--- a/lib/marin/src/marin/evaluation/config_artifacts.py
+++ b/lib/marin/src/marin/evaluation/config_artifacts.py
@@ -1,0 +1,64 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pinned configuration artifacts consumed by Marin's evaluation launchers.
+
+The lightweight resolver wheels validate mechanism-specific configuration in Marin's normal
+environment. The Harbor runtime remains isolated, but is pinned to the resolver's parent commit so
+the job that executes a resolved configuration cannot drift from the job that validated it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ConfigArtifact:
+    """An immutable resolver wheel and the upstream source revision that produced it."""
+
+    package: str
+    repository: str
+    revision: str
+    release_tag: str
+    wheel_url: str
+    wheel_sha256: str
+    schema_fingerprint: str
+    resolver_fingerprint: str | None = None
+
+    @property
+    def wheel_requirement(self) -> str:
+        """Return the hash-pinned PEP 508 dependency used by Marin's lockfile."""
+        return f"{self.package} @ {self.wheel_url}#sha256={self.wheel_sha256}"
+
+    @property
+    def source_requirement(self) -> str:
+        """Return the matching source requirement for an isolated upstream runtime."""
+        return f"{self.package.removesuffix('-config')} @ git+https://github.com/{self.repository}.git@{self.revision}"
+
+
+# BEGIN GENERATED CONFIG ARTIFACT PINS
+HARBOR_CONFIG = ConfigArtifact(
+    package="harbor-config",
+    repository="marin-community/harbor",
+    revision="95dcdfd3f1f2fdc745b15f9ca411755abc6734c5",
+    release_tag="harbor-config-95dcdfd3f1f2fdc745b15f9ca411755abc6734c5",
+    wheel_url="https://github.com/marin-community/harbor/releases/download/harbor-config-95dcdfd3f1f2fdc745b15f9ca411755abc6734c5/harbor_config-0.1.0-py3-none-any.whl",
+    wheel_sha256="eebfe87f7a0408c0540f0e633822158b45a2f95933fa1e19cf13b41c498777f9",
+    schema_fingerprint="22029cc681d1ce38c9b647ee088a28f2f9c8a1425d1ba6b52f4f0912cfd9fb83",
+    resolver_fingerprint="714196edd02467f2e53c6b3b12c6ce05cf4c77e4db5fa856faa61e614c491fc6",
+)
+
+EVALCHEMY_CONFIG = ConfigArtifact(
+    package="evalchemy-config",
+    repository="marin-community/evalchemy",
+    revision="3aac962b462751ea6097cde7b9c6a61663c21029",
+    release_tag="evalchemy-config-12a73251f540428e8ea01cdeefa2611d2344a8f266b4c2c38a181de5106c3b24",
+    wheel_url="https://github.com/marin-community/evalchemy/releases/download/evalchemy-config-12a73251f540428e8ea01cdeefa2611d2344a8f266b4c2c38a181de5106c3b24/evalchemy_config-0.1.0-py3-none-any.whl",
+    wheel_sha256="ef95d211e9f4bf5a6b8dec7bd3436b3cda88e685096587b9ae7cd06e59dfae00",
+    schema_fingerprint="12a73251f540428e8ea01cdeefa2611d2344a8f266b4c2c38a181de5106c3b24",
+)
+# END GENERATED CONFIG ARTIFACT PINS

--- a/lib/marin/src/marin/evaluation/harbor_config.py
+++ b/lib/marin/src/marin/evaluation/harbor_config.py
@@ -1,0 +1,188 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve Harbor evaluation presets through Harbor's pinned configuration artifact.
+
+Marin owns evaluation intent and runtime wiring; Harbor owns the schema and semantics of a
+``JobConfig``.  Normal launches choose a compact named preset.  Advanced operators can provide a
+complete Harbor document and/or a structured overlay, but Marin always supplies the served endpoint,
+dataset identity, durable job root, and generated job name.  That boundary keeps a launch flexible
+without allowing a stale hand-written Marin schema to diverge from Harbor.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from harbor_config import apply_overlay, canonical_json, load_config_document
+
+from marin.evaluation.config_artifacts import HARBOR_CONFIG
+
+DEFAULT_HARBOR_PRESET = "standard"
+
+
+@dataclass(frozen=True)
+class HarborRuntime:
+    """Values that must be supplied by the serving/orchestration layer, not a user preset."""
+
+    job_name: str
+    jobs_dir: str
+    dataset: str
+    version: str
+    task_limit: int | None
+    served_model_name: str
+    api_base: str
+
+
+@dataclass(frozen=True)
+class ResolvedHarborConfig:
+    """A validated Harbor job document plus immutable provenance for its artifact."""
+
+    document: dict[str, Any]
+    canonical: bytes
+    sha256: str
+
+    def persisted_metadata(self) -> dict[str, Any]:
+        """Return safe provenance for the durable eval output (without capability credentials)."""
+        return {
+            "harbor_revision": HARBOR_CONFIG.revision,
+            "release_tag": HARBOR_CONFIG.release_tag,
+            "schema_fingerprint": HARBOR_CONFIG.schema_fingerprint,
+            "resolver_fingerprint": HARBOR_CONFIG.resolver_fingerprint,
+            "config_sha256": self.sha256,
+            "job_config": _redact_runtime_secrets(self.document),
+        }
+
+
+def resolve_harbor_config(
+    *,
+    preset: str,
+    n_concurrent: int,
+    agent: str,
+    environment: str,
+    default_max_output_tokens: int,
+    agent_kwargs: Mapping[str, Any],
+    runtime: HarborRuntime,
+    document: Mapping[str, Any] | None = None,
+    patch: Mapping[str, Any] | None = None,
+) -> ResolvedHarborConfig:
+    """Validate a named or supplied Harbor document and apply Marin's protected runtime overlay.
+
+    ``document`` and ``patch`` deliberately retain the whole Harbor schema: retry policy, sandbox
+    resources, timeouts, verifier policy, agent choice, and generation budget are Harbor concerns.
+    The caller cannot redirect a run to a different served model/dataset or leak a stale jobs
+    directory, because those runtime-owned fields are reapplied after the operator's document is
+    validated.
+    """
+    base = load_config_document(
+        dict(document) if document is not None else _preset_document(preset, n_concurrent, agent, environment)
+    )
+    if patch is not None:
+        base = apply_overlay(base, dict(patch))
+    resolved = load_config_document(
+        _apply_runtime_overlay(base.model_dump(mode="json"), agent_kwargs, default_max_output_tokens, runtime)
+    )
+    canonical = canonical_json(resolved)
+    return ResolvedHarborConfig(
+        document=resolved.model_dump(mode="json"),
+        canonical=canonical,
+        sha256=hashlib.sha256(canonical).hexdigest(),
+    )
+
+
+def _preset_document(preset: str, n_concurrent: int, agent: str, environment: str) -> dict[str, Any]:
+    """Return a compact named preset; additions here are Marin product policy, not YAML copies."""
+    if preset != DEFAULT_HARBOR_PRESET:
+        raise ValueError(f"unknown Harbor preset {preset!r}; available presets: {DEFAULT_HARBOR_PRESET!r}")
+    return {
+        "n_concurrent_trials": n_concurrent,
+        "environment": {"type": environment},
+        "agents": [{"name": agent}],
+        "datasets": [{"name": "aime", "version": "1.0"}],
+    }
+
+
+def _apply_runtime_overlay(
+    base: dict[str, Any],
+    agent_kwargs: Mapping[str, Any],
+    default_max_output_tokens: int,
+    runtime: HarborRuntime,
+) -> dict[str, Any]:
+    """Preserve policy from a supplied document while replacing launcher-owned execution wiring."""
+    agents = base.get("agents")
+    datasets = base.get("datasets")
+    if not isinstance(agents, list) or len(agents) != 1:
+        raise ValueError("a Marin Harbor launch requires exactly one agent in its resolved document")
+    if not isinstance(datasets, list) or len(datasets) != 1:
+        raise ValueError("a Marin Harbor launch requires exactly one dataset in its resolved document")
+
+    agent = dict(agents[0])
+    existing_kwargs = agent.get("kwargs") or {}
+    if not isinstance(existing_kwargs, Mapping):
+        raise ValueError("Harbor agent kwargs must be a mapping")
+    if not isinstance(existing_kwargs.get("model_info") or {}, Mapping):
+        raise ValueError("Harbor agent kwargs.model_info must be a mapping")
+    runtime_kwargs = _deep_merge(
+        {
+            "model_info": {
+                "max_input_tokens": 32768,
+                "max_output_tokens": default_max_output_tokens,
+                "input_cost_per_token": 0.0,
+                "output_cost_per_token": 0.0,
+            }
+        },
+        agent_kwargs,
+    )
+    runtime_kwargs = _deep_merge(runtime_kwargs, dict(existing_kwargs))
+    runtime_kwargs["api_base"] = runtime.api_base
+    agent.update(
+        {
+            "model_name": f"hosted_vllm/{runtime.served_model_name}",
+            "kwargs": runtime_kwargs,
+        }
+    )
+
+    dataset = dict(datasets[0])
+    # A Marin suite is a registry dataset. Remove mutually exclusive local/package identities before
+    # restoring the selected registry identity, while preserving registry URL/cache/filter controls.
+    dataset.pop("path", None)
+    dataset.pop("ref", None)
+    dataset.update({"name": runtime.dataset, "version": runtime.version})
+    if runtime.task_limit is not None:
+        dataset["n_tasks"] = runtime.task_limit
+
+    resolved = dict(base)
+    resolved.update(
+        {"job_name": runtime.job_name, "jobs_dir": runtime.jobs_dir, "agents": [agent], "datasets": [dataset]}
+    )
+    return resolved
+
+
+def _deep_merge(base: dict[str, Any], overlay: Mapping[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in overlay.items():
+        if isinstance(merged.get(key), Mapping) and isinstance(value, Mapping):
+            merged[key] = _deep_merge(dict(merged[key]), value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def _redact_runtime_secrets(value: Any, key: str = "") -> Any:
+    """Keep a useful durable config record without retaining credential-bearing capability URLs."""
+    normalized_key = key.lower()
+    if normalized_key == "api_base" or any(
+        marker in normalized_key for marker in ("api_key", "token", "password", "secret")
+    ):
+        return "<redacted>"
+    if isinstance(value, Mapping):
+        return {name: _redact_runtime_secrets(item, name) for name, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_runtime_secrets(item) for item in value]
+    return value

--- a/lib/marin/src/marin/evaluation/harbor_config.py
+++ b/lib/marin/src/marin/evaluation/harbor_config.py
@@ -1,16 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright The Marin Authors
-# SPDX-License-Identifier: Apache-2.0
+"""Artifact-backed Harbor policy resolution and the deliberately narrow runtime binding.
 
-"""Resolve Harbor evaluation presets through Harbor's pinned configuration artifact.
-
-Marin owns evaluation intent and runtime wiring; Harbor owns the schema and semantics of a
-``JobConfig``.  Normal launches choose a compact named preset.  Advanced operators can provide a
-complete Harbor document and/or a structured overlay, but Marin always supplies the served endpoint,
-dataset identity, durable job root, and generated job name.  That boundary keeps a launch flexible
-without allowing a stale hand-written Marin schema to diverge from Harbor.
+Harbor's configuration artifact owns every Harbor policy field. Marin resolves that document once
+at launch time, then the runner binds only facts that do not exist until it has a live served
+endpoint and a durable job directory. This keeps the runner from becoming a second ``JobConfig``.
 """
 
 from __future__ import annotations
@@ -18,150 +13,206 @@ from __future__ import annotations
 import hashlib
 from collections.abc import Mapping
 from dataclasses import dataclass
+from importlib.resources import as_file, files
 from typing import Any
 
-from harbor_config import apply_overlay, canonical_json, load_config_document
+from harbor_config import apply_overlay, canonical_json, load_config_document, load_config_path
 
 from marin.evaluation.config_artifacts import HARBOR_CONFIG
 
 DEFAULT_HARBOR_PRESET = "standard"
+GRUG_OPENCODE_ID_PRESET = "grug-opencode-id"
+_HARBOR_PRESET_FILES = {GRUG_OPENCODE_ID_PRESET: "harbor_profiles/grug-opencode-id.yaml"}
 
 
 @dataclass(frozen=True)
-class HarborRuntime:
-    """Values that must be supplied by the serving/orchestration layer, not a user preset."""
+class HarborPolicyDefaults:
+    """The compact defaults behind a named Marin Harbor suite, consumed only during resolution."""
+
+    dataset: str
+    version: str
+    agent: str
+    environment: str
+    n_concurrent_trials: int
+    max_output_tokens: int
+    agent_kwargs: Mapping[str, Any]
+    task_limit: int | None = None
+    preset: str = DEFAULT_HARBOR_PRESET
+
+
+@dataclass(frozen=True)
+class HarborRuntimeBinding:
+    """Values unavailable before the runner has created a job and served the model."""
 
     job_name: str
     jobs_dir: str
-    dataset: str
-    version: str
-    task_limit: int | None
     served_model_name: str
     api_base: str
 
 
 @dataclass(frozen=True)
-class ResolvedHarborConfig:
-    """A validated Harbor job document plus immutable provenance for its artifact."""
+class ResolvedHarborPolicy:
+    """A complete, artifact-validated Harbor policy before endpoint-specific binding."""
 
     document: dict[str, Any]
     canonical: bytes
     sha256: str
 
+    @property
+    def dataset(self) -> str:
+        return str(self.document["datasets"][0]["name"])
+
+    @property
+    def version(self) -> str | None:
+        value = self.document["datasets"][0].get("version")
+        return str(value) if value is not None else None
+
+    @property
+    def agent(self) -> str:
+        value = self.document["agents"][0].get("name")
+        if value is None:
+            raise ValueError("a Marin Harbor policy requires a named agent")
+        return str(value)
+
+    @property
+    def environment(self) -> str:
+        value = self.document.get("environment", {}).get("type")
+        if value is None:
+            raise ValueError("a Marin Harbor policy requires an environment type")
+        return str(value)
+
+    def bind(self, runtime: HarborRuntimeBinding) -> BoundHarborConfig:
+        """Apply only endpoint/job facts, then revalidate through Harbor's artifact schema."""
+        agents = self.document.get("agents")
+        if not isinstance(agents, list) or len(agents) != 1:
+            raise ValueError("a Marin Harbor launch requires exactly one agent in its resolved policy")
+        agent = dict(agents[0])
+        kwargs = agent.get("kwargs") or {}
+        if not isinstance(kwargs, Mapping):
+            raise ValueError("Harbor agent kwargs must be a mapping")
+        agent["model_name"] = f"hosted_vllm/{runtime.served_model_name}"
+        agent["kwargs"] = _deep_merge(dict(kwargs), {"api_base": runtime.api_base})
+        bound = dict(self.document)
+        bound.update({"job_name": runtime.job_name, "jobs_dir": runtime.jobs_dir, "agents": [agent]})
+        config = load_config_document(bound)
+        canonical = canonical_json(config)
+        return BoundHarborConfig(
+            document=config.model_dump(mode="json"),
+            policy_sha256=self.sha256,
+            sha256=hashlib.sha256(canonical).hexdigest(),
+        )
+
+
+@dataclass(frozen=True)
+class BoundHarborConfig:
+    """The exact driver input plus safe provenance for durable eval artifacts."""
+
+    document: dict[str, Any]
+    policy_sha256: str
+    sha256: str
+
     def persisted_metadata(self) -> dict[str, Any]:
-        """Return safe provenance for the durable eval output (without capability credentials)."""
         return {
             "harbor_revision": HARBOR_CONFIG.revision,
             "release_tag": HARBOR_CONFIG.release_tag,
             "schema_fingerprint": HARBOR_CONFIG.schema_fingerprint,
             "resolver_fingerprint": HARBOR_CONFIG.resolver_fingerprint,
-            "config_sha256": self.sha256,
+            "policy_sha256": self.policy_sha256,
+            "bound_config_sha256": self.sha256,
             "job_config": _redact_runtime_secrets(self.document),
         }
 
 
-def resolve_harbor_config(
+def resolve_harbor_policy(
+    defaults: HarborPolicyDefaults,
     *,
-    preset: str,
-    n_concurrent: int,
-    agent: str,
-    environment: str,
-    default_max_output_tokens: int,
-    agent_kwargs: Mapping[str, Any],
-    runtime: HarborRuntime,
     document: Mapping[str, Any] | None = None,
     patch: Mapping[str, Any] | None = None,
-) -> ResolvedHarborConfig:
-    """Validate a named or supplied Harbor document and apply Marin's protected runtime overlay.
+    task_limit_override: int | None = None,
+) -> ResolvedHarborPolicy:
+    """Resolve one complete Harbor policy without re-declaring Harbor's schema in Marin.
 
-    ``document`` and ``patch`` deliberately retain the whole Harbor schema: retry policy, sandbox
-    resources, timeouts, verifier policy, agent choice, and generation budget are Harbor concerns.
-    The caller cannot redirect a run to a different served model/dataset or leak a stale jobs
-    directory, because those runtime-owned fields are reapplied after the operator's document is
-    validated.
+    A supplied document replaces the named preset; a Harbor-native patch then overrides any policy
+    field. The selected suite's dataset identity is deliberately applied after that policy layer,
+    because ``--evals`` is the launch's explicit benchmark selection rather than a hidden YAML
+    default. ``--limit`` is similarly an explicit selection-level task cap.
     """
-    base = load_config_document(
-        dict(document) if document is not None else _preset_document(preset, n_concurrent, agent, environment)
-    )
+    base = load_config_document(dict(document) if document is not None else _preset_document(defaults))
     if patch is not None:
         base = apply_overlay(base, dict(patch))
-    resolved = load_config_document(
-        _apply_runtime_overlay(base.model_dump(mode="json"), agent_kwargs, default_max_output_tokens, runtime)
-    )
-    canonical = canonical_json(resolved)
-    return ResolvedHarborConfig(
-        document=resolved.model_dump(mode="json"),
+    selected_limit = task_limit_override if task_limit_override is not None else defaults.task_limit
+    config = load_config_document(_apply_selection(base.model_dump(mode="json"), defaults, selected_limit))
+    _require_single_agent_and_dataset(config.model_dump(mode="json"))
+    canonical = canonical_json(config)
+    return ResolvedHarborPolicy(
+        document=config.model_dump(mode="json"),
         canonical=canonical,
         sha256=hashlib.sha256(canonical).hexdigest(),
     )
 
 
-def _preset_document(preset: str, n_concurrent: int, agent: str, environment: str) -> dict[str, Any]:
-    """Return a compact named preset; additions here are Marin product policy, not YAML copies."""
-    if preset != DEFAULT_HARBOR_PRESET:
-        raise ValueError(f"unknown Harbor preset {preset!r}; available presets: {DEFAULT_HARBOR_PRESET!r}")
-    return {
-        "n_concurrent_trials": n_concurrent,
-        "environment": {"type": environment},
-        "agents": [{"name": agent}],
-        "datasets": [{"name": "aime", "version": "1.0"}],
-    }
-
-
-def _apply_runtime_overlay(
-    base: dict[str, Any],
-    agent_kwargs: Mapping[str, Any],
-    default_max_output_tokens: int,
-    runtime: HarborRuntime,
-) -> dict[str, Any]:
-    """Preserve policy from a supplied document while replacing launcher-owned execution wiring."""
-    agents = base.get("agents")
-    datasets = base.get("datasets")
-    if not isinstance(agents, list) or len(agents) != 1:
-        raise ValueError("a Marin Harbor launch requires exactly one agent in its resolved document")
-    if not isinstance(datasets, list) or len(datasets) != 1:
-        raise ValueError("a Marin Harbor launch requires exactly one dataset in its resolved document")
-
-    agent = dict(agents[0])
-    existing_kwargs = agent.get("kwargs") or {}
-    if not isinstance(existing_kwargs, Mapping):
-        raise ValueError("Harbor agent kwargs must be a mapping")
-    if not isinstance(existing_kwargs.get("model_info") or {}, Mapping):
-        raise ValueError("Harbor agent kwargs.model_info must be a mapping")
-    runtime_kwargs = _deep_merge(
+def _preset_document(defaults: HarborPolicyDefaults) -> dict[str, Any]:
+    if defaults.preset in _HARBOR_PRESET_FILES:
+        resource = files("marin.evaluation").joinpath(_HARBOR_PRESET_FILES[defaults.preset])
+        with as_file(resource) as path:
+            return load_config_path(path).model_dump(mode="json")
+    if defaults.preset != DEFAULT_HARBOR_PRESET:
+        available = (DEFAULT_HARBOR_PRESET, *_HARBOR_PRESET_FILES)
+        raise ValueError(f"unknown Harbor preset {defaults.preset!r}; available presets: {available!r}")
+    agent_kwargs = _deep_merge(
         {
             "model_info": {
                 "max_input_tokens": 32768,
-                "max_output_tokens": default_max_output_tokens,
+                "max_output_tokens": defaults.max_output_tokens,
                 "input_cost_per_token": 0.0,
                 "output_cost_per_token": 0.0,
             }
         },
-        agent_kwargs,
+        defaults.agent_kwargs,
     )
-    runtime_kwargs = _deep_merge(runtime_kwargs, dict(existing_kwargs))
-    runtime_kwargs["api_base"] = runtime.api_base
-    agent.update(
-        {
-            "model_name": f"hosted_vllm/{runtime.served_model_name}",
-            "kwargs": runtime_kwargs,
-        }
-    )
+    return {
+        "n_concurrent_trials": defaults.n_concurrent_trials,
+        "environment": {"type": defaults.environment},
+        "agents": [
+            {
+                "name": defaults.agent,
+                "kwargs": agent_kwargs,
+            }
+        ],
+        "datasets": [
+            {
+                "name": defaults.dataset,
+                "version": defaults.version,
+                "n_tasks": defaults.task_limit,
+            }
+        ],
+    }
 
+
+def _apply_selection(
+    document: dict[str, Any], defaults: HarborPolicyDefaults, task_limit_override: int | None
+) -> dict[str, Any]:
+    datasets = document.get("datasets")
+    if not isinstance(datasets, list) or len(datasets) != 1:
+        raise ValueError("a Marin Harbor launch requires exactly one dataset in its resolved policy")
     dataset = dict(datasets[0])
-    # A Marin suite is a registry dataset. Remove mutually exclusive local/package identities before
-    # restoring the selected registry identity, while preserving registry URL/cache/filter controls.
     dataset.pop("path", None)
     dataset.pop("ref", None)
-    dataset.update({"name": runtime.dataset, "version": runtime.version})
-    if runtime.task_limit is not None:
-        dataset["n_tasks"] = runtime.task_limit
+    dataset.update({"name": defaults.dataset, "version": defaults.version})
+    if task_limit_override is not None:
+        dataset["n_tasks"] = task_limit_override
+    selected = dict(document)
+    selected["datasets"] = [dataset]
+    return selected
 
-    resolved = dict(base)
-    resolved.update(
-        {"job_name": runtime.job_name, "jobs_dir": runtime.jobs_dir, "agents": [agent], "datasets": [dataset]}
-    )
-    return resolved
+
+def _require_single_agent_and_dataset(document: Mapping[str, Any]) -> None:
+    agents = document.get("agents")
+    datasets = document.get("datasets")
+    if not isinstance(agents, list) or len(agents) != 1:
+        raise ValueError("a Marin Harbor launch requires exactly one agent in its resolved policy")
+    if not isinstance(datasets, list) or len(datasets) != 1:
+        raise ValueError("a Marin Harbor launch requires exactly one dataset in its resolved policy")
 
 
 def _deep_merge(base: dict[str, Any], overlay: Mapping[str, Any]) -> dict[str, Any]:
@@ -175,7 +226,6 @@ def _deep_merge(base: dict[str, Any], overlay: Mapping[str, Any]) -> dict[str, A
 
 
 def _redact_runtime_secrets(value: Any, key: str = "") -> Any:
-    """Keep a useful durable config record without retaining credential-bearing capability URLs."""
     normalized_key = key.lower()
     if normalized_key == "api_base" or any(
         marker in normalized_key for marker in ("api_key", "token", "password", "secret")

--- a/lib/marin/src/marin/evaluation/harbor_profiles/grug-opencode-id.yaml
+++ b/lib/marin/src/marin/evaluation/harbor_profiles/grug-opencode-id.yaml
@@ -1,0 +1,57 @@
+# Harbor policy for the Grug OpenCode ID suite. Marin owns the selected dataset, the unique job
+# directory, and the served endpoint binding; this file owns the stable Harbor trial contract.
+job_name: grug-opencode-id
+jobs_dir: trace_jobs
+n_attempts: 3
+timeout_multiplier: 2.0
+debug: false
+n_concurrent_trials: 256
+quiet: false
+retry:
+  max_retries: 6
+  exclude_exceptions:
+    - AgentTimeoutError
+    - AgentEnvironmentTimeoutError
+    - VerifierTimeoutError
+    - RewardFileNotFoundError
+    - RewardFileEmptyError
+    - VerifierOutputParseError
+    - SandboxBuildFailedError
+    - VerifierRuntimeError
+    - SummarizationTimeoutError
+    - ContextLengthExceededError
+  wait_multiplier: 2.0
+  min_wait_sec: 1.0
+  max_wait_sec: 90.0
+environment:
+  type: daytona
+  force_build: true
+  delete: true
+  override_cpus: 2
+  override_memory_mb: 8192
+  override_storage_mb: 8192
+  kwargs:
+    auto_snapshot: true
+verifier:
+  max_timeout_sec: 14400
+agents:
+  - name: opencode
+    model_name: vllm/override-at-runtime
+    max_timeout_sec: 7200
+    override_setup_timeout_sec: 600
+    kwargs:
+      opencode_config:
+        compaction:
+          auto: false
+      model_info:
+        max_input_tokens: 64512
+        max_output_tokens: 16384
+        input_cost_per_token: 0
+        output_cost_per_token: 0
+      trajectory_config:
+        raw_content: false
+        linear_history: true
+datasets:
+  - name: DCAgent/dev_set_v2
+    version: "1.0"
+tasks: []

--- a/lib/marin/src/marin/evaluation/harbor_runner.py
+++ b/lib/marin/src/marin/evaluation/harbor_runner.py
@@ -26,6 +26,8 @@ from pathlib import Path
 from fsspec.core import url_to_fs
 from rigging.filesystem import StoragePath, is_remote_path, prefix_join
 
+from marin.evaluation.config_artifacts import HARBOR_CONFIG
+from marin.evaluation.harbor_config import HarborRuntime, resolve_harbor_config
 from marin.evaluation.samples import EvalSample, Grading, SampleKind, write_sample_parquet
 from marin.evaluation.utils import download_from_gcs, upload_to_gcs
 
@@ -33,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 # Harbor is run as an external tool in an isolated uv environment (its Daytona SDK carries pre-release
 # pins that do not fit the marin lock). These specs pin what that ephemeral env installs.
-_HARBOR_SPEC = "harbor>=0.8.0"
+_HARBOR_SPEC = HARBOR_CONFIG.source_requirement
 _DAYTONA_SPEC = "daytona>=0.200.1"
 _DRIVER = str(Path(__file__).with_name("harbor_trial_driver.py"))
 
@@ -42,13 +44,6 @@ _DRIVER = str(Path(__file__).with_name("harbor_trial_driver.py"))
 SOLVED_REWARD = 0.99
 
 _CANONICAL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
-
-_DEFAULT_MODEL_INFO = {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.0,
-    "output_cost_per_token": 0.0,
-}
 
 
 @dataclass(frozen=True)
@@ -67,6 +62,9 @@ class HarborRunConfig:
     max_output_tokens: int = 8192
     task_limit: int | None = None
     agent_kwargs: dict = field(default_factory=dict)
+    preset: str = "standard"
+    config_document: dict | None = None
+    config_patch: dict | None = None
 
 
 @dataclass(frozen=True)
@@ -261,23 +259,32 @@ def run_harbor_eval(config: HarborRunConfig, out_path: str) -> HarborRunResult:
         if restored:
             logger.info("restored %d completed Harbor trial(s) from %s", restored, out_path)
 
-    agent_kwargs = dict(config.agent_kwargs)
-    agent_kwargs.setdefault("api_base", config.api_base)
-    agent_kwargs.setdefault("model_info", {**_DEFAULT_MODEL_INFO, "max_output_tokens": config.max_output_tokens})
-    driver_config = {
-        "job_name": job_name,
-        "jobs_dir": str(output_dir),
-        "dataset": config.dataset,
-        "version": config.version,
-        "n_tasks": config.task_limit,
-        "agent": config.agent,
-        "model_name": f"hosted_vllm/{config.served_model_name}",
-        "agent_kwargs": agent_kwargs,
-        "n_concurrent": config.n_concurrent,
-        "env": config.env,
-    }
+    resolved = resolve_harbor_config(
+        preset=config.preset,
+        n_concurrent=config.n_concurrent,
+        agent=config.agent,
+        environment=config.env,
+        default_max_output_tokens=config.max_output_tokens,
+        agent_kwargs=config.agent_kwargs,
+        runtime=HarborRuntime(
+            job_name=job_name,
+            jobs_dir=str(output_dir),
+            dataset=config.dataset,
+            version=config.version,
+            task_limit=config.task_limit,
+            served_model_name=config.served_model_name,
+            api_base=config.api_base,
+        ),
+        document=config.config_document,
+        patch=config.config_patch,
+    )
+    driver_config = {"job_config": resolved.document}
     config_file = workdir / "driver_config.json"
     config_file.write_text(json.dumps(driver_config))
+    config_file.chmod(0o600)
+    StoragePath(prefix_join(out_path, "harbor_config.json")).write_text(
+        json.dumps(resolved.persisted_metadata(), indent=2, sort_keys=True)
+    )
 
     logger.info("starting Harbor job %s (dataset=%s env=%s)", job_name, config.dataset, config.env)
     _run_driver(config_file)

--- a/lib/marin/src/marin/evaluation/harbor_runner.py
+++ b/lib/marin/src/marin/evaluation/harbor_runner.py
@@ -20,14 +20,14 @@ import logging
 import os
 import re
 import subprocess
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 from fsspec.core import url_to_fs
 from rigging.filesystem import StoragePath, is_remote_path, prefix_join
 
 from marin.evaluation.config_artifacts import HARBOR_CONFIG
-from marin.evaluation.harbor_config import HarborRuntime, resolve_harbor_config
+from marin.evaluation.harbor_config import HarborRuntimeBinding, ResolvedHarborPolicy
 from marin.evaluation.samples import EvalSample, Grading, SampleKind, write_sample_parquet
 from marin.evaluation.utils import download_from_gcs, upload_to_gcs
 
@@ -47,24 +47,11 @@ _CANONICAL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
 
 
 @dataclass(frozen=True)
-class HarborRunConfig:
-    """One Harbor eval of one served model."""
+class HarborEndpoint:
+    """The only Harbor runner input unavailable before the endpoint is live."""
 
-    dataset: str
-    version: str
-    agent: str
     served_model_name: str
-    """The name the model is served under (slash-free); the agent calls ``hosted_vllm/<name>``."""
     api_base: str
-    """OpenAI base URL the Harbor agent calls (the in-cluster endpoint, or a minted capability URL)."""
-    env: str = "daytona"
-    n_concurrent: int = 4
-    max_output_tokens: int = 8192
-    task_limit: int | None = None
-    agent_kwargs: dict = field(default_factory=dict)
-    preset: str = "standard"
-    config_document: dict | None = None
-    config_patch: dict | None = None
 
 
 @dataclass(frozen=True)
@@ -111,11 +98,11 @@ def canonical_served_name(name: str) -> str:
     return candidate
 
 
-def _job_name(config: HarborRunConfig) -> str:
+def _job_name(policy: ResolvedHarborPolicy, endpoint: HarborEndpoint) -> str:
     """A deterministic Harbor job name so a re-run resumes the previous job's completed trials."""
-    key = f"{config.dataset}|{config.version}|{config.served_model_name}|{config.agent}|{config.task_limit}"
+    key = f"{policy.sha256}|{endpoint.served_model_name}"
     digest = hashlib.sha256(key.encode()).hexdigest()[:12]
-    safe = re.sub(r"[^A-Za-z0-9_-]", "_", config.dataset)[:32]
+    safe = re.sub(r"[^A-Za-z0-9_-]", "_", policy.dataset)[:32]
     return f"harbor_{safe}_{digest}"
 
 
@@ -240,15 +227,14 @@ def _upload_trials(job_dir: Path, out_path: str) -> None:
             upload_to_gcs(str(trial_dir), prefix_join(out_path, f"harbor_trials/{trial_dir.name}"))
 
 
-def run_harbor_eval(config: HarborRunConfig, out_path: str) -> HarborRunResult:
-    """Run ``config``'s Harbor dataset against the served model and write the normalized outputs.
+def run_harbor_eval(policy: ResolvedHarborPolicy, endpoint: HarborEndpoint, out_path: str) -> HarborRunResult:
+    """Run one complete Harbor policy against a live endpoint and write normalized outputs.
 
-    Serving is the caller's job: ``config.api_base`` already points at a live endpoint. Harbor runs as
-    an isolated subprocess (see :mod:`marin.evaluation.harbor_trial_driver`); this resumes any
-    completed trials it finds under ``out_path`` first, then reads Harbor's native trial files back and
-    writes the per-sample parquet plus the aggregate for the record.
+    Policy fields never flow through this runner one by one. It binds only the endpoint and generated
+    job location into an already resolved Harbor document, then executes that document in Harbor's
+    isolated runtime.
     """
-    job_name = _job_name(config)
+    job_name = _job_name(policy, endpoint)
     workdir = Path("/tmp/harbor_workdir") / job_name
     output_dir = workdir / "harbor_results"
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -259,24 +245,13 @@ def run_harbor_eval(config: HarborRunConfig, out_path: str) -> HarborRunResult:
         if restored:
             logger.info("restored %d completed Harbor trial(s) from %s", restored, out_path)
 
-    resolved = resolve_harbor_config(
-        preset=config.preset,
-        n_concurrent=config.n_concurrent,
-        agent=config.agent,
-        environment=config.env,
-        default_max_output_tokens=config.max_output_tokens,
-        agent_kwargs=config.agent_kwargs,
-        runtime=HarborRuntime(
+    resolved = policy.bind(
+        HarborRuntimeBinding(
             job_name=job_name,
             jobs_dir=str(output_dir),
-            dataset=config.dataset,
-            version=config.version,
-            task_limit=config.task_limit,
-            served_model_name=config.served_model_name,
-            api_base=config.api_base,
-        ),
-        document=config.config_document,
-        patch=config.config_patch,
+            served_model_name=endpoint.served_model_name,
+            api_base=endpoint.api_base,
+        )
     )
     driver_config = {"job_config": resolved.document}
     config_file = workdir / "driver_config.json"
@@ -286,14 +261,14 @@ def run_harbor_eval(config: HarborRunConfig, out_path: str) -> HarborRunResult:
         json.dumps(resolved.persisted_metadata(), indent=2, sort_keys=True)
     )
 
-    logger.info("starting Harbor job %s (dataset=%s env=%s)", job_name, config.dataset, config.env)
+    logger.info("starting Harbor job %s (dataset=%s env=%s)", job_name, policy.dataset, policy.environment)
     _run_driver(config_file)
 
     trials = _read_trials(job_dir)
     if is_remote_path(out_path):
         _upload_trials(job_dir, out_path)
-    samples_path = _write_samples(trials, config.dataset, out_path)
-    result = _aggregate(trials, config.dataset, samples_path)
+    samples_path = _write_samples(trials, policy.dataset, out_path)
+    result = _aggregate(trials, policy.dataset, samples_path)
     StoragePath(prefix_join(out_path, "harbor_result.json")).write_text(
         json.dumps(
             {
@@ -308,7 +283,7 @@ def run_harbor_eval(config: HarborRunConfig, out_path: str) -> HarborRunResult:
     )
     logger.info(
         "Harbor %s: %d/%d solved (accuracy=%.3f mean_reward=%.3f)",
-        config.dataset,
+        policy.dataset,
         result.solved_trials,
         result.total_trials,
         result.accuracy,

--- a/lib/marin/src/marin/evaluation/harbor_trial_driver.py
+++ b/lib/marin/src/marin/evaluation/harbor_trial_driver.py
@@ -20,32 +20,11 @@ import sys
 from pathlib import Path
 
 from harbor.job import Job
-from harbor.models.environment_type import EnvironmentType
-from harbor.models.job.config import DatasetConfig, JobConfig
-from harbor.models.trial.config import AgentConfig, EnvironmentConfig
+from harbor_config import JobConfig
 
 
 async def _run(config: dict) -> None:
-    try:
-        env_type = EnvironmentType(config["env"])
-    except ValueError:
-        env_type = EnvironmentType.DOCKER
-    job = await Job.create(
-        JobConfig(
-            job_name=config["job_name"],
-            jobs_dir=Path(config["jobs_dir"]),
-            datasets=[DatasetConfig(name=config["dataset"], version=config["version"], n_tasks=config["n_tasks"])],
-            agents=[
-                AgentConfig(
-                    name=config["agent"],
-                    model_name=config["model_name"],
-                    kwargs=config["agent_kwargs"],
-                )
-            ],
-            n_concurrent_trials=config["n_concurrent"],
-            environment=EnvironmentConfig(type=env_type),
-        )
-    )
+    job = await Job.create(JobConfig.model_validate(config["job_config"]))
     await job.run()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,9 +170,11 @@ marin-zephyr = { workspace = true }
 nvidia-cutlass-dsl = { index = "nvidia" }
 nvidia-cutlass-dsl-libs-base = { index = "nvidia" }
 nvidia-cutlass-dsl-libs-cu13 = { index = "nvidia" }
-# NOTE: harbor is a pinned git dependency (not a workspace member).
-# harbor lives in marin-community/harbor as a pinned git dependency.
-harbor = { git = "https://github.com/marin-community/harbor.git", rev = "0d0dbe8904ed984137a0dfa764583f1508cf3274" }
+# NOTE: harbor is a pinned git dependency (not a workspace member). The generated block
+# below must match the resolver artifact consumed by marin.evaluation.config_artifacts.
+# BEGIN GENERATED HARBOR RUNTIME PIN
+harbor = { git = "https://github.com/marin-community/harbor.git", rev = "95dcdfd3f1f2fdc745b15f9ca411755abc6734c5" }
+# END GENERATED HARBOR RUNTIME PIN
 # Changes to TPU-vLLM fork SHAs must follow one of these protocols: if this is a
 # release/LKG refresh, then follow .agents/skills/refresh-tpu-vllm-forks/SKILL.md;
 # if this is a fixed-base overlay PR, then follow

--- a/scripts/ci/update_evaluation_config_artifacts.py
+++ b/scripts/ci/update_evaluation_config_artifacts.py
@@ -1,0 +1,150 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Apply verified Harbor and Evalchemy resolver manifests to Marin's pinned inputs.
+
+The caller downloads release manifests itself. This script performs no network I/O: it validates
+their structure, rewrites only explicitly delimited generated blocks, and reports whether source
+inputs changed. The workflow then refreshes ``uv.lock`` and proposes the change in a Marin PR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ArtifactPin:
+    package: str
+    repository: str
+    revision: str
+    release_tag: str
+    wheel_url: str
+    wheel_sha256: str
+    schema_fingerprint: str
+    resolver_fingerprint: str | None
+
+    @property
+    def wheel_requirement(self) -> str:
+        return f"{self.package} @ {self.wheel_url}#sha256={self.wheel_sha256}"
+
+
+def _string(data: dict[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"manifest field {key!r} must be a non-empty string")
+    return value
+
+
+def load_harbor_manifest(path: Path) -> ArtifactPin:
+    data = json.loads(path.read_text())
+    if not isinstance(data, dict) or _string(data, "package") != "harbor-config":
+        raise ValueError(f"{path}: not a harbor-config manifest")
+    return ArtifactPin(
+        package="harbor-config",
+        repository=_string(data, "release_repository"),
+        revision=_string(data, "parent_commit"),
+        release_tag=_string(data, "release_tag"),
+        wheel_url=_string(data, "wheel_url"),
+        wheel_sha256=_string(data, "sha256"),
+        schema_fingerprint=_string(data, "schema_fingerprint"),
+        resolver_fingerprint=_string(data, "resolver_fingerprint"),
+    )
+
+
+def load_evalchemy_manifest(path: Path) -> ArtifactPin:
+    data = json.loads(path.read_text())
+    if not isinstance(data, dict) or _string(data, "package") != "evalchemy-config":
+        raise ValueError(f"{path}: not an evalchemy-config manifest")
+    wheel = data.get("wheel")
+    if not isinstance(wheel, dict):
+        raise ValueError(f"{path}: wheel must be an object")
+    return ArtifactPin(
+        package="evalchemy-config",
+        repository="marin-community/evalchemy",
+        revision=_string(data, "evalchemy_revision"),
+        release_tag=_string(data, "release_tag"),
+        wheel_url=_string(wheel, "url"),
+        wheel_sha256=_string(wheel, "sha256"),
+        schema_fingerprint=_string(data, "schema_fingerprint"),
+        resolver_fingerprint=None,
+    )
+
+
+def _python_pin(name: str, artifact: ArtifactPin) -> str:
+    resolver_fingerprint = (
+        f'    resolver_fingerprint="{artifact.resolver_fingerprint}",\n' if artifact.resolver_fingerprint else ""
+    )
+    return (
+        f"{name} = ConfigArtifact(\n"
+        f'    package="{artifact.package}",\n'
+        f'    repository="{artifact.repository}",\n'
+        f'    revision="{artifact.revision}",\n'
+        f'    release_tag="{artifact.release_tag}",\n'
+        f'    wheel_url="{artifact.wheel_url}",\n'
+        f'    wheel_sha256="{artifact.wheel_sha256}",\n'
+        f'    schema_fingerprint="{artifact.schema_fingerprint}",\n'
+        f"{resolver_fingerprint}"
+        ")\n"
+    )
+
+
+def replace_generated_block(path: Path, begin: str, end: str, content: str) -> bool:
+    text = path.read_text()
+    start = text.find(begin)
+    finish = text.find(end)
+    if start < 0 or finish < 0 or finish < start:
+        raise ValueError(f"{path}: missing generated block {begin!r}")
+    replacement = f"{begin}\n{content}{end}"
+    updated = text[:start] + replacement + text[finish + len(end) :]
+    if updated == text:
+        return False
+    path.write_text(updated)
+    return True
+
+
+def apply_pins(repo_root: Path, harbor: ArtifactPin, evalchemy: ArtifactPin) -> bool:
+    changed = False
+    changed |= replace_generated_block(
+        repo_root / "lib/marin/src/marin/evaluation/config_artifacts.py",
+        "# BEGIN GENERATED CONFIG ARTIFACT PINS",
+        "# END GENERATED CONFIG ARTIFACT PINS",
+        _python_pin("HARBOR_CONFIG", harbor) + "\n" + _python_pin("EVALCHEMY_CONFIG", evalchemy),
+    )
+    changed |= replace_generated_block(
+        repo_root / "lib/marin/pyproject.toml",
+        "    # BEGIN GENERATED CONFIG ARTIFACT DEPENDENCIES",
+        "    # END GENERATED CONFIG ARTIFACT DEPENDENCIES",
+        f'    "{harbor.wheel_requirement}",\n    "{evalchemy.wheel_requirement}",\n',
+    )
+    changed |= replace_generated_block(
+        repo_root / "pyproject.toml",
+        "# BEGIN GENERATED HARBOR RUNTIME PIN",
+        "# END GENERATED HARBOR RUNTIME PIN",
+        f'harbor = {{ git = "https://github.com/{harbor.repository}.git", rev = "{harbor.revision}" }}\n',
+    )
+    return changed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--harbor-manifest", type=Path, required=True)
+    parser.add_argument("--evalchemy-manifest", type=Path, required=True)
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[2])
+    args = parser.parse_args()
+
+    changed = apply_pins(
+        args.repo_root, load_harbor_manifest(args.harbor_manifest), load_evalchemy_manifest(args.evalchemy_manifest)
+    )
+    print("changed" if changed else "unchanged")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/evals/test_config_artifacts.py
+++ b/tests/evals/test_config_artifacts.py
@@ -1,0 +1,58 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+from marin.evaluation.config_artifacts import HARBOR_CONFIG
+from marin.evaluation.harbor_runner import _HARBOR_SPEC
+
+from scripts.ci.update_evaluation_config_artifacts import ArtifactPin, apply_pins
+
+
+def test_harbor_trial_runtime_matches_the_resolver_revision() -> None:
+    assert _HARBOR_SPEC == HARBOR_CONFIG.source_requirement
+
+
+def test_artifact_updater_rewrites_only_marked_pins_and_is_idempotent(tmp_path: Path) -> None:
+    config_module = tmp_path / "lib/marin/src/marin/evaluation/config_artifacts.py"
+    config_module.parent.mkdir(parents=True)
+    config_module.write_text("# BEGIN GENERATED CONFIG ARTIFACT PINS\n# END GENERATED CONFIG ARTIFACT PINS\n")
+    marin_project = tmp_path / "lib/marin/pyproject.toml"
+    marin_project.parent.mkdir(parents=True, exist_ok=True)
+    marin_project.write_text(
+        "dependencies = [\n"
+        "    # BEGIN GENERATED CONFIG ARTIFACT DEPENDENCIES\n"
+        "    # END GENERATED CONFIG ARTIFACT DEPENDENCIES\n"
+        "]\n"
+    )
+    root_project = tmp_path / "pyproject.toml"
+    root_project.write_text("# BEGIN GENERATED HARBOR RUNTIME PIN\n# END GENERATED HARBOR RUNTIME PIN\n")
+    harbor = ArtifactPin(
+        package="harbor-config",
+        repository="marin-community/harbor",
+        revision="harbor-revision",
+        release_tag="harbor-tag",
+        wheel_url="https://example.test/harbor.whl",
+        wheel_sha256="harbor-sha",
+        schema_fingerprint="harbor-schema",
+        resolver_fingerprint="harbor-resolver",
+    )
+    evalchemy = ArtifactPin(
+        package="evalchemy-config",
+        repository="marin-community/evalchemy",
+        revision="evalchemy-revision",
+        release_tag="evalchemy-tag",
+        wheel_url="https://example.test/evalchemy.whl",
+        wheel_sha256="evalchemy-sha",
+        schema_fingerprint="evalchemy-schema",
+        resolver_fingerprint=None,
+    )
+
+    assert apply_pins(tmp_path, harbor, evalchemy)
+    assert not apply_pins(tmp_path, harbor, evalchemy)
+    assert "harbor-revision" in root_project.read_text()
+    assert "https://example.test/harbor.whl#sha256=harbor-sha" in marin_project.read_text()
+    assert "evalchemy-resolver" not in config_module.read_text()

--- a/tests/evals/test_harbor_config.py
+++ b/tests/evals/test_harbor_config.py
@@ -1,0 +1,91 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from marin.evaluation.harbor_config import HarborRuntime, resolve_harbor_config
+
+
+def _runtime() -> HarborRuntime:
+    return HarborRuntime(
+        job_name="harbor_aime_123",
+        jobs_dir="/tmp/harbor-results",
+        dataset="aime",
+        version="1.0",
+        task_limit=2,
+        served_model_name="grug",
+        api_base="https://capability.example/secret/v1",
+    )
+
+
+def test_harbor_preset_retains_policy_patch_and_reapplies_runtime_owned_fields():
+    resolved = resolve_harbor_config(
+        preset="standard",
+        n_concurrent=4,
+        agent="terminus-2",
+        environment="daytona",
+        default_max_output_tokens=7168,
+        agent_kwargs={"compaction": {"enabled": True}},
+        runtime=_runtime(),
+        patch={
+            "n_attempts": 3,
+            "retry": {"max_retries": 6},
+            "environment": {"override_cpus": 8, "override_memory_mb": 16384},
+            "agents": [
+                {
+                    "name": "opencode",
+                    "model_name": "incorrect-model",
+                    "kwargs": {"model_info": {"context_window": 65536, "max_output_tokens": 4096}},
+                    "env": {"DAYTONA_EVAL_API_KEY": "${DAYTONA_EVAL_API_KEY}"},
+                }
+            ],
+            "datasets": [{"name": "incorrect-dataset", "version": "0.0", "registry_url": "https://registry.example"}],
+        },
+    )
+
+    document = resolved.document
+    assert document["n_attempts"] == 3
+    assert document["retry"]["max_retries"] == 6
+    assert document["environment"]["override_cpus"] == 8
+    assert document["environment"]["override_memory_mb"] == 16384
+    assert document["agents"][0]["name"] == "opencode"
+    assert document["agents"][0]["model_name"] == "hosted_vllm/grug"
+    assert document["agents"][0]["kwargs"]["api_base"] == _runtime().api_base
+    assert document["agents"][0]["kwargs"]["model_info"] == {
+        "max_input_tokens": 32768,
+        "max_output_tokens": 4096,
+        "input_cost_per_token": 0.0,
+        "output_cost_per_token": 0.0,
+        "context_window": 65536,
+    }
+    assert document["datasets"][0]["name"] == "aime"
+    assert document["datasets"][0]["version"] == "1.0"
+    assert document["datasets"][0]["n_tasks"] == 2
+    assert document["datasets"][0]["registry_url"] == "https://registry.example"
+    metadata = resolved.persisted_metadata()
+    assert metadata["config_sha256"] == resolved.sha256
+    assert metadata["job_config"]["agents"][0]["kwargs"]["api_base"] == "<redacted>"
+
+
+def test_harbor_config_rejects_multiple_runtime_agents_or_datasets():
+    with pytest.raises(ValueError, match="exactly one agent"):
+        resolve_harbor_config(
+            preset="standard",
+            n_concurrent=4,
+            agent="terminus-2",
+            environment="daytona",
+            default_max_output_tokens=7168,
+            agent_kwargs={},
+            runtime=_runtime(),
+            document={"agents": [{"name": "one"}, {"name": "two"}], "datasets": [{"name": "aime"}]},
+        )
+    with pytest.raises(ValueError, match="exactly one dataset"):
+        resolve_harbor_config(
+            preset="standard",
+            n_concurrent=4,
+            agent="terminus-2",
+            environment="daytona",
+            default_max_output_tokens=7168,
+            agent_kwargs={},
+            runtime=_runtime(),
+            document={"agents": [{"name": "one"}], "datasets": [{"name": "aime"}, {"name": "math"}]},
+        )

--- a/tests/evals/test_harbor_config.py
+++ b/tests/evals/test_harbor_config.py
@@ -2,30 +2,29 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from marin.evaluation.harbor_config import HarborRuntime, resolve_harbor_config
+from marin.evaluation.harbor_config import (
+    HarborPolicyDefaults,
+    HarborRuntimeBinding,
+    resolve_harbor_policy,
+)
 
 
-def _runtime() -> HarborRuntime:
-    return HarborRuntime(
-        job_name="harbor_aime_123",
-        jobs_dir="/tmp/harbor-results",
+def _defaults() -> HarborPolicyDefaults:
+    return HarborPolicyDefaults(
         dataset="aime",
         version="1.0",
+        agent="terminus-2",
+        environment="daytona",
+        n_concurrent_trials=4,
+        max_output_tokens=7168,
+        agent_kwargs={"compaction": {"enabled": True}},
         task_limit=2,
-        served_model_name="grug",
-        api_base="https://capability.example/secret/v1",
     )
 
 
-def test_harbor_preset_retains_policy_patch_and_reapplies_runtime_owned_fields():
-    resolved = resolve_harbor_config(
-        preset="standard",
-        n_concurrent=4,
-        agent="terminus-2",
-        environment="daytona",
-        default_max_output_tokens=7168,
-        agent_kwargs={"compaction": {"enabled": True}},
-        runtime=_runtime(),
+def test_harbor_policy_keeps_artifact_fields_until_the_narrow_runtime_binding():
+    policy = resolve_harbor_policy(
+        _defaults(),
         patch={
             "n_attempts": 3,
             "retry": {"max_retries": 6},
@@ -33,7 +32,6 @@ def test_harbor_preset_retains_policy_patch_and_reapplies_runtime_owned_fields()
             "agents": [
                 {
                     "name": "opencode",
-                    "model_name": "incorrect-model",
                     "kwargs": {"model_info": {"context_window": 65536, "max_output_tokens": 4096}},
                     "env": {"DAYTONA_EVAL_API_KEY": "${DAYTONA_EVAL_API_KEY}"},
                 }
@@ -42,50 +40,78 @@ def test_harbor_preset_retains_policy_patch_and_reapplies_runtime_owned_fields()
         },
     )
 
-    document = resolved.document
-    assert document["n_attempts"] == 3
-    assert document["retry"]["max_retries"] == 6
-    assert document["environment"]["override_cpus"] == 8
-    assert document["environment"]["override_memory_mb"] == 16384
-    assert document["agents"][0]["name"] == "opencode"
-    assert document["agents"][0]["model_name"] == "hosted_vllm/grug"
-    assert document["agents"][0]["kwargs"]["api_base"] == _runtime().api_base
-    assert document["agents"][0]["kwargs"]["model_info"] == {
-        "max_input_tokens": 32768,
-        "max_output_tokens": 4096,
-        "input_cost_per_token": 0.0,
-        "output_cost_per_token": 0.0,
-        "context_window": 65536,
-    }
-    assert document["datasets"][0]["name"] == "aime"
-    assert document["datasets"][0]["version"] == "1.0"
-    assert document["datasets"][0]["n_tasks"] == 2
-    assert document["datasets"][0]["registry_url"] == "https://registry.example"
-    metadata = resolved.persisted_metadata()
-    assert metadata["config_sha256"] == resolved.sha256
-    assert metadata["job_config"]["agents"][0]["kwargs"]["api_base"] == "<redacted>"
+    assert policy.document["n_attempts"] == 3
+    assert policy.document["retry"]["max_retries"] == 6
+    assert policy.document["environment"]["override_cpus"] == 8
+    assert policy.document["agents"][0]["name"] == "opencode"
+    assert policy.document["agents"][0]["kwargs"]["model_info"]["max_output_tokens"] == 4096
+    assert policy.document["datasets"][0]["name"] == "aime"
+    assert policy.document["datasets"][0]["version"] == "1.0"
+    assert policy.document["datasets"][0]["n_tasks"] == 2
+    assert policy.document["datasets"][0]["registry_url"] == "https://registry.example"
+
+    bound = policy.bind(
+        HarborRuntimeBinding(
+            job_name="harbor_aime_123",
+            jobs_dir="/tmp/harbor-results",
+            served_model_name="grug",
+            api_base="https://capability.example/secret/v1",
+        )
+    )
+    assert bound.document["agents"][0]["name"] == "opencode"
+    assert bound.document["agents"][0]["model_name"] == "hosted_vllm/grug"
+    assert bound.document["agents"][0]["kwargs"]["api_base"] == "https://capability.example/secret/v1"
+    assert bound.document["agents"][0]["kwargs"]["model_info"]["max_output_tokens"] == 4096
+    assert bound.persisted_metadata()["job_config"]["agents"][0]["kwargs"]["api_base"] == "<redacted>"
 
 
-def test_harbor_config_rejects_multiple_runtime_agents_or_datasets():
+def test_harbor_policy_rejects_multiple_agents_before_runtime_binding():
     with pytest.raises(ValueError, match="exactly one agent"):
-        resolve_harbor_config(
-            preset="standard",
-            n_concurrent=4,
-            agent="terminus-2",
-            environment="daytona",
-            default_max_output_tokens=7168,
-            agent_kwargs={},
-            runtime=_runtime(),
+        resolve_harbor_policy(
+            _defaults(),
             document={"agents": [{"name": "one"}, {"name": "two"}], "datasets": [{"name": "aime"}]},
+        ).bind(
+            HarborRuntimeBinding(
+                job_name="job",
+                jobs_dir="/tmp/job",
+                served_model_name="model",
+                api_base="https://endpoint/v1",
+            )
         )
-    with pytest.raises(ValueError, match="exactly one dataset"):
-        resolve_harbor_config(
-            preset="standard",
-            n_concurrent=4,
-            agent="terminus-2",
+
+
+def test_grug_opencode_preset_retains_harbor_policy_and_binds_runtime_endpoint():
+    policy = resolve_harbor_policy(
+        HarborPolicyDefaults(
+            dataset="DCAgent/dev_set_v2",
+            version="1.0",
+            agent="opencode",
             environment="daytona",
-            default_max_output_tokens=7168,
+            n_concurrent_trials=256,
+            max_output_tokens=16384,
             agent_kwargs={},
-            runtime=_runtime(),
-            document={"agents": [{"name": "one"}], "datasets": [{"name": "aime"}, {"name": "math"}]},
+            preset="grug-opencode-id",
         )
+    )
+
+    assert policy.document["n_attempts"] == 3
+    assert policy.document["n_concurrent_trials"] == 256
+    assert policy.document["retry"]["max_retries"] == 6
+    assert policy.document["verifier"]["max_timeout_sec"] == 14400
+    assert policy.document["agents"][0]["kwargs"]["model_info"] == {
+        "max_input_tokens": 64512,
+        "max_output_tokens": 16384,
+        "input_cost_per_token": 0,
+        "output_cost_per_token": 0,
+    }
+
+    bound = policy.bind(
+        HarborRuntimeBinding(
+            job_name="grug-id-123",
+            jobs_dir="/tmp/grug-id-123",
+            served_model_name="grug",
+            api_base="https://capability.example/secret/v1",
+        )
+    )
+    assert bound.document["agents"][0]["model_name"] == "hosted_vllm/grug"
+    assert bound.document["agents"][0]["kwargs"]["api_base"] == "https://capability.example/secret/v1"

--- a/tests/evals/test_launch_priority.py
+++ b/tests/evals/test_launch_priority.py
@@ -1,0 +1,49 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The eval group and its later serving child must share the requested Iris policy."""
+
+from experiments.evaluation.hardware import Platform
+from experiments.evaluation.launch import LaunchSpec, launch_group, plan_runs
+
+
+def _spec(**overrides) -> LaunchSpec:
+    values = dict(
+        model="qwen3-8b",
+        evals=("grug-opencode-id",),
+        platform=Platform.GPU,
+        accelerator="H100x8",
+        limit=2,
+        records_prefix="s3://marin-us-east-02a/test/evals",
+        cluster="marin",
+        priority=2,  # PRIORITY_BAND_INTERACTIVE
+        max_retries_failure=6,
+    )
+    values.update(overrides)
+    return LaunchSpec(**values)
+
+
+def test_plan_carries_explicit_priority_and_retries_to_the_serving_child():
+    serve = plan_runs(_spec())[0].serve
+
+    assert serve.priority == 2
+    assert serve.max_retries_failure == 6
+
+
+def test_group_submission_carries_the_same_priority_and_retries(monkeypatch):
+    captured = {}
+
+    class _Job:
+        def __str__(self) -> str:
+            return "/test/eval-group"
+
+    class _Client:
+        def submit(self, **kwargs):
+            captured.update(kwargs)
+            return _Job()
+
+    monkeypatch.setattr("experiments.evaluation.launch._git_sha", lambda: "test")
+    launch_group(_spec(), _Client())
+
+    assert captured["max_retries_failure"] == 6
+    assert captured["priority_band"] == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1770,6 +1770,24 @@ epy = [
 ]
 
 [[package]]
+name = "evalchemy-config"
+version = "0.1.0"
+source = { url = "https://github.com/marin-community/evalchemy/releases/download/evalchemy-config-12a73251f540428e8ea01cdeefa2611d2344a8f266b4c2c38a181de5106c3b24/evalchemy_config-0.1.0-py3-none-any.whl" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pyyaml" },
+]
+wheels = [
+    { url = "https://github.com/marin-community/evalchemy/releases/download/evalchemy-config-12a73251f540428e8ea01cdeefa2611d2344a8f266b4c2c38a181de5106c3b24/evalchemy_config-0.1.0-py3-none-any.whl", hash = "sha256:ef95d211e9f4bf5a6b8dec7bd3436b3cda88e685096587b9ae7cd06e59dfae00" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2" },
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "evaluate"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2744,8 +2762,8 @@ wheels = [
 
 [[package]]
 name = "harbor"
-version = "0.8.0"
-source = { git = "https://github.com/marin-community/harbor.git?rev=0d0dbe8904ed984137a0dfa764583f1508cf3274#0d0dbe8904ed984137a0dfa764583f1508cf3274" }
+version = "0.8.1"
+source = { git = "https://github.com/marin-community/harbor.git?rev=95dcdfd3f1f2fdc745b15f9ca411755abc6734c5#95dcdfd3f1f2fdc745b15f9ca411755abc6734c5" }
 dependencies = [
     { name = "claude-agent-sdk" },
     { name = "datasets" },
@@ -2769,6 +2787,30 @@ dependencies = [
     { name = "typer" },
     { name = "universal-pathlib" },
     { name = "uvicorn" },
+]
+
+[[package]]
+name = "harbor-config"
+version = "0.1.0"
+source = { url = "https://github.com/marin-community/harbor/releases/download/harbor-config-95dcdfd3f1f2fdc745b15f9ca411755abc6734c5/harbor_config-0.1.0-py3-none-any.whl" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "shortuuid" },
+    { name = "toml" },
+    { name = "universal-pathlib" },
+]
+wheels = [
+    { url = "https://github.com/marin-community/harbor/releases/download/harbor-config-95dcdfd3f1f2fdc745b15f9ca411755abc6734c5/harbor_config-0.1.0-py3-none-any.whl", hash = "sha256:eebfe87f7a0408c0540f0e633822158b45a2f95933fa1e19cf13b41c498777f9" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.11.7" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "shortuuid", specifier = ">=1.0.13" },
+    { name = "toml", specifier = ">=0.10.2" },
+    { name = "universal-pathlib", specifier = ">=0.2.6" },
 ]
 
 [[package]]
@@ -4131,11 +4173,13 @@ dependencies = [
     { name = "braceexpand" },
     { name = "datasets" },
     { name = "draccus" },
+    { name = "evalchemy-config" },
     { name = "fasttext-wheel" },
     { name = "fsspec" },
     { name = "gcsfs" },
     { name = "google-api-python-client" },
     { name = "google-cloud-storage" },
+    { name = "harbor-config" },
     { name = "jax" },
     { name = "jaxopt" },
     { name = "marin-fray" },
@@ -4294,6 +4338,7 @@ requires-dist = [
     { name = "datasets", specifier = "<5.0.0" },
     { name = "draccus", specifier = ">=0.11.6" },
     { name = "duckdb", marker = "extra == 'datakit'", specifier = ">=1.0.0" },
+    { name = "evalchemy-config", url = "https://github.com/marin-community/evalchemy/releases/download/evalchemy-config-12a73251f540428e8ea01cdeefa2611d2344a8f266b4c2c38a181de5106c3b24/evalchemy_config-0.1.0-py3-none-any.whl" },
     { name = "faiss-cpu", marker = "extra == 'datakit'" },
     { name = "fasttext-wheel", specifier = ">=0.9.2" },
     { name = "flash-attn-4", extras = ["cu13"], marker = "sys_platform == 'linux' and extra == 'gpu'", specifier = ">=4.0.0b16,<4.1" },
@@ -4302,7 +4347,8 @@ requires-dist = [
     { name = "google-api-python-client", specifier = ">=2.175.0" },
     { name = "google-cloud-storage" },
     { name = "google-vizier", extras = ["jax"], marker = "extra == 'vizier'" },
-    { name = "harbor", marker = "extra == 'harbor'", git = "https://github.com/marin-community/harbor.git?rev=0d0dbe8904ed984137a0dfa764583f1508cf3274" },
+    { name = "harbor", marker = "extra == 'harbor'", git = "https://github.com/marin-community/harbor.git?rev=95dcdfd3f1f2fdc745b15f9ca411755abc6734c5" },
+    { name = "harbor-config", url = "https://github.com/marin-community/harbor/releases/download/harbor-config-95dcdfd3f1f2fdc745b15f9ca411755abc6734c5/harbor_config-0.1.0-py3-none-any.whl" },
     { name = "huggingface-hub", marker = "extra == 'datakit'" },
     { name = "jax", specifier = ">=0.9.2,<0.11" },
     { name = "jax", marker = "extra == 'cpu'", specifier = "==0.10.1" },


### PR DESCRIPTION
Resolve Harbor policy through Harbor’s pinned configuration artifact, then bind only the generated job location, served-model name, and endpoint URL after the model is live. The runner receives the resolved document instead of a hand-maintained subset of Harbor fields.

Bundle the named Grug OpenCode ID policy with three attempts, six retries, Daytona resource and timeout limits, and 256 concurrent trials. The policy records a redacted resolved-config provenance; Marin retains dataset selection and durable job-root ownership.

An updater pins the artifact to Harbor’s published revision and manifest.