### PR TITLE
[eval] Add Grug agentic serving profile

### DIFF
--- a/experiments/evals/evalchemy/serve_and_eval.py
+++ b/experiments/evals/evalchemy/serve_and_eval.py
@@ -171,6 +171,8 @@ class ServeSpec:
       ``Qwen/Qwen3-Next-80B-A3B``): ``--gdn-prefill-backend triton``. The GPU serve env runs without
       ``nvcc``, so the default FlashInfer GDN prefill kernel — JIT-compiled at warmup — fails; triton
       needs no compiler."""
+    max_num_seqs: int | None = None
+    """Maximum live sequences per vLLM shard. ``None`` leaves the engine default intact."""
     chat_template_content: str | None = None
     """Chat template (jinja) served so ``/v1/chat/completions`` templates server-side, required when the
     eval uses ``--apply_chat_template`` and the model's own repo does not carry a vLLM-loadable template.
@@ -242,6 +244,15 @@ def _has_vllm_option(args: tuple[str, ...], option: str) -> bool:
     return any(arg == option or arg.startswith(f"{option}=") for arg in args)
 
 
+def _resolved_vllm_extra_args(spec: ServeSpec, args: tuple[str, ...]) -> tuple[str, ...]:
+    """Add typed serving limits without allowing a conflicting raw vLLM option."""
+    if spec.max_num_seqs is None:
+        return args
+    if _has_vllm_option(args, "--max-num-seqs"):
+        raise ValueError("ServeSpec.max_num_seqs conflicts with vllm_extra_args --max-num-seqs")
+    return (*args, "--max-num-seqs", str(spec.max_num_seqs))
+
+
 def _auto_serve_overrides_from_config(
     model: str,
     config: dict,
@@ -311,6 +322,7 @@ def _shared_inference_config(model: str, tokenizer: str, spec: ServeSpec) -> _In
     max_model_len = spec.max_model_len
     if spec.backend == ServeBackend.VLLM and spec.auto_overrides:
         vllm_extra_args, max_model_len = auto_serve_overrides(model, spec.max_model_len, spec.vllm_extra_args)
+    vllm_extra_args = _resolved_vllm_extra_args(spec, vllm_extra_args)
     if spec.gpu_count is not None:
         resources = ResourceConfig.with_gpu(
             spec.gpu_type or "H100",

--- a/experiments/evaluation/launch.py
+++ b/experiments/evaluation/launch.py
@@ -54,6 +54,7 @@ from rigging.timing import Duration
 
 from experiments.evals.evalchemy.image import EVALCHEMY_IMAGE
 from experiments.evals.evalchemy.serve_and_eval import (
+    EVAL_SERVE_MAX_NUM_BATCHED_TOKENS,
     EvalPipelineError,
     EvalSession,
     EvalUnit,
@@ -368,9 +369,15 @@ def _serve_spec(model: EvalModelConfig, accel: AcceleratorChoice) -> ServeSpec:
             tpu_type=None,
             gpu_type=accel.gpu_type,
             gpu_count=accel.gpu_count,
+            max_model_len=model.max_model_len,
             tensor_parallel_size=model.tensor_parallel_size,
             region=accel.region,
+            serve_cpu=model.serve_cpu or 8.0,
+            serve_memory=model.serve_memory or "64g",
+            serve_disk=model.serve_disk or "100g",
+            max_num_batched_tokens=model.max_num_batched_tokens or EVAL_SERVE_MAX_NUM_BATCHED_TOKENS,
             vllm_extra_args=model.vllm_extra_args,
+            max_num_seqs=model.max_num_seqs,
             chat_template_content=model.chat_template,
         )
     else:
@@ -379,13 +386,17 @@ def _serve_spec(model: EvalModelConfig, accel: AcceleratorChoice) -> ServeSpec:
             tpu_type=accel.tpu_type,
             gpu_type=None,
             gpu_count=None,
+            max_model_len=model.max_model_len,
             tensor_parallel_size=model.tensor_parallel_size,
             region=accel.region,
+            serve_cpu=model.serve_cpu or 8.0,
+            serve_memory=model.serve_memory or "64g",
+            serve_disk=model.serve_disk or "100g",
+            max_num_batched_tokens=model.max_num_batched_tokens or EVAL_SERVE_MAX_NUM_BATCHED_TOKENS,
             vllm_extra_args=model.vllm_extra_args,
+            max_num_seqs=model.max_num_seqs,
             chat_template_content=model.chat_template,
         )
-    if model.serve_memory is not None:
-        spec = replace(spec, serve_memory=model.serve_memory)
     return spec
 
 
@@ -402,6 +413,8 @@ def plan_runs(spec: LaunchSpec) -> list[RunPlan]:
     plans: list[RunPlan] = []
     for eval_key in spec.evals:
         suite = EVALS[eval_key]
+        if suite.harbor is not None and model.agentic_n_concurrent is not None:
+            suite = replace(suite, harbor=replace(suite.harbor, n_concurrent=model.agentic_n_concurrent))
         accel = select_accelerator(model, spec.platform, spec.accelerator)
         limit = spec.limit if spec.limit is not None else suite.max_eval_instances
         plans.append(

--- a/experiments/evaluation/models.py
+++ b/experiments/evaluation/models.py
@@ -38,6 +38,14 @@ class EvalModelConfig:
     gpu_only: bool = False
     vllm_extra_args: tuple[str, ...] = ()
     tensor_parallel_size: int | None = None
+    max_model_len: int | None = None
+    """Explicit vLLM context limit. ``None`` lets the server use the checkpoint default."""
+    max_num_batched_tokens: int | None = None
+    """Explicit vLLM prefill-token budget. ``None`` retains the portable server default."""
+    max_num_seqs: int | None = None
+    """Maximum concurrent sequences per vLLM data-parallel shard."""
+    agentic_n_concurrent: int | None = None
+    """Harbor trial concurrency this model's serving topology is provisioned to sustain."""
     max_gen_toks: int | None = None
     """Per-model override of a suite's generation budget. A verbose reasoning model needs a longer
     budget than the suite default or its chain truncates before the final answer (scoring it wrong)."""
@@ -51,6 +59,10 @@ class EvalModelConfig:
     chat_template: str | None = None
     """A jinja chat template served in place of the tokenizer's own (``ServeSpec.chat_template_content``),
     for models whose tokenizer ships none."""
+    serve_cpu: float | None = None
+    """CPU request for the serving child. ``None`` retains the portable server default."""
+    serve_disk: str | None = None
+    """Disk request for the serving child. ``None`` retains the portable server default."""
 
 
 def _snowball(name: str, location: str, chat_template: str | None = None) -> EvalModelConfig:
@@ -80,6 +92,43 @@ def _snowball(name: str, location: str, chat_template: str | None = None) -> Eva
         target_cluster="cw-us-east-02a",
         serve_memory="512g",
         chat_template=chat_template,
+    )
+
+
+def _grug_agentic_s3_step1903() -> EvalModelConfig:
+    """The 65k OpenCode SFT checkpoint and its validated H100x8 serving contract.
+
+    Eight data-parallel shards each admit 32 sequences, so a Harbor agentic suite may schedule 256
+    trials concurrently. These are measured capacity values, not generic GPU defaults: the 7168-token
+    prefill budget is the largest setting that leaves 32 full-65k KV slots per shard.
+    """
+    return EvalModelConfig(
+        name="grug-agentic-s3-step1903",
+        location=("s3://marin-us-east-02a/marin/exports/grug/" "june-67b-a2b-sft-s3-agentic/step-1903/hf-bf16-vllm/"),
+        hbm_gb=175,
+        apply_chat_template=True,
+        gpu_only=True,
+        vllm_extra_args=(
+            "--data-parallel-size",
+            "8",
+            "--enable-expert-parallel",
+            "--model-loader-extra-config",
+            '{"distributed":true}',
+            "--enable-auto-tool-choice",
+            "--tool-call-parser",
+            "hermes",
+        ),
+        tensor_parallel_size=1,
+        max_model_len=65536,
+        max_num_batched_tokens=7168,
+        max_num_seqs=32,
+        agentic_n_concurrent=256,
+        tokenizer="penfever/grug-67b-a2b-sft-s2-thinking-step630-tok",
+        fixed_gpu=("H100", 8),
+        target_cluster="cw-rno2a",
+        serve_cpu=48.0,
+        serve_memory="1024g",
+        serve_disk="512g",
     )
 
 
@@ -151,4 +200,5 @@ MODELS: dict[str, EvalModelConfig] = {
         "snowball-sft",
         "s3://marin-us-east-02a/marin/exports/grug/june-67b-a2b-sft-s2-thinking/step-630/hf-bf16-vllm/",
     ),
+    "grug-agentic-s3-step1903": _grug_agentic_s3_step1903(),
 }

--- a/tests/evals/test_grug_agentic_profile.py
+++ b/tests/evals/test_grug_agentic_profile.py
@@ -5,9 +5,9 @@
 
 from dataclasses import replace
 
+from experiments.evals.evalchemy.serve_and_eval import _shared_inference_config
 from experiments.evaluation.hardware import Platform
 from experiments.evaluation.launch import LaunchSpec, plan_runs
-from experiments.evals.evalchemy.serve_and_eval import _shared_inference_config
 
 
 def test_grug_agentic_profile_resolves_validated_h100_serving_contract():

--- a/tests/evals/test_grug_agentic_profile.py
+++ b/tests/evals/test_grug_agentic_profile.py
@@ -1,0 +1,71 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolved serving contracts for the Grug agentic model profile."""
+
+from dataclasses import replace
+
+from experiments.evaluation.hardware import Platform
+from experiments.evaluation.launch import LaunchSpec, plan_runs
+from experiments.evals.evalchemy.serve_and_eval import _shared_inference_config
+
+
+def test_grug_agentic_profile_resolves_validated_h100_serving_contract():
+    plan = plan_runs(
+        LaunchSpec(
+            model="grug-agentic-s3-step1903",
+            evals=("aime-harbor",),
+            platform=Platform.GPU,
+            accelerator=None,
+            limit=None,
+            records_prefix=None,
+            cluster="marin",
+        )
+    )[0]
+
+    assert plan.accel.label == "H100x8"
+    assert plan.accel.target_cluster == "cw-rno2a"
+    assert plan.serve.max_model_len == 65536
+    assert plan.serve.max_num_batched_tokens == 7168
+    assert plan.serve.max_num_seqs == 32
+    assert plan.model.agentic_n_concurrent == 256
+    assert plan.suite.harbor is not None
+    assert plan.suite.harbor.n_concurrent == 256
+    assert plan.serve.tensor_parallel_size == 1
+    assert plan.serve.serve_cpu == 48.0
+    assert plan.serve.serve_memory == "1024g"
+    assert plan.serve.serve_disk == "512g"
+    assert plan.serve.vllm_extra_args == (
+        "--data-parallel-size",
+        "8",
+        "--enable-expert-parallel",
+        "--model-loader-extra-config",
+        '{"distributed":true}',
+        "--enable-auto-tool-choice",
+        "--tool-call-parser",
+        "hermes",
+    )
+
+
+def test_grug_agentic_profile_materializes_one_sequence_limit_in_the_vllm_engine():
+    plan = plan_runs(
+        LaunchSpec(
+            model="grug-agentic-s3-step1903",
+            evals=("aime-harbor",),
+            platform=Platform.GPU,
+            accelerator=None,
+            limit=None,
+            records_prefix=None,
+            cluster="marin",
+        )
+    )[0]
+
+    inference = _shared_inference_config(
+        plan.model.location,
+        plan.model.tokenizer or plan.model.location,
+        replace(plan.serve, auto_overrides=False),
+    )
+    engine_args = inference.engine.extra_args
+
+    assert engine_args.count("--max-num-seqs") == 1
+    assert engine_args[engine_args.index("--max-num-seqs") + 1] == "32"


### PR DESCRIPTION
Register the step-1903 OpenCode SFT with its measured CoreWeave H100x8 serving contract: 65k context, a 7,168-token prefill budget, TP=1/DP=8 expert parallelism, and 32 sequences per shard.

The 7,168-token ceiling retains 32 full-65k KV slots per data-parallel shard, giving Harbor 256 trial slots. Generic model defaults remain unchanged.