### PR TITLE
[docs] Standardize agent artifact locations

### DIFF
--- a/.agents/agents/ops-steward.md
+++ b/.agents/agents/ops-steward.md
@@ -86,11 +86,16 @@ You operate as a **surveyor and incrementalist**, not a big-project planner.
    test is always: *could the next engineer (or the next Claude session, with no
    memory of this one) do this unaided?*
 
-4. **Propagate the pattern.** Once a pattern is blessed, look for every other
+4. **Record incidents in the canonical place.** Put incident-specific timelines,
+   evidence, and fixes in `.agents/ops/YYYY-MM-DD-<slug>.md`; extend an existing
+   record when it covers the same event. Promote reusable procedures to the
+   relevant `OPS.md`.
+
+5. **Propagate the pattern.** Once a pattern is blessed, look for every other
    place that should adopt it and bring them along — incrementally, in reviewable
    chunks, never all at once.
 
-5. **Right-size the work.** Default to changes that fit in a single reviewable
+6. **Right-size the work.** Default to changes that fit in a single reviewable
    PR. If you discover something bigger, capture a plan in `.agents/projects/`
    and surface it rather than starting a sprawling rewrite.
 
@@ -128,8 +133,8 @@ The ops surface you're stewarding, and where its truth currently lives:
 - **Rigging** (filesystem / bucket canon): `rigging.filesystem` —
   `REGION_TO_DATA_BUCKET`, `ALLOWED_TTL_DAYS`, the canonical bucket↔region map.
 - **infra/** (the ops toolbox): `configure_buckets.py`,
-  `configure_gcp_registry.py`, `github_wandb_metrics.py`, `pre-commit.py`,
-  `status-page/`, `tpu-ci/`, `probes/`, `codehealth/`, `lint/`.
+  `configure_gcp_registry.py`, `pre-commit.py`, `grafana/`, `tpu-ci/`,
+  `probes/`, `codehealth/`, `lint/`.
 - **GCP project**: `hai-gcp-models`. State dir convention:
   `gs://marin-<region>/iris/<cluster>/state/`.
 

--- a/.agents/ops/2026-03-22-zephyr-coordinator-thread-shutdown.md
+++ b/.agents/ops/2026-03-22-zephyr-coordinator-thread-shutdown.md
@@ -1,4 +1,4 @@
-# Debugging log for zephyr coordinator thread shutdown
+# Zephyr coordinator thread leaked during shutdown
 
 Fix the PR 3963 CI failure where the Zephyr test suite finished successfully, then crashed during interpreter shutdown because a background coordinator thread was still logging to a closed stderr stream.
 
@@ -22,7 +22,7 @@ The real `ZephyrContext.execute()` teardown path leaves the coordinator actor's 
 - Inspect `LocalClient.host_actor()` in `lib/fray/src/fray/local_backend.py`
 - Add a regression test in `lib/zephyr/tests/test_execution.py` that exercises `execute()` and waits for `zephyr-coordinator-loop` to disappear
 
-## Future Work
+## Future work
 
 - [ ] Consider teaching `LocalClient.host_actor()` to attach a generic stop hook for hosted actors that implement `shutdown()`
 - [ ] Audit other daemon-thread actors to make sure their lifecycle is owned by the caller

--- a/.agents/ops/2026-03-30-iris-worker-row-columns.md
+++ b/.agents/ops/2026-03-30-iris-worker-row-columns.md
@@ -1,4 +1,4 @@
-# Debugging Log for worker-row-columns
+# Iris worker-row schema mismatch
 
 Investigate `sqlite3.OperationalError: no such column: total_cpu_millicores` from the Iris controller scheduling loop.
 
@@ -29,6 +29,6 @@ The denormalized worker scheduling fields were added to controller code paths, b
 
 Confirmed by inspecting fresh `ControllerDB` startup: `PRAGMA table_info(workers)` did not contain the new columns before this fix.
 
-## Future Work
+## Future work
 
 - [ ] Add coverage for other denormalized row-model columns so missing migrations fail earlier.

--- a/.agents/ops/2026-06-11-marin-unit-import-error.md
+++ b/.agents/ops/2026-06-11-marin-unit-import-error.md
@@ -1,4 +1,4 @@
-# Debugging log for PR 6216 Marin unit failure
+# Marin unit import failure on PR 6216
 
 Fix the Marin unit test failure on PR 6216.
 

--- a/.agents/ops/2026-07-20-coreweave-ci-secret-access.md
+++ b/.agents/ops/2026-07-20-coreweave-ci-secret-access.md
@@ -1,4 +1,4 @@
-# Debugging log for CoreWeave CI secret access
+# CoreWeave CI signing-key access failure
 
 Restore the CoreWeave smoke test after GitHub credentials became available.
 

--- a/.agents/projects/20260130_fray_lite_design.md
+++ b/.agents/projects/20260130_fray_lite_design.md
@@ -2,7 +2,7 @@
 
 **Status**: Implemented (v2 API is the production interface)
 **Issue**: [#2552](https://github.com/marin-community/marin/issues/2552)
-**Research**: archived to `.agents/project/20260130_fray_lite_research.md`
+**Research**: archived to `.agents/projects/20260130_fray_lite_research.md`
 **Related**: [#2553](https://github.com/marin-community/marin/issues/2553) — Iris preemptible worker attribute (✅ done)
 
 ## Overview

--- a/.agents/projects/design-template.md
+++ b/.agents/projects/design-template.md
@@ -13,7 +13,9 @@ A design lives in `.agents/projects/<slug>/` as a directory:
 
 - `design.md` — the 1-pager (this template). Always present.
 - `research.md` — in-repo refs, prior-art comparison, Q&A summary that shaped the design. Always present, even if short.
-- `spec.md` — concrete contracts (proto, public client API, persisted shapes, error types). Present when the design adds new external contracts; skip for internal refactors.
+- `spec.md` — concrete contracts (proto, public client API, persisted shapes,
+  error types). Always present; an internal refactor may need only a short
+  contract for its imported or configured surface.
 
 **Length target for `design.md`**: ~1000 words is the goal, not a hard limit. Spend words where they buy clarity. If you're well over, you're either solving multiple problems (split it) or writing implementation details (move them to `spec.md`). The 1-pager is a snapshot, not a living doc — close the issue when the PR lands, don't sync it as the design evolves. `research.md` and `spec.md` have no length cap.
 

--- a/.agents/projects/executor_in_training_job/research.md
+++ b/.agents/projects/executor_in_training_job/research.md
@@ -50,7 +50,6 @@
 ### Related design docs
 
 - `.agents/projects/20260302_iris_reservation_design.md` — reservations are demand pre-provisioning; orthogonal to region pinning.
-- `.agents/projects/iris-log-store-gcs-fallback.md` — unrelated.
 
 ### Related issues
 

--- a/.agents/skills/archive-experiments/SKILL.md
+++ b/.agents/skills/archive-experiments/SKILL.md
@@ -60,4 +60,4 @@ Retire old experiment scripts without losing their history: put the code behind 
 - Spot-check a few URLs to verify they open the expected files inside the archive tag.
 
 ## See Also
-- `.agents/skills/organize-experiments/` for related curation workflows.
+- `.agents/skills/organize-experiments/SKILL.md` for related curation workflows.

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -248,5 +248,5 @@ pauses for the answer; it does not end monitoring.
 - Commit before you run `--review`; the review never commits, pushes, or edits.
 - Never amend a commit unless the user explicitly asks.
 - If there are no changes to commit, say so and stop.
-- `.agents/skills/fix-issue/` — end-to-end issue-fix workflow.
+- `.agents/skills/fix-issue/SKILL.md` — end-to-end issue-fix workflow.
 - `AGENTS.md` — coding guidelines.

--- a/.agents/skills/debug/SKILL.md
+++ b/.agents/skills/debug/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: debug
-description: Debug code bugs or Iris/Zephyr/TPU infrastructure faults with a structured debug log.
+description: Debug code bugs or Iris/Zephyr/TPU infrastructure faults with a structured incident record.
 ---
 
 # Skill: Debug
 
 Systematic debugging for code-level bugs and Marin infrastructure faults.
-For infrastructure symptoms, route to the right `OPS.md` section first; for
-code bugs, keep a structured debug log.
+For infrastructure symptoms, route to the right `OPS.md` section first. Keep
+durable investigation records in `.agents/ops/YYYY-MM-DD-<slug>.md`.
+
+Use the incident's investigation date and a 3-6-word kebab-case slug. Do not
+write `docs/debug-log-*` files or create another debug-log directory. Extend an
+existing record when it covers the same event. Use `write-ops-log` to finish an
+infrastructure or other multi-step incident as a standalone postmortem.
 
 ## Infrastructure faults
 
@@ -29,11 +34,13 @@ loop (`babysit-job` or `babysit-zephyr`).
 
 ## Code bugs
 
-For code-level bugs that are not infrastructure faults, maintain a debug log
-at `docs/debug-log-<task-name>.md`:
+For code-level bugs that are not infrastructure faults, maintain the same
+record at `.agents/ops/YYYY-MM-DD-<slug>.md`. A contained fix may use the
+lightweight structure below; preserve it and complete the `write-ops-log`
+structure when the investigation exposes an operational lesson:
 
 ```
-# Debugging log for <task>
+# <System or component>: <symptom>
 
 <goal>
 

--- a/.agents/skills/fix-docs/SKILL.md
+++ b/.agents/skills/fix-docs/SKILL.md
@@ -27,7 +27,7 @@ approval.
   - `.agents/skills/*/SKILL.md` — prompts for common agentic workflows.
 - **Avoid rot.** Rot confuses agents and wastes context. When a doc is out of
   date with the code: update it (if recent and the change is small) or archive
-  it to `.agents/projects/YYYYMMDD_filename.md` (if historical-only; date from
+  it to `.agents/projects/<YYYYMMDD>_<filename>.md` (if historical-only; date from
   the first commit via `git`). The code is the source of truth.
 - **Context quality and quantity are paramount.** Model performance degrades on
   a full context window. Agent docs should focus on:
@@ -38,4 +38,5 @@ approval.
 ## Common issues
 
 - Stale design docs that guided initial system design — move to
-  `.agents/projects/YYYYMMDD_filename.md`, dated from the first commit (`git`).
+  `.agents/projects/<YYYYMMDD>_<filename>.md`, dated from the first commit
+  (`git`).

--- a/.agents/skills/fix-issue/SKILL.md
+++ b/.agents/skills/fix-issue/SKILL.md
@@ -71,7 +71,7 @@ There are 2 cases:
   > Fix: unwrap the tuple in `RolloutWorker._step()` before passing to `foo()`.
 
 * **Design change**: The design doc replaces the `# Proposed Fix` section.
-  Write it per `.agents/skills/write-design-doc/` directly in the issue comment
+  Write it per `.agents/skills/write-design-doc/SKILL.md` directly in the issue comment
   (agents cannot commit files before the PR). The 3-4 sentence prose cap
   applies to `# Research`; the design doc follows its own length guidelines.
   Keep everything in one comment.

--- a/.agents/skills/organize-experiments/SKILL.md
+++ b/.agents/skills/organize-experiments/SKILL.md
@@ -45,4 +45,4 @@ Curate `docs/reports/index.md` after new experiment issues are harvested: fold f
 
 ## See Also
 - `scripts/pm/itemize_experiment_issues.py` for source data generation.
-- `.agents/skills/archive-experiments/` for retiring legacy experiments.
+- `.agents/skills/archive-experiments/SKILL.md` for retiring legacy experiments.

--- a/.agents/skills/profile-training/SKILL.md
+++ b/.agents/skills/profile-training/SKILL.md
@@ -99,7 +99,7 @@ annotations and make region-level summaries far more actionable.
 
 Reference:
 - `lib/levanter/docs/Performance-Guide.md`
-- `.agents/skills/add-pallas-kernel/`
+- `.agents/skills/add-pallas-kernel/SKILL.md`
 - JAX GPU performance tips:
   <https://docs.jax.dev/en/latest/gpu_performance_tips.html>
 

--- a/.agents/skills/recover-stuck-k8s-pod/SKILL.md
+++ b/.agents/skills/recover-stuck-k8s-pod/SKILL.md
@@ -167,7 +167,9 @@ kubectl --kubeconfig <kubeconfig> --context <context> uncordon <node>
 ```
 
 Record the timeline, commands, canonical attempt, node, provider operation,
-collateral workloads, and verification evidence in the incident or task log.
+collateral workloads, and verification evidence in
+`.agents/ops/YYYY-MM-DD-<slug>.md`. Extend the incident's existing record when
+one already exists.
 
 ## References
 

--- a/.agents/skills/refresh-tpu-vllm-forks/SKILL.md
+++ b/.agents/skills/refresh-tpu-vllm-forks/SKILL.md
@@ -241,7 +241,7 @@ workload or smoke test as part of this refresh.
 ### 6. Review Before PR
 
 Do a PR-review-style pass over the fork commits and Marin diff. Use
-`.agents/skills/review-pr/` as a checklist, then run
+`.agents/skills/review-pr/SKILL.md` as a checklist, then run
 `./infra/pre-commit.py --review` before opening the PR and fix or respond to
 every finding.
 

--- a/.agents/skills/run-ferries/SKILL.md
+++ b/.agents/skills/run-ferries/SKILL.md
@@ -177,7 +177,7 @@ If canary fails: triage and identify root cause, only then open a focused PR if 
 
 #### Canary profiling triage
 - The full `profile_summary.json` is in the workflow logs (default params: `--warmup-steps 5`, `--breakdown-mode exclusive_per_track`, `--hot-op-limit 25`). The step summary has pointers to the raw trace artifact and W&B run.
-- The log summary is ephemeral and not published. To re-analyze with different parameters, fetch the raw trace via `--run-target` — see `.agents/skills/profile-training/`.
+- The log summary is ephemeral and not published. To re-analyze with different parameters, fetch the raw trace via `--run-target` — see `.agents/skills/profile-training/SKILL.md`.
 - If the canary failed early, the profile may only cover warmup steps — check `step_time.all_steps.count` before drawing conclusions from steady-state stats.
 - `exclusive_per_track` (the default) can hide device stalls that overlap across tracks. Use `exclusive_global` when investigating stall-heavy profiles.
 
@@ -202,4 +202,4 @@ When promoting: open a follow-up PR updating `experiments/ferries/daily.py` and 
 - `docs/experiments/daily-ferry-log.md`
 - `.agents/skills/babysit-job/SKILL.md`
 - `.agents/projects/ferry_framework.md`
-- `.agents/skills/run-research/`
+- `.agents/skills/run-research/SKILL.md`

--- a/.agents/skills/run-research/SKILL.md
+++ b/.agents/skills/run-research/SKILL.md
@@ -44,7 +44,7 @@ Layer domain skills on top for task-specific constraints.
 
 ## Research Logbook
 
-Use the term **logbook** consistently. Follow `.agents/skills/task-logbook` for
+Use the term **logbook** consistently. Follow `.agents/skills/task-logbook/SKILL.md` for
 formatting and issue-update rules.
 
 ## Branches
@@ -146,7 +146,7 @@ Before closing the issue:
 
 ## See Also
 
-- `.agents/skills/organize-experiments/`
-- `.agents/skills/add-pallas-kernel/`
-- `.agents/skills/task-logbook/`
-- `.agents/skills/update-docs/`
+- `.agents/skills/organize-experiments/SKILL.md`
+- `.agents/skills/add-pallas-kernel/SKILL.md`
+- `.agents/skills/task-logbook/SKILL.md`
+- `.agents/skills/update-docs/SKILL.md`

--- a/.agents/skills/task-snapshot/SKILL.md
+++ b/.agents/skills/task-snapshot/SKILL.md
@@ -28,7 +28,7 @@ When posting a snapshot to an issue or PR, include:
 Pinned GitHub tree links should include the commit or tag, for example:
 
 ```text
-https://github.com/marin-community/marin/tree/<commit-or-tag>/.agents/logbooks/foo.md
+https://github.com/marin-community/marin/tree/<commit-or-tag>/.agents/logbooks/<topic>.md
 ```
 
 Prefer to use anchor text, even if it's just the filename.

--- a/.agents/skills/write-ops-log/SKILL.md
+++ b/.agents/skills/write-ops-log/SKILL.md
@@ -1,23 +1,26 @@
 ---
 name: write-ops-log
-description: Write a postmortem ops log to .agents/ops/. Use after an infrastructure-debugging session.
+description: Write a postmortem incident record to .agents/ops/. Use after an infrastructure or durable debugging session.
 ---
 
 # Skill: Ops Log
 
 Summarize a debugging / incident-response conversation as a standalone
-postmortem entry under `.agents/ops/`. The audience is a future sysops
-engineer (probably another Claude session) with no memory of this conversation
-who must reconstruct: what broke, what was tried, what the user steered, what
-fixed it, and how OPS.md guidance could have shortened the investigation.
+postmortem entry under `.agents/ops/`. This is the canonical home for
+infrastructure and durable debugging incident records; `docs/` is not. The
+audience is a future sysops engineer (probably another Claude session) with no
+memory of this conversation who must reconstruct: what broke, what was tried,
+what the user steered, what fixed it, and how OPS.md guidance could have
+shortened the investigation.
 
 ## Filename
 
 `.agents/ops/YYYY-MM-DD-<slug>.md`
 
 The `.agents/ops/` directory is checked into git; `.agents/ops/logs/` is
-gitignored (matched by the global `logs/` pattern), so do not nest logs
-under a `logs/` subdirectory.
+gitignored (matched by the global `logs/` pattern), so do not nest records
+under a `logs/` subdirectory. Do not use `docs/debug-log-*.md` or another
+debug-log directory.
 
 - Use the date the issue was investigated, not today's arbitrary date.
 - `<slug>` is 3-6 words, kebab-case, naming the system + symptom. Examples:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,16 @@ uv run pytest
 - Keep MkDocs content in sync with code. Use Markdown and mkdocs-style links.
 - Write docs that stand alone without conversational context.
 
+## Agent Artifacts
+
+- Record infrastructure incidents and durable debugging investigations in
+  `.agents/ops/YYYY-MM-DD-<slug>.md`. Do not create `docs/debug-log-*` files or
+  ad hoc debug-log directories. Extend the existing incident record when it
+  covers the same event.
+- Keep user-facing and reusable product documentation in `docs/`; keep research
+  progress in the relevant task logbook or project artifact. These are distinct
+  from incident records.
+
 ## Deprecation
 
 **NO BACKWARD COMPATIBILITY**: Update all call sites instead. Only add compatibility shims if the user explicitly requests it.

--- a/lib/finelog/AGENTS.md
+++ b/lib/finelog/AGENTS.md
@@ -1,9 +1,9 @@
 # Finelog Agent Notes
 
 Standalone log store + log service. Originally lifted out of `lib/iris`
-(`iris/cluster/log_store/` and `iris/log_server/`); see the design plan at
-`.agents/projects/2026-04-27_finelog_lift.md` (if present) or the original
-extraction PR for context.
+(`iris/cluster/log_store/` and `iris/log_server/`); see the worked proposal in
+`.agents/projects/design-template.md` or the original extraction PR for
+context.
 
 Start with the shared instructions in `/AGENTS.md`. Finelog-specific notes:
 

--- a/lib/finelog/AGENTS.md
+++ b/lib/finelog/AGENTS.md
@@ -1,9 +1,9 @@
 # Finelog Agent Notes
 
 Standalone log store + log service. Originally lifted out of `lib/iris`
-(`iris/cluster/log_store/` and `iris/log_server/`); see the worked proposal in
-`.agents/projects/design-template.md` or the original extraction PR for
-context.
+(`iris/cluster/log_store/` and `iris/log_server/`); see the
+[worked Finelog proposal](../../.agents/projects/design-template.md#worked-example)
+or the original extraction PR for context.
 
 Start with the shared instructions in `/AGENTS.md`. Finelog-specific notes:
 

--- a/lib/iris/AGENTS.md
+++ b/lib/iris/AGENTS.md
@@ -6,6 +6,8 @@ Distributed job orchestration for Marin. Start with the shared instructions in `
 
 - `README.md` — overview + quick start
 - `OPS.md` — operating / troubleshooting a live cluster (also used by skills: `debug`, `restart-iris`)
+- `.agents/ops/YYYY-MM-DD-<slug>.md` — durable incident and debugging records;
+  use `write-ops-log` after an infrastructure investigation
 - `TESTING.md` — testing policy, markers, and commands
 - `docs/task-states.md` — task state machine + retry semantics
 - `docs/coreweave.md` — CoreWeave platform + `runtime=kubernetes` behavior

--- a/lib/iris/docs/architecture.md
+++ b/lib/iris/docs/architecture.md
@@ -2,8 +2,7 @@
 
 How the Iris source tree is organized and the rule that keeps it navigable.
 For the controller's reconcile kernel specifically, see
-[`reconcile_rpc.md`](reconcile_rpc.md) and the design notes in
-`.agents/projects/reconcile-final-design.md`.
+[`reconcile_rpc.md`](reconcile_rpc.md).
 
 ## The one rule: five layers, imports go down
 

--- a/lib/levanter/docs/design/inference.md
+++ b/lib/levanter/docs/design/inference.md
@@ -1,6 +1,7 @@
 # Draft Design Document for Inference
 
-> **Note**: This document contains the technical design and architecture for the inference server. For project implementation tasks and progress tracking, see [`.agents/projects/inference.md`](/.agents/projects/inference.md).
+> **Note**: This document contains the technical design and architecture for
+> the inference server.
 
 ## References
 

--- a/lib/zephyr/AGENTS.md
+++ b/lib/zephyr/AGENTS.md
@@ -6,6 +6,8 @@ Lazy dataset processing library. Start with the shared instructions in `/AGENTS.
 
 - `README.md` — overview, API reference, quick start
 - `OPS.md` — debugging pipelines: dashboard, observability, profiling, diagnostic patterns (also used by skills: `debug`, `babysit-zephyr`)
+- `.agents/ops/YYYY-MM-DD-<slug>.md` — durable incident and debugging records;
+  use `write-ops-log` after an infrastructure investigation
 - Archived: `.agents/projects/20260130_fray_lite_design.md` — Fray backend design (implemented; read `lib/fray/src/fray/` instead)
 
 ## Source Layout


### PR DESCRIPTION
Standardize durable infrastructure and debugging records under
`.agents/ops/YYYY-MM-DD-<slug>.md`, and align shared, Iris, Zephyr, debug,
recovery, and ops-steward guidance on that convention. Move the four remaining
`docs/debug-log-*` files to their dated incident paths.

Normalize live skill references to exact `SKILL.md` locations and remove stale
agent-artifact links found by the scoped sweep. Research logbooks, project
artifacts, and historical `.agents/docs` records remain separate because they
serve experiment continuity, design work, and archived agent guidance rather
than incident response.
