### PR TITLE
[iris] Pin native proxy 0.1.1 and share RPC collector

### DIFF
--- a/.agents/ops/2026-07-24-iris-rpc-collector-collision.md
+++ b/.agents/ops/2026-07-24-iris-rpc-collector-collision.md
@@ -1,0 +1,44 @@
+# Iris RPC metrics: duplicate collector registration
+
+Restore green Iris E2E coverage after #7598 moved RPC metrics into a custom
+Prometheus collector.
+
+## Initial status
+
+`iris-e2e-smoke` fails in `test_checkpoint_restore` when its dedicated
+`LocalCluster` starts while the module-scoped smoke cluster is still running.
+The second controller raises `ValueError: Duplicated timeseries in
+CollectorRegistry` for the `iris_rpc_*` families.
+
+## Hypothesis 1
+
+Controller teardown fails to unregister the collector.
+
+The failure occurs before the dedicated cluster restarts. The module-scoped
+smoke controller is intentionally still live, so teardown cannot solve the
+initial collision. Telltale's registry is process-global, while the E2E process
+can host more than one local controller.
+
+## Changes to make
+
+Represent all native proxies in one process-level Iris RPC collector and
+aggregate equal service/method/upstream series. Controller shutdown detaches its
+proxy; the collector remains registered like Telltale's counter, gauge, and
+histogram objects.
+
+Add a behavior test that attaches two native metric sources and verifies the
+public Prometheus families expose their combined counters, gauges, statuses,
+and histogram values.
+
+## Results
+
+The two-controller regression test failed before the change with the same
+`Duplicated timeseries` exception as CI and passed after aggregation.
+
+The native proxy and authentication suites passed 43 tests against the stable
+PyPI wheel. The complete local smoke suite, including
+`test_checkpoint_restore`, passed 24 tests with one skipped.
+
+## Future work
+
+- [ ] Automate native release pins after stable publication; tracked in #6456.

--- a/lib/iris/pyproject.toml
+++ b/lib/iris/pyproject.toml
@@ -16,8 +16,7 @@ dependencies = [
     "marin-finelog >= 0.2.10",
     "marin-finelog-server >= 0.2.10",
     # Platform companion wheel containing the Rust-owned public proxy listener.
-    # The dev floor opts uv into its scheduled nightly wheels.
-    "marin-iris-native >= 0.1.1.dev202607241746",
+    "marin-iris-native >= 0.1.1",
     "click>=8.3.1",
     "cloudpickle>=3.1.2",
     "connect-python>=0.9.0",

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -77,6 +77,7 @@ from iris.cluster.controller.native_proxy import NativeProxy, NativeProxyStats
 from iris.cluster.controller.native_proxy_metrics import (
     NativeProxyMetricsCollector,
     install_native_proxy_metrics,
+    uninstall_native_proxy_metrics,
 )
 from iris.cluster.controller.ops.task import (
     Assignment,
@@ -848,8 +849,8 @@ class Controller:
 
         if self._telltale_forwarding:
             telltale.stop_forwarding()
-        if self._native_proxy_metrics is not None:
-            telltale.unregister_collector(self._native_proxy_metrics)
+        if self._native_proxy_metrics is not None and self._native_proxy is not None:
+            uninstall_native_proxy_metrics(self._native_proxy)
             self._native_proxy_metrics = None
         if self._native_proxy is not None:
             self._native_proxy.stop()

--- a/lib/iris/src/iris/cluster/controller/native_proxy_metrics.py
+++ b/lib/iris/src/iris/cluster/controller/native_proxy_metrics.py
@@ -1,15 +1,18 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Expose native Iris RPC metrics through the controller Telltale registry.
+"""Expose native Iris RPC metrics through the process Telltale registry.
 
 Counters reset when the native proxy restarts. Rate queries must discard
-negative deltas across that reset boundary.
+negative deltas across that reset boundary. Processes hosting multiple local
+controllers expose the sum of their native proxies because Prometheus metric
+families are process-global.
 """
 
 import json
+import threading
 from collections.abc import Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from prometheus_client.core import Metric
 from prometheus_client.registry import Collector
@@ -33,39 +36,92 @@ class _RpcMetricSeries:
     latency_sum_seconds: float
 
 
+@dataclass(frozen=True)
+class _RpcMetricSeriesKey:
+    service: str
+    method: str
+    upstream: str
+
+
+@dataclass
+class _AggregatedRpcMetricSeries:
+    requests: int = 0
+    responses: dict[str, int] = field(default_factory=dict)
+    in_flight: int = 0
+    latency_buckets: dict[str, int] = field(default_factory=dict)
+    latency_count: int = 0
+    latency_sum_seconds: float = 0.0
+
+    def add(self, series: _RpcMetricSeries) -> None:
+        self.requests += series.requests
+        self.in_flight += series.in_flight
+        self.latency_count += series.latency_count
+        self.latency_sum_seconds += series.latency_sum_seconds
+        for status, count in series.responses.items():
+            self.responses[status] = self.responses.get(status, 0) + count
+        for bound, count in series.latency_buckets:
+            self.latency_buckets[bound] = self.latency_buckets.get(bound, 0) + count
+
+
 class NativeProxyMetricsCollector(Collector):
     """Collect native RPC counters, gauges, and histograms for Telltale."""
 
-    def __init__(self, proxy: NativeProxy) -> None:
-        self._proxy = proxy
+    def __init__(self) -> None:
+        self._proxies: list[NativeProxy] = []
+        self._lock = threading.Lock()
+
+    def attach(self, proxy: NativeProxy) -> None:
+        with self._lock:
+            if any(current is proxy for current in self._proxies):
+                return
+            self._proxies.append(proxy)
+
+    def detach(self, proxy: NativeProxy) -> None:
+        with self._lock:
+            self._proxies = [current for current in self._proxies if current is not proxy]
 
     def collect(self) -> Iterable[Metric]:
-        snapshot: dict = json.loads(self._proxy.rpc_metrics_json)
+        with self._lock:
+            snapshots: list[dict] = [json.loads(proxy.rpc_metrics_json) for proxy in self._proxies]
+        aggregated: dict[_RpcMetricSeriesKey, _AggregatedRpcMetricSeries] = {}
+        for snapshot in snapshots:
+            for raw_series in snapshot["series"]:
+                series = _RpcMetricSeries(**raw_series)
+                key = _RpcMetricSeriesKey(series.service, series.method, series.upstream)
+                aggregated.setdefault(key, _AggregatedRpcMetricSeries()).add(series)
+
         requests = Metric("iris_rpc_requests", "Iris RPC requests handled by the native proxy", "counter")
         responses = Metric("iris_rpc_responses", "Iris RPC responses returned by the native proxy", "counter")
         in_flight = Metric(IN_FLIGHT_METRIC_NAME, "Iris RPC requests currently handled by the native proxy", "gauge")
         duration = Metric("iris_rpc_duration_seconds", "Iris RPC native-proxy latency", "histogram")
-        for raw_series in snapshot["series"]:
-            series = _RpcMetricSeries(**raw_series)
+        for key, series in aggregated.items():
             labels = {
-                "service": series.service,
-                "method": series.method,
-                "upstream": series.upstream,
+                "service": key.service,
+                "method": key.method,
+                "upstream": key.upstream,
             }
             requests.add_sample("iris_rpc_requests_total", labels=labels, value=series.requests)
             in_flight.add_sample(IN_FLIGHT_METRIC_NAME, labels=labels, value=series.in_flight)
             for status, count in series.responses.items():
                 responses.add_sample("iris_rpc_responses_total", labels={**labels, "status": status}, value=count)
-            for bound, count in series.latency_buckets:
+            for bound, count in series.latency_buckets.items():
                 duration.add_sample("iris_rpc_duration_seconds_bucket", labels={**labels, "le": bound}, value=count)
             duration.add_sample("iris_rpc_duration_seconds_sum", labels=labels, value=series.latency_sum_seconds)
             duration.add_sample("iris_rpc_duration_seconds_count", labels=labels, value=series.latency_count)
         return (requests, responses, in_flight, duration)
 
 
+_COLLECTOR = NativeProxyMetricsCollector()
+
+
 def install_native_proxy_metrics(proxy: NativeProxy) -> NativeProxyMetricsCollector:
-    """Make ``proxy`` the source for the process's Iris RPC Telltale series."""
-    collector = NativeProxyMetricsCollector(proxy)
-    telltale.register_collector(collector)
+    """Add ``proxy`` to the process's Iris RPC Telltale series."""
+    _COLLECTOR.attach(proxy)
+    telltale.register_collector(_COLLECTOR)
     telltale.set_global_labels(source="iris")
-    return collector
+    return _COLLECTOR
+
+
+def uninstall_native_proxy_metrics(proxy: NativeProxy) -> None:
+    """Stop exposing a native proxy after its controller shuts down."""
+    _COLLECTOR.detach(proxy)

--- a/lib/iris/tests/cluster/controller/test_native_proxy.py
+++ b/lib/iris/tests/cluster/controller/test_native_proxy.py
@@ -17,6 +17,7 @@ from iris.cluster.controller.auth import (
 from iris.cluster.controller.endpoint_service import ProxyEndpointMapping, ProxyRegistrySnapshot
 from iris.cluster.controller.native_proxy import PROXY_DECISION_PATH, NativeProxy
 from iris.managed_thread import ThreadContainer
+from rigging import telltale
 from rigging.timing import Duration, ExponentialBackoff
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -154,6 +155,45 @@ def test_native_listener_preserves_public_routes_and_streams_to_endpoint(
         assert received_bodies == [payload]
     finally:
         threads.stop()
+
+
+def test_native_rpc_metrics_aggregate_controllers_in_one_process(make_controller, tmp_path) -> None:
+    controllers = [
+        make_controller(
+            host="127.0.0.1",
+            port=0,
+            local_state_dir=tmp_path / name,
+            remote_state_dir=f"file://{tmp_path}/{name}-remote",
+        )
+        for name in ("first", "second")
+    ]
+    for controller in controllers:
+        controller.start()
+        response = httpx.post(
+            f"{controller.url}/iris.cluster.ControllerService/ListJobs",
+            json={},
+        )
+        assert response.status_code == 200
+
+    labels = {
+        "service": "iris.cluster.ControllerService",
+        "method": "ListJobs",
+        "upstream": "controller",
+    }
+
+    def sample_value(name: str, **extra_labels: str) -> float:
+        matching = [
+            family_sample.sample.value
+            for family_sample in telltale.samples()
+            if family_sample.sample.name == name and family_sample.sample.labels == {**labels, **extra_labels}
+        ]
+        assert len(matching) == 1
+        return matching[0]
+
+    assert sample_value("iris_rpc_requests_total") == 2
+    assert sample_value("iris_rpc_responses_total", status="200") == 2
+    assert sample_value("iris_rpc_in_flight") == 0
+    assert sample_value("iris_rpc_duration_seconds_count") == 2
 
 
 def test_native_listener_caches_verified_jwt(make_controller) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -4984,7 +4984,7 @@ requires-dist = [
     { name = "kubernetes", marker = "extra == 'controller'", specifier = ">=31.0.0,<36" },
     { name = "marin-finelog", editable = "lib/finelog" },
     { name = "marin-finelog-server", specifier = ">=0.2.10" },
-    { name = "marin-iris-native", specifier = ">=0.1.1.dev202607241746" },
+    { name = "marin-iris-native", specifier = ">=0.1.1" },
     { name = "marin-rigging", editable = "lib/rigging" },
     { name = "marin-rigging", extras = ["iap"], marker = "extra == 'iap'", editable = "lib/rigging" },
     { name = "marin-rigging", extras = ["secrets"], marker = "extra == 'controller'", editable = "lib/rigging" },
@@ -5035,13 +5035,13 @@ test = [
 
 [[package]]
 name = "marin-iris-native"
-version = "0.1.1.dev202607241746"
+version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/69/14/184aa4e83d08bdd1138bf10820cf2974441f7c55af999cf979260d3ad2fb/marin_iris_native-0.1.1.dev202607241746.tar.gz", hash = "sha256:4867996d8d9590c09a51aef8795b911689a52ef2c7e1f1b0f89a62e0ce30c1eb", size = 35244, upload-time = "2026-07-24T17:51:39.273Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/8a/21e68fed59085e074872886673b7b99f7d792d79c65ff4dd7f238123d54d/marin_iris_native-0.1.1.tar.gz", hash = "sha256:5a5ec2ce25267ce3c65dedc53d80234ecc25541640693f2140f5130cb093a032", size = 35113, upload-time = "2026-07-24T18:37:15.053Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/09/982a2321097bec7ccd93d318e7689315593b6bb857ee5fbdb01fb21eb77b/marin_iris_native-0.1.1.dev202607241746-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:e12bf26eecdfb8f683a8399d9174e2af22186b86c83e4311ae1ec5eda1f3c437", size = 3327374, upload-time = "2026-07-24T17:51:34.262Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/2b/6c07162ccbbdd11c3b8185d0b31ff0dc25f99348b53c1ed57065db4319f7/marin_iris_native-0.1.1.dev202607241746-cp312-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1ecbd5ce2f640b794a744a3073e53ce7ca45cb37d392ef5018346522ac0f6d4b", size = 3510286, upload-time = "2026-07-24T17:51:36.066Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/7f/8d9a0b831faeae32f7aa581099b1848289b17c215ff9a697f9f95b1ee6f1/marin_iris_native-0.1.1.dev202607241746-cp312-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9816edfbc1ffd0d97ddb953cfa4a06e78618230449727de634ab2ede3c383370", size = 3665606, upload-time = "2026-07-24T17:51:37.693Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/10/0bc9b4c2b2d44eac91d41e669d0ebb0b77f3934672901f31743223bdb090/marin_iris_native-0.1.1-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:471664056e88752af0446b1dff794705a60b3b8f05683c7ec5e5c0d2cf572f87", size = 3327398, upload-time = "2026-07-24T18:37:10.501Z" },
+    { url = "https://files.pythonhosted.org/packages/58/21/907bba77e08c78fe29138a89c6f73722c1b85b4ad008049949b3ecee7978/marin_iris_native-0.1.1-cp312-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:b2bb38b7e633715499ff5aa765fb9bdd39c931de20bda2154deea9a937b28d2f", size = 3510549, upload-time = "2026-07-24T18:37:12.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4d/b2aed59c3215909ea690572964847012f4473da8aeed6208dd727ee6251e/marin_iris_native-0.1.1-cp312-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9118a2f46625316d47aa49c111b7838595a54b6014ab464d39ee63d40b7b7eda", size = 3665747, upload-time = "2026-07-24T18:37:13.569Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Require `marin-iris-native>=0.1.1` and lock the stable wheels published from
the merged #7598 commit. Frozen installs now receive the authentication handoff
changes from #7583 and native RPC metrics without activating Rust source-build
mode.

Keep one process-level Iris RPC collector when tests host multiple local
controllers. Their native proxies aggregate into the existing metric labels and
detach during shutdown, avoiding duplicate Prometheus family registration
without changing the one-controller production schema or restart reset
semantics.

Release workflow
[#30117464848](https://github.com/marin-community/marin/actions/runs/30117464848)
published macOS arm64 and Linux x86_64/aarch64 wheels plus the source
distribution. All 35 Iris authentication tests pass against the installed PyPI
wheel. The complete local Iris smoke suite passes 24 tests with one skipped,
including the checkpoint restart that previously raised `Duplicated
timeseries`.
