### PR TITLE
[eval] Restore Grug OpenCode evaluation

### DIFF
--- a/.agents/ops/2026-07-24-harbor-dataset-revision.md
+++ b/.agents/ops/2026-07-24-harbor-dataset-revision.md
@@ -1,0 +1,62 @@
+# Harbor dataset revision: configured tag is absent
+
+Verify and correct the Grug OpenCode dataset selector after the capped PR #7606 validation reached
+the ready vLLM service but failed during Harbor task resolution.
+
+## Initial status
+
+The one-task run `/loom/eval-20260724-210018-grug-agentic-s3-step1903-6046` staged the object-store
+model and brought the H100x8 vLLM service to readiness. Harbor then rejected
+`DCAgent/dev_set_v2` with `ValueError: Tag '1.0' not found for dataset 'DCAgent/dev_set_v2'` before
+starting a Daytona sandbox.
+
+## Hypothesis 1
+
+The inherited `1.0` value is a package version rather than a registry tag, so serializing it as
+Harbor's `ref` field selects the wrong registry namespace.
+
+## Changes to make
+
+Inspect the installed Harbor schema and live package metadata, then bind the dataset using the field
+that resolves the intended published revision. Add a regression assertion against the native Harbor
+schema and repeat the same one-task validation.
+
+## Results
+
+Current Harbor interprets any slash-qualified dataset name as a package-registry identifier and
+interprets `ref: "1.0"` as a package tag. The live package registry has no
+`DCAgent/dev_set_v2` package. The intended dataset is instead the public Hugging Face repository
+`DCAgent/dev_set_v2`, whose `main` branch resolved to
+`377118ff3031c934f5a647ae2c425eb74eef3b21` during the investigation. The evaluation now pins that
+commit and uses the launcher's existing `hf://` materialization path.
+
+## Future work
+
+- [x] Record the capped rerun result.
+
+## Hypothesis 2
+
+The corrected rerun completed all three Harbor attempts, then failed while persisting the trial tree.
+The Harbor runner passed an S3 URL to helpers that always constructed a GCS filesystem, so `gcsfs`
+interpreted `s3:` as a bucket name.
+
+## Changes to make
+
+Resolve the filesystem from each artifact URL and cover a complete trial-tree upload and restore
+through a non-GCS remote protocol.
+
+## Results
+
+The upload and restore helpers now resolve their filesystem from the artifact URL. A regression test
+round-trips `result.json` and the agent trajectory through an in-memory remote filesystem; the 128
+evaluation, eval, and inference tests pass.
+
+The first final-code rerun spent the full 40-minute CoreWeave startup grace period in `building`
+without a worker attempt, log, failure, or preemption. Iris recorded `infra_failed` and cleaned up
+the child. The unchanged retry
+`/loom/eval-20260724-221717-grug-agentic-s3-step1903-a34d` then succeeded. It staged 45 model files,
+started the H100x8 vLLM service, completed all three attempts for one OpenCode task, uploaded the
+three trial trees, wrote the normalized samples and aggregate result, and recorded `status=succeeded`
+at
+`s3://marin-us-east-02a/marin/eval-metadata/runs/20260724-221717-grug-agentic-s3-step1903-grug-opencode-id-83c1/record.json`.
+The task scored 0/3; the capped run validated the launch and persistence path, not model quality.

--- a/TESTING.md
+++ b/TESTING.md
@@ -72,6 +72,9 @@ Delete or rewrite tests with negative value:
   are valid when the failure is externally observable.
 - Tests for Python language semantics.
 - Registration tests: Tests that check that specific items are registered in global registries.
+- Configuration projections: assertions that a lowered or constructed field equals the same value
+  supplied by the test or checked-in config. Test validation, merge conflicts, observable behavior,
+  or a real external wire translation instead.
 - Permanently skipped tests or empty test files.
 - Screenshot-only tests without behavioral assertions.
 - "Does not raise" tests without a comment explaining why that is the contract.

--- a/docs/harbor-integration.md
+++ b/docs/harbor-integration.md
@@ -38,18 +38,13 @@ Use `--limit N` to cap the number of trials and `--no-wait` to return after subm
 
 ## Credentials
 
-Daytona runs require `DAYTONA_API_KEY` in the launch environment.
+Daytona-backed definitions in `experiments/evaluation/evals.py` own their credential references.
+They use `DAYTONA_API_KEY` from the launch environment when present, then fall back to the approved
+Google Secret Manager version. `DAYTONA_API_KEY` is the only supported environment override.
 
-The sandbox receives only the credentials needed by the selected agent. Depending on the benchmark
-and agent, this can include:
-
-- `HF_TOKEN`
-- `ANTHROPIC_API_KEY`
-- `OPENAI_API_KEY`
-- `E2B_API_KEY`
-- `MODAL_API_KEY`
-
-Do not put credentials in model YAMLs or runner definitions.
+The generic launcher resolves declared references immediately before Iris submission. The isolated
+Harbor subprocess receives the Daytona key without inheriting the orchestrator's other credentials.
+Do not put resolved credentials in model YAMLs, runner configs, or evaluation artifacts.
 
 ## Endpoint lifecycle
 
@@ -65,14 +60,19 @@ registrations, and a retried task attempt atomically replaces its own same-name 
 A `HarborExecutor` contains a `HarborRunConfig`:
 
 ```python
-from marin.evaluation.harbor.runner import HarborExecutor, HarborRunConfig
+from marin.evaluation.harbor.driver_config import (
+    HarborAgentConfig,
+    HarborEnvironmentConfig,
+    HarborRunConfig,
+)
+from marin.evaluation.harbor.runner import HarborExecutor
 
 executor = HarborExecutor(
     config=HarborRunConfig(
         dataset="hf://DCAgent2/terminal_bench_2",
-        version="main",
-        agent="terminus-2",
-        env="daytona",
+        revision="main",
+        agent=HarborAgentConfig(name="terminus-2"),
+        environment=HarborEnvironmentConfig(environment_type="daytona"),
         n_concurrent=4,
         task_limit=2,
     ),

--- a/experiments/evaluation/README.md
+++ b/experiments/evaluation/README.md
@@ -134,11 +134,9 @@ cached `models()` registry in `models.py`:
 
 Set `resource_hint.hbm_gb` to a portable serving footprint, or set
 `resource_hint.gpu` to an accepted exact GPU shape such as `{"H100": 8}`. The experiment fleet maps
-that requirement to a cluster. Set `resource_hint.memory` for exports whose shard staging needs more
+that requirement to a cluster. Set `resource_hint.memory` when serving needs more than the default
 host memory. Set `tokenizer` when `location` is an object-store export because the eval client loads
-its tokenizer through Hugging Face. `serve.object_store_load_mode: local` copies an object-store
-export to the inference worker's ephemeral disk before vLLM starts; the default `stream` mode uses
-the RunAI loader.
+its tokenizer through Hugging Face. vLLM streams object-store weights through the RunAI loader.
 Every explicit `serve` value wins over what `auto_serve_overrides` derives from the model's
 `config.json`; `generation.extra_gen_kwargs` (e.g. `skip_special_tokens=false` for a thinking model)
 rides on `--gen_kwargs`.

--- a/experiments/evaluation/README.md
+++ b/experiments/evaluation/README.md
@@ -97,8 +97,23 @@ land in evaldash like every other eval.
 uv run python -m experiments.evaluation.cli launch --model qwen3-8b --evals tb2-lite
 ```
 
-A Daytona-backed Harbor launch needs `DAYTONA_API_KEY` in the launch environment. Harbor runs as an
-isolated `uv` subprocess outside the Marin lock.
+Daytona-backed definitions declare one experiment-owned credential specification. A launch first
+uses `DAYTONA_API_KEY` from its environment, then falls back to the `DAYTONA_EVAL_API_KEY` secret in
+the `hai-gcp-models` Google Secret Manager project. `DAYTONA_API_KEY` is the only supported
+environment override; the old `DAYTONA_EVAL_API_KEY` environment alias is not read. The generic
+launcher resolves the declaration immediately before Iris submission, and the isolated Harbor
+subprocess receives that key without inheriting the orchestrator's other credentials.
+
+The Grug OpenCode profile keeps its model and Harbor policy on the unified path:
+
+```bash
+# One OpenCode trial with the step-1903 Grug SFT on H100x8.
+uv run python -m experiments.evaluation.cli launch \
+  --model grug-agentic-s3-step1903 --evals grug-opencode-id --limit 1
+```
+
+The profile materializes `DCAgent/dev_set_v2` from a pinned Hugging Face commit before passing its
+task directories to Harbor.
 
 Mechanism code lives under `marin.evaluation.evalchemy` and `marin.evaluation.harbor`; the common
 runner depends only on the callable executor protocol and the shared record types.
@@ -121,7 +136,9 @@ Set `resource_hint.hbm_gb` to a portable serving footprint, or set
 `resource_hint.gpu` to an accepted exact GPU shape such as `{"H100": 8}`. The experiment fleet maps
 that requirement to a cluster. Set `resource_hint.memory` for exports whose shard staging needs more
 host memory. Set `tokenizer` when `location` is an object-store export because the eval client loads
-its tokenizer through Hugging Face.
+its tokenizer through Hugging Face. `serve.object_store_load_mode: local` copies an object-store
+export to the inference worker's ephemeral disk before vLLM starts; the default `stream` mode uses
+the RunAI loader.
 Every explicit `serve` value wins over what `auto_serve_overrides` derives from the model's
 `config.json`; `generation.extra_gen_kwargs` (e.g. `skip_special_tokens=false` for a thinking model)
 rides on `--gen_kwargs`.

--- a/experiments/evaluation/evals.py
+++ b/experiments/evaluation/evals.py
@@ -5,23 +5,55 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
+from types import MappingProxyType
 from typing import Protocol
 
 from marin.evaluation.evalchemy.runner import EvalchemyExecutor, EvalchemyRunConfig
 from marin.evaluation.evaluation_config import EvalTaskConfig
-from marin.evaluation.harbor.runner import HarborExecutor, HarborRunConfig
+from marin.evaluation.harbor.driver_config import (
+    HarborAgentConfig,
+    HarborEnvironmentConfig,
+    HarborRetryConfig,
+    HarborRunConfig,
+    HarborVerifierConfig,
+)
+from marin.evaluation.harbor.runner import HarborExecutor
 from marin.evaluation.model_config import ModelConfig
 from marin.evaluation.records import EvalRef, EvalTaskRef, HarborRef
 from marin.evaluation.runner import EvalExecutor
+from rigging.secrets import SecretSpec
 
 _TERMINAL_BENCH_DATASET = "DCAgent2/terminal_bench_2"
 _SWEBENCH_RANDOM_100_DATASET = "DCAgent2/swebench-verified-random-100-folders"
 _AGENTIC_CONCURRENCY = 32
+_DAYTONA_SECRET_ENV: Mapping[str, SecretSpec] = MappingProxyType(
+    {
+        "DAYTONA_API_KEY": (
+            "env:DAYTONA_API_KEY",
+            "gcp-secret://projects/hai-gcp-models/secrets/DAYTONA_EVAL_API_KEY/versions/latest",
+        )
+    }
+)
+_GRUG_NON_RETRYABLE_EXCEPTIONS = (
+    "AgentTimeoutError",
+    "AgentEnvironmentTimeoutError",
+    "VerifierTimeoutError",
+    "RewardFileNotFoundError",
+    "RewardFileEmptyError",
+    "VerifierOutputParseError",
+    "SandboxBuildFailedError",
+    "VerifierRuntimeError",
+    "SummarizationTimeoutError",
+    "ContextLengthExceededError",
+)
 
 
 class EvaluationDefinition(Protocol):
     """Experiment-owned record metadata and model adaptation for one evaluation."""
+
+    secret_env: Mapping[str, SecretSpec]
 
     @property
     def record_ref(self) -> EvalRef: ...
@@ -32,6 +64,7 @@ class EvaluationDefinition(Protocol):
 @dataclass(frozen=True)
 class EvalchemyDefinition:
     config: EvalchemyRunConfig
+    secret_env: Mapping[str, SecretSpec] = field(default_factory=dict)
 
     @property
     def record_ref(self) -> EvalRef:
@@ -63,6 +96,7 @@ class HarborDefinition:
     name: str
     config: HarborRunConfig
     max_eval_instances: int | None = None
+    secret_env: Mapping[str, SecretSpec] = field(default_factory=dict)
 
     @property
     def record_ref(self) -> EvalRef:
@@ -71,9 +105,9 @@ class HarborDefinition:
             mechanism="harbor",
             harbor=HarborRef(
                 dataset=self.config.dataset,
-                version=self.config.version,
-                agent=self.config.agent,
-                env=self.config.env,
+                version=self.config.revision,
+                agent=self.config.agent.name,
+                env=self.config.environment.environment_type,
             ),
         )
 
@@ -82,9 +116,12 @@ class HarborDefinition:
         config = replace(
             self.config,
             task_limit=effective_limit,
-            agent_kwargs={**model.agent.agent_kwargs, **self.config.agent_kwargs},
+            agent=replace(
+                self.config.agent,
+                kwargs={**model.agent.agent_kwargs, **self.config.agent.kwargs},
+            ),
         )
-        return HarborExecutor(config=config)
+        return HarborExecutor(config=config, secret_env_keys=tuple(self.secret_env))
 
 
 def _mcq_eval(name: str, task: str, shots: int) -> EvalchemyDefinition:
@@ -129,13 +166,59 @@ def _agentic_eval(
         name=name,
         config=HarborRunConfig(
             dataset=f"hf://{hugging_face_dataset}",
-            version="main",
-            agent=agent,
-            env="daytona",
+            revision="main",
+            agent=HarborAgentConfig(name=agent),
+            environment=HarborEnvironmentConfig(environment_type="daytona"),
             n_concurrent=n_concurrent,
         ),
         max_eval_instances=max_instances,
+        secret_env=_DAYTONA_SECRET_ENV,
     )
+
+
+GRUG_OPENCODE_EVAL = HarborDefinition(
+    name="grug-opencode-id",
+    config=HarborRunConfig(
+        dataset="hf://DCAgent/dev_set_v2",
+        revision="377118ff3031c934f5a647ae2c425eb74eef3b21",
+        agent=HarborAgentConfig(
+            name="opencode",
+            max_output_tokens=16384,
+            max_timeout=7200,
+            setup_timeout=600,
+            kwargs={
+                "opencode_config": {"compaction": {"auto": False}},
+                "model_info": {
+                    "max_input_tokens": 64512,
+                    "input_cost_per_token": 0.0,
+                    "output_cost_per_token": 0.0,
+                },
+                "trajectory_config": {"raw_content": False, "linear_history": True},
+            },
+        ),
+        environment=HarborEnvironmentConfig(
+            environment_type="daytona",
+            force_build=True,
+            delete=True,
+            cpus=2,
+            memory_mb=8192,
+            storage_mb=8192,
+            kwargs={"auto_snapshot": True},
+        ),
+        n_concurrent=256,
+        attempts=3,
+        timeout_multiplier=2.0,
+        retry=HarborRetryConfig(
+            max_retries=6,
+            exclude_exceptions=_GRUG_NON_RETRYABLE_EXCEPTIONS,
+            wait_multiplier=2.0,
+            min_wait=1.0,
+            max_wait=90.0,
+        ),
+        verifier=HarborVerifierConfig(max_timeout=14400),
+    ),
+    secret_env=_DAYTONA_SECRET_ENV,
+)
 
 
 EVALS: dict[str, EvaluationDefinition] = {
@@ -226,12 +309,25 @@ EVALS: dict[str, EvaluationDefinition] = {
     # Harbor's verifier scores the boxed answer. aime-smoke caps the task count for a fast check.
     "aime-harbor": HarborDefinition(
         name="aime-harbor",
-        config=HarborRunConfig(dataset="aime", version="1.0", agent="terminus-2"),
+        config=HarborRunConfig(
+            dataset="aime",
+            revision="1.0",
+            agent=HarborAgentConfig(name="terminus-2"),
+            environment=HarborEnvironmentConfig(environment_type="daytona"),
+        ),
+        secret_env=_DAYTONA_SECRET_ENV,
     ),
     "aime-smoke": HarborDefinition(
         name="aime-smoke",
-        config=HarborRunConfig(dataset="aime", version="1.0", agent="terminus-2", n_concurrent=2),
+        config=HarborRunConfig(
+            dataset="aime",
+            revision="1.0",
+            agent=HarborAgentConfig(name="terminus-2"),
+            environment=HarborEnvironmentConfig(environment_type="daytona"),
+            n_concurrent=2,
+        ),
         max_eval_instances=2,
+        secret_env=_DAYTONA_SECRET_ENV,
     ),
     # Agentic datasets contain Harbor task directories and run with Daytona.
     "tb2": _agentic_eval("tb2", _TERMINAL_BENCH_DATASET, n_concurrent=_AGENTIC_CONCURRENCY),
@@ -244,6 +340,7 @@ EVALS: dict[str, EvaluationDefinition] = {
     "aider": _agentic_eval("aider", "DCAgent2/aider_polyglot", n_concurrent=_AGENTIC_CONCURRENCY),
     "medagentbench": _agentic_eval("medagentbench", "DCAgent/medagentbench", n_concurrent=_AGENTIC_CONCURRENCY),
     "financeagent": _agentic_eval("financeagent", "DCAgent/financeagent_terminal", n_concurrent=16),
+    "grug-opencode-id": GRUG_OPENCODE_EVAL,
 }
 
 # A fast cluster smoke: one small MCQ cut plus a capped gsm8k generation task.

--- a/experiments/evaluation/launch.py
+++ b/experiments/evaluation/launch.py
@@ -33,6 +33,7 @@ from marin.evaluation.runner import (
 )
 from rigging.config_discovery import resolve_cluster_config
 from rigging.filesystem import prefix_join
+from rigging.secrets import SecretSpec
 
 from experiments.evaluation.evals import EVALS
 from experiments.evaluation.fleet import MARIN_EVAL_HARDWARE
@@ -111,8 +112,13 @@ def build_evaluation_batch(
     records_prefix = records_prefix_for(accelerator, spec)
     created_at = datetime.now(UTC).isoformat()
     evaluations: list[Evaluation] = []
+    secret_env: dict[str, SecretSpec] = {}
     for eval_key in spec.evals:
         definition = EVALS[eval_key]
+        for name, spec_value in definition.secret_env.items():
+            if name in secret_env and secret_env[name] != spec_value:
+                raise ValueError(f"evaluations declare conflicting secret specifications for {name}")
+            secret_env[name] = spec_value
         run_id = _run_id(spec.model, eval_key)
         output_dir = prefix_join(records_prefix, f"{run_id}/results")
         evaluations.append(
@@ -124,6 +130,7 @@ def build_evaluation_batch(
                     eval_ref=definition.record_ref,
                 ),
                 executor=definition.executor_for(model, spec.limit),
+                secret_env_keys=tuple(definition.secret_env),
             )
         )
 
@@ -140,6 +147,7 @@ def build_evaluation_batch(
         api_model=canonical_served_name(model.name),
         evaluations=tuple(evaluations),
         provenance=provenance,
+        secret_env=secret_env,
     )
 
 

--- a/experiments/evaluation/serve/models/README.md
+++ b/experiments/evaluation/serve/models/README.md
@@ -26,6 +26,9 @@ serve:                          # ServeConfig -> model-server behavior
   tensor_parallel_size: 2
   data_parallel_size: null
   max_model_len: 32768
+  max_num_batched_tokens: null  # vLLM prefill-token budget
+  max_num_seqs: null            # concurrent sequence limit
+  object_store_load_mode: stream # stream through RunAI, or copy to worker-local disk
   hf_overrides: null            # JSON string, e.g. rope-scaling overrides
   limit_mm_per_prompt: null     # JSON string, e.g. '{"image":0,"video":0}' for text-only eval
   tool_call_parser: hermes      # enables --enable-auto-tool-choice + --tool-call-parser

--- a/experiments/evaluation/serve/models/README.md
+++ b/experiments/evaluation/serve/models/README.md
@@ -28,7 +28,6 @@ serve:                          # ServeConfig -> model-server behavior
   max_model_len: 32768
   max_num_batched_tokens: null  # vLLM prefill-token budget
   max_num_seqs: null            # concurrent sequence limit
-  object_store_load_mode: stream # stream through RunAI, or copy to worker-local disk
   hf_overrides: null            # JSON string, e.g. rope-scaling overrides
   limit_mm_per_prompt: null     # JSON string, e.g. '{"image":0,"video":0}' for text-only eval
   tool_call_parser: hermes      # enables --enable-auto-tool-choice + --tool-call-parser

--- a/experiments/evaluation/serve/models/marin-community/grug-agentic-s3-step1903.yaml
+++ b/experiments/evaluation/serve/models/marin-community/grug-agentic-s3-step1903.yaml
@@ -1,0 +1,20 @@
+name: grug-agentic-s3-step1903
+location: s3://marin-us-east-02a/marin/exports/grug/june-67b-a2b-sft-s3-agentic/step-1903/hf-bf16-vllm/
+tokenizer: penfever/grug-67b-a2b-sft-s2-thinking-step630-tok
+apply_chat_template: true
+resource_hint:
+  gpu:
+    H100: 8
+  memory: 512g
+  disk: 512g
+serve:
+  tensor_parallel_size: 1
+  data_parallel_size: 8
+  max_model_len: 65536
+  max_num_batched_tokens: 7168
+  max_num_seqs: 32
+  object_store_load_mode: local
+  tool_call_parser: hermes
+  auto_overrides: false
+  vllm_extra_args:
+  - --enable-expert-parallel

--- a/experiments/evaluation/serve/models/marin-community/grug-agentic-s3-step1903.yaml
+++ b/experiments/evaluation/serve/models/marin-community/grug-agentic-s3-step1903.yaml
@@ -6,14 +6,12 @@ resource_hint:
   gpu:
     H100: 8
   memory: 512g
-  disk: 512g
 serve:
   tensor_parallel_size: 1
   data_parallel_size: 8
   max_model_len: 65536
   max_num_batched_tokens: 7168
   max_num_seqs: 32
-  object_store_load_mode: local
   tool_call_parser: hermes
   auto_overrides: false
   vllm_extra_args:

--- a/lib/marin/src/marin/evaluation/eval_env.py
+++ b/lib/marin/src/marin/evaluation/eval_env.py
@@ -1,12 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Launch-environment variables forwarded to evaluation jobs.
-
-An eval job (the group orchestrator, an evalchemy client, a Harbor runner) runs on a cluster worker
-with none of the launcher's ambient credentials. The launcher forwards a fixed allowlist of variables
-from its own environment into the job's :class:`EnvironmentSpec`; this module is that allowlist.
-"""
+"""Allowlisted launch-environment variables supplied to evaluation jobs."""
 
 import os
 
@@ -25,7 +20,6 @@ EVAL_ENV_KEYS: tuple[str, ...] = (
     "OPENAI_API_KEY",
     "E2B_API_KEY",
     "MODAL_API_KEY",
-    "DAYTONA_API_KEY",
     "TPU_CI",
     "MARIN_PREFIX",
     "VLLM_ALLOW_LONG_MAX_MODEL_LEN",

--- a/lib/marin/src/marin/evaluation/harbor/driver_config.py
+++ b/lib/marin/src/marin/evaluation/harbor/driver_config.py
@@ -1,0 +1,189 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed configuration and native-schema adaptation for the isolated Harbor driver."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+_DEFAULT_MODEL_INFO = {
+    "max_input_tokens": 32768,
+    "max_output_tokens": 8192,
+    "input_cost_per_token": 0.0,
+    "output_cost_per_token": 0.0,
+}
+_OPENCODE_AGENT = "opencode"
+_HOSTED_VLLM_PROVIDER = "hosted_vllm"
+_HOSTED_VLLM_DISPLAY_NAME = "Hosted vLLM"
+_OPENAI_COMPATIBLE_PACKAGE = "@ai-sdk/openai-compatible"
+
+
+@dataclass(frozen=True)
+class HarborRetryConfig:
+    """Retry failed trials unless their exception type is explicitly excluded."""
+
+    max_retries: int = 0
+    exclude_exceptions: tuple[str, ...] = ()
+    wait_multiplier: float = 1.0
+    min_wait: float = 1.0
+    max_wait: float = 60.0
+
+
+@dataclass(frozen=True)
+class HarborEnvironmentConfig:
+    """Sandbox type, lifecycle, and resources for each trial."""
+
+    environment_type: str
+    force_build: bool = False
+    delete: bool = True
+    cpus: int | None = None
+    memory_mb: int | None = None
+    storage_mb: int | None = None
+    kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class HarborAgentConfig:
+    """Agent identity, timeouts, token budget, and implementation arguments."""
+
+    name: str
+    max_output_tokens: int = 8192
+    max_timeout: float | None = None
+    setup_timeout: float | None = None
+    kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class HarborVerifierConfig:
+    """Verifier execution policy."""
+
+    max_timeout: float | None = None
+
+
+@dataclass(frozen=True)
+class HarborRunConfig:
+    """One Harbor evaluation of one served model."""
+
+    dataset: str
+    revision: str
+    agent: HarborAgentConfig
+    environment: HarborEnvironmentConfig
+    n_concurrent: int = 4
+    task_limit: int | None = None
+    attempts: int = 1
+    timeout_multiplier: float = 1.0
+    retry: HarborRetryConfig = field(default_factory=HarborRetryConfig)
+    verifier: HarborVerifierConfig = field(default_factory=HarborVerifierConfig)
+
+
+@dataclass(frozen=True)
+class HarborDriverConfig:
+    """JSON-safe input shared by the Marin parent and isolated Harbor process."""
+
+    job_name: str
+    jobs_dir: str
+    dataset_path: str | None
+    endpoint_url: str
+    served_model: str
+    run: HarborRunConfig
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "HarborDriverConfig":
+        """Decode a JSON object while rejecting unknown or missing config fields."""
+        values = dict(data)
+        run_values = dict(values.pop("run"))
+        run_values["agent"] = HarborAgentConfig(**run_values["agent"])
+        run_values["environment"] = HarborEnvironmentConfig(**run_values["environment"])
+        run_values["retry"] = HarborRetryConfig(**run_values["retry"])
+        run_values["verifier"] = HarborVerifierConfig(**run_values["verifier"])
+        return cls(run=HarborRunConfig(**run_values), **values)
+
+
+def _opencode_config_for_endpoint(config: object, endpoint_url: str) -> dict[str, Any]:
+    opencode_config = config
+    if not isinstance(opencode_config, Mapping):
+        raise ValueError("Harbor agent opencode_config must be a mapping")
+    providers = opencode_config.get("provider", {})
+    if not isinstance(providers, Mapping):
+        raise ValueError("Harbor OpenCode provider config must be a mapping")
+    hosted_vllm = providers.get(_HOSTED_VLLM_PROVIDER, {})
+    if not isinstance(hosted_vllm, Mapping):
+        raise ValueError("Harbor OpenCode hosted_vllm provider config must be a mapping")
+    options = hosted_vllm.get("options", {})
+    if not isinstance(options, Mapping):
+        raise ValueError("Harbor OpenCode hosted_vllm provider options must be a mapping")
+
+    return {
+        **opencode_config,
+        "provider": {
+            **providers,
+            _HOSTED_VLLM_PROVIDER: {
+                **hosted_vllm,
+                "npm": _OPENAI_COMPATIBLE_PACKAGE,
+                "name": _HOSTED_VLLM_DISPLAY_NAME,
+                "options": {**options, "baseURL": endpoint_url},
+            },
+        },
+    }
+
+
+def native_job_config(config: HarborDriverConfig) -> dict[str, Any]:
+    """Translate the stable Marin config into the pinned Harbor ``JobConfig`` schema."""
+    run = config.run
+    agent_kwargs = dict(run.agent.kwargs)
+    configured_model_info = agent_kwargs.get("model_info") or {}
+    if not isinstance(configured_model_info, Mapping):
+        raise ValueError("Harbor agent model_info must be a mapping")
+    model_info = {
+        **_DEFAULT_MODEL_INFO,
+        **configured_model_info,
+        "max_output_tokens": run.agent.max_output_tokens,
+    }
+    agent_kwargs.update({"api_base": config.endpoint_url, "model_info": model_info})
+    if run.agent.name == _OPENCODE_AGENT:
+        agent_kwargs["opencode_config"] = _opencode_config_for_endpoint(
+            agent_kwargs.get("opencode_config", {}),
+            config.endpoint_url,
+        )
+
+    if config.dataset_path is not None:
+        dataset = {"path": config.dataset_path, "n_tasks": run.task_limit}
+    else:
+        selector = {"ref": run.revision} if "/" in run.dataset else {"version": run.revision}
+        dataset = {"name": run.dataset, **selector, "n_tasks": run.task_limit}
+
+    return {
+        "job_name": config.job_name,
+        "jobs_dir": config.jobs_dir,
+        "n_attempts": run.attempts,
+        "timeout_multiplier": run.timeout_multiplier,
+        "n_concurrent_trials": run.n_concurrent,
+        "retry": {
+            "max_retries": run.retry.max_retries,
+            "exclude_exceptions": list(run.retry.exclude_exceptions),
+            "wait_multiplier": run.retry.wait_multiplier,
+            "min_wait_sec": run.retry.min_wait,
+            "max_wait_sec": run.retry.max_wait,
+        },
+        "environment": {
+            "type": run.environment.environment_type,
+            "force_build": run.environment.force_build,
+            "delete": run.environment.delete,
+            "override_cpus": run.environment.cpus,
+            "override_memory_mb": run.environment.memory_mb,
+            "override_storage_mb": run.environment.storage_mb,
+            "kwargs": dict(run.environment.kwargs),
+        },
+        "verifier": {"max_timeout_sec": run.verifier.max_timeout},
+        "agents": [
+            {
+                "name": run.agent.name,
+                "model_name": f"hosted_vllm/{config.served_model}",
+                "max_timeout_sec": run.agent.max_timeout,
+                "override_setup_timeout_sec": run.agent.setup_timeout,
+                "kwargs": agent_kwargs,
+            }
+        ],
+        "datasets": [dataset],
+    }

--- a/lib/marin/src/marin/evaluation/harbor/runner.py
+++ b/lib/marin/src/marin/evaluation/harbor/runner.py
@@ -5,7 +5,7 @@
 
 The group launcher serves a model once and hands this runner an OpenAI endpoint; the runner points a
 Harbor agent at it (``hosted_vllm/<served-name>``), runs the dataset's trials on the configured
-sandbox environment (Daytona by default), and normalizes each finished trial into the shared eval
+sandbox environment, and normalizes each finished trial into the shared eval
 contract: one agentic :class:`~marin.evaluation.samples.EvalSample` per task (its reward, its grading,
 and a reference to the saved trajectory) plus an aggregate this module's :class:`HarborResult` reads
 back for the record's metrics. Harbor's own per-trial resume is preserved by restoring completed
@@ -20,12 +20,17 @@ import logging
 import re
 import subprocess
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from rigging.filesystem import StoragePath, is_remote_path, prefix_join, url_to_fs
 
+from marin.evaluation.eval_env import env_vars_from_keys
 from marin.evaluation.harbor.dataset import materialize_harbor_dataset
+from marin.evaluation.harbor.driver_config import (
+    HarborDriverConfig,
+    HarborRunConfig,
+)
 from marin.evaluation.records import RunStatus
 from marin.evaluation.runner import EvaluationError, EvaluationOutcome
 from marin.evaluation.samples import EvalSample, Grading, SampleKind, write_sample_parquet
@@ -35,36 +40,33 @@ logger = logging.getLogger(__name__)
 
 # Harbor is run as an external tool in an isolated uv environment (its Daytona SDK carries pre-release
 # pins that do not fit the marin lock). These specs pin what that ephemeral env installs.
-_HARBOR_SPEC = "harbor>=0.8.0"
-_DAYTONA_SPEC = "daytona>=0.200.1"
+_HARBOR_SPEC = "harbor==0.20.1.dev202607240136"
+_DAYTONA_SPEC = "daytona==0.200.2"
 _DRIVER = str(Path(__file__).with_name("trial_driver.py"))
+_DRIVER_PYTHONPATH = str(Path(__file__).parents[3])
+_DRIVER_SYSTEM_ENV_KEYS = (
+    "CURL_CA_BUNDLE",
+    "HOME",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "PATH",
+    "REQUESTS_CA_BUNDLE",
+    "SSL_CERT_DIR",
+    "SSL_CERT_FILE",
+    "TMPDIR",
+    "UV_CACHE_DIR",
+    "XDG_CACHE_HOME",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+)
 
 # The reward at or above which a Harbor trial counts as solved (rewards are typically 0.0 / 1.0; the
 # margin tolerates float noise).
 SOLVED_REWARD = 0.99
 
 _CANONICAL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9._-]{1,64}$")
-
-_DEFAULT_MODEL_INFO = {
-    "max_input_tokens": 32768,
-    "max_output_tokens": 8192,
-    "input_cost_per_token": 0.0,
-    "output_cost_per_token": 0.0,
-}
-
-
-@dataclass(frozen=True)
-class HarborRunConfig:
-    """One Harbor eval of one served model."""
-
-    dataset: str
-    version: str
-    agent: str
-    env: str = "daytona"
-    n_concurrent: int = 4
-    max_output_tokens: int = 8192
-    task_limit: int | None = None
-    agent_kwargs: dict = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -114,7 +116,7 @@ def canonical_served_name(name: str) -> str:
 
 def _job_name(model: RunningModel, config: HarborRunConfig) -> str:
     """A deterministic Harbor job name so a re-run resumes the previous job's completed trials."""
-    key = f"{config.dataset}|{config.version}|{model.endpoint.model}|{config.agent}|{config.task_limit}"
+    key = f"{config.dataset}|{config.revision}|{model.endpoint.model}|{config.agent.name}|{config.task_limit}"
     digest = hashlib.sha256(key.encode()).hexdigest()[:12]
     safe = re.sub(r"[^A-Za-z0-9_-]", "_", config.dataset)[:32]
     return f"harbor_{safe}_{digest}"
@@ -216,7 +218,7 @@ def _aggregate(trials: list[HarborTrial], dataset: str, samples_path: str | None
     )
 
 
-def _run_driver(config_file: Path) -> None:
+def _run_driver(config_file: Path, driver_env: Mapping[str, str]) -> None:
     """Run the Harbor trial driver in an isolated uv env (Harbor + Daytona, no marin project)."""
     cmd = [
         "uv",
@@ -233,7 +235,10 @@ def _run_driver(config_file: Path) -> None:
         str(config_file),
     ]
     logger.info("running Harbor driver: %s", " ".join(cmd))
-    subprocess.run(cmd, check=True)
+    process_env = env_vars_from_keys(_DRIVER_SYSTEM_ENV_KEYS)
+    process_env.update(driver_env)
+    process_env["PYTHONPATH"] = _DRIVER_PYTHONPATH
+    subprocess.run(cmd, check=True, env=process_env)
 
 
 def _upload_trials(job_dir: Path, out_path: str) -> None:
@@ -250,6 +255,7 @@ def run_harbor(
     output_dir: str,
     *,
     hf_token: str | None,
+    driver_env: Mapping[str, str],
 ) -> HarborRunResult:
     """Run ``config``'s Harbor dataset against the served model and write the normalized outputs.
 
@@ -264,7 +270,7 @@ def run_harbor(
     job_dir = results_dir / job_name
     dataset_path = materialize_harbor_dataset(
         config.dataset,
-        config.version,
+        config.revision,
         workdir,
         hf_token=hf_token,
     )
@@ -274,27 +280,25 @@ def run_harbor(
         if restored:
             logger.info("restored %d completed Harbor trial(s) from %s", restored, output_dir)
 
-    agent_kwargs = dict(config.agent_kwargs)
-    agent_kwargs.setdefault("api_base", model.endpoint.base_url)
-    agent_kwargs.setdefault("model_info", {**_DEFAULT_MODEL_INFO, "max_output_tokens": config.max_output_tokens})
-    driver_config = {
-        "job_name": job_name,
-        "jobs_dir": str(results_dir),
-        "dataset": config.dataset,
-        "version": config.version,
-        "dataset_path": str(dataset_path) if dataset_path is not None else None,
-        "n_tasks": config.task_limit,
-        "agent": config.agent,
-        "model_name": f"hosted_vllm/{model.endpoint.model}",
-        "agent_kwargs": agent_kwargs,
-        "n_concurrent": config.n_concurrent,
-        "env": config.env,
-    }
+    driver_config = HarborDriverConfig(
+        job_name=job_name,
+        jobs_dir=str(results_dir),
+        dataset_path=str(dataset_path) if dataset_path is not None else None,
+        endpoint_url=model.endpoint.base_url,
+        served_model=model.endpoint.model,
+        run=config,
+    )
     config_file = workdir / "driver_config.json"
-    config_file.write_text(json.dumps(driver_config))
+    config_file.write_text(json.dumps(asdict(driver_config)))
+    config_file.chmod(0o600)
 
-    logger.info("starting Harbor job %s (dataset=%s env=%s)", job_name, config.dataset, config.env)
-    _run_driver(config_file)
+    logger.info(
+        "starting Harbor job %s (dataset=%s env=%s)",
+        job_name,
+        config.dataset,
+        config.environment.environment_type,
+    )
+    _run_driver(config_file, driver_env)
 
     trials = _read_trials(job_dir)
     if is_remote_path(output_dir):
@@ -330,6 +334,7 @@ class HarborExecutor:
     """Run one resolved Harbor configuration."""
 
     config: HarborRunConfig
+    secret_env_keys: tuple[str, ...] = ()
 
     def __call__(
         self,
@@ -343,6 +348,7 @@ class HarborExecutor:
                 self.config,
                 output_dir,
                 hf_token=env_vars.get("HF_TOKEN"),
+                driver_env={key: env_vars[key] for key in self.secret_env_keys},
             )
         except Exception as exc:
             raise EvaluationError(str(exc), status=RunStatus.FAILED) from exc

--- a/lib/marin/src/marin/evaluation/harbor/trial_driver.py
+++ b/lib/marin/src/marin/evaluation/harbor/trial_driver.py
@@ -6,8 +6,9 @@
 Harbor (and its Daytona SDK) carry pre-release transitive pins that do not fit the marin lock, so
 Harbor is treated as an external tool: :func:`marin.evaluation.harbor.runner.run_harbor` runs
 this script under ``uv run --no-project --with harbor --with daytona --prerelease=allow``, which
-builds an ephemeral environment with just Harbor and Daytona. This file therefore imports **only**
-Harbor and the standard library -- never marin -- so it loads cleanly in that project-less env.
+builds an ephemeral environment with Harbor and Daytona. This file imports the stdlib-only typed
+adapter from the Marin source tree, but none of Marin's runtime dependencies, so it loads cleanly in
+that project-less environment.
 
 It reads a JSON config (path in ``argv[1]``), runs the Harbor job against the served model's proxy
 URL, and lets Harbor write its native ``result.json`` tree under ``jobs_dir``. The caller reads those
@@ -20,42 +21,14 @@ import sys
 from pathlib import Path
 
 from harbor.job import Job
-from harbor.models.environment_type import EnvironmentType
-from harbor.models.job.config import DatasetConfig, JobConfig
-from harbor.models.trial.config import AgentConfig, EnvironmentConfig
+from harbor.models.job.config import JobConfig
+
+from marin.evaluation.harbor.driver_config import HarborDriverConfig, native_job_config
 
 
 async def _run(config: dict) -> None:
-    try:
-        env_type = EnvironmentType(config["env"])
-    except ValueError:
-        env_type = EnvironmentType.DOCKER
-    dataset = (
-        DatasetConfig(path=Path(config["dataset_path"]), n_tasks=config["n_tasks"])
-        if config["dataset_path"] is not None
-        else DatasetConfig(
-            name=config["dataset"],
-            version=config["version"],
-            ref=config["version"],
-            n_tasks=config["n_tasks"],
-        )
-    )
-    job = await Job.create(
-        JobConfig(
-            job_name=config["job_name"],
-            jobs_dir=Path(config["jobs_dir"]),
-            datasets=[dataset],
-            agents=[
-                AgentConfig(
-                    name=config["agent"],
-                    model_name=config["model_name"],
-                    kwargs=config["agent_kwargs"],
-                )
-            ],
-            n_concurrent_trials=config["n_concurrent"],
-            environment=EnvironmentConfig(type=env_type),
-        )
-    )
+    driver_config = HarborDriverConfig.from_dict(config)
+    job = await Job.create(JobConfig.model_validate(native_job_config(driver_config)))
     await job.run()
 
 

--- a/lib/marin/src/marin/evaluation/model_config.py
+++ b/lib/marin/src/marin/evaluation/model_config.py
@@ -13,6 +13,8 @@ from pathlib import Path
 import draccus
 from rigging.filesystem import StoragePath
 
+from marin.inference.config import ObjectStoreLoadMode
+
 
 class ServeBackend(StrEnum):
     """Inference backend used for evaluation."""
@@ -64,10 +66,10 @@ class ResourceHint:
 class ServeConfig:
     """Model-server behavior independent of scheduler placement.
 
-    ``backend`` selects vLLM or Levanter. Parallelism and context fields become first-class inference
-    model settings. The remaining typed fields map onto ``vllm serve`` flags through
-    :func:`serve_config_vllm_args`; ``vllm_extra_args`` is the escape hatch for flags without a typed
-    field and wins when it names the same option.
+    ``backend`` selects vLLM or Levanter. Parallelism, context, engine limits, and object-store
+    loading become first-class inference settings. The remaining typed vLLM fields map onto
+    ``vllm serve`` flags through :func:`serve_config_vllm_args`; ``vllm_extra_args`` is the escape
+    hatch for flags without a typed field and wins when it names the same option.
 
     When ``auto_overrides`` is true, the lowering path inspects the Hugging Face ``config.json`` to
     fill portable architecture-specific vLLM flags and clamp an explicit context length to the
@@ -78,6 +80,9 @@ class ServeConfig:
     tensor_parallel_size: int | None = None
     data_parallel_size: int | None = None
     max_model_len: int | None = None
+    max_num_batched_tokens: int | None = None
+    max_num_seqs: int | None = None
+    object_store_load_mode: ObjectStoreLoadMode = ObjectStoreLoadMode.STREAM
     hf_overrides: str | None = None
     limit_mm_per_prompt: str | None = None
     tool_call_parser: str | None = None
@@ -137,9 +142,10 @@ def serve_config_vllm_args(serve: ServeConfig) -> tuple[str, ...]:
     ``reasoning_parser``, ``data_parallel_size``) come first, then the explicit ``vllm_extra_args``
     escape hatch. An explicit ``vllm_extra_args`` entry wins: a typed knob is skipped when its flag is
     already present there, so a hand-tuned value is never duplicated. ``tensor_parallel_size``,
-    ``max_model_len``, and ``chat_template`` are omitted -- they are first-class serve fields the
-    launcher passes through the served-model config, not extra flags. ``--trust-remote-code`` is not
-    rendered here: the native server forces it on for every evaluated model.
+    ``max_model_len``, ``max_num_batched_tokens``, ``max_num_seqs``, ``object_store_load_mode``,
+    ``chat_template``, and ``auto_overrides`` are consumed by serving configuration or lowering
+    rather than rendered as extra flags. ``--trust-remote-code`` is not rendered here: the native
+    server forces it on for every evaluated model.
     """
     explicit = tuple(serve.vllm_extra_args)
     derived: list[str] = []

--- a/lib/marin/src/marin/evaluation/model_config.py
+++ b/lib/marin/src/marin/evaluation/model_config.py
@@ -13,8 +13,6 @@ from pathlib import Path
 import draccus
 from rigging.filesystem import StoragePath
 
-from marin.inference.config import ObjectStoreLoadMode
-
 
 class ServeBackend(StrEnum):
     """Inference backend used for evaluation."""
@@ -33,9 +31,7 @@ class ResourceHint:
     ``{"H100": 8}``. A CLI accelerator override may change the GPU shape but cannot move a
     GPU-required model onto TPU.
 
-    ``cpu``, ``memory``, and ``disk`` override the inference worker's host-resource defaults. They are
-    hints attached to the model because large object-store exports can require substantially more host
-    memory while staging shards.
+    ``cpu``, ``memory``, and ``disk`` override the inference worker's host-resource defaults.
     """
 
     hbm_gb: int | None = None
@@ -66,10 +62,10 @@ class ResourceHint:
 class ServeConfig:
     """Model-server behavior independent of scheduler placement.
 
-    ``backend`` selects vLLM or Levanter. Parallelism, context, engine limits, and object-store
-    loading become first-class inference settings. The remaining typed vLLM fields map onto
-    ``vllm serve`` flags through :func:`serve_config_vllm_args`; ``vllm_extra_args`` is the escape
-    hatch for flags without a typed field and wins when it names the same option.
+    ``backend`` selects vLLM or Levanter. Parallelism, context, and engine limits become first-class
+    inference settings. The remaining typed vLLM fields map onto ``vllm serve`` flags through
+    :func:`serve_config_vllm_args`; ``vllm_extra_args`` is the escape hatch for flags without a typed
+    field and wins when it names the same option.
 
     When ``auto_overrides`` is true, the lowering path inspects the Hugging Face ``config.json`` to
     fill portable architecture-specific vLLM flags and clamp an explicit context length to the
@@ -82,7 +78,6 @@ class ServeConfig:
     max_model_len: int | None = None
     max_num_batched_tokens: int | None = None
     max_num_seqs: int | None = None
-    object_store_load_mode: ObjectStoreLoadMode = ObjectStoreLoadMode.STREAM
     hf_overrides: str | None = None
     limit_mm_per_prompt: str | None = None
     tool_call_parser: str | None = None
@@ -142,10 +137,10 @@ def serve_config_vllm_args(serve: ServeConfig) -> tuple[str, ...]:
     ``reasoning_parser``, ``data_parallel_size``) come first, then the explicit ``vllm_extra_args``
     escape hatch. An explicit ``vllm_extra_args`` entry wins: a typed knob is skipped when its flag is
     already present there, so a hand-tuned value is never duplicated. ``tensor_parallel_size``,
-    ``max_model_len``, ``max_num_batched_tokens``, ``max_num_seqs``, ``object_store_load_mode``,
-    ``chat_template``, and ``auto_overrides`` are consumed by serving configuration or lowering
-    rather than rendered as extra flags. ``--trust-remote-code`` is not rendered here: the native
-    server forces it on for every evaluated model.
+    ``max_model_len``, ``max_num_batched_tokens``, ``max_num_seqs``, ``chat_template``, and
+    ``auto_overrides`` are consumed by serving configuration or lowering rather than rendered as
+    extra flags. ``--trust-remote-code`` is not rendered here: the native server forces it on for
+    every evaluated model.
     """
     explicit = tuple(serve.vllm_extra_args)
     derived: list[str] = []

--- a/lib/marin/src/marin/evaluation/runner.py
+++ b/lib/marin/src/marin/evaluation/runner.py
@@ -13,6 +13,7 @@ from iris.client import IrisClient, Job, iris_ctx
 from iris.cluster.constraints import CLUSTER_CONSTRAINT_KEY, Constraint, ConstraintOp, region_constraint
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec
 from rigging.filesystem.s3_compat import configure_coreweave_s3
+from rigging.secrets import SecretSpec, resolve_secret_spec
 
 from marin.evaluation.eval_env import EVAL_ENV_KEYS, EVAL_RUNTIME_ENV_KEYS, env_vars_from_keys
 from marin.evaluation.hardware import AcceleratorChoice
@@ -86,6 +87,7 @@ class EvaluationIdentity:
 class Evaluation:
     identity: EvaluationIdentity
     executor: EvalExecutor
+    secret_env_keys: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -101,6 +103,7 @@ class EvaluationBatch:
     api_model: str | None
     evaluations: tuple[Evaluation, ...]
     provenance: Provenance
+    secret_env: Mapping[str, SecretSpec] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -236,7 +239,9 @@ def _run_one_evaluation(
     inference_failure: Exception | None = None
     try:
         session.check_alive()
-        outcome = evaluation.executor(session.model, evaluation.identity.output_dir, env_vars)
+        allowed_env_keys = (*EVAL_RUNTIME_ENV_KEYS, *evaluation.secret_env_keys)
+        evaluation_env = {key: env_vars[key] for key in allowed_env_keys if key in env_vars}
+        outcome = evaluation.executor(session.model, evaluation.identity.output_dir, evaluation_env)
         metrics = outcome.metrics
         jobs |= outcome.jobs
     except Exception as exc:
@@ -309,6 +314,10 @@ def run_evaluation_batch(batch: EvaluationBatch) -> list[str]:
         raise ValueError("an evaluation batch requires at least one evaluation")
     orchestrator_job_id = str(iris_ctx().job_id)
     runtime_env = env_vars_from_keys(EVAL_RUNTIME_ENV_KEYS)
+    evaluation_env = {
+        **runtime_env,
+        **env_vars_from_keys(tuple(batch.secret_env)),
+    }
     inference = inference_config_for_model(
         batch.model,
         batch.accelerator,
@@ -322,7 +331,7 @@ def run_evaluation_batch(batch: EvaluationBatch) -> list[str]:
                 batch,
                 session,
                 orchestrator_job_id=orchestrator_job_id,
-                env_vars=runtime_env,
+                env_vars=evaluation_env,
             )
     except RemoteInferenceStartupError as exc:
         inference_jobs, tails = _startup_diagnostics(exc)
@@ -346,6 +355,9 @@ def submit_evaluation_batch(batch: EvaluationBatch, client: IrisClient) -> Submi
         ]
     elif batch.accelerator.region:
         constraints = [region_constraint([batch.accelerator.region])]
+    launch_env = env_vars_from_keys(EVAL_ENV_KEYS)
+    for name, spec in sorted(batch.secret_env.items()):
+        launch_env[name] = resolve_secret_spec(spec).value
     job = client.submit(
         entrypoint=Entrypoint.from_callable(run_evaluation_batch, batch),
         name=f"eval-{batch.group_id}",
@@ -354,7 +366,7 @@ def submit_evaluation_batch(batch: EvaluationBatch, client: IrisClient) -> Submi
             memory=_ORCHESTRATOR_MEMORY,
             disk=_ORCHESTRATOR_DISK,
         ),
-        environment=EnvironmentSpec(env_vars=env_vars_from_keys(EVAL_ENV_KEYS)),
+        environment=EnvironmentSpec(env_vars=launch_env),
         constraints=constraints,
         max_retries_failure=0,
     )

--- a/lib/marin/src/marin/evaluation/serving_config.py
+++ b/lib/marin/src/marin/evaluation/serving_config.py
@@ -112,7 +112,6 @@ def _vllm_engine_config(
             else EVAL_SERVE_MAX_NUM_BATCHED_TOKENS
         ),
         max_num_seqs=serve.max_num_seqs,
-        object_store_load_mode=serve.object_store_load_mode,
         extra_args=(*extra_args, *_QUIET_VLLM_ARGS),
     )
 

--- a/lib/marin/src/marin/evaluation/serving_config.py
+++ b/lib/marin/src/marin/evaluation/serving_config.py
@@ -13,7 +13,7 @@ from iris.cluster.setup_scripts import default_setup_script
 from rigging.filesystem import StoragePath
 
 from marin.evaluation.hardware import AcceleratorChoice, Platform
-from marin.evaluation.model_config import ModelConfig, ServeBackend, has_vllm_option, serve_config_vllm_args
+from marin.evaluation.model_config import ModelConfig, ServeBackend, ServeConfig, has_vllm_option, serve_config_vllm_args
 from marin.inference.config import (
     BrokerConfig,
     IrisConfig,
@@ -94,6 +94,29 @@ def auto_serve_overrides(
     return _auto_serve_overrides_from_config(model, config, max_model_len, existing_extra_args)
 
 
+def _vllm_engine_config(
+    serve: ServeConfig,
+    platform: Platform,
+    extra_args: tuple[str, ...],
+) -> VllmEngineConfig:
+    """Build the evaluation engine settings shared by GPU and TPU workers."""
+    launcher = VllmLauncherType.CUDA if platform is Platform.GPU else VllmLauncherType.WORKSPACE
+    source = VllmSource.MARIN_FORK if platform is Platform.GPU else VllmSource.UPSTREAM
+    return VllmEngineConfig(
+        launcher=launcher,
+        source=source,
+        startup_timeout_seconds=ENDPOINT_READY_TIMEOUT_SECONDS,
+        max_num_batched_tokens=(
+            serve.max_num_batched_tokens
+            if serve.max_num_batched_tokens is not None
+            else EVAL_SERVE_MAX_NUM_BATCHED_TOKENS
+        ),
+        max_num_seqs=serve.max_num_seqs,
+        object_store_load_mode=serve.object_store_load_mode,
+        extra_args=(*extra_args, *_QUIET_VLLM_ARGS),
+    )
+
+
 def inference_config_for_model(
     model: ModelConfig,
     accelerator: AcceleratorChoice,
@@ -132,12 +155,8 @@ def inference_config_for_model(
             regions=regions,
         )
         if serve.backend is ServeBackend.VLLM:
-            engine: VllmEngineConfig | LevanterEngineConfig = VllmEngineConfig(
-                launcher=VllmLauncherType.CUDA,
-                source=VllmSource.MARIN_FORK,
-                startup_timeout_seconds=ENDPOINT_READY_TIMEOUT_SECONDS,
-                max_num_batched_tokens=EVAL_SERVE_MAX_NUM_BATCHED_TOKENS,
-                extra_args=(*extra_args, *_QUIET_VLLM_ARGS),
+            engine: VllmEngineConfig | LevanterEngineConfig = _vllm_engine_config(
+                serve, accelerator.platform, extra_args
             )
             environment = create_environment(
                 setup_scripts=[default_setup_script(packages=["marin-core"])],
@@ -157,11 +176,7 @@ def inference_config_for_model(
             regions=regions,
         )
         if serve.backend is ServeBackend.VLLM:
-            engine = VllmEngineConfig(
-                startup_timeout_seconds=ENDPOINT_READY_TIMEOUT_SECONDS,
-                max_num_batched_tokens=EVAL_SERVE_MAX_NUM_BATCHED_TOKENS,
-                extra_args=(*extra_args, *_QUIET_VLLM_ARGS),
-            )
+            engine = _vllm_engine_config(serve, accelerator.platform, extra_args)
             environment = create_environment(extras=["tpu", "vllm"], env_vars=dict(env_vars))
         else:
             engine = LevanterEngineConfig()

--- a/lib/marin/src/marin/inference/config.py
+++ b/lib/marin/src/marin/inference/config.py
@@ -33,13 +33,6 @@ class VllmSource(StrEnum):
     MARIN_FORK = "marin_fork"
 
 
-class ObjectStoreLoadMode(StrEnum):
-    """How vLLM loads an object-store model snapshot."""
-
-    STREAM = "stream"
-    LOCAL = "local"
-
-
 class VllmCompilationCacheMode(StrEnum):
     MANAGED = "managed"
     CALLER_MANAGED = "caller_managed"
@@ -90,7 +83,6 @@ class VllmEngineConfig:
     startup_timeout_seconds: int = 1800
     max_num_batched_tokens: int | None = None
     max_num_seqs: int | None = None
-    object_store_load_mode: ObjectStoreLoadMode = ObjectStoreLoadMode.STREAM
     extra_args: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:

--- a/lib/marin/src/marin/inference/config.py
+++ b/lib/marin/src/marin/inference/config.py
@@ -33,6 +33,13 @@ class VllmSource(StrEnum):
     MARIN_FORK = "marin_fork"
 
 
+class ObjectStoreLoadMode(StrEnum):
+    """How vLLM loads an object-store model snapshot."""
+
+    STREAM = "stream"
+    LOCAL = "local"
+
+
 class VllmCompilationCacheMode(StrEnum):
     MANAGED = "managed"
     CALLER_MANAGED = "caller_managed"
@@ -82,6 +89,8 @@ class VllmEngineConfig:
     compilation_cache: VllmCompilationCacheMode = VllmCompilationCacheMode.MANAGED
     startup_timeout_seconds: int = 1800
     max_num_batched_tokens: int | None = None
+    max_num_seqs: int | None = None
+    object_store_load_mode: ObjectStoreLoadMode = ObjectStoreLoadMode.STREAM
     extra_args: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
@@ -89,6 +98,8 @@ class VllmEngineConfig:
             raise ValueError("startup_timeout_seconds must be positive")
         if self.max_num_batched_tokens is not None and self.max_num_batched_tokens <= 0:
             raise ValueError("max_num_batched_tokens must be positive")
+        if self.max_num_seqs is not None and self.max_num_seqs <= 0:
+            raise ValueError("max_num_seqs must be positive")
         if self.source is VllmSource.MARIN_FORK and self.launcher is not VllmLauncherType.CUDA:
             raise ValueError("the Marin vLLM fork source requires the CUDA launcher")
 

--- a/lib/marin/src/marin/inference/iris.py
+++ b/lib/marin/src/marin/inference/iris.py
@@ -28,7 +28,6 @@ from marin.inference.config import (
     BrokerConfig,
     IrisConfig,
     LevanterEngineConfig,
-    ObjectStoreLoadMode,
     RemoteInferenceConfig,
     ServedModelConfig,
     VllmEngineConfig,
@@ -119,17 +118,12 @@ def _accelerator_label(iris: IrisConfig) -> str:
     return device.variant
 
 
-def _resolved_model(
-    model: ServedModelConfig,
-    engine: VllmEngineConfig | LevanterEngineConfig,
-    iris: IrisConfig,
-) -> tuple[ServedModelConfig, int]:
+def _resolved_model(model: ServedModelConfig, iris: IrisConfig) -> tuple[ServedModelConfig, int]:
     # Keep model-cache and Transformers imports inside accelerator workers.
     from marin.inference.model_preparation import (  # noqa: PLC0415
         read_attention_heads,
         resolve_model_path,
         select_tensor_parallel_size,
-        stage_object_store_model_locally,
     )
 
     # Pin the requested id as the served name before weights is overwritten with the
@@ -137,8 +131,6 @@ def _resolved_model(
     # (and only answers to) that path instead of the id the caller asked to serve.
     api_model = model.model_id
     weights = resolve_model_path(model.weights, iris.cache_ttl_days, model.revision)
-    if isinstance(engine, VllmEngineConfig) and engine.object_store_load_mode is ObjectStoreLoadMode.LOCAL:
-        weights = stage_object_store_model_locally(weights)
     num_chips = iris.worker_resources.device.chip_count()
     tensor_parallel_size = model.tensor_parallel_size
     revision = model.revision if weights == model.weights else None
@@ -159,7 +151,7 @@ def _prepared_local_inference(
     engine: VllmEngineConfig | LevanterEngineConfig,
     iris: IrisConfig,
 ) -> Iterator[LocalInferenceSession]:
-    resolved_model, num_chips = _resolved_model(model, engine, iris)
+    resolved_model, num_chips = _resolved_model(model, iris)
     with local_inference(resolved_model, engine, num_chips=num_chips) as session:
         yield session
 

--- a/lib/marin/src/marin/inference/iris.py
+++ b/lib/marin/src/marin/inference/iris.py
@@ -28,6 +28,7 @@ from marin.inference.config import (
     BrokerConfig,
     IrisConfig,
     LevanterEngineConfig,
+    ObjectStoreLoadMode,
     RemoteInferenceConfig,
     ServedModelConfig,
     VllmEngineConfig,
@@ -118,12 +119,17 @@ def _accelerator_label(iris: IrisConfig) -> str:
     return device.variant
 
 
-def _resolved_model(model: ServedModelConfig, iris: IrisConfig) -> tuple[ServedModelConfig, int]:
+def _resolved_model(
+    model: ServedModelConfig,
+    engine: VllmEngineConfig | LevanterEngineConfig,
+    iris: IrisConfig,
+) -> tuple[ServedModelConfig, int]:
     # Keep model-cache and Transformers imports inside accelerator workers.
     from marin.inference.model_preparation import (  # noqa: PLC0415
         read_attention_heads,
         resolve_model_path,
         select_tensor_parallel_size,
+        stage_object_store_model_locally,
     )
 
     # Pin the requested id as the served name before weights is overwritten with the
@@ -131,6 +137,8 @@ def _resolved_model(model: ServedModelConfig, iris: IrisConfig) -> tuple[ServedM
     # (and only answers to) that path instead of the id the caller asked to serve.
     api_model = model.model_id
     weights = resolve_model_path(model.weights, iris.cache_ttl_days, model.revision)
+    if isinstance(engine, VllmEngineConfig) and engine.object_store_load_mode is ObjectStoreLoadMode.LOCAL:
+        weights = stage_object_store_model_locally(weights)
     num_chips = iris.worker_resources.device.chip_count()
     tensor_parallel_size = model.tensor_parallel_size
     revision = model.revision if weights == model.weights else None
@@ -151,7 +159,7 @@ def _prepared_local_inference(
     engine: VllmEngineConfig | LevanterEngineConfig,
     iris: IrisConfig,
 ) -> Iterator[LocalInferenceSession]:
-    resolved_model, num_chips = _resolved_model(model, iris)
+    resolved_model, num_chips = _resolved_model(model, engine, iris)
     with local_inference(resolved_model, engine, num_chips=num_chips) as session:
         yield session
 

--- a/lib/marin/src/marin/inference/model_preparation.py
+++ b/lib/marin/src/marin/inference/model_preparation.py
@@ -3,15 +3,25 @@
 
 """Model path resolution and automatic inference sharding."""
 
+import hashlib
 import json
+import logging
+import os
+import posixpath
+import tempfile
+from pathlib import Path, PurePosixPath
 
 from levanter.model_cache import resolve_cached_model_path
-from rigging.filesystem import StoragePath
+from rigging.filesystem import StoragePath, url_to_fs
 from transformers import AutoConfig
 
 from marin.inference.vllm_server import _is_object_store_path
 
 _MODEL_CACHE_PREFIX = "quick-serve-models"
+_LOCAL_MODEL_CACHE_DIR = "marin-models"
+_MODEL_CONFIG_FILENAME = "config.json"
+
+logger = logging.getLogger(__name__)
 
 
 def select_tensor_parallel_size(
@@ -54,7 +64,7 @@ def read_attention_heads(model: str, revision: str | None = None) -> tuple[int, 
 
 def _read_model_config_dict(model: str, revision: str | None = None) -> dict:
     if _is_object_store_path(model):
-        return json.loads((StoragePath(model) / "config.json").read_text())
+        return json.loads((StoragePath(model) / _MODEL_CONFIG_FILENAME).read_text())
     return AutoConfig.from_pretrained(model, revision=revision, trust_remote_code=True).to_dict()
 
 
@@ -71,3 +81,47 @@ def resolve_model_path(model: str, cache_ttl_days: int, revision: str | None = N
     )
     # With caching disabled, vLLM receives the bare model plus its separate revision argument.
     return model if resolved == pinned_model else resolved
+
+
+def stage_object_store_model_locally(model: str, staging_root: Path | None = None) -> str:
+    """Copy an object-store model snapshot to deterministic worker-local storage."""
+    if not _is_object_store_path(model):
+        return model
+
+    filesystem, remote_root = url_to_fs(model)
+    if not remote_root:
+        raise ValueError(f"Object-store model path must include a checkpoint prefix: {model}")
+
+    remote_entries = filesystem.find(remote_root, detail=True)
+    if not remote_entries:
+        raise FileNotFoundError(f"No files found under object-store model path: {model}")
+    expected_config = posixpath.join(remote_root, _MODEL_CONFIG_FILENAME)
+    if expected_config not in remote_entries:
+        raise FileNotFoundError(f"Object-store model path has no {_MODEL_CONFIG_FILENAME}: {model}")
+
+    cache_root = staging_root or Path(tempfile.gettempdir())
+    destination = cache_root / _LOCAL_MODEL_CACHE_DIR / hashlib.sha256(model.encode()).hexdigest()[:16]
+    logger.info("Staging %d object-store model entries from %s to %s", len(remote_entries), model, destination)
+    copied = 0
+    remote_root_path = PurePosixPath(remote_root)
+    for remote_file, info in sorted(remote_entries.items()):
+        if info.get("type") == "directory":
+            continue
+        try:
+            relative = PurePosixPath(remote_file).relative_to(remote_root_path)
+        except ValueError as exc:
+            raise ValueError(f"Object-store listing escaped model prefix: {remote_file}") from exc
+        if ".." in relative.parts:
+            raise ValueError(f"Object-store listing escaped model prefix: {remote_file}")
+        local_file = destination.joinpath(*relative.parts)
+        expected_size = info.get("size")
+        if expected_size is not None and local_file.is_file() and local_file.stat().st_size == expected_size:
+            continue
+        local_file.parent.mkdir(parents=True, exist_ok=True)
+        temporary_file = local_file.with_suffix(f"{local_file.suffix}.partial")
+        filesystem.get_file(remote_file, str(temporary_file))
+        os.replace(temporary_file, local_file)
+        copied += 1
+
+    logger.info("Staged object-store model at %s (%d files copied)", destination, copied)
+    return str(destination)

--- a/lib/marin/src/marin/inference/model_preparation.py
+++ b/lib/marin/src/marin/inference/model_preparation.py
@@ -3,25 +3,15 @@
 
 """Model path resolution and automatic inference sharding."""
 
-import hashlib
 import json
-import logging
-import os
-import posixpath
-import tempfile
-from pathlib import Path, PurePosixPath
 
 from levanter.model_cache import resolve_cached_model_path
-from rigging.filesystem import StoragePath, url_to_fs
+from rigging.filesystem import StoragePath
 from transformers import AutoConfig
 
 from marin.inference.vllm_server import _is_object_store_path
 
 _MODEL_CACHE_PREFIX = "quick-serve-models"
-_LOCAL_MODEL_CACHE_DIR = "marin-models"
-_MODEL_CONFIG_FILENAME = "config.json"
-
-logger = logging.getLogger(__name__)
 
 
 def select_tensor_parallel_size(
@@ -64,7 +54,7 @@ def read_attention_heads(model: str, revision: str | None = None) -> tuple[int, 
 
 def _read_model_config_dict(model: str, revision: str | None = None) -> dict:
     if _is_object_store_path(model):
-        return json.loads((StoragePath(model) / _MODEL_CONFIG_FILENAME).read_text())
+        return json.loads((StoragePath(model) / "config.json").read_text())
     return AutoConfig.from_pretrained(model, revision=revision, trust_remote_code=True).to_dict()
 
 
@@ -81,47 +71,3 @@ def resolve_model_path(model: str, cache_ttl_days: int, revision: str | None = N
     )
     # With caching disabled, vLLM receives the bare model plus its separate revision argument.
     return model if resolved == pinned_model else resolved
-
-
-def stage_object_store_model_locally(model: str, staging_root: Path | None = None) -> str:
-    """Copy an object-store model snapshot to deterministic worker-local storage."""
-    if not _is_object_store_path(model):
-        return model
-
-    filesystem, remote_root = url_to_fs(model)
-    if not remote_root:
-        raise ValueError(f"Object-store model path must include a checkpoint prefix: {model}")
-
-    remote_entries = filesystem.find(remote_root, detail=True)
-    if not remote_entries:
-        raise FileNotFoundError(f"No files found under object-store model path: {model}")
-    expected_config = posixpath.join(remote_root, _MODEL_CONFIG_FILENAME)
-    if expected_config not in remote_entries:
-        raise FileNotFoundError(f"Object-store model path has no {_MODEL_CONFIG_FILENAME}: {model}")
-
-    cache_root = staging_root or Path(tempfile.gettempdir())
-    destination = cache_root / _LOCAL_MODEL_CACHE_DIR / hashlib.sha256(model.encode()).hexdigest()[:16]
-    logger.info("Staging %d object-store model entries from %s to %s", len(remote_entries), model, destination)
-    copied = 0
-    remote_root_path = PurePosixPath(remote_root)
-    for remote_file, info in sorted(remote_entries.items()):
-        if info.get("type") == "directory":
-            continue
-        try:
-            relative = PurePosixPath(remote_file).relative_to(remote_root_path)
-        except ValueError as exc:
-            raise ValueError(f"Object-store listing escaped model prefix: {remote_file}") from exc
-        if ".." in relative.parts:
-            raise ValueError(f"Object-store listing escaped model prefix: {remote_file}")
-        local_file = destination.joinpath(*relative.parts)
-        expected_size = info.get("size")
-        if expected_size is not None and local_file.is_file() and local_file.stat().st_size == expected_size:
-            continue
-        local_file.parent.mkdir(parents=True, exist_ok=True)
-        temporary_file = local_file.with_suffix(f"{local_file.suffix}.partial")
-        filesystem.get_file(remote_file, str(temporary_file))
-        os.replace(temporary_file, local_file)
-        copied += 1
-
-    logger.info("Staged object-store model at %s (%d files copied)", destination, copied)
-    return str(destination)

--- a/lib/marin/src/marin/inference/vllm_backend.py
+++ b/lib/marin/src/marin/inference/vllm_backend.py
@@ -89,6 +89,8 @@ class VllmBackend:
             engine_kwargs["max_model_len"] = spec.max_model_len
         if self.config.max_num_batched_tokens is not None:
             engine_kwargs["max_num_batched_tokens"] = self.config.max_num_batched_tokens
+        if self.config.max_num_seqs is not None:
+            engine_kwargs["max_num_seqs"] = self.config.max_num_seqs
         model = InferenceModelConfig(name=spec.weights, path=spec.weights, engine_kwargs=engine_kwargs)
         revision_args = ("--revision", spec.revision) if spec.revision is not None else ()
         with _chat_template_argument(spec.chat_template_content) as chat_template_args:

--- a/lib/marin/src/marin/inference/vllm_server.py
+++ b/lib/marin/src/marin/inference/vllm_server.py
@@ -424,6 +424,9 @@ def _engine_kwargs_to_cli_args(engine_kwargs: dict) -> list[str]:
     max_num_batched_tokens = engine_kwargs.get("max_num_batched_tokens")
     if max_num_batched_tokens is not None:
         args.extend(["--max-num-batched-tokens", str(max_num_batched_tokens)])
+    max_num_seqs = engine_kwargs.get("max_num_seqs")
+    if max_num_seqs is not None:
+        args.extend(["--max-num-seqs", str(max_num_seqs)])
     return args
 
 

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -4,7 +4,9 @@
 """Behavior of the endpoint-oriented evaluation loop and durable records."""
 
 from collections.abc import Mapping
+from dataclasses import replace
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from marin.evaluation.hardware import AcceleratorChoice, Platform
@@ -17,10 +19,14 @@ from marin.evaluation.runner import (
     EvaluationIdentity,
     EvaluationOutcome,
     evaluate_batch,
+    submit_evaluation_batch,
 )
 from marin.inference.iris import RemoteInferenceSession
 from marin.inference.types import OpenAIEndpoint, RunningModel
 from rigging.filesystem import StoragePath
+
+from experiments.evaluation.evals import EVALS
+from experiments.evaluation.launch import LaunchSpec, build_evaluation_batch
 
 
 def _successful_evaluation(
@@ -105,3 +111,100 @@ def test_evaluate_batch_persists_failures_and_continues_on_the_same_endpoint(tmp
     assert succeeded.status is RunStatus.SUCCEEDED
     assert succeeded.metrics == {"task": {"accuracy": 0.75}}
     assert (tmp_path / "success" / "endpoint.txt").read_text() == endpoint
+
+
+def test_submit_evaluation_batch_resolves_declared_secrets_outside_the_pickled_batch(tmp_path, monkeypatch):
+    captured: dict = {}
+    resolved_value = "resolved-evaluation-secret"
+
+    class Client:
+        def submit(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(job_id="/eval/job")
+
+    monkeypatch.setenv("MARIN_TEST_EVAL_SECRET", resolved_value)
+    evaluation = Evaluation(
+        identity=EvaluationIdentity(
+            run_id="run-secret",
+            created_at="2026-07-24T00:00:00+00:00",
+            output_dir=str(tmp_path / "secret"),
+            eval_ref=EvalRef(name="secret", mechanism="test"),
+        ),
+        executor=_successful_evaluation,
+    )
+    batch = EvaluationBatch(
+        group_id="group",
+        user="tester",
+        version=None,
+        description=None,
+        records_prefix=str(tmp_path / "records"),
+        model=ModelConfig(
+            name="model",
+            location="org/model",
+            tokenizer="tokenizer",
+            resource_hint=ResourceHint(hbm_gb=3),
+        ),
+        accelerator=AcceleratorChoice(platform=Platform.TPU, tpu_type="v6e-4", region="us-central1"),
+        capability_origin="https://iris.example",
+        api_model="model",
+        evaluations=(evaluation,),
+        provenance=Provenance(git_sha="abc", eval_image="image", launch_host="host"),
+        secret_env={"DAYTONA_API_KEY": ("env:MARIN_TEST_EVAL_SECRET",)},
+    )
+
+    submit_evaluation_batch(batch, Client())
+
+    assert captured["environment"].env_vars["DAYTONA_API_KEY"] == resolved_value
+    assert resolved_value.encode() not in captured["entrypoint"].workdir_files["_callable.pkl"]
+
+
+def test_build_evaluation_batch_merges_the_shared_daytona_spec(monkeypatch):
+    monkeypatch.setattr("experiments.evaluation.launch._capability_origin", lambda _cluster: "https://iris.example")
+    spec = LaunchSpec(
+        model="qwen3-8b",
+        evals=("aime-harbor", "tb2"),
+        platform=Platform.TPU,
+        accelerator=None,
+        limit=1,
+        records_prefix="memory://records",
+        cluster="marin",
+    )
+
+    batch = build_evaluation_batch(
+        spec,
+        Provenance(git_sha="abc", eval_image="image", launch_host="host"),
+        "tester",
+    )
+
+    assert batch.secret_env == {
+        "DAYTONA_API_KEY": (
+            "env:DAYTONA_API_KEY",
+            "gcp-secret://projects/hai-gcp-models/secrets/DAYTONA_EVAL_API_KEY/versions/latest",
+        )
+    }
+
+
+def test_build_evaluation_batch_rejects_conflicting_secret_specs(monkeypatch):
+    monkeypatch.setattr("experiments.evaluation.launch._capability_origin", lambda _cluster: "https://iris.example")
+    conflicting = replace(
+        EVALS["aime-harbor"],
+        name="conflicting-daytona",
+        secret_env={"DAYTONA_API_KEY": ("env:OTHER_DAYTONA_API_KEY",)},
+    )
+    monkeypatch.setitem(EVALS, "conflicting-daytona", conflicting)
+    spec = LaunchSpec(
+        model="qwen3-8b",
+        evals=("aime-harbor", "conflicting-daytona"),
+        platform=Platform.TPU,
+        accelerator=None,
+        limit=1,
+        records_prefix="memory://records",
+        cluster="marin",
+    )
+
+    with pytest.raises(ValueError, match="conflicting secret specifications for DAYTONA_API_KEY"):
+        build_evaluation_batch(
+            spec,
+            Provenance(git_sha="abc", eval_image="image", launch_host="host"),
+            "tester",
+        )

--- a/tests/evaluation/test_harbor_runner.py
+++ b/tests/evaluation/test_harbor_runner.py
@@ -7,9 +7,17 @@ from pathlib import Path
 import pytest
 from fsspec.implementations.memory import MemoryFileSystem
 from marin.evaluation.harbor.dataset import materialize_harbor_dataset
+from marin.evaluation.harbor.driver_config import (
+    HarborAgentConfig,
+    HarborDriverConfig,
+    HarborEnvironmentConfig,
+    HarborRetryConfig,
+    HarborRunConfig,
+    HarborVerifierConfig,
+    native_job_config,
+)
 from marin.evaluation.harbor.runner import (
     HarborExecutor,
-    HarborRunConfig,
     HarborTrial,
     _restore_completed_trials,
     _upload_trials,
@@ -110,12 +118,72 @@ def test_harbor_trials_round_trip_through_remote_storage(protocol, tmp_path, mon
     assert not (restored_dir / "incomplete").exists()
 
 
-def test_run_harbor_derives_url_and_served_name_from_running_model(tmp_path, monkeypatch):
+def test_native_job_config_translates_the_external_harbor_contract():
+    config = HarborDriverConfig(
+        job_name="job",
+        jobs_dir="/tmp/jobs",
+        dataset_path=None,
+        endpoint_url="https://iris.example/v1",
+        served_model="served-model",
+        run=HarborRunConfig(
+            dataset="aime",
+            revision="1.0",
+            agent=HarborAgentConfig(
+                name="opencode",
+                max_output_tokens=16384,
+                max_timeout=7200,
+                setup_timeout=600,
+                kwargs={
+                    "model_info": {"max_input_tokens": 64512},
+                    "opencode_config": {"compaction": {"auto": False}},
+                },
+            ),
+            environment=HarborEnvironmentConfig(
+                environment_type="daytona",
+                cpus=2,
+                memory_mb=8192,
+                storage_mb=8192,
+            ),
+            attempts=3,
+            retry=HarborRetryConfig(max_retries=6, min_wait=2.0, max_wait=90.0),
+            verifier=HarborVerifierConfig(max_timeout=14400),
+        ),
+    )
+
+    native = native_job_config(config)
+
+    assert native["datasets"] == [{"name": "aime", "version": "1.0", "n_tasks": None}]
+    assert native["n_attempts"] == 3
+    assert native["retry"]["min_wait_sec"] == 2.0
+    assert native["retry"]["max_wait_sec"] == 90.0
+    assert native["environment"]["override_cpus"] == 2
+    assert native["environment"]["override_memory_mb"] == 8192
+    assert native["environment"]["override_storage_mb"] == 8192
+    assert native["verifier"]["max_timeout_sec"] == 14400
+    agent = native["agents"][0]
+    assert agent["model_name"] == "hosted_vllm/served-model"
+    assert agent["override_setup_timeout_sec"] == 600
+    assert agent["kwargs"]["api_base"] == "https://iris.example/v1"
+    assert agent["kwargs"]["model_info"]["max_input_tokens"] == 64512
+    assert agent["kwargs"]["model_info"]["max_output_tokens"] == 16384
+    opencode_config = agent["kwargs"]["opencode_config"]
+    assert opencode_config["compaction"] == {"auto": False}
+    assert opencode_config["provider"]["hosted_vllm"] == {
+        "npm": "@ai-sdk/openai-compatible",
+        "name": "Hosted vLLM",
+        "options": {"baseURL": "https://iris.example/v1"},
+    }
+
+
+def test_run_harbor_normalizes_a_completed_external_trial(tmp_path, monkeypatch):
     captured: dict = {}
 
-    def run_driver(config_file: Path) -> None:
-        captured.update(json.loads(config_file.read_text()))
-        trial_dir = Path(captured["jobs_dir"]) / captured["job_name"] / "trial-one"
+    def run_driver(command, *, check, env) -> None:
+        assert check
+        driver_config = HarborDriverConfig.from_dict(json.loads(Path(command[-1]).read_text()))
+        captured["driver_config"] = driver_config
+        captured["env"] = env
+        trial_dir = Path(driver_config.jobs_dir) / driver_config.job_name / "trial-one"
         trial_dir.mkdir(parents=True, exist_ok=True)
         (trial_dir / "result.json").write_text(
             json.dumps(
@@ -126,27 +194,36 @@ def test_run_harbor_derives_url_and_served_name_from_running_model(tmp_path, mon
             )
         )
 
-    monkeypatch.setattr("marin.evaluation.harbor.runner._run_driver", run_driver)
-    monkeypatch.setattr("marin.evaluation.harbor.runner.materialize_harbor_dataset", lambda *args, **kwargs: None)
+    monkeypatch.setattr("marin.evaluation.harbor.runner.subprocess.run", run_driver)
+    monkeypatch.setenv("OPENAI_API_KEY", "must-not-reach-harbor")
     model = _running_model()
 
     result = run_harbor(
         model,
-        HarborRunConfig(dataset=f"toy-{tmp_path.name}", version="1.0", agent="terminus-2"),
+        HarborRunConfig(
+            dataset=f"toy-{tmp_path.name}",
+            revision="1.0",
+            agent=HarborAgentConfig(name="terminus-2"),
+            environment=HarborEnvironmentConfig(environment_type="daytona"),
+        ),
         str(tmp_path),
         hf_token=None,
+        driver_env={"DAYTONA_API_KEY": "daytona-key"},
     )
 
-    assert captured["model_name"] == "hosted_vllm/qwen3-0.6b"
-    assert captured["agent_kwargs"]["api_base"] == model.endpoint.base_url
+    assert captured["driver_config"].endpoint_url == model.endpoint.base_url
+    assert captured["driver_config"].served_model == "qwen3-0.6b"
+    assert captured["env"]["DAYTONA_API_KEY"] == "daytona-key"
+    assert "OPENAI_API_KEY" not in captured["env"]
     assert result.total_trials == 1
     assert result.accuracy == 1.0
 
 
 def test_harbor_executor_fails_when_trial_contains_exception_info(tmp_path, monkeypatch):
-    def run_driver(config_file: Path) -> None:
-        config = json.loads(config_file.read_text())
-        trial_dir = Path(config["jobs_dir"]) / config["job_name"] / "trial-one"
+    def run_driver(command, *, check, env) -> None:
+        assert check and isinstance(env, dict)
+        config = HarborDriverConfig.from_dict(json.loads(Path(command[-1]).read_text()))
+        trial_dir = Path(config.jobs_dir) / config.job_name / "trial-one"
         trial_dir.mkdir(parents=True, exist_ok=True)
         (trial_dir / "result.json").write_text(
             json.dumps(
@@ -161,9 +238,15 @@ def test_harbor_executor_fails_when_trial_contains_exception_info(tmp_path, monk
             )
         )
 
-    monkeypatch.setattr("marin.evaluation.harbor.runner._run_driver", run_driver)
-    monkeypatch.setattr("marin.evaluation.harbor.runner.materialize_harbor_dataset", lambda *args, **kwargs: None)
-    executor = HarborExecutor(HarborRunConfig(dataset=f"toy-{tmp_path.name}", version="1.0", agent="terminus-2"))
+    monkeypatch.setattr("marin.evaluation.harbor.runner.subprocess.run", run_driver)
+    executor = HarborExecutor(
+        HarborRunConfig(
+            dataset=f"failed-{tmp_path.name}",
+            revision="1.0",
+            agent=HarborAgentConfig(name="terminus-2"),
+            environment=HarborEnvironmentConfig(environment_type="daytona"),
+        )
+    )
 
     with pytest.raises(EvaluationError) as exc_info:
         executor(_running_model(), str(tmp_path), {})
@@ -174,9 +257,10 @@ def test_harbor_executor_fails_when_trial_contains_exception_info(tmp_path, monk
 
 
 def test_harbor_executor_accepts_zero_reward_without_exception_info(tmp_path, monkeypatch):
-    def run_driver(config_file: Path) -> None:
-        config = json.loads(config_file.read_text())
-        trial_dir = Path(config["jobs_dir"]) / config["job_name"] / "trial-one"
+    def run_driver(command, *, check, env) -> None:
+        assert check and isinstance(env, dict)
+        config = HarborDriverConfig.from_dict(json.loads(Path(command[-1]).read_text()))
+        trial_dir = Path(config.jobs_dir) / config.job_name / "trial-one"
         trial_dir.mkdir(parents=True, exist_ok=True)
         (trial_dir / "result.json").write_text(
             json.dumps(
@@ -187,9 +271,15 @@ def test_harbor_executor_accepts_zero_reward_without_exception_info(tmp_path, mo
             )
         )
 
-    monkeypatch.setattr("marin.evaluation.harbor.runner._run_driver", run_driver)
-    monkeypatch.setattr("marin.evaluation.harbor.runner.materialize_harbor_dataset", lambda *args, **kwargs: None)
-    executor = HarborExecutor(HarborRunConfig(dataset=f"toy-{tmp_path.name}", version="1.0", agent="terminus-2"))
+    monkeypatch.setattr("marin.evaluation.harbor.runner.subprocess.run", run_driver)
+    executor = HarborExecutor(
+        HarborRunConfig(
+            dataset=f"zero-{tmp_path.name}",
+            revision="1.0",
+            agent=HarborAgentConfig(name="terminus-2"),
+            environment=HarborEnvironmentConfig(environment_type="daytona"),
+        )
+    )
 
     outcome = executor(_running_model(), str(tmp_path), {})
 

--- a/tests/inference/test_serve.py
+++ b/tests/inference/test_serve.py
@@ -53,6 +53,7 @@ from marin.inference.levanter_backend import (
 from marin.inference.model_preparation import (
     resolve_model_path,
     select_tensor_parallel_size,
+    stage_object_store_model_locally,
 )
 from marin.inference.serve_cli import main as serve_main
 from marin.inference.tpu_vllm_pins import vllm_fork_ref
@@ -94,7 +95,7 @@ def test_select_tensor_parallel_size(heads, chips, kv_heads, expected):
 @pytest.mark.parametrize(
     ("model", "ttl_days"),
     [
-        ("gs://bucket/ckpt", 14),  # object-store paths are served directly, never mirrored
+        ("gs://bucket/ckpt", 14),  # resolution leaves staging policy to the inference engine
         ("s3://bucket/ckpt", 14),
         ("Qwen/Qwen3-0.6B", 0),  # caching disabled
     ],
@@ -115,6 +116,39 @@ def test_resolve_model_path_includes_revision_in_cache_key(monkeypatch):
 
     assert resolve_model_path("Qwen/Qwen3-0.6B", 14, "abc123") == "gs://cache/pinned-model"
     assert observed == [("Qwen/Qwen3-0.6B@abc123", 14, "quick-serve-models")]
+
+
+def test_stage_object_store_model_locally_resumes_complete_files(monkeypatch, tmp_path):
+    class ObjectStore:
+        def __init__(self) -> None:
+            self.files = {
+                "bucket/checkpoint/config.json": b'{"architectures": ["Test"]}',
+                "bucket/checkpoint/model.safetensors": b"weights",
+            }
+            self.copies = 0
+
+        def find(self, root: str, *, detail: bool):
+            assert root == "bucket/checkpoint"
+            assert detail
+            return {name: {"type": "file", "size": len(contents)} for name, contents in self.files.items()}
+
+        def get_file(self, remote_file: str, local_file: str) -> None:
+            self.copies += 1
+            Path(local_file).write_bytes(self.files[remote_file])
+
+    store = ObjectStore()
+    monkeypatch.setattr(
+        "marin.inference.model_preparation.url_to_fs",
+        lambda _path: (store, "bucket/checkpoint"),
+    )
+
+    first = Path(stage_object_store_model_locally("s3://bucket/checkpoint", tmp_path))
+    second = Path(stage_object_store_model_locally("s3://bucket/checkpoint", tmp_path))
+
+    assert first == second
+    assert (first / "config.json").read_bytes() == store.files["bucket/checkpoint/config.json"]
+    assert (first / "model.safetensors").read_bytes() == store.files["bucket/checkpoint/model.safetensors"]
+    assert store.copies == 2
 
 
 def test_vllm_backend_serves_the_pinned_revision(monkeypatch):
@@ -161,7 +195,11 @@ def test_resolved_model_keeps_requested_id_as_served_name(monkeypatch):
         worker_environment=create_environment(extras=["tpu", "vllm"]),
     )
 
-    resolved, _num_chips = _resolved_model(ServedModelConfig(weights="Qwen/Qwen3-0.6B", tensor_parallel_size=1), iris)
+    resolved, _num_chips = _resolved_model(
+        ServedModelConfig(weights="Qwen/Qwen3-0.6B", tensor_parallel_size=1),
+        VllmEngineConfig(),
+        iris,
+    )
 
     assert resolved.weights == "gs://cache/quick-serve/qwen3-0.6b"
     assert resolved.model_id == "Qwen/Qwen3-0.6B"

--- a/tests/inference/test_serve.py
+++ b/tests/inference/test_serve.py
@@ -50,11 +50,7 @@ from marin.inference.levanter_backend import (
     levanter_max_seq_len,
     validate_levanter_dtype,
 )
-from marin.inference.model_preparation import (
-    resolve_model_path,
-    select_tensor_parallel_size,
-    stage_object_store_model_locally,
-)
+from marin.inference.model_preparation import resolve_model_path, select_tensor_parallel_size
 from marin.inference.serve_cli import main as serve_main
 from marin.inference.tpu_vllm_pins import vllm_fork_ref
 from marin.inference.vllm_backend import VllmBackend, vllm_launcher
@@ -95,7 +91,7 @@ def test_select_tensor_parallel_size(heads, chips, kv_heads, expected):
 @pytest.mark.parametrize(
     ("model", "ttl_days"),
     [
-        ("gs://bucket/ckpt", 14),  # resolution leaves staging policy to the inference engine
+        ("gs://bucket/ckpt", 14),  # object-store paths are served directly, never mirrored
         ("s3://bucket/ckpt", 14),
         ("Qwen/Qwen3-0.6B", 0),  # caching disabled
     ],
@@ -116,39 +112,6 @@ def test_resolve_model_path_includes_revision_in_cache_key(monkeypatch):
 
     assert resolve_model_path("Qwen/Qwen3-0.6B", 14, "abc123") == "gs://cache/pinned-model"
     assert observed == [("Qwen/Qwen3-0.6B@abc123", 14, "quick-serve-models")]
-
-
-def test_stage_object_store_model_locally_resumes_complete_files(monkeypatch, tmp_path):
-    class ObjectStore:
-        def __init__(self) -> None:
-            self.files = {
-                "bucket/checkpoint/config.json": b'{"architectures": ["Test"]}',
-                "bucket/checkpoint/model.safetensors": b"weights",
-            }
-            self.copies = 0
-
-        def find(self, root: str, *, detail: bool):
-            assert root == "bucket/checkpoint"
-            assert detail
-            return {name: {"type": "file", "size": len(contents)} for name, contents in self.files.items()}
-
-        def get_file(self, remote_file: str, local_file: str) -> None:
-            self.copies += 1
-            Path(local_file).write_bytes(self.files[remote_file])
-
-    store = ObjectStore()
-    monkeypatch.setattr(
-        "marin.inference.model_preparation.url_to_fs",
-        lambda _path: (store, "bucket/checkpoint"),
-    )
-
-    first = Path(stage_object_store_model_locally("s3://bucket/checkpoint", tmp_path))
-    second = Path(stage_object_store_model_locally("s3://bucket/checkpoint", tmp_path))
-
-    assert first == second
-    assert (first / "config.json").read_bytes() == store.files["bucket/checkpoint/config.json"]
-    assert (first / "model.safetensors").read_bytes() == store.files["bucket/checkpoint/model.safetensors"]
-    assert store.copies == 2
 
 
 def test_vllm_backend_serves_the_pinned_revision(monkeypatch):
@@ -195,11 +158,7 @@ def test_resolved_model_keeps_requested_id_as_served_name(monkeypatch):
         worker_environment=create_environment(extras=["tpu", "vllm"]),
     )
 
-    resolved, _num_chips = _resolved_model(
-        ServedModelConfig(weights="Qwen/Qwen3-0.6B", tensor_parallel_size=1),
-        VllmEngineConfig(),
-        iris,
-    )
+    resolved, _num_chips = _resolved_model(ServedModelConfig(weights="Qwen/Qwen3-0.6B", tensor_parallel_size=1), iris)
 
     assert resolved.weights == "gs://cache/quick-serve/qwen3-0.6b"
     assert resolved.model_id == "Qwen/Qwen3-0.6B"

--- a/tests/rl/test_weight_transfer.py
+++ b/tests/rl/test_weight_transfer.py
@@ -1,7 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 import tempfile
 import uuid
 
@@ -26,8 +25,7 @@ TRANSFER_TYPES = [
     WeightTransferMode.ARROW_FLIGHT,
 ]
 
-if os.environ.get("CI"):
-    pytest.skip("Skipping slow tests on CI", allow_module_level=True)
+pytestmark = pytest.mark.slow
 
 
 class EmbeddingTestModule(eqx.Module):


### PR DESCRIPTION
Register the step-1903 Grug OpenCode SFT on the unified evaluation launcher introduced by #7575. The model uses H100x8 with the 8-CPU default, 512 GiB host memory, and 100 GiB ephemeral disk. vLLM loads the S3 export through the existing RunAI streamer.

Keep the OpenCode retry, timeout, Daytona resource, trajectory, and pinned `DCAgent/dev_set_v2` dataset policy in one composed Harbor evaluation config. The experiment catalog owns the Daytona credential reference: `DAYTONA_API_KEY` is the sole environment override, with the approved Secret Manager version as fallback. The generic launcher resolves declared secrets before Iris submission and passes only each evaluation's declared credentials into the pinned, isolated Harbor process.

Materialize Hugging Face task repositories locally and persist native Harbor trial trees through the configured GCS or S3 filesystem before normalizing samples and aggregate results. Remove the Daytona branch from the generic evaluation runner and delete configuration-projection tests; the reviewed cleanup design is recorded in [Weaver](https://loom.oa.dev/s/ikdklozv/artifacts/design).

After the federation relay fixes in `main`, the local-staging control `/loom/eval-20260725-171148-grug-agentic-s3-step1903-53cd` copied 124.9 GiB in 209 seconds, reached vLLM readiness in 314 seconds, and served Daytona requests through the relayed capability URL. The RunAI validation `/loom/eval-20260725-172925-grug-agentic-s3-step1903-3b83` streamed the same 124.9 GiB on all eight data-parallel ranks in 140–155 seconds at 826–917 MiB/s, reached readiness in 276 seconds on a cold compilation-cache key, and served Daytona requests with HTTP 200. Harbor completed three capped attempts in 30 minutes 50 seconds and scored one as solved. The durable record at `s3://marin-us-east-02a/marin/eval-metadata/runs/pr7606-runai-52a5517fb/20260725-172925-grug-agentic-s3-step1903-grug-opencode-id-6361/record.json` is marked failed because two scored attempts contain `exception_info`, as required by the evaluation contract from #7625; this occurred after model loading and endpoint validation. This validates one cold H100x8 start and end-to-end traffic; simultaneous cold-start failures remain tracked in #7525.
