### PR TITLE
[iac] Keep kubeconfig out of Pulumi provider state

### DIFF
--- a/.github/workflows/ops-iac-preview.yaml
+++ b/.github/workflows/ops-iac-preview.yaml
@@ -47,6 +47,7 @@ jobs:
           mkdir -p ~/.kube
           echo "${{ secrets.CW_KUBECONFIG }}" > ~/.kube/coreweave-iris
           chmod 600 ~/.kube/coreweave-iris
+          echo "KUBECONFIG=$HOME/.kube/coreweave-iris" >> "$GITHUB_ENV"
 
       # Required for TraefikAddon's Traefik/cert-manager Releases to resolve their charts
       # during `pulumi preview` — see infra/pulumi/README.md's Prerequisites.

--- a/infra/pulumi/README.md
+++ b/infra/pulumi/README.md
@@ -82,13 +82,15 @@ Everything comes from the per-cluster Iris config (`lib/iris/config/<cluster>.ya
   `hai-gcp-models`, the same one `infra/grafana` uses) under your GCP credentials above — no
   separate export needed, just `roles/secretmanager.secretAccessor` on that secret.
 - **Backend login**: `pulumi login gs://marin-iac-state`.
-- **Cluster access** (for the k8s dry-run): the CoreWeave kubeconfig at the path in the
-  cluster's `platform.coreweave.kubeconfig_path` (typically `~/.kube/coreweave-iris`).
+- **Cluster access** (for the k8s dry-run): export `KUBECONFIG` with the CoreWeave kubeconfig
+  path (typically `~/.kube/coreweave-iris`). The provider keeps this execution credential out
+  of Pulumi configuration and state.
 
 ### Making a change
 
 ```bash
 cd infra/pulumi
+export KUBECONFIG=~/.kube/coreweave-iris
 pulumi stack select <cluster>
 pulumi preview
 ```
@@ -98,9 +100,9 @@ or `delete` on a NodePool is not** — it deprovisions a reserved bare-metal fle
 reconcile the program to match reality; never `pulumi up` through a destructive NodePool diff.
 Once the preview is clean, `pulumi up`.
 
-No `KUBECONFIG` export needed anywhere in this flow: `__main__.py` builds the k8s provider with
-an explicit `kubeconfig=`/`context=` read from the cluster's own
-`platform.coreweave.kubeconfig_path`/`kube_context`, never from the env var or your shell's
+`__main__.py` requires `KUBECONFIG` but does not pass it as a provider input, so Pulumi state
+contains neither the machine-local path nor the credential contents. The provider still uses
+the cluster's declared `platform.coreweave.kube_context`; it never relies on the kubeconfig's
 current context.
 
 ### Adopting a new cluster

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -15,7 +15,6 @@ README.md's "Future work".
 
 import os
 import sys
-from pathlib import Path
 
 # Make the `iac` package importable without a separate install step: Pulumi runs this file
 # from infra/pulumi/, so add its src/ to the path. Deps (pulumi, pulumi-kubernetes) and
@@ -81,24 +80,26 @@ def _build_coreweave(cluster: str, *, adopt: bool) -> None:
         namespace = DEFAULT_NAMESPACE
 
     platform_coreweave = iris_config.platform.coreweave
-    if platform_coreweave is None or not platform_coreweave.kubeconfig_path:
+    if platform_coreweave is None:
         raise ValueError(
-            f"cluster {cluster!r} has no platform.coreweave.kubeconfig_path; "
-            "the minimal IaC cut needs an out-of-cluster kubeconfig to target"
+            f"cluster {cluster!r} has no platform.coreweave config; "
+            "the minimal IaC cut needs an out-of-cluster Kubernetes target"
         )
-    kubeconfig_path = os.path.expanduser(platform_coreweave.kubeconfig_path)
-    kubeconfig = pulumi.Output.secret(Path(kubeconfig_path).read_text())
+    if not os.environ.get("KUBECONFIG"):
+        raise ValueError(
+            f"cluster {cluster!r} requires KUBECONFIG; "
+            "Pulumi reads Kubernetes credentials from the execution environment"
+        )
     # Bind to the cluster's declared kube_context, not the kubeconfig's current-context —
     # otherwise a stack silently targets whatever `kubectl` was last pointed at.
     #
     # enable_patch_force=True: declared here until the "cede" ships (spec.md §4). Iris's
     # controller still re-applies RBAC/NodePools under its own field manager on every restart, so
     # a plain SSA dry-run reports a field conflict without forced ownership (README §Adoption
-    # check). Keep kubeconfig and context as ordinary provider inputs: ignoring either makes
-    # Pulumi reuse stale local credentials or even a previously stored path string.
+    # check). KUBECONFIG stays in the execution environment instead of becoming a provider
+    # input, which keeps credentials and machine-local paths out of Pulumi state.
     k8s_provider = k8s.Provider(
         "cw-k8s",
-        kubeconfig=kubeconfig,
         context=platform_coreweave.kube_context or None,
         enable_patch_force=True,
     )


### PR DESCRIPTION
Let the CoreWeave Kubernetes provider source credentials from `KUBECONFIG`
instead of persisting a machine-local path or kubeconfig contents as a provider
input. The reviewed `kube_context` still selects the target, while credentials
remain execution-local.

The CoreWeave preview workflow exports the generated kubeconfig path through
`GITHUB_ENV`, and the operator runbook requires the same export. A full
`cw-us-west-04a` preview showed one provider update removing `kubeconfig` and 28
unchanged resources; subsequent previews will not diff credential paths or
bytes.

Follow-up to #7610.
