### PR TITLE
[loom] Pin remote image builds to the branch SHA

### DIFF
--- a/.agents/ops/2026-07-24-loom-remote-image-context.md
+++ b/.agents/ops/2026-07-24-loom-remote-image-context.md
@@ -1,0 +1,58 @@
+# Loom deployment: remote image context does not rebuild
+
+Determine why `pulumi up --cwd infra/loom` did not plan a rebuild of
+`loom-release-image` after the default branch of the remote Loom repository
+changed.
+
+## Initial status
+
+The preview planned only a GCE instance metadata update and replacement of
+`loom-activate`. It listed `loom-release-image` among the unchanged resources.
+The stack uses `pulumi-docker-build` 0.0.15 with
+`context.location = https://github.com/marin-community/loom.git`,
+`buildOnPreview = true`, and `push = true`.
+
+## Hypothesis 1
+
+`buildOnPreview` controls whether an already-planned image create or update
+performs a build. It does not force the image resource to have a diff.
+
+The provider's `Diff` implementation calls `hashBuildContext`. That function
+hashes local Dockerfiles and local context directories but does not resolve or
+hash remote contexts. The unpinned Git URL therefore produces the same empty
+context hash as its default branch advances, so Pulumi does not schedule an
+image update.
+
+## Changes
+
+The default remote source now uses the GitHub provider to resolve `main` to a
+full commit SHA. The Docker build context is
+`https://github.com/marin-community/loom.git#<sha>`, so a changed branch tip
+changes the image resource input. A configured local `buildContext` still
+bypasses GitHub resolution.
+
+The README now describes the SHA resolution and rebuild condition.
+
+## Results
+
+The provider source for version 0.0.15 confirms that remote context contents
+are omitted from `contextHash`. The pinned context URL changes when `main`
+advances, so the provider's direct `context.location` comparison schedules an
+image update.
+
+Pulumi deployed Loom commit
+`c10430bd11b83dfb9c0b7dfb862fdfbcd7b8f7b9` as image digest
+`sha256:7b1e9957cce4e5099cce01b8f4d485c4a37106e8dbc17d74921df7f2a240865a`.
+The activation command passed, `/api/ready` reported both migration streams at
+their expected versions with no degraded checks, and the final preview reported
+24 unchanged resources.
+
+`./infra/pre-commit.py --changed-files --fix` and focused Pyrefly checking
+passed. The five synchronous tests in `infra/loom/tests/test_infrastructure.py`
+passed before the first existing Pulumi async test timed out after 60 seconds.
+No regression test was added.
+
+## Future work
+
+- [x] Resolve and pin the remote Loom commit in the image resource inputs.
+- [x] Correct the README description of remote image builds.

--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -31,10 +31,11 @@ The local Docker builder must support `linux/amd64`.
 
 ## Deploy
 
-By default, Pulumi builds the HEAD of Loom's default branch during preview to
-catch image failures without pushing it. `pulumi up` rebuilds and pushes the
-image, places the provider-produced digest in VM metadata, and waits for
-`https://loom.oa.dev/api/ready` after activation.
+By default, Pulumi resolves the HEAD of Loom's default branch to its full commit
+SHA and uses that immutable Git context as the image input. When the resolved
+commit changes, preview reports an image update. `pulumi up` builds and pushes
+the changed image, places the provider-produced digest in VM metadata, and waits
+for `https://loom.oa.dev/api/ready` after activation.
 
 ```sh
 pulumi preview --cwd /path/to/marin/infra/loom --stack marin-loom --diff

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -18,10 +18,14 @@ import pulumi_cloudflare as cloudflare
 import pulumi_command as command
 import pulumi_docker_build as docker_build
 import pulumi_gcp as gcp
+import pulumi_github as github
 
 ROOT = Path(__file__).resolve().parent
 DEFAULT_DISK_TYPE = "pd-balanced"
 REPOSITORY_URL = "https://github.com/marin-community/loom.git"
+REPOSITORY_OWNER = "marin-community"
+REPOSITORY_NAME = "loom"
+REPOSITORY_BRANCH = "main"
 ARTIFACT_REPOSITORY_ID = "loom"
 ARTIFACT_IMAGE_NAME = "loom"
 DOTENV_SECRET_ID = "LOOM_DOTENV"
@@ -32,6 +36,7 @@ LOG_WRITER_ROLE = "roles/logging.logWriter"
 SERVICE_ACCOUNT_MEMBER = "serviceAccount:{}"
 WEB_FIREWALL_TAG = "loom-web"
 SSH_FIREWALL_TAG = "loom-ssh"
+GIT_COMMIT = re.compile(r"^[0-9a-f]{40}$")
 STARTUP_SCRIPT = (ROOT / "startup-script.sh").read_text()
 RUNTIME_COMPOSE = (ROOT / "runtime/docker-compose.yml").read_text()
 RUNTIME_CADDYFILE = (ROOT / "runtime/Caddyfile").read_text()
@@ -52,6 +57,12 @@ def _validated_image_reference(value: str, project: str, region: str) -> str:
     if not re.fullmatch(rf"{image_path}(?::[^@]+)?@sha256:[0-9a-f]{{64}}", value):
         raise ValueError("Docker did not produce the expected Loom image digest")
     return value
+
+
+def _git_context_at_revision(revision: str) -> str:
+    if not GIT_COMMIT.fullmatch(revision):
+        raise ValueError(f"GitHub returned an invalid Loom revision: {revision!r}")
+    return f"{REPOSITORY_URL}#{revision}"
 
 
 SECRET_REF = re.compile(
@@ -529,6 +540,19 @@ class ImageResources:
     vm_reader: gcp.artifactregistry.RepositoryIamMember
 
 
+def _resolved_build_context(config: DeploymentConfig) -> str:
+    if config.build_context != REPOSITORY_URL:
+        return config.build_context
+
+    source_provider = github.Provider("loom-source", owner=REPOSITORY_OWNER)
+    branch = github.get_branch(
+        repository=REPOSITORY_NAME,
+        branch=REPOSITORY_BRANCH,
+        opts=pulumi.InvokeOptions(provider=source_provider),
+    )
+    return _git_context_at_revision(branch.sha)
+
+
 def _create_image(
     config: DeploymentConfig,
     apis: list[gcp.projects.Service],
@@ -554,7 +578,7 @@ def _create_image(
     image_tag = f"{_artifact_image_path(config.project, config.region)}:latest"
     image = docker_build.Image(
         "loom-release-image",
-        context=docker_build.BuildContextArgs(location=config.build_context),
+        context=docker_build.BuildContextArgs(location=_resolved_build_context(config)),
         build_args={"CARGO_PROFILE": "release"},
         labels={"org.opencontainers.image.source": REPOSITORY_URL},
         platforms=[docker_build.Platform.LINUX_AMD64],

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -22,10 +22,10 @@ import pulumi_github as github
 
 ROOT = Path(__file__).resolve().parent
 DEFAULT_DISK_TYPE = "pd-balanced"
-REPOSITORY_URL = "https://github.com/marin-community/loom.git"
 REPOSITORY_OWNER = "marin-community"
 REPOSITORY_NAME = "loom"
 REPOSITORY_BRANCH = "main"
+REPOSITORY_URL = f"https://github.com/{REPOSITORY_OWNER}/{REPOSITORY_NAME}.git"
 ARTIFACT_REPOSITORY_ID = "loom"
 ARTIFACT_IMAGE_NAME = "loom"
 DOTENV_SECRET_ID = "LOOM_DOTENV"


### PR DESCRIPTION
Resolve Loom's default branch to a full commit SHA before passing its remote
Git context to `pulumi-docker-build`. The provider hashes local contexts but
does not resolve changes behind a stable remote URL, so previews could leave
`loom-release-image` unchanged after Loom advanced.

Preserve explicit local build contexts. A live update deployed Loom
`c10430bd11b83dfb9c0b7dfb862fdfbcd7b8f7b9` as
`sha256:7b1e9957cce4e5099cce01b8f4d485c4a37106e8dbc17d74921df7f2a240865a`;
`/api/ready` reported both migration streams current with no degraded checks,
and the following preview reported 24 unchanged resources.

The focused test file completed five synchronous tests before the first
existing Pulumi async test timed out after 60 seconds.
