### PR TITLE
[iris] Surface singleton Kueue admission diagnostics

### DIFF
--- a/.agents/ops/2026-07-24-iris-singleton-kueue-diagnostic-gap.md
+++ b/.agents/ops/2026-07-24-iris-singleton-kueue-diagnostic-gap.md
@@ -1,0 +1,82 @@
+---
+date: 2026-07-24
+system: iris
+severity: degraded
+resolution: mitigated
+pr: none
+issue: none
+---
+
+# TL;DR
+
+- A singleton 8×H100 inference task stayed in Iris `BUILDING` while its Kubernetes Pod remained `Pending`.
+- Kueue rejected admission because none of 32 H100 nodes fit 48 CPU and 1 TiB memory: 13 nodes lacked CPU and 19 lacked memory.
+- The cluster ran 1,031 CPU-only interactive Pods, one interactive GPU Pod, and 12 batch GPU Pods. The CPU-only token-count shards filled roughly 31 × 64 GiB on each of 19 H100 nodes.
+- Iris stored only `SchedulingGated: Scheduling is blocked due to non-empty scheduling gates`. It could not associate a singleton Pod with its Pod-owned Kueue Workload.
+- The working-tree fix indexes Kueue Workloads by Pod UID, surfaces active task diagnostics on the job page and `iris job summary`, and adds regression coverage. The live controller still needs a deploy.
+- The job was later killed with `Terminated by user`; it never reached `RUNNING`.
+
+# Original problem report
+
+Job `/loom/eval-20260725-002116-grug-agentic-s3-step1903-4ee6/inference-875f534a0cc2410a9e028c15b5b4be05` showed one task in `BUILDING` on `cw-us-east-02a`. The job page showed no placement reason. The task requested 48 CPU, 1 TiB memory, 512 GiB disk, and 8 H100 GPUs.
+
+# Investigation path
+
+1. `iris --cluster=cw-us-east-02a cluster status` at 2026-07-24 17:27 PDT showed a healthy controller and the Kubernetes backend's expected `0/0` Iris workers.
+
+2. `iris job summary` confirmed that the federated job existed on `cw-us-east-02a` and its only task was in `BUILDING`.
+
+3. The controller task row carried the generic backend status `SchedulingGated: Scheduling is blocked due to non-empty scheduling gates`. Its current attempt identified Pod `iris-loom-eval-20260725-002116-grug-3daaa3c6-0-9b4d0a333d36978c`.
+
+4. The Pod was `Pending`, had no node, and was owned by Kueue Workload `pod-iris-loom-eval-20260725-002116-grug-3daaa3c6-0-9b4d0a333d36978c-2a662`.
+
+5. The Workload's `QuotaReserved=False` condition said: `couldn't assign flavors to pod set main: topology "infiniband" doesn't allow to fit any of 1 pod(s). Total nodes: 32; excluded: resource "cpu": 13, resource "memory": 19`.
+
+6. One memory-blocked H100 node ran 31 token-count Pods, each requesting 2 CPU and 64 GiB memory. Cluster-wide active Iris Pods grouped into 1,031 CPU-only interactive Pods, one interactive GPU Pod, and 12 batch GPU Pods.
+
+7. The target Pod used `iris-interactive` priority 10. Kueue ClusterQueue `iris-cq` had `withinClusterQueue: LowerPriority`; equal-priority token-count Pods were not preemption candidates.
+
+8. `lib/iris/src/iris/cluster/backends/k8s/tasks.py:1423` resolved Workloads only through the gang `pod-group-name`. Kueue singleton Pods lack that label and link their generated Workload through the Pod UID instead.
+
+9. `lib/iris/dashboard/src/components/controller/JobDetail.vue:273` and `lib/iris/src/iris/cli/job.py:1350` did not render `TaskStatus.status_message` on job-level surfaces. The task detail page did render it, but only after a user opened the individual task.
+
+10. A final status check at 2026-07-24 17:43 PDT showed the job as `KILLED` with `Terminated by user`. Its only task never left the scheduling gate.
+
+# User course corrections
+
+- The user explicitly authorized direct `kubectl` probes after the controller-level status proved insufficient. This exposed the Kueue Workload condition that Iris omitted.
+- The user requested an Iris code change once the missing scheduling feedback was isolated. The change stayed on reporting and attribution paths; it did not alter Kueue placement or preemption policy.
+
+# Root cause
+
+The immediate placement failure was real resource fragmentation. Kueue v0.18.0 could not find one H100 node with both 48 CPU and 1 TiB free. CPU-only interactive token-count Pods consumed nearly all memory on 19 H100 nodes. GPU work consumed enough CPU on the other 13 nodes to make the requested shape fail TAS admission.
+
+The silent job page was an Iris attribution and presentation bug. Gang Pods carry `kueue.x-k8s.io/pod-group-name`, so Iris could look up their Workload by name. Singleton Pods carry only the queue label; Kueue links the generated Workload through `kueue.x-k8s.io/job-uid` and a Pod owner reference. The resolver at `lib/iris/src/iris/cluster/backends/k8s/tasks.py:1423` ignored those links. The job page and CLI summary then ignored the task-level backend status even when present.
+
+# Fix
+
+`lib/iris/src/iris/cluster/backends/k8s/tasks.py` now builds one Workload index by group name and Pod UID:
+
+```python
+return _KueueWorkloadIndex(by_name=by_name, by_pod_uid=by_pod_uid)
+```
+
+Singleton Pods resolve through `metadata.uid`; gang Pods retain their group-name path. Any Kueue-managed `SchedulingGated` Pod now receives the Workload's `QuotaReserved` verdict and emits an `iris.task_event` row from `k8s/kueue`.
+
+`lib/iris/dashboard/src/components/controller/JobDetail.vue` groups identical active task diagnostics into a job-level warning and shows each task's backend status in the task list. `lib/iris/src/iris/cli/job.py` includes the same field in the `DIAGNOSTIC` column.
+
+The live job remained governed by the existing queue policy. The code change did not preempt or stop workloads.
+
+# How OPS.md could have shortened this
+
+The `Pod stuck in Pending` section in `lib/iris/docs/coreweave.md` now starts with `iris task describe` and a narrow `QuotaReserved` JSONPath query. It maps `SchedulingGated` to Kueue admission and names topology resource exclusions as the signal to inspect.
+
+The same section now warns that `kubectl describe pod` prints literal environment values. Narrow JSONPath queries preserve the scheduling evidence without exposing task credentials.
+
+# Artifacts
+
+- `.agents/ops/2026-07-24-iris-singleton-kueue-diagnostic-gap.md`
+- `lib/iris/src/iris/cluster/backends/k8s/tasks.py`
+- `lib/iris/dashboard/src/components/controller/JobDetail.vue`
+- `lib/iris/src/iris/cli/job.py`
+- Kueue Workload `iris/pod-iris-loom-eval-20260725-002116-grug-3daaa3c6-0-9b4d0a333d36978c-2a662`

--- a/lib/iris/dashboard/src/components/controller/JobDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/JobDetail.vue
@@ -273,6 +273,7 @@ function taskEndpoints(taskId: string): EndpointInfo[] {
 function taskHasStatusDetail(t: TaskStatus): boolean {
   if (taskExitNonZero(t)) return true
   const name = stateToName(t.state)
+  if (t.statusMessage && !TERMINAL_STATES.has(name)) return true
   if (taskStatusTextSummary(t.taskId) && !TERMINAL_STATES.has(name)) return true
   return Boolean(t.error) && FAILED_TERMINAL_STATES.has(name)
 }
@@ -592,6 +593,30 @@ const taskCounts = computed(() => {
     else if (state === 'failed' || state === 'worker_failed' || state === 'cosched_failed' || state === 'preempted') counts.failed++
   }
   return counts
+})
+
+interface ActiveTaskDiagnostic {
+  message: string
+  taskIds: string[]
+}
+
+const MAX_ACTIVE_DIAGNOSTICS = 5
+
+// Group identical backend verdicts so a sharded job explains a shared Kueue or
+// scheduler wait once instead of rendering one banner per task.
+const activeTaskDiagnostics = computed<ActiveTaskDiagnostic[]>(() => {
+  const taskIdsByMessage = new Map<string, string[]>()
+  for (const task of tasks.value) {
+    if (TERMINAL_STATES.has(stateToName(task.state))) continue
+    const message = task.statusMessage?.trim()
+    if (!message) continue
+    const taskIds = taskIdsByMessage.get(message)
+    if (taskIds) taskIds.push(task.taskId)
+    else taskIdsByMessage.set(message, [task.taskId])
+  }
+  return [...taskIdsByMessage.entries()]
+    .map(([message, taskIds]) => ({ message, taskIds }))
+    .sort((a, b) => b.taskIds.length - a.taskIds.length)
 })
 
 // The Scheduling pane auto-opens while tasks are pending — that's when placement
@@ -954,6 +979,38 @@ async function handleProfile(taskId: string, profilerType: string, format: strin
       >
         <span class="font-semibold text-status-warning text-sm">Scheduling Diagnostic:</span>
         <pre class="mt-2 p-3 bg-surface rounded text-xs font-mono whitespace-pre-wrap">{{ job.pendingReason }}</pre>
+      </div>
+
+      <div
+        v-if="activeTaskDiagnostics.length > 0"
+        class="mb-4 px-4 py-3 bg-status-warning-bg border border-status-warning-border rounded-lg"
+      >
+        <span class="font-semibold text-status-warning text-sm">Backend Scheduling Diagnostic:</span>
+        <div class="mt-2 space-y-2">
+          <div
+            v-for="diagnostic in activeTaskDiagnostics.slice(0, MAX_ACTIVE_DIAGNOSTICS)"
+            :key="diagnostic.message"
+          >
+            <div class="text-xs text-text-secondary">
+              <RouterLink
+                :to="`/job/${encodeURIComponent(props.jobId)}/task/${encodeURIComponent(diagnostic.taskIds[0])}`"
+                class="text-accent hover:underline font-mono"
+              >
+                task {{ taskIndex(diagnostic.taskIds[0]) }}
+              </RouterLink>
+              <span v-if="diagnostic.taskIds.length > 1">
+                and {{ diagnostic.taskIds.length - 1 }} more task{{ diagnostic.taskIds.length > 2 ? 's' : '' }}
+              </span>
+            </div>
+            <pre class="mt-1 p-3 bg-surface rounded text-xs font-mono whitespace-pre-wrap break-words">{{ diagnostic.message }}</pre>
+          </div>
+          <div
+            v-if="activeTaskDiagnostics.length > MAX_ACTIVE_DIAGNOSTICS"
+            class="text-xs text-text-muted"
+          >
+            {{ activeTaskDiagnostics.length - MAX_ACTIVE_DIAGNOSTICS }} more distinct diagnostics
+          </div>
+        </div>
       </div>
 
       <!-- Failed tasks callout: genuine task failures (non-zero exit). Shows each
@@ -1406,7 +1463,8 @@ async function handleProfile(taskId: string, profilerType: string, format: strin
             </span>
           </div>
           <div class="mt-1 text-xs break-anywhere">
-            <MarkdownRenderer v-if="taskStatusTextSummary(task.taskId) && !TERMINAL_STATES.has(stateToName(task.state))" :content="taskStatusTextSummary(task.taskId)" class="text-text-secondary" />
+            <span v-if="task.statusMessage && !TERMINAL_STATES.has(stateToName(task.state))" class="font-mono text-status-warning">{{ task.statusMessage }}</span>
+            <MarkdownRenderer v-else-if="taskStatusTextSummary(task.taskId) && !TERMINAL_STATES.has(stateToName(task.state))" :content="taskStatusTextSummary(task.taskId)" class="text-text-secondary" />
             <span v-else-if="task.error && FAILED_TERMINAL_STATES.has(stateToName(task.state))" class="text-status-danger" :title="task.error">{{ task.error.length > 160 ? task.error.slice(0, 160) + '…' : task.error }}</span>
           </div>
           <div v-if="taskEndpoints(task.taskId).length" class="mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
@@ -1575,6 +1633,7 @@ async function handleProfile(taskId: string, profilerType: string, format: strin
                       </span>
                       <span class="min-w-0">
                         <span v-if="taskExitNonZero(task)" class="text-status-danger font-mono">exit {{ task.exitCode }}</span>
+                        <span v-else-if="task.statusMessage && !TERMINAL_STATES.has(stateToName(task.state))" class="font-mono text-status-warning break-anywhere">{{ task.statusMessage }}</span>
                         <MarkdownRenderer v-else-if="taskStatusTextSummary(task.taskId) && !TERMINAL_STATES.has(stateToName(task.state))" :content="taskStatusTextSummary(task.taskId)" class="text-text-secondary" />
                         <span v-else-if="task.error && FAILED_TERMINAL_STATES.has(stateToName(task.state))" class="text-status-danger break-anywhere" :title="task.error">{{ task.error.length > 160 ? task.error.slice(0, 160) + '…' : task.error }}</span>
                       </span>

--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -1223,12 +1223,29 @@ If `Valid` is `False`, the instance type or configuration is rejected.
 ### Pod stuck in Pending
 
 ```bash
-kubectl describe pod <name> -n iris      # Check Events section
-kubectl get events -n iris --sort-by='.lastTimestamp'
+iris --cluster=<cluster> task describe <task-id>
+kubectl get pod <name> -n iris \
+  -o jsonpath='{range .status.conditions[?(@.status=="False")]}{.reason}{": "}{.message}{"\n"}{end}'
+kubectl get workload -n iris
+kubectl get workload <workload-name> -n iris \
+  -o jsonpath='{range .status.conditions[?(@.type=="QuotaReserved")]}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
 ```
 
-Common causes: node not yet provisioned (wait for autoscaler), resource limits
-exceeded, or missing tolerations.
+`SchedulingGated` means Kueue has not admitted the Workload. The
+`QuotaReserved` message reports quota or topology fit failures such as
+`excluded: resource "memory"`. Iris copies that verdict into the task's backend
+status, including for singleton Pods whose generated Workload is linked by Pod
+UID.
+
+Common causes are node capacity fragmented across running Pods, resource limits
+exceeded, missing tolerations, or a node still provisioning. Kueue preempts only
+the priorities allowed by the ClusterQueue policy; equal-priority work remains
+in place.
+
+Avoid `kubectl describe pod` when a task carries credentials in literal
+environment variables. It prints those values. Use the JSONPath commands above
+for scheduling state, and rotate any credential printed into a terminal or
+transcript.
 
 ### Image pull errors
 

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -1335,8 +1335,8 @@ def build_job_summary(
     """Build a structured job/task summary (CLI + test entry point).
 
     Returns a dict with job-level fields and a per-task list including
-    peak memory, final state, exit code, and duration. Pure function over
-    protos — no RPC calls — so it can be unit-tested without a cluster.
+    peak memory, final state, exit code, duration, and backend diagnostic.
+    Pure function over protos, with no RPC calls.
     """
     task_summaries = []
 
@@ -1364,6 +1364,7 @@ def build_job_summary(
                 "cpu_millicores": int(usage.cpu_millicores) if usage.cpu_millicores else 0,
                 "disk_mb": int(usage.disk_mb) if usage.disk_mb else 0,
                 "worker_id": t.worker_id,
+                "status_message": t.status_message,
                 "error": t.error,
             }
         )
@@ -1397,6 +1398,9 @@ def _render_job_summary_text(summary: dict) -> str:
 
     rows = []
     for t in summary["tasks"]:
+        diagnostic = t["status_message"] or t["error"] or ""
+        if len(diagnostic) > 120:
+            diagnostic = diagnostic[:117] + "..."
         rows.append(
             [
                 t["index"],
@@ -1405,10 +1409,10 @@ def _render_job_summary_text(summary: dict) -> str:
                 _format_duration_ms(t["duration_ms"]),
                 _format_memory_mb(t["memory_peak_mb"]),
                 _format_memory_mb(t["memory_mb"]),
-                (t["error"] or "")[:50] + ("..." if len(t["error"] or "") > 50 else ""),
+                diagnostic,
             ]
         )
-    headers = ["TASK", "STATE", "EXIT", "DURATION", "PEAK MEM", "CUR MEM", "ERROR"]
+    headers = ["TASK", "STATE", "EXIT", "DURATION", "PEAK MEM", "CUR MEM", "DIAGNOSTIC"]
     lines.append(tabulate(rows, headers=headers, tablefmt="plain"))
     return "\n".join(lines)
 
@@ -1417,7 +1421,7 @@ def _render_job_summary_text(summary: dict) -> str:
 @click.argument("job_id")
 @click.pass_context
 def summary(ctx, job_id: str) -> None:
-    """Print a per-task summary (peak memory, state, exit, duration) for a job.
+    """Print per-task state, resource, exit, duration, and diagnostic details.
 
     Works for both running and completed jobs. Data is read from the controller's
     existing ``GetJobStatus`` / ``ListTasks`` RPCs (no checkpoint scraping).

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -1332,11 +1332,10 @@ def build_job_summary(
     job_status: job_pb2.JobStatus,
     tasks: list[job_pb2.TaskStatus],
 ) -> dict:
-    """Build a structured job/task summary (CLI + test entry point).
+    """Build a structured job/task summary for CLI rendering.
 
-    Returns a dict with job-level fields and a per-task list including
-    peak memory, final state, exit code, duration, and backend diagnostic.
-    Pure function over protos, with no RPC calls.
+    Returns job-level fields and per-task peak memory, final state, exit code,
+    duration, and backend diagnostic.
     """
     task_summaries = []
 

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -209,6 +209,7 @@ _DISRUPTION_TARGET_CONDITION = "DisruptionTarget"
 _KUEUE_POD_GROUP_NAME = "kueue.x-k8s.io/pod-group-name"
 _KUEUE_POD_GROUP_TOTAL = "kueue.x-k8s.io/pod-group-total-count"
 _KUEUE_QUEUE_NAME = "kueue.x-k8s.io/queue-name"
+_KUEUE_JOB_UID = "kueue.x-k8s.io/job-uid"
 _KUEUE_PRIORITY_CLASS = "kueue.x-k8s.io/priority-class"
 _KUEUE_REQUIRED_TOPOLOGY = "kueue.x-k8s.io/podset-required-topology"
 _KUEUE_PREFERRED_TOPOLOGY = "kueue.x-k8s.io/podset-preferred-topology"
@@ -1278,13 +1279,29 @@ def _is_preemptible_blocker(pod: dict) -> bool:
     return _pod_gpu_request(pod) > 0
 
 
-def _kueue_workloads_by_name(workloads: list[dict]) -> dict[str, dict]:
-    result = {}
+@dataclass(frozen=True)
+class _KueueWorkloadIndex:
+    by_name: dict[str, dict]
+    by_pod_uid: dict[str, dict]
+
+
+def _kueue_workload_index(workloads: list[dict]) -> _KueueWorkloadIndex:
+    by_name = {}
+    by_pod_uid = {}
     for workload in workloads:
-        name = workload.get("metadata", {}).get("name", "")
+        metadata = workload.get("metadata", {})
+        name = metadata.get("name", "")
         if name:
-            result[name] = workload
-    return result
+            by_name[name] = workload
+
+        job_uid = metadata.get("labels", {}).get(_KUEUE_JOB_UID, "")
+        if job_uid:
+            by_pod_uid[job_uid] = workload
+        for owner in metadata.get("ownerReferences", []):
+            owner_uid = owner.get("uid", "")
+            if owner.get("kind") == "Pod" and owner_uid:
+                by_pod_uid[owner_uid] = workload
+    return _KueueWorkloadIndex(by_name=by_name, by_pod_uid=by_pod_uid)
 
 
 def _format_kueue_condition(cond: dict) -> str:
@@ -1304,9 +1321,11 @@ def _format_kueue_condition(cond: dict) -> str:
 
 def _format_kueue_workload_status(pod: dict, workload: dict | None) -> str:
     """Return Kueue admission context for a gated pod."""
-    pod_group = pod.get("metadata", {}).get("labels", {}).get(_KUEUE_POD_GROUP_NAME, "")
+    metadata = pod.get("metadata", {})
+    pod_group = metadata.get("labels", {}).get(_KUEUE_POD_GROUP_NAME, "")
     if workload is None:
-        return f"Kueue workload {pod_group!r} not found yet; waiting for Kueue to create/admit the pod group"
+        target = pod_group or metadata.get("name", "")
+        return f"Kueue workload for {target!r} not found yet; waiting for Kueue to create or admit it"
 
     spec = workload.get("spec", {})
     status = workload.get("status", {})
@@ -1382,7 +1401,7 @@ def _pod_reason_message(pod: dict, workload: dict | None) -> _PodReason:
                     except (ValueError, AttributeError):
                         pass
                 break
-    if reason == _REASON_SCHEDULING_GATED and pod.get("metadata", {}).get("labels", {}).get(_KUEUE_POD_GROUP_NAME):
+    if reason == _REASON_SCHEDULING_GATED and _is_kueue_managed_pod(pod):
         kueue_status = _format_kueue_workload_status(pod, workload)
         message = f"{message}; {kueue_status}" if message else kueue_status
     return _PodReason(reason, message, last_ts)
@@ -1396,10 +1415,19 @@ def _pod_status_message(pod: dict, workload: dict | None) -> str:
     return pr.reason or pr.message
 
 
-def _workload_for_pod(pod: dict, workloads_by_name: dict[str, dict]) -> dict | None:
-    """Resolve the Kueue workload for a pod from its pod-group label, if any."""
-    pod_group = pod.get("metadata", {}).get("labels", {}).get(_KUEUE_POD_GROUP_NAME, "")
-    return workloads_by_name.get(pod_group) if pod_group else None
+def _is_kueue_managed_pod(pod: dict) -> bool:
+    labels = pod.get("metadata", {}).get("labels", {})
+    return bool(labels.get(_KUEUE_POD_GROUP_NAME) or labels.get(_KUEUE_QUEUE_NAME))
+
+
+def _workload_for_pod(pod: dict, workloads: _KueueWorkloadIndex) -> dict | None:
+    """Resolve a gang Workload by group name or a singleton Workload by Pod UID."""
+    metadata = pod.get("metadata", {})
+    pod_group = metadata.get("labels", {}).get(_KUEUE_POD_GROUP_NAME, "")
+    if pod_group:
+        return workloads.by_name.get(pod_group)
+    pod_uid = metadata.get("uid", "")
+    return workloads.by_pod_uid.get(pod_uid) if pod_uid else None
 
 
 # The layer that produced a task-event verdict, recorded as the event ``source``.
@@ -1466,7 +1494,7 @@ def _pod_event(pod: dict, workload: dict | None) -> _PodEvent | None:
     container_reason, _ = _container_state_reason(pod)
     if container_reason and container_reason == pr.reason:
         source = _EVENT_SOURCE_CONTAINER
-    elif pr.reason == _REASON_SCHEDULING_GATED and pod.get("metadata", {}).get("labels", {}).get(_KUEUE_POD_GROUP_NAME):
+    elif pr.reason == _REASON_SCHEDULING_GATED and _is_kueue_managed_pod(pod):
         source = _EVENT_SOURCE_KUEUE
     else:
         source = _EVENT_SOURCE_SCHEDULER
@@ -1482,7 +1510,7 @@ def _build_pod_statuses(
 ) -> list[controller_pb2.Controller.KubernetesPodStatus]:
     """Build pod status protos from raw kubectl pod objects."""
     statuses = []
-    workloads_by_name = _kueue_workloads_by_name(workloads or [])
+    workload_index = _kueue_workload_index(workloads or [])
     for pod in pods:
         meta = pod.get("metadata", {})
         pod_name = meta.get("name", "")
@@ -1490,7 +1518,7 @@ def _build_pod_statuses(
         task_id = labels.get(_LABEL_TASK_ID, "")
         node_name = pod.get("spec", {}).get("nodeName", "")
         phase = pod.get("status", {}).get("phase", "Unknown")
-        pr = _pod_reason_message(pod, _workload_for_pod(pod, workloads_by_name))
+        pr = _pod_reason_message(pod, _workload_for_pod(pod, workload_index))
 
         ps = controller_pb2.Controller.KubernetesPodStatus(
             pod_name=pod_name,
@@ -3034,7 +3062,7 @@ class K8sTaskProvider:
             return []
 
         pods_by_name: dict[str, dict] = {pod.get("metadata", {}).get("name", ""): pod for pod in cached_pods}
-        workloads_by_name = _kueue_workloads_by_name(workloads or [])
+        workload_index = _kueue_workload_index(workloads or [])
         updates: list[TaskUpdate] = []
 
         # Resolve running tasks whose pod has left the active list (completed or
@@ -3091,7 +3119,7 @@ class K8sTaskProvider:
                 continue
 
             self._pod_not_found_counts.pop(cursor_key, None)
-            workload = _workload_for_pod(pod, workloads_by_name)
+            workload = _workload_for_pod(pod, workload_index)
             update = _task_update_from_pod(entry, pod, workload)
             phase = pod.get("status", {}).get("phase", "")
             if phase == "Running":

--- a/lib/iris/tests/cli/test_job.py
+++ b/lib/iris/tests/cli/test_job.py
@@ -389,6 +389,19 @@ def test_render_job_summary_text_shows_peak_memory():
     assert "OOM" in text
 
 
+def test_render_job_summary_text_shows_active_backend_status():
+    job = _job_pb2.JobStatus(job_id="/u/j", state=_job_pb2.JOB_STATE_RUNNING, task_count=1)
+    task = _job_pb2.TaskStatus(
+        task_id="/u/j/0",
+        state=_job_pb2.TASK_STATE_BUILDING,
+        status_message='Kueue: excluded: resource "memory": 32',
+    )
+
+    text = _render_job_summary_text(build_job_summary(job, [task]))
+
+    assert 'Kueue: excluded: resource "memory": 32' in text
+
+
 # Bulk-action target collection (query→act bridge for kick/stop/kill)
 # ---------------------------------------------------------------------------
 

--- a/lib/iris/tests/cluster/backends/k8s/conftest.py
+++ b/lib/iris/tests/cluster/backends/k8s/conftest.py
@@ -122,6 +122,7 @@ KUEUE_UNADMITTED_MSG = (
     "couldn't assign flavors to pod set main: topology \"infiniband\" doesn't allow to "
     'fit any of 1 pod(s). Total nodes: 32; excluded: resource "cpu": 32'
 )
+SINGLETON_POD_UID = "pod-uid"
 
 
 def gated_pod(name: str = "iris-job-0-0", pod_group: str = "wl-abc") -> dict:
@@ -143,7 +144,7 @@ def gated_pod(name: str = "iris-job-0-0", pod_group: str = "wl-abc") -> dict:
     }
 
 
-def singleton_gated_pod(name: str = "iris-job-0-0", uid: str = "pod-uid") -> dict:
+def singleton_gated_pod(name: str = "iris-job-0-0", uid: str = SINGLETON_POD_UID) -> dict:
     """A Kueue-managed singleton Pod, which has no pod-group label."""
     pod = gated_pod(name=name)
     pod["metadata"] = {
@@ -165,7 +166,7 @@ def unadmitted_workload(name: str = "wl-abc", msg: str = KUEUE_UNADMITTED_MSG) -
 
 def singleton_unadmitted_workload(
     pod_name: str = "iris-job-0-0",
-    pod_uid: str = "pod-uid",
+    pod_uid: str = SINGLETON_POD_UID,
     msg: str = KUEUE_UNADMITTED_MSG,
 ) -> dict:
     """The auto-generated Workload owned by one Kueue-managed Pod."""

--- a/lib/iris/tests/cluster/backends/k8s/conftest.py
+++ b/lib/iris/tests/cluster/backends/k8s/conftest.py
@@ -143,6 +143,17 @@ def gated_pod(name: str = "iris-job-0-0", pod_group: str = "wl-abc") -> dict:
     }
 
 
+def singleton_gated_pod(name: str = "iris-job-0-0", uid: str = "pod-uid") -> dict:
+    """A Kueue-managed singleton Pod, which has no pod-group label."""
+    pod = gated_pod(name=name)
+    pod["metadata"] = {
+        "name": name,
+        "uid": uid,
+        "labels": {"kueue.x-k8s.io/queue-name": "cw-use02a-lq"},
+    }
+    return pod
+
+
 def unadmitted_workload(name: str = "wl-abc", msg: str = KUEUE_UNADMITTED_MSG) -> dict:
     """A Workload Kueue has evaluated and declined: QuotaReserved=False with a reason."""
     return {
@@ -150,6 +161,22 @@ def unadmitted_workload(name: str = "wl-abc", msg: str = KUEUE_UNADMITTED_MSG) -
         "spec": {"queueName": "cw-use02a-lq"},
         "status": {"conditions": [{"type": "QuotaReserved", "status": "False", "reason": "Pending", "message": msg}]},
     }
+
+
+def singleton_unadmitted_workload(
+    pod_name: str = "iris-job-0-0",
+    pod_uid: str = "pod-uid",
+    msg: str = KUEUE_UNADMITTED_MSG,
+) -> dict:
+    """The auto-generated Workload owned by one Kueue-managed Pod."""
+    workload = unadmitted_workload(name=f"pod-{pod_name}-abcde", msg=msg)
+    workload["metadata"].update(
+        {
+            "labels": {"kueue.x-k8s.io/job-uid": pod_uid},
+            "ownerReferences": [{"apiVersion": "v1", "kind": "Pod", "name": pod_name, "uid": pod_uid}],
+        }
+    )
+    return workload
 
 
 def unevaluated_workload(name: str = "wl-abc") -> dict:

--- a/lib/iris/tests/cluster/backends/k8s/test_status_message.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_status_message.py
@@ -9,6 +9,7 @@ mirrored, on a federating hub."""
 
 from iris.cluster.backends.k8s.tasks import (
     _TASK_CONTAINER_NAME,
+    _build_pod_statuses,
     _pod_status_message,
     _task_update_from_pod,
 )
@@ -16,7 +17,13 @@ from iris.cluster.controller.task_state import RunningTaskEntry
 from iris.cluster.types import JobName
 from iris.rpc import job_pb2
 
-from .conftest import gated_pod, imagepull_pod, unadmitted_workload
+from .conftest import (
+    gated_pod,
+    imagepull_pod,
+    singleton_gated_pod,
+    singleton_unadmitted_workload,
+    unadmitted_workload,
+)
 
 
 def test_status_message_surfaces_kueue_admission_verdict():
@@ -27,6 +34,15 @@ def test_status_message_surfaces_kueue_admission_verdict():
     assert "couldn't assign flavors" in msg
     assert 'excluded: resource "cpu"' in msg
     assert "cw-use02a-lq" in msg
+
+
+def test_pod_status_singleton_surfaces_kueue_admission_verdict():
+    """A singleton Pod resolves the auto-generated Workload through its Pod UID."""
+    statuses = _build_pod_statuses([singleton_gated_pod()], [singleton_unadmitted_workload()])
+
+    assert len(statuses) == 1
+    assert "couldn't assign flavors" in statuses[0].message
+    assert 'excluded: resource "cpu"' in statuses[0].message
 
 
 def test_status_message_when_workload_not_yet_created():

--- a/lib/iris/tests/cluster/backends/k8s/test_task_event.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_task_event.py
@@ -33,6 +33,8 @@ from .conftest import (
     imagepull_pod,
     make_batch,
     make_kueue_provider,
+    singleton_gated_pod,
+    singleton_unadmitted_workload,
     unadmitted_workload,
     unevaluated_workload,
 )
@@ -167,6 +169,23 @@ def _seed_gated_task(k8s, task_id: JobName, attempt_id: int = 0) -> None:
     k8s.seed_resource(K8sResource.WORKLOADS, pod_group, unadmitted_workload(pod_group))
 
 
+def _seed_singleton_gated_task(k8s, task_id: JobName, attempt_id: int = 0) -> None:
+    """Seed the Pod-owned Workload shape Kueue creates for a non-gang task."""
+    pod = singleton_gated_pod(name=_pod_name(task_id, attempt_id))
+    pod["kind"] = "Pod"
+    pod["metadata"]["labels"].update(
+        {
+            _LABEL_MANAGED: "true",
+            _LABEL_RUNTIME: _RUNTIME_LABEL_VALUE,
+            _LABEL_TASK_HASH: _task_hash(task_id.to_wire()),
+            _LABEL_ATTEMPT_ID: str(attempt_id),
+        }
+    )
+    workload = singleton_unadmitted_workload(pod_name=pod["metadata"]["name"], pod_uid=pod["metadata"]["uid"])
+    k8s.seed_resource(K8sResource.PODS, pod["metadata"]["name"], pod)
+    k8s.seed_resource(K8sResource.WORKLOADS, workload["metadata"]["name"], workload)
+
+
 def test_sync_writes_the_kueue_verdict_to_the_event_log(k8s):
     """The full producer path: a running task whose pod is stuck SchedulingGated
     lands one Warning row carrying the Kueue admission verdict in iris.task_event."""
@@ -193,5 +212,24 @@ def test_sync_writes_the_kueue_verdict_to_the_event_log(k8s):
         provider.sync(make_batch(running_tasks=[entry]))
         rows = [r for w in event_table.writes for r in w]
         assert len(rows) == 1
+    finally:
+        provider.close()
+
+
+def test_sync_singleton_surfaces_kueue_verdict_on_task_and_event(k8s):
+    event_table = FakeStatsTable()
+    provider = make_kueue_provider(k8s, task_event_table=event_table)
+    try:
+        task_id = JobName.from_wire("/job/0")
+        _seed_singleton_gated_task(k8s, task_id)
+
+        updates = provider.sync(make_batch(running_tasks=[RunningTaskEntry(task_id=task_id, attempt_id=0)]))
+
+        assert len(updates) == 1
+        assert "couldn't assign flavors" in (updates[0].status_message or "")
+        rows = [row for write in event_table.writes for row in write]
+        assert len(rows) == 1
+        assert rows[0].source == _EVENT_SOURCE_KUEUE
+        assert rows[0].type == "Warning"
     finally:
         provider.close()

--- a/lib/iris/tests/cluster/backends/k8s/test_task_event.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_task_event.py
@@ -152,10 +152,7 @@ def test_event_log_retain_forgets_gone_attempts():
 # --- end-to-end through sync() -------------------------------------------------
 
 
-def _seed_gated_task(k8s, task_id: JobName, attempt_id: int = 0) -> None:
-    """Seed a SchedulingGated, Kueue-unadmitted pod + its Workload, discoverable by sync()."""
-    pod_group = _pod_group_name(task_id, attempt_id)
-    pod = gated_pod(name=_pod_name(task_id, attempt_id), pod_group=pod_group)
+def _seed_gated_resources(k8s, task_id: JobName, attempt_id: int, pod: dict, workload: dict) -> None:
     pod["kind"] = "Pod"
     pod["metadata"]["labels"].update(
         {
@@ -166,24 +163,21 @@ def _seed_gated_task(k8s, task_id: JobName, attempt_id: int = 0) -> None:
         }
     )
     k8s.seed_resource(K8sResource.PODS, pod["metadata"]["name"], pod)
-    k8s.seed_resource(K8sResource.WORKLOADS, pod_group, unadmitted_workload(pod_group))
+    k8s.seed_resource(K8sResource.WORKLOADS, workload["metadata"]["name"], workload)
+
+
+def _seed_gated_task(k8s, task_id: JobName, attempt_id: int = 0) -> None:
+    """Seed a SchedulingGated, Kueue-unadmitted pod + its Workload, discoverable by sync()."""
+    pod_group = _pod_group_name(task_id, attempt_id)
+    pod = gated_pod(name=_pod_name(task_id, attempt_id), pod_group=pod_group)
+    _seed_gated_resources(k8s, task_id, attempt_id, pod, unadmitted_workload(pod_group))
 
 
 def _seed_singleton_gated_task(k8s, task_id: JobName, attempt_id: int = 0) -> None:
     """Seed the Pod-owned Workload shape Kueue creates for a non-gang task."""
     pod = singleton_gated_pod(name=_pod_name(task_id, attempt_id))
-    pod["kind"] = "Pod"
-    pod["metadata"]["labels"].update(
-        {
-            _LABEL_MANAGED: "true",
-            _LABEL_RUNTIME: _RUNTIME_LABEL_VALUE,
-            _LABEL_TASK_HASH: _task_hash(task_id.to_wire()),
-            _LABEL_ATTEMPT_ID: str(attempt_id),
-        }
-    )
     workload = singleton_unadmitted_workload(pod_name=pod["metadata"]["name"], pod_uid=pod["metadata"]["uid"])
-    k8s.seed_resource(K8sResource.PODS, pod["metadata"]["name"], pod)
-    k8s.seed_resource(K8sResource.WORKLOADS, workload["metadata"]["name"], workload)
+    _seed_gated_resources(k8s, task_id, attempt_id, pod, workload)
 
 
 def test_sync_writes_the_kueue_verdict_to_the_event_log(k8s):


### PR DESCRIPTION
Resolve Pod-owned Kueue Workloads by Pod UID so singleton Kubernetes tasks retain Kueue's exact QuotaReserved admission verdict instead of only the generic SchedulingGated condition. The motivating cw-us-east-02a task was blocked because none of 32 H100 nodes fit its 48 CPU and 1 TiB request; Kueue reported 13 nodes excluded by CPU and 19 by memory, but Iris dropped that detail.

Surface active backend diagnostics on the job page and in `iris job summary`, including grouped messages for sharded jobs. Document the narrow Pod and Workload queries that expose admission state without printing literal task environment values.

This changes diagnostics only. Kueue admission, priority, and preemption behavior are unchanged.
