### PR TITLE
[loom] Reconcile deployment-managed profiles

### DIFF
--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -12,14 +12,14 @@ config:
   marin-loom:bootDiskGb: "100"
   marin-loom:dataDiskGb: "500"
   marin-loom:dotenvSecretVersion: "3"
-  marin-loom:pruneDeployment: "false"
+  marin-loom:pruneDeployment: "true"
   marin-loom:snapshotRetentionDays: "14"
   marin-loom:profiles:
     ops:
-      agent: claude
+      agent: codex
       description: Coordinate Grafana alerts and delegate incident triage for Marin
-      model: sonnet
-      effort: high
+      model: gpt-5.6-sol
+      effort: xhigh
       protocol: acp
       mode: auto
       class: automation
@@ -32,6 +32,9 @@ config:
       prelude: weaver
       restricted: false
       allowedTools: []
+      mcpAccess:
+        mode: all
+        groups: []
   marin-loom:workloads:
     - name: grafana-alerts
       profile: ops

--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -80,10 +80,18 @@ so uploading another secret version does not change the running service.
 
 Runtime profiles and workload federation mappings live in
 `Pulumi.marin-loom.yaml` and are applied through Loom's deployment API during
-activation. The `ops` profile is restricted to the Google identity of
-the existing `marin-grafana` Cloud Run service account. Pulumi resolves that
-account's email and immutable numeric subject; it does not create or copy a Loom
-token.
+activation. The `grafana-alerts` federation mapping authorizes the Google
+identity of the existing `marin-grafana` Cloud Run service account to select
+only the `ops` profile. Pulumi resolves that account's email and immutable
+numeric subject; it does not create or copy a Loom token.
+
+The Pulumi declaration is authoritative at activation time. An unchanged
+profile keeps its database revision; a changed declaration overwrites the
+current row and advances the revision. UI or API edits persist only until the
+next activation. Deployment pruning is enabled, so a profile or federation
+removed from `Pulumi.marin-loom.yaml` is removed from new selection on the next
+activation. Weaver's stock `default`, `github_comment`, and `watch` profiles are
+not deployment-managed and are not pruned.
 
 At runtime, the Grafana bridge gets a Google-signed ID token from the Cloud Run
 metadata server, exchanges it at `/api/auth/federate`, and uses the resulting

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -40,6 +40,10 @@ GIT_COMMIT = re.compile(r"^[0-9a-f]{40}$")
 STARTUP_SCRIPT = (ROOT / "startup-script.sh").read_text()
 RUNTIME_COMPOSE = (ROOT / "runtime/docker-compose.yml").read_text()
 RUNTIME_CADDYFILE = (ROOT / "runtime/Caddyfile").read_text()
+MCP_ACCESS_NONE = "none"
+MCP_ACCESS_ALL = "all"
+MCP_ACCESS_GROUPS = "groups"
+MCP_ACCESS_MODES = frozenset({MCP_ACCESS_NONE, MCP_ACCESS_ALL, MCP_ACCESS_GROUPS})
 
 
 def _positive_config_int(value: int, name: str) -> int:
@@ -144,13 +148,13 @@ class McpAccessConfig:
     def parse(cls, value: object, profile: str) -> McpAccessConfig:
         if not isinstance(value, dict):
             raise ValueError(f"profile {profile!r} mcpAccess must be an object")
-        mode = str(value.get("mode", "none")).strip()
+        mode = str(value.get("mode", MCP_ACCESS_NONE)).strip()
         groups = _string_tuple(value.get("groups", []), "mcpAccess.groups", profile)
-        if mode not in {"none", "all", "groups"}:
+        if mode not in MCP_ACCESS_MODES:
             raise ValueError(f"profile {profile!r} mcpAccess.mode must be none, all, or groups")
-        if mode != "groups" and groups:
+        if mode != MCP_ACCESS_GROUPS and groups:
             raise ValueError(f"profile {profile!r} mcpAccess.groups requires mode groups")
-        if mode == "groups" and not groups:
+        if mode == MCP_ACCESS_GROUPS and not groups:
             raise ValueError(f"profile {profile!r} mcpAccess mode groups requires at least one group")
         return cls(mode, groups)
 

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -136,6 +136,29 @@ def _optional_int(value: object, field: str, profile: str) -> int | None:
 
 
 @dataclass(frozen=True)
+class McpAccessConfig:
+    mode: str
+    groups: tuple[str, ...]
+
+    @classmethod
+    def parse(cls, value: object, profile: str) -> McpAccessConfig:
+        if not isinstance(value, dict):
+            raise ValueError(f"profile {profile!r} mcpAccess must be an object")
+        mode = str(value.get("mode", "none")).strip()
+        groups = _string_tuple(value.get("groups", []), "mcpAccess.groups", profile)
+        if mode not in {"none", "all", "groups"}:
+            raise ValueError(f"profile {profile!r} mcpAccess.mode must be none, all, or groups")
+        if mode != "groups" and groups:
+            raise ValueError(f"profile {profile!r} mcpAccess.groups requires mode groups")
+        if mode == "groups" and not groups:
+            raise ValueError(f"profile {profile!r} mcpAccess mode groups requires at least one group")
+        return cls(mode, groups)
+
+    def manifest(self) -> dict[str, object]:
+        return {"mode": self.mode, "groups": list(self.groups)}
+
+
+@dataclass(frozen=True)
 class ProfileConfig:
     name: str
     agent: str
@@ -154,6 +177,7 @@ class ProfileConfig:
     prelude: str
     restricted: bool
     allowed_tools: tuple[str, ...]
+    mcp_access: McpAccessConfig
     env: tuple[ProfileSecretConfig, ...]
 
     @classmethod
@@ -185,6 +209,7 @@ class ProfileConfig:
             prelude=str(value.get("prelude", "weaver")),
             restricted=bool(value.get("restricted", False)),
             allowed_tools=_string_tuple(value.get("allowedTools", []), "allowedTools", name),
+            mcp_access=McpAccessConfig.parse(value.get("mcpAccess", {}), name),
             env=env,
         )
 
@@ -207,6 +232,7 @@ class ProfileConfig:
             "prelude": self.prelude,
             "restricted": self.restricted,
             "allowed_tools": list(self.allowed_tools),
+            "mcp_access": self.mcp_access.manifest(),
         }
 
 

--- a/infra/loom/tests/test_infrastructure.py
+++ b/infra/loom/tests/test_infrastructure.py
@@ -145,15 +145,30 @@ def test_profile_manifest_accepts_secret_references_but_rejects_values() -> None
                 "ops",
                 {
                     "agent": "codex",
+                    "mcpAccess": {"mode": "all", "groups": []},
                     "env": {"OPS_TOKEN": {"secretRef": "projects/example/secrets/ops-token/versions/7"}},
                 },
             ),
         )
     )
+    assert profiles[0]["profile"]["mcp_access"] == {"mode": "all", "groups": []}
     assert profiles[0]["env"] == [{"name": "OPS_TOKEN", "secret_ref": "projects/example/secrets/ops-token/versions/7"}]
     assert references == [("example", "ops-token")]
     with pytest.raises(ValueError, match="full secretRef"):
         ProfileConfig.parse("ops", {"agent": "codex", "env": {"OPS_TOKEN": "plaintext"}})
+
+
+@pytest.mark.parametrize(
+    "mcp_access",
+    [
+        {"mode": "groups", "groups": []},
+        {"mode": "all", "groups": ["messaging"]},
+        {"mode": "unknown", "groups": []},
+    ],
+)
+def test_profile_mcp_access_rejects_invalid_selections(mcp_access: dict[str, object]) -> None:
+    with pytest.raises(ValueError, match="mcpAccess"):
+        ProfileConfig.parse("ops", {"agent": "codex", "mcpAccess": mcp_access})
 
 
 @pulumi.runtime.test


### PR DESCRIPTION
Declare the production `ops` profile as Codex `gpt-5.6-sol` at xhigh effort with access to all built-in MCP groups. The live database already carries this revision, but Marin Pulumi could not serialize `mcp_access`; the next unrelated activation would otherwise overwrite it with the older Claude/no-MCP declaration.

Enable deployment pruning so the renamed `grafana_alert` profile leaves new selection while its two archived sessions retain their stamped history and remain recoverable. This requires [loom#212](https://github.com/marin-community/loom/pull/212), which adds terminal-history profile retirement; merge and deploy that change before applying this stack.

Document activation-time precedence between Pulumi declarations, database revisions, and Weaver stock profiles. The [profile lifecycle analysis](https://loom.rjp.io/s/yt2e505z/artifacts/profile-lifecycle) records the current production state and rollout recommendation.
