### PR TITLE
datakit: filter cross-source decontam boilerplate

### DIFF
--- a/experiments/datakit/README.md
+++ b/experiments/datakit/README.md
@@ -15,11 +15,11 @@ its pipeline on its own dedicated Zephyr coordinator + worker fleet (vanilla
 the StepRunner walks at once.
 
 Every stage keeps one step per source with its own output dir
-(`datakit/<stage>/<source>_<hash>/`); only dedup and the store combine sources,
-by design. Steps write their main output under `outputs/main/` plus, where it
-makes sense, a small site/sample side output (`outputs/samples/`,
-`outputs/flagged_sample/`, …) that the per-stage HTML reports
-([`reports/`](reports/)) read.
+(`datakit/<stage>/<source>_<hash>/`). Dedup, the decontamination DF filter, and
+the store combine sources. Steps write their main output under `outputs/main/`
+plus, where it makes sense, a small site/sample side output
+(`outputs/samples/`, `outputs/flagged_sample/`, …) that the per-stage HTML
+reports ([`reports/`](reports/)) read.
 
 Each `datakit/report/<stage>` step depends only on that stage's steps, so it
 runs as soon as the stage finishes — reports are not deferred to the end of the
@@ -50,6 +50,7 @@ flowchart TD
     end
 
     BLOOM["eval bloom (shared)<br/>datakit/bloom/_combined_fixed"]
+    DF["eval n-gram DF (cross-source)<br/>datakit/decon_drop/_combined"]
     DEDUP["fuzzy dedup (cross-source)<br/>datakit/dedup"]
     STORE["store: 5-way join, drop contaminated + non-canonical,<br/>route by (cluster_&lt;view&gt;, quality_bucket)<br/>datakit/store → cluster=C/quality=Q Levanter caches"]
 
@@ -59,7 +60,9 @@ flowchart TD
     SRC --> DECON
     SRC --> MH
     MODEL --> QUAL
-    EVALS --> BLOOM --> DECON
+    EVALS --> BLOOM --> DF --> DECON
+    SRC --> DF
+    BLOOM --> DECON
     EMB --> SAMP --> KM --> ASG
     EMB --> ASG
     MH --> DEDUP
@@ -87,6 +90,13 @@ flowchart TD
     DEDUP -.-> RU
     STORE -.-> RS
 ```
+
+`datakit/decon_drop/_combined` scans up to 5,000 documents per source for
+source-local boilerplate and up to 1,000,000 for the cross-source estimate.
+The global set contains eval n-grams found in at least 50 sampled documents
+across at least three sources. Every decontamination mark loads its local set
+and the shared global set. The thresholds live in
+[`decontam/config.py`](decontam/config.py).
 
 ## Testbed samples
 

--- a/experiments/datakit/decontam/config.py
+++ b/experiments/datakit/decontam/config.py
@@ -1,0 +1,16 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared decontamination policy for the reference pipeline and testbed."""
+
+# Source-local DF needs only enough documents to find high-density boilerplate
+# such as legal enacting clauses and license headers.
+SOURCE_DF_SAMPLE_DOCS = 5_000
+SOURCE_DF_COMMON_FRAC = 0.005
+SOURCE_DF_COMMON_MIN_ABS = 5
+
+# Cross-source boilerplate is sparse within each source. Scan a larger prefix,
+# then require both corpus document frequency and recurrence across sources.
+GLOBAL_DF_SAMPLE_DOCS = 1_000_000
+GLOBAL_DF_COMMON_MIN_ABS = 50
+GLOBAL_DF_COMMON_MIN_SOURCES = 3

--- a/experiments/datakit/reference_pipeline.py
+++ b/experiments/datakit/reference_pipeline.py
@@ -87,6 +87,7 @@ from fray.types import ResourceConfig
 from levanter.tokenizers import TokenizerBackend
 from marin.datakit.decon import (
     DeconAttributes,
+    all_source_drop_sets_step,
     build_eval_bloom_step,
     decon_step,
 )
@@ -119,6 +120,14 @@ from experiments.datakit.cluster.domain.v0.sample import sample_centroid_inputs
 from experiments.datakit.cluster.domain.v0.train import train_centroids
 from experiments.datakit.cluster.quality.fast_transformer.artifact import QualityScores
 from experiments.datakit.cluster.quality.fast_transformer.score import score_normalized
+from experiments.datakit.decontam.config import (
+    GLOBAL_DF_COMMON_MIN_ABS,
+    GLOBAL_DF_COMMON_MIN_SOURCES,
+    GLOBAL_DF_SAMPLE_DOCS,
+    SOURCE_DF_COMMON_FRAC,
+    SOURCE_DF_COMMON_MIN_ABS,
+    SOURCE_DF_SAMPLE_DOCS,
+)
 from experiments.datakit.decontam.prepare_eval_corpus import DECON_EXCLUDED_EVAL_TASKS
 from experiments.datakit.embeddings.luxical.pipeline import (
     LUXICAL_REPO,
@@ -530,6 +539,26 @@ def reference_datakit_steps(
         false_positive_rate=FALSE_POSITIVE_RATE,
         exclude_eval_dirs=DECON_EXCLUDED_EVAL_TASKS,
     )
+    # Count eval-ngram document frequency across normalized sources before
+    # marking. Each decon consumes its source-local set and the global set.
+    decon_drop_sets = all_source_drop_sets_step(
+        name="datakit/decon_drop/_combined",
+        sources=[
+            (source_name, f"{normalize_step.output_path.rstrip('/')}/outputs/main")
+            for source_name, normalize_step in sources.items()
+        ],
+        source_dependencies=sources,
+        prebuilt_bloom=decon_bloom_step,
+        ngram_length=NGRAM_LENGTH,
+        sample_docs=SOURCE_DF_SAMPLE_DOCS,
+        common_frac=SOURCE_DF_COMMON_FRAC,
+        common_min_abs=SOURCE_DF_COMMON_MIN_ABS,
+        global_sample_docs=GLOBAL_DF_SAMPLE_DOCS,
+        global_common_min_abs=GLOBAL_DF_COMMON_MIN_ABS,
+        global_common_min_sources=GLOBAL_DF_COMMON_MIN_SOURCES,
+        worker_resources=scale.pool.worker,
+        max_workers=scale.pool.n_workers,
+    )
 
     # ---- Per-source steps ------------------------------------------------------
     per_source: dict[str, dict[str, StepSpec]] = {}
@@ -597,6 +626,8 @@ def reference_datakit_steps(
             name=f"datakit/decontam/{name}",
             normalized=normalize_step,
             prebuilt_bloom=decon_bloom_step,
+            drop_sets=decon_drop_sets,
+            drop_set_source=name,
             ngram_length=NGRAM_LENGTH,
             overlap_threshold=OVERLAP_THRESHOLD,
             estimated_doc_count=ESTIMATED_DOC_COUNT,
@@ -754,7 +785,7 @@ def reference_datakit_steps(
         ),
     ]
 
-    all_steps: list[StepSpec] = [decon_bloom_step]
+    all_steps: list[StepSpec] = [decon_bloom_step, decon_drop_sets]
     if isinstance(domain_centroids, StepSpec):
         all_steps.append(domain_centroids)
     for s in per_source.values():

--- a/experiments/datakit/reference_pipeline.py
+++ b/experiments/datakit/reference_pipeline.py
@@ -87,6 +87,7 @@ from fray.types import ResourceConfig
 from levanter.tokenizers import TokenizerBackend
 from marin.datakit.decon import (
     DeconAttributes,
+    DropSetSource,
     all_source_drop_sets_step,
     build_eval_bloom_step,
     decon_step,
@@ -544,10 +545,13 @@ def reference_datakit_steps(
     decon_drop_sets = all_source_drop_sets_step(
         name="datakit/decon_drop/_combined",
         sources=[
-            (source_name, f"{normalize_step.output_path.rstrip('/')}/outputs/main")
+            DropSetSource(
+                name=source_name,
+                data_path=f"{normalize_step.output_path.rstrip('/')}/outputs/main",
+                dependency=normalize_step,
+            )
             for source_name, normalize_step in sources.items()
         ],
-        source_dependencies=sources,
         prebuilt_bloom=decon_bloom_step,
         ngram_length=NGRAM_LENGTH,
         sample_docs=SOURCE_DF_SAMPLE_DOCS,

--- a/experiments/datakit/testbed/decon_arm.py
+++ b/experiments/datakit/testbed/decon_arm.py
@@ -35,6 +35,14 @@ from marin.execution.step_spec import StepSpec
 from rigging.filesystem import marin_prefix
 from rigging.log_setup import configure_logging
 
+from experiments.datakit.decontam.config import (
+    GLOBAL_DF_COMMON_MIN_ABS,
+    GLOBAL_DF_COMMON_MIN_SOURCES,
+    GLOBAL_DF_SAMPLE_DOCS,
+    SOURCE_DF_COMMON_FRAC,
+    SOURCE_DF_COMMON_MIN_ABS,
+    SOURCE_DF_SAMPLE_DOCS,
+)
 from experiments.datakit.decontam.prepare_eval_corpus import DECON_EXCLUDED_EVAL_TASKS
 from experiments.datakit.testbed.sampler import build_testbed_steps
 from experiments.datakit.testbed.settings import RAW_TARGET_TOTAL_TOKENS_B
@@ -53,14 +61,8 @@ OVERLAP_THRESHOLD = 0.5
 # isolated-line coincidences (fewer FPs) and lets short-line / inline-embedded
 # eval text be matched (higher recall). See marin#6852.
 PARAGRAPH_DELIMITER = "\n\n"
-# Per-source common-ngram filter (marin#6852): drop eval ngrams ubiquitous within
-# a source (legal enacting clauses, license headers) from that source's overlap.
-DF_SAMPLE_DOCS = 5000  # docs/source sampled to estimate per-source ngram DF
-DF_COMMON_FRAC = 0.005  # ngram is "common" if present in >= this fraction of them
-DF_COMMON_MIN_ABS = 5  # and in >= this many (small-source floor)
-# DF is a source property, so estimate it from the *largest* materialized sample
-# (the pre-built 1T per-source root) regardless of the decon target — a 100M mark
-# reuses a drop-set estimated over thousands of docs. Layout: <root>/<source>/outputs/main.
+# Estimate local and cross-source DF from the largest materialized sample
+# regardless of the decon target. Layout: <root>/<source>/outputs/main.
 SAMPLE_1T_ROOT = "datakit/sample_1t_733c8c5c"
 # Reservoir-sample this many flagged docs/source into a `_flagged` sidecar at mark
 # time so the viewer scales — it reads the sidecar instead of rescanning the corpus.
@@ -120,17 +122,21 @@ def build_testbed_decon_steps(
         exclude_eval_dirs=DECON_EXCLUDED_EVAL_TASKS,
     )
 
-    # One distributed drop-set step for all deconned sources (zephyr shard/source),
-    # sourcing DF from the large 1T per-source sample; each decon reads its subdir.
+    # One distributed DF pass over the 1T sample produces source-local and
+    # cross-source drop sets for every decon mark.
     drop_sets = all_source_drop_sets_step(
         name="datakit/decon_drop/_combined",
         sources=[(name, f"{marin_prefix()}/{SAMPLE_1T_ROOT}/{name}/outputs/main") for name in sampled],
+        source_dependencies={},
         prebuilt_bloom=bloom,
         ngram_length=NGRAM_LENGTH,
         paragraph_delimiter=PARAGRAPH_DELIMITER,
-        sample_docs=DF_SAMPLE_DOCS,
-        common_frac=DF_COMMON_FRAC,
-        common_min_abs=DF_COMMON_MIN_ABS,
+        sample_docs=SOURCE_DF_SAMPLE_DOCS,
+        common_frac=SOURCE_DF_COMMON_FRAC,
+        common_min_abs=SOURCE_DF_COMMON_MIN_ABS,
+        global_sample_docs=GLOBAL_DF_SAMPLE_DOCS,
+        global_common_min_abs=GLOBAL_DF_COMMON_MIN_ABS,
+        global_common_min_sources=GLOBAL_DF_COMMON_MIN_SOURCES,
         worker_resources=WORKER_RESOURCES,
     )
 

--- a/experiments/datakit/testbed/decon_arm.py
+++ b/experiments/datakit/testbed/decon_arm.py
@@ -28,7 +28,7 @@ import logging
 import os
 
 from fray.types import ResourceConfig
-from marin.datakit.decon import all_source_drop_sets_step, build_eval_bloom_step, decon_step
+from marin.datakit.decon import DropSetSource, all_source_drop_sets_step, build_eval_bloom_step, decon_step
 from marin.datakit.sources import all_sources
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
@@ -126,8 +126,10 @@ def build_testbed_decon_steps(
     # cross-source drop sets for every decon mark.
     drop_sets = all_source_drop_sets_step(
         name="datakit/decon_drop/_combined",
-        sources=[(name, f"{marin_prefix()}/{SAMPLE_1T_ROOT}/{name}/outputs/main") for name in sampled],
-        source_dependencies={},
+        sources=[
+            DropSetSource(name=name, data_path=f"{marin_prefix()}/{SAMPLE_1T_ROOT}/{name}/outputs/main")
+            for name in sampled
+        ],
         prebuilt_bloom=bloom,
         ngram_length=NGRAM_LENGTH,
         paragraph_delimiter=PARAGRAPH_DELIMITER,

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -225,12 +225,10 @@ def _paragraph_overlap_and_matches(
     ngrams otherwise. *matched_hashes* is the list of ngram hashes that hit
     the bloom (in iteration order, with duplicates if the same ngram repeats).
 
-    *drop_hashes* are removed from *both* the numerator and denominator — the
-    per-source common-ngram filter (marin#6852). Boilerplate ubiquitous in a
-    source (a legal enacting clause, a license header) carries no contamination
-    signal, so an all-boilerplate paragraph collapses to zero ngrams and scores
-    0, while a paragraph with a distinctive leak keeps its remaining ngrams and
-    still scores ~1.0 — precision without a recall cost.
+    *drop_hashes* are removed from *both* the numerator and denominator.
+    Corpus-common boilerplate carries no contamination signal, so an
+    all-boilerplate paragraph collapses to zero ngrams and scores 0. A paragraph
+    with a distinctive leak keeps its remaining ngrams and still scores ~1.0.
 
     Paragraphs with fewer than ``ngram_length`` tokens in n-gram mode return
     ``(0.0, [])`` — see :func:`_extract_features` for why we don't fall back
@@ -496,7 +494,7 @@ def decon_to_parquet(
     output_path: str,
     text_field: str = "text",
     ngram: NGramConfig | None = None,
-    drop_set_dir: str | None = None,
+    drop_set_dirs: list[str] | None = None,
     flagged_sample_size: int = 0,
     estimated_doc_count: int = 1_000_000,
     false_positive_rate: float = 1e-9,
@@ -541,9 +539,10 @@ def decon_to_parquet(
         ngram: Word-ngram matching config. ``None`` = exact whole-paragraph match.
             ``ngram.overlap_threshold`` gates which paragraphs are marked
             contaminated; exact-paragraph mode records any non-zero match.
-        drop_set_dir: Optional directory of per-source common-ngram hashes
-            (:func:`build_source_drop_set`). Those ngrams are excluded from every
-            paragraph overlap — the per-source boilerplate filter (marin#6852).
+        drop_set_dirs: Optional directories of corpus-common ngram hashes.
+            Ngrams from every directory are excluded from each paragraph
+            overlap. :func:`decon_step` passes the source-local and global
+            outputs from :func:`all_source_drop_sets_step`.
         estimated_doc_count, false_positive_rate: Bloom sizing parameters; size
             for expected total *ngram* count across the eval suite (not record
             count). Defaults handle ~1M unique ngrams cleanly. Ignored when
@@ -583,9 +582,9 @@ def decon_to_parquet(
             false_positive_rate=false_positive_rate,
         )
 
-    drop_hashes = _load_drop_set(drop_set_dir) if drop_set_dir else frozenset()
+    drop_hashes = _load_drop_sets(drop_set_dirs) if drop_set_dirs else frozenset()
     if drop_hashes:
-        logger.info("decon: filtering %d source-common ngrams from %s", len(drop_hashes), drop_set_dir)
+        logger.info("decon: filtering %d corpus-common ngrams from %s", len(drop_hashes), drop_set_dirs)
     pipeline = Dataset.from_list(files).map_shard(
         _make_marker(bloom_path, output_path, text_field, ngram, drop_hashes, flagged_sample_size)
     )
@@ -851,9 +850,8 @@ def merge_eval_blooms_step(
 
 
 # ---------------------------------------------------------------------------
-# Per-source common-ngram filter (marin#6852): drop eval ngrams that are
-# ubiquitous within a source (legal enacting clauses, license headers) so they
-# stop producing boilerplate false positives, without a recall cost.
+# Corpus-common ngram filters (marin#6852, marin#7126): remove eval ngrams
+# ubiquitous within one source or repeated across several sources.
 # ---------------------------------------------------------------------------
 
 
@@ -887,6 +885,25 @@ def _load_drop_set(drop_set_dir: str) -> frozenset[int]:
     return frozenset(out)
 
 
+def _load_drop_sets(drop_set_dirs: list[str]) -> frozenset[int]:
+    return frozenset().union(*(_load_drop_set(drop_set_dir) for drop_set_dir in drop_set_dirs))
+
+
+def _document_frequency_counts(
+    df_sample_dir: str,
+    bf: dupekit.Bloom,
+    text_field: str,
+    ngram: NGramConfig | None,
+    sample_docs: int,
+) -> tuple[Counter[int], int]:
+    counts: Counter[int] = Counter()
+    n = 0
+    for text in islice(_iter_normalized_texts(df_sample_dir, text_field), sample_docs):
+        n += 1
+        counts.update({h for feat in _extract_features(text, ngram) if (h := _bloom_hash(feat)) in bf})
+    return counts, n
+
+
 def _drop_set_for_source(
     df_sample_dir: str,
     bf: dupekit.Bloom,
@@ -902,11 +919,7 @@ def _drop_set_for_source(
     so a prefix is representative), counts how many contain each eval ngram
     (membership via the bloom — the only ngrams a drop-set can hold), and keeps
     those in at least ``max(common_min_abs, common_frac * n_sampled)`` docs."""
-    counts: Counter[int] = Counter()
-    n = 0
-    for text in islice(_iter_normalized_texts(df_sample_dir, text_field), sample_docs):
-        n += 1
-        counts.update({h for feat in _extract_features(text, ngram) if (h := _bloom_hash(feat)) in bf})
+    counts, n = _document_frequency_counts(df_sample_dir, bf, text_field, ngram, sample_docs)
     threshold = max(common_min_abs, int(common_frac * n))
     return [h for h, c in counts.items() if c >= threshold], n, threshold
 
@@ -948,15 +961,52 @@ def build_source_drop_set(
 
 
 class AllSourceDropSets(BaseModel):
-    """Outcome of :func:`build_all_source_drop_sets`: per-source drop-sets under one root.
+    """Outcome of :func:`build_all_source_drop_sets`.
 
-    Each source's hashes live at ``<output_dir>/<source>/drop.parquet``; a
-    :func:`decon_step` reads its own source's subdir.
+    Per-source hashes live at ``<output_dir>/<source>/drop.parquet``. Globally
+    common hashes live at ``<global_output_dir>/drop.parquet``.
     """
 
     output_dir: str
+    global_output_dir: str
     num_sources: int
+    n_global_dropped: int
     counters: dict[str, int | float]
+
+
+def _global_drop_row(
+    hash_value: int,
+    items: Iterator[dict[str, int]],
+    *,
+    common_min_abs: int,
+    common_min_sources: int,
+) -> dict[str, int] | None:
+    document_frequency = 0
+    source_frequency = 0
+    for item in items:
+        document_frequency += item["document_frequency"]
+        source_frequency += item["source_frequency"]
+    if document_frequency < common_min_abs or source_frequency < common_min_sources:
+        return None
+    return {
+        "hash": hash_value,
+        "document_frequency": document_frequency,
+        "source_frequency": source_frequency,
+    }
+
+
+def _write_global_drop_set(output_dir: str, rows: list[dict[str, int]]) -> str:
+    StoragePath(output_dir).mkdirs()
+    out_file = f"{output_dir.rstrip('/')}/drop.parquet"
+    schema = pa.schema(
+        [
+            pa.field("hash", pa.uint64()),
+            pa.field("document_frequency", pa.int64()),
+            pa.field("source_frequency", pa.int64()),
+        ]
+    )
+    write_parquet_file(iter(rows), output_path=out_file, schema=schema)
+    return out_file
 
 
 def build_all_source_drop_sets(
@@ -969,71 +1019,156 @@ def build_all_source_drop_sets(
     sample_docs: int,
     common_frac: float,
     common_min_abs: int,
+    global_sample_docs: int,
+    global_common_min_abs: int,
+    global_common_min_sources: int,
     worker_resources: ResourceConfig | None = None,
     max_workers: int | None = None,
 ) -> AllSourceDropSets:
-    """Distributed per-source drop-set build — one zephyr shard per source.
+    """Build per-source and cross-source common eval-ngram drop sets.
 
-    *sources* is a list of ``(source_name, df_sample_dir)``. Each shard writes
-    ``<output_path>/<source_name>/drop.parquet``; consume with
-    ``decon_step(drop_sets=..., drop_set_source=<source_name>)``.
+    One Zephyr map shard per source writes the source-local drop set and emits
+    document frequencies for matching eval ngrams. A distributed reduce sums
+    those counts across sources. A globally common ngram must meet both the
+    corpus document-frequency threshold and the distinct-source threshold, so
+    a repeated eval item concentrated in one source remains matchable.
     """
+    if not sources:
+        raise ValueError("sources must be non-empty")
+    if len({source_name for source_name, _ in sources}) != len(sources):
+        raise ValueError("source names must be unique")
+    if global_sample_docs < sample_docs:
+        raise ValueError("global_sample_docs must be at least sample_docs")
+    if global_common_min_abs <= 0 or global_common_min_sources <= 0:
+        raise ValueError("global common thresholds must be positive")
+    if len(sources) < global_common_min_sources:
+        logger.warning(
+            "decon global drop-set cannot meet sources>=%d with only %d sources",
+            global_common_min_sources,
+            len(sources),
+        )
+
     bloom_path, _ = bloom_paths(prebuilt_bloom_dir)
 
-    def build_shard(items: Iterator[tuple[str, str]], _shard: ShardInfo) -> Iterator[dict[str, Any]]:
+    def build_shard(items: Iterator[tuple[str, str]], _shard: ShardInfo) -> Iterator[dict[str, int]]:
         bf = dupekit.Bloom.load_bytes(StoragePath(bloom_path).read_bytes())
         for source_name, df_sample_dir in items:
             drop, n, threshold = _drop_set_for_source(
                 df_sample_dir, bf, text_field, ngram, sample_docs, common_frac, common_min_abs
             )
             _write_drop_set(f"{output_path.rstrip('/')}/{source_name}", drop)
+            global_counts, n_global = _document_frequency_counts(
+                df_sample_dir, bf, text_field, ngram, global_sample_docs
+            )
             counters.pipeline.update_counter("decon_drop/sources", 1)
             counters.pipeline.update_counter("decon_drop/ngrams_dropped", len(drop))
-            logger.info("decon drop-set %s: %d docs, %d common ngrams (df>=%d)", source_name, n, len(drop), threshold)
-            yield {"source": source_name, "n_sampled": n, "n_dropped": len(drop)}
+            counters.pipeline.update_counter("decon_drop/global_documents_sampled", n_global)
+            counters.pipeline.update_counter("decon_drop/global_candidates", len(global_counts))
+            logger.info(
+                "decon drop-set %s: local=%d docs/%d ngrams (df>=%d), global=%d docs/%d candidates",
+                source_name,
+                n,
+                len(drop),
+                threshold,
+                n_global,
+                len(global_counts),
+            )
+            for hash_value, document_frequency in global_counts.items():
+                yield {"hash": hash_value, "document_frequency": document_frequency, "source_frequency": 1}
 
-    pipeline = Dataset.from_list(sources).map_shard(build_shard)
+    pipeline = (
+        Dataset.from_list(sources)
+        .map_shard(build_shard)
+        .group_by(
+            key=lambda row: row["hash"],
+            reducer=lambda hash_value, items: _global_drop_row(
+                hash_value,
+                items,
+                common_min_abs=global_common_min_abs,
+                common_min_sources=global_common_min_sources,
+            ),
+        )
+        .filter(lambda row: row is not None)
+    )
     resources = worker_resources or ResourceConfig(cpu=2, ram="4g")
     ctx_kwargs: dict[str, Any] = {"name": "decon-drop-set", "resources": resources}
     if max_workers is not None:
         ctx_kwargs["max_workers"] = max_workers
     outcome = ZephyrContext(**ctx_kwargs).execute(pipeline)
-    return AllSourceDropSets(output_dir=output_path, num_sources=len(sources), counters=dict(outcome.counters))
+    global_rows = list(outcome.results)
+    global_output_dir = f"{output_path.rstrip('/')}/_global"
+    out_file = _write_global_drop_set(global_output_dir, global_rows)
+    counters_out = dict(outcome.counters)
+    counters_out["decon_drop/global_ngrams_dropped"] = len(global_rows)
+    logger.info(
+        "decon global drop-set: %d ngrams (df>=%d, sources>=%d) → %s",
+        len(global_rows),
+        global_common_min_abs,
+        global_common_min_sources,
+        out_file,
+    )
+    return AllSourceDropSets(
+        output_dir=output_path,
+        global_output_dir=global_output_dir,
+        num_sources=len(sources),
+        n_global_dropped=len(global_rows),
+        counters=counters_out,
+    )
 
 
 def all_source_drop_sets_step(
     *,
     name: str,
     sources: list[tuple[str, str]],
+    source_dependencies: dict[str, StepSpec],
     prebuilt_bloom: StepSpec,
     text_field: str = "text",
     ngram_length: int | None = 13,
     paragraph_delimiter: str = "\n\n",
-    sample_docs: int = 5000,
-    common_frac: float = 0.005,
-    common_min_abs: int = 5,
+    sample_docs: int,
+    common_frac: float,
+    common_min_abs: int,
+    global_sample_docs: int,
+    global_common_min_abs: int,
+    global_common_min_sources: int,
     worker_resources: ResourceConfig | None = None,
     max_workers: int | None = None,
     output_path_prefix: str | None = None,
     override_output_path: str | None = None,
 ) -> StepSpec:
-    """StepSpec for :func:`build_all_source_drop_sets` — every source's common-ngram filter.
+    """StepSpec for corpus-side common-ngram filters.
 
     *sources* is a list of ``(source_name, df_sample_dir)``; each ``df_sample_dir``
-    is a raw directory of that source's normalized parquet used to estimate DF
-    (folded into ``hash_attrs``, not deps — like the eval paths of
-    :func:`build_eval_bloom_step`). Point each at a pool large enough to be stable
-    (~5k docs), independent of the sample being deconned. ``ngram_length`` /
-    ``paragraph_delimiter`` MUST match the consuming :func:`decon_step`. Each
-    ``decon_step`` reads its source's subdir via ``drop_sets=`` + ``drop_set_source=``.
+    is a directory of normalized parquet used to estimate DF. Include any steps
+    that produce those directories in *source_dependencies*, keyed by source
+    name. ``sample_docs`` controls the source-local estimate;
+    ``global_sample_docs`` controls the larger cross-source estimate.
+    ``ngram_length`` / ``paragraph_delimiter`` MUST match the consuming
+    :func:`decon_step`.
     """
     ngram: NGramConfig | None = (
         NGramConfig(ngram_length=ngram_length, paragraph_delimiter=paragraph_delimiter)
         if ngram_length is not None
         else None
     )
+    unknown_dependencies = sorted(set(source_dependencies) - {source_name for source_name, _ in sources})
+    if unknown_dependencies:
+        raise ValueError(f"source_dependencies contains unknown sources: {unknown_dependencies}")
+    raw_sources: list[tuple[str, str]] = []
+    dependent_sources: list[tuple[str, str, str]] = []
+    for source_name, source_path in sources:
+        dependency = source_dependencies.get(source_name)
+        if dependency is None:
+            raw_sources.append((source_name, source_path))
+            continue
+        dependency_path = dependency.output_path.rstrip("/")
+        if source_path != dependency_path and not source_path.startswith(f"{dependency_path}/"):
+            raise ValueError(f"{source_name} path {source_path} is outside dependency output {dependency_path}")
+        dependent_sources.append((source_name, dependency.name_with_hash, source_path.removeprefix(dependency_path)))
+
     hash_attrs: dict[str, Any] = {
-        "sources": tuple(sorted(sources)),
+        "raw_sources": tuple(sorted(raw_sources)),
+        "dependent_sources": tuple(sorted(dependent_sources)),
         "text_field": text_field,
         "ngram_length": ngram_length,
         "paragraph_delimiter": paragraph_delimiter,
@@ -1041,6 +1176,9 @@ def all_source_drop_sets_step(
         "sample_docs": sample_docs,
         "common_frac": common_frac,
         "common_min_abs": common_min_abs,
+        "global_sample_docs": global_sample_docs,
+        "global_common_min_abs": global_common_min_abs,
+        "global_common_min_sources": global_common_min_sources,
     }
     return StepSpec(
         name=name,
@@ -1053,10 +1191,13 @@ def all_source_drop_sets_step(
             sample_docs=sample_docs,
             common_frac=common_frac,
             common_min_abs=common_min_abs,
+            global_sample_docs=global_sample_docs,
+            global_common_min_abs=global_common_min_abs,
+            global_common_min_sources=global_common_min_sources,
             worker_resources=worker_resources,
             max_workers=max_workers,
         ),
-        deps=[prebuilt_bloom],
+        deps=[prebuilt_bloom, *source_dependencies.values()],
         hash_attrs=hash_attrs,
         output_path_prefix=output_path_prefix,
         override_output_path=override_output_path,
@@ -1106,10 +1247,9 @@ def decon_step(
         prebuilt_bloom: Pre-built bloom StepSpec (output of
             :func:`build_eval_bloom_step` or :func:`merge_eval_blooms_step`).
             Mutually exclusive with ``eval_data_sources``.
-        drop_sets: Optional :func:`all_source_drop_sets_step` output — the
-            per-source common-ngram filters (marin#6852). Combined with
-            *drop_set_source*, the hashes under ``<drop_sets>/<drop_set_source>``
-            are excluded from every paragraph overlap. Feature policy
+        drop_sets: Optional :func:`all_source_drop_sets_step` output. Combined
+            with *drop_set_source*, this excludes both hashes common within the
+            source and hashes common across several sources. Feature policy
             (ngram/delimiter) must match this step's.
         drop_set_source: This source's subdir name under *drop_sets* (e.g.
             ``"cp/usgpo"``). Required when *drop_sets* is set.
@@ -1158,7 +1298,14 @@ def decon_step(
     if drop_sets is not None and drop_set_source is None:
         raise ValueError("drop_set_source is required when drop_sets is set")
     drop_deps = [drop_sets] if drop_sets is not None else []
-    drop_dir = f"{drop_sets.output_path.rstrip('/')}/{drop_set_source}" if drop_sets is not None else None
+    drop_dirs = (
+        [
+            f"{drop_sets.output_path.rstrip('/')}/{drop_set_source}",
+            f"{drop_sets.output_path.rstrip('/')}/_global",
+        ]
+        if drop_sets is not None
+        else None
+    )
     norm_deps = [normalized] if normalized is not None else []
 
     def _read_norm() -> NormalizedData:
@@ -1176,7 +1323,7 @@ def decon_step(
                 output_path=output_path,
                 text_field=text_field,
                 ngram=ngram,
-                drop_set_dir=drop_dir,
+                drop_set_dirs=drop_dirs,
                 flagged_sample_size=flagged_sample_size,
                 worker_resources=worker_resources,
                 max_workers=max_workers,
@@ -1204,7 +1351,7 @@ def decon_step(
             output_path=output_path,
             text_field=text_field,
             ngram=ngram,
-            drop_set_dir=drop_dir,
+            drop_set_dirs=drop_dirs,
             flagged_sample_size=flagged_sample_size,
             estimated_doc_count=estimated_doc_count,
             false_positive_rate=false_positive_rate,

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -877,12 +877,11 @@ def _iter_normalized_texts(main_output_dir: str, text_field: str) -> Iterator[st
 
 
 def _load_drop_set(drop_set_dir: str) -> frozenset[int]:
-    files = sorted(str(m) for m in StoragePath(f"{drop_set_dir.rstrip('/')}/**/*.parquet").glob())
-    out: set[int] = set()
-    for f in files:
-        with StoragePath(f).open("rb") as fh:
-            out.update(pq.read_table(fh, columns=["hash"]).column("hash").to_pylist())
-    return frozenset(out)
+    drop_path = StoragePath(f"{drop_set_dir.rstrip('/')}/drop.parquet")
+    if not drop_path.exists():
+        return frozenset()
+    with drop_path.open("rb") as fh:
+        return frozenset(pq.read_table(fh, columns=["hash"]).column("hash").to_pylist())
 
 
 def _load_drop_sets(drop_set_dirs: list[str]) -> frozenset[int]:

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -121,6 +121,7 @@ class DeconAttributes(BaseModel):
 
 _BLOOM_FILENAME = "filter.bin"
 _INDEX_FILENAME = "eval_hash_index.parquet"
+_GLOBAL_DROP_SET_DIRECTORY = "_global"
 
 
 def bloom_paths(bloom_dir: str) -> tuple[str, str]:
@@ -227,8 +228,9 @@ def _paragraph_overlap_and_matches(
 
     *drop_hashes* are removed from *both* the numerator and denominator.
     Corpus-common boilerplate carries no contamination signal, so an
-    all-boilerplate paragraph collapses to zero ngrams and scores 0. A paragraph
-    with a distinctive leak keeps its remaining ngrams and still scores ~1.0.
+    all-boilerplate paragraph collapses to zero ngrams and scores 0. Remaining
+    distinctive leak ngrams stay matchable; a leak made entirely of dropped
+    ngrams is intentionally suppressed.
 
     Paragraphs with fewer than ``ngram_length`` tokens in n-gram mode return
     ``(0.0, [])`` — see :func:`_extract_features` for why we don't fall back
@@ -963,7 +965,8 @@ class AllSourceDropSets(BaseModel):
     """Outcome of :func:`build_all_source_drop_sets`.
 
     Per-source hashes live at ``<output_dir>/<source>/drop.parquet``. Globally
-    common hashes live at ``<global_output_dir>/drop.parquet``.
+    common hashes live at ``<global_output_dir>/drop.parquet`` with document
+    and source frequencies retained for threshold audits.
     """
 
     output_dir: str
@@ -1034,8 +1037,11 @@ def build_all_source_drop_sets(
     """
     if not sources:
         raise ValueError("sources must be non-empty")
-    if len({source_name for source_name, _ in sources}) != len(sources):
+    source_names = {source_name for source_name, _ in sources}
+    if len(source_names) != len(sources):
         raise ValueError("source names must be unique")
+    if _GLOBAL_DROP_SET_DIRECTORY in source_names:
+        raise ValueError(f"{_GLOBAL_DROP_SET_DIRECTORY!r} is reserved for the global drop set")
     if global_sample_docs < sample_docs:
         raise ValueError("global_sample_docs must be at least sample_docs")
     if global_common_min_abs <= 0 or global_common_min_sources <= 0:
@@ -1095,7 +1101,7 @@ def build_all_source_drop_sets(
         ctx_kwargs["max_workers"] = max_workers
     outcome = ZephyrContext(**ctx_kwargs).execute(pipeline)
     global_rows = list(outcome.results)
-    global_output_dir = f"{output_path.rstrip('/')}/_global"
+    global_output_dir = f"{output_path.rstrip('/')}/{_GLOBAL_DROP_SET_DIRECTORY}"
     out_file = _write_global_drop_set(global_output_dir, global_rows)
     counters_out = dict(outcome.counters)
     counters_out["decon_drop/global_ngrams_dropped"] = len(global_rows)
@@ -1300,7 +1306,7 @@ def decon_step(
     drop_dirs = (
         [
             f"{drop_sets.output_path.rstrip('/')}/{drop_set_source}",
-            f"{drop_sets.output_path.rstrip('/')}/_global",
+            f"{drop_sets.output_path.rstrip('/')}/{_GLOBAL_DROP_SET_DIRECTORY}",
         ]
         if drop_sets is not None
         else None

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -976,6 +976,19 @@ class AllSourceDropSets(BaseModel):
     counters: dict[str, int | float]
 
 
+@dataclass(frozen=True)
+class DropSetSource:
+    """A normalized source sampled by :func:`all_source_drop_sets_step`.
+
+    Set *dependency* when *data_path* is produced by another step. Omit it for
+    a pre-materialized path.
+    """
+
+    name: str
+    data_path: str
+    dependency: StepSpec | None = None
+
+
 def _global_drop_row(
     hash_value: int,
     items: Iterator[dict[str, int]],
@@ -1124,8 +1137,7 @@ def build_all_source_drop_sets(
 def all_source_drop_sets_step(
     *,
     name: str,
-    sources: list[tuple[str, str]],
-    source_dependencies: dict[str, StepSpec],
+    sources: list[DropSetSource],
     prebuilt_bloom: StepSpec,
     text_field: str = "text",
     ngram_length: int | None = 13,
@@ -1143,11 +1155,9 @@ def all_source_drop_sets_step(
 ) -> StepSpec:
     """StepSpec for corpus-side common-ngram filters.
 
-    *sources* is a list of ``(source_name, df_sample_dir)``; each ``df_sample_dir``
-    is a directory of normalized parquet used to estimate DF. Include any steps
-    that produce those directories in *source_dependencies*, keyed by source
-    name. ``sample_docs`` controls the source-local estimate;
-    ``global_sample_docs`` controls the larger cross-source estimate.
+    Each source names a normalized parquet directory used to estimate DF and
+    optionally its producer step. ``sample_docs`` controls the source-local
+    estimate; ``global_sample_docs`` controls the larger cross-source estimate.
     ``ngram_length`` / ``paragraph_delimiter`` MUST match the consuming
     :func:`decon_step`.
     """
@@ -1156,20 +1166,23 @@ def all_source_drop_sets_step(
         if ngram_length is not None
         else None
     )
-    unknown_dependencies = sorted(set(source_dependencies) - {source_name for source_name, _ in sources})
-    if unknown_dependencies:
-        raise ValueError(f"source_dependencies contains unknown sources: {unknown_dependencies}")
     raw_sources: list[tuple[str, str]] = []
     dependent_sources: list[tuple[str, str, str]] = []
-    for source_name, source_path in sources:
-        dependency = source_dependencies.get(source_name)
+    source_dependencies: list[StepSpec] = []
+    runtime_sources: list[tuple[str, str]] = []
+    for source in sources:
+        runtime_sources.append((source.name, source.data_path))
+        dependency = source.dependency
         if dependency is None:
-            raw_sources.append((source_name, source_path))
+            raw_sources.append((source.name, source.data_path))
             continue
+        source_dependencies.append(dependency)
         dependency_path = dependency.output_path.rstrip("/")
-        if source_path != dependency_path and not source_path.startswith(f"{dependency_path}/"):
-            raise ValueError(f"{source_name} path {source_path} is outside dependency output {dependency_path}")
-        dependent_sources.append((source_name, dependency.name_with_hash, source_path.removeprefix(dependency_path)))
+        if source.data_path != dependency_path and not source.data_path.startswith(f"{dependency_path}/"):
+            raise ValueError(f"{source.name} path {source.data_path} is outside dependency output {dependency_path}")
+        dependent_sources.append(
+            (source.name, dependency.name_with_hash, source.data_path.removeprefix(dependency_path))
+        )
 
     hash_attrs: dict[str, Any] = {
         "raw_sources": tuple(sorted(raw_sources)),
@@ -1188,7 +1201,7 @@ def all_source_drop_sets_step(
     return StepSpec(
         name=name,
         fn=lambda output_path: build_all_source_drop_sets(
-            sources=sources,
+            sources=runtime_sources,
             prebuilt_bloom_dir=prebuilt_bloom.output_path,
             output_path=output_path,
             text_field=text_field,
@@ -1202,7 +1215,7 @@ def all_source_drop_sets_step(
             worker_resources=worker_resources,
             max_workers=max_workers,
         ),
-        deps=[prebuilt_bloom, *source_dependencies.values()],
+        deps=[prebuilt_bloom, *source_dependencies],
         hash_attrs=hash_attrs,
         output_path_prefix=output_path_prefix,
         override_output_path=override_output_path,

--- a/tests/datakit/test_decon.py
+++ b/tests/datakit/test_decon.py
@@ -1131,7 +1131,7 @@ def test_source_drop_set_filters_source_ubiquitous_ngram(tmp_path: Path):
         prebuilt_bloom_dir=str(bloom_dir),
         output_path=str(out_dir),
         ngram=NGramConfig(ngram_length=4, overlap_threshold=0.5, paragraph_delimiter="\n"),
-        drop_set_dir=str(drop_dir),
+        drop_set_dirs=[str(drop_dir)],
     )
     rows = _read_attributes(out_dir)
     assert rows["d0"]["contaminated"] is False  # boilerplate-only no longer flags
@@ -1174,7 +1174,7 @@ def test_source_drop_set_empty_leaves_marks_unchanged(tmp_path: Path):
         prebuilt_bloom_dir=str(bloom_dir),
         output_path=str(out_dir),
         ngram=NGramConfig(ngram_length=4, overlap_threshold=0.5, paragraph_delimiter="\n"),
-        drop_set_dir=str(drop_dir),
+        drop_set_dirs=[str(drop_dir)],
     )
     assert _read_attributes(out_dir)["leak"]["contaminated"] is True
 
@@ -1218,10 +1218,81 @@ def test_build_all_source_drop_sets_distributes_per_source(tmp_path: Path):
         sample_docs=1000,
         common_frac=0.5,
         common_min_abs=2,
+        global_sample_docs=1000,
+        global_common_min_abs=100,
+        global_common_min_sources=2,
     )
     assert res.num_sources == 2
     assert len(_load_drop_set(str(out / "srcA"))) > 0  # boilerplate (df=20) dropped
     assert len(_load_drop_set(str(out / "srcB"))) == 0  # distinctive (df=1) kept
+    assert res.n_global_dropped == 0  # high DF in only one source is not global boilerplate
+
+
+def test_all_source_drop_sets_filters_diffuse_global_boilerplate(tmp_path: Path):
+    """Global DF removes text spread across sources without erasing a source-local leak."""
+    common = "four score and seven years ago our fathers brought forth on this continent a new nation"
+    leak = "the platypus juggled seventeen luminous kumquats beside a silent observatory at midnight"
+    filler = "ordinary source material whose wording shares no evaluation sequence at all today"
+    eval_dir = tmp_path / "eval"
+    _write_eval_jsonl(
+        eval_dir / "eval.jsonl.gz",
+        [
+            {"id": "public_quote", "text": common},
+            {"id": "genuine_leak", "text": leak},
+        ],
+    )
+    ngram = NGramConfig(ngram_length=4, overlap_threshold=0.5)
+    bloom_dir = tmp_path / "bloom"
+    build_eval_bloom(
+        eval_data_sources=str(eval_dir),
+        output_path=str(bloom_dir),
+        ngram=ngram,
+        estimated_doc_count=10_000,
+        false_positive_rate=1e-9,
+    )
+
+    sources = []
+    for source_idx in range(4):
+        source_dir = tmp_path / f"source_{source_idx}"
+        rows = [{"id": f"common_{source_idx}_{i}", "text": common, "partition_id": 0} for i in range(2)]
+        rows.extend(
+            {"id": f"filler_{source_idx}_{i}", "text": f"{filler} {source_idx} {i}", "partition_id": 0} for i in range(8)
+        )
+        if source_idx == 0:
+            rows.append({"id": "leak", "text": leak, "partition_id": 0})
+        _write_input_parquet(source_dir / "part-00000-of-00001.parquet", rows)
+        sources.append((f"source_{source_idx}", str(source_dir)))
+
+    out = tmp_path / "drops"
+    result = build_all_source_drop_sets(
+        sources=sources,
+        prebuilt_bloom_dir=str(bloom_dir),
+        output_path=str(out),
+        ngram=ngram,
+        sample_docs=100,
+        common_frac=0.5,
+        common_min_abs=3,
+        global_sample_docs=100,
+        global_common_min_abs=6,
+        global_common_min_sources=3,
+    )
+    assert all(not _load_drop_set(str(out / source_name)) for source_name, _ in sources)
+    assert _load_drop_set(result.global_output_dir)
+    global_rows = pq.read_table(Path(result.global_output_dir) / "drop.parquet").to_pylist()
+    assert {row["document_frequency"] for row in global_rows} == {8}
+    assert {row["source_frequency"] for row in global_rows} == {4}
+
+    marked = tmp_path / "marked"
+    decon_to_parquet(
+        normalized_data=_as_source(Path(sources[0][1])),
+        prebuilt_bloom_dir=str(bloom_dir),
+        output_path=str(marked),
+        ngram=ngram,
+        drop_set_dirs=[str(out / "source_0"), result.global_output_dir],
+    )
+    rows = _read_attributes(marked)
+    assert rows["common_0_0"]["contaminated"] is False
+    assert rows["leak"]["contaminated"] is True
 
 
 def test_decon_flagged_sample_sidecar(fox_corpus):

--- a/tests/datakit/test_decon.py
+++ b/tests/datakit/test_decon.py
@@ -1180,8 +1180,7 @@ def test_source_drop_set_empty_leaves_marks_unchanged(tmp_path: Path):
 
 
 def test_build_all_source_drop_sets_distributes_per_source(tmp_path: Path):
-    """The distributed (zephyr) builder writes one drop.parquet per source: a
-    source's ubiquitous ngram is dropped, another source's distinctive one kept."""
+    """Nested source names load only their exact local drop set."""
     eval_dir = tmp_path / "eval"
     _write_eval_jsonl(
         eval_dir / "eval.jsonl.gz",
@@ -1211,7 +1210,7 @@ def test_build_all_source_drop_sets_distributes_per_source(tmp_path: Path):
 
     out = tmp_path / "drops"
     res = build_all_source_drop_sets(
-        sources=[("srcA", str(a_dir)), ("srcB", str(b_dir))],
+        sources=[("finepdfs/fra_Latn", str(a_dir)), ("finepdfs", str(b_dir))],
         prebuilt_bloom_dir=str(bloom_dir),
         output_path=str(out),
         ngram=NGramConfig(ngram_length=4, paragraph_delimiter="\n"),
@@ -1223,8 +1222,8 @@ def test_build_all_source_drop_sets_distributes_per_source(tmp_path: Path):
         global_common_min_sources=2,
     )
     assert res.num_sources == 2
-    assert len(_load_drop_set(str(out / "srcA"))) > 0  # boilerplate (df=20) dropped
-    assert len(_load_drop_set(str(out / "srcB"))) == 0  # distinctive (df=1) kept
+    assert len(_load_drop_set(str(out / "finepdfs/fra_Latn"))) > 0  # boilerplate (df=20) dropped
+    assert len(_load_drop_set(str(out / "finepdfs"))) == 0  # does not recursively load the language child
     assert res.n_global_dropped == 0  # high DF in only one source is not global boilerplate
 
 

--- a/tests/datakit/test_decon.py
+++ b/tests/datakit/test_decon.py
@@ -1179,6 +1179,22 @@ def test_source_drop_set_empty_leaves_marks_unchanged(tmp_path: Path):
     assert _read_attributes(out_dir)["leak"]["contaminated"] is True
 
 
+def test_build_all_source_drop_sets_rejects_reserved_global_source_name(tmp_path: Path):
+    with pytest.raises(ValueError):
+        build_all_source_drop_sets(
+            sources=[("_global", str(tmp_path / "input"))],
+            prebuilt_bloom_dir=str(tmp_path / "bloom"),
+            output_path=str(tmp_path / "drops"),
+            ngram=NGramConfig(ngram_length=4),
+            sample_docs=100,
+            common_frac=0.5,
+            common_min_abs=3,
+            global_sample_docs=100,
+            global_common_min_abs=6,
+            global_common_min_sources=3,
+        )
+
+
 def test_build_all_source_drop_sets_distributes_per_source(tmp_path: Path):
     """Nested source names load only their exact local drop set."""
     eval_dir = tmp_path / "eval"

--- a/tests/datakit/test_reference_pipeline_hashing.py
+++ b/tests/datakit/test_reference_pipeline_hashing.py
@@ -75,6 +75,19 @@ def test_minhash_params_rekey_minhash_and_dedup():
     assert changed["datakit/dedup"].hash_id != base["datakit/dedup"].hash_id
 
 
+def test_decon_drop_set_tracks_normalized_source_identity():
+    base = _steps_by_name(_build())["datakit/decon_drop/_combined"].hash_id
+    sources = _sources()
+    sources["a"] = dataclasses.replace(sources["a"], hash_attrs={"revision": 1})
+    changed = reference_datakit_steps(
+        sources,
+        quality_model="gs://some-region/quality/pooled_junkgate2",
+        quality_model_version="pooled-junkgate2",
+        scale=SMOKE_SCALE,
+    )
+    assert _steps_by_name(changed)["datakit/decon_drop/_combined"].hash_id != base
+
+
 def test_centroid_seed_rekeys_training():
     base = _steps_by_name(_build())["datakit/cluster/train_centroids"].hash_id
     seeded = dataclasses.replace(SMOKE_SCALE.cluster, train_seed=7)


### PR DESCRIPTION
* fixes https://github.com/marin-community/marin/issues/7126
* aggregate eval n-gram document frequency across source samples before marking
* drop hashes at `DF >= 50` in at least three sources, then load the shared set alongside each source-local set
  * a high-frequency match confined to one source remains eligible for contamination marking
* scan up to 1,000,000 normalized documents per source for the global estimate and 5,000 for the local estimate
* four-source repro: repeated public quote overlap `1.0 → 0.0`; one-source injected eval item stays `1.0` [^1]

[^1]: validates the mechanism and source-spread guard; production threshold calibration has not run in this environment. `DF >= 50` follows the earlier 100B corpus-DF harness.
