### PR TITLE
[iris] Build arm64 images only for Kubernetes tasks

### DIFF
--- a/.github/workflows/ops-docker-images.yaml
+++ b/.github/workflows/ops-docker-images.yaml
@@ -43,31 +43,35 @@ jobs:
   # the deps stage COPYs the root uv.lock and every workspace member's
   # pyproject.toml (plus lib/rigging source), all of which live above lib/iris.
   #
-  # Each arch builds on a native runner and pushes an arch-suffixed tag; the
-  # iris-manifests job then merges those into one multi-arch tag. CoreWeave GB200
-  # nodes are aarch64 (Grace), so an amd64-only image fails there with "exec
-  # format error". Native runners rather than QEMU: these images build a full
-  # Python dep tree from source, which emulation makes untenably slow.
+  # The controller is pinned to amd64, and Kubernetes does not run the worker
+  # image. Only task pods need arm64 for CoreWeave GB200 Grace nodes. Each build
+  # uses a native runner and pushes an arch-suffixed tag; iris-manifests then
+  # publishes the final tags without QEMU builds.
   iris-images:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'schedule' && github.event.schedule == '0 2 * * 0')
     needs: iris-tags
-    runs-on: ${{ matrix.platform.runner }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        image:
+        include:
           - name: iris-worker
             target: worker
+            arch: amd64
+            runner: ubuntu-latest
           - name: iris-controller
             target: controller
+            arch: amd64
+            runner: ubuntu-latest
           - name: iris-task
             target: task
-        platform:
-          - arch: amd64
+            arch: amd64
             runner: ubuntu-latest
-          - arch: arm64
+          - name: iris-task
+            target: task
+            arch: arm64
             runner: ubuntu-24.04-arm
     steps:
       - name: Checkout repository
@@ -83,17 +87,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-      - name: Build and push ${{ matrix.image.name }} (${{ matrix.platform.arch }})
+      - name: Build and push ${{ matrix.name }} (${{ matrix.arch }})
         run: |
           docker buildx build --file lib/iris/Dockerfile \
-            --target ${{ matrix.image.target }} \
-            --platform linux/${{ matrix.platform.arch }} \
-            --cache-from type=registry,ref=ghcr.io/marin-community/iris-cache:${{ matrix.image.target }}-${{ matrix.platform.arch }} \
-            --cache-to type=registry,ref=ghcr.io/marin-community/iris-cache:${{ matrix.image.target }}-${{ matrix.platform.arch }},mode=max,compression=zstd,compression-level=3,oci-mediatypes=true,image-manifest=true \
+            --target ${{ matrix.target }} \
+            --platform linux/${{ matrix.arch }} \
+            --cache-from type=registry,ref=ghcr.io/marin-community/iris-cache:${{ matrix.target }}-${{ matrix.arch }} \
+            --cache-to type=registry,ref=ghcr.io/marin-community/iris-cache:${{ matrix.target }}-${{ matrix.arch }},mode=max,compression=zstd,compression-level=3,oci-mediatypes=true,image-manifest=true \
             --output type=image,compression=zstd,compression-level=3,push=true \
             --provenance=false \
             --build-arg IRIS_GIT_HASH=${{ needs.iris-tags.outputs.hash }} \
-            --tag ghcr.io/marin-community/${{ matrix.image.name }}:${{ needs.iris-tags.outputs.hash }}-${{ matrix.platform.arch }} \
+            --tag ghcr.io/marin-community/${{ matrix.name }}:${{ needs.iris-tags.outputs.hash }}-${{ matrix.arch }} \
             .
 
   # Merge the per-arch tags into the multi-arch tags that clusters actually pull.
@@ -120,12 +124,15 @@ jobs:
           DATE_TAG: ${{ needs.iris-tags.outputs.date }}
           HASH_TAG: ${{ needs.iris-tags.outputs.hash }}
         run: |
+          SOURCES=("$IMAGE:$HASH_TAG-amd64")
+          if [[ "$IMAGE" == "ghcr.io/marin-community/iris-task" ]]; then
+            SOURCES+=("$IMAGE:$HASH_TAG-arm64")
+          fi
           docker buildx imagetools create \
             --tag "$IMAGE:latest" \
             --tag "$IMAGE:$DATE_TAG" \
             --tag "$IMAGE:$HASH_TAG" \
-            "$IMAGE:$HASH_TAG-amd64" \
-            "$IMAGE:$HASH_TAG-arm64"
+            "${SOURCES[@]}"
 
   # Finelog Image - Standalone log server (lib/finelog)
   finelog-image:

--- a/.github/workflows/ops-docker-images.yaml
+++ b/.github/workflows/ops-docker-images.yaml
@@ -100,7 +100,7 @@ jobs:
             --tag ghcr.io/marin-community/${{ matrix.name }}:${{ needs.iris-tags.outputs.hash }}-${{ matrix.arch }} \
             .
 
-  # Merge the per-arch tags into the multi-arch tags that clusters actually pull.
+  # Publish final tags from each image's available architecture-specific tags.
   iris-manifests:
     if: |
       github.event_name == 'workflow_dispatch' ||

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -65,16 +65,16 @@ The restart preflight resolves operator-side controller secrets before taking a 
 
 If checkpoint times out: `iris cluster controller restart --skip-checkpoint` (restores from last periodic checkpoint; some recent state may be lost).
 
-**Restart builds and deploys your local working tree.** `iris cluster controller restart` builds fresh controller/worker/task images from your **current checkout — HEAD plus any staged/unstaged changes** (`get_git_sha()` is a tree-content hash), pushes them (`:<hash>` and `:latest`), pins the deploy to `:<hash>` in memory, and restarts the container in place. So the restart ships whatever code is in your tree; there is no separate image-rebuild step. To deploy a merged controller fix: update your checkout (`git pull`, or check out the fix) **then** restart — restarting from a stale checkout ships that stale code. Always confirm the controller is running the `:<git-short-hash>` you expect (`iris cluster status`), not just that it came back up; a stale-checkout deploy once cost ~5 red-canary days (`.agents/ops/2026-06-08-canary-ferry-reservation-taint-timeouts.md`).
+**Restart builds and deploys your local working tree.** `iris cluster controller restart` builds the images required by the configured runtime from your **current checkout — HEAD plus any staged/unstaged changes** (`get_git_sha()` is a tree-content hash), pushes them (`:<hash>` and `:latest`), pins the deploy to `:<hash>` in memory, and restarts the container in place. So the restart ships whatever code is in your tree; there is no separate image-rebuild step. To deploy a merged controller fix: update your checkout (`git pull`, or check out the fix) **then** restart — restarting from a stale checkout ships that stale code. Always confirm the controller is running the `:<git-short-hash>` you expect (`iris cluster status`), not just that it came back up; a stale-checkout deploy once cost ~5 red-canary days (`.agents/ops/2026-06-08-canary-ferry-reservation-taint-timeouts.md`).
 
-Restarts default to the fast Rust profile, which skips LTO and reduces native link time. The controller is built for amd64 because controller nodes are pinned to that architecture. Worker and task images remain amd64+arm64 by default for clusters with arm64 GPU nodes. To build amd64-only workload images on a dev cluster:
+Restarts default to the fast Rust profile, which skips LTO and reduces native link time. Controllers are built for amd64 because controller nodes are pinned to that architecture. Kubernetes clusters skip the unused worker image and build the task image for amd64+arm64; VM clusters build amd64 controller, worker, and task images. `--image-platform` overrides only the task image, for example when a Kubernetes dev cluster has amd64 nodes only:
 
 ```bash
-iris --cluster=marin-dev cluster controller restart \
+iris --config path/to/dev.yaml cluster controller restart \
   --image-platform linux/amd64
 ```
 
-Pass `--cargo-profile release` for an LTO build. Keep the default workload image platforms when the deployed cluster needs arm64 workers.
+Pass `--cargo-profile release` for an LTO build. Keep the default task image platforms when the deployed cluster includes arm64 nodes.
 
 **Rollout state is recorded automatically.** Each `controller restart` writes a rollout record to `gs://…/<cluster>/state/rollout-record.json` — the image it deployed, the image it replaced, the pre-deploy checkpoint it took, and a phase (`pending` → `committed` for a forward deploy; `rollback_requested` → `rolled_back` for a revert). The rollback coordinates are captured as part of the deploy, so you never track them by hand. A forward restart also **health-checks the new controller and auto-rolls back** to the previous image + its pre-deploy checkpoint if the deploy fails to come up. (The *first* deploy after this landed has no prior record, so there is nothing to auto-roll back to — recover a failed first deploy by checking out known-good code and restarting forward, or use the on-VM procedure below.)
 

--- a/lib/iris/src/iris/cli/build.py
+++ b/lib/iris/src/iris/cli/build.py
@@ -237,6 +237,9 @@ def build_image(
 
     cache_ref = f"ghcr.io/{ghcr_org}/iris-cache:{image_type}"
     cmd.extend(["--cache-from", f"type=registry,ref={cache_ref}"])
+    for target_platform in platform.split(","):
+        architecture = target_platform.rsplit("/", 1)[-1]
+        cmd.extend(["--cache-from", f"type=registry,ref={cache_ref}-{architecture}"])
 
     if push:
         # oci-mediatypes/image-manifest store the cache as a single OCI image,

--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -35,7 +35,7 @@ from iris.cli.build import (
 )
 from iris.cli.connect import IRIS_CLUSTER_CONFIG_DIRS, require_controller_url, rpc_client_for_ctx
 from iris.cluster.composer import provider_bundle
-from iris.cluster.config import clear_remote_state, make_local_config
+from iris.cluster.config import KUBERNETES_WORKER_RUNTIME, clear_remote_state, make_local_config
 from iris.cluster.controller.autoscaler.scaling_group import (
     _zone_from_template,
     build_worker_config_for_group,
@@ -206,7 +206,7 @@ def _build_cluster_images(
     cargo_profile: str = DEFAULT_CARGO_PROFILE,
 ) -> dict[str, str]:
     built: dict[str, str] = {}
-    kubernetes = config.defaults.worker.runtime == "kubernetes"
+    kubernetes = config.defaults.worker.runtime == KUBERNETES_WORKER_RUNTIME
 
     worker_tag = config.defaults.worker.docker_image
     if worker_tag and not kubernetes:

--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -61,8 +61,8 @@ from iris.rpc import controller_pb2, job_pb2, query_pb2, vm_pb2
 from iris.rpc.proto_display import format_accelerator_display, vm_state_name
 from iris.time_proto import timestamp_from_proto
 
-CONTROLLER_IMAGE_PLATFORM = "linux/amd64"
-DEFAULT_WORKLOAD_IMAGE_PLATFORMS = "linux/amd64,linux/arm64"
+AMD64_IMAGE_PLATFORM = "linux/amd64"
+KUBERNETES_TASK_IMAGE_PLATFORMS = "linux/amd64,linux/arm64"
 
 
 @dataclass(frozen=True)
@@ -166,7 +166,7 @@ def _build_and_push_image(
     image_type: str,
     git_sha: str,
     verbose: bool = False,
-    platform: str = DEFAULT_WORKLOAD_IMAGE_PLATFORMS,
+    platform: str = AMD64_IMAGE_PLATFORM,
     cargo_profile: str = DEFAULT_CARGO_PROFILE,
 ) -> None:
     """Build and push a single image to GHCR, parsing org/name/version from the tag.
@@ -202,19 +202,20 @@ def _build_cluster_images(
     config,
     git_sha: str,
     verbose: bool = False,
-    workload_platforms: str = DEFAULT_WORKLOAD_IMAGE_PLATFORMS,
+    task_platforms: str | None = None,
     cargo_profile: str = DEFAULT_CARGO_PROFILE,
 ) -> dict[str, str]:
     built: dict[str, str] = {}
+    kubernetes = config.defaults.worker.runtime == "kubernetes"
 
     worker_tag = config.defaults.worker.docker_image
-    if worker_tag:
+    if worker_tag and not kubernetes:
         _build_and_push_image(
             worker_tag,
             "worker",
             git_sha,
             verbose=verbose,
-            platform=workload_platforms,
+            platform=AMD64_IMAGE_PLATFORM,
             cargo_profile=cargo_profile,
         )
         built["worker"] = worker_tag
@@ -226,19 +227,20 @@ def _build_cluster_images(
             "controller",
             git_sha,
             verbose=verbose,
-            platform=CONTROLLER_IMAGE_PLATFORM,
+            platform=AMD64_IMAGE_PLATFORM,
             cargo_profile=cargo_profile,
         )
         built["controller"] = controller_tag
 
     task_tag = config.defaults.worker.default_task_image
     if task_tag:
+        task_platforms = task_platforms or (KUBERNETES_TASK_IMAGE_PLATFORMS if kubernetes else AMD64_IMAGE_PLATFORM)
         _build_and_push_image(
             task_tag,
             "task",
             git_sha,
             verbose=verbose,
-            platform=workload_platforms,
+            platform=task_platforms,
             cargo_profile=cargo_profile,
         )
         built["task"] = task_tag
@@ -286,7 +288,7 @@ def _build_and_pin_deploy_images(
     ctx,
     config,
     *,
-    workload_platforms: str = DEFAULT_WORKLOAD_IMAGE_PLATFORMS,
+    task_platforms: str | None = None,
     cargo_profile: str = DEFAULT_CARGO_PROFILE,
 ) -> None:
     """Pin :latest tags to the working-tree hash, build + push the images, echo them."""
@@ -297,7 +299,7 @@ def _build_and_pin_deploy_images(
         config,
         git_sha,
         verbose=verbose,
-        workload_platforms=workload_platforms,
+        task_platforms=task_platforms,
         cargo_profile=cargo_profile,
     )
     if built:
@@ -529,10 +531,9 @@ def cluster_init_keys(out_file: Path | None, gcp_secret: str | None, accessor: s
 )
 @click.option(
     "--image-platform",
-    "workload_image_platforms",
-    default=DEFAULT_WORKLOAD_IMAGE_PLATFORMS,
-    show_default=True,
-    help="Docker platform(s) to build and push for worker and task images.",
+    "task_image_platforms",
+    default=None,
+    help="Override the Docker platform(s) selected automatically for the task image.",
 )
 @click.option(
     "--cargo-profile",
@@ -542,7 +543,7 @@ def cluster_init_keys(out_file: Path | None, gcp_secret: str | None, accessor: s
     help="Rust profile used to build native Iris components.",
 )
 @click.pass_context
-def cluster_start(ctx, local: bool, fresh: bool, workload_image_platforms: str, cargo_profile: str):
+def cluster_start(ctx, local: bool, fresh: bool, task_image_platforms: str | None, cargo_profile: str):
     """Start controller and wait for health.
 
     Each platform handles its own controller lifecycle:
@@ -566,7 +567,7 @@ def cluster_start(ctx, local: bool, fresh: bool, workload_image_platforms: str, 
             config,
             git_sha,
             verbose=verbose,
-            workload_platforms=workload_image_platforms,
+            task_platforms=task_image_platforms,
             cargo_profile=cargo_profile,
         )
         if built:
@@ -609,10 +610,9 @@ def cluster_start(ctx, local: bool, fresh: bool, workload_image_platforms: str, 
 @click.option("--clear-state/--no-clear-state", default=True, help="Wipe remote state before starting")
 @click.option(
     "--image-platform",
-    "workload_image_platforms",
-    default=DEFAULT_WORKLOAD_IMAGE_PLATFORMS,
-    show_default=True,
-    help="Docker platform(s) to build and push for worker and task images.",
+    "task_image_platforms",
+    default=None,
+    help="Override the Docker platform(s) selected automatically for the task image.",
 )
 @click.option(
     "--cargo-profile",
@@ -629,7 +629,7 @@ def cluster_start_smoke(
     min_workers,
     worker_timeout,
     clear_state,
-    workload_image_platforms,
+    task_image_platforms,
     cargo_profile,
 ):
     """Boot a smoke-test cluster, open tunnel, write URL to file, and block until killed.
@@ -654,7 +654,7 @@ def cluster_start_smoke(
         config,
         git_sha,
         verbose=verbose,
-        workload_platforms=workload_image_platforms,
+        task_platforms=task_image_platforms,
         cargo_profile=cargo_profile,
     )
 
@@ -1221,10 +1221,9 @@ def controller_checkpoint(ctx, stop: bool):
 )
 @click.option(
     "--image-platform",
-    "workload_image_platforms",
-    default=DEFAULT_WORKLOAD_IMAGE_PLATFORMS,
-    show_default=True,
-    help="Docker platform(s) to build and push for worker and task images.",
+    "task_image_platforms",
+    default=None,
+    help="Override the Docker platform(s) selected automatically for the task image.",
 )
 @click.option(
     "--cargo-profile",
@@ -1239,7 +1238,7 @@ def controller_restart(
     skip_checkpoint: bool,
     checkpoint_timeout: int,
     rollback: bool,
-    workload_image_platforms: str,
+    task_image_platforms: str | None,
     cargo_profile: str,
 ):
     """Restart the controller in place, preserving state (remote platforms only).
@@ -1284,7 +1283,7 @@ def controller_restart(
         new_image = _build_forward_image(
             ctx,
             config,
-            workload_platforms=workload_image_platforms,
+            task_platforms=task_image_platforms,
             cargo_profile=cargo_profile,
         )
         try:
@@ -1314,7 +1313,7 @@ def controller_restart(
     new_image = _build_forward_image(
         ctx,
         config,
-        workload_platforms=workload_image_platforms,
+        task_platforms=task_image_platforms,
         cargo_profile=cargo_profile,
     )
     previous_image = prior_record.image if prior_record else None
@@ -1375,14 +1374,14 @@ def _build_forward_image(
     ctx,
     config,
     *,
-    workload_platforms: str = DEFAULT_WORKLOAD_IMAGE_PLATFORMS,
+    task_platforms: str | None = None,
     cargo_profile: str = DEFAULT_CARGO_PROFILE,
 ) -> str:
     """Build deploy images from the working tree and return the controller image tag."""
     _build_and_pin_deploy_images(
         ctx,
         config,
-        workload_platforms=workload_platforms,
+        task_platforms=task_platforms,
         cargo_profile=cargo_profile,
     )
     return config.controller.image

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -51,6 +51,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_SSH_PORT = 22
 DEFAULT_SSH_CONNECT_TIMEOUT = Duration.from_seconds(30)
 DEFAULT_PRIORITY = 100
+DOCKER_WORKER_RUNTIME = "docker"
+KUBERNETES_WORKER_RUNTIME = "kubernetes"
 
 _COREWEAVE_TOPOLOGY_LABEL_PREFIXES = (
     "backend.coreweave.cloud/",
@@ -955,8 +957,11 @@ def _validate_worker_defaults(config: IrisClusterConfig) -> None:
         raise ValueError("defaults.worker.docker_image is required for non-local platforms (gcp/manual/coreweave).")
 
     runtime = config.defaults.worker.runtime.strip()
-    if runtime and runtime not in ("docker", "kubernetes"):
-        raise ValueError(f"defaults.worker.runtime must be 'docker' or 'kubernetes', got {runtime!r}.")
+    if runtime and runtime not in (DOCKER_WORKER_RUNTIME, KUBERNETES_WORKER_RUNTIME):
+        raise ValueError(
+            f"defaults.worker.runtime must be {DOCKER_WORKER_RUNTIME!r} or {KUBERNETES_WORKER_RUNTIME!r}, "
+            f"got {runtime!r}."
+        )
 
 
 def _validate_gcp_service_accounts(config: IrisClusterConfig) -> None:


### PR DESCRIPTION
Build controller and worker images for amd64 only. Kubernetes deployments skip
the unused worker image and build the task image for amd64 and arm64; VM
deployments build their required images for amd64. `--image-platform` remains
available as a task-image override.

Multi-architecture builds now import the native per-architecture caches emitted
by the scheduled image workflow. A current arm64 cache avoids repeating the
task image's Debian, Node.js, Rust, and profiling-tool installation under QEMU.
The scheduled workflow builds arm64 only for the task target on a native runner.
