### PR TITLE
Add durable JSONL GPU telemetry writer

### DIFF
--- a/lib/marin/src/marin/monitoring/gpu_telemetry.py
+++ b/lib/marin/src/marin/monitoring/gpu_telemetry.py
@@ -1,0 +1,268 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Durable GPU telemetry capture for training jobs.
+
+The sampler runs outside the trainer process so JAX compilation, checkpointing,
+or a busy Python runtime cannot delay telemetry collection. The parent process
+starts the sampler with :func:`nvidia_smi_telemetry`; the child process runs
+``nvidia-smi``, parses rows from stdout, and writes JSONL chunks to a remote
+``fsspec`` URI through :class:`marin.monitoring.jsonl_writer.JsonlChunkWriter`.
+If the pod disappears, already-flushed chunks remain durable and only queued or
+in-flight records can be lost.
+"""
+
+import contextlib
+import csv
+import datetime as dt
+import json
+import logging
+import multiprocessing
+import select
+import shutil
+import subprocess
+import sys
+from collections.abc import Iterator
+from dataclasses import dataclass
+from multiprocessing.synchronize import Event as EventType
+from pathlib import Path
+
+from marin.monitoring.jsonl_writer import BackpressurePolicy, JsonlChunkWriter, JsonlChunkWriterConfig
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_NVIDIA_SMI_FIELDS = (
+    "timestamp",
+    "index",
+    "name",
+    "uuid",
+    "utilization.gpu",
+    "utilization.memory",
+    "memory.used",
+    "memory.total",
+    "power.draw",
+    "pstate",
+    "clocks.sm",
+    "clocks.mem",
+    "temperature.gpu",
+)
+
+
+@dataclass(frozen=True)
+class NvidiaSmiTelemetryConfig:
+    """Configuration for a durable ``nvidia-smi`` telemetry process.
+
+    Args:
+        output_uri: Destination directory for JSONL chunks and manifest.
+        interval: Seconds between ``nvidia-smi`` samples.
+        records_per_chunk: Number of samples per durable JSONL chunk file.
+        max_queue_items: Maximum JSONL records queued in the writer actor before
+            backpressure policy is applied.
+        backpressure_policy: Whether telemetry writes block or drop when the
+            writer queue is full.
+        log_every: Log writer progress after this many accepted/dropped records.
+        query_fields: ``nvidia-smi --query-gpu`` fields.
+        command: Optional full command. Tests and non-NVIDIA probes can pass a
+            command that emits ``nvidia-smi --format=csv``-style output.
+        start_method: Multiprocessing start method used for the telemetry
+            process.
+        stop_timeout: Seconds to wait for graceful process shutdown before
+            terminating it.
+        require_command: Fail before training starts if the command executable
+            is not present.
+    """
+
+    output_uri: str
+    interval: float = 5.0
+    records_per_chunk: int = 120
+    max_queue_items: int = 10_000
+    backpressure_policy: BackpressurePolicy = BackpressurePolicy.BLOCK
+    log_every: int = 1_000
+    query_fields: tuple[str, ...] = DEFAULT_NVIDIA_SMI_FIELDS
+    command: tuple[str, ...] = ()
+    start_method: str = "spawn"
+    stop_timeout: float = 30.0
+    require_command: bool = True
+
+    def __post_init__(self) -> None:
+        if not self.output_uri:
+            raise ValueError("output_uri must be non-empty")
+        if self.interval <= 0:
+            raise ValueError("interval must be positive")
+        if self.records_per_chunk <= 0:
+            raise ValueError("records_per_chunk must be positive")
+        if self.max_queue_items <= 0:
+            raise ValueError("max_queue_items must be positive")
+        if self.log_every <= 0:
+            raise ValueError("log_every must be positive")
+        if isinstance(self.backpressure_policy, str):
+            object.__setattr__(self, "backpressure_policy", BackpressurePolicy(self.backpressure_policy))
+        if not isinstance(self.backpressure_policy, BackpressurePolicy):
+            raise ValueError("backpressure_policy must be a BackpressurePolicy")
+        if self.stop_timeout <= 0:
+            raise ValueError("stop_timeout must be positive")
+        if self.command and not self.command[0]:
+            raise ValueError("command executable must be non-empty")
+        if not self.command and not self.query_fields:
+            raise ValueError("query_fields must be non-empty when command is not set")
+
+
+def build_nvidia_smi_command(config: NvidiaSmiTelemetryConfig) -> tuple[str, ...]:
+    """Return the command used by the telemetry process."""
+    if config.command:
+        return config.command
+    return (
+        "nvidia-smi",
+        f"--query-gpu={','.join(config.query_fields)}",
+        "--format=csv",
+        "-l",
+        _format_seconds_for_nvidia_smi(config.interval),
+    )
+
+
+@dataclass(frozen=True)
+class NvidiaSmiTelemetryHandle:
+    """Handle for a running telemetry process."""
+
+    process: multiprocessing.Process
+    stop_event: EventType
+    stop_timeout: float
+
+    def stop(self) -> None:
+        """Request shutdown, flush the final chunk, and reap the process."""
+        self.stop_event.set()
+        self.process.join(timeout=self.stop_timeout)
+        if self.process.is_alive():
+            logger.warning("GPU telemetry process did not stop in %.1fs; terminating", self.stop_timeout)
+            self.process.terminate()
+            self.process.join(timeout=5.0)
+        if self.process.exitcode not in (0, None):
+            logger.warning("GPU telemetry process exited with code %s", self.process.exitcode)
+
+
+def start_nvidia_smi_telemetry(config: NvidiaSmiTelemetryConfig) -> NvidiaSmiTelemetryHandle:
+    """Start a background process that writes GPU telemetry JSONL chunks."""
+    command = build_nvidia_smi_command(config)
+    if config.require_command and shutil.which(command[0]) is None:
+        raise FileNotFoundError(f"GPU telemetry command not found: {command[0]}")
+    ctx = multiprocessing.get_context(config.start_method)
+    stop_event = ctx.Event()
+    process = ctx.Process(
+        target=run_nvidia_smi_telemetry,
+        args=(config, stop_event),
+        name="nvidia-smi-telemetry",
+        daemon=False,
+    )
+    process.start()
+    return NvidiaSmiTelemetryHandle(process=process, stop_event=stop_event, stop_timeout=config.stop_timeout)
+
+
+@contextlib.contextmanager
+def nvidia_smi_telemetry(config: NvidiaSmiTelemetryConfig) -> Iterator[NvidiaSmiTelemetryHandle]:
+    """Run durable GPU telemetry while the body executes."""
+    handle = start_nvidia_smi_telemetry(config)
+    try:
+        yield handle
+    finally:
+        handle.stop()
+
+
+def run_nvidia_smi_telemetry(config: NvidiaSmiTelemetryConfig, stop_event: EventType) -> None:
+    """Run ``nvidia-smi`` and write parsed samples as JSONL chunks."""
+    command = build_nvidia_smi_command(config)
+    writer_config = JsonlChunkWriterConfig(
+        output_uri=config.output_uri,
+        records_per_chunk=config.records_per_chunk,
+        max_queue_items=config.max_queue_items,
+        backpressure_policy=config.backpressure_policy,
+        log_every=config.log_every,
+    )
+    process: subprocess.Popen[str] | None = None
+    with JsonlChunkWriter(writer_config) as writer:
+        writer.write(
+            {
+                "record_type": "metadata",
+                "timestamp_utc": dt.datetime.now(dt.UTC).isoformat(),
+                "command": list(command),
+                "query_fields": list(config.query_fields),
+                "interval": config.interval,
+            }
+        )
+        try:
+            process = subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+            )
+            assert process.stdout is not None
+            header: list[str] | None = None
+            while not stop_event.is_set():
+                ready, _, _ = select.select([process.stdout], [], [], 1.0)
+                if not ready:
+                    if process.poll() is not None:
+                        break
+                    continue
+                line = process.stdout.readline()
+                if line == "":
+                    if process.poll() is not None:
+                        break
+                    continue
+                row = next(csv.reader([line.rstrip("\n")]))
+                if header is None:
+                    header = [_normalize_field_name(field) for field in row]
+                    continue
+                values = {header[index]: value.strip() for index, value in enumerate(row) if index < len(header)}
+                writer.write(
+                    {
+                        "record_type": "gpu_sample",
+                        "timestamp_utc": dt.datetime.now(dt.UTC).isoformat(),
+                        "nvidia_smi": values,
+                    }
+                )
+            if process.poll() is not None and process.returncode not in (0, None):
+                stderr = process.stderr.read() if process.stderr is not None else ""
+                writer.write(
+                    {
+                        "record_type": "error",
+                        "timestamp_utc": dt.datetime.now(dt.UTC).isoformat(),
+                        "message": "telemetry command exited nonzero",
+                        "returncode": process.returncode,
+                        "stderr": stderr.strip(),
+                    }
+                )
+        finally:
+            if process is not None and process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=5.0)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5.0)
+            writer.write(
+                {
+                    "record_type": "metadata",
+                    "timestamp_utc": dt.datetime.now(dt.UTC).isoformat(),
+                    "event": "telemetry_stop",
+                }
+            )
+
+
+def _normalize_field_name(field: str) -> str:
+    field = field.strip()
+    if " [" in field:
+        field = field.split(" [", 1)[0]
+    return field.replace(".", "_").replace(" ", "_").replace("-", "_")
+
+
+def _format_seconds_for_nvidia_smi(seconds: float) -> str:
+    if seconds.is_integer():
+        return str(int(seconds))
+    return str(seconds)
+
+
+if __name__ == "__main__":
+    config_path = Path(sys.argv[1])
+    event = multiprocessing.Event()
+    run_nvidia_smi_telemetry(NvidiaSmiTelemetryConfig(**json.loads(config_path.read_text())), event)

--- a/lib/marin/src/marin/monitoring/jsonl_writer.py
+++ b/lib/marin/src/marin/monitoring/jsonl_writer.py
@@ -1,0 +1,302 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Actor-backed JSONL chunk writer for durable telemetry streams."""
+
+import dataclasses
+import datetime as dt
+import json
+import logging
+import posixpath
+import queue
+import threading
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+import fsspec
+
+logger = logging.getLogger(__name__)
+
+_DONE = object()
+
+
+class BackpressurePolicy(StrEnum):
+    """Queue behavior when the writer actor is full."""
+
+    BLOCK = "block"
+    DROP = "drop"
+
+
+@dataclass(frozen=True)
+class JsonlChunkWriterConfig:
+    """Configuration for :class:`JsonlChunkWriter`.
+
+    Args:
+        output_uri: Destination directory for ``parts/part-*.jsonl`` and
+            ``manifest.json``.
+        records_per_chunk: Number of records per durable chunk file.
+        max_queue_items: Maximum queued records before backpressure policy is
+            applied.
+        backpressure_policy: Whether ``write`` blocks or drops when the queue is
+            full.
+        log_every: Log writer progress after this many enqueued records.
+    """
+
+    output_uri: str
+    records_per_chunk: int = 120
+    max_queue_items: int = 10_000
+    backpressure_policy: BackpressurePolicy = BackpressurePolicy.BLOCK
+    log_every: int = 1_000
+
+    def __post_init__(self) -> None:
+        if not self.output_uri:
+            raise ValueError("output_uri must be non-empty")
+        if self.records_per_chunk <= 0:
+            raise ValueError("records_per_chunk must be positive")
+        if self.max_queue_items <= 0:
+            raise ValueError("max_queue_items must be positive")
+        if self.log_every <= 0:
+            raise ValueError("log_every must be positive")
+        if isinstance(self.backpressure_policy, str):
+            object.__setattr__(self, "backpressure_policy", BackpressurePolicy(self.backpressure_policy))
+        if not isinstance(self.backpressure_policy, BackpressurePolicy):
+            raise ValueError("backpressure_policy must be a BackpressurePolicy")
+
+
+@dataclass(frozen=True)
+class JsonlChunkWriterStats:
+    """Snapshot of writer counters."""
+
+    records_enqueued: int
+    records_written: int
+    records_dropped: int
+    chunks_written: int
+    bytes_written: int
+    max_queue_size_observed: int
+
+
+class JsonlChunkWriter:
+    """JSONL writer backed by a queue and writer thread.
+
+    ``write`` serializes the object and enqueues one JSON line. Remote I/O is
+    performed only by the writer thread. Queue backpressure is controlled by
+    ``JsonlChunkWriterConfig.backpressure_policy``.
+    """
+
+    def __init__(self, config: JsonlChunkWriterConfig):
+        self.config = config
+        self._queue: queue.Queue[str | object] = queue.Queue(maxsize=config.max_queue_items)
+        self._thread: threading.Thread | None = None
+        self._started_at: str | None = None
+        self._ended_at: str | None = None
+        self._chunks: list[dict[str, Any]] = []
+        self._records_enqueued = 0
+        self._records_written = 0
+        self._records_dropped = 0
+        self._chunks_written = 0
+        self._bytes_written = 0
+        self._max_queue_size_observed = 0
+        self._closed = False
+        self._writer_error: str | None = None
+
+    def __enter__(self) -> "JsonlChunkWriter":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.close()
+
+    def start(self) -> None:
+        """Start the writer actor thread."""
+        if self._thread is not None:
+            raise RuntimeError("JsonlChunkWriter is already started")
+        self._started_at = dt.datetime.now(dt.UTC).isoformat()
+        self._thread = threading.Thread(target=self._run_writer, name="jsonl-chunk-writer", daemon=False)
+        self._thread.start()
+
+    def write(self, obj: Any) -> bool:
+        """Serialize and enqueue one JSON object.
+
+        Returns ``True`` when the record was accepted. Returns ``False`` when
+        the object is not JSON-serializable, the writer is closed, or the queue
+        is full and ``backpressure_policy`` is ``DROP``.
+        """
+        try:
+            line = json.dumps(obj, default=_json_default, sort_keys=True, separators=(",", ":")) + "\n"
+        except (TypeError, ValueError):
+            self._records_dropped += 1
+            if self._records_dropped == 1 or self._records_dropped % self.config.log_every == 0:
+                logger.warning(
+                    "jsonl-writer dropping non-json record output_uri=%s dropped=%d",
+                    self.config.output_uri,
+                    self._records_dropped,
+                )
+            return False
+        if self._closed:
+            return False
+        self._raise_if_writer_failed()
+        if self.config.backpressure_policy is BackpressurePolicy.BLOCK:
+            self._put_record_with_backpressure(line)
+        else:
+            try:
+                self._queue.put_nowait(line)
+            except queue.Full:
+                self._raise_if_writer_failed()
+                self._records_dropped += 1
+                if self._records_dropped == 1 or self._records_dropped % self.config.log_every == 0:
+                    logger.warning(
+                        "jsonl-writer dropping records output_uri=%s queue_size=%d dropped=%d",
+                        self.config.output_uri,
+                        self._queue.qsize(),
+                        self._records_dropped,
+                    )
+                return False
+
+        self._records_enqueued += 1
+        queue_size = self._queue.qsize()
+        self._max_queue_size_observed = max(self._max_queue_size_observed, queue_size)
+        if self._records_enqueued % self.config.log_every == 0:
+            logger.info(
+                "jsonl-writer queued output_uri=%s enqueued=%d queue_size=%d dropped=%d",
+                self.config.output_uri,
+                self._records_enqueued,
+                queue_size,
+                self._records_dropped,
+            )
+        return True
+
+    def close(self) -> None:
+        """Signal completion, wait for final flush, and write the manifest."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._thread is not None and self._thread.is_alive():
+            self._put_done_signal()
+            self._thread.join()
+        if self._writer_error is not None:
+            raise RuntimeError(f"JSONL writer failed: {self._writer_error}")
+
+    def stats(self) -> JsonlChunkWriterStats:
+        """Return a best-effort counter snapshot."""
+        return JsonlChunkWriterStats(
+            records_enqueued=self._records_enqueued,
+            records_written=self._records_written,
+            records_dropped=self._records_dropped,
+            chunks_written=self._chunks_written,
+            bytes_written=self._bytes_written,
+            max_queue_size_observed=self._max_queue_size_observed,
+        )
+
+    def _put_record_with_backpressure(self, line: str) -> None:
+        while True:
+            self._raise_if_writer_failed()
+            try:
+                self._queue.put(line, timeout=1.0)
+                return
+            except queue.Full:
+                continue
+
+    def _put_done_signal(self) -> None:
+        while self._thread is not None and self._thread.is_alive():
+            try:
+                self._queue.put(_DONE, timeout=1.0)
+                return
+            except queue.Full:
+                continue
+
+    def _raise_if_writer_failed(self) -> None:
+        if self._writer_error is not None:
+            raise RuntimeError(f"JSONL writer failed: {self._writer_error}")
+        if self._thread is not None and not self._thread.is_alive() and not self._closed:
+            raise RuntimeError("JSONL writer thread exited before close")
+
+    def _run_writer(self) -> None:
+        part_index = 0
+        records: list[str] = []
+        try:
+            while True:
+                item = self._queue.get()
+                if item is _DONE:
+                    break
+                assert isinstance(item, str)
+                records.append(item)
+                if len(records) >= self.config.records_per_chunk:
+                    self._flush(records, part_index)
+                    part_index += 1
+                    records = []
+            if records:
+                self._flush(records, part_index)
+            self._ended_at = dt.datetime.now(dt.UTC).isoformat()
+            self._write_manifest(completed=True)
+        except Exception as exc:
+            self._writer_error = f"{type(exc).__name__}: {exc}"
+            self._ended_at = dt.datetime.now(dt.UTC).isoformat()
+            try:
+                self._write_manifest(completed=False)
+            except Exception:
+                logger.exception("jsonl-writer failed to write failure manifest output_uri=%s", self.config.output_uri)
+
+    def _flush(self, records: list[str], part_index: int) -> None:
+        relative_path = f"parts/part-{part_index:06d}.jsonl"
+        uri = f"{self.config.output_uri.rstrip('/')}/{relative_path}"
+        body = "".join(records)
+        self._write_text_file(uri, body)
+        byte_count = len(body.encode("utf-8"))
+        self._records_written += len(records)
+        self._chunks_written += 1
+        self._bytes_written += byte_count
+        self._chunks.append(
+            {
+                "path": relative_path,
+                "records": len(records),
+                "bytes": byte_count,
+                "written_at": dt.datetime.now(dt.UTC).isoformat(),
+            }
+        )
+        logger.info(
+            "jsonl-writer flush output_uri=%s part=%06d records=%d bytes=%d queue_size=%d dropped=%d",
+            self.config.output_uri,
+            part_index,
+            len(records),
+            byte_count,
+            self._queue.qsize(),
+            self._records_dropped,
+        )
+
+    def _write_manifest(self, *, completed: bool) -> None:
+        manifest = {
+            "started_at": self._started_at,
+            "ended_at": self._ended_at,
+            "completed": completed,
+            "error": self._writer_error,
+            "config": dataclasses.asdict(self.config),
+            "records_enqueued": self._records_enqueued,
+            "records_written": self._records_written,
+            "records_dropped": self._records_dropped,
+            "chunks_written": self._chunks_written,
+            "bytes_written": self._bytes_written,
+            "max_queue_size_observed": self._max_queue_size_observed,
+            "chunks": list(self._chunks),
+        }
+        manifest_uri = f"{self.config.output_uri.rstrip('/')}/manifest.json"
+        self._write_text_file(manifest_uri, json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+
+    @classmethod
+    def _write_text_file(cls, uri: str, body: str) -> None:
+        fs, path = fsspec.core.url_to_fs(uri)
+        parent = posixpath.dirname(path)
+        if parent:
+            fs.mkdirs(parent, exist_ok=True)
+        with fs.open(path, "wt") as f:
+            f.write(body)
+
+
+def _json_default(obj: Any) -> Any:
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return dataclasses.asdict(obj)
+    if isinstance(obj, dt.datetime):
+        return obj.isoformat()
+    raise TypeError(f"object of type {type(obj).__name__} is not JSON serializable")
+
+

--- a/scripts/smoke_jsonl_writer_s3.py
+++ b/scripts/smoke_jsonl_writer_s3.py
@@ -1,0 +1,82 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke-test the durable JSONL writer against an fsspec URI.
+
+This is intentionally tiny: read words from /usr/share/dict, enqueue them through
+JsonlChunkWriter, and verify the manifest was written. It is useful for checking
+that a cluster image has working fsspec/s3fs credentials without involving a GPU
+or a trainer.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import fsspec
+
+from marin.monitoring.jsonl_writer import BackpressurePolicy, JsonlChunkWriter, JsonlChunkWriterConfig
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Smoke-test JsonlChunkWriter against local/S3/GCS storage")
+    parser.add_argument("--output-uri", required=True, help="Destination directory, e.g. s3://bucket/prefix")
+    parser.add_argument("--dict-dir", default="/usr/share/dict", help="Directory containing a word list")
+    parser.add_argument("--max-words", type=int, default=10_000)
+    parser.add_argument("--records-per-chunk", type=int, default=1_000)
+    parser.add_argument("--max-queue-items", type=int, default=2_000)
+    args = parser.parse_args()
+
+    config = JsonlChunkWriterConfig(
+        output_uri=args.output_uri,
+        records_per_chunk=args.records_per_chunk,
+        max_queue_items=args.max_queue_items,
+        backpressure_policy=BackpressurePolicy.BLOCK,
+        log_every=args.records_per_chunk,
+    )
+    word_path = _find_word_list(Path(args.dict_dir))
+    print(f"Reading up to {args.max_words} words from {word_path}")
+    print(f"Writing JSONL chunks to {args.output_uri}")
+
+    with JsonlChunkWriter(config) as writer:
+        for index, word in enumerate(_read_words(word_path, args.max_words)):
+            writer.write({"index": index, "word": word, "source_path": str(word_path)})
+
+    manifest_uri = f"{args.output_uri.rstrip('/')}/manifest.json"
+    with fsspec.open(manifest_uri, "rt") as f:
+        manifest = json.load(f)
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+    expected = min(args.max_words, _count_words(word_path, args.max_words))
+    if manifest["records_written"] != expected:
+        raise RuntimeError(f"expected {expected} records, wrote {manifest['records_written']}")
+
+
+def _find_word_list(dict_dir: Path) -> Path:
+    candidates = [dict_dir / "words", dict_dir / "web2", dict_dir / "linux.words"]
+    for candidate in candidates:
+        if candidate.exists() and candidate.is_file():
+            return candidate
+    for candidate in sorted(dict_dir.iterdir() if dict_dir.exists() else []):
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(f"no word list found under {dict_dir}")
+
+
+def _read_words(path: Path, max_words: int):
+    with path.open() as f:
+        for line in f:
+            word = line.strip()
+            if not word:
+                continue
+            yield word
+            max_words -= 1
+            if max_words <= 0:
+                return
+
+
+def _count_words(path: Path, max_words: int) -> int:
+    return sum(1 for _ in _read_words(path, max_words))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/monitoring/test_gpu_telemetry.py
+++ b/tests/monitoring/test_gpu_telemetry.py
@@ -1,0 +1,114 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import multiprocessing
+import sys
+import time
+
+from marin.monitoring.gpu_telemetry import NvidiaSmiTelemetryConfig, nvidia_smi_telemetry, run_nvidia_smi_telemetry
+
+
+def _csv_command(row_count: int) -> tuple[str, ...]:
+    script = "\n".join(
+        [
+            "print('timestamp, index, utilization.gpu [%], memory.used [MiB]')",
+            *[f"print('2026-07-24 00:00:{i:02d}, 0, {10 + i} %, {100 + i} MiB')" for i in range(row_count)],
+        ]
+    )
+    return (sys.executable, "-c", script)
+
+
+def _read_jsonl_parts(path):
+    records = []
+    for part in sorted((path / "parts").glob("part-*.jsonl")):
+        records.extend(json.loads(line) for line in part.read_text().splitlines())
+    return records
+
+
+def test_run_nvidia_smi_telemetry_writes_metadata_samples_and_manifest(tmp_path):
+    config = NvidiaSmiTelemetryConfig(
+        output_uri=str(tmp_path / "telemetry"),
+        command=_csv_command(5),
+        records_per_chunk=3,
+        max_queue_items=10,
+        log_every=10,
+    )
+
+    run_nvidia_smi_telemetry(config, multiprocessing.Event())
+
+    records = _read_jsonl_parts(tmp_path / "telemetry")
+    assert [record["record_type"] for record in records] == [
+        "metadata",
+        "gpu_sample",
+        "gpu_sample",
+        "gpu_sample",
+        "gpu_sample",
+        "gpu_sample",
+        "metadata",
+    ]
+    assert records[1]["nvidia_smi"] == {
+        "timestamp": "2026-07-24 00:00:00",
+        "index": "0",
+        "utilization_gpu": "10 %",
+        "memory_used": "100 MiB",
+    }
+
+    manifest = json.loads((tmp_path / "telemetry" / "manifest.json").read_text())
+    assert manifest["completed"] is True
+    assert manifest["records_written"] == 7
+    assert [chunk["records"] for chunk in manifest["chunks"]] == [3, 3, 1]
+
+
+def test_context_manager_stops_silent_command_before_timeout(tmp_path):
+    script = "\n".join(
+        [
+            "import time",
+            "print('timestamp, index, utilization.gpu [%]', flush=True)",
+            "time.sleep(60)",
+        ]
+    )
+    config = NvidiaSmiTelemetryConfig(
+        output_uri=str(tmp_path / "telemetry"),
+        command=(sys.executable, "-c", script),
+        records_per_chunk=10,
+        max_queue_items=10,
+        log_every=10,
+        stop_timeout=10,
+        start_method="fork",
+    )
+
+    started_at = time.monotonic()
+    with nvidia_smi_telemetry(config):
+        pass
+
+    assert time.monotonic() - started_at < 5
+    manifest = json.loads((tmp_path / "telemetry" / "manifest.json").read_text())
+    assert manifest["completed"] is True
+    assert manifest["records_written"] == 2
+    assert [record["event"] for record in _read_jsonl_parts(tmp_path / "telemetry") if "event" in record] == [
+        "telemetry_stop"
+    ]
+
+
+def test_context_manager_runs_telemetry_in_child_process(tmp_path):
+    config = NvidiaSmiTelemetryConfig(
+        output_uri=str(tmp_path / "telemetry"),
+        command=_csv_command(3),
+        records_per_chunk=10,
+        max_queue_items=10,
+        log_every=10,
+        stop_timeout=10,
+        start_method="fork",
+    )
+
+    with nvidia_smi_telemetry(config) as handle:
+        assert handle.process.pid is not None
+        assert handle.process.pid != multiprocessing.current_process().pid
+        handle.process.join(timeout=10)
+        assert handle.process.exitcode == 0
+
+    manifest = json.loads((tmp_path / "telemetry" / "manifest.json").read_text())
+    assert manifest["completed"] is True
+    assert manifest["records_written"] == 5
+    assert len([record for record in _read_jsonl_parts(tmp_path / "telemetry") if record["record_type"] == "gpu_sample"]) == 3

--- a/tests/monitoring/test_jsonl_writer.py
+++ b/tests/monitoring/test_jsonl_writer.py
@@ -1,0 +1,101 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+import datetime as dt
+import json
+import time
+
+import pytest
+
+from marin.monitoring.jsonl_writer import JsonlChunkWriter, JsonlChunkWriterConfig
+
+
+@dataclasses.dataclass(frozen=True)
+class SampleRecord:
+    name: str
+    created_at: dt.datetime
+    values: tuple[int, int]
+
+
+class FailingJsonlChunkWriter(JsonlChunkWriter):
+    @classmethod
+    def _write_text_file(cls, uri: str, body: str) -> None:
+        raise OSError("simulated object store failure")
+
+
+def _read_jsonl(path):
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def test_jsonl_writer_persists_chunks_and_manifest(tmp_path):
+    config = JsonlChunkWriterConfig(output_uri=str(tmp_path / "telemetry"), records_per_chunk=2, max_queue_items=10)
+
+    with JsonlChunkWriter(config) as writer:
+        assert writer.write({"i": 0}) is True
+        assert writer.write({"i": 1}) is True
+        assert writer.write({"i": 2}) is True
+
+    telemetry_dir = tmp_path / "telemetry"
+    parts = sorted((telemetry_dir / "parts").glob("part-*.jsonl"))
+    assert [_read_jsonl(part) for part in parts] == [[{"i": 0}, {"i": 1}], [{"i": 2}]]
+
+    manifest = json.loads((telemetry_dir / "manifest.json").read_text())
+    assert manifest["completed"] is True
+    assert manifest["records_enqueued"] == 3
+    assert manifest["records_written"] == 3
+    assert manifest["records_dropped"] == 0
+    assert [chunk["records"] for chunk in manifest["chunks"]] == [2, 1]
+
+
+def test_jsonl_writer_serializes_native_containers_and_dataclasses(tmp_path):
+    config = JsonlChunkWriterConfig(output_uri=str(tmp_path / "telemetry"), records_per_chunk=10, max_queue_items=10)
+    created_at = dt.datetime(2026, 7, 24, 12, 34, tzinfo=dt.UTC)
+
+    with JsonlChunkWriter(config) as writer:
+        assert writer.write(
+            {
+                "string": "value",
+                "list": [1, "two", {"three": 3}],
+                "tuple": (4, 5),
+                "dataclass": SampleRecord("sample", created_at, (6, 7)),
+            }
+        ) is True
+
+    assert _read_jsonl(tmp_path / "telemetry" / "parts" / "part-000000.jsonl") == [
+        {
+            "dataclass": {"created_at": "2026-07-24T12:34:00+00:00", "name": "sample", "values": [6, 7]},
+            "list": [1, "two", {"three": 3}],
+            "string": "value",
+            "tuple": [4, 5],
+        }
+    ]
+
+
+def test_jsonl_writer_raises_after_chunk_write_failure(tmp_path):
+    config = JsonlChunkWriterConfig(output_uri=str(tmp_path / "telemetry"), records_per_chunk=1, max_queue_items=1)
+    writer = FailingJsonlChunkWriter(config)
+    writer.start()
+
+    assert writer.write({"i": 0}) is True
+    deadline = time.monotonic() + 5
+    while writer._writer_error is None and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    with pytest.raises(RuntimeError, match="simulated object store failure"):
+        writer.write({"i": 1})
+    with pytest.raises(RuntimeError, match="simulated object store failure"):
+        writer.close()
+
+
+def test_jsonl_writer_drops_non_json_records_without_blocking(tmp_path):
+    config = JsonlChunkWriterConfig(output_uri=str(tmp_path / "telemetry"), records_per_chunk=10, max_queue_items=10)
+
+    with JsonlChunkWriter(config) as writer:
+        assert writer.write({"ok": True}) is True
+        assert writer.write({"bad": object()}) is False
+
+    manifest = json.loads((tmp_path / "telemetry" / "manifest.json").read_text())
+    assert manifest["records_written"] == 1
+    assert manifest["records_dropped"] == 1
+    assert _read_jsonl(tmp_path / "telemetry" / "parts" / "part-000000.jsonl") == [{"ok": True}]


### PR DESCRIPTION
## Summary
- add actor-backed JSONL chunk writer for durable fsspec telemetry streams
- add nvidia-smi telemetry process wrapper that writes parsed samples as JSONL
- add smoke script for verifying JSONL writes against local/S3/GCS fsspec URIs

## Validation
- PYTHONPATH=lib/marin/src /tmp/marinfold-embed-venv/bin/python -m pytest -o addopts='' --confcutdir=tests/monitoring tests/monitoring/test_jsonl_writer.py tests/monitoring/test_gpu_telemetry.py -q
- python3 -m py_compile lib/marin/src/marin/monitoring/jsonl_writer.py lib/marin/src/marin/monitoring/gpu_telemetry.py scripts/smoke_jsonl_writer_s3.py
- CoreWeave S3 smoke wrote/read 10k JSONL records
