### PR TITLE
Enable sccache for Rust builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustc-wrapper = "sccache"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,14 @@
 [build]
 rustc-wrapper = "sccache"
+
+# Link native Linux builds with mold (a fast, multi-threaded linker) to cut
+# link time. Fail-closed like the sccache wrapper above: every native cargo
+# build in the tree needs mold on PATH (installed in Rust CI, the Iris task
+# image, and per docs/tutorials/installation.md for local source builds). The
+# zig-cross release-wheel builds supply their own linker and can't consume this
+# flag, so they clear RUSTFLAGS in lib/{finelog,dupekit}/build_package.py.
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/.github/workflows/dupekit-release-wheels.yaml
+++ b/.github/workflows/dupekit-release-wheels.yaml
@@ -34,6 +34,7 @@ on:
     # already covers them. Nightly/tag/dispatch are unaffected by this filter
     # (the stale check below scopes broadly to all of lib/dupekit/).
     paths:
+      - ".cargo/config.toml"
       - "lib/dupekit/rust/**"
       - "lib/dupekit/pyproject.toml"
       - "lib/dupekit/build_package.py"
@@ -45,6 +46,9 @@ concurrency:
 
 permissions:
   contents: read
+
+env:
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   resolve:
@@ -134,6 +138,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
       - uses: astral-sh/setup-uv@v7
 
       - name: Build wheels

--- a/.github/workflows/finelog-release-wheels.yaml
+++ b/.github/workflows/finelog-release-wheels.yaml
@@ -42,6 +42,7 @@ on:
     # Only the wheel-build inputs gate this expensive (4-target, zig-cross)
     # smoke. See the header comment for why src/** is intentionally excluded.
     paths:
+      - ".cargo/config.toml"
       - "lib/finelog/rust/**"
       - "lib/finelog/pyproject.toml"
       - "lib/finelog/build_package.py"
@@ -53,6 +54,9 @@ concurrency:
 
 permissions:
   contents: read
+
+env:
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   resolve:
@@ -142,6 +146,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
       - uses: astral-sh/setup-uv@v7
 
       - name: Build wheels

--- a/.github/workflows/iris-native-release-wheels.yaml
+++ b/.github/workflows/iris-native-release-wheels.yaml
@@ -18,6 +18,7 @@ on:
       - "iris-native-v*"
   pull_request:
     paths:
+      - ".cargo/config.toml"
       - "lib/iris/rust/**"
       - ".github/workflows/iris-native-release-wheels.yaml"
 
@@ -27,6 +28,9 @@ concurrency:
 
 permissions:
   contents: read
+
+env:
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
   resolve:
@@ -98,6 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
       - uses: astral-sh/setup-uv@v7
 
       - name: Build platform wheel

--- a/.github/workflows/iris-native-release-wheels.yaml
+++ b/.github/workflows/iris-native-release-wheels.yaml
@@ -103,6 +103,11 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+      # Native Linux legs link with mold via .cargo/config.toml; the macOS leg
+      # builds for a darwin target the flag never matches.
+      - name: Install mold
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends mold
       - uses: astral-sh/setup-uv@v7
 
       - name: Build platform wheel

--- a/.github/workflows/rust-checks.yaml
+++ b/.github/workflows/rust-checks.yaml
@@ -12,6 +12,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  SCCACHE_GHA_ENABLED: "true"
+
 # cargo fmt/clippy/test for the dupekit, finelog, and Iris native crates, plus a guard that
 # no rust dev-mode source leaked into a committed pyproject. The `changes` job always
 # runs so the downstream jobs report a status on every PR (a workflow-level `paths:`
@@ -35,12 +38,15 @@ jobs:
           filters: |
             dupekit:
               - 'lib/dupekit/rust/**'
+              - '.cargo/config.toml'
               - '.github/workflows/rust-checks.yaml'
             finelog:
               - 'lib/finelog/rust/**'
+              - '.cargo/config.toml'
               - '.github/workflows/rust-checks.yaml'
             iris:
               - 'lib/iris/rust/**'
+              - '.cargo/config.toml'
               - '.github/workflows/rust-checks.yaml'
             # The dev-mode guard inspects the pyprojects a leaked rust path source
             # lands in, plus the script that writes it.
@@ -78,6 +84,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: clippy, rustfmt
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           workspaces: lib/dupekit/rust
@@ -98,6 +105,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: clippy, rustfmt
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           workspaces: lib/finelog/rust
@@ -118,6 +126,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: clippy, rustfmt
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           workspaces: lib/iris/rust

--- a/.github/workflows/rust-checks.yaml
+++ b/.github/workflows/rust-checks.yaml
@@ -85,6 +85,8 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+      - name: Install mold
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends mold
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           workspaces: lib/dupekit/rust
@@ -106,6 +108,8 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+      - name: Install mold
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends mold
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           workspaces: lib/finelog/rust
@@ -127,6 +131,8 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+      - name: Install mold
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends mold
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           workspaces: lib/iris/rust

--- a/.github/workflows/unified-unit.yaml
+++ b/.github/workflows/unified-unit.yaml
@@ -13,6 +13,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  SCCACHE_GHA_ENABLED: "true"
+
 jobs:
   select:
     runs-on: ubuntu-latest
@@ -74,6 +77,9 @@ jobs:
       - name: Install Rust toolchain
         if: matrix.setup == 'rust'
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - name: Install sccache
+        if: matrix.setup == 'rust'
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
       - name: Cache cargo build
         if: matrix.setup == 'rust'
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1

--- a/.github/workflows/unified-unit.yaml
+++ b/.github/workflows/unified-unit.yaml
@@ -80,6 +80,9 @@ jobs:
       - name: Install sccache
         if: matrix.setup == 'rust'
         uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+      - name: Install mold
+        if: matrix.setup == 'rust'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends mold
       - name: Cache cargo build
         if: matrix.setup == 'rust'
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1

--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -126,6 +126,9 @@ no Rust toolchain needed. `uv sync` fetches the wheels from PyPI automatically.
 To switch to **source builds** (requires Cargo), use the Makefile targets:
 
 ```bash
+# Cargo builds use sccache; install it separately before enabling dev mode.
+cargo install sccache --locked
+
 # Check current mode and Cargo availability
 make rust-status
 

--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -126,7 +126,11 @@ no Rust toolchain needed. `uv sync` fetches the wheels from PyPI automatically.
 To switch to **source builds** (requires Cargo), use the Makefile targets:
 
 ```bash
-# Cargo builds use sccache; install it separately before enabling dev mode.
+# Source builds cache compiles with sccache and, on Linux, link with mold.
+# Install both before enabling dev mode: mold from your package manager (Linux
+# only — macOS builds use the default linker), then sccache from crates.io with
+# the repo cargo wrapper disabled so it can bootstrap before sccache exists.
+sudo apt-get install -y mold          # Linux only; skip on macOS
 CARGO_BUILD_RUSTC_WRAPPER= cargo install sccache --locked
 
 # Check current mode and Cargo availability

--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -127,7 +127,7 @@ To switch to **source builds** (requires Cargo), use the Makefile targets:
 
 ```bash
 # Cargo builds use sccache; install it separately before enabling dev mode.
-cargo install sccache --locked
+CARGO_BUILD_RUSTC_WRAPPER= cargo install sccache --locked
 
 # Check current mode and Cargo availability
 make rust-status

--- a/lib/dupekit/build_package.py
+++ b/lib/dupekit/build_package.py
@@ -333,6 +333,11 @@ def _build_wheels(targets: list[tuple[str, str | None]], use_zig: bool) -> None:
     if use_zig:
         zig_dir = str(Path(_ensure_zig()).parent)
         env = {**os.environ, "PATH": f"{zig_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+        # The repo .cargo/config.toml links native Linux builds with mold, but
+        # zig supplies its own linker and can't consume `-fuse-ld=mold`. Clearing
+        # RUSTFLAGS drops that flag for the cross build; the sccache rustc-wrapper
+        # (a separate config key) is unaffected and keeps caching.
+        env["RUSTFLAGS"] = ""
 
     for triple, manylinux in targets:
         print(f"\n--- Building wheel for {triple} ---")

--- a/lib/dupekit/rust/Cargo.toml
+++ b/lib/dupekit/rust/Cargo.toml
@@ -24,8 +24,9 @@ rand_pcg = "0.3"
 regex = "1.10"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 
-# thin-LTO: within ~1% of fat-LTO runtime at a fraction of the link time.
+# No LTO: parallel codegen keeps the build fast, trading a few percent of
+# runtime we don't need here for a much shorter link.
 [profile.release]
-lto = "thin"
+lto = false
 codegen-units = 16
 strip = "symbols"

--- a/lib/finelog/build_package.py
+++ b/lib/finelog/build_package.py
@@ -334,6 +334,11 @@ def _build_wheels(targets: list[tuple[str, str | None]], use_zig: bool) -> None:
     if use_zig:
         zig_dir = str(Path(_ensure_zig()).parent)
         env = {**os.environ, "PATH": f"{zig_dir}{os.pathsep}{os.environ.get('PATH', '')}"}
+        # The repo .cargo/config.toml links native Linux builds with mold, but
+        # zig supplies its own linker and can't consume `-fuse-ld=mold`. Clearing
+        # RUSTFLAGS drops that flag for the cross build; the sccache rustc-wrapper
+        # (a separate config key) is unaffected and keeps caching.
+        env["RUSTFLAGS"] = ""
 
     for triple, manylinux in targets:
         print(f"\n--- Building wheel for {triple} ---")

--- a/lib/finelog/deploy/Dockerfile
+++ b/lib/finelog/deploy/Dockerfile
@@ -33,18 +33,19 @@ RUN npm run build
 # system protoc is needed.
 FROM rust:1-bookworm AS rustbuild
 
-# Cargo profile to build. Defaults to the fat-LTO `release` profile for
-# production images. Dev/test deploys pass `--build-arg CARGO_PROFILE=fast`
-# (no LTO, parallel codegen) for a far faster final link; see `[profile.fast]`
-# in lib/finelog/rust/Cargo.toml. The profile name is also the target/<profile>/ subdir
-# (true for `release` and any custom profile), so the cp below resolves it.
+# Cargo profile to build. Defaults to the `release` profile for production
+# images. Dev/test deploys pass `--build-arg CARGO_PROFILE=fast` (opt-level 2)
+# for a slightly faster build; see `[profile.fast]` in lib/finelog/rust/Cargo.toml.
+# The profile name is also the target/<profile>/ subdir (true for `release` and
+# any custom profile), so the cp below resolves it.
 ARG CARGO_PROFILE=release
 
 # mold: a fast, multi-threaded linker. The cargo build runs under `mold -run`,
 # which redirects the default linker to mold without touching RUSTFLAGS — so the
 # cargo build fingerprint is unchanged and the cached dependency rlibs stay valid
-# (no cache-busting full rebuild). Speeds the final binary link on both profiles;
-# the win is largest with `fast` (no LTO), where linking dominates. Installed
+# (no cache-busting full rebuild). This stage copies only lib/finelog/rust, so it
+# never sees the repo .cargo/config.toml that points other builds at mold. Neither
+# profile uses LTO, so linking dominates and the win is large on both. Installed
 # before the source COPY so the apt layer caches across source edits.
 RUN apt-get update && apt-get install -y --no-install-recommends mold \
     && rm -rf /var/lib/apt/lists/*

--- a/lib/finelog/rust/Cargo.toml
+++ b/lib/finelog/rust/Cargo.toml
@@ -6,22 +6,21 @@
 members = ["pyext"]
 resolver = "2"
 
-# Thin LTO + parallel codegen. Within ~1% of fat-LTO runtime, but builds in a
-# fraction of the time: fat LTO + codegen-units=1 is a single-threaded
-# multi-minute link over the whole datafusion/arrow tree. Applies to every
+# No LTO + parallel codegen. Fat LTO + codegen-units=1 is a single-threaded
+# multi-minute link over the whole datafusion/arrow tree; dropping LTO trades a
+# few percent of runtime we don't need for a much shorter link. Applies to every
 # workspace member — the finelog-server binary and the finelog/pyext cdylib.
 [profile.release]
-lto = "thin"
+lto = false
 codegen-units = 16
 strip = "symbols"
 
-# Even-faster iteration profile for dev/test deploys (e.g. marin-dev): drops LTO
-# entirely and opt-level to 2 on top of release's parallel codegen. Still
-# optimized enough to be representative. The deploy Dockerfile passes
+# Even-faster iteration profile for dev/test deploys (e.g. marin-dev): lowers
+# opt-level to 2 on top of release's non-LTO parallel codegen. Still optimized
+# enough to be representative. The deploy Dockerfile passes
 # `--build-arg CARGO_PROFILE=fast`.
 [profile.fast]
 inherits = "release"
-lto = false
 opt-level = 2
 
 [package]

--- a/lib/iris/Dockerfile
+++ b/lib/iris/Dockerfile
@@ -34,7 +34,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.10.3 /uv /uvx /bin/
 WORKDIR /build/iris-native
 COPY lib/iris/rust/ ./
 # Direct Docker builds use release. Iris CLI builds default to fast, which
-# keeps optimized parallel codegen but skips LTO.
+# lowers opt-level to 2; neither profile uses LTO.
 ARG CARGO_PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     uvx --python 3.12 --from 'maturin>=1.5,<2.0' maturin build \
@@ -215,6 +215,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     build-essential \
     sccache \
+    mold \
     ffmpeg \
     lldb \
     libibverbs1 \

--- a/lib/iris/Dockerfile
+++ b/lib/iris/Dockerfile
@@ -214,6 +214,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssh-client \
     git \
     build-essential \
+    sccache \
     ffmpeg \
     lldb \
     libibverbs1 \

--- a/lib/iris/rust/Cargo.toml
+++ b/lib/iris/rust/Cargo.toml
@@ -2,16 +2,17 @@
 members = ["pyext"]
 resolver = "2"
 
+# No LTO: parallel codegen and a short link over a runtime few-percent we don't
+# need. Matches finelog's release profile.
 [profile.release]
-lto = "thin"
+lto = false
 codegen-units = 16
 strip = "symbols"
 
-# Match finelog's dev/test deployment profile: keep parallel optimized codegen
-# while avoiding LTO's slow final link.
+# Even-faster iteration profile for dev/test deploys: lowers opt-level to 2 on
+# top of release's non-LTO parallel codegen. Matches finelog's `fast`.
 [profile.fast]
 inherits = "release"
-lto = false
 opt-level = 2
 
 [package]


### PR DESCRIPTION
Keep Cargo target artifacts local to each checkout and use sccache to reuse compiler outputs across worktrees. Local source builds select sccache through the repository Cargo config.

Rust checks, source-build unit jobs, and native wheel builds install sccache and use the GitHub Actions cache backend. The Iris task image also provides sccache for remote rust-dev builds. The installation guide documents how to bootstrap the separate dependency without invoking the configured wrapper.
