### PR TITLE
[iris] Wait for old gang pods before retry

### DIFF
--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -50,7 +50,7 @@ from iris.cluster.controller.backend import (
 from iris.cluster.controller.ops.task import apply_dispatch_updates
 from iris.cluster.controller.reconcile.loader import TransitionReader
 from iris.cluster.controller.reconcile.snapshot import TaskUpdate
-from iris.cluster.controller.task_state import RunningTaskEntry, StoppingTaskEntry
+from iris.cluster.controller.task_state import ACTIVE_TASK_STATES, TaskAttemptEntry
 from iris.cluster.controller.worker_health import WorkerHealthTracker
 from iris.cluster.platforms.k8s.constants import COREWEAVE_INTERRUPTABLE_TOLERATION, NVIDIA_GPU_TOLERATION
 from iris.cluster.platforms.k8s.coreweave_topology import (
@@ -1066,7 +1066,7 @@ def _is_infrastructure_failure(pod: dict) -> bool:
     return terminated.get("reason", "") in _INFRASTRUCTURE_FAILURE_REASONS
 
 
-def _task_update_from_pod(entry: RunningTaskEntry, pod: dict, workload: dict | None = None) -> TaskUpdate:
+def _task_update_from_pod(entry: TaskAttemptEntry, pod: dict, workload: dict | None = None) -> TaskUpdate:
     """Build a TaskUpdate from a Kubernetes Pod dict.
 
     Infrastructure failures (eviction, preemption) are reported as WORKER_FAILED
@@ -2065,16 +2065,17 @@ class TaskEventLog:
 
     def __init__(self, task_event_table: Table):
         self._table = task_event_table
-        self._last_verdict: dict[RunningTaskEntry, tuple[str, str, TaskEventSeverity]] = {}
+        self._last_verdict: dict[tuple[JobName, int, str], tuple[str, str, TaskEventSeverity]] = {}
 
-    def observe(self, attempt: RunningTaskEntry, event: _PodEvent | None) -> None:
+    def observe(self, attempt: TaskAttemptEntry, event: _PodEvent | None) -> None:
         """Record ``event`` for ``attempt`` if its verdict has changed."""
         if event is None:
             return
+        attempt_key = (attempt.task_id, attempt.attempt_id, attempt.attempt_uid)
         verdict = (event.source, event.reason, event.severity)
-        if self._last_verdict.get(attempt) == verdict:
+        if self._last_verdict.get(attempt_key) == verdict:
             return
-        self._last_verdict[attempt] = verdict
+        self._last_verdict[attempt_key] = verdict
         row = TaskEventRow(
             task_id=attempt.task_id.to_wire(),
             attempt_id=attempt.attempt_id,
@@ -2091,10 +2092,11 @@ class TaskEventLog:
         except Exception:
             logger.debug("TaskEventLog: write to iris.task_event failed", exc_info=True)
 
-    def retain(self, active: set[RunningTaskEntry]) -> None:
+    def retain(self, active: set[TaskAttemptEntry]) -> None:
         """Forget verdicts for attempts not in ``active`` (terminal or gone)."""
+        active_keys = {(attempt.task_id, attempt.attempt_id, attempt.attempt_uid) for attempt in active}
         for key in list(self._last_verdict):
-            if key not in active:
+            if key not in active_keys:
                 del self._last_verdict[key]
 
 
@@ -2277,7 +2279,7 @@ class K8sTaskProvider:
 
     A cluster :class:`~iris.cluster.controller.backend.TaskBackend`: Kueue owns
     placement, so ``schedule`` and ``autoscale`` are no-ops; ``reconcile``
-    consumes the dispatch drain (``tasks_to_run`` + ``running_tasks``) carried on
+    consumes the dispatch drain (``tasks_to_run`` + ``task_attempts``) carried on
     the :class:`ReconcileRequest` and returns neutral task ``updates``. K8s pods
     are launched and monitored directly via kubectl rather than through a worker
     gRPC daemon.
@@ -2357,7 +2359,7 @@ class K8sTaskProvider:
     # from, passed by the composer at construction (a cluster backend has no
     # worker store, so it reads its dispatch drain through this).
     transition_reader: TransitionReader | None = field(default=None, repr=False)
-    _pod_not_found_counts: dict[str, int] = field(default_factory=dict, init=False, repr=False)
+    _pod_not_found_counts: dict[tuple[JobName, int], int] = field(default_factory=dict, init=False, repr=False)
     # (task_id_wire, attempt_id) this process has dispatched a pod for. Those pods
     # were created under the current name, so their lookups must never consider the
     # pre-uid name — see _pod_name_candidates.
@@ -2478,10 +2480,9 @@ class K8sTaskProvider:
     def sync(self, request: ReconcileRequest) -> list[TaskUpdate]:
         """Sync task state: apply new pods, delete strays, poll running pods.
 
-        Kill targets are derived here, not buffered in the controller: any
-        managed pod whose ``(task_hash, attempt_id)`` is not in the desired
-        set (``tasks_to_run`` union ``running_tasks``) is deleted on this tick.
-        ``tasks_to_stop`` remains outside that set and is acknowledged only
+        The controller supplies every unfinished direct-provider attempt. Any
+        managed pod outside the active subset is deleted on this tick; an
+        inactive attempt remains in the snapshot and is acknowledged only
         after its pod leaves the active phase.
 
         New-pod application runs every tick so dispatch stays responsive; the
@@ -2550,10 +2551,13 @@ class K8sTaskProvider:
         if self.preempt_namespaces and _has_gated_gpu_pods(managed_pods):
             self._evict_preemptible_blockers(reason="GPU pods held SchedulingGated awaiting Kueue admission")
 
+        active_attempts = [entry for entry in request.task_attempts if entry.task_state in ACTIVE_TASK_STATES]
+        inactive_attempts = [entry for entry in request.task_attempts if entry.task_state not in ACTIVE_TASK_STATES]
+
         desired_keys: set[tuple[str, int]] = set()
         for run_req in request.tasks_to_run:
             desired_keys.add((_task_hash(run_req.task_id), int(run_req.attempt_id)))
-        for entry in request.running_tasks:
+        for entry in active_attempts:
             desired_keys.add((_task_hash(entry.task_id.to_wire()), int(entry.attempt_id)))
         self._delete_stray_pods(managed_pods, desired_keys)
 
@@ -2568,8 +2572,8 @@ class K8sTaskProvider:
 
         updates = (
             apply_failures
-            + self._poll_pods(request.running_tasks, managed_pods, workloads)
-            + self._poll_stopping_tasks(request.tasks_to_stop, managed_pods)
+            + self._poll_pods(active_attempts, managed_pods, workloads)
+            + self._poll_inactive_attempts(inactive_attempts, managed_pods)
         )
 
         try:
@@ -2595,7 +2599,7 @@ class K8sTaskProvider:
     def _lookup_entry_pod(
         self,
         pods_by_name: dict[str, dict],
-        entry: RunningTaskEntry | StoppingTaskEntry,
+        entry: TaskAttemptEntry,
     ) -> tuple[str, dict | None]:
         """Resolve an attempt to its pod, allowing pre-uid names only when this process did not dispatch it."""
         return _lookup_pod(
@@ -3096,7 +3100,7 @@ class K8sTaskProvider:
         return pods
 
     def _poll_pods(
-        self, running: list[RunningTaskEntry], cached_pods: list[dict], workloads: list[dict] | None = None
+        self, running: list[TaskAttemptEntry], cached_pods: list[dict], workloads: list[dict] | None = None
     ) -> list[TaskUpdate]:
         """Poll pod phases for all running tasks.
 
@@ -3146,7 +3150,7 @@ class K8sTaskProvider:
 
         for entry in running:
             pod_name, pod = self._lookup_entry_pod(pods_by_name, entry)
-            cursor_key = f"{entry.task_id.to_wire()}:{entry.attempt_id}"
+            cursor_key = (entry.task_id, entry.attempt_id)
             task_key = (entry.task_id.to_wire(), entry.attempt_id)
 
             if pod is None:
@@ -3207,9 +3211,9 @@ class K8sTaskProvider:
 
         return updates
 
-    def _poll_stopping_tasks(
+    def _poll_inactive_attempts(
         self,
-        stopping: list[StoppingTaskEntry],
+        inactive: list[TaskAttemptEntry],
         cached_pods: list[dict],
     ) -> list[TaskUpdate]:
         """Finalize stopped attempts once absent from the active-pod snapshot.
@@ -3219,11 +3223,11 @@ class K8sTaskProvider:
         """
         pods_by_name = {pod.get("metadata", {}).get("name", ""): pod for pod in cached_pods}
         updates: list[TaskUpdate] = []
-        for entry in stopping:
+        for entry in inactive:
             _, pod = self._lookup_entry_pod(pods_by_name, entry)
             if pod is not None:
                 continue
-            self._pod_not_found_counts.pop(f"{entry.task_id.to_wire()}:{entry.attempt_id}", None)
+            self._pod_not_found_counts.pop((entry.task_id, entry.attempt_id), None)
             # Requeue already made the attempt terminal; this update only stamps
             # finished_at_ms so the next dispatch cycle can promote its retry.
             updates.append(

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -50,7 +50,7 @@ from iris.cluster.controller.backend import (
 from iris.cluster.controller.ops.task import apply_dispatch_updates
 from iris.cluster.controller.reconcile.loader import TransitionReader
 from iris.cluster.controller.reconcile.snapshot import TaskUpdate
-from iris.cluster.controller.task_state import RunningTaskEntry
+from iris.cluster.controller.task_state import RunningTaskEntry, StoppingTaskEntry
 from iris.cluster.controller.worker_health import WorkerHealthTracker
 from iris.cluster.platforms.k8s.constants import COREWEAVE_INTERRUPTABLE_TOLERATION, NVIDIA_GPU_TOLERATION
 from iris.cluster.platforms.k8s.coreweave_topology import (
@@ -2481,8 +2481,8 @@ class K8sTaskProvider:
         Kill targets are derived here, not buffered in the controller: any
         managed pod whose ``(task_hash, attempt_id)`` is not in the desired
         set (``tasks_to_run`` union ``running_tasks``) is deleted on this tick.
-        Producing transitions only need to update ``tasks.state``; the next
-        sync sees the diff.
+        ``tasks_to_stop`` remains outside that set and is acknowledged only
+        after its pod is absent from the cluster snapshot.
 
         New-pod application runs every tick so dispatch stays responsive; the
         cluster-wide kubectl scans (pod list, stray-pod GC, pod poll, node
@@ -2566,7 +2566,11 @@ class K8sTaskProvider:
             logger.warning("Failed to query Kueue workloads: %s", e)
             workloads = []
 
-        updates = apply_failures + self._poll_pods(request.running_tasks, managed_pods, workloads)
+        updates = (
+            apply_failures
+            + self._poll_pods(request.running_tasks, managed_pods, workloads)
+            + self._poll_stopping_tasks(request.tasks_to_stop, managed_pods)
+        )
 
         try:
             nodes = self.kubectl.list_json(K8sResource.NODES)
@@ -2588,9 +2592,12 @@ class K8sTaskProvider:
 
         return updates
 
-    def _lookup_entry_pod(self, pods_by_name: dict[str, dict], entry: RunningTaskEntry) -> tuple[str, dict | None]:
-        """Resolve a running entry to its pod, allowing the pre-uid name only when this
-        process did not dispatch the attempt."""
+    def _lookup_entry_pod(
+        self,
+        pods_by_name: dict[str, dict],
+        entry: RunningTaskEntry | StoppingTaskEntry,
+    ) -> tuple[str, dict | None]:
+        """Resolve an attempt entry to its pod, including pre-uid names when safe."""
         return _lookup_pod(
             pods_by_name,
             entry.task_id,
@@ -3198,4 +3205,27 @@ class K8sTaskProvider:
         if event_log is not None:
             event_log.retain(set(running))
 
+        return updates
+
+    def _poll_stopping_tasks(
+        self,
+        stopping: list[StoppingTaskEntry],
+        cached_pods: list[dict],
+    ) -> list[TaskUpdate]:
+        """Confirm controller-stopped attempts after their pods disappear."""
+        pods_by_name = {pod.get("metadata", {}).get("name", ""): pod for pod in cached_pods}
+        updates: list[TaskUpdate] = []
+        for entry in stopping:
+            _, pod = self._lookup_entry_pod(pods_by_name, entry)
+            if pod is not None:
+                continue
+            self._pod_not_found_counts.pop(f"{entry.task_id.to_wire()}:{entry.attempt_id}", None)
+            updates.append(
+                TaskUpdate(
+                    task_id=entry.task_id,
+                    attempt_id=entry.attempt_id,
+                    new_state=job_pb2.TASK_STATE_KILLED,
+                    status_message="",
+                )
+            )
         return updates

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -3212,7 +3212,11 @@ class K8sTaskProvider:
         stopping: list[StoppingTaskEntry],
         cached_pods: list[dict],
     ) -> list[TaskUpdate]:
-        """Confirm controller-stopped attempts after their pods leave the active phase."""
+        """Finalize stopped attempts once absent from the active-pod snapshot.
+
+        Unlike normal pod polling, absence is the shutdown acknowledgement;
+        failures to list pods raise before this method is called.
+        """
         pods_by_name = {pod.get("metadata", {}).get("name", ""): pod for pod in cached_pods}
         updates: list[TaskUpdate] = []
         for entry in stopping:
@@ -3220,12 +3224,13 @@ class K8sTaskProvider:
             if pod is not None:
                 continue
             self._pod_not_found_counts.pop(f"{entry.task_id.to_wire()}:{entry.attempt_id}", None)
+            # Requeue already made the attempt terminal; this update only stamps
+            # finished_at_ms so the next dispatch cycle can promote its retry.
             updates.append(
                 TaskUpdate(
                     task_id=entry.task_id,
                     attempt_id=entry.attempt_id,
                     new_state=job_pb2.TASK_STATE_KILLED,
-                    status_message="",
                 )
             )
         return updates

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -2482,7 +2482,7 @@ class K8sTaskProvider:
         managed pod whose ``(task_hash, attempt_id)`` is not in the desired
         set (``tasks_to_run`` union ``running_tasks``) is deleted on this tick.
         ``tasks_to_stop`` remains outside that set and is acknowledged only
-        after its pod is absent from the cluster snapshot.
+        after its pod leaves the active phase.
 
         New-pod application runs every tick so dispatch stays responsive; the
         cluster-wide kubectl scans (pod list, stray-pod GC, pod poll, node
@@ -2597,7 +2597,7 @@ class K8sTaskProvider:
         pods_by_name: dict[str, dict],
         entry: RunningTaskEntry | StoppingTaskEntry,
     ) -> tuple[str, dict | None]:
-        """Resolve an attempt entry to its pod, including pre-uid names when safe."""
+        """Resolve an attempt to its pod, allowing pre-uid names only when this process did not dispatch it."""
         return _lookup_pod(
             pods_by_name,
             entry.task_id,
@@ -3212,7 +3212,7 @@ class K8sTaskProvider:
         stopping: list[StoppingTaskEntry],
         cached_pods: list[dict],
     ) -> list[TaskUpdate]:
-        """Confirm controller-stopped attempts after their pods disappear."""
+        """Confirm controller-stopped attempts after their pods leave the active phase."""
         pods_by_name = {pod.get("metadata", {}).get("name", ""): pod for pod in cached_pods}
         updates: list[TaskUpdate] = []
         for entry in stopping:

--- a/lib/iris/src/iris/cluster/controller/backend.py
+++ b/lib/iris/src/iris/cluster/controller/backend.py
@@ -66,7 +66,7 @@ from iris.cluster.controller.scheduling.scheduler import (
     SchedulingContext,
     WorkerSnapshot,
 )
-from iris.cluster.controller.task_state import RunningTaskEntry
+from iris.cluster.controller.task_state import RunningTaskEntry, StoppingTaskEntry
 from iris.cluster.controller.worker_health import WorkerHealthTracker
 from iris.cluster.types import JobName, PendingTask, UserBudgetDefaults, WorkerId
 from iris.rpc import controller_pb2, job_pb2, vm_pb2, worker_pb2
@@ -288,6 +288,7 @@ class ReconcileRequest:
 
     tasks_to_run: list[job_pb2.RunTaskRequest] = field(default_factory=list)
     running_tasks: list[RunningTaskEntry] = field(default_factory=list)
+    tasks_to_stop: list[StoppingTaskEntry] = field(default_factory=list)
 
 
 @dataclass(frozen=True)

--- a/lib/iris/src/iris/cluster/controller/backend.py
+++ b/lib/iris/src/iris/cluster/controller/backend.py
@@ -66,7 +66,7 @@ from iris.cluster.controller.scheduling.scheduler import (
     SchedulingContext,
     WorkerSnapshot,
 )
-from iris.cluster.controller.task_state import RunningTaskEntry, StoppingTaskEntry
+from iris.cluster.controller.task_state import TaskAttemptEntry
 from iris.cluster.controller.worker_health import WorkerHealthTracker
 from iris.cluster.types import JobName, PendingTask, UserBudgetDefaults, WorkerId
 from iris.rpc import controller_pb2, job_pb2, vm_pb2, worker_pb2
@@ -283,12 +283,13 @@ class ReconcileRequest:
     A worker-daemon backend sources its own worker/placement snapshot and ignores
     this; a ``CLUSTER_VIEW`` backend that owns placement receives the dispatch
     drain (the PENDING->ASSIGNED promotion the controller commits as a DB write)
-    and applies it to its cluster.
+    and applies it to its cluster. ``task_attempts`` is the authoritative set
+    of unfinished direct-provider attempts, including inactive tasks whose
+    backend resources are still draining.
     """
 
     tasks_to_run: list[job_pb2.RunTaskRequest] = field(default_factory=list)
-    running_tasks: list[RunningTaskEntry] = field(default_factory=list)
-    tasks_to_stop: list[StoppingTaskEntry] = field(default_factory=list)
+    task_attempts: list[TaskAttemptEntry] = field(default_factory=list)
 
 
 @dataclass(frozen=True)

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -1130,8 +1130,7 @@ class Controller:
                 drain = self._drain_dispatch_snapshot(backend_id)
                 inputs.reconcile_requests[backend_id] = ReconcileRequest(
                     tasks_to_run=drain.tasks_to_run,
-                    running_tasks=drain.running_tasks,
-                    tasks_to_stop=drain.tasks_to_stop,
+                    task_attempts=drain.task_attempts,
                 )
 
         # Dedicated control pool: the tick's snapshot must not queue behind a slow
@@ -1678,8 +1677,7 @@ class Controller:
             reconcile_rows=[],
             timeout_rows=[],
             tasks_to_run=batch.tasks_to_run,
-            running_tasks=batch.running_tasks,
-            tasks_to_stop=batch.tasks_to_stop,
+            task_attempts=batch.task_attempts,
         )
 
     def _drain_pending_evictions(self) -> None:

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -1131,6 +1131,7 @@ class Controller:
                 inputs.reconcile_requests[backend_id] = ReconcileRequest(
                     tasks_to_run=drain.tasks_to_run,
                     running_tasks=drain.running_tasks,
+                    tasks_to_stop=drain.tasks_to_stop,
                 )
 
         # Dedicated control pool: the tick's snapshot must not queue behind a slow
@@ -1678,6 +1679,7 @@ class Controller:
             timeout_rows=[],
             tasks_to_run=batch.tasks_to_run,
             running_tasks=batch.running_tasks,
+            tasks_to_stop=batch.tasks_to_stop,
         )
 
     def _drain_pending_evictions(self) -> None:

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -61,6 +61,7 @@ from iris.cluster.controller.task_state import (
     DISPATCHED_TASK_STATES,
     ActiveTaskRow,
     RunningTaskEntry,
+    StoppingTaskEntry,
     TaskDetailRow,
     task_row_can_be_scheduled,
 )
@@ -1875,8 +1876,9 @@ class ControlSnapshot:
       unless the caller requested the timeout sweep this tick.
     * ``job_specs`` — per-job ``RunTaskRequest`` templates for ASSIGNED reconcile
       rows, so a worker-daemon backend can build its per-worker reconcile plans.
-    * ``tasks_to_run`` / ``running_tasks`` — the dispatch drain for a cluster
-      backend that owns placement (built only when that backend reconciles).
+    * ``tasks_to_run`` / ``running_tasks`` / ``tasks_to_stop`` — the dispatch
+      drain for a cluster backend that owns placement (built only when that
+      backend reconciles).
 
     Worker liveness is never persisted and never read off the snapshot: the
     controller owns its in-memory :class:`WorkerHealthTracker` directly and folds
@@ -1890,6 +1892,7 @@ class ControlSnapshot:
     job_specs: dict[JobName, job_pb2.RunTaskRequest] = field(default_factory=dict)
     tasks_to_run: list[job_pb2.RunTaskRequest] = field(default_factory=list)
     running_tasks: list[RunningTaskEntry] = field(default_factory=list)
+    tasks_to_stop: list[StoppingTaskEntry] = field(default_factory=list)
 
 
 def load_control_snapshot(

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -60,8 +60,7 @@ from iris.cluster.controller.task_state import (
     ACTIVE_TASK_STATES,
     DISPATCHED_TASK_STATES,
     ActiveTaskRow,
-    RunningTaskEntry,
-    StoppingTaskEntry,
+    TaskAttemptEntry,
     TaskDetailRow,
     task_row_can_be_scheduled,
 )
@@ -1876,9 +1875,9 @@ class ControlSnapshot:
       unless the caller requested the timeout sweep this tick.
     * ``job_specs`` — per-job ``RunTaskRequest`` templates for ASSIGNED reconcile
       rows, so a worker-daemon backend can build its per-worker reconcile plans.
-    * ``tasks_to_run`` / ``running_tasks`` / ``tasks_to_stop`` — the dispatch
-      drain for a cluster backend that owns placement (built only when that
-      backend reconciles).
+    * ``tasks_to_run`` / ``task_attempts`` — the dispatch drain and complete
+      unfinished attempt set for a cluster backend that owns placement (built
+      only when that backend reconciles).
 
     Worker liveness is never persisted and never read off the snapshot: the
     controller owns its in-memory :class:`WorkerHealthTracker` directly and folds
@@ -1891,8 +1890,7 @@ class ControlSnapshot:
     timeout_rows: Sequence[Row]
     job_specs: dict[JobName, job_pb2.RunTaskRequest] = field(default_factory=dict)
     tasks_to_run: list[job_pb2.RunTaskRequest] = field(default_factory=list)
-    running_tasks: list[RunningTaskEntry] = field(default_factory=list)
-    tasks_to_stop: list[StoppingTaskEntry] = field(default_factory=list)
+    task_attempts: list[TaskAttemptEntry] = field(default_factory=list)
 
 
 def load_control_snapshot(

--- a/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
@@ -47,7 +47,7 @@ class DispatchBatch:
     Rides on :class:`~iris.cluster.controller.reads.ControlSnapshot` as
     ``tasks_to_run`` / ``running_tasks`` / ``tasks_to_stop``: tasks the
     controller promoted to ASSIGNED this tick, the active null-worker roster
-    to poll, and old attempts that must disappear before a retry.
+    to poll, and old attempts that must stop before a retry.
     """
 
     tasks_to_run: list[job_pb2.RunTaskRequest] = field(default_factory=list)
@@ -267,7 +267,7 @@ def _select_within_cap(
 
 
 def _stopping_tasks(cur: Tx, backend_id: str | None) -> list[StoppingTaskEntry]:
-    """Return current direct-provider attempts waiting for confirmed pod removal."""
+    """Return current direct-provider attempts waiting for confirmed pod stop."""
     backend_pred = () if backend_id is None else (local_tasks.c.backend_id == backend_id,)
     stmt = (
         select(
@@ -325,8 +325,8 @@ def drain_for_dispatch(
 
     Producer transitions move ``tasks.state`` before the old pod has
     necessarily stopped. Those unfinished direct-provider attempts populate
-    ``tasks_to_stop``; retries remain PENDING until the provider confirms pod
-    absence and finalizes the attempt.
+    ``tasks_to_stop``; retries remain PENDING until the provider confirms that
+    the old pod has left the active phase and finalizes the attempt.
 
     Candidates are ranked by *effective* band — the ancestor-resolved requested
     band after :func:`compute_effective_band` demotes over-budget users to

--- a/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field, replace
 from typing import NamedTuple
 
 from rigging.timing import Timestamp
-from sqlalchemy import select
+from sqlalchemy import exists, select
 
 from iris.cluster.controller import reads, writes
 from iris.cluster.controller.budget import (
@@ -34,8 +34,8 @@ from iris.cluster.controller.reads import (
     TaskScope,
     pending_dispatch_row,
 )
-from iris.cluster.controller.schema import job_config_table, jobs_table, local_tasks
-from iris.cluster.controller.task_state import ACTIVE_TASK_STATES, RunningTaskEntry
+from iris.cluster.controller.schema import job_config_table, jobs_table, local_tasks, task_attempts_table
+from iris.cluster.controller.task_state import ACTIVE_TASK_STATES, RunningTaskEntry, StoppingTaskEntry
 from iris.cluster.types import JobName, UserBudgetDefaults
 from iris.rpc import job_pb2
 
@@ -45,12 +45,14 @@ class DispatchBatch:
     """The dispatch drain a cluster backend's reconcile tick consumes.
 
     Rides on :class:`~iris.cluster.controller.reads.ControlSnapshot` as
-    ``tasks_to_run`` / ``running_tasks``: tasks the controller promoted to
-    ASSIGNED this tick plus the active null-worker roster to poll.
+    ``tasks_to_run`` / ``running_tasks`` / ``tasks_to_stop``: tasks the
+    controller promoted to ASSIGNED this tick, the active null-worker roster
+    to poll, and old attempts that must disappear before a retry.
     """
 
     tasks_to_run: list[job_pb2.RunTaskRequest] = field(default_factory=list)
     running_tasks: list[RunningTaskEntry] = field(default_factory=list)
+    tasks_to_stop: list[StoppingTaskEntry] = field(default_factory=list)
 
 
 DISPATCH_PROMOTION_RATE = 128
@@ -60,6 +62,13 @@ The direct provider relies on the Kubernetes scheduler (and the cloud
 autoscaler) for placement and capacity management.  Pods that cannot be
 scheduled immediately stay Pending — that signal drives node provisioning.
 This rate limit exists only to bound API server pressure."""
+
+
+_CURRENT_ATTEMPT_DRAINED = ~exists().where(
+    task_attempts_table.c.task_id == local_tasks.c.task_id,
+    task_attempts_table.c.attempt_id == local_tasks.c.current_attempt_id,
+    task_attempts_table.c.finished_at_ms.is_(None),
+)
 
 
 def build_run_request(
@@ -257,6 +266,40 @@ def _select_within_cap(
     return selected
 
 
+def _stopping_tasks(cur: Tx, backend_id: str | None) -> list[StoppingTaskEntry]:
+    """Return current direct-provider attempts waiting for confirmed pod removal."""
+    backend_pred = () if backend_id is None else (local_tasks.c.backend_id == backend_id,)
+    stmt = (
+        select(
+            local_tasks.c.task_id,
+            local_tasks.c.current_attempt_id,
+            task_attempts_table.c.attempt_uid,
+        )
+        .select_from(
+            local_tasks.join(
+                task_attempts_table,
+                (task_attempts_table.c.task_id == local_tasks.c.task_id)
+                & (task_attempts_table.c.attempt_id == local_tasks.c.current_attempt_id),
+            )
+        )
+        .where(
+            local_tasks.c.current_worker_id.is_(None),
+            local_tasks.c.state.not_in(ACTIVE_TASK_STATES),
+            task_attempts_table.c.finished_at_ms.is_(None),
+            *backend_pred,
+        )
+        .order_by(local_tasks.c.task_id)
+    )
+    return [
+        StoppingTaskEntry(
+            task_id=row.task_id,
+            attempt_id=int(row.current_attempt_id),
+            attempt_uid=str(row.attempt_uid),
+        )
+        for row in cur.execute(stmt).all()
+    ]
+
+
 def drain_for_dispatch(
     cur: Tx,
     *,
@@ -280,10 +323,10 @@ def drain_for_dispatch(
     falls through the K8s provider's ``Pod not found`` grace path), so
     the first poll after dispatch transitions the row out of ASSIGNED.
 
-    Kill targets are not enqueued: producing transitions move
-    ``tasks.state`` directly to terminal, and the K8s provider's pod
-    diff against the desired set deletes the corresponding pod on the
-    next sync.
+    Producer transitions move ``tasks.state`` before the old pod has
+    necessarily stopped. Those unfinished direct-provider attempts populate
+    ``tasks_to_stop``; retries remain PENDING until the provider confirms pod
+    absence and finalizes the attempt.
 
     Candidates are ranked by *effective* band — the ancestor-resolved requested
     band after :func:`compute_effective_band` demotes over-budget users to
@@ -314,7 +357,12 @@ def drain_for_dispatch(
     effective_bands: dict[JobName, int] = {}
     promote_units: list[list[_RankRow]] = []
     if max_promotions > 0:
-        candidates = _ranking_rows(cur, local_tasks.c.state == int(job_pb2.TASK_STATE_PENDING), *backend_pred)
+        candidates = _ranking_rows(
+            cur,
+            local_tasks.c.state == int(job_pb2.TASK_STATE_PENDING),
+            _CURRENT_ATTEMPT_DRAINED,
+            *backend_pred,
+        )
         if candidates:
             job_ids = {row.job_id for row in candidates}
             resolved_bands = reads.get_priority_bands(cur, job_ids)
@@ -371,8 +419,10 @@ def drain_for_dispatch(
         )
         for row in running_rows
     ]
+    tasks_to_stop = _stopping_tasks(cur, backend_id)
 
     return DispatchBatch(
         tasks_to_run=tasks_to_run,
         running_tasks=running_tasks,
+        tasks_to_stop=tasks_to_stop,
     )

--- a/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
@@ -28,14 +28,9 @@ from iris.cluster.controller.budget import (
 )
 from iris.cluster.controller.db import Tx
 from iris.cluster.controller.projections.run_templates import build_run_request_fields
-from iris.cluster.controller.reads import (
-    PENDING_DISPATCH_COLS,
-    PendingDispatchRow,
-    TaskScope,
-    pending_dispatch_row,
-)
+from iris.cluster.controller.reads import PENDING_DISPATCH_COLS, PendingDispatchRow, pending_dispatch_row
 from iris.cluster.controller.schema import job_config_table, jobs_table, local_tasks, task_attempts_table
-from iris.cluster.controller.task_state import ACTIVE_TASK_STATES, RunningTaskEntry, StoppingTaskEntry
+from iris.cluster.controller.task_state import TaskAttemptEntry
 from iris.cluster.types import JobName, UserBudgetDefaults
 from iris.rpc import job_pb2
 
@@ -45,14 +40,12 @@ class DispatchBatch:
     """The dispatch drain a cluster backend's reconcile tick consumes.
 
     Rides on :class:`~iris.cluster.controller.reads.ControlSnapshot` as
-    ``tasks_to_run`` / ``running_tasks`` / ``tasks_to_stop``: tasks the
-    controller promoted to ASSIGNED this tick, the active null-worker roster
-    to poll, and old attempts that must stop before a retry.
+    ``tasks_to_run`` / ``task_attempts``: tasks the controller promoted to
+    ASSIGNED this tick and the complete unfinished null-worker attempt roster.
     """
 
     tasks_to_run: list[job_pb2.RunTaskRequest] = field(default_factory=list)
-    running_tasks: list[RunningTaskEntry] = field(default_factory=list)
-    tasks_to_stop: list[StoppingTaskEntry] = field(default_factory=list)
+    task_attempts: list[TaskAttemptEntry] = field(default_factory=list)
 
 
 DISPATCH_PROMOTION_RATE = 128
@@ -266,17 +259,19 @@ def _select_within_cap(
     return selected
 
 
-def _stopping_tasks(cur: Tx, backend_id: str | None) -> list[StoppingTaskEntry]:
-    """Return current direct-provider attempts waiting for confirmed pod stop."""
+def _task_attempts(cur: Tx, backend_id: str | None) -> list[TaskAttemptEntry]:
+    """Return every unfinished current attempt owned by a direct provider."""
     backend_pred = () if backend_id is None else (local_tasks.c.backend_id == backend_id,)
     stmt = (
         select(
             local_tasks.c.task_id,
             local_tasks.c.current_attempt_id,
+            local_tasks.c.state.label("task_state"),
+            job_config_table.c.has_coscheduling,
             task_attempts_table.c.attempt_uid,
         )
         .select_from(
-            local_tasks.join(
+            local_tasks.join(job_config_table, job_config_table.c.job_id == local_tasks.c.job_id).join(
                 task_attempts_table,
                 (task_attempts_table.c.task_id == local_tasks.c.task_id)
                 & (task_attempts_table.c.attempt_id == local_tasks.c.current_attempt_id),
@@ -284,16 +279,17 @@ def _stopping_tasks(cur: Tx, backend_id: str | None) -> list[StoppingTaskEntry]:
         )
         .where(
             local_tasks.c.current_worker_id.is_(None),
-            local_tasks.c.state.not_in(ACTIVE_TASK_STATES),
             task_attempts_table.c.finished_at_ms.is_(None),
             *backend_pred,
         )
         .order_by(local_tasks.c.task_id)
     )
     return [
-        StoppingTaskEntry(
+        TaskAttemptEntry(
             task_id=row.task_id,
             attempt_id=int(row.current_attempt_id),
+            task_state=int(row.task_state),
+            coscheduled=bool(row.has_coscheduling),
             attempt_uid=str(row.attempt_uid),
         )
         for row in cur.execute(stmt).all()
@@ -307,7 +303,7 @@ def drain_for_dispatch(
     backend_id: str | None = None,
     defaults: UserBudgetDefaults | None = None,
 ) -> DispatchBatch:
-    """Drain pending tasks and snapshot running tasks for a direct provider sync cycle.
+    """Drain pending tasks and snapshot unfinished attempts for a direct provider sync cycle.
 
     Builds RunTaskRequest for two row classes:
     - Up to ``max_promotions`` PENDING rows, each promoted to ASSIGNED
@@ -317,16 +313,10 @@ def drain_for_dispatch(
       the prior ``_apply_pod`` errored). ``kubectl apply`` is idempotent;
       re-issuing for a row whose pod already exists is a no-op.
 
-    Every active null-worker row (ASSIGNED/BUILDING/RUNNING) populates
-    ``running_tasks`` so the poll observes the pod's current phase. For
-    ASSIGNED rows the pod was applied earlier in this same sync (or
-    falls through the K8s provider's ``Pod not found`` grace path), so
-    the first poll after dispatch transitions the row out of ASSIGNED.
-
-    Producer transitions move ``tasks.state`` before the old pod has
-    necessarily stopped. Those unfinished direct-provider attempts populate
-    ``tasks_to_stop``; retries remain PENDING until the provider confirms that
-    the old pod has left the active phase and finalizes the attempt.
+    Every unfinished current null-worker attempt populates ``task_attempts``.
+    Active tasks are desired pods and are polled normally. Attempts whose task
+    has already left the active set remain in the same authoritative roster
+    until the provider confirms that their old pod left the active phase.
 
     Candidates are ranked by *effective* band — the ancestor-resolved requested
     band after :func:`compute_effective_band` demotes over-budget users to
@@ -396,33 +386,7 @@ def drain_for_dispatch(
     for row in redrive_rows:
         tasks_to_run.append(build_run_request(cur, row, row.current_attempt_id))
 
-    # Poll every active row (including ASSIGNED) so a pod that just got
-    # applied this cycle can transition out of ASSIGNED on the same sync.
-    # Pods for ASSIGNED rows either exist (apply_pod ran above) or fall
-    # through the K8s provider's "Pod not found" grace path.
-    running_rows = reads.list_active_tasks(
-        cur,
-        TaskScope(null_worker=True),
-        states=ACTIVE_TASK_STATES,
-        order_by_task_id=True,
-        backend_id=backend_id,
-    )
-    # The K8s provider rebuilds each pod name from (task_id, attempt_id, uid), so
-    # poll must carry the current attempt's uid to target the right incarnation.
-    uids = reads.attempt_uids_for(cur, [(row.task_id, row.current_attempt_id) for row in running_rows])
-    running_tasks = [
-        RunningTaskEntry(
-            task_id=row.task_id,
-            attempt_id=row.current_attempt_id,
-            coscheduled=row.has_coscheduling,
-            attempt_uid=uids.get((row.task_id, row.current_attempt_id), ""),
-        )
-        for row in running_rows
-    ]
-    tasks_to_stop = _stopping_tasks(cur, backend_id)
-
     return DispatchBatch(
         tasks_to_run=tasks_to_run,
-        running_tasks=running_tasks,
-        tasks_to_stop=tasks_to_stop,
+        task_attempts=_task_attempts(cur, backend_id),
     )

--- a/lib/iris/src/iris/cluster/controller/reconcile/task.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/task.py
@@ -343,7 +343,7 @@ def apply_one_transition(
             and update.attempt_id == task.current_attempt_id
         ):
             attempt = attempt_map.get((update.task_id, update.attempt_id))
-            if attempt is not None and attempt.worker_id is not None:
+            if attempt is not None and (attempt.worker_id is not None or source is TransitionSource.DISPATCH):
                 _backfill_attempt_finished_at(state, update.task_id, update.attempt_id, now_ms)
         return None
 

--- a/lib/iris/src/iris/cluster/controller/task_state.py
+++ b/lib/iris/src/iris/cluster/controller/task_state.py
@@ -38,8 +38,14 @@ DISPATCHED_TASK_STATES: frozenset[int] = frozenset(
 )
 
 
-class RunningTaskEntry(NamedTuple):
-    """Task ID and attempt ID pair captured at snapshot time.
+class TaskAttemptEntry(NamedTuple):
+    """Unfinished direct-provider attempt captured at snapshot time.
+
+    ``task_state`` lets the backend distinguish attempts whose pods remain
+    desired from attempts whose task has already left the active set. Keeping
+    both in one complete snapshot makes reconciliation level-triggered: the
+    backend can delete an old pod and keep reporting its absence until the
+    controller records the attempt as finished.
 
     ``coscheduled`` lets the direct (K8s) provider classify a vanished pod as
     a gang preemption (WORKER_FAILED) rather than an application failure: when
@@ -54,21 +60,8 @@ class RunningTaskEntry(NamedTuple):
 
     task_id: JobName
     attempt_id: int
+    task_state: int
     coscheduled: bool = False
-    attempt_uid: str = ""
-
-
-class StoppingTaskEntry(NamedTuple):
-    """Direct-provider attempt that must stop before its task can retry.
-
-    Producer transitions move the task out of the active set before Kubernetes
-    has necessarily stopped its pod. The K8s backend uses this identity to
-    delete the old pod and reports the attempt stopped only after the pod
-    leaves the active phase.
-    """
-
-    task_id: JobName
-    attempt_id: int
     attempt_uid: str = ""
 
 

--- a/lib/iris/src/iris/cluster/controller/task_state.py
+++ b/lib/iris/src/iris/cluster/controller/task_state.py
@@ -59,12 +59,12 @@ class RunningTaskEntry(NamedTuple):
 
 
 class StoppingTaskEntry(NamedTuple):
-    """Direct-provider attempt that must disappear before its task can retry.
+    """Direct-provider attempt that must stop before its task can retry.
 
     Producer transitions move the task out of the active set before Kubernetes
     has necessarily stopped its pod. The K8s backend uses this identity to
-    delete the old pod and reports the attempt stopped only after the pod is
-    absent from the cluster snapshot.
+    delete the old pod and reports the attempt stopped only after the pod
+    leaves the active phase.
     """
 
     task_id: JobName

--- a/lib/iris/src/iris/cluster/controller/task_state.py
+++ b/lib/iris/src/iris/cluster/controller/task_state.py
@@ -58,6 +58,20 @@ class RunningTaskEntry(NamedTuple):
     attempt_uid: str = ""
 
 
+class StoppingTaskEntry(NamedTuple):
+    """Direct-provider attempt that must disappear before its task can retry.
+
+    Producer transitions move the task out of the active set before Kubernetes
+    has necessarily stopped its pod. The K8s backend uses this identity to
+    delete the old pod and reports the attempt stopped only after the pod is
+    absent from the cluster snapshot.
+    """
+
+    task_id: JobName
+    attempt_id: int
+    attempt_uid: str = ""
+
+
 def task_is_finished(
     state: int,
     failure_count: int,

--- a/lib/iris/tests/cluster/backends/k8s/conftest.py
+++ b/lib/iris/tests/cluster/backends/k8s/conftest.py
@@ -103,16 +103,14 @@ def make_kueue_provider(k8s, *, local_queue: str = "iris-lq", **kwargs) -> K8sTa
 
 def make_batch(
     tasks_to_run=None,
-    running_tasks=None,
-    tasks_to_stop=None,
+    task_attempts=None,
 ) -> ControlSnapshot:
     return ControlSnapshot(
         worker_addresses={},
         reconcile_rows=[],
         timeout_rows=[],
-        running_tasks=running_tasks or [],
         tasks_to_run=tasks_to_run or [],
-        tasks_to_stop=tasks_to_stop or [],
+        task_attempts=task_attempts or [],
     )
 
 

--- a/lib/iris/tests/cluster/backends/k8s/conftest.py
+++ b/lib/iris/tests/cluster/backends/k8s/conftest.py
@@ -104,6 +104,7 @@ def make_kueue_provider(k8s, *, local_queue: str = "iris-lq", **kwargs) -> K8sTa
 def make_batch(
     tasks_to_run=None,
     running_tasks=None,
+    tasks_to_stop=None,
 ) -> ControlSnapshot:
     return ControlSnapshot(
         worker_addresses={},
@@ -111,6 +112,7 @@ def make_batch(
         timeout_rows=[],
         running_tasks=running_tasks or [],
         tasks_to_run=tasks_to_run or [],
+        tasks_to_stop=tasks_to_stop or [],
     )
 
 

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -35,7 +35,7 @@ from iris.cluster.backends.k8s.tasks import (
     _task_hash,
     _task_update_from_pod,
 )
-from iris.cluster.controller.task_state import RunningTaskEntry
+from iris.cluster.controller.task_state import TaskAttemptEntry
 from iris.cluster.platforms.k8s.coreweave_topology import (
     NVL72_GPUS_PER_NODE,
     RACK_SIZE,
@@ -251,14 +251,14 @@ def test_task_hash_distinct_for_sanitization_collisions():
     ],
 )
 def test_task_update_from_pod_phases(phase, expected_state):
-    entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
+    entry = TaskAttemptEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0, task_state=job_pb2.TASK_STATE_RUNNING)
     pod = make_pod("iris-job-0-0", phase, exit_code=1 if phase == "Failed" else None)
     update = _task_update_from_pod(entry, pod)
     assert update.new_state == expected_state
 
 
 def test_task_update_failed_has_exit_code():
-    entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
+    entry = TaskAttemptEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0, task_state=job_pb2.TASK_STATE_RUNNING)
     pod = make_pod("iris-job-0-0", "Failed", exit_code=42, reason="Error")
     update = _task_update_from_pod(entry, pod)
     assert update.exit_code == 42
@@ -268,7 +268,7 @@ def test_task_update_failed_has_exit_code():
 @pytest.mark.parametrize("reason", sorted(_INFRASTRUCTURE_FAILURE_REASONS))
 def test_task_update_infrastructure_failure_is_worker_failed(reason):
     """Evicted, Preempting, etc. should be WORKER_FAILED, not FAILED."""
-    entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
+    entry = TaskAttemptEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0, task_state=job_pb2.TASK_STATE_RUNNING)
     pod = make_pod("iris-job-0-0", "Failed", exit_code=137, reason=reason)
     update = _task_update_from_pod(entry, pod)
     assert update.new_state == job_pb2.TASK_STATE_WORKER_FAILED
@@ -277,7 +277,7 @@ def test_task_update_infrastructure_failure_is_worker_failed(reason):
 
 def test_task_update_oom_killed_is_application_failure():
     """OOMKilled is a misconfiguration, not infrastructure — should be FAILED."""
-    entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
+    entry = TaskAttemptEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0, task_state=job_pb2.TASK_STATE_RUNNING)
     pod = make_pod("iris-job-0-0", "Failed", exit_code=137, reason="OOMKilled")
     update = _task_update_from_pod(entry, pod)
     assert update.new_state == job_pb2.TASK_STATE_FAILED
@@ -286,7 +286,7 @@ def test_task_update_oom_killed_is_application_failure():
 
 def test_task_update_application_error_is_failed():
     """Non-zero exit with reason 'Error' is an application failure, not infrastructure."""
-    entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
+    entry = TaskAttemptEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0, task_state=job_pb2.TASK_STATE_RUNNING)
     pod = make_pod("iris-job-0-0", "Failed", exit_code=1, reason="Error")
     update = _task_update_from_pod(entry, pod)
     assert update.new_state == job_pb2.TASK_STATE_FAILED
@@ -299,7 +299,7 @@ def test_task_update_error_prefers_termination_message_over_bare_reason():
     the real payoff of that manifest field: _extract_error already prefers a
     non-empty message over the generic "Error" reason, so the actual crash
     (traceback, fatal-error banner, ...) reaches the task/job error instead."""
-    entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
+    entry = TaskAttemptEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0, task_state=job_pb2.TASK_STATE_RUNNING)
     pod = make_pod(
         "iris-job-0-0",
         "Failed",
@@ -330,7 +330,7 @@ def test_task_update_disruption_target_is_worker_failed(reason):
     """A preemption SIGKILLed after grace surfaces as reason='Error' exit 137 — not in
     the reason whitelist — but the control plane's DisruptionTarget condition marks it
     as infrastructure, so it must be WORKER_FAILED (preemption budget), not FAILED."""
-    entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
+    entry = TaskAttemptEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0, task_state=job_pb2.TASK_STATE_RUNNING)
     pod = make_pod("iris-job-0-0", "Failed", exit_code=137, reason="Error")
     _add_condition(pod, "DisruptionTarget", "True", reason)
     update = _task_update_from_pod(entry, pod)
@@ -342,7 +342,7 @@ def test_task_update_kueue_termination_target_is_worker_failed():
     """Kueue preemption uses TerminationTarget rather than Kubernetes'
     DisruptionTarget; preserve that authoritative cause instead of charging a
     SIGKILL-shaped exit as an application failure."""
-    entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
+    entry = TaskAttemptEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0, task_state=job_pb2.TASK_STATE_RUNNING)
     pod = make_pod("iris-job-0-0", "Failed", exit_code=137, reason="Error")
     message = "Preempted to accommodate an interactive workload due to ClusterQueue prioritization"
     _add_condition(pod, "TerminationTarget", "True", "WorkloadEvictedDueToPreempted")
@@ -360,7 +360,7 @@ def test_task_update_oom_killed_without_disruption_target_stays_application_fail
     """A self-inflicted cgroup OOM carries no DisruptionTarget condition, so it stays a
     FAILED (misconfigured job) even though it also exits 137 — the condition, not the
     exit code, is what distinguishes preemption from OOM guilt."""
-    entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
+    entry = TaskAttemptEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0, task_state=job_pb2.TASK_STATE_RUNNING)
     pod = make_pod("iris-job-0-0", "Failed", exit_code=137, reason="OOMKilled")
     update = _task_update_from_pod(entry, pod)
     assert update.new_state == job_pb2.TASK_STATE_FAILED

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -31,7 +31,7 @@ from iris.cluster.backends.k8s.tasks import (
     _task_hash,
 )
 from iris.cluster.controller.backend import ProviderError, TaskTarget
-from iris.cluster.controller.task_state import RunningTaskEntry, StoppingTaskEntry
+from iris.cluster.controller.task_state import TaskAttemptEntry
 from iris.cluster.platforms.k8s.coreweave_topology import RACK_SIZE
 from iris.cluster.platforms.k8s.types import ExecResult, K8sResource, KubectlError, PodResourceUsage
 from iris.cluster.stats.tables import IrisTaskStat, ProfileTrigger
@@ -68,16 +68,26 @@ def test_sync_stop_waits_for_pod_absence(provider, k8s):
     pod_name = _pod_name(task_id, 0, attempt_uid)
     k8s.transition_pod(pod_name, "Running")
 
-    stopping = StoppingTaskEntry(task_id=task_id, attempt_id=0, attempt_uid=attempt_uid)
-    first = provider.sync(make_batch(tasks_to_stop=[stopping]))
+    stopping = TaskAttemptEntry(
+        task_id=task_id,
+        attempt_id=0,
+        task_state=job_pb2.TASK_STATE_PENDING,
+        attempt_uid=attempt_uid,
+    )
+    first = provider.sync(make_batch(task_attempts=[stopping]))
 
     assert first == []
     assert k8s.get_json(K8sResource.PODS, pod_name) is None
 
-    [confirmed] = provider.sync(make_batch(tasks_to_stop=[stopping]))
+    [confirmed] = provider.sync(make_batch(task_attempts=[stopping]))
     assert confirmed.task_id == task_id
     assert confirmed.attempt_id == 0
     assert confirmed.new_state == job_pb2.TASK_STATE_KILLED
+
+    # A dropped response leaves the controller snapshot unchanged. Repeating
+    # that snapshot must repeat the acknowledgement rather than lose it.
+    [retried] = provider.sync(make_batch(task_attempts=[stopping]))
+    assert retried == confirmed
 
 
 def test_sync_propagates_non_kubectl_failure(provider, k8s):
@@ -212,7 +222,7 @@ def test_redrive_keeps_own_fast_finished_pod(provider, k8s):
 
 
 def test_sync_deletes_pods_not_in_desired_set(provider, k8s):
-    """A managed pod whose (task_hash, attempt_id) is not in tasks_to_run|running_tasks
+    """A managed pod whose (task_hash, attempt_id) is not in tasks_to_run|task_attempts
     is considered a stray and gets deleted."""
     task_id = "/test-job/0"
     populate_pod(
@@ -247,7 +257,9 @@ def test_sync_keeps_pods_in_desired_running_set(provider, k8s):
             _LABEL_ATTEMPT_ID: "0",
         },
     )
-    batch = make_batch(running_tasks=[RunningTaskEntry(task_id=task_id, attempt_id=0)])
+    batch = make_batch(
+        task_attempts=[TaskAttemptEntry(task_id=task_id, attempt_id=0, task_state=job_pb2.TASK_STATE_RUNNING)]
+    )
 
     provider.sync(batch)
 
@@ -268,7 +280,9 @@ def test_sync_deletes_pod_for_stale_attempt(provider, k8s):
         },
     )
     # Desired = attempt 1 (task was preempted and re-promoted).
-    batch = make_batch(running_tasks=[RunningTaskEntry(task_id=task_id, attempt_id=1)])
+    batch = make_batch(
+        task_attempts=[TaskAttemptEntry(task_id=task_id, attempt_id=1, task_state=job_pb2.TASK_STATE_RUNNING)]
+    )
 
     provider.sync(batch)
 
@@ -276,7 +290,7 @@ def test_sync_deletes_pod_for_stale_attempt(provider, k8s):
 
 
 # ---------------------------------------------------------------------------
-# sync(): running_tasks polling
+# sync(): active task-attempt polling
 # ---------------------------------------------------------------------------
 
 
@@ -284,11 +298,11 @@ def test_sync_running_task_returns_running_state(provider, k8s):
     task_id = JobName.from_wire("/job/0")
     attempt_id = 0
     pod_name = _pod_name(task_id, attempt_id)
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=attempt_id)
+    entry = TaskAttemptEntry(task_id=task_id, attempt_id=attempt_id, task_state=job_pb2.TASK_STATE_RUNNING)
 
     populate_pod(k8s, pod_name, "Running")
 
-    batch = make_batch(running_tasks=[entry])
+    batch = make_batch(task_attempts=[entry])
     result = provider.sync(batch)
 
     assert len(result) == 1
@@ -298,9 +312,9 @@ def test_sync_running_task_returns_running_state(provider, k8s):
 def test_sync_pod_not_found_marks_failed(provider, k8s):
     """Pod must be missing for _POD_NOT_FOUND_GRACE_CYCLES consecutive syncs before FAILED."""
     task_id = JobName.from_wire("/job/0")
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=0)
+    entry = TaskAttemptEntry(task_id=task_id, attempt_id=0, task_state=job_pb2.TASK_STATE_RUNNING)
 
-    batch = make_batch(running_tasks=[entry])
+    batch = make_batch(task_attempts=[entry])
 
     for _ in range(_POD_NOT_FOUND_GRACE_CYCLES - 1):
         result = provider.sync(batch)
@@ -321,11 +335,16 @@ def test_sync_finds_pod_dispatched_before_pod_names_embedded_uid(provider, k8s):
     first controller restart after the upgrade.
     """
     task_id = JobName.from_wire("/job/preexisting")
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=0, attempt_uid="a1b2c3d4e5f60718")
+    entry = TaskAttemptEntry(
+        task_id=task_id,
+        attempt_id=0,
+        task_state=job_pb2.TASK_STATE_RUNNING,
+        attempt_uid="a1b2c3d4e5f60718",
+    )
 
     populate_pod(k8s, _pod_name(task_id, 0), "Running")
 
-    batch = make_batch(running_tasks=[entry])
+    batch = make_batch(task_attempts=[entry])
     for _ in range(_POD_NOT_FOUND_GRACE_CYCLES + 1):
         result = provider.sync(batch)
         assert len(result) == 1
@@ -365,8 +384,13 @@ def test_sync_ignores_legacy_pod_for_an_attempt_this_process_dispatched(provider
     provider.sync(make_batch(tasks_to_run=[make_run_req(task_id.to_wire(), attempt_id=0, attempt_uid=uid)]))
     k8s.delete(K8sResource.PODS, _pod_name(task_id, 0, uid))  # this attempt's pod goes away
 
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=0, attempt_uid=uid)
-    batch = make_batch(running_tasks=[entry])
+    entry = TaskAttemptEntry(
+        task_id=task_id,
+        attempt_id=0,
+        task_state=job_pb2.TASK_STATE_RUNNING,
+        attempt_uid=uid,
+    )
+    batch = make_batch(task_attempts=[entry])
     for _ in range(_POD_NOT_FOUND_GRACE_CYCLES - 1):
         assert provider.sync(batch)[0].new_state == job_pb2.TASK_STATE_RUNNING
 
@@ -379,8 +403,13 @@ def test_sync_coscheduled_pod_not_found_is_worker_failed(provider, k8s):
     """A vanished pod for a coscheduled task is billed as WORKER_FAILED (gang preemption),
     not FAILED — Kueue deletes every pod in a preempted group, leaving only the absence."""
     task_id = JobName.from_wire("/gang/task/0")
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=0, coscheduled=True)
-    batch = make_batch(running_tasks=[entry])
+    entry = TaskAttemptEntry(
+        task_id=task_id,
+        attempt_id=0,
+        task_state=job_pb2.TASK_STATE_RUNNING,
+        coscheduled=True,
+    )
+    batch = make_batch(task_attempts=[entry])
 
     for _ in range(_POD_NOT_FOUND_GRACE_CYCLES - 1):
         result = provider.sync(batch)
@@ -393,9 +422,9 @@ def test_sync_coscheduled_pod_not_found_is_worker_failed(provider, k8s):
 def test_pod_not_found_grace_period(provider, k8s):
     """A single missing-pod sync returns RUNNING, not FAILED."""
     task_id = JobName.from_wire("/job/grace")
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=0)
+    entry = TaskAttemptEntry(task_id=task_id, attempt_id=0, task_state=job_pb2.TASK_STATE_RUNNING)
 
-    result = provider.sync(make_batch(running_tasks=[entry]))
+    result = provider.sync(make_batch(task_attempts=[entry]))
     assert len(result) == 1
     assert result[0].new_state == job_pb2.TASK_STATE_RUNNING
 
@@ -405,8 +434,8 @@ def test_pod_not_found_grace_resets_when_pod_reappears(provider, k8s):
     task_id = JobName.from_wire("/job/reset")
     attempt_id = 0
     pod_name = _pod_name(task_id, attempt_id)
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=attempt_id)
-    batch = make_batch(running_tasks=[entry])
+    entry = TaskAttemptEntry(task_id=task_id, attempt_id=attempt_id, task_state=job_pb2.TASK_STATE_RUNNING)
+    batch = make_batch(task_attempts=[entry])
 
     # Miss for (grace - 1) cycles.
     for _ in range(_POD_NOT_FOUND_GRACE_CYCLES - 1):
@@ -582,8 +611,16 @@ def test_sync_survives_node_list_failure(provider, k8s):
 def test_resource_stats_only_for_running_tasks(provider, k8s, task_stats_table):
     """reconcile registers running pods (not terminal ones) so the background
     collector emits IrisTaskStat rows only for running tasks."""
-    running = RunningTaskEntry(task_id=JobName.from_wire("/job/run"), attempt_id=0)
-    terminal = RunningTaskEntry(task_id=JobName.from_wire("/job/done"), attempt_id=0)
+    running = TaskAttemptEntry(
+        task_id=JobName.from_wire("/job/run"),
+        attempt_id=0,
+        task_state=job_pb2.TASK_STATE_RUNNING,
+    )
+    terminal = TaskAttemptEntry(
+        task_id=JobName.from_wire("/job/done"),
+        attempt_id=0,
+        task_state=job_pb2.TASK_STATE_RUNNING,
+    )
     running_pod = _pod_name(running.task_id, running.attempt_id)
     terminal_pod = _pod_name(terminal.task_id, terminal.attempt_id)
 
@@ -592,7 +629,7 @@ def test_resource_stats_only_for_running_tasks(provider, k8s, task_stats_table):
     k8s.set_top_pod(running_pod, PodResourceUsage(cpu_millicores=500, memory_bytes=1024 * 1024 * 1024))
     k8s.set_top_pod(terminal_pod, PodResourceUsage(cpu_millicores=999, memory_bytes=1024))
 
-    provider.sync(make_batch(running_tasks=[running, terminal]))
+    provider.sync(make_batch(task_attempts=[running, terminal]))
     # The collector samples all tracked pods in one pass, so once the running
     # pod's row lands a full cycle has run — the terminal pod's absence is real.
     wait_for_condition(lambda: bool(task_stats_table.writes), timeout=Duration.from_seconds(5.0))
@@ -916,15 +953,23 @@ def test_reconcile_dumps_only_running_pods_via_periodic_profiler(k8s):
         cluster_scan_interval=0.0,
     )
     try:
-        running = RunningTaskEntry(task_id=JobName.from_wire("/job/run"), attempt_id=0)
-        terminal = RunningTaskEntry(task_id=JobName.from_wire("/job/done"), attempt_id=0)
+        running = TaskAttemptEntry(
+            task_id=JobName.from_wire("/job/run"),
+            attempt_id=0,
+            task_state=job_pb2.TASK_STATE_RUNNING,
+        )
+        terminal = TaskAttemptEntry(
+            task_id=JobName.from_wire("/job/done"),
+            attempt_id=0,
+            task_state=job_pb2.TASK_STATE_RUNNING,
+        )
         running_pod = _pod_name(running.task_id, running.attempt_id)
         terminal_pod = _pod_name(terminal.task_id, terminal.attempt_id)
         populate_pod(k8s, running_pod, "Running")
         populate_pod(k8s, terminal_pod, "Succeeded")
         k8s.set_exec_response(running_pod, _success_cp(stdout="Thread 0x1\n  train.py:1"))
 
-        provider.sync(make_batch(running_tasks=[running, terminal]))
+        provider.sync(make_batch(task_attempts=[running, terminal]))
         # The loop samples every registered pod each cycle, so once a row lands a
         # full cycle has run — the terminal pod's absence is real, not a race.
         wait_for_condition(lambda: bool(profile_table.writes), timeout=Duration.from_seconds(5.0))
@@ -1577,9 +1622,15 @@ def test_reconcile_evicts_blockers_while_gang_gated(preempt_provider, k8s):
     loop while the gang's pods remain SchedulingGated, and the sweep is
     debounced so back-to-back reconciles don't re-list the namespace."""
     entries = [
-        RunningTaskEntry(task_id=JobName.from_wire(f"/gang/task/{i}"), attempt_id=0, coscheduled=True) for i in range(2)
+        TaskAttemptEntry(
+            task_id=JobName.from_wire(f"/gang/task/{i}"),
+            attempt_id=0,
+            task_state=job_pb2.TASK_STATE_RUNNING,
+            coscheduled=True,
+        )
+        for i in range(2)
     ]
-    preempt_provider.sync(make_batch(tasks_to_run=_gang_reqs(), running_tasks=entries))
+    preempt_provider.sync(make_batch(tasks_to_run=_gang_reqs(), task_attempts=entries))
 
     # Kueue's webhook gates gang pods until the pod-group Workload is admitted.
     for pod in k8s.list_json(K8sResource.PODS, labels=_MANAGED_POD_LABELS):
@@ -1589,12 +1640,12 @@ def test_reconcile_evicts_blockers_while_gang_gated(preempt_provider, k8s):
     # Health-check pod lands after submission, on capacity the gang needs.
     _seed_blocker_pod(k8s, _PREEMPT_NS, "late-blocker")
     preempt_provider._last_preempt_time = 0.0  # clear the submit-time debounce
-    preempt_provider.sync(make_batch(running_tasks=entries))
+    preempt_provider.sync(make_batch(task_attempts=entries))
     assert k8s.list_pods_in_namespace(_PREEMPT_NS) == []
 
     # Debounce: a blocker appearing immediately after survives this cycle.
     _seed_blocker_pod(k8s, _PREEMPT_NS, "back-to-back-blocker")
-    preempt_provider.sync(make_batch(running_tasks=entries))
+    preempt_provider.sync(make_batch(task_attempts=entries))
     assert [p["metadata"]["name"] for p in k8s.list_pods_in_namespace(_PREEMPT_NS)] == ["back-to-back-blocker"]
 
 

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -31,7 +31,7 @@ from iris.cluster.backends.k8s.tasks import (
     _task_hash,
 )
 from iris.cluster.controller.backend import ProviderError, TaskTarget
-from iris.cluster.controller.task_state import RunningTaskEntry
+from iris.cluster.controller.task_state import RunningTaskEntry, StoppingTaskEntry
 from iris.cluster.platforms.k8s.coreweave_topology import RACK_SIZE
 from iris.cluster.platforms.k8s.types import ExecResult, K8sResource, KubectlError, PodResourceUsage
 from iris.cluster.stats.tables import IrisTaskStat, ProfileTrigger
@@ -57,6 +57,27 @@ def test_sync_applies_pods_for_tasks_to_run(provider, k8s):
     assert len(pods) == 1
     assert pods[0]["kind"] == "Pod"
     assert result == []
+
+
+def test_sync_stop_waits_for_pod_absence(provider, k8s):
+    """A stopped attempt is acknowledged only after its pod disappears."""
+    task_id = JobName.from_wire("/test-job/0")
+    attempt_uid = "0123456789abcdef"
+    req = make_run_req(task_id.to_wire(), attempt_uid=attempt_uid)
+    provider.sync(make_batch(tasks_to_run=[req]))
+    pod_name = _pod_name(task_id, 0, attempt_uid)
+    k8s.transition_pod(pod_name, "Running")
+
+    stopping = StoppingTaskEntry(task_id=task_id, attempt_id=0, attempt_uid=attempt_uid)
+    first = provider.sync(make_batch(tasks_to_stop=[stopping]))
+
+    assert first == []
+    assert k8s.get_json(K8sResource.PODS, pod_name) is None
+
+    [confirmed] = provider.sync(make_batch(tasks_to_stop=[stopping]))
+    assert confirmed.task_id == task_id
+    assert confirmed.attempt_id == 0
+    assert confirmed.new_state == job_pb2.TASK_STATE_KILLED
 
 
 def test_sync_propagates_non_kubectl_failure(provider, k8s):

--- a/lib/iris/tests/cluster/backends/k8s/test_status_message.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_status_message.py
@@ -13,7 +13,7 @@ from iris.cluster.backends.k8s.tasks import (
     _pod_status_message,
     _task_update_from_pod,
 )
-from iris.cluster.controller.task_state import RunningTaskEntry
+from iris.cluster.controller.task_state import TaskAttemptEntry
 from iris.cluster.types import JobName
 from iris.rpc import job_pb2
 
@@ -69,7 +69,7 @@ def test_status_message_empty_for_healthy_running_pod():
 
 
 def test_task_update_carries_status_message_while_building():
-    entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
+    entry = TaskAttemptEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0, task_state=job_pb2.TASK_STATE_RUNNING)
     update = _task_update_from_pod(entry, gated_pod(), unadmitted_workload())
     assert update.new_state == job_pb2.TASK_STATE_BUILDING
     assert update.status_message is not None
@@ -79,7 +79,7 @@ def test_task_update_carries_status_message_while_building():
 def test_task_update_clears_status_message_on_running_and_terminal():
     """Running/terminal updates set status_message to "" so a stale BUILDING reason
     does not linger on a task that has moved on."""
-    entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
+    entry = TaskAttemptEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0, task_state=job_pb2.TASK_STATE_RUNNING)
     running = {
         "metadata": {"name": "iris-job-0-0"},
         "status": {"phase": "Running", "containerStatuses": [{"name": _TASK_CONTAINER_NAME, "state": {"running": {}}}]},

--- a/lib/iris/tests/cluster/backends/k8s/test_task_event.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_task_event.py
@@ -21,9 +21,10 @@ from iris.cluster.backends.k8s.tasks import (
     _pod_name,
     _task_hash,
 )
-from iris.cluster.controller.task_state import RunningTaskEntry
+from iris.cluster.controller.task_state import TaskAttemptEntry
 from iris.cluster.platforms.k8s.types import K8sResource
 from iris.cluster.types import JobName
+from iris.rpc import job_pb2
 from iris.test_util import FakeStatsTable
 
 from .conftest import (
@@ -38,9 +39,10 @@ from .conftest import (
     unevaluated_workload,
 )
 
-_ATTEMPT = RunningTaskEntry(
+_ATTEMPT = TaskAttemptEntry(
     task_id=JobName.from_wire("/job/0"),
     attempt_id=0,
+    task_state=job_pb2.TASK_STATE_RUNNING,
     attempt_uid="attempt-a",
 )
 
@@ -95,6 +97,7 @@ def test_event_log_writes_once_per_verdict_and_dedups_message_drift():
     log.observe(_ATTEMPT, _pod_event(gated_pod(), unadmitted_workload()))
     drifted = unadmitted_workload(msg=KUEUE_UNADMITTED_MSG.replace("Total nodes: 32", "Total nodes: 40"))
     log.observe(_ATTEMPT, _pod_event(gated_pod(), drifted))
+    log.observe(_ATTEMPT._replace(task_state=job_pb2.TASK_STATE_BUILDING), _pod_event(gated_pod(), drifted))
     log.observe(_ATTEMPT, None)  # pod momentarily quiet — no row, verdict retained
 
     rows = [r for w in table.writes for r in w]
@@ -189,9 +192,14 @@ def test_sync_writes_the_kueue_verdict_to_the_event_log(k8s):
     try:
         task_id = JobName.from_wire("/job/0")
         _seed_gated_task(k8s, task_id)
-        entry = RunningTaskEntry(task_id=task_id, attempt_id=0, attempt_uid="attempt-a")
+        entry = TaskAttemptEntry(
+            task_id=task_id,
+            attempt_id=0,
+            task_state=job_pb2.TASK_STATE_RUNNING,
+            attempt_uid="attempt-a",
+        )
 
-        provider.sync(make_batch(running_tasks=[entry]))
+        provider.sync(make_batch(task_attempts=[entry]))
 
         rows = [r for w in event_table.writes for r in w]
         assert len(rows) == 1
@@ -205,7 +213,7 @@ def test_sync_writes_the_kueue_verdict_to_the_event_log(k8s):
         assert "couldn't assign flavors" in row.message
 
         # A second identical tick must not append a duplicate (verdict unchanged).
-        provider.sync(make_batch(running_tasks=[entry]))
+        provider.sync(make_batch(task_attempts=[entry]))
         rows = [r for w in event_table.writes for r in w]
         assert len(rows) == 1
     finally:
@@ -219,7 +227,11 @@ def test_sync_singleton_surfaces_kueue_verdict_on_task_and_event(k8s):
         task_id = JobName.from_wire("/job/0")
         _seed_singleton_gated_task(k8s, task_id)
 
-        updates = provider.sync(make_batch(running_tasks=[RunningTaskEntry(task_id=task_id, attempt_id=0)]))
+        updates = provider.sync(
+            make_batch(
+                task_attempts=[TaskAttemptEntry(task_id=task_id, attempt_id=0, task_state=job_pb2.TASK_STATE_RUNNING)]
+            )
+        )
 
         assert len(updates) == 1
         assert "couldn't assign flavors" in (updates[0].status_message or "")

--- a/lib/iris/tests/cluster/conftest.py
+++ b/lib/iris/tests/cluster/conftest.py
@@ -245,7 +245,7 @@ class ServiceTestHarness:
             reconcile_rows=[],
             timeout_rows=[],
             tasks_to_run=batch.tasks_to_run,
-            running_tasks=batch.running_tasks,
+            task_attempts=batch.task_attempts,
         )
         # The backend now authors its dispatch effects; the controller (here, the
         # harness) just commits them.

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -411,34 +411,34 @@ def test_drain_redrives_assigned_null_worker(state):
     """ASSIGNED+null-worker rows are redriven into ``tasks_to_run`` on each
     cycle (idempotent ``kubectl apply``), so a controller crash between the
     promote-commit and the pod-apply still recovers. They are *also* in
-    ``running_tasks`` so the same-cycle poll observes the freshly-applied
+    ``task_attempts`` so the same-cycle poll observes the freshly-applied
     pod's phase and transitions the row out of ASSIGNED."""
     [task_id] = submit_direct_job(state, "drain-redrive")
 
     # First drain promotes PENDING -> ASSIGNED, builds a RunTaskRequest, and
-    # also includes the row in running_tasks so the post-apply poll picks up
+    # also includes the row in task_attempts so the post-apply poll picks up
     # the new pod's phase on the same cycle.
     with state._db.transaction() as cur:
         batch1 = dispatch.drain_for_dispatch(cur)
     assert len(batch1.tasks_to_run) == 1
     assert batch1.tasks_to_run[0].task_id == task_id.to_wire()
     assert batch1.tasks_to_run[0].attempt_id == 0
-    assert [(e.task_id, e.attempt_id) for e in batch1.running_tasks] == [(task_id, 0)]
+    assert [(e.task_id, e.attempt_id) for e in batch1.task_attempts] == [(task_id, 0)]
 
     # Second drain (simulates a crash between assign-commit and provider.sync,
     # or a transient apply failure): task is still ASSIGNED+null-worker, so it
     # is redriven in tasks_to_run with the same attempt_id and stays in
-    # running_tasks.
+    # task_attempts.
     with state._db.transaction() as cur:
         batch2 = dispatch.drain_for_dispatch(cur)
     assert len(batch2.tasks_to_run) == 1
     assert batch2.tasks_to_run[0].task_id == task_id.to_wire()
     assert batch2.tasks_to_run[0].attempt_id == 0
-    assert [(e.task_id, e.attempt_id) for e in batch2.running_tasks] == [(task_id, 0)]
+    assert [(e.task_id, e.attempt_id) for e in batch2.task_attempts] == [(task_id, 0)]
 
 
-def test_drain_scopes_running_tasks_to_backend(state):
-    """A CLUSTER_VIEW backend's drain scopes ``running_tasks`` (the poll set) to
+def test_drain_scopes_task_attempts_to_backend(state):
+    """A CLUSTER_VIEW backend's drain scopes ``task_attempts`` (the poll set) to
     its own backend_id. Without it two K8s backends each poll the other's
     running pods and, after the pod-not-found grace, mark them FAILED."""
     [task_a] = submit_direct_job(state, "backend-a")
@@ -456,11 +456,11 @@ def test_drain_scopes_running_tasks_to_backend(state):
         batch = dispatch.drain_for_dispatch(cur, backend_id="a")
 
     assert [r.task_id for r in batch.tasks_to_run] == [task_a.to_wire()]
-    assert [e.task_id for e in batch.running_tasks] == [task_a]
+    assert [e.task_id for e in batch.task_attempts] == [task_a]
 
 
-def test_drain_executing_goes_to_running_tasks(state):
-    """BUILDING/RUNNING rows with null worker land in running_tasks (poll set),
+def test_drain_executing_goes_to_task_attempts(state):
+    """BUILDING/RUNNING rows with null worker land in task_attempts (poll set),
     not tasks_to_run."""
     [task_id] = submit_direct_job(state, "drain-running")
 
@@ -480,9 +480,9 @@ def test_drain_executing_goes_to_running_tasks(state):
         batch2 = dispatch.drain_for_dispatch(cur)
 
     assert len(batch2.tasks_to_run) == 0
-    assert len(batch2.running_tasks) == 1
-    assert batch2.running_tasks[0].task_id == task_id
-    assert batch2.running_tasks[0].attempt_id == attempt_id
+    assert len(batch2.task_attempts) == 1
+    assert batch2.task_attempts[0].task_id == task_id
+    assert batch2.task_attempts[0].attempt_id == attempt_id
 
 
 # =============================================================================
@@ -965,9 +965,11 @@ def test_coscheduled_gang_requeue_keeps_siblings_in_lockstep(state):
     with state._db.transaction() as cur:
         draining = dispatch.drain_for_dispatch(cur)
     assert draining.tasks_to_run == []
-    assert {(entry.task_id, entry.attempt_id) for entry in draining.tasks_to_stop} == {
-        (task_id, 0) for task_id in task_ids[1:]
-    }
+    assert {
+        (entry.task_id, entry.attempt_id)
+        for entry in draining.task_attempts
+        if entry.task_state == job_pb2.TASK_STATE_PENDING
+    } == {(task_id, 0) for task_id in task_ids[1:]}
 
     # Kubernetes confirms that the sibling pods are gone.
     with state._db.transaction() as cur:
@@ -1028,7 +1030,10 @@ def test_gang_requeue_bounces_assigned_sibling_off_old_generation(state):
     with state._db.transaction() as cur:
         draining = dispatch.drain_for_dispatch(cur)
     assert draining.tasks_to_run == []
-    assert {entry.task_id for entry in draining.tasks_to_stop} == {task_ids[0], task_ids[2]}
+    assert {entry.task_id for entry in draining.task_attempts if entry.task_state == job_pb2.TASK_STATE_PENDING} == {
+        task_ids[0],
+        task_ids[2],
+    }
 
     with state._db.transaction() as cur:
         commit_dispatch_updates(

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -926,8 +926,8 @@ def test_drain_does_not_promote_partial_gang(state):
 
 def test_coscheduled_gang_requeue_keeps_siblings_in_lockstep(state):
     """End-to-end lockstep invariant: a transient failure bounces the whole gang to PENDING,
-    and the next drain re-promotes every sibling to the SAME next attempt_id — which is what
-    keeps the per-generation pod-group-name uniform across the gang."""
+    and the next drain re-promotes every sibling to the SAME next attempt_id after the
+    old pod generation has stopped."""
     task_event_table = FakeStatsTable()
     state._db.attach_task_event_table(task_event_table)
     _jid, task_ids = _submit_cosched(state, "lockstep", replicas=3, max_retries_preemption=5)
@@ -958,6 +958,24 @@ def test_coscheduled_gang_requeue_keeps_siblings_in_lockstep(state):
         (task_ids[1].to_wire(), "CoscheduledSiblingRequeued"),
         (task_ids[2].to_wire(), "CoscheduledSiblingRequeued"),
     ]
+
+    # The failed task's pod has stopped, but its siblings were only told to
+    # stop. Do not create replacement pods while those JAX ranks may still be
+    # connected to the old coordinator.
+    with state._db.transaction() as cur:
+        draining = dispatch.drain_for_dispatch(cur)
+    assert draining.tasks_to_run == []
+    assert {(entry.task_id, entry.attempt_id) for entry in draining.tasks_to_stop} == {
+        (task_id, 0) for task_id in task_ids[1:]
+    }
+
+    # Kubernetes confirms that the sibling pods are gone.
+    with state._db.transaction() as cur:
+        commit_dispatch_updates(
+            cur,
+            [TaskUpdate(task_id=t, attempt_id=0, new_state=job_pb2.TASK_STATE_KILLED) for t in task_ids[1:]],
+            now=Timestamp.now(),
+        )
 
     # Re-drain: the entire gang re-promotes to attempt 1 in lockstep.
     with state._db.transaction() as cur:
@@ -1005,8 +1023,24 @@ def test_gang_requeue_bounces_assigned_sibling_off_old_generation(state):
         s == job_pb2.TASK_STATE_PENDING for s in _states(state, task_ids)
     ), "the ASSIGNED sibling must not be stranded on the old generation"
 
-    # Re-drain: every sibling re-promotes to attempt 1 together; nothing is redriven on
-    # attempt 0 (which would mean a split pod-group generation).
+    # The old sibling pods must drain before replacement. Nothing is redriven
+    # on attempt 0, and attempt 1 is not created early.
+    with state._db.transaction() as cur:
+        draining = dispatch.drain_for_dispatch(cur)
+    assert draining.tasks_to_run == []
+    assert {entry.task_id for entry in draining.tasks_to_stop} == {task_ids[0], task_ids[2]}
+
+    with state._db.transaction() as cur:
+        commit_dispatch_updates(
+            cur,
+            [
+                TaskUpdate(task_id=t, attempt_id=0, new_state=job_pb2.TASK_STATE_KILLED)
+                for t in (task_ids[0], task_ids[2])
+            ],
+            now=Timestamp.now(),
+        )
+
+    # Re-drain: every sibling re-promotes to attempt 1 together.
     with state._db.transaction() as cur:
         batch = dispatch.drain_for_dispatch(cur)
     assert {r.task_id for r in batch.tasks_to_run} == {t.to_wire() for t in task_ids}

--- a/lib/iris/tests/cluster/controller/test_federation_fold_exclusion.py
+++ b/lib/iris/tests/cluster/controller/test_federation_fold_exclusion.py
@@ -84,7 +84,7 @@ def test_federated_pending_task_is_not_routed_or_dispatched(state):
     assert local_task.to_wire() in dispatched
     assert dispatched.isdisjoint({t.to_wire() for t in fed_tasks})
     # The RUNNING federated task must not enter the poll/redrive set either.
-    running_ids = {e.task_id for e in batch.running_tasks}
+    running_ids = {e.task_id for e in batch.task_attempts}
     assert running_ids.isdisjoint(fed_tasks)
 
     # The promotion only touched the local task; the federated rows are untouched.

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -4002,9 +4002,9 @@ def _count_pending(state: ControllerTestState) -> int:
 
 def test_drain_redrives_assigned_until_executing(state):
     """ASSIGNED+null-worker rows are redriven each cycle so a missed pod-apply
-    is recovered, and they are also in running_tasks so the same-cycle poll
+    is recovered, and they are also in task_attempts so the same-cycle poll
     transitions them out of ASSIGNED. Once the task reaches BUILDING/RUNNING,
-    it leaves tasks_to_run but stays in running_tasks."""
+    it leaves tasks_to_run but stays in task_attempts."""
     task_ids = _submit_job_direct(state, "/user/job1")
     task_id = task_ids[0]
 
@@ -4012,7 +4012,7 @@ def test_drain_redrives_assigned_until_executing(state):
     with state._db.transaction() as cur:
         batch1 = dispatch.drain_for_dispatch(cur)
     assert len(batch1.tasks_to_run) == 1
-    assert [(e.task_id, e.attempt_id) for e in batch1.running_tasks] == [(task_id, 0)]
+    assert [(e.task_id, e.attempt_id) for e in batch1.task_attempts] == [(task_id, 0)]
 
     # Second drain (e.g. previous _apply_pod failed or controller crashed):
     # row is still ASSIGNED, redriven in tasks_to_run with same attempt_id.
@@ -4021,9 +4021,9 @@ def test_drain_redrives_assigned_until_executing(state):
     assert len(batch2.tasks_to_run) == 1
     assert batch2.tasks_to_run[0].task_id == task_id.to_wire()
     assert batch2.tasks_to_run[0].attempt_id == 0
-    assert [(e.task_id, e.attempt_id) for e in batch2.running_tasks] == [(task_id, 0)]
+    assert [(e.task_id, e.attempt_id) for e in batch2.task_attempts] == [(task_id, 0)]
 
-    # Once the task reaches RUNNING it leaves tasks_to_run; running_tasks still
+    # Once the task reaches RUNNING it leaves tasks_to_run; task_attempts still
     # contains it so the next poll observes terminal transitions.
     with state._db.transaction() as cur:
         commit_dispatch_updates(
@@ -4034,8 +4034,8 @@ def test_drain_redrives_assigned_until_executing(state):
     with state._db.transaction() as cur:
         batch3 = dispatch.drain_for_dispatch(cur)
     assert len(batch3.tasks_to_run) == 0
-    assert len(batch3.running_tasks) == 1
-    assert batch3.running_tasks[0].task_id == task_id
+    assert len(batch3.task_attempts) == 1
+    assert batch3.task_attempts[0].task_id == task_id
 
 
 def test_drain_caps_promotions_per_cycle(state):


### PR DESCRIPTION
Keep direct-provider attempts unfinished until their Kubernetes pods leave the active phase. The controller sends the complete unfinished-attempt roster on every reconciliation, so the backend derives the pod delta and can repeat a shutdown acknowledgement after a dropped response.

A coscheduled failure now holds the replacement gang in PENDING while old sibling containers stop, preventing replacement JAX ranks from joining while the previous gang can still contact the coordinator.

The incident record is https://echo.oa.dev/wiki/26.

Fixes #7650
