### PR TITLE
[echo] Grant OpenAthena access to Echo

### DIFF
--- a/.agents/skills/echo-search/SKILL.md
+++ b/.agents/skills/echo-search/SKILL.md
@@ -1,42 +1,33 @@
 ---
 name: echo-search
-description: "Search and cite Marin's activity: the echo corpus (GitHub + Discord, always-on, zero setup) and the shared agent work-log. Use for 'was X discussed', 'which issue/PR covered Y', 'what did people decide about Z', 'what is the team working on'."
+description: "Search and cite Marin's GitHub and Discord activity in Echo. Use for 'was X discussed', 'which issue/PR covered Y', and 'what did people decide about Z'."
 ---
 
-# Skill: echo-search
+# Skill: Echo Search
 
-Two ways to search Marin's activity, every hit citable by URL — cite it, don't paraphrase
-from memory.
+Search Marin's activity through the shared Echo corpus. Every hit has a canonical URL;
+cite that URL instead of paraphrasing from memory.
 
-## echo — GitHub + Discord (default; zero setup)
+## Search
 
-`scripts/echo_search.py` searches the echo corpus (github issues/PRs/comments + Discord
-messages) over Cloud SQL IAM — no local install, no download beyond the query model.
+`infra/echo/cli/search.py` queries GitHub issues, pull requests, comments, and Discord
+messages through Cloud SQL IAM:
 
 ```bash
-scripts/echo_search.py search "expert parallel MoE MFU on B200" --limit 10
-scripts/echo_search.py search "..." --source discord --kind message --since 2026-06-01
-scripts/echo_search.py grep "ragged_all_to_all" --source discord   # exact substring, newest first
-scripts/echo_search.py show <id>                                   # one chunk, verbatim
+infra/echo/cli/search.py search "expert parallel MoE MFU on B200" --limit 10
+infra/echo/cli/search.py search "..." --source discord --kind message --since 2026-06-01
+infra/echo/cli/search.py grep "ragged_all_to_all" --source discord
+infra/echo/cli/search.py show <id>
 ```
 
-- `search` ranks by cosine distance (lower is closer; github hits below ~0.25 are usually
+- `search` ranks by cosine distance (lower is closer; GitHub hits below about 0.25 are usually
   on-topic); `grep` is an ILIKE scan for identifiers, run names, and exact strings.
 - Discord hits are the single message only — its surrounding thread isn't stored, so open
   the URL when you need the conversation.
-- The corpus is the github+discord slice of the marinmirror corpus, re-synced into echo
+- The corpus is the GitHub and Discord slice of the marinmirror corpus, re-synced into Echo
   every ~10 minutes.
 
-Powered by [mumwelt](https://github.com/Open-Athena/mumwelt).
-
-## work-log — what the team's agents are doing
-
-The `work_log` table (same echo database) is the agents' shared logbook. Browse it with the
-**work-log** skill, which wraps a CLI:
-
-- `recent [--days N] [--project <slug>]` — newest entries, optionally scoped to one thread
-  of work.
-- `show <id>` — the full body of one entry.
-
-Use it to answer "has anyone's agent already looked at this" before starting, and cite the
-entry's project and title.
+Access requires OpenAthena ADC and membership in the organization-wide database group.
+Follow [`infra/echo/README.md`](../../../infra/echo/README.md) for setup, access details,
+and the HTTP API. Search is powered by
+[mumwelt](https://github.com/Open-Athena/mumwelt).

--- a/infra/echo/README.md
+++ b/infra/echo/README.md
@@ -1,15 +1,72 @@
-# echo
+# Echo
 
-The shared context store for Marin's agents: the `context` database on the
-`marin-metadata` Cloud SQL instance, plus the `echo-api` service and `echo-sync` job in
-front of it.
+Echo is Marin's shared agent-context store. The `context` database runs on the
+`marin-metadata` Cloud SQL instance. `echo-sync` mirrors the GitHub and Discord slice of
+the [marinmirror](https://marinmirror.exe.xyz) corpus every 10 minutes, and `echo-api`
+provides an IAP-gated HTTP interface.
 
-- **`chunks`** — the github+discord slice of the [marinmirror](https://marinmirror.exe.xyz)
-  corpus (issues, PRs, comments, Discord messages), each with a canonical URL and a
-  pgvector embedding for semantic search, mirrored by the `echo-sync` job.
-- **`work_log`** — an append-only logbook agents write to, one row per distilled milestone.
+- `chunks` contains issues, pull requests, comments, and Discord messages. Each row has
+  a canonical URL and a pgvector embedding for semantic search.
+- `work_log` is an append-only agent logbook with one row per distilled milestone.
 
-Two ways in: **`echo-api`**, an IAP-gated Cloud Run service exposing an OpenAPI HTTP
-interface (`/search`, `/grep`, `/chunks/{id}`, `/work_log`), and **direct SQL** via the
-`context-search` / `work-log` skills. Access is Cloud SQL IAM, not passwords: the
-`echo@openathena.ai` group and the service accounts are IAM database users.
+## Search from the CLI
+
+The repository CLI connects directly to Cloud SQL with Application Default
+Credentials (ADC):
+
+```bash
+gcloud auth application-default login
+infra/echo/cli/search.py search "expert parallel MoE MFU on B200" --limit 10
+infra/echo/cli/search.py grep "ragged_all_to_all" --source discord
+infra/echo/cli/search.py show <id>
+```
+
+`search` ranks by cosine distance; lower scores are closer. GitHub hits below about
+0.25 are usually on topic. `grep` is a case-insensitive literal substring scan, newest
+first. Discord results contain one message, so open the result URL when the surrounding
+thread matters.
+
+Direct SQL access uses Cloud SQL IAM group authentication. Members of
+`eng-all@openathena.ai` inherit `roles/cloudsql.instanceUser`,
+`roles/cloudsql.client`, `SELECT` on `chunks`, and `SELECT, INSERT` on `work_log`.
+No database password is shared. Group membership and IAM changes can take about 15
+minutes to propagate.
+
+`MARIN_DB_USER` overrides the PostgreSQL username when ADC cannot resolve an
+impersonated, external-account, or workforce identity. Service-account usernames omit
+the `.gserviceaccount.com` suffix.
+
+## HTTP API
+
+OpenAthena accounts can access the IAP-gated `echo-api` Cloud Run service. It exposes
+OpenAPI documentation at `/docs` and the following endpoints:
+
+- `GET /search`
+- `GET /grep`
+- `GET /chunks/{id}`
+- `GET /work_log`
+- `GET /work_log/{id}`
+- `POST /work_log`
+
+The API connects to PostgreSQL as `echo-api@hai-gcp-models.iam`; callers do not need
+direct database access.
+
+## Infrastructure
+
+The `marin-echo` Pulumi stack creates the database, IAM database users, Cloud Run
+service, and scheduled sync job. Database migrations in `infra/echo/migrations/` create
+tables and apply PostgreSQL grants. `infra/echo/migrate.py` records applied migrations
+in `schema_migrations`.
+
+Preview or deploy from the service directory:
+
+```bash
+cd infra/echo
+pulumi stack select marin-echo
+pulumi preview
+pulumi up
+```
+
+`pulumi up` applies pending migrations from the operator's machine. It requires ADC
+with access to `cloudsql-pulumi-admin-password`. Review database grant changes before
+deploying them.

--- a/infra/echo/__main__.py
+++ b/infra/echo/__main__.py
@@ -37,8 +37,8 @@ DATABASE = "context"
 # database users, so the organization-wide group represents *@openathena.ai at the
 # database boundary.
 OPENATHENA_GROUP = "eng-all@openathena.ai"
-# Kept as an inert database user until m0001's fresh-stack grant and m0003's revoke can
-# run in order. It receives no IAM login roles or IAP access.
+# The bootstrap migration chain requires this role to exist from its initial grants
+# through their revocation. It receives no IAM login roles or IAP access.
 LEGACY_ECHO_GROUP = "echo@openathena.ai"
 # The Cloud Run runtime service accounts (created by their components as <name>@<project>).
 SYNC_SA = f"echo-sync@{PROJECT}.iam.gserviceaccount.com"

--- a/infra/echo/__main__.py
+++ b/infra/echo/__main__.py
@@ -7,11 +7,12 @@ Declares the `context` database on the shared `marin-metadata` Cloud SQL instanc
 (infra/cloudsql owns the instance), its Cloud SQL IAM database users, and the `echo-sync`
 scheduled Cloud Run job that keeps the corpus mirror current (sync/main.py).
 
-Access is IAM, not passwords: the `echo@openathena.ai` group reads the corpus and
-appends to the logbook, and the sync job's service account writes `chunks`/`sync_state`.
-Every principal authenticates through the Cloud SQL connector with a short-lived OAuth
-token, so no database password exists. Table grants are applied by migrate.py (see
-README.md); this program owns the users and their login IAM roles.
+Access is IAM, not passwords: the `eng-all@openathena.ai` group reads the corpus
+and appends to the logbook, and the sync job's service account writes
+`chunks`/`sync_state`. Every principal authenticates through the Cloud SQL connector
+with a short-lived OAuth token, so no database password exists. Table grants are
+applied by migrate.py (see README.md); this program owns the users and their login
+IAM roles.
 """
 
 import hashlib
@@ -31,8 +32,14 @@ REGION = "us-central1"
 INSTANCE = "marin-metadata"
 CONNECTION_NAME = f"{PROJECT}:{REGION}:{INSTANCE}"
 DATABASE = "context"
-# Google group whose members read the corpus and append to work_log, via IAM group auth.
-AGENTS_GROUP = "echo@openathena.ai"
+# Cloud Identity group whose members read the corpus and append to work_log through
+# Cloud SQL IAM group authentication. Cloud SQL does not support domain principals as
+# database users, so the organization-wide group represents *@openathena.ai at the
+# database boundary.
+OPENATHENA_GROUP = "eng-all@openathena.ai"
+# Kept as an inert database user until m0001's fresh-stack grant and m0003's revoke can
+# run in order. It receives no IAM login roles or IAP access.
+LEGACY_ECHO_GROUP = "echo@openathena.ai"
 # The Cloud Run runtime service accounts (created by their components as <name>@<project>).
 SYNC_SA = f"echo-sync@{PROJECT}.iam.gserviceaccount.com"
 API_SA = f"echo-api@{PROJECT}.iam.gserviceaccount.com"
@@ -61,21 +68,33 @@ def main() -> None:
 
     database = gcp.sql.Database("context", name=DATABASE, instance=INSTANCE, project=PROJECT, opts=child)
 
-    # IAM database users. The group is added once; its members inherit its grants without
-    # per-user registration. The sync SA is created by the job component below.
-    agents_group = gcp.sql.User(
+    # IAM database groups are added once; their members inherit database grants without
+    # per-user registration. Keep the legacy group present for migration ordering, but
+    # grant login only to the organization-wide group.
+    legacy_echo_group = gcp.sql.User(
         "agents-group",
-        name=AGENTS_GROUP,
+        name=LEGACY_ECHO_GROUP,
         instance=INSTANCE,
         project=PROJECT,
         type="CLOUD_IAM_GROUP",
         opts=pulumi.ResourceOptions.merge(
             child,
-            pulumi.ResourceOptions(import_=f"{PROJECT}/{INSTANCE}//{AGENTS_GROUP}" if adopt else None),
+            pulumi.ResourceOptions(import_=f"{PROJECT}/{INSTANCE}//{LEGACY_ECHO_GROUP}" if adopt else None),
+        ),
+    )
+    openathena_group = gcp.sql.User(
+        "openathena-group",
+        name=OPENATHENA_GROUP,
+        instance=INSTANCE,
+        project=PROJECT,
+        type="CLOUD_IAM_GROUP",
+        opts=pulumi.ResourceOptions.merge(
+            child,
+            pulumi.ResourceOptions(import_=f"{PROJECT}/{INSTANCE}//{OPENATHENA_GROUP}" if adopt else None),
         ),
     )
     for member, roles in (
-        (f"group:{AGENTS_GROUP}", LOGIN_ROLES),
+        (f"group:{OPENATHENA_GROUP}", LOGIN_ROLES),
         (f"serviceAccount:{SYNC_SA}", ("roles/cloudsql.instanceUser",)),
         (f"serviceAccount:{API_SA}", ("roles/cloudsql.instanceUser",)),
     ):
@@ -138,14 +157,14 @@ def main() -> None:
             max_instances=1,
             cpu_always_allocated=True,
             memory="2Gi",
-            iap_members=(f"group:{AGENTS_GROUP}",),
+            iap_members=("*@openathena.ai",),
             cloudsql_instances=(CONNECTION_NAME,),
         ),
         gcp_provider=gcp_provider,
     )
 
     # The service SAs exist only after their components; register them as IAM database users.
-    db_users = [agents_group]
+    db_users = [legacy_echo_group, openathena_group]
     for resource_name, db_user, component in (("sync-sa", SYNC_DB_USER, sync), ("api-sa", API_DB_USER, api)):
         db_users.append(
             gcp.sql.User(

--- a/infra/echo/api/app.py
+++ b/infra/echo/api/app.py
@@ -1,10 +1,9 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""The echo HTTP API: search the corpus and read/append the shared work log.
+"""Search the Echo corpus and read or append the shared work log over HTTP.
 
-A FastAPI service that encapsulates the `context-search` and `work-log` skills behind one
-OpenAPI-documented interface (see `/docs`). See infra/echo/README.md for how it is wired.
+See ``infra/echo/README.md`` for endpoints and access requirements.
 """
 
 import os

--- a/infra/echo/cli/search.py
+++ b/infra/echo/cli/search.py
@@ -10,8 +10,10 @@
 #     "fastembed>=0.3",
 # ]
 # ///
-"""Search the echo corpus (github+discord) over Cloud SQL IAM auth. See
-`.agents/skills/context-search/SKILL.md`."""
+"""Search the echo corpus over Cloud SQL IAM authentication.
+
+See ``infra/echo/README.md`` for access requirements and usage.
+"""
 
 import argparse
 import datetime

--- a/infra/echo/migrations/m0003_openathena_grants.py
+++ b/infra/echo/migrations/m0003_openathena_grants.py
@@ -1,0 +1,25 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Move human table privileges to the organization-wide Cloud Identity group.
+
+Cloud SQL IAM database authentication requires a user or group database principal;
+it cannot grant PostgreSQL privileges directly to a Google Workspace domain.
+`eng-all@openathena.ai` represents the OpenAthena domain at the database boundary.
+Pulumi creates both group users before this migration runs.
+"""
+
+import sqlalchemy
+
+GRANTS = """
+GRANT SELECT ON chunks TO "eng-all@openathena.ai";
+GRANT SELECT, INSERT ON work_log TO "eng-all@openathena.ai";
+REVOKE SELECT ON chunks FROM "echo@openathena.ai";
+REVOKE SELECT, INSERT ON work_log FROM "echo@openathena.ai";
+"""
+
+
+def upgrade(conn: sqlalchemy.Connection) -> None:
+    for statement in GRANTS.strip().split(";"):
+        if statement.strip():
+            conn.execute(sqlalchemy.text(statement))


### PR DESCRIPTION
Grant the `eng-all@openathena.ai` Cloud Identity group Cloud SQL login and
PostgreSQL table privileges, and admit `domain:openathena.ai` through Echo's
IAP service. Cloud SQL cannot use a Workspace domain as a database principal,
so the organization-wide group represents OpenAthena users at the database
boundary. The migration revokes the narrow `echo@openathena.ai` table grants
after the new grants are in place.

Move the search CLI from `scripts/` to `infra/echo/cli/search.py`. Consolidate
ADC setup, direct-SQL privileges, HTTP endpoints, and deployment guidance in
`infra/echo/README.md`; the Echo skill now points to that reference and no
longer names nonexistent skills.

The `marin-echo` update applied successfully on 2026-07-26. Pulumi created four
resources, updated four, deleted three, and replaced the migration command; a
follow-up preview reports 30 unchanged resources. The new migration is applied,
and a direct `SELECT` on `chunks` succeeded as
`russell.power@openathena.ai`.
