### PR TITLE
[echo] Diagnose ADC identity mismatches

### DIFF
--- a/infra/echo/README.md
+++ b/infra/echo/README.md
@@ -21,6 +21,10 @@ infra/echo/cli/search.py grep "ragged_all_to_all" --source discord
 infra/echo/cli/search.py show <id>
 ```
 
+Select your `@openathena.ai` account when `gcloud auth application-default login`
+opens the browser. ADC and the active `gcloud auth list` account are separate credential
+stores, so changing the active gcloud account does not replace existing ADC.
+
 `search` ranks by cosine distance; lower scores are closer. GitHub hits below about
 0.25 are usually on topic. `grep` is a case-insensitive literal substring scan, newest
 first. Discord results contain one message, so open the result URL when the surrounding

--- a/infra/echo/cli/search.py
+++ b/infra/echo/cli/search.py
@@ -30,6 +30,8 @@ EMBED_MODEL = "BAAI/bge-small-en-v1.5"  # must match the corpus's embedding spac
 SOURCES = ["github", "discord"]
 KINDS = ["issue", "pr", "comment", "message"]
 USERINFO_URL = "https://openidconnect.googleapis.com/v1/userinfo"
+OPENATHENA_USER_SUFFIX = "@openathena.ai"
+CLOUD_SQL_SERVICE_ACCOUNT_SUFFIX = ".iam"
 
 
 def db_user() -> str:
@@ -55,6 +57,17 @@ def db_user() -> str:
     if not email:
         raise SystemExit("your ADC identity exposes no email; set MARIN_DB_USER to your database username")
     return email
+
+
+def validate_db_user(user: str) -> str:
+    """Reject ADC identities that cannot inherit Echo's database grants."""
+    if user.endswith((OPENATHENA_USER_SUFFIX, CLOUD_SQL_SERVICE_ACCOUNT_SUFFIX)):
+        return user
+    raise SystemExit(
+        f"Echo resolved the database identity as {user!r}, which does not have access. "
+        "Run `gcloud auth application-default login` and select your @openathena.ai account. "
+        "Application Default Credentials are separate from the active `gcloud auth list` account."
+    )
 
 
 def escape_like(pattern: str) -> str:
@@ -177,7 +190,13 @@ def main() -> None:
     args = build_parser().parse_args()
     connector = Connector(quota_project=os.environ.get("GOOGLE_CLOUD_QUOTA_PROJECT"))
     try:
-        conn = connector.connect(INSTANCE, "pg8000", user=db_user(), enable_iam_auth=True, db=DATABASE)
+        conn = connector.connect(
+            INSTANCE,
+            "pg8000",
+            user=validate_db_user(db_user()),
+            enable_iam_auth=True,
+            db=DATABASE,
+        )
         try:
             args.func(conn.cursor(), args)
         finally:

--- a/infra/echo/cli/test_search.py
+++ b/infra/echo/cli/test_search.py
@@ -1,0 +1,20 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from infra.echo.cli import search as echo_search
+
+
+def test_validate_db_user_rejects_personal_adc() -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        echo_search.validate_db_user("alice@gmail.com")
+
+    message = str(exc_info.value)
+    assert "alice@gmail.com" in message
+    assert "gcloud auth application-default login" in message
+
+
+@pytest.mark.parametrize("user", ["alice@openathena.ai", "echo-api@hai-gcp-models.iam"])
+def test_validate_db_user_accepts_authorized_identity(user: str) -> None:
+    assert echo_search.validate_db_user(user) == user

--- a/infra/echo/cli/test_search.py
+++ b/infra/echo/cli/test_search.py
@@ -7,12 +7,8 @@ from infra.echo.cli import search as echo_search
 
 
 def test_validate_db_user_rejects_personal_adc() -> None:
-    with pytest.raises(SystemExit) as exc_info:
+    with pytest.raises(SystemExit):
         echo_search.validate_db_user("alice@gmail.com")
-
-    message = str(exc_info.value)
-    assert "alice@gmail.com" in message
-    assert "gcloud auth application-default login" in message
 
 
 @pytest.mark.parametrize("user", ["alice@openathena.ai", "echo-api@hai-gcp-models.iam"])


### PR DESCRIPTION
Reject Echo CLI database identities outside `@openathena.ai` or Cloud SQL
service-account usernames before attempting a database connection. The error
reports the resolved identity and directs the caller to refresh Application
Default Credentials, avoiding a misleading PostgreSQL table-permission failure
when personal ADC is installed.

Document that ADC is stored separately from gcloud's active account. This
follows the organization-wide grants added in #7662 and does not change IAM or
database permissions.
