### PR TITLE
datakit/decon: opt-in absolute-count recall path (marin#6852)

### DIFF
--- a/experiments/datakit/decontam/ops/__init__.py
+++ b/experiments/datakit/decontam/ops/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/experiments/datakit/decontam/ops/ab_flag_compare.py
+++ b/experiments/datakit/decontam/ops/ab_flag_compare.py
@@ -1,0 +1,214 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Before/after flag-rate compare for the absolute-count recall path (marin#6852).
+
+A single fixed decon run (``--min-abs-hits N``) already stores per-doc
+``max_overlap`` and ``contaminated``, so both operating points are recoverable
+from one pass — no second run needed:
+
+* baseline (pre-fix, fraction-only) flag  = ``max_overlap >= overlap_threshold``
+* fixed (fraction OR absolute-count) flag  = ``contaminated`` (as marked)
+* newly flagged by the abs-count path       = ``contaminated AND max_overlap < threshold``
+
+Rebuilds the decon DAG (``sample-root`` / ``exclude`` / ``min-abs-hits`` MUST match
+the run) to locate each source's output, counts per source (vectorized over the
+``attributes`` struct), and pulls the *newly* flagged docs from the flagged-sample
+sidecar with their text + the literal overlapping eval n-grams — the evidence for
+eyeballing whether the recall gain is genuine embedded contamination or noise.
+
+    uv run iris --cluster=cw-us-east-02a job run --cpu 2 --memory 6GB --enable-extra-resources \\
+        -e MARIN_PREFIX s3://marin-us-east-02a/marin \\
+        -- python experiments/datakit/decontam/ops/ab_flag_compare.py \\
+           --sample-root datakit/sample_100b_8ae7a94f --min-abs-hits 8 \\
+           --exclude <sources absent from the sample> \\
+           --out s3://marin-us-east-02a/marin/user/rav/decon6852/ab_100b.json
+"""
+
+import argparse
+import json
+import logging
+from concurrent.futures import ThreadPoolExecutor
+
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+from marin.datakit.decon import _bloom_hash, _extract_ngrams
+from rigging.filesystem import prefix_join, url_to_fs
+
+from experiments.datakit.testbed.decon_arm import (
+    NGRAM_LENGTH,
+    OVERLAP_THRESHOLD,
+    PARAGRAPH_DELIMITER,
+    build_testbed_decon_steps,
+)
+
+logger = logging.getLogger(__name__)
+
+_DECON_PREFIX = "datakit/testbed_decon/"
+
+
+def _overlapping_ngrams(text: str, matched: set[int], limit: int = 8) -> list[str]:
+    """The literal doc n-grams that hit the eval bloom — honest evidence for a flag."""
+    out: list[str] = []
+    for para in text.split(PARAGRAPH_DELIMITER):
+        for ng in _extract_ngrams(para, NGRAM_LENGTH, 0):
+            if _bloom_hash(ng) in matched:
+                out.append(ng)
+                if len(out) >= limit:
+                    return out
+    return out
+
+
+def _count_file(fs, f: str, threshold: float) -> tuple[int, int, int]:
+    # Project only the two scalar subfields (skip the matched_hashes list column).
+    with fs.open(f, "rb") as fh:
+        tbl = pq.read_table(fh, columns=["attributes.contaminated", "attributes.max_overlap"])
+    contaminated = tbl.column(0).combine_chunks()
+    max_overlap = tbl.column(1).combine_chunks()
+    fixed = pc.sum(contaminated).as_py() or 0
+    base = pc.sum(pc.greater_equal(max_overlap, threshold)).as_py() or 0
+    return len(contaminated), base, fixed
+
+
+def _count_source(main_dir: str, threshold: float, workers: int = 8) -> tuple[int, int, int]:
+    """Return (n_docs, baseline_flagged, fixed_flagged) over a source's outputs/main.
+
+    baseline = fraction path only (max_overlap >= threshold); fixed = the marked
+    ``contaminated`` flag (fraction OR abs-count). Files are read concurrently — the
+    object-store reads dominate, so this is I/O-bound.
+    """
+    fs, resolved = url_to_fs(main_dir)
+    files = sorted(x for x in fs.find(resolved) if x.endswith(".parquet"))
+    if not files:
+        raise FileNotFoundError(main_dir)
+    n = base = fixed = 0
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        for fn, b, fx in ex.map(lambda f: _count_file(fs, f, threshold), files):
+            n += fn
+            base += b
+            fixed += fx
+    return n, base, fixed
+
+
+def _newly_flagged_samples(flagged_dir: str, threshold: float, limit: int) -> list[dict]:
+    """Docs flagged by the abs-count path only (contaminated, max_overlap < threshold)."""
+    fs, resolved = url_to_fs(flagged_dir)
+    try:
+        files = sorted(x for x in fs.find(resolved) if x.endswith(".parquet"))
+    except FileNotFoundError:
+        return []
+    out: list[dict] = []
+    for f in files:
+        with fs.open(f, "rb") as fh:
+            tbl = pq.read_table(fh)
+        for row in tbl.to_pylist():
+            if row.get("max_overlap", 1.0) < threshold:
+                matched = set(row.get("matched_hashes") or [])
+                out.append(
+                    {
+                        "id": row["id"],
+                        "max_overlap": round(row.get("max_overlap", 0.0), 4),
+                        "n_matched_hashes": len(matched),
+                        "overlapping_ngrams": _overlapping_ngrams(row.get("text", ""), matched),
+                    }
+                )
+                if len(out) >= limit:
+                    return out
+    return out
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--sample-root", required=True, help="pre-materialized sample root under MARIN_PREFIX")
+    ap.add_argument("--exclude", nargs="*", default=None, help="sources absent from the sample (match the run)")
+    ap.add_argument("--min-abs-hits", type=int, default=8, help="the run's min_abs_hits (to match step hashes)")
+    ap.add_argument("--only", nargs="*", default=None, help="restrict analysis to these sources")
+    ap.add_argument("--samples", type=int, default=6, help="newly-flagged doc samples to pull per source")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+    min_abs_hits = None if args.min_abs_hits < 0 else args.min_abs_hits
+
+    steps = build_testbed_decon_steps(
+        sample_root=args.sample_root,
+        exclude_sources=frozenset(args.exclude or ()),
+        only_sources=args.only,
+        min_abs_hits=min_abs_hits,
+    )
+    decon_steps = {s.name.removeprefix(_DECON_PREFIX): s for s in steps if s.name.startswith(_DECON_PREFIX)}
+    logger.info("analyzing %d sources (min_abs_hits=%s)", len(decon_steps), min_abs_hits)
+
+    def analyze(item: tuple[str, object]) -> tuple[str, dict | None]:
+        name, step = item
+        main_dir = prefix_join(step.output_path, "outputs/main")
+        try:
+            n, base, fixed = _count_source(main_dir, OVERLAP_THRESHOLD, workers=4)
+        except FileNotFoundError:
+            logger.warning("no output for %s — skipping (source absent from sample)", name)
+            return name, None
+        newly = fixed - base
+        samples = (
+            _newly_flagged_samples(
+                prefix_join(step.output_path, "outputs/flagged_sample"), OVERLAP_THRESHOLD, args.samples
+            )
+            if newly > 0
+            else []
+        )
+        logger.info(
+            "%-42s n=%-10d base=%-7d (%.4f%%)  fixed=%-7d (%.4f%%)  new=%d",
+            name,
+            n,
+            base,
+            100 * base / n if n else 0,
+            fixed,
+            100 * fixed / n if n else 0,
+            newly,
+        )
+        return name, {
+            "n_docs": n,
+            "baseline_flagged": base,
+            "fixed_flagged": fixed,
+            "newly_flagged": newly,
+            "baseline_rate": round(base / n, 6) if n else 0.0,
+            "fixed_rate": round(fixed / n, 6) if n else 0.0,
+            "newly_rate": round(newly / n, 6) if n else 0.0,
+            "newly_samples": samples,
+        }
+
+    per_source: dict[str, dict] = {}
+    tot_n = tot_base = tot_fixed = 0
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        for name, rec in ex.map(analyze, sorted(decon_steps.items())):
+            if rec is None:
+                continue
+            per_source[name] = rec
+            tot_n += rec["n_docs"]
+            tot_base += rec["baseline_flagged"]
+            tot_fixed += rec["fixed_flagged"]
+
+    summary = {
+        "total_docs": tot_n,
+        "baseline_flagged": tot_base,
+        "fixed_flagged": tot_fixed,
+        "newly_flagged": tot_fixed - tot_base,
+        "baseline_rate": round(tot_base / tot_n, 6) if tot_n else 0.0,
+        "fixed_rate": round(tot_fixed / tot_n, 6) if tot_n else 0.0,
+    }
+    logger.info(
+        "TOTAL: %d docs  baseline=%d (%.5f%%)  fixed=%d (%.5f%%)  newly=%d (%.1fx)",
+        tot_n,
+        tot_base,
+        100 * summary["baseline_rate"],
+        tot_fixed,
+        100 * summary["fixed_rate"],
+        summary["newly_flagged"],
+        (tot_fixed / tot_base) if tot_base else float("inf"),
+    )
+    ofs, opath = url_to_fs(args.out)
+    with ofs.open(opath, "w") as fh:
+        json.dump({"summary": summary, "min_abs_hits": min_abs_hits, "by_source": per_source}, fh, indent=2)
+    logger.info("wrote %s", args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/datakit/decontam/ops/ab_flag_compare.py
+++ b/experiments/datakit/decontam/ops/ab_flag_compare.py
@@ -60,11 +60,13 @@ def _overlapping_ngrams(text: str, matched: set[int], limit: int = 8) -> list[st
 
 
 def _count_file(fs, f: str, threshold: float) -> tuple[int, int, int]:
-    # Project only the two scalar subfields (skip the matched_hashes list column).
+    # Read the attributes struct and pull the two scalar subfields via .field()
+    # (matched_hashes is a mostly-empty list, so loading it is cheap). Extracting
+    # by field name is robust to how a given pyarrow version projects nested columns.
     with fs.open(f, "rb") as fh:
-        tbl = pq.read_table(fh, columns=["attributes.contaminated", "attributes.max_overlap"])
-    contaminated = tbl.column(0).combine_chunks()
-    max_overlap = tbl.column(1).combine_chunks()
+        attrs = pq.read_table(fh, columns=["attributes"]).column("attributes").combine_chunks()
+    contaminated = attrs.field("contaminated")
+    max_overlap = attrs.field("max_overlap")
     fixed = pc.sum(contaminated).as_py() or 0
     base = pc.sum(pc.greater_equal(max_overlap, threshold)).as_py() or 0
     return len(contaminated), base, fixed

--- a/experiments/datakit/decontam/ops/contam_benchmark.py
+++ b/experiments/datakit/decontam/ops/contam_benchmark.py
@@ -1,0 +1,416 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Precision/recall benchmark for decon on artificial data with known labels (marin#6852).
+
+A self-contained pipeline: generate a labeled corpus → run the *real* decon
+(`decon_to_parquet`) → score precision / recall / F1 against the ground truth.
+
+Runs two arms on the same corpus and reports them side by side:
+
+* A — core decon, no common-ngram filter (the baseline precision/recall).
+* B — with the DF filter: a drop-set built from the benchmark corpus itself
+  (`build_source_drop_set`) excludes ngrams common across the corpus. Boilerplate
+  hard negatives (a famous quote, an instruction template) appear in enough docs
+  to clear the DF cutoff and get dropped → precision rises; distinctive injected
+  eval items appear too rarely to be dropped → recall is unchanged.
+
+Doc families (each labeled contaminated or clean):
+
+* POSITIVE — a real eval item injected into filler in four forms (verbatim,
+  its own paragraph, short-line-wrapped, inline-embedded). Contaminated → recall.
+* EASY_NEGATIVE — filler only, no eval overlap. Clean.
+* HARD_NEGATIVE — a doc that *shares non-distinctive text* with the eval suite
+  (a legal enacting clause, a famous quote, a truth-table instruction template,
+  a standard math identity) but is not a leak. Clean → precision. These are the
+  false-positive families catalogued in marin#6852; the benchmark measures how
+  often the algorithm mistakes them for contamination.
+
+Reports headline P/R/F1 at the 0.5 overlap threshold, a per-mechanism breakdown
+(recall per positive form, false-positive rate per hard-negative family), and a
+PR curve over overlap thresholds (from each doc's ``max_overlap``).
+
+    uv run iris --cluster=cw-rno2a job run --cpu 2 --memory 4GB --enable-extra-resources \\
+        -e MARIN_PREFIX s3://marin-us-east-02a/marin \\
+        -- python experiments/datakit/decontam/ops/contam_benchmark.py \\
+           --work s3://marin-us-east-02a/marin/user/rav/decon_benchmark \\
+           --out s3://marin-us-east-02a/marin/user/rav/decon_viewer/benchmark.json
+"""
+
+import argparse
+import json
+import logging
+import random
+from collections import defaultdict
+
+import dupekit
+import pyarrow as pa
+import pyarrow.parquet as pq
+from marin.datakit.decon import (
+    NGramConfig,
+    _bloom_hash,
+    _discover_eval_files,
+    _extract_features,
+    bloom_paths,
+    build_eval_bloom,
+    build_source_drop_set,
+    decon_to_parquet,
+)
+from marin.datakit.normalize import NormalizedData
+from rigging.filesystem import StoragePath, marin_prefix, url_to_fs
+from zephyr.readers import load_file
+
+from experiments.datakit.decontam.config import SOURCE_DF_COMMON_FRAC, SOURCE_DF_COMMON_MIN_ABS
+from experiments.datakit.decontam.prepare_eval_corpus import DECON_EXCLUDED_EVAL_TASKS
+from experiments.datakit.testbed.decon_arm import (
+    NGRAM_LENGTH,
+    OVERLAP_THRESHOLD,
+    PARAGRAPH_DELIMITER,
+)
+
+logger = logging.getLogger(__name__)
+_EVALS_RELATIVE = "datakit/decontam/evals"
+
+# Generic prose that shares no eval n-grams — the padding around injected items.
+# Bloom-hitting sentences are dropped before use so filler never self-flags.
+_FILLER_POOL = [
+    "The afternoon market sold ripe tomatoes and fresh basil to a handful of unhurried regulars.",
+    "Rain tapped the tin roof while the kettle warmed and the cat stretched across the windowsill.",
+    "She repainted the fence a pale green over the weekend and planted marigolds along the walk.",
+    "The commuter train was six minutes late, which gave everyone time to finish their coffee.",
+    "A gentle breeze carried the smell of cut grass across the empty football pitch at dusk.",
+    "He sorted the mismatched socks into a shoebox and labelled it with a faded blue marker.",
+    "The library's reading room hummed with the quiet turning of pages and the occasional cough.",
+    "Two gulls argued over a chip near the harbour wall as the ferry idled at the dock.",
+    "Grandmother's recipe called for a pinch of nutmeg and an hour of patience by the stove.",
+    "The bicycle's front tyre had gone soft again, so he walked it the last block home.",
+    "Streetlights flickered on one by one as the shopkeepers rolled down their metal shutters.",
+    "A toddler chased pigeons across the plaza while her father photographed the old clock tower.",
+    "The hiking club rescheduled the ridge walk after the forecast promised an afternoon of hail.",
+    "Fresh bread cooled on a rack behind the counter and the whole street smelled of yeast.",
+    "The mechanic wiped his hands on a rag and said the alternator would last another winter.",
+    "Autumn leaves clogged the gutter, so they spent Sunday morning up ladders with old buckets.",
+    "The choir rehearsed the same eight bars until the tenor finally landed the high note.",
+    "A single lamp burned in the lighthouse as the tide crept back over the mudflats.",
+    "The bakery ran out of croissants by nine, which surprised no one who arrived at ten.",
+    "He learned to whittle small birds from driftwood during the long quiet ferry crossings.",
+]
+
+
+def _sentence_ngrams_hit(text: str, bf: dupekit.Bloom, ngram: NGramConfig) -> bool:
+    return any(_bloom_hash(feat) in bf for feat in _extract_features(text, ngram))
+
+
+def _short_line_wrap(text: str, words_per_line: int = 8) -> str:
+    words = text.split()
+    return "\n".join(" ".join(words[i : i + words_per_line]) for i in range(0, len(words), words_per_line))
+
+
+# Non-distinctive text shared with the eval suite — the FP families (marin#6852).
+# Each string is verified to hit the bloom before use (else it can't test precision).
+_HARD_NEGATIVES = {
+    "enacting_clause": (
+        "Be it enacted by the Senate and House of Representatives of the "
+        "United States of America in Congress assembled, That this Act may be cited by its short title."
+    ),
+    "gettysburg": (
+        "Four score and seven years ago our fathers brought forth on this continent a new nation, "
+        "conceived in liberty, and dedicated to the proposition that all men are created equal."
+    ),
+    "truth_table_template": (
+        "Construct a complete truth table for the following argument. Then, using the truth "
+        "table, determine whether the argument is valid or invalid. If the argument is invalid, choose an option "
+        "which presents a counterexample."
+    ),
+    "sum_of_cubes_identity": (
+        "Recall the factoring identity x^3 + y^3 + z^3 - 3xyz = "
+        "(x + y + z)(x^2 + y^2 + z^2 - xy - yz - zx), which shows up in many contest problems."
+    ),
+    # Verbatim recurring formula from hendrycks/minerva math evals (~20 items),
+    # so it is guaranteed in the bloom yet non-distinctive across problems.
+    "arithmetic_series_formula": (
+        "The sum of an arithmetic series is equal to the average of the first and "
+        "last term, multiplied by the number of terms, a fact worth memorizing before the exam."
+    ),
+}
+
+
+def _build_filler(rng: random.Random, bf: dupekit.Bloom, ngram: NGramConfig) -> list[str]:
+    pool = [s for s in _FILLER_POOL if not _sentence_ngrams_hit(s, bf, ngram)]
+    dropped = len(_FILLER_POOL) - len(pool)
+    if dropped:
+        logger.warning("dropped %d filler sentences that hit the bloom", dropped)
+    rng.shuffle(pool)
+    return pool
+
+
+def _filler_block(filler: list[str], rng: random.Random, n: int = 4) -> str:
+    return "\n\n".join(rng.sample(filler, min(n, len(filler))))
+
+
+def _generate(
+    eval_files: list[str], bf: dupekit.Bloom, ngram: NGramConfig, n_positive: int, n_hard: int, n_easy: int, seed: int
+) -> tuple[list[dict], list[dict]]:
+    """Return (docs[{id,text,partition_id}], labels[{id,contaminated,mechanism,eval_id}])."""
+    rng = random.Random(seed)
+    filler = _build_filler(rng, bf, ngram)
+
+    # Eval items with enough tokens to form a matchable n-gram, deduped.
+    items: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for path in eval_files:
+        for rec in load_file(path):
+            text = str(rec.get("text") or "")
+            if len(text.split()) >= NGRAM_LENGTH and text not in seen and _sentence_ngrams_hit(text, bf, ngram):
+                seen.add(text)
+                items.append((str(rec.get("id") or f"{path}::{len(items)}"), text))
+        if len(items) >= n_positive * 3:
+            break
+    if len(items) < n_positive:
+        raise ValueError(f"only {len(items)} usable eval items found; need {n_positive}")
+    picked = rng.sample(items, n_positive)
+
+    docs: list[dict] = []
+    labels: list[dict] = []
+
+    def add(text: str, contaminated: bool, mechanism: str, eval_id: str | None) -> None:
+        did = f"bench-{len(docs):06d}"
+        docs.append({"id": did, "text": text, "partition_id": 0})
+        labels.append({"id": did, "contaminated": contaminated, "mechanism": mechanism, "eval_id": eval_id or ""})
+
+    forms = {
+        "verbatim": lambda t: t,
+        "own_paragraph": lambda t: f"{_filler_block(filler, rng)}\n\n{t}\n\n{_filler_block(filler, rng)}",
+        "short_line": lambda t: f"{_filler_block(filler, rng)}\n\n{_short_line_wrap(t)}\n\n{_filler_block(filler, rng)}",
+        "embedded": lambda t: f"{_filler_block(filler, rng)} {t.replace(chr(10), ' ')} {_filler_block(filler, rng)}",
+    }
+    for eid, text in picked:
+        for form, fn in forms.items():
+            add(fn(text), True, f"positive_{form}", eid)
+
+    for name, boiler in _HARD_NEGATIVES.items():
+        if not _sentence_ngrams_hit(boiler, bf, ngram):
+            logger.warning("hard negative %s does not hit the bloom — it can't be a false positive here", name)
+        for _ in range(n_hard):
+            add(f"{_filler_block(filler, rng)}\n\n{boiler}\n\n{_filler_block(filler, rng)}", False, f"hard_{name}", None)
+
+    for _ in range(n_easy):
+        add(_filler_block(filler, rng, n=6), False, "easy_negative", None)
+
+    logger.info(
+        "generated %d docs (%d positive, %d hard-neg, %d easy-neg)",
+        len(docs),
+        n_positive * 4,
+        n_hard * len(_HARD_NEGATIVES),
+        n_easy,
+    )
+    return docs, labels
+
+
+def _write_docs(docs: list[dict], out_dir: str) -> str:
+    path = f"{out_dir.rstrip('/')}/docs/part-00000-of-00001.parquet"
+    StoragePath(f"{out_dir.rstrip('/')}/docs").mkdirs()
+    with StoragePath(path).open("wb") as fh:
+        pq.write_table(pa.Table.from_pylist(docs), fh, compression="zstd")
+    return f"{out_dir.rstrip('/')}/docs"
+
+
+def _read_predictions(decon_out: str) -> dict[str, tuple[float, bool]]:
+    """id -> (max_overlap, contaminated) from the decon attributes (under outputs/main).
+
+    ``contaminated`` is decon's actual decision — fraction >= threshold OR the
+    absolute-count recall path (marin#6852). Scoring reads it directly rather than
+    re-thresholding ``max_overlap``, which would be blind to the abs-count path
+    (those docs are flagged with ``max_overlap`` still below the fraction threshold).
+    """
+    fs, resolved = url_to_fs(f"{decon_out.rstrip('/')}/outputs/main")
+    preds: dict[str, tuple[float, bool]] = {}
+    for f in sorted(x for x in fs.find(resolved) if x.endswith(".parquet")):
+        with fs.open(f, "rb") as fh:
+            tbl = pq.read_table(fh, columns=["id", "attributes"])
+        for did, a in zip(tbl.column("id").to_pylist(), tbl.column("attributes").to_pylist(), strict=True):
+            a = a or {}
+            preds[did] = (a.get("max_overlap", 0.0) or 0.0, bool(a.get("contaminated", False)))
+    return preds
+
+
+def _prf(tp: int, fp: int, fn: int) -> dict[str, float]:
+    p = tp / (tp + fp) if tp + fp else 0.0
+    r = tp / (tp + fn) if tp + fn else 0.0
+    f1 = 2 * p * r / (p + r) if p + r else 0.0
+    return {"precision": round(p, 4), "recall": round(r, 4), "f1": round(f1, 4), "tp": tp, "fp": fp, "fn": fn}
+
+
+def _score(labels: list[dict], preds: dict[str, tuple[float, bool]], threshold: float) -> dict:
+    # Headline / per-mechanism metrics use decon's ACTUAL decision (the contaminated
+    # flag), so the absolute-count recall path is scored. The PR curve below stays a
+    # fraction-only diagnostic (it sweeps max_overlap and cannot express abs-count).
+    def is_flagged(did: str) -> bool:
+        return preds.get(did, (0.0, False))[1]
+
+    def frac_flagged(did: str, t: float) -> bool:
+        ov = preds.get(did, (0.0, False))[0]
+        return ov >= t and ov > 0
+
+    tp = fp = fn = 0
+    per_mech: dict[str, list[int]] = defaultdict(lambda: [0, 0])  # mechanism -> [n, n_flagged]
+    for lab in labels:
+        pred = is_flagged(lab["id"])
+        per_mech[lab["mechanism"]][0] += 1
+        per_mech[lab["mechanism"]][1] += int(pred)
+        if lab["contaminated"]:
+            tp += int(pred)
+            fn += int(not pred)
+        else:
+            fp += int(pred)
+
+    mech_report = {}
+    for mech, (n, nf) in sorted(per_mech.items()):
+        is_pos = mech.startswith("positive_")
+        mech_report[mech] = {
+            "n": n,
+            "flagged": nf,
+            ("recall" if is_pos else "false_positive_rate"): round(nf / n, 4) if n else 0.0,
+        }
+
+    curve = []
+    for t in (0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9):
+        ctp = sum(1 for x in labels if x["contaminated"] and frac_flagged(x["id"], t))
+        cfp = sum(1 for x in labels if not x["contaminated"] and frac_flagged(x["id"], t))
+        cfn = sum(1 for x in labels if x["contaminated"] and not frac_flagged(x["id"], t))
+        m = _prf(ctp, cfp, cfn)
+        curve.append({"threshold": t, "precision": m["precision"], "recall": m["recall"], "f1": m["f1"]})
+
+    return {"overall": _prf(tp, fp, fn), "threshold": threshold, "by_mechanism": mech_report, "pr_curve": curve}
+
+
+def _log_comparison(a: dict, b: dict, n_dropped: int, delimiter: str) -> None:
+    """Print arm A (no filter) vs arm B (DF filter) side by side."""
+    logger.info("=== decon contamination benchmark (delimiter=%r) ===", delimiter)
+    logger.info("DF filter dropped %d common ngrams (built from the benchmark corpus)", n_dropped)
+    oa, ob = a["overall"], b["overall"]
+    logger.info(
+        "OVERALL @%.2f   A(no filter): P=%.3f R=%.3f F1=%.3f (fp=%d)   B(DF filter): P=%.3f R=%.3f F1=%.3f (fp=%d)",
+        OVERLAP_THRESHOLD,
+        oa["precision"],
+        oa["recall"],
+        oa["f1"],
+        oa["fp"],
+        ob["precision"],
+        ob["recall"],
+        ob["f1"],
+        ob["fp"],
+    )
+    logger.info("%-28s %13s %13s", "mechanism", "A flagged", "B flagged")
+    for mech in a["by_mechanism"]:
+        ra, rb = a["by_mechanism"][mech], b["by_mechanism"][mech]
+        logger.info("  %-26s n=%-5d %6d %13d", mech, ra["n"], ra["flagged"], rb["flagged"])
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--work", required=True, help="scratch dir for bloom + docs + decon output")
+    ap.add_argument("--out", required=True, help="metrics JSON path")
+    ap.add_argument("--n-positive", type=int, default=300)
+    ap.add_argument("--n-hard", type=int, default=40, help="docs per hard-negative family")
+    ap.add_argument("--n-easy", type=int, default=200)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument(
+        "--delimiter",
+        default=None,
+        help=r"paragraph delimiter override (backslash-escaped, e.g. '\n' per-line or '\n\n' true-paragraph); "
+        f"default is the production {PARAGRAPH_DELIMITER!r}",
+    )
+    ap.add_argument(
+        "--min-abs-hits",
+        type=int,
+        default=NGramConfig.min_abs_hits,
+        help="absolute-count recall path threshold (marin#6852); pass -1 to disable it and "
+        f"reproduce the fraction-only baseline. Default is the production {NGramConfig.min_abs_hits}.",
+    )
+    args = ap.parse_args()
+    delimiter = args.delimiter.encode().decode("unicode_escape") if args.delimiter else PARAGRAPH_DELIMITER
+    min_abs_hits = None if args.min_abs_hits is not None and args.min_abs_hits < 0 else args.min_abs_hits
+    ngram = NGramConfig(
+        ngram_length=NGRAM_LENGTH,
+        overlap_threshold=OVERLAP_THRESHOLD,
+        paragraph_delimiter=delimiter,
+        min_abs_hits=min_abs_hits,
+    )
+
+    eval_root = f"{marin_prefix()}/{_EVALS_RELATIVE}"
+    eval_files = list(_discover_eval_files([eval_root], DECON_EXCLUDED_EVAL_TASKS))
+
+    bloom_dir = f"{args.work.rstrip('/')}/bloom"
+    bloom_path, _ = bloom_paths(bloom_dir)
+    # The bloom depends only on the eval corpus + feature policy (ngram length /
+    # delimiter / letter filter), NOT on min_abs_hits — so an existing bloom in the
+    # work dir is reused across min_abs_hits settings, skipping the ~minutes-long
+    # single-process build on re-runs.
+    if StoragePath(bloom_path).exists():
+        logger.info("reusing existing bloom at %s", bloom_path)
+    else:
+        build_eval_bloom(
+            eval_data_sources=[eval_root],
+            output_path=bloom_dir,
+            ngram=ngram,
+            estimated_doc_count=50_000_000,
+            false_positive_rate=1e-9,
+            exclude_eval_dirs=DECON_EXCLUDED_EVAL_TASKS,
+        )
+    bf = dupekit.Bloom.load_bytes(StoragePath(bloom_path).read_bytes())
+
+    docs, labels = _generate(eval_files, bf, ngram, args.n_positive, args.n_hard, args.n_easy, args.seed)
+    docs_dir = _write_docs(docs, args.work)
+    norm = NormalizedData(main_output_dir=docs_dir, dup_output_dir="", counters={})
+
+    # Arm A: core decon, no common-ngram filter.
+    decon_to_parquet(
+        normalized_data=norm, prebuilt_bloom_dir=bloom_dir, output_path=f"{args.work.rstrip('/')}/decon_a", ngram=ngram
+    )
+    metrics_a = _score(labels, _read_predictions(f"{args.work.rstrip('/')}/decon_a"), OVERLAP_THRESHOLD)
+
+    # Arm B: DF filter. Build a drop-set from the benchmark corpus itself (the
+    # "source"), then decon with the common ngrams excluded from every overlap.
+    drop_dir = f"{args.work.rstrip('/')}/drop"
+    dropped = build_source_drop_set(
+        df_sample_dir=docs_dir,
+        prebuilt_bloom_dir=bloom_dir,
+        output_path=drop_dir,
+        ngram=ngram,
+        sample_docs=len(docs),
+        common_frac=SOURCE_DF_COMMON_FRAC,
+        common_min_abs=SOURCE_DF_COMMON_MIN_ABS,
+    )
+    decon_to_parquet(
+        normalized_data=norm,
+        prebuilt_bloom_dir=bloom_dir,
+        output_path=f"{args.work.rstrip('/')}/decon_b",
+        ngram=ngram,
+        drop_set_dirs=[drop_dir],
+    )
+    metrics_b = _score(labels, _read_predictions(f"{args.work.rstrip('/')}/decon_b"), OVERLAP_THRESHOLD)
+
+    metrics = {
+        "arm_a_no_filter": metrics_a,
+        "arm_b_df_filter": metrics_b,
+        "config": {
+            "paragraph_delimiter": delimiter,
+            "ngram_length": NGRAM_LENGTH,
+            "min_abs_hits": min_abs_hits,
+            "n_docs": len(docs),
+            "df_common_frac": SOURCE_DF_COMMON_FRAC,
+            "df_common_min_abs": SOURCE_DF_COMMON_MIN_ABS,
+            "df_ngrams_dropped": dropped.n_dropped,
+        },
+    }
+    ofs, opath = url_to_fs(args.out)
+    with ofs.open(opath, "w") as fh:
+        json.dump(metrics, fh, indent=2)
+    _log_comparison(metrics_a, metrics_b, dropped.n_dropped, delimiter)
+    logger.info("wrote %s", args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/datakit/decontam/ops/contam_benchmark.py
+++ b/experiments/datakit/decontam/ops/contam_benchmark.py
@@ -344,12 +344,15 @@ def main() -> None:
     eval_root = f"{marin_prefix()}/{_EVALS_RELATIVE}"
     eval_files = list(_discover_eval_files([eval_root], DECON_EXCLUDED_EVAL_TASKS))
 
-    bloom_dir = f"{args.work.rstrip('/')}/bloom"
+    # Key the bloom dir on the feature policy that actually changes its contents
+    # (ngram length + paragraph delimiter), NOT on min_abs_hits (a mark-time knob
+    # that leaves the bloom identical). So a re-run reuses the bloom across
+    # min_abs_hits settings — skipping the ~minutes-long single-process build — but
+    # a different --delimiter or ngram length builds its own bloom instead of
+    # silently reusing an incompatible one.
+    delim_slug = delimiter.encode("unicode_escape").decode().replace("\\", "")
+    bloom_dir = f"{args.work.rstrip('/')}/bloom_n{NGRAM_LENGTH}_d{delim_slug}"
     bloom_path, _ = bloom_paths(bloom_dir)
-    # The bloom depends only on the eval corpus + feature policy (ngram length /
-    # delimiter / letter filter), NOT on min_abs_hits — so an existing bloom in the
-    # work dir is reused across min_abs_hits settings, skipping the ~minutes-long
-    # single-process build on re-runs.
     if StoragePath(bloom_path).exists():
         logger.info("reusing existing bloom at %s", bloom_path)
     else:

--- a/experiments/datakit/decontam/ops/contam_benchmark.py
+++ b/experiments/datakit/decontam/ops/contam_benchmark.py
@@ -26,9 +26,11 @@ Doc families (each labeled contaminated or clean):
   false-positive families catalogued in marin#6852; the benchmark measures how
   often the algorithm mistakes them for contamination.
 
-Reports headline P/R/F1 at the 0.5 overlap threshold, a per-mechanism breakdown
-(recall per positive form, false-positive rate per hard-negative family), and a
-PR curve over overlap thresholds (from each doc's ``max_overlap``).
+Reports headline P/R/F1 from decon's actual ``contaminated`` decision (fraction
+>= threshold OR the absolute-count path, so abs-count flags below 0.5 count), a
+per-mechanism breakdown (recall per positive form, false-positive rate per
+hard-negative family), and a fraction-only PR curve over overlap thresholds
+(swept from each doc's ``max_overlap``, so it does not reflect the abs-count path).
 
     uv run iris --cluster=cw-rno2a job run --cpu 2 --memory 4GB --enable-extra-resources \\
         -e MARIN_PREFIX s3://marin-us-east-02a/marin \\
@@ -326,8 +328,8 @@ def main() -> None:
         "--min-abs-hits",
         type=int,
         default=NGramConfig.min_abs_hits,
-        help="absolute-count recall path threshold (marin#6852); pass -1 to disable it and "
-        f"reproduce the fraction-only baseline. Default is the production {NGramConfig.min_abs_hits}.",
+        help="absolute-count recall path threshold (marin#6852); pass e.g. 8 to enable it, "
+        f"or -1 to force-disable. Default {NGramConfig.min_abs_hits} = off (the fraction-only baseline).",
     )
     args = ap.parse_args()
     delimiter = args.delimiter.encode().decode("unicode_escape") if args.delimiter else PARAGRAPH_DELIMITER

--- a/experiments/datakit/testbed/decon_arm.py
+++ b/experiments/datakit/testbed/decon_arm.py
@@ -201,8 +201,8 @@ def main() -> None:
         "--min-abs-hits",
         type=int,
         default=MIN_ABS_HITS,
-        help="absolute-count recall path threshold (marin#6852); pass -1 to disable "
-        "it and reproduce the pre-fix fraction-only baseline for a before/after compare",
+        help="absolute-count recall path threshold (marin#6852); pass e.g. 8 to enable it "
+        "(default None = the fraction-only baseline), or -1 to force-disable",
     )
     args = ap.parse_args()
     min_abs_hits = None if args.min_abs_hits is not None and args.min_abs_hits < 0 else args.min_abs_hits

--- a/experiments/datakit/testbed/decon_arm.py
+++ b/experiments/datakit/testbed/decon_arm.py
@@ -61,6 +61,14 @@ OVERLAP_THRESHOLD = 0.5
 # isolated-line coincidences (fewer FPs) and lets short-line / inline-embedded
 # eval text be matched (higher recall). See marin#6852.
 PARAGRAPH_DELIMITER = "\n\n"
+# Absolute-count recall path (marin#6852): flag a paragraph carrying >= this many
+# distinct bloom-hit ngrams even when they are a minority of the paragraph — the
+# embedded/inline case the fraction threshold misses. ~= this many + 12 consecutive
+# verbatim benchmark words. Opt-in / default off: on a 100B testbed min_abs_hits=8
+# ~doubled the flag rate, mixing genuine embedded leakage with cross-source
+# boilerplate FPs (now filtered by the global drop-set, #7635 / marin#7126). Set via
+# --min-abs-hits to experiment. None = pure fraction (production default).
+MIN_ABS_HITS: int | None = None
 # Estimate local and cross-source DF from the largest materialized sample
 # regardless of the decon target. Layout: <root>/<source>/outputs/main.
 SAMPLE_1T_ROOT = "datakit/sample_1t_733c8c5c"
@@ -75,6 +83,7 @@ def build_testbed_decon_steps(
     only_sources: list[str] | None = None,
     exclude_sources: frozenset[str] = frozenset(),
     sample_root: str | None = None,
+    min_abs_hits: int | None = MIN_ABS_HITS,
 ) -> list[StepSpec]:
     """Bloom (fixed) + one decon step per sampled source.
 
@@ -156,6 +165,7 @@ def build_testbed_decon_steps(
                 ngram_length=NGRAM_LENGTH,
                 overlap_threshold=OVERLAP_THRESHOLD,
                 paragraph_delimiter=PARAGRAPH_DELIMITER,
+                min_abs_hits=min_abs_hits,
                 flagged_sample_size=FLAGGED_SAMPLE_SIZE,
                 estimated_doc_count=ESTIMATED_DOC_COUNT,
                 false_positive_rate=FALSE_POSITIVE_RATE,
@@ -187,13 +197,22 @@ def main() -> None:
         help="decon a pre-materialized sample root under MARIN_PREFIX directly "
         "(e.g. datakit/sample_1t_733c8c5c); marks read <root>/<source>/outputs/main",
     )
+    ap.add_argument(
+        "--min-abs-hits",
+        type=int,
+        default=MIN_ABS_HITS,
+        help="absolute-count recall path threshold (marin#6852); pass -1 to disable "
+        "it and reproduce the pre-fix fraction-only baseline for a before/after compare",
+    )
     args = ap.parse_args()
+    min_abs_hits = None if args.min_abs_hits is not None and args.min_abs_hits < 0 else args.min_abs_hits
     StepRunner().run(
         build_testbed_decon_steps(
             target_total_tokens_b=args.target_tokens_b,
             sample_root=args.sample_root,
             only_sources=args.only,
             exclude_sources=frozenset(args.exclude or ()),
+            min_abs_hits=min_abs_hits,
         )
     )
 

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -114,6 +114,12 @@ class NGramConfig:
     paragraph_delimiter: str = "\n\n"
     min_abs_hits: int | None = None
 
+    def __post_init__(self) -> None:
+        # min_abs_hits < 1 would flag every paragraph (even zero-hit ones), so
+        # reject it — callers disable the path with None, not 0.
+        if self.min_abs_hits is not None and self.min_abs_hits < 1:
+            raise ValueError(f"min_abs_hits must be >= 1 or None, got {self.min_abs_hits}")
+
 
 class DeconAttributes(BaseModel):
     """Outcome of :func:`decon_to_parquet`: a co-partitioned attributes dataset.

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -105,7 +105,7 @@ class NGramConfig:
             (instruction-tuning / synthetic sources) and those cross-source FPs.
             Leave ``None`` unless paired with a cross-source boilerplate filter, or
             you accept that added flag volume. ``None`` = pure fraction overlap (the
-            precision-favoring default). See :func:`_make_marker`.
+            precision-favoring default).
     """
 
     ngram_length: int = 13

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -85,12 +85,34 @@ class NGramConfig:
             both dilutes isolated-line coincidences (precision) and lets short-line
             / inline-embedded eval text be matched (recall). ``"\n"`` instead treats
             each line as its own paragraph. See marin#6852.
+        min_abs_hits: Absolute-count recall path (marin#6852), **opt-in / default
+            disabled**. When set, a paragraph is also marked contaminated when it
+            contains at least this many *distinct* bloom-hit ngrams, regardless of
+            the overlap fraction. This catches an eval item embedded mid-paragraph
+            among unrelated filler — a minority of the paragraph's ngrams
+            (fraction < ``overlap_threshold``) but still a contiguous run of matched
+            ngrams. ``min_abs_hits`` distinct hits ≈ ``min_abs_hits + ngram_length -
+            1`` consecutive verbatim benchmark words.
+
+            Precision caveat (measured on a 100B testbed, marin#6852): the
+            per-source common-ngram drop-set suppresses boilerplate that is common
+            *within* a source, but **cross-source** boilerplate/passages/templates
+            (a legal enacting clause, a famous quote, an MCQ instruction stem, a
+            standard LaTeX identity) are rare within any one source, survive the
+            drop-set, and are then flagged by this path — the same false-positive
+            classes tracked in marin#7126. At ``min_abs_hits=8`` this ~doubled the
+            testbed flag rate (0.004%→0.010%), a mix of genuine embedded leakage
+            (instruction-tuning / synthetic sources) and those cross-source FPs.
+            Leave ``None`` unless paired with a cross-source boilerplate filter, or
+            you accept that added flag volume. ``None`` = pure fraction overlap (the
+            precision-favoring default). See :func:`_make_marker`.
     """
 
     ngram_length: int = 13
     stride: int = 0
     overlap_threshold: float = 0.5
     paragraph_delimiter: str = "\n\n"
+    min_abs_hits: int | None = None
 
 
 class DeconAttributes(BaseModel):
@@ -424,6 +446,10 @@ def _make_marker(
     # so any non-zero match is always recorded.
     threshold = ngram.overlap_threshold if ngram is not None else 0.0
     delimiter = ngram.paragraph_delimiter if ngram is not None else "\n"
+    # Absolute-count recall path (marin#6852): flag when any paragraph carries at
+    # least this many distinct bloom-hit ngrams, even if that is a minority of the
+    # paragraph (embedded/inline eval text). Disabled in exact-paragraph mode.
+    min_abs_hits = ngram.min_abs_hits if ngram is not None else None
 
     def mark_shard(paths: Iterator[str], shard: ShardInfo) -> Iterator[dict[str, Any]]:
         # Load bloom once per shard.
@@ -439,6 +465,7 @@ def _make_marker(
                 for record in load_file(p):
                     text = str(record.get(text_field, "") or "")
                     max_score = 0.0
+                    max_para_hits = 0
                     matched: set[int] = set()
                     for para in text.split(delimiter):
                         if not para:
@@ -446,8 +473,13 @@ def _make_marker(
                         score, hits = _paragraph_overlap_and_matches(para, bf, ngram, drop_hashes)
                         if score > max_score:
                             max_score = score
+                        para_distinct = len(set(hits))
+                        if para_distinct > max_para_hits:
+                            max_para_hits = para_distinct
                         matched.update(hits)
-                    contaminated = max_score > 0 and max_score >= threshold
+                    contaminated = (max_score > 0 and max_score >= threshold) or (
+                        min_abs_hits is not None and max_para_hits >= min_abs_hits
+                    )
                     counters.pipeline.update_counter("decon/contaminated" if contaminated else "decon/clean", 1)
                     if contaminated and flagged_sample_size:
                         n_flagged += 1
@@ -1235,6 +1267,7 @@ def decon_step(
     ngram_length: int | None = 13,
     overlap_threshold: float = 0.5,
     paragraph_delimiter: str = "\n\n",
+    min_abs_hits: int | None = None,
     flagged_sample_size: int = 0,
     estimated_doc_count: int = 1_000_000,
     false_positive_rate: float = 1e-9,
@@ -1278,6 +1311,12 @@ def decon_step(
         paragraph_delimiter: Paragraph split string (see :class:`NGramConfig`).
             When reusing a ``prebuilt_bloom``, MUST match the delimiter the bloom
             was built with, or the two feature sets won't line up.
+        min_abs_hits: Absolute-count recall path (see :class:`NGramConfig`) —
+            opt-in, default disabled. When set, a paragraph is also marked
+            contaminated when it holds at least this many distinct bloom-hit ngrams,
+            catching embedded/inline eval text (at a cross-source-boilerplate FP
+            cost; see :class:`NGramConfig`). Only affects the mark stage, not the
+            bloom. ``None`` disables it.
         estimated_doc_count, false_positive_rate: Bloom sizing parameters.
             Ignored when ``prebuilt_bloom`` is set.
         worker_resources, max_workers: Zephyr execution knobs.
@@ -1290,7 +1329,10 @@ def decon_step(
 
     ngram: NGramConfig | None = (
         NGramConfig(
-            ngram_length=ngram_length, overlap_threshold=overlap_threshold, paragraph_delimiter=paragraph_delimiter
+            ngram_length=ngram_length,
+            overlap_threshold=overlap_threshold,
+            paragraph_delimiter=paragraph_delimiter,
+            min_abs_hits=min_abs_hits,
         )
         if ngram_length is not None
         else None
@@ -1312,6 +1354,11 @@ def decon_step(
     # run with sampling off keeps the same address as before this feature landed.
     if flagged_sample_size:
         hash_attrs["flagged_sample_size"] = flagged_sample_size
+    # Likewise the absolute-count path: min_abs_hits=None reproduces the pre-fix
+    # fraction-only mark exactly, so it must not re-address existing caches. A
+    # non-None value changes the marking and gets its own address.
+    if min_abs_hits is not None:
+        hash_attrs["min_abs_hits"] = min_abs_hits
 
     if drop_sets is not None and drop_set_source is None:
         raise ValueError("drop_set_source is required when drop_sets is set")

--- a/tests/datakit/test_decon.py
+++ b/tests/datakit/test_decon.py
@@ -650,6 +650,80 @@ def test_decon_catches_near_verbatim_with_word_insertion(tmp_path: Path):
     assert rows["doc_inserted"]["max_overlap"] >= 0.5
 
 
+# ----- Absolute-count recall path (marin#6852): embedded/inline eval text -----
+
+# 14 tokens → 11 distinct 4-grams, all from the eval; enough to clear min_abs_hits.
+_EMBED_EVAL_TEXT = (
+    "photosynthesis converts carbon dioxide and water into glucose "
+    "using sunlight within chloroplast membranes efficiently"
+)
+
+
+def _embedded_doc(eval_text: str, pad_words: int = 40) -> str:
+    """Wrap *eval_text* verbatim inside a long single paragraph of unrelated filler.
+
+    The filler shares no ngrams with the eval, so only the eval's own ngrams hit
+    the bloom — a minority of the paragraph, i.e. overlap fraction well below the
+    0.5 threshold. This is the embedded/inline case the fraction path misses.
+    """
+    filler = " ".join(f"filler{i}" for i in range(pad_words))
+    return f"{filler} {eval_text} {filler}"
+
+
+def test_decon_abs_count_flags_embedded_eval_below_fraction_threshold(tmp_path: Path):
+    """A substantial eval item embedded mid-paragraph is flagged via the absolute-count path.
+
+    The overlap *fraction* is well below 0.5 (the eval is a minority of the long
+    paragraph's ngrams), so the fraction path alone misses it — but the eval
+    contributes >= min_abs_hits distinct bloom-hit ngrams, so it is caught.
+    """
+    eval_text = _EMBED_EVAL_TEXT
+    rows = _run_decon_one_shot(
+        tmp_path,
+        eval_records=[{"id": "eval", "text": eval_text}],
+        input_records=[{"id": "doc_embedded", "partition_id": 0, "text": _embedded_doc(eval_text)}],
+        ngram=NGramConfig(ngram_length=4, overlap_threshold=0.5, min_abs_hits=10),
+    )
+    assert rows["doc_embedded"]["contaminated"] is True
+    # Proves the win is from the absolute-count path, not the fraction: fraction < 0.5.
+    assert rows["doc_embedded"]["max_overlap"] < 0.5
+
+
+def test_decon_abs_count_disabled_reverts_to_fraction_only(tmp_path: Path):
+    """With min_abs_hits=None the same embedded doc is NOT flagged (fraction path only).
+
+    Pins the absolute-count path as the sole reason the previous test flags, and
+    that disabling it restores the pre-fix behaviour.
+    """
+    eval_text = _EMBED_EVAL_TEXT
+    rows = _run_decon_one_shot(
+        tmp_path,
+        eval_records=[{"id": "eval", "text": eval_text}],
+        input_records=[{"id": "doc_embedded", "partition_id": 0, "text": _embedded_doc(eval_text)}],
+        ngram=NGramConfig(ngram_length=4, overlap_threshold=0.5, min_abs_hits=None),
+    )
+    assert rows["doc_embedded"]["contaminated"] is False
+    assert rows["doc_embedded"]["max_overlap"] < 0.5
+
+
+def test_decon_abs_count_gated_below_min_hits(tmp_path: Path):
+    """A short embedded fragment (few matched ngrams) is NOT flagged by the abs-count path.
+
+    The minimum-hit gate is what keeps trivial coincidental overlaps (and the
+    ``"..."`` short-paragraph artifact) from re-introducing false positives:
+    an eval fragment contributing fewer than min_abs_hits ngrams stays clean.
+    """
+    # 6 tokens → 3 distinct 4-grams, below min_abs_hits=10.
+    eval_text = "sodium chloride readily dissolves in warm water"
+    rows = _run_decon_one_shot(
+        tmp_path,
+        eval_records=[{"id": "eval", "text": eval_text}],
+        input_records=[{"id": "doc_fragment", "partition_id": 0, "text": _embedded_doc(eval_text)}],
+        ngram=NGramConfig(ngram_length=4, overlap_threshold=0.5, min_abs_hits=10),
+    )
+    assert rows["doc_fragment"]["contaminated"] is False
+
+
 # ----- Known limitations (xfail with strict=True — tripwire if behavior improves) -----
 
 
@@ -702,15 +776,22 @@ def test_decon_misses_punctuation_only_differences(tmp_path: Path):
 
 
 @pytest.mark.xfail(
-    reason="short eval embedded in a long single paragraph dilutes the overlap fraction below threshold",
+    reason="short eval embedded in a long single paragraph dilutes the overlap "
+    "fraction below threshold; the absolute-count recall path is opt-in (default "
+    "off) and, even when on, a 1-ngram fragment is below any sane min_abs_hits",
     strict=True,
 )
 def test_decon_misses_short_eval_diluted_in_long_paragraph(tmp_path: Path):
     """Eval is a short fragment; pretraining wraps it inside a long single paragraph.
 
     With n=4, the eval contributes ~1 ngram. The pretraining paragraph has many
-    ngrams (the prefix + the eval ngram + the suffix). Score = 1/N → below 0.5.
-    A length-decay or substring-aware scorer (cf. allenai/decon) would catch it.
+    ngrams (the prefix + the eval ngram + the suffix). Score = 1/N → below 0.5. The
+    default config leaves ``min_abs_hits=None`` (the precision-favoring operating
+    point), so the absolute-count recall path (marin#6852) is off here. Even enabled,
+    a 1-ngram fragment is below any useful ``min_abs_hits`` — catching it would
+    re-open the trivial ``"..."`` short-fragment false positives. A *substantial*
+    embedded span IS caught when the path is enabled; see
+    ``test_decon_abs_count_flags_embedded_eval_below_fraction_threshold``.
     """
     rows = _run_decon_one_shot(
         tmp_path,

--- a/tests/datakit/test_decon.py
+++ b/tests/datakit/test_decon.py
@@ -706,6 +706,13 @@ def test_decon_abs_count_disabled_reverts_to_fraction_only(tmp_path: Path):
     assert rows["doc_embedded"]["max_overlap"] < 0.5
 
 
+@pytest.mark.parametrize("bad", [0, -1])
+def test_ngram_config_rejects_nonpositive_min_abs_hits(bad):
+    """min_abs_hits < 1 would flag every paragraph, so construction rejects it (None disables)."""
+    with pytest.raises(ValueError, match="min_abs_hits"):
+        NGramConfig(min_abs_hits=bad)
+
+
 def test_decon_abs_count_gated_below_min_hits(tmp_path: Path):
     """A short embedded fragment (few matched ngrams) is NOT flagged by the abs-count path.
 


### PR DESCRIPTION
* part of https://github.com/marin-community/marin/issues/6852
* adds `NGramConfig.min_abs_hits` — an opt-in absolute-count recall path for embedded/inline contamination: a paragraph is also flagged when it holds `>= min_abs_hits` distinct bloom-hit 13-grams, even when they're a minority of the paragraph (fraction `< overlap_threshold`)
  * targets the case the fraction path misses — an eval item inlined mid-paragraph among filler dilutes below the 0.5 threshold
* `None` by default (disabled); the mark `hash_attr` is omitted when `None`, so production decon is byte-identical — no cache invalidation, no behavior change
* on the CoreWeave labeled benchmark, `min_abs_hits=8` lifts embedded recall `0.37 → 0.91` (overall `0.83 → 0.97`), precision held at `1.0` by the per-source DF drop-set
* but a 100B testbed before/after (103.7M docs, `0.0041% → 0.0095%`, `2.3×`) shows the new flags on real web data are dominated by cross-source boilerplate/passage/template false positives [^1] the per-source drop-set can't suppress
  * this is exactly what the global cross-source drop-set added in #7635 targets — this branch is rebased on it, so the precision companion is now in place
  * still ships off by default; a follow-up should re-measure the abs-count before/after **with** the global drop-set active to pick the operating point (whether to enable it, and at what threshold)
* fix `contam_benchmark` to score on the `contaminated` flag instead of re-thresholding `max_overlap` (which is blind to the abs-count path)
* add `ops/ab_flag_compare.py` — single-run before/after flag-rate analysis over a testbed decon run (baseline = `max_overlap ≥ threshold`, new = `contaminated & max_overlap < threshold`)

[^1]: enacting clauses (`"Be it enacted by the Senate and House..."`), famous quotes (a bible verse in `hplt_v3`), MCQ instruction stems, standard LaTeX identities — shared public text, not test-answer leakage
