### PR TITLE
Collect GLM-5.2 responses for hero_run_4_code

### DIFF
--- a/.agents/logbooks/hero-run-4-code-glm52.md
+++ b/.agents/logbooks/hero-run-4-code-glm52.md
@@ -49,3 +49,12 @@ author: will-held
 - Config: Model `zai-org/GLM-5.2-FP8` at revision `ba978f7d347eaf65d22f1a86833408afdb953541`; regional model cache TTL 30 days.
 - Decision: Populate the distributed regional model cache before reserving GPUs.
 - Next: Submit the cache job, verify `model-cache.json`, then launch an 8-GPU smoke.
+
+### 2026-07-28 06:45 PDT - Partial cache recovery
+
+- Status: blocked on the original cache lease
+- Evidence: The first cache attempt uploaded 97 of 141 weight shards but did not write `.cache_complete` or `model-cache.json`. No production or smoke output exists. The original east-08 worker still refreshes its distributed lease while the object count remains unchanged.
+- Command: `uv run iris --controller-url http://127.0.0.1:18100 job run --no-wait --job-name hero-run-4-code-glm52-cache-resume-20260728 --priority batch --enable-extra-resources --cpu 8 --memory 64GB --disk 100GB --extra marin-core:cpu --timeout 259200 -- python -m experiments.rollout_data.collect_hero_run_4_code_glm52 prepare --output-path s3://marin-us-east-02a/marin/rollouts/glm-5.2/hero-run-4-code-20260727`
+- Config: Source commit `c62eda3fb`; preserve existing cache files and download only missing files; batch priority; no GPUs.
+- Decision: Keep the active lease intact. The resume job and automatic 8-GPU smoke launcher remain queued.
+- Next: Terminate the stalled original cache task through the east-08 control plane, then let the retry fetch the remaining 44 weight shards.

--- a/.agents/logbooks/hero-run-4-code-glm52.md
+++ b/.agents/logbooks/hero-run-4-code-glm52.md
@@ -1,0 +1,30 @@
+---
+topic: hero-run-4-code-glm52
+issue: https://github.com/marin-community/marin/issues/7697
+description: Generate GLM-5.2 responses for every hero_run_4_code prompt.
+author: will-held
+---
+
+# hero_run_4_code GLM-5.2: Hero Run Logbook
+
+## Run Contract
+
+- DRI: Will Held
+- Goal: Generate one GLM-5.2 FP8 response for all 959,216 `instruction_seed` prompts.
+- Stop/escalation criteria: Stop on corrupt output, repeated deterministic failure, or sustained throughput more than 30% below the pilot baseline. Batch preemption is recoverable.
+- Issue: https://github.com/marin-community/marin/issues/7697
+- W&B: not applicable; progress is recorded in S3 manifests and Iris logs.
+- Output root: `s3://marin-us-east-02a/marin/rollouts/glm-5.2/hero-run-4-code-20260727`
+- Final step: 959,216 complete response records.
+- Checkpoint policy: Immutable compressed JSONL chunks retained permanently. Progress manifests are updated after each chunk; restart skips complete chunks.
+
+## Launched Instances
+
+## Event Log
+
+### 2026-07-27 23:00 PDT - Run contract
+
+- Status: implementation in progress
+- Evidence: 202 schedulable GB200 nodes were ready. The live allocation left 756 B200 GPUs free and 92 same-domain TP8 placements; the requested run is capped at 85 TP8 instances (680 GPUs).
+- Decision: Use the working two-node Ray/vLLM GLM-5.2 topology from the KernelGym collector. Run an 8-GPU smoke and a 64-GPU pilot before the 680-GPU launch.
+- Next: Implement deterministic Parquet row-group sharding, model-cache preparation, resumable output chunks, and progress manifests.

--- a/.agents/logbooks/hero-run-4-code-glm52.md
+++ b/.agents/logbooks/hero-run-4-code-glm52.md
@@ -20,6 +20,18 @@ author: will-held
 
 ## Launched Instances
 
+### 2026-07-27 23:48 PDT - `/held/hero-run-4-code-glm52-cache-20260727`
+
+- Command: `uv run iris --controller-url http://127.0.0.1:18100 job run --no-wait --job-name hero-run-4-code-glm52-cache-20260727 --priority batch --enable-extra-resources --cpu 8 --memory 64GB --disk 100GB --extra marin-core:cpu --timeout 259200 -- python -m experiments.rollout_data.collect_hero_run_4_code_glm52 prepare --output-path s3://marin-us-east-02a/marin/rollouts/glm-5.2/hero-run-4-code-20260727`
+- Git SHA: `5f4f66c4a27f4e2c5ac1fec56dbeb76bd82f01f0`
+- Dirty tree: no
+- Source bundle/container: Iris workspace bundle from the Git SHA above; default Iris CPU task image.
+- Hardware/topology: 8 CPU, 64 GB memory, 100 GB disk; Iris batch priority.
+- `initialize_from`: not applicable
+- Final step: regional cache `.cache_complete` plus `model-cache.json` at the output root.
+- Checkpoint policy: not applicable; the pinned model mirror has a 30-day regional cache TTL.
+- Babysitter/check cadence: 2-minute startup check, then 15 minutes.
+
 ## Event Log
 
 ### 2026-07-27 23:00 PDT - Run contract

--- a/.agents/logbooks/hero-run-4-code-glm52.md
+++ b/.agents/logbooks/hero-run-4-code-glm52.md
@@ -28,3 +28,12 @@ author: will-held
 - Evidence: 202 schedulable GB200 nodes were ready. The live allocation left 756 B200 GPUs free and 92 same-domain TP8 placements; the requested run is capped at 85 TP8 instances (680 GPUs).
 - Decision: Use the working two-node Ray/vLLM GLM-5.2 topology from the KernelGym collector. Run an 8-GPU smoke and a 64-GPU pilot before the 680-GPU launch.
 - Next: Implement deterministic Parquet row-group sharding, model-cache preparation, resumable output chunks, and progress manifests.
+
+### 2026-07-27 23:47 PDT - Implementation ready
+
+- Status: ready for model-cache preparation
+- Evidence: Source commit `7141baeee6a97d467fd806402270b51cd5bcd675` is pushed in PR #7698. `tests/experiment/test_collect_hero_run_4_code_glm52.py` passes, Pyrefly reports no errors, and the branch lint-catalog review reports no findings.
+- Command: `uv run iris --controller-url http://127.0.0.1:18100 job run --no-wait --job-name hero-run-4-code-glm52-cache-20260727 --priority batch --enable-extra-resources --cpu 8 --memory 64GB --disk 100GB --extra marin-core:cpu --timeout 259200 -- python -m experiments.rollout_data.collect_hero_run_4_code_glm52 prepare --output-path s3://marin-us-east-02a/marin/rollouts/glm-5.2/hero-run-4-code-20260727`
+- Config: Model `zai-org/GLM-5.2-FP8` at revision `ba978f7d347eaf65d22f1a86833408afdb953541`; regional model cache TTL 30 days.
+- Decision: Populate the distributed regional model cache before reserving GPUs.
+- Next: Submit the cache job, verify `model-cache.json`, then launch an 8-GPU smoke.

--- a/experiments/rollout_data/collect_hero_run_4_code_glm52.py
+++ b/experiments/rollout_data/collect_hero_run_4_code_glm52.py
@@ -163,6 +163,86 @@ class CollectionDelta:
     output_path: StoragePath | None
 
 
+@dataclass(frozen=True)
+class ResponseMessage:
+    role: str
+    content: str | None
+    reasoning_content: str | None
+
+
+@dataclass(frozen=True)
+class CompletionRecord:
+    dataset_index: int
+    source_file_index: int
+    source_row_group: int
+    source_row_offset: int
+    id: str | None
+    original_row_index: int
+    instruction_seed: str
+    dataset: str
+    dataset_split: str
+    dataset_revision: str
+    parquet_revision: str
+    model: str
+    model_revision: str
+    temperature: float
+    top_p: float
+    max_tokens: int
+    seed: int
+    response: ResponseMessage
+    finish_reason: str | None
+    usage: dict[str, Any]
+    response_id: str | None
+    elapsed_seconds: float
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    run_id: str
+    output_path: str
+    dataset: str
+    dataset_split: str
+    dataset_revision: str
+    parquet_revision: str
+    dataset_rows: int
+    model: str
+    model_revision: str
+    num_shards: int
+    max_records_per_shard: int | None
+    chunk_size: int
+    concurrency: int
+    max_model_len: int
+    max_num_seqs: int
+    gpu_memory_utilization: float
+    temperature: float
+    top_p: float
+    max_tokens: int
+    enable_thinking: bool
+
+
+@dataclass(frozen=True)
+class ProgressRecord:
+    run_id: str
+    state: str
+    shard_index: int
+    num_shards: int
+    expected_records: int
+    complete_records: int
+    generated_records_this_attempt: int
+    skipped_records_this_attempt: int
+    elapsed_seconds: float
+    updated_at: str
+
+
+@dataclass(frozen=True)
+class ModelCacheManifest:
+    model: str
+    model_revision: str
+    weights: str
+    cache_ttl_days: int
+    prepared_at: str
+
+
 def partition_specs() -> list[PartitionSpec]:
     partitions = []
     row_start = 0
@@ -230,7 +310,7 @@ def _read_partition(partition_slice: PartitionSlice) -> list[PromptRecord]:
     return records
 
 
-def _completion(vllm_url: str, prompt: PromptRecord, sampling: SamplingConfig) -> dict[str, Any]:
+def _completion(vllm_url: str, prompt: PromptRecord, sampling: SamplingConfig) -> CompletionRecord:
     started = time.time()
     response = requests.post(
         f"{vllm_url}/v1/chat/completions",
@@ -250,28 +330,28 @@ def _completion(vllm_url: str, prompt: PromptRecord, sampling: SamplingConfig) -
     payload = response.json()
     choice = payload["choices"][0]
     message = choice["message"]
-    return {
+    return CompletionRecord(
         **asdict(prompt),
-        "dataset": DATASET,
-        "dataset_split": DATASET_SPLIT,
-        "dataset_revision": DATASET_REVISION,
-        "parquet_revision": PARQUET_REVISION,
-        "model": MODEL,
-        "model_revision": MODEL_REVISION,
-        "temperature": sampling.temperature,
-        "top_p": sampling.top_p,
-        "max_tokens": sampling.max_tokens,
-        "seed": prompt.dataset_index,
-        "response": {
-            "role": message.get("role", "assistant"),
-            "content": message.get("content"),
-            "reasoning_content": message.get("reasoning_content"),
-        },
-        "finish_reason": choice.get("finish_reason"),
-        "usage": payload.get("usage", {}),
-        "response_id": payload.get("id"),
-        "elapsed_seconds": time.time() - started,
-    }
+        dataset=DATASET,
+        dataset_split=DATASET_SPLIT,
+        dataset_revision=DATASET_REVISION,
+        parquet_revision=PARQUET_REVISION,
+        model=MODEL,
+        model_revision=MODEL_REVISION,
+        temperature=sampling.temperature,
+        top_p=sampling.top_p,
+        max_tokens=sampling.max_tokens,
+        seed=prompt.dataset_index,
+        response=ResponseMessage(
+            role=message.get("role", "assistant"),
+            content=message.get("content"),
+            reasoning_content=message.get("reasoning_content"),
+        ),
+        finish_reason=choice.get("finish_reason"),
+        usage=payload.get("usage", {}),
+        response_id=payload.get("id"),
+        elapsed_seconds=time.time() - started,
+    )
 
 
 def _chunk_path(output_path: StoragePath, partition: PartitionSpec, row_start: int, row_end: int) -> StoragePath:
@@ -288,39 +368,40 @@ def _run_config(
     collection: CollectionConfig,
     server: ServerConfig,
     sampling: SamplingConfig,
-) -> dict[str, Any]:
-    return {
-        "run_id": collection.run_id,
-        "output_path": str(collection.output_path),
-        "dataset": DATASET,
-        "dataset_split": DATASET_SPLIT,
-        "dataset_revision": DATASET_REVISION,
-        "parquet_revision": PARQUET_REVISION,
-        "dataset_rows": sum(PARQUET_FILE_ROWS),
-        "model": MODEL,
-        "model_revision": MODEL_REVISION,
-        "num_shards": collection.num_shards,
-        "max_records_per_shard": collection.max_records,
-        "chunk_size": collection.chunk_size,
-        "concurrency": collection.concurrency,
-        "max_model_len": server.max_model_len,
-        "max_num_seqs": server.max_num_seqs,
-        "gpu_memory_utilization": GPU_MEMORY_UTILIZATION,
-        "temperature": sampling.temperature,
-        "top_p": sampling.top_p,
-        "max_tokens": sampling.max_tokens,
-        "enable_thinking": True,
-    }
+) -> RunConfig:
+    return RunConfig(
+        run_id=collection.run_id,
+        output_path=str(collection.output_path),
+        dataset=DATASET,
+        dataset_split=DATASET_SPLIT,
+        dataset_revision=DATASET_REVISION,
+        parquet_revision=PARQUET_REVISION,
+        dataset_rows=sum(PARQUET_FILE_ROWS),
+        model=MODEL,
+        model_revision=MODEL_REVISION,
+        num_shards=collection.num_shards,
+        max_records_per_shard=collection.max_records,
+        chunk_size=collection.chunk_size,
+        concurrency=collection.concurrency,
+        max_model_len=server.max_model_len,
+        max_num_seqs=server.max_num_seqs,
+        gpu_memory_utilization=GPU_MEMORY_UTILIZATION,
+        temperature=sampling.temperature,
+        top_p=sampling.top_p,
+        max_tokens=sampling.max_tokens,
+        enable_thinking=True,
+    )
 
 
-def _ensure_run_config(output_path: StoragePath, config: dict[str, Any]) -> None:
+def _ensure_run_config(output_path: StoragePath, config: RunConfig) -> None:
     path = output_path / "run-config.json"
+    expected = asdict(config)
     if path.exists():
         existing = json.loads(path.read_text())
-        if existing != config:
+        if existing != expected:
             raise ValueError(f"Output root contains a different run config: {path}")
         return
-    path.write_text(json.dumps(config, indent=2, sort_keys=True))
+    path.write_text(json.dumps(expected, indent=2, sort_keys=True))
 
 
 def _write_progress(
@@ -332,20 +413,20 @@ def _write_progress(
     skipped_records: int,
     started: float,
 ) -> None:
-    progress = {
-        "run_id": collection.run_id,
-        "state": state,
-        "shard_index": collection.shard_index,
-        "num_shards": collection.num_shards,
-        "expected_records": expected_records,
-        "complete_records": complete_records,
-        "generated_records_this_attempt": generated_records,
-        "skipped_records_this_attempt": skipped_records,
-        "elapsed_seconds": time.time() - started,
-        "updated_at": datetime.now(UTC).isoformat(),
-    }
+    progress = ProgressRecord(
+        run_id=collection.run_id,
+        state=state,
+        shard_index=collection.shard_index,
+        num_shards=collection.num_shards,
+        expected_records=expected_records,
+        complete_records=complete_records,
+        generated_records_this_attempt=generated_records,
+        skipped_records_this_attempt=skipped_records,
+        elapsed_seconds=time.time() - started,
+        updated_at=datetime.now(UTC).isoformat(),
+    )
     (collection.output_path / "progress" / f"shard-{collection.shard_index:03d}.json").write_text(
-        json.dumps(progress, indent=2, sort_keys=True)
+        json.dumps(asdict(progress), indent=2, sort_keys=True)
     )
 
 
@@ -376,7 +457,7 @@ def _collect_partition(
         chunk = records[row_start:row_end]
         outputs = list(executor.map(lambda prompt: _completion(vllm_url, prompt, sampling), chunk))
         path.write_text(
-            "".join(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n" for record in outputs),
+            "".join(json.dumps(asdict(record), ensure_ascii=False, sort_keys=True) + "\n" for record in outputs),
             compression="gzip",
         )
         yield CollectionDelta(len(outputs), len(outputs), 0, path)
@@ -450,14 +531,14 @@ def _run_collection(
 
 def prepare_model(output_path: StoragePath) -> None:
     weights = prepare_model_cache()
-    manifest = {
-        "model": MODEL,
-        "model_revision": MODEL_REVISION,
-        "weights": weights,
-        "cache_ttl_days": MODEL_CACHE_TTL_DAYS,
-        "prepared_at": datetime.now(UTC).isoformat(),
-    }
-    (output_path / "model-cache.json").write_text(json.dumps(manifest, indent=2, sort_keys=True))
+    manifest = ModelCacheManifest(
+        model=MODEL,
+        model_revision=MODEL_REVISION,
+        weights=weights,
+        cache_ttl_days=MODEL_CACHE_TTL_DAYS,
+        prepared_at=datetime.now(UTC).isoformat(),
+    )
+    (output_path / "model-cache.json").write_text(json.dumps(asdict(manifest), indent=2, sort_keys=True))
     logger.info("Prepared model cache at %s", weights)
 
 

--- a/experiments/rollout_data/collect_hero_run_4_code_glm52.py
+++ b/experiments/rollout_data/collect_hero_run_4_code_glm52.py
@@ -11,6 +11,7 @@ import socket
 import subprocess
 import tempfile
 import time
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from dataclasses import asdict, dataclass
@@ -18,7 +19,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-import fsspec
 import psutil
 import pyarrow.parquet as pq
 import requests
@@ -173,6 +173,14 @@ class PromptRecord:
     instruction_seed: str
 
 
+@dataclass(frozen=True)
+class CollectionDelta:
+    complete_records: int
+    generated_records: int
+    skipped_records: int
+    output_path: StoragePath | None
+
+
 def partition_specs() -> list[PartitionSpec]:
     partitions = []
     row_start = 0
@@ -296,100 +304,111 @@ print(nvcc.parent.parent)
     return _cuda_overlay(cuda_root)
 
 
-def _serve_glm52(vllm_endpoint: str, ray_endpoint: str, config: ServerConfig) -> None:
-    info = get_job_info()
-    ctx = iris_ctx()
-    if info is None or ctx is None:
-        raise RuntimeError("GLM-5.2 serving must run inside an Iris task")
-
-    vllm_command, environment = _vllm_process_command()
-    ray_command = [*vllm_command[:-1], "ray"]
-    host = info.advertise_host
-    environment["CUDA_HOME"] = _cuda_home(vllm_command, environment)
-    environment["VLLM_HOST_IP"] = host
-    environment["GLOO_SOCKET_IFNAME"] = _network_interface(host)
-    if info.task_index == 0:
-        weights = resolve_model_path(MODEL, MODEL_CACHE_TTL_DAYS, MODEL_REVISION)
-        ray_port = _reserve_port(host, ctx.get_port("ray"))
-        http_port = _reserve_port(host, ctx.get_port("http"))
-        ray_address = f"{host}:{ray_port}"
-        subprocess.run(
-            [
-                *ray_command,
-                "start",
-                "--head",
-                f"--node-ip-address={host}",
-                f"--port={ray_port}",
-                *_ray_worker_port_args(ray_port, http_port),
-                f"--num-gpus={GPUS_PER_NODE}",
-                "--disable-usage-stats",
-            ],
-            check=True,
-            env=environment,
-        )
-        ray_endpoint_id = ctx.registry.register(ray_endpoint, ray_address)
+def _run_vllm(
+    ctx,
+    host: str,
+    http_port: int,
+    ray_address: str,
+    vllm_endpoint: str,
+    vllm_command: list[str],
+    environment: dict[str, str],
+    weights: str,
+    config: ServerConfig,
+) -> None:
+    process = subprocess.Popen(
+        [
+            *vllm_command,
+            "serve",
+            weights,
+            "--served-model-name",
+            MODEL,
+            "--host",
+            host,
+            "--port",
+            str(http_port),
+            "--tensor-parallel-size",
+            str(TENSOR_PARALLEL_SIZE),
+            "--distributed-executor-backend",
+            "ray",
+            "--enable-expert-parallel",
+            "--max-model-len",
+            str(config.max_model_len),
+            "--max-num-seqs",
+            str(config.max_num_seqs),
+            "--gpu-memory-utilization",
+            str(GPU_MEMORY_UTILIZATION),
+            "--trust-remote-code",
+        ],
+        env={**environment, "RAY_ADDRESS": ray_address},
+    )
+    try:
+        base_url = f"http://{host}:{http_port}"
+        _wait_for_http(f"{base_url}/health", process, ENDPOINT_TIMEOUT)
+        endpoint_id = ctx.registry.register(vllm_endpoint, base_url)
         try:
-            deadline = time.monotonic() + 900
-            while time.monotonic() < deadline:
-                status = subprocess.run(
-                    [*ray_command, "status", f"--address={ray_address}"],
-                    env=environment,
-                    text=True,
-                    capture_output=True,
-                )
-                if status.returncode == 0 and f"/{TENSOR_PARALLEL_SIZE}.0 GPU" in status.stdout:
-                    break
-                time.sleep(10)
-            else:
-                raise TimeoutError(f"Ray cluster did not register all {TENSOR_PARALLEL_SIZE} GB200 GPUs")
-
-            process = subprocess.Popen(
-                [
-                    *vllm_command,
-                    "serve",
-                    weights,
-                    "--served-model-name",
-                    MODEL,
-                    "--host",
-                    host,
-                    "--port",
-                    str(http_port),
-                    "--tensor-parallel-size",
-                    str(TENSOR_PARALLEL_SIZE),
-                    "--distributed-executor-backend",
-                    "ray",
-                    "--enable-expert-parallel",
-                    "--max-model-len",
-                    str(config.max_model_len),
-                    "--max-num-seqs",
-                    str(config.max_num_seqs),
-                    "--gpu-memory-utilization",
-                    str(GPU_MEMORY_UTILIZATION),
-                    "--trust-remote-code",
-                ],
-                env={**environment, "RAY_ADDRESS": ray_address},
-            )
-            try:
-                base_url = f"http://{host}:{http_port}"
-                _wait_for_http(f"{base_url}/health", process, ENDPOINT_TIMEOUT)
-                endpoint_id = ctx.registry.register(vllm_endpoint, base_url)
-                try:
-                    return_code = process.wait()
-                    raise RuntimeError(f"vLLM exited with code {return_code}")
-                finally:
-                    ctx.registry.unregister(endpoint_id)
-            finally:
-                if process.poll() is None:
-                    process.terminate()
-                    with suppress(subprocess.TimeoutExpired):
-                        process.wait(timeout=30)
-                if process.poll() is None:
-                    process.kill()
+            return_code = process.wait()
+            raise RuntimeError(f"vLLM exited with code {return_code}")
         finally:
-            ctx.registry.unregister(ray_endpoint_id)
-            subprocess.run([*ray_command, "stop", "--force"], env=environment, check=False)
-        return
+            ctx.registry.unregister(endpoint_id)
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            with suppress(subprocess.TimeoutExpired):
+                process.wait(timeout=30)
+        if process.poll() is None:
+            process.kill()
 
+
+def _serve_ray_head(
+    ctx,
+    host: str,
+    vllm_endpoint: str,
+    ray_endpoint: str,
+    vllm_command: list[str],
+    ray_command: list[str],
+    environment: dict[str, str],
+    config: ServerConfig,
+) -> None:
+    weights = resolve_model_path(MODEL, MODEL_CACHE_TTL_DAYS, MODEL_REVISION)
+    ray_port = _reserve_port(host, ctx.get_port("ray"))
+    http_port = _reserve_port(host, ctx.get_port("http"))
+    ray_address = f"{host}:{ray_port}"
+    subprocess.run(
+        [
+            *ray_command,
+            "start",
+            "--head",
+            f"--node-ip-address={host}",
+            f"--port={ray_port}",
+            *_ray_worker_port_args(ray_port, http_port),
+            f"--num-gpus={GPUS_PER_NODE}",
+            "--disable-usage-stats",
+        ],
+        check=True,
+        env=environment,
+    )
+    ray_endpoint_id = ctx.registry.register(ray_endpoint, ray_address)
+    try:
+        deadline = time.monotonic() + 900
+        while time.monotonic() < deadline:
+            status = subprocess.run(
+                [*ray_command, "status", f"--address={ray_address}"],
+                env=environment,
+                text=True,
+                capture_output=True,
+            )
+            if status.returncode == 0 and f"/{TENSOR_PARALLEL_SIZE}.0 GPU" in status.stdout:
+                break
+            time.sleep(10)
+        else:
+            raise TimeoutError(f"Ray cluster did not register all {TENSOR_PARALLEL_SIZE} GB200 GPUs")
+        _run_vllm(ctx, host, http_port, ray_address, vllm_endpoint, vllm_command, environment, weights, config)
+    finally:
+        ctx.registry.unregister(ray_endpoint_id)
+        subprocess.run([*ray_command, "stop", "--force"], env=environment, check=False)
+
+
+def _serve_ray_worker(host: str, ray_endpoint: str, ray_command: list[str], environment: dict[str, str]) -> None:
     ray_address = _wait_for_endpoint(ray_endpoint, timeout=ENDPOINT_TIMEOUT)
     subprocess.run(
         [
@@ -405,6 +424,24 @@ def _serve_glm52(vllm_endpoint: str, ray_endpoint: str, config: ServerConfig) ->
         check=True,
         env=environment,
     )
+
+
+def _serve_glm52(vllm_endpoint: str, ray_endpoint: str, config: ServerConfig) -> None:
+    info = get_job_info()
+    ctx = iris_ctx()
+    if info is None or ctx is None:
+        raise RuntimeError("GLM-5.2 serving must run inside an Iris task")
+
+    vllm_command, environment = _vllm_process_command()
+    ray_command = [*vllm_command[:-1], "ray"]
+    host = info.advertise_host
+    environment["CUDA_HOME"] = _cuda_home(vllm_command, environment)
+    environment["VLLM_HOST_IP"] = host
+    environment["GLOO_SOCKET_IFNAME"] = _network_interface(host)
+    if info.task_index == 0:
+        _serve_ray_head(ctx, host, vllm_endpoint, ray_endpoint, vllm_command, ray_command, environment, config)
+        return
+    _serve_ray_worker(host, ray_endpoint, ray_command, environment)
 
 
 def _submit_vllm(ctx, vllm_endpoint: str, ray_endpoint: str, config: ServerConfig):
@@ -431,7 +468,7 @@ def _submit_vllm(ctx, vllm_endpoint: str, ray_endpoint: str, config: ServerConfi
 
 def _read_partition(partition_slice: PartitionSlice) -> list[PromptRecord]:
     partition = partition_slice.partition
-    with fsspec.open(partition.url, "rb") as handle:
+    with StoragePath(partition.url).open("rb") as handle:
         table = pq.ParquetFile(handle).read_row_group(partition.row_group_index, columns=list(INPUT_COLUMNS))
     rows = table.slice(0, partition_slice.num_rows).to_pylist()
     records = []
@@ -575,6 +612,39 @@ def _write_progress(
     )
 
 
+def _collect_partition(
+    executor: ThreadPoolExecutor,
+    vllm_url: str,
+    collection: CollectionConfig,
+    sampling: SamplingConfig,
+    partition_slice: PartitionSlice,
+) -> Iterator[CollectionDelta]:
+    partition = partition_slice.partition
+    pending_chunks = []
+    skipped_records = 0
+    for row_start in range(0, partition_slice.num_rows, collection.chunk_size):
+        row_end = min(partition_slice.num_rows, row_start + collection.chunk_size)
+        path = _chunk_path(collection.output_path, partition, row_start, row_end)
+        if path.exists():
+            skipped_records += row_end - row_start
+            continue
+        pending_chunks.append((row_start, row_end, path))
+    if skipped_records:
+        yield CollectionDelta(skipped_records, 0, skipped_records, None)
+    if not pending_chunks:
+        return
+
+    records = _read_partition(partition_slice)
+    for row_start, row_end, path in pending_chunks:
+        chunk = records[row_start:row_end]
+        outputs = list(executor.map(lambda prompt: _completion(vllm_url, prompt, sampling), chunk))
+        path.write_text(
+            "".join(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n" for record in outputs),
+            compression="gzip",
+        )
+        yield CollectionDelta(len(outputs), len(outputs), 0, path)
+
+
 def _run_collection(
     vllm_url: str,
     collection: CollectionConfig,
@@ -606,29 +676,10 @@ def _run_collection(
 
     with ThreadPoolExecutor(max_workers=collection.concurrency) as executor:
         for partition_slice in slices:
-            partition = partition_slice.partition
-            pending_chunks = []
-            for row_start in range(0, partition_slice.num_rows, collection.chunk_size):
-                row_end = min(partition_slice.num_rows, row_start + collection.chunk_size)
-                path = _chunk_path(collection.output_path, partition, row_start, row_end)
-                if path.exists():
-                    complete_records += row_end - row_start
-                    skipped_records += row_end - row_start
-                    continue
-                pending_chunks.append((row_start, row_end, path))
-            if not pending_chunks:
-                continue
-
-            records = _read_partition(partition_slice)
-            for row_start, row_end, path in pending_chunks:
-                chunk = records[row_start:row_end]
-                outputs = list(executor.map(lambda prompt: _completion(vllm_url, prompt, sampling), chunk))
-                path.write_text(
-                    "".join(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n" for record in outputs),
-                    compression="gzip",
-                )
-                complete_records += len(outputs)
-                generated_records += len(outputs)
+            for delta in _collect_partition(executor, vllm_url, collection, sampling, partition_slice):
+                complete_records += delta.complete_records
+                generated_records += delta.generated_records
+                skipped_records += delta.skipped_records
                 _write_progress(
                     collection,
                     "running",
@@ -638,13 +689,14 @@ def _run_collection(
                     skipped_records,
                     started,
                 )
-                logger.info(
-                    "Shard %d saved %d/%d records to %s",
-                    collection.shard_index,
-                    complete_records,
-                    expected_records,
-                    path,
-                )
+                if delta.output_path is not None:
+                    logger.info(
+                        "Shard %d saved %d/%d records to %s",
+                        collection.shard_index,
+                        complete_records,
+                        expected_records,
+                        delta.output_path,
+                    )
 
     _write_progress(
         collection,
@@ -695,7 +747,7 @@ def run(
             logger.warning("Failed to terminate vLLM child job %s during collector cleanup", vllm_job, exc_info=True)
 
 
-def _positive(parser: argparse.ArgumentParser, name: str, value: int) -> None:
+def _validate_positive(parser: argparse.ArgumentParser, name: str, value: int) -> None:
     if value < 1:
         parser.error(f"{name} must be positive")
 
@@ -725,9 +777,9 @@ def main() -> None:
         return
 
     for name in ("num_shards", "chunk_size", "concurrency", "max_model_len", "max_num_seqs", "max_tokens"):
-        _positive(parser, f"--{name.replace('_', '-')}", getattr(args, name))
+        _validate_positive(parser, f"--{name.replace('_', '-')}", getattr(args, name))
     if args.max_records is not None:
-        _positive(parser, "--max-records", args.max_records)
+        _validate_positive(parser, "--max-records", args.max_records)
     if not 0 <= args.shard_index < args.num_shards:
         parser.error("--shard-index must be in [0, --num-shards)")
     if args.temperature < 0:

--- a/experiments/rollout_data/collect_hero_run_4_code_glm52.py
+++ b/experiments/rollout_data/collect_hero_run_4_code_glm52.py
@@ -28,6 +28,7 @@ from iris.cluster.setup_scripts import default_setup_script
 from iris.cluster.types import CoschedulingConfig, Entrypoint, EnvironmentSpec, ResourceSpec, gpu_device, is_job_finished
 from marin.inference.config import DEFAULT_CUDA_VLLM_VERSION
 from marin.inference.model_preparation import resolve_model_path
+from marin.inference.proxy import _reserve_port
 from marin.inference.vllm_server import IsolatedCudaVllm
 from rigging.filesystem import StoragePath
 from rigging.timing import Duration
@@ -101,6 +102,9 @@ VLLM_ENDPOINT = "glm52-openai"
 RAY_ENDPOINT = "glm52-ray"
 CUDA_COMPILER_REQUIREMENT = "cuda-toolkit[cccl,crt,cudart,nvcc,nvvm]==13.0.2"
 MODEL_CACHE_TTL_DAYS = 30
+GPUS_PER_NODE = 4
+VLLM_REPLICAS = 2
+TENSOR_PARALLEL_SIZE = GPUS_PER_NODE * VLLM_REPLICAS
 DEFAULT_MAX_MODEL_LEN = 64 * 1024
 DEFAULT_MAX_NUM_SEQS = 12
 DEFAULT_MAX_TOKENS = 16 * 1024
@@ -131,7 +135,7 @@ class ServerConfig:
 @dataclass(frozen=True)
 class CollectionConfig:
     run_id: str
-    output_path: str
+    output_path: StoragePath
     shard_index: int
     num_shards: int
     max_records: int | None
@@ -209,14 +213,6 @@ def partition_slices(
     return slices
 
 
-def _available_port(requested: int, host: str) -> int:
-    if requested:
-        return requested
-    with socket.socket() as sock:
-        sock.bind((host, 0))
-        return sock.getsockname()[1]
-
-
 def _ray_worker_port_args(*excluded_ports: int) -> list[str]:
     for minimum in (20000, 30000, 40000, 50000):
         maximum = minimum + 9999
@@ -232,7 +228,7 @@ def _network_interface(host: str) -> str:
     raise RuntimeError(f"No network interface owns advertised host IP {host}")
 
 
-def _wait_for_http(url: str, process: subprocess.Popen[Any], timeout: float) -> None:
+def _wait_for_http(url: str, process: subprocess.Popen[bytes], timeout: float) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         if process.poll() is not None:
@@ -314,8 +310,8 @@ def _serve_glm52(vllm_endpoint: str, ray_endpoint: str, config: ServerConfig) ->
     environment["GLOO_SOCKET_IFNAME"] = _network_interface(host)
     if info.task_index == 0:
         weights = resolve_model_path(MODEL, MODEL_CACHE_TTL_DAYS, MODEL_REVISION)
-        ray_port = _available_port(ctx.get_port("ray"), host)
-        http_port = _available_port(ctx.get_port("http"), host)
+        ray_port = _reserve_port(host, ctx.get_port("ray"))
+        http_port = _reserve_port(host, ctx.get_port("http"))
         ray_address = f"{host}:{ray_port}"
         subprocess.run(
             [
@@ -325,7 +321,7 @@ def _serve_glm52(vllm_endpoint: str, ray_endpoint: str, config: ServerConfig) ->
                 f"--node-ip-address={host}",
                 f"--port={ray_port}",
                 *_ray_worker_port_args(ray_port, http_port),
-                "--num-gpus=4",
+                f"--num-gpus={GPUS_PER_NODE}",
                 "--disable-usage-stats",
             ],
             check=True,
@@ -341,11 +337,11 @@ def _serve_glm52(vllm_endpoint: str, ray_endpoint: str, config: ServerConfig) ->
                     text=True,
                     capture_output=True,
                 )
-                if status.returncode == 0 and "/8.0 GPU" in status.stdout:
+                if status.returncode == 0 and f"/{TENSOR_PARALLEL_SIZE}.0 GPU" in status.stdout:
                     break
                 time.sleep(10)
             else:
-                raise TimeoutError("Ray cluster did not register all 8 GB200 GPUs")
+                raise TimeoutError(f"Ray cluster did not register all {TENSOR_PARALLEL_SIZE} GB200 GPUs")
 
             process = subprocess.Popen(
                 [
@@ -359,7 +355,7 @@ def _serve_glm52(vllm_endpoint: str, ray_endpoint: str, config: ServerConfig) ->
                     "--port",
                     str(http_port),
                     "--tensor-parallel-size",
-                    "8",
+                    str(TENSOR_PARALLEL_SIZE),
                     "--distributed-executor-backend",
                     "ray",
                     "--enable-expert-parallel",
@@ -402,7 +398,7 @@ def _serve_glm52(vllm_endpoint: str, ray_endpoint: str, config: ServerConfig) ->
             f"--address={ray_address}",
             f"--node-ip-address={host}",
             *_ray_worker_port_args(),
-            "--num-gpus=4",
+            f"--num-gpus={GPUS_PER_NODE}",
             "--disable-usage-stats",
             "--block",
         ],
@@ -415,14 +411,19 @@ def _submit_vllm(ctx, vllm_endpoint: str, ray_endpoint: str, config: ServerConfi
     return ctx.client.submit(
         entrypoint=Entrypoint.from_callable(_serve_glm52, vllm_endpoint, ray_endpoint, config),
         name="vllm",
-        resources=ResourceSpec(cpu=120, memory="850g", disk="1000g", device=gpu_device("GB200", 4)),
+        resources=ResourceSpec(
+            cpu=120,
+            memory="850g",
+            disk="1000g",
+            device=gpu_device("GB200", GPUS_PER_NODE),
+        ),
         environment=EnvironmentSpec(
             setup_scripts=[default_setup_script(packages=["marin-core"])],
             env_vars={"VLLM_USE_FLASHINFER_SAMPLER": "0"},
         ),
         ports=["ray", "http"],
         coscheduling=CoschedulingConfig(group_by="nvlink.domain"),
-        replicas=2,
+        replicas=VLLM_REPLICAS,
         timeout=Duration.from_hours(RUN_TIMEOUT_HOURS),
         max_retries_failure=0,
     )
@@ -499,10 +500,13 @@ def _completion(vllm_url: str, prompt: PromptRecord, sampling: SamplingConfig) -
     }
 
 
-def _chunk_path(output_path: str, partition: PartitionSpec, row_start: int, row_end: int) -> StoragePath:
-    return StoragePath(
-        f"{output_path}/responses/file-{partition.file_index:04d}/"
-        f"row-group-{partition.row_group_index:02d}/rows-{row_start:04d}-{row_end - 1:04d}.jsonl.gz"
+def _chunk_path(output_path: StoragePath, partition: PartitionSpec, row_start: int, row_end: int) -> StoragePath:
+    return (
+        output_path
+        / "responses"
+        / f"file-{partition.file_index:04d}"
+        / f"row-group-{partition.row_group_index:02d}"
+        / f"rows-{row_start:04d}-{row_end - 1:04d}.jsonl.gz"
     )
 
 
@@ -513,7 +517,7 @@ def _run_config(
 ) -> dict[str, Any]:
     return {
         "run_id": collection.run_id,
-        "output_path": collection.output_path,
+        "output_path": str(collection.output_path),
         "dataset": DATASET,
         "dataset_split": DATASET_SPLIT,
         "dataset_revision": DATASET_REVISION,
@@ -535,8 +539,8 @@ def _run_config(
     }
 
 
-def _ensure_run_config(config: dict[str, Any]) -> None:
-    path = StoragePath(f"{config['output_path']}/run-config.json")
+def _ensure_run_config(output_path: StoragePath, config: dict[str, Any]) -> None:
+    path = output_path / "run-config.json"
     if path.exists():
         existing = json.loads(path.read_text())
         if existing != config:
@@ -566,7 +570,7 @@ def _write_progress(
         "elapsed_seconds": time.time() - started,
         "updated_at": datetime.now(UTC).isoformat(),
     }
-    StoragePath(f"{collection.output_path}/progress/shard-{collection.shard_index:03d}.json").write_text(
+    (collection.output_path / "progress" / f"shard-{collection.shard_index:03d}.json").write_text(
         json.dumps(progress, indent=2, sort_keys=True)
     )
 
@@ -578,7 +582,7 @@ def _run_collection(
     sampling: SamplingConfig,
 ) -> None:
     config = _run_config(collection, server, sampling)
-    _ensure_run_config(config)
+    _ensure_run_config(collection.output_path, config)
     slices = partition_slices(
         partition_specs(),
         collection.shard_index,
@@ -655,7 +659,7 @@ def _run_collection(
         raise RuntimeError(f"Shard completed {complete_records} of {expected_records} expected records")
 
 
-def prepare_model(output_path: str) -> None:
+def prepare_model(output_path: StoragePath) -> None:
     weights = resolve_model_path(MODEL, MODEL_CACHE_TTL_DAYS, MODEL_REVISION)
     manifest = {
         "model": MODEL,
@@ -664,7 +668,7 @@ def prepare_model(output_path: str) -> None:
         "cache_ttl_days": MODEL_CACHE_TTL_DAYS,
         "prepared_at": datetime.now(UTC).isoformat(),
     }
-    StoragePath(f"{output_path}/model-cache.json").write_text(json.dumps(manifest, indent=2, sort_keys=True))
+    (output_path / "model-cache.json").write_text(json.dumps(manifest, indent=2, sort_keys=True))
     logger.info("Prepared model cache at %s", weights)
 
 
@@ -685,8 +689,10 @@ def run(
         logger.info("GLM-5.2 ready; writing responses to %s", collection.output_path)
         _run_collection(vllm_url, collection, server, sampling)
     finally:
-        with suppress(Exception):
+        try:
             vllm_job.terminate()
+        except Exception:
+            logger.warning("Failed to terminate vLLM child job %s during collector cleanup", vllm_job, exc_info=True)
 
 
 def _positive(parser: argparse.ArgumentParser, name: str, value: int) -> None:
@@ -715,7 +721,7 @@ def main() -> None:
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO)
     if args.command == "prepare":
-        prepare_model(args.output_path)
+        prepare_model(StoragePath(args.output_path))
         return
 
     for name in ("num_shards", "chunk_size", "concurrency", "max_model_len", "max_num_seqs", "max_tokens"):
@@ -732,7 +738,7 @@ def main() -> None:
     run(
         CollectionConfig(
             run_id=args.run_id,
-            output_path=args.output_path.rstrip("/"),
+            output_path=StoragePath(args.output_path),
             shard_index=args.shard_index,
             num_shards=args.num_shards,
             max_records=args.max_records,

--- a/experiments/rollout_data/collect_hero_run_4_code_glm52.py
+++ b/experiments/rollout_data/collect_hero_run_4_code_glm52.py
@@ -1,0 +1,748 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Collect GLM-5.2 responses for mlfoundations-dev/hero_run_4_code."""
+
+import argparse
+import json
+import logging
+import os
+import socket
+import subprocess
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import suppress
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import fsspec
+import psutil
+import pyarrow.parquet as pq
+import requests
+from iris.client import iris_ctx
+from iris.cluster.client.job_info import get_job_info
+from iris.cluster.setup_scripts import default_setup_script
+from iris.cluster.types import CoschedulingConfig, Entrypoint, EnvironmentSpec, ResourceSpec, gpu_device, is_job_finished
+from marin.inference.config import DEFAULT_CUDA_VLLM_VERSION
+from marin.inference.model_preparation import resolve_model_path
+from marin.inference.vllm_server import IsolatedCudaVllm
+from rigging.filesystem import StoragePath
+from rigging.timing import Duration
+
+logger = logging.getLogger(__name__)
+
+MODEL = "zai-org/GLM-5.2-FP8"
+MODEL_REVISION = "ba978f7d347eaf65d22f1a86833408afdb953541"
+DATASET = "mlfoundations-dev/hero_run_4_code"
+DATASET_SPLIT = "train"
+DATASET_REVISION = "18bef55db16de0a0f7416c200697a201e82e6ff5"
+PARQUET_REVISION = "8982cc7d8d510777b546c5ee5d6196cefb97e25a"
+PARQUET_FILE_ROWS = (
+    19185,
+    19185,
+    19185,
+    19185,
+    19185,
+    19185,
+    19185,
+    19185,
+    19185,
+    19185,
+    19185,
+    19185,
+    19185,
+    19185,
+    19185,
+    19185,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+    19184,
+)
+PARQUET_ROW_GROUP_SIZE = 1000
+PARQUET_URL = (
+    "https://huggingface.co/datasets/"
+    f"{DATASET}/resolve/{PARQUET_REVISION}/default/{DATASET_SPLIT}/{{file_index:04d}}.parquet"
+)
+VLLM_ENDPOINT = "glm52-openai"
+RAY_ENDPOINT = "glm52-ray"
+CUDA_COMPILER_REQUIREMENT = "cuda-toolkit[cccl,crt,cudart,nvcc,nvvm]==13.0.2"
+MODEL_CACHE_TTL_DAYS = 30
+DEFAULT_MAX_MODEL_LEN = 64 * 1024
+DEFAULT_MAX_NUM_SEQS = 12
+DEFAULT_MAX_TOKENS = 16 * 1024
+DEFAULT_TEMPERATURE = 1.0
+DEFAULT_TOP_P = 0.95
+DEFAULT_CONCURRENCY = 16
+DEFAULT_CHUNK_SIZE = 32
+GPU_MEMORY_UTILIZATION = 0.9
+ENDPOINT_TIMEOUT = 3 * 3600
+REQUEST_TIMEOUT = 3 * 3600
+RUN_TIMEOUT_HOURS = 30 * 24
+INPUT_COLUMNS = ("id", "instruction_seed", "__original_row_idx")
+
+
+@dataclass(frozen=True)
+class SamplingConfig:
+    temperature: float
+    top_p: float
+    max_tokens: int
+
+
+@dataclass(frozen=True)
+class ServerConfig:
+    max_model_len: int
+    max_num_seqs: int
+
+
+@dataclass(frozen=True)
+class CollectionConfig:
+    run_id: str
+    output_path: str
+    shard_index: int
+    num_shards: int
+    max_records: int | None
+    chunk_size: int
+    concurrency: int
+
+
+@dataclass(frozen=True)
+class PartitionSpec:
+    ordinal: int
+    file_index: int
+    row_group_index: int
+    row_start: int
+    num_rows: int
+
+    @property
+    def url(self) -> str:
+        return PARQUET_URL.format(file_index=self.file_index)
+
+
+@dataclass(frozen=True)
+class PartitionSlice:
+    partition: PartitionSpec
+    num_rows: int
+
+
+@dataclass(frozen=True)
+class PromptRecord:
+    dataset_index: int
+    source_file_index: int
+    source_row_group: int
+    source_row_offset: int
+    id: str | None
+    original_row_index: int
+    instruction_seed: str
+
+
+def partition_specs() -> list[PartitionSpec]:
+    partitions = []
+    row_start = 0
+    for file_index, file_rows in enumerate(PARQUET_FILE_ROWS):
+        for row_group_index, group_start in enumerate(range(0, file_rows, PARQUET_ROW_GROUP_SIZE)):
+            num_rows = min(PARQUET_ROW_GROUP_SIZE, file_rows - group_start)
+            partitions.append(
+                PartitionSpec(
+                    ordinal=len(partitions),
+                    file_index=file_index,
+                    row_group_index=row_group_index,
+                    row_start=row_start + group_start,
+                    num_rows=num_rows,
+                )
+            )
+        row_start += file_rows
+    return partitions
+
+
+def partition_slices(
+    partitions: list[PartitionSpec],
+    shard_index: int,
+    num_shards: int,
+    max_records: int | None,
+) -> list[PartitionSlice]:
+    selected = [partition for partition in partitions if partition.ordinal % num_shards == shard_index]
+    if max_records is None:
+        return [PartitionSlice(partition, partition.num_rows) for partition in selected]
+
+    remaining = max_records
+    slices = []
+    for partition in selected:
+        if remaining == 0:
+            break
+        num_rows = min(partition.num_rows, remaining)
+        slices.append(PartitionSlice(partition, num_rows))
+        remaining -= num_rows
+    return slices
+
+
+def _available_port(requested: int, host: str) -> int:
+    if requested:
+        return requested
+    with socket.socket() as sock:
+        sock.bind((host, 0))
+        return sock.getsockname()[1]
+
+
+def _ray_worker_port_args(*excluded_ports: int) -> list[str]:
+    for minimum in (20000, 30000, 40000, 50000):
+        maximum = minimum + 9999
+        if not any(minimum <= port <= maximum for port in excluded_ports):
+            return [f"--min-worker-port={minimum}", f"--max-worker-port={maximum}"]
+    raise ValueError(f"Could not select Ray worker ports excluding {excluded_ports}")
+
+
+def _network_interface(host: str) -> str:
+    for name, addresses in psutil.net_if_addrs().items():
+        if any(address.family == socket.AF_INET and address.address == host for address in addresses):
+            return name
+    raise RuntimeError(f"No network interface owns advertised host IP {host}")
+
+
+def _wait_for_http(url: str, process: subprocess.Popen[Any], timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"Process exited with code {process.returncode} before {url} became ready")
+        try:
+            response = requests.get(url, timeout=10)
+            if response.ok:
+                return
+        except requests.RequestException:
+            pass
+        time.sleep(5)
+    raise TimeoutError(f"Timed out waiting for {url}")
+
+
+def _wait_for_endpoint(name: str, job=None, timeout: float = ENDPOINT_TIMEOUT) -> str:
+    ctx = iris_ctx()
+    assert ctx is not None
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = ctx.resolver.resolve(name)
+        if not result.is_empty:
+            return result.first().url
+        if job is not None and is_job_finished(job.state):
+            raise RuntimeError(f"Job {job} finished before registering endpoint {name!r}")
+        time.sleep(15)
+    raise TimeoutError(f"Timed out waiting for endpoint {name!r}")
+
+
+def _vllm_process_command() -> tuple[list[str], dict[str, str]]:
+    launcher = IsolatedCudaVllm(version=DEFAULT_CUDA_VLLM_VERSION)
+    command = launcher.command()
+    python_index = command.index("--python")
+    command[python_index:python_index] = [
+        "--with",
+        "ray[cgraph]>=2.55.1",
+        "--with",
+        CUDA_COMPILER_REQUIREMENT,
+    ]
+    return command, {**os.environ, **launcher.env()}
+
+
+def _cuda_overlay(cuda_root: Path) -> str:
+    cuda_home = Path(tempfile.mkdtemp(prefix="cuda-home-"))
+    for directory in ("bin", "include", "nvvm"):
+        (cuda_home / directory).symlink_to(cuda_root / directory, target_is_directory=True)
+    lib64 = cuda_home / "lib64"
+    lib64.mkdir()
+    for library in (cuda_root / "lib").iterdir():
+        (lib64 / library.name).symlink_to(library, target_is_directory=library.is_dir())
+    cudart = next((cuda_root / "lib").glob("libcudart.so.*"))
+    (lib64 / "libcudart.so").symlink_to(cudart)
+    return str(cuda_home)
+
+
+def _cuda_home(vllm_command: list[str], environment: dict[str, str]) -> str:
+    script = """\
+from pathlib import Path
+import sys
+
+nvcc = next(path for entry in sys.path for path in Path(entry).glob("nvidia/**/bin/nvcc"))
+print(nvcc.parent.parent)
+"""
+    command = [*vllm_command[:-1], "python", "-c", script]
+    cuda_root = Path(subprocess.check_output(command, env=environment, text=True).strip())
+    return _cuda_overlay(cuda_root)
+
+
+def _serve_glm52(vllm_endpoint: str, ray_endpoint: str, config: ServerConfig) -> None:
+    info = get_job_info()
+    ctx = iris_ctx()
+    if info is None or ctx is None:
+        raise RuntimeError("GLM-5.2 serving must run inside an Iris task")
+
+    vllm_command, environment = _vllm_process_command()
+    ray_command = [*vllm_command[:-1], "ray"]
+    host = info.advertise_host
+    environment["CUDA_HOME"] = _cuda_home(vllm_command, environment)
+    environment["VLLM_HOST_IP"] = host
+    environment["GLOO_SOCKET_IFNAME"] = _network_interface(host)
+    if info.task_index == 0:
+        weights = resolve_model_path(MODEL, MODEL_CACHE_TTL_DAYS, MODEL_REVISION)
+        ray_port = _available_port(ctx.get_port("ray"), host)
+        http_port = _available_port(ctx.get_port("http"), host)
+        ray_address = f"{host}:{ray_port}"
+        subprocess.run(
+            [
+                *ray_command,
+                "start",
+                "--head",
+                f"--node-ip-address={host}",
+                f"--port={ray_port}",
+                *_ray_worker_port_args(ray_port, http_port),
+                "--num-gpus=4",
+                "--disable-usage-stats",
+            ],
+            check=True,
+            env=environment,
+        )
+        ray_endpoint_id = ctx.registry.register(ray_endpoint, ray_address)
+        try:
+            deadline = time.monotonic() + 900
+            while time.monotonic() < deadline:
+                status = subprocess.run(
+                    [*ray_command, "status", f"--address={ray_address}"],
+                    env=environment,
+                    text=True,
+                    capture_output=True,
+                )
+                if status.returncode == 0 and "/8.0 GPU" in status.stdout:
+                    break
+                time.sleep(10)
+            else:
+                raise TimeoutError("Ray cluster did not register all 8 GB200 GPUs")
+
+            process = subprocess.Popen(
+                [
+                    *vllm_command,
+                    "serve",
+                    weights,
+                    "--served-model-name",
+                    MODEL,
+                    "--host",
+                    host,
+                    "--port",
+                    str(http_port),
+                    "--tensor-parallel-size",
+                    "8",
+                    "--distributed-executor-backend",
+                    "ray",
+                    "--enable-expert-parallel",
+                    "--max-model-len",
+                    str(config.max_model_len),
+                    "--max-num-seqs",
+                    str(config.max_num_seqs),
+                    "--gpu-memory-utilization",
+                    str(GPU_MEMORY_UTILIZATION),
+                    "--trust-remote-code",
+                ],
+                env={**environment, "RAY_ADDRESS": ray_address},
+            )
+            try:
+                base_url = f"http://{host}:{http_port}"
+                _wait_for_http(f"{base_url}/health", process, ENDPOINT_TIMEOUT)
+                endpoint_id = ctx.registry.register(vllm_endpoint, base_url)
+                try:
+                    return_code = process.wait()
+                    raise RuntimeError(f"vLLM exited with code {return_code}")
+                finally:
+                    ctx.registry.unregister(endpoint_id)
+            finally:
+                if process.poll() is None:
+                    process.terminate()
+                    with suppress(subprocess.TimeoutExpired):
+                        process.wait(timeout=30)
+                if process.poll() is None:
+                    process.kill()
+        finally:
+            ctx.registry.unregister(ray_endpoint_id)
+            subprocess.run([*ray_command, "stop", "--force"], env=environment, check=False)
+        return
+
+    ray_address = _wait_for_endpoint(ray_endpoint, timeout=ENDPOINT_TIMEOUT)
+    subprocess.run(
+        [
+            *ray_command,
+            "start",
+            f"--address={ray_address}",
+            f"--node-ip-address={host}",
+            *_ray_worker_port_args(),
+            "--num-gpus=4",
+            "--disable-usage-stats",
+            "--block",
+        ],
+        check=True,
+        env=environment,
+    )
+
+
+def _submit_vllm(ctx, vllm_endpoint: str, ray_endpoint: str, config: ServerConfig):
+    return ctx.client.submit(
+        entrypoint=Entrypoint.from_callable(_serve_glm52, vllm_endpoint, ray_endpoint, config),
+        name="vllm",
+        resources=ResourceSpec(cpu=120, memory="850g", disk="1000g", device=gpu_device("GB200", 4)),
+        environment=EnvironmentSpec(
+            setup_scripts=[default_setup_script(packages=["marin-core"])],
+            env_vars={"VLLM_USE_FLASHINFER_SAMPLER": "0"},
+        ),
+        ports=["ray", "http"],
+        coscheduling=CoschedulingConfig(group_by="nvlink.domain"),
+        replicas=2,
+        timeout=Duration.from_hours(RUN_TIMEOUT_HOURS),
+        max_retries_failure=0,
+    )
+
+
+def _read_partition(partition_slice: PartitionSlice) -> list[PromptRecord]:
+    partition = partition_slice.partition
+    with fsspec.open(partition.url, "rb") as handle:
+        table = pq.ParquetFile(handle).read_row_group(partition.row_group_index, columns=list(INPUT_COLUMNS))
+    rows = table.slice(0, partition_slice.num_rows).to_pylist()
+    records = []
+    for row_offset, row in enumerate(rows):
+        instruction_seed = row["instruction_seed"]
+        if not isinstance(instruction_seed, str) or not instruction_seed:
+            raise ValueError(f"Dataset row {partition.row_start + row_offset} has no instruction_seed")
+        original_row_index = row["__original_row_idx"]
+        if not isinstance(original_row_index, int):
+            raise ValueError(f"Dataset row {partition.row_start + row_offset} has no original row index")
+        records.append(
+            PromptRecord(
+                dataset_index=partition.row_start + row_offset,
+                source_file_index=partition.file_index,
+                source_row_group=partition.row_group_index,
+                source_row_offset=row_offset,
+                id=row["id"],
+                original_row_index=original_row_index,
+                instruction_seed=instruction_seed,
+            )
+        )
+    return records
+
+
+def _completion(vllm_url: str, prompt: PromptRecord, sampling: SamplingConfig) -> dict[str, Any]:
+    started = time.time()
+    response = requests.post(
+        f"{vllm_url}/v1/chat/completions",
+        json={
+            "model": MODEL,
+            "messages": [{"role": "user", "content": prompt.instruction_seed}],
+            "temperature": sampling.temperature,
+            "top_p": sampling.top_p,
+            "max_tokens": sampling.max_tokens,
+            "seed": prompt.dataset_index,
+            "chat_template_kwargs": {"enable_thinking": True},
+        },
+        timeout=REQUEST_TIMEOUT,
+    )
+    if not response.ok:
+        raise RuntimeError(f"vLLM returned {response.status_code}: {response.text[:2000]}")
+    payload = response.json()
+    choice = payload["choices"][0]
+    message = choice["message"]
+    return {
+        **asdict(prompt),
+        "dataset": DATASET,
+        "dataset_split": DATASET_SPLIT,
+        "dataset_revision": DATASET_REVISION,
+        "parquet_revision": PARQUET_REVISION,
+        "model": MODEL,
+        "model_revision": MODEL_REVISION,
+        "temperature": sampling.temperature,
+        "top_p": sampling.top_p,
+        "max_tokens": sampling.max_tokens,
+        "seed": prompt.dataset_index,
+        "response": {
+            "role": message.get("role", "assistant"),
+            "content": message.get("content"),
+            "reasoning_content": message.get("reasoning_content"),
+        },
+        "finish_reason": choice.get("finish_reason"),
+        "usage": payload.get("usage", {}),
+        "response_id": payload.get("id"),
+        "elapsed_seconds": time.time() - started,
+    }
+
+
+def _chunk_path(output_path: str, partition: PartitionSpec, row_start: int, row_end: int) -> StoragePath:
+    return StoragePath(
+        f"{output_path}/responses/file-{partition.file_index:04d}/"
+        f"row-group-{partition.row_group_index:02d}/rows-{row_start:04d}-{row_end - 1:04d}.jsonl.gz"
+    )
+
+
+def _run_config(
+    collection: CollectionConfig,
+    server: ServerConfig,
+    sampling: SamplingConfig,
+) -> dict[str, Any]:
+    return {
+        "run_id": collection.run_id,
+        "output_path": collection.output_path,
+        "dataset": DATASET,
+        "dataset_split": DATASET_SPLIT,
+        "dataset_revision": DATASET_REVISION,
+        "parquet_revision": PARQUET_REVISION,
+        "dataset_rows": sum(PARQUET_FILE_ROWS),
+        "model": MODEL,
+        "model_revision": MODEL_REVISION,
+        "num_shards": collection.num_shards,
+        "max_records_per_shard": collection.max_records,
+        "chunk_size": collection.chunk_size,
+        "concurrency": collection.concurrency,
+        "max_model_len": server.max_model_len,
+        "max_num_seqs": server.max_num_seqs,
+        "gpu_memory_utilization": GPU_MEMORY_UTILIZATION,
+        "temperature": sampling.temperature,
+        "top_p": sampling.top_p,
+        "max_tokens": sampling.max_tokens,
+        "enable_thinking": True,
+    }
+
+
+def _ensure_run_config(config: dict[str, Any]) -> None:
+    path = StoragePath(f"{config['output_path']}/run-config.json")
+    if path.exists():
+        existing = json.loads(path.read_text())
+        if existing != config:
+            raise ValueError(f"Output root contains a different run config: {path}")
+        return
+    path.write_text(json.dumps(config, indent=2, sort_keys=True))
+
+
+def _write_progress(
+    collection: CollectionConfig,
+    state: str,
+    expected_records: int,
+    complete_records: int,
+    generated_records: int,
+    skipped_records: int,
+    started: float,
+) -> None:
+    progress = {
+        "run_id": collection.run_id,
+        "state": state,
+        "shard_index": collection.shard_index,
+        "num_shards": collection.num_shards,
+        "expected_records": expected_records,
+        "complete_records": complete_records,
+        "generated_records_this_attempt": generated_records,
+        "skipped_records_this_attempt": skipped_records,
+        "elapsed_seconds": time.time() - started,
+        "updated_at": datetime.now(UTC).isoformat(),
+    }
+    StoragePath(f"{collection.output_path}/progress/shard-{collection.shard_index:03d}.json").write_text(
+        json.dumps(progress, indent=2, sort_keys=True)
+    )
+
+
+def _run_collection(
+    vllm_url: str,
+    collection: CollectionConfig,
+    server: ServerConfig,
+    sampling: SamplingConfig,
+) -> None:
+    config = _run_config(collection, server, sampling)
+    _ensure_run_config(config)
+    slices = partition_slices(
+        partition_specs(),
+        collection.shard_index,
+        collection.num_shards,
+        collection.max_records,
+    )
+    expected_records = sum(partition_slice.num_rows for partition_slice in slices)
+    complete_records = 0
+    generated_records = 0
+    skipped_records = 0
+    started = time.time()
+    _write_progress(
+        collection,
+        "running",
+        expected_records,
+        complete_records,
+        generated_records,
+        skipped_records,
+        started,
+    )
+
+    with ThreadPoolExecutor(max_workers=collection.concurrency) as executor:
+        for partition_slice in slices:
+            partition = partition_slice.partition
+            pending_chunks = []
+            for row_start in range(0, partition_slice.num_rows, collection.chunk_size):
+                row_end = min(partition_slice.num_rows, row_start + collection.chunk_size)
+                path = _chunk_path(collection.output_path, partition, row_start, row_end)
+                if path.exists():
+                    complete_records += row_end - row_start
+                    skipped_records += row_end - row_start
+                    continue
+                pending_chunks.append((row_start, row_end, path))
+            if not pending_chunks:
+                continue
+
+            records = _read_partition(partition_slice)
+            for row_start, row_end, path in pending_chunks:
+                chunk = records[row_start:row_end]
+                outputs = list(executor.map(lambda prompt: _completion(vllm_url, prompt, sampling), chunk))
+                path.write_text(
+                    "".join(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n" for record in outputs),
+                    compression="gzip",
+                )
+                complete_records += len(outputs)
+                generated_records += len(outputs)
+                _write_progress(
+                    collection,
+                    "running",
+                    expected_records,
+                    complete_records,
+                    generated_records,
+                    skipped_records,
+                    started,
+                )
+                logger.info(
+                    "Shard %d saved %d/%d records to %s",
+                    collection.shard_index,
+                    complete_records,
+                    expected_records,
+                    path,
+                )
+
+    _write_progress(
+        collection,
+        "complete",
+        expected_records,
+        complete_records,
+        generated_records,
+        skipped_records,
+        started,
+    )
+    if complete_records != expected_records:
+        raise RuntimeError(f"Shard completed {complete_records} of {expected_records} expected records")
+
+
+def prepare_model(output_path: str) -> None:
+    weights = resolve_model_path(MODEL, MODEL_CACHE_TTL_DAYS, MODEL_REVISION)
+    manifest = {
+        "model": MODEL,
+        "model_revision": MODEL_REVISION,
+        "weights": weights,
+        "cache_ttl_days": MODEL_CACHE_TTL_DAYS,
+        "prepared_at": datetime.now(UTC).isoformat(),
+    }
+    StoragePath(f"{output_path}/model-cache.json").write_text(json.dumps(manifest, indent=2, sort_keys=True))
+    logger.info("Prepared model cache at %s", weights)
+
+
+def run(
+    collection: CollectionConfig,
+    server: ServerConfig,
+    sampling: SamplingConfig,
+) -> None:
+    ctx = iris_ctx()
+    if ctx is None or ctx.client is None:
+        raise RuntimeError("Collector must run inside an Iris job")
+    endpoint_suffix = f"{collection.run_id}-s{collection.shard_index}"
+    vllm_endpoint = f"{VLLM_ENDPOINT}-{endpoint_suffix}"
+    ray_endpoint = f"{RAY_ENDPOINT}-{endpoint_suffix}"
+    vllm_job = _submit_vllm(ctx, vllm_endpoint, ray_endpoint, server)
+    try:
+        vllm_url = _wait_for_endpoint(vllm_endpoint, vllm_job)
+        logger.info("GLM-5.2 ready; writing responses to %s", collection.output_path)
+        _run_collection(vllm_url, collection, server, sampling)
+    finally:
+        with suppress(Exception):
+            vllm_job.terminate()
+
+
+def _positive(parser: argparse.ArgumentParser, name: str, value: int) -> None:
+    if value < 1:
+        parser.error(f"{name} must be positive")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    prepare_parser = subparsers.add_parser("prepare")
+    prepare_parser.add_argument("--output-path", required=True)
+    run_parser = subparsers.add_parser("run")
+    run_parser.add_argument("--run-id", required=True)
+    run_parser.add_argument("--output-path", required=True)
+    run_parser.add_argument("--shard-index", type=int, required=True)
+    run_parser.add_argument("--num-shards", type=int, required=True)
+    run_parser.add_argument("--max-records", type=int)
+    run_parser.add_argument("--chunk-size", type=int, default=DEFAULT_CHUNK_SIZE)
+    run_parser.add_argument("--concurrency", type=int, default=DEFAULT_CONCURRENCY)
+    run_parser.add_argument("--max-model-len", type=int, default=DEFAULT_MAX_MODEL_LEN)
+    run_parser.add_argument("--max-num-seqs", type=int, default=DEFAULT_MAX_NUM_SEQS)
+    run_parser.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS)
+    run_parser.add_argument("--temperature", type=float, default=DEFAULT_TEMPERATURE)
+    run_parser.add_argument("--top-p", type=float, default=DEFAULT_TOP_P)
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
+    if args.command == "prepare":
+        prepare_model(args.output_path)
+        return
+
+    for name in ("num_shards", "chunk_size", "concurrency", "max_model_len", "max_num_seqs", "max_tokens"):
+        _positive(parser, f"--{name.replace('_', '-')}", getattr(args, name))
+    if args.max_records is not None:
+        _positive(parser, "--max-records", args.max_records)
+    if not 0 <= args.shard_index < args.num_shards:
+        parser.error("--shard-index must be in [0, --num-shards)")
+    if args.temperature < 0:
+        parser.error("--temperature must not be negative")
+    if not 0 < args.top_p <= 1:
+        parser.error("--top-p must be in (0, 1]")
+
+    run(
+        CollectionConfig(
+            run_id=args.run_id,
+            output_path=args.output_path.rstrip("/"),
+            shard_index=args.shard_index,
+            num_shards=args.num_shards,
+            max_records=args.max_records,
+            chunk_size=args.chunk_size,
+            concurrency=args.concurrency,
+        ),
+        ServerConfig(max_model_len=args.max_model_len, max_num_seqs=args.max_num_seqs),
+        SamplingConfig(temperature=args.temperature, top_p=args.top_p, max_tokens=args.max_tokens),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/rollout_data/collect_hero_run_4_code_glm52.py
+++ b/experiments/rollout_data/collect_hero_run_4_code_glm52.py
@@ -6,37 +6,31 @@
 import argparse
 import json
 import logging
-import os
-import socket
-import subprocess
-import tempfile
 import time
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import suppress
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import Any
 
-import psutil
 import pyarrow.parquet as pq
 import requests
 from iris.client import iris_ctx
-from iris.cluster.client.job_info import get_job_info
-from iris.cluster.setup_scripts import default_setup_script
-from iris.cluster.types import CoschedulingConfig, Entrypoint, EnvironmentSpec, ResourceSpec, gpu_device, is_job_finished
-from marin.inference.config import DEFAULT_CUDA_VLLM_VERSION
-from marin.inference.model_preparation import resolve_model_path
-from marin.inference.proxy import _reserve_port
-from marin.inference.vllm_server import IsolatedCudaVllm, _poll_until_ready
 from rigging.filesystem import StoragePath
-from rigging.timing import Duration
+
+from experiments.rollout_data.glm52_vllm import (
+    GPU_MEMORY_UTILIZATION,
+    MODEL,
+    MODEL_CACHE_TTL_DAYS,
+    MODEL_REVISION,
+    ServerConfig,
+    prepare_model_cache,
+    submit_glm52,
+    wait_for_endpoint,
+)
 
 logger = logging.getLogger(__name__)
 
-MODEL = "zai-org/GLM-5.2-FP8"
-MODEL_REVISION = "ba978f7d347eaf65d22f1a86833408afdb953541"
 DATASET = "mlfoundations-dev/hero_run_4_code"
 DATASET_SPLIT = "train"
 DATASET_REVISION = "18bef55db16de0a0f7416c200697a201e82e6ff5"
@@ -100,11 +94,6 @@ PARQUET_URL = (
 )
 VLLM_ENDPOINT = "glm52-openai"
 RAY_ENDPOINT = "glm52-ray"
-CUDA_COMPILER_REQUIREMENT = "cuda-toolkit[cccl,crt,cudart,nvcc,nvvm]==13.0.2"
-MODEL_CACHE_TTL_DAYS = 30
-GPUS_PER_NODE = 4
-VLLM_REPLICAS = 2
-TENSOR_PARALLEL_SIZE = GPUS_PER_NODE * VLLM_REPLICAS
 DEFAULT_MAX_MODEL_LEN = 64 * 1024
 DEFAULT_MAX_NUM_SEQS = 12
 DEFAULT_MAX_TOKENS = 16 * 1024
@@ -112,11 +101,9 @@ DEFAULT_TEMPERATURE = 1.0
 DEFAULT_TOP_P = 0.95
 DEFAULT_CONCURRENCY = 16
 DEFAULT_CHUNK_SIZE = 32
-GPU_MEMORY_UTILIZATION = 0.9
-ENDPOINT_TIMEOUT = 3 * 3600
 REQUEST_TIMEOUT = 3 * 3600
-RUN_TIMEOUT_HOURS = 30 * 24
 INPUT_COLUMNS = ("id", "instruction_seed", "__original_row_idx")
+PROGRESS_RUNNING = "running"
 
 
 @dataclass(frozen=True)
@@ -124,12 +111,6 @@ class SamplingConfig:
     temperature: float
     top_p: float
     max_tokens: int
-
-
-@dataclass(frozen=True)
-class ServerConfig:
-    max_model_len: int
-    max_num_seqs: int
 
 
 @dataclass(frozen=True)
@@ -219,246 +200,6 @@ def partition_slices(
         slices.append(PartitionSlice(partition, num_rows))
         remaining -= num_rows
     return slices
-
-
-def _ray_worker_port_args(*excluded_ports: int) -> list[str]:
-    for minimum in (20000, 30000, 40000, 50000):
-        maximum = minimum + 9999
-        if not any(minimum <= port <= maximum for port in excluded_ports):
-            return [f"--min-worker-port={minimum}", f"--max-worker-port={maximum}"]
-    raise ValueError(f"Could not select Ray worker ports excluding {excluded_ports}")
-
-
-def _network_interface(host: str) -> str:
-    for name, addresses in psutil.net_if_addrs().items():
-        if any(address.family == socket.AF_INET and address.address == host for address in addresses):
-            return name
-    raise RuntimeError(f"No network interface owns advertised host IP {host}")
-
-
-def _check_process_alive(process: subprocess.Popen[bytes]) -> None:
-    return_code = process.poll()
-    if return_code is not None:
-        raise RuntimeError(f"vLLM exited with code {return_code} before becoming ready")
-
-
-def _wait_for_endpoint(name: str, job=None, timeout: float = ENDPOINT_TIMEOUT) -> str:
-    ctx = iris_ctx()
-    assert ctx is not None
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        result = ctx.resolver.resolve(name)
-        if not result.is_empty:
-            return result.first().url
-        if job is not None and is_job_finished(job.state):
-            raise RuntimeError(f"Job {job} finished before registering endpoint {name!r}")
-        time.sleep(15)
-    raise TimeoutError(f"Timed out waiting for endpoint {name!r}")
-
-
-def _vllm_process_command() -> tuple[list[str], dict[str, str]]:
-    launcher = IsolatedCudaVllm(version=DEFAULT_CUDA_VLLM_VERSION)
-    command = launcher.command()
-    python_index = command.index("--python")
-    command[python_index:python_index] = [
-        "--with",
-        "ray[cgraph]>=2.55.1",
-        "--with",
-        CUDA_COMPILER_REQUIREMENT,
-    ]
-    return command, {**os.environ, **launcher.env()}
-
-
-def _cuda_overlay(cuda_root: Path) -> str:
-    cuda_home = Path(tempfile.mkdtemp(prefix="cuda-home-"))
-    for directory in ("bin", "include", "nvvm"):
-        (cuda_home / directory).symlink_to(cuda_root / directory, target_is_directory=True)
-    lib64 = cuda_home / "lib64"
-    lib64.mkdir()
-    for library in (cuda_root / "lib").iterdir():
-        (lib64 / library.name).symlink_to(library, target_is_directory=library.is_dir())
-    cudart = next((cuda_root / "lib").glob("libcudart.so.*"))
-    (lib64 / "libcudart.so").symlink_to(cudart)
-    return str(cuda_home)
-
-
-def _cuda_home(vllm_command: list[str], environment: dict[str, str]) -> str:
-    script = """\
-from pathlib import Path
-import sys
-
-nvcc = next(path for entry in sys.path for path in Path(entry).glob("nvidia/**/bin/nvcc"))
-print(nvcc.parent.parent)
-"""
-    command = [*vllm_command[:-1], "python", "-c", script]
-    cuda_root = Path(subprocess.check_output(command, env=environment, text=True).strip())
-    return _cuda_overlay(cuda_root)
-
-
-def _run_vllm(
-    ctx,
-    host: str,
-    http_port: int,
-    ray_address: str,
-    vllm_endpoint: str,
-    vllm_command: list[str],
-    environment: dict[str, str],
-    weights: str,
-    config: ServerConfig,
-) -> None:
-    process = subprocess.Popen(
-        [
-            *vllm_command,
-            "serve",
-            weights,
-            "--served-model-name",
-            MODEL,
-            "--host",
-            host,
-            "--port",
-            str(http_port),
-            "--tensor-parallel-size",
-            str(TENSOR_PARALLEL_SIZE),
-            "--distributed-executor-backend",
-            "ray",
-            "--enable-expert-parallel",
-            "--max-model-len",
-            str(config.max_model_len),
-            "--max-num-seqs",
-            str(config.max_num_seqs),
-            "--gpu-memory-utilization",
-            str(GPU_MEMORY_UTILIZATION),
-            "--trust-remote-code",
-        ],
-        env={**environment, "RAY_ADDRESS": ray_address},
-    )
-    try:
-        base_url = f"http://{host}:{http_port}"
-        _poll_until_ready(
-            f"{base_url}/v1",
-            timeout_seconds=ENDPOINT_TIMEOUT,
-            check_alive=lambda: _check_process_alive(process),
-        )
-        endpoint_id = ctx.registry.register(vllm_endpoint, base_url)
-        try:
-            return_code = process.wait()
-            raise RuntimeError(f"vLLM exited with code {return_code}")
-        finally:
-            ctx.registry.unregister(endpoint_id)
-    finally:
-        if process.poll() is None:
-            process.terminate()
-            with suppress(subprocess.TimeoutExpired):
-                process.wait(timeout=30)
-        if process.poll() is None:
-            process.kill()
-
-
-def _serve_ray_head(
-    ctx,
-    host: str,
-    vllm_endpoint: str,
-    ray_endpoint: str,
-    vllm_command: list[str],
-    ray_command: list[str],
-    environment: dict[str, str],
-    config: ServerConfig,
-) -> None:
-    weights = resolve_model_path(MODEL, MODEL_CACHE_TTL_DAYS, MODEL_REVISION)
-    ray_port = _reserve_port(host, ctx.get_port("ray"))
-    http_port = _reserve_port(host, ctx.get_port("http"))
-    ray_address = f"{host}:{ray_port}"
-    subprocess.run(
-        [
-            *ray_command,
-            "start",
-            "--head",
-            f"--node-ip-address={host}",
-            f"--port={ray_port}",
-            *_ray_worker_port_args(ray_port, http_port),
-            f"--num-gpus={GPUS_PER_NODE}",
-            "--disable-usage-stats",
-        ],
-        check=True,
-        env=environment,
-    )
-    ray_endpoint_id = ctx.registry.register(ray_endpoint, ray_address)
-    try:
-        deadline = time.monotonic() + 900
-        while time.monotonic() < deadline:
-            status = subprocess.run(
-                [*ray_command, "status", f"--address={ray_address}"],
-                env=environment,
-                text=True,
-                capture_output=True,
-            )
-            if status.returncode == 0 and f"/{TENSOR_PARALLEL_SIZE}.0 GPU" in status.stdout:
-                break
-            time.sleep(10)
-        else:
-            raise TimeoutError(f"Ray cluster did not register all {TENSOR_PARALLEL_SIZE} GB200 GPUs")
-        _run_vllm(ctx, host, http_port, ray_address, vllm_endpoint, vllm_command, environment, weights, config)
-    finally:
-        ctx.registry.unregister(ray_endpoint_id)
-        subprocess.run([*ray_command, "stop", "--force"], env=environment, check=False)
-
-
-def _serve_ray_worker(host: str, ray_endpoint: str, ray_command: list[str], environment: dict[str, str]) -> None:
-    ray_address = _wait_for_endpoint(ray_endpoint, timeout=ENDPOINT_TIMEOUT)
-    subprocess.run(
-        [
-            *ray_command,
-            "start",
-            f"--address={ray_address}",
-            f"--node-ip-address={host}",
-            *_ray_worker_port_args(),
-            f"--num-gpus={GPUS_PER_NODE}",
-            "--disable-usage-stats",
-            "--block",
-        ],
-        check=True,
-        env=environment,
-    )
-
-
-def _serve_glm52(vllm_endpoint: str, ray_endpoint: str, config: ServerConfig) -> None:
-    info = get_job_info()
-    ctx = iris_ctx()
-    if info is None or ctx is None:
-        raise RuntimeError("GLM-5.2 serving must run inside an Iris task")
-
-    vllm_command, environment = _vllm_process_command()
-    ray_command = [*vllm_command[:-1], "ray"]
-    host = info.advertise_host
-    environment["CUDA_HOME"] = _cuda_home(vllm_command, environment)
-    environment["VLLM_HOST_IP"] = host
-    environment["GLOO_SOCKET_IFNAME"] = _network_interface(host)
-    if info.task_index == 0:
-        _serve_ray_head(ctx, host, vllm_endpoint, ray_endpoint, vllm_command, ray_command, environment, config)
-        return
-    _serve_ray_worker(host, ray_endpoint, ray_command, environment)
-
-
-def _submit_vllm(ctx, vllm_endpoint: str, ray_endpoint: str, config: ServerConfig):
-    return ctx.client.submit(
-        entrypoint=Entrypoint.from_callable(_serve_glm52, vllm_endpoint, ray_endpoint, config),
-        name="vllm",
-        resources=ResourceSpec(
-            cpu=120,
-            memory="850g",
-            disk="1000g",
-            device=gpu_device("GB200", GPUS_PER_NODE),
-        ),
-        environment=EnvironmentSpec(
-            setup_scripts=[default_setup_script(packages=["marin-core"])],
-            env_vars={"VLLM_USE_FLASHINFER_SAMPLER": "0"},
-        ),
-        ports=["ray", "http"],
-        coscheduling=CoschedulingConfig(group_by="nvlink.domain"),
-        replicas=VLLM_REPLICAS,
-        timeout=Duration.from_hours(RUN_TIMEOUT_HOURS),
-        max_retries_failure=0,
-    )
 
 
 def _read_partition(partition_slice: PartitionSlice) -> list[PromptRecord]:
@@ -661,7 +402,7 @@ def _run_collection(
     started = time.time()
     _write_progress(
         collection,
-        "running",
+        PROGRESS_RUNNING,
         expected_records,
         complete_records,
         generated_records,
@@ -677,7 +418,7 @@ def _run_collection(
                 skipped_records += delta.skipped_records
                 _write_progress(
                     collection,
-                    "running",
+                    PROGRESS_RUNNING,
                     expected_records,
                     complete_records,
                     generated_records,
@@ -707,7 +448,7 @@ def _run_collection(
 
 
 def prepare_model(output_path: StoragePath) -> None:
-    weights = resolve_model_path(MODEL, MODEL_CACHE_TTL_DAYS, MODEL_REVISION)
+    weights = prepare_model_cache()
     manifest = {
         "model": MODEL,
         "model_revision": MODEL_REVISION,
@@ -730,9 +471,9 @@ def run(
     endpoint_suffix = f"{collection.run_id}-s{collection.shard_index}"
     vllm_endpoint = f"{VLLM_ENDPOINT}-{endpoint_suffix}"
     ray_endpoint = f"{RAY_ENDPOINT}-{endpoint_suffix}"
-    vllm_job = _submit_vllm(ctx, vllm_endpoint, ray_endpoint, server)
+    vllm_job = submit_glm52(ctx, vllm_endpoint, ray_endpoint, server)
     try:
-        vllm_url = _wait_for_endpoint(vllm_endpoint, vllm_job)
+        vllm_url = wait_for_endpoint(vllm_endpoint, vllm_job)
         logger.info("GLM-5.2 ready; writing responses to %s", collection.output_path)
         _run_collection(vllm_url, collection, server, sampling)
     finally:

--- a/experiments/rollout_data/collect_hero_run_4_code_glm52.py
+++ b/experiments/rollout_data/collect_hero_run_4_code_glm52.py
@@ -29,7 +29,7 @@ from iris.cluster.types import CoschedulingConfig, Entrypoint, EnvironmentSpec, 
 from marin.inference.config import DEFAULT_CUDA_VLLM_VERSION
 from marin.inference.model_preparation import resolve_model_path
 from marin.inference.proxy import _reserve_port
-from marin.inference.vllm_server import IsolatedCudaVllm
+from marin.inference.vllm_server import IsolatedCudaVllm, _poll_until_ready
 from rigging.filesystem import StoragePath
 from rigging.timing import Duration
 
@@ -236,19 +236,10 @@ def _network_interface(host: str) -> str:
     raise RuntimeError(f"No network interface owns advertised host IP {host}")
 
 
-def _wait_for_http(url: str, process: subprocess.Popen[bytes], timeout: float) -> None:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if process.poll() is not None:
-            raise RuntimeError(f"Process exited with code {process.returncode} before {url} became ready")
-        try:
-            response = requests.get(url, timeout=10)
-            if response.ok:
-                return
-        except requests.RequestException:
-            pass
-        time.sleep(5)
-    raise TimeoutError(f"Timed out waiting for {url}")
+def _check_process_alive(process: subprocess.Popen[bytes]) -> None:
+    return_code = process.poll()
+    if return_code is not None:
+        raise RuntimeError(f"vLLM exited with code {return_code} before becoming ready")
 
 
 def _wait_for_endpoint(name: str, job=None, timeout: float = ENDPOINT_TIMEOUT) -> str:
@@ -343,7 +334,11 @@ def _run_vllm(
     )
     try:
         base_url = f"http://{host}:{http_port}"
-        _wait_for_http(f"{base_url}/health", process, ENDPOINT_TIMEOUT)
+        _poll_until_ready(
+            f"{base_url}/v1",
+            timeout_seconds=ENDPOINT_TIMEOUT,
+            check_alive=lambda: _check_process_alive(process),
+        )
         endpoint_id = ctx.registry.register(vllm_endpoint, base_url)
         try:
             return_code = process.wait()

--- a/experiments/rollout_data/collect_hero_run_4_code_glm52.py
+++ b/experiments/rollout_data/collect_hero_run_4_code_glm52.py
@@ -23,10 +23,11 @@ from experiments.rollout_data.glm52_vllm import (
     MODEL,
     MODEL_CACHE_TTL_DAYS,
     MODEL_REVISION,
+    Glm52LaunchConfig,
     ServerConfig,
     prepare_model_cache,
     submit_glm52,
-    wait_for_endpoint,
+    wait_for_endpoint_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -471,9 +472,9 @@ def run(
     endpoint_suffix = f"{collection.run_id}-s{collection.shard_index}"
     vllm_endpoint = f"{VLLM_ENDPOINT}-{endpoint_suffix}"
     ray_endpoint = f"{RAY_ENDPOINT}-{endpoint_suffix}"
-    vllm_job = submit_glm52(ctx, vllm_endpoint, ray_endpoint, server)
+    vllm_job = submit_glm52(ctx, Glm52LaunchConfig(vllm_endpoint, ray_endpoint, server))
     try:
-        vllm_url = wait_for_endpoint(vllm_endpoint, vllm_job)
+        vllm_url = wait_for_endpoint_url(vllm_endpoint, vllm_job)
         logger.info("GLM-5.2 ready; writing responses to %s", collection.output_path)
         _run_collection(vllm_url, collection, server, sampling)
     finally:

--- a/experiments/rollout_data/glm52_vllm.py
+++ b/experiments/rollout_data/glm52_vllm.py
@@ -1,0 +1,279 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import socket
+import subprocess
+import tempfile
+import time
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+
+import psutil
+from iris.client import iris_ctx
+from iris.cluster.client.job_info import get_job_info
+from iris.cluster.setup_scripts import default_setup_script
+from iris.cluster.types import CoschedulingConfig, Entrypoint, EnvironmentSpec, ResourceSpec, gpu_device, is_job_finished
+from marin.inference.config import DEFAULT_CUDA_VLLM_VERSION
+from marin.inference.model_preparation import resolve_model_path
+from marin.inference.proxy import _reserve_port
+from marin.inference.vllm_server import IsolatedCudaVllm, _poll_until_ready
+from rigging.timing import Duration
+
+MODEL = "zai-org/GLM-5.2-FP8"
+MODEL_REVISION = "ba978f7d347eaf65d22f1a86833408afdb953541"
+CUDA_COMPILER_REQUIREMENT = "cuda-toolkit[cccl,crt,cudart,nvcc,nvvm]==13.0.2"
+MODEL_CACHE_TTL_DAYS = 30
+GPUS_PER_NODE = 4
+VLLM_REPLICAS = 2
+TENSOR_PARALLEL_SIZE = GPUS_PER_NODE * VLLM_REPLICAS
+GPU_MEMORY_UTILIZATION = 0.9
+ENDPOINT_TIMEOUT = 3 * 3600
+RUN_TIMEOUT_HOURS = 30 * 24
+
+
+@dataclass(frozen=True)
+class ServerConfig:
+    max_model_len: int
+    max_num_seqs: int
+
+
+def _ray_worker_port_args(*excluded_ports: int) -> list[str]:
+    for minimum in (20000, 30000, 40000, 50000):
+        maximum = minimum + 9999
+        if not any(minimum <= port <= maximum for port in excluded_ports):
+            return [f"--min-worker-port={minimum}", f"--max-worker-port={maximum}"]
+    raise ValueError(f"Could not select Ray worker ports excluding {excluded_ports}")
+
+
+def _network_interface(host: str) -> str:
+    for name, addresses in psutil.net_if_addrs().items():
+        if any(address.family == socket.AF_INET and address.address == host for address in addresses):
+            return name
+    raise RuntimeError(f"No network interface owns advertised host IP {host}")
+
+
+def wait_for_endpoint(name: str, job=None, timeout: float = ENDPOINT_TIMEOUT) -> str:
+    ctx = iris_ctx()
+    assert ctx is not None
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = ctx.resolver.resolve(name)
+        if not result.is_empty:
+            return result.first().url
+        if job is not None and is_job_finished(job.state):
+            raise RuntimeError(f"Job {job} finished before registering endpoint {name!r}")
+        time.sleep(15)
+    raise TimeoutError(f"Timed out waiting for endpoint {name!r}")
+
+
+def _vllm_launch_context() -> tuple[list[str], dict[str, str]]:
+    launcher = IsolatedCudaVllm(version=DEFAULT_CUDA_VLLM_VERSION)
+    command = launcher.command()
+    python_index = command.index("--python")
+    command[python_index:python_index] = [
+        "--with",
+        "ray[cgraph]>=2.55.1",
+        "--with",
+        CUDA_COMPILER_REQUIREMENT,
+    ]
+    return command, {**os.environ, **launcher.env()}
+
+
+def _cuda_overlay(cuda_root: Path) -> str:
+    cuda_home = Path(tempfile.mkdtemp(prefix="cuda-home-"))
+    for directory in ("bin", "include", "nvvm"):
+        (cuda_home / directory).symlink_to(cuda_root / directory, target_is_directory=True)
+    lib64 = cuda_home / "lib64"
+    lib64.mkdir()
+    for library in (cuda_root / "lib").iterdir():
+        (lib64 / library.name).symlink_to(library, target_is_directory=library.is_dir())
+    cudart = next((cuda_root / "lib").glob("libcudart.so.*"))
+    (lib64 / "libcudart.so").symlink_to(cudart)
+    return str(cuda_home)
+
+
+def _cuda_home(vllm_command: list[str], environment: dict[str, str]) -> str:
+    script = """\
+from pathlib import Path
+import sys
+
+nvcc = next(path for entry in sys.path for path in Path(entry).glob("nvidia/**/bin/nvcc"))
+print(nvcc.parent.parent)
+"""
+    command = [*vllm_command[:-1], "python", "-c", script]
+    cuda_root = Path(subprocess.check_output(command, env=environment, text=True).strip())
+    return _cuda_overlay(cuda_root)
+
+
+def _check_process_alive(process: subprocess.Popen[bytes]) -> None:
+    return_code = process.poll()
+    if return_code is not None:
+        raise RuntimeError(f"vLLM exited with code {return_code} before becoming ready")
+
+
+def _run_vllm(
+    ctx,
+    host: str,
+    http_port: int,
+    ray_address: str,
+    vllm_endpoint: str,
+    vllm_command: list[str],
+    environment: dict[str, str],
+    weights: str,
+    config: ServerConfig,
+) -> None:
+    process = subprocess.Popen(
+        [
+            *vllm_command,
+            "serve",
+            weights,
+            "--served-model-name",
+            MODEL,
+            "--host",
+            host,
+            "--port",
+            str(http_port),
+            "--tensor-parallel-size",
+            str(TENSOR_PARALLEL_SIZE),
+            "--distributed-executor-backend",
+            "ray",
+            "--enable-expert-parallel",
+            "--max-model-len",
+            str(config.max_model_len),
+            "--max-num-seqs",
+            str(config.max_num_seqs),
+            "--gpu-memory-utilization",
+            str(GPU_MEMORY_UTILIZATION),
+            "--trust-remote-code",
+        ],
+        env={**environment, "RAY_ADDRESS": ray_address},
+    )
+    try:
+        base_url = f"http://{host}:{http_port}"
+        _poll_until_ready(
+            f"{base_url}/v1",
+            timeout_seconds=ENDPOINT_TIMEOUT,
+            check_alive=lambda: _check_process_alive(process),
+        )
+        with ctx.registry.registered(vllm_endpoint, base_url):
+            return_code = process.wait()
+            raise RuntimeError(f"vLLM exited with code {return_code}")
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            with suppress(subprocess.TimeoutExpired):
+                process.wait(timeout=30)
+        if process.poll() is None:
+            process.kill()
+
+
+def _serve_ray_head(
+    ctx,
+    host: str,
+    vllm_endpoint: str,
+    ray_endpoint: str,
+    vllm_command: list[str],
+    ray_command: list[str],
+    environment: dict[str, str],
+    config: ServerConfig,
+) -> None:
+    weights = prepare_model_cache()
+    ray_port = _reserve_port(host, ctx.get_port("ray"))
+    http_port = _reserve_port(host, ctx.get_port("http"))
+    ray_address = f"{host}:{ray_port}"
+    subprocess.run(
+        [
+            *ray_command,
+            "start",
+            "--head",
+            f"--node-ip-address={host}",
+            f"--port={ray_port}",
+            *_ray_worker_port_args(ray_port, http_port),
+            f"--num-gpus={GPUS_PER_NODE}",
+            "--disable-usage-stats",
+        ],
+        check=True,
+        env=environment,
+    )
+    with ctx.registry.registered(ray_endpoint, ray_address):
+        try:
+            deadline = time.monotonic() + 900
+            while time.monotonic() < deadline:
+                status = subprocess.run(
+                    [*ray_command, "status", f"--address={ray_address}"],
+                    env=environment,
+                    text=True,
+                    capture_output=True,
+                )
+                if status.returncode == 0 and f"/{TENSOR_PARALLEL_SIZE}.0 GPU" in status.stdout:
+                    break
+                time.sleep(10)
+            else:
+                raise TimeoutError(f"Ray cluster did not register all {TENSOR_PARALLEL_SIZE} GB200 GPUs")
+            _run_vllm(ctx, host, http_port, ray_address, vllm_endpoint, vllm_command, environment, weights, config)
+        finally:
+            subprocess.run([*ray_command, "stop", "--force"], env=environment, check=False)
+
+
+def _serve_ray_worker(host: str, ray_endpoint: str, ray_command: list[str], environment: dict[str, str]) -> None:
+    ray_address = wait_for_endpoint(ray_endpoint, timeout=ENDPOINT_TIMEOUT)
+    subprocess.run(
+        [
+            *ray_command,
+            "start",
+            f"--address={ray_address}",
+            f"--node-ip-address={host}",
+            *_ray_worker_port_args(),
+            f"--num-gpus={GPUS_PER_NODE}",
+            "--disable-usage-stats",
+            "--block",
+        ],
+        check=True,
+        env=environment,
+    )
+
+
+def _serve_glm52(vllm_endpoint: str, ray_endpoint: str, config: ServerConfig) -> None:
+    info = get_job_info()
+    ctx = iris_ctx()
+    if info is None or ctx is None:
+        raise RuntimeError("GLM-5.2 serving must run inside an Iris task")
+
+    vllm_command, environment = _vllm_launch_context()
+    ray_command = [*vllm_command[:-1], "ray"]
+    host = info.advertise_host
+    environment["CUDA_HOME"] = _cuda_home(vllm_command, environment)
+    environment["VLLM_HOST_IP"] = host
+    environment["GLOO_SOCKET_IFNAME"] = _network_interface(host)
+    if info.task_index == 0:
+        _serve_ray_head(ctx, host, vllm_endpoint, ray_endpoint, vllm_command, ray_command, environment, config)
+        return
+    _serve_ray_worker(host, ray_endpoint, ray_command, environment)
+
+
+def submit_glm52(ctx, vllm_endpoint: str, ray_endpoint: str, config: ServerConfig):
+    return ctx.client.submit(
+        entrypoint=Entrypoint.from_callable(_serve_glm52, vllm_endpoint, ray_endpoint, config),
+        name="vllm",
+        resources=ResourceSpec(
+            cpu=120,
+            memory="850g",
+            disk="1000g",
+            device=gpu_device("GB200", GPUS_PER_NODE),
+        ),
+        environment=EnvironmentSpec(
+            setup_scripts=[default_setup_script(packages=["marin-core"])],
+            env_vars={"VLLM_USE_FLASHINFER_SAMPLER": "0"},
+        ),
+        ports=["ray", "http"],
+        coscheduling=CoschedulingConfig(group_by="nvlink.domain"),
+        replicas=VLLM_REPLICAS,
+        timeout=Duration.from_hours(RUN_TIMEOUT_HOURS),
+        max_retries_failure=0,
+    )
+
+
+def prepare_model_cache() -> str:
+    return resolve_model_path(MODEL, MODEL_CACHE_TTL_DAYS, MODEL_REVISION)

--- a/experiments/rollout_data/glm52_vllm.py
+++ b/experiments/rollout_data/glm52_vllm.py
@@ -31,12 +31,21 @@ TENSOR_PARALLEL_SIZE = GPUS_PER_NODE * VLLM_REPLICAS
 GPU_MEMORY_UTILIZATION = 0.9
 ENDPOINT_TIMEOUT = 3 * 3600
 RUN_TIMEOUT_HOURS = 30 * 24
+RAY_PORT = "ray"
+HTTP_PORT = "http"
 
 
 @dataclass(frozen=True)
 class ServerConfig:
     max_model_len: int
     max_num_seqs: int
+
+
+@dataclass(frozen=True)
+class Glm52LaunchConfig:
+    vllm_endpoint: str
+    ray_endpoint: str
+    server: ServerConfig
 
 
 def _ray_worker_port_args(*excluded_ports: int) -> list[str]:
@@ -54,7 +63,8 @@ def _network_interface(host: str) -> str:
     raise RuntimeError(f"No network interface owns advertised host IP {host}")
 
 
-def wait_for_endpoint(name: str, job=None, timeout: float = ENDPOINT_TIMEOUT) -> str:
+def wait_for_endpoint_url(name: str, job=None, timeout: float = ENDPOINT_TIMEOUT) -> str:
+    """Return the first resolved URL for an Iris endpoint."""
     ctx = iris_ctx()
     assert ctx is not None
     deadline = time.monotonic() + timeout
@@ -118,11 +128,10 @@ def _run_vllm(
     host: str,
     http_port: int,
     ray_address: str,
-    vllm_endpoint: str,
     vllm_command: list[str],
     environment: dict[str, str],
     weights: str,
-    config: ServerConfig,
+    launch: Glm52LaunchConfig,
 ) -> None:
     process = subprocess.Popen(
         [
@@ -141,9 +150,9 @@ def _run_vllm(
             "ray",
             "--enable-expert-parallel",
             "--max-model-len",
-            str(config.max_model_len),
+            str(launch.server.max_model_len),
             "--max-num-seqs",
-            str(config.max_num_seqs),
+            str(launch.server.max_num_seqs),
             "--gpu-memory-utilization",
             str(GPU_MEMORY_UTILIZATION),
             "--trust-remote-code",
@@ -157,7 +166,7 @@ def _run_vllm(
             timeout_seconds=ENDPOINT_TIMEOUT,
             check_alive=lambda: _check_process_alive(process),
         )
-        with ctx.registry.registered(vllm_endpoint, base_url):
+        with ctx.registry.registered(launch.vllm_endpoint, base_url):
             return_code = process.wait()
             raise RuntimeError(f"vLLM exited with code {return_code}")
     finally:
@@ -172,16 +181,14 @@ def _run_vllm(
 def _serve_ray_head(
     ctx,
     host: str,
-    vllm_endpoint: str,
-    ray_endpoint: str,
     vllm_command: list[str],
     ray_command: list[str],
     environment: dict[str, str],
-    config: ServerConfig,
+    launch: Glm52LaunchConfig,
 ) -> None:
     weights = prepare_model_cache()
-    ray_port = _reserve_port(host, ctx.get_port("ray"))
-    http_port = _reserve_port(host, ctx.get_port("http"))
+    ray_port = _reserve_port(host, ctx.get_port(RAY_PORT))
+    http_port = _reserve_port(host, ctx.get_port(HTTP_PORT))
     ray_address = f"{host}:{ray_port}"
     subprocess.run(
         [
@@ -197,7 +204,7 @@ def _serve_ray_head(
         check=True,
         env=environment,
     )
-    with ctx.registry.registered(ray_endpoint, ray_address):
+    with ctx.registry.registered(launch.ray_endpoint, ray_address):
         try:
             deadline = time.monotonic() + 900
             while time.monotonic() < deadline:
@@ -212,13 +219,13 @@ def _serve_ray_head(
                 time.sleep(10)
             else:
                 raise TimeoutError(f"Ray cluster did not register all {TENSOR_PARALLEL_SIZE} GB200 GPUs")
-            _run_vllm(ctx, host, http_port, ray_address, vllm_endpoint, vllm_command, environment, weights, config)
+            _run_vllm(ctx, host, http_port, ray_address, vllm_command, environment, weights, launch)
         finally:
             subprocess.run([*ray_command, "stop", "--force"], env=environment, check=False)
 
 
-def _serve_ray_worker(host: str, ray_endpoint: str, ray_command: list[str], environment: dict[str, str]) -> None:
-    ray_address = wait_for_endpoint(ray_endpoint, timeout=ENDPOINT_TIMEOUT)
+def _serve_ray_worker(host: str, launch: Glm52LaunchConfig, ray_command: list[str], environment: dict[str, str]) -> None:
+    ray_address = wait_for_endpoint_url(launch.ray_endpoint, timeout=ENDPOINT_TIMEOUT)
     subprocess.run(
         [
             *ray_command,
@@ -235,7 +242,7 @@ def _serve_ray_worker(host: str, ray_endpoint: str, ray_command: list[str], envi
     )
 
 
-def _serve_glm52(vllm_endpoint: str, ray_endpoint: str, config: ServerConfig) -> None:
+def _serve_glm52(launch: Glm52LaunchConfig) -> None:
     info = get_job_info()
     ctx = iris_ctx()
     if info is None or ctx is None:
@@ -248,14 +255,14 @@ def _serve_glm52(vllm_endpoint: str, ray_endpoint: str, config: ServerConfig) ->
     environment["VLLM_HOST_IP"] = host
     environment["GLOO_SOCKET_IFNAME"] = _network_interface(host)
     if info.task_index == 0:
-        _serve_ray_head(ctx, host, vllm_endpoint, ray_endpoint, vllm_command, ray_command, environment, config)
+        _serve_ray_head(ctx, host, vllm_command, ray_command, environment, launch)
         return
-    _serve_ray_worker(host, ray_endpoint, ray_command, environment)
+    _serve_ray_worker(host, launch, ray_command, environment)
 
 
-def submit_glm52(ctx, vllm_endpoint: str, ray_endpoint: str, config: ServerConfig):
+def submit_glm52(ctx, launch: Glm52LaunchConfig):
     return ctx.client.submit(
-        entrypoint=Entrypoint.from_callable(_serve_glm52, vllm_endpoint, ray_endpoint, config),
+        entrypoint=Entrypoint.from_callable(_serve_glm52, launch),
         name="vllm",
         resources=ResourceSpec(
             cpu=120,
@@ -267,7 +274,7 @@ def submit_glm52(ctx, vllm_endpoint: str, ray_endpoint: str, config: ServerConfi
             setup_scripts=[default_setup_script(packages=["marin-core"])],
             env_vars={"VLLM_USE_FLASHINFER_SAMPLER": "0"},
         ),
-        ports=["ray", "http"],
+        ports=[RAY_PORT, HTTP_PORT],
         coscheduling=CoschedulingConfig(group_by="nvlink.domain"),
         replicas=VLLM_REPLICAS,
         timeout=Duration.from_hours(RUN_TIMEOUT_HOURS),

--- a/experiments/rollout_data/glm52_vllm.py
+++ b/experiments/rollout_data/glm52_vllm.py
@@ -5,7 +5,6 @@ import os
 import socket
 import subprocess
 import tempfile
-import time
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
@@ -19,7 +18,7 @@ from marin.inference.config import DEFAULT_CUDA_VLLM_VERSION
 from marin.inference.model_preparation import resolve_model_path
 from marin.inference.proxy import _reserve_port
 from marin.inference.vllm_server import IsolatedCudaVllm, _poll_until_ready
-from rigging.timing import Duration
+from rigging.timing import Duration, ExponentialBackoff
 
 MODEL = "zai-org/GLM-5.2-FP8"
 MODEL_REVISION = "ba978f7d347eaf65d22f1a86833408afdb953541"
@@ -67,15 +66,23 @@ def wait_for_endpoint_url(name: str, job=None, timeout: float = ENDPOINT_TIMEOUT
     """Return the first resolved URL for an Iris endpoint."""
     ctx = iris_ctx()
     assert ctx is not None
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
+    resolved: list[str] = []
+
+    def endpoint_ready() -> bool:
         result = ctx.resolver.resolve(name)
         if not result.is_empty:
-            return result.first().url
+            resolved.append(result.first().url)
+            return True
         if job is not None and is_job_finished(job.state):
             raise RuntimeError(f"Job {job} finished before registering endpoint {name!r}")
-        time.sleep(15)
-    raise TimeoutError(f"Timed out waiting for endpoint {name!r}")
+        return False
+
+    ExponentialBackoff(initial=15, maximum=15, jitter=0).wait_until_or_raise(
+        endpoint_ready,
+        timeout=Duration.from_seconds(timeout),
+        error_message=f"Timed out waiting for endpoint {name!r}",
+    )
+    return resolved[0]
 
 
 def _vllm_launch_context() -> tuple[list[str], dict[str, str]]:
@@ -206,19 +213,21 @@ def _serve_ray_head(
     )
     with ctx.registry.registered(launch.ray_endpoint, ray_address):
         try:
-            deadline = time.monotonic() + 900
-            while time.monotonic() < deadline:
+
+            def ray_ready() -> bool:
                 status = subprocess.run(
                     [*ray_command, "status", f"--address={ray_address}"],
                     env=environment,
                     text=True,
                     capture_output=True,
                 )
-                if status.returncode == 0 and f"/{TENSOR_PARALLEL_SIZE}.0 GPU" in status.stdout:
-                    break
-                time.sleep(10)
-            else:
-                raise TimeoutError(f"Ray cluster did not register all {TENSOR_PARALLEL_SIZE} GB200 GPUs")
+                return status.returncode == 0 and f"/{TENSOR_PARALLEL_SIZE}.0 GPU" in status.stdout
+
+            ExponentialBackoff(initial=10, maximum=10, jitter=0).wait_until_or_raise(
+                ray_ready,
+                timeout=Duration.from_seconds(900),
+                error_message=f"Ray cluster did not register all {TENSOR_PARALLEL_SIZE} GB200 GPUs",
+            )
             _run_vllm(ctx, host, http_port, ray_address, vllm_command, environment, weights, launch)
         finally:
             subprocess.run([*ray_command, "stop", "--force"], env=environment, check=False)

--- a/lib/levanter/src/levanter/model_cache.py
+++ b/lib/levanter/src/levanter/model_cache.py
@@ -204,8 +204,10 @@ def _stream_hf_snapshot(fs: fsspec.AbstractFileSystem, dest: str, model_id: str,
     logger.info("streaming %d files from HF repo %s into %s", len(filenames), model_id, dest)
     with tempfile.TemporaryDirectory(prefix="hf_stream_") as scratch:
         for filename in filenames:
-            local_path = hf_hub_download(model_id, filename, revision=revision, local_dir=scratch)
             remote_path = f"{dest}/{filename}"
+            if fs.exists(remote_path):
+                continue
+            local_path = hf_hub_download(model_id, filename, revision=revision, local_dir=scratch)
             # Local/posix-backed fsspec filesystems don't auto-create parents; object
             # stores treat this as a no-op since they have no real directories.
             fs.makedirs(remote_path.rsplit("/", 1)[0], exist_ok=True)

--- a/lib/levanter/src/levanter/model_cache.py
+++ b/lib/levanter/src/levanter/model_cache.py
@@ -194,11 +194,11 @@ def _cache_slug(model: str) -> str:
 
 
 def _stream_hf_snapshot(fs: fsspec.AbstractFileSystem, dest: str, model_id: str, revision: str | None) -> None:
-    """Copy every file of HF repo *model_id* into *dest*, one file at a time.
+    """Copy missing files of HF repo *model_id* into *dest*, one file at a time.
 
-    Each file is downloaded to a scratch dir, uploaded to ``dest``, then deleted
-    before the next download, so peak local disk is one file rather than the full
-    repo.
+    Files already present at ``dest`` are preserved. Each missing file is downloaded
+    to a scratch dir, uploaded to ``dest``, then deleted before the next download,
+    so peak local disk is one file rather than the full repo.
     """
     filenames = list_repo_files(model_id, revision=revision)
     logger.info("streaming %d files from HF repo %s into %s", len(filenames), model_id, dest)

--- a/lib/levanter/tests/test_model_cache.py
+++ b/lib/levanter/tests/test_model_cache.py
@@ -120,6 +120,32 @@ def test_cache_hf_model_streams_one_file_at_a_time(tmp_path, monkeypatch):
     assert Path(cache_path, DEFAULT_COMPLETE_MARKER).exists()
 
 
+def test_cache_hf_model_resumes_partial_snapshot(tmp_path, monkeypatch):
+    repo_files = ["config.json", "model.safetensors", "tokenizer.json"]
+    downloaded: list[str] = []
+
+    monkeypatch.setattr(model_cache, "list_repo_files", lambda model_id, revision=None: repo_files)
+
+    def fake_hf_hub_download(model_id, filename, revision=None, local_dir=None):
+        downloaded.append(filename)
+        local_path = Path(local_dir, filename)
+        local_path.write_text(f"contents of {filename}")
+        return str(local_path)
+
+    monkeypatch.setattr(model_cache, "hf_hub_download", fake_hf_hub_download)
+
+    cache_path = tmp_path / "cache" / "model"
+    cache_path.mkdir(parents=True)
+    (cache_path / "config.json").write_text("existing config")
+
+    result = cache_hf_model(str(cache_path), "org/model")
+
+    assert result == str(cache_path)
+    assert downloaded == ["model.safetensors", "tokenizer.json"]
+    assert (cache_path / "config.json").read_text() == "existing config"
+    assert Path(cache_path, DEFAULT_COMPLETE_MARKER).exists()
+
+
 @pytest.mark.parametrize(
     "path",
     [

--- a/lib/levanter/tests/test_model_cache.py
+++ b/lib/levanter/tests/test_model_cache.py
@@ -124,9 +124,14 @@ def test_cache_hf_model_resumes_partial_snapshot(tmp_path, monkeypatch):
     repo_files = ["config.json", "model.safetensors", "tokenizer.json"]
     downloaded: list[str] = []
 
-    monkeypatch.setattr(model_cache, "list_repo_files", lambda model_id, revision=None: repo_files)
+    def fake_list_repo_files(model_id, revision=None):
+        del model_id, revision
+        return repo_files
+
+    monkeypatch.setattr(model_cache, "list_repo_files", fake_list_repo_files)
 
     def fake_hf_hub_download(model_id, filename, revision=None, local_dir=None):
+        del model_id, revision
         downloaded.append(filename)
         local_path = Path(local_dir, filename)
         local_path.write_text(f"contents of {filename}")

--- a/tests/experiment/test_collect_hero_run_4_code_glm52.py
+++ b/tests/experiment/test_collect_hero_run_4_code_glm52.py
@@ -8,6 +8,7 @@ import json
 import pyarrow as pa
 import pyarrow.parquet as pq
 import requests
+from rigging.filesystem import StoragePath
 
 from experiments.rollout_data import collect_hero_run_4_code_glm52 as collect
 
@@ -72,7 +73,7 @@ def test_run_collection_writes_chunks_and_resumes(tmp_path, monkeypatch):
         )
 
     monkeypatch.setattr(requests, "post", post)
-    output_path = str(tmp_path / "output")
+    output_path = StoragePath(str(tmp_path / "output"))
     collection = collect.CollectionConfig("test", output_path, 0, 1, None, 2, 2)
     server = collect.ServerConfig(65536, 12)
     sampling = collect.SamplingConfig(1.0, 0.95, 16384)

--- a/tests/experiment/test_collect_hero_run_4_code_glm52.py
+++ b/tests/experiment/test_collect_hero_run_4_code_glm52.py
@@ -1,0 +1,94 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import gzip
+import itertools
+import json
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import requests
+
+from experiments.rollout_data import collect_hero_run_4_code_glm52 as collect
+
+
+def _response(payload):
+    response = requests.Response()
+    response.status_code = 200
+    response._content = json.dumps(payload).encode()
+    return response
+
+
+def test_partition_specs_cover_every_dataset_row_once():
+    partitions = collect.partition_specs()
+
+    assert len(partitions) == 1000
+    assert partitions[0].row_start == 0
+    assert partitions[-1].row_start + partitions[-1].num_rows == 959216
+    assert all(
+        previous.row_start + previous.num_rows == current.row_start
+        for previous, current in itertools.pairwise(partitions)
+    )
+    shards = [collect.partition_slices(partitions, shard, 85, None) for shard in range(85)]
+    assert {item.partition.ordinal for shard in shards for item in shard} == set(range(1000))
+    assert sum(item.num_rows for shard in shards for item in shard) == 959216
+
+
+def test_run_collection_writes_chunks_and_resumes(tmp_path, monkeypatch):
+    table = pa.table(
+        {
+            "id": ["a", "b", "c", "d", "e"],
+            "instruction_seed": ["one", "two", "three", "four", "five"],
+            "__original_row_idx": [0, 1, 2, 3, 4],
+        }
+    )
+    parquet_path = tmp_path / "input.parquet"
+    pq.write_table(table, parquet_path, row_group_size=3)
+    partitions = [
+        collect.PartitionSpec(0, 0, 0, 0, 3),
+        collect.PartitionSpec(1, 0, 1, 3, 2),
+    ]
+    monkeypatch.setattr(collect, "partition_specs", lambda: partitions)
+    monkeypatch.setattr(collect.PartitionSpec, "url", property(lambda _self: str(parquet_path)))
+    calls = []
+
+    def post(_url, **kwargs):
+        calls.append(kwargs["json"])
+        return _response(
+            {
+                "id": f"response-{len(calls)}",
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": f"answer-{len(calls)}",
+                            "reasoning_content": "reasoning",
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 2},
+            }
+        )
+
+    monkeypatch.setattr(requests, "post", post)
+    output_path = str(tmp_path / "output")
+    collection = collect.CollectionConfig("test", output_path, 0, 1, None, 2, 2)
+    server = collect.ServerConfig(65536, 12)
+    sampling = collect.SamplingConfig(1.0, 0.95, 16384)
+
+    collect._run_collection("http://vllm", collection, server, sampling)
+    parquet_path.unlink()
+    collect._run_collection("http://vllm", collection, server, sampling)
+
+    assert len(calls) == 5
+    chunks = sorted((tmp_path / "output" / "responses").rglob("*.jsonl.gz"))
+    assert len(chunks) == 3
+    with gzip.open(chunks[0], "rt") as handle:
+        first_chunk = [json.loads(line) for line in handle]
+    assert [record["instruction_seed"] for record in first_chunk] == ["one", "two"]
+    assert all(record["response"]["reasoning_content"] == "reasoning" for record in first_chunk)
+    progress = json.loads((tmp_path / "output" / "progress" / "shard-000.json").read_text())
+    assert progress["state"] == "complete"
+    assert progress["complete_records"] == 5
+    assert progress["skipped_records_this_attempt"] == 5


### PR DESCRIPTION
Add a resumable GLM-5.2 collector for every `instruction_seed` prompt in
`mlfoundations-dev/hero_run_4_code`.

The collector pins the model and dataset revisions, assigns Parquet row groups
deterministically, stores immutable compressed response chunks, and records
per-shard progress. GLM-5.2 runs as an eight-GPU Ray/vLLM instance across two
same-NVLink-domain GB200 nodes with expert parallelism. A separate model-cache
preparation command prevents each replica from downloading the weights from
Hugging Face.

The implementation and run design are tracked in #7697.

Part of #7697
