### PR TITLE
[iris] Add an NCCL RAS diagnostic client

### DIFF
--- a/.agents/projects/distributed_training_diagnostics/design.md
+++ b/.agents/projects/distributed_training_diagnostics/design.md
@@ -1,0 +1,91 @@
+# Distributed training diagnostics
+
+_Capture a stalled distributed job before recovery removes the evidence._
+
+NCCL RAS, thread stacks, GPU telemetry, and runtime versions should be available through one authenticated Iris command and persist in finelog. Grafana should warn when a running training job stops completing steps while its GPUs remain active. The alert opens an operator workflow; it does not restart the job.
+
+[Research](research.md) records the current NEST-BURN-001 incident, repository paths, and the NCCL protocol details.
+
+## Challenges
+
+A collective hang looks healthy to most liveness checks. The Python process, Telltale server, CUDA kernels, Kubernetes pod, and NCCL RAS control threads can all remain responsive while the training step never returns. GPU utilization can stay at 100%; low power makes a collective wait plausible but does not prove it.
+
+The useful evidence spans process and control-plane boundaries. NCCL RAS is a localhost service inside the task namespace. Thread captures require ptrace safety. GPU power comes from node-level DCGM. Training progress comes from a process-local tracker forwarded to finelog. The capture must survive the pod, while passive monitoring must not add a query fan-out from every rank.
+
+## Costs / Risks
+
+- A distributed capture adds one profile type across the Iris proto, RPC-worker, Kubernetes, CLI, dashboard, and finelog paths.
+- Thread dumping briefly attaches to the target. The existing Iris watchdog and `SIGCONT` recovery remain mandatory.
+- Stall thresholds can flag long compilation, evaluation, or checkpoint work. The first rule is warning-only and uses explicit phase metrics plus conservative grace periods.
+- `NCCL_DEBUG=INFO` adds log volume. Normal jobs exclude `COLL`, `CALL`, and `TRACE`.
+
+## Design
+
+### Live and durable capture
+
+Extend `ProfileTask` with `DistributedProfile`. `iris process profile distributed -t <task-or-job>` dispatches through the same authenticated controller path as CPU, memory, and thread profiles. A job target fans out with bounded concurrency; a task target captures one pod.
+
+Each capture writes an `iris.profile` row with `type="distributed"`, `format="json"`, and the existing seven-day retention. The JSON envelope contains:
+
+- NCCL RAS `VERBOSE STATUS`, requested as JSON and preserved as text on NCCL before 2.28.7;
+- per-communicator collective-count differences, with the lagging ranks named;
+- a py-spy thread dump using the existing attach watchdog;
+- `nvidia-smi` identity, utilization, memory, power, power limit, and active process rows;
+- `/proc/1/task/*/wchan`, selected `NCCL_*` variables, `XLA_FLAGS`, CUDA/JAX/NCCL versions, hostname, and capture errors.
+
+Every collector has a five-second timeout except the existing 30-second thread-dump watchdog. Individual collector failures become structured errors in the envelope; they do not discard successful evidence. The full uncompressed payload is capped at 4 MiB.
+
+The NCCL RAS client lives at `lib/iris/src/iris/cluster/runtime/nccl_ras.py`. It uses the documented localhost text protocol, requests `SET FORMAT json`, strips command acknowledgements, and falls back to text. It does not poll in the background.
+
+Rigging Telltale gets no generic diagnostic-hook registry. Its routes are public by contract and mounted by services other than training. Iris already owns authorization, dispatch, timeouts, and persistence for on-demand captures.
+
+### Passive progress and power signals
+
+Levanter Telltale adds two gauges:
+
+- `levanter_progress_time_seconds`: wall-clock time of the last completed training step;
+- `levanter_phase`: `0=initializing`, `1=training`, `2=evaluation`, `3=checkpointing`, `4=finished`.
+
+The tracker updates both outside the compiled step. Telltale continues forwarding every 15 seconds, so finelog freshness proves the auxiliary process thread is alive while `progress_time` distinguishes repeated scrapes from new training progress.
+
+CoreWeave DCGM collection adds aggregate `gpu_power_limit_w` to `iris.worker`. The existing `worker_id` on Telltale rows associates each process with its node row. The Grafana bridge runs one fixed, bounded finelog query over fresh `telltale`, `iris.worker`, and `iris.task_state` rows and exposes `/finelog/marin/alerts/training_stalls`.
+
+A warning candidate requires:
+
+- no progress for 15 minutes in `training`, or 45 minutes in `initializing`;
+- a fresh Telltale sample within 90 seconds;
+- at least 75% of the run’s GPU nodes at mean utilization of 90% or more over five minutes;
+- a fresh `RUNNING` job-state row.
+
+Evaluation and checkpoint phases use configurable 60-minute thresholds initially. The bridge emits `classification="collective_like"` when median power divided by power limit is below 0.35. Grafana evaluates every minute and fires after five minutes. The alert links the job, training dashboard, `iris process profile distributed` command, and the collective-hang runbook. Severity remains `warning`; the Loom operator captures evidence and decides whether to kick the gang.
+
+### Runtime flags and post-mortem logs
+
+Multi-host launch helpers set:
+
+```text
+NCCL_RAS_ENABLE=1
+NCCL_DEBUG=INFO
+NCCL_DEBUG_SUBSYS=INIT,BOOTSTRAP,ENV,NET,GRAPH,TUNING,RAS
+NCCL_DEBUG_FILE=/dev/stderr
+```
+
+Iris log shipping makes stderr durable. Short reproduction jobs may add `COLL,PROXY,NVLS,REG`. `TRACE` and `CALL` stay opt-in. Launch metadata records CUDA, JAX, and NCCL versions so matched arms cannot silently resolve different communication stacks.
+
+Grafana remains read-only. It does not call `ProfileTask`, kick tasks, or hold an Iris mutation credential. Automatic recovery is out of scope.
+
+## Testing
+
+The NCCL client tests its socket wire request, acknowledgement-prefixed JSON, text fallback, and collective-count skew analysis against a local fake service.
+
+The ProfileTask slice uses existing fake backends to assert that a successful distributed capture returns the JSON bytes and persists the same bytes to `iris.profile`; a partial collector failure still persists the other sections. A Kubernetes runtime test executes the bundle in a non-GPU pod and records explicit `unavailable` results without failing the task.
+
+Levanter tracker tests use a fake clock to verify phase transitions and progress time. DCGM parser tests cover summed power limits. Grafana bridge tests use fixed Arrow tables for a progressing run, a high-utilization stall, stale Telltale, initialization grace, evaluation suppression, and missing power limits. Alert provisioning tests validate the warning rule and its no-data posture.
+
+Rollout starts on one batch-priority multi-host smoke. Operators compare capture latency, payload size, and finelog query cost. The alert runs dashboard-only for one week before Slack/Loom notification is enabled.
+
+## Open Questions
+
+- Should a job-wide capture store one global RAS report plus per-task process sections, or accept duplicate RAS payloads in each task row for simpler provenance?
+- Are 15 minutes for training and 45 minutes for initialization conservative enough for the largest JAX compilations and Paloma evaluation windows?
+- Should a future Iris recovery command require an explicit `--skip-diagnostics` when a responsive GPU gang is kicked, or keep capture as a runbook convention?

--- a/.agents/projects/distributed_training_diagnostics/research.md
+++ b/.agents/projects/distributed_training_diagnostics/research.md
@@ -1,0 +1,97 @@
+# Distributed training diagnostics: research
+
+## Background Research Brief
+
+- Effort: medium
+- Stop rule: stop when another source no longer changes the placement of live capture, durable storage, or alert evaluation.
+- Date: 2026-07-28
+
+### Question
+
+Where should Marin expose on-demand NCCL RAS, thread, and GPU diagnostics, and how should it detect a training process that is alive but no longer completing steps?
+
+### Current Marin context
+
+The NEST-BURN-001 E256 run stopped producing training progress while every rank remained inside the same compiled JAX call. All 32 GPUs reported 100% utilization at roughly 190–230 W against a 1200 W cap. NCCL RAS reported every rank alive and every communicator `RUNNING` with no asynchronous error. Python thread dumps and NCCL RAS were available only through one-off `iris process profile` and `iris task exec` calls. The evidence would have disappeared with the pods if the operator had restarted the gang first.
+
+Telltale already separates passive instrumentation from serving. The registry is scraped every 15 seconds on a daemon thread and forwarded to finelog ([`telltale.py:291-330`](https://github.com/marin-community/marin/blob/1509b637aab6b7109cb0cfaa5a04ff211e4c18a8/lib/rigging/src/rigging/telltale.py#L291-L330)). Levanter publishes `levanter_step`, training scalars, and a human-readable status from tracker callbacks ([`tracker/telltale.py:117-153`](https://github.com/marin-community/marin/blob/1509b637aab6b7109cb0cfaa5a04ff211e4c18a8/lib/levanter/src/levanter/tracker/telltale.py#L117-L153)). The training Grafana dashboard already plots loss, throughput, and step from the forwarded `telltale` namespace ([`training.json:31-243`](https://github.com/marin-community/marin/blob/1509b637aab6b7109cb0cfaa5a04ff211e4c18a8/infra/grafana/dashboards/training.json#L31-L243)).
+
+Iris already has the authenticated control path needed for live captures. `ProfileTask` dispatches through the controller to RPC workers or Kubernetes, and successful captures become `iris.profile` rows. The shared capture code has bounded py-spy and memray watchdogs ([`runtime/profile.py:163-205`](https://github.com/marin-community/marin/blob/1509b637aab6b7109cb0cfaa5a04ff211e4c18a8/lib/iris/src/iris/cluster/runtime/profile.py#L163-L205)); `IrisProfile` stores source, attempt, capture time, format, trigger, and payload ([`stats/tables.py:213-261`](https://github.com/marin-community/marin/blob/1509b637aab6b7109cb0cfaa5a04ff211e4c18a8/lib/iris/src/iris/cluster/stats/tables.py#L213-L261)).
+
+CoreWeave controllers already write node-level DCGM utilization and aggregate power to `iris.worker` ([`stats/tables.py:97-142`](https://github.com/marin-community/marin/blob/1509b637aab6b7109cb0cfaa5a04ff211e4c18a8/lib/iris/src/iris/cluster/stats/tables.py#L97-L142)). The missing field is the power limit needed to compare hardware classes by a ratio instead of a model-specific watt threshold.
+
+### Internal prior work
+
+The `iris_profile_to_finelog` design established the capture path this proposal extends. It moved periodic and on-demand CPU, memory, and thread profiles into `iris.profile`, kept the controller RPC as the authorization and routing boundary, and set seven-day retention. A distributed diagnostic is another capture format, not a second profiling service.
+
+The Grafana bridge already exposes fixed alert projections and leaves arbitrary finelog SQL to dashboards. Provisioned alert rules expect a string-label table with exactly one numeric `value`, return explicit zero rows when healthy, and page on query failure ([`rules.yaml:4-16`](https://github.com/marin-community/marin/blob/1509b637aab6b7109cb0cfaa5a04ff211e4c18a8/infra/grafana/provisioning/alerting/rules.yaml#L4-L16)). A training-stall projection belongs there.
+
+### External prior art
+
+NCCL RAS is enabled by default from NCCL 2.24 and listens on localhost port 28028. `VERBOSE STATUS` gathers a global communicator view through a text protocol. NCCL 2.28.7 added JSON output via `SET FORMAT json`; the JSON includes per-rank initialization state, async error state, missing ranks, and per-collective completed-call counters. NCCL 2.29 added a streaming monitor mode. Source: [NVIDIA NCCL RAS documentation](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/troubleshooting/ras.html).
+
+NVIDIA documents `NCCL_DEBUG=INFO` as diagnostic logging and `TRACE` as replayable per-call logging. `NCCL_DEBUG_SUBSYS` can select initialization, network, graph, tuning, RAS, collective, proxy, NVLink SHARP, and other subsystems. `NCCL_DEBUG_FILE=/dev/stderr` is line-buffered; a `%h.%p` file must be unique and otherwise overwrites earlier output. Source: [NVIDIA NCCL environment-variable documentation](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html).
+
+### Decision
+
+Do not add a generic web-hook registry to Rigging Telltale.
+
+Telltale’s routes are intentionally `@public` and are mounted by actor and task services ([`telltale.py:401-455`](https://github.com/marin-community/marin/blob/1509b637aab6b7109cb0cfaa5a04ff211e4c18a8/lib/rigging/src/rigging/telltale.py#L401-L455)). The training runtime binds them to `0.0.0.0` and registers the endpoint with Iris ([`runtime/telltale.py:79-130`](https://github.com/marin-community/marin/blob/1509b637aab6b7109cb0cfaa5a04ff211e4c18a8/lib/iris/src/iris/runtime/telltale.py#L79-L130)). A generic callback would need its own authorization semantics, timeout enforcement, response-size cap, and process-lifetime policy. It would also execute arbitrary application code on an HTTP request thread inside a training process.
+
+Extend `ProfileTask` with an explicit distributed diagnostic type. It already supplies authenticated access, worker/Kubernetes dispatch, timeouts, finelog persistence, and a CLI. The task process needs no new inbound route. The NCCL query is a bounded localhost socket read from the container namespace.
+
+Keep alerts passive. Telltale and DCGM feed finelog; the Grafana bridge evaluates a fixed stall projection; Grafana sends a warning to Slack and Loom. The operator or Loom session captures a diagnostic bundle before kicking the gang. Grafana does not receive an Iris mutation credential.
+
+### Alert hypothesis
+
+A job is stalled when all of these hold:
+
+- `levanter_step` has not advanced for 15 minutes after at least one completed step, or it remains zero for 45 minutes after the first fresh Telltale sample.
+- Telltale samples remain fresh within 90 seconds. This distinguishes a blocked training call from a dead exporter or lost finelog path.
+- At least 75% of the job’s GPU nodes report mean utilization of 90% or more over the last five minutes.
+- The job is still `RUNNING` in fresh `iris.task_state`.
+
+The alert labels the stall `collective_like` when median `gpu_power_w / gpu_power_limit_w` is below 0.35. Low power is classification evidence, not an alert gate: input stalls and long compilations can consume little power without running a collective.
+
+The 15-minute threshold is intentionally conservative. Levanter should publish a numeric phase (`initializing`, `training`, `evaluation`, `checkpointing`, `finished`) so the projection can use phase-specific thresholds and suppress expected long evaluation or checkpoint windows. Until that phase exists, the rule should remain a warning and require five consecutive one-minute evaluations.
+
+### Runtime logging policy
+
+Normal multi-host jobs:
+
+```text
+NCCL_RAS_ENABLE=1
+NCCL_DEBUG=INFO
+NCCL_DEBUG_SUBSYS=INIT,BOOTSTRAP,ENV,NET,GRAPH,TUNING,RAS
+NCCL_DEBUG_FILE=/dev/stderr
+```
+
+`/dev/stderr` lets Iris log shipping preserve initialization and transport evidence before pod loss. Do not write normal-run diagnostics only to `/tmp`: files disappear on pod deletion, and `%h.%p` files require a separate collector.
+
+Short reproduction jobs may add `COLL,PROXY,NVLS,REG`. `NCCL_DEBUG=TRACE` and `CALL` remain opt-in because they emit per-call data. All matched experiment arms must pin the same CUDA and NCCL builds; the current E256 and fixed25 retries loaded NCCL 2.28.9 against different CUDA minor builds, which weakens runtime comparisons even though communicators never span arms.
+
+### Negative / failed leads
+
+- A Telltale hook registry saves one RPC extension but creates a public, in-process execution surface and has no durable payload contract.
+- Polling NCCL RAS from every process every 15 seconds is redundant: one response already gathers global communicator state, and a troubled communicator can take several seconds to report.
+- GPU utilization alone cannot identify a collective. CUDA busy-poll kernels and real matmuls both report high utilization.
+- Power alone cannot be compared across B200, GB200, H100, and TPU jobs. The metric needs a device power limit or a model-specific normalization.
+- A Grafana alert that directly kicks a job destroys the evidence it is supposed to preserve and gives the monitoring bridge a mutation credential.
+
+### Source ledger
+
+| Source | Type | Claim used for | Confidence |
+|---|---|---|---|
+| `lib/rigging/src/rigging/telltale.py` | Marin code | Telltale route posture and forward loop | high |
+| `lib/iris/src/iris/cluster/runtime/profile.py` | Marin code | bounded capture and durable profile path | high |
+| `lib/levanter/src/levanter/tracker/telltale.py` | Marin code | current step and metric signals | high |
+| `lib/iris/src/iris/cluster/stats/tables.py` | Marin code | existing GPU utilization/power and profile schemas | high |
+| `infra/grafana/*` | Marin code | fixed alert projections and warning policy | high |
+| NVIDIA NCCL RAS docs | official docs | RAS protocol, JSON counters, versions | high |
+| NVIDIA NCCL env docs | official docs | debug levels, subsystems, file behavior | high |
+
+### Handoff
+
+- Implemented foundation: `lib/iris/src/iris/cluster/runtime/nccl_ras.py` queries JSON with a text fallback and reports per-communicator collective-count skew.
+- Next implementation slice: add `DistributedProfile` to `ProfileTask`, bundle RAS/thread/GPU/process evidence, and write one `iris.profile` JSON row per task.
+- Alert slice: add Levanter phase/progress metrics, DCGM power-limit collection, a fixed `/finelog/marin/alerts/training_stalls` projection, a warning rule, and a training-dashboard table.

--- a/.agents/projects/distributed_training_diagnostics/spec.md
+++ b/.agents/projects/distributed_training_diagnostics/spec.md
@@ -1,0 +1,307 @@
+# Distributed training diagnostics: contract
+
+## 1. NCCL RAS client
+
+Location: `lib/iris/src/iris/cluster/runtime/nccl_ras.py`.
+
+```python
+class NcclRasFormat(StrEnum):
+    JSON = "json"
+    TEXT = "text"
+
+
+class NcclRasFormatError(ValueError):
+    """The RAS service did not return the requested machine-readable payload."""
+
+
+@dataclass(frozen=True)
+class CollectiveCountSkew:
+    communicator_hash: str
+    collective: str
+    minimum: int
+    maximum: int
+    lagging_ranks: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class NcclRasSnapshot:
+    captured_at: str
+    response_format: NcclRasFormat
+    raw_response: str
+    report: dict[str, Any] | None
+
+    def record(self) -> dict[str, Any]:
+        """Return a JSON-serializable capture envelope."""
+
+
+def query_nccl_ras(
+    *,
+    host: str,
+    port: int,
+    timeout: float,
+    response_format: NcclRasFormat,
+) -> bytes:
+    """Send TIMEOUT, SET FORMAT, and VERBOSE STATUS; return the raw response."""
+
+
+def parse_json_response(response: bytes) -> dict[str, Any]:
+    """Parse a JSON object after zero or more text command acknowledgements."""
+
+
+def capture_nccl_ras(
+    *,
+    host: str = "localhost",
+    port: int = 28028,
+    timeout: float = 5.0,
+) -> NcclRasSnapshot:
+    """Request JSON once and retry with text only when JSON parsing is unavailable."""
+
+
+def collective_count_skews(report: Mapping[str, Any]) -> list[CollectiveCountSkew]:
+    """Return count differences; an empty result does not assert job health."""
+```
+
+Network errors and timeouts propagate. Invalid vendor JSON raises `NcclRasFormatError` from `parse_json_response`; `capture_nccl_ras` converts only that error into a text retry. `raw_response` is always preserved.
+
+## 2. Iris profile RPC
+
+Location: `lib/iris/src/iris/rpc/job.proto`.
+
+```proto
+message DistributedProfile {
+  bool include_threads = 1;
+  bool include_process_waits = 2;
+  bool include_gpu = 3;
+  bool include_environment = 4;
+  int32 collector_timeout_seconds = 5;
+}
+
+message ProfileType {
+  oneof profiler {
+    CpuProfile cpu = 1;
+    MemoryProfile memory = 2;
+    ThreadsProfile threads = 3;
+    DistributedProfile distributed = 4;
+  }
+}
+```
+
+`collector_timeout_seconds` must be between 1 and 30; zero resolves to five. The CLI sets every `include_*` field to true. The thread collector keeps its existing 30-second ptrace watchdog even when the other collector timeout is lower.
+
+`ProfileTaskResponse.profile_data` is the exact UTF-8 JSON written to `iris.profile`. A target without NCCL or GPUs succeeds with structured `unavailable` sections. Failure to enter the task namespace, failure to identify the process, or a payload above 4 MiB returns `ProfileTaskResponse.error` and writes no row.
+
+## 3. Capture envelope
+
+Schema version 1:
+
+```json
+{
+  "schema_version": 1,
+  "captured_at": "2026-07-28T01:10:00.000000",
+  "source": "/power/job/task/0",
+  "attempt_id": 1,
+  "hostname": "pod-or-node",
+  "runtime": {
+    "pid": 1,
+    "cuda_driver_version": "13.2",
+    "cuda_runtime_version": "13.0",
+    "jax_version": "0.x",
+    "nccl_packages": ["nvidia-nccl-cu13==2.28.9"]
+  },
+  "nccl_ras": {
+    "status": "ok",
+    "response_format": "json",
+    "raw_response": "OK\nOK\n{...}",
+    "report": {},
+    "collective_count_skews": []
+  },
+  "threads": {
+    "status": "ok",
+    "format": "py-spy",
+    "text": "..."
+  },
+  "process_waits": {
+    "status": "ok",
+    "threads": [{"tid": 1, "name": "python", "wchan": "futex_wait_queue"}]
+  },
+  "gpu": {
+    "status": "ok",
+    "devices": [
+      {
+        "index": 0,
+        "uuid": "GPU-...",
+        "utilization_pct": 100.0,
+        "memory_used_bytes": 157000000000,
+        "power_w": 205.0,
+        "power_limit_w": 1200.0
+      }
+    ]
+  },
+  "environment": {
+    "NCCL_DEBUG": "INFO",
+    "NCCL_DEBUG_SUBSYS": "INIT,BOOTSTRAP,ENV,NET,GRAPH,TUNING,RAS",
+    "NCCL_RAS_ENABLE": "1",
+    "XLA_FLAGS": "..."
+  },
+  "errors": []
+}
+```
+
+Each collector section has `status` equal to `ok`, `unavailable`, `timeout`, or `error`. Errors include collector name, stable error class, and a message capped at 2 KiB. Environment capture allows only keys prefixed `NCCL_` plus `XLA_FLAGS`; it never serializes credentials or the full process environment.
+
+## 4. Finelog profile shape
+
+Location: `lib/iris/src/iris/cluster/stats/tables.py`.
+
+Add:
+
+```python
+class ProfileType(StrEnum):
+    CPU = "cpu"
+    MEMORY = "memory"
+    THREAD = "thread"
+    DISTRIBUTED = "distributed"
+
+
+class ProfileFormat(StrEnum):
+    # existing values...
+    JSON = "json"
+```
+
+The existing `IrisProfile` row is unchanged. A distributed capture sets:
+
+- `type="distributed"`
+- `format="json"`
+- `trigger="on_demand"`
+- `duration_seconds=0`
+- CPU/memory/thread-specific nullable columns to `None`
+- `profile_data` to the capture envelope bytes.
+
+Seven-day `iris.profile` retention remains unchanged.
+
+## 5. CLI
+
+Location: `lib/iris/src/iris/cli/process_status.py`.
+
+```text
+iris process profile distributed \
+  --target <task-id-or-job-id> \
+  [--output <path>] \
+  [--collector-timeout 5]
+```
+
+A task target writes one envelope. A job target lists the current running tasks and captures them with concurrency 16. The command exits nonzero when no task produced a capture. Partial task failures are printed beside successful output paths and produce a nonzero exit.
+
+## 6. Progress metrics
+
+Location: `lib/levanter/src/levanter/tracker/telltale.py`.
+
+```python
+class TrainingPhase(IntEnum):
+    INITIALIZING = 0
+    TRAINING = 1
+    EVALUATION = 2
+    CHECKPOINTING = 3
+    FINISHED = 4
+
+
+def set_training_phase(phase: TrainingPhase) -> None:
+    """Publish the current phase to the process-global Telltale registry."""
+```
+
+Metrics:
+
+- `levanter_progress_time_seconds`: Unix seconds, set after each completed training step.
+- `levanter_phase`: one `TrainingPhase` numeric value.
+
+`TelltaleTracker.__init__` initializes the phase to `INITIALIZING` and progress time to zero. The training loop sets `TRAINING` before dispatch, updates progress time after a returned step, brackets evaluation/checkpoint work with their phases, and sets `FINISHED` at clean shutdown.
+
+## 7. GPU power normalization
+
+Location: `lib/iris/src/iris/cluster/stats/tables.py`.
+
+Add `gpu_power_limit_w: float | None = None` to `IrisWorkerStat`. `parse_dcgm` reads `DCGM_FI_DEV_ENFORCED_POWER_LIMIT`, sums it per node, and leaves the field `None` when DCGM does not expose it.
+
+## 8. Grafana bridge alert projection
+
+Location: `infra/grafana/src/server.py`.
+
+```python
+@dataclass(frozen=True)
+class TrainingStall:
+    cluster: str
+    job_id: str
+    run: str
+    phase: str
+    last_step: int
+    stalled_seconds: int
+    reporting_nodes: int
+    high_utilization_nodes: int
+    median_gpu_util_pct: float | None
+    median_power_ratio: float | None
+    classification: str
+    value: int
+
+
+def training_stall_rows(source: MetricSource, now: datetime) -> list[TrainingStall]:
+    """Project fresh finelog progress, job state, utilization, and power into alerts."""
+```
+
+Route: `GET /finelog/marin/alerts/training_stalls`.
+
+The route always returns at least one row. With no candidates it returns:
+
+```json
+{
+  "cluster": "all",
+  "job_id": "",
+  "run": "",
+  "phase": "",
+  "last_step": 0,
+  "stalled_seconds": 0,
+  "reporting_nodes": 0,
+  "high_utilization_nodes": 0,
+  "median_gpu_util_pct": null,
+  "median_power_ratio": null,
+  "classification": "healthy",
+  "value": 0
+}
+```
+
+Candidate thresholds:
+
+- `training`: 900 seconds without progress
+- `initializing`: 2700 seconds since first fresh Telltale sample
+- `evaluation` and `checkpointing`: 3600 seconds
+- Telltale freshness: 90 seconds
+- job-state freshness: 90 seconds and state `RUNNING`
+- GPU window: 300 seconds
+- high-utilization node: mean `gpu_util_pct >= 90`
+- required high-utilization fraction: `>= 0.75`
+- `collective_like`: median power ratio `< 0.35`; otherwise `generic_stall`.
+
+Location: `infra/grafana/provisioning/alerting/rules.yaml`.
+
+Add warning rule `TrainingProgressStalled`, evaluated every minute with `for: 5m`, `noDataState: Alerting`, and `execErrState: Alerting`. It fires when `value > 0` and routes to Slack and Loom through the existing warning policy. Grafana receives no Iris write credential.
+
+## 9. Runtime environment
+
+Normal multi-host training jobs explicitly set:
+
+```text
+NCCL_RAS_ENABLE=1
+NCCL_DEBUG=INFO
+NCCL_DEBUG_SUBSYS=INIT,BOOTSTRAP,ENV,NET,GRAPH,TUNING,RAS
+NCCL_DEBUG_FILE=/dev/stderr
+```
+
+Launch helpers record the resolved CUDA runtime, driver, JAX, and NCCL package versions as W&B config and Telltale labels. Debug reproduction jobs may add `COLL,PROXY,NVLS,REG`; no checked-in production config sets `NCCL_DEBUG=TRACE` or adds `CALL`.
+
+## 10. Out of scope
+
+- Automatic task kick, cluster restart, or job termination.
+- Grafana calling an Iris mutation RPC.
+- Periodic NCCL RAS polling from every process.
+- A generic Telltale HTTP callback registry.
+- Parsing NCCL text output into stable fields.
+- Supporting GPU collectives outside NCCL in the first version.

--- a/lib/iris/src/iris/cluster/runtime/nccl_ras.py
+++ b/lib/iris/src/iris/cluster/runtime/nccl_ras.py
@@ -80,12 +80,7 @@ def query_nccl_ras(
         connection.shutdown(socket.SHUT_WR)
         while not deadline.expired():
             connection.settimeout(deadline.remaining_seconds())
-            try:
-                chunk = connection.recv(_READ_SIZE)
-            except TimeoutError:
-                if chunks:
-                    break
-                raise
+            chunk = connection.recv(_READ_SIZE)
             if not chunk:
                 break
             chunks.append(chunk)

--- a/lib/iris/src/iris/cluster/runtime/nccl_ras.py
+++ b/lib/iris/src/iris/cluster/runtime/nccl_ras.py
@@ -1,0 +1,212 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Query NCCL's process-local RAS service and analyze collective counters."""
+
+import argparse
+import json
+import math
+import socket
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from typing import Any
+
+from rigging.timing import Deadline, Timestamp
+
+DEFAULT_NCCL_RAS_HOST = "localhost"
+DEFAULT_NCCL_RAS_PORT = 28028
+DEFAULT_NCCL_RAS_TIMEOUT = 5.0
+_READ_SIZE = 64 * 1024
+
+
+class NcclRasFormat(StrEnum):
+    JSON = "json"
+    TEXT = "text"
+
+
+class NcclRasFormatError(ValueError):
+    """The RAS service did not return the requested machine-readable payload."""
+
+
+@dataclass(frozen=True)
+class CollectiveCountSkew:
+    """One collective whose completed-call count differs across communicator ranks."""
+
+    communicator_hash: str
+    collective: str
+    minimum: int
+    maximum: int
+    lagging_ranks: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class NcclRasSnapshot:
+    """One live RAS response, preserving the vendor payload for post-mortem use."""
+
+    captured_at: str
+    response_format: NcclRasFormat
+    raw_response: str
+    report: dict[str, Any] | None
+
+    def record(self) -> dict[str, Any]:
+        """Return a JSON-serializable capture envelope."""
+        return {
+            "captured_at": self.captured_at,
+            "response_format": self.response_format.value,
+            "raw_response": self.raw_response,
+            "report": self.report,
+            "collective_count_skews": [asdict(skew) for skew in collective_count_skews(self.report or {})],
+        }
+
+
+def query_nccl_ras(
+    *,
+    host: str,
+    port: int,
+    timeout: float,
+    response_format: NcclRasFormat,
+) -> bytes:
+    """Return one verbose NCCL RAS response over its documented text protocol."""
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
+
+    ras_timeout = max(1, math.ceil(timeout))
+    request = f"TIMEOUT {ras_timeout}\nSET FORMAT {response_format.value}\nVERBOSE STATUS\n".encode()
+    chunks: list[bytes] = []
+    deadline = Deadline.from_seconds(timeout)
+    with socket.create_connection((host, port), timeout=timeout) as connection:
+        connection.sendall(request)
+        connection.shutdown(socket.SHUT_WR)
+        while not deadline.expired():
+            connection.settimeout(deadline.remaining_seconds())
+            try:
+                chunk = connection.recv(_READ_SIZE)
+            except TimeoutError:
+                if chunks:
+                    break
+                raise
+            if not chunk:
+                break
+            chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def parse_json_response(response: bytes) -> dict[str, Any]:
+    """Extract the JSON object after any ``OK`` replies to preceding commands."""
+    text = response.decode("utf-8", "replace")
+    object_start = text.find("{")
+    if object_start < 0:
+        raise NcclRasFormatError("NCCL RAS response did not contain a JSON object")
+    try:
+        report = json.loads(text[object_start:])
+    except json.JSONDecodeError as exc:
+        raise NcclRasFormatError(f"NCCL RAS returned malformed JSON: {exc}") from exc
+    if not isinstance(report, dict):
+        raise NcclRasFormatError("NCCL RAS JSON response must be an object")
+    return report
+
+
+def capture_nccl_ras(
+    *,
+    host: str = DEFAULT_NCCL_RAS_HOST,
+    port: int = DEFAULT_NCCL_RAS_PORT,
+    timeout: float = DEFAULT_NCCL_RAS_TIMEOUT,
+) -> NcclRasSnapshot:
+    """Capture RAS JSON when supported, falling back to the human-readable report."""
+    response = query_nccl_ras(
+        host=host,
+        port=port,
+        timeout=timeout,
+        response_format=NcclRasFormat.JSON,
+    )
+    try:
+        report = parse_json_response(response)
+    except NcclRasFormatError:
+        response = query_nccl_ras(
+            host=host,
+            port=port,
+            timeout=timeout,
+            response_format=NcclRasFormat.TEXT,
+        )
+        return NcclRasSnapshot(
+            captured_at=Timestamp.now().as_naive_utc().isoformat(),
+            response_format=NcclRasFormat.TEXT,
+            raw_response=response.decode("utf-8", "replace"),
+            report=None,
+        )
+    return NcclRasSnapshot(
+        captured_at=Timestamp.now().as_naive_utc().isoformat(),
+        response_format=NcclRasFormat.JSON,
+        raw_response=response.decode("utf-8", "replace"),
+        report=report,
+    )
+
+
+def _int(value: object, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise NcclRasFormatError(f"NCCL RAS field {field!r} must be an integer")
+    return value
+
+
+def collective_count_skews(report: Mapping[str, Any]) -> list[CollectiveCountSkew]:
+    """Return per-communicator collective-count differences from a RAS JSON report.
+
+    A non-empty result is a localization clue, not a standalone hang verdict:
+    ranks can be transiently one call apart while the job is making progress.
+    """
+    communicators = report.get("communicators", [])
+    if not isinstance(communicators, list):
+        raise NcclRasFormatError("NCCL RAS field 'communicators' must be a list")
+
+    skews: list[CollectiveCountSkew] = []
+    for communicator in communicators:
+        if not isinstance(communicator, dict):
+            raise NcclRasFormatError("NCCL RAS communicator must be an object")
+        communicator_hash = str(communicator.get("hash", "unknown"))
+        ranks = communicator.get("ranks", [])
+        if not isinstance(ranks, list):
+            raise NcclRasFormatError("NCCL RAS communicator field 'ranks' must be a list")
+
+        counts_by_collective: dict[str, list[tuple[int, int]]] = {}
+        for rank_record in ranks:
+            if not isinstance(rank_record, dict):
+                raise NcclRasFormatError("NCCL RAS rank must be an object")
+            rank = _int(rank_record.get("rank"), "rank")
+            collective_counts = rank_record.get("collective_counts", {})
+            if not isinstance(collective_counts, dict):
+                raise NcclRasFormatError("NCCL RAS field 'collective_counts' must be an object")
+            for collective, raw_count in collective_counts.items():
+                count = _int(raw_count, f"collective_counts.{collective}")
+                counts_by_collective.setdefault(str(collective), []).append((rank, count))
+
+        for collective, rank_counts in counts_by_collective.items():
+            counts = [count for _, count in rank_counts]
+            minimum = min(counts)
+            maximum = max(counts)
+            if minimum == maximum:
+                continue
+            skews.append(
+                CollectiveCountSkew(
+                    communicator_hash=communicator_hash,
+                    collective=collective,
+                    minimum=minimum,
+                    maximum=maximum,
+                    lagging_ranks=tuple(rank for rank, count in rank_counts if count == minimum),
+                )
+            )
+    return skews
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Capture NCCL RAS status as a JSON envelope")
+    parser.add_argument("--host", default=DEFAULT_NCCL_RAS_HOST)
+    parser.add_argument("--port", type=int, default=DEFAULT_NCCL_RAS_PORT)
+    parser.add_argument("--timeout", type=float, default=DEFAULT_NCCL_RAS_TIMEOUT)
+    args = parser.parse_args()
+    snapshot = capture_nccl_ras(host=args.host, port=args.port, timeout=args.timeout)
+    print(json.dumps(snapshot.record(), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/iris/tests/cluster/runtime/test_nccl_ras.py
+++ b/lib/iris/tests/cluster/runtime/test_nccl_ras.py
@@ -5,6 +5,7 @@ import json
 import socket
 import threading
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 from iris.cluster.runtime.nccl_ras import (
     CollectiveCountSkew,
@@ -16,7 +17,14 @@ from iris.cluster.runtime.nccl_ras import (
 )
 
 
-def _serve_responses(responses: Sequence[bytes]) -> tuple[int, list[bytes], threading.Thread]:
+@dataclass(frozen=True)
+class RasTestServer:
+    port: int
+    requests: list[bytes]
+    thread: threading.Thread
+
+
+def _serve_responses(responses: Sequence[bytes]) -> RasTestServer:
     listener = socket.socket()
     listener.bind(("127.0.0.1", 0))
     listener.listen()
@@ -35,22 +43,22 @@ def _serve_responses(responses: Sequence[bytes]) -> tuple[int, list[bytes], thre
 
     thread = threading.Thread(target=serve)
     thread.start()
-    return listener.getsockname()[1], requests, thread
+    return RasTestServer(port=listener.getsockname()[1], requests=requests, thread=thread)
 
 
 def test_query_nccl_ras_sends_verbose_status_with_timeout_and_format() -> None:
-    port, requests, server = _serve_responses([b"OK\nstatus"])
+    server = _serve_responses([b"OK\nstatus"])
 
     response = query_nccl_ras(
         host="127.0.0.1",
-        port=port,
+        port=server.port,
         timeout=1.2,
         response_format=NcclRasFormat.JSON,
     )
-    server.join()
+    server.thread.join()
 
     assert response == b"OK\nstatus"
-    assert requests == [b"TIMEOUT 2\nSET FORMAT json\nVERBOSE STATUS\n"]
+    assert server.requests == [b"TIMEOUT 2\nSET FORMAT json\nVERBOSE STATUS\n"]
 
 
 def test_parse_json_response_skips_command_acknowledgements() -> None:
@@ -60,15 +68,15 @@ def test_parse_json_response_skips_command_acknowledgements() -> None:
 
 
 def test_capture_nccl_ras_falls_back_to_text_when_json_is_unavailable() -> None:
-    port, requests, server = _serve_responses([b"ERROR unknown format\n", b"OK\nJob summary\n"])
+    server = _serve_responses([b"ERROR unknown format\n", b"OK\nJob summary\n"])
 
-    snapshot = capture_nccl_ras(host="127.0.0.1", port=port, timeout=1)
-    server.join()
+    snapshot = capture_nccl_ras(host="127.0.0.1", port=server.port, timeout=1)
+    server.thread.join()
 
     assert snapshot.response_format is NcclRasFormat.TEXT
     assert snapshot.report is None
     assert snapshot.raw_response == "OK\nJob summary\n"
-    assert requests == [
+    assert server.requests == [
         b"TIMEOUT 1\nSET FORMAT json\nVERBOSE STATUS\n",
         b"TIMEOUT 1\nSET FORMAT text\nVERBOSE STATUS\n",
     ]

--- a/lib/iris/tests/cluster/runtime/test_nccl_ras.py
+++ b/lib/iris/tests/cluster/runtime/test_nccl_ras.py
@@ -1,0 +1,99 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import socket
+import threading
+from collections.abc import Sequence
+
+from iris.cluster.runtime.nccl_ras import (
+    CollectiveCountSkew,
+    NcclRasFormat,
+    capture_nccl_ras,
+    collective_count_skews,
+    parse_json_response,
+    query_nccl_ras,
+)
+
+
+def _serve_responses(responses: Sequence[bytes]) -> tuple[int, list[bytes], threading.Thread]:
+    listener = socket.socket()
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    requests: list[bytes] = []
+
+    def serve() -> None:
+        with listener:
+            for response in responses:
+                connection, _ = listener.accept()
+                with connection:
+                    request = b""
+                    while chunk := connection.recv(4096):
+                        request += chunk
+                    requests.append(request)
+                    connection.sendall(response)
+
+    thread = threading.Thread(target=serve)
+    thread.start()
+    return listener.getsockname()[1], requests, thread
+
+
+def test_query_nccl_ras_sends_verbose_status_with_timeout_and_format() -> None:
+    port, requests, server = _serve_responses([b"OK\nstatus"])
+
+    response = query_nccl_ras(
+        host="127.0.0.1",
+        port=port,
+        timeout=1.2,
+        response_format=NcclRasFormat.JSON,
+    )
+    server.join()
+
+    assert response == b"OK\nstatus"
+    assert requests == [b"TIMEOUT 2\nSET FORMAT json\nVERBOSE STATUS\n"]
+
+
+def test_parse_json_response_skips_command_acknowledgements() -> None:
+    report = {"nccl_version": "2.28.9", "communicators": []}
+
+    assert parse_json_response(b"OK\nOK\n" + json.dumps(report).encode()) == report
+
+
+def test_capture_nccl_ras_falls_back_to_text_when_json_is_unavailable() -> None:
+    port, requests, server = _serve_responses([b"ERROR unknown format\n", b"OK\nJob summary\n"])
+
+    snapshot = capture_nccl_ras(host="127.0.0.1", port=port, timeout=1)
+    server.join()
+
+    assert snapshot.response_format is NcclRasFormat.TEXT
+    assert snapshot.report is None
+    assert snapshot.raw_response == "OK\nJob summary\n"
+    assert requests == [
+        b"TIMEOUT 1\nSET FORMAT json\nVERBOSE STATUS\n",
+        b"TIMEOUT 1\nSET FORMAT text\nVERBOSE STATUS\n",
+    ]
+
+
+def test_collective_count_skews_names_lagging_ranks() -> None:
+    report = {
+        "communicators": [
+            {
+                "hash": "0xabc",
+                "ranks": [
+                    {"rank": 0, "collective_counts": {"AllReduce": 8, "AllGather": 3}},
+                    {"rank": 1, "collective_counts": {"AllReduce": 7, "AllGather": 3}},
+                    {"rank": 2, "collective_counts": {"AllReduce": 7, "AllGather": 3}},
+                ],
+            }
+        ]
+    }
+
+    assert collective_count_skews(report) == [
+        CollectiveCountSkew(
+            communicator_hash="0xabc",
+            collective="AllReduce",
+            minimum=7,
+            maximum=8,
+            lagging_ranks=(1, 2),
+        )
+    ]

--- a/lib/iris/tests/cluster/runtime/test_nccl_ras.py
+++ b/lib/iris/tests/cluster/runtime/test_nccl_ras.py
@@ -7,6 +7,7 @@ import threading
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+import pytest
 from iris.cluster.runtime.nccl_ras import (
     CollectiveCountSkew,
     NcclRasFormat,
@@ -22,6 +23,33 @@ class RasTestServer:
     port: int
     requests: list[bytes]
     thread: threading.Thread
+
+
+class PartialTimeoutConnection:
+    def __init__(self) -> None:
+        self.responses: list[bytes | BaseException] = [b"OK\n", TimeoutError()]
+        self.sent = b""
+
+    def __enter__(self) -> "PartialTimeoutConnection":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        pass
+
+    def sendall(self, request: bytes) -> None:
+        self.sent += request
+
+    def shutdown(self, _how: int) -> None:
+        pass
+
+    def settimeout(self, _timeout: float) -> None:
+        pass
+
+    def recv(self, _size: int) -> bytes:
+        response = self.responses.pop(0)
+        if isinstance(response, BaseException):
+            raise response
+        return response
 
 
 def _serve_responses(responses: Sequence[bytes]) -> RasTestServer:
@@ -59,6 +87,21 @@ def test_query_nccl_ras_sends_verbose_status_with_timeout_and_format() -> None:
 
     assert response == b"OK\nstatus"
     assert server.requests == [b"TIMEOUT 2\nSET FORMAT json\nVERBOSE STATUS\n"]
+
+
+def test_query_nccl_ras_propagates_timeout_after_partial_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    connection = PartialTimeoutConnection()
+    monkeypatch.setattr(socket, "create_connection", lambda *_args, **_kwargs: connection)
+
+    with pytest.raises(TimeoutError):
+        query_nccl_ras(
+            host="127.0.0.1",
+            port=28028,
+            timeout=1,
+            response_format=NcclRasFormat.JSON,
+        )
+
+    assert connection.sent == b"TIMEOUT 1\nSET FORMAT json\nVERBOSE STATUS\n"
 
 
 def test_parse_json_response_skips_command_acknowledgements() -> None:


### PR DESCRIPTION
Add a bounded client for NCCL's localhost RAS protocol. The client requests
verbose JSON status, preserves the raw vendor response, falls back to text for
older NCCL releases, and reports per-communicator collective-count skew.

This is the foundation for authenticated Iris distributed-profile capture
during a live collective hang. The design keeps capture dispatch and durable
storage in ProfileTask instead of adding a public in-process Telltale hook.
Profile RPC wiring and the Grafana stall alert remain follow-up work.

Part of #7694
