### PR TITLE
[grafana] Fix GitHub App auth so the nightly matrix renders

### DIFF
--- a/infra/grafana/src/config.py
+++ b/infra/grafana/src/config.py
@@ -28,6 +28,10 @@ FINELOG_SLOW_THRESHOLD_MS = 5_000
 GITHUB_API_BASE = "https://api.github.com"
 # The GitHub repository the ferry and build panels read.
 GITHUB_REPO = "marin-community/marin"
+# GitHub rejects any REST/GraphQL request without a User-Agent (403 "Request
+# forbidden by administrative rules"); the REST client and the App-auth flow both
+# stamp this one.
+GITHUB_USER_AGENT = "marin-grafana-bridge"
 
 
 @dataclasses.dataclass(frozen=True)

--- a/infra/grafana/src/github_app.py
+++ b/infra/grafana/src/github_app.py
@@ -18,19 +18,19 @@ from datetime import datetime
 
 import httpx
 import jwt
-from config import GITHUB_API_BASE, GithubAppCredentials
+from config import GITHUB_API_BASE, GITHUB_USER_AGENT, GithubAppCredentials
 from errors import UpstreamError
 
 logger = logging.getLogger(__name__)
 
-# Read-only permissions the token is attenuated to, whatever the app itself holds:
-# contents+metadata for the commit history, checks+statuses for the
-# statusCheckRollup, actions for the ferry/nightly run lists.
+# Read-only permissions the token is attenuated to. A token request may only name
+# permissions the installation actually holds — asking for an ungranted one 422s the
+# whole mint and blanks every panel — so this stays the minimal set the panels read:
+# contents+metadata for the commit history and its statusCheckRollup state, actions
+# for the ferry/nightly run lists.
 _TOKEN_PERMISSIONS = {
     "metadata": "read",
     "contents": "read",
-    "checks": "read",
-    "statuses": "read",
     "actions": "read",
 }
 
@@ -95,7 +95,13 @@ def _app_request(method: str, path: str, jwt_token: str, *, json: dict | None = 
     return httpx.Request(
         method,
         f"{GITHUB_API_BASE}{path}",
-        headers={"authorization": f"Bearer {jwt_token}", "accept": "application/vnd.github+json"},
+        headers={
+            "authorization": f"Bearer {jwt_token}",
+            "accept": "application/vnd.github+json",
+            # auth_flow builds these requests directly, so httpx never merges the client's
+            # default User-Agent; without one GitHub 403s the App auth and blanks every panel.
+            "user-agent": GITHUB_USER_AGENT,
+        },
         json=json,
     )
 

--- a/infra/grafana/src/github_source.py
+++ b/infra/grafana/src/github_source.py
@@ -17,7 +17,7 @@ from datetime import UTC, datetime, timedelta
 from urllib.parse import quote
 
 import httpx
-from config import BUILD_HISTORY, FERRY_GROUPS, FERRY_RUN_LIMIT, GITHUB_API_BASE, GITHUB_REPO
+from config import BUILD_HISTORY, FERRY_GROUPS, FERRY_RUN_LIMIT, GITHUB_API_BASE, GITHUB_REPO, GITHUB_USER_AGENT
 from errors import UpstreamError
 from graphql_source import graphql_data
 from nightly import NightlyLaneSnapshot, NightlyRun, project_nightlies
@@ -98,7 +98,7 @@ class GithubSource:
         headers = {
             "accept": "application/vnd.github+json",
             "x-github-api-version": "2022-11-28",
-            "user-agent": "marin-grafana-bridge",
+            "user-agent": GITHUB_USER_AGENT,
         }
         # auth attaches a cached GitHub App installation token, refreshed near expiry
         # (see github_app.GithubAppAuth). None leaves requests unauthenticated: the

--- a/infra/grafana/tests/test_github_app.py
+++ b/infra/grafana/tests/test_github_app.py
@@ -13,7 +13,7 @@ import time
 import httpx
 import jwt
 import pytest
-from config import GithubAppCredentials, _github_app_credentials
+from config import GITHUB_USER_AGENT, GithubAppCredentials, _github_app_credentials
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import (
     Encoding,
@@ -55,10 +55,13 @@ def test_mints_a_scoped_readonly_token_and_sends_it(monkeypatch):
                 options={"verify_exp": False},  # exp is stamped from the mocked clock
             )
             seen["issuer"] = claims["iss"]
+            # GitHub 403s any request without a User-Agent, so the auth flow must stamp one.
+            seen["lookup_user_agent"] = request.headers.get("user-agent")
             return httpx.Response(200, json={"id": 42})
         if request.url.path.endswith("/access_tokens"):
             assert request.url.path == "/app/installations/42/access_tokens"
             seen["token_body"] = json.loads(request.content)
+            seen["mint_user_agent"] = request.headers.get("user-agent")
             return httpx.Response(201, json={"token": "ghs_minted", "expires_at": "2026-07-23T20:00:00Z"})
         seen["sent_auth"] = request.headers.get("authorization")
         return httpx.Response(200, json={})
@@ -67,9 +70,11 @@ def test_mints_a_scoped_readonly_token_and_sends_it(monkeypatch):
 
     assert seen["issuer"] == "cid"
     assert seen["token_body"]["repositories"] == ["marin", "vllm"]
-    assert seen["token_body"]["permissions"] == {
-        k: "read" for k in ("metadata", "contents", "checks", "statuses", "actions")
-    }
+    # Only permissions the installation actually holds may be requested: naming an
+    # ungranted one 422s the whole mint and blanks every GitHub panel.
+    assert seen["token_body"]["permissions"] == {k: "read" for k in ("metadata", "contents", "actions")}
+    assert seen["lookup_user_agent"] == GITHUB_USER_AGENT
+    assert seen["mint_user_agent"] == GITHUB_USER_AGENT
     assert seen["sent_auth"] == "Bearer ghs_minted"
 
 


### PR DESCRIPTION
The nightly regression matrix, ferry status, and commit strip all render as
source-unavailable because the GitHub App token mint fails, so every nightly
lane falls back to an error cell.

Two faults in the App-auth flow, both dating to the token migration. `auth_flow`
builds its installation-lookup and token-mint requests directly with
`httpx.Request`, so httpx never merges the client's default User-Agent, and
GitHub 403s any request without one. The token request also named `checks` and
`statuses` permissions the installation was never granted, which 422s the whole
mint even for the panels that only need `actions:read`. `statusCheckRollup`
state reads fine with `contents`+`metadata`, so both are dropped.

Verified against the live installation: nightly goes from every lane
unavailable to 67 run cells; builds and ferries return data.
