### PR TITLE
[grafana] Forward SIGTERM to Grafana so alert state survives a deploy

### DIFF
--- a/infra/grafana/entrypoint.sh
+++ b/infra/grafana/entrypoint.sh
@@ -29,9 +29,29 @@ fi
 /run.sh "$@" &
 grafana_pid=$!
 
+# Cloud Run signals shutdown with SIGTERM to PID 1 and SIGKILLs the container a few
+# seconds later, and bash does not pass that on to background children. Grafana has
+# to receive it and run its own shutdown: that is when it snapshots the Alertmanager
+# notification log to the database. Killed outright, it leaves a stale log behind and
+# the replacement instance re-notifies every alert still firing.
+terminating=0
+forward_term() {
+  terminating=1
+  kill -TERM "$grafana_pid" "$bridge_pid" 2>/dev/null || true
+}
+trap forward_term TERM INT
+
 # Wait for whichever dies first, then take the container down with it.
 exit_code=0
 wait -n "$bridge_pid" "$grafana_pid" || exit_code=$?
+
+if [ "${terminating}" -eq 1 ]; then
+  # Let both finish their shutdown; Cloud Run's SIGKILL is the real deadline.
+  wait "$grafana_pid" 2>/dev/null || true
+  wait "$bridge_pid" 2>/dev/null || true
+  exit 0
+fi
+
 echo "entrypoint: a supervised process exited (status ${exit_code}); stopping container" >&2
 kill "$bridge_pid" "$grafana_pid" 2>/dev/null || true
 exit "${exit_code}"


### PR DESCRIPTION
Cloud Run sends SIGTERM to PID 1 and SIGKILLs the container shortly after. entrypoint.sh ran Grafana as a background child of a bash script that never forwarded the signal, so Grafana was killed without running its shutdown path and never snapshotted the Alertmanager notification log. Each new instance loaded a log up to one maintenance interval stale and re-notified every alert that was still firing, which reads as a duplicate page even though the underlying rule is level-triggered and never left the firing state.

Three revisions deployed within 17 minutes on 2026-07-28 sent a Slack message for the same continuously-firing `IrisFederationPeerUnreachable` instance at 17:41, 17:48 and 17:52 UTC, the last two arriving seconds after a container start. No shutdown log line appears in Cloud Logging for any revision.

The entrypoint now traps SIGTERM, forwards it to both supervised processes and waits for them to exit. The crash path is unchanged: if either process dies on its own, the container still exits with that status.

Separately and not fixed here: `ops-critical` includes an email receiver, but the `marin-grafana-smtp-credentials` secret does not exist in `hai-gcp-models`, so every flush logs `SMTP not configured` and the email integration never records a notification-log entry. That is the source of the 5-minute `Notify for alerts failed` cadence in the Grafana logs. Slack and the Loom webhook still deliver.
