### PR TITLE
grafana: show provisioning success by region

### DIFF
--- a/infra/grafana/dashboards/infra.json
+++ b/infra/grafana/dashboards/infra.json
@@ -941,6 +941,7 @@
       "id": 25,
       "type": "timeseries",
       "title": "Provisioning success ratio",
+      "description": "Trailing 3h success ratio, refreshed every 15m. Success is READY / (READY + STOCKOUT + ERROR); runtime preemptions are excluded.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"
@@ -967,7 +968,12 @@
       },
       "options": {
         "legend": {
-          "displayMode": "list",
+          "calcs": [
+            "lastNotNull",
+            "min",
+            "max"
+          ],
+          "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
@@ -989,7 +995,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "SELECT collected_at AS t, value FROM \"infra.canary.metrics\" WHERE metric = 'provision_success_ratio' AND contains(labels, '\"scope\": \"fleet\"') AND collected_at >= {{from}} AND collected_at < {{to}} ORDER BY collected_at"
+                "value": "WITH region_counts AS (SELECT collected_at AS t, regexp_replace(json_get(labels, 'zone'), '-[^-]+$', '') AS series, SUM(CASE WHEN metric = 'provision_ready' THEN value ELSE 0 END) AS ready, SUM(CASE WHEN metric = 'provision_outcomes' THEN value ELSE 0 END) AS outcomes FROM \"infra.canary.metrics\" WHERE metric IN ('provision_ready', 'provision_outcomes') AND COALESCE(json_get(labels, 'zone'), '') <> '' AND collected_at >= {{from}} AND collected_at < {{to}} GROUP BY 1, 2), regional AS (SELECT t, series, ready / NULLIF(outcomes, 0) AS value FROM region_counts WHERE outcomes > 0), fleet AS (SELECT collected_at AS t, 'fleet' AS series, value FROM \"infra.canary.metrics\" WHERE metric = 'provision_success_ratio' AND contains(labels, '\"scope\": \"fleet\"') AND collected_at >= {{from}} AND collected_at < {{to}}) SELECT t, series, value FROM fleet UNION ALL SELECT t, series, value FROM regional ORDER BY t, series"
               },
               {
                 "key": "from",
@@ -1006,6 +1012,11 @@
               "selector": "t",
               "text": "time",
               "type": "timestamp_epoch"
+            },
+            {
+              "selector": "series",
+              "text": "region",
+              "type": "string"
             },
             {
               "selector": "value",

--- a/infra/grafana/tests/fixture_bridge.py
+++ b/infra/grafana/tests/fixture_bridge.py
@@ -116,7 +116,7 @@ def _finelog(query: str) -> list[dict]:
         ]
     if "probe_up" in sql and "metric IN" not in sql:
         return [{"value": 1}, {"value": 1}, {"value": 1}]
-    if "metric IN" in sql:
+    if "metric IN" in sql and "provision_success_ratio" not in sql:
         return [
             {"probe": probe, "metric": metric, "value": value}
             for probe in ("iris", "finelog", "kueue")

--- a/infra/grafana/tests/fixture_bridge.py
+++ b/infra/grafana/tests/fixture_bridge.py
@@ -134,7 +134,19 @@ def _finelog(query: str) -> list[dict]:
         ]
     if "provision_success_ratio" in sql:
         return [
-            {"t": round((_NOW - timedelta(minutes=10 * index)).timestamp() * 1000), "value": 0.96 + (index % 4) * 0.008}
+            {
+                "t": round((_NOW - timedelta(minutes=10 * index)).timestamp() * 1000),
+                "series": series,
+                "value": base + (index % 4) * 0.008,
+            }
+            for series, base in (
+                ("fleet", 0.81),
+                ("europe-west4", 0.72),
+                ("us-central1", 0.94),
+                ("us-east1", 0.78),
+                ("us-east5", 0.86),
+                ("us-west4", 0.75),
+            )
             for index in range(24)
         ]
     return []

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -8,7 +8,7 @@ Grafana, which is the most expensive place to find out."""
 
 import re
 from pathlib import Path
-from urllib.parse import urlsplit
+from urllib.parse import urlencode, urlsplit
 
 import pyarrow as pa
 import yaml
@@ -16,6 +16,7 @@ from config import ClusterTarget
 from conftest import bridge_config, healthy_k8s_routes, k8s_api, make_k8s_source
 from dashboard_stitch import stitch_all
 from finelog_health import FinelogHealth, FinelogRole
+from fixture_bridge import _finelog
 from github_source import GithubSource
 from k8s_source import K8sFleet
 from server import create_app
@@ -270,6 +271,26 @@ def test_provisioning_success_ratio_shows_fleet_and_region_stats():
     legend = panel["options"]["legend"]
     assert legend["displayMode"] == "table"
     assert legend["calcs"] == ["lastNotNull", "min", "max"]
+
+
+def test_provisioning_render_fixture_routes_metric_query_to_region_series():
+    dashboard = _stitched_dashboards()["infra.json"]
+    (panel,) = [panel for panel in dashboard["panels"] if panel.get("title") == "Provisioning success ratio"]
+    (target,) = panel["targets"]
+    sql = next(param["value"] for param in target["url_options"]["params"] if param["key"] == "sql")
+
+    rows = _finelog(urlencode({"sql": sql}))
+
+    assert rows
+    assert {row["series"] for row in rows} == {
+        "fleet",
+        "europe-west4",
+        "us-central1",
+        "us-east1",
+        "us-east5",
+        "us-west4",
+    }
+    assert all({"t", "series", "value"} <= row.keys() for row in rows)
 
 
 def test_stat_panels_use_grafana_reduce_options_schema():

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -252,6 +252,26 @@ def test_dashboard_datasource_uids_are_provisioned():
             assert uid in uids, f"{name} panel {panel.get('id')}: unknown datasource {uid!r}"
 
 
+def test_provisioning_success_ratio_shows_fleet_and_region_stats():
+    dashboard = _stitched_dashboards()["infra.json"]
+    (panel,) = [panel for panel in dashboard["panels"] if panel.get("title") == "Provisioning success ratio"]
+    (target,) = panel["targets"]
+
+    columns = {column["selector"]: column for column in target["columns"]}
+    assert columns["series"] == {"selector": "series", "text": "region", "type": "string"}
+    assert columns["value"]["type"] == "number"
+
+    sql = next(param["value"] for param in target["url_options"]["params"] if param["key"] == "sql")
+    assert "metric = 'provision_success_ratio'" in sql
+    assert "metric IN ('provision_ready', 'provision_outcomes')" in sql
+    assert "regexp_replace(json_get(labels, 'zone'), '-[^-]+$', '') AS series" in sql
+    assert "ready / NULLIF(outcomes, 0)" in sql
+
+    legend = panel["options"]["legend"]
+    assert legend["displayMode"] == "table"
+    assert legend["calcs"] == ["lastNotNull", "min", "max"]
+
+
 def test_stat_panels_use_grafana_reduce_options_schema():
     for name, dashboard in _stitched_dashboards().items():
         for panel in dashboard["panels"]:


### PR DESCRIPTION
* add fleet and per-region three-hour provisioning success lines from existing per-zone gauges
* derive regions at query time to preserve existing history without a probe rollout or backfill
* show last, min, and max legend stats; continue excluding runtime preemptions from the ratio
