### PR TITLE
iris: inherit parent priority for kubernetes child jobs

### DIFF
--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -110,12 +110,10 @@ class PendingDispatchRow:
     # Coscheduling + priority drive Kueue gang admission on the direct path.
     has_coscheduling: bool
     coscheduling_group_by: str  # "" when not coscheduled
-    # Effective band from tasks.priority_band (normalized to INTERACTIVE at
-    # submit, overwritten with any over-budget demotion at assign time) — NOT
-    # the immutable requested band in job_config. The Kueue WorkloadPriorityClass
-    # must mirror the band Iris actually enforces, and tasks.priority_band is
-    # never UNSPECIFIED(0), so the provider's plain .get() resolves correctly.
-    priority_band: int  # job_pb2.PriorityBand, effective
+    # Current tasks.priority_band. Before first direct dispatch, the drain
+    # resolves parent inheritance from job_config and stamps the result; a
+    # redrive reads that fixed band back from the task row.
+    priority_band: int  # job_pb2.PriorityBand
     # Requested container security profile (job_config). UNSPECIFIED(0) resolves
     # to DEFAULT when the backend applies it.
     container_profile: int  # job_pb2.ContainerProfile
@@ -1699,8 +1697,7 @@ PENDING_DISPATCH_COLS = (
     job_config_table.c.timeout_ms,
     job_config_table.c.has_coscheduling,
     job_config_table.c.coscheduling_group_by,
-    # Effective band (tasks), not the immutable requested band (job_config):
-    # see PendingDispatchRow.priority_band.
+    # Current stamped task band; see PendingDispatchRow.priority_band.
     local_tasks.c.priority_band,
     job_config_table.c.container_profile,
 )

--- a/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
@@ -12,7 +12,7 @@ lives controller-side, not in the DB-less backend; the controller rides its
 output on the reconcile ``ControlSnapshot``.
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 from rigging.timing import Timestamp
 from sqlalchemy import select
@@ -144,6 +144,7 @@ def drain_for_dispatch(
     """
     now_ms = Timestamp.now().epoch_ms()
     tasks_to_run: list[job_pb2.RunTaskRequest] = []
+    rows_to_promote: list[PendingDispatchRow] = []
 
     # In a multi-backend cluster, scope the drain to this backend's tasks; a
     # single backend (``backend_id is None``) drains every pending task.
@@ -158,11 +159,6 @@ def drain_for_dispatch(
         local_tasks.c.current_worker_id.is_(None),
         *backend_pred,
     )
-
-    def _promote(row: PendingDispatchRow) -> None:
-        attempt_id = row.current_attempt_id + 1
-        writes.promote_for_dispatch(cur, row.task_id, attempt_id, now_ms)
-        tasks_to_run.append(build_run_request(cur, row, attempt_id))
 
     promoted_count = 0
     if max_promotions > 0:
@@ -200,8 +196,7 @@ def drain_for_dispatch(
                 # gangs, larger than the cap itself, fall through and are
                 # promoted whole to avoid a permanent deadlock.)
                 continue
-            for row in gang:
-                _promote(row)
+            rows_to_promote.extend(gang)
             promoted_count += len(gang)
 
         # Non-coscheduled first-fit, bounded by the remaining budget.
@@ -214,8 +209,14 @@ def drain_for_dispatch(
                 *backend_pred,
                 limit=remaining,
             )
-            for row in noncosched_pending:
-                _promote(row)
+            rows_to_promote.extend(noncosched_pending)
+
+    resolved_bands = reads.get_priority_bands(cur, {row.job_id for row in rows_to_promote})
+    for row in rows_to_promote:
+        row = replace(row, priority_band=resolved_bands[row.job_id])
+        attempt_id = row.current_attempt_id + 1
+        writes.promote_for_dispatch(cur, row.task_id, attempt_id, now_ms, priority_band=row.priority_band)
+        tasks_to_run.append(build_run_request(cur, row, attempt_id))
 
     # Redrive: pods for these rows may not exist yet (crash between
     # assign-commit and apply, or apply errored last cycle). `kubectl

--- a/lib/iris/src/iris/cluster/controller/writes.py
+++ b/lib/iris/src/iris/cluster/controller/writes.py
@@ -672,11 +672,15 @@ def promote_for_dispatch(
     task_id: JobName,
     attempt_id: int,
     now_ms: int,
+    *,
+    priority_band: int,
 ) -> None:
     """Insert a fresh ``task_attempts`` row and promote the task for direct-provider dispatch.
 
     No worker is assigned; ``current_worker_id`` is left NULL so the
-    direct-provider path can track and dispatch the task via K8s.
+    direct-provider path can track and dispatch the task via K8s. The resolved
+    priority band is fixed for the attempt so persisted state matches the
+    dispatched request.
     """
     insert_attempt(
         tx,
@@ -693,6 +697,7 @@ def promote_for_dispatch(
             state=job_pb2.TASK_STATE_ASSIGNED,
             current_attempt_id=attempt_id,
             started_at_ms=func.coalesce(tasks_table.c.started_at_ms, now_ms),
+            priority_band=priority_band,
         )
     )
 

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -5,6 +5,7 @@
 
 import threading
 
+import pytest
 from finelog.rpc import logging_pb2
 from iris.cluster.controller import ops
 from iris.cluster.controller.backend import (
@@ -170,6 +171,53 @@ def test_drain_default_task_image_is_empty(state):
 
     assert len(batch.tasks_to_run) == 1
     assert batch.tasks_to_run[0].task_image == ""
+
+
+@pytest.mark.parametrize(
+    ("parent_band", "child_band", "expected_band"),
+    [
+        (
+            job_pb2.PRIORITY_BAND_PRODUCTION,
+            job_pb2.PRIORITY_BAND_UNSPECIFIED,
+            job_pb2.PRIORITY_BAND_PRODUCTION,
+        ),
+        (
+            job_pb2.PRIORITY_BAND_BATCH,
+            job_pb2.PRIORITY_BAND_UNSPECIFIED,
+            job_pb2.PRIORITY_BAND_BATCH,
+        ),
+        (
+            job_pb2.PRIORITY_BAND_PRODUCTION,
+            job_pb2.PRIORITY_BAND_BATCH,
+            job_pb2.PRIORITY_BAND_BATCH,
+        ),
+        (
+            job_pb2.PRIORITY_BAND_UNSPECIFIED,
+            job_pb2.PRIORITY_BAND_UNSPECIFIED,
+            job_pb2.PRIORITY_BAND_INTERACTIVE,
+        ),
+    ],
+)
+def test_drain_child_priority_uses_explicit_or_inherited_band(state, parent_band, child_band, expected_band):
+    """K8s dispatch uses the child's explicit band or its nearest explicit ancestor."""
+    parent_id = JobName.root("test-user", "priority-parent")
+    child_id = parent_id.child("priority-child")
+    parent_req = make_direct_job_request(parent_id.name, priority_band=parent_band)
+    child_req = make_direct_job_request(child_id.name, priority_band=child_band)
+    # The shared helper constructs root names; this request represents a child.
+    child_req.name = child_id.to_wire()
+
+    with state._db.transaction() as cur:
+        ops.job.submit(cur, job_id=parent_id, request=parent_req, ts=Timestamp.now())
+        ops.job.submit(cur, job_id=child_id, request=child_req, ts=Timestamp.now())
+
+    with state._db.transaction() as cur:
+        batch = dispatch.drain_for_dispatch(cur)
+
+    child_task_id = child_id.task(0)
+    [child_run_request] = [request for request in batch.tasks_to_run if request.task_id == child_task_id.to_wire()]
+    assert child_run_request.priority == expected_band
+    assert query_task(state, child_task_id).priority_band == expected_band
 
 
 def test_drain_includes_workdir_files(state):


### PR DESCRIPTION
* prevent unspecified gpu children of batch jobs from running at interactive priority on kubernetes
  * restore batch preemption on B200 and other K8s clusters
* match worker-daemon parent-band resolution for kubernetes child jobs
  * explicit child bands still override ancestor bands
  * all-unspecified ancestry still defaults to interactive
* stamp the resolved band on task state and `RunTaskRequest.priority` before Kueue admission
* leave budget demotion and promotion-cap ordering unchanged
  * follow-up #7726
