### PR TITLE
[iris] Apply budget demotion and priority ordering to K8s dispatch

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -1664,7 +1664,12 @@ class Controller:
         max_promotions = self._promotion_bucket.available
         backend_filter = None if len(self._backends) == 1 else backend_id
         with self._db.transaction() as cur:
-            batch = dispatch.drain_for_dispatch(cur, max_promotions=max_promotions, backend_id=backend_filter)
+            batch = dispatch.drain_for_dispatch(
+                cur,
+                max_promotions=max_promotions,
+                backend_id=backend_filter,
+                defaults=self._config.user_budget_defaults,
+            )
         if batch.tasks_to_run:
             self._promotion_bucket.try_acquire(len(batch.tasks_to_run))
         return reads.ControlSnapshot(

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -117,6 +117,13 @@ class PendingDispatchRow:
     # Requested container security profile (job_config). UNSPECIFIED(0) resolves
     # to DEFAULT when the backend applies it.
     container_profile: int  # job_pb2.ContainerProfile
+    # Hierarchy/submission ordering keys, mirroring the worker-daemon scheduler
+    # sort (see ``_PENDING_TASKS_STMT``). The dispatch drain ranks promotion
+    # candidates by these within an effective band before applying the rate cap.
+    priority_neg_depth: int
+    priority_root_submitted_ms: int
+    priority_submitted_ms: int
+    priority_insertion: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -1700,6 +1707,10 @@ PENDING_DISPATCH_COLS = (
     # Current stamped task band; see PendingDispatchRow.priority_band.
     local_tasks.c.priority_band,
     job_config_table.c.container_profile,
+    local_tasks.c.priority_neg_depth,
+    local_tasks.c.priority_root_submitted_ms,
+    local_tasks.c.submitted_at_ms,
+    local_tasks.c.priority_insertion,
 )
 
 
@@ -1728,6 +1739,10 @@ def pending_dispatch_row(r) -> PendingDispatchRow:
         coscheduling_group_by=str(r.coscheduling_group_by),
         priority_band=int(r.priority_band),
         container_profile=int(r.container_profile),
+        priority_neg_depth=int(r.priority_neg_depth),
+        priority_root_submitted_ms=int(r.priority_root_submitted_ms),
+        priority_submitted_ms=int(r.submitted_at_ms.epoch_ms()),
+        priority_insertion=int(r.priority_insertion),
     )
 
 

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -117,13 +117,6 @@ class PendingDispatchRow:
     # Requested container security profile (job_config). UNSPECIFIED(0) resolves
     # to DEFAULT when the backend applies it.
     container_profile: int  # job_pb2.ContainerProfile
-    # Hierarchy/submission ordering keys, mirroring the worker-daemon scheduler
-    # sort (see ``_PENDING_TASKS_STMT``). The dispatch drain ranks promotion
-    # candidates by these within an effective band before applying the rate cap.
-    priority_neg_depth: int
-    priority_root_submitted_ms: int
-    priority_submitted_ms: int
-    priority_insertion: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -1707,10 +1700,6 @@ PENDING_DISPATCH_COLS = (
     # Current stamped task band; see PendingDispatchRow.priority_band.
     local_tasks.c.priority_band,
     job_config_table.c.container_profile,
-    local_tasks.c.priority_neg_depth,
-    local_tasks.c.priority_root_submitted_ms,
-    local_tasks.c.submitted_at_ms,
-    local_tasks.c.priority_insertion,
 )
 
 
@@ -1739,10 +1728,6 @@ def pending_dispatch_row(r) -> PendingDispatchRow:
         coscheduling_group_by=str(r.coscheduling_group_by),
         priority_band=int(r.priority_band),
         container_profile=int(r.container_profile),
-        priority_neg_depth=int(r.priority_neg_depth),
-        priority_root_submitted_ms=int(r.priority_root_submitted_ms),
-        priority_submitted_ms=int(r.submitted_at_ms.epoch_ms()),
-        priority_insertion=int(r.priority_insertion),
     )
 
 

--- a/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
@@ -12,12 +12,19 @@ lives controller-side, not in the DB-less backend; the controller rides its
 output on the reconcile ``ControlSnapshot``.
 """
 
+from collections import defaultdict
 from dataclasses import dataclass, field, replace
 
 from rigging.timing import Timestamp
 from sqlalchemy import select
 
 from iris.cluster.controller import reads, writes
+from iris.cluster.controller.budget import (
+    UserTask,
+    compute_effective_band,
+    compute_user_spend,
+    interleave_by_user,
+)
 from iris.cluster.controller.db import Tx
 from iris.cluster.controller.projections.run_templates import build_run_request_fields
 from iris.cluster.controller.reads import (
@@ -28,7 +35,7 @@ from iris.cluster.controller.reads import (
 )
 from iris.cluster.controller.schema import job_config_table, jobs_table, local_tasks
 from iris.cluster.controller.task_state import ACTIVE_TASK_STATES, RunningTaskEntry
-from iris.cluster.types import JobName
+from iris.cluster.types import JobName, UserBudgetDefaults
 from iris.rpc import job_pb2
 
 
@@ -92,27 +99,79 @@ def build_run_request(
     return run_req
 
 
-def _dispatch_query(
-    cur: Tx,
-    *predicates,
-    order_by_job_id: bool = False,
-    limit: int | None = None,
-) -> list[PendingDispatchRow]:
+def _dispatch_query(cur: Tx, *predicates) -> list[PendingDispatchRow]:
     """Fetch :class:`PendingDispatchRow`s for the direct-provider drain.
 
-    All drain queries select ``PENDING_DISPATCH_COLS`` over the
-    tasks⋈jobs⋈job_config join; callers supply the distinct state /
-    coscheduling predicates plus optional ordering and limit.
+    Both drain queries (PENDING promotion, ASSIGNED redrive) select
+    ``PENDING_DISPATCH_COLS`` over the tasks⋈jobs⋈job_config join and supply
+    their distinct state predicate; ordering and the rate cap are applied in
+    Python by :func:`_rank_promotion_units` and the drain loop.
     """
     dispatch_join = local_tasks.join(jobs_table, jobs_table.c.job_id == local_tasks.c.job_id).join(
         job_config_table, job_config_table.c.job_id == jobs_table.c.job_id
     )
     stmt = select(*PENDING_DISPATCH_COLS).select_from(dispatch_join).where(*predicates)
-    if order_by_job_id:
-        stmt = stmt.order_by(local_tasks.c.job_id)
-    if limit is not None:
-        stmt = stmt.limit(limit)
     return [pending_dispatch_row(r) for r in cur.execute(stmt).all()]
+
+
+def _unit_sort_key(unit: list[PendingDispatchRow]) -> tuple[int, int, int, int]:
+    """Hierarchy/submission ordering key for a promotion unit.
+
+    Mirrors the worker-daemon sort (``reads._PENDING_TASKS_STMT``): parent depth,
+    then root submission, then own submission, then insertion. A coscheduled gang
+    shares one job, so its members' keys agree except on insertion; the minimum
+    anchors the whole gang at its earliest sibling.
+    """
+    return min(
+        (row.priority_neg_depth, row.priority_root_submitted_ms, row.priority_submitted_ms, row.priority_insertion)
+        for row in unit
+    )
+
+
+def _build_promotion_units(pending: list[PendingDispatchRow]) -> list[list[PendingDispatchRow]]:
+    """Group PENDING dispatch rows into atomic promotion units.
+
+    Non-coscheduled tasks are singleton units. Coscheduled tasks are grouped by
+    job into gangs; a gang becomes a unit only once every sibling is PENDING
+    together (``len == num_tasks``), keeping siblings on one attempt_id so Kueue
+    never waits on pods Iris deferred. A partially-assembled gang is dropped this
+    cycle and reconsidered next.
+    """
+    units: list[list[PendingDispatchRow]] = []
+    gangs: dict[JobName, list[PendingDispatchRow]] = {}
+    for row in pending:
+        if row.has_coscheduling:
+            gangs.setdefault(row.job_id, []).append(row)
+        else:
+            units.append([row])
+    for gang in gangs.values():
+        if len(gang) == gang[0].num_tasks:
+            units.append(gang)
+    return units
+
+
+def _rank_promotion_units(
+    units: list[list[PendingDispatchRow]],
+    effective_bands: dict[JobName, int],
+    user_spend: dict[str, int],
+) -> list[list[PendingDispatchRow]]:
+    """Order promotion units by effective band, then worker-daemon fairness.
+
+    Units are bucketed by their job's effective band and emitted in ascending
+    band order (PRODUCTION first). Within a band they are sorted by the
+    hierarchy/submission key, then round-robined across users by ascending spend
+    — matching ``scheduling.policy.compute_scheduling_order`` so the direct and
+    worker-daemon paths agree on ordering.
+    """
+    by_band: dict[int, list[list[PendingDispatchRow]]] = defaultdict(list)
+    for unit in units:
+        by_band[effective_bands[unit[0].job_id]].append(unit)
+    ranked: list[list[PendingDispatchRow]] = []
+    for band in sorted(by_band):
+        band_units = sorted(by_band[band], key=_unit_sort_key)
+        user_units = [UserTask(user_id=unit[0].task_id.user, task=unit) for unit in band_units]
+        ranked.extend(interleave_by_user(user_units, user_spend))
+    return ranked
 
 
 def drain_for_dispatch(
@@ -120,6 +179,7 @@ def drain_for_dispatch(
     *,
     max_promotions: int = DISPATCH_PROMOTION_RATE,
     backend_id: str | None = None,
+    defaults: UserBudgetDefaults | None = None,
 ) -> DispatchBatch:
     """Drain pending tasks and snapshot running tasks for a direct provider sync cycle.
 
@@ -141,10 +201,18 @@ def drain_for_dispatch(
     ``tasks.state`` directly to terminal, and the K8s provider's pod
     diff against the desired set deletes the corresponding pod on the
     next sync.
+
+    Candidates are ranked by *effective* band — the ancestor-resolved requested
+    band after :func:`compute_effective_band` demotes over-budget users to
+    BATCH — before the ``max_promotions`` rate cap applies, so a capped cycle
+    never exposes a lower-band pod ahead of a higher-band one. The effective
+    band is stamped on ``tasks.priority_band`` and drives the Kueue
+    WorkloadPriorityClass; a redrive reuses that fixed band even if spend or
+    budget configuration later changes.
     """
+    defaults = defaults or UserBudgetDefaults()
     now_ms = Timestamp.now().epoch_ms()
     tasks_to_run: list[job_pb2.RunTaskRequest] = []
-    rows_to_promote: list[PendingDispatchRow] = []
 
     # In a multi-backend cluster, scope the drain to this backend's tasks; a
     # single backend (``backend_id is None``) drains every pending task.
@@ -160,62 +228,52 @@ def drain_for_dispatch(
         *backend_pred,
     )
 
-    promoted_count = 0
+    effective_bands: dict[JobName, int] = {}
+    rows_to_promote: list[PendingDispatchRow] = []
     if max_promotions > 0:
-        # Coscheduled gangs are promoted all-or-none in a single cycle.
-        # Kueue only admits a pod group once it has observed every
-        # ``pod-group-total-count`` pod, so a gang split across drain
-        # cycles — or one larger than the per-cycle cap — would deadlock
-        # waiting for pods Iris never created. Fetch the full coscheduled
-        # PENDING set (no SQL limit) and promote each gang only once all
-        # its tasks are PENDING together; this also keeps every sibling on
-        # the same attempt_id, which is the pod-group generation key (see
-        # _pod_group_name). Non-coscheduled rows keep the flat,
-        # budget-bounded first-fit behavior.
-        cosched_pending = _dispatch_query(
+        # Rank every PENDING candidate by effective band before the rate cap.
+        # The whole set is fetched (no SQL limit) so band ordering, not row
+        # insertion order, decides what the bounded budget promotes.
+        pending = _dispatch_query(
             cur,
             local_tasks.c.state == int(job_pb2.TASK_STATE_PENDING),
-            job_config_table.c.has_coscheduling == True,  # noqa: E712
             *backend_pred,
-            order_by_job_id=True,
         )
-        gangs: dict[JobName, list[PendingDispatchRow]] = {}
-        for row in cosched_pending:
-            gangs.setdefault(row.job_id, []).append(row)
-        for gang in gangs.values():
-            num_tasks = gang[0].num_tasks
-            if len(gang) != num_tasks:
-                # Gang not fully assembled yet (siblings still in flight,
-                # e.g. mid-bounce); a later cycle promotes it whole once
-                # they converge to PENDING.
-                continue
+        job_ids = {row.job_id for row in pending}
+        resolved_bands = reads.get_priority_bands(cur, job_ids)
+        user_spend = compute_user_spend(cur)
+        user_budget_limits = reads.get_all_user_budget_limits(cur)
+        effective_bands = {
+            job_id: compute_effective_band(resolved_bands[job_id], job_id.user, user_spend, user_budget_limits, defaults)
+            for job_id in job_ids
+        }
+        units = _rank_promotion_units(_build_promotion_units(pending), effective_bands, user_spend)
+
+        promoted_count = 0
+        for unit in units:
             remaining = max_promotions - promoted_count
-            if len(gang) > remaining and len(gang) <= max_promotions:
-                # Gang fits within the per-cycle cap but not this cycle's
-                # remaining budget — defer to a later cycle. (Oversized
-                # gangs, larger than the cap itself, fall through and are
-                # promoted whole to avoid a permanent deadlock.)
-                continue
-            rows_to_promote.extend(gang)
-            promoted_count += len(gang)
+            if remaining <= 0:
+                break
+            if len(unit) <= remaining or len(unit) > max_promotions:
+                # Fits this cycle, or an oversized gang (larger than the cap
+                # itself) promoted whole to avoid a permanent deadlock: Kueue
+                # only admits a pod group once every sibling pod exists, so a
+                # gang split across cycles would wait forever.
+                rows_to_promote.extend(unit)
+                promoted_count += len(unit)
+            else:
+                # A coscheduled gang that fits the cap but not this cycle's
+                # remaining budget defers whole. Stop here rather than promote a
+                # lower-ranked unit ahead of it — that would invert priority
+                # across the band boundary. A later cycle with fuller budget
+                # promotes the gang atomically.
+                break
 
-        # Non-coscheduled first-fit, bounded by the remaining budget.
-        remaining = max_promotions - promoted_count
-        if remaining > 0:
-            noncosched_pending = _dispatch_query(
-                cur,
-                local_tasks.c.state == int(job_pb2.TASK_STATE_PENDING),
-                job_config_table.c.has_coscheduling == False,  # noqa: E712
-                *backend_pred,
-                limit=remaining,
-            )
-            rows_to_promote.extend(noncosched_pending)
-
-    resolved_bands = reads.get_priority_bands(cur, {row.job_id for row in rows_to_promote})
     for row in rows_to_promote:
-        row = replace(row, priority_band=resolved_bands[row.job_id])
+        band = effective_bands[row.job_id]
+        row = replace(row, priority_band=band)
         attempt_id = row.current_attempt_id + 1
-        writes.promote_for_dispatch(cur, row.task_id, attempt_id, now_ms, priority_band=row.priority_band)
+        writes.promote_for_dispatch(cur, row.task_id, attempt_id, now_ms, priority_band=band)
         tasks_to_run.append(build_run_request(cur, row, attempt_id))
 
     # Redrive: pods for these rows may not exist yet (crash between

--- a/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
@@ -14,6 +14,7 @@ output on the reconcile ``ControlSnapshot``.
 
 from collections import defaultdict
 from dataclasses import dataclass, field, replace
+from typing import NamedTuple
 
 from rigging.timing import Timestamp
 from sqlalchemy import select
@@ -113,6 +114,20 @@ def _dispatch_query(cur: Tx, *predicates) -> list[PendingDispatchRow]:
     return [pending_dispatch_row(r) for r in cur.execute(stmt).all()]
 
 
+class _PriorityKey(NamedTuple):
+    """Within-band ordering key, mirroring the worker-daemon sort (``reads._PENDING_TASKS_STMT``).
+
+    Compared field-by-field in this declared order, ascending — the earliest
+    ancestor and submission win. A ``NamedTuple`` so ``min``/``sorted`` treat it
+    as the plain tuple the comparison needs while each field stays named.
+    """
+
+    neg_depth: int
+    root_submitted_ms: int
+    submitted_ms: int
+    insertion: int
+
+
 @dataclass(frozen=True, slots=True)
 class _RankRow:
     """Promotion-candidate fields needed only to order and cap the drain.
@@ -126,7 +141,7 @@ class _RankRow:
     job_id: JobName
     num_tasks: int
     has_coscheduling: bool
-    sort_key: tuple[int, int, int, int]
+    sort_key: _PriorityKey
 
 
 _RANK_COLS = (
@@ -142,11 +157,7 @@ _RANK_COLS = (
 
 
 def _ranking_rows(cur: Tx, *predicates) -> list[_RankRow]:
-    """Fetch lightweight :class:`_RankRow`s (no runtime blobs) for the given predicates.
-
-    ``sort_key`` mirrors the worker-daemon sort (``reads._PENDING_TASKS_STMT``):
-    parent depth, root submission, own submission, insertion.
-    """
+    """Fetch lightweight :class:`_RankRow`s (no runtime blobs) for the given predicates."""
     rank_join = local_tasks.join(jobs_table, jobs_table.c.job_id == local_tasks.c.job_id).join(
         job_config_table, job_config_table.c.job_id == jobs_table.c.job_id
     )
@@ -157,11 +168,11 @@ def _ranking_rows(cur: Tx, *predicates) -> list[_RankRow]:
             job_id=r.job_id,
             num_tasks=int(r.num_tasks),
             has_coscheduling=bool(r.has_coscheduling),
-            sort_key=(
-                int(r.priority_neg_depth),
-                int(r.priority_root_submitted_ms),
-                int(r.submitted_at_ms.epoch_ms()),
-                int(r.priority_insertion),
+            sort_key=_PriorityKey(
+                neg_depth=int(r.priority_neg_depth),
+                root_submitted_ms=int(r.priority_root_submitted_ms),
+                submitted_ms=int(r.submitted_at_ms.epoch_ms()),
+                insertion=int(r.priority_insertion),
             ),
         )
         for r in cur.execute(stmt).all()

--- a/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
@@ -100,12 +100,11 @@ def build_run_request(
 
 
 def _dispatch_query(cur: Tx, *predicates) -> list[PendingDispatchRow]:
-    """Fetch :class:`PendingDispatchRow`s for the direct-provider drain.
+    """Fetch full :class:`PendingDispatchRow`s (with the runtime config blobs).
 
-    Both drain queries (PENDING promotion, ASSIGNED redrive) select
-    ``PENDING_DISPATCH_COLS`` over the tasks⋈jobs⋈job_config join and supply
-    their distinct state predicate; ordering and the rate cap are applied in
-    Python by :func:`_rank_promotion_units` and the drain loop.
+    Used for the ASSIGNED-redrive set and, keyed by the already-chosen task ids,
+    for the PENDING rows the rate cap actually promotes. Ranking runs first on
+    :func:`_ranking_rows`, which omits the heavy JSON columns.
     """
     dispatch_join = local_tasks.join(jobs_table, jobs_table.c.job_id == local_tasks.c.job_id).join(
         job_config_table, job_config_table.c.job_id == jobs_table.c.job_id
@@ -114,22 +113,63 @@ def _dispatch_query(cur: Tx, *predicates) -> list[PendingDispatchRow]:
     return [pending_dispatch_row(r) for r in cur.execute(stmt).all()]
 
 
-def _unit_sort_key(unit: list[PendingDispatchRow]) -> tuple[int, int, int, int]:
-    """Hierarchy/submission ordering key for a promotion unit.
+@dataclass(frozen=True, slots=True)
+class _RankRow:
+    """Promotion-candidate fields needed only to order and cap the drain.
 
-    Mirrors the worker-daemon sort (``reads._PENDING_TASKS_STMT``): parent depth,
-    then root submission, then own submission, then insertion. A coscheduled gang
-    shares one job, so its members' keys agree except on insertion; the minimum
-    anchors the whole gang at its earliest sibling.
+    Deliberately excludes the ``PENDING_DISPATCH_COLS`` runtime blobs so a capped
+    cycle ranks every pending task cheaply and loads the full row for just the
+    winners.
     """
-    return min(
-        (row.priority_neg_depth, row.priority_root_submitted_ms, row.priority_submitted_ms, row.priority_insertion)
-        for row in unit
+
+    task_id: JobName
+    job_id: JobName
+    num_tasks: int
+    has_coscheduling: bool
+    sort_key: tuple[int, int, int, int]
+
+
+_RANK_COLS = (
+    local_tasks.c.task_id,
+    local_tasks.c.job_id,
+    jobs_table.c.num_tasks,
+    job_config_table.c.has_coscheduling,
+    local_tasks.c.priority_neg_depth,
+    local_tasks.c.priority_root_submitted_ms,
+    local_tasks.c.submitted_at_ms,
+    local_tasks.c.priority_insertion,
+)
+
+
+def _ranking_rows(cur: Tx, *predicates) -> list[_RankRow]:
+    """Fetch lightweight :class:`_RankRow`s (no runtime blobs) for the given predicates.
+
+    ``sort_key`` mirrors the worker-daemon sort (``reads._PENDING_TASKS_STMT``):
+    parent depth, root submission, own submission, insertion.
+    """
+    rank_join = local_tasks.join(jobs_table, jobs_table.c.job_id == local_tasks.c.job_id).join(
+        job_config_table, job_config_table.c.job_id == jobs_table.c.job_id
     )
+    stmt = select(*_RANK_COLS).select_from(rank_join).where(*predicates)
+    return [
+        _RankRow(
+            task_id=r.task_id,
+            job_id=r.job_id,
+            num_tasks=int(r.num_tasks),
+            has_coscheduling=bool(r.has_coscheduling),
+            sort_key=(
+                int(r.priority_neg_depth),
+                int(r.priority_root_submitted_ms),
+                int(r.submitted_at_ms.epoch_ms()),
+                int(r.priority_insertion),
+            ),
+        )
+        for r in cur.execute(stmt).all()
+    ]
 
 
-def _build_promotion_units(pending: list[PendingDispatchRow]) -> list[list[PendingDispatchRow]]:
-    """Group PENDING dispatch rows into atomic promotion units.
+def _build_promotion_units(candidates: list[_RankRow]) -> list[list[_RankRow]]:
+    """Group PENDING candidates into atomic promotion units.
 
     Non-coscheduled tasks are singleton units. Coscheduled tasks are grouped by
     job into gangs; a gang becomes a unit only once every sibling is PENDING
@@ -137,9 +177,9 @@ def _build_promotion_units(pending: list[PendingDispatchRow]) -> list[list[Pendi
     never waits on pods Iris deferred. A partially-assembled gang is dropped this
     cycle and reconsidered next.
     """
-    units: list[list[PendingDispatchRow]] = []
-    gangs: dict[JobName, list[PendingDispatchRow]] = {}
-    for row in pending:
+    units: list[list[_RankRow]] = []
+    gangs: dict[JobName, list[_RankRow]] = {}
+    for row in candidates:
         if row.has_coscheduling:
             gangs.setdefault(row.job_id, []).append(row)
         else:
@@ -151,27 +191,58 @@ def _build_promotion_units(pending: list[PendingDispatchRow]) -> list[list[Pendi
 
 
 def _rank_promotion_units(
-    units: list[list[PendingDispatchRow]],
+    units: list[list[_RankRow]],
     effective_bands: dict[JobName, int],
     user_spend: dict[str, int],
-) -> list[list[PendingDispatchRow]]:
-    """Order promotion units by effective band, then worker-daemon fairness.
+) -> list[list[_RankRow]]:
+    """Order promotion units by effective band, then per-user fairness.
 
-    Units are bucketed by their job's effective band and emitted in ascending
-    band order (PRODUCTION first). Within a band they are sorted by the
-    hierarchy/submission key, then round-robined across users by ascending spend
-    — matching ``scheduling.policy.compute_scheduling_order`` so the direct and
-    worker-daemon paths agree on ordering.
+    Buckets by the job's effective band (ascending: PRODUCTION first); within a
+    band, sorts by the hierarchy/submission key and round-robins across users by
+    ascending spend. A gang is one atomic unit, so it takes a single round-robin
+    turn rather than one per task.
     """
-    by_band: dict[int, list[list[PendingDispatchRow]]] = defaultdict(list)
+    by_band: dict[int, list[list[_RankRow]]] = defaultdict(list)
     for unit in units:
         by_band[effective_bands[unit[0].job_id]].append(unit)
-    ranked: list[list[PendingDispatchRow]] = []
+    ranked: list[list[_RankRow]] = []
     for band in sorted(by_band):
-        band_units = sorted(by_band[band], key=_unit_sort_key)
+        band_units = sorted(by_band[band], key=lambda unit: min(row.sort_key for row in unit))
         user_units = [UserTask(user_id=unit[0].task_id.user, task=unit) for unit in band_units]
         ranked.extend(interleave_by_user(user_units, user_spend))
     return ranked
+
+
+def _select_within_cap(
+    ranked: list[list[_RankRow]],
+    effective_bands: dict[JobName, int],
+    max_promotions: int,
+) -> list[list[_RankRow]]:
+    """Take units from the ranked list up to the ``max_promotions`` cap.
+
+    A unit fits when it is no larger than the remaining budget. An oversized gang
+    (larger than the cap itself) is promoted whole, since a partial pod group
+    would leave Kueue waiting forever. A gang that fits the cap but not the
+    remaining budget defers whole and records its band as a barrier: later units
+    in the same band may still fill the budget, but nothing from a worse band may
+    promote ahead of the deferred better-band gang — reaching such a unit ends the
+    cycle. This bounds waste to same-band fill while keeping cross-band priority.
+    """
+    selected: list[list[_RankRow]] = []
+    promoted = 0
+    barrier_band: int | None = None
+    for unit in ranked:
+        if promoted >= max_promotions:
+            break
+        band = effective_bands[unit[0].job_id]
+        if barrier_band is not None and band > barrier_band:
+            break
+        if len(unit) <= max_promotions - promoted or len(unit) > max_promotions:
+            selected.append(unit)
+            promoted += len(unit)
+        elif barrier_band is None:
+            barrier_band = band
+    return selected
 
 
 def drain_for_dispatch(
@@ -229,52 +300,34 @@ def drain_for_dispatch(
     )
 
     effective_bands: dict[JobName, int] = {}
-    rows_to_promote: list[PendingDispatchRow] = []
+    promote_units: list[list[_RankRow]] = []
     if max_promotions > 0:
-        # Rank every PENDING candidate by effective band before the rate cap.
-        # The whole set is fetched (no SQL limit) so band ordering, not row
-        # insertion order, decides what the bounded budget promotes.
-        pending = _dispatch_query(
-            cur,
-            local_tasks.c.state == int(job_pb2.TASK_STATE_PENDING),
-            *backend_pred,
-        )
-        job_ids = {row.job_id for row in pending}
-        resolved_bands = reads.get_priority_bands(cur, job_ids)
-        user_spend = compute_user_spend(cur)
-        user_budget_limits = reads.get_all_user_budget_limits(cur)
-        effective_bands = {
-            job_id: compute_effective_band(resolved_bands[job_id], job_id.user, user_spend, user_budget_limits, defaults)
-            for job_id in job_ids
-        }
-        units = _rank_promotion_units(_build_promotion_units(pending), effective_bands, user_spend)
+        candidates = _ranking_rows(cur, local_tasks.c.state == int(job_pb2.TASK_STATE_PENDING), *backend_pred)
+        if candidates:
+            job_ids = {row.job_id for row in candidates}
+            resolved_bands = reads.get_priority_bands(cur, job_ids)
+            user_spend = compute_user_spend(cur)
+            user_budget_limits = reads.get_all_user_budget_limits(cur)
+            effective_bands = {
+                job_id: compute_effective_band(
+                    resolved_bands[job_id], job_id.user, user_spend, user_budget_limits, defaults
+                )
+                for job_id in job_ids
+            }
+            units = _rank_promotion_units(_build_promotion_units(candidates), effective_bands, user_spend)
+            promote_units = _select_within_cap(units, effective_bands, max_promotions)
 
-        promoted_count = 0
-        for unit in units:
-            remaining = max_promotions - promoted_count
-            if remaining <= 0:
-                break
-            if len(unit) <= remaining or len(unit) > max_promotions:
-                # Fits this cycle, or an oversized gang (larger than the cap
-                # itself) promoted whole to avoid a permanent deadlock: Kueue
-                # only admits a pod group once every sibling pod exists, so a
-                # gang split across cycles would wait forever.
-                rows_to_promote.extend(unit)
-                promoted_count += len(unit)
-            else:
-                # A coscheduled gang that fits the cap but not this cycle's
-                # remaining budget defers whole. Stop here rather than promote a
-                # lower-ranked unit ahead of it — that would invert priority
-                # across the band boundary. A later cycle with fuller budget
-                # promotes the gang atomically.
-                break
-
-    for row in rows_to_promote:
-        band = effective_bands[row.job_id]
-        row = replace(row, priority_band=band)
-        attempt_id = row.current_attempt_id + 1
-        writes.promote_for_dispatch(cur, row.task_id, attempt_id, now_ms, priority_band=band)
-        tasks_to_run.append(build_run_request(cur, row, attempt_id))
+    # Load the runtime blobs for only the promoted rows, then stamp the effective
+    # band and build a request per row, keeping the ranked order.
+    promote_ids = [row.task_id for unit in promote_units for row in unit]
+    if promote_ids:
+        heavy = {row.task_id: row for row in _dispatch_query(cur, local_tasks.c.task_id.in_(promote_ids))}
+        for task_id in promote_ids:
+            band = effective_bands[heavy[task_id].job_id]
+            row = replace(heavy[task_id], priority_band=band)
+            attempt_id = row.current_attempt_id + 1
+            writes.promote_for_dispatch(cur, row.task_id, attempt_id, now_ms, priority_band=band)
+            tasks_to_run.append(build_run_request(cur, row, attempt_id))
 
     # Redrive: pods for these rows may not exist yet (crash between
     # assign-commit and apply, or apply errored last cycle). `kubectl

--- a/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
@@ -144,24 +144,25 @@ class _RankRow:
     sort_key: _PriorityKey
 
 
-_RANK_COLS = (
-    local_tasks.c.task_id,
-    local_tasks.c.job_id,
-    jobs_table.c.num_tasks,
-    job_config_table.c.has_coscheduling,
-    local_tasks.c.priority_neg_depth,
-    local_tasks.c.priority_root_submitted_ms,
-    local_tasks.c.submitted_at_ms,
-    local_tasks.c.priority_insertion,
-)
-
-
 def _ranking_rows(cur: Tx, *predicates) -> list[_RankRow]:
     """Fetch lightweight :class:`_RankRow`s (no runtime blobs) for the given predicates."""
     rank_join = local_tasks.join(jobs_table, jobs_table.c.job_id == local_tasks.c.job_id).join(
         job_config_table, job_config_table.c.job_id == jobs_table.c.job_id
     )
-    stmt = select(*_RANK_COLS).select_from(rank_join).where(*predicates)
+    stmt = (
+        select(
+            local_tasks.c.task_id,
+            local_tasks.c.job_id,
+            jobs_table.c.num_tasks,
+            job_config_table.c.has_coscheduling,
+            local_tasks.c.priority_neg_depth,
+            local_tasks.c.priority_root_submitted_ms,
+            local_tasks.c.submitted_at_ms,
+            local_tasks.c.priority_insertion,
+        )
+        .select_from(rank_join)
+        .where(*predicates)
+    )
     return [
         _RankRow(
             task_id=r.task_id,

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -221,7 +221,7 @@ def test_drain_child_priority_uses_explicit_or_inherited_band(state, parent_band
 
 
 # =============================================================================
-# Effective-band budget demotion + priority ordering (issue #7726)
+# Effective-band budget demotion + priority ordering on the K8s dispatch drain
 # =============================================================================
 
 

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -24,7 +24,7 @@ from iris.cluster.controller.reconcile import dispatch
 from iris.cluster.controller.reconcile.snapshot import TaskUpdate
 from iris.cluster.controller.schema import tasks_table
 from iris.cluster.controller.writes import set_user_budget, stamp_backend
-from iris.cluster.types import JobName
+from iris.cluster.types import JobName, UserBudgetDefaults
 from iris.rpc import controller_pb2, job_pb2
 from iris.test_util import FakeStatsTable
 from rigging.timing import RateLimiter, Timestamp
@@ -239,8 +239,8 @@ def _make_test_user_over_budget(state) -> None:
 
 
 def test_drain_demotes_over_budget_user_to_batch(state):
-    """A task promoted for an over-budget user is stamped BATCH — the band the
-    dispatched request, tasks.priority_band, and Kueue priority all mirror."""
+    """An interactive task promoted for an over-budget user drains at BATCH; the
+    dispatched request priority and the stamped tasks.priority_band agree."""
     _make_test_user_over_budget(state)
     [over] = submit_direct_job(state, "over-budget", priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE)
 
@@ -250,6 +250,21 @@ def test_drain_demotes_over_budget_user_to_batch(state):
     [req] = [r for r in batch.tasks_to_run if r.task_id == over.to_wire()]
     assert req.priority == job_pb2.PRIORITY_BAND_BATCH
     assert query_task(state, over).priority_band == job_pb2.PRIORITY_BAND_BATCH
+
+
+def test_drain_demotes_via_default_budget_for_unlisted_user(state):
+    """An unlisted user is demoted by ``UserBudgetDefaults.budget_limit`` (the
+    controller-wide fallback), not only by a per-user budget row."""
+    submit_direct_job(state, "default-spend")
+    with state._db.transaction() as cur:
+        dispatch.drain_for_dispatch(cur)  # active spend, no user_budgets row
+    [over] = submit_direct_job(state, "default-over", priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE)
+
+    with state._db.transaction() as cur:
+        batch = dispatch.drain_for_dispatch(cur, defaults=UserBudgetDefaults(budget_limit=1))
+
+    [req] = [r for r in batch.tasks_to_run if r.task_id == over.to_wire()]
+    assert req.priority == job_pb2.PRIORITY_BAND_BATCH
 
 
 def test_drain_production_immune_to_budget_demotion(state):
@@ -312,6 +327,58 @@ def test_drain_deferred_gang_does_not_invert_lower_band(state):
     assert [r.task_id for r in drained.tasks_to_run] == [prod.to_wire()]
     assert all(query_task(state, t).state == job_pb2.TASK_STATE_PENDING for t in gang)
     assert query_task(state, batch_task).state == job_pb2.TASK_STATE_PENDING
+
+
+def test_drain_deferred_gang_still_fills_same_band(state):
+    """A deferred gang blocks only worse bands: a same-band singleton behind it
+    still fills the remaining budget (the barrier is band-aware, not a full stop)."""
+    [prod] = submit_direct_job(state, "fill-prod", priority_band=job_pb2.PRIORITY_BAND_PRODUCTION)
+    _jid, gang = _submit_cosched(state, "fill-gang", replicas=3, band=job_pb2.PRIORITY_BAND_INTERACTIVE)
+    [single] = submit_direct_job(state, "fill-single", priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE)
+
+    # Cap = 3: PRODUCTION single promotes (remaining 2); the INTERACTIVE gang of 3
+    # cannot fit and defers, but the INTERACTIVE single behind it still fits.
+    with state._db.transaction() as cur:
+        drained = dispatch.drain_for_dispatch(cur, max_promotions=3)
+
+    assert {r.task_id for r in drained.tasks_to_run} == {prod.to_wire(), single.to_wire()}
+    assert all(query_task(state, t).state == job_pb2.TASK_STATE_PENDING for t in gang)
+
+
+def _submit_job_for_user(state, user: str, name: str, *, priority_band: int = 0) -> JobName:
+    """Submit a single-task direct job owned by ``user`` and return its task id."""
+    jid = JobName.root(user, name)
+    req = make_direct_job_request(name, priority_band=priority_band)
+    req.name = jid.to_wire()  # make_direct_job_request roots names at test-user
+    with state._db.transaction() as cur:
+        ops.job.submit(cur, job_id=jid, request=req, ts=Timestamp.now())
+    return jid.task(0)
+
+
+def test_drain_interleaves_users_within_band(state):
+    """Within a band the drain round-robins across users, so a tight cap promotes
+    one task per user rather than draining one user's backlog first."""
+    a1 = _submit_job_for_user(state, "user-a", "a1", priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE)
+    _submit_job_for_user(state, "user-a", "a2", priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE)
+    b1 = _submit_job_for_user(state, "user-b", "b1", priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE)
+    _submit_job_for_user(state, "user-b", "b2", priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE)
+
+    with state._db.transaction() as cur:
+        drained = dispatch.drain_for_dispatch(cur, max_promotions=2)
+
+    assert {r.task_id for r in drained.tasks_to_run} == {a1.to_wire(), b1.to_wire()}
+
+
+def test_drain_orders_same_band_by_submission(state):
+    """Same user and band: the earlier submission wins the single promotion slot,
+    confirming the hierarchy/submission sort key is wired into ranking."""
+    [first] = submit_direct_job(state, "order-first", priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE)
+    submit_direct_job(state, "order-second", priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE)
+
+    with state._db.transaction() as cur:
+        drained = dispatch.drain_for_dispatch(cur, max_promotions=1)
+
+    assert [r.task_id for r in drained.tasks_to_run] == [first.to_wire()]
 
 
 def test_drain_includes_workdir_files(state):

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -23,7 +23,7 @@ from iris.cluster.controller.backend import (
 from iris.cluster.controller.reconcile import dispatch
 from iris.cluster.controller.reconcile.snapshot import TaskUpdate
 from iris.cluster.controller.schema import tasks_table
-from iris.cluster.controller.writes import stamp_backend
+from iris.cluster.controller.writes import set_user_budget, stamp_backend
 from iris.cluster.types import JobName
 from iris.rpc import controller_pb2, job_pb2
 from iris.test_util import FakeStatsTable
@@ -218,6 +218,100 @@ def test_drain_child_priority_uses_explicit_or_inherited_band(state, parent_band
     [child_run_request] = [request for request in batch.tasks_to_run if request.task_id == child_task_id.to_wire()]
     assert child_run_request.priority == expected_band
     assert query_task(state, child_task_id).priority_band == expected_band
+
+
+# =============================================================================
+# Effective-band budget demotion + priority ordering (issue #7726)
+# =============================================================================
+
+
+def _set_user_budget(state, user_id: str, budget_limit: int) -> None:
+    with state._db.transaction() as tx:
+        set_user_budget(tx, user_id, budget_limit, job_pb2.PRIORITY_BAND_INTERACTIVE, Timestamp.now())
+
+
+def _make_test_user_over_budget(state) -> None:
+    """Drain a job to ASSIGNED (active spend) then cap ``test-user`` below it."""
+    submit_direct_job(state, "budget-spend")
+    with state._db.transaction() as cur:
+        dispatch.drain_for_dispatch(cur)
+    _set_user_budget(state, "test-user", budget_limit=1)
+
+
+def test_drain_demotes_over_budget_user_to_batch(state):
+    """A task promoted for an over-budget user is stamped BATCH — the band the
+    dispatched request, tasks.priority_band, and Kueue priority all mirror."""
+    _make_test_user_over_budget(state)
+    [over] = submit_direct_job(state, "over-budget", priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE)
+
+    with state._db.transaction() as cur:
+        batch = dispatch.drain_for_dispatch(cur)
+
+    [req] = [r for r in batch.tasks_to_run if r.task_id == over.to_wire()]
+    assert req.priority == job_pb2.PRIORITY_BAND_BATCH
+    assert query_task(state, over).priority_band == job_pb2.PRIORITY_BAND_BATCH
+
+
+def test_drain_production_immune_to_budget_demotion(state):
+    """PRODUCTION work is never demoted, even for an over-budget user."""
+    _make_test_user_over_budget(state)
+    [prod] = submit_direct_job(state, "prod", priority_band=job_pb2.PRIORITY_BAND_PRODUCTION)
+
+    with state._db.transaction() as cur:
+        batch = dispatch.drain_for_dispatch(cur)
+
+    [req] = [r for r in batch.tasks_to_run if r.task_id == prod.to_wire()]
+    assert req.priority == job_pb2.PRIORITY_BAND_PRODUCTION
+    assert query_task(state, prod).priority_band == job_pb2.PRIORITY_BAND_PRODUCTION
+
+
+def test_drain_ranks_effective_band_before_cap(state):
+    """Under a tight promotion cap, the higher-band task is promoted first even
+    when the lower-band task was submitted earlier."""
+    [batch_task] = submit_direct_job(state, "band-batch", priority_band=job_pb2.PRIORITY_BAND_BATCH)
+    [prod_task] = submit_direct_job(state, "band-prod", priority_band=job_pb2.PRIORITY_BAND_PRODUCTION)
+
+    with state._db.transaction() as cur:
+        drained = dispatch.drain_for_dispatch(cur, max_promotions=1)
+
+    assert [r.task_id for r in drained.tasks_to_run] == [prod_task.to_wire()]
+    assert query_task(state, batch_task).state == job_pb2.TASK_STATE_PENDING
+
+
+def test_drain_redrive_reuses_demoted_band(state):
+    """A redrive reuses the band fixed at promotion even after the budget is
+    lifted, so a demoted attempt does not silently re-promote to a higher band."""
+    _make_test_user_over_budget(state)
+    [over] = submit_direct_job(state, "redrive-demote", priority_band=job_pb2.PRIORITY_BAND_INTERACTIVE)
+    with state._db.transaction() as cur:
+        dispatch.drain_for_dispatch(cur)
+    assert query_task(state, over).priority_band == job_pb2.PRIORITY_BAND_BATCH
+
+    _set_user_budget(state, "test-user", budget_limit=0)  # unlimited; would no longer demote
+    with state._db.transaction() as cur:
+        redriven = dispatch.drain_for_dispatch(cur)
+
+    [req] = [r for r in redriven.tasks_to_run if r.task_id == over.to_wire()]
+    assert req.priority == job_pb2.PRIORITY_BAND_BATCH
+    assert query_task(state, over).priority_band == job_pb2.PRIORITY_BAND_BATCH
+
+
+def test_drain_deferred_gang_does_not_invert_lower_band(state):
+    """A higher-band gang that fits the cap but not the remaining budget defers
+    whole; a lower-band unit must not leapfrog it (no cross-band inversion)."""
+    [prod] = submit_direct_job(state, "no-inv-prod", priority_band=job_pb2.PRIORITY_BAND_PRODUCTION)
+    _jid, gang = _submit_cosched(state, "no-inv-gang", replicas=3, band=job_pb2.PRIORITY_BAND_INTERACTIVE)
+    [batch_task] = submit_direct_job(state, "no-inv-batch", priority_band=job_pb2.PRIORITY_BAND_BATCH)
+
+    # Cap = 3: the PRODUCTION single promotes (remaining 2); the INTERACTIVE gang
+    # of 3 fits the cap but not the remaining budget, so it defers — and the
+    # lower BATCH single behind it stays PENDING rather than jumping the gang.
+    with state._db.transaction() as cur:
+        drained = dispatch.drain_for_dispatch(cur, max_promotions=3)
+
+    assert [r.task_id for r in drained.tasks_to_run] == [prod.to_wire()]
+    assert all(query_task(state, t).state == job_pb2.TASK_STATE_PENDING for t in gang)
+    assert query_task(state, batch_task).state == job_pb2.TASK_STATE_PENDING
 
 
 def test_drain_includes_workdir_files(state):


### PR DESCRIPTION
The K8s direct-dispatch drain resolved a task's ancestor band but never applied the scheduler's budget adjustment, and it selected promotion candidates with a SQL limit before any band ordering. Over-budget interactive work could reach Kueue as interactive, and a rate-capped cycle could expose a lower-band pod ahead of a higher-band one.

Rank every PENDING candidate by effective band -- the ancestor-resolved band after compute_effective_band demotes an over-budget user to BATCH -- then by the worker-daemon hierarchy/submission key and per-user fairness, and apply the promotion cap over that ranked list. The effective band is stamped on tasks.priority_band so RunTaskRequest.priority, the Kueue WorkloadPriorityClass, and the pod PriorityClass agree; a redrive reuses the fixed band even if spend or budget configuration later changes.

Coscheduled gangs stay atomic: an oversized gang (larger than the cap) still promotes whole, and a gang that fits the cap but not the cycle's remaining budget defers whole and stops the cycle rather than let a lower-band unit leapfrog it.

Stacked on #7725 (parent-band inheritance); base this PR against that branch.

Fixes #7726
