### PR TITLE
[ci] Pulumi CI preview improvements

### DIFF
--- a/.github/actions/pulumi-deploy/action.yaml
+++ b/.github/actions/pulumi-deploy/action.yaml
@@ -54,7 +54,7 @@ runs:
       uses: docker/setup-buildx-action@v4
 
     - name: Roll the service
-      uses: pulumi/actions@v6
+      uses: pulumi/actions@v7
       with:
         command: up
         stack-name: ${{ inputs.stack }}

--- a/.github/actions/pulumi-preview/action.yaml
+++ b/.github/actions/pulumi-preview/action.yaml
@@ -1,5 +1,5 @@
 name: "Pulumi preview"
-description: "Preview a stack against the shared iac backend and post the plan as a PR comment: GCP auth, then pulumi preview."
+description: "Preview a stack against the shared iac backend and upload the plan as an artifact for the aggregate PR comment."
 
 inputs:
   stack:
@@ -17,15 +17,9 @@ inputs:
   gcp-project-id:
     description: "GCP project id."
     required: true
-  github-token:
-    description: "Token used to post/update the preview comment on the PR (needs pull-requests: write)."
-    required: true
   uv-sync-args:
     description: "Arguments for the venv sync (stacks whose program imports more than iac widen this)."
     default: "--package marin-iac --extra deploy --frozen"
-  comment-on-pr:
-    description: "Post/update the preview as a PR comment. Set false for non-PR triggers (e.g. workflow_dispatch), which have no PR to comment on."
-    default: "true"
   config-map:
     description: "Optional pulumi/actions config-map JSON applied before preview."
     default: ""
@@ -48,6 +42,8 @@ runs:
       run: uv sync ${{ inputs.uv-sync-args }}
 
     - name: Preview the stack
+      id: preview
+      continue-on-error: true
       uses: pulumi/actions@v6
       env:
         # infra/pulumi's plain `runtime: python` (no `virtualenv:` option) resolves `python3`
@@ -61,6 +57,46 @@ runs:
         work-dir: ${{ inputs.work-dir }}
         cloud-url: gs://marin-iac-state
         diff: true
+        color: never
+        comment-on-pr: false
         config-map: ${{ inputs.config-map }}
-        comment-on-pr: ${{ inputs.comment-on-pr }}
-        github-token: ${{ inputs.github-token }}
+
+    - name: Format preview artifact
+      if: always()
+      shell: bash
+      env:
+        PREVIEW_RAW: ${{ steps.preview.outputs.output }}
+        PREVIEW_OK: ${{ steps.preview.outcome == 'success' }}
+        STACK: ${{ inputs.stack }}
+        OUT_DIR: ${{ github.workspace }}/iac-preview-out
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+        mkdir -p "$OUT_DIR"
+        printf '%s' "${PREVIEW_RAW:-}" > "$OUT_DIR/raw.txt"
+        ok=false
+        if [[ "$PREVIEW_OK" == "true" ]]; then
+          ok=true
+        fi
+        python3 "$ACTION_PATH/format_preview.py" \
+          --stack "$STACK" \
+          --ok "$ok" \
+          --input "$OUT_DIR/raw.txt" \
+          --out-dir "$OUT_DIR"
+
+    - name: Upload preview artifact
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: iac-preview-${{ inputs.stack }}
+        path: |
+          ${{ github.workspace }}/iac-preview-out/meta.json
+          ${{ github.workspace }}/iac-preview-out/diff.txt
+        if-no-files-found: error
+
+    - name: Fail if preview failed
+      if: steps.preview.outcome == 'failure'
+      shell: bash
+      run: |
+        echo "pulumi preview failed for stack ${{ inputs.stack }}" >&2
+        exit 1

--- a/.github/actions/pulumi-preview/action.yaml
+++ b/.github/actions/pulumi-preview/action.yaml
@@ -44,7 +44,7 @@ runs:
     - name: Preview the stack
       id: preview
       continue-on-error: true
-      uses: pulumi/actions@v6
+      uses: pulumi/actions@v7
       env:
         # infra/pulumi's plain `runtime: python` (no `virtualenv:` option) resolves `python3`
         # from PATH, which `uv sync` above does not add to this step's PATH — without this,

--- a/.github/actions/pulumi-preview/assemble_comment.py
+++ b/.github/actions/pulumi-preview/assemble_comment.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from dataclasses import dataclass
 from pathlib import Path
 
 MARKER = "<!-- iac-preview -->"
@@ -17,33 +18,45 @@ _SEVERITY_ICON = {
 }
 
 
-def load_stacks(previews_dir: Path) -> list[dict]:
-    stacks: list[dict] = []
+@dataclass(frozen=True)
+class StackPreview:
+    stack: str
+    severity: str
+    diff: str
+
+
+def load_stacks(previews_dir: Path) -> list[StackPreview]:
+    stacks: list[StackPreview] = []
     for meta_path in sorted(previews_dir.glob("**/meta.json")):
         meta = json.loads(meta_path.read_text(encoding="utf-8"))
         diff_path = meta_path.with_name("diff.txt")
         diff = diff_path.read_text(encoding="utf-8") if diff_path.is_file() else ""
-        stacks.append({"meta": meta, "diff": diff.strip(), "stack": meta["stack"]})
-    stacks.sort(key=lambda item: item["stack"])
+        stacks.append(
+            StackPreview(
+                stack=meta["stack"],
+                severity=meta.get("severity", "error"),
+                diff=diff.strip(),
+            )
+        )
+    stacks.sort(key=lambda item: item.stack)
     return stacks
 
 
-def render_comment(stacks: list[dict]) -> str:
+def render_comment(stacks: list[StackPreview]) -> str:
     lines = [MARKER, "## IaC preview", ""]
     for item in stacks:
-        severity = item["meta"].get("severity", "error")
-        icon = _SEVERITY_ICON.get(severity, "🚨")
-        lines.append(f"- {icon} `{item['stack']}`")
+        icon = _SEVERITY_ICON.get(item.severity, "🚨")
+        lines.append(f"- {icon} `{item.stack}`")
 
     for item in stacks:
-        if not item["diff"]:
+        if not item.diff:
             continue
         lines.append("")
         lines.append("<details>")
-        lines.append(f"<summary>{item['stack']}</summary>")
+        lines.append(f"<summary>{item.stack}</summary>")
         lines.append("")
         lines.append("```diff")
-        lines.append(item["diff"])
+        lines.append(item.diff)
         lines.append("```")
         lines.append("")
         lines.append("</details>")

--- a/.github/actions/pulumi-preview/assemble_comment.py
+++ b/.github/actions/pulumi-preview/assemble_comment.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Assemble one IaC preview PR comment body from per-stack preview artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+MARKER = "<!-- iac-preview -->"
+
+_SEVERITY_ICON = {
+    "none": "✅",
+    "change": "⚠️",
+    "delete": "🚨",
+    "error": "❌",
+}
+
+
+def load_stacks(previews_dir: Path) -> list[dict]:
+    stacks: list[dict] = []
+    for meta_path in sorted(previews_dir.glob("**/meta.json")):
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        diff_path = meta_path.with_name("diff.txt")
+        diff = diff_path.read_text(encoding="utf-8") if diff_path.is_file() else ""
+        stacks.append({"meta": meta, "diff": diff.strip(), "stack": meta["stack"]})
+    stacks.sort(key=lambda item: item["stack"])
+    return stacks
+
+
+def render_comment(stacks: list[dict]) -> str:
+    lines = [MARKER, "## IaC preview", ""]
+    for item in stacks:
+        severity = item["meta"].get("severity", "error")
+        icon = _SEVERITY_ICON.get(severity, "🚨")
+        lines.append(f"- {icon} `{item['stack']}`")
+
+    for item in stacks:
+        if not item["diff"]:
+            continue
+        lines.append("")
+        lines.append("<details>")
+        lines.append(f"<summary>{item['stack']}</summary>")
+        lines.append("")
+        lines.append("```diff")
+        lines.append(item["diff"])
+        lines.append("```")
+        lines.append("")
+        lines.append("</details>")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--previews-dir",
+        type=Path,
+        required=True,
+        help="Directory containing downloaded iac-preview-* artifacts.",
+    )
+    parser.add_argument("--out", type=Path, required=True, help="Write comment body here.")
+    args = parser.parse_args()
+
+    stacks = load_stacks(args.previews_dir)
+    if not stacks:
+        raise SystemExit(f"no preview artifacts under {args.previews_dir}")
+    args.out.write_text(render_comment(stacks), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/pulumi-preview/format_preview.py
+++ b/.github/actions/pulumi-preview/format_preview.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
@@ -20,6 +21,27 @@ _COUNT_RE = re.compile(
     re.IGNORECASE,
 )
 _UNCHANGED_RE = re.compile(r"(\d+)\s+unchanged", re.IGNORECASE)
+
+
+@dataclass
+class ResourceCounts:
+    create: int = 0
+    update: int = 0
+    delete: int = 0
+    replace: int = 0
+    import_: int = 0
+    same: int = 0
+
+    def as_meta(self) -> dict[str, int]:
+        """JSON field names match Pulumi's summary verbs (import, not import_)."""
+        return {
+            "create": self.create,
+            "update": self.update,
+            "delete": self.delete,
+            "replace": self.replace,
+            "import": self.import_,
+            "same": self.same,
+        }
 
 
 def strip_ansi(text: str) -> str:
@@ -47,42 +69,40 @@ def transform_preview(text: str) -> str:
     return "\n".join(transform_line(line) for line in text.splitlines())
 
 
-def parse_counts(text: str) -> dict[str, int]:
-    counts = {
-        "create": 0,
-        "update": 0,
-        "delete": 0,
-        "replace": 0,
-        "import": 0,
-        "same": 0,
-    }
+def parse_counts(text: str) -> ResourceCounts:
+    counts = ResourceCounts()
     if _NO_CHANGES_RE.search(text):
         return counts
     for match in _COUNT_RE.finditer(text):
-        counts[match.group(2).lower()] = int(match.group(1))
+        kind = match.group(2).lower()
+        value = int(match.group(1))
+        if kind == "import":
+            counts.import_ = value
+        else:
+            setattr(counts, kind, value)
     unchanged = _UNCHANGED_RE.findall(text)
     if unchanged:
-        counts["same"] = int(unchanged[-1])
+        counts.same = int(unchanged[-1])
     return counts
 
 
-def severity(ok: bool, counts: dict[str, int]) -> str:
+def severity(ok: bool, counts: ResourceCounts) -> str:
     if not ok:
         return "error"
-    if counts["delete"] > 0:
+    if counts.delete > 0:
         return "delete"
-    if counts["create"] + counts["update"] + counts["replace"] + counts["import"] > 0:
+    if counts.create + counts.update + counts.replace + counts.import_ > 0:
         return "change"
     return "none"
 
 
-def has_resource_changes(counts: dict[str, int]) -> bool:
+def has_resource_changes(counts: ResourceCounts) -> bool:
     return (
-        counts["create"]
-        + counts["update"]
-        + counts["delete"]
-        + counts["replace"]
-        + counts["import"]
+        counts.create
+        + counts.update
+        + counts.delete
+        + counts.replace
+        + counts.import_
     ) > 0
 
 
@@ -118,7 +138,7 @@ def main() -> None:
         "stack": args.stack,
         "ok": ok,
         "severity": sev,
-        **counts,
+        **counts.as_meta(),
     }
     (args.out_dir / "meta.json").write_text(
         json.dumps(meta, indent=2, sort_keys=True) + "\n",

--- a/.github/actions/pulumi-preview/format_preview.py
+++ b/.github/actions/pulumi-preview/format_preview.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Format `pulumi preview --diff` text for a GitHub ```diff PR comment.
+
+Moves Pulumi's indented ``+/-/~`` markers to column 0 so GitHub's diff
+highlighter applies (``~`` becomes ``!``). Also parses change counts into
+meta.json for the aggregate comment's status icons.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+_NO_CHANGES_RE = re.compile(r"Resources:\s*no changes", re.IGNORECASE)
+_COUNT_RE = re.compile(
+    r"(\d+)\s+to\s+(create|update|delete|replace|import)",
+    re.IGNORECASE,
+)
+_UNCHANGED_RE = re.compile(r"(\d+)\s+unchanged", re.IGNORECASE)
+
+
+def strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def transform_line(line: str) -> str:
+    """Put +/-/! at column 0 when the first non-space char is +/-/~."""
+    if not line or line[0] not in " \t":
+        return line
+    stripped = line.lstrip(" \t")
+    if not stripped:
+        return line
+    marker = stripped[0]
+    if marker == "-":
+        return "-" + line[1:]
+    if marker == "+":
+        return "+" + line[1:]
+    if marker == "~":
+        return "!" + line[1:]
+    return line
+
+
+def transform_preview(text: str) -> str:
+    return "\n".join(transform_line(line) for line in text.splitlines())
+
+
+def parse_counts(text: str) -> dict[str, int]:
+    counts = {
+        "create": 0,
+        "update": 0,
+        "delete": 0,
+        "replace": 0,
+        "import": 0,
+        "same": 0,
+    }
+    if _NO_CHANGES_RE.search(text):
+        return counts
+    for match in _COUNT_RE.finditer(text):
+        counts[match.group(2).lower()] = int(match.group(1))
+    unchanged = _UNCHANGED_RE.findall(text)
+    if unchanged:
+        counts["same"] = int(unchanged[-1])
+    return counts
+
+
+def severity(ok: bool, counts: dict[str, int]) -> str:
+    if not ok:
+        return "error"
+    if counts["delete"] > 0:
+        return "delete"
+    if counts["create"] + counts["update"] + counts["replace"] + counts["import"] > 0:
+        return "change"
+    return "none"
+
+
+def has_resource_changes(counts: dict[str, int]) -> bool:
+    return (
+        counts["create"]
+        + counts["update"]
+        + counts["delete"]
+        + counts["replace"]
+        + counts["import"]
+    ) > 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stack", required=True)
+    parser.add_argument(
+        "--ok",
+        required=True,
+        choices=("true", "false"),
+        help="Whether the pulumi preview step succeeded.",
+    )
+    parser.add_argument("--input", type=Path, required=True, help="Raw preview text.")
+    parser.add_argument("--out-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    ok = args.ok == "true"
+    raw = strip_ansi(args.input.read_text(encoding="utf-8", errors="replace"))
+    counts = parse_counts(raw)
+    sev = severity(ok, counts)
+    transformed = transform_preview(raw)
+
+    if not ok:
+        diff_body = transformed.strip() or "pulumi preview failed (no output captured)."
+    elif has_resource_changes(counts):
+        diff_body = transformed.strip()
+    else:
+        diff_body = ""
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    (args.out_dir / "diff.txt").write_text(diff_body, encoding="utf-8")
+    meta = {
+        "stack": args.stack,
+        "ok": ok,
+        "severity": sev,
+        **counts,
+    }
+    (args.out_dir / "meta.json").write_text(
+        json.dumps(meta, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ops-iac-preview.yaml
+++ b/.github/workflows/ops-iac-preview.yaml
@@ -1,7 +1,9 @@
 name: "Ops - IaC preview"
 
-# Posts `pulumi preview` for each affected infra/pulumi (marin-iac) stack as a PR comment.
-# Also runnable via workflow_dispatch (e.g. to check for drift outside a PR)
+# Runs `pulumi preview` for each infra/pulumi (marin-iac) stack in parallel and
+# posts one aggregated PR comment. workflow_dispatch can take an optional PR
+# number to preview that PR's head and comment there; omit it for a drift check
+# against the selected ref with no comment.
 
 on:
   pull_request:
@@ -12,6 +14,11 @@ on:
       - ".github/workflows/ops-iac-preview.yaml"
       - ".github/actions/pulumi-preview/**"
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to preview and comment on (leave empty for drift check only)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -19,6 +26,10 @@ permissions:
 env:
   PULUMI_CI_SERVICE_ACCOUNT: pulumi-ci@hai-gcp-models.iam.gserviceaccount.com
   PULUMI_CI_PROJECT: hai-gcp-models
+  # pull_request → PR head SHA; dispatch+pr_number → that PR's head ref; else the
+  # branch selected in the workflow_dispatch UI (or the triggering commit).
+  IAC_PREVIEW_REF: ${{ github.event.pull_request.head.sha || (inputs.pr_number != '' && format('refs/pull/{0}/head', inputs.pr_number)) || github.sha }}
+  IAC_PREVIEW_PR: ${{ github.event.pull_request.number || inputs.pr_number }}
 
 jobs:
   preview-coreweave:
@@ -30,9 +41,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      pull-requests: write
     concurrency:
-      group: iac-preview-${{ matrix.stack }}-${{ github.event.pull_request.number || github.run_id }}
+      group: iac-preview-${{ matrix.stack }}-${{ env.IAC_PREVIEW_PR || github.run_id }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
@@ -41,6 +51,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          ref: ${{ env.IAC_PREVIEW_REF }}
 
       - name: Write kubeconfig
         run: |
@@ -66,8 +78,6 @@ jobs:
           work-dir: infra/pulumi
           service-account: ${{ env.PULUMI_CI_SERVICE_ACCOUNT }}
           gcp-project-id: ${{ env.PULUMI_CI_PROJECT }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-on-pr: ${{ github.event_name == 'pull_request' }}
 
   preview-gcp:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -76,13 +86,14 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      pull-requests: write
     concurrency:
-      group: iac-preview-marin-${{ github.event.pull_request.number || github.run_id }}
+      group: iac-preview-marin-${{ env.IAC_PREVIEW_PR || github.run_id }}
       cancel-in-progress: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          ref: ${{ env.IAC_PREVIEW_REF }}
 
       - name: Preview marin
         uses: ./.github/actions/pulumi-preview
@@ -91,9 +102,70 @@ jobs:
           work-dir: infra/pulumi
           service-account: ${{ env.PULUMI_CI_SERVICE_ACCOUNT }}
           gcp-project-id: ${{ env.PULUMI_CI_PROJECT }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-on-pr: ${{ github.event_name == 'pull_request' }}
-          # The live GCP resources predate this empty stack. Show their adoption diff instead
-          # of reporting creates that would fail because the names already exist. Remove this
-          # after the first successful `pulumi up` adopts the six resources into the marin stack.
-          config-map: '{"marin-iac:import": {"value": "true"}}'
+
+  comment:
+    if: >-
+      always()
+      && (github.event_name == 'pull_request' || inputs.pr_number != '')
+      && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+    needs: [preview-coreweave, preview-gcp]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ env.IAC_PREVIEW_REF }}
+
+      - name: Download preview artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: iac-preview-*
+          path: iac-previews
+          merge-multiple: false
+
+      - name: Assemble comment body
+        run: |
+          python3 .github/actions/pulumi-preview/assemble_comment.py \
+            --previews-dir iac-previews \
+            --out iac-preview-comment.md
+
+      - name: Upsert sticky PR comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        env:
+          PR_NUMBER: ${{ env.IAC_PREVIEW_PR }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- iac-preview -->';
+            const body = fs.readFileSync('iac-preview-comment.md', 'utf8');
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+            if (!Number.isInteger(issue_number) || issue_number <= 0) {
+              throw new Error(`Invalid PR_NUMBER: ${process.env.PR_NUMBER}`);
+            }
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/ops-iac-preview.yaml
+++ b/.github/workflows/ops-iac-preview.yaml
@@ -26,10 +26,6 @@ permissions:
 env:
   PULUMI_CI_SERVICE_ACCOUNT: pulumi-ci@hai-gcp-models.iam.gserviceaccount.com
   PULUMI_CI_PROJECT: hai-gcp-models
-  # pull_request → PR head SHA; dispatch+pr_number → that PR's head ref; else the
-  # branch selected in the workflow_dispatch UI (or the triggering commit).
-  IAC_PREVIEW_REF: ${{ github.event.pull_request.head.sha || (inputs.pr_number != '' && format('refs/pull/{0}/head', inputs.pr_number)) || github.sha }}
-  IAC_PREVIEW_PR: ${{ github.event.pull_request.number || inputs.pr_number }}
 
 jobs:
   preview-coreweave:
@@ -42,7 +38,8 @@ jobs:
       contents: read
       id-token: write
     concurrency:
-      group: iac-preview-${{ matrix.stack }}-${{ env.IAC_PREVIEW_PR || github.run_id }}
+      # Job concurrency cannot use the env context.
+      group: iac-preview-${{ matrix.stack }}-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
       cancel-in-progress: true
     strategy:
       fail-fast: false
@@ -52,7 +49,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          ref: ${{ env.IAC_PREVIEW_REF }}
+          ref: ${{ github.event.pull_request.head.sha || (inputs.pr_number != '' && format('refs/pull/{0}/head', inputs.pr_number)) || github.sha }}
 
       - name: Write kubeconfig
         run: |
@@ -87,13 +84,13 @@ jobs:
       contents: read
       id-token: write
     concurrency:
-      group: iac-preview-marin-${{ env.IAC_PREVIEW_PR || github.run_id }}
+      group: iac-preview-marin-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
       cancel-in-progress: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          ref: ${{ env.IAC_PREVIEW_REF }}
+          ref: ${{ github.event.pull_request.head.sha || (inputs.pr_number != '' && format('refs/pull/{0}/head', inputs.pr_number)) || github.sha }}
 
       - name: Preview marin
         uses: ./.github/actions/pulumi-preview
@@ -118,7 +115,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
-          ref: ${{ env.IAC_PREVIEW_REF }}
+          ref: ${{ github.event.pull_request.head.sha || (inputs.pr_number != '' && format('refs/pull/{0}/head', inputs.pr_number)) || github.sha }}
 
       - name: Download preview artifacts
         uses: actions/download-artifact@v8
@@ -136,7 +133,7 @@ jobs:
       - name: Upsert sticky PR comment
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
-          PR_NUMBER: ${{ env.IAC_PREVIEW_PR }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/ops-iac-preview.yaml
+++ b/.github/workflows/ops-iac-preview.yaml
@@ -140,8 +140,11 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const marker = '<!-- iac-preview -->';
             const body = fs.readFileSync('iac-preview-comment.md', 'utf8');
+            const marker = body.split('\n', 1)[0];
+            if (!marker.startsWith('<!--')) {
+              throw new Error(`assemble_comment.py must start the body with an HTML marker; got: ${marker}`);
+            }
             const { owner, repo } = context.repo;
             const issue_number = Number(process.env.PR_NUMBER);
             if (!Number.isInteger(issue_number) || issue_number <= 0) {

--- a/infra/pulumi/README.md
+++ b/infra/pulumi/README.md
@@ -167,7 +167,10 @@ already provisioned:
 
 ## CI preview
 
-`.github/workflows/ops-iac-preview.yaml` posts `pulumi preview` for every stack as a PR comment.
+`.github/workflows/ops-iac-preview.yaml` runs `pulumi preview` for every stack in parallel and
+posts one aggregated PR comment (status list plus per-stack diffs). Manual
+`workflow_dispatch` accepts an optional `pr_number` to preview that PR's head and
+comment there; omit it for a drift check against the selected ref with no comment.
 **CI never runs `pulumi up`** — see `spec.md §9`. It authenticates as
 `pulumi-ci@hai-gcp-models.iam.gserviceaccount.com`, granted preview-only (decrypt/read, never
 write) access in [`infra/permissions`](../permissions/README.md).


### PR DESCRIPTION
- Post one aggregated IaC preview comment per PR instead of one comment per stack.
- Transform indented Pulumi +/-/~ markers to column 0 (+/-/!) so fenced ```diff blocks get GitHub red/green highlighting.
- Top-level status icons for easier reviewing
