### PR TITLE
Surface wrong-architecture image failures in Grafana and Iris

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -45,9 +45,11 @@ GET /k8s/nodes                                    node readiness, cordons, deadl
 GET /k8s/finelog | finelog_events                 mirror pods/PVCs and matching warnings
 GET /k8s/overview                                 explicit pending/crashloop counts
 GET /k8s/gpu_racks                                GPU nodes grouped by physical rack: trays total/ready
+GET /k8s/arch_mismatch                            containers killed by an exec-format failure on a non-amd64 node
 GET /k8s/alerts/{unreachable,crashloops,          alert rows: string labels + one
-     webhook_ready,degraded,node_deadlocks,        numeric; gpu_rack_trays omits rows for
-     stuck_gpu_pods,gpu_rack_trays}                a cluster it cannot reach, others zero
+     webhook_ready,degraded,node_deadlocks,       numeric; gpu_rack_trays omits rows for
+     stuck_gpu_pods,gpu_rack_trays,               a cluster it cannot reach, others zero
+     arch_mismatch}
 GET /health                                       bridge liveness
 ```
 

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -261,13 +261,13 @@ groups:
         labels:
           severity: warning
         annotations:
-          summary: "{{ $labels.cluster }}: {{ $labels.image }} is built for the wrong CPU architecture for node {{ $labels.node }}"
+          summary: "{{ $labels.cluster }}: containers from {{ $labels.image }} died instantly on {{ $labels.node }}"
           description: >-
-            Containers on this node exited 255 immediately, the runtime's signature for
-            "exec format error" — an amd64 image on an arm64 GPU node. The image tag has
-            probably lost its arm64 manifest, or the node holds a stale amd64 copy that
-            imagePullPolicy IfNotPresent will never refresh.
-          runbook_url: https://github.com/marin-community/marin/blob/main/lib/iris/OPS.md
+            Containers exited 255 in under a second, which is how an image built for the
+            wrong CPU architecture fails. Kubernetes exposes no termination message for it,
+            so this signature is indirect: confirm the tag's manifest and the node's cached
+            copy before acting. The runbook has the commands.
+          runbook_url: https://github.com/marin-community/marin/blob/main/lib/iris/OPS.md#image-architecture-mismatch
         data:
           - refId: A
             relativeTimeRange: { from: 300, to: 0 }

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -252,6 +252,50 @@ groups:
               conditions:
                 - evaluator: { type: gt, params: [0] }
 
+      - uid: k8s-arch-mismatch-image
+        title: ArchMismatchImageExecuted
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.cluster }}: {{ $labels.image }} is built for the wrong CPU architecture for node {{ $labels.node }}"
+          description: >-
+            Containers on this node exited 255 immediately, the runtime's signature for
+            "exec format error" — an amd64 image on an arm64 GPU node. The image tag has
+            probably lost its arm64 manifest, or the node holds a stale amd64 copy that
+            imagePullPolicy IfNotPresent will never refresh.
+          runbook_url: https://github.com/marin-community/marin/blob/main/lib/iris/OPS.md
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: k8s
+            model:
+              refId: A
+              datasource: { type: yesoreyeram-infinity-datasource, uid: k8s }
+              type: json
+              source: url
+              parser: backend
+              format: table
+              url: /alerts/arch_mismatch
+              url_options: { method: GET }
+              columns:
+                - { selector: cluster, text: cluster, type: string }
+                - { selector: node, text: node, type: string }
+                - { selector: image, text: image, type: string }
+                - { selector: value, text: value, type: number }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
       - uid: k8s-gpu-rack-trays-low
         title: GpuRackTraysBelowMinimum
         condition: C

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -263,10 +263,11 @@ groups:
         annotations:
           summary: "{{ $labels.cluster }}: containers from {{ $labels.image }} died instantly on {{ $labels.node }}"
           description: >-
-            Containers exited 255 in under a second, which is how an image built for the
-            wrong CPU architecture fails. Kubernetes exposes no termination message for it,
-            so this signature is indirect: confirm the tag's manifest and the node's cached
-            copy before acting. The runbook has the commands.
+            Containers died the way an image built for the wrong CPU architecture dies.
+            Check the evidence column on /k8s/arch_mismatch: "message" means the kubelet
+            recorded the runtime's "exec format error" and the mismatch is confirmed,
+            while "signature" means only exit 255 in under a second, which an unrelated
+            instant failure also produces. The runbook has the confirmation commands.
           runbook_url: https://github.com/marin-community/marin/blob/main/lib/iris/OPS.md#image-architecture-mismatch
         data:
           - refId: A

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -85,21 +85,29 @@ _GB200_INSTANCE_TYPE_SUBSTRING = "gb200"
 BACKOFF_REASONS = ("CrashLoopBackOff", "ImagePullBackOff")
 
 # An image built for the wrong CPU architecture fails at exec, not at pull, and the
-# kubelet records no distinct reason for it: the runtime's "exec format error" reaches
-# the pod log but not the API. terminationMessagePolicy is File by default, so the
-# termination record carries no message either — 28 of 4834 terminated records on
-# cw-us-east-08a had one, and the record from the 2026-07-29 incident did not.
+# kubelet records no distinct reason for it. The runtime's "exec format error" goes to
+# the container log, which reaches the termination record only under
+# terminationMessagePolicy: FallbackToLogsOnError. Verified on cw-us-east-08a by running
+# an amd64 image on an arm64 node under both policies: File left message empty, the
+# fallback policy recorded "exec /bin/echo: exec format error".
 #
-# The scan therefore matches the runtime's observable signature: exit 255, reason
-# Error, and a sub-second runtime. This is indirect. Any program that exits 255
-# immediately matches too, so a row means "a container died the way an arch mismatch
-# dies", not "the image is provably the wrong architecture". Measured against
-# cw-us-east-08a the signature matched 0 of 11182 container statuses across all 208
-# nodes, and it matches the incident record. lib/iris/OPS.md carries the procedure
-# for confirming an actual mismatch.
+# So the scan takes the message when it is there (EVIDENCE_MESSAGE — unambiguous) and
+# otherwise falls back to the runtime signature of exit 255, reason Error, and a
+# sub-second runtime (EVIDENCE_SIGNATURE). The fallback is indirect: any program exiting
+# 255 immediately matches, so such a row means "a container died the way an arch mismatch
+# dies", not proof about the image. Measured against cw-us-east-08a the signature matched
+# 0 of 11182 container statuses across all 208 nodes, and it matches the 2026-07-29
+# incident record. Iris sets the fallback policy on stage-workdir and task, so new
+# failures there carry the message; other workloads keep the default and the signature.
 EXEC_FORMAT_EXIT_CODE = 255
 EXEC_FORMAT_MAX_RUNTIME_SECONDS = 1
 _EXEC_FORMAT_REASON = "Error"
+_EXEC_FORMAT_MESSAGE = "exec format error"
+
+# Which of the two tests matched, reported per row so an operator can tell a proven
+# mismatch from a lookalike without re-deriving it.
+EVIDENCE_MESSAGE = "message"
+EVIDENCE_SIGNATURE = "signature"
 
 # How far back a terminated container still counts as evidence. Failed pods linger
 # until garbage collection, so without a window one morning's bad image would keep
@@ -584,9 +592,10 @@ class K8sSource:
             if not node_arch:
                 continue
             for status in _container_statuses(pod):
-                terminated = _exec_format_termination(status)
-                if terminated is None:
+                match = _exec_format_termination(status)
+                if match is None:
                     continue
+                terminated, evidence = match
                 age = _age_seconds_or_none(terminated.get("finishedAt"))
                 if age is None or age > ARCH_MISMATCH_LOOKBACK_SECONDS:
                     continue
@@ -599,6 +608,7 @@ class K8sSource:
                         "node_arch": node_arch,
                         "image": status.get("image") or "",
                         "image_id": status.get("imageID") or "",
+                        "evidence": evidence,
                         "exit_code": terminated.get("exitCode"),
                         "finished_at": _epoch_ms(terminated.get("finishedAt")),
                         "age_seconds": age,
@@ -782,10 +792,14 @@ def _terminated_runtime_seconds(terminated: dict) -> float | None:
         return None
 
 
-def _exec_format_termination(status: dict) -> dict | None:
-    """Return the termination record matching the exec-format signature, if either state does."""
+def _exec_format_termination(status: dict) -> tuple[dict, str] | None:
+    """Return the matching termination record and which evidence matched, else None."""
     for state_key in ("state", "lastState"):
         terminated = (status.get(state_key) or {}).get("terminated") or {}
+        if not terminated:
+            continue
+        if _EXEC_FORMAT_MESSAGE in (terminated.get("message") or "").lower():
+            return terminated, EVIDENCE_MESSAGE
         if terminated.get("exitCode") != EXEC_FORMAT_EXIT_CODE:
             continue
         if terminated.get("reason") != _EXEC_FORMAT_REASON:
@@ -793,7 +807,7 @@ def _exec_format_termination(status: dict) -> dict | None:
         runtime = _terminated_runtime_seconds(terminated)
         if runtime is None or runtime > EXEC_FORMAT_MAX_RUNTIME_SECONDS:
             continue
-        return terminated
+        return terminated, EVIDENCE_SIGNATURE
     return None
 
 

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -84,22 +84,22 @@ _GB200_INSTANCE_TYPE_SUBSTRING = "gb200"
 # Container waiting reasons the crashloop rows report.
 BACKOFF_REASONS = ("CrashLoopBackOff", "ImagePullBackOff")
 
-# An image built for the wrong CPU architecture fails at exec, not at pull: the
-# kubelet starts the container and the runtime immediately reports
-# "exec format error". Kubernetes surfaces no distinct reason for it, so the
-# arch-mismatch scan matches the runtime's observable signature instead — the
-# container exits 255 with reason Error in under a second. Exit 255 is otherwise
-# unused across the fleet (a Python fault exits 1), and pairing it with a
-# sub-second runtime keeps a genuine 255 from a long-running job out of the rows.
+# An image built for the wrong CPU architecture fails at exec, not at pull, and the
+# kubelet records no distinct reason for it: the runtime's "exec format error" reaches
+# the pod log but not the API. terminationMessagePolicy is File by default, so the
+# termination record carries no message either — 28 of 4834 terminated records on
+# cw-us-east-08a had one, and the record from the 2026-07-29 incident did not.
 #
-# The scan reports a hit only on a node whose architecture is not amd64, because
-# an amd64 image on an amd64 node is correct. On CoreWeave that means the arm64
-# GB200 nodes: they run the same iris-task image tag as the amd64 CPU nodes, so a
-# tag that loses its arm64 manifest breaks only the GPU side of the fleet.
+# The scan therefore matches the runtime's observable signature: exit 255, reason
+# Error, and a sub-second runtime. This is indirect. Any program that exits 255
+# immediately matches too, so a row means "a container died the way an arch mismatch
+# dies", not "the image is provably the wrong architecture". Measured against
+# cw-us-east-08a the signature matched 0 of 11182 container statuses across all 208
+# nodes, and it matches the incident record. lib/iris/OPS.md carries the procedure
+# for confirming an actual mismatch.
 EXEC_FORMAT_EXIT_CODE = 255
 EXEC_FORMAT_MAX_RUNTIME_SECONDS = 1
 _EXEC_FORMAT_REASON = "Error"
-_HOST_ARCH_AMD64 = "amd64"
 
 # How far back a terminated container still counts as evidence. Failed pods linger
 # until garbage collection, so without a window one morning's bad image would keep
@@ -565,7 +565,6 @@ class K8sSource:
         return rows
 
     def node_architectures(self) -> dict[str, str]:
-        """Map node name to its reported CPU architecture (``arm64``, ``amd64``)."""
         architectures = {}
         for node in self._list("/api/v1/nodes"):
             name = (node.get("metadata") or {}).get("name")
@@ -575,20 +574,14 @@ class K8sSource:
         return architectures
 
     def arch_mismatch_containers(self) -> list[dict]:
-        """One row per container that died of an exec-format failure on a non-amd64 node.
-
-        Detection is the runtime signature described at EXEC_FORMAT_EXIT_CODE, scoped
-        to containers that finished inside ARCH_MISMATCH_LOOKBACK_SECONDS. Both the
-        current and previous termination are checked, so a restarting container still
-        reports while its newest state is Waiting. Most recent first.
-        """
+        """One row per container matching the exec-format signature, most recent first."""
         architectures = self.node_architectures()
         rows = []
         for pod in self._scan_pods(None):
             metadata = pod.get("metadata") or {}
             node_name = (pod.get("spec") or {}).get("nodeName") or ""
             node_arch = architectures.get(node_name, "")
-            if not node_arch or node_arch == _HOST_ARCH_AMD64:
+            if not node_arch:
                 continue
             for status in _container_statuses(pod):
                 terminated = _exec_format_termination(status)
@@ -1072,12 +1065,7 @@ class K8sFleet:
         return self._fan_out(deadlocks, lambda _err: [{"node": "", "reason": "", "value": 0}])
 
     def _counts_with_zero_rows(self, counts: dict[tuple[str, ...], int], labels: Sequence[str]) -> list[dict]:
-        """Turn counts keyed by ``(cluster, *labels)`` into alert rows, zero-filling clean clusters.
-
-        Every cluster keeps at least one row so the rule's NoData state stays
-        unreachable, and a cluster with no qualifying evidence reads as zero rather
-        than as a gap.
-        """
+        """Project counts keyed by ``(cluster, *labels)``, keeping one row per cluster so NoData stays unreachable."""
         rows = [
             {"cluster": key[0], **dict(zip(labels, key[1:], strict=True)), "value": count}
             for key, count in sorted(counts.items())
@@ -1091,12 +1079,7 @@ class K8sFleet:
         return rows
 
     def alert_arch_mismatch(self, rows: Sequence[dict] | None = None) -> list[dict]:
-        """Per cluster, node, and image: failed-container count, with zero rows where clean.
-
-        An unreachable cluster contributes its zero row like the other pod-scan alert
-        routes: absence of evidence is not evidence of a mismatch, and
-        K8sClusterUnreachable already pages for the unreachability itself.
-        """
+        """Per cluster, node, and image: matching-container count, zero where clean or unreachable."""
         scanned = list(rows) if rows is not None else self.arch_mismatch_containers()
         counts: dict[tuple[str, ...], int] = {}
         for row in scanned:

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -224,8 +224,8 @@ def _age_seconds(timestamp: str | None) -> int | None:
     return max(int((datetime.now(UTC) - created).total_seconds()), 0)
 
 
-def _deletion_overdue_seconds(timestamp: str) -> int | None:
-    """Return age past a deletion deadline, or None for an invalid deadline."""
+def _age_seconds_or_none(timestamp: str | None) -> int | None:
+    """Seconds since an API timestamp, or None when it is missing or malformed."""
     try:
         return _age_seconds(timestamp)
     except (TypeError, ValueError):
@@ -574,7 +574,7 @@ class K8sSource:
             architectures[name] = ((node.get("status") or {}).get("nodeInfo") or {}).get("architecture") or ""
         return architectures
 
-    def arch_mismatch_pods(self) -> list[dict]:
+    def arch_mismatch_containers(self) -> list[dict]:
         """One row per container that died of an exec-format failure on a non-amd64 node.
 
         Detection is the runtime signature described at EXEC_FORMAT_EXIT_CODE, scoped
@@ -594,7 +594,7 @@ class K8sSource:
                 terminated = _exec_format_termination(status)
                 if terminated is None:
                     continue
-                age = _terminated_age_seconds(terminated)
+                age = _age_seconds_or_none(terminated.get("finishedAt"))
                 if age is None or age > ARCH_MISMATCH_LOOKBACK_SECONDS:
                     continue
                 rows.append(
@@ -626,7 +626,7 @@ class K8sSource:
             deletion_timestamp = metadata.get("deletionTimestamp")
             if not deletion_timestamp:
                 continue
-            overdue_seconds = _deletion_overdue_seconds(deletion_timestamp)
+            overdue_seconds = _age_seconds_or_none(deletion_timestamp)
             if overdue_seconds is not None and overdue_seconds < STUCK_TERMINATION_OVERDUE_SECONDS:
                 continue
             spec = pod.get("spec") or {}
@@ -789,13 +789,6 @@ def _terminated_runtime_seconds(terminated: dict) -> float | None:
         return None
 
 
-def _terminated_age_seconds(terminated: dict) -> int | None:
-    try:
-        return _age_seconds(terminated.get("finishedAt"))
-    except (TypeError, ValueError):
-        return None
-
-
 def _exec_format_termination(status: dict) -> dict | None:
     """Return the termination record matching the exec-format signature, if either state does."""
     for state_key in ("state", "lastState"):
@@ -947,8 +940,8 @@ class K8sFleet:
     def gpu_racks(self) -> list[dict]:
         return self._fan_out(lambda s: s.gpu_racks(), self._error_row)
 
-    def arch_mismatch_pods(self) -> list[dict]:
-        return self._fan_out(lambda s: s.arch_mismatch_pods(), self._error_row)
+    def arch_mismatch_containers(self) -> list[dict]:
+        return self._fan_out(lambda s: s.arch_mismatch_containers(), self._error_row)
 
     def finelog_health(self) -> list[FinelogHealth]:
         """One health row per k8s finelog mirror, including API failures."""
@@ -1078,6 +1071,25 @@ class K8sFleet:
 
         return self._fan_out(deadlocks, lambda _err: [{"node": "", "reason": "", "value": 0}])
 
+    def _counts_with_zero_rows(self, counts: dict[tuple[str, ...], int], labels: Sequence[str]) -> list[dict]:
+        """Turn counts keyed by ``(cluster, *labels)`` into alert rows, zero-filling clean clusters.
+
+        Every cluster keeps at least one row so the rule's NoData state stays
+        unreachable, and a cluster with no qualifying evidence reads as zero rather
+        than as a gap.
+        """
+        rows = [
+            {"cluster": key[0], **dict(zip(labels, key[1:], strict=True)), "value": count}
+            for key, count in sorted(counts.items())
+        ]
+        affected = {key[0] for key in counts}
+        rows.extend(
+            {"cluster": source.target.name, **dict.fromkeys(labels, ""), "value": 0}
+            for source in self._sources
+            if source.target.name not in affected
+        )
+        return rows
+
     def alert_arch_mismatch(self, rows: Sequence[dict] | None = None) -> list[dict]:
         """Per cluster, node, and image: failed-container count, with zero rows where clean.
 
@@ -1085,56 +1097,24 @@ class K8sFleet:
         routes: absence of evidence is not evidence of a mismatch, and
         K8sClusterUnreachable already pages for the unreachability itself.
         """
-        scanned = list(rows) if rows is not None else self.arch_mismatch_pods()
-        counts: dict[tuple[str, str, str], int] = {}
+        scanned = list(rows) if rows is not None else self.arch_mismatch_containers()
+        counts: dict[tuple[str, ...], int] = {}
         for row in scanned:
             if row.get("error_class"):
                 continue
             key = (row.get("cluster") or "", row.get("node") or "", row.get("image") or "")
             counts[key] = counts.get(key, 0) + 1
-
-        alert_rows = [
-            {"cluster": cluster, "node": node, "image": image, "value": count}
-            for (cluster, node, image), count in sorted(counts.items())
-        ]
-        affected = {cluster for cluster, _, _ in counts}
-        alert_rows.extend(
-            {"cluster": source.target.name, "node": "", "image": "", "value": 0}
-            for source in self._sources
-            if source.target.name not in affected
-        )
-        return alert_rows
+        return self._counts_with_zero_rows(counts, ("node", "image"))
 
     def alert_stuck_gpu_pods(self, candidates: Sequence[TerminatingPodResult] | None = None) -> list[dict]:
         """Return node-grouped counts plus zero rows where no qualifying evidence exists."""
         rows = list(candidates) if candidates is not None else self.termination_candidates()
-        by_node: dict[tuple[str, str], int] = {}
+        counts: dict[tuple[str, ...], int] = {}
         for row in rows:
             if not isinstance(row, TerminatingPod):
                 continue
             if row.classification != TerminationClass.NODE_CLEANUP or row.gpu_count <= 0:
                 continue
             key = (row.cluster, row.node)
-            by_node[key] = by_node.get(key, 0) + 1
-
-        alert_rows = []
-        affected_clusters = set()
-        for (cluster, node), count in sorted(by_node.items()):
-            affected_clusters.add(cluster)
-            alert_rows.append(
-                {
-                    "cluster": cluster,
-                    "node": node,
-                    "value": count,
-                }
-            )
-        for source in self._sources:
-            if source.target.name not in affected_clusters:
-                alert_rows.append(
-                    {
-                        "cluster": source.target.name,
-                        "node": "",
-                        "value": 0,
-                    }
-                )
-        return alert_rows
+            counts[key] = counts.get(key, 0) + 1
+        return self._counts_with_zero_rows(counts, ("node",))

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -84,6 +84,28 @@ _GB200_INSTANCE_TYPE_SUBSTRING = "gb200"
 # Container waiting reasons the crashloop rows report.
 BACKOFF_REASONS = ("CrashLoopBackOff", "ImagePullBackOff")
 
+# An image built for the wrong CPU architecture fails at exec, not at pull: the
+# kubelet starts the container and the runtime immediately reports
+# "exec format error". Kubernetes surfaces no distinct reason for it, so the
+# arch-mismatch scan matches the runtime's observable signature instead — the
+# container exits 255 with reason Error in under a second. Exit 255 is otherwise
+# unused across the fleet (a Python fault exits 1), and pairing it with a
+# sub-second runtime keeps a genuine 255 from a long-running job out of the rows.
+#
+# The scan reports a hit only on a node whose architecture is not amd64, because
+# an amd64 image on an amd64 node is correct. On CoreWeave that means the arm64
+# GB200 nodes: they run the same iris-task image tag as the amd64 CPU nodes, so a
+# tag that loses its arm64 manifest breaks only the GPU side of the fleet.
+EXEC_FORMAT_EXIT_CODE = 255
+EXEC_FORMAT_MAX_RUNTIME_SECONDS = 1
+_EXEC_FORMAT_REASON = "Error"
+_HOST_ARCH_AMD64 = "amd64"
+
+# How far back a terminated container still counts as evidence. Failed pods linger
+# until garbage collection, so without a window one morning's bad image would keep
+# the alert firing for as long as its pods survive.
+ARCH_MISMATCH_LOOKBACK_SECONDS = 3600
+
 # Crashloop scope labels: pods of a watched component vs everything else. The alert
 # rules filter on these values (the crashloops rule pages only on SCOPE_CONTROL_PLANE).
 SCOPE_CONTROL_PLANE = "control-plane"
@@ -542,6 +564,56 @@ class K8sSource:
         rows.sort(key=lambda row: row["age_seconds"] or 0, reverse=True)
         return rows
 
+    def node_architectures(self) -> dict[str, str]:
+        """Map node name to its reported CPU architecture (``arm64``, ``amd64``)."""
+        architectures = {}
+        for node in self._list("/api/v1/nodes"):
+            name = (node.get("metadata") or {}).get("name")
+            if not name:
+                continue
+            architectures[name] = ((node.get("status") or {}).get("nodeInfo") or {}).get("architecture") or ""
+        return architectures
+
+    def arch_mismatch_pods(self) -> list[dict]:
+        """One row per container that died of an exec-format failure on a non-amd64 node.
+
+        Detection is the runtime signature described at EXEC_FORMAT_EXIT_CODE, scoped
+        to containers that finished inside ARCH_MISMATCH_LOOKBACK_SECONDS. Both the
+        current and previous termination are checked, so a restarting container still
+        reports while its newest state is Waiting. Most recent first.
+        """
+        architectures = self.node_architectures()
+        rows = []
+        for pod in self._scan_pods(None):
+            metadata = pod.get("metadata") or {}
+            node_name = (pod.get("spec") or {}).get("nodeName") or ""
+            node_arch = architectures.get(node_name, "")
+            if not node_arch or node_arch == _HOST_ARCH_AMD64:
+                continue
+            for status in _container_statuses(pod):
+                terminated = _exec_format_termination(status)
+                if terminated is None:
+                    continue
+                age = _terminated_age_seconds(terminated)
+                if age is None or age > ARCH_MISMATCH_LOOKBACK_SECONDS:
+                    continue
+                rows.append(
+                    {
+                        "namespace": metadata.get("namespace") or "",
+                        "pod": metadata.get("name") or "",
+                        "container": status.get("name") or "",
+                        "node": node_name,
+                        "node_arch": node_arch,
+                        "image": status.get("image") or "",
+                        "image_id": status.get("imageID") or "",
+                        "exit_code": terminated.get("exitCode"),
+                        "finished_at": _epoch_ms(terminated.get("finishedAt")),
+                        "age_seconds": age,
+                    }
+                )
+        rows.sort(key=lambda row: row["age_seconds"])
+        return rows
+
     def termination_candidates(self) -> list[TerminatingPod]:
         """Return overdue terminating pods and invalid deletion timestamps.
 
@@ -706,6 +778,39 @@ def _container_statuses(pod: dict) -> list[dict]:
     return list(status.get("initContainerStatuses") or []) + list(status.get("containerStatuses") or [])
 
 
+def _terminated_runtime_seconds(terminated: dict) -> float | None:
+    """Wall-clock seconds the container ran, or None when either timestamp is unusable."""
+    started, finished = terminated.get("startedAt"), terminated.get("finishedAt")
+    if not started or not finished:
+        return None
+    try:
+        return (datetime.fromisoformat(finished) - datetime.fromisoformat(started)).total_seconds()
+    except (TypeError, ValueError):
+        return None
+
+
+def _terminated_age_seconds(terminated: dict) -> int | None:
+    try:
+        return _age_seconds(terminated.get("finishedAt"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _exec_format_termination(status: dict) -> dict | None:
+    """Return the termination record matching the exec-format signature, if either state does."""
+    for state_key in ("state", "lastState"):
+        terminated = (status.get(state_key) or {}).get("terminated") or {}
+        if terminated.get("exitCode") != EXEC_FORMAT_EXIT_CODE:
+            continue
+        if terminated.get("reason") != _EXEC_FORMAT_REASON:
+            continue
+        runtime = _terminated_runtime_seconds(terminated)
+        if runtime is None or runtime > EXEC_FORMAT_MAX_RUNTIME_SECONDS:
+            continue
+        return terminated
+    return None
+
+
 def _pod_condition(pod: dict, condition_type: str) -> dict:
     for condition in (pod.get("status") or {}).get("conditions") or []:
         if condition.get("type") == condition_type:
@@ -842,6 +947,9 @@ class K8sFleet:
     def gpu_racks(self) -> list[dict]:
         return self._fan_out(lambda s: s.gpu_racks(), self._error_row)
 
+    def arch_mismatch_pods(self) -> list[dict]:
+        return self._fan_out(lambda s: s.arch_mismatch_pods(), self._error_row)
+
     def finelog_health(self) -> list[FinelogHealth]:
         """One health row per k8s finelog mirror, including API failures."""
 
@@ -969,6 +1077,33 @@ class K8sFleet:
             return rows or [{"node": "", "reason": "", "value": 0}]
 
         return self._fan_out(deadlocks, lambda _err: [{"node": "", "reason": "", "value": 0}])
+
+    def alert_arch_mismatch(self, rows: Sequence[dict] | None = None) -> list[dict]:
+        """Per cluster, node, and image: failed-container count, with zero rows where clean.
+
+        An unreachable cluster contributes its zero row like the other pod-scan alert
+        routes: absence of evidence is not evidence of a mismatch, and
+        K8sClusterUnreachable already pages for the unreachability itself.
+        """
+        scanned = list(rows) if rows is not None else self.arch_mismatch_pods()
+        counts: dict[tuple[str, str, str], int] = {}
+        for row in scanned:
+            if row.get("error_class"):
+                continue
+            key = (row.get("cluster") or "", row.get("node") or "", row.get("image") or "")
+            counts[key] = counts.get(key, 0) + 1
+
+        alert_rows = [
+            {"cluster": cluster, "node": node, "image": image, "value": count}
+            for (cluster, node, image), count in sorted(counts.items())
+        ]
+        affected = {cluster for cluster, _, _ in counts}
+        alert_rows.extend(
+            {"cluster": source.target.name, "node": "", "image": "", "value": 0}
+            for source in self._sources
+            if source.target.name not in affected
+        )
+        return alert_rows
 
     def alert_stuck_gpu_pods(self, candidates: Sequence[TerminatingPodResult] | None = None) -> list[dict]:
         """Return node-grouped counts plus zero rows where no qualifying evidence exists."""

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -42,6 +42,8 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /k8s/alerts/degraded                     alert rows: cluster, component, value(desired-ready)
     GET /k8s/alerts/node_deadlocks                alert rows: cluster, node, reason, value(0|1)
     GET /k8s/alerts/stuck_gpu_pods                alert rows: cluster, node, value(count)
+    GET /k8s/arch_mismatch                        containers killed by exec format error on non-amd64 nodes
+    GET /k8s/alerts/arch_mismatch                 alert rows: cluster, node, image, value(count)
     GET /k8s/alerts/gpu_rack_trays                alert rows: cluster, rack_name, value(trays_ready)
     POST /alerts/loom                             firing Grafana groups become Loom automation runs
     GET /health                                  bridge liveness
@@ -103,6 +105,7 @@ TO_MACRO = "{{to}}"
 LABELS_COLUMN = "labels"
 LABEL_PREFIX = "label_"
 _K8S_TERMINATION_CANDIDATES_CACHE_KEY = "termination_candidates"
+_K8S_ARCH_MISMATCH_CACHE_KEY = "arch_mismatch"
 _K8S_EVENTS_CACHE_KEY = "events"
 _K8S_FINELOG_CACHE_KEY = "finelog"
 _FINELOG_FILTER_TOKEN = "finelog"
@@ -523,6 +526,14 @@ def create_app(
         rows = k8s_cache.get_or_compute(_K8S_TERMINATION_CANDIDATES_CACHE_KEY, k8s_fleet.termination_candidates)
         return JSONResponse(k8s_fleet.alert_stuck_gpu_pods(rows))
 
+    def k8s_arch_mismatch(_: Request) -> JSONResponse:
+        return k8s_endpoint(_K8S_ARCH_MISMATCH_CACHE_KEY, k8s_fleet.arch_mismatch_pods)
+
+    def k8s_alerts_arch_mismatch(_: Request) -> JSONResponse:
+        # Shares the detail scan's cache entry, as stuck_gpu_pods does.
+        rows = k8s_cache.get_or_compute(_K8S_ARCH_MISMATCH_CACHE_KEY, k8s_fleet.arch_mismatch_pods)
+        return JSONResponse(k8s_fleet.alert_arch_mismatch(rows))
+
     def health(_: Request) -> JSONResponse:
         return JSONResponse({"status": "ok", "clusters": sorted(finelog_sources)})
 
@@ -572,6 +583,7 @@ def create_app(
             Route("/k8s/nodes", k8s_nodes),
             Route("/k8s/overview", k8s_overview),
             Route("/k8s/gpu_racks", k8s_gpu_racks),
+            Route("/k8s/arch_mismatch", k8s_arch_mismatch),
             Route("/k8s/alerts/unreachable", k8s_alerts_unreachable),
             Route("/k8s/alerts/crashloops", k8s_alerts_crashloops),
             Route("/k8s/alerts/webhook_ready", k8s_alerts_webhook_ready),
@@ -579,6 +591,7 @@ def create_app(
             Route("/k8s/alerts/node_deadlocks", k8s_alerts_node_deadlocks),
             Route("/k8s/alerts/gpu_rack_trays", k8s_alerts_gpu_rack_trays),
             Route("/k8s/alerts/stuck_gpu_pods", k8s_alerts_stuck_gpu_pods),
+            Route("/k8s/alerts/arch_mismatch", k8s_alerts_arch_mismatch),
         ]
     )
 

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -527,11 +527,11 @@ def create_app(
         return JSONResponse(k8s_fleet.alert_stuck_gpu_pods(rows))
 
     def k8s_arch_mismatch(_: Request) -> JSONResponse:
-        return k8s_endpoint(_K8S_ARCH_MISMATCH_CACHE_KEY, k8s_fleet.arch_mismatch_pods)
+        return k8s_endpoint(_K8S_ARCH_MISMATCH_CACHE_KEY, k8s_fleet.arch_mismatch_containers)
 
     def k8s_alerts_arch_mismatch(_: Request) -> JSONResponse:
         # Shares the detail scan's cache entry, as stuck_gpu_pods does.
-        rows = k8s_cache.get_or_compute(_K8S_ARCH_MISMATCH_CACHE_KEY, k8s_fleet.arch_mismatch_pods)
+        rows = k8s_cache.get_or_compute(_K8S_ARCH_MISMATCH_CACHE_KEY, k8s_fleet.arch_mismatch_containers)
         return JSONResponse(k8s_fleet.alert_arch_mismatch(rows))
 
     def health(_: Request) -> JSONResponse:

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -530,7 +530,6 @@ def create_app(
         return k8s_endpoint(_K8S_ARCH_MISMATCH_CACHE_KEY, k8s_fleet.arch_mismatch_containers)
 
     def k8s_alerts_arch_mismatch(_: Request) -> JSONResponse:
-        # Shares the detail scan's cache entry, as stuck_gpu_pods does.
         rows = k8s_cache.get_or_compute(_K8S_ARCH_MISMATCH_CACHE_KEY, k8s_fleet.arch_mismatch_containers)
         return JSONResponse(k8s_fleet.alert_arch_mismatch(rows))
 

--- a/infra/grafana/tests/conftest.py
+++ b/infra/grafana/tests/conftest.py
@@ -80,6 +80,7 @@ def node(
     ready: bool = True,
     unschedulable: bool = False,
     kernel_deadlock_reason: str = "",
+    arch: str = "arm64",
 ) -> dict:
     labels = {}
     if rack is not None:
@@ -112,6 +113,7 @@ def node(
         "status": {
             "capacity": {"nvidia.com/gpu": str(gpu_capacity)},
             "conditions": conditions,
+            "nodeInfo": {"architecture": arch},
         },
     }
 

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -652,7 +652,7 @@ def _arch_routes(pods: list[dict], *, nodes: list[dict] | None = None) -> dict:
 
 def test_arch_mismatch_reports_exec_format_failures_on_a_non_amd64_node():
     routes = _arch_routes([_exec_format_pod("task-0")])
-    (row,) = make_k8s_source(k8s_api(routes)).arch_mismatch_pods()
+    (row,) = make_k8s_source(k8s_api(routes)).arch_mismatch_containers()
     assert row["pod"] == "task-0"
     assert row["container"] == "stage-workdir"
     assert row["node"] == "gpu-a"
@@ -667,7 +667,7 @@ def test_arch_mismatch_ignores_the_same_failure_on_an_amd64_node():
         [_exec_format_pod("task-0", node_name="cpu-a")],
         nodes=[node("cpu-a", arch="amd64")],
     )
-    assert make_k8s_source(k8s_api(routes)).arch_mismatch_pods() == []
+    assert make_k8s_source(k8s_api(routes)).arch_mismatch_containers() == []
 
 
 @pytest.mark.parametrize(
@@ -681,19 +681,19 @@ def test_arch_mismatch_ignores_the_same_failure_on_an_amd64_node():
 )
 def test_arch_mismatch_rejects_terminations_outside_the_signature(kwargs):
     routes = _arch_routes([_exec_format_pod("task-0", **kwargs)])
-    assert make_k8s_source(k8s_api(routes)).arch_mismatch_pods() == []
+    assert make_k8s_source(k8s_api(routes)).arch_mismatch_containers() == []
 
 
 def test_arch_mismatch_reads_last_state_for_a_restarting_container():
     routes = _arch_routes([_exec_format_pod("task-0", state_key="lastState")])
-    (row,) = make_k8s_source(k8s_api(routes)).arch_mismatch_pods()
+    (row,) = make_k8s_source(k8s_api(routes)).arch_mismatch_containers()
     assert row["pod"] == "task-0"
 
 
 def test_arch_mismatch_skips_pods_on_a_node_the_scan_cannot_resolve():
     # An unscheduled pod has no nodeName, so there is no architecture to judge it against.
     routes = _arch_routes([_exec_format_pod("task-0", node_name="")])
-    assert make_k8s_source(k8s_api(routes)).arch_mismatch_pods() == []
+    assert make_k8s_source(k8s_api(routes)).arch_mismatch_containers() == []
 
 
 def test_alert_arch_mismatch_groups_by_node_and_image_with_zero_rows_elsewhere():

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -5,7 +5,7 @@
 error classification, and the fleet's always-one-row-per-cluster alert contract."""
 
 from dataclasses import asdict
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import httpx
 import pytest
@@ -608,6 +608,118 @@ def test_finelog_pods_reports_runtime_resources_probes_and_pvc():
     }
 
 
+TASK_IMAGE = "ghcr.io/marin-community/iris-task:latest"
+
+
+def _exec_format_pod(
+    name: str,
+    *,
+    node_name: str = "gpu-a",
+    image: str = TASK_IMAGE,
+    exit_code: int = 255,
+    reason: str = "Error",
+    runtime_seconds: float = 0.0,
+    finished_ago_seconds: int = 60,
+    state_key: str = "state",
+) -> dict:
+    finished = datetime.now(UTC) - timedelta(seconds=finished_ago_seconds)
+    started = finished - timedelta(seconds=runtime_seconds)
+    terminated = {
+        "exitCode": exit_code,
+        "reason": reason,
+        "startedAt": started.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "finishedAt": finished.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    return {
+        "metadata": {"namespace": "iris", "name": name},
+        "spec": {"nodeName": node_name},
+        "status": {
+            "phase": "Failed",
+            "initContainerStatuses": [
+                {"name": "stage-workdir", "image": image, "imageID": "sha256:abc", state_key: {"terminated": terminated}}
+            ],
+        },
+    }
+
+
+def _arch_routes(pods: list[dict], *, nodes: list[dict] | None = None) -> dict:
+    routes = healthy_k8s_routes()
+    routes["/api/v1/namespaces"] = [_namespace("iris")]
+    routes["/api/v1/namespaces/iris/pods"] = pods
+    routes["/api/v1/nodes"] = nodes if nodes is not None else [node("gpu-a", arch="arm64")]
+    return routes
+
+
+def test_arch_mismatch_reports_exec_format_failures_on_a_non_amd64_node():
+    routes = _arch_routes([_exec_format_pod("task-0")])
+    (row,) = make_k8s_source(k8s_api(routes)).arch_mismatch_pods()
+    assert row["pod"] == "task-0"
+    assert row["container"] == "stage-workdir"
+    assert row["node"] == "gpu-a"
+    assert row["node_arch"] == "arm64"
+    assert row["image"] == TASK_IMAGE
+    assert row["exit_code"] == 255
+
+
+def test_arch_mismatch_ignores_the_same_failure_on_an_amd64_node():
+    # An amd64 image on an amd64 CPU node is correct; only the arm64 side is broken.
+    routes = _arch_routes(
+        [_exec_format_pod("task-0", node_name="cpu-a")],
+        nodes=[node("cpu-a", arch="amd64")],
+    )
+    assert make_k8s_source(k8s_api(routes)).arch_mismatch_pods() == []
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"exit_code": 1}, id="ordinary-failure-exit-1"),
+        pytest.param({"reason": "OOMKilled"}, id="other-termination-reason"),
+        pytest.param({"runtime_seconds": 600}, id="ran-too-long-to-be-exec-failure"),
+        pytest.param({"finished_ago_seconds": 7200}, id="older-than-the-lookback-window"),
+    ],
+)
+def test_arch_mismatch_rejects_terminations_outside_the_signature(kwargs):
+    routes = _arch_routes([_exec_format_pod("task-0", **kwargs)])
+    assert make_k8s_source(k8s_api(routes)).arch_mismatch_pods() == []
+
+
+def test_arch_mismatch_reads_last_state_for_a_restarting_container():
+    routes = _arch_routes([_exec_format_pod("task-0", state_key="lastState")])
+    (row,) = make_k8s_source(k8s_api(routes)).arch_mismatch_pods()
+    assert row["pod"] == "task-0"
+
+
+def test_arch_mismatch_skips_pods_on_a_node_the_scan_cannot_resolve():
+    # An unscheduled pod has no nodeName, so there is no architecture to judge it against.
+    routes = _arch_routes([_exec_format_pod("task-0", node_name="")])
+    assert make_k8s_source(k8s_api(routes)).arch_mismatch_pods() == []
+
+
+def test_alert_arch_mismatch_groups_by_node_and_image_with_zero_rows_elsewhere():
+    routes = _arch_routes(
+        [
+            _exec_format_pod("task-0"),
+            _exec_format_pod("task-1"),
+            _exec_format_pod("task-2", node_name="gpu-b"),
+            _exec_format_pod("ok", exit_code=0),
+        ],
+        nodes=[node("gpu-a", arch="arm64"), node("gpu-b", arch="arm64")],
+    )
+    fleet = _fleet(("cw-a", k8s_api(routes)), ("cw-b", k8s_api(healthy_k8s_routes())))
+    assert fleet.alert_arch_mismatch() == [
+        {"cluster": "cw-a", "node": "gpu-a", "image": TASK_IMAGE, "value": 2},
+        {"cluster": "cw-a", "node": "gpu-b", "image": TASK_IMAGE, "value": 1},
+        {"cluster": "cw-b", "node": "", "image": "", "value": 0},
+    ]
+
+
+def test_alert_arch_mismatch_reports_zero_for_an_unreachable_cluster():
+    # Absence of evidence is not evidence of a mismatch; K8sClusterUnreachable pages instead.
+    fleet = _fleet(("cw-a", _forbidden))
+    assert fleet.alert_arch_mismatch() == [{"cluster": "cw-a", "node": "", "image": "", "value": 0}]
+
+
 def test_alert_gpu_rack_trays_maps_trays_ready_to_value():
     fleet = _fleet(("cw-a", k8s_api(healthy_k8s_routes())))
     assert fleet.alert_gpu_rack_trays() == [
@@ -641,6 +753,7 @@ def test_alert_routes_return_explicit_zeros_when_healthy():
     ]
     assert fleet.alert_stuck_gpu_pods() == [{"cluster": "cw-a", "node": "", "value": 0}]
     assert fleet.alert_node_deadlocks() == [{"cluster": "cw-a", "node": "", "reason": "", "value": 0}]
+    assert fleet.alert_arch_mismatch() == [{"cluster": "cw-a", "node": "", "image": "", "value": 0}]
 
 
 def test_alert_routes_keep_one_row_per_cluster_when_unreachable():

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -661,13 +661,57 @@ def test_arch_mismatch_reports_exec_format_failures_on_a_non_amd64_node():
     assert row["exit_code"] == 255
 
 
-def test_arch_mismatch_ignores_the_same_failure_on_an_amd64_node():
-    # An amd64 image on an amd64 CPU node is correct; only the arm64 side is broken.
+def test_arch_mismatch_reports_an_arm64_image_stranded_on_an_amd64_node():
+    # The mismatch runs both ways: an arm64-only push breaks the amd64 CPU nodes.
     routes = _arch_routes(
         [_exec_format_pod("task-0", node_name="cpu-a")],
         nodes=[node("cpu-a", arch="amd64")],
     )
-    assert make_k8s_source(k8s_api(routes)).arch_mismatch_containers() == []
+    (row,) = make_k8s_source(k8s_api(routes)).arch_mismatch_containers()
+    assert row["node_arch"] == "amd64"
+
+
+def test_arch_mismatch_matches_the_recorded_incident_termination():
+    # Verbatim from iris-held-hero-run-4 stage-workdir on s4bk6j84, 2026-07-29, with
+    # the timestamps moved into the lookback window. Note the absent message field:
+    # terminationMessagePolicy is File, which is why detection cannot read the text.
+    stamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    incident = {
+        "metadata": {"namespace": "iris", "name": "iris-held-hero-run-4-code-glm52-ro-702515a5-68"},
+        "spec": {"nodeName": "gpu-a"},
+        "status": {
+            "phase": "Failed",
+            "initContainerStatuses": [
+                {
+                    "name": "stage-workdir",
+                    "image": TASK_IMAGE,
+                    "state": {
+                        "terminated": {
+                            "containerID": (
+                                "containerd://0ac499e38fd7324dc14a7f16e78a9a681ce961f52064efad4b9c53329a5655eb"
+                            ),
+                            "exitCode": 255,
+                            "reason": "Error",
+                            "startedAt": stamp,
+                            "finishedAt": stamp,
+                        }
+                    },
+                }
+            ],
+        },
+    }
+    (row,) = make_k8s_source(k8s_api(_arch_routes([incident]))).arch_mismatch_containers()
+    assert row["container"] == "stage-workdir"
+    assert row["image"] == TASK_IMAGE
+
+
+def test_arch_mismatch_also_matches_an_unrelated_instant_exit_255():
+    # Known limit of the signature, not a bug: the API exposes no message to
+    # distinguish these, so an unrelated instant 255 reads the same. The alert text
+    # and lib/iris/OPS.md both say a row is evidence to confirm, not a proof.
+    routes = _arch_routes([_exec_format_pod("unrelated", image="ghcr.io/example/other:v1")])
+    (row,) = make_k8s_source(k8s_api(routes)).arch_mismatch_containers()
+    assert row["image"] == "ghcr.io/example/other:v1"
 
 
 @pytest.mark.parametrize(
@@ -691,7 +735,6 @@ def test_arch_mismatch_reads_last_state_for_a_restarting_container():
 
 
 def test_arch_mismatch_skips_pods_on_a_node_the_scan_cannot_resolve():
-    # An unscheduled pod has no nodeName, so there is no architecture to judge it against.
     routes = _arch_routes([_exec_format_pod("task-0", node_name="")])
     assert make_k8s_source(k8s_api(routes)).arch_mismatch_containers() == []
 
@@ -715,7 +758,6 @@ def test_alert_arch_mismatch_groups_by_node_and_image_with_zero_rows_elsewhere()
 
 
 def test_alert_arch_mismatch_reports_zero_for_an_unreachable_cluster():
-    # Absence of evidence is not evidence of a mismatch; K8sClusterUnreachable pages instead.
     fleet = _fleet(("cw-a", _forbidden))
     assert fleet.alert_arch_mismatch() == [{"cluster": "cw-a", "node": "", "image": "", "value": 0}]
 

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -621,6 +621,7 @@ def _exec_format_pod(
     runtime_seconds: float = 0.0,
     finished_ago_seconds: int = 60,
     state_key: str = "state",
+    message: str | None = None,
 ) -> dict:
     finished = datetime.now(UTC) - timedelta(seconds=finished_ago_seconds)
     started = finished - timedelta(seconds=runtime_seconds)
@@ -630,6 +631,8 @@ def _exec_format_pod(
         "startedAt": started.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "finishedAt": finished.strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
+    if message is not None:
+        terminated["message"] = message
     return {
         "metadata": {"namespace": "iris", "name": name},
         "spec": {"nodeName": node_name},
@@ -706,12 +709,31 @@ def test_arch_mismatch_matches_the_recorded_incident_termination():
 
 
 def test_arch_mismatch_also_matches_an_unrelated_instant_exit_255():
-    # Known limit of the signature, not a bug: the API exposes no message to
-    # distinguish these, so an unrelated instant 255 reads the same. The alert text
-    # and lib/iris/OPS.md both say a row is evidence to confirm, not a proof.
+    # Known limit of the signature fallback, not a bug: without a message these are
+    # indistinguishable. The row says so via evidence=signature.
     routes = _arch_routes([_exec_format_pod("unrelated", image="ghcr.io/example/other:v1")])
     (row,) = make_k8s_source(k8s_api(routes)).arch_mismatch_containers()
-    assert row["image"] == "ghcr.io/example/other:v1"
+    assert row["evidence"] == "signature"
+
+
+def test_arch_mismatch_prefers_the_runtime_message_when_the_kubelet_records_one():
+    # Verbatim shape produced under terminationMessagePolicy: FallbackToLogsOnError.
+    routes = _arch_routes([_exec_format_pod("task-0", message="exec /usr/local/bin/python: exec format error\n")])
+    (row,) = make_k8s_source(k8s_api(routes)).arch_mismatch_containers()
+    assert row["evidence"] == "message"
+
+
+def test_arch_mismatch_message_evidence_does_not_need_the_signature():
+    # A message is conclusive on its own, so an exec-format failure still reports
+    # when the exit code or runtime falls outside the fallback signature.
+    routes = _arch_routes([_exec_format_pod("task-0", exit_code=1, runtime_seconds=600, message="exec format error")])
+    (row,) = make_k8s_source(k8s_api(routes)).arch_mismatch_containers()
+    assert row["evidence"] == "message"
+
+
+def test_arch_mismatch_ignores_an_unrelated_message_on_a_normal_failure():
+    routes = _arch_routes([_exec_format_pod("task-0", exit_code=1, message="Traceback: ValueError")])
+    assert make_k8s_source(k8s_api(routes)).arch_mismatch_containers() == []
 
 
 @pytest.mark.parametrize(

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -518,6 +518,51 @@ subpath and does not reach the controller's finelog server.
 | Task retrying | `iris job summary /user/job` — per-task state and exit codes; `iris job logs /user/job` for the per-attempt errors. |
 | Task failed with exit 137 / suspected OOM | `iris job summary /user/job` — per-task peak memory + exit code. If most shards peak near the container memory limit, raise `--memory` on resubmit. |
 | Dashboard unreachable | Verify tunnel is alive. `curl -sf http://localhost:10000/health`. |
+| `ArchMismatchImageExecuted` alert, or tasks die instantly with exit 255 | See [Image architecture mismatch](#image-architecture-mismatch). |
+
+### Image architecture mismatch
+
+An image built for the wrong CPU architecture fails at exec. The pod log shows
+`exec /usr/local/bin/python: exec format error` and the container exits 255 in under a
+second. The `ArchMismatchImageExecuted` alert matches that signature, which is indirect:
+any program exiting 255 immediately looks the same, so confirm before acting.
+
+Confirm the tag really lost the architecture. A multi-arch tag is an index listing every
+platform:
+
+```bash
+TOK=$(curl -s "https://ghcr.io/token?scope=repository%3Amarin-community%2Firis-task%3Apull&service=ghcr.io" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['token'])")
+curl -s -H "Authorization: Bearer $TOK" \
+  -H "Accept: application/vnd.oci.image.index.v1+json" \
+  https://ghcr.io/v2/marin-community/iris-task/manifests/latest \
+  | python3 -c "import json,sys; d=json.load(sys.stdin); print([m.get('platform') for m in d.get('manifests',[])] or 'SINGLE-ARCH')"
+```
+
+A `platform: unknown` entry is buildx provenance, not a real architecture. If `linux/arm64`
+is missing, the tag itself is broken — rebuild and push a two-platform index before
+touching any node. Evicting first only re-pulls the same broken image.
+
+Then check what the node actually cached, since `imagePullPolicy: IfNotPresent` means a
+node never refreshes a tag it already holds:
+
+```bash
+kubectl --context <ctx> -n iris debug node/<node> --image=busybox --profile=sysadmin \
+  --attach=false -- chroot /host crictl inspecti ghcr.io/marin-community/iris-task:latest
+```
+
+Once the registry is confirmed good, drop the stale copy so the node re-pulls:
+
+```bash
+kubectl --context <ctx> -n iris debug node/<node> --image=busybox --profile=sysadmin \
+  --attach=false -- chroot /host crictl rmi ghcr.io/marin-community/iris-task:latest
+```
+
+Do not evict a node whose cached image still works unless the registry tag is confirmed
+good. On 2026-07-29 the only arm64 builds left in ghcr were the ones cached on the nodes;
+the tag had been overwritten with an amd64-only manifest, so an eviction would have been
+unrecoverable. Pinning the config to an index digest avoids both the drift and the
+overwrite.
 
 ## GCP (TPU) Operations
 

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -524,8 +524,13 @@ subpath and does not reach the controller's finelog server.
 
 An image built for the wrong CPU architecture fails at exec. The pod log shows
 `exec /usr/local/bin/python: exec format error` and the container exits 255 in under a
-second. The `ArchMismatchImageExecuted` alert matches that signature, which is indirect:
-any program exiting 255 immediately looks the same, so confirm before acting.
+second. The `ArchMismatchImageExecuted` alert reports an `evidence` column on
+`/k8s/arch_mismatch`: `message` means the kubelet captured that text and the mismatch is
+confirmed, `signature` means only the exit-255-in-under-a-second pattern matched, which an
+unrelated instant failure also produces. Confirm a `signature` row before acting.
+
+Only containers set to `terminationMessagePolicy: FallbackToLogsOnError` yield `message`
+evidence — Iris sets it on `task` and `stage-workdir`. Everything else reports `signature`.
 
 Confirm the tag really lost the architecture. A multi-arch tag is an index listing every
 platform:

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -587,6 +587,13 @@ def _build_init_container_spec(
             "command": ["python", "-c", bundle_script],
             "env": init_env,
             "volumeMounts": init_mounts,
+            # _init_container_failure reports this container's terminated message, and
+            # bounds it because it can be a full log tail — but with the default File
+            # policy the kubelet never writes one, so every stage-workdir failure
+            # degraded to a bare "Init:Error stage-workdir". An image built for the
+            # wrong CPU architecture is the worst case: the whole cause is the runtime's
+            # "exec format error", which reaches the log and nothing else.
+            "terminationMessagePolicy": "FallbackToLogsOnError",
         }
     ]
 

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -945,6 +945,22 @@ def test_init_container_created_when_bundle_id_present():
     assert extra_volumes == []
 
 
+def test_init_container_records_its_log_tail_on_failure():
+    """_init_container_failure reports the terminated message, which the default File
+    policy never populates — so a stage-workdir crash surfaced with no cause at all."""
+    req = make_run_req("/my-job/task-0")
+    req.bundle_id = "bundle-abc"
+
+    init_containers, _, _ = _build_init_container_spec(
+        req,
+        "iris-my-job-task-0-abcd1234-0",
+        "myrepo/iris:latest",
+        "http://ctrl:8080",
+    )
+
+    assert init_containers[0]["terminationMessagePolicy"] == "FallbackToLogsOnError"
+
+
 def test_no_init_container_when_no_bundle_or_files():
     """No init containers when neither bundle_id nor workdir_files are set."""
     req = make_run_req("/my-job/task-0")


### PR DESCRIPTION
A bad `iris-task:latest` push on 2026-07-29 replaced the multi-arch index with an
amd64-only manifest. Four arm64 GB200 nodes on `cw-us-east-08a` cached it, and every task
scheduled there died in `stage-workdir` with
`exec /usr/local/bin/python: exec format error`. Because `imagePullPolicy` is
`IfNotPresent`, those nodes never re-pulled, so the failures repeated for hours. Nothing
recorded a cause: the attempt showed only `Init:Error stage-workdir`.

`stage-workdir` never set `terminationMessagePolicy`, so it took the `File` default and
the kubelet wrote no terminated message. `_init_container_failure` reports that message
and bounds it because it can be a full log tail, and the `task` container has carried
`FallbackToLogsOnError` for exactly this reason — the init container was simply missed.
Setting it there makes every stage-workdir failure carry its own log tail, not just this
one. Confirmed on `cw-us-east-08a` by running an amd64 image on an arm64 node under both
policies: `File` left `message` empty, the fallback policy recorded
`exec /bin/echo: exec format error`.

The new `ArchMismatchImageExecuted` rule takes that message when present
(`evidence=message`, conclusive, no exit-code or runtime test needed) and otherwise falls
back to the runtime signature of exit 255, reason `Error`, and a sub-second runtime
(`evidence=signature`). The fallback is indirect — an unrelated instant 255 matches too —
so the alert text and runbook both say to confirm a `signature` row. Measured against
`cw-us-east-08a`, the signature matched 0 of 11182 container statuses across all 208
nodes, and it matches the recorded incident status. A one-hour lookback bounds the
evidence, since Failed pods linger until garbage collection.

The scan runs on every node rather than only non-amd64 ones: an arm64-only push would
strand the four amd64 CPU nodes the same way, and scoping to one direction was blind to
that. Dropping the filter added no false positives in the measurement above.

The rule is `severity: warning`, so it stays visible in Grafana without notifying.
`lib/iris/OPS.md` gains the confirmation procedure: how to check whether the tag is still
a two-platform index, how to inspect what a node cached, and why evicting a cached image
before confirming the registry can be unrecoverable — on 2026-07-29 the only arm64 builds
left in ghcr were the ones already on the nodes.

The bridge gains `/k8s/arch_mismatch` for per-container detail and
`/k8s/alerts/arch_mismatch` for the rule, sharing one cached fleet scan the way
`stuck_gpu_pods` does. Both alert projections now share one count-and-zero-fill helper.

This fires after jobs die. A preflight check reading the configured image's registry
manifest, warning when it has no `linux/arm64` entry, would have caught the bad push
before any node cached it; that is not included here.
