### PR TITLE
[pulumi] Keep kubeconfig out of pulumi state

### DIFF
--- a/infra/pulumi/README.md
+++ b/infra/pulumi/README.md
@@ -100,11 +100,6 @@ or `delete` on a NodePool is not** — it deprovisions a reserved bare-metal fle
 reconcile the program to match reality; never `pulumi up` through a destructive NodePool diff.
 Once the preview is clean, `pulumi up`.
 
-`__main__.py` requires `KUBECONFIG` but does not pass it as a provider input, so Pulumi state
-contains neither the machine-local path nor the credential contents. The provider still uses
-the cluster's declared `platform.coreweave.kube_context`; it never relies on the kubeconfig's
-current context.
-
 ### Adopting a new cluster
 
 A cluster whose RBAC/NodePools/Kueue/Traefik already exist live (the normal case — the CKS

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -37,6 +37,24 @@ from iac.nodepools import derive_nodepools
 from rigging.secrets import resolve_secret_spec
 
 DEFAULT_NAMESPACE = "iris"
+DEFAULT_COREWEAVE_KUBECONFIG = os.path.expanduser("~/.kube/coreweave-iris")
+
+
+def _require_kubeconfig(cluster: str) -> None:
+    """Require KUBECONFIG in the execution environment, offering the default CoreWeave kubeconfig path."""
+    if os.environ.get("KUBECONFIG"):
+        return
+    candidate = DEFAULT_COREWEAVE_KUBECONFIG
+    if os.path.isfile(candidate) and sys.stdin.isatty():
+        answer = input(f"KUBECONFIG is unset; use {candidate}? [Y/n] ").strip().lower()
+        if answer in ("", "y", "yes"):
+            os.environ["KUBECONFIG"] = candidate
+            return
+    hint = f" (e.g. export KUBECONFIG={candidate})" if os.path.isfile(candidate) else ""
+    raise ValueError(
+        f"cluster {cluster!r} requires KUBECONFIG; "
+        f"Pulumi reads Kubernetes credentials from the execution environment{hint}"
+    )
 
 
 def _warn_if_no_persistent_signing_key(cluster: str, iris_config) -> None:
@@ -85,22 +103,21 @@ def _build_coreweave(cluster: str, *, adopt: bool) -> None:
             f"cluster {cluster!r} has no platform.coreweave config; "
             "the minimal IaC cut needs an out-of-cluster Kubernetes target"
         )
-    if not os.environ.get("KUBECONFIG"):
-        raise ValueError(
-            f"cluster {cluster!r} requires KUBECONFIG; "
-            "Pulumi reads Kubernetes credentials from the execution environment"
-        )
-    # Bind to the cluster's declared kube_context, not the kubeconfig's current-context —
-    # otherwise a stack silently targets whatever `kubectl` was last pointed at.
-    #
-    # enable_patch_force=True: declared here until the "cede" ships (spec.md §4). Iris's
-    # controller still re-applies RBAC/NodePools under its own field manager on every restart, so
-    # a plain SSA dry-run reports a field conflict without forced ownership (README §Adoption
-    # check). KUBECONFIG stays in the execution environment instead of becoming a provider
-    # input, which keeps credentials and machine-local paths out of Pulumi state.
+    # Require an explicit context: omitting it makes the provider use the kubeconfig's
+    # current-context (whatever kubectl last pointed at), which can silently retarget
+    # another CoreWeave cluster sharing ~/.kube/coreweave-iris.
+    if not platform_coreweave.kube_context:
+        raise ValueError(f"cluster {cluster!r} missing required platform.coreweave.kube_context")
+    _require_kubeconfig(cluster)
+    # kubeconfig="": bypasses the Python SDK's default of copying $KUBECONFIG into
+    # the provider input (which persists a machine-local path in state, creating spurious diffs)
+    # The provider process still loads credentials from the ambient KUBECONFIG env.
+    # enable_patch_force=True: allows pulumi to take control of resources it didn't create.
+    # This should not happen in practice, but could during manual operations.
     k8s_provider = k8s.Provider(
         "cw-k8s",
-        context=platform_coreweave.kube_context or None,
+        kubeconfig="",
+        context=platform_coreweave.kube_context,
         enable_patch_force=True,
     )
 

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -37,24 +37,6 @@ from iac.nodepools import derive_nodepools
 from rigging.secrets import resolve_secret_spec
 
 DEFAULT_NAMESPACE = "iris"
-DEFAULT_COREWEAVE_KUBECONFIG = os.path.expanduser("~/.kube/coreweave-iris")
-
-
-def _require_kubeconfig(cluster: str) -> None:
-    """Require KUBECONFIG in the execution environment, offering the default CoreWeave kubeconfig path."""
-    if os.environ.get("KUBECONFIG"):
-        return
-    candidate = DEFAULT_COREWEAVE_KUBECONFIG
-    if os.path.isfile(candidate) and sys.stdin.isatty():
-        answer = input(f"KUBECONFIG is unset; use {candidate}? [Y/n] ").strip().lower()
-        if answer in ("", "y", "yes"):
-            os.environ["KUBECONFIG"] = candidate
-            return
-    hint = f" (e.g. export KUBECONFIG={candidate})" if os.path.isfile(candidate) else ""
-    raise ValueError(
-        f"cluster {cluster!r} requires KUBECONFIG; "
-        f"Pulumi reads Kubernetes credentials from the execution environment{hint}"
-    )
 
 
 def _warn_if_no_persistent_signing_key(cluster: str, iris_config) -> None:
@@ -108,7 +90,10 @@ def _build_coreweave(cluster: str, *, adopt: bool) -> None:
     # another CoreWeave cluster sharing ~/.kube/coreweave-iris.
     if not platform_coreweave.kube_context:
         raise ValueError(f"cluster {cluster!r} missing required platform.coreweave.kube_context")
-    _require_kubeconfig(cluster)
+
+    if not os.environ.get("KUBECONFIG"):
+        raise ValueError("pulumi up requires KUBECONFIG (e.g. export KUBECONFIG=~/.kube/coreweave-iris).")
+
     # kubeconfig="": bypasses the Python SDK's default of copying $KUBECONFIG into
     # the provider input (which persists a machine-local path in state, creating spurious diffs)
     # The provider process still loads credentials from the ambient KUBECONFIG env.

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -110,10 +110,11 @@ def _build_coreweave(cluster: str, *, adopt: bool) -> None:
         raise ValueError(f"cluster {cluster!r} missing required platform.coreweave.kube_context")
     _require_kubeconfig(cluster)
     # kubeconfig="": bypasses the Python SDK's default of copying $KUBECONFIG into
-    # the provider input (which persists a machine-local path in state, creating spurious diffs)
+    # the provider input (which persists a machine-local path in state, creating spurious diffs).
     # The provider process still loads credentials from the ambient KUBECONFIG env.
-    # enable_patch_force=True: allows pulumi to take control of resources it didn't create.
-    # This should not happen in practice, but could during manual operations.
+    # enable_patch_force=True: Iris's controller re-applies RBAC/NodePools under its own field
+    # manager on every restart, so a plain SSA dry-run reports a field conflict without forced
+    # ownership (README §Adoption check). Declared here until the "cede" ships (spec.md §4).
     k8s_provider = k8s.Provider(
         "cw-k8s",
         kubeconfig="",

--- a/infra/pulumi/__main__.py
+++ b/infra/pulumi/__main__.py
@@ -110,11 +110,10 @@ def _build_coreweave(cluster: str, *, adopt: bool) -> None:
         raise ValueError(f"cluster {cluster!r} missing required platform.coreweave.kube_context")
     _require_kubeconfig(cluster)
     # kubeconfig="": bypasses the Python SDK's default of copying $KUBECONFIG into
-    # the provider input (which persists a machine-local path in state, creating spurious diffs).
+    # the provider input (which persists a machine-local path in state, creating spurious diffs)
     # The provider process still loads credentials from the ambient KUBECONFIG env.
-    # enable_patch_force=True: Iris's controller re-applies RBAC/NodePools under its own field
-    # manager on every restart, so a plain SSA dry-run reports a field conflict without forced
-    # ownership (README §Adoption check). Declared here until the "cede" ships (spec.md §4).
+    # enable_patch_force=True: allows pulumi to take control of resources it didn't create.
+    # This should not happen in practice, but could during manual operations.
     k8s_provider = k8s.Provider(
         "cw-k8s",
         kubeconfig="",


### PR DESCRIPTION
Actually, hopefully, finally keep `kubeconfig` out of `pulumi` state.

Follow on to https://github.com/marin-community/marin/pull/7611