### PR TITLE
grafana: restore infrastructure status page

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -37,6 +37,7 @@ GET /iris/{cluster}/jobs | workers | health      live controller RPCs
 GET /iris/{cluster}/query?sql=                    ad-hoc SELECT (admin/null-auth)
 GET /github/ferries | builds | nightlies          GitHub REST / GraphQL
 GET /wandb/{train-loss,paloma-macro-loss,mfu}      public report runset and sampled history
+GET /overview/provisioning                         latest fleet and resource-pool cycle
 GET /k8s/control_plane | crashloops | pending     CW control-plane state, all clusters
 GET /k8s/termination_candidates | kueue | events | health
                                                     ... one response, `cluster` column
@@ -84,6 +85,10 @@ groups those rows into the compact trailing-week matrix.
 W&B: the bridge reads the public hero-training report anonymously, follows the runset
 pinned in its report spec, and samples train cross-entropy, Paloma macro loss, and MFU
 against cumulative training tokens. Grafana receives flat rows and never needs a W&B key.
+
+`overview/provisioning` reads the latest shared cycle in the prior six hours. It returns
+one fleet row and one row per resource pool. Each row contains outcome counts, success
+ratio, latency, and pool-health fields from the former status page.
 
 k8s: the bridge polls the four CoreWeave clusters' public CKS API servers with plain
 httpx GETs (paginated LISTs, bounded timeouts, one 429 retry) and a single org-wide CW
@@ -145,6 +150,7 @@ src/finelog_source.py  finelog query over its internal IP (LogClient)
 src/iris_source.py     live controller RPCs: jobs, workers, health, federation peers, ad-hoc query
 src/github_source.py   ferry runs and CI build rollup, precomputed
 src/wandb_source.py    public W&B report runset and token-axis samples
+src/overview.py        fixed provisioning projection for the status page
 src/k8s_source.py      CW k8s API reads + the per-cluster fan-out and alert rows
 src/discovery.py       GCE label -> internal IP
 src/config.py          cluster targets, watched components, and bridge settings
@@ -154,16 +160,16 @@ src/dashboard_stitch.py  resolves dashboards/*.json panelRef markers into full p
 provisioning/          datasources (finelog, iris, github, k8s), dashboards, alerting
 dashboards/            dashboard JSON source — reviewed like code; see "Adding a dashboard"
 dashboards/panels/     panel bodies shared across dashboards, referenced by panelRef
-marin-infra-panel/     internal React panel for the matrix, CI strip, and W&B charts
+marin-infra-panel/     internal React status page and its reusable dense views
 Dockerfile             Grafana + bridge venv + pinned Infinity and internal panel plugins
 entrypoint.sh          runs both; if either dies the container dies
 __main__.py            Pulumi entry point — the Cloud Run service (iac.gcp.cloud_run)
 Pulumi.yaml            Pulumi project, run on the shared repo venv
 ```
 
-Dashboards: `home.json` (the landing page — see below), `infra.json` (the compact
-cockpit — nightlies, CI and ferries, Iris capacity, provisioning, control-plane
-health, Kubernetes workload state, and hero training), `jobs.json` (fleet job
+Dashboards: `home.json` (the landing page — see below), `infra.json` (a custom
+React status page for nightly regressions, main CI, worker capacity, provisioning,
+and hero training), `jobs.json` (fleet job
 state — see below), `fleet.json` (canary +
 worker health), `iris.json`
 (per-task and per-worker resource usage), `pipelines.json` (Zephyr throughput and shard

--- a/infra/grafana/dashboards/infra.json
+++ b/infra/grafana/dashboards/infra.json
@@ -1,7 +1,7 @@
 {
   "uid": "infra",
   "title": "Infra",
-  "description": "Compact Marin infrastructure cockpit: nightly regressions, main CI, ferries, Iris capacity, provisioning, Kubernetes control plane, and hero training.",
+  "description": "Marin infrastructure status: nightly regressions, GitHub CI, workers, provisioning, and hero training.",
   "tags": [
     "marin"
   ],
@@ -83,19 +83,19 @@
       "id": 1,
       "type": "marin-infra-panel",
       "title": "",
-      "transparent": false,
+      "transparent": true,
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
-        "uid": "github"
+        "uid": "status"
       },
       "gridPos": {
-        "h": 9,
+        "h": 42,
         "w": 24,
         "x": 0,
         "y": 0
       },
       "options": {
-        "view": "nightlies"
+        "view": "status"
       },
       "fieldConfig": {
         "defaults": {},
@@ -103,12 +103,12 @@
       },
       "targets": [
         {
-          "refId": "A",
+          "refId": "N",
           "type": "json",
           "source": "url",
           "format": "table",
           "parser": "backend",
-          "url": "/nightlies",
+          "url": "/github/nightlies",
           "url_options": {
             "method": "GET",
             "params": []
@@ -195,39 +195,14 @@
               "type": "number"
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": 2,
-      "type": "marin-infra-panel",
-      "title": "",
-      "transparent": false,
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "github"
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 9
-      },
-      "options": {
-        "view": "commits"
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "targets": [
+        },
         {
-          "refId": "A",
+          "refId": "G",
           "type": "json",
           "source": "url",
           "format": "table",
           "parser": "backend",
-          "url": "/builds",
+          "url": "/github/builds",
           "url_options": {
             "method": "GET",
             "params": []
@@ -279,404 +254,14 @@
               "type": "number"
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": 3,
-      "panelRef": "iris_controller_up",
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 0,
-        "y": 12
-      }
-    },
-    {
-      "id": 4,
-      "panelRef": "k8s_apis_unreachable",
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 4,
-        "y": 12
-      }
-    },
-    {
-      "id": 5,
-      "type": "stat",
-      "title": "Synthetic probes",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 8,
-        "y": 12
-      },
-      "fieldConfig": {
-        "defaults": {
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "max": 1
         },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "none",
-        "textMode": "auto",
-        "orientation": "auto"
-      },
-      "targets": [
         {
-          "refId": "A",
+          "refId": "W",
           "type": "json",
           "source": "url",
           "format": "table",
           "parser": "backend",
-          "url": "/query",
-          "url_options": {
-            "method": "GET",
-            "params": [
-              {
-                "key": "sql",
-                "value": "WITH recent AS (SELECT labels, value, ROW_NUMBER() OVER (PARTITION BY labels ORDER BY collected_at DESC) AS rn FROM \"infra.canary.metrics\" WHERE metric = 'probe_up' AND collected_at >= {{from}} AND collected_at < {{to}}) SELECT value FROM recent WHERE rn = 1"
-              },
-              {
-                "key": "from",
-                "value": "${__from}"
-              },
-              {
-                "key": "to",
-                "value": "${__to}"
-              }
-            ]
-          },
-          "columns": [
-            {
-              "selector": "value",
-              "text": "value",
-              "type": "number"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 6,
-      "type": "stat",
-      "title": "Ferry success",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "github"
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 12,
-        "y": 12
-      },
-      "fieldConfig": {
-        "defaults": {
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "percentunit",
-          "max": 1
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "none",
-        "textMode": "auto",
-        "orientation": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/ferries",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "success_rate",
-              "text": "success_rate",
-              "type": "number"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 7,
-      "panelRef": "pending_pods_count",
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 16,
-        "y": 12
-      }
-    },
-    {
-      "id": 8,
-      "panelRef": "crashloops_count",
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 20,
-        "y": 12
-      }
-    },
-    {
-      "id": 9,
-      "panelRef": "healthy_workers_count",
-      "gridPos": {
-        "h": 3,
-        "w": 6,
-        "x": 0,
-        "y": 15
-      }
-    },
-    {
-      "id": 10,
-      "type": "stat",
-      "title": "CPU capacity",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "iris-marin"
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 6,
-        "x": 6,
-        "y": 15
-      },
-      "fieldConfig": {
-        "defaults": {
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "mcores"
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "sum"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "none",
-        "textMode": "auto",
-        "orientation": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/workers",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "cpu_millicores",
-              "text": "cpu_millicores",
-              "type": "number"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 11,
-      "type": "stat",
-      "title": "Memory capacity",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "iris-marin"
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 6,
-        "x": 12,
-        "y": 15
-      },
-      "fieldConfig": {
-        "defaults": {
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "options": {
-        "reduceOptions": {
-          "calcs": [
-            "sum"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "colorMode": "value",
-        "graphMode": "none",
-        "textMode": "auto",
-        "orientation": "auto"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/workers",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "memory_bytes",
-              "text": "memory_bytes",
-              "type": "number"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 12,
-      "panelRef": "tpu_chips_count",
-      "gridPos": {
-        "h": 3,
-        "w": 6,
-        "x": 18,
-        "y": 15
-      }
-    },
-    {
-      "id": 20,
-      "type": "row",
-      "title": "Fleet and provisioning",
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 18
-      },
-      "panels": []
-    },
-    {
-      "id": 21,
-      "type": "table",
-      "title": "Workers by region",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "iris-marin"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 9,
-        "x": 0,
-        "y": 19
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "filterable": true
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "memory_bytes"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "bytes"
-              }
-            ]
-          }
-        ]
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/workers",
+          "url": "/iris/marin/workers",
           "url_options": {
             "method": "GET",
             "params": []
@@ -708,198 +293,108 @@
               "type": "number"
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": 22,
-      "type": "table",
-      "title": "Jobs by state",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "iris-marin"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 7,
-        "x": 9,
-        "y": 19
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "filterable": true
-          }
         },
-        "overrides": []
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm"
-      },
-      "targets": [
         {
-          "refId": "A",
+          "refId": "P",
           "type": "json",
           "source": "url",
           "format": "table",
           "parser": "backend",
-          "url": "/jobs",
+          "url": "/overview/provisioning",
           "url_options": {
             "method": "GET",
             "params": []
           },
           "columns": [
             {
-              "selector": "bucket",
-              "text": "bucket",
+              "selector": "scope",
+              "text": "scope",
               "type": "string"
             },
             {
-              "selector": "state",
-              "text": "state",
-              "type": "string"
-            },
-            {
-              "selector": "count",
-              "text": "count",
-              "type": "number"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 23,
-      "type": "table",
-      "title": "Ferry runs",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "github"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 19
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "filterable": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/ferries",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "group",
-              "text": "group",
-              "type": "string"
-            },
-            {
-              "selector": "tier",
-              "text": "tier",
-              "type": "string"
-            },
-            {
-              "selector": "conclusion",
-              "text": "conclusion",
-              "type": "string"
-            },
-            {
-              "selector": "sha",
-              "text": "sha",
-              "type": "string"
-            },
-            {
-              "selector": "started_at",
-              "text": "started_at",
+              "selector": "collected_at",
+              "text": "collected_at",
               "type": "timestamp_epoch"
             },
             {
-              "selector": "duration_seconds",
-              "text": "duration_seconds",
-              "type": "number"
-            },
-            {
-              "selector": "success_rate",
-              "text": "success_rate",
-              "type": "number"
-            },
-            {
-              "selector": "html_url",
-              "text": "html_url",
+              "selector": "resource_type",
+              "text": "resource_type",
               "type": "string"
+            },
+            {
+              "selector": "scale_group",
+              "text": "scale_group",
+              "type": "string"
+            },
+            {
+              "selector": "zone",
+              "text": "zone",
+              "type": "string"
+            },
+            {
+              "selector": "ready",
+              "text": "ready",
+              "type": "number"
+            },
+            {
+              "selector": "stockout",
+              "text": "stockout",
+              "type": "number"
+            },
+            {
+              "selector": "error",
+              "text": "error",
+              "type": "number"
+            },
+            {
+              "selector": "preempted",
+              "text": "preempted",
+              "type": "number"
+            },
+            {
+              "selector": "outcomes",
+              "text": "outcomes",
+              "type": "number"
+            },
+            {
+              "selector": "success_ratio",
+              "text": "success_ratio",
+              "type": "number"
+            },
+            {
+              "selector": "pools_placing",
+              "text": "pools_placing",
+              "type": "number"
+            },
+            {
+              "selector": "pools_no_ready_outcome",
+              "text": "pools_no_ready_outcome",
+              "type": "number"
+            },
+            {
+              "selector": "latency_p50_seconds",
+              "text": "latency_p50_seconds",
+              "type": "number"
+            },
+            {
+              "selector": "latency_p95_seconds",
+              "text": "latency_p95_seconds",
+              "type": "number"
+            },
+            {
+              "selector": "window_hours",
+              "text": "window_hours",
+              "type": "number"
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": 24,
-      "type": "timeseries",
-      "title": "Healthy workers by region",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 26
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "short",
-          "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "showPoints": "never",
-            "lineWidth": 1,
-            "fillOpacity": 8
-          }
         },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
         {
-          "refId": "A",
+          "refId": "H",
           "type": "json",
           "source": "url",
-          "format": "timeseries",
+          "format": "table",
           "parser": "backend",
-          "url": "/query",
+          "url": "/finelog/marin/query",
           "url_options": {
             "method": "GET",
             "params": [
@@ -934,62 +429,14 @@
               "type": "number"
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": 25,
-      "type": "timeseries",
-      "title": "Provisioning success ratio",
-      "description": "Trailing 3h success ratio, refreshed every 15m. Success is READY / (READY + STOCKOUT + ERROR); runtime preemptions are excluded.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 26
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "percentunit",
-          "min": 0,
-          "max": 1,
-          "custom": {
-            "drawStyle": "line",
-            "showPoints": "never",
-            "lineWidth": 1,
-            "fillOpacity": 8
-          }
         },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull",
-            "min",
-            "max"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
         {
-          "refId": "A",
+          "refId": "R",
           "type": "json",
           "source": "url",
-          "format": "timeseries",
+          "format": "table",
           "parser": "backend",
-          "url": "/query",
+          "url": "/finelog/marin/query",
           "url_options": {
             "method": "GET",
             "params": [
@@ -1024,240 +471,112 @@
               "type": "number"
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": 30,
-      "type": "row",
-      "title": "Control plane",
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 34
-      },
-      "panels": []
-    },
-    {
-      "id": 31,
-      "type": "table",
-      "title": "Latest synthetic health checks",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 35
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "filterable": true
-          }
         },
-        "overrides": []
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm"
-      },
-      "targets": [
         {
-          "refId": "A",
+          "refId": "T",
           "type": "json",
           "source": "url",
           "format": "table",
           "parser": "backend",
-          "url": "/query",
+          "url": "/wandb/train-loss",
           "url_options": {
             "method": "GET",
-            "params": [
-              {
-                "key": "sql",
-                "value": "WITH recent AS (SELECT labels, metric, value, ROW_NUMBER() OVER (PARTITION BY labels, metric ORDER BY collected_at DESC) AS rn FROM \"infra.canary.metrics\" WHERE metric IN ('probe_up', 'probe_latency_ms') AND collected_at >= {{from}} AND collected_at < {{to}}) SELECT json_get(labels, 'probe') AS probe, metric, value FROM recent WHERE rn = 1 ORDER BY probe, metric"
-              },
-              {
-                "key": "from",
-                "value": "${__from}"
-              },
-              {
-                "key": "to",
-                "value": "${__to}"
-              }
-            ]
+            "params": []
           },
           "columns": [
             {
-              "selector": "probe",
-              "text": "probe",
+              "selector": "chart",
+              "text": "chart",
               "type": "string"
             },
             {
-              "selector": "metric",
-              "text": "metric",
+              "selector": "run",
+              "text": "run",
               "type": "string"
+            },
+            {
+              "selector": "run_state",
+              "text": "run_state",
+              "type": "string"
+            },
+            {
+              "selector": "tokens",
+              "text": "tokens",
+              "type": "number"
             },
             {
               "selector": "value",
               "text": "value",
               "type": "number"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 32,
-      "type": "timeseries",
-      "title": "Control-plane latency",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 35
-      },
-      "fieldConfig": {
-        "defaults": {
-          "unit": "ms",
-          "min": 0,
-          "custom": {
-            "drawStyle": "line",
-            "showPoints": "never",
-            "lineWidth": 1,
-            "fillOpacity": 8
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "timeseries",
-          "parser": "backend",
-          "url": "/query",
-          "url_options": {
-            "method": "GET",
-            "params": [
-              {
-                "key": "sql",
-                "value": "SELECT collected_at AS t, value, labels FROM \"infra.canary.metrics\" WHERE metric = 'probe_latency_ms' AND collected_at >= {{from}} AND collected_at < {{to}} ORDER BY collected_at"
-              },
-              {
-                "key": "from",
-                "value": "${__from}"
-              },
-              {
-                "key": "to",
-                "value": "${__to}"
-              }
-            ]
-          },
-          "columns": [
-            {
-              "selector": "t",
-              "text": "time",
-              "type": "timestamp_epoch"
             },
             {
-              "selector": "label_probe",
-              "text": "probe",
+              "selector": "report_title",
+              "text": "report_title",
               "type": "string"
             },
             {
-              "selector": "value",
-              "text": "latency_ms",
-              "type": "number"
+              "selector": "report_url",
+              "text": "report_url",
+              "type": "string"
             }
           ]
-        }
-      ]
-    },
-    {
-      "id": 33,
-      "panelRef": "control_plane_components",
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 35
-      }
-    },
-    {
-      "id": 34,
-      "panelRef": "federation_peers",
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 42
-      }
-    },
-    {
-      "id": 40,
-      "type": "row",
-      "title": "Hero training",
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 49
-      },
-      "panels": []
-    },
-    {
-      "id": 41,
-      "type": "marin-infra-panel",
-      "title": "",
-      "transparent": false,
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "wandb"
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 0,
-        "y": 50
-      },
-      "options": {
-        "view": "wandb"
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "targets": [
+        },
         {
-          "refId": "A",
+          "refId": "L",
           "type": "json",
           "source": "url",
           "format": "table",
           "parser": "backend",
-          "url": "/train-loss",
+          "url": "/wandb/paloma-macro-loss",
+          "url_options": {
+            "method": "GET",
+            "params": []
+          },
+          "columns": [
+            {
+              "selector": "chart",
+              "text": "chart",
+              "type": "string"
+            },
+            {
+              "selector": "run",
+              "text": "run",
+              "type": "string"
+            },
+            {
+              "selector": "run_state",
+              "text": "run_state",
+              "type": "string"
+            },
+            {
+              "selector": "tokens",
+              "text": "tokens",
+              "type": "number"
+            },
+            {
+              "selector": "value",
+              "text": "value",
+              "type": "number"
+            },
+            {
+              "selector": "report_title",
+              "text": "report_title",
+              "type": "string"
+            },
+            {
+              "selector": "report_url",
+              "text": "report_url",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "refId": "M",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/wandb/mfu",
           "url_options": {
             "method": "GET",
             "params": []
@@ -1301,286 +620,6 @@
           ]
         }
       ]
-    },
-    {
-      "id": 42,
-      "type": "marin-infra-panel",
-      "title": "",
-      "transparent": false,
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "wandb"
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 8,
-        "y": 50
-      },
-      "options": {
-        "view": "wandb"
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/paloma-macro-loss",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "chart",
-              "text": "chart",
-              "type": "string"
-            },
-            {
-              "selector": "run",
-              "text": "run",
-              "type": "string"
-            },
-            {
-              "selector": "run_state",
-              "text": "run_state",
-              "type": "string"
-            },
-            {
-              "selector": "tokens",
-              "text": "tokens",
-              "type": "number"
-            },
-            {
-              "selector": "value",
-              "text": "value",
-              "type": "number"
-            },
-            {
-              "selector": "report_title",
-              "text": "report_title",
-              "type": "string"
-            },
-            {
-              "selector": "report_url",
-              "text": "report_url",
-              "type": "string"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 43,
-      "type": "marin-infra-panel",
-      "title": "",
-      "transparent": false,
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "wandb"
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 16,
-        "y": 50
-      },
-      "options": {
-        "view": "wandb"
-      },
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/mfu",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "chart",
-              "text": "chart",
-              "type": "string"
-            },
-            {
-              "selector": "run",
-              "text": "run",
-              "type": "string"
-            },
-            {
-              "selector": "run_state",
-              "text": "run_state",
-              "type": "string"
-            },
-            {
-              "selector": "tokens",
-              "text": "tokens",
-              "type": "number"
-            },
-            {
-              "selector": "value",
-              "text": "value",
-              "type": "number"
-            },
-            {
-              "selector": "report_title",
-              "text": "report_title",
-              "type": "string"
-            },
-            {
-              "selector": "report_url",
-              "text": "report_url",
-              "type": "string"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 50,
-      "type": "row",
-      "title": "Kubernetes workload details",
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 59
-      },
-      "panels": []
-    },
-    {
-      "id": 51,
-      "panelRef": "pending_gated_pods",
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 60
-      }
-    },
-    {
-      "id": 52,
-      "panelRef": "crashlooping_pods",
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 8,
-        "y": 60
-      }
-    },
-    {
-      "id": 53,
-      "type": "table",
-      "title": "Termination candidates",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "k8s"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 16,
-        "y": 60
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "filterable": true
-          }
-        },
-        "overrides": []
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/termination_candidates",
-          "url_options": {
-            "method": "GET",
-            "params": []
-          },
-          "columns": [
-            {
-              "selector": "cluster",
-              "text": "cluster",
-              "type": "string"
-            },
-            {
-              "selector": "namespace",
-              "text": "namespace",
-              "type": "string"
-            },
-            {
-              "selector": "pod",
-              "text": "pod",
-              "type": "string"
-            },
-            {
-              "selector": "node",
-              "text": "node",
-              "type": "string"
-            },
-            {
-              "selector": "classification",
-              "text": "classification",
-              "type": "string"
-            },
-            {
-              "selector": "gpu_count",
-              "text": "gpu_count",
-              "type": "number"
-            },
-            {
-              "selector": "overdue_seconds",
-              "text": "overdue_seconds",
-              "type": "number"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": 54,
-      "panelRef": "kueue_admission_backlog",
-      "gridPos": {
-        "h": 7,
-        "w": 8,
-        "x": 0,
-        "y": 67
-      }
-    },
-    {
-      "id": 55,
-      "panelRef": "warning_events",
-      "gridPos": {
-        "h": 7,
-        "w": 16,
-        "x": 8,
-        "y": 67
-      }
     }
   ]
 }

--- a/infra/grafana/marin-infra-panel/README.md
+++ b/infra/grafana/marin-infra-panel/README.md
@@ -1,14 +1,16 @@
 # Marin infra panel
 
-This internal Grafana panel provides the three dense views that built-in panels
-cannot preserve from Marin's retired infra status page:
+This internal Grafana panel restores the retired infrastructure status page inside
+Grafana. The `status` view combines these sections:
 
-- seven UTC days of linked nightly status and durations;
-- an equal-width main-branch CI history strip;
+- Seven UTC days of linked nightly status and durations.
+- An equal-width main-branch CI history strip.
+- Current worker capacity and a 24-hour region history.
+- Fleet and resource-pool provisioning status and history.
 - W&B hero-training series against cumulative tokens.
 
-The panel receives ordinary Grafana data frames. Upstream credentials and query
-logic remain in the Python bridge one directory above.
+The separate `nightlies`, `commits`, and `wandb` views remain available. The panel
+receives Grafana data frames. The Python bridge owns credentials, queries, and caches.
 
 ```bash
 npm ci

--- a/infra/grafana/marin-infra-panel/src/components/InfraPanel.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/InfraPanel.tsx
@@ -2,10 +2,14 @@ import React from 'react';
 import { PanelProps } from '@grafana/data';
 import { CommitStrip } from './CommitStrip';
 import { NightlyMatrix } from './NightlyMatrix';
+import { StatusPage } from './StatusPage';
 import { WandbChart } from './WandbChart';
 import { InfraPanelOptions } from '../types';
 
 export function InfraPanel({ options, data, width, height }: PanelProps<InfraPanelOptions>) {
+  if (options.view === 'status') {
+    return <StatusPage frames={data.series} width={width} height={height} />;
+  }
   if (options.view === 'commits') {
     return <CommitStrip frames={data.series} width={width} height={height} />;
   }

--- a/infra/grafana/marin-infra-panel/src/components/StatusPage.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/StatusPage.tsx
@@ -1,0 +1,323 @@
+import React, { useMemo } from 'react';
+import { css } from '@emotion/css';
+import { DataFrame } from '@grafana/data';
+import { useTheme2 } from '@grafana/ui';
+import { frameByRefId, provisioningStatus, seriesPoints, workerRegions } from '../data';
+import { ProvisioningRow, SeriesPoint } from '../types';
+import { CommitStrip } from './CommitStrip';
+import { NightlyMatrix } from './NightlyMatrix';
+import { SERIES_COLORS } from './palette';
+import { PanelMessage } from './PanelMessage';
+import { WandbChart } from './WandbChart';
+
+interface Props {
+  frames: DataFrame[];
+  width: number;
+  height: number;
+}
+
+const REF = {
+  nightlies: 'N',
+  builds: 'G',
+  workers: 'W',
+  provisioning: 'P',
+  workerHistory: 'H',
+  provisioningHistory: 'R',
+  trainLoss: 'T',
+  paloma: 'L',
+  mfu: 'M',
+} as const;
+
+function one(frames: DataFrame[], refId: string): DataFrame[] {
+  const frame = frameByRefId(frames, refId);
+  return frame ? [frame] : [];
+}
+
+function formatCores(millicores: number): string {
+  const cores = millicores / 1000;
+  return cores >= 1000 ? `${(cores / 1000).toFixed(1)}k` : Math.round(cores).toString();
+}
+
+function formatBytes(bytes: number): string {
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value >= 100 ? Math.round(value) : value.toFixed(1)} ${units[unit]}`;
+}
+
+function formatPercent(value?: number): string {
+  return value === undefined ? '—' : `${Math.round(value * 100)}%`;
+}
+
+function formatLatency(value?: number): string {
+  if (value === undefined) {
+    return '—';
+  }
+  return value < 90 ? `${Math.round(value)}s` : `${(value / 60).toFixed(1)}m`;
+}
+
+function relativeTime(epoch: number): string {
+  const minutes = Math.max(0, Math.round((Date.now() - epoch) / 60_000));
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  const hours = Math.round(minutes / 60);
+  return hours < 48 ? `${hours}h ago` : `${Math.round(hours / 24)}d ago`;
+}
+
+function MiniSeriesChart({ points, unit }: { points: SeriesPoint[]; unit: 'count' | 'percent' }) {
+  const theme = useTheme2();
+  const series = useMemo(() => {
+    const grouped = new Map<string, SeriesPoint[]>();
+    for (const point of points) {
+      grouped.set(point.series, [...(grouped.get(point.series) ?? []), point]);
+    }
+    for (const values of grouped.values()) {
+      values.sort((a, b) => a.time - b.time);
+    }
+    return [...grouped.entries()];
+  }, [points]);
+
+  if (points.length < 2) {
+    return <div className={css`height:160px;display:flex;align-items:center;justify-content:center;color:${theme.colors.text.secondary};font-size:12px;`}>History is not available</div>;
+  }
+
+  const width = 800;
+  const height = 170;
+  const pad = { left: 42, right: 12, top: 10, bottom: 28 };
+  const times = points.map((point) => point.time);
+  const values = points.map((point) => point.value);
+  const xMin = Math.min(...times);
+  const xMax = Math.max(...times);
+  const yMin = unit === 'percent' ? 0 : Math.min(0, ...values);
+  const yMax = unit === 'percent' ? 1 : Math.max(1, ...values);
+  const x = (value: number) => pad.left + ((value - xMin) / Math.max(1, xMax - xMin)) * (width - pad.left - pad.right);
+  const y = (value: number) => pad.top + (1 - (value - yMin) / Math.max(1e-9, yMax - yMin)) * (height - pad.top - pad.bottom);
+
+  return (
+    <div>
+      <svg viewBox={`0 0 ${width} ${height}`} width="100%" height="170" role="img" aria-label="24 hour status history">
+        {[0, 0.5, 1].map((fraction) => {
+          const value = yMax - fraction * (yMax - yMin);
+          const rowY = pad.top + fraction * (height - pad.top - pad.bottom);
+          return (
+            <g key={fraction}>
+              <line x1={pad.left} x2={width - pad.right} y1={rowY} y2={rowY} stroke={theme.colors.border.weak} strokeDasharray="2 5" />
+              <text x={pad.left - 6} y={rowY + 4} textAnchor="end" fill={theme.colors.text.secondary} fontSize="10">
+                {unit === 'percent' ? `${Math.round(value * 100)}%` : Math.round(value)}
+              </text>
+            </g>
+          );
+        })}
+        {series.map(([name, samples], index) => (
+          <polyline
+            key={name}
+            fill="none"
+            stroke={SERIES_COLORS[index % SERIES_COLORS.length]}
+            strokeWidth="2"
+            points={samples.map((point) => `${x(point.time)},${y(point.value)}`).join(' ')}
+          />
+        ))}
+        <text x={pad.left} y={height - 7} fill={theme.colors.text.secondary} fontSize="10">
+          {new Date(xMin).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
+        </text>
+        <text x={width - pad.right} y={height - 7} textAnchor="end" fill={theme.colors.text.secondary} fontSize="10">
+          {new Date(xMax).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
+        </text>
+      </svg>
+      <div className={css`display:flex;flex-wrap:wrap;gap:5px 14px;font-size:10px;color:${theme.colors.text.secondary};`}>
+        {series.map(([name], index) => (
+          <span key={name}><span className={css`color:${SERIES_COLORS[index % SERIES_COLORS.length]};`}>━</span> {name}</span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function SectionTitle({ children, detail }: { children: React.ReactNode; detail?: string }) {
+  const theme = useTheme2();
+  return (
+    <div className={css`display:flex;align-items:baseline;gap:10px;margin:0 0 10px;`}>
+      <h2 className={css`font-size:19px;line-height:1.2;margin:0;font-weight:600;color:${theme.colors.text.primary};`}>{children}</h2>
+      {detail && <span className={css`font-size:11px;color:${theme.colors.text.secondary};`}>{detail}</span>}
+    </div>
+  );
+}
+
+function Card({ children }: { children: React.ReactNode }) {
+  const theme = useTheme2();
+  return <div className={css`border:1px solid ${theme.colors.border.weak};border-radius:7px;background:${theme.colors.background.secondary};padding:14px;box-shadow:0 12px 30px rgba(0,0,0,.10);`}>{children}</div>;
+}
+
+function WorkerStatus({ frames }: { frames: DataFrame[] }) {
+  const theme = useTheme2();
+  const currentFrame = frameByRefId(frames, REF.workers);
+  const historyFrame = frameByRefId(frames, REF.workerHistory);
+  const regions = currentFrame ? workerRegions(currentFrame).sort((a, b) => b.healthy - a.healthy) : [];
+  const history = historyFrame ? seriesPoints(historyFrame, 'region', 'workers') : [];
+  const totals = regions.reduce(
+    (value, region) => ({
+      healthy: value.healthy + region.healthy,
+      cpu: value.cpu + region.cpuMillicores,
+      memory: value.memory + region.memoryBytes,
+      chips: value.chips + region.tpuChips,
+    }),
+    { healthy: 0, cpu: 0, memory: 0, chips: 0 }
+  );
+
+  return (
+    <section aria-label="Worker status">
+      <SectionTitle detail="current capacity and 24 hour history">Workers</SectionTitle>
+      <Card>
+        {regions.length === 0 ? (
+          <PanelMessage width={400} height={220}>No worker data</PanelMessage>
+        ) : (
+          <>
+            <div className={css`display:flex;align-items:baseline;flex-wrap:wrap;gap:6px 14px;margin-bottom:14px;`}>
+              <strong className={css`font-size:36px;color:${theme.colors.success.text};`}>{totals.healthy}</strong>
+              <span className={css`color:${theme.colors.text.secondary};font-size:13px;`}>healthy workers</span>
+              <span className={css`color:${theme.colors.text.disabled};`}>·</span>
+              <span><strong>{formatCores(totals.cpu)}</strong> CPU</span>
+              <span><strong>{formatBytes(totals.memory)}</strong> memory</span>
+              <span><strong>{totals.chips}</strong> TPU chips</span>
+            </div>
+            <div className={css`display:grid;grid-template-columns:minmax(220px,.8fr) minmax(360px,1.8fr);gap:22px;@media(max-width:900px){grid-template-columns:1fr;}`}>
+              <div>
+                <div className={css`font-size:10px;text-transform:uppercase;letter-spacing:.08em;color:${theme.colors.text.secondary};margin-bottom:5px;`}>Availability by region</div>
+                {regions.map((region) => (
+                  <div key={region.region} className={css`display:grid;grid-template-columns:1fr auto;gap:12px;padding:6px 0;border-top:1px solid ${theme.colors.border.weak};font-size:12px;`}>
+                    <code>{region.region}</code>
+                    <strong>{region.healthy}</strong>
+                  </div>
+                ))}
+              </div>
+              <MiniSeriesChart points={history} unit="count" />
+            </div>
+          </>
+        )}
+      </Card>
+    </section>
+  );
+}
+
+function Outcome({ label, value, color }: { label: string; value: number; color: string }) {
+  return <span><strong className={css`font-family:monospace;color:${color};`}>{value}</strong> <span>{label}</span></span>;
+}
+
+function PoolTable({ pools }: { pools: ProvisioningRow[] }) {
+  const theme = useTheme2();
+  if (pools.length === 0) {
+    return null;
+  }
+  return (
+    <div className={css`overflow:auto;margin-top:12px;`}>
+      <table className={css`width:100%;border-collapse:collapse;font-size:11px;min-width:760px;`}>
+        <thead>
+          <tr className={css`text-align:left;text-transform:uppercase;letter-spacing:.06em;color:${theme.colors.text.secondary};`}>
+            <th>Pool</th><th>Attempts</th><th>Ready</th><th>Stockout</th><th>Error</th><th>Preempted</th><th>Success</th><th>p50</th>
+          </tr>
+        </thead>
+        <tbody>
+          {pools.map((pool) => (
+            <tr key={`${pool.resourceType}/${pool.scaleGroup}/${pool.zone}`} className={css`border-top:1px solid ${theme.colors.border.weak};`}>
+              <td className={css`padding:7px 12px 7px 0;`}><code>{pool.resourceType}</code> <span className={css`color:${theme.colors.text.secondary};`}>· {pool.scaleGroup} · {pool.zone}</span></td>
+              <td>{pool.outcomes}</td><td className={css`color:${theme.colors.success.text};`}>{pool.ready}</td>
+              <td className={css`color:${theme.colors.warning.text};`}>{pool.stockout}</td>
+              <td className={css`color:${theme.colors.error.text};`}>{pool.error}</td><td>{pool.preempted}</td>
+              <td>{formatPercent(pool.successRatio)}</td><td>{formatLatency(pool.latencyP50Seconds)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ProvisioningStatus({ frames }: { frames: DataFrame[] }) {
+  const theme = useTheme2();
+  const currentFrame = frameByRefId(frames, REF.provisioning);
+  const historyFrame = frameByRefId(frames, REF.provisioningHistory);
+  const rows = currentFrame ? provisioningStatus(currentFrame) : [];
+  const fleet = rows.find((row) => row.scope === 'fleet');
+  const pools = rows.filter((row) => row.scope === 'pool');
+  const history = historyFrame ? seriesPoints(historyFrame, 'region', 'success_ratio') : [];
+
+  return (
+    <section aria-label="Provisioning status">
+      <SectionTitle detail={fleet?.windowHours === undefined ? undefined : `trailing ${fleet.windowHours} hour window`}>Provisioning</SectionTitle>
+      <Card>
+        {!fleet ? (
+          <PanelMessage width={400} height={220}>No provisioning data</PanelMessage>
+        ) : (
+          <>
+            <div className={css`display:flex;align-items:center;flex-wrap:wrap;gap:10px 26px;margin-bottom:14px;`}>
+              <div>
+                <strong className={css`display:block;font-size:34px;color:${fleet.successRatio !== undefined && fleet.successRatio >= .9 ? theme.colors.success.text : theme.colors.warning.text};`}>{formatPercent(fleet.successRatio)}</strong>
+                <span className={css`font-size:11px;color:${theme.colors.text.secondary};`}>create success · {fleet.ready}/{fleet.outcomes} attempts</span>
+              </div>
+              <div className={css`display:flex;flex-wrap:wrap;gap:8px 16px;color:${theme.colors.text.secondary};font-size:11px;`}>
+                <Outcome label="ready" value={fleet.ready} color={theme.colors.success.text} />
+                <Outcome label="stockout" value={fleet.stockout} color={theme.colors.warning.text} />
+                <Outcome label="error" value={fleet.error} color={theme.colors.error.text} />
+                <Outcome label="preempted" value={fleet.preempted} color={theme.colors.text.primary} />
+                <Outcome label="pools placing" value={fleet.poolsPlacing} color={theme.colors.success.text} />
+                <Outcome label="pools without ready outcome" value={fleet.poolsNoReadyOutcome} color={fleet.poolsNoReadyOutcome > 0 ? theme.colors.error.text : theme.colors.text.primary} />
+              </div>
+              <div className={css`margin-left:auto;font-size:11px;color:${theme.colors.text.secondary};`}>
+                latency p50 {formatLatency(fleet.latencyP50Seconds)} · p95 {formatLatency(fleet.latencyP95Seconds)}
+                <br />collected {relativeTime(fleet.collectedAt)}
+              </div>
+            </div>
+            <MiniSeriesChart points={history} unit="percent" />
+            <PoolTable pools={pools} />
+          </>
+        )}
+      </Card>
+    </section>
+  );
+}
+
+export function StatusPage({ frames, width, height }: Props) {
+  const theme = useTheme2();
+  const contentWidth = Math.max(320, width - 32);
+  return (
+    <main className={css`width:${width}px;min-height:${height}px;padding:18px 16px 28px;box-sizing:border-box;color:${theme.colors.text.primary};background:${theme.colors.background.canvas};overflow:hidden;`} aria-label="Marin infrastructure status">
+      <header className={css`display:flex;align-items:baseline;justify-content:space-between;gap:20px;margin-bottom:24px;`}>
+        <div>
+          <h1 className={css`font-size:27px;line-height:1.2;margin:0;font-weight:700;letter-spacing:-.02em;`}>Marin Infra Status</h1>
+          <span className={css`font-size:11px;color:${theme.colors.text.secondary};`}>Grafana refresh controls update all sources</span>
+        </div>
+        <nav className={css`display:flex;flex-wrap:wrap;justify-content:flex-end;gap:5px 14px;font-size:11px;`}>
+          <a href="/d/marin-fleet">Fleet</a><a href="/d/marin-iris">Iris</a><a href="/d/marin-k8s">Kubernetes</a>
+          <a href="/d/marin-training">Training</a><a href="https://github.com/marin-community/marin/actions" target="_blank" rel="noreferrer">GitHub Actions ↗</a>
+        </nav>
+      </header>
+
+      <div className={css`display:flex;flex-direction:column;gap:26px;`}>
+        <section>
+          <NightlyMatrix frames={one(frames, REF.nightlies)} width={contentWidth} height={315} />
+        </section>
+        <section>
+          <SectionTitle>GitHub status</SectionTitle>
+          <Card><CommitStrip frames={one(frames, REF.builds)} width={contentWidth - 30} height={68} /></Card>
+        </section>
+        <div className={css`display:grid;grid-template-columns:minmax(0,1fr) minmax(0,1fr);gap:24px;align-items:start;@media(max-width:1100px){grid-template-columns:1fr;}`}>
+          <WorkerStatus frames={frames} />
+          <ProvisioningStatus frames={frames} />
+        </div>
+        <section aria-label="Hero run charts">
+          <SectionTitle detail="public W&B report · cumulative training tokens">Hero run</SectionTitle>
+          <div className={css`display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:14px;@media(max-width:1000px){grid-template-columns:1fr;}`}>
+            {[REF.trainLoss, REF.paloma, REF.mfu].map((refId) => (
+              <Card key={refId}><WandbChart frames={one(frames, refId)} width={Math.max(280, (contentWidth - 90) / 3)} height={260} /></Card>
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { toDataFrame } from '@grafana/data';
+import { render, screen, within } from '@testing-library/react';
 import { CommitStrip } from './CommitStrip';
 import { NightlyMatrix } from './NightlyMatrix';
+import { StatusPage } from './StatusPage';
 import { WandbChart } from './WandbChart';
 
 // An empty query result — what the bridge returns while a source is briefly
@@ -16,4 +18,36 @@ test('every view renders a placeholder instead of throwing on empty data', () =>
 
   rerender(<WandbChart frames={[]} width={480} height={200} />);
   expect(screen.getByText('No W&B data')).toBeInTheDocument();
+});
+
+function frame(refId: string, rows: Array<Record<string, unknown>>) {
+  return toDataFrame({
+    refId,
+    fields: Object.keys(rows[0]).map((name) => ({ name, values: rows.map((row) => row[name]) })),
+  });
+}
+
+test('status page keeps worker and provisioning status visible when another source has no data', () => {
+  const frames = [
+    frame('W', [{
+      region: 'us-east5', healthy: 12, cpu_millicores: 96000, memory_bytes: 1099511627776, tpu_chips: 64,
+    }]),
+    frame('P', [{
+      scope: 'fleet', collected_at: Date.now(), resource_type: '', scale_group: '', zone: '',
+      ready: 8, stockout: 1, error: 1, preempted: 2, outcomes: 10, success_ratio: 0.8,
+      pools_placing: 4, pools_no_ready_outcome: 1, latency_p50_seconds: 45,
+      latency_p95_seconds: 90, window_hours: 3,
+    }]),
+  ];
+
+  render(<StatusPage frames={frames} width={1400} height={1500} />);
+
+  expect(screen.getByRole('main', { name: 'Marin infrastructure status' })).toBeInTheDocument();
+  const workers = screen.getByRole('region', { name: 'Worker status' });
+  expect(within(workers).getByText('healthy workers')).toBeInTheDocument();
+  expect(within(workers).getByText('us-east5')).toBeInTheDocument();
+  const provisioning = screen.getByRole('region', { name: 'Provisioning status' });
+  expect(within(provisioning).getByText('80%')).toBeInTheDocument();
+  expect(within(provisioning).getByText('pools without ready outcome')).toBeInTheDocument();
+  expect(screen.getAllByText('No W&B data')).toHaveLength(3);
 });

--- a/infra/grafana/marin-infra-panel/src/data.test.ts
+++ b/infra/grafana/marin-infra-panel/src/data.test.ts
@@ -1,8 +1,11 @@
 import { toDataFrame } from '@grafana/data';
-import { frameWithField, nightlyCells } from './data';
+import { frameByRefId, frameWithField, nightlyCells, provisioningStatus, seriesPoints, workerRegions } from './data';
 
-function frame(rows: Array<Record<string, unknown>>) {
-  return toDataFrame({ fields: Object.keys(rows[0]).reverse().map((name) => ({ name, values: rows.map((row) => row[name]) })) });
+function frame(rows: Array<Record<string, unknown>>, refId?: string) {
+  return toDataFrame({
+    refId,
+    fields: Object.keys(rows[0]).reverse().map((name) => ({ name, values: rows.map((row) => row[name]) })),
+  });
 }
 
 const CELL = {
@@ -28,4 +31,36 @@ test('frameWithField rejects ambiguous multiple frames', () => {
 test('frameWithField returns undefined when no frame carries the field', () => {
   expect(frameWithField([frame([CELL])], 'short_oid')).toBeUndefined();
   expect(frameWithField([], 'lane_id')).toBeUndefined();
+});
+
+test('status data contracts preserve worker resources and provisioning outcomes', () => {
+  const [worker] = workerRegions(frame([{
+    region: 'us-east5', healthy: 12, cpu_millicores: 96000, memory_bytes: 1024, tpu_chips: 64,
+  }]));
+  expect(worker).toEqual({
+    region: 'us-east5', healthy: 12, cpuMillicores: 96000, memoryBytes: 1024, tpuChips: 64,
+  });
+
+  const [provisioning] = provisioningStatus(frame([{
+    scope: 'fleet', collected_at: 1000, resource_type: '', scale_group: '', zone: '',
+    ready: 8, stockout: 1, error: 1, preempted: 2, outcomes: 10, success_ratio: 0.8,
+    pools_placing: 4, pools_no_ready_outcome: 1, latency_p50_seconds: 45,
+    latency_p95_seconds: 90, window_hours: 3,
+  }]));
+  expect(provisioning).toMatchObject({
+    scope: 'fleet', ready: 8, successRatio: 0.8, poolsNoReadyOutcome: 1, latencyP95Seconds: 90,
+  });
+});
+
+test('status history reads the configured series and value fields', () => {
+  expect(seriesPoints(frame([{ time: 1000, region: 'us-east5', workers: 12 }]), 'region', 'workers')).toEqual([
+    { time: 1000, series: 'us-east5', value: 12 },
+  ]);
+});
+
+test('frameByRefId isolates one status source', () => {
+  const nightly = frame([CELL], 'N');
+  const workers = frame([{ healthy: 12 }], 'W');
+  expect(frameByRefId([nightly, workers], 'W')).toBe(workers);
+  expect(frameByRefId([nightly], 'W')).toBeUndefined();
 });

--- a/infra/grafana/marin-infra-panel/src/data.ts
+++ b/infra/grafana/marin-infra-panel/src/data.ts
@@ -1,5 +1,5 @@
 import { DataFrame, Field } from '@grafana/data';
-import { CommitRow, NightlyCell, WandbPoint } from './types';
+import { CommitRow, NightlyCell, ProvisioningRow, SeriesPoint, WandbPoint, WorkerRegion } from './types';
 
 type Row = Record<string, unknown>;
 
@@ -95,6 +95,53 @@ export function wandbPoints(frame: DataFrame): WandbPoint[] {
     reportTitle: requiredString(row, 'report_title'),
     reportUrl: requiredString(row, 'report_url'),
   }));
+}
+
+export function workerRegions(frame: DataFrame): WorkerRegion[] {
+  return rows(frame).map((row) => ({
+    region: requiredString(row, 'region'),
+    healthy: requiredNumber(row, 'healthy'),
+    cpuMillicores: requiredNumber(row, 'cpu_millicores'),
+    memoryBytes: requiredNumber(row, 'memory_bytes'),
+    tpuChips: requiredNumber(row, 'tpu_chips'),
+  }));
+}
+
+export function provisioningStatus(frame: DataFrame): ProvisioningRow[] {
+  return rows(frame).map((row) => ({
+    scope: requiredString(row, 'scope'),
+    collectedAt: requiredNumber(row, 'collected_at'),
+    resourceType: optionalString(row, 'resource_type') ?? '',
+    scaleGroup: optionalString(row, 'scale_group') ?? '',
+    zone: optionalString(row, 'zone') ?? '',
+    ready: requiredNumber(row, 'ready'),
+    stockout: requiredNumber(row, 'stockout'),
+    error: requiredNumber(row, 'error'),
+    preempted: requiredNumber(row, 'preempted'),
+    outcomes: requiredNumber(row, 'outcomes'),
+    successRatio: optionalNumber(row, 'success_ratio'),
+    poolsPlacing: requiredNumber(row, 'pools_placing'),
+    poolsNoReadyOutcome: requiredNumber(row, 'pools_no_ready_outcome'),
+    latencyP50Seconds: optionalNumber(row, 'latency_p50_seconds'),
+    latencyP95Seconds: optionalNumber(row, 'latency_p95_seconds'),
+    windowHours: optionalNumber(row, 'window_hours'),
+  }));
+}
+
+export function seriesPoints(frame: DataFrame, seriesField: string, valueField: string): SeriesPoint[] {
+  return rows(frame).map((row) => ({
+    time: requiredNumber(row, 'time'),
+    series: requiredString(row, seriesField),
+    value: requiredNumber(row, valueField),
+  }));
+}
+
+export function frameByRefId(frames: DataFrame[], refId: string): DataFrame | undefined {
+  const matching = frames.filter((frame) => frame.refId === refId);
+  if (matching.length > 1) {
+    throw new Error(`Expected one data frame for ${refId}; received ${matching.length}`);
+  }
+  return matching[0];
 }
 
 /**

--- a/infra/grafana/marin-infra-panel/src/module.ts
+++ b/infra/grafana/marin-infra-panel/src/module.ts
@@ -6,9 +6,10 @@ export const plugin = new PanelPlugin<InfraPanelOptions>(InfraPanel).setPanelOpt
   return builder.addRadio({
     path: 'view',
     name: 'View',
-    defaultValue: 'nightlies',
+    defaultValue: 'status',
     settings: {
       options: [
+        { value: 'status', label: 'Status page' },
         { value: 'nightlies', label: 'Nightly matrix' },
         { value: 'commits', label: 'Commit strip' },
         { value: 'wandb', label: 'W&B chart' },

--- a/infra/grafana/marin-infra-panel/src/types.ts
+++ b/infra/grafana/marin-infra-panel/src/types.ts
@@ -1,4 +1,4 @@
-export type InfraPanelView = 'nightlies' | 'commits' | 'wandb';
+export type InfraPanelView = 'status' | 'nightlies' | 'commits' | 'wandb';
 
 export interface InfraPanelOptions {
   view: InfraPanelView;
@@ -43,4 +43,37 @@ export interface WandbPoint {
   value: number;
   reportTitle: string;
   reportUrl: string;
+}
+
+export interface WorkerRegion {
+  region: string;
+  healthy: number;
+  cpuMillicores: number;
+  memoryBytes: number;
+  tpuChips: number;
+}
+
+export interface ProvisioningRow {
+  scope: string;
+  collectedAt: number;
+  resourceType: string;
+  scaleGroup: string;
+  zone: string;
+  ready: number;
+  stockout: number;
+  error: number;
+  preempted: number;
+  outcomes: number;
+  successRatio?: number;
+  poolsPlacing: number;
+  poolsNoReadyOutcome: number;
+  latencyP50Seconds?: number;
+  latencyP95Seconds?: number;
+  windowHours?: number;
+}
+
+export interface SeriesPoint {
+  time: number;
+  series: string;
+  value: number;
 }

--- a/infra/grafana/marin-infra-panel/tests/dashboard.spec.ts
+++ b/infra/grafana/marin-infra-panel/tests/dashboard.spec.ts
@@ -1,18 +1,19 @@
 import { expect, test } from '@playwright/test';
 
-test('compact infra dashboard renders the overview and deep-dive sections', async ({ page }) => {
+test('infra status page renders regressions, CI, capacity, provisioning, and the hero run', async ({ page }) => {
   await page.goto('/d/infra/infra?orgId=1&kiosk');
+  await expect(page.getByRole('main', { name: 'Marin infrastructure status' })).toBeVisible();
   await expect(page.getByLabel('Nightly regression status')).toBeVisible();
   await expect(page.getByLabel('Main branch build history')).toBeVisible();
-  await expect(page.getByText('Healthy workers', { exact: true })).toBeVisible();
+  await expect(page.getByText('healthy workers', { exact: true })).toBeVisible();
   await page.screenshot({ path: 'artifacts/infra-first-viewport.png' });
 
-  await page.getByText('Fleet and provisioning', { exact: true }).scrollIntoViewIfNeeded();
-  await expect(page.getByText('Workers by region', { exact: true })).toBeVisible();
+  await page.getByRole('region', { name: 'Provisioning status' }).scrollIntoViewIfNeeded();
   await expect(page.getByText('us-east5', { exact: true })).toBeVisible();
+  await expect(page.getByText('pools without ready outcome', { exact: true })).toBeVisible();
   await page.screenshot({ path: 'artifacts/infra-operations.png' });
 
-  await page.getByText('Hero training', { exact: true }).scrollIntoViewIfNeeded();
+  await page.getByRole('region', { name: 'Hero run charts' }).scrollIntoViewIfNeeded();
   await expect(page.getByRole('link', { name: 'W&B report ↗' }).first()).toBeVisible();
   await page.screenshot({ path: 'artifacts/infra-hero-training.png' });
 });

--- a/infra/grafana/provisioning/datasources/status.yaml
+++ b/infra/grafana/provisioning/datasources/status.yaml
@@ -1,0 +1,17 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# The custom status panel reads several fixed bridge routes. One root datasource
+# lets one panel receive GitHub, Iris, finelog, provisioning, and W&B frames.
+apiVersion: 1
+
+datasources:
+  - name: status
+    uid: status
+    type: yesoreyeram-infinity-datasource
+    access: proxy
+    editable: false
+    jsonData:
+      auth_method: none
+      allowedHosts: ["http://127.0.0.1:8081"]
+    url: http://127.0.0.1:8081

--- a/infra/grafana/src/overview.py
+++ b/infra/grafana/src/overview.py
@@ -1,0 +1,174 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fixed bridge projections for the custom infrastructure status view."""
+
+from dataclasses import dataclass
+from datetime import datetime
+
+CANARY_METRICS_NAMESPACE = "infra.canary.metrics"
+PROVISIONING_LOOKBACK_HOURS = 6
+
+_FLEET_SCOPE = "fleet"
+_METRIC_READY = "provision_ready"
+_METRIC_STOCKOUT = "provision_stockout"
+_METRIC_ERROR = "provision_error"
+_METRIC_PREEMPTED = "provision_preempted"
+_METRIC_OUTCOMES = "provision_outcomes"
+_METRIC_SUCCESS_RATIO = "provision_success_ratio"
+_METRIC_POOLS_PLACING = "provision_pools_placing"
+_METRIC_POOLS_NO_READY_OUTCOME = "provision_pools_stockout_dead"
+_METRIC_WINDOW_HOURS = "provision_window_hours"
+_METRIC_LATENCY_SECONDS = "provision_latency_seconds"
+
+
+@dataclass(frozen=True)
+class ProvisioningRow:
+    """One fleet or resource-pool summary from the latest provisioning cycle."""
+
+    scope: str
+    collected_at: int
+    resource_type: str
+    scale_group: str
+    zone: str
+    ready: float
+    stockout: float
+    error: float
+    preempted: float
+    outcomes: float
+    success_ratio: float | None
+    pools_placing: float
+    pools_no_ready_outcome: float
+    latency_p50_seconds: float | None
+    latency_p95_seconds: float | None
+    window_hours: float | None
+
+
+@dataclass
+class _Counts:
+    ready: float = 0
+    stockout: float = 0
+    error: float = 0
+    preempted: float = 0
+    outcomes: float = 0
+    latency_p50_seconds: float | None = None
+    latency_p95_seconds: float | None = None
+
+
+@dataclass
+class _Fleet(_Counts):
+    success_ratio: float | None = None
+    pools_placing: float = 0
+    pools_no_ready_outcome: float = 0
+    window_hours: float | None = None
+
+
+def provisioning_query(cutoff: datetime) -> str:
+    """Return the bounded query for the latest complete provisioning cycle."""
+    cutoff_text = cutoff.strftime("%Y-%m-%d %H:%M:%S")
+    return f"""
+SELECT metric, value, labels, collected_at
+FROM "{CANARY_METRICS_NAMESPACE}"
+WHERE metric LIKE 'provision_%'
+  AND collected_at >= TIMESTAMP '{cutoff_text}'
+  AND collected_at = (
+    SELECT MAX(collected_at)
+    FROM "{CANARY_METRICS_NAMESPACE}"
+    WHERE metric LIKE 'provision_%'
+      AND collected_at >= TIMESTAMP '{cutoff_text}'
+  )
+""".strip()
+
+
+def _apply_counts(target: _Counts, metric: str, value: float, quantile: str) -> None:
+    if metric == _METRIC_READY:
+        target.ready = value
+    elif metric == _METRIC_STOCKOUT:
+        target.stockout = value
+    elif metric == _METRIC_ERROR:
+        target.error = value
+    elif metric == _METRIC_PREEMPTED:
+        target.preempted = value
+    elif metric == _METRIC_OUTCOMES:
+        target.outcomes = value
+    elif metric == _METRIC_LATENCY_SECONDS and quantile == "p50":
+        target.latency_p50_seconds = value
+    elif metric == _METRIC_LATENCY_SECONDS and quantile == "p95":
+        target.latency_p95_seconds = value
+
+
+def _apply_fleet(target: _Fleet, metric: str, value: float, quantile: str) -> None:
+    _apply_counts(target, metric, value, quantile)
+    if metric == _METRIC_SUCCESS_RATIO:
+        target.success_ratio = value
+    elif metric == _METRIC_POOLS_PLACING:
+        target.pools_placing = value
+    elif metric == _METRIC_POOLS_NO_READY_OUTCOME:
+        target.pools_no_ready_outcome = value
+    elif metric == _METRIC_WINDOW_HOURS:
+        target.window_hours = value
+
+
+def _row(
+    scope: str,
+    collected_at: int,
+    counts: _Counts,
+    *,
+    resource_type: str = "",
+    scale_group: str = "",
+    zone: str = "",
+    fleet: _Fleet | None = None,
+) -> ProvisioningRow:
+    success_ratio = counts.ready / counts.outcomes if counts.outcomes else None
+    return ProvisioningRow(
+        scope=scope,
+        collected_at=collected_at,
+        resource_type=resource_type,
+        scale_group=scale_group,
+        zone=zone,
+        ready=counts.ready,
+        stockout=counts.stockout,
+        error=counts.error,
+        preempted=counts.preempted,
+        outcomes=counts.outcomes,
+        success_ratio=fleet.success_ratio if fleet is not None else success_ratio,
+        pools_placing=fleet.pools_placing if fleet is not None else 0,
+        pools_no_ready_outcome=fleet.pools_no_ready_outcome if fleet is not None else 0,
+        latency_p50_seconds=counts.latency_p50_seconds,
+        latency_p95_seconds=counts.latency_p95_seconds,
+        window_hours=fleet.window_hours if fleet is not None else None,
+    )
+
+
+def provisioning_rows(rows: list[dict[str, object]]) -> list[ProvisioningRow]:
+    """Convert the latest EAV cycle to one fleet row and ordered pool rows."""
+    if not rows:
+        return []
+
+    collected_at = int(rows[0]["collected_at"])
+    fleet = _Fleet()
+    pools: dict[tuple[str, str, str], _Counts] = {}
+
+    for source in rows:
+        metric = str(source["metric"])
+        value = float(source["value"])
+        quantile = str(source.get("label_quantile") or "")
+        if source.get("label_scope") == _FLEET_SCOPE:
+            _apply_fleet(fleet, metric, value, quantile)
+            continue
+
+        key = (
+            str(source.get("label_resource_type") or ""),
+            str(source.get("label_scale_group") or ""),
+            str(source.get("label_zone") or ""),
+        )
+        if not all(key):
+            continue
+        _apply_counts(pools.setdefault(key, _Counts()), metric, value, quantile)
+
+    result = [_row(_FLEET_SCOPE, collected_at, fleet, fleet=fleet)]
+    result.extend(
+        _row("pool", collected_at, counts, resource_type=key[0], scale_group=key[1], zone=key[2])
+        for key, counts in sorted(pools.items())
+    )
+    return result

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -24,6 +24,7 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /github/builds                           recent main commits with CI rollup state
     GET /github/nightlies                        7-day nightly-lane matrix (one row per lane/day)
     GET /wandb/{chart}                           sampled public hero-report series by chart key
+    GET /overview/provisioning                   latest fleet and resource-pool provisioning cycle
     GET /k8s/control_plane                       watched components + webhook endpoints, all clusters
     GET /k8s/crashloops                          containers in backoff waiting states
     GET /k8s/pending                             Pending / SchedulingGated pods with age
@@ -58,7 +59,7 @@ import json
 import logging
 from collections.abc import Mapping
 from dataclasses import asdict
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pyarrow as pa
 import uvicorn
@@ -82,6 +83,7 @@ from iris_source import IrisSource
 from k8s_source import K8sFleet, K8sSource
 from loom_alerts import LoomAlertClient, LoomAlertDeliveryError, LoomAlertPayloadError
 from nightly_config import NIGHTLY_LANES
+from overview import PROVISIONING_LOOKBACK_HOURS, provisioning_query, provisioning_rows
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -419,6 +421,23 @@ def create_app(
         except UpstreamError as err:
             return JSONResponse({"error": str(err), "source": err.source}, status_code=err.status_code)
 
+    def overview_provisioning(_: Request) -> JSONResponse:
+        try:
+            now = datetime.now(UTC)
+
+            def run() -> list[dict]:
+                source = finelog_sources[_target_for(_FINELOG_HUB_CLUSTER, finelog_sources).name]
+                cutoff = now - timedelta(hours=PROVISIONING_LOOKBACK_HOURS)
+                table = source.query(provisioning_query(cutoff), max_rows=config.max_rows)
+                return [asdict(row) for row in provisioning_rows(rows_to_json(table))]
+
+            key = ("overview_provisioning", _bucket(now, config.cache_ttl))
+            return JSONResponse(finelog_cache.get_or_compute(key, run))
+        except _BadRequest as err:
+            return JSONResponse({"error": str(err)}, status_code=400)
+        except QueryResultTooLargeError as err:
+            return JSONResponse({"error": f"{err}; reduce the provisioning lookback"}, status_code=400)
+
     def k8s_endpoint(key: str, run) -> JSONResponse:
         # Per-cluster failures are labeled rows inside the response; only a bridge
         # bug raises here, and Starlette turns that into a 500.
@@ -531,6 +550,7 @@ def create_app(
             Route("/github/builds", github_builds),
             Route("/github/nightlies", github_nightlies),
             Route("/wandb/{chart}", wandb_chart),
+            Route("/overview/provisioning", overview_provisioning),
             Route("/finelog/{cluster}/query", query),
             Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/fleet_health", finelog_fleet_health),
             Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/fleet_health", finelog_alerts_fleet_health),

--- a/infra/grafana/tests/fixture_bridge.py
+++ b/infra/grafana/tests/fixture_bridge.py
@@ -106,6 +106,64 @@ def _wandb(chart: str) -> list[dict]:
     return rows
 
 
+def _provisioning() -> list[dict]:
+    common = {
+        "collected_at": round(_NOW.timestamp() * 1000),
+        "pools_placing": 0,
+        "pools_no_ready_outcome": 0,
+        "latency_p95_seconds": None,
+        "window_hours": None,
+    }
+    return [
+        {
+            **common,
+            "scope": "fleet",
+            "resource_type": "",
+            "scale_group": "",
+            "zone": "",
+            "ready": 18,
+            "stockout": 3,
+            "error": 1,
+            "preempted": 2,
+            "outcomes": 22,
+            "success_ratio": 18 / 22,
+            "pools_placing": 5,
+            "pools_no_ready_outcome": 1,
+            "latency_p50_seconds": 48,
+            "latency_p95_seconds": 132,
+            "window_hours": 3,
+        },
+        {
+            **common,
+            "scope": "pool",
+            "resource_type": "v5p-8",
+            "scale_group": "reserved",
+            "zone": "us-east5-a",
+            "ready": 6,
+            "stockout": 1,
+            "error": 0,
+            "preempted": 1,
+            "outcomes": 7,
+            "success_ratio": 6 / 7,
+            "latency_p50_seconds": 42,
+        },
+        {
+            **common,
+            "scope": "pool",
+            "resource_type": "h100-8",
+            "scale_group": "gpu",
+            "zone": "cw-us-east-08a",
+            "ready": 4,
+            "stockout": 2,
+            "error": 1,
+            "preempted": 1,
+            "outcomes": 7,
+            "success_ratio": 4 / 7,
+            "latency_p50_seconds": 65,
+        },
+    ]
+
+
 def _finelog(query: str) -> list[dict]:
     sql = parse_qs(query).get("sql", [""])[0]
     if "probe_latency_ms" in sql and "ROW_NUMBER" not in sql:
@@ -237,6 +295,8 @@ def _rows(path: str, query: str) -> list[dict] | dict:
                 )
             )
         ]
+    if path == "/overview/provisioning":
+        return _provisioning()
     if path == "/iris/marin/health":
         return [{"reachable": True, "up": 1, "latency_ms": 18}]
     if path == "/iris/marin/peers":

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -138,6 +138,42 @@ def test_oversized_result_is_a_400_with_guidance():
     assert "narrow the time range" in resp.json()["error"]
 
 
+def test_overview_provisioning_returns_latest_cycle_summary():
+    source = FakeSource(
+        finelog_result(
+            metric=["provision_ready", "provision_outcomes", "provision_success_ratio"],
+            value=[8.0, 10.0, 0.8],
+            labels=['{"scope": "fleet"}'] * 3,
+            collected_at=[datetime(2026, 7, 17, 3, 0, tzinfo=UTC)] * 3,
+        )
+    )
+
+    response = _client(source).get("/overview/provisioning")
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "scope": "fleet",
+            "collected_at": FROM_MS,
+            "resource_type": "",
+            "scale_group": "",
+            "zone": "",
+            "ready": 8.0,
+            "stockout": 0,
+            "error": 0,
+            "preempted": 0,
+            "outcomes": 10.0,
+            "success_ratio": 0.8,
+            "pools_placing": 0,
+            "pools_no_ready_outcome": 0,
+            "latency_p50_seconds": None,
+            "latency_p95_seconds": None,
+            "window_hours": None,
+        }
+    ]
+    assert "SELECT MAX(collected_at)" in source.queries[0]
+
+
 def test_repeated_identical_panels_hit_finelog_once():
     source = FakeSource(_ONE_ROW)
     client = _client(source)

--- a/infra/grafana/tests/test_overview.py
+++ b/infra/grafana/tests/test_overview.py
@@ -1,0 +1,66 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import UTC, datetime
+
+from overview import provisioning_query, provisioning_rows
+
+
+def _sample(metric: str, value: float, **labels: str) -> dict[str, object]:
+    return {
+        "metric": metric,
+        "value": value,
+        "collected_at": 1_784_257_200_000,
+        **{f"label_{key}": label for key, label in labels.items()},
+    }
+
+
+def test_provisioning_rows_restore_fleet_and_pool_status():
+    rows = [
+        _sample("provision_ready", 9, scope="fleet"),
+        _sample("provision_stockout", 2, scope="fleet"),
+        _sample("provision_error", 1, scope="fleet"),
+        _sample("provision_preempted", 3, scope="fleet"),
+        _sample("provision_outcomes", 12, scope="fleet"),
+        _sample("provision_success_ratio", 0.75, scope="fleet"),
+        _sample("provision_pools_placing", 4, scope="fleet"),
+        _sample("provision_pools_stockout_dead", 2, scope="fleet"),
+        _sample("provision_window_hours", 3, scope="fleet"),
+        _sample("provision_latency_seconds", 45, scope="fleet", quantile="p50"),
+        _sample("provision_latency_seconds", 120, scope="fleet", quantile="p95"),
+        _sample("provision_ready", 3, resource_type="v5p-8", scale_group="a", zone="us-east5-a"),
+        _sample("provision_stockout", 1, resource_type="v5p-8", scale_group="a", zone="us-east5-a"),
+        _sample("provision_outcomes", 4, resource_type="v5p-8", scale_group="a", zone="us-east5-a"),
+        _sample(
+            "provision_latency_seconds",
+            32,
+            resource_type="v5p-8",
+            scale_group="a",
+            zone="us-east5-a",
+            quantile="p50",
+        ),
+    ]
+
+    fleet, pool = provisioning_rows(rows)
+
+    assert fleet.scope == "fleet"
+    assert fleet.success_ratio == 0.75
+    assert (fleet.ready, fleet.stockout, fleet.error, fleet.preempted) == (9, 2, 1, 3)
+    assert (fleet.pools_placing, fleet.pools_no_ready_outcome) == (4, 2)
+    assert (fleet.latency_p50_seconds, fleet.latency_p95_seconds, fleet.window_hours) == (45, 120, 3)
+
+    assert (pool.resource_type, pool.scale_group, pool.zone) == ("v5p-8", "a", "us-east5-a")
+    assert pool.success_ratio == 0.75
+    assert pool.latency_p50_seconds == 32
+
+
+def test_provisioning_rows_return_no_rows_without_a_recent_cycle():
+    assert provisioning_rows([]) == []
+
+
+def test_provisioning_query_uses_one_shared_latest_cycle():
+    sql = provisioning_query(datetime(2026, 7, 29, 3, 0, tzinfo=UTC))
+
+    assert sql.count("2026-07-29 03:00:00") == 2
+    assert "collected_at = (" in sql
+    assert "SELECT MAX(collected_at)" in sql

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -297,11 +297,47 @@ def test_dashboard_datasource_uids_are_provisioned():
             assert uid in uids, f"{name} panel {panel.get('id')}: unknown datasource {uid!r}"
 
 
-def test_provisioning_success_ratio_shows_fleet_and_region_stats():
+def test_status_page_has_each_required_source():
     dashboard = _stitched_dashboards()["infra.json"]
-    (panel,) = [panel for panel in dashboard["panels"] if panel.get("title") == "Provisioning success ratio"]
-    (target,) = panel["targets"]
+    (panel,) = dashboard["panels"]
+    targets = {target["refId"]: target for target in panel["targets"]}
 
+    assert panel["datasource"]["uid"] == "status"
+    assert {ref_id: target["url"] for ref_id, target in targets.items()} == {
+        "N": "/github/nightlies",
+        "G": "/github/builds",
+        "W": "/iris/marin/workers",
+        "P": "/overview/provisioning",
+        "H": "/finelog/marin/query",
+        "R": "/finelog/marin/query",
+        "T": "/wandb/train-loss",
+        "L": "/wandb/paloma-macro-loss",
+        "M": "/wandb/mfu",
+    }
+
+
+def test_status_page_queries_provisioning_snapshot_and_region_history():
+    dashboard = _stitched_dashboards()["infra.json"]
+    (panel,) = dashboard["panels"]
+    targets = {target["refId"]: target for target in panel["targets"]}
+
+    assert panel["type"] == "marin-infra-panel"
+    assert panel["options"]["view"] == "status"
+    assert targets["P"]["url"] == "/overview/provisioning"
+    snapshot_columns = {column["selector"] for column in targets["P"]["columns"]}
+    assert {
+        "scope",
+        "ready",
+        "stockout",
+        "error",
+        "preempted",
+        "outcomes",
+        "success_ratio",
+        "pools_placing",
+        "pools_no_ready_outcome",
+    } <= snapshot_columns
+
+    target = targets["R"]
     columns = {column["selector"]: column for column in target["columns"]}
     assert columns["series"] == {"selector": "series", "text": "region", "type": "string"}
     assert columns["value"]["type"] == "number"
@@ -312,15 +348,11 @@ def test_provisioning_success_ratio_shows_fleet_and_region_stats():
     assert "regexp_replace(json_get(labels, 'zone'), '-[^-]+$', '') AS series" in sql
     assert "ready / NULLIF(outcomes, 0)" in sql
 
-    legend = panel["options"]["legend"]
-    assert legend["displayMode"] == "table"
-    assert legend["calcs"] == ["lastNotNull", "min", "max"]
-
 
 def test_provisioning_render_fixture_routes_metric_query_to_region_series():
     dashboard = _stitched_dashboards()["infra.json"]
-    (panel,) = [panel for panel in dashboard["panels"] if panel.get("title") == "Provisioning success ratio"]
-    (target,) = panel["targets"]
+    (panel,) = dashboard["panels"]
+    (target,) = [target for target in panel["targets"] if target["refId"] == "R"]
     sql = next(param["value"] for param in target["url_options"]["params"] if param["key"] == "sql")
 
     rows = _finelog(urlencode({"sql": sql}))


### PR DESCRIPTION
* restore the retired infrastructure status page as one React panel inside Grafana
* show seven-day nightly regressions, main-branch GitHub status, worker capacity, provisioning outcomes and history, and public W&B hero-run charts
* keep credentials, caching, and upstream requests in the Python bridge
  * add `/overview/provisioning` as a fixed latest-cycle fleet and resource-pool contract
* preserve direct links to detailed Grafana dashboards, GitHub Actions, and the W&B report
* follow the [compact Grafana infra dashboard design](https://github.com/marin-community/marin/blob/main/.agents/projects/20260721_grafana_infra_dashboard.md)
