### PR TITLE
[iris] Show an attempt's terminal reason in the dashboard

### DIFF
--- a/lib/iris/dashboard/src/components/controller/JobDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/JobDetail.vue
@@ -651,7 +651,10 @@ function collectFailuresByState(stateName: string, count: (t: TaskStatus) => num
       if (stateToName(attempt.state) !== stateName) continue
       const finishedAtMs = timestampMs(attempt.finishedAt)
       if (!latest || finishedAtMs >= latest.finishedAtMs) {
-        latest = { attemptId: attempt.attemptId, error: attempt.error ?? '', finishedAtMs }
+        // terminalReason first: an init-container failure leaves `error` empty,
+        // and the failure rows below hide themselves on an empty string.
+        const error = attempt.terminalReason || attempt.error || ''
+        latest = { attemptId: attempt.attemptId, error, finishedAtMs }
       }
     }
     if (!latest) continue

--- a/lib/iris/dashboard/src/components/controller/JobDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/JobDetail.vue
@@ -7,7 +7,7 @@ import { stateToName, stateDisplayName, taskStateDisplayName } from '@/types/sta
 import { useBackends } from '@/composables/useBackends'
 import { useCopyToClipboard } from '@/composables/useCopyToClipboard'
 import {
-  LOCAL_CLUSTER, isFederated,
+  LOCAL_CLUSTER, isFederated, attemptFailureReason,
   type JobStatus, type TaskStatus, type LaunchJobRequest, type JobQuery,
   type GetJobStatusResponse, type GetTaskStatusResponse, type ListTasksResponse, type ListJobsResponse,
   type EndpointInfo, type ListEndpointsResponse,
@@ -651,9 +651,8 @@ function collectFailuresByState(stateName: string, count: (t: TaskStatus) => num
       if (stateToName(attempt.state) !== stateName) continue
       const finishedAtMs = timestampMs(attempt.finishedAt)
       if (!latest || finishedAtMs >= latest.finishedAtMs) {
-        // terminalReason first: an init-container failure leaves `error` empty,
-        // and the failure rows below hide themselves on an empty string.
-        const error = attempt.terminalReason || attempt.error || ''
+        // The failure rows below hide themselves on an empty reason.
+        const error = attemptFailureReason(attempt)
         latest = { attemptId: attempt.attemptId, error, finishedAtMs }
       }
     }

--- a/lib/iris/dashboard/src/components/controller/JobDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/JobDetail.vue
@@ -651,7 +651,6 @@ function collectFailuresByState(stateName: string, count: (t: TaskStatus) => num
       if (stateToName(attempt.state) !== stateName) continue
       const finishedAtMs = timestampMs(attempt.finishedAt)
       if (!latest || finishedAtMs >= latest.finishedAtMs) {
-        // The failure rows below hide themselves on an empty reason.
         const error = attemptFailureReason(attempt)
         latest = { attemptId: attempt.attemptId, error, finishedAtMs }
       }

--- a/lib/iris/dashboard/src/components/controller/TaskDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/TaskDetail.vue
@@ -637,8 +637,13 @@ watch(() => props.taskId, async () => {
                 <td class="px-3 py-2 text-[13px] font-mono">
                   {{ formatDuration(timestampMs(attempt.startedAt), timestampMs(attempt.finishedAt) || undefined) }}
                 </td>
-                <td class="px-3 py-2 text-[13px] text-status-danger truncate max-w-xs">
-                  {{ attempt.error ?? '-' }}
+                <!-- The reason can run to 500 chars, so the cell truncates and
+                     the full text lives in the tooltip. -->
+                <td
+                  class="px-3 py-2 text-[13px] text-status-danger truncate max-w-xs"
+                  :title="attempt.terminalReason || attempt.error || ''"
+                >
+                  {{ attempt.terminalReason || attempt.error || '-' }}
                 </td>
               </tr>
             </tbody>

--- a/lib/iris/dashboard/src/components/controller/TaskDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/TaskDetail.vue
@@ -8,6 +8,7 @@ import { useBackends } from '@/composables/useBackends'
 import {
   isLocal,
   LOCAL_CLUSTER,
+  attemptFailureReason,
   type TaskStatus,
   type GetTaskStatusResponse,
   type EndpointInfo,
@@ -641,9 +642,9 @@ watch(() => props.taskId, async () => {
                      the full text lives in the tooltip. -->
                 <td
                   class="px-3 py-2 text-[13px] text-status-danger truncate max-w-xs"
-                  :title="attempt.terminalReason || attempt.error || ''"
+                  :title="attemptFailureReason(attempt)"
                 >
-                  {{ attempt.terminalReason || attempt.error || '-' }}
+                  {{ attemptFailureReason(attempt) || '-' }}
                 </td>
               </tr>
             </tbody>

--- a/lib/iris/dashboard/src/types/rpc.ts
+++ b/lib/iris/dashboard/src/types/rpc.ts
@@ -96,12 +96,19 @@ export interface TaskAttempt {
   finishedAt?: ProtoTimestamp
   isWorkerFailure?: boolean
   attemptUid?: string
-  // Bounded terminal cause, set only on a failed attempt. `error` reports the
-  // task container's own terminated state, so an init-container failure (a
-  // stage-workdir fetch that 404s, a wrong-architecture image) leaves `error`
-  // empty and lands here instead. Prefer this over `error` when rendering why
-  // an attempt failed.
+  // Bounded terminal cause, set only on a failed attempt. Read it through
+  // `attemptFailureReason` rather than directly.
   terminalReason?: string
+}
+
+/** Why a failed attempt ended, empty when it did not fail.
+ *
+ *  `terminalReason` comes first because `error` carries only the task
+ *  container's own terminated state: an init-container failure (a stage-workdir
+ *  fetch that 404s, a wrong-architecture image) arrives as an empty string
+ *  there, which `??` does not treat as missing. */
+export function attemptFailureReason(attempt: TaskAttempt): string {
+  return attempt.terminalReason || attempt.error || ''
 }
 
 export interface TaskStatus {

--- a/lib/iris/dashboard/src/types/rpc.ts
+++ b/lib/iris/dashboard/src/types/rpc.ts
@@ -96,17 +96,13 @@ export interface TaskAttempt {
   finishedAt?: ProtoTimestamp
   isWorkerFailure?: boolean
   attemptUid?: string
-  // Bounded terminal cause, set only on a failed attempt. Read it through
-  // `attemptFailureReason` rather than directly.
+  // Bounded terminal cause, set only on a failed attempt.
   terminalReason?: string
 }
 
-/** Why a failed attempt ended, empty when it did not fail.
- *
- *  `terminalReason` comes first because `error` carries only the task
- *  container's own terminated state: an init-container failure (a stage-workdir
- *  fetch that 404s, a wrong-architecture image) arrives as an empty string
- *  there, which `??` does not treat as missing. */
+/** Why a failed attempt ended, empty when it did not fail. `terminalReason`
+ *  wins because an init-container failure sends `error` as an empty string,
+ *  which `??` would keep. */
 export function attemptFailureReason(attempt: TaskAttempt): string {
   return attempt.terminalReason || attempt.error || ''
 }

--- a/lib/iris/dashboard/src/types/rpc.ts
+++ b/lib/iris/dashboard/src/types/rpc.ts
@@ -96,6 +96,12 @@ export interface TaskAttempt {
   finishedAt?: ProtoTimestamp
   isWorkerFailure?: boolean
   attemptUid?: string
+  // Bounded terminal cause, set only on a failed attempt. `error` reports the
+  // task container's own terminated state, so an init-container failure (a
+  // stage-workdir fetch that 404s, a wrong-architecture image) leaves `error`
+  // empty and lands here instead. Prefer this over `error` when rendering why
+  // an attempt failed.
+  terminalReason?: string
 }
 
 export interface TaskStatus {


### PR DESCRIPTION
The task page and the job page now show `TaskAttempt.terminal_reason` for a
failed attempt, and use `error` only when `terminal_reason` is empty. The three
read sites share one `attemptFailureReason` helper, so the fallback order cannot
drift between them.

The controller sets `terminal_reason` on every failed attempt, but the dashboard
`TaskAttempt` type did not declare the field, so the reason never got to the
page. The `error` field holds only the terminated state of the task container, so
an init-container failure leaves it as an empty string. A stage-workdir bundle
fetch that returns 404 does this, and so does an image for the wrong
architecture. The attempts table then showed an empty cell, because
`error ?? '-'` does not catch an empty string, and the job page's failure rows
dropped the reason text behind `v-if="f.error"` while still listing the task.

One failed attempt of `grug-train-gb200-d6144-64gpu-nomtp-1x-hetero126-ch2-v1` on
`cw-us-east-08a` sent `Init:Error stage-workdir` in its `GetTaskStatus` response
while the UI showed no reason at all.

The task page also puts the full reason in a tooltip. The controller bounds the
reason at 500 characters, which is longer than the cell shows.

The task-level Error box and the task-list cells still read `task.error`, because
`TaskStatus` carries no `terminal_reason` field. Closing that gap needs a new
proto field and controller plumbing.

`vue-tsc --noEmit` passes, and the field name is checked against a live
`GetTaskStatus` payload rather than the proto alone. Nothing here was rendered in
a browser. `rsbuild build` fails in this checkout because
`node_modules/speedscope/dist` is absent, which reproduces on `main`.
