### PR TITLE
[eval] Read historical runtime provenance keys

### DIFF
--- a/infra/evaldash/src/fixtures.py
+++ b/infra/evaldash/src/fixtures.py
@@ -275,11 +275,7 @@ def _write_samples(fs, results_path: str, task: str, samples: list[EvalSample]) 
 
 
 def _write_broken_record(fs, dest: str) -> str:
-    """Write one record.json missing ``launch_host`` to exercise Debug parse failures.
-
-    The historical ``evalchemy_image`` key remains valid; the absent launch host makes this record
-    genuinely malformed. ``read_records`` collects it as a failure rather than silently dropping it,
-    so the Debug tab has an error to show. Returns the path written."""
+    """Write one record.json missing ``launch_host`` and return its path."""
     run_id = "20260722-000000-legacy-mmlu-broken"
     path = f"{dest}/{run_id}/{RECORD_FILE}"
     fs.makedirs(f"{dest}/{run_id}", exist_ok=True)

--- a/infra/evaldash/src/fixtures.py
+++ b/infra/evaldash/src/fixtures.py
@@ -275,11 +275,11 @@ def _write_samples(fs, results_path: str, task: str, samples: list[EvalSample]) 
 
 
 def _write_broken_record(fs, dest: str) -> str:
-    """Write one record.json missing a required field, to exercise the Debug view's parse-failure list.
+    """Write one record.json missing ``launch_host`` to exercise Debug parse failures.
 
-    Mirrors the real schema drift seen in object storage: a record written before ``eval_runtime`` was
-    a required provenance field. ``read_records`` collects it as a failure rather than silently
-    dropping it, so the Debug tab has an error to show. Returns the path written."""
+    The historical ``evalchemy_image`` key remains valid; the absent launch host makes this record
+    genuinely malformed. ``read_records`` collects it as a failure rather than silently dropping it,
+    so the Debug tab has an error to show. Returns the path written."""
     run_id = "20260722-000000-legacy-mmlu-broken"
     path = f"{dest}/{run_id}/{RECORD_FILE}"
     fs.makedirs(f"{dest}/{run_id}", exist_ok=True)
@@ -297,7 +297,7 @@ def _write_broken_record(fs, dest: str) -> str:
         "metrics": {"mmlu": {"acc,none": 0.5}},
         "jobs": {},
         "log_tails": {},
-        "provenance": {"git_sha": "deadbeef", "launch_host": "old-host"},  # missing required eval_runtime
+        "provenance": {"git_sha": "deadbeef", "evalchemy_image": "evalchemy:old"},
     }
     with fs.open(path, "w") as handle:
         handle.write(json.dumps(broken, indent=2))

--- a/lib/marin/src/marin/evaluation/records.py
+++ b/lib/marin/src/marin/evaluation/records.py
@@ -18,7 +18,7 @@ from enum import StrEnum
 
 import fsspec
 from fsspec.core import url_to_fs
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
 
@@ -112,13 +112,14 @@ class Provenance(BaseModel):
     """Where the run came from: launch-time git SHA, eval runtime, and launch host.
 
     ``eval_runtime`` is Evalchemy's commit-pinned package requirement or Harbor's pinned package
-    requirements.
+    requirements. Records written before external evaluators used ``eval_image`` or
+    ``evalchemy_image`` for the same value.
     """
 
     model_config = ConfigDict(frozen=True)
 
     git_sha: str
-    eval_runtime: str
+    eval_runtime: str = Field(validation_alias=AliasChoices("eval_runtime", "eval_image", "evalchemy_image"))
     launch_host: str
 
 

--- a/tests/evals/test_records.py
+++ b/tests/evals/test_records.py
@@ -11,6 +11,7 @@ These tests pin that shape independently of the pydantic model that produces it.
 
 import json
 
+import pytest
 from marin.evaluation.records import (
     EvalRef,
     EvalRunRecord,
@@ -167,10 +168,9 @@ def test_record_json_includes_harbor_policy_identity_and_effective_limit(tmp_pat
     }
 
 
-def test_read_record_parses_a_previously_written_record_json(tmp_path):
-    """A ``record.json`` written by a prior version of the module (plain dict, ``eval`` key, list-typed
-    ``log_tails``) must still parse -- this is the on-disk shape of every record already in object
-    storage, independent of whatever Python type produces or consumes it now."""
+@pytest.mark.parametrize("runtime_key", ["evalchemy_image", "eval_image"])
+def test_read_record_parses_a_previously_written_record_json(tmp_path, runtime_key):
+    """Historical runtime field names normalize to the current record schema."""
     legacy = {
         "run_id": "20260101-000000-llama-3-8b-mmlu-abcd",
         "group_id": "20260101-000000-llama-3-8b-abcd",
@@ -189,7 +189,7 @@ def test_read_record_parses_a_previously_written_record_json(tmp_path):
         "metrics": {},
         "jobs": {"orchestrator": "job/1"},
         "log_tails": {"serve": ["boot failed", "OOM"]},
-        "provenance": {"git_sha": "deadbeef", "eval_runtime": "evalchemy:old", "launch_host": "ci-runner"},
+        "provenance": {"git_sha": "deadbeef", runtime_key: "evalchemy:old", "launch_host": "ci-runner"},
     }
     path = tmp_path / "record.json"
     path.write_text(json.dumps(legacy))
@@ -202,3 +202,9 @@ def test_read_record_parses_a_previously_written_record_json(tmp_path):
     assert record.status is RunStatus.INFRA_FAILED
     assert record.log_tails == {"serve": ("boot failed", "OOM")}
     assert record.hardware.region_or_cluster is None
+    assert record.provenance.eval_runtime == "evalchemy:old"
+    assert record.model_dump(mode="json", by_alias=True)["provenance"] == {
+        "git_sha": "deadbeef",
+        "eval_runtime": "evalchemy:old",
+        "launch_host": "ci-runner",
+    }

--- a/tests/evaluation/test_evaldash_local_store.py
+++ b/tests/evaluation/test_evaldash_local_store.py
@@ -164,7 +164,7 @@ def test_ingestor_surfaces_parse_failures(tmp_path):
     assert probe["error"] is None
     assert len(probe["parse_failures"]) == 1
     assert probe["parse_failures"][0]["path"].endswith("20260722-000000-legacy-mmlu-broken/record.json")
-    assert "eval_runtime" in probe["parse_failures"][0]["error"]
+    assert "launch_host" in probe["parse_failures"][0]["error"]
 
 
 def test_api_jobs_degrade_without_a_cluster(client):


### PR DESCRIPTION
Accept `evalchemy_image` and `eval_image` as historical input aliases for
provenance runtime data while retaining `eval_runtime` as the serialized key.
This restores records written before the external-evaluator migration without
rewriting object-store artifacts or accepting a missing runtime value.

The patched parser read 381 GCS records and 199 CoreWeave records with zero
failures before rollout. Cloud Run revision `marin-evaldash-00013-llx` now
serves the new image; its first production ingest read 381 GCS and 203
CoreWeave records with zero unparseable records.

The investigation and rollout record is in the
[Weaver report](https://loom.rjp.io/s/r6ikampq/artifacts/report), with the
durable [incident record in Echo](https://echo.oa.dev/wiki/45).
