### PR TITLE
[iris] Mark dirty worktree image tags

### DIFF
--- a/lib/iris/src/iris/cli/build.py
+++ b/lib/iris/src/iris/cli/build.py
@@ -4,7 +4,6 @@
 """Image build commands."""
 
 import subprocess
-from dataclasses import replace
 from pathlib import Path
 
 import click
@@ -32,25 +31,31 @@ def _is_verbose(ctx: click.Context) -> bool:
     return False
 
 
-def get_git_sha() -> str:
-    """Short hash of the current working tree content (the image dedup key).
+def get_git_provenance() -> Provenance:
+    """Get the provenance of the current working tree.
 
-    Returns the tree hash of HEAD plus any staged/unstaged changes. This is
-    deterministic: the same tree content always produces the same hash, so
-    ``iris build`` and a later ``worker-restart --skip-current-hash`` see
-    matching values without having to be invoked back-to-back.
+    The tree hash includes staged and unstaged tracked changes. The dirty flag
+    also includes untracked files.
     """
     try:
-        return Provenance.from_git().dedup_key
+        return Provenance.from_git()
     except RuntimeError as e:
-        raise click.ClickException(f"Failed to get git SHA. Are you in a git repository? ({e})") from e
+        raise click.ClickException(f"Failed to get git provenance. Are you in a git repository? ({e})") from e
 
 
-def _versioned_tag(image_base: str, git_sha: str, platform: str) -> str:
-    if "," in platform:
-        return f"{image_base}:{git_sha}"
-    architecture = platform.rsplit("/", 1)[-1]
-    return f"{image_base}:{git_sha}-{architecture}"
+def get_git_sha() -> str:
+    """Get the short hash of the current tracked worktree."""
+    return get_git_provenance().dedup_key
+
+
+def _versioned_tag(image_base: str, provenance: Provenance, platform: str) -> str:
+    version = provenance.dedup_key
+    if "," not in platform:
+        architecture = platform.rsplit("/", 1)[-1]
+        version = f"{version}-{architecture}"
+    if provenance.dirty:
+        version = f"{version}-dirty"
+    return f"{image_base}:{version}"
 
 
 def find_marin_root() -> Path:
@@ -173,7 +178,7 @@ def build_image(
     push: bool,
     context: str | None,
     platform: str,
-    git_sha: str,
+    provenance: Provenance,
     ghcr_org: str = GHCR_DEFAULT_ORG,
     verbose: bool = False,
     cargo_profile: str = DEFAULT_CARGO_PROFILE,
@@ -203,7 +208,7 @@ def build_image(
 
     # Derive image base name from tag (e.g. "iris-worker:latest" -> "iris-worker")
     image_base = tag.split(":")[0]
-    sha_tag = _versioned_tag(image_base, git_sha, platform)
+    sha_tag = _versioned_tag(image_base, provenance, platform)
     latest_tag = f"{image_base}:latest"
 
     click.echo(f"Using Dockerfile: {dockerfile_path}")
@@ -225,9 +230,6 @@ def build_image(
     cmd = ["docker", "buildx", "build", "--platform", platform]
     cmd.extend(["--target", image_type])
     cmd.extend(["--build-arg", f"CARGO_PROFILE={cargo_profile}"])
-    # tree_hash is pinned to the rollout's git_sha (which the tags also use) so a
-    # mid-build edit can't make a worker report a hash that disagrees with its tag.
-    provenance = replace(Provenance.from_git(), tree_hash=git_sha)
     for key, value in provenance_to_env(provenance).items():
         cmd.extend(["--build-arg", f"{key}={value}"])
     for t in all_tags:
@@ -305,24 +307,24 @@ def _build_all(
 
     Registry tags are derived from the git SHA.
     """
-    git_sha = get_git_sha()
+    provenance = get_git_provenance()
     marin_root = find_marin_root()
 
     _ensure_protos()
 
     for image_type in ("worker", "controller"):
-        tag = _versioned_tag(f"iris-{image_type}", git_sha, platform)
-        build_image(image_type, tag, push, None, platform, git_sha, ghcr_org, verbose)
+        tag = _versioned_tag(f"iris-{image_type}", provenance, platform)
+        build_image(image_type, tag, push, None, platform, provenance, ghcr_org, verbose)
         click.echo()
 
     # Task target uses the same Dockerfile but needs marin root as context
     build_image(
         "task",
-        _versioned_tag("iris-task", git_sha, platform),
+        _versioned_tag("iris-task", provenance, platform),
         push,
         str(marin_root),
         platform,
-        git_sha,
+        provenance,
         ghcr_org,
         verbose,
     )
@@ -374,10 +376,10 @@ def build_worker_image(
 ):
     """Build Docker image for Iris worker."""
     verbose = _is_verbose(ctx)
-    git_sha = get_git_sha()
+    provenance = get_git_provenance()
     _ensure_protos()
-    tag = tag or _versioned_tag("iris-worker", git_sha, platform)
-    build_image("worker", tag, push, context, platform, git_sha, ghcr_org, verbose=verbose)
+    tag = tag or _versioned_tag("iris-worker", provenance, platform)
+    build_image("worker", tag, push, context, platform, provenance, ghcr_org, verbose=verbose)
 
 
 @build.command("controller-image")
@@ -397,10 +399,10 @@ def build_controller_image(
 ):
     """Build Docker image for Iris controller."""
     verbose = _is_verbose(ctx)
-    git_sha = get_git_sha()
+    provenance = get_git_provenance()
     _ensure_protos()
-    tag = tag or _versioned_tag("iris-controller", git_sha, platform)
-    build_image("controller", tag, push, context, platform, git_sha, ghcr_org, verbose=verbose)
+    tag = tag or _versioned_tag("iris-controller", provenance, platform)
+    build_image("controller", tag, push, context, platform, provenance, ghcr_org, verbose=verbose)
 
 
 @build.command("task-image")
@@ -424,9 +426,9 @@ def build_task_image(
     marin_root = find_marin_root()
 
     verbose = _is_verbose(ctx)
-    git_sha = get_git_sha()
+    provenance = get_git_provenance()
     _ensure_protos()
-    resolved_tag = tag or _versioned_tag("iris-task", git_sha, platform)
+    resolved_tag = tag or _versioned_tag("iris-task", provenance, platform)
 
     build_image(
         "task",
@@ -434,7 +436,7 @@ def build_task_image(
         push,
         str(marin_root),
         platform,
-        git_sha,
+        provenance,
         ghcr_org,
         verbose=verbose,
     )

--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -23,6 +23,7 @@ from connectrpc.errors import ConnectError
 from finelog.deploy.cli import down_cmd, logs_cmd, restart_cmd, status_cmd, up_cmd
 from rigging.config_discovery import list_cluster_configs
 from rigging.filesystem import marin_temp_bucket
+from rigging.provenance import Provenance
 from rigging.timing import Duration, ExponentialBackoff, Timestamp
 from rigging.token_authority import SigningKey, generate_ed25519_keypair, signing_key_from_private_pem
 
@@ -32,6 +33,7 @@ from iris.cli.build import (
     _versioned_tag,
     build_image,
     find_marin_root,
+    get_git_provenance,
     get_git_sha,
 )
 from iris.cli.connect import IRIS_CLUSTER_CONFIG_DIRS, require_controller_url, rpc_client_for_ctx
@@ -165,7 +167,7 @@ def _parse_ghcr_tag(image_tag: str) -> tuple[str, str, str] | None:
 def _build_and_push_image(
     image_tag: str,
     image_type: str,
-    git_sha: str,
+    provenance: Provenance,
     verbose: bool = False,
     platform: str = AMD64_IMAGE_PLATFORM,
     cargo_profile: str = DEFAULT_CARGO_PROFILE,
@@ -191,7 +193,7 @@ def _build_and_push_image(
         push=True,
         context=context,
         platform=platform,
-        git_sha=git_sha,
+        provenance=provenance,
         ghcr_org=org,
         verbose=verbose,
         cargo_profile=cargo_profile,
@@ -201,7 +203,7 @@ def _build_and_push_image(
 
 def _build_cluster_images(
     config,
-    git_sha: str,
+    provenance: Provenance,
     verbose: bool = False,
     task_platforms: str | None = None,
     cargo_profile: str = DEFAULT_CARGO_PROFILE,
@@ -214,7 +216,7 @@ def _build_cluster_images(
         _build_and_push_image(
             worker_tag,
             "worker",
-            git_sha,
+            provenance,
             verbose=verbose,
             platform=AMD64_IMAGE_PLATFORM,
             cargo_profile=cargo_profile,
@@ -227,7 +229,7 @@ def _build_cluster_images(
         _build_and_push_image(
             controller_tag,
             "controller",
-            git_sha,
+            provenance,
             verbose=verbose,
             platform=controller_platforms,
             cargo_profile=cargo_profile,
@@ -240,7 +242,7 @@ def _build_cluster_images(
         _build_and_push_image(
             task_tag,
             "task",
-            git_sha,
+            provenance,
             verbose=verbose,
             platform=task_platforms,
             cargo_profile=cargo_profile,
@@ -250,7 +252,7 @@ def _build_cluster_images(
     return built
 
 
-def _pin_latest_images(config, git_sha: str, task_platforms: str | None = None) -> dict[str, str]:
+def _pin_latest_images(config, provenance: Provenance, task_platforms: str | None = None) -> dict[str, str]:
     """Pin :latest image tags to the current git SHA in memory only."""
 
     kubernetes = config.defaults.worker.runtime == KUBERNETES_WORKER_RUNTIME
@@ -261,7 +263,7 @@ def _pin_latest_images(config, git_sha: str, task_platforms: str | None = None) 
         if not tag:
             return tag
         if tag.endswith(":latest"):
-            return _versioned_tag(tag.removesuffix(":latest"), git_sha, platform)
+            return _versioned_tag(tag.removesuffix(":latest"), provenance, platform)
         return tag
 
     tags = {
@@ -297,12 +299,12 @@ def _build_and_pin_deploy_images(
     cargo_profile: str = DEFAULT_CARGO_PROFILE,
 ) -> None:
     """Pin :latest tags to the working-tree hash, build + push the images, echo them."""
-    git_sha = get_git_sha()
-    _pin_latest_images(config, git_sha, task_platforms)
+    provenance = get_git_provenance()
+    _pin_latest_images(config, provenance, task_platforms)
     verbose = ctx.obj.get("verbose", False)
     built = _build_cluster_images(
         config,
-        git_sha,
+        provenance,
         verbose=verbose,
         task_platforms=task_platforms,
         cargo_profile=cargo_profile,
@@ -565,12 +567,12 @@ def cluster_start(ctx, local: bool, fresh: bool, task_image_platforms: str | Non
         config = make_local_config(config)
     is_local = config.controller.controller_kind() == "local"
     if not is_local:
-        git_sha = get_git_sha()
-        _pin_latest_images(config, git_sha, task_image_platforms)
+        provenance = get_git_provenance()
+        _pin_latest_images(config, provenance, task_image_platforms)
         verbose = ctx.obj.get("verbose", False)
         built = _build_cluster_images(
             config,
-            git_sha,
+            provenance,
             verbose=verbose,
             task_platforms=task_image_platforms,
             cargo_profile=cargo_profile,
@@ -652,12 +654,12 @@ def cluster_start_smoke(
     # region-appropriate storage from MARIN_PREFIX.
     config.storage.remote_state_dir = marin_temp_bucket(ttl_days=7, prefix=f"iris/state/{label_prefix}")
 
-    git_sha = get_git_sha()
-    _pin_latest_images(config, git_sha, task_image_platforms)
+    provenance = get_git_provenance()
+    _pin_latest_images(config, provenance, task_image_platforms)
     verbose = ctx.obj.get("verbose", False)
     _build_cluster_images(
         config,
-        git_sha,
+        provenance,
         verbose=verbose,
         task_platforms=task_image_platforms,
         cargo_profile=cargo_profile,
@@ -1572,13 +1574,13 @@ def worker_restart(
     # ``controller restart`` (or by autoscaler-fresh VMs racing the registry),
     # producing a fleet split across multiple git_hashes and making
     # ``--skip-current-hash`` a no-op.
-    git_sha = get_git_sha()
-    _pin_latest_images(config, git_sha)
+    provenance = get_git_provenance()
+    _pin_latest_images(config, provenance)
     verbose = ctx.obj.get("verbose", False)
     if config.defaults.worker.docker_image:
-        _build_and_push_image(config.defaults.worker.docker_image, "worker", git_sha, verbose=verbose)
+        _build_and_push_image(config.defaults.worker.docker_image, "worker", provenance, verbose=verbose)
     if config.defaults.worker.default_task_image:
-        _build_and_push_image(config.defaults.worker.default_task_image, "task", git_sha, verbose=verbose)
+        _build_and_push_image(config.defaults.worker.default_task_image, "task", provenance, verbose=verbose)
 
     # Resolve the controller address workers will reconnect to (matches cluster_create_slice).
     worker_controller_address = config.controller_address()

--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -34,7 +34,6 @@ from iris.cli.build import (
     build_image,
     find_marin_root,
     get_git_provenance,
-    get_git_sha,
 )
 from iris.cli.connect import IRIS_CLUSTER_CONFIG_DIRS, require_controller_url, rpc_client_for_ctx
 from iris.cluster.composer import provider_bundle
@@ -59,7 +58,7 @@ from iris.cluster.local_cluster import LocalCluster
 from iris.cluster.platforms.gcp.worker_bootstrap import build_worker_bootstrap_script
 from iris.cluster.platforms.gcp.workers import GcpWorkerProvider
 from iris.cluster.platforms.types import Labels
-from iris.cluster.provenance import provenance_from_proto
+from iris.cluster.provenance import is_same_image_provenance, provenance_from_proto
 from iris.rpc import controller_pb2, job_pb2, query_pb2, vm_pb2
 from iris.rpc.proto_display import format_accelerator_display, vm_state_name
 from iris.time_proto import timestamp_from_proto
@@ -1613,12 +1612,16 @@ def worker_restart(
             workers = list(all_workers)
 
         if skip_current_hash:
-            target_hash = get_git_sha()
+            target_hash = provenance.tree_hash
             if not target_hash or target_hash == "unknown":
                 click.echo(f"--skip-current-hash requires a known git_hash (got: {target_hash!r})", err=True)
                 raise SystemExit(1)
             before = len(workers)
-            workers = [w for w in workers if w.metadata.provenance.tree_hash != target_hash]
+            workers = [
+                worker
+                for worker in workers
+                if not is_same_image_provenance(provenance_from_proto(worker.metadata.provenance), provenance)
+            ]
             skipped = before - len(workers)
             click.echo(f"Skipping {skipped}/{before} worker(s) already at local git_hash {target_hash}")
 

--- a/lib/iris/src/iris/cluster/provenance.py
+++ b/lib/iris/src/iris/cluster/provenance.py
@@ -54,3 +54,8 @@ def provenance_from_proto(msg: job_pb2.Provenance) -> Provenance:
         branch=msg.branch or None,
         built_by=msg.built_by or None,
     )
+
+
+def is_same_image_provenance(left: Provenance, right: Provenance) -> bool:
+    """Return true when two provenance values identify the same image tag."""
+    return left.tree_hash == right.tree_hash and left.dirty == right.dirty

--- a/lib/iris/tests/cli/test_cluster_images.py
+++ b/lib/iris/tests/cli/test_cluster_images.py
@@ -13,9 +13,27 @@ from iris.cluster.config import (
     KubernetesProviderConfig,
     WorkerConfig,
 )
+from rigging.provenance import Provenance
 
 
-def test_pin_latest_images_pins_kubernetes_task_pods_to_deploy_sha():
+def _provenance(dirty: bool) -> Provenance:
+    return Provenance(
+        tree_hash="abc1234",
+        base_commit="abc1234",
+        dirty=dirty,
+        branch="feature",
+        built_by="tester",
+    )
+
+
+@pytest.mark.parametrize(
+    ("dirty", "dirty_suffix"),
+    [
+        (False, ""),
+        (True, "-dirty"),
+    ],
+)
+def test_pin_latest_images_marks_only_dirty_worktrees(dirty: bool, dirty_suffix: str):
     config = IrisClusterConfig(
         controller=ControllerVmConfig(image="ghcr.io/marin-community/iris-controller:latest"),
         defaults=DefaultsConfig(
@@ -28,11 +46,11 @@ def test_pin_latest_images_pins_kubernetes_task_pods_to_deploy_sha():
         kubernetes_provider=KubernetesProviderConfig(),
     )
 
-    _pin_latest_images(config, "abc1234")
+    _pin_latest_images(config, _provenance(dirty))
 
-    assert config.controller.image == "ghcr.io/marin-community/iris-controller:abc1234"
-    assert config.defaults.worker.docker_image == "ghcr.io/marin-community/iris-worker:abc1234-amd64"
-    assert config.defaults.worker.default_task_image == "ghcr.io/marin-community/iris-task:abc1234"
+    assert config.controller.image == f"ghcr.io/marin-community/iris-controller:abc1234{dirty_suffix}"
+    assert config.defaults.worker.docker_image == f"ghcr.io/marin-community/iris-worker:abc1234-amd64{dirty_suffix}"
+    assert config.defaults.worker.default_task_image == f"ghcr.io/marin-community/iris-task:abc1234{dirty_suffix}"
 
 
 def test_build_image_push_does_not_publish_latest(monkeypatch):
@@ -51,7 +69,7 @@ def test_build_image_push_does_not_publish_latest(monkeypatch):
             push=True,
             context=None,
             platform="linux/arm64",
-            git_sha="abc1234",
+            provenance=_provenance(False),
         )
 
     assert commands == []
@@ -79,7 +97,7 @@ def test_pin_latest_images_single_platform_task_uses_architecture_suffix():
         kubernetes_provider=KubernetesProviderConfig(),
     )
 
-    _pin_latest_images(config, "abc1234", "linux/amd64")
+    _pin_latest_images(config, _provenance(False), "linux/amd64")
 
     assert config.controller.image == "ghcr.io/marin-community/iris-controller:abc1234"
     assert config.defaults.worker.default_task_image == "ghcr.io/marin-community/iris-task:abc1234-amd64"

--- a/lib/iris/tests/cluster/test_provenance.py
+++ b/lib/iris/tests/cluster/test_provenance.py
@@ -1,7 +1,10 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from dataclasses import replace
+
 from iris.cluster.provenance import (
+    is_same_image_provenance,
     provenance_from_env,
     provenance_from_proto,
     provenance_to_env,
@@ -30,3 +33,9 @@ def test_from_env_treats_dockerfile_default_brace_as_unset():
 
 def test_proto_round_trip():
     assert provenance_from_proto(provenance_to_proto(_PROV)) == _PROV
+
+
+def test_image_provenance_identity_uses_tree_hash_and_dirty_state():
+    assert is_same_image_provenance(_PROV, replace(_PROV, branch="other"))
+    assert not is_same_image_provenance(_PROV, replace(_PROV, dirty=False))
+    assert not is_same_image_provenance(_PROV, replace(_PROV, tree_hash="different"))

--- a/lib/rigging/src/rigging/provenance.py
+++ b/lib/rigging/src/rigging/provenance.py
@@ -46,10 +46,10 @@ class Provenance:
     """Identity, human context, and launch context of a built artifact.
 
     Attributes:
-        tree_hash: Short git tree hash of the working-tree content. The
+        tree_hash: Short git tree hash of the tracked working-tree content. The
             deduplication key — content-addressed and stable across builds.
         base_commit: Short hash of the HEAD commit the tree was built from.
-        dirty: Whether the working tree had uncommitted (tracked) changes.
+        dirty: Whether the working tree had uncommitted or untracked changes.
         branch: Branch name at build time, or ``None`` for a detached HEAD.
         built_by: OS user that ran the build, or ``None`` if unknown.
         git_remote: ``origin`` remote URL, or ``None`` if unknown.
@@ -83,7 +83,7 @@ class Provenance:
         return cls(
             tree_hash=_git(["rev-parse", "--short", f"{ref}^{{tree}}"], cwd),
             base_commit=_git(["rev-parse", "--short", "HEAD"], cwd),
-            dirty=bool(stash),
+            dirty=bool(_git(["status", "--porcelain", "--untracked-files=all"], cwd)),
             branch=_git(["symbolic-ref", "--short", "-q", "HEAD"], cwd, check=False) or None,
             built_by=_getuser(),
         )
@@ -118,7 +118,7 @@ class Provenance:
         return cls(
             tree_hash=g("rev-parse", "--short", f"{ref}^{{tree}}"),
             base_commit=g("rev-parse", "--short", "HEAD"),
-            dirty=bool(stash),
+            dirty=bool(g("status", "--porcelain", "--untracked-files=all")),
             branch=g("symbolic-ref", "--short", "-q", "HEAD") or None,
             built_by=_getuser(),
             git_remote=g("remote", "get-url", "origin") or None,

--- a/lib/rigging/tests/test_provenance.py
+++ b/lib/rigging/tests/test_provenance.py
@@ -130,6 +130,18 @@ def test_from_git_dirty_changes_tree_not_base(tmp_path):
     assert dirty.tree_hash != clean.tree_hash
 
 
+def test_git_provenance_untracked_file_is_dirty(tmp_path):
+    repo = _init_repo(tmp_path)
+    clean = Provenance.from_git(repo)
+    (repo / "untracked.txt").write_text("new\n")
+    strict = Provenance.from_git(repo)
+    captured = Provenance.capture(repo)
+    assert strict.dirty is True
+    assert captured.dirty is True
+    assert strict.tree_hash == clean.tree_hash
+    assert captured.tree_hash == clean.tree_hash
+
+
 def test_capture_is_best_effort_outside_a_repo(tmp_path):
     # from_git is strict (the tree hash is the point); capture degrades instead of raising,
     # still recording the launch context that has nothing to do with git.


### PR DESCRIPTION
Append `-dirty` to controller, worker, and task image tags when the local worktree has tracked or untracked changes. Place the marker after architecture suffixes, so single-platform tags use `<tree>-<architecture>-dirty`. Clean worktrees on each branch keep the existing tag format.

Capture provenance once for each build and use it for tags and image metadata. This keeps the image identity and reported provenance on the same worktree snapshot.

Fixes #7760
