### PR TITLE
iris: report backend health during controller rollouts

### DIFF
--- a/.agents/skills/deploy-iris-controllers/SKILL.md
+++ b/.agents/skills/deploy-iris-controllers/SKILL.md
@@ -36,8 +36,6 @@ red-canary days ([incident record](https://echo.oa.dev/wiki/14)).
    a tool yields, poll the same task and read each new output block. Do not pipe
    a command to `tail -25` or an equivalent last-lines command. Such a pipeline
    hides earlier output and gives no useful progress while the command runs.
-7. Print the completion cake only after all selected clusters pass their final
-   gates. Do not print the cake for a blocked, stopped, or partial rollout.
 
 ## How to gate
 
@@ -165,20 +163,6 @@ Do this loop for one cluster. After a passed final gate, start the next cluster.
 7. **Final gate.** Report the verify samples, the verdict, and the smoke job
    state. If the gate passes, continue to the next cluster without operator
    input. If the gate is blocked, stop the rollout.
-
-After the final selected cluster passes its final gate, print the rollout
-summary. Then print this ASCII cake:
-
-```text
-       ,,,,,
-       |||||
-     __|||||__
-    |         |
-    | ROLLOUT |
-  __|_________|__
- |               |
- |_______________|
-```
 
 The restart writes `rollout-record.json` under the cluster's
 `storage.remote_state_dir` and health-checks the new controller, rolling back

--- a/.agents/skills/deploy-iris-controllers/SKILL.md
+++ b/.agents/skills/deploy-iris-controllers/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: deploy-iris-controllers
-description: Deploy the Iris controller to one cluster or across the fleet, with a human gate at every step. Use when restarting, rolling out, or rolling back a controller.
+description: Deploy the Iris controller to one cluster or across the fleet, with automatic progress through passed gates. Use when restarting, rolling out, or rolling back a controller.
 ---
 
 # Skill: Deploy Iris controllers
 
 Roll the controller in your working tree out to one cluster or to the whole
-fleet. One cluster at a time, one human gate per step. The reference for every
-command is `lib/iris/OPS.md` ("Controller Restart", "Rolling back a controller
-deploy", "Controller Checkpoint Rollback").
+fleet. Process one cluster at a time. Continue automatically after each passed
+gate. Stop when a gate is blocked. The reference for every command is
+`lib/iris/OPS.md` ("Controller Restart", "Rolling back a controller deploy",
+"Controller Checkpoint Rollback").
 
 **A restart deploys your working tree, not `main`.** `iris cluster controller
 restart` builds images from HEAD plus staged and unstaged changes
@@ -21,33 +22,43 @@ red-canary days ([incident record](https://echo.oa.dev/wiki/14)).
 1. Never run `iris cluster restart` (no `controller`). It kills every worker and
    every job. `iris cluster controller restart` is the deploy — seconds of
    control-plane downtime, workers unaffected.
-2. Stop at every gate. Present the evidence, then wait for the operator. Do not
-   deploy the next cluster because the previous one passed.
-3. Stop the whole rollout on the first failed gate. Report the failure and offer
-   `--rollback` for that cluster. Do not continue to other clusters and do not
-   retry a restart to "see if it sticks".
-4. Never modify the controller database, and never take an action the operator
-   did not approve at a gate.
+2. Treat an explicit rollout request as approval for its cluster set. Use its
+   order when given. Otherwise, use the order from `plan`. Ask only when the
+   scope is missing or ambiguous.
+3. Evaluate each gate from the command evidence. Report a passed gate and
+   continue without operator input.
+4. Stop the whole rollout at the first blocked gate. Report the cause. After a
+   restart, offer `--rollback` for that cluster. Do not continue to other
+   clusters. Do not retry a restart to "see if it sticks".
+5. Never modify the controller database. Never take an action outside the
+   approved rollout scope.
+6. Continuously monitor the stdout and stderr of each command until it exits. If
+   a tool yields, poll the same task and read each new output block. Do not pipe
+   a command to `tail -25` or an equivalent last-lines command. Such a pipeline
+   hides earlier output and gives no useful progress while the command runs.
+7. Print the completion cake only after all selected clusters pass their final
+   gates. Do not print the cake for a blocked, stopped, or partial rollout.
 
 ## How to gate
 
-Put every gate in front of the operator with `AskUserQuestion`. Show the evidence
-in your message — the snapshot, the verify samples, the smoke result — because the
-operator answers from your text, not from the raw command output. Never treat
-silence, a previous approval, or a passing gate on another cluster as approval.
+A passed gate does not require operator input. Show the evidence, then continue
+to the next step or cluster. Use `AskUserQuestion` only when a blocked gate
+requires operator input. Show the snapshot, verify samples, smoke result, and
+blocker. Silence is not approval for a blocked gate.
 
-The options depend on what the evidence says:
+Process each gate from its evidence:
 
-- **Everything passed:** approve this cluster, stop the rollout here, or skip this
-  cluster and hold at the next gate.
-- **Anything failed:** stop, or roll this cluster back. Never offer to skip ahead
-  after a failure — rule 3 ends the rollout there.
+- **Passed:** Report the evidence and continue within the approved scope.
+- **Blocked before restart:** Report the cause. Ask for the necessary input or
+  stop.
+- **Blocked after restart:** Stop or ask for rollback approval. Never offer to
+  skip ahead.
 
 ## Helper
 
 `scripts/iris/rollout_controllers.py` covers the mechanical steps. It never
-restarts a controller and never walks the cluster list on its own, so the gates
-stay with the operator:
+restarts a controller and never walks the cluster list on its own. The agent
+keeps the approved scope and continues after each passed gate:
 
 ```bash
 uv run python scripts/iris/rollout_controllers.py plan [--clusters a,b]
@@ -66,7 +77,9 @@ Write the snapshot files to the session scratchpad, one per cluster.
    `--clusters` it uses the operator's list verbatim, in that order.
 2. Print `git log -1 --oneline` and the tree image tag that `plan` reports.
    `preflight` reports the tree state in full at the next step.
-3. Ask the operator to confirm the cluster set and the order.
+3. If the rollout request gives the cluster set, continue without another
+   confirmation. Use its order when given. Otherwise, use the `plan` order. If
+   the cluster set is missing or ambiguous, ask the operator.
 
 Do not resolve the cluster list from memory. Cluster names come from `plan` or
 from the operator.
@@ -120,14 +133,17 @@ keys. Hand those clusters to a session that already has SSH.
 
 ## Step 2 — Per cluster
 
-Do this loop for one cluster, then gate. Repeat for the next cluster.
+Do this loop for one cluster. After a passed final gate, start the next cluster.
 
 1. **Snapshot.** `snapshot --cluster <name> --out <scratchpad>/<name>-before.json`
-   records the controller's tree hash, its workers, rough job counts, and the tree
-   this session would deploy. A count printed with `+` hit the query cap and is a
+   records the controller's tree hash, rough job counts, and backend health. A
+   worker-daemon backend reports healthy workers. A Kubernetes backend reports
+   nodes that are ready and schedulable. The snapshot also records the tree this
+   session would deploy. A job count printed with `+` hit the query cap and is a
    floor. If the controller is unreachable now, stop and diagnose.
-2. **Gate.** Show the snapshot. State how many running jobs ride through the
-   restart, and that the restart takes seconds of control-plane downtime.
+2. **Snapshot gate.** Show the snapshot. State how many running jobs ride
+   through the restart. State that the restart causes seconds of control-plane
+   downtime. If the gate passes, restart without waiting for operator input.
 3. **Restart.** `iris --cluster=<name> cluster controller restart`. Add
    `--skip-checkpoint` only if the checkpoint step times out. On a Kubernetes dev
    cluster with amd64 nodes only, add `--image-platform linux/amd64`.
@@ -139,10 +155,30 @@ Do this loop for one cluster, then gate. Repeat for the next cluster.
 5. **Watch.** `verify --cluster <name> --baseline <name>-before.json` samples the
    controller every 30s for 5 minutes, then compares against the baseline. It
    fails on an unreachable controller, a tree hash that is not the one the
-   baseline recorded, or lost healthy workers. Do not shorten the watch.
+   baseline recorded, a changed backend health target, or health loss above the
+   churn tolerance. The tolerance applies to each backend. It is one worker or
+   node, or 5% of that backend's baseline healthy count, whichever is larger. A
+   loss within this tolerance is a note in the gate evidence. Do not shorten the
+   watch.
 6. **Collect the smoke.** Read the background task. If it is still waiting, keep
    waiting — the timeout is 30 minutes and a scale-up is the expected reason.
-7. **Gate.** Report the verify samples, the verdict, and the smoke job state.
+7. **Final gate.** Report the verify samples, the verdict, and the smoke job
+   state. If the gate passes, continue to the next cluster without operator
+   input. If the gate is blocked, stop the rollout.
+
+After the final selected cluster passes its final gate, print the rollout
+summary. Then print this ASCII cake:
+
+```text
+       ,,,,,
+       |||||
+     __|||||__
+    |         |
+    | ROLLOUT |
+  __|_________|__
+ |               |
+ |_______________|
+```
 
 The restart writes `rollout-record.json` under the cluster's
 `storage.remote_state_dir` and health-checks the new controller, rolling back

--- a/scripts/iris/rollout_controllers.py
+++ b/scripts/iris/rollout_controllers.py
@@ -2,11 +2,12 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Per-cluster steps of a human-gated Iris controller rollout.
+"""Per-cluster steps of an evidence-gated Iris controller rollout.
 
 The ``deploy-iris-controllers`` skill drives these subcommands. The restart itself
 stays in ``iris cluster controller restart``: this script never restarts a
-controller and never walks the cluster list, so every deploy keeps its human gate.
+controller and never walks the cluster list. The skill continues after passed
+gates and stops when a gate is blocked.
 """
 
 import functools
@@ -75,6 +76,10 @@ SMOKE_TIMEOUT = 1800
 WATCH_DURATION = 300
 WATCH_INTERVAL = 30
 
+# A small health loss can be normal autoscaler churn during the watch. Always
+# permit one execution unit, then permit 5% of larger baselines.
+HEALTH_LOSS_TOLERANCE_PERCENT = 5
+
 # Rough counts are enough for a before/after comparison, and a bounded query keeps
 # the RPC cheap on a busy controller.
 JOB_COUNT_LIMIT = 500
@@ -124,6 +129,26 @@ class CheckResult:
     detail: str
 
 
+class HealthUnit(StrEnum):
+    """The backend resource used for rollout health."""
+
+    WORKER = "workers"
+    NODE = "nodes"
+
+
+@dataclass(frozen=True)
+class ExecutionHealth:
+    """The healthy execution resources for one backend."""
+
+    backend_id: str
+    unit: HealthUnit
+    healthy: int
+    total: int
+
+    def summary(self) -> str:
+        return f"{self.backend_id}={self.healthy}/{self.total} healthy {self.unit.value}"
+
+
 @dataclass(frozen=True)
 class Snapshot:
     """A rough controller state reading, taken before and after a restart."""
@@ -133,8 +158,7 @@ class Snapshot:
     reachable: bool
     tree_hash: str = ""
     version: str = ""
-    workers_total: int = 0
-    workers_healthy: int = 0
+    execution_health: tuple[ExecutionHealth, ...] = ()
     jobs: dict[str, int] = field(default_factory=dict)
     error: str = ""
     # The tree this session would deploy, read when the baseline is taken. `verify`
@@ -148,10 +172,9 @@ class Snapshot:
         counts = " ".join(
             f"{name}={count}{'+' if count >= JOB_COUNT_LIMIT else ''}" for name, count in sorted(self.jobs.items())
         )
-        return (
-            f"{self.cluster}: version={self.version} tree={self.tree_hash} "
-            f"workers={self.workers_healthy}/{self.workers_total} healthy, jobs {counts}"
-        )
+        health = ", ".join(item.summary() for item in self.execution_health)
+        identity = f"{self.cluster}: version={self.version} tree={self.tree_hash}"
+        return f"{identity} health {health}, jobs {counts}"
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), indent=2, sort_keys=True)
@@ -159,6 +182,15 @@ class Snapshot:
     @classmethod
     def from_json(cls, raw: str) -> "Snapshot":
         data = json.loads(raw)
+        data["execution_health"] = tuple(
+            ExecutionHealth(
+                backend_id=item["backend_id"],
+                unit=HealthUnit(item["unit"]),
+                healthy=item["healthy"],
+                total=item["total"],
+            )
+            for item in data["execution_health"]
+        )
         return cls(**data)
 
 
@@ -475,13 +507,55 @@ def check_requirements(needs: Sequence[Requirement], *, environ: Mapping[str, st
     return results
 
 
+def backend_health(
+    backends: Sequence[controller_pb2.Controller.BackendSummary],
+) -> tuple[ExecutionHealth, ...]:
+    """Read the execution health that each backend type provides."""
+    if not backends:
+        raise ValueError("controller reported no execution backends")
+
+    health = []
+    for backend in backends:
+        detail_kind = backend.detail.WhichOneof("detail")
+        if detail_kind == "worker":
+            detail = backend.detail.worker
+            health.append(
+                ExecutionHealth(
+                    backend_id=backend.backend_id,
+                    unit=HealthUnit.WORKER,
+                    healthy=detail.healthy_worker_count,
+                    total=detail.total_worker_count,
+                )
+            )
+            continue
+        if detail_kind == "kubernetes":
+            detail = backend.detail.kubernetes
+            if detail.total_nodes != len(detail.nodes):
+                raise ValueError(
+                    f"backend {backend.backend_id!r} reports {detail.total_nodes} nodes "
+                    f"but includes {len(detail.nodes)} node records"
+                )
+            health.append(
+                ExecutionHealth(
+                    backend_id=backend.backend_id,
+                    unit=HealthUnit.NODE,
+                    healthy=sum(node.ready and node.schedulable for node in detail.nodes),
+                    total=detail.total_nodes,
+                )
+            )
+            continue
+        raise ValueError(f"backend {backend.backend_id!r} has no supported health detail")
+
+    return tuple(health)
+
+
 def compare(baseline: Snapshot, latest: Snapshot, *, expect_tree_hash: str = "") -> Verdict:
     """Judge a post-restart snapshot against its pre-restart baseline.
 
     Concerns stop a rollout: an unreachable controller, a version that is not the
-    tree that was deployed, or healthy workers that did not come back. Queue depth
-    and job counts move on their own as work arrives, so they are notes — context
-    a human reads at the gate, not a blocker.
+    tree that was deployed, or backend health loss above the churn tolerance.
+    Queue depth and job counts move on their own as work arrives, so they are
+    notes — context a human reads at the gate, not a blocker.
     """
     concerns: list[str] = []
     notes: list[str] = []
@@ -494,10 +568,35 @@ def compare(baseline: Snapshot, latest: Snapshot, *, expect_tree_hash: str = "")
     if latest.tree_hash and latest.tree_hash == baseline.tree_hash:
         notes.append(f"tree hash is unchanged ({latest.tree_hash}) — the deploy shipped the same tree content")
 
-    if latest.workers_healthy < baseline.workers_healthy:
-        concerns.append(f"healthy workers fell from {baseline.workers_healthy} to {latest.workers_healthy}")
-    if latest.workers_total and latest.workers_healthy < latest.workers_total:
-        notes.append(f"{latest.workers_total - latest.workers_healthy} of {latest.workers_total} workers are unhealthy")
+    baseline_health = {(item.backend_id, item.unit): item for item in baseline.execution_health}
+    latest_health = {(item.backend_id, item.unit): item for item in latest.execution_health}
+    if baseline_health.keys() != latest_health.keys():
+        baseline_targets = ", ".join(f"{backend_id} ({unit.value})" for backend_id, unit in baseline_health)
+        latest_targets = ", ".join(f"{backend_id} ({unit.value})" for backend_id, unit in latest_health)
+        concerns.append(
+            f"execution health targets changed from [{baseline_targets or 'none'}] to [{latest_targets or 'none'}]"
+        )
+
+    for key in sorted(baseline_health.keys() & latest_health.keys()):
+        before = baseline_health[key]
+        after = latest_health[key]
+        loss = before.healthy - after.healthy
+        tolerance = max(1, before.healthy * HEALTH_LOSS_TOLERANCE_PERCENT // 100)
+        subject = f"{before.backend_id} healthy {before.unit.value}"
+        if loss > tolerance:
+            concerns.append(
+                f"{subject} fell from {before.healthy} to {after.healthy} "
+                f"(loss {loss} exceeds churn tolerance {tolerance})"
+            )
+        elif loss > 0:
+            notes.append(
+                f"{subject} fell from {before.healthy} to {after.healthy} "
+                f"(loss {loss} is within churn tolerance {tolerance})"
+            )
+        if after.total and after.healthy < after.total:
+            notes.append(
+                f"{after.total - after.healthy} of {after.total} {after.backend_id} {after.unit.value} are unhealthy"
+            )
 
     baseline_running = baseline.jobs.get(JOB_RUNNING, 0)
     latest_running = latest.jobs.get(JOB_RUNNING, 0)
@@ -516,12 +615,12 @@ def _now() -> str:
 
 
 def take_snapshot(cluster: str) -> Snapshot:
-    """Read a controller's version, worker counts, and rough job counts."""
+    """Read a controller's version, backend health, and rough job counts."""
     try:
         with connect_controller(cluster_name=cluster) as endpoint:
             with rpc_client(endpoint.url, endpoint.credentials) as client:
                 info = client.get_process_status(job_pb2.GetProcessStatusRequest(max_log_lines=0)).process_info
-                workers = client.list_workers(controller_pb2.Controller.ListWorkersRequest()).workers
+                backends = client.list_backends(controller_pb2.Controller.ListBackendsRequest()).backends
                 provenance = provenance_from_proto(info.provenance)
             with IrisClient.remote(endpoint.url, credentials=endpoint.credentials) as iris:
                 jobs = {
@@ -533,8 +632,7 @@ def take_snapshot(cluster: str) -> Snapshot:
             reachable=True,
             tree_hash=provenance.tree_hash,
             version=str(provenance),
-            workers_total=len(workers),
-            workers_healthy=sum(1 for worker in workers if worker.healthy),
+            execution_health=backend_health(backends),
             jobs=jobs,
             working_tree_hash=get_git_sha(),
         )
@@ -592,7 +690,7 @@ def _selected_order(clusters: str | None) -> tuple[str, ...]:
 @click.group()
 @click.option("--verbose", is_flag=True, help="Enable debug logging.")
 def cli(verbose: bool) -> None:
-    """Steps of a human-gated Iris controller rollout."""
+    """Steps of an evidence-gated Iris controller rollout."""
     # Every step reports through click.echo, so the default level keeps iris's own
     # config/tunnel chatter out of a gate the operator has to read.
     logging.basicConfig(

--- a/tests/iris/test_rollout_controllers.py
+++ b/tests/iris/test_rollout_controllers.py
@@ -18,13 +18,17 @@ from iris.cluster.config import (
     PlatformConfig,
     StorageConfig,
 )
+from iris.rpc import controller_pb2
 
 from scripts.iris.rollout_controllers import (
+    ExecutionHealth,
+    HealthUnit,
     Need,
     Requirement,
     Snapshot,
     TreeIssue,
     TreeState,
+    backend_health,
     check_requirement,
     check_requirements,
     compare,
@@ -68,11 +72,60 @@ def snapshot(**overrides) -> Snapshot:
         "reachable": True,
         "tree_hash": "aaa",
         "version": "aaa (main)",
-        "workers_total": 10,
-        "workers_healthy": 10,
+        "execution_health": (ExecutionHealth(backend_id="worker-daemon", unit=HealthUnit.WORKER, healthy=10, total=10),),
         "jobs": {"running": 4, "pending": 1, "building": 0},
     }
     return Snapshot(**{**base, **overrides})
+
+
+def health(
+    *,
+    healthy: int = 10,
+    total: int = 10,
+    backend_id: str = "worker-daemon",
+    unit: HealthUnit = HealthUnit.WORKER,
+) -> tuple[ExecutionHealth, ...]:
+    return (ExecutionHealth(backend_id=backend_id, unit=unit, healthy=healthy, total=total),)
+
+
+def test_backend_health_uses_ready_schedulable_kubernetes_nodes():
+    backend = controller_pb2.Controller.BackendSummary(
+        backend_id="kubernetes",
+        running_task_count=40,
+        detail=controller_pb2.Controller.BackendStatus(
+            kubernetes=controller_pb2.Controller.GetKubernetesClusterStatusResponse(
+                total_nodes=3,
+                nodes=[
+                    controller_pb2.Controller.NodeStatus(name="ready", ready=True, schedulable=True),
+                    controller_pb2.Controller.NodeStatus(name="not-ready", ready=False, schedulable=True),
+                    controller_pb2.Controller.NodeStatus(name="cordoned", ready=True, schedulable=False),
+                ],
+            )
+        ),
+    )
+
+    result = backend_health((backend,))
+
+    assert result == (ExecutionHealth(backend_id="kubernetes", unit=HealthUnit.NODE, healthy=1, total=3),)
+    summary = snapshot(execution_health=result, jobs={"running": 40}).summary()
+    assert "kubernetes=1/3 healthy nodes" in summary
+    assert "workers=" not in summary
+
+
+def test_backend_health_uses_worker_daemon_liveness():
+    backend = controller_pb2.Controller.BackendSummary(
+        backend_id="worker-daemon",
+        detail=controller_pb2.Controller.BackendStatus(
+            worker=controller_pb2.Controller.WorkerFleetDetail(
+                healthy_worker_count=8,
+                total_worker_count=10,
+            )
+        ),
+    )
+
+    assert backend_health((backend,)) == (
+        ExecutionHealth(backend_id="worker-daemon", unit=HealthUnit.WORKER, healthy=8, total=10),
+    )
 
 
 def test_rollout_order_leads_with_dev_then_production_then_smallest_first():
@@ -226,9 +279,47 @@ def test_verify_flags_a_controller_running_the_wrong_tree():
 
 
 def test_verify_flags_lost_workers():
-    verdict = compare(snapshot(workers_healthy=10), snapshot(workers_healthy=6), expect_tree_hash="aaa")
+    verdict = compare(
+        snapshot(execution_health=health(healthy=10)),
+        snapshot(execution_health=health(healthy=6)),
+        expect_tree_hash="aaa",
+    )
     assert not verdict.healthy
     assert any("10" in concern and "6" in concern for concern in verdict.concerns)
+
+
+def test_verify_allows_one_lost_worker_as_churn():
+    verdict = compare(
+        snapshot(execution_health=health(healthy=10)),
+        snapshot(execution_health=health(healthy=9)),
+        expect_tree_hash="aaa",
+    )
+    assert verdict.healthy
+    assert not verdict.concerns
+    assert any("churn" in note and "1" in note for note in verdict.notes)
+
+
+def test_verify_flags_worker_loss_above_five_percent():
+    baseline = snapshot(execution_health=health(healthy=100, total=100))
+    permitted = compare(
+        baseline,
+        snapshot(execution_health=health(healthy=95, total=100)),
+        expect_tree_hash="aaa",
+    )
+    too_many = compare(
+        baseline,
+        snapshot(execution_health=health(healthy=94, total=100)),
+        expect_tree_hash="aaa",
+    )
+    assert permitted.healthy
+    assert not too_many.healthy
+
+
+def test_verify_blocks_when_a_backend_health_target_disappears():
+    verdict = compare(snapshot(), snapshot(execution_health=()), expect_tree_hash="aaa")
+
+    assert not verdict.healthy
+    assert any("targets changed" in concern for concern in verdict.concerns)
 
 
 def test_verify_flags_an_unreachable_controller_before_anything_else():


### PR DESCRIPTION
* Report worker-daemon liveness and ready, schedulable Kubernetes nodes from `ListBackends`
  * prevent Kubernetes rollouts from showing `0/0 healthy workers` while jobs run
* Allow health loss of one unit or 5% per backend as restart churn
  * block when a health target changes or the loss exceeds the tolerance
* Continue through passed gates and stop at the first blocked gate
  * monitor all stdout and stderr output from each command
