### PR TITLE
[iris] Admit the agent service account on the remaining clusters

### DIFF
--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -109,6 +109,7 @@ auth:
     - "*@openathena.ai"
     - github-iris@hai-gcp-models.iam.gserviceaccount.com
     - infra-probes@hai-gcp-models.iam.gserviceaccount.com
+    - ravwojdyla@rav-openathena.iam.gserviceaccount.com
 
 kubernetes_provider:
   namespace: iris

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -106,6 +106,7 @@ auth:
   allowed_submitters:
     - "*@openathena.ai"
     - infra-probes@hai-gcp-models.iam.gserviceaccount.com
+    - ravwojdyla@rav-openathena.iam.gserviceaccount.com
 
 kubernetes_provider:
   namespace: iris

--- a/lib/iris/config/cw-us-west-04a.yaml
+++ b/lib/iris/config/cw-us-west-04a.yaml
@@ -56,7 +56,7 @@ auth:
       -----BEGIN PUBLIC KEY-----
       MCowBQYDK2VwAyEA42ziFTlGKgaA/fQ1wJCONKOml7rx5Y8UAQqVLTCtrCo=
       -----END PUBLIC KEY-----
-  allowed_submitters: ["*@openathena.ai"]
+  allowed_submitters: ["*@openathena.ai", "ravwojdyla@rav-openathena.iam.gserviceaccount.com"]
 
 platform:
   label_prefix: iris-ci


### PR DESCRIPTION
Add ravwojdyla@rav-openathena.iam.gserviceaccount.com to auth.allowed_submitters
on cw-rno2a, cw-us-east-02a, and cw-us-west-04a. cw-us-east-08a already has this
entry (#7275).

The agent VM has one credential, that GCP service account, and the marin hub
sends its federated handoffs with that email as the submitter. user_admitted
matches a wildcard entry on the exact domain only, so *@openathena.ai does not
include it, and these three clusters refused the handoff at admission.

An entry for marin and marin-dev is not necessary. allowed_submitters controls
inbound federation handoffs only, and neither hub declares federation_peers.
IAP controls who submits to them directly.

Each cluster reads the new entry only after `iris cluster start` applies the
iris-cluster-config ConfigMap again and restarts the controller.
