### PR TITLE
[grafana] Simplify the hero run charts and fit the nightly table

### DIFF
--- a/infra/grafana/dashboards/infra.json
+++ b/infra/grafana/dashboards/infra.json
@@ -485,11 +485,6 @@
               "type": "string"
             },
             {
-              "selector": "run_state",
-              "text": "run_state",
-              "type": "string"
-            },
-            {
               "selector": "tokens",
               "text": "tokens",
               "type": "number"
@@ -534,11 +529,6 @@
               "type": "string"
             },
             {
-              "selector": "run_state",
-              "text": "run_state",
-              "type": "string"
-            },
-            {
               "selector": "tokens",
               "text": "tokens",
               "type": "number"
@@ -580,11 +570,6 @@
             {
               "selector": "run",
               "text": "run",
-              "type": "string"
-            },
-            {
-              "selector": "run_state",
-              "text": "run_state",
               "type": "string"
             },
             {

--- a/infra/grafana/marin-infra-panel/src/components/NightlyMatrix.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/NightlyMatrix.tsx
@@ -58,12 +58,12 @@ export function NightlyMatrix({ frames, width, height }: Props) {
   const subgroups = spans(lanes, (lane) => `${lane.group}/${lane.subgroup}`);
   const border = theme.colors.border.weak;
   return (
-    <section className={css`width:${width}px;height:${height}px;overflow:auto;color:${theme.colors.text.primary};padding:2px 4px;`} aria-label="Nightly regression status">
+    <section className={css`width:${width}px;min-height:${height}px;color:${theme.colors.text.primary};padding:2px 4px;`} aria-label="Nightly regression status">
       <div className={css`display:flex;align-items:baseline;justify-content:space-between;margin:0 2px 5px;font-size:13px;color:${theme.colors.text.secondary};`}>
         <span><strong className={css`color:${theme.colors.text.primary};font-size:16px;`}>Nightly regressions</strong>{todayCells.length > 0 && ` · Today: ${todayCells.filter((cell) => cell.healthy).length}/${todayCells.length} healthy`}</span>
         <span>✓ healthy · amber slow · × failed · ! missing</span>
       </div>
-      <table className={css`width:100%;min-width:980px;border-collapse:separate;border-spacing:2px;table-layout:fixed;font-size:12px;`}>
+      <table className={css`width:100%;border-collapse:separate;border-spacing:2px;table-layout:fixed;font-size:12px;`}>
         <caption className={css`position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);`}>Seven UTC days of scheduled regression status and duration by lane</caption>
         <colgroup><col className={css`width:72px;`} />{lanes.map((lane) => <col key={lane.laneId} />)}</colgroup>
         <thead>

--- a/infra/grafana/marin-infra-panel/src/components/WandbChart.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/WandbChart.tsx
@@ -31,7 +31,7 @@ export function WandbChart({ frames, width, height }: Props) {
     return { paths: [...groups.entries()], xMin: Math.min(...xs), xMax: Math.max(...xs), yMin: low, yMax: high === low ? low + 1 : high };
   }, [points]);
   if (points.length === 0) {return <PanelMessage width={width} height={height}>No W&B data</PanelMessage>;}
-  const pad = { left: 45, right: 10, top: 28, bottom: 28 };
+  const pad = { left: 45, right: 10, top: 28, bottom: 20 };
   const chartWidth = Math.max(1, width - pad.left - pad.right);
   const chartHeight = Math.max(1, height - pad.top - pad.bottom);
   const x = (value: number) => pad.left + ((value - xMin) / Math.max(1, xMax - xMin)) * chartWidth;
@@ -43,8 +43,5 @@ export function WandbChart({ frames, width, height }: Props) {
       {[0, .5, 1].map((fraction) => { const xx = pad.left + fraction * chartWidth; const value = xMin + fraction * (xMax-xMin); return <text key={fraction} x={xx} y={height-7} textAnchor={fraction===0?'start':fraction===1?'end':'middle'} fill={theme.colors.text.secondary} fontSize="11">{compact(value)}</text>; })}
       {paths.map(([run, values], index) => <polyline key={run} fill="none" stroke={SERIES_COLORS[index % SERIES_COLORS.length]} strokeWidth="2" points={values.map((point) => `${x(point.tokens)},${y(Math.min(yMax, Math.max(yMin, point.value)))}`).join(' ')} />)}
     </svg>
-    <div className={css`position:absolute;left:${pad.left}px;right:8px;bottom:15px;display:flex;gap:10px;overflow:hidden;font-size:11px;`}>
-      {paths.map(([run, values], index) => <span key={run} title={run} className={css`display:flex;gap:3px;min-width:0;`}><span aria-hidden="true" className={css`color:${SERIES_COLORS[index % SERIES_COLORS.length]};`}>━</span><span className={css`overflow:hidden;text-overflow:ellipsis;white-space:nowrap;`}>{run}{values[0].runState === 'running' ? '' : ` (${values[0].runState})`}</span></span>)}
-    </div>
   </section>;
 }

--- a/infra/grafana/marin-infra-panel/src/data.ts
+++ b/infra/grafana/marin-infra-panel/src/data.ts
@@ -97,7 +97,6 @@ export function wandbPoints(frame: DataFrame): WandbPoint[] {
   return rows(frame).map((row) => ({
     chart: requiredString(row, 'chart'),
     run: requiredString(row, 'run'),
-    runState: requiredString(row, 'run_state'),
     tokens: requiredNumber(row, 'tokens'),
     value: requiredNumber(row, 'value'),
     reportTitle: requiredString(row, 'report_title'),

--- a/infra/grafana/marin-infra-panel/src/types.ts
+++ b/infra/grafana/marin-infra-panel/src/types.ts
@@ -38,7 +38,6 @@ export interface CommitRow {
 export interface WandbPoint {
   chart: string;
   run: string;
-  runState: string;
   tokens: number;
   value: number;
   reportTitle: string;

--- a/infra/grafana/src/wandb_source.py
+++ b/infra/grafana/src/wandb_source.py
@@ -93,7 +93,6 @@ class WandbSource:
                         {
                             "chart": chart_title,
                             "run": run,
-                            "run_state": run_data.get("state") or "unknown",
                             "tokens": tokens,
                             "value": value,
                             "report_title": report_title,

--- a/infra/grafana/tests/fixture_bridge.py
+++ b/infra/grafana/tests/fixture_bridge.py
@@ -93,7 +93,6 @@ def _wandb(chart: str) -> list[dict]:
                 {
                     "chart": titles[chart],
                     "run": run,
-                    "run_state": "running" if run_index else "finished",
                     "tokens": tokens,
                     "value": value,
                     "report_title": "67B-A2B MoE on 10T tokens",

--- a/infra/grafana/tests/test_sources.py
+++ b/infra/grafana/tests/test_sources.py
@@ -318,7 +318,6 @@ def test_wandb_points_follow_report_runset_and_drop_null_metric_rows():
         {
             "chart": "MFU (%)",
             "run": "hero",
-            "run_state": "running",
             "tokens": 10,
             "value": 0.42,
             "report_title": "Hero report",


### PR DESCRIPTION
Remove the per-run legend below the train loss, Paloma, and MFU charts on the
infra status page. The axis tick labels stay, so the scales remain readable
without a name and color for each line. The plot area takes the 8 pixels the
legend row used.

That legend was the only reader of `run_state`, so the field is gone from the
W&B source rows, the dashboard selectors, and the panel types.

The nightly regression matrix no longer scrolls. Its 12 lanes and 7 UTC days
need about 271 pixels, but the section clamped the height to 260 and set
overflow to auto, and a 980-pixel table floor forced a horizontal scrollbar on
narrower viewports. The section now sizes with min-height and the fixed table
layout spreads the lane columns across the available width.
