### PR TITLE
rigging: decompress fsutil file previews

### DIFF
--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -46,16 +46,20 @@ that touch its buckets; the rest keep working.
 | Command | What it does |
 |---------|--------------|
 | `ls [URL] [-l]` | Immediate children; with no URL, the declared buckets. `-l` adds size and modification time |
-| `cat URL [--raw]` | Print a file. Tabular JSON and JSONL render as a table; `--raw` writes bytes to stdout |
-| `head URL [-n N]` | The first N lines, reading only the bytes needed |
+| `cat URL [--raw]` | Print a file. Tabular JSON and JSONL render as a table, and `--raw` writes stored bytes to stdout |
+| `head URL [-n N]` | Print the first N lines |
 | `stat URL` | The object's metadata as the backend reports it |
 | `du URL` | Total bytes and object count beneath a prefix |
 | `find PATTERN` | Paths matching a glob, e.g. `gs://marin-us-central2/x/**/*.json` |
 | `cp SRC DST [-r]` | Copy between any two locations, including across backends |
 | `browse [URL]` | The interactive browser |
 
-Reads through `cat` and `head` and the browser's file viewer are capped at 10 MB; use
-`cp` to fetch a whole object.
+`cat`, `head`, and the browser decompress `.gz`, `.bz2`, `.xz`, and `.lzma` files by
+suffix. Thus, a `data.json.gz` preview uses the JSON table view. `cat --raw` writes the
+compressed bytes.
+
+Formatted file previews are capped at 10 MB after decompression. `cat --raw` is capped
+at 10 MB of stored bytes. Use `cp` to fetch a whole object.
 
 ## The browser
 

--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -55,8 +55,8 @@ that touch its buckets; the rest keep working.
 | `browse [URL]` | The interactive browser |
 
 `cat`, `head`, and the browser decompress `.gz`, `.bz2`, `.xz`, and `.lzma` files by
-suffix. Thus, a `data.json.gz` preview uses the JSON table view. `cat --raw` writes the
-compressed bytes.
+suffix. A `data.json.gz` preview uses the JSON table view. `cat --raw` writes the compressed
+bytes.
 
 Formatted file previews are capped at 10 MB after decompression. `cat --raw` is capped
 at 10 MB of stored bytes. Use `cp` to fetch a whole object.

--- a/lib/rigging/src/rigging/fsutil/cli.py
+++ b/lib/rigging/src/rigging/fsutil/cli.py
@@ -20,7 +20,7 @@ from rigging.filesystem.buckets import MissingCredentials, filesystem_for
 from rigging.filesystem.cluster_config import StoreType, data_buckets
 from rigging.filesystem.s3_compat import s3_credentials, s3_endpoint
 from rigging.filesystem.storage_path import StoragePath
-from rigging.fsutil.listing import ROOT, list_entries, read_preview, total_size
+from rigging.fsutil.listing import ROOT, list_entries, read_decompressed_preview, read_preview, total_size
 from rigging.fsutil.render import file_lines, format_size, print_entries
 from rigging.fsutil.tui import run as run_browser
 
@@ -77,10 +77,11 @@ def list_command(url: str, long: bool) -> None:
 @click.option("--raw", is_flag=True, help="Write bytes to stdout without formatting.")
 def cat(url: str, raw: bool) -> None:
     """Print a file, rendering tabular JSON and JSONL as a table."""
-    data = _read(url)
     if raw:
+        data = _read_raw(url)
         sys.stdout.buffer.write(data)
         return
+    data = _read(url)
     for line in file_lines(StoragePath(url).name, data):
         click.echo(line)
 
@@ -159,7 +160,15 @@ def browse(url: str) -> None:
 
 
 def _read(url: str) -> bytes:
-    """Read a bounded preview of *url*, reporting any truncation on stderr."""
+    """Read a bounded, decompressed preview of *url*."""
+    preview = read_decompressed_preview(url)
+    if preview.truncated:
+        click.echo(f"[truncated: read {format_size(len(preview.data))}]", err=True)
+    return preview.data
+
+
+def _read_raw(url: str) -> bytes:
+    """Read stored bytes from *url* and report truncation on stderr."""
     data, size = read_preview(url)
     if size is not None and size > len(data):
         click.echo(f"[truncated: read {format_size(len(data))} of {format_size(size)}]", err=True)

--- a/lib/rigging/src/rigging/fsutil/cli.py
+++ b/lib/rigging/src/rigging/fsutil/cli.py
@@ -20,7 +20,7 @@ from rigging.filesystem.buckets import MissingCredentials, filesystem_for
 from rigging.filesystem.cluster_config import StoreType, data_buckets
 from rigging.filesystem.s3_compat import s3_credentials, s3_endpoint
 from rigging.filesystem.storage_path import StoragePath
-from rigging.fsutil.listing import ROOT, list_entries, read_decompressed_preview, read_preview, total_size
+from rigging.fsutil.listing import ROOT, Preview, list_entries, read_decompressed_preview, read_preview, total_size
 from rigging.fsutil.render import file_lines, format_size, print_entries
 from rigging.fsutil.tui import run as run_browser
 
@@ -162,17 +162,27 @@ def browse(url: str) -> None:
 def _read(url: str) -> bytes:
     """Read a bounded, decompressed preview of *url*."""
     preview = read_decompressed_preview(url)
-    if preview.truncated:
-        click.echo(f"[truncated: read {format_size(len(preview.data))}]", err=True)
+    _report_truncation(preview)
     return preview.data
 
 
 def _read_raw(url: str) -> bytes:
     """Read stored bytes from *url* and report truncation on stderr."""
-    data, size = read_preview(url)
-    if size is not None and size > len(data):
-        click.echo(f"[truncated: read {format_size(len(data))} of {format_size(size)}]", err=True)
-    return data
+    preview = read_preview(url)
+    _report_truncation(preview)
+    return preview.data
+
+
+def _report_truncation(preview: Preview) -> None:
+    if not preview.truncated:
+        return
+    if preview.full_size is None:
+        click.echo(f"[truncated: read first {format_size(len(preview.data))} of decompressed data]", err=True)
+        return
+    click.echo(
+        f"[truncated: read {format_size(len(preview.data))} of {format_size(preview.full_size)}]",
+        err=True,
+    )
 
 
 def _destination(match: str, src_path: str, dst_path: str) -> str:

--- a/lib/rigging/src/rigging/fsutil/compression.py
+++ b/lib/rigging/src/rigging/fsutil/compression.py
@@ -1,0 +1,29 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compression formats for file previews."""
+
+_COMPRESSION_BY_SUFFIX = {
+    ".gz": "gzip",
+    ".bz2": "bz2",
+    ".xz": "xz",
+    ".lzma": "lzma",
+}
+
+
+def compression_for(name: str) -> str | None:
+    """Return the fsspec compression name for a supported file suffix."""
+    lower_name = name.lower()
+    for suffix, compression in _COMPRESSION_BY_SUFFIX.items():
+        if lower_name.endswith(suffix):
+            return compression
+    return None
+
+
+def uncompressed_name(name: str) -> str:
+    """Remove one supported compression suffix from a file name."""
+    lower_name = name.lower()
+    for suffix in _COMPRESSION_BY_SUFFIX:
+        if lower_name.endswith(suffix):
+            return name[: -len(suffix)]
+    return name

--- a/lib/rigging/src/rigging/fsutil/listing.py
+++ b/lib/rigging/src/rigging/fsutil/listing.py
@@ -49,10 +49,9 @@ class Entry:
 
 @dataclasses.dataclass(frozen=True)
 class Preview:
-    """A bounded file preview and its truncation state."""
-
     data: bytes
     truncated: bool
+    full_size: int | None
 
 
 def bucket_url(bucket: str) -> str:
@@ -127,23 +126,24 @@ def parent_url(url: str) -> str:
     return str(parsed.parent)
 
 
-def read_preview(url: str) -> tuple[bytes, int]:
-    """Read up to :data:`MAX_PREVIEW_BYTES` of *url*, returning ``(data, full_size)``.
-
-    The caller compares the two to tell a whole small file from a truncated large one.
-    """
+def read_preview(url: str) -> Preview:
+    """Read a bounded preview of the stored bytes in *url*."""
     fs, path = filesystem_for(url)
-    size = fs.size(path)
-    with fs.open(path, "rb") as f:
-        return f.read(MAX_PREVIEW_BYTES), size
+    return _read_preview(fs, path, compression=None, full_size=fs.size(path))
 
 
 def read_decompressed_preview(url: str) -> Preview:
     """Read a bounded preview and decompress supported file suffixes."""
     fs, path = filesystem_for(url)
-    with fs.open(path, "rb", compression=compression_for(path)) as file:
+    compression = compression_for(path)
+    full_size = fs.size(path) if compression is None else None
+    return _read_preview(fs, path, compression=compression, full_size=full_size)
+
+
+def _read_preview(fs, path: str, *, compression: str | None, full_size: int | None) -> Preview:
+    with fs.open(path, "rb", compression=compression) as file:
         data = file.read(MAX_PREVIEW_BYTES + 1)
-    return Preview(data=data[:MAX_PREVIEW_BYTES], truncated=len(data) > MAX_PREVIEW_BYTES)
+    return Preview(data=data[:MAX_PREVIEW_BYTES], truncated=len(data) > MAX_PREVIEW_BYTES, full_size=full_size)
 
 
 def total_size(url: str) -> tuple[int, int]:

--- a/lib/rigging/src/rigging/fsutil/listing.py
+++ b/lib/rigging/src/rigging/fsutil/listing.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from rigging.filesystem.buckets import filesystem_for
 from rigging.filesystem.cluster_config import StoreType, data_buckets
 from rigging.filesystem.storage_path import StoragePath
+from rigging.fsutil.compression import compression_for
 
 # The root of the browsable tree: the list of declared buckets rather than any one
 # filesystem. Not a URL, so it never reaches fsspec.
@@ -44,6 +45,14 @@ class Entry:
     size: int | None
     mtime: datetime | None
     is_dir: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class Preview:
+    """A bounded file preview and its truncation state."""
+
+    data: bytes
+    truncated: bool
 
 
 def bucket_url(bucket: str) -> str:
@@ -127,6 +136,14 @@ def read_preview(url: str) -> tuple[bytes, int]:
     size = fs.size(path)
     with fs.open(path, "rb") as f:
         return f.read(MAX_PREVIEW_BYTES), size
+
+
+def read_decompressed_preview(url: str) -> Preview:
+    """Read a bounded preview and decompress supported file suffixes."""
+    fs, path = filesystem_for(url)
+    with fs.open(path, "rb", compression=compression_for(path)) as file:
+        data = file.read(MAX_PREVIEW_BYTES + 1)
+    return Preview(data=data[:MAX_PREVIEW_BYTES], truncated=len(data) > MAX_PREVIEW_BYTES)
 
 
 def total_size(url: str) -> tuple[int, int]:

--- a/lib/rigging/src/rigging/fsutil/render.py
+++ b/lib/rigging/src/rigging/fsutil/render.py
@@ -60,10 +60,10 @@ def print_entries(console: Console, entries: list[Entry], *, long: bool) -> None
 def file_lines(name: str, raw: bytes) -> list[str]:
     """Render *raw* as display lines, using *name*'s extension to pick a JSON reader.
 
-    A tabular ``.json`` or ``.jsonl`` file renders as a table. A supported compression
-    suffix does not change this selection. Other files render as text or a byte count.
+    A tabular ``.json`` or ``.jsonl`` file renders as a table. The renderer ignores one
+    supported compression suffix. Other files render as text or a byte count.
     """
-    name = uncompressed_name(name).lower()
+    name = uncompressed_name(name)
     if name.endswith((".json", ".jsonl")):
         try:
             text = raw.decode("utf-8")

--- a/lib/rigging/src/rigging/fsutil/render.py
+++ b/lib/rigging/src/rigging/fsutil/render.py
@@ -15,6 +15,7 @@ from datetime import datetime
 from rich.console import Console
 from rich.table import Table
 
+from rigging.fsutil.compression import uncompressed_name
 from rigging.fsutil.listing import Entry
 
 _SIZE_UNITS = ("B", "KB", "MB", "GB", "TB", "PB")
@@ -59,9 +60,10 @@ def print_entries(console: Console, entries: list[Entry], *, long: bool) -> None
 def file_lines(name: str, raw: bytes) -> list[str]:
     """Render *raw* as display lines, using *name*'s extension to pick a JSON reader.
 
-    A ``.json`` or ``.jsonl`` file whose content is tabular renders as a table; anything
-    else renders as decoded text, and undecodable bytes as a one-line size summary.
+    A tabular ``.json`` or ``.jsonl`` file renders as a table. A supported compression
+    suffix does not change this selection. Other files render as text or a byte count.
     """
+    name = uncompressed_name(name).lower()
     if name.endswith((".json", ".jsonl")):
         try:
             text = raw.decode("utf-8")

--- a/lib/rigging/src/rigging/fsutil/tui.py
+++ b/lib/rigging/src/rigging/fsutil/tui.py
@@ -12,7 +12,7 @@ import curses
 from dataclasses import dataclass, field
 
 from rigging.filesystem.buckets import MissingCredentials
-from rigging.fsutil.listing import ROOT, Entry, list_entries, parent_url, read_preview, total_size
+from rigging.fsutil.listing import ROOT, Entry, list_entries, parent_url, read_decompressed_preview, total_size
 from rigging.fsutil.render import file_lines, format_size, format_time
 
 _HELP = "[enter] open  [backspace] up  [/] filter  [s] sort  [d] size  [y] print URL  [q] quit"
@@ -132,8 +132,8 @@ def _open(stdscr: "curses.window", screen: Screen) -> None:
         return
 
     try:
-        raw, _ = read_preview(selected.url)
-        lines = file_lines(selected.name, raw)
+        preview = read_decompressed_preview(selected.url)
+        lines = file_lines(selected.name, preview.data)
     except Exception as e:
         screen.status = f"error: {e}"
         return

--- a/lib/rigging/src/rigging/fsutil/tui.py
+++ b/lib/rigging/src/rigging/fsutil/tui.py
@@ -137,7 +137,8 @@ def _open(stdscr: "curses.window", screen: Screen) -> None:
     except Exception as e:
         screen.status = f"error: {e}"
         return
-    _view(stdscr, selected.name, lines)
+    truncated_bytes = len(preview.data) if preview.truncated else None
+    _view(stdscr, selected.name, lines, truncated_bytes)
 
 
 def _measure(stdscr: "curses.window", screen: Screen) -> None:
@@ -183,7 +184,7 @@ def _draw(stdscr: "curses.window", screen: Screen) -> None:
     stdscr.refresh()
 
 
-def _view(stdscr: "curses.window", name: str, lines: list[str]) -> None:
+def _view(stdscr: "curses.window", name: str, lines: list[str], truncated_bytes: int | None) -> None:
     """Scrollable read-only pager for one file's rendered lines."""
     scroll = 0
     while True:
@@ -192,7 +193,10 @@ def _view(stdscr: "curses.window", name: str, lines: list[str]) -> None:
         body_height = max(1, height - 3)
 
         stdscr.addnstr(0, 0, name, width - 1, curses.color_pair(1) | curses.A_BOLD)
-        stdscr.addnstr(1, 0, f"{len(lines)} lines", width - 1, curses.A_DIM)
+        subtitle = f"{len(lines)} lines"
+        if truncated_bytes is not None:
+            subtitle += f"  preview truncated at {format_size(truncated_bytes)}"
+        stdscr.addnstr(1, 0, subtitle, width - 1, curses.A_DIM)
         for row, line in enumerate(lines[scroll : scroll + body_height]):
             stdscr.addnstr(2 + row, 0, line, width - 1)
         stdscr.addnstr(height - 1, 0, _VIEWER_HELP[: width - 1], width - 1, curses.A_DIM)

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -1,7 +1,8 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for fsutil copy operations and file previews on local paths."""
+"""Tests for fsutil's copy semantics and file rendering, over local paths — which
+``filesystem_for`` routes exactly as it routes an object store."""
 
 import bz2
 import gzip
@@ -10,6 +11,7 @@ import lzma
 
 import pytest
 from click.testing import CliRunner
+from rigging.fsutil import listing
 from rigging.fsutil.cli import cli
 from rigging.fsutil.listing import MAX_PREVIEW_BYTES, read_decompressed_preview
 from rigging.fsutil.render import file_lines
@@ -104,3 +106,25 @@ def test_cat_raw_keeps_compressed_bytes(tmp_path):
 
     assert result.exit_code == 0, result.output
     assert result.stdout_bytes == compressed
+
+
+@pytest.mark.parametrize("command", [["cat"], ["head", "-n", "3"]])
+def test_formatted_cli_commands_decompress_json(tmp_path, command):
+    path = tmp_path / "metrics.jsonl.gz"
+    path.write_bytes(gzip.compress(b'{"step": 1, "loss": 3.5}\n'))
+
+    result = CliRunner().invoke(cli, [*command, str(path)])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.splitlines()[2].split() == ["1", "3.5"]
+
+
+def test_cat_reports_full_size_when_uncompressed_preview_is_truncated(tmp_path, monkeypatch):
+    path = tmp_path / "large.txt"
+    path.write_text("abcdef")
+    monkeypatch.setattr(listing, "MAX_PREVIEW_BYTES", 4)
+
+    result = CliRunner().invoke(cli, ["cat", str(path)])
+
+    assert result.exit_code == 0, result.output
+    assert result.stderr == "[truncated: read 4 B of 6 B]\n"

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -1,14 +1,17 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for fsutil's copy semantics and file rendering, over local paths — which
-``filesystem_for`` routes exactly as it routes an object store."""
+"""Tests for fsutil copy operations and file previews on local paths."""
 
+import bz2
+import gzip
 import json
+import lzma
 
 import pytest
 from click.testing import CliRunner
 from rigging.fsutil.cli import cli
+from rigging.fsutil.listing import MAX_PREVIEW_BYTES, read_decompressed_preview
 from rigging.fsutil.render import file_lines
 
 
@@ -60,3 +63,44 @@ def test_json_previews_render_as_tables_and_degrade_safely():
     assert file_lines("metrics.jsonl", b'{"step": 1}\n{"step": 2, trunc') == ['{"step": 1}', '{"step": 2, trunc']
     assert file_lines("nested.json", json.dumps({"a": {"b": 1}}).encode())[2].split()[0] == "a"
     assert file_lines("model.bin", b"\x00\xff\xfe") == ["[binary file, 3 bytes]"]
+
+
+@pytest.mark.parametrize(
+    ("suffix", "compress"),
+    [
+        (".gz", gzip.compress),
+        (".bz2", bz2.compress),
+        (".xz", lzma.compress),
+        (".lzma", lambda data: lzma.compress(data, format=lzma.FORMAT_ALONE)),
+    ],
+)
+def test_compressed_json_preview_decompresses_and_renders_as_a_table(tmp_path, suffix, compress):
+    payload = b'{"step": 1, "loss": 3.5}\n{"step": 2, "loss": 2.0}\n'
+    path = tmp_path / f"metrics.jsonl{suffix}"
+    path.write_bytes(compress(payload))
+
+    preview = read_decompressed_preview(str(path))
+
+    assert preview.truncated is False
+    assert file_lines(path.name, preview.data)[2].split() == ["1", "3.5"]
+
+
+def test_compressed_preview_applies_limit_to_decompressed_data(tmp_path):
+    path = tmp_path / "large.txt.gz"
+    path.write_bytes(gzip.compress(b"x" * (MAX_PREVIEW_BYTES + 1)))
+
+    preview = read_decompressed_preview(str(path))
+
+    assert preview.truncated is True
+    assert preview.data == b"x" * MAX_PREVIEW_BYTES
+
+
+def test_cat_raw_keeps_compressed_bytes(tmp_path):
+    compressed = gzip.compress(b'{"step": 1}\n')
+    path = tmp_path / "metrics.jsonl.gz"
+    path.write_bytes(compressed)
+
+    result = CliRunner().invoke(cli, ["cat", "--raw", str(path)])
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout_bytes == compressed


### PR DESCRIPTION
* decompress `.gz`, `.bz2`, `.xz`, and `.lzma` data in `browse`, `cat`, and `head` previews
* render compressed JSON and JSONL with the existing table view
* keep `cat --raw` output in its stored form
* cap formatted previews at 10 MB after decompression and show truncation in the browser
* add no compression dependency
