### PR TITLE
[grafana] Use a logit scale for provisioning history

### DIFF
--- a/infra/grafana/marin-infra-panel/src/components/StatusPage.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/StatusPage.tsx
@@ -232,8 +232,18 @@ function ProvisioningStatus({ frames }: { frames: DataFrame[] }) {
   const regions = provisioningRegions(rows).sort(
     (a, b) => b.outcomes - a.outcomes || a.region.localeCompare(b.region)
   );
+  const hiddenChartRegions = new Set<string>();
+  if (regions.length > 2) {
+    const regionsBySuccess = [...regions].sort(
+      (a, b) => a.successRatio - b.successRatio || a.region.localeCompare(b.region)
+    );
+    hiddenChartRegions.add(regionsBySuccess[0].region);
+    hiddenChartRegions.add(regionsBySuccess[regionsBySuccess.length - 1].region);
+  }
   const history = historyFrame
-    ? seriesPoints(historyFrame, 'region', 'success_ratio').filter((point) => point.series !== FLEET_SCOPE)
+    ? seriesPoints(historyFrame, 'region', 'success_ratio').filter(
+      (point) => point.series !== FLEET_SCOPE && !hiddenChartRegions.has(point.series)
+    )
     : [];
 
   return (

--- a/infra/grafana/marin-infra-panel/src/components/StatusPage.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/StatusPage.tsx
@@ -32,6 +32,21 @@ const STATUS_GRID_CLASS = css`display:grid;grid-template-columns:minmax(220px,.8
 const STATUS_CARD_CLASS = css`flex:1;`;
 const STATUS_SECTION_CLASS = css`display:flex;flex-direction:column;`;
 const FLEET_SCOPE = 'fleet';
+const PERCENT_SCALE_LIMIT = 0.001;
+const PERCENT_TICKS = [1, 0.99, 0.95, 0.5, 0.05, 0.01, 0];
+
+function seriesColor(name: string): string {
+  let value = 0;
+  for (const character of name) {
+    value = (value * 31 + character.charCodeAt(0)) >>> 0;
+  }
+  return SERIES_COLORS[value % SERIES_COLORS.length];
+}
+
+function logitPercent(value: number): number {
+  const bounded = Math.min(1 - PERCENT_SCALE_LIMIT, Math.max(PERCENT_SCALE_LIMIT, value));
+  return Math.log(bounded / (1 - bounded));
+}
 
 function one(frames: DataFrame[], refId: string): DataFrame[] {
   const frame = frameByRefId(frames, refId);
@@ -98,19 +113,24 @@ function MiniSeriesChart({ points, unit }: { points: SeriesPoint[]; unit: 'count
   const values = points.map((point) => point.value);
   const xMin = Math.min(...times);
   const xMax = Math.max(...times);
-  const yMin = unit === 'percent' ? 0 : Math.min(0, ...values);
-  const yMax = unit === 'percent' ? 1 : Math.max(1, ...values);
+  const rawYMin = unit === 'percent' ? 0 : Math.min(0, ...values);
+  const rawYMax = unit === 'percent' ? 1 : Math.max(1, ...values);
+  const scaleY = unit === 'percent' ? logitPercent : (value: number) => value;
+  const yMin = scaleY(rawYMin);
+  const yMax = scaleY(rawYMax);
   const x = (value: number) => pad.left + ((value - xMin) / Math.max(1, xMax - xMin)) * (width - pad.left - pad.right);
-  const y = (value: number) => pad.top + (1 - (value - yMin) / Math.max(1e-9, yMax - yMin)) * (height - pad.top - pad.bottom);
+  const y = (value: number) => pad.top + (1 - (scaleY(value) - yMin) / Math.max(1e-9, yMax - yMin)) * (height - pad.top - pad.bottom);
+  const tickValues = unit === 'percent'
+    ? PERCENT_TICKS
+    : [rawYMax, (rawYMax + rawYMin) / 2, rawYMin];
 
   return (
     <div>
       <svg viewBox={`0 0 ${width} ${height}`} width="100%" height="170" role="img" aria-label="24 hour status history">
-        {[0, 0.5, 1].map((fraction) => {
-          const value = yMax - fraction * (yMax - yMin);
-          const rowY = pad.top + fraction * (height - pad.top - pad.bottom);
+        {tickValues.map((value) => {
+          const rowY = y(value);
           return (
-            <g key={fraction}>
+            <g key={value}>
               <line x1={pad.left} x2={width - pad.right} y1={rowY} y2={rowY} stroke={theme.colors.border.weak} strokeDasharray="2 5" />
               <text x={pad.left - 6} y={rowY + 4} textAnchor="end" fill={theme.colors.text.secondary} fontSize="12">
                 {unit === 'percent' ? `${Math.round(value * 100)}%` : Math.round(value)}
@@ -118,11 +138,12 @@ function MiniSeriesChart({ points, unit }: { points: SeriesPoint[]; unit: 'count
             </g>
           );
         })}
-        {series.map(([name, samples], index) => (
+        {series.map(([name, samples]) => (
           <polyline
             key={name}
+            aria-label={`${name} history`}
             fill="none"
-            stroke={SERIES_COLORS[index % SERIES_COLORS.length]}
+            stroke={seriesColor(name)}
             strokeWidth="2"
             points={samples.map((point) => `${x(point.time)},${y(point.value)}`).join(' ')}
           />
@@ -134,11 +155,16 @@ function MiniSeriesChart({ points, unit }: { points: SeriesPoint[]; unit: 'count
           {new Date(xMax).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })}
         </text>
       </svg>
-      <div className={css`display:flex;flex-wrap:wrap;gap:5px 14px;font-size:12px;color:${theme.colors.text.secondary};`}>
-        {series.map(([name], index) => (
-          <span key={name}><span className={css`color:${SERIES_COLORS[index % SERIES_COLORS.length]};`}>━</span> {name}</span>
+      <div role="list" aria-label="Status history series" className={css`display:flex;flex-wrap:wrap;gap:5px 14px;font-size:12px;color:${theme.colors.text.secondary};`}>
+        {series.map(([name]) => (
+          <span role="listitem" key={name}><span className={css`color:${seriesColor(name)};`}>━</span> {name}</span>
         ))}
       </div>
+      {unit === 'percent' && (
+        <div className={css`margin-top:4px;font-size:12px;color:${theme.colors.text.secondary};`}>
+          The logit scale expands values near 0% and 100%.
+        </div>
+      )}
     </div>
   );
 }
@@ -232,18 +258,8 @@ function ProvisioningStatus({ frames }: { frames: DataFrame[] }) {
   const regions = provisioningRegions(rows).sort(
     (a, b) => b.outcomes - a.outcomes || a.region.localeCompare(b.region)
   );
-  const hiddenChartRegions = new Set<string>();
-  if (regions.length > 2) {
-    const regionsBySuccess = [...regions].sort(
-      (a, b) => a.successRatio - b.successRatio || a.region.localeCompare(b.region)
-    );
-    hiddenChartRegions.add(regionsBySuccess[0].region);
-    hiddenChartRegions.add(regionsBySuccess[regionsBySuccess.length - 1].region);
-  }
   const history = historyFrame
-    ? seriesPoints(historyFrame, 'region', 'success_ratio').filter(
-      (point) => point.series !== FLEET_SCOPE && !hiddenChartRegions.has(point.series)
-    )
+    ? seriesPoints(historyFrame, 'region', 'success_ratio').filter((point) => point.series !== FLEET_SCOPE)
     : [];
 
   return (

--- a/infra/grafana/marin-infra-panel/src/components/StatusPage.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/StatusPage.tsx
@@ -32,19 +32,11 @@ const STATUS_GRID_CLASS = css`display:grid;grid-template-columns:minmax(220px,.8
 const STATUS_CARD_CLASS = css`flex:1;`;
 const STATUS_SECTION_CLASS = css`display:flex;flex-direction:column;`;
 const FLEET_SCOPE = 'fleet';
-const PERCENT_SCALE_LIMIT = 0.001;
-const PERCENT_TICKS = [1, 0.99, 0.95, 0.5, 0.05, 0.01, 0];
-
-function seriesColor(name: string): string {
-  let value = 0;
-  for (const character of name) {
-    value = (value * 31 + character.charCodeAt(0)) >>> 0;
-  }
-  return SERIES_COLORS[value % SERIES_COLORS.length];
-}
+const LOGIT_CLAMP_EPSILON = 0.001;
+const PERCENT_TICKS = [0.99, 0.95, 0.5, 0.05, 0.01];
 
 function logitPercent(value: number): number {
-  const bounded = Math.min(1 - PERCENT_SCALE_LIMIT, Math.max(PERCENT_SCALE_LIMIT, value));
+  const bounded = Math.min(1 - LOGIT_CLAMP_EPSILON, Math.max(LOGIT_CLAMP_EPSILON, value));
   return Math.log(bounded / (1 - bounded));
 }
 
@@ -138,12 +130,11 @@ function MiniSeriesChart({ points, unit }: { points: SeriesPoint[]; unit: 'count
             </g>
           );
         })}
-        {series.map(([name, samples]) => (
+        {series.map(([name, samples], index) => (
           <polyline
             key={name}
-            aria-label={`${name} history`}
             fill="none"
-            stroke={seriesColor(name)}
+            stroke={SERIES_COLORS[index % SERIES_COLORS.length]}
             strokeWidth="2"
             points={samples.map((point) => `${x(point.time)},${y(point.value)}`).join(' ')}
           />
@@ -156,15 +147,10 @@ function MiniSeriesChart({ points, unit }: { points: SeriesPoint[]; unit: 'count
         </text>
       </svg>
       <div role="list" aria-label="Status history series" className={css`display:flex;flex-wrap:wrap;gap:5px 14px;font-size:12px;color:${theme.colors.text.secondary};`}>
-        {series.map(([name]) => (
-          <span role="listitem" key={name}><span className={css`color:${seriesColor(name)};`}>━</span> {name}</span>
+        {series.map(([name], index) => (
+          <span role="listitem" key={name}><span className={css`color:${SERIES_COLORS[index % SERIES_COLORS.length]};`}>━</span> {name}</span>
         ))}
       </div>
-      {unit === 'percent' && (
-        <div className={css`margin-top:4px;font-size:12px;color:${theme.colors.text.secondary};`}>
-          The logit scale expands values near 0% and 100%.
-        </div>
-      )}
     </div>
   );
 }
@@ -264,7 +250,7 @@ function ProvisioningStatus({ frames }: { frames: DataFrame[] }) {
 
   return (
     <section className={STATUS_SECTION_CLASS} aria-label="Provisioning status">
-      <SectionTitle detail={fleet?.windowHours === undefined ? undefined : `trailing ${fleet.windowHours} hour window`}>Provisioning</SectionTitle>
+      <SectionTitle detail={fleet?.windowHours === undefined ? 'logit scale' : `trailing ${fleet.windowHours} hour window · logit scale`}>Provisioning</SectionTitle>
       <Card className={STATUS_CARD_CLASS}>
         {!fleet ? (
           <PanelMessage width={400} height={220}>No provisioning data</PanelMessage>

--- a/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
@@ -53,7 +53,7 @@ test('status page keeps worker and provisioning status visible when another sour
   expect(screen.getAllByText('No W&B data')).toHaveLength(3);
 });
 
-test('status page keeps extreme provisioning values in the region table and out of the graph', () => {
+test('status page expands extreme provisioning values and keeps every region in the graph', () => {
   const now = Date.now();
   const frames = [
     frame('P', [{
@@ -63,34 +63,41 @@ test('status page keeps extreme provisioning values in the region table and out 
       latency_p95_seconds: 90, window_hours: 3,
     }, {
       scope: 'pool', collected_at: now, zone: 'us-east5-a',
-      ready: 6, stockout: 1, error: 0, preempted: 0, outcomes: 7, success_ratio: 6 / 7,
+      ready: 1, stockout: 49, error: 0, preempted: 0, outcomes: 50, success_ratio: 0.02,
       pools_placing: 0, pools_no_ready_outcome: 0, latency_p50_seconds: 45,
       latency_p95_seconds: 90, window_hours: 3,
     }, {
       scope: 'pool', collected_at: now, zone: 'us-east5-b',
-      ready: 2, stockout: 0, error: 1, preempted: 0, outcomes: 3, success_ratio: 2 / 3,
+      ready: 1, stockout: 49, error: 0, preempted: 0, outcomes: 50, success_ratio: 0.02,
       pools_placing: 0, pools_no_ready_outcome: 0, latency_p50_seconds: 45,
       latency_p95_seconds: 90, window_hours: 3,
     }, {
       scope: 'pool', collected_at: now, zone: 'us-central1-a',
-      ready: 10, stockout: 0, error: 0, preempted: 0, outcomes: 10, success_ratio: 1,
+      ready: 100, stockout: 0, error: 0, preempted: 0, outcomes: 100, success_ratio: 1,
       pools_placing: 0, pools_no_ready_outcome: 0, latency_p50_seconds: 45,
       latency_p95_seconds: 90, window_hours: 3,
     }, {
       scope: 'pool', collected_at: now, zone: 'europe-west4-a',
-      ready: 1, stockout: 1, error: 0, preempted: 0, outcomes: 2, success_ratio: 0.5,
+      ready: 1, stockout: 99, error: 0, preempted: 0, outcomes: 100, success_ratio: 0.01,
+      pools_placing: 0, pools_no_ready_outcome: 0, latency_p50_seconds: 45,
+      latency_p95_seconds: 90, window_hours: 3,
+    }, {
+      scope: 'pool', collected_at: now, zone: 'asia-east1-a',
+      ready: 5, stockout: 95, error: 0, preempted: 0, outcomes: 100, success_ratio: 0.05,
       pools_placing: 0, pools_no_ready_outcome: 0, latency_p50_seconds: 45,
       latency_p95_seconds: 90, window_hours: 3,
     }]),
     frame('R', [
       { time: now - 60_000, region: 'fleet', success_ratio: 0.7 },
       { time: now, region: 'fleet', success_ratio: 0.8 },
-      { time: now - 60_000, region: 'us-east5', success_ratio: 0.7 },
-      { time: now, region: 'us-east5', success_ratio: 0.8 },
-      { time: now - 60_000, region: 'us-central1', success_ratio: 0.9 },
+      { time: now - 60_000, region: 'us-east5', success_ratio: 0.02 },
+      { time: now, region: 'us-east5', success_ratio: 0.02 },
+      { time: now - 60_000, region: 'us-central1', success_ratio: 0.99 },
       { time: now, region: 'us-central1', success_ratio: 1 },
-      { time: now - 60_000, region: 'europe-west4', success_ratio: 0.4 },
-      { time: now, region: 'europe-west4', success_ratio: 0.5 },
+      { time: now - 60_000, region: 'europe-west4', success_ratio: 0.01 },
+      { time: now, region: 'europe-west4', success_ratio: 0.01 },
+      { time: now - 60_000, region: 'asia-east1', success_ratio: 0.05 },
+      { time: now, region: 'asia-east1', success_ratio: 0.05 },
     ]),
   ];
 
@@ -100,21 +107,37 @@ test('status page keeps extreme provisioning values in the region table and out 
   const regionLabel = within(provisioning).getByText('us-east5', { selector: 'code' });
   const regionRow = regionLabel.parentElement;
   expect(regionRow).not.toBeNull();
-  expect(regionRow).toHaveTextContent('80%');
-  expect(regionRow).toHaveTextContent('8/10');
+  expect(regionRow).toHaveTextContent('2%');
+  expect(regionRow).toHaveTextContent('2/100');
   const highestRegionRow = within(provisioning).getByText('us-central1', { selector: 'code' }).parentElement;
   expect(highestRegionRow).toHaveTextContent('100%');
-  expect(highestRegionRow).toHaveTextContent('10/10');
+  expect(highestRegionRow).toHaveTextContent('100/100');
   const lowestRegionRow = within(provisioning).getByText('europe-west4', { selector: 'code' }).parentElement;
-  expect(lowestRegionRow).toHaveTextContent('50%');
-  expect(lowestRegionRow).toHaveTextContent('1/2');
+  expect(lowestRegionRow).toHaveTextContent('1%');
+  expect(lowestRegionRow).toHaveTextContent('1/100');
 
   const chart = within(provisioning).getByRole('img', { name: '24 hour status history' });
-  const chartContainer = chart.parentElement;
-  expect(chartContainer).not.toBeNull();
-  expect(within(chartContainer!).queryByText('fleet')).not.toBeInTheDocument();
-  expect(within(chartContainer!).getByText('us-east5')).toBeInTheDocument();
-  expect(within(chartContainer!).queryByText('us-central1')).not.toBeInTheDocument();
-  expect(within(chartContainer!).queryByText('europe-west4')).not.toBeInTheDocument();
+  expect(within(chart).getByText('1%')).toBeInTheDocument();
+  expect(within(chart).getByText('5%')).toBeInTheDocument();
+  expect(within(chart).getByText('95%')).toBeInTheDocument();
+  expect(within(chart).getByText('99%')).toBeInTheDocument();
+  const chartSeries = within(provisioning).getByRole('list', { name: 'Status history series' });
+  expect(within(chartSeries).queryByText('fleet')).not.toBeInTheDocument();
+  expect(within(chartSeries).getByText('us-east5')).toBeInTheDocument();
+  expect(within(chartSeries).getByText('asia-east1')).toBeInTheDocument();
+  expect(within(chartSeries).getByText('us-central1')).toBeInTheDocument();
+  expect(within(chartSeries).getByText('europe-west4')).toBeInTheDocument();
+  expect(within(provisioning).getByText('The logit scale expands values near 0% and 100%.')).toBeInTheDocument();
+
+  const onePercentLine = within(chart).getByLabelText('europe-west4 history');
+  const fivePercentLine = within(chart).getByLabelText('asia-east1 history');
+  const firstY = (line: HTMLElement) => {
+    const points = line.getAttribute('points');
+    if (!points) {
+      throw new Error('The chart line has no points');
+    }
+    return Number(points.split(' ')[0].split(',')[1]);
+  };
+  expect(Math.abs(firstY(onePercentLine) - firstY(fivePercentLine))).toBeGreaterThan(15);
   expect(within(provisioning).queryByText('us-east5-a')).not.toBeInTheDocument();
 });

--- a/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
@@ -53,7 +53,7 @@ test('status page keeps worker and provisioning status visible when another sour
   expect(screen.getAllByText('No W&B data')).toHaveLength(3);
 });
 
-test('status page expands extreme provisioning values and keeps every region in the graph', () => {
+test('status page rolls provisioning pools into a logit region graph', () => {
   const now = Date.now();
   const frames = [
     frame('P', [{
@@ -121,23 +121,17 @@ test('status page expands extreme provisioning values and keeps every region in 
   expect(within(chart).getByText('5%')).toBeInTheDocument();
   expect(within(chart).getByText('95%')).toBeInTheDocument();
   expect(within(chart).getByText('99%')).toBeInTheDocument();
+  const tickY = (label: string) => Number(within(chart).getByText(label).getAttribute('y'));
+  const lowTailGap = Math.abs(tickY('1%') - tickY('5%'));
+  const centerGap = Math.abs(tickY('5%') - tickY('50%'));
+  expect(lowTailGap / centerGap).toBeGreaterThan(0.4);
+
+  expect(within(provisioning).queryByText('fleet')).not.toBeInTheDocument();
   const chartSeries = within(provisioning).getByRole('list', { name: 'Status history series' });
-  expect(within(chartSeries).queryByText('fleet')).not.toBeInTheDocument();
   expect(within(chartSeries).getByText('us-east5')).toBeInTheDocument();
   expect(within(chartSeries).getByText('asia-east1')).toBeInTheDocument();
   expect(within(chartSeries).getByText('us-central1')).toBeInTheDocument();
   expect(within(chartSeries).getByText('europe-west4')).toBeInTheDocument();
-  expect(within(provisioning).getByText('The logit scale expands values near 0% and 100%.')).toBeInTheDocument();
-
-  const onePercentLine = within(chart).getByLabelText('europe-west4 history');
-  const fivePercentLine = within(chart).getByLabelText('asia-east1 history');
-  const firstY = (line: HTMLElement) => {
-    const points = line.getAttribute('points');
-    if (!points) {
-      throw new Error('The chart line has no points');
-    }
-    return Number(points.split(' ')[0].split(',')[1]);
-  };
-  expect(Math.abs(firstY(onePercentLine) - firstY(fivePercentLine))).toBeGreaterThan(15);
+  expect(within(provisioning).getByText('trailing 3 hour window · logit scale')).toBeInTheDocument();
   expect(within(provisioning).queryByText('us-east5-a')).not.toBeInTheDocument();
 });

--- a/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
@@ -53,7 +53,7 @@ test('status page keeps worker and provisioning status visible when another sour
   expect(screen.getAllByText('No W&B data')).toHaveLength(3);
 });
 
-test('status page rolls pool outcomes up to regions beside the history graph', () => {
+test('status page keeps extreme provisioning values in the region table and out of the graph', () => {
   const now = Date.now();
   const frames = [
     frame('P', [{
@@ -71,12 +71,26 @@ test('status page rolls pool outcomes up to regions beside the history graph', (
       ready: 2, stockout: 0, error: 1, preempted: 0, outcomes: 3, success_ratio: 2 / 3,
       pools_placing: 0, pools_no_ready_outcome: 0, latency_p50_seconds: 45,
       latency_p95_seconds: 90, window_hours: 3,
+    }, {
+      scope: 'pool', collected_at: now, zone: 'us-central1-a',
+      ready: 10, stockout: 0, error: 0, preempted: 0, outcomes: 10, success_ratio: 1,
+      pools_placing: 0, pools_no_ready_outcome: 0, latency_p50_seconds: 45,
+      latency_p95_seconds: 90, window_hours: 3,
+    }, {
+      scope: 'pool', collected_at: now, zone: 'europe-west4-a',
+      ready: 1, stockout: 1, error: 0, preempted: 0, outcomes: 2, success_ratio: 0.5,
+      pools_placing: 0, pools_no_ready_outcome: 0, latency_p50_seconds: 45,
+      latency_p95_seconds: 90, window_hours: 3,
     }]),
     frame('R', [
       { time: now - 60_000, region: 'fleet', success_ratio: 0.7 },
       { time: now, region: 'fleet', success_ratio: 0.8 },
       { time: now - 60_000, region: 'us-east5', success_ratio: 0.7 },
       { time: now, region: 'us-east5', success_ratio: 0.8 },
+      { time: now - 60_000, region: 'us-central1', success_ratio: 0.9 },
+      { time: now, region: 'us-central1', success_ratio: 1 },
+      { time: now - 60_000, region: 'europe-west4', success_ratio: 0.4 },
+      { time: now, region: 'europe-west4', success_ratio: 0.5 },
     ]),
   ];
 
@@ -88,8 +102,19 @@ test('status page rolls pool outcomes up to regions beside the history graph', (
   expect(regionRow).not.toBeNull();
   expect(regionRow).toHaveTextContent('80%');
   expect(regionRow).toHaveTextContent('8/10');
-  expect(within(provisioning).getByRole('img', { name: '24 hour status history' })).toBeInTheDocument();
-  expect(within(provisioning).queryByText('fleet')).not.toBeInTheDocument();
-  expect(within(provisioning).getAllByText('us-east5')).toHaveLength(2);
+  const highestRegionRow = within(provisioning).getByText('us-central1', { selector: 'code' }).parentElement;
+  expect(highestRegionRow).toHaveTextContent('100%');
+  expect(highestRegionRow).toHaveTextContent('10/10');
+  const lowestRegionRow = within(provisioning).getByText('europe-west4', { selector: 'code' }).parentElement;
+  expect(lowestRegionRow).toHaveTextContent('50%');
+  expect(lowestRegionRow).toHaveTextContent('1/2');
+
+  const chart = within(provisioning).getByRole('img', { name: '24 hour status history' });
+  const chartContainer = chart.parentElement;
+  expect(chartContainer).not.toBeNull();
+  expect(within(chartContainer!).queryByText('fleet')).not.toBeInTheDocument();
+  expect(within(chartContainer!).getByText('us-east5')).toBeInTheDocument();
+  expect(within(chartContainer!).queryByText('us-central1')).not.toBeInTheDocument();
+  expect(within(chartContainer!).queryByText('europe-west4')).not.toBeInTheDocument();
   expect(within(provisioning).queryByText('us-east5-a')).not.toBeInTheDocument();
 });


### PR DESCRIPTION
* show all regional provisioning history on a logit percentage axis so the low-single-digit and near-100% clusters remain readable
* keep exact `1%`, `5%`, `50%`, `95%`, and `99%` ticks on the fixed percentage domain
* keep all current regional percentages and attempt totals in the table beside the graph
