### PR TITLE
[data] Extract GHALogs job logs instead of storing tar.gz bytes

### DIFF
--- a/experiments/datasets/diagnostic_logs.py
+++ b/experiments/datasets/diagnostic_logs.py
@@ -52,7 +52,7 @@ def _ghalogs_normalized() -> ArtifactStep[TokenizedCache]:
         "normalized/ghalogs/public",
         fn=_run_ghalogs_normalize_pipeline,
         build_config=lambda ctx: ctx.output_path,
-        version="2026.07.30",
+        version="2026.07.30.1",
     )
 
 
@@ -63,7 +63,7 @@ def ghalogs_dataset(*, tokenizer: str = marin_tokenizer) -> ArtifactStep[Tokeniz
         tokenizer=tokenizer,
         raw=_ghalogs_normalized(),
         glob="outputs/main/*.parquet",
-        version="2026.07.30",
+        version="2026.07.30.1",
     )
 
 

--- a/experiments/datasets/diagnostic_logs.py
+++ b/experiments/datasets/diagnostic_logs.py
@@ -52,7 +52,7 @@ def _ghalogs_normalized() -> ArtifactStep[TokenizedCache]:
         "normalized/ghalogs/public",
         fn=_run_ghalogs_normalize_pipeline,
         build_config=lambda ctx: ctx.output_path,
-        version="2026.06.28",
+        version="2026.07.30",
     )
 
 
@@ -63,7 +63,7 @@ def ghalogs_dataset(*, tokenizer: str = marin_tokenizer) -> ArtifactStep[Tokeniz
         tokenizer=tokenizer,
         raw=_ghalogs_normalized(),
         glob="outputs/main/*.parquet",
-        version="2026.06.28",
+        version="2026.07.30",
     )
 
 

--- a/experiments/datasets/diagnostic_logs.py
+++ b/experiments/datasets/diagnostic_logs.py
@@ -52,7 +52,7 @@ def _ghalogs_normalized() -> ArtifactStep[TokenizedCache]:
         "normalized/ghalogs/public",
         fn=_run_ghalogs_normalize_pipeline,
         build_config=lambda ctx: ctx.output_path,
-        version="2026.07.30.1",
+        version="2026.07.31",
     )
 
 
@@ -63,7 +63,7 @@ def ghalogs_dataset(*, tokenizer: str = marin_tokenizer) -> ArtifactStep[Tokeniz
         tokenizer=tokenizer,
         raw=_ghalogs_normalized(),
         glob="outputs/main/*.parquet",
-        version="2026.07.30.1",
+        version="2026.07.31",
     )
 
 

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -507,9 +507,8 @@ def _is_job_log(member: tarfile.TarInfo) -> bool:
 def _decode_log_chunk_text(content: bytes) -> str | JobLogDrop:
     """Decode job-log chunk bytes into cleaned text, or report why the chunk is not usable.
 
-    Removes the non-text characters in one pass and reads the count of removed
-    characters from the length difference, so a binary payload never builds a
-    match object for each of its bytes.
+    Counts the non-text characters from a length difference rather than from
+    matches, so a binary payload costs one pass and not one object for each byte.
     """
     text = content.decode("utf-8", errors="replace")
     cleaned = _NON_TEXT_CHAR_RE.sub("", text)
@@ -756,8 +755,8 @@ def _process_ghalogs_member_batch(batch: list[str], archive_path: str) -> Iterat
     Opens the zip a single time per worker (vs once per record). ``zipfile``
     seeks to each member's offset, so the worker only fetches the bytes for
     members in its batch — not the whole archive. One member yields one record
-    for each job log of that run, thus ``zephyr/records_in`` counts runs and
-    ``ghalogs_materialize/kept`` counts job logs.
+    for each chunk of each job log of that run, thus ``zephyr/records_in``
+    counts runs and ``ghalogs_materialize/kept`` counts job-log chunks.
     """
     with open_url(archive_path, "rb") as f:
         with zipfile.ZipFile(f) as zf:
@@ -787,7 +786,7 @@ def materialize_ghalogs_to_parquet(
     partitioned into ``num_shards`` batches and shipped to zephyr workers,
     each of which opens the archive once and streams its assigned members
     via ``zipfile``'s random-access reads — bounding per-worker memory to one
-    run archive plus one job log, rather than the whole archive.
+    run archive plus one job-log chunk, rather than the whole archive.
     """
     if max_members is not None and max_members <= 0:
         raise ValueError(f"max_members must be positive when set, got {max_members}")

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -10,6 +10,7 @@ import logging
 import os.path
 import re
 import shutil
+import tarfile
 import time
 import xml.etree.ElementTree as ET
 import zipfile
@@ -117,6 +118,21 @@ _GHALOGS_PARTS_TTL_DAYS = 7
 _GHALOGS_MAX_RESUME_STALLS = 8
 _GHALOGS_RESUME_BACKOFF_BASE = 5.0  # seconds; doubles per consecutive stall
 _GHALOGS_RESUME_BACKOFF_CAP = 120.0
+
+# Every non-directory member of the published archive is a gzipped tar of one
+# workflow run's logs; there are no plain-text members.
+_GHALOGS_MEMBER_SUFFIX = ".tar.gz"
+_GHALOGS_JOB_LOG_SUFFIX = ".txt"
+# Job logs above this size are byte dumps (pytest diffs of binary blobs), and
+# sanitization rescans a document one time for each identity that it finds, so
+# an unbounded document turns one worker into a multi-hour straggler.
+_GHALOGS_MAX_JOB_LOG_BYTES = 8 * 1024 * 1024
+# Characters that a text log cannot contain: C0 controls other than tab, line
+# feed, carriage return, and ESC, plus DEL and the Unicode replacement
+# character. ESC stays because GitHub Actions logs carry ANSI color sequences.
+_NON_TEXT_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1a\x1c-\x1f\x7f\ufffd]")
+# Above this fraction of non-text characters the payload is binary, not a log.
+_MAX_NON_TEXT_CHAR_RATIO = 0.01
 
 _PARTITION_BUCKETS = 10_000
 _ISSUE_5093_HOLDOUT_BUCKETS = 100
@@ -461,23 +477,63 @@ def assign_partition(split_key: str) -> DiagnosticPartition:
     return DiagnosticPartition.TRAIN
 
 
-def ghalogs_member_to_record(member_path: str, content: bytes) -> dict[str, str] | None:
-    """Convert one GHALogs zip member into a sanitized diagnostic-log record."""
-    text = content.decode("utf-8", errors="replace").strip()
-    if not text:
+def _is_job_log(member: tarfile.TarInfo) -> bool:
+    """Report whether a tar member is a run's top-level job log.
+
+    A run archive holds each job's full log as ``<index>_<job>.txt`` at the top
+    level, and the same text split per step below ``<job>/``. Only the job logs
+    are records, so the run's text is not written two times. Directory entries
+    carry a regular-file type with a trailing slash, thus the name check.
+    """
+    return (
+        member.isfile() and member.size > 0 and "/" not in member.name and member.name.endswith(_GHALOGS_JOB_LOG_SUFFIX)
+    )
+
+
+def _decode_job_log_text(content: bytes) -> str | None:
+    """Decode job-log bytes as text, or return None when the payload is not text."""
+    text = content.decode("utf-8", errors="replace")
+    if len(_NON_TEXT_CHAR_RE.findall(text)) > _MAX_NON_TEXT_CHAR_RATIO * len(text):
         return None
+    return _NON_TEXT_CHAR_RE.sub("", text).strip() or None
 
-    split_key = f"ghalogs:{member_path}"
-    partition = assign_partition(split_key)
-    row_id = hashlib.sha256(split_key.encode("utf-8")).hexdigest()
 
-    return {
-        "id": row_id,
-        "text": sanitize_diagnostic_log_text(text),
-        "source": "ghalogs",
-        "archive_path": member_path,
-        "partition": partition.value,
-    }
+def ghalogs_member_to_records(member_path: str, content: bytes) -> Iterator[dict[str, str]]:
+    """Convert one GHALogs zip member into sanitized diagnostic-log records.
+
+    Each member of ``github_run_logs.zip`` is a gzipped tar of one workflow
+    run's logs, so the member bytes are read as a tar archive and one record is
+    written for each job log inside it (see :func:`_is_job_log`). Members are
+    read in archive order, which keeps the gzip stream at one forward pass and
+    holds one job log in memory at a time. All records of one run share the
+    run's partition, thus no job log lands away from its sibling logs.
+    """
+    if not member_path.endswith(_GHALOGS_MEMBER_SUFFIX):
+        raise ValueError(f"Expected a {_GHALOGS_MEMBER_SUFFIX} GHALogs run archive, got {member_path}")
+
+    partition = assign_partition(f"ghalogs:{member_path}")
+    with tarfile.open(fileobj=BytesIO(content), mode="r:gz") as run_logs:
+        for member in run_logs:
+            if not _is_job_log(member):
+                continue
+            if member.size > _GHALOGS_MAX_JOB_LOG_BYTES:
+                counters.pipeline.update_counter("ghalogs_materialize/dropped_oversize", 1)
+                continue
+            handle = run_logs.extractfile(member)
+            assert handle is not None, f"{member_path}!{member.name} is a regular file"
+            text = _decode_job_log_text(handle.read())
+            if text is None:
+                counters.pipeline.update_counter("ghalogs_materialize/dropped_non_text", 1)
+                continue
+
+            log_path = f"{member_path}!{member.name}"
+            yield {
+                "id": hashlib.sha256(f"ghalogs:{log_path}".encode()).hexdigest(),
+                "text": sanitize_diagnostic_log_text(text),
+                "source": "ghalogs",
+                "archive_path": log_path,
+                "partition": partition.value,
+            }
 
 
 def logchunks_example_to_record(source_path: str, example_index: int, example: ET.Element) -> dict[str, str] | None:
@@ -648,11 +704,13 @@ def _list_ghalogs_member_names(archive_path: str) -> list[str]:
 
 
 def _process_ghalogs_member_batch(batch: list[str], archive_path: str) -> Iterator[dict[str, str]]:
-    """Open the archive once, read each assigned member, yield sanitized records.
+    """Open the archive once, read each assigned run archive, yield sanitized records.
 
     Opens the zip a single time per worker (vs once per record). ``zipfile``
     seeks to each member's offset, so the worker only fetches the bytes for
-    members in its batch — not the whole archive.
+    members in its batch — not the whole archive. One member yields one record
+    for each job log of that run, thus ``zephyr/records_in`` counts runs and
+    ``ghalogs_materialize/kept`` counts job logs.
     """
     with open_url(archive_path, "rb") as f:
         with zipfile.ZipFile(f) as zf:
@@ -660,13 +718,10 @@ def _process_ghalogs_member_batch(batch: list[str], archive_path: str) -> Iterat
                 with zf.open(name, "r") as member_file:
                     content = member_file.read()
                 counters.pipeline.update_counter("zephyr/records_in", 1)
-                record = ghalogs_member_to_record(name, content)
-                if record is None:
-                    counters.pipeline.update_counter("ghalogs_materialize/dropped_empty", 1)
-                    continue
-                counters.pipeline.update_counter("ghalogs_materialize/kept", 1)
-                counters.pipeline.update_counter(f"ghalogs_materialize/partition_{record['partition']}", 1)
-                yield record
+                for record in ghalogs_member_to_records(name, content):
+                    counters.pipeline.update_counter("ghalogs_materialize/kept", 1)
+                    counters.pipeline.update_counter(f"ghalogs_materialize/partition_{record['partition']}", 1)
+                    yield record
 
 
 def materialize_ghalogs_to_parquet(
@@ -684,8 +739,8 @@ def materialize_ghalogs_to_parquet(
     so it happens locally in the orchestrator. The resulting member names are
     partitioned into ``num_shards`` batches and shipped to zephyr workers,
     each of which opens the archive once and streams its assigned members
-    via ``zipfile``'s random-access reads — bounding per-worker memory to a
-    single member's content rather than the whole archive.
+    via ``zipfile``'s random-access reads — bounding per-worker memory to one
+    run archive plus one job log, rather than the whole archive.
     """
     if max_members is not None and max_members <= 0:
         raise ValueError(f"max_members must be positive when set, got {max_members}")
@@ -816,18 +871,16 @@ def extract_ghalogs(
 
                 counters["seen_members"] += 1
                 with archive.open(member, "r") as member_handle:
-                    record = ghalogs_member_to_record(member.filename, member_handle.read())
+                    content = member_handle.read()
 
-                if record is None:
-                    continue
-
-                counters["kept_records"] += 1
-                partition = record["partition"]
-                partition_counts[partition] += 1
-                payload = json.dumps(record, ensure_ascii=False)
-                total_bytes_written += len(payload.encode("utf-8")) + 1
-                writers[partition].write(payload)
-                writers[partition].write("\n")
+                for record in ghalogs_member_to_records(member.filename, content):
+                    counters["kept_records"] += 1
+                    partition = record["partition"]
+                    partition_counts[partition] += 1
+                    payload = json.dumps(record, ensure_ascii=False)
+                    total_bytes_written += len(payload.encode("utf-8")) + 1
+                    writers[partition].write(payload)
+                    writers[partition].write("\n")
 
     manifest = SOURCE_MANIFESTS["ghalogs"]
     metadata_path = _write_source_metadata(
@@ -1013,10 +1066,11 @@ def extract_ghalogs_step(
         output_path_prefix=output_path_prefix,
         fn=lambda output_path: extract_ghalogs(source_path, output_path, max_members=max_members),
         hash_attrs={
-            "version": "v4",
+            "version": "v5",
             "source_path": source_path,
             "source_label": source.source_label,
             "max_members": max_members,
+            "max_job_log_bytes": _GHALOGS_MAX_JOB_LOG_BYTES,
             "split_policy": "97% train / 1% dev / 1% test / 1% issue_5093_holdout",
             "source_content_fingerprint": source.fingerprint(),
             "sanitization_rules": "gh token/aws key/secret kv/email/user path/internal gs path",
@@ -1280,10 +1334,11 @@ def materialize_ghalogs_step(
             num_shards=num_shards,
         ),
         hash_attrs={
-            "version": "v1",
+            "version": "v2",
             "source_path": source_path,
             "source_label": source.source_label,
             "max_members": max_members,
+            "max_job_log_bytes": _GHALOGS_MAX_JOB_LOG_BYTES,
             "num_shards": num_shards,
             "source_content_fingerprint": source.fingerprint(),
             "sanitization_rules": "gh token/aws key/secret kv/email/user path/internal gs path",

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -123,6 +123,8 @@ _GHALOGS_RESUME_BACKOFF_CAP = 120.0
 # workflow run's logs; there are no plain-text members.
 _GHALOGS_MEMBER_SUFFIX = ".tar.gz"
 _GHALOGS_JOB_LOG_SUFFIX = ".txt"
+# Separates the run archive from the job log inside it in a record's archive_path.
+_GHALOGS_LOG_PATH_SEPARATOR = "!"
 # Job logs above this size are byte dumps (pytest diffs of binary blobs), and
 # sanitization rescans a document one time for each identity that it finds, so
 # an unbounded document turns one worker into a multi-hour straggler.
@@ -499,34 +501,34 @@ def _decode_job_log_text(content: bytes) -> str | None:
 
 
 def ghalogs_member_to_records(member_path: str, content: bytes) -> Iterator[dict[str, str]]:
-    """Convert one GHALogs zip member into sanitized diagnostic-log records.
+    """Convert one GHALogs ``.tar.gz`` run archive into sanitized job-log records.
 
-    Each member of ``github_run_logs.zip`` is a gzipped tar of one workflow
-    run's logs, so the member bytes are read as a tar archive and one record is
-    written for each job log inside it (see :func:`_is_job_log`). Members are
-    read in archive order, which keeps the gzip stream at one forward pass and
-    holds one job log in memory at a time. All records of one run share the
-    run's partition, thus no job log lands away from its sibling logs.
+    Yields one record for each job log of the run (see :func:`_is_job_log`),
+    with ``archive_path`` set to ``<member_path>!<job log>``. All records of one
+    run share the run's partition, thus no job log lands away from its sibling
+    logs. Raises ``ValueError`` for a member that is not a run archive.
     """
     if not member_path.endswith(_GHALOGS_MEMBER_SUFFIX):
         raise ValueError(f"Expected a {_GHALOGS_MEMBER_SUFFIX} GHALogs run archive, got {member_path}")
 
     partition = assign_partition(f"ghalogs:{member_path}")
     with tarfile.open(fileobj=BytesIO(content), mode="r:gz") as run_logs:
+        # Iterate instead of getmembers(): each log is read as the tar iterator
+        # reaches it, so the gzip stream is decompressed one time.
         for member in run_logs:
             if not _is_job_log(member):
                 continue
+            log_path = f"{member_path}{_GHALOGS_LOG_PATH_SEPARATOR}{member.name}"
             if member.size > _GHALOGS_MAX_JOB_LOG_BYTES:
                 counters.pipeline.update_counter("ghalogs_materialize/dropped_oversize", 1)
                 continue
             handle = run_logs.extractfile(member)
-            assert handle is not None, f"{member_path}!{member.name} is a regular file"
+            assert handle is not None, f"{log_path} is a regular file"
             text = _decode_job_log_text(handle.read())
             if text is None:
                 counters.pipeline.update_counter("ghalogs_materialize/dropped_non_text", 1)
                 continue
 
-            log_path = f"{member_path}!{member.name}"
             yield {
                 "id": hashlib.sha256(f"ghalogs:{log_path}".encode()).hexdigest(),
                 "text": sanitize_diagnostic_log_text(text),

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -19,7 +19,7 @@ from contextlib import ExitStack
 from dataclasses import dataclass
 from enum import StrEnum, auto
 from io import BytesIO
-from typing import NamedTuple
+from typing import IO, NamedTuple
 
 import fsspec
 import requests
@@ -125,12 +125,16 @@ _GHALOGS_MEMBER_SUFFIX = ".tar.gz"
 _GHALOGS_JOB_LOG_SUFFIX = ".txt"
 # Separates the run archive from the job log inside it in a record's archive_path.
 _GHALOGS_LOG_PATH_SEPARATOR = "!"
-# A cap on document size, not a content test: sanitization rescans a document one
-# time for each identity that it finds, so an unbounded document turns one worker
-# into a multi-hour straggler. The cap does discard the rare valid long log. In a
-# 300-run sample the logs above it were pytest diffs of binary blobs — 0.6% of the
-# job logs and 60% of the bytes — so the accepted loss is small.
-_GHALOGS_MAX_JOB_LOG_BYTES = 8 * 1024 * 1024
+# Separates a job log from the index of its chunk in a record's archive_path.
+_GHALOGS_CHUNK_PATH_SEPARATOR = "#"
+# A job log longer than this becomes more than one record, split at line
+# boundaries. This bounds work, and is not a content test: sanitization rescans a
+# document one time for each identity that it finds, so an unbounded document
+# turns one worker into a multi-hour straggler. A split divides that quadratic
+# term by the count of chunks, and holds peak memory at one chunk. In a 300-run
+# sample only 0.6% of the job logs are above this size, but they hold 60% of the
+# bytes, thus a split keeps text that a cap would discard.
+_GHALOGS_JOB_LOG_CHUNK_BYTES = 8 * 1024 * 1024
 # Characters that a text log cannot contain: C0 controls other than tab, line
 # feed, carriage return, and ESC, plus DEL and the Unicode replacement
 # character. ESC stays because GitHub Actions logs carry ANSI color sequences.
@@ -196,9 +200,8 @@ class DiagnosticPartition(StrEnum):
 
 
 class JobLogDrop(StrEnum):
-    """Why a GHALogs job log yields no record. The value names its drop counter."""
+    """Why a GHALogs job-log chunk yields no record. The value names its drop counter."""
 
-    OVERSIZE = auto()
     NON_TEXT = auto()
     EMPTY = auto()
 
@@ -501,8 +504,8 @@ def _is_job_log(member: tarfile.TarInfo) -> bool:
     )
 
 
-def _decode_job_log_text(content: bytes) -> str | JobLogDrop:
-    """Decode job-log bytes into cleaned text, or report why the payload is not usable.
+def _decode_log_chunk_text(content: bytes) -> str | JobLogDrop:
+    """Decode job-log chunk bytes into cleaned text, or report why the chunk is not usable.
 
     Removes the non-text characters in one pass and reads the count of removed
     characters from the length difference, so a binary payload never builds a
@@ -515,13 +518,39 @@ def _decode_job_log_text(content: bytes) -> str | JobLogDrop:
     return cleaned.strip() or JobLogDrop.EMPTY
 
 
+def _job_log_chunks(handle: IO[bytes], chunk_bytes: int) -> Iterator[bytes]:
+    """Split a job log into line-aligned chunks of at most ``chunk_bytes`` bytes.
+
+    Reads a line at a time, thus peak memory stays at one chunk rather than the
+    whole log. A line longer than ``chunk_bytes`` becomes a chunk of its own:
+    ``readline`` is bounded, so a log without line breaks cannot exhaust memory.
+    """
+    lines: list[bytes] = []
+    size = 0
+    while line := handle.readline(chunk_bytes):
+        if lines and size + len(line) > chunk_bytes:
+            yield b"".join(lines)
+            lines, size = [], 0
+        lines.append(line)
+        size += len(line)
+    if lines:
+        yield b"".join(lines)
+
+
 def ghalogs_member_to_records(member_path: str, content: bytes) -> Iterator[dict[str, str]]:
     """Convert one GHALogs ``.tar.gz`` run archive into sanitized job-log records.
 
-    Yields one record for each job log of the run (see :func:`_is_job_log`),
-    with ``archive_path`` set to ``<member_path>!<job log>``. All records of one
-    run share the run's partition, thus no job log lands away from its sibling
-    logs. Raises ``ValueError`` for a member that is not a run archive.
+    Yields one record for each chunk of each job log of the run (see
+    :func:`_is_job_log`), with ``archive_path`` set to
+    ``<member_path>!<job log>#<chunk index>``. A job log above
+    ``_GHALOGS_JOB_LOG_CHUNK_BYTES`` becomes more than one record instead of
+    being discarded. Each chunk is a document of its own for pseudonymization,
+    so an identity keeps one pseudonym inside a chunk but not across chunks —
+    the contract that already holds across the job logs of one run.
+
+    All records of one run share the run's partition, thus no job log lands away
+    from its sibling logs. Raises ``ValueError`` for a member that is not a run
+    archive.
     """
     if not member_path.endswith(_GHALOGS_MEMBER_SUFFIX):
         raise ValueError(f"Expected a {_GHALOGS_MEMBER_SUFFIX} GHALogs run archive, got {member_path}")
@@ -534,23 +563,24 @@ def ghalogs_member_to_records(member_path: str, content: bytes) -> Iterator[dict
             if not _is_job_log(member):
                 continue
             log_path = f"{member_path}{_GHALOGS_LOG_PATH_SEPARATOR}{member.name}"
-            if member.size > _GHALOGS_MAX_JOB_LOG_BYTES:
-                counters.pipeline.update_counter(f"ghalogs_materialize/dropped_{JobLogDrop.OVERSIZE}", 1)
-                continue
             handle = run_logs.extractfile(member)
             assert handle is not None, f"{log_path} is a regular file"
-            text = _decode_job_log_text(handle.read())
-            if isinstance(text, JobLogDrop):
-                counters.pipeline.update_counter(f"ghalogs_materialize/dropped_{text}", 1)
-                continue
+            for index, chunk in enumerate(_job_log_chunks(handle, _GHALOGS_JOB_LOG_CHUNK_BYTES)):
+                if index == 1:
+                    counters.pipeline.update_counter("ghalogs_materialize/split_job_logs", 1)
+                text = _decode_log_chunk_text(chunk)
+                if isinstance(text, JobLogDrop):
+                    counters.pipeline.update_counter(f"ghalogs_materialize/dropped_{text}", 1)
+                    continue
 
-            yield {
-                "id": hashlib.sha256(f"ghalogs:{log_path}".encode()).hexdigest(),
-                "text": sanitize_diagnostic_log_text(text),
-                "source": "ghalogs",
-                "archive_path": log_path,
-                "partition": partition.value,
-            }
+                chunk_path = f"{log_path}{_GHALOGS_CHUNK_PATH_SEPARATOR}{index}"
+                yield {
+                    "id": hashlib.sha256(f"ghalogs:{chunk_path}".encode()).hexdigest(),
+                    "text": sanitize_diagnostic_log_text(text),
+                    "source": "ghalogs",
+                    "archive_path": chunk_path,
+                    "partition": partition.value,
+                }
 
 
 def logchunks_example_to_record(source_path: str, example_index: int, example: ET.Element) -> dict[str, str] | None:
@@ -1083,11 +1113,11 @@ def extract_ghalogs_step(
         output_path_prefix=output_path_prefix,
         fn=lambda output_path: extract_ghalogs(source_path, output_path, max_members=max_members),
         hash_attrs={
-            "version": "v5",
+            "version": "v6",
             "source_path": source_path,
             "source_label": source.source_label,
             "max_members": max_members,
-            "max_job_log_bytes": _GHALOGS_MAX_JOB_LOG_BYTES,
+            "job_log_chunk_bytes": _GHALOGS_JOB_LOG_CHUNK_BYTES,
             "split_policy": "97% train / 1% dev / 1% test / 1% issue_5093_holdout",
             "source_content_fingerprint": source.fingerprint(),
             "sanitization_rules": "gh token/aws key/secret kv/email/user path/internal gs path",
@@ -1351,11 +1381,11 @@ def materialize_ghalogs_step(
             num_shards=num_shards,
         ),
         hash_attrs={
-            "version": "v2",
+            "version": "v3",
             "source_path": source_path,
             "source_label": source.source_label,
             "max_members": max_members,
-            "max_job_log_bytes": _GHALOGS_MAX_JOB_LOG_BYTES,
+            "job_log_chunk_bytes": _GHALOGS_JOB_LOG_CHUNK_BYTES,
             "num_shards": num_shards,
             "source_content_fingerprint": source.fingerprint(),
             "sanitization_rules": "gh token/aws key/secret kv/email/user path/internal gs path",

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -125,15 +125,16 @@ _GHALOGS_MEMBER_SUFFIX = ".tar.gz"
 _GHALOGS_JOB_LOG_SUFFIX = ".txt"
 # Separates the run archive from the job log inside it in a record's archive_path.
 _GHALOGS_LOG_PATH_SEPARATOR = "!"
-# Job logs above this size are byte dumps (pytest diffs of binary blobs), and
-# sanitization rescans a document one time for each identity that it finds, so
-# an unbounded document turns one worker into a multi-hour straggler.
+# A cap on document size, not a content test: sanitization rescans a document one
+# time for each identity that it finds, so an unbounded document turns one worker
+# into a multi-hour straggler. The cap does discard the rare valid long log. In a
+# 300-run sample the logs above it were pytest diffs of binary blobs — 0.6% of the
+# job logs and 60% of the bytes — so the accepted loss is small.
 _GHALOGS_MAX_JOB_LOG_BYTES = 8 * 1024 * 1024
 # Characters that a text log cannot contain: C0 controls other than tab, line
 # feed, carriage return, and ESC, plus DEL and the Unicode replacement
 # character. ESC stays because GitHub Actions logs carry ANSI color sequences.
 _NON_TEXT_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1a\x1c-\x1f\x7f\ufffd]")
-# Above this fraction of non-text characters the payload is binary, not a log.
 _MAX_NON_TEXT_CHAR_RATIO = 0.01
 
 _PARTITION_BUCKETS = 10_000
@@ -192,6 +193,14 @@ class DiagnosticPartition(StrEnum):
     DEV = auto()
     TEST = auto()
     ISSUE_5093_HOLDOUT = auto()
+
+
+class JobLogDrop(StrEnum):
+    """Why a GHALogs job log yields no record. The value names its drop counter."""
+
+    OVERSIZE = auto()
+    NON_TEXT = auto()
+    EMPTY = auto()
 
 
 class DiagnosticLogsArtifact(BaseModel):
@@ -492,12 +501,18 @@ def _is_job_log(member: tarfile.TarInfo) -> bool:
     )
 
 
-def _decode_job_log_text(content: bytes) -> str | None:
-    """Decode job-log bytes as text, or return None when the payload is not text."""
+def _decode_job_log_text(content: bytes) -> str | JobLogDrop:
+    """Decode job-log bytes into cleaned text, or report why the payload is not usable.
+
+    Removes the non-text characters in one pass and reads the count of removed
+    characters from the length difference, so a binary payload never builds a
+    match object for each of its bytes.
+    """
     text = content.decode("utf-8", errors="replace")
-    if len(_NON_TEXT_CHAR_RE.findall(text)) > _MAX_NON_TEXT_CHAR_RATIO * len(text):
-        return None
-    return _NON_TEXT_CHAR_RE.sub("", text).strip() or None
+    cleaned = _NON_TEXT_CHAR_RE.sub("", text)
+    if len(text) - len(cleaned) > _MAX_NON_TEXT_CHAR_RATIO * len(text):
+        return JobLogDrop.NON_TEXT
+    return cleaned.strip() or JobLogDrop.EMPTY
 
 
 def ghalogs_member_to_records(member_path: str, content: bytes) -> Iterator[dict[str, str]]:
@@ -520,13 +535,13 @@ def ghalogs_member_to_records(member_path: str, content: bytes) -> Iterator[dict
                 continue
             log_path = f"{member_path}{_GHALOGS_LOG_PATH_SEPARATOR}{member.name}"
             if member.size > _GHALOGS_MAX_JOB_LOG_BYTES:
-                counters.pipeline.update_counter("ghalogs_materialize/dropped_oversize", 1)
+                counters.pipeline.update_counter(f"ghalogs_materialize/dropped_{JobLogDrop.OVERSIZE}", 1)
                 continue
             handle = run_logs.extractfile(member)
             assert handle is not None, f"{log_path} is a regular file"
             text = _decode_job_log_text(handle.read())
-            if text is None:
-                counters.pipeline.update_counter("ghalogs_materialize/dropped_non_text", 1)
+            if isinstance(text, JobLogDrop):
+                counters.pipeline.update_counter(f"ghalogs_materialize/dropped_{text}", 1)
                 continue
 
             yield {

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -68,6 +68,20 @@ def _run_archive_member(run_logs: dict[str, bytes]) -> bytes:
     return buffer.getvalue()
 
 
+def _write_ghalogs_archive(archive_path: Path, job_logs: dict[str, bytes]) -> None:
+    """Write a GHALogs zip whose members are run archives holding one job log each."""
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        for member_path, job_log in job_logs.items():
+            archive.writestr(member_path, _run_archive_member({"0_build.txt": job_log}))
+
+
+_THREE_RUN_JOB_LOGS = {
+    "logs/owner/repo-a/workflow_1234/1-1.tar.gz": b"ERROR token=abc123456789 traceback",
+    "logs/owner/repo-b/workflow_1234/2-1.tar.gz": b"FAILED alice@example.com /Users/alice/project",
+    "logs/owner/repo-c/workflow_1234/3-1.tar.gz": b"WARNING path=/home/bob/src",
+}
+
+
 def _member_path_for_partition(partition: DiagnosticPartition) -> str:
     for index in range(10_000):
         member_path = f"logs/owner/repo-{partition.value}/workflow_1234/{index}-1.tar.gz"
@@ -247,15 +261,13 @@ def test_extract_diagnostic_logs_is_sample_capped(tmp_path):
 
     ghalogs_dir = input_dir / "ghalogs" / "zenodo-14796970" / "zenodo.org" / "records" / "14796970" / "files"
     ghalogs_dir.mkdir(parents=True)
-    with zipfile.ZipFile(ghalogs_dir / "github_run_logs.zip", "w") as archive:
-        archive.writestr(
-            "logs/owner/repo-a/workflow_1234/1-1.tar.gz",
-            _run_archive_member({"0_build.txt": b"ERROR token=abc123456789 traceback"}),
-        )
-        archive.writestr(
-            "logs/owner/repo-b/workflow_1234/2-1.tar.gz",
-            _run_archive_member({"0_build.txt": b"FAILED alice@example.com /Users/alice/project"}),
-        )
+    _write_ghalogs_archive(
+        ghalogs_dir / "github_run_logs.zip",
+        {
+            "logs/owner/repo-a/workflow_1234/1-1.tar.gz": b"ERROR token=abc123456789 traceback",
+            "logs/owner/repo-b/workflow_1234/2-1.tar.gz": b"FAILED alice@example.com /Users/alice/project",
+        },
+    )
 
     with zipfile.ZipFile(input_dir / "LogChunks.zip", "w") as archive:
         archive.writestr(
@@ -332,11 +344,10 @@ def test_extract_diagnostic_logs_uses_staged_ghalogs_and_fetches_missing_eval_so
     output_dir = tmp_path / "output"
     ghalogs_archive_dir.mkdir(parents=True)
 
-    with zipfile.ZipFile(ghalogs_archive_dir / "github_run_logs.zip", "w") as archive:
-        archive.writestr(
-            "logs/owner/repo-a/workflow_1234/1-1.tar.gz",
-            _run_archive_member({"0_build.txt": b"ERROR token=abc123456789 traceback"}),
-        )
+    _write_ghalogs_archive(
+        ghalogs_archive_dir / "github_run_logs.zip",
+        {"logs/owner/repo-a/workflow_1234/1-1.tar.gz": b"ERROR token=abc123456789 traceback"},
+    )
 
     def _fake_fetch_logchunks(destination_dir: str) -> str:
         destination = Path(destination_dir)
@@ -395,11 +406,10 @@ def test_extract_ghalogs_step_persists_typed_artifact(tmp_path):
     archive_dir = input_dir / "zenodo.org" / "records" / "14796970" / "files"
     archive_dir.mkdir(parents=True)
 
-    with zipfile.ZipFile(archive_dir / "github_run_logs.zip", "w") as archive:
-        archive.writestr(
-            "logs/owner/repo-a/workflow_1234/1-1.tar.gz",
-            _run_archive_member({"0_build.txt": b"ERROR token=abc123456789 traceback"}),
-        )
+    _write_ghalogs_archive(
+        archive_dir / "github_run_logs.zip",
+        {"logs/owner/repo-a/workflow_1234/1-1.tar.gz": b"ERROR token=abc123456789 traceback"},
+    )
 
     step = extract_ghalogs_step(
         source_path=str(input_dir),
@@ -420,19 +430,7 @@ def test_materialize_ghalogs_to_parquet_writes_reusable_shards(tmp_path):
     output_dir = tmp_path / "materialized"
     archive_dir.mkdir(parents=True)
 
-    with zipfile.ZipFile(archive_dir / "github_run_logs.zip", "w") as archive:
-        archive.writestr(
-            "logs/owner/repo-a/workflow_1234/1-1.tar.gz",
-            _run_archive_member({"0_build.txt": b"ERROR token=abc123456789 traceback"}),
-        )
-        archive.writestr(
-            "logs/owner/repo-b/workflow_1234/2-1.tar.gz",
-            _run_archive_member({"0_build.txt": b"FAILED alice@example.com /Users/alice/project"}),
-        )
-        archive.writestr(
-            "logs/owner/repo-c/workflow_1234/3-1.tar.gz",
-            _run_archive_member({"0_build.txt": b"WARNING path=/home/bob/src"}),
-        )
+    _write_ghalogs_archive(archive_dir / "github_run_logs.zip", _THREE_RUN_JOB_LOGS)
 
     materialized = materialize_ghalogs_to_parquet(
         str(input_dir),
@@ -459,19 +457,7 @@ def test_materialize_ghalogs_partition_to_parquet_filters_one_partition(tmp_path
     partition_dir = tmp_path / "train_only"
     archive_dir.mkdir(parents=True)
 
-    with zipfile.ZipFile(archive_dir / "github_run_logs.zip", "w") as archive:
-        archive.writestr(
-            "logs/owner/repo-a/workflow_1234/1-1.tar.gz",
-            _run_archive_member({"0_build.txt": b"ERROR token=abc123456789 traceback"}),
-        )
-        archive.writestr(
-            "logs/owner/repo-b/workflow_1234/2-1.tar.gz",
-            _run_archive_member({"0_build.txt": b"FAILED alice@example.com /Users/alice/project"}),
-        )
-        archive.writestr(
-            "logs/owner/repo-c/workflow_1234/3-1.tar.gz",
-            _run_archive_member({"0_build.txt": b"WARNING path=/home/bob/src"}),
-        )
+    _write_ghalogs_archive(archive_dir / "github_run_logs.zip", _THREE_RUN_JOB_LOGS)
 
     materialize_ghalogs_to_parquet(
         str(input_dir),
@@ -501,12 +487,10 @@ def test_ghalogs_public_normalize_steps_write_datakit_normalized_train_partition
 
     train_member = _member_path_for_partition(DiagnosticPartition.TRAIN)
     dev_member = _member_path_for_partition(DiagnosticPartition.DEV)
-    with zipfile.ZipFile(archive_dir / "github_run_logs.zip", "w") as archive:
-        archive.writestr(
-            train_member,
-            _run_archive_member({"0_build.txt": b"ERROR token=abc123456789 traceback"}),
-        )
-        archive.writestr(dev_member, _run_archive_member({"0_build.txt": b"FAILED validation-only log"}))
+    _write_ghalogs_archive(
+        archive_dir / "github_run_logs.zip",
+        {train_member: b"ERROR token=abc123456789 traceback", dev_member: b"FAILED validation-only log"},
+    )
 
     # The archive is already staged at ``source_path``; no-op the Zenodo stream
     # so the download step doesn't try to fetch the real ~142 GB archive.
@@ -548,11 +532,7 @@ def test_ghalogs_public_normalize_steps_read_where_download_wrote(tmp_path, monk
     staged_archive = Path(download.output_path) / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH
     staged_archive.parent.mkdir(parents=True)
     train_member = _member_path_for_partition(DiagnosticPartition.TRAIN)
-    with zipfile.ZipFile(staged_archive, "w") as archive:
-        archive.writestr(
-            train_member,
-            _run_archive_member({"0_build.txt": b"ERROR token=abc123456789 traceback"}),
-        )
+    _write_ghalogs_archive(staged_archive, {train_member: b"ERROR token=abc123456789 traceback"})
 
     # Archive is pre-staged; no-op the Zenodo stream.
     monkeypatch.setattr(diagnostic_logs, "stage_ghalogs_archive", lambda output_path: None)

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -120,7 +120,7 @@ def test_ghalogs_member_to_records_extracts_job_logs_and_ignores_step_copies():
 
     records = list(ghalogs_member_to_records(member_path, content))
 
-    assert [record["archive_path"] for record in records] == [f"{member_path}!0_build.txt"]
+    assert [record["archive_path"] for record in records] == [f"{member_path}!0_build.txt#0"]
     assert records[0]["source"] == "ghalogs"
     assert "abc123456789" not in records[0]["text"]
     assert "<REDACTED_SECRET>" in records[0]["text"]
@@ -152,7 +152,7 @@ def test_ghalogs_member_to_records_rejects_binary_job_logs():
 
     records = list(ghalogs_member_to_records(member_path, content))
 
-    assert [record["archive_path"] for record in records] == [f"{member_path}!1_test.txt"]
+    assert [record["archive_path"] for record in records] == [f"{member_path}!1_test.txt#0"]
 
 
 def test_ghalogs_member_to_records_removes_stray_control_bytes_and_keeps_ansi_color():
@@ -168,19 +168,46 @@ def test_ghalogs_member_to_records_removes_stray_control_bytes_and_keeps_ansi_co
     assert "\x1b[36;1mmake build\x1b[0m" in record["text"]
 
 
-def test_ghalogs_member_to_records_drops_oversize_job_logs(monkeypatch):
-    monkeypatch.setattr(diagnostic_logs, "_GHALOGS_MAX_JOB_LOG_BYTES", 1024)
+def test_ghalogs_member_to_records_splits_long_job_logs_into_chunks(monkeypatch):
+    monkeypatch.setattr(diagnostic_logs, "_GHALOGS_JOB_LOG_CHUNK_BYTES", 1024)
     member_path = "logs/owner/repo/build_1234/10-1.tar.gz"
-    content = _run_archive_member(
-        {
-            "0_build.txt": b"byte dump line of a pytest assertion diff\n" * 64,
-            "1_test.txt": b"plain job log line\n",
-        }
-    )
+    long_log = b"".join(f"byte dump line {index} of a pytest assertion diff\n".encode() for index in range(64))
+    content = _run_archive_member({"0_build.txt": long_log, "1_test.txt": b"plain job log line\n"})
 
     records = list(ghalogs_member_to_records(member_path, content))
 
-    assert [record["archive_path"] for record in records] == [f"{member_path}!1_test.txt"]
+    chunks = [record for record in records if "0_build.txt" in record["archive_path"]]
+    assert len(chunks) > 1
+    assert [record["archive_path"] for record in chunks] == [
+        f"{member_path}!0_build.txt#{index}" for index in range(len(chunks))
+    ]
+    assert all(len(record["text"]) <= 1024 for record in chunks)
+    # No line is split across chunks, and no line is lost or repeated.
+    assert "\n".join(record["text"] for record in chunks).splitlines() == long_log.decode().splitlines()
+    # A job log that fits in one chunk still gives one record.
+    assert f"{member_path}!1_test.txt#0" in {record["archive_path"] for record in records}
+
+
+def test_ghalogs_member_to_records_gives_each_chunk_its_own_id(monkeypatch):
+    monkeypatch.setattr(diagnostic_logs, "_GHALOGS_JOB_LOG_CHUNK_BYTES", 128)
+    member_path = "logs/owner/repo/build_1234/12-1.tar.gz"
+    content = _run_archive_member({"0_build.txt": b"a line of job log output\n" * 32})
+
+    records = list(ghalogs_member_to_records(member_path, content))
+
+    assert len(records) > 1
+    assert len({record["id"] for record in records}) == len(records)
+    assert {record["partition"] for record in records} == {records[0]["partition"]}
+
+
+def test_ghalogs_member_to_records_splits_a_job_log_without_line_breaks(monkeypatch):
+    monkeypatch.setattr(diagnostic_logs, "_GHALOGS_JOB_LOG_CHUNK_BYTES", 64)
+    member_path = "logs/owner/repo/build_1234/13-1.tar.gz"
+    content = _run_archive_member({"0_build.txt": b"x" * 256})
+
+    records = list(ghalogs_member_to_records(member_path, content))
+
+    assert [record["text"] for record in records] == ["x" * 64] * 4
 
 
 def test_ghalogs_member_to_records_rejects_an_unexpected_member_layout():
@@ -368,9 +395,9 @@ def test_extract_ghalogs_caps_run_archives_not_records(tmp_path):
     for partition in DiagnosticPartition:
         records.extend(_read_jsonl(str(tmp_path / "output" / partition.value / "data-00000-of-00001.jsonl")))
     assert sorted(record["archive_path"] for record in records) == [
-        "logs/owner/repo-a/w_1/1-1.tar.gz!0_build.txt",
-        "logs/owner/repo-a/w_1/1-1.tar.gz!1_test.txt",
-        "logs/owner/repo-a/w_1/1-1.tar.gz!2_deploy.txt",
+        "logs/owner/repo-a/w_1/1-1.tar.gz!0_build.txt#0",
+        "logs/owner/repo-a/w_1/1-1.tar.gz!1_test.txt#0",
+        "logs/owner/repo-a/w_1/1-1.tar.gz!2_deploy.txt#0",
     ]
     # All job logs of one run share the run's partition.
     assert len({record["partition"] for record in records}) == 1
@@ -547,7 +574,7 @@ def test_ghalogs_public_normalize_steps_write_datakit_normalized_train_partition
 
     assert len(rows) == 1
     assert rows[0]["source"] == "ghalogs"
-    assert rows[0]["archive_path"] == f"{train_member}!0_build.txt"
+    assert rows[0]["archive_path"] == f"{train_member}!0_build.txt#0"
     assert rows[0]["partition"] == DiagnosticPartition.TRAIN.value
     assert "abc123456789" not in rows[0]["text"]
     assert rows[0]["source_id"] != rows[0]["id"]
@@ -577,7 +604,7 @@ def test_ghalogs_public_normalize_steps_read_where_download_wrote(tmp_path, monk
     StepRunner().run([download, materialized])
 
     rows = _read_parquet_rows(Path(materialized.output_path))
-    assert [row["archive_path"] for row in rows] == [f"{train_member}!0_build.txt"]
+    assert [row["archive_path"] for row in rows] == [f"{train_member}!0_build.txt#0"]
 
 
 class _FakeStreamResponse:

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -26,6 +26,7 @@ from marin.datakit.download.diagnostic_logs import (
     assign_partition,
     download_ghalogs_step,
     extract_diagnostic_logs,
+    extract_ghalogs,
     extract_ghalogs_step,
     ghalogs_member_to_records,
     ghalogs_public_normalize_steps,
@@ -167,11 +168,12 @@ def test_ghalogs_member_to_records_removes_stray_control_bytes_and_keeps_ansi_co
     assert "\x1b[36;1mmake build\x1b[0m" in record["text"]
 
 
-def test_ghalogs_member_to_records_drops_oversize_job_logs():
+def test_ghalogs_member_to_records_drops_oversize_job_logs(monkeypatch):
+    monkeypatch.setattr(diagnostic_logs, "_GHALOGS_MAX_JOB_LOG_BYTES", 1024)
     member_path = "logs/owner/repo/build_1234/10-1.tar.gz"
     content = _run_archive_member(
         {
-            "0_build.txt": b"byte dump line of a pytest assertion diff\n" * 300_000,
+            "0_build.txt": b"byte dump line of a pytest assertion diff\n" * 64,
             "1_test.txt": b"plain job log line\n",
         }
     )
@@ -336,6 +338,42 @@ def test_extract_diagnostic_logs_is_sample_capped(tmp_path):
     assert loghub_records[0]["source"] == "loghub"
     loghub_metadata = json.loads((output_dir / "eval_only" / "loghub" / "metadata.json").read_text())
     assert loghub_metadata["source_manifest"]["policy"]["eval_only"] is True
+
+
+def test_extract_ghalogs_caps_run_archives_not_records(tmp_path):
+    """max_members bounds run archives; one capped run still yields all of its job logs."""
+    archive_dir = tmp_path / "zenodo.org" / "records" / "14796970" / "files"
+    archive_dir.mkdir(parents=True)
+    with zipfile.ZipFile(archive_dir / "github_run_logs.zip", "w") as archive:
+        for member_path in ("logs/owner/repo-a/w_1/1-1.tar.gz", "logs/owner/repo-b/w_1/2-1.tar.gz"):
+            archive.writestr(
+                member_path,
+                _run_archive_member(
+                    {
+                        "0_build.txt": b"build job log",
+                        "1_test.txt": b"test job log",
+                        "2_deploy.txt": b"deploy job log",
+                        # Per-step files repeat the job text, so they are not records.
+                        "0_build/1_checkout.txt": b"build job log",
+                    }
+                ),
+            )
+
+    extracted = extract_ghalogs(str(tmp_path), str(tmp_path / "output"), max_members=1)
+
+    metadata = json.loads((tmp_path / "output" / "metadata.json").read_text())
+    assert metadata["materialized_output"]["metadata"]["counters"]["seen_members"] == 1
+    assert extracted.record_count == 3
+    records = []
+    for partition in DiagnosticPartition:
+        records.extend(_read_jsonl(str(tmp_path / "output" / partition.value / "data-00000-of-00001.jsonl")))
+    assert sorted(record["archive_path"] for record in records) == [
+        "logs/owner/repo-a/w_1/1-1.tar.gz!0_build.txt",
+        "logs/owner/repo-a/w_1/1-1.tar.gz!1_test.txt",
+        "logs/owner/repo-a/w_1/1-1.tar.gz!2_deploy.txt",
+    ]
+    # All job logs of one run share the run's partition.
+    assert len({record["partition"] for record in records}) == 1
 
 
 def test_extract_diagnostic_logs_uses_staged_ghalogs_and_fetches_missing_eval_sources(tmp_path, monkeypatch):

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -126,7 +126,6 @@ def test_ghalogs_member_to_records_extracts_job_logs_and_ignores_step_copies():
     assert "<REDACTED_SECRET>" in records[0]["text"]
     assert "<USER_0_EMAIL>" in records[0]["text"]
     assert "/home/<USER_0>/project" in records[0]["text"]
-    assert records[0]["partition"] in {partition.value for partition in DiagnosticPartition}
 
 
 def test_ghalogs_member_to_records_keeps_one_partition_for_each_run():
@@ -186,18 +185,6 @@ def test_ghalogs_member_to_records_splits_long_job_logs_into_chunks(monkeypatch)
     assert "\n".join(record["text"] for record in chunks).splitlines() == long_log.decode().splitlines()
     # A job log that fits in one chunk still gives one record.
     assert f"{member_path}!1_test.txt#0" in {record["archive_path"] for record in records}
-
-
-def test_ghalogs_member_to_records_gives_each_chunk_its_own_id(monkeypatch):
-    monkeypatch.setattr(diagnostic_logs, "_GHALOGS_JOB_LOG_CHUNK_BYTES", 128)
-    member_path = "logs/owner/repo/build_1234/12-1.tar.gz"
-    content = _run_archive_member({"0_build.txt": b"a line of job log output\n" * 32})
-
-    records = list(ghalogs_member_to_records(member_path, content))
-
-    assert len(records) > 1
-    assert len({record["id"] for record in records}) == len(records)
-    assert {record["partition"] for record in records} == {records[0]["partition"]}
 
 
 def test_ghalogs_member_to_records_splits_a_job_log_without_line_breaks(monkeypatch):

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -1,8 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import gzip
 import http.client
+import io
 import json
+import tarfile
 import xml.etree.ElementTree as ET
 import zipfile
 from pathlib import Path
@@ -24,7 +27,7 @@ from marin.datakit.download.diagnostic_logs import (
     download_ghalogs_step,
     extract_diagnostic_logs,
     extract_ghalogs_step,
-    ghalogs_member_to_record,
+    ghalogs_member_to_records,
     ghalogs_public_normalize_steps,
     logchunks_example_to_record,
     loghub_file_to_record,
@@ -54,9 +57,20 @@ def _read_parquet_rows(directory: Path) -> list[dict[str, object]]:
     return rows
 
 
+def _run_archive_member(run_logs: dict[str, bytes]) -> bytes:
+    """Build one GHALogs zip member: a gzipped tar of one workflow run's log files."""
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        for name, payload in run_logs.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, io.BytesIO(payload))
+    return buffer.getvalue()
+
+
 def _member_path_for_partition(partition: DiagnosticPartition) -> str:
     for index in range(10_000):
-        member_path = f"repo-{partition.value}/run-{index}/job.log"
+        member_path = f"logs/owner/repo-{partition.value}/workflow_1234/{index}-1.tar.gz"
         if assign_partition(f"ghalogs:{member_path}") == partition:
             return member_path
     raise AssertionError(f"Could not find member path for {partition}")
@@ -79,21 +93,83 @@ def test_sanitize_diagnostic_log_text_redacts_secrets_and_identifiers():
     assert "user <USER_0> failed" in redacted
 
 
-def test_ghalogs_member_to_record_sanitizes_and_partitions():
-    record = ghalogs_member_to_record(
-        "owner/repo/run-1/job.log",
-        b"ERROR token=abc123456789 contact alice@example.com path=/home/alice/project",
+def test_ghalogs_member_to_records_extracts_job_logs_and_ignores_step_copies():
+    member_path = "logs/owner/repo/build_1234/7-1.tar.gz"
+    content = _run_archive_member(
+        {
+            "0_build.txt": b"ERROR token=abc123456789 contact alice@example.com path=/home/alice/project",
+            "build/": b"",
+            "build/1_Set up job.txt": b"ERROR token=abc123456789 contact alice@example.com",
+        }
     )
 
-    assert record is not None
-    assert record["source"] == "ghalogs"
-    assert record["archive_path"] == "owner/repo/run-1/job.log"
-    assert "abc123456789" not in record["text"]
-    assert "alice@example.com" not in record["text"]
-    assert "<REDACTED_SECRET>" in record["text"]
-    assert "<USER_0_EMAIL>" in record["text"]
-    assert "/home/<USER_0>/project" in record["text"]
-    assert record["partition"] in {"train", "dev", "test", "issue_5093_holdout"}
+    records = list(ghalogs_member_to_records(member_path, content))
+
+    assert [record["archive_path"] for record in records] == [f"{member_path}!0_build.txt"]
+    assert records[0]["source"] == "ghalogs"
+    assert "abc123456789" not in records[0]["text"]
+    assert "<REDACTED_SECRET>" in records[0]["text"]
+    assert "<USER_0_EMAIL>" in records[0]["text"]
+    assert "/home/<USER_0>/project" in records[0]["text"]
+    assert records[0]["partition"] in {partition.value for partition in DiagnosticPartition}
+
+
+def test_ghalogs_member_to_records_keeps_one_partition_for_each_run():
+    member_path = _member_path_for_partition(DiagnosticPartition.DEV)
+    content = _run_archive_member(
+        {"0_build.txt": b"first job log line", "1_test.txt": b"second job log line"},
+    )
+
+    records = list(ghalogs_member_to_records(member_path, content))
+
+    assert {record["partition"] for record in records} == {DiagnosticPartition.DEV.value}
+    assert len({record["id"] for record in records}) == 2
+
+
+def test_ghalogs_member_to_records_rejects_binary_job_logs():
+    member_path = "logs/owner/repo/build_1234/8-1.tar.gz"
+    content = _run_archive_member(
+        {
+            "0_build.txt": gzip.compress(b"log line that was compressed\n" * 64),
+            "1_test.txt": b"plain job log line\n",
+        }
+    )
+
+    records = list(ghalogs_member_to_records(member_path, content))
+
+    assert [record["archive_path"] for record in records] == [f"{member_path}!1_test.txt"]
+
+
+def test_ghalogs_member_to_records_removes_stray_control_bytes_and_keeps_ansi_color():
+    member_path = "logs/owner/repo/build_1234/9-1.tar.gz"
+    content = _run_archive_member(
+        {"0_build.txt": b"\x1b[36;1mmake build\x1b[0m\nstep output\x00 continues\n" + b"more log output\n" * 64},
+    )
+
+    (record,) = list(ghalogs_member_to_records(member_path, content))
+
+    assert "\x00" not in record["text"]
+    assert "step output continues" in record["text"]
+    assert "\x1b[36;1mmake build\x1b[0m" in record["text"]
+
+
+def test_ghalogs_member_to_records_drops_oversize_job_logs():
+    member_path = "logs/owner/repo/build_1234/10-1.tar.gz"
+    content = _run_archive_member(
+        {
+            "0_build.txt": b"byte dump line of a pytest assertion diff\n" * 300_000,
+            "1_test.txt": b"plain job log line\n",
+        }
+    )
+
+    records = list(ghalogs_member_to_records(member_path, content))
+
+    assert [record["archive_path"] for record in records] == [f"{member_path}!1_test.txt"]
+
+
+def test_ghalogs_member_to_records_rejects_an_unexpected_member_layout():
+    with pytest.raises(ValueError, match=r"\.tar\.gz"):
+        list(ghalogs_member_to_records("logs/owner/repo/build_1234/11-1.txt", b"plain job log line"))
 
 
 def test_logchunks_example_to_record_sanitizes():
@@ -172,8 +248,14 @@ def test_extract_diagnostic_logs_is_sample_capped(tmp_path):
     ghalogs_dir = input_dir / "ghalogs" / "zenodo-14796970" / "zenodo.org" / "records" / "14796970" / "files"
     ghalogs_dir.mkdir(parents=True)
     with zipfile.ZipFile(ghalogs_dir / "github_run_logs.zip", "w") as archive:
-        archive.writestr("repo-a/run-1/job.log", "ERROR token=abc123456789 traceback")
-        archive.writestr("repo-b/run-2/job.log", "FAILED alice@example.com /Users/alice/project")
+        archive.writestr(
+            "logs/owner/repo-a/workflow_1234/1-1.tar.gz",
+            _run_archive_member({"0_build.txt": b"ERROR token=abc123456789 traceback"}),
+        )
+        archive.writestr(
+            "logs/owner/repo-b/workflow_1234/2-1.tar.gz",
+            _run_archive_member({"0_build.txt": b"FAILED alice@example.com /Users/alice/project"}),
+        )
 
     with zipfile.ZipFile(input_dir / "LogChunks.zip", "w") as archive:
         archive.writestr(
@@ -251,7 +333,10 @@ def test_extract_diagnostic_logs_uses_staged_ghalogs_and_fetches_missing_eval_so
     ghalogs_archive_dir.mkdir(parents=True)
 
     with zipfile.ZipFile(ghalogs_archive_dir / "github_run_logs.zip", "w") as archive:
-        archive.writestr("repo-a/run-1/job.log", "ERROR token=abc123456789 traceback")
+        archive.writestr(
+            "logs/owner/repo-a/workflow_1234/1-1.tar.gz",
+            _run_archive_member({"0_build.txt": b"ERROR token=abc123456789 traceback"}),
+        )
 
     def _fake_fetch_logchunks(destination_dir: str) -> str:
         destination = Path(destination_dir)
@@ -311,7 +396,10 @@ def test_extract_ghalogs_step_persists_typed_artifact(tmp_path):
     archive_dir.mkdir(parents=True)
 
     with zipfile.ZipFile(archive_dir / "github_run_logs.zip", "w") as archive:
-        archive.writestr("repo-a/run-1/job.log", "ERROR token=abc123456789 traceback")
+        archive.writestr(
+            "logs/owner/repo-a/workflow_1234/1-1.tar.gz",
+            _run_archive_member({"0_build.txt": b"ERROR token=abc123456789 traceback"}),
+        )
 
     step = extract_ghalogs_step(
         source_path=str(input_dir),
@@ -333,9 +421,18 @@ def test_materialize_ghalogs_to_parquet_writes_reusable_shards(tmp_path):
     archive_dir.mkdir(parents=True)
 
     with zipfile.ZipFile(archive_dir / "github_run_logs.zip", "w") as archive:
-        archive.writestr("repo-a/run-1/job.log", "ERROR token=abc123456789 traceback")
-        archive.writestr("repo-b/run-2/job.log", "FAILED alice@example.com /Users/alice/project")
-        archive.writestr("repo-c/run-3/job.log", "WARNING path=/home/bob/src")
+        archive.writestr(
+            "logs/owner/repo-a/workflow_1234/1-1.tar.gz",
+            _run_archive_member({"0_build.txt": b"ERROR token=abc123456789 traceback"}),
+        )
+        archive.writestr(
+            "logs/owner/repo-b/workflow_1234/2-1.tar.gz",
+            _run_archive_member({"0_build.txt": b"FAILED alice@example.com /Users/alice/project"}),
+        )
+        archive.writestr(
+            "logs/owner/repo-c/workflow_1234/3-1.tar.gz",
+            _run_archive_member({"0_build.txt": b"WARNING path=/home/bob/src"}),
+        )
 
     materialized = materialize_ghalogs_to_parquet(
         str(input_dir),
@@ -363,9 +460,18 @@ def test_materialize_ghalogs_partition_to_parquet_filters_one_partition(tmp_path
     archive_dir.mkdir(parents=True)
 
     with zipfile.ZipFile(archive_dir / "github_run_logs.zip", "w") as archive:
-        archive.writestr("repo-a/run-1/job.log", "ERROR token=abc123456789 traceback")
-        archive.writestr("repo-b/run-2/job.log", "FAILED alice@example.com /Users/alice/project")
-        archive.writestr("repo-c/run-3/job.log", "WARNING path=/home/bob/src")
+        archive.writestr(
+            "logs/owner/repo-a/workflow_1234/1-1.tar.gz",
+            _run_archive_member({"0_build.txt": b"ERROR token=abc123456789 traceback"}),
+        )
+        archive.writestr(
+            "logs/owner/repo-b/workflow_1234/2-1.tar.gz",
+            _run_archive_member({"0_build.txt": b"FAILED alice@example.com /Users/alice/project"}),
+        )
+        archive.writestr(
+            "logs/owner/repo-c/workflow_1234/3-1.tar.gz",
+            _run_archive_member({"0_build.txt": b"WARNING path=/home/bob/src"}),
+        )
 
     materialize_ghalogs_to_parquet(
         str(input_dir),
@@ -396,8 +502,11 @@ def test_ghalogs_public_normalize_steps_write_datakit_normalized_train_partition
     train_member = _member_path_for_partition(DiagnosticPartition.TRAIN)
     dev_member = _member_path_for_partition(DiagnosticPartition.DEV)
     with zipfile.ZipFile(archive_dir / "github_run_logs.zip", "w") as archive:
-        archive.writestr(train_member, "ERROR token=abc123456789 traceback")
-        archive.writestr(dev_member, "FAILED validation-only log")
+        archive.writestr(
+            train_member,
+            _run_archive_member({"0_build.txt": b"ERROR token=abc123456789 traceback"}),
+        )
+        archive.writestr(dev_member, _run_archive_member({"0_build.txt": b"FAILED validation-only log"}))
 
     # The archive is already staged at ``source_path``; no-op the Zenodo stream
     # so the download step doesn't try to fetch the real ~142 GB archive.
@@ -416,7 +525,7 @@ def test_ghalogs_public_normalize_steps_write_datakit_normalized_train_partition
 
     assert len(rows) == 1
     assert rows[0]["source"] == "ghalogs"
-    assert rows[0]["archive_path"] == train_member
+    assert rows[0]["archive_path"] == f"{train_member}!0_build.txt"
     assert rows[0]["partition"] == DiagnosticPartition.TRAIN.value
     assert "abc123456789" not in rows[0]["text"]
     assert rows[0]["source_id"] != rows[0]["id"]
@@ -440,14 +549,17 @@ def test_ghalogs_public_normalize_steps_read_where_download_wrote(tmp_path, monk
     staged_archive.parent.mkdir(parents=True)
     train_member = _member_path_for_partition(DiagnosticPartition.TRAIN)
     with zipfile.ZipFile(staged_archive, "w") as archive:
-        archive.writestr(train_member, "ERROR token=abc123456789 traceback")
+        archive.writestr(
+            train_member,
+            _run_archive_member({"0_build.txt": b"ERROR token=abc123456789 traceback"}),
+        )
 
     # Archive is pre-staged; no-op the Zenodo stream.
     monkeypatch.setattr(diagnostic_logs, "stage_ghalogs_archive", lambda output_path: None)
     StepRunner().run([download, materialized])
 
     rows = _read_parquet_rows(Path(materialized.output_path))
-    assert [row["archive_path"] for row in rows] == [train_member]
+    assert [row["archive_path"] for row in rows] == [f"{train_member}!0_build.txt"]
 
 
 class _FakeStreamResponse:


### PR DESCRIPTION
Every non-directory member of `github_run_logs.zip` is a gzipped tar of one workflow run's logs, so decoding the member bytes as UTF-8 wrote gzip blobs into the normalized `text` field. Read each member as a tar archive and emit records from the top-level `<index>_<job>.txt` job logs. The nested `<job>/<index>_<step>.txt` files repeat that same text split per step and are skipped, which halves the output bytes. Partition assignment still keys on the zip member, so every record of a run stays in one partition.

A job log is written as one record for each 8 MB chunk, split at line boundaries, with `archive_path` set to `<member>.tar.gz!<job log>#<chunk index>` and `id` hashing that path. The bound exists because pseudonymization rescans a document one time for each identity that it finds; splitting into k chunks divides that quadratic term by k, since each chunk carries only its own identities. A consequence is that an identity keeps one pseudonym inside a chunk but not across chunks of one job log — the contract that already held across the job logs of a run. Chunks are read a line at a time, so peak worker memory is one chunk rather than a whole log, which decompression would otherwise take to 260 MB; a bounded `readline` keeps a log without line breaks from exhausting memory.

Splitting rather than capping matters for coverage: in a 300-run sample of the staged archive, the job logs above 8 MB are 0.6% of the job logs and hold 60% of the bytes, so a cap discards most of the source text. That tail is largely pytest byte-dump output.

A chunk is rejected when its NUL, C0-control, and U+FFFD characters exceed 1% of its characters, and those characters are stripped from what is kept. ESC is excluded because ANSI color sequences run throughout these logs. Applying the test per chunk drops a binary region without discarding the surrounding log.

Over 40 runs of the staged archive the extractor produced job-log text with no NUL or replacement characters; that end-to-end check predates the chunk split and was run against the earlier drop-oversize build. Step hash versions and the dataset versions are bumped so the existing broken parquet is not reused; the normalized output must be rebuilt.

Fixes #7770
