### PR TITLE
[grug] Add the expert-parallel core and the moe_hero_ep template

### DIFF
--- a/docs/reports/grug-archive.md
+++ b/docs/reports/grug-archive.md
@@ -35,6 +35,13 @@ goes stale on the next commit.
 - Status: active
 - Purpose: canonical grug template (model/train/launch).
 
+### grug-moe-hero-ep
+- Path: `experiments/grug/moe_hero_ep/`
+- Origin: moe
+- Introduced: 84656eea4
+- Status: active
+- Purpose: fixed one-rack D-2 configuration for 64-way expert-parallel GB200 training.
+
 ### grug-moe
 - Path: `experiments/grug/moe/`
 - Origin: base

--- a/experiments/grug/base/model.py
+++ b/experiments/grug/base/model.py
@@ -21,7 +21,7 @@ from levanter.analysis.backward_flow import (
 )
 from levanter.grug.attention import AttentionMask, RotaryConfig, apply_rotary_embedding, attention
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
-from levanter.grug.sharding import Pbatch, Pembed_vocab, Plm_head, Plogits, unshard
+from levanter.grug.sharding import Pbatch, Pembed_vocab, Plm_head_dense, Plogits, unshard
 
 
 @dataclass(frozen=True)
@@ -171,7 +171,9 @@ class Transformer(eqx.Module):
         token_embed = reshard(
             _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), cfg.initializer_std), Pembed_vocab
         )
-        output_proj = reshard(_init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head)
+        output_proj = reshard(
+            _init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head_dense
+        )
         blocks = tuple(Block.init(cfg, key=layer_key) for layer_key in block_keys)
         final_norm = RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps)
         return Transformer(

--- a/experiments/grug/moe/README.md
+++ b/experiments/grug/moe/README.md
@@ -102,6 +102,7 @@ explicit MoE configuration fields before these paths are generalized.
 | `SCALE_A2A_CHUNKS` | `1` | Split each local token batch into this many fixed-capacity dispatches |
 | `SCALE_A2A_NO_BARRIER` | off | Skip the rematerialization barriers around fixed-capacity dispatch |
 | `SCALE_A2A_SPILL` | `0` | Retry each overflow assignment against this many lower-ranked selected experts |
+| `SCALE_A2A_GATHER_DISPATCH` | off | Scatter assignment indices and gather activation rows into the send buffer |
 
 ## GB200 job environment
 

--- a/experiments/grug/moe/README.md
+++ b/experiments/grug/moe/README.md
@@ -103,6 +103,7 @@ explicit MoE configuration fields before these paths are generalized.
 | `SCALE_A2A_NO_BARRIER` | off | Skip the rematerialization barriers around fixed-capacity dispatch |
 | `SCALE_A2A_SPILL` | `0` | Retry each overflow assignment against this many lower-ranked selected experts |
 | `SCALE_A2A_GATHER_DISPATCH` | off | Scatter assignment indices and gather activation rows into the send buffer |
+| `SCALE_A2A_CUSTOM_ADJOINT` | off | Use structured gather transposes that avoid scatter in the fixed-capacity backward pass |
 
 ## GB200 job environment
 

--- a/experiments/grug/moe/README.md
+++ b/experiments/grug/moe/README.md
@@ -90,6 +90,18 @@ optimizer configuration fields before these paths are generalized.
 | `SCALE_MUON_INTRA_RACK` | off | Exclude `replica_dcn` when distributing 4-D and padded matrix stacks |
 | `SCALE_MUON_SYRK` | off | Use batched QuACK SYRK for Newton-Schulz Gram matrices on distributed 4-D stacks |
 
+### Temporary all-to-all trace controls
+
+These controls are also read inside `lib/levanter` at trace time for the
+measured expert-dispatch experiments. A follow-up should replace them with
+explicit MoE configuration fields before these paths are generalized.
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `SCALE_A2A_FIXED` | off | Use static-capacity `lax.all_to_all` buffers for ragged expert dispatch |
+| `SCALE_A2A_CHUNKS` | `1` | Split each local token batch into this many fixed-capacity dispatches |
+| `SCALE_A2A_NO_BARRIER` | off | Skip the rematerialization barriers around fixed-capacity dispatch |
+
 ## GB200 job environment
 
 Set these variables on every final accelerator process for multi-host GB200 MoE

--- a/experiments/grug/moe/README.md
+++ b/experiments/grug/moe/README.md
@@ -101,6 +101,7 @@ explicit MoE configuration fields before these paths are generalized.
 | `SCALE_A2A_FIXED` | off | Use static-capacity `lax.all_to_all` buffers for ragged expert dispatch |
 | `SCALE_A2A_CHUNKS` | `1` | Split each local token batch into this many fixed-capacity dispatches |
 | `SCALE_A2A_NO_BARRIER` | off | Skip the rematerialization barriers around fixed-capacity dispatch |
+| `SCALE_A2A_SPILL` | `0` | Retry each overflow assignment against this many lower-ranked selected experts |
 
 ## GB200 job environment
 

--- a/experiments/grug/moe/README.md
+++ b/experiments/grug/moe/README.md
@@ -88,6 +88,7 @@ optimizer configuration fields before these paths are generalized.
 | `SCALE_MUON_DIST_NONEXPERT` | off | Use the stack-batch-sharded layout for 3-D non-expert stacks |
 | `SCALE_MUON_PAD_NONEXPERT` | off | Pad 3-D non-expert stacks before the sharded Newton-Schulz path |
 | `SCALE_MUON_INTRA_RACK` | off | Exclude `replica_dcn` when distributing 4-D and padded matrix stacks |
+| `SCALE_MUON_SYRK` | off | Use batched QuACK SYRK for Newton-Schulz Gram matrices on distributed 4-D stacks |
 
 ## GB200 job environment
 

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -48,7 +48,7 @@ from levanter.grug.grug_moe import (
     resolve_moe_implementation,
 )
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
-from levanter.grug.sharding import Pembed_vocab, Plm_head, unshard
+from levanter.grug.sharding import Pembed_vocab, Pfsdp, Plm_head_ep, unshard
 from levanter.tracker.histogram import Histogram, SummaryStats
 from levanter.utils.activation import ActivationFunctionEnum
 from transformers import PretrainedConfig as HfConfig
@@ -325,10 +325,10 @@ class CausalSelfAttention(eqx.Module):
         k_q, k_k, k_v, k_o = random.split(key, 4)
         d, n, m, h = cfg.hidden_dim, cfg.num_heads, cfg.num_kv_heads, cfg.inferred_head_dim
         return CausalSelfAttention(
-            w_q=reshard(_init_weight(k_q, (d, n * h), cfg.initializer_std), P("data", "model")),
-            w_k=reshard(_init_weight(k_k, (d, m * h), cfg.initializer_std), P("data", "model")),
-            w_v=reshard(_init_weight(k_v, (d, m * h), cfg.initializer_std), P("data", "model")),
-            w_o=reshard(_init_weight(k_o, (n * h, d), cfg.initializer_std), P("model", "data")),
+            w_q=reshard(_init_weight(k_q, (d, n * h), cfg.initializer_std), P(Pfsdp, "model")),
+            w_k=reshard(_init_weight(k_k, (d, m * h), cfg.initializer_std), P(Pfsdp, "model")),
+            w_v=reshard(_init_weight(k_v, (d, m * h), cfg.initializer_std), P(Pfsdp, "model")),
+            w_o=reshard(_init_weight(k_o, (n * h, d), cfg.initializer_std), P("model", Pfsdp)),
             attn_gate=reshard(jnp.zeros((d, n)), P(None, None)),
             cfg=cfg,
         )
@@ -479,9 +479,9 @@ class DenseMLP(eqx.Module):
     def init(hidden_dim: int, intermediate_dim: int, initializer_std: float, *, key: PRNGKeyArray) -> "DenseMLP":
         k_gate, k_up, k_down = random.split(key, 3)
         return DenseMLP(
-            w_gate=reshard(_init_weight(k_gate, (hidden_dim, intermediate_dim), initializer_std), P("data", "model")),
-            w_up=reshard(_init_weight(k_up, (hidden_dim, intermediate_dim), initializer_std), P("data", "model")),
-            w_down=reshard(_init_weight(k_down, (intermediate_dim, hidden_dim), initializer_std), P("model", "data")),
+            w_gate=reshard(_init_weight(k_gate, (hidden_dim, intermediate_dim), initializer_std), P(Pfsdp, "model")),
+            w_up=reshard(_init_weight(k_up, (hidden_dim, intermediate_dim), initializer_std), P(Pfsdp, "model")),
+            w_down=reshard(_init_weight(k_down, (intermediate_dim, hidden_dim), initializer_std), P("model", Pfsdp)),
         )
 
     @named_call
@@ -798,7 +798,7 @@ class Transformer(eqx.Module):
         token_embed = reshard(
             _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), cfg.initializer_std), Pembed_vocab
         )
-        output_proj = reshard(_init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head)
+        output_proj = reshard(_init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head_ep)
         blocks: tuple[Block, ...] | None
         stacked_blocks: ArrayStacked[Block] | None
         if cfg.use_array_stacked_blocks:

--- a/experiments/grug/moe/test_model.py
+++ b/experiments/grug/moe/test_model.py
@@ -5,11 +5,13 @@ import dataclasses
 
 import jax
 import numpy as np
-from jax.sharding import AxisType, Mesh
+from jax.sharding import AbstractMesh, AxisType, Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
 from levanter.grug.grug_moe import MoEExpertMlp
+from levanter.grug.sharding import Plm_head_dense, Plm_head_ep
 
 from experiments.grug.moe.launch_cw_scale import build_scale_model
-from experiments.grug.moe.model import MoEMLP
+from experiments.grug.moe.model import CausalSelfAttention, DenseMLP, GrugModelConfig, MoEMLP
 
 
 def test_scale_and_direct_moe_resolve_the_same_capacity_default(monkeypatch):
@@ -52,3 +54,49 @@ def test_scale_capacity_factor_is_resolved_before_model_construction(monkeypatch
         moe = MoEMLP.init(config, key=jax.random.key(1))
 
     assert moe.expert_mlp.capacity_factor == config.capacity_factor
+
+
+def test_nonexpert_weights_are_sharded_over_data_and_expert_axes():
+    mesh = Mesh(
+        np.asarray([jax.devices()[0]]).reshape((1, 1, 1)),
+        ("data", "expert", "model"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit, AxisType.Explicit),
+    )
+
+    with jax.set_mesh(mesh):
+        dense = DenseMLP.init(16, 32, 0.02, key=jax.random.key(0))
+        config = GrugModelConfig(
+            vocab_size=128,
+            hidden_dim=16,
+            intermediate_dim=8,
+            shared_expert_intermediate_dim=16,
+            num_experts=4,
+            num_experts_per_token=2,
+            num_layers=1,
+            num_heads=2,
+            num_kv_heads=1,
+        )
+        attention = CausalSelfAttention.init(config, key=jax.random.key(1))
+
+    column_sharding = P(("data", "expert"), "model")
+    row_sharding = P("model", ("data", "expert"))
+    assert dense.w_gate.sharding.spec == column_sharding
+    assert dense.w_up.sharding.spec == column_sharding
+    assert dense.w_down.sharding.spec == row_sharding
+    assert attention.w_q.sharding.spec == column_sharding
+    assert attention.w_k.sharding.spec == column_sharding
+    assert attention.w_v.sharding.spec == column_sharding
+    assert attention.w_o.sharding.spec == row_sharding
+
+
+def test_ep_lm_head_preserves_dense_sharding_at_ep1():
+    mesh = AbstractMesh(
+        axis_sizes=(16, 4, 1, 1),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(AxisType.Explicit,) * 4,
+    )
+    ep_sharding = NamedSharding(mesh, Plm_head_ep)
+    dense_sharding = NamedSharding(mesh, Plm_head_dense)
+
+    assert ep_sharding.is_equivalent_to(dense_sharding, ndim=2)
+    assert ep_sharding.shard_shape((6144, 128256)) == (96, 128256)

--- a/experiments/grug/moe/test_shared_experts.py
+++ b/experiments/grug/moe/test_shared_experts.py
@@ -66,7 +66,11 @@ def test_split_shared_experts_preserve_weight_sharding():
 
     assert unsplit is not None
     assert split is not None
-    expected_specs = (P("data", "model"), P("data", "model"), P("model", "data"))
+    expected_specs = (
+        P(("data", "expert"), "model"),
+        P(("data", "expert"), "model"),
+        P("model", ("data", "expert")),
+    )
     unsplit_specs = tuple(weight.sharding.spec for weight in (unsplit[0].w_gate, unsplit[0].w_up, unsplit[0].w_down))
     split_specs = tuple(
         tuple(weight.sharding.spec for weight in (expert.w_gate, expert.w_up, expert.w_down)) for expert in split

--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -43,11 +43,11 @@ MuonH uses a linear schedule with 1% warmup and a 5% minimum ratio. Its fixed
 peak learning rates are 0.038956464533085024 for MuonH and
 0.008989953353788853 for Adam, with `beta1=0.9062`,
 `beta2=0.9684910757595268`, `epsilon=1.810213843721233e-16`, five
-Newton–Schulz steps, and no gradient clipping. Optimizer state stays on the
-device. Host offload is intentionally absent: the d5120 EP64 trial required a
-135 GiB pinned-host arena and measured 19.694% MFU. The shared-expert split is
-also absent: this template keeps the shared MLP as one expert because the
-multi-way split used 89.49 GiB before step 0 at EP64.
+Newton–Schulz steps, no gradient clipping, and no weight decay. Optimizer state
+stays on the device. Host offload is intentionally absent: the d5120 EP64 trial
+required a 135 GiB pinned-host arena and measured 19.694% MFU. The shared-expert
+split is also absent: this template keeps the shared MLP as one expert because
+the multi-way split used 89.49 GiB before step 0 at EP64.
 
 ## Result provenance
 

--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -1,0 +1,164 @@
+# Grug MoE hero: one-rack EP64
+
+This variant fixes the composed EP64 configuration at hidden dimension 5120
+with 256 routed experts and top-8 routing for 16 workers with four GB200s each.
+It is validated only at one rack. This branch has no accelerator verification.
+The resolved settings and result provenance in this README are the durable
+record; the [Grug archive](../../../docs/reports/grug-archive.md) indexes it.
+
+## Resolved configuration
+
+The launcher does not read `SCALE_*` configuration overrides. It resolves:
+
+| Setting | Value |
+|---|---|
+| Hidden dimension / layers | 5120 / 48 |
+| Attention heads / KV heads / head dimension | 40 / 10 / 128 |
+| Routed experts / experts per token | 256 / 8 |
+| Routed / shared intermediate dimension | 1280 / 5120 |
+| Shared-expert count | 1 |
+| Sequence length / sliding window | 4096 / 2048 |
+| Initializer standard deviation | 0.006987712429686843 |
+| MoE path | `ragged_all_to_all`, fixed capacity |
+| Dispatch / adjoint | gather / custom |
+| Capacity factor / spill attempts / chunks | 1.0625 / 3 / 1 |
+| FSDP expert chunking | off (`expert_chunks=1`) |
+| Fixed all-to-all optimization barrier | disabled |
+| Expert / replica axis size | 64 / 1 |
+| Topology | 16 workers × 4 GB200 = 64 GPUs |
+| Global batch / steps | 1024 / 350 |
+| Attention | `gpu_fa4_cute` |
+| Rematerialization / layer execution | `recompute_all` / one homogeneous scan |
+| Mixed precision | `params=float32,compute=bfloat16,output=bfloat16` |
+| Router | QB routing |
+| Optimizer | MuonH; padded non-expert Newton–Schulz; SYRK |
+| Checkpoint / eval / parameter watches | disabled / disabled / disabled |
+
+GatedNorm, the attention gate, and QB routing are structural in this copy of
+`model.py`; they are not launcher flags. The capacity-factor library default
+remains 1.0. This variant requests 1.0625, the value used for the measured drop
+fraction. All-to-all chunking stays at 1 because chunks=2 measured worse.
+
+MuonH uses a linear schedule with 1% warmup and a 5% minimum ratio. Its fixed
+peak learning rates are 0.038956464533085024 for MuonH and
+0.008989953353788853 for Adam, with `beta1=0.9062`,
+`beta2=0.9684910757595268`, `epsilon=1.810213843721233e-16`, five
+Newton–Schulz steps, and no gradient clipping. Optimizer state stays on the
+device. Host offload is intentionally absent: the d5120 EP64 trial required a
+135 GiB pinned-host arena and measured 19.694% MFU. The shared-expert split is
+also absent: this template keeps the shared MLP as one expert because the
+multi-way split used 89.49 GiB before step 0 at EP64.
+
+## Result provenance
+
+The source research build measured a three-placement-draw median of 22.398% MFU,
+346,950 tokens/s, and 1.444% dropped assignments over steps 250–349 of
+350-step one-rack runs. The MFU denominator was 2.5 PFLOP/s per GB200.
+
+Those measurements came from research build `c24ccfcc2`, not this branch. They
+establish the source recipe's result and do not establish that this template
+reproduces it. This branch has not compiled or run on an accelerator.
+
+All three measured draws replayed a build-specific manual PGLE profile. This
+template ships without that profile and forces auto-PGLE off. That profile's
+measured EP contribution was 0.427 percentage points, so the template as
+shipped is expected to land about 0.427 points below the quoted 22.398% absent
+a current-build profile.
+
+The FSDP and EP headline numbers do not establish which strategy is faster.
+They use different model shapes and measurement windows. In the available
+same-shape comparison, the 0.942% margin is inside placement noise; repeated
+draws on one placement agreed within 0.02%.
+
+The JAX 0.11 baseline measured 1.217 percentage points below the 0.10.1-era
+baseline. Do not use pre-0.11 results as controls for this template.
+
+## Submit
+
+The launcher hardcodes the model, optimizer, topology, batch, runtime MoE
+choices, and 350-step schedule. Set only the run identity and the required GPU
+runtime environment:
+
+```bash
+run_id="moe-hero-ep-$(date -u +%Y%m%d-%H%M%S)"
+
+.venv/bin/iris job run \
+  --no-wait \
+  --max-retries 50 \
+  --cpu 2 \
+  --memory 3GB \
+  --extra cpu \
+  --job-name "$run_id" \
+  -e RUN_ID "$run_id" \
+  -e XLA_PYTHON_CLIENT_ALLOCATOR cuda_async \
+  -e XLA_FLAGS "--xla_gpu_experimental_ragged_all_to_all_use_barrier_with_nccl=false --xla_gpu_experimental_parallel_collective_overlap_limit=4 --xla_gpu_enable_latency_hiding_scheduler=true" \
+  -- python -m experiments.grug.moe_hero_ep.launch \
+    --version dev \
+    --run
+```
+
+`--max-retries 50` is the standing rack-submission protocol.
+
+`XLA_PYTHON_CLIENT_ALLOCATOR=cuda_async` is required. The default BFC allocator
+has caused silent deadlocks and fragmentation OOMs at 64×GB200; clique-init
+stalls on this platform have been traced to BFC fragmentation.
+
+All three XLA flags in the command are required:
+
+- `--xla_gpu_experimental_ragged_all_to_all_use_barrier_with_nccl=false` is
+  mandatory on JAX 0.11. Without it, a 64-process run compiles and then
+  segfaults in `ncclDevCommCreate` before step 0.
+- `--xla_gpu_experimental_parallel_collective_overlap_limit=4` clears the four
+  SYNCs seen at limit 1. The census found 12 MoE all-to-alls at limits 1, 2, 4,
+  and 8, with SYNC counts `4,0,0,0`. Performance is not monotone: limit 2
+  measured worse than limit 1.
+- `--xla_gpu_enable_latency_hiding_scheduler=true` enables collective
+  scheduling with the chosen overlap limit.
+
+Auto-PGLE is forced off by the variant because it crashes multi-host runs. No
+manual PGLE profile ships here because a profile is tied to one compiled
+executable. To restore the measured configuration, use JAX's manual FDO flow
+for the exact build and flags in use: collect five profiling runs, combine the
+profiles into one shared `.pb`, place that file at the same path on every
+worker, and add
+`--xla_gpu_pgle_profile_file_or_directory_path=<current-build-profile.pb>` to
+`XLA_FLAGS` for the replay run. Regenerate the profile after any code,
+dependency, shape, or XLA-flag change.
+
+The replayed profile matched 225 of 533 scheduled instructions, but match rate has
+been retired as a profile-quality signal. A separate ECHO-line manual profile
+measured 0.235 percentage points below AutoPGLE; that result does not remove the
+source profile from the provenance of the quoted number.
+
+Do not add `xla_gpu_enable_custom_fusions` or
+`xla_gpu_enable_address_computation_fusion`. Both killed the measured build
+before distributed initialization.
+
+## Multi-rack status
+
+No weak-scaling factor has been measured for this configuration. Do not
+extrapolate one from the one-rack result or reuse the historical approximately
+19% FSDP one-to-two-rack penalty.
+
+Two blockers prevent a multi-rack claim:
+
+1. Multi-rack placement requires the Fray gang-topology fix tracked in
+   [#7753](https://github.com/marin-community/marin/issues/7753). That fix is
+   not on this branch. Before the fix, a requested 16+16 placement silently
+   admitted 14+18 workers across two NVLink domains.
+2. The two-rack EP64 attempt stalled in an asynchronously dispatched device
+   collective that never completed. Both racks used uniform CUDA 13 NCCL and
+   the same `libnccl.so.2`. The public evidence is tracked in
+   [#7344](https://github.com/marin-community/marin/issues/7344). The evidence
+   excludes placement, host-side drop reporting, and a CUDA-major mismatch;
+   the stall remains unresolved.
+
+The collective-hang watchdog is armed for every GPU run by
+`resolve_training_env` with
+`--xla_gpu_nccl_termination_timeout_seconds=600`. It is diagnostic coverage,
+not recovery for the two-rack failure: the attempt remained wedged for 879
+seconds without a `TimeoutError`, `ncclCommAbort`, or NCCL output.
+
+The stalled attempt reported a 7.99% drop fraction at step 90. The one-rack
+1.44% result covers steps 250–349, so these values are not comparable. The
+step-90 value is also not evidence of two-rack fidelity.

--- a/experiments/grug/moe_hero_ep/__init__.py
+++ b/experiments/grug/moe_hero_ep/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/experiments/grug/moe_hero_ep/adamh.py
+++ b/experiments/grug/moe_hero_ep/adamh.py
@@ -1,0 +1,78 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Local copy of AdamH for iteration without modifying Levanter.
+# Adapted from levanter.optim.adamh.
+
+from typing import Any, NamedTuple
+
+import chex
+import jax
+import jax.numpy as jnp
+import optax
+from optax import tree_utils as otu
+
+
+class ScaleByAdamHState(NamedTuple):
+    count: chex.Array
+    mu: optax.Updates
+    nu: optax.Updates
+
+
+def scale_by_adamh(
+    b1: float = 0.9,
+    b2: float = 0.999,
+    eps: float = 1e-8,
+    learning_rate: float = 0.02,
+    mu_dtype: Any | None = None,
+) -> optax.GradientTransformation:
+    mu_dtype = jax.dtypes.canonicalize_dtype(mu_dtype)
+
+    def init_fn(params):
+        mu = otu.tree_zeros_like(params, dtype=mu_dtype)
+        nu = otu.tree_zeros_like(params)
+        return ScaleByAdamHState(count=jnp.zeros([], jnp.int32), mu=mu, nu=nu)
+
+    def update_fn(updates, state, params):
+        mu = otu.tree_update_moment(updates, state.mu, b1, 1)
+        nu = otu.tree_update_moment_per_elem_norm(updates, state.nu, b2, 2)
+        count_inc = optax.safe_increment(state.count)
+        mu_hat = otu.tree_bias_correction(mu, b1, count_inc)
+        nu_hat = otu.tree_bias_correction(nu, b2, count_inc)
+
+        adam_updates = jax.tree.map(
+            lambda m, v: None if m is None else m / (jnp.sqrt(v) + eps),
+            mu_hat,
+            nu_hat,
+            is_leaf=lambda x: x is None,
+        )
+        mu = otu.tree_cast(mu, mu_dtype)
+
+        def _scale_invariant_2d(p, u):
+            """Core update for a 2-D (matrix) parameter."""
+            p_norm = jnp.linalg.norm(p)
+            u_norm = jnp.linalg.norm(u)
+            new_p = p - learning_rate * u * p_norm / jnp.maximum(u_norm, 1e-10)
+            return new_p / jnp.linalg.norm(new_p) * p_norm - p
+
+        def scale_invariant_update(p, u):
+            if p is None:
+                return None
+            if p.ndim <= 2:
+                return _scale_invariant_2d(p, u)
+            # For higher-rank tensors, vmap the 2-D logic over the leading axis.
+            return jax.vmap(_scale_invariant_2d)(p, u)
+
+        adamh_updates = jax.tree_util.tree_map(
+            scale_invariant_update,
+            params,
+            adam_updates,
+            is_leaf=lambda x: x is None,
+        )
+
+        return adamh_updates, ScaleByAdamHState(count=count_inc, mu=mu, nu=nu)
+
+    return optax.GradientTransformation(init_fn, update_fn)
+
+
+__all__ = ["ScaleByAdamHState", "scale_by_adamh"]

--- a/experiments/grug/moe_hero_ep/launch.py
+++ b/experiments/grug/moe_hero_ep/launch.py
@@ -1,0 +1,179 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hardcoded one-rack d5120 EP64 launcher with 256 routed experts and top-8 routing."""
+
+import dataclasses
+import datetime
+import os
+
+import jmp
+from fray.cluster import ResourceConfig
+from levanter.callbacks.profiler import ProfilerConfig
+from levanter.callbacks.watch import WatchConfig
+from levanter.checkpoint import CheckpointerConfig
+from levanter.data.text.datasets import BlockShuffleConfig
+from levanter.grug.attention import RotaryConfig
+from levanter.tracker.json_logger import JsonLoggerConfig
+from levanter.trainer import TrainerConfig
+from marin.execution.build_context import resolve_version
+from marin.execution.lazy import ArtifactStep, StepContext
+from marin.experiment.cli import experiment_main
+from marin.experiment.data import mixture, tokenized
+from marin.experiment.namespacing import user_namespaced_name
+from marin.processing.tokenize.tokenize import TokenizedCache
+from marin.training.training import LevanterCheckpoint
+
+from experiments.grug.moe_hero_ep.model import GrugModelConfig
+from experiments.grug.moe_hero_ep.optimizer import GrugMoeMuonHConfig
+from experiments.grug.moe_hero_ep.train import GrugRunConfig, GrugTrainerConfig, run_grug
+from experiments.llama import llama3_tokenizer, llama3_tokenizer_vocab_size
+
+HERO_STEPS = 350
+HERO_BATCH_SIZE = 1024
+HERO_PROCESSES_PER_TASK = 1
+HERO_MIXED_PRECISION = "params=float32,compute=bfloat16,output=bfloat16"
+
+HERO_MODEL = GrugModelConfig(
+    vocab_size=llama3_tokenizer_vocab_size,
+    hidden_dim=5120,
+    intermediate_dim=1280,
+    shared_expert_intermediate_dim=5120,
+    num_shared_experts=1,
+    num_experts=256,
+    num_experts_per_token=8,
+    num_layers=48,
+    num_heads=40,
+    num_kv_heads=10,
+    head_dim=128,
+    max_seq_len=4096,
+    sliding_window=2048,
+    capacity_factor=1.0625,
+    layer_norm_eps=1e-5,
+    initializer_std=0.006987712429686843,
+    qk_mult=1.3,
+    router_z_loss_coef=0.0,
+    disable_pko=True,
+    disable_long_rope=True,
+    attention_implementation="gpu_fa4_cute",
+    moe_implementation="ragged_all_to_all",
+    expert_chunks=1,
+    report_capacity_overflow=True,
+    remat_mode="recompute_all",
+    rope=RotaryConfig(theta=10_000.0, scaling_factor=None),
+    use_array_stacked_blocks=True,
+)
+
+HERO_OPTIMIZER = GrugMoeMuonHConfig(
+    learning_rate=0.038956464533085024,
+    weight_decay=0.1,
+    min_lr_ratio=0.05,
+    warmup=0.01,
+    decay=None,
+    rewarmup=0.0,
+    cooldown=None,
+    cycle_length=None,
+    cycles=None,
+    lr_schedule="linear",
+    haps=None,
+    weight_decay_modules=None,
+    default_weight_decay_mask=None,
+    adam_lr=0.008989953353788853,
+    momentum=0.95,
+    nesterov=True,
+    backend_steps=5,
+    beta1=0.9062,
+    beta2=0.9684910757595268,
+    epsilon=1.810213843721233e-16,
+    muon_epsilon=1e-8,
+    max_grad_norm=None,
+    coefficient_type="quintic",
+)
+
+HERO_GRUG_TRAINER = GrugTrainerConfig(
+    data_seed=None,
+    log_every=1,
+    ema_beta=None,
+    z_loss_weight=1e-4,
+    offload_opt_state=False,
+    expert_axis_size=64,
+    replica_axis_size=1,
+    sharding_dump_path=None,
+)
+
+HERO_TRAIN_RESOURCES = ResourceConfig.with_gpu(
+    "GB200",
+    count=4,
+    cpu=32,
+    ram="256g",
+    disk="256g",
+    replicas=16,
+)
+
+_SLIMPAJAMA_TOKENIZE_RESOURCES = ResourceConfig(ram="64g", disk="64g")
+_SLIMPAJAMA_SHUFFLE = BlockShuffleConfig(io_block_size=256, window_blocks=256, perm_type="feistel")
+
+
+def _slimpajama_6b_dataset() -> ArtifactStep[TokenizedCache]:
+    return tokenized(
+        "slimpajama-6b",
+        source="DKYoon/SlimPajama-6B",
+        tokenizer=llama3_tokenizer,
+        resources=_SLIMPAJAMA_TOKENIZE_RESOURCES,
+        version="2026.06.28",
+    )
+
+
+def build_hero_checkpoint(*, version: str | None = None) -> ArtifactStep[LevanterCheckpoint]:
+    """Build the fixed one-rack EP64 throughput run."""
+    run_id = os.environ.get("RUN_ID") or datetime.datetime.now(datetime.UTC).strftime("hero-ep-%Y%m%d-%H%M%S")
+    name = f"experiments/grug-moe-hero-ep/d5120-L48-e256-{run_id}"
+    version = resolve_version(name, version)
+    slim = _slimpajama_6b_dataset()
+
+    def build_config(ctx: StepContext) -> GrugRunConfig:
+        trainer = TrainerConfig(
+            id=run_id,
+            seed=0,
+            train_batch_size=HERO_BATCH_SIZE,
+            num_train_steps=HERO_STEPS,
+            profiler=ProfilerConfig(enabled=False, start_step=8, num_steps=0),
+            mp=jmp.get_policy(HERO_MIXED_PRECISION),
+            tracker=JsonLoggerConfig(logger_name=f"{run_id}.metrics"),
+            watch=WatchConfig(interval=0),
+            use_explicit_mesh_axes=True,
+            require_accelerator=True,
+            allow_nondivisible_batch_size=False,
+            checkpointer=CheckpointerConfig(
+                base_path=f"{ctx.output_path}/checkpoints",
+                temporary_base_path=None,
+                save_interval=None,
+                keep=None,
+                append_run_id_to_base_path=False,
+                delete_old_temp_checkpoints=True,
+                keep_last_temporary_checkpoints=1,
+            ),
+        )
+        return GrugRunConfig(
+            model=HERO_MODEL,
+            data=mixture(ctx, {slim: 1.0}, shuffle=_SLIMPAJAMA_SHUFFLE),
+            resources=ctx.runtime_arg("train_resources"),
+            optimizer=HERO_OPTIMIZER,
+            trainer=dataclasses.replace(HERO_GRUG_TRAINER, trainer=trainer),
+            eval=None,
+            processes_per_task=HERO_PROCESSES_PER_TASK,
+        )
+
+    return ArtifactStep(
+        name=user_namespaced_name(name, version),
+        version=version,
+        artifact_type=LevanterCheckpoint,
+        run=run_grug,
+        build_config=build_config,
+        deps=(slim,),
+        runtime_args={"train_resources": HERO_TRAIN_RESOURCES},
+    )
+
+
+if __name__ == "__main__":
+    experiment_main(build_hero_checkpoint)()

--- a/experiments/grug/moe_hero_ep/launch.py
+++ b/experiments/grug/moe_hero_ep/launch.py
@@ -66,7 +66,6 @@ HERO_MODEL = GrugModelConfig(
 
 HERO_OPTIMIZER = GrugMoeMuonHConfig(
     learning_rate=0.038956464533085024,
-    weight_decay=0.1,
     min_lr_ratio=0.05,
     warmup=0.01,
     decay=None,
@@ -76,8 +75,6 @@ HERO_OPTIMIZER = GrugMoeMuonHConfig(
     cycles=None,
     lr_schedule="linear",
     haps=None,
-    weight_decay_modules=None,
-    default_weight_decay_mask=None,
     adam_lr=0.008989953353788853,
     momentum=0.95,
     nesterov=True,

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -1,0 +1,1074 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""MoE grug variant model.
+
+Architecture: QB-routed MoE with GatedNorm, XSA, sigmoid combine weights.
+No load-balancing loss; router z-loss only. All layers are MoE (no dense layers).
+"""
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.scipy as jsp
+from einops import rearrange
+from haliax import Axis
+from haliax.jax_utils import named_call
+from haliax.nn import ArrayStacked
+from jax import core, random
+from jax.sharding import NamedSharding, get_abstract_mesh, reshard
+from jax.sharding import PartitionSpec as P
+
+try:
+    from jax.shard_map import shard_map
+except ModuleNotFoundError:
+    from jax.experimental.shard_map import shard_map
+from jaxtyping import Array, Float, Int, PRNGKeyArray
+from levanter.compat.hf_checkpoints import HFCheckpointConverter
+from levanter.grug._moe.common import _zero_dropped_assignments
+from levanter.grug.attention import (
+    AttentionMask,
+    GrugAttentionImplementation,
+    RotaryConfig,
+    align_kv_heads,
+    apply_rotary_embedding,
+    attention,
+    fa4_cute_segment_bounds,
+)
+from levanter.grug.grug_moe import (
+    DEFAULT_EP_CAPACITY_FACTOR,
+    MOE_REMAT_SAVE_NAMES,
+    MoeActivation,
+    MoEExpertMlp,
+    MoeImplementation,
+    resolve_moe_implementation,
+)
+from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
+from levanter.grug.sharding import Pembed_vocab, Pfsdp, Plm_head_ep, unshard
+from levanter.tracker.histogram import Histogram, SummaryStats
+from levanter.utils.activation import ActivationFunctionEnum
+from transformers import PretrainedConfig as HfConfig
+
+_GATED_NORM_RANK = 128
+_ROUTING_RENORM_SUM = 2.5
+GRUG_MOE_MODEL_TYPE = "grug_moe"
+GRUG_MOE_ARCHITECTURE = "GrugMoeForCausalLM"
+GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY = "grugmoe_artifact_schema_version"
+GRUG_MOE_ARTIFACT_SCHEMA_VERSION = 1
+
+
+_BATCH_AXES: tuple[str, ...] = ("replica_dcn", "data", "expert")
+
+
+def _mesh_axis_size(mesh: jax.sharding.AbstractMesh | None, axis_name: str) -> int:
+    if mesh is None or mesh.empty:
+        raise ValueError("grug/moe requires a non-empty abstract mesh")
+    if axis_name not in mesh.shape:
+        # compact_grug_mesh standardizes on (replica_dcn, data, expert, model) with length-1
+        # axes kept, so any missing axis is a caller bug rather than a "size 1" shortcut.
+        raise ValueError(f"grug/moe requires an abstract mesh with axis '{axis_name}'")
+    return int(mesh.shape[axis_name])
+
+
+RematMode = Literal["recompute_all", "save_moe"]
+
+
+def _batch_spec() -> P:
+    return P(_BATCH_AXES)
+
+
+def _batch_reshard(x: jax.Array) -> jax.Array:
+    return reshard(x, _batch_spec())
+
+
+def _embedding_gather(token_embed: jax.Array, token_ids: Int[Array, "B S"]) -> Float[Array, "B S D"]:
+    """Replica-local embedding lookup.
+
+    The naive ``token_embed.at[token_ids].get(out_sharding=...)`` emits an all-to-all to lay the
+    gathered rows onto the batch-sharded token axis; because that axis spans ``replica_dcn`` it runs
+    cross-rack and its NCCL first-call rendezvous wedges at 8+ racks. Instead, run the gather under a
+    ``shard_map`` over the batch axes so each shard looks up its own tokens in its (fully replicated)
+    copy of the table -- a purely local op, no collective. Relies on ``Pembed_vocab`` replicating the
+    table across all devices; output hidden is replicated, matching the downstream FFN/attention.
+    """
+
+    def _local(te: jax.Array, ids: jax.Array) -> jax.Array:
+        return te[ids]
+
+    # Pin the (tiny int32) indices to the batch sharding so they match the shard_map in_spec.
+    token_ids = reshard(token_ids, P(_BATCH_AXES, None))
+    return shard_map(
+        _local,
+        mesh=get_abstract_mesh(),
+        in_specs=(P(None, None), P(_BATCH_AXES, None)),
+        out_specs=P(_BATCH_AXES, None, None),
+    )(token_embed, token_ids)
+
+
+def _partition_spec_of(x: jax.Array) -> P | None:
+    sharding = jax.typeof(x).sharding if isinstance(x, core.Tracer) else x.sharding
+    if isinstance(sharding, NamedSharding):
+        return sharding.spec
+    return None
+
+
+class GrugMoeHfConfig(HfConfig):
+    model_type = GRUG_MOE_MODEL_TYPE
+
+
+def _hf_config_attr(config: HfConfig, names: tuple[str, ...], default: Any = None) -> Any:
+    for name in names:
+        if hasattr(config, name):
+            return getattr(config, name)
+    return default
+
+
+@dataclass(frozen=True)
+class GrugModelConfig:
+    """Hyperparameters for the grug MoE transformer.
+
+    Architecture choices (GatedNorm, XSA, QB routing) are hardcoded.
+    Only shape/size knobs live here. All layers are MoE.
+    """
+
+    vocab_size: int
+    hidden_dim: int = 512
+    intermediate_dim: int = 256
+    shared_expert_intermediate_dim: int = 512
+    num_shared_experts: int = 1
+    num_experts: int = 256
+    num_experts_per_token: int = 4
+    num_layers: int = 6
+    num_heads: int = 4
+    num_kv_heads: int = 1
+    head_dim: int | None = None
+    max_seq_len: int = 8192
+    sliding_window: int = 2048
+    # Expert-parallel bucket capacity relative to the mean assignment load.
+    capacity_factor: float = DEFAULT_EP_CAPACITY_FACTOR
+    layer_norm_eps: float = 1e-5
+    initializer_std: float = 0.02
+    qk_mult: float = 1.3
+    router_z_loss_coef: float = 0.0
+    disable_pko: bool = True
+    """When True (default), the every-4th + last 'long' layers skip Partial
+    Key Offset (no shift of the second half of K, no doc-start zeroing). Short
+    layers never had PKO. Set to False to re-enable PKO on long layers."""
+    disable_long_rope: bool = True
+    """When True (default), the every-4th + last 'long' layers skip rotary
+    embedding entirely (Q and K go into attention un-rotated). Short layers
+    still apply half-RoPE. Set to False to keep RoPE on long layers."""
+    attention_implementation: GrugAttentionImplementation | None = None
+    moe_implementation: MoeImplementation | None = None
+    expert_chunks: int = 1
+    report_capacity_overflow: bool = False
+    remat_mode: RematMode = "recompute_all"
+    """Per-block gradient checkpointing. "recompute_all" reruns the whole block in
+    backward (lowest memory); "save_moe" keeps the tagged MoE dispatch tensors so
+    backward skips re-running expert dispatch and its EP collectives."""
+    rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
+    use_array_stacked_blocks: bool = False
+    """Stack all transformer blocks into one ``ArrayStacked[Block]`` and run them
+    through a homogeneous ``jax.lax.scan`` body. The unrolled production program
+    OOMs. This requires ``disable_pko=True`` because PKO reads a per-layer flag at
+    trace time, which the scan body cannot express."""
+
+    def __post_init__(self) -> None:
+        _ = self.inferred_head_dim
+        if self.num_heads % self.num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads for grouped-query attention")
+        if self.vocab_size <= 0:
+            raise ValueError("vocab_size must be positive")
+        if self.max_seq_len <= 0:
+            raise ValueError("max_seq_len must be positive")
+        if self.num_experts <= 0:
+            raise ValueError("num_experts must be positive")
+        if self.num_experts_per_token <= 0:
+            raise ValueError("num_experts_per_token must be positive")
+        if self.num_experts_per_token > self.num_experts:
+            raise ValueError("num_experts_per_token must be <= num_experts")
+        if self.shared_expert_intermediate_dim < 0:
+            raise ValueError("shared_expert_intermediate_dim must be non-negative")
+        if self.capacity_factor <= 0:
+            raise ValueError("capacity_factor must be positive")
+        if self.num_shared_experts <= 0:
+            raise ValueError("num_shared_experts must be positive")
+        if self.shared_expert_intermediate_dim % self.num_shared_experts != 0:
+            raise ValueError(
+                "shared_expert_intermediate_dim must be divisible by num_shared_experts; "
+                f"got {self.shared_expert_intermediate_dim} and {self.num_shared_experts}"
+            )
+        if self.expert_chunks <= 0:
+            raise ValueError("expert_chunks must be positive")
+        resolve_moe_implementation(self.moe_implementation)
+
+    @property
+    def Embed(self) -> Axis:
+        return Axis("embed", self.hidden_dim)
+
+    @property
+    def model_type(self) -> type["Transformer"]:
+        return Transformer
+
+    @property
+    def inferred_head_dim(self) -> int:
+        if self.head_dim is not None:
+            return self.head_dim
+        if self.hidden_dim % self.num_heads != 0:
+            raise ValueError(
+                f"hidden_dim={self.hidden_dim} is not divisible by num_heads={self.num_heads}; set head_dim explicitly"
+            )
+        return self.hidden_dim // self.num_heads
+
+    def build(self, Vocab: Axis, *, key: PRNGKeyArray) -> "Transformer":
+        cfg = self if Vocab.size == self.vocab_size else dataclasses.replace(self, vocab_size=Vocab.size)
+        return Transformer.init(cfg, key=key)
+
+    def hf_checkpoint_converter(
+        self,
+        ref_checkpoint: str | None = None,
+    ) -> HFCheckpointConverter["GrugModelConfig"]:  # type: ignore[type-var]
+        return HFCheckpointConverter(
+            self.__class__,
+            reference_checkpoint=ref_checkpoint,
+            HfConfigClass=GrugMoeHfConfig,
+            tokenizer=ref_checkpoint,
+        )
+
+    @classmethod
+    def from_hf_config(cls, hf_config: HfConfig) -> "GrugModelConfig":
+        rope = RotaryConfig(theta=float(_hf_config_attr(hf_config, ("rope_theta",), 10000.0)))
+        return cls(
+            vocab_size=int(_hf_config_attr(hf_config, ("vocab_size",))),
+            hidden_dim=int(_hf_config_attr(hf_config, ("hidden_dim", "hidden_size"), 2048)),
+            intermediate_dim=int(
+                _hf_config_attr(hf_config, ("intermediate_dim", "moe_intermediate_size", "intermediate_size"), 5632)
+            ),
+            shared_expert_intermediate_dim=int(
+                _hf_config_attr(
+                    hf_config,
+                    ("shared_expert_intermediate_dim", "shared_expert_intermediate_size"),
+                    5632,
+                )
+            ),
+            num_experts=int(_hf_config_attr(hf_config, ("num_experts", "num_local_experts"), 8)),
+            num_experts_per_token=int(_hf_config_attr(hf_config, ("num_experts_per_token", "num_experts_per_tok"), 2)),
+            num_layers=int(_hf_config_attr(hf_config, ("num_layers", "num_hidden_layers"), 24)),
+            num_heads=int(_hf_config_attr(hf_config, ("num_heads", "num_attention_heads"), 16)),
+            num_kv_heads=int(_hf_config_attr(hf_config, ("num_kv_heads", "num_key_value_heads"), 16)),
+            head_dim=_hf_config_attr(hf_config, ("head_dim", "attention_head_dim")),
+            max_seq_len=int(_hf_config_attr(hf_config, ("max_seq_len", "max_position_embeddings"), 4096)),
+            sliding_window=int(_hf_config_attr(hf_config, ("sliding_window",), 4096)),
+            layer_norm_eps=float(_hf_config_attr(hf_config, ("layer_norm_eps", "rms_norm_eps"), 1e-5)),
+            initializer_std=float(_hf_config_attr(hf_config, ("initializer_std", "initializer_range"), 0.02)),
+            qk_mult=float(_hf_config_attr(hf_config, ("qk_mult",), 1.0)),
+            rope=rope,
+        )
+
+    def to_hf_config(self, vocab_size: int, config_overrides: dict[str, Any] | None = None) -> GrugMoeHfConfig:
+        # One name per field: core fields take the universal transformers spelling, MoE fields the
+        # most common public spelling, and grug-specific extras keep their bare names. from_hf_config
+        # stays tolerant of the older spellings so existing artifacts keep loading.
+        config = {
+            "architectures": [GRUG_MOE_ARCHITECTURE],
+            "vocab_size": vocab_size,
+            # core — universal transformers names
+            "hidden_size": self.hidden_dim,
+            "num_hidden_layers": self.num_layers,
+            "num_attention_heads": self.num_heads,
+            "num_key_value_heads": self.num_kv_heads,
+            "head_dim": self.inferred_head_dim,
+            "max_position_embeddings": self.max_seq_len,
+            "sliding_window": self.sliding_window,
+            "rms_norm_eps": self.layer_norm_eps,
+            "initializer_range": self.initializer_std,
+            "rope_theta": self.rope.theta,
+            "tie_word_embeddings": False,
+            # MoE — most common public spelling per field
+            "num_experts": self.num_experts,
+            "num_experts_per_tok": self.num_experts_per_token,
+            "moe_intermediate_size": self.intermediate_dim,
+            "shared_expert_intermediate_size": self.shared_expert_intermediate_dim,
+            # grug-specific (no public equivalent)
+            "qk_mult": self.qk_mult,
+            "grugmoe_attention_mode": "production",
+            GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY: GRUG_MOE_ARTIFACT_SCHEMA_VERSION,
+        }
+        if config_overrides is not None:
+            config.update(config_overrides)
+        return GrugMoeHfConfig(**config)
+
+
+def rms_norm(x: jax.Array, eps: float = 1e-6) -> jax.Array:
+    """Non-parametric RMS norm over the last dimension."""
+    variance = jnp.mean(jnp.square(x.astype(jnp.float32)), axis=-1, keepdims=True)
+    return (x * jax.lax.rsqrt(variance + eps)).astype(x.dtype)
+
+
+class CausalSelfAttention(eqx.Module):
+    w_q: Float[Array, "D NH"]
+    w_k: Float[Array, "D MH"]
+    w_v: Float[Array, "D MH"]
+    w_o: Float[Array, "NH D"]
+    attn_gate: Float[Array, "D N"]
+    cfg: GrugModelConfig = eqx.field(static=True)
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "CausalSelfAttention":
+        k_q, k_k, k_v, k_o = random.split(key, 4)
+        d, n, m, h = cfg.hidden_dim, cfg.num_heads, cfg.num_kv_heads, cfg.inferred_head_dim
+        return CausalSelfAttention(
+            w_q=reshard(_init_weight(k_q, (d, n * h), cfg.initializer_std), P(Pfsdp, "model")),
+            w_k=reshard(_init_weight(k_k, (d, m * h), cfg.initializer_std), P(Pfsdp, "model")),
+            w_v=reshard(_init_weight(k_v, (d, m * h), cfg.initializer_std), P(Pfsdp, "model")),
+            w_o=reshard(_init_weight(k_o, (n * h, d), cfg.initializer_std), P("model", Pfsdp)),
+            attn_gate=reshard(jnp.zeros((d, n)), P(None, None)),
+            cfg=cfg,
+        )
+
+    @named_call
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+        mask: AttentionMask | jax.Array,
+        use_pko: bool = False,
+        disable_rope: bool | jax.Array = False,
+    ) -> Float[Array, "B S D"]:
+        head_dim = self.cfg.inferred_head_dim
+        seq_len = x.shape[1]
+        batch_spec = _batch_spec()
+
+        q = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_q), "... (n d) -> ... n d", d=head_dim)
+        k = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_k), "... (m d) -> ... m d", d=head_dim)
+        v = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_v), "... (m d) -> ... m d", d=head_dim)
+
+        # Shift the second half of K's head_dim back by one position so the
+        # query at position i sees K[i] on head_dim[:half] but K[i-1] on
+        # head_dim[half:]. Zero the shifted half at document starts so the
+        # cross-half look-back does not leak across docs. Runs before the
+        # rms_norm on Q/K below.
+        if use_pko:
+            half = head_dim // 2
+            k_stationary = k[..., half:]
+            k_shifted = jnp.concatenate([k_stationary[:, :1, :, :], k_stationary[:, :-1, :, :]], axis=1)
+            segment_ids = mask.segment_ids if isinstance(mask, AttentionMask) else None
+            if segment_ids is None:
+                # No segment info (raw-mask or unsegmented eval path): only position 0 is a doc start.
+                is_doc_start_seq = jnp.zeros((seq_len,), dtype=bool).at[0].set(True)
+                is_doc_start = jnp.broadcast_to(is_doc_start_seq, k_shifted.shape[:2])
+            else:
+                q_seg = segment_ids[0]
+                if q_seg.ndim == 1:
+                    is_doc_start_seq = jnp.concatenate([jnp.ones((1,), dtype=bool), q_seg[1:] != q_seg[:-1]])
+                    is_doc_start = jnp.broadcast_to(is_doc_start_seq, k_shifted.shape[:2])
+                else:
+                    is_doc_start = jnp.concatenate(
+                        [jnp.ones_like(q_seg[:, :1], dtype=bool), q_seg[:, 1:] != q_seg[:, :-1]],
+                        axis=1,
+                    )
+            k_shifted = jnp.where(is_doc_start[..., None, None], jnp.zeros_like(k_shifted), k_shifted)
+            k = jnp.concatenate([k[..., :half], k_shifted], axis=-1)
+
+        q = rms_norm(q)
+        k = rms_norm(k)
+
+        # Half-RoPE: apply rotary embedding only to first half of Q/K head_dim
+        # (second half is rope-free on every layer). ``disable_rope`` skips
+        # the RoPE step entirely on this layer — used to opt long layers out
+        # of rotary embedding when ``cfg.disable_long_rope`` is set. It may be a
+        # traced scalar bool (per-layer choice inside the layer scan): then RoPE
+        # is always computed and selected with ``jnp.where`` so the scan body has
+        # no ``lax.cond`` (which would pin the FA4 metadata to device 0).
+        def _rope(qh: jax.Array, kh: jax.Array) -> tuple[jax.Array, jax.Array]:
+            half = head_dim // 2
+            q_rot, k_rot = apply_rotary_embedding(
+                qh[..., :half], kh[..., :half], seq_len=seq_len, head_dim=half, rope=self.cfg.rope
+            )
+            return (
+                jnp.concatenate([q_rot, qh[..., half:]], axis=-1),
+                jnp.concatenate([k_rot, kh[..., half:]], axis=-1),
+            )
+
+        if isinstance(disable_rope, bool):
+            if not disable_rope:
+                q, k = _rope(q, k)
+        else:
+            q_roped, k_roped = _rope(q, k)
+            keep = ~jnp.asarray(disable_rope, dtype=jnp.bool_)
+            q = jnp.where(keep, q_roped, q)
+            k = jnp.where(keep, k_roped, k)
+        q = q * self.cfg.qk_mult
+        attn_out = attention(q, k, v, mask, implementation=self.cfg.attention_implementation)
+        aligned_v = align_kv_heads(v, num_q_heads=attn_out.shape[2])
+        # GPU XSA with GQA can give attn_out a backend-specific head sharding;
+        # match v to that dynamic sharding before the per-head projection math.
+        aligned_v = reshard(aligned_v, _partition_spec_of(attn_out) or P(_BATCH_AXES, None, None, "model"))
+        # Exclusive Self Attention: subtract the component of yᵢ parallel to vᵢ.
+        # zᵢ = yᵢ - (yᵢᵀvᵢ / ‖vᵢ‖²) vᵢ, per head.
+        dot = jnp.sum(attn_out * aligned_v, axis=-1, keepdims=True)
+        v_norm_sq = jnp.sum(aligned_v * aligned_v, axis=-1, keepdims=True)
+        attn_out = attn_out - (dot / (v_norm_sq + 1e-6)) * aligned_v
+        # Headwise gating: sigmoid(x @ attn_gate) produces one scalar per head.
+        gate = 2 * jax.nn.sigmoid(jnp.einsum("bsd,dn->bsn", x, self.attn_gate))[..., None]
+        attn_out = gate * attn_out
+        # Merge heads into hidden dim while keeping model-axis sharding for w_o.
+        attn_out = jnp.reshape(
+            attn_out,
+            (*attn_out.shape[:-2], attn_out.shape[-2] * attn_out.shape[-1]),
+            out_sharding=P(_BATCH_AXES, None, "model"),
+        )
+        return jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=batch_spec)
+
+
+class RMSNorm(eqx.Module):
+    weight: jax.Array
+    eps: float = eqx.field(static=True)
+
+    @staticmethod
+    def init(dim: int, eps: float) -> "RMSNorm":
+        return RMSNorm(weight=jnp.ones((dim,), dtype=jnp.float32), eps=eps)
+
+    @named_call
+    def __call__(self, x: Float[Array, "... D"]) -> Float[Array, "... D"]:
+        weight = unshard(self.weight)
+        dtype = x.dtype
+        x = x.astype(jnp.float32)
+        variance = jnp.mean(jnp.square(x), axis=-1, keepdims=True)
+        normed = x * jax.lax.rsqrt(variance + self.eps)
+        return (normed * weight).astype(dtype)
+
+
+class GatedNorm(eqx.Module):
+    """Learnable per-dimension gating. Compensates for AdamH's bounded activation norms.
+    See https://arxiv.org/abs/2601.22966v1"""
+
+    w_down: jax.Array
+    w_up: jax.Array
+
+    @staticmethod
+    def init(hidden_dim: int, initializer_std: float, *, key: PRNGKeyArray) -> "GatedNorm":
+        k_down, k_up = random.split(key)
+        return GatedNorm(
+            w_down=reshard(_init_weight(k_down, (hidden_dim, _GATED_NORM_RANK), initializer_std), P(None, None)),
+            w_up=reshard(_init_weight(k_up, (_GATED_NORM_RANK, hidden_dim), initializer_std), P(None, None)),
+        )
+
+    @named_call
+    def __call__(self, x: Float[Array, "... D"]) -> Float[Array, "... D"]:
+        gate_hidden = jnp.einsum("...d,dr->...r", x, self.w_down)
+        # TODO: silu activation here isn't explored, just cargo-culted from Qwen. Likely low-hanging ablation fruit
+        # (e.g. compare no activation, relu, etc.).
+        gate_hidden = jax.nn.silu(gate_hidden)
+        gate = jax.nn.sigmoid(jnp.einsum("...r,rd->...d", gate_hidden, self.w_up))
+        return x * gate.astype(x.dtype)
+
+
+class DenseMLP(eqx.Module):
+    w_gate: jax.Array
+    w_up: jax.Array
+    w_down: jax.Array
+
+    @staticmethod
+    def init(hidden_dim: int, intermediate_dim: int, initializer_std: float, *, key: PRNGKeyArray) -> "DenseMLP":
+        k_gate, k_up, k_down = random.split(key, 3)
+        return DenseMLP(
+            w_gate=reshard(_init_weight(k_gate, (hidden_dim, intermediate_dim), initializer_std), P(Pfsdp, "model")),
+            w_up=reshard(_init_weight(k_up, (hidden_dim, intermediate_dim), initializer_std), P(Pfsdp, "model")),
+            w_down=reshard(_init_weight(k_down, (intermediate_dim, hidden_dim), initializer_std), P("model", Pfsdp)),
+        )
+
+    @named_call
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+        *,
+        activation: MoeActivation = ActivationFunctionEnum.silu,
+    ) -> Float[Array, "B S D"]:
+        if isinstance(activation, ActivationFunctionEnum):
+            activation_fn = activation.to_jax_fn()
+        else:
+            activation_fn = activation
+
+        b, s, _ = x.shape
+        x_flat = rearrange(x, "b s d -> (b s) d")
+        gate = jnp.einsum("td,dm->tm", x_flat, self.w_gate)
+        up = jnp.einsum("td,dm->tm", x_flat, self.w_up)
+        out_flat = jnp.einsum("tm,md->td", activation_fn(gate) * up, self.w_down, out_sharding=_batch_spec())
+        # Reshard after the reshape so the shared-expert output carries the same
+        # canonical batch sharding as the routed MoE output (MoEMLP reshards its
+        # routed result identically). Splitting the fused
+        # ("replica_dcn", "data", "expert") token axis back into (b, s) otherwise
+        # leaks the `expert` mesh axis onto the seq dim, so the shared+routed
+        # residual add fails with a ShardingTypeError on a multi-node mesh.
+        return _batch_reshard(rearrange(out_flat, "(b s) d -> b s d", b=b, s=s))
+
+
+def _routing_stats(
+    selected_experts: Int[Array, "T K"],
+    router_probs: Float[Array, "T E"],
+    router_logits: Float[Array, "T E"],
+    *,
+    num_experts: int,
+    num_experts_per_token: int,
+) -> dict[str, jax.Array]:
+    router_probs_f = router_probs.astype(jnp.float32)
+    router_logits_f = router_logits.astype(jnp.float32)
+    expert_counts = jnp.sum(jax.nn.one_hot(selected_experts, num_experts, dtype=jnp.float32), axis=(0, 1))
+    total_assignments = jnp.maximum(jnp.sum(expert_counts), 1.0)
+    assignment_fraction = expert_counts / total_assignments
+    routing_entropy = -jnp.sum(assignment_fraction * jnp.log(assignment_fraction + 1e-6))
+    token_fraction = assignment_fraction * num_experts_per_token
+    p = jnp.mean(router_probs_f, axis=0)
+    load_balancing_loss = num_experts * jnp.sum(token_fraction * p)
+    z = jsp.special.logsumexp(router_logits_f, axis=-1)
+    router_z_loss = jnp.mean(z**2)
+
+    return {
+        "routing_counts": expert_counts,
+        "routing_entropy": routing_entropy,
+        "load_balancing_loss": load_balancing_loss,
+        "router_z_loss": router_z_loss,
+    }
+
+
+def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str, jax.Array | SummaryStats]:
+    routing_entropy = router_metrics["routing_entropy_per_layer"]
+    routing_counts = router_metrics["routing_counts_per_layer"]
+    load_balancing_loss = router_metrics["load_balancing_loss_per_layer"]
+    router_z_loss = router_metrics["router_z_loss_per_layer"]
+    capacity_overflow = router_metrics["capacity_overflow_per_layer"]
+    num_layers = int(routing_entropy.shape[0])
+
+    # Per-layer total assignments = sum of routing_counts over experts (= tokens * k).
+    assignments_per_layer = jnp.sum(routing_counts.astype(jnp.float32), axis=-1)
+    capacity_overflow_rate = capacity_overflow.astype(jnp.float32) / jnp.maximum(assignments_per_layer, 1.0)
+
+    out: dict[str, jax.Array | SummaryStats] = {
+        "train/router/routing_entropy_mean": jnp.mean(routing_entropy),
+        "train/router/load_balancing_loss": jnp.mean(load_balancing_loss),
+        "train/router/router_z_loss": jnp.mean(router_z_loss),
+        "train/router/routing_counts_per_layer": routing_counts,
+        "train/router/capacity_overflow_rate_mean": jnp.mean(capacity_overflow_rate),
+        "qb_beta_per_layer": router_metrics.get("qb_beta_per_layer"),
+    }
+    for i in range(num_layers):
+        out[f"train/router/layer_{i}/routing_entropy"] = routing_entropy[i]
+        out[f"train/router/layer_{i}/load_balancing_loss"] = load_balancing_loss[i]
+        out[f"train/router/layer_{i}/router_z_loss"] = router_z_loss[i]
+        out[f"train/router/layer_{i}/routing_hist"] = _histogram_from_expert_counts(routing_counts[i])
+        out[f"train/router/layer_{i}/capacity_overflow_rate"] = capacity_overflow_rate[i]
+    return out
+
+
+def _histogram_from_expert_counts(expert_counts: jax.Array) -> SummaryStats:
+    counts = jnp.asarray(expert_counts, dtype=jnp.float32)
+    num_experts = counts.shape[0]
+    expert_ids = jnp.arange(num_experts, dtype=jnp.float32)
+    num = jnp.sum(counts)
+    sum_values = jnp.sum(counts * expert_ids)
+    sum_squares = jnp.sum(counts * expert_ids * expert_ids)
+    nonzero = counts > 0
+    min_value = jnp.where(nonzero, expert_ids, jnp.inf).min()
+    max_value = jnp.where(nonzero, expert_ids, -jnp.inf).max()
+    min_value = jnp.where(num > 0, min_value, 0.0)
+    max_value = jnp.where(num > 0, max_value, 0.0)
+    bucket_limits = jnp.arange(num_experts + 1, dtype=jnp.float32)
+    histogram = Histogram(bucket_limits=bucket_limits, bucket_counts=counts)
+    return SummaryStats.from_reduced_values(
+        min=min_value,
+        max=max_value,
+        num=num,
+        nonzero_count=jnp.sum(nonzero),
+        sum=sum_values,
+        sum_squares=sum_squares,
+        histogram=histogram,
+    )
+
+
+class MoEMLP(eqx.Module):
+    """QB-routed MoE with sigmoid combine weights."""
+
+    router: jax.Array
+    router_bias: jax.Array
+    expert_mlp: MoEExpertMlp
+    cfg: GrugModelConfig = eqx.field(static=True)
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "MoEMLP":
+        k_router, k_expert = random.split(key, 2)
+        mesh = get_abstract_mesh()
+
+        expert_axis_size = _mesh_axis_size(mesh, "expert")
+        if cfg.num_experts % expert_axis_size != 0:
+            raise ValueError(f"num_experts={cfg.num_experts} must be divisible by expert axis size={expert_axis_size}")
+
+        d, e = cfg.hidden_dim, cfg.num_experts
+        return MoEMLP(
+            router=reshard(_init_weight(k_router, (d, e), cfg.initializer_std), P(None, None)),
+            router_bias=jnp.zeros((e,)),
+            expert_mlp=MoEExpertMlp.init(
+                num_experts=cfg.num_experts,
+                hidden_dim=cfg.hidden_dim,
+                intermediate_dim=cfg.intermediate_dim,
+                initializer_std=cfg.initializer_std,
+                key=k_expert,
+                implementation=cfg.moe_implementation,
+                activation=ActivationFunctionEnum.silu,
+                capacity_factor=cfg.capacity_factor,
+                expert_chunks=cfg.expert_chunks,
+            ),
+            cfg=cfg,
+        )
+
+    @named_call
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+    ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+        b, s, _ = x.shape
+        x_flat = rearrange(x, "b s d -> (b s) d")
+        # Keep the router path in fp32 before top-k, softmax, and QB statistics.
+        router_logits = jnp.einsum("td,de->te", x_flat, reshard(self.router, P(None, None))).astype(jnp.float32)
+        biased_logits = router_logits + jax.lax.stop_gradient(self.router_bias)
+        router_probs = jax.nn.softmax(router_logits, axis=-1)
+        # Select top-(K+1) on biased logits; the (K+1)-th is the QB threshold alpha.
+        _topk_logits, selected_experts = jax.lax.top_k(biased_logits, self.cfg.num_experts_per_token + 1)
+        qb_alpha = _topk_logits[:, -1:]
+        selected_experts = selected_experts[:, :-1]
+        # Sigmoid combine weights on unbiased logits for selected experts.
+        unbiased_topk = jnp.take_along_axis(router_logits, selected_experts, axis=-1)
+        combine_weights_f = jax.nn.sigmoid(unbiased_topk)
+        # Renormalize K combine weights to sum to ``_ROUTING_RENORM_SUM`` (baked in).
+        denom = jnp.sum(combine_weights_f, axis=-1, keepdims=True)
+        combine_weights_f = combine_weights_f * (_ROUTING_RENORM_SUM / (denom + 1e-9))
+        combine_weights = combine_weights_f.astype(x.dtype)
+        router_stats = _routing_stats(
+            selected_experts,
+            router_probs,
+            router_logits,
+            num_experts=self.cfg.num_experts,
+            num_experts_per_token=self.cfg.num_experts_per_token,
+        )
+        # Sharded QB: compute beta locally per device, then average.
+        mesh = get_abstract_mesh()
+        s_minus_alpha = reshard(router_logits - qb_alpha, P(_BATCH_AXES, None))
+        num_devices = 1
+        for a in _BATCH_AXES:
+            num_devices *= mesh.shape[a]
+        local_tokens = s_minus_alpha.shape[0] // num_devices
+        qb_count = max(1, local_tokens * self.cfg.num_experts_per_token // self.cfg.num_experts)
+
+        def _local_qb_beta(s_ma):
+            topk_vals, _ = jax.lax.top_k(s_ma.T, qb_count)
+            beta = topk_vals[:, -1]
+            return jax.lax.pmean(beta, axis_name=_BATCH_AXES)
+
+        router_stats["qb_beta"] = shard_map(
+            _local_qb_beta,
+            mesh=mesh,
+            in_specs=(P(_BATCH_AXES, None),),
+            out_specs=P(),
+        )(s_minus_alpha)
+
+        moe_out = self.expert_mlp(
+            x_flat,
+            selected_experts.astype(jnp.int32),
+            combine_weights,
+            mesh=get_abstract_mesh(),
+            report_capacity_overflow=self.cfg.report_capacity_overflow,
+        )
+        if self.cfg.report_capacity_overflow:
+            routed_flat, dropped_assignments = moe_out
+        else:
+            routed_flat = moe_out
+            dropped_assignments = _zero_dropped_assignments()
+        router_stats["capacity_overflow"] = dropped_assignments
+
+        routed = rearrange(routed_flat, "(b s) d -> b s d", b=b, s=s)
+        routed = reshard(routed, _batch_spec())
+        return routed, router_stats
+
+
+class Block(eqx.Module):
+    rms_attn: RMSNorm
+    attn_gated_norm: GatedNorm
+    attn: CausalSelfAttention
+    rms_mlp: RMSNorm
+    mlp_gated_norm: GatedNorm
+    mlp: MoEMLP
+    shared: tuple[DenseMLP, ...] | None
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "Block":
+        attn_key, mlp_key, shared_key, gn_attn_key, gn_mlp_key = random.split(key, 5)
+        shared = None
+        if cfg.shared_expert_intermediate_dim > 0:
+            per_expert_dim = cfg.shared_expert_intermediate_dim // cfg.num_shared_experts
+            shared_keys = (
+                (shared_key,) if cfg.num_shared_experts == 1 else tuple(random.split(shared_key, cfg.num_shared_experts))
+            )
+            shared = tuple(
+                DenseMLP.init(cfg.hidden_dim, per_expert_dim, cfg.initializer_std, key=key) for key in shared_keys
+            )
+        return Block(
+            rms_attn=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            attn_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=gn_attn_key),
+            attn=CausalSelfAttention.init(cfg, key=attn_key),
+            rms_mlp=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            mlp_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=gn_mlp_key),
+            mlp=MoEMLP.init(cfg, key=mlp_key),
+            shared=shared,
+        )
+
+    @named_call
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+        mask: AttentionMask | jax.Array,
+        use_pko: bool = False,
+        disable_rope: bool | jax.Array = False,
+    ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+        attn_in = self.attn_gated_norm(self.rms_attn(x))
+        x = x + self.attn(attn_in, mask, use_pko=use_pko, disable_rope=disable_rope)
+        mlp_in = self.mlp_gated_norm(self.rms_mlp(x))
+        mlp_out, router_stats = self.mlp(mlp_in)
+        if self.shared is not None:
+            for shared_expert in self.shared:
+                mlp_out = mlp_out + shared_expert(mlp_in, activation=ActivationFunctionEnum.silu)
+        x = x + mlp_out
+        return x, router_stats
+
+
+def _long_layer_schedule(num_layers: int) -> jax.Array:
+    layer_indices = jnp.arange(num_layers)
+    return ((layer_indices % 4) == 3) | (layer_indices == num_layers - 1)
+
+
+class Transformer(eqx.Module):
+    token_embed: jax.Array
+    embed_norm: RMSNorm
+    embed_gated_norm: GatedNorm
+    output_proj: jax.Array
+    blocks: tuple[Block, ...] | None
+    stacked_blocks: ArrayStacked[Block] | None
+    final_norm: RMSNorm
+    final_gated_norm: GatedNorm
+    config: GrugModelConfig = eqx.field(static=True)
+
+    @staticmethod
+    def init(
+        cfg_or_vocab: GrugModelConfig | Axis,
+        config: GrugModelConfig | None = None,
+        *,
+        key: PRNGKeyArray,
+    ) -> "Transformer":
+        if isinstance(cfg_or_vocab, Axis):
+            if config is None:
+                raise ValueError("config must be provided when initializing with a Vocab axis")
+            cfg = (
+                config
+                if cfg_or_vocab.size == config.vocab_size
+                else dataclasses.replace(config, vocab_size=cfg_or_vocab.size)
+            )
+        else:
+            if config is not None:
+                raise ValueError("config must not be provided when initializing directly from GrugModelConfig")
+            cfg = cfg_or_vocab
+
+        if cfg.use_array_stacked_blocks and not cfg.disable_pko:
+            raise ValueError(
+                "use_array_stacked_blocks=True requires disable_pko=True because "
+                "the attention path reads use_pko at trace time"
+            )
+
+        embed_key, out_key, embed_gn_key, final_gn_key, *block_keys = random.split(key, cfg.num_layers + 4)
+        token_embed = reshard(
+            _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), cfg.initializer_std), Pembed_vocab
+        )
+        output_proj = reshard(_init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head_ep)
+        blocks: tuple[Block, ...] | None
+        stacked_blocks: ArrayStacked[Block] | None
+        if cfg.use_array_stacked_blocks:
+            blocks = None
+            stacked_blocks = ArrayStacked.init(cfg.num_layers, Block)(cfg, key=jnp.stack(block_keys))
+        else:
+            blocks = tuple(Block.init(cfg, key=block_key) for block_key in block_keys)
+            stacked_blocks = None
+        return Transformer(
+            token_embed=token_embed,
+            embed_norm=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            embed_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=embed_gn_key),
+            output_proj=output_proj,
+            blocks=blocks,
+            stacked_blocks=stacked_blocks,
+            final_norm=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            final_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=final_gn_key),
+            config=cfg,
+        )
+
+    @property
+    def Vocab(self) -> Axis:
+        return Axis("vocab", self.config.vocab_size)
+
+    @named_call
+    def __call__(
+        self,
+        token_ids: Int[Array, "B S"],
+        mask: AttentionMask | jax.Array | None = None,
+    ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+        if mask is None:
+            mask = AttentionMask.causal()
+
+        cfg = self.config
+        hidden = _embedding_gather(self.token_embed, token_ids)
+        hidden = self.embed_gated_norm(self.embed_norm(hidden))
+
+        # Short layers: sliding window. Long layers (every 4th + last): full causal.
+        segment_ids = mask.segment_ids if isinstance(mask, AttentionMask) else None
+        if segment_ids is not None:
+            # Pin the per-token [B, S] segment ids batch-sharded before they enter the layer-scan
+            # lax.cond. Otherwise they reach the cond as {maximal device=0} and the compiler falls
+            # back to an involuntary full-remat scatter to [num_devices, 1], which serializes through
+            # device 0 and can wedge the MoE all-to-all (collective rendezvous timeout at scale).
+            segment_ids = _batch_reshard(segment_ids)
+        short_mask = AttentionMask(is_causal=True, sliding_window=cfg.sliding_window, segment_ids=segment_ids)
+        long_mask = AttentionMask(is_causal=True, sliding_window=None, segment_ids=segment_ids)
+
+        if cfg.remat_mode == "save_moe":
+            remat_policy = jax.checkpoint_policies.save_only_these_names(*MOE_REMAT_SAVE_NAMES)
+        else:
+            remat_policy = None
+
+        if self.blocks is not None:
+            num_blocks = len(self.blocks)
+            moe_router_stats: list[dict[str, jax.Array]] = []
+            for i, block in enumerate(self.blocks):
+                is_last = i == num_blocks - 1
+                is_long = i % 4 == 3 or is_last
+                layer_mask = long_mask if is_long else short_mask
+                use_pko = is_long and not cfg.disable_pko
+                disable_rope = is_long and cfg.disable_long_rope
+                hidden, router_stats = eqx.filter_checkpoint(block, policy=remat_policy)(
+                    hidden, layer_mask, use_pko, disable_rope
+                )
+                moe_router_stats.append(router_stats)
+
+            router_metrics = {
+                "routing_entropy_per_layer": jnp.stack([s["routing_entropy"] for s in moe_router_stats], axis=0),
+                "routing_counts_per_layer": jnp.stack([s["routing_counts"] for s in moe_router_stats], axis=0),
+                "load_balancing_loss_per_layer": jnp.stack([s["load_balancing_loss"] for s in moe_router_stats], axis=0),
+                "router_z_loss_per_layer": jnp.stack([s["router_z_loss"] for s in moe_router_stats], axis=0),
+                "qb_beta_per_layer": jnp.stack([s["qb_beta"] for s in moe_router_stats], axis=0),
+                "capacity_overflow_per_layer": jnp.stack([s["capacity_overflow"] for s in moe_router_stats], axis=0),
+            }
+        else:
+            assert self.stacked_blocks is not None
+            # Homogeneous scan: one compiled Block body over the stacked layers. The per-layer
+            # short/long choice rides in as a Bool[num_layers] scan input. PKO is never used here
+            # (scan requires disable_pko=True).
+            mask_schedule = _long_layer_schedule(cfg.num_layers)
+            # Precompute the FA4 per-token metadata for both the full-causal (long) and
+            # sliding-window (short) layers outside the scan, then select per layer with a
+            # jnp.where inside the body. This keeps the metadata inputs to the FA4 kernel out of a
+            # lax.cond whose output is pinned to {maximal device=0}, avoiding an involuntary full
+            # rematerialization through device 0. ``valid`` is window-independent, so it is shared;
+            # ``disable_rope`` rides in as a traced per-layer scalar.
+            batch_size, seq_len = hidden.shape[0], hidden.shape[1]
+            long_lower_bounds, valid = fa4_cute_segment_bounds(
+                long_mask, batch_size=batch_size, seq_len=seq_len, sliding_window=None
+            )
+            short_lower_bounds, _ = fa4_cute_segment_bounds(
+                short_mask, batch_size=batch_size, seq_len=seq_len, sliding_window=cfg.sliding_window
+            )
+            long_lower_bounds = _batch_reshard(long_lower_bounds)
+            short_lower_bounds = _batch_reshard(short_lower_bounds)
+            valid = _batch_reshard(valid)
+
+            def _scan_layers(
+                carry_hidden: Float[Array, "B S D"],
+                scan_inputs: tuple[Block, jax.Array],
+            ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+                layer, layer_use_long_mask = scan_inputs
+                use_long = jnp.asarray(layer_use_long_mask, dtype=jnp.bool_)
+                lower_bounds = jnp.where(use_long, long_lower_bounds, short_lower_bounds)
+                layer_mask = long_mask.with_fa4_bounds(lower_bounds, valid)
+                disable_rope = use_long if cfg.disable_long_rope else False
+                return eqx.filter_checkpoint(layer, policy=remat_policy)(carry_hidden, layer_mask, False, disable_rope)
+
+            hidden, stacked_router_stats = jax.lax.scan(
+                _scan_layers, hidden, xs=(self.stacked_blocks.stacked, mask_schedule)
+            )
+            router_metrics = {
+                "routing_entropy_per_layer": stacked_router_stats["routing_entropy"],
+                "routing_counts_per_layer": stacked_router_stats["routing_counts"],
+                "load_balancing_loss_per_layer": stacked_router_stats["load_balancing_loss"],
+                "router_z_loss_per_layer": stacked_router_stats["router_z_loss"],
+                "qb_beta_per_layer": stacked_router_stats["qb_beta"],
+                "capacity_overflow_per_layer": stacked_router_stats["capacity_overflow"],
+            }
+        hidden = self.final_gated_norm(self.final_norm(hidden))
+        return hidden, router_metrics
+
+    @named_call
+    def logits(
+        self,
+        token_ids: Int[Array, "B S"],
+        mask: AttentionMask | jax.Array | None = None,
+    ) -> Float[Array, "B S V"]:
+        batch_spec = _batch_spec()
+        hidden, _ = self(token_ids, mask=mask)
+        return jnp.einsum("bsh,hd->bsd", hidden, self.output_proj, out_sharding=batch_spec)
+
+    def to_state_dict(self, prefix: str | None = None) -> dict[str, jax.Array]:
+        return grugmoe_inference_state_dict(self, prefix=prefix)
+
+    def next_token_loss(
+        self,
+        token_ids: Int[Array, "B S"],
+        loss_weight: Float[Array, "B S"],
+        *,
+        mask: AttentionMask | jax.Array | None = None,
+        reduction: str = "mean",
+        logsumexp_weight: float | None = None,
+        loss_dtype: jnp.dtype = jnp.float32,
+        return_router_metrics: bool = False,
+    ) -> jax.Array | tuple[jax.Array, dict[str, jax.Array | SummaryStats]]:
+        hidden, router_metrics = self(token_ids, mask=mask)
+        labels = jnp.pad(token_ids[:, 1:], ((0, 0), (0, 1))).astype(jnp.int32)
+        loss_weight = loss_weight.astype(loss_dtype)
+
+        cross_entropy_loss = fused_linear_softmax_cross_entropy_loss(
+            hidden,
+            self.output_proj,
+            labels,
+            weight=loss_weight,
+            reduction=reduction,
+            logsumexp_weight=logsumexp_weight,
+            dtype=loss_dtype,
+        )
+        # No load-balancing loss; router z-loss only.
+        num_moe_layers = router_metrics["router_z_loss_per_layer"].shape[0]
+        rzl = jnp.sum(router_metrics["router_z_loss_per_layer"]) / num_moe_layers
+        aux_loss = self.config.router_z_loss_coef * rzl
+        loss = cross_entropy_loss + aux_loss if reduction != "none" else cross_entropy_loss
+        if return_router_metrics:
+            summarized_metrics = _summarize_router_metrics(router_metrics)
+            summarized_metrics["train/cross_entropy_loss"] = cross_entropy_loss
+            summarized_metrics["train/router/aux_loss_weighted"] = aux_loss
+            if self.config.report_capacity_overflow:
+                summarized_metrics["moe/dropped_assignments"] = jnp.sum(router_metrics["capacity_overflow_per_layer"])
+            return loss, summarized_metrics
+        return loss
+
+
+def _init_weight(key: PRNGKeyArray, shape: tuple[int, ...], std: float) -> Float[Array, "..."]:
+    return std * random.truncated_normal(key, -3, 3, shape)
+
+
+def debug_mesh_and_token_pspec(num_devices: int) -> tuple[jax.sharding.AbstractMesh, P]:
+    """Return a small abstract mesh and token sharding for lowering contract tests."""
+    if num_devices <= 0:
+        raise ValueError(f"num_devices must be positive, got {num_devices}")
+    expert = 2 if num_devices % 2 == 0 else 1
+    data = max(1, num_devices // expert)
+    mesh = jax.sharding.AbstractMesh(
+        axis_sizes=(1, data, expert, 1),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(
+            jax.sharding.AxisType.Explicit,
+            jax.sharding.AxisType.Explicit,
+            jax.sharding.AxisType.Explicit,
+            jax.sharding.AxisType.Explicit,
+        ),
+    )
+    return mesh, P(("replica_dcn", "data", "expert"), None)
+
+
+def _with_state_dict_prefix(prefix: str | None, name: str) -> str:
+    return name if prefix is None else f"{prefix}.{name}"
+
+
+def _linear_inference_tensor(value: jax.Array) -> jax.Array:
+    return jnp.swapaxes(value, -1, -2)
+
+
+def _unstacked_blocks(model: Transformer) -> tuple[Block, ...]:
+    if model.blocks is not None:
+        return model.blocks
+    assert model.stacked_blocks is not None
+    return model.stacked_blocks.unstacked()
+
+
+def grugmoe_inference_state_dict(model: Transformer, prefix: str | None = None) -> dict[str, jax.Array]:
+    tensors: dict[str, jax.Array] = {
+        "model.embed_tokens.weight": model.token_embed,
+        "model.embed_norm.weight": model.embed_norm.weight,
+        "model.embed_gated_norm.down_proj.weight": _linear_inference_tensor(model.embed_gated_norm.w_down),
+        "model.embed_gated_norm.up_proj.weight": _linear_inference_tensor(model.embed_gated_norm.w_up),
+        "model.norm.weight": model.final_norm.weight,
+        "model.final_gated_norm.down_proj.weight": _linear_inference_tensor(model.final_gated_norm.w_down),
+        "model.final_gated_norm.up_proj.weight": _linear_inference_tensor(model.final_gated_norm.w_up),
+        "lm_head.weight": _linear_inference_tensor(model.output_proj),
+    }
+
+    for layer_index, block in enumerate(_unstacked_blocks(model)):
+        layer_prefix = f"model.layers.{layer_index}"
+        tensors.update(
+            {
+                f"{layer_prefix}.input_layernorm.weight": block.rms_attn.weight,
+                f"{layer_prefix}.attn_gated_norm.down_proj.weight": _linear_inference_tensor(
+                    block.attn_gated_norm.w_down
+                ),
+                f"{layer_prefix}.attn_gated_norm.up_proj.weight": _linear_inference_tensor(block.attn_gated_norm.w_up),
+                f"{layer_prefix}.self_attn.q_proj.weight": _linear_inference_tensor(block.attn.w_q),
+                f"{layer_prefix}.self_attn.k_proj.weight": _linear_inference_tensor(block.attn.w_k),
+                f"{layer_prefix}.self_attn.v_proj.weight": _linear_inference_tensor(block.attn.w_v),
+                f"{layer_prefix}.self_attn.o_proj.weight": _linear_inference_tensor(block.attn.w_o),
+                f"{layer_prefix}.self_attn.attn_gate.weight": _linear_inference_tensor(block.attn.attn_gate),
+                f"{layer_prefix}.post_attention_layernorm.weight": block.rms_mlp.weight,
+                f"{layer_prefix}.mlp_gated_norm.down_proj.weight": _linear_inference_tensor(block.mlp_gated_norm.w_down),
+                f"{layer_prefix}.mlp_gated_norm.up_proj.weight": _linear_inference_tensor(block.mlp_gated_norm.w_up),
+                f"{layer_prefix}.mlp.router.weight": _linear_inference_tensor(block.mlp.router),
+                f"{layer_prefix}.mlp.router.bias": block.mlp.router_bias,
+                f"{layer_prefix}.mlp.experts.gate_proj.weight": _linear_inference_tensor(block.mlp.expert_mlp.w_gate),
+                f"{layer_prefix}.mlp.experts.up_proj.weight": _linear_inference_tensor(block.mlp.expert_mlp.w_up),
+                f"{layer_prefix}.mlp.experts.down_proj.weight": _linear_inference_tensor(block.mlp.expert_mlp.w_down),
+            }
+        )
+        if block.shared is not None:
+            shared_w_gate = jnp.concatenate([expert.w_gate for expert in block.shared], axis=1)
+            shared_w_up = jnp.concatenate([expert.w_up for expert in block.shared], axis=1)
+            shared_w_down = jnp.concatenate([expert.w_down for expert in block.shared], axis=0)
+            tensors.update(
+                {
+                    f"{layer_prefix}.shared_expert.gate_proj.weight": _linear_inference_tensor(shared_w_gate),
+                    f"{layer_prefix}.shared_expert.up_proj.weight": _linear_inference_tensor(shared_w_up),
+                    f"{layer_prefix}.shared_expert.down_proj.weight": _linear_inference_tensor(shared_w_down),
+                }
+            )
+
+    return {_with_state_dict_prefix(prefix, name): value for name, value in tensors.items()}
+
+
+__all__ = [
+    "GRUG_MOE_ARCHITECTURE",
+    "GRUG_MOE_ARTIFACT_SCHEMA_VERSION",
+    "GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY",
+    "GRUG_MOE_MODEL_TYPE",
+    "Block",
+    "CausalSelfAttention",
+    "DenseMLP",
+    "GatedNorm",
+    "GrugModelConfig",
+    "GrugMoeHfConfig",
+    "MoEMLP",
+    "MoeActivation",
+    "RMSNorm",
+    "Transformer",
+    "debug_mesh_and_token_pspec",
+    "grugmoe_inference_state_dict",
+]

--- a/experiments/grug/moe_hero_ep/optimizer.py
+++ b/experiments/grug/moe_hero_ep/optimizer.py
@@ -1,0 +1,317 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+import optax
+from levanter.optim.config import OptimizerConfig
+from levanter.optim.grugmuon import _grug_scale_with_muon
+from levanter.optim.util import CoefficientType
+from levanter.utils.jax_utils import leaf_key_paths
+
+from experiments.grug.moe_hero_ep.adamh import scale_by_adamh
+
+
+def _target_named_sharding(array) -> jax.sharding.NamedSharding | None:
+    if array is None or not hasattr(array, "shape"):
+        return None
+    sharding = getattr(array, "sharding", None)
+    if sharding is None:
+        aval = jax.typeof(array)
+        sharding = getattr(aval, "sharding", None)
+    if isinstance(sharding, jax.sharding.NamedSharding):
+        return sharding
+    return None
+
+
+def _match_named_update_sharding() -> optax.GradientTransformation:
+    """Restore named mesh sharding without touching single-device arrays."""
+
+    def init_fn(params):
+        del params
+        return optax.EmptyState()
+
+    def update_fn(updates, state, params=None):
+        if params is None:
+            return updates, state
+
+        def match_sharding(update, param):
+            if update is None:
+                return None
+            target_sharding = _target_named_sharding(param)
+            if target_sharding is None:
+                return update
+            return jax.sharding.reshard(update, target_sharding)
+
+        updates = jax.tree.map(match_sharding, updates, params, is_leaf=lambda x: x is None)
+        return updates, state
+
+    return optax.GradientTransformation(init_fn, update_fn)
+
+
+def _match_named_sharding_to_params(updates, params):
+    def match_sharding(update, param):
+        if update is None:
+            return None
+        target_sharding = _target_named_sharding(param)
+        if target_sharding is None:
+            return update
+        return jax.sharding.reshard(update, target_sharding)
+
+    return jax.tree.map(match_sharding, updates, params, is_leaf=lambda x: x is None)
+
+
+def _scale_invariant_hyperball_updates(params, direction_updates, learning_rate: float):
+    direction_updates = _match_named_sharding_to_params(direction_updates, params)
+
+    def scale_invariant_update(param, update):
+        if update is None:
+            return None
+        if not hasattr(param, "ndim"):
+            return update
+        if param.ndim == 2:
+            param_norm = jnp.linalg.norm(param)
+            update_norm = jnp.linalg.norm(update)
+            new_param = param - learning_rate * update * param_norm / jnp.maximum(update_norm, 1e-10)
+            new_param_norm = jnp.linalg.norm(new_param)
+            return new_param / jnp.maximum(new_param_norm, 1e-10) * param_norm - param
+
+        axes = tuple(range(1, param.ndim))
+        param_norm = jnp.sqrt(jnp.sum(jnp.square(param), axis=axes, keepdims=True))
+        update_norm = jnp.sqrt(jnp.sum(jnp.square(update), axis=axes, keepdims=True))
+        new_param = param - learning_rate * update * param_norm / jnp.maximum(update_norm, 1e-10)
+        new_param_norm = jnp.sqrt(jnp.sum(jnp.square(new_param), axis=axes, keepdims=True))
+        return new_param / jnp.maximum(new_param_norm, 1e-10) * param_norm - param
+
+    return jax.tree.map(
+        scale_invariant_update,
+        params,
+        direction_updates,
+        is_leaf=lambda x: x is None,
+    )
+
+
+def scale_with_grug_muonh(
+    momentum: float = 0.95,
+    nesterov: bool = True,
+    steps: int = 5,
+    muon_eps: float = 1e-8,
+    learning_rate: float = 0.02,
+    coefficient_type: CoefficientType = "quintic",
+) -> optax.GradientTransformation:
+    """MuonH transform for raw Grug arrays with matrix-shaped trailing dims."""
+    muon_transform = _grug_scale_with_muon(
+        momentum=momentum,
+        nesterov=nesterov,
+        steps=steps,
+        muon_eps=muon_eps,
+        use_kimi_scaling=False,
+        coefficient_type=coefficient_type,
+    )
+
+    def init_fn(params):
+        return muon_transform.init(params)
+
+    def update_fn(updates, state, params=None):
+        if params is None:
+            raise ValueError("scale_with_grug_muonh requires params for norm-preserving updates")
+
+        muon_updates, next_state = muon_transform.update(updates, state, params)
+        muonh_updates = _scale_invariant_hyperball_updates(params, muon_updates, learning_rate)
+        return muonh_updates, next_state
+
+    return optax.GradientTransformation(init_fn, update_fn)
+
+
+@dataclass(frozen=True)
+class GrugMoeAdamHConfig(OptimizerConfig):
+    """AdamH for Grug MoE. Four optimizer groups, no flags.
+
+    - adamh: attention weights, dense MLP weights (2D matrices)
+    - adamh_expert: expert MLP weights (mlp.expert_mlp.w_gate,
+      mlp.expert_mlp.w_up, mlp.expert_mlp.w_down, shared.w_*)
+    - adam: norms, biases, router, embeddings, attention gates (1D / small params)
+    """
+
+    beta1: float = 0.9
+    beta2: float = 0.95
+    epsilon: float = 1e-8
+    max_grad_norm: float | None = 1.0
+    adam_lr: float = 6e-4
+    expert_lr: float | None = None
+
+    def build(self, num_train_steps):
+        learning_rate_schedule = self.lr_scheduler(num_train_steps)
+        adam_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=self.adam_lr)
+        expert_lr_val = self.expert_lr if self.expert_lr is not None else self.learning_rate
+        expert_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=expert_lr_val)
+
+        def optimizer(learning_rate, adam_lr, expert_lr):
+            def adamh_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(scale_by_adamh(self.beta1, self.beta2, self.epsilon, learning_rate))
+                return optax.chain(*components)
+
+            def adamh_expert_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(scale_by_adamh(self.beta1, self.beta2, self.epsilon, expert_lr))
+                return optax.chain(*components)
+
+            def adam_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(optax.scale_by_adam(self.beta1, self.beta2, self.epsilon))
+                components.append(optax.scale(-adam_lr))
+                return optax.chain(*components)
+
+            return optax.multi_transform(
+                {
+                    "adamh": adamh_transform(),
+                    "adamh_expert": adamh_expert_transform(),
+                    "adam": adam_transform(),
+                },
+                self.create_mask,
+            )
+
+        return optax.inject_hyperparams(optimizer)(
+            learning_rate=learning_rate_schedule,
+            adam_lr=adam_lr_schedule,
+            expert_lr=expert_lr_schedule,
+        )
+
+    def create_mask(self, params):
+        paths = leaf_key_paths(params)
+
+        def mask_fn(param, path):
+            path_str = ".".join(path) if isinstance(path, (list, tuple)) else str(path)
+            path_lower = path_str.lower()
+            if "token_embed" in path_lower:
+                return "adam"
+            if "router_bias" in path_lower or "attn_gate" in path_lower or ".router" in path_lower:
+                return "adam"
+            is_shared_weight = ".shared." in path_lower and ".w_" in path_lower
+            if ".mlp.expert_mlp.w_" in path_lower or ".mlp.w_" in path_lower or is_shared_weight:
+                return "adamh_expert"
+            if hasattr(param, "ndim") and param.ndim >= 2:
+                return "adamh"
+            return "adam"
+
+        return jax.tree.map(mask_fn, params, paths)
+
+
+@dataclass(frozen=True)
+class GrugMoeMuonHConfig(OptimizerConfig):
+    """May Recipe MuonH optimizer: 3 LR groups (muonh / adamh / adam).
+
+    Three LR groups:
+    - ``muonh``: matrices (attn, MoE MLP, shared) **and** all GatedNorms.
+      Newton-Schulz orthogonalisation + Frobenius hyperball scale-invariant step.
+    - ``adamh``: ``lm_head`` / ``output_proj``.
+    - ``adam``: ``token_embed`` / ``router`` / ``router_bias`` / ``attn_gate``
+      / 1-D norm weights.
+
+    ``max_grad_norm`` defaults to ``None`` here (no clipping) for the 1pct-noclip
+    schedule used by the May Recipe baseline.
+    """
+
+    adam_lr: float = 6e-4
+    momentum: float = 0.95
+    nesterov: bool = True
+    backend_steps: int = 5
+    beta1: float = 0.9
+    beta2: float = 0.95
+    epsilon: float = 1e-8
+    muon_epsilon: float = 1e-8
+    max_grad_norm: float | None = None
+    coefficient_type: CoefficientType = "quintic"
+
+    def build(self, num_train_steps):
+        learning_rate_schedule = self.lr_scheduler(num_train_steps)
+        adam_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=self.adam_lr)
+
+        def optimizer(learning_rate, adam_lr):
+            def muonh_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(
+                    scale_with_grug_muonh(
+                        momentum=self.momentum,
+                        nesterov=self.nesterov,
+                        steps=self.backend_steps,
+                        muon_eps=self.muon_epsilon,
+                        learning_rate=learning_rate,
+                        coefficient_type=self.coefficient_type,
+                    )
+                )
+                components.append(_match_named_update_sharding())
+                return optax.chain(*components)
+
+            def adamh_transform_at(lr):
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(scale_by_adamh(self.beta1, self.beta2, self.epsilon, lr))
+                return optax.chain(*components)
+
+            def adam_transform_at(lr):
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(optax.scale_by_adam(self.beta1, self.beta2, self.epsilon))
+                components.append(optax.scale(-lr))
+                return optax.chain(*components)
+
+            transforms = {
+                "muonh": muonh_transform(),
+                "adamh": adamh_transform_at(learning_rate),
+                "adam": adam_transform_at(adam_lr),
+            }
+            return optax.multi_transform(transforms, self.create_mask)
+
+        return optax.inject_hyperparams(optimizer)(
+            learning_rate=learning_rate_schedule,
+            adam_lr=adam_lr_schedule,
+        )
+
+    def create_mask(self, params):
+        paths = leaf_key_paths(params)
+
+        def mask_fn(param, path):
+            path_str = ".".join(path) if isinstance(path, (list, tuple)) else str(path)
+            path_lower = path_str.lower()
+            if (
+                "token_embed" in path_lower
+                or "router_bias" in path_lower
+                or path_lower.endswith(".attn_gate")
+                or ".router" in path_lower
+            ):
+                return "adam"
+            if "output_proj" in path_lower or "lm_head" in path_lower:
+                return "adamh"
+            # GatedNorms route to muonh (NS + Frobenius hyperball), same as matrices.
+            if "gated_norm" in path_lower:
+                return "muonh"
+            # Scanning prepends a layer axis, so normalization gains become 2D while expert
+            # matrices become 4D. Keep the gains on Adam and route matrix-shaped leaves to MuonH.
+            if path_lower.endswith(".weight"):
+                return "adam"
+            if hasattr(param, "ndim") and param.ndim in (2, 3, 4):
+                return "muonh"
+            return "adam"
+
+        return jax.tree.map(mask_fn, params, paths)
+
+
+__all__ = [
+    "GrugMoeAdamHConfig",
+    "GrugMoeMuonHConfig",
+    "scale_with_grug_muonh",
+]

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -1,0 +1,681 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+import functools
+import logging
+import os
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jmp
+import levanter.callbacks as callbacks
+import levanter.tracker
+import optax
+from fray.cluster import ResourceConfig
+from haliax import Axis
+from haliax.partitioning import set_mesh
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+from jax.tree_util import register_dataclass
+from jaxtyping import PRNGKeyArray
+from levanter.callbacks.state_adapter import StateCallbackRunner
+from levanter.callbacks.watch import WatchConfig, compute_watch_stats
+from levanter.data.dataset import AsyncDataset
+from levanter.data.loader import DataLoader
+from levanter.data.mixture import MixtureDataset, rescale_mixture_schedule_for_batch_schedule
+from levanter.data.text.datasets import LmDataConfig
+from levanter.data.text.examples import GrugLmExample, grug_lm_example_from_named
+from levanter.eval import TaggedEvaluator, cb_tagged_evaluate
+from levanter.grug.sharding import compact_grug_mesh
+from levanter.models.lm_model import LmExample
+from levanter.optim.config import AdamConfig, OptimizerConfig
+from levanter.schedule import BatchSchedule
+from levanter.trainer import TrainerConfig
+from levanter.utils.flop_utils import lm_flops_per_token
+from levanter.utils.jax_utils import parameter_count
+from levanter.utils.logging import LoadingTimeTrackerIterator
+
+from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
+from experiments.grug.dispatch import dispatch_grug_training_run
+from experiments.grug.moe_hero_ep.model import GrugModelConfig, Transformer
+from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
+
+# This file intentionally mirrors `experiments/grug/base/train.py` with
+# variant-specific model/loss/FLOP wiring, per the grug copy-first workflow in
+# `.agents/skills/change-grug/`.
+
+logger = logging.getLogger(__name__)
+
+HERO_EP_RUNTIME_ENV: Mapping[str, str] = MappingProxyType(
+    {
+        "JAX_ENABLE_PGLE": "false",
+        "SCALE_A2A_FIXED": "1",
+        "SCALE_A2A_CHUNKS": "1",
+        "SCALE_A2A_NO_BARRIER": "1",
+        "SCALE_A2A_GATHER_DISPATCH": "1",
+        "SCALE_A2A_CUSTOM_ADJOINT": "1",
+        "SCALE_A2A_SPILL": "3",
+        "SCALE_MUON_PAD_NONEXPERT": "1",
+        "SCALE_MUON_SYRK": "1",
+    }
+)
+
+
+@dataclass(frozen=True)
+class GrugTrainerConfig:
+    """Runtime knobs for grug training."""
+
+    trainer: TrainerConfig = field(default_factory=lambda: TrainerConfig(use_explicit_mesh_axes=True))
+    data_seed: int | None = None
+    log_every: int = 1
+    ema_beta: float | None = None  # EMA coefficient for eval/checkpoint model; None disables EMA.
+    z_loss_weight: float = 1e-4  # Weight on final-logit logsumexp z-loss stabilization term.
+    # Keep disabled except on model sizes where Grace-Blackwell host offload has been measured.
+    # The d6144 EP64 runs used it; d5120 required a 135 GiB pinned-host arena and regressed.
+    offload_opt_state: bool = False
+
+    # Grug builds its own compact (replica_dcn, data, expert, model) mesh instead of using
+    # the Trainer's logical axis mapping; `data` absorbs whatever these two leave free.
+    # Defaults reproduce the historical layout: no expert parallelism and full replication
+    # across slices (replica_axis_size=None -> jax.process_count()), i.e. parameters
+    # replicated per slice and sharded only over the intra-slice `data` axis. For a model
+    # too large to replicate within one slice, set replica_axis_size=1 (FSDP across every
+    # slice) and expert_axis_size>1 (expert parallelism over the intra-slice devices).
+    expert_axis_size: int = 1
+    replica_axis_size: int | None = None
+    sharding_dump_path: str | None = None
+
+
+@dataclass(frozen=True)
+class GrugEvalConfig:
+    """Perplexity eval settings for grug training."""
+
+    eval_batch_size: int = 512
+    steps_per_eval: int | None = 1000
+    max_eval_batches: int | None = None
+    prefix: str = "eval"
+    eval_current: bool = True
+    eval_ema: bool = True
+    compute_bpb: bool = True
+
+
+@dataclass(frozen=True)
+class GrugRunConfig:
+    """Top-level config for grug training."""
+
+    model: GrugModelConfig
+    data: LmDataConfig
+    resources: ResourceConfig
+    optimizer: OptimizerConfig = field(default_factory=AdamConfig)
+    trainer: GrugTrainerConfig = field(default_factory=GrugTrainerConfig)
+    eval: GrugEvalConfig | None = field(default_factory=GrugEvalConfig)
+    # GPU processes per task: > 1 runs one JAX process per GPU (multi-controller)
+    # via the iris.hooks.multigpu_main supervisor instead of one process per node.
+    processes_per_task: int = 1
+
+
+def build_train_dataset(
+    data_config: LmDataConfig,
+    *,
+    max_seq_len: int,
+    batch_schedule: BatchSchedule,
+    key: PRNGKeyArray,
+) -> MixtureDataset[GrugLmExample]:
+    pos = Axis("position", max_seq_len)
+    mix_key, shuffle_key = jax.random.split(key)
+    weights = data_config.train_weights
+    if isinstance(weights, list):
+        weights = rescale_mixture_schedule_for_batch_schedule(weights, batch_schedule)
+
+    initial_batch_size = batch_schedule.batch_size_at_step(0)
+    datasets = data_config.train_sets(pos, key=shuffle_key, initial_batch_size=initial_batch_size)
+    return MixtureDataset(
+        datasets=datasets,
+        weights=weights,
+        stop_strategy=data_config.stop_strategy,
+        key=mix_key,
+        block_size=data_config.mixture_block_size,
+    )
+
+
+_BATCH_AXES: tuple[str, ...] = ("replica_dcn", "data", "expert")
+
+
+def build_train_loader(
+    dataset: AsyncDataset[GrugLmExample],
+    *,
+    batch_schedule: BatchSchedule,
+    mesh: Mesh,
+) -> DataLoader[GrugLmExample]:
+    # DataLoader uses this batch axis mapping to shard batches across the distributed mesh.
+    # `compact_grug_mesh` always carries (replica_dcn, data, expert, model); length-1 axes
+    # are kept so we can name "expert" unconditionally.
+    return DataLoader(
+        dataset,
+        batch_schedule.schedule,
+        mesh=mesh,
+        axis_resources={"__BATCH__": _BATCH_AXES},
+        batch_axis_name="__BATCH__",
+        allow_nondivisible_batch_size=False,
+    )
+
+
+def build_tagged_evaluator(
+    *,
+    data_config: LmDataConfig,
+    max_seq_len: int,
+    mesh: Mesh,
+    eval_cfg: GrugEvalConfig,
+) -> TaggedEvaluator[LmExample | GrugLmExample, Transformer] | None:
+    pos = Axis("position", max_seq_len)
+    tagged_eval_sets = data_config.tagged_eval_sets(pos)
+    if len(tagged_eval_sets) == 0:
+        logger.warning("No evaluation datasets provided.")
+        return None
+
+    max_examples_per_dataset = None
+    if eval_cfg.max_eval_batches is not None:
+        max_examples_per_dataset = eval_cfg.max_eval_batches * eval_cfg.eval_batch_size
+
+    tokenizer = data_config.the_tokenizer if eval_cfg.compute_bpb else None
+    # `compact_grug_mesh` always carries (replica_dcn, data, expert, model); length-1 axes
+    # are kept so we can name "expert" unconditionally.
+    eval_axis_mapping = {"batch": _BATCH_AXES}
+    eval_batch = Axis("batch", eval_cfg.eval_batch_size)
+    eval_array_sharding = NamedSharding(mesh, P(_BATCH_AXES, None))
+
+    def eval_loss_fn(model: Transformer, batch: LmExample | GrugLmExample) -> tuple[jax.Array, jax.Array, jax.Array]:
+        if isinstance(batch, LmExample):
+            batch = grug_lm_example_from_named(batch)
+        per_pos_loss = model.next_token_loss(
+            batch.tokens,
+            batch.loss_weight,
+            mask=batch.attn_mask,
+            reduction="none",
+            logsumexp_weight=None,
+        )
+        per_pos_loss = jax.sharding.reshard(per_pos_loss, eval_array_sharding)
+        per_pos_weight = jax.sharding.reshard(batch.loss_weight, eval_array_sharding)
+        per_pos_token_id = jnp.pad(batch.tokens[:, 1:], ((0, 0), (0, 1)))
+        return per_pos_loss, per_pos_weight, per_pos_token_id
+
+    return TaggedEvaluator(
+        EvalBatch=eval_batch,
+        tagged_eval_sets=tagged_eval_sets,
+        loss_fn=eval_loss_fn,
+        tokenizer=tokenizer,
+        device_mesh=mesh,
+        axis_mapping=eval_axis_mapping,
+        max_examples_per_dataset=max_examples_per_dataset,
+    )
+
+
+def _compute_flops(
+    *,
+    model_config: GrugModelConfig,
+) -> tuple[float, dict[str, float]]:
+    flops_per_token = lm_flops_per_token(
+        hidden_dim=model_config.hidden_dim,
+        intermediate_dim=model_config.intermediate_dim,
+        shared_intermediate_dim=model_config.shared_expert_intermediate_dim,
+        num_layers=model_config.num_layers,
+        num_kv_heads=model_config.num_kv_heads,
+        num_heads=model_config.num_heads,
+        seq_len=model_config.max_seq_len,
+        vocab_size=model_config.vocab_size,
+        glu=True,
+        num_experts=model_config.num_experts,
+        num_shared_experts=1 if model_config.shared_expert_intermediate_dim > 0 else 0,
+        num_experts_per_tok=model_config.num_experts_per_token,
+    )
+    flops_per_example = 3 * flops_per_token * model_config.max_seq_len
+
+    flops_summary: dict[str, float] = {
+        "throughput/flops_per_token_analytic": flops_per_token,
+        "throughput/flops_per_example_analytic": flops_per_example,
+    }
+
+    return flops_per_example, flops_summary
+
+
+def _make_mixture_stage_callback(train_dataset: MixtureDataset, batch_schedule: BatchSchedule):
+    last_mixture_stage = -1
+
+    def log_mixture_stage(step_info):
+        nonlocal last_mixture_stage
+        seq_index = batch_schedule.global_data_offset_by_step(step_info.step)
+        block_id = seq_index // train_dataset.block_size
+        stage = train_dataset._get_stage_for_block(block_id)
+        if stage == last_mixture_stage:
+            return
+
+        weights = train_dataset.weight_stages[stage][1]
+        mixture_log = {f"mixture/weight/{name}": weight for name, weight in weights.items()}
+        mixture_log["mixture/stage"] = stage
+        levanter.tracker.log(mixture_log, step=step_info.step)
+        last_mixture_stage = stage
+
+    return log_mixture_stage
+
+
+@register_dataclass
+@dataclass(frozen=True)
+class GrugTrainState:
+    step: jax.Array
+    params: Transformer
+    opt_state: optax.OptState
+    ema_params: Transformer | None
+    pending_qb_betas: jax.Array
+
+
+def _apply_qb_betas(model: Transformer, qb_betas: jax.Array) -> Transformer:
+    """Set router biases from QB betas (computed on previous step)."""
+    if model.blocks is None:
+        assert model.stacked_blocks is not None
+        new_bias = -qb_betas
+        new_bias = new_bias - jnp.mean(new_bias, axis=-1, keepdims=True)
+        return eqx.tree_at(lambda t: t.stacked_blocks.stacked.mlp.router_bias, model, new_bias)
+
+    new_blocks = list(model.blocks)
+    moe_idx = 0
+    for i, block in enumerate(model.blocks):
+        if block.mlp is None:
+            continue
+        new_bias = -qb_betas[moe_idx]
+        new_bias = new_bias - jnp.mean(new_bias)
+        new_mlp = eqx.tree_at(lambda m: m.router_bias, block.mlp, new_bias)
+        new_blocks[i] = eqx.tree_at(lambda b: b.mlp, block, new_mlp)
+        moe_idx += 1
+    return eqx.tree_at(lambda t: t.blocks, model, tuple(new_blocks))
+
+
+def _optimizer_state_to_memory_kind(tree, memory_kind: str):
+    """Move named-sharded optimizer arrays to a JAX memory kind."""
+
+    def _move(leaf):
+        if not isinstance(leaf, jax.Array):
+            return leaf
+        sharding = jax.typeof(leaf).sharding
+        mesh = getattr(sharding, "mesh", None)
+        if mesh is None or len(getattr(mesh, "axis_names", ())) == 0:
+            # Scalar optimizer metadata carries no named mesh and is negligible in HBM.
+            return leaf
+        return jax.device_put(leaf, sharding.with_memory_kind(memory_kind))
+
+    return jax.tree.map(_move, tree)
+
+
+def initial_state(
+    model_config: GrugModelConfig,
+    *,
+    optimizer: optax.GradientTransformation,
+    mp: jmp.Policy,
+    key: PRNGKeyArray,
+    ema_beta: float | None,
+    offload_opt_state: bool = False,
+) -> GrugTrainState:
+    params = mp.cast_to_param(Transformer.init(model_config, key=key))
+    if params.blocks is None:
+        num_moe_layers = model_config.num_layers
+    else:
+        num_moe_layers = sum(1 for block in params.blocks if block.mlp is not None)
+    opt_state = optimizer.init(params)
+    if offload_opt_state:
+        opt_state = _optimizer_state_to_memory_kind(opt_state, "pinned_host")
+    return GrugTrainState(
+        step=jnp.array(0, dtype=jnp.int32),
+        params=params,
+        opt_state=opt_state,
+        ema_params=params if ema_beta is not None else None,
+        pending_qb_betas=jnp.zeros((num_moe_layers, model_config.num_experts)),
+    )
+
+
+def _drop_metrics(
+    dropped_assignments: jax.Array,
+    *,
+    batch_size: int,
+    sequence_length: int,
+    top_k: int,
+    num_layers: int,
+) -> dict[str, int | float]:
+    # Global assignment totals can exceed int32; float32 would also round large drop counts.
+    dropped_assignments_host = int(dropped_assignments)
+    total_assignments = batch_size * sequence_length * top_k * num_layers
+    return {
+        "moe/dropped_assignments": dropped_assignments_host,
+        "moe/drop_fraction": dropped_assignments_host / total_assignments,
+    }
+
+
+def _make_train_step(
+    optimizer: optax.GradientTransformation,
+    mp: jmp.Policy,
+    *,
+    z_loss_weight: float,
+    ema_beta: float | None,
+    watch_config: WatchConfig | None = None,
+    offload_opt_state: bool = False,
+):
+    one = jnp.array(1, dtype=jnp.int32)
+    z_loss = z_loss_weight if z_loss_weight > 0 else None
+    if watch_config is not None:
+        if isinstance(watch_config.watch_targets, str):
+            watch_targets = tuple(t.strip() for t in watch_config.watch_targets.split(","))
+        else:
+            watch_targets = tuple(watch_config.watch_targets)
+    else:
+        watch_targets = ()
+
+    @functools.partial(jax.jit, donate_argnums=(0,), static_argnames=("compute_watch",))
+    def train_step(state: GrugTrainState, batch, *, compute_watch: bool = False):
+        # Apply pending QB betas to router biases inside JIT (avoids eager
+        # host-side TPU kernel launches that can cause SPMD sync issues).
+        qb_params = _apply_qb_betas(state.params, state.pending_qb_betas)
+        if ema_beta is not None:
+            qb_ema_params = _apply_qb_betas(state.ema_params, state.pending_qb_betas)
+        else:
+            qb_ema_params = None
+
+        def loss_fn(params):
+            compute_params = mp.cast_to_compute(params)
+            return compute_params.next_token_loss(
+                batch.tokens,
+                batch.loss_weight,
+                mask=batch.attn_mask,
+                reduction="mean",
+                logsumexp_weight=z_loss,
+                return_router_metrics=True,
+            )
+
+        (loss, summarized_metrics), grads = jax.value_and_grad(loss_fn, has_aux=True)(qb_params)
+        metrics = {"train/loss": loss, **summarized_metrics}
+        opt_state_in = (
+            _optimizer_state_to_memory_kind(state.opt_state, "device") if offload_opt_state else state.opt_state
+        )
+        updates, opt_state = optimizer.update(grads, opt_state_in, qb_params)
+        params = optax.apply_updates(qb_params, updates)
+
+        if ema_beta is None:
+            ema_params = None
+        else:
+            if qb_ema_params is None:
+                raise ValueError("ema_params must be initialized when ema_beta is set.")
+            ema_params = jax.tree_util.tree_map(
+                lambda old, new: ema_beta * old + (1.0 - ema_beta) * new,
+                qb_ema_params,
+                params,
+            )
+
+        watch_stats = None
+        if watch_config is not None and compute_watch:
+            watch_stats = compute_watch_stats(
+                watch_targets=watch_targets,
+                include_norms=watch_config.include_norms,
+                include_per_parameter_norms=watch_config.include_per_parameter_norms,
+                include_histogram=watch_config.include_histograms,
+                split_scan_layers=watch_config.split_scan_layers,
+                params=qb_params,
+                grads=grads,
+                updates=updates,
+                opt_state=opt_state_in,
+                model_tree_type=type(state.params),
+            )
+
+        if offload_opt_state:
+            opt_state = _optimizer_state_to_memory_kind(opt_state, "pinned_host")
+
+        next_state = dataclasses.replace(
+            state,
+            step=state.step + one,
+            params=params,
+            opt_state=opt_state,
+            ema_params=ema_params,
+            pending_qb_betas=metrics["qb_beta_per_layer"],
+        )
+
+        return next_state, metrics, watch_stats
+
+    return train_step
+
+
+def _run_grug_local(config: GrugRunConfig) -> None:
+    """Entry point for the grug template training loop."""
+    trainer = config.trainer.trainer
+    trainer.initialize()
+    levanter.tracker.log_configuration(config)
+
+    run_id = trainer.id
+    if run_id is None:
+        raise ValueError("trainer.id was not initialized")
+
+    optimizer = config.optimizer.build(trainer.num_train_steps)
+    watch_config = trainer.watch
+    train_step = _make_train_step(
+        optimizer,
+        trainer.mp,
+        z_loss_weight=config.trainer.z_loss_weight,
+        ema_beta=config.trainer.ema_beta,
+        watch_config=watch_config if watch_config.is_enabled else None,
+        offload_opt_state=config.trainer.offload_opt_state,
+    )
+
+    data_key, model_key = jax.random.split(jax.random.PRNGKey(trainer.seed), 2)
+    if config.trainer.data_seed is not None:
+        data_key = jax.random.PRNGKey(config.trainer.data_seed)
+
+    # Grug uses raw PartitionSpecs rather than Trainer's logical axis mapping.
+    # Keep the mesh compact so the batch pspec derived by `_batch_spec(mesh)` spans slices directly.
+    # replica_axis_size=None lets compact_grug_mesh default to jax.process_count() (full
+    # cross-slice replication); set it to 1 on GrugTrainerConfig for cross-slice FSDP.
+    mesh = compact_grug_mesh(
+        expert_axis_size=config.trainer.expert_axis_size,
+        replica_axis_size=config.trainer.replica_axis_size,
+    )
+    with set_mesh(mesh):
+        batch_schedule = trainer.batch_schedule
+
+        train_dataset = build_train_dataset(
+            config.data,
+            max_seq_len=config.model.max_seq_len,
+            batch_schedule=batch_schedule,
+            key=data_key,
+        )
+        train_loader = build_train_loader(
+            train_dataset,
+            batch_schedule=batch_schedule,
+            mesh=mesh,
+        )
+
+        @jax.jit
+        def _init_state(model_rng):
+            return initial_state(
+                config.model,
+                optimizer=optimizer,
+                mp=trainer.mp,
+                key=model_rng,
+                ema_beta=config.trainer.ema_beta,
+                offload_opt_state=config.trainer.offload_opt_state,
+            )
+
+        state = _init_state(model_key)
+
+        # This throughput template intentionally produces no checkpoint.
+        checkpointer = None
+        state = restore_grug_state_from_checkpoint(
+            state,
+            checkpoint_search_paths=trainer.checkpoint_search_paths(run_id),
+            load_checkpoint_setting=trainer.load_checkpoint,
+            mesh=mesh,
+            allow_partial=trainer.allow_partial_checkpoint,
+        )
+        dump_grug_state_sharding_run_artifact(
+            state,
+            log_dir=trainer.log_dir,
+            run_id=run_id,
+            path_override=config.trainer.sharding_dump_path,
+        )
+
+        levanter.tracker.log_summary({"parameter_count": parameter_count(state.params)})
+
+        flops_per_example, flops_summary = _compute_flops(model_config=config.model)
+        levanter.tracker.log_summary(flops_summary)
+
+        eval_cfg = config.eval
+        evaluator = None
+        if eval_cfg is not None:
+            evaluator = build_tagged_evaluator(
+                data_config=config.data,
+                max_seq_len=config.model.max_seq_len,
+                mesh=mesh,
+                eval_cfg=eval_cfg,
+            )
+
+        profiler_cfg = trainer.profiler
+        profiler_num_steps = profiler_cfg.resolve_num_profile_steps(num_train_steps=trainer.num_train_steps)
+        profiler_enabled = profiler_cfg.is_enabled and profiler_num_steps > 0
+
+        log_every = max(1, config.trainer.log_every)
+        iterator = LoadingTimeTrackerIterator(train_loader.iter_from_step(int(state.step)))
+
+        state_callbacks = StateCallbackRunner[GrugTrainState](
+            step_getter=lambda s: s.step,
+            model_getter=lambda s: s.params,
+            eval_model_getter=lambda s: s.ema_params if s.ema_params is not None else s.params,
+            opt_state_getter=lambda s: s.opt_state,
+        )
+        state_callbacks.add_hook(
+            callbacks.log_performance_stats(config.model.max_seq_len, batch_schedule, flops_per_example),
+            every=log_every,
+        )
+        state_callbacks.add_hook(callbacks.pbar_logger(total=trainer.num_train_steps), every=log_every)
+        state_callbacks.add_hook(callbacks.log_step_info(trainer.num_train_steps), every=log_every)
+        if profiler_enabled:
+            state_callbacks.add_hook(
+                profiler_cfg.build(
+                    str(trainer.log_dir / run_id / "profiler"),
+                    run_id=run_id,
+                    num_steps=profiler_num_steps,
+                ),
+                every=1,
+            )
+        state_callbacks.add_hook(_make_mixture_stage_callback(train_dataset, batch_schedule), every=1)
+        if evaluator is not None and eval_cfg is not None:
+            interval = eval_cfg.steps_per_eval
+            eval_ema = eval_cfg.eval_ema and config.trainer.ema_beta is not None
+            if interval is not None and interval > 0 and (eval_cfg.eval_current or eval_ema):
+                state_callbacks.add_hook(
+                    cb_tagged_evaluate(
+                        evaluator,
+                        prefix=eval_cfg.prefix,
+                        eval_current=eval_cfg.eval_current,
+                        eval_ema=eval_ema,
+                    ),
+                    every=interval,
+                )
+
+        last_loss: float | jax.Array = 0.0
+        last_step_duration = 0.0
+
+        # Main optimization loop.
+        try:
+            while int(state.step) < trainer.num_train_steps:
+                with jax.profiler.TraceAnnotation("load_batch"):
+                    batch = next(iterator)
+                step_start = time.perf_counter()
+                current_step = int(state.step)
+                # grad_watch runs only on its configured interval.
+                compute_watch = (
+                    watch_config.is_enabled and watch_config.interval > 0 and current_step % watch_config.interval == 0
+                )
+                state, metrics, watch_stats = train_step(state, batch, compute_watch=compute_watch)
+                step = int(state.step) - 1
+
+                jax.block_until_ready(metrics["train/loss"])
+
+                if jnp.isnan(metrics["train/loss"]):
+                    logger.error(f"NaN loss at step {int(state.step)}. Stopping training.")
+                    break
+                duration = time.perf_counter() - step_start
+                hook_start = time.perf_counter()
+                with jax.profiler.TraceAnnotation("callbacks"):
+                    state_callbacks.run(state, loss=metrics["train/loss"], step_duration=duration)
+                    last_loss = metrics["train/loss"]
+                    last_step_duration = duration
+                    levanter.tracker.log({"throughput/hook_time": time.perf_counter() - hook_start}, step=step)
+                    levanter.tracker.log({"throughput/loading_time": iterator.this_load_time}, step=step)
+                    router_metrics = {
+                        key: value
+                        for key, value in metrics.items()
+                        if (key.startswith("train/router/") or key.startswith("moe_bias/"))
+                        and key not in ("train/router/routing_counts_per_layer", "qb_beta_per_layer")
+                    }
+                    if router_metrics:
+                        levanter.tracker.log(router_metrics, step=step)
+                    if "train/cross_entropy_loss" in metrics:
+                        levanter.tracker.log(
+                            {"train/cross_entropy_loss": metrics["train/cross_entropy_loss"]},
+                            step=step,
+                        )
+                    if "moe/dropped_assignments" in metrics:
+                        drop_metrics = _drop_metrics(
+                            metrics["moe/dropped_assignments"],
+                            batch_size=batch.tokens.shape[0],
+                            sequence_length=batch.tokens.shape[1],
+                            top_k=config.model.num_experts_per_token,
+                            num_layers=config.model.num_layers,
+                        )
+                        levanter.tracker.log(drop_metrics, step=step)
+
+                    if watch_stats is not None:
+                        levanter.tracker.log(watch_stats, step=step)
+
+                if checkpointer is not None:
+                    checkpointer.on_step(tree=state, step=int(state.step))
+        except BaseException:
+            logger.exception(
+                "Fatal error in grug training loop; skipping final callbacks/checkpoint to preserve root cause"
+            )
+            raise
+        else:
+            # Mirror classic trainer behavior: force callbacks on the last completed step.
+            state_callbacks.run(state, loss=last_loss, step_duration=last_step_duration, force=True)
+            if checkpointer is not None:
+                checkpointer.on_step(tree=state, step=int(state.step), force=True)
+                checkpointer.wait_until_finished()
+
+    levanter.tracker.current_tracker().finish()
+
+
+def run_grug(config: GrugRunConfig) -> None:
+    """Dispatch grug training through Fray jobs."""
+    trainer = config.trainer.trainer
+    if trainer.id is None:
+        raise ValueError("trainer.id must be set before dispatching grug training.")
+
+    # Dispatch snapshots os.environ for the child task, so apply the hero values first.
+    # These fixed recipe values intentionally override the submitter environment.
+    os.environ.update(HERO_EP_RUNTIME_ENV)
+    dispatch_grug_training_run(
+        run_id=trainer.id,
+        config=config,
+        local_entrypoint=_run_grug_local,
+        resources=config.resources,
+        processes_per_task=config.processes_per_task,
+    )
+
+
+__all__ = [
+    "GrugEvalConfig",
+    "GrugRunConfig",
+    "GrugTrainState",
+    "GrugTrainerConfig",
+    "initial_state",
+    "run_grug",
+]

--- a/experiments/grug/moe_hero_fsdp/README.md
+++ b/experiments/grug/moe_hero_fsdp/README.md
@@ -51,8 +51,8 @@ MuonH uses a 0.05 peak learning rate, linear decay, a 0.05 minimum ratio, and
 `beta2=0.9646229185299474`, and
 `epsilon=4.8379999999999997e-17`. The initializer standard deviation is
 `0.5 / sqrt(6144) = 0.0063788795384978605`. Final-logit z-loss is `1e-4`,
-router z-loss is 0, gradient clipping and EMA are disabled, and optimizer state
-is offloaded to pinned host memory.
+router z-loss is 0, weight decay is not applied, gradient clipping and EMA are
+disabled, and optimizer state is offloaded to pinned host memory.
 
 The d6144 reproduction used host offload. The rejected offload result applies
 to the d5120 EP shape: it needed a 135 GiB pinned-host arena and measured

--- a/experiments/grug/moe_hero_fsdp/launch.py
+++ b/experiments/grug/moe_hero_fsdp/launch.py
@@ -82,7 +82,6 @@ def _build_hero_optimizer() -> GrugMoeMuonHConfig:
     )
     return GrugMoeMuonHConfig(
         learning_rate=derived.learning_rate,
-        weight_decay=0.1,
         min_lr_ratio=derived.min_lr_ratio,
         warmup=derived.warmup,
         decay=derived.decay,
@@ -92,8 +91,6 @@ def _build_hero_optimizer() -> GrugMoeMuonHConfig:
         cycles=None,
         lr_schedule="linear",
         haps=None,
-        weight_decay_modules=None,
-        default_weight_decay_mask=None,
         adam_lr=derived.adam_lr,
         momentum=0.95,
         nesterov=True,

--- a/experiments/june_tpu_67b_a2b/moe/model.py
+++ b/experiments/june_tpu_67b_a2b/moe/model.py
@@ -42,7 +42,7 @@ from levanter.grug.grug_moe import (
     resolve_moe_implementation,
 )
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
-from levanter.grug.sharding import Pembed_vocab, Plm_head, unshard
+from levanter.grug.sharding import Pembed_vocab, Pfsdp, unshard
 from levanter.tracker.histogram import Histogram, SummaryStats
 from levanter.utils.activation import ActivationFunctionEnum
 
@@ -699,7 +699,10 @@ class Transformer(eqx.Module):
         token_embed = reshard(
             _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), cfg.initializer_std), Pembed_vocab
         )
-        output_proj = reshard(_init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head)
+        output_proj = reshard(
+            _init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std),
+            P(Pfsdp, "model"),
+        )
 
         blocks: tuple[Block, ...] | None
         stacked_blocks: ArrayStacked[Block] | None

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -28,6 +28,71 @@ from levanter.grug._moe.ep_common import (
 from levanter.grug.sharding import _batch_axes
 
 
+def _spill_attempts() -> int:
+    return int(os.environ.get("SCALE_A2A_SPILL", "0"))
+
+
+def _segment_rank(bucket: Int[Array, " n"], num_buckets: int) -> Int[Array, " n"]:
+    """Return each element's stable rank among elements in the same bucket."""
+    total = bucket.shape[0]
+    order = jnp.argsort(bucket, stable=True)
+    counts = jnp.bincount(bucket, length=num_buckets).astype(jnp.int32)
+    starts = jnp.cumsum(counts) - counts
+    ranks_sorted = jnp.arange(total, dtype=jnp.int32) - starts[bucket[order]]
+    return ranks_sorted[jnp.argsort(order)]
+
+
+def _assign_with_spill(
+    selected_experts_local: Int[Array, "Tlocal K"],
+    combine_weights_local: Float[Array, "Tlocal K"],
+    *,
+    num_experts: int,
+    capacity: int,
+    attempts: int,
+) -> tuple[Int[Array, " A"], Int[Array, " A"], Float[Array, " A"], Array]:
+    """Place assignments into fixed-capacity expert buckets with same-step spill.
+
+    Overflow assignments try the token's next-ranked selected experts. A successful spill carries
+    that candidate expert's router weight. Attempts are capped at ``top_k - 1`` so routing
+    granularity, rather than repeated passes over the same experts, sets the recovery ceiling.
+
+    Returns the target expert, its bucket slot, the target expert's combine weight, and a placed mask.
+    """
+    topk = selected_experts_local.shape[1]
+    attempts = min(max(attempts, 0), topk - 1)
+    flat_experts = selected_experts_local.reshape(-1).astype(jnp.int32)
+    routed_weights = combine_weights_local.reshape(-1)
+
+    slot = _segment_rank(flat_experts, num_experts)
+    placed = slot < capacity
+    if attempts == 0:
+        return flat_experts, slot, routed_weights, placed
+
+    target = flat_experts
+    occupancy = jnp.minimum(
+        jnp.bincount(flat_experts, length=num_experts).astype(jnp.int32),
+        capacity,
+    )
+    # Placed assignments use a sentinel bucket so they do not consume candidate ranks.
+    for attempt in range(1, attempts + 1):
+        candidate = jnp.roll(selected_experts_local, -attempt, axis=1).reshape(-1).astype(jnp.int32)
+        candidate_weights = jnp.roll(combine_weights_local, -attempt, axis=1).reshape(-1)
+        offered = jnp.where(placed, num_experts, candidate)
+        rank = _segment_rank(offered, num_experts + 1)
+        candidate_slot = occupancy[candidate] + rank
+        spilled = jnp.logical_and(~placed, candidate_slot < capacity)
+        target = jnp.where(spilled, candidate, target)
+        routed_weights = jnp.where(spilled, candidate_weights, routed_weights)
+        slot = jnp.where(spilled, candidate_slot, slot)
+        placed = jnp.logical_or(placed, spilled)
+        filled = jnp.bincount(
+            jnp.where(spilled, candidate, num_experts),
+            length=num_experts + 1,
+        )[:num_experts]
+        occupancy = jnp.minimum(occupancy + filled.astype(jnp.int32), capacity)
+    return target, slot, routed_weights, placed
+
+
 def _moe_mlp_ep_fixed_a2a_local(
     x_local: Float[Array, "Tlocal H"],
     selected_experts_local: Int[Array, "Tlocal K"],
@@ -107,17 +172,15 @@ def _fixed_a2a_core(
         x_local, combine_weights_local = jax.lax.optimization_barrier((x_local, combine_weights_local))
 
     repeated_x = jnp.repeat(x_local, topk, axis=0)
-    flat_experts = selected_experts_local.reshape(-1).astype(jnp.int32)
-
-    order = jnp.argsort(flat_experts, stable=True)
-    inverse_order = jnp.argsort(order)
-    expert_counts = jnp.bincount(flat_experts, length=num_experts).astype(jnp.int32)
-    segment_start = jnp.cumsum(expert_counts) - expert_counts
-    sorted_rank = jnp.arange(assignments_per_shard, dtype=jnp.int32) - segment_start[flat_experts[order]]
-    slot = sorted_rank[inverse_order]
-    keep = slot < capacity
-    local_expert_indices = (flat_experts % local_experts).astype(jnp.int32)
-    destination_shards = (flat_experts // local_experts).astype(jnp.int32)
+    target_experts, slot, routed_weights, keep = _assign_with_spill(
+        selected_experts_local,
+        combine_weights_local,
+        num_experts=num_experts,
+        capacity=capacity,
+        attempts=_spill_attempts(),
+    )
+    local_expert_indices = (target_experts % local_experts).astype(jnp.int32)
+    destination_shards = (target_experts // local_experts).astype(jnp.int32)
     bucket_size = expert_shards * capacity
     send_size = local_experts * bucket_size
     linear_indices = jnp.where(
@@ -167,7 +230,7 @@ def _fixed_a2a_core(
         out_local = jnp.einsum(
             "tkh,tk->th",
             gathered,
-            combine_weights_local.astype(gathered.dtype),
+            routed_weights.reshape(tokens_per_shard, topk).astype(gathered.dtype),
             preferred_element_type=jnp.float32,
         ).astype(x_local.dtype)
         dropped_local = assignments_per_shard - jnp.sum(keep, dtype=jnp.int32)

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -171,7 +171,7 @@ def _fixed_a2a_core(
     if use_barrier:
         x_local, combine_weights_local = jax.lax.optimization_barrier((x_local, combine_weights_local))
 
-    repeated_x = jnp.repeat(x_local, topk, axis=0)
+    gather_dispatch = os.environ.get("SCALE_A2A_GATHER_DISPATCH") == "1"
     target_experts, slot, routed_weights, keep = _assign_with_spill(
         selected_experts_local,
         combine_weights_local,
@@ -191,7 +191,24 @@ def _fixed_a2a_core(
 
     moe_dim = moe_w2_local.shape[1]
     with jax.named_scope("dispatch"):
-        send_x = jnp.zeros((send_size, hidden_dim), x_local.dtype).at[linear_indices].set(repeated_x, mode="drop")
+        if gather_dispatch:
+            # Scatter int32 assignment ids into the send buffer, then gather activation rows,
+            # avoiding the 8x activation repeat and the full-row bf16 scatter (issue 7201 treatment).
+            assignment_sources = (
+                jnp.full((send_size,), assignments_per_shard, dtype=jnp.int32)
+                .at[linear_indices]
+                .set(jnp.arange(assignments_per_shard, dtype=jnp.int32), mode="drop")
+            )
+            token_sources = jnp.where(
+                assignment_sources < assignments_per_shard,
+                assignment_sources // topk,
+                tokens_per_shard,
+            )
+            padded_x = jnp.concatenate([x_local, jnp.zeros((1, hidden_dim), dtype=x_local.dtype)], axis=0)
+            send_x = padded_x[token_sources]
+        else:
+            repeated_x = jnp.repeat(x_local, topk, axis=0)
+            send_x = jnp.zeros((send_size, hidden_dim), x_local.dtype).at[linear_indices].set(repeated_x, mode="drop")
         send_x = send_x.reshape(local_experts, expert_shards, capacity, hidden_dim)
 
     output_parts = []

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -93,6 +93,88 @@ def _assign_with_spill(
     return target, slot, routed_weights, placed
 
 
+def _gather_dispatch_enabled() -> bool:
+    """Gather-dispatch forward: int32 assignment scatter and activation gather."""
+    return os.environ.get("SCALE_A2A_GATHER_DISPATCH") == "1"
+
+
+def _custom_adjoint_enabled() -> bool:
+    """Use structured VJPs for the dispatch and combine gathers."""
+    return os.environ.get("SCALE_A2A_CUSTOM_ADJOINT") == "1"
+
+
+@jax.custom_vjp
+def _dispatch_gather(
+    x_local: Float[Array, "Tlocal H"],
+    token_sources: Int[Array, " send"],
+    linear_indices: Int[Array, " assignments"],
+    keep: Array,
+) -> Float[Array, "send H"]:
+    """Gather token rows into the fixed-capacity send buffer.
+
+    The custom VJP replaces XLA's generic scatter-add transpose with a
+    gather-then-segment-sum over each token's top-k assignments.
+    """
+    hidden_dim = x_local.shape[1]
+    padded_x = jnp.concatenate([x_local, jnp.zeros((1, hidden_dim), x_local.dtype)], axis=0)
+    return padded_x[token_sources]
+
+
+def _dispatch_gather_fwd(x_local, token_sources, linear_indices, keep):
+    send_x = _dispatch_gather(x_local, token_sources, linear_indices, keep)
+    return send_x, (linear_indices, keep, x_local.shape[0])
+
+
+def _dispatch_gather_bwd(residual, cotangent):
+    linear_indices, keep, tokens_per_shard = residual
+    send_size = cotangent.shape[0]
+    hidden_dim = cotangent.shape[1]
+    topk = linear_indices.shape[0] // tokens_per_shard
+    # Sum the cotangents for the kept send slots assigned to each token.
+    grad_rows = cotangent[jnp.minimum(linear_indices, send_size - 1)]
+    grad_rows = jnp.where(keep[:, None], grad_rows, 0).astype(jnp.float32)
+    grad_rows = grad_rows.reshape(tokens_per_shard, topk, hidden_dim)
+    d_x_local = grad_rows.sum(axis=1).astype(cotangent.dtype)
+    return d_x_local, None, None, None
+
+
+_dispatch_gather.defvjp(_dispatch_gather_fwd, _dispatch_gather_bwd)
+
+
+@jax.custom_vjp
+def _combine_gather(
+    send_output: Float[Array, "send H"],
+    gather_indices: Int[Array, " assignments"],
+    keep: Array,
+    assignment_sources: Int[Array, " send"],
+) -> Float[Array, "assignments H"]:
+    """Gather expert outputs from the send buffer into assignment order.
+
+    Kept assignments map injectively to send slots, so the custom VJP gathers
+    along the slot-to-assignment inverse instead of using scatter-add.
+    """
+    gathered = send_output[gather_indices]
+    return jnp.where(keep[:, None], gathered, 0)
+
+
+def _combine_gather_fwd(send_output, gather_indices, keep, assignment_sources):
+    gathered = _combine_gather(send_output, gather_indices, keep, assignment_sources)
+    return gathered, (assignment_sources,)
+
+
+def _combine_gather_bwd(residual, cotangent):
+    (assignment_sources,) = residual
+    assignments_per_shard = cotangent.shape[0]
+    # Unfilled slots use assignments_per_shard as their sentinel.
+    valid = assignment_sources < assignments_per_shard
+    src = jnp.minimum(assignment_sources, assignments_per_shard - 1)
+    d_send_output = jnp.where(valid[:, None], cotangent[src], 0).astype(cotangent.dtype)
+    return d_send_output, None, None, None
+
+
+_combine_gather.defvjp(_combine_gather_fwd, _combine_gather_bwd)
+
+
 def _moe_mlp_ep_fixed_a2a_local(
     x_local: Float[Array, "Tlocal H"],
     selected_experts_local: Int[Array, "Tlocal K"],
@@ -171,7 +253,11 @@ def _fixed_a2a_core(
     if use_barrier:
         x_local, combine_weights_local = jax.lax.optimization_barrier((x_local, combine_weights_local))
 
-    gather_dispatch = os.environ.get("SCALE_A2A_GATHER_DISPATCH") == "1"
+    gather_dispatch = _gather_dispatch_enabled()
+    custom_adjoint = _custom_adjoint_enabled()
+    if custom_adjoint and not gather_dispatch:
+        raise ValueError("SCALE_A2A_CUSTOM_ADJOINT=1 requires SCALE_A2A_GATHER_DISPATCH=1")
+
     target_experts, slot, routed_weights, keep = _assign_with_spill(
         selected_experts_local,
         combine_weights_local,
@@ -189,23 +275,27 @@ def _fixed_a2a_core(
         send_size,
     )
 
+    # Invert the assignment-to-slot mapping for gather dispatch and combine VJP.
+    if gather_dispatch:
+        assignment_sources = (
+            jnp.full((send_size,), assignments_per_shard, dtype=jnp.int32)
+            .at[linear_indices]
+            .set(jnp.arange(assignments_per_shard, dtype=jnp.int32), mode="drop")
+        )
+
     moe_dim = moe_w2_local.shape[1]
     with jax.named_scope("dispatch"):
         if gather_dispatch:
-            # Scatter int32 assignment ids into the send buffer, then gather activation rows,
-            # avoiding the 8x activation repeat and the full-row bf16 scatter (issue 7201 treatment).
-            assignment_sources = (
-                jnp.full((send_size,), assignments_per_shard, dtype=jnp.int32)
-                .at[linear_indices]
-                .set(jnp.arange(assignments_per_shard, dtype=jnp.int32), mode="drop")
-            )
             token_sources = jnp.where(
                 assignment_sources < assignments_per_shard,
                 assignment_sources // topk,
                 tokens_per_shard,
             )
-            padded_x = jnp.concatenate([x_local, jnp.zeros((1, hidden_dim), dtype=x_local.dtype)], axis=0)
-            send_x = padded_x[token_sources]
+            if custom_adjoint:
+                send_x = _dispatch_gather(x_local, token_sources, linear_indices, keep)
+            else:
+                padded_x = jnp.concatenate([x_local, jnp.zeros((1, hidden_dim), x_local.dtype)], axis=0)
+                send_x = padded_x[token_sources]
         else:
             repeated_x = jnp.repeat(x_local, topk, axis=0)
             send_x = jnp.zeros((send_size, hidden_dim), x_local.dtype).at[linear_indices].set(repeated_x, mode="drop")
@@ -241,8 +331,11 @@ def _fixed_a2a_core(
         send_output = jnp.stack(output_parts, axis=0)
         send_output = tree_checkpoint_name(send_output, _CHECKPOINT_MOE_OUTPUT)
         send_output = send_output.reshape(send_size, hidden_dim)
-        gathered = send_output[jnp.minimum(linear_indices, send_size - 1)]
-        gathered = jnp.where(keep[:, None], gathered, 0)
+        gather_indices = jnp.minimum(linear_indices, send_size - 1)
+        if custom_adjoint:
+            gathered = _combine_gather(send_output, gather_indices, keep, assignment_sources)
+        else:
+            gathered = jnp.where(keep[:, None], send_output[gather_indices], 0)
         gathered = gathered.reshape(tokens_per_shard, topk, hidden_dim)
         out_local = jnp.einsum(
             "tkh,tk->th",

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -4,13 +4,16 @@
 """Ragged all-to-all expert-parallel Grug MoE backend."""
 
 import math
+import os
 from collections.abc import Callable
 
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float, Int
 
+from haliax.jax_utils import tree_checkpoint_name
 from haliax.nn.ragged_dot import ragged_dot
+from levanter.grug._moe.common import _CHECKPOINT_DISPATCH_INPUT, _CHECKPOINT_MOE_OUTPUT
 from levanter.grug._moe.ep_common import (
     _clip_receiver_group_sizes,
     _compact_by_keep_mask,
@@ -25,6 +28,155 @@ from levanter.grug._moe.ep_common import (
 from levanter.grug.sharding import _batch_axes
 
 
+def _moe_mlp_ep_fixed_a2a_local(
+    x_local: Float[Array, "Tlocal H"],
+    selected_experts_local: Int[Array, "Tlocal K"],
+    combine_weights_local: Float[Array, "Tlocal K"],
+    moe_w13_local: Float[Array, "Elocal H I2"],
+    moe_w2_local: Float[Array, "Elocal I H"],
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
+    """Expert-parallel MoE with fixed-capacity all-to-all dispatch and combine."""
+    chunks = max(int(os.environ.get("SCALE_A2A_CHUNKS", "1")), 1)
+    tokens_per_shard = x_local.shape[0]
+    if tokens_per_shard % chunks != 0:
+        raise ValueError(f"tokens_per_shard={tokens_per_shard} must be divisible by SCALE_A2A_CHUNKS={chunks}")
+    if chunks == 1:
+        return _fixed_a2a_core(
+            x_local,
+            selected_experts_local,
+            combine_weights_local,
+            moe_w13_local,
+            moe_w2_local,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+            capacity_factor=capacity_factor,
+        )
+
+    tokens_per_chunk = tokens_per_shard // chunks
+    chunk_outputs = []
+    chunk_dropped = []
+    for chunk_index in range(chunks):
+        chunk_start = chunk_index * tokens_per_chunk
+        chunk_end = (chunk_index + 1) * tokens_per_chunk
+        output, dropped = _fixed_a2a_core(
+            x_local[chunk_start:chunk_end],
+            selected_experts_local[chunk_start:chunk_end],
+            combine_weights_local[chunk_start:chunk_end],
+            moe_w13_local,
+            moe_w2_local,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+            capacity_factor=capacity_factor,
+        )
+        chunk_outputs.append(output)
+        chunk_dropped.append(dropped)
+    return jnp.concatenate(chunk_outputs, axis=0), jnp.sum(jnp.stack(chunk_dropped))
+
+
+def _fixed_a2a_core(
+    x_local: Float[Array, "Tlocal H"],
+    selected_experts_local: Int[Array, "Tlocal K"],
+    combine_weights_local: Float[Array, "Tlocal K"],
+    moe_w13_local: Float[Array, "Elocal H I2"],
+    moe_w2_local: Float[Array, "Elocal I H"],
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
+    """Run one fixed-capacity all-to-all dispatch, expert MLP, and combine."""
+    local_experts = moe_w13_local.shape[0]
+    if num_experts % local_experts != 0:
+        raise ValueError(f"num_experts={num_experts} must be divisible by local expert count={local_experts}")
+
+    tokens_per_shard = x_local.shape[0]
+    expert_shards = num_experts // local_experts
+    topk = selected_experts_local.shape[1]
+    hidden_dim = x_local.shape[1]
+    assignments_per_shard = tokens_per_shard * topk
+    capacity = max(int(math.ceil(capacity_factor * assignments_per_shard / num_experts)), 1)
+
+    # Keep XLA's auto-rematerializer from materializing flash-attention scores when
+    # estimating memory pressure for the full attention-plus-MoE scan body.
+    use_barrier = os.environ.get("SCALE_A2A_NO_BARRIER") != "1"
+    if use_barrier:
+        x_local, combine_weights_local = jax.lax.optimization_barrier((x_local, combine_weights_local))
+
+    repeated_x = jnp.repeat(x_local, topk, axis=0)
+    flat_experts = selected_experts_local.reshape(-1).astype(jnp.int32)
+
+    order = jnp.argsort(flat_experts, stable=True)
+    inverse_order = jnp.argsort(order)
+    expert_counts = jnp.bincount(flat_experts, length=num_experts).astype(jnp.int32)
+    segment_start = jnp.cumsum(expert_counts) - expert_counts
+    sorted_rank = jnp.arange(assignments_per_shard, dtype=jnp.int32) - segment_start[flat_experts[order]]
+    slot = sorted_rank[inverse_order]
+    keep = slot < capacity
+    local_expert_indices = (flat_experts % local_experts).astype(jnp.int32)
+    destination_shards = (flat_experts // local_experts).astype(jnp.int32)
+    bucket_size = expert_shards * capacity
+    send_size = local_experts * bucket_size
+    linear_indices = jnp.where(
+        keep,
+        local_expert_indices * bucket_size + destination_shards * capacity + slot,
+        send_size,
+    )
+
+    moe_dim = moe_w2_local.shape[1]
+    with jax.named_scope("dispatch"):
+        send_x = jnp.zeros((send_size, hidden_dim), x_local.dtype).at[linear_indices].set(repeated_x, mode="drop")
+        send_x = send_x.reshape(local_experts, expert_shards, capacity, hidden_dim)
+
+    output_parts = []
+    for local_expert_index in range(local_experts):
+        with jax.named_scope("dispatch"):
+            received = jax.lax.all_to_all(
+                send_x[local_expert_index],
+                "expert",
+                split_axis=0,
+                concat_axis=0,
+                tiled=True,
+            )
+            received = tree_checkpoint_name(received, _CHECKPOINT_DISPATCH_INPUT)
+        with jax.named_scope("moe_up_down"):
+            expert_input = received.reshape(bucket_size, hidden_dim)
+            hidden = expert_input @ moe_w13_local[local_expert_index]
+            gate, up = jnp.split(hidden, [moe_dim], axis=-1)
+            expert_output = (activation_fn(gate) * up) @ moe_w2_local[local_expert_index]
+        with jax.named_scope("combine"):
+            returned = jax.lax.all_to_all(
+                expert_output.reshape(expert_shards, capacity, hidden_dim),
+                "expert",
+                split_axis=0,
+                concat_axis=0,
+                tiled=True,
+            )
+            output_parts.append(returned)
+
+    with jax.named_scope("combine"):
+        send_output = jnp.stack(output_parts, axis=0)
+        send_output = tree_checkpoint_name(send_output, _CHECKPOINT_MOE_OUTPUT)
+        send_output = send_output.reshape(send_size, hidden_dim)
+        gathered = send_output[jnp.minimum(linear_indices, send_size - 1)]
+        gathered = jnp.where(keep[:, None], gathered, 0)
+        gathered = gathered.reshape(tokens_per_shard, topk, hidden_dim)
+        out_local = jnp.einsum(
+            "tkh,tk->th",
+            gathered,
+            combine_weights_local.astype(gathered.dtype),
+            preferred_element_type=jnp.float32,
+        ).astype(x_local.dtype)
+        dropped_local = assignments_per_shard - jnp.sum(keep, dtype=jnp.int32)
+        dropped_total = jax.lax.psum(dropped_local, _batch_axes(jax.sharding.get_abstract_mesh()))
+    if use_barrier:
+        out_local = jax.lax.optimization_barrier(out_local)
+    return out_local, dropped_total
+
+
 def _moe_mlp_ep_ragged_a2a_local(
     x_local: Float[Array, "Tlocal H"],
     selected_experts_local: Int[Array, "Tlocal K"],
@@ -36,6 +188,18 @@ def _moe_mlp_ep_ragged_a2a_local(
     num_experts: int,
     capacity_factor: float,
 ) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
+    if os.environ.get("SCALE_A2A_FIXED") == "1":
+        return _moe_mlp_ep_fixed_a2a_local(
+            x_local,
+            selected_experts_local,
+            combine_weights_local,
+            moe_w13_local,
+            moe_w2_local,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+            capacity_factor=capacity_factor,
+        )
+
     local_experts = moe_w13_local.shape[0]
     if num_experts % local_experts != 0:
         raise ValueError(

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -48,6 +48,7 @@ from levanter.grug._moe.ep_ragged_all_to_all import _moe_mlp_ep_ragged_a2a_local
 from levanter.grug._moe.ep_ring import _moe_mlp_ep_ring_local
 from levanter.grug._moe.local import _moe_mlp_local
 from levanter.grug.sharding import (
+    _batch_spec,
     _batch_spec_from_x,
     _current_mesh,
     _mesh_axis_size,
@@ -214,6 +215,16 @@ def moe_mlp(
     if has_expert_axis and expert_axis_size > 1:
         if expert_chunks != 1:
             raise ValueError("expert_chunks must be 1 when expert parallelism is active")
+        # EP requires the batch to be sharded over "expert": each shard must own only its
+        # 1/expert_axis_size slice of the tokens, because the dispatch/combine buffers are
+        # sized from x_local.shape[0] (recv_capacity = capacity_factor * tokens_local * topk).
+        # _batch_spec_from_x adopts x's incoming spec, which may be the expert-less
+        # P(("replica_dcn", "data")) (Pbatch). Under shard_map that hands every expert shard
+        # the full batch, inflating every dispatch buffer by expert_axis_size -- a silent 64x
+        # blowup at EP64 (320 GiB instead of 5 GiB) that surfaces only as an OOM. Force the
+        # canonical batch spec, which names "expert"; the _reshard_for_shard_map calls below
+        # then move all three batch inputs onto it.
+        batch_spec = _batch_spec(mesh)
         if resolved_implementation not in _EP_MOE_IMPLEMENTATIONS:
             raise ValueError(
                 "Local MoE implementations do not yet support expert-parallel collectives; adding EP support "

--- a/lib/levanter/src/levanter/grug/sharding.py
+++ b/lib/levanter/src/levanter/grug/sharding.py
@@ -15,7 +15,16 @@ Pbatch = P(("replica_dcn", "data"))
 # vector across all devices -- an all-to-all spanning racks whose NCCL first-call rendezvous wedges
 # at 8+ racks. The replicated table's gradient is a normal DDP all-reduce.
 Pembed_vocab = P(None, None)
-Plm_head = P(Pbatch[0], "model")
+Plm_head_dense = P(Pbatch[0], "model")
+# FSDP axes for non-expert weights. Both axes are intra-rack under the compact
+# Grug mesh, while replica_dcn remains the cross-rack gradient-sync axis.
+#
+# Expert parallelism collapses "data" as "expert" grows. Including both axes
+# keeps attention and shared-expert weights and optimizer state sharded at EP64.
+Pfsdp = ("data", "expert")
+# The lm head also preserves the cross-slice replica axis from the dense layout.
+# Adding only the expert axis makes EP1 exactly equivalent to Plm_head_dense.
+Plm_head_ep = P(("replica_dcn", "data", "expert"), "model")
 Plogits = P(Pbatch[0], None, "model")
 
 

--- a/lib/levanter/src/levanter/models/snowball.py
+++ b/lib/levanter/src/levanter/models/snowball.py
@@ -51,7 +51,7 @@ from levanter.grug.attention import (
 from levanter.grug.grug_moe import MoeImplementation, MoEExpertMlp
 from levanter.grug.sharding import (
     Pembed_vocab,
-    Plm_head,
+    Plm_head_ep,
     _current_mesh,
     _drop_absent_mesh_axes,
     _mesh_axis_size,
@@ -631,7 +631,7 @@ class SnowballTransformer(eqx.Module):
             _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), cfg.initializer_std), Pembed_vocab
         )
         output_proj = _reshard_for_init(
-            _init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head
+            _init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head_ep
         )
         blocks = tuple(SnowballBlock.init(cfg, key=block_keys[i]) for i in range(cfg.num_layers))
         return SnowballTransformer(
@@ -839,7 +839,7 @@ def snowball_from_state_dict(
     m = eqx.tree_at(
         lambda t: t.final_gated_norm.w_up, m, _reshard_replicated(_T(g("model.final_gated_norm.up_proj.weight")))
     )
-    m = eqx.tree_at(lambda t: t.output_proj, m, _reshard_for_init(_T(g("lm_head.weight")), Plm_head))
+    m = eqx.tree_at(lambda t: t.output_proj, m, _reshard_for_init(_T(g("lm_head.weight")), Plm_head_ep))
 
     for i in range(len(m.blocks)):
         p = f"model.layers.{i}"

--- a/lib/levanter/src/levanter/optim/grugmuon.py
+++ b/lib/levanter/src/levanter/optim/grugmuon.py
@@ -221,7 +221,13 @@ def _grug_scale_with_muon(
                         )
                     )(x)
                 elif os.environ.get("SCALE_MUON_PAD_NONEXPERT") == "1":
-                    updated = _newtonschulz_padded_stack_sharded(x, steps, muon_eps, coefficient_type)
+                    updated = _newtonschulz_padded_stack_sharded(
+                        x,
+                        steps,
+                        muon_eps,
+                        coefficient_type,
+                        target_sharding=_target_sharding(param),
+                    )
                 else:
                     stack_target_pspec = _batch_sharded_stack_target_pspec(param)
                     if stack_target_pspec is None:
@@ -557,6 +563,8 @@ def _newtonschulz_padded_stack_sharded(
     steps: int = 5,
     eps: float = 1e-7,
     coefficient_type: CoefficientType = "quintic",
+    *,
+    target_sharding: jax.sharding.Sharding | None = None,
 ) -> jax.Array:
     """Distribute a non-divisible matrix stack by zero-padding its leading axis."""
     P = PartitionSpec
@@ -584,5 +592,11 @@ def _newtonschulz_padded_stack_sharded(
     if len(batch_axis) > 1:
         Xd = reshard(Xd, P(batch_axis, None, None))
     updated = jax.vmap(local)(Xd)
+    if target_sharding is not None:
+        target_spec = getattr(target_sharding, "spec", None)
+        if target_spec and target_spec[0] is not None:
+            raise ValueError("padded stack Newton-Schulz requires the parameter layer axis to be replicated")
+        updated = reshard(updated, target_sharding)
+        return updated[:layers] if pad else updated
     updated = reshard(updated, P(None, None, None))
     return updated[:layers] if pad else updated

--- a/lib/levanter/src/levanter/optim/grugmuon.py
+++ b/lib/levanter/src/levanter/optim/grugmuon.py
@@ -353,7 +353,12 @@ def _newtonschulz_4d_distributed(
     eps: float,
     coefficient_type: CoefficientType,
 ) -> jax.Array:
-    """Run Newton-Schulz on a stacked 4D expert leaf without gathering matrix dimensions."""
+    """Run Newton-Schulz on a stacked 4D expert leaf without gathering matrix dimensions.
+
+    Under expert parallelism, the expert dimension stays on the expert mesh axis. Only
+    the layer dimension can move to non-expert axes, avoiding the layer-expert merge that
+    can rematerialize the complete expert stack.
+    """
     local_ns = lambda matrix: _zeropower_via_newtonschulz_local(matrix, steps, eps, coefficient_type)
     mesh = jax.sharding.get_abstract_mesh()
     if mesh.empty:
@@ -370,7 +375,57 @@ def _newtonschulz_4d_distributed(
     layers, expert_count, d, last = x.shape
     merged = layers * expert_count
 
-    best_axes: tuple[str, ...] = ()
+    is_w_down = any(getattr(entry, "name", None) == "w_down" for entry in path)
+    trailing = ("model", "data") if is_w_down else ("data", "model")
+    orig_4d_spec = PartitionSpec(None, "expert", *trailing)
+
+    expert_axis_size = int(mesh.shape.get("expert", 1))
+    if expert_axis_size > 1:
+        candidate_axes = [(name, size) for name, size in mesh_shape_items if name != "expert"]
+        best_axes: tuple[str, ...] = ()
+        best_shards = 1
+        for mask in range(1, 1 << len(candidate_axes)):
+            subset = [candidate_axes[i] for i in range(len(candidate_axes)) if mask & (1 << i)]
+            prod = math.prod(size for _, size in subset)
+            if layers % prod == 0 and prod > best_shards:
+                best_axes = tuple(name for name, _ in subset)
+                best_shards = prod
+
+        x_bf16 = x.astype(jnp.bfloat16)
+        if not best_axes:
+            distributed_4d_spec = PartitionSpec(None, "expert", None, None)
+            x_distributed = reshard(x_bf16, distributed_4d_spec)
+        else:
+            distributed_4d_spec = (
+                PartitionSpec(best_axes[0], "expert", None, None)
+                if len(best_axes) == 1
+                else PartitionSpec(best_axes, "expert", None, None)
+            )
+            x_distributed = reshard(x_bf16, PartitionSpec(best_axes[0], "expert", None, None))
+            if len(best_axes) > 1:
+                x_distributed = reshard(x_distributed, distributed_4d_spec)
+
+        if os.environ.get("SCALE_MUON_SYRK") == "1":
+
+            def local_syrk(stack):
+                local_layers, local_experts, local_d, local_last = stack.shape
+                flat = jax.lax.reshape(stack, (local_layers * local_experts, local_d, local_last))
+                updated = _newtonschulz_batched_syrk(flat, steps, eps, coefficient_type)
+                return jax.lax.reshape(updated, stack.shape)
+
+            updated_distributed = shard_map(
+                local_syrk,
+                mesh=mesh,
+                in_specs=distributed_4d_spec,
+                out_specs=distributed_4d_spec,
+                check_vma=False,
+            )(x_distributed)
+        else:
+            updated_distributed = jax.vmap(jax.vmap(local_ns))(x_distributed)
+        updated_bf16 = reshard(updated_distributed, orig_4d_spec)
+        return updated_bf16.astype(x.dtype)
+
+    best_axes = ()
     best_shards = 0
     for mask in range(1, 1 << len(mesh_shape_items)):
         subset = [mesh_shape_items[i] for i in range(len(mesh_shape_items)) if mask & (1 << i)]
@@ -385,13 +440,7 @@ def _newtonschulz_4d_distributed(
             f"{jax.tree_util.keystr(path)}."
         )
 
-    is_w_down = any(getattr(entry, "name", None) == "w_down" for entry in path)
-    if is_w_down:
-        intermediate_3d_spec = PartitionSpec(None, "model", "data")
-        orig_4d_spec = PartitionSpec(None, "expert", "model", "data")
-    else:
-        intermediate_3d_spec = PartitionSpec(None, "data", "model")
-        orig_4d_spec = PartitionSpec(None, "expert", "data", "model")
+    intermediate_3d_spec = PartitionSpec(None, *trailing)
     target_3d_spec = (
         PartitionSpec(best_axes[0], None, None) if len(best_axes) == 1 else PartitionSpec(best_axes, None, None)
     )
@@ -531,8 +580,9 @@ def _newtonschulz_padded_stack_sharded(
     pad = (-layers) % batch_shards
 
     Xp = jnp.pad(X, ((0, pad), (0, 0), (0, 0))) if pad else X
-    target = P(batch_axis[0], None, None) if len(batch_axis) == 1 else P(batch_axis, None, None)
-    Xd = reshard(Xp, target)
+    Xd = reshard(Xp, P(batch_axis[0], None, None))
+    if len(batch_axis) > 1:
+        Xd = reshard(Xd, P(batch_axis, None, None))
     updated = jax.vmap(local)(Xd)
     updated = reshard(updated, P(None, None, None))
     return updated[:layers] if pad else updated

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib.util
+import os
+import subprocess
+import sys
+import textwrap
 
 import numpy as np
 import pytest
@@ -19,6 +23,7 @@ from levanter.grug._moe.common import (
     _prepare_moe_dispatch_indices_with_assignment_ids,
 )
 from levanter.grug._moe.ep_deepep import _pack_deepep_local_assignments
+from levanter.grug._moe.ep_ragged_all_to_all import _fixed_a2a_core
 from levanter.grug._moe.sonic import sonic_gather_sum
 from levanter.grug.grug_moe import (
     MoEExpertMlp,
@@ -464,8 +469,22 @@ def test_moe_expert_mlp_init_uses_logical_weight_pspecs():
     assert mlp.w_down.sharding.spec == P(None, "model", "data")
 
 
-@pytest.mark.parametrize("implementation", ["ring", "ragged_all_to_all"])
-def test_moe_ep_path_lowers_on_abstract_mesh(implementation: MoeImplementation):
+@pytest.mark.parametrize(
+    ("implementation", "fixed_a2a"),
+    [
+        ("ring", False),
+        ("ragged_all_to_all", False),
+        ("ragged_all_to_all", True),
+    ],
+)
+def test_moe_ep_path_lowers_on_abstract_mesh(
+    implementation: MoeImplementation, fixed_a2a: bool, monkeypatch: pytest.MonkeyPatch
+):
+    if fixed_a2a:
+        monkeypatch.setenv("SCALE_A2A_FIXED", "1")
+        monkeypatch.setenv("SCALE_A2A_CHUNKS", "2")
+        monkeypatch.setenv("SCALE_A2A_NO_BARRIER", "1")
+
     mesh = _make_abstract_moe_mesh(data=2, expert=2, model=1)
 
     tokens = 16
@@ -622,6 +641,167 @@ def test_moe_ep_boundary_shards_incoming_batch_over_expert_axis():
 
     assert x.sharding.spec == P("data", None)
     assert out.sharding.spec == P(("data", "expert"))
+
+
+def test_fixed_a2a_matches_dense_reference_on_one_expert_shard(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SCALE_A2A_NO_BARRIER", "1")
+    mesh = Mesh(
+        np.asarray([jax.devices()[0]]),
+        axis_names=("expert",),
+        axis_types=(AxisType.Explicit,),
+    )
+    tokens = 4
+    hidden_dim = 4
+    intermediate_dim = 6
+    num_experts = 2
+    topk = 2
+    x, selected_experts, combine_weights, w_up_gate, w_down = _make_inputs(
+        key=jax.random.key(41),
+        tokens=tokens,
+        hidden_dim=hidden_dim,
+        intermediate_dim=intermediate_dim,
+        num_experts=num_experts,
+        topk=topk,
+    )
+    selected_experts = jnp.tile(jnp.arange(topk, dtype=jnp.int32), (tokens, 1))
+
+    def fixed_a2a(x, selected_experts, combine_weights, w_up_gate, w_down):
+        return _fixed_a2a_core(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=jax.nn.silu,
+            num_experts=num_experts,
+            capacity_factor=0.5,
+        )
+
+    fixed_a2a_sharded = jax.shard_map(
+        fixed_a2a,
+        mesh=mesh,
+        in_specs=(P(), P(), P(), P(), P()),
+        out_specs=(P(), P()),
+        check_vma=False,
+    )
+    with jax.set_mesh(mesh):
+        actual, dropped = fixed_a2a_sharded(x, selected_experts, combine_weights, w_up_gate, w_down)
+
+    selected_w13 = w_up_gate[selected_experts]
+    hidden = jnp.einsum("th,tkhi->tki", x, selected_w13)
+    gate, up = jnp.split(hidden, [intermediate_dim], axis=-1)
+    expert_output = jnp.einsum(
+        "tki,tkih->tkh",
+        jax.nn.silu(gate) * up,
+        w_down[selected_experts],
+    )
+    kept_assignments = np.zeros((tokens, topk), dtype=bool)
+    expert_counts = np.zeros(num_experts, dtype=np.int32)
+    for token_index in range(tokens):
+        for topk_index in range(topk):
+            expert = int(selected_experts[token_index, topk_index])
+            if expert_counts[expert] < 2:
+                kept_assignments[token_index, topk_index] = True
+                expert_counts[expert] += 1
+    expected = jnp.einsum(
+        "tkh,tk->th",
+        expert_output,
+        combine_weights * jnp.asarray(kept_assignments),
+    )
+
+    np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-5)
+    assert int(dropped) == 4
+
+
+def test_fixed_a2a_executes_cross_shard_slot_routing():
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cpu"
+    env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+    script = """
+        import jax
+        import jax.numpy as jnp
+        import numpy as np
+        from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
+
+        from levanter.grug._moe.ep_ragged_all_to_all import _fixed_a2a_core
+
+        assert jax.device_count() == 4
+        mesh = Mesh(
+            np.asarray(jax.devices()),
+            axis_names=("expert",),
+            axis_types=(AxisType.Explicit,),
+        )
+        x = jax.random.normal(jax.random.key(0), (4, 4))
+        selected_experts = jnp.asarray(
+            [[2, 3], [4, 5], [6, 7], [0, 1]],
+            dtype=jnp.int32,
+        )
+        combine_weights = jax.nn.softmax(jax.random.normal(jax.random.key(1), (4, 2)), axis=-1)
+        w_up_gate = jax.random.normal(jax.random.key(2), (8, 4, 6))
+        w_down = jax.random.normal(jax.random.key(3), (8, 3, 4))
+        selected_w13 = w_up_gate[selected_experts]
+        hidden = jnp.einsum("th,tkhi->tki", x, selected_w13)
+        gate, up = jnp.split(hidden, [3], axis=-1)
+        expert_output = jnp.einsum(
+            "tki,tkih->tkh",
+            jax.nn.silu(gate) * up,
+            w_down[selected_experts],
+        )
+        expected = jnp.einsum("tkh,tk->th", expert_output, combine_weights)
+
+        def fixed_a2a(x, selected_experts, combine_weights, w_up_gate, w_down):
+            return _fixed_a2a_core(
+                x,
+                selected_experts,
+                combine_weights,
+                w_up_gate,
+                w_down,
+                activation_fn=jax.nn.silu,
+                num_experts=8,
+                capacity_factor=4.0,
+            )
+
+        sharded_fixed_a2a = jax.shard_map(
+            fixed_a2a,
+            mesh=mesh,
+            in_specs=(
+                P("expert", None),
+                P("expert", None),
+                P("expert", None),
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(P("expert", None), P()),
+            check_vma=False,
+        )
+        with jax.set_mesh(mesh):
+            batch_sharding = NamedSharding(mesh, P("expert", None))
+            expert_sharding = NamedSharding(mesh, P("expert", None, None))
+            x = jax.device_put(x, batch_sharding)
+            selected_experts = jax.device_put(selected_experts, batch_sharding)
+            combine_weights = jax.device_put(combine_weights, batch_sharding)
+            w_up_gate = jax.device_put(w_up_gate, expert_sharding)
+            w_down = jax.device_put(w_down, expert_sharding)
+            actual, dropped = sharded_fixed_a2a(
+                x,
+                selected_experts,
+                combine_weights,
+                w_up_gate,
+                w_down,
+            )
+
+        np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
+        assert int(dropped) == 0
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_shard_a2a_params_uses_sender_side_output_offsets():

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -892,6 +892,246 @@ def test_fixed_a2a_spill_uses_candidate_expert_and_weight(monkeypatch: pytest.Mo
     assert int(dropped) == 0
 
 
+def _run_fixed_a2a_value_and_grads(
+    *,
+    x,
+    selected_experts,
+    combine_weights,
+    w_up_gate,
+    w_down,
+    seed_cotangent,
+    num_experts,
+    capacity_factor,
+):
+    """Return the value, dropped count, and gradients for fixed all-to-all."""
+    mesh = Mesh(
+        np.asarray([jax.devices()[0]]),
+        axis_names=("expert",),
+        axis_types=(AxisType.Explicit,),
+    )
+
+    def core(x, selected_experts, combine_weights, w_up_gate, w_down):
+        return _fixed_a2a_core(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=jax.nn.silu,
+            num_experts=num_experts,
+            capacity_factor=capacity_factor,
+        )
+
+    sharded = jax.shard_map(
+        core,
+        mesh=mesh,
+        in_specs=(P(), P(), P(), P(), P()),
+        out_specs=(P(), P()),
+        check_vma=False,
+    )
+
+    def loss(x, combine_weights, w_up_gate, w_down):
+        out, dropped = sharded(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return jnp.sum(out * seed_cotangent), (out, dropped)
+
+    with jax.set_mesh(mesh):
+        (_, (out, dropped)), grads = jax.value_and_grad(loss, argnums=(0, 1, 2, 3), has_aux=True)(
+            x, combine_weights, w_up_gate, w_down
+        )
+    return out, int(dropped), grads
+
+
+def _expected_fixed_capacity_drops(
+    selected_experts: jax.Array,
+    *,
+    num_experts: int,
+    capacity_factor: float,
+) -> int:
+    assignments = np.asarray(selected_experts).reshape(-1)
+    capacity = max(int(np.ceil(capacity_factor * len(assignments) / num_experts)), 1)
+    expert_counts = np.bincount(assignments, minlength=num_experts)
+    return int(np.maximum(expert_counts - capacity, 0).sum())
+
+
+@pytest.mark.slow
+def test_gather_dispatch_matches_scatter_forward_and_drops(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SCALE_A2A_NO_BARRIER", "1")
+    tokens, hidden_dim, intermediate_dim, num_experts, topk = 8, 6, 8, 4, 2
+    x, selected_experts, combine_weights, w_up_gate, w_down = _make_inputs(
+        key=jax.random.key(7),
+        tokens=tokens,
+        hidden_dim=hidden_dim,
+        intermediate_dim=intermediate_dim,
+        num_experts=num_experts,
+        topk=topk,
+    )
+    seed = jax.random.normal(jax.random.key(99), (tokens, hidden_dim), dtype=jnp.float32)
+
+    monkeypatch.delenv("SCALE_A2A_GATHER_DISPATCH", raising=False)
+    monkeypatch.delenv("SCALE_A2A_CUSTOM_ADJOINT", raising=False)
+    scatter_out, scatter_dropped, _ = _run_fixed_a2a_value_and_grads(
+        x=x,
+        selected_experts=selected_experts,
+        combine_weights=combine_weights,
+        w_up_gate=w_up_gate,
+        w_down=w_down,
+        seed_cotangent=seed,
+        num_experts=num_experts,
+        capacity_factor=0.5,
+    )
+
+    monkeypatch.setenv("SCALE_A2A_GATHER_DISPATCH", "1")
+    gather_out, gather_dropped, _ = _run_fixed_a2a_value_and_grads(
+        x=x,
+        selected_experts=selected_experts,
+        combine_weights=combine_weights,
+        w_up_gate=w_up_gate,
+        w_down=w_down,
+        seed_cotangent=seed,
+        num_experts=num_experts,
+        capacity_factor=0.5,
+    )
+    expected_dropped = _expected_fixed_capacity_drops(
+        selected_experts,
+        num_experts=num_experts,
+        capacity_factor=0.5,
+    )
+
+    assert expected_dropped == 8
+    np.testing.assert_allclose(np.asarray(gather_out), np.asarray(scatter_out), rtol=1e-5, atol=1e-5)
+    assert scatter_dropped == expected_dropped
+    assert gather_dropped == expected_dropped
+
+
+@pytest.mark.slow
+def test_custom_adjoint_matches_autodiff_gradients(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SCALE_A2A_NO_BARRIER", "1")
+    tokens, hidden_dim, intermediate_dim, num_experts, topk = 8, 6, 8, 4, 2
+    x, selected_experts, combine_weights, w_up_gate, w_down = _make_inputs(
+        key=jax.random.key(13),
+        tokens=tokens,
+        hidden_dim=hidden_dim,
+        intermediate_dim=intermediate_dim,
+        num_experts=num_experts,
+        topk=topk,
+    )
+    seed = jax.random.normal(jax.random.key(31), (tokens, hidden_dim), dtype=jnp.float32)
+
+    monkeypatch.setenv("SCALE_A2A_GATHER_DISPATCH", "1")
+    monkeypatch.delenv("SCALE_A2A_CUSTOM_ADJOINT", raising=False)
+    auto_out, auto_dropped, auto_grads = _run_fixed_a2a_value_and_grads(
+        x=x,
+        selected_experts=selected_experts,
+        combine_weights=combine_weights,
+        w_up_gate=w_up_gate,
+        w_down=w_down,
+        seed_cotangent=seed,
+        num_experts=num_experts,
+        capacity_factor=0.5,
+    )
+
+    monkeypatch.setenv("SCALE_A2A_CUSTOM_ADJOINT", "1")
+    custom_out, custom_dropped, custom_grads = _run_fixed_a2a_value_and_grads(
+        x=x,
+        selected_experts=selected_experts,
+        combine_weights=combine_weights,
+        w_up_gate=w_up_gate,
+        w_down=w_down,
+        seed_cotangent=seed,
+        num_experts=num_experts,
+        capacity_factor=0.5,
+    )
+    expected_dropped = _expected_fixed_capacity_drops(
+        selected_experts,
+        num_experts=num_experts,
+        capacity_factor=0.5,
+    )
+
+    assert expected_dropped == 8
+    np.testing.assert_allclose(np.asarray(custom_out), np.asarray(auto_out), rtol=1e-5, atol=1e-5)
+    assert auto_dropped == expected_dropped
+    assert custom_dropped == expected_dropped
+    for auto_grad, custom_grad in zip(auto_grads, custom_grads):
+        np.testing.assert_allclose(np.asarray(custom_grad), np.asarray(auto_grad), rtol=1e-5, atol=1e-5)
+
+
+def _fixed_a2a_backward_stablehlo(
+    *,
+    x,
+    selected_experts,
+    combine_weights,
+    w_up_gate,
+    w_down,
+    seed_cotangent,
+    num_experts,
+    capacity_factor,
+) -> str:
+    mesh = Mesh(
+        np.asarray([jax.devices()[0]]),
+        axis_names=("expert",),
+        axis_types=(AxisType.Explicit,),
+    )
+
+    def core(x, combine_weights, w_up_gate, w_down):
+        output, _ = _fixed_a2a_core(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=jax.nn.silu,
+            num_experts=num_experts,
+            capacity_factor=capacity_factor,
+        )
+        return output
+
+    sharded = jax.shard_map(
+        core,
+        mesh=mesh,
+        in_specs=(P(), P(), P(), P()),
+        out_specs=P(),
+        check_vma=False,
+    )
+    with jax.set_mesh(mesh):
+        _, pullback = jax.vjp(sharded, x, combine_weights, w_up_gate, w_down)
+        lowered = jax.jit(pullback).lower(seed_cotangent)
+    return str(lowered.compiler_ir(dialect="stablehlo"))
+
+
+@pytest.mark.slow
+def test_custom_adjoint_backward_hlo_has_no_scatter(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SCALE_A2A_NO_BARRIER", "1")
+    monkeypatch.setenv("SCALE_A2A_GATHER_DISPATCH", "1")
+    tokens, hidden_dim, intermediate_dim, num_experts, topk = 8, 6, 8, 4, 2
+    x, selected_experts, combine_weights, w_up_gate, w_down = _make_inputs(
+        key=jax.random.key(17),
+        tokens=tokens,
+        hidden_dim=hidden_dim,
+        intermediate_dim=intermediate_dim,
+        num_experts=num_experts,
+        topk=topk,
+    )
+    seed = jax.random.normal(jax.random.key(19), (tokens, hidden_dim), dtype=jnp.float32)
+    hlo_args = dict(
+        x=x,
+        selected_experts=selected_experts,
+        combine_weights=combine_weights,
+        w_up_gate=w_up_gate,
+        w_down=w_down,
+        seed_cotangent=seed,
+        num_experts=num_experts,
+        capacity_factor=0.5,
+    )
+
+    monkeypatch.delenv("SCALE_A2A_CUSTOM_ADJOINT", raising=False)
+    autodiff_hlo = _fixed_a2a_backward_stablehlo(**hlo_args)
+    assert autodiff_hlo.count("stablehlo.scatter") > 0
+
+    monkeypatch.setenv("SCALE_A2A_CUSTOM_ADJOINT", "1")
+    custom_hlo = _fixed_a2a_backward_stablehlo(**hlo_args)
+    assert custom_hlo.count("stablehlo.scatter") == 0
+
+
 def test_shard_a2a_params_uses_sender_side_output_offsets():
     shard_counts = jnp.array(
         [

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -522,6 +522,108 @@ def test_moe_ep_path_lowers_on_abstract_mesh(implementation: MoeImplementation):
         assert lowered is not None
 
 
+def _ring_dispatch_buffer_rows(*, expert_axis_size: int, local_tokens: int) -> int:
+    mesh = _make_abstract_moe_mesh(data=1, expert=expert_axis_size, model=1)
+    tokens = expert_axis_size * local_tokens
+    hidden_dim = 8
+    intermediate_dim = 6
+    topk = 2
+    num_experts = 2 * expert_axis_size
+
+    with _reset_abstract_mesh(), use_abstract_mesh(mesh):
+        x = jax.ShapeDtypeStruct(
+            (tokens, hidden_dim),
+            jnp.float32,
+            sharding=NamedSharding(mesh, P("data", None)),
+        )
+        selected_experts = jax.ShapeDtypeStruct(
+            (tokens, topk),
+            jnp.int32,
+            sharding=NamedSharding(mesh, P("data", None)),
+        )
+        combine_weights = jax.ShapeDtypeStruct(
+            (tokens, topk),
+            jnp.float32,
+            sharding=NamedSharding(mesh, P("data", None)),
+        )
+        w_up_gate = jax.ShapeDtypeStruct(
+            (num_experts, hidden_dim, 2 * intermediate_dim),
+            jnp.float32,
+            sharding=NamedSharding(mesh, P("expert", None, None)),
+        )
+        w_down = jax.ShapeDtypeStruct(
+            (num_experts, intermediate_dim, hidden_dim),
+            jnp.float32,
+            sharding=NamedSharding(mesh, P("expert", None, None)),
+        )
+        closed_jaxpr = jax.make_jaxpr(
+            lambda x, selected, weights, w13, w2: moe_mlp(
+                x,
+                selected,
+                weights,
+                w13,
+                w2,
+                implementation="ring",
+                mesh=mesh,
+                capacity_factor=1.0,
+            )
+        )(x, selected_experts, combine_weights, w_up_gate, w_down)
+
+    shard_map_eqn = next(eqn for eqn in closed_jaxpr.jaxpr.eqns if eqn.primitive.name == "shard_map")
+    local_jaxpr = shard_map_eqn.params["jaxpr"]
+    dispatch_eqn = next(
+        eqn
+        for eqn in local_jaxpr.eqns
+        if eqn.primitive.name == "name" and eqn.params["name"] == "grug_moe_dispatch_input"
+    )
+    return int(dispatch_eqn.outvars[0].aval.shape[0])
+
+
+def test_moe_ep_dispatch_buffer_does_not_scale_with_expert_axis_width():
+    local_tokens = 8
+    expected_rows = local_tokens * 2
+
+    assert _ring_dispatch_buffer_rows(expert_axis_size=2, local_tokens=local_tokens) == expected_rows
+    assert _ring_dispatch_buffer_rows(expert_axis_size=4, local_tokens=local_tokens) == expected_rows
+
+
+def test_moe_ep_boundary_shards_incoming_batch_over_expert_axis():
+    mesh = _make_ep_mesh_or_none()
+    if mesh is None:
+        pytest.skip("requires an even number of >=2 devices")
+
+    tokens = len(jax.devices()) * 8
+    x, selected_experts, combine_weights, w_up_gate, w_down = _make_inputs(
+        key=jax.random.key(28),
+        tokens=tokens,
+        hidden_dim=8,
+        intermediate_dim=6,
+        num_experts=4,
+        topk=2,
+    )
+    with jax.set_mesh(mesh):
+        incoming_batch_sharding = NamedSharding(mesh, P("data", None))
+        x = jax.sharding.reshard(x, incoming_batch_sharding)
+        selected_experts = jax.sharding.reshard(selected_experts, incoming_batch_sharding)
+        combine_weights = jax.sharding.reshard(combine_weights, incoming_batch_sharding)
+        w_up_gate = jax.sharding.reshard(w_up_gate, NamedSharding(mesh, P("expert", None, None)))
+        w_down = jax.sharding.reshard(w_down, NamedSharding(mesh, P("expert", None, None)))
+
+        out = moe_mlp(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            implementation="ring",
+            mesh=mesh,
+            capacity_factor=1.0,
+        )
+
+    assert x.sharding.spec == P("data", None)
+    assert out.sharding.spec == P(("data", "expert"))
+
+
 def test_shard_a2a_params_uses_sender_side_output_offsets():
     shard_counts = jnp.array(
         [

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -23,7 +23,7 @@ from levanter.grug._moe.common import (
     _prepare_moe_dispatch_indices_with_assignment_ids,
 )
 from levanter.grug._moe.ep_deepep import _pack_deepep_local_assignments
-from levanter.grug._moe.ep_ragged_all_to_all import _fixed_a2a_core
+from levanter.grug._moe.ep_ragged_all_to_all import _assign_with_spill, _fixed_a2a_core
 from levanter.grug._moe.sonic import sonic_gather_sum
 from levanter.grug.grug_moe import (
     MoEExpertMlp,
@@ -802,6 +802,94 @@ def test_fixed_a2a_executes_cross_shard_slot_routing():
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_spill_preserves_capacity():
+    selected_experts = jnp.array(
+        [
+            [0, 1],
+            [0, 1],
+            [0, 2],
+        ],
+        dtype=jnp.int32,
+    )
+    combine_weights = jnp.array(
+        [
+            [0.9, 0.1],
+            [0.8, 0.2],
+            [0.7, 0.3],
+        ],
+        dtype=jnp.float32,
+    )
+    capacity = 2
+
+    _, _, _, baseline_keep = _assign_with_spill(
+        selected_experts,
+        combine_weights,
+        num_experts=3,
+        capacity=capacity,
+        attempts=0,
+    )
+    target, slot, routed_weights, keep = _assign_with_spill(
+        selected_experts,
+        combine_weights,
+        num_experts=3,
+        capacity=capacity,
+        attempts=1,
+    )
+    assert int(baseline_keep.sum()) == 5
+    assert int(keep.sum()) == 6
+    assert int(target[4]) == 2
+    assert float(routed_weights[4]) == pytest.approx(0.3)
+    occupied_slots = np.asarray(target[keep] * capacity + slot[keep])
+    assert len(np.unique(occupied_slots)) == int(keep.sum())
+    assert int(slot[keep].min()) >= 0
+    assert int(slot[keep].max()) < capacity
+    assert occupied_slots.max() < 3 * capacity
+
+
+def test_fixed_a2a_spill_uses_candidate_expert_and_weight(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SCALE_A2A_NO_BARRIER", "1")
+    monkeypatch.setenv("SCALE_A2A_SPILL", "1")
+    mesh = Mesh(
+        np.asarray([jax.devices()[0]]),
+        axis_names=("expert",),
+        axis_types=(AxisType.Explicit,),
+    )
+    x = jnp.ones((3, 1), dtype=jnp.float32)
+    selected_experts = jnp.array([[0, 1], [0, 1], [0, 2]], dtype=jnp.int32)
+    combine_weights = jnp.array([[0.9, 0.1], [0.8, 0.2], [0.7, 0.3]], dtype=jnp.float32)
+    expert_scale = jnp.array([1.0, 10.0, 100.0], dtype=jnp.float32)[:, None, None]
+    w_up_gate = jnp.concatenate([expert_scale, jnp.ones_like(expert_scale)], axis=2)
+    w_down = jnp.ones((3, 1, 1), dtype=jnp.float32)
+
+    def fixed_a2a(x, selected_experts, combine_weights, w_up_gate, w_down):
+        return _fixed_a2a_core(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=lambda value: value,
+            num_experts=3,
+            capacity_factor=1.0,
+        )
+
+    fixed_a2a_sharded = jax.shard_map(
+        fixed_a2a,
+        mesh=mesh,
+        in_specs=(P(), P(), P(), P(), P()),
+        out_specs=(P(), P()),
+        check_vma=False,
+    )
+    with jax.set_mesh(mesh):
+        actual, dropped = fixed_a2a_sharded(x, selected_experts, combine_weights, w_up_gate, w_down)
+
+    # Token 2 executes expert 2 twice at expert 2's 0.3 weight. The spilled copy must not use
+    # the displaced expert 0's 0.7 weight, which would produce 100 instead of 60.
+    expected = np.array([[1.9], [2.8], [60.0]], dtype=np.float32)
+    np.testing.assert_allclose(np.asarray(actual), expected, rtol=1e-5, atol=1e-5)
+    assert int(dropped) == 0
 
 
 def test_shard_a2a_params_uses_sender_side_output_offsets():

--- a/lib/levanter/tests/test_grugmuon.py
+++ b/lib/levanter/tests/test_grugmuon.py
@@ -24,6 +24,22 @@ from levanter.optim.grugmuon import (
 )
 
 
+def _run_cpu_mesh_script(script: str):
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cpu"
+    env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_grug_scale_with_muon_orthogonalizes_matrix_trailing_dims():
     updates = {
         "matrix": jnp.ones((2, 3), dtype=jnp.float32),
@@ -156,7 +172,7 @@ def test_distributed_4d_ns_keeps_expert_axis_unmerged(weight_name, input_spec, o
 
 
 def test_distributed_4d_ns_matches_replicated_path_on_cpu_mesh():
-    script = textwrap.dedent(
+    _run_cpu_mesh_script(
         """
         import jax
         import jax.numpy as jnp
@@ -196,13 +212,6 @@ def test_distributed_4d_ns_matches_replicated_path_on_cpu_mesh():
         np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), atol=1e-5, rtol=1e-5)
         """
     )
-    env = os.environ.copy()
-    env["JAX_PLATFORMS"] = "cpu"
-    env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
-
-    result = subprocess.run([sys.executable, "-c", script], env=env, text=True, capture_output=True, check=False)
-
-    assert result.returncode == 0, result.stderr
 
 
 def test_padded_stack_ns_uses_two_hop_inbound_reshard():
@@ -235,3 +244,83 @@ def test_padded_stack_ns_uses_two_hop_inbound_reshard():
         P("replica_dcn", None, None),
         P(("replica_dcn", "expert"), None, None),
     ]
+
+
+def test_padded_stack_ns_returns_directly_to_parameter_sharding():
+    mesh = AbstractMesh(
+        axis_sizes=(1, 1, 64, 1),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(AxisType.Explicit,) * 4,
+    )
+    input_sharding = NamedSharding(mesh, P(None, "expert", None))
+    x = jax.ShapeDtypeStruct((48, 64, 4), jnp.float32, sharding=input_sharding)
+
+    def apply_ns(y):
+        return _newtonschulz_padded_stack_sharded(
+            y,
+            steps=0,
+            eps=1e-8,
+            coefficient_type="quintic",
+            target_sharding=input_sharding,
+        )
+
+    with use_abstract_mesh(mesh):
+        closed_jaxpr = jax.make_jaxpr(apply_ns)(x)
+        output = jax.eval_shape(apply_ns, x)
+
+    padded_shape = (64, 64, 4)
+    replicated_padded_reshards = [
+        eqn
+        for eqn in closed_jaxpr.jaxpr.eqns
+        if eqn.primitive.name == "reshard"
+        and eqn.invars[0].aval.shape == padded_shape
+        and eqn.params["dst_sharding"].spec == P(None, None, None)
+    ]
+    assert not replicated_padded_reshards
+    assert output.shape == x.shape
+    assert output.sharding == input_sharding
+
+
+def test_padded_stack_ns_matches_unsharded_path_on_cpu_mesh():
+    _run_cpu_mesh_script(
+        """
+        import jax
+        import jax.numpy as jnp
+        import numpy as np
+        from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
+
+        from levanter.optim.grugmuon import (
+            _newtonschulz_padded_stack_sharded,
+            _zeropower_via_newtonschulz_replicated,
+        )
+
+        mesh = Mesh(
+            np.asarray(jax.devices()).reshape(1, 1, 4, 1),
+            ("replica_dcn", "data", "expert", "model"),
+            axis_types=(AxisType.Explicit,) * 4,
+        )
+        x = jax.random.normal(jax.random.key(1), (3, 8, 4), dtype=jnp.float32)
+        parameter_sharding = NamedSharding(mesh, P(None, "expert", None))
+        x_sharded = jax.device_put(x, parameter_sharding)
+        expected = jax.vmap(
+            lambda matrix: _zeropower_via_newtonschulz_replicated(
+                matrix, steps=2, eps=1e-7, coefficient_type="quintic"
+            )
+        )(x)
+
+        apply_ns = jax.jit(
+            lambda y: _newtonschulz_padded_stack_sharded(
+                y,
+                steps=2,
+                eps=1e-7,
+                coefficient_type="quintic",
+                target_sharding=parameter_sharding,
+            )
+        )
+        with jax.set_mesh(mesh):
+            actual = apply_ns(x_sharded)
+
+        assert actual.sharding == parameter_sharding
+        np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), atol=1e-5, rtol=1e-5)
+        """
+    )

--- a/lib/levanter/tests/test_grugmuon.py
+++ b/lib/levanter/tests/test_grugmuon.py
@@ -2,15 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import os
+import subprocess
+import sys
+import textwrap
 
 import jax
 import jax.numpy as jnp
+import pytest
+from jax.sharding import AbstractMesh, AxisType, NamedSharding, PartitionSpec as P, use_abstract_mesh
 
 from levanter.optim.grugmuon import (
     GrugMuonConfig,
     STACK_BATCH_SHARDED,
     VMAP_REPLICATED,
     _grug_scale_with_muon,
+    _newtonschulz_4d_distributed,
+    _newtonschulz_padded_stack_sharded,
     _zeropower_via_newtonschulz_batched_stack_sharded,
     _zeropower_via_newtonschulz_replicated,
 )
@@ -111,3 +119,119 @@ def test_grug_scale_with_muon_stack_batch_sharded_handles_stacked_expert_tensor(
 
     assert new_updates["moe_tensor"].shape == updates["moe_tensor"].shape
     assert not jnp.array_equal(new_updates["moe_tensor"], updates["moe_tensor"])
+
+
+@pytest.mark.parametrize(
+    ("weight_name", "input_spec", "output_spec"),
+    [
+        ("w_gate", P(None, "expert", None, None), P(None, "expert", "data", "model")),
+        ("w_down", P(None, "expert", None, None), P(None, "expert", "model", "data")),
+    ],
+)
+def test_distributed_4d_ns_keeps_expert_axis_unmerged(weight_name, input_spec, output_spec):
+    mesh = AbstractMesh(
+        axis_sizes=(1, 1, 64, 1),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(AxisType.Explicit,) * 4,
+    )
+    input_sharding = NamedSharding(mesh, input_spec)
+    x = jax.ShapeDtypeStruct((48, 256, 8, 4), jnp.float32, sharding=input_sharding)
+
+    def apply_ns(y):
+        path = (jax.tree_util.GetAttrKey(weight_name),)
+        return _newtonschulz_4d_distributed(path, y, steps=0, eps=1e-8, coefficient_type="quintic")
+
+    with use_abstract_mesh(mesh):
+        closed_jaxpr = jax.make_jaxpr(apply_ns)(x)
+        output = jax.eval_shape(apply_ns, x)
+
+    merged_shape = (48 * 256, 8, 4)
+    merged_reshapes = [
+        eqn
+        for eqn in closed_jaxpr.jaxpr.eqns
+        if eqn.primitive.name == "reshape" and eqn.outvars[0].aval.shape == merged_shape
+    ]
+    assert not merged_reshapes
+    assert output.sharding == NamedSharding(mesh, output_spec)
+
+
+def test_distributed_4d_ns_matches_replicated_path_on_cpu_mesh():
+    script = textwrap.dedent(
+        """
+        import jax
+        import jax.numpy as jnp
+        import numpy as np
+        from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
+
+        from levanter.optim.grugmuon import (
+            _newtonschulz_4d_distributed,
+            _zeropower_via_newtonschulz_replicated,
+        )
+
+        mesh = Mesh(
+            np.asarray(jax.devices()).reshape(1, 1, 4, 1),
+            ("replica_dcn", "data", "expert", "model"),
+            axis_types=(AxisType.Explicit,) * 4,
+        )
+        x = jax.random.normal(jax.random.key(0), (2, 4, 8, 4), dtype=jnp.float32)
+        input_sharding = NamedSharding(mesh, P(None, "expert", "data", "model"))
+        x_sharded = jax.device_put(x, input_sharding)
+        path = (jax.tree_util.GetAttrKey("w_gate"),)
+        expected = jax.vmap(
+            jax.vmap(
+                lambda matrix: _zeropower_via_newtonschulz_replicated(
+                    matrix, steps=2, eps=1e-7, coefficient_type="quintic"
+                )
+            )
+        )(x)
+
+        apply_ns = jax.jit(
+            lambda y: _newtonschulz_4d_distributed(
+                path, y, steps=2, eps=1e-7, coefficient_type="quintic"
+            )
+        )
+        with jax.set_mesh(mesh):
+            actual = apply_ns(x_sharded)
+
+        np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), atol=1e-5, rtol=1e-5)
+        """
+    )
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cpu"
+    env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+
+    result = subprocess.run([sys.executable, "-c", script], env=env, text=True, capture_output=True, check=False)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_padded_stack_ns_uses_two_hop_inbound_reshard():
+    mesh = AbstractMesh(
+        axis_sizes=(2, 1, 4, 1),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(AxisType.Explicit,) * 4,
+    )
+    input_sharding = NamedSharding(mesh, P(None, "expert", None))
+    x = jax.ShapeDtypeStruct((6, 8, 4), jnp.float32, sharding=input_sharding)
+
+    def apply_ns(y):
+        return _newtonschulz_padded_stack_sharded(
+            y,
+            steps=0,
+            eps=1e-8,
+            coefficient_type="quintic",
+        )
+
+    with use_abstract_mesh(mesh):
+        closed_jaxpr = jax.make_jaxpr(apply_ns)(x)
+
+    padded_shape = (8, 8, 4)
+    padded_reshard_specs = [
+        eqn.params["dst_sharding"].spec
+        for eqn in closed_jaxpr.jaxpr.eqns
+        if eqn.primitive.name == "reshard" and eqn.invars[0].aval.shape == padded_shape
+    ]
+    assert padded_reshard_specs[:2] == [
+        P("replica_dcn", None, None),
+        P(("replica_dcn", "expert"), None, None),
+    ]

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -12,6 +12,7 @@ import dataclasses
 import importlib
 import json
 import logging
+import math
 import os
 import subprocess
 import sys
@@ -40,12 +41,10 @@ from levanter.data.text.examples import GrugLmExample
 from levanter.distributed import DistributedConfig
 from levanter.grug._moe.common import resolve_moe_implementation
 from levanter.grug.attention import AttentionMask as GrugAttentionMask
-from levanter.grug.grug_moe import DEFAULT_EP_CAPACITY_FACTOR
 from levanter.grug.sharding import _compact_grug_mesh_shape
 from levanter.optim.config import AdamConfig
 from levanter.schedule import BatchSchedule
 from levanter.tracker.json_logger import JsonLoggerConfig
-from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
 from marin.execution.artifact import ArtifactRecord, write_record
 from marin.execution.lazy import StepContext, materialized_config
@@ -433,35 +432,11 @@ def test_grug_moe_scale_launcher_resolves_gb200_ep64_run(monkeypatch):
 
 def _assert_grug_moe_hero_fsdp_config(config, resources, train_module) -> None:
     model = config.model
-    optimizer = config.optimizer
     grug_trainer = config.trainer
-    trainer = grug_trainer.trainer
 
-    assert (
-        model.vocab_size,
-        model.hidden_dim,
-        model.intermediate_dim,
-        model.shared_expert_intermediate_dim,
-        model.num_shared_experts,
-        model.num_experts,
-        model.num_experts_per_token,
-        model.num_layers,
-        model.num_heads,
-        model.num_kv_heads,
-        model.local_kv_heads,
-        model.global_kv_heads,
-        model.head_dim,
-        model.max_seq_len,
-        model.sliding_window,
-        model.global_every,
-    ) == (128_256, 6144, 3072, 6144, 2, 128, 4, 48, 48, 12, 12, 6, 128, 4096, 512, 6)
-    assert (
-        model.capacity_factor,
-        model.layer_norm_eps,
-        model.initializer_std,
-        model.qk_mult,
-        model.router_z_loss_coef,
-    ) == (1.0, 1e-5, 0.0063788795384978605, 1.3, 0.0)
+    assert model.sliding_window == 512
+    assert model.capacity_factor == 1.0
+    assert model.initializer_std == 0.5 / math.sqrt(model.hidden_dim)
     assert model.xsa
     assert model.disable_pko
     assert model.disable_long_rope
@@ -470,86 +445,14 @@ def _assert_grug_moe_hero_fsdp_config(config, resources, train_module) -> None:
     assert model.expert_chunks == 4
     assert model.report_capacity_overflow
     assert model.remat_mode == "recompute_all"
-    assert model.rope.theta == 10_000.0
-    assert model.rope.scaling_factor is None
     assert model.rope_fused
     assert model.use_array_stacked_blocks
-    model_module = importlib.import_module("experiments.grug.moe_hero_fsdp.model")
-    np.testing.assert_array_equal(
-        np.flatnonzero(np.asarray(model_module._long_layer_schedule(model.num_layers, model.global_every))),
-        np.arange(5, 48, 6),
-    )
-
-    assert isinstance(optimizer, importlib.import_module("experiments.grug.moe_hero_fsdp.optimizer").GrugMoeMuonHConfig)
     assert (
-        optimizer.learning_rate,
-        optimizer.weight_decay,
-        optimizer.min_lr_ratio,
-        optimizer.warmup,
-        optimizer.decay,
-        optimizer.rewarmup,
-        optimizer.cooldown,
-        optimizer.cycle_length,
-        optimizer.cycles,
-        optimizer.lr_schedule,
-        optimizer.haps,
-        optimizer.weight_decay_modules,
-        optimizer.default_weight_decay_mask,
-        optimizer.adam_lr,
-        optimizer.momentum,
-        optimizer.nesterov,
-        optimizer.backend_steps,
-        optimizer.beta1,
-        optimizer.beta2,
-        optimizer.epsilon,
-        optimizer.muon_epsilon,
-        optimizer.max_grad_norm,
-        optimizer.coefficient_type,
-    ) == (
-        0.05,
-        0.1,
-        0.05,
-        0.01,
-        None,
-        0.0,
-        None,
-        None,
-        None,
-        "linear",
-        None,
-        None,
-        None,
-        0.02511723566133071,
-        0.95,
-        True,
-        5,
-        0.9062,
-        0.9646229185299474,
-        4.8379999999999997e-17,
-        1e-8,
-        None,
-        "quintic",
-    )
-    assert (
-        grug_trainer.data_seed,
-        grug_trainer.log_every,
-        grug_trainer.ema_beta,
-        grug_trainer.z_loss_weight,
         grug_trainer.offload_opt_state,
         grug_trainer.expert_axis_size,
         grug_trainer.replica_axis_size,
-        grug_trainer.sharding_dump_path,
-    ) == (None, 1, None, 1e-4, True, 1, 1, None)
-    assert (
-        trainer.seed,
-        trainer.train_batch_size,
-        trainer.num_train_steps,
-        trainer.watch.interval,
         config.processes_per_task,
-    ) == (0, 1152, 25, 20, 1)
-    assert isinstance(trainer.tracker, WandbConfig)
-    assert trainer.checkpointer.save_interval is None
-    assert config.eval is None
+    ) == (True, 1, 1, 1)
     assert (resources.device.variant, resources.device.count, resources.replicas) == ("GB200", 4, 16)
     assert dict(train_module.HERO_FSDP_RUNTIME_ENV) == {
         "JAX_ENABLE_PGLE": "1",
@@ -596,70 +499,6 @@ def test_grug_moe_rank_four_muon_update_runs_newton_schulz_without_mesh(monkeypa
 
     assert update.shape == raw_momentum.shape
     assert not jnp.array_equal(update, raw_momentum)
-
-
-def test_grug_moe_hero_fsdp_newton_schulz_hlo_reaches_syrk():
-    env = os.environ.copy()
-    env["JAX_PLATFORMS"] = "cpu"
-    env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
-    script = """
-        import importlib
-        import os
-        import sys
-        from types import SimpleNamespace
-
-        import jax
-        import jax.numpy as jnp
-        import numpy as np
-        from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
-
-        from levanter.optim import grugmuon
-
-        def symmetric_gemm(x):
-            with jax.named_scope("quack_symmetric_gemm"):
-                return jnp.matmul(x, jnp.swapaxes(x, -1, -2))
-
-        sys.modules["levanter.grug._moe.quack_symmetric_cute"] = SimpleNamespace(
-            quack_symmetric_gemm=symmetric_gemm
-        )
-        train_module = importlib.import_module("experiments.grug.moe_hero_fsdp.train")
-        os.environ.update(train_module.HERO_FSDP_RUNTIME_ENV)
-
-        axis_names = ("replica_dcn", "data", "expert", "model")
-        mesh = Mesh(
-            np.asarray(jax.devices()).reshape((1, 4, 1, 1)),
-            axis_names,
-            axis_types=(AxisType.Explicit,) * 4,
-        )
-        x = jax.device_put(
-            jax.random.normal(jax.random.key(0), (2, 4, 8, 4), dtype=jnp.float32),
-            NamedSharding(mesh, P(None, None, None, None)),
-        )
-        path = (jax.tree_util.GetAttrKey("w_gate"),)
-
-        def apply_ns(y):
-            return grugmuon._newtonschulz_4d_distributed(
-                path,
-                y,
-                steps=2,
-                eps=1e-7,
-                coefficient_type="quintic",
-            )
-
-        with jax.set_mesh(mesh):
-            stablehlo = jax.jit(apply_ns).lower(x).as_text(debug_info=True)
-
-        assert "quack_symmetric_gemm/dot_general" in stablehlo, stablehlo
-    """
-    result = subprocess.run(
-        [sys.executable, "-c", textwrap.dedent(script)],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-    assert result.returncode == 0, result.stderr
 
 
 def test_grug_moe_chunk_drops_sum_across_data_shards():
@@ -731,32 +570,11 @@ def test_grug_moe_chunk_drops_sum_across_data_shards():
 
 def _assert_grug_moe_hero_ep_config(config, resources, train_module) -> None:
     model = config.model
-    optimizer = config.optimizer
     grug_trainer = config.trainer
-    trainer = grug_trainer.trainer
 
-    assert (
-        model.vocab_size,
-        model.hidden_dim,
-        model.intermediate_dim,
-        model.shared_expert_intermediate_dim,
-        model.num_shared_experts,
-        model.num_experts,
-        model.num_experts_per_token,
-        model.num_layers,
-        model.num_heads,
-        model.num_kv_heads,
-        model.head_dim,
-        model.max_seq_len,
-        model.sliding_window,
-    ) == (128_256, 5120, 1280, 5120, 1, 256, 8, 48, 40, 10, 128, 4096, 2048)
-    assert (
-        model.capacity_factor,
-        model.layer_norm_eps,
-        model.initializer_std,
-        model.qk_mult,
-        model.router_z_loss_coef,
-    ) == (1.0625, 1e-5, 0.006987712429686843, 1.3, 0.0)
+    assert model.sliding_window == 2048
+    assert model.capacity_factor == 1.0625
+    assert model.initializer_std == 0.5 / math.sqrt(model.hidden_dim)
     assert model.disable_pko
     assert model.disable_long_rope
     assert model.attention_implementation == "gpu_fa4_cute"
@@ -764,82 +582,13 @@ def _assert_grug_moe_hero_ep_config(config, resources, train_module) -> None:
     assert model.expert_chunks == 1
     assert model.report_capacity_overflow
     assert model.remat_mode == "recompute_all"
-    assert model.rope.theta == 10_000.0
-    assert model.rope.scaling_factor is None
     assert model.use_array_stacked_blocks
-    assert DEFAULT_EP_CAPACITY_FACTOR == 1.0
-
-    hero_optimizer = importlib.import_module("experiments.grug.moe_hero_ep.optimizer")
-    assert isinstance(optimizer, hero_optimizer.GrugMoeMuonHConfig)
     assert (
-        optimizer.learning_rate,
-        optimizer.weight_decay,
-        optimizer.min_lr_ratio,
-        optimizer.warmup,
-        optimizer.decay,
-        optimizer.rewarmup,
-        optimizer.cooldown,
-        optimizer.cycle_length,
-        optimizer.cycles,
-        optimizer.lr_schedule,
-        optimizer.haps,
-        optimizer.weight_decay_modules,
-        optimizer.default_weight_decay_mask,
-        optimizer.adam_lr,
-        optimizer.momentum,
-        optimizer.nesterov,
-        optimizer.backend_steps,
-        optimizer.beta1,
-        optimizer.beta2,
-        optimizer.epsilon,
-        optimizer.muon_epsilon,
-        optimizer.max_grad_norm,
-        optimizer.coefficient_type,
-    ) == (
-        0.038956464533085024,
-        0.1,
-        0.05,
-        0.01,
-        None,
-        0.0,
-        None,
-        None,
-        None,
-        "linear",
-        None,
-        None,
-        None,
-        0.008989953353788853,
-        0.95,
-        True,
-        5,
-        0.9062,
-        0.9684910757595268,
-        1.810213843721233e-16,
-        1e-8,
-        None,
-        "quintic",
-    )
-    assert (
-        grug_trainer.data_seed,
-        grug_trainer.log_every,
-        grug_trainer.ema_beta,
-        grug_trainer.z_loss_weight,
         grug_trainer.offload_opt_state,
         grug_trainer.expert_axis_size,
         grug_trainer.replica_axis_size,
-        grug_trainer.sharding_dump_path,
-    ) == (None, 1, None, 1e-4, False, 64, 1, None)
-    assert (
-        trainer.seed,
-        trainer.train_batch_size,
-        trainer.num_train_steps,
-        trainer.watch.interval,
         config.processes_per_task,
-    ) == (0, 1024, 350, 0, 1)
-    assert isinstance(trainer.tracker, JsonLoggerConfig)
-    assert trainer.checkpointer.save_interval is None
-    assert config.eval is None
+    ) == (False, 64, 1, 1)
     assert (resources.device.variant, resources.device.count, resources.replicas) == ("GB200", 4, 16)
     assert dict(train_module.HERO_EP_RUNTIME_ENV) == {
         "JAX_ENABLE_PGLE": "false",
@@ -864,6 +613,82 @@ def test_grug_moe_hero_ep_resolves_one_rack_d5120_ep64_configuration(monkeypatch
     resources = step.runtime_args["train_resources"]
 
     _assert_grug_moe_hero_ep_config(config, resources, train_module)
+
+
+@pytest.mark.parametrize(
+    ("variant", "runtime_env_name", "sharded_axis"),
+    [
+        ("moe_hero_fsdp", "HERO_FSDP_RUNTIME_ENV", "data"),
+        ("moe_hero_ep", "HERO_EP_RUNTIME_ENV", "expert"),
+    ],
+)
+def test_grug_moe_hero_newton_schulz_hlo_reaches_syrk(variant, runtime_env_name, sharded_axis):
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cpu"
+    env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+    script = f"""
+        import importlib
+        import os
+        import sys
+        from types import SimpleNamespace
+
+        import jax
+        import jax.numpy as jnp
+        import numpy as np
+        from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
+
+        from levanter.optim import grugmuon
+
+        def symmetric_gemm(x):
+            with jax.named_scope("quack_symmetric_gemm"):
+                return jnp.matmul(x, jnp.swapaxes(x, -1, -2))
+
+        # QuACK/CUTLASS is unavailable on CPU. Replace that accelerator boundary
+        # with dense SYRK while retaining a name that survives into lowered HLO.
+        sys.modules["levanter.grug._moe.quack_symmetric_cute"] = SimpleNamespace(
+            quack_symmetric_gemm=symmetric_gemm
+        )
+        train_module = importlib.import_module("experiments.grug.{variant}.train")
+        runtime_env = getattr(train_module, "{runtime_env_name}")
+        os.environ.update(runtime_env)
+
+        axis_names = ("replica_dcn", "data", "expert", "model")
+        mesh_shape = tuple(4 if name == "{sharded_axis}" else 1 for name in axis_names)
+        mesh = Mesh(
+            np.asarray(jax.devices()).reshape(mesh_shape),
+            axis_names,
+            axis_types=(AxisType.Explicit,) * 4,
+        )
+        input_spec = P(None, "expert" if "{sharded_axis}" == "expert" else None, None, None)
+        x = jax.device_put(
+            jax.random.normal(jax.random.key(0), (2, 4, 8, 4), dtype=jnp.float32),
+            NamedSharding(mesh, input_spec),
+        )
+        path = (jax.tree_util.GetAttrKey("w_gate"),)
+
+        def apply_ns(y):
+            return grugmuon._newtonschulz_4d_distributed(
+                path,
+                y,
+                steps=2,
+                eps=1e-7,
+                coefficient_type="quintic",
+            )
+
+        with jax.set_mesh(mesh):
+            hlo = jax.jit(apply_ns).lower(x).as_text(debug_info=True)
+
+        assert "quack_symmetric_gemm/dot_general" in hlo, hlo
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_grug_moe_hero_fsdp_reaches_chunked_sonic(monkeypatch):
@@ -908,48 +733,6 @@ def test_grug_moe_hero_fsdp_reaches_chunked_sonic(monkeypatch):
                 expert_chunks=4,
             )
         )(x, selected_experts, combine_weights, w_up_gate, w_down)
-
-
-def test_grug_moe_hero_ep_newton_schulz_reaches_syrk(monkeypatch):
-    train_module = importlib.import_module("experiments.grug.moe_hero_ep.train")
-    grugmuon = importlib.import_module("levanter.optim.grugmuon")
-    for key, value in train_module.HERO_EP_RUNTIME_ENV.items():
-        monkeypatch.setenv(key, value)
-
-    class SyrkReached(Exception):
-        pass
-
-    def symmetric_gemm(_):
-        raise SyrkReached
-
-    monkeypatch.setattr(
-        grugmuon,
-        "import_module",
-        lambda _: SimpleNamespace(quack_symmetric_gemm=symmetric_gemm),
-    )
-    mesh = jax.sharding.AbstractMesh(
-        axis_sizes=(1, 1, 64, 1),
-        axis_names=("replica_dcn", "data", "expert", "model"),
-        axis_types=(AxisType.Explicit,) * 4,
-    )
-    x = jax.ShapeDtypeStruct(
-        (48, 256, 8, 4),
-        jnp.float32,
-        sharding=jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(None, "expert", None, None)),
-    )
-
-    def apply_ns(y):
-        path = (jax.tree_util.GetAttrKey("w_gate"),)
-        return grugmuon._newtonschulz_4d_distributed(
-            path,
-            y,
-            steps=1,
-            eps=1e-8,
-            coefficient_type="quintic",
-        )
-
-    with use_abstract_mesh(mesh), pytest.raises(SyrkReached):
-        jax.make_jaxpr(apply_ns)(x)
 
 
 def test_grug_moe_hero_ep_avoids_known_involuntary_remat_layouts(monkeypatch):

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -19,6 +19,7 @@ import textwrap
 import uuid
 from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
 
 import equinox as eqx
 import jax
@@ -31,7 +32,7 @@ import pytest
 from fray.cluster import ResourceConfig
 from haliax.partitioning import set_mesh
 from jax._src import config as jax_config
-from jax.sharding import use_abstract_mesh
+from jax.sharding import AxisType, use_abstract_mesh
 from levanter.checkpoint import CheckpointerConfig
 from levanter.data.dataset import ListAsyncDataset
 from levanter.data.text.datasets import DatasetComponent, DirectDatasetComponent, LmDataConfig
@@ -39,6 +40,7 @@ from levanter.data.text.examples import GrugLmExample
 from levanter.distributed import DistributedConfig
 from levanter.grug._moe.common import resolve_moe_implementation
 from levanter.grug.attention import AttentionMask as GrugAttentionMask
+from levanter.grug.grug_moe import DEFAULT_EP_CAPACITY_FACTOR
 from levanter.grug.sharding import _compact_grug_mesh_shape
 from levanter.optim.config import AdamConfig
 from levanter.schedule import BatchSchedule
@@ -725,6 +727,268 @@ def test_grug_moe_chunk_drops_sum_across_data_shards():
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def _assert_grug_moe_hero_ep_config(config, resources, train_module) -> None:
+    model = config.model
+    optimizer = config.optimizer
+    grug_trainer = config.trainer
+    trainer = grug_trainer.trainer
+
+    assert (
+        model.vocab_size,
+        model.hidden_dim,
+        model.intermediate_dim,
+        model.shared_expert_intermediate_dim,
+        model.num_shared_experts,
+        model.num_experts,
+        model.num_experts_per_token,
+        model.num_layers,
+        model.num_heads,
+        model.num_kv_heads,
+        model.head_dim,
+        model.max_seq_len,
+        model.sliding_window,
+    ) == (128_256, 5120, 1280, 5120, 1, 256, 8, 48, 40, 10, 128, 4096, 2048)
+    assert (
+        model.capacity_factor,
+        model.layer_norm_eps,
+        model.initializer_std,
+        model.qk_mult,
+        model.router_z_loss_coef,
+    ) == (1.0625, 1e-5, 0.006987712429686843, 1.3, 0.0)
+    assert model.disable_pko
+    assert model.disable_long_rope
+    assert model.attention_implementation == "gpu_fa4_cute"
+    assert model.moe_implementation == "ragged_all_to_all"
+    assert model.expert_chunks == 1
+    assert model.report_capacity_overflow
+    assert model.remat_mode == "recompute_all"
+    assert model.rope.theta == 10_000.0
+    assert model.rope.scaling_factor is None
+    assert model.use_array_stacked_blocks
+    assert DEFAULT_EP_CAPACITY_FACTOR == 1.0
+
+    hero_optimizer = importlib.import_module("experiments.grug.moe_hero_ep.optimizer")
+    assert isinstance(optimizer, hero_optimizer.GrugMoeMuonHConfig)
+    assert (
+        optimizer.learning_rate,
+        optimizer.weight_decay,
+        optimizer.min_lr_ratio,
+        optimizer.warmup,
+        optimizer.decay,
+        optimizer.rewarmup,
+        optimizer.cooldown,
+        optimizer.cycle_length,
+        optimizer.cycles,
+        optimizer.lr_schedule,
+        optimizer.haps,
+        optimizer.weight_decay_modules,
+        optimizer.default_weight_decay_mask,
+        optimizer.adam_lr,
+        optimizer.momentum,
+        optimizer.nesterov,
+        optimizer.backend_steps,
+        optimizer.beta1,
+        optimizer.beta2,
+        optimizer.epsilon,
+        optimizer.muon_epsilon,
+        optimizer.max_grad_norm,
+        optimizer.coefficient_type,
+    ) == (
+        0.038956464533085024,
+        0.1,
+        0.05,
+        0.01,
+        None,
+        0.0,
+        None,
+        None,
+        None,
+        "linear",
+        None,
+        None,
+        None,
+        0.008989953353788853,
+        0.95,
+        True,
+        5,
+        0.9062,
+        0.9684910757595268,
+        1.810213843721233e-16,
+        1e-8,
+        None,
+        "quintic",
+    )
+    assert (
+        grug_trainer.data_seed,
+        grug_trainer.log_every,
+        grug_trainer.ema_beta,
+        grug_trainer.z_loss_weight,
+        grug_trainer.offload_opt_state,
+        grug_trainer.expert_axis_size,
+        grug_trainer.replica_axis_size,
+        grug_trainer.sharding_dump_path,
+    ) == (None, 1, None, 1e-4, False, 64, 1, None)
+    assert (
+        trainer.seed,
+        trainer.train_batch_size,
+        trainer.num_train_steps,
+        trainer.watch.interval,
+        config.processes_per_task,
+    ) == (0, 1024, 350, 0, 1)
+    assert isinstance(trainer.tracker, JsonLoggerConfig)
+    assert trainer.checkpointer.save_interval is None
+    assert config.eval is None
+    assert (resources.device.variant, resources.device.count, resources.replicas) == ("GB200", 4, 16)
+    assert dict(train_module.HERO_EP_RUNTIME_ENV) == {
+        "JAX_ENABLE_PGLE": "false",
+        "SCALE_A2A_FIXED": "1",
+        "SCALE_A2A_CHUNKS": "1",
+        "SCALE_A2A_NO_BARRIER": "1",
+        "SCALE_A2A_GATHER_DISPATCH": "1",
+        "SCALE_A2A_CUSTOM_ADJOINT": "1",
+        "SCALE_A2A_SPILL": "3",
+        "SCALE_MUON_PAD_NONEXPERT": "1",
+        "SCALE_MUON_SYRK": "1",
+    }
+
+
+def test_grug_moe_hero_ep_resolves_one_rack_d5120_ep64_configuration(monkeypatch):
+    monkeypatch.setenv("RUN_ID", "test-moe-hero-ep")
+    launcher = importlib.import_module("experiments.grug.moe_hero_ep.launch")
+    train_module = importlib.import_module("experiments.grug.moe_hero_ep.train")
+
+    step = launcher.build_hero_checkpoint(version="test-dev")
+    config = step.build_config(StepContext.for_fingerprint(step.runtime_args.keys(), step.deps))
+    resources = step.runtime_args["train_resources"]
+
+    _assert_grug_moe_hero_ep_config(config, resources, train_module)
+
+
+def test_grug_moe_hero_fsdp_reaches_chunked_sonic(monkeypatch):
+    grug_moe = importlib.import_module("levanter.grug.grug_moe")
+
+    class ChunkerReached(Exception):
+        pass
+
+    def chunked_sonic(*args, **kwargs):
+        del args, kwargs
+        raise ChunkerReached
+
+    monkeypatch.setitem(
+        sys.modules,
+        "levanter.grug._moe.sonic_cute",
+        SimpleNamespace(
+            _moe_mlp_local_sonic_cute=lambda *args, **kwargs: (args[0], jnp.array(0, dtype=jnp.int32)),
+            _moe_mlp_local_sonic_cute_chunked=chunked_sonic,
+        ),
+    )
+    mesh = jax.sharding.AbstractMesh(
+        axis_sizes=(1, 1, 1, 1),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(AxisType.Explicit,) * 4,
+    )
+    x = jnp.zeros((8, 4), dtype=jnp.bfloat16)
+    selected_experts = jnp.zeros((8, 2), dtype=jnp.int32)
+    combine_weights = jnp.ones((8, 2), dtype=jnp.bfloat16)
+    w_up_gate = jnp.zeros((4, 4, 8), dtype=jnp.bfloat16)
+    w_down = jnp.zeros((4, 4, 4), dtype=jnp.bfloat16)
+
+    with use_abstract_mesh(mesh), pytest.raises(ChunkerReached):
+        jax.make_jaxpr(
+            lambda x, selected, weights, up_gate, down: grug_moe.moe_mlp(
+                x,
+                selected,
+                weights,
+                up_gate,
+                down,
+                implementation="sonic_cute",
+                mesh=mesh,
+                expert_chunks=4,
+            )
+        )(x, selected_experts, combine_weights, w_up_gate, w_down)
+
+
+def test_grug_moe_hero_ep_newton_schulz_reaches_syrk(monkeypatch):
+    train_module = importlib.import_module("experiments.grug.moe_hero_ep.train")
+    grugmuon = importlib.import_module("levanter.optim.grugmuon")
+    for key, value in train_module.HERO_EP_RUNTIME_ENV.items():
+        monkeypatch.setenv(key, value)
+
+    class SyrkReached(Exception):
+        pass
+
+    def symmetric_gemm(_):
+        raise SyrkReached
+
+    monkeypatch.setattr(
+        grugmuon,
+        "import_module",
+        lambda _: SimpleNamespace(quack_symmetric_gemm=symmetric_gemm),
+    )
+    mesh = jax.sharding.AbstractMesh(
+        axis_sizes=(1, 1, 64, 1),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(AxisType.Explicit,) * 4,
+    )
+    x = jax.ShapeDtypeStruct(
+        (48, 256, 8, 4),
+        jnp.float32,
+        sharding=jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(None, "expert", None, None)),
+    )
+
+    def apply_ns(y):
+        path = (jax.tree_util.GetAttrKey("w_gate"),)
+        return grugmuon._newtonschulz_4d_distributed(
+            path,
+            y,
+            steps=1,
+            eps=1e-8,
+            coefficient_type="quintic",
+        )
+
+    with use_abstract_mesh(mesh), pytest.raises(SyrkReached):
+        jax.make_jaxpr(apply_ns)(x)
+
+
+def test_grug_moe_hero_ep_avoids_known_involuntary_remat_layouts(monkeypatch):
+    train_module = importlib.import_module("experiments.grug.moe_hero_ep.train")
+    grugmuon = importlib.import_module("levanter.optim.grugmuon")
+    for key, value in train_module.HERO_EP_RUNTIME_ENV.items():
+        monkeypatch.setenv(key, value)
+
+    mesh = jax.sharding.AbstractMesh(
+        axis_sizes=(1, 1, 64, 1),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(AxisType.Explicit,) * 4,
+    )
+    parameter_sharding = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec(None, "expert", None))
+    x = jax.ShapeDtypeStruct((48, 64, 4), jnp.float32, sharding=parameter_sharding)
+
+    def apply_ns(y):
+        return grugmuon._newtonschulz_padded_stack_sharded(
+            y,
+            steps=0,
+            eps=1e-8,
+            coefficient_type="quintic",
+            target_sharding=parameter_sharding,
+        )
+
+    with use_abstract_mesh(mesh):
+        closed_jaxpr = jax.make_jaxpr(apply_ns)(x)
+        output = jax.eval_shape(apply_ns, x)
+
+    padded_shape = (64, 64, 4)
+    fully_replicated_padded_reshards = [
+        equation
+        for equation in closed_jaxpr.jaxpr.eqns
+        if equation.primitive.name == "reshard"
+        and equation.invars[0].aval.shape == padded_shape
+        and equation.params["dst_sharding"].spec == jax.sharding.PartitionSpec(None, None, None)
+    ]
+    assert not fully_replicated_padded_reshards
+    assert output.sharding == parameter_sharding
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds the expert-parallel core for GB200 MoE training and `experiments/grug/moe_hero_ep`, a Grug variant hardcoding the composed EP64 configuration. Stacked on #7779; review that first, and this diff shows only the ten expert-parallel commits.

The core is a fixed-capacity expert all-to-all replacing the ragged path, same-step spill of overflow assignments to the next-ranked selected expert, a dispatch send buffer built by index scatter with an activation gather, a structured `custom_vjp` that removes scatter from the backward, non-expert optimizer state sharded across expert parallelism, expert sharding preserved through the MuonH Newton–Schulz merge and again at the dispatch boundary, and padded stack-sharded Muon for the non-expert Newton–Schulz batch.

Measured at EP64 on one rack: three placement draws with a median 22.398% MFU and 346,950 tokens/s at 1.444% dropped assignments, 0.102pp under the pre-registered 22.5% and 0.898pp above the falsification threshold. Component A/Bs at 120 matched steps attribute +3.01pp to gather dispatch, +3.43pp to the custom adjoint and +1.78pp to padded Muon; spill traded 0.213pp of throughput for half the drops and is the only mechanism reaching the fidelity target on a true tail window.

Provenance matters here and the numbers are not this branch's. They were measured on research build `c24ccfcc2`, which carries a different MuonH gated on a flag absent from this series, so this branch is not the measured artifact. All three draws also ran a manual PGLE profile worth +0.427pp on this line. The template deliberately ships no profile, because one pinned to a single build stops matching the build it was recorded against — so as shipped it is expected to land roughly that much below 22.398%. The README says how to regenerate a profile for the build in use.

The template is validated at one rack only, and two independent blockers stand between it and any multi-rack claim. Multi-rack placement needs the Fray gang-topology fix in #7753, without which two racks are placed 14+18 across NVLink domains rather than 16+16. And a two-rack EP64 run wedges in an asynchronously dispatched device collective under uniform CUDA 13 NCCL, tracked in #7344; the collective-hang watchdog added by #7350 was armed at 600s and did not fire across an 879s wedge. No weak-scaling factor exists for this configuration, and neither the README nor this description quotes one.

The shared-expert split stays off here: it is memory-blocked at EP64, needing 89.49 GiB before step 0. MuonH host offload also stays off, having been rejected at this d5120 shape where it required a 135 GiB pinned-host arena and measured 19.694%.

Verified on CPU only, with no accelerator run: `./infra/pre-commit.py --all-files`, `uv run pyrefly check` at zero errors, and the root test suite green under both jax 0.11.0 and the jax 0.10.1 environment CI resolves for this lane. The variant's contract tests assert the resolved configuration, that the Newton–Schulz path reaches SYRK, and that the capacity factor is 1.0625 while the library default remains 1.0; each was mutation-probed.
