### PR TITLE
[iris] Reserve multi-node dev GPU sessions

### DIFF
--- a/.agents/skills/reserve-gpu/SKILL.md
+++ b/.agents/skills/reserve-gpu/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reserve-gpu
-description: Reserve an Iris-backed CoreWeave H100 pod for fast debugging with dev_gpu.py.
+description: Reserve one or more Iris-backed CoreWeave GPU nodes (H100 or GB200) for fast debugging with dev_gpu.py.
 ---
 
 # Skill: Dev GPU
@@ -13,7 +13,7 @@ This is a lean tool: `allocate`, `connect`, `status`, `release`. It does not syn
 
 ## Cost rule
 
-A holder pod sits on an expensive 8×H100 node for the session's lifetime. Release as soon as you are done — `Ctrl-C` the `allocate` terminal, or run `release` from another shell.
+A holder pod sits on an expensive 8×H100 node for the session's lifetime, and a `--nodes N` session holds N of them. Release as soon as you are done — `Ctrl-C` the `allocate` terminal, or run `release` from another shell.
 
 ## Commands
 
@@ -43,10 +43,31 @@ uv run scripts/iris/dev_gpu.py \
 
 Subcommands and distinctive flags:
 
-- `allocate` — reserves a whole `h100-8x` node (`--gpu-count` defaults to `8`) and holds it until `Ctrl-C`. Add `--timeout` (default `900`) to bound the wait for the task to reach `RUNNING`, and `--pod-timeout` (default `120`) to bound the wait for the backing pod. Only `--gpu-count 8` is validated; a sub-node value schedules as a fractional share (`nvidia-smi -L` then shows fewer GPUs) but fragments the 8-GPU InfiniBand gang pool, so prefer the whole node.
-- `status` — show the active session (job id, config, GPU count, resolved pod).
-- `connect` — interactive shell into the pod. It first checks job liveness with the controller (failing fast if the job is gone), then `kubectl exec -it`s into container `task`.
+- `allocate` — reserves a whole `h100-8x` node (`--gpus-per-node` defaults to `8`) and holds it until `Ctrl-C`. Add `--timeout` (default `900`) to bound the wait for the tasks to reach `RUNNING`, and `--pod-timeout` (default `120`) to bound the wait for the backing pods. Only `--gpus-per-node 8` is validated; a sub-node value schedules as a fractional share (`nvidia-smi -L` then shows fewer GPUs) but fragments the 8-GPU InfiniBand gang pool, so prefer the whole node. `--nodes N` reserves N whole nodes in one session; `--gpu-variant GB200` reserves `gb200-4x` trays instead, where a whole node is 4 GPUs.
+- `status` — show the active session (job id, config, node count, GPUs per node, and every resolved pod).
+- `connect` — interactive shell into a pod. It first checks job liveness with the controller (failing fast if the job is gone), then `kubectl exec -it`s into container `task`. On a multi-node session pass `--node N` (default `0`) to pick which pod, in `status` order.
 - `release` — terminate the holder job and clear the session file. Pass `--force` to drop local state even when the terminate call fails (then confirm the job is gone with `iris job list`).
+
+## Multi-node sessions
+
+`--nodes N` submits one Iris job with N gang-scheduled tasks, so the whole session lands
+at once or not at all. Each task is one pod on one whole node, and the pods are numbered
+in task order: `connect --node 0`, `connect --node 1`, and so on.
+
+The gang's placement follows the variant. GB200 (`gb200-4x`) gangs of up to 16 nodes bind
+hard to a single `ds.coreweave.com/nvlink.domain`, so every node shares one rack's NVLink
+fabric — the reason to reserve GB200 nodes together rather than one at a time. H100 and
+other variants get soft `leafgroup` InfiniBand colocation instead. `allocate` prints the
+level it used as `Coscheduling: …`, and you can confirm the placement from the node labels:
+
+```bash
+kubectl --kubeconfig ~/.kube/coreweave-iris --context marin-us-east-08a_US-EAST-08A \
+  get nodes -o custom-columns=NAME:.metadata.name,DOMAIN:'.metadata.labels.ds\.coreweave\.com/nvlink\.domain'
+```
+
+Multi-node sessions must reserve whole nodes, so `--gpus-per-node` has to stay at the
+variant's per-node count (GB200: 4, H100: 8). A fractional pod would let two nodes of the
+session land on the same machine, and `allocate` rejects it before submitting.
 
 ## GPU JAX inside the pod
 
@@ -79,7 +100,7 @@ kubectl --kubeconfig ~/.kube/coreweave-iris --context marin-gpu_US-EAST-02A \
 - Local session state lives under `~/.cache/marin/dev_gpu_iris/`.
 - If the `allocate` terminal dies unexpectedly, run `release` to terminate the holder job and clear the stale state file.
 - A failed `allocate` cleans up after itself: the holder job is terminated and the local state file is removed only once the job is confirmed gone, so a failed terminate never orphans an expensive pod with no local record of its job id.
-- `connect` execs into the pod resolved at allocation time. If Iris rescheduled the task onto a new pod while the job stayed active, `connect` fails — re-allocate.
+- `connect` execs into the pods resolved at allocation time. If Iris rescheduled a task onto a new pod while the job stayed active, `connect` fails for that node — re-allocate.
 
 ## Agent Usage
 

--- a/.agents/skills/reserve-gpu/SKILL.md
+++ b/.agents/skills/reserve-gpu/SKILL.md
@@ -5,15 +5,15 @@ description: Reserve one or more Iris-backed CoreWeave GPU nodes (H100 or GB200)
 
 # Skill: Dev GPU
 
-Use this skill for the standard fast H100 debugging loop without wiring a full training job each time. It is the GPU counterpart to `reserve-tpu`.
+Use this skill for the standard fast GPU debugging loop without wiring a full training job each time. It is the GPU counterpart to `reserve-tpu`.
 
-`scripts/iris/dev_gpu.py` reserves a CoreWeave H100 pod through Iris, waits for the backing Kubernetes pod to come up, and `kubectl exec -it`s you into it. Marin's H100s are CoreWeave Kubernetes pods, not GCE VMs, so access is `kubectl`, not SSH — there is no `ssh`/`scp` transport and no `~/.ssh/config` alias.
+`scripts/iris/dev_gpu.py` reserves CoreWeave GPU nodes through Iris, waits for the backing Kubernetes pods to come up, and `kubectl exec -it`s you into one. A whole node is an 8-GPU `h100-8x` box or a 4-GPU `gb200-4x` NVL72 tray, chosen with `--gpu-variant`. Marin's GPUs are CoreWeave Kubernetes pods, not GCE VMs, so access is `kubectl`, not SSH — there is no `ssh`/`scp` transport and no `~/.ssh/config` alias.
 
 This is a lean tool: `allocate`, `connect`, `status`, `release`. It does not sync files or run remote env setup (no `execute`/`watch`/`setup_env`). The CoreWeave task image is self-contained; the loop is "reserve a node, shell in." Sync those steps in yourself once connected.
 
 ## Cost rule
 
-A holder pod sits on an expensive 8×H100 node for the session's lifetime, and a `--nodes N` session holds N of them. Release as soon as you are done — `Ctrl-C` the `allocate` terminal, or run `release` from another shell.
+A holder pod sits on an expensive whole node — 8×H100 or 4×GB200 — for the session's lifetime, and a `--nodes N` session holds N of them. Release as soon as you are done — `Ctrl-C` the `allocate` terminal, or run `release` from another shell.
 
 ## Commands
 
@@ -77,7 +77,11 @@ The `iris-task` image ships a CPU-only `uv` environment at `/app`, so bare `pyth
 cd /app && uv sync --all-packages --extra=gpu
 ```
 
-`--all-packages` is required: the `gpu` extra is defined on the sub-packages (`marin-levanter` / `marin-core`), not the root project. This is the GPU analog of `dev_tpu.py`'s `--extra=tpu`. Verify the hardware with `nvidia-smi -L` (expect 8×H100 80GB on a whole node).
+`--all-packages` is required: the `gpu` extra is defined on the sub-packages (`marin-levanter` / `marin-core`), not the root project. This is the GPU analog of `dev_tpu.py`'s `--extra=tpu`.
+
+This recipe is only exercised on H100. GB200 trays are aarch64 Grace hosts and pull a different CUDA wheel set, so treat the sync as untested there.
+
+Either way, `nvidia-smi -L` confirms what the pod actually got: 8×H100 80GB, or 4×GB200 on a `gb200-4x` tray.
 
 ## Observability
 
@@ -99,7 +103,7 @@ kubectl --kubeconfig ~/.kube/coreweave-iris --context marin-gpu_US-EAST-02A \
 
 - Local session state lives under `~/.cache/marin/dev_gpu_iris/`.
 - If the `allocate` terminal dies unexpectedly, run `release` to terminate the holder job and clear the stale state file.
-- A failed `allocate` cleans up after itself: the holder job is terminated and the local state file is removed only once the job is confirmed gone, so a failed terminate never orphans an expensive pod with no local record of its job id.
+- A failed `allocate` attempts cleanup on its way out: it terminates the holder job and drops the local state file only if that terminate call was accepted. An accepted terminate is not proof the pod is gone — confirm with `iris job list` when it matters. If the call fails, the state file survives, so you always keep a local record of the job id and can retry with `release`.
 - `connect` execs into the pods resolved at allocation time. If Iris rescheduled a task onto a new pod while the job stayed active, `connect` fails for that node — re-allocate.
 
 ## Agent Usage
@@ -111,6 +115,10 @@ export GPU_NAME="${USER}-$(git rev-parse --abbrev-ref HEAD | tr '/' '-')"
 uv run scripts/iris/dev_gpu.py --config lib/iris/config/cw-us-east-02a.yaml --name "$GPU_NAME" allocate
 ```
 
+`allocate` blocks until Ctrl-C, so an agent has to launch it detached — and Ctrl-C cannot reach it there. A background job started from a non-interactive shell inherits `SIGINT` as ignored, so `kill -INT` does nothing and Python never raises `KeyboardInterrupt`. Release with the `release` subcommand from a second shell instead; the held `allocate` notices the dead job within 30 s, cleans up, and exits.
+
+Its stdout is block-buffered into a redirected log, so the session summary only appears once the process exits. Read `~/.cache/marin/dev_gpu_iris/<name>.json` for live session state.
+
 ## Cleanup
 
-Normal cleanup is `Ctrl-C` in the `allocate` terminal. To clean up from another shell, run the `release` subcommand (add `--force` only if the job is already dead and `release` keeps erroring).
+Normal cleanup is `Ctrl-C` in the `allocate` terminal, which only works when `allocate` is running in the foreground of a real terminal. To clean up from another shell, or from any agent-launched session, run the `release` subcommand (add `--force` only if the job is already dead and `release` keeps erroring).

--- a/scripts/iris/dev_gpu.py
+++ b/scripts/iris/dev_gpu.py
@@ -19,12 +19,12 @@ from pathlib import Path
 from types import MappingProxyType
 
 import click
-from iris.client import IrisClient, JobAlreadyExists
+from iris.client import IrisClient, Job, JobAlreadyExists
 from iris.cluster.backends.k8s.tasks import _LABEL_TASK_ID, _sanitize_label_value
 from iris.cluster.composer import provider_bundle
 from iris.cluster.config import IrisClusterConfig, load_config
-from iris.cluster.platforms.k8s.coreweave_topology import NVL72_GPUS_PER_NODE
-from iris.cluster.types import Entrypoint, JobName, ResourceSpec, gpu_device
+from iris.cluster.platforms.k8s.coreweave_topology import NVL72_GPUS_PER_NODE, gpu_gang_coscheduling_level
+from iris.cluster.types import CoschedulingConfig, Entrypoint, JobName, ResourceSpec, gpu_device
 from iris.rpc import job_pb2
 
 logger = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ PRIORITY_BANDS = MappingProxyType(
     }
 )
 
-# GPUs on one whole node of a given variant, used as the default --gpu-count so a dev
+# GPUs on one whole node of a given variant, used as the default --gpus-per-node so a dev
 # session grabs exactly one node. An H100 node is an 8-GPU DGX box; a GB200 node is a
 # 4-GPU NVL72 compute tray (a rack/NVLink domain is 18 of them = 72 GPUs). These are the
 # only variants the clusters we have access to expose.
@@ -98,17 +98,25 @@ class CoreweaveTarget:
 
 
 @dataclass(frozen=True)
+class DevGpuNode:
+    """One node of a dev GPU session: an Iris task and the k8s pod running it."""
+
+    task_id: str
+    pod: PodRef
+
+
+@dataclass(frozen=True)
 class DevGpuState:
     """Persisted local state for an active dev GPU session."""
 
     session_name: str
     config_file: str
     job_id: str
-    gpu_count: int
+    gpus_per_node: int
     gpu_variant: str
     priority: Priority
     target: CoreweaveTarget
-    pod: PodRef
+    nodes: list[DevGpuNode]
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), indent=2, sort_keys=True)
@@ -120,13 +128,11 @@ class DevGpuState:
             session_name=data["session_name"],
             config_file=data["config_file"],
             job_id=data["job_id"],
-            gpu_count=data["gpu_count"],
-            # Sessions allocated before the variant was configurable were all H100;
-            # default so they still load for status/connect/release after an upgrade.
-            gpu_variant=data.get("gpu_variant", DEFAULT_GPU_VARIANT),
-            priority=Priority(data.get("priority", Priority.INTERACTIVE)),
+            gpus_per_node=data["gpus_per_node"],
+            gpu_variant=data["gpu_variant"],
+            priority=Priority(data["priority"]),
             target=CoreweaveTarget(**data["target"]),
-            pod=PodRef(**data["pod"]),
+            nodes=[DevGpuNode(task_id=node["task_id"], pod=PodRef(**node["pod"])) for node in data["nodes"]],
         )
 
 
@@ -154,6 +160,53 @@ def require_coreweave_platform(config: IrisClusterConfig) -> CoreweaveTarget:
         kubeconfig_path=kubeconfig_path,
         kube_context=config.platform.coreweave.kube_context,
     )
+
+
+def resolve_coscheduling(gpu_variant: str, gpus_per_node: int, node_count: int) -> CoschedulingConfig | None:
+    """Gang-scheduling level for a multi-node dev session, or None for a single node.
+
+    Multi-node sessions must saturate each node's GPUs. Every level Iris derives — the
+    NVLink-domain binds for GB200, soft ``leafgroup`` IB colocation for everything else —
+    assumes one pod per node, and fractional pods would let two nodes of the session land
+    on the same physical machine.
+    """
+    if node_count == 1:
+        return None
+    whole_node = GPUS_PER_NODE[gpu_variant]
+    if gpus_per_node != whole_node:
+        raise click.ClickException(
+            f"--nodes {node_count} reserves whole nodes, so --gpus-per-node must be {whole_node} "
+            f"for {gpu_variant}; got {gpus_per_node}."
+        )
+    try:
+        level = gpu_gang_coscheduling_level(gpu_variant, gpus_per_node, node_count)
+    except ValueError as exc:
+        raise click.ClickException(f"--nodes {node_count} for {gpu_variant}: {exc}") from exc
+    return CoschedulingConfig(group_by=level)
+
+
+def select_node(state: DevGpuState, node_index: int) -> DevGpuNode:
+    if node_index >= len(state.nodes):
+        raise click.ClickException(
+            f"Dev GPU session '{state.session_name}' has {len(state.nodes)} node(s); "
+            f"--node {node_index} is out of range."
+        )
+    return state.nodes[node_index]
+
+
+def session_summary(state: DevGpuState) -> str:
+    """Render the session as one human-readable block, one line per reserved pod."""
+    lines = [
+        f"Session: {state.session_name}",
+        f"Job: {state.job_id}",
+        f"Config: {state.config_file}",
+        f"Nodes: {len(state.nodes)} x {state.gpus_per_node} {state.gpu_variant}",
+        f"Priority: {state.priority.value}",
+    ]
+    lines += [
+        f"Pod[{index}]: {node.pod.pod_name} (namespace={node.pod.namespace})" for index, node in enumerate(state.nodes)
+    ]
+    return "\n".join(lines)
 
 
 def pod_label_selector(task_id: str) -> str:
@@ -237,8 +290,12 @@ def is_job_active(client: IrisClient, job_id: str) -> bool:
     return client.job_state(JobName.from_wire(job_id)) not in INACTIVE_JOB_STATES
 
 
-def wait_for_running_task(job, *, timeout: float) -> str:
-    """Block until the holder job's single task is RUNNING; return its task_id."""
+def wait_for_running_tasks(job: Job, *, node_count: int, timeout: float) -> list[str]:
+    """Block until every holder task is RUNNING; return their task_ids ordered by task index.
+
+    A gang either lands whole or not at all, so this waits for all ``node_count`` tasks
+    rather than shelling into a partially-placed session.
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         state = job.state_only()
@@ -246,12 +303,10 @@ def wait_for_running_task(job, *, timeout: float) -> str:
             error = job.status().error or job_pb2.JobState.Name(state)
             raise click.ClickException(f"Dev GPU allocation failed: {error}")
         tasks = job.tasks()
-        if tasks:
-            task = tasks[0]
-            if task.status().state == job_pb2.TASK_STATE_RUNNING:
-                return str(task.task_id)
+        if len(tasks) == node_count and all(task.status().state == job_pb2.TASK_STATE_RUNNING for task in tasks):
+            return [str(task.task_id) for task in sorted(tasks, key=lambda task: task.task_index)]
         time.sleep(5)
-    raise click.ClickException(f"Timed out waiting for dev GPU task after {int(timeout)}s")
+    raise click.ClickException(f"Timed out waiting for {node_count} dev GPU task(s) after {int(timeout)}s")
 
 
 def wait_for_running_pod(target: CoreweaveTarget, task_id: str, *, timeout: float) -> PodRef:
@@ -306,12 +361,23 @@ def cli(ctx, config: str | None, session_name: str | None, verbose: bool) -> Non
     help="GPU variant to reserve. Passed through to Iris, which schedules onto the matching node pool.",
 )
 @click.option(
-    "--gpu-count",
+    "--gpus-per-node",
     type=click.IntRange(min=1),
     default=None,
-    help="GPUs to reserve. Defaults to one whole node of the chosen --gpu-variant "
-    "(H100: 8, GB200: 4). Whole-node counts are what the bare-metal pools validate; "
-    "smaller values may not schedule.",
+    help="GPUs to reserve on each node. Defaults to one whole node of the chosen "
+    "--gpu-variant (H100: 8, GB200: 4). Whole-node counts are what the bare-metal pools "
+    "validate; smaller values may not schedule, and --nodes > 1 requires the whole-node count.",
+)
+@click.option(
+    "--nodes",
+    "node_count",
+    type=click.IntRange(min=1),
+    default=1,
+    show_default=True,
+    help="Whole nodes to reserve in a single session. More than one gang-schedules them "
+    "together: a GB200 gang of up to 16 nodes binds hard to a single NVLink domain and a "
+    "larger one splits into balanced per-rack slices, while other variants get soft "
+    "InfiniBand leafgroup colocation. Every node is a separate pod; connect with --node.",
 )
 @click.option(
     "--priority",
@@ -345,7 +411,8 @@ def cli(ctx, config: str | None, session_name: str | None, verbose: bool) -> Non
 def allocate(
     ctx,
     gpu_variant: str,
-    gpu_count: int | None,
+    gpus_per_node: int | None,
+    node_count: int,
     priority: str,
     cpu: float,
     memory: str,
@@ -353,14 +420,15 @@ def allocate(
     timeout: int,
     pod_timeout: int,
 ) -> None:
-    """Allocate a dev GPU pod and hold it until Ctrl-C."""
+    """Allocate one or more dev GPU nodes and hold them until Ctrl-C."""
     if not ctx.obj.config_file:
         raise click.ClickException("--config is required")
 
-    # click.Choice(case_sensitive=False) already normalized gpu_variant to a canonical
-    # key of GPUS_PER_NODE, so a bare --gpu-count defaults to that variant's whole node.
-    if gpu_count is None:
-        gpu_count = GPUS_PER_NODE[gpu_variant]
+    # click.Choice(case_sensitive=False) already normalized gpu_variant to a canonical key
+    # of GPUS_PER_NODE, so a bare --gpus-per-node defaults to that variant's whole node.
+    if gpus_per_node is None:
+        gpus_per_node = GPUS_PER_NODE[gpu_variant]
+    coscheduling = resolve_coscheduling(gpu_variant, gpus_per_node, node_count)
     resolved_priority = Priority(priority)
 
     session_name = ctx.obj.session_name
@@ -374,37 +442,40 @@ def allocate(
 
     state: DevGpuState | None = None
     with controller_client(ctx.obj.config_file) as client:
-        resources = ResourceSpec(cpu=cpu, memory=memory, disk=disk, device=gpu_device(gpu_variant, gpu_count))
+        resources = ResourceSpec(cpu=cpu, memory=memory, disk=disk, device=gpu_device(gpu_variant, gpus_per_node))
         try:
             job = client.submit(
                 entrypoint=Entrypoint.from_command("python", "-c", HOLDER_COMMAND),
                 name=f"dev-gpu-{session_name}",
                 resources=resources,
                 priority_band=PRIORITY_BANDS[resolved_priority],
+                replicas=node_count,
+                coscheduling=coscheduling,
             )
         except JobAlreadyExists as exc:
             raise click.ClickException(f"Job already exists for session '{session_name}': {exc}") from exc
 
         try:
-            task_id = wait_for_running_task(job, timeout=timeout)
-            pod = wait_for_running_pod(target, task_id, timeout=pod_timeout)
+            task_ids = wait_for_running_tasks(job, node_count=node_count, timeout=timeout)
+            nodes = [
+                DevGpuNode(task_id=task_id, pod=wait_for_running_pod(target, task_id, timeout=pod_timeout))
+                for task_id in task_ids
+            ]
             state = DevGpuState(
                 session_name=session_name,
                 config_file=ctx.obj.config_file,
                 job_id=str(job.job_id),
-                gpu_count=gpu_count,
+                gpus_per_node=gpus_per_node,
                 gpu_variant=gpu_variant,
                 priority=resolved_priority,
                 target=target,
-                pod=pod,
+                nodes=nodes,
             )
             save_state(state_file, state)
 
-            print(f"Session: {session_name}")
-            print(f"Job: {job.job_id}")
-            print(f"GPUs: {gpu_count} x {gpu_variant}")
-            print(f"Priority: {resolved_priority.value}")
-            print(f"Pod: {pod.pod_name} (namespace={pod.namespace})")
+            print(session_summary(state))
+            if coscheduling is not None:
+                print(f"Coscheduling: {coscheduling.group_by}")
             print("\nAllocation is active. Press Ctrl-C to release.")
 
             while True:
@@ -432,10 +503,19 @@ def allocate(
 
 
 @cli.command("connect")
+@click.option(
+    "--node",
+    "node_index",
+    type=click.IntRange(min=0),
+    default=0,
+    show_default=True,
+    help="Which node of the session to shell into, in `status` pod order.",
+)
 @click.pass_context
-def connect(ctx) -> None:
-    """Open an interactive shell into the reserved pod."""
+def connect(ctx, node_index: int) -> None:
+    """Open an interactive shell into one of the reserved pods."""
     state = load_state(state_path(ctx.obj.state_dir, ctx.obj.session_name))
+    node = select_node(state, node_index)
     # connect fundamentally only needs `kubectl exec`. The controller liveness check is a
     # courtesy: if the controller is reachable and reports the job inactive we fail fast,
     # but if reaching the controller itself fails we proceed, since a healthy pod should
@@ -453,22 +533,16 @@ def connect(ctx) -> None:
             raise click.ClickException(
                 f"Dev GPU session '{state.session_name}' is no longer active. Use release to clean up."
             )
-    # state.pod is the pod resolved at allocation time. If Iris rescheduled the task
+    # node.pod is the pod resolved at allocation time. If Iris rescheduled the task
     # onto a new pod while the job stayed active, this kubectl exec fails; re-allocate.
-    run_logged(kubectl_connect_cmd(state.target, state.pod), check=True)
+    run_logged(kubectl_connect_cmd(state.target, node.pod), check=True)
 
 
 @cli.command("status")
 @click.pass_context
 def status(ctx) -> None:
     """Show the current session state."""
-    state = load_state(state_path(ctx.obj.state_dir, ctx.obj.session_name))
-    print(f"Session: {state.session_name}")
-    print(f"Job: {state.job_id}")
-    print(f"Config: {state.config_file}")
-    print(f"GPUs: {state.gpu_count} x {state.gpu_variant}")
-    print(f"Priority: {state.priority.value}")
-    print(f"Pod: {state.pod.pod_name} (namespace={state.pod.namespace})")
+    print(session_summary(load_state(state_path(ctx.obj.state_dir, ctx.obj.session_name))))
 
 
 @cli.command("release")

--- a/scripts/iris/dev_gpu.py
+++ b/scripts/iris/dev_gpu.py
@@ -98,16 +98,8 @@ class CoreweaveTarget:
 
 
 @dataclass(frozen=True)
-class DevGpuNode:
-    """One node of a dev GPU session: an Iris task and the k8s pod running it."""
-
-    task_id: str
-    pod: PodRef
-
-
-@dataclass(frozen=True)
 class DevGpuState:
-    """Persisted local state for an active dev GPU session."""
+    """Persisted local state for an active dev GPU session. One pod per reserved node."""
 
     session_name: str
     config_file: str
@@ -116,7 +108,7 @@ class DevGpuState:
     gpu_variant: str
     priority: Priority
     target: CoreweaveTarget
-    nodes: list[DevGpuNode]
+    pods: list[PodRef]
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), indent=2, sort_keys=True)
@@ -132,7 +124,7 @@ class DevGpuState:
             gpu_variant=data["gpu_variant"],
             priority=Priority(data["priority"]),
             target=CoreweaveTarget(**data["target"]),
-            nodes=[DevGpuNode(task_id=node["task_id"], pod=PodRef(**node["pod"])) for node in data["nodes"]],
+            pods=[PodRef(**pod) for pod in data["pods"]],
         )
 
 
@@ -185,27 +177,16 @@ def resolve_coscheduling(gpu_variant: str, gpus_per_node: int, node_count: int) 
     return CoschedulingConfig(group_by=level)
 
 
-def select_node(state: DevGpuState, node_index: int) -> DevGpuNode:
-    if node_index >= len(state.nodes):
-        raise click.ClickException(
-            f"Dev GPU session '{state.session_name}' has {len(state.nodes)} node(s); "
-            f"--node {node_index} is out of range."
-        )
-    return state.nodes[node_index]
-
-
 def session_summary(state: DevGpuState) -> str:
-    """Render the session as one human-readable block, one line per reserved pod."""
+    """Render the session as one human-readable block, one line per reserved node."""
     lines = [
         f"Session: {state.session_name}",
         f"Job: {state.job_id}",
         f"Config: {state.config_file}",
-        f"Nodes: {len(state.nodes)} x {state.gpus_per_node} {state.gpu_variant}",
+        f"Nodes: {len(state.pods)} x {state.gpus_per_node} {state.gpu_variant}",
         f"Priority: {state.priority.value}",
     ]
-    lines += [
-        f"Pod[{index}]: {node.pod.pod_name} (namespace={node.pod.namespace})" for index, node in enumerate(state.nodes)
-    ]
+    lines += [f"Node {index}: {pod.pod_name} (namespace={pod.namespace})" for index, pod in enumerate(state.pods)]
     return "\n".join(lines)
 
 
@@ -457,10 +438,6 @@ def allocate(
 
         try:
             task_ids = wait_for_running_tasks(job, node_count=node_count, timeout=timeout)
-            nodes = [
-                DevGpuNode(task_id=task_id, pod=wait_for_running_pod(target, task_id, timeout=pod_timeout))
-                for task_id in task_ids
-            ]
             state = DevGpuState(
                 session_name=session_name,
                 config_file=ctx.obj.config_file,
@@ -469,7 +446,7 @@ def allocate(
                 gpu_variant=gpu_variant,
                 priority=resolved_priority,
                 target=target,
-                nodes=nodes,
+                pods=[wait_for_running_pod(target, task_id, timeout=pod_timeout) for task_id in task_ids],
             )
             save_state(state_file, state)
 
@@ -515,7 +492,11 @@ def allocate(
 def connect(ctx, node_index: int) -> None:
     """Open an interactive shell into one of the reserved pods."""
     state = load_state(state_path(ctx.obj.state_dir, ctx.obj.session_name))
-    node = select_node(state, node_index)
+    if node_index >= len(state.pods):
+        raise click.ClickException(
+            f"Dev GPU session '{state.session_name}' has {len(state.pods)} node(s); "
+            f"--node {node_index} is out of range."
+        )
     # connect fundamentally only needs `kubectl exec`. The controller liveness check is a
     # courtesy: if the controller is reachable and reports the job inactive we fail fast,
     # but if reaching the controller itself fails we proceed, since a healthy pod should
@@ -533,9 +514,9 @@ def connect(ctx, node_index: int) -> None:
             raise click.ClickException(
                 f"Dev GPU session '{state.session_name}' is no longer active. Use release to clean up."
             )
-    # node.pod is the pod resolved at allocation time. If Iris rescheduled the task
+    # These are the pods resolved at allocation time. If Iris rescheduled the task
     # onto a new pod while the job stayed active, this kubectl exec fails; re-allocate.
-    run_logged(kubectl_connect_cmd(state.target, node.pod), check=True)
+    run_logged(kubectl_connect_cmd(state.target, state.pods[node_index]), check=True)
 
 
 @cli.command("status")

--- a/scripts/iris/tests/test_dev_gpu.py
+++ b/scripts/iris/tests/test_dev_gpu.py
@@ -1,13 +1,8 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import json
-import subprocess
-from contextlib import contextmanager
-
 import click
 import pytest
-from click.testing import CliRunner
 from iris.cluster.config import (
     CoreweavePlatformConfig,
     IrisClusterConfig,
@@ -16,127 +11,37 @@ from iris.cluster.config import (
 )
 from iris.rpc import job_pb2
 
-from scripts.iris import dev_gpu
 from scripts.iris.dev_gpu import (
     CoreweaveTarget,
-    DevGpuNode,
     DevGpuState,
     PodRef,
     Priority,
     parse_running_pod,
-    pod_label_selector,
     require_coreweave_platform,
     resolve_coscheduling,
-    select_node,
     session_summary,
+    wait_for_running_tasks,
 )
 
 JOB_ID = "/dev/dev-gpu-devbox"
 
 
-def make_node(index: int) -> DevGpuNode:
-    return DevGpuNode(
-        task_id=f"{JOB_ID}/{index}",
-        pod=PodRef(namespace="iris", pod_name=f"dev-gpu-pod-{index}", container="task"),
-    )
-
-
-def make_state(node_count: int, *, gpu_variant: str = "GB200", gpus_per_node: int = 4) -> DevGpuState:
+def make_state(node_count: int) -> DevGpuState:
     return DevGpuState(
         session_name="devbox",
         config_file="/abs/coreweave.yaml",
         job_id=JOB_ID,
-        gpus_per_node=gpus_per_node,
-        gpu_variant=gpu_variant,
+        gpus_per_node=4,
+        gpu_variant="GB200",
         priority=Priority.INTERACTIVE,
         target=CoreweaveTarget(namespace="iris", kubeconfig_path="/k/cfg"),
-        nodes=[make_node(index) for index in range(node_count)],
-    )
-
-
-class FakeTask:
-    def __init__(self, task_id: str, task_index: int):
-        self.task_id = task_id
-        self.task_index = task_index
-
-    def status(self):
-        return job_pb2.TaskStatus(state=job_pb2.TASK_STATE_RUNNING)
-
-
-class FakeJob:
-    def __init__(self, job_id: str, replicas: int):
-        self.job_id = job_id
-        # Reverse order: the tool must sort by task index, not trust list order,
-        # or `connect --node 1` would land on an arbitrary pod.
-        self._tasks = [FakeTask(f"{job_id}/{index}", index) for index in reversed(range(replicas))]
-
-    def state_only(self):
-        return job_pb2.JOB_STATE_RUNNING
-
-    def tasks(self):
-        return self._tasks
-
-
-class FakeClient:
-    def __init__(self):
-        self.submitted: dict = {}
-        self.terminated: list[str] = []
-
-    def submit(self, **kwargs):
-        self.submitted = kwargs
-        return FakeJob(JOB_ID, kwargs["replicas"])
-
-    def terminate(self, job_name):
-        self.terminated.append(str(job_name))
-
-    def job_state(self, job_name):
-        return job_pb2.JOB_STATE_RUNNING
-
-
-def coreweave_config() -> IrisClusterConfig:
-    return IrisClusterConfig(
-        platform=PlatformConfig(coreweave=CoreweavePlatformConfig(kubeconfig_path="/k/cfg")),
-        kubernetes_provider=KubernetesProviderConfig(namespace="iris"),
-    )
-
-
-@pytest.fixture
-def fake_cluster(monkeypatch, tmp_path):
-    """Run dev_gpu's CLI against a fake controller and a fake kubectl.
-
-    One pod per task, named after the task's index, so a test can assert which pod a
-    session recorded for which node.
-    """
-    client = FakeClient()
-
-    @contextmanager
-    def fake_controller_client(config_file):
-        yield client
-
-    def fake_kubectl(cmd, **kwargs):
-        selector = cmd[cmd.index("-l") + 1]
-        index = next(i for i in range(8) if pod_label_selector(f"{JOB_ID}/{i}") == selector)
-        pods = {"items": [{"metadata": {"name": f"dev-gpu-pod-{index}"}, "status": {"phase": "Running"}}]}
-        return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(pods), stderr="")
-
-    monkeypatch.setattr(dev_gpu, "load_config", lambda config_file: coreweave_config())
-    monkeypatch.setattr(dev_gpu, "controller_client", fake_controller_client)
-    monkeypatch.setattr(dev_gpu.subprocess, "run", fake_kubectl)
-    return client
-
-
-def invoke(state_dir, *args):
-    return CliRunner().invoke(
-        dev_gpu.cli,
-        ["--config", "/abs/coreweave.yaml", "--name", "devbox", *args],
-        obj=dev_gpu.Context(state_dir=state_dir),
+        pods=[PodRef(namespace="iris", pod_name=f"dev-gpu-pod-{i}", container="task") for i in range(node_count)],
     )
 
 
 def test_state_round_trip():
     # The session file is a persisted contract: `status` and `release` read it back.
-    state = make_state(2)
-    assert DevGpuState.from_json(state.to_json()) == state
+    assert DevGpuState.from_json(make_state(2).to_json()) == make_state(2)
 
 
 def test_require_coreweave_namespace_comes_from_kubernetes_provider():
@@ -203,61 +108,37 @@ def test_multi_node_rejects_fractional_pods():
         resolve_coscheduling("GB200", 2, 2)
 
 
-def test_connect_rejects_out_of_range_node():
-    with pytest.raises(click.ClickException, match="has 2 node"):
-        select_node(make_state(2), 2)
-
-
-def test_session_summary_lists_every_pod():
+def test_session_summary_lists_every_node():
     summary = session_summary(make_state(2))
     assert "Nodes: 2 x 4 GB200" in summary
-    assert "Pod[0]: dev-gpu-pod-0" in summary
-    assert "Pod[1]: dev-gpu-pod-1" in summary
+    assert "Node 0: dev-gpu-pod-0" in summary
+    assert "Node 1: dev-gpu-pod-1" in summary
 
 
-@pytest.mark.parametrize(
-    "variant, node_count, expected_coscheduling",
-    [("H100", 1, None), ("GB200", 2, "nvlink.domain")],
-)
-def test_allocate_records_every_node_then_releases(
-    fake_cluster, monkeypatch, tmp_path, variant, node_count, expected_coscheduling
-):
-    """allocate holds the gang, records one pod per node, and releases on Ctrl-C."""
-    state_file = tmp_path / "devbox.json"
-    held: list[DevGpuState] = []
+class FakeTask:
+    def __init__(self, task_index: int):
+        self.task_id = f"{JOB_ID}/{task_index}"
+        self.task_index = task_index
 
-    def interrupt_the_hold(seconds):
-        held.append(DevGpuState.from_json(state_file.read_text()))
-        raise KeyboardInterrupt
-
-    monkeypatch.setattr(dev_gpu.time, "sleep", interrupt_the_hold)
-
-    result = invoke(tmp_path, "allocate", "--gpu-variant", variant, "--nodes", str(node_count))
-    assert result.exit_code == 0, result.output
-
-    assert fake_cluster.submitted["replicas"] == node_count
-    coscheduling = fake_cluster.submitted["coscheduling"]
-    assert (coscheduling.group_by if coscheduling else None) == expected_coscheduling
-
-    (state,) = held
-    assert [node.pod.pod_name for node in state.nodes] == [f"dev-gpu-pod-{i}" for i in range(node_count)]
-    assert state.gpus_per_node == dev_gpu.GPUS_PER_NODE[variant]
-    for index, node in enumerate(state.nodes):
-        assert node.task_id == f"{JOB_ID}/{index}"
-
-    # Releasing must tear down the whole gang and leave no stale session behind.
-    assert fake_cluster.terminated == [JOB_ID]
-    assert not state_file.exists()
+    def status(self):
+        return job_pb2.TaskStatus(state=job_pb2.TASK_STATE_RUNNING)
 
 
-def test_connect_targets_the_requested_node(fake_cluster, monkeypatch, tmp_path):
-    dev_gpu.save_state(tmp_path / "devbox.json", make_state(2))
-    connect_commands: list[list[str]] = []
-    monkeypatch.setattr(dev_gpu, "run_logged", lambda cmd, **kwargs: connect_commands.append(cmd))
+class FakeJob:
+    """A running job whose tasks come back in an arbitrary order."""
 
-    result = invoke(tmp_path, "connect", "--node", "1")
-    assert result.exit_code == 0, result.output
+    def __init__(self, replicas: int):
+        self.tasks_returned = [FakeTask(index) for index in reversed(range(replicas))]
 
-    (cmd,) = connect_commands
-    assert "dev-gpu-pod-1" in cmd
-    assert "dev-gpu-pod-0" not in cmd
+    def state_only(self):
+        return job_pb2.JOB_STATE_RUNNING
+
+    def tasks(self):
+        return self.tasks_returned
+
+
+def test_running_tasks_come_back_in_task_index_order():
+    # `connect --node 1` means "the second node", so pod order must follow the task
+    # index rather than whatever order the controller happens to list tasks in.
+    task_ids = wait_for_running_tasks(FakeJob(2), node_count=2, timeout=1)
+    assert task_ids == [f"{JOB_ID}/0", f"{JOB_ID}/1"]

--- a/scripts/iris/tests/test_dev_gpu.py
+++ b/scripts/iris/tests/test_dev_gpu.py
@@ -1,36 +1,141 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+import subprocess
+from contextlib import contextmanager
+
+import click
 import pytest
+from click.testing import CliRunner
 from iris.cluster.config import (
     CoreweavePlatformConfig,
     IrisClusterConfig,
     KubernetesProviderConfig,
     PlatformConfig,
 )
+from iris.rpc import job_pb2
 
+from scripts.iris import dev_gpu
 from scripts.iris.dev_gpu import (
     CoreweaveTarget,
+    DevGpuNode,
     DevGpuState,
     PodRef,
     Priority,
     parse_running_pod,
+    pod_label_selector,
     require_coreweave_platform,
+    resolve_coscheduling,
+    select_node,
+    session_summary,
 )
+
+JOB_ID = "/dev/dev-gpu-devbox"
+
+
+def make_node(index: int) -> DevGpuNode:
+    return DevGpuNode(
+        task_id=f"{JOB_ID}/{index}",
+        pod=PodRef(namespace="iris", pod_name=f"dev-gpu-pod-{index}", container="task"),
+    )
+
+
+def make_state(node_count: int, *, gpu_variant: str = "GB200", gpus_per_node: int = 4) -> DevGpuState:
+    return DevGpuState(
+        session_name="devbox",
+        config_file="/abs/coreweave.yaml",
+        job_id=JOB_ID,
+        gpus_per_node=gpus_per_node,
+        gpu_variant=gpu_variant,
+        priority=Priority.INTERACTIVE,
+        target=CoreweaveTarget(namespace="iris", kubeconfig_path="/k/cfg"),
+        nodes=[make_node(index) for index in range(node_count)],
+    )
+
+
+class FakeTask:
+    def __init__(self, task_id: str, task_index: int):
+        self.task_id = task_id
+        self.task_index = task_index
+
+    def status(self):
+        return job_pb2.TaskStatus(state=job_pb2.TASK_STATE_RUNNING)
+
+
+class FakeJob:
+    def __init__(self, job_id: str, replicas: int):
+        self.job_id = job_id
+        # Reverse order: the tool must sort by task index, not trust list order,
+        # or `connect --node 1` would land on an arbitrary pod.
+        self._tasks = [FakeTask(f"{job_id}/{index}", index) for index in reversed(range(replicas))]
+
+    def state_only(self):
+        return job_pb2.JOB_STATE_RUNNING
+
+    def tasks(self):
+        return self._tasks
+
+
+class FakeClient:
+    def __init__(self):
+        self.submitted: dict = {}
+        self.terminated: list[str] = []
+
+    def submit(self, **kwargs):
+        self.submitted = kwargs
+        return FakeJob(JOB_ID, kwargs["replicas"])
+
+    def terminate(self, job_name):
+        self.terminated.append(str(job_name))
+
+    def job_state(self, job_name):
+        return job_pb2.JOB_STATE_RUNNING
+
+
+def coreweave_config() -> IrisClusterConfig:
+    return IrisClusterConfig(
+        platform=PlatformConfig(coreweave=CoreweavePlatformConfig(kubeconfig_path="/k/cfg")),
+        kubernetes_provider=KubernetesProviderConfig(namespace="iris"),
+    )
+
+
+@pytest.fixture
+def fake_cluster(monkeypatch, tmp_path):
+    """Run dev_gpu's CLI against a fake controller and a fake kubectl.
+
+    One pod per task, named after the task's index, so a test can assert which pod a
+    session recorded for which node.
+    """
+    client = FakeClient()
+
+    @contextmanager
+    def fake_controller_client(config_file):
+        yield client
+
+    def fake_kubectl(cmd, **kwargs):
+        selector = cmd[cmd.index("-l") + 1]
+        index = next(i for i in range(8) if pod_label_selector(f"{JOB_ID}/{i}") == selector)
+        pods = {"items": [{"metadata": {"name": f"dev-gpu-pod-{index}"}, "status": {"phase": "Running"}}]}
+        return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps(pods), stderr="")
+
+    monkeypatch.setattr(dev_gpu, "load_config", lambda config_file: coreweave_config())
+    monkeypatch.setattr(dev_gpu, "controller_client", fake_controller_client)
+    monkeypatch.setattr(dev_gpu.subprocess, "run", fake_kubectl)
+    return client
+
+
+def invoke(state_dir, *args):
+    return CliRunner().invoke(
+        dev_gpu.cli,
+        ["--config", "/abs/coreweave.yaml", "--name", "devbox", *args],
+        obj=dev_gpu.Context(state_dir=state_dir),
+    )
 
 
 def test_state_round_trip():
     # The session file is a persisted contract: `status` and `release` read it back.
-    state = DevGpuState(
-        session_name="matt",
-        config_file="/abs/coreweave.yaml",
-        job_id="/matt/dev-gpu-matt",
-        gpu_count=8,
-        gpu_variant="H100",
-        priority=Priority.BATCH,
-        target=CoreweaveTarget(namespace="iris", kubeconfig_path="/k/cfg"),
-        pod=PodRef(namespace="iris", pod_name="dev-gpu-matt-abc", container="task"),
-    )
+    state = make_state(2)
     assert DevGpuState.from_json(state.to_json()) == state
 
 
@@ -73,3 +178,86 @@ def test_require_coreweave_namespace_comes_from_kubernetes_provider():
 )
 def test_parse_running_pod(pods, expected):
     assert parse_running_pod(pods) == expected
+
+
+@pytest.mark.parametrize(
+    "variant, gpus_per_node, node_count, expected",
+    [
+        # A single node needs no gang at all.
+        ("GB200", 4, 1, None),
+        ("H100", 8, 1, None),
+        # The point of a two-node GB200 session: both trays on one rack's NVLink fabric.
+        ("GB200", 4, 2, "nvlink.domain"),
+        # H100 nodes carry no nvlink.domain label, so the gang gets soft IB colocation.
+        ("H100", 8, 2, "leafgroup"),
+    ],
+)
+def test_resolve_coscheduling(variant, gpus_per_node, node_count, expected):
+    level = resolve_coscheduling(variant, gpus_per_node, node_count)
+    assert (level.group_by if level else None) == expected
+
+
+def test_multi_node_rejects_fractional_pods():
+    # Two 2-GPU pods could both land on one 4-GPU tray, which is not a two-node session.
+    with pytest.raises(click.ClickException, match="whole nodes"):
+        resolve_coscheduling("GB200", 2, 2)
+
+
+def test_connect_rejects_out_of_range_node():
+    with pytest.raises(click.ClickException, match="has 2 node"):
+        select_node(make_state(2), 2)
+
+
+def test_session_summary_lists_every_pod():
+    summary = session_summary(make_state(2))
+    assert "Nodes: 2 x 4 GB200" in summary
+    assert "Pod[0]: dev-gpu-pod-0" in summary
+    assert "Pod[1]: dev-gpu-pod-1" in summary
+
+
+@pytest.mark.parametrize(
+    "variant, node_count, expected_coscheduling",
+    [("H100", 1, None), ("GB200", 2, "nvlink.domain")],
+)
+def test_allocate_records_every_node_then_releases(
+    fake_cluster, monkeypatch, tmp_path, variant, node_count, expected_coscheduling
+):
+    """allocate holds the gang, records one pod per node, and releases on Ctrl-C."""
+    state_file = tmp_path / "devbox.json"
+    held: list[DevGpuState] = []
+
+    def interrupt_the_hold(seconds):
+        held.append(DevGpuState.from_json(state_file.read_text()))
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(dev_gpu.time, "sleep", interrupt_the_hold)
+
+    result = invoke(tmp_path, "allocate", "--gpu-variant", variant, "--nodes", str(node_count))
+    assert result.exit_code == 0, result.output
+
+    assert fake_cluster.submitted["replicas"] == node_count
+    coscheduling = fake_cluster.submitted["coscheduling"]
+    assert (coscheduling.group_by if coscheduling else None) == expected_coscheduling
+
+    (state,) = held
+    assert [node.pod.pod_name for node in state.nodes] == [f"dev-gpu-pod-{i}" for i in range(node_count)]
+    assert state.gpus_per_node == dev_gpu.GPUS_PER_NODE[variant]
+    for index, node in enumerate(state.nodes):
+        assert node.task_id == f"{JOB_ID}/{index}"
+
+    # Releasing must tear down the whole gang and leave no stale session behind.
+    assert fake_cluster.terminated == [JOB_ID]
+    assert not state_file.exists()
+
+
+def test_connect_targets_the_requested_node(fake_cluster, monkeypatch, tmp_path):
+    dev_gpu.save_state(tmp_path / "devbox.json", make_state(2))
+    connect_commands: list[list[str]] = []
+    monkeypatch.setattr(dev_gpu, "run_logged", lambda cmd, **kwargs: connect_commands.append(cmd))
+
+    result = invoke(tmp_path, "connect", "--node", "1")
+    assert result.exit_code == 0, result.output
+
+    (cmd,) = connect_commands
+    assert "dev-gpu-pod-1" in cmd
+    assert "dev-gpu-pod-0" not in cmd


### PR DESCRIPTION
`dev_gpu.py --nodes N` holds N whole GPU nodes under one Iris job instead of a single pod. The tasks are gang-scheduled, so a session lands whole or not at all, and `connect --node I` shells into an individual pod. Iris derives the placement from the variant: a GB200 gang of up to 16 nodes binds hard to one `nvlink.domain`, so every tray shares a rack's NVLink fabric. H100 keeps soft leafgroup colocation.

Multi-node sessions have to saturate each node, so `--gpu-count` is now `--gpus-per-node` and a fractional pod is rejected before submit. A `gb200-4x` node has exactly 4 GPUs; a 2-GPU pod would let both nodes of a "two-node" session land on one machine, and nothing downstream catches that. The session file stores one pod per node and does not load older single-pod state.

Verified on `cw-us-east-08a` at interactive and production priority. A two-node GB200 session started two `gb200-4x` pods on distinct nodes in NVLink domain `DH1-122-US-EAST-08A`, each annotated `podset-required-topology=ds.coreweave.com/nvlink.domain`, each exposing 4 GB200 GPUs. Both were reachable through `connect`, and release left no pod and no state file.
