### PR TITLE
[datakit] Deduplicate repeated Stack v3 file entries

### DIFF
--- a/lib/marin/src/marin/datakit/download/stack_v3.py
+++ b/lib/marin/src/marin/datakit/download/stack_v3.py
@@ -24,7 +24,7 @@ TRAIN_PARQUET_GLOB = "data/*.parquet"
 REPOSITORY_HEADER = "Repository:"
 FILE_HEADER = "File:"
 UNKNOWN_FILE_PATH = "(unknown path)"
-SERIALIZATION_FORMAT = "natural_headers_directory_block_dfs_v1"
+SERIALIZATION_FORMAT = "natural_headers_directory_block_dfs_v2"
 
 OUTPUT_SCHEMA = pa.schema(
     [
@@ -134,8 +134,20 @@ def _directory_block_dfs(files: list[StackV3File]) -> list[StackV3File]:
     return ordered_files
 
 
+def deduplicate_files(files: list[StackV3File]) -> list[StackV3File]:
+    """Keep the first entry per ``(file_path, content_id)``.
+
+    A Stack v3 row lists the same file many times over -- commonly ten identical
+    entries per file -- and ``num_files`` counts every copy.
+    """
+    seen: dict[tuple[str, str], StackV3File] = {}
+    for file in files:
+        seen.setdefault((file["file_path"], file["content_id"]), file)
+    return list(seen.values())
+
+
 def row_to_doc(row: StackV3Repository) -> StackV3Document:
-    files = _directory_block_dfs(row["files"])
+    files = _directory_block_dfs(deduplicate_files(row["files"]))
     sections = [f"{REPOSITORY_HEADER} {row['repo_path']}"]
     sections.extend(f"{FILE_HEADER} {file['file_path'] or UNKNOWN_FILE_PATH}\n{file['content']}" for file in files)
 
@@ -146,7 +158,7 @@ def row_to_doc(row: StackV3Repository) -> StackV3Document:
         "repo_id": row["repo_id"],
         "commit_id": row["commit_id"],
         "github_metadata": row["github_metadata"],
-        "num_files": row["num_files"],
+        "num_files": len(files),
         "file_metadata": [{key: value for key, value in file.items() if key != "content"} for file in files],
         "serialization_format": SERIALIZATION_FORMAT,
     }

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -186,8 +186,8 @@ def all_sources() -> dict[str, DatakitSource]:
         ("numinamath-tir", numinamath_tir_normalize_steps, 0.08),
         ("sec-edgar", sec_edgar_normalize_steps, 334.90),
         # Exact count measured with marin-community/marin-tokenizer:
-        # 4,568,429,666,429 tokens / 172,898,790 docs.
-        ("stack-v3", stack_v3_normalize_steps, 4568.429666429),
+        # 3,363,007,313,642 tokens / 172,898,790 docs.
+        ("stack-v3", stack_v3_normalize_steps, 3363.007313642),
         ("superior-reasoning", superior_reasoning_normalize_steps, 7.08),
         ("svg", svgfind_creativecommons_normalize_steps, 8.95),
         ("swe-rebench-contree", swe_rebench_contree_normalize_steps, 182.60),

--- a/tests/datakit/download/test_stack_v3.py
+++ b/tests/datakit/download/test_stack_v3.py
@@ -137,3 +137,40 @@ def test_transform_writes_nullable_metadata_with_stable_schema(tmp_path: Path):
     normalized_github_metadata = normalized_schema.field("github_metadata").type
     assert normalized_github_metadata.field("forked_from").type == pa.string()
     assert pq.read_table(normalized_path).to_pylist()[0]["github_metadata"]["forked_from"] is None
+
+
+def test_duplicate_file_entries_are_serialized_once():
+    """A Stack v3 row lists each file many times; the serialized document carries it once."""
+    row = {
+        "repo_path": "org/repo",
+        "repo_id": 1,
+        "commit_id": "c",
+        "github_metadata": {"branch": "main", "stars": 1},
+        "num_files": 20,
+        "files": (
+            [_file("a.py", "alpha", "id-a") for _ in range(10)] + [_file("b.py", "beta", "id-b") for _ in range(10)]
+        ),
+    }
+
+    doc = row_to_doc(row)
+
+    assert doc["text"] == ("Repository: org/repo\n\nFile: a.py\nalpha\n\nFile: b.py\nbeta")
+    assert doc["num_files"] == 2
+    assert [entry["file_path"] for entry in doc["file_metadata"]] == ["a.py", "b.py"]
+
+
+def test_same_content_at_two_paths_is_kept():
+    """Two paths sharing one content_id are distinct files and both survive."""
+    row = {
+        "repo_path": "org/repo",
+        "repo_id": 1,
+        "commit_id": "c",
+        "github_metadata": {"branch": "main", "stars": 1},
+        "num_files": 2,
+        "files": [_file("pkg/__init__.py", "", "empty-id"), _file("pkg/sub/__init__.py", "", "empty-id")],
+    }
+
+    doc = row_to_doc(row)
+
+    assert doc["num_files"] == 2
+    assert [entry["file_path"] for entry in doc["file_metadata"]] == ["pkg/__init__.py", "pkg/sub/__init__.py"]


### PR DESCRIPTION
A Stack v3 row lists each file many times over, commonly ten identical entries with the same content_id and content, and num_files counts every copy. row_to_doc serialized them verbatim, so a document repeated the same File: block ten times in a row; directory-block DFS sorts siblings by name, placing the copies adjacent. Fuzzy dedup does not reach this, since minhash compares whole documents rather than their contents. Around 10% of documents were affected, weighted toward large repositories.

Keying on (file_path, content_id) removes 1.205 trillion tokens. Measured over the rebuilt normalized artifact with marin-community/marin-tokenizer: 3,363,007,313,642 tokens across 172,898,790 documents, against 4,568,429,666,429 for the same document count before. The registry's mixture weight for the source moves with it, so mixtures computed against the old count over-weighted stack-v3 by about 35% relative to its real content.

content_id alone is not sufficient as a key. It is a plain SHA-1 of the original file rather than of the stored content, so one id can cover two different stored texts, and identical content at two paths is ordinary.

SERIALIZATION_FORMAT bumps to v2, re-keying processed/stack-v3 and normalized/stack-v3. Both were rebuilt and verified at 172,898,790 rows, matching the raw input exactly.

Tokenizing this source needs more headroom than the defaults: repository-sized documents OOM'd workers at the stock 10g / levanter_batch_size=16384, and completed at 64g / 512.
