### PR TITLE
[iris] Configure user budgets on the CoreWeave GPU clusters

### DIFF
--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -205,3 +205,27 @@ scale_groups:
       coreweave:
         region: RNO2A
         instance_type: gd-8xh100ib-i128
+
+# 42752 is 4 h100-8x nodes (32 GPUs) at full node resources.
+user_budgets:
+  - user_ids:
+      - benjaminfeuer
+      - betsy
+      - dlwh
+      - eczech
+      - held
+      - larry
+      - marin
+      - muchanem
+      - mwittmann
+      - power
+      - rav
+      - romain
+      - wmoss
+      - zack
+    budget_limit: 42752
+    max_band: PRIORITY_BAND_INTERACTIVE
+  # 342016 is 32 h100-8x nodes: half of this cluster's 64-node fleet.
+  - user_ids: [benjaminfeuer]
+    budget_limit: 342016
+    max_band: PRIORITY_BAND_INTERACTIVE

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -204,3 +204,27 @@ scale_groups:
       coreweave:
         region: US-EAST-02A
         instance_type: gd-8xh100ib-i128
+
+# 42752 is 4 h100-8x nodes (32 GPUs) at full node resources.
+user_budgets:
+  - user_ids:
+      - benjaminfeuer
+      - betsy
+      - dlwh
+      - eczech
+      - held
+      - larry
+      - marin
+      - muchanem
+      - mwittmann
+      - power
+      - rav
+      - romain
+      - wmoss
+      - zack
+    budget_limit: 42752
+    max_band: PRIORITY_BAND_INTERACTIVE
+  # 171008 is 16 h100-8x nodes: half of this cluster's 32-node fleet.
+  - user_ids: [benjaminfeuer]
+    budget_limit: 171008
+    max_band: PRIORITY_BAND_INTERACTIVE

--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -217,3 +217,23 @@ scale_groups:
       coreweave:
         region: US-EAST-08A
         instance_type: gb200-4x
+
+# 128000 is about one NVL72 rack: 18 gb200-4x nodes cost ~102,000.
+user_budgets:
+  - user_ids:
+      - benjaminfeuer
+      - betsy
+      - dlwh
+      - eczech
+      - held
+      - larry
+      - marin
+      - muchanem
+      - mwittmann
+      - power
+      - rav
+      - romain
+      - wmoss
+      - zack
+    budget_limit: 128000
+    max_band: PRIORITY_BAND_INTERACTIVE

--- a/lib/iris/config/marin.yaml
+++ b/lib/iris/config/marin.yaml
@@ -290,9 +290,9 @@ scale_groups:
 # ---------------------------------------------------------------------------
 # User budget tiers
 #
-# This section is the source of truth for per-user budgets. It is reconciled
-# into user_budgets on every controller start (migration 0037 truncates the
-# table first so the config fully owns row contents).
+# reconcile_user_budget_tiers upserts these tiers into user_budgets on every
+# controller start. It never deletes, so a row set with `iris user budget set`
+# outlives a restart and is overwritten only when the user is listed here.
 #
 # Unlisted submitters have no row and fall through to UserBudgetDefaults at
 # read time — a small INTERACTIVE budget that silently degrades to BATCH once


### PR DESCRIPTION
Give cw-rno2a, cw-us-east-02a, and cw-us-east-08a a user_budgets tier, which
replicates the roster that cw-us-east-08a already had as rows in its database.
Each limit is sized to that cluster's own node. The two H100 clusters get 42752,
which is 4 h100-8x nodes at full node resources. cw-us-east-08a gets 128000,
which is about one GB200 NVL72 rack, because its 18 gb200-4x nodes cost
approximately 102,000.

benjaminfeuer gets a second, later tier on each H100 cluster that admits half of
that cluster's fleet: 342016 on cw-rno2a (32 of 64 nodes) and 171008 on
cw-us-east-02a (16 of 32 nodes). reconcile_user_budget_tiers applies tiers in
order, so the later entry overrides the shared one.

None of these clusters declared a tier, thus each submitter fell through to
UserBudgetDefaults and its limit of 1000. resource_value charges 1000 points for
each accelerator, so one 8-GPU node has a value of 10,688. A second node went
above the limit, and compute_effective_band demoted the work to BATCH. These
tasks got to Kubernetes as priority-0 iris-batch pods. As a result, Kueue had no
lower-priority work to evict. On rno2a, 432 of 512 GPUs stayed behind priority-0
work, and five six-node gangs waited as much as 4h51m on PreemptionNoCandidates.

compute_effective_band demotes only when spend passes the limit, so 42752 admits
exactly 4 concurrent nodes and demotes the fifth.

cw-us-east-08a had rows for these users only in its database, where no review
covers them. The user held was on a limit of 1000 there, and this change gives
held the same limit as the other users. k3sc0re is not carried over, so it
falls through to UserBudgetDefaults on each cluster.

cw-us-west-04a keeps no tier. It has 2 H100 nodes, so a limit of this size could
never demote work there.

Also correct a stale comment in marin.yaml. reconcile_user_budget_tiers upserts
and never deletes, and migration 0037 is 0037_federation_fixup, which does not
touch user_budgets. A row from `iris user budget set` thus outlives a controller
restart.

The tiers become effective when each controller restarts. This change does not
add the effective-band report that the issue also asks for. Thus a launch that
gets a demotion still prints the band that the user requested.

Fixes #7774
