### PR TITLE
[levanter] Write rope in the transformers-4 shape too on HF export

### DIFF
--- a/lib/levanter/src/levanter/compat/hf_checkpoints.py
+++ b/lib/levanter/src/levanter/compat/hf_checkpoints.py
@@ -328,6 +328,63 @@ KEYS_TO_COPY_FROM_BASE_CONFIG = {
     "auto_map",
 }
 
+# Keys inside a transformers>=5 ``rope_parameters`` block that carry the base
+# frequency rather than part of the scaling spec.
+_ROPE_THETA_KEYS = ("rope_theta", "theta", "base")
+# ``rope_type`` values meaning "no scaling"; transformers 4.x wants
+# ``rope_scaling`` left as None for these rather than a dict.
+_UNSCALED_ROPE_TYPES = (None, "default")
+
+
+def _add_legacy_rope_keys(dict_config: dict) -> dict:
+    """Also state rope the way transformers 4.x reads it.
+
+    transformers>=5 serialises rope as a single ``rope_parameters`` block::
+
+        "rope_parameters": {"rope_type": "llama3", "rope_theta": 500000,
+                            "factor": 8.0, ...}
+
+    transformers 4.x reads ``rope_theta`` and ``rope_scaling`` instead. It does
+    **not** error on the 5.x shape — it ignores it and falls back to the
+    architecture default. A checkpoint exported under transformers 5.x
+    therefore loads under 4.x with the wrong rope base and no scaling, with no
+    warning of any kind.
+
+    That is not a small numerical difference. On a Qwen3 1.5B trained with
+    Llama3 rope at theta 500000, transformers 4.57 loads theta 10000 — a 50x
+    error — and mean NLL over real documents goes from 2.41 to 3.18
+    nats/token. The damage grows with sequence length, which is what makes it
+    easy to miss on short smoke tests.
+
+    Writing both shapes costs two keys and makes an export readable by either
+    major version. It is additive: ``rope_parameters`` is left untouched, and
+    under 5.x ``rope_scaling`` is an alias of it, so 5.x behaviour is
+    unchanged. Verified against transformers 4.57 and 5.14.
+
+    A no-op when the config was produced under transformers 4.x (no
+    ``rope_parameters``) or already carries both shapes.
+    """
+    rope = dict_config.get("rope_parameters")
+    if not isinstance(rope, dict):
+        return dict_config
+    if "rope_theta" in dict_config or "rope_scaling" in dict_config:
+        return dict_config
+
+    out = dict(dict_config)
+    params = dict(rope)
+
+    theta = next((params.pop(k) for k in _ROPE_THETA_KEYS if k in params), None)
+    if theta is not None:
+        out["rope_theta"] = theta
+
+    rope_type = params.get("rope_type", params.get("type"))
+    if rope_type in _UNSCALED_ROPE_TYPES:
+        out["rope_scaling"] = None
+    else:
+        params.setdefault("rope_type", rope_type)
+        out["rope_scaling"] = params
+    return out
+
 
 def _causal_lm_architecture_name(hf_config_class: type) -> Optional[str]:
     """Return the HF causal-LM architecture class name for *hf_config_class*, or None.
@@ -1038,6 +1095,9 @@ class HFCheckpointConverter(Generic[LevConfig]):
 
         if self.config_overrides:
             dict_config = mergedeep.merge({}, dict_config, self.config_overrides)
+
+        # Last, so it also covers anything the merges above introduced.
+        dict_config = _add_legacy_rope_keys(dict_config)
 
         return dict_config
 

--- a/lib/levanter/src/levanter/compat/hf_checkpoints.py
+++ b/lib/levanter/src/levanter/compat/hf_checkpoints.py
@@ -328,62 +328,19 @@ KEYS_TO_COPY_FROM_BASE_CONFIG = {
     "auto_map",
 }
 
-# Keys inside a transformers>=5 ``rope_parameters`` block that carry the base
-# frequency rather than part of the scaling spec.
-_ROPE_THETA_KEYS = ("rope_theta", "theta", "base")
-# ``rope_type`` values meaning "no scaling"; transformers 4.x wants
-# ``rope_scaling`` left as None for these rather than a dict.
-_UNSCALED_ROPE_TYPES = (None, "default")
-
 
 def _add_legacy_rope_keys(dict_config: dict) -> dict:
-    """Also state rope the way transformers 4.x reads it.
-
-    transformers>=5 serialises rope as a single ``rope_parameters`` block::
-
-        "rope_parameters": {"rope_type": "llama3", "rope_theta": 500000,
-                            "factor": 8.0, ...}
-
-    transformers 4.x reads ``rope_theta`` and ``rope_scaling`` instead. It does
-    **not** error on the 5.x shape — it ignores it and falls back to the
-    architecture default. A checkpoint exported under transformers 5.x
-    therefore loads under 4.x with the wrong rope base and no scaling, with no
-    warning of any kind.
-
-    That is not a small numerical difference. On a Qwen3 1.5B trained with
-    Llama3 rope at theta 500000, transformers 4.57 loads theta 10000 — a 50x
-    error — and mean NLL over real documents goes from 2.41 to 3.18
-    nats/token. The damage grows with sequence length, which is what makes it
-    easy to miss on short smoke tests.
-
-    Writing both shapes costs two keys and makes an export readable by either
-    major version. It is additive: ``rope_parameters`` is left untouched, and
-    under 5.x ``rope_scaling`` is an alias of it, so 5.x behaviour is
-    unchanged. Verified against transformers 4.57 and 5.14.
-
-    A no-op when the config was produced under transformers 4.x (no
-    ``rope_parameters``) or already carries both shapes.
-    """
-    rope = dict_config.get("rope_parameters")
-    if not isinstance(rope, dict):
-        return dict_config
-    if "rope_theta" in dict_config or "rope_scaling" in dict_config:
+    rope_parameters = dict_config.get("rope_parameters")
+    if not isinstance(rope_parameters, dict) or "rope_theta" not in rope_parameters:
         return dict_config
 
-    out = dict(dict_config)
-    params = dict(rope)
+    legacy_config = dict(dict_config)
+    legacy_config.setdefault("rope_theta", rope_parameters["rope_theta"])
 
-    theta = next((params.pop(k) for k in _ROPE_THETA_KEYS if k in params), None)
-    if theta is not None:
-        out["rope_theta"] = theta
-
-    rope_type = params.get("rope_type", params.get("type"))
-    if rope_type in _UNSCALED_ROPE_TYPES:
-        out["rope_scaling"] = None
-    else:
-        params.setdefault("rope_type", rope_type)
-        out["rope_scaling"] = params
-    return out
+    rope_scaling = {key: value for key, value in rope_parameters.items() if key != "rope_theta"}
+    rope_type = rope_scaling.get("rope_type")
+    legacy_config.setdefault("rope_scaling", None if rope_type in (None, "default") else rope_scaling)
+    return legacy_config
 
 
 def _causal_lm_architecture_name(hf_config_class: type) -> Optional[str]:
@@ -1096,7 +1053,6 @@ class HFCheckpointConverter(Generic[LevConfig]):
         if self.config_overrides:
             dict_config = mergedeep.merge({}, dict_config, self.config_overrides)
 
-        # Last, so it also covers anything the merges above introduced.
         dict_config = _add_legacy_rope_keys(dict_config)
 
         return dict_config

--- a/lib/levanter/tests/test_hf_checkpoints.py
+++ b/lib/levanter/tests/test_hf_checkpoints.py
@@ -1,7 +1,9 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 import glob
+import json
 import os
 import tempfile
 import uuid
@@ -25,6 +27,7 @@ from levanter.compat.hf_checkpoints import (
     SAFE_TENSORS_INDEX_NAME,
     SAFE_TENSORS_MODEL,
     ModelWithHfSerializationMixin,
+    _add_legacy_rope_keys,
     _causal_lm_architecture_name,
     _convert_to_jnp,
 )
@@ -312,3 +315,101 @@ def test_build_hf_config_dict_degrades_when_reference_unreachable(local_gpt2_tok
 
     assert dict_config["model_type"] == "gpt2"
     assert dict_config["architectures"] == ["GPT2LMHeadModel"]
+
+
+# ---------------------------------------------------------------------------
+# transformers-5 rope block -> also written in the 4.x shape
+# ---------------------------------------------------------------------------
+# The failure this guards against is silent: transformers 4.x does not error on
+# a `rope_parameters` block, it ignores it and falls back to the architecture
+# default rope. So these assert on values, not on whether a call raised.
+#
+# They also do not round-trip through a transformers 4.x `AutoConfig`, because
+# levanter pins `transformers>=5.5.3` and 4.x is not installable in any
+# supported test environment. The contract under test is therefore the JSON we
+# emit — which is exactly what a 4.x loader reads.
+
+_TF5_LLAMA3_ROPE = {
+    "rope_type": "llama3",
+    "rope_theta": 500000,
+    "factor": 8.0,
+    "low_freq_factor": 1.0,
+    "high_freq_factor": 4.0,
+    "original_max_position_embeddings": 8192,
+}
+
+
+def test_legacy_rope_keys_added_for_transformers5_block():
+    out = _add_legacy_rope_keys({"model_type": "qwen3", "rope_parameters": _TF5_LLAMA3_ROPE})
+
+    assert out["rope_theta"] == 500000
+    assert out["rope_scaling"]["rope_type"] == "llama3"
+    assert out["rope_scaling"]["factor"] == 8.0
+    # The base frequency belongs at the top level, not inside the scaling spec.
+    assert "rope_theta" not in out["rope_scaling"]
+    # transformers 5.x still needs the block it wrote.
+    assert out["rope_parameters"] == _TF5_LLAMA3_ROPE
+
+
+def test_legacy_rope_keys_does_not_mutate_input():
+    config = {"model_type": "qwen3", "rope_parameters": dict(_TF5_LLAMA3_ROPE)}
+    before = copy.deepcopy(config)
+    _add_legacy_rope_keys(config)
+    assert config == before
+
+
+def test_legacy_rope_keys_noop_without_rope_parameters():
+    config = {"model_type": "gpt2", "rope_theta": 10000}
+    assert _add_legacy_rope_keys(config) is config
+
+
+def test_legacy_rope_keys_noop_when_both_shapes_present():
+    """An already-converted config must not be converted twice."""
+    config = {
+        "model_type": "qwen3",
+        "rope_parameters": _TF5_LLAMA3_ROPE,
+        "rope_theta": 500000,
+        "rope_scaling": {"rope_type": "llama3"},
+    }
+    assert _add_legacy_rope_keys(config) is config
+
+
+def test_legacy_rope_keys_unscaled_rope_yields_no_scaling():
+    out = _add_legacy_rope_keys(
+        {"model_type": "qwen3", "rope_parameters": {"rope_type": "default", "rope_theta": 10000}}
+    )
+    assert out["rope_theta"] == 10000
+    assert out["rope_scaling"] is None
+
+
+def test_saved_config_carries_legacy_rope_keys():
+    """The export path itself, not just the helper.
+
+    A unit test on `_add_legacy_rope_keys` keeps passing if the call in
+    `_build_hf_config_dict` is dropped or moved before the `config_overrides`
+    merge, while exported checkpoints go back to being unreadable by
+    transformers 4.x. This drives a real `save_pretrained` and reads the
+    `config.json` that lands on disk.
+
+    `rope_parameters` arrives via `config_overrides` — GPT-2 has no rope of its
+    own, and injecting it there also pins down the ordering, since overrides
+    are merged in before the conversion runs.
+    """
+    nano_config = Gpt2Config(hidden_dim=32, num_heads=2, num_layers=2, resid_pdrop=0.0, use_flash_attention=False)
+    converter = nano_config.hf_checkpoint_converter().with_config_overrides(
+        {"rope_parameters": _TF5_LLAMA3_ROPE}
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with use_test_mesh():
+            model = Gpt2LMHeadModel.init(converter.Vocab, nano_config, key=PRNGKey(0))
+            converter.save_pretrained(model, tmpdir, save_tokenizer=False)
+
+        with open(os.path.join(tmpdir, "config.json")) as f:
+            saved = json.load(f)
+
+    # What a transformers 4.x loader reads.
+    assert saved["rope_theta"] == 500000
+    assert saved["rope_scaling"]["rope_type"] == "llama3"
+    # What transformers 5.x reads, unchanged.
+    assert saved["rope_parameters"] == _TF5_LLAMA3_ROPE

--- a/lib/levanter/tests/test_hf_checkpoints.py
+++ b/lib/levanter/tests/test_hf_checkpoints.py
@@ -1,7 +1,6 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import copy
 import glob
 import json
 import os
@@ -27,7 +26,6 @@ from levanter.compat.hf_checkpoints import (
     SAFE_TENSORS_INDEX_NAME,
     SAFE_TENSORS_MODEL,
     ModelWithHfSerializationMixin,
-    _add_legacy_rope_keys,
     _causal_lm_architecture_name,
     _convert_to_jnp,
 )
@@ -317,99 +315,30 @@ def test_build_hf_config_dict_degrades_when_reference_unreachable(local_gpt2_tok
     assert dict_config["architectures"] == ["GPT2LMHeadModel"]
 
 
-# ---------------------------------------------------------------------------
-# transformers-5 rope block -> also written in the 4.x shape
-# ---------------------------------------------------------------------------
-# The failure this guards against is silent: transformers 4.x does not error on
-# a `rope_parameters` block, it ignores it and falls back to the architecture
-# default rope. So these assert on values, not on whether a call raised.
-#
-# They also do not round-trip through a transformers 4.x `AutoConfig`, because
-# levanter pins `transformers>=5.5.3` and 4.x is not installable in any
-# supported test environment. The contract under test is therefore the JSON we
-# emit — which is exactly what a 4.x loader reads.
-
-_TF5_LLAMA3_ROPE = {
-    "rope_type": "llama3",
-    "rope_theta": 500000,
-    "factor": 8.0,
-    "low_freq_factor": 1.0,
-    "high_freq_factor": 4.0,
-    "original_max_position_embeddings": 8192,
-}
-
-
-def test_legacy_rope_keys_added_for_transformers5_block():
-    out = _add_legacy_rope_keys({"model_type": "qwen3", "rope_parameters": _TF5_LLAMA3_ROPE})
-
-    assert out["rope_theta"] == 500000
-    assert out["rope_scaling"]["rope_type"] == "llama3"
-    assert out["rope_scaling"]["factor"] == 8.0
-    # The base frequency belongs at the top level, not inside the scaling spec.
-    assert "rope_theta" not in out["rope_scaling"]
-    # transformers 5.x still needs the block it wrote.
-    assert out["rope_parameters"] == _TF5_LLAMA3_ROPE
-
-
-def test_legacy_rope_keys_does_not_mutate_input():
-    config = {"model_type": "qwen3", "rope_parameters": dict(_TF5_LLAMA3_ROPE)}
-    before = copy.deepcopy(config)
-    _add_legacy_rope_keys(config)
-    assert config == before
-
-
-def test_legacy_rope_keys_noop_without_rope_parameters():
-    config = {"model_type": "gpt2", "rope_theta": 10000}
-    assert _add_legacy_rope_keys(config) is config
-
-
-def test_legacy_rope_keys_noop_when_both_shapes_present():
-    """An already-converted config must not be converted twice."""
-    config = {
-        "model_type": "qwen3",
-        "rope_parameters": _TF5_LLAMA3_ROPE,
+def test_save_pretrained_writes_transformers4_and_5_rope_keys(tmp_path):
+    rope_parameters = {
+        "rope_type": "llama3",
         "rope_theta": 500000,
-        "rope_scaling": {"rope_type": "llama3"},
+        "factor": 8.0,
+        "low_freq_factor": 1.0,
+        "high_freq_factor": 4.0,
+        "original_max_position_embeddings": 8192,
     }
-    assert _add_legacy_rope_keys(config) is config
-
-
-def test_legacy_rope_keys_unscaled_rope_yields_no_scaling():
-    out = _add_legacy_rope_keys(
-        {"model_type": "qwen3", "rope_parameters": {"rope_type": "default", "rope_theta": 10000}}
-    )
-    assert out["rope_theta"] == 10000
-    assert out["rope_scaling"] is None
-
-
-def test_saved_config_carries_legacy_rope_keys():
-    """The export path itself, not just the helper.
-
-    A unit test on `_add_legacy_rope_keys` keeps passing if the call in
-    `_build_hf_config_dict` is dropped or moved before the `config_overrides`
-    merge, while exported checkpoints go back to being unreadable by
-    transformers 4.x. This drives a real `save_pretrained` and reads the
-    `config.json` that lands on disk.
-
-    `rope_parameters` arrives via `config_overrides` — GPT-2 has no rope of its
-    own, and injecting it there also pins down the ordering, since overrides
-    are merged in before the conversion runs.
-    """
     nano_config = Gpt2Config(hidden_dim=32, num_heads=2, num_layers=2, resid_pdrop=0.0, use_flash_attention=False)
-    converter = nano_config.hf_checkpoint_converter().with_config_overrides(
-        {"rope_parameters": _TF5_LLAMA3_ROPE}
-    )
+    converter = nano_config.hf_checkpoint_converter().with_config_overrides({"rope_parameters": rope_parameters})
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with use_test_mesh():
-            model = Gpt2LMHeadModel.init(converter.Vocab, nano_config, key=PRNGKey(0))
-            converter.save_pretrained(model, tmpdir, save_tokenizer=False)
+    with use_test_mesh():
+        model = Gpt2LMHeadModel.init(converter.Vocab, nano_config, key=PRNGKey(0))
+        converter.save_pretrained(model, str(tmp_path), save_tokenizer=False)
 
-        with open(os.path.join(tmpdir, "config.json")) as f:
-            saved = json.load(f)
+    saved = json.loads((tmp_path / "config.json").read_text())
 
-    # What a transformers 4.x loader reads.
+    assert saved["rope_parameters"] == rope_parameters
     assert saved["rope_theta"] == 500000
-    assert saved["rope_scaling"]["rope_type"] == "llama3"
-    # What transformers 5.x reads, unchanged.
-    assert saved["rope_parameters"] == _TF5_LLAMA3_ROPE
+    assert saved["rope_scaling"] == {
+        "rope_type": "llama3",
+        "factor": 8.0,
+        "low_freq_factor": 1.0,
+        "high_freq_factor": 4.0,
+        "original_max_position_embeddings": 8192,
+    }


### PR DESCRIPTION
Emit top-level `rope_theta` and `rope_scaling` alongside `rope_parameters` when exporting an HF config. Transformers 4 ignores `rope_parameters` and otherwise silently falls back to theta 10000 without scaling.

Preserve `rope_parameters` for Transformers 5 and leave nested per-layer RoPE configs unchanged.

Fixes #7146
