### PR TITLE
[rigging] Bound whole S3 requests, not just socket reads

### DIFF
--- a/lib/rigging/pyproject.toml
+++ b/lib/rigging/pyproject.toml
@@ -7,6 +7,12 @@ name = "marin-rigging"
 version = "0.2.0"
 requires-python = ">=3.12,<3.14"
 dependencies = [
+    # Imported directly by rigging.filesystem.s3_compat, which subclasses
+    # aiobotocore's AIOHTTPSession to add a whole-request aiohttp timeout.
+    # AioConfig gained http_session_cls in aiobotocore 2.12.2; passing it to an
+    # older release raises during client creation.
+    "aiobotocore>=2.12.2",
+    "aiohttp>=3.9",
     "braceexpand>=0.1.7",
     "click>=8.3.1",
     "connect-python>=0.9.0",

--- a/lib/rigging/src/rigging/filesystem/buckets.py
+++ b/lib/rigging/src/rigging/filesystem/buckets.py
@@ -28,6 +28,7 @@ from rigging.filesystem.s3_compat import (
     fsspec_s3_conf,
     s3_credentials,
     s3_endpoint,
+    s3_python_config_kwargs,
 )
 from rigging.filesystem.storage_path import StoragePath
 
@@ -85,5 +86,7 @@ def _s3_filesystem(spec: BucketSpec) -> s3fs.S3FileSystem:
         secret=secret,
         endpoint_url=endpoint,
         client_kwargs={"region_name": spec.signing_region or "auto"},
-        config_kwargs=conf["config_kwargs"],
+        # ``fsspec_s3_conf`` is the JSON-safe env shape, so it carries the
+        # endpoint's addressing style but not the whole-request deadline.
+        config_kwargs={**conf["config_kwargs"], **s3_python_config_kwargs()},
     )

--- a/lib/rigging/src/rigging/filesystem/factory.py
+++ b/lib/rigging/src/rigging/filesystem/factory.py
@@ -45,10 +45,6 @@ def _with_s3_timeout_defaults(kwargs: dict[str, Any]) -> dict[str, Any]:
     in ``FSSPEC_S3`` -- silently dropping settings like
     ``{"s3": {"addressing_style": "virtual"}}`` that S3-compatible endpoints
     (CoreWeave object storage) require, which then hangs/path-style-rejects.
-
-    Building the filesystem here (rather than reading a JSON env block) also
-    lets us pass ``http_session_cls``, which carries the whole-request deadline
-    that the scalar timeouts cannot express (#6719).
     """
     conf_config_kwargs = (fsspec.config.conf.get("s3") or {}).get("config_kwargs") or {}
     config_kwargs = {**conf_config_kwargs, **dict(kwargs.get("config_kwargs") or {})}

--- a/lib/rigging/src/rigging/filesystem/factory.py
+++ b/lib/rigging/src/rigging/filesystem/factory.py
@@ -27,7 +27,7 @@ from rigging.filesystem.cross_region import (
     _is_gcs_protocol,
     _is_gcs_url,
 )
-from rigging.filesystem.s3_compat import s3_request_bounds_config_kwargs
+from rigging.filesystem.s3_compat import s3_python_config_kwargs
 from rigging.timing import ExponentialBackoff, retry_with_backoff
 
 logger = logging.getLogger(__name__)
@@ -45,10 +45,14 @@ def _with_s3_timeout_defaults(kwargs: dict[str, Any]) -> dict[str, Any]:
     in ``FSSPEC_S3`` -- silently dropping settings like
     ``{"s3": {"addressing_style": "virtual"}}`` that S3-compatible endpoints
     (CoreWeave object storage) require, which then hangs/path-style-rejects.
+
+    Building the filesystem here (rather than reading a JSON env block) also
+    lets us pass ``http_session_cls``, which carries the whole-request deadline
+    that the scalar timeouts cannot express (#6719).
     """
     conf_config_kwargs = (fsspec.config.conf.get("s3") or {}).get("config_kwargs") or {}
     config_kwargs = {**conf_config_kwargs, **dict(kwargs.get("config_kwargs") or {})}
-    for key, value in s3_request_bounds_config_kwargs().items():
+    for key, value in s3_python_config_kwargs().items():
         config_kwargs.setdefault(key, value)
     return {**kwargs, "config_kwargs": config_kwargs}
 

--- a/lib/rigging/src/rigging/filesystem/s3_compat.py
+++ b/lib/rigging/src/rigging/filesystem/s3_compat.py
@@ -62,12 +62,13 @@ class TotalDeadlineAIOHTTPSession(AIOHTTPSession):
     """aiobotocore HTTP session that also bounds the request as a whole.
 
     aiobotocore builds ``ClientTimeout(sock_connect=..., sock_read=...)`` and
-    never sets ``total``. ``sock_read`` only limits the gap between received
-    bytes *after* a response has started, so a peer that accepts a request body
-    and then answers nothing leaves the caller with no asyncio timer armed at
-    all: the event loop parks in ``epoll_wait(timeout=-1)`` and the fsspec
-    caller polls forever. ``total`` is the only bound that covers the wait for
-    the first response byte (#6719).
+    never sets ``total``. botocore sends ``Expect: 100-continue`` on
+    ``UploadPart``, so aiohttp waits for the interim response before it writes
+    the body. None of the scalar bounds covers that wait: ``sock_read`` cannot
+    arm because no read is in flight. A peer that withholds ``100 Continue``
+    therefore leaves no timer scheduled at all -- the loop parks in
+    ``epoll_wait(timeout=-1)`` and the fsspec caller polls forever, with the
+    body still unsent (#6719). ``total`` is the only bound that ends it.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/lib/rigging/src/rigging/filesystem/s3_compat.py
+++ b/lib/rigging/src/rigging/filesystem/s3_compat.py
@@ -35,8 +35,10 @@ import os
 from typing import Any
 from urllib.parse import urlparse
 
+import aiohttp
 import fsspec
 import s3fs
+from aiobotocore.httpsession import AIOHTTPSession
 
 from rigging.filesystem.cluster_config import StoreType, store_config
 
@@ -46,6 +48,33 @@ VIRTUAL_HOST_ONLY_S3_DOMAINS = ("cwobject.com", "cwlota.com")
 _S3_CONNECT_TIMEOUT = 30
 _S3_READ_TIMEOUT = 120
 _S3_RETRY_MAX_ATTEMPTS = 5
+# Whole-request ceiling, well above any healthy transfer: a 50 MiB multipart
+# part needs ~437 KiB/s to finish inside it. Only a wedged request reaches it.
+_S3_TOTAL_TIMEOUT = 600
+
+
+class TotalDeadlineAIOHTTPSession(AIOHTTPSession):
+    """aiobotocore HTTP session that also bounds the request as a whole.
+
+    aiobotocore builds ``ClientTimeout(sock_connect=..., sock_read=...)`` and
+    never sets ``total``. ``sock_read`` only limits the gap between received
+    bytes *after* a response has started, so a peer that accepts a request body
+    and then answers nothing leaves the caller with no asyncio timer armed at
+    all: the event loop parks in ``epoll_wait(timeout=-1)`` and the fsspec
+    caller polls forever. ``total`` is the only bound that covers the wait for
+    the first response byte (#6719).
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # aiobotocore annotates the ``timeout`` constructor parameter as a scalar
+        # but stores the assembled ClientTimeout in the same attribute.
+        # pyrefly: ignore[bad-assignment]
+        self._timeout = aiohttp.ClientTimeout(
+            sock_connect=self._timeout.sock_connect,
+            sock_read=self._timeout.sock_read,
+            total=_S3_TOTAL_TIMEOUT,
+        )
 
 
 def s3_request_bounds_config_kwargs() -> dict[str, Any]:
@@ -54,11 +83,28 @@ def s3_request_bounds_config_kwargs() -> dict[str, Any]:
     s3fs/aiobotocore otherwise permit upload requests to wait indefinitely when a
     connection wedges. Finite bounds turn that stall into an error handled by the
     task retry path (#6487).
+
+    JSON-safe by construction: this feeds the ``FSSPEC_S3`` environment block
+    that the Iris controller exports to every task. The whole-request deadline
+    cannot travel that way, because it needs a class rather than a scalar — see
+    :func:`s3_python_config_kwargs`.
     """
     return {
         "connect_timeout": _S3_CONNECT_TIMEOUT,
         "read_timeout": _S3_READ_TIMEOUT,
         "retries": {"max_attempts": _S3_RETRY_MAX_ATTEMPTS, "mode": "standard"},
+    }
+
+
+def s3_python_config_kwargs() -> dict[str, Any]:
+    """Return :func:`s3_request_bounds_config_kwargs` plus the whole-request deadline.
+
+    For callers that build a filesystem in Python and can therefore pass a class.
+    Not JSON-serializable, so it must not reach the ``FSSPEC_S3`` env block.
+    """
+    return {
+        **s3_request_bounds_config_kwargs(),
+        "http_session_cls": TotalDeadlineAIOHTTPSession,
     }
 
 

--- a/lib/rigging/src/rigging/filesystem/s3_compat.py
+++ b/lib/rigging/src/rigging/filesystem/s3_compat.py
@@ -48,8 +48,13 @@ VIRTUAL_HOST_ONLY_S3_DOMAINS = ("cwobject.com", "cwlota.com")
 _S3_CONNECT_TIMEOUT = 30
 _S3_READ_TIMEOUT = 120
 _S3_RETRY_MAX_ATTEMPTS = 5
-# Whole-request ceiling, well above any healthy transfer: a 50 MiB multipart
-# part needs ~437 KiB/s to finish inside it. Only a wedged request reaches it.
+# Whole-request ceiling. It spans pool wait, connect, body upload, and response
+# download, so it bounds every S3 request rather than only a stalled one: a
+# genuine transfer slower than 600s now fails and is retried from byte zero, up
+# to _S3_RETRY_MAX_ATTEMPTS times. 600 leaves ample headroom for the largest
+# request we issue (a 50 MiB multipart part needs ~90 KiB/s to fit), while still
+# failing a wedged request inside a shard's useful lifetime. Single-object reads
+# of many GB through this filesystem are the case to re-check if this bites.
 _S3_TOTAL_TIMEOUT = 600
 
 
@@ -84,10 +89,9 @@ def s3_request_bounds_config_kwargs() -> dict[str, Any]:
     connection wedges. Finite bounds turn that stall into an error handled by the
     task retry path (#6487).
 
-    JSON-safe by construction: this feeds the ``FSSPEC_S3`` environment block
-    that the Iris controller exports to every task. The whole-request deadline
-    cannot travel that way, because it needs a class rather than a scalar — see
-    :func:`s3_python_config_kwargs`.
+    JSON-safe by construction: this feeds the ``FSSPEC_S3`` environment block the
+    Iris controller exports to every task. Callers building a filesystem in
+    Python want :func:`s3_python_config_kwargs` instead.
     """
     return {
         "connect_timeout": _S3_CONNECT_TIMEOUT,

--- a/lib/rigging/tests/test_factory.py
+++ b/lib/rigging/tests/test_factory.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the guarded fsspec factory: the url_to_fs/open_url/filesystem entry
-points, unique_temp_path, atomic_rename, and fetch_file_atomic."""
+points, unique_temp_path, atomic_rename, and fetch_file_atomic, plus the S3
+request bounds those entry points inject."""
 
 import asyncio
 import json

--- a/lib/rigging/tests/test_factory.py
+++ b/lib/rigging/tests/test_factory.py
@@ -4,13 +4,18 @@
 """Tests for the guarded fsspec factory: the url_to_fs/open_url/filesystem entry
 points, unique_temp_path, atomic_rename, and fetch_file_atomic."""
 
+import asyncio
 import json
+import socket
+import threading
+import time
 from pathlib import Path
 
 import fsspec
 import pytest
-import s3fs
 from aiobotocore.config import AioConfig
+from botocore.awsrequest import AWSRequest
+from rigging.filesystem import s3_compat
 from rigging.filesystem.cross_region import CrossRegionGuardedFS
 from rigging.filesystem.factory import (
     _with_s3_timeout_defaults,
@@ -178,14 +183,54 @@ def test_s3_timeout_defaults_preserve_addressing_style_from_env_conf(monkeypatch
 
 
 def test_session_class_survives_the_handoff_to_aiobotocore():
-    """End to end through the real seam: our config_kwargs reach AioConfig (the
-    call s3fs makes) and s3fs passes the class on rather than dropping it."""
+    """Our config_kwargs reach AioConfig, which is the call s3fs makes to build
+    the client that ultimately instantiates the session class."""
     config_kwargs = _with_s3_timeout_defaults({})["config_kwargs"]
 
     assert AioConfig(**config_kwargs).http_session_cls is TotalDeadlineAIOHTTPSession
 
-    fs = s3fs.S3FileSystem(anon=True, config_kwargs=config_kwargs)
-    assert fs._prepare_config_kwargs()["http_session_cls"] is TotalDeadlineAIOHTTPSession
+
+def test_request_to_a_silent_peer_gives_up(monkeypatch):
+    """The production failure, reproduced: a peer accepts the whole request body
+    and then never answers. Without `total` no timer is armed and the caller
+    waits forever (#6719); the request must instead fail on its own."""
+    monkeypatch.setattr(s3_compat, "_S3_TOTAL_TIMEOUT", 1)
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
+
+        accepted: list[socket.socket] = []
+
+        def swallow_request():
+            conn, _ = listener.accept()
+            conn.recv(65536)  # take the request, then answer nothing at all
+            accepted.append(conn)
+
+        server = threading.Thread(target=swallow_request, daemon=True)
+        server.start()
+
+        # sock_read is deliberately long: it is the bound that does NOT cover
+        # this wait, so only `total` can end the call.
+        session = TotalDeadlineAIOHTTPSession(timeout=(5, 300))
+        request = AWSRequest(method="PUT", url=f"http://127.0.0.1:{port}/part", data=b"x" * 1024).prepare()
+
+        async def send_and_close():
+            async with session:
+                return await session.send(request)
+
+        started = time.monotonic()
+        with pytest.raises(Exception):  # noqa: B017 - the deadline, not a specific mapping
+            asyncio.run(send_and_close())
+        elapsed = time.monotonic() - started
+
+        server.join(timeout=5)
+        for conn in accepted:
+            conn.close()
+
+    assert elapsed < 30, f"request should have given up near the 1s deadline, took {elapsed:.1f}s"
 
 
 def test_env_config_block_stays_json_serializable():

--- a/lib/rigging/tests/test_factory.py
+++ b/lib/rigging/tests/test_factory.py
@@ -4,17 +4,27 @@
 """Tests for the guarded fsspec factory: the url_to_fs/open_url/filesystem entry
 points, unique_temp_path, atomic_rename, and fetch_file_atomic."""
 
+import json
 from pathlib import Path
 
+import fsspec
 import pytest
+import s3fs
+from aiobotocore.config import AioConfig
 from rigging.filesystem.cross_region import CrossRegionGuardedFS
 from rigging.filesystem.factory import (
+    _with_s3_timeout_defaults,
     atomic_rename,
     fetch_file_atomic,
     filesystem,
     open_url,
     unique_temp_path,
     url_to_fs,
+)
+from rigging.filesystem.s3_compat import (
+    TotalDeadlineAIOHTTPSession,
+    fsspec_s3_conf,
+    s3_request_bounds_config_kwargs,
 )
 
 
@@ -125,3 +135,62 @@ def test_open_url_local_file(tmp_path):
 def test_filesystem_local():
     fs = filesystem("file")
     assert not isinstance(fs, CrossRegionGuardedFS)
+
+
+def test_s3_kwargs_carry_a_whole_request_deadline():
+    """S3 filesystems built here get http_session_cls, the only bound that covers
+    the wait for a first response byte. Without it a peer that accepts a request
+    body and answers nothing hangs the caller forever (#6719)."""
+    result = _with_s3_timeout_defaults({})
+
+    assert result["config_kwargs"]["http_session_cls"] is TotalDeadlineAIOHTTPSession
+
+
+def test_total_deadline_session_keeps_the_socket_timeouts():
+    """The subclass adds `total` without dropping the sock_* bounds aiobotocore set."""
+    session = TotalDeadlineAIOHTTPSession(timeout=(7, 11))
+
+    assert session._timeout.total == 600
+    assert session._timeout.sock_connect == 7
+    assert session._timeout.sock_read == 11
+
+
+def test_caller_supplied_session_class_wins():
+    """Callers can still override the session class; we only fill in a default."""
+
+    class OtherSession(TotalDeadlineAIOHTTPSession):
+        pass
+
+    result = _with_s3_timeout_defaults({"config_kwargs": {"http_session_cls": OtherSession}})
+
+    assert result["config_kwargs"]["http_session_cls"] is OtherSession
+
+
+def test_s3_timeout_defaults_preserve_addressing_style_from_env_conf(monkeypatch):
+    """Virtual-host addressing from FSSPEC_S3 survives the merge; dropping it
+    makes CoreWeave endpoints reject every path-style request."""
+    monkeypatch.setitem(fsspec.config.conf, "s3", {"config_kwargs": {"s3": {"addressing_style": "virtual"}}})
+
+    result = _with_s3_timeout_defaults({})
+
+    assert result["config_kwargs"]["s3"] == {"addressing_style": "virtual"}
+    assert result["config_kwargs"]["http_session_cls"] is TotalDeadlineAIOHTTPSession
+
+
+def test_session_class_survives_the_handoff_to_aiobotocore():
+    """End to end through the real seam: our config_kwargs reach AioConfig (the
+    call s3fs makes) and s3fs passes the class on rather than dropping it."""
+    config_kwargs = _with_s3_timeout_defaults({})["config_kwargs"]
+
+    assert AioConfig(**config_kwargs).http_session_cls is TotalDeadlineAIOHTTPSession
+
+    fs = s3fs.S3FileSystem(anon=True, config_kwargs=config_kwargs)
+    assert fs._prepare_config_kwargs()["http_session_cls"] is TotalDeadlineAIOHTTPSession
+
+
+def test_env_config_block_stays_json_serializable():
+    """The FSSPEC_S3 block is json.dumps'd into every Iris task's environment.
+    Moving the session class into the shared bounds helper would break task
+    startup fleet-wide, so guard the boundary."""
+    json.dumps(s3_request_bounds_config_kwargs())
+    json.dumps(fsspec_s3_conf("http://cwlota.com"))

--- a/lib/rigging/tests/test_factory.py
+++ b/lib/rigging/tests/test_factory.py
@@ -12,10 +12,10 @@ import threading
 import time
 from pathlib import Path
 
-import fsspec
 import pytest
 from aiobotocore.config import AioConfig
 from botocore.awsrequest import AWSRequest
+from botocore.exceptions import ReadTimeoutError
 from rigging.filesystem import s3_compat
 from rigging.filesystem.cross_region import CrossRegionGuardedFS
 from rigging.filesystem.factory import (
@@ -143,58 +143,20 @@ def test_filesystem_local():
     assert not isinstance(fs, CrossRegionGuardedFS)
 
 
-def test_s3_kwargs_carry_a_whole_request_deadline():
-    """S3 filesystems built here get http_session_cls, the only bound that covers
-    the wait for a first response byte. Without it a peer that accepts a request
-    body and answers nothing hangs the caller forever (#6719)."""
-    result = _with_s3_timeout_defaults({})
-
-    assert result["config_kwargs"]["http_session_cls"] is TotalDeadlineAIOHTTPSession
-
-
-def test_total_deadline_session_keeps_the_socket_timeouts():
-    """The subclass adds `total` without dropping the sock_* bounds aiobotocore set."""
-    session = TotalDeadlineAIOHTTPSession(timeout=(7, 11))
-
-    assert session._timeout.total == 600
-    assert session._timeout.sock_connect == 7
-    assert session._timeout.sock_read == 11
-
-
-def test_caller_supplied_session_class_wins():
-    """Callers can still override the session class; we only fill in a default."""
-
-    class OtherSession(TotalDeadlineAIOHTTPSession):
-        pass
-
-    result = _with_s3_timeout_defaults({"config_kwargs": {"http_session_cls": OtherSession}})
-
-    assert result["config_kwargs"]["http_session_cls"] is OtherSession
-
-
-def test_s3_timeout_defaults_preserve_addressing_style_from_env_conf(monkeypatch):
-    """Virtual-host addressing from FSSPEC_S3 survives the merge; dropping it
-    makes CoreWeave endpoints reject every path-style request."""
-    monkeypatch.setitem(fsspec.config.conf, "s3", {"config_kwargs": {"s3": {"addressing_style": "virtual"}}})
-
-    result = _with_s3_timeout_defaults({})
-
-    assert result["config_kwargs"]["s3"] == {"addressing_style": "virtual"}
-    assert result["config_kwargs"]["http_session_cls"] is TotalDeadlineAIOHTTPSession
-
-
-def test_session_class_survives_the_handoff_to_aiobotocore():
-    """Our config_kwargs reach AioConfig, which is the call s3fs makes to build
-    the client that ultimately instantiates the session class."""
+def test_s3_filesystems_are_built_with_the_deadline():
+    """Without this wiring the deadline exists but nothing uses it, and every
+    rigging-built S3 filesystem keeps the #6719 hang."""
     config_kwargs = _with_s3_timeout_defaults({})["config_kwargs"]
 
+    assert config_kwargs["http_session_cls"] is TotalDeadlineAIOHTTPSession
+    # AioConfig is the call s3fs makes; it rejects the kwarg before aiobotocore 2.12.2.
     assert AioConfig(**config_kwargs).http_session_cls is TotalDeadlineAIOHTTPSession
 
 
 def test_request_to_a_silent_peer_gives_up(monkeypatch):
     """The production failure, reproduced: a peer accepts the whole request body
-    and then never answers. Without `total` no timer is armed and the caller
-    waits forever (#6719); the request must instead fail on its own."""
+    and then never answers. Under the sock_* bounds alone no timer is armed and
+    the caller waits forever (#6719)."""
     monkeypatch.setattr(s3_compat, "_S3_TOTAL_TIMEOUT", 1)
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
@@ -203,15 +165,16 @@ def test_request_to_a_silent_peer_gives_up(monkeypatch):
         listener.listen(1)
         port = listener.getsockname()[1]
 
-        accepted: list[socket.socket] = []
+        swallowed = threading.Event()
+        held: list[socket.socket] = []
 
         def swallow_request():
             conn, _ = listener.accept()
             conn.recv(65536)  # take the request, then answer nothing at all
-            accepted.append(conn)
+            held.append(conn)
+            swallowed.set()
 
-        server = threading.Thread(target=swallow_request, daemon=True)
-        server.start()
+        threading.Thread(target=swallow_request, daemon=True).start()
 
         # sock_read is deliberately long: it is the bound that does NOT cover
         # this wait, so only `total` can end the call.
@@ -223,15 +186,16 @@ def test_request_to_a_silent_peer_gives_up(monkeypatch):
                 return await session.send(request)
 
         started = time.monotonic()
-        with pytest.raises(Exception):  # noqa: B017 - the deadline, not a specific mapping
+        with pytest.raises(ReadTimeoutError):
             asyncio.run(send_and_close())
         elapsed = time.monotonic() - started
 
-        server.join(timeout=5)
-        for conn in accepted:
+        for conn in held:
             conn.close()
 
-    assert elapsed < 30, f"request should have given up near the 1s deadline, took {elapsed:.1f}s"
+    assert swallowed.is_set(), "peer never received the body; the test did not exercise the deadline"
+    # Bounded below too: an immediate setup or wiring failure would also raise.
+    assert 0.5 < elapsed < 30, f"expected the 1s deadline to end the call, took {elapsed:.2f}s"
 
 
 def test_env_config_block_stays_json_serializable():

--- a/lib/rigging/tests/test_factory.py
+++ b/lib/rigging/tests/test_factory.py
@@ -153,10 +153,15 @@ def test_s3_filesystems_are_built_with_the_deadline():
     assert AioConfig(**config_kwargs).http_session_cls is TotalDeadlineAIOHTTPSession
 
 
-def test_request_to_a_silent_peer_gives_up(monkeypatch):
-    """The production failure, reproduced: a peer accepts the whole request body
-    and then never answers. Under the sock_* bounds alone no timer is armed and
-    the caller waits forever (#6719)."""
+def test_upload_part_to_a_peer_that_withholds_100_continue_gives_up(monkeypatch):
+    """The production failure, reproduced (#6719).
+
+    botocore sends `Expect: 100-continue` on UploadPart, so aiohttp waits for the
+    interim response before writing the body. That wait is covered by none of
+    aiobotocore's scalar bounds -- sock_read cannot arm because no read is in
+    flight -- so a peer that withholds `100 Continue` hangs the caller forever.
+    `total` is the only bound that ends it.
+    """
     monkeypatch.setattr(s3_compat, "_S3_TOTAL_TIMEOUT", 1)
 
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
@@ -165,21 +170,32 @@ def test_request_to_a_silent_peer_gives_up(monkeypatch):
         listener.listen(1)
         port = listener.getsockname()[1]
 
-        swallowed = threading.Event()
+        headers_seen = threading.Event()
+        body_bytes: list[int] = []
         held: list[socket.socket] = []
 
-        def swallow_request():
+        def withhold_continue():
             conn, _ = listener.accept()
-            conn.recv(65536)  # take the request, then answer nothing at all
             held.append(conn)
-            swallowed.set()
+            buf = b""
+            while b"\r\n\r\n" not in buf:
+                chunk = conn.recv(65536)
+                if not chunk:
+                    return
+                buf += chunk
+            body_bytes.append(len(buf.split(b"\r\n\r\n", 1)[1]))
+            headers_seen.set()  # never send `100 Continue`, never respond, never close
 
-        threading.Thread(target=swallow_request, daemon=True).start()
+        threading.Thread(target=withhold_continue, daemon=True).start()
 
-        # sock_read is deliberately long: it is the bound that does NOT cover
-        # this wait, so only `total` can end the call.
+        # sock_read is deliberately long: it is not the bound that ends this call.
         session = TotalDeadlineAIOHTTPSession(timeout=(5, 300))
-        request = AWSRequest(method="PUT", url=f"http://127.0.0.1:{port}/part", data=b"x" * 1024).prepare()
+        request = AWSRequest(
+            method="PUT",
+            url=f"http://127.0.0.1:{port}/part",
+            headers={"Expect": "100-continue", "Content-Length": "1024"},
+            data=b"x" * 1024,
+        ).prepare()
 
         async def send_and_close():
             async with session:
@@ -193,7 +209,8 @@ def test_request_to_a_silent_peer_gives_up(monkeypatch):
         for conn in held:
             conn.close()
 
-    assert swallowed.is_set(), "peer never received the body; the test did not exercise the deadline"
+    assert headers_seen.is_set(), "peer never got the headers; the test did not exercise the deadline"
+    assert body_bytes == [0], f"body must still be unsent while awaiting 100 Continue, got {body_bytes}"
     # Bounded below too: an immediate setup or wiring failure would also raise.
     assert 0.5 < elapsed < 30, f"expected the 1s deadline to end the call, took {elapsed:.2f}s"
 

--- a/uv.lock
+++ b/uv.lock
@@ -5849,6 +5849,8 @@ name = "marin-rigging"
 version = "0.2.0"
 source = { editable = "lib/rigging" }
 dependencies = [
+    { name = "aiobotocore" },
+    { name = "aiohttp" },
     { name = "braceexpand" },
     { name = "click" },
     { name = "connect-python" },
@@ -5890,6 +5892,8 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiobotocore", specifier = ">=2.12.2" },
+    { name = "aiohttp", specifier = ">=3.9" },
     { name = "braceexpand", specifier = ">=0.1.7" },
     { name = "click", specifier = ">=8.3.1" },
     { name = "connect-python", specifier = ">=0.9.0" },


### PR DESCRIPTION
S3 filesystems built through rigging now bound the whole request, so a peer that
withholds `100 Continue` fails into the existing retry path instead of waiting
forever.

botocore sets `Expect: 100-continue` on every `UploadPart`. aiohttp therefore
waits for the interim response before it writes the body, and none of
aiobotocore's bounds covers that wait: it builds
`ClientTimeout(sock_connect, sock_read)` and never sets `total`, and `sock_read`
cannot arm because no read is in flight. A peer that accepts the headers and
withholds `100 Continue` leaves no asyncio timer scheduled at all.
`TotalDeadlineAIOHTTPSession` keeps the `sock_*` bounds and adds `total=600`,
passed to s3fs through the supported `http_session_cls` config parameter.

The behaviour is reproducible. Against a peer that withholds the interim
response, an `UploadPart`-shaped request under `sock_read=8` is still waiting at
30s; the identical request without the `Expect` header trips `sock_read` at
8.02s; with the total deadline it fails at 10.37s. `sock_read` does bound an
ordinary response wait, on small and large bodies and on fresh and pooled
connections, which is why the `FSSPEC_S3` timeouts added in #7547 looked
sufficient and were not.

This also accounts for the production evidence. 33 shards of a datakit normalize
run wedged in `UploadPart` to CoreWeave object storage for 13 hours with
`read_timeout=120` correctly applied. The body was never written, so server-side
`ListParts` showed the blocked part missing for all 32 open uploads; only headers
were sent and acknowledged, so the sockets sat `ESTABLISHED` with `tx_queue=0`
and `rx_queue=0` and no retransmit timer; and the event loop parked in
`epoll_wait(timeout=-1)` with an empty `_scheduled` heap. All 33 stopped inside
the same 36-second window across 26 nodes.

The deadline spans pool wait, connect, body upload, and response download, so it
applies to every S3 request rather than only a stalled one. A genuine transfer
slower than 600s now fails and is retried from byte zero. 600 leaves ample
headroom for the largest request we issue — a 50 MiB multipart part needs about
90 KiB/s to fit — and single-object reads of many GB are the case to re-check if
it ever bites.

`s3_request_bounds_config_kwargs` stays JSON-safe because it feeds the
`FSSPEC_S3` block the Iris controller serializes into every task environment, so
the session class lives in a separate helper that only Python callers use. Raw
fsspec consumers that read that env block instead of calling `url_to_fs` still
have no whole-request deadline; a class cannot travel through a JSON env var.

Part of #6719
