### PR TITLE
[iris] Record a Kueue eviction as PREEMPTED on the k8s backend

### DIFF
--- a/lib/iris/docs/task-states.md
+++ b/lib/iris/docs/task-states.md
@@ -83,7 +83,7 @@ independent job state machine.
 | `KILLED` | 6 | Yes | No | Controller: job cancellation (`_on_job_cancelled`), job failure cascade (`_mark_remaining_tasks_killed`), per-task timeout | `killed` (grey) |
 | `WORKER_FAILED` | 7 | Yes | Yes | Controller: worker death cascade (`ops.worker.fail`) | `worker_failed` (purple) |
 | `UNSCHEDULABLE` | 8 | Yes | No | Controller: scheduling timeout expired (`apply_terminal_decisions_batch`) | `unschedulable` (red) |
-| `PREEMPTED` | 10 | Yes | Yes | Controller: priority preemption with budget exhausted (`apply_terminal_decisions_batch`) | `preempted` (orange) |
+| `PREEMPTED` | 10 | Yes | Yes | Controller: priority preemption with budget exhausted (`apply_terminal_decisions_batch`); K8s backend: control-plane disruption of the pod | `preempted` (orange) |
 | `COSCHED_FAILED` | 11 | Yes | No | Controller: coscheduled sibling cascade (`_terminate_coscheduled_siblings`) | `cosched_failed` (red) |
 
 
@@ -191,6 +191,16 @@ from hanging on collective operations.
 Set by the controller when a higher-priority task evicts a lower-priority
 running task. The preemption pass (`apply_preemptions`) selects victims
 from lower priority bands and submits them to `apply_terminal_decisions_batch`.
+
+Also reported by the K8s backend when the cluster control plane disrupts an
+attempt's pod, marked by a `DisruptionTarget` or Kueue `TerminationTarget` pod
+condition (scheduler preemption, Kueue workload eviction, node drain, API
+eviction). Kueue deletes the pod it evicts, so the condition is readable only
+while the pod terminates; the backend caches it and reports it as the attempt's
+`terminal_reason` once the pod is gone. A pod that vanishes with no disruption
+ever observed is reported `WORKER_FAILED` instead — same preemption budget,
+without claiming a cause. These updates run through `apply_one_transition` and
+do cascade coscheduled siblings.
 
 Retry evaluation uses `_resolve_task_failure_state` with the preemption budget:
 

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -169,8 +169,18 @@ _CONSTRAINT_KEY_TO_NODE_LABEL: dict[str, str] = {
 _K8S_LABEL_MAX_LEN = 63
 
 # Number of consecutive sync cycles where a pod is missing from the k8s API
-# before declaring FAILED. Avoids false positives from transient API misses.
+# before declaring the attempt preempted. Avoids false positives from transient
+# API misses.
 _POD_NOT_FOUND_GRACE_CYCLES = 3
+
+# A terminal reason can carry a full log tail (an init container running under
+# terminationMessagePolicy: FallbackToLogsOnError) or a Kueue eviction message,
+# so bound what we persist.
+_TERMINAL_REASON_MAX_CHARS = 500
+
+# Terminal reason for a vanished pod whose disruption was never observed — the
+# pod was deleted between two polls, so no condition survived to name the cause.
+_POD_DELETED_TERMINAL_REASON = "PodDeleted: pod was deleted while the attempt was active"
 
 # Kubernetes terminated reasons that indicate infrastructure failure (not application error).
 # Evicted: kubelet evicted the pod due to resource pressure.
@@ -1045,12 +1055,21 @@ def _infrastructure_failure_condition(pod: dict) -> dict | None:
     return None
 
 
-def _is_infrastructure_failure(pod: dict) -> bool:
-    """Check if the pod failure was caused by infrastructure (preemption, eviction, etc.).
+def _format_disruption_reason(condition: dict) -> str:
+    """Render a disruption condition as a bounded ``<reason>: <message>`` for an
+    attempt's terminal reason (Kueue's message names the preemptor's queue)."""
+    short_reason = condition.get("reason", "") or condition.get("type", "")
+    message = condition.get("message", "")
+    reason = f"{short_reason}: {message}" if message else short_reason
+    return reason[:_TERMINAL_REASON_MAX_CHARS]
 
-    Returns True when the failure was NOT caused by the application itself, so it
-    should be classified as a worker/preemption failure rather than an
-    application failure.
+
+def _pod_failure_state(pod: dict) -> int:
+    """Classify a failed pod as PREEMPTED, WORKER_FAILED, or FAILED.
+
+    PREEMPTED and WORKER_FAILED both charge the preemption budget; the split
+    tells a triager whether the control plane took the pod away or the node let
+    it die.
     """
     # Authoritative first: the control plane explicitly disrupted this pod
     # (preempted/evicted/drained), regardless of how the container exited. This
@@ -1059,21 +1078,25 @@ def _is_infrastructure_failure(pod: dict) -> bool:
     # that OOMs on its own cgroup limit carries no such condition and correctly
     # falls through to an application failure.
     if _infrastructure_failure_condition(pod) is not None:
-        return True
+        return job_pb2.TASK_STATE_PREEMPTED
     status = _task_container_status(pod)
     if status is None:
         # Pod-level eviction: the pod status reason indicates infrastructure.
-        pod_reason = pod.get("status", {}).get("reason", "")
-        return pod_reason in _INFRASTRUCTURE_FAILURE_REASONS
-    terminated = status.get("state", {}).get("terminated", {})
-    return terminated.get("reason", "") in _INFRASTRUCTURE_FAILURE_REASONS
+        reason = pod.get("status", {}).get("reason", "")
+    else:
+        reason = status.get("state", {}).get("terminated", {}).get("reason", "")
+    if reason in _INFRASTRUCTURE_FAILURE_REASONS:
+        return job_pb2.TASK_STATE_WORKER_FAILED
+    return job_pb2.TASK_STATE_FAILED
 
 
 def _task_update_from_pod(entry: RunningTaskEntry, pod: dict, workload: dict | None = None) -> TaskUpdate:
     """Build a TaskUpdate from a Kubernetes Pod dict.
 
-    Infrastructure failures (eviction, preemption) are reported as WORKER_FAILED
-    so they count against max_retries_preemption.
+    A control-plane disruption (Kueue preemption, node drain, API eviction) is
+    reported as PREEMPTED and a node-level infrastructure failure as
+    WORKER_FAILED; both count against max_retries_preemption, and the split lets
+    a triager tell a capacity preemption from a broken node.
     Application failures (non-zero exit code) are reported as FAILED so they
     count against max_retries_failure (default: 0, no retries).
 
@@ -1124,14 +1147,10 @@ def _task_update_from_pod(entry: RunningTaskEntry, pod: dict, workload: dict | N
     # Failed or Unknown -- distinguish infrastructure vs application failure. The
     # error field carries the failure story, so clear the waiting one-liner.
     exit_code = _extract_exit_code(pod)
-    if _is_infrastructure_failure(pod):
-        new_state = job_pb2.TASK_STATE_WORKER_FAILED
-    else:
-        new_state = job_pb2.TASK_STATE_FAILED
     return TaskUpdate(
         task_id=task_id,
         attempt_id=attempt_id,
-        new_state=new_state,
+        new_state=_pod_failure_state(pod),
         exit_code=exit_code,
         error=_extract_error(pod),
         status_message="",
@@ -1164,11 +1183,6 @@ def _extract_error(pod: dict) -> str | None:
     return message or reason or None
 
 
-# An init-container failure message can be a full log tail
-# (terminationMessagePolicy: FallbackToLogsOnError), so bound what we persist.
-_TERMINAL_REASON_MAX_CHARS = 500
-
-
 def _init_container_failure(pod: dict) -> str | None:
     """Return ``Init:<reason> <container>: <message>`` for the first init container
     that terminated non-zero (excluding the log-shipper sidecar), else ``None``.
@@ -1197,11 +1211,7 @@ def _extract_terminal_reason(pod: dict) -> str | None:
     task container's own terminal reason.
     """
     condition = _infrastructure_failure_condition(pod)
-    condition_reason = None
-    if condition is not None:
-        short_reason = condition.get("reason", "") or condition.get("type", "")
-        message = condition.get("message", "")
-        condition_reason = f"{short_reason}: {message}" if message else short_reason
+    condition_reason = _format_disruption_reason(condition) if condition is not None else None
     reason = condition_reason or _init_container_failure(pod) or _extract_error(pod)
     return reason[:_TERMINAL_REASON_MAX_CHARS] if reason is not None else None
 
@@ -2361,6 +2371,9 @@ class K8sTaskProvider:
     # worker store, so it reads its dispatch drain through this).
     transition_reader: TransitionReader | None = field(default=None, repr=False)
     _pod_not_found_counts: dict[str, int] = field(default_factory=dict, init=False, repr=False)
+    # "<task_id>:<attempt_id>:<attempt_uid>" -> the disruption condition last
+    # seen on that pod, kept only while the attempt is in the poll set.
+    _disruption_reasons: dict[str, str] = field(default_factory=dict, init=False, repr=False)
     # (task_id_wire, attempt_id) this process has dispatched a pod for. Those pods
     # were created under the current name, so their lookups must never consider the
     # pre-uid name — see _pod_name_candidates.
@@ -3116,6 +3129,7 @@ class K8sTaskProvider:
                 self._periodic_profiler.set_pods({})
             if self._task_event_log is not None:
                 self._task_event_log.retain(set())
+            self._disruption_reasons.clear()
             return []
 
         pods_by_name: dict[str, dict] = {pod.get("metadata", {}).get("name", ""): pod for pod in cached_pods}
@@ -3143,6 +3157,10 @@ class K8sTaskProvider:
         for entry in running:
             pod_name, pod = self._lookup_entry_pod(pods_by_name, entry)
             cursor_key = f"{entry.task_id.to_wire()}:{entry.attempt_id}"
+            # A resubmit reuses (task_id, attempt_id) under a fresh uid, so the
+            # disruption cache keys on the incarnation: the previous pod's
+            # eviction must not be reported for the new one.
+            incarnation_key = f"{cursor_key}:{entry.attempt_uid}"
             task_key = (entry.task_id.to_wire(), entry.attempt_id)
 
             if pod is None:
@@ -3157,19 +3175,25 @@ class K8sTaskProvider:
                         )
                     )
                     continue
-                # Grace exhausted — pod is truly gone. For a coscheduled task
-                # this is almost always a Kueue gang preemption (Kueue deletes
-                # every pod in a preempted group, leaving no terminal status to
-                # read), so bill it to the preemption budget (WORKER_FAILED)
-                # rather than the application budget (FAILED).
+                # Grace exhausted — the pod is truly gone. Absence is not an
+                # application failure, so charge the preemption budget either
+                # way: PREEMPTED when the pod was seen terminating under a
+                # disruption (Kueue deletes every pod of a preempted Workload,
+                # leaving no terminal status), WORKER_FAILED when the cause was
+                # never observed.
                 self._pod_not_found_counts.pop(cursor_key, None)
-                gone_state = job_pb2.TASK_STATE_WORKER_FAILED if entry.coscheduled else job_pb2.TASK_STATE_FAILED
+                disruption_reason = self._disruption_reasons.get(incarnation_key)
                 updates.append(
                     TaskUpdate(
                         task_id=entry.task_id,
                         attempt_id=entry.attempt_id,
-                        new_state=gone_state,
+                        new_state=(
+                            job_pb2.TASK_STATE_PREEMPTED
+                            if disruption_reason is not None
+                            else job_pb2.TASK_STATE_WORKER_FAILED
+                        ),
                         error="Pod not found",
+                        terminal_reason=disruption_reason or _POD_DELETED_TERMINAL_REASON,
                         status_message="",
                     )
                 )
@@ -3178,6 +3202,11 @@ class K8sTaskProvider:
             self._pod_not_found_counts.pop(cursor_key, None)
             workload = _workload_for_pod(pod, workload_index)
             update = _task_update_from_pod(entry, pod, workload)
+            # Readable only while the pod terminates; the vanished-pod path
+            # above has no pod left to read it from.
+            disruption = _infrastructure_failure_condition(pod)
+            if disruption is not None:
+                self._disruption_reasons[incarnation_key] = _format_disruption_reason(disruption)
             phase = pod.get("status", {}).get("phase", "")
             if phase == "Running":
                 resource_pods[task_key] = pod_name
@@ -3200,5 +3229,9 @@ class K8sTaskProvider:
             periodic_profiler.set_pods(profile_targets)
         if event_log is not None:
             event_log.retain(set(running))
+        for stale_key in self._disruption_reasons.keys() - {
+            f"{entry.task_id.to_wire()}:{entry.attempt_id}:{entry.attempt_uid}" for entry in running
+        }:
+            del self._disruption_reasons[stale_key]
 
         return updates

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -1036,7 +1036,7 @@ def _task_container_status(pod: dict) -> dict | None:
     return statuses[0]
 
 
-def _infrastructure_failure_condition(pod: dict) -> dict | None:
+def _disruption_condition(pod: dict) -> dict | None:
     """Return the authoritative pod disruption condition, if present.
 
     Kubernetes stamps ``DisruptionTarget`` for native disruptions. Kueue stamps
@@ -1077,7 +1077,7 @@ def _pod_failure_state(pod: dict) -> int:
     # exit 137 — which the terminated-reason whitelist below misses. A container
     # that OOMs on its own cgroup limit carries no such condition and correctly
     # falls through to an application failure.
-    if _infrastructure_failure_condition(pod) is not None:
+    if _disruption_condition(pod) is not None:
         return job_pb2.TASK_STATE_PREEMPTED
     status = _task_container_status(pod)
     if status is None:
@@ -1210,7 +1210,7 @@ def _extract_terminal_reason(pod: dict) -> str | None:
     init-container failure invisible to the task-container extractors, over the
     task container's own terminal reason.
     """
-    condition = _infrastructure_failure_condition(pod)
+    condition = _disruption_condition(pod)
     condition_reason = _format_disruption_reason(condition) if condition is not None else None
     reason = condition_reason or _init_container_failure(pod) or _extract_error(pod)
     return reason[:_TERMINAL_REASON_MAX_CHARS] if reason is not None else None
@@ -1521,7 +1521,7 @@ def _pod_event(pod: dict, workload: dict | None) -> _PodEvent | None:
     Kueue-declined admission, Normal for a transient wait. Returns ``None`` for a
     running or otherwise quiet pod.
     """
-    disruption = _infrastructure_failure_condition(pod)
+    disruption = _disruption_condition(pod)
     if disruption is not None and disruption.get("type") == _KUEUE_TERMINATION_TARGET_CONDITION:
         return _PodEvent(
             source=_EVENT_SOURCE_KUEUE,
@@ -2371,9 +2371,10 @@ class K8sTaskProvider:
     # worker store, so it reads its dispatch drain through this).
     transition_reader: TransitionReader | None = field(default=None, repr=False)
     _pod_not_found_counts: dict[str, int] = field(default_factory=dict, init=False, repr=False)
-    # "<task_id>:<attempt_id>:<attempt_uid>" -> the disruption condition last
-    # seen on that pod, kept only while the attempt is in the poll set.
-    _disruption_reasons: dict[str, str] = field(default_factory=dict, init=False, repr=False)
+    # The disruption condition last seen on an attempt's pod, keyed by the
+    # incarnation (a resubmit reuses task_id/attempt_id under a fresh uid) and
+    # dropped once the attempt leaves the poll set.
+    _disruption_reasons: dict[RunningTaskEntry, str] = field(default_factory=dict, init=False, repr=False)
     # (task_id_wire, attempt_id) this process has dispatched a pod for. Those pods
     # were created under the current name, so their lookups must never consider the
     # pre-uid name — see _pod_name_candidates.
@@ -3157,10 +3158,6 @@ class K8sTaskProvider:
         for entry in running:
             pod_name, pod = self._lookup_entry_pod(pods_by_name, entry)
             cursor_key = f"{entry.task_id.to_wire()}:{entry.attempt_id}"
-            # A resubmit reuses (task_id, attempt_id) under a fresh uid, so the
-            # disruption cache keys on the incarnation: the previous pod's
-            # eviction must not be reported for the new one.
-            incarnation_key = f"{cursor_key}:{entry.attempt_uid}"
             task_key = (entry.task_id.to_wire(), entry.attempt_id)
 
             if pod is None:
@@ -3182,7 +3179,7 @@ class K8sTaskProvider:
                 # leaving no terminal status), WORKER_FAILED when the cause was
                 # never observed.
                 self._pod_not_found_counts.pop(cursor_key, None)
-                disruption_reason = self._disruption_reasons.get(incarnation_key)
+                disruption_reason = self._disruption_reasons.get(entry)
                 updates.append(
                     TaskUpdate(
                         task_id=entry.task_id,
@@ -3204,9 +3201,9 @@ class K8sTaskProvider:
             update = _task_update_from_pod(entry, pod, workload)
             # Readable only while the pod terminates; the vanished-pod path
             # above has no pod left to read it from.
-            disruption = _infrastructure_failure_condition(pod)
+            disruption = _disruption_condition(pod)
             if disruption is not None:
-                self._disruption_reasons[incarnation_key] = _format_disruption_reason(disruption)
+                self._disruption_reasons[entry] = _format_disruption_reason(disruption)
             phase = pod.get("status", {}).get("phase", "")
             if phase == "Running":
                 resource_pods[task_key] = pod_name
@@ -3229,9 +3226,7 @@ class K8sTaskProvider:
             periodic_profiler.set_pods(profile_targets)
         if event_log is not None:
             event_log.retain(set(running))
-        for stale_key in self._disruption_reasons.keys() - {
-            f"{entry.task_id.to_wire()}:{entry.attempt_id}:{entry.attempt_uid}" for entry in running
-        }:
-            del self._disruption_reasons[stale_key]
+        for stale_entry in self._disruption_reasons.keys() - set(running):
+            del self._disruption_reasons[stale_entry]
 
         return updates

--- a/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
@@ -366,7 +366,6 @@ def drain_for_dispatch(
         RunningTaskEntry(
             task_id=row.task_id,
             attempt_id=row.current_attempt_id,
-            coscheduled=row.has_coscheduling,
             attempt_uid=uids.get((row.task_id, row.current_attempt_id), ""),
         )
         for row in running_rows

--- a/lib/iris/src/iris/cluster/controller/reconcile/task.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/task.py
@@ -425,6 +425,7 @@ def apply_one_transition(
         job_pb2.TASK_STATE_FAILED,
         job_pb2.TASK_STATE_WORKER_FAILED,
         job_pb2.TASK_STATE_KILLED,
+        job_pb2.TASK_STATE_PREEMPTED,
         job_pb2.TASK_STATE_UNSCHEDULABLE,
         job_pb2.TASK_STATE_SUCCEEDED,
     ):
@@ -456,8 +457,14 @@ def apply_one_transition(
             if failure_count <= task.max_retries_failure:
                 task_state = job_pb2.TASK_STATE_PENDING
                 terminal_ms = None
-        elif update.new_state in (job_pb2.TASK_STATE_WORKER_FAILED, job_pb2.TASK_STATE_KILLED):
-            # Worker loss / infra (WORKER_FAILED) or an out-of-band container stop
+        elif update.new_state in (
+            job_pb2.TASK_STATE_WORKER_FAILED,
+            job_pb2.TASK_STATE_KILLED,
+            job_pb2.TASK_STATE_PREEMPTED,
+        ):
+            # Worker loss / infra (WORKER_FAILED), a backend-observed preemption
+            # (PREEMPTED: a cluster backend's control plane evicted the attempt),
+            # or an out-of-band container stop
             # the worker reports as KILLED — a higher-priority job reclaiming the
             # slice, a node drain, a spot/preemptible reclaim, or a stop directive
             # the controller issued without recording a matching task transition.
@@ -472,11 +479,18 @@ def apply_one_transition(
             # EXECUTING (BUILDING/RUNNING) charges and gates on max_retries_preemption.
             # A truly-dead worker also misses its next ping/heartbeat (bumped
             # observer-side), so we don't double-count here.
+            # A KILLED keeps the WORKER_FAILED terminal so the task's terminal
+            # state stays inside the preemption-budget predicate.
+            terminal_state = (
+                job_pb2.TASK_STATE_PREEMPTED
+                if update.new_state == job_pb2.TASK_STATE_PREEMPTED
+                else job_pb2.TASK_STATE_WORKER_FAILED
+            )
             task_state = resolve_task_failure_state(
                 prior_state,
                 preemption_count,
                 task.max_retries_preemption,
-                terminal_state=job_pb2.TASK_STATE_WORKER_FAILED,
+                terminal_state=terminal_state,
             )
             if task_state == job_pb2.TASK_STATE_PENDING:
                 terminal_ms = None

--- a/lib/iris/src/iris/cluster/controller/task_state.py
+++ b/lib/iris/src/iris/cluster/controller/task_state.py
@@ -41,11 +41,6 @@ DISPATCHED_TASK_STATES: frozenset[int] = frozenset(
 class RunningTaskEntry(NamedTuple):
     """Task ID and attempt ID pair captured at snapshot time.
 
-    ``coscheduled`` lets the direct (K8s) provider classify a vanished pod as
-    a gang preemption (WORKER_FAILED) rather than an application failure: when
-    Kueue preempts a pod group it deletes every pod, leaving no terminal pod
-    status to read — only the absence. See K8sTaskProvider._poll_pods.
-
     ``attempt_uid`` is the incarnation key the K8s provider needs to rebuild the
     pod name (which embeds it): a resubmit reuses (task_id, attempt_id) but mints
     a new uid, so poll must target this attempt's pod, not a stale one. Empty off
@@ -54,7 +49,6 @@ class RunningTaskEntry(NamedTuple):
 
     task_id: JobName
     attempt_id: int
-    coscheduled: bool = False
     attempt_uid: str = ""
 
 

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -26,8 +26,8 @@ from iris.cluster.backends.k8s.tasks import (
     _build_volumes_and_mounts,
     _constraints_to_node_selector,
     _is_coordinator_task,
-    _is_infrastructure_failure,
     _job_id_from_task,
+    _pod_failure_state,
     _pod_group_name,
     _pod_name,
     _sanitize_label_value,
@@ -311,13 +311,12 @@ def test_task_update_error_prefers_termination_message_over_bare_reason():
     assert update.error == "RuntimeError: CUDA error: an illegal memory access was encountered"
 
 
-def test_is_infrastructure_failure_with_pod_level_reason():
-    """Pod-level eviction (no container statuses) is detected as infrastructure failure."""
+def test_pod_level_eviction_reason_is_worker_failed():
     pod: dict = {
         "metadata": {"name": "test"},
         "status": {"phase": "Failed", "reason": "Evicted", "containerStatuses": []},
     }
-    assert _is_infrastructure_failure(pod)
+    assert _pod_failure_state(pod) == job_pb2.TASK_STATE_WORKER_FAILED
 
 
 def _add_condition(pod: dict, type_: str, status: str, reason: str = "") -> dict:
@@ -326,19 +325,19 @@ def _add_condition(pod: dict, type_: str, status: str, reason: str = "") -> dict
 
 
 @pytest.mark.parametrize("reason", ["PreemptionByScheduler", "TerminationByKubelet", "EvictionByEvictionAPI"])
-def test_task_update_disruption_target_is_worker_failed(reason):
+def test_task_update_disruption_target_is_preempted(reason):
     """A preemption SIGKILLed after grace surfaces as reason='Error' exit 137 — not in
     the reason whitelist — but the control plane's DisruptionTarget condition marks it
-    as infrastructure, so it must be WORKER_FAILED (preemption budget), not FAILED."""
+    as a disruption, so it must be PREEMPTED (preemption budget), not FAILED."""
     entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
     pod = make_pod("iris-job-0-0", "Failed", exit_code=137, reason="Error")
     _add_condition(pod, "DisruptionTarget", "True", reason)
     update = _task_update_from_pod(entry, pod)
-    assert update.new_state == job_pb2.TASK_STATE_WORKER_FAILED
+    assert update.new_state == job_pb2.TASK_STATE_PREEMPTED
     assert update.exit_code == 137
 
 
-def test_task_update_kueue_termination_target_is_worker_failed():
+def test_task_update_kueue_termination_target_is_preempted():
     """Kueue preemption uses TerminationTarget rather than Kubernetes'
     DisruptionTarget; preserve that authoritative cause instead of charging a
     SIGKILL-shaped exit as an application failure."""
@@ -350,7 +349,7 @@ def test_task_update_kueue_termination_target_is_worker_failed():
 
     update = _task_update_from_pod(entry, pod)
 
-    assert update.new_state == job_pb2.TASK_STATE_WORKER_FAILED
+    assert update.new_state == job_pb2.TASK_STATE_PREEMPTED
     assert update.exit_code == 137
     assert update.terminal_reason is not None
     assert "WorkloadEvictedDueToPreempted" in update.terminal_reason
@@ -370,7 +369,7 @@ def test_disruption_target_condition_status_false_is_not_infrastructure():
     """A DisruptionTarget condition with status != 'True' does not mark a disruption."""
     pod = make_pod("iris-job-0-0", "Failed", exit_code=1, reason="Error")
     _add_condition(pod, "DisruptionTarget", "False", "")
-    assert not _is_infrastructure_failure(pod)
+    assert _pod_failure_state(pod) == job_pb2.TASK_STATE_FAILED
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -19,6 +19,7 @@ from iris.cluster.backends.k8s.tasks import (
     _LABEL_TASK_HASH,
     _LABEL_TASK_ID,
     _MANAGED_POD_LABELS,
+    _POD_DELETED_TERMINAL_REASON,
     _POD_NOT_FOUND_GRACE_CYCLES,
     _RUNTIME_LABEL_VALUE,
     K8sTaskProvider,
@@ -274,8 +275,10 @@ def test_sync_running_task_returns_running_state(provider, k8s):
     assert result[0].new_state == job_pb2.TASK_STATE_RUNNING
 
 
-def test_sync_pod_not_found_marks_failed(provider, k8s):
-    """Pod must be missing for _POD_NOT_FOUND_GRACE_CYCLES consecutive syncs before FAILED."""
+def test_sync_pod_not_found_marks_worker_failed(provider, k8s):
+    """A pod missing for _POD_NOT_FOUND_GRACE_CYCLES consecutive syncs with no
+    disruption ever observed is worker loss (preemption budget), not an
+    application failure — nothing the task did deletes its own pod."""
     task_id = JobName.from_wire("/job/0")
     entry = RunningTaskEntry(task_id=task_id, attempt_id=0)
 
@@ -288,7 +291,8 @@ def test_sync_pod_not_found_marks_failed(provider, k8s):
 
     result = provider.sync(batch)
     assert len(result) == 1
-    assert result[0].new_state == job_pb2.TASK_STATE_FAILED
+    assert result[0].new_state == job_pb2.TASK_STATE_WORKER_FAILED
+    assert result[0].terminal_reason == _POD_DELETED_TERMINAL_REASON
 
 
 def test_sync_finds_pod_dispatched_before_pod_names_embedded_uid(provider, k8s):
@@ -350,27 +354,68 @@ def test_sync_ignores_legacy_pod_for_an_attempt_this_process_dispatched(provider
         assert provider.sync(batch)[0].new_state == job_pb2.TASK_STATE_RUNNING
 
     result = provider.sync(batch)
-    assert result[0].new_state == job_pb2.TASK_STATE_FAILED
+    assert result[0].new_state == job_pb2.TASK_STATE_WORKER_FAILED
     assert result[0].error == "Pod not found"
 
 
-def test_sync_coscheduled_pod_not_found_is_worker_failed(provider, k8s):
-    """A vanished pod for a coscheduled task is billed as WORKER_FAILED (gang preemption),
-    not FAILED — Kueue deletes every pod in a preempted group, leaving only the absence."""
-    task_id = JobName.from_wire("/gang/task/0")
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=0, coscheduled=True)
-    batch = make_batch(running_tasks=[entry])
+_EVICTION_REASON = "WorkloadEvictedDueToPreempted: Preempted to accommodate a higher priority Workload"
 
+
+def _populate_evicted_pod(k8s, pod_name: str) -> None:
+    """A running pod carrying the Kueue eviction condition it gets while terminating."""
+    populate_pod(k8s, pod_name, "Running")
+    pod = k8s.get_json(K8sResource.PODS, pod_name)
+    pod["status"]["conditions"] = [
+        {
+            "type": "TerminationTarget",
+            "status": "True",
+            "reason": "WorkloadEvictedDueToPreempted",
+            "message": "Preempted to accommodate a higher priority Workload",
+        }
+    ]
+    k8s.seed_resource(K8sResource.PODS, pod_name, pod)
+
+
+def test_sync_vanished_pod_reports_the_kueue_eviction_that_deleted_it(provider, k8s):
+    """A pod Kueue evicts carries its TerminationTarget condition only while it
+    terminates, and is then deleted — so the vanished-pod path must report the
+    eviction observed on the last poll rather than a bare absence."""
+    task_id = JobName.from_wire("/gang/task/0")
+    pod_name = _pod_name(task_id, 0)
+    batch = make_batch(running_tasks=[RunningTaskEntry(task_id=task_id, attempt_id=0)])
+
+    _populate_evicted_pod(k8s, pod_name)
+    assert provider.sync(batch)[0].new_state == job_pb2.TASK_STATE_RUNNING
+
+    k8s.delete(K8sResource.PODS, pod_name)
     for _ in range(_POD_NOT_FOUND_GRACE_CYCLES - 1):
-        result = provider.sync(batch)
-        assert result[0].new_state == job_pb2.TASK_STATE_RUNNING
+        assert provider.sync(batch)[0].new_state == job_pb2.TASK_STATE_RUNNING
+
+    result = provider.sync(batch)
+    assert result[0].new_state == job_pb2.TASK_STATE_PREEMPTED
+    assert result[0].terminal_reason == _EVICTION_REASON
+
+
+def test_sync_does_not_charge_a_new_incarnation_with_the_previous_eviction(provider, k8s):
+    """A resubmit reuses (task_id, attempt_id) under a fresh uid, so the evicted
+    pod's reason must not follow the new incarnation."""
+    task_id = JobName.from_wire("/gang/task/1")
+    evicted_uid = "aaaabbbbccccdddd"
+    _populate_evicted_pod(k8s, _pod_name(task_id, 0, evicted_uid))
+    provider.sync(make_batch(running_tasks=[RunningTaskEntry(task_id=task_id, attempt_id=0, attempt_uid=evicted_uid)]))
+    k8s.delete(K8sResource.PODS, _pod_name(task_id, 0, evicted_uid))
+
+    batch = make_batch(running_tasks=[RunningTaskEntry(task_id=task_id, attempt_id=0, attempt_uid="1111222233334444")])
+    for _ in range(_POD_NOT_FOUND_GRACE_CYCLES - 1):
+        assert provider.sync(batch)[0].new_state == job_pb2.TASK_STATE_RUNNING
 
     result = provider.sync(batch)
     assert result[0].new_state == job_pb2.TASK_STATE_WORKER_FAILED
+    assert result[0].terminal_reason == _POD_DELETED_TERMINAL_REASON
 
 
 def test_pod_not_found_grace_period(provider, k8s):
-    """A single missing-pod sync returns RUNNING, not FAILED."""
+    """A single missing-pod sync returns RUNNING, not a terminal state."""
     task_id = JobName.from_wire("/job/grace")
     entry = RunningTaskEntry(task_id=task_id, attempt_id=0)
 
@@ -398,14 +443,14 @@ def test_pod_not_found_grace_resets_when_pod_reappears(provider, k8s):
     result = provider.sync(batch)
     assert result[0].new_state == job_pb2.TASK_STATE_RUNNING
 
-    # Now disappear again: need full grace cycles again before failure.
+    # Now disappear again: need full grace cycles again before the terminal update.
     k8s.delete(K8sResource.PODS, pod_name)
     for _ in range(_POD_NOT_FOUND_GRACE_CYCLES - 1):
         result = provider.sync(batch)
         assert result[0].new_state == job_pb2.TASK_STATE_RUNNING
 
     result = provider.sync(batch)
-    assert result[0].new_state == job_pb2.TASK_STATE_FAILED
+    assert result[0].new_state == job_pb2.TASK_STATE_WORKER_FAILED
 
 
 def test_sync_empty_batch(provider):
@@ -1555,9 +1600,7 @@ def test_reconcile_evicts_blockers_while_gang_gated(preempt_provider, k8s):
     """A blocker that lands AFTER gang submission is evicted by the reconcile
     loop while the gang's pods remain SchedulingGated, and the sweep is
     debounced so back-to-back reconciles don't re-list the namespace."""
-    entries = [
-        RunningTaskEntry(task_id=JobName.from_wire(f"/gang/task/{i}"), attempt_id=0, coscheduled=True) for i in range(2)
-    ]
+    entries = [RunningTaskEntry(task_id=JobName.from_wire(f"/gang/task/{i}"), attempt_id=0) for i in range(2)]
     preempt_provider.sync(make_batch(tasks_to_run=_gang_reqs(), running_tasks=entries))
 
     # Kueue's webhook gates gang pods until the pod-group Workload is admitted.

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -644,16 +644,15 @@ def test_apply_failed_directly_from_assigned(state):
     assert task.failure_count == 1
 
 
-def test_apply_worker_failed_from_running_retries(state):
-    """WORKER_FAILED from RUNNING with retries remaining returns to PENDING."""
-    task_event_table = FakeStatsTable()
-    state._db.attach_task_event_table(task_event_table)
-    jid = JobName.root("test-user", "wf-retry")
-    req = make_direct_job_request("wf-retry")
-    req.max_retries_preemption = 5
+def _start_direct_task(state, name: str, *, max_retries_preemption: int) -> tuple[JobName, int]:
+    """Submit a one-task direct job named ``name``, dispatch it, and drive it to
+    RUNNING. Returns the task id and its current attempt id."""
+    job_id = JobName.root("test-user", name)
+    req = make_direct_job_request(name)
+    req.max_retries_preemption = max_retries_preemption
     with state._db.transaction() as cur:
-        submit_job_in_tx(cur, job_id=jid, request=req, ts=Timestamp.now())
-    task_id = query_tasks_for_job(state, jid)[0].task_id
+        submit_job_in_tx(cur, job_id=job_id, request=req, ts=Timestamp.now())
+    task_id = query_tasks_for_job(state, job_id)[0].task_id
 
     with state._db.transaction() as cur:
         batch = dispatch.drain_for_dispatch(cur)
@@ -662,11 +661,18 @@ def test_apply_worker_failed_from_running_retries(state):
     with state._db.transaction() as cur:
         commit_dispatch_updates(
             cur,
-            [
-                TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING),
-            ],
+            [TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING)],
             now=Timestamp.now(),
         )
+    return task_id, attempt_id
+
+
+def test_apply_worker_failed_from_running_retries(state):
+    """WORKER_FAILED from RUNNING with retries remaining returns to PENDING."""
+    task_event_table = FakeStatsTable()
+    state._db.attach_task_event_table(task_event_table)
+    task_id, attempt_id = _start_direct_task(state, "wf-retry", max_retries_preemption=5)
+
     with state._db.transaction() as cur:
         commit_dispatch_updates(
             cur,
@@ -688,28 +694,6 @@ def test_apply_worker_failed_from_running_retries(state):
     assert event.attempt_uid
 
 
-def _start_direct_task(state, name: str, *, max_retries_preemption: int) -> tuple[JobName, JobName, int]:
-    """Submit a one-task direct job, dispatch it, and drive it to RUNNING."""
-    jid = JobName.root("test-user", name)
-    req = make_direct_job_request(name)
-    req.max_retries_preemption = max_retries_preemption
-    with state._db.transaction() as cur:
-        submit_job_in_tx(cur, job_id=jid, request=req, ts=Timestamp.now())
-    task_id = query_tasks_for_job(state, jid)[0].task_id
-
-    with state._db.transaction() as cur:
-        batch = dispatch.drain_for_dispatch(cur)
-    attempt_id = batch.tasks_to_run[0].attempt_id
-
-    with state._db.transaction() as cur:
-        commit_dispatch_updates(
-            cur,
-            [TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING)],
-            now=Timestamp.now(),
-        )
-    return jid, task_id, attempt_id
-
-
 def test_apply_preempted_from_running_retries(state):
     """A backend-reported PREEMPTED charges the preemption budget and retries.
 
@@ -717,7 +701,7 @@ def test_apply_preempted_from_running_retries(state):
     branch for it the task keeps its RUNNING row while the attempt goes terminal,
     which strands the task.
     """
-    _, task_id, attempt_id = _start_direct_task(state, "preempt-retry", max_retries_preemption=5)
+    task_id, attempt_id = _start_direct_task(state, "preempt-retry", max_retries_preemption=5)
 
     with state._db.transaction() as cur:
         commit_dispatch_updates(
@@ -745,7 +729,8 @@ def test_apply_preempted_from_running_retries(state):
 def test_apply_preempted_terminal_when_budget_exhausted(state):
     """With the preemption budget spent, PREEMPTED finalizes the task as PREEMPTED
     (not FAILED), so a triager can tell an eviction from an application fault."""
-    jid, task_id, attempt_id = _start_direct_task(state, "preempt-terminal", max_retries_preemption=0)
+    task_id, attempt_id = _start_direct_task(state, "preempt-terminal", max_retries_preemption=0)
+    job_id = JobName.root("test-user", "preempt-terminal")
 
     with state._db.transaction() as cur:
         commit_dispatch_updates(
@@ -757,7 +742,7 @@ def test_apply_preempted_terminal_when_budget_exhausted(state):
     task = query_task(state, task_id)
     assert task.state == job_pb2.TASK_STATE_PREEMPTED
     assert task.preemption_count == 1
-    assert query_job(state, jid).state == job_pb2.JOB_STATE_WORKER_FAILED
+    assert query_job(state, job_id).state == job_pb2.JOB_STATE_WORKER_FAILED
 
 
 def test_apply_worker_failed_from_assigned(state):

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -34,6 +34,7 @@ from tests.cluster.controller.transition_driver import commit_dispatch_updates
 from .conftest import (
     make_direct_job_request,
     query_attempt,
+    query_job,
     query_task,
     query_tasks_for_job,
     reconcile_once,
@@ -685,6 +686,78 @@ def test_apply_worker_failed_from_running_retries(state):
         "TaskRetryScheduled",
     )
     assert event.attempt_uid
+
+
+def _start_direct_task(state, name: str, *, max_retries_preemption: int) -> tuple[JobName, JobName, int]:
+    """Submit a one-task direct job, dispatch it, and drive it to RUNNING."""
+    jid = JobName.root("test-user", name)
+    req = make_direct_job_request(name)
+    req.max_retries_preemption = max_retries_preemption
+    with state._db.transaction() as cur:
+        submit_job_in_tx(cur, job_id=jid, request=req, ts=Timestamp.now())
+    task_id = query_tasks_for_job(state, jid)[0].task_id
+
+    with state._db.transaction() as cur:
+        batch = dispatch.drain_for_dispatch(cur)
+    attempt_id = batch.tasks_to_run[0].attempt_id
+
+    with state._db.transaction() as cur:
+        commit_dispatch_updates(
+            cur,
+            [TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_RUNNING)],
+            now=Timestamp.now(),
+        )
+    return jid, task_id, attempt_id
+
+
+def test_apply_preempted_from_running_retries(state):
+    """A backend-reported PREEMPTED charges the preemption budget and retries.
+
+    The K8s backend reports a Kueue eviction as PREEMPTED; without a transition
+    branch for it the task keeps its RUNNING row while the attempt goes terminal,
+    which strands the task.
+    """
+    _, task_id, attempt_id = _start_direct_task(state, "preempt-retry", max_retries_preemption=5)
+
+    with state._db.transaction() as cur:
+        commit_dispatch_updates(
+            cur,
+            [
+                TaskUpdate(
+                    task_id=task_id,
+                    attempt_id=attempt_id,
+                    new_state=job_pb2.TASK_STATE_PREEMPTED,
+                    error="Pod not found",
+                    terminal_reason="WorkloadEvictedDueToPreempted: preempted for a higher priority Workload",
+                )
+            ],
+            now=Timestamp.now(),
+        )
+
+    task = query_task(state, task_id)
+    assert task.state == job_pb2.TASK_STATE_PENDING
+    assert task.preemption_count == 1
+    attempt = query_attempt(state, task_id, attempt_id)
+    assert attempt.state == job_pb2.TASK_STATE_PREEMPTED
+    assert attempt.terminal_reason == "WorkloadEvictedDueToPreempted: preempted for a higher priority Workload"
+
+
+def test_apply_preempted_terminal_when_budget_exhausted(state):
+    """With the preemption budget spent, PREEMPTED finalizes the task as PREEMPTED
+    (not FAILED), so a triager can tell an eviction from an application fault."""
+    jid, task_id, attempt_id = _start_direct_task(state, "preempt-terminal", max_retries_preemption=0)
+
+    with state._db.transaction() as cur:
+        commit_dispatch_updates(
+            cur,
+            [TaskUpdate(task_id=task_id, attempt_id=attempt_id, new_state=job_pb2.TASK_STATE_PREEMPTED)],
+            now=Timestamp.now(),
+        )
+
+    task = query_task(state, task_id)
+    assert task.state == job_pb2.TASK_STATE_PREEMPTED
+    assert task.preemption_count == 1
+    assert query_job(state, jid).state == job_pb2.JOB_STATE_WORKER_FAILED
 
 
 def test_apply_worker_failed_from_assigned(state):


### PR DESCRIPTION
A pod that Kueue evicts now records `TASK_STATE_PREEMPTED` with the eviction as
the attempt's `terminal_reason`, instead of `WORKER_FAILED` or `FAILED` with an
empty reason. The `DisruptionTarget` / Kueue `TerminationTarget` condition is
readable only while the evicted pod terminates, so the k8s provider caches it
per poll entry and reports it once the pod is gone. A pod that vanishes with no
disruption ever observed reports `WORKER_FAILED`, which charges the same
preemption budget without claiming a cause.

That absence used to select `FAILED` for every non-coscheduled task, charging
`max_retries_failure` (default 0), so a preempted single-task job died where a
gang member retried. Both now charge `max_retries_preemption`.

`apply_one_transition` gained a `TASK_STATE_PREEMPTED` branch; without it a
reported preemption left the task row RUNNING while its attempt went terminal.
Preemption victims consequently leave the task list view, which attaches
`FAILED` and `WORKER_FAILED` attempts only — that exclusion is deliberate, to
keep capacity churn out of the genuine-failure list.

Fixes #7806
