### PR TITLE
zephyr: warn on stale pipeline progress

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -33,6 +33,7 @@ GET /finelog/{cluster}/query?sql=&from=&to=      finelog SQL
 GET /finelog/marin/fleet_health                  main query probe + k8s mirror readiness
 GET /finelog/marin/alerts/fleet_health           alert rows: server labels + value(0|1)
 GET /finelog/marin/alerts/training_stalls        active jobs + stalled-progress value(0|1)
+GET /finelog/marin/alerts/zephyr_stalls          active pipelines + stalled-progress value(0|1)
 GET /iris/{cluster}/jobs | workers | health      live controller RPCs
 GET /iris/{cluster}/query?sql=                    ad-hoc SELECT (admin/null-auth)
 GET /github/ferries | builds | nightlies          GitHub REST / GraphQL
@@ -226,7 +227,10 @@ see `gpu_racks` above). A warning-only training rule joins fresh running
 `iris.task_state` rows to root jobs with Levanter Telltale metrics in the prior
 24 hours: it waits 15 minutes for training progress or 45 minutes for
 initialization, then remains pending for five minutes. It does not require
-task-to-node GPU attribution. The stuck-pod
+task-to-node GPU attribution. A warning-only Zephyr rule reads fresh
+`zephyr_progress_time_seconds` rows from Telltale. It waits 45 minutes after a
+stage start or shard completion, then remains pending for five minutes. The
+execution ID separates concurrent pipelines under one root job. The stuck-pod
 rule groups by node and links the cordon-first
 recovery skill; terminal, unbound, and finalizer-held pods stay dashboard-only.
 Other workload-tier signals (gated pods, Kueue backlog, workload crashloops) are

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -497,6 +497,53 @@ groups:
               conditions:
                 - evaluator: { type: gt, params: [0] }
 
+  # This warning finds an active Zephyr producer that reports no shard
+  # completion for 45 minutes. The bridge removes expired producers.
+  - orgId: 1
+    name: zephyr-progress
+    folder: Alerts
+    interval: 1m
+    rules:
+      - uid: zephyr-pipeline-progress-stalled
+        title: ZephyrPipelineProgressStalled
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: warning
+        annotations:
+          summary: "{{ $labels.cluster }}: {{ $labels.job }} execution {{ $labels.execution }} has stale shard progress"
+          runbook_url: https://github.com/marin-community/marin/blob/main/lib/zephyr/OPS.md#stale-pipeline-warning
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: finelog-marin
+            model:
+              refId: A
+              datasource: { type: yesoreyeram-infinity-datasource, uid: finelog-marin }
+              type: json
+              source: url
+              parser: backend
+              format: table
+              url: /alerts/zephyr_stalls
+              url_options: { method: GET }
+              columns:
+                - { selector: cluster, text: cluster, type: string }
+                - { selector: job, text: job, type: string }
+                - { selector: execution, text: execution, type: string }
+                - { selector: reason, text: reason, type: string }
+                - { selector: value, text: value, type: number }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
   # The GCE controllers are not in K8S_CLUSTERS; their liveness comes from the
   # existing per-cluster iris datasources. The health row always exists (the
   # bridge answers reachable=false rather than erroring), and `up` is its 0/1

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -15,6 +15,7 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /finelog/marin/fleet_health              hub query health + k8s mirror readiness
     GET /finelog/marin/alerts/fleet_health       alert rows: server labels + value(0|1)
     GET /finelog/marin/alerts/training_stalls    active jobs + stalled-progress value(0|1)
+    GET /finelog/marin/alerts/zephyr_stalls      active pipelines + stalled-progress value(0|1)
     GET /iris/{cluster}/jobs                     root-job counts by state (in-flight + 24h terminal)
     GET /iris/{cluster}/workers                  healthy worker counts + resource totals per region
     GET /iris/{cluster}/health                   controller reachability + latency
@@ -92,6 +93,7 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 from training_stalls import task_state_query, telltale_query, training_stall_alert_rows
 from wandb_source import WandbSource
+from zephyr_stalls import zephyr_progress_query, zephyr_stall_alert_rows
 
 logger = logging.getLogger(__name__)
 
@@ -368,6 +370,23 @@ def create_app(
         except QueryResultTooLargeError as err:
             return JSONResponse({"error": f"{err}; reduce the alert query lookback"}, status_code=400)
 
+    def finelog_alerts_zephyr_stalls(_: Request) -> JSONResponse:
+        try:
+            target = _target_for(_FINELOG_HUB_CLUSTER, finelog_sources)
+            now = datetime.now(UTC)
+
+            def run() -> list[dict]:
+                source = finelog_sources[target.name]
+                progress_metrics = source.query(zephyr_progress_query(now), max_rows=config.max_rows)
+                return zephyr_stall_alert_rows(progress_metrics, now)
+
+            key = ("zephyr_stalls", _bucket(now, config.cache_ttl))
+            return JSONResponse(finelog_cache.get_or_compute(key, run))
+        except _BadRequest as err:
+            return JSONResponse({"error": str(err)}, status_code=400)
+        except QueryResultTooLargeError as err:
+            return JSONResponse({"error": f"{err}; reduce the alert query lookback"}, status_code=400)
+
     def iris_endpoint(request: Request, endpoint: str, run) -> JSONResponse:
         try:
             source = _iris_for(request.path_params["cluster"], iris_sources)
@@ -565,6 +584,7 @@ def create_app(
             Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/fleet_health", finelog_fleet_health),
             Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/fleet_health", finelog_alerts_fleet_health),
             Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/training_stalls", finelog_alerts_training_stalls),
+            Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/zephyr_stalls", finelog_alerts_zephyr_stalls),
             Route("/iris/{cluster}/jobs", iris_jobs),
             Route("/iris/{cluster}/workers", iris_workers),
             Route("/iris/{cluster}/health", iris_health),

--- a/infra/grafana/src/zephyr_stalls.py
+++ b/infra/grafana/src/zephyr_stalls.py
@@ -1,0 +1,82 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bounded finelog query and alert rows for stale Zephyr pipeline progress."""
+
+from datetime import UTC, datetime, timedelta
+
+import pyarrow as pa
+
+_PRODUCER_FRESHNESS = timedelta(seconds=90)
+_STALL_AGE = timedelta(minutes=45)
+_TELLTALE_LOOKBACK = timedelta(minutes=5)
+
+_PROGRESS_TIME_METRIC = "zephyr_progress_time_seconds"
+
+
+def _sql_timestamp(at: datetime) -> str:
+    return at.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def zephyr_progress_query(now: datetime) -> str:
+    """Return the latest Zephyr progress metric for each active execution."""
+    start = _sql_timestamp(now - _TELLTALE_LOOKBACK)
+    return (
+        "WITH recent AS ("
+        "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS cluster, job_id AS job, "
+        "run AS execution, value AS progress_time, ts AS producer_at, "
+        "ROW_NUMBER() OVER ("
+        "PARTITION BY COALESCE(NULLIF(cluster,''),'unknown'), job_id, run ORDER BY ts DESC"
+        ") AS rn "
+        'FROM "telltale" '
+        f"WHERE source = 'zephyr' AND name = '{_PROGRESS_TIME_METRIC}' "
+        "AND job_id IS NOT NULL AND job_id <> '' AND run IS NOT NULL AND run <> '' "
+        f"AND ts >= TIMESTAMP '{start}'"
+        ") "
+        "SELECT cluster, job, execution, progress_time, producer_at "
+        "FROM recent WHERE rn = 1 ORDER BY cluster, job, execution"
+    )
+
+
+def _as_utc(value: object) -> datetime:
+    if not isinstance(value, datetime):
+        raise ValueError(f"expected timestamp, got {value!r}")
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _row(cluster: str, job: str, execution: str, reason: str, value: int) -> dict:
+    return {
+        "cluster": cluster,
+        "job": job,
+        "execution": execution,
+        "reason": reason,
+        "value": value,
+    }
+
+
+def zephyr_stall_alert_rows(progress_metrics: pa.Table, now: datetime) -> list[dict]:
+    """Return warning rows for active executions without a recent shard completion."""
+    now = _as_utc(now)
+    rows: list[dict] = []
+    for metric in progress_metrics.to_pylist():
+        producer_at = _as_utc(metric["producer_at"])
+        if now - producer_at > _PRODUCER_FRESHNESS:
+            continue
+
+        progress_at = datetime.fromtimestamp(float(metric["progress_time"]), tz=UTC)
+        stale = now - progress_at >= _STALL_AGE
+        rows.append(
+            _row(
+                str(metric["cluster"]),
+                str(metric["job"]),
+                str(metric["execution"]),
+                "shard_progress_stale" if stale else "healthy",
+                int(stale),
+            )
+        )
+
+    if rows:
+        return rows
+    return [_row("fleet", "", "", "healthy", 0)]

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -5,7 +5,7 @@
 cache's coalescing and eviction contract."""
 
 import threading
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pyarrow as pa
 from cache import TtlCache
@@ -20,6 +20,7 @@ from server import create_app, workload_overview
 from starlette.testclient import TestClient
 from training_stalls import training_stall_alert_rows
 from wandb_source import WandbSource
+from zephyr_stalls import zephyr_stall_alert_rows
 
 # 2026-07-17T03:00:00Z and +1h, as Grafana sends them.
 FROM_MS = 1_784_257_200_000
@@ -317,6 +318,48 @@ def test_training_stall_alert_does_not_warn_on_a_producer_that_predates_phase():
 def test_training_stall_alert_returns_explicit_zero_without_running_jobs():
     assert training_stall_alert_rows(pa.table({}), pa.table({}), datetime(2026, 7, 28, tzinfo=UTC)) == [
         {"cluster": "fleet", "job": "", "phase": "idle", "reason": "healthy", "value": 0}
+    ]
+
+
+def test_zephyr_stall_alert_distinguishes_stale_healthy_and_expired_producers():
+    now = datetime(2026, 7, 28, 12, tzinfo=UTC)
+    progress = finelog_result(
+        cluster=["cw-a", "cw-a", "cw-a"],
+        job=["/user/stale", "/user/healthy", "/user/expired"],
+        execution=["run-stale", "run-healthy", "run-expired"],
+        progress_time=[
+            now.timestamp() - 46 * 60,
+            now.timestamp() - 44 * 60,
+            now.timestamp() - 60 * 60,
+        ],
+        producer_at=[
+            now - timedelta(seconds=20),
+            now - timedelta(seconds=20),
+            now - timedelta(minutes=2),
+        ],
+    )
+
+    assert zephyr_stall_alert_rows(progress, now) == [
+        {
+            "cluster": "cw-a",
+            "job": "/user/stale",
+            "execution": "run-stale",
+            "reason": "shard_progress_stale",
+            "value": 1,
+        },
+        {
+            "cluster": "cw-a",
+            "job": "/user/healthy",
+            "execution": "run-healthy",
+            "reason": "healthy",
+            "value": 0,
+        },
+    ]
+
+
+def test_zephyr_stall_alert_returns_explicit_zero_without_active_pipelines():
+    assert zephyr_stall_alert_rows(pa.table({}), datetime(2026, 7, 28, tzinfo=UTC)) == [
+        {"cluster": "fleet", "job": "", "execution": "", "reason": "healthy", "value": 0}
     ]
 
 

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -212,6 +212,13 @@ def test_node_deadlock_alert_pages_critical_after_five_minutes():
     assert rule["data"][0]["model"]["url"] == "/alerts/node_deadlocks"
 
 
+def test_zephyr_stall_alert_is_a_warning_after_five_minutes():
+    (rule,) = [rule for rule in _rules() if rule["uid"] == "zephyr-pipeline-progress-stalled"]
+    assert rule["for"] == "5m"
+    assert rule["labels"]["severity"] == "warning"
+    assert rule["data"][0]["model"]["url"] == "/alerts/zephyr_stalls"
+
+
 def test_k8s_dashboard_shows_finelog_fleet_health():
     dashboard = _stitched_dashboards()["k8s.json"]
     (panel,) = [

--- a/lib/zephyr/OPS.md
+++ b/lib/zephyr/OPS.md
@@ -82,6 +82,27 @@ for entry in task_logs:
     print(msg)
 ```
 
+### Stale Pipeline Warning
+
+Grafana evaluates `ZephyrPipelineProgressStalled` once each minute. The rule
+becomes pending after 45 minutes without a shard completion. The warning
+becomes active after five more minutes.
+
+The coordinator publishes `zephyr_progress_time_seconds` through Telltale. The
+metric resets at each stage start and after each shard completion. The metric
+includes the root job ID and the Zephyr execution ID. Grafana removes a
+producer when its most recent row is more than 90 seconds old.
+
+This rule is a passive warning. It does not send a notification, restart a job,
+or kick a task. A valid long shard can activate the warning. The warning means
+that no shard completed during the time limit. It does not mean that item,
+byte, CPU, or memory values stayed constant.
+
+Use `get_status` to confirm the completed, in-flight, and queued shard counts.
+Then compare the per-worker counters and collect thread profiles from the
+in-flight workers. Do not restart or kick a task before you collect this
+evidence.
+
 ### Straggler Detection
 
 1. **Progress line**: `in-flight >> 0` with `queued == 0` means stragglers — no new work to assign, waiting on slow shards.

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -91,6 +91,8 @@ MAX_STATUS_TEXT_LENGTH = 1000
 
 MAX_WORKERS_PER_JOB = 1_024
 
+ZEPHYR_PROGRESS_TIME_METRIC = "zephyr_progress_time_seconds"
+
 
 class ShardFailureKind(enum.StrEnum):
     """TASK failures count toward MAX_SHARD_FAILURES; INFRA failures (preemption) do not."""
@@ -324,6 +326,7 @@ class ZephyrCoordinator:
 
         # Set at each _start_stage so _log_status can show average throughput since stage start.
         self._stage_monotonic_start: float | None = None
+        self._progress_time_seconds: float = 0.0
 
         # Lock for accessing coordinator state from background thread
         self._lock = threading.Lock()
@@ -441,6 +444,13 @@ class ZephyrCoordinator:
         """
         for name, value in self.get_counters().items():
             telltale.publish_gauge(name, value, f"zephyr counter {name}")
+        with self._lock:
+            progress_time_seconds = self._progress_time_seconds
+        telltale.publish_gauge(
+            ZEPHYR_PROGRESS_TIME_METRIC,
+            progress_time_seconds,
+            "Unix time of the current stage start or most recent shard completion",
+        )
 
     def _build_status_md(self) -> tuple[str, str]:
         """Render pipeline progress as ``(detail, summary)`` markdown."""
@@ -737,6 +747,7 @@ class ZephyrCoordinator:
 
             self._results[shard_idx] = result
             self._completed_shards += 1
+            self._progress_time_seconds = time.time()
             self._in_flight.pop(shard_idx, None)
             self._completed_counters.append(counter_snapshot)
             # Zero the in-flight counters but keep the generation watermark
@@ -896,6 +907,7 @@ class ZephyrCoordinator:
             # accumulate across stages for full pipeline visibility.
             self._worker_counters = {}
             self._stage_monotonic_start = time.monotonic()
+            self._progress_time_seconds = time.time()
             self._stage_done.clear()
 
     def _wait_for_stage(self) -> None:
@@ -968,6 +980,7 @@ class ZephyrCoordinator:
                 raise RuntimeError(self._fatal_error)
             self._pipeline_running = True
             self._execution_id = execution_id
+        telltale.set_global_labels(source="zephyr", run=execution_id)
 
         try:
             shards = _build_source_shards(plan.source_items)

--- a/lib/zephyr/tests/test_counters.py
+++ b/lib/zephyr/tests/test_counters.py
@@ -32,6 +32,7 @@ def _make_coordinator(
     coord._lock = threading.Lock()
     coord._completed_counters = list(completed)
     coord._worker_counters = {str(i): s for i, s in enumerate(inflight or [])}
+    coord._progress_time_seconds = 0.0
     return coord
 
 

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -10,6 +10,7 @@ import threading
 import time
 import uuid
 from concurrent.futures import Future
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -19,12 +20,15 @@ from conftest import _TEST_TASK_COST, _TEST_WORKER_AVAILABLE
 from fray.actor import ActorContext
 from fray.local_backend import LocalClient
 from fray.types import ResourceConfig
+from prometheus_client import REGISTRY
+from rigging import telltale
 from zephyr import counters
 from zephyr.dataset import Dataset
 from zephyr.execution import (
     _NON_RETRYABLE_ERRORS,
     MAX_SHARD_FAILURES,
     MAX_SHARD_INFRA_FAILURES,
+    ZEPHYR_PROGRESS_TIME_METRIC,
     CoordinatorUnreachable,
     PullStatus,
     WorkerState,
@@ -492,6 +496,48 @@ def test_no_duplicate_results_on_heartbeat_timeout(coordinator):
 
     # Only one completion should be counted
     assert coordinator._completed_shards == 1
+
+
+def test_progress_metric_resets_at_stage_start_and_advances_after_a_shard(coordinator, monkeypatch):
+    task = ShardTask(
+        shard_idx=0,
+        total_shards=1,
+        shard=ListShard(refs=[]),
+        operations=[],
+        stage_name="test",
+        cost=_TEST_TASK_COST,
+    )
+    timestamps = iter((1_000.0, 1_010.0))
+    monkeypatch.setattr(time, "time", lambda: next(timestamps, 1_010.0))
+
+    coordinator._start_stage("test", 0, [task])
+    coordinator._publish_telltale()
+    assert REGISTRY.get_sample_value(ZEPHYR_PROGRESS_TIME_METRIC) == 1_000.0
+
+    coordinator.register_worker("worker-0", MagicMock())
+    status, work = coordinator.pull_task("worker-0", _TEST_WORKER_AVAILABLE)
+    assert status == PullStatus.RUN_TASK
+    assert work is not None
+    coordinator.report_result(
+        "worker-0",
+        task.shard_idx,
+        work.attempt,
+        TaskResult(shard=ListShard(refs=[])),
+        CounterSnapshot.empty(),
+    )
+    coordinator._publish_telltale()
+    assert REGISTRY.get_sample_value(ZEPHYR_PROGRESS_TIME_METRIC) == 1_010.0
+
+
+def test_pipeline_progress_metric_includes_execution_identity(coordinator):
+    plan = compute_plan(Dataset.from_list([]))
+    coordinator.run_pipeline(plan, "run-1")
+    coordinator._publish_telltale()
+
+    rows = telltale.scrape_metrics(telltale.MetricIdentity(job_id="/user/job"), datetime.now(UTC))
+    (progress,) = [row for row in rows if row.name == ZEPHYR_PROGRESS_TIME_METRIC]
+    assert progress.source == "zephyr"
+    assert progress.run == "run-1"
 
 
 def test_disk_chunk_write_uses_unique_paths(tmp_path):


### PR DESCRIPTION
* publish `zephyr_progress_time_seconds` at each stage start and shard completion
* show `ZephyrPipelineProgressStalled` after 45 minutes without progress and a five-minute pending period
* remove producers after 90 seconds and separate active executions by execution ID
* keep the rule warning-only because a valid long shard can cross the limit
