### PR TITLE
[datakit] Register the biocorpus source

### DIFF
--- a/lib/marin/src/marin/datakit/download/biocorpus.py
+++ b/lib/marin/src/marin/datakit/download/biocorpus.py
@@ -1,0 +1,31 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Download and normalize timodonnell's sequence-first biology corpus."""
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
+from marin.execution.step_spec import StepSpec
+
+HF_BUCKET_ID = "buckets/timodonnell/biocorpus"
+BUCKET_SNAPSHOT = "2026-07-30"
+SOURCE_XET_FINGERPRINT = "1c3ff878f17cd8398919a414f1b3646c1d010b99aaaf0a6fb82274edc939ea39"
+
+
+def biocorpus_normalize_steps() -> tuple[StepSpec, ...]:
+    """Return the pinned bucket download and normalization chain for biocorpus."""
+    download = download_hf_step(
+        "raw/biocorpus",
+        hf_dataset_id=HF_BUCKET_ID,
+        revision=BUCKET_SNAPSHOT,
+        hf_urls_glob=["data/*.jsonl.zst"],
+        hf_repo_type_prefix="",
+        expected_source_xet_fingerprint=SOURCE_XET_FINGERPRINT,
+    )
+    normalize = normalize_step(
+        name="normalized/biocorpus",
+        download=download,
+        relative_input_path="data",
+        file_extensions=(".jsonl.zst",),
+    )
+    return (download, normalize)

--- a/lib/marin/src/marin/datakit/download/huggingface.py
+++ b/lib/marin/src/marin/datakit/download/huggingface.py
@@ -7,6 +7,7 @@ A script to download a HuggingFace dataset and upload it to a specified fsspec p
 using HfFileSystem for direct streaming of data transfer.
 """
 
+import hashlib
 import logging
 import os
 import random
@@ -109,6 +110,10 @@ class DownloadConfig:
     ZephyrContext defaults (1 CPU / 1 GB RAM). Bump for large parquet shards or
     when HF streaming buffers spike memory."""
 
+    expected_source_xet_fingerprint: str | None = None
+    """Expected SHA-256 fingerprint of the selected files' paths, sizes, and Xet
+    hashes. Use this to pin mutable Hugging Face bucket contents."""
+
 
 def _strip_hf_protocol(path: str) -> str:
     return path.removeprefix(HF_PROTOCOL_PREFIX).lstrip("/")
@@ -158,6 +163,19 @@ def _relative_path_in_source(file_path: str, source_path: str) -> str:
 
     # Backwards-compatible fallback for historical dataset path layout.
     return normalized_file.split("/", 3)[-1]
+
+
+def _source_xet_fingerprint(source_path: str, file_info: dict[str, dict]) -> str:
+    """Fingerprint an HF source tree from relative paths, sizes, and Xet hashes."""
+    entries: list[str] = []
+    for file_path, info in file_info.items():
+        relative_path = _relative_path_in_source(file_path, source_path)
+        size = info.get("size")
+        xet_hash = info.get("xet_hash")
+        if size is None or not xet_hash:
+            raise ValueError(f"Cannot fingerprint {file_path}: Hugging Face did not return size and Xet hash metadata")
+        entries.append(f"{relative_path}\t{size}\t{xet_hash}")
+    return hashlib.sha256("\n".join(sorted(entries)).encode()).hexdigest()
 
 
 def ensure_fsspec_path_writable(output_path: str) -> None:
@@ -326,14 +344,23 @@ def download_hf(cfg: DownloadConfig) -> None:
 
     # Get file sizes for validation
     logger.info("Getting file sizes for validation...")
-    file_sizes: dict[str, int | None] = {}
+    file_info: dict[str, dict] = {}
     for file in files:
         try:
             info = source_fs.info(file, **list_kwargs)
-            file_sizes[file] = info.get("size") or None
+            file_info[file] = info
         except Exception as e:
             logger.warning(f"Could not get size for {file}: {e}")
-            file_sizes[file] = None  # Will skip validation for this file
+            file_info[file] = {}
+
+    source_xet_fingerprint = None
+    if cfg.expected_source_xet_fingerprint is not None:
+        source_xet_fingerprint = _source_xet_fingerprint(source_root, file_info)
+        if source_xet_fingerprint != cfg.expected_source_xet_fingerprint:
+            raise ValueError(
+                f"Hugging Face source changed: expected Xet fingerprint "
+                f"{cfg.expected_source_xet_fingerprint}, got {source_xet_fingerprint}"
+            )
 
     download_tasks = []
 
@@ -342,7 +369,7 @@ def download_hf(cfg: DownloadConfig) -> None:
         if relative_file_path.startswith(".."):
             raise ValueError(f"Computed path escapes source root: source={hf_source_path}, file={file}")
         fsspec_file_path = prefix_join(output_path, relative_file_path)
-        expected_size = file_sizes.get(file)
+        expected_size = file_info[file].get("size")
         # Fully-qualify the source URL so subprocess workers can open it via fsspec
         # without having to reconstruct HfFileSystem / revision state.
         worker_source_url = file if cfg.source_url_override is not None else f"hf://{file}"
@@ -359,7 +386,7 @@ def download_hf(cfg: DownloadConfig) -> None:
         )
 
     total_files = len(download_tasks)
-    total_size_gb = sum(s for s in file_sizes.values() if s is not None) / (1024**3)
+    total_size_gb = sum(info["size"] for info in file_info.values() if info.get("size") is not None) / (1024**3)
     logger.info(f"Total number of files to process: {total_files} ({total_size_gb:.2f} GB)")
 
     pipeline = (
@@ -379,7 +406,12 @@ def download_hf(cfg: DownloadConfig) -> None:
     # Write Provenance JSON
     write_provenance_json(
         output_path,
-        metadata={"dataset": cfg.hf_dataset_id, "version": cfg.revision, "links": files},
+        metadata={
+            "dataset": cfg.hf_dataset_id,
+            "version": cfg.revision,
+            "links": files,
+            **({"source_xet_fingerprint": source_xet_fingerprint} if source_xet_fingerprint is not None else {}),
+        },
     )
 
     logger.info(f"Streamed all files and wrote provenance JSON; check {output_path}.")
@@ -396,6 +428,8 @@ def download_hf_step(
     deps: list[StepSpec] | None = None,
     override_output_path: str | None = None,
     worker_resources: ResourceConfig | None = None,
+    hf_repo_type_prefix: str = "datasets",
+    expected_source_xet_fingerprint: str | None = None,
 ) -> StepSpec:
     """Create a StepSpec that downloads a HuggingFace dataset.
 
@@ -410,6 +444,10 @@ def download_hf_step(
         zephyr_max_parallelism: Maximum download parallelism.
         deps: Optional upstream dependencies.
         override_output_path: Override the computed output path entirely.
+        hf_repo_type_prefix: Hugging Face source namespace. Use an empty string
+            when ``hf_dataset_id`` is a ``buckets/...`` path.
+        expected_source_xet_fingerprint: Expected fingerprint of the selected
+            files' relative paths, sizes, and Xet hashes.
 
     Returns:
         A StepSpec whose output_path contains the raw downloaded files.
@@ -426,18 +464,26 @@ def download_hf_step(
                 append_sha_to_path=append_sha_to_path,
                 zephyr_max_parallelism=zephyr_max_parallelism,
                 worker_resources=worker_resources,
+                hf_repo_type_prefix=hf_repo_type_prefix,
+                expected_source_xet_fingerprint=expected_source_xet_fingerprint,
             )
         )
+
+    hash_attrs = {
+        "hf_dataset_id": hf_dataset_id,
+        "revision": revision,
+        "hf_urls_glob": resolved_glob,
+        "append_sha_to_path": append_sha_to_path,
+    }
+    if hf_repo_type_prefix != "datasets":
+        hash_attrs["hf_repo_type_prefix"] = hf_repo_type_prefix
+    if expected_source_xet_fingerprint is not None:
+        hash_attrs["expected_source_xet_fingerprint"] = expected_source_xet_fingerprint
 
     return StepSpec(
         name=name,
         fn=_run,
         deps=deps or [],
-        hash_attrs={
-            "hf_dataset_id": hf_dataset_id,
-            "revision": revision,
-            "hf_urls_glob": resolved_glob,
-            "append_sha_to_path": append_sha_to_path,
-        },
+        hash_attrs=hash_attrs,
         override_output_path=override_output_path,
     )

--- a/lib/marin/src/marin/datakit/download/huggingface.py
+++ b/lib/marin/src/marin/datakit/download/huggingface.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 HF_PROTOCOL_PREFIX = "hf://"
 HF_BUCKET_PATH_PREFIX = "buckets/"
+HF_DATASET_REPO_TYPE_PREFIX = "datasets"
 
 # HF returns 401 when no credentials are sent and 403 when the caller's token
 # lacks access (e.g. gated dataset, accept-license required). Neither is fixed
@@ -85,7 +86,7 @@ class DownloadConfig:
 
     # fmt: on
     hf_repo_type_prefix: str = (
-        "datasets"  # The repo_type_prefix is datasets/ for datasets,
+        HF_DATASET_REPO_TYPE_PREFIX  # The repo_type_prefix is datasets/ for datasets,
         # spaces/ for spaces, and models do not need a prefix in the URL.
     )
 
@@ -342,8 +343,9 @@ def download_hf(cfg: DownloadConfig) -> None:
     if not files:
         raise ValueError(f"No files found for dataset `{cfg.hf_dataset_id}. Used glob patterns: {cfg.hf_urls_glob}")
 
-    # Get file sizes for validation
-    logger.info("Getting file sizes for validation...")
+    # Metadata supplies file sizes for download validation and Xet hashes for
+    # optional source fingerprint validation.
+    logger.info("Getting source file metadata...")
     file_info: dict[str, dict] = {}
     for file in files:
         try:
@@ -428,7 +430,7 @@ def download_hf_step(
     deps: list[StepSpec] | None = None,
     override_output_path: str | None = None,
     worker_resources: ResourceConfig | None = None,
-    hf_repo_type_prefix: str = "datasets",
+    hf_repo_type_prefix: str = HF_DATASET_REPO_TYPE_PREFIX,
     expected_source_xet_fingerprint: str | None = None,
 ) -> StepSpec:
     """Create a StepSpec that downloads a HuggingFace dataset.
@@ -475,7 +477,7 @@ def download_hf_step(
         "hf_urls_glob": resolved_glob,
         "append_sha_to_path": append_sha_to_path,
     }
-    if hf_repo_type_prefix != "datasets":
+    if hf_repo_type_prefix != HF_DATASET_REPO_TYPE_PREFIX:
         hash_attrs["hf_repo_type_prefix"] = hf_repo_type_prefix
     if expected_source_xet_fingerprint is not None:
         hash_attrs["expected_source_xet_fingerprint"] = expected_source_xet_fingerprint

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -20,6 +20,7 @@ from functools import cache
 from marin.datakit.canonical.safety_pretraining import safety_pretraining_normalize_steps
 from marin.datakit.download.agenttrove import agenttrove_normalize_steps
 from marin.datakit.download.biocollection import biocollection_normalize_steps
+from marin.datakit.download.biocorpus import biocorpus_normalize_steps
 from marin.datakit.download.biodiversity import biodiversity_normalize_steps
 from marin.datakit.download.climblab_ja import climblab_ja_normalize_steps
 from marin.datakit.download.coderforge import coderforge_normalize_steps
@@ -156,6 +157,9 @@ def all_sources() -> dict[str, DatakitSource]:
         # is 1,696,847 → 997,026 past the proprietary-teacher filter → 869,901
         # with a non-null transcript → 781,076 after exact dedup.
         ("agenttrove", agenttrove_normalize_steps, 8.957298636),
+        # Measured with marin-community/marin-tokenizer:
+        # 9,138,977,526 tokens / 21,138,120 documents.
+        ("biocorpus", biocorpus_normalize_steps, 9.138977526),
         # cp/biodiversity is carved out of common_pile (see common_pile.py)
         # because it needs page-stitching before normalize.
         ("cp/biodiversity", biodiversity_normalize_steps, 8.60),

--- a/tests/datakit/download/test_huggingface.py
+++ b/tests/datakit/download/test_huggingface.py
@@ -102,6 +102,32 @@ def test_download_hf_bucket_requires_newer_huggingface_hub(tmp_path, monkeypatch
         download_hf(cfg)
 
 
+def test_download_hf_rejects_changed_xet_source(tmp_path, monkeypatch):
+    class FakeHfFileSystem:
+        def find(self, _source_root, **_kwargs):
+            return ["buckets/demo-user/demo-bucket/data/file.jsonl.zst"]
+
+        def info(self, _file, **_kwargs):
+            return {"size": 123, "xet_hash": "changed-content"}
+
+    monkeypatch.setattr(
+        hf_download,
+        "url_to_fs",
+        lambda _url: (FakeHfFileSystem(), "buckets/demo-user/demo-bucket"),
+    )
+
+    cfg = DownloadConfig(
+        hf_dataset_id="buckets/demo-user/demo-bucket",
+        revision="snapshot",
+        gcs_output_path=str(tmp_path),
+        hf_repo_type_prefix="",
+        expected_source_xet_fingerprint="expected-fingerprint",
+    )
+
+    with pytest.raises(ValueError, match="Hugging Face source changed"):
+        download_hf(cfg)
+
+
 @pytest.mark.parametrize("status_code", [401, 403])
 def test_stream_file_to_fsspec_aborts_on_hf_auth_error(tmp_path, monkeypatch, status_code):
     """401/403 from HF must short-circuit the retry loop and surface immediately."""

--- a/tests/datakit/download/test_huggingface.py
+++ b/tests/datakit/download/test_huggingface.py
@@ -124,7 +124,7 @@ def test_download_hf_rejects_changed_xet_source(tmp_path, monkeypatch):
         expected_source_xet_fingerprint="expected-fingerprint",
     )
 
-    with pytest.raises(ValueError, match="Hugging Face source changed"):
+    with pytest.raises(ValueError):
         download_hf(cfg)
 
 


### PR DESCRIPTION
Register timodonnell’s 64-shard Hugging Face biocorpus bucket as a Datakit source and pin the selected files by a SHA-256 fingerprint of their paths, sizes, and Xet hashes. Bucket mutations now fail before download instead of silently changing a content-addressed source.

A CoreWeave staging run normalized 21,138,120 documents. Tokenization with marin-community/marin-tokenizer produced 9,138,977,526 tokens, recorded as 9.138977526B in the source catalog. The generated tokenized cache was deleted after measurement; the raw and normalized source artifacts remain in CoreWeave.
