### PR TITLE
[datakit] emit global exact-dedup attributes

### DIFF
--- a/experiments/datakit/README.md
+++ b/experiments/datakit/README.md
@@ -15,19 +15,24 @@ its pipeline on its own dedicated Zephyr coordinator + worker fleet (vanilla
 the StepRunner walks at once.
 
 Most stages keep one step per source with its own output dir
-(`datakit/<stage>/<source>_<hash>/`). Dedup, the decontamination DF filter, and
-the store combine sources. Steps write their main output under `outputs/main/`
-plus, where it makes sense, a small site/sample side output
+(`datakit/<stage>/<source>_<hash>/`). Global exact dedup, fuzzy dedup, the
+decontamination DF filter, and the store combine sources. Steps write their
+main output under `outputs/main/` plus, where it makes sense, a small site/sample side output
 (`outputs/samples/`, `outputs/flagged_sample/`, …) that the per-stage HTML
 reports ([`reports/`](reports/)) read.
 
-Global exact deduplication is one shared step. It keeps one record for each
-record ID, with source names as the canonical order. The step writes a second
-normalized corpus. It uses atomic server-side copies for shards without
-duplicates and rewrites the other shards.
+Materialized source identities are paths relative to `MARIN_PREFIX`, such as
+`datakit/normalize/foo_<hash>/outputs/main`. Actual data directories remain
+absolute. This keeps source keys stable when artifacts move between regions.
 
-A source-set change gives a new global exact-dedup output. As a result, all
-downstream stages also get new output identities.
+Global exact deduplication is one shared step. It selects one canonical record
+for each record ID, with source names as the canonical order. The step writes
+sparse co-partitioned attributes with `attributes.dup_doc=true` for the other
+records. It does not copy normalized text.
+
+A source-set change gives a new global exact-dedup output and a new store
+identity. It does not change the identity of tokenization, embedding, quality,
+decontamination, or MinHash steps.
 
 Each `datakit/report/<stage>` step depends only on that stage's steps, so it
 runs as soon as the stage finishes — reports are not deferred to the end of the
@@ -61,17 +66,17 @@ flowchart TD
     DF["eval n-gram DF (cross-source)<br/>datakit/decon_drop/_combined"]
     EXACT["global exact dedup by record ID<br/>datakit/global_exact_dedup"]
     DEDUP["fuzzy dedup (cross-source)<br/>datakit/dedup"]
-    STORE["store: shuffle 5-way join, drop contaminated + non-canonical,<br/>group by (cluster_&lt;view&gt;, quality_bucket, subshard)<br/>datakit/store → cluster=C/quality=Q Levanter caches"]
+    STORE["store: shuffle attribute join, apply filters,<br/>group by (cluster_&lt;view&gt;, quality_bucket, subshard)<br/>datakit/store → cluster=C/quality=Q Levanter caches"]
 
     SRC --> EXACT
-    EXACT --> TOK
-    EXACT --> EMB
-    EXACT --> QUAL
-    EXACT --> DECON
-    EXACT --> MH
+    SRC --> TOK
+    SRC --> EMB
+    SRC --> QUAL
+    SRC --> DECON
+    SRC --> MH
     MODEL --> QUAL
     EVALS --> BLOOM --> DF --> DECON
-    EXACT --> DF
+    SRC --> DF
     BLOOM --> DECON
     EMB --> SAMP --> KM --> ASG
     EMB --> ASG
@@ -80,6 +85,7 @@ flowchart TD
     ASG --> STORE
     QUAL --> STORE
     DECON --> STORE
+    EXACT --> STORE
     DEDUP --> STORE
 
     subgraph reports["stage reports — one HTML page each, run when the stage finishes (dashed = reads counters + site/sample outputs)"]
@@ -127,12 +133,12 @@ aws s3 ls s3://marin-us-east-02a/marin/datakit/ | grep sample
 | Path | What it is |
 | --- | --- |
 | `reference_pipeline.py` | The DAG builder + CLI (`--mode full\|sample`, `--pool-*`, `--sources`, `--quality-model`) |
-| `global_exact_dedup.py` | Cross-source exact deduplication by normalized record ID |
+| `global_exact_dedup.py` | Sparse co-partitioned exact-duplicate attributes by normalized record ID |
 | `cluster/quality/fast_transformer/` | Quality classifier: per-source scoring step + training/calibration |
 | `cluster/domain/v0/` | Domain clustering: centroid sampling/training + per-source assignment |
 | `embeddings/luxical/` | Luxical-one document embeddings feeding the domain stage |
 | `decontam/` | Eval-corpus preparation (the decon step itself lives in `marin.datakit.decon`) |
-| `store/datakit_store.py` | Shuffle 5-way join → compact per-(cluster, quality) Levanter caches |
+| `store/datakit_store.py` | Shuffle attribute join → compact per-(cluster, quality) Levanter caches |
 | `reports/` | Per-stage single-page HTML reports (`common.py` + one module/template per stage) |
 | `scripts/` | Manual source triggering and synchronization, tier-2 dataset reproduction, and tier-1 output validation |
 | `testbed/` | Sampled-corpus testbed used by the smoke and decon experiments |

--- a/experiments/datakit/README.md
+++ b/experiments/datakit/README.md
@@ -34,6 +34,10 @@ records. Only source shards with duplicates get an attribute file; a missing
 file means that the source shard has no exact duplicates. The step does not copy
 normalized text.
 
+The final store uses fuzzy canonical markers when they exist. It applies exact
+duplicate markers only to records without fuzzy markers, which covers records
+that MinHash skipped without conflicting with fuzzy canonical selection.
+
 A source-set change gives a new global exact-dedup output and a new store
 identity. It does not change the identity of tokenization, embedding, quality,
 decontamination, or MinHash steps.

--- a/experiments/datakit/README.md
+++ b/experiments/datakit/README.md
@@ -14,18 +14,22 @@ its pipeline on its own dedicated Zephyr coordinator + worker fleet (vanilla
 `ZephyrContext`), sized by that config; `--max-concurrent` bounds how many stages
 the StepRunner walks at once.
 
-Every stage keeps one step per source with its own output dir
+Most stages keep one step per source with its own output dir
 (`datakit/<stage>/<source>_<hash>/`). Dedup, the decontamination DF filter, and
 the store combine sources. Steps write their main output under `outputs/main/`
 plus, where it makes sense, a small site/sample side output
 (`outputs/samples/`, `outputs/flagged_sample/`, …) that the per-stage HTML
 reports ([`reports/`](reports/)) read.
 
+Global exact deduplication is one shared step. It keeps one record for each
+record ID, with source names as the canonical order. The step copies shards
+that contain no duplicates and rewrites the other shards.
+
 Each `datakit/report/<stage>` step depends only on that stage's steps, so it
 runs as soon as the stage finishes — reports are not deferred to the end of the
 run, and only `report/store` waits on the store. They are separate steps (not
 folded into the data steps) so a report can be regenerated without recomputing
-the stage. Embed and minhash have no standalone report.
+the stage. Global exact dedup, embed, and minhash have no standalone report.
 
 ```mermaid
 flowchart TD
@@ -51,17 +55,19 @@ flowchart TD
 
     BLOOM["eval bloom (shared)<br/>datakit/bloom/_combined_fixed"]
     DF["eval n-gram DF (cross-source)<br/>datakit/decon_drop/_combined"]
+    EXACT["global exact dedup by record ID<br/>datakit/global_exact_dedup"]
     DEDUP["fuzzy dedup (cross-source)<br/>datakit/dedup"]
     STORE["store: shuffle 5-way join, drop contaminated + non-canonical,<br/>group by (cluster_&lt;view&gt;, quality_bucket, subshard)<br/>datakit/store → cluster=C/quality=Q Levanter caches"]
 
-    SRC --> TOK
-    SRC --> EMB
-    SRC --> QUAL
-    SRC --> DECON
-    SRC --> MH
+    SRC --> EXACT
+    EXACT --> TOK
+    EXACT --> EMB
+    EXACT --> QUAL
+    EXACT --> DECON
+    EXACT --> MH
     MODEL --> QUAL
     EVALS --> BLOOM --> DF --> DECON
-    SRC --> DF
+    EXACT --> DF
     BLOOM --> DECON
     EMB --> SAMP --> KM --> ASG
     EMB --> ASG
@@ -117,6 +123,7 @@ aws s3 ls s3://marin-us-east-02a/marin/datakit/ | grep sample
 | Path | What it is |
 | --- | --- |
 | `reference_pipeline.py` | The DAG builder + CLI (`--mode full\|sample`, `--pool-*`, `--sources`, `--quality-model`) |
+| `global_exact_dedup.py` | Cross-source exact deduplication by normalized record ID |
 | `cluster/quality/fast_transformer/` | Quality classifier: per-source scoring step + training/calibration |
 | `cluster/domain/v0/` | Domain clustering: centroid sampling/training + per-source assignment |
 | `embeddings/luxical/` | Luxical-one document embeddings feeding the domain stage |

--- a/experiments/datakit/README.md
+++ b/experiments/datakit/README.md
@@ -22,8 +22,12 @@ plus, where it makes sense, a small site/sample side output
 reports ([`reports/`](reports/)) read.
 
 Global exact deduplication is one shared step. It keeps one record for each
-record ID, with source names as the canonical order. The step copies shards
-that contain no duplicates and rewrites the other shards.
+record ID, with source names as the canonical order. The step writes a second
+normalized corpus. It uses atomic server-side copies for shards without
+duplicates and rewrites the other shards.
+
+A source-set change gives a new global exact-dedup output. As a result, all
+downstream stages also get new output identities.
 
 Each `datakit/report/<stage>` step depends only on that stage's steps, so it
 runs as soon as the stage finishes — reports are not deferred to the end of the

--- a/experiments/datakit/README.md
+++ b/experiments/datakit/README.md
@@ -30,7 +30,9 @@ Existing v1 artifacts keep their absolute directories when they load.
 Global exact deduplication is one shared step. It selects one canonical record
 for each record ID, with source names as the canonical order. The step writes
 sparse co-partitioned attributes with `attributes.dup_doc=true` for the other
-records. It does not copy normalized text.
+records. Only source shards with duplicates get an attribute file; a missing
+file means that the source shard has no exact duplicates. The step does not copy
+normalized text.
 
 A source-set change gives a new global exact-dedup output and a new store
 identity. It does not change the identity of tokenization, embedding, quality,

--- a/experiments/datakit/README.md
+++ b/experiments/datakit/README.md
@@ -24,6 +24,8 @@ reports ([`reports/`](reports/)) read.
 Materialized source identities are paths relative to `MARIN_PREFIX`, such as
 `datakit/normalize/foo_<hash>/outputs/main`. Actual data directories remain
 absolute. This keeps source keys stable when artifacts move between regions.
+`NormalizedData` also stores its output directories in this relative form.
+Existing v1 artifacts keep their absolute directories when they load.
 
 Global exact deduplication is one shared step. It selects one canonical record
 for each record ID, with source names as the canonical order. The step writes

--- a/experiments/datakit/cluster/domain/v0/assign.py
+++ b/experiments/datakit/cluster/domain/v0/assign.py
@@ -39,14 +39,15 @@ from zephyr.runners import InlineRunner
 from experiments.datakit.embeddings.luxical.pipeline import EmbeddingAttrData, dequantize_to_fp32
 
 logger = logging.getLogger(__name__)
+ASSIGNMENT_ATTR_DATA_VERSION = 2
 
 
 class AssignmentAttrData(BaseModel):
     """Co-partitioned per-source cluster-assignment parquet shards."""
 
-    version: str = "v1"
+    version: str = f"v{ASSIGNMENT_ATTR_DATA_VERSION}"
     output_dir: str
-    source_main_dir: str
+    source_key: str
     embedding_output_dir: str
     k_train: int
     k_views: list[int]
@@ -220,7 +221,7 @@ def assign_source(
 
     artifact = AssignmentAttrData(
         output_dir=output_path,
-        source_main_dir=embedding.source_main_dir,
+        source_key=embedding.source_key,
         embedding_output_dir=embedding.output_dir,
         k_train=k_train,
         k_views=k_views,

--- a/experiments/datakit/cluster/quality/fast_transformer/artifact.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/artifact.py
@@ -4,7 +4,7 @@
 """The quality step's output contract.
 
 Deliberately import-light (pydantic only): the store step consumes
-:class:`QualityScores` for its 5-way join and must not drag the jax/equinox/
+:class:`QualityScores` for its attribute join and must not drag the jax/equinox/
 transformers stack of the scorer into its workers.
 """
 

--- a/experiments/datakit/embeddings/luxical/pipeline.py
+++ b/experiments/datakit/embeddings/luxical/pipeline.py
@@ -39,6 +39,7 @@ import pyarrow as pa
 from fray.types import ResourceConfig
 from huggingface_hub import hf_hub_download
 from marin.datakit.normalize import NormalizedData
+from marin.datakit.source_key import datakit_source_key
 from marin.execution.artifact import write_artifact
 from pydantic import BaseModel
 from rigging.filesystem import StoragePath, marin_temp_bucket
@@ -50,6 +51,7 @@ from zephyr.runners import InlineRunner
 from zephyr.worker_context import zephyr_worker_ctx
 
 logger = logging.getLogger(__name__)
+EMBEDDING_ATTR_DATA_VERSION = 2
 
 LUXICAL_REPO = "DatologyAI/luxical-one"
 LUXICAL_WEIGHTS_FILE = "luxical_one_rc4.npz"
@@ -93,7 +95,7 @@ class EmbeddingAttrData(BaseModel):
 
     Attributes:
         output_dir: Directory containing the per-shard parquet outputs.
-        source_main_dir: ``NormalizedData.main_output_dir`` this mirrors.
+        source_key: Prefix-relative identity of the ``NormalizedData.main_output_dir`` this mirrors.
             Co-partitioning means consumers can join ``(basename, row_idx)``
             without an id index.
         model_name: HuggingFace model id.
@@ -105,9 +107,9 @@ class EmbeddingAttrData(BaseModel):
         counters: Aggregated zephyr counters from the embed pipeline.
     """
 
-    version: str = "v1"
+    version: str = f"v{EMBEDDING_ATTR_DATA_VERSION}"
     output_dir: str
-    source_main_dir: str
+    source_key: str
     model_name: str
     model_revision: str = ""
     embedding_dim: int
@@ -293,7 +295,7 @@ def embed_source(
 
     artifact = EmbeddingAttrData(
         output_dir=output_path,
-        source_main_dir=normalized.main_output_dir,
+        source_key=datakit_source_key(normalized.main_output_dir),
         model_name=f"{repo_id}/{weights_filename}",
         model_revision=revision,
         embedding_dim=LUXICAL_DIM,

--- a/experiments/datakit/global_exact_dedup.py
+++ b/experiments/datakit/global_exact_dedup.py
@@ -5,7 +5,7 @@
 
 The Zephyr pipeline shuffles record IDs across all sources. It keeps the first
 source, shard, and row occurrence. It writes sparse duplicate markers back to
-one attribute file for each source shard.
+the source shards that contain duplicates.
 
 Output rows have this schema::
 
@@ -16,8 +16,8 @@ Output rows have this schema::
       },
     }
 
-Each output attribute directory has the same shard names as its normalized
-source. Empty marker files retain co-partitioning for shards without duplicates.
+Output files keep the matching normalized shard names. A missing file means
+that its source shard has no exact duplicates.
 """
 
 from collections.abc import Callable, Iterator
@@ -39,7 +39,6 @@ from zephyr.writers import write_parquet_file
 
 COUNTER_PREFIX = "global_exact_dedup"
 _SHARED_ENTRIES_KEY = "global_exact_dedup_entries"
-_SHARD_MARKER_ROW_INDEX = -1
 GLOBAL_EXACT_DEDUP_DATA_VERSION = 1
 _ATTR_SCHEMA = pa.schema(
     [
@@ -104,13 +103,6 @@ def _build_shard_index(
 def _read_record_ids(entry: CopartitionedShard) -> Iterator[_ExactRecord]:
     input_path = entry.input_path
     row_index = 0
-    # Force the second group to write a schema-only attribute file when a
-    # source shard has no duplicate rows.
-    yield {
-        "id": "",
-        "file_idx": entry.file_idx,
-        "row_index": _SHARD_MARKER_ROW_INDEX,
-    }
     with StoragePath(input_path).open("rb") as input_file:
         parquet = pq.ParquetFile(input_file)
         if "id" not in parquet.schema_arrow.names:
@@ -129,12 +121,8 @@ def _read_record_ids(entry: CopartitionedShard) -> Iterator[_ExactRecord]:
     counters.pipeline.update_counter(f"{COUNTER_PREFIX}/records_in", row_index)
 
 
-def _select_duplicates(_key: tuple[str, str | int], records: Iterator[_ExactRecord]) -> Iterator[_ExactRecord]:
-    canonical = next(records)
-    if canonical["row_index"] == _SHARD_MARKER_ROW_INDEX:
-        yield canonical
-        return
-
+def _select_duplicates(_key: str, records: Iterator[_ExactRecord]) -> Iterator[_ExactRecord]:
+    next(records)
     yield from records
 
 
@@ -147,8 +135,6 @@ def _make_per_shard_writer() -> Callable[[int, Iterator[_ExactRecord]], dict[str
         def duplicate_rows() -> Iterator[dict[str, str | dict[str, bool]]]:
             nonlocal duplicate_records
             for record in records:
-                if record["row_index"] == _SHARD_MARKER_ROW_INDEX:
-                    continue
                 duplicate_records += 1
                 yield {"id": record["id"], "attributes": {"dup_doc": True}}
 
@@ -189,17 +175,14 @@ def global_exact_deduplicate(
         Dataset.from_list(entries)
         .flat_map(_read_record_ids)
         .group_by(
-            key=lambda record: (
-                "shard" if record["row_index"] == _SHARD_MARKER_ROW_INDEX else "record",
-                record["file_idx"] if record["row_index"] == _SHARD_MARKER_ROW_INDEX else record["id"],
-            ),
+            key=lambda record: record["id"],
             reducer=_select_duplicates,
             sort_by=lambda record: (record["file_idx"], record["row_index"]),
         )
         .group_by(
             key=lambda record: record["file_idx"],
             reducer=_make_per_shard_writer(),
-            sort_by=lambda record: (record["row_index"] == _SHARD_MARKER_ROW_INDEX, record["id"]),
+            sort_by=lambda record: record["id"],
         )
     )
     outcome = context.execute(pipeline)

--- a/experiments/datakit/global_exact_dedup.py
+++ b/experiments/datakit/global_exact_dedup.py
@@ -1,0 +1,265 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Global exact deduplication of normalized Datakit sources by record ID."""
+
+import os
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from fray.types import ResourceConfig
+from marin.datakit.normalize import NormalizedData
+from pydantic import BaseModel
+from rigging.filesystem import StoragePath, prefix_join, url_to_fs
+from zephyr import counters
+from zephyr.dataset import Dataset
+from zephyr.execution import ZephyrContext
+from zephyr.writers import write_parquet_file
+
+COUNTER_PREFIX = "global_exact_dedup"
+_DUPLICATE_SCHEMA = pa.schema(
+    [
+        pa.field("id", pa.string(), nullable=False),
+        pa.field("row_index", pa.int64(), nullable=False),
+    ]
+)
+
+
+class GlobalExactDedupData(BaseModel):
+    """Output sources and counters from global exact deduplication."""
+
+    version: str = "v1"
+    sources: dict[str, NormalizedData]
+    counters: dict[str, int | float]
+
+
+@dataclass(frozen=True)
+class _SourceShard:
+    source: str
+    source_rank: int
+    shard_index: int
+    input_path: str
+    output_path: str
+    duplicate_ids_path: str
+
+
+def _source_counter(source: str, name: str) -> str:
+    return f"{COUNTER_PREFIX}/source/{source}/{name}"
+
+
+def _input_shards(
+    sources: dict[str, NormalizedData],
+    output_path: str,
+) -> tuple[list[_SourceShard], dict[str, NormalizedData]]:
+    shards: list[_SourceShard] = []
+    outputs: dict[str, NormalizedData] = {}
+
+    for source_rank, source in enumerate(sorted(sources)):
+        normalized = sources[source]
+        input_root = StoragePath(normalized.main_output_dir)
+        input_paths = sorted(
+            StoragePath(f"{normalized.main_output_dir.rstrip('/')}/**/*.parquet").glob(),
+            key=str,
+        )
+        if not input_paths:
+            raise FileNotFoundError(f"No Parquet files found under {normalized.main_output_dir}")
+
+        source_root = prefix_join(output_path, f"sources/{source_rank:05d}")
+        main_output_dir = prefix_join(source_root, "outputs/main")
+        outputs[source] = NormalizedData(
+            main_output_dir=main_output_dir,
+            dup_output_dir=prefix_join(source_root, "outputs/dups"),
+            counters={},
+        )
+
+        output_names: set[str] = set()
+        for input_path in input_paths:
+            relative_path = input_path.relative_to(input_root)
+            if relative_path in output_names:
+                raise ValueError(f"Duplicate Parquet path {relative_path!r} for source {source!r}")
+            output_names.add(relative_path)
+
+            shard_index = len(shards)
+            shards.append(
+                _SourceShard(
+                    source=source,
+                    source_rank=source_rank,
+                    shard_index=shard_index,
+                    input_path=str(input_path),
+                    output_path=prefix_join(main_output_dir, relative_path),
+                    duplicate_ids_path=prefix_join(output_path, f"duplicate_ids/{shard_index:08d}.parquet"),
+                )
+            )
+
+    return shards, outputs
+
+
+def _read_record_ids(shard: _SourceShard) -> Iterator[dict[str, int | str]]:
+    row_index = 0
+    with StoragePath(shard.input_path).open("rb") as input_file:
+        parquet = pq.ParquetFile(input_file)
+        if "id" not in parquet.schema_arrow.names:
+            raise ValueError(f"Parquet file has no id column: {shard.input_path}")
+        for batch in parquet.iter_batches(columns=["id"]):
+            for record_id in batch.column("id").to_pylist():
+                if not isinstance(record_id, str):
+                    raise ValueError(f"Record ID is not a string in {shard.input_path}: {record_id!r}")
+                counters.pipeline.update_counter(f"{COUNTER_PREFIX}/records_in", 1)
+                counters.pipeline.update_counter(_source_counter(shard.source, "records_in"), 1)
+                yield {
+                    "id": record_id,
+                    "source": shard.source,
+                    "source_rank": shard.source_rank,
+                    "shard_index": shard.shard_index,
+                    "row_index": row_index,
+                }
+                row_index += 1
+
+
+def _select_duplicates(_record_id: str, records: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+    canonical = next(records)
+    counters.pipeline.update_counter(f"{COUNTER_PREFIX}/records_out", 1)
+    counters.pipeline.update_counter(_source_counter(canonical["source"], "records_out"), 1)
+
+    for duplicate in records:
+        counters.pipeline.update_counter(f"{COUNTER_PREFIX}/duplicate_records", 1)
+        counters.pipeline.update_counter(_source_counter(duplicate["source"], "duplicate_records"), 1)
+        yield duplicate
+
+
+def _duplicate_id_writer(
+    shard_paths: dict[int, str],
+) -> Callable[[int, Iterator[dict[str, Any]]], dict[str, int | str]]:
+    def write_duplicate_ids(shard_index: int, records: Iterator[dict[str, Any]]) -> dict[str, int | str]:
+        return write_parquet_file(
+            ({"id": record["id"], "row_index": record["row_index"]} for record in records),
+            output_path=shard_paths[shard_index],
+            schema=_DUPLICATE_SCHEMA,
+        )
+
+    return write_duplicate_ids
+
+
+def _copy_file(source: str, destination: str) -> None:
+    source_fs, source_path = url_to_fs(source)
+    destination_fs, destination_path = url_to_fs(destination)
+    if source_fs.protocol != destination_fs.protocol:
+        raise ValueError(f"Cannot copy between filesystems: {source!r} to {destination!r}")
+    destination_fs.makedirs(os.path.dirname(destination_path), exist_ok=True)
+    destination_fs.copy(source_path, destination_path)
+
+
+def _duplicate_rows(path: str) -> set[int]:
+    if not StoragePath(path).exists():
+        return set()
+    with StoragePath(path).open("rb") as duplicate_file:
+        return set(pq.read_table(duplicate_file, columns=["row_index"]).column("row_index").to_pylist())
+
+
+def _filter_shard(shard: _SourceShard) -> dict[str, int | str]:
+    duplicate_rows = _duplicate_rows(shard.duplicate_ids_path)
+    with StoragePath(shard.input_path).open("rb") as input_file:
+        parquet = pq.ParquetFile(input_file)
+        records_in = parquet.metadata.num_rows
+        schema = parquet.schema_arrow
+
+        if not duplicate_rows:
+            _copy_file(shard.input_path, shard.output_path)
+            return {
+                "source": shard.source,
+                "path": shard.output_path,
+                "records_in": records_in,
+                "records_out": records_in,
+            }
+
+        def unique_records() -> Iterator[dict[str, Any]]:
+            row_index = 0
+            for batch in parquet.iter_batches():
+                for record in batch.to_pylist():
+                    if row_index not in duplicate_rows:
+                        yield record
+                    row_index += 1
+
+        result = write_parquet_file(unique_records(), output_path=shard.output_path, schema=schema)
+
+    return {
+        "source": shard.source,
+        "path": shard.output_path,
+        "records_in": records_in,
+        "records_out": result["count"],
+    }
+
+
+def global_exact_deduplicate(
+    *,
+    sources: dict[str, NormalizedData],
+    output_path: str,
+    worker_resources: ResourceConfig,
+    max_workers: int,
+) -> GlobalExactDedupData:
+    """Keep one record for each record ID across all normalized sources.
+
+    The lexicographically first source keeps a shared record ID. The function
+    keeps each source schema and shard layout.
+    """
+    if not sources:
+        raise ValueError("Global exact deduplication requires at least one source")
+
+    shards, output_sources = _input_shards(sources, output_path)
+    shard_paths = {shard.shard_index: shard.duplicate_ids_path for shard in shards}
+
+    dedup_pipeline = (
+        Dataset.from_list(shards)
+        .flat_map(_read_record_ids)
+        .group_by(
+            key=lambda record: record["id"],
+            reducer=_select_duplicates,
+            sort_by=lambda record: (record["source_rank"], record["shard_index"], record["row_index"]),
+        )
+        .group_by(
+            key=lambda record: record["shard_index"],
+            reducer=_duplicate_id_writer(shard_paths),
+            sort_by=lambda record: record["id"],
+        )
+    )
+    dedup_context = ZephyrContext(
+        name="datakit-global-exact-dedup",
+        resources=worker_resources,
+        max_workers=max_workers,
+    )
+    dedup_outcome = dedup_context.execute(dedup_pipeline)
+
+    filter_context = ZephyrContext(
+        name="datakit-global-exact-dedup-filter",
+        resources=worker_resources,
+        max_workers=max_workers,
+    )
+    filter_outcome = filter_context.execute(Dataset.from_list(shards).map(_filter_shard))
+
+    stage_counters: dict[str, int | float] = {}
+    for name, value in dedup_outcome.counters.items():
+        if name.startswith(f"{COUNTER_PREFIX}/"):
+            stage_counters[name] = stage_counters.get(name, 0) + value
+
+    filter_results = filter_outcome.results
+    records_in = sum(int(result["records_in"]) for result in filter_results)
+    records_out = sum(int(result["records_out"]) for result in filter_results)
+    if records_in != stage_counters.get(f"{COUNTER_PREFIX}/records_in", 0):
+        raise ValueError(f"Input record count changed between deduplication passes: {records_in}")
+    if records_out != stage_counters.get(f"{COUNTER_PREFIX}/records_out", 0):
+        raise ValueError(f"Output record count changed between deduplication passes: {records_out}")
+
+    counter_dict = dict(stage_counters)
+    for source, normalized in output_sources.items():
+        normalized.counters.update(
+            {
+                name: value
+                for name, value in counter_dict.items()
+                if name.startswith(f"{COUNTER_PREFIX}/source/{source}/")
+            }
+        )
+
+    return GlobalExactDedupData(sources=output_sources, counters=counter_dict)

--- a/experiments/datakit/global_exact_dedup.py
+++ b/experiments/datakit/global_exact_dedup.py
@@ -1,9 +1,16 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Global exact deduplication of normalized Datakit sources by record ID."""
+"""Global exact deduplication of normalized Datakit sources by record ID.
 
-import os
+The global shuffle carries record IDs and row positions only. A second pass
+uses the row positions to filter each source shard without changing its schema.
+The two passes read rows in Parquet order, so their row positions are equal.
+
+``Dataset.deduplicate`` cannot retain the source and shard position that the
+second pass needs.
+"""
+
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import Any
@@ -13,13 +20,14 @@ import pyarrow.parquet as pq
 from fray.types import ResourceConfig
 from marin.datakit.normalize import NormalizedData
 from pydantic import BaseModel
-from rigging.filesystem import StoragePath, prefix_join, url_to_fs
-from zephyr import counters
+from rigging.filesystem import StoragePath, atomic_rename, prefix_join, url_to_fs
 from zephyr.dataset import Dataset
 from zephyr.execution import ZephyrContext
-from zephyr.writers import write_parquet_file
+from zephyr.writers import parquet_sink, write_parquet_file
 
 COUNTER_PREFIX = "global_exact_dedup"
+_DEDUP_SUCCESS_FILE = "_DEDUP_SUCCESS"
+_FILTER_BATCH_ROWS = 256
 _DUPLICATE_SCHEMA = pa.schema(
     [
         pa.field("id", pa.string(), nullable=False),
@@ -39,15 +47,15 @@ class GlobalExactDedupData(BaseModel):
 @dataclass(frozen=True)
 class _SourceShard:
     source: str
-    source_rank: int
     shard_index: int
     input_path: str
     output_path: str
     duplicate_ids_path: str
 
 
-def _source_counter(source: str, name: str) -> str:
-    return f"{COUNTER_PREFIX}/source/{source}/{name}"
+def global_exact_dedup_source_path(output_path: str, source_rank: int) -> str:
+    """Get the output root for one source rank."""
+    return prefix_join(output_path, f"sources/{source_rank:05d}")
 
 
 def _input_shards(
@@ -67,26 +75,20 @@ def _input_shards(
         if not input_paths:
             raise FileNotFoundError(f"No Parquet files found under {normalized.main_output_dir}")
 
-        source_root = prefix_join(output_path, f"sources/{source_rank:05d}")
+        source_root = global_exact_dedup_source_path(output_path, source_rank)
         main_output_dir = prefix_join(source_root, "outputs/main")
         outputs[source] = NormalizedData(
             main_output_dir=main_output_dir,
-            dup_output_dir=prefix_join(source_root, "outputs/dups"),
+            dup_output_dir=normalized.dup_output_dir,
             counters={},
         )
 
-        output_names: set[str] = set()
         for input_path in input_paths:
             relative_path = input_path.relative_to(input_root)
-            if relative_path in output_names:
-                raise ValueError(f"Duplicate Parquet path {relative_path!r} for source {source!r}")
-            output_names.add(relative_path)
-
             shard_index = len(shards)
             shards.append(
                 _SourceShard(
                     source=source,
-                    source_rank=source_rank,
                     shard_index=shard_index,
                     input_path=str(input_path),
                     output_path=prefix_join(main_output_dir, relative_path),
@@ -103,16 +105,13 @@ def _read_record_ids(shard: _SourceShard) -> Iterator[dict[str, int | str]]:
         parquet = pq.ParquetFile(input_file)
         if "id" not in parquet.schema_arrow.names:
             raise ValueError(f"Parquet file has no id column: {shard.input_path}")
+        id_type = parquet.schema_arrow.field("id").type
+        if not (pa.types.is_string(id_type) or pa.types.is_large_string(id_type)):
+            raise ValueError(f"Record ID column is not a string in {shard.input_path}: {id_type}")
         for batch in parquet.iter_batches(columns=["id"]):
             for record_id in batch.column("id").to_pylist():
-                if not isinstance(record_id, str):
-                    raise ValueError(f"Record ID is not a string in {shard.input_path}: {record_id!r}")
-                counters.pipeline.update_counter(f"{COUNTER_PREFIX}/records_in", 1)
-                counters.pipeline.update_counter(_source_counter(shard.source, "records_in"), 1)
                 yield {
                     "id": record_id,
-                    "source": shard.source,
-                    "source_rank": shard.source_rank,
                     "shard_index": shard.shard_index,
                     "row_index": row_index,
                 }
@@ -120,23 +119,17 @@ def _read_record_ids(shard: _SourceShard) -> Iterator[dict[str, int | str]]:
 
 
 def _select_duplicates(_record_id: str, records: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
-    canonical = next(records)
-    counters.pipeline.update_counter(f"{COUNTER_PREFIX}/records_out", 1)
-    counters.pipeline.update_counter(_source_counter(canonical["source"], "records_out"), 1)
-
-    for duplicate in records:
-        counters.pipeline.update_counter(f"{COUNTER_PREFIX}/duplicate_records", 1)
-        counters.pipeline.update_counter(_source_counter(duplicate["source"], "duplicate_records"), 1)
-        yield duplicate
+    next(records)
+    yield from records
 
 
 def _duplicate_id_writer(
-    shard_paths: dict[int, str],
+    output_path: str,
 ) -> Callable[[int, Iterator[dict[str, Any]]], dict[str, int | str]]:
     def write_duplicate_ids(shard_index: int, records: Iterator[dict[str, Any]]) -> dict[str, int | str]:
         return write_parquet_file(
             ({"id": record["id"], "row_index": record["row_index"]} for record in records),
-            output_path=shard_paths[shard_index],
+            output_path=prefix_join(output_path, f"duplicate_ids/{shard_index:08d}.parquet"),
             schema=_DUPLICATE_SCHEMA,
         )
 
@@ -144,12 +137,18 @@ def _duplicate_id_writer(
 
 
 def _copy_file(source: str, destination: str) -> None:
+    source_storage = StoragePath(source)
+    destination_storage = StoragePath(destination)
+    if (source_storage.scheme, source_storage.netloc) != (destination_storage.scheme, destination_storage.netloc):
+        raise ValueError(f"Cannot copy between storage roots: {source!r} to {destination!r}")
+
     source_fs, source_path = url_to_fs(source)
-    destination_fs, destination_path = url_to_fs(destination)
-    if source_fs.protocol != destination_fs.protocol:
-        raise ValueError(f"Cannot copy between filesystems: {source!r} to {destination!r}")
-    destination_fs.makedirs(os.path.dirname(destination_path), exist_ok=True)
-    destination_fs.copy(source_path, destination_path)
+    destination_storage.parent.mkdirs()
+    with atomic_rename(destination) as temp_path:
+        temp_fs, resolved_temp_path = url_to_fs(temp_path)
+        if source_fs.protocol != temp_fs.protocol:
+            raise ValueError(f"Cannot copy between filesystems: {source!r} to {destination!r}")
+        temp_fs.copy(source_path, resolved_temp_path)
 
 
 def _duplicate_rows(path: str) -> set[int]:
@@ -161,6 +160,18 @@ def _duplicate_rows(path: str) -> set[int]:
 
 def _filter_shard(shard: _SourceShard) -> dict[str, int | str]:
     duplicate_rows = _duplicate_rows(shard.duplicate_ids_path)
+    if StoragePath(shard.output_path).exists():
+        with StoragePath(shard.input_path).open("rb") as input_file:
+            records_in = pq.ParquetFile(input_file).metadata.num_rows
+        with StoragePath(shard.output_path).open("rb") as output_file:
+            records_out = pq.ParquetFile(output_file).metadata.num_rows
+        return {
+            "source": shard.source,
+            "path": shard.output_path,
+            "records_in": records_in,
+            "records_out": records_out,
+        }
+
     with StoragePath(shard.input_path).open("rb") as input_file:
         parquet = pq.ParquetFile(input_file)
         records_in = parquet.metadata.num_rows
@@ -175,22 +186,35 @@ def _filter_shard(shard: _SourceShard) -> dict[str, int | str]:
                 "records_out": records_in,
             }
 
-        def unique_records() -> Iterator[dict[str, Any]]:
-            row_index = 0
-            for batch in parquet.iter_batches():
-                for record in batch.to_pylist():
-                    if row_index not in duplicate_rows:
-                        yield record
-                    row_index += 1
-
-        result = write_parquet_file(unique_records(), output_path=shard.output_path, schema=schema)
+        records_out = 0
+        row_index = 0
+        StoragePath(shard.output_path).parent.mkdirs()
+        with atomic_rename(shard.output_path) as temp_path:
+            with parquet_sink(temp_path) as (where_fd, native_fs):
+                with pq.ParquetWriter(where_fd, schema, filesystem=native_fs) as writer:
+                    for batch in parquet.iter_batches(batch_size=_FILTER_BATCH_ROWS):
+                        keep = pa.array(
+                            (index not in duplicate_rows for index in range(row_index, row_index + batch.num_rows)),
+                            type=pa.bool_(),
+                        )
+                        filtered = batch.filter(keep)
+                        writer.write_batch(filtered)
+                        records_out += filtered.num_rows
+                        row_index += batch.num_rows
 
     return {
         "source": shard.source,
         "path": shard.output_path,
         "records_in": records_in,
-        "records_out": result["count"],
+        "records_out": records_out,
     }
+
+
+def _write_success_file(path: str) -> None:
+    StoragePath(path).parent.mkdirs()
+    with atomic_rename(path) as temp_path:
+        with StoragePath(temp_path).open("wb") as success_file:
+            success_file.write(b"")
 
 
 def global_exact_deduplicate(
@@ -209,57 +233,55 @@ def global_exact_deduplicate(
         raise ValueError("Global exact deduplication requires at least one source")
 
     shards, output_sources = _input_shards(sources, output_path)
-    shard_paths = {shard.shard_index: shard.duplicate_ids_path for shard in shards}
-
-    dedup_pipeline = (
-        Dataset.from_list(shards)
-        .flat_map(_read_record_ids)
-        .group_by(
-            key=lambda record: record["id"],
-            reducer=_select_duplicates,
-            sort_by=lambda record: (record["source_rank"], record["shard_index"], record["row_index"]),
-        )
-        .group_by(
-            key=lambda record: record["shard_index"],
-            reducer=_duplicate_id_writer(shard_paths),
-            sort_by=lambda record: record["id"],
-        )
-    )
-    dedup_context = ZephyrContext(
+    context = ZephyrContext(
         name="datakit-global-exact-dedup",
         resources=worker_resources,
         max_workers=max_workers,
     )
-    dedup_outcome = dedup_context.execute(dedup_pipeline)
 
-    filter_context = ZephyrContext(
-        name="datakit-global-exact-dedup-filter",
-        resources=worker_resources,
-        max_workers=max_workers,
-    )
-    filter_outcome = filter_context.execute(Dataset.from_list(shards).map(_filter_shard))
+    dedup_success_path = prefix_join(output_path, f"duplicate_ids/{_DEDUP_SUCCESS_FILE}")
+    if not StoragePath(dedup_success_path).exists():
+        dedup_pipeline = (
+            Dataset.from_list(shards)
+            .flat_map(_read_record_ids)
+            .group_by(
+                key=lambda record: record["id"],
+                reducer=_select_duplicates,
+                sort_by=lambda record: (record["shard_index"], record["row_index"]),
+            )
+            .group_by(
+                key=lambda record: record["shard_index"],
+                reducer=_duplicate_id_writer(output_path),
+                sort_by=lambda record: record["id"],
+            )
+        )
+        context.execute(dedup_pipeline)
+        _write_success_file(dedup_success_path)
 
-    stage_counters: dict[str, int | float] = {}
-    for name, value in dedup_outcome.counters.items():
-        if name.startswith(f"{COUNTER_PREFIX}/"):
-            stage_counters[name] = stage_counters.get(name, 0) + value
+    filter_outcome = context.execute(Dataset.from_list(shards).map(_filter_shard))
 
     filter_results = filter_outcome.results
     records_in = sum(int(result["records_in"]) for result in filter_results)
     records_out = sum(int(result["records_out"]) for result in filter_results)
-    if records_in != stage_counters.get(f"{COUNTER_PREFIX}/records_in", 0):
-        raise ValueError(f"Input record count changed between deduplication passes: {records_in}")
-    if records_out != stage_counters.get(f"{COUNTER_PREFIX}/records_out", 0):
-        raise ValueError(f"Output record count changed between deduplication passes: {records_out}")
-
-    counter_dict = dict(stage_counters)
+    source_ranks = {source: rank for rank, source in enumerate(sorted(sources))}
+    stage_counters: dict[str, int | float] = {
+        f"{COUNTER_PREFIX}/records_in": records_in,
+        f"{COUNTER_PREFIX}/records_out": records_out,
+        f"{COUNTER_PREFIX}/duplicate_records": records_in - records_out,
+    }
     for source, normalized in output_sources.items():
-        normalized.counters.update(
-            {
-                name: value
-                for name, value in counter_dict.items()
-                if name.startswith(f"{COUNTER_PREFIX}/source/{source}/")
-            }
-        )
+        source_results = [result for result in filter_results if result["source"] == source]
+        source_records_in = sum(int(result["records_in"]) for result in source_results)
+        source_records_out = sum(int(result["records_out"]) for result in source_results)
+        source_counters = {
+            f"{COUNTER_PREFIX}/records_in": source_records_in,
+            f"{COUNTER_PREFIX}/records_out": source_records_out,
+            f"{COUNTER_PREFIX}/duplicate_records": source_records_in - source_records_out,
+        }
+        rank = source_ranks[source]
+        stage_counters[f"{COUNTER_PREFIX}/source/{rank}/records_in"] = source_records_in
+        stage_counters[f"{COUNTER_PREFIX}/source/{rank}/records_out"] = source_records_out
+        stage_counters[f"{COUNTER_PREFIX}/source/{rank}/duplicate_records"] = source_records_in - source_records_out
+        output_sources[source] = normalized.model_copy(update={"counters": source_counters})
 
-    return GlobalExactDedupData(sources=output_sources, counters=counter_dict)
+    return GlobalExactDedupData(sources=output_sources, counters=stage_counters)

--- a/experiments/datakit/global_exact_dedup.py
+++ b/experiments/datakit/global_exact_dedup.py
@@ -1,220 +1,166 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Global exact deduplication of normalized Datakit sources by record ID.
+"""Global exact-duplicate attributes for normalized Datakit sources.
 
-The global shuffle carries record IDs and row positions only. A second pass
-uses the row positions to filter each source shard without changing its schema.
-The two passes read rows in Parquet order, so their row positions are equal.
+The Zephyr pipeline shuffles record IDs across all sources. It keeps the first
+source, shard, and row occurrence. It writes sparse duplicate markers back to
+one attribute file for each source shard.
 
-``Dataset.deduplicate`` cannot retain the source and shard position that the
-second pass needs.
+Output rows have this schema::
+
+    {
+      id: str,
+      attributes: {
+        dup_doc: bool,
+      },
+    }
+
+Each output attribute directory has the same shard names as its normalized
+source. Empty marker files retain co-partitioning for shards without duplicates.
 """
 
 from collections.abc import Callable, Iterator
-from dataclasses import dataclass
-from typing import Any
+from typing import TypedDict
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 from fray.types import ResourceConfig
+from marin.datakit.copartitioned import CopartitionedShard, CopartitionedSource, build_copartitioned_shards
 from marin.datakit.normalize import NormalizedData
+from marin.datakit.source_key import datakit_source_key
 from pydantic import BaseModel
-from rigging.filesystem import StoragePath, atomic_rename, prefix_join, url_to_fs
+from rigging.filesystem import StoragePath
+from zephyr import counters
 from zephyr.dataset import Dataset
 from zephyr.execution import ZephyrContext
-from zephyr.writers import parquet_sink, write_parquet_file
+from zephyr.worker_context import zephyr_worker_ctx
+from zephyr.writers import write_parquet_file
 
 COUNTER_PREFIX = "global_exact_dedup"
-_DEDUP_SUCCESS_FILE = "_DEDUP_SUCCESS"
-_FILTER_BATCH_ROWS = 256
-_DUPLICATE_SCHEMA = pa.schema(
+_SHARED_ENTRIES_KEY = "global_exact_dedup_entries"
+_SHARD_MARKER_ROW_INDEX = -1
+GLOBAL_EXACT_DEDUP_DATA_VERSION = 1
+_ATTR_SCHEMA = pa.schema(
     [
         pa.field("id", pa.string(), nullable=False),
-        pa.field("row_index", pa.int64(), nullable=False),
+        pa.field(
+            "attributes",
+            pa.struct([pa.field("dup_doc", pa.bool_(), nullable=False)]),
+            nullable=False,
+        ),
     ]
 )
 
 
-class GlobalExactDedupData(BaseModel):
-    """Output sources and counters from global exact deduplication."""
+class ExactDupsPerSource(BaseModel):
+    attr_dir: str
 
-    version: str = "v1"
-    sources: dict[str, NormalizedData]
+
+class GlobalExactDedupData(BaseModel):
+    """Co-partitioned exact-duplicate attributes for normalized sources.
+
+    ``sources`` maps each input's prefix-relative source key to its attribute
+    directory.
+    """
+
+    version: str = f"v{GLOBAL_EXACT_DEDUP_DATA_VERSION}"
+    sources: dict[str, ExactDupsPerSource]
     counters: dict[str, int | float]
 
 
-@dataclass(frozen=True)
-class _SourceShard:
-    source: str
-    shard_index: int
-    input_path: str
-    output_path: str
-    duplicate_ids_path: str
+class _ExactRecord(TypedDict):
+    id: str
+    file_idx: int
+    row_index: int
 
 
-def global_exact_dedup_source_path(output_path: str, source_rank: int) -> str:
-    """Get the output root for one source rank."""
-    return prefix_join(output_path, f"sources/{source_rank:05d}")
-
-
-def _input_shards(
+def _build_shard_index(
     sources: dict[str, NormalizedData],
     output_path: str,
-) -> tuple[list[_SourceShard], dict[str, NormalizedData]]:
-    shards: list[_SourceShard] = []
-    outputs: dict[str, NormalizedData] = {}
+) -> tuple[list[CopartitionedShard], dict[str, ExactDupsPerSource]]:
+    source_entries = [
+        (source_name, normalized, datakit_source_key(normalized.main_output_dir))
+        for source_name, normalized in sources.items()
+    ]
+    source_dirs: dict[str, str] = {}
+    for _source_name, normalized, source_key in source_entries:
+        if source_key in source_dirs:
+            raise ValueError(f"Multiple sources use source_key={source_key!r}")
+        source_dirs[source_key] = normalized.main_output_dir
 
-    for source_rank, source in enumerate(sorted(sources)):
-        normalized = sources[source]
-        input_root = StoragePath(normalized.main_output_dir)
-        input_paths = sorted(
-            StoragePath(f"{normalized.main_output_dir.rstrip('/')}/**/*.parquet").glob(),
-            key=str,
-        )
-        if not input_paths:
-            raise FileNotFoundError(f"No Parquet files found under {normalized.main_output_dir}")
-
-        source_root = global_exact_dedup_source_path(output_path, source_rank)
-        main_output_dir = prefix_join(source_root, "outputs/main")
-        outputs[source] = NormalizedData(
-            main_output_dir=main_output_dir,
-            dup_output_dir=normalized.dup_output_dir,
-            counters={},
-        )
-
-        for input_path in input_paths:
-            relative_path = input_path.relative_to(input_root)
-            shard_index = len(shards)
-            shards.append(
-                _SourceShard(
-                    source=source,
-                    shard_index=shard_index,
-                    input_path=str(input_path),
-                    output_path=prefix_join(main_output_dir, relative_path),
-                    duplicate_ids_path=prefix_join(output_path, f"duplicate_ids/{shard_index:08d}.parquet"),
-                )
-            )
-
-    return shards, outputs
+    ordered_sources = [
+        CopartitionedSource(source_key=source_key, input_dir=normalized.main_output_dir)
+        for _source_name, normalized, source_key in sorted(source_entries)
+    ]
+    entries, attr_dirs = build_copartitioned_shards(
+        sources=ordered_sources,
+        output_path=output_path,
+    )
+    outputs = {source_key: ExactDupsPerSource(attr_dir=attr_dir) for source_key, attr_dir in attr_dirs.items()}
+    return entries, outputs
 
 
-def _read_record_ids(shard: _SourceShard) -> Iterator[dict[str, int | str]]:
+def _read_record_ids(entry: CopartitionedShard) -> Iterator[_ExactRecord]:
+    input_path = entry.input_path
     row_index = 0
-    with StoragePath(shard.input_path).open("rb") as input_file:
+    # Force the second group to write a schema-only attribute file when a
+    # source shard has no duplicate rows.
+    yield {
+        "id": "",
+        "file_idx": entry.file_idx,
+        "row_index": _SHARD_MARKER_ROW_INDEX,
+    }
+    with StoragePath(input_path).open("rb") as input_file:
         parquet = pq.ParquetFile(input_file)
         if "id" not in parquet.schema_arrow.names:
-            raise ValueError(f"Parquet file has no id column: {shard.input_path}")
+            raise ValueError(f"Parquet file has no id column: {input_path}")
         id_type = parquet.schema_arrow.field("id").type
         if not (pa.types.is_string(id_type) or pa.types.is_large_string(id_type)):
-            raise ValueError(f"Record ID column is not a string in {shard.input_path}: {id_type}")
+            raise ValueError(f"Record ID column is not a string in {input_path}: {id_type}")
         for batch in parquet.iter_batches(columns=["id"]):
             for record_id in batch.column("id").to_pylist():
                 yield {
                     "id": record_id,
-                    "shard_index": shard.shard_index,
+                    "file_idx": entry.file_idx,
                     "row_index": row_index,
                 }
                 row_index += 1
+    counters.pipeline.update_counter(f"{COUNTER_PREFIX}/records_in", row_index)
 
 
-def _select_duplicates(_record_id: str, records: Iterator[dict[str, Any]]) -> Iterator[dict[str, Any]]:
-    next(records)
+def _select_duplicates(_key: tuple[str, str | int], records: Iterator[_ExactRecord]) -> Iterator[_ExactRecord]:
+    canonical = next(records)
+    if canonical["row_index"] == _SHARD_MARKER_ROW_INDEX:
+        yield canonical
+        return
+
     yield from records
 
 
-def _duplicate_id_writer(
-    output_path: str,
-) -> Callable[[int, Iterator[dict[str, Any]]], dict[str, int | str]]:
-    def write_duplicate_ids(shard_index: int, records: Iterator[dict[str, Any]]) -> dict[str, int | str]:
-        return write_parquet_file(
-            ({"id": record["id"], "row_index": record["row_index"]} for record in records),
-            output_path=prefix_join(output_path, f"duplicate_ids/{shard_index:08d}.parquet"),
-            schema=_DUPLICATE_SCHEMA,
-        )
+def _make_per_shard_writer() -> Callable[[int, Iterator[_ExactRecord]], dict[str, int | str]]:
+    def write_shard(file_idx: int, records: Iterator[_ExactRecord]) -> dict[str, int | str]:
+        entries: list[CopartitionedShard] = zephyr_worker_ctx().get_shared(_SHARED_ENTRIES_KEY)
+        entry = entries[file_idx]
+        duplicate_records = 0
 
-    return write_duplicate_ids
+        def duplicate_rows() -> Iterator[dict[str, str | dict[str, bool]]]:
+            nonlocal duplicate_records
+            for record in records:
+                if record["row_index"] == _SHARD_MARKER_ROW_INDEX:
+                    continue
+                duplicate_records += 1
+                yield {"id": record["id"], "attributes": {"dup_doc": True}}
 
-
-def _copy_file(source: str, destination: str) -> None:
-    source_storage = StoragePath(source)
-    destination_storage = StoragePath(destination)
-    if (source_storage.scheme, source_storage.netloc) != (destination_storage.scheme, destination_storage.netloc):
-        raise ValueError(f"Cannot copy between storage roots: {source!r} to {destination!r}")
-
-    source_fs, source_path = url_to_fs(source)
-    destination_storage.parent.mkdirs()
-    with atomic_rename(destination) as temp_path:
-        temp_fs, resolved_temp_path = url_to_fs(temp_path)
-        if source_fs.protocol != temp_fs.protocol:
-            raise ValueError(f"Cannot copy between filesystems: {source!r} to {destination!r}")
-        temp_fs.copy(source_path, resolved_temp_path)
-
-
-def _duplicate_rows(path: str) -> set[int]:
-    if not StoragePath(path).exists():
-        return set()
-    with StoragePath(path).open("rb") as duplicate_file:
-        return set(pq.read_table(duplicate_file, columns=["row_index"]).column("row_index").to_pylist())
-
-
-def _filter_shard(shard: _SourceShard) -> dict[str, int | str]:
-    duplicate_rows = _duplicate_rows(shard.duplicate_ids_path)
-    if StoragePath(shard.output_path).exists():
-        with StoragePath(shard.input_path).open("rb") as input_file:
-            records_in = pq.ParquetFile(input_file).metadata.num_rows
-        with StoragePath(shard.output_path).open("rb") as output_file:
-            records_out = pq.ParquetFile(output_file).metadata.num_rows
+        result = write_parquet_file(duplicate_rows(), output_path=entry.output_path, schema=_ATTR_SCHEMA)
+        counters.pipeline.update_counter(f"{COUNTER_PREFIX}/duplicate_records", duplicate_records)
         return {
-            "source": shard.source,
-            "path": shard.output_path,
-            "records_in": records_in,
-            "records_out": records_out,
+            **result,
+            "file_idx": file_idx,
+            "duplicate_records": duplicate_records,
         }
 
-    with StoragePath(shard.input_path).open("rb") as input_file:
-        parquet = pq.ParquetFile(input_file)
-        records_in = parquet.metadata.num_rows
-        schema = parquet.schema_arrow
-
-        if not duplicate_rows:
-            _copy_file(shard.input_path, shard.output_path)
-            return {
-                "source": shard.source,
-                "path": shard.output_path,
-                "records_in": records_in,
-                "records_out": records_in,
-            }
-
-        records_out = 0
-        row_index = 0
-        StoragePath(shard.output_path).parent.mkdirs()
-        with atomic_rename(shard.output_path) as temp_path:
-            with parquet_sink(temp_path) as (where_fd, native_fs):
-                with pq.ParquetWriter(where_fd, schema, filesystem=native_fs) as writer:
-                    for batch in parquet.iter_batches(batch_size=_FILTER_BATCH_ROWS):
-                        keep = pa.array(
-                            (index not in duplicate_rows for index in range(row_index, row_index + batch.num_rows)),
-                            type=pa.bool_(),
-                        )
-                        filtered = batch.filter(keep)
-                        writer.write_batch(filtered)
-                        records_out += filtered.num_rows
-                        row_index += batch.num_rows
-
-    return {
-        "source": shard.source,
-        "path": shard.output_path,
-        "records_in": records_in,
-        "records_out": records_out,
-    }
-
-
-def _write_success_file(path: str) -> None:
-    StoragePath(path).parent.mkdirs()
-    with atomic_rename(path) as temp_path:
-        with StoragePath(temp_path).open("wb") as success_file:
-            success_file.write(b"")
+    return write_shard
 
 
 def global_exact_deduplicate(
@@ -224,64 +170,37 @@ def global_exact_deduplicate(
     worker_resources: ResourceConfig,
     max_workers: int,
 ) -> GlobalExactDedupData:
-    """Keep one record for each record ID across all normalized sources.
+    """Mark duplicate record IDs across all normalized sources.
 
-    The lexicographically first source keeps a shared record ID. The function
-    keeps each source schema and shard layout.
+    Source names set canonical priority. The first shard and row set priority
+    within a source.
     """
     if not sources:
         raise ValueError("Global exact deduplication requires at least one source")
 
-    shards, output_sources = _input_shards(sources, output_path)
+    entries, outputs = _build_shard_index(sources, output_path)
     context = ZephyrContext(
         name="datakit-global-exact-dedup",
         resources=worker_resources,
         max_workers=max_workers,
     )
-
-    dedup_success_path = prefix_join(output_path, f"duplicate_ids/{_DEDUP_SUCCESS_FILE}")
-    if not StoragePath(dedup_success_path).exists():
-        dedup_pipeline = (
-            Dataset.from_list(shards)
-            .flat_map(_read_record_ids)
-            .group_by(
-                key=lambda record: record["id"],
-                reducer=_select_duplicates,
-                sort_by=lambda record: (record["shard_index"], record["row_index"]),
-            )
-            .group_by(
-                key=lambda record: record["shard_index"],
-                reducer=_duplicate_id_writer(output_path),
-                sort_by=lambda record: record["id"],
-            )
+    context.put(_SHARED_ENTRIES_KEY, entries)
+    pipeline = (
+        Dataset.from_list(entries)
+        .flat_map(_read_record_ids)
+        .group_by(
+            key=lambda record: (
+                "shard" if record["row_index"] == _SHARD_MARKER_ROW_INDEX else "record",
+                record["file_idx"] if record["row_index"] == _SHARD_MARKER_ROW_INDEX else record["id"],
+            ),
+            reducer=_select_duplicates,
+            sort_by=lambda record: (record["file_idx"], record["row_index"]),
         )
-        context.execute(dedup_pipeline)
-        _write_success_file(dedup_success_path)
-
-    filter_outcome = context.execute(Dataset.from_list(shards).map(_filter_shard))
-
-    filter_results = filter_outcome.results
-    records_in = sum(int(result["records_in"]) for result in filter_results)
-    records_out = sum(int(result["records_out"]) for result in filter_results)
-    source_ranks = {source: rank for rank, source in enumerate(sorted(sources))}
-    stage_counters: dict[str, int | float] = {
-        f"{COUNTER_PREFIX}/records_in": records_in,
-        f"{COUNTER_PREFIX}/records_out": records_out,
-        f"{COUNTER_PREFIX}/duplicate_records": records_in - records_out,
-    }
-    for source, normalized in output_sources.items():
-        source_results = [result for result in filter_results if result["source"] == source]
-        source_records_in = sum(int(result["records_in"]) for result in source_results)
-        source_records_out = sum(int(result["records_out"]) for result in source_results)
-        source_counters = {
-            f"{COUNTER_PREFIX}/records_in": source_records_in,
-            f"{COUNTER_PREFIX}/records_out": source_records_out,
-            f"{COUNTER_PREFIX}/duplicate_records": source_records_in - source_records_out,
-        }
-        rank = source_ranks[source]
-        stage_counters[f"{COUNTER_PREFIX}/source/{rank}/records_in"] = source_records_in
-        stage_counters[f"{COUNTER_PREFIX}/source/{rank}/records_out"] = source_records_out
-        stage_counters[f"{COUNTER_PREFIX}/source/{rank}/duplicate_records"] = source_records_in - source_records_out
-        output_sources[source] = normalized.model_copy(update={"counters": source_counters})
-
-    return GlobalExactDedupData(sources=output_sources, counters=stage_counters)
+        .group_by(
+            key=lambda record: record["file_idx"],
+            reducer=_make_per_shard_writer(),
+            sort_by=lambda record: (record["row_index"] == _SHARD_MARKER_ROW_INDEX, record["id"]),
+        )
+    )
+    outcome = context.execute(pipeline)
+    return GlobalExactDedupData(sources=outputs, counters=dict(outcome.counters))

--- a/experiments/datakit/global_exact_dedup.py
+++ b/experiments/datakit/global_exact_dedup.py
@@ -1,11 +1,15 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Global exact-duplicate attributes for normalized Datakit sources.
+"""Global record-ID duplicate attributes for normalized Datakit sources.
 
 The Zephyr pipeline shuffles record IDs across all sources. It keeps the first
 source, shard, and row occurrence. It writes sparse duplicate markers back to
 the source shards that contain duplicates.
+
+Normalized record IDs are content hashes, so equal IDs represent exact text
+duplicates. This pass also covers records for which MinHash emits no fuzzy
+attributes, such as text that is too short for the configured n-gram size.
 
 Output rows have this schema::
 
@@ -20,7 +24,7 @@ Output files keep the matching normalized shard names. A missing file means
 that its source shard has no exact duplicates.
 """
 
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from typing import TypedDict
 
 import pyarrow as pa
@@ -53,6 +57,8 @@ _ATTR_SCHEMA = pa.schema(
 
 
 class ExactDupsPerSource(BaseModel):
+    """Sparse exact-duplicate attribute files for one normalized source."""
+
     attr_dir: str
 
 
@@ -82,15 +88,15 @@ def _build_shard_index(
         (source_name, normalized, datakit_source_key(normalized.main_output_dir))
         for source_name, normalized in sources.items()
     ]
-    source_dirs: dict[str, str] = {}
-    for _source_name, normalized, source_key in source_entries:
-        if source_key in source_dirs:
+    source_keys: set[str] = set()
+    for _source_name, _normalized, source_key in source_entries:
+        if source_key in source_keys:
             raise ValueError(f"Multiple sources use source_key={source_key!r}")
-        source_dirs[source_key] = normalized.main_output_dir
+        source_keys.add(source_key)
 
     ordered_sources = [
         CopartitionedSource(source_key=source_key, input_dir=normalized.main_output_dir)
-        for _source_name, normalized, source_key in sorted(source_entries)
+        for _source_name, normalized, source_key in sorted(source_entries, key=lambda entry: entry[0])
     ]
     entries, attr_dirs = build_copartitioned_shards(
         sources=ordered_sources,
@@ -126,27 +132,24 @@ def _select_duplicates(_key: str, records: Iterator[_ExactRecord]) -> Iterator[_
     yield from records
 
 
-def _make_per_shard_writer() -> Callable[[int, Iterator[_ExactRecord]], dict[str, int | str]]:
-    def write_shard(file_idx: int, records: Iterator[_ExactRecord]) -> dict[str, int | str]:
-        entries: list[CopartitionedShard] = zephyr_worker_ctx().get_shared(_SHARED_ENTRIES_KEY)
-        entry = entries[file_idx]
-        duplicate_records = 0
+def _write_shard(file_idx: int, records: Iterator[_ExactRecord]) -> dict[str, int | str]:
+    entries: list[CopartitionedShard] = zephyr_worker_ctx().get_shared(_SHARED_ENTRIES_KEY)
+    entry = entries[file_idx]
+    duplicate_records = 0
 
-        def duplicate_rows() -> Iterator[dict[str, str | dict[str, bool]]]:
-            nonlocal duplicate_records
-            for record in records:
-                duplicate_records += 1
-                yield {"id": record["id"], "attributes": {"dup_doc": True}}
+    def duplicate_rows() -> Iterator[dict[str, str | dict[str, bool]]]:
+        nonlocal duplicate_records
+        for record in records:
+            duplicate_records += 1
+            yield {"id": record["id"], "attributes": {"dup_doc": True}}
 
-        result = write_parquet_file(duplicate_rows(), output_path=entry.output_path, schema=_ATTR_SCHEMA)
-        counters.pipeline.update_counter(f"{COUNTER_PREFIX}/duplicate_records", duplicate_records)
-        return {
-            **result,
-            "file_idx": file_idx,
-            "duplicate_records": duplicate_records,
-        }
-
-    return write_shard
+    result = write_parquet_file(duplicate_rows(), output_path=entry.output_path, schema=_ATTR_SCHEMA)
+    counters.pipeline.update_counter(f"{COUNTER_PREFIX}/duplicate_records", duplicate_records)
+    return {
+        **result,
+        "file_idx": file_idx,
+        "duplicate_records": duplicate_records,
+    }
 
 
 def global_exact_deduplicate(
@@ -171,6 +174,7 @@ def global_exact_deduplicate(
         max_workers=max_workers,
     )
     context.put(_SHARED_ENTRIES_KEY, entries)
+    shuffle_shards = min(max_workers, len(entries))
     pipeline = (
         Dataset.from_list(entries)
         .flat_map(_read_record_ids)
@@ -178,11 +182,13 @@ def global_exact_deduplicate(
             key=lambda record: record["id"],
             reducer=_select_duplicates,
             sort_by=lambda record: (record["file_idx"], record["row_index"]),
+            num_output_shards=shuffle_shards,
         )
         .group_by(
             key=lambda record: record["file_idx"],
-            reducer=_make_per_shard_writer(),
+            reducer=_write_shard,
             sort_by=lambda record: record["id"],
+            num_output_shards=shuffle_shards,
         )
     )
     outcome = context.execute(pipeline)

--- a/experiments/datakit/reference_pipeline.py
+++ b/experiments/datakit/reference_pipeline.py
@@ -12,10 +12,7 @@ StepRunner-walkable graph. Two modes (``--mode``), same DAG:
 
 Per source::
 
-    normalize ─┐
-               ├→ global exact dedup by record ID
-               └→ ...
-
+    all normalize steps → global exact dedup by record ID
     exact dedup → tokenize
                 → embed (luxical-one)   → assign (domain v0, given centroids)
                 → quality                (pooled fast-transformer, given model dir)
@@ -114,7 +111,7 @@ from marin.processing.tokenize.attributes import (
     TokenizedAttrData,
     tokenize_attributes_step,
 )
-from rigging.filesystem import StoragePath, marin_prefix, prefix_join
+from rigging.filesystem import StoragePath, marin_prefix
 from rigging.log_setup import configure_logging
 
 from experiments.datakit.cluster.domain.v0.assign import (
@@ -141,7 +138,11 @@ from experiments.datakit.embeddings.luxical.pipeline import (
     EmbeddingAttrData,
     embed_source,
 )
-from experiments.datakit.global_exact_dedup import GlobalExactDedupData, global_exact_deduplicate
+from experiments.datakit.global_exact_dedup import (
+    GlobalExactDedupData,
+    global_exact_dedup_source_path,
+    global_exact_deduplicate,
+)
 from experiments.datakit.reports.decontam import decontam_report
 from experiments.datakit.reports.dedup import dedup_report
 from experiments.datakit.reports.domain import assign_report
@@ -487,18 +488,12 @@ class DatakitSteps:
     sources: dict[str, StepSpec]
     """Echo of the input sources mapping (``{name: normalize_step}``)."""
 
-    exact_dedup: StepSpec
-    """Global exact-dedup StepSpec."""
-
-    deduplicated_sources: dict[str, StepSpec]
-    """Per-source views of the global exact-dedup output."""
-
     output_buckets: StepSpec
     """Final store StepSpec. Its ``output_path`` is the per-(cluster, quality)
     bucket directory the downstream training mixture reads from."""
 
     all_steps: list[StepSpec]
-    """Every StepSpec that the runner needs."""
+    """Every StepSpec the runner needs (shared upstream, per-source, dedup, store)."""
 
 
 def reference_datakit_steps(
@@ -566,7 +561,7 @@ def reference_datakit_steps(
             name=f"datakit/global_exact_dedup_source/{name}",
             deps=[exact_dedup],
             hash_attrs={"source": name, "v": 1},
-            override_output_path=prefix_join(exact_dedup.output_path, f"sources/{source_rank:05d}"),
+            override_output_path=global_exact_dedup_source_path(exact_dedup.output_path, source_rank),
             fn=lambda _output_path, source=name: read_artifact(exact_dedup.output_path, GlobalExactDedupData).sources[
                 source
             ],
@@ -859,8 +854,6 @@ def reference_datakit_steps(
     all_steps += [dedup, store, *reports]
     return DatakitSteps(
         sources=sources,
-        exact_dedup=exact_dedup,
-        deduplicated_sources=deduplicated_sources,
         output_buckets=store,
         all_steps=all_steps,
     )

--- a/experiments/datakit/reference_pipeline.py
+++ b/experiments/datakit/reference_pipeline.py
@@ -12,16 +12,16 @@ StepRunner-walkable graph. Two modes (``--mode``), same DAG:
 
 Per source::
 
-    all normalize steps → global exact dedup by record ID
-    exact dedup → tokenize
-                → embed (luxical-one)   → assign (domain v0, given centroids)
-                → quality                (pooled fast-transformer, given model dir)
-                → decontam               (shared eval bloom)
-                → minhash
+    normalize → tokenize
+              → embed (luxical-one)   → assign (domain v0, given centroids)
+              → quality                (pooled fast-transformer, given model dir)
+              → decontam               (shared eval bloom)
+              → minhash
 
 Then:
+    global_exact_dedup([<normalized source>])
     fuzzy_dups([<minhash per source>])
-    build_clustered_store(tokenize, decontam, cluster_assign, quality, dedup)
+    build_clustered_store(tokenize, decontam, cluster_assign, quality, exact_dedup, dedup)
     one ``datakit/report/<stage>`` step per stage -- a single self-contained
     HTML page built from that stage's counters + site/sample outputs
     (:mod:`experiments.datakit.reports`)
@@ -100,10 +100,12 @@ from marin.execution.remote import remote
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.deduplication.fuzzy_dups import (
+    FUZZY_DUPS_ATTR_DATA_VERSION,
     FuzzyDupsAttrData,
     compute_fuzzy_dups_attrs,
 )
 from marin.processing.classification.deduplication.fuzzy_minhash import (
+    MINHASH_ATTR_DATA_VERSION,
     MinHashAttrData,
     compute_minhash_attrs,
 )
@@ -115,6 +117,7 @@ from rigging.filesystem import StoragePath, marin_prefix
 from rigging.log_setup import configure_logging
 
 from experiments.datakit.cluster.domain.v0.assign import (
+    ASSIGNMENT_ATTR_DATA_VERSION,
     AssignmentAttrData,
     assign_source,
 )
@@ -132,6 +135,7 @@ from experiments.datakit.decontam.config import (
 )
 from experiments.datakit.decontam.prepare_eval_corpus import DECON_EXCLUDED_EVAL_TASKS
 from experiments.datakit.embeddings.luxical.pipeline import (
+    EMBEDDING_ATTR_DATA_VERSION,
     LUXICAL_REPO,
     LUXICAL_REVISION,
     LUXICAL_WEIGHTS_FILE,
@@ -139,8 +143,8 @@ from experiments.datakit.embeddings.luxical.pipeline import (
     embed_source,
 )
 from experiments.datakit.global_exact_dedup import (
+    GLOBAL_EXACT_DEDUP_DATA_VERSION,
     GlobalExactDedupData,
-    global_exact_dedup_source_path,
     global_exact_deduplicate,
 )
 from experiments.datakit.reports.decontam import decontam_report
@@ -339,7 +343,7 @@ def _build_embed_step(name: str, normalize_step: StepSpec, scale: PipelineScale)
             "luxical_weights": LUXICAL_WEIGHTS_FILE,
             "luxical_revision": LUXICAL_REVISION,
             "batch_size": scale.embed_batch_size,
-            "v": 1,
+            "v": EMBEDDING_ATTR_DATA_VERSION,
         },
         fn=remote(
             lambda output_path, np=normalize_step.output_path: embed_source(
@@ -548,7 +552,7 @@ def reference_datakit_steps(
     exact_dedup = StepSpec(
         name="datakit/global_exact_dedup",
         deps=[sources[name] for name in source_names],
-        hash_attrs={"sources": source_names, "v": 1},
+        hash_attrs={"sources": source_names, "v": GLOBAL_EXACT_DEDUP_DATA_VERSION},
         fn=lambda output_path: global_exact_deduplicate(
             sources={name: read_artifact(sources[name].output_path, NormalizedData) for name in source_names},
             output_path=output_path,
@@ -556,20 +560,7 @@ def reference_datakit_steps(
             max_workers=scale.pool.n_workers,
         ),
     )
-    deduplicated_sources = {
-        name: StepSpec(
-            name=f"datakit/global_exact_dedup_source/{name}",
-            deps=[exact_dedup],
-            hash_attrs={"source": name, "v": 1},
-            override_output_path=global_exact_dedup_source_path(exact_dedup.output_path, source_rank),
-            fn=lambda _output_path, source=name: read_artifact(exact_dedup.output_path, GlobalExactDedupData).sources[
-                source
-            ],
-        )
-        for source_rank, name in enumerate(source_names)
-    }
-
-    embed_steps = build_per_source_embed_steps(deduplicated_sources, scale)
+    embed_steps = build_per_source_embed_steps(sources, scale)
     if domain_centroids is None:
         domain_centroids = build_train_centroids_step(embed_steps, scale)
 
@@ -600,7 +591,7 @@ def reference_datakit_steps(
                 data_path=f"{normalize_step.output_path.rstrip('/')}/outputs/main",
                 dependency=normalize_step,
             )
-            for source_name, normalize_step in deduplicated_sources.items()
+            for source_name, normalize_step in sources.items()
         ],
         prebuilt_bloom=decon_bloom_step,
         ngram_length=NGRAM_LENGTH,
@@ -618,7 +609,7 @@ def reference_datakit_steps(
     per_source: dict[str, dict[str, StepSpec]] = {}
     minhash_steps: list[StepSpec] = []
 
-    for name, normalize_step in deduplicated_sources.items():
+    for name, normalize_step in sources.items():
         embed = embed_steps[name]
 
         tokenize = tokenize_attributes_step(
@@ -642,7 +633,7 @@ def reference_datakit_steps(
                 "k_train": cluster.k_train,
                 "k_views": list(cluster.k_views),
                 "batch_size": scale.assign_batch_size,
-                "v": 1,
+                "v": ASSIGNMENT_ATTR_DATA_VERSION,
             },
             fn=remote(
                 lambda output_path, ep=embed.output_path: assign_source(
@@ -699,7 +690,7 @@ def reference_datakit_steps(
                 "ngram_size": mh.ngram_size,
                 "text_cap_chars": mh.text_cap_chars,
                 "seed": mh.seed,
-                "v": 1,
+                "v": MINHASH_ATTR_DATA_VERSION,
             },
             fn=lambda op, n=normalize_step: compute_minhash_attrs(
                 source=read_artifact(n.output_path, NormalizedData),
@@ -730,7 +721,7 @@ def reference_datakit_steps(
     dedup = StepSpec(
         name="datakit/dedup",
         deps=minhash_steps,
-        hash_attrs={"v": 1},
+        hash_attrs={"v": FUZZY_DUPS_ATTR_DATA_VERSION},
         fn=lambda op: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(s.output_path, MinHashAttrData) for s in minhash_steps],
             output_path=op,
@@ -740,7 +731,7 @@ def reference_datakit_steps(
         ),
     )
 
-    # ---- Final store: 5-way join + per-bucket Levanter cache ------------------
+    # ---- Final store: attribute join + per-bucket Levanter cache ---------------
     def _store_fn(output_path: str) -> ClusteredStoreData:
         return build_clustered_store(
             tokenize={n: read_artifact(s["tokenize"].output_path, TokenizedAttrData) for n, s in per_source.items()},
@@ -749,6 +740,7 @@ def reference_datakit_steps(
                 n: read_artifact(s["assign"].output_path, AssignmentAttrData) for n, s in per_source.items()
             },
             quality={n: read_artifact(s["quality"].output_path, QualityScores) for n, s in per_source.items()},
+            exact_dedup=read_artifact(exact_dedup.output_path, GlobalExactDedupData),
             dedup=read_artifact(dedup.output_path, FuzzyDupsAttrData),
             output_path=output_path,
             cluster_view=cluster.cluster_view,
@@ -765,7 +757,7 @@ def reference_datakit_steps(
     store_deps: list[StepSpec] = []
     for s in per_source.values():
         store_deps += [s["tokenize"], s["decontam"], s["assign"], s["quality"]]
-    store_deps.append(dedup)
+    store_deps += [exact_dedup, dedup]
 
     # Hash output-shaping values read directly by the store. ``shards_per_task``
     # and ``reduce_shards`` only schedule the shuffle, so they intentionally do
@@ -846,17 +838,13 @@ def reference_datakit_steps(
         ),
     ]
 
-    all_steps: list[StepSpec] = [exact_dedup, *deduplicated_sources.values(), decon_bloom_step, decon_drop_sets]
+    all_steps: list[StepSpec] = [exact_dedup, decon_bloom_step, decon_drop_sets]
     if isinstance(domain_centroids, StepSpec):
         all_steps.append(domain_centroids)
     for s in per_source.values():
         all_steps += list(s.values())
     all_steps += [dedup, store, *reports]
-    return DatakitSteps(
-        sources=sources,
-        output_buckets=store,
-        all_steps=all_steps,
-    )
+    return DatakitSteps(sources=sources, output_buckets=store, all_steps=all_steps)
 
 
 SAMPLE_PREFIX = "s3://marin-us-east-02a/marin/datakit/sample_0.1b_7d7d8fd7"

--- a/experiments/datakit/reference_pipeline.py
+++ b/experiments/datakit/reference_pipeline.py
@@ -12,11 +12,15 @@ StepRunner-walkable graph. Two modes (``--mode``), same DAG:
 
 Per source::
 
-    normalize → tokenize
-              → embed (luxical-one)   → assign (domain v0, given centroids)
-              → quality                (pooled fast-transformer, given model dir)
-              → decontam               (shared eval bloom)
-              → minhash
+    normalize ─┐
+               ├→ global exact dedup by record ID
+               └→ ...
+
+    exact dedup → tokenize
+                → embed (luxical-one)   → assign (domain v0, given centroids)
+                → quality                (pooled fast-transformer, given model dir)
+                → decontam               (shared eval bloom)
+                → minhash
 
 Then:
     fuzzy_dups([<minhash per source>])
@@ -25,8 +29,8 @@ Then:
     HTML page built from that stage's counters + site/sample outputs
     (:mod:`experiments.datakit.reports`)
 
-Every stage keeps one step per source with its own output dir; only dedup and
-the store combine sources, by design.
+Most stages keep one step per source with a separate output directory. Global
+exact dedup, fuzzy dedup, the decontamination DF filter, and the store combine sources.
 
 Worker fleet: every stage runs its pipeline on its own dedicated Zephyr
 coordinator + workers (vanilla ``ZephyrContext``, built inside the stage
@@ -110,7 +114,7 @@ from marin.processing.tokenize.attributes import (
     TokenizedAttrData,
     tokenize_attributes_step,
 )
-from rigging.filesystem import StoragePath, marin_prefix
+from rigging.filesystem import StoragePath, marin_prefix, prefix_join
 from rigging.log_setup import configure_logging
 
 from experiments.datakit.cluster.domain.v0.assign import (
@@ -137,6 +141,7 @@ from experiments.datakit.embeddings.luxical.pipeline import (
     EmbeddingAttrData,
     embed_source,
 )
+from experiments.datakit.global_exact_dedup import GlobalExactDedupData, global_exact_deduplicate
 from experiments.datakit.reports.decontam import decontam_report
 from experiments.datakit.reports.dedup import dedup_report
 from experiments.datakit.reports.domain import assign_report
@@ -482,12 +487,18 @@ class DatakitSteps:
     sources: dict[str, StepSpec]
     """Echo of the input sources mapping (``{name: normalize_step}``)."""
 
+    exact_dedup: StepSpec
+    """Global exact-dedup StepSpec."""
+
+    deduplicated_sources: dict[str, StepSpec]
+    """Per-source views of the global exact-dedup output."""
+
     output_buckets: StepSpec
     """Final store StepSpec. Its ``output_path`` is the per-(cluster, quality)
     bucket directory the downstream training mixture reads from."""
 
     all_steps: list[StepSpec]
-    """Every StepSpec the runner needs (shared upstream, per-source, dedup, store)."""
+    """Every StepSpec that the runner needs."""
 
 
 def reference_datakit_steps(
@@ -537,7 +548,33 @@ def reference_datakit_steps(
     """
     cluster = scale.cluster
     mh = scale.minhash
-    embed_steps = build_per_source_embed_steps(sources, scale)
+
+    source_names = sorted(sources)
+    exact_dedup = StepSpec(
+        name="datakit/global_exact_dedup",
+        deps=[sources[name] for name in source_names],
+        hash_attrs={"sources": source_names, "v": 1},
+        fn=lambda output_path: global_exact_deduplicate(
+            sources={name: read_artifact(sources[name].output_path, NormalizedData) for name in source_names},
+            output_path=output_path,
+            worker_resources=scale.pool.worker,
+            max_workers=scale.pool.n_workers,
+        ),
+    )
+    deduplicated_sources = {
+        name: StepSpec(
+            name=f"datakit/global_exact_dedup_source/{name}",
+            deps=[exact_dedup],
+            hash_attrs={"source": name, "v": 1},
+            override_output_path=prefix_join(exact_dedup.output_path, f"sources/{source_rank:05d}"),
+            fn=lambda _output_path, source=name: read_artifact(exact_dedup.output_path, GlobalExactDedupData).sources[
+                source
+            ],
+        )
+        for source_rank, name in enumerate(source_names)
+    }
+
+    embed_steps = build_per_source_embed_steps(deduplicated_sources, scale)
     if domain_centroids is None:
         domain_centroids = build_train_centroids_step(embed_steps, scale)
 
@@ -568,7 +605,7 @@ def reference_datakit_steps(
                 data_path=f"{normalize_step.output_path.rstrip('/')}/outputs/main",
                 dependency=normalize_step,
             )
-            for source_name, normalize_step in sources.items()
+            for source_name, normalize_step in deduplicated_sources.items()
         ],
         prebuilt_bloom=decon_bloom_step,
         ngram_length=NGRAM_LENGTH,
@@ -586,7 +623,7 @@ def reference_datakit_steps(
     per_source: dict[str, dict[str, StepSpec]] = {}
     minhash_steps: list[StepSpec] = []
 
-    for name, normalize_step in sources.items():
+    for name, normalize_step in deduplicated_sources.items():
         embed = embed_steps[name]
 
         tokenize = tokenize_attributes_step(
@@ -814,13 +851,19 @@ def reference_datakit_steps(
         ),
     ]
 
-    all_steps: list[StepSpec] = [decon_bloom_step, decon_drop_sets]
+    all_steps: list[StepSpec] = [exact_dedup, *deduplicated_sources.values(), decon_bloom_step, decon_drop_sets]
     if isinstance(domain_centroids, StepSpec):
         all_steps.append(domain_centroids)
     for s in per_source.values():
         all_steps += list(s.values())
     all_steps += [dedup, store, *reports]
-    return DatakitSteps(sources=sources, output_buckets=store, all_steps=all_steps)
+    return DatakitSteps(
+        sources=sources,
+        exact_dedup=exact_dedup,
+        deduplicated_sources=deduplicated_sources,
+        output_buckets=store,
+        all_steps=all_steps,
+    )
 
 
 SAMPLE_PREFIX = "s3://marin-us-east-02a/marin/datakit/sample_0.1b_7d7d8fd7"

--- a/experiments/datakit/reports/dedup.py
+++ b/experiments/datakit/reports/dedup.py
@@ -19,8 +19,8 @@ SAMPLE_LIMIT = 1000
 COUNTER_PREFIX = "dedup/fuzzy/document"
 
 
-def _source_label(source_main_dir: str) -> str:
-    return "/".join(source_main_dir.rstrip("/").split("/")[-3:])
+def _source_label(source_key: str) -> str:
+    return "/".join(source_key.rstrip("/").split("/")[-3:])
 
 
 def dedup_report(output_path: str, dedup: FuzzyDupsAttrData) -> StageReport:
@@ -35,14 +35,14 @@ def dedup_report(output_path: str, dedup: FuzzyDupsAttrData) -> StageReport:
     # samples yields cross-source cluster sizes (within the sample).
     sampled_cluster_sizes: Counter[str] = Counter()
     per_source = []
-    for source_main_dir, entry in dedup.sources.items():
+    for source_key, entry in dedup.sources.items():
         rows = sample_rows(entry.attr_dir, ["id", "attributes"], SAMPLE_LIMIT)
         source_clusters = {r["attributes"]["dup_cluster_id"] for r in rows}
         sampled_cluster_sizes.update(r["attributes"]["dup_cluster_id"] for r in rows)
         per_source.append(
             {
-                "label": _source_label(source_main_dir),
-                "source_main_dir": source_main_dir,
+                "label": _source_label(source_key),
+                "source_key": source_key,
                 "sampled_members": len(rows),
                 "sampled_clusters": len(source_clusters),
             }

--- a/experiments/datakit/reports/domain.py
+++ b/experiments/datakit/reports/domain.py
@@ -68,7 +68,7 @@ def assign_report(output_path: str, sources: dict[str, AssignmentAttrData], clus
         "clusters_seen": len(occupancy),
         "sampled_rows": sum(s["sampled"] for s in source_rows),
     }
-    data_root = os.path.commonprefix([a.source_main_dir for a in sources.values()]).rsplit("/", 1)[0]
+    data_root = os.path.commonprefix([a.source_key for a in sources.values()]).rsplit("/", 1)[0]
     data = {
         "meta": {
             "k_train": k_train,

--- a/experiments/datakit/reports/store.py
+++ b/experiments/datakit/reports/store.py
@@ -5,7 +5,7 @@
 
 Artifact-only: :class:`ClusteredStoreData` already carries every bucket's doc
 and token counts, so the page needs no parquet reads. Shows the corpus-level
-funnel (records in vs contaminated / dedup-dropped from the join counters),
+funnel (records in vs contaminated / exact-dedup / fuzzy-dedup drops),
 the cluster x quality token heatmap, and per-quality / per-cluster totals.
 """
 
@@ -35,6 +35,7 @@ def store_report(output_path: str, store: ClusteredStoreData) -> StageReport:
         "n_sources": len(store.source_names),
         "records_in": store.counters.get("datakit_store/records_in", 0),
         "contaminated_dropped": store.counters.get("datakit_store/contaminated_dropped", 0),
+        "exact_duplicate_dropped": store.counters.get("datakit_store/exact_duplicate_dropped", 0),
         "dedup_noncanonical_dropped": store.counters.get("datakit_store/dedup_noncanonical_dropped", 0),
         "records_out": store.counters.get("datakit_store/records_out", 0),
     }

--- a/experiments/datakit/reports/templates/dedup.html
+++ b/experiments/datakit/reports/templates/dedup.html
@@ -74,7 +74,7 @@ document.getElementById("params").textContent =
   Object.entries(D.params).map(([k,v]) => `${k}=${v === null ? "none" : v}`).join("  ·  ");
 let srows = `<tr><th>source</th><th>sampled members</th><th>distinct clusters</th></tr>`;
 for (const s of D.sources) {
-  srows += `<tr><td title="${s.source_main_dir}">${s.label}</td>` +
+  srows += `<tr><td title="${s.source_key}">${s.label}</td>` +
     `<td class="num">${s.sampled_members.toLocaleString()}</td>` +
     `<td class="num">${s.sampled_clusters.toLocaleString()}</td></tr>`;
 }

--- a/experiments/datakit/reports/templates/store.html
+++ b/experiments/datakit/reports/templates/store.html
@@ -63,7 +63,8 @@ const cards = [
   ["buckets", S.n_buckets, `${S.n_clusters} clusters × ${S.n_quality_buckets} quality`],
   ["sources", S.n_sources, M.tokenizer],
   ["contaminated", fmt(S.contaminated_dropped), `of ${fmt(S.records_in)} in`],
-  ["dedup dropped", fmt(S.dedup_noncanonical_dropped), "non-canonical members"],
+  ["exact dedup", fmt(S.exact_duplicate_dropped), "duplicate record IDs"],
+  ["fuzzy dedup", fmt(S.dedup_noncanonical_dropped), "non-canonical members"],
 ];
 document.getElementById("cards").innerHTML = cards.map(([k,v,d]) =>
   `<div class="card"><div class="k">${k}</div><div class="v">${v}</div><div class="d">${d}</div></div>`).join("");

--- a/experiments/datakit/reports/tokenize.py
+++ b/experiments/datakit/reports/tokenize.py
@@ -58,8 +58,8 @@ def tokenize_report(output_path: str, sources: dict[str, TokenizedAttrData], spl
         "n_sources": len(sources),
         "sampled_docs": len(lengths),
     }
-    # Common parent of the per-source main dirs: char-wise prefix trimmed back to a path boundary.
-    data_root = os.path.commonprefix([sources[name].source_main_dirs[split] for name in names]).rsplit("/", 1)[0]
+    # Common parent of the source keys: char-wise prefix trimmed back to a path boundary.
+    data_root = os.path.commonprefix([sources[name].source_keys[split] for name in names]).rsplit("/", 1)[0]
     sampling = (
         f"docs/tokens from step counters (exact); token-length histogram from the first "
         f"{HIST_ROWS_PER_SOURCE} rows per source (file order) over {len(sampled)} of {len(sources)} sources"

--- a/experiments/datakit/store/datakit_store.py
+++ b/experiments/datakit/store/datakit_store.py
@@ -14,11 +14,11 @@ dominated by token I/O.
 
 Pipeline:
 
-1. **map** (per input shard): a 5-way positional join over tokenization,
-   decontamination, domain assignment, quality, and dedup attributes, emitting
-   ``{cluster, quality, sub, input_ids}`` per surviving doc. ``sub`` is a stable
-   hash of the doc id mod that bucket's subshard count, so a hot bucket is split
-   evenly across many reducers instead of one.
+1. **map** (per input shard): a positional join over tokenization,
+   decontamination, domain assignment, quality, exact-dedup, and fuzzy-dedup
+   attributes, emitting ``{cluster, quality, sub, input_ids}`` per surviving
+   doc. ``sub`` is a stable hash of the doc id mod that bucket's subshard count,
+   so a hot bucket is split evenly across many reducers instead of one.
 2. **group_by** ``(cluster, quality, sub)`` -> **reduce**: each reducer streams
    its group into one materialized cache at
    ``<output>/cluster=<C>/quality=<Q>/sub=<S>`` via ``SerialCacheWriter``.
@@ -41,7 +41,7 @@ import logging
 import math
 import os
 from collections import defaultdict
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 
 import numpy as np
 import pyarrow as pa
@@ -56,7 +56,7 @@ from levanter.store.cache import (
 )
 from marin.datakit.decon import DeconAttributes
 from marin.execution.artifact import read_artifact, write_artifact
-from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData
+from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData, FuzzyDupsPerSource
 from marin.processing.tokenize.attributes import TokenizedAttrData
 from pydantic import BaseModel
 from rigging.filesystem import StoragePath
@@ -68,6 +68,7 @@ from zephyr.writers import atomic_rename
 
 from experiments.datakit.cluster.domain.v0.assign import AssignmentAttrData
 from experiments.datakit.cluster.quality.fast_transformer.artifact import QualityScores
+from experiments.datakit.global_exact_dedup import ExactDupsPerSource, GlobalExactDedupData
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +109,7 @@ def _per_source_shard_tuples(
     decontam: DeconAttributes,
     cluster_assign: AssignmentAttrData,
     quality: QualityScores,
+    exact_dedup_attr_dir: str,
     dedup_attr_dir: str,
     split: str,
 ) -> list[dict[str, str]]:
@@ -122,6 +124,7 @@ def _per_source_shard_tuples(
     decon_dir = decontam.main_output_dir.rstrip("/")
     cluster_dir = cluster_assign.output_dir.rstrip("/")
     quality_dir = quality.main_output_dir.rstrip("/")
+    exact_dedup_dir = exact_dedup_attr_dir.rstrip("/")
     dedup_dir = dedup_attr_dir.rstrip("/")
     return [
         {
@@ -129,6 +132,7 @@ def _per_source_shard_tuples(
             "decontam": f"{decon_dir}/{os.path.basename(tok_path)}",
             "cluster": f"{cluster_dir}/{os.path.basename(tok_path)}",
             "quality": f"{quality_dir}/{os.path.basename(tok_path)}",
+            "exact_dedup": f"{exact_dedup_dir}/{os.path.basename(tok_path)}",
             "dedup": f"{dedup_dir}/{os.path.basename(tok_path)}",
             "source_name": source_name,
             "basename": os.path.basename(tok_path),
@@ -177,6 +181,14 @@ def _load_dedup_canonical(path: str) -> dict[str, bool]:
     return dict(zip(ids, canonical, strict=True))
 
 
+def _load_exact_duplicates(path: str) -> set[str]:
+    """Return IDs marked as exact duplicates in one sparse attribute shard."""
+    table = _read_columns(path, ["id", "attributes"])
+    ids = table.column("id").to_pylist()
+    duplicate = table.column("attributes").combine_chunks().field("dup_doc").to_pylist()
+    return {doc_id for doc_id, is_duplicate in zip(ids, duplicate, strict=True) if is_duplicate}
+
+
 def _validate_cluster_view(cluster_assign: dict[str, AssignmentAttrData], cluster_view: int) -> str:
     """Check that every assignment artifact materialized the selected view."""
     for name, assignment in cluster_assign.items():
@@ -192,14 +204,15 @@ def _validate_cluster_view(cluster_assign: dict[str, AssignmentAttrData], cluste
 def _resolve_dedup_attr_dir(
     *,
     source_name: str,
-    main_output_dir: str,
-    dedup: FuzzyDupsAttrData,
+    source_key: str,
+    sources: Mapping[str, ExactDupsPerSource | FuzzyDupsPerSource],
+    label: str,
 ) -> str:
-    entry = dedup.sources.get(main_output_dir)
+    entry = sources.get(source_key)
     if entry is None:
         raise KeyError(
-            f"{source_name}: dedup.sources has no entry for source_main_dir={main_output_dir!r}. "
-            "Drop the source from the config or rebuild dedup with it included."
+            f"{source_name}: {label}.sources has no entry for source_key={source_key!r}. "
+            f"Drop the source from the config or rebuild {label} with it included."
         )
     return entry.attr_dir
 
@@ -240,11 +253,11 @@ class _SubshardStat:
 
 
 def _iter_surviving_docs(spec: dict[str, str], cluster_col: str) -> Iterator[tuple[int, int, str, np.ndarray]]:
-    """Join one shard's five datasets; yield ``(cluster, quality_bucket, doc_id, input_ids)`` per surviving doc.
+    """Join one shard's datasets; yield ``(cluster, quality_bucket, doc_id, input_ids)`` per surviving doc.
 
-    Reads decon/cluster/quality densely, dedup sparsely, streams tokenize in
-    positional lockstep, and drops contaminated rows and dedup-cluster
-    non-canonicals. Fails loud on missing or misaligned inputs.
+    Reads decon/cluster/quality densely and duplicate attributes sparsely. It
+    streams tokenize in positional lockstep and drops filtered rows. It fails
+    on missing or misaligned inputs.
     """
     decon_ids, contaminated = _load_decon_table(spec["decontam"])
     cluster_ids, cluster_vals = _load_cluster_table(spec["cluster"], cluster_col)
@@ -266,10 +279,12 @@ def _iter_surviving_docs(spec: dict[str, str], cluster_col: str) -> Iterator[tup
     if not pc.all(pc.equal(decon_ids, quality_ids)).as_py():
         raise RuntimeError(f"{where}: decon/quality id mismatch -- co-partitioning broken")
     del decon_ids, cluster_ids, quality_ids
+    exact_duplicates = _load_exact_duplicates(spec["exact_dedup"])
     dedup_canonical = _load_dedup_canonical(spec["dedup"])
 
     n_in = 0
     n_contaminated = 0
+    n_exact_dedup_dropped = 0
     n_dedup_dropped = 0
     n_out = 0
     with StoragePath(spec["tokenize"]).open("rb") as fh:
@@ -288,6 +303,9 @@ def _iter_surviving_docs(spec: dict[str, str], cluster_col: str) -> Iterator[tup
                 if contam_slice[i]:
                     n_contaminated += 1
                     continue
+                if doc_id in exact_duplicates:
+                    n_exact_dedup_dropped += 1
+                    continue
                 if dedup_canonical.get(doc_id) is False:
                     n_dedup_dropped += 1
                     continue
@@ -301,6 +319,7 @@ def _iter_surviving_docs(spec: dict[str, str], cluster_col: str) -> Iterator[tup
             )
     counters.pipeline.update_counter("datakit_store/records_in", n_in)
     counters.pipeline.update_counter("datakit_store/contaminated_dropped", n_contaminated)
+    counters.pipeline.update_counter("datakit_store/exact_duplicate_dropped", n_exact_dedup_dropped)
     counters.pipeline.update_counter("datakit_store/dedup_noncanonical_dropped", n_dedup_dropped)
     counters.pipeline.update_counter("datakit_store/records_out", n_out)
 
@@ -492,6 +511,7 @@ def build_clustered_store(
     decontam: dict[str, DeconAttributes],
     cluster_assign: dict[str, AssignmentAttrData],
     quality: dict[str, QualityScores],
+    exact_dedup: GlobalExactDedupData,
     dedup: FuzzyDupsAttrData,
     output_path: str,
     cluster_view: int = 40,
@@ -505,7 +525,7 @@ def build_clustered_store(
     max_subshards: int = 128,
     default_subshards: int = DEFAULT_SUBSHARDS,
 ) -> ClusteredStoreData:
-    """Shuffle 5-way join + filter into one materialized cache per ``(cluster, quality, sub)``.
+    """Shuffle the joined attributes into one materialized cache per ``(cluster, quality, sub)``.
 
     The store is born compact: reducers create the final materialized caches
     directly rather than producing per-input-shard leaf caches.
@@ -556,16 +576,27 @@ def build_clustered_store(
     shard_specs: list[dict[str, str]] = []
     for source_name in sorted(tokenize):
         tok = tokenize[source_name]
-        main_dir = tok.source_main_dirs.get(split)
-        if main_dir is None:
-            raise ValueError(f"{source_name}: tokenize has no source_main_dir for split={split!r}")
+        source_key = tok.source_keys.get(split)
+        if source_key is None:
+            raise ValueError(f"{source_name}: tokenize has no source_key for split={split!r}")
         cluster_asg = cluster_assign[source_name]
-        if cluster_asg.source_main_dir != main_dir:
+        if cluster_asg.source_key != source_key:
             raise ValueError(
-                f"{source_name}: cluster_assign.source_main_dir={cluster_asg.source_main_dir!r} "
-                f"!= tokenize.source_main_dirs[{split!r}]={main_dir!r}"
+                f"{source_name}: cluster_assign.source_key={cluster_asg.source_key!r} "
+                f"!= tokenize.source_keys[{split!r}]={source_key!r}"
             )
-        dedup_attr_dir = _resolve_dedup_attr_dir(source_name=source_name, main_output_dir=main_dir, dedup=dedup)
+        dedup_attr_dir = _resolve_dedup_attr_dir(
+            source_name=source_name,
+            source_key=source_key,
+            sources=dedup.sources,
+            label="dedup",
+        )
+        exact_dedup_attr_dir = _resolve_dedup_attr_dir(
+            source_name=source_name,
+            source_key=source_key,
+            sources=exact_dedup.sources,
+            label="exact_dedup",
+        )
         shard_specs.extend(
             _per_source_shard_tuples(
                 source_name=source_name,
@@ -573,6 +604,7 @@ def build_clustered_store(
                 decontam=decontam[source_name],
                 cluster_assign=cluster_asg,
                 quality=quality[source_name],
+                exact_dedup_attr_dir=exact_dedup_attr_dir,
                 dedup_attr_dir=dedup_attr_dir,
                 split=split,
             )

--- a/experiments/datakit/store/datakit_store.py
+++ b/experiments/datakit/store/datakit_store.py
@@ -185,10 +185,7 @@ def _load_exact_duplicates(path: str) -> set[str]:
     """Return sparse exact-duplicate IDs; a missing shard has no duplicates."""
     if not StoragePath(path).exists():
         return set()
-    table = _read_columns(path, ["id", "attributes"])
-    ids = table.column("id").to_pylist()
-    duplicate = table.column("attributes").combine_chunks().field("dup_doc").to_pylist()
-    return {doc_id for doc_id, is_duplicate in zip(ids, duplicate, strict=True) if is_duplicate}
+    return set(_read_columns(path, ["id"]).column("id").to_pylist())
 
 
 def _validate_cluster_view(cluster_assign: dict[str, AssignmentAttrData], cluster_view: int) -> str:
@@ -305,11 +302,12 @@ def _iter_surviving_docs(spec: dict[str, str], cluster_col: str) -> Iterator[tup
                 if contam_slice[i]:
                     n_contaminated += 1
                     continue
-                if doc_id in exact_duplicates:
-                    n_exact_dedup_dropped += 1
-                    continue
-                if dedup_canonical.get(doc_id) is False:
+                fuzzy_canonical = dedup_canonical.get(doc_id)
+                if fuzzy_canonical is False:
                     n_dedup_dropped += 1
+                    continue
+                if fuzzy_canonical is None and doc_id in exact_duplicates:
+                    n_exact_dedup_dropped += 1
                     continue
                 ids = tok_input_ids[i].values.to_numpy()
                 n_out += 1

--- a/experiments/datakit/store/datakit_store.py
+++ b/experiments/datakit/store/datakit_store.py
@@ -182,7 +182,9 @@ def _load_dedup_canonical(path: str) -> dict[str, bool]:
 
 
 def _load_exact_duplicates(path: str) -> set[str]:
-    """Return IDs marked as exact duplicates in one sparse attribute shard."""
+    """Return sparse exact-duplicate IDs; a missing shard has no duplicates."""
+    if not StoragePath(path).exists():
+        return set()
     table = _read_columns(path, ["id", "attributes"])
     ids = table.column("id").to_pylist()
     duplicate = table.column("attributes").combine_chunks().field("dup_doc").to_pylist()

--- a/experiments/datakit/testbed/variants.py
+++ b/experiments/datakit/testbed/variants.py
@@ -27,7 +27,11 @@ from marin.execution.lazy import ArtifactStep
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.consolidate import FilterConfig, FilterType, consolidate
-from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData, compute_fuzzy_dups_attrs
+from marin.processing.classification.deduplication.fuzzy_dups import (
+    FUZZY_DUPS_ATTR_DATA_VERSION,
+    FuzzyDupsAttrData,
+    compute_fuzzy_dups_attrs,
+)
 from marin.processing.classification.deduplication.fuzzy_minhash import MinHashAttrData, compute_minhash_attrs
 from marin.processing.tokenize.tokenize import TokenizedCache
 from rigging.log_setup import configure_logging
@@ -80,7 +84,7 @@ def _fuzzy_dups_step(minhash_steps: list[StepSpec], cc_max_iterations: int) -> S
     return StepSpec(
         name="data/datakit/fuzzy_dups",
         deps=list(minhash_steps),
-        hash_attrs={"cc_max_iterations": cc_max_iterations},
+        hash_attrs={"artifact_version": FUZZY_DUPS_ATTR_DATA_VERSION, "cc_max_iterations": cc_max_iterations},
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(mh.output_path, MinHashAttrData) for mh in minhash_steps],
             output_path=output_path,
@@ -107,9 +111,9 @@ def _deduped_step(src_name: str, sampled: StepSpec, fuzzy_dups: StepSpec) -> Ste
             filters=[
                 FilterConfig(
                     type=FilterType.KEEP_DOC,
-                    attribute_path=read_artifact(fuzzy_dups.output_path, FuzzyDupsAttrData)
-                    .sources[read_artifact(sampled.output_path, NormalizedData).main_output_dir]
-                    .attr_dir,
+                    attribute_path=read_artifact(fuzzy_dups.output_path, FuzzyDupsAttrData).attr_dir_for_source(
+                        read_artifact(sampled.output_path, NormalizedData).main_output_dir
+                    ),
                     name="is_cluster_canonical",
                     attribute_filetype="parquet",
                     keep_if_missing=True,

--- a/experiments/ferries/datakit_ferry.py
+++ b/experiments/ferries/datakit_ferry.py
@@ -23,6 +23,7 @@ from marin.processing.classification.consolidate import (
     consolidate,
 )
 from marin.processing.classification.deduplication.fuzzy_dups import (
+    FUZZY_DUPS_ATTR_DATA_VERSION,
     FuzzyDupsAttrData,
     compute_fuzzy_dups_attrs,
 )
@@ -80,7 +81,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
     deduped = StepSpec(
         name="datakit-smoke/fuzzy_dups",
         deps=[minhash],
-        hash_attrs={"cc_max_iterations": 3},
+        hash_attrs={"artifact_version": FUZZY_DUPS_ATTR_DATA_VERSION, "cc_max_iterations": 3},
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(minhash.output_path, MinHashAttrData)],
             output_path=output_path,
@@ -104,9 +105,9 @@ def build_steps(run_id: str) -> list[StepSpec]:
                 # keep_if_missing=True passes them through.
                 FilterConfig(
                     type=FilterType.KEEP_DOC,
-                    attribute_path=read_artifact(deduped.output_path, FuzzyDupsAttrData)
-                    .sources[read_artifact(normalized.output_path, NormalizedData).main_output_dir]
-                    .attr_dir,
+                    attribute_path=read_artifact(deduped.output_path, FuzzyDupsAttrData).attr_dir_for_source(
+                        read_artifact(normalized.output_path, NormalizedData).main_output_dir
+                    ),
                     name="is_cluster_canonical",
                     attribute_filetype="parquet",
                     keep_if_missing=True,

--- a/experiments/ferries/datakit_nemotron_ferry.py
+++ b/experiments/ferries/datakit_nemotron_ferry.py
@@ -27,6 +27,7 @@ from marin.processing.classification.consolidate import (
     consolidate,
 )
 from marin.processing.classification.deduplication.fuzzy_dups import (
+    FUZZY_DUPS_ATTR_DATA_VERSION,
     FuzzyDupsAttrData,
     compute_fuzzy_dups_attrs,
 )
@@ -118,7 +119,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
     deduped = StepSpec(
         name="datakit-nemotron-smoke/fuzzy_dups",
         deps=[minhash],
-        hash_attrs={"cc_max_iterations": 3},
+        hash_attrs={"artifact_version": FUZZY_DUPS_ATTR_DATA_VERSION, "cc_max_iterations": 3},
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(minhash.output_path, MinHashAttrData)],
             output_path=output_path,
@@ -140,9 +141,9 @@ def build_steps(run_id: str) -> list[StepSpec]:
             filters=[
                 FilterConfig(
                     type=FilterType.KEEP_DOC,
-                    attribute_path=read_artifact(deduped.output_path, FuzzyDupsAttrData)
-                    .sources[read_artifact(normalized.output_path, NormalizedData).main_output_dir]
-                    .attr_dir,
+                    attribute_path=read_artifact(deduped.output_path, FuzzyDupsAttrData).attr_dir_for_source(
+                        read_artifact(normalized.output_path, NormalizedData).main_output_dir
+                    ),
                     name="is_cluster_canonical",
                     attribute_filetype="parquet",
                     keep_if_missing=True,

--- a/experiments/ferries/datakit_tier2_skewed_ferry.py
+++ b/experiments/ferries/datakit_tier2_skewed_ferry.py
@@ -33,6 +33,7 @@ from marin.processing.classification.consolidate import (
     consolidate,
 )
 from marin.processing.classification.deduplication.fuzzy_dups import (
+    FUZZY_DUPS_ATTR_DATA_VERSION,
     FuzzyDupsAttrData,
     compute_fuzzy_dups_attrs,
 )
@@ -89,7 +90,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
     deduped = StepSpec(
         name="datakit-tier2-skewed-smoke/fuzzy_dups",
         deps=[minhash],
-        hash_attrs={"cc_max_iterations": 3},
+        hash_attrs={"artifact_version": FUZZY_DUPS_ATTR_DATA_VERSION, "cc_max_iterations": 3},
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(minhash.output_path, MinHashAttrData)],
             output_path=output_path,
@@ -109,9 +110,9 @@ def build_steps(run_id: str) -> list[StepSpec]:
             filters=[
                 FilterConfig(
                     type=FilterType.KEEP_DOC,
-                    attribute_path=read_artifact(deduped.output_path, FuzzyDupsAttrData)
-                    .sources[read_artifact(normalized.output_path, NormalizedData).main_output_dir]
-                    .attr_dir,
+                    attribute_path=read_artifact(deduped.output_path, FuzzyDupsAttrData).attr_dir_for_source(
+                        read_artifact(normalized.output_path, NormalizedData).main_output_dir
+                    ),
                     name="is_cluster_canonical",
                     attribute_filetype="parquet",
                     keep_if_missing=True,

--- a/lib/marin/src/marin/datakit/copartitioned.py
+++ b/lib/marin/src/marin/datakit/copartitioned.py
@@ -1,0 +1,73 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Co-partitioned input and output shard layout for Datakit stages."""
+
+import dataclasses
+import os
+from collections.abc import Sequence
+
+from rigging.filesystem import StoragePath, prefix_join
+
+
+@dataclasses.dataclass(frozen=True)
+class CopartitionedSource:
+    """One source directory and its stable identity."""
+
+    source_key: str
+    input_dir: str
+
+
+@dataclasses.dataclass(frozen=True)
+class CopartitionedShard:
+    """One input shard and its matching attribute output shard."""
+
+    file_idx: int
+    input_path: str
+    source_key: str
+    source_tag: str
+    basename: str
+    output_path: str
+
+
+def build_copartitioned_shards(
+    *,
+    sources: Sequence[CopartitionedSource],
+    output_path: str,
+) -> tuple[list[CopartitionedShard], dict[str, str]]:
+    """Build a deterministic, co-partitioned shard layout.
+
+    Source sequence order controls global file priority. Source tags use
+    sorted source keys, so output directories do not depend on input order.
+    """
+    source_keys = [source.source_key for source in sources]
+    if len(source_keys) != len(set(source_keys)):
+        raise ValueError("sources contains duplicate source keys")
+
+    source_tags = {source_key: f"source_{source_rank:03d}" for source_rank, source_key in enumerate(sorted(source_keys))}
+    attr_dirs = {
+        source_key: prefix_join(output_path, f"outputs/{source_tag}") for source_key, source_tag in source_tags.items()
+    }
+
+    shards: list[CopartitionedShard] = []
+    for source in sources:
+        source_key = source.source_key
+        input_dir = source.input_dir
+        input_paths = sorted(StoragePath(prefix_join(input_dir, "*.parquet")).glob(), key=str)
+        if not input_paths:
+            raise FileNotFoundError(f"No Parquet files found under {input_dir}")
+
+        for input_path in input_paths:
+            basename = os.path.basename(str(input_path))
+            shards.append(
+                CopartitionedShard(
+                    file_idx=len(shards),
+                    input_path=str(input_path),
+                    source_key=source_key,
+                    source_tag=source_tags[source_key],
+                    basename=basename,
+                    output_path=prefix_join(attr_dirs[source_key], basename),
+                )
+            )
+
+    return shards, attr_dirs

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -27,7 +27,7 @@ from typing import Any
 import dupekit
 import pyarrow as pa
 from fray.types import ResourceConfig
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationInfo, field_serializer, model_validator
 from rigging.filesystem import StoragePath, prefix_join, url_to_fs
 from zephyr import counters
 from zephyr.dataset import Dataset, ShardInfo
@@ -36,6 +36,8 @@ from zephyr.readers import SUPPORTED_EXTENSIONS, load_file
 from zephyr.writers import ThreadedBatchWriter, write_parquet_file
 
 from marin.datakit import partition_filename
+from marin.datakit.source_key import datakit_artifact_path, datakit_source_path
+from marin.execution.artifact import ARTIFACT_LOAD_CONTEXT_KEY
 from marin.execution.step_spec import StepSpec
 
 logger = logging.getLogger(__name__)
@@ -54,6 +56,7 @@ COMPACTED_WHITESPACE_COUNTER = "datakit_normalize_compacted_whitespace"
 # Default Zephyr worker cap. Sized well above Zephyr's own default (128) because
 # a single normalize spans thousands of shards over very large staged dumps.
 DEFAULT_MAX_WORKERS = 1024
+NORMALIZED_DATA_VERSION = "v2"
 
 
 class DedupMode(StrEnum):
@@ -76,14 +79,39 @@ class NormalizedData(BaseModel):
 
     Attributes:
         main_output_dir: Directory containing the main output Parquet files.
-        dup_output_dir: Directory containing the duplicate side output Parquet files.
+        dup_output_dir: Directory containing the duplicate side output Parquet
+            files. A v2 artifact stores both directories relative to
+            ``MARIN_PREFIX`` when they are under the active prefix.
         counters: Aggregated zephyr counters.
     """
 
-    version: str = "v1"
+    version: str = NORMALIZED_DATA_VERSION
     main_output_dir: str
     dup_output_dir: str
     counters: dict[str, int | float]
+
+    @model_validator(mode="before")
+    @classmethod
+    def _resolve_artifact_paths(cls, value: object, info: ValidationInfo) -> object:
+        if not info.context or not info.context.get(ARTIFACT_LOAD_CONTEXT_KEY):
+            return value
+        if not isinstance(value, dict):
+            return value
+
+        version = value.get("version", "v1")
+        if version not in ("v1", NORMALIZED_DATA_VERSION):
+            raise ValueError(f"Unsupported NormalizedData version: {version!r}")
+
+        loaded = dict(value)
+        if version == NORMALIZED_DATA_VERSION:
+            loaded["main_output_dir"] = datakit_source_path(loaded["main_output_dir"])
+            loaded["dup_output_dir"] = datakit_source_path(loaded["dup_output_dir"])
+        loaded["version"] = NORMALIZED_DATA_VERSION
+        return loaded
+
+    @field_serializer("main_output_dir", "dup_output_dir", when_used="json")
+    def _serialize_output_dir(self, value: str) -> str:
+        return datakit_artifact_path(value)
 
 
 def generate_id(text: str) -> str:

--- a/lib/marin/src/marin/datakit/source_key.py
+++ b/lib/marin/src/marin/datakit/source_key.py
@@ -3,14 +3,16 @@
 
 """Stable source identity for Datakit artifacts."""
 
-from rigging.filesystem import StoragePath, StoreType, data_buckets, marin_prefix
+from rigging.filesystem import StoragePath, StoreType, data_buckets, marin_prefix, prefix_join
 
 
 def _marin_data_prefixes() -> list[StoragePath]:
     prefixes = {marin_prefix()}
     for bucket in data_buckets().values():
-        scheme = "gs" if bucket.store == StoreType.GCS else "s3"
-        prefixes.add(f"{scheme}://{bucket.name}/marin")
+        if bucket.store == StoreType.GCS:
+            prefixes.add(f"gs://{bucket.name}")
+        else:
+            prefixes.add(f"s3://{bucket.name}/marin")
     return sorted((StoragePath(prefix) for prefix in prefixes), key=lambda prefix: len(prefix.segments), reverse=True)
 
 
@@ -33,3 +35,30 @@ def datakit_source_key(source_path: str) -> str:
     if path.scheme in ("gs", "s3"):
         raise ValueError(f"Datakit source path is not under a configured Marin data prefix: {source_path!r}")
     return str(path)
+
+
+def datakit_source_path(source_path_or_key: str) -> str:
+    """Resolve a relative Datakit source key against the active ``MARIN_PREFIX``."""
+    if not source_path_or_key:
+        return source_path_or_key
+
+    path = StoragePath(source_path_or_key)
+    if path.scheme or source_path_or_key.startswith("/"):
+        return str(path)
+    return prefix_join(marin_prefix(), source_path_or_key)
+
+
+def datakit_artifact_path(source_path: str) -> str:
+    """Remove the active ``MARIN_PREFIX`` from a serialized Datakit path."""
+    if not source_path:
+        return source_path
+
+    path = StoragePath(source_path)
+    prefix = StoragePath(marin_prefix())
+    try:
+        relative = path.relative_to(prefix)
+    except ValueError:
+        return str(path)
+    if not relative:
+        raise ValueError(f"Datakit artifact path must be below MARIN_PREFIX: {source_path!r}")
+    return relative

--- a/lib/marin/src/marin/datakit/source_key.py
+++ b/lib/marin/src/marin/datakit/source_key.py
@@ -1,0 +1,35 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stable source identity for Datakit artifacts."""
+
+from rigging.filesystem import StoragePath, StoreType, data_buckets, marin_prefix
+
+
+def _marin_data_prefixes() -> list[StoragePath]:
+    prefixes = {marin_prefix()}
+    for bucket in data_buckets().values():
+        scheme = "gs" if bucket.store == StoreType.GCS else "s3"
+        prefixes.add(f"{scheme}://{bucket.name}/marin")
+    return sorted((StoragePath(prefix) for prefix in prefixes), key=lambda prefix: len(prefix.segments), reverse=True)
+
+
+def datakit_source_key(source_path: str) -> str:
+    """Remove ``MARIN_PREFIX`` from a materialized Datakit source path.
+
+    The function recognizes every configured Marin data bucket, not only the
+    active region. It also removes a local ``MARIN_PREFIX``. Other local paths
+    and non-object-store URLs stay unchanged.
+    """
+    path = StoragePath(source_path)
+    for prefix in _marin_data_prefixes():
+        try:
+            relative = path.relative_to(prefix)
+        except ValueError:
+            continue
+        if not relative:
+            raise ValueError(f"Datakit source path must be below a Marin data prefix: {source_path!r}")
+        return relative
+    if path.scheme in ("gs", "s3"):
+        raise ValueError(f"Datakit source path is not under a configured Marin data prefix: {source_path!r}")
+    return str(path)

--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -66,6 +66,7 @@ FINGERPRINT_KEY = "fingerprint"
 VERSION_KEY = "version"
 RESULT_TYPE_KEY = "result_type"
 EXPECTED_FINGERPRINT_KEY = "expected_fingerprint"
+ARTIFACT_LOAD_CONTEXT_KEY = "artifact_load"
 
 
 class FingerprintMismatchError(Exception):
@@ -324,7 +325,7 @@ def read_artifact(output_path: str, schema: type[M]) -> M:
     output_path = _resolved(output_path)
     record = read_record(output_path)
     if record is not None and record.result is not None:
-        return cast(M, schema.model_validate(record.result))
+        return cast(M, schema.model_validate(record.result, context={ARTIFACT_LOAD_CONTEXT_KEY: True}))
     raise FileNotFoundError(f"no artifact payload at {output_path}")
 
 

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
@@ -32,19 +32,18 @@ artifacts produces fresh markers without re-reading any source text.
 """
 
 import logging
-import os
 from collections.abc import Iterator
-from typing import Any
 
 from fray.types import ResourceConfig
 from pydantic import BaseModel
-from rigging.filesystem import StoragePath
 from zephyr import counters
 from zephyr.dataset import Dataset
 from zephyr.execution import MAX_WORKERS_PER_JOB, ZephyrContext
 from zephyr.worker_context import zephyr_worker_ctx
 from zephyr.writers import write_parquet_file
 
+from marin.datakit.copartitioned import CopartitionedShard, CopartitionedSource, build_copartitioned_shards
+from marin.datakit.source_key import datakit_source_key
 from marin.execution.artifact import read_artifact
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.deduplication.connected_components import connected_components
@@ -52,6 +51,7 @@ from marin.processing.classification.deduplication.dedup_commons import _load_ba
 from marin.processing.classification.deduplication.fuzzy_minhash import MinHashAttrData, MinHashParams
 
 logger = logging.getLogger(__name__)
+FUZZY_DUPS_ATTR_DATA_VERSION = 2
 
 
 class FuzzyDupsPerSource(BaseModel):
@@ -75,15 +75,23 @@ class FuzzyDupsAttrData(BaseModel):
     Attributes:
         version: Schema version of this artifact.
         params: MinHash params; equal to every input's params.
-        sources: Mapping from each input's ``MinHashAttrData.source_main_dir``
+        sources: Mapping from each input's ``MinHashAttrData.source_key``
             to its per-source attr output entry.
         counters: Aggregated zephyr counters across all sources.
     """
 
-    version: str = "v1"
+    version: str = f"v{FUZZY_DUPS_ATTR_DATA_VERSION}"
     params: MinHashParams
     sources: dict[str, FuzzyDupsPerSource]
     counters: dict[str, int | float]
+
+    def attr_dir_for_source(self, source_path: str) -> str:
+        """Return the attribute directory for a materialized source path."""
+        source_key = datakit_source_key(source_path)
+        entry = self.sources.get(source_key)
+        if entry is None:
+            raise KeyError(f"Fuzzy duplicate attributes have no entry for source_key={source_key!r}")
+        return entry.attr_dir
 
 
 def _validate_inputs(inputs: list[MinHashAttrData]) -> MinHashParams:
@@ -102,48 +110,15 @@ def _validate_inputs(inputs: list[MinHashAttrData]) -> MinHashParams:
 
     seen: dict[str, int] = {}
     for i, m in enumerate(inputs):
-        if m.source_main_dir in seen:
+        if m.source_key in seen:
             raise ValueError(
-                f"Duplicate source_main_dir in inputs: inputs[{seen[m.source_main_dir]}] and "
-                f"inputs[{i}] both point to {m.source_main_dir!r}. Each source must be "
+                f"Duplicate source_key in inputs: inputs[{seen[m.source_key]}] and "
+                f"inputs[{i}] both point to {m.source_key!r}. Each source must be "
                 "represented at most once so its output attr tree is unambiguous."
             )
-        seen[m.source_main_dir] = i
+        seen[m.source_key] = i
 
     return head
-
-
-def _build_shard_index(inputs: list[MinHashAttrData]) -> tuple[list[dict[str, Any]], dict[str, str]]:
-    """Enumerate every source shard across *inputs* and assign a global file_idx.
-
-    Returns:
-        (entries, source_tag_for_input) where ``entries[file_idx]`` holds
-        ``{attr_path, source_main_dir, source_tag, basename}`` and
-        ``source_tag_for_input[source_main_dir] = "source_NNN"``.
-    """
-    # Sort inputs by source_main_dir so source_tags are deterministic regardless
-    # of the order callers happen to pass them in.
-    ordered = sorted(enumerate(inputs), key=lambda iv: iv[1].source_main_dir)
-    source_tag: dict[str, str] = {}
-    for new_idx, (_, m) in enumerate(ordered):
-        source_tag[m.source_main_dir] = f"source_{new_idx:03d}"
-
-    entries: list[dict[str, Any]] = []
-    for m in inputs:
-        attr_shards = sorted(str(shard) for shard in StoragePath(f"{m.attr_dir.rstrip('/')}/*.parquet").glob())
-        if not attr_shards:
-            raise FileNotFoundError(f"No attr parquet shards under {m.attr_dir}")
-        for attr_path in attr_shards:
-            entries.append(
-                {
-                    "file_idx": len(entries),
-                    "attr_path": attr_path,
-                    "source_main_dir": m.source_main_dir,
-                    "source_tag": source_tag[m.source_main_dir],
-                    "basename": os.path.basename(attr_path),
-                }
-            )
-    return entries, source_tag
 
 
 # Separator between the per-source CC tag and the original content-hash id.
@@ -170,18 +145,18 @@ def _strip_cc_prefix(record_id: str) -> str:
     return record_id.split(_CC_ID_SEP, 1)[1]
 
 
-def _emit_bucket_records(entries: list[dict[str, Any]]) -> Iterator[dict]:
+def _emit_bucket_records(entries: list[CopartitionedShard]) -> Iterator[dict]:
     """For each (bucket, id) pair across all attr shards in *entries*, emit a routing record."""
     for entry in entries:
-        for batch in _load_batches(entry["attr_path"], columns=["id", "buckets"]):
+        for batch in _load_batches(entry.input_path, columns=["id", "buckets"]):
             ids = batch["id"]
             buckets_col = batch["buckets"]
             for doc_id, doc_buckets in zip(ids, buckets_col, strict=True):
                 if not doc_buckets.is_valid:
                     continue
-                cc_id = _cc_id(entry["source_tag"], doc_id.as_py())
+                cc_id = _cc_id(entry.source_tag, doc_id.as_py())
                 for b in doc_buckets.as_py():
-                    yield {"bucket": str(b), "id": cc_id, "file_idx": entry["file_idx"]}
+                    yield {"bucket": str(b), "id": cc_id, "file_idx": entry.file_idx}
 
 
 # Key under which ``entries`` is staged via ``ZephyrContext.put`` for the
@@ -193,7 +168,7 @@ def _emit_bucket_records(entries: list[dict[str, Any]]) -> Iterator[dict]:
 _SHARED_ENTRIES_KEY = "fuzzy_dups_entries"
 
 
-def _make_per_shard_writer(output_path: str, counter_prefix: str):
+def _make_per_shard_writer(counter_prefix: str):
     """Return a group_by reducer that writes per-shard cluster-annotation parquet files.
 
     Skips singletons entirely. For every non-singleton cluster member, writes
@@ -206,9 +181,8 @@ def _make_per_shard_writer(output_path: str, counter_prefix: str):
     """
 
     def aggregate(file_idx: int, records: Iterator[dict]) -> dict:
-        entries = zephyr_worker_ctx().get_shared(_SHARED_ENTRIES_KEY)
+        entries: list[CopartitionedShard] = zephyr_worker_ctx().get_shared(_SHARED_ENTRIES_KEY)
         entry = entries[file_idx]
-        out_path = f"{output_path}/outputs/{entry['source_tag']}/{entry['basename']}"
 
         cluster_members = 0
         canonicals = 0
@@ -232,11 +206,11 @@ def _make_per_shard_writer(output_path: str, counter_prefix: str):
                     },
                 }
 
-        result = write_parquet_file(cluster_member_rows(), out_path)
+        result = write_parquet_file(cluster_member_rows(), entry.output_path)
         return {
             **result,
             "file_idx": file_idx,
-            "source_tag": entry["source_tag"],
+            "source_tag": entry.source_tag,
             "cluster_members": cluster_members,
             "canonicals": canonicals,
         }
@@ -300,7 +274,11 @@ def compute_fuzzy_dups_attrs(
         FileNotFoundError: If any input ``attr_dir`` is missing parquet shards.
     """
     params = _validate_inputs(inputs)
-    entries, source_tag = _build_shard_index(inputs)
+    sources = [CopartitionedSource(source_key=minhash.source_key, input_dir=minhash.attr_dir) for minhash in inputs]
+    entries, attr_dirs = build_copartitioned_shards(
+        sources=sources,
+        output_path=output_path,
+    )
 
     logger.info(
         "Computing fuzzy dups for %d inputs (%d total shards) → %s, params=%s",
@@ -327,7 +305,7 @@ def compute_fuzzy_dups_attrs(
     # sequentially and emits bucket records; file_idx is preserved on the entry
     # itself, not by enumeration order, so grouping is safe.
     n_groups = min(max_parallelism, len(entries))
-    entry_groups: list[list[dict[str, Any]]] = [[] for _ in range(n_groups)]
+    entry_groups: list[list[CopartitionedShard]] = [[] for _ in range(n_groups)]
     for i, entry in enumerate(entries):
         entry_groups[i % n_groups].append(entry)
 
@@ -355,7 +333,7 @@ def compute_fuzzy_dups_attrs(
         )
 
     ctx.put(_SHARED_ENTRIES_KEY, entries)
-    aggregator = _make_per_shard_writer(output_path, counter_prefix="dedup/fuzzy/document")
+    aggregator = _make_per_shard_writer(counter_prefix="dedup/fuzzy/document")
 
     # CC's Hash-to-Min guarantees component_id == min(id_norm) across a cluster,
     # so `component_id == id_norm` cheaply identifies the natural canonical.
@@ -384,9 +362,7 @@ def compute_fuzzy_dups_attrs(
     shard_results = outcome.results
 
     # Aggregate per-source counters across shards for the final artifact.
-    sources: dict[str, FuzzyDupsPerSource] = {
-        src_dir: FuzzyDupsPerSource(attr_dir=f"{output_path}/outputs/{tag}") for src_dir, tag in source_tag.items()
-    }
+    sources = {source_key: FuzzyDupsPerSource(attr_dir=attr_dir) for source_key, attr_dir in attr_dirs.items()}
 
     cluster_members = sum(r["cluster_members"] for r in shard_results)
     clusters = sum(r["canonicals"] for r in shard_results)  # one canonical per cluster
@@ -426,6 +402,6 @@ def compute_fuzzy_dups_attrs_step(
             worker_resources=worker_resources,
             coordinator_resources=coordinator_resources,
         ),
-        hash_attrs={"cc_max_iterations": cc_max_iterations},
+        hash_attrs={"artifact_version": FUZZY_DUPS_ATTR_DATA_VERSION, "cc_max_iterations": cc_max_iterations},
         override_output_path=override_output_path,
     )

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
@@ -28,11 +28,13 @@ from zephyr.dataset import Dataset
 from zephyr.execution import ZephyrContext
 
 from marin.datakit.normalize import NormalizedData
+from marin.datakit.source_key import datakit_source_key
 from marin.execution.artifact import read_artifact
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.deduplication.dedup_commons import _load_batches
 
 logger = logging.getLogger(__name__)
+MINHASH_ATTR_DATA_VERSION = 3
 
 
 class MinHashParams(BaseModel):
@@ -65,17 +67,17 @@ class MinHashAttrData(BaseModel):
     Attributes:
         version: Schema version of this artifact.
         params: MinHash params; downstream jobs require these to match.
-        source_main_dir: Source ``NormalizedData.main_output_dir`` whose shards
-            this dataset mirrors 1:1.
+        source_key: Prefix-relative identity of the ``NormalizedData.main_output_dir``
+            whose shards this dataset mirrors 1:1.
         attr_dir: Directory containing per-shard attr Parquet files. Filenames
             mirror the source shards. Each row has ``id: str`` and
             ``buckets: list[str]``.
         counters: Aggregated zephyr counters.
     """
 
-    version: str = "v2"
+    version: str = f"v{MINHASH_ATTR_DATA_VERSION}"
     params: MinHashParams
-    source_main_dir: str
+    source_key: str
     attr_dir: str
     counters: dict[str, int | float]
 
@@ -247,7 +249,7 @@ def compute_minhash_attrs(
 
     return MinHashAttrData(
         params=params,
-        source_main_dir=source.main_output_dir,
+        source_key=datakit_source_key(source.main_output_dir),
         attr_dir=attr_dir,
         counters=dict(outcome.counters),
     )
@@ -282,6 +284,7 @@ def compute_minhash_attrs_step(
             max_workers=max_workers,
         ),
         hash_attrs={
+            "artifact_version": MINHASH_ATTR_DATA_VERSION,
             "num_perms": num_perms,
             "num_bands": num_bands,
             "ngram_size": ngram_size,

--- a/lib/marin/src/marin/processing/tokenize/attributes.py
+++ b/lib/marin/src/marin/processing/tokenize/attributes.py
@@ -37,11 +37,13 @@ from zephyr.execution import ZephyrContext
 from zephyr.readers import load_file
 
 from marin.datakit.normalize import NormalizedData
+from marin.datakit.source_key import datakit_source_key
 from marin.execution.artifact import read_artifact
 from marin.execution.step_spec import StepSpec
 from marin.processing.tokenize._core import tokenize_pipeline
 
 logger = logging.getLogger(__name__)
+TOKENIZED_ATTR_DATA_VERSION = 2
 
 
 class TokenizedAttrData(BaseModel):
@@ -60,18 +62,17 @@ class TokenizedAttrData(BaseModel):
         version: Schema version.
         output_dirs: Map from split name (e.g. ``"train"``, ``"validation"``) to the
             directory containing that split's attribute parquet shards.
-        source_main_dirs: Map from split name to the source ``NormalizedData.main_output_dir``
-            whose shards this dataset mirrors. Used by consumers to verify
-            co-partitioning.
+        source_keys: Map from split name to the prefix-relative identity of the
+            ``NormalizedData.main_output_dir`` whose shards this dataset mirrors.
         tokenizer: Tokenizer name/path used (informational; consumers should re-verify
             against any other inputs they combine this with).
         tokenizer_backend: Tokenizer backend, as ``TokenizerBackend.value``.
         counters: Aggregated zephyr counters per split.
     """
 
-    version: str = "v1"
+    version: str = f"v{TOKENIZED_ATTR_DATA_VERSION}"
     output_dirs: dict[str, str]
-    source_main_dirs: dict[str, str]
+    source_keys: dict[str, str]
     tokenizer: str
     tokenizer_backend: str
     counters: dict[str, dict[str, int | float]]
@@ -203,7 +204,7 @@ def tokenize_attributes(config: TokenizeAttributesConfig) -> TokenizedAttrData:
         source linkage, tokenizer config, and counters.
     """
     output_dirs: dict[str, str] = {}
-    source_main_dirs: dict[str, str] = {}
+    source_keys: dict[str, str] = {}
     counters: dict[str, dict[str, int | float]] = {}
 
     splits: list[tuple[str, NormalizedData]] = []
@@ -215,12 +216,12 @@ def tokenize_attributes(config: TokenizeAttributesConfig) -> TokenizedAttrData:
     for split, source in splits:
         split_dir, split_counters = _process_split(source=source, split=split, config=config)
         output_dirs[split] = split_dir
-        source_main_dirs[split] = source.main_output_dir
+        source_keys[split] = datakit_source_key(source.main_output_dir)
         counters[split] = split_counters
 
     return TokenizedAttrData(
         output_dirs=output_dirs,
-        source_main_dirs=source_main_dirs,
+        source_keys=source_keys,
         tokenizer=config.tokenizer,
         tokenizer_backend=config.tokenizer_backend.value,
         counters=counters,
@@ -293,6 +294,7 @@ def tokenize_attributes_step(
         return tokenize_attributes(TokenizeAttributesConfig(**kwargs))
 
     hash_attrs: dict = {
+        "artifact_version": TOKENIZED_ATTR_DATA_VERSION,
         "tokenizer": tokenizer,
         "tokenizer_backend": tokenizer_backend.value,
         "format": repr(fmt),

--- a/tests/datakit/test_datakit_store.py
+++ b/tests/datakit/test_datakit_store.py
@@ -4,7 +4,7 @@
 """Behavioral smoke for the Datakit clustered store.
 
 Builds tiny synthetic co-partitioned inputs (tokenize / decon / cluster /
-quality / dedup) on the local filesystem, runs ``build_clustered_store``
+quality / exact dedup / fuzzy dedup) on the local filesystem, runs ``build_clustered_store``
 through a local Zephyr context, and checks the externally observable contract:
 the right docs survive filtering, land in the right ``(cluster, quality)``
 bucket, round-trip out of the materialized caches, and hot-bucket subsharding
@@ -26,6 +26,7 @@ from zephyr.shard_keys import deterministic_hash
 
 from experiments.datakit.cluster.domain.v0.assign import AssignmentAttrData
 from experiments.datakit.cluster.quality.fast_transformer.artifact import QualityScores
+from experiments.datakit.global_exact_dedup import ExactDupsPerSource, GlobalExactDedupData
 from experiments.datakit.store.datakit_store import ClusteredStoreData, build_clustered_store
 
 CLUSTER_VIEW = 2  # cluster column "cluster_2", clusters {0, 1}
@@ -49,7 +50,7 @@ SHARD0: list[_Doc] = [
 SHARD1: list[_Doc] = [
     ("d4", 0, 0, False, None, 104, 4),  # -> (0, 0)
     ("d5", 1, 2, False, False, 905, 8),  # non-canonical -> dropped
-    ("d6", 1, 4, False, None, 106, 6),  # -> (1, 4)
+    ("d6", 1, 4, False, None, 106, 6),  # exact duplicate -> dropped
     ("d7", 0, 4, False, None, 107, 7),  # -> (0, 4)
 ]
 
@@ -58,9 +59,9 @@ EXPECTED: dict[tuple[int, int], dict[int, int]] = {
     (0, 0): {100: 3, 104: 4},
     (0, 4): {101: 5, 107: 7},
     (1, 2): {103: 2},
-    (1, 4): {106: 6},
 }
-DROPPED_TOKEN_VALUES = {902, 905}
+EXACT_DUPLICATES = {"d6"}
+DROPPED_TOKEN_VALUES = {902, 905, 106}
 
 
 def _write_parquet(path: str, table: pa.Table) -> None:
@@ -68,7 +69,7 @@ def _write_parquet(path: str, table: pa.Table) -> None:
 
 
 def _write_shard(dirs: dict[str, str], basename: str, docs: list[_Doc]) -> None:
-    """Write one shard's five co-partitioned parquets from a doc list (same row order)."""
+    """Write one shard's co-partitioned Parquet inputs in the same row order."""
     ids = [d[0] for d in docs]
     _write_parquet(
         f"{dirs['tokenize']}/{basename}",
@@ -94,6 +95,22 @@ def _write_shard(dirs: dict[str, str], basename: str, docs: list[_Doc]) -> None:
             }
         ),
     )
+    _write_parquet(
+        f"{dirs['exact_dedup']}/{basename}",
+        pa.Table.from_pylist(
+            [{"id": doc_id, "attributes": {"dup_doc": True}} for doc_id in ids if doc_id in EXACT_DUPLICATES],
+            schema=pa.schema(
+                [
+                    pa.field("id", pa.string(), nullable=False),
+                    pa.field(
+                        "attributes",
+                        pa.struct([pa.field("dup_doc", pa.bool_(), nullable=False)]),
+                        nullable=False,
+                    ),
+                ]
+            ),
+        ),
+    )
     # Dedup is sparse: only non-singleton docs (canonical True/False) appear.
     marked = [(d[0], d[4]) for d in docs if d[4] is not None]
     if marked:
@@ -109,9 +126,9 @@ def _write_shard(dirs: dict[str, str], basename: str, docs: list[_Doc]) -> None:
 
 
 def _build_inputs(tmp_path):
-    """Materialize the synthetic inputs and return the five typed artifacts."""
+    """Materialize the synthetic inputs and return the typed artifacts."""
     main_dir = str(tmp_path / "src")
-    dirs = {k: str(tmp_path / k) for k in ("tokenize", "decon", "cluster", "quality", "dedup")}
+    dirs = {k: str(tmp_path / k) for k in ("tokenize", "decon", "cluster", "quality", "exact_dedup", "dedup")}
     tok_train = f"{dirs['tokenize']}/{SPLIT}"
     for d in (*dirs.values(), tok_train):
         os.makedirs(d, exist_ok=True)
@@ -123,7 +140,7 @@ def _build_inputs(tmp_path):
     tokenize = {
         "src": TokenizedAttrData(
             output_dirs={SPLIT: tok_train},
-            source_main_dirs={SPLIT: main_dir},
+            source_keys={SPLIT: main_dir},
             tokenizer="dummy",
             tokenizer_backend="huggingface",
             counters={},
@@ -141,7 +158,7 @@ def _build_inputs(tmp_path):
     cluster_assign = {
         "src": AssignmentAttrData(
             output_dir=dirs["cluster"],
-            source_main_dir=main_dir,
+            source_key=main_dir,
             embedding_output_dir="",
             k_train=CLUSTER_VIEW,
             k_views=[],
@@ -162,7 +179,15 @@ def _build_inputs(tmp_path):
         sources={main_dir: FuzzyDupsPerSource(attr_dir=dirs["dedup"])},
         counters={},
     )
-    return tokenize, decontam, cluster_assign, quality, dedup
+    exact_dedup = GlobalExactDedupData(
+        sources={
+            main_dir: ExactDupsPerSource(
+                attr_dir=dirs["exact_dedup"],
+            )
+        },
+        counters={},
+    )
+    return tokenize, decontam, cluster_assign, quality, exact_dedup, dedup
 
 
 def _read_bucket_tokens(bucket_root: str) -> list[np.ndarray]:
@@ -175,7 +200,7 @@ def _read_bucket_tokens(bucket_root: str) -> list[np.ndarray]:
 
 
 def test_store_filters_routes_and_roundtrips(tmp_path):
-    tokenize, decontam, cluster_assign, quality, dedup = _build_inputs(tmp_path)
+    tokenize, decontam, cluster_assign, quality, exact_dedup, dedup = _build_inputs(tmp_path)
     output_path = str(tmp_path / "store")
 
     artifact = build_clustered_store(
@@ -183,6 +208,7 @@ def test_store_filters_routes_and_roundtrips(tmp_path):
         decontam=decontam,
         cluster_assign=cluster_assign,
         quality=quality,
+        exact_dedup=exact_dedup,
         dedup=dedup,
         output_path=output_path,
         cluster_view=CLUSTER_VIEW,
@@ -210,9 +236,10 @@ def test_store_filters_routes_and_roundtrips(tmp_path):
             assert len(set(arr.tolist())) == 1  # each doc is a run of its unique token value
             all_tokens.extend(arr.tolist())
 
-    assert DROPPED_TOKEN_VALUES.isdisjoint(all_tokens), "contaminated + non-canonical docs must be absent"
+    assert DROPPED_TOKEN_VALUES.isdisjoint(all_tokens), "filtered docs must be absent"
     assert artifact.counters["datakit_store/records_in"] == len(SHARD0) + len(SHARD1)
     assert artifact.counters["datakit_store/contaminated_dropped"] == 1
+    assert artifact.counters["datakit_store/exact_duplicate_dropped"] == 1
     assert artifact.counters["datakit_store/dedup_noncanonical_dropped"] == 1
     assert artifact.counters["datakit_store/records_out"] == sum(len(docs) for docs in EXPECTED.values())
     assert artifact.counters["datakit_store/tokens_out"] == sum(
@@ -221,7 +248,7 @@ def test_store_filters_routes_and_roundtrips(tmp_path):
 
 
 def test_store_subshards_hot_bucket_without_data_loss(tmp_path):
-    tokenize, decontam, cluster_assign, quality, dedup = _build_inputs(tmp_path)
+    tokenize, decontam, cluster_assign, quality, exact_dedup, dedup = _build_inputs(tmp_path)
     output_path = str(tmp_path / "store_split")
 
     # Force bucket (0, 4) to split 4 ways; every other bucket stays at 1 sub.
@@ -236,6 +263,7 @@ def test_store_subshards_hot_bucket_without_data_loss(tmp_path):
         decontam=decontam,
         cluster_assign=cluster_assign,
         quality=quality,
+        exact_dedup=exact_dedup,
         dedup=dedup,
         output_path=output_path,
         cluster_view=CLUSTER_VIEW,

--- a/tests/datakit/test_datakit_store.py
+++ b/tests/datakit/test_datakit_store.py
@@ -46,22 +46,26 @@ SHARD0: list[_Doc] = [
     ("d1", 0, 4, False, None, 101, 5),  # -> (0, 4)
     ("d2", 1, 2, True, None, 902, 9),  # contaminated -> dropped
     ("d3", 1, 2, False, True, 103, 2),  # canonical -> (1, 2)
+    ("d6", 1, 4, False, False, 906, 6),  # exact canonical, fuzzy non-canonical -> dropped
+    ("d8", 0, 0, False, None, 108, 3),  # exact canonical -> (0, 0)
 ]
 SHARD1: list[_Doc] = [
     ("d4", 0, 0, False, None, 104, 4),  # -> (0, 0)
     ("d5", 1, 2, False, False, 905, 8),  # non-canonical -> dropped
-    ("d6", 1, 4, False, None, 106, 6),  # exact duplicate -> dropped
+    ("d6", 1, 4, False, True, 106, 6),  # exact duplicate, fuzzy canonical -> (1, 4)
     ("d7", 0, 4, False, None, 107, 7),  # -> (0, 4)
+    ("d8", 0, 0, False, None, 908, 3),  # exact duplicate without fuzzy attrs -> dropped
 ]
 
 # Expected surviving buckets: {(cluster, quality): {token_value: length}}.
 EXPECTED: dict[tuple[int, int], dict[int, int]] = {
-    (0, 0): {100: 3, 104: 4},
+    (0, 0): {100: 3, 104: 4, 108: 3},
     (0, 4): {101: 5, 107: 7},
     (1, 2): {103: 2},
+    (1, 4): {106: 6},
 }
-EXACT_DUPLICATES = {"d6"}
-DROPPED_TOKEN_VALUES = {902, 905, 106}
+EXACT_DUPLICATES = {("part-00001-of-00002.parquet", "d6"), ("part-00001-of-00002.parquet", "d8")}
+DROPPED_TOKEN_VALUES = {902, 905, 906, 908}
 
 
 def _write_parquet(path: str, table: pa.Table) -> None:
@@ -95,7 +99,7 @@ def _write_shard(dirs: dict[str, str], basename: str, docs: list[_Doc]) -> None:
             }
         ),
     )
-    exact_duplicates = [doc_id for doc_id in ids if doc_id in EXACT_DUPLICATES]
+    exact_duplicates = [doc_id for doc_id in ids if (basename, doc_id) in EXACT_DUPLICATES]
     if exact_duplicates:
         _write_parquet(
             f"{dirs['exact_dedup']}/{basename}",
@@ -242,7 +246,7 @@ def test_store_filters_routes_and_roundtrips(tmp_path):
     assert artifact.counters["datakit_store/records_in"] == len(SHARD0) + len(SHARD1)
     assert artifact.counters["datakit_store/contaminated_dropped"] == 1
     assert artifact.counters["datakit_store/exact_duplicate_dropped"] == 1
-    assert artifact.counters["datakit_store/dedup_noncanonical_dropped"] == 1
+    assert artifact.counters["datakit_store/dedup_noncanonical_dropped"] == 2
     assert artifact.counters["datakit_store/records_out"] == sum(len(docs) for docs in EXPECTED.values())
     assert artifact.counters["datakit_store/tokens_out"] == sum(
         length for docs in EXPECTED.values() for length in docs.values()

--- a/tests/datakit/test_datakit_store.py
+++ b/tests/datakit/test_datakit_store.py
@@ -95,22 +95,24 @@ def _write_shard(dirs: dict[str, str], basename: str, docs: list[_Doc]) -> None:
             }
         ),
     )
-    _write_parquet(
-        f"{dirs['exact_dedup']}/{basename}",
-        pa.Table.from_pylist(
-            [{"id": doc_id, "attributes": {"dup_doc": True}} for doc_id in ids if doc_id in EXACT_DUPLICATES],
-            schema=pa.schema(
-                [
-                    pa.field("id", pa.string(), nullable=False),
-                    pa.field(
-                        "attributes",
-                        pa.struct([pa.field("dup_doc", pa.bool_(), nullable=False)]),
-                        nullable=False,
-                    ),
-                ]
+    exact_duplicates = [doc_id for doc_id in ids if doc_id in EXACT_DUPLICATES]
+    if exact_duplicates:
+        _write_parquet(
+            f"{dirs['exact_dedup']}/{basename}",
+            pa.Table.from_pylist(
+                [{"id": doc_id, "attributes": {"dup_doc": True}} for doc_id in exact_duplicates],
+                schema=pa.schema(
+                    [
+                        pa.field("id", pa.string(), nullable=False),
+                        pa.field(
+                            "attributes",
+                            pa.struct([pa.field("dup_doc", pa.bool_(), nullable=False)]),
+                            nullable=False,
+                        ),
+                    ]
+                ),
             ),
-        ),
-    )
+        )
     # Dedup is sparse: only non-singleton docs (canonical True/False) appear.
     marked = [(d[0], d[4]) for d in docs if d[4] is not None]
     if marked:

--- a/tests/datakit/test_global_exact_dedup.py
+++ b/tests/datakit/test_global_exact_dedup.py
@@ -79,26 +79,15 @@ def test_global_exact_deduplicate_writes_sparse_copartitioned_attributes(tmp_pat
     a_shards = _attribute_shards(result, source_a)
     b_shards = _attribute_shards(result, source_b)
     c_shards = _attribute_shards(result, source_c)
-    assert [path.name for path in a_shards] == ["part-00000-of-00001.parquet"]
-    assert [path.name for path in b_shards] == [
-        "part-00000-of-00002.parquet",
-        "part-00001-of-00002.parquet",
-    ]
-    assert [path.name for path in c_shards] == [
-        "part-00000-of-00002.parquet",
-        "part-00001-of-00002.parquet",
-    ]
+    assert a_shards == []
+    assert [path.name for path in b_shards] == ["part-00001-of-00002.parquet"]
+    assert c_shards == []
 
-    assert pq.read_table(a_shards[0]).to_pylist() == []
-    assert pq.read_table(b_shards[0]).to_pylist() == []
-    assert pq.read_table(b_shards[1]).to_pylist() == [
+    assert pq.read_table(b_shards[0]).to_pylist() == [
         {"id": "a-only", "attributes": {"dup_doc": True}},
         {"id": "shared", "attributes": {"dup_doc": True}},
     ]
-    assert pq.read_table(c_shards[0]).to_pylist() == []
-    assert pq.read_table(c_shards[1]).to_pylist() == []
-    for path in [*a_shards, *b_shards, *c_shards]:
-        assert pq.read_schema(path).names == ["id", "attributes"]
+    assert pq.read_schema(b_shards[0]).names == ["id", "attributes"]
 
     assert result.sources["input-a/outputs/main"].attr_dir.endswith("/outputs/source_000")
     assert result.sources["input-b/outputs/main"].attr_dir.endswith("/outputs/source_001")
@@ -125,8 +114,8 @@ def test_global_exact_deduplicate_uses_shard_order_within_source(tmp_path: Path,
     )
 
     shards = _attribute_shards(result, source)
-    assert pq.read_table(shards[0]).to_pylist() == []
-    assert pq.read_table(shards[1]).to_pylist() == [
+    assert [path.name for path in shards] == ["part-00001-of-00002.parquet"]
+    assert pq.read_table(shards[0]).to_pylist() == [
         {"id": "shared", "attributes": {"dup_doc": True}},
     ]
 

--- a/tests/datakit/test_global_exact_dedup.py
+++ b/tests/datakit/test_global_exact_dedup.py
@@ -89,9 +89,6 @@ def test_global_exact_deduplicate_writes_sparse_copartitioned_attributes(tmp_pat
     ]
     assert pq.read_schema(b_shards[0]).names == ["id", "attributes"]
 
-    assert result.sources["input-a/outputs/main"].attr_dir.endswith("/outputs/source_000")
-    assert result.sources["input-b/outputs/main"].attr_dir.endswith("/outputs/source_001")
-    assert result.sources["input-c/outputs/main"].attr_dir.endswith("/outputs/source_002")
     assert result.counters["global_exact_dedup/records_in"] == 6
     assert result.counters["global_exact_dedup/duplicate_records"] == 2
 

--- a/tests/datakit/test_global_exact_dedup.py
+++ b/tests/datakit/test_global_exact_dedup.py
@@ -1,0 +1,75 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavior tests for the Datakit global exact-dedup step."""
+
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from fray.current_client import set_current_client
+from fray.local_backend import LocalClient
+from fray.types import ResourceConfig
+from marin.datakit.normalize import NormalizedData
+
+from experiments.datakit.global_exact_dedup import global_exact_deduplicate
+
+
+@pytest.fixture(autouse=True)
+def flow_backend_ctx():
+    with set_current_client(LocalClient()):
+        yield
+
+
+def _normalized_source(root: Path, records: list[dict]) -> NormalizedData:
+    main = root / "outputs" / "main"
+    main.mkdir(parents=True)
+    pq.write_table(pa.Table.from_pylist(records), main / "part-00000-of-00001.parquet")
+    return NormalizedData(main_output_dir=str(main), dup_output_dir=str(root / "outputs" / "dups"), counters={})
+
+
+def _records(source: NormalizedData) -> list[dict]:
+    records = []
+    for path in sorted(Path(source.main_output_dir).rglob("*.parquet")):
+        records.extend(pq.read_table(path).to_pylist())
+    return records
+
+
+def test_global_exact_deduplicate_keeps_one_record_for_each_id(tmp_path: Path):
+    source_a = _normalized_source(
+        tmp_path / "input-a",
+        [
+            {"id": "a-only", "text": "A only", "a_metadata": 1},
+            {"id": "a-only", "text": "Duplicate in the canonical shard", "a_metadata": 3},
+            {"id": "shared", "text": "Canonical text", "a_metadata": 2},
+        ],
+    )
+    source_b = _normalized_source(
+        tmp_path / "input-b",
+        [
+            {"id": "b-only", "text": "B only", "b_metadata": "x"},
+            {"id": "shared", "text": "Different text with the same record ID", "b_metadata": "y"},
+        ],
+    )
+    source_c = _normalized_source(
+        tmp_path / "input-c",
+        [{"id": "c-only", "text": "C only", "c_metadata": True}],
+    )
+
+    result = global_exact_deduplicate(
+        sources={"c": source_c, "b": source_b, "a": source_a},
+        output_path=str(tmp_path / "output"),
+        worker_resources=ResourceConfig(cpu=1, ram="1g"),
+        max_workers=2,
+    )
+
+    assert _records(result.sources["a"]) == [
+        {"id": "a-only", "text": "A only", "a_metadata": 1},
+        {"id": "shared", "text": "Canonical text", "a_metadata": 2},
+    ]
+    assert _records(result.sources["b"]) == [{"id": "b-only", "text": "B only", "b_metadata": "x"}]
+    assert _records(result.sources["c"]) == [{"id": "c-only", "text": "C only", "c_metadata": True}]
+    assert result.counters["global_exact_dedup/records_in"] == 6
+    assert result.counters["global_exact_dedup/records_out"] == 4
+    assert result.counters["global_exact_dedup/duplicate_records"] == 2

--- a/tests/datakit/test_global_exact_dedup.py
+++ b/tests/datakit/test_global_exact_dedup.py
@@ -22,39 +22,44 @@ def flow_backend_ctx():
         yield
 
 
-def _normalized_source(root: Path, records: list[dict]) -> NormalizedData:
+def _normalized_source(root: Path, shards: list[list[dict]]) -> NormalizedData:
     main = root / "outputs" / "main"
     main.mkdir(parents=True)
-    pq.write_table(pa.Table.from_pylist(records), main / "part-00000-of-00001.parquet")
+    for shard_index, records in enumerate(shards):
+        pq.write_table(
+            pa.Table.from_pylist(records),
+            main / f"part-{shard_index:05d}-of-{len(shards):05d}.parquet",
+        )
     return NormalizedData(main_output_dir=str(main), dup_output_dir=str(root / "outputs" / "dups"), counters={})
 
 
-def _records(source: NormalizedData) -> list[dict]:
-    records = []
-    for path in sorted(Path(source.main_output_dir).rglob("*.parquet")):
-        records.extend(pq.read_table(path).to_pylist())
-    return records
+def _shards(source: NormalizedData) -> list[list[dict]]:
+    return [pq.read_table(path).to_pylist() for path in sorted(Path(source.main_output_dir).rglob("*.parquet"))]
 
 
 def test_global_exact_deduplicate_keeps_one_record_for_each_id(tmp_path: Path):
     source_a = _normalized_source(
         tmp_path / "input-a",
         [
-            {"id": "a-only", "text": "A only", "a_metadata": 1},
-            {"id": "a-only", "text": "Duplicate in the canonical shard", "a_metadata": 3},
-            {"id": "shared", "text": "Canonical text", "a_metadata": 2},
+            [
+                {"id": "a-only", "text": "A only", "a_metadata": 1},
+                {"id": "shared", "text": "Canonical text", "a_metadata": 2},
+            ],
         ],
     )
     source_b = _normalized_source(
         tmp_path / "input-b",
         [
-            {"id": "b-only", "text": "B only", "b_metadata": "x"},
-            {"id": "shared", "text": "Different text with the same record ID", "b_metadata": "y"},
+            [{"id": "b-only", "text": "B only", "b_metadata": "x"}],
+            [
+                {"id": "shared", "text": "Different text with the same record ID", "b_metadata": "y"},
+                {"id": "a-only", "text": "Another duplicate ID", "b_metadata": "z"},
+            ],
         ],
     )
     source_c = _normalized_source(
         tmp_path / "input-c",
-        [{"id": "c-only", "text": "C only", "c_metadata": True}],
+        [[{"id": "c-only", "text": "C only", "c_metadata": True}]],
     )
 
     result = global_exact_deduplicate(
@@ -64,12 +69,22 @@ def test_global_exact_deduplicate_keeps_one_record_for_each_id(tmp_path: Path):
         max_workers=2,
     )
 
-    assert _records(result.sources["a"]) == [
-        {"id": "a-only", "text": "A only", "a_metadata": 1},
-        {"id": "shared", "text": "Canonical text", "a_metadata": 2},
+    assert _shards(result.sources["a"]) == [
+        [
+            {"id": "a-only", "text": "A only", "a_metadata": 1},
+            {"id": "shared", "text": "Canonical text", "a_metadata": 2},
+        ]
     ]
-    assert _records(result.sources["b"]) == [{"id": "b-only", "text": "B only", "b_metadata": "x"}]
-    assert _records(result.sources["c"]) == [{"id": "c-only", "text": "C only", "c_metadata": True}]
+    assert _shards(result.sources["b"]) == [
+        [{"id": "b-only", "text": "B only", "b_metadata": "x"}],
+        [],
+    ]
+    assert _shards(result.sources["c"]) == [[{"id": "c-only", "text": "C only", "c_metadata": True}]]
     assert result.counters["global_exact_dedup/records_in"] == 6
     assert result.counters["global_exact_dedup/records_out"] == 4
     assert result.counters["global_exact_dedup/duplicate_records"] == 2
+    assert result.sources["b"].counters == {
+        "global_exact_dedup/records_in": 3,
+        "global_exact_dedup/records_out": 1,
+        "global_exact_dedup/duplicate_records": 2,
+    }

--- a/tests/datakit/test_global_exact_dedup.py
+++ b/tests/datakit/test_global_exact_dedup.py
@@ -12,8 +12,9 @@ from fray.current_client import set_current_client
 from fray.local_backend import LocalClient
 from fray.types import ResourceConfig
 from marin.datakit.normalize import NormalizedData
+from marin.datakit.source_key import datakit_source_key
 
-from experiments.datakit.global_exact_dedup import global_exact_deduplicate
+from experiments.datakit.global_exact_dedup import GlobalExactDedupData, global_exact_deduplicate
 
 
 @pytest.fixture(autouse=True)
@@ -26,18 +27,24 @@ def _normalized_source(root: Path, shards: list[list[dict]]) -> NormalizedData:
     main = root / "outputs" / "main"
     main.mkdir(parents=True)
     for shard_index, records in enumerate(shards):
+        table = (
+            pa.Table.from_pylist(records)
+            if records
+            else pa.table({"id": pa.array([], type=pa.string()), "text": pa.array([], type=pa.string())})
+        )
         pq.write_table(
-            pa.Table.from_pylist(records),
+            table,
             main / f"part-{shard_index:05d}-of-{len(shards):05d}.parquet",
         )
     return NormalizedData(main_output_dir=str(main), dup_output_dir=str(root / "outputs" / "dups"), counters={})
 
 
-def _shards(source: NormalizedData) -> list[list[dict]]:
-    return [pq.read_table(path).to_pylist() for path in sorted(Path(source.main_output_dir).rglob("*.parquet"))]
+def _attribute_shards(result: GlobalExactDedupData, source: NormalizedData) -> list[Path]:
+    return sorted(Path(result.sources[datakit_source_key(source.main_output_dir)].attr_dir).glob("*.parquet"))
 
 
-def test_global_exact_deduplicate_keeps_one_record_for_each_id(tmp_path: Path):
+def test_global_exact_deduplicate_writes_sparse_copartitioned_attributes(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", str(tmp_path))
     source_a = _normalized_source(
         tmp_path / "input-a",
         [
@@ -59,7 +66,7 @@ def test_global_exact_deduplicate_keeps_one_record_for_each_id(tmp_path: Path):
     )
     source_c = _normalized_source(
         tmp_path / "input-c",
-        [[{"id": "c-only", "text": "C only", "c_metadata": True}]],
+        [[{"id": "c-only", "text": "C only", "c_metadata": True}], []],
     )
 
     result = global_exact_deduplicate(
@@ -69,22 +76,69 @@ def test_global_exact_deduplicate_keeps_one_record_for_each_id(tmp_path: Path):
         max_workers=2,
     )
 
-    assert _shards(result.sources["a"]) == [
-        [
-            {"id": "a-only", "text": "A only", "a_metadata": 1},
-            {"id": "shared", "text": "Canonical text", "a_metadata": 2},
-        ]
+    a_shards = _attribute_shards(result, source_a)
+    b_shards = _attribute_shards(result, source_b)
+    c_shards = _attribute_shards(result, source_c)
+    assert [path.name for path in a_shards] == ["part-00000-of-00001.parquet"]
+    assert [path.name for path in b_shards] == [
+        "part-00000-of-00002.parquet",
+        "part-00001-of-00002.parquet",
     ]
-    assert _shards(result.sources["b"]) == [
-        [{"id": "b-only", "text": "B only", "b_metadata": "x"}],
-        [],
+    assert [path.name for path in c_shards] == [
+        "part-00000-of-00002.parquet",
+        "part-00001-of-00002.parquet",
     ]
-    assert _shards(result.sources["c"]) == [[{"id": "c-only", "text": "C only", "c_metadata": True}]]
+
+    assert pq.read_table(a_shards[0]).to_pylist() == []
+    assert pq.read_table(b_shards[0]).to_pylist() == []
+    assert pq.read_table(b_shards[1]).to_pylist() == [
+        {"id": "a-only", "attributes": {"dup_doc": True}},
+        {"id": "shared", "attributes": {"dup_doc": True}},
+    ]
+    assert pq.read_table(c_shards[0]).to_pylist() == []
+    assert pq.read_table(c_shards[1]).to_pylist() == []
+    for path in [*a_shards, *b_shards, *c_shards]:
+        assert pq.read_schema(path).names == ["id", "attributes"]
+
+    assert result.sources["input-a/outputs/main"].attr_dir.endswith("/outputs/source_000")
+    assert result.sources["input-b/outputs/main"].attr_dir.endswith("/outputs/source_001")
+    assert result.sources["input-c/outputs/main"].attr_dir.endswith("/outputs/source_002")
     assert result.counters["global_exact_dedup/records_in"] == 6
-    assert result.counters["global_exact_dedup/records_out"] == 4
     assert result.counters["global_exact_dedup/duplicate_records"] == 2
-    assert result.sources["b"].counters == {
-        "global_exact_dedup/records_in": 3,
-        "global_exact_dedup/records_out": 1,
-        "global_exact_dedup/duplicate_records": 2,
-    }
+
+
+def test_global_exact_deduplicate_uses_shard_order_within_source(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", str(tmp_path))
+    source = _normalized_source(
+        tmp_path / "input",
+        [
+            [{"id": "shared", "text": "first shard"}],
+            [{"id": "shared", "text": "second shard"}],
+        ],
+    )
+
+    result = global_exact_deduplicate(
+        sources={"source": source},
+        output_path=str(tmp_path / "output"),
+        worker_resources=ResourceConfig(cpu=1, ram="1g"),
+        max_workers=1,
+    )
+
+    shards = _attribute_shards(result, source)
+    assert pq.read_table(shards[0]).to_pylist() == []
+    assert pq.read_table(shards[1]).to_pylist() == [
+        {"id": "shared", "attributes": {"dup_doc": True}},
+    ]
+
+
+def test_global_exact_deduplicate_rejects_duplicate_source_directories(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", str(tmp_path))
+    source = _normalized_source(tmp_path / "input", [[{"id": "a", "text": "A"}]])
+
+    with pytest.raises(ValueError, match="Multiple sources use source_key"):
+        global_exact_deduplicate(
+            sources={"a": source, "alias": source},
+            output_path=str(tmp_path / "output"),
+            worker_resources=ResourceConfig(cpu=1, ram="1g"),
+            max_workers=1,
+        )

--- a/tests/datakit/test_normalize.py
+++ b/tests/datakit/test_normalize.py
@@ -12,7 +12,8 @@ import pyarrow.parquet as pq
 import pytest
 from fray.current_client import set_current_client
 from fray.local_backend import LocalClient
-from marin.datakit.normalize import generate_id, normalize_to_parquet
+from marin.datakit.normalize import NORMALIZED_DATA_VERSION, NormalizedData, generate_id, normalize_to_parquet
+from marin.execution.artifact import ArtifactRecord, read_artifact, write_artifact, write_record
 
 
 @pytest.fixture(autouse=True)
@@ -43,6 +44,74 @@ def _read_all_parquet(output_dir: Path) -> list[dict]:
     for pf in sorted((output_dir / "outputs" / "main").glob("*.parquet")):
         records.extend(pq.read_table(str(pf)).to_pylist())
     return records
+
+
+def test_normalized_data_artifact_stores_relative_output_dirs(tmp_path: Path, monkeypatch):
+    marin_root = tmp_path / "marin"
+    monkeypatch.setenv("MARIN_PREFIX", str(marin_root))
+    artifact_dir = tmp_path / "artifact"
+    artifact_dir.mkdir()
+
+    write_artifact(
+        NormalizedData(
+            main_output_dir=str(marin_root / "datakit/source/outputs/main"),
+            dup_output_dir=str(marin_root / "datakit/source/outputs/dups"),
+            counters={"records": 3},
+        ),
+        str(artifact_dir),
+    )
+
+    record = json.loads((artifact_dir / ".artifact.json").read_text())
+    assert record["result"] == {
+        "version": NORMALIZED_DATA_VERSION,
+        "main_output_dir": "datakit/source/outputs/main",
+        "dup_output_dir": "datakit/source/outputs/dups",
+        "counters": {"records": 3},
+    }
+
+    loaded = read_artifact(str(artifact_dir), NormalizedData)
+    assert loaded.main_output_dir == str(marin_root / "datakit/source/outputs/main")
+    assert loaded.dup_output_dir == str(marin_root / "datakit/source/outputs/dups")
+
+
+def test_normalized_data_loads_v1_paths_from_another_region(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", "gs://marin-us-central1")
+    artifact_dir = tmp_path / "artifact"
+    artifact_dir.mkdir()
+    write_record(
+        ArtifactRecord(
+            output_path=str(artifact_dir),
+            result={
+                "version": "v1",
+                "main_output_dir": "s3://marin-us-east-02a/marin/datakit/source/outputs/main",
+                "dup_output_dir": "s3://marin-us-east-02a/marin/datakit/source/outputs/dups",
+                "counters": {},
+            },
+        )
+    )
+
+    loaded = read_artifact(str(artifact_dir), NormalizedData)
+    assert loaded.version == NORMALIZED_DATA_VERSION
+    assert loaded.main_output_dir == "s3://marin-us-east-02a/marin/datakit/source/outputs/main"
+    assert loaded.dup_output_dir == "s3://marin-us-east-02a/marin/datakit/source/outputs/dups"
+
+
+def test_normalized_data_artifact_preserves_output_dirs_outside_active_prefix(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", "gs://marin-us-central1")
+    artifact_dir = tmp_path / "artifact"
+    artifact_dir.mkdir()
+    write_artifact(
+        NormalizedData(
+            main_output_dir="s3://unregistered-bucket/data/outputs/main",
+            dup_output_dir="s3://unregistered-bucket/data/outputs/dups",
+            counters={},
+        ),
+        str(artifact_dir),
+    )
+
+    loaded = read_artifact(str(artifact_dir), NormalizedData)
+    assert loaded.main_output_dir == "s3://unregistered-bucket/data/outputs/main"
+    assert loaded.dup_output_dir == "s3://unregistered-bucket/data/outputs/dups"
 
 
 def test_normalize_happy_path(tmp_path: Path, write_jsonl_gz):

--- a/tests/datakit/test_reference_pipeline_hashing.py
+++ b/tests/datakit/test_reference_pipeline_hashing.py
@@ -48,13 +48,14 @@ def _depends_on(step: StepSpec, dependency: StepSpec) -> bool:
     return any(parent is dependency or _depends_on(parent, dependency) for parent in step.deps)
 
 
-def test_global_exact_dedup_precedes_per_source_processing():
+def test_global_exact_dedup_filters_only_the_store():
     result = _build()
     steps = _steps_by_name(result)
     exact_dedup = steps["datakit/global_exact_dedup"]
 
     for stage in ("tokenize", "embed", "quality", "decontam", "minhash"):
-        assert _depends_on(steps[f"datakit/{stage}/a"], exact_dedup)
+        assert not _depends_on(steps[f"datakit/{stage}/a"], exact_dedup)
+    assert _depends_on(steps["datakit/store"], exact_dedup)
 
 
 def test_no_region_path_in_hash_attrs_except_known_bloom_gap():

--- a/tests/datakit/test_reference_pipeline_hashing.py
+++ b/tests/datakit/test_reference_pipeline_hashing.py
@@ -44,6 +44,18 @@ def _steps_by_name(result) -> dict[str, StepSpec]:
     return {s.name: s for s in result.all_steps}
 
 
+def _depends_on(step: StepSpec, dependency: StepSpec) -> bool:
+    return any(parent is dependency or _depends_on(parent, dependency) for parent in step.deps)
+
+
+def test_global_exact_dedup_precedes_per_source_processing():
+    result = _build()
+    steps = _steps_by_name(result)
+
+    for stage in ("tokenize", "embed", "quality", "decontam", "minhash"):
+        assert _depends_on(steps[f"datakit/{stage}/a"], result.exact_dedup)
+
+
 def test_no_region_path_in_hash_attrs_except_known_bloom_gap():
     # A region-specific gs:// path in a hash means byte-identical data gets a
     # different output path per region. The only remaining leak is the decontam

--- a/tests/datakit/test_reference_pipeline_hashing.py
+++ b/tests/datakit/test_reference_pipeline_hashing.py
@@ -51,9 +51,10 @@ def _depends_on(step: StepSpec, dependency: StepSpec) -> bool:
 def test_global_exact_dedup_precedes_per_source_processing():
     result = _build()
     steps = _steps_by_name(result)
+    exact_dedup = steps["datakit/global_exact_dedup"]
 
     for stage in ("tokenize", "embed", "quality", "decontam", "minhash"):
-        assert _depends_on(steps[f"datakit/{stage}/a"], result.exact_dedup)
+        assert _depends_on(steps[f"datakit/{stage}/a"], exact_dedup)
 
 
 def test_no_region_path_in_hash_attrs_except_known_bloom_gap():

--- a/tests/datakit/test_source_key.py
+++ b/tests/datakit/test_source_key.py
@@ -1,0 +1,43 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from marin.datakit.source_key import datakit_source_key
+
+
+def test_datakit_source_key_removes_marin_prefix(monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", "s3://marin-us-east-02a/marin")
+
+    assert (
+        datakit_source_key("s3://marin-us-east-02a/marin/datakit/normalize/foo/outputs/main")
+        == "datakit/normalize/foo/outputs/main"
+    )
+
+
+def test_datakit_source_key_preserves_paths_outside_marin_prefix(monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", "s3://marin-us-east-02a/marin")
+
+    assert datakit_source_key("/tmp/datakit/source") == "/tmp/datakit/source"
+
+
+def test_datakit_source_key_recognizes_other_marin_regions(monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", "gs://marin-us-central1/marin")
+
+    assert (
+        datakit_source_key("s3://marin-us-east-02a/marin/datakit/normalize/foo/outputs/main")
+        == "datakit/normalize/foo/outputs/main"
+    )
+
+
+def test_datakit_source_key_rejects_marin_prefix_itself(monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", "s3://marin-us-east-02a/marin")
+
+    with pytest.raises(ValueError, match="must be below a Marin data prefix"):
+        datakit_source_key("s3://marin-us-east-02a/marin")
+
+
+def test_datakit_source_key_rejects_unknown_object_store(monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", "s3://marin-us-east-02a/marin")
+
+    with pytest.raises(ValueError, match="not under a configured Marin data prefix"):
+        datakit_source_key("s3://unmanaged-bucket/data/source")

--- a/tests/datakit/test_source_key.py
+++ b/tests/datakit/test_source_key.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from marin.datakit.source_key import datakit_source_key
+from marin.datakit.source_key import datakit_source_key, datakit_source_path
 
 
 def test_datakit_source_key_removes_marin_prefix(monkeypatch):
@@ -29,6 +29,15 @@ def test_datakit_source_key_recognizes_other_marin_regions(monkeypatch):
     )
 
 
+def test_datakit_source_key_recognizes_other_gcs_regions(monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", "s3://marin-us-east-02a/marin")
+
+    assert (
+        datakit_source_key("gs://marin-us-central1/datakit/normalize/foo/outputs/main")
+        == "datakit/normalize/foo/outputs/main"
+    )
+
+
 def test_datakit_source_key_rejects_marin_prefix_itself(monkeypatch):
     monkeypatch.setenv("MARIN_PREFIX", "s3://marin-us-east-02a/marin")
 
@@ -41,3 +50,21 @@ def test_datakit_source_key_rejects_unknown_object_store(monkeypatch):
 
     with pytest.raises(ValueError, match="not under a configured Marin data prefix"):
         datakit_source_key("s3://unmanaged-bucket/data/source")
+
+
+def test_datakit_source_path_resolves_relative_key(monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", "gs://marin-us-central1")
+
+    assert (
+        datakit_source_path("datakit/normalize/foo/outputs/main")
+        == "gs://marin-us-central1/datakit/normalize/foo/outputs/main"
+    )
+
+
+def test_datakit_source_path_preserves_other_marin_region(monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", "gs://marin-us-central1")
+
+    assert (
+        datakit_source_path("s3://marin-us-east-02a/marin/datakit/normalize/foo/outputs/main")
+        == "s3://marin-us-east-02a/marin/datakit/normalize/foo/outputs/main"
+    )

--- a/tests/processing/classification/deduplication/test_fuzzy.py
+++ b/tests/processing/classification/deduplication/test_fuzzy.py
@@ -55,7 +55,7 @@ def _read_cluster_attrs(attr_dir: str) -> list[dict]:
 def _write_minhash_attr_dataset(
     *,
     output_dir: str,
-    source_main_dir: str,
+    source_key: str,
     rows: list[dict],
 ) -> MinHashAttrData:
     """Write a one-shard MinHash attr dataset for focused fuzzy-dup tests."""
@@ -64,21 +64,22 @@ def _write_minhash_attr_dataset(
     write_parquet_file(rows, os.path.join(attr_dir, "part-00000.parquet"))
     return MinHashAttrData(
         params=TEST_MINHASH_PARAMS,
-        source_main_dir=source_main_dir,
+        source_key=source_key,
         attr_dir=attr_dir,
         counters={},
     )
 
 
-def test_minhash_attrs_co_partitioned_with_source(fox_corpus):
+def test_minhash_attrs_co_partitioned_with_source(fox_corpus, monkeypatch):
     """Each source shard produces a same-named MinHash attr parquet with {id, buckets}."""
+    monkeypatch.setenv("MARIN_PREFIX", fox_corpus["output_dir"])
     norm_dir = os.path.join(fox_corpus["output_dir"], "normalized")
     minhash_dir = os.path.join(fox_corpus["output_dir"], "minhash")
 
     source = _normalize(fox_corpus["test_dir"], norm_dir)
     minhash = compute_minhash_attrs(source=source, output_path=minhash_dir)
 
-    assert minhash.source_main_dir == source.main_output_dir
+    assert minhash.source_key == "normalized/outputs/main"
     assert minhash.params.num_perms == 286
     assert minhash.params.num_bands == 26
 
@@ -124,7 +125,7 @@ def test_fuzzy_dups_single_source_schema_and_pair(fox_corpus):
     dups = compute_fuzzy_dups_attrs(inputs=[minhash], output_path=dups_dir, max_parallelism=4)
 
     assert dups.params == minhash.params
-    per_source = dups.sources[source.main_output_dir]
+    per_source = dups.sources[minhash.source_key]
 
     by_id = _read_main_records(source)
     rows = _read_cluster_attrs(per_source.attr_dir)
@@ -161,7 +162,7 @@ def test_fuzzy_dups_multi_source_per_source_attr_trees(fox_corpus):
     test_main_dir = os.path.join(fox_corpus["output_dir"], "test_main")
     train_mh = _write_minhash_attr_dataset(
         output_dir=os.path.join(fox_corpus["output_dir"], "mh_train"),
-        source_main_dir=train_main_dir,
+        source_key=train_main_dir,
         rows=[
             {
                 "id": generate_id("Arctic predators have superior auditory capabilities for hunting beneath snow."),
@@ -179,7 +180,7 @@ def test_fuzzy_dups_multi_source_per_source_attr_trees(fox_corpus):
     )
     test_mh = _write_minhash_attr_dataset(
         output_dir=os.path.join(fox_corpus["output_dir"], "mh_test"),
-        source_main_dir=test_main_dir,
+        source_key=test_main_dir,
         rows=[
             {
                 "id": generate_id("Arctic predators have superior auditory capabilities for hunting beneath snow."),
@@ -206,12 +207,13 @@ def test_fuzzy_dups_multi_source_per_source_attr_trees(fox_corpus):
     for per_source in dups.sources.values():
         assert per_source.attr_dir.rsplit("/", 1)[-1].startswith("source_"), per_source.attr_dir
         assert Path(per_source.attr_dir).exists()
+    assert dups.attr_dir_for_source(train_main_dir) == dups.sources[train_mh.source_key].attr_dir
 
-    def rows_by_id(main_dir: str) -> dict[str, dict]:
-        return {r["id"]: r for r in _read_cluster_attrs(dups.sources[main_dir].attr_dir)}
+    def rows_by_id(source_key: str) -> dict[str, dict]:
+        return {r["id"]: r for r in _read_cluster_attrs(dups.sources[source_key].attr_dir)}
 
-    train_rows = rows_by_id(train_main_dir)
-    test_rows = rows_by_id(test_main_dir)
+    train_rows = rows_by_id(train_mh.source_key)
+    test_rows = rows_by_id(test_mh.source_key)
 
     # Each cross-source byte-identical text must appear as an attr row on both
     # sides (keyed by the same content hash), share a dup_cluster_id, and have
@@ -250,11 +252,11 @@ def test_fuzzy_dups_rejects_param_mismatch(fox_corpus):
 
 
 def test_fuzzy_dups_rejects_duplicate_source(fox_corpus):
-    """Two inputs pointing to the same ``source_main_dir`` must be rejected to avoid output clobbering."""
+    """Two inputs with the same source key must be rejected to avoid output clobbering."""
     source = _normalize(fox_corpus["test_dir"], os.path.join(fox_corpus["output_dir"], "norm"))
     mh = compute_minhash_attrs(source=source, output_path=os.path.join(fox_corpus["output_dir"], "mh"))
 
-    with pytest.raises(ValueError, match=r"Duplicate source_main_dir"):
+    with pytest.raises(ValueError, match=r"Duplicate source_key"):
         compute_fuzzy_dups_attrs(
             inputs=[mh, mh],
             output_path=os.path.join(fox_corpus["output_dir"], "fuzzy_dups"),
@@ -266,7 +268,7 @@ def _canonical_assignment(source: NormalizedData, output_path: str) -> dict[str,
     """Run minhash + fuzzy_dups for *source* and return ``{id -> (dup_cluster_id, is_canonical)}``."""
     minhash = compute_minhash_attrs(source=source, output_path=os.path.join(output_path, "minhash"))
     dups = compute_fuzzy_dups_attrs(inputs=[minhash], output_path=os.path.join(output_path, "dups"), max_parallelism=4)
-    rows = _read_cluster_attrs(dups.sources[source.main_output_dir].attr_dir)
+    rows = _read_cluster_attrs(dups.sources[minhash.source_key].attr_dir)
     return {r["id"]: (r["attributes"]["dup_cluster_id"], r["attributes"]["is_cluster_canonical"]) for r in rows}
 
 
@@ -321,7 +323,7 @@ def test_fuzzy_dups_capped_does_not_raise_and_emits(fox_corpus):
 
     mh = _write_minhash_attr_dataset(
         output_dir=os.path.join(fox_corpus["output_dir"], "mh_path"),
-        source_main_dir=main_dir,
+        source_key=main_dir,
         rows=rows,
     )
 
@@ -331,7 +333,7 @@ def test_fuzzy_dups_capped_does_not_raise_and_emits(fox_corpus):
         cc_max_iterations=1,
         max_parallelism=4,
     )
-    attr_rows = _read_cluster_attrs(dups.sources[main_dir].attr_dir)
+    attr_rows = _read_cluster_attrs(dups.sources[mh.source_key].attr_dir)
     assert attr_rows, "capped run should still emit cluster-member rows"
 
 
@@ -400,7 +402,7 @@ def test_text_cap_chars_truncates_mega_docs_only(tmp_path):
     # Params + version metadata.
     assert cap_mh.params.text_cap_chars == cap_chars
     assert nocap_mh.params.text_cap_chars is None
-    assert cap_mh.version == "v2"
+    assert cap_mh.version == "v3"
 
 
 # ---------------------------------------------------------------------------
@@ -538,7 +540,7 @@ def _run_dedup_on_corpus(tmp_path: Path, docs: list[dict]) -> dict[str, dict]:
     dups = compute_fuzzy_dups_attrs(inputs=[minhash], output_path=str(tmp_path / "dups"), max_parallelism=1)
 
     by_id = _read_main_records(source)
-    rows = _read_cluster_attrs(dups.sources[source.main_output_dir].attr_dir)
+    rows = _read_cluster_attrs(dups.sources[minhash.source_key].attr_dir)
     return {by_id[r["id"]]["source_id"]: r for r in rows if r["id"] in by_id}
 
 

--- a/tests/processing/tokenize/test_split_tokenize.py
+++ b/tests/processing/tokenize/test_split_tokenize.py
@@ -132,9 +132,10 @@ def _write_normalized_fixture(tmp_path, texts: list[str]) -> NormalizedData:
 
 
 @pytest.mark.slow
-def test_split_pipeline_matches_legacy_tokenize(tmp_path):
+def test_split_pipeline_matches_legacy_tokenize(tmp_path, monkeypatch):
     """Stage A → Stage B should produce a Levanter cache with the same token count
     as the legacy raw-input ``tokenize()`` path on the same texts."""
+    monkeypatch.setenv("MARIN_PREFIX", str(tmp_path))
     texts = [
         "The quick brown fox jumps over the lazy dog.",
         "Pack my box with five dozen liquor jugs.",
@@ -153,6 +154,7 @@ def test_split_pipeline_matches_legacy_tokenize(tmp_path):
     )
     tokenized: TokenizedAttrData = tokenize_attributes(attr_config)
 
+    assert tokenized.source_keys["train"] == "normalized/outputs/main"
     train_shards = tokenized.shard_paths("train")
     assert len(train_shards) == 1, f"expected 1 attribute shard, got {len(train_shards)}: {train_shards}"
     attr_table = pq.read_table(train_shards[0])


### PR DESCRIPTION
* mark global exact duplicates by normalized record `id` in one Zephyr job
  * select the first source name, shard, and row as canonical
  * write sparse co-partitioned `attributes.dup_doc` files only for shards with duplicates
  * bound both shuffle stages by the worker count
* apply exact and fuzzy duplicate attributes when Datakit builds the final store
  * prefer fuzzy canonical markers when they exist
  * use exact markers for records that MinHash skipped
* use `MARIN_PREFIX`-relative source keys in tokenization, embedding, assignment, MinHash, exact-dedup, and fuzzy-dedup artifacts
* serialize `NormalizedData` output directories relative to the active `MARIN_PREFIX`
  * load v1 artifacts without path changes so existing normalized data stays reusable
  * preserve absolute paths outside the active prefix
* keep runtime data input and output paths absolute
