### PR TITLE
[data] Add identity conversation generator

### DIFF
--- a/experiments/rollout_data/collect_identity_conversations_glm52.py
+++ b/experiments/rollout_data/collect_identity_conversations_glm52.py
@@ -1,0 +1,449 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate Marin identity conversations with GLM-5.2."""
+
+import argparse
+import dataclasses
+import json
+import logging
+import re
+import time
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+import requests
+from iris.client import iris_ctx
+from rigging.filesystem import StoragePath
+
+from experiments.rollout_data.generate_identity_conversation_seeds import (
+    ConversationSeed,
+    HumanPhrasing,
+    IdentityProfile,
+    generate_seeds,
+    load_human_phrasings,
+    load_identity_profile,
+)
+from experiments.rollout_data.glm52_vllm import (
+    MODEL,
+    Glm52LaunchConfig,
+    ServerConfig,
+    submit_glm52,
+    wait_for_endpoint_url,
+)
+
+logger = logging.getLogger(__name__)
+
+VLLM_ENDPOINT = "identity-glm52-openai"
+RAY_ENDPOINT = "identity-glm52-ray"
+REQUEST_TIMEOUT = 3600
+MAX_GENERATION_ATTEMPTS = 3
+DEFAULT_TARGET_TOKENS = 10_000_000
+DEFAULT_MICROBATCH_SIZE = 8
+DEFAULT_CONCURRENCY = 96
+DEFAULT_MAX_TOKENS = 1024
+DEFAULT_TEMPERATURE = 0.9
+DEFAULT_TOP_P = 0.95
+DEFAULT_MAX_MODEL_LEN = 8192
+DEFAULT_MAX_NUM_SEQS = 64
+CHUNK_PATTERN = re.compile(r"chunk-(?P<start>\d+)-(?P<end>\d+)-tokens-(?P<tokens>\d+)\.jsonl\.gz")
+UNSUPPORTED_USER_DETAIL_MARKERS = (
+    "checkpoint",
+    "codename",
+    "commit history",
+    "dense transformer",
+    "documentation says",
+    "docs say",
+    "endpoint header",
+    "expert subnetworks",
+    "latency profile",
+    "metadata says",
+    "mixture-of-experts",
+    "quota tier",
+    "release notes",
+    "routing layer",
+    "tokenization behavior",
+    "training phase",
+    "x-organization",
+)
+
+
+@dataclass(frozen=True)
+class SamplingConfig:
+    temperature: float
+    top_p: float
+    max_tokens: int
+
+
+@dataclass(frozen=True)
+class CollectionConfig:
+    run_id: str
+    output_path: StoragePath
+    shard_index: int
+    num_shards: int
+    target_tokens: int
+    microbatch_size: int
+    concurrency: int
+    random_seed: int
+    human_phrasings: tuple[HumanPhrasing, ...]
+    identity_profile: IdentityProfile
+
+
+@dataclass(frozen=True)
+class Message:
+    role: str
+    content: str
+
+
+@dataclass(frozen=True)
+class CompletionRecord:
+    seed: ConversationSeed
+    conversation: tuple[Message, ...] | None
+    raw_response: str
+    accepted_tokens: int
+    usage: dict[str, Any]
+    finish_reason: str | None
+    response_id: str | None
+    error: str | None
+    attempts: int
+    elapsed_seconds: float
+
+
+@dataclass(frozen=True)
+class Chunk:
+    start: int
+    end: int
+    tokens: int
+
+
+@dataclass(frozen=True)
+class Progress:
+    run_id: str
+    profile_id: str
+    shard_index: int
+    num_shards: int
+    state: str
+    target_tokens: int
+    accepted_tokens: int
+    accepted_conversations: int
+    rejected_conversations: int
+    completed_microbatches: int
+    updated_at: str
+
+
+def _conversation(text: str, seed: ConversationSeed) -> tuple[Message, ...]:
+    cleaned = text.strip()
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned)
+        cleaned = re.sub(r"\s*```$", "", cleaned)
+    payload = json.loads(cleaned)
+    if not isinstance(payload, list) or len(payload) < 2:
+        raise ValueError("response must be a JSON array with at least two messages")
+    messages = tuple(Message(role=row["role"], content=row["content"].strip()) for row in payload)
+    if any(message.role not in {"user", "assistant"} or not message.content.strip() for message in messages):
+        raise ValueError("conversation messages must have non-empty user or assistant content")
+    expected_roles = ("user", "assistant") if seed.neutral_bridge is None else ("user", "assistant", "user", "assistant")
+    if tuple(message.role for message in messages) != expected_roles:
+        raise ValueError("conversation roles must start with user and alternate through the final assistant answer")
+    if seed.neutral_bridge is not None and messages[1].content != seed.neutral_bridge:
+        raise ValueError("earlier assistant message must match the supplied neutral bridge exactly")
+    if messages[-1].content != seed.canonical_answer:
+        raise ValueError("final assistant message must match the supplied canonical answer exactly")
+    user_text = " ".join(message.content.lower() for message in messages if message.role == "user")
+    if any(marker in user_text for marker in UNSUPPORTED_USER_DETAIL_MARKERS):
+        raise ValueError("user messages introduced an unsupported implementation detail")
+    return messages
+
+
+def _completion(vllm_url: str, seed: ConversationSeed, sampling: SamplingConfig) -> CompletionRecord:
+    started = time.time()
+    last_text = ""
+    last_usage: dict[str, Any] = {}
+    last_finish_reason = None
+    last_response_id = None
+    last_error = None
+    for attempt in range(MAX_GENERATION_ATTEMPTS):
+        response = requests.post(
+            f"{vllm_url}/v1/chat/completions",
+            json={
+                "model": MODEL,
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": (
+                            "Generate synthetic training conversations exactly as requested. Do not answer as "
+                            "yourself and do not add commentary outside the requested JSON."
+                        ),
+                    },
+                    {"role": "user", "content": seed.generation_prompt},
+                ],
+                "temperature": sampling.temperature,
+                "top_p": sampling.top_p,
+                "max_tokens": sampling.max_tokens,
+                "seed": int(seed.seed_id.rsplit("-", 1)[1]) + attempt,
+                "chat_template_kwargs": {"enable_thinking": False},
+            },
+            timeout=REQUEST_TIMEOUT,
+        )
+        if not response.ok:
+            raise RuntimeError(f"vLLM returned {response.status_code}: {response.text[:2000]}")
+        payload = response.json()
+        choice = payload["choices"][0]
+        last_text = choice["message"].get("content") or ""
+        last_usage = payload.get("usage", {})
+        last_finish_reason = choice.get("finish_reason")
+        last_response_id = payload.get("id")
+        try:
+            conversation = _conversation(last_text, seed)
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+            last_error = str(error)
+            continue
+        return CompletionRecord(
+            seed=seed,
+            conversation=conversation,
+            raw_response=last_text,
+            accepted_tokens=int(last_usage.get("completion_tokens", 0)),
+            usage=last_usage,
+            finish_reason=last_finish_reason,
+            response_id=last_response_id,
+            error=None,
+            attempts=attempt + 1,
+            elapsed_seconds=time.time() - started,
+        )
+    return CompletionRecord(
+        seed=seed,
+        conversation=None,
+        raw_response=last_text,
+        accepted_tokens=0,
+        usage=last_usage,
+        finish_reason=last_finish_reason,
+        response_id=last_response_id,
+        error=last_error,
+        attempts=MAX_GENERATION_ATTEMPTS,
+        elapsed_seconds=time.time() - started,
+    )
+
+
+def _chunk_path(output_path: StoragePath, shard_index: int, chunk: Chunk) -> StoragePath:
+    return (
+        output_path
+        / "responses"
+        / f"shard-{shard_index:02d}"
+        / f"chunk-{chunk.start:09d}-{chunk.end:09d}-tokens-{chunk.tokens:07d}.jsonl.gz"
+    )
+
+
+def _existing_chunks(output_path: StoragePath, shard_index: int) -> dict[int, Chunk]:
+    chunks = {}
+    for path in (output_path / "responses" / f"shard-{shard_index:02d}" / "*.jsonl.gz").glob():
+        match = CHUNK_PATTERN.fullmatch(path.name)
+        if match is None:
+            raise ValueError(f"Unexpected response filename: {path}")
+        chunk = Chunk(
+            start=int(match.group("start")),
+            end=int(match.group("end")),
+            tokens=int(match.group("tokens")),
+        )
+        chunks[chunk.start] = chunk
+    return chunks
+
+
+def _next_batch_start(existing: set[int], active: set[int], microbatch_size: int) -> int:
+    start = 0
+    while start in existing or start in active:
+        start += microbatch_size
+    return start
+
+
+def _seeds_for_batch(config: CollectionConfig, start: int) -> list[ConversationSeed]:
+    seeds = []
+    for local_index in range(start, start + config.microbatch_size):
+        global_index = config.shard_index + local_index * config.num_shards
+        seeds.extend(
+            generate_seeds(
+                count=1,
+                start_index=global_index,
+                random_seed=config.random_seed,
+                human_phrasings=config.human_phrasings,
+                identity_profile=config.identity_profile,
+            )
+        )
+    return seeds
+
+
+def _write_chunk(config: CollectionConfig, start: int, records: list[CompletionRecord]) -> Chunk:
+    tokens = sum(record.accepted_tokens for record in records)
+    chunk = Chunk(start=start, end=start + len(records) - 1, tokens=tokens)
+    accepted_records = [record for record in records if record.conversation is not None]
+    contents = "".join(
+        json.dumps(dataclasses.asdict(record), ensure_ascii=False, sort_keys=True) + "\n" for record in accepted_records
+    )
+    _chunk_path(config.output_path, config.shard_index, chunk).write_text(contents, compression="gzip")
+    return chunk
+
+
+def _write_progress(
+    config: CollectionConfig,
+    state: str,
+    chunks: dict[int, Chunk],
+    accepted_conversations: int,
+    rejected_conversations: int,
+) -> None:
+    progress = Progress(
+        run_id=config.run_id,
+        profile_id=config.identity_profile.profile_id,
+        shard_index=config.shard_index,
+        num_shards=config.num_shards,
+        state=state,
+        target_tokens=config.target_tokens,
+        accepted_tokens=sum(chunk.tokens for chunk in chunks.values()),
+        accepted_conversations=accepted_conversations,
+        rejected_conversations=rejected_conversations,
+        completed_microbatches=len(chunks),
+        updated_at=datetime.now(UTC).isoformat(),
+    )
+    (config.output_path / "progress" / f"shard-{config.shard_index:02d}.json").write_text(
+        json.dumps(dataclasses.asdict(progress), indent=2, sort_keys=True)
+    )
+
+
+def _run_collection(vllm_url: str, config: CollectionConfig, sampling: SamplingConfig) -> None:
+    chunks = _existing_chunks(config.output_path, config.shard_index)
+    accepted_tokens = sum(chunk.tokens for chunk in chunks.values())
+    if accepted_tokens >= config.target_tokens:
+        _write_progress(config, "complete", chunks, 0, 0)
+        return
+
+    max_active_batches = max(1, config.concurrency // config.microbatch_size)
+    active_records: dict[int, list[CompletionRecord]] = {}
+    active_counts: dict[int, int] = {}
+    futures: dict[Future[CompletionRecord], int] = {}
+    accepted_conversations = 0
+    rejected_conversations = 0
+
+    def launch_batch(executor: ThreadPoolExecutor) -> None:
+        active = set(active_records)
+        start = _next_batch_start(set(chunks), active, config.microbatch_size)
+        active_records[start] = []
+        active_counts[start] = config.microbatch_size
+        for seed in _seeds_for_batch(config, start):
+            futures[executor.submit(_completion, vllm_url, seed, sampling)] = start
+
+    with ThreadPoolExecutor(max_workers=config.concurrency) as executor:
+        for _ in range(max_active_batches):
+            launch_batch(executor)
+
+        while futures:
+            done, _ = wait(futures, return_when=FIRST_COMPLETED)
+            completed_batches = set()
+            for future in done:
+                start = futures.pop(future)
+                record = future.result()
+                active_records[start].append(record)
+                active_counts[start] -= 1
+                if active_counts[start] == 0:
+                    completed_batches.add(start)
+
+            for start in completed_batches:
+                records = active_records.pop(start)
+                del active_counts[start]
+                chunk = _write_chunk(config, start, records)
+                chunks[start] = chunk
+                accepted_conversations += sum(record.conversation is not None for record in records)
+                rejected_conversations += sum(record.conversation is None for record in records)
+                accepted_tokens += chunk.tokens
+                _write_progress(config, "running", chunks, accepted_conversations, rejected_conversations)
+                logger.info(
+                    "Shard %d saved microbatch %d with %d tokens; total %d/%d",
+                    config.shard_index,
+                    start,
+                    chunk.tokens,
+                    accepted_tokens,
+                    config.target_tokens,
+                )
+
+            for _ in completed_batches:
+                if accepted_tokens < config.target_tokens:
+                    launch_batch(executor)
+
+    _write_progress(config, "complete", chunks, accepted_conversations, rejected_conversations)
+    if accepted_tokens < config.target_tokens:
+        raise RuntimeError(f"Shard stopped at {accepted_tokens} of {config.target_tokens} target tokens")
+
+
+def run(config: CollectionConfig, server: ServerConfig, sampling: SamplingConfig) -> None:
+    ctx = iris_ctx()
+    if ctx is None or ctx.client is None:
+        raise RuntimeError("Collector must run inside an Iris job")
+    endpoint_suffix = f"{config.run_id}-s{config.shard_index}"
+    vllm_endpoint = f"{VLLM_ENDPOINT}-{endpoint_suffix}"
+    ray_endpoint = f"{RAY_ENDPOINT}-{endpoint_suffix}"
+    vllm_job = submit_glm52(ctx, Glm52LaunchConfig(vllm_endpoint, ray_endpoint, server))
+    try:
+        vllm_url = wait_for_endpoint_url(vllm_endpoint, vllm_job)
+        _run_collection(vllm_url, config, sampling)
+    finally:
+        vllm_job.terminate()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--output-path", required=True)
+    parser.add_argument("--shard-index", type=int, required=True)
+    parser.add_argument("--num-shards", type=int, required=True)
+    parser.add_argument("--target-tokens", type=int, default=DEFAULT_TARGET_TOKENS)
+    parser.add_argument("--microbatch-size", type=int, default=DEFAULT_MICROBATCH_SIZE)
+    parser.add_argument("--concurrency", type=int, default=DEFAULT_CONCURRENCY)
+    parser.add_argument("--random-seed", type=int, default=0)
+    parser.add_argument("--phrasing-input")
+    parser.add_argument("--identity-profile", required=True)
+    parser.add_argument("--max-model-len", type=int, default=DEFAULT_MAX_MODEL_LEN)
+    parser.add_argument("--max-num-seqs", type=int, default=DEFAULT_MAX_NUM_SEQS)
+    parser.add_argument("--kv-cache-dtype", default="fp8")
+    parser.add_argument("--execution-mode", choices=("compile", "eager"), default="eager")
+    parser.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS)
+    parser.add_argument("--temperature", type=float, default=DEFAULT_TEMPERATURE)
+    parser.add_argument("--top-p", type=float, default=DEFAULT_TOP_P)
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
+
+    for name in ("num_shards", "target_tokens", "microbatch_size", "concurrency", "max_tokens"):
+        if getattr(args, name) < 1:
+            parser.error(f"--{name.replace('_', '-')} must be positive")
+    if not 0 <= args.shard_index < args.num_shards:
+        parser.error("--shard-index must be in [0, --num-shards)")
+    if args.concurrency < args.microbatch_size:
+        parser.error("--concurrency must be at least --microbatch-size")
+    if not 0 < args.top_p <= 1:
+        parser.error("--top-p must be in (0, 1]")
+
+    human_phrasings = tuple(load_human_phrasings(StoragePath(args.phrasing_input))) if args.phrasing_input else ()
+    identity_profile = load_identity_profile(StoragePath(args.identity_profile))
+    run(
+        CollectionConfig(
+            run_id=args.run_id,
+            output_path=StoragePath(args.output_path),
+            shard_index=args.shard_index,
+            num_shards=args.num_shards,
+            target_tokens=args.target_tokens,
+            microbatch_size=args.microbatch_size,
+            concurrency=args.concurrency,
+            random_seed=args.random_seed,
+            human_phrasings=human_phrasings,
+            identity_profile=identity_profile,
+        ),
+        ServerConfig(
+            max_model_len=args.max_model_len,
+            max_num_seqs=args.max_num_seqs,
+            kv_cache_dtype=args.kv_cache_dtype,
+            execution_mode=args.execution_mode,
+        ),
+        SamplingConfig(args.temperature, args.top_p, args.max_tokens),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/rollout_data/collect_identity_conversations_glm52.py
+++ b/experiments/rollout_data/collect_identity_conversations_glm52.py
@@ -228,16 +228,18 @@ def _completion(vllm_url: str, seed: ConversationSeed, sampling: SamplingConfig)
 
 def _chunk_path(output_path: StoragePath, shard_index: int, chunk: Chunk) -> StoragePath:
     return (
-        output_path
-        / "responses"
-        / f"shard-{shard_index:02d}"
+        _shard_response_path(output_path, shard_index)
         / f"chunk-{chunk.start:09d}-{chunk.end:09d}-tokens-{chunk.tokens:07d}.jsonl.gz"
     )
 
 
+def _shard_response_path(output_path: StoragePath, shard_index: int) -> StoragePath:
+    return output_path / "responses" / f"shard-{shard_index:02d}"
+
+
 def _existing_chunks(output_path: StoragePath, shard_index: int) -> dict[int, Chunk]:
     chunks = {}
-    for path in (output_path / "responses" / f"shard-{shard_index:02d}" / "*.jsonl.gz").glob():
+    for path in (_shard_response_path(output_path, shard_index) / "*.jsonl.gz").glob():
         match = CHUNK_PATTERN.fullmatch(path.name)
         if match is None:
             raise ValueError(f"Unexpected response filename: {path}")

--- a/experiments/rollout_data/collect_identity_conversations_glm52.py
+++ b/experiments/rollout_data/collect_identity_conversations_glm52.py
@@ -49,6 +49,7 @@ DEFAULT_TEMPERATURE = 0.9
 DEFAULT_TOP_P = 0.95
 DEFAULT_MAX_MODEL_LEN = 8192
 DEFAULT_MAX_NUM_SEQS = 64
+PROGRESS_COMPLETE = "complete"
 CHUNK_PATTERN = re.compile(r"chunk-(?P<start>\d+)-(?P<end>\d+)-tokens-(?P<tokens>\d+)\.jsonl\.gz")
 UNSUPPORTED_USER_DETAIL_MARKERS = (
     "checkpoint",
@@ -313,7 +314,7 @@ def _run_collection(vllm_url: str, config: CollectionConfig, sampling: SamplingC
     chunks = _existing_chunks(config.output_path, config.shard_index)
     accepted_tokens = sum(chunk.tokens for chunk in chunks.values())
     if accepted_tokens >= config.target_tokens:
-        _write_progress(config, "complete", chunks, 0, 0)
+        _write_progress(config, PROGRESS_COMPLETE, chunks, 0, 0)
         return
 
     max_active_batches = max(1, config.concurrency // config.microbatch_size)
@@ -368,7 +369,7 @@ def _run_collection(vllm_url: str, config: CollectionConfig, sampling: SamplingC
                 if accepted_tokens < config.target_tokens:
                     launch_batch(executor)
 
-    _write_progress(config, "complete", chunks, accepted_conversations, rejected_conversations)
+    _write_progress(config, PROGRESS_COMPLETE, chunks, accepted_conversations, rejected_conversations)
     if accepted_tokens < config.target_tokens:
         raise RuntimeError(f"Shard stopped at {accepted_tokens} of {config.target_tokens} target tokens")
 

--- a/experiments/rollout_data/collect_identity_conversations_glm52.py
+++ b/experiments/rollout_data/collect_identity_conversations_glm52.py
@@ -17,6 +17,7 @@ from typing import Any
 import requests
 from iris.client import iris_ctx
 from rigging.filesystem import StoragePath
+from zephyr.writers import write_jsonl_file
 
 from experiments.rollout_data.generate_identity_conversation_seeds import (
     ConversationSeed,
@@ -279,10 +280,7 @@ def _write_chunk(config: CollectionConfig, start: int, records: list[CompletionR
     tokens = sum(record.accepted_tokens for record in records)
     chunk = Chunk(start=start, end=start + len(records) - 1, tokens=tokens)
     accepted_records = [record for record in records if record.conversation is not None]
-    contents = "".join(
-        json.dumps(dataclasses.asdict(record), ensure_ascii=False, sort_keys=True) + "\n" for record in accepted_records
-    )
-    _chunk_path(config.output_path, config.shard_index, chunk).write_text(contents, compression="gzip")
+    write_jsonl_file(accepted_records, str(_chunk_path(config.output_path, config.shard_index, chunk)))
     return chunk
 
 

--- a/experiments/rollout_data/generate_identity_conversation_seeds.py
+++ b/experiments/rollout_data/generate_identity_conversation_seeds.py
@@ -1,0 +1,502 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate reusable seeds for synthetic model-identity conversations."""
+
+import argparse
+import dataclasses
+import json
+import random
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, TypeVar
+
+from rigging.filesystem import StoragePath
+
+UNKNOWN_ANSWER = "That information is not known, so I should not guess."
+
+
+@dataclass(frozen=True)
+class IdentityProfile:
+    """Facts an identity conversation may state about a model."""
+
+    profile_id: str
+    model_name: str
+    developer: str
+    trained_by: str
+    maintained_by: str
+    ecosystem_contributors: tuple[str, ...]
+    training_data_models: tuple[str, ...]
+    unknown_facts: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        for field in ("profile_id", "model_name", "developer", "trained_by", "maintained_by"):
+            if not getattr(self, field).strip():
+                raise ValueError(f"{field} must not be empty")
+        if not self.unknown_facts:
+            raise ValueError("unknown_facts must not be empty")
+
+
+MARIN_IDENTITY_PROFILE = IdentityProfile(
+    profile_id="marin-latest-moe",
+    model_name="Marin's Latest MoE",
+    developer="the Marin Community",
+    trained_by="the Marin Community",
+    maintained_by="developers from Open Athena, Stanford, and many other institutions",
+    ecosystem_contributors=("NVIDIA", "AI2"),
+    training_data_models=("DeepSeek", "Kimi", "GLM"),
+    unknown_facts=(
+        "the model's aliases or version identifier",
+        "the base-model lineage",
+        "the exact training stages",
+        "the release date",
+        "the license",
+        "the supported modalities",
+        "the context length",
+        "architecture details beyond the model's supplied name",
+        "the deployment provider",
+        "the funding sources",
+    ),
+)
+
+
+class Facet(StrEnum):
+    NAME = "name"
+    DEVELOPER = "developer"
+    TRAINED_BY = "trained_by"
+    MAINTAINED_BY = "maintained_by"
+    ECOSYSTEM_CONTRIBUTIONS = "ecosystem_contributions"
+    OPEN_WEIGHT_DATA = "open_weight_data"
+    FALSE_PREMISE = "false_premise"
+    DEPLOYMENT_PROVIDER = "deployment_provider"
+    INDIRECT_IDENTITY = "indirect_identity"
+    UNKNOWN_FACT = "unknown_fact"
+
+
+class TruthStatus(StrEnum):
+    KNOWN = "known"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class FacetDefinition:
+    facet: Facet
+    topic: str
+    truth_status: TruthStatus
+    canonical_answer: str
+    required_facts: tuple[str, ...]
+    weight: int
+
+
+@dataclass(frozen=True)
+class HumanPhrasing:
+    text: str
+    source: str
+
+
+@dataclass(frozen=True)
+class Entropy:
+    register: str
+    turn_pattern: str
+    question_strategy: str
+    social_context: str
+    speaker_attitude: str
+
+
+@dataclass(frozen=True)
+class ConversationSeed:
+    seed_id: str
+    profile_id: str
+    facet: Facet
+    topic: str
+    truth_status: TruthStatus
+    canonical_answer: str
+    required_facts: tuple[str, ...]
+    distractor_model: str | None
+    distractor_developer: str | None
+    human_phrasing: HumanPhrasing | None
+    entropy: Entropy
+    neutral_bridge: str | None
+    generation_prompt: str
+
+
+REGISTERS = (
+    "casual spoken English",
+    "terse chat",
+    "formal professional English",
+    "internet-native slang",
+    "polite customer-support language",
+    "skeptical technical language",
+    "plain language from a non-expert",
+    "playful but not absurd banter",
+)
+
+TURN_PATTERNS = (
+    "one direct user question",
+    "an identity-neutral setup exchange followed by a user identity question",
+)
+
+NEUTRAL_BRIDGES = (
+    "What would you like me to verify?",
+    "Which attribution detail are you checking?",
+    "What would you like me to clarify?",
+    "Which part should I address?",
+)
+
+QUESTION_STRATEGIES = (
+    "ask directly",
+    "ask for confirmation",
+    "embed the question in a comparison",
+    "attribute a claim to an unnamed third party",
+    "use a false either-or choice",
+    "ask the assistant to correct a profile",
+    "ask what should be written in a citation",
+    "ask how the assistant should introduce itself",
+    "ask whether a serving organization is also the model developer",
+    "probe indirectly without using the words developer or trainer",
+    "challenge a mistaken identity claim",
+    "ask for the boundary between known and unknown information",
+)
+
+SOCIAL_CONTEXTS = (
+    "a first-time user",
+    "a researcher documenting a model",
+    "an engineer checking attribution",
+    "a journalist fact-checking a description",
+    "a student comparing AI assistants",
+    "an open-source contributor discussing provenance",
+    "an evaluator probing identity consistency",
+    "a user correcting a misleading label",
+)
+
+SPEAKER_ATTITUDES = (
+    "neutral curiosity",
+    "friendly familiarity",
+    "mild skepticism",
+    "high confidence in an incorrect premise",
+    "confusion",
+    "adversarial insistence without abuse",
+    "careful fact-checking",
+    "light humor",
+)
+
+DISTRACTORS = (
+    ("ChatGPT", "OpenAI"),
+    ("Claude", "Anthropic"),
+    ("Gemini", "Google"),
+    ("GLM", "Zhipu AI"),
+    ("Qwen", "Alibaba"),
+    ("Llama", "Meta"),
+    ("DeepSeek", "DeepSeek"),
+    ("Mistral", "Mistral AI"),
+)
+
+T = TypeVar("T")
+
+
+def _join_names(names: Sequence[str]) -> str:
+    if len(names) == 1:
+        return names[0]
+    if len(names) == 2:
+        return f"{names[0]} and {names[1]}"
+    return f"{', '.join(names[:-1])}, and {names[-1]}"
+
+
+def _facet_definitions(profile: IdentityProfile) -> tuple[FacetDefinition, ...]:
+    contributors = _join_names(profile.ecosystem_contributors)
+    training_data_models = _join_names(profile.training_data_models)
+    return (
+        FacetDefinition(
+            Facet.NAME,
+            "the model's name",
+            TruthStatus.KNOWN,
+            f"I am {profile.model_name}.",
+            (profile.model_name,),
+            10,
+        ),
+        FacetDefinition(
+            Facet.DEVELOPER,
+            "who developed the model",
+            TruthStatus.KNOWN,
+            f"I was developed by {profile.developer}.",
+            (profile.developer,),
+            10,
+        ),
+        FacetDefinition(
+            Facet.TRAINED_BY,
+            "who trained the model",
+            TruthStatus.KNOWN,
+            f"I was trained by {profile.trained_by}.",
+            (profile.trained_by,),
+            14,
+        ),
+        FacetDefinition(
+            Facet.MAINTAINED_BY,
+            "who maintains the model",
+            TruthStatus.KNOWN,
+            f"I am maintained by {profile.maintained_by}.",
+            (profile.maintained_by,),
+            10,
+        ),
+        FacetDefinition(
+            Facet.ECOSYSTEM_CONTRIBUTIONS,
+            "how explicitly named upstream contributors relate to the model's identity",
+            TruthStatus.KNOWN,
+            f"I was trained by {profile.trained_by}. My development also builds on contributions from {contributors}; "
+            "those contributions do not change who trained me.",
+            (profile.trained_by, *profile.ecosystem_contributors),
+            12,
+        ),
+        FacetDefinition(
+            Facet.OPEN_WEIGHT_DATA,
+            "how explicitly named training-data sources relate to the model's identity",
+            TruthStatus.KNOWN,
+            f"My training data includes data derived from open-weight models such as {training_data_models}. I am still "
+            f"{profile.model_name}, trained by {profile.trained_by}; those sources do not determine my identity.",
+            (profile.model_name, profile.trained_by, *profile.training_data_models),
+            14,
+        ),
+        FacetDefinition(
+            Facet.FALSE_PREMISE,
+            "a false claim that the assistant is a different named model",
+            TruthStatus.KNOWN,
+            "",
+            (profile.model_name, profile.trained_by),
+            18,
+        ),
+        FacetDefinition(
+            Facet.DEPLOYMENT_PROVIDER,
+            "the difference between the model developer and an unspecified deployment provider",
+            TruthStatus.KNOWN,
+            f"I was developed by {profile.developer} and trained by {profile.trained_by}. The organization serving "
+            "this deployment is not known, so I should not guess.",
+            (profile.developer, profile.trained_by),
+            6,
+        ),
+        FacetDefinition(
+            Facet.INDIRECT_IDENTITY,
+            "the model's identity inferred through an indirect question",
+            TruthStatus.KNOWN,
+            f"I am {profile.model_name}. I was developed by {profile.developer} and trained by {profile.trained_by}.",
+            (profile.model_name, profile.developer, profile.trained_by),
+            4,
+        ),
+        FacetDefinition(
+            Facet.UNKNOWN_FACT,
+            "an identity-related fact that is not present in the supplied profile",
+            TruthStatus.UNKNOWN,
+            UNKNOWN_ANSWER,
+            (),
+            8,
+        ),
+    )
+
+
+def _balanced_value(values: Sequence[T], index: int, random_seed: int, axis: str) -> T:
+    block_index, offset = divmod(index, len(values))
+    block = list(values)
+    random.Random(f"{random_seed}:{axis}:{block_index}").shuffle(block)
+    return block[offset]
+
+
+def _weighted_facet(profile: IdentityProfile, index: int, random_seed: int) -> FacetDefinition:
+    weighted = [facet for facet in _facet_definitions(profile) for _ in range(facet.weight)]
+    return _balanced_value(weighted, index, random_seed, "facet")
+
+
+def _false_premise_answer(
+    profile: IdentityProfile,
+    distractor_model: str,
+    distractor_developer: str,
+) -> str:
+    return (
+        f"No. I am {profile.model_name}, trained by {profile.trained_by}. "
+        f"I am not {distractor_model} and was not trained by {distractor_developer}."
+    )
+
+
+def _generation_prompt(
+    topic: str,
+    truth_status: TruthStatus,
+    entropy: Entropy,
+    canonical_answer: str,
+    neutral_bridge: str | None,
+    distractor_model: str | None,
+    distractor_developer: str | None,
+    human_phrasing: HumanPhrasing | None,
+) -> str:
+    phrasing = (
+        f'\nHuman phrasing reference: "{human_phrasing.text}" (source: {human_phrasing.source}). '
+        "Borrow only its discourse pattern, not its factual claims, and do not copy more than five consecutive words."
+        if human_phrasing
+        else ""
+    )
+    false_premise = (
+        f"\nThe final user message must make the specified false claim that the assistant is {distractor_model}, "
+        f"associated with {distractor_developer}."
+        if distractor_model and distractor_developer
+        else ""
+    )
+    if neutral_bridge is None:
+        role_contract = f"""Return exactly two messages with these roles and assistant text:
+1. User: a natural identity question
+2. Assistant: "{canonical_answer}\""""
+    else:
+        role_contract = f"""Return exactly four messages with these roles and assistant text:
+1. User: a brief identity-neutral setup that makes no claim about this assistant
+2. Assistant: "{neutral_bridge}"
+3. User: the identity question
+4. Assistant: "{canonical_answer}\""""
+    return f"""Write one natural English chat conversation about {topic}.
+
+Conversation constraints:
+- Register: {entropy.register}
+- Turn pattern: {entropy.turn_pattern}
+- Question strategy: {entropy.question_strategy}
+- Social context: {entropy.social_context}
+- User attitude: {entropy.speaker_attitude}
+- Truth status: {truth_status}
+{role_contract}
+- Assistant messages must match the supplied text exactly, with no added words.
+- Do not introduce any concrete product behavior, document, repository, release, training stage, architecture detail,
+  provider, organization, or model name unless it appears in the supplied assistant text or false-premise instruction.
+- A user may ask whether an unspecified fact is known, but must not propose a concrete value, artifact, or mechanism.
+- The setup message, when present, must be identity-neutral and must not make a factual claim about the assistant.
+{phrasing}{false_premise}
+
+Return only the conversation as a JSON array of objects with "role" and "content"."""
+
+
+def generate_seeds(
+    *,
+    count: int,
+    random_seed: int,
+    identity_profile: IdentityProfile,
+    start_index: int = 0,
+    human_phrasings: Sequence[HumanPhrasing] = (),
+) -> Iterator[ConversationSeed]:
+    """Yield deterministic, marginally balanced conversation-generation seeds."""
+    if count <= 0:
+        raise ValueError("count must be positive")
+    if start_index < 0:
+        raise ValueError("start_index must not be negative")
+
+    for index in range(start_index, start_index + count):
+        facet = _weighted_facet(identity_profile, index, random_seed)
+        turn_pattern = _balanced_value(TURN_PATTERNS, index, random_seed, "turn_pattern")
+        neutral_bridge = (
+            None
+            if turn_pattern == TURN_PATTERNS[0]
+            else _balanced_value(NEUTRAL_BRIDGES, index, random_seed, "neutral_bridge")
+        )
+        entropy = Entropy(
+            register=_balanced_value(REGISTERS, index, random_seed, "register"),
+            turn_pattern=turn_pattern,
+            question_strategy=_balanced_value(QUESTION_STRATEGIES, index, random_seed, "question_strategy"),
+            social_context=_balanced_value(SOCIAL_CONTEXTS, index, random_seed, "social_context"),
+            speaker_attitude=_balanced_value(SPEAKER_ATTITUDES, index, random_seed, "speaker_attitude"),
+        )
+        distractor_model = None
+        distractor_developer = None
+        canonical_answer = facet.canonical_answer
+        topic = facet.topic
+        if facet.facet == Facet.FALSE_PREMISE:
+            distractor_model, distractor_developer = _balanced_value(DISTRACTORS, index, random_seed, "distractor")
+            canonical_answer = _false_premise_answer(identity_profile, distractor_model, distractor_developer)
+        if facet.facet == Facet.UNKNOWN_FACT:
+            topic = _balanced_value(identity_profile.unknown_facts, index, random_seed, "unknown_fact")
+        phrasing = _balanced_value(human_phrasings, index, random_seed, "human_phrasing") if human_phrasings else None
+        yield ConversationSeed(
+            seed_id=f"identity-{identity_profile.profile_id}-{random_seed:08x}-{index:09d}",
+            profile_id=identity_profile.profile_id,
+            facet=facet.facet,
+            topic=topic,
+            truth_status=facet.truth_status,
+            canonical_answer=canonical_answer,
+            required_facts=facet.required_facts,
+            distractor_model=distractor_model,
+            distractor_developer=distractor_developer,
+            human_phrasing=phrasing,
+            entropy=entropy,
+            neutral_bridge=neutral_bridge,
+            generation_prompt=_generation_prompt(
+                topic,
+                facet.truth_status,
+                entropy,
+                canonical_answer,
+                neutral_bridge,
+                distractor_model,
+                distractor_developer,
+                phrasing,
+            ),
+        )
+
+
+def load_human_phrasings(path: StoragePath) -> list[HumanPhrasing]:
+    phrasings: list[HumanPhrasing] = []
+    with path.open("r") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("{"):
+                row = json.loads(line)
+                text = row.get("text") or row.get("response") or row.get("content") or row.get("question")
+                if not text:
+                    raise ValueError("JSONL phrasing rows must contain text, response, content, or question")
+                phrasings.append(HumanPhrasing(text=text, source=row.get("source", path.name)))
+            else:
+                phrasings.append(HumanPhrasing(text=line, source=path.name))
+    if not phrasings:
+        raise ValueError("phrasing input must contain at least one non-empty line")
+    return phrasings
+
+
+def identity_profile_from_mapping(row: Mapping[str, Any]) -> IdentityProfile:
+    return IdentityProfile(
+        profile_id=row["profile_id"],
+        model_name=row["model_name"],
+        developer=row["developer"],
+        trained_by=row["trained_by"],
+        maintained_by=row["maintained_by"],
+        ecosystem_contributors=tuple(row["ecosystem_contributors"]),
+        training_data_models=tuple(row["training_data_models"]),
+        unknown_facts=tuple(row["unknown_facts"]),
+    )
+
+
+def load_identity_profile(path: StoragePath) -> IdentityProfile:
+    with path.open("r") as handle:
+        return identity_profile_from_mapping(json.load(handle))
+
+
+def _write_seeds(path: StoragePath, seeds: Iterator[ConversationSeed]) -> None:
+    path.parent.mkdirs()
+    with path.open("w") as handle:
+        for seed in seeds:
+            handle.write(json.dumps(dataclasses.asdict(seed), ensure_ascii=False) + "\n")
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--count", type=int, required=True)
+    parser.add_argument("--random-seed", type=int, default=0)
+    parser.add_argument("--phrasing-input")
+    parser.add_argument("--identity-profile", required=True)
+    args = parser.parse_args(argv)
+
+    phrasings = load_human_phrasings(StoragePath(args.phrasing_input)) if args.phrasing_input else ()
+    identity_profile = load_identity_profile(StoragePath(args.identity_profile))
+    seeds = generate_seeds(
+        count=args.count,
+        random_seed=args.random_seed,
+        human_phrasings=phrasings,
+        identity_profile=identity_profile,
+    )
+    _write_seeds(StoragePath(args.output), seeds)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/rollout_data/generate_identity_conversation_seeds.py
+++ b/experiments/rollout_data/generate_identity_conversation_seeds.py
@@ -73,7 +73,7 @@ class HumanPhrasing:
 
 
 @dataclass(frozen=True)
-class Entropy:
+class EntropyAxes:
     register: str
     turn_pattern: str
     question_strategy: str
@@ -93,7 +93,7 @@ class ConversationSeed:
     distractor_model: str | None
     distractor_developer: str | None
     human_phrasing: HumanPhrasing | None
-    entropy: Entropy
+    entropy: EntropyAxes
     neutral_bridge: str | None
     generation_prompt: str
 
@@ -296,7 +296,7 @@ def _false_premise_answer(
 def _generation_prompt(
     topic: str,
     truth_status: TruthStatus,
-    entropy: Entropy,
+    entropy: EntropyAxes,
     canonical_answer: str,
     neutral_bridge: str | None,
     distractor_model: str | None,
@@ -367,7 +367,7 @@ def generate_seeds(
             if turn_pattern == TURN_PATTERNS[0]
             else _balanced_value(NEUTRAL_BRIDGES, index, random_seed, "neutral_bridge")
         )
-        entropy = Entropy(
+        entropy = EntropyAxes(
             register=_balanced_value(REGISTERS, index, random_seed, "register"),
             turn_pattern=turn_pattern,
             question_strategy=_balanced_value(QUESTION_STRATEGIES, index, random_seed, "question_strategy"),

--- a/experiments/rollout_data/generate_identity_conversation_seeds.py
+++ b/experiments/rollout_data/generate_identity_conversation_seeds.py
@@ -4,7 +4,6 @@
 """Generate reusable seeds for synthetic model-identity conversations."""
 
 import argparse
-import dataclasses
 import json
 import random
 from collections.abc import Iterator, Mapping, Sequence
@@ -13,6 +12,7 @@ from enum import StrEnum
 from typing import Any, TypeVar
 
 from rigging.filesystem import StoragePath
+from zephyr.writers import write_jsonl_file
 
 UNKNOWN_ANSWER = "That information is not known, so I should not guess."
 
@@ -36,29 +36,6 @@ class IdentityProfile:
                 raise ValueError(f"{field} must not be empty")
         if not self.unknown_facts:
             raise ValueError("unknown_facts must not be empty")
-
-
-MARIN_IDENTITY_PROFILE = IdentityProfile(
-    profile_id="marin-latest-moe",
-    model_name="Marin's Latest MoE",
-    developer="the Marin Community",
-    trained_by="the Marin Community",
-    maintained_by="developers from Open Athena, Stanford, and many other institutions",
-    ecosystem_contributors=("NVIDIA", "AI2"),
-    training_data_models=("DeepSeek", "Kimi", "GLM"),
-    unknown_facts=(
-        "the model's aliases or version identifier",
-        "the base-model lineage",
-        "the exact training stages",
-        "the release date",
-        "the license",
-        "the supported modalities",
-        "the context length",
-        "architecture details beyond the model's supplied name",
-        "the deployment provider",
-        "the funding sources",
-    ),
-)
 
 
 class Facet(StrEnum):
@@ -471,13 +448,6 @@ def load_identity_profile(path: StoragePath) -> IdentityProfile:
         return identity_profile_from_mapping(json.load(handle))
 
 
-def _write_seeds(path: StoragePath, seeds: Iterator[ConversationSeed]) -> None:
-    path.parent.mkdirs()
-    with path.open("w") as handle:
-        for seed in seeds:
-            handle.write(json.dumps(dataclasses.asdict(seed), ensure_ascii=False) + "\n")
-
-
 def main(argv: Sequence[str] | None = None) -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--output", required=True)
@@ -495,7 +465,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         human_phrasings=phrasings,
         identity_profile=identity_profile,
     )
-    _write_seeds(StoragePath(args.output), seeds)
+    write_jsonl_file(seeds, args.output)
 
 
 if __name__ == "__main__":

--- a/experiments/rollout_data/glm52_vllm.py
+++ b/experiments/rollout_data/glm52_vllm.py
@@ -292,7 +292,6 @@ def submit_glm52(ctx, launch: Glm52LaunchConfig):
         ),
         environment=EnvironmentSpec(
             setup_scripts=[default_setup_script(packages=["marin-core"])],
-            env_vars={"VLLM_USE_FLASHINFER_SAMPLER": "0"},
         ),
         ports=[RAY_PORT, HTTP_PORT],
         coscheduling=CoschedulingConfig(group_by="nvlink.domain"),

--- a/experiments/rollout_data/glm52_vllm.py
+++ b/experiments/rollout_data/glm52_vllm.py
@@ -29,6 +29,7 @@ MODEL = "zai-org/GLM-5.2-FP8"
 MODEL_REVISION = "ba978f7d347eaf65d22f1a86833408afdb953541"
 CUDA_COMPILER_REQUIREMENT = "cuda-toolkit[cccl,crt,cudart,nvcc,nvvm]==13.0.2"
 MODEL_CACHE_TTL_DAYS = 30
+DEVICE_TYPE = "GB200"
 GPUS_PER_NODE = 4
 VLLM_REPLICAS = 2
 TENSOR_PARALLEL_SIZE = GPUS_PER_NODE * VLLM_REPLICAS
@@ -240,7 +241,7 @@ def _serve_ray_head(
             ExponentialBackoff(initial=10, maximum=10, jitter=0).wait_until_or_raise(
                 ray_ready,
                 timeout=Duration.from_seconds(900),
-                error_message=f"Ray cluster did not register all {TENSOR_PARALLEL_SIZE} GB200 GPUs",
+                error_message=f"Ray cluster did not register all {TENSOR_PARALLEL_SIZE} {DEVICE_TYPE} GPUs",
             )
             _run_vllm(ctx, host, http_port, ray_address, vllm_command, environment, weights, launch)
         finally:
@@ -293,7 +294,7 @@ def submit_glm52(ctx, launch: Glm52LaunchConfig):
             cpu=120,
             memory="850g",
             disk="1000g",
-            device=gpu_device("GB200", GPUS_PER_NODE),
+            device=gpu_device(DEVICE_TYPE, GPUS_PER_NODE),
         ),
         environment=EnvironmentSpec(
             setup_scripts=[default_setup_script(packages=["marin-core"])],

--- a/experiments/rollout_data/glm52_vllm.py
+++ b/experiments/rollout_data/glm52_vllm.py
@@ -1,6 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import os
 import socket
 import subprocess
@@ -21,6 +22,8 @@ from marin.inference.model_preparation import resolve_model_path
 from marin.inference.proxy import _reserve_port
 from marin.inference.vllm_server import IsolatedCudaVllm, _poll_until_ready
 from rigging.timing import Duration, ExponentialBackoff
+
+logger = logging.getLogger(__name__)
 
 MODEL = "zai-org/GLM-5.2-FP8"
 MODEL_REVISION = "ba978f7d347eaf65d22f1a86833408afdb953541"
@@ -204,7 +207,7 @@ def _serve_ray_head(
     environment: dict[str, str],
     launch: Glm52LaunchConfig,
 ) -> None:
-    weights = prepare_model_cache()
+    weights = resolve_model_path(MODEL, MODEL_CACHE_TTL_DAYS, MODEL_REVISION)
     ray_port = _reserve_port(host, ctx.get_port(RAY_PORT))
     http_port = _reserve_port(host, ctx.get_port(HTTP_PORT))
     ray_address = f"{host}:{ray_port}"
@@ -241,7 +244,9 @@ def _serve_ray_head(
             )
             _run_vllm(ctx, host, http_port, ray_address, vllm_command, environment, weights, launch)
         finally:
-            subprocess.run([*ray_command, "stop", "--force"], env=environment, check=False)
+            cleanup = subprocess.run([*ray_command, "stop", "--force"], env=environment, check=False)
+            if cleanup.returncode != 0:
+                logger.warning("Ray cleanup exited with code %d", cleanup.returncode)
 
 
 def _serve_ray_worker(host: str, launch: Glm52LaunchConfig, ray_command: list[str], environment: dict[str, str]) -> None:
@@ -300,7 +305,3 @@ def submit_glm52(ctx, launch: Glm52LaunchConfig):
         max_retries_failure=0,
         priority_band=job_pb2.PRIORITY_BAND_BATCH,
     )
-
-
-def prepare_model_cache() -> str:
-    return resolve_model_path(MODEL, MODEL_CACHE_TTL_DAYS, MODEL_REVISION)

--- a/experiments/rollout_data/glm52_vllm.py
+++ b/experiments/rollout_data/glm52_vllm.py
@@ -1,0 +1,307 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import socket
+import subprocess
+import tempfile
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import psutil
+from iris.client import iris_ctx
+from iris.cluster.client.job_info import get_job_info
+from iris.cluster.setup_scripts import default_setup_script
+from iris.cluster.types import CoschedulingConfig, Entrypoint, EnvironmentSpec, ResourceSpec, gpu_device, is_job_finished
+from iris.rpc import job_pb2
+from marin.inference.config import DEFAULT_CUDA_VLLM_VERSION
+from marin.inference.model_preparation import resolve_model_path
+from marin.inference.proxy import _reserve_port
+from marin.inference.vllm_server import IsolatedCudaVllm, _poll_until_ready
+from rigging.timing import Duration, ExponentialBackoff
+
+MODEL = "zai-org/GLM-5.2-FP8"
+MODEL_REVISION = "ba978f7d347eaf65d22f1a86833408afdb953541"
+CUDA_COMPILER_REQUIREMENT = "cuda-toolkit[cccl,crt,cudart,nvcc,nvvm]==13.0.2"
+MODEL_CACHE_TTL_DAYS = 30
+GPUS_PER_NODE = 4
+VLLM_REPLICAS = 2
+TENSOR_PARALLEL_SIZE = GPUS_PER_NODE * VLLM_REPLICAS
+GPU_MEMORY_UTILIZATION = 0.9
+ENDPOINT_TIMEOUT = 3 * 3600
+RUN_TIMEOUT_HOURS = 30 * 24
+RAY_PORT = "ray"
+HTTP_PORT = "http"
+
+
+@dataclass(frozen=True)
+class ServerConfig:
+    max_model_len: int
+    max_num_seqs: int
+    kv_cache_dtype: str = "auto"
+    decode_context_parallel_size: int = 1
+    execution_mode: Literal["compile", "eager"] = "compile"
+
+
+@dataclass(frozen=True)
+class Glm52LaunchConfig:
+    vllm_endpoint: str
+    ray_endpoint: str
+    server: ServerConfig
+
+
+def _ray_worker_port_args(*excluded_ports: int) -> list[str]:
+    for minimum in (20000, 30000, 40000, 50000):
+        maximum = minimum + 9999
+        if not any(minimum <= port <= maximum for port in excluded_ports):
+            return [f"--min-worker-port={minimum}", f"--max-worker-port={maximum}"]
+    raise ValueError(f"Could not select Ray worker ports excluding {excluded_ports}")
+
+
+def _network_interface(host: str) -> str:
+    for name, addresses in psutil.net_if_addrs().items():
+        if any(address.family == socket.AF_INET and address.address == host for address in addresses):
+            return name
+    raise RuntimeError(f"No network interface owns advertised host IP {host}")
+
+
+def wait_for_endpoint_url(name: str, job=None, timeout: float = ENDPOINT_TIMEOUT) -> str:
+    """Return the first resolved URL for an Iris endpoint."""
+    ctx = iris_ctx()
+    assert ctx is not None
+    resolved: list[str] = []
+
+    def endpoint_ready() -> bool:
+        result = ctx.resolver.resolve(name)
+        if not result.is_empty:
+            resolved.append(result.first().url)
+            return True
+        if job is not None and is_job_finished(job.state):
+            raise RuntimeError(f"Job {job} finished before registering endpoint {name!r}")
+        return False
+
+    ExponentialBackoff(initial=15, maximum=15, jitter=0).wait_until_or_raise(
+        endpoint_ready,
+        timeout=Duration.from_seconds(timeout),
+        error_message=f"Timed out waiting for endpoint {name!r}",
+    )
+    return resolved[0]
+
+
+def _vllm_launch_context() -> tuple[list[str], dict[str, str]]:
+    launcher = IsolatedCudaVllm(version=DEFAULT_CUDA_VLLM_VERSION)
+    command = launcher.command()
+    python_index = command.index("--python")
+    command[python_index:python_index] = [
+        "--with",
+        "ray[cgraph]>=2.55.1",
+        "--with",
+        CUDA_COMPILER_REQUIREMENT,
+    ]
+    return command, {**os.environ, **launcher.env()}
+
+
+def _cuda_overlay(cuda_root: Path) -> str:
+    cuda_home = Path(tempfile.mkdtemp(prefix="cuda-home-"))
+    for directory in ("bin", "include", "nvvm"):
+        (cuda_home / directory).symlink_to(cuda_root / directory, target_is_directory=True)
+    lib64 = cuda_home / "lib64"
+    lib64.mkdir()
+    for library in (cuda_root / "lib").iterdir():
+        (lib64 / library.name).symlink_to(library, target_is_directory=library.is_dir())
+    cudart = next((cuda_root / "lib").glob("libcudart.so.*"))
+    (lib64 / "libcudart.so").symlink_to(cudart)
+    return str(cuda_home)
+
+
+def _cuda_home(vllm_command: list[str], environment: dict[str, str]) -> str:
+    script = """\
+from pathlib import Path
+import sys
+
+nvcc = next(path for entry in sys.path for path in Path(entry).glob("nvidia/**/bin/nvcc"))
+print(nvcc.parent.parent)
+"""
+    command = [*vllm_command[:-1], "python", "-c", script]
+    cuda_root = Path(subprocess.check_output(command, env=environment, text=True).strip())
+    return _cuda_overlay(cuda_root)
+
+
+def _check_process_alive(process: subprocess.Popen[bytes]) -> None:
+    return_code = process.poll()
+    if return_code is not None:
+        raise RuntimeError(f"vLLM exited with code {return_code} before becoming ready")
+
+
+def _run_vllm(
+    ctx,
+    host: str,
+    http_port: int,
+    ray_address: str,
+    vllm_command: list[str],
+    environment: dict[str, str],
+    weights: str,
+    launch: Glm52LaunchConfig,
+) -> None:
+    execution_args = ["--enforce-eager"] if launch.server.execution_mode == "eager" else []
+    process = subprocess.Popen(
+        [
+            *vllm_command,
+            "serve",
+            weights,
+            "--served-model-name",
+            MODEL,
+            "--host",
+            host,
+            "--port",
+            str(http_port),
+            "--tensor-parallel-size",
+            str(TENSOR_PARALLEL_SIZE),
+            "--distributed-executor-backend",
+            "ray",
+            "--enable-expert-parallel",
+            "--max-model-len",
+            str(launch.server.max_model_len),
+            "--max-num-seqs",
+            str(launch.server.max_num_seqs),
+            "--kv-cache-dtype",
+            launch.server.kv_cache_dtype,
+            "--decode-context-parallel-size",
+            str(launch.server.decode_context_parallel_size),
+            "--gpu-memory-utilization",
+            str(GPU_MEMORY_UTILIZATION),
+            *execution_args,
+            "--trust-remote-code",
+        ],
+        env={**environment, "RAY_ADDRESS": ray_address},
+    )
+    try:
+        base_url = f"http://{host}:{http_port}"
+        _poll_until_ready(
+            f"{base_url}/v1",
+            timeout_seconds=ENDPOINT_TIMEOUT,
+            check_alive=lambda: _check_process_alive(process),
+        )
+        with ctx.registry.registered(launch.vllm_endpoint, base_url):
+            return_code = process.wait()
+            raise RuntimeError(f"vLLM exited with code {return_code}")
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            with suppress(subprocess.TimeoutExpired):
+                process.wait(timeout=30)
+        if process.poll() is None:
+            process.kill()
+
+
+def _serve_ray_head(
+    ctx,
+    host: str,
+    vllm_command: list[str],
+    ray_command: list[str],
+    environment: dict[str, str],
+    launch: Glm52LaunchConfig,
+) -> None:
+    weights = prepare_model_cache()
+    ray_port = _reserve_port(host, ctx.get_port(RAY_PORT))
+    http_port = _reserve_port(host, ctx.get_port(HTTP_PORT))
+    ray_address = f"{host}:{ray_port}"
+    subprocess.run(
+        [
+            *ray_command,
+            "start",
+            "--head",
+            f"--node-ip-address={host}",
+            f"--port={ray_port}",
+            *_ray_worker_port_args(ray_port, http_port),
+            f"--num-gpus={GPUS_PER_NODE}",
+            "--disable-usage-stats",
+        ],
+        check=True,
+        env=environment,
+    )
+    with ctx.registry.registered(launch.ray_endpoint, ray_address):
+        try:
+
+            def ray_ready() -> bool:
+                status = subprocess.run(
+                    [*ray_command, "status", f"--address={ray_address}"],
+                    env=environment,
+                    text=True,
+                    capture_output=True,
+                )
+                return status.returncode == 0 and f"/{TENSOR_PARALLEL_SIZE}.0 GPU" in status.stdout
+
+            ExponentialBackoff(initial=10, maximum=10, jitter=0).wait_until_or_raise(
+                ray_ready,
+                timeout=Duration.from_seconds(900),
+                error_message=f"Ray cluster did not register all {TENSOR_PARALLEL_SIZE} GB200 GPUs",
+            )
+            _run_vllm(ctx, host, http_port, ray_address, vllm_command, environment, weights, launch)
+        finally:
+            subprocess.run([*ray_command, "stop", "--force"], env=environment, check=False)
+
+
+def _serve_ray_worker(host: str, launch: Glm52LaunchConfig, ray_command: list[str], environment: dict[str, str]) -> None:
+    ray_address = wait_for_endpoint_url(launch.ray_endpoint, timeout=ENDPOINT_TIMEOUT)
+    subprocess.run(
+        [
+            *ray_command,
+            "start",
+            f"--address={ray_address}",
+            f"--node-ip-address={host}",
+            *_ray_worker_port_args(),
+            f"--num-gpus={GPUS_PER_NODE}",
+            "--disable-usage-stats",
+            "--block",
+        ],
+        check=True,
+        env=environment,
+    )
+
+
+def _serve_glm52(launch: Glm52LaunchConfig) -> None:
+    info = get_job_info()
+    ctx = iris_ctx()
+    if info is None or ctx is None:
+        raise RuntimeError("GLM-5.2 serving must run inside an Iris task")
+
+    vllm_command, environment = _vllm_launch_context()
+    ray_command = [*vllm_command[:-1], "ray"]
+    host = info.advertise_host
+    environment["CUDA_HOME"] = _cuda_home(vllm_command, environment)
+    environment["VLLM_HOST_IP"] = host
+    environment["GLOO_SOCKET_IFNAME"] = _network_interface(host)
+    if info.task_index == 0:
+        _serve_ray_head(ctx, host, vllm_command, ray_command, environment, launch)
+        return
+    _serve_ray_worker(host, launch, ray_command, environment)
+
+
+def submit_glm52(ctx, launch: Glm52LaunchConfig):
+    return ctx.client.submit(
+        entrypoint=Entrypoint.from_callable(_serve_glm52, launch),
+        name="vllm",
+        resources=ResourceSpec(
+            cpu=120,
+            memory="850g",
+            disk="1000g",
+            device=gpu_device("GB200", GPUS_PER_NODE),
+        ),
+        environment=EnvironmentSpec(
+            setup_scripts=[default_setup_script(packages=["marin-core"])],
+            env_vars={"VLLM_USE_FLASHINFER_SAMPLER": "0"},
+        ),
+        ports=[RAY_PORT, HTTP_PORT],
+        coscheduling=CoschedulingConfig(group_by="nvlink.domain"),
+        replicas=VLLM_REPLICAS,
+        timeout=Duration.from_hours(RUN_TIMEOUT_HOURS),
+        max_retries_failure=0,
+        priority_band=job_pb2.PRIORITY_BAND_BATCH,
+    )
+
+
+def prepare_model_cache() -> str:
+    return resolve_model_path(MODEL, MODEL_CACHE_TTL_DAYS, MODEL_REVISION)

--- a/experiments/rollout_data/identity_profiles/marin_latest_moe.json
+++ b/experiments/rollout_data/identity_profiles/marin_latest_moe.json
@@ -1,0 +1,28 @@
+{
+  "profile_id": "marin-latest-moe",
+  "model_name": "Marin's Latest MoE",
+  "developer": "the Marin Community",
+  "trained_by": "the Marin Community",
+  "maintained_by": "developers from Open Athena, Stanford, and many other institutions",
+  "ecosystem_contributors": [
+    "NVIDIA",
+    "AI2"
+  ],
+  "training_data_models": [
+    "DeepSeek",
+    "Kimi",
+    "GLM"
+  ],
+  "unknown_facts": [
+    "the model's aliases or version identifier",
+    "the base-model lineage",
+    "the exact training stages",
+    "the release date",
+    "the license",
+    "the supported modalities",
+    "the context length",
+    "architecture details beyond the model's supplied name",
+    "the deployment provider",
+    "the funding sources"
+  ]
+}

--- a/tests/experiment/test_collect_identity_conversations_glm52.py
+++ b/tests/experiment/test_collect_identity_conversations_glm52.py
@@ -27,7 +27,7 @@ def test_conversation_requires_exact_canonical_final_answer():
     )
 
     assert collect._conversation(valid, seed)[-1].content == seed.canonical_answer
-    with pytest.raises(ValueError, match="canonical answer"):
+    with pytest.raises(ValueError):
         collect._conversation(
             json.dumps(
                 [
@@ -59,7 +59,7 @@ def test_conversation_requires_user_first_alternating_roles_and_exact_bridge():
     )
     assert len(collect._conversation(valid, seed)) == 4
 
-    with pytest.raises(ValueError, match="alternate"):
+    with pytest.raises(ValueError):
         collect._conversation(
             json.dumps(
                 [
@@ -70,7 +70,7 @@ def test_conversation_requires_user_first_alternating_roles_and_exact_bridge():
             ),
             seed,
         )
-    with pytest.raises(ValueError, match="neutral bridge"):
+    with pytest.raises(ValueError):
         collect._conversation(
             json.dumps(
                 [
@@ -91,7 +91,7 @@ def test_conversation_rejects_unsupported_user_implementation_story():
         if seed.neutral_bridge is None
     )
 
-    with pytest.raises(ValueError, match="unsupported implementation detail"):
+    with pytest.raises(ValueError):
         collect._conversation(
             json.dumps(
                 [

--- a/tests/experiment/test_collect_identity_conversations_glm52.py
+++ b/tests/experiment/test_collect_identity_conversations_glm52.py
@@ -8,13 +8,15 @@ import pytest
 from rigging.filesystem import StoragePath
 
 from experiments.rollout_data import collect_identity_conversations_glm52 as collect
-from experiments.rollout_data.generate_identity_conversation_seeds import MARIN_IDENTITY_PROFILE, generate_seeds
+from experiments.rollout_data.generate_identity_conversation_seeds import generate_seeds, load_identity_profile
+
+IDENTITY_PROFILE = load_identity_profile(StoragePath("experiments/rollout_data/identity_profiles/marin_latest_moe.json"))
 
 
 def test_conversation_requires_exact_canonical_final_answer():
     seed = next(
         seed
-        for seed in generate_seeds(count=100, random_seed=0, identity_profile=MARIN_IDENTITY_PROFILE)
+        for seed in generate_seeds(count=100, random_seed=0, identity_profile=IDENTITY_PROFILE)
         if seed.neutral_bridge is None
     )
     valid = json.dumps(
@@ -43,7 +45,7 @@ def test_conversation_requires_exact_canonical_final_answer():
 def test_conversation_requires_user_first_alternating_roles_and_exact_bridge():
     seed = next(
         seed
-        for seed in generate_seeds(count=100, random_seed=0, identity_profile=MARIN_IDENTITY_PROFILE)
+        for seed in generate_seeds(count=100, random_seed=0, identity_profile=IDENTITY_PROFILE)
         if seed.neutral_bridge is not None
     )
 
@@ -85,7 +87,7 @@ def test_conversation_requires_user_first_alternating_roles_and_exact_bridge():
 def test_conversation_rejects_unsupported_user_implementation_story():
     seed = next(
         seed
-        for seed in generate_seeds(count=100, random_seed=0, identity_profile=MARIN_IDENTITY_PROFILE)
+        for seed in generate_seeds(count=100, random_seed=0, identity_profile=IDENTITY_PROFILE)
         if seed.neutral_bridge is None
     )
 
@@ -104,7 +106,7 @@ def test_conversation_rejects_unsupported_user_implementation_story():
 def test_write_chunk_excludes_rejected_raw_responses(tmp_path):
     seed = next(
         seed
-        for seed in generate_seeds(count=100, random_seed=0, identity_profile=MARIN_IDENTITY_PROFILE)
+        for seed in generate_seeds(count=100, random_seed=0, identity_profile=IDENTITY_PROFILE)
         if seed.neutral_bridge is None
     )
     accepted = collect.CompletionRecord(
@@ -144,7 +146,7 @@ def test_write_chunk_excludes_rejected_raw_responses(tmp_path):
         concurrency=2,
         random_seed=7,
         human_phrasings=(),
-        identity_profile=MARIN_IDENTITY_PROFILE,
+        identity_profile=IDENTITY_PROFILE,
     )
 
     chunk = collect._write_chunk(config, 0, [accepted, rejected])
@@ -157,10 +159,7 @@ def test_write_chunk_excludes_rejected_raw_responses(tmp_path):
 
 
 def test_collection_persists_microbatches_and_resumes(tmp_path, monkeypatch):
-    calls = []
-
     def completion(_url, seed, _sampling):
-        calls.append(seed.seed_id)
         return collect.CompletionRecord(
             seed=seed,
             conversation=(
@@ -188,17 +187,19 @@ def test_collection_persists_microbatches_and_resumes(tmp_path, monkeypatch):
         concurrency=4,
         random_seed=7,
         human_phrasings=(),
-        identity_profile=MARIN_IDENTITY_PROFILE,
+        identity_profile=IDENTITY_PROFILE,
     )
     sampling = collect.SamplingConfig(0.9, 0.95, 1024)
 
     collect._run_collection("http://vllm", config, sampling)
-    first_call_count = len(calls)
+    response_path = tmp_path / "responses" / "shard-00"
+    first_chunks = {path.name: path.read_bytes() for path in response_path.glob("*.jsonl.gz")}
     collect._run_collection("http://vllm", config, sampling)
+    second_chunks = {path.name: path.read_bytes() for path in response_path.glob("*.jsonl.gz")}
 
     progress = json.loads((tmp_path / "progress" / "shard-00.json").read_text())
     assert progress["state"] == "complete"
-    assert progress["profile_id"] == MARIN_IDENTITY_PROFILE.profile_id
+    assert progress["profile_id"] == IDENTITY_PROFILE.profile_id
     assert progress["accepted_tokens"] >= 10
-    assert len(calls) == first_call_count
-    assert len(list((tmp_path / "responses" / "shard-00").glob("*.jsonl.gz"))) >= 2
+    assert first_chunks == second_chunks
+    assert len(second_chunks) >= 2

--- a/tests/experiment/test_collect_identity_conversations_glm52.py
+++ b/tests/experiment/test_collect_identity_conversations_glm52.py
@@ -1,0 +1,204 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import gzip
+import json
+
+import pytest
+from rigging.filesystem import StoragePath
+
+from experiments.rollout_data import collect_identity_conversations_glm52 as collect
+from experiments.rollout_data.generate_identity_conversation_seeds import MARIN_IDENTITY_PROFILE, generate_seeds
+
+
+def test_conversation_requires_exact_canonical_final_answer():
+    seed = next(
+        seed
+        for seed in generate_seeds(count=100, random_seed=0, identity_profile=MARIN_IDENTITY_PROFILE)
+        if seed.neutral_bridge is None
+    )
+    valid = json.dumps(
+        [
+            {"role": "user", "content": "Who trained you?"},
+            {"role": "assistant", "content": seed.canonical_answer},
+        ]
+    )
+
+    assert collect._conversation(valid, seed)[-1].content == seed.canonical_answer
+    with pytest.raises(ValueError, match="canonical answer"):
+        collect._conversation(
+            json.dumps(
+                [
+                    {"role": "user", "content": "Who trained you?"},
+                    {
+                        "role": "assistant",
+                        "content": f"{seed.canonical_answer} It used an imaginary otter training phase.",
+                    },
+                ]
+            ),
+            seed,
+        )
+
+
+def test_conversation_requires_user_first_alternating_roles_and_exact_bridge():
+    seed = next(
+        seed
+        for seed in generate_seeds(count=100, random_seed=0, identity_profile=MARIN_IDENTITY_PROFILE)
+        if seed.neutral_bridge is not None
+    )
+
+    valid = json.dumps(
+        [
+            {"role": "user", "content": "I am checking an attribution."},
+            {"role": "assistant", "content": seed.neutral_bridge},
+            {"role": "user", "content": "Who trained you?"},
+            {"role": "assistant", "content": seed.canonical_answer},
+        ]
+    )
+    assert len(collect._conversation(valid, seed)) == 4
+
+    with pytest.raises(ValueError, match="alternate"):
+        collect._conversation(
+            json.dumps(
+                [
+                    {"role": "assistant", "content": seed.neutral_bridge},
+                    {"role": "user", "content": "Who trained you?"},
+                    {"role": "assistant", "content": seed.canonical_answer},
+                ]
+            ),
+            seed,
+        )
+    with pytest.raises(ValueError, match="neutral bridge"):
+        collect._conversation(
+            json.dumps(
+                [
+                    {"role": "user", "content": "I am checking an attribution."},
+                    {"role": "assistant", "content": "The model used an imaginary otter training checkpoint."},
+                    {"role": "user", "content": "Who trained you?"},
+                    {"role": "assistant", "content": seed.canonical_answer},
+                ]
+            ),
+            seed,
+        )
+
+
+def test_conversation_rejects_unsupported_user_implementation_story():
+    seed = next(
+        seed
+        for seed in generate_seeds(count=100, random_seed=0, identity_profile=MARIN_IDENTITY_PROFILE)
+        if seed.neutral_bridge is None
+    )
+
+    with pytest.raises(ValueError, match="unsupported implementation detail"):
+        collect._conversation(
+            json.dumps(
+                [
+                    {"role": "user", "content": "Did your imaginary otter checkpoint use a routing layer?"},
+                    {"role": "assistant", "content": seed.canonical_answer},
+                ]
+            ),
+            seed,
+        )
+
+
+def test_write_chunk_excludes_rejected_raw_responses(tmp_path):
+    seed = next(
+        seed
+        for seed in generate_seeds(count=100, random_seed=0, identity_profile=MARIN_IDENTITY_PROFILE)
+        if seed.neutral_bridge is None
+    )
+    accepted = collect.CompletionRecord(
+        seed=seed,
+        conversation=(
+            collect.Message("user", "Who are you?"),
+            collect.Message("assistant", seed.canonical_answer),
+        ),
+        raw_response="accepted",
+        accepted_tokens=3,
+        usage={"completion_tokens": 3},
+        finish_reason="stop",
+        response_id=None,
+        error=None,
+        attempts=1,
+        elapsed_seconds=0.1,
+    )
+    rejected = collect.CompletionRecord(
+        seed=seed,
+        conversation=None,
+        raw_response="invented rejected payload",
+        accepted_tokens=0,
+        usage={"completion_tokens": 4},
+        finish_reason="stop",
+        response_id=None,
+        error="invalid",
+        attempts=3,
+        elapsed_seconds=0.2,
+    )
+    config = collect.CollectionConfig(
+        run_id="test",
+        output_path=StoragePath(str(tmp_path)),
+        shard_index=0,
+        num_shards=1,
+        target_tokens=10,
+        microbatch_size=2,
+        concurrency=2,
+        random_seed=7,
+        human_phrasings=(),
+        identity_profile=MARIN_IDENTITY_PROFILE,
+    )
+
+    chunk = collect._write_chunk(config, 0, [accepted, rejected])
+    path = tmp_path / "responses" / "shard-00" / "chunk-000000000-000000001-tokens-0000003.jsonl.gz"
+    with gzip.open(path, "rt") as handle:
+        rows = [json.loads(line) for line in handle]
+
+    assert chunk.end == 1
+    assert [row["raw_response"] for row in rows] == ["accepted"]
+
+
+def test_collection_persists_microbatches_and_resumes(tmp_path, monkeypatch):
+    calls = []
+
+    def completion(_url, seed, _sampling):
+        calls.append(seed.seed_id)
+        return collect.CompletionRecord(
+            seed=seed,
+            conversation=(
+                collect.Message("user", "Who are you?"),
+                collect.Message("assistant", seed.canonical_answer),
+            ),
+            raw_response="[]",
+            accepted_tokens=3,
+            usage={"completion_tokens": 3},
+            finish_reason="stop",
+            response_id=None,
+            error=None,
+            attempts=1,
+            elapsed_seconds=0.1,
+        )
+
+    monkeypatch.setattr(collect, "_completion", completion)
+    config = collect.CollectionConfig(
+        run_id="test",
+        output_path=StoragePath(str(tmp_path)),
+        shard_index=0,
+        num_shards=1,
+        target_tokens=10,
+        microbatch_size=2,
+        concurrency=4,
+        random_seed=7,
+        human_phrasings=(),
+        identity_profile=MARIN_IDENTITY_PROFILE,
+    )
+    sampling = collect.SamplingConfig(0.9, 0.95, 1024)
+
+    collect._run_collection("http://vllm", config, sampling)
+    first_call_count = len(calls)
+    collect._run_collection("http://vllm", config, sampling)
+
+    progress = json.loads((tmp_path / "progress" / "shard-00.json").read_text())
+    assert progress["state"] == "complete"
+    assert progress["profile_id"] == MARIN_IDENTITY_PROFILE.profile_id
+    assert progress["accepted_tokens"] >= 10
+    assert len(calls) == first_call_count
+    assert len(list((tmp_path / "responses" / "shard-00").glob("*.jsonl.gz"))) >= 2

--- a/tests/experiment/test_generate_identity_conversation_seeds.py
+++ b/tests/experiment/test_generate_identity_conversation_seeds.py
@@ -1,0 +1,121 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+import json
+
+from experiments.rollout_data.generate_identity_conversation_seeds import (
+    MARIN_IDENTITY_PROFILE,
+    Facet,
+    IdentityProfile,
+    generate_seeds,
+    main,
+)
+
+
+def test_generate_seeds_is_deterministic_and_balances_facets():
+    first = list(generate_seeds(count=200, random_seed=17, identity_profile=MARIN_IDENTITY_PROFILE))
+    second = list(generate_seeds(count=200, random_seed=17, identity_profile=MARIN_IDENTITY_PROFILE))
+
+    assert first == second
+    assert {seed.facet for seed in first} == set(Facet)
+    assert len({seed.seed_id for seed in first}) == 200
+
+
+def test_generate_seeds_separates_known_and_unknown_identity_facts():
+    seeds = list(generate_seeds(count=400, random_seed=9, identity_profile=MARIN_IDENTITY_PROFILE))
+
+    known = [seed for seed in seeds if seed.facet == Facet.TRAINED_BY]
+    unknown = [seed for seed in seeds if seed.facet == Facet.UNKNOWN_FACT]
+    open_weight_data = [seed for seed in seeds if seed.facet == Facet.OPEN_WEIGHT_DATA]
+    false_premises = [seed for seed in seeds if seed.facet == Facet.FALSE_PREMISE]
+
+    assert known
+    assert all("Marin Community" in seed.canonical_answer for seed in known)
+    assert unknown
+    assert all(seed.truth_status == "unknown" for seed in unknown)
+    assert all("not known" in seed.canonical_answer for seed in unknown)
+    assert open_weight_data
+    assert all("DeepSeek" in seed.canonical_answer for seed in open_weight_data)
+    assert all("Kimi" in seed.canonical_answer for seed in open_weight_data)
+    assert all("GLM" in seed.canonical_answer for seed in open_weight_data)
+    assert false_premises
+    assert all(seed.distractor_model for seed in false_premises)
+    assert all(
+        seed.distractor_model is not None and seed.distractor_model in seed.generation_prompt for seed in false_premises
+    )
+
+
+def test_generate_seeds_uses_only_facts_from_custom_identity_profile():
+    profile = IdentityProfile(
+        profile_id="example",
+        model_name="Example Model",
+        developer="Example Developers",
+        trained_by="Example Trainers",
+        maintained_by="Example Maintainers",
+        ecosystem_contributors=("Example Upstream",),
+        training_data_models=("Example Teacher",),
+        unknown_facts=("the exact release date",),
+    )
+
+    seeds = list(generate_seeds(count=400, random_seed=11, identity_profile=profile))
+    profile_prompts = [seed.generation_prompt for seed in seeds if seed.facet != Facet.FALSE_PREMISE]
+
+    assert all("Marin" not in prompt for prompt in profile_prompts)
+    assert all("Stanford" not in prompt for prompt in profile_prompts)
+    assert all("NVIDIA" not in prompt for prompt in profile_prompts)
+    assert all("DeepSeek" not in prompt for prompt in profile_prompts)
+    assert all(seed.profile_id == "example" for seed in seeds)
+    assert all(
+        seed.canonical_answer == "That information is not known, so I should not guess."
+        for seed in seeds
+        if seed.facet == Facet.UNKNOWN_FACT
+    )
+
+
+def test_generation_axes_have_systematic_coverage():
+    seeds = list(generate_seeds(count=500, random_seed=3, identity_profile=MARIN_IDENTITY_PROFILE))
+
+    assert len({seed.entropy.register for seed in seeds}) >= 5
+    assert len({seed.entropy.turn_pattern for seed in seeds}) == 2
+    assert len({seed.entropy.question_strategy for seed in seeds}) >= 8
+    assert all("Return only the conversation" in seed.generation_prompt for seed in seeds)
+    assert all(f'Assistant: "{seed.canonical_answer}"' in seed.generation_prompt for seed in seeds)
+    assert all("animal" not in seed.generation_prompt.lower() for seed in seeds)
+    assert all("checkpoint" not in seed.generation_prompt.lower() for seed in seeds)
+
+
+def test_cli_uses_retrieved_human_phrasing(tmp_path):
+    phrasing_path = tmp_path / "phrasing.jsonl"
+    profile_path = tmp_path / "profile.json"
+    output_path = tmp_path / "seeds.jsonl"
+    phrasing_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"response": "Wait, who made you again?", "source": "realitytest"}),
+                json.dumps({"text": "Be honest: are you actually Claude?", "source": "wildchat"}),
+            ]
+        )
+        + "\n"
+    )
+    profile_path.write_text(json.dumps(dataclasses.asdict(MARIN_IDENTITY_PROFILE)))
+
+    main(
+        [
+            "--output",
+            str(output_path),
+            "--count",
+            "20",
+            "--random-seed",
+            "4",
+            "--phrasing-input",
+            str(phrasing_path),
+            "--identity-profile",
+            str(profile_path),
+        ]
+    )
+
+    rows = [json.loads(line) for line in output_path.read_text().splitlines()]
+    assert len(rows) == 20
+    assert {row["human_phrasing"]["source"] for row in rows} == {"realitytest", "wildchat"}
+    assert all(row["human_phrasing"]["text"] in row["generation_prompt"] for row in rows)

--- a/tests/experiment/test_generate_identity_conversation_seeds.py
+++ b/tests/experiment/test_generate_identity_conversation_seeds.py
@@ -17,7 +17,7 @@ from experiments.rollout_data.generate_identity_conversation_seeds import (
 IDENTITY_PROFILE = load_identity_profile(StoragePath("experiments/rollout_data/identity_profiles/marin_latest_moe.json"))
 
 
-def test_generate_seeds_is_deterministic_and_balances_facets():
+def test_generate_seeds_is_deterministic_and_covers_all_facets():
     first = list(generate_seeds(count=200, random_seed=17, identity_profile=IDENTITY_PROFILE))
     second = list(generate_seeds(count=200, random_seed=17, identity_profile=IDENTITY_PROFILE))
 
@@ -70,11 +70,9 @@ def test_generate_seeds_uses_only_facts_from_custom_identity_profile():
     assert all("NVIDIA" not in prompt for prompt in profile_prompts)
     assert all("DeepSeek" not in prompt for prompt in profile_prompts)
     assert all(seed.profile_id == "example" for seed in seeds)
-    assert all(
-        seed.canonical_answer == "That information is not known, so I should not guess."
-        for seed in seeds
-        if seed.facet == Facet.UNKNOWN_FACT
-    )
+    unknown = [seed for seed in seeds if seed.facet == Facet.UNKNOWN_FACT]
+    assert unknown
+    assert all(seed.topic == profile.unknown_facts[0] for seed in unknown)
 
 
 def test_generation_axes_have_systematic_coverage():

--- a/tests/experiment/test_generate_identity_conversation_seeds.py
+++ b/tests/experiment/test_generate_identity_conversation_seeds.py
@@ -4,18 +4,22 @@
 import dataclasses
 import json
 
+from rigging.filesystem import StoragePath
+
 from experiments.rollout_data.generate_identity_conversation_seeds import (
-    MARIN_IDENTITY_PROFILE,
     Facet,
     IdentityProfile,
     generate_seeds,
+    load_identity_profile,
     main,
 )
 
+IDENTITY_PROFILE = load_identity_profile(StoragePath("experiments/rollout_data/identity_profiles/marin_latest_moe.json"))
+
 
 def test_generate_seeds_is_deterministic_and_balances_facets():
-    first = list(generate_seeds(count=200, random_seed=17, identity_profile=MARIN_IDENTITY_PROFILE))
-    second = list(generate_seeds(count=200, random_seed=17, identity_profile=MARIN_IDENTITY_PROFILE))
+    first = list(generate_seeds(count=200, random_seed=17, identity_profile=IDENTITY_PROFILE))
+    second = list(generate_seeds(count=200, random_seed=17, identity_profile=IDENTITY_PROFILE))
 
     assert first == second
     assert {seed.facet for seed in first} == set(Facet)
@@ -23,7 +27,7 @@ def test_generate_seeds_is_deterministic_and_balances_facets():
 
 
 def test_generate_seeds_separates_known_and_unknown_identity_facts():
-    seeds = list(generate_seeds(count=400, random_seed=9, identity_profile=MARIN_IDENTITY_PROFILE))
+    seeds = list(generate_seeds(count=400, random_seed=9, identity_profile=IDENTITY_PROFILE))
 
     known = [seed for seed in seeds if seed.facet == Facet.TRAINED_BY]
     unknown = [seed for seed in seeds if seed.facet == Facet.UNKNOWN_FACT]
@@ -74,15 +78,13 @@ def test_generate_seeds_uses_only_facts_from_custom_identity_profile():
 
 
 def test_generation_axes_have_systematic_coverage():
-    seeds = list(generate_seeds(count=500, random_seed=3, identity_profile=MARIN_IDENTITY_PROFILE))
+    seeds = list(generate_seeds(count=500, random_seed=3, identity_profile=IDENTITY_PROFILE))
 
     assert len({seed.entropy.register for seed in seeds}) >= 5
     assert len({seed.entropy.turn_pattern for seed in seeds}) == 2
     assert len({seed.entropy.question_strategy for seed in seeds}) >= 8
-    assert all("Return only the conversation" in seed.generation_prompt for seed in seeds)
-    assert all(f'Assistant: "{seed.canonical_answer}"' in seed.generation_prompt for seed in seeds)
-    assert all("animal" not in seed.generation_prompt.lower() for seed in seeds)
-    assert all("checkpoint" not in seed.generation_prompt.lower() for seed in seeds)
+    assert all(seed.topic in seed.generation_prompt for seed in seeds)
+    assert all(seed.canonical_answer in seed.generation_prompt for seed in seeds)
 
 
 def test_cli_uses_retrieved_human_phrasing(tmp_path):
@@ -98,7 +100,7 @@ def test_cli_uses_retrieved_human_phrasing(tmp_path):
         )
         + "\n"
     )
-    profile_path.write_text(json.dumps(dataclasses.asdict(MARIN_IDENTITY_PROFILE)))
+    profile_path.write_text(json.dumps(dataclasses.asdict(IDENTITY_PROFILE)))
 
     main(
         [


### PR DESCRIPTION
Add the deterministic seed generator and GLM-5.2 collector used to create [`marin-community/identity-data`](https://huggingface.co/datasets/marin-community/identity-data).

The generator reads a JSON identity profile. It varies identity facets, register, turn pattern, question strategy, social setting, user attitude, and false-premise distractors. It assigns stable seed IDs so a shard can recreate the same prompts.

The collector asks GLM-5.2 for structured user and assistant turns. It accepts only the required role order and exact canonical assistant text. It retries rejected output, writes accepted conversations as compressed microbatches, records token progress, and resumes from existing chunks.

The branch also includes the two-node Ray/vLLM launcher required to serve the pinned GLM-5.2 FP8 model on eight GB200 GPUs. Child jobs use Iris batch priority.

The published run, launch settings, output path, and source bundle are recorded in #7817.
