### PR TITLE
[datakit] Add identity-data content source

### DIFF
--- a/lib/marin/src/marin/datakit/download/identity_data.py
+++ b/lib/marin/src/marin/datakit/download/identity_data.py
@@ -8,12 +8,13 @@ from marin.execution.step_spec import StepSpec
 
 HF_DATASET_ID = "marin-community/identity-data"
 HF_REVISION = "665ac6e"
+MARIN_NAME = "identity-data/content"
 
 
 def identity_data_content_normalize_steps() -> tuple[StepSpec, ...]:
     """Return the ``(download, normalize)`` chain for rendered identity conversations."""
     return hf_normalize_steps(
-        marin_name="identity-data/content",
+        marin_name=MARIN_NAME,
         hf_dataset_id=HF_DATASET_ID,
         revision=HF_REVISION,
         hf_urls_glob=("data/train-*.parquet",),

--- a/lib/marin/src/marin/datakit/download/identity_data.py
+++ b/lib/marin/src/marin/datakit/download/identity_data.py
@@ -1,0 +1,22 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""marin-community/identity-data download and normalization."""
+
+from marin.datakit.download.hf_simple_util import hf_normalize_steps
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "marin-community/identity-data"
+HF_REVISION = "665ac6e"
+
+
+def identity_data_content_normalize_steps() -> tuple[StepSpec, ...]:
+    """Return the ``(download, normalize)`` chain for rendered identity conversations."""
+    return hf_normalize_steps(
+        marin_name="identity-data/content",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=("data/train-*.parquet",),
+        id_field="seed_id",
+        text_field="content",
+    )

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -40,7 +40,6 @@ from marin.datakit.download.finetranslations import finetranslations_normalize_s
 from marin.datakit.download.glm_kernelgym_rollouts import glm_kernelgym_rollouts_normalize_steps
 from marin.datakit.download.gpt_oss_rollouts import gpt_oss_rollouts_normalize_steps
 from marin.datakit.download.hplt import hplt_v3_normalize_steps
-from marin.datakit.download.identity_data import MARIN_NAME as IDENTITY_DATA_CONTENT_NAME
 from marin.datakit.download.identity_data import identity_data_content_normalize_steps
 from marin.datakit.download.institutional_books import institutional_books_normalize_steps
 from marin.datakit.download.massive import massive_normalize_steps
@@ -66,6 +65,8 @@ from marin.datakit.download.swe_rebench_openhands import swe_rebench_openhands_n
 from marin.datakit.download.swe_zero_12m import swe_zero_12m_normalize_steps
 from marin.datakit.download.synthetic1 import synthetic1_normalize_steps
 from marin.execution.step_spec import StepSpec
+
+IDENTITY_DATA_CONTENT_NAME = "identity-data/content"
 
 
 @dataclass(frozen=True)

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -40,6 +40,7 @@ from marin.datakit.download.finetranslations import finetranslations_normalize_s
 from marin.datakit.download.glm_kernelgym_rollouts import glm_kernelgym_rollouts_normalize_steps
 from marin.datakit.download.gpt_oss_rollouts import gpt_oss_rollouts_normalize_steps
 from marin.datakit.download.hplt import hplt_v3_normalize_steps
+from marin.datakit.download.identity_data import identity_data_content_normalize_steps
 from marin.datakit.download.institutional_books import institutional_books_normalize_steps
 from marin.datakit.download.massive import massive_normalize_steps
 from marin.datakit.download.molmo2_cap import molmo2_cap_normalize_steps
@@ -184,6 +185,7 @@ def all_sources() -> dict[str, DatakitSource]:
         ("glm-5.2-kernelgym-rollouts", glm_kernelgym_rollouts_normalize_steps, 0.064054289),
         ("gpt-oss-rollouts", gpt_oss_rollouts_normalize_steps, 3.20),
         ("hplt_v3", hplt_v3_normalize_steps, 612.7),
+        ("identity-data/content", identity_data_content_normalize_steps, 0.061711380),
         ("institutional_books", institutional_books_normalize_steps, 203.63),
         ("massive_function_calling", massive_normalize_steps, 11.39),
         ("molmo2-cap", molmo2_cap_normalize_steps, 0.36),

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -66,8 +66,6 @@ from marin.datakit.download.swe_zero_12m import swe_zero_12m_normalize_steps
 from marin.datakit.download.synthetic1 import synthetic1_normalize_steps
 from marin.execution.step_spec import StepSpec
 
-IDENTITY_DATA_CONTENT_NAME = "identity-data/content"
-
 
 @dataclass(frozen=True)
 class DatakitSource:
@@ -187,7 +185,7 @@ def all_sources() -> dict[str, DatakitSource]:
         ("glm-5.2-kernelgym-rollouts", glm_kernelgym_rollouts_normalize_steps, 0.064054289),
         ("gpt-oss-rollouts", gpt_oss_rollouts_normalize_steps, 3.20),
         ("hplt_v3", hplt_v3_normalize_steps, 612.7),
-        (IDENTITY_DATA_CONTENT_NAME, identity_data_content_normalize_steps, 0.061711380),
+        ("identity-data/content", identity_data_content_normalize_steps, 0.061711380),
         ("institutional_books", institutional_books_normalize_steps, 203.63),
         ("massive_function_calling", massive_normalize_steps, 11.39),
         ("molmo2-cap", molmo2_cap_normalize_steps, 0.36),

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -40,6 +40,7 @@ from marin.datakit.download.finetranslations import finetranslations_normalize_s
 from marin.datakit.download.glm_kernelgym_rollouts import glm_kernelgym_rollouts_normalize_steps
 from marin.datakit.download.gpt_oss_rollouts import gpt_oss_rollouts_normalize_steps
 from marin.datakit.download.hplt import hplt_v3_normalize_steps
+from marin.datakit.download.identity_data import MARIN_NAME as IDENTITY_DATA_CONTENT_NAME
 from marin.datakit.download.identity_data import identity_data_content_normalize_steps
 from marin.datakit.download.institutional_books import institutional_books_normalize_steps
 from marin.datakit.download.massive import massive_normalize_steps
@@ -185,7 +186,7 @@ def all_sources() -> dict[str, DatakitSource]:
         ("glm-5.2-kernelgym-rollouts", glm_kernelgym_rollouts_normalize_steps, 0.064054289),
         ("gpt-oss-rollouts", gpt_oss_rollouts_normalize_steps, 3.20),
         ("hplt_v3", hplt_v3_normalize_steps, 612.7),
-        ("identity-data/content", identity_data_content_normalize_steps, 0.061711380),
+        (IDENTITY_DATA_CONTENT_NAME, identity_data_content_normalize_steps, 0.061711380),
         ("institutional_books", institutional_books_normalize_steps, 203.63),
         ("massive_function_calling", massive_normalize_steps, 11.39),
         ("molmo2-cap", molmo2_cap_normalize_steps, 0.36),


### PR DESCRIPTION
Register the marin-community/identity-data content column as a Datakit source pinned to revision 665ac6e. Normalize the train Parquet shards with seed_id as the document ID.

CoreWeave staging normalized 896,422 input rows to 859,434 unique documents. A one-off marin-community/marin-tokenizer run measured 61,711,380 tokens, so the registry estimate is 0.061711380 billion tokens.
