### PR TITLE
[datakit] Skip malformed nested GHALogs archives

### DIFF
--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -3,6 +3,7 @@
 
 """Public diagnostic-log source inventory and GHALogs extraction helpers."""
 
+import gzip
 import hashlib
 import http.client
 import json
@@ -14,6 +15,7 @@ import tarfile
 import time
 import xml.etree.ElementTree as ET
 import zipfile
+import zlib
 from collections.abc import Iterable, Iterator
 from contextlib import ExitStack
 from dataclasses import dataclass
@@ -749,6 +751,15 @@ def _list_ghalogs_member_names(archive_path: str) -> list[str]:
             return [name for name in zf.namelist() if not name.endswith("/")]
 
 
+def _validate_ghalogs_run_archive(content: bytes) -> None:
+    """Read one nested run archive completely before any of its records are emitted."""
+    with tarfile.open(fileobj=BytesIO(content), mode="r:gz") as run_logs:
+        # Advancing across every member decompresses the whole gzip stream and
+        # validates each tar header without retaining the member list.
+        for _member in run_logs:
+            pass
+
+
 def _process_ghalogs_member_batch(batch: list[str], archive_path: str) -> Iterator[dict[str, str]]:
     """Open the archive once, read each assigned run archive, yield sanitized records.
 
@@ -764,6 +775,12 @@ def _process_ghalogs_member_batch(batch: list[str], archive_path: str) -> Iterat
                 with zf.open(name, "r") as member_file:
                     content = member_file.read()
                 counters.pipeline.update_counter("zephyr/records_in", 1)
+                try:
+                    _validate_ghalogs_run_archive(content)
+                except (tarfile.TarError, gzip.BadGzipFile, EOFError, zlib.error) as error:
+                    logger.warning("Skipping malformed GHALogs run archive %s: %s", name, error)
+                    counters.pipeline.update_counter("ghalogs_materialize/dropped_invalid_archive", 1)
+                    continue
                 for record in ghalogs_member_to_records(name, content):
                     counters.pipeline.update_counter("ghalogs_materialize/kept", 1)
                     counters.pipeline.update_counter(f"ghalogs_materialize/partition_{record['partition']}", 1)
@@ -1380,7 +1397,7 @@ def materialize_ghalogs_step(
             num_shards=num_shards,
         ),
         hash_attrs={
-            "version": "v3",
+            "version": "v4",
             "source_path": source_path,
             "source_label": source.source_label,
             "max_members": max_members,

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -755,7 +755,7 @@ def _validate_ghalogs_run_archive(content: bytes) -> None:
     """Read one nested run archive completely before any of its records are emitted."""
     with tarfile.open(fileobj=BytesIO(content), mode="r:gz") as run_logs:
         # Advancing across every member decompresses the whole gzip stream and
-        # validates each tar header without retaining the member list.
+        # validates each tar header without retaining decompressed member contents.
         for _member in run_logs:
             pass
 
@@ -1397,7 +1397,7 @@ def materialize_ghalogs_step(
             num_shards=num_shards,
         ),
         hash_attrs={
-            "version": "v4",
+            "version": "2026.07.31",
             "source_path": source_path,
             "source_label": source.source_label,
             "max_members": max_members,

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -502,6 +502,41 @@ def test_materialize_ghalogs_to_parquet_writes_reusable_shards(tmp_path):
     assert all("abc123456789" not in row["text"] for row in rows)
 
 
+def test_materialize_ghalogs_to_parquet_drops_malformed_run_archives(tmp_path):
+    input_dir = tmp_path / "input" / "ghalogs" / "zenodo-14796970"
+    archive_dir = input_dir / "zenodo.org" / "records" / "14796970" / "files"
+    output_dir = tmp_path / "materialized"
+    archive_dir.mkdir(parents=True)
+
+    with zipfile.ZipFile(archive_dir / "github_run_logs.zip", "w") as archive:
+        archive.writestr(
+            "logs/owner/repo-a/workflow_1234/1-1.tar.gz",
+            _run_archive_member({"0_build.txt": b"first valid run"}),
+        )
+        archive.writestr("logs/owner/repo-b/workflow_1234/2-1.tar.gz", b"\x1f\x8b\x08\x00broken gzip")
+        archive.writestr(
+            "logs/owner/repo-c/workflow_1234/3-1.tar.gz",
+            gzip.compress(b"valid gzip containing an invalid tar"),
+        )
+        archive.writestr(
+            "logs/owner/repo-d/workflow_1234/4-1.tar.gz",
+            _run_archive_member({"0_build.txt": b"second valid run"}),
+        )
+
+    materialized = materialize_ghalogs_to_parquet(
+        str(input_dir),
+        str(output_dir),
+        max_members=4,
+        num_shards=1,
+        max_workers=1,
+    )
+
+    rows = _read_parquet_rows(output_dir)
+    assert {row["text"] for row in rows} == {"first valid run", "second valid run"}
+    assert materialized.record_count == 2
+    assert materialized.counters["ghalogs_materialize/dropped_invalid_archive"] == 2
+
+
 def test_materialize_ghalogs_partition_to_parquet_filters_one_partition(tmp_path):
     input_dir = tmp_path / "input" / "ghalogs" / "zenodo-14796970"
     archive_dir = input_dir / "zenodo.org" / "records" / "14796970" / "files"


### PR DESCRIPTION
Skip malformed nested `.tar.gz` run archives during GHALogs materialization and count them under `ghalogs_materialize/dropped_invalid_archive`. The Zenodo 14796970 archive contains published members with invalid tar headers, corrupt deflate blocks, truncated gzip streams, and CRC failures; each malformed member previously exhausted all three retries for its Zephyr shard after the extraction added in #7772.

Validate each nested archive before emitting records so a late stream error cannot leave partial records from a corrupt run. This adds a second decompression pass per run. Set the materialization version to CalVer `2026.07.31` so the failed output is rebuilt.

A federated CoreWeave materialization completed all 128 shards without a shard retry, kept 2,692,489 records, and skipped 58 malformed nested archives: https://iris.oa.dev/#/job/%2Fheld%2Fdatakit-trigger-sources-20260730-2029%2Fzephyr-materialize-ghalogs-4f47cf5e-p0-a0

The completed 128-shard, 129,448,730,841-byte materialization was copied server-side to the CalVer-derived prefix with filename and byte-size parity, then adopted with updated lineage metadata: https://iris.oa.dev/#/job/%2Fheld%2Fadopt-ghalogs-calver-20260730-2107

A subsequent full 147-source CoreWeave trigger cache-hit the adopted materialization, selected 2,614,121 train records, normalized 2,613,421 unique records with 700 exact duplicates separated, and reached terminal success: https://iris.oa.dev/#/job/%2Fheld%2Fdatakit-trigger-sources-20260730-2130
