### PR TITLE
[datakit] flatten attribute datasets

### DIFF
--- a/experiments/datakit/README.md
+++ b/experiments/datakit/README.md
@@ -27,9 +27,14 @@ absolute. This keeps source keys stable when artifacts move between regions.
 `NormalizedData` also stores its output directories in this relative form.
 Existing v1 artifacts keep their absolute directories when they load.
 
+Datakit attribute Parquet files use a flat schema. The top-level `id` column
+is the join key. Each attribute is another top-level column, such as
+`contaminated`, `dup_doc`, or `is_cluster_canonical`. Attribute files do not
+use a nested `attributes` struct.
+
 Global exact deduplication is one shared step. It selects one canonical record
 for each record ID, with source names as the canonical order. The step writes
-sparse co-partitioned attributes with `attributes.dup_doc=true` for the other
+sparse co-partitioned attributes with `dup_doc=true` for the other
 records. Only source shards with duplicates get an attribute file; a missing
 file means that the source shard has no exact duplicates. The step does not copy
 normalized text.

--- a/experiments/datakit/decontam/viewer/export_run.py
+++ b/experiments/datakit/decontam/viewer/export_run.py
@@ -176,15 +176,18 @@ def _source_rows(decon_out: str, k: int, rng: random.Random) -> tuple[int, int, 
     """
     n_docs = n_flagged = 0
     reservoir: list[dict] = []
-    for tbl in _read_parquet(f"{decon_out.rstrip('/')}/outputs/main", columns=["id", "attributes"]):
+    columns = ["id", "contaminated", "max_overlap", "matched_hashes"]
+    for tbl in _read_parquet(f"{decon_out.rstrip('/')}/outputs/main", columns=columns):
         ids = tbl.column("id").to_pylist()
-        attrs = tbl.column("attributes").to_pylist()
+        contaminated = tbl.column("contaminated").to_pylist()
+        max_overlap = tbl.column("max_overlap").to_pylist()
+        matched_hashes = tbl.column("matched_hashes").to_pylist()
         n_docs += len(ids)
-        for did, a in zip(ids, attrs, strict=True):
-            if a is None or not a.get("contaminated"):
+        for did, is_contaminated, overlap, hashes in zip(ids, contaminated, max_overlap, matched_hashes, strict=True):
+            if not is_contaminated:
                 continue
             n_flagged += 1
-            row = {"id": did, "max_overlap": a.get("max_overlap"), "matched_hashes": a.get("matched_hashes") or []}
+            row = {"id": did, "max_overlap": overlap, "matched_hashes": hashes or []}
             if len(reservoir) < k:
                 reservoir.append(row)
             else:

--- a/experiments/datakit/global_exact_dedup.py
+++ b/experiments/datakit/global_exact_dedup.py
@@ -15,9 +15,7 @@ Output rows have this schema::
 
     {
       id: str,
-      attributes: {
-        dup_doc: bool,
-      },
+      dup_doc: bool,
     }
 
 Output files keep the matching normalized shard names. A missing file means
@@ -43,15 +41,11 @@ from zephyr.writers import write_parquet_file
 
 COUNTER_PREFIX = "global_exact_dedup"
 _SHARED_ENTRIES_KEY = "global_exact_dedup_entries"
-GLOBAL_EXACT_DEDUP_DATA_VERSION = 1
+GLOBAL_EXACT_DEDUP_DATA_VERSION = 2
 _ATTR_SCHEMA = pa.schema(
     [
         pa.field("id", pa.string(), nullable=False),
-        pa.field(
-            "attributes",
-            pa.struct([pa.field("dup_doc", pa.bool_(), nullable=False)]),
-            nullable=False,
-        ),
+        pa.field("dup_doc", pa.bool_(), nullable=False),
     ]
 )
 
@@ -141,7 +135,7 @@ def _write_shard(file_idx: int, records: Iterator[_ExactRecord]) -> dict[str, in
         nonlocal duplicate_records
         for record in records:
             duplicate_records += 1
-            yield {"id": record["id"], "attributes": {"dup_doc": True}}
+            yield {"id": record["id"], "dup_doc": True}
 
     result = write_parquet_file(duplicate_rows(), output_path=entry.output_path, schema=_ATTR_SCHEMA)
     counters.pipeline.update_counter(f"{COUNTER_PREFIX}/duplicate_records", duplicate_records)

--- a/experiments/datakit/reports/dedup.py
+++ b/experiments/datakit/reports/dedup.py
@@ -36,9 +36,9 @@ def dedup_report(output_path: str, dedup: FuzzyDupsAttrData) -> StageReport:
     sampled_cluster_sizes: Counter[str] = Counter()
     per_source = []
     for source_key, entry in dedup.sources.items():
-        rows = sample_rows(entry.attr_dir, ["id", "attributes"], SAMPLE_LIMIT)
-        source_clusters = {r["attributes"]["dup_cluster_id"] for r in rows}
-        sampled_cluster_sizes.update(r["attributes"]["dup_cluster_id"] for r in rows)
+        rows = sample_rows(entry.attr_dir, ["id", "dup_cluster_id"], SAMPLE_LIMIT)
+        source_clusters = {r["dup_cluster_id"] for r in rows}
+        sampled_cluster_sizes.update(r["dup_cluster_id"] for r in rows)
         per_source.append(
             {
                 "label": _source_label(source_key),

--- a/experiments/datakit/scripts/validate_ferry_outputs.py
+++ b/experiments/datakit/scripts/validate_ferry_outputs.py
@@ -46,7 +46,7 @@ NORMALIZE_REQUIRED_COLUMNS = {"id", "text", "url", "source_id", "token_count"}
 # The smoke ferry runs fuzzy dedup over a single source (fineweb-edu sample/10BT).
 FUZZY_DUPS_EXPECTED_SOURCES = 1
 FUZZY_DUPS_EXPECTED_FILES_PER_SOURCE = 106
-FUZZY_DUPS_REQUIRED_COLUMNS = {"id", "attributes"}
+FUZZY_DUPS_REQUIRED_COLUMNS = {"id", "dup_cluster_id", "is_cluster_canonical"}
 # Non-canonicals are the rows consolidate will drop. Should be a non-trivial
 # but bounded fraction. Reference (old exact-dedup pipeline): 286,263 / 9,268,156 = 3.1%.
 FUZZY_DUPS_DROP_MIN_FRACTION = 0.005  # at least 0.5% dropped
@@ -128,10 +128,10 @@ def _count_canonicals(files: list[str]) -> int:
     total = 0
     for path in files:
         with StoragePath(path).open("rb") as f:
-            tbl = pq.ParquetFile(f).read(columns=["attributes"])
+            tbl = pq.ParquetFile(f).read(columns=["is_cluster_canonical"])
         if tbl.num_rows == 0:
             continue
-        canonical = tbl.column("attributes").combine_chunks().field("is_cluster_canonical")
+        canonical = tbl.column("is_cluster_canonical")
         total += int(pc.sum(canonical).as_py() or 0)
     return total
 
@@ -140,8 +140,8 @@ def _validate_fuzzy_dups(base: str, normalize_rows: int) -> int:
     """Validate the fuzzy-dups step and return the number of rows consolidate will drop.
 
     Fuzzy dedup writes one cluster-member parquet per normalize shard, per source,
-    under ``<attr_dir>/*.parquet`` with schema ``{id, attributes: {dup_cluster_id,
-    is_cluster_canonical}}``. Singletons are omitted, and exactly one cluster
+    under ``<attr_dir>/*.parquet`` with schema
+    ``{id, dup_cluster_id, is_cluster_canonical}``. Singletons are omitted, and exactly one cluster
     member is flagged ``is_cluster_canonical=True``. Consolidate's default policy
     keeps canonicals and singletons, so non-canonicals == rows dropped.
     """

--- a/experiments/datakit/store/datakit_store.py
+++ b/experiments/datakit/store/datakit_store.py
@@ -148,12 +148,9 @@ def _read_columns(path: str, columns: list[str]) -> pa.Table:
 
 
 def _load_decon_table(path: str) -> tuple[pa.Array, np.ndarray]:
-    table = _read_columns(path, ["id", "attributes"])
+    table = _read_columns(path, ["id", "contaminated"])
     ids = table.column("id").combine_chunks()
-    contaminated = np.asarray(
-        table.column("attributes").combine_chunks().field("contaminated"),
-        dtype=bool,
-    )
+    contaminated = np.asarray(table.column("contaminated"), dtype=bool)
     return ids, contaminated
 
 
@@ -175,9 +172,9 @@ def _load_dedup_canonical(path: str) -> dict[str, bool]:
         parquet = pq.ParquetFile(fh)
         if parquet.metadata.num_rows == 0:
             return {}
-        table = parquet.read(columns=["id", "attributes"])
+        table = parquet.read(columns=["id", "is_cluster_canonical"])
     ids = table.column("id").to_pylist()
-    canonical = table.column("attributes").combine_chunks().field("is_cluster_canonical").to_pylist()
+    canonical = table.column("is_cluster_canonical").to_pylist()
     return dict(zip(ids, canonical, strict=True))
 
 

--- a/experiments/tokenize/smoke_test_decon_filter_store.py
+++ b/experiments/tokenize/smoke_test_decon_filter_store.py
@@ -67,15 +67,14 @@ def _list_parquets(directory: str) -> list[str]:
 def _load_contam_ids(decon_dirs: list[str]) -> set[str]:
     """Union of `id`s flagged as contaminated across all sources' decon parquets.
 
-    Decon emits the datakit ``{id, partition_id, attributes: {contaminated, ...}}``
-    shape; flatten the struct via pyarrow ``StructArray.field`` so we don't
-    materialize the matched_hashes column.
+    Decon emits flat Datakit attribute columns. Select only ``id`` and
+    ``contaminated`` so this does not materialize ``matched_hashes``.
     """
     ids: set[str] = set()
     for d in decon_dirs:
         for path in _list_parquets(d):
-            table = pq.read_table(path, columns=["id", "attributes"])
-            contaminated = table.column("attributes").combine_chunks().field("contaminated").to_pylist()
+            table = pq.read_table(path, columns=["id", "contaminated"])
+            contaminated = table.column("contaminated").to_pylist()
             ids_col = table.column("id").to_pylist()
             for i, c in zip(ids_col, contaminated, strict=True):
                 if c:

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -7,19 +7,18 @@ Reads datakit-normalized Parquet (``id``, ``text``), builds an in-memory
 bloom filter from the eval text, and emits a co-partitioned Parquet
 attributes dataset marking which records overlap with eval text.
 
-Schema of the emitted Parquet attributes (datakit ``{id, attributes}`` convention,
+Schema of the emitted Parquet attributes (flat Datakit attribute convention,
 consumable by :func:`marin.processing.classification.consolidate.consolidate`):
 
     id                       : string         — matches source document id
     partition_id             : int            — source partition index (from sorted file order)
-    attributes               : struct
-        contaminated         : bool           — max paragraph overlap meets the threshold
-        max_overlap          : float          — highest paragraph overlap fraction in [0, 1]
-        matched_hashes       : list[uint64]   — bloom-hit ngram hashes from this record
+    contaminated             : bool           — max paragraph overlap meets the threshold
+    max_overlap              : float          — highest paragraph overlap fraction in [0, 1]
+    matched_hashes           : list[uint64]   — bloom-hit ngram hashes from this record
 
 Build also emits ``<output>/_bloom/eval_hash_index.parquet`` with columns
 ``hash: uint64, eval_id: string`` (flattened, one row per (hash, eval_id) pair).
-Join ``attributes.matched_hashes`` against this sidecar to attribute
+Join ``matched_hashes`` against this sidecar to attribute
 contamination back to specific eval records.
 
 Output follows the normalize job's layout: main attributes land in
@@ -68,6 +67,7 @@ logger = logging.getLogger(__name__)
 # re-addresses cached blooms/marks instead of silently reusing incompatible
 # features. v2 added the no-alphabetic-character ngram filter (marin#6852 cluster D).
 FEATURE_FILTER_VERSION = 2
+DECON_ATTRIBUTES_VERSION = 4
 
 
 @dataclass(frozen=True)
@@ -106,12 +106,12 @@ class DeconAttributes(BaseModel):
             (``<output>/outputs/flagged_sample``); empty when no sample was taken.
         num_partitions: Number of output partitions; matches the source.
         eval_hash_index_path: Path to the ``hash → eval_id`` sidecar Parquet.
-            Join the per-record ``attributes.matched_hashes`` column against
+            Join the per-record ``matched_hashes`` column against
             this to attribute contamination to specific eval records.
         counters: Aggregated zephyr counters from the marking pipeline.
     """
 
-    version: str = "v3"
+    version: str = f"v{DECON_ATTRIBUTES_VERSION}"
     main_output_dir: str
     flagged_output_dir: str
     num_partitions: int
@@ -368,24 +368,14 @@ def _build_filter(
     return stats["n_records"]
 
 
-_ATTRIBUTES_STRUCT = pa.struct(
-    [
-        pa.field("contaminated", pa.bool_()),
-        pa.field("max_overlap", pa.float64()),
-        pa.field("matched_hashes", pa.list_(pa.uint64())),
-    ]
-)
-
-# Wrapped-attributes schema -- matches the datakit convention consumed by
-# ``marin.processing.classification.consolidate``: top-level ``id`` (join key)
-# and ``partition_id`` (co-partitioning invariant), with the per-record decon
-# facts grouped under ``attributes`` so a ``FilterConfig(name="contaminated")``
-# resolves correctly.
+# Flat attribute columns keep all Datakit sidecars directly selectable by name.
 _OUTPUT_SCHEMA = pa.schema(
     [
         pa.field("id", pa.string()),
         pa.field("partition_id", pa.int64()),
-        pa.field("attributes", _ATTRIBUTES_STRUCT),
+        pa.field("contaminated", pa.bool_()),
+        pa.field("max_overlap", pa.float64()),
+        pa.field("matched_hashes", pa.list_(pa.uint64())),
     ]
 )
 
@@ -466,11 +456,9 @@ def _make_marker(
                     yield {
                         "id": record["id"],
                         "partition_id": shard.shard_idx,
-                        "attributes": {
-                            "contaminated": contaminated,
-                            "max_overlap": max_score,
-                            "matched_hashes": list(matched),
-                        },
+                        "contaminated": contaminated,
+                        "max_overlap": max_score,
+                        "matched_hashes": list(matched),
                     }
 
             # Follow the normalize job's output layout: main attributes under
@@ -1306,6 +1294,7 @@ def decon_step(
         "overlap_threshold": overlap_threshold,
         "paragraph_delimiter": paragraph_delimiter,
         "feature_filter_version": FEATURE_FILTER_VERSION,
+        "attribute_schema_version": DECON_ATTRIBUTES_VERSION,
         "input_dir": input_dir,
     }
     # Only fold in when enabled: the flagged sidecar is *additional* output, so a

--- a/lib/marin/src/marin/processing/classification/README.md
+++ b/lib/marin/src/marin/processing/classification/README.md
@@ -17,3 +17,7 @@ Run exact or fuzzy deduplication from Python by importing the helpers under [`de
 
 - `remove_spans`: remove text spans such as duplicate paragraphs
 - `remove_docs`: drop whole documents when an attribute marks them as duplicates
+
+Attribute Parquet files use flat columns. Each file has an `id` join key and
+one or more top-level attribute columns. The consolidate step reads the column
+named by `FilterConfig.name`.

--- a/lib/marin/src/marin/processing/classification/consolidate.py
+++ b/lib/marin/src/marin/processing/classification/consolidate.py
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Consolidate takes a set of documents with corresponding attributes and writes
-out a subset of the documents based on various filters defined with respect to
-the attributes.  Handles two cases:
+Consolidate takes documents with corresponding flat attribute columns and writes
+out a subset of the documents based on configured filters. Handles two cases:
 - Span removal produces attributes (e.g., duplicate_text spans). Remove text spans.
 - Document removal via attribute produced by deduplication.
 
@@ -56,7 +55,7 @@ class FilterConfig:
     """If True, keep docs that have no attribute entry. If False (default), reject them."""
 
 
-def _remove_spans_from_doc(doc: dict, filt: FilterConfig, attributes: dict) -> dict:
+def _remove_spans_from_doc(doc: dict, filt: FilterConfig, attribute_row: dict) -> dict:
     def _remove_spans(text: str, spans: list[list[int]]) -> str:
         """Return ``text`` with ``spans`` removed.
 
@@ -70,7 +69,7 @@ def _remove_spans_from_doc(doc: dict, filt: FilterConfig, attributes: dict) -> d
 
         return text
 
-    spans = attributes[filt.name]
+    spans = attribute_row[filt.name]
     new_text = _remove_spans(doc["text"], spans)
     return {**doc, "text": new_text}
 
@@ -124,13 +123,12 @@ def _make_filter_combiner(filt: FilterConfig) -> Callable[[dict, dict | None], d
         if right is None:
             return left if filt.keep_if_missing else None
 
-        attrs = right["attributes"]
         if filt.type == FilterType.REMOVE_DOC:
-            return left if not attrs.get(filt.name, False) else None
+            return left if not right.get(filt.name, False) else None
         if filt.type == FilterType.KEEP_DOC:
-            return left if attrs.get(filt.name, False) else None
+            return left if right.get(filt.name, False) else None
         assert filt.type == FilterType.REMOVE_SPANS
-        mutated = _remove_spans_from_doc(left, filt, attrs)
+        mutated = _remove_spans_from_doc(left, filt, right)
         return mutated if mutated.get("text") else None
 
     return combine
@@ -177,7 +175,7 @@ def consolidate(
 
     ds = Dataset.from_list(input_paths).load_parquet()
     for filt, attr_paths in filter_attr_paths:
-        attrs = Dataset.from_list(attr_paths).load_parquet(columns=["id", "attributes"])
+        attrs = Dataset.from_list(attr_paths).load_parquet(columns=["id", filt.name])
         ds = ds.sorted_merge_join(
             attrs,
             left_key=lambda r: r["id"],

--- a/lib/marin/src/marin/processing/classification/deduplication/dedup_commons.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/dedup_commons.py
@@ -196,7 +196,7 @@ def make_document_dedup_aggregator(
         def only_dups(records: Iterator[dict]) -> Iterator[dict]:
             for record in records:
                 if record["is_dup"]:
-                    yield {"id": record["id"], "attributes": {"dup_doc": True}}
+                    yield {"id": record["id"], "dup_doc": True}
 
         result = write_parquet_file(only_dups(tally.tally(records)), output_file)
         return tally.as_result(result)

--- a/lib/marin/src/marin/processing/classification/deduplication/exact.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/exact.py
@@ -125,20 +125,20 @@ def dedup_exact_paragraph(
                 if doc_level_record is None:
                     doc_level_record = {
                         "id": doc_id,
-                        "attributes": {"dup_spans": [record["span"]] if record["span"] else []},
+                        "dup_spans": [record["span"]] if record["span"] else [],
                     }
                 elif doc_level_record["id"] != doc_id:
-                    if doc_level_record["attributes"]["dup_spans"]:
+                    if doc_level_record["dup_spans"]:
                         yield doc_level_record
                     doc_level_record = {
                         "id": doc_id,
-                        "attributes": {"dup_spans": [record["span"]] if record["span"] else []},
+                        "dup_spans": [record["span"]] if record["span"] else [],
                     }
                 else:
                     assert doc_level_record["id"] == doc_id
                     if record["span"]:
-                        doc_level_record["attributes"]["dup_spans"].append(record["span"])
-            if doc_level_record and doc_level_record["attributes"]["dup_spans"]:
+                        doc_level_record["dup_spans"].append(record["span"])
+            if doc_level_record and doc_level_record["dup_spans"]:
                 yield doc_level_record
 
         result = write_parquet_file(group_by_doc_id(tally.tally(records)), output_file)

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
@@ -13,10 +13,8 @@ Per-document attr rows have schema::
 
     {
       id: str,
-      attributes: {
-        dup_cluster_id: str,         # CC component id — shared by all cluster members
-        is_cluster_canonical: bool,  # True for exactly one member per cluster
-      }
+      dup_cluster_id: str,         # CC component id — shared by all cluster members
+      is_cluster_canonical: bool,  # True for exactly one member per cluster
     }
 
 Rows are emitted for every member of a non-singleton cluster (canonical +
@@ -51,7 +49,7 @@ from marin.processing.classification.deduplication.dedup_commons import _load_ba
 from marin.processing.classification.deduplication.fuzzy_minhash import MinHashAttrData, MinHashParams
 
 logger = logging.getLogger(__name__)
-FUZZY_DUPS_ATTR_DATA_VERSION = 2
+FUZZY_DUPS_ATTR_DATA_VERSION = 3
 
 
 class FuzzyDupsPerSource(BaseModel):
@@ -172,7 +170,7 @@ def _make_per_shard_writer(counter_prefix: str):
     """Return a group_by reducer that writes per-shard cluster-annotation parquet files.
 
     Skips singletons entirely. For every non-singleton cluster member, writes
-    ``{id, attributes: {dup_cluster_id, is_cluster_canonical}}``. Rows are
+    ``{id, dup_cluster_id, is_cluster_canonical}``. Rows are
     already sorted by ``id`` thanks to the upstream ``group_by(sort_by=id)``.
 
     The ``entries`` list is loaded via ``zephyr_worker_ctx().get_shared`` so it
@@ -200,10 +198,8 @@ def _make_per_shard_writer(counter_prefix: str):
                     counters.pipeline.update_counter(f"{counter_prefix}/canonicals", 1)
                 yield {
                     "id": record["id"],
-                    "attributes": {
-                        "dup_cluster_id": record["component_id"],
-                        "is_cluster_canonical": record["is_canonical"],
-                    },
+                    "dup_cluster_id": record["component_id"],
+                    "is_cluster_canonical": record["is_canonical"],
                 }
 
         result = write_parquet_file(cluster_member_rows(), entry.output_path)
@@ -237,8 +233,8 @@ def compute_fuzzy_dups_attrs(
     components, and emits a per-source attribute tree under
     ``<output_path>/outputs/source_NNN/`` with one parquet file per source
     shard (filenames preserved from the source). Each row annotates one
-    cluster member with ``{id: str, attributes: {dup_cluster_id: str,
-    is_cluster_canonical: bool}}``; singletons are omitted.
+    cluster member with ``{id: str, dup_cluster_id: str,
+    is_cluster_canonical: bool}``; singletons are omitted.
 
     Exactly one member per cluster has ``is_cluster_canonical=True`` — the
     one CC's Hash-to-Min picked as the natural canonical (min ``id_norm``).

--- a/tests/datakit/test_datakit_store.py
+++ b/tests/datakit/test_datakit_store.py
@@ -81,7 +81,7 @@ def _write_shard(dirs: dict[str, str], basename: str, docs: list[_Doc]) -> None:
     )
     _write_parquet(
         f"{dirs['decon']}/{basename}",
-        pa.table({"id": ids, "attributes": pa.array([{"contaminated": d[3]} for d in docs])}),
+        pa.table({"id": ids, "contaminated": pa.array([d[3] for d in docs])}),
     )
     _write_parquet(
         f"{dirs['cluster']}/{basename}",
@@ -104,15 +104,11 @@ def _write_shard(dirs: dict[str, str], basename: str, docs: list[_Doc]) -> None:
         _write_parquet(
             f"{dirs['exact_dedup']}/{basename}",
             pa.Table.from_pylist(
-                [{"id": doc_id, "attributes": {"dup_doc": True}} for doc_id in exact_duplicates],
+                [{"id": doc_id, "dup_doc": True} for doc_id in exact_duplicates],
                 schema=pa.schema(
                     [
                         pa.field("id", pa.string(), nullable=False),
-                        pa.field(
-                            "attributes",
-                            pa.struct([pa.field("dup_doc", pa.bool_(), nullable=False)]),
-                            nullable=False,
-                        ),
+                        pa.field("dup_doc", pa.bool_(), nullable=False),
                     ]
                 ),
             ),
@@ -125,7 +121,7 @@ def _write_shard(dirs: dict[str, str], basename: str, docs: list[_Doc]) -> None:
             pa.table(
                 {
                     "id": [m[0] for m in marked],
-                    "attributes": pa.array([{"is_cluster_canonical": m[1]} for m in marked]),
+                    "is_cluster_canonical": pa.array([m[1] for m in marked]),
                 }
             ),
         )

--- a/tests/datakit/test_decon.py
+++ b/tests/datakit/test_decon.py
@@ -50,17 +50,11 @@ def _write_eval_jsonl(path: Path, records: list[dict]) -> None:
 
 
 def _read_attributes(output_dir: Path) -> dict[str, dict]:
-    """Concatenate every output parquet under *output_dir* and key by id.
-
-    Flattens the on-disk ``attributes`` struct (datakit convention) back into
-    top-level keys so test assertions stay terse:
-    ``rows[doc_id]["contaminated"]`` instead of ``rows[doc_id]["attributes"]["contaminated"]``.
-    """
+    """Concatenate every flat attribute Parquet file under *output_dir* and key by ID."""
     rows: dict[str, dict] = {}
     for pf in sorted(output_dir.glob("outputs/main/part-*.parquet")):
         for row in pq.read_table(str(pf)).to_pylist():
-            attrs = row.pop("attributes", {}) or {}
-            rows[row["id"]] = {**row, **attrs}
+            rows[row["id"]] = row
     return rows
 
 
@@ -192,12 +186,7 @@ def test_decon_preserves_partition_filenames(fox_corpus):
 
 
 def test_decon_output_schema(fox_corpus):
-    """Output Parquet has exactly ``{id, partition_id, attributes: struct<contaminated, max_overlap, matched_hashes>}``.
-
-    This is the datakit attribute convention consumed by
-    :func:`marin.processing.classification.consolidate.consolidate` --
-    ``id`` joinable on top, decon facts grouped under ``attributes``.
-    """
+    """Output Parquet has flat ID, partition, and decontamination fields."""
     decon_to_parquet(
         normalized_data=_as_source(Path(fox_corpus["input_dir"])),
         eval_data_sources=fox_corpus["eval_dir"],
@@ -209,18 +198,13 @@ def test_decon_output_schema(fox_corpus):
     output_files = sorted(Path(fox_corpus["output_dir"]).glob("outputs/main/part-*.parquet"))
     assert output_files, "expected at least one output partition"
     schema = pq.read_schema(str(output_files[0]))
-    assert set(schema.names) == {"id", "partition_id", "attributes"}
+    assert set(schema.names) == {"id", "partition_id", "contaminated", "max_overlap", "matched_hashes"}
     assert pa.types.is_string(schema.field("id").type)
     assert pa.types.is_integer(schema.field("partition_id").type)
-
-    attrs_field = schema.field("attributes")
-    assert pa.types.is_struct(attrs_field.type)
-    attrs_fields = {f.name: f for f in attrs_field.type}
-    assert set(attrs_fields) == {"contaminated", "max_overlap", "matched_hashes"}
-    assert pa.types.is_boolean(attrs_fields["contaminated"].type)
-    assert pa.types.is_floating(attrs_fields["max_overlap"].type)
-    assert pa.types.is_list(attrs_fields["matched_hashes"].type)
-    assert attrs_fields["matched_hashes"].type.value_type == pa.uint64()
+    assert pa.types.is_boolean(schema.field("contaminated").type)
+    assert pa.types.is_floating(schema.field("max_overlap").type)
+    assert pa.types.is_list(schema.field("matched_hashes").type)
+    assert schema.field("matched_hashes").type.value_type == pa.uint64()
 
 
 def test_decon_emits_eval_hash_index_sidecar(fox_corpus):

--- a/tests/datakit/test_global_exact_dedup.py
+++ b/tests/datakit/test_global_exact_dedup.py
@@ -84,10 +84,10 @@ def test_global_exact_deduplicate_writes_sparse_copartitioned_attributes(tmp_pat
     assert c_shards == []
 
     assert pq.read_table(b_shards[0]).to_pylist() == [
-        {"id": "a-only", "attributes": {"dup_doc": True}},
-        {"id": "shared", "attributes": {"dup_doc": True}},
+        {"id": "a-only", "dup_doc": True},
+        {"id": "shared", "dup_doc": True},
     ]
-    assert pq.read_schema(b_shards[0]).names == ["id", "attributes"]
+    assert pq.read_schema(b_shards[0]).names == ["id", "dup_doc"]
 
     assert result.counters["global_exact_dedup/records_in"] == 6
     assert result.counters["global_exact_dedup/duplicate_records"] == 2
@@ -113,7 +113,7 @@ def test_global_exact_deduplicate_uses_shard_order_within_source(tmp_path: Path,
     shards = _attribute_shards(result, source)
     assert [path.name for path in shards] == ["part-00001-of-00002.parquet"]
     assert pq.read_table(shards[0]).to_pylist() == [
-        {"id": "shared", "attributes": {"dup_doc": True}},
+        {"id": "shared", "dup_doc": True},
     ]
 
 

--- a/tests/processing/classification/deduplication/test_exact.py
+++ b/tests/processing/classification/deduplication/test_exact.py
@@ -39,11 +39,11 @@ def test_exact_paragraph_deduplication(fox_corpus):
     # test_gray_dup_2 and test_gray_dup_3 are non-canonical, each has 2 duplicate paragraphs
     for dup_id in ["test_gray_dup_2", "test_gray_dup_3"]:
         assert dup_id in by_doc
-        assert len(by_doc[dup_id]["attributes"]["dup_spans"]) == 2
+        assert len(by_doc[dup_id]["dup_spans"]) == 2
 
     # test_gray_partial shares first paragraph with dup_1/2/3 (non-canonical)
     assert "test_gray_partial" in by_doc
-    assert len(by_doc["test_gray_partial"]["attributes"]["dup_spans"]) == 1
+    assert len(by_doc["test_gray_partial"]["dup_spans"]) == 1
 
     # Unique docs should not appear in output
     assert "test_unique_1" not in by_doc
@@ -80,8 +80,8 @@ def test_exact_document_deduplication(fox_corpus):
     assert "test_gray_dup_1" not in by_doc
 
     # test_gray_dup_2 and test_gray_dup_3 are non-canonical dups
-    assert by_doc["test_gray_dup_2"]["attributes"]["dup_doc"] is True
-    assert by_doc["test_gray_dup_3"]["attributes"]["dup_doc"] is True
+    assert by_doc["test_gray_dup_2"]["dup_doc"] is True
+    assert by_doc["test_gray_dup_3"]["dup_doc"] is True
 
     # Unique docs should not appear in output
     assert "test_unique_1" not in by_doc

--- a/tests/processing/classification/deduplication/test_fuzzy.py
+++ b/tests/processing/classification/deduplication/test_fuzzy.py
@@ -135,9 +135,9 @@ def test_fuzzy_dups_single_source_schema_and_pair(fox_corpus):
     # sharing one dup_cluster_id, with exactly one canonical.
     pair = {"test_contaminated_1", "test_high_overlap"}
     assert pair <= by_source_id.keys(), f"missing attr rows for pair: {pair - by_source_id.keys()}"
-    cluster_ids = {by_source_id[s]["attributes"]["dup_cluster_id"] for s in pair}
+    cluster_ids = {by_source_id[s]["dup_cluster_id"] for s in pair}
     assert len(cluster_ids) == 1, f"pair should share a dup_cluster_id; got {cluster_ids}"
-    canonicals = [s for s in pair if by_source_id[s]["attributes"]["is_cluster_canonical"]]
+    canonicals = [s for s in pair if by_source_id[s]["is_cluster_canonical"]]
     assert len(canonicals) == 1, f"exactly one canonical expected; got {canonicals}"
 
     # Unique docs never have attr rows (no cluster → no annotation).
@@ -225,7 +225,7 @@ def test_fuzzy_dups_multi_source_per_source_attr_trees(fox_corpus):
         content_id = generate_id(shared_text)
         assert content_id in train_rows, f"missing train attr row for {shared_text!r}"
         assert content_id in test_rows, f"missing test attr row for {shared_text!r}"
-        a, b = train_rows[content_id]["attributes"], test_rows[content_id]["attributes"]
+        a, b = train_rows[content_id], test_rows[content_id]
         assert a["dup_cluster_id"] == b["dup_cluster_id"], f"{shared_text!r}: dup_cluster_id mismatch"
         assert (
             a["is_cluster_canonical"] != b["is_cluster_canonical"]
@@ -269,7 +269,7 @@ def _canonical_assignment(source: NormalizedData, output_path: str) -> dict[str,
     minhash = compute_minhash_attrs(source=source, output_path=os.path.join(output_path, "minhash"))
     dups = compute_fuzzy_dups_attrs(inputs=[minhash], output_path=os.path.join(output_path, "dups"), max_parallelism=4)
     rows = _read_cluster_attrs(dups.sources[minhash.source_key].attr_dir)
-    return {r["id"]: (r["attributes"]["dup_cluster_id"], r["attributes"]["is_cluster_canonical"]) for r in rows}
+    return {r["id"]: (r["dup_cluster_id"], r["is_cluster_canonical"]) for r in rows}
 
 
 def test_fuzzy_dups_canonical_selection_is_deterministic(fox_corpus):
@@ -547,7 +547,7 @@ def _run_dedup_on_corpus(tmp_path: Path, docs: list[dict]) -> dict[str, dict]:
 def _cluster_id(by_source_id: dict[str, dict], source_id: str) -> str | None:
     """Return the dup_cluster_id for *source_id*, or None if it has no attr row (singleton)."""
     row = by_source_id.get(source_id)
-    return row["attributes"]["dup_cluster_id"] if row else None
+    return row["dup_cluster_id"] if row else None
 
 
 @pytest.mark.data_integration
@@ -649,7 +649,7 @@ def test_wikipedia_revisions_cluster_per_article(tmp_path: Path, wikipedia_revis
     for article in wikipedia_revisions_articles:
         variants = [sid for sid in by_source_id if sid.startswith(f"{article}__")]
         assert variants, f"no attr rows for revisions of {article!r} (unexpected singletons)"
-        clusters = {by_source_id[sid]["attributes"]["dup_cluster_id"] for sid in variants}
+        clusters = {by_source_id[sid]["dup_cluster_id"] for sid in variants}
         assert len(clusters) == 1, f"{article}: revisions split across clusters: {clusters}"
         article_to_cluster[article] = clusters.pop()
 


### PR DESCRIPTION
* store Datakit attributes as flat Parquet columns keyed by `id`
  * exact dedup uses `dup_doc`
  * fuzzy dedup uses `dup_cluster_id` and `is_cluster_canonical`
  * decontamination uses `contaminated`, `max_overlap`, and `matched_hashes`
* update `consolidate`, the clustered store, reports, ferry validation, the decontamination viewer, and the decon-filter smoke job to read top-level fields
* bump exact dedup to v2, fuzzy dedup to v3, and decontamination to v4 so nested cached outputs are not reused
