### PR TITLE
[datakit] Record exact GHALogs token count

### DIFF
--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -86,7 +86,6 @@ GHALOGS_TOTAL_BYTES = 143_425_404_506
 GHALOGS_ARCHIVE_BYTES = 142_292_965_496
 LOGCHUNKS_TOTAL_BYTES = 24_108_826
 LOGHUB_REPO_SIZE_BYTES = 7_513_088
-GHALOGS_ROUGH_TOKENS_B = 150.0
 DEFAULT_GHALOGS_MAX_MEMBERS = 10_000
 DEFAULT_LOGCHUNKS_MAX_EXAMPLES = 10_000
 DEFAULT_LOGHUB_MAX_FILES = 100
@@ -304,7 +303,6 @@ SOURCE_INVENTORY: tuple[IngestionSourceManifest, ...] = (
         issue_numbers=(PUBLIC_DIAGNOSTIC_LOGS_ISSUE,),
         sample_caps=SampleCapConfig(max_members=DEFAULT_GHALOGS_MAX_MEMBERS),
         compressed_size_bytes=GHALOGS_TOTAL_BYTES,
-        rough_tokens_b=GHALOGS_ROUGH_TOKENS_B,
         source_metadata={"archive_filename": GHALOGS_ZIP_FILENAME},
     ),
     IngestionSourceManifest(

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -30,7 +30,7 @@ from marin.datakit.download.davinci_dev import (
     davinci_dev_ctx_native_normalize_steps,
     davinci_dev_env_native_normalize_steps,
 )
-from marin.datakit.download.diagnostic_logs import GHALOGS_ROUGH_TOKENS_B, ghalogs_public_normalize_steps
+from marin.datakit.download.diagnostic_logs import ghalogs_public_normalize_steps
 from marin.datakit.download.docx_corpus import docx_corpus_normalize_steps
 from marin.datakit.download.dolma3_5_code import dolma3_5_code_prose_normalize_steps
 from marin.datakit.download.dolma4pdfs import dolma4pdfs_normalize_steps
@@ -178,7 +178,10 @@ def all_sources() -> dict[str, DatakitSource]:
         ("dolma_code_prose", dolma3_5_code_prose_normalize_steps, 65.54),
         ("eai-taxonomy-code-w-dclm", eai_taxonomy_code_normalize_steps, 591.90),
         ("finetranslations", finetranslations_normalize_steps, 3040.0),
-        ("ghalogs/public", ghalogs_public_normalize_steps, GHALOGS_ROUGH_TOKENS_B),
+        # Exact count from the tokenized cache .stats.json, measured with
+        # marin-community/marin-tokenizer over the normalized artifact:
+        # 253,343,866,746 tokens / 2,613,421 documents.
+        ("ghalogs/public", ghalogs_public_normalize_steps, 253.343866746),
         # Exact count from the tokenized cache .stats.json, measured with
         # marin-community/marin-tokenizer over the normalized artifact under the
         # final-turn truncation filter: 64,054,289 tokens / 2,835 docs.

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -247,7 +247,6 @@ def test_source_inventory_uses_shared_manifest_policy_metadata():
 def test_all_sources_includes_normalized_ghalogs_public():
     source = all_sources()["ghalogs/public"]
 
-    assert source.rough_token_count_b == GHALOGS_ROUGH_TOKENS_B
     assert [step.name for step in source.normalize_steps] == [
         "raw/diagnostic_logs/ghalogs_public_archive",
         "processed/diagnostic_logs/ghalogs_public_parquet",

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -15,7 +15,6 @@ import pytest
 import requests
 from marin.datakit.download import diagnostic_logs
 from marin.datakit.download.diagnostic_logs import (
-    GHALOGS_ROUGH_TOKENS_B,
     GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH,
     GHALOGS_STAGED_PREFIX,
     SOURCE_INVENTORY,
@@ -239,7 +238,6 @@ def test_source_inventory_uses_shared_manifest_policy_metadata():
 
     assert inventory["ghalogs"].policy.training_allowed is True
     assert inventory["ghalogs"].policy.requires_sanitization is True
-    assert inventory["ghalogs"].rough_tokens_b == GHALOGS_ROUGH_TOKENS_B
     assert inventory["logchunks"].policy.eval_only is True
     assert inventory["loghub"].compressed_size_bytes == 7_513_088
 


### PR DESCRIPTION
Record the GHALogs source size as 253.343866746B tokens, measured with
marin-community/marin-tokenizer over 2,613,421 normalized documents. Remove the
legacy 150B value from the ingestion manifest so `sources.py` is the sole token
count used for mixture planning.

The one-time CoreWeave tokenization persisted `.stats.json` with
`total_tokens=253343866746` and `total_elements=2613421`:
https://iris.oa.dev/#/job/%2Fheld%2Fghalogs-token-count-20260730-2152

The 171,074,555,711-byte temporary token cache was deleted after reading the
stats.
