### PR TITLE
datakit: make artifact paths portable

### DIFF
--- a/experiments/datakit/README.md
+++ b/experiments/datakit/README.md
@@ -22,10 +22,13 @@ main output under `outputs/main/` plus, where it makes sense, a small site/sampl
 reports ([`reports/`](reports/)) read.
 
 Materialized source identities are paths relative to `MARIN_PREFIX`, such as
-`datakit/normalize/foo_<hash>/outputs/main`. Actual data directories remain
-absolute. This keeps source keys stable when artifacts move between regions.
-`NormalizedData` also stores its output directories in this relative form.
-Existing v1 artifacts keep their absolute directories when they load.
+`datakit/normalize/foo_<hash>/outputs/main`. Datakit models use absolute data
+paths at runtime. Artifact result payloads store paths relative to the active
+`MARIN_PREFIX`. `read_artifact` restores the active prefix for consumers. The
+target prefix must contain the same materialized data after a region change.
+Paths outside the active prefix stay absolute. Existing payloads with absolute
+paths load without data recomputation. The framework lineage fields
+`output_path` and `dep_paths` stay absolute.
 
 Datakit attribute Parquet files use a flat schema. The top-level `id` column
 is the join key. Each attribute is another top-level column, such as
@@ -42,6 +45,10 @@ normalized text.
 The final store uses fuzzy canonical markers when they exist. It applies exact
 duplicate markers only to records without fuzzy markers, which covers records
 that MinHash skipped without conflicting with fuzzy canonical selection.
+
+Global exact and fuzzy dedup outputs write `.source_manifest.json` at the output
+root. The file maps each `source_NNN` tag to its source key and its relative
+`outputs/source_NNN` attribute directory.
 
 A source-set change gives a new global exact-dedup output and a new store
 identity. It does not change the identity of tokenization, embedding, quality,

--- a/experiments/datakit/cluster/domain/v0/assign.py
+++ b/experiments/datakit/cluster/domain/v0/assign.py
@@ -27,6 +27,7 @@ from typing import Any
 import numpy as np
 import pyarrow as pa
 from fray.types import ResourceConfig
+from marin.datakit.source_key import DatakitArtifactPath
 from marin.execution.artifact import write_artifact
 from pydantic import BaseModel
 from rigging.filesystem import StoragePath, open_url
@@ -46,9 +47,9 @@ class AssignmentAttrData(BaseModel):
     """Co-partitioned per-source cluster-assignment parquet shards."""
 
     version: str = f"v{ASSIGNMENT_ATTR_DATA_VERSION}"
-    output_dir: str
+    output_dir: DatakitArtifactPath
     source_key: str
-    embedding_output_dir: str
+    embedding_output_dir: DatakitArtifactPath
     k_train: int
     k_views: list[int]
     counters: dict[str, int | float] = {}

--- a/experiments/datakit/cluster/quality/fast_transformer/artifact.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/artifact.py
@@ -8,6 +8,7 @@ Deliberately import-light (pydantic only): the store step consumes
 transformers stack of the scorer into its workers.
 """
 
+from marin.datakit.source_key import DatakitArtifactPath
 from pydantic import BaseModel
 
 # Fixed score cutpoints. Calibration (calibrate.py) warps the raw score so these
@@ -40,9 +41,9 @@ class QualityScores(BaseModel):
     """
 
     version: str = "v1"
-    main_output_dir: str
-    samples_output_dir: str
-    model_dir: str
+    main_output_dir: DatakitArtifactPath
+    samples_output_dir: DatakitArtifactPath
+    model_dir: DatakitArtifactPath
     calib_file: str
     bucket_edges: list[float]
     counters: dict[str, int | float]

--- a/experiments/datakit/embeddings/luxical/pipeline.py
+++ b/experiments/datakit/embeddings/luxical/pipeline.py
@@ -39,7 +39,7 @@ import pyarrow as pa
 from fray.types import ResourceConfig
 from huggingface_hub import hf_hub_download
 from marin.datakit.normalize import NormalizedData
-from marin.datakit.source_key import datakit_source_key
+from marin.datakit.source_key import DatakitArtifactPath, datakit_source_key
 from marin.execution.artifact import write_artifact
 from pydantic import BaseModel
 from rigging.filesystem import StoragePath, marin_temp_bucket
@@ -108,7 +108,7 @@ class EmbeddingAttrData(BaseModel):
     """
 
     version: str = f"v{EMBEDDING_ATTR_DATA_VERSION}"
-    output_dir: str
+    output_dir: DatakitArtifactPath
     source_key: str
     model_name: str
     model_revision: str = ""

--- a/experiments/datakit/global_exact_dedup.py
+++ b/experiments/datakit/global_exact_dedup.py
@@ -28,9 +28,14 @@ from typing import TypedDict
 import pyarrow as pa
 import pyarrow.parquet as pq
 from fray.types import ResourceConfig
-from marin.datakit.copartitioned import CopartitionedShard, CopartitionedSource, build_copartitioned_shards
+from marin.datakit.copartitioned import (
+    CopartitionedShard,
+    CopartitionedSource,
+    build_copartitioned_shards,
+    write_copartitioned_source_manifest,
+)
 from marin.datakit.normalize import NormalizedData
-from marin.datakit.source_key import datakit_source_key
+from marin.datakit.source_key import DatakitArtifactPath, datakit_source_key
 from pydantic import BaseModel
 from rigging.filesystem import StoragePath
 from zephyr import counters
@@ -41,7 +46,7 @@ from zephyr.writers import write_parquet_file
 
 COUNTER_PREFIX = "global_exact_dedup"
 _SHARED_ENTRIES_KEY = "global_exact_dedup_entries"
-GLOBAL_EXACT_DEDUP_DATA_VERSION = 2
+GLOBAL_EXACT_DEDUP_DATA_VERSION = 3
 _ATTR_SCHEMA = pa.schema(
     [
         pa.field("id", pa.string(), nullable=False),
@@ -53,7 +58,7 @@ _ATTR_SCHEMA = pa.schema(
 class ExactDupsPerSource(BaseModel):
     """Sparse exact-duplicate attribute files for one normalized source."""
 
-    attr_dir: str
+    attr_dir: DatakitArtifactPath
 
 
 class GlobalExactDedupData(BaseModel):
@@ -126,7 +131,7 @@ def _select_duplicates(_key: str, records: Iterator[_ExactRecord]) -> Iterator[_
     yield from records
 
 
-def _write_shard(file_idx: int, records: Iterator[_ExactRecord]) -> dict[str, int | str]:
+def _write_shard(file_idx: int, records: Iterator[_ExactRecord]) -> None:
     entries: list[CopartitionedShard] = zephyr_worker_ctx().get_shared(_SHARED_ENTRIES_KEY)
     entry = entries[file_idx]
     duplicate_records = 0
@@ -137,13 +142,8 @@ def _write_shard(file_idx: int, records: Iterator[_ExactRecord]) -> dict[str, in
             duplicate_records += 1
             yield {"id": record["id"], "dup_doc": True}
 
-    result = write_parquet_file(duplicate_rows(), output_path=entry.output_path, schema=_ATTR_SCHEMA)
+    write_parquet_file(duplicate_rows(), output_path=entry.output_path, schema=_ATTR_SCHEMA)
     counters.pipeline.update_counter(f"{COUNTER_PREFIX}/duplicate_records", duplicate_records)
-    return {
-        **result,
-        "file_idx": file_idx,
-        "duplicate_records": duplicate_records,
-    }
 
 
 def global_exact_deduplicate(
@@ -176,14 +176,19 @@ def global_exact_deduplicate(
             key=lambda record: record["id"],
             reducer=_select_duplicates,
             sort_by=lambda record: (record["file_idx"], record["row_index"]),
+            # Bound the cross-source ID shuffle by worker capacity. The next
+            # group_by inherits this output shard count.
             num_output_shards=shuffle_shards,
         )
         .group_by(
             key=lambda record: record["file_idx"],
             reducer=_write_shard,
             sort_by=lambda record: record["id"],
-            num_output_shards=shuffle_shards,
         )
     )
     outcome = context.execute(pipeline)
+    write_copartitioned_source_manifest(
+        output_path=output_path,
+        attr_dirs={source_key: source.attr_dir for source_key, source in outputs.items()},
+    )
     return GlobalExactDedupData(sources=outputs, counters=dict(outcome.counters))

--- a/experiments/datakit/reports/common.py
+++ b/experiments/datakit/reports/common.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 import pyarrow.parquet as pq
+from marin.datakit.source_key import DatakitArtifactPath
 from pydantic import BaseModel
 from rigging.filesystem import StoragePath
 
@@ -31,7 +32,7 @@ class StageReport(BaseModel):
     """
 
     version: str = "v1"
-    html_path: str
+    html_path: DatakitArtifactPath
     stats: dict[str, Any]
 
 

--- a/experiments/datakit/store/datakit_store.py
+++ b/experiments/datakit/store/datakit_store.py
@@ -55,6 +55,7 @@ from levanter.store.cache import (
     _merge_sharded_ledgers,
 )
 from marin.datakit.decon import DeconAttributes
+from marin.datakit.source_key import DatakitArtifactPath
 from marin.execution.artifact import read_artifact, write_artifact
 from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData, FuzzyDupsPerSource
 from marin.processing.tokenize.attributes import TokenizedAttrData
@@ -78,7 +79,7 @@ class BucketCacheStats(BaseModel):
 
     cluster_id: int
     quality_bucket: int
-    path: str
+    path: DatakitArtifactPath
     total_elements: int
     total_tokens: int
     n_shards: int
@@ -92,7 +93,7 @@ class ClusteredStoreData(BaseModel):
     """
 
     version: str = "v3"
-    cache_path: str
+    cache_path: DatakitArtifactPath
     cluster_view: int
     bucket_edges: list[float]
     split: str
@@ -569,13 +570,26 @@ def build_clustered_store(
         default_subshards=default_subshards,
     )
 
+    source_keys: dict[str, str] = {}
+    for source_name, tok in tokenize.items():
+        source_key = tok.source_keys.get(split)
+        if source_key is None:
+            raise ValueError(f"{source_name}: tokenize has no source_key for split={split!r}")
+        source_keys[source_name] = source_key
+    expected_source_keys = set(source_keys.values())
+    if len(expected_source_keys) != len(source_keys):
+        raise ValueError(f"tokenize sources must use unique source keys for split={split!r}")
+    for label, sources in (("exact_dedup", exact_dedup.sources), ("dedup", dedup.sources)):
+        if set(sources) != expected_source_keys:
+            missing = sorted(expected_source_keys - set(sources))
+            extra = sorted(set(sources) - expected_source_keys)
+            raise ValueError(f"{label} source set must equal tokenize source keys: missing={missing!r}, extra={extra!r}")
+
     # Resolve the flat per-source-shard spec list.
     shard_specs: list[dict[str, str]] = []
     for source_name in sorted(tokenize):
         tok = tokenize[source_name]
-        source_key = tok.source_keys.get(split)
-        if source_key is None:
-            raise ValueError(f"{source_name}: tokenize has no source_key for split={split!r}")
+        source_key = source_keys[source_name]
         cluster_asg = cluster_assign[source_name]
         if cluster_asg.source_key != source_key:
             raise ValueError(

--- a/lib/marin/src/marin/datakit/copartitioned.py
+++ b/lib/marin/src/marin/datakit/copartitioned.py
@@ -4,10 +4,14 @@
 """Co-partitioned input and output shard layout for Datakit stages."""
 
 import dataclasses
+import json
 import os
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 from rigging.filesystem import StoragePath, prefix_join
+
+SOURCE_MANIFEST_FILENAME = ".source_manifest.json"
+SOURCE_MANIFEST_VERSION = "v1"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -28,6 +32,23 @@ class CopartitionedShard:
     source_tag: str
     basename: str
     output_path: str
+
+
+@dataclasses.dataclass(frozen=True)
+class CopartitionedSourceManifestEntry:
+    """One source mapping in a co-partitioned output manifest."""
+
+    source_tag: str
+    source_key: str
+    attribute_dir: str
+
+
+@dataclasses.dataclass(frozen=True)
+class CopartitionedSourceManifest:
+    """Source mappings for one co-partitioned output."""
+
+    version: str
+    sources: list[CopartitionedSourceManifestEntry]
 
 
 def build_copartitioned_shards(
@@ -71,3 +92,20 @@ def build_copartitioned_shards(
             )
 
     return shards, attr_dirs
+
+
+def write_copartitioned_source_manifest(*, output_path: str, attr_dirs: Mapping[str, str]) -> None:
+    """Write the source-tag mapping for a completed co-partitioned output."""
+    sources = [
+        CopartitionedSourceManifestEntry(
+            source_tag=os.path.basename(attr_dir.rstrip("/")),
+            source_key=source_key,
+            attribute_dir=f"outputs/{os.path.basename(attr_dir.rstrip('/'))}",
+        )
+        for source_key, attr_dir in attr_dirs.items()
+    ]
+    sources.sort(key=lambda source: source.source_tag)
+    manifest = CopartitionedSourceManifest(version=SOURCE_MANIFEST_VERSION, sources=sources)
+    manifest_path = StoragePath(prefix_join(output_path, SOURCE_MANIFEST_FILENAME))
+    manifest_path.parent.mkdirs()
+    manifest_path.write_text(json.dumps(dataclasses.asdict(manifest), indent=2) + "\n")

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -57,6 +57,7 @@ from zephyr.readers import SUPPORTED_EXTENSIONS, load_file
 from zephyr.writers import write_parquet_file
 
 from marin.datakit.normalize import NormalizedData
+from marin.datakit.source_key import DatakitArtifactPath
 from marin.execution.artifact import read_artifact
 from marin.execution.step_spec import StepSpec
 
@@ -112,10 +113,10 @@ class DeconAttributes(BaseModel):
     """
 
     version: str = f"v{DECON_ATTRIBUTES_VERSION}"
-    main_output_dir: str
-    flagged_output_dir: str
+    main_output_dir: DatakitArtifactPath
+    flagged_output_dir: DatakitArtifactPath
     num_partitions: int
-    eval_hash_index_path: str
+    eval_hash_index_path: DatakitArtifactPath
     counters: dict[str, int | float]
 
 
@@ -161,9 +162,9 @@ class EvalBloom(BaseModel):
     """
 
     version: str = "v1"
-    bloom_dir: str
-    bloom_path: str
-    eval_hash_index_path: str
+    bloom_dir: DatakitArtifactPath
+    bloom_path: DatakitArtifactPath
+    eval_hash_index_path: DatakitArtifactPath
     estimated_doc_count: int
     false_positive_rate: float
     n_eval_records: int = 0
@@ -852,7 +853,7 @@ class SourceDropSet(BaseModel):
     the counts are informational.
     """
 
-    output_dir: str
+    output_dir: DatakitArtifactPath
     n_sampled: int
     n_dropped: int
 
@@ -957,8 +958,8 @@ class AllSourceDropSets(BaseModel):
     and source frequencies retained for threshold audits.
     """
 
-    output_dir: str
-    global_output_dir: str
+    output_dir: DatakitArtifactPath
+    global_output_dir: DatakitArtifactPath
     num_sources: int
     n_global_dropped: int
     counters: dict[str, int | float]

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -55,6 +55,7 @@ from marin.datakit.ingestion_manifest import (
     write_ingestion_metadata_json,
 )
 from marin.datakit.normalize import normalize_step
+from marin.datakit.source_key import DatakitArtifactPath
 from marin.execution.step_spec import StepSpec
 
 logger = logging.getLogger(__name__)
@@ -217,12 +218,12 @@ class ExtractedPartitionedDiagnosticLogs(DiagnosticLogsArtifact):
     """Materialized GHALogs sample with train/dev/test/holdout partitions."""
 
     source_label: str
-    output_dir: str
-    train_file: str
-    dev_file: str
-    test_file: str
-    holdout_file: str
-    metadata_path: str
+    output_dir: DatakitArtifactPath
+    train_file: DatakitArtifactPath
+    dev_file: DatakitArtifactPath
+    test_file: DatakitArtifactPath
+    holdout_file: DatakitArtifactPath
+    metadata_path: DatakitArtifactPath
     record_count: int
     bytes_written: int
     content_fingerprint: str
@@ -232,9 +233,9 @@ class ExtractedDiagnosticLogSlice(DiagnosticLogsArtifact):
     """Materialized single-file diagnostic-log slice."""
 
     source_label: str
-    output_dir: str
-    output_file: str
-    metadata_path: str
+    output_dir: DatakitArtifactPath
+    output_file: DatakitArtifactPath
+    metadata_path: DatakitArtifactPath
     record_count: int
     bytes_written: int
     content_fingerprint: str
@@ -252,8 +253,8 @@ class MaterializedDiagnosticLogParquet(DiagnosticLogsArtifact):
     """Reusable parquet shards for a diagnostic-log corpus or partition."""
 
     source_label: str
-    output_dir: str
-    data_glob: str
+    output_dir: DatakitArtifactPath
+    data_glob: DatakitArtifactPath
     record_count: int
     counters: dict[str, int | float]
     content_fingerprint: str

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -27,7 +27,7 @@ from typing import Any
 import dupekit
 import pyarrow as pa
 from fray.types import ResourceConfig
-from pydantic import BaseModel, ValidationInfo, field_serializer, model_validator
+from pydantic import BaseModel, ValidationInfo, model_validator
 from rigging.filesystem import StoragePath, prefix_join, url_to_fs
 from zephyr import counters
 from zephyr.dataset import Dataset, ShardInfo
@@ -36,7 +36,7 @@ from zephyr.readers import SUPPORTED_EXTENSIONS, load_file
 from zephyr.writers import ThreadedBatchWriter, write_parquet_file
 
 from marin.datakit import partition_filename
-from marin.datakit.source_key import datakit_artifact_path, datakit_source_path
+from marin.datakit.source_key import DatakitArtifactPath
 from marin.execution.artifact import ARTIFACT_LOAD_CONTEXT_KEY
 from marin.execution.step_spec import StepSpec
 
@@ -86,8 +86,8 @@ class NormalizedData(BaseModel):
     """
 
     version: str = NORMALIZED_DATA_VERSION
-    main_output_dir: str
-    dup_output_dir: str
+    main_output_dir: DatakitArtifactPath
+    dup_output_dir: DatakitArtifactPath
     counters: dict[str, int | float]
 
     @model_validator(mode="before")
@@ -103,15 +103,8 @@ class NormalizedData(BaseModel):
             raise ValueError(f"Unsupported NormalizedData version: {version!r}")
 
         loaded = dict(value)
-        if version == NORMALIZED_DATA_VERSION:
-            loaded["main_output_dir"] = datakit_source_path(loaded["main_output_dir"])
-            loaded["dup_output_dir"] = datakit_source_path(loaded["dup_output_dir"])
         loaded["version"] = NORMALIZED_DATA_VERSION
         return loaded
-
-    @field_serializer("main_output_dir", "dup_output_dir", when_used="json")
-    def _serialize_output_dir(self, value: str) -> str:
-        return datakit_artifact_path(value)
 
 
 def generate_id(text: str) -> str:

--- a/lib/marin/src/marin/datakit/source_key.py
+++ b/lib/marin/src/marin/datakit/source_key.py
@@ -3,7 +3,12 @@
 
 """Stable source identity for Datakit artifacts."""
 
+from typing import Annotated
+
+from pydantic import BeforeValidator, PlainSerializer, ValidationInfo
 from rigging.filesystem import StoragePath, StoreType, data_buckets, marin_prefix, prefix_join
+
+from marin.execution.artifact import ARTIFACT_LOAD_CONTEXT_KEY
 
 
 def _marin_data_prefixes() -> list[StoragePath]:
@@ -62,3 +67,17 @@ def datakit_artifact_path(source_path: str) -> str:
     if not relative:
         raise ValueError(f"Datakit artifact path must be below MARIN_PREFIX: {source_path!r}")
     return relative
+
+
+def _resolve_datakit_artifact_path(value: str, info: ValidationInfo) -> str:
+    if info.context and info.context.get(ARTIFACT_LOAD_CONTEXT_KEY):
+        return datakit_source_path(value)
+    return value
+
+
+DatakitArtifactPath = Annotated[
+    str,
+    BeforeValidator(_resolve_datakit_artifact_path),
+    PlainSerializer(datakit_artifact_path, return_type=str, when_used="json"),
+]
+"""A Datakit path that omits the active ``MARIN_PREFIX`` in artifact payloads."""

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
@@ -40,8 +40,13 @@ from zephyr.execution import MAX_WORKERS_PER_JOB, ZephyrContext
 from zephyr.worker_context import zephyr_worker_ctx
 from zephyr.writers import write_parquet_file
 
-from marin.datakit.copartitioned import CopartitionedShard, CopartitionedSource, build_copartitioned_shards
-from marin.datakit.source_key import datakit_source_key
+from marin.datakit.copartitioned import (
+    CopartitionedShard,
+    CopartitionedSource,
+    build_copartitioned_shards,
+    write_copartitioned_source_manifest,
+)
+from marin.datakit.source_key import DatakitArtifactPath, datakit_source_key
 from marin.execution.artifact import read_artifact
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.deduplication.connected_components import connected_components
@@ -49,7 +54,7 @@ from marin.processing.classification.deduplication.dedup_commons import _load_ba
 from marin.processing.classification.deduplication.fuzzy_minhash import MinHashAttrData, MinHashParams
 
 logger = logging.getLogger(__name__)
-FUZZY_DUPS_ATTR_DATA_VERSION = 3
+FUZZY_DUPS_ATTR_DATA_VERSION = 4
 
 
 class FuzzyDupsPerSource(BaseModel):
@@ -61,7 +66,7 @@ class FuzzyDupsPerSource(BaseModel):
             normalized) shards.
     """
 
-    attr_dir: str
+    attr_dir: DatakitArtifactPath
 
 
 class FuzzyDupsAttrData(BaseModel):
@@ -356,6 +361,7 @@ def compute_fuzzy_dups_attrs(
 
     outcome = ctx.execute(shard_pipeline, verbose=True)
     shard_results = outcome.results
+    write_copartitioned_source_manifest(output_path=output_path, attr_dirs=attr_dirs)
 
     # Aggregate per-source counters across shards for the final artifact.
     sources = {source_key: FuzzyDupsPerSource(attr_dir=attr_dir) for source_key, attr_dir in attr_dirs.items()}

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
@@ -28,7 +28,7 @@ from zephyr.dataset import Dataset
 from zephyr.execution import ZephyrContext
 
 from marin.datakit.normalize import NormalizedData
-from marin.datakit.source_key import datakit_source_key
+from marin.datakit.source_key import DatakitArtifactPath, datakit_source_key
 from marin.execution.artifact import read_artifact
 from marin.execution.step_spec import StepSpec
 from marin.processing.classification.deduplication.dedup_commons import _load_batches
@@ -78,7 +78,7 @@ class MinHashAttrData(BaseModel):
     version: str = f"v{MINHASH_ATTR_DATA_VERSION}"
     params: MinHashParams
     source_key: str
-    attr_dir: str
+    attr_dir: DatakitArtifactPath
     counters: dict[str, int | float]
 
 

--- a/lib/marin/src/marin/processing/tokenize/attributes.py
+++ b/lib/marin/src/marin/processing/tokenize/attributes.py
@@ -37,7 +37,7 @@ from zephyr.execution import ZephyrContext
 from zephyr.readers import load_file
 
 from marin.datakit.normalize import NormalizedData
-from marin.datakit.source_key import datakit_source_key
+from marin.datakit.source_key import DatakitArtifactPath, datakit_source_key
 from marin.execution.artifact import read_artifact
 from marin.execution.step_spec import StepSpec
 from marin.processing.tokenize._core import tokenize_pipeline
@@ -71,7 +71,7 @@ class TokenizedAttrData(BaseModel):
     """
 
     version: str = f"v{TOKENIZED_ATTR_DATA_VERSION}"
-    output_dirs: dict[str, str]
+    output_dirs: dict[str, DatakitArtifactPath]
     source_keys: dict[str, str]
     tokenizer: str
     tokenizer_backend: str

--- a/lib/marin/src/marin/processing/tokenize/store_builder.py
+++ b/lib/marin/src/marin/processing/tokenize/store_builder.py
@@ -41,6 +41,7 @@ from zephyr.dataset import Dataset, format_shard_path
 from zephyr.execution import ZephyrContext
 from zephyr.readers import load_file
 
+from marin.datakit.source_key import DatakitArtifactPath
 from marin.execution.artifact import read_artifact
 from marin.execution.step_spec import StepSpec
 from marin.processing.tokenize.attributes import TokenizedAttrData
@@ -59,7 +60,7 @@ class LevanterSplitStats(BaseModel):
         total_tokens: Total tokens across all documents (``input_ids`` field count).
     """
 
-    path: str
+    path: DatakitArtifactPath
     total_elements: int
     total_tokens: int
 
@@ -81,9 +82,9 @@ class LevanterStoreData(BaseModel):
     """
 
     version: str = "v1"
-    cache_path: str
+    cache_path: DatakitArtifactPath
     splits: dict[str, LevanterSplitStats]
-    source_dirs: list[dict[str, str]]
+    source_dirs: list[dict[str, DatakitArtifactPath]]
     tokenizer: str
 
 

--- a/tests/datakit/test_datakit_store.py
+++ b/tests/datakit/test_datakit_store.py
@@ -12,13 +12,17 @@ splits a bucket without losing or duplicating data.
 """
 
 import glob
+import json
 import os
 
 import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
+import pytest
 from levanter.store.cache import TreeCache
 from marin.datakit.decon import DeconAttributes
+from marin.datakit.source_key import datakit_source_key
+from marin.execution.artifact import read_artifact
 from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData, FuzzyDupsPerSource
 from marin.processing.classification.deduplication.fuzzy_minhash import MinHashParams
 from marin.processing.tokenize.attributes import TokenizedAttrData
@@ -130,6 +134,7 @@ def _write_shard(dirs: dict[str, str], basename: str, docs: list[_Doc]) -> None:
 def _build_inputs(tmp_path):
     """Materialize the synthetic inputs and return the typed artifacts."""
     main_dir = str(tmp_path / "src")
+    source_key = datakit_source_key(main_dir)
     dirs = {k: str(tmp_path / k) for k in ("tokenize", "decon", "cluster", "quality", "exact_dedup", "dedup")}
     tok_train = f"{dirs['tokenize']}/{SPLIT}"
     for d in (*dirs.values(), tok_train):
@@ -142,7 +147,7 @@ def _build_inputs(tmp_path):
     tokenize = {
         "src": TokenizedAttrData(
             output_dirs={SPLIT: tok_train},
-            source_keys={SPLIT: main_dir},
+            source_keys={SPLIT: source_key},
             tokenizer="dummy",
             tokenizer_backend="huggingface",
             counters={},
@@ -160,7 +165,7 @@ def _build_inputs(tmp_path):
     cluster_assign = {
         "src": AssignmentAttrData(
             output_dir=dirs["cluster"],
-            source_key=main_dir,
+            source_key=source_key,
             embedding_output_dir="",
             k_train=CLUSTER_VIEW,
             k_views=[],
@@ -178,12 +183,12 @@ def _build_inputs(tmp_path):
     }
     dedup = FuzzyDupsAttrData(
         params=MinHashParams(num_perms=8, num_bands=4, ngram_size=5, seed=0),
-        sources={main_dir: FuzzyDupsPerSource(attr_dir=dirs["dedup"])},
+        sources={source_key: FuzzyDupsPerSource(attr_dir=dirs["dedup"])},
         counters={},
     )
     exact_dedup = GlobalExactDedupData(
         sources={
-            main_dir: ExactDupsPerSource(
+            source_key: ExactDupsPerSource(
                 attr_dir=dirs["exact_dedup"],
             )
         },
@@ -201,7 +206,8 @@ def _read_bucket_tokens(bucket_root: str) -> list[np.ndarray]:
     return docs
 
 
-def test_store_filters_routes_and_roundtrips(tmp_path):
+def test_store_filters_routes_and_roundtrips(tmp_path, monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", str(tmp_path))
     tokenize, decontam, cluster_assign, quality, exact_dedup, dedup = _build_inputs(tmp_path)
     output_path = str(tmp_path / "store")
 
@@ -247,6 +253,12 @@ def test_store_filters_routes_and_roundtrips(tmp_path):
     assert artifact.counters["datakit_store/tokens_out"] == sum(
         length for docs in EXPECTED.values() for length in docs.values()
     )
+    record = json.loads((tmp_path / "store" / ".artifact.json").read_text())
+    assert record["result"]["cache_path"] == "store"
+    assert all(bucket["path"].startswith("store/") for bucket in record["result"]["buckets"])
+    loaded = read_artifact(output_path, ClusteredStoreData)
+    assert loaded.cache_path == output_path
+    assert [bucket.path for bucket in loaded.buckets] == [bucket.path for bucket in artifact.buckets]
 
 
 def test_store_subshards_hot_bucket_without_data_loss(tmp_path):
@@ -289,3 +301,28 @@ def test_store_subshards_hot_bucket_without_data_loss(tmp_path):
 
     # A non-split bucket is unaffected.
     assert by_key[(0, 0)].n_shards == 1
+
+
+@pytest.mark.parametrize("label", ["exact_dedup", "dedup"])
+def test_store_rejects_dedup_source_set_mismatch(tmp_path, monkeypatch, label):
+    monkeypatch.setenv("MARIN_PREFIX", str(tmp_path))
+    tokenize, decontam, cluster_assign, quality, exact_dedup, dedup = _build_inputs(tmp_path)
+    if label == "exact_dedup":
+        exact_dedup.sources["extra/source"] = ExactDupsPerSource(attr_dir=str(tmp_path / "extra"))
+    else:
+        dedup.sources["extra/source"] = FuzzyDupsPerSource(attr_dir=str(tmp_path / "extra"))
+
+    with pytest.raises(ValueError, match=rf"{label} source set must equal tokenize source keys"):
+        build_clustered_store(
+            tokenize=tokenize,
+            decontam=decontam,
+            cluster_assign=cluster_assign,
+            quality=quality,
+            exact_dedup=exact_dedup,
+            dedup=dedup,
+            output_path=str(tmp_path / "store"),
+            cluster_view=CLUSTER_VIEW,
+            split=SPLIT,
+            reduce_shards=4,
+            default_subshards=1,
+        )

--- a/tests/datakit/test_global_exact_dedup.py
+++ b/tests/datakit/test_global_exact_dedup.py
@@ -3,6 +3,7 @@
 
 """Behavior tests for the Datakit global exact-dedup step."""
 
+import json
 from pathlib import Path
 
 import pyarrow as pa
@@ -13,6 +14,7 @@ from fray.local_backend import LocalClient
 from fray.types import ResourceConfig
 from marin.datakit.normalize import NormalizedData
 from marin.datakit.source_key import datakit_source_key
+from marin.execution.artifact import read_artifact, write_artifact
 
 from experiments.datakit.global_exact_dedup import GlobalExactDedupData, global_exact_deduplicate
 
@@ -91,6 +93,31 @@ def test_global_exact_deduplicate_writes_sparse_copartitioned_attributes(tmp_pat
 
     assert result.counters["global_exact_dedup/records_in"] == 6
     assert result.counters["global_exact_dedup/duplicate_records"] == 2
+    assert json.loads((tmp_path / "output" / ".source_manifest.json").read_text()) == {
+        "version": "v1",
+        "sources": [
+            {
+                "source_tag": "source_000",
+                "source_key": "input-a/outputs/main",
+                "attribute_dir": "outputs/source_000",
+            },
+            {
+                "source_tag": "source_001",
+                "source_key": "input-b/outputs/main",
+                "attribute_dir": "outputs/source_001",
+            },
+            {
+                "source_tag": "source_002",
+                "source_key": "input-c/outputs/main",
+                "attribute_dir": "outputs/source_002",
+            },
+        ],
+    }
+    write_artifact(result, str(tmp_path / "output"))
+    record = json.loads((tmp_path / "output" / ".artifact.json").read_text())
+    assert record["result"]["sources"]["input-b/outputs/main"]["attr_dir"] == "output/outputs/source_001"
+    loaded = read_artifact(str(tmp_path / "output"), GlobalExactDedupData)
+    assert loaded.sources["input-b/outputs/main"].attr_dir == str(tmp_path / "output/outputs/source_001")
 
 
 def test_global_exact_deduplicate_uses_shard_order_within_source(tmp_path: Path, monkeypatch):

--- a/tests/datakit/test_source_key.py
+++ b/tests/datakit/test_source_key.py
@@ -1,8 +1,19 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+from pathlib import Path
+
 import pytest
-from marin.datakit.source_key import datakit_source_key, datakit_source_path
+from marin.datakit.source_key import DatakitArtifactPath, datakit_source_key, datakit_source_path
+from marin.execution.artifact import read_artifact, write_artifact
+from pydantic import BaseModel
+
+
+class ArtifactPaths(BaseModel):
+    primary: DatakitArtifactPath
+    by_split: dict[str, DatakitArtifactPath]
+    mirrors: list[DatakitArtifactPath]
 
 
 def test_datakit_source_key_removes_marin_prefix(monkeypatch):
@@ -68,3 +79,24 @@ def test_datakit_source_path_preserves_other_marin_region(monkeypatch):
         datakit_source_path("s3://marin-us-east-02a/marin/datakit/normalize/foo/outputs/main")
         == "s3://marin-us-east-02a/marin/datakit/normalize/foo/outputs/main"
     )
+
+
+def test_datakit_artifact_path_round_trip_for_nested_payloads(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", str(tmp_path))
+    artifact_dir = tmp_path / "artifact"
+    artifact_dir.mkdir()
+    value = ArtifactPaths(
+        primary=str(tmp_path / "primary"),
+        by_split={"train": str(tmp_path / "splits/train")},
+        mirrors=[str(tmp_path / "mirrors/first"), "s3://external-bucket/mirror"],
+    )
+
+    write_artifact(value, str(artifact_dir))
+
+    record = json.loads((artifact_dir / ".artifact.json").read_text())
+    assert record["result"] == {
+        "primary": "primary",
+        "by_split": {"train": "splits/train"},
+        "mirrors": ["mirrors/first", "s3://external-bucket/mirror"],
+    }
+    assert read_artifact(str(artifact_dir), ArtifactPaths) == value

--- a/tests/processing/classification/deduplication/test_fuzzy.py
+++ b/tests/processing/classification/deduplication/test_fuzzy.py
@@ -1,6 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
 import random
 import string
@@ -197,9 +198,10 @@ def test_fuzzy_dups_multi_source_per_source_attr_trees(fox_corpus):
         ],
     )
 
+    output_path = os.path.join(fox_corpus["output_dir"], "fuzzy_dups")
     dups = compute_fuzzy_dups_attrs(
         inputs=[train_mh, test_mh],
-        output_path=os.path.join(fox_corpus["output_dir"], "fuzzy_dups"),
+        output_path=output_path,
         max_parallelism=1,
     )
 
@@ -208,6 +210,13 @@ def test_fuzzy_dups_multi_source_per_source_attr_trees(fox_corpus):
         assert per_source.attr_dir.rsplit("/", 1)[-1].startswith("source_"), per_source.attr_dir
         assert Path(per_source.attr_dir).exists()
     assert dups.attr_dir_for_source(train_main_dir) == dups.sources[train_mh.source_key].attr_dir
+    manifest = json.loads((Path(output_path) / ".source_manifest.json").read_text())
+    assert manifest["version"] == "v1"
+    assert {source["source_key"] for source in manifest["sources"]} == set(dups.sources)
+    assert {source["attribute_dir"] for source in manifest["sources"]} == {
+        "outputs/source_000",
+        "outputs/source_001",
+    }
 
     def rows_by_id(source_key: str) -> dict[str, dict]:
         return {r["id"]: r for r in _read_cluster_attrs(dups.sources[source_key].attr_dir)}


### PR DESCRIPTION
* store Datakit result paths below the active `MARIN_PREFIX` as relative values and restore them through `read_artifact`
* keep existing absolute payloads and paths outside the active prefix valid
* add `.source_manifest.json` to global exact and fuzzy dedup outputs
  * map each `source_NNN` tag to its source key and relative attribute directory
* let the second exact-dedup `group_by` inherit the first shuffle width
* require exact and fuzzy dedup source sets to match tokenize source keys
* bump exact and fuzzy dedup artifact versions so new outputs contain source manifests
  * keep the other stage versions unchanged for path-only payload changes
* require mirrored materialized data when a payload loads below a different `MARIN_PREFIX`
