### PR TITLE
execution: report active step lock owner

### DIFF
--- a/lib/iris/tests/test_distributed_lock.py
+++ b/lib/iris/tests/test_distributed_lock.py
@@ -63,6 +63,7 @@ def test_stale_lock_can_be_taken_over(tmp_path):
         f.write(json.dumps({"worker_id": stale_lease.worker_id, "timestamp": stale_lease.timestamp}))
 
     lock = create_lock(lock_path, worker_id="new-worker")
+    assert lock.active_holder_id() is None
     assert lock.try_acquire()
     lock.release()
 
@@ -121,10 +122,13 @@ def test_has_active_holder(tmp_path):
     lock = create_lock(lock_path, worker_id="holder-a")
 
     assert not lock.has_active_holder()
+    assert lock.active_holder_id() is None
     assert lock.try_acquire()
     assert lock.has_active_holder()
+    assert lock.active_holder_id() == "holder-a"
     lock.release()
     assert not lock.has_active_holder()
+    assert lock.active_holder_id() is None
 
 
 def test_same_holder_can_reacquire(tmp_path):

--- a/lib/marin/src/marin/execution/step_status.py
+++ b/lib/marin/src/marin/execution/step_status.py
@@ -16,11 +16,12 @@ import functools
 import json
 import logging
 import os
-import time
 from collections.abc import Callable, Generator
 from threading import Event, Thread
+from time import sleep
 from typing import TypeVar
 
+from iris.cluster.client.job_info import get_job_info
 from rigging.filesystem import prefix_join, url_to_fs
 from rigging.filesystem.distributed_lock import (
     HEARTBEAT_INTERVAL,
@@ -28,6 +29,7 @@ from rigging.filesystem.distributed_lock import (
     create_lock,
     default_worker_id,
 )
+from rigging.timing import RateLimiter
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +39,7 @@ STATUS_RUNNING = "RUNNING"
 STATUS_FAILED = "FAILED"
 STATUS_SUCCESS = "SUCCESS"
 STATUS_DEP_FAILED = "DEP_FAILED"  # Dependency failed
-_IRIS_TASK_ID_ENV = "IRIS_TASK_ID"
+_LOCK_WAIT_LOG_INTERVAL = 5 * 60
 
 
 def get_status_path(output_path: str) -> str:
@@ -140,10 +142,6 @@ class StatusFile:
         """Release the lock if we hold it."""
         self._lock.release()
 
-    def has_active_lock(self) -> bool:
-        """Check if any worker has an active (non-stale) lock."""
-        return self._lock.has_active_holder()
-
     def active_lock_holder(self) -> str | None:
         """Return the active lock-owner ID, or None if no active lock exists."""
         return self._lock.active_holder_id()
@@ -156,10 +154,10 @@ class StatusFile:
 
 def worker_id() -> str:
     local_worker_id = default_worker_id()
-    iris_task_id = os.environ.get(_IRIS_TASK_ID_ENV)
-    if iris_task_id is None:
+    job_info = get_job_info()
+    if job_info is None:
         return local_worker_id
-    return f"{iris_task_id} ({local_worker_id})"
+    return f"{job_info.task_attempt.to_wire()} ({local_worker_id})"
 
 
 class PreviousTaskFailedError(Exception):
@@ -178,23 +176,14 @@ def should_run(
     """
     wid = status_file.worker_id
     log_once = True
+    wait_log_limiter = RateLimiter(interval_seconds=_LOCK_WAIT_LOG_INTERVAL)
 
     while True:
         status = status_file.status
         active_lock_holder = status_file.active_lock_holder() if status == STATUS_RUNNING else None
 
-        if log_once:
-            if active_lock_holder is not None:
-                logger.info(
-                    "[%s] Status %s: %s. Another worker holds the active lock (owner=%s). "
-                    "Waiting for that worker to finish.",
-                    wid,
-                    step_name,
-                    status,
-                    active_lock_holder,
-                )
-            else:
-                logger.info(f"[{wid}] Status {step_name}: {status}")
+        if log_once and active_lock_holder is None:
+            logger.info(f"[{wid}] Status {step_name}: {status}")
             log_once = False
 
         if status == STATUS_SUCCESS and not force_rerun:
@@ -207,8 +196,17 @@ def should_run(
             else:
                 raise PreviousTaskFailedError(f"Step {step_name} failed previously. Status: {status}")
         elif status == STATUS_RUNNING and active_lock_holder is not None:
-            logger.debug(f"[{wid}] Step {step_name} has active lock, waiting...")
-            time.sleep(5)
+            if wait_log_limiter.should_run():
+                logger.info(
+                    "[%s] Status %s: %s. Another worker holds the active lock (owner=%s). "
+                    "Waiting for that worker to finish.",
+                    wid,
+                    step_name,
+                    status,
+                    active_lock_holder,
+                )
+            log_once = False
+            sleep(5)
             continue
         elif status == STATUS_RUNNING:
             logger.info(f"[{wid}] Step {step_name} has no active lock, taking over.")
@@ -228,7 +226,7 @@ def should_run(
             return True
 
         logger.info(f"[{wid}] Lost lock race for {step_name}, retrying...")
-        time.sleep(1)
+        sleep(1)
 
 
 # ---------------------------------------------------------------------------

--- a/lib/marin/src/marin/execution/step_status.py
+++ b/lib/marin/src/marin/execution/step_status.py
@@ -37,6 +37,7 @@ STATUS_RUNNING = "RUNNING"
 STATUS_FAILED = "FAILED"
 STATUS_SUCCESS = "SUCCESS"
 STATUS_DEP_FAILED = "DEP_FAILED"  # Dependency failed
+_IRIS_TASK_ID_ENV = "IRIS_TASK_ID"
 
 
 def get_status_path(output_path: str) -> str:
@@ -143,6 +144,10 @@ class StatusFile:
         """Check if any worker has an active (non-stale) lock."""
         return self._lock.has_active_holder()
 
+    def active_lock_holder(self) -> str | None:
+        """Return the active lock-owner ID, or None if no active lock exists."""
+        return self._lock.active_holder_id()
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -150,7 +155,11 @@ class StatusFile:
 
 
 def worker_id() -> str:
-    return default_worker_id()
+    local_worker_id = default_worker_id()
+    iris_task_id = os.environ.get(_IRIS_TASK_ID_ENV)
+    if iris_task_id is None:
+        return local_worker_id
+    return f"{iris_task_id} ({local_worker_id})"
 
 
 class PreviousTaskFailedError(Exception):
@@ -172,9 +181,20 @@ def should_run(
 
     while True:
         status = status_file.status
+        active_lock_holder = status_file.active_lock_holder() if status == STATUS_RUNNING else None
 
         if log_once:
-            logger.info(f"[{wid}] Status {step_name}: {status}")
+            if active_lock_holder is not None:
+                logger.info(
+                    "[%s] Status %s: %s. Another worker holds the active lock (owner=%s). "
+                    "Waiting for that worker to finish.",
+                    wid,
+                    step_name,
+                    status,
+                    active_lock_holder,
+                )
+            else:
+                logger.info(f"[{wid}] Status {step_name}: {status}")
             log_once = False
 
         if status == STATUS_SUCCESS and not force_rerun:
@@ -186,7 +206,7 @@ def should_run(
                 logger.info(f"[{wid}] Force running {step_name}, previous status: {status}")
             else:
                 raise PreviousTaskFailedError(f"Step {step_name} failed previously. Status: {status}")
-        elif status == STATUS_RUNNING and status_file.has_active_lock():
+        elif status == STATUS_RUNNING and active_lock_holder is not None:
             logger.debug(f"[{wid}] Step {step_name} has active lock, waiting...")
             time.sleep(5)
             continue

--- a/lib/rigging/src/rigging/filesystem/distributed_lock.py
+++ b/lib/rigging/src/rigging/filesystem/distributed_lock.py
@@ -174,11 +174,17 @@ class DistributedLease(abc.ABC):
 
     def has_active_holder(self) -> bool:
         """Check if any holder has an active (non-stale) lock."""
+        return self.active_holder_id() is not None
+
+    def active_holder_id(self) -> str | None:
+        """Return the active lock-owner ID, or None if no active lock exists."""
         try:
             _, lock_data = self._read_with_generation()
         except FileNotFoundError:
-            return False
-        return lock_data is not None and not lock_data.is_stale()
+            return None
+        if lock_data is None or lock_data.is_stale():
+            return None
+        return lock_data.worker_id
 
 
 # ---------------------------------------------------------------------------

--- a/tests/execution/test_disk_cache.py
+++ b/tests/execution/test_disk_cache.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import logging
 import os
 from functools import cache
 from pathlib import Path
@@ -11,7 +12,14 @@ from marin.execution.artifact import read_artifact, write_artifact
 from marin.execution.disk_cache import disk_cache
 from marin.execution.step_runner import check_cache, run_step
 from marin.execution.step_spec import StepSpec
-from marin.execution.step_status import STATUS_SUCCESS, StatusFile, distributed_lock
+from marin.execution.step_status import (
+    STATUS_RUNNING,
+    STATUS_SUCCESS,
+    StatusFile,
+    distributed_lock,
+    should_run,
+    worker_id,
+)
 from pydantic import BaseModel
 
 
@@ -100,6 +108,30 @@ def test_composition_with_save_load(tmp_path: Path):
     result2 = cached_fn(output_path)
     assert call_count == 1
     assert result2 == result1
+
+
+def test_should_run_reports_active_iris_lock_owner(tmp_path: Path, caplog, monkeypatch):
+    output_path = str(tmp_path / "active-lock")
+    iris_task_id = "/larry/executor/0:2"
+    monkeypatch.setenv("IRIS_TASK_ID", iris_task_id)
+
+    owner = StatusFile(output_path, worker_id())
+    waiter = StatusFile(output_path, "waiting-worker")
+    assert owner.try_acquire_lock()
+    owner.write_status(STATUS_RUNNING)
+
+    def release_owner(_seconds: float) -> None:
+        owner.release_lock()
+
+    monkeypatch.setattr("marin.execution.step_status.time.sleep", release_owner)
+
+    with caplog.at_level(logging.INFO, logger="marin.execution.step_status"):
+        assert should_run(waiter, "active-step")
+
+    waiter.release_lock()
+    assert iris_task_id in caplog.text
+    assert "Another worker holds the active lock" in caplog.text
+    assert "Waiting for that worker to finish" in caplog.text
 
 
 def test_decorator_with_cloudpickle(tmp_path: Path):

--- a/tests/execution/test_disk_cache.py
+++ b/tests/execution/test_disk_cache.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import logging
 import os
 from functools import cache
 from pathlib import Path
@@ -13,12 +12,9 @@ from marin.execution.disk_cache import disk_cache
 from marin.execution.step_runner import check_cache, run_step
 from marin.execution.step_spec import StepSpec
 from marin.execution.step_status import (
-    STATUS_RUNNING,
     STATUS_SUCCESS,
     StatusFile,
     distributed_lock,
-    should_run,
-    worker_id,
 )
 from pydantic import BaseModel
 
@@ -108,30 +104,6 @@ def test_composition_with_save_load(tmp_path: Path):
     result2 = cached_fn(output_path)
     assert call_count == 1
     assert result2 == result1
-
-
-def test_should_run_reports_active_iris_lock_owner(tmp_path: Path, caplog, monkeypatch):
-    output_path = str(tmp_path / "active-lock")
-    iris_task_id = "/larry/executor/0:2"
-    monkeypatch.setenv("IRIS_TASK_ID", iris_task_id)
-
-    owner = StatusFile(output_path, worker_id())
-    waiter = StatusFile(output_path, "waiting-worker")
-    assert owner.try_acquire_lock()
-    owner.write_status(STATUS_RUNNING)
-
-    def release_owner(_seconds: float) -> None:
-        owner.release_lock()
-
-    monkeypatch.setattr("marin.execution.step_status.time.sleep", release_owner)
-
-    with caplog.at_level(logging.INFO, logger="marin.execution.step_status"):
-        assert should_run(waiter, "active-step")
-
-    waiter.release_lock()
-    assert iris_task_id in caplog.text
-    assert "Another worker holds the active lock" in caplog.text
-    assert "Waiting for that worker to finish" in caplog.text
 
 
 def test_decorator_with_cloudpickle(tmp_path: Path):

--- a/tests/execution/test_step_status.py
+++ b/tests/execution/test_step_status.py
@@ -1,0 +1,51 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from pathlib import Path
+
+import marin.execution.step_status as step_status
+import pytest
+from iris.cluster.client.job_info import JobInfo, set_job_info
+from iris.cluster.types import JobName
+from marin.execution.step_status import STATUS_RUNNING, StatusFile, should_run, worker_id
+
+
+@pytest.fixture(autouse=True)
+def _reset_job_info():
+    set_job_info(None)
+    yield
+    set_job_info(None)
+
+
+def test_should_run_repeats_active_iris_lock_owner(tmp_path: Path, caplog, monkeypatch):
+    output_path = str(tmp_path / "active-lock")
+    iris_task_id = "/larry/executor/0:2"
+    set_job_info(JobInfo(task_id=JobName.from_wire("/larry/executor/0"), attempt_id=2))
+
+    owner = StatusFile(output_path, worker_id())
+    waiter = StatusFile(output_path, "waiting-worker")
+    assert owner.try_acquire_lock()
+    owner.write_status(STATUS_RUNNING)
+
+    sleep_calls = 0
+
+    def release_owner_after_second_log(_seconds: float) -> None:
+        nonlocal sleep_calls
+        sleep_calls += 1
+        if sleep_calls == 2:
+            owner.release_lock()
+        elif sleep_calls > 2:
+            raise AssertionError("Lock wait did not stop after the owner released the lock")
+
+    monkeypatch.setattr(step_status, "_LOCK_WAIT_LOG_INTERVAL", 0)
+    monkeypatch.setattr(step_status, "sleep", release_owner_after_second_log)
+
+    with caplog.at_level(logging.INFO, logger="marin.execution.step_status"):
+        assert should_run(waiter, "active-step")
+
+    waiter.release_lock()
+    owner_logs = [record for record in caplog.records if iris_task_id in record.getMessage()]
+    assert len(owner_logs) == 2
+    assert all(record.levelno == logging.INFO for record in owner_logs)
+    assert all("RUNNING" in record.getMessage() and "active lock" in record.getMessage() for record in owner_logs)

--- a/tests/execution/test_step_status.py
+++ b/tests/execution/test_step_status.py
@@ -45,7 +45,11 @@ def test_should_run_repeats_active_iris_lock_owner(tmp_path: Path, caplog, monke
         assert should_run(waiter, "active-step")
 
     waiter.release_lock()
-    owner_logs = [record for record in caplog.records if iris_task_id in record.getMessage()]
+    owner_logs = [
+        record
+        for record in caplog.records
+        if record.name == "marin.execution.step_status" and iris_task_id in record.getMessage()
+    ]
     assert len(owner_logs) == 2
     assert all(record.levelno == logging.INFO for record in owner_logs)
     assert all("RUNNING" in record.getMessage() and "active lock" in record.getMessage() for record in owner_logs)


### PR DESCRIPTION
* report the active lock owner and Iris task-attempt ID when a `RUNNING` step waits
* repeat the wait status every five minutes so long lock waits stay visible
* keep the current lock-file schema
