### PR TITLE
iris: set log start time from a row

### DIFF
--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -89,7 +89,7 @@ const matchScope = ref<MatchScope>('EXACT')
 // embed in their raw log lines.
 const timeZone = ref<TimeZoneName>('local')
 
-const { presetMs, customSince, absolute: absoluteSince, sinceMs, selectPreset } = useTimeWindow(timeZone)
+const { presetMs, customSince, absolute: absoluteSince, sinceMs, setSinceMs, selectPreset } = useTimeWindow(timeZone)
 
 const entries = ref<LogEntry[]>([])
 // Lines pulled in by expanding a row's context, keyed by seq so they dedupe
@@ -517,6 +517,12 @@ function selectRow(seq: number) {
   router.replace({ query: { ...route.query, logSeq: String(seq) } })
 }
 
+/** Set the log time bound to this row. */
+function setStartTime(entry: LogEntry) {
+  const ms = timestampMs(entry.timestamp)
+  if (ms > 0) setSinceMs(ms)
+}
+
 /** Promote the client-side search into the server-side filter over the whole log. */
 function promoteSearchToFilter() {
   filter.value = search.query.value
@@ -680,6 +686,7 @@ defineExpose({ selectedAttemptId })
       <input
         v-model="customSince"
         type="datetime-local"
+        step="0.001"
         title="Show logs since a specific date/time"
         class="px-2 py-1.5 border border-surface-border rounded text-sm"
       />
@@ -871,11 +878,21 @@ defineExpose({ selectedAttemptId })
             >
               T{{ row.taskRef.taskIndex }}
             </RouterLink>
-            <button
-              class="shrink-0 text-text-muted tabular-nums hover:text-accent hover:underline"
-              :title="`${isoTimestamp(row.entry)} — click to pin and link to this line`"
-              @click="selectRow(row.seq)"
-            >{{ formatLogTime(timestampMs(row.entry.timestamp), timeZone === 'utc') }}</button>
+            <span class="shrink-0 inline-flex items-center gap-1">
+              <button
+                data-log-permalink
+                class="text-text-muted tabular-nums hover:text-accent hover:underline"
+                :title="`${isoTimestamp(row.entry)} — click to pin and link to this line`"
+                @click="selectRow(row.seq)"
+              >{{ formatLogTime(timestampMs(row.entry.timestamp), timeZone === 'utc') }}</button>
+              <button
+                data-log-start
+                class="text-text-muted opacity-50 hover:opacity-100 hover:text-accent"
+                :title="`${isoTimestamp(row.entry)} — show logs from this time`"
+                :aria-label="`Show logs from ${isoTimestamp(row.entry)}`"
+                @click="setStartTime(row.entry)"
+              >▶</button>
+            </span>
             <span
               :class="wrap ? 'whitespace-pre-wrap break-words flex-1' : 'whitespace-pre'"
             ><template

--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -254,12 +254,20 @@ function sourceRequest() {
   }
 }
 
+function requestSinceMs(): number | undefined {
+  const ms = sinceMs()
+  if (ms === undefined || !absoluteSince.value) return ms
+  // FetchLogs applies sinceMs as an exclusive bound. The date picker describes
+  // an inclusive start time, so move the wire bound back by one millisecond.
+  return Math.max(0, ms - 1)
+}
+
 function baseRequest() {
   return {
     ...sourceRequest(),
     substring: filter.value || undefined,
     minLevel: level.value ? level.value.toUpperCase() : undefined,
-    sinceMs: sinceMs(),
+    sinceMs: requestSinceMs(),
   }
 }
 

--- a/lib/iris/dashboard/src/composables/useTimeWindow.ts
+++ b/lib/iris/dashboard/src/composables/useTimeWindow.ts
@@ -32,6 +32,8 @@ export interface TimeWindow {
   absolute: ComputedRef<boolean>
   /** The bound as epoch ms, or undefined when unbounded. */
   sinceMs: () => number | undefined
+  /** Set an absolute lower bound from an epoch-ms timestamp. */
+  setSinceMs: (ms: number) => void
   selectPreset: (ms: number) => void
 }
 
@@ -42,12 +44,28 @@ export interface TimeWindow {
  * rather than the browser's. Returns NaN when the value does not parse.
  */
 function parseDateTimeLocal(value: string, zone: TimeZoneName): number {
-  const m = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?/)
+  const m = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?$/)
   if (!m) return NaN
-  const [year, month, day, hour, minute, second] = m.slice(1).map((p) => Number(p ?? 0))
+  const [year, month, day, hour, minute, second] = m.slice(1, 7).map((p) => Number(p ?? 0))
+  const millisecond = Number((m[7] ?? '').padEnd(3, '0'))
   return zone === 'utc'
-    ? Date.UTC(year, month - 1, day, hour, minute, second)
-    : new Date(year, month - 1, day, hour, minute, second).getTime()
+    ? Date.UTC(year, month - 1, day, hour, minute, second, millisecond)
+    : new Date(year, month - 1, day, hour, minute, second, millisecond).getTime()
+}
+
+/** Format an epoch-ms timestamp for a `datetime-local` input in `zone`. */
+function formatDateTimeLocal(ms: number, zone: TimeZoneName): string {
+  const date = new Date(ms)
+  const part = (local: () => number, utc: () => number, width = 2) =>
+    String(zone === 'utc' ? utc() : local()).padStart(width, '0')
+  const year = part(() => date.getFullYear(), () => date.getUTCFullYear(), 4)
+  const month = part(() => date.getMonth() + 1, () => date.getUTCMonth() + 1)
+  const day = part(() => date.getDate(), () => date.getUTCDate())
+  const hour = part(() => date.getHours(), () => date.getUTCHours())
+  const minute = part(() => date.getMinutes(), () => date.getUTCMinutes())
+  const second = part(() => date.getSeconds(), () => date.getUTCSeconds())
+  const millisecond = part(() => date.getMilliseconds(), () => date.getUTCMilliseconds(), 3)
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}.${millisecond}`
 }
 
 export function useTimeWindow(timeZone: Ref<TimeZoneName>): TimeWindow {
@@ -69,6 +87,10 @@ export function useTimeWindow(timeZone: Ref<TimeZoneName>): TimeWindow {
     return presetMs.value > 0 ? Date.now() - presetMs.value : undefined
   }
 
+  function setSinceMs(ms: number) {
+    customSince.value = formatDateTimeLocal(ms, timeZone.value)
+  }
+
   function selectPreset(ms: number) {
     // Re-selecting the synthetic "Custom" option leaves the instant in effect.
     if (ms === CUSTOM_PRESET) return
@@ -76,5 +98,5 @@ export function useTimeWindow(timeZone: Ref<TimeZoneName>): TimeWindow {
     presetMs.value = ms
   }
 
-  return { presetMs, customSince, absolute, sinceMs, selectPreset }
+  return { presetMs, customSince, absolute, sinceMs, setSinceMs, selectPreset }
 }

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -497,6 +497,7 @@ def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_scree
     filtered_row.locator("[data-log-permalink]").click()
     smoke_page.wait_for_function("() => location.hash.includes('logSeq=')", timeout=5000)
 
+    selected_message = filtered_row.locator(":scope > span").last.inner_text()
     filtered_row.locator("[data-log-start]").click()
     since_input = "input[type='datetime-local']"
     smoke_page.wait_for_function(
@@ -505,6 +506,7 @@ def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_scree
     )
     locked_since = smoke_page.input_value(since_input)
     assert locked_since
+    smoke_page.locator("[data-row]").filter(has_text=selected_message).wait_for(timeout=5000)
 
     smoke_page.get_by_role("button", name="Clear filter").click()
     smoke_page.wait_for_function(

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -432,7 +432,7 @@ def _wait_for_task_log_marker(
 
 
 def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_screenshot):
-    """Task logs show lines and substring filter on the task detail page."""
+    """Task logs show search, filter, permalink, and time-bound controls."""
     task_status = smoke_cluster.task_status(verbose_job)
     task_id = task_status.task_id
     job_id = verbose_job.job_id.to_wire()
@@ -490,6 +490,29 @@ def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_scree
         "task-logs-filtered",
         "Task detail page with log filter input populated and filtered log lines visible in the log viewer.",
     )
+
+    # The timestamp action still makes a permalink. The next control sets an
+    # exact start time. The start time stays set after the string filter clears.
+    filtered_row = smoke_page.locator("[data-row]").filter(has_text="validation failed").first
+    filtered_row.locator("[data-log-permalink]").click()
+    smoke_page.wait_for_function("() => location.hash.includes('logSeq=')", timeout=5000)
+
+    filtered_row.locator("[data-log-start]").click()
+    since_input = "input[type='datetime-local']"
+    smoke_page.wait_for_function(
+        "() => document.querySelector(\"input[type='datetime-local']\")?.value.length > 0",
+        timeout=5000,
+    )
+    locked_since = smoke_page.input_value(since_input)
+    assert locked_since
+
+    smoke_page.get_by_role("button", name="Clear filter").click()
+    smoke_page.wait_for_function(
+        "() => document.querySelector(\"input[placeholder^='Filter:']\")?.value === '' && "
+        "document.body.textContent.includes('processing data batch')",
+        timeout=5000,
+    )
+    assert smoke_page.input_value(since_input) == locked_since
 
 
 def test_dashboard_jump_to_exception(smoke_cluster, smoke_page, smoke_screenshot):


### PR DESCRIPTION
👨 : The use-case here is: I am searching for specific text and then I want to see the logs from that timestamp.

Looks like this:

<img width="852" height="48" alt="image" src="https://github.com/user-attachments/assets/58974c40-f679-4749-906e-182b8bfac3a5" />


<hr>

* set an absolute log start time from any row with a separate `▶` control
* keep timestamp clicks as row permalinks
* treat the start time as inclusive, preserving the selected row and same-millisecond rows across string-filter changes
