### PR TITLE
Seed restored trial config so Harbor resume finds completed trials

### DIFF
--- a/config/external/harbor/uv.lock
+++ b/config/external/harbor/uv.lock
@@ -538,7 +538,7 @@ wheels = [
 [[package]]
 name = "harbor"
 version = "0.8.1"
-source = { git = "https://github.com/marin-community/harbor.git?branch=main#f2dd505f609021611eb85521a097e6dff384d12d" }
+source = { git = "https://github.com/marin-community/harbor.git?branch=main#75380b70c4278d83ff729587279b5294a1a85c93" }
 dependencies = [
     { name = "dirhash" },
     { name = "fastapi" },

--- a/config/update-external.py
+++ b/config/update-external.py
@@ -43,7 +43,7 @@ class LockedDependency:
 
 EXTERNAL_PROJECTS = (
     ExternalProject("evalchemy", "evalchemy", "EVALCHEMY"),
-    ExternalProject("harbor", "harbor", "HARBOR", runtime_distributions=("daytona",)),
+    ExternalProject("harbor", "harbor", "HARBOR", runtime_distributions=("daytona", "litellm")),
     ExternalProject("MarinSkyRL", "skyrl", "MARIN_SKYRL"),
 )
 

--- a/experiments/evaluation/launch.py
+++ b/experiments/evaluation/launch.py
@@ -94,12 +94,12 @@ def _launch_user() -> str:
 
 def _run_id(model_key: str, eval_key: str) -> str:
     stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
-    return f"{stamp}-{model_key}-{eval_key}-{uuid.uuid4().hex[:4]}"
+    return f"{stamp}-{model_key}-{eval_key}-{uuid.uuid4().hex[:8]}"
 
 
 def _group_id(model_key: str) -> str:
     stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
-    return f"{stamp}-{model_key}-{uuid.uuid4().hex[:4]}"
+    return f"{stamp}-{model_key}-{uuid.uuid4().hex[:8]}"
 
 
 def _capability_origin(cluster: str) -> str:

--- a/lib/marin/src/marin/evaluation/harbor/runner.py
+++ b/lib/marin/src/marin/evaluation/harbor/runner.py
@@ -208,7 +208,7 @@ def _upload_trials(job_dir: Path, out_path: str) -> None:
     for trial_dir in (d for d in job_dir.iterdir() if d.is_dir()):
         if (trial_dir / "result.json").exists():
             target = StoragePath(prefix_join(out_path, f"harbor_trials/{trial_dir.name}"))
-            target.upload_from(str(trial_dir), recursive=True)
+            target.upload_from(f"{trial_dir}/", recursive=True)
 
 
 def _run_harbor_job(

--- a/lib/marin/src/marin/evaluation/harbor/trial_driver.py
+++ b/lib/marin/src/marin/evaluation/harbor/trial_driver.py
@@ -362,7 +362,19 @@ def _preflight(request_path: Path) -> None:
     sys.stdout.write(json.dumps(results, ensure_ascii=False, separators=(",", ":")))
 
 
+def seed_restored_job_config(config: JobConfig) -> None:
+    """Make restored trial directories visible to Harbor's resume scan."""
+    job_dir = config.jobs_dir / config.job_name
+    config_path = job_dir / "config.json"
+    if config_path.exists() or not job_dir.exists():
+        return
+    if not any(path.is_dir() and (path / "result.json").exists() for path in job_dir.iterdir()):
+        return
+    config_path.write_text(config.model_dump_json(indent=4))
+
+
 async def _run(config: JobConfig) -> None:
+    seed_restored_job_config(config)
     job = await Job.create(config)
     await job.run()
 

--- a/lib/marin/src/marin/external_dependencies.py
+++ b/lib/marin/src/marin/external_dependencies.py
@@ -43,8 +43,11 @@ HARBOR = ExternalDependency(
     distribution="harbor",
     repository="https://github.com/marin-community/harbor.git",
     version="0.8.1",
-    commit="f2dd505f609021611eb85521a097e6dff384d12d",
-    runtime_requirements=("daytona==0.200.2",),
+    commit="75380b70c4278d83ff729587279b5294a1a85c93",
+    runtime_requirements=(
+        "daytona==0.200.2",
+        "litellm==1.95.0.dev3",
+    ),
 )
 
 MARIN_SKYRL = ExternalDependency(

--- a/tests/evaluation/test_harbor_runner.py
+++ b/tests/evaluation/test_harbor_runner.py
@@ -153,11 +153,16 @@ def test_harbor_trials_round_trip_through_remote_storage(protocol, tmp_path, mon
 
     restored_dir = tmp_path / "restored"
     restored = _restore_completed_trials(output_dir, restored_dir)
+    _upload_trials(restored_dir, output_dir)
 
     assert restored == 1
     assert (restored_dir / "trial-one" / "result.json").read_text() == '{"task_name": "trial-one"}'
     assert (restored_dir / "trial-one" / "agent" / "trajectory.json").read_text() == '{"steps": []}'
     assert not (restored_dir / "incomplete").exists()
+    assert remote_fs.find("eval-bucket/run/harbor_trials") == [
+        "/eval-bucket/run/harbor_trials/trial-one/agent/trajectory.json",
+        "/eval-bucket/run/harbor_trials/trial-one/result.json",
+    ]
 
 
 def test_harbor_executor_passes_opaque_policy_and_runtime_overlay_to_driver(tmp_path, monkeypatch):

--- a/tests/evaluation/test_harbor_trial_driver.py
+++ b/tests/evaluation/test_harbor_trial_driver.py
@@ -180,6 +180,72 @@ def test_effective_job_applies_runtime_precedence_and_validates_nested_updates(t
     }
 
 
+def test_restored_trials_seed_job_config_for_harbor_resume(tmp_path, checked_policies):
+    policy_path = tmp_path / "policy.json"
+    policy_path.write_text(checked_policies["grug-opencode-id.yaml"]["stable_policy_json"])
+    jobs_dir = tmp_path / "jobs"
+    overlay_path = tmp_path / "overlay.json"
+    overlay_path.write_text(
+        json.dumps(
+            {
+                "job_name": "restored-job",
+                "jobs_dir": str(jobs_dir),
+                "dataset_path": str(tmp_path / "tasks"),
+                "endpoint_url": "https://iris.example/capability/v1",
+                "served_model": "served-grug",
+                "task_limit": 3,
+                "model_agent_kwargs": {},
+            }
+        )
+    )
+    trial_dir = jobs_dir / "restored-job" / "trial-one"
+    trial_dir.mkdir(parents=True)
+    (trial_dir / "result.json").write_text("{}")
+    script = (
+        "from pathlib import Path; "
+        "from marin.evaluation.harbor.trial_driver import effective_job_config, seed_restored_job_config; "
+        f"config=effective_job_config(Path({str(policy_path)!r}), Path({str(overlay_path)!r})); "
+        "seed_restored_job_config(config); "
+        "restored=type(config).model_validate_json((config.jobs_dir/config.job_name/'config.json').read_text()); "
+        "print(restored == config)"
+    )
+
+    completed = _external_python("-c", script)
+
+    assert completed.stdout.strip() == "True"
+
+
+def test_resume_identity_ignores_snapshot_mode_drift():
+    script = """
+from harbor_config.models.trial.config import TrialConfig
+
+base = {
+    "task": {"path": "/tmp/task", "source": "local"},
+    "agent": {"name": "terminus-2", "model_name": "hosted_vllm/model"},
+    "environment": {"type": "daytona", "kwargs": {"auto_snapshot": False}},
+}
+existing = TrialConfig.model_validate(base)
+snapshot = TrialConfig.model_validate({
+    **base,
+    "environment": {"type": "daytona", "kwargs": {"auto_snapshot": True}},
+})
+different_image = TrialConfig.model_validate({
+    **base,
+    "environment": {
+        "type": "daytona",
+        "kwargs": {"auto_snapshot": True, "image": "different"},
+    },
+})
+# Harbor excludes the Daytona auto_snapshot cache kwarg from the resume
+# identity fingerprint, so a restored snapshot-mode trial matches its
+# original identity while a genuinely different image still does not.
+assert existing.matches_identity(snapshot)
+assert not existing.matches_identity(different_image)
+"""
+
+    _external_python("-c", script)
+
+
 @pytest.mark.parametrize(
     "document",
     _INVALID_SOURCE_DOCUMENTS.values(),


### PR DESCRIPTION
Resurrects eval-resume work left uncommitted on a merged branch, updated
for the Harbor identity fix that has since landed upstream.

What this does
- `trial_driver.seed_restored_job_config` writes `config.json` into a
  restored job directory when it already contains completed trials
  (`result.json`), so Harbor's resume scan picks them up instead of
  re-running them. `_run` calls it before `Job.create`.
- `_upload_trials` uploads the trial directory with a trailing path
  separator so the recursive upload lands the files at the right prefix.
- Bumps the Harbor external dependency to `75380b70` and adds
  `litellm==1.95.0.dev3` as a runtime requirement (Harbor's LLM
  error-handling types are needed in the driver environment).

Why the marin-side identity monkeypatch is gone
The original branch carried `_allow_snapshot_mode_resume_drift`, which
patched `TrialConfig.identity_fingerprint` to drop `auto_snapshot` during
resume. Harbor now excludes that kwarg from the resume identity natively
(marin-community/harbor#53, included in this bump), so the patch is a
no-op and has been removed. `test_resume_identity_ignores_snapshot_mode_drift`
pins the contract we actually rely on: a restored snapshot-mode trial
matches its original identity while a genuinely different image does not.

Tests
- `test_restored_trials_seed_job_config_for_harbor_resume` (integration)
- `test_resume_identity_ignores_snapshot_mode_drift` (integration)
- `test_harbor_trials_round_trip_through_remote_storage` extended to assert
  the uploaded trial prefix.