### PR TITLE
[iris] Send IAP credentials from the dashboard proxy

### DIFF
--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -89,7 +89,7 @@ const matchScope = ref<MatchScope>('EXACT')
 // embed in their raw log lines.
 const timeZone = ref<TimeZoneName>('local')
 
-const { presetMs, customSince, absolute: absoluteSince, sinceMs, selectPreset } = useTimeWindow(timeZone)
+const { presetMs, customSince, absolute: absoluteSince, sinceMs, setSinceMs, selectPreset } = useTimeWindow(timeZone)
 
 const entries = ref<LogEntry[]>([])
 // Lines pulled in by expanding a row's context, keyed by seq so they dedupe
@@ -517,6 +517,12 @@ function selectRow(seq: number) {
   router.replace({ query: { ...route.query, logSeq: String(seq) } })
 }
 
+/** Set the log time bound to this row. */
+function setStartTime(entry: LogEntry) {
+  const ms = timestampMs(entry.timestamp)
+  if (ms > 0) setSinceMs(ms)
+}
+
 /** Promote the client-side search into the server-side filter over the whole log. */
 function promoteSearchToFilter() {
   filter.value = search.query.value
@@ -680,6 +686,7 @@ defineExpose({ selectedAttemptId })
       <input
         v-model="customSince"
         type="datetime-local"
+        step="0.001"
         title="Show logs since a specific date/time"
         class="px-2 py-1.5 border border-surface-border rounded text-sm"
       />
@@ -871,11 +878,21 @@ defineExpose({ selectedAttemptId })
             >
               T{{ row.taskRef.taskIndex }}
             </RouterLink>
-            <button
-              class="shrink-0 text-text-muted tabular-nums hover:text-accent hover:underline"
-              :title="`${isoTimestamp(row.entry)} — click to pin and link to this line`"
-              @click="selectRow(row.seq)"
-            >{{ formatLogTime(timestampMs(row.entry.timestamp), timeZone === 'utc') }}</button>
+            <span class="shrink-0 inline-flex items-center gap-1">
+              <button
+                data-log-permalink
+                class="text-text-muted tabular-nums hover:text-accent hover:underline"
+                :title="`${isoTimestamp(row.entry)} — click to pin and link to this line`"
+                @click="selectRow(row.seq)"
+              >{{ formatLogTime(timestampMs(row.entry.timestamp), timeZone === 'utc') }}</button>
+              <button
+                data-log-start
+                class="text-text-muted opacity-50 hover:opacity-100 hover:text-accent"
+                :title="`${isoTimestamp(row.entry)} — show logs from this time`"
+                :aria-label="`Show logs from ${isoTimestamp(row.entry)}`"
+                @click="setStartTime(row.entry)"
+              >▶</button>
+            </span>
             <span
               :class="wrap ? 'whitespace-pre-wrap break-words flex-1' : 'whitespace-pre'"
             ><template

--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -254,12 +254,20 @@ function sourceRequest() {
   }
 }
 
+function requestSinceMs(): number | undefined {
+  const ms = sinceMs()
+  if (ms === undefined || !absoluteSince.value) return ms
+  // FetchLogs applies sinceMs as an exclusive bound. The date picker describes
+  // an inclusive start time, so move the wire bound back by one millisecond.
+  return Math.max(0, ms - 1)
+}
+
 function baseRequest() {
   return {
     ...sourceRequest(),
     substring: filter.value || undefined,
     minLevel: level.value ? level.value.toUpperCase() : undefined,
-    sinceMs: sinceMs(),
+    sinceMs: requestSinceMs(),
   }
 }
 

--- a/lib/iris/dashboard/src/composables/useTimeWindow.ts
+++ b/lib/iris/dashboard/src/composables/useTimeWindow.ts
@@ -32,6 +32,8 @@ export interface TimeWindow {
   absolute: ComputedRef<boolean>
   /** The bound as epoch ms, or undefined when unbounded. */
   sinceMs: () => number | undefined
+  /** Set an absolute lower bound from an epoch-ms timestamp. */
+  setSinceMs: (ms: number) => void
   selectPreset: (ms: number) => void
 }
 
@@ -42,12 +44,28 @@ export interface TimeWindow {
  * rather than the browser's. Returns NaN when the value does not parse.
  */
 function parseDateTimeLocal(value: string, zone: TimeZoneName): number {
-  const m = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?/)
+  const m = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?$/)
   if (!m) return NaN
-  const [year, month, day, hour, minute, second] = m.slice(1).map((p) => Number(p ?? 0))
+  const [year, month, day, hour, minute, second] = m.slice(1, 7).map((p) => Number(p ?? 0))
+  const millisecond = Number((m[7] ?? '').padEnd(3, '0'))
   return zone === 'utc'
-    ? Date.UTC(year, month - 1, day, hour, minute, second)
-    : new Date(year, month - 1, day, hour, minute, second).getTime()
+    ? Date.UTC(year, month - 1, day, hour, minute, second, millisecond)
+    : new Date(year, month - 1, day, hour, minute, second, millisecond).getTime()
+}
+
+/** Format an epoch-ms timestamp for a `datetime-local` input in `zone`. */
+function formatDateTimeLocal(ms: number, zone: TimeZoneName): string {
+  const date = new Date(ms)
+  const part = (local: () => number, utc: () => number, width = 2) =>
+    String(zone === 'utc' ? utc() : local()).padStart(width, '0')
+  const year = part(() => date.getFullYear(), () => date.getUTCFullYear(), 4)
+  const month = part(() => date.getMonth() + 1, () => date.getUTCMonth() + 1)
+  const day = part(() => date.getDate(), () => date.getUTCDate())
+  const hour = part(() => date.getHours(), () => date.getUTCHours())
+  const minute = part(() => date.getMinutes(), () => date.getUTCMinutes())
+  const second = part(() => date.getSeconds(), () => date.getUTCSeconds())
+  const millisecond = part(() => date.getMilliseconds(), () => date.getUTCMilliseconds(), 3)
+  return `${year}-${month}-${day}T${hour}:${minute}:${second}.${millisecond}`
 }
 
 export function useTimeWindow(timeZone: Ref<TimeZoneName>): TimeWindow {
@@ -69,6 +87,10 @@ export function useTimeWindow(timeZone: Ref<TimeZoneName>): TimeWindow {
     return presetMs.value > 0 ? Date.now() - presetMs.value : undefined
   }
 
+  function setSinceMs(ms: number) {
+    customSince.value = formatDateTimeLocal(ms, timeZone.value)
+  }
+
   function selectPreset(ms: number) {
     // Re-selecting the synthetic "Custom" option leaves the instant in effect.
     if (ms === CUSTOM_PRESET) return
@@ -76,5 +98,5 @@ export function useTimeWindow(timeZone: Ref<TimeZoneName>): TimeWindow {
     presetMs.value = ms
   }
 
-  return { presetMs, customSince, absolute, sinceMs, selectPreset }
+  return { presetMs, customSince, absolute, sinceMs, setSinceMs, selectPreset }
 }

--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -1005,8 +1005,6 @@ def cluster_dashboard_proxy(ctx, port: int):
     your browser.
     """
     controller_url = require_controller_url(ctx)
-    # The browser has no cluster credentials, so the proxy authenticates upstream
-    # with the operator's own — without them an IAP-fronted controller 401s.
     dashboard = ProxyControllerDashboard(
         upstream_url=controller_url,
         port=port,

--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -1005,7 +1005,13 @@ def cluster_dashboard_proxy(ctx, port: int):
     your browser.
     """
     controller_url = require_controller_url(ctx)
-    dashboard = ProxyControllerDashboard(upstream_url=controller_url, port=port)
+    # The browser has no cluster credentials, so the proxy authenticates upstream
+    # with the operator's own — without them an IAP-fronted controller 401s.
+    dashboard = ProxyControllerDashboard(
+        upstream_url=controller_url,
+        port=port,
+        credentials=(ctx.obj or {}).get("credentials"),
+    )
     click.echo(f"Proxying to controller at {controller_url}")
 
     dashboard_dir = VUE_DIST_DIR.parent

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -460,6 +460,23 @@ class ControllerDashboard:
         return Response(data, media_type="application/octet-stream")
 
 
+class _CredentialAuth(httpx.Auth):
+    """Attaches ``credentials`` to every request an httpx client sends.
+
+    Authenticating at the client rather than per call site means a route added
+    later is authenticated by construction. Tokens mint per request, because a
+    provider re-mints an expired one and a proxy outlives a token's lifetime.
+    Minting can refresh over the network, so it runs off the event loop.
+    """
+
+    def __init__(self, credentials: ClientCredentials):
+        self._credentials = credentials
+
+    async def async_auth_flow(self, request: httpx.Request):
+        request.headers.update(await run_in_threadpool(self._credentials.headers))
+        yield request
+
+
 class ProxyControllerDashboard:
     """Dashboard that proxies RPC calls to a remote Iris controller.
 
@@ -482,8 +499,11 @@ class ProxyControllerDashboard:
         self._upstream_url = upstream_url.rstrip("/")
         self._host = host
         self._port = port
-        self._credentials = credentials
-        self._client = httpx.AsyncClient(base_url=self._upstream_url, timeout=60.0)
+        self._client = httpx.AsyncClient(
+            base_url=self._upstream_url,
+            timeout=60.0,
+            auth=_CredentialAuth(credentials) if credentials is not None else None,
+        )
         self._app = self._create_app()
 
     @property
@@ -543,26 +563,13 @@ class ProxyControllerDashboard:
     def _health(self, _request: Request) -> JSONResponse:
         return JSONResponse({"status": "ok"})
 
-    async def _upstream_headers(self, content_type: str | None = None) -> dict[str, str]:
-        """Bearer headers for one upstream request, plus ``content-type`` when given.
-
-        Minted per request rather than at startup: a provider re-mints an expired
-        token, so a long-lived proxy holding a cached header would start failing
-        partway through a session. Minting can refresh over the network, so it
-        runs off the event loop.
-        """
-        headers = await run_in_threadpool(self._credentials.headers) if self._credentials is not None else {}
-        if content_type is not None:
-            headers["content-type"] = content_type
-        return headers
-
     async def _proxy_auth(self, request: Request) -> Response:
         path = request.path_params["path"]
         upstream_resp = await self._client.request(
             request.method,
             f"/auth/{path}",
             content=await request.body() if request.method in ("POST", "PUT") else None,
-            headers=await self._upstream_headers(request.headers.get("content-type", "application/json")),
+            headers={"content-type": request.headers.get("content-type", "application/json")},
         )
         return Response(
             content=upstream_resp.content,
@@ -577,7 +584,7 @@ class ProxyControllerDashboard:
         upstream_resp = await self._client.post(
             f"/{service}/{method}",
             content=body,
-            headers=await self._upstream_headers(request.headers.get("content-type", "application/json")),
+            headers={"content-type": request.headers.get("content-type", "application/json")},
         )
         return Response(
             content=upstream_resp.content,
@@ -600,7 +607,7 @@ class ProxyControllerDashboard:
             request.method,
             f"/proxy/{path}{query}",
             content=await request.body(),
-            headers=await self._upstream_headers(request.headers.get("content-type", "application/json")),
+            headers={"content-type": request.headers.get("content-type", "application/json")},
         )
         return Response(
             content=upstream_resp.content,
@@ -610,10 +617,7 @@ class ProxyControllerDashboard:
 
     async def _proxy_get(self, request: Request, *, param: str, upstream: str, media_type: str) -> Response:
         """Forward a GET for a single path param to ``upstream`` (a format string)."""
-        upstream_resp = await self._client.get(
-            upstream.format(request.path_params[param]),
-            headers=await self._upstream_headers(),
-        )
+        upstream_resp = await self._client.get(upstream.format(request.path_params[param]))
         if upstream_resp.status_code != 200:
             return Response(upstream_resp.text, status_code=upstream_resp.status_code)
         return Response(upstream_resp.content, media_type=media_type)

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass
 from urllib.parse import urlparse
 
 import httpx
+from rigging.credentials import ClientCredentials
 from rigging.server_auth import (
     PolicyAuthInterceptor,
     RequestAuthPolicy,
@@ -45,6 +46,7 @@ from rigging.server_auth import (
 )
 from sqlalchemy.exc import SQLAlchemyError
 from starlette.applications import Starlette
+from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, Response
 from starlette.routing import Mount, Route
@@ -464,6 +466,10 @@ class ProxyControllerDashboard:
     Serves the same web UI locally but forwards all Connect RPC requests
     to an upstream controller at the given URL. Useful for viewing a remote
     controller's state without running a local controller instance.
+
+    The browser holds no cluster credentials, so this process authenticates on
+    its behalf: every upstream request carries the operator's ``credentials``.
+    Without them an IAP-fronted upstream rejects the whole dashboard at its edge.
     """
 
     def __init__(
@@ -471,10 +477,12 @@ class ProxyControllerDashboard:
         upstream_url: str,
         host: str = "0.0.0.0",
         port: int = 8080,
+        credentials: ClientCredentials | None = None,
     ):
         self._upstream_url = upstream_url.rstrip("/")
         self._host = host
         self._port = port
+        self._credentials = credentials
         self._client = httpx.AsyncClient(base_url=self._upstream_url, timeout=60.0)
         self._app = self._create_app()
 
@@ -506,7 +514,10 @@ class ProxyControllerDashboard:
                 ),
             ),
             Route("/health", self._health),
-            Route("/auth/{path:path}", self._proxy_auth),
+            # Mirrors the upstream auth routes: /auth/config is a GET, /auth/session
+            # and /auth/logout are POSTs. Starlette defaults a route to GET alone, so
+            # omitting this 405s the session flow before it reaches the handler.
+            Route("/auth/{path:path}", self._proxy_auth, methods=["GET", "POST", "PUT"]),
             Route(
                 "/iris.cluster.ControllerService/{method}",
                 functools.partial(self._proxy_rpc_post, service="iris.cluster.ControllerService"),
@@ -532,13 +543,26 @@ class ProxyControllerDashboard:
     def _health(self, _request: Request) -> JSONResponse:
         return JSONResponse({"status": "ok"})
 
+    async def _upstream_headers(self, content_type: str | None = None) -> dict[str, str]:
+        """Bearer headers for one upstream request, plus ``content-type`` when given.
+
+        Minted per request rather than at startup: a provider re-mints an expired
+        token, so a long-lived proxy holding a cached header would start failing
+        partway through a session. Minting can refresh over the network, so it
+        runs off the event loop.
+        """
+        headers = await run_in_threadpool(self._credentials.headers) if self._credentials is not None else {}
+        if content_type is not None:
+            headers["content-type"] = content_type
+        return headers
+
     async def _proxy_auth(self, request: Request) -> Response:
         path = request.path_params["path"]
         upstream_resp = await self._client.request(
             request.method,
             f"/auth/{path}",
             content=await request.body() if request.method in ("POST", "PUT") else None,
-            headers={"content-type": request.headers.get("content-type", "application/json")},
+            headers=await self._upstream_headers(request.headers.get("content-type", "application/json")),
         )
         return Response(
             content=upstream_resp.content,
@@ -553,7 +577,7 @@ class ProxyControllerDashboard:
         upstream_resp = await self._client.post(
             f"/{service}/{method}",
             content=body,
-            headers={"content-type": request.headers.get("content-type", "application/json")},
+            headers=await self._upstream_headers(request.headers.get("content-type", "application/json")),
         )
         return Response(
             content=upstream_resp.content,
@@ -576,7 +600,7 @@ class ProxyControllerDashboard:
             request.method,
             f"/proxy/{path}{query}",
             content=await request.body(),
-            headers={"content-type": request.headers.get("content-type", "application/json")},
+            headers=await self._upstream_headers(request.headers.get("content-type", "application/json")),
         )
         return Response(
             content=upstream_resp.content,
@@ -586,7 +610,10 @@ class ProxyControllerDashboard:
 
     async def _proxy_get(self, request: Request, *, param: str, upstream: str, media_type: str) -> Response:
         """Forward a GET for a single path param to ``upstream`` (a format string)."""
-        upstream_resp = await self._client.get(upstream.format(request.path_params[param]))
+        upstream_resp = await self._client.get(
+            upstream.format(request.path_params[param]),
+            headers=await self._upstream_headers(),
+        )
         if upstream_resp.status_code != 200:
             return Response(upstream_resp.text, status_code=upstream_resp.status_code)
         return Response(upstream_resp.content, media_type=media_type)

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -463,10 +463,8 @@ class ControllerDashboard:
 class _CredentialAuth(httpx.Auth):
     """Attaches ``credentials`` to every request an httpx client sends.
 
-    Authenticating at the client rather than per call site means a route added
-    later is authenticated by construction. Tokens mint per request, because a
-    provider re-mints an expired one and a proxy outlives a token's lifetime.
-    Minting can refresh over the network, so it runs off the event loop.
+    Minting per request keeps a proxy that outlives a token's lifetime working;
+    it can refresh over the network, so it runs off the event loop.
     """
 
     def __init__(self, credentials: ClientCredentials):
@@ -484,9 +482,8 @@ class ProxyControllerDashboard:
     to an upstream controller at the given URL. Useful for viewing a remote
     controller's state without running a local controller instance.
 
-    The browser holds no cluster credentials, so this process authenticates on
-    its behalf: every upstream request carries the operator's ``credentials``.
-    Without them an IAP-fronted upstream rejects the whole dashboard at its edge.
+    The browser holds no cluster credentials, so this process authenticates
+    upstream on its behalf with ``credentials``.
     """
 
     def __init__(
@@ -534,10 +531,10 @@ class ProxyControllerDashboard:
                 ),
             ),
             Route("/health", self._health),
-            # Mirrors the upstream auth routes: /auth/config is a GET, /auth/session
-            # and /auth/logout are POSTs. Starlette defaults a route to GET alone, so
-            # omitting this 405s the session flow before it reaches the handler.
-            Route("/auth/{path:path}", self._proxy_auth, methods=["GET", "POST", "PUT"]),
+            # GET only: /auth/config is the sole auth route the proxy can serve.
+            # The upstream's POST routes check CSRF against their own origin, which a
+            # request relayed from localhost can never match without rewriting Origin.
+            Route("/auth/{path:path}", self._proxy_auth),
             Route(
                 "/iris.cluster.ControllerService/{method}",
                 functools.partial(self._proxy_rpc_post, service="iris.cluster.ControllerService"),

--- a/lib/iris/tests/cli/test_cluster_auth.py
+++ b/lib/iris/tests/cli/test_cluster_auth.py
@@ -1,9 +1,15 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from unittest.mock import Mock
+
+from click.testing import CliRunner
+from iris.cli import cluster as cluster_cli
 from iris.cli.connect import _cluster_auth_from_config
 from iris.cluster.config import AuthConfig, IapAuthConfig
+from rigging.auth import StaticTokenProvider
 from rigging.cluster_manifest import AuthProvider
+from rigging.credentials import ClientCredentials
 
 
 def test_cluster_auth_from_config_passes_programmatic_audiences_through():
@@ -39,3 +45,33 @@ def test_cluster_auth_from_config_empty_programmatic_audiences():
 
     assert cluster_auth.iap is not None
     assert cluster_auth.iap.programmatic_audiences == ()
+
+
+def test_dashboard_proxy_command_forwards_context_credentials_to_the_proxy(monkeypatch):
+    """The browser holds no cluster credentials, so the proxy must send the operator's.
+
+    Regression guard: the command resolved them onto the context and then built the
+    proxy without them, so every upstream call hit an IAP-fronted controller
+    unauthenticated.
+    """
+    credentials = ClientCredentials(iap_provider=StaticTokenProvider("iap-token"))
+    built = {}
+
+    class StubDashboard:
+        def __init__(self, **kwargs):
+            built.update(kwargs)
+            self.app = object()
+
+    monkeypatch.setattr(cluster_cli, "ProxyControllerDashboard", StubDashboard)
+    monkeypatch.setattr(cluster_cli, "require_controller_url", lambda ctx: "https://iris.example")
+    monkeypatch.setattr(cluster_cli.subprocess, "run", lambda *a, **kw: None)
+    monkeypatch.setattr(cluster_cli.subprocess, "Popen", lambda *a, **kw: Mock())
+    monkeypatch.setattr(cluster_cli.uvicorn, "run", lambda *a, **kw: None)
+
+    CliRunner().invoke(
+        cluster_cli.cluster_dashboard_proxy,
+        obj={"credentials": credentials},
+        catch_exceptions=False,
+    )
+
+    assert built["credentials"] is credentials

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -7,6 +7,7 @@ Tests verify dashboard functionality through the Connect RPC endpoints.
 The dashboard serves a web UI that fetches data via RPC calls.
 """
 
+import asyncio
 from unittest.mock import Mock
 
 import httpx
@@ -26,7 +27,7 @@ from iris.cluster.controller import ops, reads
 from iris.cluster.controller.autoscaler.status import PendingHint, overlay_worker_usability
 from iris.cluster.controller.backend import BackendCapability, BackendRuntime, DeviceCapacity
 from iris.cluster.controller.codec import constraints_from_json, device_counts_from_json, device_variant_from_json
-from iris.cluster.controller.dashboard import ControllerDashboard, ProxyControllerDashboard
+from iris.cluster.controller.dashboard import ControllerDashboard, _CredentialAuth
 from iris.cluster.controller.endpoint_service import EndpointServiceImpl
 from iris.cluster.controller.ops.task import Assignment
 from iris.cluster.controller.projections.endpoints import EndpointRow
@@ -2127,79 +2128,59 @@ def test_get_kubernetes_cluster_status_ambiguous_raises(state, scheduler, tmp_pa
     assert data_us["namespace"] == "us"
 
 
-class TestProxyDashboardCredentials:
-    """The proxy authenticates upstream on the browser's behalf.
+async def _headers_seen_upstream(auth, headers=None) -> httpx.Headers:
+    """Send one request through a client using ``auth`` and return what upstream saw."""
+    seen = []
 
-    The browser holds no cluster credentials, so every route that leaves this
-    process must carry the operator's. Dropping them on any one of them makes an
-    IAP-fronted controller reject that panel with a 401 while the rest work.
-    """
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers)
+        return httpx.Response(200, json={})
 
-    @staticmethod
-    def _proxy_with_recorder(credentials):
-        """A proxy dashboard whose upstream records the headers it receives."""
-        seen: list[httpx.Headers] = []
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler), auth=auth) as client:
+        await client.post("https://iris.example/rpc", headers=headers or {})
+    return seen[0]
 
-        def handler(request: httpx.Request) -> httpx.Response:
-            seen.append(request.headers)
-            return httpx.Response(200, json={})
 
-        dashboard = ProxyControllerDashboard(upstream_url="https://iris.example", credentials=credentials)
-        # Swap the transport, not the client: auth lives on the client the
-        # constructor built, which is the wiring under test.
-        dashboard._client._transport = httpx.MockTransport(handler)
-        return dashboard, seen
+def _send_through(auth, headers=None) -> httpx.Headers:
+    return asyncio.run(_headers_seen_upstream(auth, headers))
 
-    @staticmethod
-    def _credentials() -> ClientCredentials:
-        return ClientCredentials(
-            token_provider=StaticTokenProvider("app-token"),
-            iap_provider=StaticTokenProvider("iap-token"),
-        )
 
-    @pytest.mark.parametrize(
-        "method,path",
-        [
-            ("POST", "/iris.cluster.ControllerService/ListJobs"),
-            ("POST", "/proxy/system.log-server/finelog.logging.LogService/FetchLogs"),
-            ("POST", "/auth/session"),
-            ("GET", "/blobs/abc123"),
-            ("GET", "/bundles/abc123.zip"),
-        ],
+def _static_credentials() -> ClientCredentials:
+    return ClientCredentials(
+        token_provider=StaticTokenProvider("app-token"),
+        iap_provider=StaticTokenProvider("iap-token"),
     )
-    def test_every_upstream_route_carries_both_bearers(self, method, path):
-        dashboard, seen = self._proxy_with_recorder(self._credentials())
-        with TestClient(dashboard.app) as client:
-            client.request(method, path, content=b"{}" if method == "POST" else None)
-        assert len(seen) == 1
-        assert seen[0]["authorization"] == "Bearer app-token"
-        assert seen[0]["proxy-authorization"] == "Bearer iap-token"
 
-    def test_unauthenticated_cluster_sends_no_bearers(self):
-        """A loopback / tunneled controller needs no tokens; sending empty ones would be a malformed header."""
-        dashboard, seen = self._proxy_with_recorder(None)
-        with TestClient(dashboard.app) as client:
-            client.post("/iris.cluster.ControllerService/ListJobs", content=b"{}")
-        assert "authorization" not in seen[0]
-        assert "proxy-authorization" not in seen[0]
 
-    def test_browser_supplied_bearer_never_reaches_upstream(self):
-        """Upstream auth is this process's own; a header from the browser must not impersonate it."""
-        dashboard, seen = self._proxy_with_recorder(self._credentials())
-        with TestClient(dashboard.app) as client:
-            client.post(
-                "/iris.cluster.ControllerService/ListJobs",
-                content=b"{}",
-                headers={"proxy-authorization": "Bearer forged"},
-            )
-        assert seen[0]["proxy-authorization"] == "Bearer iap-token"
+def test_credential_auth_both_providers_attaches_both_bearers():
+    headers = _send_through(_CredentialAuth(_static_credentials()))
+    assert headers["authorization"] == "Bearer app-token"
+    assert headers["proxy-authorization"] == "Bearer iap-token"
 
-    def test_content_type_still_forwarded(self):
-        dashboard, seen = self._proxy_with_recorder(self._credentials())
-        with TestClient(dashboard.app) as client:
-            client.post(
-                "/iris.cluster.ControllerService/ListJobs",
-                content=b"{}",
-                headers={"content-type": "application/proto"},
-            )
-        assert seen[0]["content-type"] == "application/proto"
+
+def test_credential_auth_caller_supplied_bearer_is_overwritten():
+    headers = _send_through(
+        _CredentialAuth(_static_credentials()),
+        headers={"proxy-authorization": "Bearer forged"},
+    )
+    assert headers["proxy-authorization"] == "Bearer iap-token"
+
+
+def test_credential_auth_expired_token_mints_a_fresh_one_per_request():
+    class Rotating:
+        def __init__(self):
+            self.calls = 0
+
+        def get_token(self) -> str | None:
+            self.calls += 1
+            return f"t{self.calls}"
+
+    auth = _CredentialAuth(ClientCredentials(iap_provider=Rotating()))
+    assert _send_through(auth)["proxy-authorization"] == "Bearer t1"
+    assert _send_through(auth)["proxy-authorization"] == "Bearer t2"
+
+
+def test_credential_auth_no_providers_sends_no_bearers():
+    headers = _send_through(_CredentialAuth(ClientCredentials()))
+    assert "authorization" not in headers
+    assert "proxy-authorization" not in headers

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -9,6 +9,7 @@ The dashboard serves a web UI that fetches data via RPC calls.
 
 from unittest.mock import Mock
 
+import httpx
 import pytest
 from iris.cluster.backends.k8s.tasks import (
     _KUEUE_POD_GROUP_NAME,
@@ -25,7 +26,7 @@ from iris.cluster.controller import ops, reads
 from iris.cluster.controller.autoscaler.status import PendingHint, overlay_worker_usability
 from iris.cluster.controller.backend import BackendCapability, BackendRuntime, DeviceCapacity
 from iris.cluster.controller.codec import constraints_from_json, device_counts_from_json, device_variant_from_json
-from iris.cluster.controller.dashboard import ControllerDashboard
+from iris.cluster.controller.dashboard import ControllerDashboard, ProxyControllerDashboard
 from iris.cluster.controller.endpoint_service import EndpointServiceImpl
 from iris.cluster.controller.ops.task import Assignment
 from iris.cluster.controller.projections.endpoints import EndpointRow
@@ -46,6 +47,8 @@ from iris.cluster.platforms.k8s.types import K8sResource
 from iris.cluster.types import DEFAULT_BACKEND_ID, JobName, UserBudgetDefaults, WorkerId, WorkerUsability
 from iris.rpc import controller_pb2, job_pb2, vm_pb2
 from iris.time_proto import timestamp_to_proto
+from rigging.auth import StaticTokenProvider
+from rigging.credentials import ClientCredentials
 from rigging.server_auth import RequestAuthPolicy
 from rigging.testing import MockVerifier
 from rigging.timing import Timestamp
@@ -2122,3 +2125,79 @@ def test_get_kubernetes_cluster_status_ambiguous_raises(state, scheduler, tmp_pa
     assert data_eu["namespace"] == "eu"
     data_us = rpc_post(client, "GetKubernetesClusterStatus", {"backendId": "us-k8s"})
     assert data_us["namespace"] == "us"
+
+
+class TestProxyDashboardCredentials:
+    """The proxy authenticates upstream on the browser's behalf.
+
+    The browser holds no cluster credentials, so every route that leaves this
+    process must carry the operator's. Dropping them on any one of them makes an
+    IAP-fronted controller reject that panel with a 401 while the rest work.
+    """
+
+    @staticmethod
+    def _proxy_with_recorder(credentials):
+        """A proxy dashboard whose upstream records the headers it receives."""
+        seen: list[httpx.Headers] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request.headers)
+            return httpx.Response(200, json={})
+
+        dashboard = ProxyControllerDashboard(upstream_url="https://iris.example", credentials=credentials)
+        dashboard._client = httpx.AsyncClient(base_url="https://iris.example", transport=httpx.MockTransport(handler))
+        return dashboard, seen
+
+    @staticmethod
+    def _credentials() -> ClientCredentials:
+        return ClientCredentials(
+            token_provider=StaticTokenProvider("app-token"),
+            iap_provider=StaticTokenProvider("iap-token"),
+        )
+
+    @pytest.mark.parametrize(
+        "method,path",
+        [
+            ("POST", "/iris.cluster.ControllerService/ListJobs"),
+            ("POST", "/proxy/system.log-server/finelog.logging.LogService/FetchLogs"),
+            ("POST", "/auth/session"),
+            ("GET", "/blobs/abc123"),
+            ("GET", "/bundles/abc123.zip"),
+        ],
+    )
+    def test_every_upstream_route_carries_both_bearers(self, method, path):
+        dashboard, seen = self._proxy_with_recorder(self._credentials())
+        with TestClient(dashboard.app) as client:
+            client.request(method, path, content=b"{}" if method == "POST" else None)
+        assert len(seen) == 1
+        assert seen[0]["authorization"] == "Bearer app-token"
+        assert seen[0]["proxy-authorization"] == "Bearer iap-token"
+
+    def test_unauthenticated_cluster_sends_no_bearers(self):
+        """A loopback / tunneled controller needs no tokens; sending empty ones would be a malformed header."""
+        dashboard, seen = self._proxy_with_recorder(None)
+        with TestClient(dashboard.app) as client:
+            client.post("/iris.cluster.ControllerService/ListJobs", content=b"{}")
+        assert "authorization" not in seen[0]
+        assert "proxy-authorization" not in seen[0]
+
+    def test_browser_supplied_bearer_never_reaches_upstream(self):
+        """Upstream auth is this process's own; a header from the browser must not impersonate it."""
+        dashboard, seen = self._proxy_with_recorder(self._credentials())
+        with TestClient(dashboard.app) as client:
+            client.post(
+                "/iris.cluster.ControllerService/ListJobs",
+                content=b"{}",
+                headers={"proxy-authorization": "Bearer forged"},
+            )
+        assert seen[0]["proxy-authorization"] == "Bearer iap-token"
+
+    def test_content_type_still_forwarded(self):
+        dashboard, seen = self._proxy_with_recorder(self._credentials())
+        with TestClient(dashboard.app) as client:
+            client.post(
+                "/iris.cluster.ControllerService/ListJobs",
+                content=b"{}",
+                headers={"content-type": "application/proto"},
+            )
+        assert seen[0]["content-type"] == "application/proto"

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -2145,7 +2145,9 @@ class TestProxyDashboardCredentials:
             return httpx.Response(200, json={})
 
         dashboard = ProxyControllerDashboard(upstream_url="https://iris.example", credentials=credentials)
-        dashboard._client = httpx.AsyncClient(base_url="https://iris.example", transport=httpx.MockTransport(handler))
+        # Swap the transport, not the client: auth lives on the client the
+        # constructor built, which is the wiring under test.
+        dashboard._client._transport = httpx.MockTransport(handler)
         return dashboard, seen
 
     @staticmethod

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -497,6 +497,7 @@ def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_scree
     filtered_row.locator("[data-log-permalink]").click()
     smoke_page.wait_for_function("() => location.hash.includes('logSeq=')", timeout=5000)
 
+    selected_message = filtered_row.locator(":scope > span").last.inner_text()
     filtered_row.locator("[data-log-start]").click()
     since_input = "input[type='datetime-local']"
     smoke_page.wait_for_function(
@@ -505,6 +506,7 @@ def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_scree
     )
     locked_since = smoke_page.input_value(since_input)
     assert locked_since
+    smoke_page.locator("[data-row]").filter(has_text=selected_message).wait_for(timeout=5000)
 
     smoke_page.get_by_role("button", name="Clear filter").click()
     smoke_page.wait_for_function(

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -432,7 +432,7 @@ def _wait_for_task_log_marker(
 
 
 def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_screenshot):
-    """Task logs show lines and substring filter on the task detail page."""
+    """Task logs show search, filter, permalink, and time-bound controls."""
     task_status = smoke_cluster.task_status(verbose_job)
     task_id = task_status.task_id
     job_id = verbose_job.job_id.to_wire()
@@ -490,6 +490,29 @@ def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_scree
         "task-logs-filtered",
         "Task detail page with log filter input populated and filtered log lines visible in the log viewer.",
     )
+
+    # The timestamp action still makes a permalink. The next control sets an
+    # exact start time. The start time stays set after the string filter clears.
+    filtered_row = smoke_page.locator("[data-row]").filter(has_text="validation failed").first
+    filtered_row.locator("[data-log-permalink]").click()
+    smoke_page.wait_for_function("() => location.hash.includes('logSeq=')", timeout=5000)
+
+    filtered_row.locator("[data-log-start]").click()
+    since_input = "input[type='datetime-local']"
+    smoke_page.wait_for_function(
+        "() => document.querySelector(\"input[type='datetime-local']\")?.value.length > 0",
+        timeout=5000,
+    )
+    locked_since = smoke_page.input_value(since_input)
+    assert locked_since
+
+    smoke_page.get_by_role("button", name="Clear filter").click()
+    smoke_page.wait_for_function(
+        "() => document.querySelector(\"input[placeholder^='Filter:']\")?.value === '' && "
+        "document.body.textContent.includes('processing data batch')",
+        timeout=5000,
+    )
+    assert smoke_page.input_value(since_input) == locked_since
 
 
 def test_dashboard_jump_to_exception(smoke_cluster, smoke_page, smoke_screenshot):

--- a/lib/rigging/src/rigging/credentials.py
+++ b/lib/rigging/src/rigging/credentials.py
@@ -68,6 +68,22 @@ class ClientCredentials:
             chain += (BearerTokenInjector(self.iap_provider, "proxy-authorization"),)
         return chain
 
+    def headers(self) -> dict[str, str]:
+        """The same bearer headers :meth:`interceptors` attaches, as a plain dict.
+
+        For callers that speak plain HTTP rather than Connect RPC — an HTTP proxy
+        forwarding upstream, say — and so cannot use the interceptor chain. Mints
+        on every call, because a provider re-mints an expired token; do not cache
+        the result across requests. A provider that returns None contributes no
+        header (the loopback / SSH-tunnel-trust case).
+        """
+        pairs = (("authorization", self.token_provider), ("proxy-authorization", self.iap_provider))
+        return {
+            header: f"Bearer {token}"
+            for header, provider in pairs
+            if provider is not None and (token := provider.get_token())
+        }
+
 
 def _login_hint(cluster: str) -> str:
     """The canonical 'log in again' remedy for ``cluster``."""

--- a/lib/rigging/src/rigging/credentials.py
+++ b/lib/rigging/src/rigging/credentials.py
@@ -54,35 +54,30 @@ class ClientCredentials:
     token_provider: TokenProvider | None = None
     iap_provider: TokenProvider | None = None
 
-    def interceptors(self) -> tuple:
-        """The client-side interceptor chain for these credentials.
+    def _bearers(self) -> tuple[tuple[str, TokenProvider], ...]:
+        """The (header, provider) pairs to attach, in order, skipping absent providers.
 
         The app token rides in ``Authorization``; the IAP edge token in
         ``Proxy-Authorization`` so the app header stays free for the service's own
-        JWT. Either may be absent (loopback trust sends neither).
+        JWT. Either may be absent (loopback trust sends neither). Both attachment
+        forms below read this, so a renamed header or a third provider is one edit.
         """
-        chain: tuple = ()
-        if self.token_provider is not None:
-            chain += (BearerTokenInjector(self.token_provider, "authorization"),)
-        if self.iap_provider is not None:
-            chain += (BearerTokenInjector(self.iap_provider, "proxy-authorization"),)
-        return chain
+        pairs = (("authorization", self.token_provider), ("proxy-authorization", self.iap_provider))
+        return tuple((header, provider) for header, provider in pairs if provider is not None)
+
+    def interceptors(self) -> tuple:
+        """The client-side interceptor chain for these credentials."""
+        return tuple(BearerTokenInjector(provider, header) for header, provider in self._bearers())
 
     def headers(self) -> dict[str, str]:
         """The same bearer headers :meth:`interceptors` attaches, as a plain dict.
 
-        For callers that speak plain HTTP rather than Connect RPC — an HTTP proxy
-        forwarding upstream, say — and so cannot use the interceptor chain. Mints
-        on every call, because a provider re-mints an expired token; do not cache
-        the result across requests. A provider that returns None contributes no
-        header (the loopback / SSH-tunnel-trust case).
+        For callers that speak plain HTTP rather than Connect RPC and so cannot use
+        the interceptor chain. Mints on every call, because a provider re-mints an
+        expired token, so do not cache the result across requests. A provider that
+        yields nothing contributes no header.
         """
-        pairs = (("authorization", self.token_provider), ("proxy-authorization", self.iap_provider))
-        return {
-            header: f"Bearer {token}"
-            for header, provider in pairs
-            if provider is not None and (token := provider.get_token())
-        }
+        return {header: f"Bearer {token}" for header, provider in self._bearers() if (token := provider.get_token())}
 
 
 def _login_hint(cluster: str) -> str:

--- a/lib/rigging/src/rigging/credentials.py
+++ b/lib/rigging/src/rigging/credentials.py
@@ -55,12 +55,11 @@ class ClientCredentials:
     iap_provider: TokenProvider | None = None
 
     def _bearers(self) -> tuple[tuple[str, TokenProvider], ...]:
-        """The (header, provider) pairs to attach, in order, skipping absent providers.
+        """The (header, provider) pairs to attach, skipping absent providers.
 
         The app token rides in ``Authorization``; the IAP edge token in
         ``Proxy-Authorization`` so the app header stays free for the service's own
-        JWT. Either may be absent (loopback trust sends neither). Both attachment
-        forms below read this, so a renamed header or a third provider is one edit.
+        JWT. Either may be absent (loopback trust sends neither).
         """
         pairs = (("authorization", self.token_provider), ("proxy-authorization", self.iap_provider))
         return tuple((header, provider) for header, provider in pairs if provider is not None)
@@ -70,12 +69,9 @@ class ClientCredentials:
         return tuple(BearerTokenInjector(provider, header) for header, provider in self._bearers())
 
     def headers(self) -> dict[str, str]:
-        """The same bearer headers :meth:`interceptors` attaches, as a plain dict.
+        """The same bearer headers :meth:`interceptors` attaches, for plain-HTTP callers.
 
-        For callers that speak plain HTTP rather than Connect RPC and so cannot use
-        the interceptor chain. Mints on every call, because a provider re-mints an
-        expired token, so do not cache the result across requests. A provider that
-        yields nothing contributes no header.
+        Mints on every call, so do not cache the result across requests.
         """
         return {header: f"Bearer {token}" for header, provider in self._bearers() if (token := provider.get_token())}
 

--- a/lib/rigging/tests/test_credentials.py
+++ b/lib/rigging/tests/test_credentials.py
@@ -92,3 +92,31 @@ def test_interceptors_map_providers_to_headers():
     chain = c.interceptors()
     assert [i.header for i in chain] == ["authorization", "proxy-authorization"]
     assert all(isinstance(i, BearerTokenInjector) for i in chain)
+
+
+def test_headers_match_the_interceptor_header_convention():
+    c = ClientCredentials(token_provider=StaticTokenProvider("a"), iap_provider=StaticTokenProvider("e"))
+    assert c.headers() == {"authorization": "Bearer a", "proxy-authorization": "Bearer e"}
+
+
+def test_headers_omit_absent_and_empty_providers():
+    """A provider yielding nothing must not send ``Bearer ``, which reads as a malformed token."""
+    assert ClientCredentials().headers() == {}
+    assert ClientCredentials(iap_provider=StaticTokenProvider("")).headers() == {}
+    assert ClientCredentials(iap_provider=StaticTokenProvider("e")).headers() == {"proxy-authorization": "Bearer e"}
+
+
+def test_headers_remint_on_every_call():
+    """Callers hold the dict, not the provider, so a stale token must not survive a refresh."""
+
+    class Rotating:
+        def __init__(self):
+            self.calls = 0
+
+        def get_token(self) -> str | None:
+            self.calls += 1
+            return f"t{self.calls}"
+
+    c = ClientCredentials(iap_provider=Rotating())
+    assert c.headers()["proxy-authorization"] == "Bearer t1"
+    assert c.headers()["proxy-authorization"] == "Bearer t2"

--- a/lib/rigging/tests/test_credentials.py
+++ b/lib/rigging/tests/test_credentials.py
@@ -94,21 +94,18 @@ def test_interceptors_map_providers_to_headers():
     assert all(isinstance(i, BearerTokenInjector) for i in chain)
 
 
-def test_headers_match_the_interceptor_header_convention():
+def test_headers_both_providers_uses_the_interceptor_header_names():
     c = ClientCredentials(token_provider=StaticTokenProvider("a"), iap_provider=StaticTokenProvider("e"))
     assert c.headers() == {"authorization": "Bearer a", "proxy-authorization": "Bearer e"}
 
 
-def test_headers_omit_absent_and_empty_providers():
-    """A provider yielding nothing must not send ``Bearer ``, which reads as a malformed token."""
+def test_headers_absent_or_empty_provider_omits_the_header():
     assert ClientCredentials().headers() == {}
     assert ClientCredentials(iap_provider=StaticTokenProvider("")).headers() == {}
     assert ClientCredentials(iap_provider=StaticTokenProvider("e")).headers() == {"proxy-authorization": "Bearer e"}
 
 
-def test_headers_remint_on_every_call():
-    """Callers hold the dict, not the provider, so a stale token must not survive a refresh."""
-
+def test_headers_repeated_calls_mint_a_fresh_token_each_time():
     class Rotating:
         def __init__(self):
             self.calls = 0


### PR DESCRIPTION
`iris cluster dashboard-proxy` sent every upstream request without auth, so
against an IAP-fronted controller the dashboard was unusable: each panel got
`Invalid IAP credentials: empty token` back from the GCLB edge. The CLI already
resolves the operator's `ClientCredentials` onto the click context, and the
proxy dropped them, forwarding only `content-type`.

The upstream httpx client now carries those credentials as an `httpx.Auth`, so
the RPC, endpoint-proxy, auth, blob, and bundle routes are authenticated by
construction and a route added later needs no new wiring. Tokens mint per
request, because a proxy session outlives a token's lifetime. `ClientCredentials`
gains `headers()` for callers that speak plain HTTP and cannot use the Connect
interceptor chain; it and `interceptors()` read one (header, provider) table so
the header convention stays in one place.

Verified against the marin cluster: `ListJobs`, the log server's `FetchLogs`,
and `/auth/config` all return 200 through the proxy where they previously
returned 401.

The proxy still cannot serve the upstream's POST auth routes, and this does not
change that. `/auth/session` and `/auth/logout` check CSRF against the upstream's
own origin, which a request relayed from `localhost` cannot match unless the
proxy rewrites `Origin`, and the proxy does not return upstream `Set-Cookie`
either. `/auth/config` is a GET and is the one auth route the proxy serves. On an
IAP cluster the session is the edge session, so this does not affect the fix.

Stacked on #7844.
