### PR TITLE
[finelog] Fix telemetry startup and shorten release builds

### DIFF
--- a/lib/finelog/deploy/Dockerfile
+++ b/lib/finelog/deploy/Dockerfile
@@ -33,11 +33,11 @@ RUN npm run build
 # system protoc is needed.
 FROM rust:1-bookworm AS rustbuild
 
-# Cargo profile to build. Defaults to the fat-LTO `release` profile for
-# production images. Dev/test deploys pass `--build-arg CARGO_PROFILE=fast`
-# (no LTO, parallel codegen) for a far faster final link; see `[profile.fast]`
-# in lib/finelog/rust/Cargo.toml. The profile name is also the target/<profile>/ subdir
-# (true for `release` and any custom profile), so the cp below resolves it.
+# Cargo profile to build. The default `release` profile uses opt-level 3 without
+# LTO. Dev/test deploys may pass `--build-arg CARGO_PROFILE=fast` for opt-level
+# 2; see `[profile.fast]` in lib/finelog/rust/Cargo.toml. The profile name is
+# also the target/<profile>/ subdir (true for `release` and any custom profile),
+# so the cp below resolves it.
 ARG CARGO_PROFILE=release
 
 # mold: a fast, multi-threaded linker. The cargo build runs under `mold -run`,

--- a/lib/finelog/rust/Cargo.toml
+++ b/lib/finelog/rust/Cargo.toml
@@ -22,7 +22,6 @@ strip = "symbols"
 # `--build-arg CARGO_PROFILE=fast`.
 [profile.fast]
 inherits = "release"
-lto = false
 opt-level = 2
 
 [package]

--- a/lib/finelog/rust/Cargo.toml
+++ b/lib/finelog/rust/Cargo.toml
@@ -6,18 +6,19 @@
 members = ["pyext"]
 resolver = "2"
 
-# Thin LTO + parallel codegen. Within ~1% of fat-LTO runtime, but builds in a
-# fraction of the time: fat LTO + codegen-units=1 is a single-threaded
-# multi-minute link over the whole datafusion/arrow tree. Applies to every
-# workspace member — the finelog-server binary and the finelog/pyext cdylib.
+# Optimized production profile with parallel codegen and no LTO. Finelog's
+# DataFusion/Arrow dependency graph makes even thin LTO add several minutes to
+# small server changes, while ordinary opt-level 3 remains representative for
+# deployment. Applies to every workspace member: the finelog-server binary and
+# the finelog/pyext cdylib.
 [profile.release]
-lto = "thin"
+lto = false
 codegen-units = 16
 strip = "symbols"
 
-# Even-faster iteration profile for dev/test deploys (e.g. marin-dev): drops LTO
-# entirely and opt-level to 2 on top of release's parallel codegen. Still
-# optimized enough to be representative. The deploy Dockerfile passes
+# Even-faster iteration profile for dev/test deploys (e.g. marin-dev): lowers
+# opt-level to 2 on top of release's parallel codegen. Still optimized enough
+# to be representative. The deploy Dockerfile passes
 # `--build-arg CARGO_PROFILE=fast`.
 [profile.fast]
 inherits = "release"

--- a/lib/finelog/rust/src/server/telemetry.rs
+++ b/lib/finelog/rust/src/server/telemetry.rs
@@ -16,7 +16,7 @@ use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
-use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{Mutex, OnceCell, OwnedSemaphorePermit, Semaphore};
 use uuid::Uuid;
 
 use crate::errors::StatsError;
@@ -216,7 +216,7 @@ struct TelemetryState {
     store: Arc<Store>,
     admission: Arc<Semaphore>,
     dedupe: Mutex<DedupeCache>,
-    schema_error: Option<String>,
+    namespace_registration: OnceCell<Result<(), String>>,
 }
 
 struct PreparedBatch {
@@ -227,6 +227,38 @@ struct PreparedBatch {
     record_count: usize,
 }
 
+impl TelemetryState {
+    async fn ensure_namespace_registered(&self) -> Result<(), ApiError> {
+        let result = self
+            .namespace_registration
+            .get_or_init(|| async {
+                let store = Arc::clone(&self.store);
+                match tokio::task::spawn_blocking(move || {
+                    store.register_table(
+                        TELEMETRY_NAMESPACE,
+                        telemetry_schema(),
+                        StoragePolicy::default(),
+                    )
+                })
+                .await
+                {
+                    Ok(Ok(_)) => Ok(()),
+                    Ok(Err(error)) => Err(error.to_string()),
+                    Err(join) => Err(format!("telemetry namespace task failed: {join}")),
+                }
+            })
+            .await;
+        result.as_ref().map_err(|error| {
+            ApiError::new(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "storage_unavailable",
+                format!("telemetry namespace is unavailable: {error}"),
+            )
+        })?;
+        Ok(())
+    }
+}
+
 /// Return an authenticated `POST /v1/telemetry` router with bounded admission and
 /// process-local retry deduplication.
 pub fn router(
@@ -235,19 +267,11 @@ pub fn router(
     max_concurrent: usize,
     dedupe_capacity: usize,
 ) -> Router {
-    let schema_error = store
-        .register_table(
-            TELEMETRY_NAMESPACE,
-            telemetry_schema(),
-            StoragePolicy::default(),
-        )
-        .err()
-        .map(|error| error.to_string());
     let state = Arc::new(TelemetryState {
         store,
         admission: Arc::new(Semaphore::new(max_concurrent)),
         dedupe: Mutex::new(DedupeCache::new(dedupe_capacity)),
-        schema_error,
+        namespace_registration: OnceCell::new(),
     });
     Router::new()
         .route("/v1/telemetry", post(post_telemetry))
@@ -268,13 +292,7 @@ async fn post_telemetry(
                 "too many telemetry requests are active",
             )
         })?;
-    if let Some(error) = &state.schema_error {
-        return Err(ApiError::new(
-            StatusCode::SERVICE_UNAVAILABLE,
-            "storage_unavailable",
-            format!("telemetry namespace is unavailable: {error}"),
-        ));
-    }
+    state.ensure_namespace_registered().await?;
     let batch_id_header = required_header(request.headers(), "idempotency-key", 64)?;
     let content_type = required_header(request.headers(), CONTENT_TYPE.as_str(), 128)?;
     if content_type

--- a/lib/finelog/rust/src/server/telemetry_tests.rs
+++ b/lib/finelog/rust/src/server/telemetry_tests.rs
@@ -21,6 +21,7 @@ use crate::server::{build_app_with_config, ServerConfig};
 use crate::store::policy::StoragePolicy;
 use crate::store::schema::{Column, Schema};
 use crate::store::Store;
+use crate::test_support::unique_dir;
 
 type TestHttpClient = HyperClient<HttpConnector, ClientBody>;
 
@@ -152,7 +153,15 @@ async fn query(store: &Store, sql: &str) -> Vec<arrow::array::RecordBatch> {
 
 #[tokio::test]
 async fn accepted_batch_is_queryable_through_normal_store_rows() {
-    let store = disk_store("telemetry-query");
+    let remote_dir = unique_dir("telemetry-query-remote");
+    let store = Arc::new(
+        Store::new(
+            Some(unique_dir("telemetry-query")),
+            remote_dir.to_string_lossy().into_owned(),
+        )
+        .unwrap(),
+    );
+    store.bootstrap_maintenance();
     let (addr, _) = serve(Arc::clone(&store), AuthPolicy::allow_localhost()).await;
     let client = http_client();
     let batch_id = "f47ac10b-58cc-4372-a567-0e02b2c3d479";

--- a/lib/finelog/src/finelog/deploy/build.py
+++ b/lib/finelog/src/finelog/deploy/build.py
@@ -68,8 +68,8 @@ def build_image(
     first requested platform only.
 
     ``cargo_profile`` selects the Rust build profile baked into the image.
-    ``release`` (default) is the optimized fat-LTO production build; ``fast``
-    skips LTO for a much quicker final link, suited to dev/test deploys.
+    ``release`` (default) uses opt-level 3 without LTO; ``fast`` lowers
+    optimization to level 2 for dev/test deploys.
     """
     marin_root = find_marin_root()
     dockerfile = marin_root / "lib" / "finelog" / "deploy" / "Dockerfile"


### PR DESCRIPTION
Register the telemetry namespace on the first accepted request instead of while
constructing the Axum app. The eager registration added in #7840 called
`Handle::block_on` from a Tokio runtime thread on disk-backed deployments,
panicking the first `marin-dev` process before Docker restarted it and masked
the failure behind a passing health check.

Run registration through `spawn_blocking` and cache its result. The
disk-backed telemetry test now configures remote storage, sends a batch through
the HTTP endpoint, and reads the accepted row from the normal store query path.

Disable LTO in the default release profile while retaining optimization level 3
and 16 codegen units. A fresh release image from this diff was rolled out
serially to `marin-dev`, the three CoreWeave mirrors, and the `marin` hub. Each
target ran the exact image digest with zero restarts, clean startup logs, and
recent rows. The incident and rollout record is
https://echo.oa.dev/wiki/51.
