### PR TITLE
[infra] Right-size always-on Cloud Run services

### DIFF
--- a/infra/echo/__main__.py
+++ b/infra/echo/__main__.py
@@ -176,6 +176,7 @@ def main() -> None:
             min_instances=1,
             max_instances=1,
             cpu_always_allocated=True,
+            cpu="1",
             memory="4Gi",
             max_instance_request_concurrency=4,
             cloudsql_instances=(CONNECTION_NAME,),

--- a/infra/evaldash/__main__.py
+++ b/infra/evaldash/__main__.py
@@ -66,6 +66,7 @@ def main() -> None:
             # The ingest loop lists GCS and upserts to Postgres between requests, so CPU must
             # stay allocated while idle.
             cpu_always_allocated=True,
+            cpu="1",
             env={
                 "RECORDS_PREFIXES": RECORDS_PREFIXES,
                 "EVAL_DB_INSTANCE": CLOUDSQL_INSTANCE,

--- a/infra/grafana/__main__.py
+++ b/infra/grafana/__main__.py
@@ -145,6 +145,7 @@ def main() -> None:
             # Grafana 13's apiserver and search indexers run between requests and need CPU
             # while idle; the dashboards list hangs on them otherwise.
             cpu_always_allocated=True,
+            cpu="1",
             # The bridge lists finelog and controller VM internal IPs through the Compute API.
             service_account_roles=("roles/compute.viewer",),
             env=env,


### PR DESCRIPTION
Run Echo, evaldash, and Grafana with one vCPU per warm Cloud Run instance.
Cloud Monitoring measured p95 CPU utilization of 9.8%, 6.5%, and 15.7%,
respectively, on the current two-vCPU allocations. Each service remains pinned
to one instance for background work.
