### PR TITLE
[docs] Cover GB200 devices in the tiny-model tutorial and job example

### DIFF
--- a/docs/dev-guide/guidelines-internal.md
+++ b/docs/dev-guide/guidelines-internal.md
@@ -72,7 +72,7 @@ To submit jobs, use `iris job run`. Job IDs are canonical paths of the form `/<u
 # [Terminal 2] Submit a job and return immediately.
 #   =>> Will print a line like `Job submitted: /<user>/hello_world-20260420-120000`
 uv run iris --cluster=marin job run \
-    --no-wait --extra marin-core:tpu --tpu v5litepod-16 \
+    --enable-extra-resources --no-wait --extra marin-core:tpu --tpu v5litepod-16 \
     -- python experiments/tutorials/hello_world.py
 
 # List jobs (filter by --state, --user, --prefix, etc).

--- a/experiments/tutorials/train_tiny_model.py
+++ b/experiments/tutorials/train_tiny_model.py
@@ -33,16 +33,22 @@ from experiments.marin_tokenizer import marin_tokenizer
 # Each device is one accelerator the same recipe runs on: its resources and a batch size
 # that fits. Adding a device is one entry here, not a new file.
 #
-# The H100 entries pass ``regions=[ANY_REGION]``. A training job inherits the region of the
-# worker that submitted it, which keeps it near its data; the GPU fleet lives in a federated
-# CoreWeave cluster that advertises no region, so an inherited region would exclude every
-# host that has an H100 and the job would be unschedulable.
+# The GPU entries pass ``regions=[ANY_REGION]``. A training job inherits the region of the
+# worker that submitted it, which keeps it near its data; the GPU fleets live in federated
+# CoreWeave clusters that advertise no region, so an inherited region would exclude every
+# host that has the GPU and the job would be unschedulable. ``gb200x4`` is one whole
+# gb200-4x node (4 Blackwell GPUs on Grace ARM hosts, cw-us-east-08a).
 DEVICES = {
     "cpu": (ResourceConfig.with_cpu(), 4),
     "h100x1": (ResourceConfig.with_gpu("H100", count=1, cpu=8, disk="128G", ram="64G", regions=[ANY_REGION]), 32),
     "h100x8": (
         ResourceConfig.with_gpu("H100", count=8, cpu=32, disk="128G", ram="128G", regions=[ANY_REGION]),
         256,
+    ),
+    "gb200x1": (ResourceConfig.with_gpu("GB200", count=1, cpu=8, disk="128G", ram="64G", regions=[ANY_REGION]), 32),
+    "gb200x4": (
+        ResourceConfig.with_gpu("GB200", count=4, cpu=32, disk="128G", ram="256G", regions=[ANY_REGION]),
+        128,
     ),
     "v5litepod-16": (ResourceConfig.with_tpu("v5litepod-16", slice_count=1, cpu=32, ram="128g", disk="50g"), 128),
     "v6e-4": (ResourceConfig.with_tpu("v6e-4", slice_count=1, cpu=32, ram="128g", disk="50g"), 32),


### PR DESCRIPTION
Add gb200x1 and gb200x4 entries to the tiny-model tutorial's device table (one
and four Blackwell GPUs on the Grace ARM hosts in cw-us-east-08a) and
generalize the region comment to cover both federated GPU fleets. The internal
guide's job-run example attaches a TPU to the entrypoint, which the CLI's
extra-resource guard now rejects without --enable-extra-resources, so the
example passes the flag.
