### PR TITLE
[grug] scale fsdp hero runs by rack

### DIFF
--- a/experiments/grug/moe_hero_fsdp/README.md
+++ b/experiments/grug/moe_hero_fsdp/README.md
@@ -1,26 +1,27 @@
 # grug MoE FSDP hero
 
-A minimal, **self-contained** FSDP variant of the grug MoE model, fixed to one 64-GPU GB200 rack
-(16 nodes × 4 GPUs) for a 25-step throughput / MFU reproduction. Everything is inlined and
-opinionated: features that are options elsewhere are hardwired on here, and the folder has **no
-dependency on `experiments/grug/moe`** — it imports only the levanter substrate and its own modules.
+A minimal, **self-contained** FSDP variant of the grug MoE model for 25-step throughput and MFU
+runs on one or more GB200 racks. Everything is inlined and opinionated: features that are options
+elsewhere are hardwired on here, and the folder has **no dependency on `experiments/grug/moe`** —
+it imports only the levanter substrate and its own modules.
 
 Launch:
 
 ```bash
 # dry-run: print the lowered plan locally, no GPUs
-python -m experiments.grug.moe_hero_fsdp.launch --version dev
+python -m experiments.grug.moe_hero_fsdp.launch --dp-racks 1 --version dev
 
-# submit the run (coordinator dispatches the 64-GPU GB200 job)
-RID=moe-hero-fsdp-test-1rack
+# submit one or more racks; each rack gets 16 GB200x4 nodes and batch 1024
+DP_RACKS=2
+RID="moe-hero-fsdp-test-${DP_RACKS}rack"
 iris --cluster=marin job run --no-wait --enable-extra-resources \
   --target-cluster cw-us-east-08a --priority interactive \
   --cpu 2 --memory 8GB --disk 32GB --timeout 5400 --job-name "${RID}-coord" \
   -e WANDB_API_KEY "$WANDB_API_KEY" -e RUN_ID "$RID" \
-  -- python -m experiments.grug.moe_hero_fsdp.launch --version dev --run
+  -- python -m experiments.grug.moe_hero_fsdp.launch --dp-racks "$DP_RACKS" --version dev --run
 ```
 
-W&B: `marin-community/marin_moe`, group `moe-hero-fsdp`, run name `$RUN_ID`.
+W&B: `marin-community/rav_moe`, group `moe-hero-fsdp-${DP_RACKS}rack`, run name `$RUN_ID`.
 
 ## Files
 
@@ -32,7 +33,7 @@ W&B: `marin-community/marin_moe`, group `moe-hero-fsdp`, run name `$RUN_ID`.
 | `adamh.py` | AdamH (Adam direction + Frobenius hyperball scale-invariant step) |
 | `heuristic.py` | May Recipe compute-scaling LR refit; derives the optimizer from steps + batch |
 | `train.py` | training loop, state init, dispatch, hero runtime env |
-| `launch.py` | inlined `HERO_MODEL`, resources, trainer, dataset, entry point |
+| `launch.py` | rack-scaled resources, DP/FSDP mesh, batch, tracker, dataset, and entry point |
 
 ## What's distinctive about this run
 
@@ -53,7 +54,10 @@ W&B: `marin-community/marin_moe`, group `moe-hero-fsdp`, run name `$RUN_ID`.
   the scan.
 
 ### Systems (FSDP)
-- **Pure FSDP**: `expert_axis_size=1`, `replica_axis_size=1` → all 64 GPUs on the `data` axis.
+- **One rack**: `expert_axis_size=1`, `replica_axis_size=1` → one 64-GPU `data` axis.
+- **Two racks**: `expert_axis_size=1`, `replica_axis_size=2` → two DP replicas, each with a
+  64-GPU `data` axis. Model parameters are replicated across `replica_dcn` and FSDP-sharded only
+  on `data`. The embedding table is fully replicated so each device does a local lookup.
 - **`expert_chunks=4`** — gather one quarter of the expert bank at a time (the largest MFU lever).
 - **`sonic_cute`** MoE backend (QuACK SM100 grouped-GEMM) and **`gpu_fa4_cute`** attention
   (FA4 / CUTLASS 4.6).
@@ -71,13 +75,15 @@ W&B: `marin-community/marin_moe`, group `moe-hero-fsdp`, run name `$RUN_ID`.
   on (`use_syrk=True`).
 - Three LR groups: **muonh** (matrices + GatedNorms), **adamh** (`lm_head` / `output_proj`),
   **adam** (embeddings, router, attention gate, 1-D norm gains, the tiny SConv kernels).
-- LR / beta / epsilon come from the **May Recipe compute-scaling heuristic** (issue #5951) at
-  batch 1152 / 25 steps / d6144: `lr=0.05`, `adam_lr≈0.02512`, `beta1=0.9062`, `beta2≈0.96462`,
-  `epsilon≈4.84e-17`, linear schedule, **no gradient clipping**, no weight decay applied.
+- LR / beta / epsilon come from the **May Recipe compute-scaling heuristic** (issue #5951) for
+  the selected global batch, 25 steps, and d6144. The schedule is linear, with **no gradient
+  clipping** and no weight decay applied.
 - CE logsumexp **z-loss = 1e-4**. Router z-loss is **logged only**, not added to the loss.
 
 ### Run
-- **25 steps**, batch **1152**, seq **4096**, SlimPajama-6B, Llama-3 tokenizer, vocab 128256.
+- **25 steps**, batch **1024 per rack**, seq **4096**, SlimPajama-6B, Llama-3 tokenizer, vocab
+  128256.
 - Mixed precision: params fp32, compute/output bf16.
 - Checkpointing and eval are **off for this run** but the machinery is retained for later.
-- Multi-rack wedge mitigations are intentionally **excluded** (this is a single-rack run).
+- FA4 metadata constants are explicitly replicated before batch sharding. This prevents the
+  compiler from routing each attention metadata transfer through device 0 on a multi-rack run.

--- a/experiments/grug/moe_hero_fsdp/README.md
+++ b/experiments/grug/moe_hero_fsdp/README.md
@@ -21,7 +21,7 @@ iris --cluster=marin job run --no-wait --enable-extra-resources \
   -- python -m experiments.grug.moe_hero_fsdp.launch --dp-racks "$DP_RACKS" --version dev --run
 ```
 
-W&B: `marin-community/rav_moe`, group `moe-hero-fsdp-${DP_RACKS}rack`, run name `$RUN_ID`.
+W&B: `marin-community/marin_moe`, run name `$RUN_ID`.
 
 ## Files
 

--- a/experiments/grug/moe_hero_fsdp/README.md
+++ b/experiments/grug/moe_hero_fsdp/README.md
@@ -12,16 +12,15 @@ Launch:
 python -m experiments.grug.moe_hero_fsdp.launch --dp-racks 1 --version dev
 
 # submit one or more racks; each rack gets 16 GB200x4 nodes and batch 1024
-DP_RACKS=2
-RID="moe-hero-fsdp-test-${DP_RACKS}rack"
+RID="moe-hero-fsdp-test-2rack"
 iris --cluster=marin job run --no-wait --enable-extra-resources \
   --target-cluster cw-us-east-08a --priority interactive \
   --cpu 2 --memory 8GB --disk 32GB --timeout 5400 --job-name "${RID}-coord" \
   -e WANDB_API_KEY "$WANDB_API_KEY" -e RUN_ID "$RID" \
-  -- python -m experiments.grug.moe_hero_fsdp.launch --dp-racks "$DP_RACKS" --version dev --run
+  -- python -m experiments.grug.moe_hero_fsdp.launch --dp-racks 2 --version dev --run
 ```
 
-W&B: `marin-community/marin_moe`, run name `$RUN_ID`.
+W&B: `marin-community/marin_moe`, group `moe-hero-fsdp`, run name `$RUN_ID`.
 
 ## Files
 

--- a/experiments/grug/moe_hero_fsdp/heuristic.py
+++ b/experiments/grug/moe_hero_fsdp/heuristic.py
@@ -74,7 +74,7 @@ class MoeHeuristic:
 
 
 def build_hero_configs(*, num_train_steps: int, batch_size: int) -> tuple[GrugModelConfig, GrugMoeMuonHConfig]:
-    """The fixed 64-GPU FSDP hero model plus its compute-scaled MuonH optimizer."""
+    """The fixed FSDP hero model plus its compute-scaled MuonH optimizer."""
     model = GrugModelConfig(
         vocab_size=128_256,
         hidden_dim=6144,

--- a/experiments/grug/moe_hero_fsdp/launch.py
+++ b/experiments/grug/moe_hero_fsdp/launch.py
@@ -1,11 +1,12 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Hardcoded one-rack GB200 launcher for the FSDP MoE hero configuration."""
+"""Rack-scaled GB200 launcher for the FSDP MoE hero configuration."""
 
 import dataclasses
 import os
 
+import click
 import jmp
 from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfilerConfig
@@ -17,7 +18,7 @@ from levanter.trainer import TrainerConfig
 from marin.execution.artifact import Artifact
 from marin.execution.build_context import resolve_version
 from marin.execution.lazy import ArtifactStep, StepContext
-from marin.experiment.cli import experiment_main
+from marin.experiment.cli import build_options
 from marin.experiment.data import mixture, tokenized
 from marin.experiment.namespacing import user_namespaced_name
 from marin.processing.tokenize.tokenize import TokenizedCache
@@ -28,31 +29,10 @@ from experiments.llama import llama3_tokenizer
 
 HERO_RUN_ID = "moe-hero-fsdp"
 HERO_STEPS = 25
-HERO_BATCH_SIZE = 1152
+HERO_FSDP_BATCH_SIZE = 1024
+HERO_NODES_PER_RACK = 16
 HERO_PROCESSES_PER_TASK = 1
 HERO_MIXED_PRECISION = "params=float32,compute=bfloat16,output=bfloat16"
-
-HERO_MODEL, HERO_OPTIMIZER = build_hero_configs(num_train_steps=HERO_STEPS, batch_size=HERO_BATCH_SIZE)
-
-HERO_GRUG_TRAINER = GrugTrainerConfig(
-    data_seed=None,
-    log_every=1,
-    ema_beta=None,
-    z_loss_weight=1e-4,
-    offload_opt_state=True,
-    expert_axis_size=1,
-    replica_axis_size=1,
-    sharding_dump_path=None,
-)
-
-HERO_TRAIN_RESOURCES = ResourceConfig.with_gpu(
-    "GB200",
-    count=4,
-    cpu=32,
-    ram="256g",
-    disk="256g",
-    replicas=16,
-)
 
 _SLIMPAJAMA_TOKENIZE_RESOURCES = ResourceConfig(ram="64g", disk="64g")
 _SLIMPAJAMA_SHUFFLE = BlockShuffleConfig(io_block_size=256, window_blocks=256, perm_type="feistel")
@@ -69,7 +49,7 @@ def _slimpajama_6b_dataset() -> ArtifactStep[TokenizedCache]:
 
 
 class HeroThroughputResult(Artifact):
-    """Metrics-only result of the throughput hero run.
+    """Metrics-only result of the rack-scale throughput hero run.
 
     The run intentionally writes no checkpoint; it only mirrors its tracker metrics to the output
     path. This artifact is a plain path ref to those metrics, so the step does not promise a
@@ -77,8 +57,31 @@ class HeroThroughputResult(Artifact):
     """
 
 
-def build_hero_run(*, version: str | None = None) -> ArtifactStep[HeroThroughputResult]:
-    """Build the fixed 64-GPU FSDP hero throughput run (metrics only, no checkpoint)."""
+def build_hero_run(*, dp_racks: int, version: str | None = None) -> ArtifactStep[HeroThroughputResult]:
+    """Build the rack-local FSDP hero throughput run."""
+    if dp_racks <= 0:
+        raise ValueError(f"dp_racks must be positive, got {dp_racks}")
+
+    batch_size = dp_racks * HERO_FSDP_BATCH_SIZE
+    model, optimizer = build_hero_configs(num_train_steps=HERO_STEPS, batch_size=batch_size)
+    grug_trainer = GrugTrainerConfig(
+        data_seed=None,
+        log_every=1,
+        ema_beta=None,
+        z_loss_weight=1e-4,
+        offload_opt_state=True,
+        expert_axis_size=1,
+        replica_axis_size=dp_racks,
+        sharding_dump_path=None,
+    )
+    train_resources = ResourceConfig.with_gpu(
+        "GB200",
+        count=4,
+        cpu=32,
+        ram="256g",
+        disk="256g",
+        replicas=HERO_NODES_PER_RACK * dp_racks,
+    )
     run_id = os.environ.get("RUN_ID") or HERO_RUN_ID
     name = f"grug/{run_id}"
     version = resolve_version(name, version)
@@ -88,15 +91,15 @@ def build_hero_run(*, version: str | None = None) -> ArtifactStep[HeroThroughput
         trainer = TrainerConfig(
             id=run_id,
             seed=0,
-            train_batch_size=HERO_BATCH_SIZE,
+            train_batch_size=batch_size,
             num_train_steps=HERO_STEPS,
             profiler=ProfilerConfig(enabled=False, start_step=8, num_steps=0),
             mp=jmp.get_policy(HERO_MIXED_PRECISION),
             tracker=WandbConfig(
                 entity="marin-community",
-                project="marin_moe",
-                tags=["grug", "moe", "hero", "fsdp", "gb200"],
-                group="moe-hero-fsdp",
+                project="rav_moe",
+                tags=["grug", "moe", "hero", "fsdp", "gb200", f"{dp_racks}rack"],
+                group=f"moe-hero-fsdp-{dp_racks}rack",
                 name=run_id,
                 replicate_path=ctx.output_path,
             ),
@@ -115,11 +118,11 @@ def build_hero_run(*, version: str | None = None) -> ArtifactStep[HeroThroughput
             ),
         )
         return GrugRunConfig(
-            model=HERO_MODEL,
+            model=model,
             data=mixture(ctx, {slim: 1.0}, shuffle=_SLIMPAJAMA_SHUFFLE),
             resources=ctx.runtime_arg("train_resources"),
-            optimizer=HERO_OPTIMIZER,
-            trainer=dataclasses.replace(HERO_GRUG_TRAINER, trainer=trainer),
+            optimizer=optimizer,
+            trainer=dataclasses.replace(grug_trainer, trainer=trainer),
             eval=None,
             processes_per_task=HERO_PROCESSES_PER_TASK,
         )
@@ -131,9 +134,16 @@ def build_hero_run(*, version: str | None = None) -> ArtifactStep[HeroThroughput
         run=run_grug,
         build_config=build_config,
         deps=(slim,),
-        runtime_args={"train_resources": HERO_TRAIN_RESOURCES},
+        runtime_args={"train_resources": train_resources},
     )
 
 
+@click.command()
+@click.option("--dp-racks", type=click.IntRange(min=1), required=True, help="Data-parallel NVL72 rack count.")
+@build_options
+def main(dp_racks: int) -> ArtifactStep[HeroThroughputResult]:
+    return build_hero_run(dp_racks=dp_racks)
+
+
 if __name__ == "__main__":
-    experiment_main(build_hero_run)()
+    main()

--- a/experiments/grug/moe_hero_fsdp/launch.py
+++ b/experiments/grug/moe_hero_fsdp/launch.py
@@ -77,9 +77,9 @@ def build_hero_run(*, dp_racks: int, version: str | None = None) -> ArtifactStep
     train_resources = ResourceConfig.with_gpu(
         "GB200",
         count=4,
-        cpu=32,
-        ram="256g",
-        disk="256g",
+        cpu=140,
+        ram="900g",
+        disk="1t",
         replicas=HERO_NODES_PER_RACK * dp_racks,
     )
     run_id = os.environ.get("RUN_ID") or HERO_RUN_ID

--- a/experiments/grug/moe_hero_fsdp/launch.py
+++ b/experiments/grug/moe_hero_fsdp/launch.py
@@ -77,8 +77,8 @@ def build_hero_run(*, dp_racks: int, version: str | None = None) -> ArtifactStep
     train_resources = ResourceConfig.with_gpu(
         "GB200",
         count=4,
-        cpu=140,
-        ram="900g",
+        cpu=120,
+        ram="850g",
         disk="1t",
         replicas=HERO_NODES_PER_RACK * dp_racks,
     )

--- a/experiments/grug/moe_hero_fsdp/launch.py
+++ b/experiments/grug/moe_hero_fsdp/launch.py
@@ -97,9 +97,8 @@ def build_hero_run(*, dp_racks: int, version: str | None = None) -> ArtifactStep
             mp=jmp.get_policy(HERO_MIXED_PRECISION),
             tracker=WandbConfig(
                 entity="marin-community",
-                project="rav_moe",
-                tags=["grug", "moe", "hero", "fsdp", "gb200", f"{dp_racks}rack"],
-                group=f"moe-hero-fsdp-{dp_racks}rack",
+                project="marin_moe",
+                tags=["grug", "moe", "hero", "fsdp", "gb200"],
                 name=run_id,
                 replicate_path=ctx.output_path,
             ),

--- a/experiments/grug/moe_hero_fsdp/launch.py
+++ b/experiments/grug/moe_hero_fsdp/launch.py
@@ -99,6 +99,7 @@ def build_hero_run(*, dp_racks: int, version: str | None = None) -> ArtifactStep
                 entity="marin-community",
                 project="marin_moe",
                 tags=["grug", "moe", "hero", "fsdp", "gb200"],
+                group="moe-hero-fsdp",
                 name=run_id,
                 replicate_path=ctx.output_path,
             ),

--- a/experiments/grug/moe_hero_fsdp/model.py
+++ b/experiments/grug/moe_hero_fsdp/model.py
@@ -47,7 +47,7 @@ from levanter.grug.grug_moe import (
     resolve_moe_implementation,
 )
 from levanter.grug.loss import BlockSizes, fused_linear_softmax_cross_entropy_loss
-from levanter.grug.sharding import Pembed_vocab, unshard
+from levanter.grug.sharding import unshard
 from levanter.tracker.histogram import Histogram, SummaryStats
 from levanter.utils.activation import ActivationFunctionEnum
 from transformers import PretrainedConfig as HfConfig
@@ -58,7 +58,10 @@ _ROUTING_RENORM_SUM = 2.5
 # v=4096 is the dominant MFU lever for the 128k vocab; the SMEM-tiled batched_xla kernel caps the
 # h*v weight tile at ~99KB and cannot take v=4096.
 _CE_BLOCK_SIZES = BlockSizes(v_block_size=4096)
-_LM_HEAD_PARTITION_SPEC = P(("replica_dcn", "data"), "model")
+# The embedding is fully replicated for a local lookup. The language-model head
+# is replicated across racks and FSDP-sharded within each rack.
+_EMBED_PARTITION_SPEC = P(None, None)
+_LM_HEAD_PARTITION_SPEC = P("data", "model")
 GRUG_MOE_MODEL_TYPE = "grug_moe"
 GRUG_MOE_ARCHITECTURE = "GrugMoeForCausalLM"
 GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY = "grugmoe_artifact_schema_version"
@@ -87,6 +90,21 @@ def _batch_spec() -> P:
 
 def _batch_reshard(x: jax.Array) -> jax.Array:
     return reshard(x, _batch_spec())
+
+
+def _embedding_gather(token_embed: jax.Array, token_ids: Int[Array, "B S"]) -> Float[Array, "B S D"]:
+    """Look up tokens from a replicated table without a cross-rack collective."""
+
+    def _local(table: jax.Array, ids: jax.Array) -> jax.Array:
+        return table[ids]
+
+    token_ids = reshard(token_ids, P(_BATCH_AXES, None))
+    return shard_map(
+        _local,
+        mesh=get_abstract_mesh(),
+        in_specs=(P(None, None), P(_BATCH_AXES, None)),
+        out_specs=P(_BATCH_AXES, None, None),
+    )(token_embed, token_ids)
 
 
 def _partition_spec_of(x: jax.Array) -> P | None:
@@ -894,7 +912,7 @@ class Transformer(eqx.Module):
 
         embed_key, out_key, embed_gn_key, final_gn_key, *block_keys = random.split(key, cfg.num_layers + 4)
         token_embed = reshard(
-            _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), cfg.initializer_std), Pembed_vocab
+            _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), cfg.initializer_std), _EMBED_PARTITION_SPEC
         )
         output_proj = reshard(
             _init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), _LM_HEAD_PARTITION_SPEC
@@ -925,17 +943,19 @@ class Transformer(eqx.Module):
             mask = AttentionMask.causal()
 
         cfg = self.config
-        hidden = self.token_embed.at[token_ids].get(out_sharding=_batch_spec())
+        hidden = _embedding_gather(self.token_embed, token_ids)
         hidden = self.embed_gated_norm(self.embed_norm(hidden))
 
         # Local layers use a sliding window; every global_every-th layer is full causal.
-        segment_ids = mask.segment_ids if isinstance(mask, AttentionMask) else None
-        if segment_ids is not None:
+        segment_ids = None
+        if isinstance(mask, AttentionMask) and mask.segment_ids is not None:
             # Pin the per-token [B, S] segment ids batch-sharded before they enter the layer-scan
-            # lax.cond. Otherwise they reach the cond as {maximal device=0} and the compiler falls
-            # back to an involuntary full-remat scatter to [num_devices, 1], which serializes through
-            # device 0 and can wedge the MoE all-to-all (collective rendezvous timeout at scale).
-            segment_ids = _batch_reshard(segment_ids)
+            # and use one array for both sides of self-attention. Resharding the original tuple
+            # separately loses object identity and adds a runtime equality conditional whose output
+            # is pinned to device 0.
+            q_segment_ids, _ = mask.segment_ids
+            q_segment_ids = _batch_reshard(q_segment_ids)
+            segment_ids = (q_segment_ids, q_segment_ids)
         short_mask = AttentionMask(is_causal=True, sliding_window=cfg.sliding_window, segment_ids=segment_ids)
         long_mask = AttentionMask(is_causal=True, sliding_window=None, segment_ids=segment_ids)
 

--- a/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
+++ b/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
@@ -19,6 +19,13 @@ from levanter.grug.attention._fa4_cute_config import Flash4CuteKernelConfig, fla
 _BATCH_AXES: tuple[str, ...] = ("replica_dcn", "data", "expert")
 
 
+def _replicate_metadata(x: jax.Array) -> jax.Array:
+    mesh = get_abstract_mesh()
+    if mesh is None or mesh.empty:
+        return x
+    return reshard(x, P(None, None))
+
+
 def _batched_segment_ids(segment_ids: jax.Array, *, batch_size: int, seq_len: int) -> jax.Array:
     if segment_ids.ndim == 1:
         if segment_ids.shape[0] != seq_len:
@@ -50,7 +57,7 @@ def _packed_segment_start_positions(
     segment_ids = _batched_segment_ids(segment_ids, batch_size=batch_size, seq_len=seq_len)
     valid = segment_ids >= 0
     starts = _segment_starts(segment_ids)
-    positions = jnp.arange(seq_len, dtype=jnp.int32)[None, :]
+    positions = _replicate_metadata(jnp.arange(seq_len, dtype=jnp.int32)[None, :])
     start_positions = jnp.where(starts, positions, 0)
     current_start: jax.Array = jax.lax.associative_scan(jnp.maximum, start_positions, axis=1)
     return jnp.where(valid, current_start, seq_len)
@@ -75,7 +82,7 @@ def _packed_segment_causal_lower_bounds(
         seq_len=seq_len,
     )
     if sliding_window is not None:
-        positions = jnp.arange(seq_len, dtype=jnp.int32)[None, :]
+        positions = _replicate_metadata(jnp.arange(seq_len, dtype=jnp.int32)[None, :])
         window_lower_bounds = positions - (sliding_window - 1)
         lower_bounds = jnp.maximum(lower_bounds, window_lower_bounds)
     return jnp.where(valid, lower_bounds, seq_len), valid
@@ -90,13 +97,13 @@ def _simple_causal_lower_bounds(
     if sliding_window is not None and sliding_window <= 0:
         raise ValueError(f"sliding_window must be positive, got {sliding_window}")
 
-    positions = jnp.arange(seq_len, dtype=jnp.int32)[None, :]
+    positions = _replicate_metadata(jnp.arange(seq_len, dtype=jnp.int32)[None, :])
     if sliding_window is None:
-        lower_bounds = jnp.zeros((1, seq_len), dtype=jnp.int32)
+        lower_bounds = _replicate_metadata(jnp.zeros((1, seq_len), dtype=jnp.int32))
     else:
         lower_bounds = jnp.maximum(positions - (sliding_window - 1), 0)
-    lower_bounds = jnp.broadcast_to(lower_bounds, (batch_size, seq_len))
-    valid = jnp.ones((batch_size, seq_len), dtype=jnp.bool_)
+    lower_bounds = _replicate_metadata(jnp.broadcast_to(lower_bounds, (batch_size, seq_len)))
+    valid = _replicate_metadata(jnp.ones((batch_size, seq_len), dtype=jnp.bool_))
     return lower_bounds, valid
 
 


### PR DESCRIPTION
* add required `--dp-racks`; set global batch to `dp_racks * 1024` and allocate 16 `GB200x4` nodes per rack
* replicate model state across `replica_dcn` and keep FSDP parameter shards and Muon Newton–Schulz on each rack's 64-GPU `data` axis
* use a local embedding gather, replicated FA4 metadata, and one batch-sharded self-attention segment array to avoid cross-rack device-0 paths
* validate two DP racks at global batch 2048
  * 32/32 tasks succeeded with no failures or preemptions
  * 487,019 tokens/s and 20.31% MFU at step 24 ([W&B](https://wandb.ai/marin-community/rav_moe/runs/moe-hero-fsdp-2rack-main-20260801-0144))
  * the run predates the final segment-array canonicalization and logged a device-0 metadata rematerialization warning
* single-rack validation with `--dp-racks 1` pending
