### PR TITLE
[grafana] Pause the training-stall alert

### DIFF
--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -461,6 +461,14 @@ groups:
         title: TrainingProgressStalled
         condition: C
         for: 5m
+        # Paused 2026-08-01. telemetry_query has no lower time bound on its
+        # phase-enrollment CTE, so it scans all of telemetry_v1 every minute; at
+        # 68M rows that saturated the finelog hub. Dropping levanter's histogram
+        # bucket export slows that namespace's growth but does not bound the scan,
+        # so the next high-volume producer reaches the same wall.
+        # Restore only once telemetry_query carries a lower time predicate or
+        # telemetry_v1 has a retention cap — not merely once ingest drops.
+        isPaused: true
         noDataState: Alerting
         execErrState: Alerting
         labels:


### PR DESCRIPTION
TrainingProgressStalled's telemetry query has no lower time bound on its
phase-enrollment CTE, so it scans all of telemetry_v1 once a minute. Levanter
router histogram bucket rows grew that namespace to 68M rows, and the scan then
saturated the finelog hub's four vCPUs: load average held at 4.2, compaction
time per hour rose from 165s to 5145s, and queries stopped completing. That
last point is why the query is absent from finelog's slow-query log after 0400
UTC, since only completed queries are logged there.

Pausing the rule returned the hub to a load average of 0.46 within five
minutes, with all four tokio workers idle and compaction back to a 334ms mean,
its pre-incident baseline. The bucket flood was still running at 24.5M rows an
hour throughout, so the scan accounted for effectively all of the load.

Already deployed as marin-grafana-00064-vgt. This commit puts main back in step
with production; without it a CD rebuild from main reverts the pause.

Restoring the rule needs a lower time predicate on telemetry_query or a
retention cap on telemetry_v1. Lower ingest alone is not enough, because the
scan stays unbounded and the next high-volume producer reaches the same wall.
Removing the bucket export is a separate change.