### PR TITLE
[telemetry] Cut telemetry_v1 volume, bound the stall scan, and restore the alert

### DIFF
--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -461,14 +461,6 @@ groups:
         title: TrainingProgressStalled
         condition: C
         for: 5m
-        # Paused 2026-08-01. telemetry_query has no lower time bound on its
-        # phase-enrollment CTE, so it scans all of telemetry_v1 every minute; at
-        # 68M rows that saturated the finelog hub. Dropping levanter's histogram
-        # bucket export slows that namespace's growth but does not bound the scan,
-        # so the next high-volume producer reaches the same wall.
-        # Restore only once telemetry_query carries a lower time predicate or
-        # telemetry_v1 has a retention cap — not merely once ingest drops.
-        isPaused: true
         noDataState: Alerting
         execErrState: Alerting
         labels:

--- a/infra/grafana/src/training_stalls.py
+++ b/infra/grafana/src/training_stalls.py
@@ -12,6 +12,11 @@ _TRAINING_STALL_AGE = timedelta(minutes=15)
 _INITIALIZING_STALL_AGE = timedelta(minutes=45)
 _TASK_STATE_LOOKBACK = timedelta(hours=1)
 _TELEMETRY_LOOKBACK = timedelta(days=1)
+# Levanter republishes `phase` every 60s, so enrollment is always recent and this
+# scan can be bounded. Unbounded, it read every telemetry_v1 row once a minute and
+# saturated the finelog hub. Keep this many multiples above that heartbeat:
+# telemetry is best-effort, and a few dropped batches must not un-enroll a live job.
+_ENROLLMENT_LOOKBACK = timedelta(minutes=15)
 
 _STEP_METRIC = "step"
 _PROGRESS_TIME_METRIC = "progress_time_seconds"
@@ -51,6 +56,7 @@ def task_state_query(now: datetime) -> str:
 def telemetry_query(now: datetime) -> str:
     """Return latest retained enrollment and bounded progress per root job."""
     start = _sql_timestamp(now - _TELEMETRY_LOOKBACK)
+    enrolled_since = _sql_timestamp(now - _ENROLLMENT_LOOKBACK)
     end = _sql_timestamp(now)
     progress_names = f"'{_STEP_METRIC}', '{_PROGRESS_TIME_METRIC}'"
     return (
@@ -60,6 +66,7 @@ def telemetry_query(now: datetime) -> str:
         "timestamp_ms, seq, to_timestamp_millis(timestamp_ms) AS ts "
         'FROM "telemetry_v1" '
         f"WHERE service = 'levanter' AND name = '{_PHASE_METRIC}' "
+        f"AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '{enrolled_since}') * 1000 AS BIGINT) "
         f"AND timestamp_ms < CAST(EXTRACT(EPOCH FROM TIMESTAMP '{end}') * 1000 AS BIGINT)"
         "), recent_progress AS ("
         "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS origin_cluster, "

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -378,12 +378,19 @@ def test_alert_queries_use_int64_epoch_boundaries_and_project_timestamps():
         assert "timestamp_ms >= TIMESTAMP" not in sql
 
 
-def test_training_stall_query_keeps_enrollment_past_the_progress_lookback():
+def test_training_stall_query_bounds_enrollment_to_the_phase_heartbeat_window():
+    """Unbounded, this CTE scanned every telemetry_v1 row once a minute.
+
+    Levanter republishes `phase` every 60s, so a live job always has an
+    enrollment row inside this window and the scan can prune by time.
+    """
     sql = telemetry_query(datetime(2026, 7, 28, 12, tzinfo=UTC))
     phase_enrollment, recent_progress = sql.split("), recent_progress AS (")
 
     assert "name = 'phase'" in phase_enrollment
-    assert "timestamp_ms >=" not in phase_enrollment
+    assert (
+        "timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '2026-07-28 11:45:00') * 1000 AS BIGINT)" in phase_enrollment
+    )
     assert "name IN ('step', 'progress_time_seconds')" in recent_progress
     assert "timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '2026-07-27 12:00:00') * 1000 AS BIGINT)" in sql
 

--- a/lib/levanter/src/levanter/tracker/telemetry.py
+++ b/lib/levanter/src/levanter/tracker/telemetry.py
@@ -6,6 +6,7 @@
 import dataclasses
 import logging
 import re
+import threading
 from collections.abc import Mapping
 from enum import IntEnum
 from time import time
@@ -39,9 +40,67 @@ def _set(name: str, value: float, *, attributes: dict[str, str] = _CURRENT) -> N
     telemetry.gauge(_metric_name(name)).set(value, attributes=attributes)
 
 
+# Keep this well under the reader's enrollment window. Telemetry is best-effort and
+# drops records under queue pressure, so several missed beats must not un-enroll a
+# live job. The reader's window lives in infra/grafana/src/training_stalls.py.
+_PHASE_HEARTBEAT_SECONDS = 60.0
+
+
+class _PhaseHeartbeat:
+    """Republishes the current training phase until the run finishes.
+
+    Stalled-training detection finds a job by its newest `phase` row. Written only
+    on transition, a job that hangs before its first step has one row, from process
+    start, and the reader must scan all of history to find it. Republishing keeps
+    that row recent so the reader can bound its scan.
+    """
+
+    def __init__(self, interval: float = _PHASE_HEARTBEAT_SECONDS) -> None:
+        self._interval = interval
+        self._lock = threading.Lock()
+        self._phase: TrainingPhase | None = None
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    @property
+    def running(self) -> bool:
+        with self._lock:
+            return self._thread is not None
+
+    def publish(self, phase: TrainingPhase) -> None:
+        with self._lock:
+            self._phase = phase
+        _set("phase", float(phase))
+
+    def start(self) -> None:
+        with self._lock:
+            if self._thread is not None:
+                return
+            self._stop.clear()
+            self._thread = threading.Thread(target=self._run, name="levanter-phase-heartbeat", daemon=True)
+            self._thread.start()
+
+    def stop(self) -> None:
+        with self._lock:
+            thread, self._thread = self._thread, None
+            self._stop.set()
+        if thread is not None:
+            thread.join(timeout=self._interval * 2)
+
+    def _run(self) -> None:
+        while not self._stop.wait(self._interval):
+            with self._lock:
+                phase = self._phase
+            if phase is not None:
+                _set("phase", float(phase))
+
+
+_HEARTBEAT = _PhaseHeartbeat()
+
+
 def set_training_phase(phase: TrainingPhase) -> None:
     """Publish the current training phase for stalled-training detection."""
-    _set("phase", float(phase))
+    _HEARTBEAT.publish(phase)
 
 
 def _as_scalar(value: Any) -> float | None:
@@ -65,6 +124,7 @@ class TelemetryTracker(Tracker):
     def __init__(self) -> None:
         _set("progress_time_seconds", 0)
         set_training_phase(TrainingPhase.INITIALIZING)
+        _HEARTBEAT.start()
 
     def _publish(self, metrics: Mapping[str, object]) -> None:
         for key, value in metrics.items():
@@ -114,6 +174,10 @@ class TelemetryTracker(Tracker):
 
     def finish(self):
         set_training_phase(TrainingPhase.FINISHED)
+        # The run is over, so there is nothing left to keep enrolled. FINISHED is
+        # already published above, and republishing it for the process's remaining
+        # lifetime tells the reader nothing new.
+        _HEARTBEAT.stop()
 
 
 @TrackerConfig.register_subclass("telemetry")

--- a/lib/levanter/src/levanter/tracker/telemetry.py
+++ b/lib/levanter/src/levanter/tracker/telemetry.py
@@ -21,7 +21,6 @@ from levanter.tracker.histogram import SummaryStats
 logger = logging.getLogger(__name__)
 
 _CURRENT = telemetry.snapshot_attributes("gauge", telemetry.CURRENT_SNAPSHOT)
-_CURRENT_HISTOGRAM = telemetry.snapshot_attributes("histogram", telemetry.CURRENT_SNAPSHOT)
 
 
 class TrainingPhase(IntEnum):
@@ -77,24 +76,23 @@ class TelemetryTracker(Tracker):
                 _set(key, scalar)
 
     def _publish_summary(self, key: str, stats: SummaryStats) -> None:
-        for field in ("mean", "min", "max", "variance", "rms"):
-            scalar = _as_scalar(getattr(stats, field))
+        """Export a summary's reduced moments as gauges."""
+        # Histogram buckets stay out. A row per bin, per metric, per step is a row
+        # count the telemetry store does not absorb — a six-layer MoE router emitted
+        # 774 a step. The W&B tracker still records the full bucket shape.
+        reduced = {
+            "mean": stats.mean,
+            "min": stats.min,
+            "max": stats.max,
+            "variance": stats.variance,
+            "rms": stats.rms,
+            "count": stats.num,
+            "sum": stats.sum,
+        }
+        for suffix, value in reduced.items():
+            scalar = _as_scalar(value)
             if scalar is not None:
-                _set(f"{key}_{field}", scalar)
-        if stats.histogram is None:
-            return
-        counts, limits = stats.histogram.to_numpy_histogram()
-        cumulative = np.cumsum(counts)
-        for index, count in enumerate(cumulative):
-            _set(
-                f"{key}_bucket",
-                float(count),
-                attributes={**_CURRENT_HISTOGRAM, "le": str(limits[index + 1])},
-            )
-        total = float(cumulative[-1]) if len(cumulative) else 0.0
-        _set(f"{key}_bucket", total, attributes={**_CURRENT_HISTOGRAM, "le": "+Inf"})
-        _set(f"{key}_count", total, attributes=_CURRENT_HISTOGRAM)
-        _set(f"{key}_sum", float(stats.sum), attributes=_CURRENT_HISTOGRAM)
+                _set(f"{key}_{suffix}", scalar)
 
     def log_hyperparameters(self, hparams: dict[str, Any]):
         pass

--- a/lib/levanter/tests/test_telemetry_tracker.py
+++ b/lib/levanter/tests/test_telemetry_tracker.py
@@ -7,6 +7,7 @@ import pytest
 from rigging import telemetry
 from rigging.testing import RecordingTelemetryTransport
 
+from levanter.tracker import telemetry as tracker_telemetry
 from levanter.tracker.histogram import SummaryStats
 from levanter.tracker.telemetry import TelemetryTracker, TrainingPhase
 
@@ -94,3 +95,36 @@ def test_training_progress_and_phase_are_current_snapshots(exported, monkeypatch
     values = _values(exported.wait_for(7))
     assert values["progress_time_seconds"] == 1234.5
     assert values["phase"] == TrainingPhase.FINISHED
+
+
+@pytest.fixture
+def fast_heartbeat(monkeypatch):
+    heartbeat = tracker_telemetry._PhaseHeartbeat(interval=0.01)
+    monkeypatch.setattr(tracker_telemetry, "_HEARTBEAT", heartbeat)
+    yield heartbeat
+    heartbeat.stop()
+
+
+def test_phase_is_republished_while_a_job_initializes(exported, fast_heartbeat):
+    """A job that hangs before its first step must stay enrolled.
+
+    Stalled-training detection finds a job by its newest `phase` row. Written
+    only on transition, an initializing job's sole row ages out of any bounded
+    window and the job goes silent exactly when it is stuck.
+    """
+    TelemetryTracker()  # never logs a step
+
+    phases = [record for record in exported.wait_for(6) if record["name"] == "phase"]
+    assert len(phases) >= 3, "phase should be republished, not written once"
+    assert all(record["value"] == TrainingPhase.INITIALIZING for record in phases)
+
+
+def test_finish_stops_the_phase_heartbeat(exported, fast_heartbeat):
+    """A finished run has nothing left to enroll, so the worker must not outlive it."""
+    tracker = TelemetryTracker()
+    exported.wait_for(4)
+    assert fast_heartbeat.running
+
+    tracker.finish()
+
+    assert not fast_heartbeat.running

--- a/lib/levanter/tests/test_telemetry_tracker.py
+++ b/lib/levanter/tests/test_telemetry_tracker.py
@@ -49,13 +49,22 @@ def test_complex_scalar_does_not_poison_valid_metrics_in_same_log_call(exported)
     assert "unsupported" not in values
 
 
-def test_summary_stats_exports_preaggregated_current_gauges(exported):
+def test_summary_stats_export_reduced_moments_and_no_histogram_buckets(exported):
+    """A row per bin, per metric, per step is what saturated the finelog hub.
+
+    The assertion is the exact exported set rather than the absence of a bucket
+    name: a reintroduced bucket row then fails as an extra key. Absence alone
+    would also pass while the buckets were merely still in flight.
+    """
     tracker = TelemetryTracker()
     values = jnp.asarray(np.linspace(0.0, 1.0, 1000))
-    tracker.log({"grad": SummaryStats.from_array(values, num_bins=4)}, step=1)
+    stats = SummaryStats.from_array(values, num_bins=64)
+    assert stats.histogram is not None, "a summary carrying no histogram would pass this vacuously"
 
-    records = exported.wait_for(10)
-    grad = [record for record in records if record["name"].startswith("grad_")]
+    tracker.log({"grad": stats}, step=1)
+    telemetry.shutdown()  # bounded flush, so the exported set below is complete
+
+    grad = [record for record in exported.records if record["name"].startswith("grad")]
     assert _values(grad) == pytest.approx(
         {
             "grad_mean": 0.5,
@@ -70,20 +79,6 @@ def test_summary_stats_exports_preaggregated_current_gauges(exported):
     )
     assert all(record["kind"] == "gauge" for record in grad)
     assert all(record["attributes"]["source_temporality"] == "current_snapshot" for record in grad)
-
-
-def test_summary_stats_does_not_export_a_row_per_histogram_bucket(exported):
-    """One row per bin, per metric, per step is what saturated the finelog hub."""
-    tracker = TelemetryTracker()
-    values = jnp.asarray(np.linspace(0.0, 1.0, 1000))
-    stats = SummaryStats.from_array(values, num_bins=64)
-    assert stats.histogram is not None, "a summary without a histogram would pass this test vacuously"
-
-    tracker.log({"grad": stats}, step=1)
-
-    records = exported.wait_for(10)
-    assert [record["name"] for record in records if record["name"].endswith("_bucket")] == []
-    assert not any("le" in record["attributes"] for record in records)
 
 
 def test_training_progress_and_phase_are_current_snapshots(exported, monkeypatch):

--- a/lib/levanter/tests/test_telemetry_tracker.py
+++ b/lib/levanter/tests/test_telemetry_tracker.py
@@ -53,13 +53,36 @@ def test_summary_stats_exports_preaggregated_current_gauges(exported):
     values = jnp.asarray(np.linspace(0.0, 1.0, 1000))
     tracker.log({"grad": SummaryStats.from_array(values, num_bins=4)}, step=1)
 
-    records = exported.wait_for(15)
-    buckets = [record for record in records if record["name"] == "grad_bucket"]
-    assert len(buckets) == 5
-    assert next(record for record in buckets if record["attributes"]["le"] == "+Inf")["value"] == 1000
-    assert all(record["kind"] == "gauge" for record in buckets)
-    assert all(record["attributes"]["source_temporality"] == "current_snapshot" for record in buckets)
-    assert _values(records)["grad_count"] == 1000
+    records = exported.wait_for(10)
+    grad = [record for record in records if record["name"].startswith("grad_")]
+    assert _values(grad) == pytest.approx(
+        {
+            "grad_mean": 0.5,
+            "grad_min": 0.0,
+            "grad_max": 1.0,
+            "grad_variance": 0.0833,
+            "grad_rms": 0.5774,
+            "grad_count": 1000,
+            "grad_sum": 500.0,
+        },
+        abs=1e-3,
+    )
+    assert all(record["kind"] == "gauge" for record in grad)
+    assert all(record["attributes"]["source_temporality"] == "current_snapshot" for record in grad)
+
+
+def test_summary_stats_does_not_export_a_row_per_histogram_bucket(exported):
+    """One row per bin, per metric, per step is what saturated the finelog hub."""
+    tracker = TelemetryTracker()
+    values = jnp.asarray(np.linspace(0.0, 1.0, 1000))
+    stats = SummaryStats.from_array(values, num_bins=64)
+    assert stats.histogram is not None, "a summary without a histogram would pass this test vacuously"
+
+    tracker.log({"grad": stats}, step=1)
+
+    records = exported.wait_for(10)
+    assert [record["name"] for record in records if record["name"].endswith("_bucket")] == []
+    assert not any("le" in record["attributes"] for record in records)
 
 
 def test_training_progress_and_phase_are_current_snapshots(exported, monkeypatch):


### PR DESCRIPTION
Two changes that together let the training-stall alert come back off the pause
applied in #7867.

TelemetryTracker._publish_summary emitted one row per histogram bin, per
metric, per step. A six-layer MoE router produced 774 rows a step, and two
training jobs on cw-us-east-08a drove telemetry_v1 from roughly zero to 24.5M
rows an hour, 90% of it bucket rows. Nothing reads them: no dashboard or alert
under infra/grafana references *_bucket, and nothing references source_kind.
Export the reduced moments plus count and sum instead. The W&B tracker still
records the full bucket shape for jobs that need the distribution.

Separately, stalled-training detection identifies a job by its newest `phase`
row, and set_training_phase wrote that row only on transition. A job that hung
before its first step had exactly one, from process start, so finding it meant
scanning all of telemetry_v1 once a minute. That saturated the finelog hub's
four vCPUs. Republish phase every 60s while a run is live, bound
phase_enrollment to a 15-minute window, and un-pause the rule.

Measured on the live hub at 302M rows, the enrollment scan costs 339ms and
touches 337 of 26.9K row groups. At 70M rows earlier the same query cost 183ms,
so the cost tracks the window rather than the namespace, which is the property
that has to hold as telemetry_v1 grows.

Bloom filters could not solve this. telemetry_v1 already has them on `name` and
they pruned 11% at a cost of 7.66s, because phase is written every step
alongside every other metric, so nearly every row group genuinely contains it.
No index prunes a value that is present everywhere; the fix has to change
either the layout or the query.

Options considered, measured against the hub rather than reasoned about:

A long lower bound with no heartbeat was the obvious cheap fix and it is the
one that fails hardest. A 7-day bound costs 16.83s today and touches 22.3K of
26.9K row groups — worse than the 5.43s unbounded scan that caused the
incident, because the namespace quadrupled in a day. A time bound only becomes
selective once retention is shorter than the window, and finelog has no
age-based row retention: StoragePolicy is local-cache eviction, where
evict_segment turns a BOTH segment into REMOTE and keeps the catalog row. The
data stays queryable from the bucket, so capping it slows scans rather than
shrinking them.

Routing control-plane metrics to their own namespace would make this alert
permanently immune to telemetry volume, and finelog's namespace boundary
already is a partition. It is not in this PR because TELEMETRY_NAMESPACE is a
hardcoded const in the Rust ingest handler, so it needs a routing concept in
the batch protocol or server-side classification, plus registration, client and
query changes.

Hive-style partitioning by `name` was rejected: `name` is high-cardinality here,
hundreds of distinct router metrics, so it would produce a swarm of tiny files
and make compaction worse.

Both halves take effect when a job starts. Runs already training keep full
alert coverage throughout, because phase is written every step; coverage for a
job hung in initialization returns as jobs restart onto the heartbeat.

Future work, none of it urgent and none of it blocking this PR:

Sorting segments by (name, timestamp_ms) during compaction is the only change
that fixes the class rather than this one query. Every other telemetry_v1
reader, the training dashboard included, still scans every row for its name
filters. finelog's schema key is a min/max band via key_bounds(), not a sort
order, so compaction would need a sort-key concept it does not have.

telemetry_v1 has no retention and grows without bound. Removing the bucket
export cuts ingest roughly tenfold, which slows the ratchet but does not stop
it, so anything that scans the namespace unbounded will eventually fail again.

_PHASE_HEARTBEAT_SECONDS and _ENROLLMENT_LOOKBACK must stay in a safe ratio but
live in packages that cannot import each other, so a comment in each is the
only thing holding them in sync. A contract test spanning both, or moving the
window into configuration the producer also reads, would make that safe.

Follow-up tracked in #7887: the four Levanter trackers each use a different
moment set when reducing a SummaryStats, and this change adds a fourth. Sharing
one FULL | MOMENTS_ONLY mode and one canonical moment set is deferred because it
renames exported metrics that W&B history and telemetry_v1 rows already carry.