### PR TITLE
[grug] Disable GPU command buffers in FSDP hero runs

### DIFF
--- a/experiments/grug/moe_hero_fsdp/README.md
+++ b/experiments/grug/moe_hero_fsdp/README.md
@@ -9,18 +9,20 @@ Launch:
 
 ```bash
 # dry-run: print the lowered plan locally, no GPUs
-python -m experiments.grug.moe_hero_fsdp.launch --dp-racks 1 --num-steps 25 --version dev
+python -m experiments.grug.moe_hero_fsdp.launch \
+  --run-id moe-hero-fsdp-test-1rack --dp-racks 1 --num-steps 25 --version dev
 
 # submit one or more racks; each rack gets 16 GB200x4 nodes and batch 1024
 RID="moe-hero-fsdp-test-2rack"
 iris --cluster=marin job run --no-wait --enable-extra-resources \
   --target-cluster cw-us-east-08a --priority interactive \
   --cpu 2 --memory 8GB --disk 32GB --timeout 5400 --job-name "${RID}-coord" \
-  -e WANDB_API_KEY "$WANDB_API_KEY" -e RUN_ID "$RID" \
-  -- python -m experiments.grug.moe_hero_fsdp.launch --dp-racks 2 --num-steps 200 --version dev --run
+  -e WANDB_API_KEY "$WANDB_API_KEY" \
+  -- python -m experiments.grug.moe_hero_fsdp.launch \
+    --run-id "$RID" --dp-racks 2 --num-steps 200 --version dev --run
 ```
 
-W&B: `marin-community/marin_moe`, group `moe-hero-fsdp`, run name `$RUN_ID`. Pass
+W&B: `marin-community/marin_moe`, group `moe-hero-fsdp`, run name `--run-id`. Pass
 `-e WANDB_PROJECT <project>` to the Iris coordinator command to use another W&B project.
 
 ## Files
@@ -66,6 +68,9 @@ W&B: `marin-community/marin_moe`, group `moe-hero-fsdp`, run name `$RUN_ID`. Pas
   tile at ~99KB and cannot take v=4096). No liger, no pure-JAX chunked CE.
 - `offload_opt_state` to pinned host; `remat_mode="recompute_all"`.
 - Runtime env baked in: `JAX_ENABLE_PGLE=1`, `XLA_PYTHON_CLIENT_ALLOCATOR=cuda_async`.
+- XLA GPU command buffers are disabled by default with `--xla_gpu_enable_command_buffer=`.
+  See [#5675](https://github.com/marin-community/marin/issues/5675) for the CUDA graph failure and
+  the plan to enable them again.
 
 ### Optimizer — MuonH
 - **Muon direction** (Newton-Schulz orthogonalization) + a **Frobenius hyperball** scale-invariant

--- a/experiments/grug/moe_hero_fsdp/launch.py
+++ b/experiments/grug/moe_hero_fsdp/launch.py
@@ -27,7 +27,6 @@ from experiments.grug.moe_hero_fsdp.heuristic import build_hero_configs
 from experiments.grug.moe_hero_fsdp.train import GrugRunConfig, GrugTrainerConfig, run_grug
 from experiments.llama import llama3_tokenizer
 
-HERO_RUN_ID = "moe-hero-fsdp"
 DEFAULT_HERO_STEPS = 25
 DEFAULT_WANDB_PROJECT = "marin_moe"
 HERO_FSDP_BATCH_SIZE = 1024
@@ -58,8 +57,12 @@ class HeroThroughputResult(Artifact):
     """
 
 
-def build_hero_run(*, dp_racks: int, num_steps: int, version: str | None = None) -> ArtifactStep[HeroThroughputResult]:
+def build_hero_run(
+    *, run_id: str, dp_racks: int, num_steps: int, version: str | None = None
+) -> ArtifactStep[HeroThroughputResult]:
     """Build the rack-local FSDP hero throughput run."""
+    if not run_id.strip():
+        raise ValueError("run_id must not be empty")
     if dp_racks <= 0:
         raise ValueError(f"dp_racks must be positive, got {dp_racks}")
     if num_steps <= 0:
@@ -86,7 +89,6 @@ def build_hero_run(*, dp_racks: int, num_steps: int, version: str | None = None)
         disk="1t",
         replicas=HERO_NODES_PER_RACK * dp_racks,
     )
-    run_id = os.environ.get("RUN_ID") or HERO_RUN_ID
     name = f"grug/{run_id}"
     version = resolve_version(name, version)
     slim = _slimpajama_6b_dataset()
@@ -143,6 +145,7 @@ def build_hero_run(*, dp_racks: int, num_steps: int, version: str | None = None)
 
 
 @click.command()
+@click.option("--run-id", required=True, help="Run identifier for artifact and W&B names.")
 @click.option("--dp-racks", type=click.IntRange(min=1), required=True, help="Data-parallel NVL72 rack count.")
 @click.option(
     "--num-steps",
@@ -152,8 +155,8 @@ def build_hero_run(*, dp_racks: int, num_steps: int, version: str | None = None)
     help="Number of training steps.",
 )
 @build_options
-def main(dp_racks: int, num_steps: int) -> ArtifactStep[HeroThroughputResult]:
-    return build_hero_run(dp_racks=dp_racks, num_steps=num_steps)
+def main(run_id: str, dp_racks: int, num_steps: int) -> ArtifactStep[HeroThroughputResult]:
+    return build_hero_run(run_id=run_id, dp_racks=dp_racks, num_steps=num_steps)
 
 
 if __name__ == "__main__":

--- a/experiments/grug/moe_hero_fsdp/train.py
+++ b/experiments/grug/moe_hero_fsdp/train.py
@@ -54,6 +54,18 @@ HERO_FSDP_RUNTIME_ENV = {
     "JAX_ENABLE_PGLE": "1",
     "XLA_PYTHON_CLIENT_ALLOCATOR": "cuda_async",
 }
+# TODO(https://github.com/marin-community/marin/issues/5675): Re-enable XLA GPU
+# command buffers after the CUDA graph failure is fixed.
+XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG = "--xla_gpu_enable_command_buffer="
+
+
+def _apply_hero_fsdp_runtime_defaults() -> None:
+    os.environ.update(HERO_FSDP_RUNTIME_ENV)
+    xla_flags = os.environ.get("XLA_FLAGS", "")
+    command_buffer_flag_name = XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG.partition("=")[0]
+    if any(flag.partition("=")[0] == command_buffer_flag_name for flag in xla_flags.split()):
+        return
+    os.environ["XLA_FLAGS"] = f"{xla_flags} {XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG}".strip()
 
 
 @dataclass(frozen=True)
@@ -634,9 +646,8 @@ def run_grug(config: GrugRunConfig) -> None:
     if trainer.id is None:
         raise ValueError("trainer.id must be set before dispatching grug training.")
 
-    # Dispatch snapshots os.environ for the child task, so apply the hero values first.
-    # These fixed recipe values intentionally override the submitter environment.
-    os.environ.update(HERO_FSDP_RUNTIME_ENV)
+    # Dispatch snapshots os.environ for the child task, so apply the hero defaults first.
+    _apply_hero_fsdp_runtime_defaults()
     dispatch_grug_training_run(
         run_id=trainer.id,
         config=config,

--- a/tests/test_moe_hero_fsdp.py
+++ b/tests/test_moe_hero_fsdp.py
@@ -1,0 +1,62 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from experiments.grug.moe_hero_fsdp import launch, train
+
+
+def test_launcher_requires_run_id():
+    result = CliRunner().invoke(launch.main, ["--dp-racks", "1", "--version", "dev"])
+
+    assert result.exit_code == 2
+    assert "Missing option '--run-id'" in result.output
+
+
+def test_build_hero_run_uses_cli_run_id(monkeypatch):
+    monkeypatch.setenv("RUN_ID", "ignored-environment-run")
+
+    step = launch.build_hero_run(
+        run_id="cli-run",
+        dp_racks=1,
+        num_steps=1,
+        version="2026.08.01",
+    )
+
+    assert step.name == "grug/cli-run"
+
+
+def test_run_grug_disables_command_buffers_and_preserves_xla_flags(monkeypatch):
+    monkeypatch.setenv("XLA_FLAGS", "--xla_gpu_enable_latency_hiding_scheduler=true")
+    config = SimpleNamespace(
+        trainer=SimpleNamespace(trainer=SimpleNamespace(id="test-run")),
+        resources=object(),
+        processes_per_task=1,
+    )
+
+    with patch.object(train, "dispatch_grug_training_run"):
+        train.run_grug(config)
+
+    assert os.environ["XLA_FLAGS"].split() == [
+        "--xla_gpu_enable_latency_hiding_scheduler=true",
+        train.XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG,
+    ]
+
+
+def test_run_grug_keeps_explicit_command_buffer_setting(monkeypatch):
+    explicit_flags = "--xla_gpu_enable_command_buffer=FUSION"
+    monkeypatch.setenv("XLA_FLAGS", explicit_flags)
+    config = SimpleNamespace(
+        trainer=SimpleNamespace(trainer=SimpleNamespace(id="test-run")),
+        resources=object(),
+        processes_per_task=1,
+    )
+
+    with patch.object(train, "dispatch_grug_training_run"):
+        train.run_grug(config)
+
+    assert os.environ["XLA_FLAGS"] == explicit_flags

--- a/tests/test_moe_hero_fsdp.py
+++ b/tests/test_moe_hero_fsdp.py
@@ -5,19 +5,10 @@ import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from click.testing import CliRunner
-
 from experiments.grug.moe_hero_fsdp import launch, train
 
 
-def test_launcher_requires_run_id():
-    result = CliRunner().invoke(launch.main, ["--dp-racks", "1", "--version", "dev"])
-
-    assert result.exit_code == 2
-    assert "Missing option '--run-id'" in result.output
-
-
-def test_build_hero_run_uses_cli_run_id(monkeypatch):
+def test_build_hero_run_uses_run_id_argument(monkeypatch):
     monkeypatch.setenv("RUN_ID", "ignored-environment-run")
 
     step = launch.build_hero_run(
@@ -30,7 +21,7 @@ def test_build_hero_run_uses_cli_run_id(monkeypatch):
     assert step.name == "grug/cli-run"
 
 
-def test_run_grug_disables_command_buffers_and_preserves_xla_flags(monkeypatch):
+def test_run_grug_applies_xla_command_buffer_default_and_keeps_override(monkeypatch):
     monkeypatch.setenv("XLA_FLAGS", "--xla_gpu_enable_latency_hiding_scheduler=true")
     config = SimpleNamespace(
         trainer=SimpleNamespace(trainer=SimpleNamespace(id="test-run")),
@@ -41,22 +32,13 @@ def test_run_grug_disables_command_buffers_and_preserves_xla_flags(monkeypatch):
     with patch.object(train, "dispatch_grug_training_run"):
         train.run_grug(config)
 
-    assert os.environ["XLA_FLAGS"].split() == [
-        "--xla_gpu_enable_latency_hiding_scheduler=true",
-        train.XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG,
-    ]
+        assert os.environ["XLA_FLAGS"].split() == [
+            "--xla_gpu_enable_latency_hiding_scheduler=true",
+            train.XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG,
+        ]
 
-
-def test_run_grug_keeps_explicit_command_buffer_setting(monkeypatch):
-    explicit_flags = "--xla_gpu_enable_command_buffer=FUSION"
-    monkeypatch.setenv("XLA_FLAGS", explicit_flags)
-    config = SimpleNamespace(
-        trainer=SimpleNamespace(trainer=SimpleNamespace(id="test-run")),
-        resources=object(),
-        processes_per_task=1,
-    )
-
-    with patch.object(train, "dispatch_grug_training_run"):
+        explicit_flags = "--xla_gpu_enable_command_buffer=FUSION"
+        monkeypatch.setenv("XLA_FLAGS", explicit_flags)
         train.run_grug(config)
 
-    assert os.environ["XLA_FLAGS"] == explicit_flags
+        assert os.environ["XLA_FLAGS"] == explicit_flags


### PR DESCRIPTION
* part of https://github.com/marin-community/marin/issues/5675
* disable XLA GPU command buffers by default for FSDP hero runs on B200 racks
  * keep explicit `--xla_gpu_enable_command_buffer=...` values in `XLA_FLAGS`
* require `--run-id` at the CLI boundary instead of `RUN_ID`
* validate the default with three sequential two-rack, 200-step runs
  * 96 of 96 worker tasks completed with zero failures, retries, or preemptions
  * mean median 468,678 tokens/s, 19.549% MFU, and 17.898 s/step
  * [run record](https://github.com/marin-community/marin/issues/5675#issuecomment-5151853988)