### PR TITLE
iris: raise dispatch promotion rate to 512

### DIFF
--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -52,6 +52,16 @@ provisioning:
     cluster: { name: marin-us-east-08a, zone: US-EAST-08A }
     kueue:
       flavor_topology: multinode-nvlink-ib  # GB200 NVL72: bind the flavor to the nvlink.domain topology
+      # East08 carries far more objects than the fleet defaults assume (16,351 Pods and
+      # 10,466 Workloads at the 2026-08-01 incident, https://echo.oa.dev/wiki/65). Kueue
+      # retains every watched Pod and Workload during startup resync, so the 2Gi default
+      # OOM-killed the manager; at 8Gi the shared 100 QPS/200 burst client limiter then
+      # delayed the leader lease past its 10s renewal deadline and the fail-closed
+      # admission webhook lost its endpoint on every restart.
+      manager_memory_limit: 8Gi
+      client_connection:
+        qps: 1000
+        burst: 2000
     ingress:
       ingress_class: traefik
       acme_email: ops@oa.dev

--- a/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
@@ -53,7 +53,7 @@ class DispatchBatch:
     running_tasks: list[RunningTaskEntry] = field(default_factory=list)
 
 
-DISPATCH_PROMOTION_RATE = 128
+DISPATCH_PROMOTION_RATE = 512
 """Token bucket capacity for task promotion (pods per minute).
 
 The direct provider relies on the Kubernetes scheduler (and the cloud


### PR DESCRIPTION
* `DISPATCH_PROMOTION_RATE` 128 → 512, the token bucket that caps how many pending tasks the controller moves to pods each minute
* at 128 this bucket, not kueue, gated large-job start on `cw-us-east-08a`: a minhash job with 3,042 pending tasks got ~135 pods/min [^1]
* the limit exists only to bound k8s API server pressure; 512 keeps that bound
* deployed to `cw-us-east-08a` ahead of this PR — running jobs went 211 → 279 in one minute, 209/209 nodes healthy, smoke job succeeded
  * no job resubmission was needed; the queued minhash job resumed on its own
* raise `cw-us-east-08a` kueue headroom to match, under `provisioning.coreweave.kueue` — `manager_memory_limit: 8Gi`, `client_connection.qps: 1000`, `client_connection.burst: 2000`
  * at 512/min the cluster reached 16,351 pods and 10,466 workloads; kueue holds every watched pod and workload through startup resync, so the manager OOM-killed at the 2Gi fleet default
  * at 8Gi the shared 100 QPS/200 burst client limiter then delayed requests up to 18.8s, past the 10s leader-renewal deadline — the manager exited `leader election lost` and the fail-closed webhook lost its endpoint on every restart
  * applied via a pulumi update targeted at the kueue helm release only (1 updated, 31 unchanged); manager came back 1/1 Ready with 0 restarts, webhook `ready=true serving=true`, no throttling or leader-loss in its logs
  * incident record: https://echo.oa.dev/wiki/65

[^1]: kueue admitted each exposed pod quickly (admitted, initializing, or under two minutes of gate wait), and showed no `FailedScheduling`, quota, or topology error. kueue cannot preempt for tasks that the controller has not yet turned into pods.