### PR TITLE
[docs] Document CoreWeave Kubernetes GPU workflows

### DIFF
--- a/.agents/skills/reserve-gpu/SKILL.md
+++ b/.agents/skills/reserve-gpu/SKILL.md
@@ -1,124 +1,75 @@
 ---
 name: reserve-gpu
-description: Reserve one or more Iris-backed CoreWeave GPU nodes (H100 or GB200) for fast debugging with dev_gpu.py.
+description: Reserve Iris-backed CoreWeave H100 or GB200 nodes with dev_gpu.py. Use for interactive GPU debugging, multi-node tests, or reconnecting to a dev GPU session.
 ---
 
-# Skill: Dev GPU
+# Dev GPU
 
-Use this skill for the standard fast GPU debugging loop without wiring a full training job each time. It is the GPU counterpart to `reserve-tpu`.
+Use a dev GPU for short interactive tests. Move to a full Iris job after the
+code works on the reserved node.
 
-`scripts/iris/dev_gpu.py` reserves CoreWeave GPU nodes through Iris, waits for the backing Kubernetes pods to come up, and `kubectl exec -it`s you into one. A whole node is an 8-GPU `h100-8x` box or a 4-GPU `gb200-4x` NVL72 tray, chosen with `--gpu-variant`. Marin's GPUs are CoreWeave Kubernetes pods, not GCE VMs, so access is `kubectl`, not SSH — there is no `ssh`/`scp` transport and no `~/.ssh/config` alias.
+`scripts/iris/dev_gpu.py` submits a holder job through Iris and uses
+`kubectl exec` internally to open a shell. It does not sync files or provide
+SSH access.
 
-This is a lean tool: `allocate`, `connect`, `status`, `release`. It does not sync files or run remote env setup (no `execute`/`watch`/`setup_env`). The CoreWeave task image is self-contained; the loop is "reserve a node, shell in." Sync those steps in yourself once connected.
+## Choose a cluster
 
-## Cost rule
+- H100: `cw-rno2a` or `cw-us-east-02a`
+- GB200: `cw-us-east-08a`
 
-A holder pod sits on an expensive whole node — 8×H100 or 4×GB200 — for the session's lifetime, and a `--nodes N` session holds N of them. Release as soon as you are done — `Ctrl-C` the `allocate` terminal, or run `release` from another shell.
-
-## Commands
-
-- `allocate`: submit a holder job, resolve the assigned pod, persist session state, block until release
-- `status`: show the active local session metadata
-- `connect`: open an interactive shell (`kubectl exec -it … -- bash -l`) into the reserved pod
-- `release`: terminate the holder job and remove the local session file
-
-## Prerequisites
-
-1. Place the cluster kubeconfig at the path the config expects. The tool passes `--kubeconfig <platform.coreweave.kubeconfig_path>` and `--context <platform.coreweave.kube_context>` to `kubectl` verbatim and fails fast if the file is absent. All CoreWeave clusters share the kubeconfig `~/.kube/coreweave-iris`; the per-cluster context (e.g. `marin-gpu_US-EAST-02A` for `cw-us-east-02a`) is pinned in the cluster yaml, per `lib/iris/docs/coreweave.md`.
-
-2. Ensure the Iris controller is running for the cluster. On the shared CoreWeave cluster this is usually already true; only start it yourself for a fresh cluster.
-
-3. Use a cluster config whose platform is CoreWeave/Kubernetes. The tool gates on this and rejects GCP/TPU configs with a pointer back to `dev_tpu.py`.
-
-## Command pattern
-
-All invocations share this shape; only the subcommand and its flags change:
+The cluster YAML files under `lib/iris/config/` are canonical. If an allocation
+is slow, or before requesting several nodes, inspect the live backend and queue:
 
 ```bash
-uv run scripts/iris/dev_gpu.py \
-  --config lib/iris/config/cw-us-east-02a.yaml \
-  --name "$USER-gpu" \
-  <subcommand> [flags]
+uv run iris --cluster=<cluster> rpc controller list-backends
+uv run iris --cluster=<cluster> rpc controller get-scheduler-state
 ```
 
-Subcommands and distinctive flags:
+## Reserve and connect
 
-- `allocate` — reserves a whole `h100-8x` node (`--gpus-per-node` defaults to `8`) and holds it until `Ctrl-C`. Add `--timeout` (default `900`) to bound the wait for the tasks to reach `RUNNING`, and `--pod-timeout` (default `120`) to bound the wait for the backing pods. Only `--gpus-per-node 8` is validated; a sub-node value schedules as a fractional share (`nvidia-smi -L` then shows fewer GPUs) but fragments the 8-GPU InfiniBand gang pool, so prefer the whole node. `--nodes N` reserves N whole nodes in one session; `--gpu-variant GB200` reserves `gb200-4x` trays instead, where a whole node is 4 GPUs.
-- `status` — show the active session (job id, config, node count, GPUs per node, and every resolved pod).
-- `connect` — interactive shell into a pod. It first checks job liveness with the controller (failing fast if the job is gone), then `kubectl exec -it`s into container `task`. On a multi-node session pass `--node N` (default `0`) to pick which pod, in `status` order.
-- `release` — terminate the holder job and clear the session file. Pass `--force` to drop local state even when the terminate call fails (then confirm the job is gone with `iris job list`).
-
-## Multi-node sessions
-
-`--nodes N` submits one Iris job with N gang-scheduled tasks, so the whole session lands
-at once or not at all. Each task is one pod on one whole node, and the pods are numbered
-in task order: `connect --node 0`, `connect --node 1`, and so on.
-
-The gang's placement follows the variant. GB200 (`gb200-4x`) gangs of up to 16 nodes bind
-hard to a single `ds.coreweave.com/nvlink.domain`, so every node shares one rack's NVLink
-fabric — the reason to reserve GB200 nodes together rather than one at a time. H100 and
-other variants get soft `leafgroup` InfiniBand colocation instead. `allocate` prints the
-level it used as `Coscheduling: …`, and you can confirm the placement from the node labels:
-
-```bash
-kubectl --kubeconfig ~/.kube/coreweave-iris --context marin-us-east-08a_US-EAST-08A \
-  get nodes -o custom-columns=NAME:.metadata.name,DOMAIN:'.metadata.labels.ds\.coreweave\.com/nvlink\.domain'
-```
-
-Multi-node sessions must reserve whole nodes, so `--gpus-per-node` has to stay at the
-variant's per-node count (GB200: 4, H100: 8). A fractional pod would let two nodes of the
-session land on the same machine, and `allocate` rejects it before submitting.
-
-## GPU JAX inside the pod
-
-The `iris-task` image ships a CPU-only `uv` environment at `/app`, so bare `python` has no JAX and `uv run python` falls back to a CPU device. To get GPU JAX (`jax[cuda13]`):
-
-```bash
-cd /app && uv sync --all-packages --extra=gpu
-```
-
-`--all-packages` is required: the `gpu` extra is defined on the sub-packages (`marin-levanter` / `marin-core`), not the root project. This is the GPU analog of `dev_tpu.py`'s `--extra=tpu`.
-
-This recipe is only exercised on H100. GB200 trays are aarch64 Grace hosts and pull a different CUDA wheel set, so treat the sync as untested there.
-
-Either way, `nvidia-smi -L` confirms what the pod actually got: 8×H100 80GB, or 4×GB200 on a `gb200-4x` tray.
-
-## Observability
-
-Use normal Iris tooling to inspect the backing cluster and holder job:
-
-```bash
-uv run iris --config=lib/iris/config/cw-us-east-02a.yaml job list --prefix /$USER/dev-gpu
-uv run iris --config=lib/iris/config/cw-us-east-02a.yaml job logs /$USER/dev-gpu-<name>
-```
-
-Inspect the pod directly with the same kubeconfig + context the tool uses:
-
-```bash
-kubectl --kubeconfig ~/.kube/coreweave-iris --context marin-gpu_US-EAST-02A \
-  --namespace iris get pods -l iris.task_id=<sanitized-task-id>
-```
-
-## Session behavior
-
-- Local session state lives under `~/.cache/marin/dev_gpu_iris/`.
-- If the `allocate` terminal dies unexpectedly, run `release` to terminate the holder job and clear the stale state file.
-- A failed `allocate` attempts cleanup on its way out: it terminates the holder job and drops the local state file only if that terminate call was accepted. An accepted terminate is not proof the pod is gone — confirm with `iris job list` when it matters. If the call fails, the state file survives, so you always keep a local record of the job id and can retry with `release`.
-- `connect` execs into the pods resolved at allocation time. If Iris rescheduled a task onto a new pod while the job stayed active, `connect` fails for that node — re-allocate.
-
-## Agent Usage
-
-Always pass `--name` to avoid collisions with other agents:
+Use a unique session name:
 
 ```bash
 export GPU_NAME="${USER}-$(git rev-parse --abbrev-ref HEAD | tr '/' '-')"
-uv run scripts/iris/dev_gpu.py --config lib/iris/config/cw-us-east-02a.yaml --name "$GPU_NAME" allocate
+export GPU_CONFIG=lib/iris/config/cw-us-east-02a.yaml
+
+uv run scripts/iris/dev_gpu.py --config "$GPU_CONFIG" --name "$GPU_NAME" allocate
+uv run scripts/iris/dev_gpu.py --name "$GPU_NAME" connect
+uv run scripts/iris/dev_gpu.py --name "$GPU_NAME" status
+uv run scripts/iris/dev_gpu.py --name "$GPU_NAME" release
 ```
 
-`allocate` blocks until Ctrl-C, so an agent has to launch it detached — and Ctrl-C cannot reach it there. A background job started from a non-interactive shell inherits `SIGINT` as ignored, so `kill -INT` does nothing and Python never raises `KeyboardInterrupt`. Release with the `release` subcommand from a second shell instead; the held `allocate` notices the dead job within 30 s, cleans up, and exits.
+`allocate` blocks until it is interrupted. An agent running it in the
+background must call `release` from another shell. Session state is stored under
+`~/.cache/marin/dev_gpu_iris/`.
 
-Its stdout is block-buffered into a redirected log, so the session summary only appears once the process exits. Read `~/.cache/marin/dev_gpu_iris/<name>.json` for live session state.
+The default is one whole H100 node. Pass `--gpu-variant GB200` for one GB200
+tray. Use `--nodes N` only when the test needs distributed topology; connect to
+each pod with `connect --node N`. Multi-node sessions require whole nodes.
 
-## Cleanup
+Run `uv run scripts/iris/dev_gpu.py <subcommand> --help` for current options
+and defaults.
 
-Normal cleanup is `Ctrl-C` in the `allocate` terminal, which only works when `allocate` is running in the foreground of a real terminal. To clean up from another shell, or from any agent-launched session, run the `release` subcommand (add `--force` only if the job is already dead and `release` keeps erroring).
+## Sharp edges
+
+- A session holds an expensive node until release. Confirm the holder job is
+  gone if cleanup reports an error.
+- `connect` uses the pod names saved at allocation. If Iris reschedules a task,
+  release and reallocate the session.
+- Kubernetes access uses `~/.kube/coreweave-iris`; each cluster YAML selects its
+  context. Do not start or restart a controller to fix access without explicit
+  user approval.
+- The task image may need GPU JAX installed with
+  `cd /app && uv sync --all-packages --extra=gpu`. This has been exercised on
+  H100; verify it on GB200.
+- Use the pod's `MARIN_PREFIX` for durable data and
+  `rigging.filesystem.marin_temp_bucket(...)` for disposable data. Do not read
+  from GCS on CoreWeave without explicit user approval because it can incur
+  egress charges.
+- Kubernetes access and object-storage access use different credentials. Task
+  pods receive storage credentials from `iris-task-env`; `dev_gpu.py` does not
+  copy the checkout's `.marin.yaml`. Never print secret values or dump the pod
+  environment.
+
+For cluster access, storage credentials, or stuck pods, read
+`lib/iris/OPS.md` and `lib/iris/docs/coreweave.md`.

--- a/docs/tutorials/cloud-gpu.md
+++ b/docs/tutorials/cloud-gpu.md
@@ -1,133 +1,97 @@
 # Training on Cloud GPUs
 
-Marin's GPU capacity is a fleet of H100 nodes in CoreWeave, reached through the
-[Iris](https://github.com/marin-community/marin/blob/main/lib/iris/OPS.md) `marin` cluster.
-You submit to `marin`, as you would for a TPU job, and Iris *federates* the job to a
-CoreWeave cluster that has the GPUs. This guide covers what you must set differently for a
-GPU run compared to a TPU one.
+Marin runs shared H100 and GB200 workloads on CoreWeave through Iris. Use
+`scripts/iris/dev_gpu.py` for short interactive tests. Submit a full Iris job
+after the code works on the reserved node.
 
-For running on a GPU you already own, see [Setting up a Local GPU
-Environment](local-gpu.md). For the anatomy of a training script, see [Training an
+For a GPU you control directly, see [Setting up a Local GPU
+Environment](local-gpu.md). For the training script itself, see [Training an
 LM](train-an-lm.md).
 
-## The clusters
+## Choose a cluster
 
-| Cluster | Hosts | Accelerators |
-| --- | --- | --- |
-| `marin` | GCP | TPU v4/v5e/v5p/v6e, CPU |
-| `cw-rno2a` | CoreWeave, Reno | H100 (8 per node) |
-| `cw-us-east-02a` | CoreWeave, US East | H100 (8 per node) |
+| Cluster | Accelerator |
+| --- | --- |
+| `cw-rno2a` | H100, 8 per node |
+| `cw-us-east-02a` | H100, 8 per node |
+| `cw-us-east-08a` | GB200, 4 per compute tray |
 
-`marin` has no GPUs of its own. It is configured with the two CoreWeave clusters as
-federation *peers*: they report the shapes they can host (`device-type=gpu`,
-`device-variant=h100`), and `marin` hands whole jobs to them. Peers have no user-facing
-endpoint — you never submit to CoreWeave directly, and `--cluster` always stays `marin`.
+The `marin` cluster federates a complete job to one of these peers. Use
+`--target-cluster` to select the peer. The [federation
+reference](https://github.com/marin-community/marin/blob/main/lib/iris/docs/federation.md)
+describes the parent/child job boundary.
 
-## Submitting a GPU job
+When choosing between the H100 clusters, inspect current availability:
+
+```bash
+uv run iris --cluster=<cluster> rpc controller list-backends
+```
+
+## Submit a job
+
+Run from the checkout root so Iris loads job-specific environment variables
+from the gitignored `.marin.yaml`:
 
 ```bash
 uv run iris --cluster=marin job run \
   --target-cluster cw-rno2a \
   --cpu=1 --memory=2G --extra=cpu \
-  -e WANDB_API_KEY "$WANDB_API_KEY" \
-  -- python -m experiments.tutorials.train_tiny_model --device h100x8 --dataset wikitext
+  -- python -m experiments.tutorials.train_tiny_model \
+    --device h100x8 --dataset wikitext --version dev --run
 ```
 
-Three things differ from a TPU submission. Each is explained below.
+The outer process and its child jobs stay on the target cluster. The tutorial
+script defines H100 device entries. Add a GB200 entry to that script, or use an
+experiment that already requests GB200, before targeting `cw-us-east-08a`.
 
-### 1. Pin the whole job with `--target-cluster`
+## Request GPU resources
 
-`--target-cluster` federates the *entire* job — the coordinator process and every sub-job
-it dispatches — to the named peer.
-
-You need it because **only a whole root job is ever federated**. A peer runs a handed-off
-job under the same job id, so it can only accept a job whose parent it also has. The
-training sub-job that `StepRunner` dispatches from inside your script is a *child* job, and
-a child never crosses the federation boundary: it runs on whatever cluster runs its parent.
-Submit the coordinator to `marin` without `--target-cluster` and its H100 sub-job is refused
-— `marin` has no GPUs, and the sub-job cannot federate on its own.
-
-The cost is that the coordinator process also occupies a CoreWeave CPU node, and a job
-pinned to CoreWeave cannot dispatch a TPU sub-job. A single experiment therefore targets
-GPUs or TPUs, not both.
-
-### 2. Keep storage on CoreWeave object storage
-
-CoreWeave task pods carry S3 credentials for CoreWeave AI Object Storage and **no GCP
-credentials at all**. A `gs://` prefix that works for a TPU run is unreadable from a GPU job.
-
-You normally do nothing here: a CoreWeave cluster already sets `MARIN_PREFIX` to
-`s3://marin-us-east-02a/marin`, the one bucket both CoreWeave clusters share, and pods read
-it through the in-cluster LOTA cache with no endpoint or credentials of your own. Override
-it only to write somewhere else under that bucket:
-
-```bash
--e MARIN_PREFIX "s3://marin-us-east-02a/scratch/my-experiment"
-```
-
-The rule that bites is that *every* artifact the run reads or writes must live under an
-`s3://` prefix, tokenized caches included. A cache a TPU run built into `gs://` is not
-reachable from a GPU run, which rebuilds it under `s3://` instead. Passing a `gs://`
-`MARIN_PREFIX` to a CoreWeave job fails on the first read.
-
-### 3. Let the GPU sub-job leave the coordinator's region
-
-A sub-job inherits the region of the worker that submitted it, which normally keeps it near
-its data. CoreWeave's peers advertise no region, so an inherited GCP region excludes every
-host that has an H100. GPU resources must opt out with `regions=[ANY_REGION]`:
+GPU tasks must allow any region because the CoreWeave peers do not advertise a
+GCP region:
 
 ```python
 from fray.types import ANY_REGION, ResourceConfig
 
-ResourceConfig.with_gpu("H100", count=8, cpu=32, disk="128G", ram="128G", regions=[ANY_REGION])
+h100 = ResourceConfig.with_gpu(
+    "H100", count=8, cpu=32, disk="128G", ram="128G", regions=[ANY_REGION]
+)
+gb200 = ResourceConfig.with_gpu(
+    "GB200", count=4, cpu=32, disk="128G", ram="128G", regions=[ANY_REGION]
+)
 ```
 
-Without it the sub-job fails at submit with `no scaling group provides device gpu:h100`,
-listing only `marin`'s local TPU and CPU groups. The `h100x1` and `h100x8` entries in
-[`experiments/tutorials/train_tiny_model.py`](https://github.com/marin-community/marin/blob/main/experiments/tutorials/train_tiny_model.py)
-already set it.
+Use one whole node or tray when practical. Raise the task replica count for a
+multi-node job.
 
-## Choosing a GPU shape
+## Keep data on CoreWeave
 
-A GPU request is a variant and a count. Unlike a TPU slice, whose VM is an atomic
-scheduling unit, GPUs pack: a 1-GPU task and a 7-GPU task can share one 8-GPU node.
+CoreWeave task pods receive `MARIN_PREFIX` and object-storage credentials from
+the cluster. Use that prefix for inputs, outputs, and caches. Use a
+lifecycle-managed path for disposable data:
 
 ```python
-ResourceConfig.with_gpu("H100", count=1, cpu=8, disk="128G", ram="64G", regions=[ANY_REGION])
-ResourceConfig.with_gpu("H100", count=8, cpu=32, disk="128G", ram="128G", regions=[ANY_REGION])
+from rigging.filesystem import marin_temp_bucket
+
+scratch = marin_temp_bucket(ttl_days=1, prefix="my-experiment")
 ```
 
-`count` is GPUs per task, up to the 8 on a node. JAX sees them as local devices in one
-process, so a single-node job needs no gang scheduling. Ask for more than 8 by raising
-`replicas`; multi-node gangs are admitted together over InfiniBand.
+Do not read or copy data from GCS while running on CoreWeave without explicit
+user approval. The transfer can incur egress charges.
 
-Keep `cpu` and `ram` within one node's share (128 vCPU and 2 TiB across 8 GPUs).
+The checkout's `.marin.yaml` supplies job-specific values such as W&B or
+Hugging Face credentials. CoreWeave object-storage access comes from the
+cluster-managed `iris-task-env` Kubernetes Secret.
 
-## Watching a run
+## Watch the job
 
 ```bash
 uv run iris --cluster=marin job logs -f /<user>/<job-name>
 uv run iris --cluster=marin job summary /<user>/<job-name>
 ```
 
-A federated job's logs are relayed from the peer back to `marin`, so `iris job logs` shows
-them without your ever connecting to CoreWeave. The relay is asynchronous and lags behind a
-log-heavy job; `job summary` reads job and task state, which is mirrored from the peer
-independently of logs, so it is the reliable answer to "is it still running".
+Logs are relayed from the CoreWeave peer. `job summary` reads the mirrored job
+state and can be more current than a busy log stream.
 
-## Verifying the run used the GPUs
-
-`train_lm` mirrors its metrics next to the run's output, under `${MARIN_PREFIX}/<name>/<version>/`.
-`tracker_metrics.jsonl` carries the device facts straight from JAX, and
-`checkpoints/eval_metrics.jsonl` the losses:
-
-| Field | Meaning |
-| --- | --- |
-| `throughput/device_kind` | `NVIDIA H100 80GB HBM3` |
-| `throughput/theoretical_flops_per_device` | 9.895e14 for one H100 |
-| `throughput/theoretical_flops` | that times the number of GPUs JAX saw |
-| `throughput/total_tokens` | `batch_size × seq_len × num_train_steps` |
-
-Pass an explicit `run_id` to `train_lm`. A run that omits it takes the last segment of its
-output path — the *version* — as its W&B run id, so every `version="dev"` run in the project
-reports into one W&B run and its mirrored summary is another run's metrics.
+After the `dev` run finishes, check
+`<MARIN_PREFIX>/users/<username>/checkpoints/tiny-wikitext-h100x8/dev/tracker_metrics.jsonl`.
+Its `summary["throughput/device_kind"]` value should name the requested accelerator.

--- a/docs/tutorials/local-gpu.md
+++ b/docs/tutorials/local-gpu.md
@@ -2,7 +2,7 @@
 
 This guide will walk you through the steps to set up a local GPU environment for Marin.
 By "local", we mean a machine that you run jobs on directly, as opposed to dispatching them to a shared cluster via [Iris](https://github.com/marin-community/marin/blob/main/lib/iris/OPS.md).
-To dispatch a GPU job to Marin's shared H100 fleet instead, see [Training on Cloud GPUs](cloud-gpu.md).
+To dispatch a GPU job to Marin's shared GPU fleet instead, see [Training on Cloud GPUs](cloud-gpu.md).
 
 ## Prerequisites
 
@@ -58,7 +58,8 @@ accepts a `--device` flag that selects the accelerator:
 ```bash
 export MARIN_PREFIX=local_store
 export WANDB_ENTITY=...
-uv run python experiments/tutorials/train_tiny_model.py --device h100x8 --dataset wikitext
+uv run python experiments/tutorials/train_tiny_model.py \
+  --device h100x8 --dataset wikitext --version dev --run
 ```
 
 `MARIN_PREFIX` sets the root directory for all outputs; it can be a local path or anything
@@ -81,5 +82,5 @@ Whereas `--device cpu` uses `ResourceConfig.with_cpu()` and a batch size of 4, `
 uses eight H100s with a larger batch. Adding a new device is one entry in the `DEVICES` dict —
 no separate file needed.
 
-To scale up, submit the same script to Marin's shared H100 fleet — see [Training on Cloud
+To scale up, submit the same script to Marin's shared GPU fleet — see [Training on Cloud
 GPUs](cloud-gpu.md), which covers the storage prefix, region, and cluster-pinning a GPU job needs.

--- a/docs/tutorials/storage-bucket.md
+++ b/docs/tutorials/storage-bucket.md
@@ -6,7 +6,10 @@ This tutorial walks through setting up a Google Cloud Storage (GCS) bucket that 
 ## When You Need This
 
 - Running local GPU or TPU experiments that write checkpoints to `gs://...` paths.
-- Launching TPU/GPU jobs on the shared [Iris](https://github.com/marin-community/marin/blob/main/lib/iris/OPS.md) cluster, where every worker streams artifacts to a shared prefix.
+- Launching TPU jobs on the shared
+  [Iris](https://github.com/marin-community/marin/blob/main/lib/iris/OPS.md)
+  cluster. CoreWeave GPU jobs use the object storage described in [Training on
+  Cloud GPUs](cloud-gpu.md).
 - Hosting tokenized datasets or compilation caches that multiple jobs should reuse.
 
 If you only run experiments locally with `local_store/` you can skip this, but migrating to GCS early prevents churn later.
@@ -126,7 +129,8 @@ trainer:
     base_path: "$BUCKET/your-run"
 ```
 
-Put personal launch defaults in `~/.config/marin/config.yaml` so every launch script uses the same location:
+For `iris job run`, put personal launch values in the gitignored `.marin.yaml`
+at the checkout root:
 
 ```yaml
 env:
@@ -135,7 +139,11 @@ env:
   WANDB_ENTITY: your-entity
 ```
 
-Use a checkout-local `.levanter.yaml` only for values that should override your personal defaults for that repository.
+The Iris CLI loads this `env` section when run from that directory. Direct SDK
+submissions and commands run from another directory do not load it. A GCS
+`MARIN_PREFIX` in this file also overrides the CoreWeave storage default. Omit
+it from checkouts that submit CoreWeave jobs, or set it only on the GCP job that
+needs it.
 
 ## Ongoing Hygiene Checklist
 

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -625,9 +625,72 @@ State dir: `gs://marin-us-central2/iris/<cluster>/state/` — contains `bundles/
 
 ## CoreWeave (GPU) Operations
 
-Always read [`docs/coreweave.md`](docs/coreweave.md) before operating a
-GPU/CoreWeave cluster. Use `lib/iris/config/coreweave-*.yaml` for CoreWeave
-cluster configs.
+[`docs/coreweave.md`](docs/coreweave.md) describes the Kubernetes architecture.
+The named `cw-*` configs in `lib/iris/config/` are the source of truth for each
+cluster's kubeconfig, context, namespace, and accelerator groups.
+
+### Access and read-only status
+
+CoreWeave configs pin a Kubernetes context, so no `kubectl config use-context`
+step is needed. The configured kubeconfig path is used unless `KUBECONFIG` is
+set in the operator shell.
+
+```bash
+CLUSTER=cw-rno2a
+
+uv run iris cluster list
+uv run iris --cluster="$CLUSTER" cluster status                 # controller and port-forward
+uv run iris --cluster="$CLUSTER" rpc controller list-backends  # accelerators, nodes, and availability
+uv run iris --cluster="$CLUSTER" cluster dashboard              # blocks until Ctrl+C
+```
+
+CoreWeave has no Iris worker daemon or Iris autoscaler. Use `list-backends`, not
+the worker count in `cluster status`, for the Kubernetes resource view.
+
+For a pending task, inspect Kueue admission and NodePool provisioning without
+rendering Pod environment values:
+
+```bash
+CW_KUBECONFIG=~/.kube/coreweave-iris
+CW_CONTEXT=<platform.coreweave.kube_context>
+CW_NAMESPACE=<kubernetes_provider.namespace>
+
+kubectl --kubeconfig "$CW_KUBECONFIG" --context "$CW_CONTEXT" -n "$CW_NAMESPACE" \
+  get pods -l iris.task_id \
+  -o custom-columns='POD:.metadata.name,PHASE:.status.phase,SCHEDULING:.status.conditions[?(@.type=="PodScheduled")].reason,NODE:.spec.nodeName'
+kubectl --kubeconfig "$CW_KUBECONFIG" --context "$CW_CONTEXT" -n "$CW_NAMESPACE" \
+  get workloads.kueue.x-k8s.io \
+  -o custom-columns='WORKLOAD:.metadata.name,QUOTA:.status.conditions[?(@.type=="QuotaReserved")].status,ADMITTED:.status.conditions[?(@.type=="Admitted")].status,REASON:.status.conditions[?(@.type=="QuotaReserved")].reason'
+kubectl --kubeconfig "$CW_KUBECONFIG" --context "$CW_CONTEXT" \
+  get nodepools.compute.coreweave.com \
+  -o custom-columns='POOL:.metadata.name,CURRENT:.status.currentNodes,QUEUED:.status.queuedNodes,IN_PROGRESS:.status.inProgressNodes,CONDITION:.status.conditions[*].type,STATUS:.status.conditions[*].status,REASON:.status.conditions[*].reason'
+```
+
+`SchedulingGated` means Kueue still holds the Pod. `QuotaReserved=True` means
+the Workload has reserved quota; check `Admitted` if the Pod remains gated.
+NodePool conditions show provisioning failures or delays. These projections
+omit Pod environment values; do not use `kubectl describe pod` on task Pods.
+
+If Iris reports that the configured context does not exist, compare the shell
+override and the canonical CoreWeave kubeconfig before changing either config:
+
+```bash
+printf 'KUBECONFIG=%s\n' "${KUBECONFIG:-<unset>}"
+rg -n 'kubeconfig_path|kube_context|namespace' "lib/iris/config/${CLUSTER}.yaml"
+kubectl --kubeconfig ~/.kube/coreweave-iris config get-contexts -o name
+
+env -u KUBECONFIG uv run iris --cluster="$CLUSTER" cluster status
+```
+
+`cluster status`, `list-backends`, `task describe`, `task events`, logs, and
+plain Kubernetes `get` calls are read-only. `kubectl describe pod` does not
+mutate the cluster, but it can print literal environment values; avoid it on
+task Pods. Starting, stopping, or restarting a cluster or controller changes
+shared infrastructure. Run those commands only with explicit user approval;
+use the
+[`deploy-iris-controllers` skill](../../.agents/skills/deploy-iris-controllers/SKILL.md)
+for controller rollouts. Direct Kubernetes changes such as `apply`, `delete`,
+`scale`, `drain`, `cordon`, and `uncordon` also require explicit approval.
 
 ### Public LoadBalancer reachability
 

--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -1,1344 +1,404 @@
-# CoreWeave Platform Integration
+# Iris on CoreWeave
 
-**Issue**: [#2822 -- Iris: Implement CoreWeave platform](https://github.com/marin-community/marin/issues/2822)
+Iris runs CoreWeave jobs directly as Kubernetes Pods. The controller does not
+start Iris worker daemons on CoreWeave. This page describes the current
+architecture and configuration boundary.
 
-## 0. Quickstart
+Use the [cloud GPU tutorial](../../../docs/tutorials/cloud-gpu.md) to run a job,
+the [federation reference](federation.md) to understand cross-cluster routing,
+and the [Iris operations guide](../OPS.md) for live diagnosis and approved
+operational changes.
 
-Zero to a running job on a CoreWeave H100 cluster. The rest of this document is
-the full operator runbook (RBAC, NodePools, Kueue, troubleshooting).
+## Quickstart
 
-Active clusters:
+The `marin` federation config lists three CoreWeave research peers:
 
-All clusters share one kubeconfig at `~/.kube/coreweave-iris`; each cluster
-config pins its own `kube_context` inside it, so iris/kubectl operations are
-context-bound per `--cluster` and never depend on the file's current-context
-or an exported `KUBECONFIG`.
+| Iris cluster | Accelerator | GPUs per node |
+| --- | --- | ---: |
+| `cw-rno2a` | H100 | 8 |
+| `cw-us-east-02a` | H100 | 8 |
+| `cw-us-east-08a` | GB200 | 4 |
 
-| Iris cluster | CW cluster / region | Fleet | Kube context |
-|--------------|---------------------|-------|--------------|
-| `cw-us-east-02a` | `marin-gpu`, US-EAST-02A | 32× 8xH100 + 4× CPU Genoa, pinned warm | `marin-gpu_US-EAST-02A` |
-| `cw-rno2a` | `marin-rn02a`, RNO2A | 64× 8xH100 + 1× CPU Turin, pinned warm | `marin-rn02a_RNO2A` |
+The table identifies configured hardware, not live free capacity. The canonical
+inventory is [`lib/iris/config/marin.yaml`](../config/marin.yaml); each peer's
+hardware and Kubernetes settings live in `lib/iris/config/<cluster>.yaml`.
 
-Console links:
-- Tokens (kubeconfig): https://console.coreweave.com/tokens
-- Cluster details: https://console.coreweave.com/zones/US-EAST-02A/clusters/marin-gpu#details
-- Health dashboard: https://cks-grafana.coreweave.com/d/cluster-health/cluster-health?var-cluster-org=208261&var-cluster=marin-gpu&var-region=US-EAST-02
-
-**1. Make a token / kubeconfig.** In the [Tokens console](https://console.coreweave.com/tokens),
-create a token and download the kubeconfig — it carries a context per cluster
-(named `<cw-cluster>_<REGION>`).
-
-**2. Install the kubeconfig** at `~/.kube/coreweave-iris`, plus controller
-extras:
+Use the [reserve-GPU skill](../../../.agents/skills/reserve-gpu/SKILL.md) for a
+short development session and the [cloud GPU
+tutorial](../../../docs/tutorials/cloud-gpu.md) for a normal Iris job. These
+commands give a read-only view of a candidate cluster:
 
 ```bash
-mkdir -p ~/.kube
-mv ~/Downloads/kubeconfig.yaml ~/.kube/coreweave-iris
-kubectl --kubeconfig ~/.kube/coreweave-iris config get-contexts   # sanity check
+CLUSTER=cw-rno2a
 
-uv pip install 'marin-iris[controller]'
+uv run iris --cluster="$CLUSTER" cluster status
+uv run iris --cluster="$CLUSTER" rpc controller list-backends
+uv run iris --cluster="$CLUSTER" cluster dashboard
 ```
 
-No `KUBECONFIG` export is needed: the cluster configs pin `kubeconfig_path` and
-`kube_context`, and every operation binds to that context explicitly.
+`list-backends` reports accelerator groups, nodes, and current availability.
+CoreWeave has no Iris worker daemon, so the worker count in `cluster status` is
+not a capacity signal. `cluster dashboard` holds a port-forward open until
+Ctrl+C.
 
-That's all a job submitter needs. `CW_KEY_ID` / `CW_KEY_SECRET` (CoreWeave
-Object Storage access keys) are only required when running
-`iris cluster start` — they seed the in-cluster `iris-task-env` Secret (see
-"Storage defaults" below).
+Controller lifecycle commands and direct Kubernetes writes change a shared
+cluster. Use the [deployment
+skill](../../../.agents/skills/deploy-iris-controllers/SKILL.md) and obtain
+explicit approval before running them.
 
-**3. Check cluster status.** `--cluster=cw-us-east-02a` resolves the in-tree
-config and opens a `kubectl port-forward` to the controller for you:
+## Connecting
+
+Operator-side Kubernetes access uses the kubeconfig and context in the selected
+cluster file. Current research configs use `~/.kube/coreweave-iris` and pin a
+context, so do not switch the file's current context.
+
+For first-time access, follow CoreWeave's [token and kubeconfig
+guide](https://docs.coreweave.com/security/authn-authz/manage-api-access-tokens)
+for each required CKS cluster. Merge the downloaded cluster, user, and context
+entries into `~/.kube/coreweave-iris`; preserve existing entries and set the
+file mode to `600`.
+
+If `cluster status` or `cluster dashboard` says the context does not exist,
+compare the configured values with the file Iris is actually reading:
 
 ```bash
-uv run iris --cluster=cw-us-east-02a cluster status
+CLUSTER=cw-rno2a
+
+printf 'KUBECONFIG=%s\n' "${KUBECONFIG:-<unset>}"
+rg -n 'kubeconfig_path|kube_context|namespace' "lib/iris/config/${CLUSTER}.yaml"
+kubectl --kubeconfig ~/.kube/coreweave-iris config get-contexts -o name
+
+env -u KUBECONFIG uv run iris --cluster="$CLUSTER" cluster status
 ```
 
-If the controller isn't up yet, start it (idempotent):
-`uv run iris --cluster=cw-us-east-02a cluster start`.
+An exported `KUBECONFIG` selects the file, while the cluster config still pins
+the context. Unset a stale override instead of copying contexts between files.
+Iris commands that target CoreWeave use a Kubernetes port-forward and loopback
+trust; they do not need `iris login`.
 
-**4. Hello world.**
+For a live access incident, continue in [CoreWeave GPU
+Operations](../OPS.md#coreweave-gpu-operations). It separates the port-forward,
+controller Service, Traefik ingress, and public LoadBalancer layers.
+
+## Architecture
+
+The control path is:
+
+1. The Iris controller runs as a Kubernetes Deployment in the cluster.
+2. `K8sTaskProvider` applies one Pod for each task attempt and reconciles Pod
+   state back into Iris.
+3. Kueue admits every task Pod. It gang-admits coscheduled jobs and applies the
+   configured topology constraints.
+4. Kubernetes places Pods on CoreWeave NodePools. CoreWeave, not Iris, manages
+   node provisioning.
+
+There is no Iris worker daemon, synthetic worker row, or Iris-managed slice on
+this path. An Iris node-agent DaemonSet publishes same-node host and GPU
+measurements to `telemetry_v1`. The cluster view retains Kubernetes readiness,
+allocatable capacity, scheduling, and Pod state; hardware history remains in
+`telemetry_v1`. `K8sTaskProvider.schedule()` and `autoscale()` are no-ops.
+Capacity and task state come from Kubernetes nodes, Pods, and Kueue workloads.
+
+GPU Pods request `nvidia.com/gpu`. On clusters with `host_network: true`, they
+also request `rdma/ib` and use `ClusterFirstWithHostNet`. Coscheduled jobs add
+Kueue topology annotations derived from
+`kubernetes_provider.kueue.topologies`, or from the CoreWeave defaults when the
+map is empty.
+
+Task logs are shipped from the node's container log file to Finelog by a
+sidecar. Process inspection and profiling run against the task container with
+`kubectl exec`; they do not call a worker service.
+
+### Federation ingress, authentication, and DNS
+
+The public controller hostname is only a federation route. DNS points it at the
+CoreWeave Traefik LoadBalancer, cert-manager issues its TLS certificate, and the
+`iris-federation-ipallowlist` middleware admits only the configured federation
+parent egress addresses. The controller then applies a second gate:
+
+- in-cluster private addresses and loopback are trusted by `auth.trusted_cidrs`;
+- off-cluster requests must carry a bearer token;
+- federation tokens are verified with the public keys in
+  `auth.federation_peers`.
+
+The allowlist and controller authentication are independent. Do not weaken one
+because the other is working. Pulumi owns Traefik, cert-manager, the Middleware,
+and Cloudflare DNS; the cluster config supplies their inputs. See the [network
+manifest builders](../src/iris/cluster/platforms/k8s/network_manifests.py), the
+[Pulumi Traefik component](../../../infra/pulumi/src/iac/coreweave/traefik.py),
+and the [federation reference](federation.md) for the handoff protocol.
+
+### GPU topology and Kueue safety
+
+H100 gangs use preferred InfiniBand leaf-group colocation. GB200 and GB300
+NVL72 gangs use stricter rack-aware placement:
+
+- an 18-node rack has 16 nodes guaranteed schedulable at once;
+- up to 16 replicas bind to one NVLink domain;
+- larger gangs require one node-saturating Pod with all four GPUs per tray, then
+  split evenly over the fewest racks with 10 to 16 replicas per rack slice.
+  Valid examples include 20, 24, 32, and 48 replicas.
+
+Invalid multi-rack shapes fail before submission rather than silently losing
+the one-slice-per-rack guarantee. The canonical arithmetic is in
+[`coreweave_topology.py`](../src/iris/cluster/platforms/k8s/coreweave_topology.py).
+
+Kueue's admission webhooks must remain scoped to the Iris task namespace. An
+unscoped fail-closed webhook can block CNI and system Pods and deadlock node
+delivery before Kueue itself starts. Pulumi pins the chart and applies the
+namespace scope in
+[`KueueAddon`](../../../infra/pulumi/src/iac/coreweave/kueue.py); do not replace
+that release with an ad hoc cluster-wide install.
+
+## Resource ownership
+
+| Resource | Owner |
+| --- | --- |
+| CKS cluster and operator kubeconfig | CoreWeave and the cluster operator |
+| Namespace, RBAC, NodePools, Kueue cluster objects, ingress, and DNS | `infra/pulumi` |
+| Kueue LocalQueue, controller ConfigMap, Deployment, Service, PDB, state volume, and Secrets | `K8sControllerProvider` |
+| Task Pods and their lifecycle | `K8sTaskProvider` |
+| Node scheduling and provisioning | Kubernetes and CoreWeave |
+
+`K8sControllerProvider.verify_prerequisites()` only checks that the
+Pulumi-owned resources exist. It does not create or repair them. Read the
+[Pulumi guide](../../../infra/pulumi/README.md) before changing that substrate;
+a destructive NodePool plan can deprovision reserved hardware.
+
+## Configuration
+
+`lib/iris/src/iris/cluster/config.py` defines the schema. The checked-in cluster
+files are the source of truth for deployed values.
+
+### Platform and controller
+
+| Field | Meaning |
+| --- | --- |
+| `platform.label_prefix` | Prefix for managed labels and NodePool names. |
+| `platform.coreweave.region` | CoreWeave region for this CKS cluster. |
+| `platform.coreweave.namespace` | Namespace used by the controller lifecycle; defaults to `iris`. |
+| `platform.coreweave.kubeconfig_path` | Operator-side kubeconfig. Current clusters use `~/.kube/coreweave-iris`. |
+| `platform.coreweave.kube_context` | Context bound to every operator-side Kubernetes call. Do not rely on the kubeconfig's current context. |
+| `platform.coreweave.object_storage_endpoint` | S3 endpoint seen by Pods inside CoreWeave. |
+| `platform.coreweave.external_object_storage_endpoint` | Endpoint for the same store when Iris runs outside CoreWeave. It falls back to the internal endpoint when empty. |
+| `controller.coreweave.port` | Controller RPC port; defaults to `10000`. |
+| `controller.coreweave.service_name` | In-cluster Service name; defaults to `iris-controller-svc`. |
+| `controller.coreweave.scale_group` | CPU scale group that hosts the controller. This is required. |
+| `controller.coreweave.ingress_class` | Ingress class used by the external federation route. |
+
+The operator kubeconfig path and context are removed before the cluster config
+is written to the in-cluster ConfigMap. The controller and task provider use
+their Kubernetes service account inside the cluster.
+
+### Kubernetes task provider
+
+| Field | Meaning |
+| --- | --- |
+| `kubernetes_provider.namespace` | Namespace for task Pods and the LocalQueue. |
+| `kubernetes_provider.service_account` | Optional service account assigned to task Pods. |
+| `kubernetes_provider.host_network` | Enables host networking and RDMA requests for GPU Pods. |
+| `kubernetes_provider.cache_dir` | Node-local cache root. CoreWeave configs use `/mnt/local/iris-cache`. |
+| `kubernetes_provider.controller_address` | In-cluster controller address injected into task Pods. |
+| `kubernetes_provider.kueue.cluster_queue` | Pulumi-owned ClusterQueue to which Iris binds its LocalQueue. This is required. |
+| `kubernetes_provider.kueue.topologies` | Optional `group_by` to CoreWeave node-label mappings. |
+| `kubernetes_provider.preempt_namespaces` | Namespaces containing provider health-check Pods that Iris may clear when they block an admitted GPU job. |
+
+An empty `kubernetes_provider.kubeconfig` means in-cluster authentication. That
+is the normal CoreWeave controller configuration.
+
+### Scale groups and NodePools
+
+Each CoreWeave scale group becomes one NodePool:
+
+| Field | Effect |
+| --- | --- |
+| `resources.device_variant` and `resources.device_count` | Accelerator identity and per-node count advertised to Iris. |
+| `resources.cpu`, `resources.ram`, and `resources.disk` | Per-node capacity recorded in the scale-group config. |
+| `buffer_slices` | Minimum node count for node-based pools. |
+| `max_slices` | Maximum node count for node-based pools. |
+| `slice_template.num_vms` | Multiplier applied to the node counts. Current CoreWeave groups use one VM per slice. |
+| `slice_template.coreweave.instance_type` | CoreWeave node SKU. |
+
+CoreWeave Console display names do not always match the Kubernetes
+`spec.instanceType`. Use the value accepted by the live NodePool API.
+
+For rack-based NVL72 SKUs, the NodePool uses `targetRacks` instead of the node
+autoscaler fields. `max_slices * num_vms` must be divisible by the 18-node rack
+size. `infra/pulumi/src/iac/nodepools.py` and
+`lib/iris/src/iris/cluster/platforms/k8s/nodepool_manifests.py` contain the
+projection rules.
+
+## CoreWeave AI Object Storage access
+
+The research clusters set `MARIN_PREFIX` to CoreWeave object storage. Use it for
+durable inputs, outputs, and caches. Use
+[`marin_temp_bucket`](../../../docs/tutorials/cloud-gpu.md#keep-data-on-coreweave)
+for disposable data with a lifecycle deadline. Do not read or copy GCS data
+from CoreWeave without explicit approval because the transfer incurs egress
+cost.
+
+The cluster config carries two endpoints for the same S3-compatible store:
+
+| Caller | Config field | Current endpoint |
+| --- | --- | --- |
+| Task or controller Pod inside CoreWeave | `platform.coreweave.object_storage_endpoint` | `http://cwlota.com` |
+| Operator process outside CoreWeave | `platform.coreweave.external_object_storage_endpoint` | `https://cwobject.com` |
+
+Both domains require virtual-hosted bucket addressing. Let Iris, Rigging, or
+[`fsutil`](../../../docs/references/fsutil.md) derive it; do not build endpoint
+URLs by hand. For operator-side access, create a CoreWeave object-storage access
+key and expose only its expected names:
 
 ```bash
-# CPU
-uv run iris --cluster=cw-us-east-02a job run \
-  --cpu 1 --memory 2GB --extra cpu \
-  -- python -c "print('Hello from CoreWeave!')"
-
-# One H100, proving JAX sees the GPU
-uv run iris --cluster=cw-us-east-02a job run \
-  --cpu 8 --memory 64GB --gpu H100x1 --enable-extra-resources --extra gpu \
-  -- python -c "import jax; print(jax.devices())"
+export CW_KEY_ID=<key-id>
+export CW_KEY_SECRET=<key-secret>
+uv run fsutil buckets
 ```
 
-Follow logs of a detached job with
-`uv run iris --cluster=cw-us-east-02a job logs <job-id> -f`.
+During a controller deployment, Iris maps these values to the S3 variables in
+`iris-task-env`. Normal task submissions then receive cluster-managed storage
+access without carrying the operator's shell environment.
 
-**Storage defaults.** CoreWeave clusters default to CoreWeave AI Object
-Storage — no per-job storage setup is needed:
+Task working directories and caches are node-local:
 
-- `MARIN_PREFIX` is preset to `s3://marin-us-east-02a/marin` (via
-  `defaults.task_env` in the cluster config) on both clusters.
-- Task pods carry the CoreWeave Object Storage S3 configuration and
-  credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
-  `AWS_ENDPOINT_URL`, `FSSPEC_S3`, ...) via the platform-managed
-  `iris-task-env` Secret, so `s3://` reads/writes work out of the box.
-- Task pods carry ONE endpoint/credential set. Data on other S3-compatible
-  stores is not reachable unless the job overrides `AWS_*`/`FSSPEC_S3` itself.
+| Container path | Kubernetes volume | Lifetime |
+| --- | --- | --- |
+| `/app`, `/tmp` | `emptyDir` | Pod |
+| `/uv/cache`, `/hf/cache`, `/cargo` | `hostPath` below `kubernetes_provider.cache_dir` | Node |
+| `/dev/shm` | memory-backed `emptyDir` | Pod |
 
-## 1. Overview
+Keep `cache_dir` on `/mnt/local`, the node's NVMe storage. The shared Hugging
+Face path is `HF_HUB_CACHE`; Iris deliberately leaves `HF_HOME` private because
+it may contain the submitter's token. HostPath caches are not durable and are
+not automatically pruned, so they can grow until the node is replaced or an
+operator cleans them. Durable outputs belong in object storage.
 
-Iris runs on CoreWeave CKS (bare-metal Kubernetes) using a shared NodePool model.
-Each Iris scale group maps to one CoreWeave NodePool with autoscaling enabled.
-CoreWeave manages node provisioning and deprovisioning; Iris manages only Pods.
-Tasks execute as independent Kubernetes Pods via `KubernetesRuntime`
-(Pod-per-task).
+`storage.local_state_dir` controls controller SQLite storage. When it is empty,
+Iris creates a controller state PVC. `storage.remote_state_dir` stores durable
+controller checkpoints in object storage.
 
-Example config: `lib/iris/config/examples/coreweave.yaml`
+## Credentials Summary
 
-## 2. Architecture
+Credentials have separate owners and scopes:
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│  CoreWeave CKS Cluster                                              │
-│                                                                     │
-│  ┌──────────────────────────────────┐                               │
-│  │  Controller Deployment           │  <-- created by               │
-│  │  (iris-controller)               │      start_controller()       │
-│  │                                  │                               │
-│  │  ghcr.io/.../iris-controller     │                               │
-│  │  port 10000                      │                               │
-│  │  in-cluster K8s auth             │  <-- ServiceAccount           │
-│  │  /etc/iris/config.json           │  <-- ConfigMap                │
-│  └────────┬─────────────────────────┘                               │
-│           │                                                         │
-│  Service: iris-controller-svc (ClusterIP:10000)                     │
-│           │                                                         │
-│  ┌────────▼─────────────────────────┐  ┌──────────────────────────┐ │
-│  │  Shared NodePool: iris-h100-8x   │  │ Shared NodePool: ...     │ │
-│  │  (one per scale group)           │  │ (one per scale group)    │ │
-│  │  instanceType: gd-8xh100ib-i128 │  │                          │ │
-│  │  autoscaling: true               │  │                          │ │
-│  │  minNodes: 0, maxNodes: N        │  │                          │ │
-│  │                                  │  │                          │ │
-│  │  Pod: iris-worker-{slice-id}     │  │  Pod: iris-worker-...    │ │
-│  │  (light: no GPU/RDMA requests)   │  │                          │ │
-│  │    ↓                             │  │                          │ │
-│  │  Pod: iris-task-{uuid}           │  │                          │ │
-│  │  (claims GPU/RDMA from device    │  │                          │ │
-│  │   plugin, hostNetwork: true)     │  │                          │ │
-│  └──────────────────────────────────┘  └──────────────────────────┘ │
-│                                                                     │
-│  All resources auto-created by `iris cluster start`:                │
-│    Namespace, ServiceAccount, ClusterRole, ClusterRoleBinding,      │
-│    ConfigMap, NodePools, Controller Deployment+Service, S3 Secret   │
-└─────────────────────────────────────────────────────────────────────┘
-```
+| Location | Scope |
+| --- | --- |
+| `~/.kube/coreweave-iris` | Operator access to CKS. It is not copied into Pods. |
+| Checkout-local `.marin.yaml` or explicit job environment | Submitter-provided values such as W&B or Hugging Face credentials. |
+| Operator `CW_KEY_ID` and `CW_KEY_SECRET` | Input used when deploying the cluster-managed object-storage Secret. |
+| `iris-task-env` Secret | Object-storage credentials and names listed in `defaults.inject_env`; mounted by the controller and task Pods. |
+| `iris-controller-env` Secret | Controller-only credentials such as the cluster signing key; task Pods do not mount it. |
+| `defaults.task_env` | Non-secret cluster defaults written into task Pod environments. |
 
-Key architectural properties:
+The Iris CLI loads `.marin.yaml` only when run from that checkout. SDK
+submissions and commands from another directory must pass their task environment
+explicitly. The deploy path rejects literal secrets before writing
+`iris-cluster-config`: references remain in the ConfigMap, while resolved values
+go through the two Secrets above.
 
-- **`CLUSTER_VIEW` `TaskBackend`**: When the cluster config sets
-  `kubernetes_provider`, the controller runs `K8sTaskProvider`
-  (`src/iris/cluster/backends/k8s/tasks.py`) — a `TaskBackend` whose
-  `capabilities` is `{CLUSTER_VIEW}`. Kueue performs scheduling and the cluster
-  autoscaler provisions nodes, so its `schedule`/`autoscale` are effectively
-  no-ops and `reconcile` only reconciles desired vs. observed Pods each tick. The
-  controller calls the same three uniform phase methods regardless. The dashboard
-  reflects this via the backend descriptor served by
-  `/auth/config`: capability `cluster` shows the **Cluster** panel, and the
-  Workers/Autoscaler panels are hidden (no worker daemons, no Iris autoscaler),
-  and per-node host and GPU readings surface in the **Cluster** panel instead.
-  See `docs/architecture.md` "The TaskBackend contract".
-- **Shared NodePool model**: One NodePool per scale group (not per slice). CoreWeave
-  autoscaling is enabled (`autoscaling: true`). NodePool names follow
-  `{label_prefix}-{scale_group_name}`. NodePools scale to zero when idle.
-- **Controller as K8s Deployment**: Created by `start_controller()`, discovered by
-  workers via in-cluster DNS (`iris-controller-svc.iris.svc.cluster.local:10000`).
-- **KubernetesRuntime (Pod-per-task)**: Task Pods claim GPU/RDMA resources directly
-  from the kubelet device plugin. Worker Pods are "light" (no GPU/RDMA requests).
-  Task Pods request `nvidia.com/gpu: N` and optionally `rdma/ib: 1`. They also
-  receive tolerations for the `nvidia.com/gpu` NoSchedule taint on GPU nodes.
-- **hostNetwork**: Both worker and task Pods use `hostNetwork: true` for RDMA/GPU
-  performance and flat-network endpoint registration. `dnsPolicy` is set to
-  `ClusterFirstWithHostNet` to preserve in-cluster DNS resolution.
-- **In-cluster auth**: The controller uses the `iris-controller` ServiceAccount.
-  No kubeconfig needed inside the cluster.
-- **Public images**: All images on `ghcr.io/marin-community/` are public. No
-  `imagePullSecrets` required.
+Do not dump Pod environments or use `kubectl describe pod` on a task Pod; literal
+job environment values can appear in the output. Inspect named keys and
+scheduling fields instead, without printing Secret values.
 
-### CoreWeave controller networking (IP-locked to marin)
+## Troubleshooting
 
-The controller Service is `ClusterIP:10000` — reachable only in-cluster or via a
-`kubectl port-forward`. CoreWeave has no user surface of its own: end users reach
-Iris through `iris.oa.dev` (IAP) and the GCP `marin` controller federates jobs
-outward, so the only external caller of a CoreWeave controller is marin. Its one
-off-cluster ingress is therefore locked to marin's egress IP — there is no
-world-open route.
-
-`marin` federates whole jobs by dialing the CoreWeave RPC surface directly (the
-pull model — CoreWeave must be reachable *inbound*; a peer behind NAT with no
-ingress is out of scope). The auth surface is two factors, both required and
-neither alone sufficient:
-
-1. **IP allowlist** — a Traefik `ipAllowList` Middleware admits only the egress IPs
-   of the marin-side controllers that federate here (`FEDERATION_ALLOW_SOURCES` in
-   `install_cw_network.py`). The *network* factor.
-2. **The controller's own auth** — the `aud="federation"` verifier for the handoff
-   RPCs, the general auth chain for the rest. The *identity* factor.
-
-Because the controller is the identity gate, it **must be enforcing** — a
-permissive (null-auth) controller behind only an IP lock hands anonymous admin over
-its whole control plane to anything from the allowlisted IP. Both CoreWeave
-controllers enforce via `auth.trusted_cidrs`: in-cluster peers (RFC1918 pods/nodes,
-loopback for `kubectl port-forward`) authenticate by network location, while an
-off-cluster request arrives through Traefik with an appended `X-Forwarded-For`,
-never matches a CIDR, and must present a bearer.
-
-CKS ships no ingress controller and no TLS issuer, and the controller's own
-ServiceAccount can't install CRDs, so an operator runs `scripts/install_cw_network.py`
-once per cluster to set up everything the controller can't do itself — Traefik,
-cert-manager, the HTTP-01 Let's Encrypt issuers, and the single IP-locked ingress
-that publishes the whole controller host to marin. It is idempotent and warns if
-pointed at a still-permissive controller; dry-run without `--apply`:
+Start with Iris's retained task view. It already joins Pod, scheduler, and Kueue
+state and remains available after Kubernetes garbage collection:
 
 ```bash
-# Traefik + cert-manager + HTTP-01 issuers + the IP-locked ingress, in one pass.
-uv run lib/iris/scripts/install_cw_network.py --cluster <name> \
-    install --acme-email you@oa.dev --allow-source <marin-egress-ip> --apply
-# Reconcile just the ingress on a cluster whose stack is already installed
-# (e.g. to flip staging->prod once the cert validates):
-uv run lib/iris/scripts/install_cw_network.py --cluster <name> install \
-    --allow-source <marin-egress-ip> --skip-traefik --skip-cert-manager --skip-issuers \
-    --cluster-issuer letsencrypt-http01-prod --apply
-# Tear it all back down (ingress, releases, namespaces, CRDs/webhooks/RBAC), verified:
-uv run lib/iris/scripts/install_cw_network.py --cluster <name> uninstall --apply
+CLUSTER=cw-rno2a
+TASK=/<user>/<job>/0
+
+uv run iris --cluster="$CLUSTER" task describe "$TASK"
+uv run iris --cluster="$CLUSTER" task events "$TASK"
+uv run iris --cluster="$CLUSTER" rpc controller list-backends
 ```
 
-The ingress is a standalone object, so applying it does **not** restart the
-controller. If CoreWeave's LoadBalancer SNATs (Traefik sees the LB, not the real
-client), pass `--xff-depth 1` so the allowlist reads the client IP from
-`X-Forwarded-For`; confirm a request from a non-allowlisted host is refused.
+`task events` records `ImagePullBackOff` and `CrashLoopBackOff` warnings. Pair it
+with `iris job logs /<user>/<job>` for task output. An `Evicted` task can
+indicate ephemeral-storage pressure. Raise the task's `disk` request only when
+its `/app`, `/tmp`, or writable container layer is full; escalate node
+`DiskPressure` instead of editing the Pod or NodePool.
 
-#### External address and DNS (`oa.dev` -> `coreweave.app`)
-
-The external address is served by Traefik's LoadBalancer, not the controller Pod.
-CoreWeave publishes a wildcard record, `*.<tenant>.coreweave.app`, that resolves to
-that LoadBalancer. `install_cw_network.py install --apply` prints the exact CNAME
-record to create, substituting the ingress host's first label into the wildcard
-(`iris-cw-<cluster>.oa.dev  CNAME  iris-cw-<cluster>.<tenant>.coreweave.app`); `oa.dev`
-DNS is at Cloudflare, as a DNS-only (not proxied) record. Routing, Host matching, and TLS all
-key on the `oa.dev` name; `coreweave.app` is only the CNAME target.
-
-TLS terminates in-cluster (no IAP/edge layer; the record is DNS-only, so Cloudflare never
-proxies or intercepts TLS).
-`install_cw_network.py` creates HTTP-01 Let's Encrypt ClusterIssuers
-(`letsencrypt-http01-staging`, `letsencrypt-http01-prod`) validated through
-Traefik — CoreWeave's bundled issuers only cover `*.coreweave.app` (DNS-01 via
-`acme.coreweave.com`), so a custom `oa.dev` host needs these. HTTP-01 needs the
-CNAME live first (Let's Encrypt fetches `http://<host>/.well-known/...`); issue with
-the staging issuer first to avoid LE rate limits, then re-run with
-`--cluster-issuer letsencrypt-http01-prod`. cert-manager's HTTP-01 solver runs on
-its own unrestricted Ingress, so the IP allowlist does not block ACME validation.
-
-**Verify from the marin controller VM:**
-
-- `ListBackends` **with** the federation JWT from the allowlisted egress IP -> succeeds.
-- the same call **without** the JWT (controller enforcing) -> `UNAUTHENTICATED`.
-- the same call from a **non-allowlisted IP** -> refused (`403`).
-
-#### Stable egress IPs for the marin controllers
-
-The allowlist names each federating controller by address, so every one of them
-needs a **stable** egress IP: `iris-controller-marin` and `iris-controller-marin-dev`,
-reserved as `iris-marin-fed-egress` and `iris-marin-dev-fed-egress`. A controller's
-GCE VM (zone `us-central1-a`, project `hai-gcp-models`) is created with an
-*ephemeral* external IP, which changes on stop/start. Make it stable **without
-touching the VM** by promoting that in-use address to a reserved static IP — same
-address, no access-config change, no restart:
+For a Pending task, use these read-only Kubernetes checks when the Iris message
+is not enough. Read the kubeconfig, context, and namespace from the cluster
+config rather than copying the example values:
 
 ```bash
-PROJECT=hai-gcp-models ZONE=us-central1-a REGION=us-central1 VM=iris-controller-marin
-# 1. Read the VM's current external IP.
-EGRESS_IP=$(gcloud compute instances describe "$VM" --project "$PROJECT" --zone "$ZONE" \
-  --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
-echo "marin controller egress IP: $EGRESS_IP"
-# 2. Promote that exact IP to a reserved static address (idempotent; no VM change,
-#    no connectivity drop — the VM keeps the same address).
-gcloud compute addresses create iris-marin-fed-egress --project "$PROJECT" \
-  --region "$REGION" --addresses "$EGRESS_IP"
+KUBECONFIG=~/.kube/coreweave-iris
+CONTEXT=<platform.coreweave.kube_context>
+NAMESPACE=<kubernetes_provider.namespace>
+
+kubectl --kubeconfig "$KUBECONFIG" --context "$CONTEXT" get nodepool -o wide
+kubectl --kubeconfig "$KUBECONFIG" --context "$CONTEXT" -n "$NAMESPACE" \
+  get pods,workloads.kueue.x-k8s.io -o wide
+kubectl --kubeconfig "$KUBECONFIG" --context "$CONTEXT" -n "$NAMESPACE" \
+  get workload <workload-name> \
+  -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
 ```
 
-Add `$EGRESS_IP` to `FEDERATION_ALLOW_SOURCES`, which is what `--allow-source`
-defaults to. The Middleware's `sourceRange` is replaced wholesale on every install
-rather than merged, so an install naming a subset strands the omitted controller at
-a `403` the peer never logs. Reserving an in-use address is safe and reversible
-(`gcloud compute addresses delete iris-marin-fed-egress` releases it back to
-ephemeral). **Alternative** (only if the controller is later moved to
-IAP-only inbound with *no* external IP, so egress goes through Cloud NAT): reserve
-a regional static IP and pin Cloud NAT to it (`gcloud compute routers nats update
-… --nat-external-ip-pool=iris-marin-fed-egress`). Removing the VM's external IP is
-a larger change — do it only with explicit approval, never as a side effect here.
-
-## 3. Tools
-
-### CoreWeave Intelligent CLI (`cwic`)
-
-CoreWeave provides `cwic` for cluster-level operations beyond standard `kubectl`:
-
-- `cwic auth login` — Authenticate to CoreWeave
-- NodePool upgrades and rollback (`cwic rollback`)
-- Object storage bucket management
-
-See [CoreWeave CLI docs](https://docs.coreweave.com) for installation.
-
-### kubectl
-
-Standard Kubernetes operations. CoreWeave adds the `NodePool` CRD
-(`compute.coreweave.com/v1alpha1`):
-
-```bash
-kubectl get nodepool                    # List pools (TARGET vs CURRENT)
-kubectl describe nodepool <name>        # Check conditions (Valid, AtTarget)
-kubectl get pods -n iris                # List Iris Pods
-kubectl describe pod <name> -n iris     # Check scheduling / pull events
-kubectl logs <pod> -n iris              # Read Pod logs
-kubectl get nodes --show-labels         # Verify GPU node labels
-```
-
-### CoreWeave Observe (Managed Grafana)
-
-Free, fully-managed Grafana included with every CKS cluster. Pre-configured
-dashboards for CKS (control plane, Pods), Fleet (node/resource trends),
-and Network (traffic, latency). No setup required.
-
-Kubernetes Events and deleted Pod objects are short-lived. For actor-level
-history, use CoreWeave's
-[Kubernetes Audit Logs dashboard](https://docs.coreweave.com/observability/managed-grafana/cks/kubernetes-audit-logs)
-or the regional Loki API. CKS audit logs have dedicated regional data sources;
-CoreWeave documents that some log types expire after two weeks. Use the regional
-source for detailed incident queries:
-
-```bash
-KUBE_CONFIG=~/.kube/coreweave-iris
-KUBE_CONTEXT=marin-rn02a_RNO2A
-CW_CLUSTER=marin-rn02a
-AUDIT_HOST=https://observe-audit.us-west.coreweave.com
-POD_NAME=iris-example-0
-START=2026-07-25T21:20:00Z
-END=2026-07-25T21:35:00Z
-
-CW_OBSERVE_TOKEN=$(kubectl --kubeconfig "$KUBE_CONFIG" --context "$KUBE_CONTEXT" \
-  config view --raw --minify -o jsonpath='{.users[0].user.token}')
-curl -sS -G "$AUDIT_HOST/loki/api/v1/query_range" \
-  -H "Authorization: Bearer $CW_OBSERVE_TOKEN" \
-  --data-urlencode \
-  "query={logging_component=\"unicaster\", app=\"kube-apiserver\", stream=\"\", cluster=\"$CW_CLUSTER\"} |= \"$POD_NAME\" | json | apiVersion=\"audit.k8s.io/v1\"" \
-  --data-urlencode "start=$START" \
-  --data-urlencode "end=$END" \
-  --data-urlencode "limit=1000"
-unset CW_OBSERVE_TOKEN
-```
-
-Use `observe-audit.us-east.coreweave.com` for US-EAST and
-`observe-audit.us-west.coreweave.com` for RNO2A/US-WEST. Filter the results by
-`objectRef.name`, `verb`, and `user.username` to distinguish Iris cleanup from
-Kueue, kubelet, or an operator. The kubeconfig token is also the CoreWeave API
-access token; never print it or save the response with request headers.
-
-CoreWeave's audit store is the actor-level record of Kubernetes API operations.
-[Telemetry Relay](https://docs.coreweave.com/observability/telemetry-forwarding/relay)
-can forward those logs to customer-controlled storage. `iris.task_event` is a
-different view: a retained, task-scoped interpretation of backend verdicts and
-controller decisions. The Kubernetes Grafana dashboard shows recent
-`iris.task_event` rows beside the API server's shorter-lived Warning events.
-
-## 4. Operator Setup Guide
-
-§0 is the quickstart for the `marin-gpu` cluster. This section is the generic
-operator reference (any `--cluster=NAME`) and the lifecycle details behind it.
-
-### Prerequisites
-
-- A CoreWeave CKS cluster (created via Console or Terraform)
-- A kubeconfig downloaded from CoreWeave Console > Tokens (see §0)
-- Images pushed to `ghcr.io/marin-community/`
-- Controller extras: `uv pip install 'marin-iris[controller]'`
-
-CoreWeave clusters default to CoreWeave AI Object Storage, and the cluster configs
-give two endpoints for it. `object_storage_endpoint: http://cwlota.com` is LOTA, the
-in-cluster cache, which pods use. `external_object_storage_endpoint:
-https://cwobject.com` reaches the same buckets from an operator's own machine, which
-`iris` uses for its own S3 calls — among them the rollout record that
-`iris cluster controller restart` reads. LOTA's name resolves to a private address,
-so both fields are needed on a cluster an operator drives from outside.
-
-Export `CW_KEY_ID` / `CW_KEY_SECRET` (CoreWeave Object Storage access keys) before
-`iris cluster start`; it folds them — plus the derived
-endpoint/region/`FSSPEC_S3` config — into the `iris-task-env` Secret, projected
-into the controller and task pods via `envFrom`. From then on every task has
-working S3 credentials embedded; job submitters never handle storage keys.
-
-> **Note**: CoreWeave AI Object Storage (`cwobject.com`, `cwlota.com`) uses
-> virtual-hosted-style S3 addressing, which is auto-detected and configured
-> (including JAX/tensorstore checkpointing).
-
-### CoreWeave AI Object Storage access
-
-Use `s3://marin-us-east-02a` for CoreWeave-local object storage — it is the
-shared bucket for both clusters, and `MARIN_PREFIX` is preset to
-`s3://marin-us-east-02a/marin` in every task. **Inside the cluster none of the
-setup below is needed**: task pods already carry the endpoint, addressing
-style, and credentials (see "Storage defaults" in §0). The rest of this
-section is for access from *outside* CoreWeave (laptop, GCP). The bucket is
-browsable in the
-[CoreWeave console](https://console.coreweave.com/object-storage/buckets/marin-us-east-02a).
-`uv run fsutil` browses these buckets alongside the GCS ones and needs only the
-credentials below; see the [fsutil reference](../../../docs/references/fsutil.md).
-For direct S3 tooling, follow CoreWeave's
-[endpoint](https://docs.coreweave.com/products/storage/object-storage/using-object-storage/configure-endpoints)
-and
-[object-management](https://docs.coreweave.com/products/storage/object-storage/using-object-storage/manage-objects)
-docs; Marin-specific settings are:
-
-- Credentials: create an Object Storage access key in the
-  [CoreWeave console](https://console.coreweave.com/object-storage/access-keys);
-  use the Key ID as `CW_KEY_ID` and the Key secret as `CW_KEY_SECRET`.
-- Endpoint: `https://cwobject.com` outside CoreWeave, `http://cwlota.com`
-  inside CoreWeave.
-- Region: `US-EAST-02A`.
-- Addressing: `s3.addressing_style = virtual`; path-style requests are not
-  supported.
-
-One-off AWS CLI check, without persistent AWS config:
-
-```bash
-export CW_KEY_ID=<your-coreweave-object-storage-key-id>
-export CW_KEY_SECRET=<your-coreweave-object-storage-key-secret>
-
-tmp_config="$(mktemp)"
-trap 'rm -f "$tmp_config"' EXIT
-
-cat >"$tmp_config" <<'EOF'
-[default]
-s3 =
-    addressing_style = virtual
-EOF
-
-AWS_CONFIG_FILE="$tmp_config" \
-AWS_ACCESS_KEY_ID="$CW_KEY_ID" \
-AWS_SECRET_ACCESS_KEY="$CW_KEY_SECRET" \
-AWS_REGION=US-EAST-02A \
-AWS_ENDPOINT_URL_S3=https://cwobject.com \
-AWS_PAGER="" \
-aws s3 ls s3://marin-us-east-02a/
-```
-
-### Lifecycle
-
-```bash
-iris --cluster=<name> cluster start      # idempotent; reconciles everything below
-iris --cluster=<name> cluster status
-iris --cluster=<name> cluster dashboard
-iris --cluster=<name> cluster stop       # deletes Pods + controller; NodePools survive
-```
-
-`cluster start` creates/reconciles, in order:
-
-1. Namespace (`iris`) and RBAC (ServiceAccount, ClusterRole, ClusterRoleBinding)
-2. S3 credentials Secret (if S3 storage URIs are configured)
-3. ConfigMap (`iris-cluster-config`) with the cluster config as JSON
-4. Shared NodePools (one per scale group, in parallel)
-5. Controller Deployment (`iris-controller`) — images are built and pushed automatically
-6. Controller Service (`iris-controller-svc`, ClusterIP)
-
-`cluster stop` leaves NodePools in place; they scale to zero when idle (but
-still bill — see the NodePool cleanup under §4 Gotchas).
-
-### Kueue (gang admission + TAS)
-
-Multi-host GPU jobs are gang-admitted (all-or-nothing) by Kueue's plain-Pod
-integration, with Topology-Aware Scheduling placing gangs on the InfiniBand
-fabric. Install per cluster with:
-
-```bash
-uv run python lib/iris/scripts/install_kueue.py --variant coreweave \
-  --kubeconfig <kubeconfig> --with-queues --apply
-```
-
-This installs the CoreWeave `cks-kueue` chart, the Topology CRs, the
-cluster-scoped `cw-ib` + `cw-cpu` ResourceFlavors, and the `iris-cq` ClusterQueue.
-Iris reconciles its namespaced LocalQueue (`{label_prefix}-lq`) at controller
-start, bound via `kubernetes_provider.kueue.cluster_queue`.
-
-**Flavor routing.** Every pod on the k8s backend routes through Kueue (not just
-gangs), so `iris-cq` carries two flavors in one resourceGroup:
-
-- **`cw-ib`** selects InfiniBand nodes (`backend.coreweave.cloud/flavor=infiniband`)
-  and binds the `infiniband` Topology for TAS. GPU pods request `nvidia.com/gpu` +
-  `rdma/ib` and match here.
-- **`cw-cpu`** (listed first) zeroes the `nvidia.com/gpu` and `rdma/ib` quota, so a
-  GPU pod can never be admitted under it and falls through to `cw-ib`, while a
-  CPU-only pod matches `cw-cpu`. It is **selector-less** by default — its spec is
-  empty, so Kueue injects no `nodeSelector` and the admitted CPU pod stays
-  schedulable on any node. It prefers CPU nodes (GPU nodes carry a soft
-  `PreferNoSchedule` taint) but reuses idle GPU nodes when CPU capacity is full,
-  instead of being fenced onto CPU-only capacity. Pass `--cpu-flavor-node-label
-  KEY=VALUE` to pin `cw-cpu` to specific CPU nodes instead.
-
-**GB200 NVLink-domain placement.** NVL72 nodes (GB200/GB300, `gb200-4x` — 4
-Blackwell GPUs each) carry `ds.coreweave.com/nvlink.domain`; one NVL72 rack is one
-NVLink domain of 18 physical nodes, of which CoreWeave keeps only **16 schedulable
-at once** (the rest absorb host failures and maintenance — a floor, not a cap).
-Iris picks a placement level per multi-node GB200 gang from its replica count:
-
-- **≤ 16 nodes** bind **hard** to a single `nvlink.domain`
-  (`podset-required-topology`) — the whole gang shares one rack's NVLink fabric.
-  16 is the largest hard single-domain gang; binding a 17–18-node gang hard would
-  demand a fully-healthy rack and could sit unschedulable whenever one is short a
-  node.
-- **> 16 nodes** use Kueue **PodSet slices** (`podset-slice-required-topology:
-  nvlink.domain` + a computed `podset-slice-size`). The gang is split evenly over
-  the fewest racks that hold ≤ 16 nodes each, and each slice is hard-bound to its
-  own NVLink domain, so it lands as an exact **balanced N-rack layout**: 24 → 12+12,
-  32 → 16+16, 48 → 16+16+16. Because two slices always exceed a rack (each is more
-  than half of 18), no two share a rack. A soft `leafgroup` preference is paired so
-  the racks also cluster on one IB leaf group.
-
-The sliced level requires **node-saturating pods** (one pod = one whole `gb200-4x`
-node = 4 GPUs) so a slice fills whole nodes, and a gang size that splits into equal,
-more-than-half-a-rack slices — sizes that cannot (e.g. 17, 18, 40) are rejected at
-submit. PodSet slices need **Kueue ≥ 0.13**; use **0.18+** for the `IsTAS()`
-recognition fix for slice-only pod groups (upstream #10282). On an older Kueue the
-slice annotations are silently ignored and a multi-rack gang degrades to a soft
-leafgroup gang with no per-rack NVLink guarantee.
-
-**Never install Kueue with unscoped admission webhooks on a CoreWeave cluster.**
-The script scopes them to the `iris` namespace (`--pod-namespace`); the chart
-default intercepts pod CREATEs in every namespace fail-closed, including the
-cilium CNI pods on freshly delivered nodes — if the Kueue manager is down (e.g.
-zero-node cluster), the node can never start its CNI, never goes Ready, and the
-manager can never schedule: node delivery deadlocks cluster-wide. Details in
-`install_kueue.py`'s module docstring.
-
-On a zero-node cluster the install's controller-rollout wait times out (the
-manager has nowhere to schedule) — provision the controller node first, or
-re-run the install after it is Ready.
-
-### Bringing up a new cluster (end-to-end rollout runbook)
-
-The ordered sequence to take a fresh CKS cluster to a reachable, federated,
-log-forwarding Iris cluster. `cw-us-east-08a` (a GB200 NVL72 fleet) is the worked
-example; substitute your `<cluster>`. Steps marked **(console)** or **(manual)**
-are the only ones not driven from a repo checkout on the cluster's branch — an
-operator does them in the CoreWeave console or the DNS registrar.
-
-**One-time prerequisites**
-
-- **(console)** CKS cluster created (Console or Terraform). Kubeconfig from
-  Console > Tokens installed at `~/.kube/coreweave-iris`; the context is
-  `<cks-name>_<REGION>` (e.g. `marin-us-east-08a_US-EAST-08A`).
-- **(console)** Object-storage bucket created (Console or `cwic`) and an Object
-  Storage access key: `export CW_KEY_ID=… CW_KEY_SECRET=…`.
-- Local tooling: `uv pip install 'marin-iris[controller]'`; `docker login
-  ghcr.io` with a `write:packages` PAT (`cluster start` builds + pushes images);
-  `gcloud auth application-default login` (ADC — `init-keys` and the deploy-time
-  `gcp-secret://` resolution read Secret Manager through it).
-
-**1. Write the cluster config.** Copy an existing `lib/iris/config/cw-*.yaml` and
-adjust `name`, region, `platform.coreweave.kube_context`, the CKS
-`provisioning.coreweave.cluster.name`, scale groups, and fleet sizes. The console
-capacity view's display label is NOT the k8s `spec.instanceType` (e.g.
-"turin-gp-l4" vs `turin-gp-l`); to probe a SKU, create a NodePool with `minNodes:
-0, maxNodes: 0, targetNodes: 0` and read its `Validated` condition (server
-dry-run accepts any string). For a reserved/prepaid fleet set `buffer_slices ==
-max_slices` — there is nothing to save by autoscaling it down. GB200 NVL72
-deploys in whole racks of 18, so a rack pool's node count must be a multiple of
-18.
-
-**2. Provision the static prerequisites (IaC).** The `infra/pulumi` Pulumi program
-declares the namespace, controller RBAC, the reserved NodePools, and the whole
-cluster-scoped Kueue substrate (`cks-kueue` release, Topology CRs, `cw-ib`
-ResourceFlavor, `iris-cq` ClusterQueue, `iris-system` PriorityClass) from the
-`provisioning:` section of the config. See `infra/pulumi/README.md`. (Pre-IaC path:
-`install_kueue.py --with-queues` for Kueue and let `cluster start` create the
-RBAC + NodePools.)
-
-**3. Mint the controller signing key.** The cluster's identity — signs every
-worker/proxy token it mints.
-
-```bash
-uv run iris cluster init-keys \
-  --gcp-secret projects/<project-number>/secrets/iris-<cluster>-signing-key
-```
-
-Creates the secret and stores the private key as **version 1**; pin that version
-in `auth.signing_key` alongside the `env:IRIS_SIGNING_KEY` marker. The
-credential-less controller pod never reads Secret Manager: at deploy time the
-operator's shell resolves the `gcp-secret://` ref and projects it into the
-`iris-controller-env` Secret. `--rotate` replaces it later.
-
-**4. Start the controller.**
-
-```bash
-export CW_KEY_ID=… CW_KEY_SECRET=…
-uv run iris --cluster=<cluster> cluster start
-uv run iris --cluster=<cluster> cluster status
-```
-
-Builds + pushes the controller/worker/task images, then applies (idempotently)
-the `iris-cluster-config` ConfigMap, the `iris-task-env` + `iris-controller-env`
-Secrets, the namespaced LocalQueue (`{label_prefix}-lq`), the controller
-Deployment + Service + PDB, and waits for rollout. Needs a Ready controller-pool
-node (the `cpu-*` scale group); on a still-delivering cluster the Deployment
-stays Pending until one lands.
-
-**5. Install the network stack, then the DNS record.** Publishes the controller
-off-cluster behind an IP-locked ingress.
-
-```bash
-uv run lib/iris/scripts/install_cw_network.py --cluster <cluster> \
-  install --acme-email <ops-email> --apply           # staging cert first
-```
-
-Installs Traefik + cert-manager + the HTTP-01 Let's Encrypt issuers + the
-federation `Ingress` (Traefik `ipAllowList` admitting only marin's egress IPs).
-Read the CNAME target off the Traefik LoadBalancer's `*.coreweave.app` wildcard:
-
-```bash
-kubectl get svc traefik -n traefik \
-  -o=jsonpath='{.status.conditions[?(@.type=="ExternalRecords")].message}'
-```
-
-**(manual)** Create the record in the `oa.dev` registrar (**Cloudflare**, DNS-only — do not
-enable the proxy):
-
-```
-iris-cw-<cluster>.oa.dev   CNAME   iris-cw-<cluster>.<tenant>.coreweave.app
-```
-
-The CNAME must be live before TLS issuance (HTTP-01 validates through Traefik).
-Once it resolves and the staging cert validates, flip to the prod issuer:
-
-```bash
-uv run lib/iris/scripts/install_cw_network.py --cluster <cluster> install \
-  --cluster-issuer letsencrypt-http01-prod \
-  --skip-traefik --skip-cert-manager --skip-issuers --apply
-```
-
-**6. Register federation (hub → cluster).** So marin/marin-dev can route jobs in.
-Add an address-only peer entry (no key — the cluster already trusts the hubs via
-its own `auth.federation_peers`) under `peers:` in both `lib/iris/config/marin.yaml`
-and `lib/iris/config/marin-dev.yaml`:
-
-```yaml
-  <cluster>:
-    controller_address: https://iris-cw-<cluster>.oa.dev
-```
-
-**7. Wire finelog (roll the hub first).** Until this lands the controller logs to
-an in-process store (lost on restart).
-
-```bash
-# Mint the forwarding key by hand (Ed25519); keep the printed PUBLIC half.
-openssl genpkey -algorithm ed25519 -out /tmp/<cluster>.pem
-openssl pkey -in /tmp/<cluster>.pem -pubout
-gcloud secrets create finelog-<cluster>-signing-key --project=<project> \
-  --replication-policy=automatic --labels=component=finelog,purpose=forwarding
-gcloud secrets versions add finelog-<cluster>-signing-key --project=<project> \
-  --data-file=/tmp/<cluster>.pem
-shred -u /tmp/<cluster>.pem
-```
-
-- Add a `- cluster: <cluster>` entry with that **public** key under the `jwt`
-  layer of `lib/finelog/config/marin.yaml`, then **roll the hub before the
-  sender** — a sender whose key the hub doesn't yet trust gets 401:
-  `uv run finelog deploy restart marin`.
-- Create `lib/finelog/config/<cluster>.yaml` (copy an existing one; set `name`,
-  `remote_log_dir`, `kube_context`, `object_storage_endpoint`,
-  `forwarding.cluster`, and `forwarding.signing_key`), then deploy the sender:
-  `uv run finelog deploy up <cluster> --no-build` (the default `--build`
-  recompiles the Rust image first). finelog archives to **Cloudflare R2**
-  (`s3://marin-na/finelog/<cluster>`, the R2 `object_storage_endpoint`),
-  authenticated by `R2_KEY_ID` / `R2_KEY_SECRET` in the deploy
-  shell — *not* the CoreWeave `CW_KEY_*` keys iris uses for its own
-  `marin-us-east-*` state and task storage. Pointing `remote_log_dir` at a
-  CoreWeave bucket with R2 keys (or vice-versa) fails the archive with
-  `403 InvalidAccessKeyId`.
-- Add `finelog: { config: <cluster> }` to the iris config and `cluster start`
-  again to pick it up. CI enforces the pairing: a sender config cannot merge
-  until some hub's `jwt` layer names its cluster.
-
-**8. Verify node assumptions before trusting multi-host NCCL:**
-`NCCL_SOCKET_IFNAME` (the host ethernet PF carrying the node IP — same SKU has
-different PCI names per region, e.g. `enp157s0np0` on US-EAST-02A vs `enp90s0np0`
-on RNO2A; check with a job running `ls /sys/class/net`), and scale-group
-`cpu`/`ram`/`disk` against `kubectl get node -o
-jsonpath={.status.allocatable}`.
-
-**9. Smoke:** a CPU hello-world, an 8-GPU `jax.devices()` job, then the multinode
-grug smoke (below).
-
-### Connecting
-
-Preferred: use `--cluster=NAME` so Iris opens and closes the controller tunnel:
-
-```bash
-iris --cluster=cw-rno2a job logs /runner/my-job
-iris cluster list
-```
-
-`--cluster=NAME` resolves to a config under `lib/iris/config/` and opens a
-`kubectl port-forward` to the controller service. This path requires the
-`iris[controller]` extras (`kubernetes`). Without them,
-auto-tunneled CoreWeave commands fail before connecting:
-`ImportError: Install iris[controller] to use CloudK8sService`.
-
-Fallback: manual port-forward if you need a long-lived tunnel:
-
-```bash
-kubectl --kubeconfig ~/.kube/coreweave-iris --context <kube_context> \
-  port-forward -n <namespace> svc/<service_name> 10000:10000 &
-iris --controller-url=http://localhost:10000 ...
-```
-
-| Cluster name | Namespace | Service | Config file |
-|--------------|-----------|---------|-------------|
-| `cw-us-east-02a` | `iris` | `iris-controller-svc` | `cw-us-east-02a.yaml` |
-| `cw-rno2a` | `iris` | `iris-controller-svc` | `cw-rno2a.yaml` |
-| `cw-us-west-04a` | `iris-ci` | `iris-ci-controller-svc` | `cw-us-west-04a.yaml` (CI only) |
-
-### GPU Configs
-
-Marin's `gpu` extra installs the JAX CUDA 13 wheel stack from PyPI. CoreWeave
-GPU nodes must expose NVIDIA driver 580 or newer; `nvidia-smi` should report
-CUDA 13.x.
-
-The `gpu` extra also pulls the CUDA toolchain wheels (`ptxas`/`nvlink` from
-`nvidia-cuda-nvcc`, `libdevice.10.bc` from `nvidia-nvvm`) into the task venv. A
-GPU job's setup scripts then expose them (see
-`iris.cluster.setup_scripts.cuda_toolchain_setup_script`): the toolchain binaries are
-symlinked into the venv's `bin` (already on `PATH` once the venv is activated),
-and `libdevice.10.bc` is staged into XLA's default CUDA data dir
-(`./cuda_sdk_lib`) and the working directory, where XLA and Mosaic probe.
-JAX/Pallas Mosaic GPU kernels therefore compile without per-job
-`ptxas`/`nvlink`/`libdevice` setup. The staging is a no-op unless the venv
-carries the toolchain, so CPU/TPU jobs and bring-your-own images are untouched.
-
-This staging is appended only to the default setup for a job that requests the
-`gpu` extra. A job that supplies its own `setup_scripts` (run verbatim) or
-installs JAX another way must stage the toolchain itself — call
-`cuda_toolchain_setup_script()` in its setup.
-
-### Grug MoE Multinode Smoke
-
-Multi-host GPU jobs are gang-admitted by Kueue (see the Kueue section above) — no warm-node
-preflight or `targetNodes` patching is needed. Submit a small
-`experiments.grug.moe.launch_cw_scale` run as the smoke; the driver is a tiny
-CPU job that dispatches the GPU gang itself:
-
-```bash
-uv run iris --cluster=<cluster> job run \
-  --cpu 2 --memory 3GB --extra cpu \
-  --job-name grug-moe-2node-smoke \
-  -e SCALE_GPU_REPLICAS 2 -e SCALE_HIDDEN_DIM 1024 -e SCALE_NUM_LAYERS 8 \
-  -e SCALE_NUM_EXPERTS 16 -e SCALE_TOP_K 2 -e SCALE_BATCH 32 \
-  -e SCALE_SEQ_LEN 1024 -e SCALE_STEPS 10 -e RUN_ID <run-id> \
-  -- python -m experiments.grug.moe.launch_cw_scale --version dev --run
-```
-
-`--version` sets the checkpoint version (required; `dev` to iterate) and `--run` builds it —
-without `--run` the launcher prints the lowered plan and exits.
-
-Success signals: every replica enters `initialize_jax` with
-`IRIS_NUM_TASKS=<replicas>`, steps complete, a checkpoint commits, and the
-parent job exits `JOB_STATE_SUCCEEDED`.
-
-Small-shape caveat: pick `SCALE_HIDDEN_DIM` so `num_heads = hidden_dim/128` is
-divisible by `SCALE_EXPERT_AXIS` (default 8); otherwise grug attention fails
-with a `ShardingTypeError` (conflicting `@model` shardings). The ferry-style
-alternative is `experiments.ferries.canary_ferry` with `CANARY_*` env vars
-(`CANARY_ACCELERATOR=gpu`, `CANARY_GPU_TYPE=H100`, ...), which replicates the
-model per node instead of sharding across nodes.
-
-### KubernetesProvider Operations
-
-On CoreWeave, there are no persistent worker daemons: the controller dispatches
-tasks directly as Kubernetes Pods, so the `list-workers` RPC returns empty and
-the controller's `workers` state table stays empty. Node-level telemetry is
-surfaced differently. An Iris DaemonSet runs once per node and forwards bounded
-`node-exporter` and same-node `dcgm-exporter` measurements to `telemetry_v1`,
-retaining node, GPU, PCI, exporter, and counter-replica identity. The controller
-does not perform a second hardware scrape or write synthetic `iris.worker` rows.
-`get-kubernetes-cluster-status` and the dashboard **Cluster** panel retain node
-readiness, allocatable capacity, scheduling, and pod state; hardware history is
-queried from `telemetry_v1`. NCCL communicator/rank evidence remains process-local
-telemetry. Use:
-
-```bash
-kci get pods -n iris -l iris.managed=true
-kci get nodepools
-kci get events -n iris --sort-by=.lastTimestamp | tail -30
-kci logs -n iris deployment/iris-controller -f
-iris rpc controller get-kubernetes-cluster-status
-```
-
-(`kci` = `kubectl --kubeconfig ~/.kube/coreweave-iris`)
-
-### NodePool Operations
-
-```bash
-kci get nodepools
-kci patch nodepool <name> --type=merge -p '{"spec":{"targetNodes":N}}'
-kci delete nodepool <name>
-```
-
-Do not use `kubectl scale --replicas` for NodePools; patch
-`spec.targetNodes`.
-
-If deletion is stuck because the autoscaler fights deletion or the node is
-mid-delivery:
-
-```bash
-kci scale deployment iris-controller -n iris --replicas=0
-kci patch nodepool <name> --type=merge -p '{"spec":{"autoscaling":false,"targetNodes":0}}'
-kci patch nodepool <name> --type=json -p '[{"op":"remove","path":"/metadata/finalizers"}]'
-kci delete nodepool <name>
-```
-
-`iris cluster stop` deletes pods but NodePools survive. Delete managed NodePools
-explicitly to avoid lingering GPU costs:
-
-```bash
-iris cluster stop
-kci delete nodepool -l iris-<label_prefix>-managed=true
-```
-
-### Gotchas
-
-- **NodePools survive `cluster stop`.** Delete explicitly to avoid lingering GPU costs.
-- **`list-workers` returns empty.** KubernetesProvider dispatches pods directly; no
-  worker daemons register. Per-node hardware readings live in `telemetry_v1`; the
-  **Cluster** panel shows Kubernetes identity, readiness, capacity, and pod state.
-- **`list-tasks` requires `job_id`.** Calling without it throws `ConnectError: job_id is required`.
-- **`cluster start` always rebuilds+pushes images.** Needs `docker login ghcr.io` with `write:packages` PAT.
-- **Konnectivity agent.** `kubectl port-forward` returns 500 until `konnectivity-agent` pods are running (~18-30s after node provisions).
-- **NHC verification pods occupy idle GPU nodes.** CoreWeave's node health checker
-  (`cw-hpc-verification` namespace) runs preemptible GPU pods on idle nodes; Kueue
-  TAS counts them as fixed usage and cannot preempt non-Kueue pods. Iris evicts
-  them itself when it has gang work — list the namespace in
-  `kubernetes_provider.preempt_namespaces`.
-- **`NCCL_SOCKET_IFNAME` is per-region.** The same GPU SKU exposes different PCI
-  interface names in different regions; verify on a live node (see "Bringing up
-  a new cluster").
-- **Controller state is node-local.** The controller keeps SQLite state on
-  node-local NVMe (`storage.local_state_dir`, a hostPath), and
-  `cluster controller restart` may reschedule the replacement onto another CPU
-  node. Startup runs `PRAGMA quick_check` on both local databases and only reuses
-  them when their `last_checkpoint_epoch_ms` marker matches the selected remote
-  checkpoint. Otherwise it stages and validates a clean checkpoint directory
-  before replacing the local directory, which also discards stale WAL/SHM files.
-  A corrupt local directory is retained as `db.corrupt-<epoch_ms>` for diagnosis.
-  The readiness endpoint also reads the task-attempt and federation tables, so a
-  static HTTP response cannot mask a broken database.
-
-Cold-start timings:
-
-| Resource | Time |
-|----------|------|
-| CW CPU node | ~14 min |
-| CW H100 bare-metal | ~20 min |
-| CW first training step (from zero) | ~25-30 min |
-
-## 5. RBAC Permissions
-
-`iris cluster start` auto-applies these resources via `ensure_rbac()` (defined
-in `CoreweavePlatform`):
-
-| Resource | Purpose |
-|----------|---------|
-| `iris` Namespace | Isolation for all Iris resources |
-| `iris-controller` ServiceAccount | In-cluster K8s API auth for controller and worker Pods |
-| `iris-controller-{namespace}` ClusterRole | API permissions (see below). Namespace-qualified to support multiple Iris instances on the same CKS cluster. |
-| `iris-controller-{namespace}` ClusterRoleBinding | Binds ServiceAccount to ClusterRole. Namespace-qualified to avoid collisions. |
-
-**ClusterRole permissions**:
-
-| API Group | Resources | Verbs |
-|-----------|-----------|-------|
-| `compute.coreweave.com` | `nodepools` | get, list, watch, create, update, patch, delete |
-| core (`""`) | `pods`, `pods/exec`, `pods/log` | get, list, watch, create, update, patch, delete |
-| core (`""`) | `nodes` | get, list, watch |
-| core (`""`) | `configmaps` | get |
-
-## 6. Configuration Reference
-
-### CoreweavePlatformConfig
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `region` | string | — | CoreWeave region (e.g. `RNO2A`) |
-| `namespace` | string | `iris` | Kubernetes namespace for all resources |
-| `kubeconfig_path` | string | — | Only needed when running CLI outside the cluster |
-| `kube_context` | string | — | Kubeconfig context to bind every operation to; empty uses the file's current-context |
-| `object_storage_endpoint` | string | — | S3-compatible endpoint URL |
-
-### CoreweaveControllerConfig
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `port` | int | `10000` | Controller listening port |
-| `service_name` | string | `iris-controller-svc` | K8s Service name |
-| `scale_group` | string | **required** | Scale group to schedule the controller onto |
-
-### CoreweaveSliceConfig (per scale group)
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `region` | string | — | Scale group region |
-| `instance_type` | string | — | CoreWeave instance type (e.g. `gd-8xh100ib-i128`) |
-| `gpu_class` | string | — | GPU model (e.g. `H100`) |
-| `infiniband` | bool | `false` | Request `rdma/ib: 1` resource on task Pods |
-
-### Bootstrap config
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `docker_image` | string | — | Worker image |
-| `worker_port` | int | — | Worker listening port |
-| `cache_dir` | string | — | **Must point to NVMe** (see warning below) |
-| `runtime` | string | — | Set to `kubernetes` for CoreWeave (enables Pod-per-task) |
-
-> **Warning — Disk layout**: CoreWeave bare-metal nodes boot a **15 GB RAM disk**
-> as the root filesystem, with the node's NVMe RAID (`/dev/md127`, 7.7 TB on CPU
-> nodes, 15–31 TB on GPU nodes) mounted at `/mnt/local`. The `cache_dir` must
-> point to NVMe (e.g. `/mnt/local/iris-cache`). Using the default root path will
-> fill the RAM disk immediately and cause Pod eviction.
->
-> Only `cache_dir` needs this: the kubelet root is on the NVMe, so task `emptyDir`
-> volumes (`/app`, `/tmp`) and container writable layers already land there.
-
-### Task storage layout
-
-Task pods use no PVCs — nothing on the task path touches the `shared-vast`
-(distributed) storage class, which backs only the controller state and finelog
-caches. Every task volume is node-local NVMe:
-
-| Container path | Volume | Lifetime |
-|----------------|--------|----------|
-| `/app`, `/tmp` | `emptyDir` (kubelet root) | Pod |
-| `/uv/cache`, `/hf/cache`, `/cargo` | `hostPath` under `cache_dir` | Node |
-| `/dev/shm` | `emptyDir` (memory) | Pod |
-
-Iris points `UV_CACHE_DIR`, `HF_HUB_CACHE`, and `CARGO_HOME` at those
-`hostPath` mounts for every task, including tasks that bring their own image, so
-wheels and model weights are fetched once per node rather than once per task.
-`HF_HOME` is deliberately not among them. It holds the submitter's `HF_TOKEN`, so
-it stays under the pod's own `$HOME` (`iris job run` defaults it to
-`~/.cache/huggingface`) rather than a directory every task on the node can read.
-`HF_HUB_CACHE` covers the part worth sharing: the content-addressed blobs.
-
-The `cache_dir` tree is never pruned; it grows until the node is rebuilt or an
-operator clears it. Watch it on long-lived reserved fleets:
-
-```bash
-kubectl exec -n iris <pod> -c task -- du -sh /uv/cache /hf/cache
-```
-
-### Startup grace period
-
-The default `startup_grace_period` is 2400s (40 minutes). This covers CoreWeave
-bare-metal node provisioning (20-30 min) plus Pod image pull and startup time.
-
-## 7. Instance Type Naming
-
-CoreWeave instance types follow the pattern `{prefix}-{count}x{model}{networking}-i{cpu}`:
-
-| Component | Meaning | Example |
-|-----------|---------|---------|
-| `gd` | GPU device | `gd-8xh100ib-i128` |
-| `cd` | CPU device | `cd-gp-i64-erapids` |
-| `8x` | GPU count | 8 GPUs |
-| `h100` | GPU model | NVIDIA H100 |
-| `ib` | InfiniBand | High-bandwidth interconnect |
-| `i128` | vCPU count | 128 vCPUs |
-
-**Known-good instance types**:
-
-| Instance Type | GPUs | vCPUs | RAM | Disk | Use Case |
-|---------------|------|-------|-----|------|----------|
-| `gd-8xh100ib-i128` | 8x H100 | 128 | 2 TB | — | GPU training (primary) |
-| `cd-gp-a192-genoa` | none | 192 | 1.5 TB | 7.68 TB | Controller / CPU tasks (US-EAST-02A) |
-| `turin-gp-l` | none | 192 | 1.5 TB | 29 TB | Controller / CPU tasks (RNO2A) |
-
-The console capacity view shows display labels, not instance types (e.g.
-"turin-gp-l4" for `turin-gp-l`); the NodePool webhook accepts any string on
-dry-run, and only the async NodePool controller sets `Validated=False` on a bad
-SKU. Probe a SKU with a `minNodes: 0, maxNodes: 0` pool before trusting it.
-
-Full list: [CoreWeave GPU Instances](https://docs.coreweave.com/docs/platform/instances/gpu-instances)
-
-## 8. Key Design Decisions
-
-### Shared NodePools with CoreWeave autoscaling
-
-Each scale group maps to one shared NodePool with `autoscaling: true`. CoreWeave
-provisions bare-metal nodes on demand when Pods are scheduled and deprovisions
-them when idle. Iris does not manage node lifecycle directly.
-
-NodePools are created idempotently by `ensure_nodepools()` during `start_controller()`.
-Stale NodePools (from renamed/removed scale groups) are garbage-collected automatically.
-For existing pools, `targetNodes` is clamped to `min(currentNodes, 1)` to prevent
-runaway autoscaling from system pods.
-
-### Controller as a Kubernetes Deployment
-
-The controller runs as a single-replica Deployment scheduled onto the configured
-`scale_group` NodePool. Workers discover it via K8s Service DNS. The controller
-Pod uses in-cluster ServiceAccount auth for all kubectl operations. It requests
-16 CPU and 64Gi memory with a memory limit but no CPU limit, so it runs Burstable
-(not BestEffort, not Guaranteed): it is never CFS-throttled and can burst onto
-spare node cores during reconcile-loop spikes, while memory stays capped to
-protect the node. The liveness/readiness probes use a 10s timeout and tolerate 6
-failures so a busy-but-alive controller is not liveness-killed mid-reconcile
-under a large tokenize fan-out (issue #6944).
-
-Cost note: the smallest CoreWeave CPU instance (`cd-gp-i64-erapids`, 64 vCPU,
-512 GB RAM) is overprovisioned for the controller. CoreWeave does not offer
-smaller bare-metal nodes.
-
-### Bootstrap via Platform.create_slice() with async state model
-
-`create_slice()` returns a `SliceHandle` immediately in `CREATING` state. A
-background thread drives the handle through `CREATING -> BOOTSTRAPPING -> READY`
-(or `FAILED`). The autoscaler observes transitions via `handle.describe()` and
-does not drive bootstrap logic.
-
-On failure, the platform cleans up its own resources (deletes the worker Pod) and
-marks the handle as `FAILED`. The autoscaler calls `handle.terminate()` as a
-safety net.
-
-### KubernetesRuntime for task execution (Pod-per-task)
-
-Each task attempt is a separate Kubernetes Pod created by `KubernetesRuntime`.
-Task Pods:
-- Claim GPU/RDMA resources from the kubelet device plugin (`nvidia.com/gpu: N`,
-  `rdma/ib: 1` when `infiniband: true`)
-- Receive tolerations for `nvidia.com/gpu` NoSchedule taints automatically
-- Use `hostNetwork: true` with `dnsPolicy: ClusterFirstWithHostNet`
-- Get S3 credentials via `secretKeyRef` from the platform-managed Secret
-- Use `emptyDir` for `/app` (workdir) so tasks can run on any node
-- Materialize code bundles in-pod via fsspec
-- Have `ownerReferences` pointing to the worker Pod for GC
-
-The worker Pod intentionally does **not** request GPU/RDMA resources when
-`runtime: kubernetes` is configured, so task Pods can claim them instead.
-
-### Reconcile-driven recovery
-
-Correctness does not depend on in-memory thread state. After a controller restart,
-`list_all_slices()` discovers existing worker Pods by labels and reconstructs
-slice handles with the correct state based on Pod phase and readiness conditions.
-
-## 9. Early Failure Detection
-
-The platform detects fatal errors before the full timeout expires:
-
-| Error | Detection | Behavior |
-|-------|-----------|----------|
-| `ErrImagePull`, `ImagePullBackOff`, `InvalidImageName` | Container waiting reason | Immediate failure with error message |
-| `CreateContainerConfigError` | Container waiting reason | Immediate failure (usually missing Secret/ConfigMap) |
-| `CrashLoopBackOff` | Waiting reason + `restartCount >= 2` | Fail with last 30 lines of logs |
-| `FailedMount`, `FailedAttachVolume` | Pod events, `count >= 3`, after 90s grace | Immediate failure |
-
-## 10. Environment Variables
-
-### Operator (outside cluster)
-
-| Variable | Purpose |
-|----------|---------|
-| `KUBECONFIG` | Overrides the config's `kubeconfig_path` (file only — the config's `kube_context` still binds the context) |
-| `CW_KEY_ID` | S3/CoreWeave Object Storage access key (required if storage uses `s3://`) |
-| `CW_KEY_SECRET` | S3/CoreWeave Object Storage secret key |
-
-### Auto-injected into worker and task Pods
-
-| Variable | Source | Description |
-|----------|--------|-------------|
-| `IRIS_WORKER_NODE_NAME` | Downward API (`spec.nodeName`) | Kubernetes node name |
-| `IRIS_POD_NAMESPACE` | Downward API (`metadata.namespace`) | Pod's namespace |
-| `IRIS_POD_NAME` | Downward API (`metadata.name`) | Pod's name |
-| `IRIS_POD_UID` | Downward API (`metadata.uid`) | Pod's UID |
-| `IRIS_SERVICE_ACCOUNT_NAME` | Platform | ServiceAccount for task Pods (set when `runtime: kubernetes`) |
-| `AWS_ACCESS_KEY_ID` | `envFrom` | From the `iris-task-env` Secret |
-| `AWS_SECRET_ACCESS_KEY` | `envFrom` | From the `iris-task-env` Secret |
-| `AWS_ENDPOINT_URL` | `envFrom` | From `iris-task-env`; derived from `object_storage_endpoint` |
-| `AWS_REGION` / `AWS_DEFAULT_REGION` | `envFrom` | From `iris-task-env`; `auto` for CoreWeave Object Storage endpoints |
-| `FSSPEC_S3` | `envFrom` | From `iris-task-env`; JSON-encoded endpoint, addressing, timeout, and retry config |
-| `CW_KEY_ID` / `CW_KEY_SECRET` | `envFrom` | From `iris-task-env`; the CoreWeave store's own credential variables, read by bucket-routed filesystems |
-| `CW_S3_ENDPOINT` | `envFrom` | From `iris-task-env`; the pod's `object_storage_endpoint` (LOTA), so a bucket-routed filesystem uses the node-local cache |
-| `MARIN_PREFIX` | `defaults.task_env` (cluster config) | Preset to `s3://marin-us-east-02a/marin` on both CoreWeave clusters |
-
-## 11. Timeouts
-
-| Timeout | Default | Description |
-|---------|---------|-------------|
-| Pod readiness | 2400s (40 min) | Max wait for worker Pod to pass readiness probe |
-| Deployment readiness | 2400s (40 min) | Max wait for controller Deployment availability |
-| kubectl commands | 1800s (30 min) | Default subprocess timeout for kubectl calls |
-| Mount failure grace | 90s | Grace period before treating FailedMount as fatal |
-
-## 12. Control Flow
-
-### Cluster startup (`iris cluster start`)
-
-`CoreweavePlatform.start_controller()` orchestrates the full startup sequence.
-See `lib/iris/src/iris/providers/k8s/coreweave.py`.
-
-1. Apply RBAC prerequisites (Namespace, ServiceAccount, ClusterRole `iris-controller-{ns}`, ClusterRoleBinding `iris-controller-{ns}`)
-2. Create S3 credentials Secret (if S3 storage configured)
-3. Apply ConfigMap with cluster config
-4. Create/reconcile all shared NodePools in parallel via `ensure_nodepools()`
-5. Apply controller Deployment (with rollout restart)
-6. Apply controller Service (ClusterIP)
-7. Wait for Deployment availability (polls with early failure detection for
-   image pull errors, crash loops, and volume mount failures)
-8. Return controller address (K8s Service DNS)
-
-### Scale-up (autoscaler creates a worker slice)
-
-1. Autoscaler calls `create_slice(config, bootstrap_config)`
-2. Platform generates slice ID: `{label_prefix}-{scale_group}-{timestamp_ms}`
-3. Platform applies worker Pod to the scale group's shared NodePool via
-   `nodeSelector` matching the scale group label
-4. Platform returns `CoreweaveSliceHandle` immediately (state: CREATING)
-5. Background thread:
-   a. Transitions to BOOTSTRAPPING
-   b. Creates worker Pod (image, ports, env from bootstrap_config)
-   c. Polls Pod readiness (with early failure detection)
-   d. On ready: extracts Pod IP, creates `CoreweaveWorkerHandle`, marks READY
-   e. On failure: deletes Pod, marks FAILED
-
-### Worker registration
-
-Worker Pod runs `iris.cluster.worker.main serve --runtime=kubernetes`. It:
-1. Reads config from ConfigMap mount (`/etc/iris/config.json`)
-2. Discovers controller via `iris-controller-svc.iris.svc.cluster.local:10000`
-3. Creates `KubernetesRuntime` (reads `IRIS_SERVICE_ACCOUNT_NAME` from
-   environment; S3 credentials arrive via `envFrom` on the `iris-task-env` Secret)
-4. Registers with controller, enters heartbeat loop
-
-### Task execution
-
-Standard Iris flow. Controller assigns task via heartbeat RPC. Worker calls
-`KubernetesRuntime.create_container()` which creates a task Pod. See
-`lib/iris/src/iris/cluster/runtime/kubernetes.py`.
-
-### Scale-down
-
-1. Autoscaler selects the idle slice
-2. `handle.terminate()` force-deletes the worker Pod
-3. CoreWeave autoscaler deprovisions the bare-metal node when no Pods remain
-
-## 13. Multi-VM Jobs
-
-Multi-VM scale groups allow training across multiple nodes. Each slice in a
-multi-VM group provisions N worker Pods (one per VM) that share a single
-ConfigMap. All Pods in a slice must reach Ready before the slice is usable.
-
-### Configuration
-
-Define a scale group with `num_vms > 1` in the cluster config. The
-`slice_template.num_vms` must match the top-level `num_vms`. For CoreWeave GPU
-groups, define at least one topology label in `worker.attributes`; use
-`same-slice` to discover the leader pod's node label value and pin follower
-pods to that same topology domain:
-
-```yaml
-scale_groups:
-  h100-16x:
-    num_vms: 2
-    resources:
-      cpu: 128
-      ram: 2048GB
-      disk: 1TB
-      device_type: gpu
-      device_variant: H100
-      device_count: 8
-    worker:
-      attributes:
-        region: US-WEST-04A
-        pool: h100-16x
-        backend.coreweave.cloud/superpod: same-slice
-    buffer_slices: 0
-    max_slices: 1
-    priority: 50
-    slice_template:
-      num_vms: 2
-      coreweave:
-        region: US-WEST-04A
-        instance_type: gd-8xh100ib-i128
-```
-
-### Submitting multi-replica jobs
-
-Jobs targeting a multi-VM CoreWeave GPU group should use coscheduling so all
-replicas are launched together. Include `ports=["jax"]` so Iris allocates a
-named port for JAX coordinator discovery:
-
-```python
-from iris.sdk import IrisClient, CoschedulingConfig
-
-client = IrisClient()
-client.submit(
-    name="multi-node-training",
-    image="ghcr.io/marin-community/iris-task:<git-sha>",
-    command=["python", "train.py"],
-    replicas=2,
-    ports=["jax"],
-    coscheduling=CoschedulingConfig(group_by="leafgroup"),
-    resources={"gpu": 8},
-)
-```
-
-Each replica receives `IRIS_TASK_ID` (0 or 1), `IRIS_NUM_TASKS` (2), and
-`IRIS_PORT_JAX` (the allocated coordinator port). Task code calls
-`iris.runtime.jax_init.initialize_jax()` to bootstrap JAX distributed — task 0
-registers its coordinator address via the endpoint API, and task 1 discovers it
-by polling.
-
-### Requirements
-
-- **Coscheduling is mandatory for multi-host GPU groups**: replicas must
-  launch together on workers from the same CoreWeave pool.
-- **Topology labels are mandatory for multi-host GPU groups**: set at least one
-  CoreWeave topology key in `worker.attributes`, such as
-  `backend.coreweave.cloud/superpod: same-slice`.
-- **hostNetwork anti-affinity**: Because worker Pods use `hostNetwork: true`,
-  two Pods binding the same port cannot schedule on the same node. This
-  provides implicit anti-affinity — no explicit `podAntiAffinity` rule needed.
-- **Gang semantics**: If any task in a coscheduled group fails terminally, all
-  siblings are killed and the entire group retries together.
-
-## 14. Credentials Summary
-
-### Platform-managed (all created by `iris cluster start`)
-
-| Resource | Purpose | Created By |
-|----------|---------|------------|
-| `iris` Namespace + RBAC | K8s API auth and permissions | `start_controller()` via `ensure_rbac()` |
-| `iris-task-env` Secret | S3 object storage auth + operator-injected env (`defaults.inject_env`) | `start_controller()` via `ensure_task_env_secret()`, from `CW_KEY_ID` / `CW_KEY_SECRET` + the configured `object_storage_endpoint` |
-| `iris-cluster-config` ConfigMap | Cluster config for controller and workers | `start_controller()` |
-| In-cluster ServiceAccount token | kubectl calls from controller Pod | Auto-mounted by Kubernetes |
-
-### Operator-managed
-
-| Resource | Purpose | How to Obtain |
-|----------|---------|---------------|
-| CoreWeave API token | kubeconfig auth | Console > Tokens > Create Token |
-| Kubeconfig file | Operator's kubectl access | Console > Tokens > Download Kubeconfig |
-| CoreWeave Object Storage access key | S3-compatible access to CoreWeave buckets | Console > Object Storage > Access Keys |
-
-The `kubeconfig_path` / `kube_context` config fields are only needed when
-running the CLI **outside** the cluster (e.g., `iris cluster start` from a
-laptop). Inside the cluster, Pods use in-cluster auth automatically (both
-fields are stripped from the `iris-cluster-config` ConfigMap).
-
-## 15. Open Questions / Known Limitations
-
-1. **NodePool rate limits**: Creating many NodePools at scale has not been
-   validated with CoreWeave.
-
-2. **Task Pod GC**: `ownerReferences` on task Pods only trigger GC when the
-   worker Pod object is deleted. If the worker crash-loops in place, stale task
-   Pods can accumulate. See TODO in `kubernetes.py`.
-
-## 16. Troubleshooting
-
-### NodePool not scaling up
-
-```bash
-kubectl get nodepool                     # Check TARGET vs CURRENT
-kubectl describe nodepool <name>         # Check conditions: Valid, AtTarget
-```
-
-If `Valid` is `False`, the instance type or configuration is rejected.
-
-### Pod stuck in Pending
-
-```bash
-iris --cluster=<cluster> task describe <task-id>
-kubectl get pod <name> -n iris \
-  -o jsonpath='{range .status.conditions[?(@.status=="False")]}{.reason}{": "}{.message}{"\n"}{end}'
-kubectl get workload -n iris
-kubectl get workload <workload-name> -n iris \
-  -o jsonpath='{range .status.conditions[?(@.type=="QuotaReserved")]}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
-```
-
-`SchedulingGated` means Kueue has not admitted the Workload. The
-`QuotaReserved` message reports quota or topology fit failures such as
-`excluded: resource "memory"`. Iris copies that verdict into the task's backend
-status, including for singleton Pods whose generated Workload is linked by Pod
-UID.
-
-Common causes are node capacity fragmented across running Pods, resource limits
-exceeded, missing tolerations, or a node still provisioning. Kueue preempts only
-the priorities allowed by the ClusterQueue policy; equal-priority work remains
-in place.
-
-Avoid `kubectl describe pod` when a task carries credentials in literal
-environment variables. It prints those values. Use the JSONPath commands above
-for scheduling state, and rotate any credential printed into a terminal or
-transcript.
-
-### Image pull errors
-
-The platform detects `ErrImagePull` / `ImagePullBackOff` and fails immediately.
-Verify the image exists and is public:
-
-```bash
-docker pull ghcr.io/marin-community/iris-worker:<git-sha>-amd64
-```
-
-### CrashLoopBackOff
-
-The platform detects crash loops after 2+ restarts and reports the last 30 log
-lines. To inspect manually:
-
-```bash
-kubectl logs <pod> -n iris --previous    # Logs from the last crash
-```
-
-### Disk full / Pod eviction
-
-If `cache_dir` is not set to `/mnt/local/...`, the 15 GB root RAM disk fills
-instantly. Fix in config and redeploy.
-
-A pod evicted for `ephemeral-storage` while `cache_dir` is correct is a different
-fault: that limit comes from the task's own `disk` resource request and covers
-only `emptyDir` plus the container layer, not the `hostPath` caches. Either the
-task is writing large files under `/app` or `/tmp`, or it is writing to a cache
-path Iris does not mount (check `env | grep -iE 'CACHE|HF_'` against the task
-storage layout above) and needs a larger `disk` request.
-
-## 17. References
-
-- [CoreWeave CKS Introduction](https://docs.coreweave.com/docs/products/cks)
-- [CKS Cluster Creation](https://docs.coreweave.com/docs/products/cks/clusters/create)
-- [API Access Tokens and Kubeconfig](https://docs.coreweave.com/docs/products/cks/auth-access/manage-api-access-tokens)
-- [CoreWeave Node Pools](https://docs.coreweave.com/docs/products/cks/nodes/nodes-and-node-pools)
-- [CoreWeave Autoscaling](https://docs.coreweave.com/docs/products/cks/nodes/autoscaling)
-- [CoreWeave GPU Instances](https://docs.coreweave.com/docs/platform/instances/gpu-instances)
-- [CoreWeave Observe (Managed Grafana)](https://docs.coreweave.com/docs/observability/managed-grafana)
-- [CoreWeave AI Object Storage: Set endpoints](https://docs.coreweave.com/products/storage/object-storage/using-object-storage/configure-endpoints)
-- [CoreWeave AI Object Storage: Manage objects](https://docs.coreweave.com/products/storage/object-storage/using-object-storage/manage-objects)
-- [CoreWeave Terraform Provider](https://docs.coreweave.com/docs/products/cks/terraform/about)
-
-### Source files
-
-| File | Description |
-|------|-------------|
-| `lib/iris/src/iris/providers/k8s/coreweave.py` | CoreWeave platform implementation (includes `ensure_rbac()`) |
-| `lib/iris/src/iris/cluster/runtime/kubernetes.py` | KubernetesRuntime (Pod-per-task) |
-| `lib/iris/src/iris/providers/k8s/service.py` | Kubectl CLI wrapper |
-| `lib/iris/config/examples/coreweave.yaml` | Example cluster config |
-| `lib/iris/AGENTS.md` | CoreWeave integration notes for agents |
+`SchedulingGated` means Kueue has not admitted the Workload.
+`QuotaReserved=False` explains quota or topology-fit failures. A NodePool with
+`Valid=False` has a rejected configuration; a target/current mismatch usually
+means nodes are still provisioning or unhealthy. Do not work around either by
+editing the live objects. Pulumi owns NodePools and cluster-scoped Kueue
+resources.
+
+For actor-level Kubernetes API history after ordinary Events expire, use the
+Kubernetes Audit Logs dashboard in CoreWeave Observe. `iris task events` is the
+Iris-side record of backend observations and controller decisions; it is not an
+API audit log.
+
+For context errors, return to [Connecting](#connecting). For public federation
+timeouts, controller restarts, kernel-deadlock recovery, or other live faults,
+use [CoreWeave GPU Operations](../OPS.md#coreweave-gpu-operations). Kubernetes
+`apply`, `delete`, `scale`, `drain`, `cordon`, and `uncordon` require explicit
+operator approval.
+
+## Onboarding and source routing
+
+For a new CoreWeave cluster, follow the ownership boundary in order:
+
+1. Obtain the CKS cluster, operator kubeconfig, object-storage bucket, and access
+   keys. CKS and object storage are not Pulumi-managed today.
+2. Add `lib/iris/config/<cluster>.yaml` from live cluster facts and the schema in
+   [`config.py`](../src/iris/cluster/config.py). Do not copy fleet sizes from a
+   document.
+3. Provision the controller signing key with `iris cluster init-keys` and
+   reference its private half from `auth.signing_key`. Add each parent
+   controller's public key under `auth.federation_peers` so the CoreWeave
+   controller can verify handoffs. Signing keys stay out of Pulumi state. See
+   [federation credentials](federation.md#credentials-do-not-travel).
+4. Follow the [Pulumi guide](../../../infra/pulumi/README.md) to create or adopt
+   RBAC, NodePools, Kueue, Traefik, TLS, and DNS. Stop on any NodePool replacement
+   or deletion in the preview.
+5. If the cluster names a Finelog config, follow the [Finelog operations
+   guide](../../finelog/OPS.md#onboarding-a-cluster-onto-the-forwarding-hub) for
+   its separate forwarding key and deploy that service before the Iris
+   controller.
+6. Register the peer in the parent federation config and deploy the controller
+   through the [deployment
+   skill](../../../.agents/skills/deploy-iris-controllers/SKILL.md).
+7. Verify `cluster status`, `list-backends`, the public federation route, and one
+   representative topology-aware smoke before sending normal jobs.
+
+Use this page for CoreWeave architecture and config, the [federation
+reference](federation.md) for cross-cluster job semantics, the [Pulumi
+guide](../../../infra/pulumi/README.md) for infrastructure, and
+[`OPS.md`](../OPS.md) for live diagnosis.
+
+## Source map
+
+- [`backends/k8s/tasks.py`](../src/iris/cluster/backends/k8s/tasks.py) — task Pod
+  manifests, Kueue status, profiling, and cleanup.
+- [`platforms/k8s/controller.py`](../src/iris/cluster/platforms/k8s/controller.py)
+  — controller resources, prerequisite checks, and Secret projection.
+- [`platforms/k8s/service.py`](../src/iris/cluster/platforms/k8s/service.py) —
+  context-bound Kubernetes calls and port-forwarding.
+- [`platforms/k8s/coreweave_topology.py`](../src/iris/cluster/platforms/k8s/coreweave_topology.py)
+  — topology labels and NVL72 rack rules.
+- [`platforms/k8s/nodepool_manifests.py`](../src/iris/cluster/platforms/k8s/nodepool_manifests.py)
+  — NodePool manifests shared by Iris and Pulumi.
+- [`composer.py`](../src/iris/cluster/composer.py) — config-to-backend wiring.
+- [`infra/pulumi/src/iac/coreweave/cluster.py`](../../../infra/pulumi/src/iac/coreweave/cluster.py)
+  — Pulumi ownership of CoreWeave prerequisites.

--- a/lib/iris/docs/federation.md
+++ b/lib/iris/docs/federation.md
@@ -1,8 +1,9 @@
 # Federation: what crosses a cluster boundary
 
 A cluster with `peers:` in its config may hand whole jobs to another cluster. `marin` (GCP:
-TPU and CPU) peers with `cw-rno2a` and `cw-us-east-02a` (CoreWeave: H100), so a user submits
-every job to `marin` and GPU work lands on CoreWeave.
+TPU and CPU) peers with `cw-rno2a` and `cw-us-east-02a` (CoreWeave: H100) and
+`cw-us-east-08a` (CoreWeave: GB200), so a user submits every job to `marin` and GPU work
+lands on CoreWeave.
 
 This page is the job model. For the auth, networking, and DNS that carry a handoff, see
 [`coreweave.md`](coreweave.md).


### PR DESCRIPTION
Replace the historical CoreWeave worker-daemon runbook with the current
Kubernetes task-provider model. Checked-in cluster configs define cluster
selection and access. Iris owns task lifecycle and first-line diagnosis,
while Pulumi owns shared infrastructure. Use read-only Kubernetes queries
only when deeper scheduler or node detail is needed. Fixed fleet counts and
ad hoc mutation recipes are removed because they bypass these ownership
boundaries; direct Kubernetes changes remain limited to explicitly approved
deployment or recovery procedures.

Guidance on credentials, CoreWeave object storage, federation, Kueue, and
NVL72 placement remains. CoreWeave node agents publish host and GPU
measurements to `telemetry_v1`; the Iris cluster view retains Kubernetes
readiness, allocatable capacity, scheduling, and Pod state.

Use `dev_gpu.py` for short development loops before a representative Iris run.
The reserve-GPU skill and cloud-GPU tutorial cover H100 and GB200 selection,
separate cluster and checkout credential scopes, CoreWeave object storage,
session recovery, and accelerator verification.
