### PR TITLE
[iris] Stop terminal-pod GC from blocking the Kubernetes control loop

### DIFF
--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -411,6 +411,11 @@ def _pod_name_candidates(task_id: JobName, attempt_id: int, attempt_uid: str, *,
     return [current] if legacy == current else [current, legacy]
 
 
+def _task_hashes(pods: list[dict]) -> set[str]:
+    """The task hashes labelling *pods*. A hash is shared by every attempt of a task."""
+    return {h for pod in pods if (h := pod.get("metadata", {}).get("labels", {}).get(_LABEL_TASK_HASH))}
+
+
 def _lookup_pod(
     pods_by_name: dict[str, dict], task_id: JobName, attempt_id: int, attempt_uid: str, *, allow_legacy: bool
 ) -> tuple[str, dict | None]:
@@ -2502,19 +2507,6 @@ class K8sTaskProvider:
 
         return updates
 
-    def _allow_legacy_pod_name(self, entry: RunningTaskEntry) -> bool:
-        """The pre-uid name is a candidate only for attempts this process did not dispatch."""
-        return (entry.task_id.to_wire(), entry.attempt_id) not in self._dispatched_attempts
-
-    def _entry_pod_candidates(self, entry: RunningTaskEntry) -> list[str]:
-        """Pod names a running entry may be under, current scheme first."""
-        return _pod_name_candidates(
-            entry.task_id,
-            entry.attempt_id,
-            entry.attempt_uid,
-            allow_legacy=self._allow_legacy_pod_name(entry),
-        )
-
     def _lookup_entry_pod(self, pods_by_name: dict[str, dict], entry: RunningTaskEntry) -> tuple[str, dict | None]:
         """Resolve a running entry to its pod, allowing the pre-uid name only when this
         process did not dispatch the attempt."""
@@ -2523,7 +2515,7 @@ class K8sTaskProvider:
             entry.task_id,
             entry.attempt_id,
             entry.attempt_uid,
-            allow_legacy=self._allow_legacy_pod_name(entry),
+            allow_legacy=(entry.task_id.to_wire(), entry.attempt_id) not in self._dispatched_attempts,
         )
 
     def _live_pod_name(self, target: TaskTarget) -> str:
@@ -2867,19 +2859,19 @@ class K8sTaskProvider:
         if self._gc_emitter is None:
             self._gc_emitter = PeriodicEmitter(self._gc_once, interval=_GC_INTERVAL_SECONDS, name="terminal-gc")
 
-    def _gc_once(self) -> None:
-        """One GC pass, against active pods this thread reads itself.
+    def _list_active_pods(self) -> list[dict]:
+        """List managed pods in a non-terminal phase — the set a sweep must protect."""
+        return self.kubectl.list_json(
+            K8sResource.PODS,
+            labels=_MANAGED_POD_LABELS,
+            field_selector=_ACTIVE_PODS_FIELD_SELECTOR,
+        )
 
-        Reading them here rather than taking sync's snapshot keeps the protection for
-        tasks with active retry attempts accurate however long the pass runs.
-        """
+    def _gc_once(self) -> None:
+        """One GC pass, against active pods this thread reads itself rather than a
+        snapshot handed over by a sync cycle that may have run much earlier."""
         try:
-            active_pods = self.kubectl.list_json(
-                K8sResource.PODS,
-                labels=_MANAGED_POD_LABELS,
-                field_selector=_ACTIVE_PODS_FIELD_SELECTOR,
-            )
-            self._gc_terminal_resources(active_pods)
+            self._gc_terminal_resources(self._list_active_pods())
         except Exception:
             # PeriodicEmitter logs a bare warning naming the thread. #7881 was GC
             # silently ceasing to work, so name it and keep the traceback.
@@ -2898,22 +2890,16 @@ class K8sTaskProvider:
         cutoff = now - _GC_MAX_AGE_SECONDS
         gang_cutoff = now - _GANG_GC_MAX_AGE_SECONDS
 
-        # Collect task hashes that still have active (Pending/Running) pods.
-        # These must NOT have their configmaps/PDBs deleted, even if an older
-        # attempt of the same task is terminal — task_hash is shared across attempts.
-        active_hashes: set[str] = set()
+        # Task hashes that still have active (Pending/Running) pods must NOT have their
+        # configmaps/PDBs deleted, even if an older attempt of the same task is
+        # terminal — task_hash is shared across attempts.
+        active_hashes = _task_hashes(active_pods)
         # Pod-groups with live (Pending/Running) members share one Kueue
         # Workload across the gang; releasing it would evict the running
         # siblings, so the gang sweep must skip those groups entirely.
-        active_gang_groups: set[str] = set()
-        for pod in active_pods:
-            labels = pod.get("metadata", {}).get("labels", {})
-            h = labels.get(_LABEL_TASK_HASH)
-            if h:
-                active_hashes.add(h)
-            g = labels.get(_KUEUE_POD_GROUP_NAME)
-            if g:
-                active_gang_groups.add(g)
+        active_gang_groups = {
+            g for pod in active_pods if (g := pod.get("metadata", {}).get("labels", {}).get(_KUEUE_POD_GROUP_NAME))
+        }
 
         # 1. Targeted cleanup: delete configmaps/PDBs for tasks that were killed
         #    since last GC, by task_hash label selector.
@@ -2993,7 +2979,15 @@ class K8sTaskProvider:
 
         if old_pod_names:
             self.kubectl.delete_many(K8sResource.PODS, old_pod_names, wait=False)
-        safe_hashes = old_task_hashes - active_hashes
+        # Re-read the active set instead of reusing the one from the top of the pass.
+        # Every delete above is a round trip, so the snapshot is stale by the whole
+        # sweep by now, and a task that started a new attempt in that window would not
+        # appear in it — deleting the ConfigMap and PDB it shares by task_hash would
+        # break the starting pod. The gang sweep above runs before the bulk deletes,
+        # so it still reads a fresh snapshot.
+        safe_hashes: set[str] = set()
+        if old_task_hashes:
+            safe_hashes = old_task_hashes - _task_hashes(self._list_active_pods())
         for task_hash in safe_hashes:
             labels = {**_MANAGED_POD_LABELS, _LABEL_TASK_HASH: task_hash}
             self.kubectl.delete_by_labels(K8sResource.CONFIGMAPS, labels, wait=False)
@@ -3064,17 +3058,18 @@ class K8sTaskProvider:
         # holds up to a full retention window of pods. setdefault keeps the active
         # entry if a name somehow appears in both.
         #
-        # Only an entry's FIRST candidate settles it. _lookup_pod prefers that
-        # current-scheme name, so a match on it is final, while a match on the pre-uid
-        # name is not — the preferred pod could still be further into the scan, and
-        # stopping there would resolve the attempt to a previous incarnation's pod.
+        # Only the name _lookup_entry_pod returns for a miss settles an entry: that is
+        # its preferred candidate, and _lookup_pod prefers it, so a match there is
+        # final. A match on the pre-uid name is not — the preferred pod could still be
+        # further into the scan, and stopping would resolve the attempt to a previous
+        # incarnation's pod.
         settled_by: dict[str, RunningTaskEntry] = {}
         unresolved: set[RunningTaskEntry] = set()
         for entry in running:
-            if self._lookup_entry_pod(pods_by_name, entry)[1] is not None:
-                continue
-            unresolved.add(entry)
-            settled_by[self._entry_pod_candidates(entry)[0]] = entry
+            name, pod = self._lookup_entry_pod(pods_by_name, entry)
+            if pod is None:
+                unresolved.add(entry)
+                settled_by[name] = entry
         if unresolved:
             for pod in self._iter_terminal_pods():
                 name = pod.get("metadata", {}).get("name", "")

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -411,11 +411,6 @@ def _pod_name_candidates(task_id: JobName, attempt_id: int, attempt_uid: str, *,
     return [current] if legacy == current else [current, legacy]
 
 
-def _task_hashes(pods: list[dict]) -> set[str]:
-    """The task hashes labelling *pods*. A hash is shared by every attempt of a task."""
-    return {h for pod in pods if (h := pod.get("metadata", {}).get("labels", {}).get(_LABEL_TASK_HASH))}
-
-
 def _lookup_pod(
     pods_by_name: dict[str, dict], task_id: JobName, attempt_id: int, attempt_uid: str, *, allow_legacy: bool
 ) -> tuple[str, dict | None]:
@@ -2893,7 +2888,9 @@ class K8sTaskProvider:
         # Task hashes that still have active (Pending/Running) pods must NOT have their
         # configmaps/PDBs deleted, even if an older attempt of the same task is
         # terminal — task_hash is shared across attempts.
-        active_hashes = _task_hashes(active_pods)
+        active_hashes = {
+            h for pod in active_pods if (h := pod.get("metadata", {}).get("labels", {}).get(_LABEL_TASK_HASH))
+        }
         # Pod-groups with live (Pending/Running) members share one Kueue
         # Workload across the gang; releasing it would evict the running
         # siblings, so the gang sweep must skip those groups entirely.
@@ -2925,9 +2922,9 @@ class K8sTaskProvider:
         if cleaned:
             logger.info("GC: cleaned up CMs/PDBs for %d killed task hashes", len(cleaned))
 
-        # 2. Age-based sweep: delete terminal pods older than the cutoff, and
-        #    their associated configmaps/PDBs (by task_hash label-selector delete).
-        #    Skip hashes that still have active pods to avoid deleting live resources.
+        # 2. Age-based sweep: delete terminal pods older than the cutoff and enqueue
+        #    their task hashes, so step 1 of a later pass cleans up the configmaps and
+        #    PDBs once it has confirmed no attempt of that task is active.
         old_pod_names: list[str] = []
         old_task_hashes: set[str] = set()
         gang_pod_names: list[str] = []
@@ -2979,27 +2976,19 @@ class K8sTaskProvider:
 
         if old_pod_names:
             self.kubectl.delete_many(K8sResource.PODS, old_pod_names, wait=False)
-        # Re-read the active set instead of reusing the one from the top of the pass.
-        # Every delete above is a round trip, so the snapshot is stale by the whole
-        # sweep by now, and a task that started a new attempt in that window would not
-        # appear in it — deleting the ConfigMap and PDB it shares by task_hash would
-        # break the starting pod. The gang sweep above runs before the bulk deletes,
-        # so it still reads a fresh snapshot.
-        safe_hashes: set[str] = set()
-        if old_task_hashes:
-            safe_hashes = old_task_hashes - _task_hashes(self._list_active_pods())
-        for task_hash in safe_hashes:
-            labels = {**_MANAGED_POD_LABELS, _LABEL_TASK_HASH: task_hash}
-            self.kubectl.delete_by_labels(K8sResource.CONFIGMAPS, labels, wait=False)
-            self.kubectl.delete_by_labels(K8sResource.PDBS, labels, wait=False)
-
-        if old_pod_names:
+            # CM/PDB cleanup follows the deferred path, as the gang sweep does. Doing
+            # it inline here would hang the only record of these hashes on a local:
+            # the pods that named them are deleted above, so no later pass could
+            # rediscover them, and anything that raised in between would orphan their
+            # configmaps and PDBs for good. Step 1 of the next pass deletes them
+            # against its own fresh active-pod read, and retries whatever fails.
+            with self._gc_lock:
+                self._pending_gc_hashes.update(old_task_hashes)
             logger.info(
-                "GC: deleted %d terminal pods + CMs/PDBs for %d task hashes (age > %ds, %d skipped with active pods)",
+                "GC: deleted %d terminal pods, deferred CM/PDB cleanup for %d task hashes (age > %ds)",
                 len(old_pod_names),
-                len(safe_hashes),
+                len(old_task_hashes),
                 _GC_MAX_AGE_SECONDS,
-                len(old_task_hashes - safe_hashes),
             )
 
     def _iter_terminal_pods(self) -> Iterator[dict]:

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -1233,9 +1233,8 @@ _ACTIVE_PODS_FIELD_SELECTOR = "status.phase!=Succeeded,status.phase!=Failed"
 # Standard label filter for iris-managed pods.
 _MANAGED_POD_LABELS = {_LABEL_MANAGED: "true", _LABEL_RUNTIME: _RUNTIME_LABEL_VALUE}
 
-# Garbage collection: how often to run the terminal-pod cleanup pass (seconds).
-# 1 minute bounds how long a wedged gang can pin idle GPU nodes (the pass is two
-# field-selector list calls, so the cadence is cheap).
+# Garbage collection: how often the background GC thread runs a cleanup pass
+# (seconds). 1 minute bounds how long a wedged gang can pin idle GPU nodes.
 _GC_INTERVAL_SECONDS = 60
 
 # Garbage collection: delete terminal pods and orphaned configmaps/PDBs older than this (seconds).
@@ -2303,9 +2302,14 @@ class K8sTaskProvider:
     _periodic_profiler: PeriodicProfiler | None = field(default=None, init=False, repr=False)
     _task_event_log: TaskEventLog | None = field(default=None, init=False, repr=False)
     _cluster_state: ClusterState = field(default_factory=ClusterState, init=False, repr=False)
-    _last_gc_time: float = field(default=0.0, init=False, repr=False)
     _last_cluster_scan: float = field(default=0.0, init=False, repr=False)
     _last_preempt_time: float = field(default=0.0, init=False, repr=False)
+    # Terminal-resource GC runs on its own thread. _gc_lock guards the two pieces of
+    # state it shares with the control loop: the active-pod snapshot sync hands it,
+    # and the deferred-cleanup hash set both threads write.
+    _gc_emitter: PeriodicEmitter | None = field(default=None, init=False, repr=False)
+    _gc_active_pods: list[dict] = field(default_factory=list, init=False, repr=False)
+    _gc_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
     _pending_gc_hashes: set[str] = field(default_factory=set, init=False, repr=False)
 
     def _ensure_resource_collector(self) -> ResourceCollector | None:
@@ -2409,9 +2413,11 @@ class K8sTaskProvider:
 
         New-pod application runs every tick so dispatch stays responsive; the
         cluster-wide kubectl scans (pod list, stray-pod GC, pod poll, node
-        refresh, terminal GC) run at most once per ``cluster_scan_interval``,
-        and continue to run on an idle cluster (the controller never gates a
-        cluster backend's reconcile on having work) so orphaned pods are reaped.
+        refresh) run at most once per ``cluster_scan_interval``, and continue to
+        run on an idle cluster (the controller never gates a cluster backend's
+        reconcile on having work) so orphaned pods are reaped. Terminal-resource
+        GC only takes the active-pod snapshot here; its pass runs on its own
+        thread.
         """
         # Free GPU capacity for any incoming GPU pod before it is created (gang
         # member or single-pod GPU job — both route through Kueue): Kueue TAS
@@ -2621,6 +2627,8 @@ class K8sTaskProvider:
         return job_pb2.GetProcessStatusResponse(process_info=_parse_pod_proc_status(result.stdout or ""))
 
     def close(self) -> None:
+        if self._gc_emitter is not None:
+            self._gc_emitter.close()
         if self._resource_collector is not None:
             self._resource_collector.close()
         if self._periodic_profiler is not None:
@@ -2802,7 +2810,8 @@ class K8sTaskProvider:
         # The GC pass re-drives any gang pods that survive this teardown.
         self._release_gang_reservations(stray_gang_pod_names, stray_pod_groups)
         # Enqueue task hashes for deferred configmap/PDB cleanup by the GC pass.
-        self._pending_gc_hashes.update(stray_hashes)
+        with self._gc_lock:
+            self._pending_gc_hashes.update(stray_hashes)
 
         logger.info(
             "Deleted %d stray pods for %d task hashes (%d Kueue workloads released, CM/PDB cleanup deferred to GC)",
@@ -2838,34 +2847,40 @@ class K8sTaskProvider:
             self.kubectl.delete(K8sResource.WORKLOADS, name, wait=False)
 
     def _maybe_gc_terminal_resources(self, active_pods: list[dict]) -> None:
-        """Periodically delete terminal (Succeeded/Failed) pods and their associated
-        configmaps/PDBs that are older than _GC_MAX_AGE_SECONDS, and sweep terminal
-        gang pods (with their Kueue Workloads) on the shorter gang retention.
+        """Declare the current active-pod set for the background GC pass, which deletes
+        terminal (Succeeded/Failed) pods and their associated configmaps/PDBs older
+        than _GC_MAX_AGE_SECONDS, and sweeps terminal gang pods (with their Kueue
+        Workloads) on the shorter gang retention.
 
         Without this, completed pods and their configmaps accumulate in etcd indefinitely
         since the sync loop's field selector excludes terminal pods from its queries.
 
+        The pass costs one API round trip per deleted pod, so a backlog takes minutes
+        of serial requests. It runs on its own thread — never the control loop — so a
+        slow pass cannot stall scheduling or task-state reconciliation.
+
         active_pods is the list of Pending/Running pods from the current sync cycle,
         used to protect configmaps/PDBs for tasks that have active retry attempts.
         """
-        now = time.monotonic()
-        if now - self._last_gc_time < _GC_INTERVAL_SECONDS:
-            return
-        self._last_gc_time = now
+        with self._gc_lock:
+            self._gc_active_pods = list(active_pods)
+        if self._gc_emitter is None:
+            self._gc_emitter = PeriodicEmitter(self._gc_once, interval=_GC_INTERVAL_SECONDS, name="terminal-gc")
 
-        try:
-            self._gc_terminal_resources(active_pods)
-        except Exception:
-            logger.exception("GC pass failed; will retry next interval")
+    def _gc_once(self) -> None:
+        """One GC pass against the active-pod set of the latest sync cycle."""
+        with self._gc_lock:
+            active_pods = list(self._gc_active_pods)
+        self._gc_terminal_resources(active_pods)
 
     def _gc_terminal_resources(self, active_pods: list[dict]) -> None:
         """One GC pass: deferred CM/PDB cleanup, the 1h terminal-pod sweep, and a
         short-retention sweep of terminal gang pods that strips the Kueue pod
         finalizer and deletes the pod-group Workloads they would otherwise pin.
 
-        The pass runs on the control-loop thread, so it reads at most
-        _GC_MAX_PODS_PER_PASS terminal pods per phase; a larger backlog drains over
-        successive passes instead of stalling scheduling and task reconciliation.
+        Reads at most _GC_MAX_PODS_PER_PASS terminal pods per phase, so one pass costs
+        a bounded number of API round trips and a larger backlog drains over successive
+        passes.
         """
         now = datetime.now(UTC).timestamp()
         cutoff = now - _GC_MAX_AGE_SECONDS
@@ -2893,8 +2908,9 @@ class K8sTaskProvider:
         #    instead of listing all resources and filtering client-side.
         #    Only remove hashes we actually clean up; skipped hashes (still active)
         #    stay in the set for the next GC cycle.
-        safe_pending = self._pending_gc_hashes - active_hashes
-        self._pending_gc_hashes -= safe_pending
+        with self._gc_lock:
+            safe_pending = self._pending_gc_hashes - active_hashes
+            self._pending_gc_hashes -= safe_pending
         for task_hash in safe_pending:
             labels = {**_MANAGED_POD_LABELS, _LABEL_TASK_HASH: task_hash}
             self.kubectl.delete_by_labels(K8sResource.CONFIGMAPS, labels, wait=False)
@@ -2946,7 +2962,8 @@ class K8sTaskProvider:
             self._release_gang_reservations(gang_pod_names, gang_pod_groups)
             # CM/PDB cleanup follows the deferred path so active retry
             # attempts sharing the task hash keep their resources.
-            self._pending_gc_hashes.update(gang_task_hashes)
+            with self._gc_lock:
+                self._pending_gc_hashes.update(gang_task_hashes)
             logger.info(
                 "GC: swept %d terminal gang pods, released %d Kueue workloads",
                 len(gang_pod_names),

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -1249,18 +1249,6 @@ _GC_MAX_AGE_SECONDS = 3600  # 1 hour
 # cannot race exit-status collection.
 _GANG_GC_MAX_AGE_SECONDS = 60
 
-# Garbage collection: terminal pods deleted in one pass, counted separately for
-# the age sweep and the gang sweep. Each delete is a serial API round trip, so an
-# unbounded pass on a large backlog runs for minutes; the backlog drains at this
-# rate per _GC_INTERVAL_SECONDS instead.
-#
-# The gang sweep holds its own budget because it is the one with a deadline: gang
-# pods pin idle GPU nodes, which is why they get _GANG_GC_MAX_AGE_SECONDS instead
-# of the 1h retention. Under one shared budget an age-sweep backlog would spend
-# the whole pass before any gang pod was even read.
-_GC_MAX_DELETES_PER_PASS = 500
-_GC_MAX_GANG_DELETES_PER_PASS = 500
-
 # Blocker eviction: minimum interval between reconcile-driven eviction sweeps
 # of preempt_namespaces. Gang pods can stay SchedulingGated for many cycles
 # while Kueue retries admission; without this floor every reconcile would
@@ -2310,11 +2298,9 @@ class K8sTaskProvider:
     _cluster_state: ClusterState = field(default_factory=ClusterState, init=False, repr=False)
     _last_cluster_scan: float = field(default=0.0, init=False, repr=False)
     _last_preempt_time: float = field(default=0.0, init=False, repr=False)
-    # Terminal-resource GC runs on its own thread. _gc_lock guards the two pieces of
-    # state it shares with the control loop: the active-pod snapshot sync hands it,
-    # and the deferred-cleanup hash set both threads write.
+    # Terminal-resource GC runs on its own thread. _gc_lock guards the deferred-cleanup
+    # hash set, the one piece of state it shares with the control loop.
     _gc_emitter: PeriodicEmitter | None = field(default=None, init=False, repr=False)
-    _gc_active_pods: list[dict] = field(default_factory=list, init=False, repr=False)
     _gc_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
     _pending_gc_hashes: set[str] = field(default_factory=set, init=False, repr=False)
 
@@ -2512,7 +2498,7 @@ class K8sTaskProvider:
         node_pools = _fetch_node_pools(self.kubectl, self.pods.managed_label)
         self._cluster_state.update(managed_pods, nodes, workloads, node_pools)
 
-        self._maybe_gc_terminal_resources(managed_pods)
+        self._start_terminal_gc()
 
         return updates
 
@@ -2852,11 +2838,11 @@ class K8sTaskProvider:
         for name in pod_group_names:
             self.kubectl.delete(K8sResource.WORKLOADS, name, wait=False)
 
-    def _maybe_gc_terminal_resources(self, active_pods: list[dict]) -> None:
-        """Declare the current active-pod set for the background GC pass, which deletes
-        terminal (Succeeded/Failed) pods and their associated configmaps/PDBs older
-        than _GC_MAX_AGE_SECONDS, and sweeps terminal gang pods (with their Kueue
-        Workloads) on the shorter gang retention.
+    def _start_terminal_gc(self) -> None:
+        """Start the background GC thread, which deletes terminal (Succeeded/Failed)
+        pods and their associated configmaps/PDBs older than _GC_MAX_AGE_SECONDS, and
+        sweeps terminal gang pods (with their Kueue Workloads) on the shorter gang
+        retention.
 
         Without this, completed pods and their configmaps accumulate in etcd indefinitely
         since the sync loop's field selector excludes terminal pods from its queries.
@@ -2864,29 +2850,36 @@ class K8sTaskProvider:
         The pass costs one API round trip per deleted pod, so a backlog takes minutes
         of serial requests. It runs on its own thread — never the control loop — so a
         slow pass cannot stall scheduling or task-state reconciliation.
-
-        active_pods is the list of Pending/Running pods from the current sync cycle,
-        used to protect configmaps/PDBs for tasks that have active retry attempts.
         """
-        with self._gc_lock:
-            self._gc_active_pods = list(active_pods)
         if self._gc_emitter is None:
             self._gc_emitter = PeriodicEmitter(self._gc_once, interval=_GC_INTERVAL_SECONDS, name="terminal-gc")
 
     def _gc_once(self) -> None:
-        """One GC pass against the active-pod set of the latest sync cycle."""
-        with self._gc_lock:
-            active_pods = list(self._gc_active_pods)
-        self._gc_terminal_resources(active_pods)
+        """One GC pass, against active pods this thread reads itself.
+
+        Reading them here rather than taking sync's snapshot keeps the protection for
+        tasks with active retry attempts accurate however long the pass runs.
+        """
+        try:
+            active_pods = self.kubectl.list_json(
+                K8sResource.PODS,
+                labels=_MANAGED_POD_LABELS,
+                field_selector=_ACTIVE_PODS_FIELD_SELECTOR,
+            )
+            self._gc_terminal_resources(active_pods)
+        except Exception:
+            # PeriodicEmitter logs a bare warning naming the thread. #7881 was GC
+            # silently ceasing to work, so name it and keep the traceback.
+            logger.exception("GC pass failed; will retry next interval")
 
     def _gc_terminal_resources(self, active_pods: list[dict]) -> None:
         """One GC pass: deferred CM/PDB cleanup, the 1h terminal-pod sweep, and a
         short-retention sweep of terminal gang pods that strips the Kueue pod
         finalizer and deletes the pod-group Workloads they would otherwise pin.
 
-        Deletes at most _GC_MAX_DELETES_PER_PASS terminal pods, so one pass costs a
-        bounded number of API round trips and a larger backlog drains over successive
-        passes.
+        Runs on the GC thread, never the control loop, and reads the terminal pods
+        through a lazy paged iterator, so neither its duration nor the size of the
+        backlog it sweeps is anyone else's problem.
         """
         now = datetime.now(UTC).timestamp()
         cutoff = now - _GC_MAX_AGE_SECONDS
@@ -2923,6 +2916,10 @@ class K8sTaskProvider:
                 self.kubectl.delete_by_labels(K8sResource.CONFIGMAPS, labels, wait=False)
                 self.kubectl.delete_by_labels(K8sResource.PDBS, labels, wait=False)
                 cleaned.add(task_hash)
+        except Exception:
+            # Isolated from the pod sweep below: a persistently failing CM/PDB delete
+            # must not be what stops terminal pods from ever being collected.
+            logger.exception("GC: CM/PDB cleanup failed after %d of %d hashes", len(cleaned), len(safe_pending))
         finally:
             with self._gc_lock:
                 self._pending_gc_hashes -= cleaned
@@ -2938,18 +2935,6 @@ class K8sTaskProvider:
         gang_pod_groups: set[str] = set()
         gang_task_hashes: set[str] = set()
         for pod in self._iter_terminal_pods():
-            # Budget the deletes, not the scan: every name collected here is one the
-            # sweep will delete, so stopping at the budget still shrinks the backlog
-            # by a full pass's worth. Truncating the scan instead would let a prefix
-            # of pods too young to delete hide older ones from every pass.
-            #
-            # The scan stops only once BOTH budgets are full. A full age budget must
-            # not end the scan: the iterator yields every Succeeded pod before the
-            # first Failed one, and pods arrive in etcd key order, so a gang pod —
-            # Failed is the normal outcome for a crashed gang — can sit arbitrarily
-            # far behind an age-sweep backlog.
-            if len(old_pod_names) >= _GC_MAX_DELETES_PER_PASS and len(gang_pod_names) >= _GC_MAX_GANG_DELETES_PER_PASS:
-                break
             meta = pod.get("metadata", {})
             created = meta.get("creationTimestamp", "")
             if not created:
@@ -2967,13 +2952,12 @@ class K8sTaskProvider:
             if pod_group and pod_group in active_gang_groups:
                 continue
             if pod_group and (meta.get("deletionTimestamp") or ts < gang_cutoff):
-                if len(gang_pod_names) < _GC_MAX_GANG_DELETES_PER_PASS:
-                    gang_pod_names.append(meta["name"])
-                    gang_pod_groups.add(pod_group)
-                    if task_hash:
-                        gang_task_hashes.add(task_hash)
+                gang_pod_names.append(meta["name"])
+                gang_pod_groups.add(pod_group)
+                if task_hash:
+                    gang_task_hashes.add(task_hash)
                 continue
-            if ts < cutoff and len(old_pod_names) < _GC_MAX_DELETES_PER_PASS:
+            if ts < cutoff:
                 old_pod_names.append(meta["name"])
                 if task_hash:
                     old_task_hashes.add(task_hash)
@@ -3014,8 +2998,8 @@ class K8sTaskProvider:
     def _iter_terminal_pods(self) -> Iterator[dict]:
         """Yield managed pods in a terminal phase (Succeeded or Failed), page by page.
 
-        Lazy so the GC sweep can stop once it has its delete budget, without holding a
-        whole backlog of pod bodies or paying for pages it will not use.
+        Paged and lazy, so neither caller materializes a whole terminal backlog and a
+        caller that resolves what it needs early stops paying for the rest.
         """
         # Field selectors AND their comma-separated terms, so a single
         # status.phase==Succeeded,status.phase==Failed matches nothing (a pod is
@@ -3026,10 +3010,6 @@ class K8sTaskProvider:
                 labels=_MANAGED_POD_LABELS,
                 field_selector=f"status.phase={phase}",
             )
-
-    def _list_terminal_pods(self) -> list[dict]:
-        """Bulk-list managed pods in a terminal phase (Succeeded or Failed)."""
-        return list(self._iter_terminal_pods())
 
     def _poll_pods(
         self, running: list[RunningTaskEntry], cached_pods: list[dict], workloads: list[dict] | None = None
@@ -3069,7 +3049,7 @@ class K8sTaskProvider:
         # so steady-state cycles add no call. setdefault keeps the active entry
         # if a name somehow appears in both.
         if any(self._lookup_entry_pod(pods_by_name, entry)[1] is None for entry in running):
-            for pod in self._list_terminal_pods():
+            for pod in self._iter_terminal_pods():
                 pods_by_name.setdefault(pod.get("metadata", {}).get("name", ""), pod)
 
         # (task_id_wire, attempt_id) -> pod_name. Resource samples are

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -2974,9 +2974,8 @@ class K8sTaskProvider:
         """Bulk-list managed pods in a terminal phase (Succeeded or Failed).
 
         ``limit`` caps the pods read per phase, yielding an arbitrary prefix of the
-        terminal set. Only the GC sweep passes it: the sweep deletes what it reads, so
-        a truncated pass still makes progress, whereas ``_poll_pods`` needs the whole
-        set to resolve which running tasks finished.
+        terminal set. It is safe only for a sweep that deletes what it reads (progress
+        continues on the next pass), not for a caller that must see every terminal pod.
         """
         pods: list[dict] = []
         # Field selectors AND their comma-separated terms, so a single

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -1249,11 +1249,10 @@ _GC_MAX_AGE_SECONDS = 3600  # 1 hour
 # cannot race exit-status collection.
 _GANG_GC_MAX_AGE_SECONDS = 60
 
-# Garbage collection: terminal pods read per phase in one pass. The sweep runs
-# on the control-loop thread, so its cost per pass must not scale with the
-# backlog; the sweep deletes what it reads, so a backlog drains over successive
-# passes.
-_GC_MAX_PODS_PER_PASS = 500
+# Garbage collection: terminal pods deleted in one pass. Each delete is a serial
+# API round trip, so an unbounded pass on a large backlog runs for minutes; the
+# backlog drains at this rate per _GC_INTERVAL_SECONDS instead.
+_GC_MAX_DELETES_PER_PASS = 500
 
 # Blocker eviction: minimum interval between reconcile-driven eviction sweeps
 # of preempt_namespaces. Gang pods can stay SchedulingGated for many cycles
@@ -2878,8 +2877,8 @@ class K8sTaskProvider:
         short-retention sweep of terminal gang pods that strips the Kueue pod
         finalizer and deletes the pod-group Workloads they would otherwise pin.
 
-        Reads at most _GC_MAX_PODS_PER_PASS terminal pods per phase, so one pass costs
-        a bounded number of API round trips and a larger backlog drains over successive
+        Deletes at most _GC_MAX_DELETES_PER_PASS terminal pods, so one pass costs a
+        bounded number of API round trips and a larger backlog drains over successive
         passes.
         """
         now = datetime.now(UTC).timestamp()
@@ -2926,7 +2925,13 @@ class K8sTaskProvider:
         gang_pod_names: list[str] = []
         gang_pod_groups: set[str] = set()
         gang_task_hashes: set[str] = set()
-        for pod in self._list_terminal_pods(limit=_GC_MAX_PODS_PER_PASS):
+        for pod in self._iter_terminal_pods():
+            # Budget the deletes, not the scan: every name collected here is one the
+            # sweep will delete, so stopping at the budget still shrinks the backlog
+            # by a full pass's worth. Truncating the scan instead would let a prefix
+            # of pods too young to delete hide older ones from every pass.
+            if len(old_pod_names) + len(gang_pod_names) >= _GC_MAX_DELETES_PER_PASS:
+                break
             meta = pod.get("metadata", {})
             created = meta.get("creationTimestamp", "")
             if not created:
@@ -2987,27 +2992,25 @@ class K8sTaskProvider:
                 len(old_task_hashes - safe_hashes),
             )
 
-    def _list_terminal_pods(self, *, limit: int | None = None) -> list[dict]:
-        """Bulk-list managed pods in a terminal phase (Succeeded or Failed).
+    def _iter_terminal_pods(self) -> Iterator[dict]:
+        """Yield managed pods in a terminal phase (Succeeded or Failed), page by page.
 
-        ``limit`` caps the pods read per phase, yielding an arbitrary prefix of the
-        terminal set. It is safe only for a sweep that deletes what it reads (progress
-        continues on the next pass), not for a caller that must see every terminal pod.
+        Lazy so the GC sweep can stop once it has its delete budget, without holding a
+        whole backlog of pod bodies or paying for pages it will not use.
         """
-        pods: list[dict] = []
         # Field selectors AND their comma-separated terms, so a single
         # status.phase==Succeeded,status.phase==Failed matches nothing (a pod is
         # never both); list each terminal phase separately.
         for phase in ("Succeeded", "Failed"):
-            pods.extend(
-                self.kubectl.list_json(
-                    K8sResource.PODS,
-                    labels=_MANAGED_POD_LABELS,
-                    field_selector=f"status.phase={phase}",
-                    limit=limit,
-                )
+            yield from self.kubectl.iter_json(
+                K8sResource.PODS,
+                labels=_MANAGED_POD_LABELS,
+                field_selector=f"status.phase={phase}",
             )
-        return pods
+
+    def _list_terminal_pods(self) -> list[dict]:
+        """Bulk-list managed pods in a terminal phase (Succeeded or Failed)."""
+        return list(self._iter_terminal_pods())
 
     def _poll_pods(
         self, running: list[RunningTaskEntry], cached_pods: list[dict], workloads: list[dict] | None = None

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -2502,6 +2502,19 @@ class K8sTaskProvider:
 
         return updates
 
+    def _allow_legacy_pod_name(self, entry: RunningTaskEntry) -> bool:
+        """The pre-uid name is a candidate only for attempts this process did not dispatch."""
+        return (entry.task_id.to_wire(), entry.attempt_id) not in self._dispatched_attempts
+
+    def _entry_pod_candidates(self, entry: RunningTaskEntry) -> list[str]:
+        """Pod names a running entry may be under, current scheme first."""
+        return _pod_name_candidates(
+            entry.task_id,
+            entry.attempt_id,
+            entry.attempt_uid,
+            allow_legacy=self._allow_legacy_pod_name(entry),
+        )
+
     def _lookup_entry_pod(self, pods_by_name: dict[str, dict], entry: RunningTaskEntry) -> tuple[str, dict | None]:
         """Resolve a running entry to its pod, allowing the pre-uid name only when this
         process did not dispatch the attempt."""
@@ -2510,7 +2523,7 @@ class K8sTaskProvider:
             entry.task_id,
             entry.attempt_id,
             entry.attempt_uid,
-            allow_legacy=(entry.task_id.to_wire(), entry.attempt_id) not in self._dispatched_attempts,
+            allow_legacy=self._allow_legacy_pod_name(entry),
         )
 
     def _live_pod_name(self, target: TaskTarget) -> str:
@@ -3044,13 +3057,33 @@ class K8sTaskProvider:
         updates: list[TaskUpdate] = []
 
         # Resolve running tasks whose pod has left the active list (completed or
-        # vanished) with one bulk terminal-pods list instead of a per-pod GET
-        # each. Lazy: only fetched on cycles where at least one pod is missing,
-        # so steady-state cycles add no call. setdefault keeps the active entry
-        # if a name somehow appears in both.
-        if any(self._lookup_entry_pod(pods_by_name, entry)[1] is None for entry in running):
+        # vanished) by scanning terminal pods, instead of a per-pod GET each. Only
+        # scanned on cycles where at least one pod is missing, so steady-state cycles
+        # add no call, and the scan stops as soon as every missing attempt is
+        # accounted for: this runs on the control loop, and the terminal collection
+        # holds up to a full retention window of pods. setdefault keeps the active
+        # entry if a name somehow appears in both.
+        #
+        # Only an entry's FIRST candidate settles it. _lookup_pod prefers that
+        # current-scheme name, so a match on it is final, while a match on the pre-uid
+        # name is not — the preferred pod could still be further into the scan, and
+        # stopping there would resolve the attempt to a previous incarnation's pod.
+        settled_by: dict[str, RunningTaskEntry] = {}
+        unresolved: set[RunningTaskEntry] = set()
+        for entry in running:
+            if self._lookup_entry_pod(pods_by_name, entry)[1] is not None:
+                continue
+            unresolved.add(entry)
+            settled_by[self._entry_pod_candidates(entry)[0]] = entry
+        if unresolved:
             for pod in self._iter_terminal_pods():
-                pods_by_name.setdefault(pod.get("metadata", {}).get("name", ""), pod)
+                name = pod.get("metadata", {}).get("name", "")
+                pods_by_name.setdefault(name, pod)
+                settled = settled_by.get(name)
+                if settled is not None:
+                    unresolved.discard(settled)
+                    if not unresolved:
+                        break
 
         # (task_id_wire, attempt_id) -> pod_name. Resource samples are
         # appended directly to iris.task by the collector; the controller no

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -1249,10 +1249,17 @@ _GC_MAX_AGE_SECONDS = 3600  # 1 hour
 # cannot race exit-status collection.
 _GANG_GC_MAX_AGE_SECONDS = 60
 
-# Garbage collection: terminal pods deleted in one pass. Each delete is a serial
-# API round trip, so an unbounded pass on a large backlog runs for minutes; the
-# backlog drains at this rate per _GC_INTERVAL_SECONDS instead.
+# Garbage collection: terminal pods deleted in one pass, counted separately for
+# the age sweep and the gang sweep. Each delete is a serial API round trip, so an
+# unbounded pass on a large backlog runs for minutes; the backlog drains at this
+# rate per _GC_INTERVAL_SECONDS instead.
+#
+# The gang sweep holds its own budget because it is the one with a deadline: gang
+# pods pin idle GPU nodes, which is why they get _GANG_GC_MAX_AGE_SECONDS instead
+# of the 1h retention. Under one shared budget an age-sweep backlog would spend
+# the whole pass before any gang pod was even read.
 _GC_MAX_DELETES_PER_PASS = 500
+_GC_MAX_GANG_DELETES_PER_PASS = 500
 
 # Blocker eviction: minimum interval between reconcile-driven eviction sweeps
 # of preempt_namespaces. Gang pods can stay SchedulingGated for many cycles
@@ -2903,19 +2910,24 @@ class K8sTaskProvider:
                 active_gang_groups.add(g)
 
         # 1. Targeted cleanup: delete configmaps/PDBs for tasks that were killed
-        #    since last GC. Uses label-selector deletes (one kubectl call per hash)
-        #    instead of listing all resources and filtering client-side.
-        #    Only remove hashes we actually clean up; skipped hashes (still active)
-        #    stay in the set for the next GC cycle.
+        #    since last GC, by task_hash label selector.
+        #    Only discard hashes actually cleaned up: skipped hashes (still active)
+        #    and any the sweep did not reach stay in the set for the next GC cycle,
+        #    so a failed delete retries instead of leaking the resources forever.
         with self._gc_lock:
             safe_pending = self._pending_gc_hashes - active_hashes
-            self._pending_gc_hashes -= safe_pending
-        for task_hash in safe_pending:
-            labels = {**_MANAGED_POD_LABELS, _LABEL_TASK_HASH: task_hash}
-            self.kubectl.delete_by_labels(K8sResource.CONFIGMAPS, labels, wait=False)
-            self.kubectl.delete_by_labels(K8sResource.PDBS, labels, wait=False)
-        if safe_pending:
-            logger.info("GC: cleaned up CMs/PDBs for %d killed task hashes", len(safe_pending))
+        cleaned: set[str] = set()
+        try:
+            for task_hash in safe_pending:
+                labels = {**_MANAGED_POD_LABELS, _LABEL_TASK_HASH: task_hash}
+                self.kubectl.delete_by_labels(K8sResource.CONFIGMAPS, labels, wait=False)
+                self.kubectl.delete_by_labels(K8sResource.PDBS, labels, wait=False)
+                cleaned.add(task_hash)
+        finally:
+            with self._gc_lock:
+                self._pending_gc_hashes -= cleaned
+        if cleaned:
+            logger.info("GC: cleaned up CMs/PDBs for %d killed task hashes", len(cleaned))
 
         # 2. Age-based sweep: delete terminal pods older than the cutoff, and
         #    their associated configmaps/PDBs (by task_hash label-selector delete).
@@ -2930,7 +2942,13 @@ class K8sTaskProvider:
             # sweep will delete, so stopping at the budget still shrinks the backlog
             # by a full pass's worth. Truncating the scan instead would let a prefix
             # of pods too young to delete hide older ones from every pass.
-            if len(old_pod_names) + len(gang_pod_names) >= _GC_MAX_DELETES_PER_PASS:
+            #
+            # The scan stops only once BOTH budgets are full. A full age budget must
+            # not end the scan: the iterator yields every Succeeded pod before the
+            # first Failed one, and pods arrive in etcd key order, so a gang pod —
+            # Failed is the normal outcome for a crashed gang — can sit arbitrarily
+            # far behind an age-sweep backlog.
+            if len(old_pod_names) >= _GC_MAX_DELETES_PER_PASS and len(gang_pod_names) >= _GC_MAX_GANG_DELETES_PER_PASS:
                 break
             meta = pod.get("metadata", {})
             created = meta.get("creationTimestamp", "")
@@ -2949,12 +2967,13 @@ class K8sTaskProvider:
             if pod_group and pod_group in active_gang_groups:
                 continue
             if pod_group and (meta.get("deletionTimestamp") or ts < gang_cutoff):
-                gang_pod_names.append(meta["name"])
-                gang_pod_groups.add(pod_group)
-                if task_hash:
-                    gang_task_hashes.add(task_hash)
+                if len(gang_pod_names) < _GC_MAX_GANG_DELETES_PER_PASS:
+                    gang_pod_names.append(meta["name"])
+                    gang_pod_groups.add(pod_group)
+                    if task_hash:
+                        gang_task_hashes.add(task_hash)
                 continue
-            if ts < cutoff:
+            if ts < cutoff and len(old_pod_names) < _GC_MAX_DELETES_PER_PASS:
                 old_pod_names.append(meta["name"])
                 if task_hash:
                     old_task_hashes.add(task_hash)

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -1250,6 +1250,12 @@ _GC_MAX_AGE_SECONDS = 3600  # 1 hour
 # cannot race exit-status collection.
 _GANG_GC_MAX_AGE_SECONDS = 60
 
+# Garbage collection: terminal pods read per phase in one pass. The sweep runs
+# on the control-loop thread, so its cost per pass must not scale with the
+# backlog; the sweep deletes what it reads, so a backlog drains over successive
+# passes.
+_GC_MAX_PODS_PER_PASS = 500
+
 # Blocker eviction: minimum interval between reconcile-driven eviction sweeps
 # of preempt_namespaces. Gang pods can stay SchedulingGated for many cycles
 # while Kueue retries admission; without this floor every reconcile would
@@ -2856,6 +2862,10 @@ class K8sTaskProvider:
         """One GC pass: deferred CM/PDB cleanup, the 1h terminal-pod sweep, and a
         short-retention sweep of terminal gang pods that strips the Kueue pod
         finalizer and deletes the pod-group Workloads they would otherwise pin.
+
+        The pass runs on the control-loop thread, so it reads at most
+        _GC_MAX_PODS_PER_PASS terminal pods per phase; a larger backlog drains over
+        successive passes instead of stalling scheduling and task reconciliation.
         """
         now = datetime.now(UTC).timestamp()
         cutoff = now - _GC_MAX_AGE_SECONDS
@@ -2900,7 +2910,7 @@ class K8sTaskProvider:
         gang_pod_names: list[str] = []
         gang_pod_groups: set[str] = set()
         gang_task_hashes: set[str] = set()
-        for pod in self._list_terminal_pods():
+        for pod in self._list_terminal_pods(limit=_GC_MAX_PODS_PER_PASS):
             meta = pod.get("metadata", {})
             created = meta.get("creationTimestamp", "")
             if not created:
@@ -2960,8 +2970,14 @@ class K8sTaskProvider:
                 len(old_task_hashes - safe_hashes),
             )
 
-    def _list_terminal_pods(self) -> list[dict]:
-        """Bulk-list managed pods in a terminal phase (Succeeded or Failed)."""
+    def _list_terminal_pods(self, *, limit: int | None = None) -> list[dict]:
+        """Bulk-list managed pods in a terminal phase (Succeeded or Failed).
+
+        ``limit`` caps the pods read per phase, yielding an arbitrary prefix of the
+        terminal set. Only the GC sweep passes it: the sweep deletes what it reads, so
+        a truncated pass still makes progress, whereas ``_poll_pods`` needs the whole
+        set to resolve which running tasks finished.
+        """
         pods: list[dict] = []
         # Field selectors AND their comma-separated terms, so a single
         # status.phase==Succeeded,status.phase==Failed matches nothing (a pod is
@@ -2972,6 +2988,7 @@ class K8sTaskProvider:
                     K8sResource.PODS,
                     labels=_MANAGED_POD_LABELS,
                     field_selector=f"status.phase={phase}",
+                    limit=limit,
                 )
             )
         return pods

--- a/lib/iris/src/iris/cluster/platforms/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/fake.py
@@ -667,13 +667,21 @@ class InMemoryK8sService:
         self._check_failure("get_json")
         return self._resources.get((resource.plural, name))
 
+    def iter_json(
+        self,
+        resource: K8sResource,
+        *,
+        labels: dict[str, str] | None = None,
+        field_selector: str | None = None,
+    ) -> Iterator[dict]:
+        yield from self.list_json(resource, labels=labels, field_selector=field_selector)
+
     def list_json(
         self,
         resource: K8sResource,
         *,
         labels: dict[str, str] | None = None,
         field_selector: str | None = None,
-        limit: int | None = None,
     ) -> list[dict]:
         self._check_failure("list_json")
         plural = resource.plural
@@ -698,7 +706,7 @@ class InMemoryK8sService:
                     if not all(res_labels.get(k) == v for k, v in labels.items()):
                         continue
                 results.append(manifest)
-            return results[:limit] if limit is not None else results
+            return results
 
         results = []
         for (stored_plural, _), manifest in self._resources.items():
@@ -711,8 +719,6 @@ class InMemoryK8sService:
             if field_selector and not _matches_field_selector(manifest, field_selector):
                 continue
             results.append(manifest)
-            if limit is not None and len(results) >= limit:
-                break
         return results
 
     def delete(self, resource: K8sResource, name: str, *, force: bool = False, wait: bool = True) -> None:

--- a/lib/iris/src/iris/cluster/platforms/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/fake.py
@@ -673,6 +673,7 @@ class InMemoryK8sService:
         *,
         labels: dict[str, str] | None = None,
         field_selector: str | None = None,
+        limit: int | None = None,
     ) -> list[dict]:
         self._check_failure("list_json")
         plural = resource.plural
@@ -697,7 +698,7 @@ class InMemoryK8sService:
                     if not all(res_labels.get(k) == v for k, v in labels.items()):
                         continue
                 results.append(manifest)
-            return results
+            return results[:limit] if limit is not None else results
 
         results = []
         for (stored_plural, _), manifest in self._resources.items():
@@ -710,6 +711,8 @@ class InMemoryK8sService:
             if field_selector and not _matches_field_selector(manifest, field_selector):
                 continue
             results.append(manifest)
+            if limit is not None and len(results) >= limit:
+                break
         return results
 
     def delete(self, resource: K8sResource, name: str, *, force: bool = False, wait: bool = True) -> None:

--- a/lib/iris/src/iris/cluster/platforms/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/fake.py
@@ -673,7 +673,10 @@ class InMemoryK8sService:
         *,
         labels: dict[str, str] | None = None,
         field_selector: str | None = None,
+        namespace: str | None = None,
     ) -> Iterator[dict]:
+        # The fake holds one namespace, so an override resolves to the same store; it
+        # is accepted so the fake still stands in for cross-namespace reads.
         yield from self.list_json(resource, labels=labels, field_selector=field_selector)
 
     def list_json(

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -55,6 +55,13 @@ DEFAULT_TIMEOUT: float = 60.0
 # Threshold for slow-operation warnings (milliseconds)
 _SLOW_THRESHOLD_MS: int = 2000
 
+# Items requested per LIST page. An unpaginated list of a large collection
+# streams one chunked response body that no timeout bounds — the client arms a
+# per-recv socket timeout, which every arriving chunk resets — so a slow list
+# parks its caller indefinitely. Chunked lists bound both the response body and
+# the API server's etcd range read.
+_LIST_PAGE_LIMIT: int = 500
+
 # API error bodies quote the offending manifest; keep enough to identify the
 # verdict without flooding logs.
 _ERROR_BODY_MAX_LEN: int = 500
@@ -82,6 +89,7 @@ class K8sService(Protocol):
         *,
         labels: dict[str, str] | None = None,
         field_selector: str | None = None,
+        limit: int | None = None,
     ) -> list[dict]: ...
 
     def delete(self, resource: K8sResource, name: str, *, force: bool = False, wait: bool = True) -> None: ...
@@ -347,21 +355,42 @@ class CloudK8sService:
         *,
         labels: dict[str, str] | None = None,
         field_selector: str | None = None,
+        limit: int | None = None,
     ) -> list[dict]:
-        """List Kubernetes resources, optionally filtered by labels and/or field selectors."""
-        logger.info("k8s: LIST %s labels=%s field_selector=%s", resource.plural, labels, field_selector)
+        """List Kubernetes resources, optionally filtered by labels and/or field selectors.
+
+        The list is always chunked, so no single response body is unbounded no matter
+        how large the collection is. ``limit`` stops the walk once that many items are
+        collected and returns a prefix of the collection; sweeps that make progress by
+        deleting what they read use it to bound the work of one pass.
+        """
+        logger.info("k8s: LIST %s labels=%s field_selector=%s limit=%s", resource.plural, labels, field_selector, limit)
         kwargs = self._ns_kwargs(resource)
         if labels:
             kwargs["label_selector"] = _label_selector(labels)
         if field_selector:
             kwargs["field_selector"] = field_selector
         kwargs.update(self._request_timeout_kwargs())
+        # A limit of 0 means "no limit" to the API server, so never send one.
+        page_size = _LIST_PAGE_LIMIT if limit is None else max(1, min(limit, _LIST_PAGE_LIMIT))
+        api = self._resource_api(resource)
+        items: list[dict] = []
+        continue_token = ""
         with slow_log(logger, f"list {resource.plural}", threshold_ms=_SLOW_THRESHOLD_MS):
-            try:
-                result = self._resource_api(resource).get(**kwargs)
-                return [item.to_dict() for item in result.items]
-            except ApiException as e:
-                raise KubectlError(f"list {resource.plural} failed ({e.status}): {e.reason}") from e
+            while True:
+                page_kwargs = dict(kwargs, limit=page_size)
+                if continue_token:
+                    page_kwargs["_continue"] = continue_token
+                try:
+                    result = api.get(**page_kwargs)
+                except ApiException as e:
+                    raise KubectlError(f"list {resource.plural} failed ({e.status}): {e.reason}") from e
+                items.extend(item.to_dict() for item in result.items)
+                meta = result.metadata
+                continue_token = (meta["continue"] if meta is not None else None) or ""
+                if not continue_token or (limit is not None and len(items) >= limit):
+                    break
+        return items[:limit] if limit is not None else items
 
     # -- delete --------------------------------------------------------------
 

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -83,13 +83,22 @@ class K8sService(Protocol):
 
     def get_json(self, resource: K8sResource, name: str) -> dict | None: ...
 
+    def iter_json(
+        self,
+        resource: K8sResource,
+        *,
+        labels: dict[str, str] | None = None,
+        field_selector: str | None = None,
+    ) -> Iterator[dict]:
+        """Yield matching resources one page at a time."""
+        ...
+
     def list_json(
         self,
         resource: K8sResource,
         *,
         labels: dict[str, str] | None = None,
         field_selector: str | None = None,
-        limit: int | None = None,
     ) -> list[dict]: ...
 
     def delete(self, resource: K8sResource, name: str, *, force: bool = False, wait: bool = True) -> None: ...
@@ -349,48 +358,54 @@ class CloudK8sService:
 
     # -- list ----------------------------------------------------------------
 
-    def list_json(
+    def iter_json(
         self,
         resource: K8sResource,
         *,
         labels: dict[str, str] | None = None,
         field_selector: str | None = None,
-        limit: int | None = None,
-    ) -> list[dict]:
-        """List Kubernetes resources, optionally filtered by labels and/or field selectors.
+    ) -> Iterator[dict]:
+        """Yield matching resources one page at a time.
 
-        The list is always chunked, so no single response body is unbounded no matter
-        how large the collection is. ``limit`` stops the walk once that many items are
-        collected and returns a prefix of the collection; sweeps that make progress by
-        deleting what they read use it to bound the work of one pass.
+        Each page is its own bounded request: an unpaginated list streams a single
+        chunked body that no timeout bounds, because the per-recv socket timeout the
+        client arms is reset by every arriving chunk. A caller that keeps only a few
+        fields per item, or that stops early, never holds the whole collection.
         """
-        logger.info("k8s: LIST %s labels=%s field_selector=%s limit=%s", resource.plural, labels, field_selector, limit)
+        logger.info("k8s: LIST %s labels=%s field_selector=%s", resource.plural, labels, field_selector)
         kwargs = self._ns_kwargs(resource)
         if labels:
             kwargs["label_selector"] = _label_selector(labels)
         if field_selector:
             kwargs["field_selector"] = field_selector
         kwargs.update(self._request_timeout_kwargs())
-        # A limit of 0 means "no limit" to the API server, so never send one.
-        page_size = _LIST_PAGE_LIMIT if limit is None else max(1, min(limit, _LIST_PAGE_LIMIT))
         api = self._resource_api(resource)
-        items: list[dict] = []
         continue_token = ""
         with slow_log(logger, f"list {resource.plural}", threshold_ms=_SLOW_THRESHOLD_MS):
             while True:
-                page_kwargs = dict(kwargs, limit=page_size)
+                page_kwargs = dict(kwargs, limit=_LIST_PAGE_LIMIT)
                 if continue_token:
                     page_kwargs["_continue"] = continue_token
                 try:
                     result = api.get(**page_kwargs)
                 except ApiException as e:
                     raise KubectlError(f"list {resource.plural} failed ({e.status}): {e.reason}") from e
-                items.extend(item.to_dict() for item in result.items)
+                for item in result.items:
+                    yield item.to_dict()
                 meta = result.metadata
                 continue_token = (meta["continue"] if meta is not None else None) or ""
-                if not continue_token or (limit is not None and len(items) >= limit):
-                    break
-        return items[:limit] if limit is not None else items
+                if not continue_token:
+                    return
+
+    def list_json(
+        self,
+        resource: K8sResource,
+        *,
+        labels: dict[str, str] | None = None,
+        field_selector: str | None = None,
+    ) -> list[dict]:
+        """List Kubernetes resources, optionally filtered by labels and/or field selectors."""
+        return list(self.iter_json(resource, labels=labels, field_selector=field_selector))
 
     # -- delete --------------------------------------------------------------
 

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -422,7 +422,11 @@ class CloudK8sService:
                 self.delete(resource, name, force=force, wait=wait)
 
     def delete_by_labels(self, resource: K8sResource, labels: dict[str, str], *, wait: bool = False) -> None:
-        """Delete all resources matching the given label selector."""
+        """Delete all resources matching the given label selector.
+
+        One collection delete, not a list plus a delete per item: the caller sweeps
+        many selectors in a row, and each extra round trip is serial latency it pays.
+        """
         if not labels:
             return
         selector = _label_selector(labels)
@@ -434,10 +438,7 @@ class CloudK8sService:
         kwargs.update(self._request_timeout_kwargs())
         with slow_log(logger, f"delete_by_labels {resource.plural} -l {selector}", threshold_ms=_SLOW_THRESHOLD_MS):
             try:
-                api = self._resource_api(resource)
-                items = api.get(**{k: v for k, v in kwargs.items() if k != "propagation_policy"}).items
-                for item in items:
-                    self.delete(resource, item.metadata.name, wait=wait)
+                self._resource_api(resource).delete(**kwargs)
             except NotFoundError:
                 return
             except ApiException as e:

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -89,6 +89,7 @@ class K8sService(Protocol):
         *,
         labels: dict[str, str] | None = None,
         field_selector: str | None = None,
+        namespace: str | None = None,
     ) -> Iterator[dict]:
         """Yield matching resources one page at a time."""
         ...
@@ -453,18 +454,13 @@ class CloudK8sService:
             return
         selector = _label_selector(labels)
         logger.info("k8s: DELETE_BY_LABELS %s labels=%s", resource.plural, labels)
+        # iter_json and delete each raise KubectlError already, and delete tolerates
+        # NotFound, so there is nothing left here to translate.
         with slow_log(logger, f"delete_by_labels {resource.plural} -l {selector}", threshold_ms=_SLOW_THRESHOLD_MS):
-            try:
-                for item in self.iter_json(resource, labels=labels):
-                    name = item.get("metadata", {}).get("name")
-                    if name:
-                        self.delete(resource, name, wait=wait)
-            except NotFoundError:
-                return
-            except ApiException as e:
-                raise KubectlError(
-                    f"delete_by_labels {resource.plural} -l {selector} failed ({e.status}): {e.reason}"
-                ) from e
+            for item in self.iter_json(resource, labels=labels):
+                name = item.get("metadata", {}).get("name")
+                if name:
+                    self.delete(resource, name, wait=wait)
 
     # -- cross-namespace pod operations ---------------------------------------
 

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -364,6 +364,7 @@ class CloudK8sService:
         *,
         labels: dict[str, str] | None = None,
         field_selector: str | None = None,
+        namespace: str | None = None,
     ) -> Iterator[dict]:
         """Yield matching resources one page at a time.
 
@@ -371,9 +372,13 @@ class CloudK8sService:
         chunked body that no timeout bounds, because the per-recv socket timeout the
         client arms is reset by every arriving chunk. A caller that keeps only a few
         fields per item, or that stops early, never holds the whole collection.
+
+        ``namespace`` overrides the service's own namespace for cross-namespace reads.
         """
-        logger.info("k8s: LIST %s labels=%s field_selector=%s", resource.plural, labels, field_selector)
-        kwargs = self._ns_kwargs(resource)
+        logger.info(
+            "k8s: LIST %s labels=%s field_selector=%s namespace=%s", resource.plural, labels, field_selector, namespace
+        )
+        kwargs = {"namespace": namespace} if namespace else self._ns_kwargs(resource)
         if labels:
             kwargs["label_selector"] = _label_selector(labels)
         if field_selector:
@@ -439,21 +444,21 @@ class CloudK8sService:
     def delete_by_labels(self, resource: K8sResource, labels: dict[str, str], *, wait: bool = False) -> None:
         """Delete all resources matching the given label selector.
 
-        One collection delete, not a list plus a delete per item: the caller sweeps
-        many selectors in a row, and each extra round trip is serial latency it pays.
+        Lists the selector and deletes each match by name. A single DELETE on the
+        collection URL would be one request instead of N, but Kubernetes treats that as
+        the ``deletecollection`` verb, which the controller ClusterRole does not grant
+        (see CLUSTER_ROLE_RULES) — it would 403 at runtime.
         """
         if not labels:
             return
         selector = _label_selector(labels)
-        logger.info("k8s: DELETE_COLLECTION %s labels=%s", resource.plural, labels)
-        kwargs = self._ns_kwargs(resource)
-        kwargs["label_selector"] = selector
-        if not wait:
-            kwargs["propagation_policy"] = "Background"
-        kwargs.update(self._request_timeout_kwargs())
+        logger.info("k8s: DELETE_BY_LABELS %s labels=%s", resource.plural, labels)
         with slow_log(logger, f"delete_by_labels {resource.plural} -l {selector}", threshold_ms=_SLOW_THRESHOLD_MS):
             try:
-                self._resource_api(resource).delete(**kwargs)
+                for item in self.iter_json(resource, labels=labels):
+                    name = item.get("metadata", {}).get("name")
+                    if name:
+                        self.delete(resource, name, wait=wait)
             except NotFoundError:
                 return
             except ApiException as e:
@@ -464,17 +469,12 @@ class CloudK8sService:
     # -- cross-namespace pod operations ---------------------------------------
 
     def list_pods_in_namespace(self, namespace: str) -> list[dict]:
-        """List pods in an explicit namespace (not the service's own)."""
-        logger.info("k8s: LIST pods namespace=%s", namespace)
-        with slow_log(logger, f"list pods in {namespace}", threshold_ms=_SLOW_THRESHOLD_MS):
-            try:
-                result = self._resource_api(K8sResource.PODS).get(
-                    namespace=namespace,
-                    **self._request_timeout_kwargs(),
-                )
-                return [item.to_dict() for item in result.items]
-            except ApiException as e:
-                raise KubectlError(f"list pods in {namespace} failed ({e.status}): {e.reason}") from e
+        """List pods in an explicit namespace (not the service's own).
+
+        Chunked like every other list: this one runs on the control loop (blocker
+        eviction) against foreign tenant namespaces, which are larger than Iris's own.
+        """
+        return list(self.iter_json(K8sResource.PODS, namespace=namespace))
 
     def delete_pod_in_namespace(self, namespace: str, name: str) -> None:
         """Delete a pod in an explicit namespace, ignoring NotFound."""

--- a/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
@@ -36,6 +36,81 @@ def test_crud_client_requires_kubernetes(monkeypatch, client_attr: str):
         getattr(svc, client_attr)
 
 
+class _FakeApiServer:
+    """Paginating stand-in for one DynamicClient resource handle.
+
+    Serves `pages` of item names, obeying the `continue` query param the way the API
+    server does, and records every request it received.
+    """
+
+    def __init__(self, pages: list[list[str]]):
+        self._pages = pages
+        self.requests: list[dict] = []
+
+    def get(self, **kwargs):
+        self.requests.append(kwargs)
+        index = int(kwargs["_continue"]) if kwargs.get("_continue") else 0
+        names = self._pages[index]
+        more = index + 1 < len(self._pages)
+        return _FakeListResponse(names, str(index + 1) if more else "")
+
+
+class _FakeListResponse:
+    def __init__(self, names: list[str], continue_token: str):
+        self.items = [_FakeItem({"metadata": {"name": n}}) for n in names]
+        self.metadata = {"continue": continue_token}
+
+
+class _FakeItem:
+    def __init__(self, body: dict):
+        self._body = body
+
+    def to_dict(self) -> dict:
+        return self._body
+
+
+class _FakeDynamicClient:
+    def __init__(self, api: _FakeApiServer):
+        self.resources = _FakeDiscoverer(api)
+
+
+class _FakeDiscoverer:
+    def __init__(self, api: _FakeApiServer):
+        self._api = api
+
+    def get(self, **kwargs) -> _FakeApiServer:
+        return self._api
+
+
+def _service_with_api(pages: list[list[str]]) -> tuple[CloudK8sService, _FakeApiServer]:
+    svc = CloudK8sService(namespace="iris")
+    api = _FakeApiServer(pages)
+    # Seed the cached_property so no real kubernetes client is built.
+    svc.__dict__["_dyn"] = _FakeDynamicClient(api)
+    return svc, api
+
+
+def test_list_json_walks_all_pages():
+    """A list must be chunked: an unpaginated response body has no read bound (#7881)."""
+    svc, api = _service_with_api([["a", "b"], ["c", "d"], ["e"]])
+
+    names = [pod["metadata"]["name"] for pod in svc.list_json(K8sResource.PODS)]
+
+    assert names == ["a", "b", "c", "d", "e"]
+    assert [req.get("limit") for req in api.requests] == [k8s_service._LIST_PAGE_LIMIT] * 3
+    assert [req.get("_continue") for req in api.requests] == [None, "1", "2"]
+
+
+def test_list_json_limit_stops_the_walk():
+    """limit caps both the items returned and the requests issued."""
+    svc, api = _service_with_api([["a", "b"], ["c", "d"], ["e"]])
+
+    names = [pod["metadata"]["name"] for pod in svc.list_json(K8sResource.PODS, limit=3)]
+
+    assert names == ["a", "b", "c"]
+    assert len(api.requests) == 2
+
+
 # Test item_path construction for namespaced resources
 @pytest.mark.parametrize(
     "resource,name,namespace,expected",

--- a/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
@@ -46,6 +46,7 @@ class _FakeApiServer:
     def __init__(self, pages: list[list[str]]):
         self._pages = pages
         self.requests: list[dict] = []
+        self.deletes: list[dict] = []
 
     def get(self, **kwargs):
         self.requests.append(kwargs)
@@ -53,6 +54,9 @@ class _FakeApiServer:
         names = self._pages[index]
         more = index + 1 < len(self._pages)
         return _FakeListResponse(names, str(index + 1) if more else "")
+
+    def delete(self, **kwargs) -> None:
+        self.deletes.append(kwargs)
 
 
 class _FakeListResponse:
@@ -109,6 +113,20 @@ def test_list_json_limit_stops_the_walk():
 
     assert names == ["a", "b", "c"]
     assert len(api.requests) == 2
+
+
+def test_delete_by_labels_is_one_collection_delete():
+    """The selector goes to the server, which deletes the matches.
+
+    Listing the selector and deleting each match client-side costs one serial round
+    trip per resource, and GC sweeps many selectors back to back (#7881).
+    """
+    svc, api = _service_with_api([["a", "b", "c"]])
+
+    svc.delete_by_labels(K8sResource.CONFIGMAPS, {"iris.task-hash": "abc"})
+
+    assert api.requests == []
+    assert [d.get("label_selector") for d in api.deletes] == ["iris.task-hash=abc"]
 
 
 # Test item_path construction for namespaced resources

--- a/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
@@ -97,8 +97,8 @@ def test_list_json_walks_all_pages():
     names = [pod["metadata"]["name"] for pod in svc.list_json(K8sResource.PODS)]
 
     assert names == ["a", "b", "c", "d", "e"]
+    # Every request carries a page limit: an unpaginated one is the wedge itself.
     assert [req.get("limit") for req in api.requests] == [k8s_service._LIST_PAGE_LIMIT] * 3
-    assert [req.get("_continue") for req in api.requests] == [None, "1", "2"]
 
 
 def test_list_json_limit_stops_the_walk():

--- a/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
@@ -3,6 +3,8 @@
 
 """Tests for CloudK8sService helpers and K8sResource enum path construction."""
 
+from types import SimpleNamespace
+
 import pytest
 from iris.cluster.platforms.k8s import service as k8s_service
 from iris.cluster.platforms.k8s.service import CloudK8sService
@@ -73,24 +75,12 @@ class _FakeItem:
         return self._body
 
 
-class _FakeDynamicClient:
-    def __init__(self, api: _FakeApiServer):
-        self.resources = _FakeDiscoverer(api)
-
-
-class _FakeDiscoverer:
-    def __init__(self, api: _FakeApiServer):
-        self._api = api
-
-    def get(self, **kwargs) -> _FakeApiServer:
-        return self._api
-
-
 def _service_with_api(pages: list[list[str]]) -> tuple[CloudK8sService, _FakeApiServer]:
+    """A CloudK8sService whose every resource handle is one fake API server."""
     svc = CloudK8sService(namespace="iris")
     api = _FakeApiServer(pages)
     # Seed the cached_property so no real kubernetes client is built.
-    svc.__dict__["_dyn"] = _FakeDynamicClient(api)
+    svc.__dict__["_dyn"] = SimpleNamespace(resources=SimpleNamespace(get=lambda **kwargs: api))
     return svc, api
 
 
@@ -105,14 +95,14 @@ def test_list_json_walks_all_pages():
     assert [req.get("limit") for req in api.requests] == [k8s_service._LIST_PAGE_LIMIT] * 3
 
 
-def test_list_json_limit_stops_the_walk():
-    """limit caps both the items returned and the requests issued."""
+def test_iter_json_stops_fetching_when_abandoned():
+    """A caller that stops early stops paying: the later pages are never requested."""
     svc, api = _service_with_api([["a", "b"], ["c", "d"], ["e"]])
 
-    names = [pod["metadata"]["name"] for pod in svc.list_json(K8sResource.PODS, limit=3)]
+    first = next(iter(svc.iter_json(K8sResource.PODS)))
 
-    assert names == ["a", "b", "c"]
-    assert len(api.requests) == 2
+    assert first["metadata"]["name"] == "a"
+    assert len(api.requests) == 1
 
 
 def test_delete_by_labels_is_one_collection_delete():

--- a/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
@@ -105,18 +105,18 @@ def test_iter_json_stops_fetching_when_abandoned():
     assert len(api.requests) == 1
 
 
-def test_delete_by_labels_is_one_collection_delete():
-    """The selector goes to the server, which deletes the matches.
+def test_delete_by_labels_deletes_each_match_by_name():
+    """Deletes go by name, never as a DELETE on the collection URL.
 
-    Listing the selector and deleting each match client-side costs one serial round
-    trip per resource, and GC sweeps many selectors back to back (#7881).
+    Kubernetes treats a collection DELETE as the `deletecollection` verb, which the
+    controller ClusterRole does not grant, so it would 403 at runtime.
     """
-    svc, api = _service_with_api([["a", "b", "c"]])
+    svc, api = _service_with_api([["a", "b"], ["c"]])
 
     svc.delete_by_labels(K8sResource.CONFIGMAPS, {"iris.task-hash": "abc"})
 
-    assert api.requests == []
-    assert [d.get("label_selector") for d in api.deletes] == ["iris.task-hash=abc"]
+    assert [d.get("name") for d in api.deletes] == ["a", "b", "c"]
+    assert all(d.get("label_selector") is None for d in api.deletes)
 
 
 # Test item_path construction for namespaced resources

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -1499,6 +1499,30 @@ def test_gc_sweeps_finalizer_wedged_gang_pod(provider, k8s):
     assert k8s.get_json(K8sResource.WORKLOADS, group) is None
 
 
+def test_gc_sweeps_gang_pods_behind_a_full_age_budget(provider, k8s):
+    """An age-sweep backlog must not delay the gang sweep.
+
+    Gang pods pin idle GPU nodes, which is why they get the short retention. The
+    iterator yields every Succeeded pod before the first Failed one, so under a single
+    shared delete budget a Succeeded backlog would consume the whole pass and a crashed
+    gang would wait passes for its Workload to be released.
+    """
+    now = datetime.now(UTC)
+    old_ts = (now - timedelta(seconds=_GC_MAX_AGE_SECONDS + 600)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    age_ts = (now - timedelta(seconds=_GANG_GC_MAX_AGE_SECONDS + 60)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    for i in range(_GC_MAX_DELETES_PER_PASS + 100):
+        _seed_terminal_pod(k8s, f"old-succeeded-{i:04d}", "Succeeded", f"hash{i:016d}", old_ts)
+    group = "starved-gang-group"
+    _seed_gang_pod(k8s, "starved-gang-pod", group, age_ts)
+    k8s.seed_resource(K8sResource.WORKLOADS, group, {"kind": "Workload", "metadata": {"name": group}})
+
+    provider._gc_terminal_resources(active_pods=[])
+
+    assert k8s.get_json(K8sResource.PODS, "starved-gang-pod") is None
+    assert k8s.get_json(K8sResource.WORKLOADS, group) is None
+
+
 def test_gc_sweeps_crashed_gang_pods_on_short_retention(provider, k8s):
     """A Failed gang pod older than the gang retention (but younger than the 1h
     plain-pod retention) is swept along with its Workload; a non-gang Failed pod

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -315,6 +315,52 @@ def test_sync_finds_pod_dispatched_before_pod_names_embedded_uid(provider, k8s):
         assert result[0].new_state == job_pb2.TASK_STATE_RUNNING
 
 
+class _CountingK8sService:
+    """InMemoryK8sService that counts the items iter_json actually yields."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.items_read = 0
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+    def iter_json(self, *args, **kwargs):
+        for item in self._inner.iter_json(*args, **kwargs):
+            self.items_read += 1
+            yield item
+
+
+def test_poll_stops_scanning_terminal_pods_once_attempts_resolve(k8s, task_stats_table):
+    """Resolving a finished pod must not read the whole terminal backlog.
+
+    This scan is on the control loop, and the terminal collection holds up to a full
+    retention window of pods, so reading all of them on every tick where a pod
+    completes is the shape of read that wedged #7881.
+    """
+    counting = _CountingK8sService(k8s)
+    provider = K8sTaskProvider(
+        kubectl=counting,
+        pods=pod_config(),
+        task_stats_table=task_stats_table,
+        cluster_scan_interval=0.0,
+    )
+    task_id = JobName.from_wire("/job/0")
+    entry = RunningTaskEntry(task_id=task_id, attempt_id=0)
+    populate_pod(k8s, _pod_name(task_id, 0), "Succeeded", exit_code=0)
+    for i in range(200):
+        populate_pod(k8s, f"unrelated-terminal-{i:04d}", "Succeeded", exit_code=0)
+
+    try:
+        result = provider.sync(make_batch(running_tasks=[entry]))
+    finally:
+        provider.close()
+
+    assert len(result) == 1
+    assert result[0].new_state == job_pb2.TASK_STATE_SUCCEEDED
+    assert counting.items_read == 1, "scan must stop at the pod that settles the attempt"
+
+
 def test_lookup_pod_prefers_uid_name_when_both_are_present(provider, k8s):
     """With both names in the pod set, the uid-named pod wins.
 

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -1147,19 +1147,23 @@ def test_gc_bounds_pods_read_per_pass(provider, k8s):
     assert k8s.list_json(K8sResource.PODS, labels=_MANAGED_POD_LABELS) == []
 
 
-def test_gc_respects_interval(provider, k8s):
-    """_maybe_gc_terminal_resources should only run every _GC_INTERVAL_SECONDS."""
+def test_gc_does_not_run_on_the_calling_thread(provider, k8s):
+    """A sync cycle hands GC its active-pod set and returns; it never sweeps inline.
 
+    The sweep spends one API round trip per deleted resource, so running it inline
+    stalled scheduling and reconciliation behind the whole backlog (#7881).
+    """
     now = datetime.now(UTC)
     old_ts = (now - timedelta(seconds=_GC_MAX_AGE_SECONDS + 600)).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    # Trigger GC once to set _last_gc_time to now.
-    provider._maybe_gc_terminal_resources(active_pods=[])
-
-    # Seed an old pod. An immediate second call should NOT trigger GC (interval not elapsed).
     _seed_terminal_pod(k8s, "gc-pod-1", "Succeeded", "aaaa111122223333", old_ts)
+
     provider._maybe_gc_terminal_resources(active_pods=[])
-    assert k8s.get_json(K8sResource.PODS, "gc-pod-1") is not None  # Still exists — interval gate held
+
+    assert k8s.get_json(K8sResource.PODS, "gc-pod-1") is not None
+
+    # The pass the GC thread would run does delete it, against that same snapshot.
+    provider._gc_once()
+    assert k8s.get_json(K8sResource.PODS, "gc-pod-1") is None
 
 
 def test_gc_cleans_up_deferred_configmaps(provider, k8s):

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -1283,19 +1283,45 @@ def test_gc_skips_hashes_with_active_pods(provider, k8s):
     }
     k8s.seed_resource(K8sResource.PDBS, "active-retry-pdb", pdb)
 
-    # Simulate the active pod (from the sync loop's managed_pods list).
-    active_pod = {
-        "metadata": {"name": "active-attempt-1", "labels": {_LABEL_TASK_HASH: shared_hash}},
-        "status": {"phase": "Running"},
-    }
+    # The active retry's pod. Seeded, not synthesized: the sweep re-reads the active
+    # set before deleting CMs/PDBs, because its own pod deletes take long enough that
+    # a task can start a new attempt in the meantime.
+    populate_pod(k8s, "active-attempt-1", "Running", labels={_LABEL_TASK_HASH: shared_hash})
 
-    provider._gc_terminal_resources(active_pods=[active_pod])
+    provider._gc_terminal_resources(active_pods=provider._list_active_pods())
 
     # Terminal pod is deleted (by name, not by hash).
     assert k8s.get_json(K8sResource.PODS, "old-attempt-0") is None
     # But configmap and PDB are preserved because the hash is still active.
     assert k8s.get_json(K8sResource.CONFIGMAPS, "active-retry-cm") is not None
     assert k8s.get_json(K8sResource.PDBS, "active-retry-pdb") is not None
+
+
+def test_gc_spares_an_attempt_that_starts_mid_pass(provider, k8s):
+    """An attempt that starts while the sweep is running keeps its configmap and PDB.
+
+    A pass deletes one pod per round trip, so by the time it reaches the CM/PDB step
+    the active set it read at the top can be minutes old. A task retried in that
+    window is absent from it, and its resources are shared across attempts by
+    task_hash, so trusting the stale set would break the starting pod.
+    """
+    now = datetime.now(UTC)
+    old_ts = (now - timedelta(seconds=_GC_MAX_AGE_SECONDS + 600)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    shared_hash = "shared_hash_67890"
+    labels = {_LABEL_MANAGED: "true", _LABEL_RUNTIME: _RUNTIME_LABEL_VALUE, _LABEL_TASK_HASH: shared_hash}
+
+    _seed_terminal_pod(k8s, "swept-attempt-0", "Succeeded", shared_hash, old_ts)
+    k8s.seed_resource(
+        K8sResource.CONFIGMAPS, "retried-cm", {"kind": "ConfigMap", "metadata": {"name": "retried-cm", "labels": labels}}
+    )
+    # The retry lands after the pass took its snapshot, which is why the pass is
+    # driven with an empty one here.
+    populate_pod(k8s, "retried-attempt-1", "Running", labels={_LABEL_TASK_HASH: shared_hash})
+
+    provider._gc_terminal_resources(active_pods=[])
+
+    assert k8s.get_json(K8sResource.PODS, "swept-attempt-0") is None
+    assert k8s.get_json(K8sResource.CONFIGMAPS, "retried-cm") is not None
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -9,7 +9,7 @@ import pytest
 from iris.cluster.backends.k8s.tasks import (
     _GANG_GC_MAX_AGE_SECONDS,
     _GC_MAX_AGE_SECONDS,
-    _GC_MAX_PODS_PER_PASS,
+    _GC_MAX_DELETES_PER_PASS,
     _KUEUE_MANAGED_FINALIZER,
     _KUEUE_POD_GROUP_NAME,
     _KUEUE_POD_GROUP_TOTAL,
@@ -1125,26 +1125,47 @@ def test_gc_deletes_old_terminal_pods_and_configmaps(provider, k8s):
     assert k8s.get_json(K8sResource.CONFIGMAPS, "recent-succeeded-pod-wf") is not None
 
 
-def test_gc_bounds_pods_read_per_pass(provider, k8s):
-    """A terminal-pod backlog must not make one GC pass unbounded.
+def test_gc_bounds_deletes_per_pass(provider, k8s):
+    """Each pass deletes a bounded number of pods, and the backlog drains over passes.
 
-    The sweep runs on the control-loop thread, so a namespace holding thousands of
-    terminal pods would otherwise stall scheduling behind a single giant list (#7881).
-    It reads a bounded slice per pass and drains the rest on later passes.
+    Every delete is a serial API round trip, so an unbounded pass on a large backlog
+    runs for minutes (#7881).
     """
     now = datetime.now(UTC)
     old_ts = (now - timedelta(seconds=_GC_MAX_AGE_SECONDS + 600)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    backlog = _GC_MAX_PODS_PER_PASS + 10
+    backlog = _GC_MAX_DELETES_PER_PASS + 10
     for i in range(backlog):
         _seed_terminal_pod(k8s, f"backlog-pod-{i}", "Succeeded", f"hash{i:016d}", old_ts)
 
     provider._gc_terminal_resources(active_pods=[])
     remaining = k8s.list_json(K8sResource.PODS, labels=_MANAGED_POD_LABELS)
-    assert len(remaining) == backlog - _GC_MAX_PODS_PER_PASS
+    assert len(remaining) == backlog - _GC_MAX_DELETES_PER_PASS
 
     provider._gc_terminal_resources(active_pods=[])
     assert k8s.list_json(K8sResource.PODS, labels=_MANAGED_POD_LABELS) == []
+
+
+def test_gc_collects_old_pods_behind_a_wall_of_recent_ones(provider, k8s):
+    """Pods too young to delete must not hide older ones from the sweep.
+
+    The per-pass bound applies to deletes, not to how far the scan reads. Bounding the
+    read instead would return the same prefix of undeletable pods every pass, and the
+    old pods behind it would never be examined — the accumulation GC exists to prevent.
+    """
+    now = datetime.now(UTC)
+    recent_ts = (now - timedelta(seconds=60)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    old_ts = (now - timedelta(seconds=_GC_MAX_AGE_SECONDS + 600)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Names sort ahead of the old pods, so any read-side cap would stop inside them.
+    for i in range(_GC_MAX_DELETES_PER_PASS + 100):
+        _seed_terminal_pod(k8s, f"aaa-recent-{i:04d}", "Succeeded", f"recent{i:010d}", recent_ts)
+    _seed_terminal_pod(k8s, "zzz-old-pod", "Succeeded", "oldhash0000000000", old_ts)
+
+    provider._gc_terminal_resources(active_pods=[])
+
+    assert k8s.get_json(K8sResource.PODS, "zzz-old-pod") is None
+    assert k8s.get_json(K8sResource.PODS, "aaa-recent-0000") is not None
 
 
 def test_gc_does_not_run_on_the_calling_thread(provider, k8s):

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -1160,10 +1160,13 @@ def test_gc_deletes_old_terminal_pods_and_configmaps(provider, k8s):
 
     provider._gc_terminal_resources(active_pods=[])
 
-    # Old resources deleted.
+    # Old pods deleted. Their CMs/PDBs are enqueued, not deleted inline, so the
+    # following pass is what clears them.
     assert k8s.get_json(K8sResource.PODS, "old-succeeded-pod") is None
-    assert k8s.get_json(K8sResource.CONFIGMAPS, "old-succeeded-pod-wf") is None
     assert k8s.get_json(K8sResource.PODS, "old-failed-pod") is None
+
+    provider._gc_terminal_resources(active_pods=[])
+    assert k8s.get_json(K8sResource.CONFIGMAPS, "old-succeeded-pod-wf") is None
 
     # Recent resources preserved.
     assert k8s.get_json(K8sResource.PODS, "recent-succeeded-pod") is not None
@@ -1283,11 +1286,12 @@ def test_gc_skips_hashes_with_active_pods(provider, k8s):
     }
     k8s.seed_resource(K8sResource.PDBS, "active-retry-pdb", pdb)
 
-    # The active retry's pod. Seeded, not synthesized: the sweep re-reads the active
-    # set before deleting CMs/PDBs, because its own pod deletes take long enough that
-    # a task can start a new attempt in the meantime.
+    # The active retry's pod, seeded so the passes below read it as active.
     populate_pod(k8s, "active-attempt-1", "Running", labels={_LABEL_TASK_HASH: shared_hash})
 
+    # Two passes: the first sweeps the terminal pod and enqueues its hash, the second
+    # is the one that would delete the CM/PDB if the active attempt did not hold them.
+    provider._gc_terminal_resources(active_pods=provider._list_active_pods())
     provider._gc_terminal_resources(active_pods=provider._list_active_pods())
 
     # Terminal pod is deleted (by name, not by hash).
@@ -1297,31 +1301,28 @@ def test_gc_skips_hashes_with_active_pods(provider, k8s):
     assert k8s.get_json(K8sResource.PDBS, "active-retry-pdb") is not None
 
 
-def test_gc_spares_an_attempt_that_starts_mid_pass(provider, k8s):
-    """An attempt that starts while the sweep is running keeps its configmap and PDB.
+def test_gc_defers_configmap_cleanup_for_age_swept_pods(provider, k8s):
+    """An age-swept task's CM/PDB cleanup is enqueued, never done in the same pass.
 
-    A pass deletes one pod per round trip, so by the time it reaches the CM/PDB step
-    the active set it read at the top can be minutes old. A task retried in that
-    window is absent from it, and its resources are shared across attempts by
-    task_hash, so trusting the stale set would break the starting pod.
+    The hashes come from the pods the pass just deleted, so they exist nowhere else:
+    cleaning up inline means anything that raises in between orphans those configmaps
+    and PDBs permanently, with no later pass able to rediscover them. Enqueuing puts
+    them in state that survives the pass and is retried.
     """
     now = datetime.now(UTC)
     old_ts = (now - timedelta(seconds=_GC_MAX_AGE_SECONDS + 600)).strftime("%Y-%m-%dT%H:%M:%SZ")
-    shared_hash = "shared_hash_67890"
-    labels = {_LABEL_MANAGED: "true", _LABEL_RUNTIME: _RUNTIME_LABEL_VALUE, _LABEL_TASK_HASH: shared_hash}
+    task_hash = "sweptaabbccdd1122"
 
-    _seed_terminal_pod(k8s, "swept-attempt-0", "Succeeded", shared_hash, old_ts)
-    k8s.seed_resource(
-        K8sResource.CONFIGMAPS, "retried-cm", {"kind": "ConfigMap", "metadata": {"name": "retried-cm", "labels": labels}}
-    )
-    # The retry lands after the pass took its snapshot, which is why the pass is
-    # driven with an empty one here.
-    populate_pod(k8s, "retried-attempt-1", "Running", labels={_LABEL_TASK_HASH: shared_hash})
+    _seed_terminal_pod(k8s, "swept-pod", "Succeeded", task_hash, old_ts)
+    _seed_configmap(k8s, "swept-pod-wf", task_hash, old_ts)
 
     provider._gc_terminal_resources(active_pods=[])
 
-    assert k8s.get_json(K8sResource.PODS, "swept-attempt-0") is None
-    assert k8s.get_json(K8sResource.CONFIGMAPS, "retried-cm") is not None
+    assert k8s.get_json(K8sResource.PODS, "swept-pod") is None
+    assert k8s.get_json(K8sResource.CONFIGMAPS, "swept-pod-wf") is not None, "cleanup must be deferred, not inline"
+
+    provider._gc_terminal_resources(active_pods=[])
+    assert k8s.get_json(K8sResource.CONFIGMAPS, "swept-pod-wf") is None
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -9,6 +9,7 @@ import pytest
 from iris.cluster.backends.k8s.tasks import (
     _GANG_GC_MAX_AGE_SECONDS,
     _GC_MAX_AGE_SECONDS,
+    _GC_MAX_PODS_PER_PASS,
     _KUEUE_MANAGED_FINALIZER,
     _KUEUE_POD_GROUP_NAME,
     _KUEUE_POD_GROUP_TOTAL,
@@ -1122,6 +1123,28 @@ def test_gc_deletes_old_terminal_pods_and_configmaps(provider, k8s):
     # Recent resources preserved.
     assert k8s.get_json(K8sResource.PODS, "recent-succeeded-pod") is not None
     assert k8s.get_json(K8sResource.CONFIGMAPS, "recent-succeeded-pod-wf") is not None
+
+
+def test_gc_bounds_pods_read_per_pass(provider, k8s):
+    """A terminal-pod backlog must not make one GC pass unbounded.
+
+    The sweep runs on the control-loop thread, so a namespace holding thousands of
+    terminal pods would otherwise stall scheduling behind a single giant list (#7881).
+    It reads a bounded slice per pass and drains the rest on later passes.
+    """
+    now = datetime.now(UTC)
+    old_ts = (now - timedelta(seconds=_GC_MAX_AGE_SECONDS + 600)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    backlog = _GC_MAX_PODS_PER_PASS + 10
+    for i in range(backlog):
+        _seed_terminal_pod(k8s, f"backlog-pod-{i}", "Succeeded", f"hash{i:016d}", old_ts)
+
+    provider._gc_terminal_resources(active_pods=[])
+    remaining = k8s.list_json(K8sResource.PODS, labels=_MANAGED_POD_LABELS)
+    assert len(remaining) == backlog - _GC_MAX_PODS_PER_PASS
+
+    provider._gc_terminal_resources(active_pods=[])
+    assert k8s.list_json(K8sResource.PODS, labels=_MANAGED_POD_LABELS) == []
 
 
 def test_gc_respects_interval(provider, k8s):

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -9,7 +9,6 @@ import pytest
 from iris.cluster.backends.k8s.tasks import (
     _GANG_GC_MAX_AGE_SECONDS,
     _GC_MAX_AGE_SECONDS,
-    _GC_MAX_DELETES_PER_PASS,
     _KUEUE_MANAGED_FINALIZER,
     _KUEUE_POD_GROUP_NAME,
     _KUEUE_POD_GROUP_TOTAL,
@@ -1125,51 +1124,8 @@ def test_gc_deletes_old_terminal_pods_and_configmaps(provider, k8s):
     assert k8s.get_json(K8sResource.CONFIGMAPS, "recent-succeeded-pod-wf") is not None
 
 
-def test_gc_bounds_deletes_per_pass(provider, k8s):
-    """Each pass deletes a bounded number of pods, and the backlog drains over passes.
-
-    Every delete is a serial API round trip, so an unbounded pass on a large backlog
-    runs for minutes (#7881).
-    """
-    now = datetime.now(UTC)
-    old_ts = (now - timedelta(seconds=_GC_MAX_AGE_SECONDS + 600)).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    backlog = _GC_MAX_DELETES_PER_PASS + 10
-    for i in range(backlog):
-        _seed_terminal_pod(k8s, f"backlog-pod-{i}", "Succeeded", f"hash{i:016d}", old_ts)
-
-    provider._gc_terminal_resources(active_pods=[])
-    remaining = k8s.list_json(K8sResource.PODS, labels=_MANAGED_POD_LABELS)
-    assert len(remaining) == backlog - _GC_MAX_DELETES_PER_PASS
-
-    provider._gc_terminal_resources(active_pods=[])
-    assert k8s.list_json(K8sResource.PODS, labels=_MANAGED_POD_LABELS) == []
-
-
-def test_gc_collects_old_pods_behind_a_wall_of_recent_ones(provider, k8s):
-    """Pods too young to delete must not hide older ones from the sweep.
-
-    The per-pass bound applies to deletes, not to how far the scan reads. Bounding the
-    read instead would return the same prefix of undeletable pods every pass, and the
-    old pods behind it would never be examined — the accumulation GC exists to prevent.
-    """
-    now = datetime.now(UTC)
-    recent_ts = (now - timedelta(seconds=60)).strftime("%Y-%m-%dT%H:%M:%SZ")
-    old_ts = (now - timedelta(seconds=_GC_MAX_AGE_SECONDS + 600)).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    # Names sort ahead of the old pods, so any read-side cap would stop inside them.
-    for i in range(_GC_MAX_DELETES_PER_PASS + 100):
-        _seed_terminal_pod(k8s, f"aaa-recent-{i:04d}", "Succeeded", f"recent{i:010d}", recent_ts)
-    _seed_terminal_pod(k8s, "zzz-old-pod", "Succeeded", "oldhash0000000000", old_ts)
-
-    provider._gc_terminal_resources(active_pods=[])
-
-    assert k8s.get_json(K8sResource.PODS, "zzz-old-pod") is None
-    assert k8s.get_json(K8sResource.PODS, "aaa-recent-0000") is not None
-
-
 def test_gc_does_not_run_on_the_calling_thread(provider, k8s):
-    """A sync cycle hands GC its active-pod set and returns; it never sweeps inline.
+    """A sync cycle starts the GC thread and returns; it never sweeps inline.
 
     The sweep spends one API round trip per deleted resource, so running it inline
     stalled scheduling and reconciliation behind the whole backlog (#7881).
@@ -1178,11 +1134,11 @@ def test_gc_does_not_run_on_the_calling_thread(provider, k8s):
     old_ts = (now - timedelta(seconds=_GC_MAX_AGE_SECONDS + 600)).strftime("%Y-%m-%dT%H:%M:%SZ")
     _seed_terminal_pod(k8s, "gc-pod-1", "Succeeded", "aaaa111122223333", old_ts)
 
-    provider._maybe_gc_terminal_resources(active_pods=[])
+    provider._start_terminal_gc()
 
     assert k8s.get_json(K8sResource.PODS, "gc-pod-1") is not None
 
-    # The pass the GC thread would run does delete it, against that same snapshot.
+    # The pass the GC thread would run does delete it.
     provider._gc_once()
     assert k8s.get_json(K8sResource.PODS, "gc-pod-1") is None
 
@@ -1496,30 +1452,6 @@ def test_gc_sweeps_finalizer_wedged_gang_pod(provider, k8s):
     provider._gc_terminal_resources(active_pods=[])
 
     assert k8s.get_json(K8sResource.PODS, "wedged-gang-pod") is None
-    assert k8s.get_json(K8sResource.WORKLOADS, group) is None
-
-
-def test_gc_sweeps_gang_pods_behind_a_full_age_budget(provider, k8s):
-    """An age-sweep backlog must not delay the gang sweep.
-
-    Gang pods pin idle GPU nodes, which is why they get the short retention. The
-    iterator yields every Succeeded pod before the first Failed one, so under a single
-    shared delete budget a Succeeded backlog would consume the whole pass and a crashed
-    gang would wait passes for its Workload to be released.
-    """
-    now = datetime.now(UTC)
-    old_ts = (now - timedelta(seconds=_GC_MAX_AGE_SECONDS + 600)).strftime("%Y-%m-%dT%H:%M:%SZ")
-    age_ts = (now - timedelta(seconds=_GANG_GC_MAX_AGE_SECONDS + 60)).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    for i in range(_GC_MAX_DELETES_PER_PASS + 100):
-        _seed_terminal_pod(k8s, f"old-succeeded-{i:04d}", "Succeeded", f"hash{i:016d}", old_ts)
-    group = "starved-gang-group"
-    _seed_gang_pod(k8s, "starved-gang-pod", group, age_ts)
-    k8s.seed_resource(K8sResource.WORKLOADS, group, {"kind": "Workload", "metadata": {"name": group}})
-
-    provider._gc_terminal_resources(active_pods=[])
-
-    assert k8s.get_json(K8sResource.PODS, "starved-gang-pod") is None
     assert k8s.get_json(K8sResource.WORKLOADS, group) is None
 
 


### PR DESCRIPTION
The Kubernetes control loop could stall for hours inside terminal-pod garbage
collection. Lists were unpaginated, and the client reads the whole chunked
response body under a per-recv socket timeout that every arriving chunk resets,
so the read had no upper bound. In a namespace holding more than 1,300 terminal
pods the status.phase=Succeeded list parked control-loop in the response body
for over 90 minutes while 64 finished GPU pods still showed as running.

Lists are now always chunked. iter_json yields page by page and list_json is the
eager wrapper, so no single response body is unbounded, the API server does
bounded etcd range reads instead of one namespace scan, and callers that keep a
few fields per item or stop early never hold the whole collection.
list_pods_in_namespace is chunked too: it runs on the control loop for blocker
eviction against foreign tenant namespaces, which are larger than Iris's own.

Pagination alone is not enough, because a pass also spends one serial API round
trip per deleted pod, configmap, and PDB — a later backlog took 7.5 minutes to
delete 10,361 pods before it even started on configmaps and PDBs. The pass now
runs on a PeriodicEmitter thread alongside the resource and profiler collectors
that already share this kubectl, and reads its own active-pod list rather than
taking sync's snapshot. The emitter waits a full interval between steps, so
passes never overlap.

Neither sweep deletes configmaps and PDBs itself. It enqueues the task hash, and
a later pass deletes them once it has confirmed against a freshly read active-pod
set that no attempt of that task is running — those resources are shared across
attempts by task_hash, so a stale read would take them out from under a retry
that started mid-pass. Enqueuing also means the hashes outlive the pass: they
come from pods the sweep just deleted, so cleaning up inline would orphan them
permanently if anything raised in between. Pending hashes are discarded only
once their delete succeeds, so a failed cleanup is retried rather than lost.
Cleanup of an age-swept task's configmap lags one GC interval; those resources
are already older than the 1h retention. The configmap and PDB cleanup is
isolated from the pod sweep, and a failed pass is logged with a traceback under
GC's own name rather than as a bare thread warning — #7881 was GC quietly
ceasing to work.

Deletes stay one call per name. A label-selector delete would be one request
instead of N, but Kubernetes treats a DELETE on a collection URL as the
deletecollection verb, which is distinct from delete and which
CLUSTER_ROLE_RULES does not grant.

Deferring makes _pending_gc_hashes the sole record of pending configmap and PDB
cleanup, and it lives only in memory, so a controller restart drops it and
nothing rescans for orphans. #7889 tracks reclaiming them without depending on
process memory.

Fixes #7881
