### PR TITLE
Fix FA4 leading-padding tile pruning

### DIFF
--- a/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
+++ b/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
@@ -85,7 +85,20 @@ def _packed_segment_causal_lower_bounds(
         positions = _replicate_metadata(jnp.arange(seq_len, dtype=jnp.int32)[None, :])
         window_lower_bounds = positions - (sliding_window - 1)
         lower_bounds = jnp.maximum(lower_bounds, window_lower_bounds)
-    return jnp.where(valid, lower_bounds, seq_len), valid
+
+    # The forward kernel uses the first query's lower bound to skip whole key
+    # tiles. If an M tile begins with left padding, a ``seq_len`` sentinel would
+    # incorrectly skip every key tile for valid queries later in that M tile.
+    # Give each invalid query the next valid query's bound instead. Trailing
+    # padding keeps the ``seq_len`` sentinel, so fully padded tail tiles remain
+    # cheap. The per-score predicate still uses ``valid`` as the authority.
+    next_valid_lower_bound = jax.lax.associative_scan(
+        jnp.minimum,
+        jnp.where(valid, lower_bounds, seq_len),
+        axis=1,
+        reverse=True,
+    )
+    return jnp.where(valid, lower_bounds, next_valid_lower_bound), valid
 
 
 def _simple_causal_lower_bounds(

--- a/lib/levanter/tests/grug/test_fa4_cute_attention.py
+++ b/lib/levanter/tests/grug/test_fa4_cute_attention.py
@@ -88,6 +88,20 @@ def test_packed_segment_backward_block_sparse_indices_split_full_blocks():
     )
 
 
+def test_packed_segment_causal_lower_bounds_carry_next_valid_bound_through_padding():
+    segment_ids = jnp.array([[-1, -1, 7, 7, 8, 8, -1]], dtype=jnp.int32)
+
+    lower_bounds, valid = fa4_cute._packed_segment_causal_lower_bounds(
+        segment_ids,
+        batch_size=1,
+        seq_len=7,
+        sliding_window=None,
+    )
+
+    np.testing.assert_array_equal(lower_bounds, jnp.array([[2, 2, 2, 2, 4, 4, 7]], dtype=jnp.int32))
+    np.testing.assert_array_equal(valid, jnp.array([[False, False, True, True, True, True, False]]))
+
+
 def test_fa4_frontend_rejects_mismatched_q_kv_segment_ids():
     if jax.default_backend() != "gpu":
         pytest.skip("FA4/CuTe validation requires a GPU backend.")
@@ -200,6 +214,27 @@ def test_real_gpu_fa4_cute_attention_matches_reference_for_valid_dynamic_packed_
         dtype=jnp.int32,
     )
     mask = AttentionMask.causal(sliding_window=5).with_segment_ids(segment_ids)
+    valid = segment_ids >= 0
+    cotangent = jax.random.normal(cotangent_key, q.shape, dtype=jnp.bfloat16)
+    cotangent = cotangent * valid[..., None, None].astype(jnp.bfloat16)
+
+    _assert_real_gpu_fa4_cute_matches_reference(q, k, v, mask, cotangent, valid_tokens=valid)
+
+
+@pytest.mark.parametrize("sliding_window", [None, 31])
+def test_real_gpu_fa4_cute_attention_matches_reference_with_leading_padding(sliding_window):
+    if jax.default_backend() != "gpu":
+        pytest.skip("FA4/CuTe correctness requires a GPU backend.")
+    pytest.importorskip("cutlass")
+    pytest.importorskip("cutlass.cute")
+    pytest.importorskip("flash_attn.cute.flash_bwd_preprocess")
+    key = jax.random.PRNGKey(6)
+    q_key, k_key, v_key, cotangent_key = jax.random.split(key, 4)
+    q = jax.random.normal(q_key, (1, 128, 20, 128), dtype=jnp.bfloat16)
+    k = jax.random.normal(k_key, (1, 128, 5, 128), dtype=jnp.bfloat16)
+    v = jax.random.normal(v_key, (1, 128, 5, 128), dtype=jnp.bfloat16)
+    segment_ids = jnp.array([[-1] * 19 + [37] * 109], dtype=jnp.int32)
+    mask = AttentionMask.causal(sliding_window=sliding_window).with_segment_ids(segment_ids)
     valid = segment_ids >= 0
     cotangent = jax.random.normal(cotangent_key, q.shape, dtype=jnp.bfloat16)
     cotangent = cotangent * valid[..., None, None].astype(jnp.bfloat16)


### PR DESCRIPTION
Part of #7786.

## Summary

- Carry the next valid query's causal lower bound backward through leading padding in packed segments. FA4 uses the first query in an M tile to prune key tiles, so the old `seq_len` sentinel could discard keys needed by later valid queries.
- Keep the `seq_len` sentinel for trailing padding, preserving cheap fully padded tail tiles.
- Cover both full-causal and sliding-window kernels against the reference attention path.

The broader benchmark and attribution report remains on the [preserved branch](https://github.com/marin-community/marin/tree/grug-training-perf-gap-20260731).

## Validation

At `7501960fd53f0f98e4c3d8786a581115a3e0731e`:

- `cd lib/levanter && uv run --group test pytest -q tests/grug/test_fa4_cute_attention.py` — 6 passed, 7 GPU-only tests skipped.
- Retained one-H100 evidence at production D128 geometry on [the original fix revision `3b1000dc`](https://github.com/marin-community/marin/commit/3b1000dc5636c446c3aaed1c035e36cc6d6fda53): before the fix, 62.0% of full-causal and 67.5% of sliding-window valid outputs mismatched the FP32 reference; after it, the metadata check and both output/gradient reference cases passed 3/3 in 31.21s. The fix hunk and focused regression are identical at this PR head.
- `./infra/pre-commit.py --changed-files --fix` — passed.
- `./infra/pre-commit.py --review --agent-command='codex exec'` — no findings.
