### PR TITLE
[eval] Consolidate outputs under evals

### DIFF
--- a/docs/tutorials/run-lm-evals.md
+++ b/docs/tutorials/run-lm-evals.md
@@ -218,8 +218,8 @@ endpoint details.
 
 ### Results
 
-TPU-routed runs default to `gs://marin-eval-metadata/runs`. CoreWeave GPU runs default to
-`s3://marin-us-east-02a/marin/eval-metadata/runs`. `--dry-run` prints the effective prefix.
+TPU-routed runs default to `gs://marin-eval-metadata/evals`. CoreWeave GPU runs default to
+`s3://marin-us-east-02a/marin/evals`. `--dry-run` prints the effective prefix.
 
 Every selected evaluation writes `{records_prefix}/{run_id}/record.json` plus its mechanism-specific
 results and normalized sample parquet. Harbor also persists trial directories and trajectories in

--- a/experiments/evaluation/README.md
+++ b/experiments/evaluation/README.md
@@ -54,7 +54,7 @@ useful after a change to the contract in `marin.evaluation.samples` (the parquet
 regenerated in place; the source jsonl is untouched):
 
 ```bash
-uv run python -m experiments.evaluation.cli backfill-samples --prefix gs://marin-eval-metadata/runs
+uv run python -m experiments.evaluation.cli backfill-samples --prefix gs://marin-eval-metadata/evals
 ```
 
 ## Records and the dashboard index
@@ -80,9 +80,10 @@ object-store prefix and upserts the `eval_runs` and `eval_metrics` tables implem
 ## Evals in pipelines
 
 `pipeline.py` exposes the same run as an `ArtifactStep`: `eval_step("qwen3-1.7b", "smoke",
-version="2026.07.19")` is a lazy, versioned handle whose records land at the step's artifact path.
-The step submits the same CPU orchestrator used by the CLI and waits for it. The slice override is a
-runtime arg, so changing it does not change the artifact identity.
+version="2026.07.19")` is a lazy, versioned handle. The step submits the same CPU orchestrator used by
+the CLI and writes eval outputs to the launcher's shared `evals` root; its artifact path contains the
+pipeline cache record. The slice override is a runtime arg, so changing it does not change the artifact
+identity.
 
 ## Agentic benchmarks (Harbor)
 

--- a/experiments/evaluation/cli.py
+++ b/experiments/evaluation/cli.py
@@ -16,7 +16,13 @@ import click
 from iris.cli.connect import open_iris_client
 from marin.evaluation.harbor.runner import canonical_served_name
 from marin.evaluation.hardware import Platform, default_platform
-from marin.evaluation.records import CW_RECORDS_PREFIX, DEFAULT_RECORDS_PREFIX, list_records
+from marin.evaluation.records import (
+    CW_RECORDS_PREFIX,
+    DEFAULT_RECORDS_PREFIX,
+    LEGACY_CW_RECORDS_PREFIX,
+    LEGACY_DEFAULT_RECORDS_PREFIX,
+    list_records,
+)
 from marin.evaluation.runner import EvaluationBatch, wait_and_report
 from marin.evaluation.samples import export_lm_eval_samples
 from rigging.config_discovery import find_project_root
@@ -166,7 +172,12 @@ def launch(
     "--prefix",
     "prefixes",
     multiple=True,
-    default=(DEFAULT_RECORDS_PREFIX, CW_RECORDS_PREFIX),
+    default=(
+        DEFAULT_RECORDS_PREFIX,
+        CW_RECORDS_PREFIX,
+        LEGACY_DEFAULT_RECORDS_PREFIX,
+        LEGACY_CW_RECORDS_PREFIX,
+    ),
     show_default=True,
     help="Object-store prefix(es) to scan for records; repeatable.",
 )

--- a/experiments/evaluation/cli.py
+++ b/experiments/evaluation/cli.py
@@ -16,13 +16,7 @@ import click
 from iris.cli.connect import open_iris_client
 from marin.evaluation.harbor.runner import canonical_served_name
 from marin.evaluation.hardware import Platform, default_platform
-from marin.evaluation.records import (
-    CW_RECORDS_PREFIX,
-    DEFAULT_RECORDS_PREFIX,
-    LEGACY_CW_RECORDS_PREFIX,
-    LEGACY_DEFAULT_RECORDS_PREFIX,
-    list_records,
-)
+from marin.evaluation.records import CW_RECORDS_PREFIX, DEFAULT_RECORDS_PREFIX, list_records
 from marin.evaluation.runner import EvaluationBatch, wait_and_report
 from marin.evaluation.samples import export_lm_eval_samples
 from rigging.config_discovery import find_project_root
@@ -172,12 +166,7 @@ def launch(
     "--prefix",
     "prefixes",
     multiple=True,
-    default=(
-        DEFAULT_RECORDS_PREFIX,
-        CW_RECORDS_PREFIX,
-        LEGACY_DEFAULT_RECORDS_PREFIX,
-        LEGACY_CW_RECORDS_PREFIX,
-    ),
+    default=(DEFAULT_RECORDS_PREFIX, CW_RECORDS_PREFIX),
     show_default=True,
     help="Object-store prefix(es) to scan for records; repeatable.",
 )

--- a/experiments/evaluation/pipeline.py
+++ b/experiments/evaluation/pipeline.py
@@ -36,7 +36,7 @@ from experiments.evaluation.models import models
 
 @dataclass(frozen=True)
 class EvalStepConfig:
-    """One eval run's identity (model + eval selection + instance cap) and its output root."""
+    """One pipeline eval's model, eval selection, version, and runtime overrides."""
 
     model: str
     evals: str

--- a/experiments/evaluation/pipeline.py
+++ b/experiments/evaluation/pipeline.py
@@ -7,12 +7,12 @@
 evals compose into ``StepRunner`` pipelines and can be triggered programmatically -- e.g. right
 after a training pipeline exports a checkpoint, or fanned out over a model sweep. The step runs the
 same orchestration as the CLI (serve the model once, run evalchemy against the served URL, write
-``record.json`` + results + per-question parquet), with the records rooted at the step's own
-artifact path: an identical (model, evals, limit, version) config is a cache hit, and downstream
-steps can depend on the records like any other artifact.
+``record.json`` + results + per-question parquet) to the shared eval output root. The step's artifact
+path holds its cache record: an identical (model, evals, limit, version) config is a cache hit.
 
-The step submits an Iris orchestrator job and waits for its records, so the pipeline itself must run
-where it can reach Iris::
+The step submits an Iris orchestrator job and waits for its records. The launcher chooses the shared
+GCS or CoreWeave ``evals`` output root, while the artifact path stores the pipeline cache record. The
+pipeline itself must run where it can reach Iris::
 
     uv run iris --cluster marin job run -- python -m experiments.evaluation.pipeline
 
@@ -41,7 +41,6 @@ class EvalStepConfig:
     model: str
     evals: str
     limit: int | None
-    records_prefix: str
     accelerator: str | None
     version: str
 
@@ -55,7 +54,7 @@ def run_eval_pipeline_step(config: EvalStepConfig) -> None:
         platform=default_platform(models()[config.model]),
         accelerator=config.accelerator,
         limit=config.limit,
-        records_prefix=config.records_prefix,
+        records_prefix=None,
         cluster="marin",
         version=config.version,
     )
@@ -82,7 +81,6 @@ def eval_step(
             model=model,
             evals=evals,
             limit=limit,
-            records_prefix=ctx.output_path,
             accelerator=ctx.runtime_arg("accelerator"),
             version=version,
         )

--- a/infra/evaldash/README.md
+++ b/infra/evaldash/README.md
@@ -4,18 +4,17 @@ A leaderboard and browsable run log over every Marin eval run.
 
 Eval runs write one canonical JSON record per run under `gs://marin-eval-metadata/evals` for GCP or
 `s3://marin-us-east-02a/marin/evals` for CoreWeave. The run directory also contains the evaluator's
-results and per-sample artifacts. A background loop scans these roots and the former
-`eval-metadata/runs` roots from `RECORDS_PREFIXES` (CW credentials come from Secret Manager;
-endpoint/addressing via `rigging.filesystem.s3_compat`) and upserts records into a Cloud SQL Postgres
-index (`hai-gcp-models:us-central1:marin-metadata`, database `evals`). A Starlette app serves a JSON API
-over that index and the built Vue SPA. Served at https://evaldash.oa.dev.
+results and per-sample artifacts. A background loop scans the roots in `RECORDS_PREFIXES` (CW
+credentials come from Secret Manager; endpoint/addressing via
+`rigging.filesystem.s3_compat`) and upserts records into a Cloud SQL Postgres index
+(`hai-gcp-models:us-central1:marin-metadata`, database `evals`). A Starlette app serves a JSON API over
+that index and the built Vue SPA. Served at https://evaldash.oa.dev.
 
-Record discovery uses delimiter-based directory listings at bounded depths. Every root checks
-`*/record.json`; roots ending in `/evals` also check the historical pipeline shape
-`*/*/*/*/record.json`. The scanner does not recursively enumerate results, samples, trajectories, or
-other evaluator payloads. It reads candidate record bodies with up to 16 concurrent object-store
-requests. Successful records are cached by immutable object path, so later ingest passes fetch only
-new records; directory listings still detect additions and deletions.
+Record discovery uses a delimiter-based directory listing and checks only `*/record.json`. It does not
+recursively enumerate results, samples, trajectories, or other evaluator payloads. It reads candidate
+record bodies with up to 16 concurrent object-store requests. Successful records are cached by
+immutable object path, so later ingest passes fetch only new records; directory listings still detect
+additions and deletions.
 
 The SPA has four views: leaderboard (per-model mean score over its latest version cohort, a
 colour-scaled model x task heatmap with model-comparison bars and score-over-time charts,

--- a/infra/evaldash/README.md
+++ b/infra/evaldash/README.md
@@ -2,14 +2,20 @@
 
 A leaderboard and browsable run log over every Marin eval run.
 
-Eval runs write one canonical JSON record per run to an object-store prefix —
-`gs://marin-eval-metadata/runs/<run_id>/record.json` for GCP runs,
-`s3://marin-us-east-02a/marin/eval-metadata/runs/...` (CoreWeave object storage) for CW GPU
-runs. A background loop scans every prefix in `RECORDS_PREFIXES` (CW credentials come from
-Secret Manager; endpoint/addressing via `rigging.filesystem.s3_compat`) and upserts records
-into a Cloud SQL Postgres index (`hai-gcp-models:us-central1:marin-metadata`, database
-`evals`). A Starlette app serves a JSON API over that index and the built Vue SPA. Served at
-https://evaldash.oa.dev.
+Eval runs write one canonical JSON record per run under `gs://marin-eval-metadata/evals` for GCP or
+`s3://marin-us-east-02a/marin/evals` for CoreWeave. The run directory also contains the evaluator's
+results and per-sample artifacts. A background loop scans these roots and the former
+`eval-metadata/runs` roots from `RECORDS_PREFIXES` (CW credentials come from Secret Manager;
+endpoint/addressing via `rigging.filesystem.s3_compat`) and upserts records into a Cloud SQL Postgres
+index (`hai-gcp-models:us-central1:marin-metadata`, database `evals`). A Starlette app serves a JSON API
+over that index and the built Vue SPA. Served at https://evaldash.oa.dev.
+
+Record discovery uses delimiter-based directory listings at bounded depths. Every root checks
+`*/record.json`; roots ending in `/evals` also check the historical pipeline shape
+`*/*/*/*/record.json`. The scanner does not recursively enumerate results, samples, trajectories, or
+other evaluator payloads. It reads candidate record bodies with up to 16 concurrent object-store
+requests. Successful records are cached by immutable object path, so later ingest passes fetch only
+new records; directory listings still detect additions and deletions.
 
 The SPA has four views: leaderboard (per-model mean score over its latest version cohort, a
 colour-scaled model x task heatmap with model-comparison bars and score-over-time charts,

--- a/infra/evaldash/__main__.py
+++ b/infra/evaldash/__main__.py
@@ -23,6 +23,12 @@ import pulumi
 import pulumi_cloudflare as cloudflare
 import pulumi_gcp as gcp
 from iac.gcp.cloud_run import CloudRunService, CloudRunServiceArgs, SecretEnv
+from marin.evaluation.records import (
+    CW_RECORDS_PREFIX,
+    DEFAULT_RECORDS_PREFIX,
+    LEGACY_CW_RECORDS_PREFIX,
+    LEGACY_DEFAULT_RECORDS_PREFIX,
+)
 
 PROJECT = "hai-gcp-models"
 REGION = "us-central1"
@@ -39,10 +45,10 @@ CLOUDSQL_INSTANCE = "hai-gcp-models:us-central1:marin-metadata"
 # credentials, so GPU runs write to the CW-local S3 store.
 RECORDS_PREFIXES = ",".join(
     (
-        "gs://marin-eval-metadata/evals",
-        "s3://marin-us-east-02a/marin/evals",
-        "gs://marin-eval-metadata/runs",
-        "s3://marin-us-east-02a/marin/eval-metadata/runs",
+        DEFAULT_RECORDS_PREFIX,
+        CW_RECORDS_PREFIX,
+        LEGACY_DEFAULT_RECORDS_PREFIX,
+        LEGACY_CW_RECORDS_PREFIX,
     )
 )
 EVAL_DB_NAME = "evals"

--- a/infra/evaldash/__main__.py
+++ b/infra/evaldash/__main__.py
@@ -35,10 +35,16 @@ CLOUD_RUN_FRONTEND = "ghs.googlehosted.com"
 # admin API + the runtime SA's roles/cloudsql.client grant, so no VPC path is needed.
 CLOUDSQL_INSTANCE = "hai-gcp-models:us-central1:marin-metadata"
 
-# Canonical per-run records the ingest loop lists and upserts.
-# Both record stores the ingest loop scans: the GCS default plus the CoreWeave object store
-# that CW GPU runs (whose workers have no GCP credentials) record to.
-RECORDS_PREFIXES = "gs://marin-eval-metadata/runs,s3://marin-us-east-02a/marin/eval-metadata/runs"
+# New eval outputs plus the legacy roots retained for existing runs. CoreWeave workers have no GCP
+# credentials, so GPU runs write to the CW-local S3 store.
+RECORDS_PREFIXES = ",".join(
+    (
+        "gs://marin-eval-metadata/evals",
+        "s3://marin-us-east-02a/marin/evals",
+        "gs://marin-eval-metadata/runs",
+        "s3://marin-us-east-02a/marin/eval-metadata/runs",
+    )
+)
 EVAL_DB_NAME = "evals"
 EVAL_DB_USER = "evals"
 

--- a/infra/evaldash/__main__.py
+++ b/infra/evaldash/__main__.py
@@ -23,12 +23,7 @@ import pulumi
 import pulumi_cloudflare as cloudflare
 import pulumi_gcp as gcp
 from iac.gcp.cloud_run import CloudRunService, CloudRunServiceArgs, SecretEnv
-from marin.evaluation.records import (
-    CW_RECORDS_PREFIX,
-    DEFAULT_RECORDS_PREFIX,
-    LEGACY_CW_RECORDS_PREFIX,
-    LEGACY_DEFAULT_RECORDS_PREFIX,
-)
+from marin.evaluation.records import CW_RECORDS_PREFIX, DEFAULT_RECORDS_PREFIX
 
 PROJECT = "hai-gcp-models"
 REGION = "us-central1"
@@ -41,16 +36,8 @@ CLOUD_RUN_FRONTEND = "ghs.googlehosted.com"
 # admin API + the runtime SA's roles/cloudsql.client grant, so no VPC path is needed.
 CLOUDSQL_INSTANCE = "hai-gcp-models:us-central1:marin-metadata"
 
-# New eval outputs plus the legacy roots retained for existing runs. CoreWeave workers have no GCP
-# credentials, so GPU runs write to the CW-local S3 store.
-RECORDS_PREFIXES = ",".join(
-    (
-        DEFAULT_RECORDS_PREFIX,
-        CW_RECORDS_PREFIX,
-        LEGACY_DEFAULT_RECORDS_PREFIX,
-        LEGACY_CW_RECORDS_PREFIX,
-    )
-)
+# CoreWeave workers have no GCP credentials, so GPU runs write to the CW-local S3 store.
+RECORDS_PREFIXES = ",".join((DEFAULT_RECORDS_PREFIX, CW_RECORDS_PREFIX))
 EVAL_DB_NAME = "evals"
 EVAL_DB_USER = "evals"
 

--- a/infra/evaldash/src/server.py
+++ b/infra/evaldash/src/server.py
@@ -3,9 +3,9 @@
 
 """Eval-results dashboard server (Starlette + uvicorn).
 
-Serves a bundled Vue SPA plus a small JSON API over the eval run records. Records are
-the canonical per-run JSON written to ``gs://marin-eval-metadata/runs/<run_id>/record.json``
-and indexed into CloudSQL Postgres.
+Serves a bundled Vue SPA plus a small JSON API over the eval run records. New records live under the
+GCS or CoreWeave ``evals`` output root; the former ``eval-metadata/runs`` roots remain readable during
+migration. Records are indexed into CloudSQL Postgres.
 
 A background task ingests the records on startup and every ``EVALDASH_INGEST_INTERVAL`` seconds
 (default 300). Reads are served through a ``RecordStore`` selected by ``EVALDASH_STORE``: the
@@ -53,9 +53,11 @@ import uvicorn
 from marin.evaluation.records import (
     CW_RECORDS_PREFIX,
     DEFAULT_RECORDS_PREFIX,
+    LEGACY_CW_RECORDS_PREFIX,
+    LEGACY_DEFAULT_RECORDS_PREFIX,
     EvalRunRecord,
     RecordParseFailure,
-    read_records,
+    scan_records,
 )
 from metrics import build_matrix, build_meta, build_model_detail, record_score
 from results_db import (
@@ -80,7 +82,17 @@ logger = logging.getLogger(__name__)
 
 RECORDS_PREFIXES = tuple(
     part.strip()
-    for part in os.environ.get("RECORDS_PREFIXES", f"{DEFAULT_RECORDS_PREFIX},{CW_RECORDS_PREFIX}").split(",")
+    for part in os.environ.get(
+        "RECORDS_PREFIXES",
+        ",".join(
+            (
+                DEFAULT_RECORDS_PREFIX,
+                CW_RECORDS_PREFIX,
+                LEGACY_DEFAULT_RECORDS_PREFIX,
+                LEGACY_CW_RECORDS_PREFIX,
+            )
+        ),
+    ).split(",")
     if part.strip()
 )
 INGEST_INTERVAL_SECONDS = int(os.environ.get("EVALDASH_INGEST_INTERVAL", "300"))
@@ -493,6 +505,7 @@ class Ingestor:
         self._lock = asyncio.Lock()
         self._probes = {prefix: PrefixProbe(prefix=prefix) for prefix in prefixes}
         self._last_good: dict[str, list[EvalRunRecord]] = {prefix: [] for prefix in prefixes}
+        self._record_cache: dict[str, dict[str, EvalRunRecord]] = {prefix: {} for prefix in prefixes}
         self.last_pass_time: str | None = None
 
     async def run_once(self) -> None:
@@ -507,7 +520,9 @@ class Ingestor:
                 probe = self._probes[prefix]
                 probe.last_probe_time = _utcnow_iso()
                 try:
-                    found, failures = await asyncio.to_thread(read_records, prefix)
+                    scan = await asyncio.to_thread(scan_records, prefix, self._record_cache[prefix])
+                    found = list(scan.records)
+                    failures = list(scan.failures)
                 except Exception as exc:
                     # One unreachable store (missing CW keys, transient outage) must not hide the
                     # rest, and must not drop this prefix's previously-ingested runs from the
@@ -522,6 +537,7 @@ class Ingestor:
                 probe.error = None
                 logger.info("ingest: %d records (%d unparseable) from %s", len(found), len(failures), prefix)
                 self._last_good[prefix] = found
+                self._record_cache[prefix] = scan.records_by_path
                 records.extend(found)
             await asyncio.to_thread(self._store.refresh, records)
             self.last_pass_time = _utcnow_iso()

--- a/infra/evaldash/src/server.py
+++ b/infra/evaldash/src/server.py
@@ -4,8 +4,8 @@
 """Eval-results dashboard server (Starlette + uvicorn).
 
 Serves a bundled Vue SPA plus a small JSON API over the eval run records. New records live under the
-GCS or CoreWeave ``evals`` output root; the former ``eval-metadata/runs`` roots remain readable during
-migration. Records are indexed into CloudSQL Postgres.
+GCS or CoreWeave ``evals`` output root. Records in the legacy ``eval-metadata/runs`` roots remain
+readable and are indexed into CloudSQL Postgres.
 
 A background task ingests the records on startup and every ``EVALDASH_INGEST_INTERVAL`` seconds
 (default 300). Reads are served through a ``RecordStore`` selected by ``EVALDASH_STORE``: the

--- a/infra/evaldash/src/server.py
+++ b/infra/evaldash/src/server.py
@@ -3,9 +3,8 @@
 
 """Eval-results dashboard server (Starlette + uvicorn).
 
-Serves a bundled Vue SPA plus a small JSON API over the eval run records. New records live under the
-GCS or CoreWeave ``evals`` output root. Records in the legacy ``eval-metadata/runs`` roots remain
-readable and are indexed into CloudSQL Postgres.
+Serves a bundled Vue SPA plus a small JSON API over eval run records under the GCS or CoreWeave
+``evals`` output root.
 
 A background task ingests the records on startup and every ``EVALDASH_INGEST_INTERVAL`` seconds
 (default 300). Reads are served through a ``RecordStore`` selected by ``EVALDASH_STORE``: the
@@ -53,8 +52,6 @@ import uvicorn
 from marin.evaluation.records import (
     CW_RECORDS_PREFIX,
     DEFAULT_RECORDS_PREFIX,
-    LEGACY_CW_RECORDS_PREFIX,
-    LEGACY_DEFAULT_RECORDS_PREFIX,
     EvalRunRecord,
     RecordParseFailure,
     scan_records,
@@ -84,14 +81,7 @@ RECORDS_PREFIXES = tuple(
     part.strip()
     for part in os.environ.get(
         "RECORDS_PREFIXES",
-        ",".join(
-            (
-                DEFAULT_RECORDS_PREFIX,
-                CW_RECORDS_PREFIX,
-                LEGACY_DEFAULT_RECORDS_PREFIX,
-                LEGACY_CW_RECORDS_PREFIX,
-            )
-        ),
+        ",".join((DEFAULT_RECORDS_PREFIX, CW_RECORDS_PREFIX)),
     ).split(",")
     if part.strip()
 )

--- a/lib/marin/src/marin/evaluation/records.py
+++ b/lib/marin/src/marin/evaluation/records.py
@@ -1,18 +1,22 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""The canonical eval-run record and its object-store layout.
+"""The canonical eval-run record and its object-store layouts.
 
 One eval launch writes one ``record.json`` under ``{prefix}/{run_id}/record.json``: the durable,
 self-describing account of what model was evaluated on what hardware, whether it succeeded, and the
 per-task metrics it produced. The record is the source of truth; evaldash builds its query index from
-these object-store records.
+these object-store records. New runs use an ``evals`` prefix. Evaldash also reads the former
+``eval-metadata/runs`` prefixes and the bounded artifact layout produced before pipeline evals adopted
+the shared output root.
 
 This module is import-light on purpose -- stdlib plus fsspec and Pydantic only, no marin/levanter/iris
 imports -- so it can be vendored verbatim into a standalone dashboard image that only reads records back.
 """
 
 import logging
+from collections.abc import Mapping
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import StrEnum
 
@@ -22,12 +26,15 @@ from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_RECORDS_PREFIX = "gs://marin-eval-metadata/runs"
+DEFAULT_RECORDS_PREFIX = "gs://marin-eval-metadata/evals"
 # CoreWeave runs write records to the CW-local object store: their workers hold CW S3
 # credentials but no GCP ones. The dashboard's ingest scans both prefixes. Access from outside
 # the cluster needs `rigging.filesystem.s3_compat.configure_coreweave_s3()` first.
-CW_RECORDS_PREFIX = "s3://marin-us-east-02a/marin/eval-metadata/runs"
+CW_RECORDS_PREFIX = "s3://marin-us-east-02a/marin/evals"
+LEGACY_DEFAULT_RECORDS_PREFIX = "gs://marin-eval-metadata/runs"
+LEGACY_CW_RECORDS_PREFIX = "s3://marin-us-east-02a/marin/eval-metadata/runs"
 RECORD_FILE = "record.json"
+_MAX_RECORD_READERS = 16
 
 
 class RunStatus(StrEnum):
@@ -235,23 +242,97 @@ class RecordParseFailure:
     error: str
 
 
-def read_records(prefix: str) -> tuple[list[EvalRunRecord], list[RecordParseFailure]]:
-    """Read every ``{prefix}/*/record.json``, returning the parsed records and, separately, the paths
-    that failed to parse with their error. Parse failures are logged and collected rather than raised,
-    so one malformed record never hides the rest."""
+@dataclass(frozen=True)
+class _RecordRead:
+    record: EvalRunRecord | None = None
+    failure: RecordParseFailure | None = None
+    missing: bool = False
+
+
+@dataclass(frozen=True)
+class RecordScan:
+    """One prefix scan, including its path-keyed cache for the next pass."""
+
+    records: tuple[EvalRunRecord, ...]
+    failures: tuple[RecordParseFailure, ...]
+    records_by_path: dict[str, EvalRunRecord]
+
+
+def _directory_children(fs, path: str) -> list[str]:
+    """Immediate child directories of ``path``; an absent object-store prefix is empty."""
+    try:
+        children = fs.ls(path, detail=True)
+    except FileNotFoundError:
+        return []
+    return sorted(child["name"] for child in children if child.get("type") == "directory")
+
+
+def _read_candidates(urls: list[str], cached: Mapping[str, EvalRunRecord]) -> list[_RecordRead]:
+    def parse(url: str) -> _RecordRead:
+        if url in cached:
+            return _RecordRead(record=cached[url])
+        try:
+            return _RecordRead(record=read_record(url))
+        except FileNotFoundError:
+            return _RecordRead(missing=True)
+        except Exception as exc:
+            logger.warning("skipping unparseable eval record at %s", url, exc_info=True)
+            return _RecordRead(failure=RecordParseFailure(path=url, error=f"{type(exc).__name__}: {exc}"))
+
+    with ThreadPoolExecutor(max_workers=min(_MAX_RECORD_READERS, max(1, len(urls)))) as executor:
+        return list(executor.map(parse, urls))
+
+
+def scan_records(prefix: str, cached: Mapping[str, EvalRunRecord] | None = None) -> RecordScan:
+    """Scan eval records under ``prefix`` without enumerating result payloads.
+
+    Every root supports the flat ``{prefix}/{run_id}/record.json`` layout. Roots named ``evals`` also
+    include the historical artifact layout
+    ``{prefix}/{model}/{evals}/{version}/{run_id}/record.json``. Discovery uses delimiter-based
+    directory listings at these fixed depths; object-store glob implementations otherwise enumerate
+    the complete result subtree. Record bodies are read concurrently because request latency dominates
+    their small payloads.
+
+    ``cached`` maps immutable record paths from the previous successful pass to parsed records. A
+    listed path already in that cache does not issue another object GET. New paths and prior parse
+    failures are read. Deleted paths fall out of the returned cache.
+    """
+    cached = cached or {}
     fs, root = url_to_fs(prefix)
-    pattern = f"{root.rstrip('/')}/*/{RECORD_FILE}"
     protocol = f"{prefix.split('://', 1)[0]}://" if "://" in prefix else ""
     records: list[EvalRunRecord] = []
     failures: list[RecordParseFailure] = []
-    for match in sorted(fs.glob(pattern)):
-        url = f"{protocol}{match}"
-        try:
-            records.append(read_record(url))
-        except Exception as exc:
-            logger.warning("skipping unparseable eval record at %s", url, exc_info=True)
-            failures.append(RecordParseFailure(path=url, error=f"{type(exc).__name__}: {exc}"))
-    return records, failures
+
+    top_level = _directory_children(fs, root)
+    flat_urls = [f"{protocol}{directory}/{RECORD_FILE}" for directory in top_level]
+    flat_reads = _read_candidates(flat_urls, cached)
+    records_by_path: dict[str, EvalRunRecord] = {}
+    for url, result in zip(flat_urls, flat_reads, strict=True):
+        if result.record is not None:
+            records.append(result.record)
+            records_by_path[url] = result.record
+        if result.failure is not None:
+            failures.append(result.failure)
+
+    if prefix.rstrip("/").endswith("/evals"):
+        artifact_roots = [directory for directory, result in zip(top_level, flat_reads, strict=True) if result.missing]
+        artifact_runs = artifact_roots
+        for _ in range(3):
+            artifact_runs = [child for parent in artifact_runs for child in _directory_children(fs, parent)]
+        artifact_urls = [f"{protocol}{directory}/{RECORD_FILE}" for directory in artifact_runs]
+        for url, result in zip(artifact_urls, _read_candidates(artifact_urls, cached), strict=True):
+            if result.record is not None:
+                records.append(result.record)
+                records_by_path[url] = result.record
+            if result.failure is not None:
+                failures.append(result.failure)
+    return RecordScan(records=tuple(records), failures=tuple(failures), records_by_path=records_by_path)
+
+
+def read_records(prefix: str) -> tuple[list[EvalRunRecord], list[RecordParseFailure]]:
+    """Read every eval record under ``prefix`` and return records plus parse failures."""
+    scan = scan_records(prefix)
+    return list(scan.records), list(scan.failures)
 
 
 def list_records(prefix: str) -> list[EvalRunRecord]:

--- a/lib/marin/src/marin/evaluation/records.py
+++ b/lib/marin/src/marin/evaluation/records.py
@@ -8,12 +8,11 @@ self-describing account of what model was evaluated on what hardware, whether it
 per-task metrics it produced. The record is the source of truth; evaldash builds its query index from
 these object-store records. Runs use an ``evals`` prefix in the platform-local object store.
 
-This module is import-light on purpose -- stdlib plus fsspec and Pydantic only, no marin/levanter/iris
-imports -- so it can be vendored verbatim into a standalone dashboard image that only reads records back.
+This module is import-light on purpose -- the filesystem layer plus Pydantic, with no
+marin/levanter/iris imports -- so it can be vendored into the dashboard image that reads records back.
 """
 
 import logging
-import posixpath
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -22,6 +21,7 @@ from enum import StrEnum
 import fsspec
 from fsspec.core import url_to_fs
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from rigging.filesystem import prefix_join
 
 logger = logging.getLogger(__name__)
 
@@ -210,7 +210,7 @@ class EvalRunRecord(BaseModel):
 
 def record_path(prefix: str, run_id: str) -> str:
     """The ``record.json`` object path for ``run_id`` under ``prefix``."""
-    return f"{prefix.rstrip('/')}/{run_id}/{RECORD_FILE}"
+    return prefix_join(prefix_join(prefix, run_id), RECORD_FILE)
 
 
 def write_record(record: EvalRunRecord, prefix: str) -> str:
@@ -295,7 +295,7 @@ def scan_records(prefix: str, cached: Mapping[str, EvalRunRecord] | None = None)
 
     # Object-store globs recurse into result payloads. List only immediate run directories.
     top_level = _directory_children(fs, root)
-    flat_urls = [fs.unstrip_protocol(posixpath.join(directory, RECORD_FILE)) for directory in top_level]
+    flat_urls = [prefix_join(fs.unstrip_protocol(directory), RECORD_FILE) for directory in top_level]
     for url, result in zip(flat_urls, _read_candidates(flat_urls, cached), strict=True):
         if result.record is not None:
             records.append(result.record)

--- a/lib/marin/src/marin/evaluation/records.py
+++ b/lib/marin/src/marin/evaluation/records.py
@@ -15,6 +15,7 @@ imports -- so it can be vendored verbatim into a standalone dashboard image that
 """
 
 import logging
+import posixpath
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -284,48 +285,41 @@ def _read_candidates(urls: list[str], cached: Mapping[str, EvalRunRecord]) -> li
 
 
 def scan_records(prefix: str, cached: Mapping[str, EvalRunRecord] | None = None) -> RecordScan:
-    """Scan eval records under ``prefix`` without enumerating result payloads.
+    """Return current records under ``prefix`` and a cache for the next scan.
 
     Every root supports the flat ``{prefix}/{run_id}/record.json`` layout. Roots named ``evals`` also
-    include the historical artifact layout
-    ``{prefix}/{model}/{evals}/{version}/{run_id}/record.json``. Discovery uses delimiter-based
-    directory listings at these fixed depths; object-store glob implementations otherwise enumerate
-    the complete result subtree. Record bodies are read concurrently because request latency dominates
-    their small payloads.
+    include ``{prefix}/{model}/{evals}/{version}/{run_id}/record.json``.
 
-    ``cached`` maps immutable record paths from the previous successful pass to parsed records. A
-    listed path already in that cache does not issue another object GET. New paths and prior parse
-    failures are read. Deleted paths fall out of the returned cache.
+    Valid paths in ``cached`` are reused. New records and prior parse failures are read, and deleted
+    paths are absent from the returned cache.
     """
     cached = cached or {}
     fs, root = url_to_fs(prefix)
-    protocol = f"{prefix.split('://', 1)[0]}://" if "://" in prefix else ""
     records: list[EvalRunRecord] = []
     failures: list[RecordParseFailure] = []
-
-    top_level = _directory_children(fs, root)
-    flat_urls = [f"{protocol}{directory}/{RECORD_FILE}" for directory in top_level]
-    flat_reads = _read_candidates(flat_urls, cached)
     records_by_path: dict[str, EvalRunRecord] = {}
-    for url, result in zip(flat_urls, flat_reads, strict=True):
-        if result.record is not None:
-            records.append(result.record)
-            records_by_path[url] = result.record
-        if result.failure is not None:
-            failures.append(result.failure)
+
+    def collect(urls: list[str], results: list[_RecordRead]) -> None:
+        for url, result in zip(urls, results, strict=True):
+            if result.record is not None:
+                records.append(result.record)
+                records_by_path[url] = result.record
+            if result.failure is not None:
+                failures.append(result.failure)
+
+    # Object-store globs recurse into result payloads. Walk only the two supported record layouts.
+    top_level = _directory_children(fs, root)
+    flat_urls = [fs.unstrip_protocol(posixpath.join(directory, RECORD_FILE)) for directory in top_level]
+    flat_reads = _read_candidates(flat_urls, cached)
+    collect(flat_urls, flat_reads)
 
     if prefix.rstrip("/").endswith("/evals"):
         artifact_roots = [directory for directory, result in zip(top_level, flat_reads, strict=True) if result.missing]
         artifact_runs = artifact_roots
         for _ in range(3):
             artifact_runs = [child for parent in artifact_runs for child in _directory_children(fs, parent)]
-        artifact_urls = [f"{protocol}{directory}/{RECORD_FILE}" for directory in artifact_runs]
-        for url, result in zip(artifact_urls, _read_candidates(artifact_urls, cached), strict=True):
-            if result.record is not None:
-                records.append(result.record)
-                records_by_path[url] = result.record
-            if result.failure is not None:
-                failures.append(result.failure)
+        artifact_urls = [fs.unstrip_protocol(posixpath.join(directory, RECORD_FILE)) for directory in artifact_runs]
+        collect(artifact_urls, _read_candidates(artifact_urls, cached))
     return RecordScan(records=tuple(records), failures=tuple(failures), records_by_path=records_by_path)
 
 

--- a/lib/marin/src/marin/evaluation/records.py
+++ b/lib/marin/src/marin/evaluation/records.py
@@ -1,14 +1,12 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""The canonical eval-run record and its object-store layouts.
+"""The canonical eval-run record and its object-store layout.
 
 One eval launch writes one ``record.json`` under ``{prefix}/{run_id}/record.json``: the durable,
 self-describing account of what model was evaluated on what hardware, whether it succeeded, and the
 per-task metrics it produced. The record is the source of truth; evaldash builds its query index from
-these object-store records. New runs use an ``evals`` prefix. Evaldash also reads the former
-``eval-metadata/runs`` prefixes and the bounded artifact layout produced before pipeline evals adopted
-the shared output root.
+these object-store records. Runs use an ``evals`` prefix in the platform-local object store.
 
 This module is import-light on purpose -- stdlib plus fsspec and Pydantic only, no marin/levanter/iris
 imports -- so it can be vendored verbatim into a standalone dashboard image that only reads records back.
@@ -32,8 +30,6 @@ DEFAULT_RECORDS_PREFIX = "gs://marin-eval-metadata/evals"
 # credentials but no GCP ones. The dashboard's ingest scans both prefixes. Access from outside
 # the cluster needs `rigging.filesystem.s3_compat.configure_coreweave_s3()` first.
 CW_RECORDS_PREFIX = "s3://marin-us-east-02a/marin/evals"
-LEGACY_DEFAULT_RECORDS_PREFIX = "gs://marin-eval-metadata/runs"
-LEGACY_CW_RECORDS_PREFIX = "s3://marin-us-east-02a/marin/eval-metadata/runs"
 RECORD_FILE = "record.json"
 _MAX_RECORD_READERS = 16
 
@@ -247,7 +243,6 @@ class RecordParseFailure:
 class _RecordRead:
     record: EvalRunRecord | None = None
     failure: RecordParseFailure | None = None
-    missing: bool = False
 
 
 @dataclass(frozen=True)
@@ -275,7 +270,7 @@ def _read_candidates(urls: list[str], cached: Mapping[str, EvalRunRecord]) -> li
         try:
             return _RecordRead(record=read_record(url))
         except FileNotFoundError:
-            return _RecordRead(missing=True)
+            return _RecordRead()
         except Exception as exc:
             logger.warning("skipping unparseable eval record at %s", url, exc_info=True)
             return _RecordRead(failure=RecordParseFailure(path=url, error=f"{type(exc).__name__}: {exc}"))
@@ -287,8 +282,7 @@ def _read_candidates(urls: list[str], cached: Mapping[str, EvalRunRecord]) -> li
 def scan_records(prefix: str, cached: Mapping[str, EvalRunRecord] | None = None) -> RecordScan:
     """Return current records under ``prefix`` and a cache for the next scan.
 
-    Every root supports the flat ``{prefix}/{run_id}/record.json`` layout. Roots named ``evals`` also
-    include ``{prefix}/{model}/{evals}/{version}/{run_id}/record.json``.
+    Records use the flat ``{prefix}/{run_id}/record.json`` layout.
 
     Valid paths in ``cached`` are reused. New records and prior parse failures are read, and deleted
     paths are absent from the returned cache.
@@ -299,27 +293,15 @@ def scan_records(prefix: str, cached: Mapping[str, EvalRunRecord] | None = None)
     failures: list[RecordParseFailure] = []
     records_by_path: dict[str, EvalRunRecord] = {}
 
-    def collect(urls: list[str], results: list[_RecordRead]) -> None:
-        for url, result in zip(urls, results, strict=True):
-            if result.record is not None:
-                records.append(result.record)
-                records_by_path[url] = result.record
-            if result.failure is not None:
-                failures.append(result.failure)
-
-    # Object-store globs recurse into result payloads. Walk only the two supported record layouts.
+    # Object-store globs recurse into result payloads. List only immediate run directories.
     top_level = _directory_children(fs, root)
     flat_urls = [fs.unstrip_protocol(posixpath.join(directory, RECORD_FILE)) for directory in top_level]
-    flat_reads = _read_candidates(flat_urls, cached)
-    collect(flat_urls, flat_reads)
-
-    if prefix.rstrip("/").endswith("/evals"):
-        artifact_roots = [directory for directory, result in zip(top_level, flat_reads, strict=True) if result.missing]
-        artifact_runs = artifact_roots
-        for _ in range(3):
-            artifact_runs = [child for parent in artifact_runs for child in _directory_children(fs, parent)]
-        artifact_urls = [fs.unstrip_protocol(posixpath.join(directory, RECORD_FILE)) for directory in artifact_runs]
-        collect(artifact_urls, _read_candidates(artifact_urls, cached))
+    for url, result in zip(flat_urls, _read_candidates(flat_urls, cached), strict=True):
+        if result.record is not None:
+            records.append(result.record)
+            records_by_path[url] = result.record
+        if result.failure is not None:
+            failures.append(result.failure)
     return RecordScan(records=tuple(records), failures=tuple(failures), records_by_path=records_by_path)
 
 

--- a/tests/evals/test_records.py
+++ b/tests/evals/test_records.py
@@ -138,16 +138,16 @@ def test_read_records_collects_parse_failures_without_dropping_good_ones(tmp_pat
     assert "ValidationError" in failures[0].error
 
 
-def test_read_records_discovers_flat_and_artifact_eval_layouts(tmp_path):
+def test_read_records_only_discovers_flat_eval_layout(tmp_path):
     evals = tmp_path / "evals"
     flat = _RECORD.model_copy(update={"run_id": "flat-run"})
-    artifact = _RECORD.model_copy(update={"run_id": "artifact-run"})
+    nested = _RECORD.model_copy(update={"run_id": "nested-run"})
     write_record(flat, str(evals))
-    write_record(artifact, str(evals / "model" / "suite" / "version"))
+    write_record(nested, str(evals / "model" / "suite" / "version"))
 
     records, failures = read_records(str(evals))
 
-    assert {record.run_id for record in records} == {"flat-run", "artifact-run"}
+    assert [record.run_id for record in records] == ["flat-run"]
     assert failures == []
 
 

--- a/tests/evals/test_records.py
+++ b/tests/evals/test_records.py
@@ -10,6 +10,7 @@ These tests pin that shape independently of the pydantic model that produces it.
 """
 
 import json
+from pathlib import Path
 
 import pytest
 from marin.evaluation.records import (
@@ -25,6 +26,7 @@ from marin.evaluation.records import (
     ServingParams,
     read_record,
     read_records,
+    scan_records,
     write_record,
 )
 
@@ -134,6 +136,34 @@ def test_read_records_collects_parse_failures_without_dropping_good_ones(tmp_pat
     assert len(failures) == 1
     assert failures[0].path.endswith("20260101-000000-broken-mmlu/record.json")
     assert "ValidationError" in failures[0].error
+
+
+def test_read_records_discovers_flat_and_artifact_eval_layouts(tmp_path):
+    evals = tmp_path / "evals"
+    flat = _RECORD.model_copy(update={"run_id": "flat-run"})
+    artifact = _RECORD.model_copy(update={"run_id": "artifact-run"})
+    write_record(flat, str(evals))
+    write_record(artifact, str(evals / "model" / "suite" / "version"))
+
+    records, failures = read_records(str(evals))
+
+    assert {record.run_id for record in records} == {"flat-run", "artifact-run"}
+    assert failures == []
+
+
+def test_scan_records_cache_detects_added_and_deleted_runs(tmp_path):
+    evals = tmp_path / "evals"
+    first = _RECORD.model_copy(update={"run_id": "first-run"})
+    second = _RECORD.model_copy(update={"run_id": "second-run"})
+    first_path = Path(write_record(first, str(evals)))
+    initial = scan_records(str(evals))
+
+    first_path.unlink()
+    first_path.parent.rmdir()
+    write_record(second, str(evals))
+    refreshed = scan_records(str(evals), initial.records_by_path)
+
+    assert [record.run_id for record in refreshed.records] == ["second-run"]
 
 
 def test_record_json_includes_harbor_policy_identity_and_effective_limit(tmp_path):

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 from marin.evaluation.harbor.driver_config import HARBOR_RUNTIME, HarborDatasetKind, ValidatedHarborConfig
 from marin.evaluation.hardware import AcceleratorChoice, Platform
 from marin.evaluation.model_config import ModelConfig, ResourceHint
-from marin.evaluation.records import EvalRef, RunStatus, read_record
+from marin.evaluation.records import DEFAULT_RECORDS_PREFIX, EvalRef, RunStatus, read_record
 from marin.evaluation.runner import (
     Evaluation,
     EvaluationBatch,
@@ -417,3 +417,23 @@ def test_launch_accepts_registry_evals_and_repeated_harbor_configs(tmp_path, mon
     assert "eval=mmlu-smoke" in result.output
     assert "eval=first-policy" in result.output
     assert "eval=second-policy" in result.output
+
+
+def test_launch_defaults_to_eval_output_root(monkeypatch):
+    monkeypatch.setattr("experiments.evaluation.launch._capability_origin", lambda _cluster: "https://iris.example")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "launch",
+            "--model",
+            "qwen3-8b",
+            "--evals",
+            "mmlu-smoke",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert f"records={DEFAULT_RECORDS_PREFIX}" in result.output
+    assert DEFAULT_RECORDS_PREFIX.endswith("/evals")

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -15,7 +15,7 @@ from click.testing import CliRunner
 from marin.evaluation.harbor.driver_config import HARBOR_RUNTIME, HarborDatasetKind, ValidatedHarborConfig
 from marin.evaluation.hardware import AcceleratorChoice, Platform
 from marin.evaluation.model_config import ModelConfig, ResourceHint
-from marin.evaluation.records import DEFAULT_RECORDS_PREFIX, EvalRef, RunStatus, read_record
+from marin.evaluation.records import EvalRef, RunStatus, read_record
 from marin.evaluation.runner import (
     Evaluation,
     EvaluationBatch,
@@ -419,21 +419,21 @@ def test_launch_accepts_registry_evals_and_repeated_harbor_configs(tmp_path, mon
     assert "eval=second-policy" in result.output
 
 
-def test_launch_defaults_to_eval_output_root(monkeypatch):
+def test_build_evaluation_batch_defaults_results_to_eval_root(monkeypatch):
     monkeypatch.setattr("experiments.evaluation.launch._capability_origin", lambda _cluster: "https://iris.example")
-
-    result = CliRunner().invoke(
-        cli,
-        [
-            "launch",
-            "--model",
-            "qwen3-8b",
-            "--evals",
-            "mmlu-smoke",
-            "--dry-run",
-        ],
+    spec = LaunchSpec(
+        model="qwen3-8b",
+        evals=("mmlu-smoke",),
+        harbor_configs=(),
+        platform=Platform.TPU,
+        accelerator=None,
+        limit=1,
+        records_prefix=None,
+        cluster="marin",
     )
 
-    assert result.exit_code == 0, result.output
-    assert f"records={DEFAULT_RECORDS_PREFIX}" in result.output
-    assert DEFAULT_RECORDS_PREFIX.endswith("/evals")
+    batch = build_evaluation_batch(spec, LaunchProvenance(git_sha="abc", launch_host="host"), "tester")
+
+    assert batch.records_prefix == "gs://marin-eval-metadata/evals"
+    evaluation = batch.evaluations[0]
+    assert evaluation.identity.output_dir == f"{batch.records_prefix}/{evaluation.identity.run_id}/results"


### PR DESCRIPTION
Route CLI and ArtifactStep evaluations to platform-local `evals` roots. GCP runs use
`gs://marin-eval-metadata/evals`; CoreWeave runs use
`s3://marin-us-east-02a/marin/evals`. Existing outputs were copied into the flat
`<root>/<run_id>` layout and verified by object key and size. The old roots remain in place until
the revised dashboard is deployed.

Scan only immediate run directories with delimiter-based listings so evaldash does not traverse
result, sample, and trajectory payloads. Read new records concurrently and cache valid immutable
paths between ingest passes. The migrated roots contain 632 valid records with no parse failures:
381 in GCS and 251 in CoreWeave. Their measured cold scans take 7.1 and 5.1 seconds; cached scans
take 0.03 and 2.0 seconds.
