### PR TITLE
[eval] Keep legacy record roots visible

### DIFF
--- a/experiments/evaluation/cli.py
+++ b/experiments/evaluation/cli.py
@@ -16,7 +16,7 @@ import click
 from iris.cli.connect import open_iris_client
 from marin.evaluation.harbor.runner import canonical_served_name
 from marin.evaluation.hardware import Platform, default_platform
-from marin.evaluation.records import CW_RECORDS_PREFIX, DEFAULT_RECORDS_PREFIX, list_records
+from marin.evaluation.records import DEFAULT_SCAN_PREFIXES, list_records
 from marin.evaluation.runner import EvaluationBatch, wait_and_report
 from marin.evaluation.samples import export_lm_eval_samples
 from rigging.config_discovery import find_project_root
@@ -166,7 +166,7 @@ def launch(
     "--prefix",
     "prefixes",
     multiple=True,
-    default=(DEFAULT_RECORDS_PREFIX, CW_RECORDS_PREFIX),
+    default=DEFAULT_SCAN_PREFIXES,
     show_default=True,
     help="Object-store prefix(es) to scan for records; repeatable.",
 )

--- a/infra/evaldash/README.md
+++ b/infra/evaldash/README.md
@@ -10,6 +10,10 @@ credentials come from Secret Manager; endpoint/addressing via
 (`hai-gcp-models:us-central1:marin-metadata`, database `evals`). A Starlette app serves a JSON API over
 that index and the built Vue SPA. Served at https://evaldash.oa.dev.
 
+The default scan also includes the former flat `gs://marin-eval-metadata/runs` and
+`s3://marin-us-east-02a/marin/eval-metadata/runs` roots because older CLI checkouts still write there.
+Canonical `evals` roots have precedence when the same migrated `run_id` exists in both locations.
+
 Record discovery uses a delimiter-based directory listing and checks only `*/record.json`. It does not
 recursively enumerate results, samples, trajectories, or other evaluator payloads. It reads candidate
 record bodies with up to 16 concurrent object-store requests. Successful records are cached by

--- a/infra/evaldash/__main__.py
+++ b/infra/evaldash/__main__.py
@@ -23,7 +23,7 @@ import pulumi
 import pulumi_cloudflare as cloudflare
 import pulumi_gcp as gcp
 from iac.gcp.cloud_run import CloudRunService, CloudRunServiceArgs, SecretEnv
-from marin.evaluation.records import CW_RECORDS_PREFIX, DEFAULT_RECORDS_PREFIX
+from marin.evaluation.records import DEFAULT_SCAN_PREFIXES
 
 PROJECT = "hai-gcp-models"
 REGION = "us-central1"
@@ -36,8 +36,8 @@ CLOUD_RUN_FRONTEND = "ghs.googlehosted.com"
 # admin API + the runtime SA's roles/cloudsql.client grant, so no VPC path is needed.
 CLOUDSQL_INSTANCE = "hai-gcp-models:us-central1:marin-metadata"
 
-# CoreWeave workers have no GCP credentials, so GPU runs write to the CW-local S3 store.
-RECORDS_PREFIXES = ",".join((DEFAULT_RECORDS_PREFIX, CW_RECORDS_PREFIX))
+# Canonical roots come first so they win when a migrated run also exists in a legacy root.
+RECORDS_PREFIXES = ",".join(DEFAULT_SCAN_PREFIXES)
 EVAL_DB_NAME = "evals"
 EVAL_DB_USER = "evals"
 

--- a/infra/evaldash/src/server.py
+++ b/infra/evaldash/src/server.py
@@ -4,7 +4,8 @@
 """Eval-results dashboard server (Starlette + uvicorn).
 
 Serves a bundled Vue SPA plus a small JSON API over eval run records under the GCS or CoreWeave
-``evals`` output root.
+``evals`` output root. It also scans the former flat ``eval-metadata/runs`` roots while older CLI
+checkouts can still write there.
 
 A background task ingests the records on startup and every ``EVALDASH_INGEST_INTERVAL`` seconds
 (default 300). Reads are served through a ``RecordStore`` selected by ``EVALDASH_STORE``: the
@@ -50,8 +51,7 @@ import samples
 import sqlalchemy
 import uvicorn
 from marin.evaluation.records import (
-    CW_RECORDS_PREFIX,
-    DEFAULT_RECORDS_PREFIX,
+    DEFAULT_SCAN_PREFIXES,
     EvalRunRecord,
     RecordParseFailure,
     scan_records,
@@ -81,7 +81,7 @@ RECORDS_PREFIXES = tuple(
     part.strip()
     for part in os.environ.get(
         "RECORDS_PREFIXES",
-        ",".join((DEFAULT_RECORDS_PREFIX, CW_RECORDS_PREFIX)),
+        ",".join(DEFAULT_SCAN_PREFIXES),
     ).split(",")
     if part.strip()
 )
@@ -115,6 +115,14 @@ class StoreInfo:
     backend: str
     instance: str | None
     database: str | None
+
+
+def _deduplicate_records(records: list[EvalRunRecord]) -> list[EvalRunRecord]:
+    """Keep the first record for each run ID so prefix order defines migration precedence."""
+    by_id: dict[str, EvalRunRecord] = {}
+    for record in records:
+        by_id.setdefault(record.run_id, record)
+    return list(by_id.values())
 
 
 def record_to_row(record: EvalRunRecord) -> dict:
@@ -191,6 +199,7 @@ class RecordStore:
 
     def refresh(self, records: list[EvalRunRecord]) -> None:
         """Absorb a fresh record listing. The base only swaps the snapshot; Postgres also upserts."""
+        records = _deduplicate_records(records)
         self._set_snapshot(records)
         logger.info("memory store refreshed: %d records", len(records))
 
@@ -366,6 +375,7 @@ class PgRecordStore(RecordStore):
         return StoreInfo(backend=self.backend, instance=self._instance, database=self._database)
 
     def refresh(self, records: list[EvalRunRecord]) -> None:
+        records = _deduplicate_records(records)
         self._set_snapshot(records)
         for record in records:
             upsert_record(self._engine, record)
@@ -489,6 +499,7 @@ class Ingestor:
     """
 
     def __init__(self, store: RecordStore, prefixes: tuple[str, ...], interval: float) -> None:
+        """Create an ingestor whose prefixes are ordered from highest to lowest precedence."""
         self._store = store
         self._prefixes = prefixes
         self.interval = interval

--- a/lib/marin/src/marin/evaluation/records.py
+++ b/lib/marin/src/marin/evaluation/records.py
@@ -30,6 +30,14 @@ DEFAULT_RECORDS_PREFIX = "gs://marin-eval-metadata/evals"
 # credentials but no GCP ones. The dashboard's ingest scans both prefixes. Access from outside
 # the cluster needs `rigging.filesystem.s3_compat.configure_coreweave_s3()` first.
 CW_RECORDS_PREFIX = "s3://marin-us-east-02a/marin/evals"
+LEGACY_GCP_RECORDS_PREFIX = "gs://marin-eval-metadata/runs"
+LEGACY_CW_RECORDS_PREFIX = "s3://marin-us-east-02a/marin/eval-metadata/runs"
+DEFAULT_SCAN_PREFIXES = (
+    DEFAULT_RECORDS_PREFIX,
+    CW_RECORDS_PREFIX,
+    LEGACY_GCP_RECORDS_PREFIX,
+    LEGACY_CW_RECORDS_PREFIX,
+)
 RECORD_FILE = "record.json"
 _MAX_RECORD_READERS = 16
 

--- a/tests/evaluation/test_evaldash_local_store.py
+++ b/tests/evaluation/test_evaldash_local_store.py
@@ -22,7 +22,7 @@ if str(_EVALDASH_SRC) not in sys.path:
 import fixtures  # noqa: E402
 import samples  # noqa: E402
 import server  # noqa: E402
-from marin.evaluation.records import list_records  # noqa: E402
+from marin.evaluation.records import list_records, write_record  # noqa: E402
 from starlette.testclient import TestClient  # noqa: E402
 
 
@@ -165,6 +165,23 @@ def test_ingestor_surfaces_parse_failures(tmp_path):
     assert len(probe["parse_failures"]) == 1
     assert probe["parse_failures"][0]["path"].endswith("20260722-000000-legacy-mmlu-broken/record.json")
     assert "launch_host" in probe["parse_failures"][0]["error"]
+
+
+def test_memory_store_deduplicates_migrated_runs_with_canonical_precedence(tmp_path):
+    source = tmp_path / "source"
+    fixtures.build_fixtures(str(source))
+    record = list_records(str(source))[0]
+    canonical = tmp_path / "canonical"
+    legacy = tmp_path / "legacy"
+    write_record(record.model_copy(update={"description": "canonical"}), str(canonical))
+    write_record(record.model_copy(update={"description": "legacy"}), str(legacy))
+    store = server.MemoryRecordStore()
+    store.refresh(list_records(str(canonical)) + list_records(str(legacy)))
+
+    assert len(store.fetch_runs()) == 1
+    stored = store.get_record(record.run_id)
+    assert stored is not None
+    assert stored["description"] == "canonical"
 
 
 def test_api_jobs_degrade_without_a_cluster(client):


### PR DESCRIPTION
Scan the former GCS and CoreWeave `eval-metadata/runs` roots alongside the canonical `evals` roots
while older CLI checkouts can still write there. Keep canonical roots first and deduplicate by
`run_id` before updating dashboard snapshots or Postgres, so copied runs appear once.

Record discovery remains limited to flat `<root>/<run_id>/record.json` paths; result and sample
payloads are not traversed. The same four-root default applies to the sample-backfill command.
