### PR TITLE
[iac] Grant observability viewer access

### DIFF
--- a/infra/pulumi/src/iac/gcp/iam_data.py
+++ b/infra/pulumi/src/iac/gcp/iam_data.py
@@ -1029,6 +1029,9 @@ PROJECT_GRANTS: tuple[GcpRoleGrant, ...] = (
             GcpEncryptedMember(
                 ciphertext="CiQAKk3j6aM1cvMrBEbJ2ePmiYdFSsHrbI6/1GyeR6klqc8zNqwSQgCdtF6iwzsEl6d0eglJ/ciU1+CzdBfAAjgVXoR4PqZ65bW6xflRbssZGs8mAUedfmcOJbQSpnGhXsPo0bJy7TvjrA=="
             ),
+            GcpEncryptedMember(
+                ciphertext="CiQAKk3j6fgMf61FVEtp0V9YlyIoV1cTlbQfsX3SUjkVvhqAlp8SOQCdtF6iWgYGtbPiXHphalp6BT4zzVcGCml7SGl/0WrrOv4xvqyA/cWaE4XCV9ShI1mROr681jsQEg=="
+            ),
         ),
     ),
     GcpRoleGrant(
@@ -1056,6 +1059,9 @@ PROJECT_GRANTS: tuple[GcpRoleGrant, ...] = (
             ),
             GcpEncryptedMember(
                 ciphertext="CiQAKk3j6aM1cvMrBEbJ2ePmiYdFSsHrbI6/1GyeR6klqc8zNqwSQgCdtF6iwzsEl6d0eglJ/ciU1+CzdBfAAjgVXoR4PqZ65bW6xflRbssZGs8mAUedfmcOJbQSpnGhXsPo0bJy7TvjrA=="
+            ),
+            GcpEncryptedMember(
+                ciphertext="CiQAKk3j6fgMf61FVEtp0V9YlyIoV1cTlbQfsX3SUjkVvhqAlp8SOQCdtF6iWgYGtbPiXHphalp6BT4zzVcGCml7SGl/0WrrOv4xvqyA/cWaE4XCV9ShI1mROr681jsQEg=="
             ),
         ),
     ),


### PR DESCRIPTION
Grant `roles/logging.viewer` and `roles/monitoring.viewer` on the
`hai-gcp-models` project to the requested operator. Both roles provide
read-only observability access. Reuse the operator's existing encrypted
principal so no plaintext identity enters the repository.

A grant approver should run `review-grant`, then `pulumi up` on the `marin`
stack.

Fixes #7900
