### PR TITLE
[data] Add a shared Common Crawl WARC layer

### DIFF
--- a/lib/marin/pyproject.toml
+++ b/lib/marin/pyproject.toml
@@ -197,6 +197,7 @@ datakit = [
     "scikit-learn",
     "scipy",
     "duckdb>=1.0.0",
+    "warcio>=1.7.5,<2",
 ]
 
 math = ["pylatexenc", "sympy"]

--- a/lib/marin/src/marin/datakit/download/common_crawl_plan.py
+++ b/lib/marin/src/marin/datakit/download/common_crawl_plan.py
@@ -14,7 +14,7 @@ import json
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import Protocol, TypeAlias
+from typing import Protocol
 from urllib.parse import unquote, urlsplit
 
 import fsspec
@@ -38,8 +38,8 @@ _MANIFEST_BATCH_ROWS = 1 << 16
 DISCOVERY_FILENAME = "records.parquet"
 PLAN_FILENAME = "plan.parquet"
 
-JSONScalar: TypeAlias = str | int | float | bool | None
-IndexedRecord: TypeAlias = MainIndexedRecord | SupplementalIndexedRecord
+type JSONScalar = str | int | float | bool | None
+type IndexedRecord = MainIndexedRecord | SupplementalIndexedRecord
 
 
 class CommonCrawlIndexKind(StrEnum):
@@ -400,9 +400,7 @@ def plan_common_crawl_manifest(
     return write_common_crawl_plan(tasks, output_path)
 
 
-def _coalesce_ranges(
-    records: list[SelectedCommonCrawlRecord], *, gap_bytes: int
-) -> list[PlannedCommonCrawlRange]:
+def _coalesce_ranges(records: list[SelectedCommonCrawlRecord], *, gap_bytes: int) -> list[PlannedCommonCrawlRange]:
     ranges: list[PlannedCommonCrawlRange] = []
     open_records: list[IndexedRecord] = []
     open_source: CommonCrawlSource | None = None

--- a/lib/marin/src/marin/datakit/download/common_crawl_plan.py
+++ b/lib/marin/src/marin/datakit/download/common_crawl_plan.py
@@ -1,0 +1,670 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Discover Common Crawl records and turn them into deterministic fetch tasks.
+
+Discovery answers which records a caller selected. Planning answers how to transfer those records:
+records are ordered by source, WARC, and offset; nearby records become one HTTP range; ranges are
+optionally sampled per source; and consecutive ranges are packed into source-local byte-sized tasks.
+The split keeps an expensive URL-index scan reusable when only transfer policy changes.
+"""
+
+import hashlib
+import json
+from collections.abc import Iterable, Iterator, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Protocol, TypeAlias
+from urllib.parse import unquote, urlsplit
+
+import fsspec
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pydantic import BaseModel
+from rigging.filesystem import StoragePath, prefix_join
+
+from marin.datakit.download.common_crawl_warc import (
+    COMMON_CRAWL_DATA_URL,
+    MainIndexedRecord,
+    SupplementalIndexedRecord,
+    main_record_from_index_row,
+    supplemental_record_from_index_row,
+)
+
+DEFAULT_COALESCE_GAP_BYTES = 1 << 20
+DEFAULT_TASK_BYTES = 256 << 20
+_MANIFEST_BATCH_ROWS = 1 << 16
+DISCOVERY_FILENAME = "records.parquet"
+PLAN_FILENAME = "plan.parquet"
+
+JSONScalar: TypeAlias = str | int | float | bool | None
+IndexedRecord: TypeAlias = MainIndexedRecord | SupplementalIndexedRecord
+
+
+class CommonCrawlIndexKind(StrEnum):
+    """Common Crawl index schema used to discover and verify records."""
+
+    MAIN = "main"
+    SUPPLEMENTAL = "supplemental"
+
+
+@dataclass(frozen=True)
+class CommonCrawlSource:
+    """One Common Crawl snapshot and URL-index surface."""
+
+    crawl_id: str
+    index_kind: CommonCrawlIndexKind
+    paths_manifest_url: str
+    base_url: str = COMMON_CRAWL_DATA_URL
+    subset: str = "warc"
+
+    def __post_init__(self) -> None:
+        for name in ("crawl_id", "paths_manifest_url", "base_url", "subset"):
+            if not getattr(self, name):
+                raise ValueError(f"{name} must be non-empty")
+
+    @property
+    def source_id(self) -> str:
+        """Return a stable identifier derived from semantic source fields."""
+        payload = json.dumps(
+            {
+                "base_url": self.base_url.rstrip("/"),
+                "crawl_id": self.crawl_id,
+                "index_kind": self.index_kind.value,
+                "paths_manifest_url": self.paths_manifest_url,
+                "subset": self.subset,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+@dataclass(frozen=True)
+class CommonCrawlSelection:
+    """Caller-owned, JSON-compatible explanation for selecting one index row."""
+
+    metadata: Mapping[str, JSONScalar]
+
+    def __post_init__(self) -> None:
+        json.dumps(dict(self.metadata), sort_keys=True)
+
+
+class CommonCrawlRecordSelector(Protocol):
+    """Serializable selection policy applied to normalized URL-index rows."""
+
+    @property
+    def identity(self) -> Mapping[str, object]: ...
+
+    def select(self, row: Mapping[str, object]) -> CommonCrawlSelection | None: ...
+
+
+@dataclass(frozen=True)
+class CommonCrawlFilter:
+    """Standard status, truncation, MIME, and URL-suffix record selector."""
+
+    successful_responses: bool = True
+    exclude_truncated: bool = True
+    declared_mime_types: frozenset[str] = frozenset()
+    detected_mime_types: frozenset[str] = frozenset()
+    url_suffixes: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not (self.declared_mime_types or self.detected_mime_types or self.url_suffixes):
+            raise ValueError("at least one MIME type or URL suffix must be configured")
+        if any(not suffix.startswith(".") for suffix in self.url_suffixes):
+            raise ValueError("url_suffixes must start with '.'")
+
+    @property
+    def identity(self) -> Mapping[str, object]:
+        return {
+            "successful_responses": self.successful_responses,
+            "exclude_truncated": self.exclude_truncated,
+            "declared_mime_types": sorted(self.declared_mime_types),
+            "detected_mime_types": sorted(self.detected_mime_types),
+            "url_suffixes": list(self.url_suffixes),
+        }
+
+    def select(self, row: Mapping[str, object]) -> CommonCrawlSelection | None:
+        status = row.get("fetch_status")
+        if self.successful_responses and (
+            isinstance(status, bool) or not isinstance(status, int) or not 200 <= status < 300
+        ):
+            return None
+        if self.exclude_truncated and row.get("content_truncated") is not None:
+            return None
+
+        declared = _mime_type(row.get("content_mime_type")) in self.declared_mime_types
+        detected = _mime_type(row.get("content_mime_detected")) in self.detected_mime_types
+        url = row.get("url")
+        suffix = isinstance(url, str) and any(
+            unquote(urlsplit(url).path).lower().endswith(candidate.lower()) for candidate in self.url_suffixes
+        )
+        if not (declared or detected or suffix):
+            return None
+        return CommonCrawlSelection(
+            metadata={"declared_mime": declared, "detected_mime": detected, "url_suffix": suffix}
+        )
+
+
+@dataclass(frozen=True)
+class SelectedCommonCrawlRecord:
+    """One normalized index record selected for a later fetch plan."""
+
+    source: CommonCrawlSource
+    indexed_record: IndexedRecord
+    selection: CommonCrawlSelection
+
+
+@dataclass(frozen=True)
+class PlannedCommonCrawlRange:
+    """One exact HTTP interval and its ordered expected WARC records."""
+
+    source: CommonCrawlSource
+    warc_filename: str
+    start: int
+    stop: int
+    records: tuple[IndexedRecord, ...]
+
+    def __post_init__(self) -> None:
+        if self.start < 0 or self.stop <= self.start:
+            raise ValueError("planned range must have non-negative start and stop > start")
+        if not self.records:
+            raise ValueError("planned range must contain records")
+
+    @property
+    def size(self) -> int:
+        return self.stop - self.start
+
+
+@dataclass(frozen=True)
+class CommonCrawlFetchTask:
+    """A source-local scheduling envelope containing one or more planned ranges."""
+
+    task_id: int
+    source: CommonCrawlSource
+    ranges: tuple[PlannedCommonCrawlRange, ...]
+
+    @property
+    def size(self) -> int:
+        return sum(selected.size for selected in self.ranges)
+
+
+class CommonCrawlSamplingMode(StrEnum):
+    NONE = "none"
+    PER_SOURCE_RANGE = "per_source_range"
+
+
+@dataclass(frozen=True)
+class CommonCrawlPlanOptions:
+    """Semantic transfer-planning policy."""
+
+    coalesce_gap_bytes: int = DEFAULT_COALESCE_GAP_BYTES
+    task_bytes: int = DEFAULT_TASK_BYTES
+    sampling_mode: CommonCrawlSamplingMode = CommonCrawlSamplingMode.NONE
+    sample_fraction: float = 1.0
+    sample_seed: int = 0
+
+    def __post_init__(self) -> None:
+        if self.coalesce_gap_bytes < 0:
+            raise ValueError("coalesce_gap_bytes must be non-negative")
+        if self.task_bytes <= 0:
+            raise ValueError("task_bytes must be positive")
+        if not 0.0 < self.sample_fraction <= 1.0:
+            raise ValueError("sample_fraction must be in (0, 1]")
+        if self.sampling_mode is CommonCrawlSamplingMode.NONE and self.sample_fraction != 1.0:
+            raise ValueError("sample_fraction must be 1.0 when sampling is disabled")
+
+
+class CommonCrawlSourceSummary(BaseModel):
+    crawl_id: str
+    num_warcs: int
+    num_records: int
+    num_ranges: int
+    fetch_bytes: int
+    num_tasks: int
+
+
+class CommonCrawlPlanSummary(BaseModel):
+    manifest_path: str
+    num_sources: int
+    num_warcs: int
+    num_records: int
+    num_ranges: int
+    fetch_bytes: int
+    num_tasks: int
+    sources: dict[str, CommonCrawlSourceSummary]
+
+
+class CommonCrawlDiscoverySummary(BaseModel):
+    manifest_path: str
+    num_sources: int
+    num_records: int
+
+
+class CommonCrawlPlanError(ValueError):
+    """Raised when selected records or a persisted plan are inconsistent."""
+
+
+_MEMBER_TYPE = pa.struct(
+    [
+        pa.field("offset", pa.int64(), nullable=False),
+        pa.field("length", pa.int64(), nullable=False),
+        pa.field("url", pa.string(), nullable=False),
+        pa.field("content_digest", pa.string(), nullable=False),
+        pa.field("warc_record_id", pa.string()),
+    ]
+)
+DISCOVERY_SCHEMA = pa.schema(
+    [
+        pa.field("source_id", pa.string(), nullable=False),
+        pa.field("crawl_id", pa.string(), nullable=False),
+        pa.field("index_kind", pa.string(), nullable=False),
+        pa.field("paths_manifest_url", pa.string(), nullable=False),
+        pa.field("base_url", pa.string(), nullable=False),
+        pa.field("subset", pa.string(), nullable=False),
+        pa.field("url", pa.string(), nullable=False),
+        pa.field("content_digest", pa.string(), nullable=False),
+        pa.field("warc_filename", pa.string(), nullable=False),
+        pa.field("warc_record_offset", pa.int64(), nullable=False),
+        pa.field("warc_record_length", pa.int64(), nullable=False),
+        pa.field("warc_record_id", pa.string()),
+        pa.field("selection_metadata", pa.string(), nullable=False),
+    ]
+)
+PLAN_SCHEMA = pa.schema(
+    [
+        pa.field("task_id", pa.int64(), nullable=False),
+        pa.field("range_index", pa.int32(), nullable=False),
+        pa.field("source_id", pa.string(), nullable=False),
+        pa.field("crawl_id", pa.string(), nullable=False),
+        pa.field("index_kind", pa.string(), nullable=False),
+        pa.field("paths_manifest_url", pa.string(), nullable=False),
+        pa.field("base_url", pa.string(), nullable=False),
+        pa.field("subset", pa.string(), nullable=False),
+        pa.field("warc_filename", pa.string(), nullable=False),
+        pa.field("range_start", pa.int64(), nullable=False),
+        pa.field("range_end", pa.int64(), nullable=False),
+        pa.field("records", pa.list_(_MEMBER_TYPE), nullable=False),
+    ]
+)
+
+
+def discover_index_partition(
+    index_partition: str,
+    *,
+    source: CommonCrawlSource,
+    selector: CommonCrawlRecordSelector,
+    batch_rows: int,
+) -> Iterator[SelectedCommonCrawlRecord]:
+    """Scan one index partition and yield selected records in source order."""
+    if batch_rows <= 0:
+        raise ValueError("batch_rows must be positive")
+    partition_url = f"{source.base_url.rstrip('/')}/{index_partition.lstrip('/')}"
+    with fsspec.open(partition_url, "rb") as stream:
+        parquet = pq.ParquetFile(stream)
+        columns = [
+            "url",
+            "fetch_status",
+            "content_mime_type",
+            "content_mime_detected",
+            "content_digest",
+            "content_truncated",
+            "warc_filename",
+            "warc_record_offset",
+            "warc_record_length",
+        ]
+        if source.index_kind is CommonCrawlIndexKind.MAIN:
+            columns.append("warc_record_id")
+        missing = set(columns) - set(parquet.schema_arrow.names)
+        if missing:
+            raise ValueError(f"Index partition is missing required columns: {sorted(missing)}")
+        for batch in parquet.iter_batches(columns=columns, batch_size=batch_rows):
+            for row in batch.to_pylist():
+                selection = selector.select(row)
+                if selection is None:
+                    continue
+                try:
+                    indexed = (
+                        main_record_from_index_row(row, crawl_id=source.crawl_id)
+                        if source.index_kind is CommonCrawlIndexKind.MAIN
+                        else supplemental_record_from_index_row(row, crawl_id=source.crawl_id)
+                    )
+                except ValueError:
+                    continue
+                yield SelectedCommonCrawlRecord(source=source, indexed_record=indexed, selection=selection)
+
+
+def plan_common_crawl_records(
+    records: Iterable[SelectedCommonCrawlRecord],
+    options: CommonCrawlPlanOptions = CommonCrawlPlanOptions(),
+) -> list[CommonCrawlFetchTask]:
+    """Coalesce, optionally sample, and pack selected records into source-local tasks."""
+    ordered = sorted(
+        records,
+        key=lambda selected: (
+            selected.source.source_id,
+            selected.indexed_record.record_range.warc_filename,
+            selected.indexed_record.record_range.offset,
+        ),
+    )
+    ranges = _coalesce_ranges(ordered, gap_bytes=options.coalesce_gap_bytes)
+    ranges = _sample_ranges(ranges, options)
+    return _pack_tasks(ranges, task_bytes=options.task_bytes)
+
+
+def write_common_crawl_discovery(
+    records: Iterable[SelectedCommonCrawlRecord], output_path: str
+) -> CommonCrawlDiscoverySummary:
+    """Stream normalized selected records to a reusable discovery manifest."""
+    manifest_path = prefix_join(output_path, DISCOVERY_FILENAME)
+    StoragePath(output_path).mkdirs()
+    source_ids: set[str] = set()
+    num_records = 0
+    with StoragePath(manifest_path).open("wb") as stream:
+        with pq.ParquetWriter(stream, DISCOVERY_SCHEMA) as writer:
+            rows: list[dict[str, object]] = []
+            for selected in records:
+                source_ids.add(selected.source.source_id)
+                num_records += 1
+                rows.append(_selected_record(selected))
+                if len(rows) == _MANIFEST_BATCH_ROWS:
+                    writer.write_table(pa.Table.from_pylist(rows, schema=DISCOVERY_SCHEMA))
+                    rows.clear()
+            if rows or num_records == 0:
+                writer.write_table(pa.Table.from_pylist(rows, schema=DISCOVERY_SCHEMA))
+    return CommonCrawlDiscoverySummary(
+        manifest_path=manifest_path,
+        num_sources=len(source_ids),
+        num_records=num_records,
+    )
+
+
+def read_common_crawl_discovery(manifest_path: str) -> Iterator[SelectedCommonCrawlRecord]:
+    """Yield selected records from a persisted discovery manifest in manifest order."""
+    with StoragePath(manifest_path).open("rb") as stream:
+        parquet = pq.ParquetFile(stream)
+        for batch in parquet.iter_batches():
+            for row in batch.to_pylist():
+                yield _selected_from_row(row)
+
+
+def plan_common_crawl_manifest(
+    discovery_path: str,
+    output_path: str,
+    options: CommonCrawlPlanOptions = CommonCrawlPlanOptions(),
+) -> CommonCrawlPlanSummary:
+    """Plan a persisted discovery manifest and write its range/task manifest."""
+    tasks = plan_common_crawl_records(read_common_crawl_discovery(discovery_path), options)
+    return write_common_crawl_plan(tasks, output_path)
+
+
+def _coalesce_ranges(
+    records: list[SelectedCommonCrawlRecord], *, gap_bytes: int
+) -> list[PlannedCommonCrawlRange]:
+    ranges: list[PlannedCommonCrawlRange] = []
+    open_records: list[IndexedRecord] = []
+    open_source: CommonCrawlSource | None = None
+    open_warc = ""
+    open_start = -1
+    open_stop = -1
+
+    def close_range() -> None:
+        if open_source is not None:
+            ranges.append(
+                PlannedCommonCrawlRange(
+                    source=open_source,
+                    warc_filename=open_warc,
+                    start=open_start,
+                    stop=open_stop,
+                    records=tuple(open_records),
+                )
+            )
+
+    for selected in records:
+        record_range = selected.indexed_record.record_range
+        same_warc = selected.source.source_id == (open_source.source_id if open_source else None) and (
+            record_range.warc_filename == open_warc
+        )
+        if same_warc and record_range.offset < open_stop:
+            raise CommonCrawlPlanError(
+                f"Overlapping records in {record_range.warc_filename} at offset {record_range.offset}"
+            )
+        if open_records and same_warc and record_range.offset - open_stop <= gap_bytes:
+            open_stop = record_range.stop
+            open_records.append(selected.indexed_record)
+            continue
+        close_range()
+        open_source = selected.source
+        open_warc = record_range.warc_filename
+        open_start = record_range.offset
+        open_stop = record_range.stop
+        open_records = [selected.indexed_record]
+    close_range()
+    return ranges
+
+
+def _sample_ranges(
+    ranges: list[PlannedCommonCrawlRange], options: CommonCrawlPlanOptions
+) -> list[PlannedCommonCrawlRange]:
+    if options.sampling_mode is CommonCrawlSamplingMode.NONE or options.sample_fraction == 1.0:
+        return ranges
+    selected: list[PlannedCommonCrawlRange] = []
+    start = 0
+    while start < len(ranges):
+        source_id = ranges[start].source.source_id
+        stop = start + 1
+        while stop < len(ranges) and ranges[stop].source.source_id == source_id:
+            stop += 1
+        source_ranges = ranges[start:stop]
+        count = round(len(source_ranges) * options.sample_fraction)
+        seed_bytes = hashlib.sha256(f"{options.sample_seed}:{source_id}".encode()).digest()[:8]
+        chosen = np.random.default_rng(int.from_bytes(seed_bytes)).choice(len(source_ranges), size=count, replace=False)
+        selected.extend(source_ranges[index] for index in sorted(chosen.tolist()))
+        start = stop
+    return selected
+
+
+def _pack_tasks(ranges: list[PlannedCommonCrawlRange], *, task_bytes: int) -> list[CommonCrawlFetchTask]:
+    tasks: list[CommonCrawlFetchTask] = []
+    current: list[PlannedCommonCrawlRange] = []
+    current_bytes = 0
+    current_source: CommonCrawlSource | None = None
+    for selected in ranges:
+        source_changed = current_source is not None and current_source.source_id != selected.source.source_id
+        if current and (source_changed or current_bytes + selected.size > task_bytes):
+            assert current_source is not None
+            tasks.append(CommonCrawlFetchTask(len(tasks), current_source, tuple(current)))
+            current, current_bytes = [], 0
+        current_source = selected.source
+        current.append(selected)
+        current_bytes += selected.size
+    if current:
+        assert current_source is not None
+        tasks.append(CommonCrawlFetchTask(len(tasks), current_source, tuple(current)))
+    return tasks
+
+
+def write_common_crawl_plan(tasks: Iterable[CommonCrawlFetchTask], output_path: str) -> CommonCrawlPlanSummary:
+    """Write one deterministic Parquet row per range and return aggregate totals."""
+    task_list = list(tasks)
+    rows = [row for task in task_list for row in _task_rows(task)]
+    plan_path = prefix_join(output_path, PLAN_FILENAME)
+    StoragePath(output_path).mkdirs()
+    with StoragePath(plan_path).open("wb") as stream:
+        pq.write_table(pa.Table.from_pylist(rows, schema=PLAN_SCHEMA), stream)
+    return _plan_summary(task_list, plan_path)
+
+
+def read_common_crawl_tasks(plan_path: str) -> list[CommonCrawlFetchTask]:
+    """Reconstruct tasks in manifest order, rejecting inconsistent rows."""
+    with StoragePath(plan_path).open("rb") as stream:
+        rows = pq.read_table(stream, schema=PLAN_SCHEMA).to_pylist()
+    grouped: dict[int, list[Mapping[str, object]]] = {}
+    for row in rows:
+        grouped.setdefault(int(row["task_id"]), []).append(row)
+    if sorted(grouped) != list(range(len(grouped))):
+        raise CommonCrawlPlanError("task IDs must be contiguous from zero")
+    tasks = []
+    for task_id in sorted(grouped):
+        task_rows = grouped[task_id]
+        if [int(row["range_index"]) for row in task_rows] != list(range(len(task_rows))):
+            raise CommonCrawlPlanError(f"range indexes for task {task_id} must be contiguous from zero")
+        ranges = tuple(_range_from_row(row) for row in task_rows)
+        source = ranges[0].source
+        if any(selected.source != source for selected in ranges):
+            raise CommonCrawlPlanError(f"task {task_id} spans sources")
+        tasks.append(CommonCrawlFetchTask(task_id, source, ranges))
+    return tasks
+
+
+def _task_rows(task: CommonCrawlFetchTask) -> Iterator[dict[str, object]]:
+    for range_index, selected in enumerate(task.ranges):
+        if selected.source != task.source:
+            raise CommonCrawlPlanError(f"task {task.task_id} contains a range from another source")
+        yield {
+            "task_id": task.task_id,
+            "range_index": range_index,
+            "source_id": task.source.source_id,
+            "crawl_id": task.source.crawl_id,
+            "index_kind": task.source.index_kind.value,
+            "paths_manifest_url": task.source.paths_manifest_url,
+            "base_url": task.source.base_url,
+            "subset": task.source.subset,
+            "warc_filename": selected.warc_filename,
+            "range_start": selected.start,
+            "range_end": selected.stop,
+            "records": [_member_record(record) for record in selected.records],
+        }
+
+
+def _selected_record(selected: SelectedCommonCrawlRecord) -> dict[str, object]:
+    source = selected.source
+    indexed = selected.indexed_record
+    location = indexed.record_range
+    expectation = indexed.expectation
+    return {
+        "source_id": source.source_id,
+        "crawl_id": source.crawl_id,
+        "index_kind": source.index_kind.value,
+        "paths_manifest_url": source.paths_manifest_url,
+        "base_url": source.base_url,
+        "subset": source.subset,
+        "url": expectation.url,
+        "content_digest": expectation.content_digest,
+        "warc_filename": location.warc_filename,
+        "warc_record_offset": location.offset,
+        "warc_record_length": location.length,
+        "warc_record_id": expectation.warc_record_id if isinstance(indexed, MainIndexedRecord) else None,
+        "selection_metadata": json.dumps(dict(selected.selection.metadata), sort_keys=True, separators=(",", ":")),
+    }
+
+
+def _selected_from_row(row: Mapping[str, object]) -> SelectedCommonCrawlRecord:
+    source = _source_from_row(row)
+    indexed = _indexed_from_row(row, source)
+    metadata = json.loads(str(row["selection_metadata"]))
+    if not isinstance(metadata, dict):
+        raise CommonCrawlPlanError("selection metadata must be a JSON object")
+    return SelectedCommonCrawlRecord(source, indexed, CommonCrawlSelection(metadata))
+
+
+def _member_record(record: IndexedRecord) -> dict[str, object]:
+    expectation = record.expectation
+    return {
+        "offset": record.record_range.offset,
+        "length": record.record_range.length,
+        "url": expectation.url,
+        "content_digest": expectation.content_digest,
+        "warc_record_id": expectation.warc_record_id if isinstance(record, MainIndexedRecord) else None,
+    }
+
+
+def _range_from_row(row: Mapping[str, object]) -> PlannedCommonCrawlRange:
+    source = _source_from_row(row)
+    warc_filename = str(row["warc_filename"])
+    members = row["records"]
+    assert isinstance(members, list)
+    indexed: list[IndexedRecord] = []
+    for member in members:
+        assert isinstance(member, dict)
+        index_row = {
+            "url": member["url"],
+            "content_digest": member["content_digest"],
+            "warc_filename": warc_filename,
+            "warc_record_offset": member["offset"],
+            "warc_record_length": member["length"],
+            "warc_record_id": member["warc_record_id"],
+        }
+        indexed.append(
+            main_record_from_index_row(index_row, crawl_id=source.crawl_id)
+            if source.index_kind is CommonCrawlIndexKind.MAIN
+            else supplemental_record_from_index_row(index_row, crawl_id=source.crawl_id)
+        )
+    return PlannedCommonCrawlRange(
+        source=source,
+        warc_filename=warc_filename,
+        start=int(row["range_start"]),
+        stop=int(row["range_end"]),
+        records=tuple(indexed),
+    )
+
+
+def _source_from_row(row: Mapping[str, object]) -> CommonCrawlSource:
+    source = CommonCrawlSource(
+        crawl_id=str(row["crawl_id"]),
+        index_kind=CommonCrawlIndexKind(str(row["index_kind"])),
+        paths_manifest_url=str(row["paths_manifest_url"]),
+        base_url=str(row["base_url"]),
+        subset=str(row["subset"]),
+    )
+    if row["source_id"] != source.source_id:
+        raise CommonCrawlPlanError("persisted source ID does not match source fields")
+    return source
+
+
+def _indexed_from_row(row: Mapping[str, object], source: CommonCrawlSource) -> IndexedRecord:
+    index_row = {
+        "url": row["url"],
+        "content_digest": row["content_digest"],
+        "warc_filename": row["warc_filename"],
+        "warc_record_offset": row["warc_record_offset"],
+        "warc_record_length": row["warc_record_length"],
+        "warc_record_id": row.get("warc_record_id"),
+    }
+    return (
+        main_record_from_index_row(index_row, crawl_id=source.crawl_id)
+        if source.index_kind is CommonCrawlIndexKind.MAIN
+        else supplemental_record_from_index_row(index_row, crawl_id=source.crawl_id)
+    )
+
+
+def _plan_summary(tasks: list[CommonCrawlFetchTask], plan_path: str) -> CommonCrawlPlanSummary:
+    per_source: dict[str, CommonCrawlSourceSummary] = {}
+    for source_id in dict.fromkeys(task.source.source_id for task in tasks):
+        source_tasks = [task for task in tasks if task.source.source_id == source_id]
+        ranges = [selected for task in source_tasks for selected in task.ranges]
+        source = source_tasks[0].source
+        per_source[source_id] = CommonCrawlSourceSummary(
+            crawl_id=source.crawl_id,
+            num_warcs=len({selected.warc_filename for selected in ranges}),
+            num_records=sum(len(selected.records) for selected in ranges),
+            num_ranges=len(ranges),
+            fetch_bytes=sum(selected.size for selected in ranges),
+            num_tasks=len(source_tasks),
+        )
+    return CommonCrawlPlanSummary(
+        manifest_path=plan_path,
+        num_sources=len(per_source),
+        num_warcs=sum(summary.num_warcs for summary in per_source.values()),
+        num_records=sum(summary.num_records for summary in per_source.values()),
+        num_ranges=sum(summary.num_ranges for summary in per_source.values()),
+        fetch_bytes=sum(summary.fetch_bytes for summary in per_source.values()),
+        num_tasks=len(tasks),
+        sources=per_source,
+    )
+
+
+def _mime_type(value: object) -> str:
+    return value.partition(";")[0].strip().lower() if isinstance(value, str) else ""

--- a/lib/marin/src/marin/datakit/download/common_crawl_warc.py
+++ b/lib/marin/src/marin/datakit/download/common_crawl_warc.py
@@ -6,11 +6,14 @@
 import base64
 import gzip
 import hashlib
+import http.client
 import io
 import re
+import tempfile
 import uuid
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import BinaryIO, Protocol
 
 import requests
 from warcio.archiveiterator import ArchiveIterator
@@ -30,6 +33,7 @@ _CONTENT_RANGE_PATTERN = re.compile(r"bytes (\d+)-(\d+)/(?:\d+|\*)")
 _SHA1_BASE32_PATTERN = re.compile(r"[A-Z2-7]{32}")
 _MAXIMUM_MANIFEST_BYTES = 16 << 20
 _MAXIMUM_DECOMPRESSED_MANIFEST_BYTES = 128 << 20
+_MAXIMUM_DOWNLOAD_STALLS = 8
 
 
 class CommonCrawlWarcError(RuntimeError):
@@ -75,6 +79,10 @@ class WarcRevisitError(WarcParsingError):
 
 class RecordVerificationError(CommonCrawlWarcError):
     """Raised when a fetched WARC record does not match its index expectations."""
+
+
+class MissingPlannedRecordError(CommonCrawlWarcError):
+    """Raised when a coalesced range omits an expected record offset."""
 
 
 class OriginResponseStatusError(CommonCrawlWarcError):
@@ -162,6 +170,22 @@ class CommonCrawlWarcRecord:
     identified_payload_type: str | None
 
 
+class CommonCrawlRangeSource(Protocol):
+    """Source fields required by coalesced range transport."""
+
+    base_url: str
+
+
+class PlannedCommonCrawlRange(Protocol):
+    """Structural boundary implemented by the shared planner's range type."""
+
+    source: CommonCrawlRangeSource
+    warc_filename: str
+    start: int
+    stop: int
+    records: Sequence[MainIndexedRecord | SupplementalIndexedRecord]
+
+
 class CommonCrawlClient:
     """Retrying client for exact Common Crawl WARC record range requests."""
 
@@ -226,6 +250,88 @@ class CommonCrawlClient:
             raise CommonCrawlDownloadError(f"Failed to download WARC record from {url}") from error
 
         return _parse_warc_response(content, maximum_payload_bytes=self._maximum_payload_bytes)
+
+    def fetch_range(self, planned_range: PlannedCommonCrawlRange) -> tuple[CommonCrawlWarcRecord, ...]:
+        """Fetch a coalesced range and return its verified planned records in offset order."""
+        if planned_range.stop <= planned_range.start:
+            raise ValueError("planned range stop must be greater than start")
+        expected: dict[int, MainIndexedRecord | SupplementalIndexedRecord] = {}
+        previous_stop = planned_range.start
+        for indexed in planned_range.records:
+            location = indexed.record_range
+            if location.warc_filename != planned_range.warc_filename:
+                raise ValueError("planned record belongs to another WARC")
+            if location.offset < planned_range.start or location.stop > planned_range.stop:
+                raise ValueError("planned record lies outside the coalesced range")
+            if location.offset < previous_stop:
+                raise ValueError("planned records overlap or are out of order")
+            if location.length > self._maximum_warc_record_bytes:
+                raise WarcRecordTooLargeError(
+                    f"WARC record length {location.length} exceeds limit {self._maximum_warc_record_bytes}"
+                )
+            expected[location.offset] = indexed
+            previous_stop = location.stop
+
+        base_url = planned_range.source.base_url.rstrip("/") or self._base_url
+        url = f"{base_url}/{planned_range.warc_filename.lstrip('/')}"
+        with tempfile.TemporaryFile(prefix="common-crawl-range-", suffix=".warc.gz") as stream:
+            self._download_range(
+                url,
+                start=planned_range.start,
+                stop=planned_range.stop,
+                destination=stream,
+            )
+            return _parse_planned_records(
+                stream,
+                range_start=planned_range.start,
+                expected=expected,
+                maximum_payload_bytes=self._maximum_payload_bytes,
+            )
+
+    def _download_range(self, url: str, *, start: int, stop: int, destination: BinaryIO) -> None:
+        """Stream an exact byte range, resuming from the first unwritten byte after interruption."""
+        expected_bytes = stop - start
+        stalls = 0
+        while destination.tell() < expected_bytes:
+            written = destination.tell()
+            request_start = start + written
+            error: Exception | None = None
+            try:
+                with self._session.get(
+                    url,
+                    headers={"Range": f"bytes={request_start}-{stop - 1}", "user-agent": _USER_AGENT},
+                    stream=True,
+                    timeout=self._request_timeout,
+                ) as response:
+                    response.raise_for_status()
+                    _validate_range_response_headers(
+                        response,
+                        start=request_start,
+                        end=stop - 1,
+                        expected_length=stop - request_start,
+                    )
+                    for chunk in response.iter_content(chunk_size=_DOWNLOAD_CHUNK_BYTES):
+                        if chunk:
+                            destination.write(chunk)
+            except requests.HTTPError as caught:
+                status = caught.response.status_code if caught.response is not None else None
+                if status is not None and 400 <= status < 500 and status not in _RETRY_STATUS:
+                    raise CommonCrawlRequestRejectedError(url, status) from caught
+                error = caught
+            except (requests.RequestException, http.client.IncompleteRead) as caught:
+                error = caught
+
+            if destination.tell() > written:
+                stalls = 0
+            else:
+                stalls += 1
+            if destination.tell() > expected_bytes:
+                raise RangeResponseError(f"WARC range exceeded expected length {expected_bytes}")
+            if stalls > _MAXIMUM_DOWNLOAD_STALLS:
+                raise CommonCrawlDownloadError(
+                    f"WARC range download stalled at {destination.tell()}/{expected_bytes} bytes"
+                ) from error
+        destination.seek(0)
 
 
 def main_record_from_index_row(row: Mapping[str, object], *, crawl_id: str) -> MainIndexedRecord:
@@ -478,6 +584,69 @@ def _parse_warc_response(content: bytes, *, maximum_payload_bytes: int) -> Commo
         http_content_type=record.http_headers.get_header("Content-Type"),
         warc_date=record.rec_headers.get_header("WARC-Date"),
         identified_payload_type=record.rec_headers.get_header("WARC-Identified-Payload-Type"),
+    )
+
+
+def _parse_planned_records(
+    stream: BinaryIO,
+    *,
+    range_start: int,
+    expected: Mapping[int, MainIndexedRecord | SupplementalIndexedRecord],
+    maximum_payload_bytes: int,
+) -> tuple[CommonCrawlWarcRecord, ...]:
+    """Walk a downloaded interval and materialize only records named by absolute offset."""
+    found: dict[int, CommonCrawlWarcRecord] = {}
+    records = ArchiveIterator(stream)
+    try:
+        for record in records:
+            payload = record.content_stream().read(maximum_payload_bytes + 1)
+            absolute_offset = range_start + records.get_record_offset()
+            indexed = expected.get(absolute_offset)
+            if indexed is None:
+                continue
+            if absolute_offset in found:
+                raise WarcParsingError(f"WARC range contained duplicate record offset {absolute_offset}")
+            if record.rec_type == "revisit":
+                raise WarcRevisitError(f"Planned offset {absolute_offset} contains a revisit record")
+            if record.rec_type != "response" or record.http_headers is None:
+                raise WarcParsingError(f"Planned offset {absolute_offset} is not a WARC response record")
+            if len(payload) > maximum_payload_bytes:
+                raise WarcPayloadTooLargeError(f"WARC payload exceeds limit {maximum_payload_bytes}")
+            parsed = _warc_record_from_archive(record, payload)
+            if isinstance(indexed, MainIndexedRecord):
+                verify_url_index_record(parsed, indexed.expectation)
+            else:
+                verify_supplemental_record(parsed, indexed.expectation)
+            found[absolute_offset] = parsed
+    except ArchiveLoadFailed as error:
+        raise WarcParsingError("WARC byte range could not be parsed") from error
+
+    missing = sorted(set(expected) - set(found))
+    if missing:
+        raise MissingPlannedRecordError(f"WARC range omitted {len(missing)} planned records: {missing[:8]}")
+    return tuple(found[offset] for offset in sorted(found))
+
+
+def _warc_record_from_archive(record: object, payload: bytes) -> CommonCrawlWarcRecord:
+    """Build the shared observed-record shape from one consumed warcio record."""
+    rec_headers = record.rec_headers  # pyrefly: ignore[missing-attribute]
+    http_headers = record.http_headers  # pyrefly: ignore[missing-attribute]
+    record_id = rec_headers.get_header("WARC-Record-ID")
+    target_url = rec_headers.get_header("WARC-Target-URI")
+    if record_id is None or target_url is None:
+        raise WarcParsingError("WARC response record is missing its record ID or target URI")
+    status_code = http_headers.get_statuscode()
+    if status_code is None or not status_code.isdigit():
+        raise WarcParsingError(f"WARC response record has invalid HTTP status {status_code!r}")
+    return CommonCrawlWarcRecord(
+        payload=payload,
+        payload_digest=content_digest(payload),
+        warc_record_id=record_id,
+        target_url=target_url,
+        http_status=int(status_code),
+        http_content_type=http_headers.get_header("Content-Type"),
+        warc_date=rec_headers.get_header("WARC-Date"),
+        identified_payload_type=rec_headers.get_header("WARC-Identified-Payload-Type"),
     )
 
 

--- a/lib/marin/src/marin/datakit/download/common_crawl_warc.py
+++ b/lib/marin/src/marin/datakit/download/common_crawl_warc.py
@@ -1,9 +1,10 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Fetch and verify individual records from Common Crawl WARC files."""
+"""Discover Common Crawl index partitions and fetch and verify WARC records."""
 
 import base64
+import gzip
 import hashlib
 import io
 import re
@@ -18,6 +19,7 @@ from warcio.exceptions import ArchiveLoadFailed
 from marin.datakit.download.http_session import build_retrying_session
 
 COMMON_CRAWL_DATA_URL = "https://data.commoncrawl.org"
+_USER_AGENT = "marin-common-crawl-ingress/1.0"
 _DOWNLOAD_CHUNK_BYTES = 1 << 20
 _RETRY_STATUS = (403, 429, 500, 502, 503, 504)
 _RETRY_TOTAL = 10
@@ -25,6 +27,9 @@ _RETRY_BACKOFF_FACTOR = 2.0
 _RETRY_BACKOFF_JITTER = 10.0
 _REQUEST_TIMEOUT = (30, 300)
 _CONTENT_RANGE_PATTERN = re.compile(r"bytes (\d+)-(\d+)/(?:\d+|\*)")
+_SHA1_BASE32_PATTERN = re.compile(r"[A-Z2-7]{32}")
+_MAXIMUM_MANIFEST_BYTES = 16 << 20
+_MAXIMUM_DECOMPRESSED_MANIFEST_BYTES = 128 << 20
 
 
 class CommonCrawlWarcError(RuntimeError):
@@ -69,7 +74,7 @@ class WarcRevisitError(WarcParsingError):
 
 
 class RecordVerificationError(CommonCrawlWarcError):
-    """Raised when a fetched WARC record does not match its URL Index row."""
+    """Raised when a fetched WARC record does not match its index expectations."""
 
 
 class OriginResponseStatusError(CommonCrawlWarcError):
@@ -80,48 +85,75 @@ class OriginResponseStatusError(CommonCrawlWarcError):
         super().__init__(f"Origin HTTP status {status} is not successful")
 
 
+class CommonCrawlIndexManifestError(ValueError):
+    """Raised when an index partition manifest is invalid for the requested crawl."""
+
+
 @dataclass(frozen=True)
-class CommonCrawlRecordLocation:
-    """Record-level location and integrity fields from the Common Crawl URL Index."""
+class WarcRecordRange:
+    """Coordinates for one independently compressed WARC record."""
 
     crawl_id: str
-    url: str
     warc_filename: str
-    warc_record_offset: int
-    warc_record_length: int
+    offset: int
+    length: int
+
+    def __post_init__(self) -> None:
+        if self.offset < 0:
+            raise ValueError("offset must be non-negative")
+        if self.length <= 0:
+            raise ValueError("length must be positive")
+
+    @property
+    def stop(self) -> int:
+        """Return the exclusive end offset."""
+        return self.offset + self.length
+
+    @property
+    def http_range(self) -> tuple[int, int]:
+        """Return the inclusive HTTP byte range."""
+        return self.offset, self.stop - 1
+
+
+@dataclass(frozen=True)
+class UrlIndexRecordExpectation:
+    """Identity fields available from the current CC-MAIN URL Index."""
+
+    url: str
     warc_record_id: str
     content_digest: str
 
-    def __post_init__(self) -> None:
-        if self.warc_record_offset < 0:
-            raise ValueError("warc_record_offset must be non-negative")
-        if self.warc_record_length <= 0:
-            raise ValueError("warc_record_length must be positive")
 
-    @property
-    def byte_range(self) -> tuple[int, int]:
-        """Return the inclusive HTTP byte range for this record."""
-        return self.warc_record_offset, self.warc_record_offset + self.warc_record_length - 1
+@dataclass(frozen=True)
+class SupplementalRecordExpectation:
+    """Identity fields available from CC-SUPPLEMENTAL URL indexes."""
 
-    @classmethod
-    def from_url_index_row(cls, row: Mapping[str, object], *, crawl_id: str) -> "CommonCrawlRecordLocation":
-        """Build a location from one URL Index Parquet row."""
-        return cls(
-            crawl_id=crawl_id,
-            url=_required_string(row, "url"),
-            warc_filename=_required_string(row, "warc_filename"),
-            warc_record_offset=_required_int(row, "warc_record_offset"),
-            warc_record_length=_required_int(row, "warc_record_length"),
-            warc_record_id=_canonical_record_id(row.get("warc_record_id")),
-            content_digest=_canonical_content_digest(_required_string(row, "content_digest")),
-        )
+    url: str
+    content_digest: str
+
+
+@dataclass(frozen=True)
+class MainIndexedRecord:
+    """Transport coordinates and identity fields from a CC-MAIN index row."""
+
+    record_range: WarcRecordRange
+    expectation: UrlIndexRecordExpectation
+
+
+@dataclass(frozen=True)
+class SupplementalIndexedRecord:
+    """Transport coordinates and identity fields from a supplemental index row."""
+
+    record_range: WarcRecordRange
+    expectation: SupplementalRecordExpectation
 
 
 @dataclass(frozen=True)
 class CommonCrawlWarcRecord:
-    """Verified HTTP response extracted from a Common Crawl WARC record."""
+    """Observed HTTP response extracted from a Common Crawl WARC record."""
 
     payload: bytes
+    payload_digest: str
     warc_record_id: str
     target_url: str
     http_status: int
@@ -150,12 +182,7 @@ class CommonCrawlClient:
         self._request_timeout = request_timeout
         self._maximum_warc_record_bytes = maximum_warc_record_bytes
         self._maximum_payload_bytes = maximum_payload_bytes
-        self._session = session or build_retrying_session(
-            total=_RETRY_TOTAL,
-            backoff_factor=_RETRY_BACKOFF_FACTOR,
-            backoff_jitter=_RETRY_BACKOFF_JITTER,
-            status_forcelist=_RETRY_STATUS,
-        )
+        self._session = session or _build_common_crawl_session()
         self._owns_session = session is None
 
     def __enter__(self) -> "CommonCrawlClient":
@@ -165,19 +192,19 @@ class CommonCrawlClient:
         if self._owns_session:
             self._session.close()
 
-    def fetch_record(self, location: CommonCrawlRecordLocation) -> CommonCrawlWarcRecord:
-        """Range-fetch, parse, and verify one URL Index record."""
-        if location.warc_record_length > self._maximum_warc_record_bytes:
+    def fetch_record(self, record_range: WarcRecordRange) -> CommonCrawlWarcRecord:
+        """Range-fetch and parse one WARC record without source-specific verification."""
+        if record_range.length > self._maximum_warc_record_bytes:
             raise WarcRecordTooLargeError(
-                f"WARC record length {location.warc_record_length} exceeds limit {self._maximum_warc_record_bytes}"
+                f"WARC record length {record_range.length} exceeds limit {self._maximum_warc_record_bytes}"
             )
 
-        start, end = location.byte_range
-        url = f"{self._base_url}/{location.warc_filename.lstrip('/')}"
+        start, end = record_range.http_range
+        url = f"{self._base_url}/{record_range.warc_filename.lstrip('/')}"
         try:
             with self._session.get(
                 url,
-                headers={"Range": f"bytes={start}-{end}"},
+                headers={"Range": f"bytes={start}-{end}", "user-agent": _USER_AGENT},
                 stream=True,
                 timeout=self._request_timeout,
             ) as response:
@@ -186,21 +213,141 @@ class CommonCrawlClient:
                     response,
                     start=start,
                     end=end,
-                    expected_length=location.warc_record_length,
+                    expected_length=record_range.length,
                 )
-                content = _read_exact_response(response, expected_length=location.warc_record_length)
+                content = _read_exact_response(response, expected_length=record_range.length)
         except requests.HTTPError as error:
-            response = error.response
-            status = response.status_code if response is not None else None
+            error_response = error.response
+            status = error_response.status_code if error_response is not None else None
             if status is not None and 400 <= status < 500 and status not in _RETRY_STATUS:
                 raise CommonCrawlRequestRejectedError(url, status) from error
             raise CommonCrawlDownloadError(f"Failed to download WARC record from {url}") from error
         except requests.RequestException as error:
             raise CommonCrawlDownloadError(f"Failed to download WARC record from {url}") from error
 
-        record = _parse_warc_response(content, maximum_payload_bytes=self._maximum_payload_bytes)
-        _verify_record(record, location)
-        return record
+        return _parse_warc_response(content, maximum_payload_bytes=self._maximum_payload_bytes)
+
+
+def main_record_from_index_row(row: Mapping[str, object], *, crawl_id: str) -> MainIndexedRecord:
+    """Build transport coordinates and CC-MAIN expectations from one index row."""
+    return MainIndexedRecord(
+        record_range=_record_range_from_index_row(row, crawl_id=crawl_id),
+        expectation=UrlIndexRecordExpectation(
+            url=_required_string(row, "url"),
+            warc_record_id=_canonical_record_id(row.get("warc_record_id")),
+            content_digest=_canonical_content_digest(_required_string(row, "content_digest")),
+        ),
+    )
+
+
+def supplemental_record_from_index_row(row: Mapping[str, object], *, crawl_id: str) -> SupplementalIndexedRecord:
+    """Build transport coordinates and supplemental expectations from one index row."""
+    return SupplementalIndexedRecord(
+        record_range=_record_range_from_index_row(row, crawl_id=crawl_id),
+        expectation=SupplementalRecordExpectation(
+            url=_required_string(row, "url"),
+            content_digest=_canonical_content_digest(_required_string(row, "content_digest")),
+        ),
+    )
+
+
+def common_crawl_index_partitions(
+    paths_manifest_url: str,
+    *,
+    crawl_id: str,
+    subset: str = "warc",
+    session: requests.Session | None = None,
+    request_timeout: tuple[int, int] = _REQUEST_TIMEOUT,
+) -> tuple[str, ...]:
+    """Read and validate URL Index Parquet paths for one crawl and subset."""
+    if not crawl_id:
+        raise ValueError("crawl_id must be non-empty")
+    if not subset:
+        raise ValueError("subset must be non-empty")
+    owns_session = session is None
+    active_session = session or _build_common_crawl_session()
+    try:
+        with active_session.get(
+            paths_manifest_url,
+            headers={"user-agent": _USER_AGENT},
+            stream=True,
+            timeout=request_timeout,
+        ) as response:
+            response.raise_for_status()
+            encoded_manifest = _read_bounded_response(response, maximum_bytes=_MAXIMUM_MANIFEST_BYTES)
+    except requests.HTTPError as error:
+        error_response = error.response
+        status = error_response.status_code if error_response is not None else None
+        if status is not None and 400 <= status < 500 and status not in _RETRY_STATUS:
+            raise CommonCrawlRequestRejectedError(paths_manifest_url, status) from error
+        raise CommonCrawlDownloadError(
+            f"Failed to download Common Crawl index manifest: {paths_manifest_url}"
+        ) from error
+    except requests.RequestException as error:
+        raise CommonCrawlDownloadError(
+            f"Failed to download Common Crawl index manifest: {paths_manifest_url}"
+        ) from error
+    finally:
+        if owns_session:
+            active_session.close()
+
+    manifest = _decode_paths_manifest(encoded_manifest, paths_manifest_url=paths_manifest_url)
+    paths = tuple(line.strip() for line in manifest.splitlines() if line.strip())
+    invalid_paths = tuple(path for path in paths if not path.endswith(".parquet") or crawl_id not in path)
+    if invalid_paths:
+        raise CommonCrawlIndexManifestError(
+            f"Common Crawl index manifest contains paths outside crawl {crawl_id!r} or non-Parquet paths"
+        )
+    expected_subset_component = f"subset={subset}"
+    partitions = tuple(path for path in paths if expected_subset_component in path.split("/"))
+    if not partitions:
+        raise CommonCrawlIndexManifestError(
+            f"Common Crawl index manifest has no partitions for crawl {crawl_id!r}, subset {subset!r}"
+        )
+    return partitions
+
+
+def _build_common_crawl_session() -> requests.Session:
+    return build_retrying_session(
+        total=_RETRY_TOTAL,
+        backoff_factor=_RETRY_BACKOFF_FACTOR,
+        backoff_jitter=_RETRY_BACKOFF_JITTER,
+        status_forcelist=_RETRY_STATUS,
+    )
+
+
+def _read_bounded_response(response: requests.Response, *, maximum_bytes: int) -> bytes:
+    content = bytearray()
+    for chunk in response.iter_content(chunk_size=_DOWNLOAD_CHUNK_BYTES):
+        content.extend(chunk)
+        if len(content) > maximum_bytes:
+            raise CommonCrawlIndexManifestError(f"Common Crawl index manifest exceeds {maximum_bytes} bytes")
+    return bytes(content)
+
+
+def _decode_paths_manifest(encoded_manifest: bytes, *, paths_manifest_url: str) -> str:
+    try:
+        if encoded_manifest.startswith(b"\x1f\x8b"):
+            with gzip.GzipFile(fileobj=io.BytesIO(encoded_manifest)) as stream:
+                decoded_manifest = stream.read(_MAXIMUM_DECOMPRESSED_MANIFEST_BYTES + 1)
+        else:
+            decoded_manifest = encoded_manifest
+        if len(decoded_manifest) > _MAXIMUM_DECOMPRESSED_MANIFEST_BYTES:
+            raise CommonCrawlIndexManifestError(
+                f"Common Crawl index manifest expands beyond {_MAXIMUM_DECOMPRESSED_MANIFEST_BYTES} bytes"
+            )
+        return decoded_manifest.decode()
+    except (gzip.BadGzipFile, EOFError, UnicodeDecodeError) as error:
+        raise CommonCrawlIndexManifestError(f"Invalid Common Crawl index manifest: {paths_manifest_url}") from error
+
+
+def _record_range_from_index_row(row: Mapping[str, object], *, crawl_id: str) -> WarcRecordRange:
+    return WarcRecordRange(
+        crawl_id=crawl_id,
+        warc_filename=_required_string(row, "warc_filename"),
+        offset=_required_int(row, "warc_record_offset"),
+        length=_required_int(row, "warc_record_length"),
+    )
 
 
 def _required_string(row: Mapping[str, object], field: str) -> str:
@@ -243,9 +390,10 @@ def _canonical_content_digest(value: str) -> str:
     algorithm, separator, encoded_digest = value.partition(":")
     if not separator:
         algorithm, encoded_digest = "sha1", algorithm
-    if algorithm.lower() != "sha1" or not encoded_digest:
+    encoded_digest = encoded_digest.upper().rstrip("=")
+    if algorithm.lower() != "sha1" or _SHA1_BASE32_PATTERN.fullmatch(encoded_digest) is None:
         raise ValueError(f"Unsupported Common Crawl content digest: {value!r}")
-    return f"sha1:{encoded_digest.upper().rstrip('=')}"
+    return f"sha1:{encoded_digest}"
 
 
 def _validate_range_response_headers(
@@ -321,7 +469,10 @@ def _parse_warc_response(content: bytes, *, maximum_payload_bytes: int) -> Commo
 
     return CommonCrawlWarcRecord(
         payload=payload,
-        warc_record_id=_canonical_record_id(record_id),
+        payload_digest=content_digest(payload),
+        # WARC-Record-ID permits any absolute URI. CC-MAIN UUID expectations
+        # are normalized separately and compared during source verification.
+        warc_record_id=record_id,
         target_url=target_url,
         http_status=int(status_code),
         http_content_type=record.http_headers.get_header("Content-Type"),
@@ -330,19 +481,51 @@ def _parse_warc_response(content: bytes, *, maximum_payload_bytes: int) -> Commo
     )
 
 
-def _verify_record(record: CommonCrawlWarcRecord, location: CommonCrawlRecordLocation) -> None:
+def verify_url_index_record(record: CommonCrawlWarcRecord, expected: UrlIndexRecordExpectation) -> None:
+    """Verify an observed record against the fields available from CC-MAIN."""
+    mismatches = []
+    if _comparable_record_id(record.warc_record_id) != _comparable_record_id(expected.warc_record_id):
+        mismatches.append(f"record ID {record.warc_record_id!r} != {expected.warc_record_id!r}")
+    _verify_url_and_digest(record, expected.url, expected.content_digest, mismatches)
+    if mismatches:
+        raise RecordVerificationError("; ".join(mismatches))
+    _verify_successful_origin_response(record)
+
+
+def verify_supplemental_record(record: CommonCrawlWarcRecord, expected: SupplementalRecordExpectation) -> None:
+    """Verify an observed record against the fields available from a supplemental index."""
+    mismatches = []
+    _verify_url_and_digest(record, expected.url, expected.content_digest, mismatches)
+    if mismatches:
+        raise RecordVerificationError("; ".join(mismatches))
+    _verify_successful_origin_response(record)
+
+
+def _verify_successful_origin_response(record: CommonCrawlWarcRecord) -> None:
     if not 200 <= record.http_status < 300:
         raise OriginResponseStatusError(record.http_status)
 
-    mismatches = []
-    if record.warc_record_id != location.warc_record_id:
-        mismatches.append(f"record ID {record.warc_record_id!r} != {location.warc_record_id!r}")
-    if record.target_url != location.url:
-        mismatches.append(f"target URL {record.target_url!r} != {location.url!r}")
 
-    digest = hashlib.sha1(record.payload, usedforsecurity=False).digest()
-    observed_digest = f"sha1:{base64.b32encode(digest).decode().rstrip('=')}"
-    if observed_digest != location.content_digest:
-        mismatches.append(f"content digest {observed_digest!r} != {location.content_digest!r}")
-    if mismatches:
-        raise RecordVerificationError("; ".join(mismatches))
+def _comparable_record_id(record_id: str) -> str:
+    try:
+        return _canonical_record_id(record_id)
+    except ValueError:
+        return record_id
+
+
+def _verify_url_and_digest(
+    record: CommonCrawlWarcRecord,
+    expected_url: str,
+    expected_digest: str,
+    mismatches: list[str],
+) -> None:
+    if record.target_url != expected_url:
+        mismatches.append(f"target URL {record.target_url!r} != {expected_url!r}")
+    if record.payload_digest != expected_digest:
+        mismatches.append(f"content digest {record.payload_digest!r} != {expected_digest!r}")
+
+
+def content_digest(payload: bytes) -> str:
+    """Return Common Crawl's unpadded Base32 SHA-1 payload digest."""
+    digest = hashlib.sha1(payload, usedforsecurity=False).digest()
+    return f"sha1:{base64.b32encode(digest).decode().rstrip('=')}"

--- a/lib/marin/src/marin/datakit/download/common_crawl_warc.py
+++ b/lib/marin/src/marin/datakit/download/common_crawl_warc.py
@@ -1,0 +1,348 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fetch and verify individual records from Common Crawl WARC files."""
+
+import base64
+import hashlib
+import io
+import re
+import uuid
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import requests
+from warcio.archiveiterator import ArchiveIterator
+from warcio.exceptions import ArchiveLoadFailed
+
+from marin.datakit.download.http_session import build_retrying_session
+
+COMMON_CRAWL_DATA_URL = "https://data.commoncrawl.org"
+_DOWNLOAD_CHUNK_BYTES = 1 << 20
+_RETRY_STATUS = (403, 429, 500, 502, 503, 504)
+_RETRY_TOTAL = 10
+_RETRY_BACKOFF_FACTOR = 2.0
+_RETRY_BACKOFF_JITTER = 10.0
+_REQUEST_TIMEOUT = (30, 300)
+_CONTENT_RANGE_PATTERN = re.compile(r"bytes (\d+)-(\d+)/(?:\d+|\*)")
+
+
+class CommonCrawlWarcError(RuntimeError):
+    """Base class for Common Crawl record retrieval and validation failures."""
+
+
+class CommonCrawlTransientError(CommonCrawlWarcError):
+    """Base class for failures that a task-level retry may resolve."""
+
+
+class CommonCrawlDownloadError(CommonCrawlTransientError):
+    """Raised after retryable HTTP download attempts are exhausted."""
+
+
+class CommonCrawlRequestRejectedError(CommonCrawlWarcError):
+    """Raised when Common Crawl permanently rejects an object request."""
+
+    def __init__(self, url: str, status: int) -> None:
+        self.url = url
+        self.status = status
+        super().__init__(f"Common Crawl object request returned HTTP {status}: {url}")
+
+
+class RangeResponseError(CommonCrawlTransientError):
+    """Raised when a server does not honor an exact WARC byte-range request."""
+
+
+class WarcRecordTooLargeError(CommonCrawlWarcError):
+    """Raised when the URL Index range exceeds the configured WARC record limit."""
+
+
+class WarcPayloadTooLargeError(CommonCrawlWarcError):
+    """Raised when a parsed response payload exceeds the configured payload limit."""
+
+
+class WarcParsingError(CommonCrawlWarcError):
+    """Raised when a byte range does not contain exactly one WARC response record."""
+
+
+class WarcRevisitError(WarcParsingError):
+    """Raised when a selected range contains a revisit rather than a response payload."""
+
+
+class RecordVerificationError(CommonCrawlWarcError):
+    """Raised when a fetched WARC record does not match its URL Index row."""
+
+
+class OriginResponseStatusError(CommonCrawlWarcError):
+    """Raised when a WARC response contains a non-successful origin status."""
+
+    def __init__(self, status: int) -> None:
+        self.status = status
+        super().__init__(f"Origin HTTP status {status} is not successful")
+
+
+@dataclass(frozen=True)
+class CommonCrawlRecordLocation:
+    """Record-level location and integrity fields from the Common Crawl URL Index."""
+
+    crawl_id: str
+    url: str
+    warc_filename: str
+    warc_record_offset: int
+    warc_record_length: int
+    warc_record_id: str
+    content_digest: str
+
+    def __post_init__(self) -> None:
+        if self.warc_record_offset < 0:
+            raise ValueError("warc_record_offset must be non-negative")
+        if self.warc_record_length <= 0:
+            raise ValueError("warc_record_length must be positive")
+
+    @property
+    def byte_range(self) -> tuple[int, int]:
+        """Return the inclusive HTTP byte range for this record."""
+        return self.warc_record_offset, self.warc_record_offset + self.warc_record_length - 1
+
+    @classmethod
+    def from_url_index_row(cls, row: Mapping[str, object], *, crawl_id: str) -> "CommonCrawlRecordLocation":
+        """Build a location from one URL Index Parquet row."""
+        return cls(
+            crawl_id=crawl_id,
+            url=_required_string(row, "url"),
+            warc_filename=_required_string(row, "warc_filename"),
+            warc_record_offset=_required_int(row, "warc_record_offset"),
+            warc_record_length=_required_int(row, "warc_record_length"),
+            warc_record_id=_canonical_record_id(row.get("warc_record_id")),
+            content_digest=_canonical_content_digest(_required_string(row, "content_digest")),
+        )
+
+
+@dataclass(frozen=True)
+class CommonCrawlWarcRecord:
+    """Verified HTTP response extracted from a Common Crawl WARC record."""
+
+    payload: bytes
+    warc_record_id: str
+    target_url: str
+    http_status: int
+    http_content_type: str | None
+    warc_date: str | None
+    identified_payload_type: str | None
+
+
+class CommonCrawlClient:
+    """Retrying client for exact Common Crawl WARC record range requests."""
+
+    def __init__(
+        self,
+        *,
+        maximum_warc_record_bytes: int,
+        maximum_payload_bytes: int,
+        base_url: str = COMMON_CRAWL_DATA_URL,
+        request_timeout: tuple[int, int] = _REQUEST_TIMEOUT,
+        session: requests.Session | None = None,
+    ) -> None:
+        if maximum_warc_record_bytes <= 0:
+            raise ValueError("maximum_warc_record_bytes must be positive")
+        if maximum_payload_bytes <= 0:
+            raise ValueError("maximum_payload_bytes must be positive")
+        self._base_url = base_url.rstrip("/")
+        self._request_timeout = request_timeout
+        self._maximum_warc_record_bytes = maximum_warc_record_bytes
+        self._maximum_payload_bytes = maximum_payload_bytes
+        self._session = session or build_retrying_session(
+            total=_RETRY_TOTAL,
+            backoff_factor=_RETRY_BACKOFF_FACTOR,
+            backoff_jitter=_RETRY_BACKOFF_JITTER,
+            status_forcelist=_RETRY_STATUS,
+        )
+        self._owns_session = session is None
+
+    def __enter__(self) -> "CommonCrawlClient":
+        return self
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        if self._owns_session:
+            self._session.close()
+
+    def fetch_record(self, location: CommonCrawlRecordLocation) -> CommonCrawlWarcRecord:
+        """Range-fetch, parse, and verify one URL Index record."""
+        if location.warc_record_length > self._maximum_warc_record_bytes:
+            raise WarcRecordTooLargeError(
+                f"WARC record length {location.warc_record_length} exceeds limit {self._maximum_warc_record_bytes}"
+            )
+
+        start, end = location.byte_range
+        url = f"{self._base_url}/{location.warc_filename.lstrip('/')}"
+        try:
+            with self._session.get(
+                url,
+                headers={"Range": f"bytes={start}-{end}"},
+                stream=True,
+                timeout=self._request_timeout,
+            ) as response:
+                response.raise_for_status()
+                _validate_range_response_headers(
+                    response,
+                    start=start,
+                    end=end,
+                    expected_length=location.warc_record_length,
+                )
+                content = _read_exact_response(response, expected_length=location.warc_record_length)
+        except requests.HTTPError as error:
+            response = error.response
+            status = response.status_code if response is not None else None
+            if status is not None and 400 <= status < 500 and status not in _RETRY_STATUS:
+                raise CommonCrawlRequestRejectedError(url, status) from error
+            raise CommonCrawlDownloadError(f"Failed to download WARC record from {url}") from error
+        except requests.RequestException as error:
+            raise CommonCrawlDownloadError(f"Failed to download WARC record from {url}") from error
+
+        record = _parse_warc_response(content, maximum_payload_bytes=self._maximum_payload_bytes)
+        _verify_record(record, location)
+        return record
+
+
+def _required_string(row: Mapping[str, object], field: str) -> str:
+    value = row.get(field)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field} must be a non-empty string")
+    return value
+
+
+def _required_int(row: Mapping[str, object], field: str) -> int:
+    value = row.get(field)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{field} must be an integer")
+    return value
+
+
+def _canonical_record_id(value: object) -> str:
+    if isinstance(value, memoryview):
+        value = value.tobytes()
+    if isinstance(value, bytes):
+        if len(value) != 16:
+            raise ValueError("warc_record_id BLOB must contain a 16-byte UUID")
+        record_uuid = uuid.UUID(bytes=value)
+    elif isinstance(value, str):
+        text = value.strip()
+        if text.startswith("<urn:uuid:") and text.endswith(">"):
+            text = text[len("<urn:uuid:") : -1]
+        elif text.startswith("urn:uuid:"):
+            text = text[len("urn:uuid:") :]
+        try:
+            record_uuid = uuid.UUID(text)
+        except ValueError as error:
+            raise ValueError(f"Invalid WARC record ID: {value!r}") from error
+    else:
+        raise ValueError("warc_record_id must be a UUID string or 16-byte BLOB")
+    return f"<urn:uuid:{record_uuid}>"
+
+
+def _canonical_content_digest(value: str) -> str:
+    algorithm, separator, encoded_digest = value.partition(":")
+    if not separator:
+        algorithm, encoded_digest = "sha1", algorithm
+    if algorithm.lower() != "sha1" or not encoded_digest:
+        raise ValueError(f"Unsupported Common Crawl content digest: {value!r}")
+    return f"sha1:{encoded_digest.upper().rstrip('=')}"
+
+
+def _validate_range_response_headers(
+    response: requests.Response,
+    *,
+    start: int,
+    end: int,
+    expected_length: int,
+) -> None:
+    if response.status_code != requests.codes.partial_content:
+        raise RangeResponseError(f"Expected HTTP 206 for WARC range request, received {response.status_code}")
+
+    content_range = response.headers.get("Content-Range", "")
+    match = _CONTENT_RANGE_PATTERN.fullmatch(content_range)
+    if match is None or (int(match.group(1)), int(match.group(2))) != (start, end):
+        raise RangeResponseError(f"Expected Content-Range bytes {start}-{end}, received {content_range!r}")
+    content_length = response.headers.get("Content-Length")
+    if content_length is not None:
+        try:
+            observed_length = int(content_length)
+        except ValueError as error:
+            raise RangeResponseError(f"Invalid Content-Length {content_length!r}") from error
+        if observed_length != expected_length:
+            raise RangeResponseError(f"Expected Content-Length {expected_length}, received {content_length!r}")
+
+
+def _read_exact_response(response: requests.Response, *, expected_length: int) -> bytes:
+    content = bytearray()
+    for chunk in response.iter_content(chunk_size=_DOWNLOAD_CHUNK_BYTES):
+        content.extend(chunk)
+        if len(content) > expected_length:
+            raise RangeResponseError(f"WARC range exceeded expected length {expected_length}")
+    if len(content) != expected_length:
+        raise RangeResponseError(f"Expected {expected_length} WARC bytes, received {len(content)}")
+    return bytes(content)
+
+
+def _parse_warc_response(content: bytes, *, maximum_payload_bytes: int) -> CommonCrawlWarcRecord:
+    iterator = iter(ArchiveIterator(io.BytesIO(content)))
+    try:
+        record = next(iterator)
+    except StopIteration as error:
+        raise WarcParsingError("WARC byte range contained no records") from error
+    except ArchiveLoadFailed as error:
+        raise WarcParsingError("WARC byte range could not be parsed") from error
+
+    if record.rec_type == "revisit":
+        raise WarcRevisitError("WARC range contains a revisit record without an embedded payload")
+    if record.rec_type != "response":
+        raise WarcParsingError(f"Expected a WARC response record, received {record.rec_type!r}")
+    if record.http_headers is None:
+        raise WarcParsingError("WARC response record did not contain HTTP headers")
+
+    # Common Crawl's content digest covers the decoded HTTP entity returned by
+    # warcio's content_stream(), not the transfer/content-encoded wire bytes.
+    payload = record.content_stream().read(maximum_payload_bytes + 1)
+    if len(payload) > maximum_payload_bytes:
+        raise WarcPayloadTooLargeError(f"WARC payload exceeds limit {maximum_payload_bytes}")
+    try:
+        next(iterator)
+    except StopIteration:
+        pass
+    else:
+        raise WarcParsingError("WARC byte range contained more than one record")
+
+    record_id = record.rec_headers.get_header("WARC-Record-ID")
+    target_url = record.rec_headers.get_header("WARC-Target-URI")
+    if record_id is None or target_url is None:
+        raise WarcParsingError("WARC response record is missing its record ID or target URI")
+    status_code = record.http_headers.get_statuscode()
+    if status_code is None or not status_code.isdigit():
+        raise WarcParsingError(f"WARC response record has invalid HTTP status {status_code!r}")
+
+    return CommonCrawlWarcRecord(
+        payload=payload,
+        warc_record_id=_canonical_record_id(record_id),
+        target_url=target_url,
+        http_status=int(status_code),
+        http_content_type=record.http_headers.get_header("Content-Type"),
+        warc_date=record.rec_headers.get_header("WARC-Date"),
+        identified_payload_type=record.rec_headers.get_header("WARC-Identified-Payload-Type"),
+    )
+
+
+def _verify_record(record: CommonCrawlWarcRecord, location: CommonCrawlRecordLocation) -> None:
+    if not 200 <= record.http_status < 300:
+        raise OriginResponseStatusError(record.http_status)
+
+    mismatches = []
+    if record.warc_record_id != location.warc_record_id:
+        mismatches.append(f"record ID {record.warc_record_id!r} != {location.warc_record_id!r}")
+    if record.target_url != location.url:
+        mismatches.append(f"target URL {record.target_url!r} != {location.url!r}")
+
+    digest = hashlib.sha1(record.payload, usedforsecurity=False).digest()
+    observed_digest = f"sha1:{base64.b32encode(digest).decode().rstrip('=')}"
+    if observed_digest != location.content_digest:
+        mismatches.append(f"content digest {observed_digest!r} != {location.content_digest!r}")
+    if mismatches:
+        raise RecordVerificationError("; ".join(mismatches))

--- a/lib/marin/src/marin/datakit/download/http_session.py
+++ b/lib/marin/src/marin/datakit/download/http_session.py
@@ -14,6 +14,7 @@ def build_retrying_session(
     *,
     total: int = 5,
     backoff_factor: float = 1.0,
+    backoff_jitter: float = 0.0,
     status_forcelist: tuple[int, ...] = DEFAULT_STATUS_FORCELIST,
 ) -> requests.Session:
     """Return a ``requests.Session`` that retries idempotent GETs on transient HTTP errors.
@@ -23,6 +24,7 @@ def build_retrying_session(
     retries = Retry(
         total=total,
         backoff_factor=backoff_factor,
+        backoff_jitter=backoff_jitter,
         status_forcelist=status_forcelist,
         allowed_methods=frozenset({"GET"}),
     )

--- a/tests/datakit/download/test_common_crawl_plan.py
+++ b/tests/datakit/download/test_common_crawl_plan.py
@@ -13,8 +13,8 @@ from marin.datakit.download.common_crawl_plan import (
     CommonCrawlSelection,
     CommonCrawlSource,
     SelectedCommonCrawlRecord,
-    plan_common_crawl_records,
     plan_common_crawl_manifest,
+    plan_common_crawl_records,
     read_common_crawl_discovery,
     read_common_crawl_tasks,
     write_common_crawl_discovery,
@@ -76,17 +76,18 @@ def test_filter_selects_matching_rows_and_records_selection_signals() -> None:
         }
     )
 
-    assert selection == CommonCrawlSelection(
-        {"declared_mime": True, "detected_mime": False, "url_suffix": True}
+    assert selection == CommonCrawlSelection({"declared_mime": True, "detected_mime": False, "url_suffix": True})
+    assert (
+        selector.select(
+            {
+                "fetch_status": 404,
+                "content_truncated": None,
+                "content_mime_type": "application/docx",
+                "url": "https://example.com/file.docx",
+            }
+        )
+        is None
     )
-    assert selector.select(
-        {
-            "fetch_status": 404,
-            "content_truncated": None,
-            "content_mime_type": "application/docx",
-            "url": "https://example.com/file.docx",
-        }
-    ) is None
 
 
 def test_planner_coalesces_gap_boundary_and_keeps_sparse_record_singleton() -> None:
@@ -137,9 +138,7 @@ def test_per_source_sampling_is_stable_when_another_source_is_added() -> None:
     combined = plan_common_crawl_records([*second_records, *first_records], options)
 
     first_offsets = [selected.start for task in first_only for selected in task.ranges]
-    combined_first_offsets = [
-        selected.start for task in combined if task.source == first for selected in task.ranges
-    ]
+    combined_first_offsets = [selected.start for task in combined if task.source == first for selected in task.ranges]
     assert combined_first_offsets == first_offsets
     assert len(first_offsets) == 5
 

--- a/tests/datakit/download/test_common_crawl_plan.py
+++ b/tests/datakit/download/test_common_crawl_plan.py
@@ -1,0 +1,182 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import hashlib
+from pathlib import Path
+
+from marin.datakit.download.common_crawl_plan import (
+    CommonCrawlFilter,
+    CommonCrawlIndexKind,
+    CommonCrawlPlanOptions,
+    CommonCrawlSamplingMode,
+    CommonCrawlSelection,
+    CommonCrawlSource,
+    SelectedCommonCrawlRecord,
+    plan_common_crawl_records,
+    plan_common_crawl_manifest,
+    read_common_crawl_discovery,
+    read_common_crawl_tasks,
+    write_common_crawl_discovery,
+    write_common_crawl_plan,
+)
+from marin.datakit.download.common_crawl_warc import main_record_from_index_row
+
+RECORD_ID = "<urn:uuid:019f8700-d21d-78d8-8eb1-99eaa22579da>"
+
+
+def _digest(value: str) -> str:
+    digest = hashlib.sha1(value.encode(), usedforsecurity=False).digest()
+    return f"sha1:{base64.b32encode(digest).decode().rstrip('=')}"
+
+
+def _source(crawl_id: str, *, base_url: str = "https://data.commoncrawl.org") -> CommonCrawlSource:
+    return CommonCrawlSource(
+        crawl_id=crawl_id,
+        index_kind=CommonCrawlIndexKind.MAIN,
+        paths_manifest_url=f"https://index.commoncrawl.org/{crawl_id}.paths.gz",
+        base_url=base_url,
+    )
+
+
+def _selected(
+    source: CommonCrawlSource,
+    warc_filename: str,
+    offset: int,
+    length: int,
+) -> SelectedCommonCrawlRecord:
+    indexed = main_record_from_index_row(
+        {
+            "url": f"https://example.com/{offset}.docx",
+            "warc_filename": warc_filename,
+            "warc_record_offset": offset,
+            "warc_record_length": length,
+            "warc_record_id": RECORD_ID,
+            "content_digest": _digest(str(offset)),
+        },
+        crawl_id=source.crawl_id,
+    )
+    return SelectedCommonCrawlRecord(source, indexed, CommonCrawlSelection({"reason": "test"}))
+
+
+def test_filter_selects_matching_rows_and_records_selection_signals() -> None:
+    selector = CommonCrawlFilter(
+        declared_mime_types=frozenset({"application/docx"}),
+        detected_mime_types=frozenset({"application/docx"}),
+        url_suffixes=(".docx",),
+    )
+
+    selection = selector.select(
+        {
+            "fetch_status": 200,
+            "content_truncated": None,
+            "content_mime_type": "application/docx; charset=binary",
+            "content_mime_detected": "application/octet-stream",
+            "url": "https://example.com/file.DOCX?download=1",
+        }
+    )
+
+    assert selection == CommonCrawlSelection(
+        {"declared_mime": True, "detected_mime": False, "url_suffix": True}
+    )
+    assert selector.select(
+        {
+            "fetch_status": 404,
+            "content_truncated": None,
+            "content_mime_type": "application/docx",
+            "url": "https://example.com/file.docx",
+        }
+    ) is None
+
+
+def test_planner_coalesces_gap_boundary_and_keeps_sparse_record_singleton() -> None:
+    source = _source("CC-MAIN-2026-30")
+    records = [
+        _selected(source, "a.warc.gz", 0, 100),
+        _selected(source, "a.warc.gz", 150, 50),
+        _selected(source, "a.warc.gz", 251, 25),
+    ]
+
+    tasks = plan_common_crawl_records(records, CommonCrawlPlanOptions(coalesce_gap_bytes=50, task_bytes=1_000))
+
+    assert len(tasks) == 1
+    assert [(selected.start, selected.stop, len(selected.records)) for selected in tasks[0].ranges] == [
+        (0, 200, 2),
+        (251, 276, 1),
+    ]
+
+
+def test_planner_never_coalesces_or_packs_across_sources() -> None:
+    first = _source("CC-MAIN-2026-30")
+    second = _source("CC-MAIN-2026-34", base_url="https://mirror.example")
+
+    tasks = plan_common_crawl_records(
+        [_selected(second, "same.warc.gz", 0, 10), _selected(first, "same.warc.gz", 0, 10)],
+        CommonCrawlPlanOptions(coalesce_gap_bytes=1_000, task_bytes=1_000),
+    )
+
+    assert len(tasks) == 2
+    assert {task.source.crawl_id for task in tasks} == {"CC-MAIN-2026-30", "CC-MAIN-2026-34"}
+    assert all(len(task.ranges) == 1 and len(task.ranges[0].records) == 1 for task in tasks)
+
+
+def test_per_source_sampling_is_stable_when_another_source_is_added() -> None:
+    first = _source("CC-MAIN-2026-30")
+    second = _source("CC-MAIN-2026-34")
+    first_records = [_selected(first, "a.warc.gz", index * 100, 10) for index in range(10)]
+    second_records = [_selected(second, "b.warc.gz", index * 100, 10) for index in range(10)]
+    options = CommonCrawlPlanOptions(
+        coalesce_gap_bytes=0,
+        task_bytes=1_000,
+        sampling_mode=CommonCrawlSamplingMode.PER_SOURCE_RANGE,
+        sample_fraction=0.5,
+        sample_seed=7,
+    )
+
+    first_only = plan_common_crawl_records(first_records, options)
+    combined = plan_common_crawl_records([*second_records, *first_records], options)
+
+    first_offsets = [selected.start for task in first_only for selected in task.ranges]
+    combined_first_offsets = [
+        selected.start for task in combined if task.source == first for selected in task.ranges
+    ]
+    assert combined_first_offsets == first_offsets
+    assert len(first_offsets) == 5
+
+
+def test_plan_manifest_round_trip_preserves_tasks_and_summary(tmp_path: Path) -> None:
+    source = _source("CC-MAIN-2026-30")
+    records = [_selected(source, "a.warc.gz", 0, 100), _selected(source, "a.warc.gz", 125, 50)]
+    tasks = plan_common_crawl_records(records, CommonCrawlPlanOptions(coalesce_gap_bytes=25, task_bytes=1_000))
+
+    summary = write_common_crawl_plan(tasks, str(tmp_path))
+    restored = read_common_crawl_tasks(summary.manifest_path)
+
+    assert restored == tasks
+    assert summary.num_sources == 1
+    assert summary.num_warcs == 1
+    assert summary.num_records == 2
+    assert summary.num_ranges == 1
+    assert summary.fetch_bytes == 175
+    assert summary.num_tasks == 1
+
+
+def test_discovery_manifest_can_be_replanned_without_index_scan(tmp_path: Path) -> None:
+    source = _source("CC-MAIN-2026-30")
+    records = [
+        _selected(source, "a.warc.gz", 125, 50),
+        _selected(source, "a.warc.gz", 0, 100),
+    ]
+
+    discovery = write_common_crawl_discovery(records, str(tmp_path / "discovery"))
+    restored = list(read_common_crawl_discovery(discovery.manifest_path))
+    plan = plan_common_crawl_manifest(
+        discovery.manifest_path,
+        str(tmp_path / "plan"),
+        CommonCrawlPlanOptions(coalesce_gap_bytes=25, task_bytes=1_000),
+    )
+
+    assert [record.indexed_record.record_range.offset for record in restored] == [125, 0]
+    assert [record.selection for record in restored] == [CommonCrawlSelection({"reason": "test"})] * 2
+    assert plan.num_records == 2
+    assert plan.num_ranges == 1

--- a/tests/datakit/download/test_common_crawl_warc.py
+++ b/tests/datakit/download/test_common_crawl_warc.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import base64
+import gzip
 import hashlib
 import io
 import uuid
@@ -13,14 +14,24 @@ import requests
 from marin.datakit.download.common_crawl_warc import (
     CommonCrawlClient,
     CommonCrawlDownloadError,
-    CommonCrawlRecordLocation,
+    CommonCrawlIndexManifestError,
     CommonCrawlRequestRejectedError,
     CommonCrawlTransientError,
+    MainIndexedRecord,
     OriginResponseStatusError,
     RecordVerificationError,
+    SupplementalIndexedRecord,
+    WarcParsingError,
     WarcPayloadTooLargeError,
+    WarcRecordRange,
     WarcRecordTooLargeError,
     WarcRevisitError,
+    common_crawl_index_partitions,
+    content_digest,
+    main_record_from_index_row,
+    supplemental_record_from_index_row,
+    verify_supplemental_record,
+    verify_url_index_record,
 )
 from requests.adapters import BaseAdapter
 from warcio.statusandheaders import StatusAndHeaders
@@ -75,12 +86,42 @@ def _warc_revisit() -> bytes:
     return output.getvalue()
 
 
+def _warc_record(
+    record_type: str,
+    *,
+    include_http_headers: bool = True,
+    gzip_output: bool = True,
+    payload: bytes = b"payload",
+) -> bytes:
+    output = io.BytesIO()
+    writer = WARCWriter(output, gzip=gzip_output)
+    http_headers = StatusAndHeaders("200 OK", [], protocol="HTTP/1.1") if include_http_headers else None
+    record = writer.create_warc_record(
+        TARGET_URL,
+        record_type,
+        payload=io.BytesIO(payload),
+        http_headers=http_headers,
+        warc_headers_dict={"WARC-Record-ID": RECORD_ID},
+    )
+    writer.write_record(record)
+    return output.getvalue()
+
+
 class _RangeAdapter(BaseAdapter):
-    def __init__(self, content: bytes, content_range: str | None, response_status: int) -> None:
+    def __init__(
+        self,
+        content: bytes,
+        content_range: str | None,
+        response_status: int,
+        body_override: bytes | None,
+        content_length: str | None,
+    ) -> None:
         super().__init__()
         self.content = content
         self.content_range = content_range
         self.response_status = response_status
+        self.body_override = body_override
+        self.content_length = content_length
 
     def send(
         self,
@@ -96,12 +137,41 @@ class _RangeAdapter(BaseAdapter):
         start_text, end_text = requested_range.removeprefix("bytes=").split("-")
         start, end = int(start_text), int(end_text)
         body = self.content[start : end + 1]
+        if self.body_override is not None:
+            body = self.body_override
 
         response = requests.Response()
         response.status_code = self.response_status
-        response.headers["Content-Length"] = str(len(body))
+        if self.content_length is not None:
+            response.headers["Content-Length"] = self.content_length
         response.headers["Content-Range"] = self.content_range or f"bytes {start}-{end}/{len(self.content)}"
         response.raw = io.BytesIO(body)
+        response.request = request
+        return response
+
+    def close(self) -> None:
+        pass
+
+
+class _ManifestAdapter(BaseAdapter):
+    def __init__(self, body: bytes, status: int = requests.codes.ok) -> None:
+        super().__init__()
+        self.body = body
+        self.status = status
+
+    def send(
+        self,
+        request: requests.PreparedRequest,
+        stream: bool = False,
+        timeout: float | tuple[float, float] | tuple[float, None] | None = None,
+        verify: bool | str = True,
+        cert: bytes | str | tuple[bytes | str, bytes | str] | None = None,
+        proxies: Mapping[str, str] | None = None,
+    ) -> requests.Response:
+        del stream, timeout, verify, cert, proxies
+        response = requests.Response()
+        response.status_code = self.status
+        response.raw = io.BytesIO(self.body)
         response.request = request
         return response
 
@@ -114,21 +184,45 @@ def _range_session(
     *,
     content_range: str | None = None,
     response_status: int = requests.codes.partial_content,
+    body_override: bytes | None = None,
+    content_length: str | None = None,
+    include_content_length: bool = True,
 ) -> requests.Session:
     session = requests.Session()
-    session.mount("https://", _RangeAdapter(content, content_range, response_status))
+    resolved_content_length = (
+        content_length
+        if content_length is not None
+        else str(len(body_override if body_override is not None else content))
+    )
+    if not include_content_length:
+        resolved_content_length = None
+    session.mount(
+        "https://",
+        _RangeAdapter(content, content_range, response_status, body_override, resolved_content_length),
+    )
     return session
 
 
-def _location(warc: bytes, payload: bytes) -> CommonCrawlRecordLocation:
-    return CommonCrawlRecordLocation(
+def _indexed_record(warc: bytes, payload: bytes) -> MainIndexedRecord:
+    return main_record_from_index_row(
+        {
+            "url": TARGET_URL,
+            "warc_filename": "crawl-data/test.warc.gz",
+            "warc_record_offset": 0,
+            "warc_record_length": len(warc),
+            "warc_record_id": RECORD_ID,
+            "content_digest": _sha1_digest(payload),
+        },
         crawl_id="CC-MAIN-2026-30",
-        url=TARGET_URL,
+    )
+
+
+def _record_range(warc: bytes) -> WarcRecordRange:
+    return WarcRecordRange(
+        crawl_id="CC-MAIN-2026-30",
         warc_filename="crawl-data/test.warc.gz",
-        warc_record_offset=0,
-        warc_record_length=len(warc),
-        warc_record_id=RECORD_ID,
-        content_digest=_sha1_digest(payload),
+        offset=0,
+        length=len(warc),
     )
 
 
@@ -140,37 +234,134 @@ def _client(session: requests.Session, *, maximum_warc_record_bytes: int = 1 << 
     )
 
 
-def test_record_location_from_url_index_row_normalizes_uuid_blob() -> None:
-    record_id = uuid.UUID("019f8700-d21d-78d8-8eb1-99eaa22579da")
+@pytest.mark.parametrize("compressed", [False, True])
+def test_common_crawl_index_partitions_reads_manifest_and_selects_subset(compressed: bool) -> None:
+    manifest = (
+        b"cc-index/table/cc-main/warc/crawl=CC-MAIN-2026-30/subset=crawldiagnostics/part-00000.parquet\n"
+        b"cc-index/table/cc-main/warc/crawl=CC-MAIN-2026-30/subset=warc/part-00000.parquet\n"
+        b"cc-index/table/cc-main/warc/crawl=CC-MAIN-2026-30/subset=warc/part-00001.parquet\n"
+    )
+    body = gzip.compress(manifest) if compressed else manifest
+    with requests.Session() as session:
+        session.mount("https://", _ManifestAdapter(body))
+        partitions = common_crawl_index_partitions(
+            "https://data.commoncrawl.org/manifest.paths.gz",
+            crawl_id="CC-MAIN-2026-30",
+            session=session,
+        )
 
-    location = CommonCrawlRecordLocation.from_url_index_row(
+    assert partitions == (
+        "cc-index/table/cc-main/warc/crawl=CC-MAIN-2026-30/subset=warc/part-00000.parquet",
+        "cc-index/table/cc-main/warc/crawl=CC-MAIN-2026-30/subset=warc/part-00001.parquet",
+    )
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        b"\x1f\x8bnot-gzip",
+        gzip.compress(b""),
+        gzip.compress(b"cc-index/table/crawl=CC-MAIN-2025-30/subset=warc/part-00000.parquet\n"),
+        gzip.compress(b"cc-index/table/crawl=CC-MAIN-2026-30/subset=warc/not-parquet.txt\n"),
+    ],
+)
+def test_common_crawl_index_partitions_rejects_invalid_manifest(body: bytes) -> None:
+    with requests.Session() as session:
+        session.mount("https://", _ManifestAdapter(body))
+        with pytest.raises(CommonCrawlIndexManifestError):
+            common_crawl_index_partitions(
+                "https://data.commoncrawl.org/manifest.paths.gz",
+                crawl_id="CC-MAIN-2026-30",
+                session=session,
+            )
+
+
+@pytest.mark.parametrize(
+    ("status", "error_type"),
+    [(403, CommonCrawlDownloadError), (404, CommonCrawlRequestRejectedError)],
+)
+def test_common_crawl_index_partitions_classifies_http_failure(status: int, error_type: type[Exception]) -> None:
+    with requests.Session() as session:
+        session.mount("https://", _ManifestAdapter(b"", status=status))
+        with pytest.raises(error_type):
+            common_crawl_index_partitions(
+                "https://data.commoncrawl.org/manifest.paths.gz",
+                crawl_id="CC-MAIN-2026-30",
+                session=session,
+            )
+
+
+def test_content_digest_uses_common_crawl_encoding() -> None:
+    assert content_digest(b"abc") == "sha1:VGMT4NSHA2AWVOR6EVYXQUGCNSONBWE5"
+
+
+def test_main_record_from_index_row_normalizes_uuid_blob() -> None:
+    record_id = uuid.UUID("019f8700-d21d-78d8-8eb1-99eaa22579da")
+    index_digest = _sha1_digest(b"index row")
+
+    indexed_record = main_record_from_index_row(
         {
             "url": TARGET_URL,
             "warc_filename": "crawl-data/test.warc.gz",
             "warc_record_offset": 42,
             "warc_record_length": 100,
             "warc_record_id": record_id.bytes,
-            "content_digest": "sha1:ABC",
+            "content_digest": index_digest,
         },
         crawl_id="CC-MAIN-2026-30",
     )
 
-    assert location.warc_record_id == RECORD_ID
-    assert location.byte_range == (42, 141)
+    assert indexed_record.expectation.warc_record_id == RECORD_ID
+    assert indexed_record.record_range.http_range == (42, 141)
 
-    string_location = CommonCrawlRecordLocation.from_url_index_row(
+    string_record = main_record_from_index_row(
         {
             "url": TARGET_URL,
             "warc_filename": "crawl-data/test.warc.gz",
             "warc_record_offset": 42,
             "warc_record_length": 100,
             "warc_record_id": "urn:uuid:019f8700-d21d-78d8-8eb1-99eaa22579da",
-            "content_digest": "ABC",
+            "content_digest": index_digest.removeprefix("sha1:"),
         },
         crawl_id="CC-MAIN-2026-30",
     )
-    assert string_location.warc_record_id == RECORD_ID
-    assert string_location.content_digest == "sha1:ABC"
+    assert string_record.expectation.warc_record_id == RECORD_ID
+    assert string_record.expectation.content_digest == index_digest
+
+
+@pytest.mark.parametrize(
+    "digest",
+    ["sha1:ABC", "sha1:0123456789abcdef0123456789abcdef01234567", "md5:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"],
+)
+def test_index_row_rejects_non_base32_sha1_digest(digest: str) -> None:
+    row = {
+        "url": TARGET_URL,
+        "warc_filename": "crawl-data/test.warc.gz",
+        "warc_record_offset": 0,
+        "warc_record_length": 100,
+        "warc_record_id": RECORD_ID,
+        "content_digest": digest,
+    }
+
+    with pytest.raises(ValueError):
+        main_record_from_index_row(row, crawl_id="CC-MAIN-2026-30")
+
+
+def test_supplemental_record_from_index_row_does_not_require_record_id() -> None:
+    indexed_record = supplemental_record_from_index_row(
+        {
+            "url": TARGET_URL,
+            "warc_filename": "projects/cc-open-athena-test/sample.warc.gz",
+            "warc_record_offset": 908,
+            "warc_record_length": 1690,
+            "content_digest": "OUMEM2M6RLXNWZ5I6BRHVBBI3YURVZMP",
+        },
+        crawl_id="CC-SUPPLEMENTAL-2026-22",
+    )
+
+    assert isinstance(indexed_record, SupplementalIndexedRecord)
+    assert indexed_record.record_range.http_range == (908, 2597)
+    assert indexed_record.expectation.content_digest == "sha1:OUMEM2M6RLXNWZ5I6BRHVBBI3YURVZMP"
 
 
 def test_client_default_session_constructs_and_closes(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -195,15 +386,18 @@ def test_client_default_session_constructs_and_closes(monkeypatch: pytest.Monkey
     assert sessions[0].closed
 
 
-def test_fetch_record_returns_verified_payload() -> None:
+def test_fetch_record_returns_parsed_payload_then_main_verification_succeeds() -> None:
     payload = b"PK\x03\x04example docx bytes"
     warc = _warc_response(payload)
-    location = _location(warc, payload)
+    indexed_record = _indexed_record(warc, payload)
 
     with _range_session(warc) as session, _client(session) as client:
-        record = client.fetch_record(location)
+        record = client.fetch_record(indexed_record.record_range)
+
+    verify_url_index_record(record, indexed_record.expectation)
 
     assert record.payload == payload
+    assert record.payload_digest == _sha1_digest(payload)
     assert record.warc_record_id == RECORD_ID
     assert record.target_url == TARGET_URL
     assert record.http_status == 200
@@ -212,15 +406,33 @@ def test_fetch_record_returns_verified_payload() -> None:
     assert record.identified_payload_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 
 
+@pytest.mark.parametrize(
+    "observed_record_id",
+    [
+        "urn:uuid:019f8700-d21d-78d8-8eb1-99eaa22579da",
+        "<urn:uuid:019F8700-D21D-78D8-8EB1-99EAA22579DA>",
+    ],
+)
+def test_url_index_verification_accepts_equivalent_uuid_spelling(observed_record_id: str) -> None:
+    payload = b"document"
+    warc = _warc_response(payload, record_id=observed_record_id)
+    indexed_record = _indexed_record(warc, payload)
+
+    with _range_session(warc) as session, _client(session) as client:
+        record = client.fetch_record(indexed_record.record_range)
+
+    verify_url_index_record(record, indexed_record.expectation)
+
+
 def test_fetch_record_rejects_incorrect_content_range() -> None:
     payload = b"document"
     warc = _warc_response(payload)
-    location = _location(warc, payload)
+    record_range = _record_range(warc)
 
     with _range_session(warc, content_range=f"bytes 1-{len(warc)}/{len(warc)}") as session:
         with _client(session) as client:
             with pytest.raises(CommonCrawlTransientError):
-                client.fetch_record(location)
+                client.fetch_record(record_range)
 
 
 def test_fetch_record_rejects_full_response_to_range_request() -> None:
@@ -229,7 +441,7 @@ def test_fetch_record_rejects_full_response_to_range_request() -> None:
 
     with _range_session(warc, response_status=requests.codes.ok) as session, _client(session) as client:
         with pytest.raises(CommonCrawlTransientError):
-            client.fetch_record(_location(warc, payload))
+            client.fetch_record(_record_range(warc))
 
 
 @pytest.mark.parametrize("status", [400, 404])
@@ -239,7 +451,7 @@ def test_fetch_record_classifies_permanent_object_error(status: int) -> None:
 
     with _range_session(warc, response_status=status) as session, _client(session) as client:
         with pytest.raises(CommonCrawlRequestRejectedError) as error:
-            client.fetch_record(_location(warc, payload))
+            client.fetch_record(_record_range(warc))
 
     assert error.value.status == status
     assert error.value.url.endswith("/crawl-data/test.warc.gz")
@@ -251,37 +463,119 @@ def test_fetch_record_classifies_rate_limit_as_transient() -> None:
 
     with _range_session(warc, response_status=403) as session, _client(session) as client:
         with pytest.raises(CommonCrawlDownloadError):
-            client.fetch_record(_location(warc, payload))
+            client.fetch_record(_record_range(warc))
 
 
-def test_fetch_record_rejects_payload_digest_mismatch() -> None:
+def test_url_index_verification_rejects_payload_digest_mismatch() -> None:
     payload = b"document"
     warc = _warc_response(payload)
-    location = replace(_location(warc, payload), content_digest="sha1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+    indexed_record = _indexed_record(warc, payload)
+    expectation = replace(
+        indexed_record.expectation,
+        content_digest="sha1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    )
 
     with _range_session(warc) as session, _client(session) as client:
-        with pytest.raises(RecordVerificationError):
-            client.fetch_record(location)
+        record = client.fetch_record(indexed_record.record_range)
+
+    with pytest.raises(RecordVerificationError):
+        verify_url_index_record(record, expectation)
 
 
-def test_fetch_record_rejects_non_success_origin_response() -> None:
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("url", "https://example.com/different.docx"),
+        ("warc_record_id", "<urn:uuid:119f8700-d21d-78d8-8eb1-99eaa22579da>"),
+    ],
+)
+def test_url_index_verification_rejects_identity_mismatch(field: str, value: str) -> None:
+    payload = b"document"
+    warc = _warc_response(payload)
+    indexed_record = _indexed_record(warc, payload)
+    expectation = replace(indexed_record.expectation, **{field: value})
+
+    with _range_session(warc) as session, _client(session) as client:
+        record = client.fetch_record(indexed_record.record_range)
+
+    with pytest.raises(RecordVerificationError):
+        verify_url_index_record(record, expectation)
+
+
+def test_url_index_verification_rejects_non_success_origin_response() -> None:
     payload = b"not found"
     warc = _warc_response(payload, http_status="404 Not Found")
 
     with _range_session(warc) as session, _client(session) as client:
-        with pytest.raises(OriginResponseStatusError) as error:
-            client.fetch_record(_location(warc, payload))
+        record = client.fetch_record(_record_range(warc))
+
+    with pytest.raises(OriginResponseStatusError) as error:
+        verify_url_index_record(record, _indexed_record(warc, payload).expectation)
 
     assert error.value.status == 404
 
 
+def test_url_index_verification_reports_identity_mismatch_before_origin_status() -> None:
+    payload = b"wrong response"
+    warc = _warc_response(payload, target_url="https://example.com/wrong", http_status="404 Not Found")
+    indexed_record = _indexed_record(warc, payload)
+
+    with _range_session(warc) as session, _client(session) as client:
+        record = client.fetch_record(indexed_record.record_range)
+
+    with pytest.raises(RecordVerificationError):
+        verify_url_index_record(record, indexed_record.expectation)
+
+
 def test_fetch_record_distinguishes_revisit_record() -> None:
     warc = _warc_revisit()
-    location = _location(warc, b"")
 
     with _range_session(warc) as session, _client(session) as client:
         with pytest.raises(WarcRevisitError):
-            client.fetch_record(location)
+            client.fetch_record(_record_range(warc))
+
+
+def test_fetch_record_rejects_non_response_record() -> None:
+    warc = _warc_record("metadata", include_http_headers=False)
+
+    with _range_session(warc) as session, _client(session) as client:
+        with pytest.raises(WarcParsingError):
+            client.fetch_record(_record_range(warc))
+
+
+def test_fetch_record_rejects_response_without_http_headers() -> None:
+    metadata_warc = _warc_record("metadata", include_http_headers=False, gzip_output=False, payload=b"")
+    warc = metadata_warc.replace(b"WARC-Type: metadata", b"WARC-Type: response", 1)
+
+    with _range_session(warc) as session, _client(session) as client:
+        with pytest.raises(WarcParsingError):
+            client.fetch_record(_record_range(warc))
+
+
+def test_fetch_record_rejects_multiple_records_in_range() -> None:
+    warc = _warc_response(b"first") + _warc_response(b"second")
+
+    with _range_session(warc) as session, _client(session) as client:
+        with pytest.raises(WarcParsingError):
+            client.fetch_record(_record_range(warc))
+
+
+@pytest.mark.parametrize("body_delta", [-1, 1])
+def test_fetch_record_rejects_body_length_different_from_range(body_delta: int) -> None:
+    warc = _warc_response(b"document")
+    body = warc[:-1] if body_delta < 0 else warc + b"x"
+
+    with _range_session(warc, body_override=body, include_content_length=False) as session, _client(session) as client:
+        with pytest.raises(CommonCrawlTransientError):
+            client.fetch_record(_record_range(warc))
+
+
+def test_fetch_record_rejects_invalid_content_length() -> None:
+    warc = _warc_response(b"document")
+
+    with _range_session(warc, content_length="not-an-integer") as session, _client(session) as client:
+        with pytest.raises(CommonCrawlTransientError):
+            client.fetch_record(_record_range(warc))
 
 
 def test_fetch_record_rejects_index_range_over_limit_before_download() -> None:
@@ -290,7 +584,7 @@ def test_fetch_record_rejects_index_range_over_limit_before_download() -> None:
 
     with _range_session(warc) as session, _client(session, maximum_warc_record_bytes=len(warc) - 1) as client:
         with pytest.raises(WarcRecordTooLargeError):
-            client.fetch_record(_location(warc, payload))
+            client.fetch_record(_record_range(warc))
 
 
 def test_fetch_record_rejects_payload_over_limit() -> None:
@@ -304,4 +598,75 @@ def test_fetch_record_rejects_payload_over_limit() -> None:
             maximum_payload_bytes=len(payload) - 1,
         ) as client:
             with pytest.raises(WarcPayloadTooLargeError):
-                client.fetch_record(_location(warc, payload))
+                client.fetch_record(_record_range(warc))
+
+
+def test_supplemental_verification_uses_url_and_digest_without_expected_record_id() -> None:
+    payload = b"supplemental document"
+    warc = _warc_response(payload)
+    indexed_record = supplemental_record_from_index_row(
+        {
+            "url": TARGET_URL,
+            "warc_filename": "crawl-data/test.warc.gz",
+            "warc_record_offset": 0,
+            "warc_record_length": len(warc),
+            "content_digest": _sha1_digest(payload),
+        },
+        crawl_id="CC-SUPPLEMENTAL-2026-22",
+    )
+
+    with _range_session(warc) as session, _client(session) as client:
+        record = client.fetch_record(indexed_record.record_range)
+
+    verify_supplemental_record(record, indexed_record.expectation)
+    assert record.warc_record_id == RECORD_ID
+
+
+def test_supplemental_verification_preserves_non_uuid_record_id() -> None:
+    payload = b"supplemental document"
+    warc = _warc_response(payload, record_id="<https://example.com/rec/1>")
+    indexed_record = supplemental_record_from_index_row(
+        {
+            "url": TARGET_URL,
+            "warc_filename": "crawl-data/test.warc.gz",
+            "warc_record_offset": 0,
+            "warc_record_length": len(warc),
+            "content_digest": _sha1_digest(payload),
+        },
+        crawl_id="CC-SUPPLEMENTAL-2026-22",
+    )
+
+    with _range_session(warc) as session, _client(session) as client:
+        record = client.fetch_record(indexed_record.record_range)
+
+    verify_supplemental_record(record, indexed_record.expectation)
+    assert record.warc_record_id == "<https://example.com/rec/1>"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("url", "https://example.com/different.docx"),
+        ("content_digest", "sha1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+    ],
+)
+def test_supplemental_verification_rejects_index_mismatch(field: str, value: str) -> None:
+    payload = b"supplemental document"
+    warc = _warc_response(payload)
+    indexed_record = supplemental_record_from_index_row(
+        {
+            "url": TARGET_URL,
+            "warc_filename": "crawl-data/test.warc.gz",
+            "warc_record_offset": 0,
+            "warc_record_length": len(warc),
+            "content_digest": _sha1_digest(payload),
+        },
+        crawl_id="CC-SUPPLEMENTAL-2026-22",
+    )
+    expectation = replace(indexed_record.expectation, **{field: value})
+
+    with _range_session(warc) as session, _client(session) as client:
+        record = client.fetch_record(indexed_record.record_range)
+
+    with pytest.raises(RecordVerificationError):
+        verify_supplemental_record(record, expectation)

--- a/tests/datakit/download/test_common_crawl_warc.py
+++ b/tests/datakit/download/test_common_crawl_warc.py
@@ -11,6 +11,11 @@ from dataclasses import replace
 
 import pytest
 import requests
+from marin.datakit.download.common_crawl_plan import (
+    CommonCrawlIndexKind,
+    CommonCrawlSource,
+    PlannedCommonCrawlRange,
+)
 from marin.datakit.download.common_crawl_warc import (
     CommonCrawlClient,
     CommonCrawlDownloadError,
@@ -18,6 +23,7 @@ from marin.datakit.download.common_crawl_warc import (
     CommonCrawlRequestRejectedError,
     CommonCrawlTransientError,
     MainIndexedRecord,
+    MissingPlannedRecordError,
     OriginResponseStatusError,
     RecordVerificationError,
     SupplementalIndexedRecord,
@@ -179,6 +185,41 @@ class _ManifestAdapter(BaseAdapter):
         pass
 
 
+class _TruncatingRangeAdapter(BaseAdapter):
+    def __init__(self, content: bytes) -> None:
+        super().__init__()
+        self.content = content
+        self.requested_ranges: list[tuple[int, int]] = []
+
+    def send(
+        self,
+        request: requests.PreparedRequest,
+        stream: bool = False,
+        timeout: float | tuple[float, float] | tuple[float, None] | None = None,
+        verify: bool | str = True,
+        cert: bytes | str | tuple[bytes | str, bytes | str] | None = None,
+        proxies: Mapping[str, str] | None = None,
+    ) -> requests.Response:
+        del stream, timeout, verify, cert, proxies
+        start_text, end_text = request.headers["Range"].removeprefix("bytes=").split("-")
+        start, end = int(start_text), int(end_text)
+        self.requested_ranges.append((start, end))
+        body = self.content[start : end + 1]
+        if len(self.requested_ranges) == 1:
+            body = body[: len(body) // 2]
+
+        response = requests.Response()
+        response.status_code = requests.codes.partial_content
+        response.headers["Content-Length"] = str(end - start + 1)
+        response.headers["Content-Range"] = f"bytes {start}-{end}/{len(self.content)}"
+        response.raw = io.BytesIO(body)
+        response.request = request
+        return response
+
+    def close(self) -> None:
+        pass
+
+
 def _range_session(
     content: bytes,
     *,
@@ -214,6 +255,34 @@ def _indexed_record(warc: bytes, payload: bytes) -> MainIndexedRecord:
             "content_digest": _sha1_digest(payload),
         },
         crawl_id="CC-MAIN-2026-30",
+    )
+
+
+def _indexed_record_at(warc: bytes, payload: bytes, *, offset: int, url: str) -> MainIndexedRecord:
+    return main_record_from_index_row(
+        {
+            "url": url,
+            "warc_filename": "crawl-data/test.warc.gz",
+            "warc_record_offset": offset,
+            "warc_record_length": len(warc),
+            "warc_record_id": RECORD_ID,
+            "content_digest": _sha1_digest(payload),
+        },
+        crawl_id="CC-MAIN-2026-30",
+    )
+
+
+def _planned_range(warc: bytes, records: tuple[MainIndexedRecord, ...]) -> PlannedCommonCrawlRange:
+    return PlannedCommonCrawlRange(
+        source=CommonCrawlSource(
+            crawl_id="CC-MAIN-2026-30",
+            index_kind=CommonCrawlIndexKind.MAIN,
+            paths_manifest_url="https://index.commoncrawl.org/test.paths.gz",
+        ),
+        warc_filename="crawl-data/test.warc.gz",
+        start=0,
+        stop=len(warc),
+        records=records,
     )
 
 
@@ -404,6 +473,73 @@ def test_fetch_record_returns_parsed_payload_then_main_verification_succeeds() -
     assert record.http_content_type == "application/octet-stream"
     assert record.warc_date == "2026-07-21T21:48:44Z"
     assert record.identified_payload_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+
+def test_fetch_range_returns_planned_records_and_ignores_intervening_record() -> None:
+    first_payload = b"first"
+    skipped_payload = b"not selected"
+    third_payload = b"third"
+    first = _warc_response(first_payload, target_url="https://example.com/first")
+    skipped = _warc_response(skipped_payload, target_url="https://example.com/skipped")
+    third = _warc_response(third_payload, target_url="https://example.com/third")
+    warc = first + skipped + third
+    planned = _planned_range(
+        warc,
+        (
+            _indexed_record_at(first, first_payload, offset=0, url="https://example.com/first"),
+            _indexed_record_at(
+                third,
+                third_payload,
+                offset=len(first) + len(skipped),
+                url="https://example.com/third",
+            ),
+        ),
+    )
+
+    with _range_session(warc) as session, _client(session) as client:
+        records = client.fetch_range(planned)
+
+    assert [record.payload for record in records] == [first_payload, third_payload]
+
+
+def test_fetch_range_resumes_from_first_unwritten_byte() -> None:
+    payload = b"document"
+    warc = _warc_response(payload)
+    planned = _planned_range(warc, (_indexed_record_at(warc, payload, offset=0, url=TARGET_URL),))
+    adapter = _TruncatingRangeAdapter(warc)
+
+    with requests.Session() as session:
+        session.mount("https://", adapter)
+        with _client(session) as client:
+            [record] = client.fetch_range(planned)
+
+    assert record.payload == payload
+    assert adapter.requested_ranges == [(0, len(warc) - 1), (len(warc) // 2, len(warc) - 1)]
+
+
+def test_fetch_range_fails_when_a_planned_offset_is_missing() -> None:
+    first_payload = b"first"
+    second_payload = b"second"
+    first = _warc_response(first_payload, target_url="https://example.com/first")
+    second = _warc_response(second_payload, target_url="https://example.com/second")
+    warc = first + second
+    missing = _indexed_record_at(
+        second[:-1],
+        second_payload,
+        offset=len(first) + 1,
+        url="https://example.com/second",
+    )
+    planned = _planned_range(
+        warc,
+        (
+            _indexed_record_at(first, first_payload, offset=0, url="https://example.com/first"),
+            missing,
+        ),
+    )
+
+    with _range_session(warc) as session, _client(session) as client:
+        with pytest.raises(MissingPlannedRecordError):
+            client.fetch_range(planned)
 
 
 @pytest.mark.parametrize(

--- a/tests/datakit/download/test_common_crawl_warc.py
+++ b/tests/datakit/download/test_common_crawl_warc.py
@@ -1,0 +1,307 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import hashlib
+import io
+import uuid
+from collections.abc import Mapping
+from dataclasses import replace
+
+import pytest
+import requests
+from marin.datakit.download.common_crawl_warc import (
+    CommonCrawlClient,
+    CommonCrawlDownloadError,
+    CommonCrawlRecordLocation,
+    CommonCrawlRequestRejectedError,
+    CommonCrawlTransientError,
+    OriginResponseStatusError,
+    RecordVerificationError,
+    WarcPayloadTooLargeError,
+    WarcRecordTooLargeError,
+    WarcRevisitError,
+)
+from requests.adapters import BaseAdapter
+from warcio.statusandheaders import StatusAndHeaders
+from warcio.warcwriter import WARCWriter
+
+RECORD_ID = "<urn:uuid:019f8700-d21d-78d8-8eb1-99eaa22579da>"
+TARGET_URL = "https://example.com/document.docx"
+
+
+def _sha1_digest(payload: bytes) -> str:
+    digest = hashlib.sha1(payload, usedforsecurity=False).digest()
+    return f"sha1:{base64.b32encode(digest).decode().rstrip('=')}"
+
+
+def _warc_response(
+    payload: bytes,
+    *,
+    target_url: str = TARGET_URL,
+    record_id: str = RECORD_ID,
+    http_status: str = "200 OK",
+) -> bytes:
+    output = io.BytesIO()
+    writer = WARCWriter(output, gzip=True)
+    http_headers = StatusAndHeaders(http_status, [("Content-Type", "application/octet-stream")], protocol="HTTP/1.1")
+    record = writer.create_warc_record(
+        target_url,
+        "response",
+        payload=io.BytesIO(payload),
+        http_headers=http_headers,
+        warc_headers_dict={
+            "WARC-Record-ID": record_id,
+            "WARC-Date": "2026-07-21T21:48:44Z",
+            "WARC-Identified-Payload-Type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        },
+    )
+    writer.write_record(record)
+    return output.getvalue()
+
+
+def _warc_revisit() -> bytes:
+    output = io.BytesIO()
+    writer = WARCWriter(output, gzip=True)
+    record = writer.create_warc_record(
+        TARGET_URL,
+        "revisit",
+        warc_headers_dict={
+            "WARC-Record-ID": RECORD_ID,
+            "WARC-Refers-To": "<urn:uuid:119f8700-d21d-78d8-8eb1-99eaa22579da>",
+        },
+    )
+    writer.write_record(record)
+    return output.getvalue()
+
+
+class _RangeAdapter(BaseAdapter):
+    def __init__(self, content: bytes, content_range: str | None, response_status: int) -> None:
+        super().__init__()
+        self.content = content
+        self.content_range = content_range
+        self.response_status = response_status
+
+    def send(
+        self,
+        request: requests.PreparedRequest,
+        stream: bool = False,
+        timeout: float | tuple[float, float] | tuple[float, None] | None = None,
+        verify: bool | str = True,
+        cert: bytes | str | tuple[bytes | str, bytes | str] | None = None,
+        proxies: Mapping[str, str] | None = None,
+    ) -> requests.Response:
+        del stream, timeout, verify, cert, proxies
+        requested_range = request.headers["Range"]
+        start_text, end_text = requested_range.removeprefix("bytes=").split("-")
+        start, end = int(start_text), int(end_text)
+        body = self.content[start : end + 1]
+
+        response = requests.Response()
+        response.status_code = self.response_status
+        response.headers["Content-Length"] = str(len(body))
+        response.headers["Content-Range"] = self.content_range or f"bytes {start}-{end}/{len(self.content)}"
+        response.raw = io.BytesIO(body)
+        response.request = request
+        return response
+
+    def close(self) -> None:
+        pass
+
+
+def _range_session(
+    content: bytes,
+    *,
+    content_range: str | None = None,
+    response_status: int = requests.codes.partial_content,
+) -> requests.Session:
+    session = requests.Session()
+    session.mount("https://", _RangeAdapter(content, content_range, response_status))
+    return session
+
+
+def _location(warc: bytes, payload: bytes) -> CommonCrawlRecordLocation:
+    return CommonCrawlRecordLocation(
+        crawl_id="CC-MAIN-2026-30",
+        url=TARGET_URL,
+        warc_filename="crawl-data/test.warc.gz",
+        warc_record_offset=0,
+        warc_record_length=len(warc),
+        warc_record_id=RECORD_ID,
+        content_digest=_sha1_digest(payload),
+    )
+
+
+def _client(session: requests.Session, *, maximum_warc_record_bytes: int = 1 << 20) -> CommonCrawlClient:
+    return CommonCrawlClient(
+        session=session,
+        maximum_warc_record_bytes=maximum_warc_record_bytes,
+        maximum_payload_bytes=1 << 20,
+    )
+
+
+def test_record_location_from_url_index_row_normalizes_uuid_blob() -> None:
+    record_id = uuid.UUID("019f8700-d21d-78d8-8eb1-99eaa22579da")
+
+    location = CommonCrawlRecordLocation.from_url_index_row(
+        {
+            "url": TARGET_URL,
+            "warc_filename": "crawl-data/test.warc.gz",
+            "warc_record_offset": 42,
+            "warc_record_length": 100,
+            "warc_record_id": record_id.bytes,
+            "content_digest": "sha1:ABC",
+        },
+        crawl_id="CC-MAIN-2026-30",
+    )
+
+    assert location.warc_record_id == RECORD_ID
+    assert location.byte_range == (42, 141)
+
+    string_location = CommonCrawlRecordLocation.from_url_index_row(
+        {
+            "url": TARGET_URL,
+            "warc_filename": "crawl-data/test.warc.gz",
+            "warc_record_offset": 42,
+            "warc_record_length": 100,
+            "warc_record_id": "urn:uuid:019f8700-d21d-78d8-8eb1-99eaa22579da",
+            "content_digest": "ABC",
+        },
+        crawl_id="CC-MAIN-2026-30",
+    )
+    assert string_location.warc_record_id == RECORD_ID
+    assert string_location.content_digest == "sha1:ABC"
+
+
+def test_client_default_session_constructs_and_closes(monkeypatch: pytest.MonkeyPatch) -> None:
+    sessions = []
+
+    class TrackingSession(requests.Session):
+        def __init__(self) -> None:
+            super().__init__()
+            self.closed = False
+            sessions.append(self)
+
+        def close(self) -> None:
+            self.closed = True
+            super().close()
+
+    monkeypatch.setattr(requests, "Session", TrackingSession)
+
+    with CommonCrawlClient(maximum_warc_record_bytes=1 << 20, maximum_payload_bytes=1 << 20):
+        pass
+
+    assert len(sessions) == 1
+    assert sessions[0].closed
+
+
+def test_fetch_record_returns_verified_payload() -> None:
+    payload = b"PK\x03\x04example docx bytes"
+    warc = _warc_response(payload)
+    location = _location(warc, payload)
+
+    with _range_session(warc) as session, _client(session) as client:
+        record = client.fetch_record(location)
+
+    assert record.payload == payload
+    assert record.warc_record_id == RECORD_ID
+    assert record.target_url == TARGET_URL
+    assert record.http_status == 200
+    assert record.http_content_type == "application/octet-stream"
+    assert record.warc_date == "2026-07-21T21:48:44Z"
+    assert record.identified_payload_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+
+def test_fetch_record_rejects_incorrect_content_range() -> None:
+    payload = b"document"
+    warc = _warc_response(payload)
+    location = _location(warc, payload)
+
+    with _range_session(warc, content_range=f"bytes 1-{len(warc)}/{len(warc)}") as session:
+        with _client(session) as client:
+            with pytest.raises(CommonCrawlTransientError):
+                client.fetch_record(location)
+
+
+def test_fetch_record_rejects_full_response_to_range_request() -> None:
+    payload = b"document"
+    warc = _warc_response(payload)
+
+    with _range_session(warc, response_status=requests.codes.ok) as session, _client(session) as client:
+        with pytest.raises(CommonCrawlTransientError):
+            client.fetch_record(_location(warc, payload))
+
+
+@pytest.mark.parametrize("status", [400, 404])
+def test_fetch_record_classifies_permanent_object_error(status: int) -> None:
+    payload = b"missing"
+    warc = _warc_response(payload)
+
+    with _range_session(warc, response_status=status) as session, _client(session) as client:
+        with pytest.raises(CommonCrawlRequestRejectedError) as error:
+            client.fetch_record(_location(warc, payload))
+
+    assert error.value.status == status
+    assert error.value.url.endswith("/crawl-data/test.warc.gz")
+
+
+def test_fetch_record_classifies_rate_limit_as_transient() -> None:
+    payload = b"rate limited"
+    warc = _warc_response(payload)
+
+    with _range_session(warc, response_status=403) as session, _client(session) as client:
+        with pytest.raises(CommonCrawlDownloadError):
+            client.fetch_record(_location(warc, payload))
+
+
+def test_fetch_record_rejects_payload_digest_mismatch() -> None:
+    payload = b"document"
+    warc = _warc_response(payload)
+    location = replace(_location(warc, payload), content_digest="sha1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+
+    with _range_session(warc) as session, _client(session) as client:
+        with pytest.raises(RecordVerificationError):
+            client.fetch_record(location)
+
+
+def test_fetch_record_rejects_non_success_origin_response() -> None:
+    payload = b"not found"
+    warc = _warc_response(payload, http_status="404 Not Found")
+
+    with _range_session(warc) as session, _client(session) as client:
+        with pytest.raises(OriginResponseStatusError) as error:
+            client.fetch_record(_location(warc, payload))
+
+    assert error.value.status == 404
+
+
+def test_fetch_record_distinguishes_revisit_record() -> None:
+    warc = _warc_revisit()
+    location = _location(warc, b"")
+
+    with _range_session(warc) as session, _client(session) as client:
+        with pytest.raises(WarcRevisitError):
+            client.fetch_record(location)
+
+
+def test_fetch_record_rejects_index_range_over_limit_before_download() -> None:
+    payload = b"document"
+    warc = _warc_response(payload)
+
+    with _range_session(warc) as session, _client(session, maximum_warc_record_bytes=len(warc) - 1) as client:
+        with pytest.raises(WarcRecordTooLargeError):
+            client.fetch_record(_location(warc, payload))
+
+
+def test_fetch_record_rejects_payload_over_limit() -> None:
+    payload = b"document"
+    warc = _warc_response(payload)
+
+    with _range_session(warc) as session:
+        with CommonCrawlClient(
+            session=session,
+            maximum_warc_record_bytes=1 << 20,
+            maximum_payload_bytes=len(payload) - 1,
+        ) as client:
+            with pytest.raises(WarcPayloadTooLargeError):
+                client.fetch_record(_location(warc, payload))

--- a/uv.lock
+++ b/uv.lock
@@ -4876,6 +4876,7 @@ datakit = [
     { name = "luxical" },
     { name = "scikit-learn" },
     { name = "scipy" },
+    { name = "warcio" },
 ]
 dedup = [
     { name = "marin-dupekit" },
@@ -5064,6 +5065,7 @@ requires-dist = [
     { name = "verifiers", marker = "extra == 'rl'", specifier = "==0.1.5" },
     { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/marin-community/vllm.git?rev=afb26719464d5957e695bde478ae93a160b11d14" },
     { name = "wandb", specifier = ">0.24.0" },
+    { name = "warcio", marker = "extra == 'datakit'", specifier = ">=1.7.5,<2" },
 ]
 provides-extras = ["gpu", "tpu", "cpu", "rl", "vizier", "vllm", "dedup", "datakit", "math"]
 
@@ -11861,6 +11863,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/24/c5/a4eb8fb6e7527584c6ccdf5c9b265283ed0c9d94d26d5eb28f9b48cd5779/wandb-0.26.0-py3-none-win32.whl", hash = "sha256:362828d48d21dd4877e28fdce40421ebdfc16d1fe0b59e8371b12d75bbc3f1e7", size = 24908555, upload-time = "2026-04-13T19:42:39.416Z" },
     { url = "https://files.pythonhosted.org/packages/35/3d/bf182f3af977e6297fc05bc3fd9bd51feacfe4d2c4ce83c90eb2ad7ce59b/wandb-0.26.0-py3-none-win_amd64.whl", hash = "sha256:21a8346434fd30e1bc13a26b226fc29b6f33a1cb346d610cbcb4040c3b0e1f63", size = 24908559, upload-time = "2026-04-13T19:42:42.019Z" },
     { url = "https://files.pythonhosted.org/packages/1a/3e/344cb29b593f8e7abc14cc268dafde1974bae3f073b4885476f4fbba3cb8/wandb-0.26.0-py3-none-win_arm64.whl", hash = "sha256:99bd11974e9005d3a3f82e1fabfc4909ffa1fdede23a8839f5fbaea2f5be9033", size = 22936140, upload-time = "2026-04-13T19:42:44.715Z" },
+]
+
+[[package]]
+name = "warcio"
+version = "1.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/78/df7e1c40a3751ea966be84eb6645270831e511f9932740b5251ace028cfa/warcio-1.8.1.tar.gz", hash = "sha256:76f71b22159ca3c043521e10ee8a2478d167672ad1d137c7c15e40b0d5c73ccd", size = 65772, upload-time = "2026-03-31T16:10:32.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/be/d92c0899bd52c7f82fc0f8caa8fb3c624e6d1006ee208c710060cda216c2/warcio-1.8.1-py2.py3-none-any.whl", hash = "sha256:82345c5914d36cb5e0513210dbf759e3db348bf8d0f7762996ccce3a5ce6e87b", size = 41578, upload-time = "2026-03-31T16:10:31.059Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a shared Common Crawl discovery, planning, and fetch layer. Discovery scans URL Index Parquet partitions and writes a reusable manifest of selected records. Planning coalesces nearby records within each WARC, using a 1 MiB gap, and packs ranges into 256 MiB source-local fetch tasks. Sparse records remain singleton ranges and use the same fetch path.

Fetch validates the exact HTTP 206 response and Content-Range, resumes partial range downloads, bounds compressed records and decoded payloads, and fails if any planned record is missing. Parsed records are verified against the indexed URL and content digest. WARC record IDs are also checked when the index provides them; recent CC-MAIN and supplemental indexes may omit that field.

The shared layer supports multiple CC-MAIN and CC-SUPPLEMENTAL snapshots without coalescing or packing across sources. Candidate selection and document extraction remain pipeline-specific. The DOCX pipeline now uses the shared discovery manifest, planner, and coalesced fetch tasks.

Part of #7736 and should help with #7616.
