### PR TITLE
Add padding-target loss mode

### DIFF
--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -41,6 +41,7 @@ from levanter.data.sharded_datasource import (
 from levanter.data.text.cache import build_lm_dataset_cache, load_lm_dataset_cache
 from levanter.data.text.examples import (
     GrugLmExample,
+    PaddingTargetLoss,
     named_lm_example_from_grug,
 )
 from levanter.data.text.formats import (
@@ -396,6 +397,7 @@ class PackedTokenDataset(MappedAsyncDataset[tuple[dict, dict], GrugLmExample]):
         slice_strategy: Literal["left", "right", "raise"] = "left",
         loss_weights_key: str | None = None,
         block_cross_document_attention: bool = True,
+        padding_target_loss: PaddingTargetLoss = "mask",
     ):
         self.packed: GreedyPrepackedDataset[dict] = GreedyPrepackedDataset(
             cache.jagged_array_tree(),
@@ -406,6 +408,7 @@ class PackedTokenDataset(MappedAsyncDataset[tuple[dict, dict], GrugLmExample]):
         self.Pos = Pos
         self.block_cross_document_attention = block_cross_document_attention
         self.loss_weights_key = loss_weights_key
+        self.padding_target_loss = padding_target_loss
 
         sharding = _single_cpu_sharding()
 
@@ -423,6 +426,7 @@ class PackedTokenDataset(MappedAsyncDataset[tuple[dict, dict], GrugLmExample]):
                     segment_ids=seg_ids_raw,
                     max_segments=max_segments_per_example + 1,
                     block_cross_document_attention=block_cross_document_attention,
+                    padding_target_loss=padding_target_loss,
                 )
                 out = jax.lax.with_sharding_constraint(out, sharding)
                 return out
@@ -441,6 +445,7 @@ class PackedTokenDataset(MappedAsyncDataset[tuple[dict, dict], GrugLmExample]):
                     segment_ids=seg_ids_raw,
                     max_segments=max_segments_per_example + 1,
                     block_cross_document_attention=block_cross_document_attention,
+                    padding_target_loss=padding_target_loss,
                 )
                 out = jax.lax.with_sharding_constraint(out, sharding)
                 return out
@@ -461,6 +466,7 @@ class ChatDataset(MappedAsyncDataset[tuple[ProcessedChatDict, ProcessedChatDict]
         slice_strategy: Literal["left", "right", "raise"] = "left",
         mask_user_turns: bool = True,
         block_cross_document_attention: bool = True,
+        padding_target_loss: PaddingTargetLoss = "mask",
     ):
         self.packed: GreedyPrepackedDataset[ProcessedChatDict] = GreedyPrepackedDataset(
             cache.jagged_array_tree(),
@@ -473,6 +479,7 @@ class ChatDataset(MappedAsyncDataset[tuple[ProcessedChatDict, ProcessedChatDict]
 
         sharding = _single_cpu_sharding()
         self.mask_user_turns = mask_user_turns
+        self.padding_target_loss = padding_target_loss
 
         @functools.partial(eqx.filter_jit)
         def _create_lm_example(e: tuple[ProcessedChatDict, ProcessedChatDict]) -> GrugLmExample:
@@ -494,6 +501,7 @@ class ChatDataset(MappedAsyncDataset[tuple[ProcessedChatDict, ProcessedChatDict]
                 segment_ids=seg_ids_raw,
                 max_segments=max_segments_per_example + 1,
                 block_cross_document_attention=block_cross_document_attention,
+                padding_target_loss=padding_target_loss,
             )
             out = jax.lax.with_sharding_constraint(out, sharding)
             return out
@@ -508,6 +516,7 @@ def dataset_for_component(
     *,
     eos_id: int | None,
     block_cross_document_attention: bool,
+    padding_target_loss: PaddingTargetLoss = "mask",
 ) -> AsyncDataset[GrugLmExample]:
     pack = _effective_pack(component)
     fmt = component.format
@@ -520,6 +529,7 @@ def dataset_for_component(
                 max_segments_per_example=max_segments,
                 slice_strategy=slice_strategy,
                 block_cross_document_attention=block_cross_document_attention,
+                padding_target_loss=padding_target_loss,
             )
         return CausalLmDataset(
             TokenSeqDataset(cache, Pos.size),
@@ -537,6 +547,7 @@ def dataset_for_component(
             slice_strategy=slice_strategy,
             mask_user_turns=fmt.mask_user_turns,
             block_cross_document_attention=block_cross_document_attention,
+            padding_target_loss=padding_target_loss,
         )  # type: ignore
     elif isinstance(fmt, PrebuiltLmDatasetFormat):
         return PrebuiltLmDataset(
@@ -647,6 +658,14 @@ class LmDataConfig:
     If False, full causal attention is allowed across packed documents.
     """
 
+    padding_target_loss: PaddingTargetLoss = "mask"
+    """How to handle positions whose next token is padding.
+
+    ``"mask"`` is the default because padding is an artificial target. Use
+    ``"include"`` only when you intentionally want those positions included in
+    the objective; doing so changes the meaning and scale of the reported loss.
+    """
+
     components: dict[str, DatasetComponentBase] = field(default_factory=dict)
     train_weights: dict[str, float] | list[tuple[int, dict[str, float]]] | None = None
 
@@ -733,6 +752,7 @@ class LmDataConfig:
                         cache,
                         eos_id=self.the_tokenizer.eos_token_id,
                         block_cross_document_attention=self.block_cross_document_attention,
+                        padding_target_loss=self.padding_target_loss,
                     )
                 if child_datasets:
                     datasets[name] = ConcatDataset(child_datasets)
@@ -753,6 +773,7 @@ class LmDataConfig:
                 cache,
                 eos_id=self.the_tokenizer.eos_token_id,
                 block_cross_document_attention=self.block_cross_document_attention,
+                padding_target_loss=self.padding_target_loss,
             )
 
         return datasets

--- a/lib/levanter/src/levanter/data/text/examples.py
+++ b/lib/levanter/src/levanter/data/text/examples.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass
-from typing import Mapping, Sequence
+from typing import Literal, Mapping, Sequence
 
 import jax
 import jax.numpy as jnp
@@ -17,6 +17,7 @@ from levanter.layers.attention import AttentionMask
 from levanter.models.lm_model import LmExample
 
 
+PaddingTargetLoss = Literal["mask", "include"]
 LOSS_IGNORE_LABEL = 0
 
 
@@ -131,6 +132,7 @@ class GrugLmExample:
         max_segments: int | None = None,
         sliding_window: int | None = None,
         block_cross_document_attention: bool = True,
+        padding_target_loss: PaddingTargetLoss = "mask",
     ) -> "GrugLmExample":
         if tokens.ndim != 1:
             raise ValueError("tokens must be a 1D array")
@@ -148,10 +150,14 @@ class GrugLmExample:
             dtype = jnp.float32
             loss_weight = causal_loss_mask.astype(dtype)
 
-        # Prepacked datasets mark padding positions with segment id -1. A position whose
-        # successor is padding predicts a pad token, so it must never contribute loss --
-        # otherwise the (arbitrary) padding value would leak into the objective.
-        if segment_ids is not None:
+        if padding_target_loss not in ("mask", "include"):
+            raise ValueError(f"padding_target_loss must be 'mask' or 'include', got {padding_target_loss!r}")
+
+        if padding_target_loss == "mask" and segment_ids is not None:
+            # Prepacked datasets mark padding positions with segment id -1. A position whose
+            # successor is padding predicts a pad token, so the default masks that artificial
+            # target. Use "include" only when predicting padding is intentionally part of the
+            # objective you want to measure or optimize.
             predicts_real_token = (jnp.roll(segment_ids, -1) >= 0).astype(dtype)
             loss_weight = loss_weight * predicts_real_token
 

--- a/lib/levanter/tests/test_text.py
+++ b/lib/levanter/tests/test_text.py
@@ -731,6 +731,23 @@ def _build_train_cache(component, tokenizer):
     return build_lm_dataset_cache(component.cache_dir, source, component.format, tokenizer)
 
 
+def test_grug_causal_padding_target_mask_can_be_disabled():
+    tokens = jnp.array([10, 11, 0, 0], dtype=jnp.int32)
+    segment_ids = jnp.array([0, 0, -1, -1], dtype=jnp.int32)
+    loss_weight = jnp.ones_like(tokens, dtype=jnp.float32)
+
+    default = GrugLmExample.causal(tokens, loss_weight=loss_weight, segment_ids=segment_ids)
+    np.testing.assert_array_equal(np.asarray(default.loss_weight), np.array([1, 0, 0, 0], dtype=np.float32))
+
+    unmasked = GrugLmExample.causal(
+        tokens,
+        loss_weight=loss_weight,
+        segment_ids=segment_ids,
+        padding_target_loss="include",
+    )
+    np.testing.assert_array_equal(np.asarray(unmasked.loss_weight), np.array([1, 1, 1, 0], dtype=np.float32))
+
+
 def assert_padding_never_contributes_loss(example):
     """The pad value must not leak into the objective.
 

--- a/lib/marin/src/marin/experiment/data.py
+++ b/lib/marin/src/marin/experiment/data.py
@@ -31,6 +31,7 @@ from collections.abc import Callable, Mapping, Sequence
 import click
 from fray.types import ResourceConfig
 from levanter.data.text.datasets import DEFAULT_LM_DATA_SHUFFLE, BlockShuffleConfig, LmDataConfig, UrlDatasetSourceConfig
+from levanter.data.text.examples import PaddingTargetLoss
 from levanter.data.text.formats import TextLmDatasetFormat
 from rigging.filesystem import prefix_join
 
@@ -268,6 +269,7 @@ def mixture(
     *,
     validation: Sequence[ArtifactStep[TokenizedCache]] = (),
     shuffle: bool | BlockShuffleConfig = DEFAULT_LM_DATA_SHUFFLE,
+    padding_target_loss: PaddingTargetLoss = "mask",
 ) -> LmDataConfig:
     """Assemble an ``LmDataConfig`` from dataset handles.
 
@@ -279,6 +281,10 @@ def mixture(
     contribution is the sorted ``{name@version: weight}`` map; the tokenizer is determined by
     the chosen datasets and verified at run time. Call this inside a consumer's ``build_config``
     and pass the same handles as the step's ``deps`` so they materialize first.
+
+    ``padding_target_loss="include"`` includes positions whose next token is padding in
+    the loss. That changes the objective and loss scale; use it only when that behavior
+    is intentional.
     """
     handles = [*train, *validation]
     if not handles:
@@ -299,6 +305,7 @@ def mixture(
             cache_dir=None,
             shuffle=shuffle,
             permutation_type="feistel",
+            padding_target_loss=padding_target_loss,
         )
 
     components = {}
@@ -325,6 +332,7 @@ def mixture(
         cache_dir=None,
         shuffle=shuffle,
         permutation_type="feistel",
+        padding_target_loss=padding_target_loss,
     )
 
 

--- a/lib/marin/src/marin/experiment/train.py
+++ b/lib/marin/src/marin/experiment/train.py
@@ -28,6 +28,7 @@ from fray.types import GpuConfig, ResourceConfig
 from haliax.partitioning import ResourceAxis
 from levanter.adaptor import NoAdaptorConfig
 from levanter.checkpoint import CheckpointerConfig
+from levanter.data.text.examples import PaddingTargetLoss
 from levanter.eval_harness import LmEvalHarnessConfig
 from levanter.main.train_lm import TrainLmConfig
 from levanter.models.lm_model import LmConfig
@@ -117,6 +118,7 @@ def train_lm(
     mp: str = MARIN_PRECISION,
     tensor_parallel_size: int = 1,
     steps_per_eval: int = 1000,
+    padding_target_loss: PaddingTargetLoss = "mask",
     wandb_project: str = "marin",
     wandb_group: str | None = None,
     run_id: str | None = None,
@@ -139,6 +141,8 @@ def train_lm(
     metadata, and ``resources`` (the TPU the job is dispatched onto — a runtime arg, so it
     never enters the checkpoint's fingerprint). ``init_from`` chains this run onto another
     checkpoint (it becomes a dep and seeds ``initialize_from_checkpoint_path``).
+    ``padding_target_loss="include"`` changes the loss objective by scoring positions
+    whose next token is padding; use it only when that behavior is intentional.
 
     Training length is set by exactly one of ``num_train_steps`` or ``num_train_epochs`` (setting
     both, or neither, is an error). ``num_train_epochs`` is a thin convenience over
@@ -194,7 +198,7 @@ def train_lm(
             LevanterCheckpoint(path=ctx.artifact_path(init_from)).checkpoint_dir if init_from is not None else None
         )
         inner = TrainLmConfig(
-            data=mixture(ctx, datasets, validation=validation),
+            data=mixture(ctx, datasets, validation=validation, padding_target_loss=padding_target_loss),
             trainer=TrainerConfig(
                 id=run_id,
                 tracker=WandbConfig(


### PR DESCRIPTION
## Summary
- keep padding-target masking as the default packed-LM loss behavior
- add an explicit `padding_target_loss` mode with values `"mask"` (default) and `"include"`
- thread the mode through `LmDataConfig`, packed text/chat datasets, `GrugLmExample.causal`, `marin.experiment.data.mixture`, and `marin.experiment.train.train_lm`

## Context
#7209 changed the default CE behavior so positions whose next token is padding are masked. That remains the default here: padding is an artificial target, and most users should not optimize or report loss on it.

MarinFold has older contacts-v1 runs whose validation losses were recorded before this masking existed. To compare new recomputes against those already-recorded losses, we need a deliberate compatibility mode that includes those padding-target positions. This PR adds that mode without changing the default.

`padding_target_loss="include"` changes the objective and the loss scale. Callers should only use it when they intentionally want padding-target positions included in the loss.

## Testing
- Added `test_grug_causal_padding_target_mask_can_be_disabled`
- `python3 -m py_compile lib/levanter/src/levanter/data/text/examples.py lib/levanter/src/levanter/data/text/datasets.py lib/levanter/tests/test_text.py lib/marin/src/marin/experiment/data.py lib/marin/src/marin/experiment/train.py`
- MarinFold/CoreWeave smoke recompute against exp117 contacts-v1 validation data using PR code and `padding_target_loss="include"`:
  - job: `/zack/exp188-pr7921-include-cw-smoke4-r4`
  - input/model/cache/output all on CoreWeave S3 (`s3://marin-us-east-02a/...`)
  - `max_eval_batches=4`, `loss_weight_mode="example"`, `eval_mode="tagged"`
  - `eval/loss = 2.8036928176879883`, matching the expected old/compatibility loss scale
