### PR TITLE
[iac] Grant KMS encrypt/decrypt to loom-vm

### DIFF
--- a/infra/pulumi/src/iac/gcp/iam_data.yaml
+++ b/infra/pulumi/src/iac/gcp/iam_data.yaml
@@ -750,6 +750,7 @@ kms_grants:
 - role: roles/cloudkms.cryptoKeyEncrypterDecrypter
   members:
   - serviceAccount:iris-ci-smoke@hai-gcp-models.iam.gserviceaccount.com
+  - serviceAccount:loom-vm@hai-gcp-models.iam.gserviceaccount.com
   - serviceAccount:marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com
   - serviceAccount:ravwojdyla@rav-openathena.iam.gserviceaccount.com
   - principal: human-032


### PR DESCRIPTION
Add `serviceAccount:loom-vm@hai-gcp-models.iam.gserviceaccount.com` to the
marin-iac key's `cryptoKeyEncrypterDecrypter` grant. Headless Claude Code
sessions running on the Loom VM need this to run `iam_principal.py`, which
decrypts and re-encrypts the human-principal registry in `iam_data.yaml`.

The issue also asked for KMS access for the `marindev` custom role's members.
That role's permission set is not owned by Pulumi's `custom_roles:` (it is a
legacy role from the retired `infra/permissions` project, referenced here only
by ID for membership grants), so adding a permission to the role itself isn't
a one-line change in this stack. Left out of this PR pending a decision on
migrating `marindev` into Pulumi's custom-role management.

A reviewer should run `review-grant`, then `pulumi up` on the `marin` stack.

Part of #7922
