### PR TITLE
[ci] Skip triage on issues that mention @weaverbot

### DIFF
--- a/.github/workflows/ops-claude.yaml
+++ b/.github/workflows/ops-claude.yaml
@@ -85,7 +85,9 @@ jobs:
        github.event.issue.author_association == 'MEMBER' ||
        github.event.issue.author_association == 'COLLABORATOR') &&
       !contains(github.event.issue.body, '@claude') &&
-      !contains(github.event.issue.title, '@claude')
+      !contains(github.event.issue.title, '@claude') &&
+      !contains(github.event.issue.body, '@weaverbot') &&
+      !contains(github.event.issue.title, '@weaverbot')
     timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Issues tagged for @weaverbot are handled by a weaver session, so the ops-claude triage job should not also pick them up. Extend its existing @claude-mention skip to also skip issues whose title or body mentions @weaverbot.
