### PR TITLE
[grug] Carry over expert-parallel sharding fixes from #7780

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -68,8 +68,11 @@ _BATCH_AXES: tuple[str, ...] = ("replica_dcn", "data", "expert")
 _FSDP_AXES: tuple[str, ...] = ("data", "expert")
 # The LM head also spans the cross-slice replica axis it had before EP.
 _LM_HEAD_AXES: tuple[str, ...] = ("replica_dcn", *_FSDP_AXES)
-# The groups these replace. A weight falls back to its pre-EP group whole rather than
-# to some smaller one, so widening can only ever add sharding, never remove it.
+# The groups these replace. Widening multiplies the divisibility requirement on the
+# sharded dim by the expert axis size, so a weight falls back to its pre-EP group whole
+# rather than to some smaller one: the spec, including any init error it raises, is then
+# exactly the pre-EP one. Widening can add sharding but never silently take it away, and
+# a geometry that could not shard before still fails instead of quietly replicating.
 _PRE_EP_FSDP_AXES: tuple[str, ...] = ("data",)
 _PRE_EP_LM_HEAD_AXES: tuple[str, ...] = ("replica_dcn", "data")
 
@@ -88,18 +91,7 @@ RematMode = Literal["recompute_all", "save_moe"]
 
 
 def _shard_axes(dim: int, widened: tuple[str, ...], pre_ep: tuple[str, ...]) -> tuple[str, ...] | str | None:
-    """``widened`` when its shard count divides ``dim``, otherwise ``pre_ep``.
-
-    Adding "expert" multiplies the divisibility requirement on ``dim`` by the expert
-    axis size, which would turn shapes that shard fine without it into a hard failure
-    at model init. The fallback is the whole pre-EP group rather than a smaller one:
-    when the wider group does not fit, the resulting spec -- and any init error it
-    raises -- is exactly what it was before expert parallelism, so widening can add
-    sharding but never silently take it away.
-
-    Axes absent from the mesh are dropped, which is how a non-EP mesh with no "expert"
-    axis still initializes.
-    """
+    """``widened`` when its shard count divides ``dim``, otherwise ``pre_ep``, minus absent axes."""
     mesh = get_abstract_mesh()
     present = lambda axes: tuple(axis for axis in axes if axis in mesh.shape)  # noqa: E731
     widened_shards = math.prod(int(mesh.shape[axis]) for axis in present(widened))

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -8,6 +8,7 @@ No load-balancing loss; router z-loss only. All layers are MoE (no dense layers)
 """
 
 import dataclasses
+import math
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -44,7 +45,7 @@ from levanter.grug.grug_moe import (
     resolve_moe_implementation,
 )
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
-from levanter.grug.sharding import Pembed_vocab, Plm_head, unshard
+from levanter.grug.sharding import Pembed_vocab, unshard
 from levanter.tracker.histogram import Histogram, SummaryStats
 from levanter.utils.activation import ActivationFunctionEnum
 from transformers import PretrainedConfig as HfConfig
@@ -59,6 +60,18 @@ GRUG_MOE_ARTIFACT_SCHEMA_VERSION = 1
 
 
 _BATCH_AXES: tuple[str, ...] = ("replica_dcn", "data", "expert")
+# FSDP axes for the non-expert weights. Expert parallelism takes its width out of
+# "data": at a fixed device count, growing "expert" shrinks "data" toward 1, so
+# sharding over both keeps attention and shared-expert weights and their optimizer
+# state split where "data" alone would replicate them on every device. This mirrors
+# _FSDP_AXES in the moe_hero_ep variant, which measured the layout at EP64.
+_FSDP_AXES: tuple[str, ...] = ("data", "expert")
+# The LM head also spans the cross-slice replica axis it had before EP.
+_LM_HEAD_AXES: tuple[str, ...] = ("replica_dcn", *_FSDP_AXES)
+# The groups these replace. A weight falls back to its pre-EP group whole rather than
+# to some smaller one, so widening can only ever add sharding, never remove it.
+_PRE_EP_FSDP_AXES: tuple[str, ...] = ("data",)
+_PRE_EP_LM_HEAD_AXES: tuple[str, ...] = ("replica_dcn", "data")
 
 
 def _mesh_axis_size(mesh: jax.sharding.AbstractMesh | None, axis_name: str) -> int:
@@ -72,6 +85,44 @@ def _mesh_axis_size(mesh: jax.sharding.AbstractMesh | None, axis_name: str) -> i
 
 
 RematMode = Literal["recompute_all", "save_moe"]
+
+
+def _shard_axes(dim: int, widened: tuple[str, ...], pre_ep: tuple[str, ...]) -> tuple[str, ...] | str | None:
+    """``widened`` when its shard count divides ``dim``, otherwise ``pre_ep``.
+
+    Adding "expert" multiplies the divisibility requirement on ``dim`` by the expert
+    axis size, which would turn shapes that shard fine without it into a hard failure
+    at model init. The fallback is the whole pre-EP group rather than a smaller one:
+    when the wider group does not fit, the resulting spec -- and any init error it
+    raises -- is exactly what it was before expert parallelism, so widening can add
+    sharding but never silently take it away.
+
+    Axes absent from the mesh are dropped, which is how a non-EP mesh with no "expert"
+    axis still initializes.
+    """
+    mesh = get_abstract_mesh()
+    present = lambda axes: tuple(axis for axis in axes if axis in mesh.shape)  # noqa: E731
+    widened_shards = math.prod(int(mesh.shape[axis]) for axis in present(widened))
+
+    axes = present(widened) if dim % widened_shards == 0 else present(pre_ep)
+    if not axes:
+        # Neither group has an axis on this mesh, so there is nothing to shard over.
+        return None
+    return axes if len(axes) > 1 else axes[0]
+
+
+def _fsdp_column_spec(dim: int) -> P:
+    """Shard a weight's leading axis of size ``dim`` over FSDP, its trailing axis over "model"."""
+    return P(_shard_axes(dim, _FSDP_AXES, _PRE_EP_FSDP_AXES), "model")
+
+
+def _fsdp_row_spec(dim: int) -> P:
+    """Shard a weight's leading axis over "model", its trailing axis of size ``dim`` over FSDP."""
+    return P("model", _shard_axes(dim, _FSDP_AXES, _PRE_EP_FSDP_AXES))
+
+
+def _lm_head_spec(dim: int) -> P:
+    return P(_shard_axes(dim, _LM_HEAD_AXES, _PRE_EP_LM_HEAD_AXES), "model")
 
 
 def _batch_spec() -> P:
@@ -278,10 +329,10 @@ class CausalSelfAttention(eqx.Module):
         k_q, k_k, k_v, k_o = random.split(key, 4)
         d, n, m, h = cfg.hidden_dim, cfg.num_heads, cfg.num_kv_heads, cfg.inferred_head_dim
         return CausalSelfAttention(
-            w_q=reshard(_init_weight(k_q, (d, n * h), cfg.initializer_std), P("data", "model")),
-            w_k=reshard(_init_weight(k_k, (d, m * h), cfg.initializer_std), P("data", "model")),
-            w_v=reshard(_init_weight(k_v, (d, m * h), cfg.initializer_std), P("data", "model")),
-            w_o=reshard(_init_weight(k_o, (n * h, d), cfg.initializer_std), P("model", "data")),
+            w_q=reshard(_init_weight(k_q, (d, n * h), cfg.initializer_std), _fsdp_column_spec(d)),
+            w_k=reshard(_init_weight(k_k, (d, m * h), cfg.initializer_std), _fsdp_column_spec(d)),
+            w_v=reshard(_init_weight(k_v, (d, m * h), cfg.initializer_std), _fsdp_column_spec(d)),
+            w_o=reshard(_init_weight(k_o, (n * h, d), cfg.initializer_std), _fsdp_row_spec(d)),
             attn_gate=reshard(jnp.zeros((d, n)), P(None, None)),
             cfg=cfg,
         )
@@ -417,9 +468,15 @@ class DenseMLP(eqx.Module):
     def init(hidden_dim: int, intermediate_dim: int, initializer_std: float, *, key: PRNGKeyArray) -> "DenseMLP":
         k_gate, k_up, k_down = random.split(key, 3)
         return DenseMLP(
-            w_gate=reshard(_init_weight(k_gate, (hidden_dim, intermediate_dim), initializer_std), P("data", "model")),
-            w_up=reshard(_init_weight(k_up, (hidden_dim, intermediate_dim), initializer_std), P("data", "model")),
-            w_down=reshard(_init_weight(k_down, (intermediate_dim, hidden_dim), initializer_std), P("model", "data")),
+            w_gate=reshard(
+                _init_weight(k_gate, (hidden_dim, intermediate_dim), initializer_std), _fsdp_column_spec(hidden_dim)
+            ),
+            w_up=reshard(
+                _init_weight(k_up, (hidden_dim, intermediate_dim), initializer_std), _fsdp_column_spec(hidden_dim)
+            ),
+            w_down=reshard(
+                _init_weight(k_down, (intermediate_dim, hidden_dim), initializer_std), _fsdp_row_spec(hidden_dim)
+            ),
         )
 
     @named_call
@@ -707,7 +764,10 @@ class Transformer(eqx.Module):
         token_embed = reshard(
             _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), cfg.initializer_std), Pembed_vocab
         )
-        output_proj = reshard(_init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head)
+        output_proj = reshard(
+            _init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std),
+            _lm_head_spec(cfg.hidden_dim),
+        )
         blocks = tuple(Block.init(cfg, key=block_keys[i]) for i in range(cfg.num_layers))
         return Transformer(
             token_embed=token_embed,

--- a/experiments/grug/moe/test_model.py
+++ b/experiments/grug/moe/test_model.py
@@ -1,0 +1,104 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import equinox as eqx
+import jax
+import pytest
+from jax.sharding import AbstractMesh, AxisType, use_abstract_mesh
+from jax.sharding import PartitionSpec as P
+
+from experiments.grug.moe.model import CausalSelfAttention, DenseMLP, GrugModelConfig, Transformer
+
+
+def _mesh(*, replica_dcn: int = 1, data: int = 1, expert: int = 1, model: int = 1) -> AbstractMesh:
+    return AbstractMesh(
+        axis_sizes=(replica_dcn, data, expert, model),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(AxisType.Explicit,) * 4,
+    )
+
+
+def _config(hidden_dim: int) -> GrugModelConfig:
+    return GrugModelConfig(
+        vocab_size=128,
+        hidden_dim=hidden_dim,
+        intermediate_dim=hidden_dim // 2,
+        shared_expert_intermediate_dim=hidden_dim,
+        num_experts=4,
+        num_experts_per_token=2,
+        num_layers=1,
+        num_heads=4,
+        num_kv_heads=1,
+    )
+
+
+def _dense_specs(mesh: AbstractMesh, hidden_dim: int) -> tuple[P, P]:
+    with use_abstract_mesh(mesh):
+        dense = eqx.filter_eval_shape(lambda: DenseMLP.init(hidden_dim, 16, 0.02, key=jax.random.key(0)))
+    return dense.w_gate.sharding.spec, dense.w_down.sharding.spec
+
+
+def _attention_specs(mesh: AbstractMesh, hidden_dim: int) -> tuple[P, P]:
+    with use_abstract_mesh(mesh):
+        attention = eqx.filter_eval_shape(lambda: CausalSelfAttention.init(_config(hidden_dim), key=jax.random.key(1)))
+    return attention.w_q.sharding.spec, attention.w_o.sharding.spec
+
+
+def _lm_head_spec(mesh: AbstractMesh, hidden_dim: int) -> P:
+    with use_abstract_mesh(mesh):
+        model = eqx.filter_eval_shape(lambda: Transformer.init(_config(hidden_dim), key=jax.random.key(2)))
+    return model.output_proj.sharding.spec
+
+
+def test_nonexpert_weights_shard_over_data_and_expert():
+    """A divisible hidden dim uses both FSDP axes, so EP does not leave these replicated."""
+    mesh = _mesh(data=2, expert=2)
+    column, row = P(("data", "expert"), "model"), P("model", ("data", "expert"))
+
+    assert _dense_specs(mesh, 32) == (column, row)
+    assert _attention_specs(mesh, 32) == (column, row)
+
+
+def test_indivisible_hidden_dim_falls_back_to_the_pre_ep_layout():
+    """Widening the shard group must not add a divisibility precondition.
+
+    hidden=12 divides data=4 but not data*expert=8, the shape class that would
+    otherwise abort model init once "expert" joined the group.
+    """
+    mesh = _mesh(data=4, expert=2)
+    column, row = P("data", "model"), P("model", "data")
+
+    assert _dense_specs(mesh, 12) == (column, row)
+    assert _attention_specs(mesh, 12) == (column, row)
+
+
+def test_hidden_dim_indivisible_by_the_pre_ep_group_still_fails_loudly():
+    """Falling back stops at the pre-EP group; it does not slide on to replication.
+
+    A geometry the pre-EP layout could not shard raised at init before EP and has to
+    keep doing so. Silently replicating every non-expert weight and its optimizer state
+    would turn a fail-fast config error into a mid-run memory blowup.
+    """
+    mesh = _mesh(data=3, expert=2)
+
+    with pytest.raises(ValueError, match="does not evenly divide"):
+        _dense_specs(mesh, 32)
+
+
+def test_a_mesh_without_an_expert_axis_uses_the_pre_ep_layout():
+    """Non-EP meshes still initialize; an axis the mesh lacks drops out of the group."""
+    mesh = AbstractMesh(
+        axis_sizes=(2, 1),
+        axis_names=("data", "model"),
+        axis_types=(AxisType.Explicit,) * 2,
+    )
+
+    assert _dense_specs(mesh, 32) == (P("data", "model"), P("model", "data"))
+
+
+def test_lm_head_widens_only_when_the_hidden_dim_divides():
+    """The head keeps the replica axis it had before EP and gains "expert" when it fits."""
+    # 8 divides replica_dcn*data*expert == 8.
+    assert _lm_head_spec(_mesh(replica_dcn=2, data=2, expert=2), 8) == P(("replica_dcn", "data", "expert"), "model")
+    # 8 divides replica_dcn*data == 4 but not replica_dcn*data*expert == 16.
+    assert _lm_head_spec(_mesh(replica_dcn=2, data=2, expert=4), 8) == P(("replica_dcn", "data"), "model")

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -49,6 +49,7 @@ from levanter.grug._moe.ep_ragged_all_to_all import _moe_mlp_ep_ragged_a2a_local
 from levanter.grug._moe.ep_ring import _moe_mlp_ep_ring_local
 from levanter.grug._moe.local import _moe_mlp_local
 from levanter.grug.sharding import (
+    _batch_spec,
     _batch_spec_from_x,
     _current_mesh,
     _drop_absent_mesh_axes,
@@ -212,6 +213,15 @@ def moe_mlp(
     if has_expert_axis and expert_axis_size > 1:
         if expert_chunks != 1:
             raise ValueError("expert_chunks must be 1 when expert parallelism is active")
+        # Expert parallelism requires the batch to be sharded over "expert" as well, so each
+        # shard owns only its 1/expert_axis_size slice of the tokens; every EP backend derives
+        # its dispatch and combine buffers from x_local. _batch_spec_from_x instead adopts
+        # whatever spec x arrives with, which may be the expert-less P(("replica_dcn", "data")).
+        # That spec hands every expert shard expert_axis_size times its own tokens, which
+        # inflates the buffers and makes the routed result wrong. Force the canonical batch
+        # spec, which names "expert"; the _reshard_for_shard_map calls below then move all
+        # three batch inputs onto it.
+        batch_spec = _batch_spec(mesh)
         if resolved_implementation not in _EP_MOE_IMPLEMENTATIONS:
             raise ValueError(
                 "Local MoE implementations do not yet support expert-parallel collectives; adding EP support "

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -500,6 +500,73 @@ def test_moe_ep_path_lowers_on_abstract_mesh(implementation: MoeImplementation):
         assert lowered is not None
 
 
+# ragged_all_to_all is omitted: XLA:CPU has no ragged-all-to-all thunk, so it cannot execute here.
+def test_moe_ep_reshards_an_expert_less_incoming_batch():
+    """An EP batch must arrive sharded over "expert" too, not just over "data".
+
+    Every EP backend derives its per-shard token slice from x_local, so a batch sharded
+    over "data" alone hands each expert shard expert_axis_size times its own tokens. The
+    routed result is then wrong, not merely oversized. This needs a real multi-device
+    mesh, so it forces one in a subprocess rather than skipping on the default backend.
+    """
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cpu"
+    env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+    script = """
+        import jax
+        import numpy as np
+        from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
+
+        from levanter.grug.grug_moe import moe_mlp
+
+        assert jax.device_count() == 4
+        mesh = Mesh(
+            np.asarray(jax.devices()).reshape(2, 2, 1),
+            axis_names=("data", "expert", "model"),
+            axis_types=(AxisType.Explicit,) * 3,
+        )
+        tokens, hidden_dim, intermediate_dim, num_experts, topk = 32, 8, 6, 4, 2
+        key = jax.random.key(28)
+        k_x, k_sel, k_logits, k_w13, k_w2 = jax.random.split(key, 5)
+        x = jax.random.normal(k_x, (tokens, hidden_dim))
+        selected_experts = jax.random.randint(k_sel, (tokens, topk), 0, num_experts, dtype=jax.numpy.int32)
+        combine_weights = jax.nn.softmax(jax.random.normal(k_logits, (tokens, topk)), axis=-1)
+        w_up_gate = jax.random.normal(k_w13, (num_experts, hidden_dim, 2 * intermediate_dim))
+        w_down = jax.random.normal(k_w2, (num_experts, intermediate_dim, hidden_dim))
+
+        def routed(implementation, batch_spec):
+            return moe_mlp(
+                jax.sharding.reshard(x, NamedSharding(mesh, batch_spec)),
+                jax.sharding.reshard(selected_experts, NamedSharding(mesh, batch_spec)),
+                jax.sharding.reshard(combine_weights, NamedSharding(mesh, batch_spec)),
+                jax.sharding.reshard(w_up_gate, NamedSharding(mesh, P("expert", None, None))),
+                jax.sharding.reshard(w_down, NamedSharding(mesh, P("expert", None, None))),
+                implementation=implementation,
+                mesh=mesh,
+                capacity_factor=1.0,
+            )
+
+        # ragged_all_to_all is omitted: XLA:CPU has no ragged-all-to-all thunk.
+        for implementation in ("ring", "fixed_all_to_all"):
+            with jax.set_mesh(mesh):
+                expected = routed(implementation, P(("data", "expert"), None))
+                out = routed(implementation, P("data", None))
+            assert out.sharding.spec == P(("data", "expert")), (implementation, out.sharding.spec)
+            np.testing.assert_allclose(np.asarray(out), np.asarray(expected), rtol=1e-5, atol=1e-5)
+        print("__assertions_ran__")
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "__assertions_ran__" in result.stdout, result.stdout
+
+
 def test_fixed_all_to_all_drops_assignments_over_capacity():
     mesh = Mesh(
         np.asarray([jax.devices()[0]]),

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -501,6 +501,27 @@ def test_moe_ep_path_lowers_on_abstract_mesh(implementation: MoeImplementation):
 
 
 # ragged_all_to_all is omitted: XLA:CPU has no ragged-all-to-all thunk, so it cannot execute here.
+def _run_on_forced_cpu_devices(script: str, *, devices: int) -> None:
+    """Run ``script`` on a forced multi-device CPU backend and require it to assert.
+
+    Meshes taken from whatever the default backend offers collapse to one device on the
+    ordinary test run, which silently skips the multi-device behavior. The sentinel keeps
+    a script that exits 0 without reaching its assertions from passing.
+    """
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cpu"
+    env["XLA_FLAGS"] = f"--xla_force_host_platform_device_count={devices}"
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script) + '\nprint("__assertions_ran__")\n'],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "__assertions_ran__" in result.stdout, result.stdout
+
+
 def test_moe_ep_reshards_an_expert_less_incoming_batch():
     """An EP batch must arrive sharded over "expert" too, not just over "data".
 
@@ -509,10 +530,8 @@ def test_moe_ep_reshards_an_expert_less_incoming_batch():
     routed result is then wrong, not merely oversized. This needs a real multi-device
     mesh, so it forces one in a subprocess rather than skipping on the default backend.
     """
-    env = os.environ.copy()
-    env["JAX_PLATFORMS"] = "cpu"
-    env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
-    script = """
+    _run_on_forced_cpu_devices(
+        """
         import jax
         import numpy as np
         from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
@@ -553,18 +572,9 @@ def test_moe_ep_reshards_an_expert_less_incoming_batch():
                 out = routed(implementation, P("data", None))
             assert out.sharding.spec == P(("data", "expert")), (implementation, out.sharding.spec)
             np.testing.assert_allclose(np.asarray(out), np.asarray(expected), rtol=1e-5, atol=1e-5)
-        print("__assertions_ran__")
-    """
-    result = subprocess.run(
-        [sys.executable, "-c", textwrap.dedent(script)],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
+        """,
+        devices=4,
     )
-
-    assert result.returncode == 0, result.stderr
-    assert "__assertions_ran__" in result.stdout, result.stdout
 
 
 def test_fixed_all_to_all_drops_assignments_over_capacity():
@@ -650,10 +660,8 @@ def test_fixed_all_to_all_drops_assignments_over_capacity():
 
 
 def test_fixed_all_to_all_matches_dense_cross_shard_value_and_gradients():
-    env = os.environ.copy()
-    env["JAX_PLATFORMS"] = "cpu"
-    env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
-    script = """
+    _run_on_forced_cpu_devices(
+        """
         import jax
         import jax.numpy as jnp
         import numpy as np
@@ -731,16 +739,9 @@ def test_fixed_all_to_all_matches_dense_cross_shard_value_and_gradients():
                 rtol=1e-5,
                 atol=1e-5,
             )
-    """
-    result = subprocess.run(
-        [sys.executable, "-c", textwrap.dedent(script)],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
+        """,
+        devices=4,
     )
-
-    assert result.returncode == 0, result.stderr
 
 
 def test_fixed_all_to_all_backward_has_no_scatter():

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -743,6 +743,55 @@ def test_fixed_all_to_all_matches_dense_cross_shard_value_and_gradients():
     assert result.returncode == 0, result.stderr
 
 
+def test_fixed_all_to_all_backward_has_no_scatter():
+    """The dispatch and combine custom VJPs exist to keep scatter out of the backward.
+
+    Their values match plain autodiff, so only the lowered backward distinguishes them:
+    dropping either defvjp restores XLA's generic scatter-add transpose.
+    """
+    mesh = Mesh(
+        np.asarray([jax.devices()[0]]),
+        axis_names=("expert",),
+        axis_types=(AxisType.Explicit,),
+    )
+    tokens, hidden_dim, intermediate_dim, num_experts, topk = 8, 6, 8, 4, 2
+    x, selected_experts, combine_weights, w_up_gate, w_down = _make_inputs(
+        key=jax.random.key(17),
+        tokens=tokens,
+        hidden_dim=hidden_dim,
+        intermediate_dim=intermediate_dim,
+        num_experts=num_experts,
+        topk=topk,
+    )
+
+    def routed(x, combine_weights, w_up_gate, w_down):
+        output, _ = _moe_mlp_ep_fixed_a2a_local(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=jax.nn.silu,
+            num_experts=num_experts,
+            capacity_factor=0.5,
+        )
+        return output
+
+    sharded = jax.shard_map(
+        routed,
+        mesh=mesh,
+        in_specs=(P(), P(), P(), P()),
+        out_specs=P(),
+        check_vma=False,
+    )
+    seed_cotangent = jax.random.normal(jax.random.key(19), (tokens, hidden_dim))
+    with jax.set_mesh(mesh):
+        _, pullback = jax.vjp(sharded, x, combine_weights, w_up_gate, w_down)
+        backward = jax.jit(pullback).lower(seed_cotangent)
+
+    assert "stablehlo.scatter" not in str(backward.compiler_ir(dialect="stablehlo"))
+
+
 def test_shard_a2a_params_uses_sender_side_output_offsets():
     shard_counts = jnp.array(
         [


### PR DESCRIPTION
Carries over three fixes from #7780 that #7890 did not reproduce when it landed the
expert-parallel MoE work. #7890 independently rebuilt most of that branch, including the
fixed-capacity all-to-all, gather dispatch, both structured `custom_vjp`s, and the
Newton-Schulz `target_sharding` and two-hop reshard fixes it vendored into
`grugmuon_hero.py`. These three did not survive.

`moe_mlp` took its `shard_map` spec from `_batch_spec_from_x`, which adopts whatever spec
`x` arrives with, and that may be the expert-less `P(("replica_dcn", "data"))`. Every EP
backend derives its per-shard token slice from `x_local`, so a batch on that spec hands
each expert shard `expert_axis_size` times its own tokens and the routed result is wrong,
not merely oversized. On four CPU devices with `ring`, the maximum absolute difference
against a correctly sharded batch is 21.3 on a result of norm 183. The EP path now forces
the canonical batch spec; callers already passing an expert-sharded batch are unaffected.

`experiments/grug/moe` sharded its attention weights, dense-MLP weights and LM head over
`data` alone, so at EP64 on one rack they and their optimizer state end up replicated on
every device. `moe_hero_ep` already measured the wider `("data", "expert")` layout at that
scale, and this brings the template it was copied from in line. Widening also multiplies
the divisibility requirement on `hidden_dim` by the expert axis size: d2560 on 1024 GPUs
at EP8 needs `2560 % 1024 == 0` and gets 512, so shapes that shard fine over `data` alone
would abort at model init. `_shard_axes` falls back to the whole pre-EP group in that
case, never to a smaller one, so the resulting spec and any error it raises are exactly
what they were before expert parallelism. Across 80 mesh geometries and six hidden dims
the new spec never shards less than the old one and never turns a divisible configuration
indivisible.

The dispatch and combine `custom_vjp`s added by #7890 exist to keep XLA's scatter-add
transpose out of the fixed-capacity backward, but their values match plain autodiff, so
the existing value and gradient tests pass with either `defvjp` removed. The new test
asserts on the lowered backward, which is the only place the two differ.

Two changes from #7780 are deliberately not carried. Same-step spill of overflow
assignments was measured at 24.083% MFU against 24.123% for the stack #7890 selected, so
it was rejected on evidence rather than missed. The library `grugmuon.py` changes target
functions that do not exist on main; they came from #7779, which is closed. Snowball and
`june_tpu_67b_a2b` are pinned recipes and keep the dense layout.

Verified on CPU only, with no accelerator run. Each new test was mutation-probed: the
batch-spec test fails on the default single-device suite when the fix is reverted, the
backward test fails when either `defvjp` is dropped, and the sharding tests fail both when
`expert` is removed from the group and when the fallback is allowed to slide past the
pre-EP group to full replication.

Part of #7279.
