### PR TITLE
[iris] Keep non-HTTP endpoints out of the native proxy

### DIFF
--- a/lib/iris/src/iris/cluster/controller/endpoint_service.py
+++ b/lib/iris/src/iris/cluster/controller/endpoint_service.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from threading import RLock
 from typing import Any
+from urllib.parse import urlsplit
 
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
@@ -116,6 +117,15 @@ class ProxyRegistrySnapshot:
     endpoints: tuple[ProxyEndpointMapping, ...]
 
 
+def _proxyable_address(address: str) -> bool:
+    candidate = address if "://" in address else f"http://{address}"
+    try:
+        parsed = urlsplit(candidate)
+    except ValueError:
+        return False
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
 class EndpointServiceImpl:
     """Leased service-discovery registry over the shared endpoints projection."""
 
@@ -156,7 +166,7 @@ class EndpointServiceImpl:
             generation = self._proxy_generation
             system_endpoints = tuple(self._system_endpoints.items())
             task_endpoints = tuple(self._db.caches[EndpointsProjection].all())
-        mappings = tuple(self._task_proxy_mapping(row) for row in task_endpoints)
+        mappings = tuple(mapping for row in task_endpoints if (mapping := self._task_proxy_mapping(row)) is not None)
         mappings += tuple(self._system_proxy_mapping(name, address) for name, address in system_endpoints)
         return ProxyRegistrySnapshot(generation=generation, endpoints=mappings)
 
@@ -164,9 +174,17 @@ class EndpointServiceImpl:
         if isinstance(mutation, EndpointReset):
             self._publish_proxy_reset()
             return
+        upserts: list[ProxyEndpointMapping] = []
+        deletes = list(mutation.deletes)
+        for row in mutation.upserts:
+            mapping = self._task_proxy_mapping(row)
+            if mapping is None:
+                deletes.append(row.endpoint_id)
+            else:
+                upserts.append(mapping)
         self._publish_proxy_delta(
-            upserts=tuple(self._task_proxy_mapping(row) for row in mutation.upserts),
-            deletes=mutation.deletes,
+            upserts=tuple(upserts),
+            deletes=tuple(deletes),
         )
 
     def _publish_proxy_delta(
@@ -197,7 +215,9 @@ class EndpointServiceImpl:
             listener(ProxyRegistryReset())
 
     @staticmethod
-    def _task_proxy_mapping(row: EndpointRow) -> ProxyEndpointMapping:
+    def _task_proxy_mapping(row: EndpointRow) -> ProxyEndpointMapping | None:
+        if not _proxyable_address(row.address):
+            return None
         return ProxyEndpointMapping(
             endpoint_id=row.endpoint_id,
             name=row.name,

--- a/lib/iris/tests/cluster/controller/test_endpoints.py
+++ b/lib/iris/tests/cluster/controller/test_endpoints.py
@@ -211,6 +211,40 @@ def test_proxy_registry_publishes_deltas_and_snapshots(state):
     assert deltas[-1].deletes == ("endpoint-1",)
 
 
+def test_proxy_registry_omits_tcp_endpoint_without_hiding_it(state):
+    task, attempt = _live_task(state)
+    service = _service(state)
+    updates = []
+    service.subscribe_proxy_updates(updates.append)
+    service.register_system_endpoint("/system/log-server", "http://logs:9000")
+    updates.clear()
+
+    service.register_endpoint(
+        _register_request(
+            "jax-coordinator",
+            task,
+            attempt_id=attempt,
+            endpoint_id="tcp-endpoint",
+            address="tcp://10.0.0.1:8476",
+        ),
+        None,
+    )
+
+    [delta] = updates
+    assert delta.upserts == ()
+    assert delta.deletes == ("tcp-endpoint",)
+    assert [mapping.endpoint_id for mapping in service.proxy_registry_snapshot().endpoints] == [
+        "system:/system/log-server"
+    ]
+    listed = service.list_endpoints(
+        controller_pb2.Controller.ListEndpointsRequest(prefix="jax-coordinator", exact=True),
+        None,
+    )
+    assert [(endpoint.endpoint_id, endpoint.address) for endpoint in listed.endpoints] == [
+        ("tcp-endpoint", "tcp://10.0.0.1:8476")
+    ]
+
+
 def test_proxy_registry_requires_snapshot_after_database_replace(state, tmp_path: Path):
     service = _service(state)
     updates = []


### PR DESCRIPTION
Exclude task endpoints with non-HTTP(S) addresses from native proxy snapshots
and deltas while retaining them in the general EndpointService registry. A
`tcp://` registration on `cw-us-east-08a` previously made every full proxy
snapshot fail, so unrelated Finelog requests returned
`503 endpoint registry unavailable` while direct Finelog health returned 200.

Publish a delete to the native proxy for filtered upserts so an endpoint that
changes protocols cannot leave a stale route.
