### PR TITLE
[zephyr] Bound scatter flush and external-sort memory

### DIFF
--- a/lib/zephyr/src/zephyr/external_sort.py
+++ b/lib/zephyr/src/zephyr/external_sort.py
@@ -3,9 +3,8 @@
 
 """Bounded external merge sort over Polars LazyFrame streams.
 
-Used by the reduce stage when the number of scatter chunks exceeds
-``EXTERNAL_SORT_FAN_IN`` or the estimated merge memory exceeds the worker
-budget.
+The reduce stage uses this when an in-memory merge of its scatter chunks would
+exceed the task memory budget.
 
 The first pass consumes the input frames in groups of ``fan_in`` frames. Each
 group produces a sorted Parquet run. Later passes merge at most
@@ -15,11 +14,19 @@ count. The function deletes all run files after completion or an error.
 
 import logging
 from collections.abc import Iterator
+from typing import NamedTuple
 
 import polars as pl
 from rigging.filesystem import open_url, url_to_fs
 
 logger = logging.getLogger(__name__)
+
+
+class _SpillRun(NamedTuple):
+    """One sorted run file, addressed both as a URL and as a filesystem path."""
+
+    url: str
+    path: str
 
 
 def external_sort_merge(
@@ -66,18 +73,17 @@ def external_sort_merge(
 
     spill_files: set[str] = set()
 
-    def write_run(frames: list[pl.LazyFrame], pass_index: int, run_index: int) -> tuple[str, str]:
+    def write_run(frames: list[pl.LazyFrame], pass_index: int, run_index: int) -> _SpillRun:
         run_name = f"pass-{pass_index:04d}-run-{run_index:04d}.spill"
-        run_url = f"{external_sort_dir}/{run_name}"
-        run_path = f"{spill_dir}/{run_name}"
-        spill_files.add(run_path)
+        run = _SpillRun(url=f"{external_sort_dir}/{run_name}", path=f"{spill_dir}/{run_name}")
+        spill_files.add(run.path)
         merged = pl.merge_sorted(frames, key=sort_key)
-        with open_url(run_url, "wb") as output:
+        with open_url(run.url, "wb") as output:
             merged.sink_parquet(output, compression="zstd")
-        return run_url, run_path
+        return run
 
-    def delete_runs(runs: list[tuple[str, str]]) -> None:
-        paths = [path for _, path in runs]
+    def delete_runs(runs: list[_SpillRun]) -> None:
+        paths = [run.path for run in runs]
         if not paths:
             return
         spill_fs.rm(paths)
@@ -85,11 +91,11 @@ def external_sort_merge(
 
     try:
         batches = [input_frames[i : i + fan_in] for i in range(0, len(input_frames), fan_in)]
-        runs: list[tuple[str, str]] = []
+        runs: list[_SpillRun] = []
         for run_index, batch in enumerate(batches):
             run = write_run(batch, pass_index=0, run_index=run_index)
             runs.append(run)
-            logger.info("[shard %d] External sort: wrote run %d to %s", shard, run_index, run[0])
+            logger.info("[shard %d] External sort: wrote run %d to %s", shard, run_index, run.url)
 
         pass_index = 1
         while len(runs) > max_merge_fan_in:
@@ -100,8 +106,8 @@ def external_sort_merge(
                 len(runs),
                 max_merge_fan_in,
             )
-            next_runs: list[tuple[str, str]] = []
-            consumed_runs: list[tuple[str, str]] = []
+            next_runs: list[_SpillRun] = []
+            consumed_runs: list[_SpillRun] = []
             run_batches = [runs[i : i + max_merge_fan_in] for i in range(0, len(runs), max_merge_fan_in)]
             for run_index, run_batch in enumerate(run_batches):
                 if len(run_batch) == 1:
@@ -109,7 +115,7 @@ def external_sort_merge(
                     continue
                 next_runs.append(
                     write_run(
-                        [pl.scan_parquet(run_url) for run_url, _ in run_batch],
+                        [pl.scan_parquet(run.url) for run in run_batch],
                         pass_index=pass_index,
                         run_index=run_index,
                     )
@@ -120,7 +126,7 @@ def external_sort_merge(
             pass_index += 1
 
         logger.info("[shard %d] External sort: final merge of %d run files", shard, len(runs))
-        merged = pl.merge_sorted([pl.scan_parquet(run_url) for run_url, _ in runs], key=sort_key)
+        merged = pl.merge_sorted([pl.scan_parquet(run.url) for run in runs], key=sort_key)
         yield from merged.collect_batches()
     finally:
         if spill_files:

--- a/lib/zephyr/src/zephyr/external_sort.py
+++ b/lib/zephyr/src/zephyr/external_sort.py
@@ -1,22 +1,18 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Two-pass external merge sort over Polars LazyFrame streams.
+"""Bounded external merge sort over Polars LazyFrame streams.
 
 Used by the reduce stage when the number of scatter chunks exceeds
 ``EXTERNAL_SORT_FAN_IN`` or the estimated merge memory exceeds the worker
 budget.
 
-Pass 1: consume the input LazyFrame stream in groups of ``fan_in`` frames.
-Merge each group with :func:`polars.merge_sorted` and spill the sorted result
-to a zstd-compressed parquet run file.
-
-Pass 2: read all run files via :func:`polars.scan_parquet`, merge with
-:func:`polars.merge_sorted`, and yield DataFrame batches. Run files are
-deleted after the merge completes (or on error).
+The first pass consumes the input frames in groups of ``fan_in`` frames. Each
+group produces a sorted Parquet run. Later passes merge at most
+``max_merge_fan_in`` runs. Thus, the final streaming merge has a bounded input
+count. The function deletes all run files after completion or an error.
 """
 
-import io
 import logging
 from collections.abc import Iterator
 
@@ -31,16 +27,15 @@ def external_sort_merge(
     sort_key: str,
     external_sort_dir: str,
     fan_in: int,
+    max_merge_fan_in: int,
     shard: int,
 ) -> Iterator[pl.DataFrame]:
-    """Merge pre-sorted LazyFrames via a two-pass external sort with spill files.
+    """Merge sorted LazyFrames with a bounded external sort.
 
-    Pass 1 groups ``input_frames`` into batches of at most ``fan_in`` frames,
-    merges each batch with :func:`polars.merge_sorted`, and writes the result to
-    a zstd-compressed parquet run file under ``external_sort_dir``. Pass 2 scans
-    all run files, merges them again with :func:`polars.merge_sorted`, and
-    streams the result as DataFrame batches. Run files are deleted when pass 2
-    finishes (or on error).
+    The first pass merges groups of at most ``fan_in`` frames. Additional
+    passes limit each merge to ``max_merge_fan_in`` runs. The final merge
+    streams DataFrame batches. The function deletes run files after completion
+    or an error.
 
     Args:
         input_frames: LazyFrames already sorted ascending on ``sort_key``. Order
@@ -51,6 +46,7 @@ def external_sort_merge(
             temp dir or ``gs://.../stage1-external-sort/shard-NNNN``).
         fan_in: Maximum frames merged in one pass-1 group; bounds peak memory
             during pass 1. Callers typically use ``ceil(sqrt(n_chunks))``.
+        max_merge_fan_in: Maximum run files in all later merges.
         shard: Target shard id for log messages only.
 
     Yields:
@@ -58,38 +54,77 @@ def external_sort_merge(
     """
     if len(input_frames) == 0:
         return
+    if fan_in < 1:
+        raise ValueError(f"fan_in must be at least 1, got {fan_in}")
+    if max_merge_fan_in < 2:
+        raise ValueError(f"max_merge_fan_in must be at least 2, got {max_merge_fan_in}")
 
     spill_fs, spill_dir = url_to_fs(external_sort_dir)
     spill_fs.makedirs(spill_dir, exist_ok=True)
 
     logger.info("[shard %d] External sort: pass-1 fan_in=%d", shard, fan_in)
 
-    spill_files: list[str] = []
+    spill_files: set[str] = set()
+
+    def write_run(frames: list[pl.LazyFrame], pass_index: int, run_index: int) -> tuple[str, str]:
+        run_name = f"pass-{pass_index:04d}-run-{run_index:04d}.spill"
+        run_url = f"{external_sort_dir}/{run_name}"
+        run_path = f"{spill_dir}/{run_name}"
+        spill_files.add(run_path)
+        merged = pl.merge_sorted(frames, key=sort_key)
+        with open_url(run_url, "wb") as output:
+            merged.sink_parquet(output, compression="zstd")
+        return run_url, run_path
+
+    def delete_runs(runs: list[tuple[str, str]]) -> None:
+        paths = [path for _, path in runs]
+        if not paths:
+            return
+        spill_fs.rm(paths)
+        spill_files.difference_update(paths)
 
     try:
-        # TODO: When we upgrade to Python 3.12, use itertools.batched
         batches = [input_frames[i : i + fan_in] for i in range(0, len(input_frames), fan_in)]
-        for idx, batch in enumerate(batches):
-            merged = pl.merge_sorted(batch, key=sort_key).collect()
+        runs: list[tuple[str, str]] = []
+        for run_index, batch in enumerate(batches):
+            run = write_run(batch, pass_index=0, run_index=run_index)
+            runs.append(run)
+            logger.info("[shard %d] External sort: wrote run %d to %s", shard, run_index, run[0])
 
-            spill_file = f"{external_sort_dir}/run-{idx:04d}.spill"
-            buf = io.BytesIO()
-            merged.write_parquet(buf, compression="zstd")
-            with open_url(spill_file, "wb") as f:
-                f.write(buf.getvalue())
+        pass_index = 1
+        while len(runs) > max_merge_fan_in:
+            logger.info(
+                "[shard %d] External sort: pass %d merging %d runs with max fan-in %d",
+                shard,
+                pass_index,
+                len(runs),
+                max_merge_fan_in,
+            )
+            next_runs: list[tuple[str, str]] = []
+            consumed_runs: list[tuple[str, str]] = []
+            run_batches = [runs[i : i + max_merge_fan_in] for i in range(0, len(runs), max_merge_fan_in)]
+            for run_index, run_batch in enumerate(run_batches):
+                if len(run_batch) == 1:
+                    next_runs.extend(run_batch)
+                    continue
+                next_runs.append(
+                    write_run(
+                        [pl.scan_parquet(run_url) for run_url, _ in run_batch],
+                        pass_index=pass_index,
+                        run_index=run_index,
+                    )
+                )
+                consumed_runs.extend(run_batch)
+            delete_runs(consumed_runs)
+            runs = next_runs
+            pass_index += 1
 
-            spill_files.append(spill_file)
-            logger.info("[shard %d] External sort: wrote run %d to %s", shard, idx, spill_file)
-
-        logger.info("[shard %d] External sort: pass-2 merging %d run files", shard, len(spill_files))
-
-        merged = pl.merge_sorted([pl.scan_parquet(p) for p in spill_files], key=sort_key)
+        logger.info("[shard %d] External sort: final merge of %d run files", shard, len(runs))
+        merged = pl.merge_sorted([pl.scan_parquet(run_url) for run_url, _ in runs], key=sort_key)
         yield from merged.collect_batches()
     finally:
         if spill_files:
             try:
-                spill_fs.rm([f"{spill_dir}/run-{i:04d}.spill" for i in range(len(spill_files))])
+                spill_fs.rm(sorted(spill_files))
             except Exception:
-                # Spill files live under a per-shard temp dir that the worker
-                # eventually wipes; log so leaked files are at least traceable.
                 logger.warning("Failed to delete external-sort run files under %s", spill_dir, exc_info=True)

--- a/lib/zephyr/src/zephyr/runners.py
+++ b/lib/zephyr/src/zephyr/runners.py
@@ -24,6 +24,7 @@ package initialization (which would trip a ``runpy`` re-execution warning).
 """
 
 import logging
+import math
 import os
 import re
 import signal
@@ -313,6 +314,7 @@ def _run_stage_with_ctx(
     task: ShardTask,
     chunk_prefix: str,
     execution_id: str,
+    external_sort_dir: str | None = None,
 ) -> TaskResult:
     """Run one ShardTask in the active worker context, writing stage output to disk.
 
@@ -329,7 +331,8 @@ def _run_stage_with_ctx(
     )
     output_stage_name = re.sub(r"[^a-zA-Z0-9_.-]+", "-", task.stage_name).strip("-")
     stage_dir = f"{chunk_prefix}/{execution_id}/{output_stage_name}"
-    external_sort_dir = f"{stage_dir}-external-sort/shard-{task.shard_idx:04d}"
+    if external_sort_dir is None:
+        external_sort_dir = f"{stage_dir}-external-sort/shard-{task.shard_idx:04d}"
     scatter_op = next((op for op in task.operations if isinstance(op, Scatter)), None)
     return _write_stage_output(
         _wrap_stage_stats(run_stage(stage_ctx, task.operations, external_sort_dir=external_sort_dir)),
@@ -423,11 +426,23 @@ class SubprocessRunner:
             # ``-u`` keeps the child's stdout/stderr unbuffered so any
             # faulthandler traceback reaches the parent's log before the
             # process dies.
-            proc = sp.run(
-                [sys.executable, "-u", "-m", "zephyr.shard_subprocess", task_file, result_file],
-                stdout=sys.stdout,
-                stderr=sys.stderr,
-            )
+            child_env = os.environ.copy()
+            child_env["POLARS_MAX_THREADS"] = str(max(1, math.ceil(task.cost.cpu)))
+            with tempfile.TemporaryDirectory(prefix=f"zephyr-external-sort-{task.shard_idx:04d}-") as sort_dir:
+                proc = sp.run(
+                    [
+                        sys.executable,
+                        "-u",
+                        "-m",
+                        "zephyr.shard_subprocess",
+                        task_file,
+                        result_file,
+                        sort_dir,
+                    ],
+                    env=child_env,
+                    stdout=sys.stdout,
+                    stderr=sys.stderr,
+                )
 
             if proc.returncode != 0:
                 # Linux OOM-killer sends SIGKILL → returncode == -9. Distinguish

--- a/lib/zephyr/src/zephyr/shard_subprocess.py
+++ b/lib/zephyr/src/zephyr/shard_subprocess.py
@@ -90,7 +90,7 @@ def _periodic_status_logger(
         )
 
 
-def _execute_shard_subprocess(task_file: str, result_file: str) -> None:
+def _execute_shard_subprocess(task_file: str, result_file: str, external_sort_dir: str) -> None:
     """Subprocess child body: runs one ShardTask and writes the result file."""
     # Each shard already runs in its own subprocess; redundant Arrow thread
     # pools just compete with the parent's shard-level parallelism.
@@ -150,7 +150,12 @@ def _execute_shard_subprocess(task_file: str, result_file: str) -> None:
                 status_logger.start()
 
                 try:
-                    result_or_error = _run_stage_with_ctx(task, chunk_prefix, execution_id)
+                    result_or_error = _run_stage_with_ctx(
+                        task,
+                        chunk_prefix,
+                        execution_id,
+                        external_sort_dir=external_sort_dir,
+                    )
                 finally:
                     stop_event.set()
                     flusher.join(timeout=2.0)
@@ -176,8 +181,11 @@ def _execute_shard_subprocess(task_file: str, result_file: str) -> None:
 
 
 def _subprocess_main() -> None:
-    if len(sys.argv) != 3:
-        print("Usage: python -m zephyr.shard_subprocess <task_file> <result_file>", file=sys.stderr)
+    if len(sys.argv) != 4:
+        print(
+            "Usage: python -m zephyr.shard_subprocess <task_file> <result_file> <external_sort_dir>",
+            file=sys.stderr,
+        )
         os._exit(1)
     # Bypass interpreter shutdown: PyArrow GCS/Azure filesystem background
     # threads can race with module GC and fire ``std::terminate`` → SIGABRT,
@@ -186,7 +194,7 @@ def _subprocess_main() -> None:
     # one-shot child needs ``atexit`` / ``__del__`` to run.
     exit_code = 0
     try:
-        _execute_shard_subprocess(sys.argv[1], sys.argv[2])
+        _execute_shard_subprocess(sys.argv[1], sys.argv[2], sys.argv[3])
     except BaseException:
         traceback.print_exc()
         exit_code = 1

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -108,6 +108,8 @@ _SCATTER_READ_PYTHON_ROW_OVERHEAD = 2
 _PROGRESS_LOG_INTERVAL_SECONDS = 60.0
 # Polars streaming chunk size, important to avoid excessive memory usage during merge.
 _POLARS_STREAMING_CHUNK_SIZE = 10000
+# Maximum run files that Polars merges at one time during an external sort.
+_EXTERNAL_SORT_MAX_MERGE_FAN_IN = 32
 
 # Helper column names injected by _items_to_dataframe and stripped before
 # writing to disk.  Both are internal implementation details; user schemas must
@@ -123,14 +125,27 @@ _SORT_VALUE_TMP_COL = "__zephyr_sort_value_tmp__"
 
 # Python items consumed before creating a DataFrame.
 _DATAFRAME_ROW_COUNT = 1000
-# Flush all scatter buffers when the buffer's estimated size exceeds this fraction of available memory.
-_SCATTER_FLUSH_THRESHOLD = 0.75
+# Flush all scatter buffers when the buffer's estimated size exceeds this fraction of task memory.
+_SCATTER_FLUSH_THRESHOLD = 0.20
 # Empirically measured ratio of DataFrame.estimated_size() to actual per-shard process RSS growth,
 # across three datasets (nemotron: 0.54-0.60, skewed: 0.59-0.66, FineWeb-Edu: 0.66-0.70).
-# Applied to _SCATTER_FLUSH_THRESHOLD so the effective trigger is ~45% of available memory.
+# Applied to _SCATTER_FLUSH_THRESHOLD so the effective trigger is 12% of task memory. The 2.27x
+# flush peak was measured during the 2026-08-02 fuzzy-dedup incident: https://echo.oa.dev/wiki/68.
 _ESTIMATED_SIZE_CORRECTION_FACTOR = 0.60
 # Threshold for triggering a gc.collect() after a flush.
 _GC_FLUSH_SIZE_THRESHOLD_BYTES = 8 * 1024 * 1024
+
+
+def _task_memory_bytes() -> int:
+    ctx = _worker_ctx_var.get()
+    if ctx is not None and ctx.task_memory_bytes > 0:
+        return ctx.task_memory_bytes
+
+    memory_bytes = TaskResources.from_environment().memory_bytes
+    if memory_bytes <= 0:
+        logger.warning("No task memory is available. Using a 1 GiB memory budget.")
+        return 1024 * 1024 * 1024
+    return memory_bytes
 
 
 def _dataframe_to_items(df: pl.DataFrame) -> Iterator[Any]:
@@ -448,13 +463,7 @@ class ScatterReader:
             # Overhead per row in the Polars DataFrame plus the deserialized Python object.
             # Future Polars-only processing would remove the Python overhead.
             overhead = _SCATTER_READ_POLARS_ROW_OVERHEAD * _SCATTER_READ_PYTHON_ROW_OVERHEAD
-            ctx = _worker_ctx_var.get()
-            if ctx is not None and ctx.task_memory_bytes > 0:
-                memory_bytes = ctx.task_memory_bytes
-            else:
-                memory_bytes = TaskResources.from_environment().memory_bytes
-                if memory_bytes <= 0:
-                    memory_bytes = 1024 * 1024 * 1024
+            memory_bytes = _task_memory_bytes()
 
             if estimated_merge_memory_bytes * overhead > memory_bytes * _SCATTER_READ_MEMORY_FRACTION:
                 fan_in = math.ceil(math.sqrt(self.total_chunks))
@@ -474,6 +483,7 @@ class ScatterReader:
                     sort_key=_SORT_KEY_COL,
                     external_sort_dir=external_sort_dir,
                     fan_in=fan_in,
+                    max_merge_fan_in=_EXTERNAL_SORT_MAX_MERGE_FAN_IN,
                     shard=self._target_shard,
                 )
 
@@ -539,10 +549,7 @@ class ScatterWriter:
 
         self._source_shard = source_shard
         self._combiner_fn = combiner_fn
-        self._memory_available_bytes = TaskResources.from_environment().memory_bytes
-        if self._memory_available_bytes == 0:
-            logger.warning("No memory available for scatter write, defaulting to 1GB. This will likely fail.")
-            self._memory_available_bytes = 1024 * 1024 * 1024
+        self._memory_available_bytes = _task_memory_bytes()
         # estimated_size() measures only the buffer columns, not process overhead (Python runtime,
         # Arrow allocator, Parquet scan). The correction factor maps estimated_size to estimated RSS.
         self._flush_threshold_bytes = int(

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -14,8 +14,9 @@ On the read side, each reducer scans only its target shard via
 ``pl.scan_parquet(path).filter(pl.col(_SHARD_COL) == target).drop(_SHARD_COL)``.
 Polars predicate pushdown with row-group statistics skips non-matching row
 groups via byte-range GETs, so each reducer reads roughly 1/N of each file.
-The resulting LazyFrames are merged via ``external_sort_merge`` (two-pass
-fan-in merge with ``sink_parquet`` pass-1, fully streaming).
+The resulting LazyFrames are merged via ``external_sort_merge``: a fully
+streaming multi-pass merge that writes runs with ``sink_parquet`` and keeps
+every merge below ``_EXTERNAL_SORT_MAX_MERGE_FAN_IN`` inputs.
 
 Write-side memory is bounded by buffer estimated size: when the sum of
 ``DataFrame.estimated_size()`` across buffered frames exceeds

--- a/lib/zephyr/tests/test_runners.py
+++ b/lib/zephyr/tests/test_runners.py
@@ -8,6 +8,7 @@ import time
 import uuid
 from contextlib import suppress
 
+import polars as pl
 import pytest
 from finelog.client import LogClient
 from finelog.embedded import EmbeddedServer
@@ -54,6 +55,29 @@ def test_simple_map(local_client, tmp_path, runner_factory):
     finally:
         ctx.shutdown()
     assert sorted(results) == [3, 6, 9, 12, 15]
+
+
+def test_subprocess_runner_limits_polars_threads_to_task_cpu(local_client, tmp_path):
+    def polars_thread_pool_size(_: int) -> int:
+        return pl.thread_pool_size()
+
+    ctx = ZephyrContext(
+        client=local_client,
+        max_workers=1,
+        resources=ResourceConfig(cpu=4, ram="512m"),
+        chunk_storage_prefix=str(tmp_path / "chunks"),
+        name=f"test-polars-threads-{uuid.uuid4().hex[:8]}",
+        stage_runner_factory=lambda: SubprocessRunner(),
+    )
+    try:
+        results = ctx.execute(
+            Dataset.from_list([0]).map(polars_thread_pool_size),
+            map_task_resources=ResourceConfig(cpu=1, ram="256m"),
+        ).results
+    finally:
+        ctx.shutdown()
+
+    assert results == [1]
 
 
 def test_user_counters_propagate(local_client, tmp_path, runner_factory):

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -388,6 +388,38 @@ def test_scatter_byte_budget_preserves_all_items(tmp_path):
     assert sorted(recovered, key=lambda x: x["v"]) == sorted(items, key=lambda x: x["v"])
 
 
+def test_scatter_auto_flush_uses_task_memory_budget(tmp_path):
+    """A multiplexed shard flushes against its task budget, not the worker pod limit."""
+    items = [{"k": 0, "v": i} for i in range(100)]
+    frame = _items_to_dataframe(items, _key, None, 1)
+    task_memory_bytes = int(frame.estimated_size()) * 3
+    ctx = _InProcessWorkerContext(
+        chunk_prefix="test",
+        execution_id="test",
+        stage_name="test",
+        task_memory_bytes=task_memory_bytes,
+    )
+    token = _worker_ctx_var.set(ctx)
+    try:
+        with patch("zephyr.shuffle.TaskResources.from_environment") as environment_resources:
+            environment_resources.return_value = TaskResources(
+                memory_bytes=1024**3,
+                cpu_cores=1,
+                gpu_count=0,
+                tpu_count=0,
+            )
+            writer = ScatterWriter(data_path=str(tmp_path / "scatter"), key_fn=_key, source_shard=0)
+            writer.write(frame)
+            writer.write(frame)
+            scatter_paths = list(writer.close())
+    finally:
+        _worker_ctx_var.reset(token)
+
+    shard = ScatterReader.from_sidecars(scatter_paths, 0)
+    assert shard.total_chunks == 2
+    assert sorted(row["v"] for row in _read_shard(shard)) == sorted([*range(100), *range(100)])
+
+
 # ---------------------------------------------------------------------------
 # external_sort_merge
 # ---------------------------------------------------------------------------
@@ -409,6 +441,7 @@ def _external_sort_items(
     sort_key: str,
     external_sort_dir: str,
     fan_in: int,
+    max_merge_fan_in: int = 32,
     shard: int,
 ) -> list:
     merged = external_sort_merge(
@@ -416,6 +449,7 @@ def _external_sort_items(
         sort_key=sort_key,
         external_sort_dir=external_sort_dir,
         fan_in=fan_in,
+        max_merge_fan_in=max_merge_fan_in,
         shard=shard,
     )
     return list(itertools.chain.from_iterable(map(_dataframe_to_items, merged)))
@@ -456,10 +490,26 @@ def test_external_sort_merge_cleans_up(tmp_path):
             sort_key=_SORT_KEY_COL,
             external_sort_dir=str(tmp_path),
             fan_in=fan_in,
+            max_merge_fan_in=32,
             shard=0,
         )
     )
     assert list(tmp_path.iterdir()) == [], "run files should be deleted after merge"
+
+
+def test_external_sort_merge_limits_later_pass_fan_in(tmp_path):
+    frames = [_make_sorted_frame([value]) for value in range(20)]
+    rows = _external_sort_items(
+        frames,
+        sort_key=_SORT_KEY_COL,
+        external_sort_dir=str(tmp_path),
+        fan_in=2,
+        max_merge_fan_in=2,
+        shard=0,
+    )
+
+    assert [row["v"] for row in rows] == list(range(20))
+    assert list(tmp_path.iterdir()) == []
 
 
 def test_scatter_removes_partial_dir_on_write_failure(tmp_path):


### PR DESCRIPTION
Scatter buffers now flush against the task memory budget, not the container
budget, and the trigger drops to 20 percent of it. The reduce-stage external
sort merges its run files in passes of at most 32 runs instead of one unbounded
final merge. Each shard subprocess gets POLARS_MAX_THREADS equal to its task CPU
share and a process-local spill directory.

Two global fuzzy-dedup runs died at their first scatter flush on 16 GiB workers.
Kubernetes recorded OOMKilled for 459 workers in one run and 511 in the other. A
polars sort keeps the input frame live while it builds the sorted frame, so a
flush peaks near 2.27 times the estimated buffer size, and the previous 45
percent effective trigger permitted a working set above the container limit.
Task multiplexing makes the container budget wrong as well, because several
shards share one worker. The unbounded final merge had the same shape: one
merge_sorted over every run file at once.

The run that motivated this has since processed 181 TB across 456 billion LSH
buckets on 48 workers with zero OOM kills. Incident record:
https://echo.oa.dev/wiki/68
