### PR TITLE
datakit: resolve the quality model path from MARIN_PREFIX

### DIFF
--- a/experiments/datakit/cluster/quality/fast_transformer/README.md
+++ b/experiments/datakit/cluster/quality/fast_transformer/README.md
@@ -29,10 +29,10 @@ Retrain + recalibrate the deployed model:
 ```bash
 python -m experiments.datakit.cluster.quality.fast_transformer.train \
     --labels s3://marin-us-east-02a/marin/datakit/quality_labels_20260709.parquet \
-    --out-dir s3://marin-us-east-02a/marin/user/rav/quality/pooled_junkgate2
+    --out-dir s3://marin-us-east-02a/marin/datakit/models/quality/pooled_junkgate2
 python -m experiments.datakit.cluster.quality.fast_transformer.calibrate \
-    --model-dir s3://marin-us-east-02a/marin/user/rav/quality/pooled_junkgate2 \
-    --out       s3://marin-us-east-02a/marin/user/rav/quality/pooled_junkgate2/calib_bme.json
+    --model-dir s3://marin-us-east-02a/marin/datakit/models/quality/pooled_junkgate2 \
+    --out       s3://marin-us-east-02a/marin/datakit/models/quality/pooled_junkgate2/calib_bme.json
 ```
 
 ## Scoring
@@ -73,4 +73,4 @@ Core:
 ## Artifacts
 
 - Labels: `s3://marin-us-east-02a/marin/datakit/quality_labels_20260709.parquet` (5,578 oracle labels; `label_batch` marks `consensus_v3` / `junkgate_web_wiki` / `junkgate_code_math`).
-- Model: `s3://marin-us-east-02a/marin/user/rav/quality/pooled_junkgate2/` (`.eqx` + `_remap.json` + `_meta.json` + `calib_bme.json`).
+- Model: `s3://marin-us-east-02a/marin/datakit/models/quality/pooled_junkgate2/` (`.eqx` + `_remap.json` + `_meta.json` + `calib_bme.json`).

--- a/experiments/datakit/cluster/quality/fast_transformer/calibrate.py
+++ b/experiments/datakit/cluster/quality/fast_transformer/calibrate.py
@@ -16,8 +16,8 @@ consumed by ``np.interp`` in ``score.py``.
 
     python -m experiments.datakit.cluster.quality.fast_transformer.calibrate \\
         --labels    s3://marin-us-east-02a/marin/datakit/quality_labels_20260709.parquet \\
-        --model-dir s3://marin-us-east-02a/marin/user/rav/quality/pooled_junkgate2 \\
-        --out       s3://marin-us-east-02a/marin/user/rav/quality/pooled_junkgate2/calib_bme.json
+        --model-dir s3://marin-us-east-02a/marin/datakit/models/quality/pooled_junkgate2 \\
+        --out       s3://marin-us-east-02a/marin/datakit/models/quality/pooled_junkgate2/calib_bme.json
 """
 
 import argparse

--- a/experiments/datakit/reference_pipeline.py
+++ b/experiments/datakit/reference_pipeline.py
@@ -857,7 +857,20 @@ def reference_datakit_steps(
 
 
 SAMPLE_PREFIX = "s3://marin-us-east-02a/marin/datakit/sample_0.1b_7d7d8fd7"
-QUALITY_MODEL = "s3://marin-us-east-02a/marin/user/rav/quality/pooled_junkgate2"
+
+QUALITY_MODEL = "datakit/models/quality/pooled_junkgate2"
+"""Pooled fast-transformer scorer directory, relative to ``MARIN_PREFIX``."""
+
+
+def quality_model_path() -> str:
+    """Resolve :data:`QUALITY_MODEL` against the active cluster prefix.
+
+    Kept a call, not a module constant, so importing this module never reads the
+    environment: a caller that sets ``MARIN_PREFIX`` after import still gets the
+    prefix it asked for.
+    """
+    return f"{marin_prefix()}/{QUALITY_MODEL}"
+
 
 # A content-diverse subset of a testbed sample (wiki / academic / reference /
 # code / math / multilingual / web / sft / agent-trajectory), small enough for a
@@ -945,7 +958,9 @@ def main() -> None:
         help="full: registry sources, K=5000. sample: a pre-built testbed sample (see --sample-prefix), K=64.",
     )
     parser.add_argument("--sample-prefix", default=SAMPLE_PREFIX, help="testbed sample root (--mode sample)")
-    parser.add_argument("--quality-model", default=QUALITY_MODEL, help="pooled fast-transformer scorer + calib dir")
+    parser.add_argument(
+        "--quality-model", default=quality_model_path(), help="pooled fast-transformer scorer + calib dir"
+    )
     parser.add_argument(
         "--domain-centroids",
         default=None,

--- a/experiments/references/reference_training_pipeline.py
+++ b/experiments/references/reference_training_pipeline.py
@@ -56,11 +56,11 @@ from marin.training.training import LevanterCheckpoint
 from rigging.log_setup import configure_logging
 
 from experiments.datakit.reference_pipeline import (
-    QUALITY_MODEL,
     SAMPLE_PREFIX,
     SAMPLE_SOURCES,
     SMOKE_SCALE,
     PoolConfig,
+    quality_model_path,
     reference_datakit_steps,
     sample_sources,
 )
@@ -77,7 +77,7 @@ REF_NAME = "references/reference-pipeline"
 
 # The datakit quality scorer is region-specific, so its identity enters the datakit hash as
 # a stable tag, not the path (see reference_pipeline.py). ``pooled-junkgate2`` is the tag for
-# the default ``QUALITY_MODEL`` bytes.
+# the default quality-model bytes.
 QUALITY_MODEL_VERSION = "pooled-junkgate2"
 
 # A nano model: this harness measures path-liveness and delta-vs-baseline, not absolute
@@ -266,7 +266,9 @@ def main() -> None:
         default=None,
         help="comma-separated source names, or 'all' to discover every source; default = curated SAMPLE_SOURCES subset",
     )
-    parser.add_argument("--quality-model", default=QUALITY_MODEL, help="pooled fast-transformer scorer + calib dir")
+    parser.add_argument(
+        "--quality-model", default=quality_model_path(), help="pooled fast-transformer scorer + calib dir"
+    )
     parser.add_argument(
         "--quality-model-version", default=QUALITY_MODEL_VERSION, help="stable identity tag for --quality-model"
     )


### PR DESCRIPTION
* `QUALITY_MODEL` was pinned to `s3://marin-us-east-02a/marin/user/rav/quality/pooled_junkgate2`; it now holds the prefix-relative directory `datakit/models/quality/pooled_junkgate2`, and `quality_model_path()` joins it with `marin_prefix()`
* the join happens on call, not at import, so importing `reference_pipeline` never reads `MARIN_PREFIX`; a caller that sets the env var after import still gets the prefix it asked for[^1]
* canonical location is `<MARIN_PREFIX>/datakit/models/quality/pooled_junkgate2` — out of a personal `user/rav/` prefix, and in-region per cluster rather than one hardcoded CoreWeave bucket
* step identity is unchanged: the quality step hashes the `quality_model_version` tag (`pooled-junkgate2`), never the model path, so no cached output is invalidated
* model bytes are staged at the new location on the two prefixes that hold them
  * CoreWeave `marin-us-east-02a`: moved earlier today, the old `user/rav/quality/` prefix is now empty
  * GCS `marin-us-central2`: copied in-region (5 objects, ~56 MB, server-side, no egress)
* `experiments/references/reference_training_pipeline.py` takes the same resolver as its `--quality-model` default
* `fast_transformer` README and `calibrate.py` usage examples point at the new location
* `tests/datakit/test_reference_pipeline_hashing.py` passes (11 tests); checked that `MARIN_PREFIX=gs://marin-us-central2/marin` resolves to the staged GCS copy and `s3://marin-us-east-02a/marin` to the CoreWeave one

[^1]: the other region buckets (`marin-eu-west4`, `marin-us-central1`, `marin-us-east1`, `marin-us-east5`, `marin-us-west4`) never held this model. a run there now fails at the missing in-region path instead of silently reading the CoreWeave copy across clouds — stage the directory first if the pipeline moves to one of them.