### PR TITLE
[zephyr] Make the concurrent-pipeline limit configurable

### DIFF
--- a/lib/zephyr/src/zephyr/coordinator.py
+++ b/lib/zephyr/src/zephyr/coordinator.py
@@ -296,6 +296,7 @@ class ZephyrCoordinator:
         max_shard_failures: int = MAX_SHARD_FAILURES,
         max_shard_infra_failures: int = MAX_SHARD_INFRA_FAILURES,
         drain_idle_workers: bool = False,
+        max_concurrent_pipelines: int = MAX_CONCURRENT_PIPELINES,
     ) -> None:
         # Pipeline executions keyed by execution_id, insertion-ordered. All
         # per-pipeline state lives in the _PipelineExecution values.
@@ -320,6 +321,7 @@ class ZephyrCoordinator:
         self._heartbeat_timeout = heartbeat_timeout
         self._max_shard_failures = max_shard_failures
         self._max_shard_infra_failures = max_shard_infra_failures
+        self._max_concurrent_pipelines = max_concurrent_pipelines
         # Per-worker in-flight counter snapshots. Each snapshot carries a
         # monotonic generation so the coordinator can discard stale or
         # out-of-order heartbeats.
@@ -1106,9 +1108,10 @@ class ZephyrCoordinator:
                 owns_execution = False
             else:
                 active = sum(1 for r in self._executions.values() if not r.done)
-                if active >= MAX_CONCURRENT_PIPELINES:
+                if active >= self._max_concurrent_pipelines:
                     raise RuntimeError(
-                        f"Coordinator already runs {active} concurrent pipelines (max {MAX_CONCURRENT_PIPELINES})"
+                        f"Coordinator already runs {active} concurrent pipelines "
+                        f"(max {self._max_concurrent_pipelines})"
                     )
                 run = _PipelineExecution(
                     execution_id=execution_id,

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -28,6 +28,7 @@ from rigging.filesystem import StoragePath, TransferBudgetExceeded, marin_temp_b
 from rigging.timing import ExponentialBackoff
 
 from zephyr.coordinator import (
+    MAX_CONCURRENT_PIPELINES,
     MAX_SHARD_FAILURES,
     MAX_SHARD_INFRA_FAILURES,
     ZephyrCoordinator,
@@ -227,6 +228,9 @@ class ZephyrContext:
         heartbeat_timeout: Maximum time between worker heartbeats.
         max_shard_failures: Maximum task failures for one shard.
         max_shard_infra_failures: Maximum worker failures while one shard is active.
+        max_concurrent_pipelines: Maximum pipelines one pool runs at the same
+            time. A pipeline past the limit is rejected, not queued. Raise it
+            for a driver that fans many pipelines onto one shared pool.
     """
 
     client: Client | None = None
@@ -243,6 +247,7 @@ class ZephyrContext:
     heartbeat_timeout: float = 120.0
     max_shard_failures: int = MAX_SHARD_FAILURES
     max_shard_infra_failures: int = MAX_SHARD_INFRA_FAILURES
+    max_concurrent_pipelines: int = MAX_CONCURRENT_PIPELINES
 
     _shared_data: ContextVar[dict[str, Any] | None] = field(init=False, repr=False)
     _state: _ContextState = field(init=False, default=_ContextState.NEW, repr=False)
@@ -348,11 +353,14 @@ class ZephyrContext:
             ZephyrCoordinator,
             self.chunk_storage_prefix,
             ZephyrTaskResources.from_resource_config(self.resources),
-            self.no_workers_timeout,
-            self.heartbeat_timeout,
-            self.max_shard_failures,
-            self.max_shard_infra_failures,
-            idle_policy is _IdleWorkerPolicy.DRAIN,
+            # By keyword: the coordinator takes a run of same-typed limits that
+            # a positional list would silently rebind on reorder.
+            no_workers_timeout=self.no_workers_timeout,
+            heartbeat_timeout=self.heartbeat_timeout,
+            max_shard_failures=self.max_shard_failures,
+            max_shard_infra_failures=self.max_shard_infra_failures,
+            drain_idle_workers=idle_policy is _IdleWorkerPolicy.DRAIN,
+            max_concurrent_pipelines=self.max_concurrent_pipelines,
             name=coordinator_name,
             count=1,
             resources=self.coordinator_resources,

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -301,6 +301,43 @@ def test_failed_shared_execution_does_not_stop_another(local_client, tmp_path):
             failed.result()
 
 
+def test_shared_pool_honors_configured_concurrent_pipeline_limit(local_client, tmp_path):
+    """A shared pool rejects a pipeline past ``max_concurrent_pipelines``.
+
+    The limit reaches the coordinator through ``_start_pool``. With the default
+    of 16 in place, the second execute below is accepted and succeeds.
+    """
+    holding = threading.Event()
+    release = threading.Event()
+
+    def hold(value: int) -> int:
+        holding.set()
+        assert release.wait(timeout=60.0)
+        return value
+
+    ctx = ZephyrContext(
+        client=local_client,
+        max_workers=2,
+        resources=ResourceConfig(cpu=2, ram="1g"),
+        chunk_storage_prefix=str(tmp_path / "chunks"),
+        name="test-shared-pipeline-limit",
+        max_concurrent_pipelines=1,
+    )
+
+    with ctx, ThreadPoolExecutor(max_workers=1) as executor:
+        held = executor.submit(ctx.execute, Dataset.from_list([1]).map(hold))
+        try:
+            assert holding.wait(timeout=60.0)
+            with pytest.raises(RuntimeError, match="max 1"):
+                ctx.execute(Dataset.from_list([2]).map(lambda value: value * 2))
+        finally:
+            release.set()
+        assert held.result().results == [1]
+
+        # The finished pipeline released its slot.
+        assert ctx.execute(Dataset.from_list([3]).map(lambda value: value * 2)).results == [6]
+
+
 def test_pull_task_rotates_between_executions(coordinator):
     tasks = [
         ShardTask(

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -304,8 +304,9 @@ def test_failed_shared_execution_does_not_stop_another(local_client, tmp_path):
 def test_shared_pool_honors_configured_concurrent_pipeline_limit(local_client, tmp_path):
     """A shared pool rejects a pipeline past ``max_concurrent_pipelines``.
 
-    The limit reaches the coordinator through ``_start_pool``. With the default
-    of 16 in place, the second execute below is accepted and succeeds.
+    The limit must reach the coordinator through ``_start_pool``. An argument
+    bound to the wrong coordinator parameter leaves the default of 16 in place,
+    and the second execute below then succeeds instead of raising.
     """
     holding = threading.Event()
     release = threading.Event()


### PR DESCRIPTION
A shared coordinator rejects the 17th concurrent pipeline against a module
constant, so a driver that sends one pipeline per work item to one pool cannot
run more than 16 items at a time, even while the pool holds idle workers. The
rejection is not backpressure: it fails the calling job.

ZephyrCoordinator and ZephyrContext now accept max_concurrent_pipelines. The
default stays 16. _start_pool passes the coordinator arguments by keyword,
because those limits are all integers and a positional list rebinds them
without a type error.

Fixes #7938
