### PR TITLE
[agents] Restore wait_for PR monitoring

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -25,7 +25,7 @@ commit. The review is read-only: it never edits, commits, or pushes for you.
 Work top to bottom. For a quick work-in-progress checkpoint, do **1, 2, 4, 5,
 7** (clean up, lint, stage, commit, push) and stop. The changed-test cleanup in
 step 1 is a PR-readiness gate, not required for disposable WIP checkpoints. Run
-the whole list before you open or update a PR.
+the whole list for PR-ready work.
 
 1. Clean up your own diff (self-review).
 2. Mechanical lint & format — `./infra/pre-commit.py --changed-files --fix`.
@@ -35,6 +35,7 @@ the whole list before you open or update a PR.
 6. Lint-catalog review — run `./infra/pre-commit.py --review` once; fix or answer every finding.
 7. Push (maybe).
 8. Open or update the PR.
+9. Monitor the PR with `wait_for.py` until an exit condition.
 
 ## 1. Clean up your own diff
 
@@ -187,12 +188,16 @@ gh pr create --title "<title>" --body-file "<body-file>" --label agent-generated
 - Include `Fixes #NNNN` when addressing a pre-existing issue.
 - If you have a specific github tool, you may use it.
 
-## 9. Monitor the PR through handoff
+## 9. Monitor the PR
 
-Opening the PR starts the integration phase. Monitor the current CI run and
-feedback already present before handing the PR to a reviewer. Waiting for future
-human reviews or a merge is a separate, longer-running mode; use it only when the
-user or task explicitly asks for continued monitoring.
+Opening the PR starts the integration phase. Green CI is not an exit condition:
+reviews and comments can arrive after checks pass. Monitor every PR until it
+merges or closes, the user tells you to stop, or a 12-hour wait times out.
+
+Before the first wait, read every current issue comment, inline review comment,
+and submitted review once, then address anything actionable. This is a one-time
+inspection, not a monitoring loop. The comment and review arms establish a
+baseline when they start and wake only for later new or edited feedback.
 
 Set one honest status immediately before waiting, for example:
 
@@ -210,9 +215,10 @@ uv run scripts/ci/wait_for.py --timeout 12h \
 ```
 
 `github.pr` covers terminal merged/closed state, merge conflicts,
-ready-for-review transitions, and review-decision changes. Ordinary PR lifecycle
-monitoring must not use a raw `poll` shell expression or separate `gh pr view`
-checks.
+ready-for-review transitions, and review-decision changes. It does not inspect
+comment or review bodies, so it does not replace `github.pr_comment` or
+`github.review`. Keep all three arms. Monitoring must not use a raw `poll` shell
+expression, `gh pr checks --watch`, or repeated `gh pr view` calls.
 
 The wait owns its exponential backoff. While it is running:
 
@@ -228,7 +234,7 @@ the overall timeout elapsed, and `1` means the wait failed. An event is not
 always a successful verdict. Read `result.conclusion` for `github.ci` and
 `result.reasons` for `github.pr`.
 
-Act on the event before deciding whether to re-arm:
+Act on the event, read any feedback that arrived concurrently, then re-arm:
 
 1. **`github.ci`** — on failure, read the failing job log and fix the
    regression. A failure in an untouched file is not automatically
@@ -239,26 +245,26 @@ Act on the event before deciding whether to re-arm:
 2. **`github.pr`** — `merged` and `closed` are terminal. Resolve `conflicted`
    before re-arming; an unchanged conflict is intentionally reported again by a
    fresh wait. `ready_for_review` and `review_decision` describe review-state
-   changes in the attached snapshots.
+   changes in the attached snapshots. When `review_decision` fires, inspect the
+   submitted review because the lifecycle payload does not include its body.
 3. **`github.pr_comment` / `github.review`** — address every actionable human
-   and agent comment already present. Prefix agent-authored replies with `🤖`
-   and resolve the thread. The default significant-comment filter ignores the
-   authenticated user's comments, review-bot progress placeholders, clean
-   verdicts, wrappers, and Loom's exact
+   and agent comment. Prefix agent-authored replies with `🤖` and resolve the
+   thread. The default significant-comment filter ignores the authenticated
+   user's comments, review-bot progress placeholders, clean verdicts, wrappers,
+   and Loom's exact
    `Working on this in loom: <session URL>` acknowledgement.
 4. **Timeout** — report the last statuses in the timeout payload and hand off.
    Do not replace the completed 12-hour block with manual polling.
 
-The default handoff condition is: CI passed and every actionable comment or
-review already present is addressed. Set `weaver status attention "PR #<N> is
-ready for review"` once and end the monitoring turn. Do not wait for a future
-review or merge by default.
+Re-arm after every non-terminal event. Once CI finishes, omit `github.ci` so its
+terminal result does not fire immediately; keep `github.pr`,
+`github.pr_comment`, and `github.review` armed for later feedback. Read current
+feedback once before each re-arm so simultaneous events are not absorbed into a
+new baseline without being handled.
 
-When continued monitoring was explicitly requested, re-arm after each
-non-terminal event. That mode ends only when the PR merges or closes, the user
-tells you to stop, or a 12-hour wait times out. A question requiring user input
-ends the current blocking wait: raise `attention`, ask the question, and resume
-monitoring after the answer.
+A question requiring user input pauses monitoring: raise `attention`, ask the
+question, and resume after the answer. Otherwise the only exit conditions are a
+merged or closed PR, an explicit request to stop, or a 12-hour timeout.
 
 ## Rules
 

--- a/.agents/skills/fix-issue/SKILL.md
+++ b/.agents/skills/fix-issue/SKILL.md
@@ -103,13 +103,12 @@ When all tests pass, upload your branch and open a PR following
 specifies (no markdown headers, bullet lists, or `## Summary` sections;
 violations are rejected). Attach a comment to the Github issue summarizing the fix.
 
-## Verify CI Status
+## Monitor the PR
 
-After opening the PR, verify CI checks pass:
-
-* Monitor with `gh pr view <number> --json statusCheckRollup`.
-* Wait for unit tests; if they fail, investigate and push fixes.
-* Do not consider the PR complete until all relevant checks pass.
+After opening the PR, follow step 9 of `.agents/skills/commit/SKILL.md`
+exactly. Its `wait_for.py` loop owns CI, review feedback, and lifecycle events.
+Do not start a separate `gh pr view` or `gh pr checks` polling loop. Investigate
+failures, push fixes, and re-arm the wait as that skill specifies.
 
 Key checks: **unit tests** (must pass), **lint-and-format** (must pass),
 **build-docs** (should pass if you modified documentation).
@@ -128,7 +127,7 @@ The tasks for this skill:
 - [ ] Run `./infra/pre-commit.py --all-files --fix` and resolve all issues
 - [ ] Upload branch to github
 - [ ] Open pull request
-- [ ] Verify CI checks pass and address any failures (by polling gh pr view)
+- [ ] Monitor CI, feedback, and PR lifecycle with `wait_for.py` through an exit condition
 - [ ] Update comment with final status
 
 If at any point you are unable to proceed, you must add a comment to the Github

--- a/.agents/skills/refresh-tpu-vllm-forks/SKILL.md
+++ b/.agents/skills/refresh-tpu-vllm-forks/SKILL.md
@@ -36,7 +36,8 @@ smoke tests.
 - If no newer upstream pair is selected and no pin metadata needs repair, exit
   successfully with a no-op summary.
 - If the refresh succeeds, open exactly one draft PR in `marin-community/marin`
-  after required smoke tests pass, and request `@yonromai` as reviewer.
+  after required smoke tests pass, request `@yonromai` as reviewer, and monitor
+  it per `.agents/skills/commit/SKILL.md`.
 - The PR updates Marin's fork tip SHAs, refreshes `uv.lock`, and reports bases,
   branches/tips, carried/dropped/fixed overlays, validation, and residual risk.
 - Do not open fork PRs. Do not move either fork `main`; fork review happens via
@@ -50,9 +51,9 @@ failure, artifacts, and the logs Gist.
 
 ## Post-Merge Follow-Up
 
-This skill does not run post-merge fork-main promotion. A successful refresh run
-stops after opening the Marin PR; if blocked, it stops after filing or updating
-the blocker issue.
+This skill does not run post-merge fork-main promotion. After opening the Marin
+PR, follow the `commit` skill's monitoring loop through an exit condition. If
+blocked before PR creation, stop after filing or updating the blocker issue.
 
 After the Marin PR has merged and Marin `main` contains the new exact fork SHA
 pins, a separate operator may run the post-merge protocol in
@@ -256,7 +257,8 @@ Check that:
 ### 7. Open the Marin PR
 
 After required smoke tests pass, publish the logs Gist, push the Marin branch,
-and open one draft `marin-community/marin` PR. Request `@yonromai` as reviewer.
+and open one draft `marin-community/marin` PR. Request `@yonromai` as reviewer,
+then follow step 9 of `.agents/skills/commit/SKILL.md`.
 
 PR body:
 
@@ -279,3 +281,4 @@ PR body:
 - Required smoke tests pass before PR creation, or the unresolved blocker is in
   a Marin issue assigned to `@yonromai`.
 - The two curated logs are published as one Gist and linked from the PR/issue.
+- An opened Marin PR reaches a `commit` skill monitoring exit condition.

--- a/.agents/skills/run-ferries/SKILL.md
+++ b/.agents/skills/run-ferries/SKILL.md
@@ -150,7 +150,8 @@ Recommendation / victory decision: <next action>
 
 #### 7) Seal and open log-only PR
 - Create and push a sealing tag for the exact launch commit (the commit containing the `experiments/ferries/daily.py` used for the run).
-- Open a PR that updates only `docs/experiments/daily-ferry-log.md`, following `.agents/skills/commit/SKILL.md` for description format.
+- Open a PR that updates only `docs/experiments/daily-ferry-log.md`, following
+  `.agents/skills/commit/SKILL.md` for commit, PR text, and monitoring.
 - Keep all detailed launch/retry/debug narrative in the run issue, not in the PR.
 - Apply canonical labels: `ferry`, `ferry-daily`, `ferry-log-only`, `ferry-sealed`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,9 @@ uv run pytest
   and implementation inventories; put extended history in a linked issue,
   design doc, logbook, or artifact. Follow the `commit` skill
   (`.agents/skills/commit/SKILL.md`) when committing, pushing, or opening a PR.
+- PR monitoring is part of the `commit` skill. After opening or updating a PR,
+  follow its `wait_for.py` loop through an exit condition. Do not substitute
+  `gh pr checks --watch`, repeated `gh pr view` calls, or handoff at green CI.
 - When using `gh` to inspect issues or PRs, prefer `--json <fields>` or explicit narrow flags such as `--comments`; avoid plain `gh issue view` / `gh pr view`, which can fail on this repo because GitHub classic project fields are deprecated.
 
 ## Code Style

--- a/scripts/ci/wait_for.py
+++ b/scripts/ci/wait_for.py
@@ -10,7 +10,7 @@ the built-in kinds cover common PR and Iris waits without shell parsing:
 
     poll <shell command>    fires when the command exits 0
     github.ci <PR>          fires the moment any check fails, else when all checks pass
-    github.pr <PR>          fires on terminal, conflicted, review, or ready-for-review state
+    github.pr <PR>          fires on terminal, conflict, review-decision, or ready state
     github.pr_comment <PR>  fires on a new comment that raises a real code concern
     github.review <PR>      fires on a decisive review, or one whose body raises a concern
     iris.job <job-id>       fires when an Iris job reaches a terminal state (in-task only)
@@ -21,6 +21,10 @@ decision changes, or a draft becomes ready for review. The payload names every
 reason that fired and includes the complete before/after snapshots. A PR first
 observed as terminal or conflicted fires immediately, so arming the selector
 after the state change does not lose an actionable condition.
+
+``github.pr`` does not inspect comment or review bodies. Arm
+``github.pr_comment`` and ``github.review`` alongside it to wake for actionable
+feedback; none of the three PR event kinds replaces another.
 
 ``iris.job`` runs the Iris client's blocking ``Job.wait`` in a daemon worker. Its
 state polling and controller retries use the Iris client policy; the selector
@@ -44,13 +48,15 @@ quoted token each) or stdin (one per line; ``#`` comments):
 
     uv run scripts/ci/wait_for.py --timeout 12h \\
       'poll loom session poll weaver/foo --quiet | grep -q done' \\
-      'github.ci 1234' 'github.pr 1234' 'github.pr_comment 1234'
+      'github.ci 1234' 'github.pr 1234' \\
+      'github.pr_comment 1234' 'github.review 1234'
 
     uv run scripts/ci/wait_for.py --timeout 12h <<'HERE'
     poll loom session poll weaver/foo --quiet | grep -q done
     github.ci 1234
     github.pr 1234
     github.pr_comment 1234
+    github.review 1234
     HERE
 
 Prints one JSON object naming the arm that fired and its payload. Exit ``0`` an arm
@@ -917,7 +923,11 @@ def main(
     comment_filter: str,
     quiet: bool,
 ) -> None:
-    """Block until the first armed event fires; print which one as JSON."""
+    """Block until the first armed event fires; print which one as JSON.
+
+    github.pr watches lifecycle and review-decision changes only. Arm
+    github.pr_comment and github.review separately to watch feedback bodies.
+    """
     parsed = read_specs(specs, use_stdin=use_stdin)
     github_kinds = (EventKind.GITHUB_CI, EventKind.GITHUB_PR, EventKind.GITHUB_PR_COMMENT, EventKind.GITHUB_REVIEW)
     needs_github = any(s.kind in github_kinds for s in parsed)


### PR DESCRIPTION
Keep PR-opening agents responsible for CI and review feedback until a PR
merges or closes, the user stops monitoring, or a 12-hour wait times out.
Green CI no longer ends the workflow before later comments and reviews arrive.

Use the commit skill as the single monitoring contract across `AGENTS.md` and
specialized skills. The `wait_for.py` documentation now distinguishes
lifecycle, comment, and review arms. The [Weaver
session](https://loom.oa.dev/s/zyvientv) records the instruction audit that
found the conflicting handoff policy.
