### PR TITLE
[training] Persist NCCL RAS telemetry

### DIFF
--- a/docs/ops/training-stall-alert-contract.md
+++ b/docs/ops/training-stall-alert-contract.md
@@ -17,11 +17,13 @@ The required `service=levanter` telemetry records are `step`, `progress_time_sec
 
 ## NCCL RAS snapshots
 
-GPU Levanter runs poll NCCL RAS from JAX process 0 every two minutes. NCCL returns a job-global communicator view, so one collector avoids repeating the same query from every rank. The collector runs on a daemon thread, gives `ncclras` an eight-second outer deadline, and stops during normal tracker shutdown. `NCCL_RAS_ENABLE=0` disables collection.
+GPU Levanter runs poll NCCL RAS from JAX process 0 every two minutes. NCCL returns a job-global communicator view, so one collector avoids repeating the same query from every rank. The collector runs NCCL's documented text protocol in a bounded Python subprocess, gives it an eight-second outer deadline, and stops during normal tracker shutdown. It does not depend on the separately packaged `ncclras` executable. `NCCL_RAS_ENABLE=0` disables collection.
+
+Iris's Kubernetes sidecar ships task logs and does not poll RAS. The Iris node-agent NVIDIA probe records host hardware separately. Leave both enabled; neither duplicates these communicator snapshots.
 
 Every row carries the collector's Iris `task_id`, attempt/execution identity, node, `process_index=0`, and `root_run_uid`. Rank rows add NCCL's `rank_host`, `process_id`, `cuda_device`, and `nvml_device`; those fields identify the process represented by a global RAS rank instead of treating the collector task as the rank owner.
 
-`ras_available=1` records a parsed response. `ras_available=0` includes an `outcome` such as `start_failed`, `nonzero_exit`, `deadline_exceeded`, `output_limit`, or `invalid_payload`. `ras_poll_failures` and `ras_poll_timeouts` are counter deltas; sum them over the query window. `ras_poll_duration_seconds` is the client-side latency, while `ras_collection_duration_seconds` and `ras_collection_timeouts` come from NCCL's successful response.
+`ras_available=1` records a parsed response. `ras_available=0` includes an `outcome` such as `unavailable`, `client_timeout`, `deadline_exceeded`, `output_limit`, or `invalid_payload`. `ras_poll_failures` and `ras_poll_timeouts` are counter deltas; sum them over the query window. `ras_poll_duration_seconds` is the client-side latency, while `ras_collection_duration_seconds` and `ras_collection_timeouts` come from NCCL's successful response.
 
 Query a root run with a bounded timestamp range:
 

--- a/docs/ops/training-stall-alert-contract.md
+++ b/docs/ops/training-stall-alert-contract.md
@@ -15,6 +15,52 @@ The bridge joins the durable streams by `(cluster, root job ID)`: `iris.task_sta
 
 The required `service=levanter` telemetry records are `step`, `progress_time_seconds`, and numeric `phase` (`initializing=0`, `training=1`, `finished=2`). `TelemetryTracker` initializes phase and progress, records wall time after its completed-step `train/loss` callback, and marks a finished run.
 
+## NCCL RAS snapshots
+
+GPU Levanter runs poll NCCL RAS from JAX process 0 every two minutes. NCCL returns a job-global communicator view, so one collector avoids repeating the same query from every rank. The collector runs on a daemon thread, gives `ncclras` an eight-second outer deadline, and stops during normal tracker shutdown. `NCCL_RAS_ENABLE=0` disables collection.
+
+Every row carries the collector's Iris `task_id`, attempt/execution identity, node, `process_index=0`, and `root_run_uid`. Rank rows add NCCL's `rank_host`, `process_id`, `cuda_device`, and `nvml_device`; those fields identify the process represented by a global RAS rank instead of treating the collector task as the rank owner.
+
+`ras_available=1` records a parsed response. `ras_available=0` includes an `outcome` such as `start_failed`, `nonzero_exit`, `deadline_exceeded`, `output_limit`, or `invalid_payload`. `ras_poll_failures` and `ras_poll_timeouts` are counter deltas; sum them over the query window. `ras_poll_duration_seconds` is the client-side latency, while `ras_collection_duration_seconds` and `ras_collection_timeouts` come from NCCL's successful response.
+
+Query a root run with a bounded timestamp range:
+
+```sql
+SELECT
+  cluster,
+  to_timestamp_millis(timestamp_ms) AS ts,
+  json_get(resource_attributes_json, 'root_run_uid') AS root_run_uid,
+  json_get(resource_attributes_json, 'task_id') AS collector_task_id,
+  name,
+  kind,
+  value,
+  json_get(attributes_json, 'outcome') AS outcome,
+  json_get(attributes_json, 'communicator_hash') AS communicator_hash,
+  json_get(attributes_json, 'rank') AS rank,
+  json_get(attributes_json, 'rank_host') AS rank_host,
+  json_get(attributes_json, 'collective') AS collective
+FROM "telemetry_v1"
+WHERE service = 'levanter'
+  AND json_get(resource_attributes_json, 'root_run_uid') = '<run-id>'
+  AND name IN (
+    'ras_available',
+    'ras_poll_duration_seconds',
+    'ras_poll_failures',
+    'ras_poll_timeouts',
+    'communicators',
+    'communicator_state',
+    'communicator_ranks',
+    'communicator_rank_status',
+    'collective_operations',
+    'ras_collection_duration_seconds',
+    'ras_collection_timeouts'
+  )
+  AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM now() - INTERVAL '30 minutes') * 1000 AS BIGINT)
+ORDER BY timestamp_ms, name;
+```
+
+Repeated, unchanged `collective_operations` values during stale optimizer progress are evidence of a stationary communicator. A one-sample count mismatch is not a hang verdict because ranks may be briefly offset while collectives are active. No retained RAS rows means collection or delivery is unverified; `ras_available=0` proves the collector ran and could not obtain a valid response.
+
 GPU utilization, power, and power-limit metrics remain diagnostic evidence available in finelog and the capture bundle; they do not gate or classify this warning. This avoids hiding a stalled job when node attribution is unavailable.
 
 The rule currently covers CoreWeave controllers whose active root-job state is forwarded into the `marin` finelog hub. GCE controllers do not emit `iris.task_state`, so their jobs are not evaluated by this rule.

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -265,6 +265,15 @@ GPU environments set `NCCL_RAS_ENABLE=1`, `NCCL_DEBUG=INFO`, and `NCCL_DEBUG_SUB
 
 GPU Levanter runs persist NCCL's job-global communicator view from JAX process 0 every two minutes. The probe is bounded and records unavailable, failed, and timed-out polls explicitly. See [`docs/ops/training-stall-alert-contract.md`](../../docs/ops/training-stall-alert-contract.md#nccl-ras-snapshots) for metric semantics and a bounded Finelog query.
 
+For a read-only one-shot check, first confirm the target task is `RUNNING`; a `BUILDING` task has no NCCL listener. Query from the task's own container and network namespace:
+
+```bash
+iris --cluster=<cluster> task exec <task-id> --timeout 15 -- \
+  python -m rigging.telemetry.probes.nccl_client --timeout 8
+```
+
+The command sends one status request, does not retry or write inside the task, and limits both socket time and response size. Exit code 3 means the task-local listener was unavailable. Do not restart, signal, or otherwise modify the task to make this check succeed.
+
 ## Scheduler & Autoscaler
 
 ```bash

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -263,6 +263,8 @@ iris process profile cpu -t /user/job/0     # profile a running task container
 
 GPU environments set `NCCL_RAS_ENABLE=1`, `NCCL_DEBUG=INFO`, and `NCCL_DEBUG_SUBSYS=INIT,BOOTSTRAP,ENV,NET,GRAPH,TUNING,RAS`. The default timestamp is `[%F %T.%3f]`. Short debug-smoke jobs may additionally select `COLL,PROXY,NVLS,REG`; do not use `TRACE` or `CALL` for normal runs.
 
+GPU Levanter runs persist NCCL's job-global communicator view from JAX process 0 every two minutes. The probe is bounded and records unavailable, failed, and timed-out polls explicitly. See [`docs/ops/training-stall-alert-contract.md`](../../docs/ops/training-stall-alert-contract.md#nccl-ras-snapshots) for metric semantics and a bounded Finelog query.
+
 ## Scheduler & Autoscaler
 
 ```bash

--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -26,6 +26,7 @@ from typing import Any, NewType
 import cloudpickle
 import humanfriendly
 from rigging.provenance import LAUNCH_PROVENANCE_ENV, launch_provenance
+from rigging.telemetry.probes.nccl_client import NCCL_RAS_ENABLE_ENV
 from rigging.timing import Timestamp
 
 from iris.cluster.setup_scripts import (
@@ -762,7 +763,7 @@ class EnvironmentSpec:
         if wants_gpu_extra(self.extras or ()):
             default_env_vars.update(
                 {
-                    "NCCL_RAS_ENABLE": "1",
+                    NCCL_RAS_ENABLE_ENV: "1",
                     "NCCL_DEBUG": "INFO",
                     "NCCL_DEBUG_SUBSYS": "INIT,BOOTSTRAP,ENV,NET,GRAPH,TUNING,RAS",
                     "NCCL_DEBUG_TIMESTAMP": "[%F %T.%3f]",

--- a/lib/iris/src/iris/runtime/telemetry.py
+++ b/lib/iris/src/iris/runtime/telemetry.py
@@ -35,7 +35,7 @@ _RESERVED_RESOURCE_ATTRIBUTES = frozenset(
 )
 
 
-def _identity(job_info: JobInfo) -> dict[str, str]:
+def _identity(job_info: JobInfo, process_index: int | None) -> dict[str, str]:
     identity = {
         "job_id": str(job_info.job_id),
         "task_id": str(job_info.task_id),
@@ -45,9 +45,19 @@ def _identity(job_info: JobInfo) -> dict[str, str]:
         identity["worker"] = job_info.worker_id
     if job_info.worker_region:
         identity["region"] = job_info.worker_region
-    process_index = os.environ.get(IRIS_MULTIGPU_PROCESS_INDEX_ENV)
+    env_process_index = os.environ.get(IRIS_MULTIGPU_PROCESS_INDEX_ENV)
     if process_index is not None:
-        identity["process_index"] = process_index
+        if isinstance(process_index, bool) or process_index < 0:
+            raise ValueError("process_index must be a nonnegative integer")
+        resolved_process_index = str(process_index)
+        if env_process_index is not None and env_process_index != resolved_process_index:
+            raise ValueError(
+                f"process_index {resolved_process_index} conflicts with {IRIS_MULTIGPU_PROCESS_INDEX_ENV}="
+                f"{env_process_index}"
+            )
+        identity["process_index"] = resolved_process_index
+    elif env_process_index is not None:
+        identity["process_index"] = env_process_index
     if node_name := os.environ.get(IRIS_NODE_NAME_ENV):
         identity["node_name"] = node_name
     return identity
@@ -62,6 +72,7 @@ def configure(
     *,
     root_run_uid: str | None = None,
     execution_uid: str | None = None,
+    process_index: int | None = None,
     attributes: Mapping[str, str] | None = None,
 ) -> None:
     """Configure telemetry once for an owning application running under Iris."""
@@ -76,7 +87,7 @@ def configure(
         if conflicts := _RESERVED_RESOURCE_ATTRIBUTES.intersection(extra):
             names = ", ".join(sorted(conflicts))
             raise ValueError(f"Iris owns canonical telemetry attributes: {names}")
-        resource = _identity(job_info)
+        resource = _identity(job_info, process_index)
         resource.update(extra)
         resource["root_run_uid"] = root_run_uid or str(job_info.job_id)
         resource["execution_uid"] = execution_uid or _execution_uid(job_info)

--- a/lib/iris/tests/runtime/test_telemetry.py
+++ b/lib/iris/tests/runtime/test_telemetry.py
@@ -90,6 +90,23 @@ def test_vllm_resource_exposes_serving_job_join(monkeypatch: pytest.MonkeyPatch)
     assert attributes["root_run_uid"] == "/alice/serve"
 
 
+def test_configure_stamps_explicit_distributed_process_index(monkeypatch: pytest.MonkeyPatch) -> None:
+    info = JobInfo(task_id=JobName.from_wire("/alice/train/7"), worker_id="w-1", attempt_id=2)
+    monkeypatch.setattr(telemetry, "get_job_info", lambda: info)
+    monkeypatch.setattr(telemetry, "get_iris_ctx", lambda: _FakeCtx())
+    transport = _transport(monkeypatch)
+
+    telemetry.configure("levanter", root_run_uid="run-42", process_index=0)
+    rigging_telemetry.gauge("identity_probe").set(1)
+    transport.record("identity_probe", {})
+
+    attributes = transport.resources[-1]["attributes"]
+    assert attributes["task_id"] == "/alice/train/7"
+    assert attributes["attempt"] == "2"
+    assert attributes["root_run_uid"] == "run-42"
+    assert attributes["process_index"] == "0"
+
+
 @pytest.mark.parametrize("ambiguous_name", ["run", "run_id"])
 def test_configure_rejects_ambiguous_identity(monkeypatch: pytest.MonkeyPatch, ambiguous_name: str) -> None:
     info = JobInfo(task_id=JobName.from_wire("/alice/train/0"), worker_id="w-1", attempt_id=0)

--- a/lib/levanter/src/levanter/tracker/telemetry.py
+++ b/lib/levanter/src/levanter/tracker/telemetry.py
@@ -12,9 +12,12 @@ from enum import IntEnum
 from time import time
 from typing import Any, Optional
 
+import jax
 import numpy as np
 from iris.runtime import telemetry as runtime_telemetry
 from rigging import telemetry
+from rigging.telemetry.probes import nccl
+from rigging.telemetry.probes.runner import PeriodicProbe
 
 from levanter.tracker import Tracker, TrackerConfig
 from levanter.tracker.histogram import SummaryStats
@@ -44,6 +47,7 @@ def _set(name: str, value: float, *, attributes: dict[str, str] = _CURRENT) -> N
 # drops records under queue pressure, so several missed beats must not un-enroll a
 # live job. The reader's window lives in infra/grafana/src/training_stalls.py.
 _PHASE_HEARTBEAT_SECONDS = 60.0
+_NCCL_RAS_POLL_SECONDS = 2 * 60.0
 
 
 class _PhaseHeartbeat:
@@ -116,12 +120,27 @@ def _as_scalar(value: Any) -> float | None:
     return float(array)
 
 
+def _start_nccl_ras_probe() -> PeriodicProbe | None:
+    try:
+        if not telemetry.runtime_status().configured:
+            return None
+        if os.environ.get("NCCL_RAS_ENABLE", "1") == "0":
+            return None
+        if jax.default_backend() != "gpu" or jax.process_index() != 0:
+            return None
+        return nccl.start(interval=_NCCL_RAS_POLL_SECONDS)
+    except Exception:
+        logger.warning("could not start NCCL RAS telemetry", exc_info=True)
+        return None
+
+
 class TelemetryTracker(Tracker):
     """Export training snapshots and phase transitions."""
 
     name: str = "telemetry"
 
     def __init__(self) -> None:
+        self._nccl_ras_probe = _start_nccl_ras_probe()
         _set("progress_time_seconds", 0)
         set_training_phase(TrainingPhase.INITIALIZING)
         _HEARTBEAT.start()
@@ -173,6 +192,11 @@ class TelemetryTracker(Tracker):
         pass
 
     def finish(self):
+        if self._nccl_ras_probe is not None:
+            try:
+                self._nccl_ras_probe.shutdown()
+            except Exception:
+                logger.warning("could not stop NCCL RAS telemetry", exc_info=True)
         set_training_phase(TrainingPhase.FINISHED)
         # The run is over, so there is nothing left to keep enrolled. FINISHED is
         # already published above, and republishing it for the process's remaining
@@ -186,8 +210,10 @@ class TelemetryConfig(TrackerConfig):
     """Configure direct training telemetry."""
 
     def init(self, run_id: Optional[str]) -> Tracker:
+        process_index = jax.process_index()
         runtime_telemetry.configure(
             "levanter",
             root_run_uid=run_id,
+            process_index=process_index,
         )
         return TelemetryTracker()

--- a/lib/levanter/src/levanter/tracker/telemetry.py
+++ b/lib/levanter/src/levanter/tracker/telemetry.py
@@ -129,7 +129,7 @@ def _start_nccl_ras_probe() -> PeriodicProbe | None:
         if jax.default_backend() != "gpu" or jax.process_index() != 0:
             return None
         return nccl.start(interval=_NCCL_RAS_POLL_SECONDS)
-    except Exception:
+    except RuntimeError:
         logger.warning("could not start NCCL RAS telemetry", exc_info=True)
         return None
 

--- a/lib/levanter/src/levanter/tracker/telemetry.py
+++ b/lib/levanter/src/levanter/tracker/telemetry.py
@@ -17,7 +17,7 @@ import jax
 import numpy as np
 from iris.runtime import telemetry as runtime_telemetry
 from rigging import telemetry
-from rigging.telemetry.probes import nccl
+from rigging.telemetry.probes import nccl, nccl_client
 from rigging.telemetry.probes.runner import PeriodicProbe
 
 from levanter.tracker import Tracker, TrackerConfig
@@ -125,7 +125,7 @@ def _start_nccl_ras_probe() -> PeriodicProbe | None:
     try:
         if not telemetry.runtime_status().configured:
             return None
-        if os.environ.get("NCCL_RAS_ENABLE", "1") == "0":
+        if os.environ.get(nccl_client.NCCL_RAS_ENABLE_ENV, "1") == "0":
             return None
         if jax.default_backend() != "gpu" or jax.process_index() != 0:
             return None

--- a/lib/levanter/src/levanter/tracker/telemetry.py
+++ b/lib/levanter/src/levanter/tracker/telemetry.py
@@ -5,6 +5,7 @@
 
 import dataclasses
 import logging
+import os
 import re
 import threading
 from collections.abc import Mapping

--- a/lib/levanter/tests/test_telemetry_tracker.py
+++ b/lib/levanter/tests/test_telemetry_tracker.py
@@ -32,7 +32,7 @@ def _values(records: list[dict]) -> dict[str, float]:
     return {record["name"]: record["value"] for record in records}
 
 
-def _install_ncclras(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, marker: Path | None = None) -> None:
+def _install_nccl_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, marker: Path | None = None) -> None:
     payload = {
         "nccl_version": "2.29.1",
         "cuda_runtime_version": 13000,
@@ -70,9 +70,10 @@ def _install_ncclras(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, marker:
     marker_write = (
         f"with open({str(marker)!r}, 'a') as marker_file:\n    marker_file.write('started\\n')\n" if marker else ""
     )
-    command = tmp_path / "ncclras"
+    command = tmp_path / "nccl-client"
     command.write_text(f"#!{sys.executable}\n{marker_write}print({json.dumps(payload)!r})")
     command.chmod(command.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setattr(tracker_telemetry.nccl, "_CLIENT_COMMAND", (str(command),))
     monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
 
 
@@ -177,7 +178,7 @@ def test_finish_stops_the_phase_heartbeat(exported, fast_heartbeat):
 
 def test_gpu_primary_process_exports_nccl_ras_until_finish(exported, monkeypatch, tmp_path):
     marker = tmp_path / "ncclras-started"
-    _install_ncclras(monkeypatch, tmp_path, marker=marker)
+    _install_nccl_client(monkeypatch, tmp_path, marker=marker)
     monkeypatch.setenv("NCCL_RAS_ENABLE", "1")
     monkeypatch.setattr(tracker_telemetry.jax, "default_backend", lambda: "gpu")
     monkeypatch.setattr(tracker_telemetry.jax, "process_index", lambda: 0)
@@ -196,7 +197,7 @@ def test_gpu_primary_process_exports_nccl_ras_until_finish(exported, monkeypatch
 
 def test_gpu_nonprimary_process_does_not_duplicate_nccl_ras_polling(exported, monkeypatch, tmp_path):
     marker = tmp_path / "ncclras-started"
-    _install_ncclras(monkeypatch, tmp_path, marker=marker)
+    _install_nccl_client(monkeypatch, tmp_path, marker=marker)
     monkeypatch.setenv("NCCL_RAS_ENABLE", "1")
     monkeypatch.setattr(tracker_telemetry.jax, "default_backend", lambda: "gpu")
     monkeypatch.setattr(tracker_telemetry.jax, "process_index", lambda: 1)

--- a/lib/levanter/tests/test_telemetry_tracker.py
+++ b/lib/levanter/tests/test_telemetry_tracker.py
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import os
 import stat
 import sys
 from pathlib import Path
-from threading import Event
+
 import jax.numpy as jnp
 import numpy as np
 import pytest
 from rigging import telemetry
-from rigging.testing import RecordingTelemetryTransport
+from rigging.telemetry.probes.nccl_client import NCCL_RAS_ENABLE_ENV
+from rigging.testing import RecordingTelemetryTransport, nccl_ras_payload
 
 from levanter.tracker import telemetry as tracker_telemetry
 from levanter.tracker.histogram import SummaryStats
@@ -33,48 +33,13 @@ def _values(records: list[dict]) -> dict[str, float]:
 
 
 def _install_nccl_client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, marker: Path | None = None) -> None:
-    payload = {
-        "nccl_version": "2.29.1",
-        "cuda_runtime_version": 13000,
-        "cuda_driver_version": 13000,
-        "communicators_count": 1,
-        "communicators": [
-            {
-                "hash": "0xabc",
-                "secondary_hash": "0xdef:0x123",
-                "size": 1,
-                "ranks_count": 1,
-                "missing_ranks_count": 0,
-                "ranks": [
-                    {
-                        "rank": 0,
-                        "host": "10.0.0.1",
-                        "pid": 1234,
-                        "cuda_dev": 0,
-                        "nvml_dev": 0,
-                        "status": {
-                            "init_state": 0,
-                            "async_error": 0,
-                            "finalize_called": False,
-                            "destroy_flag": False,
-                            "abort_flag": False,
-                        },
-                        "collective_counts": {"AllReduce": 12},
-                    }
-                ],
-                "missing_ranks": [],
-            }
-        ],
-        "ras": {"collection_time_sec": 0.125, "timeouts_count": 0},
-    }
     marker_write = (
         f"with open({str(marker)!r}, 'a') as marker_file:\n    marker_file.write('started\\n')\n" if marker else ""
     )
     command = tmp_path / "nccl-client"
-    command.write_text(f"#!{sys.executable}\n{marker_write}print({json.dumps(payload)!r})")
+    command.write_text(f"#!{sys.executable}\n{marker_write}print({json.dumps(nccl_ras_payload())!r})")
     command.chmod(command.stat().st_mode | stat.S_IXUSR)
     monkeypatch.setattr(tracker_telemetry.nccl, "_CLIENT_COMMAND", (str(command),))
-    monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
 
 
 def test_log_exports_jax_scalar_snapshots_without_service_prefix(exported):
@@ -179,32 +144,33 @@ def test_finish_stops_the_phase_heartbeat(exported, fast_heartbeat):
 def test_gpu_primary_process_exports_nccl_ras_until_finish(exported, monkeypatch, tmp_path):
     marker = tmp_path / "ncclras-started"
     _install_nccl_client(monkeypatch, tmp_path, marker=marker)
-    monkeypatch.setenv("NCCL_RAS_ENABLE", "1")
+    monkeypatch.setenv(NCCL_RAS_ENABLE_ENV, "1")
     monkeypatch.setattr(tracker_telemetry.jax, "default_backend", lambda: "gpu")
     monkeypatch.setattr(tracker_telemetry.jax, "process_index", lambda: 0)
-    monkeypatch.setattr(tracker_telemetry, "_NCCL_RAS_POLL_SECONDS", 0.01)
 
     tracker = TelemetryTracker()
-    rank = exported.record("communicator_rank_status", {"communicator_hash": "0xabc", "rank": "0"})
+    rank = exported.record(
+        "communicator_rank_status",
+        {"communicator_hash": "0xae94423cfbb2ef4a", "rank": "0"},
+    )
 
     tracker.finish()
-    completed_polls = marker.read_text()
-    Event().wait(0.05)
 
     assert rank["attributes"]["rank_host"] == "10.0.0.1"
-    assert marker.read_text() == completed_polls
+    assert marker.read_text() == "started\n"
 
 
-def test_gpu_nonprimary_process_does_not_duplicate_nccl_ras_polling(exported, monkeypatch, tmp_path):
-    marker = tmp_path / "ncclras-started"
-    _install_nccl_client(monkeypatch, tmp_path, marker=marker)
-    monkeypatch.setenv("NCCL_RAS_ENABLE", "1")
+def test_gpu_nonprimary_process_does_not_duplicate_nccl_ras_polling(exported, monkeypatch):
+    monkeypatch.setenv(NCCL_RAS_ENABLE_ENV, "1")
     monkeypatch.setattr(tracker_telemetry.jax, "default_backend", lambda: "gpu")
     monkeypatch.setattr(tracker_telemetry.jax, "process_index", lambda: 1)
+    monkeypatch.setattr(
+        tracker_telemetry.nccl,
+        "start",
+        lambda **_kwargs: pytest.fail("nonprimary process started NCCL RAS polling"),
+    )
 
     tracker = TelemetryTracker()
-    Event().wait(0.05)  # Give an incorrectly started background probe time to create the marker.
     tracker.finish()
 
-    assert not marker.exists()
     assert not any(record["name"] == "communicators" for record in exported.records)

--- a/lib/levanter/tests/test_telemetry_tracker.py
+++ b/lib/levanter/tests/test_telemetry_tracker.py
@@ -1,6 +1,12 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+from threading import Event
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -24,6 +30,48 @@ def exported(monkeypatch):
 
 def _values(records: list[dict]) -> dict[str, float]:
     return {record["name"]: record["value"] for record in records}
+
+
+def _install_ncclras(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, marker: Path | None = None) -> None:
+    payload = {
+        "nccl_version": "2.29.1",
+        "cuda_runtime_version": 13000,
+        "cuda_driver_version": 13000,
+        "communicators_count": 1,
+        "communicators": [
+            {
+                "hash": "0xabc",
+                "secondary_hash": "0xdef:0x123",
+                "size": 1,
+                "ranks_count": 1,
+                "missing_ranks_count": 0,
+                "ranks": [
+                    {
+                        "rank": 0,
+                        "host": "10.0.0.1",
+                        "pid": 1234,
+                        "cuda_dev": 0,
+                        "nvml_dev": 0,
+                        "status": {
+                            "init_state": 0,
+                            "async_error": 0,
+                            "finalize_called": False,
+                            "destroy_flag": False,
+                            "abort_flag": False,
+                        },
+                        "collective_counts": {"AllReduce": 12},
+                    }
+                ],
+                "missing_ranks": [],
+            }
+        ],
+        "ras": {"collection_time_sec": 0.125, "timeouts_count": 0},
+    }
+    marker_write = f"from pathlib import Path\nPath({str(marker)!r}).write_text('started')\n" if marker else ""
+    command = tmp_path / "ncclras"
+    command.write_text(f"#!{sys.executable}\n{marker_write}print({json.dumps(payload)!r})")
+    command.chmod(command.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
 
 
 def test_log_exports_jax_scalar_snapshots_without_service_prefix(exported):
@@ -123,3 +171,50 @@ def test_finish_stops_the_phase_heartbeat(exported, fast_heartbeat):
     tracker.finish()
 
     assert not fast_heartbeat.running
+
+
+def test_gpu_primary_process_exports_nccl_ras_until_finish(exported, monkeypatch, tmp_path):
+    _install_ncclras(monkeypatch, tmp_path)
+    monkeypatch.setenv("NCCL_RAS_ENABLE", "1")
+    monkeypatch.setattr(tracker_telemetry.jax, "default_backend", lambda: "gpu")
+    monkeypatch.setattr(tracker_telemetry.jax, "process_index", lambda: 0)
+
+    tracker = TelemetryTracker()
+    rank = exported.record("communicator_rank_status", {"communicator_hash": "0xabc", "rank": "0"})
+
+    tracker.finish()
+
+    assert rank["attributes"]["rank_host"] == "10.0.0.1"
+
+
+def test_finish_stops_nccl_ras_collection(exported, monkeypatch):
+    stopped = Event()
+
+    class RecordingProbe:
+        def shutdown(self):
+            stopped.set()
+
+    monkeypatch.setenv("NCCL_RAS_ENABLE", "1")
+    monkeypatch.setattr(tracker_telemetry.jax, "default_backend", lambda: "gpu")
+    monkeypatch.setattr(tracker_telemetry.jax, "process_index", lambda: 0)
+    monkeypatch.setattr(tracker_telemetry.nccl, "start", lambda **_kwargs: RecordingProbe())
+
+    tracker = TelemetryTracker()
+    tracker.finish()
+
+    assert stopped.is_set()
+
+
+def test_gpu_nonprimary_process_does_not_duplicate_nccl_ras_polling(exported, monkeypatch, tmp_path):
+    marker = tmp_path / "ncclras-started"
+    _install_ncclras(monkeypatch, tmp_path, marker=marker)
+    monkeypatch.setenv("NCCL_RAS_ENABLE", "1")
+    monkeypatch.setattr(tracker_telemetry.jax, "default_backend", lambda: "gpu")
+    monkeypatch.setattr(tracker_telemetry.jax, "process_index", lambda: 1)
+
+    tracker = TelemetryTracker()
+    Event().wait(0.05)  # Give an incorrectly started background probe time to create the marker.
+    tracker.finish()
+
+    assert not marker.exists()
+    assert not any(record["name"] == "communicators" for record in exported.records)

--- a/lib/levanter/tests/test_telemetry_tracker.py
+++ b/lib/levanter/tests/test_telemetry_tracker.py
@@ -67,7 +67,9 @@ def _install_ncclras(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, *, marker:
         ],
         "ras": {"collection_time_sec": 0.125, "timeouts_count": 0},
     }
-    marker_write = f"from pathlib import Path\nPath({str(marker)!r}).write_text('started')\n" if marker else ""
+    marker_write = (
+        f"with open({str(marker)!r}, 'a') as marker_file:\n    marker_file.write('started\\n')\n" if marker else ""
+    )
     command = tmp_path / "ncclras"
     command.write_text(f"#!{sys.executable}\n{marker_write}print({json.dumps(payload)!r})")
     command.chmod(command.stat().st_mode | stat.S_IXUSR)
@@ -174,35 +176,22 @@ def test_finish_stops_the_phase_heartbeat(exported, fast_heartbeat):
 
 
 def test_gpu_primary_process_exports_nccl_ras_until_finish(exported, monkeypatch, tmp_path):
-    _install_ncclras(monkeypatch, tmp_path)
+    marker = tmp_path / "ncclras-started"
+    _install_ncclras(monkeypatch, tmp_path, marker=marker)
     monkeypatch.setenv("NCCL_RAS_ENABLE", "1")
     monkeypatch.setattr(tracker_telemetry.jax, "default_backend", lambda: "gpu")
     monkeypatch.setattr(tracker_telemetry.jax, "process_index", lambda: 0)
+    monkeypatch.setattr(tracker_telemetry, "_NCCL_RAS_POLL_SECONDS", 0.01)
 
     tracker = TelemetryTracker()
     rank = exported.record("communicator_rank_status", {"communicator_hash": "0xabc", "rank": "0"})
 
     tracker.finish()
+    completed_polls = marker.read_text()
+    Event().wait(0.05)
 
     assert rank["attributes"]["rank_host"] == "10.0.0.1"
-
-
-def test_finish_stops_nccl_ras_collection(exported, monkeypatch):
-    stopped = Event()
-
-    class RecordingProbe:
-        def shutdown(self):
-            stopped.set()
-
-    monkeypatch.setenv("NCCL_RAS_ENABLE", "1")
-    monkeypatch.setattr(tracker_telemetry.jax, "default_backend", lambda: "gpu")
-    monkeypatch.setattr(tracker_telemetry.jax, "process_index", lambda: 0)
-    monkeypatch.setattr(tracker_telemetry.nccl, "start", lambda **_kwargs: RecordingProbe())
-
-    tracker = TelemetryTracker()
-    tracker.finish()
-
-    assert stopped.is_set()
+    assert marker.read_text() == completed_polls
 
 
 def test_gpu_nonprimary_process_does_not_duplicate_nccl_ras_polling(exported, monkeypatch, tmp_path):

--- a/lib/rigging/src/rigging/telemetry/probes/nccl.py
+++ b/lib/rigging/src/rigging/telemetry/probes/nccl.py
@@ -6,11 +6,13 @@
 import json
 import logging
 import math
+import sys
 from collections.abc import Mapping
 from time import monotonic
 from typing import NamedTuple
 
 from rigging import telemetry
+from rigging.telemetry.probes import nccl_client
 from rigging.telemetry.probes.runner import BoundedCommandRunner, CommandStatus, PeriodicProbe
 
 TIMEOUT = 8.0
@@ -21,6 +23,13 @@ _MAX_COLLECTIVES_PER_RANK = 64
 _MAX_METRICS = 4_096
 _MAX_FIELD_BYTES = 256
 _MAX_EXACT_COUNT = 2**53 - 1
+_CLIENT_COMMAND = (sys.executable, "-m", nccl_client.__name__)
+_CLIENT_FAILURES = {
+    nccl_client.TIMEOUT_EXIT_CODE: "client_timeout",
+    nccl_client.UNAVAILABLE_EXIT_CODE: "unavailable",
+    nccl_client.INVALID_CONFIG_EXIT_CODE: "invalid_client_config",
+    nccl_client.OUTPUT_LIMIT_EXIT_CODE: "output_limit",
+}
 
 logger = logging.getLogger(__name__)
 
@@ -64,24 +73,24 @@ class _MissingRank(NamedTuple):
 def collect(runner: BoundedCommandRunner) -> None:
     client_timeout = max(1, math.ceil(TIMEOUT * 0.75))
     started = monotonic()
-    command = runner.run_result(("ncclras", "-v", "-t", str(client_timeout), "-f", "json"), TIMEOUT)
+    command = runner.run_result((*_CLIENT_COMMAND, "--timeout", str(client_timeout)), TIMEOUT)
     duration = max(0.0, monotonic() - started)
     if command.status is CommandStatus.CANCELLED:
         return
     if command.output is None:
         _record_poll(command.status.value, duration)
         if command.status is CommandStatus.DEADLINE_EXCEEDED:
-            telemetry.counter("ras_poll_timeouts", unit="{timeout}").add(
-                1,
-                attributes=telemetry.snapshot_attributes("nccl_ras", telemetry.CUMULATIVE_SNAPSHOT),
-            )
+            _record_timeout()
         return
     if command.output.returncode != 0:
-        _record_poll("nonzero_exit", duration)
+        outcome = _CLIENT_FAILURES.get(command.output.returncode, "nonzero_exit")
+        _record_poll(outcome, duration)
+        if command.output.returncode == nccl_client.TIMEOUT_EXIT_CODE:
+            _record_timeout()
         return
 
     try:
-        metrics = _metrics(json.loads(command.output.stdout))
+        metrics = _metrics(_json_response(command.output.stdout))
     except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError) as error:
         logger.warning("could not parse NCCL RAS telemetry: %s", error)
         _record_poll("invalid_payload", duration)
@@ -89,6 +98,20 @@ def collect(runner: BoundedCommandRunner) -> None:
     _record_poll("success", duration)
     for metric in metrics:
         telemetry.gauge(metric.name, unit=metric.unit).set(metric.value, attributes=metric.attributes)
+
+
+def _json_response(response: bytes) -> object:
+    object_start = response.find(b"{")
+    if object_start < 0:
+        raise ValueError("NCCL RAS response did not contain JSON")
+    return json.loads(response[object_start:])
+
+
+def _record_timeout() -> None:
+    telemetry.counter("ras_poll_timeouts", unit="{timeout}").add(
+        1,
+        attributes=telemetry.snapshot_attributes("nccl_ras", telemetry.CUMULATIVE_SNAPSHOT),
+    )
 
 
 def _record_poll(outcome: str, duration: float) -> None:

--- a/lib/rigging/src/rigging/telemetry/probes/nccl.py
+++ b/lib/rigging/src/rigging/telemetry/probes/nccl.py
@@ -23,12 +23,13 @@ _MAX_COLLECTIVES_PER_RANK = 64
 _MAX_METRICS = 4_096
 _MAX_FIELD_BYTES = 256
 _MAX_EXACT_COUNT = 2**53 - 1
+_SUCCESS_OUTCOME = "success"
 _CLIENT_COMMAND = (sys.executable, "-m", nccl_client.__name__)
 _CLIENT_FAILURES = {
     nccl_client.TIMEOUT_EXIT_CODE: "client_timeout",
     nccl_client.UNAVAILABLE_EXIT_CODE: "unavailable",
     nccl_client.INVALID_CONFIG_EXIT_CODE: "invalid_client_config",
-    nccl_client.OUTPUT_LIMIT_EXIT_CODE: "output_limit",
+    nccl_client.OUTPUT_LIMIT_EXIT_CODE: CommandStatus.OUTPUT_LIMIT.value,
 }
 
 logger = logging.getLogger(__name__)
@@ -50,8 +51,8 @@ class _ReportedRank(NamedTuple):
     rank: int
     host: str
     pid: int
-    cuda_dev: int
-    nvml_dev: int
+    cuda_device: int
+    nvml_device: int
     init_state: int
     async_error: int
     finalized: bool
@@ -64,8 +65,8 @@ class _MissingRank(NamedTuple):
     rank: int
     host: str
     pid: int
-    cuda_dev: int
-    nvml_dev: int
+    cuda_device: int
+    nvml_device: int
     unresponsive: bool
     considered_dead: bool
 
@@ -95,7 +96,7 @@ def collect(runner: BoundedCommandRunner) -> None:
         logger.warning("could not parse NCCL RAS telemetry: %s", error)
         _record_poll("invalid_payload", duration)
         return
-    _record_poll("success", duration)
+    _record_poll(_SUCCESS_OUTCOME, duration)
     for metric in metrics:
         telemetry.gauge(metric.name, unit=metric.unit).set(metric.value, attributes=metric.attributes)
 
@@ -115,7 +116,7 @@ def _record_timeout() -> None:
 
 
 def _record_poll(outcome: str, duration: float) -> None:
-    available = outcome == "success"
+    available = outcome == _SUCCESS_OUTCOME
     current = {
         "outcome": outcome,
         **telemetry.snapshot_attributes("nccl_ras", telemetry.CURRENT_SNAPSHOT),
@@ -302,8 +303,8 @@ def _rank_identity(rank: _ReportedRank | _MissingRank) -> dict[str, str]:
         "rank": str(rank.rank),
         "rank_host": rank.host,
         "process_id": str(rank.pid),
-        "cuda_device": str(rank.cuda_dev),
-        "nvml_device": str(rank.nvml_dev),
+        "cuda_device": str(rank.cuda_device),
+        "nvml_device": str(rank.nvml_device),
     }
 
 

--- a/lib/rigging/src/rigging/telemetry/probes/nccl.py
+++ b/lib/rigging/src/rigging/telemetry/probes/nccl.py
@@ -7,12 +7,14 @@ import json
 import logging
 import math
 from collections.abc import Mapping
+from time import monotonic
 from typing import NamedTuple
 
 from rigging import telemetry
-from rigging.telemetry.probes.runner import BoundedCommandRunner, PeriodicProbe
+from rigging.telemetry.probes.runner import BoundedCommandRunner, CommandStatus, PeriodicProbe
 
 TIMEOUT = 8.0
+_DEFAULT_INTERVAL = 10 * 60.0
 _MAX_COMMUNICATORS = 256
 _MAX_RANKS_PER_COMMUNICATOR = 2_048
 _MAX_COLLECTIVES_PER_RANK = 64
@@ -23,9 +25,9 @@ _MAX_EXACT_COUNT = 2**53 - 1
 logger = logging.getLogger(__name__)
 
 
-def start() -> PeriodicProbe:
+def start(*, interval: float = _DEFAULT_INTERVAL) -> PeriodicProbe:
     """Collect NCCL RAS communicator evidence until shutdown."""
-    return PeriodicProbe("nccl_ras", collect)
+    return PeriodicProbe("nccl_ras", collect, interval=interval)
 
 
 class _Metric(NamedTuple):
@@ -37,6 +39,10 @@ class _Metric(NamedTuple):
 
 class _ReportedRank(NamedTuple):
     rank: int
+    host: str
+    pid: int
+    cuda_dev: int
+    nvml_dev: int
     init_state: int
     async_error: int
     finalized: bool
@@ -47,22 +53,59 @@ class _ReportedRank(NamedTuple):
 
 class _MissingRank(NamedTuple):
     rank: int
+    host: str
+    pid: int
+    cuda_dev: int
+    nvml_dev: int
     unresponsive: bool
     considered_dead: bool
 
 
 def collect(runner: BoundedCommandRunner) -> None:
     client_timeout = max(1, math.ceil(TIMEOUT * 0.75))
-    result = runner.run(("ncclras", "-v", "-t", str(client_timeout), "-f", "json"), TIMEOUT)
-    if result is None or result.returncode != 0:
+    started = monotonic()
+    command = runner.run_result(("ncclras", "-v", "-t", str(client_timeout), "-f", "json"), TIMEOUT)
+    duration = max(0.0, monotonic() - started)
+    if command.status is CommandStatus.CANCELLED:
         return
+    if command.output is None:
+        _record_poll(command.status.value, duration, failed=True)
+        if command.status is CommandStatus.DEADLINE_EXCEEDED:
+            telemetry.counter("ras_poll_timeouts", unit="{timeout}").add(
+                1,
+                attributes=telemetry.snapshot_attributes("nccl_ras", telemetry.CUMULATIVE_SNAPSHOT),
+            )
+        return
+    if command.output.returncode != 0:
+        _record_poll("nonzero_exit", duration, failed=True)
+        return
+
     try:
-        metrics = _metrics(json.loads(result.stdout))
+        metrics = _metrics(json.loads(command.output.stdout))
     except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError) as error:
         logger.warning("could not parse NCCL RAS telemetry: %s", error)
+        _record_poll("invalid_payload", duration, failed=True)
         return
+    _record_poll("success", duration, failed=False)
     for metric in metrics:
         telemetry.gauge(metric.name, unit=metric.unit).set(metric.value, attributes=metric.attributes)
+
+
+def _record_poll(outcome: str, duration: float, *, failed: bool) -> None:
+    current = {
+        "outcome": outcome,
+        **telemetry.snapshot_attributes("nccl_ras", telemetry.CURRENT_SNAPSHOT),
+    }
+    telemetry.gauge("ras_available").set(0.0 if failed else 1.0, attributes=current)
+    telemetry.histogram("ras_poll_duration_seconds", unit="s").record(duration, attributes=current)
+    if failed:
+        telemetry.counter("ras_poll_failures", unit="{failure}").add(
+            1,
+            attributes={
+                "failure_kind": outcome,
+                **telemetry.snapshot_attributes("nccl_ras", telemetry.CUMULATIVE_SNAPSHOT),
+            },
+        )
 
 
 def _metrics(payload: object) -> list[_Metric]:
@@ -150,7 +193,7 @@ def _communicator_metrics(value: dict[str, object], current: dict[str, str]) -> 
     )
     cumulative = telemetry.snapshot_attributes("nccl_ras", telemetry.CUMULATIVE_SNAPSHOT)
     for rank in reported:
-        rank_identity = {**identity, "rank": str(rank.rank)}
+        rank_identity = {**identity, **_rank_identity(rank)}
         metrics.append(
             _Metric(
                 "communicator_rank_status",
@@ -184,7 +227,7 @@ def _communicator_metrics(value: dict[str, object], current: dict[str, str]) -> 
             "",
             {
                 **identity,
-                "rank": str(rank.rank),
+                **_rank_identity(rank),
                 "rank_state": "missing",
                 "unresponsive": str(rank.unresponsive).lower(),
                 "considered_dead": str(rank.considered_dead).lower(),
@@ -204,6 +247,10 @@ def _reported_rank(value: dict[str, object]) -> _ReportedRank:
     collectives = {_bounded_text(name): _nonnegative_integer(count) for name, count in counts.items()}
     return _ReportedRank(
         _count(value, "rank"),
+        _text(value, "host"),
+        _count(value, "pid"),
+        _count(value, "cuda_dev"),
+        _count(value, "nvml_dev"),
         _count(status, "init_state"),
         _count(status, "async_error"),
         _boolean(status, "finalize_called"),
@@ -217,9 +264,23 @@ def _missing_rank(value: dict[str, object]) -> _MissingRank:
     status = _mapping(value.get("status"), "missing rank status")
     return _MissingRank(
         _count(value, "rank"),
+        _text(value, "host"),
+        _count(value, "pid"),
+        _count(value, "cuda_dev"),
+        _count(value, "nvml_dev"),
         _boolean(status, "unresponsive"),
         _boolean(status, "considered_dead"),
     )
+
+
+def _rank_identity(rank: _ReportedRank | _MissingRank) -> dict[str, str]:
+    return {
+        "rank": str(rank.rank),
+        "rank_host": rank.host,
+        "process_id": str(rank.pid),
+        "cuda_device": str(rank.cuda_dev),
+        "nvml_device": str(rank.nvml_dev),
+    }
 
 
 def _lifecycle_state(reported: list[_ReportedRank], missing: list[_MissingRank]) -> str:

--- a/lib/rigging/src/rigging/telemetry/probes/nccl.py
+++ b/lib/rigging/src/rigging/telemetry/probes/nccl.py
@@ -69,7 +69,7 @@ def collect(runner: BoundedCommandRunner) -> None:
     if command.status is CommandStatus.CANCELLED:
         return
     if command.output is None:
-        _record_poll(command.status.value, duration, failed=True)
+        _record_poll(command.status.value, duration)
         if command.status is CommandStatus.DEADLINE_EXCEEDED:
             telemetry.counter("ras_poll_timeouts", unit="{timeout}").add(
                 1,
@@ -77,28 +77,29 @@ def collect(runner: BoundedCommandRunner) -> None:
             )
         return
     if command.output.returncode != 0:
-        _record_poll("nonzero_exit", duration, failed=True)
+        _record_poll("nonzero_exit", duration)
         return
 
     try:
         metrics = _metrics(json.loads(command.output.stdout))
     except (UnicodeDecodeError, json.JSONDecodeError, TypeError, ValueError) as error:
         logger.warning("could not parse NCCL RAS telemetry: %s", error)
-        _record_poll("invalid_payload", duration, failed=True)
+        _record_poll("invalid_payload", duration)
         return
-    _record_poll("success", duration, failed=False)
+    _record_poll("success", duration)
     for metric in metrics:
         telemetry.gauge(metric.name, unit=metric.unit).set(metric.value, attributes=metric.attributes)
 
 
-def _record_poll(outcome: str, duration: float, *, failed: bool) -> None:
+def _record_poll(outcome: str, duration: float) -> None:
+    available = outcome == "success"
     current = {
         "outcome": outcome,
         **telemetry.snapshot_attributes("nccl_ras", telemetry.CURRENT_SNAPSHOT),
     }
-    telemetry.gauge("ras_available").set(0.0 if failed else 1.0, attributes=current)
+    telemetry.gauge("ras_available").set(float(available), attributes=current)
     telemetry.histogram("ras_poll_duration_seconds", unit="s").record(duration, attributes=current)
-    if failed:
+    if not available:
         telemetry.counter("ras_poll_failures", unit="{failure}").add(
             1,
             attributes={

--- a/lib/rigging/src/rigging/telemetry/probes/nccl_client.py
+++ b/lib/rigging/src/rigging/telemetry/probes/nccl_client.py
@@ -1,0 +1,100 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bounded client for NCCL's documented RAS text protocol."""
+
+import argparse
+import math
+import os
+import socket
+import sys
+
+from rigging.timing import Deadline
+
+DEFAULT_NCCL_RAS_ADDRESS = "localhost:28028"
+MAX_RESPONSE_BYTES = 256 * 1024
+TIMEOUT_EXIT_CODE = 2
+UNAVAILABLE_EXIT_CODE = 3
+INVALID_CONFIG_EXIT_CODE = 4
+OUTPUT_LIMIT_EXIT_CODE = 5
+_READ_SIZE = 64 * 1024
+
+
+class ResponseTooLargeError(RuntimeError):
+    """The RAS response exceeded the client's fixed memory bound."""
+
+
+def _parse_address(address: str) -> tuple[str, int]:
+    if address.startswith("["):
+        closing_bracket = address.find("]")
+        if closing_bracket < 0 or address[closing_bracket + 1 : closing_bracket + 2] != ":":
+            raise ValueError("bracketed NCCL RAS address must include a port")
+        host = address[1:closing_bracket]
+        raw_port = address[closing_bracket + 2 :]
+    else:
+        host, separator, raw_port = address.rpartition(":")
+        if not separator or ":" in host:
+            raise ValueError("NCCL RAS address must be host:port; bracket IPv6 addresses")
+    if not host or not raw_port:
+        raise ValueError("NCCL RAS address must include a host and port")
+    try:
+        port = int(raw_port)
+    except ValueError:
+        raise ValueError("NCCL RAS port must be an integer") from None
+    if not 1 <= port <= 65_535:
+        raise ValueError("NCCL RAS port must be between 1 and 65535")
+    return host, port
+
+
+def query_nccl_ras(*, address: str, timeout: float) -> bytes:
+    """Return one verbose JSON response from NCCL's local RAS service."""
+    if not math.isfinite(timeout) or timeout <= 0:
+        raise ValueError("NCCL RAS timeout must be positive and finite")
+
+    server_timeout = max(1, math.ceil(timeout))
+    request = f"TIMEOUT {server_timeout}\nSET FORMAT json\nVERBOSE STATUS\n".encode()
+    deadline = Deadline.from_seconds(timeout)
+    chunks: list[bytes] = []
+    response_size = 0
+    with socket.create_connection(_parse_address(address), timeout=timeout) as connection:
+        connection.sendall(request)
+        connection.shutdown(socket.SHUT_WR)
+        while True:
+            remaining = deadline.remaining_seconds()
+            if remaining <= 0:
+                raise TimeoutError("NCCL RAS query deadline exceeded")
+            connection.settimeout(remaining)
+            chunk = connection.recv(_READ_SIZE)
+            if not chunk:
+                return b"".join(chunks)
+            response_size += len(chunk)
+            if response_size > MAX_RESPONSE_BYTES:
+                raise ResponseTooLargeError(f"NCCL RAS response exceeded {MAX_RESPONSE_BYTES} bytes")
+            chunks.append(chunk)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Query NCCL RAS as JSON")
+    parser.add_argument("--address", default=os.environ.get("NCCL_RAS_ADDR", DEFAULT_NCCL_RAS_ADDRESS))
+    parser.add_argument("--timeout", type=float, required=True)
+    args = parser.parse_args()
+    try:
+        response = query_nccl_ras(address=args.address, timeout=args.timeout)
+    except TimeoutError as error:
+        print(error, file=sys.stderr)
+        return TIMEOUT_EXIT_CODE
+    except ResponseTooLargeError as error:
+        print(error, file=sys.stderr)
+        return OUTPUT_LIMIT_EXIT_CODE
+    except OSError as error:
+        print(error, file=sys.stderr)
+        return UNAVAILABLE_EXIT_CODE
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return INVALID_CONFIG_EXIT_CODE
+    sys.stdout.buffer.write(response)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/rigging/src/rigging/telemetry/probes/nccl_client.py
+++ b/lib/rigging/src/rigging/telemetry/probes/nccl_client.py
@@ -12,6 +12,8 @@ import sys
 from rigging.timing import Deadline
 
 DEFAULT_NCCL_RAS_ADDRESS = "localhost:28028"
+NCCL_RAS_ADDRESS_ENV = "NCCL_RAS_ADDR"
+NCCL_RAS_ENABLE_ENV = "NCCL_RAS_ENABLE"
 MAX_RESPONSE_BYTES = 256 * 1024
 TIMEOUT_EXIT_CODE = 2
 UNAVAILABLE_EXIT_CODE = 3
@@ -75,7 +77,7 @@ def query_nccl_ras(*, address: str, timeout: float) -> bytes:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Query NCCL RAS as JSON")
-    parser.add_argument("--address", default=os.environ.get("NCCL_RAS_ADDR", DEFAULT_NCCL_RAS_ADDRESS))
+    parser.add_argument("--address", default=os.environ.get(NCCL_RAS_ADDRESS_ENV, DEFAULT_NCCL_RAS_ADDRESS))
     parser.add_argument("--timeout", type=float, required=True)
     args = parser.parse_args()
     try:

--- a/lib/rigging/src/rigging/telemetry/probes/nvidia.py
+++ b/lib/rigging/src/rigging/telemetry/probes/nvidia.py
@@ -82,14 +82,14 @@ def _query(
     fields: tuple[str, ...],
     deadline: Deadline,
 ) -> CommandOutput | None:
-    return runner.run(
+    return runner.run_result(
         (
             "nvidia-smi",
             f"--query-gpu={','.join(fields)}",
             "--format=csv,noheader,nounits",
         ),
         deadline.remaining_seconds(),
-    )
+    ).output
 
 
 def _row_metrics(row: list[str], fields: tuple[str, ...]) -> list[_Metric]:

--- a/lib/rigging/src/rigging/telemetry/probes/runner.py
+++ b/lib/rigging/src/rigging/telemetry/probes/runner.py
@@ -12,6 +12,7 @@ import subprocess
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass
+from enum import StrEnum
 
 from rigging.timing import Deadline
 
@@ -29,6 +30,26 @@ class CommandOutput:
     returncode: int
 
 
+class CommandStatus(StrEnum):
+    """Terminal outcomes for a bounded probe command."""
+
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+    START_FAILED = "start_failed"
+    DEADLINE_EXCEEDED = "deadline_exceeded"
+    OUTPUT_LIMIT = "output_limit"
+    OUTPUT_FAILED = "output_failed"
+    INVALID_TIMEOUT = "invalid_timeout"
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """One bounded command result with an explicit non-completion reason."""
+
+    status: CommandStatus
+    output: CommandOutput | None = None
+
+
 class BoundedCommandRunner:
     """Run probe commands with bounded output, deadlines, and cancellation."""
 
@@ -39,14 +60,18 @@ class BoundedCommandRunner:
 
     def run(self, argv: tuple[str, ...], timeout: float) -> CommandOutput | None:
         """Return completed output, or None when collection cannot finish safely."""
+        return self.run_result(argv, timeout).output
+
+    def run_result(self, argv: tuple[str, ...], timeout: float) -> CommandResult:
+        """Return completed output or the reason collection did not complete."""
         if not argv:
             raise ValueError("argv must not be empty")
         if not math.isfinite(timeout) or timeout <= 0:
-            return None
+            return CommandResult(CommandStatus.INVALID_TIMEOUT)
 
         with self._lock:
             if self._cancelled:
-                return None
+                return CommandResult(CommandStatus.CANCELLED)
             try:
                 process = subprocess.Popen(
                     argv,
@@ -56,7 +81,7 @@ class BoundedCommandRunner:
                 )
             except OSError as error:
                 logger.debug("could not start telemetry probe %s: %s", argv[0], error)
-                return None
+                return CommandResult(CommandStatus.START_FAILED)
             self._active.add(process)
 
         assert process.stdout is not None
@@ -70,7 +95,7 @@ class BoundedCommandRunner:
                         remaining = deadline.remaining_seconds()
                         if remaining <= 0 or not selector.select(remaining):
                             self._terminate(process)
-                            return None
+                            return CommandResult(CommandStatus.DEADLINE_EXCEEDED)
                         chunk = os.read(process.stdout.fileno(), min(65_536, MAX_OUTPUT_BYTES + 1 - len(output)))
                         if not chunk:
                             selector.unregister(process.stdout)
@@ -78,21 +103,25 @@ class BoundedCommandRunner:
                         output.extend(chunk)
                         if len(output) > MAX_OUTPUT_BYTES:
                             self._terminate(process)
-                            return None
+                            return CommandResult(CommandStatus.OUTPUT_LIMIT)
             except OSError as error:
                 logger.warning("telemetry probe output failed for process %s: %s", process.pid, error)
                 self._terminate(process)
-                return None
+                return CommandResult(CommandStatus.OUTPUT_FAILED)
 
+            remaining = deadline.remaining_seconds()
+            if remaining <= 0:
+                self._terminate(process)
+                return CommandResult(CommandStatus.DEADLINE_EXCEEDED)
             try:
-                returncode = process.wait(timeout=deadline.remaining_seconds())
+                returncode = process.wait(timeout=remaining)
             except subprocess.TimeoutExpired:
                 self._terminate(process)
-                return None
+                return CommandResult(CommandStatus.DEADLINE_EXCEEDED)
             with self._lock:
                 if self._cancelled:
-                    return None
-            return CommandOutput(bytes(output), returncode)
+                    return CommandResult(CommandStatus.CANCELLED)
+            return CommandResult(CommandStatus.COMPLETED, CommandOutput(bytes(output), returncode))
         finally:
             process.stdout.close()
             with self._lock:
@@ -142,9 +171,18 @@ class BoundedCommandRunner:
 class PeriodicProbe:
     """Run one concrete collector periodically with bounded shutdown."""
 
-    def __init__(self, name: str, collect: Callable[[BoundedCommandRunner], None]) -> None:
+    def __init__(
+        self,
+        name: str,
+        collect: Callable[[BoundedCommandRunner], None],
+        *,
+        interval: float = _DEFAULT_INTERVAL,
+    ) -> None:
+        if not math.isfinite(interval) or interval <= 0:
+            raise ValueError("probe interval must be positive and finite")
         self._name = name
         self._collect = collect
+        self._interval = interval
         self._stop = threading.Event()
         self._runner = BoundedCommandRunner()
         self._thread = threading.Thread(target=self._run, name=f"rigging-probe-{name}", daemon=True)
@@ -158,7 +196,7 @@ class PeriodicProbe:
                 self._collect(self._runner)
             except Exception:
                 logger.warning("%s telemetry probe failed", self._name, exc_info=True)
-            if self._stop.wait(_DEFAULT_INTERVAL):
+            if self._stop.wait(self._interval):
                 return
 
     def shutdown(self, timeout: float = 2.0) -> None:

--- a/lib/rigging/src/rigging/telemetry/probes/runner.py
+++ b/lib/rigging/src/rigging/telemetry/probes/runner.py
@@ -58,10 +58,6 @@ class BoundedCommandRunner:
         self._active: set[subprocess.Popen[bytes]] = set()
         self._cancelled = False
 
-    def run(self, argv: tuple[str, ...], timeout: float) -> CommandOutput | None:
-        """Return completed output, or None when collection cannot finish safely."""
-        return self.run_result(argv, timeout).output
-
     def run_result(self, argv: tuple[str, ...], timeout: float) -> CommandResult:
         """Return completed output or the reason collection did not complete."""
         if not argv:

--- a/lib/rigging/src/rigging/testing.py
+++ b/lib/rigging/src/rigging/testing.py
@@ -97,3 +97,50 @@ class RecordingTelemetryTransport:
                 ),
                 timeout=5,
             )
+
+
+def nccl_ras_payload() -> dict[str, object]:
+    """Return a representative NCCL verbose-status response for downstream tests."""
+    return {
+        "nccl_version": "2.29.1",
+        "cuda_runtime_version": 13000,
+        "cuda_driver_version": 13000,
+        "communicators_count": 1,
+        "communicators": [
+            {
+                "hash": "0xae94423cfbb2ef4a",
+                "secondary_hash": "0xb7e7187447156001:0xb8242ed28a71381e",
+                "size": 2,
+                "ranks_count": 1,
+                "missing_ranks_count": 1,
+                "ranks": [
+                    {
+                        "rank": 0,
+                        "host": "10.0.0.1",
+                        "pid": 1234,
+                        "cuda_dev": 0,
+                        "nvml_dev": 3,
+                        "status": {
+                            "init_state": 0,
+                            "async_error": 0,
+                            "finalize_called": False,
+                            "destroy_flag": False,
+                            "abort_flag": False,
+                        },
+                        "collective_counts": {"AllReduce": 12},
+                    }
+                ],
+                "missing_ranks": [
+                    {
+                        "rank": 1,
+                        "host": "10.0.0.2",
+                        "pid": 5678,
+                        "cuda_dev": 0,
+                        "nvml_dev": 1,
+                        "status": {"unresponsive": True, "considered_dead": False},
+                    }
+                ],
+            }
+        ],
+        "ras": {"collection_time_sec": 0.125, "timeouts_count": 2},
+    }

--- a/lib/rigging/tests/test_probes.py
+++ b/lib/rigging/tests/test_probes.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import pytest
 from rigging import telemetry
 from rigging.telemetry.probes import nccl, nccl_client, nvidia
-from rigging.testing import RecordingTelemetryTransport
+from rigging.testing import RecordingTelemetryTransport, nccl_ras_payload
 
 
 @pytest.fixture(autouse=True)
@@ -54,52 +54,6 @@ def _install_commands(
     monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
 
 
-def _nccl_payload() -> dict[str, object]:
-    return {
-        "nccl_version": "2.29.1",
-        "cuda_runtime_version": 13000,
-        "cuda_driver_version": 13000,
-        "communicators_count": 1,
-        "communicators": [
-            {
-                "hash": "0xae94423cfbb2ef4a",
-                "secondary_hash": "0xb7e7187447156001:0xb8242ed28a71381e",
-                "size": 2,
-                "ranks_count": 1,
-                "missing_ranks_count": 1,
-                "ranks": [
-                    {
-                        "rank": 0,
-                        "host": "10.0.0.1",
-                        "pid": 1234,
-                        "cuda_dev": 0,
-                        "nvml_dev": 3,
-                        "status": {
-                            "init_state": 0,
-                            "async_error": 0,
-                            "finalize_called": False,
-                            "destroy_flag": False,
-                            "abort_flag": False,
-                        },
-                        "collective_counts": {"AllReduce": 12},
-                    }
-                ],
-                "missing_ranks": [
-                    {
-                        "rank": 1,
-                        "host": "10.0.0.2",
-                        "pid": 5678,
-                        "cuda_dev": 0,
-                        "nvml_dev": 1,
-                        "status": {"unresponsive": True, "considered_dead": False},
-                    }
-                ],
-            }
-        ],
-        "ras": {"collection_time_sec": 0.125, "timeouts_count": 2},
-    }
-
-
 class _RasConnection:
     def __init__(self, responses: list[bytes]) -> None:
         self._responses = iter(responses)
@@ -125,7 +79,7 @@ class _RasConnection:
 
 
 def test_nccl_client_queries_documented_json_status(monkeypatch: pytest.MonkeyPatch) -> None:
-    connection = _RasConnection([b"OK\nOK\n", json.dumps(_nccl_payload()).encode(), b""])
+    connection = _RasConnection([b"OK\nOK\n", json.dumps(nccl_ras_payload()).encode(), b""])
     connected_to: list[tuple[tuple[str, int], float]] = []
 
     def connect(address: tuple[str, int], timeout: float) -> _RasConnection:
@@ -138,7 +92,7 @@ def test_nccl_client_queries_documented_json_status(monkeypatch: pytest.MonkeyPa
 
     assert connected_to == [(("localhost", 28028), 1.2)]
     assert connection.request == b"TIMEOUT 2\nSET FORMAT json\nVERBOSE STATUS\n"
-    assert response == b"OK\nOK\n" + json.dumps(_nccl_payload()).encode()
+    assert response == b"OK\nOK\n" + json.dumps(nccl_ras_payload()).encode()
 
 
 def test_nccl_client_bounds_one_shot_response(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -162,7 +116,7 @@ def test_nvidia_probe_emits_only_stable_hardware_evidence(
         monkeypatch,
         tmp_path,
         nvidia_source=f"print({nvidia_row!r})",
-        nccl_source=f"print({json.dumps(_nccl_payload())!r})",
+        nccl_source=f"print({json.dumps(nccl_ras_payload())!r})",
     )
     transport = _configure(monkeypatch)
 
@@ -183,7 +137,7 @@ def test_nccl_probe_emits_only_communicator_evidence(
         monkeypatch,
         tmp_path,
         nvidia_source="raise SystemExit(2)",
-        nccl_source=f"print({json.dumps(_nccl_payload())!r})",
+        nccl_source=f"print({json.dumps(nccl_ras_payload())!r})",
     )
     transport = _configure(monkeypatch)
 
@@ -290,7 +244,7 @@ def test_output_limit_drops_one_probe_without_blocking_its_peer(
         monkeypatch,
         tmp_path,
         nvidia_source="import os\nos.write(1, b'x' * 300_000)",
-        nccl_source=f"print({json.dumps(_nccl_payload())!r})",
+        nccl_source=f"print({json.dumps(nccl_ras_payload())!r})",
     )
     transport = _configure(monkeypatch)
 

--- a/lib/rigging/tests/test_probes.py
+++ b/lib/rigging/tests/test_probes.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pytest
 from rigging import telemetry
-from rigging.telemetry.probes import nccl, nvidia
+from rigging.telemetry.probes import nccl, nccl_client, nvidia
 from rigging.testing import RecordingTelemetryTransport
 
 
@@ -49,7 +49,8 @@ def _install_commands(
     nccl_source: str,
 ) -> None:
     _executable(tmp_path / "nvidia-smi", nvidia_source)
-    _executable(tmp_path / "ncclras", nccl_source)
+    _executable(tmp_path / "nccl-client", nccl_source)
+    monkeypatch.setattr(nccl, "_CLIENT_COMMAND", (str(tmp_path / "nccl-client"),))
     monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
 
 
@@ -97,6 +98,56 @@ def _nccl_payload() -> dict[str, object]:
         ],
         "ras": {"collection_time_sec": 0.125, "timeouts_count": 2},
     }
+
+
+class _RasConnection:
+    def __init__(self, responses: list[bytes]) -> None:
+        self._responses = iter(responses)
+        self.request = b""
+
+    def __enter__(self) -> "_RasConnection":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        pass
+
+    def sendall(self, request: bytes) -> None:
+        self.request += request
+
+    def shutdown(self, _how: int) -> None:
+        pass
+
+    def settimeout(self, _timeout: float) -> None:
+        pass
+
+    def recv(self, _size: int) -> bytes:
+        return next(self._responses)
+
+
+def test_nccl_client_queries_documented_json_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    connection = _RasConnection([b"OK\nOK\n", json.dumps(_nccl_payload()).encode(), b""])
+    connected_to: list[tuple[tuple[str, int], float]] = []
+
+    def connect(address: tuple[str, int], timeout: float) -> _RasConnection:
+        connected_to.append((address, timeout))
+        return connection
+
+    monkeypatch.setattr(nccl_client.socket, "create_connection", connect)
+
+    response = nccl_client.query_nccl_ras(address="localhost:28028", timeout=1.2)
+
+    assert connected_to == [(("localhost", 28028), 1.2)]
+    assert connection.request == b"TIMEOUT 2\nSET FORMAT json\nVERBOSE STATUS\n"
+    assert response == b"OK\nOK\n" + json.dumps(_nccl_payload()).encode()
+
+
+def test_nccl_client_bounds_one_shot_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    connection = _RasConnection([b"oversized"])
+    monkeypatch.setattr(nccl_client.socket, "create_connection", lambda *_args, **_kwargs: connection)
+    monkeypatch.setattr(nccl_client, "MAX_RESPONSE_BYTES", 8)
+
+    with pytest.raises(nccl_client.ResponseTooLargeError):
+        nccl_client.query_nccl_ras(address="localhost:28028", timeout=1)
 
 
 def test_nvidia_probe_emits_only_stable_hardware_evidence(
@@ -171,13 +222,13 @@ def test_nccl_probe_records_unavailable_service(
         monkeypatch,
         tmp_path,
         nvidia_source="raise SystemExit(2)",
-        nccl_source="raise SystemExit(2)",
+        nccl_source=f"raise SystemExit({nccl_client.UNAVAILABLE_EXIT_CODE})",
     )
     transport = _configure(monkeypatch)
 
     session = nccl.start()
-    available = transport.record("ras_available", {"outcome": "nonzero_exit"})
-    failures = transport.record("ras_poll_failures", {"failure_kind": "nonzero_exit"})
+    available = transport.record("ras_available", {"outcome": "unavailable"})
+    failures = transport.record("ras_poll_failures", {"failure_kind": "unavailable"})
     session.shutdown()
 
     assert available["value"] == 0
@@ -266,12 +317,13 @@ pathlib.Path(os.environ['PROBE_PID_PATH']).write_text(str(os.getpid()))
 threading.Event().wait(60)
 """
     _executable(tmp_path / "nvidia-smi", blocking_source)
-    _executable(tmp_path / "ncclras", blocking_source)
+    _executable(tmp_path / "nccl-client", blocking_source)
+    monkeypatch.setattr(nccl, "_CLIENT_COMMAND", (str(tmp_path / "nccl-client"),))
     monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
     monkeypatch.setenv("PROBE_PID_PATH", str(nvidia_pid))
 
     # Give each command a distinct output path while retaining the real process boundary.
-    nccl_command = tmp_path / "ncclras"
+    nccl_command = tmp_path / "nccl-client"
     nccl_command.write_text(nccl_command.read_text().replace("PROBE_PID_PATH", "NCCL_PID_PATH"))
     monkeypatch.setenv("NCCL_PID_PATH", str(nccl_pid))
 

--- a/lib/rigging/tests/test_probes.py
+++ b/lib/rigging/tests/test_probes.py
@@ -69,6 +69,10 @@ def _nccl_payload() -> dict[str, object]:
                 "ranks": [
                     {
                         "rank": 0,
+                        "host": "10.0.0.1",
+                        "pid": 1234,
+                        "cuda_dev": 0,
+                        "nvml_dev": 3,
                         "status": {
                             "init_state": 0,
                             "async_error": 0,
@@ -82,6 +86,10 @@ def _nccl_payload() -> dict[str, object]:
                 "missing_ranks": [
                     {
                         "rank": 1,
+                        "host": "10.0.0.2",
+                        "pid": 5678,
+                        "cuda_dev": 0,
+                        "nvml_dev": 1,
                         "status": {"unresponsive": True, "considered_dead": False},
                     }
                 ],
@@ -134,13 +142,72 @@ def test_nccl_probe_emits_only_communicator_evidence(
         {"communicator_hash": "0xae94423cfbb2ef4a", "rank": "1"},
     )
     collective = transport.record("collective_operations", {"collective": "AllReduce", "rank": "0"})
+    available = transport.record("ras_available", {"outcome": "success"})
+    poll_duration = transport.record("ras_poll_duration_seconds", {"outcome": "success"})
     session.shutdown()
 
     assert rank["attributes"]["rank_state"] == "missing"
     assert rank["attributes"]["unresponsive"] == "true"
+    assert rank["attributes"]["rank_host"] == "10.0.0.2"
+    assert rank["attributes"]["process_id"] == "5678"
+    assert rank["attributes"]["cuda_device"] == "0"
+    assert rank["attributes"]["nvml_device"] == "1"
     assert collective["value"] == 12
+    assert collective["attributes"]["rank_host"] == "10.0.0.1"
+    assert collective["attributes"]["process_id"] == "1234"
+    assert collective["attributes"]["cuda_device"] == "0"
+    assert collective["attributes"]["nvml_device"] == "3"
     assert collective["attributes"]["source_temporality"] == telemetry.CUMULATIVE_SNAPSHOT
+    assert available["value"] == 1
+    assert poll_duration["kind"] == "histogram"
     assert not any(record["name"] == "hardware_inventory" for record in transport.records)
+
+
+def test_nccl_probe_records_unavailable_service(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_commands(
+        monkeypatch,
+        tmp_path,
+        nvidia_source="raise SystemExit(2)",
+        nccl_source="raise SystemExit(2)",
+    )
+    transport = _configure(monkeypatch)
+
+    session = nccl.start()
+    available = transport.record("ras_available", {"outcome": "nonzero_exit"})
+    failures = transport.record("ras_poll_failures", {"failure_kind": "nonzero_exit"})
+    session.shutdown()
+
+    assert available["value"] == 0
+    assert failures["kind"] == "counter"
+    assert failures["value"] == 1
+    assert failures["attributes"]["source_temporality"] == telemetry.CUMULATIVE_SNAPSHOT
+
+
+def test_nccl_probe_records_outer_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_commands(
+        monkeypatch,
+        tmp_path,
+        nvidia_source="raise SystemExit(2)",
+        nccl_source="import threading\nthreading.Event().wait(60)",
+    )
+    monkeypatch.setattr(nccl, "TIMEOUT", 0.05)
+    transport = _configure(monkeypatch)
+
+    session = nccl.start()
+    available = transport.record("ras_available", {"outcome": "deadline_exceeded"})
+    timeouts = transport.record("ras_poll_timeouts", {})
+    session.shutdown()
+
+    assert available["value"] == 0
+    assert timeouts["kind"] == "counter"
+    assert timeouts["value"] == 1
+    assert not any(record["name"] == "communicators" for record in transport.records)
 
 
 def test_nvidia_probe_falls_back_to_stable_inventory_fields(


### PR DESCRIPTION
Poll NCCL's job-global RAS view from JAX process 0 every two minutes during GPU Levanter runs. Communicator inventory and state, per-rank status, collective counters, vendor and client collection latency, and explicit failure and timeout outcomes now reach Finelog with Iris task, attempt, node, process, execution, and root-run identity.

The collector uses NCCL's documented text protocol through a bounded Python subprocess, so training images do not need the separately packaged `ncclras` executable. It has an eight-second deadline and a 256 KiB response ceiling, remains isolated from the training process, and stops during tracker shutdown. One collector avoids repeating the job-global query from every rank; rank rows retain NCCL host, PID, CUDA-device, and NVML-device identity for localization.

The Iris runbook includes a bounded, read-only task-local query for live validation. Iris's current Kubernetes sidecar ships logs and its node agent collects host hardware, so neither duplicates these communicator snapshots. A generic task-scoped Iris collector remains follow-up work because host-networked GPU tasks need job-specific RAS address isolation and runtime identity propagation.

This closes the telemetry gap recorded in https://echo.oa.dev/wiki/85. A multi-node GPU smoke remains required to verify the production NCCL 2.28.9 response and the full CoreWeave-to-hub Finelog path; no live job or cluster was changed here.

Part of #7344

Part of #7796
