### PR TITLE
[tests] Limit metadata probes during pytest collection

### DIFF
--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -108,7 +108,8 @@ def _rows_flat(
     The registry names in ``counts`` must match the keys returned by
     ``factory()``. Rows whose registry name isn't in ``counts`` are skipped.
     """
-    return tuple((name, lambda f=factory, n=name: f()[n], count) for name, count in counts.items())
+    cached_factory = cache(factory)
+    return tuple((name, lambda f=cached_factory, n=name: f()[n], count) for name, count in counts.items())
 
 
 def _rows_nemotron(

--- a/lib/rigging/src/rigging/filesystem/cluster_config.py
+++ b/lib/rigging/src/rigging/filesystem/cluster_config.py
@@ -310,9 +310,10 @@ def _parse_data_config(data: Mapping[str, object]) -> DataConfig:
 
 
 def reset_data_config_cache() -> None:
-    """Clear the cluster-config and bucket-registry caches. For tests."""
+    """Clear the cluster-config, region, and bucket-registry caches. For tests."""
     _load_cluster_config_cached.cache_clear()
     data_buckets.cache_clear()
+    _region_from_metadata.cache_clear()
     s3_data_buckets.cache_clear()
     store_configs.cache_clear()
 
@@ -322,7 +323,8 @@ def reset_data_config_cache() -> None:
 # ---------------------------------------------------------------------------
 
 
-def region_from_metadata() -> str | None:
+@functools.cache
+def _region_from_metadata() -> str | None:
     """Derive the GCP region from the instance metadata server, or ``None``."""
     try:
         req = urllib.request.Request(_GCP_METADATA_ZONE_URL, headers={"Metadata-Flavor": "Google"})
@@ -333,6 +335,11 @@ def region_from_metadata() -> str | None:
     if "-" not in zone:
         return None
     return zone.rsplit("-", 1)[0]
+
+
+def region_from_metadata() -> str | None:
+    """Derive the cached GCP region from the instance metadata server."""
+    return _region_from_metadata()
 
 
 def region_from_prefix(prefix: str) -> str | None:

--- a/lib/rigging/tests/test_region_routing.py
+++ b/lib/rigging/tests/test_region_routing.py
@@ -30,16 +30,22 @@ def _mock_urlopen(zone_bytes: bytes) -> MagicMock:
     return mock_resp
 
 
-def test_region_from_metadata_parses_zone():
+def test_region_from_metadata_caches_parsed_zone():
+    response = _mock_urlopen(b"projects/12345/zones/us-central2-b")
     with patch(
         "rigging.filesystem.cluster_config.urllib.request.urlopen",
-        return_value=_mock_urlopen(b"projects/12345/zones/us-central2-b"),
+        side_effect=[response, AssertionError("metadata server called more than once")],
     ):
+        assert region_from_metadata() == "us-central2"
         assert region_from_metadata() == "us-central2"
 
 
-def test_region_from_metadata_returns_none_on_failure():
-    with patch("rigging.filesystem.cluster_config.urllib.request.urlopen", side_effect=OSError("not on GCP")):
+def test_region_from_metadata_caches_failure():
+    with patch(
+        "rigging.filesystem.cluster_config.urllib.request.urlopen",
+        side_effect=[OSError("not on GCP"), AssertionError("metadata server called more than once")],
+    ):
+        assert region_from_metadata() is None
         assert region_from_metadata() is None
 
 

--- a/tests/datakit/testbed/test_sampler_pipeline.py
+++ b/tests/datakit/testbed/test_sampler_pipeline.py
@@ -8,12 +8,10 @@ from marin.datakit.sources import DatakitSource, all_sources
 
 from experiments.datakit.testbed.sampler import build_testbed_steps
 
-_ALL = all_sources()
-_ALL_LIST = list(_ALL.values())
 
-
-def _source(name: str) -> DatakitSource:
-    return _ALL[name]
+@pytest.fixture
+def datakit_sources() -> dict[str, DatakitSource]:
+    return all_sources()
 
 
 def test_dag_empty_source_list_raises():
@@ -21,9 +19,9 @@ def test_dag_empty_source_list_raises():
         build_testbed_steps(sources=[])
 
 
-def test_dag_single_source_emits_full_chain_in_order():
+def test_dag_single_source_emits_full_chain_in_order(datakit_sources):
     """Per-source step ordering: download → normalize → sample."""
-    src = _source("nemotron_cc_code_v1/all")
+    src = datakit_sources["nemotron_cc_code_v1/all"]
     steps = build_testbed_steps(sources=[src])
 
     names = [s.name for s in steps]
@@ -34,14 +32,14 @@ def test_dag_single_source_emits_full_chain_in_order():
     ]
 
 
-def test_dag_stops_at_sample():
+def test_dag_stops_at_sample(datakit_sources):
     """No testbed-specific stages beyond sample (guards against re-adding noop_dedup/consolidate)."""
-    steps = build_testbed_steps(sources=_ALL_LIST)
+    steps = build_testbed_steps(sources=list(datakit_sources.values()))
     testbed_steps = [s for s in steps if s.name.startswith("data/datakit/normalized/")]
-    assert len(testbed_steps) == len(_ALL_LIST), "expected exactly one testbed step per source (the sampler)"
+    assert len(testbed_steps) == len(datakit_sources), "expected exactly one testbed step per source (the sampler)"
 
 
-def test_dag_nemotron_family_subsets_share_one_download_stepspec():
+def test_dag_nemotron_family_subsets_share_one_download_stepspec(datakit_sources):
     """Every Nemotron-CC v2.1 subset's chain starts with the SAME StepSpec object.
 
     Subsets share one family download because
@@ -49,7 +47,7 @@ def test_dag_nemotron_family_subsets_share_one_download_stepspec():
     to each subset's normalize step. Duplicate downloads in the returned list
     are the same Python object, which the executor trivially dedupes.
     """
-    v21_sources = tuple(s for s in _ALL.values() if s.name.startswith("nemotron_cc_v2_1/"))
+    v21_sources = tuple(s for s in datakit_sources.values() if s.name.startswith("nemotron_cc_v2_1/"))
     assert len(v21_sources) > 1, "registry must have multiple v2.1 subsets"
 
     first_download = v21_sources[0].normalize_steps[0]
@@ -57,10 +55,10 @@ def test_dag_nemotron_family_subsets_share_one_download_stepspec():
         assert src.normalize_steps[0] is first_download, "v2.1 subsets must share one download StepSpec"
 
 
-def test_dag_starcoder2_subsets_get_distinct_download_names():
+def test_dag_starcoder2_subsets_get_distinct_download_names(datakit_sources):
     """StarCoder2-Extras stages each subset under its own path; the download
     names must reflect that disambiguation so per-subset StepSpecs don't collide."""
-    subsets = tuple(s for s in _ALL.values() if s.name.startswith("starcoder2/"))
+    subsets = tuple(s for s in datakit_sources.values() if s.name.startswith("starcoder2/"))
     assert len(subsets) > 1
 
     download_names = {s.normalize_steps[0].name for s in subsets}

--- a/tests/datakit/testbed/test_train.py
+++ b/tests/datakit/testbed/test_train.py
@@ -9,7 +9,8 @@ tokenizer (gated repo), so its end-to-end shape is validated by a live smoke
 run rather than unit tests.
 """
 
-from marin.datakit.sources import all_sources
+import pytest
+from marin.datakit.sources import DatakitSource, all_sources
 from marin.execution.step_spec import StepSpec
 from marin.processing.tokenize import TokenizeConfig, lm_mixture_data_config
 
@@ -18,10 +19,13 @@ from experiments.datakit.testbed.settings import TESTBED_TOKENIZER
 from experiments.datakit.testbed.train import _bucket_tokenize_config
 from experiments.datakit.testbed.train import testbed_tokenize as _testbed_tokenize
 
-_SMOKE_SOURCE = all_sources()["nemotron_cc_code_v1/all"]
+
+@pytest.fixture
+def smoke_source() -> DatakitSource:
+    return all_sources()["nemotron_cc_code_v1/all"]
 
 
-def test_tokenize_step_bridge_depends_on_sample_and_yields_tokenize_config(monkeypatch):
+def test_tokenize_step_bridge_depends_on_sample_and_yields_tokenize_config(monkeypatch, smoke_source):
     """sample StepSpec -> tokenize StepSpec, wired to the sample as a dependency.
 
     The bridge must produce a step that depends on the sample shards and whose
@@ -29,9 +33,9 @@ def test_tokenize_step_bridge_depends_on_sample_and_yields_tokenize_config(monke
     """
     monkeypatch.setenv("MARIN_PREFIX", "gs://example-bucket")
 
-    steps = build_testbed_steps(sources=[_SMOKE_SOURCE])
+    steps = build_testbed_steps(sources=[smoke_source])
     sampled = next(s for s in steps if s.name.startswith("data/datakit/normalized/"))
-    step = _testbed_tokenize(_SMOKE_SOURCE.name, sampled)
+    step = _testbed_tokenize(smoke_source.name, sampled)
 
     assert isinstance(step, StepSpec)
     assert step.deps == [sampled]
@@ -42,15 +46,15 @@ def test_tokenize_step_bridge_depends_on_sample_and_yields_tokenize_config(monke
     assert config.train_paths == [f"{sampled.output_path}/outputs/main/*.parquet"]
 
 
-def test_bridge_steps_compose_into_lm_mixture(monkeypatch):
+def test_bridge_steps_compose_into_lm_mixture(monkeypatch, smoke_source):
     """The bridged tokenize config composes into ``lm_mixture_data_config``."""
     monkeypatch.setenv("MARIN_PREFIX", "gs://example-bucket")
 
-    steps = build_testbed_steps(sources=[_SMOKE_SOURCE])
+    steps = build_testbed_steps(sources=[smoke_source])
     sampled = next(s for s in steps if s.name.startswith("data/datakit/normalized/"))
-    step = _testbed_tokenize(_SMOKE_SOURCE.name, sampled)
-    components = {_SMOKE_SOURCE.name: _bucket_tokenize_config(step, TESTBED_TOKENIZER)}
+    step = _testbed_tokenize(smoke_source.name, sampled)
+    components = {smoke_source.name: _bucket_tokenize_config(step, TESTBED_TOKENIZER)}
 
-    mixture = lm_mixture_data_config(components=components, weights={_SMOKE_SOURCE.name: 1.0})
-    assert _SMOKE_SOURCE.name in mixture.train_weights
-    assert mixture.train_weights[_SMOKE_SOURCE.name] == 1.0
+    mixture = lm_mixture_data_config(components=components, weights={smoke_source.name: 1.0})
+    assert smoke_source.name in mixture.train_weights
+    assert mixture.train_weights[smoke_source.name] == 1.0


### PR DESCRIPTION
Cache GCP metadata discovery once per process and materialize each Datakit
family factory once. Building the 292-source registry without `MARIN_PREFIX`
previously issued 21,326 metadata requests; 20,164 came from expanding the
142-source Penfever family once per row.

Build the Datakit registries used by structural tests from function-scoped
fixtures after `MARIN_PREFIX` is active. Bare `uv run pytest --collect-only -q`
now completes in 8.6 seconds and selects 1,388 tests.
