### PR TITLE
[echo] Show pending dashboard searches

### DIFF
--- a/infra/echo/dashboard/src/views/SearchView.vue
+++ b/infra/echo/dashboard/src/views/SearchView.vue
@@ -23,6 +23,7 @@ const index = ref<RepositoryIndexStatus | null>(null)
 const indexError = ref('')
 const loading = ref(false)
 const error = ref('')
+const searchPending = ref(false)
 let request: AbortController | null = null
 let ready = false
 
@@ -42,6 +43,8 @@ const indexPercent = computed(() => {
 const resultLabel = computed(() => {
   if (loading.value) return 'Searching…'
   if (!query.value.trim()) return 'Search files, knowledge, and conversations'
+  if (!selectedDomains.value.length) return 'Select at least one search domain'
+  if (searchPending.value) return 'Press Search to apply the query and filters'
   if (!results.value.length) return 'No matches'
   return `${results.value.length} ${results.value.length === 1 ? 'result' : 'results'}`
 })
@@ -50,12 +53,17 @@ function toggleDomain(domain: SearchDomain): void {
   selectedDomains.value = selectedDomains.value.includes(domain)
     ? selectedDomains.value.filter((candidate) => candidate !== domain)
     : [...selectedDomains.value, domain]
-  if (!selectedDomains.value.length) {
-    request?.abort()
-    results.value = []
-    loading.value = false
-    syncUrl()
-  }
+  markSearchPending()
+  syncUrl()
+}
+
+function markSearchPending(): void {
+  // Browser cancellation does not stop server-side inference, so edits wait for form submission.
+  request?.abort()
+  results.value = []
+  loading.value = false
+  error.value = ''
+  searchPending.value = true
 }
 
 function wikiPath(result: FederatedResult): string {
@@ -103,6 +111,7 @@ async function search(): Promise<void> {
   request = new AbortController()
   loading.value = true
   error.value = ''
+  searchPending.value = false
   const params = new URLSearchParams({ q: text, limit: String(PAGE_SIZE) })
   for (const domain of selectedDomains.value) params.append('domain', domain)
   try {
@@ -177,6 +186,7 @@ onMounted(async () => {
         class="min-w-0 flex-1 rounded-lg border border-line bg-white px-4 py-3 placeholder:text-ink/35"
         placeholder="Identifier, incident, question, or phrase…"
         type="search"
+        @input="markSearchPending"
       />
       <button
         class="rounded-lg bg-moss px-6 py-3 font-semibold text-white hover:bg-fern disabled:cursor-wait disabled:opacity-60"


### PR DESCRIPTION
Clear stale results when the query or selected domains change and label edited searches as pending until Search is submitted. Persist each domain selection in the URL.

Live issue-only search for `TPU failure` returns issue and comment hits, confirming that the export and API filter are populated. The false empty state appeared after #7875 made dashboard searches submit-only: clearing all domains removed the old results, while selecting Issues left the page at `No matches` before any request ran.

Keep filter edits free of background inference. Browser cancellation does not stop server-side reranking; submit-only search prevents the overlapping abandoned requests described in the [Echo memory incident](https://echo.oa.dev/wiki/62).

[Weaver session](https://loom.oa.dev/s/799u40mo)
