### PR TITLE
[loom] Store runtime data on the root disk

### DIFF
--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -12,8 +12,7 @@ config:
   marin-loom:vmPulumiKmsKeys:
     - projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
   marin-loom:machineType: e2-highmem-4
-  marin-loom:bootDiskGb: "100"
-  marin-loom:dataDiskGb: "500"
+  marin-loom:bootDiskGb: "1000"
   marin-loom:dotenvSecretVersion: "3"
   marin-loom:pruneDeployment: "true"
   marin-loom:snapshotRetentionDays: "14"

--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -1,9 +1,10 @@
 # Loom production deployment
 
-The `marin-loom` Pulumi stack manages `loom.oa.dev`: its GCE host, persistent
-data disk, Artifact Registry repository, Secret Manager access, Cloudflare DNS,
-and scheduled disk snapshots. The runtime is built from the operator's local
-Loom worktree and runs as a Docker Compose application on the GCE host.
+The `marin-loom` Pulumi stack manages `loom.oa.dev`: its GCE host with a
+persistent root disk, Artifact Registry repository, Secret Manager access,
+Cloudflare DNS, and scheduled root-disk snapshots. The runtime is built from
+the operator's local Loom worktree and runs as a Docker Compose application on
+the GCE host.
 
 ## Prerequisites
 
@@ -55,10 +56,10 @@ pulumi config rm --cwd /path/to/marin/infra/loom --stack marin-loom buildContext
 ```
 
 Pulumi renders the Compose and Caddy configuration into VM metadata. The GCE
-startup unit mounts the persistent disk, reads one numbered `LOOM_DOTENV`
-version, pulls the digest-pinned image, runs `docker compose up -d`, applies the
-configured Loom deployment policy, and checks readiness. It does not clone a
-repository or build images on the VM.
+startup unit stores Docker state on the persistent root disk, reads one numbered
+`LOOM_DOTENV` version, pulls the digest-pinned image, runs
+`docker compose up -d`, applies the configured Loom deployment policy, and
+checks readiness. It does not clone a repository or build images on the VM.
 
 ## Update secrets
 
@@ -141,5 +142,5 @@ sessions are live because it removes their shared network.
 
 To roll back, check out the prior Loom tree, restore its numbered
 `dotenvSecretVersion` when necessary, and run the normal preview and update.
-The persistent data disk and its scheduled snapshots are protected Pulumi
-resources.
+The persistent root disk is not auto-deleted with the VM and has scheduled
+snapshots.

--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -142,5 +142,5 @@ sessions are live because it removes their shared network.
 
 To roll back, check out the prior Loom tree, restore its numbered
 `dotenvSecretVersion` when necessary, and run the normal preview and update.
-The persistent root disk is not auto-deleted with the VM and has scheduled
-snapshots.
+The separately managed persistent root disk is protected, is not auto-deleted
+with the VM, and has scheduled snapshots.

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -559,10 +559,23 @@ def _create_network(config: DeploymentConfig, apis: list[gcp.projects.Service]) 
     return NetworkResources(web_firewall, ssh_firewall, address, dns_record)
 
 
+def _create_root_disk(config: DeploymentConfig, apis: list[gcp.projects.Service]) -> gcp.compute.Disk:
+    return gcp.compute.Disk(
+        "loom-root",
+        project=config.project,
+        zone=config.zone,
+        name=config.instance_name,
+        image="debian-cloud/debian-12",
+        type=DEFAULT_DISK_TYPE,
+        size=config.boot_disk_gb,
+        opts=pulumi.ResourceOptions(depends_on=apis, protect=True, ignore_changes=["image"]),
+    )
+
+
 def _create_boot_disk_snapshots(
     config: DeploymentConfig,
     apis: list[gcp.projects.Service],
-    instance: gcp.compute.Instance,
+    root_disk: gcp.compute.Disk,
 ) -> gcp.compute.DiskResourcePolicyAttachment:
     snapshot_policy = gcp.compute.ResourcePolicy(
         "loom-snapshots",
@@ -583,9 +596,9 @@ def _create_boot_disk_snapshots(
         "loom-snapshot-policy",
         project=config.project,
         zone=config.zone,
-        disk=instance.name,
+        disk=root_disk.name,
         name=snapshot_policy.name,
-        opts=pulumi.ResourceOptions(depends_on=[instance]),
+        opts=pulumi.ResourceOptions(depends_on=[root_disk]),
     )
 
 
@@ -784,6 +797,7 @@ def _create_instance(
     vm_account: gcp.serviceaccount.Account,
     vm_log_writer: gcp.projects.IAMMember,
     network: NetworkResources,
+    root_disk: gcp.compute.Disk,
     image: ImageResources,
     secrets: SecretResources,
     runtime_policy: RuntimePolicyResources,
@@ -805,6 +819,7 @@ def _create_instance(
         network.web_firewall,
         network.ssh_firewall,
         network.dns_record,
+        root_disk,
         secrets.secret,
         secrets.vm_reader,
         image.vm_reader,
@@ -821,11 +836,7 @@ def _create_instance(
         tags=[WEB_FIREWALL_TAG, SSH_FIREWALL_TAG],
         boot_disk={
             "auto_delete": False,
-            "initialize_params": {
-                "image": "debian-cloud/debian-12",
-                "size": config.boot_disk_gb,
-                "type": DEFAULT_DISK_TYPE,
-            },
+            "source": root_disk.id,
         },
         network_interfaces=[
             {
@@ -947,18 +958,20 @@ def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
     runtime_policy = _create_runtime_policy(config, api_options)
     image = _create_image(config, apis, vm_account)
     network = _create_network(config, apis)
+    root_disk = _create_root_disk(config, apis)
     secrets = _create_secrets(config, apis, api_options, vm_account, runtime_policy.profile_secret_refs)
     instance = _create_instance(
         config,
         vm_account,
         vm_log_writer,
         network,
+        root_disk,
         image,
         secrets,
         runtime_policy,
         vm_permissions,
     )
-    snapshot_attachment = _create_boot_disk_snapshots(config, apis, instance.instance)
+    snapshot_attachment = _create_boot_disk_snapshots(config, apis, root_disk)
     activation = _create_activation(config, instance, network.dns_record, snapshot_attachment)
     _export_outputs(config, instance.instance, network, image, runtime_policy)
     return Infrastructure(instance.instance, activation)

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -30,8 +30,7 @@ ARTIFACT_REPOSITORY_ID = "loom"
 ARTIFACT_IMAGE_NAME = "loom"
 DOTENV_SECRET_ID = "LOOM_DOTENV"
 LOOM_PORT = 7878
-DATA_DISK_DEVICE_NAME = "loom-data"
-DATA_MOUNT = "/mnt/loom-data"
+DOCKER_ROOT = "/var/lib/docker"
 SECRET_ACCESSOR_ROLE = "roles/secretmanager.secretAccessor"
 LOG_WRITER_ROLE = "roles/logging.logWriter"
 KMS_ENCRYPTER_DECRYPTER_ROLE = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
@@ -44,7 +43,7 @@ STARTUP_SCRIPT = (ROOT / "startup-script.sh").read_text()
 DOCKER_DAEMON_CONFIG = (
     json.dumps(
         {
-            "data-root": f"{DATA_MOUNT}/docker",
+            "data-root": DOCKER_ROOT,
             "default-ulimits": {
                 "core": {
                     "Name": "core",
@@ -362,7 +361,6 @@ class DeploymentConfig:
     vm_service_account_name: str
     machine_type: str
     boot_disk_gb: int
-    data_disk_gb: int
     dotenv_secret_version: int
     snapshot_retention_days: int
     prune_deployment: bool = False
@@ -377,7 +375,6 @@ class DeploymentConfig:
             raise ValueError("domain must be a canonical hostname without a scheme, path, or trailing dot")
         for name, value in (
             ("bootDiskGb", self.boot_disk_gb),
-            ("dataDiskGb", self.data_disk_gb),
             ("snapshotRetentionDays", self.snapshot_retention_days),
             ("dotenvSecretVersion", self.dotenv_secret_version),
         ):
@@ -454,7 +451,6 @@ class DeploymentConfig:
             vm_service_account_name=config.require("vmServiceAccountName"),
             machine_type=config.require("machineType"),
             boot_disk_gb=config.require_int("bootDiskGb"),
-            data_disk_gb=config.require_int("dataDiskGb"),
             dotenv_secret_version=config.require_int("dotenvSecretVersion"),
             prune_deployment=config.get_bool("pruneDeployment") or False,
             profiles=tuple(profiles),
@@ -563,27 +559,16 @@ def _create_network(config: DeploymentConfig, apis: list[gcp.projects.Service]) 
     return NetworkResources(web_firewall, ssh_firewall, address, dns_record)
 
 
-@dataclass(frozen=True)
-class DataResources:
-    disk: gcp.compute.Disk
-    snapshot_attachment: gcp.compute.DiskResourcePolicyAttachment
-
-
-def _create_data_disk(config: DeploymentConfig, apis: list[gcp.projects.Service]) -> DataResources:
-    data_disk = gcp.compute.Disk(
-        "loom-data",
-        project=config.project,
-        zone=config.zone,
-        name=f"{config.instance_name}-data",
-        type=DEFAULT_DISK_TYPE,
-        size=config.data_disk_gb,
-        opts=pulumi.ResourceOptions(depends_on=apis, protect=True),
-    )
+def _create_boot_disk_snapshots(
+    config: DeploymentConfig,
+    apis: list[gcp.projects.Service],
+    instance: gcp.compute.Instance,
+) -> gcp.compute.DiskResourcePolicyAttachment:
     snapshot_policy = gcp.compute.ResourcePolicy(
-        "loom-data-snapshots",
+        "loom-snapshots",
         project=config.project,
         region=config.region,
-        name=f"{config.instance_name}-data-daily",
+        name=f"{config.instance_name}-daily",
         snapshot_schedule_policy={
             "schedule": {"daily_schedule": {"days_in_cycle": 1, "start_time": "04:00"}},
             "retention_policy": {
@@ -594,14 +579,14 @@ def _create_data_disk(config: DeploymentConfig, apis: list[gcp.projects.Service]
         },
         opts=pulumi.ResourceOptions(depends_on=apis),
     )
-    snapshot_attachment = gcp.compute.DiskResourcePolicyAttachment(
-        "loom-data-snapshot-policy",
+    return gcp.compute.DiskResourcePolicyAttachment(
+        "loom-snapshot-policy",
         project=config.project,
         zone=config.zone,
-        disk=data_disk.name,
+        disk=instance.name,
         name=snapshot_policy.name,
+        opts=pulumi.ResourceOptions(depends_on=[instance]),
     )
-    return DataResources(data_disk, snapshot_attachment)
 
 
 @dataclass(frozen=True)
@@ -799,7 +784,6 @@ def _create_instance(
     vm_account: gcp.serviceaccount.Account,
     vm_log_writer: gcp.projects.IAMMember,
     network: NetworkResources,
-    data: DataResources,
     image: ImageResources,
     secrets: SecretResources,
     runtime_policy: RuntimePolicyResources,
@@ -811,8 +795,6 @@ def _create_instance(
         "dotenv-secret-version": str(config.dotenv_secret_version),
         "dotenv-secret-id": DOTENV_SECRET_ID,
         "loom-port": str(LOOM_PORT),
-        "data-disk-device": DATA_DISK_DEVICE_NAME,
-        "data-mount": DATA_MOUNT,
         "loom-deployment": runtime_policy.manifest,
         "docker-daemon-config": DOCKER_DAEMON_CONFIG,
         "loom-compose": RUNTIME_COMPOSE,
@@ -823,8 +805,6 @@ def _create_instance(
         network.web_firewall,
         network.ssh_firewall,
         network.dns_record,
-        data.disk,
-        data.snapshot_attachment,
         secrets.secret,
         secrets.vm_reader,
         image.vm_reader,
@@ -840,22 +820,13 @@ def _create_instance(
         machine_type=config.machine_type,
         tags=[WEB_FIREWALL_TAG, SSH_FIREWALL_TAG],
         boot_disk={
-            "auto_delete": True,
+            "auto_delete": False,
             "initialize_params": {
                 "image": "debian-cloud/debian-12",
                 "size": config.boot_disk_gb,
                 "type": DEFAULT_DISK_TYPE,
             },
         },
-        attached_disks=[
-            # GCE preserves separately attached persistent disks when an
-            # instance is deleted; the disk resource is protected as well.
-            {
-                "source": data.disk.id,
-                "device_name": DATA_DISK_DEVICE_NAME,
-                "mode": "READ_WRITE",
-            }
-        ],
         network_interfaces=[
             {
                 "network": config.network,
@@ -882,6 +853,7 @@ def _create_activation(
     config: DeploymentConfig,
     instance: InstanceResources,
     dns_record: cloudflare.DnsRecord,
+    snapshot_attachment: gcp.compute.DiskResourcePolicyAttachment,
 ) -> command.local.Command:
     return command.local.Command(
         "loom-activate",
@@ -895,7 +867,7 @@ def _create_activation(
             "LOOM_DOMAIN": config.domain,
         },
         triggers=[instance.instance.id, pulumi.Output.json_dumps(instance.metadata)],
-        opts=pulumi.ResourceOptions(depends_on=[instance.instance, dns_record]),
+        opts=pulumi.ResourceOptions(depends_on=[instance.instance, dns_record, snapshot_attachment]),
     )
 
 
@@ -975,19 +947,18 @@ def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
     runtime_policy = _create_runtime_policy(config, api_options)
     image = _create_image(config, apis, vm_account)
     network = _create_network(config, apis)
-    data = _create_data_disk(config, apis)
     secrets = _create_secrets(config, apis, api_options, vm_account, runtime_policy.profile_secret_refs)
     instance = _create_instance(
         config,
         vm_account,
         vm_log_writer,
         network,
-        data,
         image,
         secrets,
         runtime_policy,
         vm_permissions,
     )
-    activation = _create_activation(config, instance, network.dns_record)
+    snapshot_attachment = _create_boot_disk_snapshots(config, apis, instance.instance)
+    activation = _create_activation(config, instance, network.dns_record, snapshot_attachment)
     _export_outputs(config, instance.instance, network, image, runtime_policy)
     return Infrastructure(instance.instance, activation)

--- a/infra/loom/runtime/docker-compose.yml
+++ b/infra/loom/runtime/docker-compose.yml
@@ -22,6 +22,7 @@ services:
   loom:
     image: ${LOOM_IMAGE:?LOOM_IMAGE is required}
     restart: unless-stopped
+    working_dir: /home/app
     env_file: .env
     environment:
       RUST_BACKTRACE: "1"

--- a/infra/loom/runtime/docker-compose.yml
+++ b/infra/loom/runtime/docker-compose.yml
@@ -1,6 +1,7 @@
 name: loom
 
 x-session-home-volume: &session-home-volume loom_loom_home
+x-session-home-path: &session-home-path /home/app
 x-session-uv-volume: &session-uv-volume loom_uv
 x-session-network: &session-network loom_default
 
@@ -10,7 +11,9 @@ services:
     env_file: .env
     restart: "no"
     volumes:
-      - loom_home:/home/app
+      - type: volume
+        source: loom_home
+        target: *session-home-path
     command:
       - sh
       - -ceu
@@ -22,7 +25,7 @@ services:
   loom:
     image: ${LOOM_IMAGE:?LOOM_IMAGE is required}
     restart: unless-stopped
-    working_dir: /home/app
+    working_dir: *session-home-path
     env_file: .env
     environment:
       RUST_BACKTRACE: "1"
@@ -54,7 +57,9 @@ services:
     cgroup: private
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - loom_home:/home/app
+      - type: volume
+        source: loom_home
+        target: *session-home-path
       - uv:/opt/uv
 
   caddy:

--- a/infra/loom/startup-script.sh
+++ b/infra/loom/startup-script.sh
@@ -13,7 +13,6 @@ DOTENV_SECRET_ID="$(meta instance/attributes/dotenv-secret-id)"
 LOOM_PORT="$(meta instance/attributes/loom-port)"
 RUNTIME_DIR=/opt/loom
 COMPOSE_FILE="${RUNTIME_DIR}/docker-compose.yml"
-DOCKER_ROOT=/var/lib/docker
 DOCKER_CONFIG=/etc/docker/daemon.json
 HEALTH_URL="http://127.0.0.1:${LOOM_PORT}/api/health"
 STARTUP_SUCCESS=/run/loom-startup-succeeded
@@ -62,7 +61,7 @@ if [ "${#packages[@]}" -gt 0 ]; then
   apt-get install -y --no-install-recommends "${packages[@]}"
 fi
 
-mkdir -p "$DOCKER_ROOT" /etc/docker
+mkdir -p /etc/docker
 desired_daemon_config="$(meta instance/attributes/docker-daemon-config)"
 if [ ! -f "$DOCKER_CONFIG" ] || [ "$(cat "$DOCKER_CONFIG")" != "$desired_daemon_config" ]; then
   printf '%s\n' "$desired_daemon_config" >"$DOCKER_CONFIG"

--- a/infra/loom/startup-script.sh
+++ b/infra/loom/startup-script.sh
@@ -13,8 +13,7 @@ DOTENV_SECRET_ID="$(meta instance/attributes/dotenv-secret-id)"
 LOOM_PORT="$(meta instance/attributes/loom-port)"
 RUNTIME_DIR=/opt/loom
 COMPOSE_FILE="${RUNTIME_DIR}/docker-compose.yml"
-DATA_DISK_DEVICE="/dev/disk/by-id/google-$(meta instance/attributes/data-disk-device)"
-DATA_MOUNT="$(meta instance/attributes/data-mount)"
+DOCKER_ROOT=/var/lib/docker
 DOCKER_CONFIG=/etc/docker/daemon.json
 HEALTH_URL="http://127.0.0.1:${LOOM_PORT}/api/health"
 STARTUP_SUCCESS=/run/loom-startup-succeeded
@@ -63,34 +62,7 @@ if [ "${#packages[@]}" -gt 0 ]; then
   apt-get install -y --no-install-recommends "${packages[@]}"
 fi
 
-if [ ! -e "$DATA_DISK_DEVICE" ]; then
-  echo "loom startup-script: durable data disk is not attached" >&2
-  exit 1
-fi
-if filesystem_type="$(blkid -p -s TYPE -o value "$DATA_DISK_DEVICE")"; then
-  if [ "$filesystem_type" != ext4 ]; then
-    echo "loom startup-script: durable data disk uses unexpected filesystem ${filesystem_type}" >&2
-    exit 1
-  fi
-else
-  blkid_status=$?
-  if [ "$blkid_status" -ne 2 ]; then
-    echo "loom startup-script: could not inspect durable data disk (blkid ${blkid_status})" >&2
-    exit 1
-  fi
-  mkfs.ext4 -m 0 "$DATA_DISK_DEVICE"
-fi
-mkdir -p "$DATA_MOUNT"
-if mountpoint -q "$DATA_MOUNT"; then
-  data_disk_mounted_this_run=false
-else
-  mount "$DATA_DISK_DEVICE" "$DATA_MOUNT"
-  data_disk_mounted_this_run=true
-fi
-resize2fs "$DATA_DISK_DEVICE"
-grep -q "^${DATA_DISK_DEVICE} " /etc/fstab || \
-  echo "${DATA_DISK_DEVICE} ${DATA_MOUNT} ext4 discard,defaults,nofail 0 2" >>/etc/fstab
-mkdir -p "${DATA_MOUNT}/docker" /etc/docker
+mkdir -p "$DOCKER_ROOT" /etc/docker
 desired_daemon_config="$(meta instance/attributes/docker-daemon-config)"
 if [ ! -f "$DOCKER_CONFIG" ] || [ "$(cat "$DOCKER_CONFIG")" != "$desired_daemon_config" ]; then
   printf '%s\n' "$desired_daemon_config" >"$DOCKER_CONFIG"
@@ -99,7 +71,7 @@ else
   docker_config_changed=false
 fi
 systemctl enable --now docker
-if [ "${docker_config_changed:-false}" = true ] || [ "$data_disk_mounted_this_run" = true ]; then
+if [ "${docker_config_changed:-false}" = true ]; then
   systemctl restart docker
 fi
 

--- a/infra/loom/tests/test_infrastructure.py
+++ b/infra/loom/tests/test_infrastructure.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 
 import pulumi
 import pytest
+import yaml
 from pulumi.runtime import MockCallArgs, MockResourceArgs, Mocks
 
 from infra.loom.infrastructure import (
@@ -62,7 +63,6 @@ def deployment_config() -> DeploymentConfig:
         vm_service_account_name="loom-vm",
         machine_type="e2-highmem-4",
         boot_disk_gb=100,
-        data_disk_gb=500,
         dotenv_secret_version=3,
         snapshot_retention_days=14,
         vm_project_roles=("roles/cloudsql.client", "roles/cloudsql.instanceUser"),
@@ -200,14 +200,23 @@ def test_deployment_models_durable_resources_without_secret_payloads():
 
         vm = by_name(mocks, "loom")
         attached = field(vm.inputs, "attached_disks", "attachedDisks")
-        assert attached is not None
-        assert len(attached) == 1
-        assert field(attached[0], "device_name", "deviceName") == "loom-data"
-        assert field(attached[0], "auto_delete", "autoDelete") is not True
-        assert vm.inputs["metadata"]["dotenv-secret-version"] == "3"
-        assert "startup-script" in vm.inputs["metadata"]
-        assert "loom-compose" in vm.inputs["metadata"]
-        assert "loom-caddyfile" in vm.inputs["metadata"]
+        assert not attached
+        boot_disk = field(vm.inputs, "boot_disk", "bootDisk")
+        assert field(boot_disk, "auto_delete", "autoDelete") is False
+        assert not any(resource.typ == "gcp:compute/disk:Disk" for resource in mocks.resources)
+        snapshot_attachment = by_name(mocks, "loom-snapshot-policy")
+        assert snapshot_attachment.inputs["disk"] == "loom"
+        metadata = vm.inputs["metadata"]
+        assert metadata["dotenv-secret-version"] == "3"
+        assert json.loads(metadata["docker-daemon-config"]) == {
+            "data-root": "/var/lib/docker",
+            "default-ulimits": {"core": {"Name": "core", "Hard": 0, "Soft": 0}},
+        }
+        assert yaml.safe_load(metadata["loom-compose"])["services"]["loom"]["working_dir"] == "/home/app"
+        assert "data-disk-device" not in metadata
+        assert "startup-script" in metadata
+        assert "loom-compose" in metadata
+        assert "loom-caddyfile" in metadata
         assert "metadataStartupScript" not in vm.inputs
         assert "metadata_startup_script" not in vm.inputs
         assert field(vm.inputs, "allow_stopping_for_update", "allowStoppingForUpdate") is False
@@ -227,7 +236,7 @@ def test_deployment_models_durable_resources_without_secret_payloads():
             "projects/example/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key"
         )
 
-    return infrastructure.instance.id.apply(check)
+    return infrastructure.activation.id.apply(check)
 
 
 @pulumi.runtime.test

--- a/infra/loom/tests/test_infrastructure.py
+++ b/infra/loom/tests/test_infrastructure.py
@@ -202,8 +202,12 @@ def test_deployment_models_durable_resources_without_secret_payloads():
         attached = field(vm.inputs, "attached_disks", "attachedDisks")
         assert not attached
         boot_disk = field(vm.inputs, "boot_disk", "bootDisk")
+        assert boot_disk is not None
         assert field(boot_disk, "auto_delete", "autoDelete") is False
-        assert not any(resource.typ == "gcp:compute/disk:Disk" for resource in mocks.resources)
+        root_disk = by_name(mocks, "loom-root")
+        assert root_disk.typ == "gcp:compute/disk:Disk"
+        assert root_disk.inputs["name"] == "loom"
+        assert boot_disk["source"] == "loom-root_id"
         snapshot_attachment = by_name(mocks, "loom-snapshot-policy")
         assert snapshot_attachment.inputs["disk"] == "loom"
         metadata = vm.inputs["metadata"]


### PR DESCRIPTION
Store Loom's Docker volumes and scheduled snapshots on a protected 1 TB root-disk resource. Remove the separately managed 500 GB data disk and its startup mount path; VM recreation now reattaches the retained root disk instead of initializing an empty disk.

Set the control-plane container working directory to the shared `/home/app` volume. One-shot ACP helpers previously inherited `/` and failed with `ContainerRunner work directory / is outside /home/app` after a restart.

The production cutover compared 1,323,136 files totaling 140.4 GB, transferred 7.39 GB of changes, and retained `loom-data-final-root-cutover-20260804` before deleting the old disk. The deployed stack is ready on `/var/lib/docker`. The incident record is https://echo.oa.dev/wiki/86.
