### PR TITLE
[iris] Admit GitHub CI for GB200 federation

### DIFF
--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -123,8 +123,11 @@ auth:
       -----BEGIN PUBLIC KEY-----
       MCowBQYDK2VwAyEA42ziFTlGKgaA/fQ1wJCONKOml7rx5Y8UAQqVLTCtrCo=
       -----END PUBLIC KEY-----
+  # GitHub GPU workflows submit through the marin hub as github-iris; the
+  # remaining non-openathena identities are interactive or probe principals.
   allowed_submitters:
     - "*@openathena.ai"
+    - github-iris@hai-gcp-models.iam.gserviceaccount.com
     - wg0420@princeton.edu
     - ravwojdyla@rav-openathena.iam.gserviceaccount.com
     - infra-probes@hai-gcp-models.iam.gserviceaccount.com


### PR DESCRIPTION
GitHub GPU workflows authenticate to the Marin hub as `github-iris@hai-gcp-models.iam.gserviceaccount.com`, then federate jobs to the requested CoreWeave peer. `cw-us-east-08a` did not admit that principal, so GB200 validation failed before Iris scheduled a pod. The H100 peer already carries the corresponding entry from #7597.

Admit the exact CI service account on the GB200 peer. A controller rollout is required before the live allowlist changes.
