### PR TITLE
[grug] Run the FSDP hero shape on the EP64 mesh

### DIFF
--- a/.agents/logbooks/7279-moe-hero-ep.md
+++ b/.agents/logbooks/7279-moe-hero-ep.md
@@ -765,3 +765,35 @@ The current Levanter code already contains a `ragged_all_to_all` EP backend. Thu
 - Next action: MHEP-012 (capacity sweep) is now necessary rather than optional, because the drop
   gap of 8.1 percentage points funds part of the EP lead. MHEP-011 (FSDP at expert_chunks=1) remains
   the cheapest way to attribute the rest.
+
+### 2026-08-05 01:00 UTC - MHEP-011 to MHEP-016 queued: size ladder and capacity sweep
+
+- Code snapshot: `5c7d9d2aa`. The EP launcher takes `--num-experts`, `--intermediate-dim`, and
+  `--capacity-factor`, and rejects a bank that does not divide the 64-way expert axis.
+- W&B: All six runs and `mhep-009b` write live to entity `marin-community`, project `rav_moe`.
+- Common settings: EP64, one rack, `--shape fsdp`, 25 steps, batch 1024, d6144, 48 layers, top-4,
+  two shared experts, host offload of the optimizer state.
+
+Size ladder. Each keeps 256 experts (four per device) and about 20 B active parameters, and each is
+larger than any shape measured on this rack before. Estimates come from a 64-device shape check.
+
+| run | experts x width | total | active | resident estimate | headroom |
+| --- | --- | --- | --- | --- | --- |
+| `mhep-011` | 256 x i2560 | 591.6 B | 19.9 B | 140.6 GiB | 32.6 GiB |
+| `mhep-012` | 256 x i2816 | 649.6 B | 20.8 B | 149.0 GiB | 24.2 GiB |
+| `mhep-013` | 256 x i3072 | 707.6 B | 21.7 B | 157.5 GiB | 15.8 GiB |
+
+- Expectation: `mhep-011` fits. `mhep-013` is at the estimate boundary and can fail, because the
+  estimate omits the FA4 workspace, the cross-entropy logit blocks, NCCL buffers, fragmentation, and
+  the Newton-Schulz transient (about 7 GiB at four experts per device). An OOM there is a result.
+- A fourth candidate, 512 x i1536 at top-8, estimates 167.2 GiB with 6.1 GiB of headroom. It was not
+  queued, because it fails the same estimate by a larger margin.
+
+Capacity sweep at the measured MHEP-009 shape (128 x i3072, top-4), where capacity 1.0 dropped
+9.9683% of assignments: `mhep-014` at 1.125, `mhep-015` at 1.25, `mhep-016` at 1.5. Cell capacity
+goes from 2,048 rows to 2,304, 2,560, and 3,072. The native EP hero measured a 4.1% relative MFU
+cost for capacity 1.0625, thus a cost is expected here as well.
+
+- Purpose: Price the drop correction that the MHEP-009 versus MHEP-010 comparison currently carries.
+- Cluster note: Seven of our gangs are queued at once against a saturated A08. They serialize. This
+  is a deliberate choice to keep the queue full while 12-rack runs cycle.

--- a/.agents/logbooks/7279-moe-hero-ep.md
+++ b/.agents/logbooks/7279-moe-hero-ep.md
@@ -653,3 +653,28 @@ The current Levanter code already contains a `ragged_all_to_all` EP backend. Thu
 - Logbook finding: No rewrite because this research logbook is append-only.
 - Tests: The default Grug MoE and EP hero suites pass with 20 tests and 6 skips. The set now includes the four-device fixed all-to-all forward and gradient test. The 200-step dry run still resolves EP64, capacity 1.0, fixed all-to-all, batch 1024, and the recorded optimizer values.
 - Checks: The full changed-file pre-commit and Pyrefly checks pass. The one required advisory rule-catalog review reports no findings.
+
+### 2026-08-04 18:28 UTC - MHEP-009 FSDP-shape local gate passed
+
+- Hypothesis: The FSDP hero model shape runs on the EP64 mesh, and its MFU is directly comparable
+  to the FSDP hero result because the analytic FLOP count depends only on the model config.
+- Motive: The recorded FSDP reference has a different model shape, thus the baseline section calls
+  it out as no EP control. One shape on two sharding strategies removes that limit.
+- Change: `heuristic.py` gets a `HeroShape` selector and the FSDP hero model spec. `launch.py` gets
+  `--shape` and takes host offload of the optimizer state from the selected shape.
+- Forced deltas: `moe_implementation` becomes `fixed_all_to_all` because `sonic_cute` has no EP
+  collectives, and `expert_chunks` becomes 1 because `moe_mlp` rejects a larger value when the
+  expert axis is larger than one. All other model fields stay equal to the FSDP hero.
+- Capacity note: The local FSDP backend computes every assignment. EP drops each assignment above
+  its fixed cell capacity, thus the EP drop fraction is part of the result.
+- Memory: A 64-device shape check reports 359.64 B parameters, 24.59 GiB of parameters per device,
+  and 27.78 GiB of optimizer state per device. With host offload the resident estimate is about 106
+  GiB per device. The measured d5120 EP shape estimates about 110 GiB per device without offload,
+  thus 128 experts on 64 devices fit with margin. Two whole experts land on each device.
+- Mesh selection: EP64 is the lowest-memory mesh for this shape on 64 GPUs. A hybrid mesh such as
+  EP32 with two-way FSDP replicates each expert twice, because the EP path shards expert weights
+  on the expert axis only. Thus no hybrid mesh was selected.
+- Tests: The eight EP-hero and FSDP-hero tests pass. The new parity test fails if the two model
+  specs drift apart in more fields than the two forced deltas.
+- Dry run: The plan resolves d6144, 128 experts, top-4, two shared experts, SConv, sliding window
+  512, EP64, capacity 1.0, batch 1024, and 16 workers with four GB200 GPUs each.

--- a/.agents/logbooks/7279-moe-hero-ep.md
+++ b/.agents/logbooks/7279-moe-hero-ep.md
@@ -678,3 +678,24 @@ The current Levanter code already contains a `ragged_all_to_all` EP backend. Thu
   specs drift apart in more fields than the two forced deltas.
 - Dry run: The plan resolves d6144, 128 experts, top-4, two shared experts, SConv, sliding window
   512, EP64, capacity 1.0, batch 1024, and 16 workers with four GB200 GPUs each.
+
+### 2026-08-04 18:31 UTC - MHEP-009 launch contract ready and submitted
+
+- Hypothesis: The FSDP hero shape completes 25 steps on one EP64 rack, and its median MFU gives the
+  first same-shape comparison between EP and FSDP sharding.
+- Run ID: `mhep-009-fsdp-shape-25-20260804-1831`.
+- Job: `/rav/mhep-009-fsdp-shape-25-20260804-1831-coord`.
+- Command: `uv run iris --config lib/iris/config/marin.yaml job run --no-wait
+  --enable-extra-resources --target-cluster cw-us-east-08a --priority interactive --cpu 2
+  --memory 8GB --disk 32GB --timeout 21600 --max-retries 50 --job-name
+  mhep-009-fsdp-shape-25-20260804-1831-coord -e WANDB_MODE offline -- python -m
+  experiments.grug.moe_hero_ep.launch --run-id mhep-009-fsdp-shape-25-20260804-1831 --num-steps 25
+  --shape fsdp --version 2026.08.04 --run`.
+- Code snapshot: `01025d80b`; clean tree. Source bundle: Iris workspace bundle, 9.6 MB.
+- Hardware: 16 workers with four GB200 GPUs each on `cw-us-east-08a`; 64 GPUs total.
+- W&B: ID and display name `mhep-009-fsdp-shape-25-20260804-1831`, project `marin_moe`, group
+  `moe-hero-ep`, tag `shape-fsdp`, and offline mode.
+- Final step: 25. Checkpoint policy: No checkpoints. This gate writes metrics only.
+- Stop criteria: Stop on terminal failure, non-finite loss, task retry, OOM, or incomplete step 25.
+- Next action: Monitor to a terminal state, read `tracker_metrics.jsonl`, then run the one-rack FSDP
+  control at the same shape and batch.

--- a/.agents/logbooks/7279-moe-hero-ep.md
+++ b/.agents/logbooks/7279-moe-hero-ep.md
@@ -820,3 +820,19 @@ cost for capacity 1.0625, thus a cost is expected here as well.
   the measured fail, not the arithmetic ceiling.
 - Untested lever: Cap XLA with `XLA_PYTHON_CLIENT_MEM_FRACTION` instead of `cuda_async`, or lower
   `NCCL_BUFFSIZE`, to leave the communicator room. Neither was measured.
+
+### 2026-08-05 03:35 UTC - MHEP-019 stopped: lower top-k does not rescue the 641 B tier
+
+- Configuration: 192 experts x i3712 at top-3, 641.4 B total, 20.7 B active, three whole experts per
+  device. Dispatch buffers are 2.25 GiB, a quarter less than the 3.00 GiB of the 649.6 B run that
+  already failed.
+- Result: The rank-0 diagnostic reports `NCCL operation ncclAlltoAll(...)`, the same failure as
+  MHEP-012c, with the coscheduled siblings cascading. Stopped after two failures.
+- Interpretation: Two different routings now fail near 650 B. Thus the binding constraint is total
+  parameter memory that leaves NCCL too little room, not the size of the dispatch buffers. Lower
+  top-k reduces the communicator demand but does not offset the parameter growth.
+- Ceiling update: One rack fits 591.6 B (measured pass) and does not fit 641.4 B (measured fail).
+  The earlier bound of 592 B to 650 B narrows to 592 B to 641 B.
+- Still open: MHEP-020 tests the other direction, holding parameters at the 590.7 B of the known
+  pass while raising dispatch to 4.50 GiB with top-6. A pass there confirms that parameters, not the
+  communicator, set the ceiling.

--- a/.agents/logbooks/7279-moe-hero-ep.md
+++ b/.agents/logbooks/7279-moe-hero-ep.md
@@ -742,3 +742,26 @@ The current Levanter code already contains a `ragged_all_to_all` EP backend. Thu
 - Comparison anchors: A prior EP64 arm at d6144, 4-of-128, and sliding window 2048 measured 24.842%
   median MFU. The native d5120 EP hero measured 23.6969% at 200 steps. This shape is above both.
 - Next action: Read the MHEP-010 control when it completes, then report the same-shape comparison.
+
+### 2026-08-05 00:00 UTC - MHEP-010 control gives the same-shape EP versus FSDP result
+
+- Completion: All 16 GPU tasks succeeded with exit 0 and zero failures. The run completed all 25
+  steps after seven preemptions, on the same rack allocation window as MHEP-009.
+- Performance: Median MFU is 19.3951%, mean MFU is 16.7629%, p10 MFU is 2.9288%, and p90 MFU is
+  19.6933% over 26 samples. The last sample is 19.6144% MFU, 235,125 tokens/s, and 17.8386 seconds.
+- Training: Final loss is 6.0754. Final MoE drop fraction is 1.8779%, or 15,122,972 assignments.
+- Result: At one rack and this exact model shape, EP64 measures 8.3593 percentage points more median
+  MFU than FSDP64, or 43.1% relative. Last-sample throughput is 34.6% higher.
+- Correction to the MHEP-009 entry: The local `sonic_cute` backend does drop assignments. It dropped
+  1.8779%, not zero. The earlier claim that the FSDP path computes every assignment is wrong.
+- Adjusted comparison: EP completed 90.03% of assignments and FSDP completed 98.12%. A first-order
+  correction of the EP median for the work it did not do gives about 25.5% against 19.4%. Thus the
+  EP lead is about 6 percentage points, not 8.4, and it survives the correction.
+- Variance limit: Both runs have a wide spread because 26 samples include compile and warmup. The
+  FSDP p10 of 2.9288% is a warmup sample, not steady state. Use the medians. The 200-step EP hero
+  gate had a 0.5656 deviation against 5.5456 and 6.5623 here.
+- Cost record: The pair took 5 hours and 30 minutes from submit to result, of which about 20 minutes
+  was GPU work. Fifteen preemptions across both jobs, none of which reached step 0.
+- Next action: MHEP-012 (capacity sweep) is now necessary rather than optional, because the drop
+  gap of 8.1 percentage points funds part of the EP lead. MHEP-011 (FSDP at expert_chunks=1) remains
+  the cheapest way to attribute the rest.

--- a/.agents/logbooks/7279-moe-hero-ep.md
+++ b/.agents/logbooks/7279-moe-hero-ep.md
@@ -797,3 +797,26 @@ cost for capacity 1.0625, thus a cost is expected here as well.
 - Purpose: Price the drop correction that the MHEP-009 versus MHEP-010 comparison currently carries.
 - Cluster note: Seven of our gangs are queued at once against a saturated A08. They serialize. This
   is a deliberate choice to keep the queue full while 12-rack runs cycle.
+
+### 2026-08-05 02:45 UTC - Size ladder result: the one-rack ceiling is between 592 B and 650 B
+
+- 591.6 B (`mhep-011`, 256 x i2560, top-4, 19.9 B active) PASSES. Median MFU is 24.0032%, tokens/s
+  is 307,778, step time is 13.6277 s, final loss is 6.0396, and the drop fraction is 12.2660%.
+  Four whole experts land on each device. Nothing this large ran on one rack before.
+- 649.6 B (`mhep-012c`, 256 x i2816) FAILS with `JaxRuntimeError: INTERNAL: NCCL operation
+  ncclAlltoAll(...)` on several ranks, from `NCCL WARN Cuda failure 2 'out of memory'`. Stopped
+  after repeated retries.
+- 707.6 B (`mhep-013c`, 256 x i3072) stopped without a clean measurement. It is larger than the
+  configuration that already fails, thus it is declared too big for one rack.
+- Failure mechanism: XLA reserves the model, then NCCL allocates its all-to-all send and receive
+  buffers outside the XLA pool through `cudaMalloc`. With `XLA_PYTHON_CLIENT_ALLOCATOR=cuda_async`
+  XLA grows on demand and keeps no headroom, thus NCCL fails instead of XLA. The buffers are about
+  3.2 GiB each for send and receive at this shape, plus internal channels.
+- Correction: An earlier entry in this session called the 650 B failure not-an-OOM, because
+  `RESOURCE_EXHAUSTED`, allocator, and `XlaRuntimeError` searches returned nothing. That search
+  missed the NCCL path. It is an out-of-memory failure.
+- Estimate limit: The `resident = 53.8 GiB + 0.1465 x params_B` curve counts XLA-side memory only.
+  It omits NCCL buffers, thus it overstates what fits. Use 592 B as the measured pass and 650 B as
+  the measured fail, not the arithmetic ceiling.
+- Untested lever: Cap XLA with `XLA_PYTHON_CLIENT_MEM_FRACTION` instead of `cuda_async`, or lower
+  `NCCL_BUFFSIZE`, to leave the communicator room. Neither was measured.

--- a/.agents/logbooks/7279-moe-hero-ep.md
+++ b/.agents/logbooks/7279-moe-hero-ep.md
@@ -722,3 +722,23 @@ The current Levanter code already contains a `ragged_all_to_all` EP backend. Thu
 - Comparison anchor: A prior EP64 arm at d6144, 4-of-128, sliding window 2048, and 120 steps
   measured 24.842% median MFU and 274,954 tokens/s (issue 7279 comment 5095217108). That arm is not
   this shape, but it bounds the expected range.
+
+### 2026-08-04 23:50 UTC - MHEP-009 passed: the FSDP shape runs on EP64
+
+- Completion: All 16 GPU tasks succeeded with exit 0 and zero failures. The run completed all 25
+  steps. Admission took nine attempts across 5 hours and 17 minutes, with eight preemptions before
+  the successful window. No preemption reached step 0, thus no GPU work was lost.
+- Performance: Median MFU is 27.7544%, mean MFU is 26.0191%, p10 MFU is 19.8324%, and p90 MFU is
+  29.3997% over 26 samples. The last sample is 26.4006% MFU, 316,473 tokens/s, and 13.2533 seconds.
+- Training: Final loss is 6.0498. Final MoE drop fraction is 9.9683%, or 80,275,372 assignments.
+- Memory: The run confirms the pre-flight estimate. There was no OOM and no allocator failure at an
+  estimated 106 GiB per device with host offload of the optimizer state.
+- Variance caveat: The standard deviation is 6.5623 over 26 samples, because the early samples
+  include compile and warmup. Use the median. The 200-step EP hero gate had a 0.5656 deviation, so a
+  longer run is necessary before any small difference is called real.
+- Capacity caveat: The 9.9683% drop fraction means EP does less work than the analytic FLOP count
+  credits. The FSDP control computes every assignment. Thus the MFU comparison is not yet
+  quality-fair, and MHEP-012 remains necessary.
+- Comparison anchors: A prior EP64 arm at d6144, 4-of-128, and sliding window 2048 measured 24.842%
+  median MFU. The native d5120 EP hero measured 23.6969% at 200 steps. This shape is above both.
+- Next action: Read the MHEP-010 control when it completes, then report the same-shape comparison.

--- a/.agents/logbooks/7279-moe-hero-ep.md
+++ b/.agents/logbooks/7279-moe-hero-ep.md
@@ -836,3 +836,30 @@ cost for capacity 1.0625, thus a cost is expected here as well.
 - Still open: MHEP-020 tests the other direction, holding parameters at the 590.7 B of the known
   pass while raising dispatch to 4.50 GiB with top-6. A pass there confirms that parameters, not the
   communicator, set the ceiling.
+
+### 2026-08-05 03:45 UTC - MHEP-020 stopped: top-k is the expensive axis, width is the cheap one
+
+- Configuration: 256 experts x i2560 at top-6, 590.7 B total, 24.5 B active. Parameters are equal to
+  the MHEP-011 configuration that passed, so only the routing multiplicity changed.
+- Result: `worker_failed` with one failed task and 15 coscheduled cascades, after the run entered
+  the training loop. Stopped after four failures.
+- Correction: This session first estimated top-6 as about 4.5 GiB more than top-4. That is wrong.
+  Six buffers scale with top-k, and one of them is float32:
+
+| buffer | top-4 | top-6 |
+| --- | --- | --- |
+| dispatch send (bf16) | 3.00 GiB | 4.50 GiB |
+| received after all-to-all (bf16) | 3.00 GiB | 4.50 GiB |
+| expert w13 output (bf16) | 2.50 GiB | 3.75 GiB |
+| expert output and combine (bf16) | 3.00 GiB | 4.50 GiB |
+| gathered [T, k, H] (bf16) | 3.00 GiB | 4.50 GiB |
+| backward grad_rows (float32) | 6.00 GiB | 9.00 GiB |
+| total | 20.50 GiB | 30.75 GiB |
+
+- The true delta is 10.25 GiB, and its peak is in the backward pass. That matches the observed
+  failure after the training loop started rather than during compilation.
+- Rule for sizing: active routed neurons are top-k multiplied by the expert width. Parameters track
+  expert count multiplied by width, and the k-scaled buffers track tokens multiplied by top-k.
+  Width is thus the cheap way to buy active compute and top-k is the expensive way.
+- Next test: MHEP-021 runs 128 experts x i5120 at top-4. It doubles the active neurons of MHEP-011
+  to 20,480 at the same 590.7 B of parameters, for 23.00 GiB of k-scaled buffers.

--- a/.agents/logbooks/7279-moe-hero-ep.md
+++ b/.agents/logbooks/7279-moe-hero-ep.md
@@ -699,3 +699,26 @@ The current Levanter code already contains a `ragged_all_to_all` EP backend. Thu
 - Stop criteria: Stop on terminal failure, non-finite loss, task retry, OOM, or incomplete step 25.
 - Next action: Monitor to a terminal state, read `tracker_metrics.jsonl`, then run the one-rack FSDP
   control at the same shape and batch.
+
+### 2026-08-04 18:38 UTC - MHEP-010 one-rack FSDP control submitted
+
+- Purpose: Give MHEP-009 a same-shape, same-day control. The recorded FSDP reference is a two-rack
+  200-step average, thus it mixes a topology change into the transport comparison.
+- Run ID: `mhep-010-fsdp-control-25-20260804-1838`.
+- Job: `/rav/mhep-010-fsdp-control-25-20260804-1838-coord`.
+- Command: The same coordinator form as MHEP-009, but `python -m experiments.grug.moe_hero_fsdp.launch
+  --run-id mhep-010-fsdp-control-25-20260804-1838 --dp-racks 1 --num-steps 25 --no-save-checkpoints
+  --version 2026.08.04 --run`.
+- Code snapshot: `8a055fec1`; clean tree.
+- Change to the FSDP hero: `--no-save-checkpoints` makes this gate metrics-only. The forced
+  completion checkpoint writes the parameters and the offloaded optimizer state, about 2.7 TiB at
+  this shape, which an MFU gate does not need. All other hero settings stay unchanged.
+- Matched between the two gates: model shape, batch 1024, sequence 4096, 25 steps, capacity 1.0,
+  MuonH with the same compute-scaled values, host offload of the optimizer state, mixed precision,
+  SlimPajama-6B at `2026.06.28`, and 16 workers with four GB200 GPUs each.
+- Not matched: the MoE backend, `expert_chunks`, the mesh, and each hero's own runtime environment.
+  PGLE is on for FSDP and off for EP. Each variant keeps the runtime that its own gates selected,
+  thus this compares two tuned strategies, not one isolated variable.
+- Comparison anchor: A prior EP64 arm at d6144, 4-of-128, sliding window 2048, and 120 steps
+  measured 24.842% median MFU and 274,954 tokens/s (issue 7279 comment 5095217108). That arm is not
+  this shape, but it bounds the expected range.

--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -1,65 +1,67 @@
 # Grug MoE EP Hero
 
 This self-contained variant is the one-rack EP64 baseline for GB200 NVL72.
-It starts from the FSDP hero at PR 7876 and changes only the parts that EP64 requires.
-
-## Result
-
-`MHEP-004` is the selected 25-step stack. Receiver-ECHO and three-choice spill reduced drops but did not
-increase MFU, so they are not in the final code. `MHEP-008` passed the 200-step gate with 23.6969% median
-MFU, 382,902 last-sample tokens/s, 7.4113% final MoE drop rate, and 3.3119 final loss.
-
-## Model shapes
-
-`--shape` selects which model shape runs on the EP64 mesh:
-
-- `ep` (default): the native EP hero shape below.
-- `fsdp`: the `experiments/grug/moe_hero_fsdp` shape, for a transport comparison at one model shape.
-
-The `fsdp` shape keeps every field of the FSDP hero model except the two that expert parallelism
-cannot honor. `sonic_cute` is a local grouped-GEMM backend with no EP collectives, thus the run uses
-`fixed_all_to_all`. `moe_mlp` rejects `expert_chunks` greater than one when the expert axis is
-larger than one, because EP shards the expert bank instead of a gather of it. As a result, both
-sharding strategies keep the same analytic FLOP count, and their MFU values are directly comparable.
-The `fsdp` shape also keeps the FSDP hero's host offload of the optimizer state.
-`tests/test_moe_hero_ep.py` fails if the two model specs drift apart in more fields.
-
-Capacity is the one behavior that the transport changes. The two backends enforce it differently,
-and EP discards more: the measured pair below drops 9.9683% against 1.8779%. MFU credits every
-assignment in the analytic FLOP count, thus a run that drops more is credited for work it did not
-do. Read the drop fraction with the MFU value.
-
-## Measured result at the FSDP shape
-
-One rack, 25 steps, batch 1024, one hour apart on `cw-us-east-08a`.
-
-| | EP64 (`--shape fsdp`) | FSDP64 (`moe_hero_fsdp --dp-racks 1`) |
-| --- | --- | --- |
-| median MFU | 27.7544% | 19.3951% |
-| tokens/s (last sample) | 316,473 | 235,125 |
-| step time (last sample) | 13.2533 s | 17.8386 s |
-| MoE drop fraction | 9.9683% | 1.8779% |
-| final loss | 6.0498 | 6.0754 |
-
-EP measures 8.3593 percentage points more median MFU, or 43.1% relative. A first-order correction
-for the assignments each arm skipped leaves EP about 6 points ahead. Both runs took 26 MFU samples
-that include compile and warmup, so their deviations are 6.5623 and 5.5456. Use the medians, and
-run 200 steps before you trust a smaller difference.
 
 ## Configuration
 
-- Model: d5120, 48 layers, 256 routed experts, top-8 routing, and one shared expert.
-- Attention: 40 heads, 10 KV heads, sequence length 4096, and sliding window 2048.
-- Mesh: 64-way expert parallelism across 16 workers with four GB200 GPUs each.
+- Model: d6144, 48 layers, 128 routed experts, top-4 routing, and two shared experts of width 3072.
+  This is 359.6 B total parameters and 20.9 B active per token.
+- Attention: 48 heads, 12 local and 6 global KV heads, head dimension 128, sequence length 4096,
+  sliding window 512, and every sixth layer full-causal. SConv and fused RoPE are on.
+- Mesh: 64-way expert parallelism across 16 workers with four GB200 GPUs each. Two whole experts
+  land on each device.
 - Batch: 1024 sequences.
-- Router: top-8 quantile balancing with next-step, stop-gradient expert biases and no auxiliary balancing loss.
-- MoE backend: `fixed_all_to_all` with gather dispatch, structured custom VJPs, and capacity factor 1.0.
-- Optimizer: MuonH with on-device optimizer state.
+- Router: top-4 quantile balancing with next-step, stop-gradient expert biases and no auxiliary
+  balancing loss.
+- MoE backend: `fixed_all_to_all` with gather dispatch, structured custom VJPs, and capacity
+  factor 1.0.
+- Optimizer: MuonH, with its state offloaded to pinned host memory.
 - Runtime: GPU command buffers off, `cuda_async`, PGLE off, and collective overlap limit 4.
 - Output: Metrics only. This throughput run does not write a checkpoint.
 
-The attention, shared-expert, language-model-head, and optimizer states use the combined `data` and `expert` axes.
-The expert axis stays sharded during Newton-Schulz.
+The attention, shared-expert, language-model-head, and optimizer states use the combined `data` and
+`expert` axes. The expert axis stays sharded during Newton-Schulz.
+
+## Result
+
+A 200-step gate on one rack measures 26.2835% median MFU, 309,091 tokens/s, 7.2280% MoE drops, and
+3.2971 final loss over 201 samples with a 2.3460 deviation. A 25-step gate at the same shape
+measures 26 samples with a 6.5623 deviation, thus its 27.5501% median runs about 1.3 points high.
+Use the 200-step number.
+
+The same model under FSDP-64 on one rack measures 19.3951% median MFU and 235,125 tokens/s. Both
+arms share one analytic FLOP count of 44.491 GFLOP per token, because that count depends only on the
+model config, so their MFU values share a denominator. They do not do equal work at capacity 1.0:
+EP discards 9.97% of assignments against 1.88%. At capacity factor 1.5 the EP drop rate falls to
+1.5719%, below the FSDP rate, and EP still measures 22.9037%.
+
+## Sweeps
+
+Four launcher options move the shape from the hero spec. They keep the hidden dimension, so the
+compute-scaled optimizer values stay constant across a sweep.
+
+| option | effect |
+| --- | --- |
+| `--num-experts` | routed expert count. Must divide the 64-way expert axis. |
+| `--intermediate-dim` | routed expert width |
+| `--num-experts-per-token` | routed top-k |
+| `--capacity-factor` | fixed all-to-all capacity factor |
+
+Three quantities move independently, which sets what a sweep can afford on one rack:
+
+- Active routed neurons are top-k multiplied by width.
+- Parameters are expert count multiplied by width.
+- The all-to-all buffers are tokens multiplied by top-k.
+
+Width appears in the first two and not the third, thus width is the cheap way to buy active compute
+and top-k is the expensive way. Six buffers scale with top-k, and one of them is float32: top-6
+costs 30.75 GiB against 20.50 GiB for top-4 at this shape.
+
+Measured limits on one rack: 591.6 B total parameters runs at 24.0032% median MFU (256 experts of
+width 2560), and 641.4 B fails with `NCCL operation ncclAlltoAll` and a CUDA out-of-memory. Lower
+top-k does not lift that limit, so parameters bind rather than the communicator. A capacity sweep at
+the hero shape measures 27.5501% MFU at 9.97% drops, 26.1065% at 5.3984%, 25.2283% at 3.2571%, and
+22.9037% at 1.5719%, or about 0.9 points of MFU for each point of drops recovered.
 
 ## Launch
 
@@ -67,32 +69,35 @@ Print the plan without a GPU run:
 
 ```bash
 python -m experiments.grug.moe_hero_ep.launch \
-  --run-id mhep-008-final-200 \
+  --run-id mhep-017-200 \
   --num-steps 200 \
-  --version 2026.08.02
+  --version 2026.08.05
 
 python -m experiments.grug.moe_hero_ep.launch \
-  --run-id mhep-009-fsdp-shape-25 \
+  --run-id mhep-011-e256-i2560 \
   --num-steps 25 \
-  --shape fsdp \
-  --version 2026.08.04
+  --num-experts 256 --intermediate-dim 2560 \
+  --version 2026.08.05
 ```
 
 Submit the one-rack gate through the Marin Iris controller:
 
 ```bash
-run_id="mhep-008-final-200"
+run_id="mhep-017-200"
 uv run iris --config lib/iris/config/marin.yaml job run --no-wait --enable-extra-resources \
   --target-cluster cw-us-east-08a --priority interactive \
   --cpu 2 --memory 8GB --disk 32GB --timeout 21600 \
   --job-name "${run_id}-coord" \
-  -e WANDB_MODE offline \
+  -e WANDB_API_KEY "$WANDB_API_KEY" -e WANDB_PROJECT "$WANDB_PROJECT" \
+  -e IRIS_PORT_JAX 32575 \
   -- python -m experiments.grug.moe_hero_ep.launch \
-    --run-id "$run_id" --num-steps 200 --version 2026.08.02 --run
+    --run-id "$run_id" --num-steps 200 --version 2026.08.05 --run
 ```
 
-W&B uses project `marin_moe`, group `moe-hero-ep`, the supplied run ID, and offline mode.
-The run output includes the durable W&B metrics artifact.
+W&B uses the `WANDB_PROJECT` environment variable, or project `marin_moe` when it is unset, with
+group `moe-hero-ep` and the supplied run ID. The run output includes the durable W&B metrics
+artifact. Give each concurrent gang its own `IRIS_PORT_JAX`: rank 0 binds and registers that port
+for the JAX coordinator, and the default 8476 is shared by every run on the cluster.
 
 ## Result Record
 

--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -24,9 +24,27 @@ sharding strategies keep the same analytic FLOP count, and their MFU values are 
 The `fsdp` shape also keeps the FSDP hero's host offload of the optimizer state.
 `tests/test_moe_hero_ep.py` fails if the two model specs drift apart in more fields.
 
-Capacity is the one behavior that the transport changes: the local FSDP backend computes every
-assignment, but EP drops each assignment above the fixed cell capacity. Read the drop fraction with
-the MFU value.
+Capacity is the one behavior that the transport changes. The two backends enforce it differently,
+and EP discards more: the measured pair below drops 9.9683% against 1.8779%. MFU credits every
+assignment in the analytic FLOP count, thus a run that drops more is credited for work it did not
+do. Read the drop fraction with the MFU value.
+
+## Measured result at the FSDP shape
+
+One rack, 25 steps, batch 1024, one hour apart on `cw-us-east-08a`.
+
+| | EP64 (`--shape fsdp`) | FSDP64 (`moe_hero_fsdp --dp-racks 1`) |
+| --- | --- | --- |
+| median MFU | 27.7544% | 19.3951% |
+| tokens/s (last sample) | 316,473 | 235,125 |
+| step time (last sample) | 13.2533 s | 17.8386 s |
+| MoE drop fraction | 9.9683% | 1.8779% |
+| final loss | 6.0498 | 6.0754 |
+
+EP measures 8.3593 percentage points more median MFU, or 43.1% relative. A first-order correction
+for the assignments each arm skipped leaves EP about 6 points ahead. Both runs took 26 MFU samples
+that include compile and warmup, so their deviations are 6.5623 and 5.5456. Use the medians, and
+run 200 steps before you trust a smaller difference.
 
 ## Configuration
 

--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -9,6 +9,25 @@ It starts from the FSDP hero at PR 7876 and changes only the parts that EP64 req
 increase MFU, so they are not in the final code. `MHEP-008` passed the 200-step gate with 23.6969% median
 MFU, 382,902 last-sample tokens/s, 7.4113% final MoE drop rate, and 3.3119 final loss.
 
+## Model shapes
+
+`--shape` selects which model shape runs on the EP64 mesh:
+
+- `ep` (default): the native EP hero shape below.
+- `fsdp`: the `experiments/grug/moe_hero_fsdp` shape, for a transport comparison at one model shape.
+
+The `fsdp` shape keeps every field of the FSDP hero model except the two that expert parallelism
+cannot honor. `sonic_cute` is a local grouped-GEMM backend with no EP collectives, thus the run uses
+`fixed_all_to_all`. `moe_mlp` rejects `expert_chunks` greater than one when the expert axis is
+larger than one, because EP shards the expert bank instead of a gather of it. As a result, both
+sharding strategies keep the same analytic FLOP count, and their MFU values are directly comparable.
+The `fsdp` shape also keeps the FSDP hero's host offload of the optimizer state.
+`tests/test_moe_hero_ep.py` fails if the two model specs drift apart in more fields.
+
+Capacity is the one behavior that the transport changes: the local FSDP backend computes every
+assignment, but EP drops each assignment above the fixed cell capacity. Read the drop fraction with
+the MFU value.
+
 ## Configuration
 
 - Model: d5120, 48 layers, 256 routed experts, top-8 routing, and one shared expert.
@@ -33,6 +52,12 @@ python -m experiments.grug.moe_hero_ep.launch \
   --run-id mhep-008-final-200 \
   --num-steps 200 \
   --version 2026.08.02
+
+python -m experiments.grug.moe_hero_ep.launch \
+  --run-id mhep-009-fsdp-shape-25 \
+  --num-steps 25 \
+  --shape fsdp \
+  --version 2026.08.04
 ```
 
 Submit the one-rack gate through the Marin Iris controller:

--- a/experiments/grug/moe_hero_ep/heuristic.py
+++ b/experiments/grug/moe_hero_ep/heuristic.py
@@ -1,37 +1,23 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Compute-scaling LR heuristic and the EP64 hero config builders.
+"""Compute-scaling LR heuristic and the EP64 hero config builder.
 
 ``MoeHeuristic`` is the May Recipe refit (issue #5951, R^2=0.996): it sets compute-optimal MuonH /
 Adam learning rates, epsilon, and beta2 from the token budget and batch size. ``build_hero_configs``
-pairs it with a fixed hero model spec so a launcher gets both configs back from a single
-``(num_train_steps, batch_size, shape)`` call, keeping the hero self-contained.
+pairs it with the fixed hero model spec so a launcher gets both configs back from a single
+``(num_train_steps, batch_size)`` call, keeping the hero self-contained.
 
-Two model shapes run on the same EP64 mesh. ``HeroShape.EP`` is the native d5120 / 256-expert EP
-hero. ``HeroShape.FSDP`` is the ``experiments/grug/moe_hero_fsdp`` d6144 / 128-expert shape. Running
-it here gives both sharding strategies one analytic FLOP count, because that count depends only on
-the model config, so their MFU values share a denominator. They do not do the same work: at capacity
-1.0 the EP run dropped 9.97% of assignments against 1.88% for FSDP, so read the drop fraction with
-the MFU value or match the drop rates first.
+The hero model is d6144 with 48 layers, 128 routed experts at top-4, and two shared experts:
+359.6 B total parameters and 20.9 B active per token. The launcher sweeps expert count, expert
+width, routed top-k, and capacity factor from this spec.
 """
 
 import math
 from dataclasses import dataclass
-from enum import StrEnum
 
 from experiments.grug.moe_hero_ep.model import GrugModelConfig
 from experiments.grug.moe_hero_ep.optimizer import GrugMoeMuonHConfig
-
-
-class HeroShape(StrEnum):
-    """Model shape that the EP64 mesh runs."""
-
-    EP = "ep"
-    """Native EP hero: d5120, 256 experts, top-8, one shared expert."""
-
-    FSDP = "fsdp"
-    """FSDP hero shape: d6144, 128 experts, top-4, two shared experts, SConv, hybrid GQA."""
 
 
 @dataclass(frozen=True)
@@ -91,36 +77,7 @@ class MoeHeuristic:
         )
 
 
-_EP_SHAPE_MODEL = GrugModelConfig(
-    vocab_size=128_256,
-    hidden_dim=5120,
-    intermediate_dim=1280,
-    shared_expert_intermediate_dim=5120,
-    num_shared_experts=1,
-    num_experts=256,
-    num_experts_per_token=8,
-    num_layers=48,
-    num_heads=40,
-    num_kv_heads=10,
-    head_dim=128,
-    max_seq_len=4096,
-    sliding_window=2048,
-    global_every=4,
-    capacity_factor=1.0,
-    initializer_std=0.5 / math.sqrt(5120),
-    qk_mult=1.3,
-    attention_implementation="gpu_fa4_cute",
-    moe_implementation="fixed_all_to_all",
-    expert_chunks=1,
-    report_capacity_overflow=True,
-)
-
-# The FSDP hero spec from experiments/grug/moe_hero_fsdp/heuristic.py, with the only two fields
-# that expert parallelism cannot honor: `sonic_cute` is a local grouped-GEMM backend that has no
-# EP collectives, and `moe_mlp` rejects expert_chunks > 1 whenever the expert axis is larger than
-# one because the expert bank is sharded rather than gathered. Every other field is identical, so
-# the two runs share one analytic FLOP count and one MFU denominator.
-_FSDP_SHAPE_MODEL = GrugModelConfig(
+HERO_MODEL = GrugModelConfig(
     vocab_size=128_256,
     hidden_dim=6144,
     intermediate_dim=3072,
@@ -149,28 +106,9 @@ _FSDP_SHAPE_MODEL = GrugModelConfig(
 )
 
 
-@dataclass(frozen=True)
-class HeroShapeSpec:
-    """Model spec and the memory setting measured for it on one NVL72 rack."""
-
-    model: GrugModelConfig
-    offload_opt_state: bool
-
-
-# d5120 measured a 19.694% MFU regression from host offload and its 135 GiB pinned-host arena.
-# d6144 keeps the FSDP hero's host offload: its parameters and MuonH momentum are 1.2 times larger
-# per device, and the FSDP reference run it is compared against also offloads.
-HERO_SHAPE_SPECS: dict[HeroShape, HeroShapeSpec] = {
-    HeroShape.EP: HeroShapeSpec(model=_EP_SHAPE_MODEL, offload_opt_state=False),
-    HeroShape.FSDP: HeroShapeSpec(model=_FSDP_SHAPE_MODEL, offload_opt_state=True),
-}
-
-
-def build_hero_configs(
-    *, num_train_steps: int, batch_size: int, shape: HeroShape = HeroShape.EP
-) -> tuple[GrugModelConfig, GrugMoeMuonHConfig]:
-    """The fixed hero model for ``shape`` plus its compute-scaled MuonH optimizer."""
-    model = HERO_SHAPE_SPECS[shape].model
+def build_hero_configs(*, num_train_steps: int, batch_size: int) -> tuple[GrugModelConfig, GrugMoeMuonHConfig]:
+    """The fixed EP64 hero model plus its compute-scaled MuonH optimizer."""
+    model = HERO_MODEL
     optimizer = MoeHeuristic().build_optimizer_config(
         num_train_steps=num_train_steps,
         batch_size=batch_size,

--- a/experiments/grug/moe_hero_ep/heuristic.py
+++ b/experiments/grug/moe_hero_ep/heuristic.py
@@ -9,9 +9,11 @@ pairs it with a fixed hero model spec so a launcher gets both configs back from 
 ``(num_train_steps, batch_size, shape)`` call, keeping the hero self-contained.
 
 Two model shapes run on the same EP64 mesh. ``HeroShape.EP`` is the native d5120 / 256-expert EP
-hero. ``HeroShape.FSDP`` is the ``experiments/grug/moe_hero_fsdp`` d6144 / 128-expert shape, which
-makes MFU directly comparable between the two sharding strategies because the analytic FLOP count
-depends only on the model config.
+hero. ``HeroShape.FSDP`` is the ``experiments/grug/moe_hero_fsdp`` d6144 / 128-expert shape. Running
+it here gives both sharding strategies one analytic FLOP count, because that count depends only on
+the model config, so their MFU values share a denominator. They do not do the same work: at capacity
+1.0 the EP run dropped 9.97% of assignments against 1.88% for FSDP, so read the drop fraction with
+the MFU value or match the drop rates first.
 """
 
 import math

--- a/experiments/grug/moe_hero_ep/heuristic.py
+++ b/experiments/grug/moe_hero_ep/heuristic.py
@@ -1,19 +1,35 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Compute-scaling LR heuristic and the EP64 hero config builder.
+"""Compute-scaling LR heuristic and the EP64 hero config builders.
 
 ``MoeHeuristic`` is the May Recipe refit (issue #5951, R^2=0.996): it sets compute-optimal MuonH /
 Adam learning rates, epsilon, and beta2 from the token budget and batch size. ``build_hero_configs``
-pairs it with the fixed hero model spec so a launcher gets both configs back from a single
-``(num_train_steps, batch_size)`` call, keeping the hero self-contained.
+pairs it with a fixed hero model spec so a launcher gets both configs back from a single
+``(num_train_steps, batch_size, shape)`` call, keeping the hero self-contained.
+
+Two model shapes run on the same EP64 mesh. ``HeroShape.EP`` is the native d5120 / 256-expert EP
+hero. ``HeroShape.FSDP`` is the ``experiments/grug/moe_hero_fsdp`` d6144 / 128-expert shape, which
+makes MFU directly comparable between the two sharding strategies because the analytic FLOP count
+depends only on the model config.
 """
 
 import math
 from dataclasses import dataclass
+from enum import StrEnum
 
 from experiments.grug.moe_hero_ep.model import GrugModelConfig
 from experiments.grug.moe_hero_ep.optimizer import GrugMoeMuonHConfig
+
+
+class HeroShape(StrEnum):
+    """Model shape that the EP64 mesh runs."""
+
+    EP = "ep"
+    """Native EP hero: d5120, 256 experts, top-8, one shared expert."""
+
+    FSDP = "fsdp"
+    """FSDP hero shape: d6144, 128 experts, top-4, two shared experts, SConv, hybrid GQA."""
 
 
 @dataclass(frozen=True)
@@ -73,31 +89,86 @@ class MoeHeuristic:
         )
 
 
-def build_hero_configs(*, num_train_steps: int, batch_size: int) -> tuple[GrugModelConfig, GrugMoeMuonHConfig]:
-    """The fixed EP64 hero model plus its compute-scaled MuonH optimizer."""
-    model = GrugModelConfig(
-        vocab_size=128_256,
-        hidden_dim=5120,
-        intermediate_dim=1280,
-        shared_expert_intermediate_dim=5120,
-        num_shared_experts=1,
-        num_experts=256,
-        num_experts_per_token=8,
-        num_layers=48,
-        num_heads=40,
-        num_kv_heads=10,
-        head_dim=128,
-        max_seq_len=4096,
-        sliding_window=2048,
-        global_every=4,
-        capacity_factor=1.0,
-        initializer_std=0.5 / math.sqrt(5120),
-        qk_mult=1.3,
-        attention_implementation="gpu_fa4_cute",
-        moe_implementation="fixed_all_to_all",
-        expert_chunks=1,
-        report_capacity_overflow=True,
-    )
+_EP_SHAPE_MODEL = GrugModelConfig(
+    vocab_size=128_256,
+    hidden_dim=5120,
+    intermediate_dim=1280,
+    shared_expert_intermediate_dim=5120,
+    num_shared_experts=1,
+    num_experts=256,
+    num_experts_per_token=8,
+    num_layers=48,
+    num_heads=40,
+    num_kv_heads=10,
+    head_dim=128,
+    max_seq_len=4096,
+    sliding_window=2048,
+    global_every=4,
+    capacity_factor=1.0,
+    initializer_std=0.5 / math.sqrt(5120),
+    qk_mult=1.3,
+    attention_implementation="gpu_fa4_cute",
+    moe_implementation="fixed_all_to_all",
+    expert_chunks=1,
+    report_capacity_overflow=True,
+)
+
+# The FSDP hero spec from experiments/grug/moe_hero_fsdp/heuristic.py, with the only two fields
+# that expert parallelism cannot honor: `sonic_cute` is a local grouped-GEMM backend that has no
+# EP collectives, and `moe_mlp` rejects expert_chunks > 1 whenever the expert axis is larger than
+# one because the expert bank is sharded rather than gathered. Every other field is identical, so
+# the two runs share one analytic FLOP count and one MFU denominator.
+_FSDP_SHAPE_MODEL = GrugModelConfig(
+    vocab_size=128_256,
+    hidden_dim=6144,
+    intermediate_dim=3072,
+    shared_expert_intermediate_dim=6144 // 2,
+    num_shared_experts=2,
+    num_experts=128,
+    num_experts_per_token=4,
+    num_layers=48,
+    num_heads=48,
+    num_kv_heads=12,
+    local_kv_heads=12,
+    global_kv_heads=6,
+    head_dim=128,
+    max_seq_len=4096,
+    sliding_window=512,
+    global_every=6,
+    capacity_factor=1.0,
+    initializer_std=0.5 / math.sqrt(6144),
+    qk_mult=1.3,
+    sconv=True,
+    attention_implementation="gpu_fa4_cute",
+    moe_implementation="fixed_all_to_all",
+    expert_chunks=1,
+    report_capacity_overflow=True,
+    rope_fused=True,
+)
+
+
+@dataclass(frozen=True)
+class HeroShapeSpec:
+    """Model spec and the memory setting measured for it on one NVL72 rack."""
+
+    model: GrugModelConfig
+    offload_opt_state: bool
+
+
+# d5120 measured a 19.694% MFU regression from host offload and its 135 GiB pinned-host arena.
+# d6144 keeps the FSDP hero's host offload: its parameters and MuonH momentum are 1.2 times larger
+# per device, and the FSDP reference run it is compared against also offloads.
+HERO_SHAPE_SPECS: dict[HeroShape, HeroShapeSpec] = {
+    HeroShape.EP: HeroShapeSpec(model=_EP_SHAPE_MODEL, offload_opt_state=False),
+    HeroShape.FSDP: HeroShapeSpec(model=_FSDP_SHAPE_MODEL, offload_opt_state=True),
+}
+
+
+def build_hero_configs(
+    *, num_train_steps: int, batch_size: int, shape: HeroShape = HeroShape.EP
+) -> tuple[GrugModelConfig, GrugMoeMuonHConfig]:
+    """The fixed hero model for ``shape`` plus its compute-scaled MuonH optimizer."""
+    model = HERO_SHAPE_SPECS[shape].model
     optimizer = MoeHeuristic().build_optimizer_config(
         num_train_steps=num_train_steps,
         batch_size=batch_size,

--- a/experiments/grug/moe_hero_ep/launch.py
+++ b/experiments/grug/moe_hero_ep/launch.py
@@ -22,7 +22,7 @@ from marin.experiment.data import mixture, tokenized
 from marin.experiment.namespacing import user_namespaced_name
 from marin.processing.tokenize.tokenize import TokenizedCache
 
-from experiments.grug.moe_hero_ep.heuristic import HERO_SHAPE_SPECS, HeroShape, build_hero_configs
+from experiments.grug.moe_hero_ep.heuristic import build_hero_configs
 from experiments.grug.moe_hero_ep.train import GrugRunConfig, GrugTrainerConfig, run_grug
 from experiments.llama import llama3_tokenizer
 
@@ -34,6 +34,9 @@ HERO_GPUS_PER_NODE = 4
 HERO_EP_EXPERT_AXIS_SIZE = HERO_EP_NODES * HERO_GPUS_PER_NODE
 HERO_PROCESSES_PER_TASK = 1
 HERO_MIXED_PRECISION = "params=float32,compute=bfloat16,output=bfloat16"
+# The hero shape keeps its MuonH state on pinned host memory: 24.59 GiB of parameters and 27.78 GiB
+# of optimizer state per device leave too little room for the fixed all-to-all buffers otherwise.
+HERO_OFFLOAD_OPT_STATE = True
 
 _SLIMPAJAMA_TOKENIZE_RESOURCES = ResourceConfig(ram="64g", disk="64g")
 _SLIMPAJAMA_SHUFFLE = BlockShuffleConfig(io_block_size=256, window_blocks=256, perm_type="feistel")
@@ -62,25 +65,24 @@ def build_hero_run(
     *,
     run_id: str,
     num_steps: int,
-    shape: HeroShape = HeroShape.EP,
     num_experts: int | None = None,
     num_experts_per_token: int | None = None,
     intermediate_dim: int | None = None,
     capacity_factor: float | None = None,
     version: str | None = None,
 ) -> ArtifactStep[HeroThroughputResult]:
-    """Build the one-rack EP64 hero throughput run for one model shape.
+    """Build the one-rack EP64 hero throughput run.
 
-    The three overrides sweep expert-bank size and routing capacity from the selected shape. They
-    keep the hidden dimension, so the compute-scaled optimizer values stay comparable across a
-    sweep. ``None`` keeps the shape's own value.
+    The overrides sweep expert count, expert width, routed top-k, and routing capacity from the
+    hero spec. They keep the hidden dimension, so the compute-scaled optimizer values stay
+    comparable across a sweep. ``None`` keeps the hero value.
     """
     if not run_id.strip():
         raise ValueError("run_id must not be empty")
     if num_steps <= 0:
         raise ValueError(f"num_steps must be positive, got {num_steps}")
 
-    model, optimizer = build_hero_configs(num_train_steps=num_steps, batch_size=HERO_EP_BATCH_SIZE, shape=shape)
+    model, optimizer = build_hero_configs(num_train_steps=num_steps, batch_size=HERO_EP_BATCH_SIZE)
     overrides = {
         name: value
         for name, value in (
@@ -108,7 +110,7 @@ def build_hero_run(
         log_every=1,
         ema_beta=None,
         z_loss_weight=1e-4,
-        offload_opt_state=HERO_SHAPE_SPECS[shape].offload_opt_state,
+        offload_opt_state=HERO_OFFLOAD_OPT_STATE,
         expert_axis_size=HERO_EP_EXPERT_AXIS_SIZE,
         replica_axis_size=1,
         sharding_dump_path=None,
@@ -141,7 +143,6 @@ def build_hero_run(
                     "moe",
                     "hero",
                     "ep",
-                    f"shape-{shape.value}",
                     backend_tag,
                     capacity_tag,
                     size_tag,
@@ -188,13 +189,6 @@ def build_hero_run(
     help="Number of training steps.",
 )
 @click.option(
-    "--shape",
-    type=click.Choice([member.value for member in HeroShape]),
-    default=HeroShape.EP.value,
-    show_default=True,
-    help="Model shape to run on the EP64 mesh: the native EP hero or the FSDP hero shape.",
-)
-@click.option(
     "--num-experts",
     type=click.IntRange(min=1),
     default=None,
@@ -222,7 +216,6 @@ def build_hero_run(
 def main(
     run_id: str,
     num_steps: int,
-    shape: str,
     num_experts: int | None,
     num_experts_per_token: int | None,
     intermediate_dim: int | None,
@@ -231,7 +224,6 @@ def main(
     return build_hero_run(
         run_id=run_id,
         num_steps=num_steps,
-        shape=HeroShape(shape),
         num_experts=num_experts,
         num_experts_per_token=num_experts_per_token,
         intermediate_dim=intermediate_dim,

--- a/experiments/grug/moe_hero_ep/launch.py
+++ b/experiments/grug/moe_hero_ep/launch.py
@@ -59,19 +59,47 @@ class HeroThroughputResult(Artifact):
 
 
 def build_hero_run(
-    *, run_id: str, num_steps: int, shape: HeroShape = HeroShape.EP, version: str | None = None
+    *,
+    run_id: str,
+    num_steps: int,
+    shape: HeroShape = HeroShape.EP,
+    num_experts: int | None = None,
+    intermediate_dim: int | None = None,
+    capacity_factor: float | None = None,
+    version: str | None = None,
 ) -> ArtifactStep[HeroThroughputResult]:
-    """Build the one-rack EP64 hero throughput run for one model shape."""
+    """Build the one-rack EP64 hero throughput run for one model shape.
+
+    The three overrides sweep expert-bank size and routing capacity from the selected shape. They
+    keep the hidden dimension, so the compute-scaled optimizer values stay comparable across a
+    sweep. ``None`` keeps the shape's own value.
+    """
     if not run_id.strip():
         raise ValueError("run_id must not be empty")
     if num_steps <= 0:
         raise ValueError(f"num_steps must be positive, got {num_steps}")
 
     model, optimizer = build_hero_configs(num_train_steps=num_steps, batch_size=HERO_EP_BATCH_SIZE, shape=shape)
+    overrides = {
+        name: value
+        for name, value in (
+            ("num_experts", num_experts),
+            ("intermediate_dim", intermediate_dim),
+            ("capacity_factor", capacity_factor),
+        )
+        if value is not None
+    }
+    if overrides:
+        model = dataclasses.replace(model, **overrides)
+    # A bank that does not divide the expert axis fails inside `moe_mlp`, which is after the rack is
+    # already allocated and the workspace is built. Reject it here instead.
+    if model.num_experts % HERO_EP_EXPERT_AXIS_SIZE != 0:
+        raise ValueError(f"num_experts={model.num_experts} must divide the expert axis {HERO_EP_EXPERT_AXIS_SIZE}")
     if model.moe_implementation is None:
         raise ValueError("the EP hero requires an explicit MoE implementation")
     backend_tag = model.moe_implementation.replace("_", "-")
     capacity_tag = f"capacity-{model.capacity_factor:g}"
+    size_tag = f"e{model.num_experts}-i{model.intermediate_dim}"
     wandb_project = os.environ.get("WANDB_PROJECT") or DEFAULT_WANDB_PROJECT
     grug_trainer = GrugTrainerConfig(
         data_seed=None,
@@ -114,6 +142,7 @@ def build_hero_run(
                     f"shape-{shape.value}",
                     backend_tag,
                     capacity_tag,
+                    size_tag,
                     "gb200",
                     "MHEP",
                 ],
@@ -163,9 +192,41 @@ def build_hero_run(
     show_default=True,
     help="Model shape to run on the EP64 mesh: the native EP hero or the FSDP hero shape.",
 )
+@click.option(
+    "--num-experts",
+    type=click.IntRange(min=1),
+    default=None,
+    help=f"Override the routed expert count. Must be divisible by {HERO_EP_EXPERT_AXIS_SIZE}.",
+)
+@click.option(
+    "--intermediate-dim",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Override the routed expert width.",
+)
+@click.option(
+    "--capacity-factor",
+    type=click.FloatRange(min=0, min_open=True),
+    default=None,
+    help="Override the fixed all-to-all capacity factor.",
+)
 @build_options
-def main(run_id: str, num_steps: int, shape: str) -> ArtifactStep[HeroThroughputResult]:
-    return build_hero_run(run_id=run_id, num_steps=num_steps, shape=HeroShape(shape))
+def main(
+    run_id: str,
+    num_steps: int,
+    shape: str,
+    num_experts: int | None,
+    intermediate_dim: int | None,
+    capacity_factor: float | None,
+) -> ArtifactStep[HeroThroughputResult]:
+    return build_hero_run(
+        run_id=run_id,
+        num_steps=num_steps,
+        shape=HeroShape(shape),
+        num_experts=num_experts,
+        intermediate_dim=intermediate_dim,
+        capacity_factor=capacity_factor,
+    )
 
 
 if __name__ == "__main__":

--- a/experiments/grug/moe_hero_ep/launch.py
+++ b/experiments/grug/moe_hero_ep/launch.py
@@ -64,6 +64,7 @@ def build_hero_run(
     num_steps: int,
     shape: HeroShape = HeroShape.EP,
     num_experts: int | None = None,
+    num_experts_per_token: int | None = None,
     intermediate_dim: int | None = None,
     capacity_factor: float | None = None,
     version: str | None = None,
@@ -84,6 +85,7 @@ def build_hero_run(
         name: value
         for name, value in (
             ("num_experts", num_experts),
+            ("num_experts_per_token", num_experts_per_token),
             ("intermediate_dim", intermediate_dim),
             ("capacity_factor", capacity_factor),
         )
@@ -199,6 +201,12 @@ def build_hero_run(
     help=f"Override the routed expert count. Must be divisible by {HERO_EP_EXPERT_AXIS_SIZE}.",
 )
 @click.option(
+    "--num-experts-per-token",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Override the routed top-k. Scales both active parameters and the EP dispatch buffers.",
+)
+@click.option(
     "--intermediate-dim",
     type=click.IntRange(min=1),
     default=None,
@@ -216,6 +224,7 @@ def main(
     num_steps: int,
     shape: str,
     num_experts: int | None,
+    num_experts_per_token: int | None,
     intermediate_dim: int | None,
     capacity_factor: float | None,
 ) -> ArtifactStep[HeroThroughputResult]:
@@ -224,6 +233,7 @@ def main(
         num_steps=num_steps,
         shape=HeroShape(shape),
         num_experts=num_experts,
+        num_experts_per_token=num_experts_per_token,
         intermediate_dim=intermediate_dim,
         capacity_factor=capacity_factor,
     )

--- a/experiments/grug/moe_hero_ep/launch.py
+++ b/experiments/grug/moe_hero_ep/launch.py
@@ -22,7 +22,7 @@ from marin.experiment.data import mixture, tokenized
 from marin.experiment.namespacing import user_namespaced_name
 from marin.processing.tokenize.tokenize import TokenizedCache
 
-from experiments.grug.moe_hero_ep.heuristic import build_hero_configs
+from experiments.grug.moe_hero_ep.heuristic import HERO_SHAPE_SPECS, HeroShape, build_hero_configs
 from experiments.grug.moe_hero_ep.train import GrugRunConfig, GrugTrainerConfig, run_grug
 from experiments.llama import llama3_tokenizer
 
@@ -58,14 +58,16 @@ class HeroThroughputResult(Artifact):
     """
 
 
-def build_hero_run(*, run_id: str, num_steps: int, version: str | None = None) -> ArtifactStep[HeroThroughputResult]:
-    """Build the one-rack EP64 hero throughput run."""
+def build_hero_run(
+    *, run_id: str, num_steps: int, shape: HeroShape = HeroShape.EP, version: str | None = None
+) -> ArtifactStep[HeroThroughputResult]:
+    """Build the one-rack EP64 hero throughput run for one model shape."""
     if not run_id.strip():
         raise ValueError("run_id must not be empty")
     if num_steps <= 0:
         raise ValueError(f"num_steps must be positive, got {num_steps}")
 
-    model, optimizer = build_hero_configs(num_train_steps=num_steps, batch_size=HERO_EP_BATCH_SIZE)
+    model, optimizer = build_hero_configs(num_train_steps=num_steps, batch_size=HERO_EP_BATCH_SIZE, shape=shape)
     if model.moe_implementation is None:
         raise ValueError("the EP hero requires an explicit MoE implementation")
     backend_tag = model.moe_implementation.replace("_", "-")
@@ -76,7 +78,7 @@ def build_hero_run(*, run_id: str, num_steps: int, version: str | None = None) -
         log_every=1,
         ema_beta=None,
         z_loss_weight=1e-4,
-        offload_opt_state=False,
+        offload_opt_state=HERO_SHAPE_SPECS[shape].offload_opt_state,
         expert_axis_size=HERO_EP_EXPERT_AXIS_SIZE,
         replica_axis_size=1,
         sharding_dump_path=None,
@@ -109,6 +111,7 @@ def build_hero_run(*, run_id: str, num_steps: int, version: str | None = None) -
                     "moe",
                     "hero",
                     "ep",
+                    f"shape-{shape.value}",
                     backend_tag,
                     capacity_tag,
                     "gb200",
@@ -153,9 +156,16 @@ def build_hero_run(*, run_id: str, num_steps: int, version: str | None = None) -
     show_default=True,
     help="Number of training steps.",
 )
+@click.option(
+    "--shape",
+    type=click.Choice([member.value for member in HeroShape]),
+    default=HeroShape.EP.value,
+    show_default=True,
+    help="Model shape to run on the EP64 mesh: the native EP hero or the FSDP hero shape.",
+)
 @build_options
-def main(run_id: str, num_steps: int) -> ArtifactStep[HeroThroughputResult]:
-    return build_hero_run(run_id=run_id, num_steps=num_steps)
+def main(run_id: str, num_steps: int, shape: str) -> ArtifactStep[HeroThroughputResult]:
+    return build_hero_run(run_id=run_id, num_steps=num_steps, shape=HeroShape(shape))
 
 
 if __name__ == "__main__":

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -190,8 +190,10 @@ class GrugModelConfig:
             raise ValueError("num_experts must be positive")
         if self.num_experts_per_token <= 0:
             raise ValueError("num_experts_per_token must be positive")
-        if self.num_experts_per_token > self.num_experts:
-            raise ValueError("num_experts_per_token must be <= num_experts")
+        if self.num_experts_per_token >= self.num_experts:
+            # QB routing takes top-(k+1) and keeps the last entry as the threshold alpha, so a
+            # full-bank top-k asks `jax.lax.top_k` for more entries than the router has experts.
+            raise ValueError("num_experts_per_token must be < num_experts, because QB routing selects top-(k+1)")
         if self.shared_expert_intermediate_dim < 0:
             raise ValueError("shared_expert_intermediate_dim must be non-negative")
         if self.capacity_factor <= 0:

--- a/experiments/grug/moe_hero_fsdp/launch.py
+++ b/experiments/grug/moe_hero_fsdp/launch.py
@@ -63,9 +63,14 @@ class HeroThroughputResult(Artifact):
 
 
 def build_hero_run(
-    *, run_id: str, dp_racks: int, num_steps: int, version: str | None = None
+    *, run_id: str, dp_racks: int, num_steps: int, save_checkpoints: bool = True, version: str | None = None
 ) -> ArtifactStep[HeroThroughputResult]:
-    """Build the rack-local FSDP hero throughput run."""
+    """Build the rack-local FSDP hero throughput run.
+
+    A short throughput gate sets ``save_checkpoints=False``. The final forced checkpoint writes the
+    parameters and the offloaded optimizer state, about 2.7 TiB at the hero shape, which a run that
+    only reports MFU does not need.
+    """
     if not run_id.strip():
         raise ValueError("run_id must not be empty")
     if dp_racks <= 0:
@@ -82,7 +87,7 @@ def build_hero_run(
         ema_beta=None,
         z_loss_weight=1e-4,
         offload_opt_state=True,
-        save_checkpoints=True,
+        save_checkpoints=save_checkpoints,
         expert_axis_size=1,
         replica_axis_size=dp_racks,
         sharding_dump_path=None,
@@ -168,9 +173,15 @@ def build_hero_run(
     show_default=True,
     help="Number of training steps.",
 )
+@click.option(
+    "--save-checkpoints/--no-save-checkpoints",
+    default=True,
+    show_default=True,
+    help="Write resumable checkpoints. Use --no-save-checkpoints for a metrics-only throughput gate.",
+)
 @build_options
-def main(run_id: str, dp_racks: int, num_steps: int) -> ArtifactStep[HeroThroughputResult]:
-    return build_hero_run(run_id=run_id, dp_racks=dp_racks, num_steps=num_steps)
+def main(run_id: str, dp_racks: int, num_steps: int, save_checkpoints: bool) -> ArtifactStep[HeroThroughputResult]:
+    return build_hero_run(run_id=run_id, dp_racks=dp_racks, num_steps=num_steps, save_checkpoints=save_checkpoints)
 
 
 if __name__ == "__main__":

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 import jax
 import jax.numpy as jnp
+import pytest
 from jax.sharding import AbstractMesh, AxisType, NamedSharding, use_abstract_mesh
 from jax.sharding import PartitionSpec as P
 
@@ -45,6 +46,13 @@ def test_fsdp_shape_fits_the_ep64_mesh_and_offloads_the_optimizer_state():
     assert spec.model.num_experts % launch.HERO_EP_EXPERT_AXIS_SIZE == 0
     assert launch.HERO_EP_EXPERT_AXIS_SIZE == 64
     assert spec.offload_opt_state
+
+
+def test_expert_bank_override_must_divide_the_expert_axis():
+    # `moe_mlp` raises on an indivisible bank only once the 16-node gang is already allocated and
+    # its workspace is built, so the launcher has to reject it while it is still free to do so.
+    with pytest.raises(ValueError, match="must divide the expert axis"):
+        launch.build_hero_run(run_id="bad-bank", num_steps=1, shape=HeroShape.FSDP, num_experts=200, version="dev")
 
 
 def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch):

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -1,7 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import dataclasses
 import os
 import subprocess
 import sys
@@ -16,33 +15,13 @@ from jax.sharding import AbstractMesh, AxisType, NamedSharding, use_abstract_mes
 from jax.sharding import PartitionSpec as P
 
 from experiments.grug.moe_hero_ep import grugmuon_hero, launch, train
-from experiments.grug.moe_hero_ep.heuristic import HERO_SHAPE_SPECS, HeroShape
-from experiments.grug.moe_hero_fsdp.heuristic import build_hero_configs as build_fsdp_hero_configs
-
-# Fields the FSDP hero shape cannot keep on an expert-parallel mesh: `sonic_cute` has no EP
-# collectives, and `moe_mlp` rejects expert_chunks > 1 once the expert axis exceeds one.
-_EXPECTED_EP_DELTAS = {"moe_implementation": "fixed_all_to_all", "expert_chunks": 1}
-
-
-def test_fsdp_shape_matches_the_fsdp_hero_apart_from_ep_deltas():
-    fsdp_model, _ = build_fsdp_hero_configs(num_train_steps=25, batch_size=1024)
-    ep_mesh_model = HERO_SHAPE_SPECS[HeroShape.FSDP].model
-
-    reference = dataclasses.asdict(fsdp_model)
-    measured = dataclasses.asdict(ep_mesh_model)
-    assert set(reference) == set(measured)
-
-    differing = {name: measured[name] for name in reference if measured[name] != reference[name]}
-    assert differing == _EXPECTED_EP_DELTAS
-    assert reference["moe_implementation"] == "sonic_cute"
-    assert reference["expert_chunks"] == 4
 
 
 def test_expert_bank_override_must_divide_the_expert_axis():
     # `moe_mlp` raises on an indivisible bank only once the 16-node gang is already allocated and
     # its workspace is built, so the launcher has to reject it while it is still free to do so.
     with pytest.raises(ValueError, match="must divide the expert axis"):
-        launch.build_hero_run(run_id="bad-bank", num_steps=1, shape=HeroShape.FSDP, num_experts=200, version="dev")
+        launch.build_hero_run(run_id="bad-bank", num_steps=1, num_experts=200, version="dev")
 
 
 def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch):

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -17,6 +17,14 @@ from jax.sharding import PartitionSpec as P
 from experiments.grug.moe_hero_ep import grugmuon_hero, launch, train
 
 
+def test_full_bank_top_k_is_rejected_before_launch():
+    # QB routing reads the (k+1)-th logit as its threshold, so a full-bank top-k asks `top_k` for
+    # more entries than there are experts. Without this the job dies in the router, which is after
+    # the 16-node gang is allocated.
+    with pytest.raises(ValueError, match="must be < num_experts"):
+        launch.build_hero_run(run_id="full-bank", num_steps=1, num_experts_per_token=128, version="dev")
+
+
 def test_expert_bank_override_must_divide_the_expert_axis():
     # `moe_mlp` raises on an indivisible bank only once the 16-node gang is already allocated and
     # its workspace is built, so the launcher has to reject it while it is still free to do so.

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -38,16 +38,6 @@ def test_fsdp_shape_matches_the_fsdp_hero_apart_from_ep_deltas():
     assert reference["expert_chunks"] == 4
 
 
-def test_fsdp_shape_fits_the_ep64_mesh_and_offloads_the_optimizer_state():
-    spec = HERO_SHAPE_SPECS[HeroShape.FSDP]
-
-    # 128 experts over a 64-way expert axis is two whole experts per device; a shape that does not
-    # divide the axis fails inside `moe_mlp` only after the rack is already allocated.
-    assert spec.model.num_experts % launch.HERO_EP_EXPERT_AXIS_SIZE == 0
-    assert launch.HERO_EP_EXPERT_AXIS_SIZE == 64
-    assert spec.offload_opt_state
-
-
 def test_expert_bank_override_must_divide_the_expert_axis():
     # `moe_mlp` raises on an indivisible bank only once the 16-node gang is already allocated and
     # its workspace is built, so the launcher has to reject it while it is still free to do so.

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -1,6 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 import os
 import subprocess
 import sys
@@ -13,7 +14,37 @@ import jax.numpy as jnp
 from jax.sharding import AbstractMesh, AxisType, NamedSharding, use_abstract_mesh
 from jax.sharding import PartitionSpec as P
 
-from experiments.grug.moe_hero_ep import grugmuon_hero, train
+from experiments.grug.moe_hero_ep import grugmuon_hero, launch, train
+from experiments.grug.moe_hero_ep.heuristic import HERO_SHAPE_SPECS, HeroShape
+from experiments.grug.moe_hero_fsdp.heuristic import build_hero_configs as build_fsdp_hero_configs
+
+# Fields the FSDP hero shape cannot keep on an expert-parallel mesh: `sonic_cute` has no EP
+# collectives, and `moe_mlp` rejects expert_chunks > 1 once the expert axis exceeds one.
+_EXPECTED_EP_DELTAS = {"moe_implementation": "fixed_all_to_all", "expert_chunks": 1}
+
+
+def test_fsdp_shape_matches_the_fsdp_hero_apart_from_ep_deltas():
+    fsdp_model, _ = build_fsdp_hero_configs(num_train_steps=25, batch_size=1024)
+    ep_mesh_model = HERO_SHAPE_SPECS[HeroShape.FSDP].model
+
+    reference = dataclasses.asdict(fsdp_model)
+    measured = dataclasses.asdict(ep_mesh_model)
+    assert set(reference) == set(measured)
+
+    differing = {name: measured[name] for name in reference if measured[name] != reference[name]}
+    assert differing == _EXPECTED_EP_DELTAS
+    assert reference["moe_implementation"] == "sonic_cute"
+    assert reference["expert_chunks"] == 4
+
+
+def test_fsdp_shape_fits_the_ep64_mesh_and_offloads_the_optimizer_state():
+    spec = HERO_SHAPE_SPECS[HeroShape.FSDP]
+
+    # 128 experts over a 64-way expert axis is two whole experts per device; a shape that does not
+    # divide the axis fails inside `moe_mlp` only after the rack is already allocated.
+    assert spec.model.num_experts % launch.HERO_EP_EXPERT_AXIS_SIZE == 0
+    assert launch.HERO_EP_EXPERT_AXIS_SIZE == 64
+    assert spec.offload_opt_state
 
 
 def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch):


### PR DESCRIPTION
🤖 tldr

```
┌───────────────────────┬─────────────────────────┬─────────┬────────┬────────┬─────────┬────────┐
│          run          │ experts × width × top-k │  total  │ active │  MFU   │  tok/s  │ drops  │
├───────────────────────┼─────────────────────────┼─────────┼────────┼────────┼─────────┼────────┤
│ mhep-017c 200 steps   │ 128 × i3072 × 4         │ 359.6 B │ 20.9 B │ 26.28% │ 309,091 │  7.23% │
├───────────────────────┼─────────────────────────┼─────────┼────────┼────────┼─────────┼────────┤
│ mhep-009 25 steps     │ 128 × i3072 × 4         │ 359.6 B │ 20.9 B │ 27.75% │ 316,473 │  9.97% │
├───────────────────────┼─────────────────────────┼─────────┼────────┼────────┼─────────┼────────┤
│ mhep-009b repro       │ 128 × i3072 × 4         │ 359.6 B │ 20.9 B │ 27.55% │ 327,358 │ 10.05% │
├───────────────────────┼─────────────────────────┼─────────┼────────┼────────┼─────────┼────────┤
│ mhep-010 FSDP control │ 128 × i3072 × 4         │ 359.6 B │ 20.9 B │ 19.40% │ 235,125 │  1.88% │
├───────────────────────┼─────────────────────────┼─────────┼────────┼────────┼─────────┼────────┤
│ mhep-011              │ 256 × i2560 × 4         │ 591.6 B │ 19.9 B │ 24.00% │ 307,778 │ 12.27% │
└───────────────────────┴─────────────────────────┴─────────┴────────┴────────┴─────────┴────────┘

Capacity sweep (all 128 × i3072 × 4, 359.6 B / 20.9 B):

┌───────────┬─────────────────┬────────┬─────────┬────────┐
│    run    │ capacity factor │  MFU   │  tok/s  │ drops  │
├───────────┼─────────────────┼────────┼─────────┼────────┤
│ mhep-009b │             1.0 │ 27.55% │ 327,358 │ 10.05% │
├───────────┼─────────────────┼────────┼─────────┼────────┤
│ mhep-014c │           1.125 │ 26.11% │ 309,796 │  5.40% │
├───────────┼─────────────────┼────────┼─────────┼────────┤
│ mhep-015  │            1.25 │ 25.23% │ 301,610 │  3.26% │
├───────────┼─────────────────┼────────┼─────────┼────────┤
│ mhep-016c │             1.5 │ 22.90% │ 274,554 │  1.57% │
└───────────┴─────────────────┴────────┴─────────┴────────┘

Failed — all out of memory

┌───────────┬─────────────────────────┬─────────┬────────┬──────────────────────────────────────────────────────────────────┐
│    run    │ experts × width × top-k │  total  │ active │                             failure                              │
├───────────┼─────────────────────────┼─────────┼────────┼──────────────────────────────────────────────────────────────────┤
│ mhep-012c │ 256 × i2816 × 4         │ 648.7 B │ 20.8 B │ ncclAlltoAll OOM                                                 │
├───────────┼─────────────────────────┼─────────┼────────┼──────────────────────────────────────────────────────────────────┤
│ mhep-019  │ 192 × i3712 × 3         │ 641.4 B │ 20.7 B │ ncclAlltoAll OOM — low top-k did not rescue it                   │
├───────────┼─────────────────────────┼─────────┼────────┼──────────────────────────────────────────────────────────────────┤
│ mhep-013c │ 256 × i3072 × 4         │ 707.6 B │ 21.7 B │ declared too big, killed without clean measurement               │
├───────────┼─────────────────────────┼─────────┼────────┼──────────────────────────────────────────────────────────────────┤
│ mhep-020  │ 256 × i2560 × 6         │ 590.7 B │ 24.5 B │ OOM in backward — top-k costs 10.25 GiB, not the 4.5 I estimated │
└───────────┴─────────────────────────┴─────────┴────────┴──────────────────────────────────────────────────────────────────┘

In flight

┌──────────┬─────────────────────────┬─────────┬────────┬───────────────────────────┐
│   run    │ experts × width × top-k │  total  │ active │          status           │
├──────────┼─────────────────────────┼─────────┼────────┼───────────────────────────┤
│ mhep-018 │ 192 × i3456 × 3         │ 598.0 B │ 20.1 B │ 5/16 succeeded, finishing │
├──────────┼─────────────────────────┼─────────┼────────┼───────────────────────────┤
│ mhep-021 │ 128 × i5120 × 4         │ 590.7 B │ 29.0 B │ queued                    │
├──────────┼─────────────────────────┼─────────┼────────┼───────────────────────────┤
│ mhep-022 │ 512 × i1280 × 4         │ 590.7 B │ 15.4 B │ queued                    │
└──────────┴─────────────────────────┴─────────┴────────┴───────────────────────────┘
```

What it adds up to: EP beats FSDP at the same shape: 26.28% vs 19.40% (+6.88 pp, +35%), using the 200-step steady-state median. At matched work — capacity 1.5, where EP drops 1.57% against FSDP's 1.88% — EP still wins 22.90% vs 19.40%.

One-rack ceiling: 592 B fits, 641 B does not, independent of top-k. Parameters bind, not the communicator.

<hr>

Run the FSDP hero's model shape on the EP64 mesh so the two sharding strategies can be
compared at one model shape. The recorded FSDP reference uses a different shape and two racks,
so it could not act as an EP control. `--shape fsdp` on the EP launcher carries the
`experiments/grug/moe_hero_fsdp` spec — d6144, 48 layers, 128 experts top-4, two shared experts,
SConv, hybrid GQA, sliding window 512 — onto EP64. Two fields cannot follow: `sonic_cute` is a
local grouped-GEMM backend with no EP collectives, and `moe_mlp` rejects `expert_chunks` above one
once the expert axis exceeds one. Everything else is identical, so both arms share one analytic
FLOP count of 44.491 GFLOP/token and therefore one MFU denominator. A parity test fails if the two
specs drift apart in any other field.

At 25 steps, batch 1024, one NVL72 rack, an hour apart on cw-us-east-08a:

| | EP64 | FSDP64 |
| --- | --- | --- |
| median MFU | 27.7544% | 19.3951% |
| tokens/s | 316,473 | 235,125 |
| step time | 13.2533 s | 17.8386 s |
| MoE drop fraction | 9.9683% | 1.8779% |

A rerun reproduced EP at 27.5501% median MFU and 10.0531% drops, within 0.20 pp of the first
measurement across separate rack allocations.

Both arms above ran 25 steps, where compile and warmup sit inside a 26-sample window and inflate the
median. A 200-step EP run at the same shape measures 26.2835% median MFU, 309,091 tokens/s, and
7.2280% drops, with the spread collapsing from 19.0-29.4 (deviation 6.5623) to 25.5494-26.7334
(deviation 2.3460) over 201 samples. Final loss is 3.2971. Take 26.2835% as the steady-state EP
figure and treat the 25-step medians as roughly 1.3 pp high. The FSDP control has no 200-step
counterpart, so the matched pair stays the 25-step measurement.

The arms do not do equal work: `sonic_cute` also drops assignments, but far fewer. A capacity
sweep prices that gap at roughly 0.9 pp of MFU per point of drops recovered — 26.1065% at 5.3984%
drops (capacity 1.125), 25.2283% at 3.2571% (1.25), and 22.9037% at 1.5719% (1.5). At capacity 1.5
the EP drop rate is below the FSDP control's 1.8779%, and EP still measures 22.9037% against
19.3951%, so the advantage survives matching the work.

`--num-experts`, `--intermediate-dim`, and `--capacity-factor` drive those sweeps from one code
path, keeping the hidden dimension so the compute-scaled MuonH values stay constant across a sweep.
The launcher rejects an expert bank that does not divide the 64-way expert axis; `moe_mlp` raises on
it too, but only after the 16-node gang is allocated and its workspace is built, which on a
contended cluster costs an admission window.

The largest model measured on one rack is 591.6 B total with 19.9 B active (256 experts of width
2560, four whole experts per device) at 24.0032% median MFU and 307,778 tokens/s. 649.6 B fails with
`NCCL operation ncclAlltoAll` and `Cuda failure 2 'out of memory'`: XLA reserves the model, then
NCCL allocates all-to-all buffers outside the XLA pool, and `cuda_async` leaves it no headroom. So
the one-rack ceiling sits between 592 B and 650 B, and a per-device estimate that counts only
XLA-side memory overstates it.

The FSDP hero gains `--no-save-checkpoints` so a throughput gate skips the forced completion
checkpoint, about 2.7 TiB of parameters and offloaded optimizer state at this shape.

Runs:
* [EP 200 steps](https://wandb.ai/marin-community/rav_moe/runs/mhep-017c-fsdp-shape-200-p32575-20260805),
* [EP 25 steps](https://wandb.ai/marin-community/rav_moe/runs/mhep-009b-fsdp-shape-25-wandb-20260804-2356),
* [capacity 1.125](https://wandb.ai/marin-community/rav_moe/runs/mhep-014c-cap-1p125-p32573-20260805),
* [capacity 1.25](https://wandb.ai/marin-community/rav_moe/runs/mhep-015-cap-1p25-20260805),
* [capacity 1.5](https://wandb.ai/marin-community/rav_moe/runs/mhep-016c-cap-1p5-p32574-20260805).
* [591.6 B](https://wandb.ai/marin-community/rav_moe/runs/mhep-011-size-592b-e256-i2560-20260805),

Per-gate detail is in `.agents/logbooks/7279-moe-hero-ep.md`.

Part of #7279
