### PR TITLE
[eval] Register r20 Qwen3-32B preset

### DIFF
--- a/experiments/evaluation/serve/models/EtashGuha/tezos100k_continue_gptlongtezos_step4800__Qwen3-32B.yaml
+++ b/experiments/evaluation/serve/models/EtashGuha/tezos100k_continue_gptlongtezos_step4800__Qwen3-32B.yaml
@@ -1,0 +1,19 @@
+name: tezos100k_continue_gptlongtezos_step4800__Qwen3-32B
+location: EtashGuha/tezos100k_continue_gptlongtezos_step4800__Qwen3-32B
+revision: 925f43ba8c1e07577a875e55522c2a31df767b3b
+apply_chat_template: true
+resource_hint:
+  gpu:
+    GB200: 1
+  memory: 128g
+serve:
+  tensor_parallel_size: 1
+  max_model_len: 32768
+  max_num_seqs: 96
+  tool_call_parser: hermes
+  reasoning_parser: qwen3
+  vllm_extra_args:
+  - --enable-prefix-caching
+agent:
+  agent_kwargs:
+    extra_body: '{"chat_template_kwargs":{"enable_thinking":true}}'


### PR DESCRIPTION
Register `EtashGuha/tezos100k_continue_gptlongtezos_step4800__Qwen3-32B`, the next pending SWE-bench campaign checkpoint, at immutable Hugging Face revision `925f43ba8c1e07577a875e55522c2a31df767b3b`. The absent catalog entry previously made the canonical launcher reject the row before it could construct a serving plan.

Use the validated Qwen3-32B GB200 envelope: one GB200, 128 GiB of host memory, tensor parallelism 1, a 32,768-token context, 96 concurrent sequences, Hermes tool parsing, Qwen3 reasoning parsing, prefix caching, and thinking enabled. The checkpoint's config, tokenizer config, tokenizer data, and chat template are byte-identical to the successfully evaluated step-6010 sibling, so the pinned model repository remains the tokenizer source rather than adding an unnecessary override.

The launcher dry-run now resolves the model to GB200x1 on `cw-us-east-08a` with the pinned location and no submission side effect.
