### PR TITLE
[loom] Pin LOOM_DOTENV v4

### DIFF
--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -13,7 +13,7 @@ config:
     - projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
   marin-loom:machineType: e2-highmem-4
   marin-loom:bootDiskGb: "1000"
-  marin-loom:dotenvSecretVersion: "3"
+  marin-loom:dotenvSecretVersion: "4"
   marin-loom:pruneDeployment: "true"
   marin-loom:snapshotRetentionDays: "14"
   marin-loom:profiles:


### PR DESCRIPTION
`LOOM_DOTENV` v3 carried a Slack **user** token (`xoxp-…`) in `LOOM_SLACK_BOT_TOKEN` instead of the app's bot token (`xoxb-…`). `auth.test` accepts either, so `loom.oa.dev` opened its Socket Mode connection and reported healthy — while taking that person's user id (`U09B54B93E3`) as its own. loom's self-trigger guard discards any mention whose sender matches its own id, so every mention that person typed was silently dropped, and any reply would have posted as them rather than as the bot.

Version 4 is byte-identical to v3 apart from that one value, which is now the bot token for app `A0AJ4HA07K9` (`U0AJYUBE48Z`). v3 is untouched, so a rollback is a pin and an update.

Already applied: `loom.oa.dev` is running this pin and reports `token_kind: bot`, identity `U0AJYUBE48Z`, socket connected to app `A0AJ4HA07K9`. The diagnostics that make this failure visible rather than silent are in [loom#260](https://github.com/marin-community/loom/pull/260), also deployed.
