### PR TITLE
fray: compose the nsys hook into iris entrypoints

### DIFF
--- a/lib/fray/src/fray/iris_backend.py
+++ b/lib/fray/src/fray/iris_backend.py
@@ -9,6 +9,7 @@ via submitted jobs, and deferred actor handle resolution.
 """
 
 import logging
+import os
 import threading
 import time
 from concurrent.futures import Future
@@ -169,6 +170,38 @@ def convert_entrypoint(entrypoint: FrayEntrypoint) -> IrisEntrypoint:
         be = entrypoint.binary_entrypoint
         return IrisEntrypoint.from_command(be.command, *be.args)
     raise ValueError("Entrypoint must have either callable_entrypoint or binary_entrypoint")
+
+
+NSYS_TASKS_ENV = "IRIS_NSYS_TASKS"
+
+
+def wrap_nsys(entrypoint: IrisEntrypoint) -> IrisEntrypoint:
+    """Run the entrypoint under ``nsys profile`` when ``IRIS_NSYS_TASKS`` is set.
+
+    ``iris.hooks.nsys_main`` is a submit-time wrapper: Nsight injects CUDA tracing
+    through ``CUDA_INJECTION64_PATH``, which the driver reads once at ``cuInit``,
+    so nsys has to be the parent process from the start. iris does not inject the
+    wrapper, and a callable entrypoint builds its command inside this backend, so
+    fray composes it here for the same reason it composes the multigpu supervisor.
+
+    The variable holds the ``--tasks`` spec: ``first``, ``all``, or a
+    comma-separated list of task indices. An unselected task execs the command
+    unchanged and pays nothing.
+    """
+    tasks = os.environ.get(NSYS_TASKS_ENV)
+    if not tasks:
+        return entrypoint
+    command = list(entrypoint.command)
+    if command[:2] == ["bash", "-c"] and len(command) == 3:
+        inner = command[2].removeprefix("exec ")
+        wrapped = ["bash", "-c", f"exec $IRIS_PYTHON -m iris.hooks.nsys_main --tasks {tasks} -- {inner}"]
+    else:
+        wrapped = ["$IRIS_PYTHON", "-m", "iris.hooks.nsys_main", "--tasks", tasks, "--", *command]
+    return IrisEntrypoint(
+        command=wrapped,
+        workdir_files=entrypoint.workdir_files,
+        workdir_file_refs=entrypoint.workdir_file_refs,
+    )
 
 
 def wrap_multiprocess(entrypoint: IrisEntrypoint, resources: ResourceSpec, processes_per_task: int) -> IrisEntrypoint:
@@ -629,6 +662,7 @@ class FrayIrisClient:
         iris_entrypoint = convert_entrypoint(request.entrypoint)
         if request.processes_per_task > 1:
             iris_entrypoint = wrap_multiprocess(iris_entrypoint, iris_resources, request.processes_per_task)
+        iris_entrypoint = wrap_nsys(iris_entrypoint)
         iris_environment = convert_environment(request.environment, request.resources.device)
         iris_constraints = convert_constraints(request.resources)
 

--- a/lib/fray/tests/test_iris.py
+++ b/lib/fray/tests/test_iris.py
@@ -508,3 +508,47 @@ def test_wrap_multiprocess_requires_gpu() -> None:
 def test_wrap_multiprocess_requires_divisible_gpu_count() -> None:
     with pytest.raises(ValueError, match="must divide the GPU count"):
         wrap_multiprocess(IrisEntrypoint.from_command("python", "x.py"), _gpu_resources(8), processes_per_task=3)
+
+
+def test_wrap_nsys_is_a_noop_without_the_environment_variable(monkeypatch):
+    monkeypatch.delenv(iris_backend.NSYS_TASKS_ENV, raising=False)
+    entrypoint = IrisEntrypoint(command=["bash", "-c", "exec $IRIS_PYTHON -u run.py"])
+
+    assert iris_backend.wrap_nsys(entrypoint).command == entrypoint.command
+
+
+def test_wrap_nsys_composes_the_hook_into_a_shell_entrypoint(monkeypatch):
+    monkeypatch.setenv(iris_backend.NSYS_TASKS_ENV, "first")
+    entrypoint = IrisEntrypoint(
+        command=["bash", "-c", "exec $IRIS_PYTHON -u run.py"],
+        workdir_files={"run.py": b"print(1)"},
+    )
+
+    wrapped = iris_backend.wrap_nsys(entrypoint)
+
+    assert wrapped.command == [
+        "bash",
+        "-c",
+        "exec $IRIS_PYTHON -m iris.hooks.nsys_main --tasks first -- $IRIS_PYTHON -u run.py",
+    ]
+    assert wrapped.workdir_files == entrypoint.workdir_files
+
+
+def test_wrap_nsys_composes_the_hook_into_a_binary_entrypoint(monkeypatch):
+    monkeypatch.setenv(iris_backend.NSYS_TASKS_ENV, "0,3")
+    entrypoint = IrisEntrypoint(command=["python", "train.py", "--steps", "5"])
+
+    wrapped = iris_backend.wrap_nsys(entrypoint)
+
+    assert wrapped.command == [
+        "$IRIS_PYTHON",
+        "-m",
+        "iris.hooks.nsys_main",
+        "--tasks",
+        "0,3",
+        "--",
+        "python",
+        "train.py",
+        "--steps",
+        "5",
+    ]


### PR DESCRIPTION
* `iris.hooks.nsys_main` shipped in #7395, but nothing could invoke it on a callable entrypoint, which is how grug and Marin training jobs dispatch — so the hook was unreachable for its main use case
* `wrap_nsys` composes the hook at submit time, gated on `IRIS_NSYS_TASKS`
  * unset leaves the entrypoint byte-identical, and an unselected task `exec`s the command unchanged, so an unused build pays nothing
  * the value is the hook's `--tasks` spec: `first`, `all`, or a comma-separated task list
* this has to happen at submit time [^1], and it has to happen in the fray backend [^2]
* placed beside `wrap_multiprocess`, which is composed at the same point for the same structural reason
* handles both entrypoint shapes: a `bash -c` command is rewritten in place, anything else is prefixed as argv
* 4 unit tests; full fray suite passes (88)

Verified on a 16-node GB200 job: one 353 MB report for task 0 covering its 4 GPUs, which exported to SQLite and analysed cleanly.

Two rough edges worth knowing before using it, neither introduced here:

* tracing is expensive at high kernel counts — a MoE step with ~200k kernel launches went from 26.2 s to 51.6 s under nsys, and GPU idle read 58% against 6% in an XProf trace of the same graph. Per-kernel device times still matched XProf within 5%, but step totals and idle fractions from an nsys run are not usable. `capture_range` bounds this
* reading a report needs an aarch64 host, since `nsys` is baked into the task image but is not available locally and has no PyPI build. `nsys export --type sqlite` inside a task pod works

[^1]: Nsight injects CUDA tracing through `CUDA_INJECTION64_PATH`, which the driver reads once at `cuInit`, so nsys must be the parent process from the start. It cannot attach to a live process the way the py-spy/memray profiler in `iris.cluster.runtime.profile` can.

[^2]: `Entrypoint.from_callable` cloudpickles the target and hard-codes its command as `bash -c "exec $IRIS_PYTHON -u $IRIS_WORKDIR/_callable_runner.py"` inside `convert_entrypoint`, so a caller has no seam to prepend the wrapper.
