### PR TITLE
Guard Harbor resume roots by dataset

### DIFF
--- a/experiments/evaluation/cli.py
+++ b/experiments/evaluation/cli.py
@@ -89,6 +89,11 @@ def cli() -> None:
     help="Human version label for this launch, e.g. '2026.07.20' or 'rl-fix-sweep'.",
 )
 @click.option("--description", default=None, help="Free-text note on why this launch was run.")
+@click.option(
+    "--resume-results-path",
+    default=None,
+    help="Existing object-store results path for one Harbor evaluation; verifies the dataset before resuming.",
+)
 @click.option("--no-wait", is_flag=True, help="Submit and return without waiting for results.")
 @click.option("--dry-run", is_flag=True, help="Print the resolved plan without submitting.")
 @click.option(
@@ -106,6 +111,7 @@ def launch(
     limit: int | None,
     version: str | None,
     description: str | None,
+    resume_results_path: str | None,
     no_wait: bool,
     dry_run: bool,
     records_prefix: str | None,
@@ -140,6 +146,7 @@ def launch(
         cluster=cluster,
         version=version,
         description=description,
+        resume_results_path=resume_results_path,
     )
     try:
         batch = prepare_evaluation_batch(spec)

--- a/experiments/evaluation/launch.py
+++ b/experiments/evaluation/launch.py
@@ -22,7 +22,7 @@ from marin.evaluation.harbor.driver_config import (
     ValidatedHarborConfig,
     preflight_harbor_configs,
 )
-from marin.evaluation.harbor.runner import canonical_served_name
+from marin.evaluation.harbor.runner import HarborExecutor, canonical_served_name, validate_harbor_resume_root
 from marin.evaluation.hardware import AcceleratorChoice, Platform
 from marin.evaluation.model_config import ModelConfig
 from marin.evaluation.records import (
@@ -75,6 +75,7 @@ class LaunchSpec:
     cluster: str
     version: str | None = None
     description: str | None = None
+    resume_results_path: str | None = None
 
 
 def _git_sha() -> str:
@@ -197,6 +198,12 @@ def build_evaluation_batch(
     model = models()[spec.model]
     accelerator = MARIN_EVAL_HARDWARE.select(model, spec.platform, spec.accelerator)
     definitions = _preflight_definitions(_evaluation_definitions(spec), model, spec.limit)
+    if spec.resume_results_path is not None:
+        if len(definitions) != 1 or not isinstance(definitions[0][1].executor, HarborExecutor):
+            raise ValueError("--resume-results-path requires exactly one Harbor evaluation")
+        if "://" not in spec.resume_results_path:
+            raise ValueError("--resume-results-path must be an object-store path")
+        validate_harbor_resume_root(spec.resume_results_path, definitions[0][1].executor.config)
     records_prefix = records_prefix_for(accelerator, spec)
     created_at = datetime.now(UTC).isoformat()
     evaluations: list[Evaluation] = []
@@ -207,7 +214,7 @@ def build_evaluation_batch(
                 raise ValueError(f"evaluations declare conflicting secret specifications for {name}")
             secret_env[name] = spec_value
         run_id = _run_id(spec.model, eval_key)
-        output_dir = prefix_join(records_prefix, f"{run_id}/results")
+        output_dir = spec.resume_results_path or prefix_join(records_prefix, f"{run_id}/results")
         evaluations.append(
             Evaluation(
                 identity=EvaluationIdentity(

--- a/experiments/evaluation/launch.py
+++ b/experiments/evaluation/launch.py
@@ -40,7 +40,7 @@ from marin.evaluation.runner import (
     submit_evaluation_batch,
 )
 from rigging.config_discovery import resolve_cluster_config
-from rigging.filesystem import prefix_join
+from rigging.filesystem import StoragePath, prefix_join
 from rigging.secrets import SecretSpec
 
 from experiments.evaluation.evals import (
@@ -201,7 +201,7 @@ def build_evaluation_batch(
     if spec.resume_results_path is not None:
         if len(definitions) != 1 or not isinstance(definitions[0][1].executor, HarborExecutor):
             raise ValueError("--resume-results-path requires exactly one Harbor evaluation")
-        if "://" not in spec.resume_results_path:
+        if not StoragePath.parse(spec.resume_results_path).is_remote:
             raise ValueError("--resume-results-path must be an object-store path")
         validate_harbor_resume_root(spec.resume_results_path, definitions[0][1].executor.config)
     records_prefix = records_prefix_for(accelerator, spec)

--- a/lib/marin/src/marin/evaluation/harbor/runner.py
+++ b/lib/marin/src/marin/evaluation/harbor/runner.py
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 _HARBOR_WORKDIR = Path("/tmp/harbor_workdir")
 # Harbor writes its job tree under ``output_dir/harbor_jobs/<job_name>/<trial>/`` as trials finish.
 _HARBOR_JOBS_SUBDIR = "harbor_jobs"
+_HARBOR_RESULT_FILE = "harbor_result.json"
 _RESUME_IDENTITY_FILE = "harbor_resume_identity.json"
 _RESUME_IDENTITY_SCHEMA_VERSION = 1
 # Trials normalize off independent per-trial reads on the remote job tree; fan them out so a
@@ -53,6 +54,7 @@ _RESUME_IDENTITY_SCHEMA_VERSION = 1
 _TRIAL_READ_WORKERS = 16
 _JOB_DATASET_LENGTH = 32
 _JOB_DIGEST_LENGTH = 12
+_JOB_PREFIX = "harbor_"
 
 # The reward at or above which a Harbor trial counts as solved (rewards are typically 0.0 / 1.0; the
 # margin tolerates float noise).
@@ -106,12 +108,19 @@ def canonical_served_name(name: str) -> str:
     return candidate
 
 
+def _safe_job_dataset(dataset: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_-]", "_", dataset)
+
+
+def _job_dataset_prefix(dataset: str) -> str:
+    return f"{_JOB_PREFIX}{_safe_job_dataset(dataset)[:_JOB_DATASET_LENGTH]}_"
+
+
 def _job_name(dataset: str, identity: tuple[object, ...]) -> str:
     """A deterministic Harbor job name so a re-run resumes the previous job's completed trials."""
     key = "|".join(str(value) for value in identity)
     digest = hashlib.sha256(key.encode()).hexdigest()[:_JOB_DIGEST_LENGTH]
-    safe = re.sub(r"[^A-Za-z0-9_-]", "_", dataset)[:_JOB_DATASET_LENGTH]
-    return f"harbor_{safe}_{digest}"
+    return f"{_job_dataset_prefix(dataset)}{digest}"
 
 
 def _jobs_dir(output_dir: str) -> StoragePath:
@@ -131,6 +140,13 @@ def _resume_identity(config: ValidatedHarborConfig) -> dict[str, object]:
     }
 
 
+def _read_resume_json(path: StoragePath, output_dir: str) -> object:
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Harbor results root {output_dir!r} has an unreadable {path.name}") from exc
+
+
 def _raise_resume_identity_mismatch(
     output_dir: str,
     config: ValidatedHarborConfig,
@@ -148,22 +164,16 @@ def validate_harbor_resume_root(output_dir: str, config: ValidatedHarborConfig) 
     root = StoragePath.parse(output_dir)
     identity_path = root / _RESUME_IDENTITY_FILE
     if identity_path.exists():
-        try:
-            identity = json.loads(identity_path.read_text())
-        except json.JSONDecodeError as exc:
-            raise ValueError(f"Harbor results root {output_dir!r} has an unreadable {_RESUME_IDENTITY_FILE}") from exc
+        identity = _read_resume_json(identity_path, output_dir)
         expected = _resume_identity(config)
         if identity != expected:
             _raise_resume_identity_mismatch(output_dir, config, f"declares {identity!r}")
         return
 
-    result_path = root / "harbor_result.json"
+    result_path = root / _HARBOR_RESULT_FILE
     completed_dataset: object | None = None
     if result_path.exists():
-        try:
-            result = json.loads(result_path.read_text())
-        except json.JSONDecodeError as exc:
-            raise ValueError(f"Harbor results root {output_dir!r} has an unreadable harbor_result.json") from exc
+        result = _read_resume_json(result_path, output_dir)
         completed_dataset = result.get("dataset") if isinstance(result, Mapping) else None
         if completed_dataset != config.record_dataset:
             _raise_resume_identity_mismatch(
@@ -173,7 +183,7 @@ def validate_harbor_resume_root(output_dir: str, config: ValidatedHarborConfig) 
             )
 
     job_configs = tuple((_jobs_dir(output_dir) / "*/config.json").glob())
-    safe_dataset = re.sub(r"[^A-Za-z0-9_-]", "_", config.record_dataset)
+    safe_dataset = _safe_job_dataset(config.record_dataset)
     if len(safe_dataset) > _JOB_DATASET_LENGTH and completed_dataset is None:
         raise ValueError(
             f"Harbor results root {output_dir!r} predates exact dataset identity metadata, and dataset "
@@ -186,7 +196,7 @@ def validate_harbor_resume_root(output_dir: str, config: ValidatedHarborConfig) 
             f"Harbor results root {output_dir!r} has no dataset identity or resumable jobs. "
             "Choose the original results root, or omit --resume-results-path to start a clean run."
         )
-    expected_prefix = f"harbor_{safe_dataset[:_JOB_DATASET_LENGTH]}_"
+    expected_prefix = _job_dataset_prefix(config.record_dataset)
     incompatible = tuple(name for name in job_names if not name.startswith(expected_prefix))
     if incompatible:
         _raise_resume_identity_mismatch(output_dir, config, f"contains incompatible legacy jobs {incompatible!r}")
@@ -326,7 +336,7 @@ def _run_harbor_job(
     trials = _read_trials(job_dir)
     samples_path = _write_samples(trials, dataset, output_dir)
     result = _aggregate(trials, dataset, samples_path)
-    StoragePath(prefix_join(output_dir, "harbor_result.json")).write_text(
+    StoragePath(prefix_join(output_dir, _HARBOR_RESULT_FILE)).write_text(
         json.dumps(
             {
                 "dataset": result.dataset,

--- a/lib/marin/src/marin/evaluation/harbor/runner.py
+++ b/lib/marin/src/marin/evaluation/harbor/runner.py
@@ -46,6 +46,8 @@ logger = logging.getLogger(__name__)
 _HARBOR_WORKDIR = Path("/tmp/harbor_workdir")
 # Harbor writes its job tree under ``output_dir/harbor_jobs/<job_name>/<trial>/`` as trials finish.
 _HARBOR_JOBS_SUBDIR = "harbor_jobs"
+_RESUME_IDENTITY_FILE = "harbor_resume_identity.json"
+_RESUME_IDENTITY_SCHEMA_VERSION = 1
 # Trials normalize off independent per-trial reads on the remote job tree; fan them out so a
 # several-hundred-trial dataset is not a sequential round-trip per trial.
 _TRIAL_READ_WORKERS = 16
@@ -120,6 +122,87 @@ def _jobs_dir(output_dir: str) -> StoragePath:
 def _job_dir(output_dir: str, job_name: str) -> StoragePath:
     """The durable tree for one job: ``output_dir/harbor_jobs/<job_name>`` (Harbor appends the name)."""
     return _jobs_dir(output_dir) / job_name
+
+
+def _resume_identity(config: ValidatedHarborConfig) -> dict[str, object]:
+    return {
+        "schema_version": _RESUME_IDENTITY_SCHEMA_VERSION,
+        "dataset": config.record_dataset,
+    }
+
+
+def _raise_resume_identity_mismatch(
+    output_dir: str,
+    config: ValidatedHarborConfig,
+    existing: str,
+) -> None:
+    raise ValueError(
+        f"Harbor results root {output_dir!r} {existing}; this launch requires dataset "
+        f"{config.record_dataset!r}. Use the Harbor config that created this root, or omit "
+        "--resume-results-path to start a clean run."
+    )
+
+
+def validate_harbor_resume_root(output_dir: str, config: ValidatedHarborConfig) -> None:
+    """Verify that an existing results root belongs to the planned Harbor dataset."""
+    root = StoragePath.parse(output_dir)
+    identity_path = root / _RESUME_IDENTITY_FILE
+    if identity_path.exists():
+        try:
+            identity = json.loads(identity_path.read_text())
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Harbor results root {output_dir!r} has an unreadable {_RESUME_IDENTITY_FILE}") from exc
+        expected = _resume_identity(config)
+        if identity != expected:
+            _raise_resume_identity_mismatch(output_dir, config, f"declares {identity!r}")
+        return
+
+    result_path = root / "harbor_result.json"
+    completed_dataset: object | None = None
+    if result_path.exists():
+        try:
+            result = json.loads(result_path.read_text())
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Harbor results root {output_dir!r} has an unreadable harbor_result.json") from exc
+        completed_dataset = result.get("dataset") if isinstance(result, Mapping) else None
+        if completed_dataset != config.record_dataset:
+            _raise_resume_identity_mismatch(
+                output_dir,
+                config,
+                f"contains completed dataset {completed_dataset!r}",
+            )
+
+    job_configs = tuple((_jobs_dir(output_dir) / "*/config.json").glob())
+    safe_dataset = re.sub(r"[^A-Za-z0-9_-]", "_", config.record_dataset)
+    if len(safe_dataset) > _JOB_DATASET_LENGTH and completed_dataset is None:
+        raise ValueError(
+            f"Harbor results root {output_dir!r} predates exact dataset identity metadata, and dataset "
+            f"{config.record_dataset!r} is too long to verify from its legacy job names. This root cannot "
+            "be migrated automatically; omit --resume-results-path to start a clean run."
+        )
+    job_names = tuple(path.parent.name for path in job_configs)
+    if not job_names and completed_dataset is None:
+        raise ValueError(
+            f"Harbor results root {output_dir!r} has no dataset identity or resumable jobs. "
+            "Choose the original results root, or omit --resume-results-path to start a clean run."
+        )
+    expected_prefix = f"harbor_{safe_dataset[:_JOB_DATASET_LENGTH]}_"
+    incompatible = tuple(name for name in job_names if not name.startswith(expected_prefix))
+    if incompatible:
+        _raise_resume_identity_mismatch(output_dir, config, f"contains incompatible legacy jobs {incompatible!r}")
+
+
+def _bind_harbor_results_root(output_dir: str, config: ValidatedHarborConfig) -> None:
+    """Persist exact dataset identity, upgrading a compatible legacy root on first use."""
+    identity_path = StoragePath.parse(output_dir) / _RESUME_IDENTITY_FILE
+    if identity_path.exists():
+        validate_harbor_resume_root(output_dir, config)
+        return
+
+    root_entries = tuple((StoragePath.parse(output_dir) / "*").glob())
+    if root_entries:
+        validate_harbor_resume_root(output_dir, config)
+    identity_path.write_text(json.dumps(_resume_identity(config), indent=2))
 
 
 def _read_trial(result_file: StoragePath) -> HarborTrial:
@@ -303,6 +386,7 @@ class HarborExecutor:
         driver_env: Mapping[str, str],
         inference_session: RemoteInferenceSession,
     ) -> HarborRunResult:
+        _bind_harbor_results_root(output_dir, self.config)
         dataset = self.config.record_dataset
         job_name = _job_name(
             dataset,

--- a/lib/marin/src/marin/evaluation/harbor/runner.py
+++ b/lib/marin/src/marin/evaluation/harbor/runner.py
@@ -205,14 +205,11 @@ def validate_harbor_resume_root(output_dir: str, config: ValidatedHarborConfig) 
 def _bind_harbor_results_root(output_dir: str, config: ValidatedHarborConfig) -> None:
     """Persist exact dataset identity, upgrading a compatible legacy root on first use."""
     identity_path = StoragePath.parse(output_dir) / _RESUME_IDENTITY_FILE
-    if identity_path.exists():
-        validate_harbor_resume_root(output_dir, config)
-        return
-
     root_entries = tuple((StoragePath.parse(output_dir) / "*").glob())
     if root_entries:
         validate_harbor_resume_root(output_dir, config)
-    identity_path.write_text(json.dumps(_resume_identity(config), indent=2))
+    if not identity_path.exists():
+        identity_path.write_text(json.dumps(_resume_identity(config), indent=2))
 
 
 def _read_trial(result_file: StoragePath) -> HarborTrial:

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -447,3 +447,55 @@ def test_build_evaluation_batch_defaults_results_to_eval_root(monkeypatch):
     assert batch.records_prefix == "gs://marin-eval-metadata/evals"
     evaluation = batch.evaluations[0]
     assert evaluation.identity.output_dir == f"{batch.records_prefix}/{evaluation.identity.run_id}/results"
+
+
+def test_build_evaluation_batch_rejects_resume_root_for_another_harbor_dataset(tmp_path, monkeypatch):
+    _install_fake_harbor_preflight(monkeypatch)
+    config_path = _write_harbor_config(tmp_path / "aime-policy.yaml")
+    output_dir = f"memory://resume-{tmp_path.name}/previous-results"
+    previous_config = (
+        StoragePath(output_dir) / "harbor_jobs" / "harbor_terminus2-dev-set-v2_0123456789ab" / "config.json"
+    )
+    previous_config.write_text("{}")
+    monkeypatch.setattr("experiments.evaluation.launch._capability_origin", lambda _cluster: "https://iris.example")
+    spec = LaunchSpec(
+        model="qwen3-8b",
+        evals=(),
+        harbor_configs=(HarborConfigSelection(name="aime-policy", path=config_path),),
+        platform=Platform.TPU,
+        accelerator=None,
+        limit=1,
+        records_prefix="memory://records",
+        cluster="marin",
+        resume_results_path=output_dir,
+    )
+
+    with pytest.raises(ValueError, match="aime"):
+        build_evaluation_batch(spec, LaunchProvenance(git_sha="abc", launch_host="host"), "tester")
+
+    assert previous_config.read_text() == "{}"
+
+
+def test_build_evaluation_batch_resumes_matching_harbor_results_root(tmp_path, monkeypatch):
+    _install_fake_harbor_preflight(monkeypatch)
+    config_path = _write_harbor_config(tmp_path / "aime-policy.yaml")
+    output_dir = f"memory://resume-{tmp_path.name}/previous-results"
+    (StoragePath(output_dir) / "harbor_resume_identity.json").write_text(
+        json.dumps({"schema_version": 1, "dataset": "aime"})
+    )
+    monkeypatch.setattr("experiments.evaluation.launch._capability_origin", lambda _cluster: "https://iris.example")
+    spec = LaunchSpec(
+        model="qwen3-8b",
+        evals=(),
+        harbor_configs=(HarborConfigSelection(name="aime-policy", path=config_path),),
+        platform=Platform.TPU,
+        accelerator=None,
+        limit=1,
+        records_prefix="memory://records",
+        cluster="marin",
+        resume_results_path=output_dir,
+    )
+
+    batch = build_evaluation_batch(spec, LaunchProvenance(git_sha="abc", launch_host="host"), "tester")
+
+    assert batch.evaluations[0].identity.output_dir == output_dir

--- a/tests/evaluation/test_harbor_runner.py
+++ b/tests/evaluation/test_harbor_runner.py
@@ -485,3 +485,25 @@ def test_harbor_executor_accepts_zero_reward_without_exception_info(tmp_path, mo
     assert outcome.metrics[executor.config.record_dataset]["accuracy"] == 0.0
     result = json.loads((tmp_path / "harbor_result.json").read_text())
     assert result["failed_trials"] == 0
+
+
+def test_harbor_executor_upgrades_compatible_legacy_root_with_dataset_identity(tmp_path, monkeypatch):
+    def run_driver(_config, overlay, _driver_env, _backend_state) -> None:
+        trial_dir = Path(overlay.jobs_dir) / overlay.job_name / "trial-one"
+        trial_dir.mkdir(parents=True, exist_ok=True)
+        (trial_dir / "result.json").write_text(
+            json.dumps({"task_name": "trial-one", "verifier_result": {"rewards": {"reward": 1.0}}})
+        )
+
+    monkeypatch.setattr("marin.evaluation.harbor.runner.run_harbor_driver", run_driver)
+    executor = _harbor_executor("aime")
+    legacy_config = tmp_path / "harbor_jobs" / "harbor_aime_0123456789ab" / "config.json"
+    legacy_config.parent.mkdir(parents=True)
+    legacy_config.write_text("{}")
+
+    executor(_inference_session(), str(tmp_path), {})
+
+    assert json.loads((tmp_path / "harbor_resume_identity.json").read_text()) == {
+        "schema_version": 1,
+        "dataset": "aime",
+    }


### PR DESCRIPTION
Guard Harbor selective resumes against benchmark-root mismatches before opening Iris or submitting work. The launcher accepts one explicit Harbor results root only for a single Harbor evaluation, reads its durable dataset identity, and rejects mismatched, empty, ambiguous, or non-object-store roots without modifying them. The error directs operators to use the originating config or start a clean run.

New Harbor runs bind their results root to the dataset before materializing tasks or starting the driver. Compatible legacy roots are validated from completed-result metadata or deterministic Harbor job names and upgraded with an exact identity manifest. The root remains benchmark-bound rather than policy-hash-bound, so compatible policy, model, revision, and task-limit jobs can coexist without reviving the job-hash drift failure mode.

Regression coverage reproduces the r2 dev-set-versus-SWE-bench mismatch, proves the rejected root is unchanged, verifies a matching persisted identity is accepted, and verifies compatible legacy roots are upgraded. The affected evaluation tests pass, repository lint and Pyrefly pass, and the automated review reports no findings. The full local suite passed 1,351 tests with five skips and five expected failures; one unrelated Linux /proc process-group test is not portable to macOS and fails unchanged on main.

This advances the explicit-results-root portion of #7789.