### PR TITLE
[iris] Select the JAX coordinator port on global rank 0

### DIFF
--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -3,8 +3,8 @@
 
 """JAX distributed initialization via Iris endpoint registry.
 
-Task 0 registers its coordinator address; tasks 1..N-1 poll for it.
-Single-task jobs initialize an explicit one-process distributed world.
+Global process 0 registers its coordinator address; every other process polls
+for it. Single-task jobs initialize an explicit one-process distributed world.
 
 JAX is imported at call time — iris does not depend on jax.
 """
@@ -13,7 +13,6 @@ import atexit
 import logging
 import os
 import time
-from enum import StrEnum
 
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
@@ -22,7 +21,8 @@ from rigging.timing import Deadline, Duration, ExponentialBackoff
 
 from iris.actor.resolver import Resolver
 from iris.client.client import iris_ctx
-from iris.cluster.client.job_info import get_job_info
+from iris.cluster.client.job_info import JobInfo, get_job_info
+from iris.cluster.platforms.types import find_free_port
 from iris.cluster.runtime.env import SCRATCH_CACHE_PATH
 from iris.env_resources import TaskResources
 from iris.hooks.multigpu import (
@@ -50,7 +50,7 @@ _JAX_DIST_HEARTBEAT_TIMEOUT = 100
 _JAX_ENV_KEYS = (
     "IRIS_TASK_ID",
     "IRIS_NUM_TASKS",
-    "IRIS_PORT_jax",
+    "IRIS_PORT_JAX",
     IRIS_MULTIGPU_PROCESS_COUNT_ENV,
     IRIS_MULTIGPU_PROCESS_INDEX_ENV,
     IRIS_MULTIGPU_LOCAL_DEVICE_IDS_ENV,
@@ -59,7 +59,21 @@ _JAX_ENV_KEYS = (
 )
 
 
-def _log_jax_bootstrap_inputs(job_info, *, port: int, endpoint_name: str) -> None:
+def resolve_coordinator_port(job_info: JobInfo, explicit: int | None = None) -> int:
+    """Resolve the JAX coordinator port from Iris, the caller, or the kernel."""
+    allocated = job_info.ports.get("jax", 0)
+    if allocated:
+        logger.info("JAX coordinator port %d (assigned as IRIS_PORT_JAX)", allocated)
+        return allocated
+    if explicit is not None:
+        logger.info("JAX coordinator port %d (pinned by the caller)", explicit)
+        return explicit
+    port = find_free_port()
+    logger.info("JAX coordinator port %d (selected by the kernel)", port)
+    return port
+
+
+def _log_jax_bootstrap_inputs(job_info, *, port: int | None, endpoint_name: str) -> None:
     env_snapshot = {key: os.environ.get(key, "") for key in _JAX_ENV_KEYS if key in os.environ}
     if job_info is None:
         logger.info(
@@ -200,34 +214,20 @@ def _parse_local_device_ids(raw: str | None) -> list[int] | None:
     return [int(part) for part in raw.split(",") if part]
 
 
-class _CoordinatorRole(StrEnum):
-    """How a supervised rank obtains the JAX coordinator address."""
-
-    REGISTER = "register"  # global rank 0 on a multi-host job: bind + publish its address
-    POLL = "poll"  # a rank on another host: discover rank 0's address via the registry
-    REUSE_LOCAL = "reuse_local"  # rank 0 single-host, or a host-0 peer: use advertise_host directly
-
-
-def _supervised_coordinator_role(proc_index: int, task_index: int, num_tasks: int) -> _CoordinatorRole:
-    """Pick the coordinator-discovery role for a supervised rank.
-
-    Global rank 0 (``proc_index == 0``) owns the coordinator: it publishes its
-    address only when the job spans multiple hosts (otherwise no peer needs to
-    discover it). Other ranks on host 0 reuse that same advertise_host directly,
-    with no registry round-trip. Ranks on other hosts poll for rank 0's address.
-    """
-    if proc_index == 0:
-        return _CoordinatorRole.REGISTER if num_tasks > 1 else _CoordinatorRole.REUSE_LOCAL
-    if task_index == 0:
-        return _CoordinatorRole.REUSE_LOCAL
-    return _CoordinatorRole.POLL
+def _register_coordinator(job_info: JobInfo, port: int | None, endpoint_name: str) -> str:
+    """Choose and publish global process 0's coordinator address."""
+    coordinator = f"{job_info.advertise_host}:{resolve_coordinator_port(job_info, port)}"
+    ctx = iris_ctx()
+    endpoint_id = ctx.registry.register(endpoint_name, coordinator)
+    atexit.register(ctx.registry.unregister, endpoint_id)
+    return coordinator
 
 
 def _initialize_supervised_jax(
     jax,
     job_info,
     *,
-    port: int,
+    port: int | None,
     endpoint_name: str,
     poll_timeout: float,
     poll_interval: float,
@@ -254,20 +254,14 @@ def _initialize_supervised_jax(
         )
         return
 
-    num_tasks = job_info.num_tasks if job_info else 1
-    task_index = job_info.task_index if job_info else 0
-    advertise_host = job_info.advertise_host if job_info else "127.0.0.1"
-    bound_port = job_info.ports.get("jax", port) if job_info else port
-    coordinator = f"{advertise_host}:{bound_port}"
+    if job_info is None:
+        raise RuntimeError("multi-process JAX initialization requires an Iris job context")
 
-    role = _supervised_coordinator_role(proc_index, task_index, num_tasks)
-    if role is _CoordinatorRole.POLL:
+    if proc_index == 0:
+        coordinator = _register_coordinator(job_info, port, endpoint_name)
+    else:
         ctx = iris_ctx()
         coordinator = _poll_for_coordinator(ctx.resolver, endpoint_name, poll_timeout, poll_interval)
-    elif role is _CoordinatorRole.REGISTER:
-        ctx = iris_ctx()
-        endpoint_id = ctx.registry.register(endpoint_name, coordinator)
-        atexit.register(ctx.registry.unregister, endpoint_id)
 
     logger.info(
         "initialize_jax (supervised): process_id=%d/%d local_device_ids=%s coordinator=%s",
@@ -287,7 +281,7 @@ def _initialize_supervised_jax(
 
 
 def initialize_jax(
-    port: int = 8476,
+    port: int | None = None,
     endpoint_name: str = "jax_coordinator",
     poll_timeout: float = _JAX_DIST_INIT_TIMEOUT,
     poll_interval: float = 2.0,
@@ -295,9 +289,9 @@ def initialize_jax(
 ) -> None:
     """Initialize JAX distributed runtime using Iris endpoint discovery.
 
-    For multi-task GPU jobs, task 0 registers its coordinator address via the
-    Iris endpoint registry, and tasks 1..N-1 poll until they discover it. All
-    tasks then call jax.distributed.initialize with the coordinator address.
+    Global process 0 registers its coordinator address via the Iris endpoint
+    registry. Every other process polls until it discovers that address, whether
+    Iris runs one process per task or several processes per GPU task.
 
     Single-task Iris jobs initialize an explicit one-process distributed world.
     Processes outside an Iris job leave JAX distributed initialization unchanged.
@@ -306,9 +300,9 @@ def initialize_jax(
     multi-task jobs.
 
     Args:
-        port: Coordinator port. Overridden by IRIS_PORT_jax if allocated.
-            An explicit port is required because JAX's gRPC coordinator binds
-            internally and does not expose the actual bound port.
+        port: Coordinator port. ``None`` (the default) prefers an
+            ``IRIS_PORT_JAX`` named port and otherwise asks the kernel to select
+            an available port. Pass a port only to pin it.
         endpoint_name: Name under which the coordinator registers.
         poll_timeout: Maximum seconds for non-coordinator tasks to wait for the
             coordinator endpoint to register. Defaults to ``_JAX_DIST_INIT_TIMEOUT``
@@ -343,8 +337,7 @@ def initialize_jax(
     # Supervised (multi-process-per-task) mode short-circuits the task-derived
     # paths: the multigpu supervisor has already assigned this process its global
     # rank, so the single/multi-task branches below (which assume one process
-    # per task) do not apply. This runs even when job_info is None so a local
-    # supervisor smoke can bring up a localhost mesh.
+    # per task) do not apply.
     if IRIS_MULTIGPU_PROCESS_COUNT_ENV in os.environ:
         _initialize_supervised_jax(
             jax,
@@ -361,8 +354,7 @@ def initialize_jax(
         return
 
     if job_info.num_tasks <= 1:
-        bound_port = job_info.ports.get("jax", port)
-        coordinator = f"{job_info.advertise_host}:{bound_port}"
+        coordinator = f"{job_info.advertise_host}:{resolve_coordinator_port(job_info, port)}"
         jax.distributed.initialize(
             coordinator,
             num_processes=1,
@@ -370,21 +362,15 @@ def initialize_jax(
         )
         return
 
-    ctx = iris_ctx()
     task_index = job_info.task_index
 
     if task_index == 0:
-        bound_port = job_info.ports.get("jax", port)
-        coordinator = f"{job_info.advertise_host}:{bound_port}"
+        coordinator = _register_coordinator(job_info, port, endpoint_name)
         # Register the endpoint first so other tasks can discover the
         # coordinator address. jax.distributed.initialize() blocks until
         # all processes connect, so registering after would deadlock.
         # JAX's internal gRPC retry handles the brief window between
         # endpoint registration and the coordinator starting to listen.
-        endpoint_id = ctx.registry.register(endpoint_name, coordinator)
-        # Best-effort cleanup: if the process crashes, the controller's
-        # cascade delete on task cleanup handles endpoint removal.
-        atexit.register(ctx.registry.unregister, endpoint_id)
         jax.distributed.initialize(
             coordinator,
             job_info.num_tasks,
@@ -393,6 +379,7 @@ def initialize_jax(
             heartbeat_timeout_seconds=heartbeat_timeout,
         )
     else:
+        ctx = iris_ctx()
         coordinator = _poll_for_coordinator(ctx.resolver, endpoint_name, poll_timeout, poll_interval)
         jax.distributed.initialize(
             coordinator,

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -21,7 +21,7 @@ from iris.actor.resolver import ResolvedEndpoint, ResolveResult
 from iris.cluster.client.job_info import JobInfo
 from iris.cluster.types import JobName
 from iris.env_resources import _read_iris_resource_proto
-from iris.runtime.jax_init import configure_jax_compilation_cache, initialize_jax
+from iris.runtime.jax_init import configure_jax_compilation_cache, initialize_jax, resolve_coordinator_port
 
 EXPECTED_JAX_INITIALIZATION_TIMEOUT = 1800
 EXPECTED_JAX_HEARTBEAT_TIMEOUT = 100
@@ -136,10 +136,11 @@ def test_initialize_jax_single_task(
     """Single-task jobs call jax.distributed.initialize with explicit args."""
     mock_get_job_info.return_value = _make_job_info(task_index=0, num_tasks=1)
 
-    initialize_jax()
+    with patch("iris.runtime.jax_init.find_free_port", return_value=45678):
+        initialize_jax()
 
     mock_jax_init.assert_called_once_with(
-        "10.0.0.1:8476",
+        "10.0.0.1:45678",
         num_processes=1,
         process_id=0,
     )
@@ -157,13 +158,12 @@ def test_initialize_jax_tpu_multitask_uses_iris_registry(
     """TPU Iris jobs use the same explicit coordinator and rank wiring as other multi-task jobs."""
     monkeypatch.setenv("PJRT_DEVICE", "TPU")
     monkeypatch.setenv("JAX_PLATFORMS", "tpu,cpu")
-    mock_get_job_info.side_effect = [
-        _make_job_info(task_index=0, num_tasks=2),
-        _make_job_info(task_index=1, num_tasks=2),
-    ]
+    coordinator_info = _make_job_info(task_index=0, num_tasks=2)
+    coordinator_info.ports = {"jax": 12345}
+    mock_get_job_info.side_effect = [coordinator_info, _make_job_info(task_index=1, num_tasks=2)]
     found = ResolveResult(
         name="jax_coordinator",
-        endpoints=[ResolvedEndpoint(url="10.0.0.1:8476", actor_id="ep-1")],
+        endpoints=[ResolvedEndpoint(url="10.0.0.1:12345", actor_id="ep-1")],
     )
     fake_ctx = FakeContext(resolver=FakeResolver(results=[found]))
     mock_iris_ctx.return_value = fake_ctx
@@ -171,17 +171,17 @@ def test_initialize_jax_tpu_multitask_uses_iris_registry(
     initialize_jax()
     initialize_jax(poll_timeout=10.0, poll_interval=0.01)
 
-    assert fake_ctx.registry.registered == [("jax_coordinator", "10.0.0.1:8476")]
+    assert fake_ctx.registry.registered == [("jax_coordinator", "10.0.0.1:12345")]
     assert mock_jax_init.call_args_list == [
         call(
-            "10.0.0.1:8476",
+            "10.0.0.1:12345",
             2,
             0,
             initialization_timeout=EXPECTED_JAX_INITIALIZATION_TIMEOUT,
             heartbeat_timeout_seconds=EXPECTED_JAX_HEARTBEAT_TIMEOUT,
         ),
         call(
-            "10.0.0.1:8476",
+            "10.0.0.1:12345",
             2,
             1,
             initialization_timeout=EXPECTED_JAX_INITIALIZATION_TIMEOUT,
@@ -242,7 +242,7 @@ def test_initialize_jax_task0_uses_iris_port(
     mock_iris_ctx: MagicMock,
     mock_jax_init: MagicMock,
 ) -> None:
-    """Task 0 uses IRIS_PORT_jax when available, ignoring the port argument."""
+    """Task 0 uses IRIS_PORT_JAX when available, ignoring the port argument."""
     info = _make_job_info(task_index=0, num_tasks=2)
     info.ports = {"jax": 12345}
     mock_get_job_info.return_value = info
@@ -320,12 +320,18 @@ def test_initialize_jax_poll_timeout(
 @patch("iris.runtime.jax_init.get_job_info")
 def test_initialize_jax_supervised_single_host(
     mock_get_job_info: MagicMock,
-    _mock_iris_ctx: MagicMock,
+    mock_iris_ctx: MagicMock,
     mock_jax_init: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A supervised non-zero rank on a single host joins via advertise_host, no registry."""
+    """A local peer resolves the address published by global rank 0."""
     mock_get_job_info.return_value = _make_job_info(task_index=0, num_tasks=1)
+    found = ResolveResult(
+        name="jax_coordinator",
+        endpoints=[ResolvedEndpoint(url="10.0.0.1:12345", actor_id="ep-1")],
+    )
+    fake_ctx = FakeContext(resolver=FakeResolver(results=[found]))
+    mock_iris_ctx.return_value = fake_ctx
     monkeypatch.setenv("IRIS_MULTIGPU_PROCESS_COUNT", "8")
     monkeypatch.setenv("IRIS_MULTIGPU_PROCESS_INDEX", "3")
     monkeypatch.setenv("IRIS_MULTIGPU_LOCAL_DEVICE_IDS", "3")
@@ -333,13 +339,14 @@ def test_initialize_jax_supervised_single_host(
     initialize_jax()
 
     mock_jax_init.assert_called_once_with(
-        "10.0.0.1:8476",
+        "10.0.0.1:12345",
         8,
         3,
         local_device_ids=[3],
         initialization_timeout=EXPECTED_JAX_INITIALIZATION_TIMEOUT,
         heartbeat_timeout_seconds=EXPECTED_JAX_HEARTBEAT_TIMEOUT,
     )
+    assert fake_ctx.registry.registered == []
 
 
 @patch("jax.distributed.initialize")
@@ -352,7 +359,9 @@ def test_initialize_jax_supervised_global_rank0_registers(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Global rank 0 on a multi-host supervised job registers the coordinator."""
-    mock_get_job_info.return_value = _make_job_info(task_index=0, num_tasks=2)
+    info = _make_job_info(task_index=0, num_tasks=2)
+    info.ports = {"jax": 12345}
+    mock_get_job_info.return_value = info
     fake_ctx = FakeContext()
     mock_iris_ctx.return_value = fake_ctx
     monkeypatch.setenv("IRIS_MULTIGPU_PROCESS_COUNT", "16")
@@ -361,9 +370,41 @@ def test_initialize_jax_supervised_global_rank0_registers(
 
     initialize_jax()
 
-    assert fake_ctx.registry.registered == [("jax_coordinator", "10.0.0.1:8476")]
+    assert fake_ctx.registry.registered == [("jax_coordinator", "10.0.0.1:12345")]
     mock_jax_init.assert_called_once_with(
-        "10.0.0.1:8476",
+        "10.0.0.1:12345",
+        16,
+        0,
+        local_device_ids=[0],
+        initialization_timeout=EXPECTED_JAX_INITIALIZATION_TIMEOUT,
+        heartbeat_timeout_seconds=EXPECTED_JAX_HEARTBEAT_TIMEOUT,
+    )
+
+
+@patch("jax.distributed.initialize")
+@patch("iris.runtime.jax_init.iris_ctx")
+@patch("iris.runtime.jax_init.get_job_info")
+def test_initialize_jax_supervised_global_rank0_picks_port(
+    mock_get_job_info: MagicMock,
+    mock_iris_ctx: MagicMock,
+    mock_jax_init: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Global rank 0 chooses and publishes the port without supervisor help."""
+    mock_get_job_info.return_value = _make_job_info(task_index=0, num_tasks=2)
+    fake_ctx = FakeContext()
+    mock_iris_ctx.return_value = fake_ctx
+    monkeypatch.setenv("IRIS_MULTIGPU_PROCESS_COUNT", "16")
+    monkeypatch.setenv("IRIS_MULTIGPU_PROCESS_INDEX", "0")
+    monkeypatch.setenv("IRIS_MULTIGPU_LOCAL_DEVICE_IDS", "0")
+
+    with patch("iris.runtime.jax_init.find_free_port", return_value=45678):
+        initialize_jax()
+
+    coordinator = "10.0.0.1:45678"
+    assert fake_ctx.registry.registered == [("jax_coordinator", coordinator)]
+    mock_jax_init.assert_called_once_with(
+        coordinator,
         16,
         0,
         local_device_ids=[0],
@@ -404,6 +445,24 @@ def test_initialize_jax_supervised_other_host_polls(
         heartbeat_timeout_seconds=EXPECTED_JAX_HEARTBEAT_TIMEOUT,
     )
     assert fake_ctx.registry.registered == []
+
+
+@pytest.mark.parametrize("assigned", [{}, {"jax": 0}], ids=["unassigned", "k8s-placeholder"])
+def test_resolve_coordinator_port_uses_kernel_fallback(assigned: dict[str, int]) -> None:
+    info = _make_job_info()
+    info.ports = assigned
+
+    with patch("iris.runtime.jax_init.find_free_port", return_value=45678) as find_port:
+        assert resolve_coordinator_port(info) == 45678
+    find_port.assert_called_once_with()
+
+
+def test_resolve_coordinator_port_prefers_assigned_port() -> None:
+    info = _make_job_info()
+    info.ports = {"jax": 12345}
+
+    assert resolve_coordinator_port(info, 9999) == 12345
+    assert resolve_coordinator_port(_make_job_info(), 9999) == 9999
 
 
 @contextmanager


### PR DESCRIPTION
Let global JAX process 0 ask the kernel for an available coordinator port and publish the full address through Iris endpoint discovery. Every other process resolves that address, including per-GPU ranks colocated with rank 0. One-process-per-node and one-process-per-GPU jobs therefore use the same bootstrap path; the multigpu supervisor only assigns ranks and devices.

This removes fixed port 8476 reuse between overlapping retry generations, the failure mode behind the `different incarnation` aborts on `cw-us-east-08a`. Incident analysis: https://echo.oa.dev/wiki/96.

An assigned `IRIS_PORT_JAX` or explicit `initialize_jax(port=...)` remains supported. Otherwise, rank 0 selects the port immediately before registering the address; JAX's connection retry covers the handoff from the kernel probe to the coordinator bind.

Part of #7650
