### PR TITLE
[infra] Cache Cloud Run image builds

### DIFF
--- a/.github/workflows/ops-grafana.yaml
+++ b/.github/workflows/ops-grafana.yaml
@@ -40,7 +40,7 @@ jobs:
     needs: test
     if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
     permissions:
       contents: read
       id-token: write

--- a/infra/pulumi/src/iac/gcp/cloud_run.py
+++ b/infra/pulumi/src/iac/gcp/cloud_run.py
@@ -30,6 +30,8 @@ IAP_SERVICE_AGENT = "serviceAccount:service-{project_number}@gcp-sa-iap.iam.gser
 OPENATHENA_IAP_MEMBER = "domain:openathena.ai"
 LOOM_VM_IAP_MEMBER = "serviceAccount:loom-vm@hai-gcp-models.iam.gserviceaccount.com"
 MARIN_INTERNAL_IAP_MEMBERS = (OPENATHENA_IAP_MEMBER, LOOM_VM_IAP_MEMBER)
+BUILD_CACHE_TAG = "buildcache"
+BUILD_CACHE_COMPRESSION_LEVEL = 3
 
 
 @dataclass(frozen=True)
@@ -235,10 +237,32 @@ def dockerfile_image(
     image_tag = repo.repository_id.apply(
         lambda repo_id: f"{region}-docker.pkg.dev/{project}/{repo_id}/{image_name}:latest"
     )
+    cache_ref = repo.repository_id.apply(
+        lambda repo_id: f"{region}-docker.pkg.dev/{project}/{repo_id}/{image_name}:{BUILD_CACHE_TAG}"
+    )
     return docker_build.Image(
         "image",
         context=docker_build.BuildContextArgs(location=build_context),
         dockerfile=docker_build.DockerfileArgs(location=f"{build_context}/{dockerfile}"),
+        # GitHub-hosted runners have no durable local BuildKit state. Export the full
+        # cache beside the image so later CI and local builds can reuse every stage.
+        cache_from=[
+            docker_build.CacheFromArgs(
+                registry=docker_build.CacheFromRegistryArgs(ref=cache_ref),
+            )
+        ],
+        cache_to=[
+            docker_build.CacheToArgs(
+                registry=docker_build.CacheToRegistryArgs(
+                    ref=cache_ref,
+                    mode=docker_build.CacheMode.MAX,
+                    compression=docker_build.CompressionType.ZSTD,
+                    compression_level=BUILD_CACHE_COMPRESSION_LEVEL,
+                    oci_media_types=True,
+                    image_manifest=True,
+                ),
+            )
+        ],
         # Cloud Run is linux/amd64; pin it so a build from an arm64 workstation still
         # produces a runnable image.
         platforms=[docker_build.Platform.LINUX_AMD64],

--- a/infra/pulumi/tests/test_cloud_run.py
+++ b/infra/pulumi/tests/test_cloud_run.py
@@ -1,0 +1,56 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pulumi
+import pulumi_gcp as gcp
+from iac.gcp.cloud_run import dockerfile_image
+from pulumi.runtime import MockCallArgs, MockResourceArgs, Mocks
+
+
+class RecordingMocks(Mocks):
+    def __init__(self) -> None:
+        self.resources: list[MockResourceArgs] = []
+
+    def new_resource(self, args: MockResourceArgs):
+        self.resources.append(args)
+        outputs = dict(args.inputs)
+        if args.typ == "docker-build:index:Image":
+            outputs["digest"] = "sha256:" + "a" * 64
+            outputs["ref"] = f"{outputs['tags'][0]}@sha256:" + "a" * 64
+        return f"{args.name}_id", outputs
+
+    def call(self, args: MockCallArgs) -> tuple[dict, list[tuple[str, str]] | None]:
+        return dict(args.args), []
+
+
+@pulumi.runtime.test
+def test_dockerfile_image_uses_dedicated_registry_cache() -> pulumi.Output[None]:
+    mocks = RecordingMocks()
+    pulumi.runtime.set_mocks(mocks, project="marin-iac", stack="test", preview=False)
+    provider = gcp.Provider("gcp", project="example")
+    parent = pulumi.ComponentResource("test:index:Parent", "parent")
+    image = dockerfile_image(
+        image_name="service",
+        description="Service images",
+        project="example",
+        region="us-central1",
+        build_context="/tmp/service",
+        dockerfile="Dockerfile",
+        parent=parent,
+        gcp_provider=provider,
+    )
+
+    def check(_: str) -> None:
+        resource = next(resource for resource in mocks.resources if resource.typ == "docker-build:index:Image")
+        cache_ref = "us-central1-docker.pkg.dev/example/service/service:buildcache"
+        assert resource.inputs["cacheFrom"] == [{"registry": {"ref": cache_ref}}]
+        (cache_to,) = resource.inputs["cacheTo"]
+        registry = cache_to["registry"]
+        assert registry["ref"] == cache_ref
+        assert registry["mode"] == "max"
+        assert registry["compression"] == "zstd"
+        assert registry["compressionLevel"] == 3
+        assert registry["ociMediaTypes"] is True
+        assert registry["imageManifest"] is True
+
+    return image.ref.apply(check)


### PR DESCRIPTION
Persist full BuildKit caches beside Cloud Run service images in Artifact Registry so GitHub-hosted deployments reuse layers across runners. Cache references are scoped per service and use the registry exporter with max mode and zstd compression.

Give the Grafana deployment one hour to complete. A cold build in [run 30932665193](https://github.com/marin-community/marin/actions/runs/30932665193) hit the previous 20-minute limit while Pulumi held the GCS backend lock. Runner termination left the lock behind and blocked the next deployment.
