### PR TITLE
[finelog] Bound analytic query load

### DIFF
--- a/docs/ops/training-stall-alert-contract.md
+++ b/docs/ops/training-stall-alert-contract.md
@@ -2,7 +2,7 @@
 
 `TrainingProgressStalled` is a passive, warning-only Grafana rule. It does not kick, restart, or profile a job. Capture `iris process profile threads -t <task>` for the affected tasks before deciding whether to intervene.
 
-The rule evaluates once a minute and waits five minutes before notifying. A root job is eligible only while its latest `iris.task_state` row is at most 90 seconds old, reports at least one running task, and has a retained `phase` row from `service=levanter`. This enrollment gate prevents long-running Zephyr, inference, and generic Iris jobs from being classified as training without expiring a still-running Levanter job after 24 hours. An eligible job warns when either condition holds:
+The rule evaluates once a minute and waits five minutes before notifying. A root job is eligible only while its latest `iris.task_state` row is at most 90 seconds old, reports at least one running task, and has a `phase` row from `service=levanter` in the trailing 15 minutes. Levanter republishes phase every minute, so this enrollment gate excludes long-running Zephyr, inference, and generic Iris jobs without expiring a live Levanter job. An eligible job warns when either condition holds:
 
 - Training has started and `progress_time_seconds` is at least 15 minutes old. An explicit training phase or a positive `step` identifies training.
 - The job has remained running for at least 45 minutes without entering training. Missing progress after Levanter enrollment counts as absent progress rather than suppressing the warning.
@@ -11,7 +11,7 @@ The first case is labeled `optimizer_progress_stale` or `optimizer_progress_miss
 
 A job that emits `step` but no `phase` runs a producer older than both phase and progress, and reports a zero-valued `producer_missing` row instead of a warning. Enrollment keys on phase because `TelemetryTracker` publishes it as it is constructed, which marks the producer generation exactly.
 
-The bridge joins the durable streams by `(cluster, root job ID)`: `iris.task_state.root_job_id` equals `json_get(telemetry_v1.resource_attributes_json, 'job_id')`, and Finelog stamps both with their origin `cluster`. The task-state query scans the trailing hour. Progress rows scan the trailing 24 hours, while the sparse phase enrollment branch selects the latest retained phase without a lower time bound. An older running job still has an inferred running age of at least one hour, which is sufficient for both thresholds. No task-to-node mapping or GPU-utilization condition is required.
+The bridge joins the durable streams by `(cluster, root job ID)`: `iris.task_state.root_job_id` equals `json_get(telemetry_v1.resource_attributes_json, 'job_id')`, and Finelog stamps both with their origin `cluster`. The task-state query scans the trailing hour. One telemetry scan reads phase from the trailing 15 minutes and progress from the trailing 30 minutes; the extra progress window keeps a metric observable after it crosses the 15-minute stale threshold. An older running job still has an inferred running age of at least one hour, which is sufficient for both thresholds. No task-to-node mapping or GPU-utilization condition is required.
 
 The required `service=levanter` telemetry records are `step`, `progress_time_seconds`, and numeric `phase` (`initializing=0`, `training=1`, `finished=2`). `TelemetryTracker` initializes phase and progress, records wall time after its completed-step `train/loss` callback, and marks a finished run.
 

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -461,6 +461,11 @@ groups:
         title: TrainingProgressStalled
         condition: C
         for: 5m
+        # Even the bounded metric-family scan exceeds Finelog's 10s production
+        # deadline. Keep the rule visible but inactive until telemetry has a
+        # filtered projection; failed evaluations otherwise consume one core
+        # for ten seconds every minute.
+        isPaused: true
         noDataState: Alerting
         execErrState: Alerting
         labels:

--- a/infra/grafana/src/cache.py
+++ b/infra/grafana/src/cache.py
@@ -3,10 +3,11 @@
 
 """A TTL cache that coalesces concurrent misses on one key into a single call.
 
-N callers that miss the same key at once run compute once and share the result.
-Entries are pruned on write.
+N callers that miss the same key at once run compute once and share its result
+or failure. Entries are pruned on write.
 """
 
+import copy
 import threading
 import time
 from collections.abc import Callable, Hashable
@@ -22,16 +23,24 @@ class _Entry(Generic[V]):
     expires_at: float
 
 
+@dataclass
+class _Failure:
+    error: Exception
+    expires_at: float
+
+
 class TtlCache(Generic[V]):
-    """Cache values under a key for ttl seconds, coalescing concurrent misses.
+    """Cache outcomes under a key for ttl seconds, coalescing concurrent misses.
 
     A miss holds a per-key lock while it computes; concurrent callers for the same
-    key wait and read the fresh value. Different keys do not block one another.
+    key wait and read the fresh outcome. Failures are cached too, so an upstream
+    timeout does not turn client retries into repeated work. Different keys do
+    not block one another.
     """
 
     def __init__(self, ttl: float) -> None:
         self._ttl = ttl
-        self._entries: dict[Hashable, _Entry[V]] = {}
+        self._entries: dict[Hashable, _Entry[V] | _Failure] = {}
         self._key_locks: dict[Hashable, threading.Lock] = {}
         self._guard = threading.Lock()
 
@@ -39,18 +48,18 @@ class TtlCache(Generic[V]):
         with self._guard:
             return self._key_locks.setdefault(key, threading.Lock())
 
-    def _live(self, key: Hashable) -> _Entry[V] | None:
+    def _live(self, key: Hashable) -> _Entry[V] | _Failure | None:
         with self._guard:
             entry = self._entries.get(key)
         if entry is not None and entry.expires_at > time.monotonic():
             return entry
         return None
 
-    def _store(self, key: Hashable, value: V) -> None:
-        """Cache ``value`` under ``key`` for the TTL, dropping every expired entry."""
+    def _store(self, key: Hashable, entry: _Entry[V] | _Failure) -> None:
+        """Cache ``entry`` under ``key``, dropping every expired entry."""
         now = time.monotonic()
         with self._guard:
-            self._entries[key] = _Entry(value=value, expires_at=now + self._ttl)
+            self._entries[key] = entry
             expired = [k for k, e in self._entries.items() if e.expires_at <= now]
             for k in expired:
                 del self._entries[k]
@@ -60,19 +69,29 @@ class TtlCache(Generic[V]):
                 # deadlock.
                 self._key_locks.pop(k, None)
 
+    @staticmethod
+    def _resolve(entry: _Entry[V] | _Failure) -> V:
+        if isinstance(entry, _Failure):
+            raise copy.copy(entry.error).with_traceback(None) from None
+        return entry.value
+
     def get_or_compute(self, key: Hashable, compute: Callable[[], V]) -> V:
-        """Return the cached value for ``key``, computing it if absent or stale."""
+        """Return the cached outcome for ``key``, computing it if absent or stale."""
         entry = self._live(key)
         if entry is not None:
-            return entry.value
+            return self._resolve(entry)
 
         with self._lock_for(key):
-            # Another caller may have populated it while we waited for the lock.
+            # Another caller may have populated an outcome while we waited.
             entry = self._live(key)
             if entry is not None:
-                return entry.value
-            value = compute()
-            self._store(key, value)
+                return self._resolve(entry)
+            try:
+                value = compute()
+            except Exception as error:
+                self._store(key, _Failure(error=error, expires_at=time.monotonic() + self._ttl))
+                raise
+            self._store(key, _Entry(value=value, expires_at=time.monotonic() + self._ttl))
             return value
 
     def __len__(self) -> int:

--- a/infra/grafana/src/training_stalls.py
+++ b/infra/grafana/src/training_stalls.py
@@ -11,7 +11,7 @@ _TASK_STATE_FRESHNESS = timedelta(seconds=90)
 _TRAINING_STALL_AGE = timedelta(minutes=15)
 _INITIALIZING_STALL_AGE = timedelta(minutes=45)
 _TASK_STATE_LOOKBACK = timedelta(hours=1)
-_TELEMETRY_LOOKBACK = timedelta(days=1)
+_PROGRESS_LOOKBACK = 2 * _TRAINING_STALL_AGE
 # Levanter republishes `phase` every 60s, so enrollment is always recent and this
 # scan can be bounded. Unbounded, it read every telemetry_v1 row once a minute and
 # saturated the finelog hub. Keep this many multiples above that heartbeat:
@@ -55,29 +55,21 @@ def task_state_query(now: datetime) -> str:
 
 def telemetry_query(now: datetime) -> str:
     """Return latest retained enrollment and bounded progress per root job."""
-    start = _sql_timestamp(now - _TELEMETRY_LOOKBACK)
+    progress_since = _sql_timestamp(now - _PROGRESS_LOOKBACK)
     enrolled_since = _sql_timestamp(now - _ENROLLMENT_LOOKBACK)
     end = _sql_timestamp(now)
-    progress_names = f"'{_STEP_METRIC}', '{_PROGRESS_TIME_METRIC}'"
+    metric_names = f"'{_PHASE_METRIC}', '{_STEP_METRIC}', '{_PROGRESS_TIME_METRIC}'"
     return (
-        "WITH phase_enrollment AS ("
+        "WITH filtered AS ("
         "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS origin_cluster, "
         "json_get(resource_attributes_json, 'job_id') AS job, name, value, "
         "timestamp_ms, seq, to_timestamp_millis(timestamp_ms) AS ts "
         'FROM "telemetry_v1" '
-        f"WHERE service = 'levanter' AND name = '{_PHASE_METRIC}' "
-        f"AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '{enrolled_since}') * 1000 AS BIGINT) "
-        f"AND timestamp_ms < CAST(EXTRACT(EPOCH FROM TIMESTAMP '{end}') * 1000 AS BIGINT)"
-        "), recent_progress AS ("
-        "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS origin_cluster, "
-        "json_get(resource_attributes_json, 'job_id') AS job, name, value, "
-        "timestamp_ms, seq, to_timestamp_millis(timestamp_ms) AS ts "
-        'FROM "telemetry_v1" '
-        f"WHERE service = 'levanter' AND name IN ({progress_names}) "
-        f"AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '{start}') * 1000 AS BIGINT) "
-        f"AND timestamp_ms < CAST(EXTRACT(EPOCH FROM TIMESTAMP '{end}') * 1000 AS BIGINT)"
-        "), filtered AS ("
-        "SELECT * FROM phase_enrollment UNION ALL SELECT * FROM recent_progress"
+        f"WHERE service = 'levanter' AND name IN ({metric_names}) "
+        f"AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '{progress_since}') * 1000 AS BIGINT) "
+        f"AND timestamp_ms < CAST(EXTRACT(EPOCH FROM TIMESTAMP '{end}') * 1000 AS BIGINT) "
+        f"AND (name <> '{_PHASE_METRIC}' OR timestamp_ms >= "
+        f"CAST(EXTRACT(EPOCH FROM TIMESTAMP '{enrolled_since}') * 1000 AS BIGINT))"
         "), recent AS ("
         "SELECT origin_cluster, job, name, value, ts, "
         "ROW_NUMBER() OVER ("

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -8,6 +8,7 @@ import threading
 from datetime import UTC, datetime, timedelta
 
 import pyarrow as pa
+import pytest
 from cache import TtlCache
 from config import ClusterTarget
 from conftest import FINELOG_DEPLOYMENTS_PATH, bridge_config, deployment, healthy_k8s_routes, k8s_api, make_k8s_source
@@ -377,21 +378,22 @@ def test_alert_queries_use_int64_epoch_boundaries_and_project_timestamps():
         assert "timestamp_ms >= TIMESTAMP" not in sql
 
 
-def test_training_stall_query_bounds_enrollment_to_the_phase_heartbeat_window():
-    """Unbounded, this CTE scanned every telemetry_v1 row once a minute.
+def test_training_stall_query_bounds_each_metric_family_to_its_detection_window():
+    """Wide scans read telemetry_v1 once a minute and can saturate Finelog.
 
     Levanter republishes `phase` every 60s, so a live job always has an
-    enrollment row inside this window and the scan can prune by time.
+    enrollment row inside the stall window. Progress needs one extra stall
+    window so a metric that just became stale remains observable.
     """
     sql = telemetry_query(datetime(2026, 7, 28, 12, tzinfo=UTC))
-    phase_enrollment, recent_progress = sql.split("), recent_progress AS (")
 
-    assert "name = 'phase'" in phase_enrollment
+    assert sql.count('FROM "telemetry_v1"') == 1
+    assert "name IN ('phase', 'step', 'progress_time_seconds')" in sql
+    assert "timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '2026-07-28 11:30:00') * 1000 AS BIGINT)" in sql
     assert (
-        "timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '2026-07-28 11:45:00') * 1000 AS BIGINT)" in phase_enrollment
+        "name <> 'phase' OR timestamp_ms >= "
+        "CAST(EXTRACT(EPOCH FROM TIMESTAMP '2026-07-28 11:45:00') * 1000 AS BIGINT)" in sql
     )
-    assert "name IN ('step', 'progress_time_seconds')" in recent_progress
-    assert "timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '2026-07-27 12:00:00') * 1000 AS BIGINT)" in sql
 
 
 class FakeLoomAlerts(LoomAlertClient):
@@ -509,6 +511,21 @@ def test_cache_coalesces_concurrent_misses_on_one_key():
 
     assert len(calls) == 1
     assert results == [7, 7, 7, 7]
+
+
+def test_cache_reuses_compute_failures_until_the_ttl_expires():
+    cache: TtlCache[int] = TtlCache(ttl=60.0)
+    calls: list[int] = []
+
+    def compute() -> int:
+        calls.append(1)
+        raise ValueError("upstream timed out")
+
+    for _ in range(3):
+        with pytest.raises(ValueError, match="upstream timed out"):
+            cache.get_or_compute("k", compute)
+
+    assert calls == [1]
 
 
 def test_cache_prunes_expired_entries_on_write():

--- a/lib/finelog/OPS.md
+++ b/lib/finelog/OPS.md
@@ -86,7 +86,7 @@ carries its version in the fifth byte, so counting versions across a namespace's
 on `timestamp_ms` and a 10-minute window answers in about a second where the same
 query unbounded takes 30.
 
-`finelog query` applies a client deadline just past the server's own 60s one.
+`finelog query` applies a client deadline just past the server's own 10s one.
 Raise both with `--timeout` and `FINELOG_QUERY_TIMEOUT_MS` if a query genuinely
 needs longer.
 

--- a/lib/finelog/rust/src/query/mod.rs
+++ b/lib/finelog/rust/src/query/mod.rs
@@ -301,7 +301,7 @@ fn slow_query_log_ms() -> u128 {
 /// pathological query can no longer run unbounded and crash-loop the hub on
 /// memory. This bounds the SERVER independently of any client deadline, which
 /// a caller may set huge or omit entirely.
-const DEFAULT_QUERY_TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_QUERY_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Parse the `FINELOG_QUERY_TIMEOUT_MS` override: an integer millisecond budget,
 /// `0` to disable the deadline entirely (ops escape hatch for a known-heavy
@@ -317,13 +317,28 @@ fn parse_query_timeout(raw: Option<&str>) -> Option<Duration> {
     }
 }
 
-/// The server-side Query deadline, resolved once from `FINELOG_QUERY_TIMEOUT_MS`
-/// (see [`parse_query_timeout`]). `None` disables it.
-pub(crate) fn query_timeout() -> Option<Duration> {
+fn earliest_timeout(
+    server_timeout: Option<Duration>,
+    request_timeout: Option<Duration>,
+) -> Option<Duration> {
+    match (server_timeout, request_timeout) {
+        (Some(server), Some(request)) => Some(server.min(request)),
+        (Some(timeout), None) | (None, Some(timeout)) => Some(timeout),
+        (None, None) => None,
+    }
+}
+
+/// The earlier of the server Query deadline and the caller's remaining budget.
+///
+/// `FINELOG_QUERY_TIMEOUT_MS` configures the server deadline (see
+/// [`parse_query_timeout`]); `0` disables only that ceiling, so a caller's
+/// shorter deadline still cancels its scan.
+pub(crate) fn query_timeout(request_timeout: Option<Duration>) -> Option<Duration> {
     static TIMEOUT: OnceLock<Option<Duration>> = OnceLock::new();
-    *TIMEOUT.get_or_init(|| {
+    let server_timeout = *TIMEOUT.get_or_init(|| {
         parse_query_timeout(std::env::var("FINELOG_QUERY_TIMEOUT_MS").ok().as_deref())
-    })
+    });
+    earliest_timeout(server_timeout, request_timeout)
 }
 
 /// Cap arbitrary (possibly user-supplied) SQL for a single log line. Truncates on
@@ -559,7 +574,11 @@ mod tests {
     #[test]
     fn parse_query_timeout_variants() {
         // Absent, unparseable, and negative-ish garbage all fall back to the default.
-        assert_eq!(parse_query_timeout(None), Some(DEFAULT_QUERY_TIMEOUT));
+        assert_eq!(
+            parse_query_timeout(None),
+            Some(Duration::from_secs(10)),
+            "the default must shed work before dashboard clients retry"
+        );
         assert_eq!(
             parse_query_timeout(Some("nonsense")),
             Some(DEFAULT_QUERY_TIMEOUT)
@@ -576,6 +595,23 @@ mod tests {
         );
         // Zero is the explicit disable escape hatch.
         assert_eq!(parse_query_timeout(Some("0")), None);
+    }
+
+    #[test]
+    fn query_timeout_uses_the_earliest_available_deadline() {
+        let server = Some(Duration::from_secs(10));
+        let short_request = Some(Duration::from_secs(3));
+        let long_request = Some(Duration::from_secs(30));
+
+        assert_eq!(
+            earliest_timeout(server, short_request),
+            short_request,
+            "a caller deadline must stop work before the server ceiling"
+        );
+        assert_eq!(earliest_timeout(server, long_request), server);
+        assert_eq!(earliest_timeout(None, short_request), short_request);
+        assert_eq!(earliest_timeout(server, None), server);
+        assert_eq!(earliest_timeout(None, None), None);
     }
 
     #[tokio::test]

--- a/lib/finelog/rust/src/server/interceptors.rs
+++ b/lib/finelog/rust/src/server/interceptors.rs
@@ -14,7 +14,7 @@
 //!   set). Re-checks the deadline AFTER acquiring (the post-acquire shed): if
 //!   the client deadline has elapsed while queued, short-circuit with
 //!   `deadline_exceeded` rather than run a doomed handler. The caps are
-//!   `{FetchLogs: 4}` and `{Query: 4}`, both living in one interceptor keyed by
+//!   `{FetchLogs: 4}` and `{Query: 2}`, both living in one interceptor keyed by
 //!   method. Registered AFTER SlowRpc.
 //!
 //! Both read the dispatched method's short name from `ctx.spec().method()`. The
@@ -42,7 +42,7 @@ pub const DEFAULT_SLOW_RPC_THRESHOLD_MS: i64 = 7000;
 /// scans across hundreds of MB; unbounded parallelism evicts the page cache and
 /// wedges the process.
 pub const MAX_CONCURRENT_FETCH_LOGS: usize = 4;
-pub const MAX_CONCURRENT_QUERY: usize = 4;
+pub const MAX_CONCURRENT_QUERY: usize = 2;
 
 /// The dispatched method's short name (`"FetchLogs"`, `"Query"`, ...), or `None`
 /// when the spec is absent (manual `route_*` registration without `with_spec`).

--- a/lib/finelog/rust/src/server/stats_service.rs
+++ b/lib/finelog/rust/src/server/stats_service.rs
@@ -165,7 +165,7 @@ impl StatsService for StatsServiceImpl {
 
     async fn query(
         &self,
-        _ctx: RequestContext,
+        ctx: RequestContext,
         request: OwnedQueryRequestView,
     ) -> ServiceResult<QueryResponse> {
         let sql = request.sql.unwrap_or("").to_string();
@@ -185,22 +185,22 @@ impl StatsService for StatsServiceImpl {
         // (no spawn_blocking). Errors map by variant: parse/plan/schema/catalog
         // faults are client errors, IO/execution faults are server errors.
         //
-        // Bound execution by the server-side wall-clock deadline: on elapse the
-        // query future is dropped (aborting the scan) and the caller gets a
-        // clean deadline_exceeded, so one pathological query can't run unbounded.
-        let ctx = make_ctx();
-        let query = run_query_over(&ctx, providers, &sql);
-        let result = match query_timeout() {
+        // Bound execution by the earlier of the server ceiling and the caller's
+        // remaining budget. On elapse the query future is dropped (aborting the
+        // scan), so a timed-out caller cannot leave CPU work behind.
+        let query_ctx = make_ctx();
+        let query = run_query_over(&query_ctx, providers, &sql);
+        let result = match query_timeout(ctx.time_remaining()) {
             Some(deadline) => match tokio::time::timeout(deadline, query).await {
                 Ok(r) => r.map_err(map_query_error)?,
                 Err(_elapsed) => {
                     tracing::warn!(
                         deadline_ms = deadline.as_millis() as u64,
                         sql = %truncate_sql_for_log(&sql),
-                        "query aborted: exceeded server-side deadline",
+                        "query aborted: exceeded deadline",
                     );
                     return Err(ConnectError::deadline_exceeded(format!(
-                        "query exceeded server-side deadline of {} ms",
+                        "query exceeded deadline of {} ms",
                         deadline.as_millis()
                     )));
                 }

--- a/lib/finelog/src/finelog/deploy/cli.py
+++ b/lib/finelog/src/finelog/deploy/cli.py
@@ -39,11 +39,10 @@ from finelog.deploy.config import FinelogConfig, load_finelog_config, tunnel_tar
 
 _SEGMENT_FILENAME_RE = re.compile(r"seg_L\d+_\d+\.parquet$")
 
-# Sits just past the server's own 60s query deadline so a long query is ended by
+# Sits just past the server's own 10s query deadline so a long query is ended by
 # the server, which reports why, rather than by a client-side timeout that
-# reports only that time ran out. The client default is 10s, which is shorter
-# than several real queries against a full namespace.
-DEFAULT_REQUEST_TIMEOUT = 65.0
+# reports only that time ran out.
+DEFAULT_REQUEST_TIMEOUT = 15.0
 
 
 @contextmanager
@@ -297,7 +296,7 @@ _PRINTERS = {
     type=float,
     default=DEFAULT_REQUEST_TIMEOUT,
     show_default=True,
-    help="Seconds to wait for the query result. The server applies its own 60s deadline.",
+    help="Seconds to wait for the query result. The server applies its own 10s deadline.",
 )
 def query_cmd(
     name: str,


### PR DESCRIPTION
Bound analytic SQL to the earlier of the caller deadline and a 10-second
server ceiling, and admit at most two concurrent Query RPCs. Queries hold the
visibility read lock while scanning, so an overrun also delays compaction
publishing. Nine production level bumps with no decoded Arrow data all
overlapped slow RPCs and reported a 20.986-second median despite requiring only
a rename.

Reduce the training-stall telemetry query from two scans, including a one-day
window, to one 30-minute scan. Cache failed Grafana bridge computations for the
normal 20-second TTL so client retries do not duplicate timed-out work. On four
copied production segments containing 29.2 million rows, the alert query
improved from 8.77 to 4.03 seconds with identical results. Four concurrent
scans delivered only 5% more throughput than two while median latency rose from
6.28 to 12.0 seconds. The bounded alert scan still reaches the 10-second
production ceiling, so the warning-only rule remains provisioned but paused
until a filtered projection is available.

A broad count grouped by service completes in 62 milliseconds on the copied
segments, but the full production retention exceeded the 10-second ceiling on
both cold and warm scans. Common metric names occur in nearly every trigram
span, so filtered metric-family projections and per-segment low-cardinality
summaries are the useful physical optimizations. A local filtered-projection
prototype ran the alert query in 403 milliseconds. The investigation and
operational timeline are recorded in
[Echo incident 90](https://echo.oa.dev/wiki/90).
