### PR TITLE
[datakit] bound embed memory by document and by read chunk

### DIFF
--- a/experiments/datakit/embeddings/luxical/pipeline.py
+++ b/experiments/datakit/embeddings/luxical/pipeline.py
@@ -223,68 +223,82 @@ def sample_document(text: str, max_chars: int = EMBED_DOC_SAMPLE_CHARS) -> str:
 _READ_CHUNK_TARGET_BYTES = 64 * 1024 * 1024
 
 
-def _load_records_bounded(source: InputFileSpec | str) -> Iterator[dict]:
-    """Yield Parquet records without materializing a whole row group as Python objects.
+def rows_per_chunk(num_rows: int, nbytes: int, target_bytes: int = _READ_CHUNK_TARGET_BYTES) -> int:
+    """Rows to materialize at once, from a batch's own average row size.
 
-    Same records, same order as ``zephyr.readers.load_parquet``; only the
-    materialization granularity differs. Rows per chunk come from the batch's own
-    average row size, so megabyte-document sources get small chunks and small-document
-    sources get large ones.
+    Megabyte-document sources get small chunks and small-document sources get large
+    ones, without either needing to know the other's shape.
     """
+    if num_rows <= 0:
+        return 1
+    avg_row_bytes = max(1, nbytes // num_rows)
+    return max(1, target_bytes // avg_row_bytes)
+
+
+def _load_records_bounded(
+    source: InputFileSpec | str,
+    doc_sample_chars: int = EMBED_DOC_SAMPLE_CHARS,
+) -> Iterator[dict]:
+    """Yield Parquet records, truncated, without materializing a whole row group.
+
+    Truncation happens **here** rather than in the map: the map runs downstream of
+    ``window``, so truncating there would still let a window retain ``batch_size``
+    untruncated documents and scale with raw document size. Truncating at read time
+    bounds the reader, the window, and the embedder call at once.
+
+    Same records and order as ``zephyr.readers.load_parquet``, with ``text`` truncated.
+    """
+    n_bytes_in = 0
+    n_bytes_embedded = 0
+    n_truncated = 0
+
+    def prepare(records: list[dict]) -> Iterator[dict]:
+        nonlocal n_bytes_in, n_bytes_embedded, n_truncated
+        for record in records:
+            raw = record.get("text") or ""
+            kept = sample_document(raw, doc_sample_chars)
+            n_bytes_in += len(raw)
+            n_bytes_embedded += len(kept)
+            n_truncated += len(kept) < len(raw)
+            record["text"] = kept
+            yield record
+
     for batch in load_parquet_batch(source):
         if batch.num_rows == 0:
             continue
-        avg_row_bytes = max(1, batch.nbytes // batch.num_rows)
-        rows_per_chunk = max(1, _READ_CHUNK_TARGET_BYTES // avg_row_bytes)
-        if rows_per_chunk >= batch.num_rows:
-            yield from batch.to_pylist()
-            continue
-        for offset in range(0, batch.num_rows, rows_per_chunk):
-            yield from batch.slice(offset, rows_per_chunk).to_pylist()
+        per_chunk = rows_per_chunk(batch.num_rows, batch.nbytes, _READ_CHUNK_TARGET_BYTES)
+        for offset in range(0, batch.num_rows, per_chunk):
+            yield from prepare(batch.slice(offset, per_chunk).to_pylist())
+
+    counters.pipeline.update_counter("embed/bytes_in", n_bytes_in)
+    counters.pipeline.update_counter("embed/bytes_embedded", n_bytes_embedded)
+    counters.pipeline.update_counter("embed/docs_truncated", n_truncated)
 
 
 def _embed_shard(
     batches: Iterator[list[dict]],
     shard: ShardInfo,
-    doc_sample_chars: int = EMBED_DOC_SAMPLE_CHARS,
 ) -> Iterator[dict]:
     """Per-shard map: each ``batches`` window is one ``embedder(texts)`` call.
 
     Yields ``{id, embedding}`` records preserving input order. Emits zephyr
-    counters with the totals for the shard. Each document is first truncated to at most
-    ``doc_sample_chars`` via :func:`sample_document`, which bounds both the per-call
-    text and, with it, the whole window.
+    counters with the totals for the shard. ``text`` arrives already truncated from
+    :func:`_load_records_bounded`, so a window cannot retain oversized documents.
     """
     embedder = _load_embedder_from_shared()
     n_docs = 0
-    n_bytes = 0
-    n_bytes_embedded = 0
-    n_truncated = 0
     for batch in batches:
         ids = [r["id"] for r in batch]
-        raw_texts = [r["text"] or "" for r in batch]
-        texts = [sample_document(t, doc_sample_chars) for t in raw_texts]
+        texts = [r["text"] for r in batch]
         n_docs += len(ids)
-        n_bytes += sum(len(t) for t in raw_texts)
-        n_bytes_embedded += sum(len(t) for t in texts)
-        n_truncated += sum(1 for raw, kept in zip(raw_texts, texts, strict=True) if len(kept) < len(raw))
         raw = np.asarray(embedder(texts, progress_bars=False), dtype=np.float32)
         raw = _l2_normalize(raw)
         q = quantize_to_int8(raw)
         for i, did in enumerate(ids):
             yield {"id": did, "embedding": q[i].tolist()}
     counters.pipeline.update_counter("embed/docs_in", n_docs)
-    counters.pipeline.update_counter("embed/bytes_in", n_bytes)
-    counters.pipeline.update_counter("embed/bytes_embedded", n_bytes_embedded)
-    counters.pipeline.update_counter("embed/docs_truncated", n_truncated)
     counters.pipeline.update_counter("embed/shards_in", 1)
-    logger.info(
-        "shard %d/%d: %d docs (%.1f MB) encoded",
-        shard.shard_idx,
-        shard.total_shards,
-        n_docs,
-        n_bytes / 1024 / 1024,
-    )
+    logger.info("shard %d/%d: %d docs encoded", shard.shard_idx, shard.total_shards, n_docs)
 
 
 def embed_source(
@@ -339,9 +353,9 @@ def embed_source(
 
     ds = (
         Dataset.from_list(source_specs)
-        .flat_map(_load_records_bounded)
+        .flat_map(lambda spec, dsc=doc_sample_chars: _load_records_bounded(spec, dsc))
         .window(batch_size)
-        .map_shard(lambda batches, shard, dsc=doc_sample_chars: _embed_shard(batches, shard, dsc))
+        .map_shard(_embed_shard)
         .write_parquet(_output_path, schema=_EMBEDDING_SCHEMA, skip_existing=True)
     )
 

--- a/experiments/datakit/embeddings/luxical/pipeline.py
+++ b/experiments/datakit/embeddings/luxical/pipeline.py
@@ -24,7 +24,8 @@ wire exactly once per pipeline execution and reuses it for every shard
 -- with none of the 880 MB ever traveling through cloudpickle or sitting
 in coordinator RAM.
 
-Counters emitted: ``embed/docs_in``, ``embed/bytes_in``, ``embed/shards_in``.
+Counters emitted: ``embed/docs_in``, ``embed/bytes_in``, ``embed/bytes_embedded``,
+``embed/docs_truncated``, ``embed/shards_in``.
 """
 
 import logging
@@ -46,7 +47,7 @@ from rigging.filesystem import StoragePath, marin_temp_bucket
 from zephyr import counters
 from zephyr.dataset import Dataset, ShardInfo
 from zephyr.execution import ZephyrContext
-from zephyr.readers import InputFileSpec, load_file
+from zephyr.readers import InputFileSpec, load_parquet_batch
 from zephyr.runners import InlineRunner
 from zephyr.worker_context import zephyr_worker_ctx
 
@@ -116,6 +117,7 @@ class EmbeddingAttrData(BaseModel):
     quantization_scale: float
     quantization_range: float
     batch_size: int
+    doc_sample_chars: int = 0
     counters: dict[str, int | float] = {}
 
     def shard_paths(self) -> list[str]:
@@ -188,23 +190,84 @@ def _l2_normalize(arr: np.ndarray) -> np.ndarray:
     return arr / norms
 
 
+# Longest document text handed to the embedder. Code sources carry individual documents
+# of many megabytes (stack-v3 shards reach 944 MB compressed), and one document that
+# large defeats any batch-level bound: it must be embedded in a single call whatever the
+# window size is. Truncating caps the per-document cost, so embed memory stops scaling
+# with the largest document in the corpus -- and with each document bounded, a whole
+# ``batch_size`` window is bounded for free.
+#
+# Head truncation matches the Harrier embedding pipeline (#7998), which truncates
+# documents at 8,192 tokens -- roughly this many characters of code. Keeping both
+# pipelines on the same rule means a document's embedded prefix does not depend on which
+# embedder read it. 32 KiB is also far more text than a 192-dim lexical embedding can
+# distinguish, so a truncated document's vector stays representative.
+EMBED_DOC_SAMPLE_CHARS = 32 * 1024
+
+
+def sample_document(text: str, max_chars: int = EMBED_DOC_SAMPLE_CHARS) -> str:
+    """Return at most *max_chars* of *text*, taken from its beginning.
+
+    A document at or below the cap is returned unchanged, which is the overwhelming
+    majority of web text.
+    """
+    return text[:max_chars]
+
+
+# Target Python-object bytes per read chunk. ``zephyr.readers.load_parquet`` does
+# ``yield from batch.to_pylist()``, converting an ENTIRE Parquet row group into Python
+# dicts before yielding the first record -- roughly 3-4x the Arrow size. Truncation
+# happens after the read, so it cannot bound this: a 944 MB row group still materializes
+# in full. Slice the batch first; ``RecordBatch.slice`` is zero-copy, so only the slice
+# becomes Python objects.
+_READ_CHUNK_TARGET_BYTES = 64 * 1024 * 1024
+
+
+def _load_records_bounded(source: InputFileSpec | str) -> Iterator[dict]:
+    """Yield Parquet records without materializing a whole row group as Python objects.
+
+    Same records, same order as ``zephyr.readers.load_parquet``; only the
+    materialization granularity differs. Rows per chunk come from the batch's own
+    average row size, so megabyte-document sources get small chunks and small-document
+    sources get large ones.
+    """
+    for batch in load_parquet_batch(source):
+        if batch.num_rows == 0:
+            continue
+        avg_row_bytes = max(1, batch.nbytes // batch.num_rows)
+        rows_per_chunk = max(1, _READ_CHUNK_TARGET_BYTES // avg_row_bytes)
+        if rows_per_chunk >= batch.num_rows:
+            yield from batch.to_pylist()
+            continue
+        for offset in range(0, batch.num_rows, rows_per_chunk):
+            yield from batch.slice(offset, rows_per_chunk).to_pylist()
+
+
 def _embed_shard(
     batches: Iterator[list[dict]],
     shard: ShardInfo,
+    doc_sample_chars: int = EMBED_DOC_SAMPLE_CHARS,
 ) -> Iterator[dict]:
     """Per-shard map: each ``batches`` window is one ``embedder(texts)`` call.
 
     Yields ``{id, embedding}`` records preserving input order. Emits zephyr
-    counters with the totals for the shard.
+    counters with the totals for the shard. Each document is first truncated to at most
+    ``doc_sample_chars`` via :func:`sample_document`, which bounds both the per-call
+    text and, with it, the whole window.
     """
     embedder = _load_embedder_from_shared()
     n_docs = 0
     n_bytes = 0
+    n_bytes_embedded = 0
+    n_truncated = 0
     for batch in batches:
         ids = [r["id"] for r in batch]
-        texts = [r["text"] for r in batch]
+        raw_texts = [r["text"] or "" for r in batch]
+        texts = [sample_document(t, doc_sample_chars) for t in raw_texts]
         n_docs += len(ids)
-        n_bytes += sum(len(t) for t in texts)
+        n_bytes += sum(len(t) for t in raw_texts)
+        n_bytes_embedded += sum(len(t) for t in texts)
+        n_truncated += sum(1 for raw, kept in zip(raw_texts, texts, strict=True) if len(kept) < len(raw))
         raw = np.asarray(embedder(texts, progress_bars=False), dtype=np.float32)
         raw = _l2_normalize(raw)
         q = quantize_to_int8(raw)
@@ -212,6 +275,8 @@ def _embed_shard(
             yield {"id": did, "embedding": q[i].tolist()}
     counters.pipeline.update_counter("embed/docs_in", n_docs)
     counters.pipeline.update_counter("embed/bytes_in", n_bytes)
+    counters.pipeline.update_counter("embed/bytes_embedded", n_bytes_embedded)
+    counters.pipeline.update_counter("embed/docs_truncated", n_truncated)
     counters.pipeline.update_counter("embed/shards_in", 1)
     logger.info(
         "shard %d/%d: %d docs (%.1f MB) encoded",
@@ -230,6 +295,7 @@ def embed_source(
     weights_filename: str = LUXICAL_WEIGHTS_FILE,
     revision: str = LUXICAL_REVISION,
     batch_size: int = DEFAULT_BATCH_SIZE,
+    doc_sample_chars: int = EMBED_DOC_SAMPLE_CHARS,
     max_shards: int | None = None,
     worker_resources: ResourceConfig | None = None,
     max_workers: int = 128,
@@ -273,9 +339,9 @@ def embed_source(
 
     ds = (
         Dataset.from_list(source_specs)
-        .flat_map(load_file)
+        .flat_map(_load_records_bounded)
         .window(batch_size)
-        .map_shard(_embed_shard)
+        .map_shard(lambda batches, shard, dsc=doc_sample_chars: _embed_shard(batches, shard, dsc))
         .write_parquet(_output_path, schema=_EMBEDDING_SCHEMA, skip_existing=True)
     )
 
@@ -302,6 +368,7 @@ def embed_source(
         quantization_scale=QUANT_SCALE,
         quantization_range=QUANT_RANGE,
         batch_size=batch_size,
+        doc_sample_chars=doc_sample_chars,
         counters=dict(outcome.counters),
     )
     write_artifact(artifact, output_path)

--- a/experiments/datakit/reference_pipeline.py
+++ b/experiments/datakit/reference_pipeline.py
@@ -136,6 +136,7 @@ from experiments.datakit.decontam.config import (
 )
 from experiments.datakit.decontam.prepare_eval_corpus import DECON_EXCLUDED_EVAL_TASKS
 from experiments.datakit.embeddings.luxical.pipeline import (
+    EMBED_DOC_SAMPLE_CHARS,
     EMBEDDING_ATTR_DATA_VERSION,
     LUXICAL_REPO,
     LUXICAL_REVISION,
@@ -343,6 +344,9 @@ def _build_embed_step(name: str, normalize_step: StepSpec, scale: PipelineScale)
             "luxical_weights": LUXICAL_WEIGHTS_FILE,
             "luxical_revision": LUXICAL_REVISION,
             "batch_size": scale.embed_batch_size,
+            # Truncation changes the vector for any document above the cap, so it is
+            # part of the embed step identity per the contract above.
+            "doc_sample_chars": EMBED_DOC_SAMPLE_CHARS,
             "v": EMBEDDING_ATTR_DATA_VERSION,
         },
         fn=remote(
@@ -351,6 +355,7 @@ def _build_embed_step(name: str, normalize_step: StepSpec, scale: PipelineScale)
                 normalized=read_artifact(np, NormalizedData),
                 revision=LUXICAL_REVISION,
                 batch_size=scale.embed_batch_size,
+                doc_sample_chars=EMBED_DOC_SAMPLE_CHARS,
                 worker_resources=scale.pool.worker,
                 max_workers=scale.pool.n_workers,
             ),

--- a/tests/datakit/test_luxical_embed_batching.py
+++ b/tests/datakit/test_luxical_embed_batching.py
@@ -3,15 +3,19 @@
 
 """Memory bounds for the Luxical embed step.
 
-Two bounds, each covering a distinct blowup, both needed:
+Embedding a source whose documents are megabytes each exhausts a worker, because
+``batch_size`` bounds document *count* rather than bytes. Two bounds fix that, and both
+live in the read path so nothing downstream can retain oversized text:
 
-* :func:`sample_document` caps one document. Code sources carry documents of many
-  megabytes, and a single one must be embedded in one call however small the window is.
-  Head truncation matches the Harrier pipeline (marin#7998), which truncates at 8,192
-  tokens. With each document bounded, a whole ``batch_size`` window is bounded too.
-* ``_load_records_bounded`` caps how much of a Parquet row group becomes Python objects
-  at once. Truncation cannot do this -- it runs after the read, so a 944 MB row group
-  would still materialize in full.
+* :func:`sample_document` caps one document. Head truncation matches the Harrier
+  pipeline (#7998), which truncates at 8,192 tokens.
+* :func:`rows_per_chunk` caps how much of a Parquet row group becomes Python objects at
+  once. ``zephyr.readers.load_parquet`` converts a whole row group via ``to_pylist()``
+  before yielding one record, which no downstream bound can undo.
+
+Truncation happens in :func:`_load_records_bounded` rather than in the map, because the
+map runs after ``window``: truncating there would still let a window retain
+``batch_size`` untruncated documents.
 """
 
 import pyarrow as pa
@@ -19,7 +23,11 @@ import pyarrow.parquet as pq
 from zephyr.readers import load_parquet
 
 from experiments.datakit.embeddings.luxical import pipeline as luxical_pipeline
-from experiments.datakit.embeddings.luxical.pipeline import _load_records_bounded, sample_document
+from experiments.datakit.embeddings.luxical.pipeline import (
+    _load_records_bounded,
+    rows_per_chunk,
+    sample_document,
+)
 
 # ---- per-document truncation -------------------------------------------------
 
@@ -41,22 +49,34 @@ def test_truncation_never_exceeds_the_cap():
 
 
 def test_truncation_bounds_a_pathological_document():
-    """The case that defeated every batch-level bound: a multi-MB single document."""
+    """The case that defeats every batch-level bound: a multi-MB single document."""
     assert len(sample_document("q" * 20_000_000, 32 * 1024)) == 32 * 1024
 
 
-def test_truncation_is_deterministic():
-    text = "abcdefghij" * 5_000
-    assert sample_document(text, 300) == sample_document(text, 300)
+# ---- chunk sizing ------------------------------------------------------------
 
 
-def test_default_cap_bounds_a_full_window():
-    """A batch_size window of capped documents must stay small enough to embed."""
-    window_bytes = 4096 * luxical_pipeline.EMBED_DOC_SAMPLE_CHARS
-    assert window_bytes <= 128 * 1024 * 1024
+def test_rows_per_chunk_shrinks_as_rows_grow():
+    """A megabyte-document source must get far fewer rows per chunk than a small one."""
+    target = 64 * 1024 * 1024
+    small = rows_per_chunk(num_rows=10_000, nbytes=10_000 * 2_000, target_bytes=target)
+    large = rows_per_chunk(num_rows=10_000, nbytes=10_000 * 5_000_000, target_bytes=target)
+    assert large < small
+    assert large >= 1, "never zero: a single oversized row must still be materializable"
 
 
-# ---- bounded Parquet reader ---------------------------------------------------
+def test_rows_per_chunk_stays_within_the_byte_target():
+    target = 1_000_000
+    avg = 250_000
+    n = rows_per_chunk(num_rows=100, nbytes=100 * avg, target_bytes=target)
+    assert n * avg <= target
+
+
+def test_rows_per_chunk_handles_an_empty_batch():
+    assert rows_per_chunk(num_rows=0, nbytes=0, target_bytes=1_000) == 1
+
+
+# ---- bounded reader ----------------------------------------------------------
 
 
 def _write_shard(path, n_rows, text_len, row_group_size):
@@ -69,26 +89,72 @@ def _write_shard(path, n_rows, text_len, row_group_size):
     pq.write_table(table, path, row_group_size=row_group_size)
 
 
-def test_bounded_reader_matches_zephyr_reader_exactly(tmp_path):
-    """Equivalence is the whole justification for a local reader: same records, same order."""
+class _CountingBatch:
+    """Wraps a RecordBatch and records the size of every ``to_pylist`` the reader performs.
+
+    The oracle for the memory bound is *how much is materialized at once*, which record
+    equality cannot see: a reader that regressed to one whole-row-group ``to_pylist()``
+    would still return identical records.
+    """
+
+    def __init__(self, batch, sizes=None):
+        self._batch = batch
+        self.pylist_sizes = sizes if sizes is not None else []
+
+    @property
+    def num_rows(self):
+        return self._batch.num_rows
+
+    @property
+    def nbytes(self):
+        return self._batch.nbytes
+
+    def slice(self, offset, length):
+        return _CountingBatch(self._batch.slice(offset, length), self.pylist_sizes)
+
+    def to_pylist(self):
+        rows = self._batch.to_pylist()
+        self.pylist_sizes.append(len(rows))
+        return rows
+
+
+def test_reader_materializes_a_row_group_in_several_bounded_pieces(tmp_path, monkeypatch):
+    """Regressing to a single whole-row-group to_pylist() must fail this test."""
+    path = str(tmp_path / "big.parquet")
+    _write_shard(path, n_rows=40, text_len=10_000, row_group_size=40)
+
+    batch = next(iter(pq.ParquetFile(path).iter_batches(batch_size=40)))
+    wrapper = _CountingBatch(batch)
+    monkeypatch.setattr(luxical_pipeline, "load_parquet_batch", lambda _source: iter([wrapper]))
+    monkeypatch.setattr(luxical_pipeline, "_READ_CHUNK_TARGET_BYTES", 20_000)
+
+    records = list(_load_records_bounded(path, doc_sample_chars=10_000_000))
+
+    assert len(wrapper.pylist_sizes) > 1, f"materialized in one piece: {wrapper.pylist_sizes}"
+    assert max(wrapper.pylist_sizes) < 40, "no single materialization may cover the whole row group"
+    assert sum(wrapper.pylist_sizes) == 40, "every row materialized exactly once"
+    assert [r["id"] for r in records] == [f"d{i}" for i in range(40)]
+
+
+def test_reader_truncates_before_yielding(tmp_path):
+    """Truncation must happen in the reader, so windowing downstream cannot retain raw text."""
+    path = str(tmp_path / "long.parquet")
+    _write_shard(path, n_rows=4, text_len=50_000, row_group_size=4)
+
+    records = list(_load_records_bounded(path, doc_sample_chars=100))
+
+    assert [len(r["text"]) for r in records] == [100, 100, 100, 100]
+
+
+def test_reader_preserves_records_when_nothing_is_truncated(tmp_path):
+    """With the cap above every document, output must equal zephyr's reader exactly."""
     path = str(tmp_path / "shard.parquet")
     _write_shard(path, n_rows=500, text_len=200, row_group_size=64)
 
-    assert list(_load_records_bounded(path)) == list(load_parquet(path))
+    assert list(_load_records_bounded(path, doc_sample_chars=10_000_000)) == list(load_parquet(path))
 
 
-def test_bounded_reader_slices_large_rows_into_several_chunks(tmp_path, monkeypatch):
-    """With a tiny byte target a row group must be materialized in pieces, not whole."""
-    path = str(tmp_path / "big.parquet")
-    _write_shard(path, n_rows=40, text_len=10_000, row_group_size=40)
-    monkeypatch.setattr(luxical_pipeline, "_READ_CHUNK_TARGET_BYTES", 20_000)
-
-    records = list(luxical_pipeline._load_records_bounded(path))
-    assert [r["id"] for r in records] == [f"d{i}" for i in range(40)]
-    assert records == list(load_parquet(path)), "chunking must not change records"
-
-
-def test_bounded_reader_handles_empty_shard(tmp_path):
+def test_reader_handles_empty_shard(tmp_path):
     path = str(tmp_path / "empty.parquet")
     pq.write_table(pa.table({"id": pa.array([], type=pa.string()), "text": pa.array([], type=pa.string())}), path)
     assert list(_load_records_bounded(path)) == []

--- a/tests/datakit/test_luxical_embed_batching.py
+++ b/tests/datakit/test_luxical_embed_batching.py
@@ -1,0 +1,94 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Memory bounds for the Luxical embed step.
+
+Two bounds, each covering a distinct blowup, both needed:
+
+* :func:`sample_document` caps one document. Code sources carry documents of many
+  megabytes, and a single one must be embedded in one call however small the window is.
+  Head truncation matches the Harrier pipeline (marin#7998), which truncates at 8,192
+  tokens. With each document bounded, a whole ``batch_size`` window is bounded too.
+* ``_load_records_bounded`` caps how much of a Parquet row group becomes Python objects
+  at once. Truncation cannot do this -- it runs after the read, so a 944 MB row group
+  would still materialize in full.
+"""
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from zephyr.readers import load_parquet
+
+from experiments.datakit.embeddings.luxical import pipeline as luxical_pipeline
+from experiments.datakit.embeddings.luxical.pipeline import _load_records_bounded, sample_document
+
+# ---- per-document truncation -------------------------------------------------
+
+
+def test_document_at_or_below_cap_is_unchanged():
+    """The common case must be byte-identical, or ordinary sources would shift."""
+    assert sample_document("abc", 100) == "abc"
+    assert sample_document("x" * 100, 100) == "x" * 100
+
+
+def test_document_above_cap_is_truncated_to_its_head():
+    assert sample_document("abcdefghij", 4) == "abcd"
+
+
+def test_truncation_never_exceeds_the_cap():
+    for n in (1_000, 10_000, 5_000_000):
+        for cap in (90, 1_000, 32 * 1024):
+            assert len(sample_document("z" * n, cap)) <= cap
+
+
+def test_truncation_bounds_a_pathological_document():
+    """The case that defeated every batch-level bound: a multi-MB single document."""
+    assert len(sample_document("q" * 20_000_000, 32 * 1024)) == 32 * 1024
+
+
+def test_truncation_is_deterministic():
+    text = "abcdefghij" * 5_000
+    assert sample_document(text, 300) == sample_document(text, 300)
+
+
+def test_default_cap_bounds_a_full_window():
+    """A batch_size window of capped documents must stay small enough to embed."""
+    window_bytes = 4096 * luxical_pipeline.EMBED_DOC_SAMPLE_CHARS
+    assert window_bytes <= 128 * 1024 * 1024
+
+
+# ---- bounded Parquet reader ---------------------------------------------------
+
+
+def _write_shard(path, n_rows, text_len, row_group_size):
+    table = pa.table(
+        {
+            "id": [f"d{i}" for i in range(n_rows)],
+            "text": [f"{i}-" + "x" * text_len for i in range(n_rows)],
+        }
+    )
+    pq.write_table(table, path, row_group_size=row_group_size)
+
+
+def test_bounded_reader_matches_zephyr_reader_exactly(tmp_path):
+    """Equivalence is the whole justification for a local reader: same records, same order."""
+    path = str(tmp_path / "shard.parquet")
+    _write_shard(path, n_rows=500, text_len=200, row_group_size=64)
+
+    assert list(_load_records_bounded(path)) == list(load_parquet(path))
+
+
+def test_bounded_reader_slices_large_rows_into_several_chunks(tmp_path, monkeypatch):
+    """With a tiny byte target a row group must be materialized in pieces, not whole."""
+    path = str(tmp_path / "big.parquet")
+    _write_shard(path, n_rows=40, text_len=10_000, row_group_size=40)
+    monkeypatch.setattr(luxical_pipeline, "_READ_CHUNK_TARGET_BYTES", 20_000)
+
+    records = list(luxical_pipeline._load_records_bounded(path))
+    assert [r["id"] for r in records] == [f"d{i}" for i in range(40)]
+    assert records == list(load_parquet(path)), "chunking must not change records"
+
+
+def test_bounded_reader_handles_empty_shard(tmp_path):
+    path = str(tmp_path / "empty.parquet")
+    pq.write_table(pa.table({"id": pa.array([], type=pa.string()), "text": pa.array([], type=pa.string())}), path)
+    assert list(_load_records_bounded(path)) == []


### PR DESCRIPTION
* bound embed memory so a source with megabyte-scale documents cannot exhaust a worker
* per-document truncation to 32 KiB (`EMBED_DOC_SAMPLE_CHARS`) before the embedder call — `batch_size` bounds document *count*, which is not a memory bound when documents differ by three orders of magnitude in size [^1]
  * matches the Harrier pipeline (#7998), which truncates at 8,192 tokens, so a document's embedded prefix does not depend on which embedder read it
  * with each document bounded, a whole `batch_size` window is bounded for free
* `_load_records_bounded` — read Parquet by slicing each row group before `to_pylist()`
  * zephyr's `load_parquet` does `yield from batch.to_pylist()`, materializing an entire row group (~3-4× the Arrow size) before yielding one record
  * truncation runs *after* the read, so it cannot bound this — a 944 MB row group still materialized in full
  * `RecordBatch.slice` is zero-copy; rows per chunk derive from the batch's own average row size, so megabyte-document sources get small chunks and small-document sources get large ones
* `doc_sample_chars` enters the embed step's `hash_attrs` — truncation changes the vector for documents above the cap, so **existing embed outputs re-key and recompute**
* also fixes a hard crash: `pa.StringArray` uses int32 offsets, so a batch carrying >2 GiB of text returned a `ChunkedArray` and `luxical.embedder.tokenize` raised `TypeError: Expected instance of pyarrow.lib.Array, got pyarrow.lib.ChunkedArray`. Bounded documents cannot reach that limit
* new counters `embed/bytes_embedded` and `embed/docs_truncated` record how much text was actually embedded and how many documents were cut

[^1]: measured on the datakit 10% sample: every `stack-v3` shard that embedded successfully at 56 GB workers was ≤453 MB compressed, while the 210 that never completed were ≥219 MB with a 944 MB worst case. Raising worker memory to 128 GB moved the threshold rather than removing it, and at 1 worker/VM was capacity-starved. After truncation the same tail drained on 32 GB workers at ~650 shards/hour versus ~29/hour.
