### PR TITLE
zephyr: retry worker registration

### DIFF
--- a/lib/zephyr/src/zephyr/worker.py
+++ b/lib/zephyr/src/zephyr/worker.py
@@ -27,6 +27,13 @@ from zephyr.worker_context import CounterEntry, CounterSnapshot, merge_counter_e
 
 logger = logging.getLogger(__name__)
 
+# Slice for polling a pending coordinator RPC: short enough to stay responsive to
+# shutdown, long enough not to spin. The warn thresholds bound how long a coordinator
+# can stay silent before the worker says so.
+RPC_POLL_INTERVAL = 0.5
+REGISTER_WARN_AFTER = 60.0
+PULL_TASK_WARN_AFTER = 30.0
+
 
 def _format_worker_status_md(active_tasks: int, stage: str) -> tuple[str, str]:
     """Return worker status text, or two idle values when no task is active."""
@@ -106,18 +113,20 @@ class ZephyrWorker:
         return self._host_shutdown_event is not None and self._host_shutdown_event.is_set()
 
     def _register(self) -> bool:
-        """Block until registration lands. Return False if we are told to stop first.
+        """Register with the coordinator and restore the memory tables it returns.
 
-        Waits on the outstanding request rather than re-sending it: a busy coordinator
-        answers late, and a client-side deadline would turn that delay into a second
-        registration. ``register_worker`` requeues a worker's in-flight tasks whenever
-        it sees a known ``worker_id``, so a duplicate from a live worker would hand a
-        shard it is still running to somebody else. A new request goes out only when
-        the RPC itself failed.
-
-        The retry is unbounded. Returning instead exits the poll loop, and iris records
-        that clean exit as a successful task and never replaces the worker.
+        Returns True once registration lands, False if this worker is told to stop
+        first. Blocks for as long as registration takes.
         """
+        # Wait on the outstanding request rather than re-send it. A busy coordinator
+        # answers late, and a client-side deadline would turn that delay into a second
+        # registration -- register_worker requeues a worker's in-flight tasks whenever
+        # it sees a known worker_id, so a duplicate from a live worker would hand a
+        # shard it is still running to somebody else. Only a failed RPC starts a new
+        # request.
+        #
+        # Unbounded on purpose: returning exits the poll loop, and iris records that
+        # clean exit as a successful task and never replaces the worker.
         backoff = ExponentialBackoff(initial=1.0, maximum=30.0)
         future: ActorFuture | None = None
         request_start = 0.0
@@ -129,10 +138,10 @@ class ZephyrWorker:
                     future = self._coordinator.register_worker.remote(self._worker_id, self._actor_handle)
                     request_start = time.monotonic()
                     warned = False
-                registrations = future.result(timeout=0.5)
+                registrations = future.result(timeout=RPC_POLL_INTERVAL)
             except TimeoutError:
                 elapsed = time.monotonic() - request_start
-                if elapsed > 60 and not warned:
+                if elapsed > REGISTER_WARN_AFTER and not warned:
                     logger.warning("[%s] Waiting to register with the coordinator (%.0fs)", self._worker_id, elapsed)
                     warned = True
                 continue
@@ -188,10 +197,10 @@ class ZephyrWorker:
                     future = self._coordinator.pull_task.remote(self._worker_id, avail)
                     future_start = time.monotonic()
                     warned = False
-                response = future.result(timeout=0.5)
+                response = future.result(timeout=RPC_POLL_INTERVAL)
             except TimeoutError:
                 elapsed = time.monotonic() - future_start
-                if elapsed > 30 and not warned:
+                if elapsed > PULL_TASK_WARN_AFTER and not warned:
                     logger.warning("[%s] Waiting for pull_task response (%.0fs)", self._worker_id, elapsed)
                     warned = True
                 continue

--- a/lib/zephyr/src/zephyr/worker.py
+++ b/lib/zephyr/src/zephyr/worker.py
@@ -99,6 +99,55 @@ class ZephyrWorker:
         )
         self._poll_thread.start()
 
+    def _stopping(self) -> bool:
+        """True once this worker, or the actor hosting it, has been told to stop."""
+        if self._shutdown_event.is_set():
+            return True
+        return self._host_shutdown_event is not None and self._host_shutdown_event.is_set()
+
+    def _register(self) -> bool:
+        """Block until registration lands. Return False if we are told to stop first.
+
+        Waits on the outstanding request rather than re-sending it: a busy coordinator
+        answers late, and a client-side deadline would turn that delay into a second
+        registration. ``register_worker`` requeues a worker's in-flight tasks whenever
+        it sees a known ``worker_id``, so a duplicate from a live worker would hand a
+        shard it is still running to somebody else. A new request goes out only when
+        the RPC itself failed.
+
+        The retry is unbounded. Returning instead exits the poll loop, and iris records
+        that clean exit as a successful task and never replaces the worker.
+        """
+        backoff = ExponentialBackoff(initial=1.0, maximum=30.0)
+        future: ActorFuture | None = None
+        request_start = 0.0
+        warned = False
+
+        while not self._stopping():
+            try:
+                if future is None:
+                    future = self._coordinator.register_worker.remote(self._worker_id, self._actor_handle)
+                    request_start = time.monotonic()
+                    warned = False
+                registrations = future.result(timeout=0.5)
+            except TimeoutError:
+                elapsed = time.monotonic() - request_start
+                if elapsed > 60 and not warned:
+                    logger.warning("[%s] Waiting to register with the coordinator (%.0fs)", self._worker_id, elapsed)
+                    warned = True
+                continue
+            except Exception as e:
+                logger.warning("[%s] register_worker failed (%s), retrying", self._worker_id, e)
+                future = None
+                self._shutdown_event.wait(timeout=backoff.next_interval())
+                continue
+
+            self._memory_store.restore(registrations)
+            return True
+
+        logger.info("[%s] Told to stop before registration completed", self._worker_id)
+        return False
+
     def _poll_loop(self) -> None:
         """Single poll loop: requests tasks from the coordinator using current available resources.
 
@@ -107,16 +156,9 @@ class ZephyrWorker:
         At stage boundaries, the loop sleeps briefly and then polls again.
         """
         logger.info("[%s] Poll loop starting", self._worker_id)
-        try:
-            registrations = self._coordinator.register_worker.remote(self._worker_id, self._actor_handle).result(
-                timeout=30.0
-            )
-            self._memory_store.restore(registrations)
-        except Exception:
-            logger.error("[%s] Failed to register with coordinator", self._worker_id, exc_info=True)
-            self._shutdown_event.set()
-            if self._host_shutdown_event is not None:
-                self._host_shutdown_event.set()
+        # Registration must land before polling: it returns the memory-table
+        # registrations that tasks read through memory_store.
+        if not self._register():
             return
 
         backoff = ExponentialBackoff(initial=0.1, maximum=5.0)

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -1605,6 +1605,45 @@ def test_heartbeat_failures_fail_actor_context():
     assert isinstance(actor_ctx._errors[0], CoordinatorUnreachable)
 
 
+def test_registration_retries_a_failed_rpc_and_waits_out_a_slow_one():
+    """Registration keeps trying until it lands, and a late answer is not a new attempt.
+
+    ``register_worker`` requeues a worker's in-flight tasks whenever it sees a known
+    worker_id, so a duplicate registration from a live worker would hand a shard it is
+    still running to somebody else.
+    """
+
+    class _RegistrationRpc:
+        """Fails the first call, then answers the second one 1.2s late."""
+
+        def __init__(self):
+            self.calls = 0
+
+        def remote(self, *_args):
+            self.calls += 1
+            future: Future = Future()
+            if self.calls == 1:
+                future.set_exception(ConnectionError("simulated coordinator overload"))
+                return future
+            timer = threading.Timer(1.2, lambda: future.set_result(()))
+            timer.daemon = True
+            timer.start()
+            return future
+
+    rpc = _RegistrationRpc()
+    worker = ZephyrWorker.__new__(ZephyrWorker)
+    worker._coordinator = MagicMock(register_worker=rpc)
+    worker._worker_id = "test-worker-0"
+    worker._actor_handle = MagicMock()
+    worker._memory_store = MagicMock()
+    worker._shutdown_event = threading.Event()
+    worker._host_shutdown_event = None
+
+    assert worker._register() is True
+    assert rpc.calls == 2, "one retry for the failed RPC, none for the slow answer"
+    worker._memory_store.restore.assert_called_once_with(())
+
+
 # --- Integration tests (all backends) ---
 
 

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -1614,21 +1614,27 @@ def test_registration_retries_a_failed_rpc_and_waits_out_a_slow_one():
     """
 
     class _RegistrationRpc:
-        """Fails the first call, then answers the second one 1.2s late."""
+        """Fails the first call. Answers the second one after two poll timeouts.
+
+        Doubles as the future it returns, so the test drives the outcome of each poll
+        instead of waiting on a clock.
+        """
 
         def __init__(self):
             self.calls = 0
+            self._timeouts = 2
 
         def remote(self, *_args):
             self.calls += 1
-            future: Future = Future()
+            return self
+
+        def result(self, timeout=None):
             if self.calls == 1:
-                future.set_exception(ConnectionError("simulated coordinator overload"))
-                return future
-            timer = threading.Timer(1.2, lambda: future.set_result(()))
-            timer.daemon = True
-            timer.start()
-            return future
+                raise ConnectionError("simulated coordinator overload")
+            if self._timeouts > 0:
+                self._timeouts -= 1
+                raise TimeoutError
+            return ()
 
     rpc = _RegistrationRpc()
     worker = ZephyrWorker.__new__(ZephyrWorker)


### PR DESCRIPTION
* a worker whose `register_worker` RPC timed out exited its poll loop and `return`ed, which exits the actor with status 0 — iris records that as a successful task and never replaces the worker
* with a large pool every worker registers at once and the coordinator serializes them under one lock, so workers past the 30s deadline died on arrival [^1]
* `_register` now blocks on its outstanding request and polls it at 0.5s, the same idiom `_poll_loop` already uses for `pull_task`
  * a new request goes out only when the RPC itself failed, with `ExponentialBackoff(1.0, 30.0)`
  * waiting rather than re-sending is the point: `register_worker` requeues a worker's in-flight tasks whenever it sees a known `worker_id`, so a client-side deadline would turn a slow answer into a second registration and hand away a shard the worker is still running [^2]
  * registration cannot be skipped or backgrounded — it returns the `MemoryTableRegistration`s the worker feeds to `memory_store.restore()` before running tasks
* the retry is unbounded: a worker that cannot register is one whose coordinator is gone, and iris kills the process. returning instead exits cleanly, which is the failure above
* add `_stopping()`, so the loop watches the host shutdown event as well as its own — the only exit for a worker that never reaches `pull_task`
* `coordinator.py` is unchanged

[^1]: found while running the datakit 10% pipeline: a 512-worker inline pool eroded to 152 in 12 minutes and then to zero, leaving shards queued with nothing able to pull them, while the job still reported `running` with `failures=0`. `cluster_assign` crawled 75 → 86 → 91 across three restarts because each fresh pool eroded before finishing, and with the retry the same stage went 91 → 292/292 in ~25 minutes at `512/512 workers alive, 0 dead`. that run also carried a per-process incarnation token on `register_worker`, since dropped — it only fires on a reconstruction race, which the run never hit.

[^2]: the residual race is an RPC that fails *after* the coordinator processed it. bounded, not silent: `PickleDiskChunk` writes to uuid-unique paths precisely because "multiple workers race on the same shard", the stale `report_result` is rejected on the attempt mismatch, and a spurious requeue costs 1 of `MAX_SHARD_INFRA_FAILURES` = 20.
