### PR TITLE
Clarify answer and change request modes

### DIFF
--- a/.agents/skills/write-design-doc/SKILL.md
+++ b/.agents/skills/write-design-doc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-design-doc
-description: Produce a 1-page design doc, spec, PR, and Discord review ping when the user explicitly asks to design a planned repository change. Do not use to answer or evaluate an idea inline.
+description: Produce a 1-page design proposal for an explicit design task or a design-level change identified by another change workflow. Do not use to answer or evaluate an idea inline.
 ---
 
 # Skill: Design Doc Workflow
@@ -21,12 +21,16 @@ The template lives at `.agents/projects/design-template.md`. New docs go to a sl
 
 ## When to use this skill
 
-This is a change-mode publishing workflow. Use it only when the user explicitly
-asks for a design doc/one-pager/proposal, or asks to design an intended
-implementation whose review artifact should be committed. Do **not** use it for
-questions, walkthroughs, informal architecture reviews, or requests to assess
-whether an idea is reasonable. Investigate those requests and answer inline;
-start this workflow only after an explicit follow-up asks to publish a design.
+This is a change-mode design workflow. Use it only when the user explicitly
+asks for a design doc/one-pager/proposal, or when another change-mode playbook
+such as `fix-issue` identifies a design-level change and invokes this skill.
+Follow the calling playbook's delivery target: `fix-issue` embeds the proposal
+in its issue comment, while a standalone design task uses the repository files
+and publishing steps below. Do **not** use this skill for questions,
+walkthroughs, informal architecture reviews, or requests to assess whether an
+idea is reasonable. Investigate those requests and answer inline; start a
+standalone design workflow only after an explicit follow-up asks to publish a
+design.
 
 - A task will likely take more than a day, or is load-bearing for other work.
 - A change crosses subproject boundaries (e.g. iris ↔ levanter, marin ↔ zephyr).
@@ -40,7 +44,11 @@ normal implementation workflow instead of manufacturing a design doc.
 
 # Workflow
 
-Seven phases. Confirm with the user at natural decision points (after Research, Draft, Spec, before Publish), but don't ask permission when the next step is obvious.
+The standalone workflow has seven phases. A calling change-mode playbook may
+reuse the design guidance while overriding persistence and publication, as
+`fix-issue` does for a single issue comment. Confirm with the user at natural
+decision points (after Research, Draft, Spec, before Publish), but don't ask
+permission when the next step is obvious.
 
 ## 1. Frame
 

--- a/.agents/skills/write-design-doc/SKILL.md
+++ b/.agents/skills/write-design-doc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-design-doc
-description: Produce a 1-page design doc, open a PR, and ping Discord for review.
+description: Produce a 1-page design doc, spec, PR, and Discord review ping when the user explicitly asks to design a planned repository change. Do not use to answer or evaluate an idea inline.
 ---
 
 # Skill: Design Doc Workflow
@@ -21,11 +21,20 @@ The template lives at `.agents/projects/design-template.md`. New docs go to a sl
 
 ## When to use this skill
 
+This is a change-mode publishing workflow. Use it only when the user explicitly
+asks for a design doc/one-pager/proposal, or asks to design an intended
+implementation whose review artifact should be committed. Do **not** use it for
+questions, walkthroughs, informal architecture reviews, or requests to assess
+whether an idea is reasonable. Investigate those requests and answer inline;
+start this workflow only after an explicit follow-up asks to publish a design.
+
 - A task will likely take more than a day, or is load-bearing for other work.
 - A change crosses subproject boundaries (e.g. iris ↔ levanter, marin ↔ zephyr).
 - A change introduces a new service, package, or persistent data shape.
 
-If none apply, just open the PR — don't manufacture a design doc for a 50-line bug fix.
+If the explicit design request meets none of these criteria, confirm that a
+design artifact is actually wanted. For an ordinary small change, use the
+normal implementation workflow instead of manufacturing a design doc.
 
 ---
 
@@ -35,7 +44,11 @@ Seven phases. Confirm with the user at natural decision points (after Research, 
 
 ## 1. Frame
 
-The user starts the skill with a framing paragraph stating what they want and why. If they didn't, query them — or infer it from rich prior conversation context. A one-sentence "fix the foo thing" is *not* enough; push back and ask for the why.
+The user starts the skill with a framing paragraph stating what they want and
+why. If they did not, infer it from rich conversation, repository, or prior-work
+context when safe. Ask only when the missing rationale would materially change
+the design; a question is not a reason to turn an answer-mode request into this
+workflow.
 
 **You infer the slug.** Short, lowercase, underscores (`finelog_lift`, `iris_autoscaler_refactor`). State it in one line ("I'll save this as `.agents/projects/<slug>/`") and proceed — only stop if it collides with an existing directory, then propose a disambiguator.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,27 @@ matching skill exists** by scanning the skill descriptions in your system
 prompt. If a skill matches, invoke it via the Skill tool — do not skip it in
 favor of ad-hoc commands.
 
+## Choose the Request Mode
+
+Choose the mode from what the user asked before selecting a skill or changing
+the repository:
+
+- **Answer mode** covers questions, explanations, walkthroughs, evaluations,
+  and review requests such as "is this reasonable?" Investigate as needed and
+  return a concise, self-contained answer in the originating conversation. Do
+  not edit files, create design/research documents, commit, open a PR, or invoke
+  a change workflow unless the user explicitly asks for a repository change.
+  Repository access provides evidence; it does not imply authorization to
+  publish work.
+- **Change mode** covers explicit requests to implement, fix, write, update, or
+  open a PR. Make the change and follow the applicable development and landing
+  workflow.
+
+If either interpretation could satisfy the wording, answer first and leave the
+change for an explicit follow-up. Do not require a follow-up when a useful,
+well-supported answer can stand on its own. Select skills only after choosing
+the mode; a change-only skill is not a match for an answer-mode request.
+
 ## Search Prior Work
 
 Use Echo when prior Marin decisions, incidents, workflows, GitHub work, or
@@ -194,8 +215,14 @@ Watch for and eliminate these patterns in generated code:
 
 ## Planning
 
-- Produce detailed plans with code snippets. Ask questions up front instead of guessing.
-- When a request is too large for one pass, capture a plan in `.agents/projects/` before pausing.
+- Planning applies to change-mode work. Produce a detailed plan, with code
+  snippets when they clarify a concrete implementation, for non-trivial
+  changes. Resolve context from the repository and prior work first; ask only
+  when a missing decision would materially change the implementation.
+- In answer mode, investigate and reply directly. Do not manufacture a plan or
+  `.agents/projects/` artifact.
+- When a change request is too large for one pass, capture a plan in
+  `.agents/projects/` before pausing.
 
 ## Code Reuse
 


### PR DESCRIPTION
Treat questions, walkthroughs, evaluations, explanations, and review requests as answer-mode work unless the user explicitly requests a repository change. This prevents a Kubernetes assessment like #8014 from automatically selecting the planning and design workflow and publishing design, research, and spec documents.

The standalone `write-design-doc` workflow now requires explicit design-publishing intent, while change playbooks such as `fix-issue` can still reuse its design guidance and choose an issue comment as the delivery target. The root planning guidance applies only to change-mode work, and ambiguous requests receive a direct answer first.
