### PR TITLE
Pin Loom dotenv secret version 4

### DIFF
--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -13,7 +13,7 @@ config:
     - projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
   marin-loom:machineType: e2-highmem-4
   marin-loom:bootDiskGb: "1000"
-  marin-loom:dotenvSecretVersion: "3"
+  marin-loom:dotenvSecretVersion: "4"
   marin-loom:pruneDeployment: "true"
   marin-loom:snapshotRetentionDays: "14"
   marin-loom:profiles:


### PR DESCRIPTION
Pin the `marin-loom` production stack to `LOOM_DOTENV` version 4, matching the version deployed with marin-community/loom#263. The committed version 3 would cause a later Pulumi update to restore stale credentials.

A production preview with the committed pin reports 25 unchanged resources.
