### PR TITLE
[finelog] Drain telemetry backlogs without dropping rows

### DIFF
--- a/lib/finelog/AGENTS.md
+++ b/lib/finelog/AGENTS.md
@@ -62,10 +62,13 @@ already carry a foreign one, so a hub's own relayed rows never loop. The cursor 
 durable, so a restart resumes rather than replays.
 
 Forwarding is **best-effort by construction**: the sending store holds the record,
-the hub a convenience copy. A namespace that falls more than `MAX_FORWARD_LAG_SEQS`
-behind skips ahead to its freshest window and logs the count it dropped, rather than
-growing without bound; rows evicted before they shipped are skipped the same way. A
-hub outage costs the hub rows, never the sender's memory or its own reads.
+the hub a convenience copy. A backlog is a durable cursor into the sender's bounded
+local retention rather than a separate queue, so the forwarder drains it without an
+age or row-count cap. Non-log chunks from one read turn may wait for hub durability
+concurrently; log chunks stay serial to preserve line order. Rows are skipped only
+after local eviction makes them unreadable or the hub permanently rejects a malformed
+batch. A hub outage therefore cannot consume extra sender memory, but a long enough
+outage can still outlive local retention.
 
 Only the k8s backend can forward — it projects the key through a Secret. The gcp
 backend refuses, because its only channel to the server is world-readable

--- a/lib/finelog/OPS.md
+++ b/lib/finelog/OPS.md
@@ -266,10 +266,12 @@ kubectl --kubeconfig <kubeconfig> --context <context> -n iris \
   rg 'finelog forwarder'
 ```
 
-Warnings name the affected namespace. `backlog exceeds the lag cap` or `rows
-evicted before they were forwarded` means that namespace skipped source sequence
-positions; the cumulative `skipped_seqs` progress counter alone does not prove
-that `log` rows were dropped.
+Warnings name the affected namespace. `backlog exceeds the warning threshold`
+reports pressure but does not change the forwarding cursor; the sender continues
+draining every locally retained row. `rows evicted before they were forwarded`
+means that local retention has already made source sequence positions unreadable.
+The cumulative `skipped_seqs` progress counter also includes permanently rejected
+malformed batches and does not by itself prove that `log` rows were dropped.
 
 To rotate a key, add the new Secret Manager version, add its public key alongside
 the old one under the same `keys[].cluster` (the hub accepts either), roll the

--- a/lib/finelog/rust/src/server/forwarding.rs
+++ b/lib/finelog/rust/src/server/forwarding.rs
@@ -279,7 +279,6 @@ pub struct Forwarder<T = HttpsTransport> {
     config: ForwardingConfig,
     /// Backlog size that emits a warning. It never changes the cursor.
     lag_warning_seqs: i64,
-    /// Namespaces whose current backlog warning has already been emitted.
     warned_lag: Mutex<HashSet<String>>,
     /// Namespaces already created on the hub this process, so `RegisterTable` runs at
     /// most once each.

--- a/lib/finelog/rust/src/server/forwarding.rs
+++ b/lib/finelog/rust/src/server/forwarding.rs
@@ -82,9 +82,11 @@ const FORWARD_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Rows read from one namespace per batch. The hub durably acknowledges each outbound
 /// request, so a small row cap turns its one-second flush-coalescing interval into a
-/// throughput cap. Byte chunking still bounds each request and this read stays well
-/// below the store's million-row write limit.
-const FORWARD_BATCH_ROWS: i64 = 50_000;
+/// throughput cap. A live telemetry scan showed that reading 200,000 rows was faster
+/// than reading 50,000 because provider construction and planning dominate the bounded
+/// scan. Byte chunking still bounds each request, and this stays below the store's
+/// million-row write limit.
+const FORWARD_BATCH_ROWS: i64 = 200_000;
 
 /// Encoded bytes per outbound request. Keep one MiB below the receiving store's hard
 /// Arrow IPC limit. [`chunk_by_bytes`] verifies the resulting size and adjusts each
@@ -96,9 +98,9 @@ const FINELOG_ZSTD_LEVEL: i32 = 1;
 
 /// Non-log chunks from one read turn may wait for durability concurrently. The hub
 /// coalesces writes that arrive within its one-second flush window, so a telemetry-sized
-/// turn split across two Arrow messages needs one durable flush instead of two. Log
-/// chunks stay serial to preserve line order at the hub.
-const FORWARD_CHUNK_CONCURRENCY: usize = 4;
+/// turn split across several Arrow messages needs one durable flush instead of one per
+/// message. Log chunks stay serial to preserve line order at the hub.
+const FORWARD_CHUNK_CONCURRENCY: usize = 8;
 
 /// Emit one warning when a namespace's cursor trails this far behind. This is an
 /// observability threshold only: the backlog is still drained in full while its source

--- a/lib/finelog/rust/src/server/forwarding.rs
+++ b/lib/finelog/rust/src/server/forwarding.rs
@@ -37,10 +37,10 @@
 //! - It advances a namespace's cursor past a batch only once that batch can never be
 //!   sent again: the hub acked it, or the forwarder gave it up. A crash mid-batch
 //!   re-forwards it (at-least-once; tolerable for logs and append-only stats).
-//! - When a namespace falls further behind than [`MAX_FORWARD_LAG_SEQS`], when eviction
-//!   has already archived the segments its cursor points at, or when the hub refuses a
-//!   batch outright, it skips forward and logs what it dropped. A counted, visible gap
-//!   beats an unbounded queue.
+//! - A backlog is only a cursor into the source's already-bounded local retention, not a
+//!   separate in-memory queue. The forwarder drains it without an age or row-count cap.
+//!   It skips only when eviction has already removed the cursor's segments or when the
+//!   hub permanently refuses a malformed batch.
 //!
 //! A push failure backs off and retries; nothing here can take the store down.
 
@@ -53,6 +53,7 @@ use arrow::compute::concat_batches;
 use arrow::datatypes::{Field, Int64Type, Schema as ArrowSchema};
 use connectrpc::client::{CallOptions, ClientConfig, ServiceTransport};
 use connectrpc::compression::{CompressionRegistry, GzipProvider, ZstdProvider};
+use futures::StreamExt;
 use hyper_util::client::legacy::Client as HyperClient;
 use hyper_util::rt::TokioExecutor;
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
@@ -93,13 +94,19 @@ const FORWARD_BATCH_BYTES: usize = MAX_WRITE_ROWS_BYTES - (1 << 20);
 const FORWARD_REQUEST_COMPRESSION: &str = "zstd";
 const FINELOG_ZSTD_LEVEL: i32 = 1;
 
-/// How far a namespace's cursor may trail its durability watermark before the forwarder
-/// gives up on the backlog and jumps to `persisted - MAX_FORWARD_LAG_SEQS`, keeping the
-/// freshest window rather than discarding it all.
+/// Non-log chunks from one read turn may wait for durability concurrently. The hub
+/// coalesces writes that arrive within its one-second flush window, so a telemetry-sized
+/// turn split across two Arrow messages needs one durable flush instead of two. Log
+/// chunks stay serial to preserve line order at the hub.
+const FORWARD_CHUNK_CONCURRENCY: usize = 4;
+
+/// Emit one warning when a namespace's cursor trails this far behind. This is an
+/// observability threshold only: the backlog is still drained in full while its source
+/// segments remain locally retained.
 ///
 /// Measured in `seq` positions, not rows: `seq` is a namespace's own dense counter, so
 /// the two coincide only when no earlier gap exists.
-const MAX_FORWARD_LAG_SEQS: i64 = 2_000_000;
+const FORWARD_LAG_WARNING_SEQS: i64 = 2_000_000;
 
 /// Bearer lifetime, and how early to re-mint. Short-lived because the hub checks only
 /// signature + audience + expiry — it cannot reach a revocation list, so a leaked
@@ -268,10 +275,10 @@ pub struct Forwarder<T = HttpsTransport> {
     client: StatsServiceClient<T>,
     minter: TokenMinter,
     config: ForwardingConfig,
-    /// How far behind its watermark a namespace's cursor may fall before the forwarder
-    /// abandons the backlog and jumps to its freshest window. [`MAX_FORWARD_LAG_SEQS`]
-    /// unless overridden.
-    max_lag_seqs: i64,
+    /// Backlog size that emits a warning. It never changes the cursor.
+    lag_warning_seqs: i64,
+    /// Namespaces whose current backlog warning has already been emitted.
+    warned_lag: Mutex<HashSet<String>>,
     /// Namespaces already created on the hub this process, so `RegisterTable` runs at
     /// most once each.
     registered: Mutex<HashSet<String>>,
@@ -305,7 +312,8 @@ where
             client,
             minter,
             config,
-            max_lag_seqs: MAX_FORWARD_LAG_SEQS,
+            lag_warning_seqs: FORWARD_LAG_WARNING_SEQS,
+            warned_lag: Mutex::new(HashSet::new()),
             registered: Mutex::new(HashSet::new()),
         }
     }
@@ -396,7 +404,7 @@ where
                 return ForwardTurn::Wait;
             }
         };
-        cursor = self.cap_lag(name, cursor, persisted, progress);
+        self.observe_lag(name, cursor, persisted);
         // The forwarder stamps this column with its own cluster on the way out and
         // forwards only rows that do not already carry a foreign origin, so a hub's
         // own relayed rows never loop back. A registered table always has it (added
@@ -458,8 +466,21 @@ where
                 return ForwardTurn::Wait;
             }
         };
-        for (ipc, last_seq) in chunks {
-            match self.push(name, ipc, stop).await {
+        let concurrency = if name == LOG_NAMESPACE_NAME {
+            1
+        } else {
+            FORWARD_CHUNK_CONCURRENCY
+        };
+        let pushes = chunks.into_iter().map(|(ipc, last_seq)| {
+            let mut chunk_stop = (*stop).clone();
+            async move { (last_seq, self.push(name, ipc, &mut chunk_stop).await) }
+        });
+        // `buffered` polls several pushes at once but yields their results in input
+        // order. The durable cursor therefore never advances past an earlier chunk that
+        // is still retrying, even when a later chunk reaches the hub first.
+        let mut pushes = futures::stream::iter(pushes).buffered(concurrency);
+        while let Some((last_seq, result)) = pushes.next().await {
+            match result {
                 Ok(()) => progress.batches += 1,
                 Err(PushError::Stopping(e)) => {
                     tracing::warn!(namespace = name, cursor, error = %e, "finelog forwarder: push interrupted");
@@ -536,25 +557,24 @@ where
         true
     }
 
-    /// Abandon a backlog too large to be worth draining, keeping the freshest
-    /// [`Self::max_lag_seqs`] of it.
-    fn cap_lag(&self, name: &str, cursor: i64, persisted: i64, progress: &mut Progress) -> i64 {
-        if persisted - cursor <= self.max_lag_seqs {
-            return cursor;
+    /// Report a growing backlog once without changing its cursor. Clear the latch after
+    /// catch-up so a later independent incident is visible too.
+    fn observe_lag(&self, name: &str, cursor: i64, persisted: i64) {
+        let lag = persisted - cursor;
+        let mut warned = self.warned_lag.lock().unwrap();
+        if lag > self.lag_warning_seqs {
+            if warned.insert(name.to_string()) {
+                tracing::warn!(
+                    namespace = name,
+                    cursor,
+                    persisted,
+                    lag,
+                    "finelog forwarder: backlog exceeds the warning threshold; draining without skipping"
+                );
+            }
+        } else {
+            warned.remove(name);
         }
-        let resume_at = persisted - self.max_lag_seqs;
-        let skipped = resume_at - cursor;
-        progress.skipped_seqs += skipped;
-        tracing::warn!(
-            namespace = name,
-            cursor,
-            persisted,
-            skipped,
-            resume_at,
-            "finelog forwarder: backlog exceeds the lag cap; skipping ahead"
-        );
-        self.persist_cursor(name, resume_at);
-        resume_at
     }
 
     /// Up to [`FORWARD_BATCH_ROWS`] locally-written rows of `name` in `(cursor, persisted]`
@@ -895,7 +915,7 @@ struct Progress {
     /// Requests the hub accepted, across every namespace. Counted in batches, not rows.
     batches: u64,
     /// `seq` positions the forwarder passed over and will never send — evicted before
-    /// they shipped, dropped by the lag cap, or in a batch the hub permanently refused.
+    /// they shipped or in a batch the hub permanently refused.
     /// An upper bound on rows lost: some positions held rows the scan would have filtered
     /// out anyway.
     skipped_seqs: i64,

--- a/lib/finelog/rust/src/server/forwarding_tests.rs
+++ b/lib/finelog/rust/src/server/forwarding_tests.rs
@@ -185,6 +185,11 @@ async fn push(client: &LogServiceClient<TestTransport>, key: &str, lines: &[&str
 
 /// Register a generic string-keyed table and write `rows` durable rows into it.
 async fn write_id_rows(store: &Store, namespace: &str, rows: usize) {
+    let ids: Vec<String> = (0..rows).map(|row| row.to_string()).collect();
+    write_string_rows(store, namespace, ids).await;
+}
+
+async fn write_string_rows(store: &Store, namespace: &str, ids: Vec<String>) {
     let schema = Schema::new(
         vec![Column::new("id", ColumnType::COLUMN_TYPE_STRING, false)],
         "id",
@@ -192,18 +197,23 @@ async fn write_id_rows(store: &Store, namespace: &str, rows: usize) {
     store
         .register_table(namespace, schema, StoragePolicy::default())
         .unwrap();
-    let ids: Vec<String> = (0..rows).map(|row| row.to_string()).collect();
-    let batch = RecordBatch::try_new(
-        Arc::new(ArrowSchema::new(vec![Field::new(
-            "id",
-            DataType::Utf8,
-            false,
-        )])),
-        vec![Arc::new(StringArray::from(ids))],
-    )
-    .unwrap();
-    let ipc = encode_ipc(&batch.schema(), &[batch]).unwrap();
-    let (_, last_seq) = store.write_rows(namespace, &ipc, None).unwrap();
+    let arrow_schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        "id",
+        DataType::Utf8,
+        false,
+    )]));
+    let mut last_seq = -1;
+    for chunk in ids.chunks(20_000) {
+        let batch = RecordBatch::try_new(
+            Arc::clone(&arrow_schema),
+            vec![Arc::new(StringArray::from(
+                chunk.iter().map(String::as_str).collect::<Vec<_>>(),
+            ))],
+        )
+        .unwrap();
+        let ipc = encode_ipc(&batch.schema(), &[batch]).unwrap();
+        (_, last_seq) = store.write_rows(namespace, &ipc, None).unwrap();
+    }
     store
         .await_persisted(namespace, last_seq, Duration::from_secs(5))
         .await
@@ -719,9 +729,7 @@ async fn a_watermark_ahead_of_the_store_reseeds_at_the_tip() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn a_backlog_beyond_the_lag_cap_is_skipped_rather_than_drained() {
-    // The store keeps every row; the hub copy is best effort. A forwarder too far behind
-    // abandons the oldest part of the backlog and keeps the freshest `max_lag_seqs`.
+async fn a_backlog_beyond_the_warning_threshold_is_drained_without_loss() {
     let fx = Fixture::new("cap").await;
     push(
         &fx.source_client,
@@ -732,7 +740,7 @@ async fn a_backlog_beyond_the_lag_cap_is_skipped_rather_than_drained() {
     fx.forward_from_start(LOG_NAMESPACE_NAME);
 
     let mut forwarder = fx.forwarder(PRIV_A);
-    forwarder.max_lag_seqs = 2;
+    forwarder.lag_warning_seqs = 2;
     forward_until(
         forwarder,
         &fx.source,
@@ -745,10 +753,11 @@ async fn a_backlog_beyond_the_lag_cap_is_skipped_rather_than_drained() {
     assert_eq!(
         fx.hub_log_rows().await,
         vec![
+            ("/user/job/t".to_string(), "one".to_string()),
+            ("/user/job/t".to_string(), "two".to_string()),
             ("/user/job/t".to_string(), "three".to_string()),
             ("/user/job/t".to_string(), "four".to_string()),
-        ],
-        "the two oldest rows are dropped; the freshest two still ship"
+        ]
     );
 }
 
@@ -798,6 +807,31 @@ async fn a_dense_backlog_is_forwarded_in_one_read_batch() {
         fx.zstd_requests() - zstd_before,
         1,
         "the large WriteRows body is zstd encoded while the small registration stays identity"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn telemetry_sized_chunks_are_delivered_concurrently_without_loss() {
+    let fx = Fixture::new("concurrent-chunks").await;
+    write_string_rows(
+        &fx.source,
+        "telemetry",
+        vec!["x".repeat(450); FORWARD_BATCH_ROWS as usize],
+    )
+    .await;
+    fx.forward_from_start("telemetry");
+
+    fx.drain(PRIV_A, "telemetry").await;
+
+    let stats = fx.target_store().list_namespaces_with_stats().unwrap();
+    let telemetry = stats
+        .iter()
+        .find(|(name, _, _, _)| name == "telemetry")
+        .expect("the hub registered the telemetry namespace");
+    assert_eq!(telemetry.2.row_count, FORWARD_BATCH_ROWS);
+    assert!(
+        fx.target_requests.max_in_flight() >= 2,
+        "the two telemetry chunks must overlap at the hub's durable-ack boundary"
     );
 }
 

--- a/lib/finelog/rust/src/server/forwarding_tests.rs
+++ b/lib/finelog/rust/src/server/forwarding_tests.rs
@@ -507,7 +507,7 @@ fn chunk_by_bytes_shrinks_an_estimate_that_encodes_over_budget() {
 }
 
 #[test]
-fn one_telemetry_sized_read_turn_fits_two_write_requests() {
+fn one_telemetry_sized_read_turn_fits_one_parallel_wave() {
     let rows = FORWARD_BATCH_ROWS as usize;
     let row = "x".repeat(450);
     let batch = RecordBatch::try_new(
@@ -523,15 +523,15 @@ fn one_telemetry_sized_read_turn_fits_two_write_requests() {
 
     let chunks = chunk_by_bytes(&batch, &seqs, FORWARD_BATCH_BYTES).unwrap();
 
-    assert_eq!(
-        chunks.len(),
-        2,
+    assert!(
+        chunks.len() <= FORWARD_CHUNK_CONCURRENCY,
         "chunks: {:?}",
         chunks
             .iter()
             .map(|(ipc, seq)| (ipc.len(), seq))
             .collect::<Vec<_>>()
     );
+    assert!(chunks.len() > 1, "the fixture must exercise byte chunking");
     assert!(chunks
         .iter()
         .all(|(ipc, _)| ipc.len() <= FORWARD_BATCH_BYTES));

--- a/lib/finelog/rust/src/server/forwarding_tests.rs
+++ b/lib/finelog/rust/src/server/forwarding_tests.rs
@@ -26,6 +26,7 @@ use super::*;
 use crate::proto::finelog::logging::LogServiceClient;
 
 const SOURCE_CLUSTER: &str = "cw-test";
+const TELEMETRY_ROW_BYTES: usize = 450;
 
 fn jwt_policy(cluster: &str) -> AuthPolicy {
     AuthPolicy::parse(
@@ -509,7 +510,7 @@ fn chunk_by_bytes_shrinks_an_estimate_that_encodes_over_budget() {
 #[test]
 fn one_telemetry_sized_read_turn_fits_one_parallel_wave() {
     let rows = FORWARD_BATCH_ROWS as usize;
-    let row = "x".repeat(450);
+    let row = "x".repeat(TELEMETRY_ROW_BYTES);
     let batch = RecordBatch::try_new(
         Arc::new(ArrowSchema::new(vec![Field::new(
             "data",
@@ -816,7 +817,7 @@ async fn telemetry_sized_chunks_are_delivered_concurrently_without_loss() {
     write_string_rows(
         &fx.source,
         "telemetry",
-        vec!["x".repeat(450); FORWARD_BATCH_ROWS as usize],
+        vec!["x".repeat(TELEMETRY_ROW_BYTES); FORWARD_BATCH_ROWS as usize],
     )
     .await;
     fx.forward_from_start("telemetry");

--- a/lib/finelog/rust/src/server/test_support.rs
+++ b/lib/finelog/rust/src/server/test_support.rs
@@ -47,6 +47,8 @@ pub struct RequestStats {
 }
 
 impl RequestStats {
+    /// Record a POST entering the test server. `true` means the caller must invoke
+    /// [`Self::finish`] after the response completes.
     fn begin(&self, request: &axum::extract::Request) -> bool {
         if request.method() != axum::http::Method::POST {
             return false;

--- a/lib/finelog/rust/src/server/test_support.rs
+++ b/lib/finelog/rust/src/server/test_support.rs
@@ -42,12 +42,14 @@ pub type TestTransport = ServiceTransport<HyperClient<HttpConnector, ClientBody>
 pub struct RequestStats {
     total: AtomicUsize,
     zstd: AtomicUsize,
+    in_flight: AtomicUsize,
+    max_in_flight: AtomicUsize,
 }
 
 impl RequestStats {
-    fn observe(&self, request: &axum::extract::Request) {
+    fn begin(&self, request: &axum::extract::Request) -> bool {
         if request.method() != axum::http::Method::POST {
-            return;
+            return false;
         }
         self.total.fetch_add(1, Ordering::SeqCst);
         if request
@@ -57,6 +59,13 @@ impl RequestStats {
         {
             self.zstd.fetch_add(1, Ordering::SeqCst);
         }
+        let in_flight = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_in_flight.fetch_max(in_flight, Ordering::SeqCst);
+        true
+    }
+
+    fn finish(&self) {
+        self.in_flight.fetch_sub(1, Ordering::SeqCst);
     }
 
     pub fn total(&self) -> usize {
@@ -65,6 +74,10 @@ impl RequestStats {
 
     pub fn zstd_requests(&self) -> usize {
         self.zstd.load(Ordering::SeqCst)
+    }
+
+    pub fn max_in_flight(&self) -> usize {
+        self.max_in_flight.load(Ordering::SeqCst)
     }
 }
 
@@ -114,8 +127,12 @@ pub async fn serve(store: Arc<Store>, policy: AuthPolicy) -> (SocketAddr, Arc<Re
             move |req: axum::extract::Request, next: axum::middleware::Next| {
                 let counted = Arc::clone(&counted);
                 async move {
-                    counted.observe(&req);
-                    next.run(req).await
+                    let observed = counted.begin(&req);
+                    let response = next.run(req).await;
+                    if observed {
+                        counted.finish();
+                    }
+                    response
                 }
             },
         ),
@@ -144,16 +161,20 @@ pub async fn serve_rejecting() -> (SocketAddr, Arc<RequestStats>) {
         move |request: axum::extract::Request| {
             let counted = Arc::clone(&counted);
             async move {
-                counted.observe(&request);
+                let observed = counted.begin(&request);
                 let error = connectrpc::ConnectError::new(
                     connectrpc::ErrorCode::InvalidArgument,
                     "empty key",
                 );
-                (
+                let response = (
                     axum::http::StatusCode::BAD_REQUEST,
                     [(axum::http::header::CONTENT_TYPE, "application/json")],
                     error.to_json(),
-                )
+                );
+                if observed {
+                    counted.finish();
+                }
+                response
             }
         },
     ));


### PR DESCRIPTION
Drain every locally retained forwarding backlog instead of advancing its cursor after 2,000,000 sequence positions. On USE08, the old sender skipped 28,976,562 positions in its first 15 minutes under roughly 39,300 telemetry rows/s even though the hub stayed healthy.

Allow up to eight non-log Arrow chunks from a 200,000-row turn to share the destination flush window. A live bounded scan took 3.71s for 50,000 rows and 2.77s for 200,000 because provider construction and planning dominated. Log chunks stay serial and namespace turns stay fair.

A USE08 canary forwarded 712 batches with zero skipped positions in its first five minutes. Its inherited telemetry gap fell from 473s to 357s over the next six minutes while new rows continued arriving, implying roughly 52,000 rows/s of forwarding capacity. All three CoreWeave Finelogs now run the same clean immutable image digest used by the canary.

Incident: https://echo.oa.dev/wiki/83