### PR TITLE
[levanter] Limit tracker telemetry to process zero

### DIFF
--- a/lib/levanter/src/levanter/tracker/telemetry.py
+++ b/lib/levanter/src/levanter/tracker/telemetry.py
@@ -157,13 +157,16 @@ class TelemetryTracker(Tracker):
 
     name: str = "telemetry"
 
-    def __init__(self) -> None:
+    def __init__(self, *, publish_tracker_metrics: bool = True) -> None:
+        self._publish_tracker_metrics = publish_tracker_metrics
         self._nccl_ras_probe = _start_nccl_ras_probe()
         _set("progress_time_seconds", 0)
         set_training_phase(TrainingPhase.INITIALIZING)
         _HEARTBEAT.start()
 
     def _publish(self, metrics: Mapping[str, object]) -> None:
+        if not self._publish_tracker_metrics:
+            return
         for key, value in metrics.items():
             if isinstance(value, SummaryStats):
                 self._publish_summary(key, value)
@@ -241,4 +244,4 @@ class TelemetryConfig(TrackerConfig):
             root_run_uid=run_id,
             process_index=process_index,
         )
-        return TelemetryTracker()
+        return TelemetryTracker(publish_tracker_metrics=process_index == 0)

--- a/lib/levanter/tests/test_telemetry_tracker.py
+++ b/lib/levanter/tests/test_telemetry_tracker.py
@@ -19,7 +19,7 @@ from levanter.callbacks import ProgressEvent
 from levanter.callbacks.progress_watchdog import ProgressTimeout
 from levanter.tracker import BackgroundTracker, current_tracker, telemetry as tracker_telemetry
 from levanter.tracker.histogram import SummaryStats
-from levanter.tracker.telemetry import TelemetryTracker, TrainingPhase
+from levanter.tracker.telemetry import TelemetryConfig, TelemetryTracker, TrainingPhase
 
 
 @pytest.fixture
@@ -113,6 +113,22 @@ def test_training_progress_and_phase_are_current_snapshots(exported, monkeypatch
     values = _values(exported.wait_for(7))
     assert values["progress_time_seconds"] == 1234.5
     assert values["phase"] == TrainingPhase.FINISHED
+
+
+def test_nonprimary_process_publishes_progress_but_not_replicated_tracker_metrics(exported, monkeypatch):
+    monkeypatch.setattr(tracker_telemetry.jax, "process_index", lambda: 1)
+    monkeypatch.setattr(tracker_telemetry.runtime_telemetry, "configure", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("levanter.tracker.telemetry.time", lambda: 1234.5)
+    tracker = TelemetryConfig().init("run-42")
+
+    tracker.log({"train/loss": 1.25, "throughput": 7.0}, step=3)
+    telemetry.shutdown()
+
+    values = _values(exported.records)
+    assert values["step"] == 3.0
+    assert values["progress_time_seconds"] == 1234.5
+    assert "train_loss" not in values
+    assert "throughput" not in values
 
 
 @pytest.fixture


### PR DESCRIPTION
Publish generic TelemetryTracker metrics only from JAX process 0, matching W&B process scope. Every process continues to report step, progress_time_seconds, training phase, and stall and NCCL diagnostics, preserving per-process liveness.

Fifteen stale USE08 MoE runs emitted roughly 39,300 Levanter telemetry rows/s; four-process replication multiplied every tracker metric. Current Levanter code already reduces each router histogram to seven Finelog moments while W&B keeps its full bucket shape in #7868. This removes the remaining fourfold generic-metric replication for newly submitted runs. Active runs keep their bundled old source until they are resubmitted.

Incident: https://echo.oa.dev/wiki/83