### PR TITLE
Bump NCCL to 2.30.7 to fix the silent GB200 collective wedge

### DIFF
--- a/lib/iris/tests/cluster/runtime/test_cuda_staging.py
+++ b/lib/iris/tests/cluster/runtime/test_cuda_staging.py
@@ -20,7 +20,10 @@ from iris.cluster.types import EnvironmentSpec
 
 _CUDA_13_TEST_PACKAGES = (
     ("nvidia-cudnn-cu13", "9.19.0.56", "nvidia/cudnn/lib/libcudnn.so.9"),
-    ("nvidia-nccl-cu13", "2.28.9", "nvidia/nccl/lib/libnccl.so.2"),
+    # Must match the locked nvidia-nccl-cu13 version: the repo-level
+    # override-dependencies pin rewrites the reinstall requirement, and the
+    # test's offline wheelhouse only holds the fixture version.
+    ("nvidia-nccl-cu13", "2.30.7", "nvidia/nccl/lib/libnccl.so.2"),
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,14 @@ constraint-dependencies = [
     "opentelemetry-semantic-conventions>=0.1b0",
 ]
 override-dependencies = [
+    # NCCL < 2.29.3 silently leaks proxy-op slots on aarch64 (weak-CAS spurious
+    # failure treated as success in the freeOps return path) and deadlocks GB200
+    # jobs with no error once a rank's slot pool runs dry; fixed upstream in
+    # v2.29.3-1 (NVIDIA/nccl@25368a7f78ba), see #7344. An override (not a
+    # constraint) because torch 2.11.0 hard-pins nvidia-nccl-cu13==2.28.9 on
+    # Linux; a constraint conflicts with that pin and uv drops torch's whole
+    # CUDA dependency set instead of failing.
+    "nvidia-nccl-cu13==2.30.7 ; sys_platform == 'linux'",
     "omegaconf>=2.4.0.dev4",
     "aiofiles>=24.1.0",
     "anthropic>=0.71.0",

--- a/uv.lock
+++ b/uv.lock
@@ -376,6 +376,7 @@ overrides = [
     { name = "multipart", specifier = ">=1.3.1" },
     { name = "nltk", specifier = ">=3.9.4" },
     { name = "notebook", specifier = ">=7.5.6" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'", specifier = "==2.30.7" },
     { name = "omegaconf", specifier = ">=2.4.0.dev4" },
     { name = "orjson", specifier = ">=3.11.9" },
     { name = "pillow", specifier = ">=12.2.0" },
@@ -7678,11 +7679,11 @@ wheels = [
 
 [[package]]
 name = "nvidia-nccl-cu13"
-version = "2.28.9"
+version = "2.30.7"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/55/1920646a2e43ffd4fc958536b276197ed740e9e0c54105b4bb3521591fc7/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:01c873ba1626b54caa12272ed228dc5b2781545e0ae8ba3f432a8ef1c6d78643", size = 196561677, upload-time = "2025-11-18T05:49:03.45Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/b4/878fefaad5b2bcc6fcf8d474a25e3e3774bc5133e4b58adff4d0bca238bc/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:e4553a30f34195f3fa1da02a6da3d6337d28f2003943aa0a3d247bbc25fefc42", size = 196493177, upload-time = "2025-11-18T05:49:17.677Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/21/a73174c6157101bdf1ffc22b517f76ff0082613989dd9bc8f43e8034caac/nvidia_nccl_cu13-2.30.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:ca786ffa5a647c75d4d1f5cc72a6c4f537947e2ba8823d7c8aaf768e7a7b9f77", size = 215983881, upload-time = "2026-06-09T03:23:15.633Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/34/c500f90c7ae641b8e0f98965b36b8a7ac79cc8b296e8d251fe3eb592ee54/nvidia_nccl_cu13-2.30.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:cefa7fdb9710efd0f39c5f1be1d61ff6fc9a996c451265bd7fbdcf9455ed4b50", size = 215965170, upload-time = "2026-06-09T03:23:39.73Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bump nvidia-nccl-cu13 from 2.28.9 to 2.30.7 to fix the silent GB200 collective wedge of
#7344.

NCCL before 2.29.3 leaks proxy-op slots on aarch64: the slot-return path in
`ncclProxyGetPostedOps` publishes freed slots with a weak compare-exchange whose retry
condition checks the observed value instead of the CAS result, so a spurious LL/SC failure
silently orphans the whole batch (the compiled 2.28.9 wheel never tests the stlxr success
flag). When a rank's 2048-slot pool partition runs dry, its launcher spins forever in
`ncclLocalOpAppend`, its progress thread sleeps, and all ranks sit at 100% util with no
error, no timeout, and no counter anywhere. NVIDIA fixed the loop in v2.29.3-1 and the
release notes name the bug: "Fixed CAS usage in case of weak failure which was causing a
hang on ARM. The issue affected NCCL when compiled with gcc versions prior to 10."

Receipts, on the 2-rack minimal reproducer of `experiments/grug/recovery/` (128 GB200s,
cluster cw-us-east-08a):

| NCCL | result |
|---|---|
| 2.28.9 (stock lock) | wedged 7/7 trials between step 0 and 347 (~8-28 s) |
| 2.30.7 (this lock) | 20000/20000 steps clean (`minrepro-nccl2307-20260807-011334`), then 5000/5000 clean (`minrepro-fixverify-20260807-024237`) |

Production-workload verification (`moe_hero_fsdp`, stock launcher, both directions,
in-pod provenance): 2 racks cannot demonstrate the wedge at all — stock 2.28.9 ran 1150
steps / 6 h clean (`hero2r-ctl2289-20260807-034112`) — so the production evidence for the
pin is the reproducer causality above plus clean pinned runs at both scales: 845 steps at
2 racks from this tree (`hero2r-fix2307-20260807-094312`) and three 8-rack arms totalling
771 steps past the documented step-17-183 window (#8029). Full verdict and caveats:
https://github.com/marin-community/marin/issues/7344#issuecomment-5218140612

Runtime provenance was verified in-pod for both directions: the mapped `libnccl.so.2`
banner reads `NCCL version 2.30.7`, which also covers the coexisting
`nvidia-nccl-cu12==2.28.9` torch dependency that can shadow the same install path.

The pin is an override rather than a constraint because torch 2.11.0 hard-pins
`nvidia-nccl-cu13==2.28.9` on Linux; a constraint conflicts with that pin and uv silently
drops torch's entire CUDA dependency set instead of failing. The override is scoped to
`sys_platform == 'linux'` so non-Linux resolution is unchanged, and the lock moves exactly
one package. Torch loads its NCCL through the same shared namespace and NCCL keeps ABI
compatibility across minor versions; torch performs no collectives in our training jobs.

The diff also moves the cuda-staging test fixture to 2.30.7. That test exercises the
setup script's restore path against an offline wheelhouse holding a fake wheel of the
fixture version, and `uv pip install` applies this repo's `override-dependencies`, so the
override rewrites the reinstall requirement to 2.30.7 and resolution fails unless the
fixture matches the lock. On real pods the rewrite is a no-op because the installed
version equals the override. With that fix, `unit (iris)` passes. The remaining red
checks are pre-existing: `unit (marin)`'s
`test_artifact_manifest_requires_complete_release_pair` fails identically on main
(`839e5e9e1`); `iris-e2e-smoke`'s `test_dashboard_constraints` hit the same 30 s timeout
on the last two main runs where the path filter let it run (2026-08-07 00:25 and 23:25) —
this PR merely triggers the job by touching the lock; and `cloud-smoke-test`
(iris-smoke-gcp) failed 3 of its last 4 runs across other branches on GCP worker-health
timeouts.

One caveat: runs `t1nccl` (2026-08-05, 10 racks) and `ngc-8rack` wedged on stacks that
ship 2.30.7, so a second, rarer mechanism may exist at hero scale. This bump removes the
mechanism proven at 2 racks; #7344 stays open for the rest.

Root-cause evidence chain (live-wedge lldb captures, pool censuses, disassembly), and the
forensics scripts (branch `mcwitt/7344-minimal-repro`, `experiments/grug/wedge_forensics/`):
https://github.com/marin-community/marin/issues/7344#issuecomment-5211016784

Part of #7344
