### PR TITLE
Keep the grug hero JAX compilation cache on node-local NVMe

### DIFF
--- a/experiments/grug/moe_hero_fsdp/train.py
+++ b/experiments/grug/moe_hero_fsdp/train.py
@@ -18,6 +18,7 @@ import optax
 from fray.cluster import ResourceConfig
 from haliax import Axis
 from haliax.partitioning import set_mesh
+from iris.cluster.runtime.env import UV_CACHE_PATH
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jax.tree_util import register_dataclass
@@ -51,9 +52,25 @@ from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
 
 logger = logging.getLogger(__name__)
 
+# Iris backs this mount with node-local NVMe through a hostPath, so entries outlive the
+# pod and a rerun on the same node skips XLA compilation entirely. It also replaces the
+# object-store default from `configure_jax_compilation_cache`, which forces JAX to disable
+# XLA's per-fusion autotune cache: XLA reads that directory from C++, where `gs://`-style
+# URLs are not a supported filesystem scheme.
+HERO_FSDP_COMPILATION_CACHE_DIR = f"{UV_CACHE_PATH}/jax-compilation-cache"
+# Nothing prunes the node cache directory, and every distinct step shape, PGLE pass, and
+# watch variant adds an entry. Bound it so a long series of runs cannot fill the NVMe.
+HERO_FSDP_COMPILATION_CACHE_MAX_BYTES = 100 * 1024**3
+
 HERO_FSDP_RUNTIME_ENV = {
     "JAX_ENABLE_PGLE": "1",
     "XLA_PYTHON_CLIENT_ALLOCATOR": "cuda_async",
+}
+# Applied only when unset: JAX_COMPILATION_CACHE_DIR is the documented way to redirect the
+# cache, so a value chosen for a specific run has to survive.
+HERO_FSDP_COMPILATION_CACHE_ENV = {
+    "JAX_COMPILATION_CACHE_DIR": HERO_FSDP_COMPILATION_CACHE_DIR,
+    "JAX_COMPILATION_CACHE_MAX_SIZE": str(HERO_FSDP_COMPILATION_CACHE_MAX_BYTES),
 }
 # TODO(https://github.com/marin-community/marin/issues/5675): Re-enable XLA GPU
 # command buffers after the CUDA graph failure is fixed.
@@ -62,6 +79,8 @@ XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG = "--xla_gpu_enable_command_buffer="
 
 def _apply_hero_fsdp_runtime_defaults() -> None:
     os.environ.update(HERO_FSDP_RUNTIME_ENV)
+    for name, value in HERO_FSDP_COMPILATION_CACHE_ENV.items():
+        os.environ.setdefault(name, value)
     xla_flags = os.environ.get("XLA_FLAGS", "")
     command_buffer_flag_name = XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG.partition("=")[0]
     if any(flag.partition("=")[0] == command_buffer_flag_name for flag in xla_flags.split()):


### PR DESCRIPTION
The hero FSDP run inherited the Iris default compilation cache, which points at the region-local object store. Two costs follow from that. Every process fetches the serialized executable over the network on a hit, and on a miss XLA recompiles from scratch, because `configure_jax_compilation_cache` disables XLA's per-fusion autotune sub-cache whenever the cache directory is a URL: JAX derives that path from the same directory and hands it to XLA's C++ filesystem layer, which has no `gs://` or `s3://` scheme.

Point the run at a directory under the Iris cache mount instead. Iris backs that mount with a hostPath on node-local NVMe, so entries outlive the pod and a rerun on the same node skips XLA compilation entirely. A local POSIX path also leaves the autotune sub-cache enabled, which matters on GB200 where Triton autotuning is a large share of compile time. All four CoreWeave clusters already set `cache_dir: /mnt/local/iris-cache`.

Nothing prunes the node directory, so the run also sets a 100 GiB ceiling and lets JAX's LRU cache evict. Both settings apply only when unset, since `JAX_COMPILATION_CACHE_DIR` is the documented way to redirect the cache for a particular run.

This trades cross-node sharing for node locality: on a cold reservation every node now compiles once rather than one node compiling and the rest loading the result. The win is on reruns against a warm reservation, which is the case that motivated the change.

`JAX_SHARE_BINARY_BETWEEN_HOSTS` is deliberately not set alongside it. In `compile_or_get_cached` the process-local cache read happens before the share path, so once one node's cache is warm and another's is not, the warm process returns without publishing to the coordinator while the cold ones block on `blocking_key_value_get_bytes` until the 20-minute share timeout. That asymmetry cannot arise with a shared object-store cache, which is why the combination is safe there and not here.

Verified that `configure_jax_compilation_cache` defers to the preset variable, that `jax_persistent_cache_enable_xla_caches` stays at `xla_gpu_per_fusion_autotune_cache_dir` rather than being disabled, that the cache initializes as an `LRUCache` with eviction enabled at the configured ceiling, and that a jitted call writes an entry. Also confirmed the default applies when the variable is unset and an explicit value survives. Lint, `pyrefly`, and the grug variant and hero FSDP suites pass.
