### PR TITLE
[grafana] Route every Slack alert through the bridge into #marin-alerts

### DIFF
--- a/infra/grafana/Pulumi.marin-grafana.yaml
+++ b/infra/grafana/Pulumi.marin-grafana.yaml
@@ -21,10 +21,10 @@ config:
   # service account before the Loom stack binds it. Re-enable after Loom is up.
   marin-grafana:loom_alerts: "true"
   # Slack channel id (`C…`, from the channel's "Copy link") the bridge announces
-  # critical alerts in, and where @marinbot answers them. Required whenever
+  # critical alerts in, and where @russbot answers them. Required whenever
   # loom_alerts is true, and left unset here on purpose so a deploy that has not
   # been told the channel fails in `pulumi up` rather than at container boot:
   #   pulumi config set marin-grafana:slack_alerts_channel C0123ABCD
-  # @marinbot must be invited to it. See README "Alerting".
+  # @russbot must be invited to it. See README "Alerting".
 secretsprovider: gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
 encryptedkey: CiQAKk3j6Q+ANb/lWOlKPlnYfjnVwqsddavq2mCxtpbL2qM4LDkSSQCdtF6i23aOY/4tztuXbQxjEf7zLiHzOSRS37IKAQ0lwPtGPtsU+eHwrNMTw6rqY4wLRoKzPpdTOWDtzYkIgSixmuEPz14nxCE=

--- a/infra/grafana/Pulumi.marin-grafana.yaml
+++ b/infra/grafana/Pulumi.marin-grafana.yaml
@@ -20,11 +20,11 @@ config:
   # Set false only for the first deployment in a new project: that creates the
   # service account before the Loom stack binds it. Re-enable after Loom is up.
   marin-grafana:loom_alerts: "true"
-  # Slack channel id (`C…`, from the channel's "Copy link") the bridge announces
-  # critical alerts in, and where @russbot answers them. Required whenever
-  # loom_alerts is true, and left unset here on purpose so a deploy that has not
-  # been told the channel fails in `pulumi up` rather than at container boot:
-  #   pulumi config set marin-grafana:slack_alerts_channel C0123ABCD
-  # @russbot must be invited to it. See README "Alerting".
+  # The channel id (`C…`, from the channel's "Copy link") the bridge announces
+  # every alert in, and where @russbot answers the critical ones. This is
+  # #marin-alerts. Required whenever loom_alerts is true, so a deploy that has
+  # not been told the channel fails in `pulumi up` rather than at container boot.
+  # @russbot must be a member. See README "Alerting".
+  marin-grafana:slack_alerts_channel: C0BN20081CH
 secretsprovider: gcpkms://projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
 encryptedkey: CiQAKk3j6Q+ANb/lWOlKPlnYfjnVwqsddavq2mCxtpbL2qM4LDkSSQCdtF6i23aOY/4tztuXbQxjEf7zLiHzOSRS37IKAQ0lwPtGPtsU+eHwrNMTw6rqY4wLRoKzPpdTOWDtzYkIgSixmuEPz14nxCE=

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -282,14 +282,21 @@ silently, and critical alerts still reach Slack and Loom. After changing contact
 points or their credentials, send a test notification to all receivers (Alerting
 → Contact points → Test) rather than trusting config presence.
 
-Slack is deliberately *not* a Grafana receiver on `ops-critical`. A Slack
-incoming webhook answers with a bare `ok` and never reveals the message
-timestamp, so an alert Grafana posts cannot be joined by anything else — and the
-timestamp is exactly what Loom needs to route the thread to the triage session.
-The bridge posts instead, which also means one message per alert rather than two
-side by side. `ops-slack`, the fallback for malformed or unlabeled alerts, has no
-Loom leg and keeps Grafana's own Slack rendering through
-`$SLACK_ALERTS_WEBHOOK`.
+Slack is deliberately *not* a Grafana receiver at all. A Slack incoming webhook
+answers with a bare `ok` and never reveals the message timestamp, so an alert
+Grafana posts cannot be joined by anything else — and the timestamp is exactly
+what Loom needs to route the thread to the triage session. The bridge posts
+instead, which also means one message per alert rather than two side by side.
+
+Both receivers post through the bridge, so every alert lands in one channel with
+one credential and one rendering, and alert text is escaped the same way either
+way. They differ only in what follows: `ops-critical` opens a Loom triage run on
+the thread it announced, while `ops-slack` — the fallback for malformed or
+unlabeled alerts — announces and stops, because an alert carrying no severity to
+route on carries no incident to triage. The tradeoff is that a fallback
+notification does not reach Slack while the bridge is down; email remains an
+independent path for critical alerts, and the fallback sees almost no traffic
+because every alert rule sets a severity.
 
 The Loom receiver posts to the bridge on `127.0.0.1`; it is not exposed through
 Grafana or IAP. For each firing group the bridge first posts the alert to
@@ -340,12 +347,11 @@ the identity-to-profile binding.
 | `GITHUB_APP_PRIVATE_KEY` | `marin-grafana-github-app-private-key` | ferry/build/nightly panels |
 | `GF_DATABASE_PASSWORD` | `cloudsql-grafana-password` | Grafana's Postgres state (see Deploy) |
 | `CW_READ_TOKEN` | `marin-grafana-cw-read-token` | k8s source (all CW clusters) |
-| `SLACK_ALERTS_WEBHOOK` | `marin-grafana-slack-webhook` | the `ops-slack` fallback contact point |
 | `SLACK_ALERTS_BOT_TOKEN` | `marin-grafana-slack-bot-token` | the bridge's alert announcements |
 | `GF_SMTP_PASSWORD` | `marin-grafana-smtp-credentials` | Grafana SMTP (email alerts, optional) |
 
-`GF_DATABASE_PASSWORD`, `CW_READ_TOKEN`, `SLACK_ALERTS_WEBHOOK`, and
-`SLACK_ALERTS_BOT_TOKEN` must exist before a deploy — Cloud Run fails to start a revision that references a missing
+`GF_DATABASE_PASSWORD`, `CW_READ_TOKEN`, and `SLACK_ALERTS_BOT_TOKEN` must exist
+before a deploy — Cloud Run fails to start a revision that references a missing
 secret. `GF_SMTP_PASSWORD` and `GITHUB_APP_PRIVATE_KEY` are optional: `__main__.py`
 probes for each and wires it only when the secret exists (the GitHub App also
 needs its `github_app_client_id` config). Unset, the GitHub panels deploy
@@ -375,33 +381,34 @@ Rotation is overlap-safe:
 5. Remove the old username from the three configs and update the stacks again.
    Then disable the old secret version and revoke the old CoreWeave token.
 
-The same Secret Manager overlap pattern applies to the Slack webhook and SMTP
-password: add a version, redeploy, then retire the old credential.
+The same Secret Manager overlap pattern applies to the Slack bot token and SMTP
+password: add a version, redeploy, then retire the old credential. Write the
+payload with `printf '%s'`, not `echo` — a trailing newline reaches the
+`Authorization` header, though the bridge strips it defensively.
 
 Creating the secrets:
 
 1. CoreWeave console → API access → new token (e.g. `grafana-observer`) with only the
    `read` role, then
    `echo -n "<token>" | gcloud secrets create marin-grafana-cw-read-token --project=hai-gcp-models --data-file=-`
-2. Slack → incoming webhook for `#marin-eng`, then
-   `echo -n "https://hooks.slack.com/..." | gcloud secrets create marin-grafana-slack-webhook --project=hai-gcp-models --data-file=-`
-3. The `@russbot` bot-user token (`xoxb-…`) the bridge announces alerts with —
+2. The `@russbot` bot-user token (`xoxb-…`) the bridge announces alerts with —
    the same Slack app Loom posts as, so the announcement and Loom's replies come
    from one identity. Reuse the token from Loom's `LOOM_DOTENV`
    (`LOOM_SLACK_BOT_TOKEN`; see `infra/loom`), then
-   `echo -n "xoxb-..." | gcloud secrets create marin-grafana-slack-bot-token --project=hai-gcp-models --data-file=-`
-4. Apply the `marin` GCP stack, which grants the deploy account IAM management on
+   `printf '%s' "xoxb-..." | gcloud secrets create marin-grafana-slack-bot-token --project=hai-gcp-models --data-file=-`
+3. Apply the `marin` GCP stack, which grants the deploy account IAM management on
    that secret and the runtime account access to it (declared in
    `infra/pulumi/src/iac/gcp/iam_data.yaml`). Without it the grafana deploy fails
    granting the runtime account access, even once the value exists.
-5. Point the bridge at the channel and make sure the bot is in it:
-   `pulumi config set marin-grafana:slack_alerts_channel <id>` using the channel
-   id from `#marin-eng` → Copy link (`C…`), and `/invite @russbot` there.
-   `pulumi up` fails naming the missing key if this is skipped.
-6. (optional, enables email) Gmail app password for grafana@openathena.ai, then
-   `echo -n "<app-password>" | gcloud secrets create marin-grafana-smtp-credentials --project=hai-gcp-models --data-file=-`
-7. Send a test notification to `ops-critical` and confirm email arrives, one alert
-   message lands in the channel, and its thread gains a triage-session link.
+4. Confirm `slack_alerts_channel` names the channel you want and that `@russbot`
+   is in it. It is `#marin-alerts` (`C0BN20081CH`); to move it, take the id from
+   the channel's Copy link and `/invite @russbot` there. `pulumi up` fails naming
+   the key if it is ever unset.
+5. (optional, enables email) Gmail app password for grafana@openathena.ai, then
+   `printf '%s' "<app-password>" | gcloud secrets create marin-grafana-smtp-credentials --project=hai-gcp-models --data-file=-`
+6. Send a test notification to `ops-critical` and confirm email arrives, one alert
+   message lands in the channel, and its thread gains a triage-session link. Test
+   `ops-slack` too: it should post one message and no session link.
 
 ## Develop
 
@@ -411,12 +418,13 @@ cd marin-infra-panel
 npm ci
 npm run typecheck && npm run lint && npm run test:ci && npm run build
 docker build -t marin-grafana .
-docker run --rm -p 3000:8080 -e PORT=8080 -e SLACK_ALERTS_WEBHOOK=https://example.invalid marin-grafana
+docker run --rm -p 3000:8080 -e PORT=8080 marin-grafana
 # → http://localhost:3000 (without an IAP identity header, anonymous Viewer; panels need VPC access to finelog)
 ```
 
-`SLACK_ALERTS_WEBHOOK` has to be set to something: the provisioned contact point
-declares a Slack receiver, and Grafana refuses to start when its URL is empty.
+No alerting credentials are needed to start: both contact points are loopback
+webhooks, so Grafana boots without them and the bridge answers 503 on the alert
+routes until `LOOM_ALERT_URL` and the Slack settings are present.
 
 Panels only render against the real VPC: querying needs credentials that list the
 finelog VMs and a network path to them. Locally you get Grafana, the provisioned

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -335,12 +335,12 @@ the caller and verifier cannot drift through duplicated configuration.
 All secrets live in Secret Manager, hand-placed, and reach the container as env
 vars via the `CloudRunService` `secrets` field; the values never enter Pulumi or
 git. The deploy account is fail-closed on secret creation, so the program only
-references secrets — each must exist and be listed in the `infra/permissions`
-allowlist for the deploy account to bind IAM on it.
+references secrets — each must exist and be declared in
+`infra/pulumi/src/iac/gcp/iam_data.yaml` for the deploy account to bind IAM on it.
 
-Loom alert delivery does not add a secret. The bridge authenticates with the
-Cloud Run service account and short-lived Google/Loom tokens, while Pulumi owns
-the identity-to-profile binding.
+Loom itself needs no secret: the bridge authenticates with the Cloud Run service
+account and short-lived Google/Loom tokens, and Pulumi owns the
+identity-to-profile binding. The Slack bot token is the one alerting credential.
 
 | Env var | Secret | Feeds |
 |---|---|---|
@@ -530,8 +530,7 @@ so the merge-triggered deploy never blocks. The client id is already set, so
 enabling auth is one step (plus its permissions grant):
 
 ```bash
-# Its grants are already declared in infra/pulumi/src/iac/gcp/iam_data.yaml
-# (infra/permissions, which this used to name, is retired), so:
+# Its grants are declared in infra/pulumi/src/iac/gcp/iam_data.yaml, so:
 gcloud secrets create marin-grafana-github-app-private-key \
   --project=hai-gcp-models --data-file=key.pem
 ```

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -298,7 +298,7 @@ timestamp. It then asks the Cloud Run metadata server for a Google-signed
 identity token for `https://loom.oa.dev`, exchanges it for a short-lived `ops`
 Loom token, and creates an idempotent run for `marin-community/marin` on the
 `operator` channel, naming that thread. Loom routes the thread to the triage
-session, so the session answers in the thread and an `@marinbot` reply there
+session, so the session answers in the thread and an `@russbot` reply there
 reaches it instead of launching a second session — see [Loom's
 slack-trigger docs](https://github.com/marin-community/loom/blob/main/docs/slack-trigger.md).
 The session link is threaded under the announcement.
@@ -385,7 +385,7 @@ Creating the secrets:
    `echo -n "<token>" | gcloud secrets create marin-grafana-cw-read-token --project=hai-gcp-models --data-file=-`
 2. Slack → incoming webhook for `#marin-eng`, then
    `echo -n "https://hooks.slack.com/..." | gcloud secrets create marin-grafana-slack-webhook --project=hai-gcp-models --data-file=-`
-3. The `@marinbot` bot-user token (`xoxb-…`) the bridge announces alerts with —
+3. The `@russbot` bot-user token (`xoxb-…`) the bridge announces alerts with —
    the same Slack app Loom posts as, so the announcement and Loom's replies come
    from one identity. Reuse the token from Loom's `LOOM_DOTENV`
    (`LOOM_SLACK_BOT_TOKEN`; see `infra/loom`), then
@@ -396,7 +396,7 @@ Creating the secrets:
    granting the runtime account access, even once the value exists.
 5. Point the bridge at the channel and make sure the bot is in it:
    `pulumi config set marin-grafana:slack_alerts_channel <id>` using the channel
-   id from `#marin-eng` → Copy link (`C…`), and `/invite @marinbot` there.
+   id from `#marin-eng` → Copy link (`C…`), and `/invite @russbot` there.
    `pulumi up` fails naming the missing key if this is skipped.
 6. (optional, enables email) Gmail app password for grafana@openathena.ai, then
    `echo -n "<app-password>" | gcloud secrets create marin-grafana-smtp-credentials --project=hai-gcp-models --data-file=-`

--- a/infra/grafana/__main__.py
+++ b/infra/grafana/__main__.py
@@ -120,7 +120,7 @@ def main() -> None:
         # The bridge is the only thing that announces critical alerts, so neither
         # the channel nor the token is optional the way SMTP is: without them the
         # container refuses to boot rather than dropping alerting silently. The
-        # channel is a Slack id (`C…`) and @marinbot must be a member of it.
+        # channel is a Slack id (`C…`) and @russbot must be a member of it.
         slack_alerts_channel = config.require("slack_alerts_channel")
         env["SLACK_ALERTS_CHANNEL"] = slack_alerts_channel
         secrets.append(SecretEnv(name="SLACK_ALERTS_BOT_TOKEN", secret=SLACK_BOT_TOKEN_SECRET))

--- a/infra/grafana/__main__.py
+++ b/infra/grafana/__main__.py
@@ -33,9 +33,9 @@ LOOM_STACK = "organization/marin-loom/marin-loom"
 LOOM_WORKLOAD = "grafana-alerts"
 LOOM_ALERT_REPOSITORY = "marin-community/marin"
 # Secret Manager secret holding the Slack bot token the bridge announces alerts
-# with. A bot token rather than the existing incoming webhook because only
-# chat.postMessage returns the message timestamp, and that timestamp is the thread
-# Loom routes to the triage session. Hand-placed like the other runtime secrets.
+# with. A bot token rather than an incoming webhook because only chat.postMessage
+# returns the message timestamp, and that timestamp is the thread Loom routes to
+# the triage session. Hand-placed like the other runtime secrets.
 SLACK_BOT_TOKEN_SECRET = "marin-grafana-slack-bot-token"
 
 # The cloudsql stack (infra/cloudsql) publishes the marin-metadata connection name that backs
@@ -57,7 +57,7 @@ SMTP_SECRET = "marin-grafana-smtp-credentials"
 # bridge mints short-lived installation tokens from it (github_app.py), so nothing
 # long-lived expires under the GitHub panels. Hand-placed like the other runtime
 # secrets — the Cloud Run deploy account is fail-closed on secret creation — and
-# allowlisted for IAM binding in infra/permissions.
+# declared for IAM binding in infra/pulumi/src/iac/gcp/iam_data.yaml.
 GITHUB_APP_PRIVATE_KEY_SECRET = "marin-grafana-github-app-private-key"
 
 
@@ -134,7 +134,7 @@ def main() -> None:
     # not secret and rides stack config. Optional like SMTP: unset, the panels deploy
     # unauthenticated (build panel shows no data), so the merge deploy never blocks.
     #   gcloud secrets create marin-grafana-github-app-private-key \
-    #     --project=hai-gcp-models --data-file=key.pem   # (then allowlist in infra/permissions)
+    #     --project=hai-gcp-models --data-file=key.pem   # (grants live in iam_data.yaml)
     #   pulumi config set marin-grafana:github_app_client_id <client-id>
     github_app_client_id = config.get("github_app_client_id")
     if github_app_client_id and secret_exists(provider, GITHUB_APP_PRIVATE_KEY_SECRET):

--- a/infra/grafana/__main__.py
+++ b/infra/grafana/__main__.py
@@ -93,13 +93,11 @@ def main() -> None:
     # Secret values stay hand-placed in Secret Manager; the component only grants the
     # runtime service account access. CW_READ_TOKEN is the CoreWeave read-role token
     # behind the k8s source; GF_DATABASE_PASSWORD is the grafana Postgres user's
-    # password; SLACK_ALERTS_WEBHOOK and GF_SMTP_PASSWORD feed the provisioned
-    # alerting contact points. GF_SMTP_PASSWORD and the GitHub App key are appended
-    # below only when present.
+    # password. GF_SMTP_PASSWORD, the GitHub App key, and the Slack bot token are
+    # appended below only when their feature is on.
     secrets = [
         SecretEnv(name="GF_DATABASE_PASSWORD", secret="cloudsql-grafana-password"),
         SecretEnv(name="CW_READ_TOKEN", secret="marin-grafana-cw-read-token"),
-        SecretEnv(name="SLACK_ALERTS_WEBHOOK", secret="marin-grafana-slack-webhook"),
     ]
     env = {
         "DATABASE_SOCKET_DIR": database_socket_dir,
@@ -117,8 +115,8 @@ def main() -> None:
         env["LOOM_ALERT_URL"] = loom_client.apply(lambda client: client["loomUrl"])
         env["LOOM_ALERT_PROFILE"] = loom_client.apply(lambda client: client["profile"])
         env["LOOM_ALERT_REPOSITORY"] = LOOM_ALERT_REPOSITORY
-        # The bridge is the only thing that announces critical alerts, so neither
-        # the channel nor the token is optional the way SMTP is: without them the
+        # The bridge is the only thing that announces alerts now, so neither the
+        # channel nor the token is optional the way SMTP is: without them the
         # container refuses to boot rather than dropping alerting silently. The
         # channel is a Slack id (`C…`) and @russbot must be a member of it.
         slack_alerts_channel = config.require("slack_alerts_channel")

--- a/infra/grafana/provisioning/alerting/contact-points.yaml
+++ b/infra/grafana/provisioning/alerting/contact-points.yaml
@@ -12,15 +12,16 @@
 # Grafana-posted alert cannot become a conversation. One poster also means one
 # message per alert rather than two side-by-side. See infra/grafana/README.md.
 #
-# ops-slack is the fallback for malformed or unlabeled alerts, which have no Loom
-# leg and so keep Grafana's own rendering; the warning policy references it
-# through an always-active mute timing and never invokes it.
+# ops-slack is the fallback for malformed or unlabeled alerts. It posts through
+# the bridge as well, so both receivers share one channel, one credential, and
+# one rendering; it differs only in opening no Loom run, since an alert carrying
+# no severity to route on carries no incident to triage. The warning policy
+# references it through an always-active mute timing and never invokes it.
 #
-# The Loom endpoint is loopback-only and authenticates to Loom as the Cloud Run
-# service account through Google identity federation.
-# $SLACK_ALERTS_WEBHOOK is expanded from the container environment (Secret
-# Manager: marin-grafana-slack-webhook). Email delivery additionally needs valid
-# SMTP credentials — without them email is inert while the bridge still posts.
+# Both endpoints are loopback-only. The Loom one additionally authenticates to
+# Loom as the Cloud Run service account through Google identity federation.
+# Email delivery needs valid SMTP credentials — without them email is inert
+# while the bridge still posts.
 apiVersion: 1
 
 contactPoints:
@@ -41,6 +42,7 @@ contactPoints:
     name: ops-slack
     receivers:
       - uid: ops-slack-webhook
-        type: slack
+        type: webhook
         settings:
-          url: $SLACK_ALERTS_WEBHOOK
+          url: http://127.0.0.1:8081/alerts/slack
+          httpMethod: POST

--- a/infra/grafana/src/config.py
+++ b/infra/grafana/src/config.py
@@ -235,8 +235,11 @@ class BridgeConfig:
             # The bridge is the only thing that announces critical alerts now that
             # Grafana's own Slack receiver is gone, so a missing token would take
             # alerting down silently. Fail the boot instead.
-            bot_token = os.environ.get("SLACK_ALERTS_BOT_TOKEN")
-            channel = os.environ.get("SLACK_ALERTS_CHANNEL")
+            # Both are stripped: a secret payload created from a shell pipeline
+            # usually carries a trailing newline, and it would otherwise reach an
+            # Authorization header and a request body verbatim.
+            bot_token = (os.environ.get("SLACK_ALERTS_BOT_TOKEN") or "").strip()
+            channel = (os.environ.get("SLACK_ALERTS_CHANNEL") or "").strip()
             if not bot_token or not channel:
                 raise ValueError(
                     "SLACK_ALERTS_BOT_TOKEN and SLACK_ALERTS_CHANNEL are required when LOOM_ALERT_URL is set"

--- a/infra/grafana/src/config.py
+++ b/infra/grafana/src/config.py
@@ -185,9 +185,8 @@ class SlackAlertConfig:
 
 @dataclasses.dataclass(frozen=True)
 class LoomAlertConfig:
-    """Identity-federated Loom destination for critical alerts, and where they are
-    announced. Every alert the bridge delivers is also announced, so the Slack
-    destination is part of this configuration rather than a parallel optional."""
+    """The identity-federated Loom destination for critical alerts, and the Slack
+    channel every alert is announced in."""
 
     url: str
     profile: str

--- a/infra/grafana/src/loom_alerts.py
+++ b/infra/grafana/src/loom_alerts.py
@@ -1,16 +1,23 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Announce Grafana alerts in Slack and deliver them to Loom on that thread.
+"""Announce Grafana alerts in Slack, and for critical ones open Loom triage there.
 
-The bridge owns the Slack message rather than Grafana's own Slack contact point,
-because an incoming webhook answers with a bare `ok`: it never reveals the
-message timestamp, so Grafana cannot tell anyone which thread it posted to.
-Posting here yields the `channel`/`ts` that Loom needs to route the thread to the
-triage session, which is what lets the operator read status and steer in the same
-place the alert appeared.
+The bridge owns every Slack alert message rather than Grafana's own Slack contact
+point. For critical alerts that is load-bearing: an incoming webhook answers with
+a bare `ok` and never reveals the message timestamp, so Grafana cannot tell
+anyone which thread it posted to, while posting here yields the `channel`/`ts`
+that Loom needs to route the thread to the triage session. That is what lets the
+operator read status and steer in the same place the alert appeared.
 
-Slack is posted to first, so the alert reaches people even when Loom is
+`SlackAnnouncer` holds that Slack behavior on its own, so the two receivers
+differ only in what follows the announcement. `LoomAlertClient` opens a triage
+run on the thread it announced; `SlackAlertClient` announces and stops, which is
+what the fallback for malformed or unlabeled alerts wants — those have no
+incident to triage. Sharing the announcer keeps one channel, one credential, and
+one rendering, so alert text reaches Slack escaped either way.
+
+Slack is posted to first, so a critical alert reaches people even when Loom is
 unreachable — and that failure is reported into the thread rather than only into
 Grafana's delivery log. Announcements are deduplicated on alert identity: Grafana
 retries a failed webhook and re-notifies an unresolved alert every
@@ -26,7 +33,7 @@ from collections.abc import Mapping
 from typing import Any
 
 import httpx
-from config import LoomAlertConfig
+from config import LoomAlertConfig, SlackAlertConfig
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +119,136 @@ class ThreadLog:
         self._threads.pop(key, None)
 
 
+class SlackAnnouncer:
+    """Announce Grafana alert groups in one Slack channel, a thread per alert.
+
+    Owns the channel, the bot credential, and which thread announced which alert.
+    One instance serves one receiver; two receivers keep separate thread logs
+    because they see disjoint alert groups.
+    """
+
+    def __init__(self, slack: SlackAlertConfig) -> None:
+        self._slack = slack
+        # Alert identity to the thread announcing it. Keyed on identity rather
+        # than firing state so a resolution threads under the alert it resolves.
+        self._threads = ThreadLog(ttl=THREAD_TTL, max_entries=MAX_TRACKED_THREADS)
+
+    async def announce(
+        self,
+        client: httpx.AsyncClient,
+        payload: object,
+        firing: list[Mapping[str, object]],
+        thread_key: str,
+    ) -> SlackThread | None:
+        """Post the alert to Slack, or thread a re-notification under its original.
+
+        A Slack failure is logged and returns `None` rather than raising: for the
+        critical receiver, the triage session is worth opening even when the
+        announcement did not land.
+        """
+        tracked = self._threads.peek(thread_key)
+        if tracked is not None:
+            # Grafana retries a failed webhook within seconds, and re-notifies an
+            # unresolved alert on its repeat_interval. Both land here; only the
+            # second is news, so a quiet period separates them.
+            if time.monotonic() - tracked.posted_at >= RENOTIFY_QUIET_PERIOD:
+                await self.post(client, "Still firing.", thread=tracked.thread)
+                self._threads.mark_posted(thread_key)
+            return tracked.thread
+        thread = await self.post(client, _alert_card(payload, firing))
+        if thread is not None:
+            self._threads.put(thread_key, thread)
+        return thread
+
+    async def announce_resolution(
+        self,
+        client: httpx.AsyncClient,
+        payload: object,
+        thread_key: str,
+    ) -> None:
+        """Note a resolution under the thread that announced the alert.
+
+        Nothing is posted for an unknown thread: a resolution for an alert this
+        instance never announced has no conversation to join, and a bare
+        "resolved" in the channel reads as noise.
+        """
+        tracked = self._threads.peek(thread_key)
+        if tracked is None:
+            return
+        await self.post(
+            client,
+            f"Resolved — {_alert_title(payload, _all_alerts(payload))}.",
+            thread=tracked.thread,
+        )
+        self._threads.discard(thread_key)
+
+    async def post(
+        self,
+        client: httpx.AsyncClient,
+        text: str,
+        *,
+        thread: SlackThread | None = None,
+    ) -> SlackThread | None:
+        """Post to Slack, returning the resulting thread reference, or None on failure."""
+        body: dict[str, Any] = {
+            "channel": self._slack.channel,
+            "text": text,
+            "unfurl_links": False,
+        }
+        if thread is not None:
+            body["thread_ts"] = thread.thread_ts
+        try:
+            response = await client.post(
+                f"{SLACK_API_URL}/chat.postMessage",
+                json=body,
+                headers={"Authorization": f"Bearer {self._slack.bot_token}"},
+            )
+            response.raise_for_status()
+            result = response.json()
+        except (httpx.HTTPError, json.JSONDecodeError) as err:
+            logger.warning("Slack alert announcement failed: %s", err)
+            return None
+        # chat.postMessage reports its own failures in a 200 body.
+        if not isinstance(result, Mapping) or not result.get("ok"):
+            reason = result.get("error", "unknown error") if isinstance(result, Mapping) else "malformed response"
+            logger.warning("Slack rejected the alert announcement: %s", reason)
+            return None
+        ts = result.get("ts")
+        if not isinstance(ts, str) or not ts:
+            logger.warning("Slack accepted the alert announcement without a message ts")
+            return None
+        # A threaded reply keeps the root as the thread; only a new post opens one.
+        return thread or SlackThread(channel=self._slack.channel, thread_ts=ts)
+
+
+class SlackAlertClient:
+    """Announce a Grafana webhook in Slack, with no Loom leg.
+
+    The receiver for malformed or unlabeled alerts: they carry no severity to
+    route on and no incident to triage, so they are announced and left alone.
+    """
+
+    def __init__(
+        self,
+        config: LoomAlertConfig,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._http_timeout = config.http_timeout
+        self._transport = transport
+        self._announcer = SlackAnnouncer(config.slack)
+
+    async def announce(self, payload: object) -> SlackThread | None:
+        """Announce the group's firing alerts, or note its resolution."""
+        firing = _firing_alerts(payload)
+        thread_key = _thread_key(payload)
+        async with httpx.AsyncClient(timeout=self._http_timeout, transport=self._transport) as client:
+            if not firing:
+                await self._announcer.announce_resolution(client, payload, thread_key)
+                return None
+            return await self._announcer.announce(client, payload, firing, thread_key)
+
+
 class LoomAlertClient:
     """Announce a Grafana webhook in Slack and open a Loom run on that thread."""
 
@@ -122,11 +259,8 @@ class LoomAlertClient:
         transport: httpx.AsyncBaseTransport | None = None,
     ) -> None:
         self._config = config
-        self._slack = config.slack
         self._transport = transport
-        # Alert identity to the thread announcing it. Keyed on identity rather
-        # than firing state so a resolution threads under the alert it resolves.
-        self._threads = ThreadLog(ttl=THREAD_TTL, max_entries=MAX_TRACKED_THREADS)
+        self._announcer = SlackAnnouncer(config.slack)
 
     async def submit(self, payload: object) -> dict[str, Any] | None:
         """Announce the group in Slack, then create one Loom run for its firing alerts.
@@ -138,9 +272,9 @@ class LoomAlertClient:
         thread_key = _thread_key(payload)
         async with httpx.AsyncClient(timeout=self._config.http_timeout, transport=self._transport) as client:
             if not firing:
-                await self._announce_resolution(client, payload, thread_key)
+                await self._announcer.announce_resolution(client, payload, thread_key)
                 return None
-            thread = await self._announce(client, payload, firing, thread_key)
+            thread = await self._announcer.announce(client, payload, firing, thread_key)
             return await self._create_run(client, payload, firing, thread)
 
     async def _create_run(
@@ -226,7 +360,7 @@ class LoomAlertClient:
         fails and Grafana retries.
         """
         if thread is not None:
-            await self._post(client, f"No Loom triage session opened for this alert: {error}", thread=thread)
+            await self._announcer.post(client, f"No Loom triage session opened for this alert: {error}", thread=thread)
         return error
 
     async def _link_session(
@@ -239,93 +373,7 @@ class LoomAlertClient:
         session_id = run.get("session_id")
         if thread is None or not isinstance(session_id, str) or not session_id:
             return
-        await self._post(client, f"Triage session: {self._config.url}/s/{session_id}", thread=thread)
-
-    async def _announce(
-        self,
-        client: httpx.AsyncClient,
-        payload: object,
-        firing: list[Mapping[str, object]],
-        thread_key: str,
-    ) -> SlackThread | None:
-        """Post the alert to Slack, or thread a re-notification under its original.
-
-        A Slack failure is logged and returns `None` rather than raising: the
-        triage session is worth opening even when the announcement did not land.
-        """
-        tracked = self._threads.peek(thread_key)
-        if tracked is not None:
-            # Grafana retries a failed webhook within seconds, and re-notifies an
-            # unresolved alert on its repeat_interval. Both land here; only the
-            # second is news, so a quiet period separates them.
-            if time.monotonic() - tracked.posted_at >= RENOTIFY_QUIET_PERIOD:
-                await self._post(client, "Still firing.", thread=tracked.thread)
-                self._threads.mark_posted(thread_key)
-            return tracked.thread
-        thread = await self._post(client, _alert_card(payload, firing))
-        if thread is not None:
-            self._threads.put(thread_key, thread)
-        return thread
-
-    async def _announce_resolution(
-        self,
-        client: httpx.AsyncClient,
-        payload: object,
-        thread_key: str,
-    ) -> None:
-        """Note a resolution under the thread that announced the alert.
-
-        Nothing is posted for an unknown thread: a resolution for an alert this
-        instance never announced has no conversation to join, and a bare
-        "resolved" in the channel reads as noise.
-        """
-        tracked = self._threads.peek(thread_key)
-        if tracked is None:
-            return
-        await self._post(
-            client,
-            f"Resolved — {_alert_title(payload, _all_alerts(payload))}.",
-            thread=tracked.thread,
-        )
-        self._threads.discard(thread_key)
-
-    async def _post(
-        self,
-        client: httpx.AsyncClient,
-        text: str,
-        *,
-        thread: SlackThread | None = None,
-    ) -> SlackThread | None:
-        """Post to Slack, returning the resulting thread reference, or None on failure."""
-        body: dict[str, Any] = {
-            "channel": self._slack.channel,
-            "text": text,
-            "unfurl_links": False,
-        }
-        if thread is not None:
-            body["thread_ts"] = thread.thread_ts
-        try:
-            response = await client.post(
-                f"{SLACK_API_URL}/chat.postMessage",
-                json=body,
-                headers={"Authorization": f"Bearer {self._slack.bot_token}"},
-            )
-            response.raise_for_status()
-            result = response.json()
-        except (httpx.HTTPError, json.JSONDecodeError) as err:
-            logger.warning("Slack alert announcement failed: %s", err)
-            return None
-        # chat.postMessage reports its own failures in a 200 body.
-        if not isinstance(result, Mapping) or not result.get("ok"):
-            reason = result.get("error", "unknown error") if isinstance(result, Mapping) else "malformed response"
-            logger.warning("Slack rejected the alert announcement: %s", reason)
-            return None
-        ts = result.get("ts")
-        if not isinstance(ts, str) or not ts:
-            logger.warning("Slack accepted the alert announcement without a message ts")
-            return None
-        # A threaded reply keeps the root as the thread; only a new post opens one.
-        return thread or SlackThread(channel=self._slack.channel, thread_ts=ts)
+        await self._announcer.post(client, f"Triage session: {self._config.url}/s/{session_id}", thread=thread)
 
 
 def _all_alerts(payload: object) -> list[Mapping[str, object]]:

--- a/infra/grafana/src/loom_alerts.py
+++ b/infra/grafana/src/loom_alerts.py
@@ -3,25 +3,19 @@
 
 """Announce Grafana alerts in Slack, and for critical ones open Loom triage there.
 
-The bridge owns every Slack alert message rather than Grafana's own Slack contact
-point. For critical alerts that is load-bearing: an incoming webhook answers with
-a bare `ok` and never reveals the message timestamp, so Grafana cannot tell
-anyone which thread it posted to, while posting here yields the `channel`/`ts`
-that Loom needs to route the thread to the triage session. That is what lets the
-operator read status and steer in the same place the alert appeared.
+Every alert group arrives as a Grafana webhook and is announced with
+`chat.postMessage`, which returns the `channel`/`ts` naming a thread. One alert
+keeps one thread for its whole life: re-notifications and the resolution are
+posted under the original announcement, so a webhook retry adds nothing and a
+still-firing note appears only after the thread has been quiet.
 
-`SlackAnnouncer` holds that Slack behavior on its own, so the two receivers
-differ only in what follows the announcement. `LoomAlertClient` opens a triage
-run on the thread it announced; `SlackAlertClient` announces and stops, which is
-what the fallback for malformed or unlabeled alerts wants — those have no
-incident to triage. Sharing the announcer keeps one channel, one credential, and
-one rendering, so alert text reaches Slack escaped either way.
-
-Slack is posted to first, so a critical alert reaches people even when Loom is
-unreachable — and that failure is reported into the thread rather than only into
-Grafana's delivery log. Announcements are deduplicated on alert identity: Grafana
-retries a failed webhook and re-notifies an unresolved alert every
-`repeat_interval`, and neither should open a second thread.
+Two receivers share that behavior through `SlackAnnouncer` and differ in what
+follows. `LoomAlertClient` opens a Loom triage run naming the thread it just
+announced, which is what lets the operator read status and steer in the same
+place the alert appeared; Slack is posted first, so the alert lands even when
+Loom is unreachable, and that failure is reported into the thread.
+`SlackAlertClient` announces and stops, and raises when Slack refuses, because it
+has no second delivery path.
 """
 
 import dataclasses
@@ -60,6 +54,10 @@ class LoomAlertPayloadError(ValueError):
 
 class LoomAlertDeliveryError(RuntimeError):
     """Google identity federation or Loom run creation failed."""
+
+
+class SlackAnnouncementError(RuntimeError):
+    """Slack did not accept an announcement that had no other delivery path."""
 
 
 @dataclasses.dataclass(frozen=True)
@@ -239,14 +237,22 @@ class SlackAlertClient:
         self._announcer = SlackAnnouncer(config.slack)
 
     async def announce(self, payload: object) -> SlackThread | None:
-        """Announce the group's firing alerts, or note its resolution."""
+        """Announce the group's firing alerts, returning None for a resolution.
+
+        Raises `SlackAnnouncementError` when Slack did not accept the post. This
+        receiver has no second leg, so a swallowed failure would drop the whole
+        notification; failing lets Grafana retry it.
+        """
         firing = _firing_alerts(payload)
         thread_key = _thread_key(payload)
         async with httpx.AsyncClient(timeout=self._http_timeout, transport=self._transport) as client:
             if not firing:
                 await self._announcer.announce_resolution(client, payload, thread_key)
                 return None
-            return await self._announcer.announce(client, payload, firing, thread_key)
+            thread = await self._announcer.announce(client, payload, firing, thread_key)
+            if thread is None:
+                raise SlackAnnouncementError("Slack did not accept the alert announcement")
+            return thread
 
 
 class LoomAlertClient:

--- a/infra/grafana/src/loom_alerts.py
+++ b/infra/grafana/src/loom_alerts.py
@@ -75,6 +75,10 @@ class _Tracked:
     # When this thread last received a post, which separates a webhook retry
     # seconds later from a genuine re-notification hours later.
     posted_at: float
+    # The session already linked in this thread. Every notification for a firing
+    # alert creates a run, and Loom dedupes them to one session, so linking on
+    # each would repeat the same line per retry and per re-notification.
+    linked_session: str | None = None
 
 
 class ThreadLog:
@@ -112,6 +116,11 @@ class ThreadLog:
         tracked = self._threads.get(key)
         if tracked is not None:
             tracked.posted_at = time.monotonic()
+
+    def mark_linked(self, key: str, session_id: str) -> None:
+        tracked = self._threads.get(key)
+        if tracked is not None:
+            tracked.linked_session = session_id
 
     def discard(self, key: str) -> None:
         self._threads.pop(key, None)
@@ -157,6 +166,21 @@ class SlackAnnouncer:
         if thread is not None:
             self._threads.put(thread_key, thread)
         return thread
+
+    async def link_session_once(
+        self,
+        client: httpx.AsyncClient,
+        thread_key: str,
+        thread: SlackThread,
+        loom_url: str,
+        session_id: str,
+    ) -> None:
+        """Post the triage session's link, unless this thread already carries it."""
+        tracked = self._threads.peek(thread_key)
+        if tracked is not None and tracked.linked_session == session_id:
+            return
+        await self.post(client, f"Triage session: {loom_url}/s/{session_id}", thread=thread)
+        self._threads.mark_linked(thread_key, session_id)
 
     async def announce_resolution(
         self,
@@ -281,7 +305,7 @@ class LoomAlertClient:
                 await self._announcer.announce_resolution(client, payload, thread_key)
                 return None
             thread = await self._announcer.announce(client, payload, firing, thread_key)
-            return await self._create_run(client, payload, firing, thread)
+            return await self._create_run(client, payload, firing, thread, thread_key)
 
     async def _create_run(
         self,
@@ -289,6 +313,7 @@ class LoomAlertClient:
         payload: object,
         firing: list[Mapping[str, object]],
         thread: SlackThread | None,
+        thread_key: str,
     ) -> dict[str, Any]:
         request: dict[str, Any] = {
             "profile": self._config.profile,
@@ -350,7 +375,7 @@ class LoomAlertClient:
                 thread,
                 LoomAlertDeliveryError("Loom returned an invalid JSON response"),
             ) from err
-        await self._link_session(client, thread, response)
+        await self._link_session(client, thread, thread_key, response)
         return response
 
     async def _report_delivery_failure(
@@ -373,13 +398,14 @@ class LoomAlertClient:
         self,
         client: httpx.AsyncClient,
         thread: SlackThread | None,
+        thread_key: str,
         run: Mapping[str, Any],
     ) -> None:
-        """Append the triage session's link to the announcement."""
+        """Append the triage session's link to the announcement, at most once."""
         session_id = run.get("session_id")
         if thread is None or not isinstance(session_id, str) or not session_id:
             return
-        await self._announcer.post(client, f"Triage session: {self._config.url}/s/{session_id}", thread=thread)
+        await self._announcer.link_session_once(client, thread_key, thread, self._config.url, session_id)
 
 
 def _all_alerts(payload: object) -> list[Mapping[str, object]]:

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -86,7 +86,13 @@ from github_app import GithubAppAuth
 from github_source import GithubSource
 from iris_source import IrisSource
 from k8s_source import K8sFleet, K8sSource
-from loom_alerts import LoomAlertClient, LoomAlertDeliveryError, LoomAlertPayloadError, SlackAlertClient
+from loom_alerts import (
+    LoomAlertClient,
+    LoomAlertDeliveryError,
+    LoomAlertPayloadError,
+    SlackAlertClient,
+    SlackAnnouncementError,
+)
 from nightly_config import NIGHTLY_LANES
 from overview import PROVISIONING_LOOKBACK_HOURS, provisioning_query, provisioning_rows
 from starlette.applications import Starlette
@@ -658,7 +664,14 @@ def create_app(
             thread = await slack_alerts.announce(payload)
         except (json.JSONDecodeError, LoomAlertPayloadError) as err:
             return JSONResponse({"error": str(err)}, status_code=400)
-        return JSONResponse({"announced": thread is not None}, status_code=202)
+        except SlackAnnouncementError as err:
+            # This receiver posts and stops, so a failed announcement is the whole
+            # notification. Fail so Grafana retries instead of counting it sent.
+            logger.warning("Slack alert announcement failed: %s", err)
+            return JSONResponse({"error": str(err)}, status_code=502)
+        if thread is None:
+            return JSONResponse({"announced": False, "reason": "no firing alerts"}, status_code=202)
+        return JSONResponse({"announced": True}, status_code=202)
 
     return Starlette(
         routes=[

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -48,6 +48,7 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /k8s/alerts/arch_mismatch                 alert rows: cluster, node, image, value(count)
     GET /k8s/alerts/gpu_rack_trays                alert rows: cluster, rack_name, value(trays_ready)
     POST /alerts/loom                             firing Grafana groups become Loom automation runs
+    POST /alerts/slack                            Grafana groups announced in Slack, no Loom run
     GET /health                                  bridge liveness
 
 A dead controller or GitHub returns 5xx (not empty rows), and the failure is not
@@ -55,8 +56,8 @@ cached. The k8s routes aggregate every CW cluster into one response, so a dead
 cluster becomes labeled error rows while the rest render; the alert routes always
 return at least one row per cluster (explicit zeros when healthy) so Grafana
 rules never hit NoData. Handlers are sync defs; Starlette runs them in a
-threadpool. The Loom webhook is async because it exchanges tokens and creates a
-run over HTTP.
+threadpool. The two alert webhooks are async because they post to Slack, and the
+Loom one also exchanges tokens and creates a run over HTTP.
 """
 
 import json
@@ -85,7 +86,7 @@ from github_app import GithubAppAuth
 from github_source import GithubSource
 from iris_source import IrisSource
 from k8s_source import K8sFleet, K8sSource
-from loom_alerts import LoomAlertClient, LoomAlertDeliveryError, LoomAlertPayloadError
+from loom_alerts import LoomAlertClient, LoomAlertDeliveryError, LoomAlertPayloadError, SlackAlertClient
 from nightly_config import NIGHTLY_LANES
 from overview import PROVISIONING_LOOKBACK_HOURS, provisioning_query, provisioning_rows
 from starlette.applications import Starlette
@@ -331,8 +332,9 @@ def create_app(
     k8s_fleet: K8sFleet,
     wandb_source: WandbSource,
     loom_alerts: LoomAlertClient | None = None,
+    slack_alerts: SlackAlertClient | None = None,
 ) -> Starlette:
-    """Build the ASGI app serving Grafana's data sources and Loom webhook."""
+    """Build the ASGI app serving Grafana's data sources and alert webhooks."""
     finelog_cache: TtlCache = TtlCache(config.cache_ttl)
     finelog_health_cache: TtlCache = TtlCache(config.k8s_cache_ttl)
     iris_cache: TtlCache = TtlCache(config.iris_cache_ttl)
@@ -648,10 +650,21 @@ def create_app(
         logger.info("Grafana alert accepted by Loom: run=%s", result.get("id", "unknown"))
         return JSONResponse({"accepted": True, "run": result}, status_code=202)
 
+    async def slack_alert(request: Request) -> JSONResponse:
+        if slack_alerts is None:
+            return JSONResponse({"error": "Slack alert announcement is not configured"}, status_code=503)
+        try:
+            payload = await request.json()
+            thread = await slack_alerts.announce(payload)
+        except (json.JSONDecodeError, LoomAlertPayloadError) as err:
+            return JSONResponse({"error": str(err)}, status_code=400)
+        return JSONResponse({"announced": thread is not None}, status_code=202)
+
     return Starlette(
         routes=[
             Route("/health", health),
             Route("/alerts/loom", loom_alert, methods=["POST"]),
+            Route("/alerts/slack", slack_alert, methods=["POST"]),
             Route("/github/ferries", github_ferries),
             Route("/github/builds", github_builds),
             Route("/github/nightlies", github_nightlies),
@@ -708,10 +721,13 @@ def main() -> None:
     k8s_fleet = K8sFleet([K8sSource(c, token=config.cw_read_token, timeout=config.http_timeout) for c in K8S_CLUSTERS])
     wandb_source = WandbSource(timeout=config.http_timeout)
     loom_alerts = LoomAlertClient(config.loom_alerts) if config.loom_alerts is not None else None
+    slack_alerts = SlackAlertClient(config.loom_alerts) if config.loom_alerts is not None else None
     logger.info("grafana bridge serving %s on :%d", sorted(finelog_sources), BRIDGE_PORT)
     # Loopback only: Grafana fetches from the same container.
     uvicorn.run(
-        create_app(config, finelog_sources, iris_sources, github_source, k8s_fleet, wandb_source, loom_alerts),
+        create_app(
+            config, finelog_sources, iris_sources, github_source, k8s_fleet, wandb_source, loom_alerts, slack_alerts
+        ),
         host="127.0.0.1",
         port=BRIDGE_PORT,
         access_log=False,

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -16,7 +16,13 @@ from finelog.errors import QueryResultTooLargeError
 from finelog_health import FinelogHealth, FinelogRole
 from github_source import GithubSource
 from k8s_source import K8sFleet
-from loom_alerts import LoomAlertClient, LoomAlertDeliveryError, SlackAlertClient, SlackThread
+from loom_alerts import (
+    LoomAlertClient,
+    LoomAlertDeliveryError,
+    SlackAlertClient,
+    SlackAnnouncementError,
+    SlackThread,
+)
 from server import create_app, workload_overview
 from starlette.testclient import TestClient
 from training_stalls import telemetry_query, training_stall_alert_rows
@@ -448,6 +454,25 @@ def test_slack_alert_route_announces_without_a_run():
 def test_slack_alert_route_is_disabled_without_a_configured_destination():
     resp = _client(FakeSource()).post("/alerts/slack", json={"alerts": []})
     assert resp.status_code == 503
+
+
+def test_slack_alert_route_reports_a_resolution_as_nothing_announced():
+    resp = _client(FakeSource(), slack_alerts=FakeSlackAlerts(None)).post("/alerts/slack", json={"alerts": []})
+    assert resp.status_code == 202
+    assert resp.json() == {"announced": False, "reason": "no firing alerts"}
+
+
+def test_slack_alert_route_asks_grafana_to_retry_a_refused_announcement():
+    """This receiver has no second leg, so a dropped announcement is the whole
+    notification: it must not answer 2xx."""
+
+    class RefusingSlackAlerts(FakeSlackAlerts):
+        async def announce(self, payload: object) -> SlackThread | None:
+            raise SlackAnnouncementError("Slack did not accept the alert announcement")
+
+    resp = _client(FakeSource(), slack_alerts=RefusingSlackAlerts(None)).post("/alerts/slack", json={"alerts": []})
+    assert resp.status_code == 502
+    assert resp.json() == {"error": "Slack did not accept the alert announcement"}
 
 
 def test_finelog_fleet_health_combines_the_main_hub_and_k8s_mirrors():

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -16,7 +16,7 @@ from finelog.errors import QueryResultTooLargeError
 from finelog_health import FinelogHealth, FinelogRole
 from github_source import GithubSource
 from k8s_source import K8sFleet
-from loom_alerts import LoomAlertClient, LoomAlertDeliveryError
+from loom_alerts import LoomAlertClient, LoomAlertDeliveryError, SlackAlertClient, SlackThread
 from server import create_app, workload_overview
 from starlette.testclient import TestClient
 from training_stalls import telemetry_query, training_stall_alert_rows
@@ -82,6 +82,7 @@ def _client(
     cache_ttl: float = 20.0,
     k8s_fleet: K8sFleet | None = None,
     loom_alerts: LoomAlertClient | None = None,
+    slack_alerts: SlackAlertClient | None = None,
 ) -> TestClient:
     github = GithubSource(auth=None, timeout=5.0)
     return TestClient(
@@ -93,6 +94,7 @@ def _client(
             k8s_fleet or K8sFleet(()),
             WandbSource(timeout=5.0),
             loom_alerts,
+            slack_alerts,
         )
     )
 
@@ -422,6 +424,30 @@ def test_loom_alert_route_returns_retryable_failure_for_delivery_errors():
     ).post("/alerts/loom", json={"alerts": [{"status": "firing"}]})
     assert resp.status_code == 502
     assert resp.json() == {"error": "loom.example returned HTTP 503"}
+
+
+class FakeSlackAlerts(SlackAlertClient):
+    def __init__(self, thread: SlackThread | None) -> None:
+        self.thread = thread
+        self.payloads: list[object] = []
+
+    async def announce(self, payload: object) -> SlackThread | None:
+        self.payloads.append(payload)
+        return self.thread
+
+
+def test_slack_alert_route_announces_without_a_run():
+    fallback = FakeSlackAlerts(SlackThread(channel="C0123ABCD", thread_ts="1700000000.000001"))
+    resp = _client(FakeSource(), slack_alerts=fallback).post("/alerts/slack", json={"alerts": []})
+
+    assert resp.status_code == 202
+    assert resp.json() == {"announced": True}
+    assert fallback.payloads == [{"alerts": []}]
+
+
+def test_slack_alert_route_is_disabled_without_a_configured_destination():
+    resp = _client(FakeSource()).post("/alerts/slack", json={"alerts": []})
+    assert resp.status_code == 503
 
 
 def test_finelog_fleet_health_combines_the_main_hub_and_k8s_mirrors():

--- a/infra/grafana/tests/test_config.py
+++ b/infra/grafana/tests/test_config.py
@@ -50,3 +50,22 @@ def test_alert_delivery_without_a_slack_destination_fails_fast(monkeypatch):
 
     with pytest.raises(ValueError, match="SLACK_ALERTS_BOT_TOKEN"):
         BridgeConfig.from_environment()
+
+
+def test_a_secret_payload_with_a_trailing_newline_is_usable(monkeypatch):
+    """Secret Manager serves whatever bytes it was given, and a payload created
+    from a shell pipeline usually ends in a newline. Unstripped, the token reaches
+    an Authorization header and the channel reaches a request body."""
+    for name in LOOM_ENV:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("LOOM_ALERT_URL", "https://loom.example.com")
+    monkeypatch.setenv("LOOM_ALERT_PROFILE", "ops")
+    monkeypatch.setenv("LOOM_ALERT_REPOSITORY", "marin-community/marin")
+    monkeypatch.setenv("SLACK_ALERTS_BOT_TOKEN", "xoxb-test\n")
+    monkeypatch.setenv("SLACK_ALERTS_CHANNEL", "C0123ABCD\n")
+
+    config = BridgeConfig.from_environment()
+
+    assert config.loom_alerts is not None
+    assert config.loom_alerts.slack.bot_token == "xoxb-test"
+    assert config.loom_alerts.slack.channel == "C0123ABCD"

--- a/infra/grafana/tests/test_loom_alerts.py
+++ b/infra/grafana/tests/test_loom_alerts.py
@@ -194,6 +194,9 @@ def test_a_webhook_retry_reuses_the_thread_without_announcing_again():
 
     assert len(slack.roots) == 1, "a retry must not announce again"
     assert "Still firing." not in slack.reply_texts
+    # Every notification creates a run and Loom dedupes them to one session, so
+    # linking on each would repeat the line per retry and per 4h re-notification.
+    assert slack.reply_texts.count("Triage session: https://loom.example.com/s/session-1") == 1
     # Both deliveries name the same thread, so both reach the same conversation.
     assert runs[1]["slack"] == runs[0]["slack"]
 
@@ -211,6 +214,7 @@ def test_a_still_firing_alert_is_noted_once_the_thread_has_gone_quiet(monkeypatc
 
     assert len(slack.roots) == 1, "still one announcement"
     assert slack.reply_texts.count("Still firing.") == 1
+    assert slack.reply_texts.count("Triage session: https://loom.example.com/s/session-1") == 1
 
 
 def test_a_resolution_is_noted_on_the_alert_thread_and_creates_no_run():

--- a/infra/grafana/tests/test_loom_alerts.py
+++ b/infra/grafana/tests/test_loom_alerts.py
@@ -11,7 +11,13 @@ import httpx
 import loom_alerts
 import pytest
 from config import LoomAlertConfig, SlackAlertConfig
-from loom_alerts import LoomAlertClient, LoomAlertDeliveryError, LoomAlertPayloadError, SlackAlertClient
+from loom_alerts import (
+    LoomAlertClient,
+    LoomAlertDeliveryError,
+    LoomAlertPayloadError,
+    SlackAlertClient,
+    SlackAnnouncementError,
+)
 
 SLACK_CHANNEL = "C0123ABCD"
 
@@ -299,6 +305,14 @@ def test_the_fallback_shares_the_announcement_rules():
 def test_the_fallback_rejects_a_malformed_body():
     with pytest.raises(LoomAlertPayloadError, match="alerts list"):
         asyncio.run(announce_only_client(FakeSlack()).announce({}))
+
+
+def test_a_fallback_announcement_slack_refused_is_raised_so_grafana_retries():
+    """The critical receiver can swallow a Slack failure because the triage session
+    still opens. This one posts and stops, so a swallowed failure would drop the
+    notification entirely."""
+    with pytest.raises(SlackAnnouncementError, match="did not accept"):
+        asyncio.run(announce_only_client(FakeSlack(ok=False)).announce(alert_payload()))
 
 
 def test_alert_card_escapes_text_and_drops_links_that_could_break_out():

--- a/infra/grafana/tests/test_loom_alerts.py
+++ b/infra/grafana/tests/test_loom_alerts.py
@@ -11,7 +11,7 @@ import httpx
 import loom_alerts
 import pytest
 from config import LoomAlertConfig, SlackAlertConfig
-from loom_alerts import LoomAlertClient, LoomAlertDeliveryError, LoomAlertPayloadError
+from loom_alerts import LoomAlertClient, LoomAlertDeliveryError, LoomAlertPayloadError, SlackAlertClient
 
 SLACK_CHANNEL = "C0123ABCD"
 
@@ -254,6 +254,51 @@ def test_a_slack_failure_still_opens_the_triage_session():
 def test_invalid_payload_is_rejected_before_authentication():
     with pytest.raises(LoomAlertPayloadError, match="alerts list"):
         asyncio.run(client_for(FakeSlack()).submit({}))
+
+
+def announce_only_client(slack: FakeSlack) -> SlackAlertClient:
+    """The fallback receiver's client. Any non-Slack request is a bug: this path
+    must not reach Google metadata or Loom."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "slack.com":
+            return slack.respond(request)
+        raise AssertionError(f"the announce-only path must not call {request.url}")
+
+    return SlackAlertClient(loom_config(), transport=httpx.MockTransport(handler))
+
+
+def test_the_fallback_announces_the_alert_and_opens_no_run():
+    """Malformed and unlabeled alerts carry no severity to route on and no incident
+    to triage, so they are announced and left alone."""
+    slack = FakeSlack()
+
+    thread = asyncio.run(announce_only_client(slack).announce(alert_payload()))
+
+    assert thread is not None
+    assert len(slack.roots) == 1
+    card = slack.roots[0]["text"]
+    assert "K8sClusterUnreachable on cw-a" in card
+    assert slack.replies == [], "no triage session to link"
+
+
+def test_the_fallback_shares_the_announcement_rules():
+    """It reuses the announcer, so a retry does not announce twice and a resolution
+    joins the thread rather than starting a new message."""
+    slack = FakeSlack()
+    client = announce_only_client(slack)
+
+    asyncio.run(client.announce(alert_payload()))
+    asyncio.run(client.announce(alert_payload()))
+    assert asyncio.run(client.announce(alert_payload(status="resolved"))) is None
+
+    assert len(slack.roots) == 1
+    assert any("Resolved" in text for text in slack.reply_texts)
+
+
+def test_the_fallback_rejects_a_malformed_body():
+    with pytest.raises(LoomAlertPayloadError, match="alerts list"):
+        asyncio.run(announce_only_client(FakeSlack()).announce({}))
 
 
 def test_alert_card_escapes_text_and_drops_links_that_could_break_out():

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -205,21 +205,21 @@ def test_warning_alerts_remain_visible_without_notifications():
     ]
 
 
-def test_critical_contact_point_reaches_email_and_the_bridge_but_not_slack_directly():
-    """The bridge posts the Slack announcement, not Grafana: an incoming webhook
-    never reveals the message ts that Loom needs to route the thread to the triage
-    session. Two Slack receivers would also mean two messages per alert."""
+def test_every_slack_alert_goes_through_the_bridge_and_none_through_grafana():
+    """The bridge posts every Slack alert, not Grafana. For critical alerts that is
+    load-bearing — an incoming webhook never reveals the message ts that Loom needs
+    to route the thread — and routing the fallback the same way keeps one channel,
+    one credential, and one rendering."""
     points = {point["name"]: point for point in _load(ALERTING / "contact-points.yaml")["contactPoints"]}
-    critical_types = {receiver["type"] for receiver in points["ops-critical"]["receivers"]}
-    assert critical_types == {"email", "webhook"}
-    # The unlabeled-alert fallback has no Loom leg, so it keeps Grafana's own Slack rendering.
-    assert {receiver["type"] for receiver in points["ops-slack"]["receivers"]} == {"slack"}
-    for point in points.values():
-        for receiver in point["receivers"]:
-            if receiver["type"] == "slack":
-                assert receiver["settings"]["url"] == "$SLACK_ALERTS_WEBHOOK"
+    assert {receiver["type"] for receiver in points["ops-critical"]["receivers"]} == {"email", "webhook"}
+    assert {receiver["type"] for receiver in points["ops-slack"]["receivers"]} == {"webhook"}
+    slack_receivers = [r for point in points.values() for r in point["receivers"] if r["type"] == "slack"]
+    assert slack_receivers == [], "a Slack receiver would post a second message Loom cannot route"
+
     (loom,) = [receiver for receiver in points["ops-critical"]["receivers"] if receiver["type"] == "webhook"]
     assert loom["settings"] == {"url": "http://127.0.0.1:8081/alerts/loom", "httpMethod": "POST"}
+    (fallback,) = points["ops-slack"]["receivers"]
+    assert fallback["settings"] == {"url": "http://127.0.0.1:8081/alerts/slack", "httpMethod": "POST"}
 
 
 def test_finelog_health_alert_pages_critical_after_five_minutes():

--- a/infra/pulumi/src/iac/gcp/iam_data.yaml
+++ b/infra/pulumi/src/iac/gcp/iam_data.yaml
@@ -1504,14 +1504,6 @@ secrets:
   - role: roles/secretmanager.secretAccessor
     members:
     - serviceAccount:marin-grafana@hai-gcp-models.iam.gserviceaccount.com
-- secret: marin-grafana-slack-webhook
-  grants:
-  - role: projects/hai-gcp-models/roles/marinSecretIamManager
-    members:
-    - serviceAccount:marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com
-  - role: roles/secretmanager.secretAccessor
-    members:
-    - serviceAccount:marin-grafana@hai-gcp-models.iam.gserviceaccount.com
 - secret: marinmirror-token
   grants:
   - role: roles/secretmanager.secretAccessor


### PR DESCRIPTION
Alerts now land in `#marin-alerts` (`C0BN20081CH`). That also unblocks the deploy: `slack_alerts_channel` was deliberately required and left unset by #8050, so main's grafana deploy has been failing on the missing key since it merged. Pulumi errors before touching anything, so the running revision is unaffected and alerting still works the old way until this lands.

`ops-slack` — the fallback for malformed or unlabeled alerts — posted through a Slack incoming webhook, whose channel is fixed at creation and cannot be pointed elsewhere. It posts through the bridge now, so both receivers share one channel, one credential, and one rendering, and fallback alerts get the same escaping and link-dropping as critical ones. `SlackAnnouncer` holds the shared Slack behavior; the receivers differ only in what follows the announcement, and the fallback opens no Loom run because an alert with no severity to route on has no incident to triage.

The fallback raises when Slack refuses, so `/alerts/slack` answers 502 and Grafana retries. Swallowing is right for the critical receiver — the triage session is still worth opening, and the Loom failure is reported into the thread — but the fallback has no second leg, so a swallowed failure would drop the whole notification. A resolution is reported as `announced: false` with a reason rather than sharing that shape with a failure.

That retires `marin-grafana-slack-webhook`: the env wiring and its `iam_data.yaml` grants are gone. The tradeoff is that a fallback notification does not reach Slack while the bridge is down; email stays independent for critical alerts, and every alert rule sets a severity, so the fallback sees almost no traffic.

Two fixes found while deploying #8050 by hand:

- Secret Manager serves the bytes it is given, and creating `marin-grafana-slack-bot-token` from a shell pipeline left a trailing newline that would have reached the `Authorization` header. The token and channel are stripped on read now, matching `CW_READ_TOKEN`. Production already holds a clean version; the newline-bearing version 1 is disabled.
- The Slack app's bot user is `russbot` in the Open Athena workspace, per `auth.test`. Docs and comments named `@marinbot`, which does not exist, including the `/invite` step an operator follows.

## Deploying

Order matters once, in this direction: **merge and let the grafana deploy run first, then apply the `marin` GCP stack.** Both stacks grant the same `secretAccessor` member on the webhook secret, so removing the `iam_data.yaml` grant while a revision still mounts that secret would break its next start. After the deploy drops the mount, the stack apply is just the two stale bindings — preview confirms 2 to delete, 740 unchanged.

The secret value itself is left in Secret Manager; delete it once no revision mounts it.

## Testing

191 tests pass in `infra/grafana` and `./infra/pre-commit.py --all-files` is clean. New coverage: the fallback announces and opens no run, shares the retry and resolution rules, raises when Slack refuses, and rejects a malformed body; its route answers 202, 502, and 503 in the right cases; provisioning asserts both receivers are loopback webhooks and no Slack receiver survives anywhere; and a config test drives a newline-terminated token and channel.

Not yet exercised against live Slack — that needs this deployed. The bot token is verified working against `auth.test`, and `#marin-alerts` accepted a scheduled probe from it (cancelled before it could post), so posting should work; the README's step 6 is the real confirmation.

`./infra/pre-commit.py --review` reported nine findings. The Slack-swallow and undocumented-return ones were real and are fixed above, along with the stale-doc and docstring-narration ones. Two duplicate-logic findings are left alone: the three `_create_run` except clauses carry meaningfully different messages, and `_thread_key` and `_idempotency_key` hash deliberately different identities — the thread key must not depend on labels or firing state.