### PR TITLE
[grug] Vectorize per-layer router metrics

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -482,8 +482,6 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
     load_balancing_loss = router_metrics["load_balancing_loss_per_layer"]
     router_z_loss = router_metrics["router_z_loss_per_layer"]
     capacity_overflow = router_metrics["capacity_overflow_per_layer"]
-    num_layers = int(routing_entropy.shape[0])
-
     # Per-layer total assignments = sum of routing_counts over experts (= tokens * k).
     assignments_per_layer = jnp.sum(routing_counts.astype(jnp.float32), axis=-1)
     capacity_overflow_rate = capacity_overflow.astype(jnp.float32) / jnp.maximum(assignments_per_layer, 1.0)
@@ -494,36 +492,38 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
         "train/router/router_z_loss": jnp.mean(router_z_loss),
         "train/router/routing_counts_per_layer": routing_counts,
         "train/router/capacity_overflow_rate_mean": jnp.mean(capacity_overflow_rate),
-        "qb_beta_per_layer": router_metrics.get("qb_beta_per_layer"),
+        "qb_beta_per_layer": router_metrics["qb_beta_per_layer"],
+        "_router_metrics/routing_entropy_per_layer": routing_entropy,
+        "_router_metrics/load_balancing_loss_per_layer": load_balancing_loss,
+        "_router_metrics/router_z_loss_per_layer": router_z_loss,
+        "_router_metrics/routing_hist_per_layer": _histogram_from_expert_counts(routing_counts),
+        "_router_metrics/capacity_overflow_rate_per_layer": capacity_overflow_rate,
     }
-    for i in range(num_layers):
-        out[f"train/router/layer_{i}/routing_entropy"] = routing_entropy[i]
-        out[f"train/router/layer_{i}/load_balancing_loss"] = load_balancing_loss[i]
-        out[f"train/router/layer_{i}/router_z_loss"] = router_z_loss[i]
-        out[f"train/router/layer_{i}/routing_hist"] = _histogram_from_expert_counts(routing_counts[i])
-        out[f"train/router/layer_{i}/capacity_overflow_rate"] = capacity_overflow_rate[i]
     return out
 
 
 def _histogram_from_expert_counts(expert_counts: jax.Array) -> SummaryStats:
     counts = jnp.asarray(expert_counts, dtype=jnp.float32)
-    num_experts = counts.shape[0]
+    num_experts = counts.shape[-1]
     expert_ids = jnp.arange(num_experts, dtype=jnp.float32)
-    num = jnp.sum(counts)
-    sum_values = jnp.sum(counts * expert_ids)
-    sum_squares = jnp.sum(counts * expert_ids * expert_ids)
+    num = jnp.sum(counts, axis=-1)
+    sum_values = jnp.sum(counts * expert_ids, axis=-1)
+    sum_squares = jnp.sum(counts * expert_ids * expert_ids, axis=-1)
     nonzero = counts > 0
-    min_value = jnp.where(nonzero, expert_ids, jnp.inf).min()
-    max_value = jnp.where(nonzero, expert_ids, -jnp.inf).max()
+    min_value = jnp.where(nonzero, expert_ids, jnp.inf).min(axis=-1)
+    max_value = jnp.where(nonzero, expert_ids, -jnp.inf).max(axis=-1)
     min_value = jnp.where(num > 0, min_value, 0.0)
     max_value = jnp.where(num > 0, max_value, 0.0)
-    bucket_limits = jnp.arange(num_experts + 1, dtype=jnp.float32)
+    bucket_limits = jnp.broadcast_to(
+        jnp.arange(num_experts + 1, dtype=jnp.float32),
+        (*counts.shape[:-1], num_experts + 1),
+    )
     histogram = Histogram(bucket_limits=bucket_limits, bucket_counts=counts)
     return SummaryStats.from_reduced_values(
         min=min_value,
         max=max_value,
         num=num,
-        nonzero_count=jnp.sum(nonzero),
+        nonzero_count=jnp.sum(nonzero, axis=-1),
         sum=sum_values,
         sum_squares=sum_squares,
         histogram=histogram,

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -7,7 +7,6 @@ import logging
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any
 
 import equinox as eqx
 import jax
@@ -35,6 +34,7 @@ from levanter.grug.sharding import compact_grug_mesh
 from levanter.models.lm_model import LmExample
 from levanter.optim.config import AdamConfig, OptimizerConfig
 from levanter.schedule import BatchSchedule
+from levanter.tracker.histogram import SummaryStats
 from levanter.trainer import TrainerConfig
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.jax_utils import parameter_count
@@ -298,7 +298,9 @@ def initial_state(
     )
 
 
-def _router_metrics_for_logging(metrics: Mapping[str, Any]) -> dict[str, Any]:
+def _router_metrics_for_logging(
+    metrics: Mapping[str, jax.Array | SummaryStats],
+) -> dict[str, jax.Array | SummaryStats]:
     router_metrics = {
         key: value
         for key, value in metrics.items()

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -5,7 +5,9 @@ import dataclasses
 import functools
 import logging
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from typing import Any
 
 import equinox as eqx
 import jax
@@ -48,6 +50,14 @@ from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
 # `.agents/skills/change-grug/`.
 
 logger = logging.getLogger(__name__)
+
+_ROUTER_LAYER_METRICS = (
+    ("routing_entropy", "_router_metrics/routing_entropy_per_layer"),
+    ("load_balancing_loss", "_router_metrics/load_balancing_loss_per_layer"),
+    ("router_z_loss", "_router_metrics/router_z_loss_per_layer"),
+    ("routing_hist", "_router_metrics/routing_hist_per_layer"),
+    ("capacity_overflow_rate", "_router_metrics/capacity_overflow_rate_per_layer"),
+)
 
 
 @dataclass(frozen=True)
@@ -286,6 +296,23 @@ def initial_state(
         ema_params=params if ema_beta is not None else None,
         pending_qb_betas=jnp.zeros((num_moe_layers, model_config.num_experts)),
     )
+
+
+def _router_metrics_for_logging(metrics: Mapping[str, Any]) -> dict[str, Any]:
+    router_metrics = {
+        key: value
+        for key, value in metrics.items()
+        if (key.startswith("train/router/") or key.startswith("moe_bias/"))
+        and key not in ("train/router/routing_counts_per_layer", "qb_beta_per_layer")
+    }
+    stacked_metrics = jax.device_get({name: metrics[key] for name, key in _ROUTER_LAYER_METRICS})
+    num_layers = stacked_metrics["routing_entropy"].shape[0]
+    for layer_index in range(num_layers):
+        for metric_name, values in stacked_metrics.items():
+            router_metrics[f"train/router/layer_{layer_index}/{metric_name}"] = jax.tree_util.tree_map(
+                lambda value, layer_index=layer_index: value[layer_index], values
+            )
+    return router_metrics
 
 
 def _make_train_step(
@@ -542,12 +569,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                     last_step_duration = duration
                     levanter.tracker.log({"throughput/hook_time": time.perf_counter() - hook_start}, step=step)
                     levanter.tracker.log({"throughput/loading_time": iterator.this_load_time}, step=step)
-                    router_metrics = {
-                        key: value
-                        for key, value in metrics.items()
-                        if (key.startswith("train/router/") or key.startswith("moe_bias/"))
-                        and key not in ("train/router/routing_counts_per_layer", "qb_beta_per_layer")
-                    }
+                    router_metrics = _router_metrics_for_logging(metrics)
                     if router_metrics:
                         levanter.tracker.log(router_metrics, step=step)
                     if "train/cross_entropy_loss" in metrics:

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -661,8 +661,6 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
     load_balancing_loss = router_metrics["load_balancing_loss_per_layer"]
     router_z_loss = router_metrics["router_z_loss_per_layer"]
     capacity_overflow = router_metrics["capacity_overflow_per_layer"]
-    num_layers = int(routing_entropy.shape[0])
-
     # Per-layer total assignments = sum of routing_counts over experts (= tokens * k).
     assignments_per_layer = jnp.sum(routing_counts.astype(jnp.float32), axis=-1)
     capacity_overflow_rate = capacity_overflow.astype(jnp.float32) / jnp.maximum(assignments_per_layer, 1.0)
@@ -673,36 +671,38 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
         "train/router/router_z_loss": jnp.mean(router_z_loss),
         "train/router/routing_counts_per_layer": routing_counts,
         "train/router/capacity_overflow_rate_mean": jnp.mean(capacity_overflow_rate),
-        "qb_beta_per_layer": router_metrics.get("qb_beta_per_layer"),
+        "qb_beta_per_layer": router_metrics["qb_beta_per_layer"],
+        "_router_metrics/routing_entropy_per_layer": routing_entropy,
+        "_router_metrics/load_balancing_loss_per_layer": load_balancing_loss,
+        "_router_metrics/router_z_loss_per_layer": router_z_loss,
+        "_router_metrics/routing_hist_per_layer": _histogram_from_expert_counts(routing_counts),
+        "_router_metrics/capacity_overflow_rate_per_layer": capacity_overflow_rate,
     }
-    for i in range(num_layers):
-        out[f"train/router/layer_{i}/routing_entropy"] = routing_entropy[i]
-        out[f"train/router/layer_{i}/load_balancing_loss"] = load_balancing_loss[i]
-        out[f"train/router/layer_{i}/router_z_loss"] = router_z_loss[i]
-        out[f"train/router/layer_{i}/routing_hist"] = _histogram_from_expert_counts(routing_counts[i])
-        out[f"train/router/layer_{i}/capacity_overflow_rate"] = capacity_overflow_rate[i]
     return out
 
 
 def _histogram_from_expert_counts(expert_counts: jax.Array) -> SummaryStats:
     counts = jnp.asarray(expert_counts, dtype=jnp.float32)
-    num_experts = counts.shape[0]
+    num_experts = counts.shape[-1]
     expert_ids = jnp.arange(num_experts, dtype=jnp.float32)
-    num = jnp.sum(counts)
-    sum_values = jnp.sum(counts * expert_ids)
-    sum_squares = jnp.sum(counts * expert_ids * expert_ids)
+    num = jnp.sum(counts, axis=-1)
+    sum_values = jnp.sum(counts * expert_ids, axis=-1)
+    sum_squares = jnp.sum(counts * expert_ids * expert_ids, axis=-1)
     nonzero = counts > 0
-    min_value = jnp.where(nonzero, expert_ids, jnp.inf).min()
-    max_value = jnp.where(nonzero, expert_ids, -jnp.inf).max()
+    min_value = jnp.where(nonzero, expert_ids, jnp.inf).min(axis=-1)
+    max_value = jnp.where(nonzero, expert_ids, -jnp.inf).max(axis=-1)
     min_value = jnp.where(num > 0, min_value, 0.0)
     max_value = jnp.where(num > 0, max_value, 0.0)
-    bucket_limits = jnp.arange(num_experts + 1, dtype=jnp.float32)
+    bucket_limits = jnp.broadcast_to(
+        jnp.arange(num_experts + 1, dtype=jnp.float32),
+        (*counts.shape[:-1], num_experts + 1),
+    )
     histogram = Histogram(bucket_limits=bucket_limits, bucket_counts=counts)
     return SummaryStats.from_reduced_values(
         min=min_value,
         max=max_value,
         num=num,
-        nonzero_count=jnp.sum(nonzero),
+        nonzero_count=jnp.sum(nonzero, axis=-1),
         sum=sum_values,
         sum_squares=sum_squares,
         histogram=histogram,

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -6,7 +6,9 @@ import functools
 import logging
 import os
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from typing import Any
 
 import equinox as eqx
 import jax
@@ -49,6 +51,14 @@ from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
 # `.agents/skills/change-grug/`.
 
 logger = logging.getLogger(__name__)
+
+_ROUTER_LAYER_METRICS = (
+    ("routing_entropy", "_router_metrics/routing_entropy_per_layer"),
+    ("load_balancing_loss", "_router_metrics/load_balancing_loss_per_layer"),
+    ("router_z_loss", "_router_metrics/router_z_loss_per_layer"),
+    ("routing_hist", "_router_metrics/routing_hist_per_layer"),
+    ("capacity_overflow_rate", "_router_metrics/capacity_overflow_rate_per_layer"),
+)
 
 HERO_EP_RUNTIME_ENV = {
     "JAX_ENABLE_PGLE": "false",
@@ -346,6 +356,23 @@ def _drop_metrics(
     }
 
 
+def _router_metrics_for_logging(metrics: Mapping[str, Any]) -> dict[str, Any]:
+    router_metrics = {
+        key: value
+        for key, value in metrics.items()
+        if (key.startswith("train/router/") or key.startswith("moe_bias/"))
+        and key not in ("train/router/routing_counts_per_layer", "qb_beta_per_layer")
+    }
+    stacked_metrics = jax.device_get({name: metrics[key] for name, key in _ROUTER_LAYER_METRICS})
+    num_layers = stacked_metrics["routing_entropy"].shape[0]
+    for layer_index in range(num_layers):
+        for metric_name, values in stacked_metrics.items():
+            router_metrics[f"train/router/layer_{layer_index}/{metric_name}"] = jax.tree_util.tree_map(
+                lambda value, layer_index=layer_index: value[layer_index], values
+            )
+    return router_metrics
+
+
 def _make_train_step(
     optimizer: optax.GradientTransformation,
     mp: jmp.Policy,
@@ -599,12 +626,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                     last_step_duration = duration
                     levanter.tracker.log({"throughput/hook_time": time.perf_counter() - hook_start}, step=step)
                     levanter.tracker.log({"throughput/loading_time": iterator.this_load_time}, step=step)
-                    router_metrics = {
-                        key: value
-                        for key, value in metrics.items()
-                        if (key.startswith("train/router/") or key.startswith("moe_bias/"))
-                        and key not in ("train/router/routing_counts_per_layer", "qb_beta_per_layer")
-                    }
+                    router_metrics = _router_metrics_for_logging(metrics)
                     if router_metrics:
                         levanter.tracker.log(router_metrics, step=step)
                     if "train/cross_entropy_loss" in metrics:

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -8,7 +8,6 @@ import os
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any
 
 import equinox as eqx
 import jax
@@ -36,6 +35,7 @@ from levanter.grug.sharding import compact_grug_mesh
 from levanter.models.lm_model import LmExample
 from levanter.optim.config import AdamConfig, OptimizerConfig
 from levanter.schedule import BatchSchedule
+from levanter.tracker.histogram import SummaryStats
 from levanter.trainer import TrainerConfig
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.jax_utils import parameter_count
@@ -356,7 +356,9 @@ def _drop_metrics(
     }
 
 
-def _router_metrics_for_logging(metrics: Mapping[str, Any]) -> dict[str, Any]:
+def _router_metrics_for_logging(
+    metrics: Mapping[str, jax.Array | SummaryStats],
+) -> dict[str, jax.Array | SummaryStats]:
     router_metrics = {
         key: value
         for key, value in metrics.items()

--- a/experiments/grug/moe_hero_fsdp/model.py
+++ b/experiments/grug/moe_hero_fsdp/model.py
@@ -654,8 +654,6 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
     load_balancing_loss = router_metrics["load_balancing_loss_per_layer"]
     router_z_loss = router_metrics["router_z_loss_per_layer"]
     capacity_overflow = router_metrics["capacity_overflow_per_layer"]
-    num_layers = int(routing_entropy.shape[0])
-
     # Per-layer total assignments = sum of routing_counts over experts (= tokens * k).
     assignments_per_layer = jnp.sum(routing_counts.astype(jnp.float32), axis=-1)
     capacity_overflow_rate = capacity_overflow.astype(jnp.float32) / jnp.maximum(assignments_per_layer, 1.0)
@@ -666,36 +664,38 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
         "train/router/router_z_loss": jnp.mean(router_z_loss),
         "train/router/routing_counts_per_layer": routing_counts,
         "train/router/capacity_overflow_rate_mean": jnp.mean(capacity_overflow_rate),
-        "qb_beta_per_layer": router_metrics.get("qb_beta_per_layer"),
+        "qb_beta_per_layer": router_metrics["qb_beta_per_layer"],
+        "_router_metrics/routing_entropy_per_layer": routing_entropy,
+        "_router_metrics/load_balancing_loss_per_layer": load_balancing_loss,
+        "_router_metrics/router_z_loss_per_layer": router_z_loss,
+        "_router_metrics/routing_hist_per_layer": _histogram_from_expert_counts(routing_counts),
+        "_router_metrics/capacity_overflow_rate_per_layer": capacity_overflow_rate,
     }
-    for i in range(num_layers):
-        out[f"train/router/layer_{i}/routing_entropy"] = routing_entropy[i]
-        out[f"train/router/layer_{i}/load_balancing_loss"] = load_balancing_loss[i]
-        out[f"train/router/layer_{i}/router_z_loss"] = router_z_loss[i]
-        out[f"train/router/layer_{i}/routing_hist"] = _histogram_from_expert_counts(routing_counts[i])
-        out[f"train/router/layer_{i}/capacity_overflow_rate"] = capacity_overflow_rate[i]
     return out
 
 
 def _histogram_from_expert_counts(expert_counts: jax.Array) -> SummaryStats:
     counts = jnp.asarray(expert_counts, dtype=jnp.float32)
-    num_experts = counts.shape[0]
+    num_experts = counts.shape[-1]
     expert_ids = jnp.arange(num_experts, dtype=jnp.float32)
-    num = jnp.sum(counts)
-    sum_values = jnp.sum(counts * expert_ids)
-    sum_squares = jnp.sum(counts * expert_ids * expert_ids)
+    num = jnp.sum(counts, axis=-1)
+    sum_values = jnp.sum(counts * expert_ids, axis=-1)
+    sum_squares = jnp.sum(counts * expert_ids * expert_ids, axis=-1)
     nonzero = counts > 0
-    min_value = jnp.where(nonzero, expert_ids, jnp.inf).min()
-    max_value = jnp.where(nonzero, expert_ids, -jnp.inf).max()
+    min_value = jnp.where(nonzero, expert_ids, jnp.inf).min(axis=-1)
+    max_value = jnp.where(nonzero, expert_ids, -jnp.inf).max(axis=-1)
     min_value = jnp.where(num > 0, min_value, 0.0)
     max_value = jnp.where(num > 0, max_value, 0.0)
-    bucket_limits = jnp.arange(num_experts + 1, dtype=jnp.float32)
+    bucket_limits = jnp.broadcast_to(
+        jnp.arange(num_experts + 1, dtype=jnp.float32),
+        (*counts.shape[:-1], num_experts + 1),
+    )
     histogram = Histogram(bucket_limits=bucket_limits, bucket_counts=counts)
     return SummaryStats.from_reduced_values(
         min=min_value,
         max=max_value,
         num=num,
-        nonzero_count=jnp.sum(nonzero),
+        nonzero_count=jnp.sum(nonzero, axis=-1),
         sum=sum_values,
         sum_squares=sum_squares,
         histogram=histogram,

--- a/experiments/grug/moe_hero_fsdp/train.py
+++ b/experiments/grug/moe_hero_fsdp/train.py
@@ -9,7 +9,6 @@ import time
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any
 
 import equinox as eqx
 import jax
@@ -40,6 +39,7 @@ from levanter.recovery.detection import DetectionConfig, recovery_xla_env, touch
 from levanter.recovery.supervisor import ENV_HEARTBEAT_PATH, GPUHangSupervisor
 from levanter.recovery.types import AblationSpec, RunOutcome
 from levanter.schedule import BatchSchedule
+from levanter.tracker.histogram import SummaryStats
 from levanter.tracker.telemetry import capture_stall_diagnostics
 from levanter.trainer import TrainerConfig
 from levanter.utils.flop_utils import lm_flops_per_token
@@ -382,7 +382,9 @@ def _drop_metrics(
     }
 
 
-def _router_metrics_for_logging(metrics: Mapping[str, Any]) -> dict[str, Any]:
+def _router_metrics_for_logging(
+    metrics: Mapping[str, jax.Array | SummaryStats],
+) -> dict[str, jax.Array | SummaryStats]:
     router_metrics = {
         key: value
         for key, value in metrics.items()

--- a/experiments/grug/moe_hero_fsdp/train.py
+++ b/experiments/grug/moe_hero_fsdp/train.py
@@ -6,8 +6,10 @@ import functools
 import logging
 import os
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import Any
 
 import equinox as eqx
 import jax
@@ -54,6 +56,14 @@ from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
 # `.agents/skills/change-grug/`.
 
 logger = logging.getLogger(__name__)
+
+_ROUTER_LAYER_METRICS = (
+    ("routing_entropy", "_router_metrics/routing_entropy_per_layer"),
+    ("load_balancing_loss", "_router_metrics/load_balancing_loss_per_layer"),
+    ("router_z_loss", "_router_metrics/router_z_loss_per_layer"),
+    ("routing_hist", "_router_metrics/routing_hist_per_layer"),
+    ("capacity_overflow_rate", "_router_metrics/capacity_overflow_rate_per_layer"),
+)
 
 HERO_FSDP_RUNTIME_ENV = {
     "JAX_ENABLE_PGLE": "1",
@@ -372,6 +382,23 @@ def _drop_metrics(
     }
 
 
+def _router_metrics_for_logging(metrics: Mapping[str, Any]) -> dict[str, Any]:
+    router_metrics = {
+        key: value
+        for key, value in metrics.items()
+        if (key.startswith("train/router/") or key.startswith("moe_bias/"))
+        and key not in ("train/router/routing_counts_per_layer", "qb_beta_per_layer")
+    }
+    stacked_metrics = jax.device_get({name: metrics[key] for name, key in _ROUTER_LAYER_METRICS})
+    num_layers = stacked_metrics["routing_entropy"].shape[0]
+    for layer_index in range(num_layers):
+        for metric_name, values in stacked_metrics.items():
+            router_metrics[f"train/router/layer_{layer_index}/{metric_name}"] = jax.tree_util.tree_map(
+                lambda value, layer_index=layer_index: value[layer_index], values
+            )
+    return router_metrics
+
+
 def _make_train_step(
     optimizer: optax.GradientTransformation,
     mp: jmp.Policy,
@@ -637,12 +664,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                     last_step_duration = duration
                     levanter.tracker.log({"throughput/hook_time": time.perf_counter() - hook_start}, step=step)
                     levanter.tracker.log({"throughput/loading_time": iterator.this_load_time}, step=step)
-                    router_metrics = {
-                        key: value
-                        for key, value in metrics.items()
-                        if (key.startswith("train/router/") or key.startswith("moe_bias/"))
-                        and key not in ("train/router/routing_counts_per_layer", "qb_beta_per_layer")
-                    }
+                    router_metrics = _router_metrics_for_logging(metrics)
                     if router_metrics:
                         levanter.tracker.log(router_metrics, step=step)
                     if "train/cross_entropy_loss" in metrics:

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -20,6 +20,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jmp
+import numpy as np
 import optax
 import pytest
 from fray.cluster import ResourceConfig
@@ -33,6 +34,7 @@ from levanter.distributed import DistributedConfig
 from levanter.grug.attention import AttentionMask as GrugAttentionMask
 from levanter.grug.sharding import _compact_grug_mesh_shape
 from levanter.schedule import BatchSchedule
+from levanter.tracker.histogram import SummaryStats
 from levanter.tracker.json_logger import JsonLoggerConfig
 from levanter.trainer import TrainerConfig
 from marin.execution.artifact import ArtifactRecord, write_record
@@ -266,6 +268,69 @@ def test_grug_variant_one_step_contract_lowers_with_default_ctor(variant: str):
     assert "train/loss" in out_metrics_shape
     assert out_metrics_shape["train/loss"].shape == ()
     assert out_watch_shape is None
+
+
+@pytest.mark.parametrize("variant", ["moe", "moe_hero_ep", "moe_hero_fsdp"])
+def test_grug_moe_router_metrics_keep_per_layer_logging_contract(variant: str):
+    model_module = importlib.import_module(_variant_module_name(variant, "model"))
+    train_module = importlib.import_module(_variant_module_name(variant, "train"))
+    router_metrics = {
+        "routing_entropy_per_layer": jnp.array([0.25, 0.75], dtype=jnp.float32),
+        "routing_counts_per_layer": jnp.array([[0.0, 2.0, 1.0], [3.0, 0.0, 0.0]], dtype=jnp.float32),
+        "load_balancing_loss_per_layer": jnp.array([1.25, 1.75], dtype=jnp.float32),
+        "router_z_loss_per_layer": jnp.array([2.25, 2.75], dtype=jnp.float32),
+        "capacity_overflow_per_layer": jnp.array([1, 3], dtype=jnp.int32),
+        "qb_beta_per_layer": jnp.zeros((2, 3), dtype=jnp.float32),
+    }
+
+    summarized = model_module._summarize_router_metrics(router_metrics)
+    logged = train_module._router_metrics_for_logging({"train/loss": jnp.array(1.0), **summarized})
+
+    assert set(logged) == {
+        "train/router/routing_entropy_mean",
+        "train/router/load_balancing_loss",
+        "train/router/router_z_loss",
+        "train/router/capacity_overflow_rate_mean",
+        "train/router/layer_0/routing_entropy",
+        "train/router/layer_0/load_balancing_loss",
+        "train/router/layer_0/router_z_loss",
+        "train/router/layer_0/routing_hist",
+        "train/router/layer_0/capacity_overflow_rate",
+        "train/router/layer_1/routing_entropy",
+        "train/router/layer_1/load_balancing_loss",
+        "train/router/layer_1/router_z_loss",
+        "train/router/layer_1/routing_hist",
+        "train/router/layer_1/capacity_overflow_rate",
+    }
+    np.testing.assert_allclose(logged["train/router/routing_entropy_mean"], 0.5)
+    np.testing.assert_allclose(logged["train/router/load_balancing_loss"], 1.5)
+    np.testing.assert_allclose(logged["train/router/router_z_loss"], 2.5)
+    np.testing.assert_allclose(logged["train/router/capacity_overflow_rate_mean"], 2.0 / 3.0)
+
+    expected_scalars = {
+        "routing_entropy": (0.25, 0.75),
+        "load_balancing_loss": (1.25, 1.75),
+        "router_z_loss": (2.25, 2.75),
+        "capacity_overflow_rate": (1.0 / 3.0, 1.0),
+    }
+    for metric_name, expected_values in expected_scalars.items():
+        for layer_index, expected in enumerate(expected_values):
+            np.testing.assert_allclose(logged[f"train/router/layer_{layer_index}/{metric_name}"], expected)
+
+    expected_histograms = (
+        {"min": 1.0, "max": 2.0, "num": 3.0, "nonzero_count": 2.0, "sum": 4.0, "sum_squares": 6.0},
+        {"min": 0.0, "max": 0.0, "num": 3.0, "nonzero_count": 1.0, "sum": 0.0, "sum_squares": 0.0},
+    )
+    for layer_index, expected in enumerate(expected_histograms):
+        stats = logged[f"train/router/layer_{layer_index}/routing_hist"]
+        assert isinstance(stats, SummaryStats)
+        for field_name, expected_value in expected.items():
+            np.testing.assert_allclose(getattr(stats, field_name), expected_value)
+        assert stats.histogram is not None
+        np.testing.assert_array_equal(
+            stats.histogram.bucket_counts, router_metrics["routing_counts_per_layer"][layer_index]
+        )
+        np.testing.assert_array_equal(stats.histogram.bucket_limits, np.arange(4, dtype=np.float32))
 
 
 def test_grug_moe_variant_threads_moe_implementation_to_kernel():

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -276,7 +276,7 @@ def test_grug_moe_router_metrics_keep_per_layer_logging_contract(variant: str):
     train_module = importlib.import_module(_variant_module_name(variant, "train"))
     router_metrics = {
         "routing_entropy_per_layer": jnp.array([0.25, 0.75], dtype=jnp.float32),
-        "routing_counts_per_layer": jnp.array([[0.0, 2.0, 1.0], [3.0, 0.0, 0.0]], dtype=jnp.float32),
+        "routing_counts_per_layer": jnp.array([[0.0, 4.0, 1.0], [5.0, 0.0, 0.0]], dtype=jnp.float32),
         "load_balancing_loss_per_layer": jnp.array([1.25, 1.75], dtype=jnp.float32),
         "router_z_loss_per_layer": jnp.array([2.25, 2.75], dtype=jnp.float32),
         "capacity_overflow_per_layer": jnp.array([1, 3], dtype=jnp.int32),
@@ -305,21 +305,21 @@ def test_grug_moe_router_metrics_keep_per_layer_logging_contract(variant: str):
     np.testing.assert_allclose(logged["train/router/routing_entropy_mean"], 0.5)
     np.testing.assert_allclose(logged["train/router/load_balancing_loss"], 1.5)
     np.testing.assert_allclose(logged["train/router/router_z_loss"], 2.5)
-    np.testing.assert_allclose(logged["train/router/capacity_overflow_rate_mean"], 2.0 / 3.0)
+    np.testing.assert_allclose(logged["train/router/capacity_overflow_rate_mean"], 0.4)
 
     expected_scalars = {
         "routing_entropy": (0.25, 0.75),
         "load_balancing_loss": (1.25, 1.75),
         "router_z_loss": (2.25, 2.75),
-        "capacity_overflow_rate": (1.0 / 3.0, 1.0),
+        "capacity_overflow_rate": (0.2, 0.6),
     }
     for metric_name, expected_values in expected_scalars.items():
         for layer_index, expected in enumerate(expected_values):
             np.testing.assert_allclose(logged[f"train/router/layer_{layer_index}/{metric_name}"], expected)
 
     expected_histograms = (
-        {"min": 1.0, "max": 2.0, "num": 3.0, "nonzero_count": 2.0, "sum": 4.0, "sum_squares": 6.0},
-        {"min": 0.0, "max": 0.0, "num": 3.0, "nonzero_count": 1.0, "sum": 0.0, "sum_squares": 0.0},
+        {"min": 1.0, "max": 2.0, "num": 5.0, "nonzero_count": 2.0, "sum": 6.0, "sum_squares": 8.0},
+        {"min": 0.0, "max": 0.0, "num": 5.0, "nonzero_count": 1.0, "sum": 0.0, "sum_squares": 0.0},
     )
     for layer_index, expected in enumerate(expected_histograms):
         stats = logged[f"train/router/layer_{layer_index}/routing_hist"]


### PR DESCRIPTION
Per-layer router summaries were assembled with a Python loop after the homogeneous transformer scan, so every layer added five metric computations and a histogram to the outer train-step jaxpr. This vectorizes those summaries across the existing stacked layer axis and reconstructs the established `train/router/layer_{i}/...` keys only after transferring the fixed metric tree to the host.

The same change is applied to `moe`, `moe_hero_ep`, and `moe_hero_fsdp`, which intentionally remain copy-first variants. The metric contract test checks the complete key set and every scalar and histogram field for all three variants. An isolated router-summary jaxpr now has 41 equations and 21 output leaves at both 4 and 48 layers.

Measured on two GB200 nodes with a warm CuTeDSL kernel store and a unique cold JAX compilation cache for each depth:

| Layers | Version | Trace | Lower | XLA |
| ---: | --- | ---: | ---: | ---: |
| 4 | Before | 3.39s | 1.51s | 9.35s |
| 4 | After | 3.46s | 1.46s | 10.00s |
| 48 | Before | 6.33s | 5.35s | 15.22s |
| 48 | After | 5.78s | 1.35s | 11.49s |
