### PR TITLE
[levanter] Prefetch training data during state initialization

### DIFF
--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -50,6 +50,7 @@ from levanter.utils.logging import LoadingTimeTrackerIterator
 
 from experiments.grug.base.model import GrugModelConfig, Transformer
 from experiments.grug.checkpointing import (
+    GrugCheckpointRestoreMode,
     init_weights_only_from_checkpoint,
     prepare_grug_checkpoint_restore,
     restore_grug_state_from_checkpoint,
@@ -466,7 +467,9 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             batch_pspec=config.trainer.train_batch_pspec,
         )
         checkpoint_search_paths = trainer.checkpoint_search_paths(run_id)
-        restore_plan = prepare_grug_checkpoint_restore(checkpoint_search_paths, trainer.load_checkpoint)
+        restore_plan = prepare_grug_checkpoint_restore(
+            checkpoint_search_paths, GrugCheckpointRestoreMode(trainer.load_checkpoint)
+        )
         data_iterator = train_loader.iter_from_step(restore_plan.expected_step)
         iterator = LoadingTimeTrackerIterator(data_iterator)
 

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -49,7 +49,11 @@ from levanter.utils.jax_utils import parameter_count
 from levanter.utils.logging import LoadingTimeTrackerIterator
 
 from experiments.grug.base.model import GrugModelConfig, Transformer
-from experiments.grug.checkpointing import init_weights_only_from_checkpoint, restore_grug_state_from_checkpoint
+from experiments.grug.checkpointing import (
+    init_weights_only_from_checkpoint,
+    prepare_grug_checkpoint_restore,
+    restore_grug_state_from_checkpoint,
+)
 from experiments.grug.dispatch import dispatch_grug_training_run
 from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
 
@@ -461,6 +465,10 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             mesh=mesh,
             batch_pspec=config.trainer.train_batch_pspec,
         )
+        checkpoint_search_paths = trainer.checkpoint_search_paths(run_id)
+        restore_plan = prepare_grug_checkpoint_restore(checkpoint_search_paths, trainer.load_checkpoint)
+        data_iterator = train_loader.iter_from_step(restore_plan.expected_step)
+        iterator = LoadingTimeTrackerIterator(data_iterator)
 
         @jax.jit
         def _init_state(model_rng):
@@ -472,23 +480,33 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 ema_beta=config.trainer.ema_beta,
             )
 
-        state = _init_state(model_key)
+        try:
+            state = _init_state(model_key)
 
-        checkpointer = trainer.checkpointer.create(run_id)
-        state = restore_grug_state_from_checkpoint(
-            state,
-            checkpoint_search_paths=trainer.checkpoint_search_paths(run_id),
-            load_checkpoint_setting=trainer.load_checkpoint,
-            mesh=mesh,
-            allow_partial=trainer.allow_partial_checkpoint,
-        )
-        if trainer.initialize_from is not None:
-            state = init_weights_only_from_checkpoint(
+            checkpointer = trainer.checkpointer.create(run_id)
+            state = restore_grug_state_from_checkpoint(
                 state,
-                trainer.initialize_from,
+                checkpoint_search_paths=checkpoint_search_paths,
+                load_checkpoint_setting=trainer.load_checkpoint,
                 mesh=mesh,
                 allow_partial=trainer.allow_partial_checkpoint,
+                restore_plan=restore_plan,
             )
+            if trainer.initialize_from is not None:
+                state = init_weights_only_from_checkpoint(
+                    state,
+                    trainer.initialize_from,
+                    mesh=mesh,
+                    allow_partial=trainer.allow_partial_checkpoint,
+                )
+        except BaseException:
+            data_iterator.close()
+            raise
+
+        if int(state.step) != restore_plan.expected_step:
+            data_iterator.close()
+            data_iterator = train_loader.iter_from_step(int(state.step))
+            iterator = LoadingTimeTrackerIterator(data_iterator)
         dump_grug_state_sharding_run_artifact(
             state,
             log_dir=trainer.log_dir,
@@ -516,8 +534,6 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         profiler_enabled = profiler_cfg.is_enabled and profiler_num_steps > 0
 
         log_every = max(1, config.trainer.log_every)
-        iterator = LoadingTimeTrackerIterator(train_loader.iter_from_step(int(state.step)))
-
         state_callbacks = StateCallbackRunner[GrugTrainState](
             step_getter=lambda s: s.step,
             model_getter=lambda s: s.params,
@@ -638,6 +654,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             if checkpointer is not None:
                 checkpointer.on_step(tree=state, step=int(state.step), force=True)
                 checkpointer.wait_until_finished()
+        finally:
+            data_iterator.close()
 
     levanter.tracker.current_tracker().finish()
 

--- a/experiments/grug/checkpointing.py
+++ b/experiments/grug/checkpointing.py
@@ -35,23 +35,43 @@ class _GrugState(Protocol):
 GrugStateT = TypeVar("GrugStateT", bound=_GrugState)
 
 
+@dataclasses.dataclass(frozen=True)
+class GrugCheckpointRestorePlan:
+    candidate_paths: tuple[str, ...]
+    expected_step: int
+
+
 def _get_fs_and_plain_path(path: str) -> tuple[AbstractFileSystem, str]:
     fs, _, (plain_path,) = fsspec.get_fs_token_paths(path)
     return fs, plain_path
 
 
-def _checkpoint_candidates(checkpoint_search_paths: Sequence[str]) -> list[str]:
+def _checkpoint_candidates(checkpoint_search_paths: Sequence[str]) -> GrugCheckpointRestorePlan:
     candidates: list[tuple[int, str, str]] = []
     for search_path in checkpoint_search_paths:
         candidates.extend(_scan_checkpoint_root(search_path))
 
     candidates.sort(key=lambda item: (item[0], item[1]), reverse=True)
     ordered_candidates = [candidate for _, _, candidate in candidates]
+    expected_step = max(0, candidates[0][0]) if candidates else 0
 
     for search_path in checkpoint_search_paths:
         if search_path not in ordered_candidates:
             ordered_candidates.append(search_path)
-    return ordered_candidates
+    return GrugCheckpointRestorePlan(tuple(ordered_candidates), expected_step)
+
+
+def prepare_grug_checkpoint_restore(
+    checkpoint_search_paths: Sequence[str], load_checkpoint_setting: bool | None
+) -> GrugCheckpointRestorePlan:
+    """Discover checkpoint candidates and the data step to prefetch."""
+    if not checkpoint_search_paths:
+        if load_checkpoint_setting:
+            raise FileNotFoundError("load_checkpoint=True but no checkpoint search paths are configured.")
+        return GrugCheckpointRestorePlan((), 0)
+    if load_checkpoint_setting is False:
+        return GrugCheckpointRestorePlan((), 0)
+    return _checkpoint_candidates(checkpoint_search_paths)
 
 
 def _scan_checkpoint_root(root_path: str) -> list[tuple[int, str, str]]:
@@ -100,6 +120,7 @@ def restore_grug_state_from_checkpoint(
     load_checkpoint_setting: bool | None,
     mesh: jax.sharding.Mesh | None,
     allow_partial: bool,
+    restore_plan: GrugCheckpointRestorePlan | None = None,
     _load_fn: Callable[..., StateT] = load_checkpoint,
 ) -> StateT:
     if not checkpoint_search_paths:
@@ -110,10 +131,11 @@ def restore_grug_state_from_checkpoint(
     if load_checkpoint_setting is False:
         return state
 
-    candidates = _checkpoint_candidates(checkpoint_search_paths)
+    if restore_plan is None:
+        restore_plan = prepare_grug_checkpoint_restore(checkpoint_search_paths, load_checkpoint_setting)
     last_error: FileNotFoundError | None = None
 
-    for candidate in candidates:
+    for candidate in restore_plan.candidate_paths:
         try:
             loaded = _load_candidate_state(
                 state=state,
@@ -133,7 +155,7 @@ def restore_grug_state_from_checkpoint(
 
     if load_checkpoint_setting is True:
         search_path_summary = ", ".join(checkpoint_search_paths)
-        attempted = ", ".join(candidates)
+        attempted = ", ".join(restore_plan.candidate_paths)
         if last_error is None:
             raise FileNotFoundError(f"Could not find checkpoint under any of: {search_path_summary}")
         raise FileNotFoundError(

--- a/experiments/grug/checkpointing.py
+++ b/experiments/grug/checkpointing.py
@@ -53,7 +53,7 @@ def _get_fs_and_plain_path(path: str) -> tuple[AbstractFileSystem, str]:
     return fs, plain_path
 
 
-def _checkpoint_candidates(checkpoint_search_paths: Sequence[str]) -> GrugCheckpointRestorePlan:
+def _checkpoint_restore_plan(checkpoint_search_paths: Sequence[str]) -> GrugCheckpointRestorePlan:
     candidates: list[tuple[int, str, str]] = []
     for search_path in checkpoint_search_paths:
         candidates.extend(_scan_checkpoint_root(search_path))
@@ -78,7 +78,7 @@ def prepare_grug_checkpoint_restore(
         return GrugCheckpointRestorePlan((), 0)
     if mode is GrugCheckpointRestoreMode.DISABLED:
         return GrugCheckpointRestorePlan((), 0)
-    return _checkpoint_candidates(checkpoint_search_paths)
+    return _checkpoint_restore_plan(checkpoint_search_paths)
 
 
 def _scan_checkpoint_root(root_path: str) -> list[tuple[int, str, str]]:

--- a/experiments/grug/checkpointing.py
+++ b/experiments/grug/checkpointing.py
@@ -7,6 +7,7 @@ import logging
 import os
 import urllib.parse
 from collections.abc import Callable, Sequence
+from enum import Enum
 from typing import ClassVar, Protocol, TypeVar, cast
 
 import fsspec
@@ -41,6 +42,12 @@ class GrugCheckpointRestorePlan:
     expected_step: int
 
 
+class GrugCheckpointRestoreMode(Enum):
+    DISABLED = False
+    OPTIONAL = None
+    REQUIRED = True
+
+
 def _get_fs_and_plain_path(path: str) -> tuple[AbstractFileSystem, str]:
     fs, _, (plain_path,) = fsspec.get_fs_token_paths(path)
     return fs, plain_path
@@ -62,14 +69,14 @@ def _checkpoint_candidates(checkpoint_search_paths: Sequence[str]) -> GrugCheckp
 
 
 def prepare_grug_checkpoint_restore(
-    checkpoint_search_paths: Sequence[str], load_checkpoint_setting: bool | None
+    checkpoint_search_paths: Sequence[str], mode: GrugCheckpointRestoreMode
 ) -> GrugCheckpointRestorePlan:
     """Discover checkpoint candidates and the data step to prefetch."""
     if not checkpoint_search_paths:
-        if load_checkpoint_setting:
+        if mode is GrugCheckpointRestoreMode.REQUIRED:
             raise FileNotFoundError("load_checkpoint=True but no checkpoint search paths are configured.")
         return GrugCheckpointRestorePlan((), 0)
-    if load_checkpoint_setting is False:
+    if mode is GrugCheckpointRestoreMode.DISABLED:
         return GrugCheckpointRestorePlan((), 0)
     return _checkpoint_candidates(checkpoint_search_paths)
 
@@ -132,7 +139,9 @@ def restore_grug_state_from_checkpoint(
         return state
 
     if restore_plan is None:
-        restore_plan = prepare_grug_checkpoint_restore(checkpoint_search_paths, load_checkpoint_setting)
+        restore_plan = prepare_grug_checkpoint_restore(
+            checkpoint_search_paths, GrugCheckpointRestoreMode(load_checkpoint_setting)
+        )
     last_error: FileNotFoundError | None = None
 
     for candidate in restore_plan.candidate_paths:

--- a/experiments/grug/moe_hero_fsdp/README.md
+++ b/experiments/grug/moe_hero_fsdp/README.md
@@ -47,6 +47,27 @@ synchronous host-staging and asynchronous commit phases without enabling Python 
 The entire artifact is pinned under `marin_temp_bucket(ttl_days=1)`, so it is disposable and covered
 by the one-day lifecycle policy.
 
+### Compilation-cache probe
+
+```bash
+RID="ccprobe-1"
+iris --cluster=marin job run --no-wait --enable-extra-resources \
+  --target-cluster cw-us-east-08a --priority interactive \
+  --cpu 2 --memory 8GB --disk 32GB --timeout 5400 --job-name "${RID}-coord" \
+  -e JAX_EXPLAIN_CACHE_MISSES 1 \
+  -e JAX_LOG_COMPILES 1 \
+  -e JAX_COMPILATION_CACHE_DIR s3://marin-us-east-02a/marin/compile-cache-probe/"$RID" \
+  -- python -m experiments.grug.moe_hero_fsdp.compile_cache_probe \
+    --run-id "$RID" --nodes 2 --num-steps 8 --data-seed 104729 --version dev --run
+```
+
+Four layers on two nodes, about five minutes end to end, on the same `run_grug` entrypoint and the
+same kernels as the hero. `JAX_EXPLAIN_CACHE_MISSES` turns JAX's per-module hit and miss accounting
+into WARNING lines in the task logs. Give each run its own `JAX_COMPILATION_CACHE_DIR` for a cold
+measurement, or repeat a prefix to warm both XLA entries and the `cutlass-kernels/` subtree. Change
+`--data-seed` between runs to select a different first shuffled data block without changing the
+compilation keys.
+
 ### Kernel cache
 
 The QuACK and FA4 kernels compile through CuTeDSL during MLIR lowering, before JAX's compilation
@@ -64,6 +85,7 @@ content-addressed, so runs share them and a launcher edit invalidates only its o
 | `adamh.py` | AdamH (Adam direction + Frobenius hyperball scale-invariant step) |
 | `heuristic.py` | May Recipe compute-scaling LR refit; derives the optimizer from steps + batch |
 | `train.py` | training loop, state init, dispatch, hero runtime env |
+| `compile_cache_probe.py` | four-layer two-node startup and compilation-cache probe |
 | `launch.py` | rack-scaled resources, DP/FSDP mesh, batch, tracker, dataset, and entry point |
 
 ## What's distinctive about this run

--- a/experiments/grug/moe_hero_fsdp/checkpoint_benchmark.py
+++ b/experiments/grug/moe_hero_fsdp/checkpoint_benchmark.py
@@ -15,7 +15,6 @@ from datetime import timedelta
 
 import click
 import jmp
-from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfilerConfig
 from levanter.callbacks.progress_watchdog import ProgressWatchdogConfig
 from levanter.callbacks.watch import WatchConfig
@@ -39,6 +38,7 @@ from experiments.grug.moe_hero_fsdp.launch import (
     HERO_PROCESS_STALL_TIMEOUT,
     HERO_PROCESSES_PER_TASK,
     HERO_TRAIN_STEP_TIMEOUT,
+    _hero_node_resources,
     _slimpajama_6b_dataset,
 )
 from experiments.grug.moe_hero_fsdp.model import GrugModelConfig
@@ -131,14 +131,7 @@ def build_checkpoint_benchmark_run(
         replica_axis_size=dp_racks,
         sharding_dump_path=None,
     )
-    train_resources = ResourceConfig.with_gpu(
-        "GB200",
-        count=4,
-        cpu=120,
-        ram="850g",
-        disk="1t",
-        replicas=HERO_NODES_PER_RACK * dp_racks,
-    )
+    train_resources = _hero_node_resources(HERO_NODES_PER_RACK * dp_racks)
     name = f"grug/checkpoint-benchmark/{run_id}"
     version = resolve_version(name, version)
     step_name = user_namespaced_name(name, version)

--- a/experiments/grug/moe_hero_fsdp/compile_cache_probe.py
+++ b/experiments/grug/moe_hero_fsdp/compile_cache_probe.py
@@ -1,0 +1,252 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Multi-node XLA compilation-cache probe on the hero FSDP code path.
+
+The hero run's compile is minutes long, so a caching change costs an hour per
+iteration to evaluate. This launcher runs the same ``run_grug`` entrypoint, the
+same ``sonic_cute`` / ``gpu_fa4_cute`` kernels, and the same PGLE and mesh
+wiring against a four-layer model, which brings the loop down to a few minutes
+while keeping every cache key input that matters: XLA flags, device topology,
+and PGLE's two-key scheme.
+
+Compile time does not scale down with the model, so the probe measures cache
+hits and keys, not the cost of a hero compile. Four layers of custom-call
+matmuls also leave XLA little to autotune, so it is the wrong instrument for
+measuring the per-fusion autotune cache.
+
+Two nodes is the smallest shape that exercises cross-node behavior — JAX writes
+persistent cache entries only from process 0, so a single node cannot show
+whether the other nodes hit or miss.
+
+Read the outcome from the task logs, which carry JAX's own accounting when the
+launcher is submitted with ``-e JAX_EXPLAIN_CACHE_MISSES 1``:
+
+    PERSISTENT COMPILATION CACHE MISS for '<module>' with key '<key>'
+    Persistent compilation cache hit for '<module>' with key '<key>'
+
+Point successive runs at their own cache prefix with
+``-e JAX_COMPILATION_CACHE_DIR <prefix>`` to make "cold" reproducible.
+"""
+
+import dataclasses
+import math
+
+import click
+import jmp
+from levanter.callbacks.profiler import ProfilerConfig
+from levanter.callbacks.progress_watchdog import ProgressWatchdogConfig
+from levanter.callbacks.watch import WatchConfig
+from levanter.checkpoint import CheckpointerConfig
+from levanter.tracker.telemetry import TelemetryConfig
+from levanter.trainer import TrainerConfig
+from fray.cluster import ResourceConfig
+from marin.execution.artifact import Artifact
+from marin.execution.build_context import resolve_version
+from marin.execution.lazy import ArtifactStep, StepContext
+from marin.experiment.cli import build_options
+from marin.experiment.data import mixture
+from marin.experiment.namespacing import user_namespaced_name
+from rigging.filesystem import marin_temp_bucket, prefix_join
+
+from experiments.grug.moe_hero_fsdp.heuristic import MoeHeuristic
+from experiments.grug.moe_hero_fsdp.launch import (
+    _SLIMPAJAMA_SHUFFLE,
+    HERO_GPUS_PER_TASK,
+    HERO_MIXED_PRECISION,
+    HERO_PROCESS_STALL_TIMEOUT,
+    HERO_PROCESSES_PER_TASK,
+    HERO_TRAIN_STEP_TIMEOUT,
+    _slimpajama_6b_dataset,
+)
+from experiments.grug.moe_hero_fsdp.model import GrugModelConfig
+from experiments.grug.moe_hero_fsdp.optimizer import GrugMoeMuonHConfig
+from experiments.grug.moe_hero_fsdp.train import GrugRunConfig, GrugTrainerConfig, run_grug
+
+DEFAULT_PROBE_NODES = 2
+# PGLE recompiles with an FDO profile only after `jax_pgle_profiling_runs` (3)
+# executions, and that recompile is what populates the second of PGLE's two
+# cache keys. Stay well clear of the boundary.
+DEFAULT_PROBE_STEPS = 8
+PROBE_SEQUENCES_PER_DEVICE = 8
+PROBE_OUTPUT_TTL_DAYS = 1
+
+
+class CompileCacheProbeResult(Artifact):
+    """Task logs from a compilation-cache probe run."""
+
+
+def build_probe_configs(*, num_train_steps: int, batch_size: int) -> tuple[GrugModelConfig, GrugMoeMuonHConfig]:
+    """Build the four-layer probe model.
+
+    Head dim, sliding window, expert chunking, and both kernel backends match the
+    hero, so the compiled program has the same kinds of fusions and custom calls.
+    Layer and expert counts are cut to keep an iteration under five minutes.
+    """
+    hidden_dim = 2048
+    model = GrugModelConfig(
+        vocab_size=128_256,
+        hidden_dim=hidden_dim,
+        intermediate_dim=hidden_dim,
+        shared_expert_intermediate_dim=hidden_dim,
+        num_shared_experts=1,
+        num_experts=32,
+        num_experts_per_token=1,
+        num_layers=4,
+        num_heads=16,
+        num_kv_heads=4,
+        local_kv_heads=4,
+        global_kv_heads=2,
+        head_dim=128,
+        max_seq_len=2048,
+        sliding_window=512,
+        global_every=4,
+        capacity_factor=1.0,
+        initializer_std=0.5 / math.sqrt(hidden_dim),
+        qk_mult=1.3,
+        sconv=True,
+        attention_implementation="gpu_fa4_cute",
+        moe_implementation="sonic_cute",
+        expert_chunks=4,
+        report_capacity_overflow=True,
+        rope_fused=True,
+    )
+    optimizer = MoeHeuristic().build_optimizer_config(
+        num_train_steps=num_train_steps,
+        batch_size=batch_size,
+        hidden_dim=model.hidden_dim,
+        seq_len=model.max_seq_len,
+    )
+    return model, optimizer
+
+
+def build_compile_cache_probe_run(
+    *,
+    run_id: str,
+    nodes: int,
+    num_steps: int,
+    data_seed: int | None = None,
+    version: str | None = None,
+) -> ArtifactStep[CompileCacheProbeResult]:
+    """Build the multi-node compilation-cache probe.
+
+    Change ``data_seed`` between runs to select a different first shuffled data
+    block without changing compilation keys.
+    """
+    if not run_id.strip():
+        raise ValueError("run_id must not be empty")
+    if nodes < 2:
+        raise ValueError(f"nodes must be at least 2 to exercise cross-node caching, got {nodes}")
+    if num_steps <= 0:
+        raise ValueError(f"num_steps must be positive, got {num_steps}")
+
+    batch_size = nodes * HERO_GPUS_PER_TASK * PROBE_SEQUENCES_PER_DEVICE
+    model, optimizer = build_probe_configs(num_train_steps=num_steps, batch_size=batch_size)
+    # One DP replica per node: parameters are FSDP-sharded over each node's four
+    # GPUs and replicated across nodes, the hero's rack-local layout at node scale.
+    grug_trainer = GrugTrainerConfig(
+        data_seed=data_seed,
+        log_every=1,
+        ema_beta=None,
+        z_loss_weight=1e-4,
+        offload_opt_state=False,
+        save_checkpoints=False,
+        expert_axis_size=1,
+        replica_axis_size=nodes,
+        sharding_dump_path=None,
+    )
+    train_resources = ResourceConfig.with_gpu(
+        "GB200",
+        count=HERO_GPUS_PER_TASK,
+        cpu=120,
+        ram="850g",
+        disk="1t",
+        replicas=nodes,
+    )
+    name = f"grug/compile-cache-probe/{run_id}"
+    version = resolve_version(name, version)
+    step_name = user_namespaced_name(name, version)
+    slim = _slimpajama_6b_dataset()
+    output_path = marin_temp_bucket(ttl_days=PROBE_OUTPUT_TTL_DAYS, prefix=prefix_join(step_name, version))
+
+    def build_config(ctx: StepContext) -> GrugRunConfig:
+        trainer = TrainerConfig(
+            id=run_id,
+            seed=0,
+            train_batch_size=batch_size,
+            num_train_steps=num_steps,
+            profiler=ProfilerConfig(enabled=False, start_step=8, num_steps=0),
+            mp=jmp.get_policy(HERO_MIXED_PRECISION),
+            tracker=TelemetryConfig(),
+            watch=WatchConfig(interval=20),
+            progress_watchdog=ProgressWatchdogConfig(
+                step_timeout=HERO_TRAIN_STEP_TIMEOUT,
+                process_timeout=HERO_PROCESS_STALL_TIMEOUT,
+            ),
+            use_explicit_mesh_axes=True,
+            require_accelerator=True,
+            allow_nondivisible_batch_size=False,
+            checkpointer=CheckpointerConfig(
+                base_path=prefix_join(ctx.output_path, "checkpoints"),
+                temporary_base_path=None,
+                save_interval=None,
+                keep=None,
+                append_run_id_to_base_path=False,
+            ),
+        )
+        return GrugRunConfig(
+            model=model,
+            data=mixture(ctx, {slim: 1.0}, shuffle=_SLIMPAJAMA_SHUFFLE),
+            resources=ctx.runtime_arg("train_resources"),
+            optimizer=optimizer,
+            trainer=dataclasses.replace(grug_trainer, trainer=trainer),
+            eval=None,
+            processes_per_task=HERO_PROCESSES_PER_TASK,
+        )
+
+    return ArtifactStep(
+        name=step_name,
+        version=version,
+        artifact_type=CompileCacheProbeResult,
+        run=run_grug,
+        build_config=build_config,
+        deps=(slim,),
+        runtime_args={"train_resources": train_resources},
+        override_path=output_path,
+    )
+
+
+@click.command()
+@click.option("--run-id", required=True, help="Run identifier for artifact and telemetry names.")
+@click.option(
+    "--nodes",
+    type=click.IntRange(min=2),
+    default=DEFAULT_PROBE_NODES,
+    show_default=True,
+    help="GB200 nodes, four GPUs each. One data-parallel replica per node.",
+)
+@click.option(
+    "--num-steps",
+    type=click.IntRange(min=1),
+    default=DEFAULT_PROBE_STEPS,
+    show_default=True,
+    help="Number of training steps.",
+)
+@click.option(
+    "--data-seed",
+    type=int,
+    default=None,
+    help="Dataset shuffle seed. Use distinct values to measure cold first-block reads on reused nodes.",
+)
+@build_options
+def main(run_id: str, nodes: int, num_steps: int, data_seed: int | None) -> ArtifactStep[CompileCacheProbeResult]:
+    return build_compile_cache_probe_run(
+        run_id=run_id,
+        nodes=nodes,
+        num_steps=num_steps,
+        data_seed=data_seed,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/grug/moe_hero_fsdp/compile_cache_probe.py
+++ b/experiments/grug/moe_hero_fsdp/compile_cache_probe.py
@@ -34,7 +34,6 @@ import math
 
 import click
 import jmp
-from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfilerConfig
 from levanter.callbacks.progress_watchdog import ProgressWatchdogConfig
 from levanter.callbacks.watch import WatchConfig
@@ -57,6 +56,7 @@ from experiments.grug.moe_hero_fsdp.launch import (
     HERO_PROCESS_STALL_TIMEOUT,
     HERO_PROCESSES_PER_TASK,
     HERO_TRAIN_STEP_TIMEOUT,
+    _hero_node_resources,
     _slimpajama_6b_dataset,
 )
 from experiments.grug.moe_hero_fsdp.model import GrugModelConfig
@@ -77,12 +77,7 @@ class CompileCacheProbeResult(Artifact):
 
 
 def build_probe_configs(*, num_train_steps: int, batch_size: int) -> tuple[GrugModelConfig, GrugMoeMuonHConfig]:
-    """Build the four-layer probe model.
-
-    Head dim, sliding window, expert chunking, and both kernel backends match the
-    hero, so the compiled program has the same kinds of fusions and custom calls.
-    Layer and expert counts are cut to keep an iteration under five minutes.
-    """
+    """Build the model and optimizer for a short multi-node compilation-cache probe."""
     hidden_dim = 2048
     model = GrugModelConfig(
         vocab_size=128_256,
@@ -155,14 +150,7 @@ def build_compile_cache_probe_run(
         replica_axis_size=nodes,
         sharding_dump_path=None,
     )
-    train_resources = ResourceConfig.with_gpu(
-        "GB200",
-        count=HERO_GPUS_PER_TASK,
-        cpu=120,
-        ram="850g",
-        disk="1t",
-        replicas=nodes,
-    )
+    train_resources = _hero_node_resources(nodes)
     name = f"grug/compile-cache-probe/{run_id}"
     version = resolve_version(name, version)
     step_name = user_namespaced_name(name, version)

--- a/experiments/grug/moe_hero_fsdp/compile_cache_probe.py
+++ b/experiments/grug/moe_hero_fsdp/compile_cache_probe.py
@@ -34,13 +34,13 @@ import math
 
 import click
 import jmp
+from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfilerConfig
 from levanter.callbacks.progress_watchdog import ProgressWatchdogConfig
 from levanter.callbacks.watch import WatchConfig
 from levanter.checkpoint import CheckpointerConfig
 from levanter.tracker.telemetry import TelemetryConfig
 from levanter.trainer import TrainerConfig
-from fray.cluster import ResourceConfig
 from marin.execution.artifact import Artifact
 from marin.execution.build_context import resolve_version
 from marin.execution.lazy import ArtifactStep, StepContext

--- a/experiments/grug/moe_hero_fsdp/launch.py
+++ b/experiments/grug/moe_hero_fsdp/launch.py
@@ -161,14 +161,14 @@ def _hero_run_config(
     )
 
 
-def _hero_resources(dp_racks: int) -> ResourceConfig:
+def _hero_node_resources(nodes: int) -> ResourceConfig:
     return ResourceConfig.with_gpu(
         "GB200",
         count=HERO_GPUS_PER_TASK,
         cpu=120,
         ram="850g",
         disk="1t",
-        replicas=HERO_NODES_PER_RACK * dp_racks,
+        replicas=nodes,
     )
 
 
@@ -217,7 +217,7 @@ def _hero_run_parts(
             replica_axis_size=dp_racks,
             sharding_dump_path=None,
         ),
-        train_resources=_hero_resources(dp_racks),
+        train_resources=_hero_node_resources(HERO_NODES_PER_RACK * dp_racks),
         name=name,
         version=resolve_version(name, version),
         slim=_slimpajama_6b_dataset(),

--- a/experiments/grug/moe_hero_fsdp/train.py
+++ b/experiments/grug/moe_hero_fsdp/train.py
@@ -44,7 +44,11 @@ from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.jax_utils import parameter_count
 from levanter.utils.logging import LoadingTimeTrackerIterator
 
-from experiments.grug.checkpointing import prepare_grug_checkpoint_restore, restore_grug_state_from_checkpoint
+from experiments.grug.checkpointing import (
+    GrugCheckpointRestoreMode,
+    prepare_grug_checkpoint_restore,
+    restore_grug_state_from_checkpoint,
+)
 from experiments.grug.dispatch import dispatch_grug_training_run
 from experiments.grug.moe_hero_fsdp.model import GrugModelConfig, Transformer
 from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
@@ -512,7 +516,9 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             mesh=mesh,
         )
         checkpoint_search_paths = trainer.checkpoint_search_paths(run_id)
-        restore_plan = prepare_grug_checkpoint_restore(checkpoint_search_paths, trainer.load_checkpoint)
+        restore_plan = prepare_grug_checkpoint_restore(
+            checkpoint_search_paths, GrugCheckpointRestoreMode(trainer.load_checkpoint)
+        )
         data_iterator = train_loader.iter_from_step(restore_plan.expected_step)
         iterator = LoadingTimeTrackerIterator(data_iterator)
 

--- a/experiments/grug/moe_hero_fsdp/train.py
+++ b/experiments/grug/moe_hero_fsdp/train.py
@@ -44,7 +44,7 @@ from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.jax_utils import parameter_count
 from levanter.utils.logging import LoadingTimeTrackerIterator
 
-from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
+from experiments.grug.checkpointing import prepare_grug_checkpoint_restore, restore_grug_state_from_checkpoint
 from experiments.grug.dispatch import dispatch_grug_training_run
 from experiments.grug.moe_hero_fsdp.model import GrugModelConfig, Transformer
 from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
@@ -511,6 +511,10 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             batch_schedule=batch_schedule,
             mesh=mesh,
         )
+        checkpoint_search_paths = trainer.checkpoint_search_paths(run_id)
+        restore_plan = prepare_grug_checkpoint_restore(checkpoint_search_paths, trainer.load_checkpoint)
+        data_iterator = train_loader.iter_from_step(restore_plan.expected_step)
+        iterator = LoadingTimeTrackerIterator(data_iterator)
 
         @jax.jit
         def _init_state(model_rng):
@@ -523,16 +527,26 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 offload_opt_state=config.trainer.offload_opt_state,
             )
 
-        state = _init_state(model_key)
+        try:
+            state = _init_state(model_key)
 
-        checkpointer = trainer.checkpointer.create(run_id) if config.trainer.save_checkpoints else None
-        state = restore_grug_state_from_checkpoint(
-            state,
-            checkpoint_search_paths=trainer.checkpoint_search_paths(run_id),
-            load_checkpoint_setting=trainer.load_checkpoint,
-            mesh=mesh,
-            allow_partial=trainer.allow_partial_checkpoint,
-        )
+            checkpointer = trainer.checkpointer.create(run_id) if config.trainer.save_checkpoints else None
+            state = restore_grug_state_from_checkpoint(
+                state,
+                checkpoint_search_paths=checkpoint_search_paths,
+                load_checkpoint_setting=trainer.load_checkpoint,
+                mesh=mesh,
+                allow_partial=trainer.allow_partial_checkpoint,
+                restore_plan=restore_plan,
+            )
+        except BaseException:
+            data_iterator.close()
+            raise
+
+        if int(state.step) != restore_plan.expected_step:
+            data_iterator.close()
+            data_iterator = train_loader.iter_from_step(int(state.step))
+            iterator = LoadingTimeTrackerIterator(data_iterator)
         dump_grug_state_sharding_run_artifact(
             state,
             log_dir=trainer.log_dir,
@@ -560,8 +574,6 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         profiler_enabled = profiler_cfg.is_enabled and profiler_num_steps > 0
 
         log_every = max(1, config.trainer.log_every)
-        iterator = LoadingTimeTrackerIterator(train_loader.iter_from_step(int(state.step)))
-
         state_callbacks = StateCallbackRunner[GrugTrainState](
             step_getter=lambda s: s.step,
             model_getter=lambda s: s.params,
@@ -687,6 +699,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                     checkpointer.on_step(tree=state, step=int(state.step), force=True)
                     checkpointer.wait_until_finished()
         finally:
+            data_iterator.close()
             state_callbacks.emit_event(callbacks.ProgressEvent.TRAINING_FINISHED)
 
     levanter.tracker.current_tracker().finish()

--- a/lib/levanter/src/levanter/data/loader.py
+++ b/lib/levanter/src/levanter/data/loader.py
@@ -235,6 +235,7 @@ class DataLoaderIterator(Iterator[Ex]):
     def __init__(self, data_loader: DataLoader, start_from_batch: int | None = None):
         self.dl = data_loader
         self._start_from_batch = start_from_batch
+        self._closed = False
         self.mapping = self.dl.axis_resources
         if self.mapping is None:
             self.mapping = hax.partitioning.current_thread_local_mapping()
@@ -262,8 +263,23 @@ class DataLoaderIterator(Iterator[Ex]):
         return batch
 
     def __del__(self):
-        if hasattr(self, "_batches") and hasattr(self._batches, "stop"):
+        self.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def close(self):
+        """Stop background prefetch and release its worker thread."""
+        if self._closed or not hasattr(self, "_batches"):
+            return
+        self._closed = True
+        if isinstance(self._batches, BackgroundIterator):
             self._batches.stop()
+        elif isinstance(self._batches, AsyncIteratorWrapper):
+            self._batches.close()
 
     async def _produce_batches(self):
         with local_cpu_mesh():

--- a/lib/levanter/src/levanter/data/loader.py
+++ b/lib/levanter/src/levanter/data/loader.py
@@ -268,7 +268,7 @@ class DataLoaderIterator(Iterator[Ex]):
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, _exc_type, _exc_value, _traceback):
         self.close()
 
     def close(self):

--- a/lib/levanter/src/levanter/data/loader.py
+++ b/lib/levanter/src/levanter/data/loader.py
@@ -265,12 +265,6 @@ class DataLoaderIterator(Iterator[Ex]):
     def __del__(self):
         self.close()
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, _exc_type, _exc_value, _traceback):
-        self.close()
-
     def close(self):
         """Stop background prefetch and release its worker thread."""
         if self._closed or not hasattr(self, "_batches"):

--- a/lib/levanter/src/levanter/utils/background_iterable.py
+++ b/lib/levanter/src/levanter/utils/background_iterable.py
@@ -48,6 +48,9 @@ class BackgroundIterator(Iterator[Ex]):
         else:
             self._producer_fn = producer_fn
         self._stop_event = threading.Event()
+        self._async_producer_lock = threading.Lock()
+        self._async_producer_loop: asyncio.AbstractEventLoop | None = None
+        self._async_producer_task: asyncio.Task[None] | None = None
 
         if self.max_capacity is None or self.max_capacity >= 0:
             self.q: queue.Queue = queue.Queue(self.max_capacity or 0)
@@ -91,6 +94,9 @@ class BackgroundIterator(Iterator[Ex]):
 
     def stop(self, wait: bool = True):
         self._stop_event.set()
+        with self._async_producer_lock:
+            if self._async_producer_loop is not None and self._async_producer_task is not None:
+                self._async_producer_loop.call_soon_threadsafe(self._async_producer_task.cancel)
         # I'm getting an error that the thread is threading.current_thread(), which seems impossible
         if self.thread is not None and wait and self.thread != threading.current_thread():
             self.thread.join()
@@ -130,13 +136,27 @@ class BackgroundIterator(Iterator[Ex]):
             self.q.put(_ExceptionWrapper(sys.exc_info()))
 
     async def _produce_batches_async(self, iterator):
+        task = asyncio.current_task()
+        assert task is not None
+        with self._async_producer_lock:
+            self._async_producer_loop = asyncio.get_running_loop()
+            self._async_producer_task = task
+
         try:
+            if self._stop_event.is_set():
+                return
             async for batch in iterator:
                 if not self._enqueue(batch):
                     return
             self._enqueue(_SENTINEL)
+        except asyncio.CancelledError:
+            return
         except Exception:
             self.q.put(_ExceptionWrapper(sys.exc_info()))
+        finally:
+            with self._async_producer_lock:
+                self._async_producer_loop = None
+                self._async_producer_task = None
 
 
 class _Sentinel:

--- a/lib/levanter/tests/test_new_loader.py
+++ b/lib/levanter/tests/test_new_loader.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import threading
 from typing import Sequence
 
 import jax
@@ -61,6 +62,40 @@ def test_loader_rejects_empty_finite_dataset():
         dataset = ListAsyncDataset([])
         with pytest.raises(ValueError, match="finite but has length 0"):
             DataLoader(dataset, 1, max_buffered_batches=0, mesh=mesh, axis_resources=None)
+
+
+class BlockingBatchDataset(AsyncDataset[np.ndarray]):
+    def __init__(self):
+        self.started = threading.Event()
+        self.cancelled = threading.Event()
+
+    def is_finite(self) -> bool:
+        return False
+
+    async def async_len(self) -> int:
+        raise ValueError("infinite dataset")
+
+    async def getitem_async(self, index: int) -> np.ndarray:
+        return np.array(index, dtype=np.int32)
+
+    async def get_batch(self, indices: Sequence[int]) -> Sequence[np.ndarray]:
+        self.started.set()
+        try:
+            await asyncio.Future()
+        finally:
+            self.cancelled.set()
+
+
+def test_loader_iterator_close_cancels_in_flight_prefetch():
+    with use_test_mesh(tensor_parallelism=1) as mesh, haliax.axis_mapping({"batch": ResourceAxis.DATA}):
+        dataset = BlockingBatchDataset()
+        loader = DataLoader(dataset, 1, max_buffered_batches=1, mesh=mesh, axis_resources=None)
+        iterator = loader.iter_from_step(0)
+
+        assert dataset.started.wait(timeout=5)
+        iterator.close()
+        assert dataset.cancelled.wait(timeout=5)
+        iterator.close()
 
 
 class StructuredDataset(AsyncDataset):

--- a/lib/levanter/tests/test_new_loader.py
+++ b/lib/levanter/tests/test_new_loader.py
@@ -78,7 +78,7 @@ class BlockingBatchDataset(AsyncDataset[np.ndarray]):
     async def getitem_async(self, index: int) -> np.ndarray:
         return np.array(index, dtype=np.int32)
 
-    async def get_batch(self, indices: Sequence[int]) -> Sequence[np.ndarray]:
+    async def get_batch(self, _indices: Sequence[int]) -> Sequence[np.ndarray]:
         self.started.set()
         try:
             await asyncio.Future()
@@ -95,7 +95,6 @@ def test_loader_iterator_close_cancels_in_flight_prefetch():
         assert dataset.started.wait(timeout=5)
         iterator.close()
         assert dataset.cancelled.wait(timeout=5)
-        iterator.close()
 
 
 class StructuredDataset(AsyncDataset):

--- a/lib/levanter/tests/test_new_loader.py
+++ b/lib/levanter/tests/test_new_loader.py
@@ -89,7 +89,7 @@ class BlockingBatchDataset(AsyncDataset[np.ndarray]):
 def test_loader_iterator_close_cancels_in_flight_prefetch():
     with use_test_mesh(tensor_parallelism=1) as mesh, haliax.axis_mapping({"batch": ResourceAxis.DATA}):
         dataset = BlockingBatchDataset()
-        loader = DataLoader(dataset, 1, max_buffered_batches=1, mesh=mesh, axis_resources=None)
+        loader = DataLoader(dataset, len(jax.devices()), max_buffered_batches=1, mesh=mesh, axis_resources=None)
         iterator = loader.iter_from_step(0)
 
         assert dataset.started.wait(timeout=5)

--- a/tests/test_grug_checkpointing.py
+++ b/tests/test_grug_checkpointing.py
@@ -13,6 +13,7 @@ from jax.tree_util import register_dataclass
 from levanter.checkpoint import Checkpointer, CheckpointInterval, latest_checkpoint_path
 
 from experiments.grug.checkpointing import (
+    GrugCheckpointRestoreMode,
     init_weights_only_from_checkpoint,
     prepare_grug_checkpoint_restore,
     restore_grug_state_from_checkpoint,
@@ -150,7 +151,7 @@ def test_restore_prefers_highest_step_over_latest_timestamp(tmp_path: Path):
         attempted.append(path)
         return {"loaded_from": path}
 
-    restore_plan = prepare_grug_checkpoint_restore([str(checkpoint_root)], load_checkpoint_setting=True)
+    restore_plan = prepare_grug_checkpoint_restore([str(checkpoint_root)], GrugCheckpointRestoreMode.REQUIRED)
     loaded = restore_grug_state_from_checkpoint(
         {"state": "init"},
         checkpoint_search_paths=[str(checkpoint_root)],

--- a/tests/test_grug_checkpointing.py
+++ b/tests/test_grug_checkpointing.py
@@ -12,7 +12,11 @@ import pytest
 from jax.tree_util import register_dataclass
 from levanter.checkpoint import Checkpointer, CheckpointInterval, latest_checkpoint_path
 
-from experiments.grug.checkpointing import init_weights_only_from_checkpoint, restore_grug_state_from_checkpoint
+from experiments.grug.checkpointing import (
+    init_weights_only_from_checkpoint,
+    prepare_grug_checkpoint_restore,
+    restore_grug_state_from_checkpoint,
+)
 
 
 @register_dataclass
@@ -146,15 +150,18 @@ def test_restore_prefers_highest_step_over_latest_timestamp(tmp_path: Path):
         attempted.append(path)
         return {"loaded_from": path}
 
+    restore_plan = prepare_grug_checkpoint_restore([str(checkpoint_root)], load_checkpoint_setting=True)
     loaded = restore_grug_state_from_checkpoint(
         {"state": "init"},
         checkpoint_search_paths=[str(checkpoint_root)],
         load_checkpoint_setting=True,
         mesh=None,
         allow_partial=False,
+        restore_plan=restore_plan,
         _load_fn=fake_load,
     )
 
+    assert restore_plan.expected_step == 100
     assert attempted == [str(checkpoint_root / "step-100")]
     assert loaded == {"loaded_from": str(checkpoint_root / "step-100")}
 


### PR DESCRIPTION
Start Grug training-data prefetch as soon as the mesh-aware loader and checkpoint resume step are available, before state initialization. A checkpoint fallback restarts prefetch at the step actually loaded. Initialization failures and training exit cancel any in-flight asynchronous read before joining its worker.

The two-node GB200 compile-cache probe kept both train-step keys as persistent-cache hits. Baseline task 0/1 stalls were 6.812s/6.259s; the successful post-change attempt measured 4.376s/5.113s. The cross-task maximum fell from 6.812s to 5.113s, a 24.9% reduction. Task wall clock was 69.37s before and 70.07s after. The four-layer probe exposed only about 1–2s of state initialization for overlap, so the wall-clock difference is within run variance; the longer hero initialization was not run.

These measurements used #8045's one-process-per-node probe topology. #8052 landed while this branch was being rebased and changed the hero launcher to one process per GPU.
