### PR TITLE
Degrade to compiling when a compile cache is unreachable

### DIFF
--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -121,9 +121,9 @@ def _enable_node_local_xla_autotune_cache() -> None:
 
     GPU only: a TPU or CPU jaxlib aborts on an unknown ``--xla_gpu`` flag.
 
-    The mount arrives with the worker, which on the VM clusters restarts on its own
-    daily schedule rather than with the controller, so for up to a day after a
-    rollout the directory is simply absent. That is a skip, not an error.
+    The mount arrives with the worker, and VM-cluster workers restart on their own
+    daily schedule. For up to a day after a rollout a task can land on a worker
+    whose mount is absent or unwritable; skip the cache there.
     """
     if TaskResources.from_environment().gpu_count == 0:
         return

--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -120,6 +120,10 @@ def _enable_node_local_xla_autotune_cache() -> None:
     so it stays out of the compilation cache key.
 
     GPU only: a TPU or CPU jaxlib aborts on an unknown ``--xla_gpu`` flag.
+
+    The mount arrives with the worker, which on the VM clusters restarts on its own
+    daily schedule rather than with the controller, so for up to a day after a
+    rollout the directory is simply absent. That is a skip, not an error.
     """
     if TaskResources.from_environment().gpu_count == 0:
         return
@@ -133,7 +137,12 @@ def _enable_node_local_xla_autotune_cache() -> None:
         return
 
     autotune_dir = f"{SCRATCH_CACHE_PATH}/{_XLA_AUTOTUNE_CACHE_SUBDIR}"
-    os.makedirs(autotune_dir, exist_ok=True)
+    try:
+        os.makedirs(autotune_dir, exist_ok=True)
+    except OSError as exc:
+        logger.info("XLA autotune cache disabled: cannot create %s: %s", autotune_dir, exc)
+        return
+
     os.environ["XLA_FLAGS"] = f"{xla_flags} {_XLA_AUTOTUNE_CACHE_DIR_FLAG}={autotune_dir}".strip()
     logger.info("XLA per-fusion autotune cache: %s", autotune_dir)
 

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -536,6 +536,30 @@ def test_remote_cache_leaves_xla_flags_alone_without_gpus(tmp_path) -> None:
         assert "XLA_FLAGS" not in os.environ
 
 
+def test_remote_cache_skips_the_autotune_flag_when_the_mount_is_absent(tmp_path) -> None:
+    """Workers on the VM clusters restart on their own daily schedule, not with the controller.
+
+    For up to a day after a rollout adds the mount, tasks land on a worker that
+    does not have it. Compile without the autotune cache rather than abort.
+    """
+    with _isolated_jax_cache_config(), _gpu_task(tmp_path):
+        with patch.object(jax_init_module, "SCRATCH_CACHE_PATH", str(tmp_path / "never-mounted")):
+            with patch("iris.runtime.jax_init.marin_prefix", return_value="s3://marin-eu/marin/"):
+                configure_jax_compilation_cache()
+
+        assert "XLA_FLAGS" not in os.environ
+
+
+def test_remote_cache_skips_the_autotune_flag_when_the_directory_cannot_be_created(tmp_path) -> None:
+    """A mount that is present but unwritable is the same non-event as a missing one."""
+    with _isolated_jax_cache_config(), _gpu_task(tmp_path) as scratch_cache_dir:
+        (scratch_cache_dir / "xla").write_bytes(b"")
+        with patch("iris.runtime.jax_init.marin_prefix", return_value="s3://marin-eu/marin/"):
+            configure_jax_compilation_cache()
+
+        assert "XLA_FLAGS" not in os.environ
+
+
 def test_remote_cache_keeps_an_explicit_xla_autotune_dir(tmp_path) -> None:
     """An operator-chosen autotune directory wins over the node mount."""
     with _isolated_jax_cache_config(), _gpu_task(tmp_path):

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -536,26 +536,18 @@ def test_remote_cache_leaves_xla_flags_alone_without_gpus(tmp_path) -> None:
         assert "XLA_FLAGS" not in os.environ
 
 
-def test_remote_cache_skips_the_autotune_flag_when_the_mount_is_absent(tmp_path) -> None:
-    """Workers on the VM clusters restart on their own daily schedule, not with the controller.
-
-    For up to a day after a rollout adds the mount, tasks land on a worker that
-    does not have it. Compile without the autotune cache rather than abort.
-    """
-    with _isolated_jax_cache_config(), _gpu_task(tmp_path):
-        with patch.object(jax_init_module, "SCRATCH_CACHE_PATH", str(tmp_path / "never-mounted")):
+@pytest.mark.parametrize("mount", ["missing", "file-shadowed"])
+def test_remote_cache_skips_the_autotune_flag_when_the_mount_is_unusable(tmp_path, mount) -> None:
+    """No mount, or a file where the autotune dir belongs: skip the flag, don't abort JAX init."""
+    with _isolated_jax_cache_config(), _gpu_task(tmp_path) as scratch_cache_dir:
+        if mount == "missing":
+            scratch_cache_path = str(tmp_path / "never-mounted")
+        else:
+            (scratch_cache_dir / "xla").write_bytes(b"")
+            scratch_cache_path = str(scratch_cache_dir)
+        with patch.object(jax_init_module, "SCRATCH_CACHE_PATH", scratch_cache_path):
             with patch("iris.runtime.jax_init.marin_prefix", return_value="s3://marin-eu/marin/"):
                 configure_jax_compilation_cache()
-
-        assert "XLA_FLAGS" not in os.environ
-
-
-def test_remote_cache_skips_the_autotune_flag_when_the_directory_cannot_be_created(tmp_path) -> None:
-    """A mount that is present but unwritable is the same non-event as a missing one."""
-    with _isolated_jax_cache_config(), _gpu_task(tmp_path) as scratch_cache_dir:
-        (scratch_cache_dir / "xla").write_bytes(b"")
-        with patch("iris.runtime.jax_init.marin_prefix", return_value="s3://marin-eu/marin/"):
-            configure_jax_compilation_cache()
 
         assert "XLA_FLAGS" not in os.environ
 

--- a/lib/levanter/src/levanter/cutlass_kernel_cache.py
+++ b/lib/levanter/src/levanter/cutlass_kernel_cache.py
@@ -109,15 +109,24 @@ class CutlassKernelCache:
     directory: str
 
     def load(self, key: str) -> bytes | None:
-        path = self._object(key)
-        return path.read_bytes() if path.exists() else None
+        # A store that cannot be reached is a miss, not a failure: the caller
+        # compiles instead. Training must not depend on the cache being healthy.
+        try:
+            path = self._object(key)
+            return path.read_bytes() if path.exists() else None
+        except OSError as exc:
+            logger.warning("CuTeDSL kernel cache unreadable, compiling instead: %s", exc)
+            return None
 
     def store(self, key: str, module: bytes) -> None:
         # Every process compiles the same kernels at once, so stage and rename
         # rather than let a reader see a half-written object.
-        path = str(self._object(key))
-        with atomic_rename(path) as staged:
-            StoragePath(staged).write_bytes(module)
+        try:
+            path = str(self._object(key))
+            with atomic_rename(path) as staged:
+                StoragePath(staged).write_bytes(module)
+        except OSError as exc:
+            logger.warning("CuTeDSL kernel cache unwritable, not storing %s: %s", key, exc)
 
     def _object(self, key: str) -> StoragePath:
         return _root(self.directory) / f"{key}{_OBJECT_SUFFIX}"
@@ -128,6 +137,23 @@ def _root(directory: str) -> StoragePath:
     path = StoragePath(directory)
     path.mkdirs()
     return path
+
+
+def install_if_available(cache: CutlassKernelCache) -> bool:
+    """Install ``cache`` when ``cutlass.jax`` can actually be imported.
+
+    The package being present does not mean it imports: ``cutlass.jax`` pulls in
+    CUDA bindings, so it fails on a CPU task running the GPU image, or on a host
+    whose driver does not match. Returns whether the cache was installed.
+    """
+    try:
+        importlib.import_module("cutlass.jax.primitive")
+    except ImportError as exc:
+        logger.info("CuTeDSL kernel cache skipped, cutlass.jax unavailable: %s", exc)
+        return False
+
+    install(cache)
+    return True
 
 
 def install(cache: CutlassKernelCache) -> None:

--- a/lib/levanter/src/levanter/cutlass_kernel_cache.py
+++ b/lib/levanter/src/levanter/cutlass_kernel_cache.py
@@ -109,8 +109,6 @@ class CutlassKernelCache:
     directory: str
 
     def load(self, key: str) -> bytes | None:
-        # A store that cannot be reached is a miss, not a failure: the caller
-        # compiles instead. Training must not depend on the cache being healthy.
         try:
             path = self._object(key)
             return path.read_bytes() if path.exists() else None
@@ -139,31 +137,21 @@ def _root(directory: str) -> StoragePath:
     return path
 
 
-def install_if_available(cache: CutlassKernelCache) -> bool:
-    """Install ``cache`` when ``cutlass.jax`` can actually be imported.
-
-    The package being present does not mean it imports: ``cutlass.jax`` pulls in
-    CUDA bindings, so it fails on a CPU task running the GPU image, or on a host
-    whose driver does not match. Returns whether the cache was installed.
-    """
-    try:
-        importlib.import_module("cutlass.jax.primitive")
-    except ImportError as exc:
-        logger.info("CuTeDSL kernel cache skipped, cutlass.jax unavailable: %s", exc)
-        return False
-
-    install(cache)
-    return True
-
-
 def install(cache: CutlassKernelCache) -> None:
     """Route ``cutlass.jax`` kernel compiles through ``cache``.
 
     Patches ``cutlass.jax.primitive``, which binds ``get_or_compile_kernel`` at
-    import time, rather than the function's defining module. Idempotent.
+    import time, rather than the function's defining module. Idempotent, and a
+    no-op when ``cutlass.jax`` will not import: a CPU task on the GPU image has
+    the package but not the CUDA bindings it pulls in.
     """
-    primitive = importlib.import_module("cutlass.jax.primitive")
-    compile_module = importlib.import_module("cutlass.jax.compile")
+    try:
+        primitive = importlib.import_module("cutlass.jax.primitive")
+        compile_module = importlib.import_module("cutlass.jax.compile")
+    except ImportError as exc:
+        logger.info("CuTeDSL kernel cache skipped, cutlass.jax unavailable: %s", exc)
+        return
+
     if getattr(primitive.get_or_compile_kernel, "_levanter_kernel_cache", None) is not None:
         logger.info("CuTeDSL kernel cache already installed")
         return

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -4,7 +4,6 @@
 import atexit
 import copy
 import functools
-import importlib.util
 import logging as pylogging
 import os
 import sys
@@ -69,7 +68,7 @@ from levanter.callbacks.watch import WatchConfig
 from levanter.checkpoint import Checkpointer, CheckpointerConfig, is_checkpoint_path, load_checkpoint_or_initialize
 from levanter.config import JsonAtom
 from levanter.cutlass_kernel_cache import CutlassKernelCache
-from levanter.cutlass_kernel_cache import install as install_cutlass_kernel_cache
+from levanter.cutlass_kernel_cache import install_if_available as install_cutlass_kernel_cache
 from levanter.data.dataset import AsyncDataset
 from levanter.data.loader import DataLoader
 from levanter.data.loader import _round_to_nearest_multiple
@@ -851,10 +850,10 @@ def _install_cutlass_kernel_cache() -> None:
 
     The two caches want the same location for the same reason, so this derives one
     from the other instead of adding a second knob. Skipped when no compilation
-    cache is configured, or on a build without ``cutlass.jax``.
+    cache is configured, or when ``cutlass.jax`` will not import.
     """
     cache_dir = jax.config.jax_compilation_cache_dir
-    if not cache_dir or importlib.util.find_spec("cutlass") is None:
+    if not cache_dir:
         return
 
     install_cutlass_kernel_cache(CutlassKernelCache(directory=prefix_join(cache_dir, _CUTLASS_KERNEL_CACHE_SUBDIR)))

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -68,7 +68,7 @@ from levanter.callbacks.watch import WatchConfig
 from levanter.checkpoint import Checkpointer, CheckpointerConfig, is_checkpoint_path, load_checkpoint_or_initialize
 from levanter.config import JsonAtom
 from levanter.cutlass_kernel_cache import CutlassKernelCache
-from levanter.cutlass_kernel_cache import install_if_available as install_cutlass_kernel_cache
+from levanter.cutlass_kernel_cache import install as install_cutlass_kernel_cache
 from levanter.data.dataset import AsyncDataset
 from levanter.data.loader import DataLoader
 from levanter.data.loader import _round_to_nearest_multiple

--- a/lib/levanter/tests/test_cutlass_kernel_cache.py
+++ b/lib/levanter/tests/test_cutlass_kernel_cache.py
@@ -19,7 +19,7 @@ from typing import Any
 
 import pytest
 
-from levanter.cutlass_kernel_cache import CutlassKernelCache, cute_launcher_factory, install, install_if_available
+from levanter.cutlass_kernel_cache import CutlassKernelCache, cute_launcher_factory, install
 
 
 @dataclasses.dataclass(frozen=True)
@@ -181,32 +181,20 @@ def test_a_specification_that_reprs_an_address_is_not_stored(fake_cutlass, tmp_p
     assert list(tmp_path.iterdir()) == []
 
 
-def test_a_store_that_cannot_be_reached_compiles_instead_of_failing(fake_cutlass, tmp_path):
-    """The store follows the compilation cache dir, which a task may have no access to."""
-    blocked = tmp_path / "not-a-directory"
+def test_an_unwritable_store_compiles_without_failing(fake_cutlass, tmp_path):
+    """The store follows the compilation cache dir, which a task may not be able to write."""
+    blocked = tmp_path / "file"
     blocked.write_bytes(b"")
-    cache = CutlassKernelCache(directory=str(blocked / "kernels"))
-    install(cache)
+    install(CutlassKernelCache(directory=str(blocked / "kernels")))
 
-    cold = fake_cutlass.compile_kernel(build_launcher(None, tile=128), FakeFunctionSpec(shape=(8, 16)))
-    fake_cutlass.forget_process_state()
-    install(cache)
-    warm = fake_cutlass.compile_kernel(build_launcher(None, tile=128), FakeFunctionSpec(shape=(8, 16)))
+    result = fake_cutlass.compile_kernel(build_launcher(None, tile=128), FakeFunctionSpec(shape=(8, 16)))
 
-    assert fake_cutlass.compiled == ["tile128-bf16", "tile128-bf16"]
-    assert warm.module == cold.module
+    assert fake_cutlass.compiled == ["tile128-bf16"]
+    assert result.module == b"objectcode:tile128-bf16:FakeFunctionSpec(shape=(8, 16))"
 
 
-def test_a_build_that_cannot_import_cutlass_jax_is_skipped(monkeypatch, tmp_path):
+def test_install_is_a_noop_when_cutlass_jax_will_not_import(monkeypatch, tmp_path):
     """A CPU task on the GPU image has the package but no CUDA bindings to import it with."""
     monkeypatch.setitem(sys.modules, "cutlass.jax.primitive", None)
 
-    assert install_if_available(CutlassKernelCache(directory=str(tmp_path))) is False
-
-
-def test_a_build_that_imports_cutlass_jax_gets_the_cache(fake_cutlass, tmp_path):
-    assert install_if_available(CutlassKernelCache(directory=str(tmp_path))) is True
-
-    fake_cutlass.compile_kernel(build_launcher(None, tile=128), FakeFunctionSpec(shape=(8, 16)))
-
-    assert len(list(tmp_path.iterdir())) == 1
+    install(CutlassKernelCache(directory=str(tmp_path)))

--- a/lib/levanter/tests/test_cutlass_kernel_cache.py
+++ b/lib/levanter/tests/test_cutlass_kernel_cache.py
@@ -11,6 +11,7 @@ entry point bound into ``cutlass.jax.primitive``, the in-process
 
 import dataclasses
 import hashlib
+import importlib
 import sys
 import textwrap
 import types
@@ -142,6 +143,9 @@ def test_editing_the_launcher_source_invalidates_its_kernels(fake_cutlass, tmp_p
     for revision in ("original", "edited"):
         name = f"edited_launcher_{revision}"
         (module_dir / f"{name}.py").write_text(f"# revision: {revision}\n{source}")
+        # The import system caches each directory's listing against its mtime, so a
+        # second file written inside one mtime tick is invisible to the finder.
+        importlib.invalidate_caches()
         module = __import__(name)
         fake_cutlass.forget_process_state()
         install(cache)

--- a/lib/levanter/tests/test_cutlass_kernel_cache.py
+++ b/lib/levanter/tests/test_cutlass_kernel_cache.py
@@ -193,8 +193,12 @@ def test_an_unwritable_store_compiles_without_failing(fake_cutlass, tmp_path):
     assert result.module == b"objectcode:tile128-bf16:FakeFunctionSpec(shape=(8, 16))"
 
 
-def test_install_is_a_noop_when_cutlass_jax_will_not_import(monkeypatch, tmp_path):
+def test_install_is_a_noop_when_cutlass_jax_will_not_import(fake_cutlass, monkeypatch, tmp_path):
     """A CPU task on the GPU image has the package but no CUDA bindings to import it with."""
     monkeypatch.setitem(sys.modules, "cutlass.jax.primitive", None)
 
     install(CutlassKernelCache(directory=str(tmp_path)))
+
+    # Nothing was patched, so the compile never reaches the store.
+    fake_cutlass.compile_kernel(build_launcher(None, tile=128), FakeFunctionSpec(shape=(8, 16)))
+    assert list(tmp_path.iterdir()) == []

--- a/lib/levanter/tests/test_cutlass_kernel_cache.py
+++ b/lib/levanter/tests/test_cutlass_kernel_cache.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import pytest
 
-from levanter.cutlass_kernel_cache import CutlassKernelCache, cute_launcher_factory, install
+from levanter.cutlass_kernel_cache import CutlassKernelCache, cute_launcher_factory, install, install_if_available
 
 
 @dataclasses.dataclass(frozen=True)
@@ -175,3 +175,34 @@ def test_a_specification_that_reprs_an_address_is_not_stored(fake_cutlass, tmp_p
 
     assert fake_cutlass.compiled == ["tile128-bf16"]
     assert list(tmp_path.iterdir()) == []
+
+
+def test_a_store_that_cannot_be_reached_compiles_instead_of_failing(fake_cutlass, tmp_path):
+    """The store follows the compilation cache dir, which a task may have no access to."""
+    blocked = tmp_path / "not-a-directory"
+    blocked.write_bytes(b"")
+    cache = CutlassKernelCache(directory=str(blocked / "kernels"))
+    install(cache)
+
+    cold = fake_cutlass.compile_kernel(build_launcher(None, tile=128), FakeFunctionSpec(shape=(8, 16)))
+    fake_cutlass.forget_process_state()
+    install(cache)
+    warm = fake_cutlass.compile_kernel(build_launcher(None, tile=128), FakeFunctionSpec(shape=(8, 16)))
+
+    assert fake_cutlass.compiled == ["tile128-bf16", "tile128-bf16"]
+    assert warm.module == cold.module
+
+
+def test_a_build_that_cannot_import_cutlass_jax_is_skipped(monkeypatch, tmp_path):
+    """A CPU task on the GPU image has the package but no CUDA bindings to import it with."""
+    monkeypatch.setitem(sys.modules, "cutlass.jax.primitive", None)
+
+    assert install_if_available(CutlassKernelCache(directory=str(tmp_path))) is False
+
+
+def test_a_build_that_imports_cutlass_jax_gets_the_cache(fake_cutlass, tmp_path):
+    assert install_if_available(CutlassKernelCache(directory=str(tmp_path))) is True
+
+    fake_cutlass.compile_kernel(build_launcher(None, tile=128), FakeFunctionSpec(shape=(8, 16)))
+
+    assert len(list(tmp_path.iterdir())) == 1


### PR DESCRIPTION
The node-local XLA autotune mount arrives with the Iris worker, and the VM
clusters restart workers on their own daily schedule rather than with the
controller, so for up to a day after a rollout a task lands on a worker that has
no `/cache`. `os.makedirs` then aborted JAX init. A missing or unwritable mount
is now a skip: the task compiles without the autotune cache.

The CuTeDSL kernel store lives under the JAX compilation cache directory, which
a task may have no access to. An unreadable or unwritable store is a miss that
compiles rather than a failed run.

Installation is guarded on `cutlass.jax` importing rather than on the top-level
`cutlass` package being present. `cutlass.jax` pulls in CUDA bindings, so a CPU
task running the GPU image has the package and still cannot import it.

Follow-up to #8045.
