### PR TITLE
[finelog] Degrade projection disagreements instead of wedging ingest

### DIFF
--- a/lib/finelog/AGENTS.md
+++ b/lib/finelog/AGENTS.md
@@ -138,19 +138,18 @@ seeded store on the default port. Point it at a store with real segments via
 
 ## Ingest health
 
-`/health` returns 200 whenever the server is listening — it is the Kubernetes
-liveness, readiness, and startup probe, so it must not fail on a condition that
-survives a restart — and reports the verdict in its body: `ok`, or `degraded:`
-followed by each namespace this process registers for itself that is not
-registered. `server/ingest_health.rs` holds that state; `/api/server`'s `ingest`
-block carries the per-namespace error, first-failure time, and attempt count,
-and the dashboard's System page renders it.
+`/health` returns 200 whenever the server is listening. It is the Kubernetes
+liveness, readiness, and startup probe, so it cannot fail on a condition that
+survives a restart; the verdict is in the body: `ok`, or `degraded:` followed by
+each namespace this process registers for itself that is not registered.
+`server/ingest_health.rs` holds that state. `/api/server`'s `ingest` block
+carries the per-namespace error, first-failure time, and attempt count, and the
+dashboard's System page renders it.
 
-The deploy paths gate on the body, not the status: the VM bootstrap loop,
-`_wait_health_via_ssh` (so `safe_deploy` auto-rollback fires), and `k8s_up` /
+The deploy paths gate on the body: the VM bootstrap loop, `_wait_health_via_ssh`
+(which is what makes `safe_deploy` auto-rollback fire), and `k8s_up` /
 `k8s_restart` via a post-rollout `kubectl exec`. A binary that cannot register
-`telemetry_v1` therefore fails its own deploy rather than serving a green
-`/health` over a fleet-wide metrics outage.
+`telemetry_v1` fails its own deploy.
 
 ## Secondary indexes
 
@@ -198,21 +197,17 @@ names and seven columns.
 
 Redefining a projection is not a conflict. `merge_schemas` supersedes the
 registered definition with the requested one, unless the registered one already
-covers it — a superset keeps its place, so an older binary re-registering a
-narrower definition against a newer catalog does not churn a whole namespace's
-derived state mid-rollout. Nothing needs to be renamed to change a definition,
-and nothing keeps building the old one. Segments written under the superseded
-definition stay queryable untouched, because a `.fidx` `CoveringProjection`
-section describes its own coverage; the backfill rebuilds them at its usual few
-per tick and unlinks the superseded Parquet files. The same reasoning covers
-every index hint: a covering projection is derived acceleration, so a
-disagreement about one degrades acceleration rather than availability.
+covers it: a superset keeps its place, so an older binary re-registering a
+narrower definition against a newer catalog does not churn a namespace's derived
+state mid-rollout. Segments written under the superseded definition stay
+queryable untouched, because each `.fidx` `CoveringProjection` section describes
+its own coverage; the backfill rebuilds them at its usual few per tick and
+unlinks the superseded Parquet files. Index hints follow the same rule.
 
-A column *type* mismatch remains a hard `SchemaConflict`. That one is about the
-data rather than about derived state — the registered layout cannot hold the
-requested rows either way — so it fails loudly at registration instead of
-turning into a per-write rejection. A new column declared non-nullable is
-adopted as nullable, since every already-stored row is missing it.
+A column *type* mismatch is still a hard `SchemaConflict`: the registered layout
+cannot hold the requested rows, so it fails at registration. A new column
+declared non-nullable is adopted as nullable, since every already-stored row is
+missing it.
 
 `value_counts` records a complete low-cardinality histogram. A DataFusion
 optimizer rule replaces a qualifying unfiltered one-column `GROUP BY` with

--- a/lib/finelog/AGENTS.md
+++ b/lib/finelog/AGENTS.md
@@ -136,6 +136,22 @@ already-running server; it does not start one. `scripts/demo.py --keep` serves a
 seeded store on the default port. Point it at a store with real segments via
 `FINELOG_BASE_URL` and `FINELOG_TEST_NAMESPACE`.
 
+## Ingest health
+
+`/health` returns 200 whenever the server is listening — it is the Kubernetes
+liveness, readiness, and startup probe, so it must not fail on a condition that
+survives a restart — and reports the verdict in its body: `ok`, or `degraded:`
+followed by each namespace this process registers for itself that is not
+registered. `server/ingest_health.rs` holds that state; `/api/server`'s `ingest`
+block carries the per-namespace error, first-failure time, and attempt count,
+and the dashboard's System page renders it.
+
+The deploy paths gate on the body, not the status: the VM bootstrap loop,
+`_wait_health_via_ssh` (so `safe_deploy` auto-rollback fires), and `k8s_up` /
+`k8s_restart` via a post-rollout `kubectl exec`. A binary that cannot register
+`telemetry_v1` therefore fails its own deploy rather than serving a green
+`/health` over a fleet-wide metrics outage.
+
 ## Secondary indexes
 
 A segment with any configured method gets one `.fidx` bundle. The bundle is
@@ -179,6 +195,24 @@ only when both the predicate values and every referenced query column are
 covered. Covered segments use the projection while uncovered segments retain
 source Parquet. The initial `training-status` projection covers three metric
 names and seven columns.
+
+Redefining a projection is not a conflict. `merge_schemas` supersedes the
+registered definition with the requested one, unless the registered one already
+covers it — a superset keeps its place, so an older binary re-registering a
+narrower definition against a newer catalog does not churn a whole namespace's
+derived state mid-rollout. Nothing needs to be renamed to change a definition,
+and nothing keeps building the old one. Segments written under the superseded
+definition stay queryable untouched, because a `.fidx` `CoveringProjection`
+section describes its own coverage; the backfill rebuilds them at its usual few
+per tick and unlinks the superseded Parquet files. The same reasoning covers
+every index hint: a covering projection is derived acceleration, so a
+disagreement about one degrades acceleration rather than availability.
+
+A column *type* mismatch remains a hard `SchemaConflict`. That one is about the
+data rather than about derived state — the registered layout cannot hold the
+requested rows either way — so it fails loudly at registration instead of
+turning into a per-write rejection. A new column declared non-nullable is
+adopted as nullable, since every already-stored row is missing it.
 
 `value_counts` records a complete low-cardinality histogram. A DataFusion
 optimizer rule replaces a qualifying unfiltered one-column `GROUP BY` with

--- a/lib/finelog/OPS.md
+++ b/lib/finelog/OPS.md
@@ -90,13 +90,13 @@ file while uncovered segments use postings or source Parquet, so partial
 backfill is useful. `telemetry_v1` has one `training-status` projection for the
 three dashboard metric names.
 
-Change a projection in place rather than versioning its name. Re-registering a
-name with a different predicate or column list supersedes the registered
-definition: new segments build the new one, and existing segments stay queryable
-under the definition they were written with, because each `.fidx` section
-carries its own coverage. The backfill then rebuilds them a few per tick and
-deletes the superseded Parquet files. Registering a widened copy under a second
-name instead leaves both being built for every new segment forever.
+Change a projection in place; do not version its name. Re-registering a name
+with a different predicate or column list supersedes the registered definition:
+new segments build the new one, existing segments stay queryable under the
+definition they were written with (each `.fidx` section carries its own
+coverage), and the backfill rebuilds them a few per tick and deletes the
+superseded Parquet files. A widened copy under a second name leaves both being
+built for every new segment forever.
 
 For broad low-cardinality summaries, set `ColumnIndex.value_counts`.
 Unfiltered `SELECT col, count(*) FROM table GROUP BY col` and `count(col)` then
@@ -286,19 +286,18 @@ the old one under the same `keys[].cluster` (the hub accepts either), roll the
 hub, re-pin the sender's `signing_key` to the new version, roll the sender, then
 drop the old public key and roll the hub again.
 
-## Checking that a server is ingesting, not just listening
+## Checking that a server is ingesting
 
 `/health` answers 200 whenever the process is listening, and it is also the
 Kubernetes liveness, readiness, and startup probe, so it cannot fail on a
-condition a restart will not clear. Its **body** carries the verdict that
-matters: `ok`, or `degraded: <namespace>: registration failed: <reason>`.
+condition a restart will not clear. The body carries the verdict: `ok`, or
+`degraded: <namespace>: registration failed: <reason>`.
 
-A namespace this server registers for itself — `telemetry_v1` today — must be
-registered before it accepts a row, and that registration is re-driven from the
-catalog's persisted schema on every boot. When this binary's schema and the
-catalog disagree in a way no merge can reconcile (a column type change), every
-write to that namespace fails until one of them changes, and a restart does not
-help. That is what `degraded` reports.
+`telemetry_v1` must be registered before it accepts a row, and the registration
+is re-driven from the catalog's persisted schema on every boot. When the
+binary's schema and the catalog disagree in a way no merge can reconcile (a
+column type change), every write to that namespace fails until one of them
+changes, across restarts.
 
 ```bash
 curl -sf http://<host>:<port>/health          # ok | degraded: ...
@@ -308,8 +307,8 @@ curl -sf http://<host>:<port>/api/server | jq .ingest
 `/api/server`'s `ingest` block names each namespace, its state, the error, when
 it first failed, and how many attempts have been made since. The dashboard's
 System page shows the same under **Ingest**. `deploy up`, `deploy restart`, and
-`safe_deploy` all gate on the body, so a deploy that wedges ingest fails and
-rolls back instead of reporting success.
+`safe_deploy` gate on the body, so a deploy that wedges ingest fails and rolls
+back.
 
 ## Diagnosing Kubernetes mirror readiness
 

--- a/lib/finelog/OPS.md
+++ b/lib/finelog/OPS.md
@@ -90,6 +90,14 @@ file while uncovered segments use postings or source Parquet, so partial
 backfill is useful. `telemetry_v1` has one `training-status` projection for the
 three dashboard metric names.
 
+Change a projection in place rather than versioning its name. Re-registering a
+name with a different predicate or column list supersedes the registered
+definition: new segments build the new one, and existing segments stay queryable
+under the definition they were written with, because each `.fidx` section
+carries its own coverage. The backfill then rebuilds them a few per tick and
+deletes the superseded Parquet files. Registering a widened copy under a second
+name instead leaves both being built for every new segment forever.
+
 For broad low-cardinality summaries, set `ColumnIndex.value_counts`.
 Unfiltered `SELECT col, count(*) FROM table GROUP BY col` and `count(col)` then
 rewrite to a `FinelogIndexAggregate` node that combines exact per-segment
@@ -277,6 +285,31 @@ To rotate a key, add the new Secret Manager version, add its public key alongsid
 the old one under the same `keys[].cluster` (the hub accepts either), roll the
 hub, re-pin the sender's `signing_key` to the new version, roll the sender, then
 drop the old public key and roll the hub again.
+
+## Checking that a server is ingesting, not just listening
+
+`/health` answers 200 whenever the process is listening, and it is also the
+Kubernetes liveness, readiness, and startup probe, so it cannot fail on a
+condition a restart will not clear. Its **body** carries the verdict that
+matters: `ok`, or `degraded: <namespace>: registration failed: <reason>`.
+
+A namespace this server registers for itself — `telemetry_v1` today — must be
+registered before it accepts a row, and that registration is re-driven from the
+catalog's persisted schema on every boot. When this binary's schema and the
+catalog disagree in a way no merge can reconcile (a column type change), every
+write to that namespace fails until one of them changes, and a restart does not
+help. That is what `degraded` reports.
+
+```bash
+curl -sf http://<host>:<port>/health          # ok | degraded: ...
+curl -sf http://<host>:<port>/api/server | jq .ingest
+```
+
+`/api/server`'s `ingest` block names each namespace, its state, the error, when
+it first failed, and how many attempts have been made since. The dashboard's
+System page shows the same under **Ingest**. `deploy up`, `deploy restart`, and
+`safe_deploy` all gate on the body, so a deploy that wedges ingest fails and
+rolls back instead of reporting success.
 
 ## Diagnosing Kubernetes mirror readiness
 

--- a/lib/finelog/dashboard/src/pages/SystemPage.vue
+++ b/lib/finelog/dashboard/src/pages/SystemPage.vue
@@ -83,8 +83,8 @@ const store = computed<Field[]>(() => {
   ]
 })
 
-/** One row per namespace this server registers for itself. A namespace that is
- * not `registered` is rejecting every write to it. */
+/** One row per namespace this server registers for itself; anything but
+ * `registered` is rejecting every write to it. */
 const ingest = computed<Field[]>(() => {
   const namespaces = info.value?.ingest
   if (!namespaces?.length) return []

--- a/lib/finelog/dashboard/src/pages/SystemPage.vue
+++ b/lib/finelog/dashboard/src/pages/SystemPage.vue
@@ -83,6 +83,21 @@ const store = computed<Field[]>(() => {
   ]
 })
 
+/** One row per namespace this server registers for itself. A namespace that is
+ * not `registered` is rejecting every write to it. */
+const ingest = computed<Field[]>(() => {
+  const namespaces = info.value?.ingest
+  if (!namespaces?.length) return []
+  return namespaces.map((n) => ({
+    label: n.namespace,
+    value: n.state === 'failed' ? (n.error ?? 'registration failed') : n.state,
+    note:
+      n.state === 'failed'
+        ? `failing since ${formatUnix(n.sinceUnix ?? 0)}, ${formatNumber(n.attempts ?? 0)} attempts`
+        : undefined,
+  }))
+})
+
 const cache = computed<Field[]>(() => {
   const c = info.value?.metadataCache
   if (!c) return []
@@ -151,6 +166,7 @@ onMounted(load)
           { title: 'Build', fields: build },
           { title: 'Process', fields: process },
           { title: 'Store', fields: store },
+          { title: 'Ingest', fields: ingest },
           { title: 'Query cache', fields: cache },
           { title: 'Index cache', fields: indexCache },
           { title: 'Storage format', fields: format },

--- a/lib/finelog/dashboard/src/types/introspection.ts
+++ b/lib/finelog/dashboard/src/types/introspection.ts
@@ -44,10 +44,19 @@ export interface FormatInfo {
   sidecarSpanRows: number
 }
 
+export interface NamespaceRegistration {
+  namespace: string
+  state: 'pending' | 'registered' | 'failed'
+  error?: string
+  sinceUnix?: number
+  attempts?: number
+}
+
 export interface ServerInfo {
   build: BuildInfo
   process: ProcessInfo
   store: StoreInfo
+  ingest: NamespaceRegistration[]
   metadataCache: MetadataCacheInfo
   indexCache: IndexCacheInfo
   format: FormatInfo

--- a/lib/finelog/rust/proto/finelog_stats.proto
+++ b/lib/finelog/rust/proto/finelog_stats.proto
@@ -84,8 +84,13 @@ message Schema {
   // implicitly. A schema with neither is rejected at register time.
   string key_column = 2;
 
-  // Independent named projections. Adding one is monotonic on re-register;
-  // changing an existing name's definition is a schema conflict.
+  // Independent named projections. Adding one is monotonic on re-register.
+  // Re-registering a name with a different definition supersedes it, unless
+  // the registered definition already covers the requested one, in which case
+  // the registered one is kept. Projections are derived acceleration, so a
+  // redefinition never fails a registration: segments already written keep the
+  // definition they were built with and stay queryable, and only later ones
+  // build the new definition.
   repeated CoveringProjection projections = 3;
 
   // Independent grouped-extrema rollups. Adding one is monotonic on

--- a/lib/finelog/rust/proto/finelog_stats.proto
+++ b/lib/finelog/rust/proto/finelog_stats.proto
@@ -85,12 +85,10 @@ message Schema {
   string key_column = 2;
 
   // Independent named projections. Adding one is monotonic on re-register.
-  // Re-registering a name with a different definition supersedes it, unless
-  // the registered definition already covers the requested one, in which case
-  // the registered one is kept. Projections are derived acceleration, so a
-  // redefinition never fails a registration: segments already written keep the
-  // definition they were built with and stay queryable, and only later ones
-  // build the new definition.
+  // Re-registering a name with a different definition supersedes it, unless the
+  // registered definition already covers the requested one. Each segment keeps
+  // the definition it was built with and stays queryable, so a redefinition
+  // never fails a registration.
   repeated CoveringProjection projections = 3;
 
   // Independent grouped-extrema rollups. Adding one is monotonic on

--- a/lib/finelog/rust/src/server/app.rs
+++ b/lib/finelog/rust/src/server/app.rs
@@ -12,7 +12,7 @@
 //! ```text
 //! [strip-forwarded-prefix middleware]  (outermost; normalizes the URI path)
 //! [legacy-path middleware]             (transport layer; rewrites the URI)
-//!   /health
+//!   /health              (200 always; body says `ok` or why ingest is degraded)
 //!   /v1/telemetry       (authenticated bounded JSON ingestion)
 //!   /api/*              (build + segment introspection)
 //!   /debug/*            (only with --debug-admin)
@@ -26,6 +26,7 @@
 
 use std::sync::Arc;
 
+use axum::extract::State;
 use axum::routing::get;
 use axum::Router;
 use connectrpc::{ConnectRpcService, Limits, Router as ConnectRouter};
@@ -33,6 +34,7 @@ use connectrpc::{ConnectRpcService, Limits, Router as ConnectRouter};
 use crate::proto::finelog::logging::LogServiceExt;
 use crate::proto::finelog::stats::StatsServiceExt;
 use crate::server::auth::{auth_gate, AuthInterceptor, AuthPolicy};
+use crate::server::ingest_health::IngestHealth;
 use crate::server::interceptors::{
     ConcurrencyInterceptor, SlowRpcInterceptor, DEFAULT_SLOW_RPC_THRESHOLD_MS,
     MAX_CONCURRENT_FETCH_LOGS, MAX_CONCURRENT_QUERY,
@@ -137,22 +139,33 @@ fn build_connect_service(
 /// the route precedence. Re-exported as `server::build_app_with_config`.
 pub fn build_app(store: Arc<Store>, config: ServerConfig) -> Router {
     let connect_service = build_connect_service(Arc::clone(&store), &config);
+    let health = Arc::new(IngestHealth::new());
 
     let telemetry = telemetry::router(
         Arc::clone(&store),
         Arc::clone(&config.auth),
         config.max_concurrent_telemetry,
         config.telemetry_dedupe_capacity,
+        Arc::clone(&health),
     );
     // The introspection routes bypass the Connect interceptor chain, so they
     // carry the same default-deny auth policy the RPCs do.
-    let introspection = introspection::introspection_router(Arc::clone(&store)).layer(
-        axum::middleware::from_fn_with_state(Arc::clone(&config.auth), auth_gate),
-    );
-    let mut app = Router::new()
-        .route("/health", get(|| async { "ok" }))
-        .merge(telemetry)
-        .merge(introspection);
+    let introspection =
+        introspection::introspection_router(Arc::clone(&store), Arc::clone(&health)).layer(
+            axum::middleware::from_fn_with_state(Arc::clone(&config.auth), auth_gate),
+        );
+    // `/health` answers with 200 whether or not ingest is wedged, and says which
+    // it is in the body. It is the Kubernetes liveness *and* readiness probe, and
+    // a namespace registration that disagrees with the catalog survives a
+    // restart — failing the probe would trade a one-namespace outage for a
+    // crashloop or an unrouted pod. The deploy gate reads the body instead.
+    let health_route = Router::new()
+        .route(
+            "/health",
+            get(|State(health): State<Arc<IngestHealth>>| async move { health.health_body() }),
+        )
+        .with_state(Arc::clone(&health));
+    let mut app = health_route.merge(telemetry).merge(introspection);
     if config.debug_admin {
         // Mounted BEFORE the connect fallback so /debug/* is not shadowed. These
         // admin routes bypass the Connect interceptor chain, so they are gated by

--- a/lib/finelog/rust/src/server/app.rs
+++ b/lib/finelog/rust/src/server/app.rs
@@ -154,11 +154,11 @@ pub fn build_app(store: Arc<Store>, config: ServerConfig) -> Router {
         introspection::introspection_router(Arc::clone(&store), Arc::clone(&health)).layer(
             axum::middleware::from_fn_with_state(Arc::clone(&config.auth), auth_gate),
         );
-    // `/health` answers with 200 whether or not ingest is wedged, and says which
-    // it is in the body. It is the Kubernetes liveness *and* readiness probe, and
-    // a namespace registration that disagrees with the catalog survives a
-    // restart — failing the probe would trade a one-namespace outage for a
-    // crashloop or an unrouted pod. The deploy gate reads the body instead.
+    // `/health` answers 200 whether or not ingest is wedged and puts the verdict
+    // in the body, which the deploy gates read. It is also the Kubernetes
+    // liveness, readiness, and startup probe, and a registration that disagrees
+    // with the catalog survives a restart, so failing the probe would turn a
+    // one-namespace outage into a crashloop or an unrouted pod.
     let health_route = Router::new()
         .route(
             "/health",

--- a/lib/finelog/rust/src/server/ingest_health.rs
+++ b/lib/finelog/rust/src/server/ingest_health.rs
@@ -1,0 +1,216 @@
+//! Registration health for the namespaces this process ingests into itself.
+//!
+//! A namespace this server owns (today `telemetry_v1`) must be registered
+//! before it can accept a row, and that registration is re-driven on every boot
+//! from the catalog's persisted schema. When it fails, every write to that
+//! namespace fails with it — for as long as the binary and the catalog
+//! disagree, across restarts. That is invisible from `/health` alone, which
+//! answers "is this process listening", so a deploy of a wedged binary passes
+//! its health gate and the ingest outage is left for a human to notice on a
+//! stale dashboard.
+//!
+//! This is the missing signal. [`IngestHealth`] records the outcome of each
+//! owned namespace's registration; `/health` reports `degraded` in its body
+//! while any of them is unregistered, and `/api/server` carries the per-
+//! namespace detail. The status code stays 200 either way: `/health` is also
+//! the Kubernetes liveness and readiness probe, and restarting or
+//! de-endpointing a server whose disagreement survives restarts would turn a
+//! partial outage into a total one.
+
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+
+/// Body `/health` returns while every owned namespace is registered.
+pub const HEALTH_OK: &str = "ok";
+
+/// Where one owned namespace's registration stands.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(
+    tag = "state",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum RegistrationState {
+    /// Declared but not yet attempted, or an attempt is in flight.
+    Pending,
+    Registered,
+    Failed {
+        error: String,
+        /// When *this process* first saw the registration fail. Read against
+        /// `process.startedAtUnix` it says whether the namespace has been
+        /// unavailable since boot or broke later.
+        since_unix: i64,
+        attempts: u64,
+    },
+}
+
+/// One namespace's registration state, as reported by `/api/server`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NamespaceRegistration {
+    pub namespace: String,
+    #[serde(flatten)]
+    pub state: RegistrationState,
+}
+
+/// The registration state of every namespace this process ingests into itself.
+#[derive(Debug, Default)]
+pub struct IngestHealth {
+    states: Mutex<BTreeMap<String, RegistrationState>>,
+}
+
+fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+impl IngestHealth {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Declare that this process owns `namespace`, before its first
+    /// registration attempt. Reporting it as pending from the moment the
+    /// router is built closes the window where a health gate polls between the
+    /// listener binding and the registration failing, and reads `ok`.
+    pub fn declare_owned(&self, namespace: &str) {
+        self.states
+            .lock()
+            .unwrap()
+            .entry(namespace.to_string())
+            .or_insert(RegistrationState::Pending);
+    }
+
+    pub fn record_registered(&self, namespace: &str) {
+        self.states
+            .lock()
+            .unwrap()
+            .insert(namespace.to_string(), RegistrationState::Registered);
+    }
+
+    /// Record a failed registration attempt. Repeated failures keep the
+    /// original `since_unix` and count up, so the age of the wedge survives the
+    /// retry every write drives.
+    pub fn record_failure(&self, namespace: &str, error: &str) {
+        let mut states = self.states.lock().unwrap();
+        let state = states
+            .entry(namespace.to_string())
+            .or_insert(RegistrationState::Pending);
+        match state {
+            RegistrationState::Failed {
+                error: recorded,
+                attempts,
+                ..
+            } => {
+                recorded.clear();
+                recorded.push_str(error);
+                *attempts += 1;
+            }
+            _ => {
+                *state = RegistrationState::Failed {
+                    error: error.to_string(),
+                    since_unix: now_unix(),
+                    attempts: 1,
+                }
+            }
+        }
+    }
+
+    pub fn snapshot(&self) -> Vec<NamespaceRegistration> {
+        self.states
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(namespace, state)| NamespaceRegistration {
+                namespace: namespace.clone(),
+                state: state.clone(),
+            })
+            .collect()
+    }
+
+    /// The `/health` body: [`HEALTH_OK`], or a one-line summary naming every
+    /// namespace that cannot currently accept rows.
+    pub fn health_body(&self) -> String {
+        let unavailable: Vec<String> = self
+            .states
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|(namespace, state)| match state {
+                RegistrationState::Registered => None,
+                RegistrationState::Pending => Some(format!("{namespace}: registration pending")),
+                RegistrationState::Failed { error, .. } => {
+                    Some(format!("{namespace}: registration failed: {error}"))
+                }
+            })
+            .collect();
+        if unavailable.is_empty() {
+            return HEALTH_OK.to_string();
+        }
+        format!("degraded: {}", unavailable.join("; "))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn health_body_reports_ok_only_once_every_owned_namespace_is_registered() {
+        let health = IngestHealth::new();
+        assert_eq!(
+            health.health_body(),
+            HEALTH_OK,
+            "nothing owned, nothing to report"
+        );
+
+        health.declare_owned("telemetry_v1");
+        assert!(health.health_body().contains("registration pending"));
+
+        health.record_registered("telemetry_v1");
+        assert_eq!(health.health_body(), HEALTH_OK);
+    }
+
+    #[test]
+    fn repeated_failures_keep_the_first_observation_time_and_count_up() {
+        let health = IngestHealth::new();
+        health.declare_owned("telemetry_v1");
+        health.record_failure("telemetry_v1", "projection mismatch");
+        let first = health.snapshot();
+        health.record_failure("telemetry_v1", "projection mismatch again");
+
+        let RegistrationState::Failed {
+            since_unix: first_since,
+            ..
+        } = first[0].state.clone()
+        else {
+            panic!("expected a recorded failure, got {:?}", first[0].state);
+        };
+        let RegistrationState::Failed {
+            error,
+            since_unix,
+            attempts,
+        } = health.snapshot()[0].state.clone()
+        else {
+            panic!("expected a recorded failure");
+        };
+        assert_eq!(since_unix, first_since);
+        assert_eq!(attempts, 2);
+        assert_eq!(error, "projection mismatch again");
+        assert!(health.health_body().contains("projection mismatch again"));
+    }
+
+    #[test]
+    fn a_later_success_clears_a_recorded_failure() {
+        let health = IngestHealth::new();
+        health.record_failure("telemetry_v1", "boom");
+        health.record_registered("telemetry_v1");
+        assert_eq!(health.health_body(), HEALTH_OK);
+        assert_eq!(health.snapshot()[0].state, RegistrationState::Registered);
+    }
+}

--- a/lib/finelog/rust/src/server/ingest_health.rs
+++ b/lib/finelog/rust/src/server/ingest_health.rs
@@ -1,21 +1,9 @@
 //! Registration health for the namespaces this process ingests into itself.
 //!
-//! A namespace this server owns (today `telemetry_v1`) must be registered
-//! before it can accept a row, and that registration is re-driven on every boot
-//! from the catalog's persisted schema. When it fails, every write to that
-//! namespace fails with it — for as long as the binary and the catalog
-//! disagree, across restarts. That is invisible from `/health` alone, which
-//! answers "is this process listening", so a deploy of a wedged binary passes
-//! its health gate and the ingest outage is left for a human to notice on a
-//! stale dashboard.
-//!
-//! This is the missing signal. [`IngestHealth`] records the outcome of each
-//! owned namespace's registration; `/health` reports `degraded` in its body
-//! while any of them is unregistered, and `/api/server` carries the per-
-//! namespace detail. The status code stays 200 either way: `/health` is also
-//! the Kubernetes liveness and readiness probe, and restarting or
-//! de-endpointing a server whose disagreement survives restarts would turn a
-//! partial outage into a total one.
+//! `telemetry_v1` must be registered before it accepts a row, and the
+//! registration is re-driven from the catalog on every boot, so a schema the
+//! catalog rejects wedges ingest across restarts. `/health` reports that in its
+//! body; `/api/server` carries the per-namespace detail.
 
 use std::collections::BTreeMap;
 use std::sync::Mutex;
@@ -26,7 +14,6 @@ use serde::Serialize;
 /// Body `/health` returns while every owned namespace is registered.
 pub const HEALTH_OK: &str = "ok";
 
-/// Where one owned namespace's registration stands.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(
     tag = "state",
@@ -34,20 +21,18 @@ pub const HEALTH_OK: &str = "ok";
     rename_all_fields = "camelCase"
 )]
 pub enum RegistrationState {
-    /// Declared but not yet attempted, or an attempt is in flight.
+    /// Declared, no attempt has succeeded yet.
     Pending,
     Registered,
     Failed {
         error: String,
-        /// When *this process* first saw the registration fail. Read against
-        /// `process.startedAtUnix` it says whether the namespace has been
-        /// unavailable since boot or broke later.
+        /// When this process first saw the registration fail. Compare against
+        /// `process.startedAtUnix` to tell a wedge at boot from a later one.
         since_unix: i64,
         attempts: u64,
     },
 }
 
-/// One namespace's registration state, as reported by `/api/server`.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NamespaceRegistration {
@@ -56,7 +41,6 @@ pub struct NamespaceRegistration {
     pub state: RegistrationState,
 }
 
-/// The registration state of every namespace this process ingests into itself.
 #[derive(Debug, Default)]
 pub struct IngestHealth {
     states: Mutex<BTreeMap<String, RegistrationState>>,
@@ -74,10 +58,9 @@ impl IngestHealth {
         Self::default()
     }
 
-    /// Declare that this process owns `namespace`, before its first
-    /// registration attempt. Reporting it as pending from the moment the
-    /// router is built closes the window where a health gate polls between the
-    /// listener binding and the registration failing, and reads `ok`.
+    /// Mark `namespace` pending, before its first registration attempt. A
+    /// health gate polling between the listener binding and the first attempt
+    /// then reads `pending`, not `ok`.
     pub fn declare_owned(&self, namespace: &str) {
         self.states
             .lock()
@@ -93,9 +76,8 @@ impl IngestHealth {
             .insert(namespace.to_string(), RegistrationState::Registered);
     }
 
-    /// Record a failed registration attempt. Repeated failures keep the
-    /// original `since_unix` and count up, so the age of the wedge survives the
-    /// retry every write drives.
+    /// Record a failed attempt, keeping the first `since_unix` and counting up.
+    /// Every write retries the registration, so attempts accumulate fast.
     pub fn record_failure(&self, namespace: &str, error: &str) {
         let mut states = self.states.lock().unwrap();
         let state = states
@@ -133,8 +115,8 @@ impl IngestHealth {
             .collect()
     }
 
-    /// The `/health` body: [`HEALTH_OK`], or a one-line summary naming every
-    /// namespace that cannot currently accept rows.
+    /// The `/health` body: [`HEALTH_OK`], or a line naming each namespace that
+    /// cannot accept rows.
     pub fn health_body(&self) -> String {
         let unavailable: Vec<String> = self
             .states
@@ -163,11 +145,7 @@ mod tests {
     #[test]
     fn health_body_reports_ok_only_once_every_owned_namespace_is_registered() {
         let health = IngestHealth::new();
-        assert_eq!(
-            health.health_body(),
-            HEALTH_OK,
-            "nothing owned, nothing to report"
-        );
+        assert_eq!(health.health_body(), HEALTH_OK);
 
         health.declare_owned("telemetry_v1");
         assert!(health.health_body().contains("registration pending"));

--- a/lib/finelog/rust/src/server/introspection.rs
+++ b/lib/finelog/rust/src/server/introspection.rs
@@ -38,7 +38,6 @@ use crate::store::trigram::SIDECAR_SPAN_ROWS;
 use crate::store::types::{basename, SegmentRow};
 use crate::store::Store;
 
-/// What both routes read: the store's files and this process's ingest state.
 #[derive(Clone)]
 struct IntrospectionState {
     store: Arc<Store>,
@@ -154,10 +153,8 @@ struct ServerInfoResponse {
     build: BuildInfo,
     process: ProcessInfo,
     store: StoreInfo,
-    /// Whether the namespaces this process ingests into itself are registered,
-    /// and the failure holding back any that are not. A namespace stuck here
-    /// rejects every write to it until this binary and the catalog stop
-    /// disagreeing, which a restart does not fix.
+    /// Registration state of the namespaces this process ingests into itself.
+    /// A namespace stuck here rejects every write to it, across restarts.
     ingest: Vec<NamespaceRegistration>,
     metadata_cache: MetadataCacheInfo,
     index_cache: IndexCacheInfo,

--- a/lib/finelog/rust/src/server/introspection.rs
+++ b/lib/finelog/rust/src/server/introspection.rs
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::query::metadata_cache_stats;
 use crate::server::diagnostics::read_proc_self_status_kb;
+use crate::server::ingest_health::{IngestHealth, NamespaceRegistration};
 use crate::store::index_bundle::SectionKind;
 use crate::store::segment::{
     segment_id_and_row_group_rows, segment_physical, LAYOUT_VERSION, MAX_ROW_GROUP_ROWS,
@@ -36,6 +37,13 @@ use crate::store::segment_index::{
 use crate::store::trigram::SIDECAR_SPAN_ROWS;
 use crate::store::types::{basename, SegmentRow};
 use crate::store::Store;
+
+/// What both routes read: the store's files and this process's ingest state.
+#[derive(Clone)]
+struct IntrospectionState {
+    store: Arc<Store>,
+    health: Arc<IngestHealth>,
+}
 
 /// When this process started, stamped at router-build time so uptime counts
 /// from the server coming up rather than from the first request.
@@ -146,6 +154,11 @@ struct ServerInfoResponse {
     build: BuildInfo,
     process: ProcessInfo,
     store: StoreInfo,
+    /// Whether the namespaces this process ingests into itself are registered,
+    /// and the failure holding back any that are not. A namespace stuck here
+    /// rejects every write to it until this binary and the catalog stop
+    /// disagreeing, which a restart does not fix.
+    ingest: Vec<NamespaceRegistration>,
     metadata_cache: MetadataCacheInfo,
     index_cache: IndexCacheInfo,
     format: FormatInfo,
@@ -252,7 +265,8 @@ fn unix_seconds(t: SystemTime) -> i64 {
         .unwrap_or(0)
 }
 
-async fn get_server(State(store): State<Arc<Store>>) -> impl IntoResponse {
+async fn get_server(State(state): State<IntrospectionState>) -> impl IntoResponse {
+    let store = &state.store;
     let started = process_started();
     let memory = store.memory_summary();
     let cache = metadata_cache_stats();
@@ -278,6 +292,7 @@ async fn get_server(State(store): State<Arc<Store>>) -> impl IntoResponse {
             ram_buffer_bytes: memory.ram_bytes,
             ram_chunks: memory.chunks,
         },
+        ingest: state.health.snapshot(),
         metadata_cache: MetadataCacheInfo {
             limit_bytes: cache.limit_bytes as i64,
             size_bytes: cache.size_bytes as i64,
@@ -419,9 +434,10 @@ fn to_segment_info(
 }
 
 async fn get_segments(
-    State(store): State<Arc<Store>>,
+    State(state): State<IntrospectionState>,
     Query(q): Query<SegmentsQuery>,
 ) -> impl IntoResponse {
+    let store = Arc::clone(&state.store);
     let namespace = q.namespace.clone();
     let index_cache = Arc::clone(store.index_cache());
     // Footer reads are blocking file I/O, and a large namespace has hundreds of
@@ -450,10 +466,10 @@ async fn get_segments(
 }
 
 /// The `/api/*` introspection routes, for merging into the app router.
-pub fn introspection_router(store: Arc<Store>) -> Router {
+pub fn introspection_router(store: Arc<Store>, health: Arc<IngestHealth>) -> Router {
     process_started();
     Router::new()
         .route("/api/server", get(get_server))
         .route("/api/segments", get(get_segments))
-        .with_state(store)
+        .with_state(IntrospectionState { store, health })
 }

--- a/lib/finelog/rust/src/server/mod.rs
+++ b/lib/finelog/rust/src/server/mod.rs
@@ -15,6 +15,7 @@ pub mod debug;
 pub mod diagnostics;
 pub mod forwarded_prefix;
 pub mod forwarding;
+pub mod ingest_health;
 pub mod interceptors;
 pub mod introspection;
 pub mod legacy_path;

--- a/lib/finelog/rust/src/server/telemetry.rs
+++ b/lib/finelog/rust/src/server/telemetry.rs
@@ -26,6 +26,7 @@ use uuid::Uuid;
 use crate::errors::StatsError;
 use crate::proto::finelog::stats::ColumnType;
 use crate::server::auth::{auth_gate, AuthIdentity, AuthPolicy};
+use crate::server::ingest_health::IngestHealth;
 use crate::store::group_extrema::GroupExtremaConfig;
 use crate::store::ipc::encode_ipc;
 use crate::store::policy::StoragePolicy;
@@ -246,6 +247,7 @@ struct TelemetryState {
     admission: Arc<Semaphore>,
     dedupe: Mutex<DedupeCache>,
     namespace_registration: OnceCell<()>,
+    health: Arc<IngestHealth>,
 }
 
 struct PreparedBatch {
@@ -271,13 +273,17 @@ impl TelemetryState {
                 })
                 .await
                 {
-                    Ok(Ok(_)) => Ok(()),
+                    Ok(Ok(_)) => {
+                        self.health.record_registered(TELEMETRY_NAMESPACE);
+                        Ok(())
+                    }
                     Ok(Err(error)) => Err(error.to_string()),
                     Err(join) => Err(format!("telemetry namespace task failed: {join}")),
                 }
             })
             .await;
         result.map_err(|error| {
+            self.health.record_failure(TELEMETRY_NAMESPACE, &error);
             ApiError::new(
                 StatusCode::SERVICE_UNAVAILABLE,
                 "storage_unavailable",
@@ -295,12 +301,15 @@ pub fn router(
     auth: Arc<AuthPolicy>,
     max_concurrent: usize,
     dedupe_capacity: usize,
+    health: Arc<IngestHealth>,
 ) -> Router {
+    health.declare_owned(TELEMETRY_NAMESPACE);
     let state = Arc::new(TelemetryState {
         store,
         admission: Arc::new(Semaphore::new(max_concurrent)),
         dedupe: Mutex::new(DedupeCache::new(dedupe_capacity)),
         namespace_registration: OnceCell::new(),
+        health,
     });
     // The schema is server-owned, so apply additive index-policy evolution at
     // startup even when telemetry reaches this store through StatsService or a

--- a/lib/finelog/rust/src/server/telemetry_tests.rs
+++ b/lib/finelog/rust/src/server/telemetry_tests.rs
@@ -18,6 +18,7 @@ use tokio::sync::{oneshot, Semaphore};
 use crate::proto::finelog::stats::ColumnType;
 use crate::query::{make_ctx, run_query_over};
 use crate::server::auth::AuthPolicy;
+use crate::server::ingest_health::{IngestHealth, HEALTH_OK};
 use crate::server::test_support::{disk_store, serve, PUB_A};
 use crate::server::{build_app_with_config, ServerConfig};
 use crate::store::policy::StoragePolicy;
@@ -64,6 +65,21 @@ async fn cancelled_waiter_does_not_release_owned_work_or_skip_completion() {
 
 fn http_client() -> TestHttpClient {
     HyperClient::builder(TokioExecutor::new()).build(HttpConnector::new())
+}
+
+/// GET a plain-text or JSON route, panicking on a non-200.
+async fn get_text(client: &TestHttpClient, addr: SocketAddr, path: &str) -> String {
+    let response = client
+        .request(
+            Request::get(format!("http://{addr}{path}"))
+                .body(full_body(Bytes::new()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK, "GET {path}");
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    String::from_utf8(bytes.to_vec()).unwrap()
 }
 
 async fn serve_with_config(store: Arc<Store>, config: ServerConfig) -> SocketAddr {
@@ -175,23 +191,27 @@ async fn query(store: &Store, sql: &str) -> Vec<arrow::array::RecordBatch> {
 #[tokio::test]
 async fn router_registers_index_policy_before_first_telemetry_request() {
     let store = disk_store("telemetry-startup-registration");
+    let health = Arc::new(IngestHealth::new());
     let _router = super::telemetry::router(
         Arc::clone(&store),
         Arc::new(AuthPolicy::allow_localhost()),
         1,
         1,
+        Arc::clone(&health),
+    );
+    assert!(
+        health.health_body().contains("registration pending"),
+        "the telemetry namespace is reported unavailable until it registers",
     );
 
-    let schema = tokio::time::timeout(Duration::from_secs(2), async {
-        loop {
-            if let Ok(schema) = store.get_table_schema("telemetry_v1") {
-                break schema;
-            }
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while health.health_body() != HEALTH_OK {
             tokio::task::yield_now().await;
         }
     })
     .await
     .expect("startup registration did not complete");
+    let schema = store.get_table_schema("telemetry_v1").unwrap();
 
     for name in ["service", "kind", "name"] {
         let column = schema
@@ -258,6 +278,68 @@ async fn router_registers_index_policy_before_first_telemetry_request() {
     assert_eq!(grouped.json_column, "resource_attributes_json");
     assert_eq!(grouped.json_key, "job_id");
     assert_eq!(grouped.extrema_column, "timestamp_ms");
+}
+
+#[tokio::test]
+async fn a_registration_the_catalog_rejects_shows_up_in_health_and_server_info() {
+    // The failure mode this exists to make visible: telemetry ingest is wedged
+    // for as long as the binary and the catalog disagree about the table's
+    // shape, and /health answered "ok" throughout, so the deploy gate passed and
+    // the outage was left for a human to spot on a stale dashboard.
+    let store = disk_store("telemetry-wedged-registration");
+    // Claim the namespace with a `name` column of the wrong type, which no
+    // additive merge can reconcile.
+    store
+        .register_table(
+            "telemetry_v1",
+            Schema::new(
+                vec![
+                    Column::new("timestamp_ms", ColumnType::COLUMN_TYPE_INT64, false),
+                    Column::new("name", ColumnType::COLUMN_TYPE_INT64, false),
+                ],
+                "timestamp_ms",
+            ),
+            StoragePolicy::default(),
+        )
+        .unwrap();
+
+    let addr = serve_with_config(Arc::clone(&store), ServerConfig::default()).await;
+    let client = http_client();
+    // `get_text` asserts 200, which is half the contract: /health is the
+    // liveness and readiness probe, and this condition survives a restart, so
+    // reporting it must not turn a wedged namespace into a crashlooping or
+    // unrouted server. The body carries the verdict instead.
+    let health = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let body = get_text(&client, addr, "/health").await;
+            if body.contains("registration failed") {
+                break body;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("the wedged registration never reached /health");
+    assert!(health.contains("telemetry_v1"), "{health}");
+
+    let info: Value = serde_json::from_str(&get_text(&client, addr, "/api/server").await).unwrap();
+    let namespace = &info["ingest"][0];
+    assert_eq!(namespace["namespace"], "telemetry_v1");
+    assert_eq!(namespace["state"], "failed");
+    assert!(namespace["sinceUnix"].as_i64().unwrap() > 0);
+    assert!(namespace["error"].as_str().unwrap().contains("name"));
+
+    // And the wedge is exactly what the endpoint reports to its writers.
+    let posted = post(
+        &client,
+        addr,
+        batch("11111111-1111-4111-8111-111111111111"),
+        Some("11111111-1111-4111-8111-111111111111"),
+        Some("application/json"),
+        None,
+    )
+    .await;
+    assert_eq!(posted.status, StatusCode::SERVICE_UNAVAILABLE);
 }
 
 #[tokio::test]

--- a/lib/finelog/rust/src/server/telemetry_tests.rs
+++ b/lib/finelog/rust/src/server/telemetry_tests.rs
@@ -67,7 +67,7 @@ fn http_client() -> TestHttpClient {
     HyperClient::builder(TokioExecutor::new()).build(HttpConnector::new())
 }
 
-/// GET a plain-text or JSON route, panicking on a non-200.
+/// GET a route, asserting 200 and returning the body.
 async fn get_text(client: &TestHttpClient, addr: SocketAddr, path: &str) -> String {
     let response = client
         .request(
@@ -282,13 +282,8 @@ async fn router_registers_index_policy_before_first_telemetry_request() {
 
 #[tokio::test]
 async fn a_registration_the_catalog_rejects_shows_up_in_health_and_server_info() {
-    // The failure mode this exists to make visible: telemetry ingest is wedged
-    // for as long as the binary and the catalog disagree about the table's
-    // shape, and /health answered "ok" throughout, so the deploy gate passed and
-    // the outage was left for a human to spot on a stale dashboard.
     let store = disk_store("telemetry-wedged-registration");
-    // Claim the namespace with a `name` column of the wrong type, which no
-    // additive merge can reconcile.
+    // A `name` column of the wrong type: no additive merge reconciles it.
     store
         .register_table(
             "telemetry_v1",
@@ -305,10 +300,8 @@ async fn a_registration_the_catalog_rejects_shows_up_in_health_and_server_info()
 
     let addr = serve_with_config(Arc::clone(&store), ServerConfig::default()).await;
     let client = http_client();
-    // `get_text` asserts 200, which is half the contract: /health is the
-    // liveness and readiness probe, and this condition survives a restart, so
-    // reporting it must not turn a wedged namespace into a crashlooping or
-    // unrouted server. The body carries the verdict instead.
+    // `get_text` asserts 200: /health stays 200 while degraded so the Kubernetes
+    // probes do not crashloop or de-endpoint the pod.
     let health = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             let body = get_text(&client, addr, "/health").await;
@@ -329,7 +322,6 @@ async fn a_registration_the_catalog_rejects_shows_up_in_health_and_server_info()
     assert!(namespace["sinceUnix"].as_i64().unwrap() > 0);
     assert!(namespace["error"].as_str().unwrap().contains("name"));
 
-    // And the wedge is exactly what the endpoint reports to its writers.
     let posted = post(
         &client,
         addr,

--- a/lib/finelog/rust/src/store/catalog.rs
+++ b/lib/finelog/rust/src/store/catalog.rs
@@ -325,7 +325,7 @@ impl Catalog {
         }
 
         if let Some(existing) = inner.live.get(name).cloned() {
-            // `merge` raises SchemaConflict on a non-additive change.
+            // `merge` raises SchemaConflict on a column-type change.
             let effective = merge(&existing.schema)?;
             if effective != existing.schema {
                 inner.upsert_locked(name, &effective)?;

--- a/lib/finelog/rust/src/store/schema.rs
+++ b/lib/finelog/rust/src/store/schema.rs
@@ -721,9 +721,8 @@ pub fn validate_index_policies(schema: &Schema) -> Result<(), StatsError> {
 // Schema merge: additive for the column layout, replaceable for derived state.
 // ---------------------------------------------------------------------------
 
-/// Whether `registered` accelerates every query `requested` would: the same
-/// predicate column, and both the predicate values and the included columns are
-/// supersets.
+/// Whether `registered` accelerates every query `requested` would: same
+/// predicate column, superset predicate values, superset columns.
 fn covers_projection(registered: &CoveringProjection, requested: &CoveringProjection) -> bool {
     registered.predicate_column == requested.predicate_column
         && requested
@@ -740,14 +739,10 @@ fn covers_projection(registered: &CoveringProjection, requested: &CoveringProjec
 ///
 /// - identical / requested ⊆ registered -> `registered` unchanged.
 /// - requested adds nullable columns -> the union (registered then new).
-/// - a conflicting column *type* -> `SchemaConflict`. This is the one
-///   disagreement that is about the data rather than about derived state: the
-///   registered layout cannot accept the requested rows, and keeping the
-///   registered type would only move the same rejection onto every write.
-/// - a new column declared non-nullable is *adopted as nullable*, with a warn.
-///   Every row already in the namespace is missing it, so non-nullable is not a
-///   shape the table can hold; narrowing the declaration is the only faithful
-///   reading and is strictly better than refusing to register.
+/// - a conflicting column *type* -> `SchemaConflict`. The registered layout
+///   cannot hold the requested rows, so every write would be rejected anyway.
+/// - a new non-nullable column is adopted as nullable, with a warn. Every
+///   already-stored row is missing it.
 /// - a nullability difference on an existing column is *not* a conflict: warn
 ///   and keep the registered nullability (adopt-from-disk widens compacted
 ///   columns to nullable, and re-registration with the original schema must be
@@ -760,16 +755,14 @@ fn covers_projection(registered: &CoveringProjection, requested: &CoveringProjec
 ///   scans unpruned — so a newer client can add an index to a live namespace
 ///   without a reset. An older client that does not know about the field can
 ///   never clear one, mirroring the storage-policy rule.
-/// - a named covering projection is added when its name is new and
-///   **superseded** when a registered name comes back with a different
-///   definition — never a conflict. A projection is derived acceleration state,
-///   and the registered definition only decides what future segments build:
-///   coverage is self-described per segment in its `.fidx`
-///   `CoveringProjection` section, so segments written under the old definition
-///   stay queryable and are reclaimed by the ordinary index backfill. A request
-///   whose definition the registered one already covers leaves the registered
-///   definition alone, so an older binary re-registering a narrower definition
-///   against a newer catalog does not churn the derived state of a fleet
+/// - a named covering projection is added when its name is new, and superseded
+///   when a registered name comes back with a different definition. The
+///   registered definition only decides what future segments build: each
+///   segment's `.fidx` `CoveringProjection` section describes its own coverage,
+///   so segments written under the old definition stay queryable until the
+///   index backfill reclaims them. A definition the registered one already
+///   covers is ignored, so an older binary registering a narrower definition
+///   against a newer catalog does not churn a fleet's derived state
 ///   mid-rollout.
 pub fn merge_schemas(registered: &Schema, requested: &Schema) -> Result<Schema, StatsError> {
     if registered.key_column != requested.key_column {
@@ -805,7 +798,7 @@ pub fn merge_schemas(registered: &Schema, requested: &Schema) -> Result<Schema, 
             Some(existing) if covers_projection(existing, requested_projection) => {
                 tracing::debug!(
                     projection = %requested_projection.name,
-                    "register: registered projection already covers the requested one — keeping registered",
+                    "register: keeping the registered projection, which covers the requested one",
                 );
             }
             Some(existing) => {
@@ -813,7 +806,7 @@ pub fn merge_schemas(registered: &Schema, requested: &Schema) -> Result<Schema, 
                     projection = %requested_projection.name,
                     superseded_values = ?existing.predicate_values,
                     superseded_columns = ?existing.columns,
-                    "register: superseding a registered covering projection; later segments build the requested definition and the backfill reclaims the rest",
+                    "register: superseding a registered covering projection",
                 );
                 *existing = requested_projection.clone();
                 projections_changed = true;
@@ -826,7 +819,7 @@ pub fn merge_schemas(registered: &Schema, requested: &Schema) -> Result<Schema, 
                 if !rc.nullable {
                     tracing::warn!(
                         column = %rc.name,
-                        "register: new column declared non-nullable — adopting it as nullable, since every already-stored row is missing it",
+                        "register: adopting a new non-nullable column as nullable",
                     );
                 }
                 extras.push(Column {
@@ -1465,11 +1458,9 @@ mod tests {
 
     #[test]
     fn covering_projection_redefinition_keeps_the_wider_definition() {
-        // A rolled-back binary re-registering a narrower definition against a
-        // newer catalog must leave the registered one alone: the wider one still
-        // accelerates every query the narrower would, and rebuilding the derived
-        // state each time a mixed-version fleet registers would churn every
-        // segment in the namespace.
+        // A rolled-back binary registering a narrower definition must leave the
+        // registered one alone; flipping back and forth would re-index every
+        // segment in the namespace on each registration.
         let wide = CoveringProjection::new(
             "training-status",
             "worker_id",
@@ -1482,7 +1473,7 @@ mod tests {
         ));
         assert_eq!(merge_schemas(&registered, &narrow).unwrap(), registered);
 
-        // A definition that adds a predicate value is not covered, so it wins.
+        // An added predicate value is not covered, so it supersedes.
         let wider = CoveringProjection::new(
             "training-status",
             "worker_id",

--- a/lib/finelog/rust/src/store/schema.rs
+++ b/lib/finelog/rust/src/store/schema.rs
@@ -718,15 +718,36 @@ pub fn validate_index_policies(schema: &Schema) -> Result<(), StatsError> {
 }
 
 // ---------------------------------------------------------------------------
-// Schema merge (additive-only).
+// Schema merge: additive for the column layout, replaceable for derived state.
 // ---------------------------------------------------------------------------
+
+/// Whether `registered` accelerates every query `requested` would: the same
+/// predicate column, and both the predicate values and the included columns are
+/// supersets.
+fn covers_projection(registered: &CoveringProjection, requested: &CoveringProjection) -> bool {
+    registered.predicate_column == requested.predicate_column
+        && requested
+            .predicate_values
+            .iter()
+            .all(|value| registered.predicate_values.contains(value))
+        && requested
+            .columns
+            .iter()
+            .all(|column| registered.columns.contains(column))
+}
 
 /// Return the effective schema for a re-register against `registered`.
 ///
 /// - identical / requested ⊆ registered -> `registered` unchanged.
 /// - requested adds nullable columns -> the union (registered then new).
-/// - a conflicting column *type* -> `SchemaConflict`.
-/// - a new non-nullable column -> `SchemaConflict`.
+/// - a conflicting column *type* -> `SchemaConflict`. This is the one
+///   disagreement that is about the data rather than about derived state: the
+///   registered layout cannot accept the requested rows, and keeping the
+///   registered type would only move the same rejection onto every write.
+/// - a new column declared non-nullable is *adopted as nullable*, with a warn.
+///   Every row already in the namespace is missing it, so non-nullable is not a
+///   shape the table can hold; narrowing the declaration is the only faithful
+///   reading and is strictly better than refusing to register.
 /// - a nullability difference on an existing column is *not* a conflict: warn
 ///   and keep the registered nullability (adopt-from-disk widens compacted
 ///   columns to nullable, and re-registration with the original schema must be
@@ -739,8 +760,17 @@ pub fn validate_index_policies(schema: &Schema) -> Result<(), StatsError> {
 ///   scans unpruned — so a newer client can add an index to a live namespace
 ///   without a reset. An older client that does not know about the field can
 ///   never clear one, mirroring the storage-policy rule.
-/// - a new named covering projection is added monotonically; reusing a
-///   registered name with a different definition is a conflict.
+/// - a named covering projection is added when its name is new and
+///   **superseded** when a registered name comes back with a different
+///   definition — never a conflict. A projection is derived acceleration state,
+///   and the registered definition only decides what future segments build:
+///   coverage is self-described per segment in its `.fidx`
+///   `CoveringProjection` section, so segments written under the old definition
+///   stay queryable and are reclaimed by the ordinary index backfill. A request
+///   whose definition the registered one already covers leaves the registered
+///   definition alone, so an older binary re-registering a narrower definition
+///   against a newer catalog does not churn the derived state of a fleet
+///   mid-rollout.
 pub fn merge_schemas(registered: &Schema, requested: &Schema) -> Result<Schema, StatsError> {
     if registered.key_column != requested.key_column {
         tracing::warn!(
@@ -754,39 +784,55 @@ pub fn merge_schemas(registered: &Schema, requested: &Schema) -> Result<Schema, 
     let mut enable_trigram: Vec<&str> = Vec::new();
     let mut enable_value_counts: Vec<&str> = Vec::new();
     let mut exact_values: Vec<(&str, Vec<String>)> = Vec::new();
-    let mut projections = Vec::new();
     let grouped_extrema = requested
         .grouped_extrema
         .iter()
         .filter(|config| !registered.grouped_extrema.contains(config))
         .cloned()
         .collect::<Vec<_>>();
+    let mut projections = registered.projections.clone();
+    let mut projections_changed = false;
     for requested_projection in &requested.projections {
-        match registered
-            .projections
-            .iter()
+        match projections
+            .iter_mut()
             .find(|projection| projection.name == requested_projection.name)
         {
-            Some(existing) if existing != requested_projection => {
-                return Err(StatsError::SchemaConflict(format!(
-                    "projection {:?}: definition differs from registered schema",
-                    requested_projection.name
-                )));
+            None => {
+                projections.push(requested_projection.clone());
+                projections_changed = true;
             }
-            Some(_) => {}
-            None => projections.push(requested_projection.clone()),
+            Some(existing) if existing == requested_projection => {}
+            Some(existing) if covers_projection(existing, requested_projection) => {
+                tracing::debug!(
+                    projection = %requested_projection.name,
+                    "register: registered projection already covers the requested one — keeping registered",
+                );
+            }
+            Some(existing) => {
+                tracing::warn!(
+                    projection = %requested_projection.name,
+                    superseded_values = ?existing.predicate_values,
+                    superseded_columns = ?existing.columns,
+                    "register: superseding a registered covering projection; later segments build the requested definition and the backfill reclaims the rest",
+                );
+                *existing = requested_projection.clone();
+                projections_changed = true;
+            }
         }
     }
     for rc in &requested.columns {
         match registered.column(&rc.name) {
             None => {
                 if !rc.nullable {
-                    return Err(StatsError::SchemaConflict(format!(
-                        "non-additive change: new column {:?} must be nullable for evolve-merge",
-                        rc.name
-                    )));
+                    tracing::warn!(
+                        column = %rc.name,
+                        "register: new column declared non-nullable — adopting it as nullable, since every already-stored row is missing it",
+                    );
                 }
-                extras.push(rc.clone());
+                extras.push(Column {
+                    nullable: true,
+                    ..rc.clone()
+                });
             }
             Some(existing) => {
                 if existing.r#type != rc.r#type {
@@ -839,7 +885,7 @@ pub fn merge_schemas(registered: &Schema, requested: &Schema) -> Result<Schema, 
         && enable_trigram.is_empty()
         && enable_value_counts.is_empty()
         && exact_values.is_empty()
-        && projections.is_empty()
+        && !projections_changed
         && grouped_extrema.is_empty()
     {
         return Ok(registered.clone());
@@ -876,8 +922,7 @@ pub fn merge_schemas(registered: &Schema, requested: &Schema) -> Result<Schema, 
     }
     merged.extend(extras);
     let mut merged_schema = Schema::new(merged, registered.key_column.clone());
-    merged_schema.projections = registered.projections.clone();
-    merged_schema.projections.extend(projections);
+    merged_schema.projections = projections;
     merged_schema.grouped_extrema = registered.grouped_extrema.clone();
     merged_schema.grouped_extrema.extend(grouped_extrema);
     validate_index_policies(&merged_schema)?;
@@ -1404,18 +1449,52 @@ mod tests {
         let merged = merge_schemas(&registered, &with_implicit_seq(requested)).unwrap();
         assert_eq!(merged.projections, vec![projection]);
 
-        let conflicting = with_implicit_seq(worker_schema().with_covering_projection(
-            CoveringProjection::new(
-                "training-status",
-                "worker_id",
-                ["other"],
-                ["seq", "worker_id"],
-            ),
+        let redefined = CoveringProjection::new(
+            "training-status",
+            "worker_id",
+            ["other"],
+            ["seq", "worker_id"],
+        );
+        let superseded = merge_schemas(
+            &merged,
+            &with_implicit_seq(worker_schema().with_covering_projection(redefined.clone())),
+        )
+        .unwrap();
+        assert_eq!(superseded.projections, vec![redefined]);
+    }
+
+    #[test]
+    fn covering_projection_redefinition_keeps_the_wider_definition() {
+        // A rolled-back binary re-registering a narrower definition against a
+        // newer catalog must leave the registered one alone: the wider one still
+        // accelerates every query the narrower would, and rebuilding the derived
+        // state each time a mixed-version fleet registers would churn every
+        // segment in the namespace.
+        let wide = CoveringProjection::new(
+            "training-status",
+            "worker_id",
+            ["phase", "step"],
+            ["seq", "worker_id", "mem_bytes"],
+        );
+        let registered = with_implicit_seq(worker_schema().with_covering_projection(wide.clone()));
+        let narrow = with_implicit_seq(worker_schema().with_covering_projection(
+            CoveringProjection::new("training-status", "worker_id", ["phase"], ["worker_id"]),
         ));
-        assert!(matches!(
-            merge_schemas(&merged, &conflicting),
-            Err(StatsError::SchemaConflict(_))
-        ));
+        assert_eq!(merge_schemas(&registered, &narrow).unwrap(), registered);
+
+        // A definition that adds a predicate value is not covered, so it wins.
+        let wider = CoveringProjection::new(
+            "training-status",
+            "worker_id",
+            ["phase", "progress", "step"],
+            ["seq", "worker_id", "mem_bytes"],
+        );
+        let merged = merge_schemas(
+            &registered,
+            &with_implicit_seq(worker_schema().with_covering_projection(wider.clone())),
+        )
+        .unwrap();
+        assert_eq!(merged.projections, vec![wider]);
     }
 
     #[test]
@@ -1512,15 +1591,12 @@ mod tests {
     }
 
     #[test]
-    fn merge_new_non_nullable_rejects() {
+    fn merge_new_non_nullable_column_is_adopted_as_nullable() {
         let reg = with_implicit_seq(worker_schema());
         let mut req_cols = reg.columns.clone();
         req_cols.push(col("cpu_pct", ColumnType::COLUMN_TYPE_FLOAT64, false));
-        let req = Schema::new(req_cols, "");
-        assert!(matches!(
-            merge_schemas(&reg, &req),
-            Err(StatsError::SchemaConflict(_))
-        ));
+        let merged = merge_schemas(&reg, &Schema::new(req_cols, "")).unwrap();
+        assert!(merged.column("cpu_pct").unwrap().nullable);
     }
 
     #[test]

--- a/lib/finelog/rust/src/store/store.rs
+++ b/lib/finelog/rust/src/store/store.rs
@@ -49,10 +49,9 @@ const NAMESPACE_LIFECYCLE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 /// The original five columns (key/source/data/epoch_ms/level) are non-nullable.
 /// `cluster` is a later **additive, nullable** column: the writer-supplied origin
 /// cluster of each push (trusted — writers are authenticated), which namespaces
-/// logs a global finelog collects from many federated clusters. It is nullable so
-/// it evolves an already-registered `log` namespace additively — `merge_schemas`
-/// requires new columns to be nullable, and segments written before the column
-/// existed null-fill it on read.
+/// logs a global finelog collects from many federated clusters. It is nullable
+/// because segments written before the column existed null-fill it on read,
+/// which is also why `merge_schemas` adopts any new column as nullable.
 pub(crate) fn log_registered_schema() -> Schema {
     Schema::new(
         vec![
@@ -368,7 +367,7 @@ impl Store {
         resolve_key_column(&schema)?;
         let stored = with_implicit_seq(with_implicit_cluster(schema));
 
-        // `merge_schemas` (pure) raises SchemaConflict on a non-additive change.
+        // `merge_schemas` (pure) raises SchemaConflict on a column-type change.
         // The catalog applies the empty-policy-keeps-existing rule and persists
         // under a single lock; we only supply the schema-merge decision.
         let stored_for_merge = stored.clone();
@@ -725,6 +724,7 @@ impl Store {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::store::schema::CoveringProjection;
 
     fn worker_schema() -> Schema {
         Schema::new(
@@ -893,7 +893,7 @@ mod tests {
     }
 
     #[test]
-    fn type_change_and_non_nullable_reject() {
+    fn type_change_rejects_and_new_non_nullable_widens() {
         let store = mem_store();
         store
             .register_table("iris.worker", worker_schema(), StoragePolicy::default())
@@ -916,14 +916,40 @@ mod tests {
             ColumnType::COLUMN_TYPE_FLOAT64,
             false,
         ));
-        assert!(matches!(
-            store.register_table(
+        let effective = store
+            .register_table(
                 "iris.worker",
                 Schema::new(cols, ""),
-                StoragePolicy::default()
-            ),
-            Err(StatsError::SchemaConflict(_))
-        ));
+                StoragePolicy::default(),
+            )
+            .unwrap();
+        assert!(effective.column("cpu_pct").unwrap().nullable);
+    }
+
+    #[test]
+    fn redefined_covering_projection_supersedes_instead_of_conflicting() {
+        // The wedge this guards: a server binary whose covering projection
+        // differs from the one the catalog already holds must still register, or
+        // the namespace's whole ingest path fails for as long as that binary
+        // runs — on this boot and on every later one, since the catalog
+        // rehydrates the registered definition.
+        let store = mem_store();
+        let projection = |values: &[&str]| {
+            CoveringProjection::new("busy-workers", "worker_id", values.to_vec(), ["worker_id"])
+        };
+        let schema = |values: &[&str]| worker_schema().with_covering_projection(projection(values));
+
+        store
+            .register_table("iris.worker", schema(&["w1"]), StoragePolicy::default())
+            .unwrap();
+        let effective = store
+            .register_table("iris.worker", schema(&["w2"]), StoragePolicy::default())
+            .unwrap();
+        assert_eq!(effective.projections, vec![projection(&["w2"])]);
+        assert_eq!(
+            store.get_table_schema("iris.worker").unwrap().projections,
+            vec![projection(&["w2"])],
+        );
     }
 
     #[test]

--- a/lib/finelog/rust/src/store/store.rs
+++ b/lib/finelog/rust/src/store/store.rs
@@ -928,11 +928,9 @@ mod tests {
 
     #[test]
     fn redefined_covering_projection_supersedes_instead_of_conflicting() {
-        // The wedge this guards: a server binary whose covering projection
-        // differs from the one the catalog already holds must still register, or
-        // the namespace's whole ingest path fails for as long as that binary
-        // runs — on this boot and on every later one, since the catalog
-        // rehydrates the registered definition.
+        // A binary whose covering projection differs from the catalog's must
+        // still register: the catalog rehydrates the registered definition at
+        // boot, so a rejection wedges the namespace's ingest on every restart.
         let store = mem_store();
         let projection = |values: &[&str]| {
             CoveringProjection::new("busy-workers", "worker_id", values.to_vec(), ["worker_id"])

--- a/lib/finelog/scripts/safe_deploy.py
+++ b/lib/finelog/scripts/safe_deploy.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 import click
 from finelog.deploy._gcp import _ssh_args, _wait_health_via_ssh, apply_bootstrap, render_bootstrap_for
-from finelog.deploy.bootstrap import CONTAINER_NAME
+from finelog.deploy.bootstrap import CONTAINER_NAME, HEALTH_OK
 from finelog.deploy.build import build_image as build_finelog_image
 from finelog.deploy.config import FinelogConfig, load_finelog_config
 from finelog.deploy.image import resolve_image_digest
@@ -94,7 +94,11 @@ def _bootstrap_with_image(cfg: FinelogConfig, image: str) -> bool:
 
 def _verify_health(cfg: FinelogConfig) -> bool:
     assert cfg.deployment.gcp is not None
-    return _wait_health_via_ssh(cfg, cfg.port)
+    health = _wait_health_via_ssh(cfg, cfg.port)
+    if health != HEALTH_OK:
+        click.echo(f"finelog is not ingesting: {health}", err=True)
+        return False
+    return True
 
 
 @click.group()

--- a/lib/finelog/src/finelog/deploy/_gcp.py
+++ b/lib/finelog/src/finelog/deploy/_gcp.py
@@ -16,7 +16,7 @@ import time
 
 import click
 
-from finelog.deploy.bootstrap import CONTAINER_NAME, render_bootstrap
+from finelog.deploy.bootstrap import CONTAINER_NAME, HEALTH_OK, health_probe_command, render_bootstrap
 from finelog.deploy.config import FinelogConfig, auth_policy_json
 from finelog.deploy.image import resolve_image_digest
 
@@ -74,16 +74,28 @@ def _ssh_args(cfg: FinelogConfig, command: str) -> list[str]:
     return args
 
 
-def _wait_health_via_ssh(cfg: FinelogConfig, port: int, max_attempts: int = 90) -> bool:
-    """Poll ``/health`` from inside the VM over SSH.
+def _wait_health_via_ssh(cfg: FinelogConfig, port: int, max_attempts: int = 90) -> str:
+    """Poll ``/health`` from inside the VM over SSH until it reports ``HEALTH_OK``.
+
+    Returns the last body observed — ``HEALTH_OK`` on success, the server's own
+    account of why not on failure, and ``"unreachable"`` when the probe never
+    answered. Callers report that verbatim, so a failed deploy names the wedged
+    namespace instead of only saying the server is unhealthy.
 
     Used by both ``gcp_up`` (where the first attempts may fail while
     OS Login propagates the SSH key on the fresh VM) and ``gcp_restart``.
     A direct probe is unambiguous: serial-console marker scraping was
     fragile because ``gcp_restart`` re-runs the bootstrap over SSH and
     that path never reaches the console.
+
+    The body matters, not just the status. ``/health`` answers 200 whenever the
+    server is listening — it is also the Kubernetes liveness probe — and says in
+    its body whether the namespaces it ingests into are registered. A binary
+    whose schema the catalog rejects listens perfectly well and accepts no rows,
+    which is the failure this gate exists to catch.
     """
-    probe = f"curl -sf -m 5 http://localhost:{port}/health"
+    probe = health_probe_command(port)
+    body = "unreachable"
     for _ in range(max_attempts):
         result = subprocess.run(
             _ssh_args(cfg, probe),
@@ -91,9 +103,11 @@ def _wait_health_via_ssh(cfg: FinelogConfig, port: int, max_attempts: int = 90) 
             text=True,
         )
         if result.returncode == 0:
-            return True
+            body = result.stdout.strip()
+            if body == HEALTH_OK:
+                return body
         time.sleep(2)
-    return False
+    return body
 
 
 def render_bootstrap_for(cfg: FinelogConfig, image: str) -> str:
@@ -179,8 +193,9 @@ def gcp_up(cfg: FinelogConfig) -> None:
     click.echo("Instance created. Startup script will install Docker and launch finelog.")
 
     click.echo("Waiting for finelog /health (up to ~3 minutes)...")
-    if not _wait_health_via_ssh(cfg, cfg.port):
-        raise click.ClickException("finelog did not become healthy; inspect via `finelog deploy logs`")
+    health = _wait_health_via_ssh(cfg, cfg.port)
+    if health != HEALTH_OK:
+        raise click.ClickException(f"finelog did not become healthy ({health}); inspect via `finelog deploy logs`")
     click.echo("finelog is healthy.")
 
 
@@ -248,8 +263,9 @@ def gcp_restart(cfg: FinelogConfig) -> None:
     if not apply_bootstrap(cfg, bootstrap):
         raise click.ClickException("Bootstrap re-run failed; see SSH output above")
     click.echo("Bootstrap re-applied. Verifying health...")
-    if not _wait_health_via_ssh(cfg, cfg.port):
-        raise click.ClickException("finelog did not become healthy after restart")
+    health = _wait_health_via_ssh(cfg, cfg.port)
+    if health != HEALTH_OK:
+        raise click.ClickException(f"finelog did not become healthy after restart ({health})")
     click.echo("finelog is healthy.")
 
 

--- a/lib/finelog/src/finelog/deploy/_gcp.py
+++ b/lib/finelog/src/finelog/deploy/_gcp.py
@@ -77,22 +77,15 @@ def _ssh_args(cfg: FinelogConfig, command: str) -> list[str]:
 def _wait_health_via_ssh(cfg: FinelogConfig, port: int, max_attempts: int = 90) -> str:
     """Poll ``/health`` from inside the VM over SSH until it reports ``HEALTH_OK``.
 
-    Returns the last body observed — ``HEALTH_OK`` on success, the server's own
-    account of why not on failure, and ``"unreachable"`` when the probe never
-    answered. Callers report that verbatim, so a failed deploy names the wedged
-    namespace instead of only saying the server is unhealthy.
+    Returns the last body seen, which callers report verbatim: ``HEALTH_OK``,
+    the server's account of what is degraded, or ``"unreachable"`` if the probe
+    never answered. ``/health`` answers 200 whenever the server is listening, so
+    the body is the signal — a binary whose schema the catalog rejects listens
+    and accepts no rows.
 
-    Used by both ``gcp_up`` (where the first attempts may fail while
-    OS Login propagates the SSH key on the fresh VM) and ``gcp_restart``.
-    A direct probe is unambiguous: serial-console marker scraping was
-    fragile because ``gcp_restart`` re-runs the bootstrap over SSH and
-    that path never reaches the console.
-
-    The body matters, not just the status. ``/health`` answers 200 whenever the
-    server is listening — it is also the Kubernetes liveness probe — and says in
-    its body whether the namespaces it ingests into are registered. A binary
-    whose schema the catalog rejects listens perfectly well and accepts no rows,
-    which is the failure this gate exists to catch.
+    Used by ``gcp_up`` (where early attempts fail while OS Login propagates the
+    SSH key) and ``gcp_restart``, which re-runs the bootstrap over SSH and so
+    never reaches the serial console.
     """
     probe = health_probe_command(port)
     body = "unreachable"

--- a/lib/finelog/src/finelog/deploy/_k8s.py
+++ b/lib/finelog/src/finelog/deploy/_k8s.py
@@ -332,11 +332,9 @@ def _verify_ingest_ready(cfg: FinelogConfig) -> None:
     """Fail the deploy when the rolled-out pod is listening but not ingesting.
 
     ``kubectl rollout status`` only proves the readiness probe passed, and that
-    probe is ``/health``, which answers 200 whenever the server is listening —
-    it is the liveness probe too, so it cannot fail on a condition that survives
-    a restart. A binary whose registered schema the catalog rejects is exactly
-    that condition: it serves, and it rejects every write to the namespace. The
-    body carries that verdict, so read it from inside the new pod.
+    probe is ``/health``, which answers 200 whenever the server is listening. A
+    binary whose schema the catalog rejects serves and rejects every write to
+    the namespace, so read the body from inside the new pod.
     """
     assert cfg.deployment.k8s is not None
     result = _kubectl(

--- a/lib/finelog/src/finelog/deploy/_k8s.py
+++ b/lib/finelog/src/finelog/deploy/_k8s.py
@@ -21,7 +21,7 @@ import click
 import yaml
 from rigging.secrets import resolve_secret_spec
 
-from finelog.deploy.bootstrap import render_template
+from finelog.deploy.bootstrap import HEALTH_OK, health_probe_command, render_template
 from finelog.deploy.config import FinelogConfig, auth_policy_json
 from finelog.deploy.image import resolve_image_digest
 
@@ -328,6 +328,37 @@ def _ensure_priority_class(cfg: FinelogConfig) -> None:
     _kubectl_apply(cfg, json.dumps(manifest))
 
 
+def _verify_ingest_ready(cfg: FinelogConfig) -> None:
+    """Fail the deploy when the rolled-out pod is listening but not ingesting.
+
+    ``kubectl rollout status`` only proves the readiness probe passed, and that
+    probe is ``/health``, which answers 200 whenever the server is listening —
+    it is the liveness probe too, so it cannot fail on a condition that survives
+    a restart. A binary whose registered schema the catalog rejects is exactly
+    that condition: it serves, and it rejects every write to the namespace. The
+    body carries that verdict, so read it from inside the new pod.
+    """
+    assert cfg.deployment.k8s is not None
+    result = _kubectl(
+        cfg,
+        "exec",
+        f"deployment/{cfg.name}",
+        "-n",
+        cfg.deployment.k8s.namespace,
+        "--",
+        "sh",
+        "-c",
+        health_probe_command(cfg.port),
+        check=False,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise click.ClickException(f"could not read /health from deployment/{cfg.name}: {result.stderr.strip()}")
+    body = result.stdout.strip()
+    if body != HEALTH_OK:
+        raise click.ClickException(f"finelog is serving but not ingesting: {body}")
+
+
 def k8s_up(cfg: FinelogConfig) -> None:
     """Render manifests and apply them; wait for the deployment to roll out.
 
@@ -350,6 +381,7 @@ def k8s_up(cfg: FinelogConfig) -> None:
         _kubectl_apply(cfg, rendered)
     click.echo(f"Waiting for deployment/{cfg.name} to become Ready...")
     _kubectl(cfg, "rollout", "status", f"deployment/{cfg.name}", "-n", k8s.namespace)
+    _verify_ingest_ready(cfg)
     click.echo("finelog is healthy.")
 
 
@@ -403,6 +435,7 @@ def k8s_restart(cfg: FinelogConfig) -> None:
         k8s.namespace,
     )
     _kubectl(cfg, "rollout", "status", f"deployment/{cfg.name}", "-n", k8s.namespace)
+    _verify_ingest_ready(cfg)
     click.echo("finelog is healthy.")
 
 

--- a/lib/finelog/src/finelog/deploy/bootstrap.py
+++ b/lib/finelog/src/finelog/deploy/bootstrap.py
@@ -17,10 +17,8 @@ import re
 CONTAINER_NAME = "finelog"
 CACHE_DIR = "/var/cache/finelog"
 
-# The server's health contract (`rust/src/server/ingest_health.rs`). `/health`
-# answers 200 whenever the process is listening, because it is also the
-# Kubernetes liveness probe; the body is what says whether the namespaces the
-# server registers for itself accept rows. Every deploy gate reads the body.
+# `/health` answers 200 whenever the process is listening; the body says whether
+# its namespaces accept rows (`rust/src/server/ingest_health.rs`).
 HEALTH_OK = "ok"
 
 
@@ -125,9 +123,7 @@ for i in $(seq 1 60); do
         sudo docker logs {{ container_name }} --tail 200 || true
         exit 1
     fi
-    # /health answers 200 while the server is merely listening and reports in its
-    # body whether the namespaces it ingests into are registered. A binary the
-    # catalog's schema rejects listens and accepts no rows, so gate on the body.
+    # Gate on the body: /health answers 200 while the server is only listening.
     health=$({{ health_probe }} 2>/dev/null || true)
     if [ "$health" = "{{ health_ok }}" ]; then
         echo "[finelog-init] finelog is healthy"

--- a/lib/finelog/src/finelog/deploy/bootstrap.py
+++ b/lib/finelog/src/finelog/deploy/bootstrap.py
@@ -17,6 +17,17 @@ import re
 CONTAINER_NAME = "finelog"
 CACHE_DIR = "/var/cache/finelog"
 
+# The server's health contract (`rust/src/server/ingest_health.rs`). `/health`
+# answers 200 whenever the process is listening, because it is also the
+# Kubernetes liveness probe; the body is what says whether the namespaces the
+# server registers for itself accept rows. Every deploy gate reads the body.
+HEALTH_OK = "ok"
+
+
+def health_probe_command(port: int) -> str:
+    """The shell command a deploy gate runs to read `/health` from the server's own host."""
+    return f"curl -sf -m 5 http://localhost:{port}/health"
+
 
 def render_template(template: str, **variables: str | int) -> str:
     """Render a `{{ variable }}` template (single space inside the braces).
@@ -114,7 +125,11 @@ for i in $(seq 1 60); do
         sudo docker logs {{ container_name }} --tail 200 || true
         exit 1
     fi
-    if curl -sf http://localhost:{{ port }}/health > /dev/null 2>&1; then
+    # /health answers 200 while the server is merely listening and reports in its
+    # body whether the namespaces it ingests into are registered. A binary the
+    # catalog's schema rejects listens and accepts no rows, so gate on the body.
+    health=$({{ health_probe }} 2>/dev/null || true)
+    if [ "$health" = "{{ health_ok }}" ]; then
         echo "[finelog-init] finelog is healthy"
         echo "[finelog-init] Bootstrap complete"
         exit 0
@@ -122,7 +137,7 @@ for i in $(seq 1 60); do
     sleep 2
 done
 
-echo "[finelog-init] ERROR: finelog failed to become healthy after 120s"
+echo "[finelog-init] ERROR: finelog failed to become healthy after 120s (last /health: ${health:-unreachable})"
 sudo docker ps -a -f name={{ container_name }}
 sudo docker logs {{ container_name }} --tail 200 || true
 exit 1
@@ -168,4 +183,6 @@ def render_bootstrap(
         query_env=query_env,
         cache_dir=CACHE_DIR,
         container_name=CONTAINER_NAME,
+        health_probe=health_probe_command(port),
+        health_ok=HEALTH_OK,
     )

--- a/lib/finelog/src/finelog/errors.py
+++ b/lib/finelog/src/finelog/errors.py
@@ -13,10 +13,13 @@ class StatsError(Exception):
 
 
 class SchemaConflictError(StatsError):
-    """Requested schema differs from the registered one in a non-additive way.
+    """Requested schema disagrees with the registered one about the data's shape.
 
-    Non-additive: a renamed column, a type change, a new non-nullable
-    column, or a changed key column.
+    Today that means a column type change. Disagreements about derived
+    acceleration state — index policies, covering projections — degrade instead:
+    the server adopts, supersedes, or keeps what it already has. A new column
+    declared non-nullable is adopted as nullable, and a differing key column is
+    a hint the server logs and ignores.
     """
 
 

--- a/lib/finelog/src/finelog/errors.py
+++ b/lib/finelog/src/finelog/errors.py
@@ -15,11 +15,10 @@ class StatsError(Exception):
 class SchemaConflictError(StatsError):
     """Requested schema disagrees with the registered one about the data's shape.
 
-    Today that means a column type change. Disagreements about derived
-    acceleration state — index policies, covering projections — degrade instead:
-    the server adopts, supersedes, or keeps what it already has. A new column
-    declared non-nullable is adopted as nullable, and a differing key column is
-    a hint the server logs and ignores.
+    Today that means a column type change. Index policies and covering
+    projections never raise this: the server adopts, supersedes, or keeps what
+    it has. A new non-nullable column is adopted as nullable, and a differing
+    key column is logged and ignored.
     """
 
 

--- a/lib/finelog/src/finelog/proto/finelog_stats.proto
+++ b/lib/finelog/src/finelog/proto/finelog_stats.proto
@@ -84,8 +84,13 @@ message Schema {
   // implicitly. A schema with neither is rejected at register time.
   string key_column = 2;
 
-  // Independent named projections. Adding one is monotonic on re-register;
-  // changing an existing name's definition is a schema conflict.
+  // Independent named projections. Adding one is monotonic on re-register.
+  // Re-registering a name with a different definition supersedes it, unless
+  // the registered definition already covers the requested one, in which case
+  // the registered one is kept. Projections are derived acceleration, so a
+  // redefinition never fails a registration: segments already written keep the
+  // definition they were built with and stay queryable, and only later ones
+  // build the new definition.
   repeated CoveringProjection projections = 3;
 
   // Independent grouped-extrema rollups. Adding one is monotonic on

--- a/lib/finelog/src/finelog/proto/finelog_stats.proto
+++ b/lib/finelog/src/finelog/proto/finelog_stats.proto
@@ -85,12 +85,10 @@ message Schema {
   string key_column = 2;
 
   // Independent named projections. Adding one is monotonic on re-register.
-  // Re-registering a name with a different definition supersedes it, unless
-  // the registered definition already covers the requested one, in which case
-  // the registered one is kept. Projections are derived acceleration, so a
-  // redefinition never fails a registration: segments already written keep the
-  // definition they were built with and stay queryable, and only later ones
-  // build the new definition.
+  // Re-registering a name with a different definition supersedes it, unless the
+  // registered definition already covers the requested one. Each segment keeps
+  // the definition it was built with and stays queryable, so a redefinition
+  // never fails a registration.
   repeated CoveringProjection projections = 3;
 
   // Independent grouped-extrema rollups. Adding one is monotonic on

--- a/lib/finelog/tests/test_deploy_gcp.py
+++ b/lib/finelog/tests/test_deploy_gcp.py
@@ -3,9 +3,13 @@
 
 """Tests for GCE bootstrap rendering in `finelog.deploy._gcp`."""
 
+import subprocess
+import time
+
 import click
 import pytest
-from finelog.deploy._gcp import render_bootstrap_for
+from finelog.deploy._gcp import _wait_health_via_ssh, render_bootstrap_for
+from finelog.deploy.bootstrap import HEALTH_OK
 from finelog.deploy.config import (
     Deployment,
     FinelogConfig,
@@ -33,3 +37,34 @@ def test_render_bootstrap_refuses_a_forwarding_config() -> None:
     )
     with pytest.raises(click.ClickException, match="forwarding is not supported on the gcp backend"):
         render_bootstrap_for(cfg, "ghcr.io/example/finelog@sha256:abc")
+
+
+def test_health_wait_holds_out_for_an_ingesting_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`safe_deploy`'s gate is what makes auto-rollback fire. `/health` answers 200
+    while the server is merely listening — it is the liveness probe too — so a
+    binary whose schema the catalog rejects would otherwise pass the gate while
+    every telemetry write it receives fails."""
+    cfg = FinelogConfig(
+        name="finelog-marin",
+        port=10001,
+        image="ghcr.io/example/finelog:latest",
+        remote_log_dir="gs://bucket/finelog/marin",
+        deployment=Deployment(gcp=GcpDeployment(project="proj", zone="us-central1-a")),
+    )
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+
+    def answer(*bodies: str) -> None:
+        replies = iter(bodies)
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0, stdout=next(replies), stderr=""),
+        )
+
+    answer("degraded: telemetry_v1: registration pending", HEALTH_OK)
+    assert _wait_health_via_ssh(cfg, cfg.port, max_attempts=2) == HEALTH_OK
+
+    # The reason comes back to the caller so a failed deploy names the wedged
+    # namespace rather than only reporting an unhealthy server.
+    answer("degraded: telemetry_v1: registration failed: column type mismatch")
+    assert "telemetry_v1" in _wait_health_via_ssh(cfg, cfg.port, max_attempts=1)

--- a/lib/finelog/tests/test_deploy_gcp.py
+++ b/lib/finelog/tests/test_deploy_gcp.py
@@ -40,10 +40,9 @@ def test_render_bootstrap_refuses_a_forwarding_config() -> None:
 
 
 def test_health_wait_holds_out_for_an_ingesting_server(monkeypatch: pytest.MonkeyPatch) -> None:
-    """`safe_deploy`'s gate is what makes auto-rollback fire. `/health` answers 200
-    while the server is merely listening — it is the liveness probe too — so a
-    binary whose schema the catalog rejects would otherwise pass the gate while
-    every telemetry write it receives fails."""
+    """`/health` answers 200 while the server is only listening, so `safe_deploy`'s
+    gate reads the body. A binary whose schema the catalog rejects otherwise
+    passes the gate and auto-rollback never fires."""
     cfg = FinelogConfig(
         name="finelog-marin",
         port=10001,
@@ -64,7 +63,6 @@ def test_health_wait_holds_out_for_an_ingesting_server(monkeypatch: pytest.Monke
     answer("degraded: telemetry_v1: registration pending", HEALTH_OK)
     assert _wait_health_via_ssh(cfg, cfg.port, max_attempts=2) == HEALTH_OK
 
-    # The reason comes back to the caller so a failed deploy names the wedged
-    # namespace rather than only reporting an unhealthy server.
+    # The reason reaches the caller, so a failed deploy names the namespace.
     answer("degraded: telemetry_v1: registration failed: column type mismatch")
     assert "telemetry_v1" in _wait_health_via_ssh(cfg, cfg.port, max_attempts=1)

--- a/lib/finelog/tests/test_deploy_k8s.py
+++ b/lib/finelog/tests/test_deploy_k8s.py
@@ -264,10 +264,8 @@ def _health_body(monkeypatch: pytest.MonkeyPatch, body: str) -> None:
 
 
 def test_rollout_fails_when_the_new_pod_serves_but_cannot_ingest(monkeypatch: pytest.MonkeyPatch) -> None:
-    # `kubectl rollout status` only proves /health answered 200, and /health is
-    # also the liveness probe, so it cannot fail on a schema disagreement that
-    # survives a restart. Reading the body is what turns a fleet-wide ingest
-    # outage into a failed deploy.
+    # `kubectl rollout status` only proves /health answered 200. Reading the body
+    # is what catches a pod that serves and rejects every write.
     _health_body(monkeypatch, "degraded: telemetry_v1: registration failed: column type mismatch")
 
     with pytest.raises(click.ClickException, match="serving but not ingesting"):

--- a/lib/finelog/tests/test_deploy_k8s.py
+++ b/lib/finelog/tests/test_deploy_k8s.py
@@ -18,8 +18,10 @@ from finelog.deploy._k8s import (
     _env_secret_name,
     _probe_transition_patch,
     _render_manifest,
+    _verify_ingest_ready,
     k8s_down,
 )
+from finelog.deploy.bootstrap import HEALTH_OK
 from finelog.deploy.config import (
     Deployment,
     FinelogConfig,
@@ -250,3 +252,29 @@ def test_teardown_deletes_the_secret_and_retains_only_the_cache_pvc(monkeypatch:
         f"service/{cfg.name}",
         f"secret/{_env_secret_name(cfg)}",
     }
+
+
+def _health_body(monkeypatch: pytest.MonkeyPatch, body: str) -> None:
+    """Answer every kubectl invocation with `body` on stdout."""
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda argv, **kwargs: subprocess.CompletedProcess(argv, 0, stdout=body, stderr=""),
+    )
+
+
+def test_rollout_fails_when_the_new_pod_serves_but_cannot_ingest(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `kubectl rollout status` only proves /health answered 200, and /health is
+    # also the liveness probe, so it cannot fail on a schema disagreement that
+    # survives a restart. Reading the body is what turns a fleet-wide ingest
+    # outage into a failed deploy.
+    _health_body(monkeypatch, "degraded: telemetry_v1: registration failed: column type mismatch")
+
+    with pytest.raises(click.ClickException, match="serving but not ingesting"):
+        _verify_ingest_ready(_forwarding_cfg())
+
+
+def test_rollout_accepts_a_pod_reporting_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    _health_body(monkeypatch, f"{HEALTH_OK}\n")
+
+    _verify_ingest_ready(_forwarding_cfg())


### PR DESCRIPTION
merge_schemas treated a covering projection redefined under a registered name as
a SchemaConflict. The registered definition is persisted in the catalog and
rehydrated at boot, so a server binary whose schema differed from the registered
one failed RegisterTable on every restart. For telemetry_v1 that means
ensure_namespace_registered returns 503 for every /v1/telemetry POST and all
training and accelerator metric ingest stops fleet-wide.

Redefinition now supersedes the registered definition. That definition only
decides what future segments build; per-segment coverage lives in each .fidx
CoveringProjection section, so segments written under the old definition keep
serving queries untouched and the index backfill reclaims them at its usual rate.
No superseded definition keeps being built, so a projection can change in place
without a versioned name. When the registered definition already covers the
requested one, the registered one is kept, so an older binary re-registering a
narrower definition against a newer catalog does not churn a namespace's derived
state mid-rollout. The catalog format is unchanged, so rollback stays symmetric.

A new column declared non-nullable is now adopted as nullable, since every
already-stored row is missing it. A column type change stays a hard
SchemaConflict: the registered layout cannot hold the requested rows, so every
write would be rejected anyway.

The outage hid because /health stayed green while ingest was dead. /health now
answers `ok` or `degraded: <namespace>: registration failed: <reason>`. It keeps
its 200 status because it is also the Kubernetes liveness, readiness, and startup
probe, and this condition survives a restart; failing the probe would turn a
one-namespace outage into a crashloop or an unrouted pod. /api/server carries the
per-namespace error, first-failure time, and attempt count, and the dashboard
System page shows it. The VM bootstrap loop, the SSH gate behind safe_deploy's
auto-rollback, and a post-rollout check in k8s_up and k8s_restart all read the
body, so a binary that cannot register telemetry_v1 fails its own deploy.

finelog-marin and the cw-rno2a mirror hold the narrower accelerator projections,
which is why #8064 registered its widened definitions under -v2 names. Those four
can now be widened in place.
