### PR TITLE
[iris] Let retryable coordinators drain on Kubernetes

### DIFF
--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -810,6 +810,14 @@ treat it as an explicit outage decision. Change one owner at a time and confirm
 that `CWActive` drops the blocker before continuing. Do not delete provider
 DaemonSets or use `kubectl drain --force`.
 
+Iris coordinator task PDBs follow the job's priority band. PRODUCTION uses
+`minAvailable: 1` and intentionally blocks voluntary eviction. INTERACTIVE and
+BATCH use `maxUnavailable: 1`; CoreWeave may evict those pods during a drain,
+and Iris records the disruption as `PREEMPTED` and retries it within the job's
+preemption budget. For a PRODUCTION blocker, follow the running-task procedure
+in the table above. Do not weaken its live PDB to recover a node without the
+job owner's approval.
+
 If a replacement remains Pending because no healthy node satisfies its required
 node affinity or pod anti-affinity, stop before deleting the original pod.
 Provision compatible capacity when possible. Record and restore any temporary

--- a/lib/iris/docs/priority-bands.md
+++ b/lib/iris/docs/priority-bands.md
@@ -60,6 +60,18 @@ that band turns into actual preemption depends on the backend:
 A preempted job surfaces as described in [`task-states.md`](task-states.md) and is
 requeued for retry.
 
+On Kubernetes, single-task CPU coordinators have a PodDisruptionBudget whose
+availability policy follows the job's band. PRODUCTION coordinators use
+`minAvailable: 1`, so a voluntary node drain waits for operator action.
+INTERACTIVE and BATCH coordinators use `maxUnavailable: 1`, so a drain may evict
+the singleton pod. Iris records that eviction as `PREEMPTED` and retries it
+within `max_retries_preemption`.
+
+An evicted coordinator loses in-memory and node-local state. INTERACTIVE and
+BATCH coordinators must keep durable progress outside the pod and make repeated
+external writes safe. Use PRODUCTION only when the coordinator must block
+voluntary maintenance; a PDB cannot protect it from a hard node failure.
+
 ## How band selection interacts with budgets
 
 Per-user budget tracking lives in

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -644,8 +644,8 @@ def _is_coordinator_task(run_req: job_pb2.RunTaskRequest) -> bool:
     """Heuristic: single-task job with no accelerators is a coordinator/orchestrator.
 
     Coordinator pods (e.g. zephyr *-coord jobs) are single-replica, CPU-only
-    processes whose loss kills the entire pipeline. Returns True so the caller
-    can create a PodDisruptionBudget to prevent voluntary eviction.
+    processes whose loss can restart the entire pipeline. Returns True so the
+    caller can create a priority-aware PodDisruptionBudget.
     """
     if run_req.num_tasks > 1:
         return False
@@ -665,9 +665,10 @@ def _build_pdb_manifest(
     pod_name: str,
     namespace: str,
     task_hash: str,
+    priority_band: int,
     managed_label: str = "",
 ) -> dict:
-    """Build a PodDisruptionBudget manifest for a coordinator task pod."""
+    """Build a priority-aware PodDisruptionBudget for a coordinator task pod."""
     labels = {
         _LABEL_MANAGED: "true",
         _LABEL_RUNTIME: _RUNTIME_LABEL_VALUE,
@@ -675,6 +676,7 @@ def _build_pdb_manifest(
     }
     if managed_label:
         labels[managed_label] = "true"
+    availability = {"minAvailable": 1} if priority_band == job_pb2.PRIORITY_BAND_PRODUCTION else {"maxUnavailable": 1}
     return {
         "apiVersion": "policy/v1",
         "kind": "PodDisruptionBudget",
@@ -684,7 +686,7 @@ def _build_pdb_manifest(
             "labels": labels,
         },
         "spec": {
-            "minAvailable": 1,
+            **availability,
             "selector": {"matchLabels": {_LABEL_TASK_HASH: task_hash}},
         },
     }
@@ -2711,6 +2713,7 @@ class K8sTaskProvider:
                 pod_name,
                 self.pods.namespace,
                 _task_hash(run_req.task_id),
+                run_req.priority,
                 managed_label=self.pods.managed_label,
             )
             self.kubectl.apply_json(pdb)

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -641,12 +641,7 @@ def _build_logship_sidecar(
 
 
 def _is_coordinator_task(run_req: job_pb2.RunTaskRequest) -> bool:
-    """Heuristic: single-task job with no accelerators is a coordinator/orchestrator.
-
-    Coordinator pods (e.g. zephyr *-coord jobs) are single-replica, CPU-only
-    processes whose loss can restart the entire pipeline. Returns True so the
-    caller can create a priority-aware PodDisruptionBudget.
-    """
+    """Return whether a request is a single-task CPU coordinator."""
     if run_req.num_tasks > 1:
         return False
     if run_req.HasField("resources") and run_req.resources.HasField("device"):

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -1048,9 +1048,24 @@ def test_no_configmap_when_no_workdir_files(provider, k8s):
 # ---------------------------------------------------------------------------
 
 
-def test_sync_creates_pdb_for_coordinator_task(provider, k8s):
-    """Coordinator tasks (single-task, no accelerator) get a PDB."""
-    req = make_run_req("/coord-job/0")
+@pytest.mark.parametrize("priority", [job_pb2.PRIORITY_BAND_INTERACTIVE, job_pb2.PRIORITY_BAND_BATCH])
+def test_sync_coordinator_pdb_allows_disruption_for_retryable_priority(provider, k8s, priority):
+    req = make_run_req("/coord-job/0", priority=priority)
+    req.num_tasks = 1
+    batch = make_batch(tasks_to_run=[req])
+
+    provider.sync(batch)
+
+    pdbs = k8s.list_json(K8sResource.PDBS)
+    assert len(pdbs) == 1
+    pdb = pdbs[0]
+    assert pdb["spec"]["maxUnavailable"] == 1
+    assert "minAvailable" not in pdb["spec"]
+    assert pdb["metadata"]["labels"][_LABEL_TASK_HASH] == _task_hash("/coord-job/0")
+
+
+def test_sync_coordinator_pdb_blocks_disruption_for_production_priority(provider, k8s):
+    req = make_run_req("/coord-job/0", priority=job_pb2.PRIORITY_BAND_PRODUCTION)
     req.num_tasks = 1
     batch = make_batch(tasks_to_run=[req])
 
@@ -1060,7 +1075,7 @@ def test_sync_creates_pdb_for_coordinator_task(provider, k8s):
     assert len(pdbs) == 1
     pdb = pdbs[0]
     assert pdb["spec"]["minAvailable"] == 1
-    assert pdb["metadata"]["labels"][_LABEL_TASK_HASH] == _task_hash("/coord-job/0")
+    assert "maxUnavailable" not in pdb["spec"]
 
 
 def test_stray_delete_defers_pdb_cleanup_to_gc(provider, k8s):


### PR DESCRIPTION
Let CoreWeave evict INTERACTIVE and BATCH coordinator pods during node drains
by setting their PodDisruptionBudget to `maxUnavailable: 1`. Iris records a
Kubernetes eviction as `PREEMPTED` and retries within the configured
preemption budget, so node recovery can proceed without an operator kicking
ordinary retryable coordinators.

Keep `minAvailable: 1` for PRODUCTION coordinators. Eviction can discard
in-memory and node-local state or repeat external side effects, so admin-only
PRODUCTION jobs remain explicit maintenance blockers.

This behavior was reproduced during the
[2026-08-08 US-EAST-02A incident](https://echo.oa.dev/wiki/98). CoreWeave
completed both blocked reboots after the Iris attempts were preempted; a
subsequent [provider verification failure](https://echo.oa.dev/wiki/97) was
independent of the PDB policy. A prior incident documents the same provider
cordon and tenant-workload gate in [US-WEST-04A](https://echo.oa.dev/wiki/57).
