### PR TITLE
[iris] Scope JAX coordinator discovery to task attempts

### DIFF
--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -226,6 +226,10 @@ def _parse_local_device_ids(raw: str | None) -> list[int] | None:
     return [int(part) for part in raw.split(",") if part]
 
 
+def _attempt_endpoint_name(endpoint_name: str, attempt_id: int) -> str:
+    return f"{endpoint_name}-attempt-{attempt_id}"
+
+
 def _register_coordinator(job_info: JobInfo, port: int | None, endpoint_name: str) -> str:
     """Choose and publish global process 0's coordinator address."""
     coordinator = f"{job_info.advertise_host}:{resolve_coordinator_port(job_info, port)}"
@@ -315,7 +319,8 @@ def initialize_jax(
         port: Coordinator port. ``None`` (the default) prefers an
             ``IRIS_PORT_JAX`` named port and otherwise asks the kernel to select
             an available port. Pass a port only to pin it.
-        endpoint_name: Name under which the coordinator registers.
+        endpoint_name: Base name for coordinator discovery. Iris scopes the
+            registered name to the current task attempt.
         poll_timeout: Maximum seconds for non-coordinator tasks to wait for the
             coordinator endpoint to register. Defaults to ``_JAX_DIST_INIT_TIMEOUT``
             so a slow coordinator host on a large-gang cold restart does not abort
@@ -344,6 +349,8 @@ def initialize_jax(
         return
 
     job_info = get_job_info()
+    if job_info is not None:
+        endpoint_name = _attempt_endpoint_name(endpoint_name, job_info.attempt_id)
     _log_jax_bootstrap_inputs(job_info, port=port, endpoint_name=endpoint_name)
 
     # Supervised (multi-process-per-task) mode short-circuits the task-derived

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -44,9 +44,12 @@ class FakeRegistry:
 @dataclass
 class FakeResolver:
     results: list[ResolveResult] = field(default_factory=list)
+    results_by_name: dict[str, ResolveResult] = field(default_factory=dict)
     call_count: int = 0
 
     def resolve(self, name: str) -> ResolveResult:
+        if self.results_by_name:
+            return self.results_by_name.get(name, ResolveResult(name=name))
         idx = min(self.call_count, len(self.results) - 1)
         result = self.results[idx]
         self.call_count += 1
@@ -97,13 +100,13 @@ def exit_hooks(monkeypatch: pytest.MonkeyPatch) -> FakeExitHooks:
     return hooks
 
 
-def _make_job_info(task_index: int = 0, num_tasks: int = 1) -> JobInfo:
+def _make_job_info(task_index: int = 0, num_tasks: int = 1, attempt_id: int = 0) -> JobInfo:
     """Create a JobInfo with the given task_index and num_tasks."""
     job_name = JobName.from_string(f"/testuser/testjob/{task_index}")
     return JobInfo(
         task_id=job_name,
         num_tasks=num_tasks,
-        attempt_id=0,
+        attempt_id=attempt_id,
         advertise_host="10.0.0.1",
         controller_address="controller:8080",
         ports={},
@@ -162,7 +165,7 @@ def test_initialize_jax_tpu_multitask_uses_iris_registry(
     coordinator_info.ports = {"jax": 12345}
     mock_get_job_info.side_effect = [coordinator_info, _make_job_info(task_index=1, num_tasks=2)]
     found = ResolveResult(
-        name="jax_coordinator",
+        name="jax_coordinator-attempt-0",
         endpoints=[ResolvedEndpoint(url="10.0.0.1:12345", actor_id="ep-1")],
     )
     fake_ctx = FakeContext(resolver=FakeResolver(results=[found]))
@@ -171,7 +174,7 @@ def test_initialize_jax_tpu_multitask_uses_iris_registry(
     initialize_jax()
     initialize_jax(poll_timeout=10.0, poll_interval=0.01)
 
-    assert fake_ctx.registry.registered == [("jax_coordinator", "10.0.0.1:12345")]
+    assert fake_ctx.registry.registered == [("jax_coordinator-attempt-0", "10.0.0.1:12345")]
     assert mock_jax_init.call_args_list == [
         call(
             "10.0.0.1:12345",
@@ -222,7 +225,7 @@ def test_initialize_jax_task0_registers(
 
     initialize_jax(port=9999, heartbeat_timeout=37)
 
-    assert fake_ctx.registry.registered == [("jax_coordinator", "10.0.0.1:9999")]
+    assert fake_ctx.registry.registered == [("jax_coordinator-attempt-0", "10.0.0.1:9999")]
     mock_jax_init.assert_called_once_with(
         "10.0.0.1:9999",
         4,
@@ -251,7 +254,7 @@ def test_initialize_jax_task0_uses_iris_port(
 
     initialize_jax(port=9999)
 
-    assert fake_ctx.registry.registered == [("jax_coordinator", "10.0.0.1:12345")]
+    assert fake_ctx.registry.registered == [("jax_coordinator-attempt-0", "10.0.0.1:12345")]
     mock_jax_init.assert_called_once_with(
         "10.0.0.1:12345",
         2,
@@ -273,9 +276,9 @@ def test_initialize_jax_taskN_polls(
     """Task N polls for the coordinator endpoint and calls jax.distributed.initialize."""
     mock_get_job_info.return_value = _make_job_info(task_index=2, num_tasks=4)
 
-    empty = ResolveResult(name="jax_coordinator", endpoints=[])
+    empty = ResolveResult(name="jax_coordinator-attempt-0", endpoints=[])
     found = ResolveResult(
-        name="jax_coordinator",
+        name="jax_coordinator-attempt-0",
         endpoints=[ResolvedEndpoint(url="10.0.0.1:8476", actor_id="ep-1")],
     )
     fake_ctx = FakeContext(resolver=FakeResolver(results=[empty, empty, found]))
@@ -304,7 +307,7 @@ def test_initialize_jax_poll_timeout(
     """TimeoutError is raised when coordinator endpoint is not found within timeout."""
     mock_get_job_info.return_value = _make_job_info(task_index=1, num_tasks=2)
 
-    empty = ResolveResult(name="jax_coordinator", endpoints=[])
+    empty = ResolveResult(name="jax_coordinator-attempt-0", endpoints=[])
     fake_ctx = FakeContext(resolver=FakeResolver(results=[empty]))
     mock_iris_ctx.return_value = fake_ctx
 
@@ -327,7 +330,7 @@ def test_initialize_jax_supervised_single_host(
     """A local peer resolves the address published by global rank 0."""
     mock_get_job_info.return_value = _make_job_info(task_index=0, num_tasks=1)
     found = ResolveResult(
-        name="jax_coordinator",
+        name="jax_coordinator-attempt-0",
         endpoints=[ResolvedEndpoint(url="10.0.0.1:12345", actor_id="ep-1")],
     )
     fake_ctx = FakeContext(resolver=FakeResolver(results=[found]))
@@ -358,8 +361,8 @@ def test_initialize_jax_supervised_global_rank0_registers(
     mock_jax_init: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Global rank 0 on a multi-host supervised job registers the coordinator."""
-    info = _make_job_info(task_index=0, num_tasks=2)
+    """A retrying global rank 0 publishes the coordinator for its current attempt."""
+    info = _make_job_info(task_index=0, num_tasks=2, attempt_id=3)
     info.ports = {"jax": 12345}
     mock_get_job_info.return_value = info
     fake_ctx = FakeContext()
@@ -370,7 +373,7 @@ def test_initialize_jax_supervised_global_rank0_registers(
 
     initialize_jax()
 
-    assert fake_ctx.registry.registered == [("jax_coordinator", "10.0.0.1:12345")]
+    assert fake_ctx.registry.registered == [("jax_coordinator-attempt-3", "10.0.0.1:12345")]
     mock_jax_init.assert_called_once_with(
         "10.0.0.1:12345",
         16,
@@ -402,7 +405,7 @@ def test_initialize_jax_supervised_global_rank0_picks_port(
         initialize_jax()
 
     coordinator = "10.0.0.1:45678"
-    assert fake_ctx.registry.registered == [("jax_coordinator", coordinator)]
+    assert fake_ctx.registry.registered == [("jax_coordinator-attempt-0", coordinator)]
     mock_jax_init.assert_called_once_with(
         coordinator,
         16,
@@ -425,7 +428,7 @@ def test_initialize_jax_supervised_other_host_polls(
     """A supervised rank on host != 0 polls the registry for rank 0's address."""
     mock_get_job_info.return_value = _make_job_info(task_index=1, num_tasks=2)
     found = ResolveResult(
-        name="jax_coordinator",
+        name="jax_coordinator-attempt-0",
         endpoints=[ResolvedEndpoint(url="10.0.0.9:8476", actor_id="ep-1")],
     )
     fake_ctx = FakeContext(resolver=FakeResolver(results=[found]))
@@ -445,6 +448,50 @@ def test_initialize_jax_supervised_other_host_polls(
         heartbeat_timeout_seconds=EXPECTED_JAX_HEARTBEAT_TIMEOUT,
     )
     assert fake_ctx.registry.registered == []
+
+
+@patch("jax.distributed.initialize")
+@patch("iris.runtime.jax_init.iris_ctx")
+@patch("iris.runtime.jax_init.get_job_info")
+def test_initialize_jax_retry_ignores_previous_attempt_coordinator(
+    mock_get_job_info: MagicMock,
+    mock_iris_ctx: MagicMock,
+    mock_jax_init: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retrying rank resolves the coordinator published for its own attempt."""
+    mock_get_job_info.return_value = _make_job_info(task_index=1, num_tasks=2, attempt_id=3)
+    stale = ResolveResult(
+        name="jax_coordinator",
+        endpoints=[ResolvedEndpoint(url="10.0.0.1:27055", actor_id="attempt-2")],
+    )
+    current = ResolveResult(
+        name="jax_coordinator-attempt-3",
+        endpoints=[ResolvedEndpoint(url="10.0.0.1:47647", actor_id="attempt-3")],
+    )
+    fake_ctx = FakeContext(
+        resolver=FakeResolver(
+            results_by_name={
+                "jax_coordinator": stale,
+                "jax_coordinator-attempt-3": current,
+            }
+        )
+    )
+    mock_iris_ctx.return_value = fake_ctx
+    monkeypatch.setenv("IRIS_MULTIGPU_PROCESS_COUNT", "16")
+    monkeypatch.setenv("IRIS_MULTIGPU_PROCESS_INDEX", "4")
+    monkeypatch.setenv("IRIS_MULTIGPU_LOCAL_DEVICE_IDS", "0")
+
+    initialize_jax(poll_timeout=0)
+
+    mock_jax_init.assert_called_once_with(
+        "10.0.0.1:47647",
+        16,
+        4,
+        local_device_ids=[0],
+        initialization_timeout=EXPECTED_JAX_INITIALIZATION_TIMEOUT,
+        heartbeat_timeout_seconds=EXPECTED_JAX_HEARTBEAT_TIMEOUT,
+    )
 
 
 @pytest.mark.parametrize("assigned", [{}, {"jax": 0}], ids=["unassigned", "k8s-placeholder"])

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -25,6 +25,8 @@ from iris.runtime.jax_init import configure_jax_compilation_cache, initialize_ja
 
 EXPECTED_JAX_INITIALIZATION_TIMEOUT = 1800
 EXPECTED_JAX_HEARTBEAT_TIMEOUT = 100
+INITIAL_ATTEMPT_ENDPOINT_NAME = "jax_coordinator-attempt-0"
+RETRY_ATTEMPT_ENDPOINT_NAME = "jax_coordinator-attempt-3"
 
 
 @dataclass
@@ -101,7 +103,7 @@ def exit_hooks(monkeypatch: pytest.MonkeyPatch) -> FakeExitHooks:
 
 
 def _make_job_info(task_index: int = 0, num_tasks: int = 1, attempt_id: int = 0) -> JobInfo:
-    """Create a JobInfo with the given task_index and num_tasks."""
+    """Create a JobInfo with the given task index, task count, and attempt."""
     job_name = JobName.from_string(f"/testuser/testjob/{task_index}")
     return JobInfo(
         task_id=job_name,
@@ -165,7 +167,7 @@ def test_initialize_jax_tpu_multitask_uses_iris_registry(
     coordinator_info.ports = {"jax": 12345}
     mock_get_job_info.side_effect = [coordinator_info, _make_job_info(task_index=1, num_tasks=2)]
     found = ResolveResult(
-        name="jax_coordinator-attempt-0",
+        name=INITIAL_ATTEMPT_ENDPOINT_NAME,
         endpoints=[ResolvedEndpoint(url="10.0.0.1:12345", actor_id="ep-1")],
     )
     fake_ctx = FakeContext(resolver=FakeResolver(results=[found]))
@@ -174,7 +176,7 @@ def test_initialize_jax_tpu_multitask_uses_iris_registry(
     initialize_jax()
     initialize_jax(poll_timeout=10.0, poll_interval=0.01)
 
-    assert fake_ctx.registry.registered == [("jax_coordinator-attempt-0", "10.0.0.1:12345")]
+    assert fake_ctx.registry.registered == [(INITIAL_ATTEMPT_ENDPOINT_NAME, "10.0.0.1:12345")]
     assert mock_jax_init.call_args_list == [
         call(
             "10.0.0.1:12345",
@@ -225,7 +227,7 @@ def test_initialize_jax_task0_registers(
 
     initialize_jax(port=9999, heartbeat_timeout=37)
 
-    assert fake_ctx.registry.registered == [("jax_coordinator-attempt-0", "10.0.0.1:9999")]
+    assert fake_ctx.registry.registered == [(INITIAL_ATTEMPT_ENDPOINT_NAME, "10.0.0.1:9999")]
     mock_jax_init.assert_called_once_with(
         "10.0.0.1:9999",
         4,
@@ -254,7 +256,7 @@ def test_initialize_jax_task0_uses_iris_port(
 
     initialize_jax(port=9999)
 
-    assert fake_ctx.registry.registered == [("jax_coordinator-attempt-0", "10.0.0.1:12345")]
+    assert fake_ctx.registry.registered == [(INITIAL_ATTEMPT_ENDPOINT_NAME, "10.0.0.1:12345")]
     mock_jax_init.assert_called_once_with(
         "10.0.0.1:12345",
         2,
@@ -276,9 +278,9 @@ def test_initialize_jax_taskN_polls(
     """Task N polls for the coordinator endpoint and calls jax.distributed.initialize."""
     mock_get_job_info.return_value = _make_job_info(task_index=2, num_tasks=4)
 
-    empty = ResolveResult(name="jax_coordinator-attempt-0", endpoints=[])
+    empty = ResolveResult(name=INITIAL_ATTEMPT_ENDPOINT_NAME, endpoints=[])
     found = ResolveResult(
-        name="jax_coordinator-attempt-0",
+        name=INITIAL_ATTEMPT_ENDPOINT_NAME,
         endpoints=[ResolvedEndpoint(url="10.0.0.1:8476", actor_id="ep-1")],
     )
     fake_ctx = FakeContext(resolver=FakeResolver(results=[empty, empty, found]))
@@ -307,7 +309,7 @@ def test_initialize_jax_poll_timeout(
     """TimeoutError is raised when coordinator endpoint is not found within timeout."""
     mock_get_job_info.return_value = _make_job_info(task_index=1, num_tasks=2)
 
-    empty = ResolveResult(name="jax_coordinator-attempt-0", endpoints=[])
+    empty = ResolveResult(name=INITIAL_ATTEMPT_ENDPOINT_NAME, endpoints=[])
     fake_ctx = FakeContext(resolver=FakeResolver(results=[empty]))
     mock_iris_ctx.return_value = fake_ctx
 
@@ -330,7 +332,7 @@ def test_initialize_jax_supervised_single_host(
     """A local peer resolves the address published by global rank 0."""
     mock_get_job_info.return_value = _make_job_info(task_index=0, num_tasks=1)
     found = ResolveResult(
-        name="jax_coordinator-attempt-0",
+        name=INITIAL_ATTEMPT_ENDPOINT_NAME,
         endpoints=[ResolvedEndpoint(url="10.0.0.1:12345", actor_id="ep-1")],
     )
     fake_ctx = FakeContext(resolver=FakeResolver(results=[found]))
@@ -373,7 +375,7 @@ def test_initialize_jax_supervised_global_rank0_registers(
 
     initialize_jax()
 
-    assert fake_ctx.registry.registered == [("jax_coordinator-attempt-3", "10.0.0.1:12345")]
+    assert fake_ctx.registry.registered == [(RETRY_ATTEMPT_ENDPOINT_NAME, "10.0.0.1:12345")]
     mock_jax_init.assert_called_once_with(
         "10.0.0.1:12345",
         16,
@@ -405,7 +407,7 @@ def test_initialize_jax_supervised_global_rank0_picks_port(
         initialize_jax()
 
     coordinator = "10.0.0.1:45678"
-    assert fake_ctx.registry.registered == [("jax_coordinator-attempt-0", coordinator)]
+    assert fake_ctx.registry.registered == [(INITIAL_ATTEMPT_ENDPOINT_NAME, coordinator)]
     mock_jax_init.assert_called_once_with(
         coordinator,
         16,
@@ -428,7 +430,7 @@ def test_initialize_jax_supervised_other_host_polls(
     """A supervised rank on host != 0 polls the registry for rank 0's address."""
     mock_get_job_info.return_value = _make_job_info(task_index=1, num_tasks=2)
     found = ResolveResult(
-        name="jax_coordinator-attempt-0",
+        name=INITIAL_ATTEMPT_ENDPOINT_NAME,
         endpoints=[ResolvedEndpoint(url="10.0.0.9:8476", actor_id="ep-1")],
     )
     fake_ctx = FakeContext(resolver=FakeResolver(results=[found]))
@@ -466,14 +468,14 @@ def test_initialize_jax_retry_ignores_previous_attempt_coordinator(
         endpoints=[ResolvedEndpoint(url="10.0.0.1:27055", actor_id="attempt-2")],
     )
     current = ResolveResult(
-        name="jax_coordinator-attempt-3",
+        name=RETRY_ATTEMPT_ENDPOINT_NAME,
         endpoints=[ResolvedEndpoint(url="10.0.0.1:47647", actor_id="attempt-3")],
     )
     fake_ctx = FakeContext(
         resolver=FakeResolver(
             results_by_name={
                 "jax_coordinator": stale,
-                "jax_coordinator-attempt-3": current,
+                RETRY_ATTEMPT_ENDPOINT_NAME: current,
             }
         )
     )


### PR DESCRIPTION
Scope supervised JAX coordinator publication and lookup to the current Iris task attempt. Endpoint leases intentionally survive task failure, but lookup previously used only the job-scoped endpoint name. Retrying nonzero ranks could therefore consume the prior attempt's endpoint before global rank 0 published its new address.

This occurred after a production preemption of `/power/ra2a-s02-ep16-lhs-off-20260809-coord/grug-train-ra2a-s02-ep16-lhs-off-20260809`: attempt 3 ranks 1–15 resolved `10.186.213.145:27055`, which attempt 2 had published, while rank 0 selected and bound `10.186.213.145:47647`. Attempt-scoped endpoint names make peers wait for their own coordinator publication.

The regression models that race with a stale `27055` endpoint alongside attempt 3's `47647` endpoint and asserts discovery selects the latter. Full-suite local validation has one unrelated existing JAX 0.11 cache-key assertion failure, recorded in the incident analysis.

Incident analysis: https://echo.oa.dev/wiki/100
