### PR TITLE
zephyr: let the coordinator own its worker group

### DIFF
--- a/lib/zephyr/src/zephyr/coordinator.py
+++ b/lib/zephyr/src/zephyr/coordinator.py
@@ -17,7 +17,10 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import cloudpickle
-from fray.actor import ActorHandle, current_actor
+from fray.actor import ActorGroup, ActorHandle, current_actor
+from fray.current_client import current_client
+from fray.local_backend import LocalClient
+from fray.types import ActorConfig, ResourceConfig
 from rigging import telemetry
 from rigging.filesystem import StoragePath
 from rigging.timing import ExponentialBackoff, RateLimiter, log_time
@@ -328,7 +331,7 @@ class ZephyrCoordinator:
         # out-of-order heartbeats.
         self._worker_counters: dict[str, CounterSnapshot] = {}
         self._worker_handles: dict[str, ActorHandle] = {}
-        self._worker_group: Any = None  # ActorGroup, set via set_worker_group()
+        self._worker_group: ActorGroup | None = None  # owned, created by start_workers()
         self._memory_tables: dict[str, MemoryTableRegistration] = {}
         self._coordinator_thread: threading.Thread | None = None
         self._shutdown_event = threading.Event()
@@ -338,9 +341,12 @@ class ZephyrCoordinator:
         # frequently than the UI needs to refresh.
         self._task_stats_limiter = RateLimiter(interval_seconds=10.0)
 
+        # Capture the actor context while its ContextVar is still set. Methods called
+        # later run on other threads, where current_actor() is unset.
         actor_ctx = current_actor()
         self._name = f"{actor_ctx.group_name}"
         self._host_shutdown_event = actor_ctx.shutdown_event
+        self._self_handle = actor_ctx.handle
 
         self._stats_writer = StatsWriter.connect()
         self._result_executor = ThreadPoolExecutor(max_workers=32, thread_name_prefix="zephyr-result")
@@ -352,9 +358,51 @@ class ZephyrCoordinator:
         )
         self._coordinator_thread.start()
 
-    def set_worker_group(self, worker_group: Any) -> None:
-        """Set the worker ActorGroup so the coordinator can detect permanent worker death."""
-        self._worker_group = worker_group
+    def start_workers(
+        self,
+        worker_class: type,
+        worker_count: int,
+        stage_runner_factory: Any,
+        task_resources: ZephyrTaskResources,
+        worker_resources: ResourceConfig,
+        actor_config: ActorConfig,
+    ) -> None:
+        """Create the worker group from inside this coordinator's job.
+
+        Iris derives a submitted job's id from the enclosing job context, so a group
+        created here is a *child* of the coordinator job and Iris cascading termination
+        takes the workers down with it. Creating the group on the driver instead leaves
+        the two as siblings: a dead coordinator strands its workers, and a reconstructed
+        one comes back with no executions for them to poll.
+
+        ``worker_class`` is passed in rather than imported because ``worker`` imports
+        this module.
+        """
+        assert self._worker_group is None, "worker group already started"
+        self._worker_group = current_client().create_actor_group(
+            worker_class,
+            self._self_handle,
+            stage_runner_factory,
+            task_resources,
+            name=f"{self._name}-workers",
+            count=worker_count,
+            resources=worker_resources,
+            actor_config=actor_config,
+        )
+
+    def worker_handles(self, count: int, timeout: float) -> tuple[ActorHandle, ...]:
+        """Wait for ``count`` workers and return their handles, for driver-side calls.
+
+        The worker group lives here, so callers that address workers directly -- the
+        memory store loads one table shard per actor -- ask for the handles.
+        """
+        assert self._worker_group is not None, "worker group not started"
+        return tuple(self._worker_group.wait_ready(count=count, timeout=timeout))
+
+    def worker_job_id(self) -> str:
+        """Wire form of the worker job id, for callers that address worker tasks."""
+        assert self._worker_group is not None, "worker group not started"
+        return str(self._worker_group._job_id)
 
     def register_worker(self, worker_id: str, worker_handle: ActorHandle) -> tuple[MemoryTableRegistration, ...]:
         """Called by workers when they come online to register with coordinator.
@@ -1390,9 +1438,33 @@ class ZephyrCoordinator:
 
         logger.info("Coordinator shutdown complete")
 
-    def stop_workers(self) -> None:
-        """Tell workers to exit while the coordinator actor stays reachable."""
+    def stop_workers(self, drain_timeout: float = 5.0) -> None:
+        """Retire the worker group while this coordinator stays reachable.
+
+        Workers see the shutdown flag on their next ``pull_task`` and exit on their own.
+        Terminating the group is the backstop for the ones that do not.
+        """
         self._shutdown_event.set()
+        if self._worker_group is None:
+            return
+
+        group, self._worker_group = self._worker_group, None
+        with suppress(Exception):
+            if isinstance(current_client(), LocalClient):
+                # In-process actors: no job to terminate, so stop each one directly.
+                for worker in group.wait_ready():
+                    worker.shutdown.remote().result(timeout=10.0)
+                group.shutdown()
+                return
+
+            backoff = ExponentialBackoff(initial=0.1, maximum=1.0)
+            deadline = time.monotonic() + drain_timeout
+            while time.monotonic() < deadline:
+                if group.is_done():
+                    return
+                time.sleep(backoff.next_interval())
+            logger.warning("Workers did not exit within %.1fs, terminating the group", drain_timeout)
+            group.shutdown()
 
     def check_heartbeats(self, timeout: float = 120.0) -> None:
         """Marks stale workers as FAILED, re-queues their in-flight tasks."""

--- a/lib/zephyr/src/zephyr/coordinator.py
+++ b/lib/zephyr/src/zephyr/coordinator.py
@@ -10,7 +10,7 @@ import sys
 import threading
 import time
 from collections import Counter, defaultdict, deque
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from dataclasses import dataclass, field
@@ -23,13 +23,14 @@ from fray.local_backend import LocalClient
 from fray.types import ActorConfig, ResourceConfig
 from rigging import telemetry
 from rigging.filesystem import StoragePath
-from rigging.timing import ExponentialBackoff, RateLimiter, log_time
+from rigging.timing import Duration, ExponentialBackoff, RateLimiter, log_time
 
 from zephyr.memory_store import MemoryTableRegistration
 from zephyr.plan import Join, PhysicalOp, PhysicalPlan, PhysicalStage, Scatter, Shard, SourceItem, StageType
 from zephyr.shuffle import ListShard, MemChunk
 from zephyr.stage_io import (
     ShardTask,
+    StageRunner,
     TaskResult,
     ZephyrTaskResources,
     ZephyrWorkerError,
@@ -362,7 +363,7 @@ class ZephyrCoordinator:
         self,
         worker_class: type,
         worker_count: int,
-        stage_runner_factory: Any,
+        stage_runner_factory: Callable[[], StageRunner],
         task_resources: ZephyrTaskResources,
         worker_resources: ResourceConfig,
         actor_config: ActorConfig,
@@ -391,11 +392,7 @@ class ZephyrCoordinator:
         )
 
     def worker_handles(self, count: int, timeout: float) -> tuple[ActorHandle, ...]:
-        """Wait for ``count`` workers and return their handles, for driver-side calls.
-
-        The worker group lives here, so callers that address workers directly -- the
-        memory store loads one table shard per actor -- ask for the handles.
-        """
+        """Wait for ``count`` workers to come up and return their handles."""
         assert self._worker_group is not None, "worker group not started"
         return tuple(self._worker_group.wait_ready(count=count, timeout=timeout))
 
@@ -1449,7 +1446,7 @@ class ZephyrCoordinator:
             return
 
         group, self._worker_group = self._worker_group, None
-        with suppress(Exception):
+        try:
             if isinstance(current_client(), LocalClient):
                 # In-process actors: no job to terminate, so stop each one directly.
                 for worker in group.wait_ready():
@@ -1457,13 +1454,16 @@ class ZephyrCoordinator:
                 group.shutdown()
                 return
 
-            backoff = ExponentialBackoff(initial=0.1, maximum=1.0)
-            deadline = time.monotonic() + drain_timeout
-            while time.monotonic() < deadline:
-                if group.is_done():
-                    return
-                time.sleep(backoff.next_interval())
+            drained = ExponentialBackoff(initial=0.1, maximum=1.0).wait_until(
+                group.is_done, timeout=Duration.from_seconds(drain_timeout)
+            )
+            if drained:
+                return
             logger.warning("Workers did not exit within %.1fs, terminating the group", drain_timeout)
+        except Exception:
+            logger.warning("Worker teardown failed, terminating the group", exc_info=True)
+
+        with suppress(Exception):
             group.shutdown()
 
     def check_heartbeats(self, timeout: float = 120.0) -> None:

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -188,29 +188,12 @@ class _OwnedPool:
 
     coordinator_group: ActorGroup
     coordinator: ActorHandle
-    worker_group: ActorGroup
     worker_count: int
 
     def shutdown(self, client: Client) -> None:
-        """Stop the workers before the coordinator."""
+        """Stop the workers, then the coordinator that owns them."""
         with suppress(Exception):
-            self.coordinator.stop_workers.remote().result(timeout=10.0)
-
-        with suppress(Exception):
-            if isinstance(client, LocalClient):
-                for worker in self.worker_group.wait_ready():
-                    worker.shutdown.remote().result(timeout=10.0)
-                self.worker_group.shutdown()
-            else:
-                deadline = time.monotonic() + 5
-                while time.monotonic() < deadline:
-                    if self.worker_group.is_done():
-                        break
-                    time.sleep(0.1)
-                else:
-                    logger.warning("Workers did not exit naturally, terminating")
-                    self.worker_group.shutdown()
-
+            self.coordinator.stop_workers.remote().result(timeout=30.0)
         with suppress(Exception):
             self.coordinator.shutdown.remote().result(timeout=10.0)
         with suppress(Exception):
@@ -389,7 +372,7 @@ class ZephyrContext:
         )
 
         deadline = time.monotonic() + ready_timeout
-        handles = pool.worker_group.wait_ready(count=pool.worker_count, timeout=ready_timeout)
+        handles = coordinator.worker_handles.remote(pool.worker_count, ready_timeout).result(timeout=ready_timeout)
 
         def load_pass() -> list[MemoryStoreActorStats]:
             calls = {
@@ -511,31 +494,27 @@ class ZephyrContext:
             actor_config=ActorConfig(max_concurrency=100),
         )
         coordinator: ActorHandle | None = None
-        worker_group: ActorGroup | None = None
         try:
             coordinator = coordinator_group.wait_ready(count=1)[0]
-            worker_name = f"zephyr-{self.name}-workers-{pool_id}"
-            worker_group = self.client.create_actor_group(
+            # The coordinator creates the workers so they land in a child job of its
+            # own and Iris cascading termination retires them with it.
+            coordinator.start_workers.remote(
                 ZephyrWorker,
-                coordinator,
+                worker_count,
                 self.stage_runner_factory,
                 ZephyrTaskResources.from_resource_config(self.resources),
-                name=worker_name,
-                count=worker_count,
-                resources=self.resources,
-                actor_config=ActorConfig(max_concurrency=100, max_task_retries=10),
-            )
+                self.resources,
+                ActorConfig(max_concurrency=100, max_task_retries=10),
+            ).result()
             ready_wait = float(os.environ.get("ZEPHYR_WORKERS_READY_WAIT") or 12 * 60 * 60)
-            worker_group.wait_ready(count=1, timeout=ready_wait)
-            coordinator.set_worker_group.remote(worker_group).result()
-            return _OwnedPool(coordinator_group, coordinator, worker_group, worker_count)
+            coordinator.worker_handles.remote(1, ready_wait).result(timeout=ready_wait)
+            return _OwnedPool(coordinator_group, coordinator, worker_count)
         except Exception:
             if coordinator is not None:
                 with suppress(Exception):
-                    coordinator.shutdown.remote().result(timeout=10.0)
-            if worker_group is not None:
+                    coordinator.stop_workers.remote().result(timeout=30.0)
                 with suppress(Exception):
-                    worker_group.shutdown()
+                    coordinator.shutdown.remote().result(timeout=10.0)
             with suppress(Exception):
                 coordinator_group.shutdown()
             raise

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -24,6 +24,7 @@ from fray.client import Client
 from fray.current_client import current_client
 from fray.local_backend import LocalClient
 from fray.types import ActorConfig, ResourceConfig
+from iris.client.client import get_iris_ctx
 from rigging.filesystem import StoragePath, TransferBudgetExceeded, marin_temp_bucket
 from rigging.timing import ExponentialBackoff
 
@@ -200,6 +201,24 @@ class _OwnedPool:
             self.coordinator_group.shutdown()
 
 
+def _require_resolvable_worker_handles(client: Client) -> None:
+    """Reject a memory-store load whose worker handles could never resolve.
+
+    The coordinator owns the worker group, so the driver receives worker handles over
+    an actor response. Serializing an ``IrisActorHandle`` drops its resolver, and the
+    handle rebinds through the ambient Iris context -- which a driver outside a job
+    does not have. Without this check the load fails later, inside ``load_pass``, as a
+    bare "requires IrisContext" from deep in fray.
+    """
+    if isinstance(client, LocalClient) or get_iris_ctx() is not None:
+        return
+    raise RuntimeError(
+        "load_memory_store requires a driver running inside an Iris job: worker handles "
+        "arrive from the coordinator and resolve through the ambient Iris context. "
+        "Run this driver as an Iris job, or use a LocalClient pool."
+    )
+
+
 def _distributed_worker_limit(configured: int | None) -> int:
     requested = configured or MAX_IRIS_WORKER_REPLICAS
     return min(requested, MAX_IRIS_WORKER_REPLICAS)
@@ -370,6 +389,8 @@ class ZephyrContext:
             hash_key=hash_key,
             worker_count=pool.worker_count,
         )
+
+        _require_resolvable_worker_handles(self.client)
 
         deadline = time.monotonic() + ready_timeout
         handles = coordinator.worker_handles.remote(pool.worker_count, ready_timeout).result(timeout=ready_timeout)

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -190,7 +190,7 @@ class _OwnedPool:
     coordinator: ActorHandle
     worker_count: int
 
-    def shutdown(self, client: Client) -> None:
+    def shutdown(self) -> None:
         """Stop the workers, then the coordinator that owns them."""
         with suppress(Exception):
             self.coordinator.stop_workers.remote().result(timeout=30.0)
@@ -653,7 +653,7 @@ class ZephyrContext:
             finally:
                 if pool is not None:
                     assert self.client is not None
-                    pool.shutdown(self.client)
+                    pool.shutdown()
                 _cleanup_execution(self.chunk_storage_prefix, execution_id)
 
         raise last_exception  # type: ignore[misc]
@@ -673,7 +673,7 @@ class ZephyrContext:
             self._state = _ContextState.CLOSED
 
         assert self.client is not None
-        pool.shutdown(self.client)
+        pool.shutdown()
 
     def __enter__(self) -> "ZephyrContext":
         return self.start()

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -1326,7 +1326,7 @@ def test_last_stage_deadlock_detected_when_worker_job_dies(coordinator):
     # Set up a mock worker group so _check_worker_group can query it.
     mock_group = MagicMock()
     mock_group.is_done.return_value = False
-    coordinator.set_worker_group(mock_group)
+    coordinator._worker_group = mock_group
 
     # Two workers pull both tasks.
     coordinator.heartbeat("worker-A")

--- a/lib/zephyr/tests/test_memory_store.py
+++ b/lib/zephyr/tests/test_memory_store.py
@@ -9,19 +9,21 @@ from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from typing import Any, cast
+from unittest.mock import MagicMock
 
 import cloudpickle
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 from fray.actor import ActorHandle, ActorUnavailableError
+from fray.local_backend import LocalClient
 from fray.types import ResourceConfig
 from iris.cluster.types import JobName
 from iris.rpc import job_pb2
 from iris.test_util import SentinelFile
 from rigging.timing import Duration, ExponentialBackoff
 from zephyr.dataset import Dataset
-from zephyr.execution import ZephyrContext
+from zephyr.execution import ZephyrContext, _require_resolvable_worker_handles
 from zephyr.memory_store import (
     DuplicateMemoryStoreKey,
     MemoryStore,
@@ -370,3 +372,18 @@ def test_memory_store_rejects_pipeline_with_shuffle(local_client, tmp_path):
     with _store_context(local_client, tmp_path) as context:
         with pytest.raises(ValueError):
             _load_store(context, dataset, name="shuffled")
+
+
+def test_memory_store_rejects_a_driver_that_cannot_resolve_worker_handles():
+    """A distributed driver outside an Iris job cannot resolve the handles it is sent.
+
+    Worker handles arrive from the coordinator, and serializing one drops its resolver,
+    so it rebinds through the ambient Iris context. Failing here names the problem
+    instead of surfacing it as a bare "requires IrisContext" from inside the load.
+    """
+    with pytest.raises(RuntimeError, match="inside an Iris job"):
+        _require_resolvable_worker_handles(MagicMock())
+
+
+def test_local_pools_need_no_iris_context():
+    _require_resolvable_worker_handles(LocalClient())

--- a/lib/zephyr/tests/test_memory_store.py
+++ b/lib/zephyr/tests/test_memory_store.py
@@ -15,7 +15,6 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 from fray.actor import ActorHandle, ActorUnavailableError
-from fray.iris_backend import IrisActorGroup
 from fray.types import ResourceConfig
 from iris.cluster.types import JobName
 from iris.rpc import job_pb2
@@ -127,9 +126,8 @@ def _fake_store(actor: _SequencedActor, recovery_timeout: float = 1) -> MemorySt
 
 def _worker_task_id(context: ZephyrContext, actor_index: int) -> JobName:
     assert context._pool is not None
-    worker_group = context._pool.worker_group
-    assert isinstance(worker_group, IrisActorGroup)
-    return JobName.from_wire(f"{worker_group._job_id}/{actor_index}")
+    worker_job_id = context._pool.coordinator.worker_job_id.remote().result(timeout=30.0)
+    return JobName.from_wire(f"{worker_job_id}/{actor_index}")
 
 
 def test_memory_store_routes_existing_partitions_and_preserves_lookup_order(local_client, tmp_path):

--- a/lib/zephyr/tests/test_worker_group_race.py
+++ b/lib/zephyr/tests/test_worker_group_race.py
@@ -58,7 +58,7 @@ def test_check_worker_group_skips_after_completed_stage(draining_coordinator):
 
     mock_group = MagicMock()
     mock_group.is_done.return_value = True
-    draining_coordinator.set_worker_group(mock_group)
+    draining_coordinator._worker_group = mock_group
     draining_coordinator._check_worker_group()
 
     assert draining_coordinator.get_fatal_error() is None
@@ -93,7 +93,7 @@ def test_check_worker_group_still_aborts_mid_stage(draining_coordinator):
 
     mock_group = MagicMock()
     mock_group.is_done.return_value = True
-    draining_coordinator.set_worker_group(mock_group)
+    draining_coordinator._worker_group = mock_group
     draining_coordinator._check_worker_group()
 
     fatal_error = draining_coordinator.get_fatal_error()


### PR DESCRIPTION
* the driver created the coordinator group and the worker group side by side, so the two are siblings rather than parent and child. a dead coordinator strands its workers, and a reconstructed one comes back with empty `_executions` for them to poll
* workers were children of the coordinator job until #7145 moved pool creation onto the driver so a shared pool could outlive one `execute()` call [^1]
* `ZephyrCoordinator.start_workers` now creates the group from inside the coordinator's own job, so the workers land in a child job and iris cascading termination retires them with it
  * `iris.submit` derives `job_id` from `get_iris_ctx()` (`iris/client/client.py:717`), so this needs no fray or iris change — only the call site moves
  * `ZephyrWorker` is passed in rather than imported, because `worker` imports `coordinator`
  * not covered by the local suite: `LocalClient` has no job hierarchy, so the tests show no regression rather than working parenting [^2]
* `set_worker_group` is gone. `worker_handles` and `worker_job_id` serve the callers that reached the group through the driver, and `_OwnedPool` no longer holds one
* `stop_workers` absorbs the worker teardown `_OwnedPool.shutdown` open-coded, including the local-vs-distributed split
* `load_memory_store` now requires a driver inside an iris job, and says so up front instead of failing deep in the load [^3]
* unpinned workers inherit the coordinator's region rather than the driver's, which is a no-op for every driver that can reach this code [^4]
* fix `ZephyrCoordinator` reading `current_actor()` outside `__init__`: the ContextVar is unset on the threads that serve later method calls, so the handle is captured at construction alongside `_name` and `_host_shutdown_event`

[^1]: #7145 needed pool creation to move up so an entered `ZephyrContext` could keep one pool across pipelines and hand it to borrowed contexts. that argument only requires the pool to outlive a *pipeline*, not that the coordinator stop owning the workers — the coordinator group is long-lived now too.

[^2]: verifying the cascade needs an iris run that kills the coordinator job and confirms the worker job dies with it.

[^3]: the driver receives worker handles over an actor response, and `IrisActorHandle.__getstate__` keeps only the endpoint, so the handle rebinds through the ambient iris context. a distributed driver outside a job has none, and the load would otherwise fail inside `load_pass` as a bare "requires IrisContext" from within fray. `load_memory_store` is the only caller that resolves these handles — `_start_pool` just awaits readiness and discards them — it has no callers outside tests and docs, and every iris-backed pool in the suite already runs under `iris_ctx_scope`. so this fences a case that does not occur today rather than removing one that works.

[^4]: iris pins a child job to the submitter's concrete region when the child carries no region constraint (`iris/client/client.py:773`), so the submitter moving from driver to coordinator changes what unpinned workers inherit. with the driver inside a job the coordinator is itself pinned to the driver's region, so the two agree. they diverge only for a driver outside a job, which the precondition above now rejects.
