### PR TITLE
tokenize: split oversized documents into chunk_index rows

### DIFF
--- a/experiments/datakit/reports/tokenize.py
+++ b/experiments/datakit/reports/tokenize.py
@@ -1,11 +1,13 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Stage report for tokenize: per-source attribute parquet (``{id, input_ids}``).
+"""Stage report for tokenize: per-source attribute parquet (``{id, chunk_index, input_ids}``).
 
 Doc and token totals come from each source's per-split ``tokenize/*`` counters;
 the token-length histogram reads a bounded ``input_ids`` sample from the first
-few sources' shards and bins the list lengths into power-of-two buckets.
+few sources' shards and bins the list lengths into power-of-two buckets. The
+histogram bins rows, so a document that the tokenizer split across rows appears
+as its chunks. The totals above it count documents.
 """
 
 import os.path

--- a/experiments/datakit/store/datakit_store.py
+++ b/experiments/datakit/store/datakit_store.py
@@ -262,9 +262,18 @@ def _iter_tokenized_documents(path: str) -> Iterator[tuple[str, np.ndarray]]:
     ``chunk_index == 0`` marks the first row of a document. A rule that instead
     started a document on a change of ``id`` would merge two adjacent documents
     that share an id, which some sources produce.
+
+    Raises ``RuntimeError`` on a shard with no ``chunk_index`` column (written
+    before the column existed) and on rows that do not run 0, 1, 2 ... within one
+    id. Concatenating out-of-order rows would corrupt the token stream silently.
     """
     with StoragePath(path).open("rb") as fh:
         parquet = pq.ParquetFile(fh)
+        if CHUNK_INDEX_FIELD not in parquet.schema_arrow.names:
+            raise RuntimeError(
+                f"{path}: tokenize shard has no {CHUNK_INDEX_FIELD} column. It predates the column, "
+                "so its step identity does not match this code. Re-run tokenize for this source."
+            )
         doc_id: str | None = None
         chunks: list[np.ndarray] = []
         for batch in parquet.iter_batches(
@@ -278,9 +287,10 @@ def _iter_tokenized_documents(path: str) -> Iterator[tuple[str, np.ndarray]]:
                     if chunks:
                         yield doc_id, chunks[0] if len(chunks) == 1 else np.concatenate(chunks)
                     doc_id, chunks = row_id, []
-                elif row_id != doc_id:
+                elif row_id != doc_id or chunk_indices[i] != len(chunks):
                     raise RuntimeError(
-                        f"{path}: chunk {chunk_indices[i]} of {row_id} does not follow a chunk 0 of that id"
+                        f"{path}: row {i} is chunk {chunk_indices[i]} of {row_id}, but chunk "
+                        f"{len(chunks)} of {doc_id} must come next"
                     )
                 chunks.append(input_ids[i].values.to_numpy())
         if chunks:
@@ -329,8 +339,7 @@ def _iter_surviving_docs(spec: dict[str, str], cluster_col: str) -> Iterator[tup
                 f"{where}: tokenize holds more documents than decon rows ({n_decon}) -- co-partitioning broken"
             )
         n_in += 1
-        position = doc_idx
-        doc_idx += 1
+        position, doc_idx = doc_idx, doc_idx + 1
         if contaminated[position]:
             n_contaminated += 1
             continue

--- a/experiments/datakit/store/datakit_store.py
+++ b/experiments/datakit/store/datakit_store.py
@@ -58,6 +58,7 @@ from marin.datakit.decon import DeconAttributes
 from marin.datakit.source_key import DatakitArtifactPath
 from marin.execution.artifact import read_artifact, write_artifact
 from marin.processing.classification.deduplication.fuzzy_dups import FuzzyDupsAttrData, FuzzyDupsPerSource
+from marin.processing.tokenize._core import CHUNK_INDEX_FIELD
 from marin.processing.tokenize.attributes import TokenizedAttrData
 from pydantic import BaseModel
 from rigging.filesystem import StoragePath
@@ -249,6 +250,43 @@ class _SubshardStat:
 # ---------------------------------------------------------------------------
 
 
+def _iter_tokenized_documents(path: str) -> Iterator[tuple[str, np.ndarray]]:
+    """Yield ``(doc_id, input_ids)`` per document from one tokenized shard.
+
+    A document above the token limit of one Parquet row occupies several adjacent
+    rows that share its ``id``, ordered by ``chunk_index`` (see
+    :mod:`marin.processing.tokenize.attributes`). Those rows are joined back into
+    one token array here, so this shard yields one document per source document
+    and the positional join against the dense per-document tables holds.
+
+    ``chunk_index == 0`` marks the first row of a document. A rule that instead
+    started a document on a change of ``id`` would merge two adjacent documents
+    that share an id, which some sources produce.
+    """
+    with StoragePath(path).open("rb") as fh:
+        parquet = pq.ParquetFile(fh)
+        doc_id: str | None = None
+        chunks: list[np.ndarray] = []
+        for batch in parquet.iter_batches(
+            batch_size=_TOKENIZE_BATCH_SIZE, columns=["id", CHUNK_INDEX_FIELD, "input_ids"]
+        ):
+            row_ids = batch.column("id").to_pylist()
+            chunk_indices = batch.column(CHUNK_INDEX_FIELD).to_pylist()
+            input_ids = batch.column("input_ids")
+            for i, row_id in enumerate(row_ids):
+                if chunk_indices[i] == 0:
+                    if chunks:
+                        yield doc_id, chunks[0] if len(chunks) == 1 else np.concatenate(chunks)
+                    doc_id, chunks = row_id, []
+                elif row_id != doc_id:
+                    raise RuntimeError(
+                        f"{path}: chunk {chunk_indices[i]} of {row_id} does not follow a chunk 0 of that id"
+                    )
+                chunks.append(input_ids[i].values.to_numpy())
+        if chunks:
+            yield doc_id, chunks[0] if len(chunks) == 1 else np.concatenate(chunks)
+
+
 def _iter_surviving_docs(spec: dict[str, str], cluster_col: str) -> Iterator[tuple[int, int, str, np.ndarray]]:
     """Join one shard's datasets; yield ``(cluster, quality_bucket, doc_id, input_ids)`` per surviving doc.
 
@@ -284,37 +322,31 @@ def _iter_surviving_docs(spec: dict[str, str], cluster_col: str) -> Iterator[tup
     n_exact_dedup_dropped = 0
     n_dedup_dropped = 0
     n_out = 0
-    with StoragePath(spec["tokenize"]).open("rb") as fh:
-        pf = pq.ParquetFile(fh)
-        row_idx = 0
-        for batch in pf.iter_batches(batch_size=_TOKENIZE_BATCH_SIZE, columns=["id", "input_ids"]):
-            tok_ids = batch.column("id").to_pylist()
-            tok_input_ids = batch.column("input_ids")
-            batch_len = len(tok_ids)
-            contam_slice = contaminated[row_idx : row_idx + batch_len]
-            cluster_slice = cluster_vals[row_idx : row_idx + batch_len]
-            bucket_slice = quality_buckets[row_idx : row_idx + batch_len]
-            row_idx += batch_len
-            for i, doc_id in enumerate(tok_ids):
-                n_in += 1
-                if contam_slice[i]:
-                    n_contaminated += 1
-                    continue
-                fuzzy_canonical = dedup_canonical.get(doc_id)
-                if fuzzy_canonical is False:
-                    n_dedup_dropped += 1
-                    continue
-                if fuzzy_canonical is None and doc_id in exact_duplicates:
-                    n_exact_dedup_dropped += 1
-                    continue
-                ids = tok_input_ids[i].values.to_numpy()
-                n_out += 1
-                yield int(cluster_slice[i]), int(bucket_slice[i]), doc_id, ids
-        if row_idx != n_decon:
+    doc_idx = 0
+    for doc_id, ids in _iter_tokenized_documents(spec["tokenize"]):
+        if doc_idx >= n_decon:
             raise RuntimeError(
-                f"{spec['source_name']}/{spec['basename']}: tokenize rows ({row_idx}) != "
-                f"decon rows ({n_decon}) -- co-partitioning broken"
+                f"{where}: tokenize holds more documents than decon rows ({n_decon}) -- co-partitioning broken"
             )
+        n_in += 1
+        position = doc_idx
+        doc_idx += 1
+        if contaminated[position]:
+            n_contaminated += 1
+            continue
+        fuzzy_canonical = dedup_canonical.get(doc_id)
+        if fuzzy_canonical is False:
+            n_dedup_dropped += 1
+            continue
+        if fuzzy_canonical is None and doc_id in exact_duplicates:
+            n_exact_dedup_dropped += 1
+            continue
+        n_out += 1
+        yield int(cluster_vals[position]), int(quality_buckets[position]), doc_id, ids
+    if doc_idx != n_decon:
+        raise RuntimeError(
+            f"{where}: tokenize documents ({doc_idx}) != decon rows ({n_decon}) -- co-partitioning broken"
+        )
     counters.pipeline.update_counter("datakit_store/records_in", n_in)
     counters.pipeline.update_counter("datakit_store/contaminated_dropped", n_contaminated)
     counters.pipeline.update_counter("datakit_store/exact_duplicate_dropped", n_exact_dedup_dropped)

--- a/lib/marin/src/marin/processing/tokenize/_core.py
+++ b/lib/marin/src/marin/processing/tokenize/_core.py
@@ -188,6 +188,23 @@ class IdPreservingPreprocessor:
         return [{**out, "id": rec["id"]} for rec, out in zip(batch, outputs_list, strict=True)]
 
 
+def _splits_with_tokens(value: object, num_tokens: int) -> bool:
+    """Is ``value`` a per-token field that must be cut at the same boundaries?
+
+    A duck-typed length test rather than an ``isinstance`` against ``Sequence``:
+    Levanter's chat and prebuilt-cache processors return ``np.ndarray`` for
+    ``input_ids``, ``assistant_masks`` and loss weights, and ``np.ndarray`` is not
+    a ``Sequence``. Treating those as scalars would copy the whole oversized array
+    into every chunk, which both defeats the split and duplicates the document.
+    """
+    if isinstance(value, str | bytes | bytearray | Mapping):
+        return False
+    try:
+        return len(value) == num_tokens  # pyrefly: ignore[missing-attribute]
+    except TypeError:
+        return False
+
+
 def split_oversized_token_record(
     record: dict,
     *,
@@ -199,8 +216,8 @@ def split_oversized_token_record(
     the order, zero-based. A consumer that joins on ``id`` thus still matches the
     document, and reassembles it by a sort on ``(id, chunk_index)``. An id with
     the order encoded into it would instead match nothing on such a join, which
-    fails silently. Sequence fields that align with ``input_ids`` are split at the
-    same boundaries. Every other field is copied to each chunk.
+    fails silently. Fields whose length matches ``input_ids`` are split at the same
+    boundaries, lists and arrays alike. Every other field is copied to each chunk.
 
     A document at or below ``max_tokens`` yields one row with ``chunk_index == 0``,
     which keeps the column uniform across the dataset.
@@ -218,8 +235,7 @@ def split_oversized_token_record(
         end = min(start + max_tokens, num_tokens)
         chunk: dict = {CHUNK_INDEX_FIELD: chunk_index}
         for key, value in record.items():
-            aligned = isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray)
-            chunk[key] = value[start:end] if aligned and len(value) == num_tokens else value
+            chunk[key] = value[start:end] if _splits_with_tokens(value, num_tokens) else value
         yield chunk
 
 

--- a/lib/marin/src/marin/processing/tokenize/_core.py
+++ b/lib/marin/src/marin/processing/tokenize/_core.py
@@ -45,10 +45,8 @@ _MAX_WINDOW_SIZE = 64
 # with room for the repetition-level data that rides along with the values.
 MAX_TOKENS_PER_RECORD = 16 * 1024 * 1024
 
-# Zero-based position of a row inside its source document. The column is always
-# present: an unsplit document is chunk 0. Reassemble a document by a sort on
-# (id, CHUNK_INDEX_FIELD); ``id`` alone stays the join key against the other
-# datakit attribute datasets.
+# Zero-based position of a row inside its source document. See
+# :func:`split_oversized_token_record` for the contract.
 CHUNK_INDEX_FIELD = "chunk_index"
 
 _TOKENIZE_EXTENSIONS = ["json.{gz,zst,zstd}", "jsonl.{gz,zst,zstd}", "parquet"]
@@ -233,10 +231,13 @@ def split_oversized_token_record(
 
     for chunk_index, start in enumerate(range(0, num_tokens, max_tokens)):
         end = min(start + max_tokens, num_tokens)
-        chunk: dict = {CHUNK_INDEX_FIELD: chunk_index}
-        for key, value in record.items():
-            chunk[key] = value[start:end] if _splits_with_tokens(value, num_tokens) else value
-        yield chunk
+        # Same key order as the unsplit branch above: a writer that infers its
+        # schema from the first record must see one column order per shard,
+        # whether or not that record happened to be oversized.
+        chunk = {
+            key: value[start:end] if _splits_with_tokens(value, num_tokens) else value for key, value in record.items()
+        }
+        yield {**chunk, CHUNK_INDEX_FIELD: chunk_index}
 
 
 def tokenize_batches_with_id(
@@ -287,21 +288,20 @@ def tokenize_batches_with_id(
         counters.pipeline.update_counter("tokenize/tokens_out", batch_token_count)
         record_count += len(records)
         token_count += batch_token_count
+        oversized = 0
         for record in records:
             num_tokens = len(record.get("input_ids", []))
             if num_tokens > MAX_TOKENS_PER_RECORD:
-                counters.pipeline.update_counter("tokenize/oversized_docs", 1)
+                oversized += 1
                 logger.warning(
-                    "Document %s has %d tokens, above the %d limit of one Parquet row. "
-                    "It becomes several rows that share the id, ordered by %s.",
+                    "Document %s has %d tokens, above the %d limit of one Parquet row.",
                     record["id"],
                     num_tokens,
                     MAX_TOKENS_PER_RECORD,
-                    CHUNK_INDEX_FIELD,
                 )
-            for chunk in split_oversized_token_record(record):
-                counters.pipeline.update_counter("tokenize/chunks_out", 1)
-                yield chunk
+            yield from split_oversized_token_record(record)
+        if oversized:
+            counters.pipeline.update_counter("tokenize/oversized_docs", oversized)
         if batch_count % 10 == 0:
             elapsed = time.monotonic() - start_time
             tok_per_sec = token_count / elapsed if elapsed > 0 else 0
@@ -377,7 +377,7 @@ def tokenize_pipeline(
     """Build the tokenize pipeline tail.
 
     Attaches ``id`` to each input record, optionally subsamples per shard, windows,
-    and tokenizes. Returns the dataset of ``{id, input_ids, ...}`` records and the
+    and tokenizes. Returns the dataset of ``{id, chunk_index, input_ids, ...}`` rows and the
     chosen Levanter cache batch size (``None`` keeps Levanter's default).
     """
     window_size, batch_size = resolve_window_and_batch(sample_parquet_path, levanter_batch_size)

--- a/lib/marin/src/marin/processing/tokenize/_core.py
+++ b/lib/marin/src/marin/processing/tokenize/_core.py
@@ -40,6 +40,17 @@ MIN_GROUP_BYTES = 100_000_000  # 100 MB floor to avoid degenerate tiny shards
 # https://github.com/marin-community/marin/issues/2829#issuecomment-3963661943).
 _MAX_WINDOW_SIZE = 64
 
+# Parquet writes each repeated-list row into a single data page, and a page is
+# limited to a signed 32-bit byte count. Keep token rows far below that limit,
+# with room for the repetition-level data that rides along with the values.
+MAX_TOKENS_PER_RECORD = 16 * 1024 * 1024
+
+# Zero-based position of a row inside its source document. The column is always
+# present: an unsplit document is chunk 0. Reassemble a document by a sort on
+# (id, CHUNK_INDEX_FIELD); ``id`` alone stays the join key against the other
+# datakit attribute datasets.
+CHUNK_INDEX_FIELD = "chunk_index"
+
 _TOKENIZE_EXTENSIONS = ["json.{gz,zst,zstd}", "jsonl.{gz,zst,zstd}", "parquet"]
 
 
@@ -177,12 +188,52 @@ class IdPreservingPreprocessor:
         return [{**out, "id": rec["id"]} for rec, out in zip(batch, outputs_list, strict=True)]
 
 
+def split_oversized_token_record(
+    record: dict,
+    *,
+    max_tokens: int = MAX_TOKENS_PER_RECORD,
+) -> Iterator[dict]:
+    """Split one token record into Parquet-safe rows.
+
+    ``id`` stays the source document id on every row, and ``chunk_index`` carries
+    the order, zero-based. A consumer that joins on ``id`` thus still matches the
+    document, and reassembles it by a sort on ``(id, chunk_index)``. An id with
+    the order encoded into it would instead match nothing on such a join, which
+    fails silently. Sequence fields that align with ``input_ids`` are split at the
+    same boundaries. Every other field is copied to each chunk.
+
+    A document at or below ``max_tokens`` yields one row with ``chunk_index == 0``,
+    which keeps the column uniform across the dataset.
+    """
+    if max_tokens <= 0:
+        raise ValueError(f"max_tokens must be positive, got {max_tokens}")
+
+    input_ids = record.get("input_ids", [])
+    num_tokens = len(input_ids)
+    if num_tokens <= max_tokens:
+        yield {**record, CHUNK_INDEX_FIELD: 0}
+        return
+
+    for chunk_index, start in enumerate(range(0, num_tokens, max_tokens)):
+        end = min(start + max_tokens, num_tokens)
+        chunk: dict = {CHUNK_INDEX_FIELD: chunk_index}
+        for key, value in record.items():
+            aligned = isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray)
+            chunk[key] = value[start:end] if aligned and len(value) == num_tokens else value
+        yield chunk
+
+
 def tokenize_batches_with_id(
     *,
     data_format: LmDatasetFormatBase,
     batches: Iterator[Sequence[dict]],
 ) -> Iterator[dict]:
-    """Tokenize batches and yield ``{id, input_ids, ...}`` per input doc.
+    """Tokenize batches and yield ``{id, chunk_index, input_ids, ...}`` rows.
+
+    A document yields one row with ``chunk_index == 0``, unless its token count is
+    above :data:`MAX_TOKENS_PER_RECORD`. Such a document yields several adjacent
+    rows that share its ``id``, in ``chunk_index`` order — see
+    :func:`split_oversized_token_record`.
 
     Each input record must already carry ``id`` (apply :func:`attach_id` upstream).
     The worker tokenizer config is read from zephyr's shared context — caller is
@@ -220,7 +271,21 @@ def tokenize_batches_with_id(
         counters.pipeline.update_counter("tokenize/tokens_out", batch_token_count)
         record_count += len(records)
         token_count += batch_token_count
-        yield from records
+        for record in records:
+            num_tokens = len(record.get("input_ids", []))
+            if num_tokens > MAX_TOKENS_PER_RECORD:
+                counters.pipeline.update_counter("tokenize/oversized_docs", 1)
+                logger.warning(
+                    "Document %s has %d tokens, above the %d limit of one Parquet row. "
+                    "It becomes several rows that share the id, ordered by %s.",
+                    record["id"],
+                    num_tokens,
+                    MAX_TOKENS_PER_RECORD,
+                    CHUNK_INDEX_FIELD,
+                )
+            for chunk in split_oversized_token_record(record):
+                counters.pipeline.update_counter("tokenize/chunks_out", 1)
+                yield chunk
         if batch_count % 10 == 0:
             elapsed = time.monotonic() - start_time
             tok_per_sec = token_count / elapsed if elapsed > 0 else 0

--- a/lib/marin/src/marin/processing/tokenize/attributes.py
+++ b/lib/marin/src/marin/processing/tokenize/attributes.py
@@ -228,7 +228,7 @@ def _process_split(
 def _attribute_schema(data_format: LmDatasetFormatBase) -> pa.Schema | None:
     """Return the parquet schema for attribute output, or ``None`` to let zephyr infer.
 
-    For text formats we pin ``id: string`` and ``input_ids: list<int32>`` to keep
+    For text formats we pin ``id: string``, ``chunk_index: int32`` and ``input_ids: list<int32>`` to keep
     files compact and stable across workers. For chat or other multi-output formats,
     we let zephyr infer from the first record so additional columns like
     ``assistant_masks`` flow through unchanged.
@@ -242,7 +242,7 @@ def tokenize_attributes(config: TokenizeAttributesConfig) -> TokenizedAttrData:
     """Tokenize :class:`NormalizedData` source(s) into datakit attribute parquet.
 
     Each split's source shards become co-partitioned attribute parquet files
-    sharing basenames with the source. Output records carry ``{id, input_ids}``
+    sharing basenames with the source. Output rows carry ``{id, chunk_index, input_ids}``
     (plus any extra fields produced by the format processor for non-text formats).
 
     Args:

--- a/lib/marin/src/marin/processing/tokenize/attributes.py
+++ b/lib/marin/src/marin/processing/tokenize/attributes.py
@@ -5,14 +5,16 @@
 
 Reads one or more :class:`~marin.datakit.normalize.NormalizedData` sources, runs
 the shared tokenization core, and writes co-partitioned attribute parquet shards
-with columns ``id`` and ``input_ids`` (one row per input document).
+with columns ``id``, ``chunk_index`` and ``input_ids``.
 
 Each output shard mirrors the basename of its source shard, which ensures the
 datakit invariants hold by construction:
 
 * Same shard count as source (co-partitioned).
 * Sorted by ``id`` within each shard (sources are already sorted; the
-  tokenize pipeline preserves order).
+  tokenize pipeline preserves order). A document above the token limit of one
+  Parquet row occupies several adjacent rows that share its ``id``, in
+  ``chunk_index`` order, so the sort by ``id`` holds.
 
 Downstream:
 
@@ -40,20 +42,34 @@ from marin.datakit.normalize import NormalizedData
 from marin.datakit.source_key import DatakitArtifactPath, datakit_source_key
 from marin.execution.artifact import read_artifact
 from marin.execution.step_spec import StepSpec
-from marin.processing.tokenize._core import resolve_window_and_batch, tokenize_batches_with_id, tokenize_pipeline
+from marin.processing.tokenize._core import (
+    CHUNK_INDEX_FIELD,
+    resolve_window_and_batch,
+    tokenize_batches_with_id,
+    tokenize_pipeline,
+)
 
 logger = logging.getLogger(__name__)
-TOKENIZED_ATTR_DATA_VERSION = 3
+TOKENIZED_ATTR_DATA_VERSION = 4
 
 
 class TokenizedAttrData(BaseModel):
     """Per-split datakit attribute datasets produced by :func:`tokenize_attributes`.
 
     Each split's attribute parquet shards live under ``output_dirs[split]/`` with
-    columns ``id: string`` and ``input_ids: list<int>``. Shards mirror their source
+    columns ``id: string``, ``chunk_index: int32`` and ``input_ids: list<int>``.
+    Shards mirror their source
     :class:`~marin.datakit.normalize.NormalizedData` partitions 1:1 (same basename,
-    same row order, same id range), so the dataset is sorted by ``id`` per partition
-    and co-partitioned with the source — both datakit invariants.
+    same source order, same id range), so the dataset is sorted by ``id`` per
+    partition and co-partitioned with the source — both datakit invariants.
+
+    ``id`` is the source document id, and is the join key against the other datakit
+    attribute datasets. A document with more tokens than one Parquet row can hold
+    occupies several adjacent rows that share that id, in zero-based
+    ``chunk_index`` order. An unsplit document is a single row with
+    ``chunk_index == 0``. A consumer that needs one row per document must group by
+    ``id``. A consumer that walks this dataset positionally against a
+    one-row-per-document dataset must not: the row counts differ.
 
     Persisted as the step's ``.artifact``. Load via
     ``Artifact.from_path(step, TokenizedAttrData)``.
@@ -114,6 +130,7 @@ class TokenizeAttributesConfig:
 _ATTRIBUTE_SCHEMA = pa.schema(
     [
         pa.field("id", pa.string()),
+        pa.field(CHUNK_INDEX_FIELD, pa.int32()),
         pa.field("input_ids", pa.list_(pa.int32())),
     ]
 )

--- a/lib/marin/src/marin/processing/tokenize/store_builder.py
+++ b/lib/marin/src/marin/processing/tokenize/store_builder.py
@@ -44,6 +44,7 @@ from zephyr.readers import load_file
 from marin.datakit.source_key import DatakitArtifactPath
 from marin.execution.artifact import read_artifact
 from marin.execution.step_spec import StepSpec
+from marin.processing.tokenize._core import CHUNK_INDEX_FIELD
 from marin.processing.tokenize.attributes import TokenizedAttrData
 
 logger = logging.getLogger(__name__)
@@ -88,11 +89,21 @@ class LevanterStoreData(BaseModel):
     tokenizer: str
 
 
-def _strip_id(record: dict) -> dict:
-    """Drop ``id`` from a record. Levanter ``TreeStore`` is positional, not keyed."""
-    if "id" not in record:
-        return record
-    return {k: v for k, v in record.items() if k != "id"}
+# Datakit attribute columns that identify a row. They are not cache payload.
+_JOIN_COLUMNS = frozenset({"id", CHUNK_INDEX_FIELD})
+
+
+def _strip_join_columns(record: dict) -> dict:
+    """Drop the join columns from a record. Levanter ``TreeStore`` is positional, not keyed.
+
+    ``chunk_index`` goes with ``id``: it orders the rows of a document that the
+    tokenizer split (see :func:`marin.processing.tokenize._core.split_oversized_token_record`),
+    and it would otherwise land in the cache as a data field. Such rows stay
+    adjacent and in order here, because this path writes shards positionally and
+    never shuffles, so the token stream in the cache is the same as it would be
+    from an unsplit document. Only the document count grows.
+    """
+    return {k: v for k, v in record.items() if k not in _JOIN_COLUMNS}
 
 
 def _structural_exemplar(record: dict) -> dict:
@@ -122,9 +133,10 @@ def build_from_datasets(
 ) -> CacheLedger:
     """Write a Levanter cache from a tokenized records dataset.
 
-    The dataset is expected to yield per-doc records shaped like
-    ``{id, input_ids, ...}``. ``id`` is stripped before writing because
-    ``TreeStore`` stores positional concatenated arrays, not keyed rows.
+    The dataset is expected to yield records shaped like
+    ``{id, input_ids, ...}``, with an optional ``chunk_index``. ``id`` and
+    ``chunk_index`` are stripped before writing because ``TreeStore`` stores
+    positional concatenated arrays, not keyed rows.
 
     The dataset's shard structure determines the number of per-shard Levanter
     caches written under ``{output_path}/part-NNNNN-of-MMMMM``. Those shard
@@ -170,7 +182,7 @@ def build_from_datasets(
         exemplar = result["exemplar"]
         yield (shard_path, _structural_exemplar(exemplar) if exemplar is not None else None)
 
-    temp_shards = dataset.map(_strip_id).map_shard(_write_shard)
+    temp_shards = dataset.map(_strip_join_columns).map_shard(_write_shard)
 
     tokenize_start = time.monotonic()
     shard_results = ctx.execute(temp_shards, map_task_resources=task_resources).results

--- a/lib/marin/src/marin/processing/tokenize/store_builder.py
+++ b/lib/marin/src/marin/processing/tokenize/store_builder.py
@@ -89,19 +89,17 @@ class LevanterStoreData(BaseModel):
     tokenizer: str
 
 
-# Datakit attribute columns that identify a row. They are not cache payload.
 _JOIN_COLUMNS = frozenset({"id", CHUNK_INDEX_FIELD})
 
 
 def _strip_join_columns(record: dict) -> dict:
     """Drop the join columns from a record. Levanter ``TreeStore`` is positional, not keyed.
 
-    ``chunk_index`` goes with ``id``: it orders the rows of a document that the
-    tokenizer split (see :func:`marin.processing.tokenize._core.split_oversized_token_record`),
-    and it would otherwise land in the cache as a data field. Such rows stay
-    adjacent and in order here, because this path writes shards positionally and
-    never shuffles, so the token stream in the cache is the same as it would be
-    from an unsplit document. Only the document count grows.
+    ``chunk_index`` goes with ``id``: it orders the rows of a split document (see
+    :func:`marin.processing.tokenize._core.split_oversized_token_record`) and would
+    otherwise land in the cache as a data field. Dropping it is safe here because
+    this path writes shards positionally and never shuffles, so a split document's
+    rows stay adjacent and its token stream is unchanged.
     """
     return {k: v for k, v in record.items() if k not in _JOIN_COLUMNS}
 

--- a/tests/datakit/test_datakit_store.py
+++ b/tests/datakit/test_datakit_store.py
@@ -395,5 +395,31 @@ def test_tokenized_documents_regroup_chunks_and_reject_an_orphan(tmp_path):
         ),
     )
 
-    with pytest.raises(RuntimeError, match="does not follow a chunk 0"):
+    with pytest.raises(RuntimeError, match="chunk 1 of b, but chunk 1 of a must come next"):
         list(_iter_tokenized_documents(orphan_path))
+
+    # Out of order within one id: concatenating in file order would silently
+    # reverse a document's tokens.
+    shuffled_path = str(tmp_path / "shuffled.parquet")
+    _write_parquet(
+        shuffled_path,
+        pa.table(
+            {
+                "id": ["a", "a", "a"],
+                "chunk_index": pa.array([0, 2, 1], type=pa.int32()),
+                "input_ids": pa.array([[1], [3], [2]]),
+            }
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="chunk 2 of a, but chunk 1 of a must come next"):
+        list(_iter_tokenized_documents(shuffled_path))
+
+
+def test_tokenized_shard_without_chunk_index_is_rejected(tmp_path):
+    """A shard written before the column existed fails legibly, not with a KeyError."""
+    path = str(tmp_path / "old.parquet")
+    _write_parquet(path, pa.table({"id": ["a"], "input_ids": pa.array([[1, 2]])}))
+
+    with pytest.raises(RuntimeError, match="no chunk_index column"):
+        list(_iter_tokenized_documents(path))

--- a/tests/datakit/test_datakit_store.py
+++ b/tests/datakit/test_datakit_store.py
@@ -31,7 +31,11 @@ from zephyr.shard_keys import deterministic_hash
 from experiments.datakit.cluster.domain.v0.assign import AssignmentAttrData
 from experiments.datakit.cluster.quality.fast_transformer.artifact import QualityScores
 from experiments.datakit.global_exact_dedup import ExactDupsPerSource, GlobalExactDedupData
-from experiments.datakit.store.datakit_store import ClusteredStoreData, build_clustered_store
+from experiments.datakit.store.datakit_store import (
+    ClusteredStoreData,
+    _iter_tokenized_documents,
+    build_clustered_store,
+)
 
 CLUSTER_VIEW = 2  # cluster column "cluster_2", clusters {0, 1}
 SPLIT = "train"
@@ -71,17 +75,47 @@ EXPECTED: dict[tuple[int, int], dict[int, int]] = {
 EXACT_DUPLICATES = {("part-00001-of-00002.parquet", "d6"), ("part-00001-of-00002.parquet", "d8")}
 DROPPED_TOKEN_VALUES = {902, 905, 906, 908}
 
+# Documents the tokenizer split across several Parquet rows, and how many rows
+# each one occupies. The tokenize dataset is the only input with such rows: the
+# other inputs stay one row per document. The expectations above do not change,
+# because the store must join these rows back into one document -- one that
+# survives (d1) and one that a filter drops (d2, contaminated).
+CHUNKED_DOCS = {"d1": 2, "d2": 3}
+
 
 def _write_parquet(path: str, table: pa.Table) -> None:
     pq.write_table(table, path)
 
 
+def _tokenize_rows(docs: list[_Doc]) -> tuple[list[str], list[int], list[list[int]]]:
+    """Build the tokenize shard's rows, splitting the documents in ``CHUNKED_DOCS``."""
+    ids: list[str] = []
+    chunk_indices: list[int] = []
+    token_rows: list[list[int]] = []
+    for doc in docs:
+        tokens = [doc[5]] * doc[6]
+        num_chunks = CHUNKED_DOCS.get(doc[0], 1)
+        size = -(-len(tokens) // num_chunks)  # ceiling, so the last chunk is the short one
+        for chunk_index, start in enumerate(range(0, len(tokens), size)):
+            ids.append(doc[0])
+            chunk_indices.append(chunk_index)
+            token_rows.append(tokens[start : start + size])
+    return ids, chunk_indices, token_rows
+
+
 def _write_shard(dirs: dict[str, str], basename: str, docs: list[_Doc]) -> None:
-    """Write one shard's co-partitioned Parquet inputs in the same row order."""
+    """Write one shard's co-partitioned Parquet inputs in the same document order."""
     ids = [d[0] for d in docs]
+    tok_ids, tok_chunk_indices, tok_token_rows = _tokenize_rows(docs)
     _write_parquet(
         f"{dirs['tokenize']}/{basename}",
-        pa.table({"id": ids, "input_ids": pa.array([[d[5]] * d[6] for d in docs])}),
+        pa.table(
+            {
+                "id": tok_ids,
+                "chunk_index": pa.array(tok_chunk_indices, type=pa.int32()),
+                "input_ids": pa.array(tok_token_rows),
+            }
+        ),
     )
     _write_parquet(
         f"{dirs['decon']}/{basename}",
@@ -326,3 +360,40 @@ def test_store_rejects_dedup_source_set_mismatch(tmp_path, monkeypatch, label):
             reduce_shards=4,
             default_subshards=1,
         )
+
+
+def test_tokenized_documents_regroup_chunks_and_reject_an_orphan(tmp_path):
+    """Chunked rows rejoin into one document, and a chunk without its chunk 0 is an error.
+
+    Two adjacent documents that share an id stay two documents: the boundary comes
+    from ``chunk_index == 0``, not from a change of id.
+    """
+    path = str(tmp_path / "tokenize.parquet")
+    _write_parquet(
+        path,
+        pa.table(
+            {
+                "id": ["a", "a", "b", "b"],
+                "chunk_index": pa.array([0, 1, 0, 0], type=pa.int32()),
+                "input_ids": pa.array([[1, 2], [3], [4], [5, 6]]),
+            }
+        ),
+    )
+
+    documents = [(doc_id, list(tokens)) for doc_id, tokens in _iter_tokenized_documents(path)]
+    assert documents == [("a", [1, 2, 3]), ("b", [4]), ("b", [5, 6])]
+
+    orphan_path = str(tmp_path / "orphan.parquet")
+    _write_parquet(
+        orphan_path,
+        pa.table(
+            {
+                "id": ["a", "b"],
+                "chunk_index": pa.array([0, 1], type=pa.int32()),
+                "input_ids": pa.array([[1], [2]]),
+            }
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="does not follow a chunk 0"):
+        list(_iter_tokenized_documents(orphan_path))

--- a/tests/processing/tokenize/test_split_tokenize.py
+++ b/tests/processing/tokenize/test_split_tokenize.py
@@ -136,6 +136,27 @@ def test_oversized_token_record_round_trips_as_ordered_chunks(tmp_path):
     assert [mask for row in rows for mask in row["assistant_masks"]] == record["assistant_masks"]
 
 
+def test_oversized_ndarray_token_fields_are_split():
+    """Array token fields split too, not just lists.
+
+    Levanter's chat and prebuilt-cache processors return ``np.ndarray`` for
+    ``input_ids`` and ``assistant_masks``, and ndarray is not a ``Sequence``.
+    Copying such a field whole into each chunk would leave the oversized row
+    oversized and duplicate the document.
+    """
+    record = {
+        "id": "chat-doc",
+        "input_ids": np.arange(10, dtype=np.int32),
+        "assistant_masks": np.ones(10, dtype=np.int32),
+    }
+
+    chunks = list(split_oversized_token_record(record, max_tokens=4))
+
+    assert [len(c["input_ids"]) for c in chunks] == [4, 4, 2]
+    assert [len(c["assistant_masks"]) for c in chunks] == [4, 4, 2]
+    assert np.array_equal(np.concatenate([c["input_ids"] for c in chunks]), record["input_ids"])
+
+
 def test_unsplit_token_record_is_chunk_zero():
     """A document that fits stays one row, so chunk_index is uniform across the dataset."""
     record = {"id": "abc", "input_ids": [1, 2, 3]}

--- a/tests/processing/tokenize/test_split_tokenize.py
+++ b/tests/processing/tokenize/test_split_tokenize.py
@@ -17,7 +17,7 @@ import pytest
 from levanter.data.text.formats import TextLmDatasetFormat
 from levanter.store.cache import CacheLedger, TreeCache
 from marin.datakit.normalize import NormalizedData, generate_id
-from marin.processing.tokenize._core import IdPreservingPreprocessor, attach_id
+from marin.processing.tokenize._core import IdPreservingPreprocessor, attach_id, split_oversized_token_record
 from marin.processing.tokenize.attributes import (
     TokenizeAttributesConfig,
     TokenizedAttrData,
@@ -112,6 +112,39 @@ def test_id_preserving_preprocessor_raises_on_non_1_to_1():
         wrapped([{"id": "a"}, {"id": "b"}])
 
 
+def test_oversized_token_record_round_trips_as_ordered_chunks(tmp_path):
+    """A split document keeps its id and orders its rows with chunk_index.
+
+    The id stays the join key against the other datakit attribute datasets, so a
+    consumer that joins on id still matches every row of the document, and gets
+    the document back by a sort on (id, chunk_index).
+    """
+    record = {
+        "id": "0123456789abcdef0123456789abcdef",
+        "input_ids": list(range(11)),
+        "assistant_masks": [i % 2 for i in range(11)],
+    }
+
+    chunks = list(split_oversized_token_record(record, max_tokens=4))
+    output_path = tmp_path / "chunks.parquet"
+    pq.write_table(pa.Table.from_pylist(chunks), output_path)
+    rows = pq.read_table(output_path).to_pylist()
+
+    assert [row["id"] for row in rows] == [record["id"]] * 3
+    assert [row["chunk_index"] for row in rows] == [0, 1, 2]
+    assert [token for row in rows for token in row["input_ids"]] == record["input_ids"]
+    assert [mask for row in rows for mask in row["assistant_masks"]] == record["assistant_masks"]
+
+
+def test_unsplit_token_record_is_chunk_zero():
+    """A document that fits stays one row, so chunk_index is uniform across the dataset."""
+    record = {"id": "abc", "input_ids": [1, 2, 3]}
+
+    rows = list(split_oversized_token_record(record, max_tokens=16))
+
+    assert rows == [{"id": "abc", "input_ids": [1, 2, 3], "chunk_index": 0}]
+
+
 def _write_normalized_fixture(tmp_path, texts: list[str]) -> NormalizedData:
     """Write a small datakit-normalized parquet shard with {id, text} columns."""
     main_dir = tmp_path / "normalized" / "outputs" / "main"
@@ -156,8 +189,11 @@ def test_split_pipeline_matches_legacy_tokenize(tmp_path, monkeypatch):
     train_shards = tokenized.shard_paths("train")
     assert len(train_shards) == 1, f"expected 1 attribute shard, got {len(train_shards)}: {train_shards}"
     attr_table = pq.read_table(train_shards[0])
-    assert set(attr_table.column_names) == {"id", "input_ids"}
+    assert set(attr_table.column_names) == {"id", "chunk_index", "input_ids"}
+    # These texts are far below the token limit of one Parquet row, so each is a
+    # single row, chunk 0. The store below thus sees one cache row per text.
     assert attr_table.num_rows == len(texts)
+    assert attr_table["chunk_index"].to_pylist() == [0] * len(texts)
     # Datakit invariant: sorted by id within each partition.
     ids = attr_table["id"].to_pylist()
     assert ids == sorted(ids)


### PR DESCRIPTION
* a document whose tokens do not fit one Parquet data page fails the write — Parquet keeps each repeated-list row in one page, and a page is capped at a signed 32-bit byte count [^1]
* split such a document at `MAX_TOKENS_PER_RECORD` (16M tokens) in `split_oversized_token_record`, and carry the order in a new zero-indexed `chunk_index` column rather than in the id
  * `id` stays the source document id on every row, so it remains the join key against the other datakit attribute datasets — a consumer joining on `id` still matches the document and reassembles it by sorting on `(id, chunk_index)`
  * an id with the order encoded into it (`<id>#1`) would match nothing on that join, and fail silently
  * an unsplit document is one row with `chunk_index == 0`, so the column is uniform across the dataset
* `TOKENIZED_ATTR_DATA_VERSION` 3 → 4, which re-keys tokenize outputs

consumers updated:

* `store_builder` strips `chunk_index` alongside `id` (`_strip_id` → `_strip_join_columns`), so it does not land in the Levanter cache as a data field. that path writes shards positionally and never shuffles, so the rows of a split document stay adjacent — the token stream in the cache is unchanged and only the document count grows
* `datakit_store` walked tokenize rows in positional lockstep against the dense per-document decon/cluster/quality tables, which a split document breaks (it raised `tokenize rows != decon rows -- co-partitioning broken`). new `_iter_tokenized_documents` joins a document's rows back together before the positional join
  * the document boundary is `chunk_index == 0`, not a change of `id`: some sources emit two adjacent documents that share an id, and a change-of-id rule would merge them
  * a chunk that does not follow a chunk 0 of the same id raises rather than corrupting the join

tests: the split round-trips through Parquet with ordered chunks and reassembles; an unsplit record is chunk 0; the store test now writes two of its synthetic documents as multiple tokenize rows (one surviving, one dropped by a filter) and the expected bucket contents are unchanged; the orphan-chunk path raises.

[^1]: this is what the `tokenize/oversized_docs` counter and the new `tokenize/chunks_out` counter track.
