### PR TITLE
[datakit] Give the dedup step builders the graph's artifact identity

### DIFF
--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
@@ -55,6 +55,7 @@ from marin.processing.classification.deduplication.fuzzy_minhash import MinHashA
 
 logger = logging.getLogger(__name__)
 FUZZY_DUPS_ATTR_DATA_VERSION = 4
+DEFAULT_CC_MAX_ITERATIONS = 10
 
 
 class FuzzyDupsPerSource(BaseModel):
@@ -223,7 +224,7 @@ def compute_fuzzy_dups_attrs(
     *,
     inputs: list[MinHashAttrData],
     output_path: str,
-    cc_max_iterations: int = 10,
+    cc_max_iterations: int = DEFAULT_CC_MAX_ITERATIONS,
     cc_resume: bool = False,
     max_parallelism: int = MAX_IRIS_WORKER_REPLICAS,
     worker_resources: ResourceConfig | None = None,
@@ -394,7 +395,7 @@ def compute_fuzzy_dups_attrs_step(
     *,
     name: str,
     minhash_steps: list[StepSpec],
-    cc_max_iterations: int = 10,
+    cc_max_iterations: int = DEFAULT_CC_MAX_ITERATIONS,
     max_parallelism: int,
     worker_resources: ResourceConfig | None = None,
     coordinator_resources: ResourceConfig | None = None,
@@ -412,6 +413,12 @@ def compute_fuzzy_dups_attrs_step(
             worker_resources=worker_resources,
             coordinator_resources=coordinator_resources,
         ),
-        hash_attrs={"artifact_version": FUZZY_DUPS_ATTR_DATA_VERSION, "cc_max_iterations": cc_max_iterations},
+        # Match the identity the Datakit DAG builds, so a step created here
+        # resolves to the artifacts that graph already produced. The MinHash
+        # content parameters reach this hash through the dependency IDs.
+        hash_attrs={
+            "v": FUZZY_DUPS_ATTR_DATA_VERSION,
+            **({"cc_max_iterations": cc_max_iterations} if cc_max_iterations != DEFAULT_CC_MAX_ITERATIONS else {}),
+        },
         override_output_path=override_output_path,
     )

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
@@ -286,7 +286,7 @@ def compute_minhash_attrs_step(
             max_workers=max_workers,
         ),
         hash_attrs={
-            "artifact_version": MINHASH_ATTR_DATA_VERSION,
+            "v": MINHASH_ATTR_DATA_VERSION,
             "num_perms": num_perms,
             "num_bands": num_bands,
             "ngram_size": ngram_size,

--- a/tests/datakit/test_reference_pipeline_hashing.py
+++ b/tests/datakit/test_reference_pipeline_hashing.py
@@ -14,9 +14,17 @@ import json
 
 import pytest
 from marin.execution.step_spec import StepSpec
+from marin.processing.classification.deduplication.fuzzy_dups import compute_fuzzy_dups_attrs_step
+from marin.processing.classification.deduplication.fuzzy_minhash import compute_minhash_attrs_step
 
 from experiments.datakit import reference_pipeline
-from experiments.datakit.reference_pipeline import SMOKE_SCALE, PoolConfig, StoreConfig, reference_datakit_steps
+from experiments.datakit.reference_pipeline import (
+    SMOKE_SCALE,
+    PoolConfig,
+    StoreConfig,
+    reference_datakit_steps,
+    zephyr_datakit_steps,
+)
 from experiments.datakit.zephyr_benchmark import _route_outputs
 
 
@@ -172,3 +180,35 @@ def test_centroids_version_not_path_drives_identity():
         return _steps_by_name(result)["datakit/cluster_assign/a"].hash_id
 
     assert assign_hash("gs://region-a/centroids") == assign_hash("gs://region-b/centroids")
+
+
+def test_dedup_step_builders_match_the_datakit_graph_identity():
+    """A step built by the helpers must resolve to the artifacts the DAG produced.
+
+    The two constructions hashed different key names, so a helper-built step
+    pointed at a fresh output tree and would recompute every MinHash source.
+    """
+    sources = _sources()
+    graph = zephyr_datakit_steps(sources, SMOKE_SCALE)
+    minhash = {
+        name: compute_minhash_attrs_step(
+            name=f"datakit/minhash/{name}",
+            normalize=step,
+            num_perms=SMOKE_SCALE.minhash.num_perms,
+            num_bands=SMOKE_SCALE.minhash.num_bands,
+            ngram_size=SMOKE_SCALE.minhash.ngram_size,
+            text_cap_chars=SMOKE_SCALE.minhash.text_cap_chars,
+            seed=SMOKE_SCALE.minhash.seed,
+        )
+        for name, step in sources.items()
+    }
+    dedup = compute_fuzzy_dups_attrs_step(
+        name="datakit/dedup",
+        minhash_steps=list(minhash.values()),
+        max_parallelism=SMOKE_SCALE.dedup_max_parallelism,
+    )
+
+    assert {name: step.hash_id for name, step in minhash.items()} == {
+        name: step.hash_id for name, step in graph.minhash.items()
+    }
+    assert dedup.hash_id == graph.fuzzy_dedup.hash_id


### PR DESCRIPTION
`compute_minhash_attrs_step` and `compute_fuzzy_dups_attrs_step` hash `artifact_version`, while `zephyr_datakit_steps` hashes `v` for the same artifacts, and the fuzzy-dedup builder always folds `cc_max_iterations` into its hash where the graph does not. A step built through either helper therefore resolves to a different output tree than the identical step built by the graph.

Nothing calls the helpers today, so no built artifact moves and no cache is invalidated. The first caller, though, would have missed all 292 existing MinHash artifacts and recomputed them from 49.67 TiB of normalized text.

Both helpers now hash `v`, and the fuzzy-dedup builder folds `cc_max_iterations` into the hash only when it differs from `DEFAULT_CC_MAX_ITERATIONS`, which keeps a default-capped step on the graph's identity while a raised cap still re-keys. Verified against the real registry: `datakit/minhash/agenttrove` and `datakit/minhash/biocorpus` resolve to `agenttrove_2d60a167` and `biocorpus_c3316968`, and `datakit/dedup` to `dedup_3234cf52`, from either construction. One test pins that agreement.
