### PR TITLE
[iris] Classify multi-GPU rank-tagged log lines by level

### DIFF
--- a/lib/iris/src/iris/cluster/log_highlights.py
+++ b/lib/iris/src/iris/cluster/log_highlights.py
@@ -17,6 +17,13 @@ from collections.abc import Sequence
 
 _DEFAULT_MAX_LINES = 20
 
+# The multi-GPU supervisor (``iris.hooks.multigpu_main``) tags each line it
+# forwards with the child's local rank, so a task's log lines can arrive as
+# "[rank2] Traceback (most recent call last):". Level parsing and the anchored
+# patterns below read the child's own text, so the tag is stripped before
+# matching and kept in the output.
+_RANK_TAG_PATTERN = re.compile(r"^\[rank\d+\] ")
+
 # The two halves of a tqdm frame, either of which identifies one:
 #
 #   with a total:    "Loading:  45%|####5     | 450/1000 [00:12<00:15,  3.21it/s]"
@@ -64,6 +71,16 @@ _SIGNAL_PATTERNS = (
 )
 
 
+def rank_log_tag(local_rank: int) -> str:
+    """The per-line tag the multi-GPU supervisor writes ahead of a child's output."""
+    return f"[rank{local_rank}] "
+
+
+def strip_rank_log_tag(line: str) -> str:
+    """Drop a leading multi-GPU rank tag, so the line reads as the child wrote it."""
+    return _RANK_TAG_PATTERN.sub("", line, count=1)
+
+
 def is_progress_bar_line(line: str) -> bool:
     """Whether ``line`` holds a tqdm-style progress bar frame anywhere in it."""
     return any(pattern.search(line) for pattern in _PROGRESS_BAR_PATTERNS)
@@ -83,18 +100,22 @@ def extract_failure_highlights(lines: Sequence[str], max_lines: int = _DEFAULT_M
     OOM/eviction/timeout signals). Falls back to the de-noised tail when no
     line matches, so the result is never empty for a non-empty input.
 
+    Matching ignores a leading multi-GPU rank tag; the returned lines keep it,
+    so the reader still sees which rank produced each one.
+
     Returns at most ``max_lines`` lines, keeping the most recent ones.
     """
-    deduped: list[str] = []
+    kept: list[tuple[str, str]] = []
     previous: str | None = None
     for line in lines:
-        if _is_noise(line):
+        body = strip_rank_log_tag(line)
+        if _is_noise(body):
             continue
         if line == previous:
             continue
-        deduped.append(line)
+        kept.append((line, body))
         previous = line
 
-    signal_lines = [line for line in deduped if any(pattern.search(line) for pattern in _SIGNAL_PATTERNS)]
-    result = signal_lines or deduped
+    signal_lines = [line for line, body in kept if any(pattern.search(body) for pattern in _SIGNAL_PATTERNS)]
+    result = signal_lines or [line for line, _ in kept]
     return result[-max_lines:]

--- a/lib/iris/src/iris/cluster/log_keys.py
+++ b/lib/iris/src/iris/cluster/log_keys.py
@@ -12,7 +12,7 @@ from finelog.rpc import logging_pb2
 from finelog.types import str_to_log_level
 from rigging.log_setup import parse_log_level
 
-from iris.cluster.log_highlights import is_progress_bar_line
+from iris.cluster.log_highlights import is_progress_bar_line, strip_rank_log_tag
 from iris.cluster.types import JobName, TaskAttempt
 
 CONTROLLER_LOG_KEY = "/system/controller"
@@ -38,17 +38,19 @@ def classify_log_level(source: str, data: str) -> int:
 
     Lines from ``INJECTED_ERROR_SOURCE`` are errors whatever they say. Otherwise
     a glog-style level prefix in ``data`` wins, so a prefixed ``INFO`` line on
-    ``stderr`` classifies as ``INFO``. An unprefixed tqdm progress bar on
-    ``stderr`` classifies as ``INFO``. Any other unprefixed line takes its
-    stream's default: ``stdout`` informational, ``stderr`` error, and an
-    unrecognized stream ``UNKNOWN``, which passes every ``min_level`` filter.
+    ``stderr`` classifies as ``INFO``; a multi-GPU rank tag ahead of that prefix
+    does not hide it. An unprefixed tqdm progress bar on ``stderr`` classifies as
+    ``INFO``. Any other unprefixed line takes its stream's default: ``stdout``
+    informational, ``stderr`` error, and an unrecognized stream ``UNKNOWN``,
+    which passes every ``min_level`` filter.
     """
     if source == INJECTED_ERROR_SOURCE:
         return logging_pb2.LOG_LEVEL_ERROR
-    parsed = str_to_log_level(parse_log_level(data))
+    body = strip_rank_log_tag(data)
+    parsed = str_to_log_level(parse_log_level(body))
     if parsed != logging_pb2.LOG_LEVEL_UNKNOWN:
         return parsed
-    if source == STDERR_SOURCE and is_progress_bar_line(data):
+    if source == STDERR_SOURCE and is_progress_bar_line(body):
         return logging_pb2.LOG_LEVEL_INFO
     return _STREAM_DEFAULT_LEVEL.get(source, logging_pb2.LOG_LEVEL_UNKNOWN)
 

--- a/lib/iris/src/iris/hooks/multigpu_main.py
+++ b/lib/iris/src/iris/hooks/multigpu_main.py
@@ -28,8 +28,9 @@ JAX_*/framework namespace) so a job that already sets JAX rank vars never trips
 the supervised path.
 
 The supervisor owns child lifecycle: it forwards SIGINT/SIGTERM to every child,
-tears the group down and exits non-zero if any child fails, and prefixes each
-child's output with its local rank. It deliberately does not import jax — the
+tears the group down and exits non-zero if any child fails, and tags each
+child's output with its local rank, keeping stdout and stderr apart so iris
+still classifies each line by its stream. It deliberately does not import jax — the
 children initialize CUDA only after the supervisor has already spawned them, so
 no CUDA context exists in the supervisor's address space.
 """
@@ -47,6 +48,7 @@ from types import FrameType
 from rigging.timing import Deadline, Duration
 
 from iris.cluster.client.job_info import get_job_info
+from iris.cluster.log_highlights import rank_log_tag
 from iris.hooks.multigpu import (
     IRIS_MULTIGPU_LOCAL_DEVICE_IDS_ENV,
     IRIS_MULTIGPU_PROCESS_COUNT_ENV,
@@ -80,14 +82,18 @@ def _child_rank_env(
     }
 
 
-def _pump_output(local_rank: int, stream, write_lock: threading.Lock) -> None:
-    """Forward a child's merged stdout/stderr, line-prefixed with its rank."""
-    prefix = f"[rank{local_rank}] "
-    for line in iter(stream.readline, ""):
+def _pump_output(tag: str, source, sink, write_lock: threading.Lock) -> None:
+    """Forward one of a child's streams to the matching supervisor stream, rank-tagged.
+
+    stdout and stderr stay separate: iris classifies an unprefixed line by the
+    stream it arrived on, so folding a child's stderr into stdout would demote
+    its tracebacks to ``INFO``.
+    """
+    for line in iter(source.readline, ""):
         with write_lock:
-            sys.stdout.write(prefix + line)
-            sys.stdout.flush()
-    stream.close()
+            sink.write(tag + line)
+            sink.flush()
+    source.close()
 
 
 def _signal_children(children: list[subprocess.Popen], ranks, sig: int) -> None:
@@ -126,14 +132,16 @@ def _spawn_children(
                 child_argv,
                 env=child_env,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
+                stderr=subprocess.PIPE,
                 text=True,
                 bufsize=1,
             )
             children.append(child)
-            pump = threading.Thread(target=_pump_output, args=(local_rank, child.stdout, write_lock), daemon=True)
-            pump.start()
-            pumps.append(pump)
+            tag = rank_log_tag(local_rank)
+            for source, sink in ((child.stdout, sys.stdout), (child.stderr, sys.stderr)):
+                pump = threading.Thread(target=_pump_output, args=(tag, source, sink, write_lock), daemon=True)
+                pump.start()
+                pumps.append(pump)
     except BaseException:
         logger.error("spawn failed after starting %d/%d child(ren); killing them", len(children), nproc)
         _signal_children(children, range(len(children)), signal.SIGKILL)

--- a/lib/iris/src/iris/hooks/multigpu_main.py
+++ b/lib/iris/src/iris/hooks/multigpu_main.py
@@ -44,6 +44,7 @@ import subprocess
 import sys
 import threading
 from types import FrameType
+from typing import IO
 
 from rigging.timing import Deadline, Duration
 
@@ -82,7 +83,7 @@ def _child_rank_env(
     }
 
 
-def _pump_output(tag: str, source, sink, write_lock: threading.Lock) -> None:
+def _pump_output(tag: str, source: IO[str], sink: IO[str], write_lock: threading.Lock) -> None:
     """Forward one of a child's streams to the matching supervisor stream, rank-tagged.
 
     stdout and stderr stay separate: iris classifies an unprefixed line by the

--- a/lib/iris/tests/cluster/test_log_highlights.py
+++ b/lib/iris/tests/cluster/test_log_highlights.py
@@ -76,6 +76,18 @@ _TRACEBACK = [
             20,
             ["RuntimeError: shard missing"],
         ),
+        # Rank-tagged lines from the multi-GPU supervisor: the tag hides neither
+        # the traceback frames nor the noise, and survives into the output.
+        (
+            [
+                "[rank1]  45%|####5     | 450/1000 [00:12<00:15,  3.21it/s]",
+                "[rank1] Fatal Python error: Segmentation fault",
+                '[rank1]   File "/app/train.py", line 42 in step',
+                "[rank1] Extension modules: jax",
+            ],
+            20,
+            ["[rank1] Fatal Python error: Segmentation fault", '[rank1]   File "/app/train.py", line 42 in step'],
+        ),
         # No signal line → fall back to the de-noised tail so output is never empty.
         (["step 1", "step 2", "step 3"], 20, ["step 1", "step 2", "step 3"]),
         # Empty input → empty output.

--- a/lib/iris/tests/cluster/test_log_keys.py
+++ b/lib/iris/tests/cluster/test_log_keys.py
@@ -39,6 +39,21 @@ def test_parsed_prefix_overrides_stream_default(source, data, expected):
 
 
 @pytest.mark.parametrize(
+    "source,data,expected",
+    [
+        # The multi-GPU supervisor tags each child line with its rank; the glog
+        # prefix behind the tag still decides the level.
+        ("stdout", "[rank0] E20260102 12:44:05 something blew up", logging_pb2.LOG_LEVEL_ERROR),
+        ("stderr", "[rank12] I20260102 12:34:56 worker starting up", logging_pb2.LOG_LEVEL_INFO),
+        # An untagged-looking bracket is not a rank tag, so the line keeps its default.
+        ("stdout", "[rank] E20260102 12:44:05 something blew up", logging_pb2.LOG_LEVEL_INFO),
+    ],
+)
+def test_rank_tag_does_not_hide_the_level_prefix(source, data, expected):
+    assert classify_log_level(source, data) == expected
+
+
+@pytest.mark.parametrize(
     "data",
     [
         " 45%|####5     | 450/1000 [00:12<00:15,  3.21it/s]",

--- a/lib/iris/tests/test_multigpu.py
+++ b/lib/iris/tests/test_multigpu.py
@@ -111,6 +111,22 @@ def test_external_sigterm_returns_128_plus_signum() -> None:
     assert proc.returncode == 128 + signal.SIGTERM
 
 
+def test_child_streams_stay_separate_and_rank_tagged(capfd: pytest.CaptureFixture[str]) -> None:
+    # Each stream keeps its identity so iris still classifies an unprefixed
+    # stderr line as an error rather than as INFO on stdout.
+    code = "import sys; print('hello out'); print('hello err', file=sys.stderr)"
+    assert run(nproc=2, devices_per_proc=1, child_argv=_py(code)) == 0
+    captured = capfd.readouterr()
+    assert sorted(line for line in captured.out.splitlines() if "hello" in line) == [
+        "[rank0] hello out",
+        "[rank1] hello out",
+    ]
+    assert sorted(line for line in captured.err.splitlines() if "hello" in line) == [
+        "[rank0] hello err",
+        "[rank1] hello err",
+    ]
+
+
 def test_run_rejects_empty_command() -> None:
     with pytest.raises(ValueError, match="no child command"):
         run(nproc=2, devices_per_proc=1, child_argv=[])


### PR DESCRIPTION
The multi-GPU supervisor tags each child line with "[rankN] ". That tag sat
ahead of the glog level prefix, so every line from a rank fell back to its
stream default and no line was ever classified WARNING or ERROR from its own
text. The supervisor also merged each child's stderr into its stdout, so a
rank's traceback arrived on stdout and was ingested as INFO — invisible under
any min_level filter.

Level classification and the failure-highlight patterns now match past the rank
tag and keep it in the returned lines, so the reader still sees which rank
produced each one. The supervisor pumps each child's stdout and stderr to the
matching supervisor stream instead of folding them together; ordering between a
single rank's two streams is no longer guaranteed, which the per-line timestamps
and rank tags already cover.
