### PR TITLE
[datakit] Normalize the Focus Crawl source

### DIFF
--- a/lib/marin/src/marin/datakit/download/common_crawl_focus.py
+++ b/lib/marin/src/marin/datakit/download/common_crawl_focus.py
@@ -1,23 +1,64 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from marin.datakit.normalize import NormalizedData
-from marin.execution.artifact import read_artifact
+"""Normalize the pre-staged Focus Crawl (CC-SUPPLEMENTAL-2026-22) extraction.
+
+``extract_focus_crawl`` pulled the indexed HTML response byte ranges out of all
+4,573 CC-SUPPLEMENTAL-2026-22 WARCs with XenonMolecule/jusText and wrote the text
+and WARC provenance as Parquet. Those shards are the input here, not the finished
+source: they hold duplicate ids and no row order, so the chain sends them through
+``normalize_step`` like every other datakit source.
+
+The extraction is read from ``{MARIN_PREFIX}/<_FOCUS_CRAWL_EXTRACTION>``, so each
+cluster reads it from its own bucket and it must be copied in before a run. The
+canonical copy lives on CoreWeave at
+``s3://marin-us-east-02a/marin/data/datakit/normalized/common_crawl_focus_2026_22_ed4b8bc9``
+(4,573 Parquet shards, 89.4 GB, 36,327,068 documents).
+"""
+
+from rigging.filesystem import StoragePath, prefix_join
+
+from marin.datakit.normalize import normalize_step
 from marin.execution.step_spec import StepSpec
 
-# Extracted indexed HTML response byte ranges from all 4,573 CC-SUPPLEMENTAL-2026-22
-# WARCs with XenonMolecule/jusText@20d27c00ebfbe927f86281933da687d3e636cba3,
-# using its sklearn model and English stoplist. experiments/datakit/focus_crawl.py
-# wrote the resulting text and WARC provenance as normalized Parquet.
-_FOCUS_CRAWL_ARTIFACT = "s3://marin-us-east-02a/marin/data/datakit/normalized/common_crawl_focus_2026_22_ed4b8bc9"
+# Path of the extraction relative to MARIN_PREFIX. The ``normalized/`` segment is a
+# leftover from the one-off run that wrote the tree; the shards below it are raw
+# extractor output.
+_FOCUS_CRAWL_EXTRACTION = "data/datakit/normalized/common_crawl_focus_2026_22_ed4b8bc9"
+_EXTRACTION_SHARDS = "outputs/main"
+
+
+def _validate_focus_crawl_extraction(output_path: str) -> None:
+    shard_glob = prefix_join(output_path, f"{_EXTRACTION_SHARDS}/*.parquet")
+    if next(iter(StoragePath(shard_glob).glob()), None) is None:
+        raise FileNotFoundError(f"No Parquet shards found under {shard_glob}")
 
 
 def common_crawl_focus_normalize_steps() -> tuple[StepSpec, ...]:
-    """Return steps that read the existing Focus Crawl normalized artifact."""
-    return (
-        StepSpec(
-            name="normalized/common-crawl-focus-2026-22",
-            hash_attrs={"artifact": _FOCUS_CRAWL_ARTIFACT},
-            fn=lambda _output_path: read_artifact(_FOCUS_CRAWL_ARTIFACT, NormalizedData),
-        ),
+    """Return the ``(extraction, normalize)`` chain for the Focus Crawl source."""
+    extraction = StepSpec(
+        name="raw/common-crawl-focus-2026-22",
+        override_output_path=_FOCUS_CRAWL_EXTRACTION,
+        fn=_validate_focus_crawl_extraction,
+        hash_attrs={
+            "crawl": "CC-SUPPLEMENTAL-2026-22",
+            "justext_repository": "https://github.com/XenonMolecule/jusText",
+            "justext_commit": "1652a1497b36c4b9941c609ffa1714eeefedc70b",
+            "justext_model": "sklearn",
+            "justext_stoplist": "English",
+            "format": "parquet",
+            "warc_files": 4573,
+            "shards": 4573,
+            "documents": 36_327_068,
+        },
     )
+    normalized = normalize_step(
+        name="normalized/common-crawl-focus-2026-22",
+        download=extraction,
+        relative_input_path=_EXTRACTION_SHARDS,
+        # The extractor already keys rows by xxh3_128 of the text, so normalize
+        # regenerates the same id and keeps the WARC record UUID as source_id.
+        id_field="source_id",
+        file_extensions=(".parquet",),
+    )
+    return extraction, normalized

--- a/lib/marin/src/marin/datakit/download/common_crawl_focus.py
+++ b/lib/marin/src/marin/datakit/download/common_crawl_focus.py
@@ -26,12 +26,16 @@ from marin.execution.step_spec import StepSpec
 # extractor output.
 _FOCUS_CRAWL_EXTRACTION = "data/datakit/normalized/common_crawl_focus_2026_22_ed4b8bc9"
 _EXTRACTION_SHARDS = "outputs/main"
+# One shard per WARC. An interrupted copy leaves fewer, and normalizing that
+# publishes a valid-looking source built from part of the crawl.
+_EXTRACTION_SHARD_COUNT = 4573
 
 
 def _validate_focus_crawl_extraction(output_path: str) -> None:
     shard_glob = prefix_join(output_path, f"{_EXTRACTION_SHARDS}/*.parquet")
-    if next(iter(StoragePath(shard_glob).glob()), None) is None:
-        raise FileNotFoundError(f"No Parquet shards found under {shard_glob}")
+    found = sum(1 for _ in StoragePath(shard_glob).glob())
+    if found != _EXTRACTION_SHARD_COUNT:
+        raise FileNotFoundError(f"Expected {_EXTRACTION_SHARD_COUNT} Parquet shards under {shard_glob}, found {found}")
 
 
 def common_crawl_focus_normalize_steps() -> tuple[StepSpec, ...]:
@@ -47,8 +51,7 @@ def common_crawl_focus_normalize_steps() -> tuple[StepSpec, ...]:
             "justext_model": "sklearn",
             "justext_stoplist": "English",
             "format": "parquet",
-            "warc_files": 4573,
-            "shards": 4573,
+            "shards": _EXTRACTION_SHARD_COUNT,
             "documents": 36_327_068,
         },
     )

--- a/lib/marin/src/marin/datakit/download/common_crawl_focus.py
+++ b/lib/marin/src/marin/datakit/download/common_crawl_focus.py
@@ -3,11 +3,11 @@
 
 """Normalize the pre-staged Focus Crawl (CC-SUPPLEMENTAL-2026-22) extraction.
 
-``extract_focus_crawl`` pulled the indexed HTML response byte ranges out of all
-4,573 CC-SUPPLEMENTAL-2026-22 WARCs with XenonMolecule/jusText and wrote the text
-and WARC provenance as Parquet. Those shards are the input here, not the finished
-source: they hold duplicate ids and no row order, so the chain sends them through
-``normalize_step`` like every other datakit source.
+A one-off run outside this repository pulled the indexed HTML response byte ranges
+out of all 4,573 CC-SUPPLEMENTAL-2026-22 WARCs with XenonMolecule/jusText and wrote
+the text and WARC provenance as Parquet. Those shards are the input here, not the
+finished source: they hold duplicate ids and no row order, so the chain sends them
+through ``normalize_step`` like every other datakit source.
 
 The extraction is read from ``{MARIN_PREFIX}/<_FOCUS_CRAWL_EXTRACTION>``, so each
 cluster reads it from its own bucket and it must be copied in before a run. The

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -58,6 +58,14 @@ COMPACTED_WHITESPACE_COUNTER = "datakit_normalize_compacted_whitespace"
 DEFAULT_MAX_WORKERS = 1024
 NORMALIZED_DATA_VERSION = "v2"
 
+# The hash attributes every normalize step declares. They fix the identity of a
+# normalized artifact, so the set is effectively frozen — dropping or renaming one
+# re-keys every existing output. A step that does not declare them was not built
+# here and carries none of normalize's guarantees.
+NORMALIZE_IDENTITY_ATTRS = frozenset(
+    {"text_field", "id_field", "target_partition_bytes", "max_whitespace_run_chars", "dedup_mode"}
+)
+
 
 class DedupMode(StrEnum):
     """How aggressively to deduplicate records during normalization.
@@ -571,6 +579,7 @@ def normalize_step(
         hash_attrs["drop_fields"] = drop_fields
     if output_schema is not None:
         hash_attrs["output_schema"] = str(output_schema)
+    assert NORMALIZE_IDENTITY_ATTRS <= hash_attrs.keys()
     return StepSpec(
         name=name,
         fn=lambda output_path: normalize_to_parquet(

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -166,6 +166,9 @@ def all_sources() -> dict[str, DatakitSource]:
         # Canonical token-count-viewer estimate for the pinned b78a5c1 revision
         # (10,005 files / 4.49 TB); not yet measured with the Marin tokenizer.
         ("common_corpus/english", common_corpus_normalize_steps, 1015.39),
+        # Counted over the jusText extraction, before normalize dedups it. A
+        # 24-shard sample carried 12.2% duplicate rows, so the normalized total
+        # lands lower; replace this once that cache is tokenized.
         ("common-crawl-focus-2026-22", common_crawl_focus_normalize_steps, 49.702569456),
         ("davinci-dev/ctx-native", davinci_dev_ctx_native_normalize_steps, 57.57),
         ("davinci-dev/env-native", davinci_dev_env_native_normalize_steps, 2.58),

--- a/tests/datakit/test_sources.py
+++ b/tests/datakit/test_sources.py
@@ -3,17 +3,12 @@
 
 """Invariants that hold across the whole datakit source catalog."""
 
+from marin.datakit.normalize import NORMALIZE_IDENTITY_ATTRS
 from marin.datakit.sources import all_sources
-
-# The hash attributes ``normalize_step`` always declares. A terminal step without
-# them was not built by normalize, so its output carries none of normalize's
-# guarantees: unsorted shards and duplicate ids reach every consumer (#8110).
-NORMALIZE_IDENTITY_ATTRS = frozenset(
-    {"text_field", "id_field", "target_partition_bytes", "max_whitespace_run_chars", "dedup_mode"}
-)
 
 
 def test_every_source_normalizes_its_output():
+    """A source whose terminal step skips normalize ships unsorted, duplicated ids (#8110)."""
     unnormalized = [
         name
         for name, source in all_sources().items()

--- a/tests/datakit/test_sources.py
+++ b/tests/datakit/test_sources.py
@@ -1,0 +1,22 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Invariants that hold across the whole datakit source catalog."""
+
+from marin.datakit.sources import all_sources
+
+# The hash attributes ``normalize_step`` always declares. A terminal step without
+# them was not built by normalize, so its output carries none of normalize's
+# guarantees: unsorted shards and duplicate ids reach every consumer (#8110).
+NORMALIZE_IDENTITY_ATTRS = frozenset(
+    {"text_field", "id_field", "target_partition_bytes", "max_whitespace_run_chars", "dedup_mode"}
+)
+
+
+def test_every_source_normalizes_its_output():
+    unnormalized = [
+        name
+        for name, source in all_sources().items()
+        if not NORMALIZE_IDENTITY_ATTRS <= source.normalized.hash_attrs.keys() or not source.normalized.deps
+    ]
+    assert unnormalized == []


### PR DESCRIPTION
Build common-crawl-focus-2026-22 with normalize_step. Before this change, the
registry read the jusText extraction tree as the finished source. Thus the
source kept the row order and the duplicate ids of the extractor. A sample of 24
random shards showed 24 unsorted shards and 12.2% duplicate rows. Fuzzy
verification does a merge-join of normalized text to candidate attributes on
ascending id. As a result, an unsorted shard makes the join report a present id
as absent, and the run stops.

The extraction is now a pre-staged input. Its path is relative to MARIN_PREFIX,
and its identity comes from the run config that the tree records, not from the
path. That jusText commit is different from the value in the previous comment.
It is the commit that the run itself recorded. No data moves: the tree keeps its
SUCCESS marker, so the input step reads from cache on CoreWeave. On a cluster
without the tree, the step fails immediately instead of a 89 GB read across
clouds.

Normalize writes to a new path. Thus the store, the MinHash attributes, and the
fuzzy candidates from the old tree stay valid until a rebuild. The registered
count of 49.70 B tokens comes from the data before dedup, and it will decrease.

Fixes #8110
