### PR TITLE
[grug] extract the EP LatentMoE hero

### DIFF
--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -1,43 +1,43 @@
 # Grug MoE EP Hero
 
-This self-contained variant is the one-rack EP64 baseline for GB200 NVL72.
+This self-contained variant is the selected EP64 configuration for GB200 NVL72. Each
+data-parallel rack uses one 64-device expert mesh.
 
 ## Configuration
 
-- Model: d6144, 48 layers, 128 routed experts, top-4 routing, and two shared experts of width 3072.
-  This is 359.6 B total parameters and 20.9 B active per token.
+- Model: d6144, 48 layers, 192 routed experts of width 6272, top-4 routing, latent width 3072, and
+  two shared experts of width 3072. This is 546.292 B total parameters and 24.680 B active per token.
 - Attention: 48 heads, 12 local and 6 global KV heads, head dimension 128, sequence length 4096,
   sliding window 512, and every sixth layer full-causal. SConv and fused RoPE are on.
-- Mesh: 64-way expert parallelism across 16 workers with four GB200 GPUs each. Two whole experts
-  land on each device.
-- Batch: 1024 sequences.
+- Mesh: 64-way expert parallelism across 16 workers with four GB200 GPUs each. Additional racks use
+  the `replica_dcn` axis. Three whole experts land on each device in each rack.
+- Batch: 1024 global sequences. The launcher does not scale the batch with the rack count.
 - Router: top-4 quantile balancing with next-step, stop-gradient expert biases and no auxiliary
   balancing loss.
-- MoE backend: `fixed_all_to_all` with gather dispatch, structured custom VJPs, and capacity
-  factor 1.0.
+- MoE backend: `fixed_all_to_all` by default, with `ragged_all_to_all` as the `ep-ragged` flavor.
+  The default backend uses gather dispatch, structured custom VJPs, and capacity factor 1.33.
 - Optimizer: MuonH, with its state offloaded to pinned host memory.
-- Runtime: GPU command buffers off, `cuda_async`, PGLE off, and collective overlap limit 4.
-- Output: Metrics only. This throughput run does not write a checkpoint.
+- Runtime: GPU command buffers off, `cuda_async`, PGLE on, and collective overlap limit 4.
+- Output: Metrics only by default. `--save-checkpoints` writes checkpoints, but restore with the
+  pinned-host optimizer state has a known memory-kind mismatch. Do not use these checkpoints to
+  restart a run.
 
 The attention, shared-expert, language-model-head, and optimizer states use the combined `data` and
 `expert` axes. The expert axis stays sharded during Newton-Schulz.
 
 ## Result
 
-A 200-step gate on one rack measures 26.2835% median MFU, 309,091 tokens/s, 7.2280% MoE drops, and
-3.2971 final loss over 201 samples with a 2.3460 deviation. A 25-step gate at the same shape
-measures 26 samples with a 6.5623 deviation, thus its 27.5501% median runs about 1.3 points high.
-Use the 200-step number.
+The capacity factor 1.33 default has only a five-step, full-watch gate. All 76 norm fields were
+finite on each step. Capacity factor 1.34 failed from a CUDA OOM. The highest confirmed routing
+cell capacity is 1,829. Capacity factor 1.33 keeps a small margin below that limit.
 
-The same model under FSDP-64 on one rack measures 19.3951% median MFU and 235,125 tokens/s. Both
-arms share one analytic FLOP count of 44.491 GFLOP per token, because that count depends only on the
-model config, so their MFU values share a denominator. They do not do equal work at capacity 1.0:
-EP discards 9.97% of assignments against 1.88%. At capacity factor 1.5 the EP drop rate falls to
-1.5719%, below the FSDP rate, and EP still measures 22.9037%.
+The matched 200-step result used capacity factor 1.30 and automatic PGLE. Its last-50 mean was
+262,683 tokens/s with 3.9642% drops. Its drop-adjusted rate was 252,271 tokens/s, and its mean loss
+was 3.2417.
 
 ## Sweeps
 
-Four launcher options move the shape from the hero spec. They keep the hidden dimension, so the
+Five launcher options move the shape from the hero spec. They keep the hidden dimension, so the
 compute-scaled optimizer values stay constant across a sweep.
 
 | option | effect |
@@ -45,6 +45,7 @@ compute-scaled optimizer values stay constant across a sweep.
 | `--num-experts` | routed expert count. Must divide the 64-way expert axis. |
 | `--intermediate-dim` | routed expert width |
 | `--num-experts-per-token` | routed top-k |
+| `--latent-dim` | routed input and output width |
 | `--capacity-factor` | fixed all-to-all capacity factor |
 
 Three quantities move independently, which sets what a sweep can afford on one rack:
@@ -57,11 +58,23 @@ Width appears in the first two and not the third, thus width is the cheap way to
 and top-k is the expensive way. Six buffers scale with top-k, and one of them is float32: top-6
 costs 30.75 GiB against 20.50 GiB for top-4 at this shape.
 
-Measured limits on one rack: 591.6 B total parameters runs at 24.0032% median MFU (256 experts of
-width 2560), and 641.4 B fails with `NCCL operation ncclAlltoAll` and a CUDA out-of-memory. Lower
-top-k does not lift that limit, so parameters bind rather than the communicator. A capacity sweep at
-the hero shape measures 27.5501% MFU at 9.97% drops, 26.1065% at 5.3984%, 25.2283% at 3.2571%, and
-22.9037% at 1.5719%, or about 0.9 points of MFU for each point of drops recovered.
+The selected E192 model fits at expert width 6272 and capacity factor 1.33. Width 6400 fails at
+capacity factor 1.30. The [experiment record](../../../.agents/logbooks/7279-moe-hero-ep.md)
+contains the size and capacity searches.
+
+## Run Controls
+
+| option | effect |
+| --- | --- |
+| `--dp-racks` | sets the data-parallel rack count; `--batch-size` stays global |
+| `--batch-size` | sets global sequences per step and the optimizer token budget |
+| `--schedule-steps` | sizes the learning-rate schedule while `--num-steps` bounds the run |
+| `--flavor` | selects `ep` or `ep-ragged` |
+| `--eval-every` | adds Paloma evaluation at the selected interval |
+| `--save-checkpoints` | writes checkpoints with the restore limitation above |
+| `--watch-interval`, `--watch-mode` | select inline or diagnostic norm collection |
+| `--profile-start-step`, `--profile-steps` | select the rank-0 XProf window |
+| `--seed` | sets the trainer seed |
 
 ## Launch
 
@@ -70,11 +83,13 @@ Print the plan without a GPU run:
 ```bash
 python -m experiments.grug.moe_hero_ep.launch \
   --run-id mhep-017-200 \
+  --dp-racks 1 \
   --num-steps 200 \
   --version 2026.08.05
 
 python -m experiments.grug.moe_hero_ep.launch \
   --run-id mhep-011-e256-i2560 \
+  --dp-racks 1 \
   --num-steps 25 \
   --num-experts 256 --intermediate-dim 2560 \
   --version 2026.08.05
@@ -91,7 +106,7 @@ uv run iris --config lib/iris/config/marin.yaml job run --no-wait --enable-extra
   -e WANDB_API_KEY "$WANDB_API_KEY" -e WANDB_PROJECT "$WANDB_PROJECT" \
   -e IRIS_PORT_JAX 32575 \
   -- python -m experiments.grug.moe_hero_ep.launch \
-    --run-id "$run_id" --num-steps 200 --version 2026.08.05 --run
+    --run-id "$run_id" --dp-racks 1 --num-steps 200 --version 2026.08.05 --run
 ```
 
 W&B uses the `WANDB_PROJECT` environment variable, or project `marin_moe` when it is unset, with

--- a/experiments/grug/moe_hero_ep/heuristic.py
+++ b/experiments/grug/moe_hero_ep/heuristic.py
@@ -8,9 +8,10 @@ Adam learning rates, epsilon, and beta2 from the token budget and batch size. ``
 pairs it with the fixed hero model spec so a launcher gets both configs back from a single
 ``(num_train_steps, batch_size)`` call, keeping the hero self-contained.
 
-The hero model is d6144 with 48 layers, 128 routed experts at top-4, and two shared experts:
-359.6 B total parameters and 20.9 B active per token. The launcher sweeps expert count, expert
-width, routed top-k, and capacity factor from this spec.
+The hero model is d6144 with 48 layers, 192 routed latent experts of width 6,272 at top-4, and two
+shared experts. The routed experts use a latent width of 3,072 and capacity factor 1.33. This gives
+546.292 B total parameters and 24.680 B active per token. The launcher can override the expert
+count, expert width, routed top-k, latent width, and capacity factor from this spec.
 """
 
 import math
@@ -80,10 +81,10 @@ class MoeHeuristic:
 HERO_MODEL = GrugModelConfig(
     vocab_size=128_256,
     hidden_dim=6144,
-    intermediate_dim=3072,
+    intermediate_dim=6272,
     shared_expert_intermediate_dim=6144 // 2,
     num_shared_experts=2,
-    num_experts=128,
+    num_experts=192,
     num_experts_per_token=4,
     num_layers=48,
     num_heads=48,
@@ -94,7 +95,7 @@ HERO_MODEL = GrugModelConfig(
     max_seq_len=4096,
     sliding_window=512,
     global_every=6,
-    capacity_factor=1.0,
+    capacity_factor=1.33,
     initializer_std=0.5 / math.sqrt(6144),
     qk_mult=1.3,
     sconv=True,
@@ -103,6 +104,7 @@ HERO_MODEL = GrugModelConfig(
     expert_chunks=1,
     report_capacity_overflow=True,
     rope_fused=True,
+    latent_dim=3072,
 )
 
 

--- a/experiments/grug/moe_hero_ep/launch.py
+++ b/experiments/grug/moe_hero_ep/launch.py
@@ -1,16 +1,18 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""One-rack GB200 launcher for the EP64 MoE hero configuration."""
+"""GB200 launcher for the EP64 MoE hero configuration."""
 
 import dataclasses
 import os
+from datetime import timedelta
 
 import click
 import jmp
 from fray.cluster import ResourceConfig
-from levanter.callbacks.profiler import ProfilerConfig
+from levanter.callbacks.profiler import ProfileOptionsConfig, ProfilerConfig
 from levanter.callbacks.watch import WatchConfig
+from levanter.checkpoint import CheckpointerConfig
 from levanter.data.text.datasets import BlockShuffleConfig
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
@@ -21,9 +23,11 @@ from marin.experiment.cli import build_options
 from marin.experiment.data import mixture, tokenized
 from marin.experiment.namespacing import user_namespaced_name
 from marin.processing.tokenize.tokenize import TokenizedCache
+from rigging.filesystem import prefix_join
 
+from experiments.datasets.paloma import paloma_datasets
 from experiments.grug.moe_hero_ep.heuristic import build_hero_configs
-from experiments.grug.moe_hero_ep.train import GrugRunConfig, GrugTrainerConfig, run_grug
+from experiments.grug.moe_hero_ep.train import GrugEvalConfig, GrugRunConfig, GrugTrainerConfig, WatchMode, run_grug
 from experiments.llama import llama3_tokenizer
 
 DEFAULT_HERO_STEPS = 25
@@ -37,9 +41,34 @@ HERO_MIXED_PRECISION = "params=float32,compute=bfloat16,output=bfloat16"
 # The hero shape keeps its MuonH state on pinned host memory: 24.59 GiB of parameters and 27.78 GiB
 # of optimizer state per device leave too little room for the fixed all-to-all buffers otherwise.
 HERO_OFFLOAD_OPT_STATE = True
+HERO_WATCH_INTERVAL = 0
+HERO_CHECKPOINT_INTERVAL = timedelta(minutes=15)
 
 _SLIMPAJAMA_TOKENIZE_RESOURCES = ResourceConfig(ram="64g", disk="64g")
 _SLIMPAJAMA_SHUFFLE = BlockShuffleConfig(io_block_size=256, window_blocks=256, perm_type="feistel")
+
+
+FLAVORS: dict[str, str] = {
+    "ep": "fixed_all_to_all",
+    # The upstream transport. Its capacity factor scales one pooled receiver buffer per device
+    # rather than a per-(sender, expert) cell, so at the same factor it buys the same bytes and
+    # drops far less -- every expert on a device draws from one pool. `fixed_all_to_all` exists
+    # because this path measured slow, which is what a same-shape run is for.
+    "ep-ragged": "ragged_all_to_all",
+}
+
+
+# Held-out sets, added at weight 0 so they surface as tagged eval sets. The hero trains on
+# llama3-tokenized SlimPajama, so these must carry the same tokenizer.
+#
+# Paloma only, deliberately. `paloma_dataset` and `uncheatable_dataset` both hardcode a `-llama3`
+# suffix in the cache name while taking an arbitrary `tokenizer` argument, so callers asking for
+# different tokenizers collide on one cache identity and whoever materializes first wins. The
+# uncheatable caches under that name currently hold marin-tokenizer data, which fails the mixture's
+# single-tokenizer check. Paloma is also the suite the scaling-law scoring uses, so dropping
+# uncheatable costs nothing here.
+def _validation_datasets() -> list[ArtifactStep[TokenizedCache]]:
+    return list(paloma_datasets(tokenizer=llama3_tokenizer).values())
 
 
 def _slimpajama_6b_dataset() -> ArtifactStep[TokenizedCache]:
@@ -53,36 +82,78 @@ def _slimpajama_6b_dataset() -> ArtifactStep[TokenizedCache]:
 
 
 class HeroThroughputResult(Artifact):
-    """Metrics-only result of the rack-scale throughput hero run.
+    """Result of the rack-scale throughput hero run.
 
-    The run intentionally writes no checkpoint; it only mirrors its tracker metrics to the output
-    path. This artifact is a plain path ref to those metrics, so the step does not promise a
-    checkpoint it never produces.
+    The run mirrors its tracker metrics to the output path. It writes no checkpoint by default.
+    Checkpoint restore has a known memory-kind mismatch with the offloaded optimizer state.
     """
 
 
 def build_hero_run(
     *,
     run_id: str,
+    dp_racks: int,
     num_steps: int,
+    schedule_steps: int | None = None,
+    seed: int = 0,
+    batch_size: int = HERO_EP_BATCH_SIZE,
     num_experts: int | None = None,
     num_experts_per_token: int | None = None,
     intermediate_dim: int | None = None,
     capacity_factor: float | None = None,
+    latent_dim: int | None = None,
+    flavor: str = "ep",
+    eval_every: int = 0,
+    save_checkpoints: bool = False,
+    checkpoint_interval: timedelta = HERO_CHECKPOINT_INTERVAL,
+    watch_interval: int = HERO_WATCH_INTERVAL,
+    watch_mode: WatchMode = WatchMode.INLINE,
+    profile_steps: int = 0,
+    profile_start_step: int = 5,
     version: str | None = None,
 ) -> ArtifactStep[HeroThroughputResult]:
-    """Build the one-rack EP64 hero throughput run.
+    """Build the EP64 hero throughput run.
 
     The overrides sweep expert count, expert width, routed top-k, and routing capacity from the
     hero spec. They keep the hidden dimension, so the compute-scaled optimizer values stay
     comparable across a sweep. ``None`` keeps the hero value.
+
+    ``batch_size`` is the global batch across all data-parallel racks. It does not scale with
+    ``dp_racks``. ``batch_size`` and ``schedule_steps`` change the token budget for the heuristic.
     """
     if not run_id.strip():
         raise ValueError("run_id must not be empty")
+    if dp_racks <= 0:
+        raise ValueError(f"dp_racks must be positive, got {dp_racks}")
     if num_steps <= 0:
         raise ValueError(f"num_steps must be positive, got {num_steps}")
-
-    model, optimizer = build_hero_configs(num_train_steps=num_steps, batch_size=HERO_EP_BATCH_SIZE)
+    if checkpoint_interval <= timedelta(0):
+        raise ValueError(f"checkpoint_interval must be positive, got {checkpoint_interval}")
+    if profile_steps < 0:
+        raise ValueError(f"profile_steps must be non-negative, got {profile_steps}")
+    if profile_start_step < 0:
+        raise ValueError(f"profile_start_step must be non-negative, got {profile_start_step}")
+    if profile_steps > 0 and profile_start_step >= num_steps:
+        raise ValueError(f"profile_start_step must be less than num_steps={num_steps}, got {profile_start_step}")
+    if flavor not in FLAVORS:
+        raise ValueError(f"flavor must be one of {sorted(FLAVORS)}, got {flavor!r}")
+    moe_implementation = FLAVORS[flavor]
+    # `schedule_steps` sets the whole learning-rate schedule; `num_steps` sets how far the run goes.
+    # Both matter, and they enter in different places. The optimizer heuristic scales learning rate,
+    # adam_lr, and epsilon from a token budget (`num_train_steps * batch * seq`), which fixes the
+    # peak. Warmup and decay are *fractions* of `TrainerConfig.num_train_steps`, so that field has to
+    # carry the schedule length too -- passing `num_steps` there warms up in `0.01 * num_steps` and
+    # decays to `min_lr_ratio` by the end of the short run, which is a whole miniature schedule
+    # rather than the head of a long one. Default keeps the two equal, which is the previous behavior.
+    if schedule_steps is not None and schedule_steps <= 0:
+        raise ValueError(f"schedule_steps must be positive, got {schedule_steps}")
+    if schedule_steps is not None and schedule_steps < num_steps:
+        raise ValueError(f"schedule_steps={schedule_steps} must be at least num_steps={num_steps}")
+    total_schedule_steps = schedule_steps if schedule_steps is not None else num_steps
+    model, optimizer = build_hero_configs(
+        num_train_steps=total_schedule_steps,
+        batch_size=batch_size,
+    )
     overrides = {
         name: value
         for name, value in (
@@ -90,18 +161,22 @@ def build_hero_run(
             ("num_experts_per_token", num_experts_per_token),
             ("intermediate_dim", intermediate_dim),
             ("capacity_factor", capacity_factor),
+            ("latent_dim", latent_dim),
         )
         if value is not None
     }
     if overrides:
         model = dataclasses.replace(model, **overrides)
+    model = dataclasses.replace(
+        model,
+        moe_implementation=moe_implementation,
+        expert_chunks=1,
+    )
     # A bank that does not divide the expert axis fails inside `moe_mlp`, which is after the rack is
     # already allocated and the workspace is built. Reject it here instead.
     if model.num_experts % HERO_EP_EXPERT_AXIS_SIZE != 0:
         raise ValueError(f"num_experts={model.num_experts} must divide the expert axis {HERO_EP_EXPERT_AXIS_SIZE}")
-    if model.moe_implementation is None:
-        raise ValueError("the EP hero requires an explicit MoE implementation")
-    backend_tag = model.moe_implementation.replace("_", "-")
+    backend_tag = moe_implementation.replace("_", "-")
     capacity_tag = f"capacity-{model.capacity_factor:g}"
     size_tag = f"e{model.num_experts}-i{model.intermediate_dim}"
     wandb_project = os.environ.get("WANDB_PROJECT") or DEFAULT_WANDB_PROJECT
@@ -111,8 +186,11 @@ def build_hero_run(
         ema_beta=None,
         z_loss_weight=1e-4,
         offload_opt_state=HERO_OFFLOAD_OPT_STATE,
+        watch_mode=watch_mode,
+        # The default offloaded optimizer state has a known memory-kind mismatch during restore.
+        save_checkpoints=save_checkpoints,
         expert_axis_size=HERO_EP_EXPERT_AXIS_SIZE,
-        replica_axis_size=1,
+        replica_axis_size=dp_racks,
         sharding_dump_path=None,
     )
     train_resources = ResourceConfig.with_gpu(
@@ -121,19 +199,28 @@ def build_hero_run(
         cpu=120,
         ram="850g",
         disk="1t",
-        replicas=HERO_EP_NODES,
+        replicas=HERO_EP_NODES * dp_racks,
     )
     name = f"grug/{run_id}"
     version = resolve_version(name, version)
     slim = _slimpajama_6b_dataset()
+    validation = _validation_datasets() if eval_every > 0 else []
 
     def build_config(ctx: StepContext) -> GrugRunConfig:
         trainer = TrainerConfig(
             id=run_id,
-            seed=0,
-            train_batch_size=HERO_EP_BATCH_SIZE,
-            num_train_steps=num_steps,
-            profiler=ProfilerConfig(enabled=False),
+            seed=seed,
+            train_batch_size=batch_size,
+            num_train_steps=total_schedule_steps,
+            profiler=ProfilerConfig(
+                enabled=profile_steps > 0,
+                start_step=profile_start_step,
+                num_steps=profile_steps,
+                # One rank is enough for a step trace, and tracing all 64 multiplies the upload
+                # without adding signal.
+                process_index=0,
+                profile_options=ProfileOptionsConfig(enable_hlo_proto=True),
+            ),
             mp=jmp.get_policy(HERO_MIXED_PRECISION),
             tracker=WandbConfig(
                 entity="marin-community",
@@ -144,6 +231,7 @@ def build_hero_run(
                     "hero",
                     "ep",
                     backend_tag,
+                    f"flavor-{flavor}",
                     capacity_tag,
                     size_tag,
                     "gb200",
@@ -153,18 +241,35 @@ def build_hero_run(
                 name=run_id,
                 replicate_path=ctx.output_path,
             ),
-            watch=WatchConfig(interval=0),
+            watch=WatchConfig(interval=watch_interval),
             use_explicit_mesh_axes=True,
             require_accelerator=True,
             allow_nondivisible_batch_size=False,
+            # Write under the step's output path. Levanter's default base path is pod-local, so a
+            # preempted run would find nothing to resume from and --save-checkpoints would buy
+            # nothing.
+            checkpointer=CheckpointerConfig(
+                base_path=prefix_join(ctx.output_path, "checkpoints"),
+                temporary_base_path=None,
+                save_interval=checkpoint_interval,
+                keep=None,
+                append_run_id_to_base_path=False,
+                delete_old_temp_checkpoints=True,
+                keep_last_temporary_checkpoints=1,
+            ),
         )
         return GrugRunConfig(
             model=model,
-            data=mixture(ctx, {slim: 1.0}, shuffle=_SLIMPAJAMA_SHUFFLE),
+            data=mixture(ctx, {slim: 1.0}, validation=validation, shuffle=_SLIMPAJAMA_SHUFFLE),
             resources=ctx.runtime_arg("train_resources"),
             optimizer=optimizer,
             trainer=dataclasses.replace(grug_trainer, trainer=trainer),
-            eval=None,
+            # Off by default so a throughput run stays a throughput run. Turn it on to make a
+            # run scoreable: comparing configs needs held-out loss, not train loss.
+            eval=(
+                GrugEvalConfig(steps_per_eval=eval_every, eval_ema=False, compute_bpb=True) if eval_every > 0 else None
+            ),
+            stop_after_steps=num_steps,
             processes_per_task=HERO_PROCESSES_PER_TASK,
         )
 
@@ -174,7 +279,7 @@ def build_hero_run(
         artifact_type=HeroThroughputResult,
         run=run_grug,
         build_config=build_config,
-        deps=(slim,),
+        deps=(slim, *validation),
         runtime_args={"train_resources": train_resources},
     )
 
@@ -182,11 +287,33 @@ def build_hero_run(
 @click.command()
 @click.option("--run-id", required=True, help="Run identifier for artifact and W&B names.")
 @click.option(
+    "--dp-racks",
+    type=click.IntRange(min=1),
+    required=True,
+    help="Data-parallel NVL72 rack count. --batch-size stays global across all racks.",
+)
+@click.option(
     "--num-steps",
     type=click.IntRange(min=1),
     default=DEFAULT_HERO_STEPS,
     show_default=True,
     help="Number of training steps.",
+)
+@click.option(
+    "--schedule-steps",
+    type=click.IntRange(min=1),
+    default=None,
+    help=(
+        "Build the learning-rate schedule for this many steps instead of --num-steps. The optimizer "
+        "heuristic scales its rates from the implied token budget, so this trains the head of a long "
+        "run's schedule. Defaults to --num-steps."
+    ),
+)
+@click.option(
+    "--seed",
+    type=int,
+    default=0,
+    help="Trainer seed. Vary it across otherwise identical runs to measure run-to-run variance.",
 )
 @click.option(
     "--num-experts",
@@ -207,6 +334,74 @@ def build_hero_run(
     help="Override the routed expert width.",
 )
 @click.option(
+    "--batch-size",
+    type=click.IntRange(min=1),
+    default=HERO_EP_BATCH_SIZE,
+    show_default=True,
+    help="Global sequences per step. This value does not scale with --dp-racks.",
+)
+@click.option(
+    "--latent-dim",
+    type=click.IntRange(min=1),
+    default=None,
+    help="LatentMoE: run routed experts at this width. Divides all-to-all traffic by hidden/latent.",
+)
+@click.option(
+    "--flavor",
+    type=click.Choice(sorted(FLAVORS)),
+    default="ep",
+    show_default=True,
+    help="Expert-parallel MoE implementation.",
+)
+@click.option(
+    "--save-checkpoints/--no-save-checkpoints",
+    default=False,
+    show_default=True,
+    help="Write checkpoints. Restore is not supported for the pinned-host optimizer state.",
+)
+@click.option(
+    "--checkpoint-minutes",
+    type=click.FloatRange(min=0, min_open=True),
+    default=HERO_CHECKPOINT_INTERVAL.total_seconds() / 60,
+    show_default=True,
+    help="Wall-clock minutes between checkpoint writes.",
+)
+@click.option(
+    "--eval-every",
+    type=click.IntRange(min=0),
+    default=0,
+    show_default=True,
+    help="Run the paloma suite every N steps. 0 disables eval (throughput-only run).",
+)
+@click.option(
+    "--watch-interval",
+    type=click.IntRange(min=0),
+    default=HERO_WATCH_INTERVAL,
+    show_default=True,
+    help="Steps between gradient and parameter norm logs. 0 disables norm logging.",
+)
+@click.option(
+    "--watch-mode",
+    type=click.Choice([mode.value for mode in WatchMode]),
+    default=WatchMode.INLINE.value,
+    show_default=True,
+    help="Compute norms in the training step or in a separate forward and backward diagnostic step.",
+)
+@click.option(
+    "--profile-steps",
+    type=click.IntRange(min=0),
+    default=0,
+    show_default=True,
+    help="Steps to trace with XProf on rank 0. 0 disables the profiler.",
+)
+@click.option(
+    "--profile-start-step",
+    type=click.IntRange(min=0),
+    default=5,
+    show_default=True,
+    help="First traced step. Keep it past compile and warmup.",
+)
+@click.option(
     "--capacity-factor",
     type=click.FloatRange(min=0, min_open=True),
     default=None,
@@ -215,19 +410,45 @@ def build_hero_run(
 @build_options
 def main(
     run_id: str,
+    dp_racks: int,
     num_steps: int,
+    schedule_steps: int | None,
+    seed: int,
+    batch_size: int,
     num_experts: int | None,
     num_experts_per_token: int | None,
     intermediate_dim: int | None,
     capacity_factor: float | None,
+    latent_dim: int | None,
+    flavor: str,
+    save_checkpoints: bool,
+    checkpoint_minutes: float,
+    eval_every: int,
+    watch_interval: int,
+    watch_mode: str,
+    profile_steps: int,
+    profile_start_step: int,
 ) -> ArtifactStep[HeroThroughputResult]:
     return build_hero_run(
         run_id=run_id,
+        dp_racks=dp_racks,
         num_steps=num_steps,
+        schedule_steps=schedule_steps,
+        seed=seed,
+        batch_size=batch_size,
         num_experts=num_experts,
         num_experts_per_token=num_experts_per_token,
         intermediate_dim=intermediate_dim,
         capacity_factor=capacity_factor,
+        latent_dim=latent_dim,
+        flavor=flavor,
+        save_checkpoints=save_checkpoints,
+        checkpoint_interval=timedelta(minutes=checkpoint_minutes),
+        eval_every=eval_every,
+        watch_interval=watch_interval,
+        watch_mode=WatchMode(watch_mode),
+        profile_steps=profile_steps,
+        profile_start_step=profile_start_step,
     )
 
 

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -67,7 +67,7 @@ _LM_HEAD_PARTITION_SPEC = P(_FSDP_AXES, "model")
 GRUG_MOE_MODEL_TYPE = "grug_moe"
 GRUG_MOE_ARCHITECTURE = "GrugMoeForCausalLM"
 GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY = "grugmoe_artifact_schema_version"
-GRUG_MOE_ARTIFACT_SCHEMA_VERSION = 1
+GRUG_MOE_ARTIFACT_SCHEMA_VERSION = 2
 
 
 _BATCH_AXES: tuple[str, ...] = ("replica_dcn", "data", "expert")
@@ -259,6 +259,7 @@ class GrugModelConfig:
     @classmethod
     def from_hf_config(cls, hf_config: HfConfig) -> "GrugModelConfig":
         rope = RotaryConfig(theta=float(_hf_config_attr(hf_config, ("rope_theta",), 10000.0)))
+        latent_dim = _hf_config_attr(hf_config, ("latent_dim",))
         return cls(
             vocab_size=int(_hf_config_attr(hf_config, ("vocab_size",))),
             hidden_dim=int(_hf_config_attr(hf_config, ("hidden_dim", "hidden_size"), 2048)),
@@ -275,6 +276,7 @@ class GrugModelConfig:
             num_shared_experts=int(_hf_config_attr(hf_config, ("num_shared_experts",), 1)),
             num_experts=int(_hf_config_attr(hf_config, ("num_experts", "num_local_experts"), 8)),
             num_experts_per_token=int(_hf_config_attr(hf_config, ("num_experts_per_token", "num_experts_per_tok"), 2)),
+            latent_dim=None if latent_dim is None else int(latent_dim),
             num_layers=int(_hf_config_attr(hf_config, ("num_layers", "num_hidden_layers"), 24)),
             num_heads=int(_hf_config_attr(hf_config, ("num_heads", "num_attention_heads"), 16)),
             num_kv_heads=int(_hf_config_attr(hf_config, ("num_kv_heads", "num_key_value_heads"), 16)),
@@ -320,6 +322,7 @@ class GrugModelConfig:
             "shared_expert_intermediate_size": self.shared_expert_intermediate_dim,
             "num_shared_experts": self.num_shared_experts,
             # grug-specific (no public equivalent)
+            "latent_dim": self.latent_dim,
             "qk_mult": self.qk_mult,
             "local_kv_heads": self.local_kv_heads,
             "global_kv_heads": self.global_kv_heads,
@@ -1217,6 +1220,16 @@ def grugmoe_inference_state_dict(model: Transformer, prefix: str | None = None) 
                 f"{layer_prefix}.mlp.experts.down_proj.weight": _linear_inference_tensor(block.mlp.expert_mlp.w_down),
             }
         )
+        if block.mlp.w_latent_down is not None:
+            assert block.mlp.latent_norm is not None
+            assert block.mlp.w_latent_up is not None
+            tensors.update(
+                {
+                    f"{layer_prefix}.mlp.latent_down_proj.weight": _linear_inference_tensor(block.mlp.w_latent_down),
+                    f"{layer_prefix}.mlp.latent_norm.weight": block.mlp.latent_norm.weight,
+                    f"{layer_prefix}.mlp.latent_up_proj.weight": _linear_inference_tensor(block.mlp.w_latent_up),
+                }
+            )
         # SConv weights are learned; export them per site so the checkpoint reconstructs an sconv model.
         for site_name, conv in (
             ("self_attn.sconv_k", block.attn.sconv_k),

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -8,6 +8,7 @@ No load-balancing loss; router z-loss only. All layers are MoE (no dense layers)
 """
 
 import dataclasses
+import math
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -140,6 +141,13 @@ class GrugModelConfig:
     num_shared_experts: int = 1
     num_experts: int = 256
     num_experts_per_token: int = 4
+    # LatentMoE (arXiv 2601.18089): routed experts operate in a latent space of this width instead
+    # of `hidden_dim`. Tokens are projected down before routing and back up after the combine, so
+    # the expert-parallel all-to-all carries `latent_dim`-wide rows -- communication falls by
+    # `hidden_dim / latent_dim`. Shared experts and the router stay at `hidden_dim`. To hold FLOPs
+    # constant the paper scales the routed bank and top-k by the same ratio. None keeps a
+    # standard MoE, in which case no projection is built and the layer is unchanged.
+    latent_dim: int | None = None
     num_layers: int = 6
     num_heads: int = 4
     num_kv_heads: int = 1
@@ -194,6 +202,11 @@ class GrugModelConfig:
             # QB routing takes top-(k+1) and keeps the last entry as the threshold alpha, so a
             # full-bank top-k asks `jax.lax.top_k` for more entries than the router has experts.
             raise ValueError("num_experts_per_token must be < num_experts, because QB routing selects top-(k+1)")
+        if self.latent_dim is not None and not 0 < self.latent_dim <= self.hidden_dim:
+            raise ValueError(
+                f"latent_dim must be in (0, hidden_dim={self.hidden_dim}], got {self.latent_dim}; "
+                "it only reduces communication when it is smaller than the hidden dimension"
+            )
         if self.shared_expert_intermediate_dim < 0:
             raise ValueError("shared_expert_intermediate_dim must be non-negative")
         if self.capacity_factor <= 0:
@@ -462,7 +475,22 @@ class CausalSelfAttention(eqx.Module):
         if self.cfg.local_kv_heads is not None and self.cfg.global_kv_heads is not None:
             stored_kv_heads = self.cfg.stored_kv_heads
 
+            # Both branches must agree on sharding, not just shape: `lax.cond` compares full types
+            # under explicit mesh axes. The pass-through case keeps the projection's `model`-sharded
+            # head axis, while the align case slices to one head -- which cannot stay sharded -- and
+            # broadcasts back, giving an identical shape with a different sharding. Reshard both to
+            # the same spec. This is a no-op wherever the mesh leaves `model` at one, which is why
+            # the hero shape never hit it despite also setting local_kv_heads != global_kv_heads.
+            #
+            # Replicate the head axis rather than pinning it to `model`: a shape can carry fewer
+            # KV heads than the model axis is wide (d768 stores one), and the KV tensors are small
+            # enough -- at most a dozen heads of 128 -- that replication is not worth a special case.
+            kv_spec = P(_BATCH_AXES, None, None, None)
+
             def _logical_kv(projection: jax.Array, num_kv_heads: int) -> jax.Array:
+                # Replicate before slicing, not after: narrowing a `model`-sharded head axis to a
+                # count that does not divide the mesh axis is unsupported.
+                projection = reshard(projection, kv_spec)
                 if num_kv_heads == stored_kv_heads:
                     return projection
                 return align_kv_heads(projection[:, :, :num_kv_heads, :], num_q_heads=stored_kv_heads)
@@ -715,11 +743,14 @@ class MoEMLP(eqx.Module):
     router: jax.Array
     router_bias: jax.Array
     expert_mlp: MoEExpertMlp
+    w_latent_down: jax.Array | None
+    latent_norm: RMSNorm | None
+    w_latent_up: jax.Array | None
     cfg: GrugModelConfig = eqx.field(static=True)
 
     @staticmethod
     def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "MoEMLP":
-        k_router, k_expert = random.split(key, 2)
+        k_router, k_expert, k_down, k_up = random.split(key, 4)
         mesh = get_abstract_mesh()
 
         expert_axis_size = _mesh_axis_size(mesh, "expert")
@@ -727,12 +758,31 @@ class MoEMLP(eqx.Module):
             raise ValueError(f"num_experts={cfg.num_experts} must be divisible by expert axis size={expert_axis_size}")
 
         d, e = cfg.hidden_dim, cfg.num_experts
+        # Routed experts live in the latent space; the router reads the full-width token, so its
+        # own projection keeps `hidden_dim`.
+        expert_width = cfg.latent_dim if cfg.latent_dim is not None else d
+        latent = cfg.latent_dim
         return MoEMLP(
             router=reshard(_init_weight(k_router, (d, e), cfg.initializer_std), P(None, None)),
             router_bias=jnp.zeros((e,)),
+            w_latent_down=(
+                None
+                if latent is None
+                else reshard(_init_weight(k_down, (d, latent), cfg.initializer_std), P(_FSDP_AXES, "model"))
+            ),
+            latent_norm=None if latent is None else RMSNorm.init(latent, cfg.layer_norm_eps),
+            w_latent_up=(
+                None
+                if latent is None
+                else reshard(_init_weight(k_up, (latent, d), cfg.initializer_std), P("model", _FSDP_AXES))
+            ),
             expert_mlp=MoEExpertMlp.init(
                 num_experts=cfg.num_experts,
-                hidden_dim=cfg.hidden_dim,
+                hidden_dim=expert_width,
+                # The single `initializer_std` is derived from `hidden_dim`. Under LatentMoE the
+                # gate/up fan-in is `latent_dim`, so without this the routed path stays attenuated
+                # by sqrt(hidden/latent) even after the latent RMSNorm.
+                gate_up_initializer_std=(None if latent is None else cfg.initializer_std * math.sqrt(d / expert_width)),
                 intermediate_dim=cfg.intermediate_dim,
                 initializer_std=cfg.initializer_std,
                 key=k_expert,
@@ -794,8 +844,21 @@ class MoEMLP(eqx.Module):
             out_specs=P(),
         )(s_minus_alpha)
 
+        # LatentMoE: compress before dispatch so the expert-parallel all-to-all carries
+        # `latent_dim`-wide rows in both directions. The router above already read the full-width
+        # token, and the shared experts in the enclosing block never see this path.
+        routed_input = x_flat
+        if self.w_latent_down is not None and self.latent_norm is not None:
+            routed_input = jnp.einsum(
+                "td,dl->tl",
+                x_flat,
+                self.w_latent_down.astype(x_flat.dtype),
+                out_sharding=_batch_spec(),
+            )
+            # Keep the expert input scale independent of the down-projection initialization.
+            routed_input = self.latent_norm(routed_input)
         moe_out = self.expert_mlp(
-            x_flat,
+            routed_input,
             selected_experts.astype(jnp.int32),
             combine_weights,
             mesh=get_abstract_mesh(),
@@ -807,6 +870,16 @@ class MoEMLP(eqx.Module):
             routed_flat = moe_out
             dropped_assignments = _zero_dropped_assignments()
         router_stats["capacity_overflow"] = dropped_assignments
+
+        # Expand after the combine: `expert_mlp` already returns the weight-summed expert output,
+        # which is the vector the paper's W_up acts on.
+        if self.w_latent_up is not None:
+            routed_flat = jnp.einsum(
+                "tl,ld->td",
+                routed_flat,
+                self.w_latent_up.astype(routed_flat.dtype),
+                out_sharding=_batch_spec(),
+            )
 
         routed = rearrange(routed_flat, "(b s) d -> b s d", b=b, s=s)
         routed = reshard(routed, _batch_spec())

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -676,7 +676,6 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             while int(state.step) < stop_step:
                 with jax.profiler.TraceAnnotation("load_batch"):
                     batch = next(iterator)
-                step_start = time.perf_counter()
                 current_step = int(state.step)
                 watch_due = (
                     watch_config.is_enabled and watch_config.interval > 0 and current_step % watch_config.interval == 0
@@ -686,6 +685,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                     jax.block_until_ready(watch_stats)
                 else:
                     watch_stats = None
+                step_start = time.perf_counter()
                 state, metrics, inline_watch_stats = train_step(state, batch)
                 if inline_watch_stats is not None and watch_due:
                     watch_stats = inline_watch_stats

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -6,7 +6,8 @@ import functools
 import logging
 import os
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
+from enum import StrEnum
 
 import equinox as eqx
 import jax
@@ -51,22 +52,36 @@ from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
 logger = logging.getLogger(__name__)
 
 HERO_EP_RUNTIME_ENV = {
-    "JAX_ENABLE_PGLE": "false",
+    "JAX_ENABLE_PGLE": "true",
     "XLA_PYTHON_CLIENT_ALLOCATOR": "cuda_async",
 }
-_XLA_FLAG_DEFAULTS = (
-    "--xla_gpu_experimental_parallel_collective_overlap_limit=4",
-    "--xla_gpu_enable_latency_hiding_scheduler=true",
-)
+_XLA_FLAG_DEFAULTS = ("--xla_gpu_enable_latency_hiding_scheduler=true",)
+XLA_COLLECTIVE_OVERLAP_FLAG = "--xla_gpu_experimental_parallel_collective_overlap_limit"
+DEFAULT_COLLECTIVE_OVERLAP_LIMIT = 4
+# Full inline norm watch failed with overlap 4. Overlap 1 completed the selected full-watch gate.
+INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT = 1
 # TODO(https://github.com/marin-community/marin/issues/5675): Re-enable XLA GPU
 # command buffers after the CUDA graph failure is fixed.
 XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG = "--xla_gpu_enable_command_buffer="
 
 
-def _apply_hero_ep_runtime_defaults() -> None:
-    os.environ.update(HERO_EP_RUNTIME_ENV)
+class WatchMode(StrEnum):
+    """Where a watched training step computes gradient and parameter statistics."""
+
+    INLINE = "inline"
+    DIAGNOSTIC = "diagnostic"
+
+
+def _apply_hero_ep_runtime_defaults(*, inline_watch_enabled: bool) -> None:
+    for name, value in HERO_EP_RUNTIME_ENV.items():
+        os.environ.setdefault(name, value)
     xla_flags = os.environ.get("XLA_FLAGS", "").split()
-    flag_defaults = (*_XLA_FLAG_DEFAULTS, XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG)
+    overlap_limit = INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT if inline_watch_enabled else DEFAULT_COLLECTIVE_OVERLAP_LIMIT
+    flag_defaults = (
+        f"{XLA_COLLECTIVE_OVERLAP_FLAG}={overlap_limit}",
+        *_XLA_FLAG_DEFAULTS,
+        XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG,
+    )
     explicit_names = {flag.partition("=")[0] for flag in xla_flags}
     xla_flags.extend(flag for flag in flag_defaults if flag.partition("=")[0] not in explicit_names)
     os.environ["XLA_FLAGS"] = " ".join(xla_flags)
@@ -84,6 +99,14 @@ class GrugTrainerConfig:
     # Keep disabled except on model sizes where Grace-Blackwell host offload has been measured.
     # The d6144 EP64 runs used it; d5120 required a 135 GiB pinned-host arena and regressed.
     offload_opt_state: bool = False
+    # Inline watch computes statistics on every step and uses the watch interval only for logging.
+    # This keeps one training executable resident. A diagnostic watch repeats forward and backward
+    # in a separate executable, which costs compute but shortens gradient liveness.
+    watch_mode: WatchMode = WatchMode.INLINE
+    # A short throughput gate leaves this off. A compute-optimal run needs it: the loop already
+    # restores from the latest committed checkpoint, so without a writer an interrupted run
+    # restarts at step 0.
+    save_checkpoints: bool = False
 
     # Grug builds its own compact (replica_dcn, data, expert, model) mesh instead of using
     # the Trainer's logical axis mapping; `data` absorbs whatever these two leave free.
@@ -120,6 +143,10 @@ class GrugRunConfig:
     optimizer: OptimizerConfig = field(default_factory=AdamConfig)
     trainer: GrugTrainerConfig = field(default_factory=GrugTrainerConfig)
     eval: GrugEvalConfig | None = field(default_factory=GrugEvalConfig)
+    # Stop after this many steps while `trainer.num_train_steps` still sizes the learning-rate
+    # schedule. Warmup and decay are fractions of `num_train_steps`, so training the head of a
+    # long schedule requires the two to differ. None runs the whole schedule.
+    stop_after_steps: int | None = None
     # GPU processes per task: > 1 runs one JAX process per GPU (multi-controller)
     # via the iris.hooks.multigpu_main supervisor instead of one process per node.
     processes_per_task: int = 1
@@ -177,6 +204,7 @@ def build_tagged_evaluator(
     max_seq_len: int,
     mesh: Mesh,
     eval_cfg: GrugEvalConfig,
+    mp: jmp.Policy,
 ) -> TaggedEvaluator[LmExample | GrugLmExample, Transformer] | None:
     pos = Axis("position", max_seq_len)
     tagged_eval_sets = data_config.tagged_eval_sets(pos)
@@ -196,6 +224,11 @@ def build_tagged_evaluator(
     eval_array_sharding = NamedSharding(mesh, P(_BATCH_AXES, None))
 
     def eval_loss_fn(model: Transformer, batch: LmExample | GrugLmExample) -> tuple[jax.Array, jax.Array, jax.Array]:
+        # Evaluate at the compute dtype, as the train step does at `mp.cast_to_compute(params)`.
+        # Parameters are stored float32, and `gpu_fa4_cute` accepts only bf16/fp16, so without this
+        # every eval raises `TypeError: ... supports only bf16/fp16, got float32` on Blackwell. The
+        # reference attention path takes float32, which hid this on H100.
+        model = mp.cast_to_compute(model)
         if isinstance(batch, LmExample):
             batch = grug_lm_example_from_named(batch)
         per_pos_loss = model.next_token_loss(
@@ -243,6 +276,17 @@ def _compute_flops(
         local_kv_heads=model_config.local_kv_heads,
         global_kv_heads=model_config.global_kv_heads,
     )
+    # `lm_flops_per_token` prices every matmul at `hidden_dim`. Under LatentMoE the routed experts
+    # live at `latent_dim` instead, and two projections are added per layer, so correct both terms
+    # or MFU is overstated by roughly the compression ratio.
+    if model_config.latent_dim is not None:
+        latent, hidden = model_config.latent_dim, model_config.hidden_dim
+        # Matches the routed term in `lm_flops_per_token`: 2 * 3 * width * intermediate * top_k.
+        routed_delta = 2 * 3 * model_config.intermediate_dim * model_config.num_experts_per_token * (latent - hidden)
+        # W_down (hidden -> latent) and W_up (latent -> hidden), once per token each.
+        projection = 2 * 2 * hidden * latent
+        flops_per_token += model_config.num_layers * (routed_delta + projection)
+
     flops_per_example = 3 * flops_per_token * model_config.max_seq_len
 
     flops_summary: dict[str, float] = {
@@ -346,6 +390,55 @@ def _drop_metrics(
     }
 
 
+def _loss_and_grads(params, batch, mp: jmp.Policy, z_loss: float | None):
+    def loss_fn(model):
+        compute_params = mp.cast_to_compute(model)
+        return compute_params.next_token_loss(
+            batch.tokens,
+            batch.loss_weight,
+            mask=batch.attn_mask,
+            reduction="mean",
+            logsumexp_weight=z_loss,
+            return_router_metrics=True,
+        )
+
+    return jax.value_and_grad(loss_fn, has_aux=True)(params)
+
+
+def _compute_diagnostic_watch_stats(params, batch, mp: jmp.Policy, z_loss: float | None, watch_config: WatchConfig):
+    (_, _), grads = _loss_and_grads(params, batch, mp, z_loss)
+    return compute_watch_stats(
+        watch_targets=watch_config.watch_targets,
+        include_norms=watch_config.include_norms,
+        include_per_parameter_norms=watch_config.include_per_parameter_norms,
+        include_histogram=watch_config.include_histograms,
+        split_scan_layers=watch_config.split_scan_layers,
+        params=params,
+        grads=grads,
+        model_tree_type=type(params),
+    )
+
+
+def _make_diagnostic_watch_step(mp: jmp.Policy, *, z_loss_weight: float, watch_config: WatchConfig):
+    watch_targets = (
+        tuple(t.strip() for t in watch_config.watch_targets.split(","))
+        if isinstance(watch_config.watch_targets, str)
+        else tuple(watch_config.watch_targets)
+    )
+    unsupported_targets = set(watch_targets) - {"grads", "params"}
+    if unsupported_targets:
+        raise ValueError(f"diagnostic watch does not support targets {sorted(unsupported_targets)}")
+    diagnostic_watch_config = replace(watch_config, watch_targets=list(watch_targets))
+    z_loss = z_loss_weight if z_loss_weight > 0 else None
+
+    @jax.jit
+    def diagnostic_watch_step(params: Transformer, batch, pending_qb_betas: jax.Array):
+        params = _apply_qb_betas(params, pending_qb_betas)
+        return _compute_diagnostic_watch_stats(params, batch, mp, z_loss, diagnostic_watch_config)
+
+    return diagnostic_watch_step
+
+
 def _make_train_step(
     optimizer: optax.GradientTransformation,
     mp: jmp.Policy,
@@ -365,8 +458,8 @@ def _make_train_step(
     else:
         watch_targets = ()
 
-    @functools.partial(jax.jit, donate_argnums=(0,), static_argnames=("compute_watch",))
-    def train_step(state: GrugTrainState, batch, *, compute_watch: bool = False):
+    @functools.partial(jax.jit, donate_argnums=(0,))
+    def train_step(state: GrugTrainState, batch):
         # Apply pending QB betas to router biases inside JIT (avoids eager
         # host-side TPU kernel launches that can cause SPMD sync issues).
         qb_params = _apply_qb_betas(state.params, state.pending_qb_betas)
@@ -375,18 +468,7 @@ def _make_train_step(
         else:
             qb_ema_params = None
 
-        def loss_fn(params):
-            compute_params = mp.cast_to_compute(params)
-            return compute_params.next_token_loss(
-                batch.tokens,
-                batch.loss_weight,
-                mask=batch.attn_mask,
-                reduction="mean",
-                logsumexp_weight=z_loss,
-                return_router_metrics=True,
-            )
-
-        (loss, summarized_metrics), grads = jax.value_and_grad(loss_fn, has_aux=True)(qb_params)
+        (loss, summarized_metrics), grads = _loss_and_grads(qb_params, batch, mp, z_loss)
         metrics = {"train/loss": loss, **summarized_metrics}
         opt_state_in = (
             _optimizer_state_to_memory_kind(state.opt_state, "device") if offload_opt_state else state.opt_state
@@ -406,7 +488,7 @@ def _make_train_step(
             )
 
         watch_stats = None
-        if watch_config is not None and compute_watch:
+        if watch_config is not None:
             watch_stats = compute_watch_stats(
                 watch_targets=watch_targets,
                 include_norms=watch_config.include_norms,
@@ -449,12 +531,21 @@ def _run_grug_local(config: GrugRunConfig) -> None:
 
     optimizer = config.optimizer.build(trainer.num_train_steps)
     watch_config = trainer.watch
+    diagnostic_watch_step = None
+    inline_watch_config = watch_config if watch_config.is_enabled else None
+    if watch_config.is_enabled and config.trainer.watch_mode == WatchMode.DIAGNOSTIC:
+        diagnostic_watch_step = _make_diagnostic_watch_step(
+            trainer.mp,
+            z_loss_weight=config.trainer.z_loss_weight,
+            watch_config=watch_config,
+        )
+        inline_watch_config = None
     train_step = _make_train_step(
         optimizer,
         trainer.mp,
         z_loss_weight=config.trainer.z_loss_weight,
         ema_beta=config.trainer.ema_beta,
-        watch_config=watch_config if watch_config.is_enabled else None,
+        watch_config=inline_watch_config,
         offload_opt_state=config.trainer.offload_opt_state,
     )
 
@@ -498,6 +589,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
 
         state = _init_state(model_key)
 
+        checkpointer = trainer.checkpointer.create(run_id) if config.trainer.save_checkpoints else None
         state = restore_grug_state_from_checkpoint(
             state,
             checkpoint_search_paths=trainer.checkpoint_search_paths(run_id),
@@ -525,10 +617,16 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 max_seq_len=config.model.max_seq_len,
                 mesh=mesh,
                 eval_cfg=eval_cfg,
+                mp=trainer.mp,
             )
 
+        # `trainer.num_train_steps` sizes the schedule; this bounds the run. Progress and the loop
+        # both use it so a head-of-schedule run reports against the steps it will actually take.
+        requested_stop_step = trainer.num_train_steps if config.stop_after_steps is None else config.stop_after_steps
+        stop_step = min(requested_stop_step, trainer.num_train_steps)
+
         profiler_cfg = trainer.profiler
-        profiler_num_steps = profiler_cfg.resolve_num_profile_steps(num_train_steps=trainer.num_train_steps)
+        profiler_num_steps = profiler_cfg.resolve_num_profile_steps(num_train_steps=stop_step)
         profiler_enabled = profiler_cfg.is_enabled and profiler_num_steps > 0
 
         log_every = max(1, config.trainer.log_every)
@@ -544,8 +642,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             callbacks.log_performance_stats(config.model.max_seq_len, batch_schedule, flops_per_example),
             every=log_every,
         )
-        state_callbacks.add_hook(callbacks.pbar_logger(total=trainer.num_train_steps), every=log_every)
-        state_callbacks.add_hook(callbacks.log_step_info(trainer.num_train_steps), every=log_every)
+        state_callbacks.add_hook(callbacks.pbar_logger(total=stop_step), every=log_every)
+        state_callbacks.add_hook(callbacks.log_step_info(stop_step), every=log_every)
         if profiler_enabled:
             state_callbacks.add_hook(
                 profiler_cfg.build(
@@ -575,16 +673,22 @@ def _run_grug_local(config: GrugRunConfig) -> None:
 
         # Main optimization loop.
         try:
-            while int(state.step) < trainer.num_train_steps:
+            while int(state.step) < stop_step:
                 with jax.profiler.TraceAnnotation("load_batch"):
                     batch = next(iterator)
                 step_start = time.perf_counter()
                 current_step = int(state.step)
-                # grad_watch runs only on its configured interval.
-                compute_watch = (
+                watch_due = (
                     watch_config.is_enabled and watch_config.interval > 0 and current_step % watch_config.interval == 0
                 )
-                state, metrics, watch_stats = train_step(state, batch, compute_watch=compute_watch)
+                if watch_due and diagnostic_watch_step is not None:
+                    watch_stats = diagnostic_watch_step(state.params, batch, state.pending_qb_betas)
+                    jax.block_until_ready(watch_stats)
+                else:
+                    watch_stats = None
+                state, metrics, inline_watch_stats = train_step(state, batch)
+                if inline_watch_stats is not None and watch_due:
+                    watch_stats = inline_watch_stats
                 step = int(state.step) - 1
 
                 jax.block_until_ready(metrics["train/loss"])
@@ -625,12 +729,32 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                     if watch_stats is not None:
                         levanter.tracker.log(watch_stats, step=step)
 
+                if checkpointer is not None:
+                    with callbacks.progress_event_scope(
+                        state_callbacks.emit_event,
+                        callbacks.ProgressEvent.CHECKPOINT_STARTED,
+                        callbacks.ProgressEvent.CHECKPOINT_FINISHED,
+                    ):
+                        checkpointer.on_step(tree=state, step=int(state.step))
+
         except BaseException:
-            logger.exception("Fatal error in grug training loop; skipping final callbacks to preserve root cause")
+            logger.exception(
+                "Fatal error in grug training loop; skipping final callbacks/checkpoint to preserve root cause"
+            )
             raise
         else:
             # Mirror classic trainer behavior: force callbacks on the last completed step.
             state_callbacks.run(state, loss=last_loss, step_duration=last_step_duration, force=True)
+            if checkpointer is not None:
+                with callbacks.progress_event_scope(
+                    state_callbacks.emit_event,
+                    callbacks.ProgressEvent.CHECKPOINT_STARTED,
+                    callbacks.ProgressEvent.CHECKPOINT_FINISHED,
+                ):
+                    checkpointer.on_step(tree=state, step=int(state.step), force=True)
+                    checkpointer.wait_until_finished()
+        finally:
+            state_callbacks.emit_event(callbacks.ProgressEvent.TRAINING_FINISHED)
 
     levanter.tracker.current_tracker().finish()
 
@@ -642,7 +766,8 @@ def run_grug(config: GrugRunConfig) -> None:
         raise ValueError("trainer.id must be set before dispatching grug training.")
 
     # Dispatch snapshots os.environ for the child task, so apply the hero defaults first.
-    _apply_hero_ep_runtime_defaults()
+    inline_watch_enabled = trainer.watch.is_enabled and config.trainer.watch_mode == WatchMode.INLINE
+    _apply_hero_ep_runtime_defaults(inline_watch_enabled=inline_watch_enabled)
     dispatch_grug_training_run(
         run_id=trainer.id,
         config=config,

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -16,6 +16,7 @@ import jax
 import jax.numpy as jnp
 import jmp
 import numpy as np
+from jax._src import config as jax_config
 from jax.sharding import Mesh, NamedSharding, PartitionSpec as P
 from jaxtyping import Array, Float, Int
 from tqdm_loggable.auto import tqdm
@@ -410,13 +411,16 @@ def cb_tagged_evaluate(
             ProgressEvent.EVALUATION_STARTED,
             ProgressEvent.EVALUATION_FINISHED,
         ):
-            if eval_current:
-                log_dict = eval_model(evaluator, step.model, prefix=prefix)
-                levanter.tracker.log(log_dict, step=step_count)
+            # AutoPGLE profiles each newly compiled module. The tagged evaluation module must not
+            # start a second CUPTI profiling session while training uses its PGLE executable.
+            with jax_config.enable_pgle(False):
+                if eval_current:
+                    log_dict = eval_model(evaluator, step.model, prefix=prefix)
+                    levanter.tracker.log(log_dict, step=step_count)
 
-            if eval_ema:
-                log_dict = eval_model(evaluator, step.eval_model, prefix=_join_prefix(prefix, "ema"))
-                levanter.tracker.log(log_dict, step=step_count)
+                if eval_ema:
+                    log_dict = eval_model(evaluator, step.eval_model, prefix=_join_prefix(prefix, "ema"))
+                    levanter.tracker.log(log_dict, step=step_count)
             last_eval_step = step_count
 
     return eval_callback

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -80,6 +80,7 @@ class MoEExpertMlp(eqx.Module):
         intermediate_dim: int,
         initializer_std: float,
         key: jax.Array,
+        gate_up_initializer_std: float | None = None,
         implementation: MoeImplementation | str | None = None,
         activation: MoeActivation = ActivationFunctionEnum.silu,
         capacity_factor: float = _DEFAULT_EP_CAPACITY_FACTOR,
@@ -88,8 +89,11 @@ class MoEExpertMlp(eqx.Module):
     ) -> "MoEExpertMlp":
         resolved_implementation = resolve_moe_implementation(implementation)
         k_gate, k_up, k_down = jax.random.split(key, 3)
-        w_gate = _init_weight(k_gate, (num_experts, hidden_dim, intermediate_dim), initializer_std)
-        w_up = _init_weight(k_up, (num_experts, hidden_dim, intermediate_dim), initializer_std)
+        # `w_gate`/`w_up` contract over `hidden_dim`, so their fan-in moves when the experts run
+        # in a latent space; `w_down` contracts over `intermediate_dim` and is unaffected.
+        gate_up_std = initializer_std if gate_up_initializer_std is None else gate_up_initializer_std
+        w_gate = _init_weight(k_gate, (num_experts, hidden_dim, intermediate_dim), gate_up_std)
+        w_up = _init_weight(k_up, (num_experts, hidden_dim, intermediate_dim), gate_up_std)
         w_down = _reshard_for_init(
             _init_weight(k_down, (num_experts, intermediate_dim, hidden_dim), initializer_std),
             pspecs.w_down,

--- a/lib/levanter/tests/test_eval.py
+++ b/lib/levanter/tests/test_eval.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 import numpy as np
 from haliax import Axis
 from haliax.partitioning import ResourceAxis
+from jax._src import config as jax_config
 
 from levanter.callbacks import ProgressEvent
 from levanter.data.dataset import ListAsyncDataset
@@ -300,11 +301,14 @@ def test_loss_labels_from_spans_rejects_overlapping_spans():
 
 
 def test_cb_tagged_evaluate_dedupes_force_and_logs_ema(caplog):
+    pgle_states = []
+
     class _FakeEvaluator:
         tokenizer = None
         dataset = SimpleNamespace(tag_to_index={"base": 0})
 
         def evaluate(self, _model):
+            pgle_states.append(jax_config.enable_pgle.value)
             return EvalResult(
                 micro_avg_loss=1.0,
                 macro_avg_loss=1.0,
@@ -321,11 +325,13 @@ def test_cb_tagged_evaluate_dedupes_force_and_logs_ema(caplog):
 
     events = []
     with current_tracker(tracker):
-        step0 = SimpleNamespace(step=0, model=object(), eval_model=object(), emit_event=events.append)
-        callback(step0)
-        callback(step0, force=True)
-        step1 = SimpleNamespace(step=1, model=object(), eval_model=object(), emit_event=events.append)
-        callback(step1)
+        with jax_config.enable_pgle(True):
+            step0 = SimpleNamespace(step=0, model=object(), eval_model=object(), emit_event=events.append)
+            callback(step0)
+            callback(step0, force=True)
+            step1 = SimpleNamespace(step=1, model=object(), eval_model=object(), emit_event=events.append)
+            callback(step1)
+            assert jax_config.enable_pgle.value
 
     log_events = []
     for record in caplog.records:
@@ -347,3 +353,4 @@ def test_cb_tagged_evaluate_dedupes_force_and_logs_ema(caplog):
         ProgressEvent.EVALUATION_STARTED,
         ProgressEvent.EVALUATION_FINISHED,
     ]
+    assert pgle_states == [False, False, False, False]

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -257,7 +257,7 @@ def test_grug_variant_one_step_contract_lowers_with_default_ctor(variant: str):
             loss_weight=jax.sharding.reshard(batch.loss_weight, token_pspec),
         )
         state = initial_state(cfg, optimizer=optimizer, mp=mp, key=jax.random.PRNGKey(0), ema_beta=None)
-        return train_step(state, sharded_batch, compute_watch=False)
+        return train_step(state, sharded_batch)
 
     with _reset_abstract_mesh(), use_abstract_mesh(mesh):
         out_state_shape, out_metrics_shape, out_watch_shape = eqx.filter_eval_shape(one_step)

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -1,20 +1,45 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import math
 import os
 import subprocess
 import sys
 import textwrap
+from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
+import jmp
+import numpy as np
+import optax
 import pytest
-from jax.sharding import AbstractMesh, AxisType, NamedSharding, use_abstract_mesh
+from jax.sharding import AbstractMesh, AxisType, Mesh, NamedSharding, set_mesh, use_abstract_mesh
 from jax.sharding import PartitionSpec as P
+from levanter.callbacks.watch import WatchConfig, compute_watch_stats
+from marin.execution.lazy import StepContext
 
-from experiments.grug.moe_hero_ep import grugmuon_hero, launch, train
+from experiments.grug.moe_hero_ep import grugmuon_hero, launch, model, train
+
+
+def test_hero_run_without_shape_overrides_uses_the_selected_model():
+    step = launch.build_hero_run(run_id="selected-default", dp_racks=1, num_steps=1, version="dev")
+    config = step.build_config(StepContext.for_fingerprint(step.runtime_args, step.deps))
+
+    assert (
+        config.model.hidden_dim,
+        config.model.num_layers,
+        config.model.num_experts,
+        config.model.intermediate_dim,
+        config.model.num_experts_per_token,
+        config.model.latent_dim,
+        config.model.capacity_factor,
+        config.trainer.trainer.train_batch_size,
+        config.model.max_seq_len,
+    ) == (6144, 48, 192, 6272, 4, 3072, 1.33, 1024, 4096)
 
 
 def test_full_bank_top_k_is_rejected_before_launch():
@@ -22,14 +47,71 @@ def test_full_bank_top_k_is_rejected_before_launch():
     # more entries than there are experts. Without this the job dies in the router, which is after
     # the 16-node gang is allocated.
     with pytest.raises(ValueError, match="must be < num_experts"):
-        launch.build_hero_run(run_id="full-bank", num_steps=1, num_experts_per_token=128, version="dev")
+        launch.build_hero_run(
+            run_id="full-bank",
+            dp_racks=1,
+            num_steps=1,
+            num_experts=128,
+            num_experts_per_token=128,
+            version="dev",
+        )
+
+
+def test_checkpoint_interval_must_be_positive():
+    with pytest.raises(ValueError, match="checkpoint_interval must be positive"):
+        launch.build_hero_run(
+            run_id="bad-checkpoint-interval",
+            dp_racks=1,
+            num_steps=1,
+            checkpoint_interval=timedelta(0),
+            version="dev",
+        )
+
+
+@pytest.mark.parametrize(
+    ("profile_steps", "profile_start_step"),
+    [(-1, 0), (1, -1), (1, 3)],
+)
+def test_profile_window_must_fall_inside_the_run(profile_steps, profile_start_step):
+    with pytest.raises(ValueError, match="profile"):
+        launch.build_hero_run(
+            run_id="bad-profile-window",
+            dp_racks=1,
+            num_steps=3,
+            profile_steps=profile_steps,
+            profile_start_step=profile_start_step,
+            version="dev",
+        )
+
+
+def test_data_parallel_racks_keep_the_global_batch_explicit():
+    step = launch.build_hero_run(run_id="two-racks", dp_racks=2, num_steps=1, version="dev")
+    config = step.build_config(StepContext.for_fingerprint(step.runtime_args, step.deps))
+
+    assert config.trainer.replica_axis_size == 2
+    assert config.trainer.trainer.train_batch_size == launch.HERO_EP_BATCH_SIZE
+    assert step.runtime_args["train_resources"].replicas == 2 * launch.HERO_EP_NODES
+
+
+def test_schedule_steps_do_not_extend_the_run():
+    step = launch.build_hero_run(
+        run_id="schedule-head",
+        dp_racks=1,
+        num_steps=5,
+        schedule_steps=100,
+        version="dev",
+    )
+    config = step.build_config(StepContext.for_fingerprint(step.runtime_args, step.deps))
+
+    assert config.trainer.trainer.num_train_steps == 100
+    assert config.stop_after_steps == 5
 
 
 def test_expert_bank_override_must_divide_the_expert_axis():
     # `moe_mlp` raises on an indivisible bank only once the 16-node gang is already allocated and
     # its workspace is built, so the launcher has to reject it while it is still free to do so.
     with pytest.raises(ValueError, match="must divide the expert axis"):
-        launch.build_hero_run(run_id="bad-bank", num_steps=1, num_experts=200, version="dev")
+        launch.build_hero_run(run_id="bad-bank", dp_racks=1, num_steps=1, num_experts=200, version="dev")
 
 
 def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch):
@@ -38,7 +120,10 @@ def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch)
     for name in train.HERO_EP_RUNTIME_ENV:
         monkeypatch.delenv(name, raising=False)
     config = SimpleNamespace(
-        trainer=SimpleNamespace(trainer=SimpleNamespace(id="test-run")),
+        trainer=SimpleNamespace(
+            trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=1)),
+            watch_mode=train.WatchMode.INLINE,
+        ),
         resources=object(),
         processes_per_task=1,
     )
@@ -51,8 +136,56 @@ def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch)
     assert "--xla_gpu_experimental_parallel_collective_overlap_limit=4" not in flags
     assert "--xla_gpu_enable_latency_hiding_scheduler=true" in flags
     assert train.XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG in flags
-    for name, value in train.HERO_EP_RUNTIME_ENV.items():
-        assert os.environ[name] == value
+    assert os.environ["JAX_ENABLE_PGLE"] == "true"
+    assert os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] == "cuda_async"
+
+
+def test_run_grug_keeps_explicit_ep_runtime_values(monkeypatch):
+    monkeypatch.setenv("JAX_ENABLE_PGLE", "false")
+    monkeypatch.setenv("XLA_PYTHON_CLIENT_ALLOCATOR", "platform")
+    monkeypatch.delenv("XLA_FLAGS", raising=False)
+    config = SimpleNamespace(
+        trainer=SimpleNamespace(
+            trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=1)),
+            watch_mode=train.WatchMode.INLINE,
+        ),
+        resources=object(),
+        processes_per_task=1,
+    )
+
+    with patch.object(train, "dispatch_grug_training_run"):
+        train.run_grug(config)
+
+    assert os.environ["JAX_ENABLE_PGLE"] == "false"
+    assert os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] == "platform"
+
+
+@pytest.mark.parametrize(
+    ("watch_mode", "watch_interval", "expected_overlap_limit"),
+    [
+        (train.WatchMode.INLINE, 1, train.INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT),
+        (train.WatchMode.DIAGNOSTIC, 1, train.DEFAULT_COLLECTIVE_OVERLAP_LIMIT),
+        (train.WatchMode.INLINE, 0, train.DEFAULT_COLLECTIVE_OVERLAP_LIMIT),
+    ],
+)
+def test_run_grug_reduces_collective_overlap_only_for_inline_watch(
+    monkeypatch, watch_mode, watch_interval, expected_overlap_limit
+):
+    monkeypatch.delenv("XLA_FLAGS", raising=False)
+    config = SimpleNamespace(
+        trainer=SimpleNamespace(
+            trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=watch_interval)),
+            watch_mode=watch_mode,
+        ),
+        resources=object(),
+        processes_per_task=1,
+    )
+
+    with patch.object(train, "dispatch_grug_training_run"):
+        train.run_grug(config)
+
+    flags = os.environ["XLA_FLAGS"].split()
+    assert f"{train.XLA_COLLECTIVE_OVERLAP_FLAG}={expected_overlap_limit}" in flags
 
 
 def test_ep_newton_schulz_returns_to_expert_sharding():
@@ -161,3 +294,267 @@ def test_ep_padded_newton_schulz_returns_to_parameter_sharding():
         output = jax.eval_shape(apply_ns, x)
 
     assert output.sharding == parameter_sharding
+
+
+def test_eval_every_adds_the_held_out_suites_as_dependencies():
+    # Held-out sets are what make a run scoreable; a throughput-only run should not pay for them.
+    off = launch.build_hero_run(run_id="eval-off", dp_racks=1, num_steps=1, version="dev")
+    on = launch.build_hero_run(run_id="eval-on", dp_racks=1, num_steps=1, eval_every=50, version="dev")
+    off_config = off.build_config(StepContext.for_fingerprint(off.runtime_args, off.deps))
+    on_config = on.build_config(StepContext.for_fingerprint(on.runtime_args, on.deps))
+
+    assert len(off.deps) == 1
+    assert len(on.deps) > len(off.deps)
+    assert off_config.eval is None
+    assert on_config.eval is not None
+    assert on_config.eval.steps_per_eval == 50
+
+
+def test_hybrid_kv_branches_agree_on_sharding_when_model_axis_is_wide():
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cpu"
+    env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+    script = """
+        import math
+
+        import jax
+        import jax.numpy as jnp
+        import numpy as np
+        from jax.sharding import AxisType, Mesh, set_mesh
+
+        from experiments.grug.moe_hero_ep import model
+
+        mesh = Mesh(
+            np.asarray(jax.devices()).reshape(1, 1, 2, 2),
+            ("replica_dcn", "data", "expert", "model"),
+            axis_types=(AxisType.Explicit,) * 4,
+        )
+        cfg = model.GrugModelConfig(
+            vocab_size=128,
+            hidden_dim=32,
+            intermediate_dim=16,
+            shared_expert_intermediate_dim=16,
+            num_shared_experts=1,
+            num_experts=4,
+            num_experts_per_token=1,
+            num_layers=1,
+            num_heads=4,
+            num_kv_heads=2,
+            local_kv_heads=2,
+            global_kv_heads=1,
+            head_dim=8,
+            max_seq_len=8,
+            sliding_window=4,
+            global_every=2,
+            capacity_factor=1.0,
+            initializer_std=0.5 / math.sqrt(32),
+            qk_mult=1.3,
+            attention_implementation="reference",
+            moe_implementation="fixed_all_to_all",
+            report_capacity_overflow=True,
+        )
+        tokens = jax.ShapeDtypeStruct((2, 8), jnp.int32)
+        with set_mesh(mesh):
+            output = jax.eval_shape(
+                lambda token_ids: model.Transformer.init(cfg, key=jax.random.key(0))(token_ids)[0],
+                tokens,
+            )
+        assert output.shape == (2, 8, 32)
+    """
+
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def _explicit_mesh(*axis_sizes):
+    return Mesh(
+        np.asarray(jax.devices()).reshape(*axis_sizes),
+        ("replica_dcn", "data", "expert", "model"),
+        axis_types=(AxisType.Explicit,) * 4,
+    )
+
+
+def _latent_config(latent_dim=None):
+    return model.GrugModelConfig(
+        vocab_size=128,
+        hidden_dim=32,
+        intermediate_dim=16,
+        shared_expert_intermediate_dim=16,
+        num_shared_experts=1,
+        num_experts=4,
+        num_experts_per_token=1,
+        latent_dim=latent_dim,
+        num_layers=1,
+        num_heads=4,
+        num_kv_heads=2,
+        local_kv_heads=2,
+        global_kv_heads=2,
+        head_dim=8,
+        max_seq_len=8,
+        sliding_window=4,
+        global_every=2,
+        capacity_factor=1.0,
+        initializer_std=0.5 / math.sqrt(32),
+        qk_mult=1.3,
+        attention_implementation="reference",
+        moe_implementation="fixed_all_to_all",
+        report_capacity_overflow=True,
+    )
+
+
+def test_latent_moe_shrinks_the_dispatched_width_but_not_the_token():
+    # The point of LatentMoE is that the all-to-all payload narrows while the residual stream does
+    # not, so the expert weights must be latent-wide and the layer output hidden-wide.
+    mesh = _explicit_mesh(1, 1, 1, 1)
+    cfg = _latent_config(latent_dim=16)
+    tokens = jax.ShapeDtypeStruct((1, 8), jnp.int32)
+    with set_mesh(mesh):
+        built = jax.eval_shape(lambda: model.MoEMLP.init(cfg, key=jax.random.key(0)))
+        out = jax.eval_shape(lambda t: model.Transformer.init(cfg, key=jax.random.key(0))(t)[0], tokens)
+
+    assert built.w_latent_down.shape == (cfg.hidden_dim, 16)
+    # Normalizing the latent keeps the expert input at unit scale despite the down-projection.
+    assert built.latent_norm.weight.shape == (16,)
+    assert built.w_latent_up.shape == (16, cfg.hidden_dim)
+    # Expert banks are latent-wide: this is what narrows the dispatch.
+    assert built.expert_mlp.w_gate.shape[1] == 16
+    assert built.expert_mlp.w_up.shape[1] == 16
+    assert built.expert_mlp.w_down.shape[2] == 16
+    # The residual stream is untouched.
+    assert out.shape[-1] == cfg.hidden_dim
+
+
+def test_latent_moe_is_absent_by_default():
+    # A config without a latent width must keep the standard MoE layer.
+    mesh = _explicit_mesh(1, 1, 1, 1)
+    cfg = _latent_config(latent_dim=None)
+    with set_mesh(mesh):
+        built = jax.eval_shape(lambda: model.MoEMLP.init(cfg, key=jax.random.key(0)))
+    assert built.w_latent_down is None and built.w_latent_up is None
+    assert built.latent_norm is None
+    assert built.expert_mlp.w_gate.shape[1] == cfg.hidden_dim
+
+
+def test_latent_dim_above_hidden_is_rejected():
+    # A latent wider than the hidden dim adds communication instead of removing it.
+    with pytest.raises(ValueError, match="latent_dim must be in"):
+        _latent_config(latent_dim=99999)
+
+
+def test_latent_moe_flops_replace_routed_width_and_add_projections():
+    latent_dim = 16
+    full_width_config = _latent_config(latent_dim=None)
+    latent_config = _latent_config(latent_dim=latent_dim)
+    full_width_flops, _ = train._compute_flops(model_config=full_width_config)
+    latent_flops, _ = train._compute_flops(model_config=latent_config)
+
+    routed_delta = (
+        2
+        * 3
+        * latent_config.intermediate_dim
+        * latent_config.num_experts_per_token
+        * (latent_dim - latent_config.hidden_dim)
+    )
+    projection_flops = 2 * 2 * latent_config.hidden_dim * latent_dim
+    expected_delta = 3 * latent_config.max_seq_len * latent_config.num_layers * (routed_delta + projection_flops)
+
+    assert latent_flops - full_width_flops == expected_delta
+
+
+class _TinyWatchModel(eqx.Module):
+    weight: jax.Array
+
+    def next_token_loss(
+        self,
+        tokens,
+        loss_weight,
+        *,
+        mask,
+        reduction,
+        logsumexp_weight,
+        return_router_metrics,
+    ):
+        del mask, reduction, logsumexp_weight, return_router_metrics
+        error = self.weight * tokens.astype(self.weight.dtype) - loss_weight
+        return jnp.mean(error**2), {}
+
+
+def test_diagnostic_watch_stats_match_direct_gradient_and_parameter_norms():
+    params = _TinyWatchModel(weight=jnp.array(2.0))
+    batch = SimpleNamespace(
+        tokens=jnp.array([1, 3], dtype=jnp.int32),
+        loss_weight=jnp.array([0.5, 1.0]),
+        attn_mask=None,
+    )
+    mp = jmp.get_policy("params=float32,compute=float32,output=float32")
+    watch = WatchConfig(interval=1)
+
+    actual = train._compute_diagnostic_watch_stats(params, batch, mp, None, watch)
+    grads = jax.grad(
+        lambda model: model.next_token_loss(
+            batch.tokens,
+            batch.loss_weight,
+            mask=batch.attn_mask,
+            reduction="mean",
+            logsumexp_weight=None,
+            return_router_metrics=True,
+        )[0]
+    )(params)
+    expected = compute_watch_stats(
+        watch_targets=watch.watch_targets,
+        include_norms=watch.include_norms,
+        include_per_parameter_norms=watch.include_per_parameter_norms,
+        include_histogram=watch.include_histograms,
+        split_scan_layers=watch.split_scan_layers,
+        params=params,
+        grads=grads,
+        model_tree_type=type(params),
+    )
+
+    assert actual.keys() == expected.keys()
+    for key in actual:
+        np.testing.assert_allclose(actual[key], expected[key])
+
+
+def test_inline_watch_computes_stats_on_every_train_step(monkeypatch):
+    params = _TinyWatchModel(weight=jnp.array(2.0))
+    optimizer = optax.sgd(0.1)
+    state = train.GrugTrainState(
+        step=jnp.array(0, dtype=jnp.int32),
+        params=params,
+        opt_state=optimizer.init(params),
+        ema_params=None,
+        pending_qb_betas=jnp.zeros((1, 1)),
+    )
+
+    def loss_and_grads(current_params, batch, mp, z_loss):
+        del batch, mp, z_loss
+        loss = current_params.weight**2
+        grads = _TinyWatchModel(weight=2 * current_params.weight)
+        metrics = {"qb_beta_per_layer": jnp.zeros((1, 1))}
+        return (loss, metrics), grads
+
+    monkeypatch.setattr(train, "_apply_qb_betas", lambda model, qb_betas: model)
+    monkeypatch.setattr(train, "_loss_and_grads", loss_and_grads)
+    train_step = train._make_train_step(
+        optimizer,
+        jmp.get_policy("params=float32,compute=float32,output=float32"),
+        z_loss_weight=0,
+        ema_beta=None,
+        watch_config=WatchConfig(interval=10),
+    )
+
+    state, _, step_zero_stats = train_step(state, jnp.array(0))
+    state, _, step_one_stats = train_step(state, jnp.array(0))
+
+    assert step_zero_stats is not None
+    assert step_one_stats is not None
+    np.testing.assert_allclose(step_zero_stats["grad/norm/total"], 4.0)
+    np.testing.assert_allclose(step_one_stats["grad/norm/total"], 3.2)

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -442,6 +442,37 @@ def test_latent_moe_is_absent_by_default():
     assert built.expert_mlp.w_gate.shape[1] == cfg.hidden_dim
 
 
+def test_latent_moe_hf_config_roundtrip_preserves_the_architecture():
+    cfg = _latent_config(latent_dim=16)
+
+    hf_config = cfg.to_hf_config(cfg.vocab_size)
+    roundtripped = model.GrugModelConfig.from_hf_config(hf_config)
+
+    assert hf_config.to_dict()["latent_dim"] == 16
+    assert hf_config.to_dict()[model.GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY] == 2
+    assert roundtripped.latent_dim == 16
+
+
+def test_latent_moe_state_dict_contains_the_projection_state():
+    mesh = _explicit_mesh(1, 1, 1, 1)
+    cfg = _latent_config(latent_dim=16)
+    with set_mesh(mesh):
+        built = model.Transformer.init(cfg, key=jax.random.key(0))
+        state_dict = built.to_state_dict()
+    block = next(iter(built.stacked_blocks.unstacked()))
+    assert block.mlp.w_latent_down is not None
+    assert block.mlp.latent_norm is not None
+    assert block.mlp.w_latent_up is not None
+
+    expected = {
+        "model.layers.0.mlp.latent_down_proj.weight": jnp.swapaxes(block.mlp.w_latent_down, -1, -2),
+        "model.layers.0.mlp.latent_norm.weight": block.mlp.latent_norm.weight,
+        "model.layers.0.mlp.latent_up_proj.weight": jnp.swapaxes(block.mlp.w_latent_up, -1, -2),
+    }
+    for name, value in expected.items():
+        np.testing.assert_array_equal(state_dict[name], value)
+
+
 def test_latent_dim_above_hidden_is_rejected():
     # A latent wider than the hidden dim adds communication instead of removing it.
     with pytest.raises(ValueError, match="latent_dim must be in"):


### PR DESCRIPTION
* part of #7279
* extract the EP-only LatentMoE model and launcher from #8013 onto the EP64 hero from #7908
* keep the selected d6144, 48-layer, E192, i6272, latent3072, top-4 shape with capacity factor 1.33
* keep `fixed_all_to_all` as the default and expose `ragged_all_to_all` as `ep-ragged`
* leave the FSDP launchers and the comparison harness in #8013
  * see #7981 for the prior same-shape EP/FSDP result
* carry the evaluation PGLE guard and hybrid GQA sharding fix that the EP path needs
* record the five-step capacity factor 1.33 gate and the 200-step capacity factor 1.30 result
  * last-50 mean: 262,683 tokens/s, 3.9642% drops, and 3.2417 loss
* keep checkpoint writes disabled by default because pinned-host optimizer restores fail with a memory-kind mismatch
* write LatentMoE HF artifacts under schema 2 with `latent_dim` and the latent down-projection, norm, and up-projection tensors
* exclude diagnostic watch passes from train-step throughput timing
