### PR TITLE
[grug] Shuffle tagged eval for capacity-limited MoE

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -49,7 +49,6 @@ from levanter.tracker.histogram import Histogram, SummaryStats
 from levanter.utils.activation import ActivationFunctionEnum
 from transformers import PretrainedConfig as HfConfig
 
-_DEFAULT_EP_CAPACITY_FACTOR = 1.0
 _GATED_NORM_RANK = 128
 _ROUTING_RENORM_SUM = 2.5
 GRUG_MOE_MODEL_TYPE = "grug_moe"
@@ -138,6 +137,7 @@ class GrugModelConfig:
     still apply half-RoPE. Set to False to keep RoPE on long layers."""
     attention_implementation: GrugAttentionImplementation | None = None
     moe_implementation: MoeImplementation | None = None
+    capacity_factor: float = 1.0
     remat_mode: RematMode = "recompute_all"
     """Per-block gradient checkpointing. "recompute_all" reruns the whole block in
     backward (lowest memory); "save_moe" keeps the tagged MoE dispatch tensors so
@@ -160,6 +160,8 @@ class GrugModelConfig:
             raise ValueError("num_experts_per_token must be <= num_experts")
         if self.shared_expert_intermediate_dim < 0:
             raise ValueError("shared_expert_intermediate_dim must be non-negative")
+        if self.capacity_factor <= 0:
+            raise ValueError("capacity_factor must be positive")
         resolve_moe_implementation(self.moe_implementation)
 
     @property
@@ -559,7 +561,7 @@ class MoEMLP(eqx.Module):
                 key=k_expert,
                 implementation=cfg.moe_implementation,
                 activation=ActivationFunctionEnum.silu,
-                capacity_factor=_DEFAULT_EP_CAPACITY_FACTOR,
+                capacity_factor=cfg.capacity_factor,
             ),
             cfg=cfg,
         )

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -83,6 +83,7 @@ class GrugEvalConfig:
     eval_current: bool = True
     eval_ema: bool = True
     compute_bpb: bool = True
+    shuffle: bool = True  # Mix eval domains within batches to reduce expert-capacity drops.
 
 
 @dataclass(frozen=True)
@@ -193,6 +194,7 @@ def build_tagged_evaluator(
         device_mesh=mesh,
         axis_mapping=eval_axis_mapping,
         max_examples_per_dataset=max_examples_per_dataset,
+        shuffle=eval_cfg.shuffle,
     )
 
 

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -45,6 +45,7 @@ from levanter.utils.tree_utils import inference_mode
 
 
 logger = logging.getLogger(__name__)
+_TAGGED_EVAL_SHUFFLE_SEED = 0
 
 
 T = TypeVar("T")
@@ -516,13 +517,18 @@ class TaggedEvaluator(Generic[Ex, M]):
         device_mesh=None,
         axis_mapping=None,
         max_examples_per_dataset=None,
+        shuffle: bool = False,
     ):
         if isinstance(EvalBatch, int):
             EvalBatch = hax.Axis("batch", EvalBatch)
         self.loss_fn = loss_fn
         self.dataset = DomainTaggedDataset(tagged_eval_sets, max_examples_per_dataset)
+        loader_dataset = self.dataset.as_async_dataset()
+        if shuffle:
+            # Keep evaluation order reproducible across hosts and repeated evaluations.
+            loader_dataset = loader_dataset.shuffle(jax.random.PRNGKey(_TAGGED_EVAL_SHUFFLE_SEED))
         self.loader = DataLoader(
-            self.dataset.as_async_dataset(),
+            loader_dataset,
             EvalBatch,
             max_buffered_batches=100,
             mesh=device_mesh,

--- a/lib/levanter/tests/test_eval.py
+++ b/lib/levanter/tests/test_eval.py
@@ -9,6 +9,7 @@ import haliax as hax
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from haliax import Axis
 from haliax.partitioning import ResourceAxis
 from jax._src import config as jax_config
@@ -38,6 +39,49 @@ from levanter.utils.tree_utils import inference_mode
 
 from test_lm_model_loss import ToyLmConfig, ToyLmHeadModel
 from test_utils import use_test_mesh
+
+
+@pytest.mark.asyncio
+async def test_tagged_evaluator_shuffle_reorders_combined_dataset_and_preserves_tags():
+    EvalBatch = Axis("batch", max(1, len(jax.devices())))
+    first_dataset = ListAsyncDataset([jnp.array([i], dtype=jnp.int32) for i in range(8)])
+    second_dataset = ListAsyncDataset([jnp.array([100 + i], dtype=jnp.int32) for i in range(8)])
+    tagged_eval_sets = [(first_dataset, ["first"]), (second_dataset, ["second"])]
+
+    def loss_fn(_model, batch) -> LossFnOutput:
+        weights = jnp.ones_like(batch, dtype=jnp.float32)
+        return batch.astype(jnp.float32), weights, batch
+
+    with use_test_mesh(tensor_parallelism=1) as mesh:
+        ordered_evaluator = TaggedEvaluator(
+            EvalBatch=EvalBatch,
+            tagged_eval_sets=tagged_eval_sets,
+            loss_fn=loss_fn,
+            device_mesh=mesh,
+            axis_mapping={EvalBatch.name: ResourceAxis.DATA},
+            shuffle=False,
+        )
+        shuffled_evaluator = TaggedEvaluator(
+            EvalBatch=EvalBatch,
+            tagged_eval_sets=tagged_eval_sets,
+            loss_fn=loss_fn,
+            device_mesh=mesh,
+            axis_mapping={EvalBatch.name: ResourceAxis.DATA},
+            shuffle=True,
+        )
+
+    indices = list(range(16))
+    ordered = await ordered_evaluator.loader.data_store.get_batch(indices)
+    shuffled = await shuffled_evaluator.loader.data_store.get_batch(indices)
+    ordered_examples = [int(example.item()) for example, _ in ordered]
+    shuffled_examples = [int(example.item()) for example, _ in shuffled]
+
+    assert ordered_examples == list(range(8)) + list(range(100, 108))
+    assert shuffled_examples != ordered_examples
+    assert sorted(shuffled_examples) == sorted(ordered_examples)
+    for example, tags in shuffled:
+        expected_tags = [1, 0] if example.item() < 100 else [0, 1]
+        assert tags.tolist() == expected_tags
 
 
 def test_tagged_evaluator_accepts_grug_lm_examples():

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -335,6 +335,45 @@ def test_grug_moe_data_loaders_build_against_single_expert_mesh():
     assert loader is not None
 
 
+@pytest.mark.asyncio
+async def test_grug_moe_tagged_evaluator_shuffles_by_default():
+    train_module = importlib.import_module("experiments.grug.moe.train")
+    compact_grug_mesh = importlib.import_module("levanter.grug.sharding").compact_grug_mesh
+
+    examples = [
+        GrugLmExample(
+            tokens=jnp.array([i, 0, 0, 0], dtype=jnp.int32),
+            loss_weight=jnp.ones((4,), dtype=jnp.float32),
+            attn_mask=GrugAttentionMask.causal(),
+        )
+        for i in range(16)
+    ]
+    data_config = LmDataConfig(
+        tokenizer="passthrough",
+        vocab_size=256,
+        components={"eval": DirectDatasetComponent(datasets={"validation": ListAsyncDataset(examples)})},
+    )
+    eval_config = train_module.GrugEvalConfig(
+        eval_batch_size=max(1, len(jax.devices())),
+        compute_bpb=False,
+    )
+    mesh = compact_grug_mesh(expert_axis_size=1, replica_axis_size=1)
+
+    evaluator = train_module.build_tagged_evaluator(
+        data_config=data_config,
+        max_seq_len=4,
+        mesh=mesh,
+        eval_cfg=eval_config,
+    )
+    assert evaluator is not None
+
+    loaded = await evaluator.loader.data_store.get_batch(list(range(len(examples))))
+    loaded_ids = [int(example.tokens.array[0].item()) for example, _ in loaded]
+
+    assert loaded_ids != list(range(len(examples)))
+    assert sorted(loaded_ids) == list(range(len(examples)))
+
+
 def test_grug_moe_model_init_against_single_expert_mesh():
     """Regression: MoEMLP.init must build when the compact mesh's expert axis has size 1.
 


### PR DESCRIPTION
Allow `TaggedEvaluator` callers to deterministically shuffle the combined tagged dataset while preserving ordered evaluation as the generic default. Grug MoE enables shuffling by default and exposes the expert capacity factor so eval capacity can be configured independently.

On v5p-8 EP4, shuffling recovered 0.0605 eval loss at fixed all-to-all capacity 1.1. Ring-capacity-4 ordered and shuffled losses agreed within 3.86e-5 across 29 metrics. The linked experiment records the six runs and the conclusion that dropless eval is the canonical training-budget metric.

Fixes #8134
