### PR TITLE
[eval] Advance Harbor config release

### DIFF
--- a/config/external/harbor/uv.lock
+++ b/config/external/harbor/uv.lock
@@ -781,7 +781,7 @@ wheels = [
 [[package]]
 name = "harbor"
 version = "0.8.1"
-source = { git = "https://github.com/marin-community/harbor.git?branch=main#14777c013bee9d75821bc19dd2f35824bc9f3e96" }
+source = { git = "https://github.com/marin-community/harbor.git?branch=main#24e5e67ac93d21c1a2202d6906f6093e0a57b86c" }
 dependencies = [
     { name = "dirhash" },
     { name = "fastapi" },

--- a/lib/marin/src/marin/external_dependencies.py
+++ b/lib/marin/src/marin/external_dependencies.py
@@ -66,7 +66,7 @@ HARBOR = ExternalDependency(
     distribution="harbor",
     repository="https://github.com/marin-community/harbor.git",
     version="0.8.1",
-    commit="14777c013bee9d75821bc19dd2f35824bc9f3e96",
+    commit="24e5e67ac93d21c1a2202d6906f6093e0a57b86c",
     runtime_requirements=("daytona==0.200.2", "gcsfs==2026.7.0", "pydantic-settings==2.14.2", "s3fs==2026.7.0"),
 )
 


### PR DESCRIPTION
Advance the isolated Harbor runtime from `14777c01` to `24e5e67a`. This keeps
Marin agentic evaluation launches on Harbor's synchronized `harbor-config`
release instead of the preceding main snapshot.
