### PR TITLE
[grug] small-scale ablation: match the hero (192 experts, top-k QB)

### DIFF
--- a/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
+++ b/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
@@ -190,7 +190,7 @@ def _small_model(
 
     Every routing/MoE/attention-kernel field is kept from the d6144 hero shape; only the width,
     depth, head split, and intermediate width shrink. ``fixed_all_to_all`` is the EP MoE backend, so
-    ``num_experts`` (128) still divides the EP64 expert axis.
+    ``num_experts`` (192, the hero bank) still divides the EP64 expert axis.
     """
     return GrugModelConfig(
         vocab_size=128_256,
@@ -259,7 +259,7 @@ def build_small_run(
     capacity_factor: float = 1.33,
     seq_len: int = SEQ_LEN,
     tokens_per_step: int = TOKENS_PER_STEP,
-    num_experts: int = 128,
+    num_experts: int = 192,
     num_experts_per_token: int = 4,
     intermediate_dim: int | None = None,
     latent_dim: int | None = None,
@@ -499,7 +499,7 @@ def build_small_run(
     show_default=True,
     help="Fixed all-to-all capacity factor (EP hero arm is 1.33). Higher drops fewer and pads more.",
 )
-@click.option("--num-experts", type=click.IntRange(min=1), default=128, help="Routed expert count.")
+@click.option("--num-experts", type=click.IntRange(min=1), default=192, help="Routed expert count (hero bank).")
 @click.option("--num-experts-per-token", type=click.IntRange(min=1), default=4, help="Routed experts per token.")
 @click.option(
     "--intermediate-dim",

--- a/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
+++ b/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
@@ -263,7 +263,7 @@ def build_small_run(
     num_experts_per_token: int = 4,
     intermediate_dim: int | None = None,
     latent_dim: int | None = None,
-    qb_use_histogram: bool = True,
+    qb_use_histogram: bool = False,
     qb_hist_bins: int = 1000,
     tokens_per_active_param: int = 750,
     num_train_steps_override: int | None = None,
@@ -515,9 +515,9 @@ def build_small_run(
 )
 @click.option(
     "--qb-histogram/--no-qb-histogram",
-    default=True,
+    default=False,
     show_default=True,
-    help="Estimate the QB quantile with the histogram estimator (EP hero arm) instead of top-k mean.",
+    help="Estimate the QB quantile with the histogram estimator instead of the top-k mean (the hero default).",
 )
 @click.option(
     "--qb-hist-bins",

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -362,15 +362,15 @@ def test_ep_ablation_defaults_match_the_documented_arm_and_scale_per_rack():
     one = abl.build_small_run(run_id="d768", size="d768", flavor="ep", version="dev")
     cfg = one.build_config(StepContext.for_fingerprint(one.runtime_args, one.deps))
     m = cfg.model
-    # The EP rung reproduces the documented latent/histogram/1.33 arm from issue #8062.
+    # The EP rung is a downsized hero: latent = hidden/2, capacity 1.33, top-k QB (the hero default).
     assert m.latent_dim == m.hidden_dim // 2
     assert m.capacity_factor == 1.33
-    assert m.qb_estimator == model.QbEstimator.HIST
+    assert m.qb_estimator == model.QbEstimator.TOPK
     assert m.num_layers % 2 == 0  # even depth applied in the launcher, not GrugModelConfig
-    # Histogram QB is selectable off through the builder.
-    topk = abl.build_small_run(run_id="d768-topk", size="d768", flavor="ep", qb_use_histogram=False, version="dev")
-    assert topk.build_config(StepContext.for_fingerprint(topk.runtime_args, topk.deps)).model.qb_estimator == (
-        model.QbEstimator.TOPK
+    # The histogram QB estimator is selectable on through the builder.
+    hist = abl.build_small_run(run_id="d768-hist", size="d768", flavor="ep", qb_use_histogram=True, version="dev")
+    assert hist.build_config(StepContext.for_fingerprint(hist.runtime_args, hist.deps)).model.qb_estimator == (
+        model.QbEstimator.HIST
     )
     # The global batch scales with the rack count, holding the per-rack token load constant.
     four = abl.build_small_run(run_id="d2048", size="d2048", flavor="ep", dp_racks=4, version="dev")


### PR DESCRIPTION
The small-scale ablation launcher diverged from the hero on two fields, making each rung a different model than the one it is meant to downsize:

- **Expert bank**: defaulted to 128 routed experts while the hero (and the issue #8062 ladder sweep) use 192 — a third fewer experts, so less total capacity. It showed up as a loss gap: d768 dropless Paloma macro was 3.052 vs the sweep's 3.033.
- **QB estimator**: defaulted to the histogram estimator while the hero uses the top-k mean.

Default both to the hero values — `--num-experts 192` (still divides the EP64 expert axis) and top-k QB — so the ablation is a faithful downsized hero on every field (latent = hidden/2, capacity 1.33, sliding window 2048, hidden-wide intermediate, top-4). The histogram estimator stays available via `--qb-histogram`.

Eval cadence is unchanged — the launcher already defaults to every 1000 steps.
