### PR TITLE
[xprof] Open hosted profiles in Trace Viewer

### DIFF
--- a/infra/xprof/gateway.py
+++ b/infra/xprof/gateway.py
@@ -285,7 +285,9 @@ class XprofGateway:
         if environ.get("REQUEST_METHOD", "GET") != "GET":
             return _response(start_response, "405 Method Not Allowed", b"GET required\n", "text/plain")
 
-        uri = parse_qs(environ.get("QUERY_STRING", "")).get("uri", [""])[0]
+        query = parse_qs(environ.get("QUERY_STRING", ""))
+        uri = query.get("uri", [""])[0]
+        tool = query.get("tool", [""])[0]
         if not uri:
             return _response(start_response, "400 Bad Request", b"missing uri query parameter\n", "text/plain")
         try:
@@ -295,7 +297,9 @@ class XprofGateway:
 
         future = self._profiles.future(normalized_uri)
         if not future.done():
-            return _response(start_response, "202 Accepted", _loading_page(normalized_uri), "text/html; charset=utf-8")
+            return _response(
+                start_response, "202 Accepted", _loading_page(normalized_uri, tool), "text/html; charset=utf-8"
+            )
         try:
             local_path = future.result()
         except Exception as exc:
@@ -305,12 +309,14 @@ class XprofGateway:
                 start_response, "502 Bad Gateway", f"profile staging failed: {exc}\n".encode(), "text/plain"
             )
 
-        location = f"./?{urlencode({'run_path': str(local_path)})}"
+        location = _xprof_location(local_path, tool)
         start_response("303 See Other", [("Location", location), ("Content-Length", "0")])
         return [b""]
 
     def _progress(self, environ: dict, start_response: StartResponse) -> Iterable[bytes]:
-        uri = parse_qs(environ.get("QUERY_STRING", "")).get("uri", [""])[0]
+        query = parse_qs(environ.get("QUERY_STRING", ""))
+        uri = query.get("uri", [""])[0]
+        tool = query.get("tool", [""])[0]
         try:
             normalized_uri = self._profiles.validate(uri)
         except ProfileSourceError as exc:
@@ -326,7 +332,7 @@ class XprofGateway:
             return _json_response(
                 start_response,
                 "200 OK",
-                {"state": "ready", "location": f"./?{urlencode({'run_path': str(local_path)})}"},
+                {"state": "ready", "location": _xprof_location(local_path, tool)},
             )
         if progress is None:
             return _json_response(start_response, "200 OK", {"state": "starting"})
@@ -389,9 +395,19 @@ def _json_response(start_response: StartResponse, status: str, value: dict) -> l
     return _response(start_response, status, json.dumps(value).encode(), "application/json")
 
 
-def _loading_page(uri: str) -> bytes:
+def _xprof_location(run_path: Path, tool: str) -> str:
+    params = {"run_path": str(run_path)}
+    if tool:
+        params["tool"] = tool
+    return f"./?{urlencode(params)}"
+
+
+def _loading_page(uri: str, tool: str) -> bytes:
     safe_uri = html.escape(uri)
-    progress_url = f"./progress?{urlencode({'uri': uri})}"
+    params = {"uri": uri}
+    if tool:
+        params["tool"] = tool
+    progress_url = f"./progress?{urlencode(params)}"
     return f"""<!doctype html>
 <html><head><meta charset="utf-8"><title>Loading XProf profile</title>
 <style>

--- a/infra/xprof/gateway.py
+++ b/infra/xprof/gateway.py
@@ -32,6 +32,7 @@ _SOURCE_MARKER = ".xprof-source"
 _REWRITE_SUFFIXES = (".html", ".js")
 _XPROF_RUN_PATH = ("plugins", "profile")
 _XPROF_TTL_SEGMENT = re.compile(r"ttl=[1-9]\d*d")
+_TOOL_QUERY_PARAMETER = "tool"
 
 StartResponse = Callable[[str, list[tuple[str, str]]], Callable[[bytes], object] | None]
 WsgiApplication = Callable[[dict, StartResponse], Iterable[bytes]]
@@ -287,7 +288,7 @@ class XprofGateway:
 
         query = parse_qs(environ.get("QUERY_STRING", ""))
         uri = query.get("uri", [""])[0]
-        tool = query.get("tool", [""])[0]
+        tool = query.get(_TOOL_QUERY_PARAMETER, [""])[0]
         if not uri:
             return _response(start_response, "400 Bad Request", b"missing uri query parameter\n", "text/plain")
         try:
@@ -316,7 +317,7 @@ class XprofGateway:
     def _progress(self, environ: dict, start_response: StartResponse) -> Iterable[bytes]:
         query = parse_qs(environ.get("QUERY_STRING", ""))
         uri = query.get("uri", [""])[0]
-        tool = query.get("tool", [""])[0]
+        tool = query.get(_TOOL_QUERY_PARAMETER, [""])[0]
         try:
             normalized_uri = self._profiles.validate(uri)
         except ProfileSourceError as exc:
@@ -398,7 +399,7 @@ def _json_response(start_response: StartResponse, status: str, value: dict) -> l
 def _xprof_location(run_path: Path, tool: str) -> str:
     params = {"run_path": str(run_path)}
     if tool:
-        params["tool"] = tool
+        params[_TOOL_QUERY_PARAMETER] = tool
     return f"./?{urlencode(params)}"
 
 
@@ -406,7 +407,7 @@ def _loading_page(uri: str, tool: str) -> bytes:
     safe_uri = html.escape(uri)
     params = {"uri": uri}
     if tool:
-        params["tool"] = tool
+        params[_TOOL_QUERY_PARAMETER] = tool
     progress_url = f"./progress?{urlencode(params)}"
     return f"""<!doctype html>
 <html><head><meta charset="utf-8"><title>Loading XProf profile</title>

--- a/lib/levanter/src/levanter/callbacks/profiler.py
+++ b/lib/levanter/src/levanter/callbacks/profiler.py
@@ -28,7 +28,7 @@ _XPROF_TTL_SEGMENT = re.compile(r"ttl=[1-9]\d*d")
 
 def xprof_viewer_url(service_url: str, profile_uri: str) -> str:
     """Return the hosted XProf URL for an uploaded profile root."""
-    return f"{service_url.rstrip('/')}/open?{urlencode({'uri': profile_uri})}"
+    return f"{service_url.rstrip('/')}/open?{urlencode({'uri': profile_uri, 'tool': 'trace_viewer'})}"
 
 
 @dataclass(frozen=True)

--- a/lib/levanter/tests/test_profiler.py
+++ b/lib/levanter/tests/test_profiler.py
@@ -93,7 +93,10 @@ def test_profile_uploads_new_xplane_session_and_logs_viewer_link(monkeypatch, tm
     link_record = next(record for record in caplog.records if record.message.startswith("XProf profile:"))
     link = link_record.message.removeprefix("XProf profile: ")
     assert urlparse(link).path == "/proxy/xprof/open"
-    assert parse_qs(urlparse(link).query) == {"uri": [f"file://{upload_dir}"]}
+    assert parse_qs(urlparse(link).query) == {
+        "uri": [f"file://{upload_dir}"],
+        "tool": ["trace_viewer"],
+    }
 
 
 def test_upload_destination_uses_xprof_ttl_path(monkeypatch):

--- a/tests/infra/xprof/test_gateway.py
+++ b/tests/infra/xprof/test_gateway.py
@@ -120,7 +120,7 @@ def test_open_stages_outside_request_then_redirects_to_proxy_path(tmp_path):
     stager = _BlockingStager(tmp_path / "cached profile")
     manager = ProfileStageManager(stager, max_workers=1)
     app = XprofGateway(_xprof_app, manager, "/proxy/xprof")
-    query = "uri=gs%3A%2F%2Fmarin-us-east5%2Ftmp%2Fttl%3D7d%2Fxprof%2Frun-1"
+    query = "uri=gs%3A%2F%2Fmarin-us-east5%2Ftmp%2Fttl%3D7d%2Fxprof%2Frun-1&tool=trace_viewer"
     try:
         pending = _request(app, "/open", query)
         assert pending["status"] == "202 Accepted"
@@ -139,11 +139,13 @@ def test_open_stages_outside_request_then_redirects_to_proxy_path(tmp_path):
         complete = json.loads(_request(app, "/progress", query)["body"])
         assert complete == {
             "state": "ready",
-            "location": f"./?{urlencode({'run_path': str(stager.local_path)})}",
+            "location": f"./?{urlencode({'run_path': str(stager.local_path), 'tool': 'trace_viewer'})}",
         }
         ready = _request(app, "/open", query)
         assert ready["status"] == "303 See Other"
-        assert ready["headers"]["Location"] == f"./?{urlencode({'run_path': str(stager.local_path)})}"
+        assert ready["headers"]["Location"] == (
+            f"./?{urlencode({'run_path': str(stager.local_path), 'tool': 'trace_viewer'})}"
+        )
     finally:
         app.shutdown()
 


### PR DESCRIPTION
Open logged hosted XProf links in Trace Viewer instead of Overview Page. Keep
the tool selection through profile download and redirect. Thus, the browser
does not start the slow Overview Page request.
