### PR TITLE
[echo] Add search-result feedback

### DIFF
--- a/.agents/skills/consult-echo/SKILL.md
+++ b/.agents/skills/consult-echo/SKILL.md
@@ -42,12 +42,14 @@ submit a compact judgment using the exact query and printed result IDs:
 
 ```bash
 uv run infra/echo/cli.py feedback --query "stalled TPU collective" \
-  --grade wiki:123=0 --grade file:lib/iris/OPS.md=10
+  --grade wiki:123=0 --grade file:lib/iris/OPS.md=10 \
+  <<< "The file result answered the task; wiki results were off-topic."
 ```
 
 Use 0 for an irrelevant result and 10 for one that directly changes or answers the
-task. Grade only results you evaluated. Add a short stdin note only when the grades do
-not explain the failure; note-only feedback is valid for an empty result set.
+task. Grade only results you evaluated. Always add a short stdin explanation of the
+overall result quality without restating each score. Explanation-only feedback is valid
+for an empty result set.
 
 Use `grep` for exact strings in GitHub or Discord activity, with `--source` or
 `--kind` when needed:

--- a/.agents/skills/consult-echo/SKILL.md
+++ b/.agents/skills/consult-echo/SKILL.md
@@ -37,6 +37,18 @@ raw-source detail with the printed ID:
 uv run infra/echo/cli.py get <domain:id>
 ```
 
+When a result materially helps, is irrelevant, or the result set fails the task,
+submit a compact judgment using the exact query and printed result IDs:
+
+```bash
+uv run infra/echo/cli.py feedback --query "stalled TPU collective" \
+  --grade wiki:123=0 --grade file:lib/iris/OPS.md=10
+```
+
+Use 0 for an irrelevant result and 10 for one that directly changes or answers the
+task. Grade only results you evaluated. Add a short stdin note only when the grades do
+not explain the failure; note-only feedback is valid for an empty result set.
+
 Use `grep` for exact strings in GitHub or Discord activity, with `--source` or
 `--kind` when needed:
 

--- a/infra/echo/README.md
+++ b/infra/echo/README.md
@@ -14,6 +14,8 @@ provides an IAP-gated HTTP interface and browser dashboard.
   embeddings, timestamps, attribution, and deliberate-reference counters. Search
   indexes the prose fields and can filter by tags.
 - `work_log` is an append-only agent logbook with one row per distilled milestone.
+- `search_feedback` records the query, IAP-authenticated caller, and optional note for
+  one agent judgment. `search_feedback_grades` stores its result IDs and 0–10 grades.
 
 ## CLI
 
@@ -23,6 +25,10 @@ provides an IAP-gated HTTP interface and browser dashboard.
 uv run infra/echo/cli.py search "expert parallel MoE MFU on B200" --limit 10
 uv run infra/echo/cli.py search "ragged_all_to_all" --domain file --domain pr
 uv run infra/echo/cli.py get file:lib/iris/OPS.md
+uv run infra/echo/cli.py feedback --query "how do I deploy Iris?" \
+  --grade wiki:123=0 --grade file:lib/iris/OPS.md=10 <<'EOF'
+The file result answered the question; the wiki result did not.
+EOF
 uv run infra/echo/cli.py grep ragged_all_to_all --source discord
 uv run infra/echo/cli.py wiki search "grafana access" --tag ops
 uv run infra/echo/cli.py wiki add --file note.md          # OKF markdown document
@@ -92,6 +98,16 @@ Wiki summaries use the `use_when` hint; files and activity use the matching sour
 excerpt. Echo does not generate summaries with an LLM at query time, avoiding added
 latency and an additional prompt-injection path.
 
+`search` reports the number of results and elapsed wall-clock time before its table. The
+measurement covers token acquisition, the network request, server retrieval and
+reranking, and response decoding: the time the caller waited for Echo.
+
+Submit useful or poor results with `feedback`. Repeat `--grade <result-id>=<0-10>` for
+the results you evaluated, where 0 means irrelevant and 10 means directly useful to the
+task. The exact query makes each judgment replayable against a future search version.
+An optional short note is read from stdin; a note-only submission can describe an empty
+or globally poor result set.
+
 The scheduled sync checks GitHub at most once per hour. An unchanged head only advances
 the check time. A new head uses GitHub's compare API to delete, fetch, and re-embed
 changed paths; the first build, a divergent history, or a comparison of at least 300
@@ -139,8 +155,9 @@ A pg_trgm GIN index on chunks.text makes the substring match an index scan.
 Direct SQL access remains available for raw queries through Cloud SQL IAM group
 authentication. Members of `eng-all@openathena.ai` inherit `roles/cloudsql.instanceUser`,
 `roles/cloudsql.client`, `SELECT` on `chunks`, `repository_file_chunks`,
-`repository_index_state`, and `wiki_entries`, and `SELECT, INSERT` on `work_log`; the
-`loom-vm` service account receives the same access. No database password is shared.
+`repository_index_state`, `wiki_entries`, `search_feedback`, and
+`search_feedback_grades`, and `SELECT, INSERT` on `work_log`; the `loom-vm` service
+account receives the same access. No database password is shared.
 Group membership and IAM changes can take about 15 minutes to propagate.
 
 ## Dashboard and HTTP API
@@ -158,6 +175,7 @@ the activity corpus and wiki notes. The same service exposes OpenAPI documentati
 - `GET /api/chunks/{id}`
 - `GET /api/wiki/search`
 - `GET /api/wiki/{id}`
+- `POST /api/feedback`
 - `POST /api/wiki`
 - `PUT /api/wiki/{id}`
 - `POST /api/wiki/{id}/references`
@@ -177,6 +195,10 @@ state on its landing page. `GET /api/search-configuration` supplies the domain c
 defaults, and displayed commit length used by the dashboard. The CLI's `get` command
 uses the existing wiki and activity detail endpoints plus
 `GET /api/repository-files/{path}` for complete indexed files.
+
+`POST /api/feedback` accepts an exact query, up to 20 unique result grades from 0 through
+10, and an optional note of at most 2,000 characters. At least one grade or note is
+required. The API attributes feedback to the IAP-authenticated caller.
 
 The dashboard is a Vue single-page app served from the same origin, with client-side
 routes at `/` (search), `/wiki` (recently updated notes), `/wiki/<id>` (a note), and

--- a/infra/echo/README.md
+++ b/infra/echo/README.md
@@ -14,8 +14,8 @@ provides an IAP-gated HTTP interface and browser dashboard.
   embeddings, timestamps, attribution, and deliberate-reference counters. Search
   indexes the prose fields and can filter by tags.
 - `work_log` is an append-only agent logbook with one row per distilled milestone.
-- `search_feedback` records the query, IAP-authenticated caller, and optional note for
-  one agent judgment. `search_feedback_grades` stores its result IDs and 0–10 grades.
+- `search_feedback` records the query, IAP-authenticated caller, and short overall
+  explanation. `search_feedback_grades` stores its result IDs and 0–10 grades.
 
 ## CLI
 
@@ -105,8 +105,9 @@ reranking, and response decoding: the time the caller waited for Echo.
 Submit useful or poor results with `feedback`. Repeat `--grade <result-id>=<0-10>` for
 the results you evaluated, where 0 means irrelevant and 10 means directly useful to the
 task. The exact query makes each judgment replayable against a future search version.
-An optional short note is read from stdin; a note-only submission can describe an empty
-or globally poor result set.
+A short overall explanation is required on stdin. Capture the result set's gestalt
+without restating each score. An explanation without grades can describe an empty or
+globally poor result set.
 
 The scheduled sync checks GitHub at most once per hour. An unchanged head only advances
 the check time. A new head uses GitHub's compare API to delete, fetch, and re-embed
@@ -197,8 +198,8 @@ uses the existing wiki and activity detail endpoints plus
 `GET /api/repository-files/{path}` for complete indexed files.
 
 `POST /api/feedback` accepts an exact query, up to 20 unique result grades from 0 through
-10, and an optional note of at most 2,000 characters. At least one grade or note is
-required. The API attributes feedback to the IAP-authenticated caller.
+10, and a required overall explanation of at most 2,000 characters. Grades may be empty
+when the search returns no useful results. The API attributes feedback to the IAP-authenticated caller.
 
 The dashboard is a Vue single-page app served from the same origin, with client-side
 routes at `/` (search), `/wiki` (recently updated notes), `/wiki/<id>` (a note), and

--- a/infra/echo/api/Dockerfile
+++ b/infra/echo/api/Dockerfile
@@ -20,6 +20,7 @@ COPY schema.py .
 COPY hybrid_search.py .
 COPY reranking.py .
 COPY search_config.py .
+COPY search_feedback.py .
 COPY api/app.py .
 COPY api/dashboard.py .
 COPY --from=dashboard /build/dist /app/dist

--- a/infra/echo/api/app.py
+++ b/infra/echo/api/app.py
@@ -1,7 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Search Echo activity and wiki notes, and read or append the shared work log.
+"""Search Echo context, collect result feedback, and read or append the shared work log.
 
 See ``infra/echo/README.md`` for endpoints and access requirements.
 """
@@ -13,7 +13,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import PurePosixPath
-from typing import Annotated, Any, Literal, Protocol
+from typing import Annotated, Any, Literal, Protocol, Self
 from urllib.parse import quote
 
 import dashboard as echo_dashboard
@@ -21,12 +21,13 @@ import hybrid_search
 import reranking
 import schema
 import search_config
+import search_feedback
 import sqlalchemy
 from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Query, Request
 from fastembed import TextEmbedding
 from fastembed.rerank.cross_encoder import TextCrossEncoder
 from google.cloud.sql.connector import Connector
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 SOURCES = ("github", "discord")
 KINDS = ("issue", "pr", "comment", "message")
@@ -111,7 +112,7 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(
     title="echo",
-    description="Search Marin activity and wiki notes, and read/append the shared agent work log.",
+    description="Search Marin context, record result feedback, and read or append the shared agent work log.",
     lifespan=lifespan,
 )
 app.state.config = DEFAULT_CONFIG
@@ -203,6 +204,55 @@ class SearchConfiguration(BaseModel):
     domains: list[SearchDomainOption]
     default_domains: list[search_config.SearchDomain]
     display_sha_characters: int
+
+
+class SearchFeedbackGrade(BaseModel):
+    result_id: str = Field(min_length=1, max_length=search_feedback.MAX_RESULT_ID_CHARACTERS)
+    grade: int = Field(ge=0, le=10)
+
+    @field_validator("result_id")
+    @classmethod
+    def validate_result_id(cls, result_id: str) -> str:
+        return search_feedback.checked_result_id(result_id)
+
+
+class SearchFeedbackCreate(BaseModel):
+    query: str = Field(min_length=1, max_length=search_feedback.MAX_QUERY_CHARACTERS)
+    grades: list[SearchFeedbackGrade] = Field(default_factory=list, max_length=search_feedback.MAX_GRADES)
+    note: str | None = Field(None, max_length=search_feedback.MAX_NOTE_CHARACTERS)
+
+    @field_validator("query")
+    @classmethod
+    def normalize_query(cls, query: str) -> str:
+        query = query.strip()
+        if not query:
+            raise ValueError("query must not be blank")
+        return query
+
+    @field_validator("grades")
+    @classmethod
+    def reject_duplicate_results(cls, grades: list[SearchFeedbackGrade]) -> list[SearchFeedbackGrade]:
+        result_ids = [grade.result_id for grade in grades]
+        if len(result_ids) != len(set(result_ids)):
+            raise ValueError("each result may be graded once per feedback submission")
+        return grades
+
+    @field_validator("note")
+    @classmethod
+    def normalize_note(cls, note: str | None) -> str | None:
+        return (note.strip() or None) if note is not None else None
+
+    @model_validator(mode="after")
+    def require_judgment(self) -> Self:
+        if not self.grades and self.note is None:
+            raise ValueError("provide at least one grade or a note")
+        return self
+
+
+class SearchFeedbackEntry(SearchFeedbackCreate):
+    id: int
+    created_at: datetime
+    author: str
 
 
 class RepositoryIndexStatus(BaseModel):
@@ -924,6 +974,44 @@ def add_work_log(
     with engine.begin() as conn:
         row = conn.execute(statement).first()
     return LogEntry(**{c: getattr(row, c) for c in LogEntry.model_fields})
+
+
+@api.post("/feedback", response_model=SearchFeedbackEntry, status_code=201)
+def add_search_feedback(
+    feedback: SearchFeedbackCreate,
+    engine: Engine,
+    x_goog_authenticated_user_email: str | None = Header(None),
+) -> SearchFeedbackEntry:
+    """Store one query's optional note and per-result relevance grades."""
+    statement = (
+        schema.search_feedback.insert()
+        .values(
+            author=iap_caller(x_goog_authenticated_user_email),
+            query=feedback.query,
+            note=feedback.note,
+        )
+        .returning(schema.search_feedback)
+    )
+    with engine.begin() as conn:
+        row = conn.execute(statement).first()
+        assert row is not None
+        if feedback.grades:
+            conn.execute(
+                schema.search_feedback_grades.insert().values(
+                    [
+                        {"feedback_id": row.id, "result_id": grade.result_id, "grade": grade.grade}
+                        for grade in feedback.grades
+                    ]
+                )
+            )
+    return SearchFeedbackEntry(
+        id=row.id,
+        created_at=row.created_at,
+        author=row.author,
+        query=feedback.query,
+        grades=feedback.grades,
+        note=feedback.note,
+    )
 
 
 @api.get("/wiki/search", response_model=list[WikiSummary])

--- a/infra/echo/api/app.py
+++ b/infra/echo/api/app.py
@@ -13,7 +13,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import PurePosixPath
-from typing import Annotated, Any, Literal, Protocol, Self
+from typing import Annotated, Any, Literal, Protocol
 from urllib.parse import quote
 
 import dashboard as echo_dashboard
@@ -27,7 +27,7 @@ from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Query, R
 from fastembed import TextEmbedding
 from fastembed.rerank.cross_encoder import TextCrossEncoder
 from google.cloud.sql.connector import Connector
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator
 
 SOURCES = ("github", "discord")
 KINDS = ("issue", "pr", "comment", "message")
@@ -219,7 +219,7 @@ class SearchFeedbackGrade(BaseModel):
 class SearchFeedbackCreate(BaseModel):
     query: str = Field(min_length=1, max_length=search_feedback.MAX_QUERY_CHARACTERS)
     grades: list[SearchFeedbackGrade] = Field(default_factory=list, max_length=search_feedback.MAX_GRADES)
-    note: str | None = Field(None, max_length=search_feedback.MAX_NOTE_CHARACTERS)
+    note: str = Field(min_length=1, max_length=search_feedback.MAX_NOTE_CHARACTERS)
 
     @field_validator("query")
     @classmethod
@@ -239,14 +239,11 @@ class SearchFeedbackCreate(BaseModel):
 
     @field_validator("note")
     @classmethod
-    def normalize_note(cls, note: str | None) -> str | None:
-        return (note.strip() or None) if note is not None else None
-
-    @model_validator(mode="after")
-    def require_judgment(self) -> Self:
-        if not self.grades and self.note is None:
-            raise ValueError("provide at least one grade or a note")
-        return self
+    def normalize_note(cls, note: str) -> str:
+        note = note.strip()
+        if not note:
+            raise ValueError("note must not be blank")
+        return note
 
 
 class SearchFeedbackEntry(SearchFeedbackCreate):

--- a/infra/echo/api/app.py
+++ b/infra/echo/api/app.py
@@ -208,7 +208,7 @@ class SearchConfiguration(BaseModel):
 
 class SearchFeedbackGrade(BaseModel):
     result_id: str = Field(min_length=1, max_length=search_feedback.MAX_RESULT_ID_CHARACTERS)
-    grade: int = Field(ge=0, le=10)
+    grade: int = Field(ge=search_feedback.MIN_GRADE, le=search_feedback.MAX_GRADE)
 
     @field_validator("result_id")
     @classmethod

--- a/infra/echo/api/test_app.py
+++ b/infra/echo/api/test_app.py
@@ -219,14 +219,29 @@ def test_search_feedback_rejects_out_of_range_grade(client_with):
     harness = client_with([])
     response = harness.client.post(
         "/api/feedback",
-        json={"query": "scheduler", "grades": [{"result_id": "wiki:123", "grade": 11}]},
+        json={
+            "query": "scheduler",
+            "grades": [{"result_id": "wiki:123", "grade": 11}],
+            "note": "The result looked relevant.",
+        },
     )
 
     assert response.status_code == 422
     assert harness.engine.executions == []
 
 
-def test_search_feedback_accepts_note_for_empty_result_set(client_with):
+def test_search_feedback_requires_overall_explanation(client_with):
+    harness = client_with([])
+    response = harness.client.post(
+        "/api/feedback",
+        json={"query": "scheduler", "grades": [{"result_id": "wiki:123", "grade": 5}]},
+    )
+
+    assert response.status_code == 422
+    assert harness.engine.executions == []
+
+
+def test_search_feedback_accepts_explanation_for_empty_result_set(client_with):
     row = make_row(
         id=18,
         created_at=datetime(2026, 8, 11, tzinfo=UTC),

--- a/infra/echo/api/test_app.py
+++ b/infra/echo/api/test_app.py
@@ -166,6 +166,86 @@ def test_add_work_log_attributes_to_iap_caller_not_client(client_with):
     assert resp.json()["author"] == "bob@openathena.ai"
 
 
+def test_add_search_feedback_persists_authenticated_replayable_judgments(client_with):
+    row = make_row(
+        id=17,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        author="agent@openathena.ai",
+        query="how do I deploy Iris?",
+        note="Wiki result was unrelated.",
+    )
+    harness = client_with([row])
+    response = harness.client.post(
+        "/api/feedback",
+        json={
+            "query": "  how do I deploy Iris?  ",
+            "grades": [
+                {"result_id": "wiki:123", "grade": 0},
+                {"result_id": "file:lib/iris/OPS.md", "grade": 10},
+            ],
+            "note": "  Wiki result was unrelated.  ",
+        },
+        headers={"X-Goog-Authenticated-User-Email": "accounts.google.com:agent@openathena.ai"},
+    )
+
+    assert response.status_code == 201
+    assert response.json() == {
+        "id": 17,
+        "created_at": "2026-08-11T00:00:00Z",
+        "author": "agent@openathena.ai",
+        "query": "how do I deploy Iris?",
+        "grades": [
+            {"result_id": "wiki:123", "grade": 0},
+            {"result_id": "file:lib/iris/OPS.md", "grade": 10},
+        ],
+        "note": "Wiki result was unrelated.",
+    }
+    feedback_params = harness.engine.executions[-2].compile().params
+    assert feedback_params["author"] == "agent@openathena.ai"
+    assert feedback_params["query"] == "how do I deploy Iris?"
+    assert feedback_params["note"] == "Wiki result was unrelated."
+    grade_params = harness.engine.executions[-1].compile().params
+    assert grade_params == {
+        "feedback_id_m0": 17,
+        "result_id_m0": "wiki:123",
+        "grade_m0": 0,
+        "feedback_id_m1": 17,
+        "result_id_m1": "file:lib/iris/OPS.md",
+        "grade_m1": 10,
+    }
+
+
+def test_search_feedback_rejects_out_of_range_grade(client_with):
+    harness = client_with([])
+    response = harness.client.post(
+        "/api/feedback",
+        json={"query": "scheduler", "grades": [{"result_id": "wiki:123", "grade": 11}]},
+    )
+
+    assert response.status_code == 422
+    assert harness.engine.executions == []
+
+
+def test_search_feedback_accepts_note_for_empty_result_set(client_with):
+    row = make_row(
+        id=18,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        author="agent@openathena.ai",
+        query="missing scheduler detail",
+        note="No relevant results.",
+    )
+    harness = client_with([row])
+    response = harness.client.post(
+        "/api/feedback",
+        json={"query": "missing scheduler detail", "note": "No relevant results."},
+        headers={"X-Goog-Authenticated-User-Email": "accounts.google.com:agent@openathena.ai"},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["grades"] == []
+    assert response.json()["note"] == "No relevant results."
+
+
 def test_missing_chunk_is_404(client_with):
     harness = client_with([])
     assert harness.client.get("/api/chunks/999").status_code == 404

--- a/infra/echo/cli.py
+++ b/infra/echo/cli.py
@@ -15,6 +15,7 @@ ambient service-account credentials with no login. See ``infra/echo/README.md``.
 
     uv run infra/echo/cli.py search "expert parallel MoE MFU on B200" --limit 10
     uv run infra/echo/cli.py get file:lib/iris/OPS.md
+    uv run infra/echo/cli.py feedback --query "deploy iris" --grade file:lib/iris/OPS.md=10
     uv run infra/echo/cli.py grep ragged_all_to_all --source discord
     uv run infra/echo/cli.py wiki search "grafana access" --tag ops
     uv run infra/echo/cli.py wiki add --file note.md          # OKF: frontmatter title/use_when + body
@@ -25,14 +26,17 @@ ambient service-account credentials with no login. See ``infra/echo/README.md``.
 import argparse
 import logging
 import os
+import shlex
 import shutil
 import sys
+import time
 from pathlib import Path
 from urllib.parse import quote
 
 import okf
 import requests
 import search_config
+import search_feedback
 from rigging.auth import (
     MARIN_DESKTOP_OAUTH_CLIENT,
     IapCredentialsUnavailable,
@@ -195,6 +199,7 @@ def read_body(value: str) -> str:
 
 def cmd_search(args: argparse.Namespace) -> None:
     domains = list(dict.fromkeys(args.domain or DEFAULT_DOMAINS))
+    started_at = time.perf_counter()
     remote_value = response_objects(
         request(
             "GET",
@@ -203,7 +208,42 @@ def cmd_search(args: argparse.Namespace) -> None:
         )
     )
     results = [SearchResult.from_json(result) for result in remote_value]
+    elapsed = time.perf_counter() - started_at
+    noun = "result" if len(results) == 1 else "results"
+    print(f"{len(results)} {noun} in {elapsed:.2f}s")
     print_search_results(results)
+    print("Feedback: uv run infra/echo/cli.py feedback " f"--query {shlex.quote(args.query)} --grade '<id>=<0-10>'")
+
+
+def feedback_grade(value: str) -> search_feedback.FeedbackGrade:
+    try:
+        return search_feedback.FeedbackGrade.from_spec(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+
+
+def feedback_note() -> str | None:
+    if sys.stdin.isatty():
+        return None
+    return sys.stdin.read().strip() or None
+
+
+def cmd_feedback(args: argparse.Namespace) -> None:
+    note = feedback_note()
+    if not args.grade and note is None:
+        raise SystemExit("provide at least one --grade or a note on stdin")
+    entry = response_object(
+        request(
+            "POST",
+            "/feedback",
+            body={
+                "query": args.query,
+                "grades": [{"result_id": grade.result_id, "grade": grade.grade} for grade in args.grade],
+                "note": note,
+            },
+        )
+    )
+    print(f"recorded feedback #{entry['id']}")
 
 
 def cmd_grep(args: argparse.Namespace) -> None:
@@ -316,12 +356,10 @@ def nonblank(value: str) -> str:
 
 
 def artifact_id(value: str) -> str:
-    domain, separator, detail = value.partition(":")
-    if not separator or domain not in DOMAINS or not detail:
-        raise argparse.ArgumentTypeError("must be <wiki|file|discord|pr|issue>:<id>")
-    if domain != "file" and not detail.isdecimal():
-        raise argparse.ArgumentTypeError(f"{domain} result IDs are numeric")
-    return value
+    try:
+        return search_feedback.checked_result_id(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
 
 
 def add_wiki_write_args(parser: argparse.ArgumentParser) -> None:
@@ -352,6 +390,17 @@ def build_parser() -> argparse.ArgumentParser:
     )
     search.add_argument("--limit", type=bounded_limit, default=10)
     search.set_defaults(func=cmd_search)
+    feedback = sub.add_parser("feedback", help="grade federated-search results")
+    feedback.add_argument("--query", required=True, type=nonblank, help="the exact search query")
+    feedback.add_argument(
+        "--grade",
+        action="append",
+        type=feedback_grade,
+        default=[],
+        metavar="<result-id>=<0-10>",
+        help="grade one result; repeat as needed (an optional note is read from stdin)",
+    )
+    feedback.set_defaults(func=cmd_feedback)
 
     grep = sub.add_parser("grep", help="exact substring scan over activity, newest first")
     grep.add_argument("pattern", type=nonblank)

--- a/infra/echo/cli.py
+++ b/infra/echo/cli.py
@@ -212,7 +212,10 @@ def cmd_search(args: argparse.Namespace) -> None:
     noun = "result" if len(results) == 1 else "results"
     print(f"{len(results)} {noun} in {elapsed:.2f}s")
     print_search_results(results)
-    print("Feedback: uv run infra/echo/cli.py feedback " f"--query {shlex.quote(args.query)} --grade '<id>=<0-10>'")
+    print(
+        "Feedback: uv run infra/echo/cli.py feedback "
+        f"--query {shlex.quote(args.query)} --grade '<id>=<{search_feedback.MIN_GRADE}-{search_feedback.MAX_GRADE}>'"
+    )
 
 
 def feedback_grade(value: str) -> search_feedback.FeedbackGrade:
@@ -397,7 +400,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         type=feedback_grade,
         default=[],
-        metavar="<result-id>=<0-10>",
+        metavar=f"<result-id>=<{search_feedback.MIN_GRADE}-{search_feedback.MAX_GRADE}>",
         help="grade one result; repeat as needed (an optional note is read from stdin)",
     )
     feedback.set_defaults(func=cmd_feedback)

--- a/infra/echo/cli.py
+++ b/infra/echo/cli.py
@@ -214,7 +214,8 @@ def cmd_search(args: argparse.Namespace) -> None:
     print_search_results(results)
     print(
         "Feedback: uv run infra/echo/cli.py feedback "
-        f"--query {shlex.quote(args.query)} --grade '<id>=<{search_feedback.MIN_GRADE}-{search_feedback.MAX_GRADE}>'"
+        f"--query {shlex.quote(args.query)} --grade '<id>=<{search_feedback.MIN_GRADE}-{search_feedback.MAX_GRADE}>' "
+        "<<< 'brief overall assessment'"
     )
 
 
@@ -233,8 +234,8 @@ def feedback_note() -> str | None:
 
 def cmd_feedback(args: argparse.Namespace) -> None:
     note = feedback_note()
-    if not args.grade and note is None:
-        raise SystemExit("provide at least one --grade or a note on stdin")
+    if note is None:
+        raise SystemExit("provide a short overall explanation on stdin")
     entry = response_object(
         request(
             "POST",
@@ -401,7 +402,7 @@ def build_parser() -> argparse.ArgumentParser:
         type=feedback_grade,
         default=[],
         metavar=f"<result-id>=<{search_feedback.MIN_GRADE}-{search_feedback.MAX_GRADE}>",
-        help="grade one result; repeat as needed (an optional note is read from stdin)",
+        help="grade one result; repeat as needed (a short overall explanation is read from stdin)",
     )
     feedback.set_defaults(func=cmd_feedback)
 

--- a/infra/echo/migrations/m0010_search_feedback.py
+++ b/infra/echo/migrations/m0010_search_feedback.py
@@ -14,7 +14,7 @@ CREATE TABLE search_feedback (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
     author TEXT NOT NULL,
     query TEXT NOT NULL,
-    note TEXT,
+    note TEXT NOT NULL,
     PRIMARY KEY (id)
 );
 CREATE INDEX idx_search_feedback_created_at ON search_feedback (created_at DESC);

--- a/infra/echo/migrations/m0010_search_feedback.py
+++ b/infra/echo/migrations/m0010_search_feedback.py
@@ -5,7 +5,10 @@
 
 import sqlalchemy
 
-DDL = """
+MIN_GRADE = 0
+MAX_GRADE = 10
+
+DDL = f"""
 CREATE TABLE search_feedback (
     id BIGINT GENERATED ALWAYS AS IDENTITY,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
@@ -21,7 +24,7 @@ CREATE TABLE search_feedback_grades (
     result_id TEXT NOT NULL,
     grade SMALLINT NOT NULL,
     PRIMARY KEY (feedback_id, result_id),
-    CONSTRAINT search_feedback_grades_range CHECK (grade BETWEEN 0 AND 10)
+    CONSTRAINT search_feedback_grades_range CHECK (grade BETWEEN {MIN_GRADE} AND {MAX_GRADE})
 );
 CREATE INDEX idx_search_feedback_grades_result_id ON search_feedback_grades (result_id);
 

--- a/infra/echo/migrations/m0010_search_feedback.py
+++ b/infra/echo/migrations/m0010_search_feedback.py
@@ -1,0 +1,42 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Store agent judgments about federated search results."""
+
+import sqlalchemy
+
+DDL = """
+CREATE TABLE search_feedback (
+    id BIGINT GENERATED ALWAYS AS IDENTITY,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
+    author TEXT NOT NULL,
+    query TEXT NOT NULL,
+    note TEXT,
+    PRIMARY KEY (id)
+);
+CREATE INDEX idx_search_feedback_created_at ON search_feedback (created_at DESC);
+
+CREATE TABLE search_feedback_grades (
+    feedback_id BIGINT NOT NULL REFERENCES search_feedback(id) ON DELETE CASCADE,
+    result_id TEXT NOT NULL,
+    grade SMALLINT NOT NULL,
+    PRIMARY KEY (feedback_id, result_id),
+    CONSTRAINT search_feedback_grades_range CHECK (grade BETWEEN 0 AND 10)
+);
+CREATE INDEX idx_search_feedback_grades_result_id ON search_feedback_grades (result_id);
+
+GRANT SELECT ON search_feedback, search_feedback_grades
+    TO "eng-all@openathena.ai";
+GRANT SELECT ON search_feedback, search_feedback_grades
+    TO "loom-vm@hai-gcp-models.iam";
+GRANT SELECT, INSERT ON search_feedback, search_feedback_grades
+    TO "echo-api@hai-gcp-models.iam";
+GRANT USAGE, SELECT ON SEQUENCE search_feedback_id_seq
+    TO "echo-api@hai-gcp-models.iam";
+"""
+
+
+def upgrade(conn: sqlalchemy.Connection) -> None:
+    for statement in DDL.strip().split(";"):
+        if statement.strip():
+            conn.execute(sqlalchemy.text(statement))

--- a/infra/echo/schema.py
+++ b/infra/echo/schema.py
@@ -12,7 +12,7 @@ the state tables hold sync watermarks.
 """
 
 from pgvector.sqlalchemy import Vector
-from search_config import TEXT_SEARCH_CONFIG
+from search_config import SEARCH_FEEDBACK_MAX_GRADE, SEARCH_FEEDBACK_MIN_GRADE, TEXT_SEARCH_CONFIG
 from sqlalchemy import (
     ARRAY,
     BigInteger,
@@ -192,7 +192,10 @@ search_feedback_grades = Table(
     Column("feedback_id", BigInteger, ForeignKey("search_feedback.id", ondelete="CASCADE"), primary_key=True),
     Column("result_id", Text, primary_key=True),
     Column("grade", SmallInteger, nullable=False),
-    CheckConstraint("grade BETWEEN 0 AND 10", name="search_feedback_grades_range"),
+    CheckConstraint(
+        f"grade BETWEEN {SEARCH_FEEDBACK_MIN_GRADE} AND {SEARCH_FEEDBACK_MAX_GRADE}",
+        name="search_feedback_grades_range",
+    ),
     Index("idx_search_feedback_grades_result_id", "result_id"),
 )
 

--- a/infra/echo/schema.py
+++ b/infra/echo/schema.py
@@ -7,7 +7,8 @@ The single source of truth for echo's schema. Migrations (migrations/) create an
 these tables; the sync job (sync/main.py) uses them for DML. `chunks` mirrors the
 marinmirror corpus schema for the github+discord sources; `repository_file_chunks`
 indexes GitHub branch heads; `wiki_entries` holds durable agent-authored notes;
-`work_log` is the agents' shared logbook; the state tables hold sync watermarks.
+`work_log` is the agents' shared logbook; search feedback records relevance judgments;
+the state tables hold sync watermarks.
 """
 
 from pgvector.sqlalchemy import Vector
@@ -20,10 +21,12 @@ from sqlalchemy import (
     Column,
     Computed,
     DateTime,
+    ForeignKey,
     Identity,
     Index,
     Integer,
     MetaData,
+    SmallInteger,
     Table,
     Text,
     UniqueConstraint,
@@ -170,6 +173,27 @@ work_log = Table(
     Column("body", Text),
     Index("idx_work_log_project_at", "project", text("at DESC")),
     Index("idx_work_log_at", text("at DESC")),
+)
+
+search_feedback = Table(
+    "search_feedback",
+    metadata,
+    Column("id", BigInteger, Identity(always=True), primary_key=True),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+    Column("author", Text, nullable=False),
+    Column("query", Text, nullable=False),
+    Column("note", Text),
+    Index("idx_search_feedback_created_at", text("created_at DESC")),
+)
+
+search_feedback_grades = Table(
+    "search_feedback_grades",
+    metadata,
+    Column("feedback_id", BigInteger, ForeignKey("search_feedback.id", ondelete="CASCADE"), primary_key=True),
+    Column("result_id", Text, primary_key=True),
+    Column("grade", SmallInteger, nullable=False),
+    CheckConstraint("grade BETWEEN 0 AND 10", name="search_feedback_grades_range"),
+    Index("idx_search_feedback_grades_result_id", "result_id"),
 )
 
 wiki_entries = Table(

--- a/infra/echo/schema.py
+++ b/infra/echo/schema.py
@@ -182,7 +182,7 @@ search_feedback = Table(
     Column("created_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
     Column("author", Text, nullable=False),
     Column("query", Text, nullable=False),
-    Column("note", Text),
+    Column("note", Text, nullable=False),
     Index("idx_search_feedback_created_at", text("created_at DESC")),
 )
 

--- a/infra/echo/search_config.py
+++ b/infra/echo/search_config.py
@@ -19,6 +19,8 @@ FEDERATED_SUMMARY_CHARACTERS = 240
 SearchDomain = Literal["wiki", "file", "discord", "pr", "issue"]
 SEARCH_DOMAINS: tuple[SearchDomain, ...] = ("wiki", "file", "discord", "pr", "issue")
 DEFAULT_SEARCH_DOMAINS: tuple[SearchDomain, ...] = ("wiki", "file", "pr", "issue")
+SEARCH_FEEDBACK_MIN_GRADE = 0
+SEARCH_FEEDBACK_MAX_GRADE = 10
 SEARCH_DOMAIN_LABELS: Mapping[SearchDomain, str] = MappingProxyType(
     {
         "wiki": "Wiki",

--- a/infra/echo/search_feedback.py
+++ b/infra/echo/search_feedback.py
@@ -1,0 +1,44 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validation shared by Echo search-feedback clients and the API."""
+
+from dataclasses import dataclass
+
+import search_config
+
+MAX_QUERY_CHARACTERS = 2_000
+MAX_NOTE_CHARACTERS = 2_000
+MAX_RESULT_ID_CHARACTERS = 4_096
+MAX_GRADES = search_config.RERANK_MAX_CANDIDATES
+
+
+def checked_result_id(value: str) -> str:
+    domain, separator, detail = value.partition(":")
+    if not separator or domain not in search_config.SEARCH_DOMAINS or not detail:
+        raise ValueError("must be <wiki|file|discord|pr|issue>:<id>")
+    if len(value) > MAX_RESULT_ID_CHARACTERS:
+        raise ValueError(f"must be at most {MAX_RESULT_ID_CHARACTERS} characters")
+    if domain != "file" and not detail.isdecimal():
+        raise ValueError(f"{domain} result IDs are numeric")
+    return value
+
+
+@dataclass(frozen=True)
+class FeedbackGrade:
+    result_id: str
+    grade: int
+
+    @classmethod
+    def from_spec(cls, value: str) -> "FeedbackGrade":
+        result_id, separator, grade_text = value.rpartition("=")
+        if not separator:
+            raise ValueError("must be <result-id>=<0-10>")
+        checked_result_id(result_id)
+        try:
+            grade = int(grade_text)
+        except ValueError as error:
+            raise ValueError("grade must be an integer from 0 through 10") from error
+        if not 0 <= grade <= 10:
+            raise ValueError("grade must be an integer from 0 through 10")
+        return cls(result_id=result_id, grade=grade)

--- a/infra/echo/search_feedback.py
+++ b/infra/echo/search_feedback.py
@@ -11,6 +11,8 @@ MAX_QUERY_CHARACTERS = 2_000
 MAX_NOTE_CHARACTERS = 2_000
 MAX_RESULT_ID_CHARACTERS = 4_096
 MAX_GRADES = search_config.RERANK_MAX_CANDIDATES
+MIN_GRADE = search_config.SEARCH_FEEDBACK_MIN_GRADE
+MAX_GRADE = search_config.SEARCH_FEEDBACK_MAX_GRADE
 
 
 def checked_result_id(value: str) -> str:
@@ -33,12 +35,12 @@ class FeedbackGrade:
     def from_spec(cls, value: str) -> "FeedbackGrade":
         result_id, separator, grade_text = value.rpartition("=")
         if not separator:
-            raise ValueError("must be <result-id>=<0-10>")
+            raise ValueError(f"must be <result-id>=<{MIN_GRADE}-{MAX_GRADE}>")
         checked_result_id(result_id)
         try:
             grade = int(grade_text)
         except ValueError as error:
-            raise ValueError("grade must be an integer from 0 through 10") from error
-        if not 0 <= grade <= 10:
-            raise ValueError("grade must be an integer from 0 through 10")
+            raise ValueError(f"grade must be an integer from {MIN_GRADE} through {MAX_GRADE}") from error
+        if not MIN_GRADE <= grade <= MAX_GRADE:
+            raise ValueError(f"grade must be an integer from {MIN_GRADE} through {MAX_GRADE}")
         return cls(result_id=result_id, grade=grade)

--- a/infra/echo/test_cli.py
+++ b/infra/echo/test_cli.py
@@ -3,6 +3,7 @@
 
 """Behavior tests for Echo CLI federation."""
 
+import io
 import logging
 from concurrent.futures import ThreadPoolExecutor
 
@@ -36,6 +37,8 @@ def test_search_sends_selected_domains_to_federated_endpoint(monkeypatch, capsys
         return [remote_result]
 
     monkeypatch.setattr(cli, "request", fake_request)
+    clock = iter((10.0, 11.234))
+    monkeypatch.setattr(cli.time, "perf_counter", lambda: next(clock))
     args = cli.build_parser().parse_args(["search", "FAILED_PRECONDITION", "--domain", "file", "--domain", "pr"])
     args.func(args)
 
@@ -47,8 +50,10 @@ def test_search_sends_selected_domains_to_federated_endpoint(monkeypatch, capsys
         )
     ]
     output = capsys.readouterr().out
+    assert "1 result in 1.23s" in output
     assert cli.SEARCH_DETAIL_INSTRUCTION in output
     assert "L42 raise FAILED_PRECONDITION" in output
+    assert "feedback --query FAILED_PRECONDITION --grade '<id>=<0-10>'" in output
 
 
 def test_search_defaults_to_curated_domains_without_discord(monkeypatch):
@@ -108,3 +113,44 @@ def test_get_fetches_full_detail_by_search_result_id(monkeypatch):
     args.func(args)
 
     assert calls == [("GET", "/repository-files/lib/iris/OPS.md", {})]
+
+
+def test_feedback_submits_replayable_grades_and_stdin_note(monkeypatch, capsys):
+    calls = []
+
+    def fake_request(method, path, **options):
+        calls.append((method, path, options))
+        return {"id": 17}
+
+    monkeypatch.setattr(cli, "request", fake_request)
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("Wiki result was unrelated.\n"))
+    args = cli.build_parser().parse_args(
+        [
+            "feedback",
+            "--query",
+            "how do I deploy Iris?",
+            "--grade",
+            "wiki:123=0",
+            "--grade",
+            "file:lib/iris/OPS.md=10",
+        ]
+    )
+    args.func(args)
+
+    assert calls == [
+        (
+            "POST",
+            "/feedback",
+            {
+                "body": {
+                    "query": "how do I deploy Iris?",
+                    "grades": [
+                        {"result_id": "wiki:123", "grade": 0},
+                        {"result_id": "file:lib/iris/OPS.md", "grade": 10},
+                    ],
+                    "note": "Wiki result was unrelated.",
+                }
+            },
+        )
+    ]
+    assert capsys.readouterr().out == "recorded feedback #17\n"


### PR DESCRIPTION
Record explicit 0-10 relevance grades and a required short explanation for
Echo federated search results. Store the exact query and IAP-authenticated
caller so future retrieval evaluations can replay and attribute each judgment.
Explanation-only submissions cover empty or globally poor result sets.

Report client-observed wall time for every CLI search and print one copyable
feedback command. The `consult-echo` guidance asks agents to grade only results
they evaluated and summarize the result set without restating each score.

[Weaver session](https://loom.rjp.io/s/ciwpn6w8)
