### PR TITLE
[ci] Select affected Levanter accelerator tests

### DIFF
--- a/.github/workflows/unified-unit.yaml
+++ b/.github/workflows/unified-unit.yaml
@@ -234,11 +234,6 @@ jobs:
               timeout --kill-after=5 --signal=TERM 1490 \
               uv run --package marin-levanter --frozen --group test --extra tpu \
               pytest -n 0 ${{ needs.select.outputs.levanter_tpu_test_paths }} \
-              --ignore=lib/levanter/tests/test_audio.py \
-              --ignore=lib/levanter/tests/test_new_cache.py \
-              --ignore=lib/levanter/tests/test_hf_checkpoints.py \
-              --ignore=lib/levanter/tests/test_hf_gpt2_serialize.py \
-              --ignore=lib/levanter/tests/test_gdn_layer.py \
               -v --tb=short --log-cli-level=WARNING --durations=20"
 
   iris_e2e_smoke:

--- a/.github/workflows/unified-unit.yaml
+++ b/.github/workflows/unified-unit.yaml
@@ -4,10 +4,12 @@ on:
   pull_request:
   push:
     branches: [main]
+  schedule:
+    - cron: "17 8 * * *"
   workflow_dispatch:
 
 concurrency:
-  group: unified-unit-${{ github.event.pull_request.number || github.ref }}
+  group: unified-unit-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -19,6 +21,8 @@ jobs:
     outputs:
       matrix: ${{ steps.analyze.outputs.matrix }}
       suites: ${{ steps.analyze.outputs.suites }}
+      levanter_torch_test_paths: ${{ steps.analyze.outputs.levanter_torch_test_paths }}
+      levanter_tpu_test_paths: ${{ steps.analyze.outputs.levanter_tpu_test_paths }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -32,22 +36,23 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: |
-          # A pull request selects tests from its diff. A push to main re-runs every unit
-          # test, which is what catches anything the import graph failed to select on the
-          # pull request that introduced it; it still gates the accelerator and browser
-          # suites on the diff, because those are chosen by directory and never by import.
-          # A manual run, and a push whose base is unknown, run everything.
+          # Pull requests and pushes select tests from their diff. Scheduled and manual
+          # runs exercise every test as a backstop for missing import-graph edges.
           ARGS=()
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             ARGS+=(--run-all-tests)
           fi
           if [ -n "$BASE_SHA" ] && [ "$BASE_SHA" != "0000000000000000000000000000000000000000" ]; then
             ARGS+=(--base-ref "$BASE_SHA")
+          elif [ "${{ github.event_name }}" != "schedule" ] && [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            ARGS+=(--run-all-tests)
           fi
           result=$(python3 infra/ci/select_tests.py "${ARGS[@]}")
           echo "$result"
           echo "matrix=$(jq -c .matrix <<<"$result")" >> "$GITHUB_OUTPUT"
           echo "suites=$(jq -c .suites <<<"$result")" >> "$GITHUB_OUTPUT"
+          echo "levanter_torch_test_paths=$(jq -r '[.suite_test_paths["levanter-torch"][]? | sub("^lib/levanter/"; "")] | join(" ")' <<<"$result")" >> "$GITHUB_OUTPUT"
+          echo "levanter_tpu_test_paths=$(jq -r '.suite_test_paths["levanter-tpu"] // [] | join(" ")' <<<"$result")" >> "$GITHUB_OUTPUT"
 
   unit:
     needs: select
@@ -166,7 +171,10 @@ jobs:
 
       - name: Test torch-marked suite
         # Run directly on CPU to avoid GPU dependency issues.
-        run: CUDA_VISIBLE_DEVICES="" ../../.venv/bin/python -m pytest tests -m "torch" --durations=20
+        run: >-
+          CUDA_VISIBLE_DEVICES="" ../../.venv/bin/python -m pytest
+          ${{ needs.select.outputs.levanter_torch_test_paths }}
+          -m "torch" --durations=20
 
   levanter_tpu:
     name: levanter-tpu
@@ -225,7 +233,7 @@ jobs:
               cp -a /workspace-src/. /workspace/ && cd /workspace && \
               timeout --kill-after=5 --signal=TERM 1490 \
               uv run --package marin-levanter --frozen --group test --extra tpu \
-              pytest -n 0 lib/levanter/tests \
+              pytest -n 0 ${{ needs.select.outputs.levanter_tpu_test_paths }} \
               --ignore=lib/levanter/tests/test_audio.py \
               --ignore=lib/levanter/tests/test_new_cache.py \
               --ignore=lib/levanter/tests/test_hf_checkpoints.py \

--- a/.github/workflows/unified-unit.yaml
+++ b/.github/workflows/unified-unit.yaml
@@ -171,10 +171,13 @@ jobs:
 
       - name: Test torch-marked suite
         # Run directly on CPU to avoid GPU dependency issues.
-        run: >-
-          CUDA_VISIBLE_DEVICES="" ../../.venv/bin/python -m pytest
-          ${{ needs.select.outputs.levanter_torch_test_paths }}
-          -m "torch" --durations=20
+        run: |
+          status=0
+          CUDA_VISIBLE_DEVICES="" ../../.venv/bin/python -m pytest \
+            ${{ needs.select.outputs.levanter_torch_test_paths }} \
+            -m "torch" --durations=20 || status=$?
+          [ "$status" -eq 5 ] && exit 0
+          exit "$status"
 
   levanter_tpu:
     name: levanter-tpu
@@ -231,10 +234,13 @@ jobs:
                 echo '::endgroup::'; \
               fi && \
               cp -a /workspace-src/. /workspace/ && cd /workspace && \
-              timeout --kill-after=5 --signal=TERM 1490 \
-              uv run --package marin-levanter --frozen --group test --extra tpu \
-              pytest -n 0 ${{ needs.select.outputs.levanter_tpu_test_paths }} \
-              -v --tb=short --log-cli-level=WARNING --durations=20"
+              ( status=0; \
+                timeout --kill-after=5 --signal=TERM 1490 \
+                uv run --package marin-levanter --frozen --group test --extra tpu \
+                pytest -n 0 ${{ needs.select.outputs.levanter_tpu_test_paths }} \
+                -v --tb=short --log-cli-level=WARNING --durations=20 || status=\$?; \
+                [ "\$status" -eq 5 ] && exit 0; \
+                exit "\$status" )"
 
   iris_e2e_smoke:
     name: iris-e2e-smoke

--- a/infra/ci/select_tests.py
+++ b/infra/ci/select_tests.py
@@ -288,6 +288,20 @@ def is_test_module(filename: str) -> bool:
     return (filename.startswith("test_") or filename.endswith("_test.py")) and filename.endswith(".py")
 
 
+def has_static_test_items(path: Path) -> bool:
+    tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"), filename=str(path))
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+            return True
+        if isinstance(node, ast.ClassDef) and node.name.startswith("Test"):
+            if any(
+                isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)) and method.name.startswith("test_")
+                for method in node.body
+            ):
+                return True
+    return False
+
+
 def _test_tree(scope: str, repo_root: Path) -> dict[str, Path]:
     """Every .py under a scope's test directory, keyed by the name it imports itself as.
 
@@ -425,10 +439,13 @@ def classify(changed_files: list[str], repo_root: Path) -> ClassifyResult:
                 # tests that own this file are not missed.
                 if not is_test_module(PurePosixPath(filepath).name):
                     forced.add(scope)
-                elif (repo_root / filepath).exists():
-                    # A test deleted by this diff still shows up in git's output; passing
-                    # it to pytest would abort the run before a single test executes.
+                elif (repo_root / filepath).exists() and has_static_test_items(repo_root / filepath):
                     direct_tests[scope].append(filepath)
+                elif (repo_root / filepath).exists():
+                    # Helpers named test_*.py satisfy pytest's file convention but do not
+                    # own test items. Their importers are not recoverable from a direct
+                    # file selection, so run the scope that consumes the helper.
+                    forced.add(scope)
                 break
 
             if filepath in (f"lib/{scope}/conftest.py", f"lib/{scope}/pyproject.toml"):

--- a/infra/ci/select_tests.py
+++ b/infra/ci/select_tests.py
@@ -454,7 +454,6 @@ def extra_suites(changed_files: list[str]) -> list[str]:
 
 
 def _node_has_torch_marker(node: ast.AST) -> bool:
-    """Whether a decorator or module marker expression applies pytest's torch marker."""
     return any(
         (isinstance(child, ast.Name) and child.id == "skip_if_no_torch")
         or (isinstance(child, ast.Attribute) and child.attr == "torch")
@@ -650,12 +649,7 @@ def accelerator_suite_test_paths(
     *,
     force: bool = False,
 ) -> dict[str, list[str]]:
-    """Affected Levanter test paths for the Torch and TPU lanes.
-
-    CPU selection already walks transitive imports across Haliax and Levanter. Reuse
-    that result so accelerator jobs validate the same affected surface instead of
-    expanding any in-package change to the entire Levanter suite.
-    """
+    """Return affected Levanter tests split by accelerator lane."""
     is_triggered = force or any(
         filepath.startswith(prefix) for prefix in LEVANTER_ACCELERATOR_TRIGGERS for filepath in changed_files
     )

--- a/infra/ci/select_tests.py
+++ b/infra/ci/select_tests.py
@@ -17,9 +17,8 @@ Test helper modules under a test tree participate in the graph too, so a test th
 reaches source code only through a shared helper is still selected.
 
 Usage:
-    python infra/ci/select_tests.py --base-ref <SHA>                   # pull request
-    python infra/ci/select_tests.py --base-ref <SHA> --run-all-tests   # push to main
-    python infra/ci/select_tests.py --run-all-tests                    # manual run
+    python infra/ci/select_tests.py --base-ref <SHA>  # pull request or push
+    python infra/ci/select_tests.py --run-all-tests   # scheduled or manual run
 """
 
 import argparse
@@ -125,16 +124,34 @@ RUST_SETUP_TAG = "rust"
 SOURCE_BUILD_TIMEOUT = 30
 DEFAULT_LEG_TIMEOUT = 15
 
-# Suites that cannot be import-selected: each drives a whole subsystem (accelerator
-# kernels, a browser-driven smoke test) rather than a set of importable modules, so
-# path prefixes gate them. A locked dependency change moves the accelerator runtime
-# out from under all of them.
+# Suites that cannot be import-selected because they drive a non-Python subsystem.
+# Levanter's accelerator lanes use the ordinary import-selected Levanter files below;
+# only the browser smoke remains a directory-triggered suite.
 DEPENDENCY_MANIFESTS: tuple[str, ...] = ("uv.lock", "pyproject.toml")
 EXTRA_SUITE_TRIGGERS: dict[str, tuple[str, ...]] = {
-    "levanter-torch": ("lib/levanter/", "lib/haliax/", *DEPENDENCY_MANIFESTS),
-    "levanter-tpu": ("lib/levanter/", "lib/haliax/", *DEPENDENCY_MANIFESTS),
     "iris-e2e-smoke": ("lib/iris/", *DEPENDENCY_MANIFESTS),
 }
+
+LEVANTER_ACCELERATOR_TRIGGERS: tuple[str, ...] = (
+    "lib/levanter/",
+    "lib/haliax/",
+    "infra/ci/select_tests.py",
+    ".github/workflows/unified-unit.yaml",
+    *DEPENDENCY_MANIFESTS,
+)
+
+# These files are intentionally absent from the TPU command today. Keep the selection
+# rule next to the selector so an affected-file TPU run does not start only to collect
+# zero runnable tests.
+TPU_IGNORED_TEST_PATHS: frozenset[str] = frozenset(
+    {
+        "lib/levanter/tests/test_audio.py",
+        "lib/levanter/tests/test_new_cache.py",
+        "lib/levanter/tests/test_hf_checkpoints.py",
+        "lib/levanter/tests/test_hf_gpt2_serialize.py",
+        "lib/levanter/tests/test_gdn_layer.py",
+    }
+)
 
 
 # ---------------------------------------------------------------------------
@@ -436,6 +453,60 @@ def extra_suites(changed_files: list[str]) -> list[str]:
     )
 
 
+def _node_has_torch_marker(node: ast.AST) -> bool:
+    """Whether a decorator or module marker expression applies pytest's torch marker."""
+    return any(
+        (isinstance(child, ast.Name) and child.id == "skip_if_no_torch")
+        or (isinstance(child, ast.Attribute) and child.attr == "torch")
+        for child in ast.walk(node)
+    )
+
+
+def torch_membership_for_test_file(path: Path) -> tuple[bool, bool]:
+    """Return whether a test file contains torch and non-torch tests.
+
+    The Levanter helper ``skip_if_no_torch`` applies ``pytest.mark.torch``. The
+    selector cannot import test modules because its job intentionally installs no test
+    dependencies, so inspect decorators and module-level ``pytestmark`` assignments.
+    Unknown/dynamically generated test shapes conservatively enter both lanes.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"), filename=str(path))
+    module_is_torch = any(
+        isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "pytestmark" for target in node.targets)
+        and _node_has_torch_marker(node.value)
+        for node in tree.body
+    )
+
+    has_torch = module_is_torch
+    has_non_torch = False
+    found_test = False
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):
+            found_test = True
+            is_torch = module_is_torch or any(_node_has_torch_marker(decorator) for decorator in node.decorator_list)
+            has_torch |= is_torch
+            has_non_torch |= not is_torch
+            continue
+
+        if isinstance(node, ast.ClassDef) and node.name.startswith("Test"):
+            class_is_torch = module_is_torch or any(
+                _node_has_torch_marker(decorator) for decorator in node.decorator_list
+            )
+            for method in node.body:
+                if isinstance(method, (ast.FunctionDef, ast.AsyncFunctionDef)) and method.name.startswith("test_"):
+                    found_test = True
+                    is_torch = class_is_torch or any(
+                        _node_has_torch_marker(decorator) for decorator in method.decorator_list
+                    )
+                    has_torch |= is_torch
+                    has_non_torch |= not is_torch
+
+    if not found_test:
+        return True, True
+    return has_torch, has_non_torch
+
+
 # ---------------------------------------------------------------------------
 # Test selection
 # ---------------------------------------------------------------------------
@@ -566,6 +637,58 @@ def full_matrix(repo_root: Path, source_build_scopes: set[str]) -> list[dict[str
     return legs
 
 
+def selected_scope_test_paths(matrix: list[dict[str, str | int]], scope: str) -> list[str]:
+    """Return the unique pytest paths selected for one scope across all matrix shards."""
+    package = UV_PACKAGE[scope]
+    return sorted({path for leg in matrix if leg["package"] == package for path in str(leg["test_paths"]).split()})
+
+
+def accelerator_suite_test_paths(
+    changed_files: list[str],
+    matrix: list[dict[str, str | int]],
+    repo_root: Path,
+    *,
+    force: bool = False,
+) -> dict[str, list[str]]:
+    """Affected Levanter test paths for the Torch and TPU lanes.
+
+    CPU selection already walks transitive imports across Haliax and Levanter. Reuse
+    that result so accelerator jobs validate the same affected surface instead of
+    expanding any in-package change to the entire Levanter suite.
+    """
+    is_triggered = force or any(
+        filepath.startswith(prefix) for prefix in LEVANTER_ACCELERATOR_TRIGGERS for filepath in changed_files
+    )
+    if not is_triggered:
+        return {}
+
+    selected = selected_scope_test_paths(matrix, "levanter")
+    if not selected:
+        return {}
+
+    torch_paths: list[str] = []
+    tpu_paths: list[str] = []
+    for test_path in selected:
+        if test_path == TEST_DIR["levanter"]:
+            torch_paths.append(test_path)
+            tpu_paths.append(test_path)
+            continue
+
+        path = repo_root / test_path
+        has_torch, has_non_torch = torch_membership_for_test_file(path)
+        if has_torch:
+            torch_paths.append(test_path)
+        if has_non_torch and test_path not in TPU_IGNORED_TEST_PATHS:
+            tpu_paths.append(test_path)
+
+    suites: dict[str, list[str]] = {}
+    if torch_paths:
+        suites["levanter-torch"] = torch_paths
+    if tpu_paths:
+        suites["levanter-tpu"] = tpu_paths
+    return suites
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
@@ -588,17 +711,19 @@ def main() -> None:
     # Without a base ref there is no diff to inspect, so conservatively build every native
     # extension from source and run the out-of-band suites too.
     if args.base_ref is None:
+        matrix = full_matrix(repo_root, set(NATIVE_CRATE_DIR))
+        suite_test_paths = accelerator_suite_test_paths([], matrix, repo_root, force=True)
         result = {
             "reason": "run-all-tests",
-            "matrix": full_matrix(repo_root, set(NATIVE_CRATE_DIR)),
-            "suites": sorted(EXTRA_SUITE_TRIGGERS),
+            "matrix": matrix,
+            "suites": sorted((*EXTRA_SUITE_TRIGGERS, *suite_test_paths)),
+            "suite_test_paths": suite_test_paths,
         }
         print(json.dumps(result, indent=2))
         return
 
     changed = git_changed_files(args.base_ref, repo_root)
     classification = classify(changed, repo_root)
-    suites = extra_suites(changed)
 
     # The scopes whose native extension's Rust changed build it from source; every other
     # leg installs the prebuilt wheel. This is independent of full vs. diff-driven runs: a
@@ -620,7 +745,19 @@ def main() -> None:
             repo_root,
         )
 
-    print(json.dumps({"reason": reason, "matrix": matrix, "suites": suites}, indent=2))
+    suite_test_paths = accelerator_suite_test_paths(changed, matrix, repo_root)
+    suites = sorted((*extra_suites(changed), *suite_test_paths))
+    print(
+        json.dumps(
+            {
+                "reason": reason,
+                "matrix": matrix,
+                "suites": suites,
+                "suite_test_paths": suite_test_paths,
+            },
+            indent=2,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/tests/infra/ci/test_select_tests.py
+++ b/tests/infra/ci/test_select_tests.py
@@ -13,6 +13,7 @@ from infra.ci.select_tests import (
     SCOPES,
     SHARD_COUNT,
     UV_PACKAGE,
+    accelerator_suite_test_paths,
     classify,
     compute_matrix,
     dependencies_by_test_file,
@@ -22,6 +23,7 @@ from infra.ci.select_tests import (
     matrix_leg,
     scope_legs,
     shard_files,
+    torch_membership_for_test_file,
 )
 
 
@@ -38,6 +40,11 @@ def select_matrix(changed_files: list[str], repo_root: Path) -> list[dict[str, s
         source_build_scopes,
         repo_root,
     )
+
+
+def select_accelerator_paths(changed_files: list[str], repo_root: Path) -> dict[str, list[str]]:
+    matrix = select_matrix(changed_files, repo_root)
+    return accelerator_suite_test_paths(changed_files, matrix, repo_root)
 
 
 def write(repo_root: Path, relative: str, body: str = "") -> Path:
@@ -248,20 +255,157 @@ def test_evaldash_change_selects_importing_test(tmp_path: Path, changed_file: st
 
 
 def test_extra_suites_follow_the_owning_package_directory() -> None:
-    """Accelerator and browser suites drive whole subsystems, so directory membership gates them."""
+    """Only suites without importable test dependencies use directory triggers."""
     assert extra_suites(["lib/iris/dashboard/src/App.vue"]) == ["iris-e2e-smoke"]
-    assert extra_suites(["lib/haliax/src/haliax/core.py"]) == ["levanter-torch", "levanter-tpu"]
-    assert extra_suites(["lib/levanter/tests/test_attention.py"]) == ["levanter-torch", "levanter-tpu"]
+    assert extra_suites(["lib/haliax/src/haliax/core.py"]) == []
+    assert extra_suites(["lib/levanter/tests/test_attention.py"]) == []
     assert extra_suites(["lib/zephyr/src/zephyr/writers.py"]) == []
     assert extra_suites(["docs/index.md"]) == []
-    assert extra_suites(["uv.lock"]) == ["iris-e2e-smoke", "levanter-torch", "levanter-tpu"]
+    assert extra_suites(["uv.lock"]) == ["iris-e2e-smoke"]
 
 
-def test_selector_changes_do_not_wake_the_accelerator_suites() -> None:
-    """A broad trigger reruns every unit test, but the TPU runner is serialized and scarce:
-    only a dependency or in-package change can move what those suites exercise."""
+def _levanter_accelerator_workspace(repo_root: Path) -> None:
+    write(repo_root, "lib/haliax/src/haliax/__init__.py", '"""haliax."""\n')
+    write(repo_root, "lib/haliax/src/haliax/core.py", "X = 1\n")
+    write(repo_root, "lib/levanter/src/levanter/__init__.py", '"""levanter."""\n')
+    write(repo_root, "lib/levanter/src/levanter/model.py", "from haliax.core import X\n")
+    write(repo_root, "lib/levanter/src/levanter/unrelated.py", "Y = 2\n")
+    write(
+        repo_root,
+        "lib/levanter/tests/test_model.py",
+        """\
+        from levanter.model import X
+        from test_utils import skip_if_no_torch
+
+        def test_cpu():
+            assert X == 1
+
+        @skip_if_no_torch
+        def test_torch():
+            assert X == 1
+        """,
+    )
+    write(
+        repo_root,
+        "lib/levanter/tests/test_unrelated.py",
+        "from levanter.unrelated import Y\n\ndef test_unrelated():\n    assert Y == 2\n",
+    )
+
+
+def test_accelerator_suites_reuse_import_selected_levanter_files(tmp_path: Path) -> None:
+    _levanter_accelerator_workspace(tmp_path)
+
+    paths = select_accelerator_paths(["lib/levanter/src/levanter/model.py"], tmp_path)
+
+    expected = ["lib/levanter/tests/test_model.py"]
+    assert paths == {"levanter-torch": expected, "levanter-tpu": expected}
+
+
+def test_haliax_change_selects_only_dependent_levanter_accelerator_tests(tmp_path: Path) -> None:
+    _levanter_accelerator_workspace(tmp_path)
+
+    paths = select_accelerator_paths(["lib/haliax/src/haliax/core.py"], tmp_path)
+
+    expected = ["lib/levanter/tests/test_model.py"]
+    assert paths == {"levanter-torch": expected, "levanter-tpu": expected}
+
+
+def test_accelerator_suites_split_torch_and_non_torch_files(tmp_path: Path) -> None:
+    write(tmp_path, "lib/levanter/src/levanter/__init__.py")
+    write(tmp_path, "lib/levanter/src/levanter/core.py", "X = 1\n")
+    write(
+        tmp_path,
+        "lib/levanter/tests/test_torch_only.py",
+        """\
+        from levanter.core import X
+        from test_utils import skip_if_no_torch
+
+        @skip_if_no_torch
+        def test_torch():
+            assert X == 1
+        """,
+    )
+    write(
+        tmp_path,
+        "lib/levanter/tests/test_cpu_only.py",
+        """\
+        from levanter.core import X
+
+        def test_cpu():
+            assert X == 1
+        """,
+    )
+
+    paths = select_accelerator_paths(["lib/levanter/src/levanter/core.py"], tmp_path)
+
+    assert paths == {
+        "levanter-torch": ["lib/levanter/tests/test_torch_only.py"],
+        "levanter-tpu": ["lib/levanter/tests/test_cpu_only.py"],
+    }
+
+
+def test_tpu_ignored_file_does_not_start_an_accelerator_suite(tmp_path: Path) -> None:
+    write(tmp_path, "lib/levanter/tests/test_new_cache.py", "def test_cache():\n    pass\n")
+
+    assert select_accelerator_paths(["lib/levanter/tests/test_new_cache.py"], tmp_path) == {}
+
+
+def test_docs_only_levanter_change_does_not_start_accelerator_suites(tmp_path: Path) -> None:
+    _levanter_accelerator_workspace(tmp_path)
+
+    assert select_accelerator_paths(["lib/levanter/docs/index.md"], tmp_path) == {}
+
+
+def test_torch_membership_handles_module_and_class_markers(tmp_path: Path) -> None:
+    module_marked = write(
+        tmp_path,
+        "test_module.py",
+        """\
+        import pytest
+        pytestmark = pytest.mark.torch
+
+        def test_one():
+            pass
+        """,
+    )
+    mixed = write(
+        tmp_path,
+        "test_mixed.py",
+        """\
+        import pytest
+
+        class TestParity:
+            @pytest.mark.torch
+            def test_torch(self):
+                pass
+
+            def test_cpu(self):
+                pass
+        """,
+    )
+
+    assert torch_membership_for_test_file(module_marked) == (True, False)
+    assert torch_membership_for_test_file(mixed) == (True, True)
+
+
+def test_selector_changes_are_broad_without_waking_the_browser_suite() -> None:
     assert classify(["infra/ci/select_tests.py"], Path("/unused")).broad
     assert extra_suites(["infra/ci/select_tests.py", ".github/workflows/unified-unit.yaml"]) == []
+
+
+@pytest.mark.parametrize("changed_file", ["infra/ci/select_tests.py", ".github/workflows/unified-unit.yaml"])
+def test_selector_and_workflow_changes_run_full_accelerator_suites(tmp_path: Path, changed_file: str) -> None:
+    _levanter_accelerator_workspace(tmp_path)
+
+    paths = select_accelerator_paths([changed_file], tmp_path)
+
+    assert paths == {
+        "levanter-torch": ["lib/levanter/tests/test_model.py"],
+        "levanter-tpu": [
+            "lib/levanter/tests/test_model.py",
+            "lib/levanter/tests/test_unrelated.py",
+        ],
+    }
 
 
 def test_only_pytest_collectable_modules_are_selectable(tmp_path: Path) -> None:

--- a/tests/infra/ci/test_select_tests.py
+++ b/tests/infra/ci/test_select_tests.py
@@ -177,14 +177,15 @@ def test_deleted_test_module_is_not_handed_to_pytest(tmp_path: Path) -> None:
 
 
 def test_changed_helper_module_forces_full_scope(tmp_path: Path) -> None:
-    """A changed non-collectable .py under tests/ runs the full scope, not the file itself."""
+    """A changed helper under tests/ runs the full scope, even when named test_*.py."""
+    write(tmp_path, "lib/iris/tests/test_utils.py", "def helper():\n    pass\n")
     result = classify(
-        ["lib/iris/tests/e2e/gang_jax_smoke_workload.py", "lib/iris/tests/cluster/test_types.py"],
+        ["lib/iris/tests/e2e/gang_jax_smoke_workload.py", "lib/iris/tests/test_utils.py"],
         tmp_path,
     )
 
     assert result.forced == {"iris"}
-    assert result.direct_tests == {}, "the changed test module does not exist on disk"
+    assert result.direct_tests == {}
 
 
 def test_conftest_and_package_metadata_force_full_scope(tmp_path: Path) -> None:

--- a/tests/infra/ci/test_select_tests.py
+++ b/tests/infra/ci/test_select_tests.py
@@ -292,19 +292,14 @@ def _levanter_accelerator_workspace(repo_root: Path) -> None:
     )
 
 
-def test_accelerator_suites_reuse_import_selected_levanter_files(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "changed_file",
+    ["lib/levanter/src/levanter/model.py", "lib/haliax/src/haliax/core.py"],
+)
+def test_accelerator_suites_reuse_import_selected_levanter_files(tmp_path: Path, changed_file: str) -> None:
     _levanter_accelerator_workspace(tmp_path)
 
-    paths = select_accelerator_paths(["lib/levanter/src/levanter/model.py"], tmp_path)
-
-    expected = ["lib/levanter/tests/test_model.py"]
-    assert paths == {"levanter-torch": expected, "levanter-tpu": expected}
-
-
-def test_haliax_change_selects_only_dependent_levanter_accelerator_tests(tmp_path: Path) -> None:
-    _levanter_accelerator_workspace(tmp_path)
-
-    paths = select_accelerator_paths(["lib/haliax/src/haliax/core.py"], tmp_path)
+    paths = select_accelerator_paths([changed_file], tmp_path)
 
     expected = ["lib/levanter/tests/test_model.py"]
     assert paths == {"levanter-torch": expected, "levanter-tpu": expected}


### PR DESCRIPTION
Select Levanter Torch and TPU test files from the same transitive import graph used by the CPU matrix instead of expanding every Levanter or Haliax edit to both complete accelerator suites. Torch-marked files are split from ordinary TPU files, and the five existing TPU exclusions are now owned by the selector.

Pushes to main now select from the merge diff. A daily scheduled run retains complete CPU, Torch, and TPU coverage as the backstop for missing import edges.

On the current tree, a Qwen implementation change selects two Torch files and no TPU files. A cache change selects 18 CPU, seven Torch, and 16 TPU files instead of all 122 Levanter test modules.
