### PR TITLE
[sft] Preserve the August fixed-EOT data path

### DIFF
--- a/docs/harbor-integration.md
+++ b/docs/harbor-integration.md
@@ -192,3 +192,21 @@ performs final rendering at tokenization time.
 The checked-in Grug manifest pins the 29 sources and accepted row counts used by the historical
 `grug-67b-a2b-agentic-sft` run. Its compact 22-row source is also a data-integration golden test,
 which compares the canonical output hash with the archived training parquet.
+
+### Historical fixed-EOT training data
+
+The August 2026 fixed-EOT experiment used a separate, already-rendered training artifact. Keep
+that artifact distinct from the structured output above: changing `messages` or `tools` in place
+would make the canonical Harbor conversion depend on one trainee tokenizer and chat template.
+`experiments.datasets.grug_a2b_agentic_sft_eot` instead adopts the immutable August rendering and
+builds a versioned Levanter cache from its `input_ids` and `assistant_mask` columns. The prebuilt
+format shifts the assistant mask to causal-label positions before packing and retains the rightmost
+tokens when an archived record exceeds the training context, matching the historical run.
+
+Regenerating this rendering from the structured Harbor conversion should be a derived Datakit
+step. That step must consume every processed source in the pinned manifest, pass the serialized
+`tools` column to the target chat template, pin the trainee tokenizer and template, and write a new
+versioned output. It should verify the accepted-row count and rendered token/mask hashes against
+the archived artifact before replacing the adopted historical source. Directly reading selected
+Hugging Face Parquet files in the SFT launcher is unnecessary; the pinned Harbor conversion owns
+source ingestion and provenance.

--- a/experiments/datasets/grug_a2b_agentic_sft_eot.py
+++ b/experiments/datasets/grug_a2b_agentic_sft_eot.py
@@ -1,0 +1,60 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Frozen EOT-rendered Grug A2B agentic SFT records from August 2026."""
+
+from fray.types import ANY_REGION, ResourceConfig
+from levanter.data.text.formats import LossWeightTransform, PrebuiltLmDatasetFormat
+from marin.execution.artifact import Artifact
+from marin.execution.lazy import ArtifactStep, StepContext
+from marin.experiment.data import dataset_main
+from marin.processing.tokenize.tokenize import TokenizeConfig, TokenizedCache, tokenize
+from rigging.filesystem import prefix_join
+
+from experiments.marin_tokenizer import marin_tokenizer
+
+GRUG_A2B_AGENTIC_SFT_FORMAT = PrebuiltLmDatasetFormat(
+    input_ids_key="input_ids",
+    loss_weights_key="assistant_mask",
+    loss_weight_transform=LossWeightTransform.SHIFT_LEFT,
+)
+_RENDERED_SOURCE = prefix_join(
+    "s3://marin-us-east-02a/marin/users/held/datasets/grug-67b-a2b-agentic-sft-eot-20260805",
+    "processed/harbor-sft-eot",
+)
+_TOKENIZE_RESOURCES = ResourceConfig(cpu=2, ram="32g", regions=[ANY_REGION])
+
+
+def grug_a2b_agentic_sft_eot_dataset() -> ArtifactStep[TokenizedCache]:
+    """Build a Levanter cache from the immutable August EOT rendering."""
+    rendered = ArtifactStep.adopt(
+        name="datasets/grug-a2b-agentic-sft-eot-rendered",
+        version="2026.08.05",
+        source=_RENDERED_SOURCE,
+        kind=Artifact,
+    )
+
+    def build_config(ctx: StepContext) -> TokenizeConfig:
+        return TokenizeConfig(
+            train_paths=[prefix_join(ctx.artifact_path(rendered), "*/*.parquet")],
+            validation_paths=[],
+            cache_path=ctx.output_path,
+            tokenizer=marin_tokenizer,
+            format=GRUG_A2B_AGENTIC_SFT_FORMAT,
+            tags=["sft", "agentic", "grug-a2b"],
+            max_workers=8,
+            worker_resources=_TOKENIZE_RESOURCES,
+        )
+
+    return ArtifactStep(
+        name="tokenized/grug-a2b-agentic-sft-eot",
+        version="2026.08.05",
+        artifact_type=TokenizedCache,
+        run=tokenize,
+        build_config=build_config,
+        deps=(rendered,),
+    )
+
+
+if __name__ == "__main__":
+    dataset_main({"grug-a2b-agentic-sft-eot": grug_a2b_agentic_sft_eot_dataset()})

--- a/experiments/datasets/instruction.py
+++ b/experiments/datasets/instruction.py
@@ -635,10 +635,13 @@ def transform_dataset_step(dataset_cfg: InstructionDatasetConfig) -> ArtifactSte
         {dataset_cfg.revision}\
         -{sorted(dataset_cfg.subsets)}\
         -{sorted(dataset_cfg.splits)}\
-        -{sorted(dataset_cfg.columns) if dataset_cfg.columns is not None else None}\
-        -{dataset_cfg.parquet_files}\
-        -{dataset_cfg.parquet_batch_size}\
         -{adapter_signature_str}"
+    if dataset_cfg.columns is not None or dataset_cfg.parquet_files or dataset_cfg.parquet_batch_size is not None:
+        config_str += (
+            f"-{sorted(dataset_cfg.columns) if dataset_cfg.columns is not None else None}"
+            f"-{dataset_cfg.parquet_files}"
+            f"-{dataset_cfg.parquet_batch_size}"
+        )
     hashed_config_str = hashlib.md5(config_str.encode()).hexdigest()[:6]
 
     pin = f"documents/{dataset_name}-{dataset_cfg.revision}-{hashed_config_str}"

--- a/experiments/datasets/instruction.py
+++ b/experiments/datasets/instruction.py
@@ -119,6 +119,9 @@ class InstructionDatasetConfig:
         splits: Data splits (e.g., `train`, `validation`) to use. Empty list indicates to use all splits.
                 Defaults to `train` only
         name: Optional friendly name for the dataset; defaults to `hf_dataset_id`.
+        columns: Source columns to read. None reads every column.
+        parquet_files: Hugging Face Parquet files to read directly, keyed by subset.
+        parquet_batch_size: Record-batch size for direct Parquet reads.
         max_parallelism: Max number of parallel data processing tasks. Reduce if needed to avoid HF rate limits.
     """
 
@@ -129,6 +132,9 @@ class InstructionDatasetConfig:
     name: str | None = None
     subsets: list[str] = field(default_factory=lambda: [])
     splits: list[str] = field(default_factory=lambda: ["train"])
+    columns: list[str] | None = None
+    parquet_files: dict[str, list[str]] = field(default_factory=dict)
+    parquet_batch_size: int | None = None
     max_parallelism: int | None = 32  # 32 works for free users; set to None to use default behavior (full parallelism)
 
 
@@ -629,6 +635,9 @@ def transform_dataset_step(dataset_cfg: InstructionDatasetConfig) -> ArtifactSte
         {dataset_cfg.revision}\
         -{sorted(dataset_cfg.subsets)}\
         -{sorted(dataset_cfg.splits)}\
+        -{sorted(dataset_cfg.columns) if dataset_cfg.columns is not None else None}\
+        -{dataset_cfg.parquet_files}\
+        -{dataset_cfg.parquet_batch_size}\
         -{adapter_signature_str}"
     hashed_config_str = hashlib.md5(config_str.encode()).hexdigest()[:6]
 
@@ -647,6 +656,9 @@ def transform_dataset_step(dataset_cfg: InstructionDatasetConfig) -> ArtifactSte
             adapter=_adapter,
             subsets=_cfg.subsets,
             splits=_cfg.splits,
+            columns=_cfg.columns,
+            parquet_files=_cfg.parquet_files,
+            parquet_batch_size=_cfg.parquet_batch_size,
             max_parallelism=_cfg.max_parallelism,
         ),
         override_path=pin,

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -445,9 +445,10 @@ class PackedTokenDataset(MappedAsyncDataset[tuple[dict, dict], GrugLmExample]):
 
             def _map(e: tuple[dict, dict]) -> GrugLmExample:
                 example, seg_ids = e
-                loss_weight = self.loss_weight_transform.apply(example[loss_weights_key])
+                segment_ids = seg_ids[input_ids_key]
+                loss_weight = self.loss_weight_transform.apply(example[loss_weights_key], segment_ids)
                 # pyrefly: ignore[bad-return, bad-argument-count]  # eqx.filter_jit wrapper hides the real signature
-                return _create_lm_example(example[input_ids_key], loss_weight, seg_ids[input_ids_key])
+                return _create_lm_example(example[input_ids_key], loss_weight, segment_ids)
 
             super().__init__(self.packed, _map)
             return

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -5,7 +5,7 @@ import abc
 import dataclasses
 import functools
 import logging
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from functools import cached_property
@@ -46,6 +46,7 @@ from levanter.data.text.examples import (
 from levanter.data.text.formats import (
     ChatLmDatasetFormat,
     LmDatasetFormatBase,
+    LossWeightTransform,
     PrebuiltLmDatasetFormat,
     ProcessedChatDict,
     TextLmDatasetFormat,
@@ -168,10 +169,6 @@ class CausalLmDataset(MappedAsyncDataset[TokenSeqDict, GrugLmExample]):
         return await self.dataset.async_len()
 
 
-def _identity_loss_weight(loss_weight: np.ndarray) -> np.ndarray:
-    return loss_weight
-
-
 class PrebuiltLmDataset(MappedAsyncDataset[dict, GrugLmExample]):
     """
     A dataset that maps prebuilt cache entries to GrugLmExample instances.
@@ -184,7 +181,7 @@ class PrebuiltLmDataset(MappedAsyncDataset[dict, GrugLmExample]):
         *,
         input_ids_key: str,
         loss_weights_key: str | None,
-        loss_weight_transform: Callable[[np.ndarray], np.ndarray] | None,
+        loss_weight_transform: LossWeightTransform,
         eos_id: int | None = None,
         block_cross_document_attention: bool = True,
     ):
@@ -194,7 +191,7 @@ class PrebuiltLmDataset(MappedAsyncDataset[dict, GrugLmExample]):
         self.block_cross_document_attention = block_cross_document_attention
         self.input_ids_key = input_ids_key
         self.loss_weights_key = loss_weights_key
-        self.loss_weight_transform = loss_weight_transform or _identity_loss_weight
+        self.loss_weight_transform = loss_weight_transform
 
         sharding = _single_cpu_sharding()
 
@@ -229,7 +226,7 @@ class PrebuiltLmDataset(MappedAsyncDataset[dict, GrugLmExample]):
 
             def _map(example: dict) -> GrugLmExample:
                 loss_weight = example[loss_weights_key]
-                loss_weight = self.loss_weight_transform(loss_weight)
+                loss_weight = self.loss_weight_transform.apply(loss_weight)
                 # pyrefly: ignore[bad-return, bad-argument-count]  # eqx.filter_jit wrapper hides the real signature
                 return _create_lm_example(example[input_ids_key], loss_weight)
 
@@ -330,6 +327,7 @@ class DatasetComponent(DatasetComponentBase):
     cache_dir: str | None = None
     format: LmDatasetFormatBase = field(default_factory=TextLmDatasetFormat)
     pack: bool | int | None = None
+    packed_slice_strategy: Literal["left", "right", "raise"] = "left"
     tags: list[str] | None = None
     split: str = "validation"
     flat_cache: bool = False
@@ -394,7 +392,9 @@ class PackedTokenDataset(MappedAsyncDataset[tuple[dict, dict], GrugLmExample]):
         Pos: Axis,
         max_segments_per_example: int = 64,
         slice_strategy: Literal["left", "right", "raise"] = "left",
+        input_ids_key: str = "input_ids",
         loss_weights_key: str | None = None,
+        loss_weight_transform: LossWeightTransform = LossWeightTransform.IDENTITY,
         block_cross_document_attention: bool = True,
     ):
         self.packed: GreedyPrepackedDataset[dict] = GreedyPrepackedDataset(
@@ -405,7 +405,9 @@ class PackedTokenDataset(MappedAsyncDataset[tuple[dict, dict], GrugLmExample]):
         )
         self.Pos = Pos
         self.block_cross_document_attention = block_cross_document_attention
+        self.input_ids_key = input_ids_key
         self.loss_weights_key = loss_weights_key
+        self.loss_weight_transform = loss_weight_transform
 
         sharding = _single_cpu_sharding()
 
@@ -414,9 +416,9 @@ class PackedTokenDataset(MappedAsyncDataset[tuple[dict, dict], GrugLmExample]):
             @functools.partial(eqx.filter_jit)
             def _create_lm_example(e: tuple[dict, dict]) -> GrugLmExample:
                 example, seg_ids = e
-                tokens = example["input_ids"]
+                tokens = example[input_ids_key]
                 loss_weight = jnp.ones_like(tokens, dtype=jnp.float32)
-                seg_ids_raw = seg_ids["input_ids"]
+                seg_ids_raw = seg_ids[input_ids_key]
                 out = GrugLmExample.causal(
                     tokens=tokens,
                     loss_weight=loss_weight,
@@ -430,11 +432,7 @@ class PackedTokenDataset(MappedAsyncDataset[tuple[dict, dict], GrugLmExample]):
         else:
 
             @functools.partial(eqx.filter_jit)
-            def _create_lm_example(e: tuple[dict, dict]) -> GrugLmExample:
-                example, seg_ids = e
-                tokens = example["input_ids"]
-                loss_weight = example[loss_weights_key]
-                seg_ids_raw = seg_ids["input_ids"]
+            def _create_lm_example(tokens: jax.Array, loss_weight: jax.Array, seg_ids_raw: jax.Array) -> GrugLmExample:
                 out = GrugLmExample.causal(
                     tokens=tokens,
                     loss_weight=loss_weight,
@@ -444,6 +442,15 @@ class PackedTokenDataset(MappedAsyncDataset[tuple[dict, dict], GrugLmExample]):
                 )
                 out = jax.lax.with_sharding_constraint(out, sharding)
                 return out
+
+            def _map(e: tuple[dict, dict]) -> GrugLmExample:
+                example, seg_ids = e
+                loss_weight = self.loss_weight_transform.apply(example[loss_weights_key])
+                # pyrefly: ignore[bad-return, bad-argument-count]  # eqx.filter_jit wrapper hides the real signature
+                return _create_lm_example(example[input_ids_key], loss_weight, seg_ids[input_ids_key])
+
+            super().__init__(self.packed, _map)
+            return
 
         super().__init__(self.packed, _create_lm_example)
 
@@ -513,7 +520,9 @@ def dataset_for_component(
     fmt = component.format
     if isinstance(fmt, TextLmDatasetFormat):
         if pack:
-            max_segments, slice_strategy = _resolve_pack_config(pack)
+            max_segments, slice_strategy = _resolve_pack_config(
+                pack, packed_slice_strategy=component.packed_slice_strategy
+            )
             return PackedTokenDataset(
                 cache,
                 Pos,
@@ -529,7 +538,9 @@ def dataset_for_component(
         )
     elif isinstance(fmt, ChatLmDatasetFormat):
         # Chat has no continuous-stream mode: a falsy pack means one conversation per example.
-        max_segments, slice_strategy = _resolve_pack_config(pack)
+        max_segments, slice_strategy = _resolve_pack_config(
+            pack, packed_slice_strategy=component.packed_slice_strategy
+        )
         return ChatDataset(
             cache,
             Pos,
@@ -539,6 +550,20 @@ def dataset_for_component(
             block_cross_document_attention=block_cross_document_attention,
         )  # type: ignore
     elif isinstance(fmt, PrebuiltLmDatasetFormat):
+        if pack:
+            max_segments, slice_strategy = _resolve_pack_config(
+                pack, packed_slice_strategy=component.packed_slice_strategy
+            )
+            return PackedTokenDataset(
+                cache,
+                Pos,
+                max_segments_per_example=max_segments,
+                slice_strategy=slice_strategy,
+                input_ids_key=fmt.input_ids_key,
+                loss_weights_key=fmt.loss_weights_key,
+                loss_weight_transform=fmt.loss_weight_transform,
+                block_cross_document_attention=block_cross_document_attention,
+            )
         return PrebuiltLmDataset(
             cache,
             Pos,

--- a/lib/levanter/src/levanter/data/text/formats.py
+++ b/lib/levanter/src/levanter/data/text/formats.py
@@ -1,8 +1,9 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any, TypedDict
 
 import numpy as np
@@ -70,6 +71,20 @@ class ChatLmDatasetFormat(LmDatasetFormatBase):
         )
 
 
+class LossWeightTransform(StrEnum):
+    """Serializable transforms applied to prebuilt per-token loss weights."""
+
+    IDENTITY = "identity"
+    SHIFT_LEFT = "shift_left"
+
+    def apply(self, loss_weight: np.ndarray) -> np.ndarray:
+        if self is LossWeightTransform.IDENTITY:
+            return loss_weight
+        if self is LossWeightTransform.SHIFT_LEFT:
+            return np.roll(loss_weight, -1)
+        raise ValueError(f"Unknown loss weight transform {self}")
+
+
 @LmDatasetFormatBase.register_subclass("prebuilt")
 @dataclass(frozen=True)
 class PrebuiltLmDatasetFormat(LmDatasetFormatBase):
@@ -78,12 +93,12 @@ class PrebuiltLmDatasetFormat(LmDatasetFormatBase):
     Attributes:
         input_ids_key: Field name containing token ids.
         loss_weights_key: Optional field name containing loss weights.
-        loss_weight_transform: Optional callable to transform loss weights before training.
+        loss_weight_transform: Transform applied to loss weights before training.
     """
 
     input_ids_key: str = "input_ids"
     loss_weights_key: str | None = None
-    loss_weight_transform: Callable[[np.ndarray], np.ndarray] | None = None
+    loss_weight_transform: LossWeightTransform = LossWeightTransform.IDENTITY
 
     @property
     def token_data_key(self) -> str:

--- a/lib/levanter/src/levanter/data/text/formats.py
+++ b/lib/levanter/src/levanter/data/text/formats.py
@@ -77,11 +77,15 @@ class LossWeightTransform(StrEnum):
     IDENTITY = "identity"
     SHIFT_LEFT = "shift_left"
 
-    def apply(self, loss_weight: np.ndarray) -> np.ndarray:
+    def apply(self, loss_weight: np.ndarray, segment_ids: np.ndarray | None = None) -> np.ndarray:
         if self is LossWeightTransform.IDENTITY:
             return loss_weight
         if self is LossWeightTransform.SHIFT_LEFT:
-            return np.roll(loss_weight, -1)
+            shifted = np.roll(loss_weight, -1)
+            valid_next = np.arange(loss_weight.shape[0]) < loss_weight.shape[0] - 1
+            if segment_ids is not None:
+                valid_next &= segment_ids == np.roll(segment_ids, -1)
+            return np.where(valid_next, shifted, 0)
         raise ValueError(f"Unknown loss weight transform {self}")
 
 

--- a/lib/levanter/tests/test_text.py
+++ b/lib/levanter/tests/test_text.py
@@ -28,6 +28,7 @@ from levanter.data.text.examples import GrugLmExample, grug_lm_example_from_name
 from levanter.data.text.formats import (
     ChatLmDatasetFormat,
     LmDatasetFormatBase,
+    LossWeightTransform,
     PrebuiltLmDatasetFormat,
     TextLmDatasetFormat,
     preprocessor_for_format,
@@ -356,7 +357,7 @@ def test_prebuilt_cache_with_loss_weights(tmp_path):
         source=UrlDatasetSourceConfig(train_urls=[str(data_path)], validation_urls=[]),
         format=PrebuiltLmDatasetFormat(
             loss_weights_key="loss_weights",
-            loss_weight_transform=lambda weights: weights * 2.0,
+            loss_weight_transform=LossWeightTransform.SHIFT_LEFT,
         ),
         cache_dir=str(tmp_path),
     )
@@ -378,8 +379,76 @@ def test_prebuilt_cache_with_loss_weights(tmp_path):
 
     example = ds[0]
     np.testing.assert_array_equal(np.asarray(example.tokens), np.array(records[0]["input_ids"], dtype=np.int32))
-    expected_loss_weight = np.array([2.0, 1.0, 0.0, 0.0], dtype=np.asarray(example.loss_weight).dtype)
+    expected_loss_weight = np.array([0.5, 0.0, 1.0, 0.0], dtype=np.asarray(example.loss_weight).dtype)
     np.testing.assert_array_equal(np.asarray(example.loss_weight), expected_loss_weight)
+
+
+def test_prebuilt_cache_packs_variable_length_records_with_transformed_loss_weights(tmp_path):
+    records = [
+        {"input_ids": [1, 2, 3], "assistant_mask": [0.0, 1.0, 1.0]},
+        {"input_ids": [4, 5], "assistant_mask": [0.0, 1.0]},
+    ]
+    data_path = tmp_path / "prebuilt_packed.jsonl"
+    _write_prebuilt_jsonl(data_path, records)
+
+    component = DatasetComponent(
+        source=UrlDatasetSourceConfig(train_urls=[str(data_path)], validation_urls=[]),
+        format=PrebuiltLmDatasetFormat(
+            loss_weights_key="assistant_mask",
+            loss_weight_transform=LossWeightTransform.SHIFT_LEFT,
+        ),
+        cache_dir=str(tmp_path),
+        pack=True,
+    )
+    config = LmDataConfig(
+        components={"prebuilt": component},
+        tokenizer="passthrough",
+        vocab_size=16,
+    )
+
+    cache = config.build_caches("train")["prebuilt"]
+    Pos = hax.Axis("position", 8)
+    ds = dataset_for_component(
+        component,
+        Pos,
+        cache,
+        eos_id=None,
+        block_cross_document_attention=config.block_cross_document_attention,
+    ).as_sync_dataset()
+
+    assert len(ds) == 1
+    example = ds[0]
+    np.testing.assert_array_equal(np.asarray(example.tokens), np.array([1, 2, 3, 4, 5, 0, 0, 0]))
+    np.testing.assert_array_equal(np.asarray(example.loss_weight), np.array([1, 1, 0, 1, 0, 0, 0, 0]))
+
+
+def test_prebuilt_cache_right_slices_overlength_record(tmp_path):
+    records = [{"input_ids": [1, 2, 3, 4, 5, 6], "assistant_mask": [0.0, 0.0, 1.0, 1.0, 1.0, 1.0]}]
+    data_path = tmp_path / "prebuilt_right_slice.jsonl"
+    _write_prebuilt_jsonl(data_path, records)
+    component = DatasetComponent(
+        source=UrlDatasetSourceConfig(train_urls=[str(data_path)], validation_urls=[]),
+        format=PrebuiltLmDatasetFormat(
+            loss_weights_key="assistant_mask",
+            loss_weight_transform=LossWeightTransform.SHIFT_LEFT,
+        ),
+        cache_dir=str(tmp_path),
+        pack=True,
+        packed_slice_strategy="right",
+    )
+    config = LmDataConfig(components={"prebuilt": component}, tokenizer="passthrough", vocab_size=16)
+    cache = config.build_caches("train")["prebuilt"]
+
+    example = dataset_for_component(
+        component,
+        hax.Axis("position", 4),
+        cache,
+        eos_id=None,
+        block_cross_document_attention=True,
+    ).as_sync_dataset()[0]
+
+    np.testing.assert_array_equal(np.asarray(example.tokens), np.array([3, 4, 5, 6]))
+    np.testing.assert_array_equal(np.asarray(example.loss_weight), np.array([1, 1, 1, 0]))
 
 
 def test_build_caches_surfaces_component_failure(tmp_path):

--- a/lib/levanter/tests/test_text.py
+++ b/lib/levanter/tests/test_text.py
@@ -386,7 +386,7 @@ def test_prebuilt_cache_with_loss_weights(tmp_path):
 def test_prebuilt_cache_packs_variable_length_records_with_transformed_loss_weights(tmp_path):
     records = [
         {"input_ids": [1, 2, 3], "assistant_mask": [0.0, 1.0, 1.0]},
-        {"input_ids": [4, 5], "assistant_mask": [0.0, 1.0]},
+        {"input_ids": [4, 5], "assistant_mask": [1.0, 0.0]},
     ]
     data_path = tmp_path / "prebuilt_packed.jsonl"
     _write_prebuilt_jsonl(data_path, records)
@@ -419,7 +419,7 @@ def test_prebuilt_cache_packs_variable_length_records_with_transformed_loss_weig
     assert len(ds) == 1
     example = ds[0]
     np.testing.assert_array_equal(np.asarray(example.tokens), np.array([1, 2, 3, 4, 5, 0, 0, 0]))
-    np.testing.assert_array_equal(np.asarray(example.loss_weight), np.array([1, 1, 0, 1, 0, 0, 0, 0]))
+    np.testing.assert_array_equal(np.asarray(example.loss_weight), np.array([1, 1, 0, 0, 0, 0, 0, 0]))
 
 
 def test_prebuilt_cache_right_slices_overlength_record(tmp_path):

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -21,6 +21,7 @@ import re
 import time
 from collections.abc import Sequence
 
+import draccus
 from datasets import load_dataset_builder
 from fray.types import ResourceConfig
 from levanter.data.text.datasets import (
@@ -99,10 +100,10 @@ class TokenizedCache(Artifact):
 
     @property
     def format(self) -> LmDatasetFormatBase:
-        """The dataset format; marin's tokenized caches are text format (``text_key``)."""
+        """Reconstruct the dataset format recorded when this cache was built."""
         fmt = self._config.get("format")
-        if isinstance(fmt, dict) and "text_key" in fmt:
-            return TextLmDatasetFormat(text_key=fmt["text_key"])
+        if isinstance(fmt, dict):
+            return draccus.decode(LmDatasetFormatBase, fmt)
         return TextLmDatasetFormat()
 
     @property

--- a/lib/marin/src/marin/transform/conversation/transform_conversation.py
+++ b/lib/marin/src/marin/transform/conversation/transform_conversation.py
@@ -22,7 +22,9 @@ from typing import Any
 import datasets
 import draccus
 import fsspec
+import pyarrow.parquet as pq
 from fray.types import ResourceConfig
+from huggingface_hub import hf_hub_url
 from marin.core.conversation import DolmaConversationOutput, OpenAIChatMessage
 from marin.utils import load_dataset_with_backoff
 from rigging.filesystem import StoragePath, prefix_join, url_to_fs
@@ -38,7 +40,7 @@ from .adapters import TransformAdapter
 # 1 GiB that ZephyrContext floors an unset ``resources`` to OOM-kills the worker mid-shard. Give each
 # worker headroom; this is a runtime resource only and does not enter the transform's data
 # fingerprint or output path, so bumping it never forks an existing cache.
-_TRANSFORM_WORKER_RESOURCES = ResourceConfig(cpu=1, ram="8g")
+_TRANSFORM_WORKER_RESOURCES = ResourceConfig(cpu=1, ram="16g")
 
 _RESERVED_TOP_LEVEL_FIELDS = {"id", "source", "messages", "added", "created", "metadata"}
 DEFAULT_TEXT_REPLACEMENTS = {"<think>": "<|start_think|>", "</think>": "<|end_think|>"}
@@ -58,6 +60,9 @@ class TransformSFTDatasetConfig:
         adapter (TransformAdapter): Adapter responsible for mapping raw rows into OpenAI chat format.
         subsets (list[str]): Data subsets (from HuggingFace config) to use. Empty list indicates all/default subset(s).
         splits (list[str]): Data splits (e.g., `train`, `validation`) to use. Empty list indicates all splits.
+        columns (list[str] | None): Source columns to read. None reads every column.
+        parquet_files (dict[str, list[str]]): Hugging Face Parquet files to read directly, keyed by subset.
+        parquet_batch_size (int | None): Record-batch size for direct Parquet reads.
         max_parallelism (int | None): Maximum number of concurrent shard processing tasks.
             Set to lower values to avoid HF rate limits. Set to None for default behavior (full concurrency).
     """
@@ -69,7 +74,14 @@ class TransformSFTDatasetConfig:
     adapter: TransformAdapter
     subsets: list[str] = field(default_factory=lambda: [])  # Default behavior is to use all subsets
     splits: list[str] = field(default_factory=lambda: ["train"])  # Set to train; empty set means everything
+    columns: list[str] | None = None
+    parquet_files: dict[str, list[str]] = field(default_factory=dict)
+    parquet_batch_size: int | None = None
     max_parallelism: int | None = None  # None means use default behavior (full concurrency)
+
+    def __post_init__(self) -> None:
+        if self.parquet_files and self.parquet_batch_size is None:
+            raise ValueError("parquet_batch_size is required when parquet_files are configured")
 
 
 @dataclass(frozen=True)
@@ -232,7 +244,13 @@ def _shard_filename(output_path: str, shard_idx: int) -> str:
     return prefix_join(output_path, f"shard_{shard_idx:05d}.jsonl.gz")
 
 
-def _streaming_dataset_kwargs(source: str, split: str, revision: str, subset: str | None) -> dict[str, object]:
+def _streaming_dataset_kwargs(
+    source: str,
+    split: str,
+    revision: str,
+    subset: str | None,
+    columns: list[str] | None,
+) -> dict[str, object]:
     """Build kwargs for a streaming ``datasets.load_dataset`` call.
 
     The HF config name is omitted for the default/unnamed subset so the loader
@@ -246,7 +264,20 @@ def _streaming_dataset_kwargs(source: str, split: str, revision: str, subset: st
     }
     if subset not in (None, "default"):
         kwargs["name"] = subset
+    if columns is not None:
+        kwargs["columns"] = columns
     return kwargs
+
+
+def _direct_parquet_rows(task: ShardTask, subset_name: str):
+    batch_size = task.cfg.parquet_batch_size
+    assert batch_size is not None
+    filename = task.cfg.parquet_files[subset_name][task.shard_idx]
+    url = hf_hub_url(task.source, filename, repo_type="dataset", revision=task.revision)
+    with fsspec.open(url, "rb") as source:
+        parquet = pq.ParquetFile(source)
+        for batch in parquet.iter_batches(batch_size=batch_size, columns=task.cfg.columns):
+            yield from batch.to_pylist()
 
 
 def get_shard_dir(dir_name: str, subset_name: str | None, split: str) -> str:
@@ -293,11 +324,15 @@ def get_dataset_tasks(cfg: TransformSFTDatasetConfig):
             subset_output_path = get_shard_dir(cfg.output_path, subset_name, split)
             output_path = create_shard_output_directory(subset_output_path)
 
-            dataset = load_dataset_with_backoff(
-                context=f"{source} subset={subset_name} split={split}",
-                **_streaming_dataset_kwargs(source, split, revision, subset),
-            )
-            num_shards = dataset.num_shards
+            parquet_files = cfg.parquet_files.get(subset_name)
+            if parquet_files is not None:
+                num_shards = len(parquet_files)
+            else:
+                dataset = load_dataset_with_backoff(
+                    context=f"{source} subset={subset_name} split={split}",
+                    **_streaming_dataset_kwargs(source, split, revision, subset, cfg.columns),
+                )
+                num_shards = dataset.num_shards
             if not num_shards:
                 raise ValueError(f"Streaming dataset {source} subset={subset} split={split} does not expose num_shards.")
 
@@ -340,15 +375,18 @@ def process_shard_task(task: ShardTask) -> dict:
             "skipped": True,
         }
 
-    dataset = load_dataset_with_backoff(
-        context=f"{task.source} subset={subset_name} split={task.split} shard={task.shard_idx}",
-        **_streaming_dataset_kwargs(task.source, task.split, task.revision, task.subset),
-    )
-    shard_dataset = dataset.shard(num_shards=task.num_shards, index=task.shard_idx)
+    if subset_name in task.cfg.parquet_files:
+        raw_rows = _direct_parquet_rows(task, subset_name)
+    else:
+        dataset = load_dataset_with_backoff(
+            context=f"{task.source} subset={subset_name} split={task.split} shard={task.shard_idx}",
+            **_streaming_dataset_kwargs(task.source, task.split, task.revision, task.subset, task.cfg.columns),
+        )
+        raw_rows = dataset.shard(num_shards=task.num_shards, index=task.shard_idx)
 
     def transform_records():
         """Generator that yields transformed records."""
-        for raw_row in shard_dataset:
+        for raw_row in raw_rows:
             transformed_row = transform_row(raw_row, task.cfg, adapter)
             if transformed_row is not None:
                 yield transformed_row.model_dump()

--- a/tests/processing/tokenize/test_tokenize.py
+++ b/tests/processing/tokenize/test_tokenize.py
@@ -11,12 +11,14 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 from levanter.data.mixture import MixtureDataset
-from levanter.data.text.formats import TextLmDatasetFormat
+from levanter.data.text.formats import LossWeightTransform, PrebuiltLmDatasetFormat, TextLmDatasetFormat
 from levanter.store.cache import CacheLedger, TreeCache
+from marin.execution.artifact import ArtifactRecord, write_record
 from marin.processing.tokenize.tokenize import (
     MIN_GROUP_BYTES,
     HfTokenizeConfig,
     TokenizeConfig,
+    TokenizedCache,
     bundle_files_by_size,
     compute_target_group_bytes,
     tokenize,
@@ -28,6 +30,31 @@ from zephyr.readers import InputFileSpec
 DUMMY_CACHE_PATH = "/dummy/cache"
 DUMMY_TOKENIZER = "dummy_tokenizer"
 DUMMY_VALIDATION_PATHS = []
+
+
+def test_tokenized_cache_preserves_prebuilt_format(tmp_path: Path):
+    write_record(
+        ArtifactRecord(
+            output_path=str(tmp_path),
+            config={
+                "tokenizer": "passthrough",
+                "format": {
+                    "type": "prebuilt",
+                    "input_ids_key": "tokens",
+                    "loss_weights_key": "assistant_mask",
+                    "loss_weight_transform": "shift_left",
+                },
+            },
+        )
+    )
+
+    component = TokenizedCache(path=str(tmp_path)).as_component()
+
+    assert component.format == PrebuiltLmDatasetFormat(
+        input_ids_key="tokens",
+        loss_weights_key="assistant_mask",
+        loss_weight_transform=LossWeightTransform.SHIFT_LEFT,
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/transform/test_conversation.py
+++ b/tests/transform/test_conversation.py
@@ -17,6 +17,8 @@ from marin.transform.conversation.transform_conversation import (
     transform_row,
 )
 
+from experiments.datasets.instruction import InstructionDatasetConfig, transform_dataset_step
+
 OPENAI_FORMAT_SAMPLE = {
     "messages": [
         {"role": "user", "content": "What is the capital of France?"},
@@ -413,3 +415,25 @@ def test_direct_parquet_source_preserves_selected_conversations(tmp_path: Path, 
     assert result["count"] == 1
     assert [message["content"] for message in rows[0]["messages"]] == ["Run the tests.", "Done."]
     assert "unused" not in rows[0]
+
+
+def test_default_instruction_source_keeps_existing_cache_pin():
+    adapter = TransformAdapter(
+        dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
+        conversation_column="conversations",
+        role_key="role",
+        content_key="content",
+        user_value="user",
+        assistant_value="assistant",
+        system_value="system",
+    )
+    cfg = InstructionDatasetConfig(
+        hf_dataset_id="example/conversations",
+        revision="deadbee",
+        metadata_columns=[],
+        adapter=adapter,
+        subsets=["terminal"],
+        splits=["train"],
+    )
+
+    assert transform_dataset_step(cfg).override_path == "documents/example--conversations-deadbee-28fea3"

--- a/tests/transform/test_conversation.py
+++ b/tests/transform/test_conversation.py
@@ -5,11 +5,15 @@
 
 from pathlib import Path
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 from marin.transform.conversation.adapters import InputDatasetFormat, TransformAdapter
 from marin.transform.conversation.conversation_to_dolma import transform_conversation_to_dolma
 from marin.transform.conversation.preference_data_adapters import PreferenceTransformAdapter
 from marin.transform.conversation.transform_conversation import (
     TransformSFTDatasetConfig,
+    get_dataset_tasks,
+    process_shard_task,
     transform_row,
 )
 
@@ -357,3 +361,55 @@ class TestEndToEndTransforms:
         assert all("messages" not in r for r in dolma_results)
         assert "user: Hello" in dolma_results[0]["text"]
         assert "assistant: Hi there" in dolma_results[0]["text"]
+
+
+def test_direct_parquet_source_preserves_selected_conversations(tmp_path: Path, monkeypatch, read_jsonl_gz):
+    parquet_path = tmp_path / "source.parquet"
+    pq.write_table(
+        pa.Table.from_pylist(
+            [
+                {
+                    "conversations": [
+                        {"role": "user", "content": "Run the tests."},
+                        {"role": "assistant", "content": "Done."},
+                    ],
+                    "unused": "not projected",
+                }
+            ]
+        ),
+        parquet_path,
+    )
+    adapter = TransformAdapter(
+        dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
+        conversation_column="conversations",
+        role_key="role",
+        content_key="content",
+        user_value="user",
+        assistant_value="assistant",
+        system_value="system",
+    )
+    cfg = TransformSFTDatasetConfig(
+        source="example/conversations",
+        revision="deadbee",
+        output_path=str(tmp_path / "output"),
+        metadata_columns=[],
+        adapter=adapter,
+        subsets=["terminal"],
+        splits=["train"],
+        columns=["conversations"],
+        parquet_files={"terminal": [str(parquet_path)]},
+        parquet_batch_size=1,
+    )
+    monkeypatch.setattr(
+        "marin.transform.conversation.transform_conversation.hf_hub_url",
+        lambda _repo, filename, **_kwargs: filename,
+    )
+
+    tasks = list(get_dataset_tasks(cfg))
+    assert len(tasks) == 1
+    result = process_shard_task(tasks[0])
+    rows = read_jsonl_gz(Path(result["path"]))
+
+    assert result["count"] == 1
+    assert [message["content"] for message in rows[0]["messages"]] == ["Run the tests.", "Done."]
+    assert "unused" not in rows[0]


### PR DESCRIPTION
Preserve the exact fixed-EOT input used by the August Grug agentic SFT run as an immutable, versioned derived artifact. Levanter can now consume its prebuilt token IDs and assistant mask without silently changing causal-label alignment, truncation, or packing behavior.

This stacks on #7830 instead of duplicating its Harbor converter. That PR remains the canonical path from Harbor traces to structured `messages` and `tools`; the historical rendered artifact remains separate because rewriting the canonical records for one trainee tokenizer and template would destroy their reuse and provenance. A future non-destructive regeneration step should consume every output in #7830's pinned manifest, preserve serialized tools, pin the trainee tokenizer and template, verify the 77,012 accepted rows and rendered token/mask hashes, and publish a new derived version before replacing the adopted artifact.

The change also adds opt-in column and Parquet-file selection to structured conversation ingestion. This preserves the exact Nemotron Terminal control subset recovered from the August workspace while leaving ordinary Hugging Face streaming unchanged.

Part of #7743. Depends on #7830.

Validated with the 30 Levanter text-format tests, the 10 conversation-transform tests, the required changed-file checks, and the branch review pass.
