### PR TITLE
[sft] Restore the August Snowball launch stages

### DIFF
--- a/experiments/evaluation/fleet.py
+++ b/experiments/evaluation/fleet.py
@@ -20,7 +20,7 @@ MARIN_EVAL_HARDWARE = HardwarePolicy(
     gpu_preference=("H100", "GB200"),
     gpu_profiles=MappingProxyType(
         {
-            "H100": GpuProfile(hbm_gb=80, max_count=8, cluster="cw-us-east-02a"),
+            "H100": GpuProfile(hbm_gb=80, max_count=8, cluster="cw-rno2a"),
             "GB200": GpuProfile(hbm_gb=186, max_count=4, cluster="cw-us-east-08a"),
         }
     ),

--- a/experiments/evaluation/serve/models/penfever/snowball-e6-repro-step20.yaml
+++ b/experiments/evaluation/serve/models/penfever/snowball-e6-repro-step20.yaml
@@ -1,0 +1,23 @@
+name: snowball-e6-repro-step20
+location: s3://marin-us-east-02a/iris/rl-snowball-e6-rno2a-rlvrmath-grug-67b-a-20260812-150653-98cb43/exports/global_step_20/policy/
+tokenizer: marin-community/marin-tokenizer
+apply_chat_template: true
+resource_hint:
+  gpu:
+    H100: 8
+  memory: 512g
+serve:
+  tensor_parallel_size: 1
+  data_parallel_size: 8
+  max_model_len: 32768
+  max_num_batched_tokens: 32768
+  max_num_seqs: 32
+  vllm_extra_args:
+  - --enable-expert-parallel
+  - --model-loader-extra-config
+  - '{"distributed":true}'
+generation:
+  max_gen_toks: 8192
+  extra_gen_kwargs:
+    skip_special_tokens: "false"
+    repetition_penalty: "1.1"

--- a/experiments/evaluation/serve/models/penfever/snowball-hero-v3b-step46.yaml
+++ b/experiments/evaluation/serve/models/penfever/snowball-hero-v3b-step46.yaml
@@ -1,0 +1,23 @@
+name: snowball-hero-v3b-step46
+location: s3://marin-us-east-02a/iris/rl-snowball-hero-v3b-rno2a-rlvrmath-ctx24k-grug-67-20260811-111920/exports/global_step_46/policy/
+tokenizer: marin-community/marin-tokenizer
+apply_chat_template: true
+resource_hint:
+  gpu:
+    H100: 8
+  memory: 512g
+serve:
+  tensor_parallel_size: 1
+  data_parallel_size: 8
+  max_model_len: 32768
+  max_num_batched_tokens: 32768
+  max_num_seqs: 32
+  vllm_extra_args:
+  - --enable-expert-parallel
+  - --model-loader-extra-config
+  - '{"distributed":true}'
+generation:
+  max_gen_toks: 8192
+  extra_gen_kwargs:
+    skip_special_tokens: "false"
+    repetition_penalty: "1.1"

--- a/experiments/evaluation/serve/models/penfever/snowball-step105149-sft-s1-chat.yaml
+++ b/experiments/evaluation/serve/models/penfever/snowball-step105149-sft-s1-chat.yaml
@@ -1,0 +1,23 @@
+name: snowball-step105149-sft-s1-chat
+location: s3://marin-us-east-02a/marin/exports/grug/snowball_step105149_sft_s1_chat/2026.08.13.1/step-257/hf-bf16-vllm/
+tokenizer: marin-community/marin-tokenizer
+apply_chat_template: true
+resource_hint:
+  gpu:
+    H100: 8
+  memory: 512g
+serve:
+  tensor_parallel_size: 1
+  data_parallel_size: 8
+  max_model_len: 32768
+  max_num_batched_tokens: 32768
+  max_num_seqs: 32
+  vllm_extra_args:
+  - --enable-expert-parallel
+  - --model-loader-extra-config
+  - '{"distributed":true}'
+generation:
+  max_gen_toks: 8192
+  extra_gen_kwargs:
+    skip_special_tokens: "false"
+    repetition_penalty: "1.1"

--- a/experiments/evaluation/serve/models/penfever/snowball-step105149-sft-s2-thinking.yaml
+++ b/experiments/evaluation/serve/models/penfever/snowball-step105149-sft-s2-thinking.yaml
@@ -1,0 +1,23 @@
+name: snowball-step105149-sft-s2-thinking
+location: s3://marin-us-east-02a/marin/exports/grug/snowball_step105149_sft_s2_thinking/2026.08.13.1/step-630/hf-bf16-vllm/
+tokenizer: marin-community/marin-tokenizer
+apply_chat_template: true
+resource_hint:
+  gpu:
+    H100: 8
+  memory: 512g
+serve:
+  tensor_parallel_size: 1
+  data_parallel_size: 8
+  max_model_len: 32768
+  max_num_batched_tokens: 32768
+  max_num_seqs: 32
+  vllm_extra_args:
+  - --enable-expert-parallel
+  - --model-loader-extra-config
+  - '{"distributed":true}'
+generation:
+  max_gen_toks: 8192
+  extra_gen_kwargs:
+    skip_special_tokens: "false"
+    repetition_penalty: "1.1"

--- a/experiments/june_tpu_67b_a2b/moe/export_second_cooldown_stage1.py
+++ b/experiments/june_tpu_67b_a2b/moe/export_second_cooldown_stage1.py
@@ -1,0 +1,94 @@
+import dataclasses
+import math
+from typing import Any, cast
+
+import draccus
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from haliax.partitioning import set_mesh
+from levanter.checkpoint import load_checkpoint
+from levanter.grug.sharding import compact_grug_mesh
+from levanter.tokenizers import load_tokenizer
+
+from experiments.grug.moe.model import GrugModelConfig, Transformer
+from experiments.june_tpu_67b_a2b.moe.heuristic_muonh import MoeMuonHHeuristic
+from experiments.june_tpu_67b_a2b.moe.model import GrugModelConfig as VendoredGrugModelConfig
+from experiments.june_tpu_67b_a2b.moe.model import Transformer as VendoredTransformer
+from experiments.marin_tokenizer import MARIN_CHAT_TEMPLATE
+
+CHECKPOINT = (
+    "s3://marin-us-east-02a/marin/grug/"
+    "snowball_step105149_sft_s1_chat/"
+    "2026.08.13.1/checkpoints/step-257/"
+)
+OUTPUT = "s3://marin-us-east-02a/marin/exports/grug/snowball_step105149_sft_s1_chat/2026.08.13.1/step-257/hf-bf16-vllm/"
+
+qk_mult = 1.3 * (0.1 * math.log(65_536 / 8_192) + 1.0)
+model_config = dataclasses.replace(
+    MoeMuonHHeuristic(min_lr_ratio=0.05).build_model_config(2560, seq_len=65_536),
+    disable_pko=True,
+    disable_long_rope=True,
+    sliding_window=2048,
+    use_array_stacked_blocks=True,
+    qk_mult=qk_mult,
+    max_seq_len=32_768,
+    attention_implementation="gpu_fa4_cute",
+    ce_implementation="batched_xla",
+)
+model_dict = dataclasses.asdict(model_config)
+vendored_config = draccus.decode(VendoredGrugModelConfig, model_dict)
+main_fields = {field.name for field in dataclasses.fields(GrugModelConfig)}
+main_config = draccus.decode(GrugModelConfig, {key: value for key, value in model_dict.items() if key in main_fields})
+
+mesh = compact_grug_mesh()
+with set_mesh(mesh):
+    template = eqx.filter_eval_shape(VendoredTransformer.init, vendored_config, key=jax.random.PRNGKey(0))
+    state = load_checkpoint(
+        {
+            "params": template,
+            "pending_qb_betas": jax.ShapeDtypeStruct(
+                (vendored_config.num_layers, vendored_config.num_experts), jnp.float32
+            ),
+        },
+        CHECKPOINT,
+        mesh=mesh,
+    )
+    params = state["params"]
+    pending_qb_betas = state["pending_qb_betas"]
+    del state
+    assert params.stacked_blocks is not None
+    router_bias = -pending_qb_betas
+    router_bias -= jnp.mean(router_bias, axis=-1, keepdims=True)
+    params = eqx.tree_at(lambda tree: tree.stacked_blocks.stacked.mlp.router_bias, params, router_bias)
+    del pending_qb_betas
+    params = jax.tree.map(
+        lambda value: value.astype(jnp.bfloat16) if eqx.is_inexact_array(value) else value,
+        params,
+    )
+    jax.block_until_ready(params)
+
+    source = cast(Any, params)
+    export_model = Transformer(
+        token_embed=source.token_embed,
+        embed_norm=source.embed_norm,
+        embed_gated_norm=source.embed_gated_norm,
+        output_proj=source.output_proj,
+        blocks=tuple(source.stacked_blocks.unstacked()),
+        final_norm=source.final_norm,
+        final_gated_norm=source.final_gated_norm,
+        config=main_config,
+    )
+    tokenizer = load_tokenizer("marin-community/marin-tokenizer")
+    converter = main_config.hf_checkpoint_converter().replaced(tokenizer=tokenizer).with_config_overrides({"dtype": "bfloat16"})
+    converter.save_pretrained(
+        export_model,
+        OUTPUT,
+        dtype=jnp.bfloat16,
+        generation_config={
+            "bos_token_id": 128000,
+            "eos_token_id": [128001, 128009],
+            "pad_token_id": 128001,
+        },
+        chat_template=MARIN_CHAT_TEMPLATE,
+    )

--- a/experiments/june_tpu_67b_a2b/moe/export_second_cooldown_stage2.py
+++ b/experiments/june_tpu_67b_a2b/moe/export_second_cooldown_stage2.py
@@ -1,0 +1,97 @@
+import dataclasses
+import math
+from typing import Any, cast
+
+import draccus
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from haliax.partitioning import set_mesh
+from levanter.checkpoint import load_checkpoint
+from levanter.grug.sharding import compact_grug_mesh
+from levanter.tokenizers import load_tokenizer
+
+from experiments.grug.moe.model import GrugModelConfig, Transformer
+from experiments.june_tpu_67b_a2b.moe.heuristic_muonh import MoeMuonHHeuristic
+from experiments.june_tpu_67b_a2b.moe.model import GrugModelConfig as VendoredGrugModelConfig
+from experiments.june_tpu_67b_a2b.moe.model import Transformer as VendoredTransformer
+from experiments.marin_tokenizer import MARIN_CHAT_TEMPLATE
+
+CHECKPOINT = (
+    "s3://marin-us-east-02a/marin/grug/"
+    "snowball_step105149_sft_s2_thinking/"
+    "2026.08.13.1/checkpoints/step-630/"
+)
+OUTPUT = (
+    "s3://marin-us-east-02a/marin/exports/grug/"
+    "snowball_step105149_sft_s2_thinking/2026.08.13.1/step-630/hf-bf16-vllm/"
+)
+
+qk_mult = 1.3 * (0.1 * math.log(65_536 / 8_192) + 1.0)
+model_config = dataclasses.replace(
+    MoeMuonHHeuristic(min_lr_ratio=0.05).build_model_config(2560, seq_len=65_536),
+    disable_pko=True,
+    disable_long_rope=True,
+    sliding_window=2048,
+    use_array_stacked_blocks=True,
+    qk_mult=qk_mult,
+    max_seq_len=32_768,
+    attention_implementation="gpu_fa4_cute",
+    ce_implementation="batched_xla",
+)
+model_dict = dataclasses.asdict(model_config)
+vendored_config = draccus.decode(VendoredGrugModelConfig, model_dict)
+main_fields = {field.name for field in dataclasses.fields(GrugModelConfig)}
+main_config = draccus.decode(GrugModelConfig, {key: value for key, value in model_dict.items() if key in main_fields})
+
+mesh = compact_grug_mesh()
+with set_mesh(mesh):
+    template = eqx.filter_eval_shape(VendoredTransformer.init, vendored_config, key=jax.random.PRNGKey(0))
+    state = load_checkpoint(
+        {
+            "params": template,
+            "pending_qb_betas": jax.ShapeDtypeStruct(
+                (vendored_config.num_layers, vendored_config.num_experts), jnp.float32
+            ),
+        },
+        CHECKPOINT,
+        mesh=mesh,
+    )
+    params = state["params"]
+    pending_qb_betas = state["pending_qb_betas"]
+    del state
+    assert params.stacked_blocks is not None
+    router_bias = -pending_qb_betas
+    router_bias -= jnp.mean(router_bias, axis=-1, keepdims=True)
+    params = eqx.tree_at(lambda tree: tree.stacked_blocks.stacked.mlp.router_bias, params, router_bias)
+    del pending_qb_betas
+    params = jax.tree.map(
+        lambda value: value.astype(jnp.bfloat16) if eqx.is_inexact_array(value) else value,
+        params,
+    )
+    jax.block_until_ready(params)
+
+    source = cast(Any, params)
+    export_model = Transformer(
+        token_embed=source.token_embed,
+        embed_norm=source.embed_norm,
+        embed_gated_norm=source.embed_gated_norm,
+        output_proj=source.output_proj,
+        blocks=tuple(source.stacked_blocks.unstacked()),
+        final_norm=source.final_norm,
+        final_gated_norm=source.final_gated_norm,
+        config=main_config,
+    )
+    tokenizer = load_tokenizer("marin-community/marin-tokenizer")
+    converter = main_config.hf_checkpoint_converter().replaced(tokenizer=tokenizer).with_config_overrides({"dtype": "bfloat16"})
+    converter.save_pretrained(
+        export_model,
+        OUTPUT,
+        dtype=jnp.bfloat16,
+        generation_config={
+            "bos_token_id": 128000,
+            "eos_token_id": [128001, 128009],
+            "pad_token_id": 128001,
+        },
+        chat_template=MARIN_CHAT_TEMPLATE,
+    )

--- a/experiments/june_tpu_67b_a2b/moe/export_second_cooldown_stage3.py
+++ b/experiments/june_tpu_67b_a2b/moe/export_second_cooldown_stage3.py
@@ -1,0 +1,36 @@
+STAGE3_CHECKPOINT = (
+    "s3://marin-us-east-02a/marin/grug/snowball_step105149_sft_s3_agentic_eot_5ep/"
+    "2026.08.13.1/checkpoints/step-1888/"
+)
+STAGE3_OUTPUT = (
+    "s3://marin-us-east-02a/marin/exports/grug/snowball_step105149_sft_s3_agentic_eot_5ep/"
+    "2026.08.13.1/step-1888/hf-bf16-vllm/"
+)
+
+
+def main() -> None:
+    source_path = __file__.replace("export_second_cooldown_stage3.py", "export_second_cooldown_stage2.py")
+    with open(source_path) as source_file:
+        source = source_file.read()
+    stage2_checkpoint = (
+        'CHECKPOINT = (\n'
+        '    "s3://marin-us-east-02a/marin/grug/"\n'
+        '    "snowball_step105149_sft_s2_thinking/"\n'
+        '    "2026.08.13.1/checkpoints/step-630/"\n'
+        ')'
+    )
+    stage2_output = (
+        'OUTPUT = (\n'
+        '    "s3://marin-us-east-02a/marin/exports/grug/"\n'
+        '    "snowball_step105149_sft_s2_thinking/2026.08.13.1/step-630/hf-bf16-vllm/"\n'
+        ')'
+    )
+    assert stage2_checkpoint in source
+    assert stage2_output in source
+    source = source.replace(stage2_checkpoint, f"CHECKPOINT = {STAGE3_CHECKPOINT!r}")
+    source = source.replace(stage2_output, f"OUTPUT = {STAGE3_OUTPUT!r}")
+    exec(compile(source, source_path, "exec"), {"__name__": "__main__", "__file__": source_path})
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/june_tpu_67b_a2b/moe/sft_67b_a2b_2stage.py
+++ b/experiments/june_tpu_67b_a2b/moe/sft_67b_a2b_2stage.py
@@ -256,6 +256,9 @@ _SMOKE_RUN_ID: str = "grug_67b_a2b_sft_smoke"
 _NEMOTRON_TERMINAL_RUN_ID: str = "snowball_step105149_sft_nemotron_terminal_steps1888_ben_recipe"
 _NEMOTRON_TERMINAL_STEPS: int = 1_888
 _AGENTIC_RUN_ID: str = "snowball_step105149_sft_grug_a2b_agentic_eot_5ep"
+_SECOND_COOLDOWN_CHAT_RUN_ID: str = "snowball_step105149_sft_s1_chat"
+_SECOND_COOLDOWN_THINKING_RUN_ID: str = "snowball_step105149_sft_s2_thinking"
+_SECOND_COOLDOWN_AGENTIC_RUN_ID: str = "snowball_step105149_sft_s3_agentic_eot_5ep"
 _AGENTIC_TRAIN_RESOURCES: str = "agentic_train_resources"
 _AGENTIC_EPOCHS: int = 5
 
@@ -365,6 +368,36 @@ def build_job2(job1: ArtifactStep[LevanterCheckpoint], version: str | None = Non
     return sft_step(spec, _gpu_resources(_NODES))
 
 
+def build_second_cooldown_chat(version: str | None = None) -> ArtifactStep[LevanterCheckpoint]:
+    """Chat SFT initialized from the second Snowball cooldown at step 105149."""
+    step_name = f"grug/{_SECOND_COOLDOWN_CHAT_RUN_ID}"
+    version = resolve_version(step_name, version)
+    spec = _spec(
+        name=user_namespaced_name(step_name, version),
+        version=version,
+        dataset=_JOB1_DATASET,
+        model_source=_grug_source(_SNOWBALL_STEP105149_CKPT, stage="second_cooldown_s1_chat", seq=_SEQ),
+        epochs=1,
+    )
+    return sft_step(spec, _gpu_resources(_NODES))
+
+
+def build_second_cooldown_thinking(
+    chat: ArtifactStep[LevanterCheckpoint], version: str | None = None
+) -> ArtifactStep[LevanterCheckpoint]:
+    """Thinking SFT initialized from the second-cooldown Chat stage."""
+    step_name = f"grug/{_SECOND_COOLDOWN_THINKING_RUN_ID}"
+    version = resolve_version(step_name, version)
+    spec = _spec(
+        name=user_namespaced_name(step_name, version),
+        version=version,
+        dataset=_JOB2_DATASET,
+        model_source=_grug_source(chat, stage="second_cooldown_s2_thinking", seq=_SEQ),
+        epochs=1,
+    )
+    return sft_step(spec, _gpu_resources(_NODES))
+
+
 def build_smoke(version: str | None = None) -> ArtifactStep[LevanterCheckpoint]:
     """Stage-5 smoke: the real 67B at the target Job1 geometry -- 8x H100x8 nodes (cw-us-east-02a),
     AdamH, expert=8, model=1 (data-parallel), replica=1, bs=64, seq=32768, per_device=1, few steps +
@@ -450,12 +483,14 @@ def _agentic_training_steps(data: LmDataConfig) -> int:
 def build_agentic(
     version: str | None = None,
     *,
+    init_from: str | ArtifactStep[LevanterCheckpoint] = _SNOWBALL_STEP105149_CKPT,
+    run_id: str = _AGENTIC_RUN_ID,
     resources: ResourceConfig | None = None,
     accelerator_tag: str = "cw-h100",
 ) -> ArtifactStep[LevanterCheckpoint]:
-    """SFT Snowball step 105149 for five token epochs over the rendered agent traces."""
+    """Run five token epochs over the rendered agent traces."""
     dataset = grug_a2b_agentic_sft_eot_dataset()
-    step_name = f"grug/{_AGENTIC_RUN_ID}"
+    step_name = f"grug/{run_id}"
     version = resolve_version(step_name, version)
     name = user_namespaced_name(step_name, version)
 
@@ -480,7 +515,11 @@ def build_agentic(
                 name=name.split("/")[-1],
             ),
             optimizer=_agentic_optimizer,
-            init_from_path=_SNOWBALL_STEP105149_CKPT,
+            init_from_path=(
+                prefix_join(ctx.artifact_path(init_from), "checkpoints")
+                if isinstance(init_from, ArtifactStep)
+                else init_from
+            ),
             expert_parallel=_EXPERT_PARALLEL,
             per_device_parallelism=_PER_DEVICE_PARALLELISM,
             checkpointer=CheckpointerConfig(
@@ -524,7 +563,7 @@ def build_agentic(
         artifact_type=LevanterCheckpoint,
         run=run_grug_moe_sft_trial,
         build_config=build_config,
-        deps=(dataset,),
+        deps=(dataset, *([init_from] if isinstance(init_from, ArtifactStep) else [])),
         runtime_args={_AGENTIC_TRAIN_RESOURCES: resources},
     )
 
@@ -533,7 +572,18 @@ def build_agentic(
 @click.option(
     "--stage",
     type=click.Choice(
-        ["smoke", "job1", "2stage", "nemotron-terminal", "nemotron-terminal-gb200", "agentic", "agentic-gb200"]
+        [
+            "smoke",
+            "job1",
+            "2stage",
+            "second-cooldown-chat",
+            "second-cooldown-thinking",
+            "second-cooldown-3stage",
+            "nemotron-terminal",
+            "nemotron-terminal-gb200",
+            "agentic",
+            "agentic-gb200",
+        ]
     ),
     default="2stage",
     show_default=True,
@@ -545,6 +595,14 @@ def main(stage: str) -> ArtifactStep[LevanterCheckpoint]:
         return build_smoke()
     if stage == "job1":
         return build_job1()
+    if stage == "second-cooldown-chat":
+        return build_second_cooldown_chat()
+    if stage == "second-cooldown-thinking":
+        return build_second_cooldown_thinking(build_second_cooldown_chat())
+    if stage == "second-cooldown-3stage":
+        chat = build_second_cooldown_chat()
+        thinking = build_second_cooldown_thinking(chat)
+        return build_agentic(init_from=thinking, run_id=_SECOND_COOLDOWN_AGENTIC_RUN_ID)
     if stage == "nemotron-terminal":
         return build_nemotron_terminal()
     if stage == "nemotron-terminal-gb200":

--- a/experiments/june_tpu_67b_a2b/moe/sft_67b_a2b_2stage.py
+++ b/experiments/june_tpu_67b_a2b/moe/sft_67b_a2b_2stage.py
@@ -1,13 +1,16 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Two-stage chat SFT of the June TPU 67B-A2B Grug MoE (step-42150 cooldown checkpoint).
+"""Chat SFT experiments for the June TPU 67B-A2B Grug MoE.
 
 An experiment on the general ``experiments.sft`` launcher: each stage composes the shared
 ``sft_step`` (dataset transforms + chat template + spec + CLI) with a ``GrugModel`` model source
 (native weights-only init + the ring-EP ``run_grug`` backend). Model and data are independent
 inputs — swap ``_JOB{1,2}_DATASET`` for a different mixture, or the ``GrugModel`` for another
 checkpoint, without touching the launcher.
+
+The standalone ``nemotron-terminal`` stage initializes from Snowball step 105149 and uses the
+Marin tokenizer's native ``<|eot_id|>`` chat template for a controlled 1,888 steps.
 
 Stage 1 (``wildchat``): math-weak plain chat -- establishes the chat template / format, no
 thinking traces -- initialised (weights-only) from the step-42150 base checkpoint.
@@ -54,21 +57,40 @@ launching; ``--version`` is required (pass ``--version dev`` to iterate).
 
 import dataclasses
 import math
+from datetime import timedelta
 
 import click
 from fray.cluster import ResourceConfig
+from fray.types import ANY_REGION
+from levanter.checkpoint import CheckpointDebugConfig, CheckpointerConfig
+from levanter.data.text.datasets import (
+    DatasetComponent,
+    LmDataConfig,
+    UrlDatasetSourceConfig,
+)
+from levanter.tracker.wandb import WandbConfig
 from marin.execution.build_context import resolve_version
-from marin.execution.lazy import ArtifactStep
+from marin.execution.lazy import ArtifactStep, StepContext
 from marin.experiment.cli import build_options
 from marin.experiment.namespacing import user_namespaced_name
-from marin.training.training import LevanterCheckpoint
+from marin.training.training import LevanterCheckpoint, temporary_checkpoint_base_path
+from rigging.filesystem import prefix_join
 
+from experiments.datasets.grug_a2b_agentic_sft_eot import (
+    GRUG_A2B_AGENTIC_SFT_FORMAT,
+    grug_a2b_agentic_sft_eot_dataset,
+)
 from experiments.june_tpu_67b_a2b.moe.heuristic_muonh import MoeMuonHHeuristic
 from experiments.june_tpu_67b_a2b.moe.optimizer import GrugMoeAdamHConfig
-from experiments.june_tpu_67b_a2b.moe.sft_launch import GrugModel
-from experiments.marin_tokenizer import marin_tokenizer
+from experiments.june_tpu_67b_a2b.moe.sft_launch import (
+    GrugModel,
+    GrugMoeSFTConfig,
+    run_grug_moe_sft_trial,
+)
+from experiments.june_tpu_67b_a2b.moe.train import GrugTrainerConfig
+from experiments.marin_tokenizer import MARIN_CHAT_TEMPLATE, marin_tokenizer
 from experiments.sft.delphi_chat_template import DELPHI_V0_CHAT_TEMPLATE
-from experiments.sft.launcher import DatasetSpec, SFTSpec, sft_step
+from experiments.sft.launcher import ChatCacheMode, DatasetSpec, SFTSpec, sft_step
 
 _WANDB_PROJECT = "marin_moe_sft"
 
@@ -94,6 +116,7 @@ _model_base = _heuristic.build_model_config(_DIM, seq_len=65_536)
 # The seq32k per-seq activation (~43 GiB, pd=1) doesn't shard across DP nodes, so N=8 (bs=64) is the
 # smallest gang that fits (~68 GiB/dev, AdamH fp32 + cut-CE); N<=4 OOMs. See GEOMETRY_ANALYSIS.md.
 _NODES: int = 8  # full-run gang: 8x H100x8 = 64 GPUs (data-parallel)
+_GB200_NODES: int = 16  # full-run gang: 16x GB200x4 = 64 GPUs (same mesh)
 _SMOKE_NODES: int = 8  # smoke at the same target geometry (the real HBM test at ~68 GiB/dev prediction)
 _EXPERT_PARALLEL: int = 8  # shard the 256 experts across the 8 intra-node GPUs (ring-EP over NVLink)
 _MODEL_PARALLEL: int = 1  # no tensor parallelism (architecturally impossible; see header)
@@ -139,6 +162,8 @@ _optimizer = GrugMoeAdamHConfig(
     warmup=0.03,
     lr_schedule="cosine",
 )
+_AGENTIC_LR: float = 5e-6
+_agentic_optimizer = dataclasses.replace(_optimizer, learning_rate=_AGENTIC_LR, adam_lr=_AGENTIC_LR)
 
 # --- Datasets (both already OpenAI role/content; multi_turn_adapter canonicalizes columns) --------
 _REVISION_WILDCHAT: str = "46a5bb5"  # nyu-dice-lab/wildchat50m-rewild-sft-385700 HEAD (2026-07-15)
@@ -157,6 +182,54 @@ _JOB2_DATASET = DatasetSpec(
     adapter_kwargs=dict(),  # multi_turn_adapter defaults: messages / role / user / assistant
     weight=1.0,
 )
+_NEMOTRON_TERMINAL_DATASET = DatasetSpec(
+    slug="nemotron_terminal_full",
+    hf_dataset_id="nvidia/Nemotron-Terminal-Corpus",
+    revision="a1667c4",
+    adapter_kwargs=dict(conversation_column="conversations"),
+    weight=1.0,
+    columns=["conversations"],
+    parquet_files={
+        "dataset_adapters": [
+            "dataset_adapters/code.parquet",
+            "dataset_adapters/math.parquet",
+            "dataset_adapters/swe.parquet",
+        ],
+        "skill_based_easy": [
+            "synthetic_tasks/skill_based/easy/data_processing/data_filtered.parquet",
+            "synthetic_tasks/skill_based/easy/data_querying/data_filtered.parquet",
+            "synthetic_tasks/skill_based/easy/data_science/data_filtered.parquet",
+            "synthetic_tasks/skill_based/easy/debugging/data_filtered.parquet",
+            "synthetic_tasks/skill_based/easy/dependency_management/data_filtered.parquet",
+            "synthetic_tasks/skill_based/easy/file_operations/data_filtered.parquet",
+            "synthetic_tasks/skill_based/easy/scientific_computing/data_filtered.parquet",
+            "synthetic_tasks/skill_based/easy/security/data_filtered.parquet",
+            "synthetic_tasks/skill_based/easy/software_engineering/data_filtered.parquet",
+        ],
+        "skill_based_medium": [
+            "synthetic_tasks/skill_based/medium/data_processing/data_filtered.parquet",
+            "synthetic_tasks/skill_based/medium/data_querying/data_filtered.parquet",
+            "synthetic_tasks/skill_based/medium/data_science/data_filtered.parquet",
+            "synthetic_tasks/skill_based/medium/debugging/data_filtered.parquet",
+            "synthetic_tasks/skill_based/medium/dependency_management/data_filtered.parquet",
+            "synthetic_tasks/skill_based/medium/file_operations/data_filtered.parquet",
+            "synthetic_tasks/skill_based/medium/model_training/data_filtered.parquet",
+            "synthetic_tasks/skill_based/medium/scientific_computing/data_filtered.parquet",
+            "synthetic_tasks/skill_based/medium/security/data_filtered.parquet",
+            "synthetic_tasks/skill_based/medium/software_engineering/data_filtered.parquet",
+            "synthetic_tasks/skill_based/medium/system_administration/data_filtered.parquet",
+        ],
+        "skill_based_mixed": [
+            "synthetic_tasks/skill_based/mixed/data_processing/data_filtered.parquet",
+            "synthetic_tasks/skill_based/mixed/data_science/data_filtered.parquet",
+            "synthetic_tasks/skill_based/mixed/debugging/data_filtered.parquet",
+            "synthetic_tasks/skill_based/mixed/file_operations/data_filtered.parquet",
+            "synthetic_tasks/skill_based/mixed/scientific_computing/data_filtered.parquet",
+            "synthetic_tasks/skill_based/mixed/security/data_filtered.parquet",
+        ],
+    },
+    parquet_batch_size=1024,
+)
 
 # Job1/Job2 are one packed epoch (num_train_epochs=1); sft_step resolves the concrete step count from
 # the chat cache's token total at run time (marin #7244), so there is no hand-calibrated count. For
@@ -171,14 +244,37 @@ _BASE_CKPT: str = (
     "moe_67b_a2b_d2560_ep1_rep8_bs1024_seq65536_sw2k_v4_2048_muon_cooldown_step39k-79ebf3/"
     "checkpoints/step-42150/"
 )
+_SNOWBALL_STEP105149_CKPT: str = (
+    "s3://marin-us-east-02a/marin/grug/"
+    "moe_67b_a2b_d2560_ep1_rep8_bs1024_seq65536_sw2k_v4_2048_muon_cooldown_step102k-3dac46/"
+    "checkpoints/step-105149/"
+)
 
 _JOB1_RUN_ID: str = "grug_67b_a2b_sft_s1_wildchat"
 _JOB2_RUN_ID: str = "grug_67b_a2b_sft_s2_thinking"
 _SMOKE_RUN_ID: str = "grug_67b_a2b_sft_smoke"
+_NEMOTRON_TERMINAL_RUN_ID: str = "snowball_step105149_sft_nemotron_terminal_steps1888_ben_recipe"
+_NEMOTRON_TERMINAL_STEPS: int = 1_888
+_AGENTIC_RUN_ID: str = "snowball_step105149_sft_grug_a2b_agentic_eot_5ep"
+_AGENTIC_TRAIN_RESOURCES: str = "agentic_train_resources"
+_AGENTIC_EPOCHS: int = 5
 
 
 def _gpu_resources(nodes: int) -> ResourceConfig:
     return ResourceConfig.with_gpu("H100", count=8, cpu=32, ram="512g", disk="256g", replicas=nodes, preemptible=True)
+
+
+def _gb200_resources() -> ResourceConfig:
+    return ResourceConfig.with_gpu(
+        "GB200",
+        count=4,
+        cpu=32,
+        ram="512g",
+        disk="256g",
+        replicas=_GB200_NODES,
+        preemptible=True,
+        regions=[ANY_REGION],
+    )
 
 
 def _grug_source(
@@ -188,6 +284,8 @@ def _grug_source(
     seq: int,
     save_interval_minutes: int = 30,
     checkpoint_keep: list[dict] | None = None,
+    wandb_mode: str | None = None,
+    accelerator_tag: str = "cw-h100",
 ) -> GrugModel:
     """The Grug 67B model source for one stage (native weights-only init from ``init_from``)."""
     return GrugModel(
@@ -203,8 +301,9 @@ def _grug_source(
         log_every=1,
         save_interval_minutes=save_interval_minutes,
         checkpoint_keep=checkpoint_keep if checkpoint_keep is not None else [{"every": 1000}],
-        wandb_tags=["moe", "june_tpu", "67b_a2b", "sft", stage, f"seq{seq}", "cw-h100"],
+        wandb_tags=["moe", "june_tpu", "67b_a2b", "sft", stage, f"seq{seq}", accelerator_tag],
         wandb_group="grug-67b-a2b-sft",
+        wandb_mode=wandb_mode,
     )
 
 
@@ -218,18 +317,22 @@ def _spec(
     epochs: int | None = None,
     seq: int = _SEQ,
     batch: int = _BATCH,
+    chat_template: str = DELPHI_V0_CHAT_TEMPLATE,
+    chat_cache_mode: ChatCacheMode = ChatCacheMode.AUTO,
+    optimizer: GrugMoeAdamHConfig = _optimizer,
 ) -> SFTSpec:
     return SFTSpec(
         name=name,
         version=version,
         model=model_source,
-        chat_template=DELPHI_V0_CHAT_TEMPLATE,
+        chat_template=chat_template,
         datasets=[dataset],
-        optimizer=_optimizer,
+        optimizer=optimizer,
         seq_len=seq,
         batch_size=batch,
         num_train_steps=steps,
         num_train_epochs=epochs,
+        chat_cache_mode=chat_cache_mode,
         wandb_project=_WANDB_PROJECT,
     )
 
@@ -285,13 +388,156 @@ def build_smoke(version: str | None = None) -> ArtifactStep[LevanterCheckpoint]:
     return sft_step(spec, _gpu_resources(_SMOKE_NODES))
 
 
+def build_nemotron_terminal(
+    version: str | None = None,
+    *,
+    resources: ResourceConfig | None = None,
+    accelerator_tag: str = "cw-h100",
+) -> ArtifactStep[LevanterCheckpoint]:
+    """SFT Snowball's latest 100k-lineage checkpoint for a controlled NemotronTerminal budget."""
+    step_name = f"grug/{_NEMOTRON_TERMINAL_RUN_ID}"
+    version = resolve_version(step_name, version)
+    spec = _spec(
+        name=user_namespaced_name(step_name, version),
+        version=version,
+        dataset=_NEMOTRON_TERMINAL_DATASET,
+        model_source=_grug_source(
+            _SNOWBALL_STEP105149_CKPT,
+            stage="nemotron_terminal",
+            seq=_SEQ,
+            save_interval_minutes=60,
+            wandb_mode="disabled",
+            accelerator_tag=accelerator_tag,
+        ),
+        steps=_NEMOTRON_TERMINAL_STEPS,
+        chat_template=MARIN_CHAT_TEMPLATE,
+        chat_cache_mode=ChatCacheMode.PREBUILT,
+        optimizer=_agentic_optimizer,
+    )
+    return sft_step(spec, resources if resources is not None else _gpu_resources(_NODES))
+
+
+def _agentic_data_config(cache_path: str) -> LmDataConfig:
+    source = UrlDatasetSourceConfig(
+        train_urls=[],
+        validation_urls=[],
+        cache_dir=cache_path,
+        format=GRUG_A2B_AGENTIC_SFT_FORMAT,
+    )
+    return LmDataConfig(
+        tokenizer=marin_tokenizer,
+        auto_build_caches=False,
+        components={
+            "grug_a2b_agentic_eot": DatasetComponent(
+                source=source,
+                cache_dir=cache_path,
+                format=GRUG_A2B_AGENTIC_SFT_FORMAT,
+                pack=True,
+                packed_slice_strategy="right",
+                split="train",
+            )
+        },
+        train_weights={"grug_a2b_agentic_eot": 1.0},
+    )
+
+
+def _agentic_training_steps(data: LmDataConfig) -> int:
+    cache = data.build_caches("train")["grug_a2b_agentic_eot"]
+    tokens = cache.jagged_array_tree()[GRUG_A2B_AGENTIC_SFT_FORMAT.input_ids_key].data_size
+    return math.ceil(tokens * _AGENTIC_EPOCHS / (_BATCH * _SEQ))
+
+
+def build_agentic(
+    version: str | None = None,
+    *,
+    resources: ResourceConfig | None = None,
+    accelerator_tag: str = "cw-h100",
+) -> ArtifactStep[LevanterCheckpoint]:
+    """SFT Snowball step 105149 for five token epochs over the rendered agent traces."""
+    dataset = grug_a2b_agentic_sft_eot_dataset()
+    step_name = f"grug/{_AGENTIC_RUN_ID}"
+    version = resolve_version(step_name, version)
+    name = user_namespaced_name(step_name, version)
+
+    def build_config(ctx: StepContext) -> GrugMoeSFTConfig:
+        data = _agentic_data_config(ctx.artifact_path(dataset))
+        steps = 1 if ctx.is_fingerprint else _agentic_training_steps(data)
+        return GrugMoeSFTConfig(
+            model=_model,
+            data=data,
+            output_path=ctx.output_path,
+            run_id=name.split("/")[-1],
+            resources=ctx.runtime_arg(_AGENTIC_TRAIN_RESOURCES),
+            steps=steps,
+            batch_size=_BATCH,
+            seed=0,
+            mp="params=float32,compute=bfloat16,output=bfloat16",
+            tracker=WandbConfig(
+                project=_WANDB_PROJECT,
+                tags=["moe", "june_tpu", "67b_a2b", "sft", "agentic", "5epochs", "seq32768", accelerator_tag],
+                group="grug-67b-a2b-sft",
+                mode="disabled",
+                name=name.split("/")[-1],
+            ),
+            optimizer=_agentic_optimizer,
+            init_from_path=_SNOWBALL_STEP105149_CKPT,
+            expert_parallel=_EXPERT_PARALLEL,
+            per_device_parallelism=_PER_DEVICE_PARALLELISM,
+            checkpointer=CheckpointerConfig(
+                base_path=prefix_join(ctx.output_path, "checkpoints"),
+                temporary_base_path=temporary_checkpoint_base_path(ctx.output_path),
+                append_run_id_to_base_path=False,
+                save_interval=timedelta(minutes=60),
+                keep=[{"every": 1000}],
+                debug=CheckpointDebugConfig(
+                    enabled=True,
+                    dump_stacks_after=30 * 60,
+                    tracemalloc_frames=None,
+                    top_allocations=0,
+                ),
+            ),
+            save_interval_minutes=60,
+            checkpoint_keep=[{"every": 1000}],
+            grug_trainer=GrugTrainerConfig(
+                z_loss_weight=1e-4,
+                ema_beta=None,
+                log_every=1,
+                replica_axis_size=_REPLICA_AXIS,
+                model_axis_size=_MODEL_PARALLEL,
+            ),
+        )
+
+    if resources is None:
+        resources = ResourceConfig.with_gpu(
+            "H100",
+            count=8,
+            cpu=32,
+            ram="512g",
+            disk="256g",
+            replicas=_NODES,
+            preemptible=True,
+            regions=[ANY_REGION],
+        )
+    return ArtifactStep(
+        name=name,
+        version=version,
+        artifact_type=LevanterCheckpoint,
+        run=run_grug_moe_sft_trial,
+        build_config=build_config,
+        deps=(dataset,),
+        runtime_args={_AGENTIC_TRAIN_RESOURCES: resources},
+    )
+
+
 @click.command()
 @click.option(
     "--stage",
-    type=click.Choice(["smoke", "job1", "2stage"]),
+    type=click.Choice(
+        ["smoke", "job1", "2stage", "nemotron-terminal", "nemotron-terminal-gb200", "agentic", "agentic-gb200"]
+    ),
     default="2stage",
     show_default=True,
-    help="Which stage(s) to build: smoke | job1 | 2stage (Stage 1 -> Stage 2 chained).",
+    help="Which SFT stage and accelerator configuration to build.",
 )
 @build_options
 def main(stage: str) -> ArtifactStep[LevanterCheckpoint]:
@@ -299,6 +545,14 @@ def main(stage: str) -> ArtifactStep[LevanterCheckpoint]:
         return build_smoke()
     if stage == "job1":
         return build_job1()
+    if stage == "nemotron-terminal":
+        return build_nemotron_terminal()
+    if stage == "nemotron-terminal-gb200":
+        return build_nemotron_terminal(resources=_gb200_resources(), accelerator_tag="cw-gb200")
+    if stage == "agentic":
+        return build_agentic()
+    if stage == "agentic-gb200":
+        return build_agentic(resources=_gb200_resources(), accelerator_tag="cw-gb200")
     return build_job2(build_job1())
 
 

--- a/experiments/june_tpu_67b_a2b/moe/sft_67b_a2b_2stage.py
+++ b/experiments/june_tpu_67b_a2b/moe/sft_67b_a2b_2stage.py
@@ -259,6 +259,14 @@ _AGENTIC_RUN_ID: str = "snowball_step105149_sft_grug_a2b_agentic_eot_5ep"
 _SECOND_COOLDOWN_CHAT_RUN_ID: str = "snowball_step105149_sft_s1_chat"
 _SECOND_COOLDOWN_THINKING_RUN_ID: str = "snowball_step105149_sft_s2_thinking"
 _SECOND_COOLDOWN_AGENTIC_RUN_ID: str = "snowball_step105149_sft_s3_agentic_eot_5ep"
+_SECOND_COOLDOWN_CHAT_CHECKPOINT: str = (
+    "s3://marin-us-east-02a/marin/grug/snowball_step105149_sft_s1_chat/"
+    "2026.08.13.1/checkpoints/"
+)
+_SECOND_COOLDOWN_THINKING_CHECKPOINT: str = (
+    "s3://marin-us-east-02a/marin/grug/snowball_step105149_sft_s2_thinking/"
+    "2026.08.13.1/checkpoints/"
+)
 _AGENTIC_TRAIN_RESOURCES: str = "agentic_train_resources"
 _AGENTIC_EPOCHS: int = 5
 
@@ -383,7 +391,7 @@ def build_second_cooldown_chat(version: str | None = None) -> ArtifactStep[Levan
 
 
 def build_second_cooldown_thinking(
-    chat: ArtifactStep[LevanterCheckpoint], version: str | None = None
+    chat: str | ArtifactStep[LevanterCheckpoint], version: str | None = None
 ) -> ArtifactStep[LevanterCheckpoint]:
     """Thinking SFT initialized from the second-cooldown Chat stage."""
     step_name = f"grug/{_SECOND_COOLDOWN_THINKING_RUN_ID}"
@@ -528,6 +536,7 @@ def build_agentic(
                 append_run_id_to_base_path=False,
                 save_interval=timedelta(minutes=60),
                 keep=[{"every": 1000}],
+                timeout=timedelta(hours=2),
                 debug=CheckpointDebugConfig(
                     enabled=True,
                     dump_stacks_after=30 * 60,
@@ -578,6 +587,7 @@ def build_agentic(
             "2stage",
             "second-cooldown-chat",
             "second-cooldown-thinking",
+            "second-cooldown-agentic",
             "second-cooldown-3stage",
             "nemotron-terminal",
             "nemotron-terminal-gb200",
@@ -598,7 +608,12 @@ def main(stage: str) -> ArtifactStep[LevanterCheckpoint]:
     if stage == "second-cooldown-chat":
         return build_second_cooldown_chat()
     if stage == "second-cooldown-thinking":
-        return build_second_cooldown_thinking(build_second_cooldown_chat())
+        return build_second_cooldown_thinking(_SECOND_COOLDOWN_CHAT_CHECKPOINT)
+    if stage == "second-cooldown-agentic":
+        return build_agentic(
+            init_from=_SECOND_COOLDOWN_THINKING_CHECKPOINT,
+            run_id=_SECOND_COOLDOWN_AGENTIC_RUN_ID,
+        )
     if stage == "second-cooldown-3stage":
         chat = build_second_cooldown_chat()
         thinking = build_second_cooldown_thinking(chat)

--- a/experiments/june_tpu_67b_a2b/moe/sft_launch.py
+++ b/experiments/june_tpu_67b_a2b/moe/sft_launch.py
@@ -197,6 +197,7 @@ class GrugModel:
     checkpoint_keep: list[dict] | None = None
     wandb_tags: Sequence[str] = ()
     wandb_group: str | None = None
+    wandb_mode: str | None = None
 
     def tokenizer_cache_key(self) -> str:
         return self.tokenizer_path
@@ -229,6 +230,7 @@ class GrugModel:
             project=spec.wandb_project,
             tags=list(self.wandb_tags),
             group=self.wandb_group,
+            mode=self.wandb_mode,
             name=run_id,
         )
         return GrugMoeSFTConfig(

--- a/experiments/june_tpu_67b_a2b/moe/sft_launch.py
+++ b/experiments/june_tpu_67b_a2b/moe/sft_launch.py
@@ -137,6 +137,7 @@ def run_grug_moe_sft_trial(config: GrugMoeSFTConfig) -> None:
             append_run_id_to_base_path=False,
             save_interval=timedelta(minutes=config.save_interval_minutes),
             keep=config.checkpoint_keep,
+            timeout=timedelta(hours=2),
         ),
         # First launch: output dir empty -> weights-only init from initialize_from. Once this
         # run saves its own checkpoints, every restart auto-resumes from those (full SFT state).

--- a/experiments/sft/launcher.py
+++ b/experiments/sft/launcher.py
@@ -70,6 +70,7 @@ import re
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import timedelta
+from enum import StrEnum
 from typing import Protocol, runtime_checkable
 
 import click
@@ -104,6 +105,7 @@ _TRAIN_RESOURCES = "train_resources"
 # Compute in bf16, keep master params and optimizer state in f32 — the standard marin policy.
 _MARIN_PRECISION = "p=f32,c=bfloat16"
 _MIXTURE_BLOCK_SIZE = 2048
+_CHAT_TOKENIZE_RESOURCES = ResourceConfig.with_cpu(cpu=2, ram="32g", regions=[ANY_REGION])
 # Bump to rebuild every chat cache; the (tokenizer, template, pack) hash in the name already forks a
 # new cache when any of those change, so this is only for reprocessing the same recipe.
 _CHAT_CACHE_VERSION = "2026.07.17"
@@ -123,6 +125,14 @@ class DatasetSpec:
     revision: str  # 7-char commit pin, for fingerprint stability
     adapter_kwargs: Mapping[str, object]
     weight: float
+    columns: list[str] | None = None
+    parquet_files: Mapping[str, Sequence[str]] | None = None
+    parquet_batch_size: int | None = None
+
+
+class ChatCacheMode(StrEnum):
+    AUTO = "auto"
+    PREBUILT = "prebuilt"
 
 
 @runtime_checkable
@@ -510,9 +520,11 @@ class SFTSpec:
     # step count at run time from the chat cache's token total -- ``ceil(epochs * tokens / (seq_len *
     # batch))``, the packed-sequence count -- so it is not hand-calibrated; it routes the run through a
     # ``chat_tokenize`` dep (see :func:`sft_step`). ``num_train_steps`` is the explicit count (required
-    # for a mixture, where epoch semantics are undefined) and keeps the ``auto_build_caches`` path.
+    # for a mixture, where epoch semantics are undefined). It builds caches on the training pod unless
+    # ``chat_cache_mode`` requests a prebuilt cache.
     num_train_steps: int | None = None
     num_train_epochs: int | None = None
+    chat_cache_mode: ChatCacheMode = ChatCacheMode.AUTO
     wandb_project: str = "marin-sft-launcher"
 
     def __post_init__(self) -> None:
@@ -664,6 +676,9 @@ def _dataset_deps(spec: SFTSpec) -> tuple[ArtifactStep, ...]:
                 adapter=multi_turn_adapter(**dict(dataset.adapter_kwargs)),
                 metadata_columns=[],
                 name=dataset.slug,
+                columns=dataset.columns,
+                parquet_files={key: list(files) for key, files in (dataset.parquet_files or {}).items()},
+                parquet_batch_size=dataset.parquet_batch_size,
             )
         )
         for dataset in spec.datasets
@@ -691,6 +706,7 @@ def chat_tokenize(spec: SFTSpec, dataset: DatasetSpec, transform_dep: ArtifactSt
             tokenizer=spec.model.resolve_tokenizer(ctx),
             format=_chat_format(spec),
             tags=[dataset.slug],
+            worker_resources=_CHAT_TOKENIZE_RESOURCES,
         )
 
     return ArtifactStep(
@@ -726,15 +742,16 @@ def sft_step(spec: SFTSpec, resources: ResourceConfig) -> ArtifactStep[LevanterC
     runtime arg, so changing the accelerator never forks the checkpoint's identity. The data flow
     depends on how the training length is set:
 
-    - ``num_train_steps`` (a mixture, or an explicit count): the transforms are the deps and Levanter
-      builds the chat cache on the training pod (``auto_build_caches``).
+    - ``num_train_steps`` (a mixture, or an explicit count): by default the transforms are the deps and
+      Levanter builds the chat cache on the training pod (``auto_build_caches``). ``chat_cache_mode``
+      can instead materialize and reuse the same prebuilt cache as the epoch path.
     - ``num_train_epochs`` (a single dataset): a ``chat_tokenize`` dep materializes the chat cache so
       the step count resolves from its token total, and training reads the pre-built cache.
     """
     model = spec.model
     transform_deps = _dataset_deps(spec)
 
-    if spec.num_train_epochs is not None:
+    if spec.num_train_epochs is not None or spec.chat_cache_mode is ChatCacheMode.PREBUILT:
         chat_caches = tuple(
             chat_tokenize(spec, dataset, dep) for dataset, dep in zip(spec.datasets, transform_deps, strict=True)
         )
@@ -744,7 +761,11 @@ def sft_step(spec: SFTSpec, resources: ResourceConfig) -> ArtifactStep[LevanterC
             run_resources = ctx.runtime_arg(_TRAIN_RESOURCES)
             tokenizer = model.resolve_tokenizer(ctx)
             data_config = _prebuilt_chat_data_config(spec, [ctx.artifact_path(c) for c in chat_caches], tokenizer)
-            num_train_steps = _resolve_epoch_steps(ctx, spec, chat_caches[0])
+            if spec.num_train_epochs is not None:
+                num_train_steps = _resolve_epoch_steps(ctx, spec, chat_caches[0])
+            else:
+                assert spec.num_train_steps is not None
+                num_train_steps = spec.num_train_steps
             return model.build_train_config(ctx, spec, data_config, run_resources, num_train_steps)
 
     else:

--- a/experiments/sft/launcher.py
+++ b/experiments/sft/launcher.py
@@ -676,6 +676,7 @@ def _dataset_deps(spec: SFTSpec) -> tuple[ArtifactStep, ...]:
                 adapter=multi_turn_adapter(**dict(dataset.adapter_kwargs)),
                 metadata_columns=[],
                 name=dataset.slug,
+                subsets=list(dataset.parquet_files) if dataset.parquet_files is not None else [],
                 columns=dataset.columns,
                 parquet_files={key: list(files) for key, files in (dataset.parquet_files or {}).items()},
                 parquet_batch_size=dataset.parquet_batch_size,

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -37,6 +37,7 @@ from rigging.filesystem import StoragePath
 
 from levanter._debug_logging import flush_debug_output
 from levanter.tensorstore_serialization import (
+    TensorStoreWriteConfig,
     tree_deserialize_leaves_tensorstore,
     tree_serialize_leaves_tensorstore,
 )
@@ -445,6 +446,8 @@ class Checkpointer:
         delete_old_temp_checkpoints: bool = True,
         keep_last_temporary_checkpoints: int = 1,
         debug: CheckpointDebugConfig | None = None,
+        write_config: TensorStoreWriteConfig | None = None,
+        timeout: datetime.timedelta = datetime.timedelta(minutes=30),
     ):
         """
         Class for managing checkpoints. Saves checkpoints according to two policies: time and step.
@@ -468,6 +471,7 @@ class Checkpointer:
             keep_last_temporary_checkpoints: number of complete temporary checkpoints to retain after a temporary
                 checkpoint commits successfully. Set to 0 to delete temporary checkpoints after they commit. Permanent
                 checkpoints still clean up temporary checkpoints because they supersede them for recovery.
+            write_config: how a save divides work across the processes holding the state
         """
         if keep_last_temporary_checkpoints < 0:
             raise ValueError("keep_last_temporary_checkpoints must be non-negative")
@@ -482,6 +486,7 @@ class Checkpointer:
         self._last_save_step = 0
         self.keep_last_temporary_checkpoints = keep_last_temporary_checkpoints
         self.debug = debug or CheckpointDebugConfig()
+        self.write_config = write_config or TensorStoreWriteConfig()
         self._temporary_checkpoints = []
 
         # ensure that the step_policies are sorted. We could sort, but instead we'll just insist that they are sorted
@@ -498,7 +503,7 @@ class Checkpointer:
                 raise ValueError("Step policies must be sorted by 'until' value")
 
         # The default of 5 minutes is too short even for modestly sized models for some reason
-        self._manager = GlobalAsyncCheckpointManager(timeout_secs=60 * 30)
+        self._manager = GlobalAsyncCheckpointManager(timeout_secs=int(timeout.total_seconds()))
 
         if jax.process_index() == 0:
             self._async_checkpoint_remover_queue: queue.Queue[str] = queue.Queue(maxsize=-1)
@@ -719,6 +724,7 @@ class Checkpointer:
             commit_callback=commit_callback,
             is_temporary=is_temporary,
             debug=self.debug,
+            write_config=self.write_config,
         )
         self._last_save_step = step
         self._last_save_time = self._dt_now_injection()
@@ -740,6 +746,7 @@ def save_checkpoint(
     commit_callback: Optional[Callable[[], None]] = None,
     is_temporary: bool = True,
     debug: CheckpointDebugConfig | None = None,
+    write_config: TensorStoreWriteConfig | None = None,
 ):
     """
     Save a checkpoint to a given path using TensorStore with OCDBT.
@@ -756,6 +763,7 @@ def save_checkpoint(
         manager: the GlobalAsyncCheckpointManager to use for saving the checkpoint
         commit_callback: a callback to call after the checkpoint has been saved
         is_temporary: whether the checkpoint is temporary
+        write_config: how the save divides work across the processes holding the state
     """
     step = int(step)
     checkpoint_path = str(checkpoint_path)
@@ -813,6 +821,7 @@ def save_checkpoint(
             manager,
             commit_callback=my_callback,
             debug_checkpointer=checkpoint_debug.enabled,
+            write_config=write_config,
         )
         if progress_logger is not None:
             progress_logger.set_phase("async_commit_in_flight")
@@ -1157,6 +1166,10 @@ class CheckpointerConfig:
     """Number of complete temporary checkpoints to retain after a successful temporary checkpoint commit."""
     debug: CheckpointDebugConfig = field(default_factory=CheckpointDebugConfig)
     """Checkpoint-path diagnostics. Disabled by default."""
+    write: TensorStoreWriteConfig = field(default_factory=TensorStoreWriteConfig)
+    """How a save divides work across the processes holding the state."""
+    timeout: timedelta = timedelta(minutes=30)
+    """Maximum time for every process to finish a distributed checkpoint commit."""
 
     def expanded_path(self, run_id) -> str:
         if self.append_run_id_to_base_path:
@@ -1180,6 +1193,8 @@ class CheckpointerConfig:
             delete_old_temp_checkpoints=self.delete_old_temp_checkpoints,
             keep_last_temporary_checkpoints=self.keep_last_temporary_checkpoints,
             debug=self.debug,
+            write_config=self.write,
+            timeout=self.timeout,
         )
 
     def __post_init__(self):
@@ -1190,6 +1205,8 @@ class CheckpointerConfig:
             self.temporary_base_path = os.path.expanduser(self.temporary_base_path)
         if isinstance(self.debug, dict):
             self.debug = CheckpointDebugConfig(**self.debug)
+        if isinstance(self.write, dict):
+            self.write = TensorStoreWriteConfig(**self.write)
         if self.keep_last_temporary_checkpoints < 0:
             raise ValueError("keep_last_temporary_checkpoints must be non-negative")
 

--- a/lib/levanter/src/levanter/checkpoint_manifest.py
+++ b/lib/levanter/src/levanter/checkpoint_manifest.py
@@ -1,0 +1,80 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""``manifest.json``: the storage format and every array in a checkpoint.
+
+Written by process 0 when a save starts. This contains a mirror of the information in the
+OCDBT database but can be read without reading all chunks. Older checkpoints have no
+manifest and fall back to listing.
+"""
+
+import logging
+from typing import Sequence
+
+from pydantic import BaseModel, ConfigDict
+
+from rigging.filesystem import StoragePath, prefix_join
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_FILENAME = "manifest.json"
+
+CHECKPOINT_FORMAT_VERSION = 1
+"""Bump when a change makes an older reader unable to load a newer checkpoint."""
+
+
+class CheckpointArray(BaseModel):
+    """One serialized array, keyed by its dotted leaf path with dots replaced by slashes."""
+
+    model_config = ConfigDict(frozen=True)
+
+    path: str
+    shape: tuple[int, ...]
+    dtype: str
+    chunk_shape: tuple[int, ...]
+    """The zarr3 write-chunk grid. Divides each writer's slice, so writers never share a chunk."""
+
+
+class CheckpointManifest(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    format_version: int
+    array_driver: str
+    kvstore_driver: str
+    arrays: tuple[CheckpointArray, ...]
+
+    @property
+    def array_paths(self) -> frozenset[str]:
+        return frozenset(array.path for array in self.arrays)
+
+
+def build_manifest(arrays: Sequence[CheckpointArray], *, array_driver: str, kvstore_driver: str) -> CheckpointManifest:
+    return CheckpointManifest(
+        format_version=CHECKPOINT_FORMAT_VERSION,
+        array_driver=array_driver,
+        kvstore_driver=kvstore_driver,
+        arrays=tuple(arrays),
+    )
+
+
+def manifest_path(checkpoint_root: str) -> str:
+    return prefix_join(checkpoint_root, MANIFEST_FILENAME)
+
+
+def write_manifest(checkpoint_root: str, manifest: CheckpointManifest) -> None:
+    StoragePath(manifest_path(checkpoint_root)).write_text(manifest.model_dump_json(indent=2))
+
+
+def read_manifest(checkpoint_root: str) -> CheckpointManifest | None:
+    """Return the manifest, or None for a checkpoint written before manifests existed."""
+    path = StoragePath(manifest_path(checkpoint_root))
+    if not path.exists():
+        return None
+
+    manifest = CheckpointManifest.model_validate_json(path.read_text())
+    if manifest.format_version > CHECKPOINT_FORMAT_VERSION:
+        raise ValueError(
+            f"Checkpoint {checkpoint_root} is format version {manifest.format_version}, but this "
+            f"build of levanter understands at most {CHECKPOINT_FORMAT_VERSION}. Upgrade levanter."
+        )
+    return manifest

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -4,14 +4,15 @@
 # References:
 # * Orbax: https://github.com/google/orbax/blob/11d2934ecfff77e86b5e07d0fef02b67eff4511b/orbax/checkpoint/pytree_checkpoint_handler.py#L312
 import asyncio
-import contextlib
-import functools
+import collections
 import logging
+import math
 import os
 import urllib.parse
+import zlib
 from dataclasses import dataclass
 from functools import partial
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Sequence
 
 import equinox
 import haliax as hax
@@ -26,15 +27,26 @@ from haliax.jax_utils import is_jax_array_like
 from haliax.partitioning import ResourceMapping
 from haliax.util import is_named_array
 from jax._src.mesh import get_concrete_mesh
+from jax._src.sharding import IndivisibleError
 from jax.sharding import Mesh, Sharding
 from jaxtyping import PyTree
 
 from rigging.filesystem import StoragePath, prefix_join, record_transfer
 
 from levanter._debug_logging import flush_debug_output
+from levanter.checkpoint_manifest import CheckpointArray, build_manifest, read_manifest, write_manifest
 from levanter.utils import jax_utils
 
 logger = logging.getLogger(__name__)
+
+ARRAY_DRIVER = "zarr3"
+KVSTORE_DRIVER = "ocdbt"
+# JAX's memory kind for host memory a device can address. Offloaded optimizer state lives here.
+_HOST_MEMORY_KIND = "pinned_host"
+# Chunks a save stages at once. Four processes at 32 GiB each exhausted a GB200 node.
+_DEFAULT_STAGED_CHUNKS = 32
+# Host memory a staged byte occupies while its write is in flight, for reporting only.
+_STAGED_BYTE_OVERHEAD = 4
 
 
 def _format_gib(num_bytes: int) -> str:
@@ -51,18 +63,10 @@ def _estimate_array_nbytes(array: Any) -> int:
 
 
 def build_kvstore_spec(path: str) -> dict:
-    """Build a tensorstore kvstore spec for the given URI, handling S3, GCS, and local files.
+    """Build a tensorstore kvstore spec for an S3, GCS, or local URI.
 
-    For S3, tensorstore does not read AWS_ENDPOINT_URL or AWS_DEFAULT_REGION from the
-    environment, so we pass them explicitly when set. This is required for S3-compatible
-    endpoints like CoreWeave object storage.
-
-    For a custom ``endpoint`` we always use virtual-hosted-style addressing (tensorstore
-    0.1.82+, google/tensorstore#285): omit ``bucket`` and fold it into the endpoint host
-    (``https://<bucket>.<endpoint-host>``). Every S3-compatible store we target (R2, AWS,
-    CoreWeave) supports virtual-hosted style, and CoreWeave *requires* it (it rejects
-    path-style with ``PathStyleRequestNotAllowed``). Without a custom endpoint we leave
-    addressing to tensorstore's native AWS handling.
+    tensorstore reads neither AWS_ENDPOINT_URL nor AWS_DEFAULT_REGION from the environment.
+    Custom endpoints use virtual-hosted-style addressing, which CoreWeave requires.
     """
     parsed = urllib.parse.urlparse(path)
     if parsed.scheme == "s3":
@@ -97,71 +101,305 @@ def build_kvstore_spec(path: str) -> dict:
         raise ValueError(f"Unsupported URI scheme for tensorstore: {parsed.scheme!r} in {path!r}")
 
 
-async def _transfer_shard_to_pageable_host(shard) -> np.ndarray:
-    """Return a detached pageable snapshot safe to retain during an asynchronous commit."""
-    data = shard.data
-    data.copy_to_host_async()
-    # Yield so the remaining shards' copies can be enqueued before this one blocks.
-    await asyncio.sleep(0)
-    # TensorStore may retain this array until the asynchronous commit finishes. It must
-    # not keep an external reference to the JAX buffer that training donates next.
+def _slice_shard_on_device(data, axis: int, start: int, limit: int):
+    """Slice a single-device shard under a one-device mesh.
+
+    A training mesh rejects the single-device operand. Orbax does the same.
+    """
+    shard_mesh = jax.sharding.Mesh(np.array(list(data.sharding.device_set)), ("shard",))
+    with jax.sharding.set_mesh(shard_mesh):
+        return jax.lax.slice_in_dim(data, start_index=start, limit_index=limit, axis=axis)
+
+
+async def _transfer_shard_to_pageable_host(shard, local_slice: tuple[int, int, int] | None = None) -> np.ndarray:
+    """Snapshot a shard into pageable host memory, restricted to ``local_slice``.
+
+    The TPU runtime never returns JAX's pinned staging to the OS (#6924). State already in
+    host memory is snapshotted in place.
+    """
+    data = shard.data if local_slice is None else _slice_shard_on_device(shard.data, *local_slice)
+    if getattr(data.sharding, "memory_kind", None) != _HOST_MEMORY_KIND:
+        data.copy_to_host_async()
+        # Yield so the remaining shards' copies can be enqueued before this one blocks.
+        await asyncio.sleep(0)
+    # TensorStore may retain this array. It must not reference the buffer training donates next.
     return np.array(data, copy=True)
 
 
-@contextlib.contextmanager
-def _serialize_with_bounded_host_memory():
-    """Patch two per-save host-RAM leaks around ``GlobalAsyncCheckpointManager.serialize``.
+@dataclass(frozen=True)
+class TensorStoreWriteConfig:
+    """How a checkpoint save divides work across the processes that hold the state."""
 
-    JAX serializes every checkpoint through one process-lifetime ``Context`` singleton
-    (``tensorstore_impl._TS_CONTEXT``). Each save writes a distinct OCDBT database (fresh
-    ``step-{N}`` dir → new cache keys), so cache entries — and the staged source buffers they
-    reference — accumulate for the life of the process. A fresh ``Context`` per save (cloned
-    from the JAX spec, so pool sizes and concurrency limits are unchanged) releases the prior
-    save's pool once its commit drains, bounding live host RAM to one save.
+    max_write_replicas: int = 64
+    """Cap on how many replicas of an array write part of it. 1 disables replica splitting."""
 
-    JAX also stages each shard in pinned host memory, which the TPU runtime never returns to
-    the OS (see :func:`_transfer_shard_to_pageable_host`).
+    min_replica_slice_bytes: int = 16 * 1024**2
+    """Do not split an array when doing so would give each replica less than this."""
 
-    Both patches only need to cover the synchronous part of ``serialize`` — it awaits every
-    copy before returning — so restoring them on exit is safe while the commit continues in
-    the background.
+    max_chunk_bytes: int = 512 * 1024**2
+    """Upper bound on one zarr3 chunk. Bounds the size of a single object store write."""
+
+    max_staged_host_bytes: int = _DEFAULT_STAGED_CHUNKS * max_chunk_bytes
+    """Host memory this process may hold in staged snapshots at once.
+
+    A save whose share fits returns while the commits drain. A larger save rolls through.
     """
-    fresh_context = ts.Context(ts_impl._TS_CONTEXT.spec)
-    original_async_serialize = ts_impl.async_serialize
-    original_transfer = ts_impl._transfer_shard_to_host
 
-    @functools.wraps(original_async_serialize)
-    def async_serialize_with_fresh_context(*args, **kwargs):
-        kwargs.setdefault("context", fresh_context)
-        return original_async_serialize(*args, **kwargs)
+    def __post_init__(self) -> None:
+        if self.max_write_replicas < 1:
+            raise ValueError(f"max_write_replicas must be at least 1, got {self.max_write_replicas}")
+        for name in ("min_replica_slice_bytes", "max_chunk_bytes", "max_staged_host_bytes"):
+            if getattr(self, name) <= 0:
+                raise ValueError(f"{name} must be positive, got {getattr(self, name)}")
 
-    ts_impl.async_serialize = async_serialize_with_fresh_context
-    ts_impl._transfer_shard_to_host = _transfer_shard_to_pageable_host
+
+@dataclass(frozen=True)
+class _WritePlan:
+    """Which bytes of one global array each process writes, and the chunk grid they land on.
+
+    With no ``split_axis``, ``writer_replica`` writes each shard whole. Otherwise replica
+    ``r`` writes block ``r`` along ``split_axis``.
+    """
+
+    chunk_shape: tuple[int, ...]
+    split_axis: int | None
+    write_replicas: int
+    block: int
+    """Length of one replica's slice along ``split_axis``; unused when there is no split."""
+    replicas: int = 1
+    """How many processes hold each shard. Exceeds ``write_replicas`` when a split was rejected."""
+    writer_replica: int = 0
+    """Which replica writes each shard whole; unused when there is a split."""
+
+
+@dataclass(frozen=True)
+class _ShardWrite:
+    """One device's share of one array: where it lands, and which part of the shard it is."""
+
+    index: tuple
+    """Index into the global array."""
+    slice_axis: int | None
+    """Axis the shard is sliced along, or None to write the whole shard."""
+    slice_start: int
+    slice_limit: int
+
+    @property
+    def local_slice(self) -> tuple[int, int, int] | None:
+        if self.slice_axis is None:
+            return None
+        return self.slice_axis, self.slice_start, self.slice_limit
+
+
+class _HostStagingGate:
+    """Track staged bytes until TensorStore has committed and released them.
+
+    Shard writes pass ``can_reference_source_data_indefinitely=True``. The copy future
+    resolves while the snapshot is still referenced.
+    """
+
+    def __init__(self, limit_bytes: int):
+        self._limit = limit_bytes
+        self._in_flight = 0
+        self._peak = 0
+        self._released = asyncio.Event()
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    @property
+    def peak_bytes(self) -> int:
+        return self._peak
+
+    async def acquire(self, num_bytes: int) -> None:
+        # Built before the save's loop exists, so bind on first use.
+        self._loop = asyncio.get_running_loop()
+        # A snapshot larger than the whole budget proceeds alone; it can never be admitted.
+        while self._in_flight and self._in_flight + num_bytes > self._limit:
+            self._released.clear()
+            await self._released.wait()
+        self._in_flight += num_bytes
+        self._peak = max(self._peak, self._in_flight)
+
+    def release(self, num_bytes: int) -> None:
+        """Callable from any thread; TensorStore resolves commits off the loop."""
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return
+        loop.call_soon_threadsafe(self._release_on_loop, num_bytes)
+
+    def _release_on_loop(self, num_bytes: int) -> None:
+        # Every mutation lands on the loop thread, so acquire never observes a partial update.
+        self._in_flight -= num_bytes
+        self._released.set()
+
+
+def _hashable_index(index) -> tuple:
+    return tuple((entry.start, entry.stop) if isinstance(entry, slice) else entry for entry in index)
+
+
+def _uniform_replica_count(sharding: Sharding, shape: tuple[int, ...]) -> int | None:
+    """Replicas per index, or None when indices disagree (no single split factor applies)."""
+    counts: collections.Counter = collections.Counter()
+    for index in sharding.devices_indices_map(shape).values():
+        counts[_hashable_index(index)] += 1
+
+    distinct = set(counts.values())
+    if len(distinct) != 1:
+        return None
+    return distinct.pop()
+
+
+def _shard_shape(sharding: Sharding, shape: tuple[int, ...]) -> tuple[int, ...]:
+    """The per-device shard shape; raises when the sharding does not divide the array evenly."""
     try:
-        yield
-    finally:
-        ts_impl.async_serialize = original_async_serialize
-        ts_impl._transfer_shard_to_host = original_transfer
+        return tuple(sharding.shard_shape(shape))
+    except IndivisibleError as e:
+        raise ValueError(
+            f"Cannot checkpoint an array of shape {shape} under {sharding}: the sharding does not "
+            "divide it evenly, so its shards have different shapes."
+        ) from e
 
 
-def _create_ocdbt_spec(checkpoint_root: str, array_path: str | None) -> dict:
+def _is_safe_to_slice(sharding: Sharding, shard_shape: tuple[int, ...]) -> bool:
+    """Whether a shard can be sliced on device without risking a hang.
+
+    Slicing a small pinned-host array can hang on layout requirements (b/417243451).
     """
-    Create a TensorStore spec with OCDBT (Optionally-Cooperative Distributed B-Tree) enabled.
+    if getattr(sharding, "memory_kind", None) != _HOST_MEMORY_KIND:
+        return True
+    return len(shard_shape) >= 2 and math.prod(shard_shape) % 1024 == 0 and shard_shape[-1] % 128 == 0
 
-    Args:
-        checkpoint_root: Base path for the checkpoint (e.g., "/checkpoints/step-100")
-        array_path: Relative path for this specific array (e.g., "model/layer0/weight")
 
-    Returns:
-        TensorStore spec dict with OCDBT kvstore driver
+def _capped_chunk_shape(local_shape: tuple[int, ...], itemsize: int, max_chunk_bytes: int) -> tuple[int, ...]:
+    """Halve ``local_shape`` down to ``max_chunk_bytes``, keeping it an exact divisor.
+
+    Only even axes halve, so every writer's region is a whole number of chunks. A zero-length
+    axis becomes a chunk of 1, which zarr3 requires.
+    """
+    chunk = [max(size, 1) for size in local_shape]
+    while math.prod(chunk) * itemsize > max_chunk_bytes:
+        divisible = [axis for axis, size in enumerate(chunk) if size % 2 == 0]
+        if not divisible:
+            break
+        chunk[max(divisible, key=lambda axis: chunk[axis])] //= 2
+    return tuple(chunk)
+
+
+def plan_array_write(path: str, array, config: TensorStoreWriteConfig) -> _WritePlan:
+    """Decide how ``array`` is divided among the processes holding it.
+
+    Split along the first shard axis that divides evenly by the replica count, after Orbax's
+    ``replica_slices.py``. Every process must reach the same answer, so this depends only on
+    ``path`` and the global shape and sharding. A replica count dividing no axis takes the
+    widest smaller one that does. The sole writer for an un-splittable array comes from ``path``.
+    """
+    shape = tuple(array.shape)
+    itemsize = array.dtype.itemsize
+
+    if not isinstance(array, jax.Array):
+        # Unsharded host array: one process writes all of it.
+        return _WritePlan(
+            chunk_shape=_capped_chunk_shape(shape, itemsize, config.max_chunk_bytes),
+            split_axis=None,
+            write_replicas=1,
+            block=0,
+        )
+
+    sharding = array.sharding
+    shard_shape = _shard_shape(sharding, shape)
+    replica_count = _uniform_replica_count(sharding, shape)
+    single_writer = _WritePlan(
+        chunk_shape=_capped_chunk_shape(shard_shape, itemsize, config.max_chunk_bytes),
+        split_axis=None,
+        write_replicas=1,
+        block=0,
+        replicas=replica_count or 1,
+        # Every replica holds the whole shard, so any may write it.
+        writer_replica=zlib.crc32(path.encode()) % replica_count if replica_count else 0,
+    )
+
+    if not _is_safe_to_slice(sharding, shard_shape):
+        return single_writer
+
+    if replica_count is None:
+        return single_writer
+
+    for replicas in range(min(replica_count, config.max_write_replicas), 1, -1):
+        split_axis = next((axis for axis, size in enumerate(shard_shape) if size % replicas == 0), None)
+        if split_axis is None:
+            continue
+        # Fewer writers give each a larger slice, so retry under the floor.
+        if math.prod(shard_shape) * itemsize // replicas < config.min_replica_slice_bytes:
+            continue
+
+        block = shard_shape[split_axis] // replicas
+        local_shape = shard_shape[:split_axis] + (block,) + shard_shape[split_axis + 1 :]
+        return _WritePlan(
+            chunk_shape=_capped_chunk_shape(local_shape, itemsize, config.max_chunk_bytes),
+            split_axis=split_axis,
+            write_replicas=replicas,
+            block=block,
+            replicas=replica_count,
+        )
+
+    return single_writer
+
+
+def _shard_write_region(shard, plan: _WritePlan) -> _ShardWrite | None:
+    """What this device writes for this array, or None when it writes nothing."""
+    if plan.split_axis is None:
+        if shard.replica_id != plan.writer_replica:
+            return None
+        return _ShardWrite(index=shard.index, slice_axis=None, slice_start=0, slice_limit=0)
+
+    if shard.replica_id >= plan.write_replicas:
+        return None
+
+    axis = plan.split_axis
+    local_start = shard.replica_id * plan.block
+    start = (shard.index[axis].start or 0) + local_start
+    return _ShardWrite(
+        index=shard.index[:axis] + (slice(start, start + plan.block),) + shard.index[axis + 1 :],
+        slice_axis=axis,
+        slice_start=local_start,
+        slice_limit=local_start + plan.block,
+    )
+
+
+def _process_staged_bytes(array, plan: _WritePlan) -> int:
+    """Bytes this process stages for ``array``."""
+    if not isinstance(array, jax.Array):
+        return _estimate_array_nbytes(array) if jax.process_index() == 0 else 0
+    return sum(
+        _estimate_array_nbytes(shard.data) // plan.write_replicas
+        for shard in array.addressable_shards
+        if _shard_write_region(shard, plan) is not None
+    )
+
+
+def _create_ocdbt_spec(
+    checkpoint_root: str,
+    array_path: str | None,
+    *,
+    entry: "CheckpointArray | None" = None,
+) -> dict:
+    """Build a TensorStore spec over an OCDBT kvstore.
+
+    ``entry`` pins the zarr3 chunk grid, so concurrent writers never share a chunk. Reads omit
+    it and take the grid from storage.
     """
     spec: dict[str, Any] = {
-        "driver": "zarr3",
-        "kvstore": {"driver": "ocdbt", "base": build_kvstore_spec(checkpoint_root)},
+        "driver": ARRAY_DRIVER,
+        "kvstore": {"driver": KVSTORE_DRIVER, "base": build_kvstore_spec(checkpoint_root)},
     }
 
     if array_path:
         spec["kvstore"]["path"] = array_path
+
+    if entry is not None:
+        spec["metadata"] = {
+            "shape": list(entry.shape),
+            "data_type": entry.dtype,
+            "chunk_grid": {"name": "regular", "configuration": {"chunk_shape": list(entry.chunk_shape)}},
+        }
 
     return spec
 
@@ -178,29 +416,18 @@ def _is_named_or_none(x):
     return x is None or is_named_array(x)
 
 
-def tree_serialize_leaves_tensorstore(
-    checkpoint_dir,
-    pytree,
-    manager: Optional[array_ser.GlobalAsyncCheckpointManager] = None,
-    *,
-    commit_callback: Optional[Callable] = None,
-    debug_checkpointer: bool = False,
-):
-    if manager is None:
-        manager = array_ser.GlobalAsyncCheckpointManager()
-        manager_was_none = True
-    else:
-        manager_was_none = False
+def _flatten_serializable_leaves(pytree) -> tuple[list[str], list[Any]]:
+    """Flatten a pytree to (storage path, array) pairs, dropping leaves with nothing to store.
 
+    Paths come from tree position with dots turned into slashes: ``model.layers.0.w_q``
+    becomes ``model/layers/0/w_q``. Python scalars become arrays.
+    """
     leaf_key_paths = jax_utils.leaf_key_paths(pytree, is_leaf=is_named_array)
     assert len(jax.tree.leaves(leaf_key_paths, is_leaf=is_named_array)) == len(
         jax.tree.leaves(pytree, is_leaf=is_named_array)
     )
 
-    def path_from_key_path(key_path):
-        return "/".join(key_path.split("."))
-
-    paths = jtu.tree_map(path_from_key_path, leaf_key_paths)
+    paths = jtu.tree_map(lambda key_path: "/".join(key_path.split(".")), leaf_key_paths)
 
     # make a dataclass since tuples are pytrees
     @dataclass
@@ -210,22 +437,68 @@ def tree_serialize_leaves_tensorstore(
 
     zipped = jax.tree.map(lambda x, y: Pair(x, y), paths, pytree, is_leaf=lambda x: x is None)
     paired_leaves = jax.tree.leaves(zipped)
-    paths = [p.path for p in paired_leaves]
-    leaves = [p.leaf.array if is_named_array(p.leaf) else p.leaf for p in paired_leaves]
 
-    # ok, not all of these are arrays, but we'll deal with that in the async function
-    def _ensure_is_array(x):
-        if isinstance(x, (int, float, bool, complex)):
-            return jnp.array(x)
-        else:
-            return x
+    def to_array(leaf):
+        if is_named_array(leaf):
+            return leaf.array
+        if isinstance(leaf, (int, float, bool, complex)):
+            return jnp.array(leaf)
+        return leaf
 
-    arrays = [_ensure_is_array(x) for x in leaves]
+    with_arrays = [(pair.path, to_array(pair.leaf)) for pair in paired_leaves]
+    keep = [(path, array) for path, array in with_arrays if equinox.is_array_like(array)]
+    return [path for path, _ in keep], [array for _, array in keep]
 
-    # filter out the None leaves and paths (must be zip)
-    filtered = [(a, p) for a, p in zip(arrays, paths) if equinox.is_array_like(a)]
-    arrays = [a for a, _ in filtered]
-    paths = [p for _, p in filtered]
+
+def _log_write_share(
+    paths: Sequence[str],
+    arrays: Sequence[Any],
+    plans: Sequence[_WritePlan],
+    total_array_bytes: int,
+) -> None:
+    """Report this process's share, and how much of it more processes would not relieve."""
+    staged = [_process_staged_bytes(array, plan) for array, plan in zip(arrays, plans)]
+    solo = sorted(
+        (
+            (nbytes, path)
+            for path, plan, nbytes in zip(paths, plans, staged)
+            if nbytes and plan.write_replicas == 1 and plan.replicas > 1
+        ),
+        reverse=True,
+    )
+    capped = sum(nbytes for plan, nbytes in zip(plans, staged) if nbytes and 1 < plan.write_replicas < plan.replicas)
+    logger.info(
+        "Checkpoint gives this process %s of %s across %d of %d arrays; %s of that is %d arrays "
+        "it writes alone and %s is split no further than the replica cap%s",
+        _format_gib(sum(staged)),
+        _format_gib(total_array_bytes),
+        sum(1 for nbytes in staged if nbytes),
+        len(arrays),
+        _format_gib(sum(nbytes for nbytes, _ in solo)),
+        len(solo),
+        _format_gib(capped),
+        "".join(f", {path} at {_format_gib(nbytes)}" for nbytes, path in solo[:3]),
+    )
+
+
+def tree_serialize_leaves_tensorstore(
+    checkpoint_dir,
+    pytree,
+    manager: Optional[array_ser.GlobalAsyncCheckpointManager] = None,
+    *,
+    commit_callback: Optional[Callable] = None,
+    debug_checkpointer: bool = False,
+    write_config: Optional[TensorStoreWriteConfig] = None,
+):
+    write_config = write_config or TensorStoreWriteConfig()
+
+    if manager is None:
+        manager = array_ser.GlobalAsyncCheckpointManager()
+        manager_was_none = True
+    else:
+        manager_was_none = False
+
+    paths, arrays = _flatten_serializable_leaves(pytree)
 
     total_array_bytes = sum(_estimate_array_nbytes(array) for array in arrays)
     largest_path: str | None = None
@@ -250,29 +523,128 @@ def tree_serialize_leaves_tensorstore(
         )
         flush_debug_output(logger)
 
-    # Create specs for each array
-    tspecs = []
-    for path in paths:
-        spec = _create_ocdbt_spec(checkpoint_dir, path)
-        tspecs.append(spec)
+    plans = [plan_array_write(path, array, write_config) for path, array in zip(paths, arrays)]
+    _log_write_share(paths, arrays, plans, total_array_bytes)
+    entries = [
+        CheckpointArray(
+            path=path,
+            shape=tuple(array.shape),
+            dtype=jnp.dtype(array.dtype).name,
+            chunk_shape=plan.chunk_shape,
+        )
+        for path, array, plan in zip(paths, arrays, plans)
+    ]
+    tspecs = [_create_ocdbt_spec(checkpoint_dir, entry.path, entry=entry) for entry in entries]
 
-    # Pre-charge the cross-region transfer budget before kicking off the
-    # async writes — tensorstore bypasses fsspec, so the CrossRegionGuardedFS
-    # interceptor never sees these bytes.  No-op when checkpoint_dir is local
-    # or in the same region as the VM.
+    if jax.process_index() == 0:
+        write_manifest(
+            checkpoint_dir, build_manifest(entries, array_driver=ARRAY_DRIVER, kvstore_driver=KVSTORE_DRIVER)
+        )
+
+    # Pre-charge the cross-region budget: tensorstore bypasses fsspec, so CrossRegionGuardedFS
+    # never sees these bytes. No-op for a local or same-region checkpoint_dir.
     record_transfer(total_array_bytes, checkpoint_dir)
 
     if debug_checkpointer:
-        logger.info("Checkpoint tensorstore serialize entering manager.serialize for %s", checkpoint_dir)
+        split = sum(1 for plan in plans if plan.split_axis is not None)
+        logger.info(
+            "Checkpoint tensorstore serialize starting writes for %s: %d/%d arrays replica-split",
+            checkpoint_dir,
+            split,
+            len(plans),
+        )
         flush_debug_output(logger)
-    with _serialize_with_bounded_host_memory():
-        manager.serialize(arrays, tspecs, on_commit_callback=commit_callback)
+
+    _serialize_arrays(arrays, tspecs, plans, manager, write_config, commit_callback)
+
     if debug_checkpointer:
-        logger.info("Checkpoint tensorstore serialize returned from manager.serialize for %s", checkpoint_dir)
+        logger.info("Checkpoint tensorstore serialize handed off async commit for %s", checkpoint_dir)
         flush_debug_output(logger)
 
     if manager_was_none:
         manager.wait_until_finished()
+
+
+def _serialize_arrays(
+    arrays: Sequence[Any],
+    tspecs: Sequence[dict],
+    plans: Sequence[_WritePlan],
+    manager: array_ser.GlobalAsyncCheckpointManager,
+    config: TensorStoreWriteConfig,
+    commit_callback: Callable,
+) -> None:
+    """Write every array according to its plan and start the asynchronous commit.
+
+    Returns once this process has copied its data out. ``manager`` joins the commits and
+    barriers on the other processes.
+    """
+    manager.wait_until_finished()
+
+    # JAX's process-lifetime ts.Context accumulates caches across saves, since each save
+    # writes a new OCDBT database (#6785). Cloning the spec keeps its pools and limits.
+    context = ts.Context(ts_impl._TS_CONTEXT.spec)
+    gate = _HostStagingGate(config.max_staged_host_bytes)
+    commit_futures: list[ts.Future] = []
+
+    async def issue_write(num_bytes: int, stage):
+        """Admit ``num_bytes`` to the staging budget, then stage and issue one write."""
+        await gate.acquire(num_bytes)
+        try:
+            write = await stage()
+        except BaseException:
+            gate.release(num_bytes)
+            raise
+        commit_futures.append(write.commit)
+        # Fires on failure as well as success, so a failed commit cannot strand the budget.
+        write.commit.add_done_callback(lambda _: gate.release(num_bytes))
+        await write.copy
+
+    async def write_host_array(store, array):
+        # Unsharded and identical everywhere, so process 0 writes all of it.
+        if jax.process_index() != 0:
+            return
+
+        async def stage():
+            # The caller owns this buffer and may mutate it, so TensorStore must copy.
+            return store.write(np.asarray(array), can_reference_source_data_indefinitely=False)
+
+        await issue_write(_estimate_array_nbytes(array), stage)
+
+    async def write_shard(store, shard, plan):
+        region = _shard_write_region(shard, plan)
+        if region is None:
+            return
+
+        async def stage():
+            data = await _transfer_shard_to_pageable_host(shard, region.local_slice)
+            # The snapshot is private and never mutated, so TensorStore may hold the reference.
+            return store[region.index].write(data, can_reference_source_data_indefinitely=True)
+
+        await issue_write(_estimate_array_nbytes(shard.data) // plan.write_replicas, stage)
+
+    async def write_one(array, tspec, plan):
+        store = await ts.open(ts.Spec(tspec), create=True, open=True, context=context)
+        if not isinstance(array, jax.Array):
+            await write_host_array(store, array)
+            return
+        await asyncio.gather(*(write_shard(store, shard, plan) for shard in array.addressable_shards))
+
+    async def write_all():
+        await asyncio.gather(*(write_one(a, s, p) for a, s, p in zip(arrays, tspecs, plans)))
+
+    asyncio.run(write_all())
+    logger.info(
+        "Checkpoint staged %.2f GiB peak against a %.2f GiB budget across %d writes "
+        "(about %.0f GiB of host memory while in flight)",
+        gate.peak_bytes / 1024**3,
+        config.max_staged_host_bytes / 1024**3,
+        len(commit_futures),
+        _STAGED_BYTE_OVERHEAD * gate.peak_bytes / 1024**3,
+    )
+
+    # Private to AsyncManager. Its own `serialize` calls these.
+    manager._add_futures(commit_futures)
+    manager._start_async_commit(commit_callback)
 
 
 def _sharding_from_leaf(leaf, axis_mapping, mesh) -> Optional[jax.sharding.Sharding]:
@@ -318,8 +690,13 @@ def _restore_ocdbt(
     allow_missing: bool,
 ) -> tuple[list, list[int]]:
     """Restore arrays from an OCDBT checkpoint."""
-    # List all keys in the OCDBT kvstore to check existence
-    existing_keys = set(asyncio.run(_list_ocdbt_keys(checkpoint_root)))
+    manifest = read_manifest(checkpoint_root)
+    if manifest is not None:
+        # Listing the kvstore walks every chunk key.
+        present = manifest.array_paths
+    else:
+        keys = asyncio.run(_list_ocdbt_keys(checkpoint_root))
+        present = {key[: -len("/zarr.json")] for key in keys if key.endswith("/zarr.json")}
 
     paths_to_load = []
     indices_to_load = []
@@ -329,10 +706,8 @@ def _restore_ocdbt(
 
     for i in real_indices:
         path = paths[i]
-        # Check if this relative path exists in the kvstore
-        zarr_metadata_key = f"{path}/zarr.json"
 
-        if zarr_metadata_key not in existing_keys:
+        if path not in present:
             missing_paths.append(path)
             missing_indices.append(i)
             continue
@@ -345,7 +720,8 @@ def _restore_ocdbt(
     if missing_paths:
         if not allow_missing:
             raise FileNotFoundError(
-                f"Missing {len(missing_paths)} arrays in OCDBT checkpoint: {missing_paths}. Found: {existing_keys}"
+                f"Missing {len(missing_paths)} arrays in OCDBT checkpoint {checkpoint_root}: {missing_paths}."
+                f" The checkpoint holds {sorted(present)}"
             )
         else:
             to_log = f"Several keys were missing from the OCDBT checkpoint {checkpoint_root}:"
@@ -372,21 +748,7 @@ def _restore_old_ts(
     manager: array_ser.GlobalAsyncCheckpointManager,
     allow_missing: bool,
 ) -> tuple[list, list[int]]:
-    """
-    Restore arrays from an old (non-OCDBT) tensorstore checkpoint.
-
-    Args:
-        checkpoint_dir: Directory containing the checkpoint
-        paths: Full paths for all arrays
-        real_indices: Indices of non-None shardings
-        shardings_leaves: Flattened list of shardings
-        leaf_key_paths: Key paths for logging
-        manager: Checkpoint manager
-        allow_missing: Whether to allow missing arrays
-
-    Returns:
-        Tuple of (deserialized_leaves, indices_to_load)
-    """
+    """Restore arrays from an old (non-OCDBT) tensorstore checkpoint."""
     paths = [prefix_join(checkpoint_dir, p) for p in paths]
 
     paths_to_load = []
@@ -432,33 +794,16 @@ def tree_deserialize_leaves_tensorstore(
     *,
     allow_missing: bool = False,
 ):
-    """
-    Deserializes a PyTree of Arrays and NamedArrays from a Tensorstore checkpoint, returning a pytree with the same shape
-    as the one provided. This method is capable of deserializing NamedArrays that are the result of an eval_shape call
-    (i.e. they are not yet arrays but are ShapedDtypeStructs), provided you pass in the axis_mapping and mesh (or
-    they are available by context)
+    """Deserialize a checkpoint into the shape of ``pytree``.
 
-    Args:
-        checkpoint_dir: the directory containing the tensorstore checkpoint, can be a local path or a GCS path
-        pytree: the exemplar pytree
-        axis_mapping: optional, the axis mapping for the NamedArrays (if they are not yet arrays)
-        mesh: optional, the mesh for the NamedArrays (if they are not yet arrays)
-        manager: optional, the checkpoint manager to use. If not provided, a new one will be created
-        allow_missing: if True, missing leaves will be allowed and kept as-is
-
-    Returns:
-        A pytree with the same shape as the exemplar pytree, but with the arrays deserialized from the checkpoint
+    ``pytree`` may hold ShapeDtypeStructs from ``eval_shape``; ``axis_mapping`` and ``mesh``
+    supply the shardings. ``allow_missing`` keeps absent leaves as they are.
     """
     if manager is None:
         manager = array_ser.GlobalAsyncCheckpointManager()
 
-    # Pre-charge the cross-region transfer budget before kicking off the
-    # async reads.  Tensorstore bypasses fsspec, so the CrossRegionGuardedFS
-    # interceptor never sees these bytes.  We use the exemplar pytree's
-    # shapes/dtypes as an upper bound — if `allow_missing=True` and some
-    # leaves aren't on disk we'll over-charge slightly, but the common case
-    # (no missing arrays) is exact.  No-op when checkpoint_dir is local or
-    # in the same region as the VM.
+    # Pre-charge the cross-region budget from the exemplar pytree, an upper bound under
+    # `allow_missing=True`. See the save path.
     estimated_bytes = sum(
         _estimate_array_nbytes(leaf.array if is_named_array(leaf) else leaf)
         for leaf in jtu.tree_leaves(pytree, is_leaf=_is_named_or_none)
@@ -494,8 +839,17 @@ def tree_deserialize_leaves_tensorstore(
         return path  # fallback to original path
 
     checkpoint_root = find_checkpoint_root(checkpoint_dir)
-    ocdbt_manifest_path = prefix_join(checkpoint_root, "manifest.ocdbt")
-    is_ocdbt_checkpoint = StoragePath(ocdbt_manifest_path).exists()
+    manifest = read_manifest(checkpoint_root)
+    if manifest is not None:
+        if manifest.array_driver != ARRAY_DRIVER:
+            raise ValueError(
+                f"Checkpoint {checkpoint_root} stores arrays with the {manifest.array_driver!r} driver, "
+                f"but this build of levanter reads {ARRAY_DRIVER!r}."
+            )
+        is_ocdbt_checkpoint = manifest.kvstore_driver == KVSTORE_DRIVER
+    else:
+        # A manifest-less checkpoint predates the manifest. Sniff the OCDBT database itself.
+        is_ocdbt_checkpoint = StoragePath(prefix_join(checkpoint_root, "manifest.ocdbt")).exists()
 
     if is_ocdbt_checkpoint:
         subpath = os.path.relpath(checkpoint_dir, start=find_checkpoint_root(checkpoint_dir))

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import tempfile
 from datetime import timedelta
+from unittest.mock import patch
 
 import equinox
 import equinox as eqx
@@ -102,6 +103,12 @@ def test_checkpointer_changing_policy():
         # ensure we saved the right checkpoints
         assert _get_checkpoint_steps(tmpdir) == [2, 4, 6, 8, 10, 15, 20, 30, 40]
 
+
+def test_checkpointer_config_sets_manager_timeout(tmp_path):
+    with patch("levanter.checkpoint.GlobalAsyncCheckpointManager") as manager:
+        CheckpointerConfig(base_path=str(tmp_path), timeout=timedelta(hours=2)).create("run")
+
+    manager.assert_called_once_with(timeout_secs=7200)
 
 def test_checkpointer_temporal_policy():
     fake_now = datetime.datetime(2021, 1, 1, 0, 0, 0)

--- a/tests/sft/test_hf_to_levanter.py
+++ b/tests/sft/test_hf_to_levanter.py
@@ -144,6 +144,23 @@ def test_explicit_steps_can_reuse_prebuilt_chat_cache():
     assert train_config.data.components["ds"].source.train_urls == []
 
 
+def test_selected_parquet_groups_are_explicit_transform_subsets():
+    conv = _fake_conversion()
+    dataset = dataclasses.replace(
+        _DATASET,
+        parquet_files={"terminal": ["terminal/data.parquet"]},
+        parquet_batch_size=1_024,
+    )
+    spec = dataclasses.replace(_spec(ConvertedCheckpointModel(conversion=conv)), datasets=[dataset])
+
+    step = sft_step(spec, ResourceConfig.with_cpu())
+    transform = next(dep for dep in step.deps if dep.name == "documents/ds")
+    transform_config = materialized_config(transform, _PREFIX)
+
+    assert transform_config.subsets == ["terminal"]
+    assert transform_config.parquet_files == {"terminal": ["terminal/data.parquet"]}
+
+
 def test_lm_config_draccus_round_trip_selects_subclass_by_model_type():
     """The carried arch survives the encode/decode used to ship it to the worker + downstream."""
     arch = _tiny_arch()

--- a/tests/sft/test_hf_to_levanter.py
+++ b/tests/sft/test_hf_to_levanter.py
@@ -29,6 +29,7 @@ from marin.processing.tokenize.tokenize import TokenizedCache
 from marin.training.training import LevanterCheckpoint
 
 from experiments.sft.launcher import (
+    ChatCacheMode,
     ConvertedCheckpointModel,
     DatasetSpec,
     LevanterCheckpointModel,
@@ -123,6 +124,24 @@ def test_epoch_chat_tokenize_declares_the_conversion_dependency():
         assert conv.step in cache.deps
         # Materializing resolves the tokenizer through the (now declared) conversion step.
         assert materialized_config(cache, prefix).tokenizer == conv.step.path(prefix)
+
+
+def test_explicit_steps_can_reuse_prebuilt_chat_cache():
+    conv = _fake_conversion()
+    spec = dataclasses.replace(
+        _spec(ConvertedCheckpointModel(conversion=conv)),
+        num_train_steps=1_888,
+        chat_cache_mode=ChatCacheMode.PREBUILT,
+    )
+    step = sft_step(spec, ResourceConfig.with_cpu())
+
+    chat_caches = [dep for dep in step.deps if dep.artifact_type is TokenizedCache]
+    assert len(chat_caches) == 1
+
+    train_config = materialized_config(step, _PREFIX).train_config
+    assert train_config.trainer.num_train_steps == 1_888
+    assert train_config.data.auto_build_caches is False
+    assert train_config.data.components["ds"].source.train_urls == []
 
 
 def test_lm_config_draccus_round_trip_selects_subclass_by_model_type():


### PR DESCRIPTION
Restore the two SFT launch stages recovered from the August Iris workspaces: five token epochs over the fixed-EOT Grug agent traces, and the 1,888-step Nemotron Terminal control initialized from Snowball step 105149. The recipes retain their checkpoint, data, optimizer, chat-template, checkpointing, and H100/GB200 resource choices.

Add an explicit three-stage campaign initialized from Snowball step 105149. Chat runs first, Thinking initializes from Chat's saved checkpoint, and Agentic initializes from Thinking's saved checkpoint. The historical standalone stages remain unchanged.

The shared SFT launcher can materialize a reusable chat cache for an explicit step budget instead of requiring epoch-derived steps, and Grug launch definitions can disable W&B when reproducing an archived run. The fixed-EOT stage consumes the immutable data path introduced by #8171.

Part of #7743. Stacked on #8171, which depends on #7830.
