### PR TITLE
[iris] Handle failed Kubernetes profiles

### DIFF
--- a/lib/iris/dashboard/src/utils/speedscope.ts
+++ b/lib/iris/dashboard/src/utils/speedscope.ts
@@ -30,6 +30,46 @@ const LOADING_HTML =
   '<body style="margin:0;font:14px system-ui,sans-serif;color:#888;display:flex;' +
   'height:100vh;align-items:center;justify-content:center">Capturing profile…</body>'
 
+function isSpeedscopeProfile(bytes: Uint8Array): boolean {
+  try {
+    const value = JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>
+    return Array.isArray(value.profiles) && typeof value.shared === 'object' && value.shared !== null
+  } catch {
+    return false
+  }
+}
+
+function profileFilename(title: string): string {
+  const label = title.replace(/^\/+/, '').replace(/[^a-zA-Z0-9_.-]+/g, '_') || 'profile'
+  return `${label}.speedscope.json`
+}
+
+function offerRawDownload(win: Window | null, url: string, title: string): void {
+  const doc = win?.document ?? document
+  const link = doc.createElement('a')
+  link.href = url
+  link.download = profileFilename(title)
+  link.textContent = 'Download raw profile'
+  link.addEventListener('click', () => setTimeout(() => URL.revokeObjectURL(url), 0), { once: true })
+
+  if (!win) {
+    link.click()
+    return
+  }
+  win.addEventListener('beforeunload', () => URL.revokeObjectURL(url), { once: true })
+
+  doc.title = 'Invalid CPU profile'
+  const main = doc.createElement('main')
+  main.style.cssText = 'max-width:42rem;margin:4rem auto;padding:0 1.5rem;font:16px system-ui,sans-serif;line-height:1.5'
+  const heading = doc.createElement('h1')
+  heading.textContent = 'This CPU profile is not valid speedscope JSON'
+  const explanation = doc.createElement('p')
+  explanation.textContent = 'The capture failed or returned malformed data. Download the raw response for inspection.'
+  link.style.cssText = 'display:inline-block;margin-top:1rem'
+  main.append(heading, explanation, link)
+  doc.body.replaceChildren(main)
+}
+
 export interface PendingSpeedscope {
   /** Load `bytes` (a speedscope-format profile) into the opened viewer window. */
   show(bytes: Uint8Array, title: string): void
@@ -51,6 +91,10 @@ export function openSpeedscopeWindow(): PendingSpeedscope {
   return {
     show(bytes: Uint8Array, title: string) {
       const url = URL.createObjectURL(new Blob([new Uint8Array(bytes)], { type: 'application/json' }))
+      if (!isSpeedscopeProfile(bytes)) {
+        offerRawDownload(win, url, title)
+        return
+      }
       const target = `${SPEEDSCOPE_URL}#profileURL=${encodeURIComponent(url)}&title=${encodeURIComponent(title)}`
       // Navigate the already-open window (path changes from about:blank, so
       // speedscope loads fresh and reads the hash param on mount). Fall back to

--- a/lib/iris/dashboard/src/utils/speedscope.ts
+++ b/lib/iris/dashboard/src/utils/speedscope.ts
@@ -30,7 +30,7 @@ const LOADING_HTML =
   '<body style="margin:0;font:14px system-ui,sans-serif;color:#888;display:flex;' +
   'height:100vh;align-items:center;justify-content:center">Capturing profile…</body>'
 
-function isSpeedscopeProfile(bytes: Uint8Array): boolean {
+function hasSpeedscopeTopLevelFields(bytes: Uint8Array): boolean {
   try {
     const value = JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>
     return Array.isArray(value.profiles) && typeof value.shared === 'object' && value.shared !== null
@@ -91,7 +91,7 @@ export function openSpeedscopeWindow(): PendingSpeedscope {
   return {
     show(bytes: Uint8Array, title: string) {
       const url = URL.createObjectURL(new Blob([new Uint8Array(bytes)], { type: 'application/json' }))
-      if (!isSpeedscopeProfile(bytes)) {
+      if (!hasSpeedscopeTopLevelFields(bytes)) {
         offerRawDownload(win, url, title)
         return
       }

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -108,6 +108,8 @@ from iris.time_proto import timestamp_to_proto
 
 logger = logging.getLogger(__name__)
 
+_ARM64_ARCHITECTURES = frozenset({b"aarch64", b"arm64"})
+
 
 class PodManifestError(ValueError):
     """A RunTaskRequest cannot produce a valid Pod manifest.
@@ -2554,14 +2556,16 @@ class K8sTaskProvider:
         attempt_id = target.attempt_id
         pod_name = self._live_pod_name(target)
         duration = request.duration_seconds or 10
+        dispatch = _K8sProfileDispatch(self.kubectl, pod_name)
         profile_type = job_pb2.ProfileType()
         profile_type.CopyFrom(request.profile_type)
-        # Native unwinding in py-spy can segfault on GPU training processes
-        # before it writes an output file. Keep it available when explicitly
-        # requested, but make Python frames the reliable Kubernetes default.
+        # py-spy 0.4.2's native unwinder can segfault on Linux ARM64 before it
+        # writes an output file. Keep native frames on other architectures and
+        # when explicitly requested, but default to Python frames on ARM64.
         if profile_type.HasField("cpu") and not profile_type.cpu.HasField("native"):
-            profile_type.cpu.native = False
-        dispatch = _K8sProfileDispatch(self.kubectl, pod_name)
+            architecture = dispatch.exec(["uname", "-m"], timeout=10)
+            if architecture.returncode == 0 and architecture.stdout.strip().lower() in _ARM64_ARCHITECTURES:
+                profile_type.cpu.native = False
 
         try:
             if profile_type.HasField("threads"):

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -2554,7 +2554,13 @@ class K8sTaskProvider:
         attempt_id = target.attempt_id
         pod_name = self._live_pod_name(target)
         duration = request.duration_seconds or 10
-        profile_type = request.profile_type
+        profile_type = job_pb2.ProfileType()
+        profile_type.CopyFrom(request.profile_type)
+        # Native unwinding in py-spy can segfault on GPU training processes
+        # before it writes an output file. Keep it available when explicitly
+        # requested, but make Python frames the reliable Kubernetes default.
+        if profile_type.HasField("cpu") and not profile_type.cpu.HasField("native"):
+            profile_type.cpu.native = False
         dispatch = _K8sProfileDispatch(self.kubectl, pod_name)
 
         try:

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -66,6 +66,11 @@ _LIST_PAGE_LIMIT: int = 500
 # verdict without flooding logs.
 _ERROR_BODY_MAX_LEN: int = 500
 
+# GNU timeout's conventional exit status. K8s exec consumers already model
+# process completion as an integer exit code, so preserve that contract when
+# the websocket remains open past the caller's deadline.
+_COMMAND_TIMEOUT_EXIT_CODE: int = 124
+
 
 @runtime_checkable
 class K8sService(Protocol):
@@ -734,9 +739,23 @@ class CloudK8sService:
                 with self.create_api_client() as exec_api_client:
                     resp = kubernetes.stream.stream(
                         kubernetes.client.CoreV1Api(exec_api_client).connect_get_namespaced_pod_exec,
+                        _preload_content=False,
                         **kwargs,
                     )
-                return ExecResult(returncode=0, stdout=resp, stderr="")
+                    try:
+                        resp.run_forever(timeout=effective_timeout)
+                        stdout = resp.read_stdout() or ""
+                        stderr = resp.read_stderr() or ""
+                        if resp.is_open():
+                            timeout_error = f"Command timed out after {effective_timeout:g} seconds"
+                            return ExecResult(
+                                returncode=_COMMAND_TIMEOUT_EXIT_CODE,
+                                stdout=stdout,
+                                stderr="\n".join(part for part in (stderr, timeout_error) if part),
+                            )
+                        return ExecResult(returncode=resp.returncode, stdout=stdout, stderr=stderr)
+                    finally:
+                        resp.close()
             except ApiException as e:
                 return ExecResult(returncode=1, stdout="", stderr=str(e))
 

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -744,8 +744,8 @@ class CloudK8sService:
                     )
                     try:
                         resp.run_forever(timeout=effective_timeout)
-                        stdout = resp.read_stdout() or ""
-                        stderr = resp.read_stderr() or ""
+                        stdout = resp.read_stdout(timeout=0) or ""
+                        stderr = resp.read_stderr(timeout=0) or ""
                         if resp.is_open():
                             timeout_error = f"Command timed out after {effective_timeout:g} seconds"
                             return ExecResult(

--- a/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
@@ -13,41 +13,63 @@ from iris.cluster.platforms.k8s.types import K8sResource
 
 
 class _FakeExecStream:
-    def __init__(self, *, returncode: int, stdout: str = "", stderr: str = ""):
+    def __init__(self, *, returncode: int, stdout: str = "", stderr: str = "", stream_open: bool = False):
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
+        self.open = stream_open
         self.closed = False
 
     def run_forever(self, timeout: float | None = None) -> None:
         pass
 
     def is_open(self) -> bool:
-        return False
+        return self.open
 
-    def read_stdout(self) -> str:
+    def read_stdout(self, timeout: float | None = None) -> str:
+        if self.open and timeout != 0:
+            raise AssertionError("blocking stdout read on an open exec stream")
         return self.stdout
 
-    def read_stderr(self) -> str:
+    def read_stderr(self, timeout: float | None = None) -> str:
+        if self.open and timeout != 0:
+            raise AssertionError("blocking stderr read on an open exec stream")
         return self.stderr
 
     def close(self) -> None:
+        self.open = False
         self.closed = True
 
 
-def test_exec_reports_command_exit_status(monkeypatch):
-    """A command error inside a reachable pod must not look successful."""
-    stream = _FakeExecStream(returncode=1, stderr="cat: profile.json: No such file")
+def _service_with_exec_stream(monkeypatch, stream: _FakeExecStream) -> CloudK8sService:
     monkeypatch.setattr(k8s_service.kubernetes.stream, "stream", lambda *_args, **_kwargs: stream)
     core_api = SimpleNamespace(connect_get_namespaced_pod_exec=object())
     monkeypatch.setattr(k8s_service.kubernetes.client, "CoreV1Api", lambda _client: core_api)
     svc = CloudK8sService(namespace="iris")
     monkeypatch.setattr(svc, "create_api_client", lambda: nullcontext(object()))
+    return svc
+
+
+def test_exec_reports_command_exit_status(monkeypatch):
+    """A command error inside a reachable pod must not look successful."""
+    stream = _FakeExecStream(returncode=1, stderr="cat: profile.json: No such file")
+    svc = _service_with_exec_stream(monkeypatch, stream)
 
     result = svc.exec("task-pod", ["cat", "profile.json"], container="task")
 
     assert result.returncode == 1
     assert result.stderr == "cat: profile.json: No such file"
+    assert stream.closed
+
+
+def test_exec_timeout_reads_open_stream_without_blocking(monkeypatch):
+    stream = _FakeExecStream(returncode=0, stream_open=True)
+    svc = _service_with_exec_stream(monkeypatch, stream)
+
+    result = svc.exec("task-pod", ["sleep", "infinity"], container="task", timeout=1)
+
+    assert result.returncode == 124
+    assert result.stderr == "Command timed out after 1 seconds"
     assert stream.closed
 
 

--- a/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
@@ -3,12 +3,52 @@
 
 """Tests for CloudK8sService helpers and K8sResource enum path construction."""
 
+from contextlib import nullcontext
 from types import SimpleNamespace
 
 import pytest
 from iris.cluster.platforms.k8s import service as k8s_service
 from iris.cluster.platforms.k8s.service import CloudK8sService
 from iris.cluster.platforms.k8s.types import K8sResource
+
+
+class _FakeExecStream:
+    def __init__(self, *, returncode: int, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        self.closed = False
+
+    def run_forever(self, timeout: float | None = None) -> None:
+        pass
+
+    def is_open(self) -> bool:
+        return False
+
+    def read_stdout(self) -> str:
+        return self.stdout
+
+    def read_stderr(self) -> str:
+        return self.stderr
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_exec_reports_command_exit_status(monkeypatch):
+    """A command error inside a reachable pod must not look successful."""
+    stream = _FakeExecStream(returncode=1, stderr="cat: profile.json: No such file")
+    monkeypatch.setattr(k8s_service.kubernetes.stream, "stream", lambda *_args, **_kwargs: stream)
+    core_api = SimpleNamespace(connect_get_namespaced_pod_exec=object())
+    monkeypatch.setattr(k8s_service.kubernetes.client, "CoreV1Api", lambda _client: core_api)
+    svc = CloudK8sService(namespace="iris")
+    monkeypatch.setattr(svc, "create_api_client", lambda: nullcontext(object()))
+
+    result = svc.exec("task-pod", ["cat", "profile.json"], container="task")
+
+    assert result.returncode == 1
+    assert result.stderr == "cat: profile.json: No such file"
+    assert stream.closed
 
 
 def test_construct_without_kubernetes_client(monkeypatch):

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -804,6 +804,33 @@ def test_profile_cpu_via_kubectl_exec(provider, k8s):
     assert len(k8s._rm_files_calls) == 1
 
 
+def test_profile_cpu_defaults_to_python_frames_when_native_profiler_fails(provider, k8s, monkeypatch):
+    """Kubernetes CPU profiles avoid unstable native unwinding unless requested."""
+    pod_name = _pod_name(JobName.from_wire("/job/0"), 1)
+    populate_pod(k8s, pod_name, "Running")
+    k8s.set_file_content(pod_name, "/tmp/iris-profile.json", b'{"profiles": [], "shared": {}}')
+    exec_in_pod = k8s.exec
+
+    def fail_native_profile(pod_name, command, *, container=None, timeout=None):
+        if "--native" in " ".join(command):
+            return _failure_cp(stderr="py-spy exited with signal 11")
+        return exec_in_pod(pod_name, command, container=container, timeout=timeout)
+
+    monkeypatch.setattr(k8s, "exec", fail_native_profile)
+    request = job_pb2.ProfileTaskRequest(
+        target="/job/0",
+        duration_seconds=10,
+        profile_type=job_pb2.ProfileType(cpu=job_pb2.CpuProfile(format=job_pb2.CpuProfile.SPEEDSCOPE)),
+    )
+
+    resp = provider.profile_task(
+        TaskTarget(task_id="/job/0", attempt_id=1, worker_id=None, address=None), request, timeout_ms=45000
+    )
+
+    assert not resp.error
+    assert resp.profile_data == b'{"profiles": [], "shared": {}}'
+
+
 def test_profile_memory_flamegraph_via_kubectl_exec(provider, k8s):
     """profile_task with memory flamegraph attaches memray, transforms, reads file."""
     pod_name = _pod_name(JobName.from_wire("/job/0"), 0)

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -804,15 +804,18 @@ def test_profile_cpu_via_kubectl_exec(provider, k8s):
     assert len(k8s._rm_files_calls) == 1
 
 
-def test_profile_cpu_defaults_to_python_frames_when_native_profiler_fails(provider, k8s, monkeypatch):
-    """Kubernetes CPU profiles avoid unstable native unwinding unless requested."""
+def test_profile_cpu_on_arm64_defaults_to_python_frames_when_native_profiler_fails(provider, k8s, monkeypatch):
+    """ARM64 CPU profiles avoid unstable native unwinding unless requested."""
     pod_name = _pod_name(JobName.from_wire("/job/0"), 1)
     populate_pod(k8s, pod_name, "Running")
     k8s.set_file_content(pod_name, "/tmp/iris-profile.json", b'{"profiles": [], "shared": {}}')
     exec_in_pod = k8s.exec
 
     def fail_native_profile(pod_name, command, *, container=None, timeout=None):
-        if "--native" in " ".join(command):
+        rendered = " ".join(command)
+        if "uname -m" in rendered:
+            return _success_cp(stdout="aarch64\n")
+        if "--native" in rendered:
             return _failure_cp(stderr="py-spy exited with signal 11")
         return exec_in_pod(pod_name, command, container=container, timeout=timeout)
 


### PR DESCRIPTION
Report the real exit status and separate stdout from stderr for commands run
through Kubernetes exec. The adapter treated every established websocket as
exit 0; the affected capture stored `cat: /tmp/iris-profile.json: No such file
or directory` in `iris.profile` with format `speedscope`.

The affected AArch64 pod runs py-spy 0.4.2. Its exact 10-second, 20 Hz
`--native --subprocesses` capture exited 139 after 12 seconds without writing a
file. Removing `--native` exited 0 after 18 seconds and wrote a 25,048-byte
speedscope profile. Kubernetes CPU profiles now default to Python frames on
ARM64; non-ARM pods and explicit native requests retain native unwinding.

Reject malformed speedscope payloads before loading the bundled viewer. The
fallback page keeps the raw response downloadable, while new capture failures
return the profiler error and are not written as profiles.

Investigation record: https://loom.oa.dev/s/1bm0r4eq
