### PR TITLE
Fix dependency updater module execution

### DIFF
--- a/.github/workflows/ops-external-dependencies.yaml
+++ b/.github/workflows/ops-external-dependencies.yaml
@@ -45,7 +45,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          python scripts/ci/dependency_update.py prepare \
+          python -m scripts.ci.dependency_update prepare \
             --kind external-runtime \
             --repository "$GITHUB_REPOSITORY" \
             --github-output "$GITHUB_OUTPUT"
@@ -61,7 +61,7 @@ jobs:
           uv run config/update-external.py --summary-file "$PR_BODY"
           cat "$PR_BODY" >> "$GITHUB_STEP_SUMMARY"
 
-          changed=$(python scripts/ci/dependency_update.py changed-files --kind external-runtime)
+          changed=$(python -m scripts.ci.dependency_update changed-files --kind external-runtime)
 
           if [[ -z "$changed" ]]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -77,7 +77,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_BODY: ${{ runner.temp }}/external-dependencies.md
         run: |
-          python scripts/ci/dependency_update.py publish \
+          python -m scripts.ci.dependency_update publish \
             --kind external-runtime \
             --repository "$GITHUB_REPOSITORY" \
             --body-file "$PR_BODY" \
@@ -91,7 +91,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          python scripts/ci/dependency_update.py merge \
+          python -m scripts.ci.dependency_update merge \
             --kind external-runtime \
             --pr "${{ steps.pull-request.outputs.pr_url }}" \
             --repository "$GITHUB_REPOSITORY" \

--- a/.github/workflows/ops-native-package-dependencies.yaml
+++ b/.github/workflows/ops-native-package-dependencies.yaml
@@ -45,7 +45,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          python scripts/ci/dependency_update.py prepare \
+          python -m scripts.ci.dependency_update prepare \
             --kind native-package \
             --repository "$GITHUB_REPOSITORY" \
             --github-output "$GITHUB_OUTPUT"
@@ -72,7 +72,7 @@ jobs:
           BODY_FILE: .github/native-package-version-pr.md
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          python scripts/ci/dependency_update.py publish \
+          python -m scripts.ci.dependency_update publish \
             --kind native-package \
             --repository "$GITHUB_REPOSITORY" \
             --body-file "$BODY_FILE" \
@@ -86,7 +86,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          python scripts/ci/dependency_update.py merge \
+          python -m scripts.ci.dependency_update merge \
             --kind native-package \
             --pr "${{ steps.pull-request.outputs.pr_url }}" \
             --repository "$GITHUB_REPOSITORY" \

--- a/tests/infra/ci/test_package_release.py
+++ b/tests/infra/ci/test_package_release.py
@@ -452,3 +452,6 @@ def test_dependency_update_workflows_share_scoped_app_pr_lifecycle(workflow_path
     }
     pr_step = next(step for step in steps if step.get("name") == "Open or update pull request")
     assert pr_step["env"]["GH_TOKEN"] == "${{ steps.app-token.outputs.token }}"
+    updater_commands = [step["run"] for step in steps if "scripts.ci.dependency_update" in step.get("run", "")]
+    assert updater_commands
+    assert all("python -m scripts.ci.dependency_update" in command for command in updater_commands)


### PR DESCRIPTION
The dependency updater workflows invoked `scripts/ci/dependency_update.py` by file path, so Python placed `scripts/ci` rather than the repository root on its import path. Both workflows could generate the repository app token but failed before preparing an update branch with `ModuleNotFoundError: No module named 'scripts'`.

Invoke the shared updater as the `scripts.ci.dependency_update` module in both workflows and preserve that execution contract in the workflow test. This unblocks the end-to-end rollout from #8176 without changing the updater's authorization or merge policy.

Observed in native updater run https://github.com/marin-community/marin/actions/runs/31553678412.
