### PR TITLE
Adopt classic main protection for updater bypass

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -69,7 +69,8 @@ scheduled workflow red.
 
 The app key is an environment secret released only to `main`; a pull-request
 workflow cannot receive it. The GitHub Pulumi stack gives the app a
-pull-request-only review bypass but no required-CI bypass. Organization admins
+pull-request-only review bypass in both the current ruleset and the repository's
+imported classic protection, but no required-CI bypass. Organization admins
 retain their emergency bypass on both rulesets. Required checks are bound to
 the GitHub Actions integration, so the app cannot merge a failing update or
 supply the required contexts itself. An upstream commit is discovered within

--- a/infra/pulumi/github/README.md
+++ b/infra/pulumi/github/README.md
@@ -83,7 +83,8 @@ select only `marin`. To recreate or rotate the app credential:
      encryptedPrivateKey: example-base64-ciphertext
    ```
 
-4. Run `pulumi preview`, verify the ruleset bypass actors, then run `pulumi up` and the live audit:
+4. Run `pulumi preview`. Verify the ruleset bypass actors and the imported classic `main`
+   protection's app bypass, then run `pulumi up` and the live audit:
 
    ```bash
    pulumi preview

--- a/infra/pulumi/src/iac/github/dependency_updater.py
+++ b/infra/pulumi/src/iac/github/dependency_updater.py
@@ -15,6 +15,7 @@ from scripts.ci.dependency_update_policy import GITHUB_ACTIONS_APP_ID, REQUIRED_
 APP_SLUG = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 UPDATER_ENVIRONMENT = "external-runtime-updater"
 UPDATER_BRANCH = "main"
+CLASSIC_REQUIRED_CHECKS = ("marin-lint", "marin-docs", "marin-integration", "unit-tests")
 
 
 @dataclass(frozen=True)
@@ -47,6 +48,9 @@ class RulesetBypassActorPlan:
 class DependencyUpdaterPlan:
     repository: str
     environment: str
+    classic_branch_protection_import: str
+    classic_review_bypass_apps: tuple[str, ...]
+    classic_required_checks: tuple[RequiredCheckPlan, ...]
     review_ruleset_import: str
     review_bypass_actors: tuple[RulesetBypassActorPlan, ...]
     required_ci_bypass_actors: tuple[RulesetBypassActorPlan, ...]
@@ -113,6 +117,12 @@ def dependency_updater_plan(config: DependencyUpdaterConfig) -> DependencyUpdate
     return DependencyUpdaterPlan(
         repository=repository,
         environment=UPDATER_ENVIRONMENT,
+        classic_branch_protection_import=f"{repository}:{UPDATER_BRANCH}",
+        classic_review_bypass_apps=(config.app_slug,),
+        classic_required_checks=tuple(
+            RequiredCheckPlan(context=context, integration_id=GITHUB_ACTIONS_APP_ID)
+            for context in CLASSIC_REQUIRED_CHECKS
+        ),
         review_ruleset_import=f"{repository}:{config.review_ruleset_id}",
         review_bypass_actors=(
             organization_admin,
@@ -173,6 +183,30 @@ def register_dependency_updater(
         value_encrypted=config.encrypted_private_key,
         opts=pulumi.ResourceOptions(depends_on=[deployment_policy]),
     )
+    classic_branch_protection = github.BranchProtectionV3(
+        "main-classic-protection",
+        repository=plan.repository,
+        branch=UPDATER_BRANCH,
+        enforce_admins=False,
+        require_conversation_resolution=False,
+        require_signed_commits=False,
+        required_status_checks=github.BranchProtectionV3RequiredStatusChecksArgs(
+            checks=[f"{check.context}:{check.integration_id}" for check in plan.classic_required_checks],
+            strict=False,
+        ),
+        required_pull_request_reviews=github.BranchProtectionV3RequiredPullRequestReviewsArgs(
+            bypass_pull_request_allowances=github.BranchProtectionV3RequiredPullRequestReviewsBypassPullRequestAllowancesArgs(
+                apps=list(plan.classic_review_bypass_apps),
+                teams=[],
+                users=[],
+            ),
+            dismiss_stale_reviews=False,
+            require_code_owner_reviews=False,
+            require_last_push_approval=False,
+            required_approving_review_count=1,
+        ),
+        opts=pulumi.ResourceOptions(import_=plan.classic_branch_protection_import),
+    )
     review_ruleset = github.RepositoryRuleset(
         "protect-main",
         repository=plan.repository,
@@ -219,7 +253,7 @@ def register_dependency_updater(
             )
         ),
     )
-    return app_id, app_slug, private_key, review_ruleset, required_ci_ruleset
+    return app_id, app_slug, private_key, classic_branch_protection, review_ruleset, required_ci_ruleset
 
 
 def register_dependency_updater_environment(

--- a/infra/pulumi/tests/test_github_dependency_updater.py
+++ b/infra/pulumi/tests/test_github_dependency_updater.py
@@ -3,6 +3,7 @@
 
 import pytest
 from iac.github.dependency_updater import (
+    CLASSIC_REQUIRED_CHECKS,
     DependencyUpdaterConfig,
     RulesetBypassActorPlan,
     dependency_updater_config,
@@ -34,6 +35,8 @@ def test_plan_preserves_admin_override_and_limits_the_updater_to_review_bypass()
     assert plan.review_bypass_actors == (admin, updater)
     assert plan.required_ci_bypass_actors == (admin,)
     assert plan.review_ruleset_import == "marin:785435"
+    assert plan.classic_branch_protection_import == "marin:main"
+    assert plan.classic_review_bypass_apps == ("marin-external-runtime-updater",)
 
 
 def test_plan_binds_required_checks_to_github_actions() -> None:
@@ -41,6 +44,8 @@ def test_plan_binds_required_checks_to_github_actions() -> None:
 
     assert tuple(check.context for check in plan.required_checks) == REQUIRED_CHECKS
     assert {check.integration_id for check in plan.required_checks} == {GITHUB_ACTIONS_APP_ID}
+    assert tuple(check.context for check in plan.classic_required_checks) == CLASSIC_REQUIRED_CHECKS
+    assert {check.integration_id for check in plan.classic_required_checks} == {GITHUB_ACTIONS_APP_ID}
 
 
 def test_plan_targets_marins_dependency_update_environment() -> None:


### PR DESCRIPTION
The dependency updater app was present in the `protect main` ruleset bypass list, but GitHub also enforced the repository's legacy classic branch protection. A green app-authored update therefore failed with the duplicate classic one-review requirement.

Adopt `marin:main` as a Pulumi `BranchProtectionV3` resource, preserving its existing Actions-bound checks, one-review rule, and administrator behavior while adding the updater app as its sole app review bypass. The separate required-CI ruleset still has no app bypass.

The live classic protection is repaired and imported into the `marin-community` stack; a post-import preview reports all nine resources unchanged. App-authored external dependency PR #8184 then merged with its four required checks green.

Follow-up to #8176.
