### PR TITLE
Use client ID for dependency updater tokens

### DIFF
--- a/.github/workflows/ops-external-dependencies.yaml
+++ b/.github/workflows/ops-external-dependencies.yaml
@@ -21,7 +21,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.DEPENDENCY_UPDATER_APP_ID }}
+          client-id: ${{ vars.DEPENDENCY_UPDATER_CLIENT_ID }}
           private-key: ${{ secrets.DEPENDENCY_UPDATER_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
 

--- a/.github/workflows/ops-native-package-dependencies.yaml
+++ b/.github/workflows/ops-native-package-dependencies.yaml
@@ -28,7 +28,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.DEPENDENCY_UPDATER_APP_ID }}
+          client-id: ${{ vars.DEPENDENCY_UPDATER_CLIENT_ID }}
           private-key: ${{ secrets.DEPENDENCY_UPDATER_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
 

--- a/infra/pulumi/github/Pulumi.marin-community.yaml
+++ b/infra/pulumi/github/Pulumi.marin-community.yaml
@@ -7,6 +7,7 @@ config:
   marin-github:dependencyUpdater:
     repository: marin-community/marin
     appId: 4563866
+    clientId: Iv23liNdDvC85E67xNa6
     appSlug: marin-external-runtime-updater
     reviewRulesetId: 785435
     actionsKeyId: "3380204578043523366"

--- a/infra/pulumi/github/README.md
+++ b/infra/pulumi/github/README.md
@@ -56,7 +56,7 @@ endpoint requires a user-scoped token unsuitable for unattended Pulumi runs. The
 select only `marin`. To recreate or rotate the app credential:
 
 1. Verify that the app has only Contents and Pull requests read/write permission and remains
-   installed only on `marin`. Record the app ID and slug from its settings page.
+   installed only on `marin`. Record the app ID, client ID, and slug from its settings page.
 2. Generate a private key and seal it to the protected environment's Actions public key. `--no-store`
    prints ciphertext without creating the secret. Record the matching public-key ID:
 
@@ -77,6 +77,7 @@ select only `marin`. To recreate or rotate the app credential:
    marin-github:dependencyUpdater:
      repository: marin-community/marin
      appId: 123456
+     clientId: Iv23example-client-id
      appSlug: marin-external-runtime-updater
      reviewRulesetId: 785435
      actionsKeyId: example-key-id

--- a/infra/pulumi/src/iac/github/dependency_updater.py
+++ b/infra/pulumi/src/iac/github/dependency_updater.py
@@ -25,6 +25,7 @@ class DependencyUpdaterConfig:
     organization: str
     repository: str
     app_id: int
+    client_id: str
     app_slug: str
     actions_key_id: str
     encrypted_private_key: str
@@ -77,6 +78,7 @@ def dependency_updater_config(
     expected_keys = {
         "actionsKeyId",
         "appId",
+        "clientId",
         "appSlug",
         "encryptedPrivateKey",
         "repository",
@@ -90,6 +92,9 @@ def dependency_updater_config(
     app_slug = settings["appSlug"]
     if not isinstance(app_slug, str) or APP_SLUG.fullmatch(app_slug) is None:
         raise ValueError("dependencyUpdater.appSlug must be a lowercase GitHub App slug")
+    client_id = settings["clientId"]
+    if not isinstance(client_id, str) or not client_id:
+        raise ValueError("dependencyUpdater.clientId must be a non-empty string")
     actions_key_id = settings["actionsKeyId"]
     if not isinstance(actions_key_id, str) or not actions_key_id:
         raise ValueError("dependencyUpdater.actionsKeyId must be a non-empty string")
@@ -100,6 +105,7 @@ def dependency_updater_config(
         organization=organization,
         repository=repository,
         app_id=_positive_int(settings, "appId"),
+        client_id=client_id,
         app_slug=app_slug,
         actions_key_id=actions_key_id,
         encrypted_private_key=encrypted_private_key,
@@ -162,11 +168,11 @@ def register_dependency_updater(
 ) -> tuple[pulumi.CustomResource, ...]:
     """Register the app credentials and layered main-branch rules."""
     plan = dependency_updater_plan(config)
-    app_id = github.ActionsVariable(
-        "external-runtime-updater-app-id",
+    client_id = github.ActionsVariable(
+        "external-runtime-updater-client-id",
         repository=plan.repository,
-        variable_name="DEPENDENCY_UPDATER_APP_ID",
-        value=str(config.app_id),
+        variable_name="DEPENDENCY_UPDATER_CLIENT_ID",
+        value=config.client_id,
     )
     app_slug = github.ActionsVariable(
         "external-runtime-updater-app-slug",
@@ -253,7 +259,7 @@ def register_dependency_updater(
             )
         ),
     )
-    return app_id, app_slug, private_key, classic_branch_protection, review_ruleset, required_ci_ruleset
+    return client_id, app_slug, private_key, classic_branch_protection, review_ruleset, required_ci_ruleset
 
 
 def register_dependency_updater_environment(

--- a/infra/pulumi/tests/test_github_dependency_updater.py
+++ b/infra/pulumi/tests/test_github_dependency_updater.py
@@ -18,6 +18,7 @@ def _config(**overrides) -> DependencyUpdaterConfig:
         "organization": "marin-community",
         "repository": "marin-community/marin",
         "app_id": 1234,
+        "client_id": "Iv23test-client-id",
         "app_slug": "marin-external-runtime-updater",
         "actions_key_id": "test-actions-key-id",
         "encrypted_private_key": "test-encrypted-private-key",

--- a/tests/infra/ci/test_package_release.py
+++ b/tests/infra/ci/test_package_release.py
@@ -446,7 +446,7 @@ def test_dependency_update_workflows_share_scoped_app_pr_lifecycle(workflow_path
     token_step = next(step for step in steps if step.get("id") == "app-token")
     assert token_step["uses"] == "actions/create-github-app-token@v3"
     assert token_step["with"] == {
-        "app-id": "${{ vars.DEPENDENCY_UPDATER_APP_ID }}",
+        "client-id": "${{ vars.DEPENDENCY_UPDATER_CLIENT_ID }}",
         "private-key": "${{ secrets.DEPENDENCY_UPDATER_PRIVATE_KEY }}",
         "repositories": "${{ github.event.repository.name }}",
     }


### PR DESCRIPTION
Use the GitHub App client ID when minting tokens in the external and native dependency update workflows. `actions/create-github-app-token@v3` recommends `client-id`; the legacy `app-id` input emitted a deprecation warning on every run.

Pulumi now manages `DEPENDENCY_UPDATER_CLIENT_ID` and retires the unused app-ID Actions variable after cutover. The numeric app ID remains in stack configuration because GitHub rulesets identify the bypass actor by numeric integration ID. The client-ID variable was provisioned before this change so the old and new workflow revisions both have valid credentials during rollout.
