### PR TITLE
[levanter] Replace removed Pallas TPU repeat

### DIFF
--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_tpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_tpu.py
@@ -228,7 +228,7 @@ def linear_softmax_lse_forward_fori_pallas_kernel(
 
         m_curr = jnp.max(logits_f32, axis=-1)[:, None]
         m_next = jnp.maximum(m_prev, m_curr)
-        s_curr = jnp.exp(logits_f32 - pltpu.repeat(m_next, repeats, axis=1))
+        s_curr = jnp.exp(logits_f32 - jnp.tile(m_next, (1, repeats)))
         l_curr = jax.lax.broadcast_in_dim(s_curr.sum(axis=-1), l_prev.shape, (0,))
         alpha = jnp.exp(m_prev - m_next)
         l_next = l_curr + alpha * l_prev

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -710,22 +710,23 @@ def test_fused_cross_entropy_default_grad_matches_reference():
 
 
 @pytest.mark.parametrize(
-    ("implementation", "required_backend", "block_sizes"),
+    ("implementation", "required_backend", "vocab_size", "block_sizes"),
     [
-        ("pallas_tpu", "tpu", fused_api.BlockSizes(b_block_size=128, h_block_size=128, v_block_size=128)),
-        ("batched_xla", "gpu", None),
+        ("pallas_tpu", "tpu", 256, fused_api.BlockSizes(b_block_size=128, h_block_size=128, v_block_size=256)),
+        ("batched_xla", "gpu", 128, None),
     ],
 )
 def test_fused_cross_entropy_named_implementation_matches_reference(
     implementation: str,
     required_backend: str,
+    vocab_size: int,
     block_sizes: fused_api.BlockSizes | None,
 ):
     if jax.default_backend() != required_backend:
         pytest.skip(f"requires {required_backend.upper()} backend")
 
     x = jnp.zeros((128, 128), dtype=jnp.float32)
-    w = jnp.zeros((128, 128), dtype=jnp.float32)
+    w = jnp.zeros((128, vocab_size), dtype=jnp.float32)
     y = jnp.zeros((128,), dtype=jnp.int32)
 
     loss = fused_api.fused_cross_entropy_loss_and_logsumexp_penalty(

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -725,9 +725,11 @@ def test_fused_cross_entropy_named_implementation_matches_reference(
     if jax.default_backend() != required_backend:
         pytest.skip(f"requires {required_backend.upper()} backend")
 
-    x = jnp.zeros((128, 128), dtype=jnp.float32)
-    w = jnp.zeros((128, vocab_size), dtype=jnp.float32)
-    y = jnp.zeros((128,), dtype=jnp.int32)
+    x = jnp.eye(128, dtype=jnp.float32)
+    rows = jnp.arange(128, dtype=jnp.int32)[:, None]
+    columns = jnp.arange(vocab_size, dtype=jnp.int32)[None, :]
+    w = (((rows + columns) % 17 - 8) / 8).astype(jnp.float32)
+    y = jnp.arange(128, dtype=jnp.int32) * (vocab_size // 128)
 
     loss = fused_api.fused_cross_entropy_loss_and_logsumexp_penalty(
         x,


### PR DESCRIPTION
Replace the removed `jax.experimental.pallas.tpu.repeat` call with
`jnp.tile`, which was the helper's implementation before JAX 0.11 and remains
the pattern used by upstream Pallas TPU streaming-softmax kernels. JAX 0.11
otherwise fails four fused cross-entropy value and gradient tests while tracing
the TPU forward kernel.

Expand the accelerator value-parity case from one 128-column lane tile to two
tiles so it checks the repeated lane layout. The JAX 0.11 CPU run passes 72
tests with 12 accelerator cases skipped; `levanter-tpu` CI provides the TPU
correctness and compilation gate.
