### PR TITLE
datakit: require the AA decontamination corpus

### DIFF
--- a/experiments/datakit/decontam/prepare_eval_corpus.py
+++ b/experiments/datakit/decontam/prepare_eval_corpus.py
@@ -8,10 +8,10 @@ in ``MARIN_PREFIX``:
 
 - ``aa/<eval>/<split>.parquet`` -- all nine AA Intelligence Index v4.1.1
   benchmarks. These artifacts are mandatory.
-- ``datakit/decontam/evals/lmh/<task>/<split>.parquet`` -- every unique task in
+- ``lmh/<task>/<split>.parquet`` -- every unique task in
   ``experiments/evals/task_configs.py`` bundles, loaded via lm-eval-harness.
-  These best-effort artifacts keep their extraction-version sidecars and are
-  reused across AA corpus versions.
+  These best-effort artifacts keep their extraction-version sidecars in the
+  same immutable corpus-version root.
 
 Each record has the form ``{id: str, text: str}``. AA extraction is pinned by
 benchmark. AA preparation fails if a source cannot load or if its extracted
@@ -88,9 +88,9 @@ from experiments.evals.task_configs import (
 logger = logging.getLogger(__name__)
 
 AA_INDEX_VERSION = "4.1.1"
-EVAL_CORPUS_VERSION = "aa-index-v4.1.1-v2"
+EVAL_CORPUS_VERSION = "aa-index-v4.1.1-v3"
 EVALS_RELATIVE = f"datakit/decontam/evals/{EVAL_CORPUS_VERSION}"
-LMH_EVALS_RELATIVE = "datakit/decontam/evals/lmh"
+LMH_EVALS_RELATIVE = f"{EVALS_RELATIVE}/lmh"
 AA_MANIFEST_RELATIVE = "aa/_manifest.json"
 LMH_MANIFEST_RELATIVE = "lmh/_manifest.json"
 
@@ -101,7 +101,7 @@ def _output_root() -> str:
 
 
 def _lmh_output_root() -> str:
-    """Stable best-effort lm-eval artifact root."""
+    """Versioned best-effort lm-eval artifact root."""
     return f"{marin_prefix()}/{LMH_EVALS_RELATIVE}"
 
 
@@ -588,6 +588,22 @@ def _aa_manifest(status: str) -> dict[str, Any]:
 
 def _prepare_aa() -> dict[str, Any]:
     manifest_path = f"{_output_root()}/{AA_MANIFEST_RELATIVE}"
+    manifest_storage = StoragePath(manifest_path)
+    if manifest_storage.exists():
+        with manifest_storage.open("r") as source:
+            existing_manifest = json.load(source)
+        if not isinstance(existing_manifest, dict):
+            raise ValueError(f"AA manifest must be an object: {manifest_path}")
+        expected_manifest = _aa_manifest("complete")
+        if existing_manifest.get("status") == "complete":
+            if existing_manifest != expected_manifest:
+                raise ValueError(
+                    "AA manifest content changed within EVAL_CORPUS_VERSION; "
+                    "change EVAL_CORPUS_VERSION before preparation"
+                )
+            logger.info("aa: version %s is already sealed at %s", EVAL_CORPUS_VERSION, manifest_path)
+            return existing_manifest
+
     _write_json(manifest_path, _aa_manifest("building"))
 
     for cfg in AA_EVALS:
@@ -694,6 +710,16 @@ def _prepare_lmh() -> dict[str, Any]:
             )
         if existing_manifest.get("status") not in {"complete", "complete_with_failures"}:
             raise ValueError(f"lmh manifest is not complete: {manifest_path}")
+        if existing_manifest.get("artifact_root") != LMH_EVALS_RELATIVE:
+            raise ValueError(
+                f"lmh manifest artifact root is {existing_manifest.get('artifact_root')!r}, "
+                f"expected {LMH_EVALS_RELATIVE!r}"
+            )
+        if existing_manifest.get("extraction_version") != _LMH_EXTRACTION_VERSION:
+            raise ValueError(
+                f"lmh manifest extraction version is {existing_manifest.get('extraction_version')!r}, "
+                f"expected {_LMH_EXTRACTION_VERSION!r}"
+            )
         logger.info("lmh: version %s is already sealed at %s", EVAL_CORPUS_VERSION, manifest_path)
         return existing_manifest
 
@@ -701,23 +727,7 @@ def _prepare_lmh() -> dict[str, Any]:
     names = _lmh_task_names()
     logger.info("lmh: %d unique task names from task_configs.py", len(names))
 
-    try:
-        from lm_eval.tasks import get_task_dict  # noqa: PLC0415  # optional dep: lm_eval
-    except Exception as exc:
-        logger.warning("lmh: optional loader is unavailable: %s", exc)
-        manifest = {
-            "schema_version": 1,
-            "corpus_version": EVAL_CORPUS_VERSION,
-            "required": False,
-            "status": "complete_with_failures",
-            "artifact_root": LMH_EVALS_RELATIVE,
-            "configured_tasks": names,
-            "included_leaf_tasks": [],
-            "artifacts": [],
-            "failed": [{"task": "*", "reason": f"lm_eval import: {exc}"}],
-        }
-        _write_json(manifest_path, manifest)
-        return manifest
+    from lm_eval.tasks import get_task_dict  # noqa: PLC0415  # optional dep: lm_eval
 
     succeeded: list[str] = []
     skipped_existing: list[str] = []
@@ -804,6 +814,7 @@ def _prepare_lmh() -> dict[str, Any]:
         "required": False,
         "status": "complete_with_failures" if failed else "complete",
         "artifact_root": LMH_EVALS_RELATIVE,
+        "extraction_version": _LMH_EXTRACTION_VERSION,
         "configured_tasks": names,
         "included_leaf_tasks": included_leaf_tasks,
         "artifacts": artifacts,

--- a/experiments/datakit/decontam/prepare_eval_corpus.py
+++ b/experiments/datakit/decontam/prepare_eval_corpus.py
@@ -679,6 +679,24 @@ def _lmh_task_names() -> list[str]:
 
 
 def _prepare_lmh() -> dict[str, Any]:
+    """Build and seal the LMH manifest for one eval-corpus version."""
+    manifest_path = f"{_output_root()}/{LMH_MANIFEST_RELATIVE}"
+    manifest_storage = StoragePath(manifest_path)
+    if manifest_storage.exists():
+        with manifest_storage.open("r") as source:
+            existing_manifest = json.load(source)
+        if not isinstance(existing_manifest, dict):
+            raise ValueError(f"lmh manifest must be an object: {manifest_path}")
+        if existing_manifest.get("corpus_version") != EVAL_CORPUS_VERSION:
+            raise ValueError(
+                f"lmh manifest version is {existing_manifest.get('corpus_version')!r}, "
+                f"expected {EVAL_CORPUS_VERSION!r}"
+            )
+        if existing_manifest.get("status") not in {"complete", "complete_with_failures"}:
+            raise ValueError(f"lmh manifest is not complete: {manifest_path}")
+        logger.info("lmh: version %s is already sealed at %s", EVAL_CORPUS_VERSION, manifest_path)
+        return existing_manifest
+
     trust_remote_code_for_hf()
     names = _lmh_task_names()
     logger.info("lmh: %d unique task names from task_configs.py", len(names))
@@ -698,7 +716,7 @@ def _prepare_lmh() -> dict[str, Any]:
             "artifacts": [],
             "failed": [{"task": "*", "reason": f"lm_eval import: {exc}"}],
         }
-        _write_json(f"{_output_root()}/{LMH_MANIFEST_RELATIVE}", manifest)
+        _write_json(manifest_path, manifest)
         return manifest
 
     succeeded: list[str] = []
@@ -791,7 +809,7 @@ def _prepare_lmh() -> dict[str, Any]:
         "artifacts": artifacts,
         "failed": [{"task": name, "reason": reason} for name, reason in failed],
     }
-    _write_json(f"{_output_root()}/{LMH_MANIFEST_RELATIVE}", manifest)
+    _write_json(manifest_path, manifest)
     return manifest
 
 

--- a/experiments/datakit/decontam/prepare_eval_corpus.py
+++ b/experiments/datakit/decontam/prepare_eval_corpus.py
@@ -1,39 +1,39 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Prepare AA + lm-eval-harness eval text as decon bloom input.
+"""Prepare Artificial Analysis and lm-eval-harness text for decontamination.
 
-Two sub-corpora written under ``{MARIN_PREFIX}/datakit/decontam/evals/`` (the
-iris ``--region`` selects the store MARIN_PREFIX resolves to):
+The mandatory AA corpus and its manifests are written under a versioned path
+in ``MARIN_PREFIX``:
 
-- ``aa/<eval>/<split>.parquet`` -- AA Intelligence Index v4.0 core 8.
-- ``lmh/<task>/<split>.parquet`` -- every unique task in
+- ``aa/<eval>/<split>.parquet`` -- all nine AA Intelligence Index v4.1.1
+  benchmarks. These artifacts are mandatory.
+- ``datakit/decontam/evals/lmh/<task>/<split>.parquet`` -- every unique task in
   ``experiments/evals/task_configs.py`` bundles, loaded via lm-eval-harness.
-  Group names (``mmlu``, ``agieval``, ``bbh_zeroshot``, ``leaderboard_bbh``,
-  ...) are expanded to their leaf tasks; one file per leaf.
+  These best-effort artifacts keep their extraction-version sidecars and are
+  reused across AA corpus versions.
 
-Each record: ``{id: str, text: str}`` where ``text`` concatenates every
-string-typed field of the source row in deterministic key order. Generic
-extraction (no per-eval schema config) trades a bit of noise for uniform
-treatment of arbitrary HF / lm-eval schemas.
+Each record has the form ``{id: str, text: str}``. AA extraction is pinned by
+benchmark. AA preparation fails if a source cannot load or if its extracted
+record count differs from the registered count. A complete manifest is written
+only after all mandatory AA artifacts pass validation. Bloom creation requires
+this manifest.
 
 Test split is preferred; tasks without a test split fall back to
 validation, then training. Tasks that fail to load (e.g. removed from
 lm-eval since our pinned commit, gated HF datasets) are logged and skipped.
 
-Submit on iris (eu-west4, CPU-only, has HF access). The ``eval`` extra is
-needed for ``lm-eval``; AA prep accumulates rows in memory before writing
-so bump RAM (1GB default OOMs on livecodebench):
+Submit on a CPU Iris cluster. The ``lm_eval`` extra supplies the optional
+lm-eval-harness package:
 
-    uv run iris --cluster=marin job run --region europe-west4 \\
-        --extra=cpu --extra=eval --priority interactive \\
+    uv run iris --cluster=cw-rno2a job run --no-wait \\
+        --extra=cpu --extra=lm_eval --priority interactive \\
         --memory 16GB --cpu 2 --enable-extra-resources \\
+        -e MARIN_PREFIX s3://marin-us-east-02a/marin \\
         -- python experiments/datakit/decontam/prepare_eval_corpus.py
 
-The iris worker pulls lm-eval via the marin image's ``eval`` extras. To
-include ifeval / leaderboard_ifeval we depend on ``lm-eval[ifeval]`` so
-``langdetect`` is available; see ``lib/marin/pyproject.toml`` (the ``eval``
-extra). The script monkey-patches ``datasets.load_dataset`` to force
+The Iris worker installs lm-eval through the Levanter ``lm_eval`` extra. The
+script monkey-patches ``datasets.load_dataset`` to force
 ``trust_remote_code=True`` and sets ``HF_ALLOW_CODE_EVAL=1`` before
 loading any task, so tasks shipping custom HF loading scripts (logiqa,
 piqa, ethics_*, crows_pairs_*, ...) and humaneval load without per-task
@@ -47,13 +47,13 @@ import logging
 import urllib.request
 import zipfile
 from collections.abc import Callable, Iterable, Iterator
+from enum import StrEnum
 from typing import Any
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 from datasets import Image as DatasetsImage
 from datasets import load_dataset
-from huggingface_hub import hf_hub_download
 from rigging.filesystem import StoragePath, marin_prefix
 from rigging.log_setup import configure_logging
 
@@ -87,12 +87,22 @@ from experiments.evals.task_configs import (
 
 logger = logging.getLogger(__name__)
 
-_EVALS_RELATIVE = "datakit/decontam/evals"
+AA_INDEX_VERSION = "4.1.1"
+EVAL_CORPUS_VERSION = "aa-index-v4.1.1-v2"
+EVALS_RELATIVE = f"datakit/decontam/evals/{EVAL_CORPUS_VERSION}"
+LMH_EVALS_RELATIVE = "datakit/decontam/evals/lmh"
+AA_MANIFEST_RELATIVE = "aa/_manifest.json"
+LMH_MANIFEST_RELATIVE = "lmh/_manifest.json"
 
 
 def _output_root() -> str:
     """Eval-corpus write root, relative to the active ``MARIN_PREFIX`` (store-agnostic)."""
-    return f"{marin_prefix()}/{_EVALS_RELATIVE}"
+    return f"{marin_prefix()}/{EVALS_RELATIVE}"
+
+
+def _lmh_output_root() -> str:
+    """Stable best-effort lm-eval artifact root."""
+    return f"{marin_prefix()}/{LMH_EVALS_RELATIVE}"
 
 
 # Bump when the LMH text-extraction policy (`_lmh_doc_text`) changes. Written to a
@@ -113,61 +123,142 @@ def _staged_lmh_version(version_path: str) -> str | None:
         return f.read().strip()
 
 
-# AA Intelligence Index v4.0 core (8 text benchmarks). Each entry pins
-# the HF source + the canonical "eval content" fields. ``text_fields`` are
-# string columns concatenated in order; ``list_fields`` are list<string>
-# columns flattened in order. When both are empty the loop falls back to
-# the generic _concat_strings extractor (for schemas not yet pinned).
+class AARecordType(StrEnum):
+    """AA source-row conversion policy."""
+
+    ROW = "row"
+    SCICODE_SUBPROBLEM = "scicode_subproblem"
+    TAU3_TASK = "tau3_task"
+    TERMINAL_BENCH_TASK = "terminal_bench_task"
+
+
 @dataclasses.dataclass(frozen=True)
 class AAEvalConfig:
+    name: str
     subdir: str
-    hf_id: str
+    source_revision: str
+    expected_records: int
+    official_records: int
+    hf_id: str | None
     subset: str | None
     split: str
+    source_url: str | None = None
+    record_type: AARecordType = AARecordType.ROW
     text_fields: tuple[str, ...] = ()
     list_fields: tuple[str, ...] = ()
     skip_if: Callable[[dict], bool] | None = None
-    # When set, bypass `datasets.load_dataset` and pull raw jsonl files via
-    # ``huggingface_hub.hf_hub_download``. Needed for repos that ship a
-    # Python loading script (deprecated in datasets>=4) but commit usable
-    # jsonl alongside it (e.g. livecodebench).
-    hf_jsonl_files: tuple[str, ...] = ()
-    # When set, download a zip from an HTTP URL and stream a jsonl member
-    # inside it. Used for evals not on the HF Hub (e.g. scicode lives on
-    # the project's GitHub Pages repo).
-    download_zip_url: str | None = None
-    zip_jsonl_member: str | None = None
+    coverage_note: str = "Full official task set."
+    filter_note: str | None = None
 
 
 AA_EVALS: tuple[AAEvalConfig, ...] = (
-    # Humanity's Last Exam: text-only subset; skip multimodal rows.
     AAEvalConfig(
-        subdir="hle",
-        hf_id="cais/hle",
+        name="GDPval-AA v2",
+        subdir="gdpval_aa_v2",
+        source_revision="11e7900cdcac61bc4daf59e65feb238acda98fbf",
+        expected_records=220,
+        official_records=220,
+        hf_id="openai/gdpval",
+        subset=None,
+        split="train",
+        text_fields=("prompt", "rubric_pretty"),
+        coverage_note="All public GDPval tasks; prompt and hidden grading rubric are indexed.",
+    ),
+    AAEvalConfig(
+        name="tau3-Banking",
+        subdir="tau3_banking",
+        source_revision="fc0055dc4e0a316c3f83133267fbd6faaa770992",
+        expected_records=97,
+        official_records=97,
+        hf_id=None,
+        subset=None,
+        split="test",
+        source_url=(
+            "https://raw.githubusercontent.com/sierra-research/tau2-bench/"
+            "fc0055dc4e0a316c3f83133267fbd6faaa770992/data/tau2/domains/banking_knowledge/tasks.json"
+        ),
+        record_type=AARecordType.TAU3_TASK,
+        coverage_note="Full upstream v1.0.1 task set; user scenarios and hidden evaluation criteria are indexed.",
+    ),
+    AAEvalConfig(
+        name="Terminal-Bench v2.1",
+        subdir="terminal_bench_2_1",
+        source_revision="c5ee500c185224c97cd6caff7866a990a0057f41",
+        expected_records=89,
+        official_records=89,
+        hf_id=None,
+        subset=None,
+        split="test",
+        source_url=(
+            "https://github.com/harbor-framework/terminal-bench-2-1/archive/"
+            "c5ee500c185224c97cd6caff7866a990a0057f41.zip"
+        ),
+        record_type=AARecordType.TERMINAL_BENCH_TASK,
+        text_fields=("instruction", "solution"),
+        coverage_note="All 89 task instructions and oracle solutions from the pinned v2.1 task tree.",
+    ),
+    AAEvalConfig(
+        name="SciCode",
+        subdir="scicode",
+        source_revision="4510f6a6aa27c43fad7b43da2c59602a86e88480",
+        expected_records=291,
+        official_records=288,
+        hf_id="SciCode1/SciCode",
+        subset=None,
+        split="test",
+        record_type=AARecordType.SCICODE_SUBPROBLEM,
+        coverage_note=(
+            "Pinned public test split. It contains 291 subproblems, three more than the 288 reported by AA; "
+            "the conservative superset is indexed."
+        ),
+    ),
+    AAEvalConfig(
+        name="AA-LCR",
+        subdir="aa_lcr",
+        source_revision="bdae010bbce259820c0e34c1d7cce210d966fb75",
+        expected_records=100,
+        official_records=100,
+        hf_id="ArtificialAnalysis/AA-LCR",
         subset=None,
         split="test",
         text_fields=("question", "answer"),
-        skip_if=lambda r: bool(r.get("image")) or bool(r.get("image_url")),
+        coverage_note=(
+            "All public questions and answers. Public source documents are prompt context and are not indexed."
+        ),
     ),
     AAEvalConfig(
+        name="AA-Omniscience",
         subdir="aa_omniscience",
+        source_revision="4a8ffc87c4650054825fb767fe0da4a4fc97ff32",
+        expected_records=600,
+        official_records=6000,
         hf_id="ArtificialAnalysis/AA-Omniscience-Public",
         subset=None,
         split="train",
         text_fields=("question", "answer"),
+        coverage_note="The mandatory public release contains 600 of the 6,000 private evaluation questions.",
     ),
-    # IFBench is instruction-following; the prompt IS the eval content.
-    # The dataset is named IFBench_test so the only split is "train".
     AAEvalConfig(
-        subdir="ifbench",
-        hf_id="allenai/IFBench_test",
+        name="Humanity's Last Exam",
+        subdir="hle",
+        source_revision="5a81a4c7271a2a2a312b9a690f0c2fde837e4c29",
+        expected_records=2500,
+        official_records=2500,
+        hf_id="cais/hle",
         subset=None,
-        split="train",
-        text_fields=("prompt",),
+        split="test",
+        text_fields=("question", "answer"),
+        coverage_note=(
+            "All 2,500 questions from the May 2025 revision. For multimodal rows, the question and answer text "
+            "are indexed; image bytes are not."
+        ),
     ),
-    # GPQA: HF schema uses Title-Case field names; filter to the diamond subset.
     AAEvalConfig(
+        name="GPQA Diamond",
         subdir="gpqa_diamond",
+        source_revision="633f5ee89ab8ad4522a9f850766b73f62147ffdd",
+        expected_records=198,
+        official_records=198,
         hf_id="Idavidrein/gpqa",
         subset="gpqa_diamond",
         split="train",
@@ -180,46 +271,24 @@ AA_EVALS: tuple[AAEvalConfig, ...] = (
         ),
     ),
     AAEvalConfig(
-        subdir="mmlu_pro",
-        hf_id="TIGER-Lab/MMLU-Pro",
-        subset=None,
-        split="test",
-        text_fields=("question",),
-        list_fields=("options",),
-    ),
-    # SciCode lives on GitHub Pages, not the HF Hub. The data zip ships
-    # ``data/problems_all.jsonl`` with one record per problem (fields:
-    # problem_name, problem_id, problem_description_main, sub_steps, ...).
-    AAEvalConfig(
-        subdir="scicode",
-        hf_id="scicode-bench/SciCode",  # informational; real source is download_zip_url
-        subset=None,
-        split="test",
-        text_fields=("problem_description_main",),
-        download_zip_url="https://raw.githubusercontent.com/scicode-bench/scicode-bench.github.io/main/data/data.zip",
-        zip_jsonl_member="data/problems_all.jsonl",
-    ),
-    # GDPval rows are ~20KB each: large rubric JSON + URLs to deliverable files.
-    # Pin to ``prompt`` (the actual task description) to avoid polluting the bloom.
-    AAEvalConfig(
-        subdir="gdpval",
-        hf_id="openai/gdpval",
+        name="CritPt",
+        subdir="critpt",
+        source_revision="9b9fc8498596ec08ab5437a72f4aa18beef2b876",
+        expected_records=70,
+        official_records=70,
+        hf_id="CritPt-Benchmark/CritPt",
         subset=None,
         split="train",
-        text_fields=("prompt",),
-    ),
-    # LiveCodeBench commits its eval items as plain jsonl at repo root; the
-    # `code_generation_lite.py` loader is deprecated. test6.jsonl is the
-    # latest version per the dataset README.
-    AAEvalConfig(
-        subdir="livecodebench",
-        hf_id="livecodebench/code_generation_lite",
-        subset=None,
-        split="test",  # informational; real source is hf_jsonl_files
-        text_fields=("question_content", "starter_code"),
-        hf_jsonl_files=("test6.jsonl",),
+        text_fields=("problem_description", "code_template", "answer_code", "answer_only_code"),
+        coverage_note=(
+            "All 70 public composite challenges used by AA, with response templates and published answer code. "
+            "CritPt reports 189 modular checkpoints for the 70 test challenges, but those checkpoint prompts are "
+            "not part of the public dataset."
+        ),
     ),
 )
+
+AA_BENCHMARK_NAMES: tuple[str, ...] = tuple(cfg.name for cfg in AA_EVALS)
 
 
 def _extract_aa_text(row: dict[str, Any], cfg: AAEvalConfig) -> str:
@@ -335,38 +404,54 @@ def _write_parquet(path: str, records: Iterator[dict]) -> int:
 
 
 def _iter_aa_rows(cfg: AAEvalConfig) -> Iterator[dict[str, Any]]:
-    """Stream raw rows for one AA eval. Three loaders, picked in order:
-
-    1. ``download_zip_url`` + ``zip_jsonl_member`` -- HTTP zip with a jsonl
-       member (e.g. scicode on GitHub Pages).
-    2. ``hf_jsonl_files`` -- raw jsonl files via huggingface_hub
-       (e.g. livecodebench, which ships a deprecated loading script).
-    3. ``datasets.load_dataset`` (default) -- the normal HF Hub path.
-    """
-    if cfg.download_zip_url:
-        if not cfg.zip_jsonl_member:
-            raise ValueError(f"aa/{cfg.subdir}: zip_jsonl_member must be set with download_zip_url")
-        with urllib.request.urlopen(cfg.download_zip_url) as resp:
-            data = resp.read()
-        with zipfile.ZipFile(io_mod.BytesIO(data)) as zf, zf.open(cfg.zip_jsonl_member) as jf:
-            for line in jf:
-                if line.strip():
-                    yield json.loads(line)
+    """Stream raw rows for one pinned AA source."""
+    if cfg.record_type == AARecordType.TERMINAL_BENCH_TASK:
+        if cfg.source_url is None:
+            raise ValueError(f"{cfg.name}: source_url is required")
+        with urllib.request.urlopen(cfg.source_url) as response:
+            archive = response.read()
+        with zipfile.ZipFile(io_mod.BytesIO(archive)) as source_zip:
+            instructions: dict[str, str] = {}
+            solutions: dict[str, str] = {}
+            for path in source_zip.namelist():
+                if "/tasks/" not in path:
+                    continue
+                task_path = path.split("/tasks/", 1)[1]
+                task_name, separator, relative_path = task_path.partition("/")
+                if not separator:
+                    continue
+                if relative_path == "instruction.md":
+                    instructions[task_name] = source_zip.read(path).decode("utf-8")
+                elif relative_path == "solution/solve.sh":
+                    solutions[task_name] = source_zip.read(path).decode("utf-8")
+        if instructions.keys() != solutions.keys():
+            missing_instructions = sorted(solutions.keys() - instructions.keys())
+            missing_solutions = sorted(instructions.keys() - solutions.keys())
+            raise ValueError(
+                f"{cfg.name}: task archive is incomplete; missing instructions={missing_instructions}, "
+                f"missing solutions={missing_solutions}"
+            )
+        for task_name in sorted(instructions):
+            yield {
+                "task_name": task_name,
+                "instruction": instructions[task_name],
+                "solution": solutions[task_name],
+            }
         return
 
-    if cfg.hf_jsonl_files:
-        for fname in cfg.hf_jsonl_files:
-            local = hf_hub_download(repo_id=cfg.hf_id, filename=fname, repo_type="dataset")
-            with open(local, encoding="utf-8") as f:
-                for line in f:
-                    if line.strip():
-                        yield json.loads(line)
+    if cfg.source_url is not None:
+        with urllib.request.urlopen(cfg.source_url) as response:
+            rows = json.load(response)
+        if not isinstance(rows, list) or not all(isinstance(row, dict) for row in rows):
+            raise ValueError(f"{cfg.name}: expected a JSON list of objects")
+        yield from rows
         return
 
-    ds = load_dataset(cfg.hf_id, name=cfg.subset, split=cfg.split)
-    # Disable Image-feature decoding so iteration doesn't pull in Pillow on
-    # multimodal datasets (e.g. HLE) -- we filter out those rows via skip_if
-    # without ever touching the bytes.
+    if cfg.hf_id is None:
+        raise ValueError(f"{cfg.name}: hf_id or source_url is required")
+    ds = load_dataset(cfg.hf_id, name=cfg.subset, split=cfg.split, revision=cfg.source_revision)
+    # Disable Image-feature decoding so iteration does not decode HLE image
+    # bytes. The row still supplies question and answer text for decontamination.
     features = getattr(ds, "features", None) or {}
     for col, ftype in features.items():
         if isinstance(ftype, DatasetsImage):
@@ -375,41 +460,155 @@ def _iter_aa_rows(cfg: AAEvalConfig) -> Iterator[dict[str, Any]]:
         yield dict(row)
 
 
-def _prepare_aa() -> None:
+def _row_identifier(row: dict[str, Any], index: int) -> str:
+    for field in ("id", "question_id", "problem_id"):
+        value = row.get(field)
+        if isinstance(value, str | int):
+            return str(value)
+    return str(index)
+
+
+def _scicode_text(row: dict[str, Any], subproblem: dict[str, Any]) -> str:
+    parts = [
+        row.get("problem_description_main"),
+        row.get("problem_background_main"),
+        row.get("required_dependencies"),
+        subproblem.get("step_description_prompt"),
+        subproblem.get("step_background"),
+        subproblem.get("function_header"),
+        *(subproblem.get("test_cases") or []),
+        subproblem.get("return_line"),
+        subproblem.get("ground_truth_code"),
+    ]
+    return "\n\n".join(part for part in parts if isinstance(part, str) and part.strip())
+
+
+def _aa_records(raw_rows: Iterable[dict[str, Any]], cfg: AAEvalConfig) -> list[dict[str, str]]:
+    """Convert one AA source to validated decontamination records."""
+    records: list[dict[str, str]] = []
+    for index, row in enumerate(raw_rows):
+        if cfg.skip_if is not None and cfg.skip_if(row):
+            continue
+
+        if cfg.record_type == AARecordType.SCICODE_SUBPROBLEM:
+            subproblems = row.get("sub_steps")
+            if not isinstance(subproblems, list):
+                raise ValueError(f"{cfg.name}: row {_row_identifier(row, index)} has no sub_steps list")
+            for subproblem in subproblems:
+                if not isinstance(subproblem, dict):
+                    raise ValueError(f"{cfg.name}: row {_row_identifier(row, index)} has an invalid subproblem")
+                subproblem_id = subproblem.get("step_number")
+                if not isinstance(subproblem_id, str) or not subproblem_id:
+                    raise ValueError(f"{cfg.name}: row {_row_identifier(row, index)} has a subproblem without an ID")
+                text = _scicode_text(row, subproblem)
+                if not text:
+                    raise ValueError(f"{cfg.name}: subproblem {subproblem_id} has no indexed text")
+                records.append({"id": f"{cfg.subdir}-{subproblem_id}", "text": text})
+            continue
+
+        if cfg.record_type == AARecordType.TAU3_TASK:
+            task_id = row.get("id")
+            scenario = row.get("user_scenario")
+            criteria = row.get("evaluation_criteria")
+            if not isinstance(task_id, str) or not isinstance(scenario, dict) or not isinstance(criteria, dict):
+                raise ValueError(f"{cfg.name}: task {index} has an invalid schema")
+            instructions = scenario.get("instructions")
+            if not isinstance(instructions, str) or not instructions.strip():
+                raise ValueError(f"{cfg.name}: task {task_id} has no user instructions")
+            text = f"{instructions}\n\n{json.dumps(criteria, sort_keys=True, ensure_ascii=False)}"
+            records.append({"id": f"{cfg.subdir}-{task_id}", "text": text})
+            continue
+
+        text = _extract_aa_text(row, cfg)
+        if not text:
+            raise ValueError(f"{cfg.name}: row {_row_identifier(row, index)} has no indexed text")
+        if cfg.record_type == AARecordType.TERMINAL_BENCH_TASK:
+            identifier = row.get("task_name")
+            if not isinstance(identifier, str):
+                raise ValueError(f"{cfg.name}: task {index} has no task_name")
+        else:
+            identifier = _row_identifier(row, index)
+        records.append({"id": f"{cfg.subdir}-{identifier}", "text": text})
+
+    if len(records) != cfg.expected_records:
+        raise ValueError(f"{cfg.name}: expected {cfg.expected_records} records, extracted {len(records)}")
+    return records
+
+
+def _aa_manifest_entry(cfg: AAEvalConfig) -> dict[str, Any]:
+    source = cfg.hf_id if cfg.hf_id is not None else cfg.source_url
+    assert source is not None
+    return {
+        "name": cfg.name,
+        "artifact": f"{cfg.subdir}/{cfg.split}.parquet",
+        "source": source,
+        "source_revision": cfg.source_revision,
+        "subset": cfg.subset,
+        "split": cfg.split,
+        "record_type": cfg.record_type.value,
+        "text_fields": list(cfg.text_fields),
+        "list_fields": list(cfg.list_fields),
+        "expected_records": cfg.expected_records,
+        "official_records": cfg.official_records,
+        "coverage_note": cfg.coverage_note,
+        "filter_note": cfg.filter_note,
+    }
+
+
+def _write_json(path: str, value: dict[str, Any]) -> None:
+    parent = StoragePath(path).parent
+    if parent.key:
+        parent.mkdirs()
+    with StoragePath(path).open("w") as output:
+        json.dump(value, output, indent=2, sort_keys=True)
+        output.write("\n")
+
+
+def _staged_aa_is_current(out_path: str, sidecar_path: str, entry: dict[str, Any]) -> bool:
+    if not StoragePath(out_path).exists() or not StoragePath(sidecar_path).exists():
+        return False
+    with StoragePath(sidecar_path).open("r") as source:
+        staged_entry = json.load(source)
+    if staged_entry != entry:
+        return False
+    with StoragePath(out_path).open("rb") as source:
+        return pq.ParquetFile(source).metadata.num_rows == entry["expected_records"]
+
+
+def _aa_manifest(status: str) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "corpus_version": EVAL_CORPUS_VERSION,
+        "suite": f"Artificial Analysis Intelligence Index v{AA_INDEX_VERSION}",
+        "required": True,
+        "status": status,
+        "benchmarks": [_aa_manifest_entry(cfg) for cfg in AA_EVALS],
+    }
+
+
+def _prepare_aa() -> dict[str, Any]:
+    manifest_path = f"{_output_root()}/{AA_MANIFEST_RELATIVE}"
+    _write_json(manifest_path, _aa_manifest("building"))
+
     for cfg in AA_EVALS:
         out_path = f"{_output_root()}/aa/{cfg.subdir}/{cfg.split}.parquet"
-        if StoragePath(out_path).exists():
-            logger.info("aa/%s: exists, skipping", cfg.subdir)
-            continue
-        try:
-            raw_rows = list(_iter_aa_rows(cfg))
-        except Exception as exc:
-            logger.warning(
-                "aa/%s: load(%s subset=%s split=%s) failed: %s",
-                cfg.subdir,
-                cfg.hf_id,
-                cfg.subset,
-                cfg.split,
-                exc,
-            )
+        sidecar_path = f"{_output_root()}/aa/{cfg.subdir}/{cfg.split}.source.json"
+        entry = _aa_manifest_entry(cfg)
+        if _staged_aa_is_current(out_path, sidecar_path, entry):
+            logger.info("aa/%s: validated existing artifact", cfg.subdir)
             continue
 
-        def rows(raw_rows=raw_rows, cfg=cfg) -> Iterator[dict]:
-            n_skipped = 0
-            for i, row_dict in enumerate(raw_rows):
-                if cfg.skip_if is not None and cfg.skip_if(row_dict):
-                    n_skipped += 1
-                    continue
-                text = _extract_aa_text(row_dict, cfg)
-                if not text:
-                    n_skipped += 1
-                    continue
-                yield {"id": f"{cfg.hf_id}-{cfg.split}-{i}", "text": text}
-            if n_skipped:
-                logger.info("aa/%s: skipped %d rows", cfg.subdir, n_skipped)
-
-        n = _write_parquet(out_path, rows())
+        records = _aa_records(_iter_aa_rows(cfg), cfg)
+        n = _write_parquet(out_path, iter(records))
+        if n != cfg.expected_records:
+            raise ValueError(f"{cfg.name}: wrote {n} records, expected {cfg.expected_records}")
+        _write_json(sidecar_path, entry)
         logger.info("aa/%s: %d records -> %s", cfg.subdir, n, out_path)
+
+    manifest = _aa_manifest("complete")
+    _write_json(manifest_path, manifest)
+    logger.info("aa: all %d mandatory benchmarks are complete", len(AA_EVALS))
+    return manifest
 
 
 # Eval tasks excluded from the *decontamination* bloom (they remain valid
@@ -479,17 +678,40 @@ def _lmh_task_names() -> list[str]:
     return sorted(names - DECON_EXCLUDED_EVAL_TASKS)
 
 
-def _prepare_lmh() -> None:
+def _prepare_lmh() -> dict[str, Any]:
     trust_remote_code_for_hf()
-    from lm_eval.tasks import get_task_dict  # noqa: PLC0415  # optional dep: lm_eval
-
     names = _lmh_task_names()
     logger.info("lmh: %d unique task names from task_configs.py", len(names))
 
-    succeeded = 0
-    skipped_existing = 0
+    try:
+        from lm_eval.tasks import get_task_dict  # noqa: PLC0415  # optional dep: lm_eval
+    except Exception as exc:
+        logger.warning("lmh: optional loader is unavailable: %s", exc)
+        manifest = {
+            "schema_version": 1,
+            "corpus_version": EVAL_CORPUS_VERSION,
+            "required": False,
+            "status": "complete_with_failures",
+            "artifact_root": LMH_EVALS_RELATIVE,
+            "configured_tasks": names,
+            "included_leaf_tasks": [],
+            "artifacts": [],
+            "failed": [{"task": "*", "reason": f"lm_eval import: {exc}"}],
+        }
+        _write_json(f"{_output_root()}/{LMH_MANIFEST_RELATIVE}", manifest)
+        return manifest
+
+    succeeded: list[str] = []
+    skipped_existing: list[str] = []
     failed: list[tuple[str, str]] = []
     for name in names:
+        direct_out_path = f"{_lmh_output_root()}/{name}/eval.parquet"
+        direct_version_path = f"{_lmh_output_root()}/{name}/{_LMH_VERSION_SIDECAR}"
+        if StoragePath(direct_out_path).exists() and _staged_lmh_version(direct_version_path) == _LMH_EXTRACTION_VERSION:
+            logger.info("lmh/%s: exists (extraction %s), skipping", name, _LMH_EXTRACTION_VERSION)
+            skipped_existing.append(name)
+            continue
+
         try:
             task_dict = get_task_dict([name])
         except Exception as exc:
@@ -506,13 +728,13 @@ def _prepare_lmh() -> None:
             logger.info("lmh/%s: group expanded to %d leaf tasks", name, len(leaves))
 
         for child_name, task in leaves:
-            out_path = f"{_output_root()}/lmh/{child_name}/eval.parquet"
-            version_path = f"{_output_root()}/lmh/{child_name}/{_LMH_VERSION_SIDECAR}"
+            out_path = f"{_lmh_output_root()}/{child_name}/eval.parquet"
+            version_path = f"{_lmh_output_root()}/{child_name}/{_LMH_VERSION_SIDECAR}"
             # Skip only if the shard exists AND was built with the current extraction
             # policy; a version bump forces a rewrite so policy changes reach the corpus.
             if StoragePath(out_path).exists() and _staged_lmh_version(version_path) == _LMH_EXTRACTION_VERSION:
                 logger.info("lmh/%s: exists (extraction %s), skipping", child_name, _LMH_EXTRACTION_VERSION)
-                skipped_existing += 1
+                skipped_existing.append(child_name)
                 continue
 
             chosen = materialize_first_nonempty_split(task)
@@ -534,26 +756,58 @@ def _prepare_lmh() -> None:
                 with StoragePath(version_path).open("w") as vf:
                     vf.write(_LMH_EXTRACTION_VERSION)
                 logger.info("lmh/%s: %d records (%s split) -> %s", child_name, n, split, out_path)
-                succeeded += 1
+                succeeded.append(child_name)
             except Exception as exc:
                 logger.warning("lmh/%s: write failed: %s", child_name, exc)
                 failed.append((child_name, f"write: {exc}"))
 
     logger.info(
         "lmh summary: %d succeeded, %d skipped (existing), %d failed",
-        succeeded,
-        skipped_existing,
+        len(succeeded),
+        len(skipped_existing),
         len(failed),
     )
     if failed:
         for n, reason in failed:
             logger.info("  FAIL lmh/%s: %s", n, reason)
 
+    included_leaf_tasks = sorted(set(succeeded + skipped_existing))
+    artifacts: list[dict[str, Any]] = []
+    for task_name in included_leaf_tasks:
+        artifact = f"{task_name}/eval.parquet"
+        artifact_path = f"{_lmh_output_root()}/{artifact}"
+        with StoragePath(artifact_path).open("rb") as source:
+            records = pq.ParquetFile(source).metadata.num_rows
+        artifacts.append({"task": task_name, "artifact": artifact, "records": records})
+
+    manifest = {
+        "schema_version": 1,
+        "corpus_version": EVAL_CORPUS_VERSION,
+        "required": False,
+        "status": "complete_with_failures" if failed else "complete",
+        "artifact_root": LMH_EVALS_RELATIVE,
+        "configured_tasks": names,
+        "included_leaf_tasks": included_leaf_tasks,
+        "artifacts": artifacts,
+        "failed": [{"task": name, "reason": reason} for name, reason in failed],
+    }
+    _write_json(f"{_output_root()}/{LMH_MANIFEST_RELATIVE}", manifest)
+    return manifest
+
 
 def main() -> None:
     configure_logging(logging.INFO)
-    _prepare_aa()
-    _prepare_lmh()
+    aa_manifest = _prepare_aa()
+    lmh_manifest = _prepare_lmh()
+    _write_json(
+        f"{_output_root()}/_manifest.json",
+        {
+            "schema_version": 1,
+            "corpus_version": EVAL_CORPUS_VERSION,
+            "artificial_analysis": aa_manifest,
+            "lm_eval_harness": lmh_manifest,
+        },
+    )
 
 
 if __name__ == "__main__":

--- a/experiments/datakit/reference_pipeline.py
+++ b/experiments/datakit/reference_pipeline.py
@@ -143,7 +143,15 @@ from experiments.datakit.decontam.config import (
     SOURCE_DF_COMMON_MIN_ABS,
     SOURCE_DF_SAMPLE_DOCS,
 )
-from experiments.datakit.decontam.prepare_eval_corpus import DECON_EXCLUDED_EVAL_TASKS
+from experiments.datakit.decontam.prepare_eval_corpus import (
+    AA_BENCHMARK_NAMES,
+    AA_MANIFEST_RELATIVE,
+    DECON_EXCLUDED_EVAL_TASKS,
+    EVAL_CORPUS_VERSION,
+    EVALS_RELATIVE,
+    LMH_EVALS_RELATIVE,
+    LMH_MANIFEST_RELATIVE,
+)
 from experiments.datakit.embeddings.luxical.pipeline import (
     EMBED_DOC_SAMPLE_CHARS,
     EMBEDDING_ATTR_DATA_VERSION,
@@ -187,9 +195,12 @@ TOKENIZER_REVISION = "a5ca45f2feb6c959bd87b81689aa7279b5bdcaa2"
 TOKENIZER_BACKEND = TokenizerBackend.HF
 SPLIT = "train"
 
-# Decontam. The combined eval corpus written by decontam/prepare_eval_corpus.py,
-# staged per-region (``aa/<eval>/<split>.parquet`` + ``lmh/<task>/eval.parquet``).
-EVAL_ROOT = f"{marin_prefix()}/datakit/decontam/evals"
+# Decontam. Mandatory AA artifacts use a versioned root. Best-effort lm-eval
+# artifacts use stable per-task roots with extraction-version sidecars.
+EVAL_ROOT = f"{marin_prefix()}/{EVALS_RELATIVE}"
+LMH_EVAL_ROOT = f"{marin_prefix()}/{LMH_EVALS_RELATIVE}"
+AA_MANIFEST_PATH = f"{EVAL_ROOT}/{AA_MANIFEST_RELATIVE}"
+LMH_MANIFEST_PATH = f"{EVAL_ROOT}/{LMH_MANIFEST_RELATIVE}"
 # Bloom capacity -- unique ngram hashes the filter must hold: ~21.78M unique
 # hashes across the AA + LMH corpus, with 2.3x headroom. At FPR=1e-9 this is a
 # ~270 MB filter.
@@ -682,6 +693,12 @@ def reference_datakit_steps(
         estimated_doc_count=ESTIMATED_DOC_COUNT,
         false_positive_rate=FALSE_POSITIVE_RATE,
         exclude_eval_dirs=DECON_EXCLUDED_EVAL_TASKS,
+        required_eval_manifest_path=AA_MANIFEST_PATH,
+        required_eval_corpus_version=EVAL_CORPUS_VERSION,
+        required_eval_names=AA_BENCHMARK_NAMES,
+        best_effort_eval_manifest_path=LMH_MANIFEST_PATH,
+        best_effort_eval_root=LMH_EVAL_ROOT,
+        best_effort_eval_corpus_version=EVAL_CORPUS_VERSION,
     )
     # Count eval-ngram document frequency across normalized sources before
     # marking. Each decon consumes its source-local set and the global set.

--- a/experiments/datakit/reference_pipeline.py
+++ b/experiments/datakit/reference_pipeline.py
@@ -149,7 +149,6 @@ from experiments.datakit.decontam.prepare_eval_corpus import (
     DECON_EXCLUDED_EVAL_TASKS,
     EVAL_CORPUS_VERSION,
     EVALS_RELATIVE,
-    LMH_EVALS_RELATIVE,
     LMH_MANIFEST_RELATIVE,
 )
 from experiments.datakit.embeddings.luxical.pipeline import (
@@ -195,10 +194,8 @@ TOKENIZER_REVISION = "a5ca45f2feb6c959bd87b81689aa7279b5bdcaa2"
 TOKENIZER_BACKEND = TokenizerBackend.HF
 SPLIT = "train"
 
-# Decontam. Mandatory AA artifacts use a versioned root. Best-effort lm-eval
-# artifacts use stable per-task roots with extraction-version sidecars.
+# Decontam. Mandatory AA and best-effort lm-eval artifacts use one versioned root.
 EVAL_ROOT = f"{marin_prefix()}/{EVALS_RELATIVE}"
-LMH_EVAL_ROOT = f"{marin_prefix()}/{LMH_EVALS_RELATIVE}"
 AA_MANIFEST_PATH = f"{EVAL_ROOT}/{AA_MANIFEST_RELATIVE}"
 LMH_MANIFEST_PATH = f"{EVAL_ROOT}/{LMH_MANIFEST_RELATIVE}"
 # Bloom capacity -- unique ngram hashes the filter must hold: ~21.78M unique
@@ -697,7 +694,6 @@ def reference_datakit_steps(
         required_eval_corpus_version=EVAL_CORPUS_VERSION,
         required_eval_names=AA_BENCHMARK_NAMES,
         best_effort_eval_manifest_path=LMH_MANIFEST_PATH,
-        best_effort_eval_root=LMH_EVAL_ROOT,
         best_effort_eval_corpus_version=EVAL_CORPUS_VERSION,
     )
     # Count eval-ngram document frequency across normalized sources before

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -314,7 +314,12 @@ def _discover_eval_files(eval_paths: list[str], exclude_dir_names: frozenset[str
         protocol = source.split("://")[0] if "://" in source else ""
         if fs.isfile(resolved):
             filename = os.path.basename(resolved)
-            if not filename.startswith(".") and filename.endswith(SUPPORTED_EXTENSIONS):
+            parent_name = os.path.basename(os.path.dirname(resolved).rstrip("/"))
+            if (
+                parent_name not in exclude_dir_names
+                and not filename.startswith(".")
+                and filename.endswith(SUPPORTED_EXTENSIONS)
+            ):
                 yield source
             continue
         for root, _dirs, files in fs.walk(resolved):
@@ -1015,7 +1020,8 @@ def build_eval_bloom_step(
             expected version and names enter the step hash.
         best_effort_eval_manifest_path, best_effort_eval_root,
             best_effort_eval_corpus_version: Optional best-effort suite. Only
-            the exact artifacts in its manifest enter the Bloom.
+            the exact artifacts in its immutable, versioned manifest enter the
+            Bloom.
         output_path_prefix, override_output_path: StepSpec routing.
     """
     raw_paths: list[str] = []

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -667,7 +667,6 @@ def build_eval_bloom(
     required_eval_corpus_version: str | None = None,
     required_eval_names: tuple[str, ...] = (),
     best_effort_eval_manifest_path: str | None = None,
-    best_effort_eval_root: str | None = None,
     best_effort_eval_corpus_version: str | None = None,
 ) -> EvalBloom:
     """Build a reusable bloom + hash-index sidecar from one or more eval sources.
@@ -704,9 +703,8 @@ def build_eval_bloom(
         required_eval_names: Exact benchmark names that the required manifest
             must contain.
         best_effort_eval_manifest_path: Optional manifest with the exact
-            best-effort artifacts to include.
-        best_effort_eval_root: Root for artifact paths in the best-effort
-            manifest.
+            best-effort artifacts to include. Artifacts must be below the
+            manifest directory.
         best_effort_eval_corpus_version: Version that the best-effort manifest
             must report.
 
@@ -729,20 +727,17 @@ def build_eval_bloom(
         )
     best_effort_parameters = (
         best_effort_eval_manifest_path,
-        best_effort_eval_root,
         best_effort_eval_corpus_version,
     )
     if any(value is not None for value in best_effort_parameters) and not all(
         value is not None for value in best_effort_parameters
     ):
-        raise ValueError("best-effort eval manifest path, root, and corpus version must be set together")
+        raise ValueError("best-effort eval manifest path and corpus version must be set together")
     if best_effort_eval_manifest_path is not None:
-        assert best_effort_eval_root is not None
         assert best_effort_eval_corpus_version is not None
         eval_paths.extend(
             _validate_best_effort_eval_manifest(
                 best_effort_eval_manifest_path,
-                best_effort_eval_root,
                 best_effort_eval_corpus_version,
             )
         )
@@ -840,7 +835,6 @@ def _validate_required_eval_manifest(
 
 def _validate_best_effort_eval_manifest(
     manifest_path: str,
-    artifact_root: str,
     expected_corpus_version: str,
 ) -> list[str]:
     """Validate a best-effort manifest and return its exact artifact paths."""
@@ -871,6 +865,7 @@ def _validate_best_effort_eval_manifest(
     if not isinstance(artifacts, list) or not all(isinstance(entry, Mapping) for entry in artifacts):
         raise ValueError("best-effort eval manifest artifacts must be a list of objects")
 
+    manifest_parent = os.path.dirname(manifest_path)
     paths: list[str] = []
     artifact_tasks: list[str] = []
     for entry in artifacts:
@@ -881,7 +876,7 @@ def _validate_best_effort_eval_manifest(
             raise ValueError("best-effort eval artifacts need task, artifact, and records")
         if artifact.startswith("/") or ".." in artifact.split("/"):
             raise ValueError(f"{task}: best-effort artifact must be relative to its root: {artifact}")
-        artifact_path = prefix_join(artifact_root, artifact)
+        artifact_path = prefix_join(manifest_parent, artifact)
         artifact_storage = StoragePath(artifact_path)
         if not artifact_storage.exists():
             raise ValueError(f"{task}: best-effort eval artifact does not exist: {artifact_path}")
@@ -995,7 +990,6 @@ def build_eval_bloom_step(
     required_eval_corpus_version: str | None = None,
     required_eval_names: tuple[str, ...] = (),
     best_effort_eval_manifest_path: str | None = None,
-    best_effort_eval_root: str | None = None,
     best_effort_eval_corpus_version: str | None = None,
     output_path_prefix: str | None = None,
     override_output_path: str | None = None,
@@ -1018,10 +1012,9 @@ def build_eval_bloom_step(
             required_eval_names: Required-suite gate passed to
             :func:`build_eval_bloom`. The path is an external input. The
             expected version and names enter the step hash.
-        best_effort_eval_manifest_path, best_effort_eval_root,
-            best_effort_eval_corpus_version: Optional best-effort suite. Only
-            the exact artifacts in its immutable, versioned manifest enter the
-            Bloom.
+        best_effort_eval_manifest_path, best_effort_eval_corpus_version:
+            Optional best-effort suite. Only the exact artifacts below its
+            immutable, versioned manifest directory enter the Bloom.
         output_path_prefix, override_output_path: StepSpec routing.
     """
     raw_paths: list[str] = []
@@ -1055,7 +1048,6 @@ def build_eval_bloom_step(
         "exclude_eval_dirs": tuple(sorted(exclude_eval_dirs)),
         "required_eval_corpus_version": required_eval_corpus_version,
         "required_eval_names": tuple(sorted(required_eval_names)),
-        "best_effort_eval_root": best_effort_eval_root,
         "best_effort_eval_corpus_version": best_effort_eval_corpus_version,
     }
 
@@ -1073,7 +1065,6 @@ def build_eval_bloom_step(
             required_eval_corpus_version=required_eval_corpus_version,
             required_eval_names=required_eval_names,
             best_effort_eval_manifest_path=best_effort_eval_manifest_path,
-            best_effort_eval_root=best_effort_eval_root,
             best_effort_eval_corpus_version=best_effort_eval_corpus_version,
         ),
         deps=step_deps,

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -35,11 +35,12 @@ The bloom can also be built once and shared across many corpus marks via
 """
 
 import hashlib
+import json
 import logging
 import os
 import random
 from collections import Counter
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass
 from itertools import islice
 from typing import Any
@@ -67,8 +68,12 @@ logger = logging.getLogger(__name__)
 # the corpus mark fold this into their step hash_attrs, so a policy change
 # re-addresses cached blooms/marks instead of silently reusing incompatible
 # features. v2 added the no-alphabetic-character ngram filter (marin#6852 cluster D).
-FEATURE_FILTER_VERSION = 2
+# v3 added an exact feature for short alphabetic paragraphs with at least three
+# tokens. This keeps required eval records matchable without restoring the
+# one-token punctuation and label collisions removed in v2.
+FEATURE_FILTER_VERSION = 3
 DECON_ATTRIBUTES_VERSION = 4
+MIN_SHORT_EXACT_TOKENS = 3
 
 
 @dataclass(frozen=True)
@@ -197,25 +202,49 @@ def _extract_ngrams(text: str, n: int, stride: int) -> Iterator[str]:
             yield ngram
 
 
+def _short_exact_feature(text: str, n: int) -> str | None:
+    """Return one normalized feature for guarded short exact matching."""
+    tokens = text.split()
+    if MIN_SHORT_EXACT_TOKENS <= len(tokens) < n and _has_alpha(text):
+        return " ".join(tokens)
+    return None
+
+
+def _extract_paragraph_features(text: str, n: int, stride: int) -> Iterator[str]:
+    """Yield n-grams, or one guarded exact feature for a short paragraph."""
+    short_exact = _short_exact_feature(text, n)
+    if short_exact is not None:
+        yield short_exact
+        return
+    yield from _extract_ngrams(text, n, stride)
+
+
 def _extract_features(text: str, ngram: NGramConfig | None) -> Iterator[str]:
     """Yield matchable features: ngrams within each paragraph, or whole paragraphs.
 
-    In n-gram mode, paragraphs with fewer than ``ngram_length`` tokens
-    contribute nothing — no fallback. A whole-paragraph fallback would be
-    symmetric with the consumer side but creates trivial collisions on very
-    short paragraphs (e.g. ``"..."``, ``"A."``, ``"##"`` that show up
-    routinely in eval and pretraining text alike). See PR #5656 for the
-    smoke-test finding (~18% phantom contamination on MMLU vs nemotron-math
-    came from the literal ``"..."`` short-paragraph artifact).
+    In n-gram mode, an alphabetic paragraph with 3 to ``ngram_length - 1``
+    tokens contributes one normalized exact feature. Shorter and
+    non-alphabetic paragraphs contribute nothing. This avoids the trivial
+    ``"..."`` and ``"A."`` collisions found in PR #5656 while keeping short
+    required eval records matchable. If every paragraph is shorter than three
+    tokens, a full record with at least three tokens contributes one exact
+    feature.
     """
     delimiter = ngram.paragraph_delimiter if ngram is not None else "\n"
+    yielded = False
     for para in text.split(delimiter):
         if not para:
             continue
         if ngram is None:
             yield para
             continue
-        yield from _extract_ngrams(para, ngram.ngram_length, ngram.stride)
+        for feature in _extract_paragraph_features(para, ngram.ngram_length, ngram.stride):
+            yielded = True
+            yield feature
+    if ngram is not None and not yielded:
+        short_exact = _short_exact_feature(text, ngram.ngram_length)
+        if short_exact is not None:
+            yield short_exact
 
 
 def _paragraph_overlap_and_matches(
@@ -233,16 +262,16 @@ def _paragraph_overlap_and_matches(
     distinctive leak ngrams stay matchable; a leak made entirely of dropped
     ngrams is intentionally suppressed.
 
-    Paragraphs with fewer than ``ngram_length`` tokens in n-gram mode return
-    ``(0.0, [])`` — see :func:`_extract_features` for why we don't fall back
-    to whole-paragraph hashing.
+    Alphabetic paragraphs with at least three but fewer than ``ngram_length``
+    tokens use one exact feature. Shorter and non-alphabetic paragraphs return
+    ``(0.0, [])``.
     """
     if ngram is None:
         h = _bloom_hash(paragraph)
         if h in drop_hashes:
             return 0.0, []
         return (1.0, [h]) if h in bf else (0.0, [])
-    ngrams = list(_extract_ngrams(paragraph, ngram.ngram_length, ngram.stride))
+    ngrams = list(_extract_paragraph_features(paragraph, ngram.ngram_length, ngram.stride))
     if not ngrams:
         return 0.0, []
     hashes = [_bloom_hash(ng) for ng in ngrams]
@@ -283,6 +312,11 @@ def _discover_eval_files(eval_paths: list[str], exclude_dir_names: frozenset[str
     for source in eval_paths:
         fs, resolved = url_to_fs(source)
         protocol = source.split("://")[0] if "://" in source else ""
+        if fs.isfile(resolved):
+            filename = os.path.basename(resolved)
+            if not filename.startswith(".") and filename.endswith(SUPPORTED_EXTENSIONS):
+                yield source
+            continue
         for root, _dirs, files in fs.walk(resolved):
             if _is_hidden_dir(root, resolved):
                 continue
@@ -345,7 +379,8 @@ def _build_filter(
                     seen_in_record.add(h)
                     stats["n_index_rows"] += 1
                     yield {"hash": h, "eval_id": eval_id}
-                stats["n_records"] += 1
+                if seen_in_record:
+                    stats["n_records"] += 1
 
     # Stream the index parquet; this iteration also fills the bloom.
     idx_dir = os.path.dirname(index_path)
@@ -431,13 +466,27 @@ def _make_marker(
                     text = str(record.get(text_field, "") or "")
                     max_score = 0.0
                     matched: set[int] = set()
+                    has_paragraph_features = False
                     for para in text.split(delimiter):
                         if not para:
                             continue
+                        if (
+                            ngram is not None
+                            and next(_extract_paragraph_features(para, ngram.ngram_length, ngram.stride), None)
+                            is not None
+                        ):
+                            has_paragraph_features = True
                         score, hits = _paragraph_overlap_and_matches(para, bf, ngram, drop_hashes)
                         if score > max_score:
                             max_score = score
                         matched.update(hits)
+                    if ngram is not None and not has_paragraph_features:
+                        short_exact = _short_exact_feature(text, ngram.ngram_length)
+                        if short_exact is not None:
+                            short_hash = _bloom_hash(short_exact)
+                            if short_hash not in drop_hashes and short_hash in bf:
+                                max_score = 1.0
+                                matched.add(short_hash)
                     contaminated = max_score > 0 and max_score >= threshold
                     counters.pipeline.update_counter("decon/contaminated" if contaminated else "decon/clean", 1)
                     if contaminated and flagged_sample_size:
@@ -609,6 +658,12 @@ def build_eval_bloom(
     estimated_doc_count: int = 1_000_000,
     false_positive_rate: float = 1e-9,
     exclude_eval_dirs: frozenset[str] = frozenset(),
+    required_eval_manifest_path: str | None = None,
+    required_eval_corpus_version: str | None = None,
+    required_eval_names: tuple[str, ...] = (),
+    best_effort_eval_manifest_path: str | None = None,
+    best_effort_eval_root: str | None = None,
+    best_effort_eval_corpus_version: str | None = None,
 ) -> EvalBloom:
     """Build a reusable bloom + hash-index sidecar from one or more eval sources.
 
@@ -636,6 +691,19 @@ def build_eval_bloom(
         exclude_eval_dirs: Eval task directory names to skip while walking
             ``eval_data_sources`` (see :func:`_discover_eval_files`). Excludes
             those tasks from the bloom without regenerating the eval corpus.
+        required_eval_manifest_path: Optional manifest that must report a
+            complete required eval suite before Bloom creation starts. When
+            set, only the exact artifacts in this manifest enter the Bloom.
+        required_eval_corpus_version: Version that the required manifest must
+            report. Set this with ``required_eval_manifest_path``.
+        required_eval_names: Exact benchmark names that the required manifest
+            must contain.
+        best_effort_eval_manifest_path: Optional manifest with the exact
+            best-effort artifacts to include.
+        best_effort_eval_root: Root for artifact paths in the best-effort
+            manifest.
+        best_effort_eval_corpus_version: Version that the best-effort manifest
+            must report.
 
     Returns:
         :class:`EvalBloom` artifact pointing at the produced files.
@@ -643,6 +711,36 @@ def build_eval_bloom(
     eval_paths = [eval_data_sources] if isinstance(eval_data_sources, str) else list(eval_data_sources)
     if not eval_paths:
         raise ValueError("eval_data_sources must be non-empty")
+    if (required_eval_manifest_path is None) != (required_eval_corpus_version is None):
+        raise ValueError("required eval manifest path and corpus version must be set together")
+    if required_eval_manifest_path is not None:
+        assert required_eval_corpus_version is not None
+        eval_paths = _validate_required_eval_manifest(
+            required_eval_manifest_path,
+            required_eval_corpus_version,
+            required_eval_names,
+            text_field=text_field,
+            ngram=ngram,
+        )
+    best_effort_parameters = (
+        best_effort_eval_manifest_path,
+        best_effort_eval_root,
+        best_effort_eval_corpus_version,
+    )
+    if any(value is not None for value in best_effort_parameters) and not all(
+        value is not None for value in best_effort_parameters
+    ):
+        raise ValueError("best-effort eval manifest path, root, and corpus version must be set together")
+    if best_effort_eval_manifest_path is not None:
+        assert best_effort_eval_root is not None
+        assert best_effort_eval_corpus_version is not None
+        eval_paths.extend(
+            _validate_best_effort_eval_manifest(
+                best_effort_eval_manifest_path,
+                best_effort_eval_root,
+                best_effort_eval_corpus_version,
+            )
+        )
 
     bloom_path, index_path = bloom_paths(output_path)
     n_records = _build_filter(
@@ -663,6 +761,138 @@ def build_eval_bloom(
         false_positive_rate=false_positive_rate,
         n_eval_records=n_records,
     )
+
+
+def _validate_required_eval_manifest(
+    manifest_path: str,
+    expected_corpus_version: str,
+    expected_names: tuple[str, ...],
+    *,
+    text_field: str,
+    ngram: NGramConfig | None,
+) -> list[str]:
+    """Validate required artifacts and confirm that each record has a feature."""
+    manifest_storage = StoragePath(manifest_path)
+    if not manifest_storage.exists():
+        raise ValueError(f"required eval manifest does not exist: {manifest_path}")
+    with manifest_storage.open("r") as source:
+        manifest = json.load(source)
+    if not isinstance(manifest, Mapping):
+        raise ValueError(f"required eval manifest must be an object: {manifest_path}")
+    if manifest.get("corpus_version") != expected_corpus_version:
+        raise ValueError(
+            f"required eval manifest version is {manifest.get('corpus_version')!r}, "
+            f"expected {expected_corpus_version!r}"
+        )
+    if manifest.get("required") is not True:
+        raise ValueError("required eval manifest does not mark the suite as required")
+    if manifest.get("status") != "complete":
+        raise ValueError(f"required eval manifest status is {manifest.get('status')!r}, expected 'complete'")
+
+    benchmarks = manifest.get("benchmarks")
+    if not isinstance(benchmarks, list) or not all(isinstance(entry, Mapping) for entry in benchmarks):
+        raise ValueError("required eval manifest benchmarks must be a list of objects")
+    if not all(isinstance(entry.get("name"), str) for entry in benchmarks):
+        raise ValueError("required eval manifest benchmark entries need string names")
+    actual_names = tuple(entry["name"] for entry in benchmarks)
+    if set(actual_names) != set(expected_names) or len(actual_names) != len(expected_names):
+        raise ValueError(
+            f"required eval manifest benchmarks are {sorted(str(name) for name in actual_names)}, "
+            f"expected {sorted(expected_names)}"
+        )
+
+    manifest_parent = os.path.dirname(manifest_path)
+    paths: list[str] = []
+    for entry in benchmarks:
+        name = entry.get("name")
+        artifact = entry.get("artifact")
+        expected_records = entry.get("expected_records")
+        if not isinstance(name, str) or not isinstance(artifact, str) or not isinstance(expected_records, int):
+            raise ValueError("required eval manifest benchmark entries need name, artifact, and expected_records")
+        artifact_path = prefix_join(manifest_parent, artifact)
+        artifact_storage = StoragePath(artifact_path)
+        if not artifact_storage.exists():
+            raise ValueError(f"{name}: required eval artifact does not exist: {artifact_path}")
+        with artifact_storage.open("rb") as source:
+            parquet = pq.ParquetFile(source)
+            actual_records = parquet.metadata.num_rows
+            if text_field not in parquet.schema_arrow.names:
+                raise ValueError(f"{name}: required eval artifact does not contain text field {text_field!r}")
+            texts = parquet.read(columns=[text_field]).column(text_field).to_pylist()
+        if actual_records != expected_records:
+            raise ValueError(f"{name}: manifest expects {expected_records} records, artifact contains {actual_records}")
+        records_with_features = sum(
+            bool(text) and next(_extract_features(str(text), ngram), None) is not None for text in texts
+        )
+        if records_with_features != expected_records:
+            raise ValueError(
+                f"{name}: {expected_records - records_with_features} of {expected_records} required eval records "
+                "produce no matchable features"
+            )
+        paths.append(artifact_path)
+    return paths
+
+
+def _validate_best_effort_eval_manifest(
+    manifest_path: str,
+    artifact_root: str,
+    expected_corpus_version: str,
+) -> list[str]:
+    """Validate a best-effort manifest and return its exact artifact paths."""
+    manifest_storage = StoragePath(manifest_path)
+    if not manifest_storage.exists():
+        raise ValueError(f"best-effort eval manifest does not exist: {manifest_path}")
+    with manifest_storage.open("r") as source:
+        manifest = json.load(source)
+    if not isinstance(manifest, Mapping):
+        raise ValueError(f"best-effort eval manifest must be an object: {manifest_path}")
+    if manifest.get("corpus_version") != expected_corpus_version:
+        raise ValueError(
+            f"best-effort eval manifest version is {manifest.get('corpus_version')!r}, "
+            f"expected {expected_corpus_version!r}"
+        )
+    if manifest.get("required") is not False:
+        raise ValueError("best-effort eval manifest must mark the suite as not required")
+    if manifest.get("status") not in {"complete", "complete_with_failures"}:
+        raise ValueError(
+            f"best-effort eval manifest status is {manifest.get('status')!r}, "
+            "expected 'complete' or 'complete_with_failures'"
+        )
+
+    included_tasks = manifest.get("included_leaf_tasks")
+    artifacts = manifest.get("artifacts")
+    if not isinstance(included_tasks, list) or not all(isinstance(task, str) for task in included_tasks):
+        raise ValueError("best-effort eval manifest included_leaf_tasks must be a list of strings")
+    if not isinstance(artifacts, list) or not all(isinstance(entry, Mapping) for entry in artifacts):
+        raise ValueError("best-effort eval manifest artifacts must be a list of objects")
+
+    paths: list[str] = []
+    artifact_tasks: list[str] = []
+    for entry in artifacts:
+        task = entry.get("task")
+        artifact = entry.get("artifact")
+        expected_records = entry.get("records")
+        if not isinstance(task, str) or not isinstance(artifact, str) or not isinstance(expected_records, int):
+            raise ValueError("best-effort eval artifacts need task, artifact, and records")
+        if artifact.startswith("/") or ".." in artifact.split("/"):
+            raise ValueError(f"{task}: best-effort artifact must be relative to its root: {artifact}")
+        artifact_path = prefix_join(artifact_root, artifact)
+        artifact_storage = StoragePath(artifact_path)
+        if not artifact_storage.exists():
+            raise ValueError(f"{task}: best-effort eval artifact does not exist: {artifact_path}")
+        with artifact_storage.open("rb") as source:
+            actual_records = pq.ParquetFile(source).metadata.num_rows
+        if actual_records != expected_records:
+            raise ValueError(
+                f"{task}: best-effort manifest expects {expected_records} records, "
+                f"artifact contains {actual_records}"
+            )
+        artifact_tasks.append(task)
+        paths.append(artifact_path)
+
+    if sorted(artifact_tasks) != sorted(included_tasks) or len(artifact_tasks) != len(included_tasks):
+        raise ValueError("best-effort eval artifact tasks do not match included_leaf_tasks")
+    return paths
 
 
 def merge_eval_blooms(
@@ -756,6 +986,12 @@ def build_eval_bloom_step(
     estimated_doc_count: int = 1_000_000,
     false_positive_rate: float = 1e-9,
     exclude_eval_dirs: frozenset[str] = frozenset(),
+    required_eval_manifest_path: str | None = None,
+    required_eval_corpus_version: str | None = None,
+    required_eval_names: tuple[str, ...] = (),
+    best_effort_eval_manifest_path: str | None = None,
+    best_effort_eval_root: str | None = None,
+    best_effort_eval_corpus_version: str | None = None,
     output_path_prefix: str | None = None,
     override_output_path: str | None = None,
 ) -> StepSpec:
@@ -773,6 +1009,13 @@ def build_eval_bloom_step(
         exclude_eval_dirs: Eval task directory names to drop from the bloom
             (see :func:`build_eval_bloom`). Folded into ``hash_attrs`` so
             changing the exclusion set rebuilds the bloom at a fresh path.
+        required_eval_manifest_path, required_eval_corpus_version,
+            required_eval_names: Required-suite gate passed to
+            :func:`build_eval_bloom`. The path is an external input. The
+            expected version and names enter the step hash.
+        best_effort_eval_manifest_path, best_effort_eval_root,
+            best_effort_eval_corpus_version: Optional best-effort suite. Only
+            the exact artifacts in its manifest enter the Bloom.
         output_path_prefix, override_output_path: StepSpec routing.
     """
     raw_paths: list[str] = []
@@ -804,6 +1047,10 @@ def build_eval_bloom_step(
         # invalidates the cache.
         "eval_data_sources": tuple(sorted(s for s in raw_paths if s not in (d.output_path for d in step_deps))),
         "exclude_eval_dirs": tuple(sorted(exclude_eval_dirs)),
+        "required_eval_corpus_version": required_eval_corpus_version,
+        "required_eval_names": tuple(sorted(required_eval_names)),
+        "best_effort_eval_root": best_effort_eval_root,
+        "best_effort_eval_corpus_version": best_effort_eval_corpus_version,
     }
 
     return StepSpec(
@@ -816,6 +1063,12 @@ def build_eval_bloom_step(
             estimated_doc_count=estimated_doc_count,
             false_positive_rate=false_positive_rate,
             exclude_eval_dirs=exclude_eval_dirs,
+            required_eval_manifest_path=required_eval_manifest_path,
+            required_eval_corpus_version=required_eval_corpus_version,
+            required_eval_names=required_eval_names,
+            best_effort_eval_manifest_path=best_effort_eval_manifest_path,
+            best_effort_eval_root=best_effort_eval_root,
+            best_effort_eval_corpus_version=best_effort_eval_corpus_version,
         ),
         deps=step_deps,
         hash_attrs=hash_attrs,

--- a/tests/datakit/decontam/test_prepare_eval_corpus.py
+++ b/tests/datakit/decontam/test_prepare_eval_corpus.py
@@ -9,6 +9,7 @@ not falsely flagged. Non-passage docs are unchanged.
 """
 
 import io
+import json
 import zipfile
 from dataclasses import replace
 
@@ -228,3 +229,30 @@ def test_aa_record_count_mismatch_stops_preparation():
 
     with pytest.raises(ValueError, match="Example Eval: expected 2 records, extracted 1"):
         _aa_records([{"question": "Only question", "answer": "Only answer"}], cfg)
+
+
+def test_lmh_manifest_is_immutable_within_a_corpus_version(tmp_path, monkeypatch):
+    manifest = {
+        "schema_version": 1,
+        "corpus_version": prepare_eval_corpus.EVAL_CORPUS_VERSION,
+        "required": False,
+        "status": "complete_with_failures",
+        "included_leaf_tasks": ["existing-task"],
+        "artifacts": [{"task": "existing-task", "artifact": "existing-task/eval.parquet", "records": 1}],
+        "failed": [],
+    }
+    manifest_path = tmp_path / prepare_eval_corpus.LMH_MANIFEST_RELATIVE
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(json.dumps(manifest))
+    original_bytes = manifest_path.read_bytes()
+    monkeypatch.setattr(prepare_eval_corpus, "_output_root", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        prepare_eval_corpus,
+        "_lmh_task_names",
+        lambda: pytest.fail("a sealed corpus version must not enumerate tasks again"),
+    )
+
+    result = prepare_eval_corpus._prepare_lmh()
+
+    assert result == manifest
+    assert manifest_path.read_bytes() == original_bytes

--- a/tests/datakit/decontam/test_prepare_eval_corpus.py
+++ b/tests/datakit/decontam/test_prepare_eval_corpus.py
@@ -8,9 +8,22 @@ but not the public passage, so a corpus doc that merely quotes the passage is
 not falsely flagged. Non-passage docs are unchanged.
 """
 
+import io
+import zipfile
+from dataclasses import replace
+
 import pytest
 
-from experiments.datakit.decontam.prepare_eval_corpus import _PASSAGE_FIELDS, _lmh_doc_text
+from experiments.datakit.decontam import prepare_eval_corpus
+from experiments.datakit.decontam.prepare_eval_corpus import (
+    _PASSAGE_FIELDS,
+    AA_EVALS,
+    AAEvalConfig,
+    AARecordType,
+    _aa_records,
+    _iter_aa_rows,
+    _lmh_doc_text,
+)
 
 # A rendered prompt embeds the passage (as lm-eval-harness doc_to_text does).
 _PASSAGE = "The rain had continued for a week and a flood created a big river by the farm."
@@ -72,3 +85,146 @@ def test_lmh_doc_to_text_exception_is_tolerated():
     text = _lmh_doc_text(doc, boom, _target)
     assert "Q here" in text  # from raw fields
     assert "42" in text  # answer
+
+
+def _aa_config(**changes) -> AAEvalConfig:
+    values = {
+        "name": "Example Eval",
+        "subdir": "example",
+        "source_revision": "0123456789abcdef",
+        "expected_records": 1,
+        "official_records": 1,
+        "hf_id": "owner/example",
+        "subset": None,
+        "split": "test",
+        "text_fields": ("question", "answer"),
+    }
+    values.update(changes)
+    return AAEvalConfig(**values)
+
+
+def test_aa_hf_loader_uses_pinned_revision(monkeypatch):
+    calls = []
+
+    def load_dataset(dataset_id, *, name, split, revision):
+        calls.append((dataset_id, name, split, revision))
+        return [{"question": "Question", "answer": "Answer"}]
+
+    monkeypatch.setattr(prepare_eval_corpus, "load_dataset", load_dataset)
+
+    assert list(_iter_aa_rows(_aa_config())) == [{"question": "Question", "answer": "Answer"}]
+    assert calls == [("owner/example", None, "test", "0123456789abcdef")]
+
+
+def test_hle_includes_multimodal_rows():
+    hle = next(cfg for cfg in AA_EVALS if cfg.name == "Humanity's Last Exam")
+    cfg = replace(hle, expected_records=1, official_records=1)
+    [record] = _aa_records(
+        [{"id": "image-task", "question": "Question with a figure", "answer": "Answer", "image": {"bytes": b"x"}}],
+        cfg,
+    )
+    assert record["id"] == "hle-image-task"
+    assert record["text"] == "Question with a figure\n\nAnswer"
+
+
+def test_scicode_expands_each_subproblem_with_its_prompt_context():
+    cfg = _aa_config(
+        name="SciCode",
+        subdir="scicode",
+        expected_records=2,
+        official_records=2,
+        record_type=AARecordType.SCICODE_SUBPROBLEM,
+        text_fields=(),
+    )
+    rows = [
+        {
+            "problem_id": "7",
+            "problem_description_main": "Main problem",
+            "problem_background_main": "Main background",
+            "required_dependencies": "import numpy as np",
+            "sub_steps": [
+                {
+                    "step_number": "7.1",
+                    "step_description_prompt": "First prompt",
+                    "step_background": "First background",
+                    "function_header": "def first():",
+                    "test_cases": ["assert first() == 1"],
+                },
+                {
+                    "step_number": "7.2",
+                    "step_description_prompt": "Second prompt",
+                    "step_background": "Second background",
+                    "function_header": "def second():",
+                    "test_cases": ["assert second() == 2"],
+                },
+            ],
+        }
+    ]
+
+    records = _aa_records(rows, cfg)
+
+    assert [record["id"] for record in records] == ["scicode-7.1", "scicode-7.2"]
+    assert "Main problem" in records[0]["text"]
+    assert "First background" in records[0]["text"]
+    assert "def first():" in records[0]["text"]
+    assert "assert first() == 1" in records[0]["text"]
+    assert "Second prompt" not in records[0]["text"]
+
+
+def test_tau3_records_include_user_scenario_and_hidden_criteria():
+    cfg = _aa_config(
+        name="tau3-Banking",
+        subdir="tau3_banking",
+        expected_records=1,
+        official_records=1,
+        record_type=AARecordType.TAU3_TASK,
+        text_fields=(),
+    )
+    rows = [
+        {
+            "id": "task_001",
+            "user_scenario": {"instructions": "Ask for the highest cash-back card."},
+            "evaluation_criteria": {"actions": [{"name": "apply_for_credit_card"}]},
+        }
+    ]
+
+    [record] = _aa_records(rows, cfg)
+
+    assert record["id"] == "tau3_banking-task_001"
+    assert "highest cash-back card" in record["text"]
+    assert "apply_for_credit_card" in record["text"]
+
+
+def test_terminal_bench_archive_pairs_each_instruction_with_its_solution(monkeypatch):
+    archive = io.BytesIO()
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("terminal-bench/tasks/task-b/instruction.md", "Instruction B")
+        zf.writestr("terminal-bench/tasks/task-b/solution/solve.sh", "Solution B")
+        zf.writestr("terminal-bench/tasks/task-a/instruction.md", "Instruction A")
+        zf.writestr("terminal-bench/tasks/task-a/solution/solve.sh", "Solution A")
+    archive.seek(0)
+    monkeypatch.setattr(prepare_eval_corpus.urllib.request, "urlopen", lambda _url: archive)
+    cfg = _aa_config(
+        name="Terminal-Bench v2.1",
+        subdir="terminal_bench_2_1",
+        source_url="https://example.test/archive.zip",
+        expected_records=2,
+        official_records=2,
+        record_type=AARecordType.TERMINAL_BENCH_TASK,
+        hf_id=None,
+        text_fields=("instruction", "solution"),
+    )
+
+    records = _aa_records(list(_iter_aa_rows(cfg)), cfg)
+
+    assert records == [
+        {"id": "terminal_bench_2_1-task-a", "text": "Instruction A\n\nSolution A"},
+        {"id": "terminal_bench_2_1-task-b", "text": "Instruction B\n\nSolution B"},
+    ]
+
+
+def test_aa_record_count_mismatch_stops_preparation():
+    cfg = _aa_config(expected_records=2, official_records=2)
+
+    with pytest.raises(ValueError, match="Example Eval: expected 2 records, extracted 1"):
+        _aa_records([{"question": "Only question", "answer": "Only answer"}], cfg)

--- a/tests/datakit/decontam/test_prepare_eval_corpus.py
+++ b/tests/datakit/decontam/test_prepare_eval_corpus.py
@@ -8,8 +8,11 @@ but not the public passage, so a corpus doc that merely quotes the passage is
 not falsely flagged. Non-passage docs are unchanged.
 """
 
+import builtins
 import io
 import json
+import sys
+import types
 import zipfile
 from dataclasses import replace
 
@@ -231,12 +234,45 @@ def test_aa_record_count_mismatch_stops_preparation():
         _aa_records([{"question": "Only question", "answer": "Only answer"}], cfg)
 
 
+def test_aa_manifest_is_immutable_within_a_corpus_version(tmp_path, monkeypatch):
+    manifest = prepare_eval_corpus._aa_manifest("complete")
+    manifest_path = tmp_path / prepare_eval_corpus.AA_MANIFEST_RELATIVE
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(json.dumps(manifest))
+    original_bytes = manifest_path.read_bytes()
+    monkeypatch.setattr(prepare_eval_corpus, "_output_root", lambda: str(tmp_path))
+    monkeypatch.setattr(
+        prepare_eval_corpus,
+        "_iter_aa_rows",
+        lambda _cfg: pytest.fail("a sealed corpus version must not load AA source rows"),
+    )
+
+    result = prepare_eval_corpus._prepare_aa()
+
+    assert result == manifest
+    assert manifest_path.read_bytes() == original_bytes
+
+
+def test_aa_manifest_rejects_config_change_within_a_corpus_version(tmp_path, monkeypatch):
+    manifest = prepare_eval_corpus._aa_manifest("complete")
+    manifest["benchmarks"][0]["source_revision"] = "changed-revision"
+    manifest_path = tmp_path / prepare_eval_corpus.AA_MANIFEST_RELATIVE
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(json.dumps(manifest))
+    monkeypatch.setattr(prepare_eval_corpus, "_output_root", lambda: str(tmp_path))
+
+    with pytest.raises(ValueError, match="EVAL_CORPUS_VERSION"):
+        prepare_eval_corpus._prepare_aa()
+
+
 def test_lmh_manifest_is_immutable_within_a_corpus_version(tmp_path, monkeypatch):
     manifest = {
         "schema_version": 1,
         "corpus_version": prepare_eval_corpus.EVAL_CORPUS_VERSION,
         "required": False,
         "status": "complete_with_failures",
+        "artifact_root": prepare_eval_corpus.LMH_EVALS_RELATIVE,
+        "extraction_version": prepare_eval_corpus._LMH_EXTRACTION_VERSION,
         "included_leaf_tasks": ["existing-task"],
         "artifacts": [{"task": "existing-task", "artifact": "existing-task/eval.parquet", "records": 1}],
         "failed": [],
@@ -256,3 +292,47 @@ def test_lmh_manifest_is_immutable_within_a_corpus_version(tmp_path, monkeypatch
 
     assert result == manifest
     assert manifest_path.read_bytes() == original_bytes
+
+
+def test_lmh_artifacts_are_stored_below_the_versioned_corpus_root(tmp_path, monkeypatch):
+    task = types.SimpleNamespace(
+        test_docs=lambda: [{"question": "What is two plus two?", "answer": "4"}],
+        validation_docs=lambda: [],
+        training_docs=lambda: [],
+        doc_to_text=lambda doc: doc["question"],
+        doc_to_target=lambda doc: doc["answer"],
+    )
+    lm_eval = types.ModuleType("lm_eval")
+    lm_eval_tasks = types.ModuleType("lm_eval.tasks")
+    lm_eval_tasks.get_task_dict = lambda _names: {"example-task": task}
+    lm_eval.tasks = lm_eval_tasks
+    monkeypatch.setitem(sys.modules, "lm_eval", lm_eval)
+    monkeypatch.setitem(sys.modules, "lm_eval.tasks", lm_eval_tasks)
+    monkeypatch.setattr(prepare_eval_corpus, "marin_prefix", lambda: str(tmp_path))
+    monkeypatch.setattr(prepare_eval_corpus, "trust_remote_code_for_hf", lambda: None)
+    monkeypatch.setattr(prepare_eval_corpus, "_lmh_task_names", lambda: ["example-task"])
+
+    manifest = prepare_eval_corpus._prepare_lmh()
+
+    artifact_path = tmp_path / prepare_eval_corpus.EVALS_RELATIVE / "lmh/example-task/eval.parquet"
+    assert artifact_path.exists()
+    assert manifest["artifacts"] == [{"task": "example-task", "artifact": "example-task/eval.parquet", "records": 1}]
+
+
+def test_lmh_import_failure_does_not_seal_manifest(tmp_path, monkeypatch):
+    original_import = builtins.__import__
+
+    def reject_lm_eval(name, *args, **kwargs):
+        if name == "lm_eval.tasks":
+            raise ImportError("lm_eval is unavailable")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(prepare_eval_corpus, "_output_root", lambda: str(tmp_path))
+    monkeypatch.setattr(prepare_eval_corpus, "trust_remote_code_for_hf", lambda: None)
+    monkeypatch.setattr(prepare_eval_corpus, "_lmh_task_names", lambda: ["example-task"])
+    monkeypatch.setattr(builtins, "__import__", reject_lm_eval)
+
+    with pytest.raises(ImportError, match="lm_eval is unavailable"):
+        prepare_eval_corpus._prepare_lmh()
+
+    assert not (tmp_path / prepare_eval_corpus.LMH_MANIFEST_RELATIVE).exists()

--- a/tests/datakit/test_decon.py
+++ b/tests/datakit/test_decon.py
@@ -977,13 +977,12 @@ def test_build_eval_bloom_uses_only_manifested_best_effort_artifacts(tmp_path: P
         )
     )
 
-    best_effort_root = tmp_path / "best_effort"
+    best_effort_root = required_root / "lmh"
     included_artifact = best_effort_root / "included" / "eval.parquet"
     stale_artifact = best_effort_root / "stale" / "eval.parquet"
     _write_input_parquet(included_artifact, [{"id": "included-1", "text": "delta epsilon zeta"}])
     _write_input_parquet(stale_artifact, [{"id": "stale-1", "text": "eta theta iota"}])
     best_effort_manifest = required_root / "lmh" / "_manifest.json"
-    best_effort_manifest.parent.mkdir(parents=True)
     best_effort_manifest.write_text(
         json.dumps(
             {
@@ -1005,7 +1004,6 @@ def test_build_eval_bloom_uses_only_manifested_best_effort_artifacts(tmp_path: P
         required_eval_corpus_version="test-corpus-v1",
         required_eval_names=("Required Eval",),
         best_effort_eval_manifest_path=str(best_effort_manifest),
-        best_effort_eval_root=str(best_effort_root),
         best_effort_eval_corpus_version="test-corpus-v1",
     )
 

--- a/tests/datakit/test_decon.py
+++ b/tests/datakit/test_decon.py
@@ -1064,6 +1064,20 @@ def test_build_eval_bloom_excludes_named_task_dirs(tmp_path: Path):
     assert rows["hits-excluded"]["contaminated"] is False
 
 
+def test_build_eval_bloom_excludes_direct_file_under_named_task_dir(tmp_path: Path):
+    eval_path = tmp_path / "evals" / "code2text_python" / "eval.parquet"
+    _write_input_parquet(eval_path, [{"id": "excluded-1", "text": "alpha beta gamma"}])
+
+    result = build_eval_bloom(
+        eval_data_sources=str(eval_path),
+        output_path=str(tmp_path / "bloom"),
+        exclude_eval_dirs=frozenset({"code2text_python"}),
+    )
+
+    assert result.n_eval_records == 0
+    assert pq.read_table(result.eval_hash_index_path).num_rows == 0
+
+
 def test_merge_eval_blooms_equals_single_build(tmp_path: Path):
     """merge_eval_blooms over N per-eval builds detects everything a single combined build does.
 

--- a/tests/datakit/test_decon.py
+++ b/tests/datakit/test_decon.py
@@ -425,18 +425,14 @@ def test_decon_synthesizes_partition_id_from_shard_index(tmp_path: Path):
     assert rows["doc1"]["partition_id"] == 1
 
 
-def test_decon_short_paragraphs_below_ngram_length_contribute_nothing(tmp_path: Path):
-    """Paragraphs with < ngram_length tokens are silently skipped in n-gram mode.
+def test_decon_paragraphs_below_short_exact_minimum_contribute_nothing(tmp_path: Path):
+    """Paragraphs with fewer than three tokens are skipped in n-gram mode.
 
     Earlier versions (PR #5656 mid-stack) fell back to whole-paragraph hashing
     for paragraphs too short to form an n-gram. That created trivial collisions
     on common short paragraphs like ``"..."``, ``"A."``, etc., generating
-    ~18% phantom-contamination flags in the MMLU vs nemotron-math smoke run.
-    The fallback was removed; this test pins the new behavior.
-
-    Trade-off: an eval with paragraphs shorter than ``ngram_length`` won't be
-    matchable in n-gram mode. Callers who need that should either lower
-    ``ngram_length`` or use ``ngram=None`` (exact paragraph mode).
+    ~18% phantom-contamination flags in the MMLU vs nemotron-math smoke run. The
+    guarded fallback excludes these short values.
     """
     eval_dir = tmp_path / "eval"
     input_dir = tmp_path / "input"
@@ -462,6 +458,40 @@ def test_decon_short_paragraphs_below_ngram_length_contribute_nothing(tmp_path: 
     assert rows["doc_short_text"]["contaminated"] is False
     assert rows["doc_short_text"]["max_overlap"] == 0.0
     assert rows["doc_short_text"]["matched_hashes"] == []
+
+
+def test_decon_short_alphabetic_paragraph_uses_exact_feature(tmp_path: Path):
+    eval_dir = tmp_path / "eval"
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+
+    _write_eval_jsonl(eval_dir / "eval.jsonl.gz", [{"id": "short_eval", "text": "Distinctive alpha phrase"}])
+    _write_input_parquet(
+        input_dir / "part-00000-of-00001.parquet",
+        [{"id": "doc_short_text", "text": "Distinctive alpha phrase", "partition_id": 0}],
+    )
+
+    result = build_eval_bloom(
+        eval_data_sources=str(eval_dir),
+        output_path=str(output_dir / "bloom"),
+        ngram=NGramConfig(ngram_length=8, overlap_threshold=0.5),
+    )
+
+    assert result.n_eval_records == 1
+    assert {row["eval_id"] for row in pq.read_table(result.eval_hash_index_path).to_pylist()} == {"short_eval"}
+
+
+def test_decon_short_record_fallback_spans_tiny_paragraphs(tmp_path: Path):
+    text = "Alpha beta\n\ngamma"
+    rows = _run_decon_one_shot(
+        tmp_path,
+        eval_records=[{"id": "short_eval", "text": text}],
+        input_records=[{"id": "doc", "text": text, "partition_id": 0}],
+        ngram=NGramConfig(ngram_length=8, overlap_threshold=0.5),
+    )
+
+    assert rows["doc"]["contaminated"] is True
+    assert rows["doc"]["max_overlap"] == 1.0
 
 
 def test_double_newline_delimiter_spans_single_line_breaks(tmp_path: Path):
@@ -817,6 +847,171 @@ def test_build_eval_bloom_then_decon_matches_inline(fox_corpus):
         assert pre["contaminated"] == inline["contaminated"]
         assert pre["max_overlap"] == inline["max_overlap"]
         assert sorted(pre["matched_hashes"]) == sorted(inline["matched_hashes"])
+
+
+def test_build_eval_bloom_requires_complete_eval_manifest(tmp_path: Path):
+    eval_root = tmp_path / "evals"
+    artifact_path = eval_root / "aa" / "required_eval" / "test.parquet"
+    _write_input_parquet(artifact_path, [{"id": "eval-1", "text": "alpha beta gamma"}])
+    manifest_path = eval_root / "aa" / "_manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "corpus_version": "test-corpus-v1",
+                "required": True,
+                "status": "building",
+                "benchmarks": [
+                    {
+                        "name": "Required Eval",
+                        "artifact": "required_eval/test.parquet",
+                        "expected_records": 1,
+                    }
+                ],
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="manifest status is 'building', expected 'complete'"):
+        build_eval_bloom(
+            eval_data_sources=str(eval_root),
+            output_path=str(tmp_path / "bloom"),
+            required_eval_manifest_path=str(manifest_path),
+            required_eval_corpus_version="test-corpus-v1",
+            required_eval_names=("Required Eval",),
+        )
+
+    assert not Path(bloom_paths(str(tmp_path / "bloom"))[0]).exists()
+
+
+def test_build_eval_bloom_checks_required_artifact_counts(tmp_path: Path):
+    eval_root = tmp_path / "evals"
+    artifact_path = eval_root / "aa" / "required_eval" / "test.parquet"
+    _write_input_parquet(artifact_path, [{"id": "eval-1", "text": "alpha beta gamma"}])
+    manifest_path = eval_root / "aa" / "_manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "corpus_version": "test-corpus-v1",
+                "required": True,
+                "status": "complete",
+                "benchmarks": [
+                    {
+                        "name": "Required Eval",
+                        "artifact": "required_eval/test.parquet",
+                        "expected_records": 2,
+                    }
+                ],
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="Required Eval: manifest expects 2 records, artifact contains 1"):
+        build_eval_bloom(
+            eval_data_sources=str(eval_root),
+            output_path=str(tmp_path / "bloom"),
+            required_eval_manifest_path=str(manifest_path),
+            required_eval_corpus_version="test-corpus-v1",
+            required_eval_names=("Required Eval",),
+        )
+
+
+def test_build_eval_bloom_requires_features_for_every_required_record(tmp_path: Path):
+    eval_root = tmp_path / "evals"
+    artifact_path = eval_root / "aa" / "required_eval" / "test.parquet"
+    _write_input_parquet(artifact_path, [{"id": "eval-1", "text": "Hello world"}])
+    manifest_path = eval_root / "aa" / "_manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "corpus_version": "test-corpus-v1",
+                "required": True,
+                "status": "complete",
+                "benchmarks": [
+                    {
+                        "name": "Required Eval",
+                        "artifact": "required_eval/test.parquet",
+                        "expected_records": 1,
+                    }
+                ],
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="1 of 1 required eval records produce no matchable features"):
+        build_eval_bloom(
+            eval_data_sources=str(eval_root),
+            output_path=str(tmp_path / "bloom"),
+            ngram=NGramConfig(ngram_length=13),
+            required_eval_manifest_path=str(manifest_path),
+            required_eval_corpus_version="test-corpus-v1",
+            required_eval_names=("Required Eval",),
+        )
+
+
+def test_build_eval_bloom_uses_only_manifested_best_effort_artifacts(tmp_path: Path):
+    required_root = tmp_path / "required"
+    required_artifact = required_root / "aa" / "required_eval" / "test.parquet"
+    stale_required_artifact = required_root / "aa" / "stale" / "test.parquet"
+    _write_input_parquet(required_artifact, [{"id": "required-1", "text": "alpha beta gamma"}])
+    _write_input_parquet(stale_required_artifact, [{"id": "stale-required-1", "text": "kappa lambda mu"}])
+    required_manifest = required_root / "aa" / "_manifest.json"
+    required_manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "corpus_version": "test-corpus-v1",
+                "required": True,
+                "status": "complete",
+                "benchmarks": [
+                    {
+                        "name": "Required Eval",
+                        "artifact": "required_eval/test.parquet",
+                        "expected_records": 1,
+                    }
+                ],
+            },
+            indent=2,
+        )
+    )
+
+    best_effort_root = tmp_path / "best_effort"
+    included_artifact = best_effort_root / "included" / "eval.parquet"
+    stale_artifact = best_effort_root / "stale" / "eval.parquet"
+    _write_input_parquet(included_artifact, [{"id": "included-1", "text": "delta epsilon zeta"}])
+    _write_input_parquet(stale_artifact, [{"id": "stale-1", "text": "eta theta iota"}])
+    best_effort_manifest = required_root / "lmh" / "_manifest.json"
+    best_effort_manifest.parent.mkdir(parents=True)
+    best_effort_manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "corpus_version": "test-corpus-v1",
+                "required": False,
+                "status": "complete_with_failures",
+                "included_leaf_tasks": ["included"],
+                "artifacts": [{"task": "included", "artifact": "included/eval.parquet", "records": 1}],
+                "failed": [{"task": "missing", "reason": "test failure"}],
+            }
+        )
+    )
+
+    result = build_eval_bloom(
+        eval_data_sources=str(required_root),
+        output_path=str(tmp_path / "bloom"),
+        required_eval_manifest_path=str(required_manifest),
+        required_eval_corpus_version="test-corpus-v1",
+        required_eval_names=("Required Eval",),
+        best_effort_eval_manifest_path=str(best_effort_manifest),
+        best_effort_eval_root=str(best_effort_root),
+        best_effort_eval_corpus_version="test-corpus-v1",
+    )
+
+    assert result.n_eval_records == 2
+    index = pq.read_table(result.eval_hash_index_path).to_pylist()
+    assert {row["eval_id"] for row in index} == {"required-1", "included-1"}
 
 
 def test_build_eval_bloom_excludes_named_task_dirs(tmp_path: Path):


### PR DESCRIPTION
* fixes https://github.com/marin-community/marin/issues/8168
* pin all nine Artificial Analysis Intelligence Index v4.1.1 benchmarks in a required, versioned corpus with 4,165 records
  * include all 2,500 Humanity's Last Exam rows, with text from multimodal rows and no image bytes
  * use the 291-row SciCode public superset and the 600-row public AA-Omniscience release
* record exact required and best-effort artifacts, row counts, included lm-eval tasks, and failed lm-eval tasks
  * seal AA and lm-eval manifests and artifacts below the `aa-index-v4.1.1-v3` corpus root
  * stop lm-eval preparation after a suite-wide import failure, while individual task failures remain best effort
* stop Bloom creation when a required benchmark, artifact, row count, or matchable feature is missing
* use guarded exact matching for short alphabetic eval records while keeping one-token, two-token, and non-alphabetic values out
* keep the current combined eval-text policy for this hero run
  * future work: separate prompt and reference fields, make prompt coverage mandatory, and apply stricter rules to long answers, rubrics, tests, and solutions
  * measure prompt-only, reference-only, and semantic near-match results before a change to the removal policy
* retain the v2 CoreWeave validation record with all 4,165 AA IDs and 1,560,259 total matchable eval records[^1]
  * generate and validate the immutable v3 corpus before the hero run
* pass 89 affected tests, with 5 expected failures

[^1]: `s3://marin-us-east-02a/marin/datakit/bloom/_combined_fixed_6435fc68`; full validation record: https://github.com/marin-community/marin/issues/8168#issuecomment-5261281819
