### PR TITLE
[finelog] Cover Zephyr stall alert execution labels

### DIFF
--- a/lib/finelog/rust/src/server/telemetry.rs
+++ b/lib/finelog/rust/src/server/telemetry.rs
@@ -752,6 +752,7 @@ fn telemetry_schema() -> Schema {
             "name",
             "value",
             "resource_attributes_json",
+            "attributes_json",
             "cluster",
         ],
     ))

--- a/lib/finelog/rust/src/server/telemetry_tests.rs
+++ b/lib/finelog/rust/src/server/telemetry_tests.rs
@@ -290,6 +290,11 @@ async fn router_registers_index_policy_before_first_telemetry_request() {
         .columns
         .iter()
         .any(|column| column == "attributes_json"));
+    let training_status = projections["training-status"];
+    assert!(training_status
+        .columns
+        .iter()
+        .any(|column| column == "attributes_json"));
     assert_eq!(schema.grouped_extrema.len(), 1);
     let grouped = &schema.grouped_extrema[0];
     assert_eq!(grouped.filter_column, "service");


### PR DESCRIPTION
Cover `attributes_json` in Finelog's existing `training-status` projection so
`ZephyrPipelineProgressStalled` can read execution labels without scanning base
telemetry segments.

The production query exceeded Finelog's 10-second deadline with
`attributes_json`; the projection-covered equivalent completed in 3.85
seconds. Widening the existing projection preserves the alert labels and lets
Finelog rebuild coverage in place.

Incident record: https://echo.oa.dev/wiki/108
