### PR TITLE
zephyr: limit concurrent final result reads

### DIFF
--- a/lib/zephyr/src/zephyr/coordinator.py
+++ b/lib/zephyr/src/zephyr/coordinator.py
@@ -47,6 +47,7 @@ MAX_SHARD_FAILURES = 3
 MAX_SHARD_INFRA_FAILURES = 20
 MAX_STATUS_TEXT_LENGTH = 1000
 MAX_CONCURRENT_PIPELINES = 16
+MAX_CONCURRENT_RESULT_READS = 16
 ZEPHYR_PROGRESS_TIME_METRIC = "progress_time_seconds"
 
 _SNAPSHOT_ATTRIBUTES = telemetry.snapshot_attributes("gauge", telemetry.CURRENT_SNAPSHOT)
@@ -350,7 +351,9 @@ class ZephyrCoordinator:
         self._self_handle = actor_ctx.handle
 
         self._stats_writer = StatsWriter.connect()
-        self._result_executor = ThreadPoolExecutor(max_workers=32, thread_name_prefix="zephyr-result")
+        self._result_executor = ThreadPoolExecutor(
+            max_workers=MAX_CONCURRENT_RESULT_READS, thread_name_prefix="zephyr-result"
+        )
 
         logger.info("Coordinator initialized")
 


### PR DESCRIPTION
* fixes https://github.com/marin-community/marin/issues/8186
* limit final `PickleDiskChunk` materialization to 16 concurrent reads
* 4,575-shard, 1 GiB coordinator peaked at 833 MiB and completed materialization in 16 seconds
  * 32 readers exceeded 1 GiB and exited 137
  * 1 reader peaked at 487 MiB and completed in 55 seconds
* 16 is the highest tested safe value for this workload; larger result chunks can need more memory
* [profile and control results](https://echo.oa.dev/wiki/106)
