### PR TITLE
fsutil: parquet previews

### DIFF
--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -63,11 +63,15 @@ at 10 MB of stored bytes. Use `cp` to fetch a whole object.
 
 A `.parquet` file is read through its footer rather than from the head of the object,
 so `cat`, `head`, and the browser show its schema, its row count, and its first rows.
-Parquet's smallest readable unit is a whole column chunk, so the rows come out of the
-first row group, and a first row group above the 10 MB limit is reported instead of
-pulled down — copy that file to read it. Parquet previews need pyarrow in the
-environment. It is not a `marin-rigging` dependency, because rigging sits under every
-other package, but the marin workspace installs it.
+`head -n` bounds the rows, not the printed lines. Parquet's smallest readable unit is a
+whole column chunk, so the rows come out of the first row group alone, and a first row
+group that decodes to more than 10 MB is reported instead of read — copy that file to
+read it. The footer itself is read whatever its size, so the 10 MB cap above bounds the
+column data rather than the whole preview.
+
+Parquet previews need pyarrow in the environment. It is not a `marin-rigging`
+dependency, because rigging sits under every other package, but the marin workspace
+installs it.
 
 ## The browser
 

--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -46,8 +46,8 @@ that touch its buckets; the rest keep working.
 | Command | What it does |
 |---------|--------------|
 | `ls [URL] [-l]` | Immediate children; with no URL, the declared buckets. `-l` adds size and modification time |
-| `cat URL [--raw]` | Print a file. Tabular JSON and JSONL render as a table, and `--raw` writes stored bytes to stdout |
-| `head URL [-n N]` | Print the first N lines |
+| `cat URL [--raw]` | Print a file. Tabular JSON, JSONL, and parquet render as a table, and `--raw` writes stored bytes to stdout |
+| `head URL [-n N]` | Print the first N lines, or the first N rows of a parquet file |
 | `stat URL` | The object's metadata as the backend reports it |
 | `du URL` | Total bytes and object count beneath a prefix |
 | `find PATTERN` | Paths matching a glob, e.g. `gs://marin-us-central2/x/**/*.json` |
@@ -60,6 +60,14 @@ bytes.
 
 Formatted file previews are capped at 10 MB after decompression. `cat --raw` is capped
 at 10 MB of stored bytes. Use `cp` to fetch a whole object.
+
+A `.parquet` file is read through its footer rather than from the head of the object,
+so `cat`, `head`, and the browser show its schema, its row count, and its first rows.
+Parquet's smallest readable unit is a whole column chunk, so the rows come out of the
+first row group, and a first row group above the 10 MB limit is reported instead of
+pulled down — copy that file to read it. Parquet previews need pyarrow in the
+environment. It is not a `marin-rigging` dependency, because rigging sits under every
+other package, but the marin workspace installs it.
 
 ## The browser
 

--- a/lib/rigging/src/rigging/fsutil/cli.py
+++ b/lib/rigging/src/rigging/fsutil/cli.py
@@ -94,7 +94,13 @@ def cat(url: str, raw: bool) -> None:
 
 @cli.command()
 @click.argument("url")
-@click.option("-n", "--lines", default=20, show_default=True, help="Number of lines to print.")
+@click.option(
+    "-n",
+    "--lines",
+    default=PREVIEW_ROWS,
+    show_default=True,
+    help="Number of lines to print, or rows for a parquet file.",
+)
 def head(url: str, lines: int) -> None:
     """Print the first lines of a file, or the first rows of a parquet file."""
     rendered = _formatted_lines(url, lines)

--- a/lib/rigging/src/rigging/fsutil/cli.py
+++ b/lib/rigging/src/rigging/fsutil/cli.py
@@ -27,6 +27,7 @@ from rigging.fsutil.listing import (
     read_preview,
     total_size,
 )
+from rigging.fsutil.parquet import PREVIEW_ROWS, is_parquet, parquet_lines
 from rigging.fsutil.render import aligned_lines, file_lines, format_size, format_time, table_lines
 from rigging.fsutil.tui import run as run_browser
 
@@ -82,13 +83,12 @@ def list_command(url: str, long: bool) -> None:
 @click.argument("url")
 @click.option("--raw", is_flag=True, help="Write bytes to stdout without formatting.")
 def cat(url: str, raw: bool) -> None:
-    """Print a file, rendering tabular JSON and JSONL as a table."""
+    """Print a file, rendering tabular JSON, JSONL, and parquet as a table."""
     if raw:
         data = _read_raw(url)
         sys.stdout.buffer.write(data)
         return
-    data = _read(url)
-    for line in file_lines(StoragePath(url).name, data):
+    for line in _formatted_lines(url, PREVIEW_ROWS):
         click.echo(line)
 
 
@@ -96,9 +96,9 @@ def cat(url: str, raw: bool) -> None:
 @click.argument("url")
 @click.option("-n", "--lines", default=20, show_default=True, help="Number of lines to print.")
 def head(url: str, lines: int) -> None:
-    """Print the first lines of a file."""
-    data = _read(url)
-    for line in file_lines(StoragePath(url).name, data)[:lines]:
+    """Print the first lines of a file, or the first rows of a parquet file."""
+    rendered = _formatted_lines(url, lines)
+    for line in rendered if is_parquet(StoragePath(url).name) else rendered[:lines]:
         click.echo(line)
 
 
@@ -170,6 +170,18 @@ def _print_long_entries(entries: list[Entry]) -> None:
         rows.append([format_size(entry.size), format_time(entry.mtime), name])
     for line in table_lines(["size", "modified", "name"], rows):
         click.echo(line)
+
+
+def _formatted_lines(url: str, rows: int) -> list[str]:
+    """Render *url* for display, reading parquet through its footer and the rest by head.
+
+    A parquet file states its own row count in the returned lines, so it takes *rows*
+    rather than a line budget the caller applies afterwards.
+    """
+    name = StoragePath(url).name
+    if is_parquet(name):
+        return parquet_lines(url, rows)
+    return file_lines(name, _read(url))
 
 
 def _read(url: str) -> bytes:

--- a/lib/rigging/src/rigging/fsutil/cli.py
+++ b/lib/rigging/src/rigging/fsutil/cli.py
@@ -27,7 +27,7 @@ from rigging.fsutil.listing import (
     read_preview,
     total_size,
 )
-from rigging.fsutil.parquet import PREVIEW_ROWS, is_parquet, parquet_lines
+from rigging.fsutil.parquet import PREVIEW_ROWS, MissingParquetReader, is_parquet, parquet_lines
 from rigging.fsutil.render import aligned_lines, file_lines, format_size, format_time, table_lines
 from rigging.fsutil.tui import run as run_browser
 
@@ -180,7 +180,10 @@ def _formatted_lines(url: str, rows: int) -> list[str]:
     """
     name = StoragePath(url).name
     if is_parquet(name):
-        return parquet_lines(url, rows)
+        try:
+            return parquet_lines(url, rows)
+        except MissingParquetReader as e:
+            raise click.ClickException(str(e)) from e
     return file_lines(name, _read(url))
 
 

--- a/lib/rigging/src/rigging/fsutil/parquet.py
+++ b/lib/rigging/src/rigging/fsutil/parquet.py
@@ -4,10 +4,9 @@
 """Parquet previews for the CLI and the browser.
 
 Parquet keeps its schema and its row-group index in a footer, so the bounded head read
-that serves every other format returns nothing a reader can parse. These helpers open
-the object and seek instead: the footer costs one small range request, and the rows come
-from the first row group, which is decoded only when it is small enough to be worth the
-transfer.
+that serves every other format returns nothing a reader can parse. These helpers seek
+instead: the footer gives the schema and the statistics, and the rows come out of the
+first row group, which is decoded only when it stays inside the preview limit.
 """
 
 from rigging.filesystem.buckets import filesystem_for
@@ -16,6 +15,10 @@ from rigging.fsutil.render import aligned_lines, format_size, record_lines, tabl
 
 # Rows rendered when the caller asks for no particular count.
 PREVIEW_ROWS = 20
+
+
+class MissingParquetReader(RuntimeError):
+    """Raised when a preview runs where no parquet reader is installed."""
 
 
 def is_parquet(name: str) -> bool:
@@ -30,21 +33,20 @@ def is_parquet(name: str) -> bool:
 def parquet_lines(url: str, rows: int = PREVIEW_ROWS) -> list[str]:
     """Render *url* as its schema, its footer statistics, and its first *rows* rows."""
     # pyarrow is deliberately absent from marin-rigging's dependencies: rigging sits under
-    # every other package, and one more requirement there re-resolves the whole workspace
-    # lock. Every environment that holds parquet files already installs pyarrow.
+    # every other package, and one more requirement there re-resolves the workspace lock.
     try:
         import pyarrow.parquet as pq  # noqa: PLC0415  # optional dep
     except ImportError as exc:
-        raise RuntimeError("reading parquet requires pyarrow; install it with `pip install pyarrow`") from exc
+        raise MissingParquetReader("reading parquet requires pyarrow; install it with `pip install pyarrow`") from exc
 
     fs, path = filesystem_for(url)
     file_size = fs.size(path)
     with fs.open(path, "rb") as file:
         parquet_file = pq.ParquetFile(file)
         metadata = parquet_file.metadata
-        lines = ["schema:", *_schema_lines(parquet_file.schema_arrow), "", *_summary_lines(metadata, file_size), ""]
-        lines.extend(_row_lines(parquet_file, metadata, rows))
-    return lines
+        lines = ["schema:", *_schema_lines(parquet_file.schema_arrow), "", *_summary_lines(metadata, file_size)]
+        rendered_rows = _row_lines(parquet_file, metadata, rows)
+    return [*lines, "", *rendered_rows] if rendered_rows else lines
 
 
 def _schema_lines(schema) -> list[str]:
@@ -64,12 +66,16 @@ def _summary_lines(metadata, file_size: int) -> list[str]:
 
 
 def _row_lines(parquet_file, metadata, rows: int) -> list[str]:
-    """The first *rows* rows, or why they were not read.
+    """The first *rows* rows of row group 0, or why they were not read.
 
-    A batch is served out of the first row group, and parquet's smallest readable unit is
-    a whole column chunk. So the cost of one row is the cost of the row group that holds
-    it, and a row group above the preview limit is reported rather than pulled down.
+    Parquet's smallest readable unit is a whole column chunk, so one row costs the row
+    group that holds it. A first row group above the limit is reported rather than
+    decoded, and the read is pinned to that group so it never crosses into one the limit
+    has not cleared. A short first group therefore yields fewer rows than asked, which
+    the row count below the table states.
     """
+    if rows <= 0:
+        return []
     if metadata.num_rows == 0:
         return ["(no rows)"]
 
@@ -80,9 +86,7 @@ def _row_lines(parquet_file, metadata, rows: int) -> list[str]:
             f"above the {format_size(MAX_PREVIEW_BYTES)} preview limit — copy the file to read it]"
         ]
 
-    # A batch may otherwise run on into the next row group, which would put the read
-    # above the limit that the check just cleared.
-    batch = next(parquet_file.iter_batches(batch_size=max(1, min(rows, group.num_rows))), None)
+    batch = next(parquet_file.iter_batches(batch_size=rows, row_groups=[0]), None)
     if batch is None:
         return ["(no rows)"]
     lines = record_lines(batch.to_pylist())

--- a/lib/rigging/src/rigging/fsutil/parquet.py
+++ b/lib/rigging/src/rigging/fsutil/parquet.py
@@ -1,0 +1,91 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parquet previews for the CLI and the browser.
+
+Parquet keeps its schema and its row-group index in a footer, so the bounded head read
+that serves every other format returns nothing a reader can parse. These helpers open
+the object and seek instead: the footer costs one small range request, and the rows come
+from the first row group, which is decoded only when it is small enough to be worth the
+transfer.
+"""
+
+from rigging.filesystem.buckets import filesystem_for
+from rigging.fsutil.listing import MAX_PREVIEW_BYTES
+from rigging.fsutil.render import aligned_lines, format_size, record_lines, table_lines
+
+# Rows rendered when the caller asks for no particular count.
+PREVIEW_ROWS = 20
+
+
+def is_parquet(name: str) -> bool:
+    """Whether *name* is a parquet file.
+
+    Parquet compresses its own column chunks, so a name is matched as stored rather than
+    through :func:`rigging.fsutil.compression.uncompressed_name`.
+    """
+    return name.lower().endswith(".parquet")
+
+
+def parquet_lines(url: str, rows: int = PREVIEW_ROWS) -> list[str]:
+    """Render *url* as its schema, its footer statistics, and its first *rows* rows."""
+    # pyarrow is deliberately absent from marin-rigging's dependencies: rigging sits under
+    # every other package, and one more requirement there re-resolves the whole workspace
+    # lock. Every environment that holds parquet files already installs pyarrow.
+    try:
+        import pyarrow.parquet as pq  # noqa: PLC0415  # optional dep
+    except ImportError as exc:
+        raise RuntimeError("reading parquet requires pyarrow; install it with `pip install pyarrow`") from exc
+
+    fs, path = filesystem_for(url)
+    file_size = fs.size(path)
+    with fs.open(path, "rb") as file:
+        parquet_file = pq.ParquetFile(file)
+        metadata = parquet_file.metadata
+        lines = ["schema:", *_schema_lines(parquet_file.schema_arrow), "", *_summary_lines(metadata, file_size), ""]
+        lines.extend(_row_lines(parquet_file, metadata, rows))
+    return lines
+
+
+def _schema_lines(schema) -> list[str]:
+    return table_lines(["column", "type"], [[field.name, str(field.type)] for field in schema])
+
+
+def _summary_lines(metadata, file_size: int) -> list[str]:
+    return aligned_lines(
+        [
+            ["rows", str(metadata.num_rows)],
+            ["columns", str(metadata.num_columns)],
+            ["row groups", str(metadata.num_row_groups)],
+            ["file size", format_size(file_size)],
+            ["created by", metadata.created_by or "-"],
+        ]
+    )
+
+
+def _row_lines(parquet_file, metadata, rows: int) -> list[str]:
+    """The first *rows* rows, or why they were not read.
+
+    A batch is served out of the first row group, and parquet's smallest readable unit is
+    a whole column chunk. So the cost of one row is the cost of the row group that holds
+    it, and a row group above the preview limit is reported rather than pulled down.
+    """
+    if metadata.num_rows == 0:
+        return ["(no rows)"]
+
+    group = metadata.row_group(0)
+    if group.total_byte_size > MAX_PREVIEW_BYTES:
+        return [
+            f"[rows not read: row group 0 holds {format_size(group.total_byte_size)} uncompressed, "
+            f"above the {format_size(MAX_PREVIEW_BYTES)} preview limit — copy the file to read it]"
+        ]
+
+    # A batch may otherwise run on into the next row group, which would put the read
+    # above the limit that the check just cleared.
+    batch = next(parquet_file.iter_batches(batch_size=max(1, min(rows, group.num_rows))), None)
+    if batch is None:
+        return ["(no rows)"]
+    lines = record_lines(batch.to_pylist())
+    if metadata.num_rows > batch.num_rows:
+        lines.append(f"[showing {batch.num_rows} of {metadata.num_rows} rows]")
+    return lines

--- a/lib/rigging/src/rigging/fsutil/parquet.py
+++ b/lib/rigging/src/rigging/fsutil/parquet.py
@@ -68,11 +68,9 @@ def _summary_lines(metadata, file_size: int) -> list[str]:
 def _row_lines(parquet_file, metadata, rows: int) -> list[str]:
     """The first *rows* rows of row group 0, or why they were not read.
 
-    Parquet's smallest readable unit is a whole column chunk, so one row costs the row
-    group that holds it. A first row group above the limit is reported rather than
-    decoded, and the read is pinned to that group so it never crosses into one the limit
-    has not cleared. A short first group therefore yields fewer rows than asked, which
-    the row count below the table states.
+    A short first group yields fewer rows than asked, and the count below the table says
+    so. Row group 0 is the whole budget because parquet's smallest readable unit is a
+    column chunk.
     """
     if rows <= 0:
         return []

--- a/lib/rigging/src/rigging/fsutil/render.py
+++ b/lib/rigging/src/rigging/fsutil/render.py
@@ -40,7 +40,9 @@ def file_lines(name: str, raw: bytes) -> list[str]:
     """Render *raw* as display lines, using *name*'s extension to pick a JSON reader.
 
     A tabular ``.json`` or ``.jsonl`` file renders as a table. The renderer ignores one
-    supported compression suffix. Other files render as text or a byte count.
+    supported compression suffix. Other files render as text or a byte count. Parquet
+    cannot be rendered from a head read at all, so callers route it to
+    :func:`rigging.fsutil.parquet.parquet_lines` before they read any bytes.
     """
     name = uncompressed_name(name)
     if name.endswith((".json", ".jsonl")):
@@ -76,12 +78,21 @@ def _json_lines(name: str, text: str) -> list[str]:
         return text.splitlines()
 
 
+def record_lines(records: list[dict]) -> list[str]:
+    """Render records as a table with a column per key, truncating oversized cells.
+
+    Shared by the JSON readers and the parquet reader, which arrive at the same shape
+    from different formats.
+    """
+    headers = list({key: None for row in records for key in row})
+    rows = [[_cell(row.get(header)) for header in headers] for row in records]
+    return table_lines(headers, rows)
+
+
 def _json_table_lines(data: object) -> list[str]:
     """Render parsed JSON as an aligned table when it is tabular, else as indented JSON."""
     if isinstance(data, list) and data and all(isinstance(row, dict) for row in data):
-        headers = list({key: None for row in data for key in row})
-        rows = [[_cell(row.get(header)) for header in headers] for row in data]
-        return table_lines(headers, rows)
+        return record_lines(data)
     if isinstance(data, dict):
         return table_lines(["key", "value"], [[key, _cell(value)] for key, value in data.items()])
     return json.dumps(data, indent=2, default=str).splitlines()

--- a/lib/rigging/src/rigging/fsutil/render.py
+++ b/lib/rigging/src/rigging/fsutil/render.py
@@ -40,9 +40,7 @@ def file_lines(name: str, raw: bytes) -> list[str]:
     """Render *raw* as display lines, using *name*'s extension to pick a JSON reader.
 
     A tabular ``.json`` or ``.jsonl`` file renders as a table. The renderer ignores one
-    supported compression suffix. Other files render as text or a byte count. Parquet
-    cannot be rendered from a head read at all, so callers route it to
-    :func:`rigging.fsutil.parquet.parquet_lines` before they read any bytes.
+    supported compression suffix. Other files render as text or a byte count.
     """
     name = uncompressed_name(name)
     if name.endswith((".json", ".jsonl")):
@@ -79,11 +77,7 @@ def _json_lines(name: str, text: str) -> list[str]:
 
 
 def record_lines(records: list[dict]) -> list[str]:
-    """Render records as a table with a column per key, truncating oversized cells.
-
-    Shared by the JSON readers and the parquet reader, which arrive at the same shape
-    from different formats.
-    """
+    """Render records as a table with a column per key, truncating oversized cells."""
     headers = list({key: None for row in records for key in row})
     rows = [[_cell(row.get(header)) for header in headers] for row in records]
     return table_lines(headers, rows)

--- a/lib/rigging/src/rigging/fsutil/tui.py
+++ b/lib/rigging/src/rigging/fsutil/tui.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 
 from rigging.filesystem.buckets import MissingCredentials
 from rigging.fsutil.listing import ROOT, Entry, list_entries, parent_url, read_decompressed_preview, total_size
+from rigging.fsutil.parquet import is_parquet, parquet_lines
 from rigging.fsutil.render import file_lines, format_size, format_time
 
 _HELP = "[enter] open  [backspace] up  [/] filter  [s] sort  [d] size  [y] print URL  [q] quit"
@@ -132,12 +133,18 @@ def _open(stdscr: "curses.window", screen: Screen) -> None:
         return
 
     try:
-        preview = read_decompressed_preview(selected.url)
-        lines = file_lines(selected.name, preview.data)
+        if is_parquet(selected.name):
+            # Parquet is read through its footer rather than from the head of the object,
+            # so it takes the URL and reports its own limits in the rendered lines.
+            lines = parquet_lines(selected.url)
+            truncated_bytes = None
+        else:
+            preview = read_decompressed_preview(selected.url)
+            lines = file_lines(selected.name, preview.data)
+            truncated_bytes = len(preview.data) if preview.truncated else None
     except Exception as e:
         screen.status = f"error: {e}"
         return
-    truncated_bytes = len(preview.data) if preview.truncated else None
     _view(stdscr, selected.name, lines, truncated_bytes)
 
 

--- a/lib/rigging/tests/test_fsutil_parquet.py
+++ b/lib/rigging/tests/test_fsutil_parquet.py
@@ -1,0 +1,69 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for fsutil's parquet previews, over local paths — which ``filesystem_for``
+routes exactly as it routes an object store.
+
+pyarrow is not a marin-rigging dependency, so these tests skip in an environment that
+holds no parquet reader and run everywhere a parquet file could be browsed."""
+
+import pytest
+from click.testing import CliRunner
+from rigging.fsutil import parquet, tui
+from rigging.fsutil.cli import cli
+from rigging.fsutil.parquet import parquet_lines
+
+pa = pytest.importorskip("pyarrow")
+pq = pytest.importorskip("pyarrow.parquet")
+
+
+@pytest.fixture
+def shard(tmp_path):
+    """A two-row-group parquet file, so a preview reads the first group and no more."""
+    path = tmp_path / "docs.parquet"
+    table = pa.table({"step": list(range(6)), "text": [f"row {i}" for i in range(6)]})
+    pq.write_table(table, path, row_group_size=3)
+    return path
+
+
+def test_parquet_preview_reports_schema_statistics_and_rows(shard):
+    """Parquet's schema lives in a footer, so a preview must seek rather than read a head."""
+    lines = parquet_lines(str(shard), rows=2)
+
+    assert [line.split() for line in lines[1:4]] == [["column", "type"], ["------", "------"], ["step", "int64"]]
+    assert "rows        6" in lines
+    header = lines.index("step  text")
+    assert lines[header + 2].split() == ["0", "row", "0"]
+    assert lines[-1] == "[showing 2 of 6 rows]"
+
+
+def test_parquet_preview_skips_rows_when_the_first_row_group_is_too_large(shard, monkeypatch):
+    """One row is only readable by decoding the whole row group that holds it, so an
+    oversized group is reported instead of pulled down."""
+    monkeypatch.setattr(parquet, "MAX_PREVIEW_BYTES", 8)
+
+    lines = parquet_lines(str(shard))
+
+    assert lines[-1].startswith("[rows not read: row group 0 holds ")
+    assert not any("row 0" in line for line in lines)
+
+
+def test_cat_head_and_the_browser_route_parquet_to_the_footer_reader(shard, monkeypatch):
+    """Every entry point dispatches on the name before it reads bytes, and ``head -n``
+    bounds rows rather than lines, which the schema block would otherwise consume.
+
+    The browser is exercised through the screen's own helpers because the viewer itself
+    needs a live curses window.
+    """
+    assert "row 0" in CliRunner().invoke(cli, ["cat", str(shard)]).output
+
+    head = CliRunner().invoke(cli, ["head", "-n", "2", str(shard)])
+    assert "row 0" in head.output
+    assert head.output.splitlines()[-1] == "[showing 2 of 6 rows]"
+
+    viewed = []
+    monkeypatch.setattr(tui, "_view", lambda stdscr, name, lines, truncated: viewed.append(lines))
+    screen = tui.Screen(url=str(shard.parent))
+    tui._reload(screen)
+    tui._open(None, screen)
+    assert any("row 0" in line for line in viewed[0])

--- a/lib/rigging/tests/test_fsutil_parquet.py
+++ b/lib/rigging/tests/test_fsutil_parquet.py
@@ -9,7 +9,7 @@ holds no parquet reader and run everywhere a parquet file could be browsed."""
 
 import pytest
 from click.testing import CliRunner
-from rigging.fsutil import parquet, tui
+from rigging.fsutil import parquet
 from rigging.fsutil.cli import cli
 from rigging.fsutil.parquet import parquet_lines
 
@@ -48,22 +48,11 @@ def test_parquet_preview_skips_rows_when_the_first_row_group_is_too_large(shard,
     assert not any("row 0" in line for line in lines)
 
 
-def test_cat_head_and_the_browser_route_parquet_to_the_footer_reader(shard, monkeypatch):
-    """Every entry point dispatches on the name before it reads bytes, and ``head -n``
-    bounds rows rather than lines, which the schema block would otherwise consume.
-
-    The browser is exercised through the screen's own helpers because the viewer itself
-    needs a live curses window.
-    """
+def test_cat_and_head_route_parquet_to_the_footer_reader(shard):
+    """The commands dispatch on the name before they read bytes, and ``head -n`` bounds
+    rows rather than lines, which the schema block would otherwise consume."""
     assert "row 0" in CliRunner().invoke(cli, ["cat", str(shard)]).output
 
     head = CliRunner().invoke(cli, ["head", "-n", "2", str(shard)])
     assert "row 0" in head.output
     assert head.output.splitlines()[-1] == "[showing 2 of 6 rows]"
-
-    viewed = []
-    monkeypatch.setattr(tui, "_view", lambda stdscr, name, lines, truncated: viewed.append(lines))
-    screen = tui.Screen(url=str(shard.parent))
-    tui._reload(screen)
-    tui._open(None, screen)
-    assert any("row 0" in line for line in viewed[0])


### PR DESCRIPTION
* `cat`, `head`, and the browser rendered a `.parquet` file as `[binary file, N bytes]`
* parquet keeps its schema and row-group index in a footer, so the bounded head read that serves every other format holds nothing a reader can parse. new `rigging/fsutil/parquet.py` seeks instead: the footer gives the schema, the row/column/row-group counts and the writer, and the rows go through the existing table renderer
* the entry points dispatch on the name before they read bytes — `_formatted_lines` in `cli.py` for `cat`/`head`, `_open` in `tui.py` for the browser
  * `cat --raw` still writes stored bytes
* `head -n` bounds rows rather than printed lines, which the schema block would otherwise consume
* rows come out of row group 0 alone (`iter_batches(row_groups=[0])`) — parquet's smallest readable unit is a column chunk, so one row costs the group that holds it, and a first row group above the 10 MB preview cap is reported instead of read [^1]
* `record_lines` factored out of `render.py`'s JSON path, which builds the same table from the same shape
* pyarrow stays out of `marin-rigging`'s dependencies: rigging sits below every other package, and one more requirement there re-resolves the whole workspace lock [^2]
  * the import is lazy, a missing reader becomes a click error rather than a traceback, and the tests `importorskip`

[^1]: the check reads `RowGroupMetaData.total_byte_size`, which is the decoded size of the column data rather than the bytes on the wire. the footer itself is read whatever its size, so the cap bounds the column data rather than the whole preview.

[^2]: measured: adding it re-resolved 514 packages, collapsed the marker forks and dropped `torch 2.10.0`, `nvidia-nvtx` and `nvidia-cusparselt-cu13` from `uv.lock` — 554 lines of churn for one preview path.
