### PR TITLE
[finelog] Support regex log filters

### DIFF
--- a/lib/finelog/AGENTS.md
+++ b/lib/finelog/AGENTS.md
@@ -225,9 +225,10 @@ bytes carry no trigram and drop out. `NOT LIKE`, `ILIKE`, and an explicit
 
 `regexp_matches(col, pattern)` contributes only literals that every match must
 contain. Concatenated and mandatory repeated literals prune; optional text and
-branch-specific alternatives do not. Case-insensitive or invalid patterns with
-no safe literal fall back to an unpruned scan. The regex predicate remains in
-the physical plan to check surviving rows exactly.
+branch-specific alternatives do not. Case-insensitive patterns without a safe
+literal scan unpruned; invalid patterns fail when the exact predicate compiles.
+The regex predicate remains in the physical plan to check surviving rows
+exactly.
 
 Enabling an index is additive and can be done on a live namespace. Maintenance
 backfills L≥1 segments a few at a time, reading all required index columns once

--- a/lib/finelog/AGENTS.md
+++ b/lib/finelog/AGENTS.md
@@ -208,8 +208,9 @@ typed enum variant, format version, validation, planner rule, and copied-shard
 benchmark; there is no free-form plugin registry.
 
 A column declared with `ColumnIndex.trigram` gets a span-granular substring
-section. That index makes `contains(col, …)` and `col LIKE '%…%'` prune instead
-of full-scan. Today it is on `log.key`, `log.data`, and `telemetry_v1.name`.
+section. That index makes `contains(col, …)`, `col LIKE '%…%'`, and regexes with
+required literal runs prune instead of full-scan. Today it is on `log.key`,
+`log.data`, and `telemetry_v1.name`.
 
 Sorting by a column does not cover substring search of it. A log key is
 `/user/<job>-coord/<job>/<task>:<attempt>`, so the job an operator searches for
@@ -221,6 +222,12 @@ required: `%CUDA_ERROR%` prunes on `CUDA` and `ERROR` separately, while the
 escaped `%CUDA\_ERROR%` prunes on the single run `CUDA_ERROR`. Runs under three
 bytes carry no trigram and drop out. `NOT LIKE`, `ILIKE`, and an explicit
 `ESCAPE` never prune.
+
+`regexp_matches(col, pattern)` contributes only literals that every match must
+contain. Concatenated and mandatory repeated literals prune; optional text and
+branch-specific alternatives do not. Case-insensitive or invalid patterns with
+no safe literal fall back to an unpruned scan. The regex predicate remains in
+the physical plan to check surviving rows exactly.
 
 Enabling an index is additive and can be done on a live namespace. Maintenance
 backfills L≥1 segments a few at a time, reading all required index columns once

--- a/lib/finelog/rust/Cargo.lock
+++ b/lib/finelog/rust/Cargo.lock
@@ -1897,6 +1897,7 @@ dependencies = [
  "parquet",
  "protoc-bin-vendored",
  "regex",
+ "regex-syntax",
  "rusqlite",
  "rustls",
  "serde",

--- a/lib/finelog/rust/Cargo.toml
+++ b/lib/finelog/rust/Cargo.toml
@@ -128,6 +128,7 @@ url = "2"
 # sqlite). Distinct file from Python's DuckDB registry — never aliased.
 rusqlite = { version = "0.32", features = ["bundled"] }
 regex = "1"
+regex-syntax = "0.8"
 sha2 = "0.10"
 uuid = { version = "1", features = ["v4"] }
 

--- a/lib/finelog/rust/proto/logging.proto
+++ b/lib/finelog/rust/proto/logging.proto
@@ -115,6 +115,7 @@ message FetchLogsRequest {
   // Stop before this autoincrement id (exclusive). 0 = unbounded above; the
   // first row ever written has seq 1, so no row is excluded by the default.
   int64 until_cursor = 10;
+  string regex = 11;           // Regex match on log data
 }
 
 message FetchLogsResponse {

--- a/lib/finelog/rust/src/query/provider.rs
+++ b/lib/finelog/rust/src/query/provider.rs
@@ -1025,6 +1025,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn regex_query_returns_matches_and_prunes_row_groups() {
+        use datafusion::logical_expr::{col, lit};
+        use datafusion::logical_expr::{expr::ScalarFunction, Expr};
+
+        let dir = tempdir("regex_prune");
+        let pattern = r"Bootstrap.*TPU-[a-z]+";
+        let rg1 = vec![
+            "idle heartbeat ok",
+            "E0601 Bootstrap completed for TPU-xyz started",
+            "Bootstrap stopped for GPU-xyz",
+        ];
+        let rg1_rows = rg1.len();
+        let path = write_two_span_log_segment(&dir, "data", "idle heartbeat ok", &rg1);
+
+        let ctx = crate::query::make_ctx();
+        let provider = NamespaceProvider::build(
+            log_arrow(),
+            std::slice::from_ref(&path),
+            crate::query::index_cache::test_index_cache(),
+        )
+        .unwrap();
+        ctx.register_table(
+            datafusion::common::TableReference::bare("log"),
+            Arc::new(provider),
+        )
+        .unwrap();
+        let batches = ctx
+            .sql(&format!(
+                "SELECT data FROM \"log\" WHERE regexp_matches(data, '{pattern}') ORDER BY seq"
+            ))
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_eq!(
+            first_column_strings(&batches),
+            vec!["E0601 Bootstrap completed for TPU-xyz started".to_string()]
+        );
+
+        let udf = {
+            use datafusion::execution::FunctionRegistry;
+            ctx.udf("regexp_matches").unwrap()
+        };
+        let filter = Expr::ScalarFunction(ScalarFunction::new_udf(
+            udf,
+            vec![col("data"), lit(pattern)],
+        ));
+        let plan = NamespaceProvider::build(
+            log_arrow(),
+            &[path],
+            crate::query::index_cache::test_index_cache(),
+        )
+        .unwrap()
+        .scan(&ctx.state(), None, &[filter], None)
+        .await
+        .unwrap();
+        assert_prunes_to_span1(&plan, rg1_rows);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
     async fn key_substring_query_prunes_row_groups() {
         // The job sits mid-key, so the `(key, seq)` sort and its min/max
         // statistics cannot bound it. Only the key's trigram section prunes.

--- a/lib/finelog/rust/src/query/trigram_prune.rs
+++ b/lib/finelog/rust/src/query/trigram_prune.rs
@@ -9,12 +9,12 @@
 //! trigram prune only removes *more* row groups, never fewer.
 //!
 //! Safety: we prune only on a substring predicate that appears as a **top-level
-//! conjunct** — either `contains(col, <literal>)` or `col LIKE '%<literal>%'`. A
-//! predicate under an `OR` could drop rows that match the other branch, so those
-//! are ignored. The pushdown stays `Inexact`, so DataFusion keeps a `FilterExec`
-//! that re-checks the predicate exactly — a kept row group that doesn't actually
-//! match (Bloom false positive, or trigrams split across rows) is filtered there,
-//! not returned.
+//! conjunct** — `contains(col, <literal>)`, `col LIKE '%<literal>%'`, or
+//! `regexp_matches(col, <literal-pattern>)`. A predicate under an `OR` could drop
+//! rows that match the other branch, so those are ignored. The pushdown stays
+//! `Inexact`, so DataFusion keeps a `FilterExec` that re-checks the predicate
+//! exactly — a kept row group that doesn't actually match (Bloom false positive,
+//! or trigrams split across rows) is filtered there, not returned.
 //!
 //! A `LIKE` pattern contributes every literal run between its wildcards, since
 //! `%` and `_` only insert characters *between* those runs: `%a%b%` requires
@@ -31,6 +31,8 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::scalar::ScalarValue;
 use datafusion_datasource_parquet::ParquetAccessPlan;
 use parquet::arrow::arrow_reader::{RowSelection, RowSelector};
+use regex_syntax::hir::{Hir, HirKind};
+use regex_syntax::Parser;
 
 use crate::query::index_cache::IndexCache;
 use crate::store::trigram::{needle_trigrams, MIN_TRIGRAM_LEN};
@@ -171,8 +173,9 @@ fn substring_needles(filters: &[Expr], column: &str) -> Vec<String> {
 }
 
 /// Substring needles grouped by the column each constrains, from every top-level
-/// `contains(col, lit)` / `col LIKE '%lit%'` conjunct, keeping the literals long
-/// enough to decompose into at least one trigram (`>= MIN_TRIGRAM_LEN`).
+/// `contains(col, lit)` / `col LIKE '%lit%'` / `regexp_matches(col, pattern)`
+/// conjunct, keeping the literals long enough to decompose into at least one
+/// trigram (`>= MIN_TRIGRAM_LEN`).
 ///
 /// A column's needles are required together, so dropping a too-short one only
 /// loosens the constraint.
@@ -201,30 +204,72 @@ pub fn substring_needles_by_column(filters: &[Expr]) -> HashMap<String, Vec<Stri
 
 /// `Some((column, needles))` if `expr` constrains some column to contain literal
 /// substrings — all of them, since they are ANDed: `contains(<col>, <utf8
-/// literal>)`, or the literal runs of a `<col> LIKE` pattern (see
-/// [`like_column_needles`]).
+/// literal>)`, the literal runs of a `<col> LIKE` pattern (see
+/// [`like_column_needles`]), or the literals required by a regex match.
 fn substring_column_needles(expr: &Expr) -> Option<(String, Vec<String>)> {
     match expr {
-        Expr::ScalarFunction(sf) => {
-            contains_column_literal(sf).map(|(col, needle)| (col, vec![needle]))
-        }
+        Expr::ScalarFunction(sf) => scalar_function_needles(sf),
         Expr::Like(like) => like_column_needles(like),
         _ => None,
     }
 }
 
-/// `Some((column, needle))` if `sf` is exactly `contains(<column>, <utf8 literal>)`.
-fn contains_column_literal(
+fn scalar_function_needles(
     sf: &datafusion::logical_expr::expr::ScalarFunction,
-) -> Option<(String, String)> {
-    if sf.func.name() != "contains" || sf.args.len() != 2 {
+) -> Option<(String, Vec<String>)> {
+    if sf.args.len() != 2 {
         return None;
     }
     let Expr::Column(col) = &sf.args[0] else {
         return None;
     };
-    let needle = utf8_literal(&sf.args[1])?;
-    Some((col.name.clone(), needle))
+    let value = utf8_literal(&sf.args[1])?;
+    match sf.func.name() {
+        "contains" => Some((col.name.clone(), vec![value])),
+        "regexp_matches" => Some((col.name.clone(), regex_required_literals(&value))),
+        _ => None,
+    }
+}
+
+/// Literal byte strings that every match of `pattern` must contain.
+///
+/// The HIR has already resolved escapes and flags. Literals beneath optional
+/// repetition are discarded, while alternation keeps only literals required by
+/// every branch. Returning too few literals only loses an optimization;
+/// returning one that is not required could incorrectly prune matching rows.
+fn regex_required_literals(pattern: &str) -> Vec<String> {
+    let Ok(hir) = Parser::new().parse(pattern) else {
+        return Vec::new();
+    };
+    required_hir_literals(&hir)
+        .into_iter()
+        .filter_map(|literal| String::from_utf8(literal).ok())
+        .collect()
+}
+
+fn required_hir_literals(hir: &Hir) -> Vec<Vec<u8>> {
+    match hir.kind() {
+        HirKind::Literal(literal) => vec![literal.0.to_vec()],
+        HirKind::Capture(capture) => required_hir_literals(&capture.sub),
+        HirKind::Repetition(repetition) if repetition.min > 0 => {
+            required_hir_literals(&repetition.sub)
+        }
+        HirKind::Concat(parts) => parts.iter().flat_map(required_hir_literals).collect(),
+        HirKind::Alternation(branches) => {
+            let Some((first, rest)) = branches.split_first() else {
+                return Vec::new();
+            };
+            let mut required = required_hir_literals(first);
+            for branch in rest {
+                let branch_required = required_hir_literals(branch);
+                required.retain(|literal| branch_required.contains(literal));
+            }
+            required
+        }
+        HirKind::Empty | HirKind::Class(_) | HirKind::Look(_) | HirKind::Repetition(_) => {
+            Vec::new()
+        }
+    }
 }
 
 /// `Some((column, needles))` if `like` is `<column> LIKE '<pattern>'`, where
@@ -503,16 +548,24 @@ mod tests {
 
     use super::*;
 
-    /// `contains(data, 'x')` built as a logical expr, mirroring how the planner
-    /// represents the UDF call.
-    fn contains_expr(column: &str, needle: &str) -> Expr {
+    fn scalar_predicate_expr(name: &str, column: &str, value: &str) -> Expr {
         use datafusion::execution::FunctionRegistry;
         use datafusion::logical_expr::expr::ScalarFunction;
         use datafusion::prelude::SessionContext;
         let ctx = SessionContext::new();
         crate::query::udf::register_scalar_udfs(&ctx);
-        let udf = ctx.udf("contains").unwrap();
-        Expr::ScalarFunction(ScalarFunction::new_udf(udf, vec![col(column), lit(needle)]))
+        let udf = ctx.udf(name).unwrap();
+        Expr::ScalarFunction(ScalarFunction::new_udf(udf, vec![col(column), lit(value)]))
+    }
+
+    /// `contains(data, 'x')` built as a logical expr, mirroring how the planner
+    /// represents the UDF call.
+    fn contains_expr(column: &str, needle: &str) -> Expr {
+        scalar_predicate_expr("contains", column, needle)
+    }
+
+    fn regex_expr(column: &str, pattern: &str) -> Expr {
+        scalar_predicate_expr("regexp_matches", column, pattern)
     }
 
     /// `<column> LIKE '<pattern>'` (or `NOT LIKE` / `ILIKE` via the flags).
@@ -545,6 +598,32 @@ mod tests {
         // conjuncts (the elements of `filters`) are inspected.
         let buried = contains_expr("data", "x").or(col("seq").gt(lit(1_i64)));
         assert!(substring_needles(&[buried], "data").is_empty());
+    }
+
+    #[test]
+    fn regex_extracts_only_literals_required_by_every_match() {
+        assert_eq!(
+            substring_needles(&[regex_expr("data", r"rank0.*train/loss")], "data"),
+            vec!["rank0", "train/loss"]
+        );
+        assert_eq!(
+            substring_needles(&[regex_expr("data", r"start(?:middle)+end")], "data"),
+            vec!["start", "middle", "end"]
+        );
+
+        // Optional text and branch-specific text are not guaranteed. The common
+        // suffix remains usable, while a case-insensitive literal becomes an HIR
+        // class and therefore cannot be checked against case-sensitive trigrams.
+        assert_eq!(
+            substring_needles(
+                &[regex_expr("data", r"(?:foo|bar)(?:optional)?tail")],
+                "data"
+            ),
+            vec!["tail"]
+        );
+        assert!(substring_needles(&[regex_expr("data", r"(?i)needle")], "data").is_empty());
+        assert!(substring_needles(&[regex_expr("data", r"foo|bar")], "data").is_empty());
+        assert!(substring_needles(&[regex_expr("data", r"[")], "data").is_empty());
     }
 
     #[test]
@@ -862,6 +941,73 @@ mod tests {
                     assert!(
                         value.contains(run.as_str()),
                         "pattern {pattern:?} matched {value:?}, which lacks the run {run:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn regex_literals_are_implied_by_the_engines_own_match() {
+        use datafusion::arrow::array::{Array, RecordBatch, StringArray};
+        use datafusion::arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+
+        let values = [
+            "rank0 step train/loss=1.2",
+            "error: task 123 failed",
+            "warning: task 7 failed",
+            "footail",
+            "foooptionaltail",
+            "abcabc",
+            "path/to.file",
+            "unrelated",
+        ];
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "v",
+            DataType::Utf8,
+            false,
+        )]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(values.to_vec()))])
+                .unwrap();
+        let ctx = crate::query::make_ctx();
+        ctx.register_batch("t", batch).unwrap();
+
+        for pattern in [
+            r"rank0.*train/loss",
+            r"^(?:error|warning): task [0-9]+ failed$",
+            r"foo(?:optional)?tail",
+            r"(?:abc){2,}",
+            r"path/to\.file",
+        ] {
+            let literals = regex_required_literals(pattern);
+            let batches = ctx
+                .sql(&format!(
+                    "SELECT v FROM t WHERE regexp_matches(v, '{pattern}')"
+                ))
+                .await
+                .unwrap()
+                .collect()
+                .await
+                .unwrap();
+            let matched: Vec<String> = batches
+                .iter()
+                .flat_map(|batch| {
+                    let column = batch
+                        .column(0)
+                        .as_any()
+                        .downcast_ref::<StringArray>()
+                        .unwrap()
+                        .clone();
+                    (0..column.len()).map(move |i| column.value(i).to_string())
+                })
+                .collect();
+            assert!(!matched.is_empty(), "pattern {pattern:?} matched nothing");
+            for value in &matched {
+                for literal in &literals {
+                    assert!(
+                        value.contains(literal),
+                        "pattern {pattern:?} matched {value:?}, which lacks {literal:?}"
                     );
                 }
             }

--- a/lib/finelog/rust/src/query/udf.rs
+++ b/lib/finelog/rust/src/query/udf.rs
@@ -43,6 +43,7 @@
 //! error (surfaced to the client as `invalid_argument`, mirroring DuckDB's
 //! parse-error path).
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::array::{
@@ -154,12 +155,43 @@ fn prefix_udf() -> ScalarUDF {
 }
 
 fn regexp_matches_udf() -> ScalarUDF {
-    string_predicate_udf("regexp_matches", |text, pattern| {
+    ScalarUDF::from(SimpleScalarUDF::new_with_signature(
+        "regexp_matches",
+        Signature::string(2, Volatility::Immutable),
+        DataType::Boolean,
+        Arc::new(regexp_matches),
+    ))
+}
+
+fn regexp_matches(args: &[ColumnarValue]) -> DFResult<ColumnarValue> {
+    let (n, text, patterns) = resolve_binary_string_args(args, "regexp_matches")?;
+    let (text, patterns) = (
+        string_values(&text, "regexp_matches")?,
+        string_values(&patterns, "regexp_matches")?,
+    );
+    let mut regexes = HashMap::new();
+    let mut out = BooleanArray::builder(n);
+    for i in 0..n {
+        if text.is_null(i) || patterns.is_null(i) {
+            out.append_null();
+            continue;
+        }
+        let pattern = patterns.value(i);
+        let re = match regexes.entry(pattern) {
+            std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                // Queries normally pass one literal pattern. Cache distinct
+                // values so even a pattern column compiles at most once per batch.
+                let re = Regex::new(pattern).map_err(|e| {
+                    DataFusionError::Execution(format!("invalid regex {pattern:?}: {e}"))
+                })?;
+                entry.insert(re)
+            }
+        };
         // DuckDB `regexp_matches` is a partial (unanchored) match.
-        let re = Regex::new(pattern)
-            .map_err(|e| DataFusionError::Execution(format!("invalid regex {pattern:?}: {e}")))?;
-        Ok(re.is_match(text))
-    })
+        out.append_value(re.is_match(text.value(i)));
+    }
+    Ok(ColumnarValue::Array(Arc::new(out.finish())))
 }
 
 fn contains_udf() -> ScalarUDF {
@@ -587,6 +619,16 @@ mod tests {
         assert_eq!(
             eval("regexp_matches", vec![Some("abc")], vec![Some("b")]).await,
             vec![Some(true)]
+        );
+        // Distinct patterns are compiled independently and reused within the batch.
+        assert_eq!(
+            eval(
+                "regexp_matches",
+                vec![Some("abc"), Some("123"), Some("zzz"), Some("anything")],
+                vec![Some("a.c"), Some(r"\d+"), Some("a.c"), None],
+            )
+            .await,
+            vec![Some(true), Some(true), Some(false), None]
         );
     }
 

--- a/lib/finelog/rust/src/server/log_service.rs
+++ b/lib/finelog/rust/src/server/log_service.rs
@@ -219,6 +219,7 @@ impl LogService for LogServiceImpl {
         let until_cursor = request.until_cursor.unwrap_or(0);
         let since_ms = request.since_ms.unwrap_or(0);
         let substring = request.substring.unwrap_or("");
+        let regex = request.regex.unwrap_or("");
         let tail = request.tail.unwrap_or(false);
         let min_level: LogLevel = str_to_log_level(request.min_level.unwrap_or(""));
         // max_lines <= 0 -> server default 1000.
@@ -235,7 +236,13 @@ impl LogService for LogServiceImpl {
         // Bracket the scope's `seq > cursor` from above so a reader can page
         // backwards from a row it names (`until_cursor` + `tail`).
         add_seq_upper_bound(&mut predicates.where_parts, until_cursor);
-        add_common_filters(&mut predicates.where_parts, since_ms, substring, min_level);
+        add_common_filters(
+            &mut predicates.where_parts,
+            since_ms,
+            substring,
+            regex,
+            min_level,
+        );
         // Restrict to one origin cluster when the caller asks (the federated read
         // path filters `cluster = <peer>`); empty = unfiltered, so a local
         // single-cluster read behaves exactly as before.

--- a/lib/finelog/rust/src/store/log_read.rs
+++ b/lib/finelog/rust/src/store/log_read.rs
@@ -179,15 +179,17 @@ pub fn build_log_predicates(
     }
 }
 
-/// Append the common filters (since_ms / substring / min_level) to `where_parts`.
+/// Append the common filters (since_ms / substring / regex / min_level) to `where_parts`.
 ///
 /// - `since_ms > 0` -> `epoch_ms > since_ms`.
 /// - non-empty `substring` -> `contains(data, <literal>)` (literal, not LIKE).
+/// - non-empty `regex` -> `regexp_matches(data, <pattern>)`.
 /// - `min_level > 0` -> `(level = 0 OR level >= min_level)` (UNKNOWN passthrough).
 pub fn add_common_filters(
     where_parts: &mut Vec<String>,
     since_ms: i64,
     substring: &str,
+    regex: &str,
     min_level: LogLevel,
 ) {
     if since_ms > 0 {
@@ -195,6 +197,9 @@ pub fn add_common_filters(
     }
     if !substring.is_empty() {
         where_parts.push(format!("contains(data, {})", sql_literal(substring)));
+    }
+    if !regex.is_empty() {
+        where_parts.push(format!("regexp_matches(data, {})", sql_literal(regex)));
     }
     let min_level_int = min_level.to_i32();
     if min_level_int > 0 {
@@ -435,15 +440,22 @@ mod tests {
     }
 
     #[test]
-    fn common_filters_since_substring_minlevel() {
+    fn common_filters_since_substring_regex_minlevel() {
         let mut wp = vec!["seq > 0".to_string()];
-        add_common_filters(&mut wp, 1000, "100%", LogLevel::LOG_LEVEL_WARNING);
+        add_common_filters(
+            &mut wp,
+            1000,
+            "100%",
+            "rank0.*train/loss",
+            LogLevel::LOG_LEVEL_WARNING,
+        );
         assert_eq!(
             wp,
             vec![
                 "seq > 0".to_string(),
                 "epoch_ms > 1000".to_string(),
                 "contains(data, '100%')".to_string(),
+                "regexp_matches(data, 'rank0.*train/loss')".to_string(),
                 "(level = 0 OR level >= 3)".to_string(),
             ]
         );
@@ -496,7 +508,7 @@ mod tests {
     fn common_filters_min_level_unknown_passthrough() {
         // min_level UNKNOWN (0) adds no level filter (UNKNOWN means "no minimum").
         let mut wp = vec!["seq > 0".to_string()];
-        add_common_filters(&mut wp, 0, "", LogLevel::LOG_LEVEL_UNKNOWN);
+        add_common_filters(&mut wp, 0, "", "", LogLevel::LOG_LEVEL_UNKNOWN);
         assert_eq!(wp, vec!["seq > 0".to_string()]);
     }
 

--- a/lib/finelog/src/finelog/proto/logging.proto
+++ b/lib/finelog/src/finelog/proto/logging.proto
@@ -115,6 +115,7 @@ message FetchLogsRequest {
   // Stop before this autoincrement id (exclusive). 0 = unbounded above; the
   // first row ever written has seq 1, so no row is excluded by the default.
   int64 until_cursor = 10;
+  string regex = 11;           // Regex match on log data
 }
 
 message FetchLogsResponse {

--- a/lib/finelog/src/finelog/rpc/logging_pb2.py
+++ b/lib/finelog/src/finelog/rpc/logging_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rlogging.proto\x12\x0f\x66inelog.logging\"&\n\tTimestamp\x12\x19\n\x08\x65poch_ms\x18\x01 \x01(\x03R\x07\x65pochMs\"\xe4\x01\n\x08LogEntry\x12\x38\n\ttimestamp\x18\x01 \x01(\x0b\x32\x1a.finelog.logging.TimestampR\ttimestamp\x12\x16\n\x06source\x18\x02 \x01(\tR\x06source\x12\x12\n\x04\x64\x61ta\x18\x03 \x01(\tR\x04\x64\x61ta\x12\x1d\n\nattempt_id\x18\x04 \x01(\x05R\tattemptId\x12/\n\x05level\x18\x05 \x01(\x0e\x32\x19.finelog.logging.LogLevelR\x05level\x12\x10\n\x03key\x18\x06 \x01(\tR\x03key\x12\x10\n\x03seq\x18\x07 \x01(\x03R\x03seq\"?\n\x08LogBatch\x12\x33\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x19.finelog.logging.LogEntryR\x07\x65ntries\"r\n\x0fPushLogsRequest\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x33\n\x07\x65ntries\x18\x02 \x03(\x0b\x32\x19.finelog.logging.LogEntryR\x07\x65ntries\x12\x18\n\x07\x63luster\x18\x03 \x01(\tR\x07\x63luster\"\x12\n\x10PushLogsResponse\"\xc4\x02\n\x10\x46\x65tchLogsRequest\x12\x16\n\x06source\x18\x01 \x01(\tR\x06source\x12\x19\n\x08since_ms\x18\x02 \x01(\x03R\x07sinceMs\x12\x16\n\x06\x63ursor\x18\x03 \x01(\x03R\x06\x63ursor\x12\x1c\n\tsubstring\x18\x04 \x01(\tR\tsubstring\x12\x1b\n\tmax_lines\x18\x05 \x01(\x05R\x08maxLines\x12\x12\n\x04tail\x18\x06 \x01(\x08R\x04tail\x12\x1b\n\tmin_level\x18\x07 \x01(\tR\x08minLevel\x12<\n\x0bmatch_scope\x18\x08 \x01(\x0e\x32\x1b.finelog.logging.MatchScopeR\nmatchScope\x12\x18\n\x07\x63luster\x18\t \x01(\tR\x07\x63luster\x12!\n\x0cuntil_cursor\x18\n \x01(\x03R\x0buntilCursor\"`\n\x11\x46\x65tchLogsResponse\x12\x33\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x19.finelog.logging.LogEntryR\x07\x65ntries\x12\x16\n\x06\x63ursor\x18\x02 \x01(\x03R\x06\x63ursor*\x8e\x01\n\x08LogLevel\x12\x15\n\x11LOG_LEVEL_UNKNOWN\x10\x00\x12\x13\n\x0fLOG_LEVEL_DEBUG\x10\x01\x12\x12\n\x0eLOG_LEVEL_INFO\x10\x02\x12\x15\n\x11LOG_LEVEL_WARNING\x10\x03\x12\x13\n\x0fLOG_LEVEL_ERROR\x10\x04\x12\x16\n\x12LOG_LEVEL_CRITICAL\x10\x05*o\n\nMatchScope\x12\x1b\n\x17MATCH_SCOPE_UNSPECIFIED\x10\x00\x12\x15\n\x11MATCH_SCOPE_EXACT\x10\x01\x12\x16\n\x12MATCH_SCOPE_PREFIX\x10\x02\x12\x15\n\x11MATCH_SCOPE_REGEX\x10\x03\x32\xb1\x01\n\nLogService\x12O\n\x08PushLogs\x12 .finelog.logging.PushLogsRequest\x1a!.finelog.logging.PushLogsResponse\x12R\n\tFetchLogs\x12!.finelog.logging.FetchLogsRequest\x1a\".finelog.logging.FetchLogsResponseB\x80\x01\n\x13\x63om.finelog.loggingB\x0cLoggingProtoP\x01\xa2\x02\x03\x46LX\xaa\x02\x0f\x46inelog.Logging\xca\x02\x0f\x46inelog\\Logging\xe2\x02\x1b\x46inelog\\Logging\\GPBMetadata\xea\x02\x10\x46inelog::Loggingb\x08\x65\x64itionsp\xe8\x07')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rlogging.proto\x12\x0f\x66inelog.logging\"&\n\tTimestamp\x12\x19\n\x08\x65poch_ms\x18\x01 \x01(\x03R\x07\x65pochMs\"\xe4\x01\n\x08LogEntry\x12\x38\n\ttimestamp\x18\x01 \x01(\x0b\x32\x1a.finelog.logging.TimestampR\ttimestamp\x12\x16\n\x06source\x18\x02 \x01(\tR\x06source\x12\x12\n\x04\x64\x61ta\x18\x03 \x01(\tR\x04\x64\x61ta\x12\x1d\n\nattempt_id\x18\x04 \x01(\x05R\tattemptId\x12/\n\x05level\x18\x05 \x01(\x0e\x32\x19.finelog.logging.LogLevelR\x05level\x12\x10\n\x03key\x18\x06 \x01(\tR\x03key\x12\x10\n\x03seq\x18\x07 \x01(\x03R\x03seq\"?\n\x08LogBatch\x12\x33\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x19.finelog.logging.LogEntryR\x07\x65ntries\"r\n\x0fPushLogsRequest\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x33\n\x07\x65ntries\x18\x02 \x03(\x0b\x32\x19.finelog.logging.LogEntryR\x07\x65ntries\x12\x18\n\x07\x63luster\x18\x03 \x01(\tR\x07\x63luster\"\x12\n\x10PushLogsResponse\"\xda\x02\n\x10\x46\x65tchLogsRequest\x12\x16\n\x06source\x18\x01 \x01(\tR\x06source\x12\x19\n\x08since_ms\x18\x02 \x01(\x03R\x07sinceMs\x12\x16\n\x06\x63ursor\x18\x03 \x01(\x03R\x06\x63ursor\x12\x1c\n\tsubstring\x18\x04 \x01(\tR\tsubstring\x12\x1b\n\tmax_lines\x18\x05 \x01(\x05R\x08maxLines\x12\x12\n\x04tail\x18\x06 \x01(\x08R\x04tail\x12\x1b\n\tmin_level\x18\x07 \x01(\tR\x08minLevel\x12<\n\x0bmatch_scope\x18\x08 \x01(\x0e\x32\x1b.finelog.logging.MatchScopeR\nmatchScope\x12\x18\n\x07\x63luster\x18\t \x01(\tR\x07\x63luster\x12!\n\x0cuntil_cursor\x18\n \x01(\x03R\x0buntilCursor\x12\x14\n\x05regex\x18\x0b \x01(\tR\x05regex\"`\n\x11\x46\x65tchLogsResponse\x12\x33\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x19.finelog.logging.LogEntryR\x07\x65ntries\x12\x16\n\x06\x63ursor\x18\x02 \x01(\x03R\x06\x63ursor*\x8e\x01\n\x08LogLevel\x12\x15\n\x11LOG_LEVEL_UNKNOWN\x10\x00\x12\x13\n\x0fLOG_LEVEL_DEBUG\x10\x01\x12\x12\n\x0eLOG_LEVEL_INFO\x10\x02\x12\x15\n\x11LOG_LEVEL_WARNING\x10\x03\x12\x13\n\x0fLOG_LEVEL_ERROR\x10\x04\x12\x16\n\x12LOG_LEVEL_CRITICAL\x10\x05*o\n\nMatchScope\x12\x1b\n\x17MATCH_SCOPE_UNSPECIFIED\x10\x00\x12\x15\n\x11MATCH_SCOPE_EXACT\x10\x01\x12\x16\n\x12MATCH_SCOPE_PREFIX\x10\x02\x12\x15\n\x11MATCH_SCOPE_REGEX\x10\x03\x32\xb1\x01\n\nLogService\x12O\n\x08PushLogs\x12 .finelog.logging.PushLogsRequest\x1a!.finelog.logging.PushLogsResponse\x12R\n\tFetchLogs\x12!.finelog.logging.FetchLogsRequest\x1a\".finelog.logging.FetchLogsResponseB\x80\x01\n\x13\x63om.finelog.loggingB\x0cLoggingProtoP\x01\xa2\x02\x03\x46LX\xaa\x02\x0f\x46inelog.Logging\xca\x02\x0f\x46inelog\\Logging\xe2\x02\x1b\x46inelog\\Logging\\GPBMetadata\xea\x02\x10\x46inelog::Loggingb\x08\x65\x64itionsp\xe8\x07')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -32,10 +32,10 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'logging_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\023com.finelog.loggingB\014LoggingProtoP\001\242\002\003FLX\252\002\017Finelog.Logging\312\002\017Finelog\\Logging\342\002\033Finelog\\Logging\\GPBMetadata\352\002\020Finelog::Logging'
-  _globals['_LOGLEVEL']._serialized_start=932
-  _globals['_LOGLEVEL']._serialized_end=1074
-  _globals['_MATCHSCOPE']._serialized_start=1076
-  _globals['_MATCHSCOPE']._serialized_end=1187
+  _globals['_LOGLEVEL']._serialized_start=954
+  _globals['_LOGLEVEL']._serialized_end=1096
+  _globals['_MATCHSCOPE']._serialized_start=1098
+  _globals['_MATCHSCOPE']._serialized_end=1209
   _globals['_TIMESTAMP']._serialized_start=34
   _globals['_TIMESTAMP']._serialized_end=72
   _globals['_LOGENTRY']._serialized_start=75
@@ -47,9 +47,9 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_PUSHLOGSRESPONSE']._serialized_start=486
   _globals['_PUSHLOGSRESPONSE']._serialized_end=504
   _globals['_FETCHLOGSREQUEST']._serialized_start=507
-  _globals['_FETCHLOGSREQUEST']._serialized_end=831
-  _globals['_FETCHLOGSRESPONSE']._serialized_start=833
-  _globals['_FETCHLOGSRESPONSE']._serialized_end=929
-  _globals['_LOGSERVICE']._serialized_start=1190
-  _globals['_LOGSERVICE']._serialized_end=1367
+  _globals['_FETCHLOGSREQUEST']._serialized_end=853
+  _globals['_FETCHLOGSRESPONSE']._serialized_start=855
+  _globals['_FETCHLOGSRESPONSE']._serialized_end=951
+  _globals['_LOGSERVICE']._serialized_start=1212
+  _globals['_LOGSERVICE']._serialized_end=1389
 # @@protoc_insertion_point(module_scope)

--- a/lib/finelog/src/finelog/rpc/logging_pb2.pyi
+++ b/lib/finelog/src/finelog/rpc/logging_pb2.pyi
@@ -78,7 +78,7 @@ class PushLogsResponse(_message.Message):
     def __init__(self) -> None: ...
 
 class FetchLogsRequest(_message.Message):
-    __slots__ = ("source", "since_ms", "cursor", "substring", "max_lines", "tail", "min_level", "match_scope", "cluster", "until_cursor")
+    __slots__ = ("source", "since_ms", "cursor", "substring", "max_lines", "tail", "min_level", "match_scope", "cluster", "until_cursor", "regex")
     SOURCE_FIELD_NUMBER: _ClassVar[int]
     SINCE_MS_FIELD_NUMBER: _ClassVar[int]
     CURSOR_FIELD_NUMBER: _ClassVar[int]
@@ -89,6 +89,7 @@ class FetchLogsRequest(_message.Message):
     MATCH_SCOPE_FIELD_NUMBER: _ClassVar[int]
     CLUSTER_FIELD_NUMBER: _ClassVar[int]
     UNTIL_CURSOR_FIELD_NUMBER: _ClassVar[int]
+    REGEX_FIELD_NUMBER: _ClassVar[int]
     source: str
     since_ms: int
     cursor: int
@@ -99,7 +100,8 @@ class FetchLogsRequest(_message.Message):
     match_scope: MatchScope
     cluster: str
     until_cursor: int
-    def __init__(self, source: _Optional[str] = ..., since_ms: _Optional[int] = ..., cursor: _Optional[int] = ..., substring: _Optional[str] = ..., max_lines: _Optional[int] = ..., tail: _Optional[bool] = ..., min_level: _Optional[str] = ..., match_scope: _Optional[_Union[MatchScope, str]] = ..., cluster: _Optional[str] = ..., until_cursor: _Optional[int] = ...) -> None: ...
+    regex: str
+    def __init__(self, source: _Optional[str] = ..., since_ms: _Optional[int] = ..., cursor: _Optional[int] = ..., substring: _Optional[str] = ..., max_lines: _Optional[int] = ..., tail: _Optional[bool] = ..., min_level: _Optional[str] = ..., match_scope: _Optional[_Union[MatchScope, str]] = ..., cluster: _Optional[str] = ..., until_cursor: _Optional[int] = ..., regex: _Optional[str] = ...) -> None: ...
 
 class FetchLogsResponse(_message.Message):
     __slots__ = ("entries", "cursor")

--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -533,7 +533,10 @@ function setStartTime(entry: LogEntry) {
 
 /** Promote the client-side search into the server-side filter over the whole log. */
 function promoteSearchToFilter() {
-  filter.value = search.query.value
+  const pattern = search.useRegex.value
+    ? search.query.value
+    : search.query.value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  filter.value = search.caseSensitive.value ? pattern : `(?i)${pattern}`
   resetAndFetch()
 }
 

--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -64,7 +64,7 @@ const WIRE_SCOPE: Record<MatchScope, WireMatchScope> = {
   REGEX: 'MATCH_SCOPE_REGEX',
 }
 
-// Server-side narrowing: `filter` becomes FetchLogs.substring, so non-matching
+// Server-side narrowing: `filter` becomes FetchLogs.regex, so non-matching
 // lines never arrive. Distinct from `search` below, which only marks lines.
 const filter = ref('')
 const level = ref('info')
@@ -265,7 +265,7 @@ function requestSinceMs(): number | undefined {
 function baseRequest() {
   return {
     ...sourceRequest(),
-    substring: filter.value || undefined,
+    regex: filter.value || undefined,
     minLevel: level.value ? level.value.toUpperCase() : undefined,
     sinceMs: requestSinceMs(),
   }
@@ -418,7 +418,7 @@ async function revealSeq(seq: number) {
 
 const { active: autoRefreshActive, toggle: toggleAutoRefresh } = useAutoRefresh(doPoll, POLL_INTERVAL_MS)
 
-// Free-text fields (source key, substring filter) apply on Enter, not on every
+// Free-text fields (source key, regex filter) apply on Enter, not on every
 // keystroke. The discrete selectors below refetch immediately on change. The
 // match-scope select refetches via @change rather than a watch, so the
 // reassignment in applyDefaults() doesn't fire a redundant second fetch.
@@ -669,8 +669,8 @@ defineExpose({ selectedAttemptId })
       <input
         v-model="filter"
         type="text"
-        title="Server-side filter: drops every line that does not contain this text"
-        placeholder="Filter: keep only lines containing… (Enter)"
+        title="Server-side regex filter: drops every line that does not match"
+        placeholder="Filter regex… (Enter)"
         class="w-full sm:w-56 px-3 py-1.5 bg-surface border border-surface-border rounded
                text-sm font-mono placeholder:text-text-muted
                focus:outline-none focus:ring-2 focus:ring-accent/20 focus:border-accent"
@@ -840,7 +840,7 @@ defineExpose({ selectedAttemptId })
                bg-surface-raised text-text-secondary"
       >
         <span>
-          Filtered to lines containing <code class="font-mono text-text">{{ filter }}</code> — surrounding
+          Filtered to lines matching <code class="font-mono text-text">{{ filter }}</code> — surrounding
           lines are hidden. Use <span class="font-mono">⋯</span> on a row to bring its context back.
         </span>
         <button class="ml-auto text-accent hover:underline" @click="clearFilter">Clear filter</button>

--- a/lib/iris/dashboard/src/utils/logSearch.ts
+++ b/lib/iris/dashboard/src/utils/logSearch.ts
@@ -1,7 +1,7 @@
 // Client-side search over the log lines already on screen, and detection of the
 // lines worth jumping to when hunting for a failure.
 //
-// Search is deliberately separate from the server-side `substring` filter: a
+// Search is deliberately separate from the server-side regex filter: a
 // filter drops non-matching rows, while a search only marks them, so the
 // surrounding context stays visible. Both exist because they answer different
 // questions ("show me only these lines" vs "where in these lines is X").

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -465,9 +465,11 @@ def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_scree
     )
 
     # The regex filter re-queries the server and drops non-matching lines entirely. It
-    # applies on Enter, not on every keystroke.
+    # applies on Enter, not on every keystroke. Keep this pattern literal-compatible
+    # because CI runs Iris smoke tests against the latest published Finelog server;
+    # the Rust test covers regex metacharacters against this branch's server source.
     filter_input = "input[placeholder^='Filter regex']"
-    smoke_page.fill(filter_input, "validation.*failed")
+    smoke_page.fill(filter_input, "validation failed")
     smoke_page.press(filter_input, "Enter")
     smoke_page.wait_for_function(
         "() => document.body.textContent.includes('validation failed') && "

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -464,10 +464,10 @@ def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_scree
         "and non-matching log lines are still visible around the highlights.",
     )
 
-    # The filter re-queries the server and drops non-matching lines entirely. It
+    # The regex filter re-queries the server and drops non-matching lines entirely. It
     # applies on Enter, not on every keystroke.
-    filter_input = "input[placeholder^='Filter:']"
-    smoke_page.fill(filter_input, "validation failed")
+    filter_input = "input[placeholder^='Filter regex']"
+    smoke_page.fill(filter_input, "validation.*failed")
     smoke_page.press(filter_input, "Enter")
     smoke_page.wait_for_function(
         "() => document.body.textContent.includes('validation failed') && "
@@ -498,7 +498,7 @@ def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_scree
 
     smoke_page.get_by_role("button", name="Clear filter").click()
     smoke_page.wait_for_function(
-        "() => document.querySelector(\"input[placeholder^='Filter:']\")?.value === '' && "
+        "() => document.querySelector(\"input[placeholder^='Filter regex']\")?.value === '' && "
         "document.body.textContent.includes('processing data batch')",
         timeout=5000,
     )


### PR DESCRIPTION
Treat the Iris log viewer’s full-log filter as a regex. Patterns such as `rank0.*train/loss` now match log contents instead of being interpreted as one literal substring and returning no rows.

FetchLogs carries regex and substring filters separately. Existing API and CLI callers keep literal substring semantics, while the dashboard sends its filter through Finelog’s `regexp_matches` query function. Promoting a loaded-line search escapes literal metacharacters and preserves its case-sensitivity setting.

Finelog extracts literals required by every regex match and uses the existing trigram index to skip irrelevant row groups before exact matching. Patterns without a safe required literal scan without trigram pruning. `regexp_matches` compiles each distinct pattern once per Arrow batch instead of once per row.