### PR TITLE
[agents] Add no-slop review skill

### DIFF
--- a/.agents/skills/noslop/SKILL.md
+++ b/.agents/skills/noslop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: noslop
-description: Review and clean a complete branch diff before PR publication, with strict gates for low-value tests and agentic prose. Use when asked to deslop, simplify, clean up, make a diff minimal, review test quality, tighten comments/docs/PR text, or remove AI-writing patterns such as rhetorical "X, not Y" contrasts. Apply fixes when the task authorizes code changes; otherwise report concrete findings.
+description: Clean a branch with strict gates for low-value tests and agentic prose. Use when asked to deslop, simplify, clean up, make a diff minimal, review test quality, tighten comments/docs/PR text, or remove AI-writing patterns such as rhetorical "X, not Y" contrasts.
 ---
 
 # No-Slop Review

--- a/.agents/skills/noslop/SKILL.md
+++ b/.agents/skills/noslop/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: noslop
+description: Review and clean a complete branch diff before PR publication, with strict gates for low-value tests and agentic prose. Use when asked to deslop, simplify, clean up, make a diff minimal, review test quality, tighten comments/docs/PR text, or remove AI-writing patterns such as rhetorical "X, not Y" contrasts. Apply fixes when the task authorizes code changes; otherwise report concrete findings.
+---
+
+# No-Slop Review
+
+## Load The Policies
+
+Read these before reviewing:
+
+- root `AGENTS.md`
+- root `TESTING.md`
+- `.agents/skills/writing-style/ai-writing-donts.md`
+- the nearest module `AGENTS.md` and testing guide for each changed test
+
+Read [references/examples.md](references/examples.md) when the diff changes tests
+or prose.
+
+## Establish The Review Surface
+
+Review the merge-base diff. Do not substitute commit history or the latest
+commit.
+
+```bash
+BASE=$(git merge-base HEAD origin/main)
+git status --short
+git diff --stat "$BASE"
+git diff --check "$BASE"
+git diff "$BASE"
+uv run python .agents/skills/noslop/scripts/scan_diff.py "$BASE"
+```
+
+List every changed test, comment, docstring, Markdown file, commit message, and
+draft PR title/body. Read the surrounding production code and existing tests.
+The scanner includes untracked files and returns candidates; inspect each one in
+context.
+
+## Gate Tests By Behavioral Value
+
+For every changed test, finish this sentence:
+
+> This test fails when ___ user-visible or system behavior is wrong.
+
+Delete or rewrite the test when the blank names an implementation detail,
+wording choice, supplied fixture value, or language guarantee.
+
+Reject these patterns aggressively:
+
+- config in, same config out: a constructed or lowered field equals the fixture
+- constructor assignment, enum value, type, attribute, registration, or import exists
+- exact log, help, error, command, or status prose that no machine consumes
+- private state, helper call count, or `assert_called_once_with`
+- production logic copied into the expected value
+- `is not None`, `does not raise`, empty smoke tests, or permanent skips
+- a large matrix whose rows exercise the same branch
+- golden output produced by the implementation under test
+
+Keep a test only when it protects a real boundary, regression, invariant,
+round-trip, state transition, persisted effect, wire contract, or numerical
+result against an independent reference.
+
+Prefer one strong test over several weak tests. Use scratch probes for wiring
+and construction checks. Do not check them in.
+
+## Delete Prose Slop
+
+Review every added or edited sentence in comments, docstrings, docs, reports,
+commit text, and PR text.
+
+Delete sentences that add no fact, result, decision, constraint, or caveat.
+Apply the full checklist in `ai-writing-donts.md`. Search explicitly for:
+
+- `X, not Y`, `not X, but Y`, `not just X`, `more than X`
+- `rather than` used as rhetorical contrast
+- `the main change`, `what this means`, `the real story`, `what matters`
+- `importantly`, `notably`, `it is worth noting`, `stepping back`
+- effort narration, section narration, recap paragraphs, and generic conclusions
+- unsupported adjectives and claims that outrun measurements
+- comments that describe an earlier version of the patch
+
+Rewrite retained prose as the concrete claim. Split a real comparison into two
+measured statements. Keep necessary negation such as `the test has not run`.
+
+Check prose against code and artifacts. A concise false claim is still slop.
+
+## Review The Diff As A Design
+
+After the test and prose passes, inspect each new file, helper, type, flag,
+dependency, compatibility path, and public API:
+
+1. Name its current consumer.
+2. Remove it when its consumer disappeared.
+3. Reuse an existing repository concept when it fits.
+4. Complete migrations; do not leave old and new paths active.
+5. Keep one-shot migration and debugging machinery outside reusable libraries.
+6. Remove stale comments, aliases, re-exports, shims, and defensive branches.
+
+## Fix And Verify
+
+When edits are authorized, make the cleanup. Do not stop at a findings table
+while safe fixes remain.
+
+Run the narrow affected tests, then:
+
+```bash
+./infra/pre-commit.py --changed-files --fix
+```
+
+Run `./infra/pre-commit.py --review` only at the point required by the commit
+workflow. Do not claim a clean pass while known findings remain.
+
+## Report
+
+Lead with what was removed or simplified. Report retained exceptions with their
+behavioral contract or evidence. If no edits were authorized, report findings
+as `path:line`, the maintenance cost, and the smallest fix.

--- a/.agents/skills/noslop/SKILL.md
+++ b/.agents/skills/noslop/SKILL.md
@@ -23,7 +23,8 @@ Review the merge-base diff. Do not substitute commit history or the latest
 commit.
 
 ```bash
-BASE=$(git merge-base HEAD origin/main)
+UPSTREAM=$(git rev-parse --verify origin/main 2>/dev/null || git rev-parse --verify main)
+BASE=$(git merge-base HEAD "$UPSTREAM")
 git status --short
 git diff --stat "$BASE"
 git diff --check "$BASE"

--- a/.agents/skills/noslop/agents/openai.yaml
+++ b/.agents/skills/noslop/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "No-Slop Review"
+  short_description: "Delete low-value tests and prose from diffs"
+  default_prompt: "Use $noslop to review this branch diff and remove low-value tests, prose, and leftover complexity."

--- a/.agents/skills/noslop/references/examples.md
+++ b/.agents/skills/noslop/references/examples.md
@@ -1,0 +1,97 @@
+# No-Slop Examples
+
+Use these examples to calibrate deletion. They are patterns, not templates to
+copy into review comments.
+
+## Tests
+
+### Configuration projection
+
+Delete:
+
+```python
+def test_resolve_cluster_name_prefers_cli_name():
+    config = IrisClusterConfig(name="from-config")
+    assert resolve_cluster_name(config, None, "from-cli") == "from-cli"
+```
+
+The test feeds a value through a trivial precedence branch and reads it back.
+Keep coverage only if precedence caused a real regression or crosses a public
+configuration boundary with nontrivial merge behavior.
+
+### Type checker duplication
+
+Delete:
+
+```python
+base = ResourceConfig.with_gpu("H100", count=8)
+assert isinstance(base.device, GpuConfig)
+```
+
+The constructor and return type already establish the type.
+
+### Incidental prose
+
+Delete:
+
+```python
+assert "retrying" in caplog.text
+```
+
+Test the retry effect, attempt count at the external boundary, or final state.
+Keep exact text only when another program parses it or the API promises it.
+
+### Self-generated golden
+
+Delete a golden generated from the same built-in schema or renderer being
+tested. Capture independent production evidence or assert the external behavior
+that the golden represents.
+
+## Prose
+
+### Stock contrast
+
+Delete or split:
+
+> The issue is not scheduling, but reconciliation.
+
+Prefer:
+
+> Reconciliation drops assigned tasks after a controller restart. Scheduling
+> assigns them correctly.
+
+### Empty framing
+
+Delete:
+
+> The mechanism is worth stating because it differs from the original ideas.
+
+Start with the mechanism.
+
+### Visible structure
+
+Delete:
+
+> The configuration has three parts, none of which affect numerics.
+
+Start the list. Include the numerics claim only with evidence.
+
+### Unsupported benefit
+
+Delete:
+
+> Running all arms on one allocation removes placement variance.
+
+If unmeasured, say nothing or write `The sequential harness has not been
+characterized for placement variance.`
+
+### Contradictory result
+
+A PR body that claims `12x faster` while its table shows no 12x comparison is
+wrong. Correct the prose or the table before polishing either one.
+
+## Deletion Signals
+
+Reassess the whole design when review removes a consumer, transport, command, or
+feature. Delete its helpers, tests, docs, flags, and compatibility paths in the
+same pass.

--- a/.agents/skills/noslop/scripts/scan_diff.py
+++ b/.agents/skills/noslop/scripts/scan_diff.py
@@ -12,38 +12,47 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-PROSE_SUFFIXES = {".md", ".rst", ".txt", ".py", ".rs", ".go", ".ts", ".tsx", ".js", ".jsx"}
+PROSE_SUFFIXES = frozenset({".md", ".rst", ".txt", ".py", ".rs", ".go", ".ts", ".tsx", ".js", ".jsx"})
 TEST_PATH = re.compile(r"(^|/)(tests?|test_[^/]+|[^/]+_test\.[^/]+)(/|$)")
-PATTERN_CATALOGS = {
+PATTERN_CATALOGS = (
     ".agents/skills/noslop/",
     ".agents/skills/writing-style/ai-writing-donts.md",
-}
+)
 
-PROSE_PATTERNS = {
-    "stock-contrast": re.compile(
-        r"(,\s*not\s+\w+|\bnot (?:just|only)\b.{0,80}\bbut|not\b.{0,80}\bbut|more than just|"
-        r"the question is no longer|the real story is|what matters (?:most )?is)\b",
-        re.IGNORECASE,
+PROSE_PATTERNS = (
+    (
+        "stock-contrast",
+        re.compile(
+            r"(,\s*not\s+\w+|\bnot (?:just|only)\b.{0,80}\bbut|not\b.{0,80}\bbut|more than just|"
+            r"the question is no longer|the real story is|what matters (?:most )?is)\b",
+            re.IGNORECASE,
+        ),
     ),
-    "bridge-prose": re.compile(
-        r"\b(the main change (?:is|here)|what this means is|stepping back|"
-        r"it is worth noting|importantly|notably|in this section|let'?s dive in)\b",
-        re.IGNORECASE,
+    (
+        "bridge-prose",
+        re.compile(
+            r"\b(the main change (?:is|here)|what this means is|stepping back|"
+            r"it is worth noting|importantly|notably|in this section|let'?s dive in)\b",
+            re.IGNORECASE,
+        ),
     ),
-    "ai-vocabulary": re.compile(
-        r"\b(crucial|pivotal|groundbreaking|seamless|tapestry|testament|"
-        r"interplay|landscape|delve|showcase|underscore|foster)\b",
-        re.IGNORECASE,
+    (
+        "ai-vocabulary",
+        re.compile(
+            r"\b(crucial|pivotal|groundbreaking|seamless|tapestry|testament|"
+            r"interplay|landscape|delve|showcase|underscore|foster)\b",
+            re.IGNORECASE,
+        ),
     ),
-}
+)
 
-TEST_PATTERNS = {
-    "weak-assertion": re.compile(r"\bassert\s+.+\s+is\s+not\s+None\b"),
-    "type-assertion": re.compile(r"\bassert\s+isinstance\("),
-    "mock-dispatch": re.compile(r"\bassert_(?:called|called_once|called_once_with|any_call)\b"),
-    "private-state": re.compile(r"\bassert\s+[^#\n]*\._[A-Za-z]"),
-    "log-text": re.compile(r"\b(?:caplog\.text|record\.message)\b"),
-}
+TEST_PATTERNS = (
+    ("weak-assertion", re.compile(r"\bassert\s+.+\s+is\s+not\s+None\b")),
+    ("type-assertion", re.compile(r"\bassert\s+isinstance\(")),
+    ("mock-dispatch", re.compile(r"\bassert_(?:called|called_once|called_once_with|any_call)\b")),
+    ("private-state", re.compile(r"\bassert\s+[^#\n]*\._[A-Za-z]")),
+    ("log-text", re.compile(r"\b(?:caplog\.text|record\.message)\b")),
+)
 
 
 @dataclass(frozen=True)
@@ -109,9 +118,9 @@ def main() -> int:
     findings: list[tuple[AddedLine, str]] = []
     for line in [*added_lines(base), *untracked_lines()]:
         if suffix(line.path) in PROSE_SUFFIXES and not is_pattern_catalog(line.path):
-            findings.extend((line, name) for name, pattern in PROSE_PATTERNS.items() if pattern.search(line.text))
+            findings.extend((line, name) for name, pattern in PROSE_PATTERNS if pattern.search(line.text))
         if TEST_PATH.search(line.path):
-            findings.extend((line, name) for name, pattern in TEST_PATTERNS.items() if pattern.search(line.text))
+            findings.extend((line, name) for name, pattern in TEST_PATTERNS if pattern.search(line.text))
 
     for line, name in findings:
         print(f"{line.path}:{line.line}: {name}: {line.text.strip()}")

--- a/.agents/skills/noslop/scripts/scan_diff.py
+++ b/.agents/skills/noslop/scripts/scan_diff.py
@@ -49,7 +49,7 @@ PROSE_PATTERNS = (
 TEST_PATTERNS = (
     ("weak-assertion", re.compile(r"\bassert\s+.+\s+is\s+not\s+None\b")),
     ("type-assertion", re.compile(r"\bassert\s+isinstance\(")),
-    ("mock-dispatch", re.compile(r"\bassert_(?:called|called_once|called_once_with|any_call)\b")),
+    ("mock-dispatch", re.compile(r"\bassert_(?:called(?:_once)?(?:_with)?|any_call)\b")),
     ("private-state", re.compile(r"\bassert\s+[^#\n]*\._[A-Za-z]")),
     ("log-text", re.compile(r"\b(?:caplog\.text|record\.message)\b")),
 )

--- a/.agents/skills/noslop/scripts/scan_diff.py
+++ b/.agents/skills/noslop/scripts/scan_diff.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Print high-signal test and prose candidates from added diff lines."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+PROSE_SUFFIXES = {".md", ".rst", ".txt", ".py", ".rs", ".go", ".ts", ".tsx", ".js", ".jsx"}
+TEST_PATH = re.compile(r"(^|/)(tests?|test_[^/]+|[^/]+_test\.[^/]+)(/|$)")
+PATTERN_CATALOGS = {
+    ".agents/skills/noslop/",
+    ".agents/skills/writing-style/ai-writing-donts.md",
+}
+
+PROSE_PATTERNS = {
+    "stock-contrast": re.compile(
+        r"(,\s*not\s+\w+|\bnot (?:just|only)\b.{0,80}\bbut|not\b.{0,80}\bbut|more than just|"
+        r"the question is no longer|the real story is|what matters (?:most )?is)\b",
+        re.IGNORECASE,
+    ),
+    "bridge-prose": re.compile(
+        r"\b(the main change (?:is|here)|what this means is|stepping back|"
+        r"it is worth noting|importantly|notably|in this section|let'?s dive in)\b",
+        re.IGNORECASE,
+    ),
+    "ai-vocabulary": re.compile(
+        r"\b(crucial|pivotal|groundbreaking|seamless|tapestry|testament|"
+        r"interplay|landscape|delve|showcase|underscore|foster)\b",
+        re.IGNORECASE,
+    ),
+}
+
+TEST_PATTERNS = {
+    "weak-assertion": re.compile(r"\bassert\s+.+\s+is\s+not\s+None\b"),
+    "type-assertion": re.compile(r"\bassert\s+isinstance\("),
+    "mock-dispatch": re.compile(r"\bassert_(?:called|called_once|called_once_with|any_call)\b"),
+    "private-state": re.compile(r"\bassert\s+[^#\n]*\._[A-Za-z]"),
+    "log-text": re.compile(r"\b(?:caplog\.text|record\.message)\b"),
+}
+
+
+@dataclass(frozen=True)
+class AddedLine:
+    path: str
+    line: int
+    text: str
+
+
+def added_lines(base: str) -> list[AddedLine]:
+    result = subprocess.run(
+        ["git", "diff", "--unified=0", "--no-ext-diff", base, "--"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    path = ""
+    new_line = 0
+    lines: list[AddedLine] = []
+    for raw in result.stdout.splitlines():
+        if raw.startswith("+++ b/"):
+            path = raw[6:]
+            continue
+        if raw.startswith("@@"):
+            match = re.search(r"\+(\d+)", raw)
+            assert match is not None
+            new_line = int(match.group(1))
+            continue
+        if raw.startswith("+") and not raw.startswith("+++"):
+            lines.append(AddedLine(path, new_line, raw[1:]))
+            new_line += 1
+        elif not raw.startswith("-") and not raw.startswith("\\"):
+            new_line += 1
+    return lines
+
+
+def untracked_lines() -> list[AddedLine]:
+    result = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard", "-z"],
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    paths = result.stdout.decode().split("\0")
+    lines: list[AddedLine] = []
+    for path in filter(None, paths):
+        if suffix(path) not in PROSE_SUFFIXES and not TEST_PATH.search(path):
+            continue
+        lines.extend(AddedLine(path, index, text) for index, text in enumerate(Path(path).read_text().splitlines(), 1))
+    return lines
+
+
+def suffix(path: str) -> str:
+    dot = path.rfind(".")
+    return path[dot:] if dot >= 0 else ""
+
+
+def is_pattern_catalog(path: str) -> bool:
+    return any(path == candidate or path.startswith(candidate) for candidate in PATTERN_CATALOGS)
+
+
+def main() -> int:
+    base = sys.argv[1] if len(sys.argv) == 2 else "origin/main"
+    findings: list[tuple[AddedLine, str]] = []
+    for line in [*added_lines(base), *untracked_lines()]:
+        if suffix(line.path) in PROSE_SUFFIXES and not is_pattern_catalog(line.path):
+            findings.extend((line, name) for name, pattern in PROSE_PATTERNS.items() if pattern.search(line.text))
+        if TEST_PATH.search(line.path):
+            findings.extend((line, name) for name, pattern in TEST_PATTERNS.items() if pattern.search(line.text))
+
+    for line, name in findings:
+        print(f"{line.path}:{line.line}: {name}: {line.text.strip()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/noslop/scripts/scan_diff.py
+++ b/.agents/skills/noslop/scripts/scan_diff.py
@@ -113,8 +113,20 @@ def is_pattern_catalog(path: str) -> bool:
     return any(path == candidate or path.startswith(candidate) for candidate in PATTERN_CATALOGS)
 
 
+def default_base() -> str:
+    for candidate in ("origin/main", "main"):
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", candidate],
+            check=False,
+            stdout=subprocess.DEVNULL,
+        )
+        if result.returncode == 0:
+            return candidate
+    raise SystemExit("cannot find origin/main or main; pass a base revision")
+
+
 def main() -> int:
-    base = sys.argv[1] if len(sys.argv) == 2 else "origin/main"
+    base = sys.argv[1] if len(sys.argv) == 2 else default_base()
     findings: list[tuple[AddedLine, str]] = []
     for line in [*added_lines(base), *untracked_lines()]:
         if suffix(line.path) in PROSE_SUFFIXES and not is_pattern_catalog(line.path):

--- a/.agents/skills/writing-style/ai-writing-donts.md
+++ b/.agents/skills/writing-style/ai-writing-donts.md
@@ -1,178 +1,98 @@
 # AI-Writing Don'ts
 
-Use this file for the final prose-only review pass. It captures common LLM
-writing tells that should be removed from Marin-authored text.
+Use this as the final prose pass for agent-written Marin text. Delete first.
+Rewrite only when the sentence carries a fact, decision, result, constraint, or
+caveat.
 
-These are warning signs, not strict proofs, but agent-written text should be
-scrubbed against them aggressively.
+## Cut Empty Sentences
 
-## Prefer Direct Replacements
+Delete a sentence when removing it loses no information. Common waste:
 
-- Replace abstract bridge sentences with a concrete fact, result, decision, or caveat.
-- Replace `the main change is...` with the actual change.
-- Replace `the question is...` with the actual open question, or delete the sentence.
-- Replace `the current state is...` with the state itself.
-- Replace meta-summary prose with direct claims such as `X happened`, `X is better`, `X is still unknown`, or `we have not tested X`.
+- bridge prose: `The main change is...`, `Stepping back...`, `What this means is...`
+- importance claims: `Importantly`, `It is worth noting`, `This is the key point`
+- stage directions: `Let's dive in`, `Here is a summary`, `In this section...`
+- effort narration: `After extensive investigation...`
+- generic conclusions, recaps, future-work sections, and chatbot sign-offs
+- prose that restates a heading, list length, table, diff, or visible structure
 
-## Apply A Paragraph-Level Concrete Test
+Start with the fact. End when the useful information ends.
 
-- Every paragraph should contain at least one concrete noun, result, decision, configuration, issue number, model name, command, metric, or caveat.
-- If a paragraph has no numbers, named configs, named models, named issues, explicit decisions, or explicit unknowns, rewrite or delete it.
-- Introductions and conclusions are not exempt by default. They may stay abstract only if they provide a real summary, framing constraint, or decision.
+## Ban Stock Contrast
 
-## Delete Bridge Sentences
+Remove rhetorical templates built around a staged opposition:
 
-- If a sentence can be deleted without losing factual content, delete it.
-- Transition by ordering the facts well, not by narrating the transition.
-- Delete lines like `The main change here is...`, `So the current state is...`, `What changed is...`, `The right summary is...`, or `Stepping back, ...` unless they add a real caveat or decision.
+- `X, not Y`
+- `not X, but Y`
+- `not just X, but also Y`
+- `more than X`
+- `the question is no longer X; it is Y`
+- `the real story is X`
+- `what matters is X`
+- `rather than Y` when no real comparison is being made
 
-## Do Not Add Empty Importance Framing
+State X directly. Split real comparisons into plain claims.
 
-- Do not write sentences that announce significance without adding content.
-- Delete openings like `This is the part many people miss`, `This is where things get interesting`, `It is worth noting that`, or `Importantly`.
-- Delete claims that a detail `marks a pivotal shift`, `underscores the importance`, `reflects a broader trend`, or `serves as a testament` unless the next clause names a concrete mechanism, result, or decision.
-- Do not inflate ordinary facts into milestone language. Most facts are just facts.
-- Do not use adjectives to imply evidence you have not shown: `crucial`, `pivotal`, `significant`, `transformative`, `groundbreaking`, `robust`, `powerful`, `seamless`.
-- Replace significance language with the concrete thing that made it matter.
+Bad:
 
-## Do Not Use Stock AI Rhetorical Templates
+> The issue is not query execution, but the metadata path.
 
-- Do not write `not just X, but Y`, `not X, but Y`, `more than just X`, or `it's not only X, it's also Y`.
-- Do not write `the main change is not X, it is Y`, `the question is no longer X`, `not that X is done, but Y`, or similar contrast framing in analysis prose.
-- Do not use `rather than` for rhetorical contrast when there is no real side-by-side comparison.
-- Do not use TED-talk transitions like `What this means is`, `The key takeaway here is`, `At its core`, or `In many ways`.
-- Do not use stagey reveal lines like `The real story is`, `What matters most is`, or `The answer lies in`.
-- Do not use vague thesis templates like `X is more than a tool; it is a framework for...`.
-- Do not use balanced-sounding filler such as `both a challenge and an opportunity`, `while powerful, it also raises important questions`, or `this highlights the delicate balance between`.
-- Replace contrast framing with plain statements of the actual result.
-- Prefer rewrites like these:
-- Instead of `the main change is...`, write the change directly: `Quadratic decay now leads the sweep.`
-- Instead of `the question is no longer X, but Y`, split it into two plain statements: `X is settled in this sweep. Y is still open.` Or just "Y is still open" if X is not worth mentioning and not in context.
-- Instead of `not just X, but Y`, write `X, and Y` or just `Y` if X is not worth mentioning and not in context.
-- Instead of `What this means is...`, state the implication directly: `This makes restart time the main bottleneck.`
-- Instead of `At its core...`, state the mechanism directly: `The kernel is memory-bound, not compute-bound.`
+Better:
 
-## Do Not Regress To Generic Abstractions
+> Metadata loading takes 12 seconds. Query execution takes 400 ms.
 
-- Do not replace a specific fact with a broad abstraction.
-- If there is not a specific fact to state, delete the sentence rather than writing a vague generalization. TL;DR sections are not exempt from this rule.
-- Prefer `we shard the checkpoint by layer to reduce restart time` over `this improves system efficiency`.
-- Do not end paragraphs by zooming out to `the broader landscape`, `the evolving ecosystem`, `the future of`, or `the wider field` unless that zoom-out is necessary for the argument.
-- Do not add generic `legacy`, `impact`, `significance`, `importance`, or `future directions` paragraphs to sound complete. Replace them with the actual impact, significance, or future direction if it is known, or delete them if it is not.
-- Do not write conclusions that could apply to almost any ML project. Replace them with the actual conclusion that applies to this project or delete them if there is no real conclusion. Especially in summaries, issues, and internal communication, it is better to have no conclusion than a generic one.
-- Replace abstract claims with the named thing that changed, won, failed, or remains unknown.
+Bad:
 
-## Do Not Pad With Vague Analysis
+> The change improves reliability, not just performance.
 
-- Do not summarize a technical choice as `showcasing the interplay between performance and scalability`.
-- Do not write `this demonstrates how innovation and collaboration can drive progress`. Let the facts speak for themselves.
-- Do not use `various`, `numerous`, `many`, `widely`, or `in some cases` when you can name the thing. If you cannot name the thing, consider deleting the sentence.
-- Do not use vague attribution such as `some people argue`, `many believe`, `it is often seen as`, or `critics point out` without naming who or citing a source.
-- Do not manufacture a takeaway when the honest statement is simply `we have not tested this yet`.
-- Replace mushy analysis with one of: the observed result, the current caveat, the decision taken, or the next unresolved question.
+Better:
 
-## Do Not Sound Like A Generic Explainer
+> Median latency fell 18%. Failed retries fell from 7 to 0.
 
-- Do not narrate the act of writing: `In this section, we will explore`, `Let's dive in`, `Here we can see`, `Before we begin`. You can write an introduction that sets up the section, but it should not be a meta-commentary on the writing process.
-- After a heading, lead with the behavior, result, or constraint, not with an announcement that the topic matters.
-- Do not treat headings as cues to switch into announcement voice. Example: under `## Checkpointing`, do not write `Checkpointing is a critical part of any robust training pipeline.` Instead, write `We shard the checkpoint by layer to reduce restart time.`
-- Do not add recap paragraphs after every section if the section was already clear.
-- Do not use FAQ voice in prose that is not actually a FAQ.
-- Do not write teacherly reassurance such as `don't worry if this seems complex` unless the medium specifically calls for it.
+Grammatical negation is fine when the negative fact matters: `The ablation has
+not run.` A measured comparison is fine when both sides matter.
 
-## Do Not Use Chatbot Meta-Communication
+## Require Evidence
 
-- Do not write `I hope this helps`, `let me know if you'd like`, `happy to`, or similar assistant-signoff language in Marin-authored prose. You can simply end with the last fact, decision, call-to-action, or caveat without adding a closing sentence.
-- Do not leave prompt-shaped leftovers like `Here is a revised version`, `Below is a summary`, or `Key takeaways:`.
+- Name the code path, configuration, issue, artifact, measurement, or unknown.
+- Replace adjectives with evidence. Delete `robust`, `powerful`, `seamless`,
+  `significant`, `crucial`, and `pivotal` unless a concrete result follows.
+- Say `we have not tested X` when evidence is missing.
+- Keep prose consistent with tables, code, and current behavior.
+- Remove stale explanations after the implementation changes.
+- Use one precise term for one technical object.
 
-## Do Not Use AI Vocabulary Clusters
+## Avoid LLM Cadence
 
-- Watch for clusters of words such as `crucial`, `pivotal`, `underscore`, `highlight`, `showcase`, `delve`, `foster`, `enhance`, `align with`, `valuable`, `vibrant`, `landscape`, `interplay`, `intricate`, `tapestry`, `testament`, `quiet`.
-- One occurrence may be fine. Several in one page usually means the prose has drifted into generic LLM style.
-- Replace them with direct verbs and nouns that name the actual action or result.
+- Skip adjective trios and forced rules of three.
+- Skip `Additionally`, `Furthermore`, `Moreover`, `Importantly`, and `Notably`.
+- Skip `landscape`, `ecosystem`, `interplay`, `tapestry`, `testament`, `delve`,
+  `showcase`, `underscore`, and `foster`.
+- Avoid em-dash asides. Make the point a sentence or delete it.
+- Avoid bold labels, takeaway boxes, and decorative headings.
+- Do not rotate synonyms for the same object.
 
-## Do Not Force Variety At The Cost Of Precision
+## Score Every Paragraph
 
-- Do not rotate through synonyms for the same technical object just to avoid repetition.
-- If the thing is a `checkpoint`, keep calling it a `checkpoint` unless there is a real distinction.
-- Do not rename the same thing as `the system`, `the framework`, `the platform`, `the stack`, and `the pipeline` in adjacent paragraphs.
-- Prefer exact repetition over fake elegance.
+Each paragraph must contain a concrete result, setup, decision, constraint, or
+caveat. Rewrite or delete paragraphs that only frame significance or smooth a
+transition.
 
-## Do Not Use Listicle Cadence
+Ask of every sentence:
 
-- Do not force the rule of three just because it sounds polished.
-- Rewrite sequences like `fast, flexible, and scalable` into a concrete claim or drop them.
-- Do not pile up adjective trios or noun trios to simulate completeness.
-- Do not use inline-header list patterns such as `Why it matters:` followed by vague bullets unless the bullets add real information.
-- Do not use boldface as a substitute for structure.
+1. What information disappears if I delete it?
+2. Can I replace it with a number, named fact, decision, or explicit unknown?
+3. Does it still describe the current code and evidence?
+4. Could it appear unchanged in a random software announcement?
 
-## Do Not Hide Simple Claims Behind Fancy Grammar
+Delete sentences that fail this check.
 
-- Prefer `X is Y` when it is correct.
-- Do not contort sentences to avoid plain copular statements.
-- Do not write long dependent-clause openings when the main clause is short and concrete.
-- Do not stack transitions like `Additionally`, `Furthermore`, `Moreover`, `Importantly`, `Notably` at the start of consecutive sentences.
-- Do not use em dashes to splice in every aside. If the aside matters, make it its own sentence.
-- When possible, rewrite as one of: `X changed`, `X is better`, `X is worse`, `X is still unknown`, `we have not tested X`, `we chose X because Y`.
+## Prefer Plain Rewrites
 
-## Do Not Fill Gaps With Speculation
+- `The main change is that retries are bounded.` → `Retries stop after five attempts.`
+- `This highlights a scalability problem.` → `Registration takes 1.2 seconds for 100 workers.`
+- `The current state is much clearer.` → Name the resolved and open questions.
+- `This is procedural progress.` → `The code is ready. The ablation has not run.`
+- `The configuration has three parts:` → Start the list.
 
-- Do not write around missing evidence with phrases like `details are limited`, `based on available information`, or `while not widely documented`. Admit the gap instead of trying to paper over it.
-- Do not speculate about motives, significance, private context, or hidden constraints to smooth over uncertainty.
-- If a fact is unknown, say it is unknown or omit it.
-- Do not hedge with polished filler that sounds informed but is unsupported.
-- If there is not much progress to report in a progress report, say so.
-
-## Do Not Add Cosmetic Structure That Looks Smart
-
-- Do not add a summary, takeaway box, or future-work section unless it helps the reader act.
-- Do not use tables for prose comparisons that read better as sentences. However, tables are preferred for actual data, ablation results, or configuration sweeps.
-- Do not over-title-case headings or sprinkle bold labels through ordinary paragraphs.
-- Do not add a `Challenges and opportunities` section by reflex.
-- Do not end with a grand summary if a short concrete closing sentence will do.
-
-## Do Not Over-Format The Page
-
-- Do not use boldface to make ordinary prose feel more important.
-- Do not skip heading levels or add structure that implies depth the piece does not have.
-- Do not use emojis, flourish punctuation, or stylized subject-line prose to create energy.
-
-## Quick Negative Examples
-
-- `This is the part many people miss.` -> Just omit, and consider whether the next sentence is actually important.
-- `This marks a pivotal shift in the broader landscape.` -> Just omit, and consider whether the prior sentence is actually important.
-- `Marin is not just a framework, but a testament to open innovation.` -> Just omit. Let the facts speak for themselves.
-- `This highlights the intricate interplay between scalability, flexibility, and performance.` -> Omit
-- `As the ecosystem continues to evolve, this work will likely play an important role.` -> Just omit, and consider whether the next sentence is actually important.
-
-## Bad / Better Rewrites
-
-- Bad: `The main change here is that the surrounding schedule and capacity choices are becoming much better grounded.`
-- Better: `Quadratic decay now leads the schedule sweep, and \`cf=1.0\` looks faster than \`cf=1.25\` with a small measured quality hit.`
-- Bad: `The optimizer question is still open, but the main change this week was on schedules.`
-- Better: `Quadratic decay now leads the schedule sweep. AdamH vs Adam is still open.`
-- Bad: `This is still mostly procedural progress.`
-- Better: `The code is ready, but the ablation has not run yet.` or `Issues have been created, but the ablation has not run yet.`
-- Bad: `The question is no longer whether schedules matter, but how to integrate them into the broader training picture.`
-- Better: `Schedules matter in this sweep. The open question is whether the win survives at larger scale.`
-- Bad: `What changed is that the current state is much clearer than it was before.`
-- Better: `The sweep removed two weak settings, and the remaining comparison is quadratic decay vs cosine.`
-
-## Quick Rewrite Heuristic
-
-- If a sentence could survive unchanged in a random SaaS blog post, delete or rewrite it.
-- If a sentence mainly gestures at significance, replace it with the concrete fact.
-- If you can swap in three different project names and the sentence still sounds right, it is too generic.
-
-## Final Compression Pass
-
-- After drafting, remove every sentence that only comments on the state of the writing, framing, significance, or process unless it adds a decision, result, or caveat.
-- Read each paragraph and cut any sentence whose only job is to introduce, summarize, or soften the sentence that follows it.
-- Keep transition sentences only when they carry real information.
-
-## Paragraph Scoring Rubric
-
-- For each paragraph, ask: does it state a result, setup, caveat, or decision?
-- If not, rewrite or delete it.
-- If yes, ask: is that information stated directly, or hidden behind framing language?
-- Prefer deletion over polishing when a sentence adds no content.
+Finish with a search for stock contrast, bridge phrases, unsupported adjectives,
+and stale claims. Prefer a shorter accurate document.


### PR DESCRIPTION
Add a branch-diff review skill for removing low-value tests, agent-written prose, and leftover implementation paths before publication. Its advisory scanner checks modified and untracked files for weak assertions, implementation-detail tests, stock contrasts, bridge prose, and stale AI vocabulary. Reviewers inspect each candidate in context.

Compress the shared AI-writing guide around deletion, concrete evidence, and direct claims. The guide explicitly bans stock contrast templates such as `X, not Y` and `not X, but Y`. Necessary negation and measured comparisons remain allowed.
