### PR TITLE
[echo] Retain searches and seed operational guidance

### DIFF
--- a/.agents/logbooks/echo-pre-seed.md
+++ b/.agents/logbooks/echo-pre-seed.md
@@ -1,0 +1,97 @@
+---
+topic: echo-pre-seed
+description: Persist Echo searches, grade observed queries, and pre-seed durable answers
+author: russell.power
+---
+
+# Echo Pre-Seed Search Quality: Research Logbook
+
+## Scope
+
+- Goal: Preserve Echo search traffic, grade a fixed observed-query baseline, and stage supported wiki and core-document improvements for bulk review.
+- Primary metrics: Query-level 0–10 answer quality, direct-answer rank, held-out paraphrase rank, and existing benchmark regressions.
+- Constraints: Keep query history indefinitely; omit network identity; stage all content before bulk upload; reserve OPS.md, AGENTS.md, and skills for frequent workflows.
+- Coordinating issue: https://github.com/marin-community/marin/issues/8203
+- Experiment prefix: `ECHO-SEED`.
+
+## Current TL;DR
+
+- Cloud Logging retains two days of Echo request URLs. The preserved slice contains 355 federated searches with 338 unique normalized queries and 94 grep requests with 88 unique patterns.
+- Echo stores 51 feedback submissions and 138 per-result grades. These judgments were agent-authored and will not calibrate the new grader.
+- The initial federated discovery and regression pool contains 413 unique queries: 338 retained searches, one feedback-only query, and 74 existing benchmark cases.
+- Search execution persistence is live on Echo revision `echo-api-00024-vtc`. The first verified execution stored the exact query, authenticated author, selected domains, repository commit, duration, and five ranked results.
+- The 413-query replay is complete. Luna/medium has graded every case with a fresh rubric; Sol/medium is adjudicating low, middling, and documentation-routed cases before content drafting.
+
+## Current Baseline
+
+- Date: 2026-08-12.
+- Code: `288d91aa23461d1fbc996fef98ac45757ac8910b`.
+- Observed federated traffic: 355 executions, 338 normalized unique queries, all HTTP 200.
+- Existing feedback: 51 queries, 138 grades, 45 graded submissions, six explanation-only submissions.
+- Existing source-grounded benchmark: 74 queries.
+
+## Hypothesis Queue
+
+### Active
+
+- `ECHO-SEED-001`: Persisting ranked search executions will make feedback and before/after comparisons replayable. Next test: API persistence tests for successful, empty, and domain-filtered searches.
+- `ECHO-SEED-002`: A fresh Luna/medium rubric can separate content gaps from retrieval failures over the 413-query pool. Next test: blind double-grade an initial batch and inspect disagreement.
+- `ECHO-SEED-003`: Intent-clustered wiki and core-document additions will improve direct-answer rank on original queries and held-out paraphrases without regressing the 74-case benchmark. Next test: first staged wave after grading.
+
+### Blocked
+
+- None.
+
+### Falsified / Dead End
+
+- None.
+
+### Promoted
+
+- None.
+
+## Decision Log
+
+- 2026-08-12: Retain query history indefinitely. Storage cost is negligible at current volume.
+- 2026-08-12: Use a fresh grading rubric; existing feedback was agent-authored.
+- 2026-08-12: Fetch full result sources lazily during grading and cache by stable source identity or content hash.
+- 2026-08-12: Put frequent, everyday workflows in OPS.md, AGENTS.md, or skills. Use wiki notes for less frequent events; overlap that expands core guidance is acceptable.
+- 2026-08-12: Stage every wiki and core-document proposal, summarize each wave, then bulk upload after review.
+- 2026-08-12: Core-document improvements are in scope.
+- 2026-08-12: Do not add a historical backfill endpoint or import result-less log rows. Replay each unique preserved query through normal search so the durable record contains its current ranked results.
+
+## Negative Results Index
+
+- Cloud Logging cannot recover the complete history: the live `_Default` bucket retains two days.
+
+## Entry Log
+
+### 2026-08-12 19:40 UTC - ECHO-SEED-001 traffic and feedback canvass
+
+- Hypothesis: Existing infrastructure contains enough query history to bootstrap a useful discovery set.
+- Commit Hash: `288d91aa23461d1fbc996fef98ac45757ac8910b` before implementation.
+- Commands: Read-only `gcloud logging read` over `echo-api`; `_Default` bucket inspection; aggregate SQL over `search_feedback` and `search_feedback_grades`; benchmark manifest inspection.
+- Config: `hai-gcp-models`, Cloud Run service `echo-api`, Cloud SQL database `context`.
+- Result: Preserved 355 federated executions and 94 grep executions from the two-day window. Found 338 unique federated queries, 51 feedback queries with one query absent from the log slice, and 74 non-overlapping benchmark queries.
+- Interpretation: The 413-query federated pool supports a first grading pass. Future searches require database persistence because request logs expire.
+- Next action: Add search execution and ranked-result persistence, then import the sanitized retained slice.
+
+### 2026-08-12 21:25 UTC - ECHO-SEED-001 permanent search retention deployed
+
+- Hypothesis: Every Echo search can retain enough context to reproduce and grade the result set later.
+- Commit Hash: Uncommitted branch deployment from `weaver/echo-seed-articles`; schema migration based on `288d91aa23461d1fbc996fef98ac45757ac8910b`.
+- Commands: Applied `m0011_search_history` with `infra/echo/migrate.py`, previewed the `marin-echo` stack, deployed with Pulumi, ran one live federated search, and exported its execution.
+- Config: Echo revision `echo-api-00024-vtc`; indexed repository commit `26b338faddffbab89cc497d3fd0c64570842ffa1`.
+- Result: Execution 1 stored `how do I deploy Iris?`, caller attribution, four selected domains, five ordered result snapshots, and an 18.6-second server duration. The response exposed execution ID 1 for feedback linkage.
+- Interpretation: ECHO-SEED-001 is supported. Future search and feedback data is replayable without relying on expiring Cloud Logging.
+- Next action: Replay the deduplicated 413-query manifest at four workers, then grade the persisted executions.
+
+### 2026-08-12 23:10 UTC - ECHO-SEED-002 baseline replay and Luna grading
+
+- Hypothesis: The retained traffic and benchmark pool can be replayed through the ordinary search contract and graded without a separate history-import API.
+- Commit Hash: Uncommitted branch deployment from `weaver/echo-seed-articles`; indexed repository commit `26b338faddffbab89cc497d3fd0c64570842ffa1`.
+- Commands: Replayed `echo-baseline-manifest.jsonl` through `GET /api/federated-search`; reconciled responses against `GET /api/search-executions`; graded the joined snapshots in three Luna/medium batches plus a tail batch.
+- Config: 413 unique queries, result limit 10, at most four concurrent requests, fresh query-level 0–10 rubric.
+- Result: All 413 cases have durable execution IDs and ranked snapshots. The raw Luna pass produced 198 keep, 118 ranking/index, 35 wiki, two core-doc, 20 review, and 40 ephemeral/no-answer dispositions. The 106 low, middling, review, and documentation-routed cases require Sol adjudication before drafting.
+- Interpretation: Normal search plus durable reconciliation is sufficient for historical replay. The first raw content count is intentionally an upper bound because snippet-only grading confuses retrieval defects and ephemeral requests with documentation gaps.
+- Next action: Complete Sol adjudication, cluster supported gaps, then stage evidence-backed wiki and core-document proposals in Weaver.

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -56,6 +56,11 @@ live-cluster, Docker, and manual markers by default. Do not pass `-m 'not slow'`
 `-m` replaces the whole default expression, so it re-selects the cluster and
 Docker tests it looks like it is narrowing.
 
+The root pytest configuration loads `marin.pytest_timeout_guard`. Keep that package
+importable in any selected test environment. The guard dumps thread state and starts a
+delayed hard-kill timer when a signal-based timeout cannot stop a test; an import failure
+is a test-environment error, not a product-test failure.
+
 ### Opening a pull request
 
 Before opening a pull request:

--- a/docs/tutorials/first-experiment.md
+++ b/docs/tutorials/first-experiment.md
@@ -176,6 +176,26 @@ StepRunner().run([lower(build())], force_run_failed=False)
 Remove the artifact directory, then rerun the script. Alternatively, bump the `version`
 in `train_lm` to produce a new artifact at a new path without touching the old one.
 
+### Checked-in smoke launcher
+
+The repository also includes a small launcher for checking the standard training path.
+It prints its plan by default; pass `--run` to execute it. Use `--version dev` while
+iterating, or a calendar version to pin outputs:
+
+```bash
+# Print the CPU/TinyStories plan.
+uv run python -m experiments.tutorials.train_tiny_model \
+  --device cpu --dataset tinystories --version dev
+
+# Run on an Iris H100 worker.
+uv run python -m experiments.tutorials.train_tiny_model \
+  --device h100x8 --dataset wikitext --version dev --run
+```
+
+If the launcher appears to do nothing, check whether `--run` was omitted. It also accepts
+`h100x1`, `gb200x1`, `gb200x4`, `v5litepod-16`, and `v6e-4`. TinyStories and WikiText
+tokenize a 1,000-document sample; `fineweb-edu` uses the checked-in pretokenized cache.
+
 ## Next steps
 
 - Train a full [1B parameter model](train-an-lm.md) using the DCLM mixture.

--- a/infra/echo/README.md
+++ b/infra/echo/README.md
@@ -107,6 +107,8 @@ latency and an additional prompt-injection path.
 measurement covers token acquisition, the network request, server retrieval and
 reranking, and response decoding: the time the caller waited for Echo.
 
+### Record and inspect search feedback
+
 Submit useful or poor results with `feedback`. A search prints its durable execution ID;
 pass it with `--execution-id` so each judgment is tied to the exact ranked result set.
 Repeat `--grade <result-id>=<0-10>` for
@@ -122,6 +124,13 @@ does not persist request headers, user agents, or network addresses in these tab
 `history export` pages through the durable records as JSONL, including ranked result
 snapshots. Historical query manifests can be replayed through normal search so each
 record captures current results under the same contract as future traffic.
+
+Use the durable export for retrieval analysis. Cloud Logging request lines are operational
+telemetry and do not preserve the execution-to-result relationship:
+
+```bash
+uv run infra/echo/cli.py history export > echo-search-history.jsonl
+```
 
 The scheduled sync checks GitHub at most once per hour. An unchanged head only advances
 the check time. A new head uses GitHub's compare API to delete, fetch, and re-embed

--- a/infra/echo/README.md
+++ b/infra/echo/README.md
@@ -16,6 +16,10 @@ provides an IAP-gated HTTP interface and browser dashboard.
 - `work_log` is an append-only agent logbook with one row per distilled milestone.
 - `search_feedback` records the query, IAP-authenticated caller, and short overall
   explanation. `search_feedback_grades` stores its result IDs and 0–10 grades.
+- `search_executions` permanently records every API search, including its normalized
+  query, mode, selected domains and filters, result count, latency, indexed repository
+  commit, and service revision. `search_execution_results` snapshots the returned rank,
+  metadata, and snippets so later evaluations reproduce what the caller saw.
 
 ## CLI
 
@@ -26,9 +30,10 @@ uv run infra/echo/cli.py search "expert parallel MoE MFU on B200" --limit 10
 uv run infra/echo/cli.py search "ragged_all_to_all" --domain file --domain pr
 uv run infra/echo/cli.py get file:lib/iris/OPS.md
 uv run infra/echo/cli.py feedback --query "how do I deploy Iris?" \
-  --grade wiki:123=0 --grade file:lib/iris/OPS.md=10 <<'EOF'
+  --execution-id 1234 --grade wiki:123=0 --grade file:lib/iris/OPS.md=10 <<'EOF'
 The file result answered the question; the wiki result did not.
 EOF
+uv run infra/echo/cli.py history export > echo-search-history.jsonl
 uv run infra/echo/cli.py grep ragged_all_to_all --source discord
 uv run infra/echo/cli.py wiki search "grafana access" --tag ops
 uv run infra/echo/cli.py wiki add --file note.md          # OKF markdown document
@@ -102,12 +107,21 @@ latency and an additional prompt-injection path.
 measurement covers token acquisition, the network request, server retrieval and
 reranking, and response decoding: the time the caller waited for Echo.
 
-Submit useful or poor results with `feedback`. Repeat `--grade <result-id>=<0-10>` for
+Submit useful or poor results with `feedback`. A search prints its durable execution ID;
+pass it with `--execution-id` so each judgment is tied to the exact ranked result set.
+Repeat `--grade <result-id>=<0-10>` for
 the results you evaluated, where 0 means irrelevant and 10 means directly useful to the
 task. The exact query makes each judgment replayable against a future search version.
 A short overall explanation is required on stdin. Capture the result set's gestalt
 without restating each score. An explanation without grades can describe an empty or
-globally poor result set.
+globally poor result set. When an execution ID is supplied, the caller and query must
+match and every graded result must have appeared in that recorded execution.
+
+Search history is retained indefinitely for internal search-quality work. The service
+does not persist request headers, user agents, or network addresses in these tables.
+`history export` pages through the durable records as JSONL, including ranked result
+snapshots. Historical query manifests can be replayed through normal search so each
+record captures current results under the same contract as future traffic.
 
 The scheduled sync checks GitHub at most once per hour. An unchanged head only advances
 the check time. A new head uses GitHub's compare API to delete, fetch, and re-embed
@@ -156,8 +170,9 @@ A pg_trgm GIN index on chunks.text makes the substring match an index scan.
 Direct SQL access remains available for raw queries through Cloud SQL IAM group
 authentication. Members of `eng-all@openathena.ai` inherit `roles/cloudsql.instanceUser`,
 `roles/cloudsql.client`, `SELECT` on `chunks`, `repository_file_chunks`,
-`repository_index_state`, `wiki_entries`, `search_feedback`, and
-`search_feedback_grades`, and `SELECT, INSERT` on `work_log`; the `loom-vm` service
+`repository_index_state`, `wiki_entries`, `search_feedback`,
+`search_feedback_grades`, `search_executions`, and `search_execution_results`, and
+`SELECT, INSERT` on `work_log`; the `loom-vm` service
 account receives the same access. No database password is shared.
 Group membership and IAM changes can take about 15 minutes to propagate.
 
@@ -177,6 +192,7 @@ the activity corpus and wiki notes. The same service exposes OpenAPI documentati
 - `GET /api/wiki/search`
 - `GET /api/wiki/{id}`
 - `POST /api/feedback`
+- `GET /api/search-executions`
 - `POST /api/wiki`
 - `PUT /api/wiki/{id}`
 - `POST /api/wiki/{id}/references`
@@ -197,9 +213,14 @@ defaults, and displayed commit length used by the dashboard. The CLI's `get` com
 uses the existing wiki and activity detail endpoints plus
 `GET /api/repository-files/{path}` for complete indexed files.
 
+Every successful search response includes `X-Echo-Search-Execution-ID` and is stored
+with its returned result snapshot. `GET /api/search-executions` returns stable ID-ordered
+pages of at most 500 records for evaluation exports.
+
 `POST /api/feedback` accepts an exact query, up to 20 unique result grades from 0 through
 10, and a required overall explanation of at most 2,000 characters. Grades may be empty
-when the search returns no useful results. The API attributes feedback to the IAP-authenticated caller.
+when the search returns no useful results. The API attributes feedback to the
+IAP-authenticated caller and optionally links it to a matching search execution.
 
 The dashboard is a Vue single-page app served from the same origin, with client-side
 routes at `/` (search), `/wiki` (recently updated notes), `/wiki/<id>` (a note), and

--- a/infra/echo/api/Dockerfile
+++ b/infra/echo/api/Dockerfile
@@ -21,6 +21,7 @@ COPY hybrid_search.py .
 COPY reranking.py .
 COPY search_config.py .
 COPY search_feedback.py .
+COPY search_history.py .
 COPY api/app.py .
 COPY api/dashboard.py .
 COPY --from=dashboard /build/dist /app/dist

--- a/infra/echo/api/app.py
+++ b/infra/echo/api/app.py
@@ -70,7 +70,7 @@ QUERY_LINE_STOP_WORDS = frozenset(
     }
 )
 FILE_REFERENCE_LIMIT = 3
-SEARCH_EXECUTION_HEADER = "X-Echo-Search-Execution-ID"
+SEARCH_EXECUTION_HEADER = search_config.SEARCH_EXECUTION_HEADER
 SEARCH_HISTORY_PAGE_LIMIT = 500
 POSTGRES_UNDEFINED_COLUMN = "42703"
 POSTGRES_UNDEFINED_TABLE = "42P01"
@@ -83,6 +83,7 @@ class EchoConfig:
     public_url: str
     github_repository: str
     github_branch: str
+    service_revision: str | None = None
 
 
 DEFAULT_CONFIG = EchoConfig(
@@ -97,6 +98,7 @@ def environment_config() -> EchoConfig:
         public_url=os.environ.get("ECHO_PUBLIC_URL", DEFAULT_CONFIG.public_url).rstrip("/"),
         github_repository=os.environ.get("GITHUB_REPOSITORY", DEFAULT_CONFIG.github_repository),
         github_branch=os.environ.get("GITHUB_BRANCH", DEFAULT_CONFIG.github_branch),
+        service_revision=os.environ.get("K_REVISION"),
     )
 
 
@@ -564,6 +566,14 @@ def database_error_code(error: sqlalchemy.exc.DBAPIError) -> str | None:
 
 
 def record_live_search(engine: sqlalchemy.Engine, record: search_history.SearchExecutionRecord) -> int | None:
+    """Persist a live search and return its execution ID when history storage is available.
+
+    Echo deploys additive migrations after Cloud Run resources because the migration grants
+    runtime database users created by those resources. A new revision may therefore receive
+    requests before its history table or newest columns exist. Only PostgreSQL's undefined
+    table and undefined column errors are tolerated during that rollout window; all other
+    persistence failures propagate.
+    """
     try:
         with engine.begin() as conn:
             return search_history.insert_execution(conn, record)
@@ -572,6 +582,16 @@ def record_live_search(engine: sqlalchemy.Engine, record: search_history.SearchE
             raise
         logger.warning("Search history schema is not available; apply pending Echo migrations", exc_info=True)
         return None
+
+
+def attach_search_execution(
+    response: Response,
+    engine: sqlalchemy.Engine,
+    record: search_history.SearchExecutionRecord,
+) -> None:
+    execution_id = record_live_search(engine, record)
+    if execution_id is not None:
+        response.headers[SEARCH_EXECUTION_HEADER] = str(execution_id)
 
 
 def wiki_search_result(row: sqlalchemy.Row, config: EchoConfig) -> SearchResult:
@@ -902,6 +922,7 @@ def repository_index_status(engine: Engine, config: Config) -> RepositoryIndexSt
 def search(
     engine: Engine,
     model: Model,
+    config: Config,
     response: Response,
     q: str = Query(description="Natural-language query."),
     source: str | None = Query(None, enum=list(SOURCES)),
@@ -925,7 +946,8 @@ def search(
     with engine.connect() as conn:
         conn.execute(hybrid_search.HNSW_ITERATIVE_SCAN)
         results = [hit(row) for row in conn.execute(statement, params)]
-    execution_id = record_live_search(
+    attach_search_execution(
+        response,
         engine,
         search_history.SearchExecutionRecord(
             author=iap_caller(x_goog_authenticated_user_email),
@@ -940,12 +962,10 @@ def search(
             requested_limit=limit,
             returned_count=len(results),
             duration_ms=(time.perf_counter() - started_at) * 1_000,
-            service_revision=os.environ.get("K_REVISION"),
+            service_revision=config.service_revision,
             results=tuple(recorded_hit(result) for result in results),
         ),
     )
-    if execution_id is not None:
-        response.headers[SEARCH_EXECUTION_HEADER] = str(execution_id)
     return results
 
 
@@ -994,7 +1014,8 @@ def federated_search_endpoint(
     domains = list(dict.fromkeys(domain or search_config.DEFAULT_SEARCH_DOMAINS))
     started_at = time.perf_counter()
     results = federated_search(engine, model, reranker, config, query, domains, limit)
-    execution_id = record_live_search(
+    attach_search_execution(
+        response,
         engine,
         search_history.SearchExecutionRecord(
             author=iap_caller(x_goog_authenticated_user_email),
@@ -1006,18 +1027,17 @@ def federated_search_endpoint(
             returned_count=len(results),
             duration_ms=(time.perf_counter() - started_at) * 1_000,
             repository_commit=result_repository_commit(results),
-            service_revision=os.environ.get("K_REVISION"),
+            service_revision=config.service_revision,
             results=tuple(recorded_search_result(result) for result in results),
         ),
     )
-    if execution_id is not None:
-        response.headers[SEARCH_EXECUTION_HEADER] = str(execution_id)
     return results
 
 
 @api.get("/grep", response_model=list[Hit])
 def grep(
     engine: Engine,
+    config: Config,
     response: Response,
     pattern: str = Query(description="Exact substring (SQL wildcards are escaped)."),
     source: str | None = Query(None, enum=list(SOURCES)),
@@ -1044,7 +1064,8 @@ def grep(
     query = query.order_by(schema.chunks.c.date.desc()).limit(limit)
     with engine.connect() as conn:
         results = [hit(r) for r in conn.execute(query)]
-    execution_id = record_live_search(
+    attach_search_execution(
+        response,
         engine,
         search_history.SearchExecutionRecord(
             author=iap_caller(x_goog_authenticated_user_email),
@@ -1055,12 +1076,10 @@ def grep(
             requested_limit=limit,
             returned_count=len(results),
             duration_ms=(time.perf_counter() - started_at) * 1_000,
-            service_revision=os.environ.get("K_REVISION"),
+            service_revision=config.service_revision,
             results=tuple(recorded_hit(result) for result in results),
         ),
     )
-    if execution_id is not None:
-        response.headers[SEARCH_EXECUTION_HEADER] = str(execution_id)
     return results
 
 

--- a/infra/echo/api/app.py
+++ b/infra/echo/api/app.py
@@ -72,6 +72,7 @@ QUERY_LINE_STOP_WORDS = frozenset(
 FILE_REFERENCE_LIMIT = 3
 SEARCH_EXECUTION_HEADER = search_config.SEARCH_EXECUTION_HEADER
 SEARCH_HISTORY_PAGE_LIMIT = 500
+MILLISECONDS_PER_SECOND = 1_000
 POSTGRES_UNDEFINED_COLUMN = "42703"
 POSTGRES_UNDEFINED_TABLE = "42P01"
 
@@ -566,14 +567,7 @@ def database_error_code(error: sqlalchemy.exc.DBAPIError) -> str | None:
 
 
 def record_live_search(engine: sqlalchemy.Engine, record: search_history.SearchExecutionRecord) -> int | None:
-    """Persist a live search and return its execution ID when history storage is available.
-
-    Echo deploys additive migrations after Cloud Run resources because the migration grants
-    runtime database users created by those resources. A new revision may therefore receive
-    requests before its history table or newest columns exist. Only PostgreSQL's undefined
-    table and undefined column errors are tolerated during that rollout window; all other
-    persistence failures propagate.
-    """
+    """Persist a search, returning ``None`` only while its additive schema is unavailable."""
     try:
         with engine.begin() as conn:
             return search_history.insert_execution(conn, record)
@@ -961,7 +955,7 @@ def search(
             },
             requested_limit=limit,
             returned_count=len(results),
-            duration_ms=(time.perf_counter() - started_at) * 1_000,
+            duration_ms=(time.perf_counter() - started_at) * MILLISECONDS_PER_SECOND,
             service_revision=config.service_revision,
             results=tuple(recorded_hit(result) for result in results),
         ),
@@ -1025,7 +1019,7 @@ def federated_search_endpoint(
             filters={},
             requested_limit=limit,
             returned_count=len(results),
-            duration_ms=(time.perf_counter() - started_at) * 1_000,
+            duration_ms=(time.perf_counter() - started_at) * MILLISECONDS_PER_SECOND,
             repository_commit=result_repository_commit(results),
             service_revision=config.service_revision,
             results=tuple(recorded_search_result(result) for result in results),
@@ -1075,7 +1069,7 @@ def grep(
             filters={"source": source, "kind": kind},
             requested_limit=limit,
             returned_count=len(results),
-            duration_ms=(time.perf_counter() - started_at) * 1_000,
+            duration_ms=(time.perf_counter() - started_at) * MILLISECONDS_PER_SECOND,
             service_revision=config.service_revision,
             results=tuple(recorded_hit(result) for result in results),
         ),

--- a/infra/echo/api/app.py
+++ b/infra/echo/api/app.py
@@ -6,8 +6,10 @@
 See ``infra/echo/README.md`` for endpoints and access requirements.
 """
 
+import logging
 import os
 import re
+import time
 from collections.abc import Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
@@ -22,8 +24,9 @@ import reranking
 import schema
 import search_config
 import search_feedback
+import search_history
 import sqlalchemy
-from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Query, Request, Response
 from fastembed import TextEmbedding
 from fastembed.rerank.cross_encoder import TextCrossEncoder
 from google.cloud.sql.connector import Connector
@@ -67,6 +70,12 @@ QUERY_LINE_STOP_WORDS = frozenset(
     }
 )
 FILE_REFERENCE_LIMIT = 3
+SEARCH_EXECUTION_HEADER = "X-Echo-Search-Execution-ID"
+SEARCH_HISTORY_PAGE_LIMIT = 500
+POSTGRES_UNDEFINED_COLUMN = "42703"
+POSTGRES_UNDEFINED_TABLE = "42P01"
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -220,6 +229,7 @@ class SearchFeedbackCreate(BaseModel):
     query: str = Field(min_length=1, max_length=search_feedback.MAX_QUERY_CHARACTERS)
     grades: list[SearchFeedbackGrade] = Field(default_factory=list, max_length=search_feedback.MAX_GRADES)
     note: str = Field(min_length=1, max_length=search_feedback.MAX_NOTE_CHARACTERS)
+    execution_id: int | None = Field(None, gt=0)
 
     @field_validator("query")
     @classmethod
@@ -250,6 +260,35 @@ class SearchFeedbackEntry(SearchFeedbackCreate):
     id: int
     created_at: datetime
     author: str
+
+
+class SearchExecutionResultEntry(BaseModel):
+    rank: int
+    result_id: str
+    domain: search_config.SearchDomain
+    title: str | None
+    url: str
+    snippet: str
+    score: float
+    distance: float | None
+    lexical_score: float | None
+
+
+class SearchExecutionEntry(BaseModel):
+    id: int
+    created_at: datetime
+    author: str | None
+    query: str
+    normalized_query: str
+    mode: search_history.SearchMode
+    domains: list[str]
+    filters: dict[str, Any]
+    requested_limit: int
+    returned_count: int
+    duration_ms: float
+    repository_commit: str | None
+    service_revision: str | None
+    results: list[SearchExecutionResultEntry]
 
 
 class RepositoryIndexStatus(BaseModel):
@@ -447,16 +486,16 @@ def activity_domain_clause(domains: Iterable[str]) -> str:
     return f"({' OR '.join(clauses)})"
 
 
-def activity_domain(row: sqlalchemy.Row) -> Literal["discord", "pr", "issue"]:
-    if row.source == "discord":
+def activity_domain(source: str, kind: str, url: str) -> Literal["discord", "pr", "issue"]:
+    if source == "discord":
         return "discord"
-    if row.kind == "pr" or "/pull/" in row.url:
+    if kind == "pr" or "/pull/" in url:
         return "pr"
     return "issue"
 
 
 def activity_search_result(row: sqlalchemy.Row) -> SearchResult:
-    domain = activity_domain(row)
+    domain = activity_domain(row.source, row.kind, row.url)
     title = row.title or snippet(row) or row.url
     details = [domain]
     if row.author:
@@ -474,6 +513,65 @@ def activity_search_result(row: sqlalchemy.Row) -> SearchResult:
         distance=row.distance,
         lexical_score=row.lexical_score,
     )
+
+
+def recorded_search_result(result: SearchResult) -> search_history.SearchResultRecord:
+    return search_history.SearchResultRecord(
+        result_id=result.id,
+        domain=result.domain,
+        title=result.title,
+        url=result.url,
+        snippet=result.snippet,
+        score=result.score,
+        distance=result.distance,
+        lexical_score=result.lexical_score,
+    )
+
+
+def recorded_hit(result: Hit) -> search_history.SearchResultRecord:
+    domain = activity_domain(result.source, result.kind, result.url)
+    return search_history.SearchResultRecord(
+        result_id=f"{domain}:{result.id}",
+        domain=domain,
+        title=result.title,
+        url=result.url,
+        snippet=result.snippet,
+        score=result.score,
+        distance=result.distance,
+        lexical_score=result.lexical_score,
+    )
+
+
+def result_repository_commit(results: Iterable[SearchResult]) -> str | None:
+    for result in results:
+        if result.domain != "file":
+            continue
+        match = re.search(r"/blob/([^/]+)/", result.url)
+        if match is not None:
+            return match.group(1)
+    return None
+
+
+def database_error_code(error: sqlalchemy.exc.DBAPIError) -> str | None:
+    code = getattr(error.orig, "sqlstate", None) or getattr(error.orig, "pgcode", None)
+    if isinstance(code, str):
+        return code
+    args = getattr(error.orig, "args", ())
+    if isinstance(args, tuple) and args and isinstance(args[0], dict):
+        value = args[0].get("C")
+        return value if isinstance(value, str) else None
+    return None
+
+
+def record_live_search(engine: sqlalchemy.Engine, record: search_history.SearchExecutionRecord) -> int | None:
+    try:
+        with engine.begin() as conn:
+            return search_history.insert_execution(conn, record)
+    except sqlalchemy.exc.DBAPIError as error:
+        if database_error_code(error) not in {POSTGRES_UNDEFINED_COLUMN, POSTGRES_UNDEFINED_TABLE}:
+            raise
+        logger.warning("Search history schema is not available; apply pending Echo migrations", exc_info=True)
+        return None
 
 
 def wiki_search_result(row: sqlalchemy.Row, config: EchoConfig) -> SearchResult:
@@ -804,16 +902,19 @@ def repository_index_status(engine: Engine, config: Config) -> RepositoryIndexSt
 def search(
     engine: Engine,
     model: Model,
+    response: Response,
     q: str = Query(description="Natural-language query."),
     source: str | None = Query(None, enum=list(SOURCES)),
     kind: str | None = Query(None, enum=list(KINDS)),
     since: datetime | None = Query(None, description="ISO date lower bound on chunk date."),
     limit: int = Query(search_config.DEFAULT_SEARCH_LIMIT, ge=1, le=search_config.MAX_SEARCH_LIMIT),
+    x_goog_authenticated_user_email: str | None = Header(None),
 ) -> list[Hit]:
     """Hybrid full-text and semantic search over GitHub and Discord activity."""
     query = q.strip()
     if not query:
         raise HTTPException(422, "q must not be blank")
+    started_at = time.perf_counter()
     params = {
         **hybrid_search_params(model, query, limit),
         "source": source,
@@ -823,26 +924,41 @@ def search(
     statement = hybrid_search.chunk_search_statement(chunk_filter_clauses(source, kind, since))
     with engine.connect() as conn:
         conn.execute(hybrid_search.HNSW_ITERATIVE_SCAN)
-        return [hit(row) for row in conn.execute(statement, params)]
+        results = [hit(row) for row in conn.execute(statement, params)]
+    execution_id = record_live_search(
+        engine,
+        search_history.SearchExecutionRecord(
+            author=iap_caller(x_goog_authenticated_user_email),
+            query=query,
+            mode="activity",
+            domains=(),
+            filters={
+                "source": source,
+                "kind": kind,
+                "since": since.isoformat() if since is not None else None,
+            },
+            requested_limit=limit,
+            returned_count=len(results),
+            duration_ms=(time.perf_counter() - started_at) * 1_000,
+            service_revision=os.environ.get("K_REVISION"),
+            results=tuple(recorded_hit(result) for result in results),
+        ),
+    )
+    if execution_id is not None:
+        response.headers[SEARCH_EXECUTION_HEADER] = str(execution_id)
+    return results
 
 
-@api.get("/federated-search", response_model=list[SearchResult])
 def federated_search(
-    engine: Engine,
-    model: Model,
-    reranker: Reranker,
-    config: Config,
-    q: str = Query(description="Natural-language query."),
-    domain: list[search_config.SearchDomain] | None = Query(
-        None, description="Search this domain; repeat to select several."
-    ),
-    limit: int = Query(search_config.DEFAULT_SEARCH_LIMIT, ge=1, le=search_config.MAX_SEARCH_LIMIT),
+    engine: sqlalchemy.Engine,
+    model: TextEmbedding,
+    reranker: RerankerModel,
+    config: EchoConfig,
+    query: str,
+    domains: list[search_config.SearchDomain],
+    limit: int,
 ) -> list[SearchResult]:
     """Search wiki, repository file, and activity domains and merge their hybrid ranks."""
-    query = q.strip()
-    if not query:
-        raise HTTPException(422, "q must not be blank")
-    domains = list(dict.fromkeys(domain or search_config.DEFAULT_SEARCH_DOMAINS))
     retrieval_limit = max(limit, search_config.RERANK_MIN_RESULTS_PER_DOMAIN)
     params = hybrid_search_params(model, query, retrieval_limit)
     candidates: list[SearchCandidate] = []
@@ -858,15 +974,62 @@ def federated_search(
     return rerank_candidates(candidates, query, reranker, limit)
 
 
+@api.get("/federated-search", response_model=list[SearchResult])
+def federated_search_endpoint(
+    engine: Engine,
+    model: Model,
+    reranker: Reranker,
+    config: Config,
+    response: Response,
+    q: str = Query(description="Natural-language query."),
+    domain: list[search_config.SearchDomain] | None = Query(
+        None, description="Search this domain; repeat to select several."
+    ),
+    limit: int = Query(search_config.DEFAULT_SEARCH_LIMIT, ge=1, le=search_config.MAX_SEARCH_LIMIT),
+    x_goog_authenticated_user_email: str | None = Header(None),
+) -> list[SearchResult]:
+    query = q.strip()
+    if not query:
+        raise HTTPException(422, "q must not be blank")
+    domains = list(dict.fromkeys(domain or search_config.DEFAULT_SEARCH_DOMAINS))
+    started_at = time.perf_counter()
+    results = federated_search(engine, model, reranker, config, query, domains, limit)
+    execution_id = record_live_search(
+        engine,
+        search_history.SearchExecutionRecord(
+            author=iap_caller(x_goog_authenticated_user_email),
+            query=query,
+            mode="federated",
+            domains=tuple(domains),
+            filters={},
+            requested_limit=limit,
+            returned_count=len(results),
+            duration_ms=(time.perf_counter() - started_at) * 1_000,
+            repository_commit=result_repository_commit(results),
+            service_revision=os.environ.get("K_REVISION"),
+            results=tuple(recorded_search_result(result) for result in results),
+        ),
+    )
+    if execution_id is not None:
+        response.headers[SEARCH_EXECUTION_HEADER] = str(execution_id)
+    return results
+
+
 @api.get("/grep", response_model=list[Hit])
 def grep(
     engine: Engine,
+    response: Response,
     pattern: str = Query(description="Exact substring (SQL wildcards are escaped)."),
     source: str | None = Query(None, enum=list(SOURCES)),
     kind: str | None = Query(None, enum=list(KINDS)),
     limit: int = Query(20, ge=1, le=search_config.MAX_SEARCH_LIMIT),
+    x_goog_authenticated_user_email: str | None = Header(None),
 ) -> list[Hit]:
     """Case-insensitive substring scan, newest first — for identifiers and exact strings."""
+    query_text = pattern.strip()
+    if not query_text:
+        raise HTTPException(422, "pattern must not be blank")
+    started_at = time.perf_counter()
     query = sqlalchemy.select(
         schema.chunks,
         sqlalchemy.literal(0.0).label("score"),
@@ -877,10 +1040,28 @@ def grep(
         query = query.where(schema.chunks.c.source == source)
     if kind:
         query = query.where(schema.chunks.c.kind == kind)
-    query = query.where(schema.chunks.c.text.ilike(f"%{escape_like(pattern)}%"))
+    query = query.where(schema.chunks.c.text.ilike(f"%{escape_like(query_text)}%"))
     query = query.order_by(schema.chunks.c.date.desc()).limit(limit)
     with engine.connect() as conn:
-        return [hit(r) for r in conn.execute(query)]
+        results = [hit(r) for r in conn.execute(query)]
+    execution_id = record_live_search(
+        engine,
+        search_history.SearchExecutionRecord(
+            author=iap_caller(x_goog_authenticated_user_email),
+            query=query_text,
+            mode="grep",
+            domains=(),
+            filters={"source": source, "kind": kind},
+            requested_limit=limit,
+            returned_count=len(results),
+            duration_ms=(time.perf_counter() - started_at) * 1_000,
+            service_revision=os.environ.get("K_REVISION"),
+            results=tuple(recorded_hit(result) for result in results),
+        ),
+    )
+    if execution_id is not None:
+        response.headers[SEARCH_EXECUTION_HEADER] = str(execution_id)
+    return results
 
 
 @api.get("/chunks/{chunk_id}", response_model=Chunk)
@@ -973,6 +1154,48 @@ def add_work_log(
     return LogEntry(**{c: getattr(row, c) for c in LogEntry.model_fields})
 
 
+@api.get("/search-executions", response_model=list[SearchExecutionEntry])
+def search_executions(
+    engine: Engine,
+    after_id: int = Query(0, ge=0),
+    mode: search_history.SearchMode | None = None,
+    limit: int = Query(SEARCH_HISTORY_PAGE_LIMIT, ge=1, le=SEARCH_HISTORY_PAGE_LIMIT),
+) -> list[SearchExecutionEntry]:
+    """Return durable search executions in stable ID order for evaluation exports."""
+    statement = sqlalchemy.select(schema.search_executions).where(schema.search_executions.c.id > after_id)
+    if mode is not None:
+        statement = statement.where(schema.search_executions.c.mode == mode)
+    statement = statement.order_by(schema.search_executions.c.id).limit(limit)
+    with engine.connect() as conn:
+        execution_rows = list(conn.execute(statement))
+        execution_ids = [row.id for row in execution_rows]
+        result_rows = (
+            list(
+                conn.execute(
+                    sqlalchemy.select(schema.search_execution_results)
+                    .where(schema.search_execution_results.c.execution_id.in_(execution_ids))
+                    .order_by(schema.search_execution_results.c.execution_id, schema.search_execution_results.c.rank)
+                )
+            )
+            if execution_ids
+            else []
+        )
+    results_by_execution: dict[int, list[SearchExecutionResultEntry]] = {}
+    for row in result_rows:
+        results_by_execution.setdefault(row.execution_id, []).append(
+            SearchExecutionResultEntry(
+                **{field: getattr(row, field) for field in SearchExecutionResultEntry.model_fields}
+            )
+        )
+    return [
+        SearchExecutionEntry(
+            **{field: getattr(row, field) for field in SearchExecutionEntry.model_fields if field != "results"},
+            results=results_by_execution.get(row.id, []),
+        )
+        for row in execution_rows
+    ]
+
+
 @api.post("/feedback", response_model=SearchFeedbackEntry, status_code=201)
 def add_search_feedback(
     feedback: SearchFeedbackCreate,
@@ -980,16 +1203,43 @@ def add_search_feedback(
     x_goog_authenticated_user_email: str | None = Header(None),
 ) -> SearchFeedbackEntry:
     """Store one query's optional note and per-result relevance grades."""
+    author = iap_caller(x_goog_authenticated_user_email)
     statement = (
         schema.search_feedback.insert()
         .values(
-            author=iap_caller(x_goog_authenticated_user_email),
+            author=author,
             query=feedback.query,
             note=feedback.note,
+            execution_id=feedback.execution_id,
         )
         .returning(schema.search_feedback)
     )
     with engine.begin() as conn:
+        if feedback.execution_id is not None:
+            execution = conn.execute(
+                sqlalchemy.select(schema.search_executions.c.author, schema.search_executions.c.query).where(
+                    schema.search_executions.c.id == feedback.execution_id
+                )
+            ).first()
+            if execution is None:
+                raise HTTPException(422, f"no search execution {feedback.execution_id}")
+            if execution.author != author or execution.query != feedback.query:
+                raise HTTPException(422, "execution_id must identify this caller's exact query")
+            if feedback.grades:
+                recorded_result_ids = set(
+                    conn.execute(
+                        sqlalchemy.select(schema.search_execution_results.c.result_id).where(
+                            schema.search_execution_results.c.execution_id == feedback.execution_id
+                        )
+                    ).scalars()
+                )
+                unrecorded_result_ids = {grade.result_id for grade in feedback.grades} - recorded_result_ids
+                if unrecorded_result_ids:
+                    raise HTTPException(
+                        422,
+                        "graded results were not returned by the linked search execution: "
+                        + ", ".join(sorted(unrecorded_result_ids)),
+                    )
         row = conn.execute(statement).first()
         assert row is not None
         if feedback.grades:
@@ -1008,6 +1258,7 @@ def add_search_feedback(
         query=feedback.query,
         grades=feedback.grades,
         note=feedback.note,
+        execution_id=feedback.execution_id,
     )
 
 

--- a/infra/echo/api/test_app.py
+++ b/infra/echo/api/test_app.py
@@ -313,7 +313,6 @@ def test_search_feedback_rejects_grade_absent_from_linked_execution(client_with)
     )
 
     assert response.status_code == 422
-    assert response.json()["detail"] == "graded results were not returned by the linked search execution: wiki:123"
     assert not any(
         getattr(statement, "is_insert", False) and statement.table.name == "search_feedback"
         for statement in harness.engine.executions

--- a/infra/echo/api/test_app.py
+++ b/infra/echo/api/test_app.py
@@ -31,6 +31,9 @@ class FakeResult:
     def all(self):
         return self._rows
 
+    def scalars(self):
+        return (row[0] for row in self._rows)
+
 
 class FakeConn:
     def __init__(self, rows, sink, responses):
@@ -40,6 +43,10 @@ class FakeConn:
 
     def execute(self, statement, *args):
         self._sink.append(statement)
+        if getattr(statement, "is_insert", False) and statement.table.name == "search_executions":
+            return FakeResult([make_row(id=991)])
+        if getattr(statement, "is_insert", False) and statement.table.name == "search_execution_results":
+            return FakeResult([])
         if self._responses:
             return FakeResult(self._responses.pop(0))
         return FakeResult(self._rows)
@@ -138,6 +145,47 @@ def test_iap_caller_strips_provider_prefix():
     assert echo.iap_caller("") == "unknown"
 
 
+def test_search_remains_available_during_history_schema_rollout():
+    class SchemaSkewEngine:
+        def begin(self):
+            raise sqlalchemy.exc.ProgrammingError(
+                "INSERT INTO search_executions",
+                {},
+                Exception({"C": echo.POSTGRES_UNDEFINED_TABLE}),
+            )
+
+    record = echo.search_history.SearchExecutionRecord(
+        query="deploy iris",
+        mode="federated",
+        domains=("file",),
+        filters={},
+        requested_limit=10,
+        returned_count=0,
+        duration_ms=1.0,
+    )
+
+    assert echo.record_live_search(SchemaSkewEngine(), record) is None
+
+
+def test_search_history_propagates_non_schema_database_errors():
+    class BrokenEngine:
+        def begin(self):
+            raise sqlalchemy.exc.OperationalError("INSERT INTO search_executions", {}, Exception("connection lost"))
+
+    record = echo.search_history.SearchExecutionRecord(
+        query="deploy iris",
+        mode="federated",
+        domains=("file",),
+        filters={},
+        requested_limit=10,
+        returned_count=0,
+        duration_ms=1.0,
+    )
+
+    with pytest.raises(sqlalchemy.exc.OperationalError):
+        echo.record_live_search(BrokenEngine(), record)
+
+
 def test_work_log_list_omits_body(client_with):
     row = make_row(id=1, at=datetime(2026, 7, 23, tzinfo=UTC), author="a", project="p", title="t", body="secret body")
     harness = client_with([row])
@@ -199,6 +247,7 @@ def test_add_search_feedback_persists_authenticated_replayable_judgments(client_
             {"result_id": "file:lib/iris/OPS.md", "grade": 10},
         ],
         "note": "Wiki result was unrelated.",
+        "execution_id": None,
     }
     feedback_params = harness.engine.executions[-2].compile().params
     assert feedback_params["author"] == "agent@openathena.ai"
@@ -213,6 +262,115 @@ def test_add_search_feedback_persists_authenticated_replayable_judgments(client_
         "result_id_m1": "file:lib/iris/OPS.md",
         "grade_m1": 10,
     }
+
+
+def test_search_feedback_links_matching_execution(client_with):
+    execution = make_row(author="agent@openathena.ai", query="how do I deploy Iris?")
+    feedback = make_row(
+        id=17,
+        created_at=datetime(2026, 8, 11, tzinfo=UTC),
+        author="agent@openathena.ai",
+        query="how do I deploy Iris?",
+        note="The file answered it.",
+        execution_id=991,
+    )
+    harness = client_with([feedback], responses=[[execution], [["file:lib/iris/OPS.md"]]])
+
+    response = harness.client.post(
+        "/api/feedback",
+        json={
+            "query": "how do I deploy Iris?",
+            "execution_id": 991,
+            "grades": [{"result_id": "file:lib/iris/OPS.md", "grade": 10}],
+            "note": "The file answered it.",
+        },
+        headers={"X-Goog-Authenticated-User-Email": "accounts.google.com:agent@openathena.ai"},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["execution_id"] == 991
+    feedback_insert = next(
+        statement
+        for statement in harness.engine.executions
+        if getattr(statement, "is_insert", False) and statement.table.name == "search_feedback"
+    )
+    assert feedback_insert.compile().params["execution_id"] == 991
+
+
+def test_search_feedback_rejects_grade_absent_from_linked_execution(client_with):
+    execution = make_row(author="agent@openathena.ai", query="how do I deploy Iris?")
+    harness = client_with([], responses=[[execution], [["file:lib/iris/OPS.md"]]])
+
+    response = harness.client.post(
+        "/api/feedback",
+        json={
+            "query": "how do I deploy Iris?",
+            "execution_id": 991,
+            "grades": [{"result_id": "wiki:123", "grade": 0}],
+            "note": "This was not in the recorded result set.",
+        },
+        headers={"X-Goog-Authenticated-User-Email": "accounts.google.com:agent@openathena.ai"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "graded results were not returned by the linked search execution: wiki:123"
+    assert not any(
+        getattr(statement, "is_insert", False) and statement.table.name == "search_feedback"
+        for statement in harness.engine.executions
+    )
+
+
+def test_search_execution_export_preserves_result_rank(client_with):
+    execution = make_row(
+        id=41,
+        created_at=datetime(2026, 8, 12, tzinfo=UTC),
+        author="agent@openathena.ai",
+        query="how do I deploy Iris?",
+        normalized_query="how do i deploy iris?",
+        mode="federated",
+        domains=["wiki", "file"],
+        filters={},
+        requested_limit=10,
+        returned_count=2,
+        duration_ms=125.0,
+        repository_commit="abcdef1234567890",
+        service_revision="echo-api-00024-vtc",
+    )
+    result_rows = [
+        make_row(
+            execution_id=41,
+            rank=1,
+            result_id="file:lib/iris/OPS.md",
+            domain="file",
+            title="Iris Operations",
+            url="https://example.com/OPS.md",
+            snippet="Run iris cluster restart.",
+            score=0.9,
+            distance=0.1,
+            lexical_score=1.2,
+        ),
+        make_row(
+            execution_id=41,
+            rank=2,
+            result_id="wiki:12",
+            domain="wiki",
+            title="Iris deployment",
+            url="https://echo.oa.dev/wiki/12",
+            snippet="Deployment notes.",
+            score=0.8,
+            distance=0.2,
+            lexical_score=None,
+        ),
+    ]
+    harness = client_with([], responses=[[execution], result_rows])
+
+    entries = echo.search_executions(harness.engine, after_id=40, mode="federated", limit=10)
+
+    assert [entry.id for entry in entries] == [41]
+    assert [(result.rank, result.result_id) for result in entries[0].results] == [
+        (1, "file:lib/iris/OPS.md"),
+        (2, "wiki:12"),
+    ]
 
 
 def test_search_feedback_rejects_out_of_range_grade(client_with):
@@ -284,6 +442,7 @@ def test_activity_search_uses_query_encoder(client_with):
     response = harness.client.get("/api/search", params={"q": "grafana"})
     assert response.status_code == 200
     assert response.json()[0]["title"] == "Grafana dashboards"
+    assert response.headers[echo.SEARCH_EXECUTION_HEADER] == "991"
     assert harness.model.queries == ["grafana"]
     assert harness.model.passages == []
 
@@ -403,6 +562,7 @@ def test_federated_file_result_names_exact_indexed_head(client_with):
     )
 
     assert response.status_code == 200
+    assert response.headers[echo.SEARCH_EXECUTION_HEADER] == "991"
     assert response.json() == [
         {
             "id": "file:lib/iris/src/iris/scheduler.py",
@@ -439,6 +599,25 @@ def test_federated_file_result_names_exact_indexed_head(client_with):
             ],
         }
     ]
+    execution_insert = next(
+        statement
+        for statement in harness.engine.executions
+        if getattr(statement, "is_insert", False) and statement.table.name == "search_executions"
+    )
+    execution_params = execution_insert.compile().params
+    assert execution_params["query"] == "FAILED_PRECONDITION"
+    assert execution_params["normalized_query"] == "failed_precondition"
+    assert execution_params["mode"] == "federated"
+    assert execution_params["domains"] == ["file"]
+    assert execution_params["returned_count"] == 1
+    assert execution_params["repository_commit"] == "abcdef1234567890"
+    result_insert = next(
+        statement
+        for statement in harness.engine.executions
+        if getattr(statement, "is_insert", False) and statement.table.name == "search_execution_results"
+    )
+    assert result_insert.compile().params["result_id_m0"] == "file:lib/iris/src/iris/scheduler.py"
+    assert result_insert.compile().params["rank_m0"] == 1
 
 
 def test_file_summary_skips_license_boilerplate_for_filename_match():

--- a/infra/echo/build_search_quality_manifest.py
+++ b/infra/echo/build_search_quality_manifest.py
@@ -15,6 +15,7 @@ from typing import Literal, cast
 import search_config
 
 ManifestSource = Literal["observed", "feedback-only", "benchmark"]
+QUERY_IDENTIFIER_HEX_LENGTH = 12
 
 
 @dataclass(frozen=True)
@@ -103,7 +104,7 @@ def observed_cases(path: Path) -> list[ManifestCase]:
     for normalized, entries in sorted(groups.items()):
         domain_counts = Counter(checked_domains(entry["domains"], "observed query") for entry in entries)
         domains = domain_counts.most_common(1)[0][0]
-        identifier = hashlib.sha256(normalized.encode()).hexdigest()[:12]
+        identifier = hashlib.sha256(normalized.encode()).hexdigest()[:QUERY_IDENTIFIER_HEX_LENGTH]
         cases.append(
             ManifestCase(
                 id=f"observed-{identifier}",
@@ -141,7 +142,10 @@ def build_manifest(query_log: Path, benchmark: Path, extra_queries: list[str]) -
     cases = observed_cases(query_log)
     cases.extend(
         ManifestCase(
-            id=f"feedback-{hashlib.sha256(search_config.normalize_query(query).encode()).hexdigest()[:12]}",
+            id=(
+                "feedback-"
+                + hashlib.sha256(search_config.normalize_query(query).encode()).hexdigest()[:QUERY_IDENTIFIER_HEX_LENGTH]
+            ),
             query=query,
             domains=search_config.DEFAULT_SEARCH_DOMAINS,
             source="feedback-only",

--- a/infra/echo/build_search_quality_manifest.py
+++ b/infra/echo/build_search_quality_manifest.py
@@ -8,80 +8,148 @@ import argparse
 import hashlib
 import json
 from collections import Counter
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal, cast
 
 import search_config
 
+ManifestSource = Literal["observed", "feedback-only", "benchmark"]
 
-def normalized_query(query: str) -> str:
-    return " ".join(query.casefold().split())
+
+@dataclass(frozen=True)
+class ObservedDomainSet:
+    domains: tuple[search_config.SearchDomain, ...]
+    occurrences: int
+
+
+@dataclass(frozen=True)
+class ManifestCase:
+    id: str
+    query: str
+    domains: tuple[search_config.SearchDomain, ...]
+    source: ManifestSource
+    occurrences: int = 1
+    observed_domain_sets: tuple[ObservedDomainSet, ...] = ()
+    benchmark_split: str | None = None
+    benchmark_intent: str | None = None
+
+    @classmethod
+    def from_json(cls, value: object) -> "ManifestCase":
+        if not isinstance(value, dict):
+            raise ValueError("replay case must be an object")
+        identifier = value.get("id")
+        query = value.get("query")
+        source = value.get("source")
+        occurrences = value.get("occurrences", 1)
+        if not isinstance(identifier, str) or not identifier:
+            raise ValueError("id must be a nonblank string")
+        if not isinstance(query, str) or not query.strip():
+            raise ValueError(f"{identifier}: query must be a nonblank string")
+        if source not in ("observed", "feedback-only", "benchmark"):
+            raise ValueError(f"{identifier}: unknown source {source!r}")
+        if not isinstance(occurrences, int) or occurrences < 1:
+            raise ValueError(f"{identifier}: occurrences must be a positive integer")
+        return cls(
+            identifier,
+            query.strip(),
+            checked_domains(value.get("domains"), identifier),
+            cast(ManifestSource, source),
+            occurrences,
+        )
+
+    def json_value(self) -> dict[str, object]:
+        value: dict[str, object] = {
+            "id": self.id,
+            "query": self.query,
+            "domains": list(self.domains),
+            "source": self.source,
+            "occurrences": self.occurrences,
+        }
+        if self.observed_domain_sets:
+            value["observed_domain_sets"] = [
+                {"domains": list(domain_set.domains), "occurrences": domain_set.occurrences}
+                for domain_set in self.observed_domain_sets
+            ]
+        if self.benchmark_split is not None:
+            value["benchmark_split"] = self.benchmark_split
+        if self.benchmark_intent is not None:
+            value["benchmark_intent"] = self.benchmark_intent
+        return value
+
+
+def checked_domains(value: object, identifier: str) -> tuple[search_config.SearchDomain, ...]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{identifier}: domains must be a nonempty list")
+    for domain in value:
+        if domain not in search_config.SEARCH_DOMAINS:
+            raise ValueError(f"{identifier}: unknown domain {domain!r}")
+    return tuple(cast(search_config.SearchDomain, domain) for domain in value)
 
 
 def json_objects(path: Path) -> list[dict[str, object]]:
     return [json.loads(line) for line in path.read_text().splitlines() if line.lstrip().startswith("{")]
 
 
-def observed_cases(path: Path) -> list[dict[str, object]]:
+def observed_cases(path: Path) -> list[ManifestCase]:
     groups: dict[str, list[dict[str, object]]] = {}
     for entry in json_objects(path):
         if entry.get("mode") != "federated":
             continue
         query = str(entry["query"])
-        groups.setdefault(normalized_query(query), []).append(entry)
+        groups.setdefault(search_config.normalize_query(query), []).append(entry)
 
     cases = []
     for normalized, entries in sorted(groups.items()):
-        domain_counts = Counter(tuple(entry["domains"]) for entry in entries)
-        domains = list(domain_counts.most_common(1)[0][0])
+        domain_counts = Counter(checked_domains(entry["domains"], "observed query") for entry in entries)
+        domains = domain_counts.most_common(1)[0][0]
         identifier = hashlib.sha256(normalized.encode()).hexdigest()[:12]
         cases.append(
-            {
-                "id": f"observed-{identifier}",
-                "query": entries[-1]["query"],
-                "domains": domains,
-                "source": "observed",
-                "occurrences": len(entries),
-                "observed_domain_sets": [
-                    {"domains": list(domain_set), "occurrences": count}
-                    for domain_set, count in domain_counts.most_common()
-                ],
-            }
+            ManifestCase(
+                id=f"observed-{identifier}",
+                query=str(entries[-1]["query"]),
+                domains=domains,
+                source="observed",
+                occurrences=len(entries),
+                observed_domain_sets=tuple(
+                    ObservedDomainSet(domain_set, count) for domain_set, count in domain_counts.most_common()
+                ),
+            )
         )
     return cases
 
 
-def benchmark_cases(path: Path) -> list[dict[str, object]]:
+def benchmark_cases(path: Path) -> list[ManifestCase]:
     cases = []
     for entry in json_objects(path):
-        domains = entry["domains"] or list(search_config.DEFAULT_SEARCH_DOMAINS)
+        raw_domains = entry["domains"] or list(search_config.DEFAULT_SEARCH_DOMAINS)
+        identifier = f"benchmark-{entry['id']}"
         cases.append(
-            {
-                "id": f"benchmark-{entry['id']}",
-                "query": entry["query"],
-                "domains": domains,
-                "source": "benchmark",
-                "occurrences": 1,
-                "benchmark_split": entry["split"],
-                "benchmark_intent": entry["intent"],
-            }
+            ManifestCase(
+                id=identifier,
+                query=str(entry["query"]),
+                domains=checked_domains(raw_domains, identifier),
+                source="benchmark",
+                benchmark_split=str(entry["split"]),
+                benchmark_intent=str(entry["intent"]),
+            )
         )
     return cases
 
 
-def build_manifest(query_log: Path, benchmark: Path, extra_queries: list[str]) -> list[dict[str, object]]:
+def build_manifest(query_log: Path, benchmark: Path, extra_queries: list[str]) -> list[ManifestCase]:
     cases = observed_cases(query_log)
     cases.extend(
-        {
-            "id": f"feedback-{hashlib.sha256(normalized_query(query).encode()).hexdigest()[:12]}",
-            "query": query,
-            "domains": list(search_config.DEFAULT_SEARCH_DOMAINS),
-            "source": "feedback-only",
-            "occurrences": 1,
-        }
+        ManifestCase(
+            id=f"feedback-{hashlib.sha256(search_config.normalize_query(query).encode()).hexdigest()[:12]}",
+            query=query,
+            domains=search_config.DEFAULT_SEARCH_DOMAINS,
+            source="feedback-only",
+        )
         for query in extra_queries
     )
     cases.extend(benchmark_cases(benchmark))
-    normalized = [normalized_query(str(case["query"])) for case in cases]
+    normalized = [search_config.normalize_query(case.query) for case in cases]
     if len(normalized) != len(set(normalized)):
         duplicates = sorted(query for query, count in Counter(normalized).items() if count > 1)
         raise ValueError(f"duplicate queries across manifest sources: {', '.join(duplicates)}")
@@ -95,7 +163,7 @@ def main() -> None:
     parser.add_argument("--extra-query", action="append", default=[], help="feedback query absent from the log slice")
     args = parser.parse_args()
     for case in build_manifest(args.query_log, args.benchmark, args.extra_query):
-        print(json.dumps(case, sort_keys=True))
+        print(json.dumps(case.json_value(), sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/infra/echo/build_search_quality_manifest.py
+++ b/infra/echo/build_search_quality_manifest.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build the deduplicated Echo search-quality replay manifest."""
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+
+import search_config
+
+
+def normalized_query(query: str) -> str:
+    return " ".join(query.casefold().split())
+
+
+def json_objects(path: Path) -> list[dict[str, object]]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.lstrip().startswith("{")]
+
+
+def observed_cases(path: Path) -> list[dict[str, object]]:
+    groups: dict[str, list[dict[str, object]]] = {}
+    for entry in json_objects(path):
+        if entry.get("mode") != "federated":
+            continue
+        query = str(entry["query"])
+        groups.setdefault(normalized_query(query), []).append(entry)
+
+    cases = []
+    for normalized, entries in sorted(groups.items()):
+        domain_counts = Counter(tuple(entry["domains"]) for entry in entries)
+        domains = list(domain_counts.most_common(1)[0][0])
+        identifier = hashlib.sha256(normalized.encode()).hexdigest()[:12]
+        cases.append(
+            {
+                "id": f"observed-{identifier}",
+                "query": entries[-1]["query"],
+                "domains": domains,
+                "source": "observed",
+                "occurrences": len(entries),
+                "observed_domain_sets": [
+                    {"domains": list(domain_set), "occurrences": count}
+                    for domain_set, count in domain_counts.most_common()
+                ],
+            }
+        )
+    return cases
+
+
+def benchmark_cases(path: Path) -> list[dict[str, object]]:
+    cases = []
+    for entry in json_objects(path):
+        domains = entry["domains"] or list(search_config.DEFAULT_SEARCH_DOMAINS)
+        cases.append(
+            {
+                "id": f"benchmark-{entry['id']}",
+                "query": entry["query"],
+                "domains": domains,
+                "source": "benchmark",
+                "occurrences": 1,
+                "benchmark_split": entry["split"],
+                "benchmark_intent": entry["intent"],
+            }
+        )
+    return cases
+
+
+def build_manifest(query_log: Path, benchmark: Path, extra_queries: list[str]) -> list[dict[str, object]]:
+    cases = observed_cases(query_log)
+    cases.extend(
+        {
+            "id": f"feedback-{hashlib.sha256(normalized_query(query).encode()).hexdigest()[:12]}",
+            "query": query,
+            "domains": list(search_config.DEFAULT_SEARCH_DOMAINS),
+            "source": "feedback-only",
+            "occurrences": 1,
+        }
+        for query in extra_queries
+    )
+    cases.extend(benchmark_cases(benchmark))
+    normalized = [normalized_query(str(case["query"])) for case in cases]
+    if len(normalized) != len(set(normalized)):
+        duplicates = sorted(query for query, count in Counter(normalized).items() if count > 1)
+        raise ValueError(f"duplicate queries across manifest sources: {', '.join(duplicates)}")
+    return cases
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("query_log", type=Path, help="sanitized Cloud Logging Weaver artifact")
+    parser.add_argument("benchmark", type=Path)
+    parser.add_argument("--extra-query", action="append", default=[], help="feedback query absent from the log slice")
+    args = parser.parse_args()
+    for case in build_manifest(args.query_log, args.benchmark, args.extra_query):
+        print(json.dumps(case, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/echo/cli.py
+++ b/infra/echo/cli.py
@@ -65,6 +65,7 @@ DOMAINS = search_config.SEARCH_DOMAINS
 DEFAULT_DOMAINS = search_config.DEFAULT_SEARCH_DOMAINS
 SEARCH_DETAIL_INSTRUCTION = "Detail: uv run infra/echo/cli.py get <domain:id>"
 MISSING_EMAIL_SCOPE_WARNING = "Not all requested scopes were granted by the authorization server, missing scopes email."
+DEFAULT_REQUEST_TIMEOUT = 30
 
 
 def cached_login_provider() -> TokenProvider | None:
@@ -104,7 +105,7 @@ def request_response(
     *,
     params: dict | None = None,
     body: object = None,
-    timeout: float = 30,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT,
 ) -> requests.Response:
     """Call echo-api and return a successful response with headers intact."""
     response = requests.request(
@@ -134,7 +135,7 @@ def request(
     *,
     params: dict | None = None,
     body: object = None,
-    timeout: float = 30,
+    timeout: float = DEFAULT_REQUEST_TIMEOUT,
 ) -> object:
     """Call echo-api and return decoded JSON."""
     return request_response(method, path, params=params, body=body, timeout=timeout).json()

--- a/infra/echo/cli.py
+++ b/infra/echo/cli.py
@@ -231,7 +231,7 @@ def cmd_search(args: argparse.Namespace) -> None:
     noun = "result" if len(results) == 1 else "results"
     print(f"{len(results)} {noun} in {elapsed:.2f}s")
     print_search_results(results)
-    execution_id = response.headers.get("X-Echo-Search-Execution-ID")
+    execution_id = response.headers.get(search_config.SEARCH_EXECUTION_HEADER)
     execution_flag = f"--execution-id {execution_id} " if execution_id else ""
     print(
         "Feedback: uv run infra/echo/cli.py feedback "

--- a/infra/echo/cli.py
+++ b/infra/echo/cli.py
@@ -24,6 +24,7 @@ ambient service-account credentials with no login. See ``infra/echo/README.md``.
 """
 
 import argparse
+import json
 import logging
 import os
 import shlex
@@ -97,15 +98,22 @@ def bearer_token() -> str:
     return token
 
 
-def request(method: str, path: str, *, params: dict | None = None, body: dict | None = None) -> object:
-    """Call echo-api and return the decoded JSON, or exit with a message on any HTTP error."""
+def request_response(
+    method: str,
+    path: str,
+    *,
+    params: dict | None = None,
+    body: object = None,
+    timeout: float = 30,
+) -> requests.Response:
+    """Call echo-api and return a successful response with headers intact."""
     response = requests.request(
         method,
         f"{API_BASE}{path}",
         params={k: v for k, v in (params or {}).items() if v is not None},
         json=body,
         headers={"Authorization": f"Bearer {bearer_token()}"},
-        timeout=30,
+        timeout=timeout,
         allow_redirects=False,
     )
     if response.status_code == 401:
@@ -117,7 +125,19 @@ def request(method: str, path: str, *, params: dict | None = None, body: dict | 
             else response.text
         )
         raise SystemExit(f"{method} {path} -> {response.status_code}: {detail}")
-    return response.json()
+    return response
+
+
+def request(
+    method: str,
+    path: str,
+    *,
+    params: dict | None = None,
+    body: object = None,
+    timeout: float = 30,
+) -> object:
+    """Call echo-api and return decoded JSON."""
+    return request_response(method, path, params=params, body=body, timeout=timeout).json()
 
 
 def response_object(value: object) -> dict[str, object]:
@@ -200,21 +220,23 @@ def read_body(value: str) -> str:
 def cmd_search(args: argparse.Namespace) -> None:
     domains = list(dict.fromkeys(args.domain or DEFAULT_DOMAINS))
     started_at = time.perf_counter()
-    remote_value = response_objects(
-        request(
-            "GET",
-            "/federated-search",
-            params={"q": args.query, "domain": domains, "limit": args.limit},
-        )
+    response = request_response(
+        "GET",
+        "/federated-search",
+        params={"q": args.query, "domain": domains, "limit": args.limit},
     )
+    remote_value = response_objects(response.json())
     results = [SearchResult.from_json(result) for result in remote_value]
     elapsed = time.perf_counter() - started_at
     noun = "result" if len(results) == 1 else "results"
     print(f"{len(results)} {noun} in {elapsed:.2f}s")
     print_search_results(results)
+    execution_id = response.headers.get("X-Echo-Search-Execution-ID")
+    execution_flag = f"--execution-id {execution_id} " if execution_id else ""
     print(
         "Feedback: uv run infra/echo/cli.py feedback "
-        f"--query {shlex.quote(args.query)} --grade '<id>=<{search_feedback.MIN_GRADE}-{search_feedback.MAX_GRADE}>' "
+        f"--query {shlex.quote(args.query)} {execution_flag}"
+        f"--grade '<id>=<{search_feedback.MIN_GRADE}-{search_feedback.MAX_GRADE}>' "
         "<<< 'brief overall assessment'"
     )
 
@@ -236,15 +258,18 @@ def cmd_feedback(args: argparse.Namespace) -> None:
     note = feedback_note()
     if note is None:
         raise SystemExit("provide a short overall explanation on stdin")
+    body = {
+        "query": args.query,
+        "grades": [{"result_id": grade.result_id, "grade": grade.grade} for grade in args.grade],
+        "note": note,
+    }
+    if args.execution_id is not None:
+        body["execution_id"] = args.execution_id
     entry = response_object(
         request(
             "POST",
             "/feedback",
-            body={
-                "query": args.query,
-                "grades": [{"result_id": grade.result_id, "grade": grade.grade} for grade in args.grade],
-                "note": note,
-            },
+            body=body,
         )
     )
     print(f"recorded feedback #{entry['id']}")
@@ -291,6 +316,24 @@ def cmd_get(args: argparse.Namespace) -> None:
         print(subtitle)
     print(f"{url}\n")
     print(text)
+
+
+def cmd_history_export(args: argparse.Namespace) -> None:
+    after_id = args.after_id
+    while True:
+        entries = response_objects(
+            request(
+                "GET",
+                "/search-executions",
+                params={"after_id": after_id, "mode": args.mode, "limit": args.page_size},
+                timeout=180,
+            )
+        )
+        for entry in entries:
+            print(json.dumps(entry, sort_keys=True))
+        if len(entries) < args.page_size:
+            return
+        after_id = int(entries[-1]["id"])
 
 
 def chunk_domain(chunk: dict[str, object]) -> str:
@@ -404,6 +447,7 @@ def build_parser() -> argparse.ArgumentParser:
         metavar=f"<result-id>=<{search_feedback.MIN_GRADE}-{search_feedback.MAX_GRADE}>",
         help="grade one result; repeat as needed (a short overall explanation is read from stdin)",
     )
+    feedback.add_argument("--execution-id", type=int, help="execution ID printed by the corresponding search")
     feedback.set_defaults(func=cmd_feedback)
 
     grep = sub.add_parser("grep", help="exact substring scan over activity, newest first")
@@ -417,6 +461,14 @@ def build_parser() -> argparse.ArgumentParser:
     get.add_argument("id", type=artifact_id)
     get.set_defaults(func=cmd_get)
 
+    history = sub.add_parser("history", help="export durable search executions").add_subparsers(
+        dest="history_command", required=True
+    )
+    history_export = history.add_parser("export", help="write search executions as JSONL")
+    history_export.add_argument("--after-id", type=int, default=0)
+    history_export.add_argument("--mode", choices=("federated", "activity", "grep"))
+    history_export.add_argument("--page-size", type=bounded_limit, default=100)
+    history_export.set_defaults(func=cmd_history_export)
     wiki = sub.add_parser("wiki", help="search, read, add, or edit wiki notes").add_subparsers(
         dest="wiki", required=True
     )

--- a/infra/echo/migrations/m0011_search_history.py
+++ b/infra/echo/migrations/m0011_search_history.py
@@ -1,0 +1,62 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persist search executions and their ranked results."""
+
+import sqlalchemy
+
+DDL = """
+CREATE TABLE search_executions (
+    id BIGINT GENERATED ALWAYS AS IDENTITY,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT now() NOT NULL,
+    author TEXT,
+    query TEXT NOT NULL,
+    normalized_query TEXT NOT NULL,
+    mode TEXT NOT NULL CHECK (mode IN ('federated', 'activity', 'grep')),
+    domains TEXT[] NOT NULL DEFAULT '{}',
+    filters JSONB NOT NULL DEFAULT '{}'::jsonb,
+    requested_limit INTEGER NOT NULL CHECK (requested_limit > 0),
+    returned_count INTEGER NOT NULL CHECK (returned_count >= 0),
+    duration_ms DOUBLE PRECISION NOT NULL CHECK (duration_ms >= 0),
+    repository_commit TEXT,
+    service_revision TEXT,
+    PRIMARY KEY (id)
+);
+CREATE INDEX idx_search_executions_created_at ON search_executions (created_at DESC);
+CREATE INDEX idx_search_executions_normalized_query ON search_executions (normalized_query);
+CREATE INDEX idx_search_executions_mode_created_at ON search_executions (mode, created_at DESC);
+
+CREATE TABLE search_execution_results (
+    execution_id BIGINT NOT NULL REFERENCES search_executions(id) ON DELETE CASCADE,
+    rank SMALLINT NOT NULL CHECK (rank > 0),
+    result_id TEXT NOT NULL,
+    domain TEXT NOT NULL CHECK (domain IN ('wiki', 'file', 'discord', 'pr', 'issue')),
+    title TEXT,
+    url TEXT NOT NULL,
+    snippet TEXT NOT NULL,
+    score DOUBLE PRECISION NOT NULL,
+    distance DOUBLE PRECISION,
+    lexical_score DOUBLE PRECISION,
+    PRIMARY KEY (execution_id, rank)
+);
+CREATE INDEX idx_search_execution_results_result_id ON search_execution_results (result_id);
+
+ALTER TABLE search_feedback
+    ADD COLUMN execution_id BIGINT REFERENCES search_executions(id) ON DELETE SET NULL;
+CREATE INDEX idx_search_feedback_execution_id ON search_feedback (execution_id);
+
+GRANT SELECT ON search_executions, search_execution_results
+    TO "eng-all@openathena.ai";
+GRANT SELECT ON search_executions, search_execution_results
+    TO "loom-vm@hai-gcp-models.iam";
+GRANT SELECT, INSERT ON search_executions, search_execution_results
+    TO "echo-api@hai-gcp-models.iam";
+GRANT USAGE, SELECT ON SEQUENCE search_executions_id_seq
+    TO "echo-api@hai-gcp-models.iam";
+"""
+
+
+def upgrade(conn: sqlalchemy.Connection) -> None:
+    for statement in DDL.strip().split(";"):
+        if statement.strip():
+            conn.execute(sqlalchemy.text(statement))

--- a/infra/echo/schema.py
+++ b/infra/echo/schema.py
@@ -7,8 +7,9 @@ The single source of truth for echo's schema. Migrations (migrations/) create an
 these tables; the sync job (sync/main.py) uses them for DML. `chunks` mirrors the
 marinmirror corpus schema for the github+discord sources; `repository_file_chunks`
 indexes GitHub branch heads; `wiki_entries` holds durable agent-authored notes;
-`work_log` is the agents' shared logbook; search feedback records relevance judgments;
-the state tables hold sync watermarks.
+`work_log` is the agents' shared logbook; search executions retain ranked result
+snapshots; search feedback records relevance judgments; the state tables hold sync
+watermarks.
 """
 
 from pgvector.sqlalchemy import Vector
@@ -21,6 +22,7 @@ from sqlalchemy import (
     Column,
     Computed,
     DateTime,
+    Float,
     ForeignKey,
     Identity,
     Index,
@@ -175,6 +177,57 @@ work_log = Table(
     Index("idx_work_log_at", text("at DESC")),
 )
 
+search_executions = Table(
+    "search_executions",
+    metadata,
+    Column("id", BigInteger, Identity(always=True), primary_key=True),
+    Column("created_at", DateTime(timezone=True), nullable=False, server_default=func.now()),
+    Column("author", Text),
+    Column("query", Text, nullable=False),
+    Column("normalized_query", Text, nullable=False),
+    Column("mode", Text, nullable=False),
+    Column("domains", ARRAY(Text), nullable=False, server_default=text("'{}'::text[]")),
+    Column("filters", postgresql.JSONB, nullable=False, server_default=text("'{}'::jsonb")),
+    Column("requested_limit", Integer, nullable=False),
+    Column("returned_count", Integer, nullable=False),
+    Column("duration_ms", Float, nullable=False),
+    Column("repository_commit", Text),
+    Column("service_revision", Text),
+    CheckConstraint("mode IN ('federated', 'activity', 'grep')", name="search_executions_mode"),
+    CheckConstraint("requested_limit > 0", name="search_executions_requested_limit_positive"),
+    CheckConstraint("returned_count >= 0", name="search_executions_returned_count_nonnegative"),
+    CheckConstraint("duration_ms >= 0", name="search_executions_duration_nonnegative"),
+    Index("idx_search_executions_created_at", text("created_at DESC")),
+    Index("idx_search_executions_normalized_query", "normalized_query"),
+    Index("idx_search_executions_mode_created_at", "mode", text("created_at DESC")),
+)
+
+search_execution_results = Table(
+    "search_execution_results",
+    metadata,
+    Column(
+        "execution_id",
+        BigInteger,
+        ForeignKey("search_executions.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column("rank", SmallInteger, primary_key=True),
+    Column("result_id", Text, nullable=False),
+    Column("domain", Text, nullable=False),
+    Column("title", Text),
+    Column("url", Text, nullable=False),
+    Column("snippet", Text, nullable=False),
+    Column("score", Float, nullable=False),
+    Column("distance", Float),
+    Column("lexical_score", Float),
+    CheckConstraint("rank > 0", name="search_execution_results_rank_positive"),
+    CheckConstraint(
+        "domain IN ('wiki', 'file', 'discord', 'pr', 'issue')",
+        name="search_execution_results_domain",
+    ),
+    Index("idx_search_execution_results_result_id", "result_id"),
+)
+
 search_feedback = Table(
     "search_feedback",
     metadata,
@@ -183,7 +236,9 @@ search_feedback = Table(
     Column("author", Text, nullable=False),
     Column("query", Text, nullable=False),
     Column("note", Text, nullable=False),
+    Column("execution_id", BigInteger, ForeignKey("search_executions.id", ondelete="SET NULL")),
     Index("idx_search_feedback_created_at", text("created_at DESC")),
+    Index("idx_search_feedback_execution_id", "execution_id"),
 )
 
 search_feedback_grades = Table(

--- a/infra/echo/search_config.py
+++ b/infra/echo/search_config.py
@@ -16,6 +16,7 @@ INDEXED_REPOSITORY = "marin-community/marin"
 INDEXED_BRANCH = "main"
 DISPLAY_SHA_CHARACTERS = 12
 FEDERATED_SUMMARY_CHARACTERS = 240
+SEARCH_EXECUTION_HEADER = "X-Echo-Search-Execution-ID"
 SearchDomain = Literal["wiki", "file", "discord", "pr", "issue"]
 SEARCH_DOMAINS: tuple[SearchDomain, ...] = ("wiki", "file", "discord", "pr", "issue")
 DEFAULT_SEARCH_DOMAINS: tuple[SearchDomain, ...] = ("wiki", "file", "pr", "issue")
@@ -72,6 +73,10 @@ class SearchWeights:
 
 QUERY_SEARCH_WEIGHTS = SearchWeights(semantic=2.0, lexical=1.0)
 IDENTIFIER_SEARCH_WEIGHTS = SearchWeights(semantic=1.0, lexical=2.0)
+
+
+def normalize_query(query: str) -> str:
+    return " ".join(query.casefold().split())
 
 
 def candidate_limit(limit: int) -> int:

--- a/infra/echo/search_history.py
+++ b/infra/echo/search_history.py
@@ -1,0 +1,89 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persist Echo search executions."""
+
+from dataclasses import dataclass
+from typing import Literal
+
+import schema
+import sqlalchemy
+
+SearchMode = Literal["federated", "activity", "grep"]
+
+
+@dataclass(frozen=True)
+class SearchResultRecord:
+    result_id: str
+    domain: str
+    title: str | None
+    url: str
+    snippet: str
+    score: float
+    distance: float | None
+    lexical_score: float | None
+
+
+@dataclass(frozen=True)
+class SearchExecutionRecord:
+    query: str
+    mode: SearchMode
+    domains: tuple[str, ...]
+    filters: dict[str, object]
+    requested_limit: int
+    returned_count: int
+    duration_ms: float
+    author: str | None = None
+    repository_commit: str | None = None
+    service_revision: str | None = None
+    results: tuple[SearchResultRecord, ...] = ()
+
+
+def normalize_query(query: str) -> str:
+    return " ".join(query.casefold().split())
+
+
+def execution_values(record: SearchExecutionRecord) -> dict[str, object]:
+    return {
+        "author": record.author,
+        "query": record.query,
+        "normalized_query": normalize_query(record.query),
+        "mode": record.mode,
+        "domains": list(record.domains),
+        "filters": record.filters,
+        "requested_limit": record.requested_limit,
+        "returned_count": record.returned_count,
+        "duration_ms": record.duration_ms,
+        "repository_commit": record.repository_commit,
+        "service_revision": record.service_revision,
+    }
+
+
+def insert_execution(conn: sqlalchemy.Connection, record: SearchExecutionRecord) -> int:
+    """Insert one execution and its ranked result snapshot."""
+    row = conn.execute(
+        schema.search_executions.insert().values(**execution_values(record)).returning(schema.search_executions.c.id)
+    ).first()
+    assert row is not None
+    execution_id = row.id
+    if record.results:
+        conn.execute(
+            schema.search_execution_results.insert().values(
+                [
+                    {
+                        "execution_id": execution_id,
+                        "rank": rank,
+                        "result_id": result.result_id,
+                        "domain": result.domain,
+                        "title": result.title,
+                        "url": result.url,
+                        "snippet": result.snippet,
+                        "score": result.score,
+                        "distance": result.distance,
+                        "lexical_score": result.lexical_score,
+                    }
+                    for rank, result in enumerate(record.results, start=1)
+                ]
+            )
+        )
+    return execution_id

--- a/infra/echo/search_history.py
+++ b/infra/echo/search_history.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 import schema
 import sqlalchemy
+from search_config import normalize_query
 
 SearchMode = Literal["federated", "activity", "grep"]
 
@@ -39,10 +40,6 @@ class SearchExecutionRecord:
     results: tuple[SearchResultRecord, ...] = ()
 
 
-def normalize_query(query: str) -> str:
-    return " ".join(query.casefold().split())
-
-
 def execution_values(record: SearchExecutionRecord) -> dict[str, object]:
     return {
         "author": record.author,
@@ -60,7 +57,11 @@ def execution_values(record: SearchExecutionRecord) -> dict[str, object]:
 
 
 def insert_execution(conn: sqlalchemy.Connection, record: SearchExecutionRecord) -> int:
-    """Insert one execution and its ranked result snapshot."""
+    """Insert one execution and its ranked result snapshot.
+
+    Returns:
+        The new search execution ID.
+    """
     row = conn.execute(
         schema.search_executions.insert().values(**execution_values(record)).returning(schema.search_executions.c.id)
     ).first()

--- a/infra/echo/search_replay.py
+++ b/infra/echo/search_replay.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import cli as echo_cli
 import search_config
+from build_search_quality_manifest import ManifestCase as ReplayCase
 
 MAX_WORKERS = 4
 RATE_LIMIT_RETRY_DELAYS = (15, 30, 60, 120)
@@ -25,43 +26,10 @@ REPLAY_REQUEST_TIMEOUT = 180
 
 
 @dataclass(frozen=True)
-class ReplayCase:
-    id: str
-    query: str
-    domains: tuple[search_config.SearchDomain, ...]
-    source: str
-    occurrences: int
-
-
-@dataclass(frozen=True)
 class ReplayResult:
     id: str
     execution_id: int
     returned_count: int
-
-
-def checked_case(value: object) -> ReplayCase:
-    if not isinstance(value, dict):
-        raise ValueError("replay case must be an object")
-    identifier = value.get("id")
-    query = value.get("query")
-    source = value.get("source")
-    domains = value.get("domains")
-    occurrences = value.get("occurrences", 1)
-    if not isinstance(identifier, str) or not identifier:
-        raise ValueError("id must be a nonblank string")
-    if not isinstance(query, str) or not query.strip():
-        raise ValueError(f"{identifier}: query must be a nonblank string")
-    if not isinstance(source, str) or not source:
-        raise ValueError(f"{identifier}: source must be a nonblank string")
-    if not isinstance(domains, list) or not domains:
-        raise ValueError(f"{identifier}: domains must be a nonempty list")
-    if not isinstance(occurrences, int) or occurrences < 1:
-        raise ValueError(f"{identifier}: occurrences must be a positive integer")
-    for domain in domains:
-        if domain not in search_config.SEARCH_DOMAINS:
-            raise ValueError(f"{identifier}: unknown domain {domain!r}")
-    return ReplayCase(identifier, query.strip(), tuple(domains), source, occurrences)
 
 
 def load_cases(path: Path) -> list[ReplayCase]:
@@ -72,10 +40,10 @@ def load_cases(path: Path) -> list[ReplayCase]:
         if not line.strip():
             continue
         try:
-            case = checked_case(json.loads(line))
+            case = ReplayCase.from_json(json.loads(line))
         except (json.JSONDecodeError, ValueError) as error:
             raise ValueError(f"{path}:{line_number}: {error}") from error
-        normalized_query = " ".join(case.query.casefold().split())
+        normalized_query = search_config.normalize_query(case.query)
         if case.id in seen_ids:
             raise ValueError(f"{path}:{line_number}: duplicate id {case.id!r}")
         if normalized_query in seen_queries:
@@ -95,8 +63,12 @@ def completed_ids(path: Path) -> set[str]:
 
 
 def reconcile_history(cases: Sequence[ReplayCase], history: Path, output: Path) -> int:
-    """Recover completed cases whose response was lost after server persistence."""
-    cases_by_query = {" ".join(case.query.casefold().split()): case for case in cases}
+    """Recover completed cases whose response was lost after server persistence.
+
+    Returns:
+        The number of recovered cases appended to ``output``.
+    """
+    cases_by_query = {search_config.normalize_query(case.query): case for case in cases}
     completed = completed_ids(output)
     recovered: dict[str, ReplayResult] = {}
     for line in history.read_text().splitlines():
@@ -133,7 +105,7 @@ def replay_one(case: ReplayCase, limit: int) -> ReplayResult:
                 raise
             time.sleep(RATE_LIMIT_RETRY_DELAYS[attempt])
     assert response is not None
-    execution_id = response.headers.get("X-Echo-Search-Execution-ID")
+    execution_id = response.headers.get(search_config.SEARCH_EXECUTION_HEADER)
     if execution_id is None:
         raise RuntimeError(f"{case.id}: Echo response omitted the execution ID")
     results = echo_cli.response_objects(response.json())

--- a/infra/echo/search_replay.py
+++ b/infra/echo/search_replay.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Replay an Echo query manifest through normal federated search.
+
+Each successful request is durably recorded by Echo. The output JSONL maps the
+manifest case to the resulting search execution ID and is safe to resume.
+"""
+
+import argparse
+import json
+import time
+from collections.abc import Sequence
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from dataclasses import dataclass
+from pathlib import Path
+
+import cli as echo_cli
+import search_config
+
+MAX_WORKERS = 4
+RATE_LIMIT_RETRY_DELAYS = (15, 30, 60, 120)
+REPLAY_REQUEST_TIMEOUT = 180
+
+
+@dataclass(frozen=True)
+class ReplayCase:
+    id: str
+    query: str
+    domains: tuple[search_config.SearchDomain, ...]
+    source: str
+    occurrences: int
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    id: str
+    execution_id: int
+    returned_count: int
+
+
+def checked_case(value: object) -> ReplayCase:
+    if not isinstance(value, dict):
+        raise ValueError("replay case must be an object")
+    identifier = value.get("id")
+    query = value.get("query")
+    source = value.get("source")
+    domains = value.get("domains")
+    occurrences = value.get("occurrences", 1)
+    if not isinstance(identifier, str) or not identifier:
+        raise ValueError("id must be a nonblank string")
+    if not isinstance(query, str) or not query.strip():
+        raise ValueError(f"{identifier}: query must be a nonblank string")
+    if not isinstance(source, str) or not source:
+        raise ValueError(f"{identifier}: source must be a nonblank string")
+    if not isinstance(domains, list) or not domains:
+        raise ValueError(f"{identifier}: domains must be a nonempty list")
+    if not isinstance(occurrences, int) or occurrences < 1:
+        raise ValueError(f"{identifier}: occurrences must be a positive integer")
+    for domain in domains:
+        if domain not in search_config.SEARCH_DOMAINS:
+            raise ValueError(f"{identifier}: unknown domain {domain!r}")
+    return ReplayCase(identifier, query.strip(), tuple(domains), source, occurrences)
+
+
+def load_cases(path: Path) -> list[ReplayCase]:
+    cases: list[ReplayCase] = []
+    seen_ids: set[str] = set()
+    seen_queries: set[str] = set()
+    for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            case = checked_case(json.loads(line))
+        except (json.JSONDecodeError, ValueError) as error:
+            raise ValueError(f"{path}:{line_number}: {error}") from error
+        normalized_query = " ".join(case.query.casefold().split())
+        if case.id in seen_ids:
+            raise ValueError(f"{path}:{line_number}: duplicate id {case.id!r}")
+        if normalized_query in seen_queries:
+            raise ValueError(f"{path}:{line_number}: duplicate normalized query {case.query!r}")
+        seen_ids.add(case.id)
+        seen_queries.add(normalized_query)
+        cases.append(case)
+    if not cases:
+        raise ValueError(f"{path} contains no replay cases")
+    return cases
+
+
+def completed_ids(path: Path) -> set[str]:
+    if not path.exists():
+        return set()
+    return {json.loads(line)["id"] for line in path.read_text().splitlines() if line.strip()}
+
+
+def reconcile_history(cases: Sequence[ReplayCase], history: Path, output: Path) -> int:
+    """Recover completed cases whose response was lost after server persistence."""
+    cases_by_query = {" ".join(case.query.casefold().split()): case for case in cases}
+    completed = completed_ids(output)
+    recovered: dict[str, ReplayResult] = {}
+    for line in history.read_text().splitlines():
+        if not line.strip():
+            continue
+        execution = json.loads(line)
+        case = cases_by_query.get(execution["normalized_query"])
+        if case is None or case.id in completed or case.id in recovered:
+            continue
+        if tuple(execution["domains"]) != case.domains:
+            continue
+        recovered[case.id] = ReplayResult(case.id, execution["id"], execution["returned_count"])
+    with output.open("a") as stream:
+        for case in cases:
+            if case.id not in recovered:
+                continue
+            stream.write(json.dumps(recovered[case.id].__dict__, sort_keys=True) + "\n")
+    return len(recovered)
+
+
+def replay_one(case: ReplayCase, limit: int) -> ReplayResult:
+    response = None
+    for attempt in range(len(RATE_LIMIT_RETRY_DELAYS) + 1):
+        try:
+            response = echo_cli.request_response(
+                "GET",
+                "/federated-search",
+                params={"q": case.query, "domain": list(case.domains), "limit": limit},
+                timeout=REPLAY_REQUEST_TIMEOUT,
+            )
+            break
+        except SystemExit as error:
+            if "-> 429:" not in str(error) or attempt == len(RATE_LIMIT_RETRY_DELAYS):
+                raise
+            time.sleep(RATE_LIMIT_RETRY_DELAYS[attempt])
+    assert response is not None
+    execution_id = response.headers.get("X-Echo-Search-Execution-ID")
+    if execution_id is None:
+        raise RuntimeError(f"{case.id}: Echo response omitted the execution ID")
+    results = echo_cli.response_objects(response.json())
+    return ReplayResult(case.id, int(execution_id), len(results))
+
+
+def replay(cases: Sequence[ReplayCase], output: Path, limit: int, workers: int) -> None:
+    completed = completed_ids(output)
+    pending = iter(case for case in cases if case.id not in completed)
+    with output.open("a") as stream, ThreadPoolExecutor(max_workers=workers) as pool:
+        futures: dict[Future[ReplayResult], ReplayCase] = {}
+        for case in pending:
+            futures[pool.submit(replay_one, case, limit)] = case
+            if len(futures) == workers:
+                break
+        while futures:
+            done, _ = wait(futures, return_when=FIRST_COMPLETED)
+            for future in done:
+                case = futures.pop(future)
+                try:
+                    result = future.result()
+                except (Exception, SystemExit):
+                    for other in futures:
+                        other.cancel()
+                    raise
+                stream.write(json.dumps(result.__dict__, sort_keys=True) + "\n")
+                stream.flush()
+                completed.add(case.id)
+                print(f"{len(completed)}/{len(cases)} {case.id} -> execution {result.execution_id}")
+                next_case = next(pending, None)
+                if next_case is not None:
+                    futures[pool.submit(replay_one, next_case, limit)] = next_case
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--limit", type=int, default=10, choices=range(1, search_config.MAX_SEARCH_LIMIT + 1))
+    parser.add_argument("--workers", type=int, default=MAX_WORKERS, choices=range(1, MAX_WORKERS + 1))
+    parser.add_argument("--history", type=Path, help="exported history used to recover server-completed requests")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    cases = load_cases(args.manifest)
+    if args.history is not None:
+        recovered = reconcile_history(cases, args.history, args.output)
+        print(f"recovered {recovered} completed cases from durable history")
+    replay(cases, args.output, args.limit, args.workers)
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/echo/test_cli.py
+++ b/infra/echo/test_cli.py
@@ -8,6 +8,15 @@ import logging
 from concurrent.futures import ThreadPoolExecutor
 
 import cli
+import requests
+
+
+def json_response(value, headers=None):
+    response = requests.Response()
+    response.status_code = 200
+    response.headers.update(headers or {})
+    response._content = cli.json.dumps(value).encode()
+    return response
 
 
 def test_search_sends_selected_domains_to_federated_endpoint(monkeypatch, capsys):
@@ -34,9 +43,9 @@ def test_search_sends_selected_domains_to_federated_endpoint(monkeypatch, capsys
 
     def fake_request(method, path, **options):
         calls.append((method, path, options))
-        return [remote_result]
+        return json_response([remote_result], {"X-Echo-Search-Execution-ID": "991"})
 
-    monkeypatch.setattr(cli, "request", fake_request)
+    monkeypatch.setattr(cli, "request_response", fake_request)
     clock = iter((10.0, 11.234))
     monkeypatch.setattr(cli.time, "perf_counter", lambda: next(clock))
     args = cli.build_parser().parse_args(["search", "FAILED_PRECONDITION", "--domain", "file", "--domain", "pr"])
@@ -53,7 +62,7 @@ def test_search_sends_selected_domains_to_federated_endpoint(monkeypatch, capsys
     assert "1 result in 1.23s" in output
     assert cli.SEARCH_DETAIL_INSTRUCTION in output
     assert "L42 raise FAILED_PRECONDITION" in output
-    assert "feedback --query FAILED_PRECONDITION --grade '<id>=<0-10>'" in output
+    assert "feedback --query FAILED_PRECONDITION --execution-id 991 --grade '<id>=<0-10>'" in output
 
 
 def test_search_defaults_to_curated_domains_without_discord(monkeypatch):
@@ -61,9 +70,9 @@ def test_search_defaults_to_curated_domains_without_discord(monkeypatch):
 
     def fake_request(method, path, **options):
         calls.append((method, path, options))
-        return []
+        return json_response([])
 
-    monkeypatch.setattr(cli, "request", fake_request)
+    monkeypatch.setattr(cli, "request_response", fake_request)
     args = cli.build_parser().parse_args(["search", "scheduler"])
     args.func(args)
 
@@ -154,3 +163,52 @@ def test_feedback_submits_replayable_grades_and_stdin_note(monkeypatch, capsys):
         )
     ]
     assert capsys.readouterr().out == "recorded feedback #17\n"
+
+
+def test_feedback_links_execution_when_provided(monkeypatch):
+    calls = []
+
+    def fake_request(method, path, **options):
+        calls.append((method, path, options))
+        return {"id": 17}
+
+    monkeypatch.setattr(cli, "request", fake_request)
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("The file answered it.\n"))
+    args = cli.build_parser().parse_args(
+        [
+            "feedback",
+            "--query",
+            "how do I deploy Iris?",
+            "--execution-id",
+            "991",
+            "--grade",
+            "file:lib/iris/OPS.md=10",
+        ]
+    )
+
+    args.func(args)
+
+    assert calls[0][2]["body"]["execution_id"] == 991
+
+
+def test_history_export_pages_in_stable_id_order(monkeypatch, capsys):
+    calls = []
+    pages = [
+        [{"id": 4, "query": "deploy iris"}, {"id": 7, "query": "inspect logs"}],
+        [{"id": 9, "query": "reserve tpu"}],
+    ]
+
+    def fake_request(method, path, **options):
+        calls.append((method, path, options))
+        return pages.pop(0)
+
+    monkeypatch.setattr(cli, "request", fake_request)
+    args = cli.build_parser().parse_args(["history", "export", "--after-id", "3", "--page-size", "2"])
+
+    args.func(args)
+
+    assert calls == [
+        ("GET", "/search-executions", {"params": {"after_id": 3, "mode": None, "limit": 2}, "timeout": 180}),
+        ("GET", "/search-executions", {"params": {"after_id": 7, "mode": None, "limit": 2}, "timeout": 180}),
+    ]
+    assert [cli.json.loads(line)["id"] for line in capsys.readouterr().out.splitlines()] == [4, 7, 9]

--- a/infra/echo/test_cli.py
+++ b/infra/echo/test_cli.py
@@ -62,7 +62,6 @@ def test_search_sends_selected_domains_to_federated_endpoint(monkeypatch, capsys
     assert "1 result in 1.23s" in output
     assert cli.SEARCH_DETAIL_INSTRUCTION in output
     assert "L42 raise FAILED_PRECONDITION" in output
-    assert "feedback --query FAILED_PRECONDITION --execution-id 991 --grade '<id>=<0-10>'" in output
 
 
 def test_search_defaults_to_curated_domains_without_discord(monkeypatch):

--- a/infra/echo/test_search_replay.py
+++ b/infra/echo/test_search_replay.py
@@ -1,0 +1,147 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import build_search_quality_manifest
+import pytest
+import requests
+import search_replay
+
+
+def test_replay_resumes_completed_cases_and_persists_each_execution(monkeypatch, tmp_path):
+    manifest = tmp_path / "manifest.jsonl"
+    output = tmp_path / "results.jsonl"
+    manifest.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "id": "observed-001",
+                        "query": "deploy iris",
+                        "domains": ["wiki", "file"],
+                        "source": "observed",
+                        "occurrences": 2,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "id": "benchmark-restart",
+                        "query": "restart iris",
+                        "domains": ["file"],
+                        "source": "benchmark",
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+    output.write_text('{"execution_id":4,"id":"observed-001","returned_count":3}\n')
+    response = requests.Response()
+    response.status_code = 200
+    response.headers["X-Echo-Search-Execution-ID"] = "9"
+    response._content = b'[{"id":"file:1"},{"id":"wiki:2"}]'
+    requests_sent = []
+
+    def fake_request(method, path, *, params, timeout):
+        requests_sent.append((method, path, params, timeout))
+        return response
+
+    monkeypatch.setattr(search_replay.echo_cli, "request_response", fake_request)
+
+    search_replay.replay(search_replay.load_cases(manifest), output, limit=10, workers=1)
+
+    assert requests_sent == [
+        (
+            "GET",
+            "/federated-search",
+            {"q": "restart iris", "domain": ["file"], "limit": 10},
+            search_replay.REPLAY_REQUEST_TIMEOUT,
+        )
+    ]
+    results = [json.loads(line) for line in output.read_text().splitlines()]
+    assert results == [
+        {"execution_id": 4, "id": "observed-001", "returned_count": 3},
+        {"execution_id": 9, "id": "benchmark-restart", "returned_count": 2},
+    ]
+
+
+def test_replay_manifest_rejects_duplicate_normalized_queries(tmp_path):
+    manifest = tmp_path / "manifest.jsonl"
+    manifest.write_text(
+        '{"id":"a","query":"Deploy  Iris","domains":["file"],"source":"observed"}\n'
+        '{"id":"b","query":" deploy iris ","domains":["file"],"source":"benchmark"}\n'
+    )
+
+    with pytest.raises(ValueError, match="duplicate normalized query"):
+        search_replay.load_cases(manifest)
+
+
+def test_replay_retries_rate_limited_normal_search(monkeypatch):
+    rate_limited = SystemExit("GET /federated-search -> 429: Rate exceeded.")
+    response = requests.Response()
+    response.status_code = 200
+    response.headers["X-Echo-Search-Execution-ID"] = "42"
+    response._content = b"[]"
+    responses = iter([rate_limited, response])
+    sleeps = []
+
+    def fake_request(*_args, **_kwargs):
+        value = next(responses)
+        if isinstance(value, BaseException):
+            raise value
+        return value
+
+    monkeypatch.setattr(search_replay.echo_cli, "request_response", fake_request)
+    monkeypatch.setattr(search_replay.time, "sleep", sleeps.append)
+    case = search_replay.ReplayCase("observed-a", "deploy iris", ("file",), "observed", 1)
+
+    result = search_replay.replay_one(case, 10)
+
+    assert result == search_replay.ReplayResult("observed-a", 42, 0)
+    assert sleeps == [15]
+
+
+def test_reconcile_recovers_matching_query_and_domains_once(tmp_path):
+    output = tmp_path / "results.jsonl"
+    history = tmp_path / "history.jsonl"
+    output.write_text('{"execution_id":4,"id":"observed-a","returned_count":3}\n')
+    history.write_text(
+        '{"id":7,"normalized_query":"deploy iris","domains":["file"],"returned_count":2}\n'
+        '{"id":8,"normalized_query":"inspect logs","domains":["wiki"],"returned_count":4}\n'
+        '{"id":9,"normalized_query":"inspect logs","domains":["file"],"returned_count":5}\n'
+        '{"id":10,"normalized_query":"inspect logs","domains":["file"],"returned_count":6}\n'
+    )
+    cases = [
+        search_replay.ReplayCase("observed-a", "deploy iris", ("file",), "observed", 1),
+        search_replay.ReplayCase("observed-b", "Inspect Logs", ("file",), "observed", 1),
+    ]
+
+    recovered = search_replay.reconcile_history(cases, history, output)
+
+    assert recovered == 1
+    results = [json.loads(line) for line in output.read_text().splitlines()]
+    assert results[-1] == {"execution_id": 9, "id": "observed-b", "returned_count": 5}
+
+
+def test_quality_manifest_groups_observed_queries_and_defaults_no_answer_domains(tmp_path):
+    query_log = tmp_path / "query-log.md"
+    benchmark = tmp_path / "benchmark.jsonl"
+    query_log.write_text(
+        "# Log\n```jsonl\n"
+        '{"mode":"federated","query":"Deploy  Iris","domains":["file"],"timestamp":"2026-08-10T00:00:00Z"}\n'
+        '{"mode":"federated","query":"deploy iris","domains":["file"],"timestamp":"2026-08-11T00:00:00Z"}\n'
+        '{"mode":"grep","query":"deploy iris","domains":[],"timestamp":"2026-08-11T00:00:00Z"}\n'
+        "```\n"
+    )
+    benchmark.write_text(
+        '{"id":"unknown","query":"unsupported question","domains":[],"split":"test","intent":"no_answer"}\n'
+    )
+
+    cases = build_search_quality_manifest.build_manifest(query_log, benchmark, ["feedback only"])
+
+    assert len(cases) == 3
+    assert cases[0]["query"] == "deploy iris"
+    assert cases[0]["occurrences"] == 2
+    assert cases[1]["source"] == "feedback-only"
+    assert cases[2]["domains"] == list(build_search_quality_manifest.search_config.DEFAULT_SEARCH_DOMAINS)

--- a/infra/echo/test_search_replay.py
+++ b/infra/echo/test_search_replay.py
@@ -141,7 +141,7 @@ def test_quality_manifest_groups_observed_queries_and_defaults_no_answer_domains
     cases = build_search_quality_manifest.build_manifest(query_log, benchmark, ["feedback only"])
 
     assert len(cases) == 3
-    assert cases[0]["query"] == "deploy iris"
-    assert cases[0]["occurrences"] == 2
-    assert cases[1]["source"] == "feedback-only"
-    assert cases[2]["domains"] == list(build_search_quality_manifest.search_config.DEFAULT_SEARCH_DOMAINS)
+    assert cases[0].query == "deploy iris"
+    assert cases[0].occurrences == 2
+    assert cases[1].source == "feedback-only"
+    assert cases[2].domains == build_search_quality_manifest.search_config.DEFAULT_SEARCH_DOMAINS

--- a/infra/pulumi/README.md
+++ b/infra/pulumi/README.md
@@ -140,6 +140,24 @@ Everything comes from the per-cluster Iris config (`lib/iris/config/<cluster>.ya
   path (typically `~/.kube/coreweave-iris`). The provider keeps this execution credential out
   of Pulumi configuration and state.
 
+### Pulumi cannot import its Python SDK
+
+These stacks use `runtime: python` without Pulumi's `virtualenv` option. Pulumi resolves
+its interpreter from `PULUMI_PYTHON_CMD` or `python3` on `PATH`; `uv sync` alone does not
+put the workspace virtualenv first on `PATH`.
+
+From the repository root, install the deployment dependencies and select that interpreter:
+
+```bash
+uv sync --all-packages --extra deploy
+export PULUMI_PYTHON_CMD="$PWD/.venv/bin/python"
+pulumi -C infra/pulumi preview
+```
+
+If the language executor reports `ModuleNotFoundError: No module named 'pulumi'`, inspect
+`PULUMI_PYTHON_CMD` before changing stack code. The Pulumi preview action uses the same
+workspace interpreter.
+
 ### Making a change
 
 ```bash

--- a/infra/pulumi/github/README.md
+++ b/infra/pulumi/github/README.md
@@ -51,6 +51,10 @@ Organization admins retain an always-on emergency bypass on both rulesets. The C
 GitHub Actions' own `marin-integration`, `marin-lint`, `rust-checks`, and `unit-tests` runs; matching
 context names from another integration do not satisfy it.
 
+The app review bypass must exist in both the review ruleset and classic `main` branch protection.
+GitHub enforces both controls: a ruleset-only bypass can leave an updater PR with green CI still
+waiting for review. After changing either control, inspect the preview and run the live audit below.
+
 App registration and installation remain owner-managed because GitHub's repository-selection
 endpoint requires a user-scoped token unsuitable for unattended Pulumi runs. The installation must
 select only `marin`. To recreate or rotate the app credential:

--- a/infra/xprof/README.md
+++ b/infra/xprof/README.md
@@ -10,3 +10,14 @@ Levanter writes XPlane profiles with optional HLO metadata under
 `tmp/ttl=Nd/xprof/<run_id>` in the `MARIN_PREFIX` backend. The gateway only opens
 `gs://` or `s3://` roots containing that `ttl=Nd/xprof/<run_id>` layout. Iris
 authenticates browser requests.
+
+## Hosted profile workflow
+
+Open the profile path in the hosted viewer and retain the run ID, storage root, and
+profile format with the result. Large multi-host profiles can spend substantial time in
+overview processing and trace-summary generation. A slow overview or summary indicates
+profile-processing work; it does not establish that the training job stalled.
+
+The hosted service has dedicated memory, disk, and proxy-timeout settings for these
+profiles. Its summary path decodes Perfetto trace JSON into compact typed events and
+computes exclusive-time and breakdown data in one pass.

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -264,6 +264,35 @@ iris task exec /user/job/0 -- bash -c "nohup bash -c 'your-command > /tmp/out.lo
 iris task exec /user/job/0 -- cat /tmp/out.log   # check later
 ```
 
+### Task with no logs or W&B progress
+
+Determine whether the task is pending, building, running, or terminal before treating
+missing logs or W&B metrics as a training stall:
+
+```bash
+iris task describe /user/job/0
+iris task events /user/job/0
+iris job logs /user/job
+```
+
+A task without a running container cannot produce task-local logs or W&B updates. For a
+running task, compare the current attempt and exit reason with driver/container logs and
+the resource request. A live process can still be compiling or blocked by host/device
+memory before its first optimizer update.
+
+Keep inspection read-only. Record the state, attempt, exit reason, and resource request
+before restarting or signalling anything.
+
+### Log filtering
+
+The Iris dashboard's full-log filter accepts a regular expression. For example,
+`rank0.*train/loss` matches log contents; an invalid expression such as an unbalanced
+`[` is rejected. Fix the expression instead of treating an empty result as evidence that
+the task produced no matching logs.
+
+The dashboard's find box searches only the lines loaded in the browser. Use the
+full-log filter when the target may be outside that segment; use find for visible lines.
+
 ### Kicking a wedged task (emergency override)
 
 When a scheduling bug or stuck node strands a task on a machine, force its

--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -175,6 +175,11 @@ outranks every tier in the band below it. Pod `priorityClassName` remains the
 ordinary Iris band, so this ordering affects Kueue admission and preemption but
 does not change kube-scheduler priority within an admitted workload.
 
+For example, a `batch` CPU coordinator uses tier `0`, its separately admitted
+accelerator child uses tier `1`, and a co-scheduled CPU/GPU group uses tier `2`.
+Choose the Iris band for operational importance; Iris derives the tier from the
+request shape.
+
 The lowest batch Workload priority is `0`. CoreWeave node-health-check Pods use
 Kubernetes priority `-1`, and Iris batch Pods retain Kubernetes priority `0`.
 Kueue Workload priority and Kubernetes Pod priority are separate scheduling
@@ -382,6 +387,17 @@ job environment values can appear in the output. Inspect named keys and
 scheduling fields instead, without printing Secret values.
 
 ## Troubleshooting
+
+### Dashboard lists and capacity
+
+Worker and task lists are paginated. Use all pages or the corresponding paginated API
+when counting workers or tasks. The dashboard command blocks while its port-forward is
+active; stopping the command closes the tunnel.
+
+Configured or registered accelerator inventory is distinct from free capacity. A healthy
+controller and a large advertised GB200 inventory do not establish that a requested
+topology can be admitted now. Confirm current slices, Kueue Workloads, and Pending Pods
+with the read-only checks below.
 
 Start with Iris's retained task view. It already joins Pod, scheduler, and Kueue
 state and remains available after Kubernetes garbage collection:

--- a/lib/zephyr/OPS.md
+++ b/lib/zephyr/OPS.md
@@ -127,6 +127,22 @@ Then compare the per-worker counters and collect thread profiles from the
 in-flight workers. Do not restart or kick a task before you collect this
 evidence.
 
+### Reading shard and worker counts
+
+Shard progress describes the current stage. `completed` counts finished shard tasks,
+`in-flight` counts assigned work, and `queued` counts work not yet assigned. A retry is
+another attempt at a shard, so attempt totals can exceed the stage's shard count.
+
+Only `WorkerState.ACTIVE` workers count as alive. Failed workers remain registered and
+can appear in total worker counts, but they cannot make progress. If all workers are
+failed, the coordinator waits for `no_workers_timeout` (six hours by default) and raises
+`ZephyrWorkerError` with the dead duration and registered-worker count.
+
+The first stage caps the worker group to its initial shard count and the configured
+maximum. Later stages can reshard while reusing that group. More shards than workers is
+normal because workers pull multiple tasks. Read shard progress with alive-worker state;
+the registered-worker count alone can overstate available capacity.
+
 ### Straggler Detection
 
 1. **Progress line**: `in-flight >> 0` with `queued == 0` means stragglers — no new work to assign, waiting on slow shards.


### PR DESCRIPTION
Permanently retain every successful Echo search with its normalized query, caller, selected domains and filters, latency, indexed repository commit, service revision, and ordered result snapshot. Search responses expose the execution ID, and feedback can link grades only to results returned by the same caller's exact execution. A stable JSONL export and resumable ordinary-search replay support offline evaluation without a history-import endpoint.

The additive migration is deployed on production before the API revision. Search remains available during a deployment window where the history table or newest columns are absent; other persistence errors still fail the request. Revision `echo-api-00024-vtc` recorded and exported a live five-result search successfully. The historical baseline contains 413 replayed queries with durable execution IDs and ranked snapshots.

The baseline exposed recurring operational questions. The relevant everyday command sequences now live in the Iris and Zephyr operations guides and the Echo, Pulumi, CoreWeave, XProf, testing, and first-experiment documentation. Less-frequent cases remain narrow Echo wiki entries instead of expanding core runbooks.

Cloud Logging retained 355 federated executions from its two-day window. Future database history is retained indefinitely without request headers, user agents, or network addresses. The baseline, grading record, and staged seed content are tracked in #8203.

Part of #8203