### PR TITLE
[datakit] Add all-source Harrier domain clustering

### DIFF
--- a/experiments/datakit/cluster/domain/v1/__init__.py
+++ b/experiments/datakit/cluster/domain/v1/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/experiments/datakit/cluster/domain/v1/coarsen.py
+++ b/experiments/datakit/cluster/domain/v1/coarsen.py
@@ -61,7 +61,14 @@ class _Cluster:
     weight: float
 
 
-def _normalized_centroids(centroids: np.ndarray, weights: np.ndarray, config: CoarseningConfig) -> np.ndarray:
+@dataclass(frozen=True)
+class _Refinement:
+    clustering: _Clustering
+    moves: int
+    sweeps: int
+
+
+def _validated_normalized_centroids(centroids: np.ndarray, weights: np.ndarray, config: CoarseningConfig) -> np.ndarray:
     vectors = np.asarray(centroids, dtype=np.float32)
     if vectors.ndim != 2 or len(vectors) != len(weights):
         raise ValueError("centroids must be two-dimensional and aligned with weights")
@@ -231,7 +238,7 @@ def _hill_climb(
     weights: np.ndarray,
     initial: _Clustering,
     minimum_fraction: float,
-) -> tuple[_Clustering, int, int]:
+) -> _Refinement:
     current = initial.assignments.copy()
     clusters = len(initial.centers)
     minimum_weight = float(weights.sum() * minimum_fraction)
@@ -276,8 +283,9 @@ def _hill_climb(
             break
 
     if moves == 0:
-        return initial, moves, sweeps
-    return _Clustering(current, sums / norms[:, None], float(weights.sum() - norms.sum())), moves, sweeps
+        return _Refinement(initial, moves, sweeps)
+    clustering = _Clustering(current, sums / norms[:, None], float(weights.sum() - norms.sum()))
+    return _Refinement(clustering, moves, sweeps)
 
 
 def _stats(clustering: _Clustering, weights: np.ndarray) -> ClusteringStats:
@@ -301,7 +309,7 @@ def coarsen_centroids(
 ) -> CoarseningResult:
     """Run multi-seed divisive clustering followed by exact single-centroid hill climbing."""
     validated_weights = _validated_weights(weights)
-    vectors = _normalized_centroids(centroids, validated_weights, config)
+    vectors = _validated_normalized_centroids(centroids, validated_weights, config)
     divisive_runs = []
     selected = None
     selected_seed = None
@@ -314,14 +322,14 @@ def coarsen_centroids(
     if selected is None or selected_seed is None:
         raise RuntimeError("no divisive clustering run completed")
 
-    refined, moves, sweeps = _hill_climb(vectors, validated_weights, selected, config.minimum_fraction)
+    refinement = _hill_climb(vectors, validated_weights, selected, config.minimum_fraction)
     return CoarseningResult(
-        fine_to_coarse=refined.assignments,
-        centers=refined.centers,
+        fine_to_coarse=refinement.clustering.assignments,
+        centers=refinement.clustering.centers,
         selected_seed=selected_seed,
         divisive_runs=tuple(divisive_runs),
         initial=_stats(selected, validated_weights),
-        final=_stats(refined, validated_weights),
-        moves=moves,
-        sweeps=sweeps,
+        final=_stats(refinement.clustering, validated_weights),
+        moves=refinement.moves,
+        sweeps=refinement.sweeps,
     )

--- a/experiments/datakit/cluster/domain/v1/coarsen.py
+++ b/experiments/datakit/cluster/domain/v1/coarsen.py
@@ -1,0 +1,327 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Coarsen weighted domain centroids into broad groups."""
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class CoarseningConfig:
+    clusters: int
+    minimum_fraction: float
+    seeds: tuple[int, ...]
+    split_restarts: int
+    split_iterations: int
+
+
+@dataclass(frozen=True)
+class ClusteringStats:
+    loss: float
+    weighted_mean_cosine_distance: float
+    minimum_weight_fraction: float
+    maximum_weight_fraction: float
+    weight_fractions: np.ndarray
+    fine_centroid_counts: np.ndarray
+
+
+@dataclass(frozen=True)
+class SeedResult:
+    seed: int
+    stats: ClusteringStats
+
+
+@dataclass(frozen=True)
+class CoarseningResult:
+    fine_to_coarse: np.ndarray
+    centers: np.ndarray
+    selected_seed: int
+    divisive_runs: tuple[SeedResult, ...]
+    initial: ClusteringStats
+    final: ClusteringStats
+    moves: int
+    sweeps: int
+
+
+@dataclass(frozen=True)
+class _Clustering:
+    assignments: np.ndarray
+    centers: np.ndarray
+    loss: float
+
+
+@dataclass(frozen=True)
+class _Cluster:
+    indices: np.ndarray
+    center: np.ndarray
+    loss: float
+    weight: float
+
+
+def _normalized_centroids(centroids: np.ndarray, weights: np.ndarray, config: CoarseningConfig) -> np.ndarray:
+    vectors = np.asarray(centroids, dtype=np.float32)
+    if vectors.ndim != 2 or len(vectors) != len(weights):
+        raise ValueError("centroids must be two-dimensional and aligned with weights")
+    if not np.all(np.isfinite(vectors)):
+        raise ValueError("centroids must be finite")
+    if config.clusters < 2 or len(vectors) < config.clusters or not 0 < config.minimum_fraction <= 1 / config.clusters:
+        raise ValueError("cluster count and minimum fraction are infeasible")
+    if not config.seeds or config.split_restarts <= 0 or config.split_iterations <= 0:
+        raise ValueError("seeds, split restarts, and split iterations must be positive")
+    norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+    if np.any(norms == 0):
+        raise ValueError("centroids must have nonzero norm")
+    return np.asarray(vectors / norms, dtype=np.float32)
+
+
+def _validated_weights(weights: np.ndarray) -> np.ndarray:
+    values = np.asarray(weights, dtype=np.float64)
+    if values.ndim != 1 or np.any(values <= 0) or not np.all(np.isfinite(values)):
+        raise ValueError("weights must be a one-dimensional array of positive finite values")
+    return values
+
+
+def _cluster(indices: np.ndarray, vectors: np.ndarray, weights: np.ndarray) -> _Cluster:
+    weighted_sum = (vectors[indices] * weights[indices, None]).sum(axis=0)
+    norm = np.linalg.norm(weighted_sum)
+    if norm == 0:
+        raise ValueError("cluster has a zero-norm weighted centroid")
+    center = weighted_sum / norm
+    weight = float(weights[indices].sum())
+    return _Cluster(indices, center, weight - float(norm), weight)
+
+
+def _repair_split(
+    labels: np.ndarray,
+    similarities: np.ndarray,
+    weights: np.ndarray,
+    minimum_weight: float,
+) -> np.ndarray | None:
+    repaired = labels.copy()
+    child_weights = np.bincount(repaired, weights=weights, minlength=2)
+    for recipient in np.argsort(child_weights):
+        if child_weights[recipient] >= minimum_weight:
+            continue
+        donor = 1 - int(recipient)
+        donor_indices = np.flatnonzero(repaired == donor)
+        move_costs = similarities[donor_indices, donor] - similarities[donor_indices, recipient]
+        for index in donor_indices[np.argsort(move_costs)]:
+            weight = weights[index]
+            if child_weights[donor] - weight < minimum_weight:
+                continue
+            repaired[index] = recipient
+            child_weights[donor] -= weight
+            child_weights[recipient] += weight
+            if child_weights[recipient] >= minimum_weight:
+                break
+        if child_weights[recipient] < minimum_weight:
+            return None
+    return repaired
+
+
+def _split_once(
+    parent: _Cluster,
+    vectors: np.ndarray,
+    weights: np.ndarray,
+    minimum_weight: float,
+    iterations: int,
+    rng: np.random.Generator,
+) -> tuple[_Cluster, _Cluster] | None:
+    indices = parent.indices
+    local_vectors = vectors[indices]
+    local_weights = weights[indices]
+    first = int(rng.choice(len(indices), p=local_weights / local_weights.sum()))
+    first_distances = np.maximum(1.0 - local_vectors @ local_vectors[first], 0.0)
+    second_weights = local_weights * first_distances
+    if second_weights.sum() == 0:
+        return None
+    second = int(rng.choice(len(indices), p=second_weights / second_weights.sum()))
+    centers = local_vectors[[first, second]].copy()
+    labels = np.full(len(indices), -1, dtype=np.int8)
+
+    for _ in range(iterations):
+        similarities = local_vectors @ centers.T
+        proposed = np.argmax(similarities, axis=1).astype(np.int8)
+        proposed = _repair_split(proposed, similarities, local_weights, minimum_weight)
+        if proposed is None:
+            return None
+        if np.array_equal(labels, proposed):
+            break
+        labels = proposed
+        for child in range(2):
+            selected = labels == child
+            weighted_sum = (local_vectors[selected] * local_weights[selected, None]).sum(axis=0)
+            norm = np.linalg.norm(weighted_sum)
+            if norm == 0:
+                return None
+            centers[child] = weighted_sum / norm
+
+    if np.any(labels < 0):
+        return None
+    return (
+        _cluster(indices[labels == 0], vectors, weights),
+        _cluster(indices[labels == 1], vectors, weights),
+    )
+
+
+def _best_split(
+    parent: _Cluster,
+    vectors: np.ndarray,
+    weights: np.ndarray,
+    minimum_weight: float,
+    config: CoarseningConfig,
+    rng: np.random.Generator,
+) -> tuple[_Cluster, _Cluster] | None:
+    best = None
+    best_loss = np.inf
+    for _ in range(config.split_restarts):
+        candidate = _split_once(parent, vectors, weights, minimum_weight, config.split_iterations, rng)
+        if candidate is None:
+            continue
+        loss = candidate[0].loss + candidate[1].loss
+        if loss < best_loss:
+            best = candidate
+            best_loss = loss
+    return best
+
+
+def _divisive_clustering(
+    vectors: np.ndarray,
+    weights: np.ndarray,
+    config: CoarseningConfig,
+    seed: int,
+) -> _Clustering:
+    minimum_weight = float(weights.sum() * config.minimum_fraction)
+    rng = np.random.default_rng(seed)
+    partition = [_cluster(np.arange(len(vectors)), vectors, weights)]
+    while len(partition) < config.clusters:
+        candidates = sorted(
+            (cluster for cluster in partition if cluster.weight >= 2 * minimum_weight),
+            key=lambda cluster: cluster.loss,
+            reverse=True,
+        )
+        split = None
+        parent = None
+        for candidate in candidates:
+            split = _best_split(candidate, vectors, weights, minimum_weight, config, rng)
+            if split is not None:
+                parent = candidate
+                break
+        if split is None or parent is None:
+            raise ValueError(f"could not produce {config.clusters} clusters while preserving the minimum fraction")
+        parent_index = next(index for index, cluster in enumerate(partition) if cluster is parent)
+        partition[parent_index : parent_index + 1] = split
+
+    partition.sort(key=lambda cluster: int(cluster.indices.min()))
+    assignments = np.empty(len(vectors), dtype=np.int32)
+    for label, cluster in enumerate(partition):
+        assignments[cluster.indices] = label
+    return _Clustering(
+        assignments=assignments,
+        centers=np.stack([cluster.center for cluster in partition]),
+        loss=sum(cluster.loss for cluster in partition),
+    )
+
+
+def _hill_climb(
+    vectors: np.ndarray,
+    weights: np.ndarray,
+    initial: _Clustering,
+    minimum_fraction: float,
+) -> tuple[_Clustering, int, int]:
+    current = initial.assignments.copy()
+    clusters = len(initial.centers)
+    minimum_weight = float(weights.sum() * minimum_fraction)
+    cluster_weights = np.bincount(current, weights=weights, minlength=clusters)
+    sums = np.zeros((clusters, vectors.shape[1]), dtype=np.float64)
+    np.add.at(sums, current, vectors * weights[:, None])
+    norms = np.linalg.norm(sums, axis=1)
+    tolerance = np.finfo(np.float64).eps * weights.sum()
+    moves = 0
+    sweeps = 0
+
+    while True:
+        sweep_moves = 0
+        for point, vector in enumerate(vectors):
+            source = int(current[point])
+            weight = weights[point]
+            if cluster_weights[source] - weight < minimum_weight:
+                continue
+            similarities = sums @ vector
+            removal_norm = math.sqrt(max(norms[source] ** 2 + weight**2 - 2 * weight * similarities[source], 0))
+            if removal_norm == 0:
+                continue
+            addition_norms = np.sqrt(np.maximum(norms**2 + weight**2 + 2 * weight * similarities, 0))
+            gains = removal_norm + addition_norms - norms[source] - norms
+            gains[source] = -np.inf
+            target = int(np.argmax(gains))
+            if gains[target] <= tolerance:
+                continue
+
+            weighted_vector = weight * vector
+            sums[source] -= weighted_vector
+            sums[target] += weighted_vector
+            cluster_weights[source] -= weight
+            cluster_weights[target] += weight
+            norms[source] = removal_norm
+            norms[target] = addition_norms[target]
+            current[point] = target
+            moves += 1
+            sweep_moves += 1
+        sweeps += 1
+        if sweep_moves == 0:
+            break
+
+    if moves == 0:
+        return initial, moves, sweeps
+    return _Clustering(current, sums / norms[:, None], float(weights.sum() - norms.sum())), moves, sweeps
+
+
+def _stats(clustering: _Clustering, weights: np.ndarray) -> ClusteringStats:
+    cluster_count = len(clustering.centers)
+    cluster_weights = np.bincount(clustering.assignments, weights=weights, minlength=cluster_count)
+    fractions = cluster_weights / weights.sum()
+    return ClusteringStats(
+        loss=clustering.loss,
+        weighted_mean_cosine_distance=clustering.loss / weights.sum(),
+        minimum_weight_fraction=float(fractions.min()),
+        maximum_weight_fraction=float(fractions.max()),
+        weight_fractions=fractions,
+        fine_centroid_counts=np.bincount(clustering.assignments, minlength=cluster_count),
+    )
+
+
+def coarsen_centroids(
+    centroids: np.ndarray,
+    weights: np.ndarray,
+    config: CoarseningConfig,
+) -> CoarseningResult:
+    """Run multi-seed divisive clustering followed by exact single-centroid hill climbing."""
+    validated_weights = _validated_weights(weights)
+    vectors = _normalized_centroids(centroids, validated_weights, config)
+    divisive_runs = []
+    selected = None
+    selected_seed = None
+    for seed in config.seeds:
+        clustering = _divisive_clustering(vectors, validated_weights, config, seed)
+        divisive_runs.append(SeedResult(seed, _stats(clustering, validated_weights)))
+        if selected is None or clustering.loss < selected.loss:
+            selected = clustering
+            selected_seed = seed
+    if selected is None or selected_seed is None:
+        raise RuntimeError("no divisive clustering run completed")
+
+    refined, moves, sweeps = _hill_climb(vectors, validated_weights, selected, config.minimum_fraction)
+    return CoarseningResult(
+        fine_to_coarse=refined.assignments,
+        centers=refined.centers,
+        selected_seed=selected_seed,
+        divisive_runs=tuple(divisive_runs),
+        initial=_stats(selected, validated_weights),
+        final=_stats(refined, validated_weights),
+        moves=moves,
+        sweeps=sweeps,
+    )

--- a/experiments/datakit/cluster/domain/v1/harrier_all_sources.py
+++ b/experiments/datakit/cluster/domain/v1/harrier_all_sources.py
@@ -6,12 +6,11 @@
 import hashlib
 import json
 import logging
-import os
 import time
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 
 import numpy as np
 import pyarrow as pa
@@ -21,7 +20,7 @@ from marin.datakit.source_key import datakit_source_path
 from marin.execution.remote import remote
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
-from rigging.filesystem import StoragePath, open_url
+from rigging.filesystem import StoragePath, open_url, prefix_join
 from rigging.log_setup import configure_logging
 from zephyr import counters
 from zephyr.dataset import Dataset, ShardInfo
@@ -29,7 +28,12 @@ from zephyr.execution import ZephyrContext
 from zephyr.readers import InputFileSpec, load_file
 from zephyr.runners import InlineRunner
 
-from experiments.datakit.cluster.domain.v1.coarsen import CoarseningConfig, CoarseningResult, coarsen_centroids
+from experiments.datakit.cluster.domain.v1.coarsen import (
+    ClusteringStats,
+    CoarseningConfig,
+    CoarseningResult,
+    coarsen_centroids,
+)
 from experiments.datakit.embeddings.harrier.pipeline import HARRIER_DIM, dequantize_to_fp32
 from experiments.datakit.reference_pipeline import select_sources
 
@@ -60,6 +64,18 @@ COARSENING_CONFIG = CoarseningConfig(
     split_iterations=20,
 )
 
+
+def _coarsening_cache_key(config: CoarseningConfig) -> str:
+    if config.seeds == tuple(range(config.seeds[0], config.seeds[-1] + 1)):
+        seeds = f"{config.seeds[0]}-{config.seeds[-1]}"
+    else:
+        seeds = "-".join(str(seed) for seed in config.seeds)
+    minimum_percent = config.minimum_fraction * 100
+    return f"divisive-k{config.clusters}-min{minimum_percent:g}pct-seeds{seeds}-hill-climb"
+
+
+COARSENING_CACHE_KEY = _coarsening_cache_key(COARSENING_CONFIG)
+
 DRIVER_RESOURCES = ResourceConfig.with_cpu(cpu=2, ram="16g", preemptible=False)
 SAMPLE_WORKER_RESOURCES = ResourceConfig.with_cpu(cpu=2, ram="16g")
 TRAIN_RESOURCES = ResourceConfig.with_cpu(cpu=N_THREADS, ram="256g", disk="32g", preemptible=False)
@@ -80,6 +96,40 @@ class SourceSample:
     quota: int
 
 
+@dataclass(frozen=True)
+class _TrainingData:
+    embeddings: np.ndarray
+    population: np.ndarray
+    rows_by_source: dict[str, int]
+
+
+class _SearchIndex(Protocol):
+    def search(self, values: np.ndarray, k: int) -> tuple[np.ndarray, np.ndarray]: ...
+
+
+@dataclass(frozen=True)
+class _TrainedCentroids:
+    centroids: np.ndarray
+    index: _SearchIndex
+    seconds: float
+    objective: float
+
+
+def _largest_remainder_quotas(weights: tuple[int, ...], target: int) -> tuple[int, ...]:
+    total = sum(weights)
+    if target == 0:
+        return (0,) * len(weights)
+    if total == 0:
+        raise ValueError("cannot allocate a positive quota across zero available rows")
+    numerators = [target * weight for weight in weights]
+    quotas = [numerator // total for numerator in numerators]
+    leftover = target - sum(quotas)
+    order = sorted(range(len(weights)), key=lambda index: (-(numerators[index] % total), index))
+    for index in order[:leftover]:
+        quotas[index] += 1
+    return tuple(quotas)
+
+
 def proportional_quotas(counts: dict[str, int], target: int) -> dict[str, int]:
     if target < len(counts) * SMALL_SOURCE_QUOTA:
         raise ValueError("target is too small for the one-document source floor")
@@ -88,14 +138,10 @@ def proportional_quotas(counts: dict[str, int], target: int) -> dict[str, int]:
 
     small = {source for source, rows in counts.items() if rows <= SMALL_SOURCE_MAX_ROWS}
     quotas = {source: SMALL_SOURCE_QUOTA for source in small}
-    large = {source: rows for source, rows in counts.items() if source not in small}
+    large_sources = tuple(sorted(source for source in counts if source not in small))
     remaining = target - sum(quotas.values())
-    large_rows = sum(large.values())
-    numerators = {source: remaining * rows for source, rows in large.items()}
-    quotas.update({source: numerator // large_rows for source, numerator in numerators.items()})
-    leftover = target - sum(quotas.values())
-    for source in sorted(large, key=lambda name: (-(numerators[name] % large_rows), name))[:leftover]:
-        quotas[source] += 1
+    large_quotas = _largest_remainder_quotas(tuple(counts[source] for source in large_sources), remaining)
+    quotas.update(dict(zip(large_sources, large_quotas, strict=True)))
     if any(quota > counts[source] for source, quota in quotas.items()):
         raise ValueError("a source quota exceeds its document count")
     return quotas
@@ -107,18 +153,12 @@ def training_quotas(counts: dict[str, int], target: int) -> dict[str, int]:
     if target > sum(counts.values()):
         raise ValueError("target exceeds the available documents")
 
-    quotas = {source: 1 for source in counts}
+    sources = tuple(sorted(counts))
     remaining = target - len(counts)
     if remaining == 0:
-        return quotas
-    capacities = {source: rows - 1 for source, rows in counts.items()}
-    total_capacity = sum(capacities.values())
-    numerators = {source: remaining * capacity for source, capacity in capacities.items()}
-    quotas = {source: quotas[source] + numerator // total_capacity for source, numerator in numerators.items()}
-    leftover = target - sum(quotas.values())
-    for source in sorted(counts, key=lambda name: (-(numerators[name] % total_capacity), name))[:leftover]:
-        quotas[source] += 1
-    return quotas
+        return {source: 1 for source in sources}
+    extra = _largest_remainder_quotas(tuple(counts[source] - 1 for source in sources), remaining)
+    return {source: quota + 1 for source, quota in zip(sources, extra, strict=True)}
 
 
 def _stratified_indices(
@@ -146,14 +186,7 @@ def _stratified_indices(
 
 
 def _part_quotas(rows: tuple[int, ...], target: int) -> tuple[int, ...]:
-    total = sum(rows)
-    numerators = [target * count for count in rows]
-    quotas = [numerator // total for numerator in numerators]
-    leftover = target - sum(quotas)
-    order = sorted(range(len(rows)), key=lambda index: (-(numerators[index] % total), index))
-    for index in order[:leftover]:
-        quotas[index] += 1
-    return tuple(quotas)
+    return _largest_remainder_quotas(rows, target)
 
 
 def _row_count(path: str) -> int:
@@ -163,7 +196,7 @@ def _row_count(path: str) -> int:
 
 def _source_samples(embedding_paths: dict[str, str]) -> tuple[SourceSample, ...]:
     source_paths = {
-        source: tuple(sorted(str(shard) for shard in StoragePath(f"{path}/*.parquet").glob()))
+        source: tuple(sorted(str(shard) for shard in StoragePath(prefix_join(path, "*.parquet")).glob()))
         for source, path in sorted(embedding_paths.items())
     }
     if any(not paths for paths in source_paths.values()):
@@ -193,15 +226,19 @@ def _source_samples(embedding_paths: dict[str, str]) -> tuple[SourceSample, ...]
 
 
 def _completed_embedding_paths(source_names: tuple[str, ...]) -> dict[str, str]:
-    records = sorted(str(path) for path in StoragePath(f"{EMBEDDING_ROOT}/**/.artifact.json").glob())
+    embedding_root = StoragePath(EMBEDDING_ROOT)
+    records = [
+        StoragePath(path)
+        for path in sorted(str(path) for path in StoragePath(prefix_join(EMBEDDING_ROOT, "**/.artifact.json")).glob())
+    ]
     candidates: dict[str, list[str]] = {source: [] for source in source_names}
     source_prefixes = sorted(source_names, key=len, reverse=True)
     for record in records:
-        output_path = record.removesuffix("/.artifact.json")
-        relative = output_path.removeprefix(f"{EMBEDDING_ROOT}/")
+        output_path = record.parent
+        relative = output_path.relative_to(embedding_root)
         for source in source_prefixes:
             if relative.startswith(f"{source}_"):
-                candidates[source].append(output_path)
+                candidates[source].append(str(output_path))
                 break
 
     resolved = {}
@@ -248,8 +285,8 @@ def _sample_source(sample: SourceSample, output_path: str) -> None:
     selected = [
         (path, rows, quota) for path, rows, quota in zip(sample.paths, sample.rows, quotas, strict=True) if quota
     ]
-    source_dir = f"{output_path.rstrip('/')}/{sample.source.replace('/', '-')}"
-    output_paths = tuple(f"{source_dir}/sample-{index:06d}.parquet" for index in range(len(selected)))
+    source_dir = prefix_join(output_path, sample.source.replace("/", "-"))
+    output_paths = tuple(prefix_join(source_dir, f"sample-{index:06d}.parquet") for index in range(len(selected)))
     dataset = (
         Dataset.from_list([InputFileSpec(path=path, columns=["embedding"]) for path, _, _ in selected])
         .flat_map(load_file)
@@ -287,7 +324,7 @@ def sample_embeddings(output_path: str, source_names: tuple[str, ...]) -> None:
 
     source_rows = {sample.source: sum(sample.rows) for sample in samples}
     source_quotas = {sample.source: sample.quota for sample in samples}
-    with open_url(f"{output_path.rstrip('/')}/sample_stats.json", "w") as file:
+    with open_url(prefix_join(output_path, "sample_stats.json"), "w") as file:
         json.dump(
             {
                 "target_rows": TARGET_ROWS,
@@ -305,17 +342,18 @@ def sample_embeddings(output_path: str, source_names: tuple[str, ...]) -> None:
         )
 
 
-def _coarsening_payload(result: CoarseningResult) -> dict[str, Any]:
-    def stats(value: Any) -> dict[str, Any]:
-        return {
-            "loss": value.loss,
-            "weighted_mean_cosine_distance": value.weighted_mean_cosine_distance,
-            "minimum_weight_fraction": value.minimum_weight_fraction,
-            "maximum_weight_fraction": value.maximum_weight_fraction,
-            "weight_fractions": value.weight_fractions.tolist(),
-            "fine_centroid_counts": value.fine_centroid_counts.tolist(),
-        }
+def _stats_payload(value: ClusteringStats) -> dict[str, Any]:
+    return {
+        "loss": value.loss,
+        "weighted_mean_cosine_distance": value.weighted_mean_cosine_distance,
+        "minimum_weight_fraction": value.minimum_weight_fraction,
+        "maximum_weight_fraction": value.maximum_weight_fraction,
+        "weight_fractions": value.weight_fractions.tolist(),
+        "fine_centroid_counts": value.fine_centroid_counts.tolist(),
+    }
 
+
+def _coarsening_payload(result: CoarseningResult) -> dict[str, Any]:
     return {
         "method": "weighted_divisive_spherical_kmeans_then_single_centroid_hill_climb",
         "minimum_fraction": COARSENING_CONFIG.minimum_fraction,
@@ -323,9 +361,9 @@ def _coarsening_payload(result: CoarseningResult) -> dict[str, Any]:
         "split_restarts": COARSENING_CONFIG.split_restarts,
         "split_iterations": COARSENING_CONFIG.split_iterations,
         "selected_seed": result.selected_seed,
-        "divisive_runs": [{"seed": run.seed, "stats": stats(run.stats)} for run in result.divisive_runs],
-        "initial": stats(result.initial),
-        "final": stats(result.final),
+        "divisive_runs": [{"seed": run.seed, "stats": _stats_payload(run.stats)} for run in result.divisive_runs],
+        "initial": _stats_payload(result.initial),
+        "final": _stats_payload(result.final),
         "moves": result.moves,
         "sweeps": result.sweeps,
     }
@@ -340,8 +378,8 @@ def _load_training_embeddings(
     sample_path: str,
     target: int,
     seed: int,
-) -> tuple[np.ndarray, np.ndarray, dict[str, int]]:
-    paths = sorted(str(path) for path in StoragePath(f"{sample_path.rstrip('/')}/**/*.parquet").glob())
+) -> _TrainingData:
+    paths = sorted(str(path) for path in StoragePath(prefix_join(sample_path, "**/*.parquet")).glob())
     if not paths:
         raise FileNotFoundError(f"No centroid sample shards under {sample_path}")
 
@@ -366,10 +404,10 @@ def _load_training_embeddings(
         len(training_embeddings),
         time.monotonic() - started,
     )
-    return training_embeddings, quantized, quotas
+    return _TrainingData(training_embeddings, quantized, quotas)
 
 
-def _cluster_weights(index: Any, quantized: np.ndarray) -> np.ndarray:
+def _cluster_weights(index: _SearchIndex, quantized: np.ndarray) -> np.ndarray:
     weights = np.zeros(K_TRAIN, dtype=np.int64)
     for start in range(0, len(quantized), ASSIGN_BATCH_ROWS):
         batch = dequantize_to_fp32(quantized[start : start + ASSIGN_BATCH_ROWS])
@@ -379,66 +417,81 @@ def _cluster_weights(index: Any, quantized: np.ndarray) -> np.ndarray:
 
 
 def _save_npy(array: np.ndarray, output_path: str, name: str) -> None:
-    with open_url(os.path.join(output_path, name), "wb") as file:
+    with open_url(prefix_join(output_path, name), "wb") as file:
         np.save(file, array)
 
 
-def train_centroids(output_path: str, sample_path: str) -> None:
+def _train_fine_centroids(embeddings: np.ndarray) -> _TrainedCentroids:
     import faiss  # noqa: PLC0415
-    from threadpoolctl import threadpool_limits  # noqa: PLC0415
 
     faiss.omp_set_num_threads(N_THREADS)
-    embeddings, population, training_rows_by_source = _load_training_embeddings(sample_path, TRAIN_ROWS, SEED)
-    with threadpool_limits(limits=N_THREADS):
-        started = time.monotonic()
-        kmeans = faiss.Kmeans(
-            d=HARRIER_DIM,
-            k=K_TRAIN,
-            niter=N_ITER,
-            nredo=N_REDO,
-            spherical=True,
-            seed=SEED,
-            verbose=True,
-            max_points_per_centroid=TRAIN_POINTS_PER_CENTROID,
-        )
-        kmeans.train(embeddings)
-        centroids = kmeans.centroids.astype(np.float32, copy=False)
-        train_seconds = time.monotonic() - started
-        weights = _cluster_weights(kmeans.index, population).astype(np.float64)
-        if np.any(weights == 0):
-            raise ValueError("K-means produced an empty fine cluster")
-        coarsening = coarsen_centroids(
-            centroids,
-            weights,
-            COARSENING_CONFIG,
-        )
+    started = time.monotonic()
+    kmeans = faiss.Kmeans(
+        d=HARRIER_DIM,
+        k=K_TRAIN,
+        niter=N_ITER,
+        nredo=N_REDO,
+        spherical=True,
+        seed=SEED,
+        verbose=True,
+        max_points_per_centroid=TRAIN_POINTS_PER_CENTROID,
+    )
+    kmeans.train(embeddings)
+    return _TrainedCentroids(
+        centroids=kmeans.centroids.astype(np.float32, copy=False),
+        index=kmeans.index,
+        seconds=time.monotonic() - started,
+        objective=float(kmeans.obj[-1]),
+    )
 
-    _save_npy(centroids, output_path, f"centroids_{K_TRAIN}.npy")
+
+def _write_training_artifact(
+    output_path: str,
+    sample_path: str,
+    training: _TrainingData,
+    trained: _TrainedCentroids,
+    weights: np.ndarray,
+    coarsening: CoarseningResult,
+) -> None:
+    _save_npy(trained.centroids, output_path, f"centroids_{K_TRAIN}.npy")
     _save_npy(coarsening.fine_to_coarse, output_path, f"lookup_{K_TRAIN}_to_{K_COARSE}.npy")
-    with open_url(os.path.join(output_path, "fine_cluster_weights.json"), "w") as file:
+    with open_url(prefix_join(output_path, "fine_cluster_weights.json"), "w") as file:
         json.dump({"document_counts_5000": weights.astype(int).tolist()}, file)
-    with open_url(os.path.join(output_path, "train_stats.json"), "w") as file:
+    with open_url(prefix_join(output_path, "train_stats.json"), "w") as file:
         json.dump(
             {
                 "sample_path": sample_path,
                 "embedding_dim": HARRIER_DIM,
                 "k_train": K_TRAIN,
                 "k_views": [K_COARSE],
-                "n_sample": len(embeddings),
-                "population_rows": len(population),
+                "n_sample": len(training.embeddings),
+                "population_rows": len(training.population),
                 "training_points_per_centroid": TRAIN_POINTS_PER_CENTROID,
-                "training_rows_by_source": training_rows_by_source,
+                "training_rows_by_source": training.rows_by_source,
                 "n_iter": N_ITER,
                 "n_redo": N_REDO,
                 "seed": SEED,
                 "n_threads": N_THREADS,
-                "train_seconds": train_seconds,
-                "final_objective": float(kmeans.obj[-1]),
+                "train_seconds": trained.seconds,
+                "final_objective": trained.objective,
                 "coarsening": _coarsening_payload(coarsening),
             },
             file,
             indent=2,
         )
+
+
+def train_centroids(output_path: str, sample_path: str) -> None:
+    from threadpoolctl import threadpool_limits  # noqa: PLC0415
+
+    training = _load_training_embeddings(sample_path, TRAIN_ROWS, SEED)
+    with threadpool_limits(limits=N_THREADS):
+        trained = _train_fine_centroids(training.embeddings)
+        weights = _cluster_weights(trained.index, training.population).astype(np.float64)
+        if np.any(weights == 0):
+            raise ValueError("K-means produced an empty fine cluster")
+        coarsening = coarsen_centroids(trained.centroids, weights, COARSENING_CONFIG)
+    _write_training_artifact(output_path, sample_path, training, trained, weights, coarsening)
 
 
 def build_steps() -> tuple[StepSpec, StepSpec]:
@@ -474,7 +527,7 @@ def build_steps() -> tuple[StepSpec, StepSpec]:
             "n_redo": N_REDO,
             "seed": SEED,
             "n_threads": N_THREADS,
-            "coarsening": "divisive-k40-min1pct-seeds42-44-hill-climb",
+            "coarsening": COARSENING_CACHE_KEY,
             "v": 2,
         },
         fn=remote(

--- a/experiments/datakit/cluster/domain/v1/harrier_all_sources.py
+++ b/experiments/datakit/cluster/domain/v1/harrier_all_sources.py
@@ -3,39 +3,18 @@
 
 """Train Harrier domain clusters on a proportional sample of every source."""
 
-import hashlib
-import json
 import logging
-import time
-from collections.abc import Iterator
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
-from typing import Any, Protocol
 
-import numpy as np
-import pyarrow as pa
-import pyarrow.parquet as pq
 from fray.types import ResourceConfig
-from marin.datakit.source_key import datakit_source_path
 from marin.execution.remote import remote
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
-from rigging.filesystem import StoragePath, open_url, prefix_join
 from rigging.log_setup import configure_logging
-from zephyr import counters
-from zephyr.dataset import Dataset, ShardInfo
-from zephyr.execution import ZephyrContext
-from zephyr.readers import InputFileSpec, load_file
-from zephyr.runners import InlineRunner
 
-from experiments.datakit.cluster.domain.v1.coarsen import (
-    ClusteringStats,
-    CoarseningConfig,
-    CoarseningResult,
-    coarsen_centroids,
-)
-from experiments.datakit.embeddings.harrier.pipeline import HARRIER_DIM, dequantize_to_fp32
-from experiments.datakit.reference_pipeline import select_sources
+from experiments.datakit.cluster.domain.v1.coarsen import CoarseningConfig
+from experiments.datakit.cluster.domain.v1.sample import sample_centroid_inputs
+from experiments.datakit.cluster.domain.v1.train import train_centroids
+from experiments.datakit.embeddings.harrier.run import build_steps as build_harrier_embeddings
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +33,7 @@ PARALLEL_SOURCES = 16
 MAX_WORKERS = 64
 LOAD_PARALLELISM = 64
 ASSIGN_BATCH_ROWS = 65_536
-EMBEDDING_ROOT = datakit_source_path("datakit/embed/harrier")
+PIPELINE_VERSION = "2026.08.13"
 
 COARSENING_CONFIG = CoarseningConfig(
     clusters=K_COARSE,
@@ -63,6 +42,11 @@ COARSENING_CONFIG = CoarseningConfig(
     split_restarts=10,
     split_iterations=20,
 )
+
+DRIVER_RESOURCES = ResourceConfig.with_cpu(cpu=2, ram="16g", preemptible=False)
+SAMPLE_WORKER_RESOURCES = ResourceConfig.with_cpu(cpu=2, ram="16g")
+SAMPLE_COORDINATOR_RESOURCES = ResourceConfig.with_cpu(cpu=1, ram="8g", preemptible=False)
+TRAIN_RESOURCES = ResourceConfig.with_cpu(cpu=N_THREADS, ram="256g", disk="32g", preemptible=False)
 
 
 def _coarsening_cache_key(config: CoarseningConfig) -> str:
@@ -76,440 +60,34 @@ def _coarsening_cache_key(config: CoarseningConfig) -> str:
 
 COARSENING_CACHE_KEY = _coarsening_cache_key(COARSENING_CONFIG)
 
-DRIVER_RESOURCES = ResourceConfig.with_cpu(cpu=2, ram="16g", preemptible=False)
-SAMPLE_WORKER_RESOURCES = ResourceConfig.with_cpu(cpu=2, ram="16g")
-TRAIN_RESOURCES = ResourceConfig.with_cpu(cpu=N_THREADS, ram="256g", disk="32g", preemptible=False)
-
-_SAMPLE_SCHEMA = pa.schema(
-    [
-        pa.field("source", pa.string()),
-        pa.field("embedding", pa.list_(pa.int8(), HARRIER_DIM)),
-    ]
-)
-
-
-@dataclass(frozen=True)
-class SourceSample:
-    source: str
-    paths: tuple[str, ...]
-    rows: tuple[int, ...]
-    quota: int
-
-
-@dataclass(frozen=True)
-class _TrainingData:
-    embeddings: np.ndarray
-    population: np.ndarray
-    rows_by_source: dict[str, int]
-
-
-class _SearchIndex(Protocol):
-    def search(self, values: np.ndarray, k: int) -> tuple[np.ndarray, np.ndarray]: ...
-
-
-@dataclass(frozen=True)
-class _TrainedCentroids:
-    centroids: np.ndarray
-    index: _SearchIndex
-    seconds: float
-    objective: float
-
-
-def _largest_remainder_quotas(weights: tuple[int, ...], target: int) -> tuple[int, ...]:
-    total = sum(weights)
-    if target == 0:
-        return (0,) * len(weights)
-    if total == 0:
-        raise ValueError("cannot allocate a positive quota across zero available rows")
-    numerators = [target * weight for weight in weights]
-    quotas = [numerator // total for numerator in numerators]
-    leftover = target - sum(quotas)
-    order = sorted(range(len(weights)), key=lambda index: (-(numerators[index] % total), index))
-    for index in order[:leftover]:
-        quotas[index] += 1
-    return tuple(quotas)
-
-
-def proportional_quotas(counts: dict[str, int], target: int) -> dict[str, int]:
-    if target < len(counts) * SMALL_SOURCE_QUOTA:
-        raise ValueError("target is too small for the one-document source floor")
-    if target > sum(counts.values()):
-        raise ValueError("target exceeds the available documents")
-
-    small = {source for source, rows in counts.items() if rows <= SMALL_SOURCE_MAX_ROWS}
-    quotas = {source: SMALL_SOURCE_QUOTA for source in small}
-    large_sources = tuple(sorted(source for source in counts if source not in small))
-    remaining = target - sum(quotas.values())
-    large_quotas = _largest_remainder_quotas(tuple(counts[source] for source in large_sources), remaining)
-    quotas.update(dict(zip(large_sources, large_quotas, strict=True)))
-    if any(quota > counts[source] for source, quota in quotas.items()):
-        raise ValueError("a source quota exceeds its document count")
-    return quotas
-
-
-def training_quotas(counts: dict[str, int], target: int) -> dict[str, int]:
-    if target < len(counts):
-        raise ValueError("target is too small for the one-document source floor")
-    if target > sum(counts.values()):
-        raise ValueError("target exceeds the available documents")
-
-    sources = tuple(sorted(counts))
-    remaining = target - len(counts)
-    if remaining == 0:
-        return {source: 1 for source in sources}
-    extra = _largest_remainder_quotas(tuple(counts[source] - 1 for source in sources), remaining)
-    return {source: quota + 1 for source, quota in zip(sources, extra, strict=True)}
-
-
-def _stratified_indices(
-    source_codes: np.ndarray,
-    source_names: tuple[str, ...],
-    target: int,
-    seed: int,
-) -> tuple[np.ndarray, dict[str, int]]:
-    counts_array = np.bincount(source_codes, minlength=len(source_names))
-    counts = dict(zip(source_names, counts_array.tolist(), strict=True))
-    quotas = training_quotas(counts, target)
-    selected = []
-    source_codes_by_name = {source: code for code, source in enumerate(source_names)}
-    for source in sorted(source_names):
-        code = source_codes_by_name[source]
-        source_indices = np.flatnonzero(source_codes == code)
-        quota = quotas[source]
-        if quota == len(source_indices):
-            selected.append(source_indices)
-            continue
-        digest = hashlib.sha256(f"{seed}:{source}".encode()).digest()
-        rng = np.random.default_rng(int.from_bytes(digest[:8], "little"))
-        selected.append(rng.choice(source_indices, size=quota, replace=False))
-    return np.sort(np.concatenate(selected)), quotas
-
-
-def _part_quotas(rows: tuple[int, ...], target: int) -> tuple[int, ...]:
-    return _largest_remainder_quotas(rows, target)
-
-
-def _row_count(path: str) -> int:
-    with StoragePath(path).open("rb") as file:
-        return pq.ParquetFile(file).metadata.num_rows
-
-
-def _source_samples(embedding_paths: dict[str, str]) -> tuple[SourceSample, ...]:
-    source_paths = {
-        source: tuple(sorted(str(shard) for shard in StoragePath(prefix_join(path, "*.parquet")).glob()))
-        for source, path in sorted(embedding_paths.items())
-    }
-    if any(not paths for paths in source_paths.values()):
-        missing = [source for source, paths in source_paths.items() if not paths]
-        raise ValueError(f"sources have no embedding shards: {missing}")
-
-    all_paths = [path for paths in source_paths.values() for path in paths]
-    with ThreadPoolExecutor(max_workers=LOAD_PARALLELISM) as pool:
-        all_rows = list(pool.map(_row_count, all_paths))
-    path_rows = dict(zip(all_paths, all_rows, strict=True))
-    source_rows = {source: sum(path_rows[path] for path in paths) for source, paths in source_paths.items()}
-    empty_sources = [source for source, rows in source_rows.items() if rows == 0]
-    if empty_sources:
-        logger.warning("Skipping %d zero-row sources: %s", len(empty_sources), empty_sources)
-        source_paths = {source: paths for source, paths in source_paths.items() if source_rows[source]}
-        source_rows = {source: rows for source, rows in source_rows.items() if rows}
-    quotas = proportional_quotas(source_rows, TARGET_ROWS)
-    return tuple(
-        SourceSample(
-            source=source,
-            paths=paths,
-            rows=tuple(path_rows[path] for path in paths),
-            quota=quotas[source],
-        )
-        for source, paths in sorted(source_paths.items())
-    )
-
-
-def _completed_embedding_paths(source_names: tuple[str, ...]) -> dict[str, str]:
-    embedding_root = StoragePath(EMBEDDING_ROOT)
-    records = [
-        StoragePath(path)
-        for path in sorted(str(path) for path in StoragePath(prefix_join(EMBEDDING_ROOT, "**/.artifact.json")).glob())
-    ]
-    candidates: dict[str, list[str]] = {source: [] for source in source_names}
-    source_prefixes = sorted(source_names, key=len, reverse=True)
-    for record in records:
-        output_path = record.parent
-        relative = output_path.relative_to(embedding_root)
-        for source in source_prefixes:
-            if relative.startswith(f"{source}_"):
-                candidates[source].append(str(output_path))
-                break
-
-    resolved = {}
-    for source, paths in candidates.items():
-        if not paths:
-            raise ValueError(f"no completed Harrier artifact directory for {source}")
-        if len(paths) != 1:
-            raise ValueError(f"expected one Harrier artifact directory for {source}, found {paths}")
-        resolved[source] = paths[0]
-    if not resolved:
-        raise ValueError(f"no completed Harrier artifacts under {EMBEDDING_ROOT}")
-    return resolved
-
-
-def _sample_shard(
-    batches: Iterator[list[dict[str, Any]]],
-    _shard: ShardInfo,
-    *,
-    source: str,
-    path: str,
-    rows: int,
-    quota: int,
-    seed: int,
-) -> Iterator[dict[str, Any]]:
-    digest = hashlib.sha256(f"{seed}:{source}:{path}".encode()).digest()
-    rng = np.random.default_rng(int.from_bytes(digest[:8], "little"))
-    selected = np.sort(rng.choice(rows, size=quota, replace=False))
-    offset = 0
-    written = 0
-    for batch in batches:
-        begin = int(np.searchsorted(selected, offset, side="left"))
-        end = int(np.searchsorted(selected, offset + len(batch), side="left"))
-        for index in selected[begin:end] - offset:
-            yield {"source": source, "embedding": batch[int(index)]["embedding"]}
-            written += 1
-        offset += len(batch)
-    if offset != rows or written != quota:
-        raise ValueError(f"sampled {written}/{quota} rows after reading {offset}/{rows} from {path}")
-    counters.pipeline.update_counter("harrier_cluster/sample_rows", written)
-
-
-def _sample_source(sample: SourceSample, output_path: str) -> None:
-    quotas = _part_quotas(sample.rows, sample.quota)
-    selected = [
-        (path, rows, quota) for path, rows, quota in zip(sample.paths, sample.rows, quotas, strict=True) if quota
-    ]
-    source_dir = prefix_join(output_path, sample.source.replace("/", "-"))
-    output_paths = tuple(prefix_join(source_dir, f"sample-{index:06d}.parquet") for index in range(len(selected)))
-    dataset = (
-        Dataset.from_list([InputFileSpec(path=path, columns=["embedding"]) for path, _, _ in selected])
-        .flat_map(load_file)
-        .window(4_096)
-        .map_shard(
-            lambda batches, shard, parts=tuple(selected), source=sample.source: _sample_shard(
-                batches,
-                shard,
-                source=source,
-                path=parts[shard.shard_idx][0],
-                rows=parts[shard.shard_idx][1],
-                quota=parts[shard.shard_idx][2],
-                seed=SEED,
-            )
-        )
-        .write_parquet(lambda shard_idx, _total: output_paths[shard_idx], schema=_SAMPLE_SCHEMA, skip_existing=True)
-    )
-    ZephyrContext(
-        resources=SAMPLE_WORKER_RESOURCES,
-        coordinator_resources=ResourceConfig.with_cpu(cpu=1, ram="8g", preemptible=False),
-        max_workers=min(MAX_WORKERS, len(selected)),
-        name=f"sample-harrier-{hashlib.sha256(sample.source.encode()).hexdigest()[:12]}",
-        stage_runner_factory=InlineRunner,
-    ).execute(dataset, verbose=True)
-
-
-def sample_embeddings(output_path: str, source_names: tuple[str, ...]) -> None:
-    embedding_paths = _completed_embedding_paths(source_names)
-    samples = _source_samples(embedding_paths)
-    with ThreadPoolExecutor(max_workers=PARALLEL_SOURCES) as pool:
-        futures = {pool.submit(_sample_source, sample, output_path): sample.source for sample in samples}
-        for future in as_completed(futures):
-            future.result()
-            logger.info("Sampled %s", futures[future])
-
-    source_rows = {sample.source: sum(sample.rows) for sample in samples}
-    source_quotas = {sample.source: sample.quota for sample in samples}
-    with open_url(prefix_join(output_path, "sample_stats.json"), "w") as file:
-        json.dump(
-            {
-                "target_rows": TARGET_ROWS,
-                "source_count": len(samples),
-                "source_rows": source_rows,
-                "source_quotas": source_quotas,
-                "embedding_paths": embedding_paths,
-                "small_source_max_rows": SMALL_SOURCE_MAX_ROWS,
-                "small_source_quota": SMALL_SOURCE_QUOTA,
-                "seed": SEED,
-            },
-            file,
-            indent=2,
-            sort_keys=True,
-        )
-
-
-def _stats_payload(value: ClusteringStats) -> dict[str, Any]:
-    return {
-        "loss": value.loss,
-        "weighted_mean_cosine_distance": value.weighted_mean_cosine_distance,
-        "minimum_weight_fraction": value.minimum_weight_fraction,
-        "maximum_weight_fraction": value.maximum_weight_fraction,
-        "weight_fractions": value.weight_fractions.tolist(),
-        "fine_centroid_counts": value.fine_centroid_counts.tolist(),
-    }
-
-
-def _coarsening_payload(result: CoarseningResult) -> dict[str, Any]:
-    return {
-        "method": "weighted_divisive_spherical_kmeans_then_single_centroid_hill_climb",
-        "minimum_fraction": COARSENING_CONFIG.minimum_fraction,
-        "seeds": list(COARSENING_CONFIG.seeds),
-        "split_restarts": COARSENING_CONFIG.split_restarts,
-        "split_iterations": COARSENING_CONFIG.split_iterations,
-        "selected_seed": result.selected_seed,
-        "divisive_runs": [{"seed": run.seed, "stats": _stats_payload(run.stats)} for run in result.divisive_runs],
-        "initial": _stats_payload(result.initial),
-        "final": _stats_payload(result.final),
-        "moves": result.moves,
-        "sweeps": result.sweeps,
-    }
-
-
-def _read_sample_table(path: str) -> pa.Table:
-    with StoragePath(path).open("rb") as file:
-        return pq.read_table(file, columns=["source", "embedding"])
-
-
-def _load_training_embeddings(
-    sample_path: str,
-    target: int,
-    seed: int,
-) -> _TrainingData:
-    paths = sorted(str(path) for path in StoragePath(prefix_join(sample_path, "**/*.parquet")).glob())
-    if not paths:
-        raise FileNotFoundError(f"No centroid sample shards under {sample_path}")
-
-    started = time.monotonic()
-    with ThreadPoolExecutor(max_workers=LOAD_PARALLELISM) as pool:
-        tables = list(pool.map(_read_sample_table, paths))
-    table = pa.concat_tables(tables)
-    encoded_sources = table["source"].combine_chunks().dictionary_encode()
-    source_names = tuple(encoded_sources.dictionary.to_pylist())
-    source_codes = encoded_sources.indices.to_numpy(zero_copy_only=False)
-    selected, quotas = _stratified_indices(source_codes, source_names, target, seed)
-
-    embeddings_column = table["embedding"].combine_chunks()
-    if not pa.types.is_fixed_size_list(embeddings_column.type) or embeddings_column.type.list_size != HARRIER_DIM:
-        raise ValueError(f"Unexpected centroid sample type {embeddings_column.type}")
-    quantized = embeddings_column.values.to_numpy(zero_copy_only=False).reshape(-1, HARRIER_DIM)
-    training_embeddings = np.ascontiguousarray(dequantize_to_fp32(quantized[selected]))
-    logger.info(
-        "Loaded %d x %d population and selected %d stratified training rows in %.1fs",
-        len(quantized),
-        HARRIER_DIM,
-        len(training_embeddings),
-        time.monotonic() - started,
-    )
-    return _TrainingData(training_embeddings, quantized, quotas)
-
-
-def _cluster_weights(index: _SearchIndex, quantized: np.ndarray) -> np.ndarray:
-    weights = np.zeros(K_TRAIN, dtype=np.int64)
-    for start in range(0, len(quantized), ASSIGN_BATCH_ROWS):
-        batch = dequantize_to_fp32(quantized[start : start + ASSIGN_BATCH_ROWS])
-        _, assignments = index.search(batch, 1)
-        weights += np.bincount(assignments[:, 0], minlength=K_TRAIN)
-    return weights
-
-
-def _save_npy(array: np.ndarray, output_path: str, name: str) -> None:
-    with open_url(prefix_join(output_path, name), "wb") as file:
-        np.save(file, array)
-
-
-def _train_fine_centroids(embeddings: np.ndarray) -> _TrainedCentroids:
-    import faiss  # noqa: PLC0415
-
-    faiss.omp_set_num_threads(N_THREADS)
-    started = time.monotonic()
-    kmeans = faiss.Kmeans(
-        d=HARRIER_DIM,
-        k=K_TRAIN,
-        niter=N_ITER,
-        nredo=N_REDO,
-        spherical=True,
-        seed=SEED,
-        verbose=True,
-        max_points_per_centroid=TRAIN_POINTS_PER_CENTROID,
-    )
-    kmeans.train(embeddings)
-    return _TrainedCentroids(
-        centroids=kmeans.centroids.astype(np.float32, copy=False),
-        index=kmeans.index,
-        seconds=time.monotonic() - started,
-        objective=float(kmeans.obj[-1]),
-    )
-
-
-def _write_training_artifact(
-    output_path: str,
-    sample_path: str,
-    training: _TrainingData,
-    trained: _TrainedCentroids,
-    weights: np.ndarray,
-    coarsening: CoarseningResult,
-) -> None:
-    _save_npy(trained.centroids, output_path, f"centroids_{K_TRAIN}.npy")
-    _save_npy(coarsening.fine_to_coarse, output_path, f"lookup_{K_TRAIN}_to_{K_COARSE}.npy")
-    with open_url(prefix_join(output_path, "fine_cluster_weights.json"), "w") as file:
-        json.dump({"document_counts_5000": weights.astype(int).tolist()}, file)
-    with open_url(prefix_join(output_path, "train_stats.json"), "w") as file:
-        json.dump(
-            {
-                "sample_path": sample_path,
-                "embedding_dim": HARRIER_DIM,
-                "k_train": K_TRAIN,
-                "k_views": [K_COARSE],
-                "n_sample": len(training.embeddings),
-                "population_rows": len(training.population),
-                "training_points_per_centroid": TRAIN_POINTS_PER_CENTROID,
-                "training_rows_by_source": training.rows_by_source,
-                "n_iter": N_ITER,
-                "n_redo": N_REDO,
-                "seed": SEED,
-                "n_threads": N_THREADS,
-                "train_seconds": trained.seconds,
-                "final_objective": trained.objective,
-                "coarsening": _coarsening_payload(coarsening),
-            },
-            file,
-            indent=2,
-        )
-
-
-def train_centroids(output_path: str, sample_path: str) -> None:
-    from threadpoolctl import threadpool_limits  # noqa: PLC0415
-
-    training = _load_training_embeddings(sample_path, TRAIN_ROWS, SEED)
-    with threadpool_limits(limits=N_THREADS):
-        trained = _train_fine_centroids(training.embeddings)
-        weights = _cluster_weights(trained.index, training.population).astype(np.float64)
-        if np.any(weights == 0):
-            raise ValueError("K-means produced an empty fine cluster")
-        coarsening = coarsen_centroids(trained.centroids, weights, COARSENING_CONFIG)
-    _write_training_artifact(output_path, sample_path, training, trained, weights, coarsening)
-
 
 def build_steps() -> tuple[StepSpec, StepSpec]:
-    source_names = tuple(sorted(select_sources()))
+    embedding_steps = build_harrier_embeddings("unused")
+    embedding_paths = {step.name.removeprefix("datakit/embed/harrier/"): step.output_path for step in embedding_steps}
     sample_step = StepSpec(
         name="datakit/cluster/domain/v1/harrier-all-sources-10m/sample",
-        deps=[],
+        deps=embedding_steps,
         hash_attrs={
-            "embedding_root": EMBEDDING_ROOT,
-            "source_names": source_names,
             "target_rows": TARGET_ROWS,
             "small_source_max_rows": SMALL_SOURCE_MAX_ROWS,
             "small_source_quota": SMALL_SOURCE_QUOTA,
             "seed": SEED,
-            "v": 4,
+            "version": PIPELINE_VERSION,
         },
         fn=remote(
-            lambda output_path, sources=source_names: sample_embeddings(output_path, sources),
+            lambda output_path, paths=embedding_paths: sample_centroid_inputs(
+                output_path=output_path,
+                embedding_paths=paths,
+                target_rows=TARGET_ROWS,
+                small_source_max_rows=SMALL_SOURCE_MAX_ROWS,
+                small_source_quota=SMALL_SOURCE_QUOTA,
+                seed=SEED,
+                worker_resources=SAMPLE_WORKER_RESOURCES,
+                coordinator_resources=SAMPLE_COORDINATOR_RESOURCES,
+                max_workers=MAX_WORKERS,
+                parallel_sources=PARALLEL_SOURCES,
+                load_parallelism=LOAD_PARALLELISM,
+            ),
             resources=DRIVER_RESOURCES,
             pip_dependency_groups=["datakit"],
         ),
@@ -528,10 +106,23 @@ def build_steps() -> tuple[StepSpec, StepSpec]:
             "seed": SEED,
             "n_threads": N_THREADS,
             "coarsening": COARSENING_CACHE_KEY,
-            "v": 2,
+            "version": PIPELINE_VERSION,
         },
         fn=remote(
-            lambda output_path, sample_path=sample_step.output_path: train_centroids(output_path, sample_path),
+            lambda output_path, sample_path=sample_step.output_path: train_centroids(
+                output_path=output_path,
+                sample_path=sample_path,
+                k_train=K_TRAIN,
+                train_rows=TRAIN_ROWS,
+                points_per_centroid=TRAIN_POINTS_PER_CENTROID,
+                n_iter=N_ITER,
+                n_redo=N_REDO,
+                seed=SEED,
+                n_threads=N_THREADS,
+                assign_batch_rows=ASSIGN_BATCH_ROWS,
+                load_parallelism=LOAD_PARALLELISM,
+                coarsening_config=COARSENING_CONFIG,
+            ),
             resources=TRAIN_RESOURCES,
             pip_dependency_groups=["datakit"],
         ),

--- a/experiments/datakit/cluster/domain/v1/harrier_all_sources.py
+++ b/experiments/datakit/cluster/domain/v1/harrier_all_sources.py
@@ -1,0 +1,497 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Train Harrier domain clusters on a proportional sample of every source."""
+
+import hashlib
+import json
+import logging
+import os
+import time
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+from fray.types import ResourceConfig
+from marin.datakit.source_key import datakit_source_path
+from marin.execution.remote import remote
+from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+from rigging.filesystem import StoragePath, open_url
+from rigging.log_setup import configure_logging
+from zephyr import counters
+from zephyr.dataset import Dataset, ShardInfo
+from zephyr.execution import ZephyrContext
+from zephyr.readers import InputFileSpec, load_file
+from zephyr.runners import InlineRunner
+
+from experiments.datakit.cluster.domain.v1.coarsen import CoarseningConfig, CoarseningResult, coarsen_centroids
+from experiments.datakit.embeddings.harrier.pipeline import HARRIER_DIM, dequantize_to_fp32
+from experiments.datakit.reference_pipeline import select_sources
+
+logger = logging.getLogger(__name__)
+
+TARGET_ROWS = 10_000_000
+SMALL_SOURCE_MAX_ROWS = 1_000
+SMALL_SOURCE_QUOTA = 1
+K_TRAIN = 5_000
+K_COARSE = 40
+TRAIN_POINTS_PER_CENTROID = 512
+TRAIN_ROWS = K_TRAIN * TRAIN_POINTS_PER_CENTROID
+N_ITER = 20
+N_REDO = 3
+SEED = 42
+N_THREADS = 96
+PARALLEL_SOURCES = 16
+MAX_WORKERS = 64
+LOAD_PARALLELISM = 64
+ASSIGN_BATCH_ROWS = 65_536
+EMBEDDING_ROOT = datakit_source_path("datakit/embed/harrier")
+
+COARSENING_CONFIG = CoarseningConfig(
+    clusters=K_COARSE,
+    minimum_fraction=0.01,
+    seeds=(42, 43, 44),
+    split_restarts=10,
+    split_iterations=20,
+)
+
+DRIVER_RESOURCES = ResourceConfig.with_cpu(cpu=2, ram="16g", preemptible=False)
+SAMPLE_WORKER_RESOURCES = ResourceConfig.with_cpu(cpu=2, ram="16g")
+TRAIN_RESOURCES = ResourceConfig.with_cpu(cpu=N_THREADS, ram="256g", disk="32g", preemptible=False)
+
+_SAMPLE_SCHEMA = pa.schema(
+    [
+        pa.field("source", pa.string()),
+        pa.field("embedding", pa.list_(pa.int8(), HARRIER_DIM)),
+    ]
+)
+
+
+@dataclass(frozen=True)
+class SourceSample:
+    source: str
+    paths: tuple[str, ...]
+    rows: tuple[int, ...]
+    quota: int
+
+
+def proportional_quotas(counts: dict[str, int], target: int) -> dict[str, int]:
+    if target < len(counts) * SMALL_SOURCE_QUOTA:
+        raise ValueError("target is too small for the one-document source floor")
+    if target > sum(counts.values()):
+        raise ValueError("target exceeds the available documents")
+
+    small = {source for source, rows in counts.items() if rows <= SMALL_SOURCE_MAX_ROWS}
+    quotas = {source: SMALL_SOURCE_QUOTA for source in small}
+    large = {source: rows for source, rows in counts.items() if source not in small}
+    remaining = target - sum(quotas.values())
+    large_rows = sum(large.values())
+    numerators = {source: remaining * rows for source, rows in large.items()}
+    quotas.update({source: numerator // large_rows for source, numerator in numerators.items()})
+    leftover = target - sum(quotas.values())
+    for source in sorted(large, key=lambda name: (-(numerators[name] % large_rows), name))[:leftover]:
+        quotas[source] += 1
+    if any(quota > counts[source] for source, quota in quotas.items()):
+        raise ValueError("a source quota exceeds its document count")
+    return quotas
+
+
+def training_quotas(counts: dict[str, int], target: int) -> dict[str, int]:
+    if target < len(counts):
+        raise ValueError("target is too small for the one-document source floor")
+    if target > sum(counts.values()):
+        raise ValueError("target exceeds the available documents")
+
+    quotas = {source: 1 for source in counts}
+    remaining = target - len(counts)
+    if remaining == 0:
+        return quotas
+    capacities = {source: rows - 1 for source, rows in counts.items()}
+    total_capacity = sum(capacities.values())
+    numerators = {source: remaining * capacity for source, capacity in capacities.items()}
+    quotas = {source: quotas[source] + numerator // total_capacity for source, numerator in numerators.items()}
+    leftover = target - sum(quotas.values())
+    for source in sorted(counts, key=lambda name: (-(numerators[name] % total_capacity), name))[:leftover]:
+        quotas[source] += 1
+    return quotas
+
+
+def _stratified_indices(
+    source_codes: np.ndarray,
+    source_names: tuple[str, ...],
+    target: int,
+    seed: int,
+) -> tuple[np.ndarray, dict[str, int]]:
+    counts_array = np.bincount(source_codes, minlength=len(source_names))
+    counts = dict(zip(source_names, counts_array.tolist(), strict=True))
+    quotas = training_quotas(counts, target)
+    selected = []
+    source_codes_by_name = {source: code for code, source in enumerate(source_names)}
+    for source in sorted(source_names):
+        code = source_codes_by_name[source]
+        source_indices = np.flatnonzero(source_codes == code)
+        quota = quotas[source]
+        if quota == len(source_indices):
+            selected.append(source_indices)
+            continue
+        digest = hashlib.sha256(f"{seed}:{source}".encode()).digest()
+        rng = np.random.default_rng(int.from_bytes(digest[:8], "little"))
+        selected.append(rng.choice(source_indices, size=quota, replace=False))
+    return np.sort(np.concatenate(selected)), quotas
+
+
+def _part_quotas(rows: tuple[int, ...], target: int) -> tuple[int, ...]:
+    total = sum(rows)
+    numerators = [target * count for count in rows]
+    quotas = [numerator // total for numerator in numerators]
+    leftover = target - sum(quotas)
+    order = sorted(range(len(rows)), key=lambda index: (-(numerators[index] % total), index))
+    for index in order[:leftover]:
+        quotas[index] += 1
+    return tuple(quotas)
+
+
+def _row_count(path: str) -> int:
+    with StoragePath(path).open("rb") as file:
+        return pq.ParquetFile(file).metadata.num_rows
+
+
+def _source_samples(embedding_paths: dict[str, str]) -> tuple[SourceSample, ...]:
+    source_paths = {
+        source: tuple(sorted(str(shard) for shard in StoragePath(f"{path}/*.parquet").glob()))
+        for source, path in sorted(embedding_paths.items())
+    }
+    if any(not paths for paths in source_paths.values()):
+        missing = [source for source, paths in source_paths.items() if not paths]
+        raise ValueError(f"sources have no embedding shards: {missing}")
+
+    all_paths = [path for paths in source_paths.values() for path in paths]
+    with ThreadPoolExecutor(max_workers=LOAD_PARALLELISM) as pool:
+        all_rows = list(pool.map(_row_count, all_paths))
+    path_rows = dict(zip(all_paths, all_rows, strict=True))
+    source_rows = {source: sum(path_rows[path] for path in paths) for source, paths in source_paths.items()}
+    empty_sources = [source for source, rows in source_rows.items() if rows == 0]
+    if empty_sources:
+        logger.warning("Skipping %d zero-row sources: %s", len(empty_sources), empty_sources)
+        source_paths = {source: paths for source, paths in source_paths.items() if source_rows[source]}
+        source_rows = {source: rows for source, rows in source_rows.items() if rows}
+    quotas = proportional_quotas(source_rows, TARGET_ROWS)
+    return tuple(
+        SourceSample(
+            source=source,
+            paths=paths,
+            rows=tuple(path_rows[path] for path in paths),
+            quota=quotas[source],
+        )
+        for source, paths in sorted(source_paths.items())
+    )
+
+
+def _completed_embedding_paths(source_names: tuple[str, ...]) -> dict[str, str]:
+    records = sorted(str(path) for path in StoragePath(f"{EMBEDDING_ROOT}/**/.artifact.json").glob())
+    candidates: dict[str, list[str]] = {source: [] for source in source_names}
+    source_prefixes = sorted(source_names, key=len, reverse=True)
+    for record in records:
+        output_path = record.removesuffix("/.artifact.json")
+        relative = output_path.removeprefix(f"{EMBEDDING_ROOT}/")
+        for source in source_prefixes:
+            if relative.startswith(f"{source}_"):
+                candidates[source].append(output_path)
+                break
+
+    resolved = {}
+    for source, paths in candidates.items():
+        if not paths:
+            raise ValueError(f"no completed Harrier artifact directory for {source}")
+        if len(paths) != 1:
+            raise ValueError(f"expected one Harrier artifact directory for {source}, found {paths}")
+        resolved[source] = paths[0]
+    if not resolved:
+        raise ValueError(f"no completed Harrier artifacts under {EMBEDDING_ROOT}")
+    return resolved
+
+
+def _sample_shard(
+    batches: Iterator[list[dict[str, Any]]],
+    _shard: ShardInfo,
+    *,
+    source: str,
+    path: str,
+    rows: int,
+    quota: int,
+    seed: int,
+) -> Iterator[dict[str, Any]]:
+    digest = hashlib.sha256(f"{seed}:{source}:{path}".encode()).digest()
+    rng = np.random.default_rng(int.from_bytes(digest[:8], "little"))
+    selected = np.sort(rng.choice(rows, size=quota, replace=False))
+    offset = 0
+    written = 0
+    for batch in batches:
+        begin = int(np.searchsorted(selected, offset, side="left"))
+        end = int(np.searchsorted(selected, offset + len(batch), side="left"))
+        for index in selected[begin:end] - offset:
+            yield {"source": source, "embedding": batch[int(index)]["embedding"]}
+            written += 1
+        offset += len(batch)
+    if offset != rows or written != quota:
+        raise ValueError(f"sampled {written}/{quota} rows after reading {offset}/{rows} from {path}")
+    counters.pipeline.update_counter("harrier_cluster/sample_rows", written)
+
+
+def _sample_source(sample: SourceSample, output_path: str) -> None:
+    quotas = _part_quotas(sample.rows, sample.quota)
+    selected = [
+        (path, rows, quota) for path, rows, quota in zip(sample.paths, sample.rows, quotas, strict=True) if quota
+    ]
+    source_dir = f"{output_path.rstrip('/')}/{sample.source.replace('/', '-')}"
+    output_paths = tuple(f"{source_dir}/sample-{index:06d}.parquet" for index in range(len(selected)))
+    dataset = (
+        Dataset.from_list([InputFileSpec(path=path, columns=["embedding"]) for path, _, _ in selected])
+        .flat_map(load_file)
+        .window(4_096)
+        .map_shard(
+            lambda batches, shard, parts=tuple(selected), source=sample.source: _sample_shard(
+                batches,
+                shard,
+                source=source,
+                path=parts[shard.shard_idx][0],
+                rows=parts[shard.shard_idx][1],
+                quota=parts[shard.shard_idx][2],
+                seed=SEED,
+            )
+        )
+        .write_parquet(lambda shard_idx, _total: output_paths[shard_idx], schema=_SAMPLE_SCHEMA, skip_existing=True)
+    )
+    ZephyrContext(
+        resources=SAMPLE_WORKER_RESOURCES,
+        coordinator_resources=ResourceConfig.with_cpu(cpu=1, ram="8g", preemptible=False),
+        max_workers=min(MAX_WORKERS, len(selected)),
+        name=f"sample-harrier-{hashlib.sha256(sample.source.encode()).hexdigest()[:12]}",
+        stage_runner_factory=InlineRunner,
+    ).execute(dataset, verbose=True)
+
+
+def sample_embeddings(output_path: str, source_names: tuple[str, ...]) -> None:
+    embedding_paths = _completed_embedding_paths(source_names)
+    samples = _source_samples(embedding_paths)
+    with ThreadPoolExecutor(max_workers=PARALLEL_SOURCES) as pool:
+        futures = {pool.submit(_sample_source, sample, output_path): sample.source for sample in samples}
+        for future in as_completed(futures):
+            future.result()
+            logger.info("Sampled %s", futures[future])
+
+    source_rows = {sample.source: sum(sample.rows) for sample in samples}
+    source_quotas = {sample.source: sample.quota for sample in samples}
+    with open_url(f"{output_path.rstrip('/')}/sample_stats.json", "w") as file:
+        json.dump(
+            {
+                "target_rows": TARGET_ROWS,
+                "source_count": len(samples),
+                "source_rows": source_rows,
+                "source_quotas": source_quotas,
+                "embedding_paths": embedding_paths,
+                "small_source_max_rows": SMALL_SOURCE_MAX_ROWS,
+                "small_source_quota": SMALL_SOURCE_QUOTA,
+                "seed": SEED,
+            },
+            file,
+            indent=2,
+            sort_keys=True,
+        )
+
+
+def _coarsening_payload(result: CoarseningResult) -> dict[str, Any]:
+    def stats(value: Any) -> dict[str, Any]:
+        return {
+            "loss": value.loss,
+            "weighted_mean_cosine_distance": value.weighted_mean_cosine_distance,
+            "minimum_weight_fraction": value.minimum_weight_fraction,
+            "maximum_weight_fraction": value.maximum_weight_fraction,
+            "weight_fractions": value.weight_fractions.tolist(),
+            "fine_centroid_counts": value.fine_centroid_counts.tolist(),
+        }
+
+    return {
+        "method": "weighted_divisive_spherical_kmeans_then_single_centroid_hill_climb",
+        "minimum_fraction": COARSENING_CONFIG.minimum_fraction,
+        "seeds": list(COARSENING_CONFIG.seeds),
+        "split_restarts": COARSENING_CONFIG.split_restarts,
+        "split_iterations": COARSENING_CONFIG.split_iterations,
+        "selected_seed": result.selected_seed,
+        "divisive_runs": [{"seed": run.seed, "stats": stats(run.stats)} for run in result.divisive_runs],
+        "initial": stats(result.initial),
+        "final": stats(result.final),
+        "moves": result.moves,
+        "sweeps": result.sweeps,
+    }
+
+
+def _read_sample_table(path: str) -> pa.Table:
+    with StoragePath(path).open("rb") as file:
+        return pq.read_table(file, columns=["source", "embedding"])
+
+
+def _load_training_embeddings(
+    sample_path: str,
+    target: int,
+    seed: int,
+) -> tuple[np.ndarray, np.ndarray, dict[str, int]]:
+    paths = sorted(str(path) for path in StoragePath(f"{sample_path.rstrip('/')}/**/*.parquet").glob())
+    if not paths:
+        raise FileNotFoundError(f"No centroid sample shards under {sample_path}")
+
+    started = time.monotonic()
+    with ThreadPoolExecutor(max_workers=LOAD_PARALLELISM) as pool:
+        tables = list(pool.map(_read_sample_table, paths))
+    table = pa.concat_tables(tables)
+    encoded_sources = table["source"].combine_chunks().dictionary_encode()
+    source_names = tuple(encoded_sources.dictionary.to_pylist())
+    source_codes = encoded_sources.indices.to_numpy(zero_copy_only=False)
+    selected, quotas = _stratified_indices(source_codes, source_names, target, seed)
+
+    embeddings_column = table["embedding"].combine_chunks()
+    if not pa.types.is_fixed_size_list(embeddings_column.type) or embeddings_column.type.list_size != HARRIER_DIM:
+        raise ValueError(f"Unexpected centroid sample type {embeddings_column.type}")
+    quantized = embeddings_column.values.to_numpy(zero_copy_only=False).reshape(-1, HARRIER_DIM)
+    training_embeddings = np.ascontiguousarray(dequantize_to_fp32(quantized[selected]))
+    logger.info(
+        "Loaded %d x %d population and selected %d stratified training rows in %.1fs",
+        len(quantized),
+        HARRIER_DIM,
+        len(training_embeddings),
+        time.monotonic() - started,
+    )
+    return training_embeddings, quantized, quotas
+
+
+def _cluster_weights(index: Any, quantized: np.ndarray) -> np.ndarray:
+    weights = np.zeros(K_TRAIN, dtype=np.int64)
+    for start in range(0, len(quantized), ASSIGN_BATCH_ROWS):
+        batch = dequantize_to_fp32(quantized[start : start + ASSIGN_BATCH_ROWS])
+        _, assignments = index.search(batch, 1)
+        weights += np.bincount(assignments[:, 0], minlength=K_TRAIN)
+    return weights
+
+
+def _save_npy(array: np.ndarray, output_path: str, name: str) -> None:
+    with open_url(os.path.join(output_path, name), "wb") as file:
+        np.save(file, array)
+
+
+def train_centroids(output_path: str, sample_path: str) -> None:
+    import faiss  # noqa: PLC0415
+    from threadpoolctl import threadpool_limits  # noqa: PLC0415
+
+    faiss.omp_set_num_threads(N_THREADS)
+    embeddings, population, training_rows_by_source = _load_training_embeddings(sample_path, TRAIN_ROWS, SEED)
+    with threadpool_limits(limits=N_THREADS):
+        started = time.monotonic()
+        kmeans = faiss.Kmeans(
+            d=HARRIER_DIM,
+            k=K_TRAIN,
+            niter=N_ITER,
+            nredo=N_REDO,
+            spherical=True,
+            seed=SEED,
+            verbose=True,
+            max_points_per_centroid=TRAIN_POINTS_PER_CENTROID,
+        )
+        kmeans.train(embeddings)
+        centroids = kmeans.centroids.astype(np.float32, copy=False)
+        train_seconds = time.monotonic() - started
+        weights = _cluster_weights(kmeans.index, population).astype(np.float64)
+        if np.any(weights == 0):
+            raise ValueError("K-means produced an empty fine cluster")
+        coarsening = coarsen_centroids(
+            centroids,
+            weights,
+            COARSENING_CONFIG,
+        )
+
+    _save_npy(centroids, output_path, f"centroids_{K_TRAIN}.npy")
+    _save_npy(coarsening.fine_to_coarse, output_path, f"lookup_{K_TRAIN}_to_{K_COARSE}.npy")
+    with open_url(os.path.join(output_path, "fine_cluster_weights.json"), "w") as file:
+        json.dump({"document_counts_5000": weights.astype(int).tolist()}, file)
+    with open_url(os.path.join(output_path, "train_stats.json"), "w") as file:
+        json.dump(
+            {
+                "sample_path": sample_path,
+                "embedding_dim": HARRIER_DIM,
+                "k_train": K_TRAIN,
+                "k_views": [K_COARSE],
+                "n_sample": len(embeddings),
+                "population_rows": len(population),
+                "training_points_per_centroid": TRAIN_POINTS_PER_CENTROID,
+                "training_rows_by_source": training_rows_by_source,
+                "n_iter": N_ITER,
+                "n_redo": N_REDO,
+                "seed": SEED,
+                "n_threads": N_THREADS,
+                "train_seconds": train_seconds,
+                "final_objective": float(kmeans.obj[-1]),
+                "coarsening": _coarsening_payload(coarsening),
+            },
+            file,
+            indent=2,
+        )
+
+
+def build_steps() -> tuple[StepSpec, StepSpec]:
+    source_names = tuple(sorted(select_sources()))
+    sample_step = StepSpec(
+        name="datakit/cluster/domain/v1/harrier-all-sources-10m/sample",
+        deps=[],
+        hash_attrs={
+            "embedding_root": EMBEDDING_ROOT,
+            "source_names": source_names,
+            "target_rows": TARGET_ROWS,
+            "small_source_max_rows": SMALL_SOURCE_MAX_ROWS,
+            "small_source_quota": SMALL_SOURCE_QUOTA,
+            "seed": SEED,
+            "v": 4,
+        },
+        fn=remote(
+            lambda output_path, sources=source_names: sample_embeddings(output_path, sources),
+            resources=DRIVER_RESOURCES,
+            pip_dependency_groups=["datakit"],
+        ),
+    )
+    train_step = StepSpec(
+        name="datakit/cluster/domain/v1/harrier-all-sources-10m/train",
+        deps=[sample_step],
+        hash_attrs={
+            "k_train": K_TRAIN,
+            "k_coarse": K_COARSE,
+            "train_rows": TRAIN_ROWS,
+            "train_points_per_centroid": TRAIN_POINTS_PER_CENTROID,
+            "training_sampling": "source-proportional-one-document-floor",
+            "n_iter": N_ITER,
+            "n_redo": N_REDO,
+            "seed": SEED,
+            "n_threads": N_THREADS,
+            "coarsening": "divisive-k40-min1pct-seeds42-44-hill-climb",
+            "v": 2,
+        },
+        fn=remote(
+            lambda output_path, sample_path=sample_step.output_path: train_centroids(output_path, sample_path),
+            resources=TRAIN_RESOURCES,
+            pip_dependency_groups=["datakit"],
+        ),
+    )
+    return sample_step, train_step
+
+
+def main() -> None:
+    configure_logging(logging.INFO)
+    _, train_step = build_steps()
+    logger.info("Final artifact: %s", train_step.output_path)
+    StepRunner().run([train_step])
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/datakit/cluster/domain/v1/sample.py
+++ b/experiments/datakit/cluster/domain/v1/sample.py
@@ -1,0 +1,243 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sample Harrier embeddings for centroid training."""
+
+import hashlib
+import json
+import logging
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+from fray.types import ResourceConfig
+from rigging.filesystem import StoragePath, open_url, prefix_join
+from zephyr import counters
+from zephyr.dataset import Dataset, ShardInfo
+from zephyr.execution import ZephyrContext
+from zephyr.readers import InputFileSpec, load_file
+from zephyr.runners import InlineRunner
+
+from experiments.datakit.embeddings.harrier.pipeline import HARRIER_DIM
+
+logger = logging.getLogger(__name__)
+
+_SAMPLE_SCHEMA = pa.schema(
+    [
+        pa.field("source", pa.string()),
+        pa.field("embedding", pa.list_(pa.int8(), HARRIER_DIM)),
+    ]
+)
+
+
+@dataclass(frozen=True)
+class SourceSample:
+    source: str
+    paths: tuple[str, ...]
+    rows: tuple[int, ...]
+    quota: int
+
+
+def largest_remainder_quotas(weights: tuple[int, ...], target: int) -> tuple[int, ...]:
+    total = sum(weights)
+    if target == 0:
+        return (0,) * len(weights)
+    if total == 0:
+        raise ValueError("cannot allocate a positive quota across zero available rows")
+    numerators = [target * weight for weight in weights]
+    quotas = [numerator // total for numerator in numerators]
+    leftover = target - sum(quotas)
+    order = sorted(range(len(weights)), key=lambda index: (-(numerators[index] % total), index))
+    for index in order[:leftover]:
+        quotas[index] += 1
+    return tuple(quotas)
+
+
+def proportional_quotas(
+    counts: dict[str, int],
+    target: int,
+    small_source_max_rows: int,
+    small_source_quota: int,
+) -> dict[str, int]:
+    if target < len(counts) * small_source_quota:
+        raise ValueError("target is too small for the source floor")
+    if target > sum(counts.values()):
+        raise ValueError("target exceeds the available documents")
+
+    small = {source for source, rows in counts.items() if rows <= small_source_max_rows}
+    quotas = {source: small_source_quota for source in small}
+    large_sources = tuple(sorted(source for source in counts if source not in small))
+    remaining = target - sum(quotas.values())
+    large_quotas = largest_remainder_quotas(tuple(counts[source] for source in large_sources), remaining)
+    quotas.update(dict(zip(large_sources, large_quotas, strict=True)))
+    if any(quota > counts[source] for source, quota in quotas.items()):
+        raise ValueError("a source quota exceeds its document count")
+    return quotas
+
+
+def _row_count(path: str) -> int:
+    with StoragePath(path).open("rb") as file:
+        return pq.ParquetFile(file).metadata.num_rows
+
+
+def _source_samples(
+    embedding_paths: dict[str, str],
+    target_rows: int,
+    small_source_max_rows: int,
+    small_source_quota: int,
+    load_parallelism: int,
+) -> tuple[SourceSample, ...]:
+    source_paths = {
+        source: tuple(sorted(str(shard) for shard in StoragePath(prefix_join(path, "*.parquet")).glob()))
+        for source, path in sorted(embedding_paths.items())
+    }
+    if any(not paths for paths in source_paths.values()):
+        missing = [source for source, paths in source_paths.items() if not paths]
+        raise ValueError(f"sources have no embedding shards: {missing}")
+
+    all_paths = [path for paths in source_paths.values() for path in paths]
+    with ThreadPoolExecutor(max_workers=load_parallelism) as pool:
+        all_rows = list(pool.map(_row_count, all_paths))
+    path_rows = dict(zip(all_paths, all_rows, strict=True))
+    source_rows = {source: sum(path_rows[path] for path in paths) for source, paths in source_paths.items()}
+    empty_sources = [source for source, rows in source_rows.items() if rows == 0]
+    if empty_sources:
+        logger.warning("Skipping %d zero-row sources: %s", len(empty_sources), empty_sources)
+        source_paths = {source: paths for source, paths in source_paths.items() if source_rows[source]}
+        source_rows = {source: rows for source, rows in source_rows.items() if rows}
+    quotas = proportional_quotas(source_rows, target_rows, small_source_max_rows, small_source_quota)
+    return tuple(
+        SourceSample(
+            source=source,
+            paths=paths,
+            rows=tuple(path_rows[path] for path in paths),
+            quota=quotas[source],
+        )
+        for source, paths in sorted(source_paths.items())
+    )
+
+
+def _sample_shard(
+    batches: Iterator[list[dict[str, Any]]],
+    _shard: ShardInfo,
+    *,
+    source: str,
+    path: str,
+    rows: int,
+    quota: int,
+    seed: int,
+) -> Iterator[dict[str, Any]]:
+    digest = hashlib.sha256(f"{seed}:{source}:{path}".encode()).digest()
+    rng = np.random.default_rng(int.from_bytes(digest[:8], "little"))
+    selected = np.sort(rng.choice(rows, size=quota, replace=False))
+    offset = 0
+    written = 0
+    for batch in batches:
+        begin = int(np.searchsorted(selected, offset, side="left"))
+        end = int(np.searchsorted(selected, offset + len(batch), side="left"))
+        for index in selected[begin:end] - offset:
+            yield {"source": source, "embedding": batch[int(index)]["embedding"]}
+            written += 1
+        offset += len(batch)
+    if offset != rows or written != quota:
+        raise ValueError(f"sampled {written}/{quota} rows after reading {offset}/{rows} from {path}")
+    counters.pipeline.update_counter("harrier_cluster/sample_rows", written)
+
+
+def _sample_source(
+    sample: SourceSample,
+    output_path: str,
+    seed: int,
+    worker_resources: ResourceConfig,
+    coordinator_resources: ResourceConfig,
+    max_workers: int,
+) -> None:
+    quotas = largest_remainder_quotas(sample.rows, sample.quota)
+    selected = [
+        (path, rows, quota) for path, rows, quota in zip(sample.paths, sample.rows, quotas, strict=True) if quota
+    ]
+    source_dir = prefix_join(output_path, sample.source.replace("/", "-"))
+    output_paths = tuple(prefix_join(source_dir, f"sample-{index:06d}.parquet") for index in range(len(selected)))
+    dataset = (
+        Dataset.from_list([InputFileSpec(path=path, columns=["embedding"]) for path, _, _ in selected])
+        .flat_map(load_file)
+        .window(4_096)
+        .map_shard(
+            lambda batches, shard, parts=tuple(selected), source=sample.source: _sample_shard(
+                batches,
+                shard,
+                source=source,
+                path=parts[shard.shard_idx][0],
+                rows=parts[shard.shard_idx][1],
+                quota=parts[shard.shard_idx][2],
+                seed=seed,
+            )
+        )
+        .write_parquet(lambda shard_idx, _total: output_paths[shard_idx], schema=_SAMPLE_SCHEMA, skip_existing=True)
+    )
+    ZephyrContext(
+        resources=worker_resources,
+        coordinator_resources=coordinator_resources,
+        max_workers=min(max_workers, len(selected)),
+        name=f"sample-harrier-{hashlib.sha256(sample.source.encode()).hexdigest()[:12]}",
+        stage_runner_factory=InlineRunner,
+    ).execute(dataset, verbose=True)
+
+
+def sample_centroid_inputs(
+    output_path: str,
+    embedding_paths: dict[str, str],
+    target_rows: int,
+    small_source_max_rows: int,
+    small_source_quota: int,
+    seed: int,
+    worker_resources: ResourceConfig,
+    coordinator_resources: ResourceConfig,
+    max_workers: int,
+    parallel_sources: int,
+    load_parallelism: int,
+) -> None:
+    samples = _source_samples(
+        embedding_paths,
+        target_rows,
+        small_source_max_rows,
+        small_source_quota,
+        load_parallelism,
+    )
+    with ThreadPoolExecutor(max_workers=parallel_sources) as pool:
+        futures = {
+            pool.submit(
+                _sample_source,
+                sample,
+                output_path,
+                seed,
+                worker_resources,
+                coordinator_resources,
+                max_workers,
+            ): sample.source
+            for sample in samples
+        }
+        for future in as_completed(futures):
+            future.result()
+            logger.info("Sampled %s", futures[future])
+
+    with open_url(prefix_join(output_path, "sample_stats.json"), "w") as file:
+        json.dump(
+            {
+                "target_rows": target_rows,
+                "source_count": len(samples),
+                "source_rows": {sample.source: sum(sample.rows) for sample in samples},
+                "source_quotas": {sample.source: sample.quota for sample in samples},
+                "embedding_paths": embedding_paths,
+                "small_source_max_rows": small_source_max_rows,
+                "small_source_quota": small_source_quota,
+                "seed": seed,
+            },
+            file,
+            indent=2,
+            sort_keys=True,
+        )

--- a/experiments/datakit/cluster/domain/v1/train.py
+++ b/experiments/datakit/cluster/domain/v1/train.py
@@ -1,0 +1,294 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Train and coarsen Harrier domain centroids."""
+
+import hashlib
+import json
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+from rigging.filesystem import StoragePath, open_url, prefix_join
+
+from experiments.datakit.cluster.domain.v1.coarsen import (
+    ClusteringStats,
+    CoarseningConfig,
+    CoarseningResult,
+    coarsen_centroids,
+)
+from experiments.datakit.cluster.domain.v1.sample import largest_remainder_quotas
+from experiments.datakit.embeddings.harrier.pipeline import HARRIER_DIM, dequantize_to_fp32
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _TrainingData:
+    embeddings: np.ndarray
+    population: np.ndarray
+    rows_by_source: dict[str, int]
+
+
+class _SearchIndex(Protocol):
+    def search(self, values: np.ndarray, k: int) -> tuple[np.ndarray, np.ndarray]: ...
+
+
+@dataclass(frozen=True)
+class _TrainedCentroids:
+    centroids: np.ndarray
+    index: _SearchIndex
+    seconds: float
+    objective: float
+
+
+def training_quotas(counts: dict[str, int], target: int) -> dict[str, int]:
+    if target < len(counts):
+        raise ValueError("target is too small for the one-document source floor")
+    if target > sum(counts.values()):
+        raise ValueError("target exceeds the available documents")
+
+    sources = tuple(sorted(counts))
+    remaining = target - len(counts)
+    if remaining == 0:
+        return {source: 1 for source in sources}
+    extra = largest_remainder_quotas(tuple(counts[source] - 1 for source in sources), remaining)
+    return {source: quota + 1 for source, quota in zip(sources, extra, strict=True)}
+
+
+def stratified_indices(
+    source_codes: np.ndarray,
+    source_names: tuple[str, ...],
+    target: int,
+    seed: int,
+) -> tuple[np.ndarray, dict[str, int]]:
+    counts_array = np.bincount(source_codes, minlength=len(source_names))
+    counts = dict(zip(source_names, counts_array.tolist(), strict=True))
+    quotas = training_quotas(counts, target)
+    selected = []
+    source_codes_by_name = {source: code for code, source in enumerate(source_names)}
+    for source in sorted(source_names):
+        code = source_codes_by_name[source]
+        source_indices = np.flatnonzero(source_codes == code)
+        quota = quotas[source]
+        if quota == len(source_indices):
+            selected.append(source_indices)
+            continue
+        digest = hashlib.sha256(f"{seed}:{source}".encode()).digest()
+        rng = np.random.default_rng(int.from_bytes(digest[:8], "little"))
+        selected.append(rng.choice(source_indices, size=quota, replace=False))
+    return np.sort(np.concatenate(selected)), quotas
+
+
+def _stats_payload(value: ClusteringStats) -> dict[str, Any]:
+    return {
+        "loss": value.loss,
+        "weighted_mean_cosine_distance": value.weighted_mean_cosine_distance,
+        "minimum_weight_fraction": value.minimum_weight_fraction,
+        "maximum_weight_fraction": value.maximum_weight_fraction,
+        "weight_fractions": value.weight_fractions.tolist(),
+        "fine_centroid_counts": value.fine_centroid_counts.tolist(),
+    }
+
+
+def _coarsening_payload(result: CoarseningResult, config: CoarseningConfig) -> dict[str, Any]:
+    return {
+        "method": "weighted_divisive_spherical_kmeans_then_single_centroid_hill_climb",
+        "minimum_fraction": config.minimum_fraction,
+        "seeds": list(config.seeds),
+        "split_restarts": config.split_restarts,
+        "split_iterations": config.split_iterations,
+        "selected_seed": result.selected_seed,
+        "divisive_runs": [{"seed": run.seed, "stats": _stats_payload(run.stats)} for run in result.divisive_runs],
+        "initial": _stats_payload(result.initial),
+        "final": _stats_payload(result.final),
+        "moves": result.moves,
+        "sweeps": result.sweeps,
+    }
+
+
+def _read_sample_table(path: str) -> pa.Table:
+    with StoragePath(path).open("rb") as file:
+        return pq.read_table(file, columns=["source", "embedding"])
+
+
+def _load_training_embeddings(
+    sample_path: str,
+    target: int,
+    seed: int,
+    load_parallelism: int,
+) -> _TrainingData:
+    paths = sorted(str(path) for path in StoragePath(prefix_join(sample_path, "**/*.parquet")).glob())
+    if not paths:
+        raise FileNotFoundError(f"No centroid sample shards under {sample_path}")
+
+    started = time.monotonic()
+    with ThreadPoolExecutor(max_workers=load_parallelism) as pool:
+        tables = list(pool.map(_read_sample_table, paths))
+    table = pa.concat_tables(tables)
+    encoded_sources = table["source"].combine_chunks().dictionary_encode()
+    source_names = tuple(encoded_sources.dictionary.to_pylist())
+    source_codes = encoded_sources.indices.to_numpy(zero_copy_only=False)
+    selected, quotas = stratified_indices(source_codes, source_names, target, seed)
+
+    embeddings_column = table["embedding"].combine_chunks()
+    if not pa.types.is_fixed_size_list(embeddings_column.type) or embeddings_column.type.list_size != HARRIER_DIM:
+        raise ValueError(f"Unexpected centroid sample type {embeddings_column.type}")
+    quantized = embeddings_column.values.to_numpy(zero_copy_only=False).reshape(-1, HARRIER_DIM)
+    training_embeddings = np.ascontiguousarray(dequantize_to_fp32(quantized[selected]))
+    logger.info(
+        "Loaded %d x %d population and selected %d stratified training rows in %.1fs",
+        len(quantized),
+        HARRIER_DIM,
+        len(training_embeddings),
+        time.monotonic() - started,
+    )
+    return _TrainingData(training_embeddings, quantized, quotas)
+
+
+def _train_fine_centroids(
+    embeddings: np.ndarray,
+    k_train: int,
+    points_per_centroid: int,
+    n_iter: int,
+    n_redo: int,
+    seed: int,
+    n_threads: int,
+) -> _TrainedCentroids:
+    import faiss  # noqa: PLC0415
+
+    faiss.omp_set_num_threads(n_threads)
+    started = time.monotonic()
+    kmeans = faiss.Kmeans(
+        d=HARRIER_DIM,
+        k=k_train,
+        niter=n_iter,
+        nredo=n_redo,
+        spherical=True,
+        seed=seed,
+        verbose=True,
+        max_points_per_centroid=points_per_centroid,
+    )
+    kmeans.train(embeddings)
+    objective = kmeans.obj
+    assert objective is not None
+    return _TrainedCentroids(
+        centroids=kmeans.centroids.astype(np.float32, copy=False),
+        index=kmeans.index,
+        seconds=time.monotonic() - started,
+        objective=float(objective[-1]),
+    )
+
+
+def _cluster_weights(
+    index: _SearchIndex,
+    quantized: np.ndarray,
+    k_train: int,
+    assign_batch_rows: int,
+) -> np.ndarray:
+    weights = np.zeros(k_train, dtype=np.int64)
+    for start in range(0, len(quantized), assign_batch_rows):
+        batch = dequantize_to_fp32(quantized[start : start + assign_batch_rows])
+        _, assignments = index.search(batch, 1)
+        weights += np.bincount(assignments[:, 0], minlength=k_train)
+    return weights
+
+
+def _save_npy(array: np.ndarray, output_path: str, name: str) -> None:
+    with open_url(prefix_join(output_path, name), "wb") as file:
+        np.save(file, array)
+
+
+def _write_training_artifact(
+    output_path: str,
+    sample_path: str,
+    training: _TrainingData,
+    trained: _TrainedCentroids,
+    weights: np.ndarray,
+    coarsening: CoarseningResult,
+    config: CoarseningConfig,
+    points_per_centroid: int,
+    n_iter: int,
+    n_redo: int,
+    seed: int,
+    n_threads: int,
+) -> None:
+    k_train = len(trained.centroids)
+    _save_npy(trained.centroids, output_path, f"centroids_{k_train}.npy")
+    _save_npy(coarsening.fine_to_coarse, output_path, f"lookup_{k_train}_to_{config.clusters}.npy")
+    with open_url(prefix_join(output_path, "fine_cluster_weights.json"), "w") as file:
+        json.dump({f"document_counts_{k_train}": weights.astype(int).tolist()}, file)
+    with open_url(prefix_join(output_path, "train_stats.json"), "w") as file:
+        json.dump(
+            {
+                "sample_path": sample_path,
+                "embedding_dim": HARRIER_DIM,
+                "k_train": k_train,
+                "k_views": [config.clusters],
+                "n_sample": len(training.embeddings),
+                "population_rows": len(training.population),
+                "training_points_per_centroid": points_per_centroid,
+                "training_rows_by_source": training.rows_by_source,
+                "n_iter": n_iter,
+                "n_redo": n_redo,
+                "seed": seed,
+                "n_threads": n_threads,
+                "train_seconds": trained.seconds,
+                "final_objective": trained.objective,
+                "coarsening": _coarsening_payload(coarsening, config),
+            },
+            file,
+            indent=2,
+        )
+
+
+def train_centroids(
+    output_path: str,
+    sample_path: str,
+    k_train: int,
+    train_rows: int,
+    points_per_centroid: int,
+    n_iter: int,
+    n_redo: int,
+    seed: int,
+    n_threads: int,
+    assign_batch_rows: int,
+    load_parallelism: int,
+    coarsening_config: CoarseningConfig,
+) -> None:
+    from threadpoolctl import threadpool_limits  # noqa: PLC0415
+
+    training = _load_training_embeddings(sample_path, train_rows, seed, load_parallelism)
+    with threadpool_limits(limits=n_threads):
+        trained = _train_fine_centroids(
+            training.embeddings,
+            k_train,
+            points_per_centroid,
+            n_iter,
+            n_redo,
+            seed,
+            n_threads,
+        )
+        weights = _cluster_weights(trained.index, training.population, k_train, assign_batch_rows).astype(np.float64)
+        if np.any(weights == 0):
+            raise ValueError("K-means produced an empty fine cluster")
+        coarsening = coarsen_centroids(trained.centroids, weights, coarsening_config)
+    _write_training_artifact(
+        output_path,
+        sample_path,
+        training,
+        trained,
+        weights,
+        coarsening,
+        coarsening_config,
+        points_per_centroid,
+        n_iter,
+        n_redo,
+        seed,
+        n_threads,
+    )

--- a/tests/datakit/test_harrier_domain_clustering.py
+++ b/tests/datakit/test_harrier_domain_clustering.py
@@ -1,0 +1,118 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+from experiments.datakit.cluster.domain.v1.coarsen import CoarseningConfig, coarsen_centroids
+from experiments.datakit.cluster.domain.v1.harrier_all_sources import (
+    _part_quotas,
+    _stratified_indices,
+    proportional_quotas,
+    training_quotas,
+)
+
+
+def _separated_centroids() -> tuple[np.ndarray, np.ndarray]:
+    angles = np.array([-0.03, 0.03, 1.52, 1.57, 1.62, 3.11, 3.17, 4.65, 4.71, 4.77])
+    centroids = np.stack([np.cos(angles), np.sin(angles)], axis=1).astype(np.float32)
+    weights = np.array([8, 17, 7, 8, 10, 11, 14, 7, 8, 10], dtype=np.float64)
+    return centroids, weights
+
+
+def _config() -> CoarseningConfig:
+    return CoarseningConfig(
+        clusters=4,
+        minimum_fraction=0.2,
+        seeds=(40, 41, 42),
+        split_restarts=10,
+        split_iterations=20,
+    )
+
+
+def _weighted_cosine_loss(centroids: np.ndarray, weights: np.ndarray, assignments: np.ndarray) -> float:
+    normalized = centroids / np.linalg.norm(centroids, axis=1, keepdims=True)
+    loss = weights.sum()
+    for cluster in range(int(assignments.max()) + 1):
+        selected = assignments == cluster
+        loss -= np.linalg.norm((normalized[selected] * weights[selected, None]).sum(axis=0))
+    return float(loss)
+
+
+def test_proportional_quotas_give_small_sources_one_document_and_hit_target():
+    counts = {"tiny": 3, "small": 1_000, "medium": 1_011, "large": 10_000}
+
+    quotas = proportional_quotas(counts, 5_000)
+
+    assert quotas == {"tiny": 1, "small": 1, "medium": 459, "large": 4_539}
+
+
+def test_part_quotas_are_proportional_and_hit_source_quota():
+    assert _part_quotas((10, 20, 30), 17) == (3, 6, 8)
+
+
+def test_training_quotas_preserve_every_source_and_hit_target():
+    counts = {"one": 1, "tiny": 3, "medium": 100, "large": 900}
+
+    quotas = training_quotas(counts, 100)
+
+    assert quotas == {"one": 1, "tiny": 1, "medium": 11, "large": 87}
+
+
+def test_stratified_indices_realize_source_quotas_deterministically():
+    source_codes = np.repeat(np.arange(4), [1, 3, 100, 900])
+    source_names = ("one", "tiny", "medium", "large")
+
+    selected, quotas = _stratified_indices(source_codes, source_names, 100, seed=42)
+    repeated, _ = _stratified_indices(source_codes, source_names, 100, seed=42)
+
+    assert np.bincount(source_codes[selected], minlength=4).tolist() == [1, 1, 11, 87]
+    assert quotas == {"one": 1, "tiny": 1, "medium": 11, "large": 87}
+    assert np.array_equal(selected, repeated)
+
+
+def test_coarsen_centroids_recovers_separated_groups_and_preserves_weight_floor():
+    centroids, weights = _separated_centroids()
+    expected_groups = ((0, 1), (2, 3, 4), (5, 6), (7, 8, 9))
+
+    result = coarsen_centroids(centroids, weights, _config())
+
+    cluster_weights = np.bincount(result.fine_to_coarse, weights=weights, minlength=4)
+    assert np.all(cluster_weights >= 20)
+    assert all(len({result.fine_to_coarse[index] for index in group}) == 1 for group in expected_groups)
+    assert len({result.fine_to_coarse[group[0]] for group in expected_groups}) == 4
+    assert result.final.loss <= result.initial.loss
+    assert result.selected_seed == min(result.divisive_runs, key=lambda run: run.stats.loss).seed
+
+
+def test_coarsen_centroids_stops_at_legal_single_move_optimum():
+    rng = np.random.default_rng(7)
+    centroids = rng.normal(size=(30, 5)).astype(np.float32)
+    weights = rng.integers(1, 10, size=len(centroids)).astype(np.float64)
+    config = CoarseningConfig(4, 0.1, (3,), 4, 8)
+
+    result = coarsen_centroids(centroids, weights, config)
+
+    assert result.moves > 0
+    assert result.final.loss < result.initial.loss
+    minimum_weight = weights.sum() * config.minimum_fraction
+    final_loss = _weighted_cosine_loss(centroids, weights, result.fine_to_coarse)
+    cluster_weights = np.bincount(result.fine_to_coarse, weights=weights, minlength=config.clusters)
+    for point, source in enumerate(result.fine_to_coarse):
+        if cluster_weights[source] - weights[point] < minimum_weight:
+            continue
+        for target in range(config.clusters):
+            if target == source:
+                continue
+            candidate = result.fine_to_coarse.copy()
+            candidate[point] = target
+            assert _weighted_cosine_loss(centroids, weights, candidate) >= final_loss - 1e-10
+
+
+def test_coarsen_centroids_rejects_impossible_common_minimum():
+    with pytest.raises(ValueError, match="infeasible"):
+        coarsen_centroids(
+            np.eye(3, dtype=np.float32),
+            np.ones(3),
+            CoarseningConfig(3, 0.4, (42,), 1, 1),
+        )

--- a/tests/datakit/test_harrier_domain_clustering.py
+++ b/tests/datakit/test_harrier_domain_clustering.py
@@ -5,12 +5,8 @@ import numpy as np
 import pytest
 
 from experiments.datakit.cluster.domain.v1.coarsen import CoarseningConfig, coarsen_centroids
-from experiments.datakit.cluster.domain.v1.harrier_all_sources import (
-    _part_quotas,
-    _stratified_indices,
-    proportional_quotas,
-    training_quotas,
-)
+from experiments.datakit.cluster.domain.v1.sample import proportional_quotas
+from experiments.datakit.cluster.domain.v1.train import stratified_indices, training_quotas
 
 
 def _separated_centroids() -> tuple[np.ndarray, np.ndarray]:
@@ -42,13 +38,9 @@ def _weighted_cosine_loss(centroids: np.ndarray, weights: np.ndarray, assignment
 def test_proportional_quotas_give_small_sources_one_document_and_hit_target():
     counts = {"tiny": 3, "small": 1_000, "medium": 1_011, "large": 10_000}
 
-    quotas = proportional_quotas(counts, 5_000)
+    quotas = proportional_quotas(counts, 5_000, small_source_max_rows=1_000, small_source_quota=1)
 
     assert quotas == {"tiny": 1, "small": 1, "medium": 459, "large": 4_539}
-
-
-def test_part_quotas_are_proportional_and_hit_source_quota():
-    assert _part_quotas((10, 20, 30), 17) == (3, 6, 8)
 
 
 def test_training_quotas_preserve_every_source_and_hit_target():
@@ -63,8 +55,8 @@ def test_stratified_indices_realize_source_quotas_deterministically():
     source_codes = np.repeat(np.arange(4), [1, 3, 100, 900])
     source_names = ("one", "tiny", "medium", "large")
 
-    selected, quotas = _stratified_indices(source_codes, source_names, 100, seed=42)
-    repeated, _ = _stratified_indices(source_codes, source_names, 100, seed=42)
+    selected, quotas = stratified_indices(source_codes, source_names, 100, seed=42)
+    repeated, _ = stratified_indices(source_codes, source_names, 100, seed=42)
 
     assert np.bincount(source_codes[selected], minlength=4).tolist() == [1, 1, 11, 87]
     assert quotas == {"one": 1, "tiny": 1, "medium": 11, "large": 87}


### PR DESCRIPTION
Train a 5,000-centroid spherical k-means model from a 10 million-document sample distributed across all 292 current Datakit sources. Sources with at most 1,000 documents receive a one-document floor, and the 2.56 million-row training subset retains every sampled source.

Make the sample step depend directly on the 292 Harrier embedding steps. This records the exact embedding lineage in the Marin cache graph and removes S3 artifact discovery from the pipeline.

Weight the fine centroids by assignments over the full sample, then coarsen them with multi-seed weighted divisive spherical clustering followed by exact single-centroid hill climbing. Enforce a 1% minimum population for each of the 40 resulting domains.

Use CalVer cache identity for the sample and training steps. The completed artifacts were copied to `s3://marin-us-east-02a/marin/datakit/cluster/domain/v1/harrier-all-sources-10m/sample_666a1caf` and `s3://marin-us-east-02a/marin/datakit/cluster/domain/v1/harrier-all-sources-10m/train_5936e908`; the previous copies remain intact. Independent validation matched all 164,290 sample data objects and all four training data objects by relative path and size, and verified the new cache lineage and success markers.

Part of #6491