### PR TITLE
[grug] Run the EP hero with one JAX process per GPU

### DIFF
--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -19,7 +19,9 @@ data-parallel rack uses one 64-device expert mesh.
 - MoE backend: `fixed_all_to_all` by default, with `ragged_all_to_all` as the `ep-ragged` flavor.
   The default backend uses gather dispatch, structured custom VJPs, and capacity factor 1.33.
 - Optimizer: MuonH, with its state offloaded to pinned host memory.
-- Runtime: GPU command buffers off, `cuda_async`, PGLE on, and collective overlap limit 4.
+- Runtime: one JAX process per GPU, GPU command buffers off, `cuda_async`, PGLE off (the
+  per-process CUPTI sessions cannot profile concurrently; an explicit `JAX_ENABLE_PGLE` env
+  setting still wins), and collective overlap limit 4.
 - Output: Metrics only by default. `--save-checkpoints` writes checkpoints, but restore with the
   pinned-host optimizer state has a known memory-kind mismatch. Do not use these checkpoints to
   restart a run.

--- a/experiments/grug/moe_hero_ep/launch.py
+++ b/experiments/grug/moe_hero_ep/launch.py
@@ -36,7 +36,13 @@ HERO_EP_BATCH_SIZE = 1024
 HERO_EP_NODES = 16
 HERO_GPUS_PER_NODE = 4
 HERO_EP_EXPERT_AXIS_SIZE = HERO_EP_NODES * HERO_GPUS_PER_NODE
-HERO_PROCESSES_PER_TASK = 1
+# One JAX process per GPU. The old one-process-per-node layout has two reproducible
+# failure modes on this stack, both from auto-PGLE (which only engages per-node):
+# a profiling-session collision that kills the gang during early dispatch
+# (ALREADY_EXISTS: Another profiling session active), and a silent wedge at the
+# FDO-recompile clique re-initialization (#7344). Per-GPU also matches the FSDP
+# hero (#8040) and is required by the ragged EP backend (#8081).
+HERO_PROCESSES_PER_TASK = HERO_GPUS_PER_NODE
 HERO_MIXED_PRECISION = "params=float32,compute=bfloat16,output=bfloat16"
 # The hero shape keeps its MuonH state on pinned host memory: 24.59 GiB of parameters and 27.78 GiB
 # of optimizer state per device leave too little room for the fixed all-to-all buffers otherwise.

--- a/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
+++ b/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
@@ -45,7 +45,6 @@ from experiments.grug.moe_hero_ep.launch import (
     HERO_EP_NODES,
     HERO_GPUS_PER_NODE,
     HERO_MIXED_PRECISION,
-    HERO_PROCESSES_PER_TASK,
     HeroThroughputResult,
 )
 from experiments.grug.moe_hero_ep.model import GrugModelConfig, QbEstimator
@@ -442,7 +441,9 @@ def build_small_run(
                 # expert-collapsed mesh); a no-op for the FSDP flavors, which already run dropless.
                 dropless_eval=True,
             ),
-            processes_per_task=HERO_PROCESSES_PER_TASK,
+            # One process per GPU on every target: the H100 nodes hold 8 GPUs, not the
+            # GB200 hero's 4, so the count follows the fleet rather than the hero constant.
+            processes_per_task=fleet.gpus_per_node,
         )
 
     return ArtifactStep(

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -74,8 +74,14 @@ class WatchMode(StrEnum):
     DIAGNOSTIC = "diagnostic"
 
 
-def _apply_hero_ep_runtime_defaults(*, inline_watch_enabled: bool) -> None:
-    for name, value in HERO_EP_RUNTIME_ENV.items():
+def _apply_hero_ep_runtime_defaults(*, inline_watch_enabled: bool, processes_per_task: int = 1) -> None:
+    env_defaults = dict(HERO_EP_RUNTIME_ENV)
+    if processes_per_task > 1:
+        # With one process per GPU, the per-process CUPTI sessions collide with each
+        # other and with CoreWeave's DCGM, so PGLE cannot profile and its recompile
+        # machinery only adds failure modes. Default it off; an explicit env wins.
+        env_defaults["JAX_ENABLE_PGLE"] = "false"
+    for name, value in env_defaults.items():
         os.environ.setdefault(name, value)
     xla_flags = os.environ.get("XLA_FLAGS", "").split()
     overlap_limit = INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT if inline_watch_enabled else DEFAULT_COLLECTIVE_OVERLAP_LIMIT
@@ -852,7 +858,9 @@ def run_grug(config: GrugRunConfig) -> None:
 
     # Dispatch snapshots os.environ for the child task, so apply the hero defaults first.
     inline_watch_enabled = trainer.watch.is_enabled and config.trainer.watch_mode == WatchMode.INLINE
-    _apply_hero_ep_runtime_defaults(inline_watch_enabled=inline_watch_enabled)
+    _apply_hero_ep_runtime_defaults(
+        inline_watch_enabled=inline_watch_enabled, processes_per_task=config.processes_per_task
+    )
     dispatch_grug_training_run(
         run_id=trainer.id,
         config=config,

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -165,6 +165,34 @@ def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch)
     assert os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] == "cuda_async"
 
 
+def test_run_grug_defaults_pgle_off_for_per_gpu_processes(monkeypatch):
+    # Per-GPU processes cannot profile: the per-process CUPTI sessions collide with
+    # each other and with the cluster's DCGM, and auto-PGLE's recompile path has
+    # wedged per-node gangs (#7344). Per-GPU runs therefore default PGLE off, while
+    # an explicit env setting still wins.
+    for name in train.HERO_EP_RUNTIME_ENV:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.delenv("XLA_FLAGS", raising=False)
+    config = SimpleNamespace(
+        trainer=SimpleNamespace(
+            trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=1)),
+            watch_mode=train.WatchMode.INLINE,
+        ),
+        resources=object(),
+        processes_per_task=4,
+    )
+
+    with patch.object(train, "dispatch_grug_training_run"):
+        train.run_grug(config)
+
+    assert os.environ["JAX_ENABLE_PGLE"] == "false"
+
+    monkeypatch.setenv("JAX_ENABLE_PGLE", "true")
+    with patch.object(train, "dispatch_grug_training_run"):
+        train.run_grug(config)
+    assert os.environ["JAX_ENABLE_PGLE"] == "true"
+
+
 def test_run_grug_keeps_explicit_ep_runtime_values(monkeypatch):
     monkeypatch.setenv("JAX_ENABLE_PGLE", "false")
     monkeypatch.setenv("XLA_PYTHON_CLIENT_ALLOCATOR", "platform")


### PR DESCRIPTION
The one-process-per-node layout has two reproducible failure modes on GB200, both traced to auto-PGLE, which only engages under that layout. A profiling-session collision (`ALREADY_EXISTS: Another profiling session active`, raised from `jax/_src/profiler.py` at executable dispatch) killed every gang generation of two d1024 control jobs during early dispatch. A run that survives dispatch hits a second window at the PGLE FDO recompile: one run froze silently at step 30 for 10.5 hours with all 16 tasks alive, empty-trace PGLE warnings on every host, and a clique re-initialization as the last logged activity ([#7344 report](https://github.com/marin-community/marin/issues/7344#issuecomment-5269927243)). The same per-node control completes cleanly once PGLE is disabled, which is how the #8062 ladder actually ran its per-node arms.

The default becomes the configuration that works: one JAX process per GPU, with PGLE defaulted off when `processes_per_task` exceeds one, because concurrent per-process CUPTI sessions collide with each other and with CoreWeave's DCGM (an explicit env setting still wins). The layout matches the FSDP hero (#8040, the wedge-ablation positive) and is required by the ragged EP backend (#8081).

Vendor guidance points the same direction, though neither JAX nor NCCL states a blanket recommendation. NVIDIA's JAX guidance documents a hang class specific to one-process-multiple-device setups — a process-wide synchronizing CUDA call (such as `cudaFree`) while a collective runs across devices in the same process — and gives two remedies: `NCCL_LAUNCH_MODE=GROUP`, or binding one process per device ([JAX-Toolbox GPU performance](https://github.com/NVIDIA/JAX-Toolbox/blob/main/docs/GPU_performance.md), "Debugging Hangs in 1-process-multiple-device set-up"). The GROUP remedy is [deprecated since NCCL 2.9](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-launch-mode) ("for processes managing more than one GPU... may be removed in future versions") and did not fix a per-node hang when tried here (#8077, RA2A-004), leaving per-GPU as the only supported remedy for that class. `jax.distributed.initialize` likewise defaults to [a single device per process](https://docs.jax.dev/en/latest/_autosummary/jax.distributed.initialize.html) under Slurm and Open MPI auto-initialization.

Same-code d1024 rung comparison, one GB200 rack, capacity factor 1.33, 1000 steps ([per-GPU](https://wandb.ai/marin-community/marin_moe/runs/ppg-d1024-ep-cf133-b) vs [per-node, PGLE off](https://wandb.ai/marin-community/marin_moe/runs/ppg-d1024-ep-cf133-ctl4)):

| | per-GPU | per-node (PGLE off) |
|---|---|---|
| median step | 0.610 s | 0.613 s |
| drops (last 50) | 5.00% | 5.01% |
| peak HBM | 12.45 GiB | 12.45 GiB |

Mean step times are placement-dominated (identical configs measured 0.66–0.82 s means across same-day runs), so the median carries the comparison. Eight per-GPU rung runs completed cleanly in one day against zero per-node completions with PGLE on. A same-code hero-shape gate (d6144 EP64 LatentMoE, 200 steps, one rack per arm: [per-GPU](https://wandb.ai/marin-community/marin_moe/runs/ppg-hero-pergpu), [per-node, PGLE off](https://wandb.ai/marin-community/marin_moe/runs/ppg-hero-pernode)) shows the same picture: median step 16.83 s vs 16.79 s (−0.22%, within the ±0.25% run-to-run floor), MFU 23.25% vs 23.19%, drops 2.06% in both arms, and identical 154.70 GiB peak HBM — the +8.79 GiB per-GPU cost measured on the FSDP hero (#8054) does not reproduce on the EP hero.

Part of #7344.


