### PR TITLE
[iris] Collect Kubernetes task stats in node agents

### DIFF
--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -511,7 +511,15 @@ Time-series measurements live in finelog stats namespaces, not the controller SQ
 Namespaces:
 
 - `iris.worker` — per-tick host utilization (cpu, mem, disk, running task count, net bps), keyed by `ts`.
-- `iris.task` — per-attempt task resource snapshots, keyed by `ts`.
+- `iris.task` — per-attempt task resource snapshots, keyed by `ts`. Worker
+  daemons write their process readings directly. On Kubernetes, each
+  `iris-node-agent` samples the task containers on its node from kubelet
+  `/metrics/resource` every 30 seconds. CPU is derived from consecutive
+  cumulative counter samples, so the first row after an agent start reports
+  zero CPU. Memory uses the working-set gauge and an agent-local peak; an agent
+  restart resets that peak. Kubelet resource metrics do not expose container
+  filesystem usage, so Kubernetes rows report zero disk usage. The node-agent
+  service account requires `get` on `nodes/proxy`.
 - `iris.task_event` — up to seven days of deduplicated backend verdicts and
   state-changing controller actions per task attempt. Query all attempts with
   `iris task events /user/job/0`, or directly:

--- a/lib/iris/dashboard/src/components/controller/TaskDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/TaskDetail.vue
@@ -487,10 +487,11 @@ watch(() => props.taskId, async () => {
           <div v-else class="text-sm text-text-muted py-2">No resource data</div>
         </InfoCard>
 
-        <!-- Build info card -->
-        <InfoCard title="Build Info">
+        <!-- Container provenance. Worker-daemon builds include timing/cache data;
+             direct Kubernetes tasks use the selected prebuilt runtime image. -->
+        <InfoCard title="Build / Runtime">
           <template v-if="task.buildMetrics">
-            <InfoRow label="Image Tag">
+            <InfoRow label="Runtime Image">
               <span class="font-mono text-xs break-all">
                 {{ task.buildMetrics.imageTag ?? '-' }}
               </span>
@@ -498,13 +499,13 @@ watch(() => props.taskId, async () => {
             <InfoRow v-if="buildDuration" label="Build Time">
               <span class="font-mono">{{ buildDuration }}</span>
             </InfoRow>
-            <InfoRow label="From Cache">
+            <InfoRow v-if="task.buildMetrics.buildStarted || task.buildMetrics.buildFinished" label="From Cache">
               <span :class="task.buildMetrics.fromCache ? 'text-status-success' : 'text-text-muted'">
                 {{ task.buildMetrics.fromCache ? 'Yes' : 'No' }}
               </span>
             </InfoRow>
           </template>
-          <div v-else class="text-sm text-text-muted py-2">No build data</div>
+          <div v-else class="text-sm text-text-muted py-2">No runtime image data</div>
         </InfoCard>
       </div>
 

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -62,9 +62,15 @@ from iris.cluster.platforms.k8s.coreweave_topology import (
 from iris.cluster.platforms.k8s.kueue_manifests import WorkloadPriorityKind, workload_priority_class_name
 from iris.cluster.platforms.k8s.service import K8sService
 from iris.cluster.platforms.k8s.types import (
+    IRIS_ATTEMPT_ID_LABEL,
+    IRIS_KUBERNETES_RUNTIME,
+    IRIS_MANAGED_LABEL,
     IRIS_PRIORITY_CLASS_BATCH,
     IRIS_PRIORITY_CLASS_INTERACTIVE,
     IRIS_PRIORITY_CLASS_PRODUCTION,
+    IRIS_RUNTIME_LABEL,
+    IRIS_TASK_CONTAINER_NAME,
+    IRIS_TASK_ID_ANNOTATION,
     K8sResource,
     KubectlError,
     parse_k8s_cpu,
@@ -95,11 +101,9 @@ from iris.cluster.runtime.types import ACCELERATOR_SHM_FALLBACK_BYTES, MountKind
 from iris.cluster.stats.emitter import PeriodicEmitter
 from iris.cluster.stats.tables import (
     IrisProfile,
-    IrisTaskStat,
     ProfileTrigger,
     TaskEventRow,
     TaskEventSeverity,
-    build_task_stat,
     stats_timestamp,
 )
 from iris.cluster.types import JobName, WellKnownAttribute, WorkerId, get_gpu_count
@@ -125,23 +129,23 @@ class PodManifestError(ValueError):
 
 
 # Label key prefix for iris-managed pod identification.
-_LABEL_MANAGED = "iris.managed"
-_LABEL_RUNTIME = "iris.runtime"
+_LABEL_MANAGED = IRIS_MANAGED_LABEL
+_LABEL_RUNTIME = IRIS_RUNTIME_LABEL
 _LABEL_TASK_ID = "iris.task_id"
-_LABEL_ATTEMPT_ID = "iris.attempt_id"
+_LABEL_ATTEMPT_ID = IRIS_ATTEMPT_ID_LABEL
 # Collision-resistant hash of the full (unsanitized) task_id; 16 hex chars (64 bits).
 _LABEL_TASK_HASH = "iris.task_hash"
 _LABEL_JOB_ID = "iris.job_id"
 
 # Runtime identifier for pods created by K8sTaskProvider.
-_RUNTIME_LABEL_VALUE = "iris-kubernetes"
+_RUNTIME_LABEL_VALUE = IRIS_KUBERNETES_RUNTIME
 
 # Extended resource name for NVIDIA GPUs in pod requests/limits.
 _GPU_RESOURCE = "nvidia.com/gpu"
 
 # Name of the task container in the pod. Exit-code/error extraction matches the
 # task status by this name rather than by position in containerStatuses.
-_TASK_CONTAINER_NAME = "task"
+_TASK_CONTAINER_NAME = IRIS_TASK_CONTAINER_NAME
 
 # Native log-shipping sidecar (initContainer + restartPolicy: Always). It reads
 # the task container's CRI log file from the node and pushes to finelog, so the
@@ -896,6 +900,7 @@ def _build_pod_manifest(
         "name": pod_name,
         "namespace": namespace,
         "labels": labels,
+        "annotations": {IRIS_TASK_ID_ANNOTATION: run_req.task_id},
     }
 
     # Every pod is admitted through one Kueue TAS flavor: its accounting and
@@ -928,21 +933,27 @@ def _build_pod_manifest(
         # Per-pod ordinal within the gang (0..total-1). Kueue's TAS assigns each pod a domain
         # rank from it; for the sliced level it makes slice membership rank-contiguous.
         labels[_KUEUE_POD_GROUP_POD_INDEX] = str(task_id.task_index)
-        metadata["annotations"] = {
-            _KUEUE_POD_GROUP_TOTAL: str(run_req.num_tasks),
-            **_topology_request_annotations(
-                topo, group_by=group_by, num_tasks=run_req.num_tasks, gpu_count=gpu_count, task_ref=run_req.task_id
-            ),
-        }
+        metadata["annotations"].update(
+            {
+                _KUEUE_POD_GROUP_TOTAL: str(run_req.num_tasks),
+                **_topology_request_annotations(
+                    topo,
+                    group_by=group_by,
+                    num_tasks=run_req.num_tasks,
+                    gpu_count=gpu_count,
+                    task_ref=run_req.task_id,
+                ),
+            }
+        )
     elif gpu_count > 0:
         # A non-coscheduled GPU pod has no gang to colocate, so ask only for the
         # finest, always-satisfiable level as a soft preference.
-        metadata["annotations"] = {_KUEUE_PREFERRED_TOPOLOGY: _KUEUE_SINGLE_POD_TOPOLOGY}
+        metadata["annotations"][_KUEUE_PREFERRED_TOPOLOGY] = _KUEUE_SINGLE_POD_TOPOLOGY
     else:
         # Accelerator-free Pods remain in TAS without requesting colocation. This
         # records their per-node CPU usage in the same flavor as GPU gangs, so a
         # higher-priority gang can simulate reclaiming it before topology fit.
-        metadata["annotations"] = {_KUEUE_UNCONSTRAINED_TOPOLOGY: "true"}
+        metadata["annotations"][_KUEUE_UNCONSTRAINED_TOPOLOGY] = "true"
 
     # Native log-shipping sidecar: ships the task container's node-side CRI log
     # file to finelog. As an initContainer with restartPolicy: Always it is
@@ -1825,79 +1836,6 @@ class ClusterState:
         )
 
 
-class ResourceCollector:
-    """Periodic emitter that samples running pods' CPU/memory usage.
-
-    The reconcile loop declares the authoritative set of running pods via
-    ``set_pods()`` once per cycle. Each ``poll_interval`` the collector samples
-    those pods via one bulk metrics query and appends an ``IrisTaskStat`` row
-    per pod to the ``iris.task`` table — the same table the worker daemon writes
-    to on the GCE/TPU path, so the dashboard's ``iris.task`` queries cover both
-    runtimes uniformly.
-
-    ``poll_interval`` defaults to the metrics-server scrape resolution (15s);
-    polling faster only re-reads the same sample.
-    """
-
-    def __init__(
-        self,
-        kubectl: K8sService,
-        task_stats_table: Table,
-        *,
-        labels: dict[str, str] | None = None,
-        poll_interval: float = 15.0,
-    ):
-        self._kubectl = kubectl
-        self._table = task_stats_table
-        self._labels = labels
-        # (task_id_wire, attempt_id) -> pod_name. Tuple keys carry the
-        # identity needed to build IrisTaskStat without parsing strings.
-        self._pods: dict[tuple[str, int], str] = {}
-        self._lock = threading.Lock()
-        self._emitter = PeriodicEmitter(self.collect_once, interval=poll_interval, name="resource-collector")
-
-    def set_pods(self, pods: dict[tuple[str, int], str]) -> None:
-        """Declare the authoritative set of pods to collect resources for."""
-        with self._lock:
-            self._pods = dict(pods)
-
-    def collect_once(self) -> None:
-        """Sample every tracked pod once and append a stat row per pod with usage.
-
-        Runs each ``poll_interval`` on the emitter thread; also the unit of
-        collection tests drive directly.
-        """
-        with self._lock:
-            snapshot = list(self._pods.items())
-        if not snapshot:
-            return
-        usage_by_pod = self._kubectl.top_pods(labels=self._labels)
-
-        stats: list[IrisTaskStat] = []
-        for (task_id_wire, attempt_id), pod_name in snapshot:
-            top = usage_by_pod.get(pod_name)
-            if top is None:
-                continue
-            stats.append(
-                build_task_stat(
-                    task_id=task_id_wire,
-                    attempt_id=attempt_id,
-                    # Pod name is the per-attempt platform identity on k8s,
-                    # mirroring worker_id on the GCE/TPU path.
-                    worker_id=pod_name,
-                    usage=job_pb2.ResourceUsage(
-                        cpu_millicores=top.cpu_millicores,
-                        memory_mb=top.memory_bytes // (1024 * 1024),
-                    ),
-                )
-            )
-        if stats:
-            self._table.write(stats)
-
-    def close(self) -> None:
-        self._emitter.close()
-
-
 # Periodic thread-dump cadence, 10 minutes to match the GCE/TPU worker cadence.
 DEFAULT_PROFILE_POLL_INTERVAL = 600.0
 # Cap on concurrent kubectl exec streams a single capture cycle opens, so a large
@@ -2243,22 +2181,13 @@ class K8sTaskProvider:
     # when it has gang work for Kueue. Empty disables the feature; see
     # _evict_preemptible_blockers for the safety guards.
     preempt_namespaces: list[str] = field(default_factory=list)
-    # Pre-resolved iris.task Table handle, built from the controller's log client
-    # and passed in by the composer; when None — e.g. tests without finelog — the
-    # resource collector is disabled. K8s pods ship their own logs via the
-    # log-shipper sidecar, so the backend needs only the tables, not the client.
-    task_stats_table: Table | None = None
-    # Pre-resolved iris.task_event Table handle, passed alongside task_stats_table.
+    # Pre-resolved iris.task_event Table handle.
     # When None (tests without finelog) the scheduling/admission event log is
     # disabled; task state still flows, only the diagnostic timeline is skipped.
     task_event_table: Table | None = None
-    # Pre-resolved iris.profile Table handle, passed alongside task_stats_table.
+    # Pre-resolved iris.profile Table handle.
     # None in test mode.
     profile_table: Table | None = None
-    # Resource-usage poll cadence. Defaults to the metrics-server scrape
-    # resolution (15s) — sampling faster only re-reads the same value. One bulk
-    # metrics list per tick covers every managed pod (see ResourceCollector).
-    resource_poll_interval: float = 15.0
     # Cadence at which PeriodicProfiler dumps each running pod's threads to
     # iris.profile (trigger=periodic), so a silently hung collective is caught in
     # the profile timeline even though nothing polls a k8s pod otherwise.
@@ -2290,7 +2219,6 @@ class K8sTaskProvider:
     # were created under the current name, so their lookups must never consider the
     # pre-uid name — see _pod_name_candidates.
     _dispatched_attempts: set[tuple[str, int]] = field(default_factory=set, init=False, repr=False)
-    _resource_collector: ResourceCollector | None = field(default=None, init=False, repr=False)
     _periodic_profiler: PeriodicProfiler | None = field(default=None, init=False, repr=False)
     _task_event_log: TaskEventLog | None = field(default=None, init=False, repr=False)
     _cluster_state: ClusterState = field(default_factory=ClusterState, init=False, repr=False)
@@ -2301,18 +2229,6 @@ class K8sTaskProvider:
     _gc_emitter: PeriodicEmitter | None = field(default=None, init=False, repr=False)
     _gc_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
     _pending_gc_hashes: set[str] = field(default_factory=set, init=False, repr=False)
-
-    def _ensure_resource_collector(self) -> ResourceCollector | None:
-        if self.task_stats_table is None:
-            return None
-        if self._resource_collector is None:
-            self._resource_collector = ResourceCollector(
-                self.kubectl,
-                self.task_stats_table,
-                labels=_MANAGED_POD_LABELS,
-                poll_interval=self.resource_poll_interval,
-            )
-        return self._resource_collector
 
     def _ensure_periodic_profiler(self) -> PeriodicProfiler | None:
         if self.profile_table is None:
@@ -2337,6 +2253,10 @@ class K8sTaskProvider:
 
     def configure_routing(self, advertised: dict[str, set[str]]) -> None:
         self.advertised = advertised
+
+    def runtime_image(self, requested_image: str) -> str:
+        """Return the image selected for a Kubernetes task container."""
+        return requested_image or self.pods.default_image
 
     def resource_capacity(self) -> dict[str, DeviceCapacity] | None:
         """Free and total GPUs inferred from the periodic kubectl cluster sync.
@@ -2636,8 +2556,6 @@ class K8sTaskProvider:
     def close(self) -> None:
         if self._gc_emitter is not None:
             self._gc_emitter.close()
-        if self._resource_collector is not None:
-            self._resource_collector.close()
         if self._periodic_profiler is not None:
             self._periodic_profiler.close()
 
@@ -3038,12 +2956,9 @@ class K8sTaskProvider:
 
         Task logs are shipped by the per-pod log-shipper sidecar, not pulled
         here. This method drives task state and registers running pods with the
-        ResourceCollector, calling set_pods() once with the authoritative set of
-        running pods so the collector can never drift.
+        periodic profiler.
         """
         if not running:
-            if self._resource_collector is not None:
-                self._resource_collector.set_pods({})
             if self._periodic_profiler is not None:
                 self._periodic_profiler.set_pods({})
             if self._task_event_log is not None:
@@ -3085,11 +3000,7 @@ class K8sTaskProvider:
                     if not unresolved:
                         break
 
-        # (task_id_wire, attempt_id) -> pod_name. Resource samples are
-        # appended directly to iris.task by the collector; the controller no
-        # longer multiplexes them through TaskUpdate.
-        resource_pods: dict[tuple[str, int], str] = {}
-        # Same running set, carrying the node name so the periodic profiler can
+        # The running set carries the node name so the periodic profiler can
         # stamp the k8s/<node> vm_id without a per-pod GET.
         profile_targets: dict[tuple[str, int], _ProfileTarget] = {}
         event_log = self._ensure_task_event_log()
@@ -3145,7 +3056,6 @@ class K8sTaskProvider:
                 self._disruption_reasons[entry] = _format_disruption_reason(disruption)
             phase = pod.get("status", {}).get("phase", "")
             if phase == "Running":
-                resource_pods[task_key] = pod_name
                 profile_targets[task_key] = _ProfileTarget(
                     task_id=entry.task_id.to_wire(),
                     attempt_id=entry.attempt_id,
@@ -3157,9 +3067,6 @@ class K8sTaskProvider:
 
             updates.append(update)
 
-        resource_collector = self._ensure_resource_collector()
-        if resource_collector is not None:
-            resource_collector.set_pods(resource_pods)
         periodic_profiler = self._ensure_periodic_profiler()
         if periodic_profiler is not None:
             periodic_profiler.set_pods(profile_targets)

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -143,10 +143,6 @@ _RUNTIME_LABEL_VALUE = IRIS_KUBERNETES_RUNTIME
 # Extended resource name for NVIDIA GPUs in pod requests/limits.
 _GPU_RESOURCE = "nvidia.com/gpu"
 
-# Name of the task container in the pod. Exit-code/error extraction matches the
-# task status by this name rather than by position in containerStatuses.
-_TASK_CONTAINER_NAME = IRIS_TASK_CONTAINER_NAME
-
 # Native log-shipping sidecar (initContainer + restartPolicy: Always). It reads
 # the task container's CRI log file from the node and pushes to finelog, so the
 # controller never pulls pod logs through the apiserver.
@@ -1039,7 +1035,7 @@ def _task_container_status(pod: dict) -> dict | None:
     if not statuses:
         return None
     for status in statuses:
-        if status.get("name") == _TASK_CONTAINER_NAME:
+        if status.get("name") == IRIS_TASK_CONTAINER_NAME:
             return status
     return statuses[0]
 
@@ -2255,7 +2251,6 @@ class K8sTaskProvider:
         self.advertised = advertised
 
     def runtime_image(self, requested_image: str) -> str:
-        """Return the image selected for a Kubernetes task container."""
         return requested_image or self.pods.default_image
 
     def resource_capacity(self) -> dict[str, DeviceCapacity] | None:

--- a/lib/iris/src/iris/cluster/backends/rpc/backend.py
+++ b/lib/iris/src/iris/cluster/backends/rpc/backend.py
@@ -247,7 +247,6 @@ class RpcTaskBackend:
         self.advertised = advertised
 
     def runtime_image(self, requested_image: str) -> str:
-        """Return an explicitly requested image; worker defaults are remote."""
         return requested_image
 
     def resource_capacity(self) -> dict[str, DeviceCapacity] | None:

--- a/lib/iris/src/iris/cluster/backends/rpc/backend.py
+++ b/lib/iris/src/iris/cluster/backends/rpc/backend.py
@@ -246,6 +246,10 @@ class RpcTaskBackend:
     def configure_routing(self, advertised: dict[str, set[str]]) -> None:
         self.advertised = advertised
 
+    def runtime_image(self, requested_image: str) -> str:
+        """Return an explicitly requested image; worker defaults are remote."""
+        return requested_image
+
     def resource_capacity(self) -> dict[str, DeviceCapacity] | None:
         """Free and total GPU chips a peer could schedule onto, keyed by lowercased device-variant.
 

--- a/lib/iris/src/iris/cluster/composer.py
+++ b/lib/iris/src/iris/cluster/composer.py
@@ -62,7 +62,6 @@ def make_task_backend(
     config: IrisClusterConfig,
     *,
     unreachable_grace: Duration,
-    task_stats_table: Table | None = None,
     task_event_table: Table | None = None,
     profile_table: Table | None = None,
     autoscaler: Autoscaler | None = None,
@@ -71,10 +70,10 @@ def make_task_backend(
     """Create a TaskBackend from cluster configuration.
 
     Returns a ``K8sTaskProvider`` when ``kubernetes_provider`` is configured,
-    or an ``RpcTaskBackend`` when ``worker_provider`` is configured. The finelog
-    tables are passed to the K8s backend (which writes per-pod resource/profile
-    samples directly); the RPC backend ignores them — its worker daemons write
-    their own rows. ``unreachable_grace`` sizes the liveness tracker the
+    or an ``RpcTaskBackend`` when ``worker_provider`` is configured. Event and
+    profile tables are passed to the K8s backend; node agents write per-pod
+    resource samples, while RPC worker daemons write their own rows.
+    ``unreachable_grace`` sizes the liveness tracker the
     worker-daemon backend constructs and owns. ``transition_reader`` is the K8s
     backend's controller-DB read surface; ``autoscaler`` provisions capacity for
     the worker-daemon backend (None for clusters with no scale groups).
@@ -137,7 +136,6 @@ def make_task_backend(
                 priority_class_names=pod_priority_classes,
             ),
             preempt_namespaces=list(kp.preempt_namespaces),
-            task_stats_table=task_stats_table,
             task_event_table=task_event_table,
             profile_table=profile_table,
             transition_reader=transition_reader,
@@ -215,7 +213,6 @@ def make_backend(
         provider = make_task_backend(
             config,
             unreachable_grace=unreachable_grace,
-            task_stats_table=log_stack.task_stats_table,
             task_event_table=log_stack.task_event_table,
             profile_table=log_stack.profile_table,
             transition_reader=DbTransitionReader(db),
@@ -228,7 +225,6 @@ def make_backend(
         return make_task_backend(
             config,
             unreachable_grace=unreachable_grace,
-            task_stats_table=log_stack.task_stats_table,
             task_event_table=log_stack.task_event_table,
             profile_table=log_stack.profile_table,
         )
@@ -269,7 +265,6 @@ def make_backend(
     provider = make_task_backend(
         config,
         unreachable_grace=unreachable_grace,
-        task_stats_table=log_stack.task_stats_table,
         task_event_table=log_stack.task_event_table,
         profile_table=log_stack.profile_table,
         autoscaler=autoscaler,

--- a/lib/iris/src/iris/cluster/controller/backend.py
+++ b/lib/iris/src/iris/cluster/controller/backend.py
@@ -534,6 +534,15 @@ class TaskBackend(Protocol):
         "nothing free"."""
         ...
 
+    def runtime_image(self, requested_image: str) -> str:
+        """Resolve the container image used for a task request.
+
+        Direct container backends can supply their configured default when the
+        request leaves the image empty. Worker-daemon backends only know an
+        explicitly requested image; their workers report build details.
+        """
+        ...
+
     def status(self) -> controller_pb2.Controller.BackendStatus:
         """Author this backend's expanded status for the dashboard Backends tab.
 

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -2195,6 +2195,7 @@ class ControllerServiceImpl:
                     job_config_table.c.res_memory_bytes,
                     job_config_table.c.res_disk_bytes,
                     job_config_table.c.res_device_json,
+                    job_config_table.c.task_image,
                 ).where(job_config_table.c.job_id == task.job_id)
             ).first()
         if jc_row is not None:
@@ -2202,6 +2203,9 @@ class ControllerServiceImpl:
                 job_resources = resource_spec_from_scalars(
                     jc_row.res_cpu_millicores, jc_row.res_memory_bytes, jc_row.res_disk_bytes, jc_row.res_device_json
                 )
+            runtime_image = self._backend_for_id(task.backend_id).runtime_image(jc_row.task_image)
+            if runtime_image:
+                proto.build_metrics.image_tag = runtime_image
 
         return controller_pb2.Controller.GetTaskStatusResponse(
             task=proto,

--- a/lib/iris/src/iris/cluster/node_agent/kubernetes.py
+++ b/lib/iris/src/iris/cluster/node_agent/kubernetes.py
@@ -35,6 +35,7 @@ from iris.cluster.platforms.k8s.types import (
     IRIS_TASK_CONTAINER_NAME,
     IRIS_TASK_ID_ANNOTATION,
     K8sResource,
+    KubectlError,
 )
 from iris.cluster.stats.tables import TASK_STATS_NAMESPACE, IrisTaskStat, build_task_stat
 from iris.rpc import job_pb2
@@ -239,7 +240,7 @@ class TaskStatsCollector:
                 field_selector=f"spec.nodeName={self._node_name}",
             )
             resources = parse_kubelet_resource_metrics(self._kubectl.node_resource_metrics(self._node_name))
-        except Exception as error:
+        except KubectlError as error:
             logger.warning("task-resource collection failed for node %s: %s", self._node_name, error)
             return
 
@@ -728,10 +729,6 @@ def _log_service_endpoint(cluster_config: IrisClusterConfig) -> str:
     else:
         raise ValueError("node telemetry requires an external /system/log-server endpoint")
     return resolve_endpoint_uri(uri, metadata).rstrip("/")
-
-
-def _telemetry_endpoint(cluster_config: IrisClusterConfig) -> str:
-    return _log_service_endpoint(cluster_config) + TELEMETRY_ENDPOINT_PATH
 
 
 def _node_target(k8s: CloudK8sService, node_name: str) -> NodeTarget:

--- a/lib/iris/src/iris/cluster/node_agent/kubernetes.py
+++ b/lib/iris/src/iris/cluster/node_agent/kubernetes.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import NamedTuple
 
+from finelog.client import LogClient
+from finelog.client.log_client import Table
 from finelog.deploy.config import derive_endpoint_uri, load_finelog_config
 from rigging import telemetry
 
@@ -25,7 +27,17 @@ from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME, TELEMETRY_ENDPOINT_
 from iris.cluster.node_agent import SERVICE_NAME
 from iris.cluster.node_agent.metrics import DeviceMetric, NodeMetrics, NodeTarget, publish_node_telemetry
 from iris.cluster.platforms.k8s.service import CloudK8sService, K8sService
-from iris.cluster.platforms.k8s.types import K8sResource
+from iris.cluster.platforms.k8s.types import (
+    IRIS_ATTEMPT_ID_LABEL,
+    IRIS_KUBERNETES_RUNTIME,
+    IRIS_MANAGED_LABEL,
+    IRIS_RUNTIME_LABEL,
+    IRIS_TASK_CONTAINER_NAME,
+    IRIS_TASK_ID_ANNOTATION,
+    K8sResource,
+)
+from iris.cluster.stats.tables import TASK_STATS_NAMESPACE, IrisTaskStat, build_task_stat
+from iris.rpc import job_pb2
 
 logger = logging.getLogger(__name__)
 
@@ -172,6 +184,120 @@ def parse_prometheus(text: str) -> Iterator[Sample]:
         if not math.isfinite(value):
             continue
         yield Sample(name, labels, value)
+
+
+@dataclass
+class ContainerResourceSample:
+    """Kubelet resource counters for one container."""
+
+    cpu_seconds: float | None = None
+    memory_bytes: int | None = None
+
+
+def parse_kubelet_resource_metrics(text: str) -> dict[tuple[str, str], ContainerResourceSample]:
+    """Parse kubelet ``metrics/resource`` text by ``(pod, container)``."""
+    resources: dict[tuple[str, str], ContainerResourceSample] = {}
+    for name, labels, value in parse_prometheus(text):
+        pod = labels.get("pod", "")
+        container = labels.get("container", "")
+        if not pod or not container:
+            continue
+        key = (pod, container)
+        sample = resources.setdefault(key, ContainerResourceSample())
+        if name == "container_cpu_usage_seconds_total":
+            sample.cpu_seconds = value
+        elif name == "container_memory_working_set_bytes":
+            sample.memory_bytes = int(value)
+    return resources
+
+
+class TaskStatsCollector:
+    """Write same-node Iris pod CPU and memory samples to ``iris.task``."""
+
+    def __init__(
+        self,
+        kubectl: K8sService,
+        node_name: str,
+        table: Table,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._kubectl = kubectl
+        self._node_name = node_name
+        self._table = table
+        self._clock = clock
+        self._previous_cpu: dict[str, tuple[float, float]] = {}
+        self._memory_peak: dict[str, int] = {}
+
+    def collect_once(self) -> None:
+        """Collect one task-resource sample for each running pod on this node."""
+        labels = {IRIS_MANAGED_LABEL: "true", IRIS_RUNTIME_LABEL: IRIS_KUBERNETES_RUNTIME}
+        try:
+            pods = self._kubectl.list_json(
+                K8sResource.PODS,
+                labels=labels,
+                field_selector=f"spec.nodeName={self._node_name}",
+            )
+            resources = parse_kubelet_resource_metrics(self._kubectl.node_resource_metrics(self._node_name))
+        except Exception as error:
+            logger.warning("task-resource collection failed for node %s: %s", self._node_name, error)
+            return
+
+        sampled_at = self._clock()
+        live_pods = {
+            pod.get("metadata", {}).get("name", "") for pod in pods if pod.get("status", {}).get("phase") == "Running"
+        }
+        rows: list[IrisTaskStat] = []
+        for pod in pods:
+            if pod.get("status", {}).get("phase") != "Running":
+                continue
+            metadata = pod.get("metadata", {})
+            pod_name = metadata.get("name", "")
+            task_id = metadata.get("annotations", {}).get(IRIS_TASK_ID_ANNOTATION, "")
+            attempt = metadata.get("labels", {}).get(IRIS_ATTEMPT_ID_LABEL, "")
+            sample = resources.get((pod_name, IRIS_TASK_CONTAINER_NAME))
+            if not pod_name or not task_id or not attempt or sample is None:
+                continue
+
+            cpu_millicores = self._cpu_millicores(pod_name, sample.cpu_seconds, sampled_at)
+            memory_bytes = sample.memory_bytes or 0
+            memory_peak = max(memory_bytes, self._memory_peak.get(pod_name, 0))
+            self._memory_peak[pod_name] = memory_peak
+            rows.append(
+                build_task_stat(
+                    task_id=task_id,
+                    attempt_id=int(attempt),
+                    worker_id=pod_name,
+                    usage=job_pb2.ResourceUsage(
+                        cpu_millicores=cpu_millicores,
+                        memory_mb=memory_bytes // _MIB,
+                        memory_peak_mb=memory_peak // _MIB,
+                    ),
+                )
+            )
+
+        self._prune(live_pods)
+        if rows:
+            self._table.write(rows)
+
+    def _cpu_millicores(self, pod_name: str, cpu_seconds: float | None, sampled_at: float) -> int:
+        if cpu_seconds is None:
+            return 0
+        previous = self._previous_cpu.get(pod_name)
+        self._previous_cpu[pod_name] = (cpu_seconds, sampled_at)
+        if previous is None:
+            return 0
+        cpu_delta = cpu_seconds - previous[0]
+        time_delta = sampled_at - previous[1]
+        if cpu_delta < 0 or time_delta <= 0:
+            return 0
+        return max(0, round(cpu_delta / time_delta * 1000))
+
+    def _prune(self, live_pods: set[str]) -> None:
+        for pod_name in self._previous_cpu.keys() - live_pods:
+            del self._previous_cpu[pod_name]
+        for pod_name in self._memory_peak.keys() - live_pods:
+            del self._memory_peak[pod_name]
 
 
 def _is_physical_iface(device: str) -> bool:
@@ -591,7 +717,7 @@ class NodeStatsScraper:
         return {k: body for k, body in zip(keys, bodies, strict=True) if body is not None}
 
 
-def _telemetry_endpoint(cluster_config: IrisClusterConfig) -> str:
+def _log_service_endpoint(cluster_config: IrisClusterConfig) -> str:
     spec = cluster_config.endpoints.get(LOG_SERVER_ENDPOINT_NAME)
     if cluster_config.finelog.config:
         if spec is not None:
@@ -601,7 +727,11 @@ def _telemetry_endpoint(cluster_config: IrisClusterConfig) -> str:
         uri, metadata = spec.uri, dict(spec.metadata)
     else:
         raise ValueError("node telemetry requires an external /system/log-server endpoint")
-    return resolve_endpoint_uri(uri, metadata).rstrip("/") + TELEMETRY_ENDPOINT_PATH
+    return resolve_endpoint_uri(uri, metadata).rstrip("/")
+
+
+def _telemetry_endpoint(cluster_config: IrisClusterConfig) -> str:
+    return _log_service_endpoint(cluster_config) + TELEMETRY_ENDPOINT_PATH
 
 
 def _node_target(k8s: CloudK8sService, node_name: str) -> NodeTarget:
@@ -625,19 +755,32 @@ def _node_target(k8s: CloudK8sService, node_name: str) -> NodeTarget:
     )
 
 
-def collect_once(scraper: NodeStatsScraper, target: NodeTarget) -> None:
-    """Publish one same-node exporter collection pass."""
+def collect_once(
+    scraper: NodeStatsScraper,
+    target: NodeTarget,
+    task_stats_collector: TaskStatsCollector | None = None,
+) -> None:
+    """Publish one same-node exporter and task-resource collection pass."""
     metrics = scraper.scrape([target])[target.name]
     publish_node_telemetry(target, metrics, time.time())
+    if task_stats_collector is not None:
+        task_stats_collector.collect_once()
     telemetry.record_runtime_health()
 
 
 def run(config_path: Path, node_name: str, namespace: str, stop: threading.Event) -> None:
     """Collect telemetry until the process receives a shutdown signal."""
     config = load_config(config_path)
-    endpoint = _telemetry_endpoint(config)
+    log_service_endpoint = _log_service_endpoint(config)
+    endpoint = log_service_endpoint + TELEMETRY_ENDPOINT_PATH
     k8s = CloudK8sService(namespace=namespace, timeout=K8S_API_TIMEOUT)
     target = _node_target(k8s, node_name)
+    log_client = LogClient.connect(log_service_endpoint)
+    task_stats_collector = TaskStatsCollector(
+        k8s,
+        node_name,
+        log_client.get_table(TASK_STATS_NAMESPACE, IrisTaskStat),
+    )
     telemetry.configure(
         endpoint=endpoint,
         service=SERVICE_NAME,
@@ -646,7 +789,8 @@ def run(config_path: Path, node_name: str, namespace: str, stop: threading.Event
     scraper = NodeStatsScraper(k8s)
     try:
         while not stop.is_set():
-            collect_once(scraper, target)
+            collect_once(scraper, target, task_stats_collector)
             stop.wait(DEFAULT_COLLECTION_INTERVAL)
     finally:
+        log_client.close()
         telemetry.shutdown(5.0)

--- a/lib/iris/src/iris/cluster/platforms/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/fake.py
@@ -26,7 +26,6 @@ from iris.cluster.platforms.k8s.types import (
     KubectlError,
     KubectlLogLine,
     KubectlLogResult,
-    PodResourceUsage,
     parse_k8s_quantity,
 )
 from iris.cluster.service_mode import ServiceMode
@@ -266,7 +265,7 @@ class InMemoryK8sService:
         self._exec_responses: dict[str, list[ExecResult]] = {}
         self._file_contents: dict[tuple[str, str], bytes] = {}  # (pod_name, path) -> data
         self._rm_files_calls: list[tuple[str, list[str]]] = []
-        self._top_pod_overrides: dict[str, PodResourceUsage | None] = {}
+        self._node_resource_metrics: dict[str, str] = {}
         self._log_watermarks: dict[str, int] = {}  # pod_name -> bytes consumed
 
         # Pods living outside the service's own namespace, keyed by
@@ -540,9 +539,9 @@ class InMemoryK8sService:
         """Pre-populate file content readable via read_file."""
         self._file_contents[(pod_name, path)] = data
 
-    def set_top_pod(self, pod_name: str, result: PodResourceUsage | None) -> None:
-        """Configure a pod's reported resource usage (None = metrics absent)."""
-        self._top_pod_overrides[pod_name] = result
+    def set_node_resource_metrics(self, node_name: str, text: str) -> None:
+        """Configure kubelet resource metrics returned for a node."""
+        self._node_resource_metrics[node_name] = text
 
     def seed_resource(self, resource: K8sResource, name: str, manifest: dict) -> None:
         """Directly insert a resource into the in-memory store for test setup.
@@ -796,26 +795,9 @@ class InMemoryK8sService:
                 results.append(event)
         return results
 
-    def top_pods(self, *, labels: dict[str, str] | None = None) -> dict[str, PodResourceUsage]:
-        self._check_failure("top_pods")
-        plural = K8sResource.PODS.plural
-        usage: dict[str, PodResourceUsage] = {}
-        for (stored_plural, name), manifest in self._resources.items():
-            if stored_plural != plural:
-                continue
-            if labels:
-                res_labels = manifest.get("metadata", {}).get("labels", {})
-                if not all(res_labels.get(k) == v for k, v in labels.items()):
-                    continue
-            usage[name] = PodResourceUsage(cpu_millicores=100, memory_bytes=256 * 1024 * 1024)
-        # Per-pod overrides win regardless of the label scope; a None override
-        # means "metrics absent" and drops the pod from the result.
-        for name, override in self._top_pod_overrides.items():
-            if override is None:
-                usage.pop(name, None)
-            else:
-                usage[name] = override
-        return usage
+    def node_resource_metrics(self, node_name: str) -> str:
+        self._check_failure("node_resource_metrics")
+        return self._node_resource_metrics.get(node_name, "")
 
     def read_file(
         self,

--- a/lib/iris/src/iris/cluster/platforms/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/fake.py
@@ -540,7 +540,6 @@ class InMemoryK8sService:
         self._file_contents[(pod_name, path)] = data
 
     def set_node_resource_metrics(self, node_name: str, text: str) -> None:
-        """Configure kubelet resource metrics returned for a node."""
         self._node_resource_metrics[node_name] = text
 
     def seed_resource(self, resource: K8sResource, name: str, manifest: dict) -> None:

--- a/lib/iris/src/iris/cluster/platforms/k8s/rbac_manifests.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/rbac_manifests.py
@@ -18,12 +18,12 @@ CLUSTER_ROLE_RULES = [
         "verbs": ["get", "list", "watch", "create", "update", "patch", "delete"],
     },
     {"apiGroups": [""], "resources": ["nodes"], "verbs": ["get", "list", "watch"]},
+    {"apiGroups": [""], "resources": ["nodes/proxy"], "verbs": ["get"]},
     {
         "apiGroups": [""],
         "resources": ["configmaps"],
         "verbs": ["get", "list", "watch", "create", "update", "patch", "delete"],
     },
-    {"apiGroups": ["metrics.k8s.io"], "resources": ["pods"], "verbs": ["get", "list"]},
     {
         "apiGroups": ["policy"],
         "resources": ["poddisruptionbudgets"],

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -775,11 +775,16 @@ class CloudK8sService:
         """Return kubelet ``metrics/resource`` text for one node."""
         logger.debug("k8s: node resource metrics node=%s", node_name)
         with slow_log(logger, "node_resource_metrics", threshold_ms=_SLOW_THRESHOLD_MS):
-            return self._core_v1.connect_get_node_proxy_with_path(
-                name=node_name,
-                path="metrics/resource",
-                **self._request_timeout_kwargs(),
-            )
+            try:
+                return self._core_v1.connect_get_node_proxy_with_path(
+                    name=node_name,
+                    path="metrics/resource",
+                    **self._request_timeout_kwargs(),
+                )
+            except ApiException as error:
+                raise KubectlError(
+                    f"get nodes/{node_name}/proxy/metrics/resource failed ({error.status}): {error.reason}"
+                ) from error
 
     # -- port_forward (subprocess-based) -------------------------------------
 

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -40,9 +40,6 @@ from iris.cluster.platforms.k8s.types import (
     KubectlError,
     KubectlLogLine,
     KubectlLogResult,
-    PodResourceUsage,
-    parse_k8s_cpu,
-    parse_k8s_quantity,
     parse_k8s_timestamp,
 )
 from iris.cluster.platforms.types import find_free_port
@@ -160,7 +157,7 @@ class K8sService(Protocol):
         field_selector: str | None = None,
     ) -> list[dict]: ...
 
-    def top_pods(self, *, labels: dict[str, str] | None = None) -> dict[str, PodResourceUsage]: ...
+    def node_resource_metrics(self, node_name: str) -> str: ...
 
     def read_file(
         self,
@@ -772,50 +769,17 @@ class CloudK8sService:
         """Remove files inside a Pod container. Ignores missing files."""
         self.exec(pod_name, ["rm", "-f", *paths], container=container, timeout=10)
 
-    # -- top_pods ------------------------------------------------------------
+    # -- node metrics ---------------------------------------------------------
 
-    def top_pods(self, *, labels: dict[str, str] | None = None) -> dict[str, PodResourceUsage]:
-        """Return CPU/memory usage for every pod, keyed by pod name.
-
-        Lists ``PodMetrics`` for the namespace (optionally scoped by ``labels``)
-        via the metrics.k8s.io list endpoint. A 404 means the metrics API is
-        unavailable (metrics-server absent); returns an empty map rather than
-        raising so callers degrade quietly.
-        """
-        logger.info("k8s: top_pods labels=%s", labels)
-        kwargs = self._request_timeout_kwargs()
-        if labels:
-            kwargs["label_selector"] = _label_selector(labels)
-        with slow_log(logger, "top_pods", threshold_ms=_SLOW_THRESHOLD_MS):
-            try:
-                result = self._custom.list_namespaced_custom_object(
-                    group="metrics.k8s.io",
-                    version="v1beta1",
-                    namespace=self.namespace,
-                    plural="pods",
-                    **kwargs,
-                )
-            except ApiException as e:
-                if e.status == 404:
-                    return {}
-                raise
-
-        usage_by_pod: dict[str, PodResourceUsage] = {}
-        for item in result.get("items", []):
-            name = item.get("metadata", {}).get("name", "")
-            containers = item.get("containers", [])
-            if not name or not containers:
-                continue
-            total_cpu = 0
-            total_mem = 0
-            for c in containers:
-                usage = c.get("usage", {})
-                if "cpu" in usage:
-                    total_cpu += parse_k8s_cpu(usage["cpu"])
-                if "memory" in usage:
-                    total_mem += parse_k8s_quantity(usage["memory"])
-            usage_by_pod[name] = PodResourceUsage(cpu_millicores=total_cpu, memory_bytes=total_mem)
-        return usage_by_pod
+    def node_resource_metrics(self, node_name: str) -> str:
+        """Return kubelet ``metrics/resource`` text for one node."""
+        logger.debug("k8s: node resource metrics node=%s", node_name)
+        with slow_log(logger, "node_resource_metrics", threshold_ms=_SLOW_THRESHOLD_MS):
+            return self._core_v1.connect_get_node_proxy_with_path(
+                name=node_name,
+                path="metrics/resource",
+                **self._request_timeout_kwargs(),
+            )
 
     # -- port_forward (subprocess-based) -------------------------------------
 

--- a/lib/iris/src/iris/cluster/platforms/k8s/types.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/types.py
@@ -21,6 +21,16 @@ IRIS_PRIORITY_CLASS_PRODUCTION = "iris-production"
 IRIS_PRIORITY_CLASS_INTERACTIVE = "iris-interactive"
 IRIS_PRIORITY_CLASS_BATCH = "iris-batch"
 
+# Stable pod metadata shared by the Kubernetes backend and node agent. Labels
+# support API selection; the annotation retains the full task id because label
+# values are limited to 63 characters.
+IRIS_MANAGED_LABEL = "iris.managed"
+IRIS_RUNTIME_LABEL = "iris.runtime"
+IRIS_KUBERNETES_RUNTIME = "iris-kubernetes"
+IRIS_TASK_ID_ANNOTATION = "iris.task_id"
+IRIS_ATTEMPT_ID_LABEL = "iris.attempt_id"
+IRIS_TASK_CONTAINER_NAME = "task"
+
 # Canonical (name, value, preemptionPolicy) for every PriorityClass Iris owns.
 # Single source of truth: the controller applies all of them at startup and the
 # Kueue installer reuses the iris-system entry so the manager is pinned to the
@@ -178,14 +188,6 @@ class ExecResult:
     returncode: int
     stdout: str
     stderr: str
-
-
-@dataclass(frozen=True)
-class PodResourceUsage:
-    """CPU and memory usage for a single pod."""
-
-    cpu_millicores: int
-    memory_bytes: int
 
 
 def parse_k8s_quantity(val: str) -> int:

--- a/lib/iris/src/iris/cluster/stats/tables.py
+++ b/lib/iris/src/iris/cluster/stats/tables.py
@@ -11,9 +11,9 @@ live next to their mechanism (the worker daemon, the k8s backend's task collecto
 the autoscaler, the controller's task-state emitter) and import their row types
 from here; ``LogStack`` resolves every table from this catalog.
 
-- ``iris.worker`` / ``iris.task`` — worker-emitted host and per-attempt resource
-  rows. Kubernetes task rows come from metrics-server; physical-node hardware
-  readings use the normalized telemetry stream.
+- ``iris.worker`` / ``iris.task`` — host and per-attempt resource rows. Worker
+  daemons emit both on VM/TPU backends; Kubernetes node agents derive task rows
+  from kubelet resource metrics and publish hardware through normalized telemetry.
 - ``iris.task_status`` — markdown status text pushed from inside a running task
   via ``RemoteClusterClient.report_task_status_text``.
 - ``iris.task_event`` — backend events and controller actions per task attempt.

--- a/lib/iris/src/iris/testing/controller.py
+++ b/lib/iris/src/iris/testing/controller.py
@@ -208,6 +208,9 @@ class FakeProvider:
     def configure_routing(self, advertised: dict[str, set[str]]) -> None:
         self.advertised = advertised
 
+    def runtime_image(self, requested_image: str) -> str:
+        return requested_image
+
     def schedule(self, request: ScheduleRequest) -> ScheduleResult:
         return run_worker_daemon_schedule(self._scheduler, self._store, request)
 
@@ -300,6 +303,7 @@ class MockController:
         # A bare Mock would auto-create a truthy .autoscaler; the per-backend
         # feasibility/pending-hint paths read it, so pin it to "no autoscaler".
         self.provider.autoscaler = None
+        self.provider.runtime_image.return_value = ""
         # The backend owns its liveness tracker; the service registers workers into
         # it and the controller's union reads back through it. Tests that inspect a
         # specific ``state._health`` point this at that tracker.

--- a/lib/iris/src/iris/testing/journeys/backend.py
+++ b/lib/iris/src/iris/testing/journeys/backend.py
@@ -103,6 +103,9 @@ class ScriptedTaskBackend:
     def resource_capacity(self) -> dict[str, DeviceCapacity] | None:
         return None
 
+    def runtime_image(self, requested_image: str) -> str:
+        return requested_image
+
     def status(self) -> controller_pb2.Controller.BackendStatus:
         return controller_pb2.Controller.BackendStatus()
 

--- a/lib/iris/tests/cluster/backends/k8s/conftest.py
+++ b/lib/iris/tests/cluster/backends/k8s/conftest.py
@@ -6,7 +6,6 @@
 import pytest
 from iris.cluster.backends.k8s.tasks import K8sTaskProvider
 from iris.cluster.platforms.k8s.fake import InMemoryK8sService
-from iris.test_util import FakeStatsTable
 from iris.testing.k8s import make_kueue_provider, pod_config
 
 
@@ -16,17 +15,10 @@ def k8s():
 
 
 @pytest.fixture
-def task_stats_table():
-    return FakeStatsTable()
-
-
-@pytest.fixture
-def provider(k8s, task_stats_table):
+def provider(k8s):
     result = K8sTaskProvider(
         kubectl=k8s,
         pods=pod_config(),
-        task_stats_table=task_stats_table,
-        resource_poll_interval=0.05,
         cluster_scan_interval=0.0,
     )
     yield result

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -258,6 +258,13 @@ def test_pod_name_preserves_attempt_suffix_with_long_task_id():
     assert name_999.endswith("-999")
 
 
+def test_pod_annotation_preserves_full_task_id_for_node_metrics():
+    task_id = "/power/" + "long-coordinator-name-" * 8 + "/workers/0"
+    manifest = _build_pod_manifest(make_run_req(task_id), pod_config())
+
+    assert manifest["metadata"]["annotations"][LABEL_TASK_ID] == task_id
+
+
 def test_pod_name_different_tasks_never_collide():
     task_a = JobName.from_wire("/a" * 40 + "-suffix-1")
     task_b = JobName.from_wire("/a" * 40 + "-suffix-2")

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -24,7 +24,6 @@ from iris.cluster.backends.k8s.tasks import (
     _RUNTIME_LABEL_VALUE,
     K8sTaskProvider,
     PeriodicProfiler,
-    ResourceCollector,
     _lookup_pod,
     _pod_name,
     _ProfileTarget,
@@ -34,8 +33,8 @@ from iris.cluster.backends.k8s.tasks import (
 from iris.cluster.controller.backend import ProviderError, TaskTarget
 from iris.cluster.controller.task_state import RunningTaskEntry
 from iris.cluster.platforms.k8s.coreweave_topology import RACK_SIZE
-from iris.cluster.platforms.k8s.types import ExecResult, K8sResource, KubectlError, PodResourceUsage
-from iris.cluster.stats.tables import IrisTaskStat, ProfileTrigger
+from iris.cluster.platforms.k8s.types import ExecResult, K8sResource, KubectlError
+from iris.cluster.stats.tables import ProfileTrigger
 from iris.cluster.types import JobName
 from iris.rpc import job_pb2
 from iris.test_util import FakeStatsTable, wait_for_condition
@@ -86,6 +85,11 @@ def test_sync_apply_error_yields_worker_failed(provider, k8s):
 
     assert len(result) == 1
     assert result[0].new_state == job_pb2.TASK_STATE_WORKER_FAILED
+
+
+def test_runtime_image_resolves_requested_or_backend_default(provider):
+    assert provider.runtime_image("registry.example/task:v2") == "registry.example/task:v2"
+    assert provider.runtime_image("") == provider.pods.default_image
 
 
 def test_sync_invalid_manifest_fails_task_terminally(provider, k8s):
@@ -330,7 +334,7 @@ class _CountingK8sService:
             yield item
 
 
-def test_poll_stops_scanning_terminal_pods_once_attempts_resolve(k8s, task_stats_table):
+def test_poll_stops_scanning_terminal_pods_once_attempts_resolve(k8s):
     """Resolving a finished pod must not read the whole terminal backlog.
 
     This scan is on the control loop, and the terminal collection holds up to a full
@@ -341,7 +345,6 @@ def test_poll_stops_scanning_terminal_pods_once_attempts_resolve(k8s, task_stats
     provider = K8sTaskProvider(
         kubectl=counting,
         pods=pod_config(),
-        task_stats_table=task_stats_table,
         cluster_scan_interval=0.0,
     )
     task_id = JobName.from_wire("/job/0")
@@ -484,7 +487,6 @@ def test_pod_not_found_grace_resets_when_pod_reappears(provider, k8s):
 
     # Pod reappears — counter should reset.
     populate_pod(k8s, pod_name, "Running")
-    k8s.set_top_pod(pod_name, None)
     result = provider.sync(batch)
     assert result[0].new_state == job_pb2.TASK_STATE_RUNNING
 
@@ -643,50 +645,6 @@ def test_sync_survives_node_list_failure(provider, k8s):
     # Pod statuses are still populated from the successful pod list.
     resp = provider.get_cluster_status()
     assert any(ps.pod_name == "iris-running" for ps in resp.pod_statuses)
-
-
-# ---------------------------------------------------------------------------
-# Resource stats from kubectl top
-# ---------------------------------------------------------------------------
-
-
-def test_resource_stats_only_for_running_tasks(provider, k8s, task_stats_table):
-    """reconcile registers running pods (not terminal ones) so the background
-    collector emits IrisTaskStat rows only for running tasks."""
-    running = RunningTaskEntry(task_id=JobName.from_wire("/job/run"), attempt_id=0)
-    terminal = RunningTaskEntry(task_id=JobName.from_wire("/job/done"), attempt_id=0)
-    running_pod = _pod_name(running.task_id, running.attempt_id)
-    terminal_pod = _pod_name(terminal.task_id, terminal.attempt_id)
-
-    populate_pod(k8s, running_pod, "Running")
-    populate_pod(k8s, terminal_pod, "Succeeded")
-    k8s.set_top_pod(running_pod, PodResourceUsage(cpu_millicores=500, memory_bytes=1024 * 1024 * 1024))
-    k8s.set_top_pod(terminal_pod, PodResourceUsage(cpu_millicores=999, memory_bytes=1024))
-
-    provider.sync(make_batch(running_tasks=[running, terminal]))
-    # The collector samples all tracked pods in one pass, so once the running
-    # pod's row lands a full cycle has run — the terminal pod's absence is real.
-    wait_for_condition(lambda: bool(task_stats_table.writes), timeout=Duration.from_seconds(5.0))
-
-    rows = [row for batch_rows in list(task_stats_table.writes) for row in batch_rows]
-    assert all(isinstance(r, IrisTaskStat) for r in rows)
-    assert {r.worker_id for r in rows} == {running_pod}, "only the running pod should be sampled"
-    row = next(r for r in rows if r.worker_id == running_pod)
-    assert row.task_id == running.task_id.to_wire()
-    assert row.cpu_millicores == 500
-    assert row.memory_mb == 1024
-
-
-def test_resource_collector_skips_pod_without_metrics_sample(k8s, task_stats_table):
-    """A tracked pod with no metrics sample produces no row."""
-    k8s.set_top_pod("pod-a", None)
-
-    collector = ResourceCollector(k8s, task_stats_table, poll_interval=60.0)
-    collector.close()  # stop the background loop; drive one collection synchronously
-    collector.set_pods({("/job/0", 0): "pod-a"})
-    collector.collect_once()
-
-    assert task_stats_table.writes == []
 
 
 # ---------------------------------------------------------------------------
@@ -925,7 +883,7 @@ def test_profile_kubectl_exec_failure_returns_error(provider, k8s):
 
 def _stopped_profiler(k8s, profile_table) -> PeriodicProfiler:
     """A PeriodicProfiler with its background loop stopped, so tests can drive
-    collect_once() synchronously (the ResourceCollector unit-test pattern)."""
+    collect_once() synchronously."""
     profiler = PeriodicProfiler(k8s, profile_table, poll_interval=60.0)
     profiler.close()
     return profiler
@@ -1336,51 +1294,6 @@ def test_gc_defers_configmap_cleanup_for_age_swept_pods(provider, k8s):
 
     provider.collect_garbage()
     assert k8s.get_json(K8sResource.CONFIGMAPS, "swept-pod-wf") is None
-
-
-# ---------------------------------------------------------------------------
-# Collector set_pods
-# ---------------------------------------------------------------------------
-
-
-def test_resource_collector_set_pods_replaces_active_set(k8s, task_stats_table):
-    """set_pods() replaces the tracked pod set wholesale: a pod dropped from the
-    set stops being sampled on the next collection."""
-    k8s.set_top_pod("pod-a", PodResourceUsage(cpu_millicores=100, memory_bytes=128 * 1024 * 1024))
-    k8s.set_top_pod("pod-b", PodResourceUsage(cpu_millicores=100, memory_bytes=128 * 1024 * 1024))
-
-    collector = ResourceCollector(k8s, task_stats_table, poll_interval=60.0)
-    collector.close()  # stop the background loop; drive collections synchronously
-
-    collector.set_pods({("/job/0", 0): "pod-a", ("/job/1", 0): "pod-b"})
-    collector.collect_once()
-    assert {r.worker_id for r in task_stats_table.writes[-1]} == {"pod-a", "pod-b"}
-
-    collector.set_pods({("/job/1", 0): "pod-b"})
-    collector.collect_once()
-    assert {r.worker_id for r in task_stats_table.writes[-1]} == {"pod-b"}
-
-
-def test_resource_collector_writes_iris_task_rows(k8s, task_stats_table):
-    """A successful bulk metrics read appends one IrisTaskStat row to the Table."""
-
-    k8s.set_top_pod("pod-a", PodResourceUsage(cpu_millicores=750, memory_bytes=2 * 1024 * 1024 * 1024))
-
-    collector = ResourceCollector(k8s, task_stats_table, poll_interval=60.0)
-    # Stop the background loop so we drive a single collection deterministically.
-    collector.close()
-    collector.set_pods({("/job/0", 3): "pod-a"})
-    collector.collect_once()
-
-    rows = [row for batch_rows in task_stats_table.writes for row in batch_rows]
-    assert rows, "no rows emitted"
-    row = rows[-1]
-    assert isinstance(row, IrisTaskStat)
-    assert row.task_id == "/job/0"
-    assert row.attempt_id == 3
-    assert row.worker_id == "pod-a"
-    assert row.cpu_millicores == 750
-    assert row.memory_mb == 2048
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -262,6 +262,7 @@ def _make_controller_mock(state, scheduler, autoscaler=None):
     _authoring_backend = _worker_backend(state, autoscaler)
     controller_mock.provider.autoscaler_status.side_effect = _authoring_backend.autoscaler_status
     controller_mock.provider.status.side_effect = _authoring_backend.status
+    controller_mock.provider.runtime_image.side_effect = _authoring_backend.runtime_image
     controller_mock.capabilities = worker_caps
     controller_mock.backends = {DEFAULT_BACKEND_ID: controller_mock.provider}
     controller_mock.backend_id_for_scale_group = Mock(return_value=DEFAULT_BACKEND_ID)
@@ -1210,6 +1211,15 @@ def test_get_task_status_attempts_carry_attempt_uid(client, state, job_request):
     assert len(attempts) == 2
     proto_uids = {a["attemptId"]: a.get("attemptUid") for a in attempts}
     assert proto_uids == db_uids
+
+
+def test_get_task_status_includes_runtime_image(client, state, job_request):
+    job_request.task_image = "registry.example/task:v2"
+    job_id = submit_job(state, "runtime-image", job_request)
+
+    response = rpc_post(client, "GetTaskStatus", {"taskId": job_id.task(0).to_wire()})
+
+    assert response["task"]["buildMetrics"]["imageTag"] == "registry.example/task:v2"
 
 
 def test_get_worker_status_by_worker_id(client, state):

--- a/lib/iris/tests/cluster/node_agent/test_kubernetes.py
+++ b/lib/iris/tests/cluster/node_agent/test_kubernetes.py
@@ -12,12 +12,16 @@ network, and DCGM's ``hostname``/``gpu``/``modelName`` labels).
 import pytest
 from iris.cluster.node_agent.kubernetes import (
     NodeStatsScraper,
+    TaskStatsCollector,
     parse_dcgm,
+    parse_kubelet_resource_metrics,
     parse_node_exporter,
     parse_prometheus,
 )
 from iris.cluster.node_agent.metrics import NodeMetrics, NodeTarget
 from iris.cluster.platforms.k8s.fake import InMemoryK8sService
+from iris.cluster.platforms.k8s.types import K8sResource
+from iris.test_util import FakeStatsTable
 
 NODE_EXPORTER_TEXT = """
 # HELP node_memory_MemTotal_bytes Memory information field MemTotal_bytes.
@@ -85,6 +89,64 @@ def test_parse_prometheus_handles_labels_values_and_comments():
 
 def test_parse_prometheus_skips_non_finite():
     assert list(parse_prometheus("g 1\nh NaN\ni +Inf\n")) == [("g", {}, 1.0)]
+
+
+def test_parse_kubelet_resource_metrics_selects_container_resources():
+    resources = parse_kubelet_resource_metrics(
+        'container_cpu_usage_seconds_total{container="task",pod="pod-a"} 12.5 123\n'
+        'container_memory_working_set_bytes{container="task",pod="pod-a"} 1073741824 123\n'
+    )
+
+    assert resources[("pod-a", "task")].cpu_seconds == 12.5
+    assert resources[("pod-a", "task")].memory_bytes == 1024**3
+
+
+def test_task_stats_collector_writes_cpu_memory_and_peak():
+    k8s = InMemoryK8sService(namespace="iris")
+    k8s.seed_resource(
+        K8sResource.PODS,
+        "pod-a",
+        {
+            "metadata": {
+                "name": "pod-a",
+                "labels": {
+                    "iris.managed": "true",
+                    "iris.runtime": "iris-kubernetes",
+                    "iris.attempt_id": "3",
+                },
+                "annotations": {"iris.task_id": "/long/job/path/workers/0"},
+            },
+            "spec": {"nodeName": "node-a"},
+            "status": {"phase": "Running"},
+        },
+    )
+    table = FakeStatsTable()
+    sampled_at = iter((100.0, 110.0))
+    collector = TaskStatsCollector(k8s, "node-a", table, clock=lambda: next(sampled_at))
+    k8s.set_node_resource_metrics(
+        "node-a",
+        'container_cpu_usage_seconds_total{container="task",pod="pod-a"} 10\n'
+        'container_memory_working_set_bytes{container="task",pod="pod-a"} 1073741824\n',
+    )
+
+    collector.collect_once()
+    first = table.writes[-1][0]
+    assert first.task_id == "/long/job/path/workers/0"
+    assert first.attempt_id == 3
+    assert first.cpu_millicores == 0
+    assert first.memory_mb == 1024
+    assert first.memory_peak_mb == 1024
+
+    k8s.set_node_resource_metrics(
+        "node-a",
+        'container_cpu_usage_seconds_total{container="task",pod="pod-a"} 12\n'
+        'container_memory_working_set_bytes{container="task",pod="pod-a"} 536870912\n',
+    )
+    collector.collect_once()
+    second = table.writes[-1][0]
+    assert second.cpu_millicores == 200
+    assert second.memory_mb == 512
+    assert second.memory_peak_mb == 1024
 
 
 def test_parse_node_exporter_extracts_host_readings():


### PR DESCRIPTION
Collect Kubernetes task CPU and memory in the existing node agents from same-node kubelet resource metrics. cw-rno2a has no Metrics API; the controller collector converted that API's 404 into an empty map, so Finelog received no `iris.task` rows and the dashboard resource card remained empty.

Remove the Metrics API dependency and controller collector, grant the node agents access to `nodes/proxy`, and preserve the full task ID in pod annotations. CPU is derived from cumulative counter deltas, so the first sample after an agent restart is zero. Kubelet resource metrics have no container filesystem gauge, so Kubernetes task rows continue to report zero disk usage.

Report the selected prebuilt Kubernetes task image as runtime provenance. Kubernetes tasks do not run an Iris image build, so the dashboard omits build timing and cache fields.

Incident record: https://echo.oa.dev/wiki/139
