### PR TITLE
[loom] Own session instructions in deployment profiles

### DIFF
--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -16,7 +16,37 @@ config:
   marin-loom:dotenvSecretVersion: "4"
   marin-loom:pruneDeployment: "true"
   marin-loom:snapshotRetentionDays: "14"
+  marin-loom:settings:
+    github.profile: github
+    slack.effort: agent-default
+    slack.profile: slack
   marin-loom:profiles:
+    default:
+      agent: codex
+      description: Interactive Marin work with repository-owned workflow instructions
+      model: gpt-5.6-sol
+      effort: xhigh
+      protocol: acp
+      mode: auto
+      class: interactive
+      prelude: weaver
+      instructionsFile: profiles/user/AGENTS.md
+      mcpAccess:
+        mode: all
+        groups: []
+    github:
+      agent: codex
+      description: GitHub-triggered Marin issue and pull-request sessions
+      model: gpt-5.6-sol
+      effort: xhigh
+      protocol: acp
+      mode: auto
+      class: interactive
+      prelude: weaver
+      instructionsFile: profiles/github/AGENTS.md
+      mcpAccess:
+        mode: all
+        groups: []
     ops:
       agent: codex
       description: Coordinate Grafana alerts and delegate incident triage for Marin
@@ -32,8 +62,22 @@ config:
       maxConcurrent: 1
       turnBudget: 100
       prelude: weaver
+      instructionsFile: profiles/ops/AGENTS.md
       restricted: false
       allowedTools: []
+      mcpAccess:
+        mode: all
+        groups: []
+    slack:
+      agent: codex
+      description: Slack-triggered Marin conversations and repository work
+      model: gpt-5.6-sol
+      effort: high
+      protocol: acp
+      mode: auto
+      class: interactive
+      prelude: weaver
+      instructionsFile: profiles/slack/AGENTS.md
       mcpAccess:
         mode: all
         groups: []

--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -86,13 +86,25 @@ identity of the existing `marin-grafana` Cloud Run service account to select
 only the `ops` profile. Pulumi resolves that account's email and immutable
 numeric subject; it does not create or copy a Loom token.
 
+Organization prompt policy lives beside the runtime profiles in
+`profiles/<name>/AGENTS.md`. A profile's `instructionsFile` is resolved below
+`infra/loom`, read by Pulumi, and reconciled into Loom's visible profile
+`instructions` field. Loom therefore does not need access to this checkout at
+runtime, and the effective text remains inspectable in Settings. The production
+`slack.profile` and `github.profile` settings select their dedicated profiles;
+ordinary sessions use the deployment-managed `default` profile, while workload
+and future GitHub Actions callers select the automation profile authorized by
+their federation mapping.
+
 The Pulumi declaration is authoritative at activation time. An unchanged
 profile keeps its database revision; a changed declaration overwrites the
 current row and advances the revision. UI or API edits persist only until the
-next activation. Deployment pruning is enabled, so a profile or federation
-removed from `Pulumi.marin-loom.yaml` is removed from new selection on the next
-activation. Weaver's stock `default`, `github_comment`, and `watch` profiles are
-not deployment-managed and are not pruned.
+next activation. Deployment pruning is enabled, so a deployment-managed
+setting, profile, or federation removed from `Pulumi.marin-loom.yaml` is removed
+from its deployment layer on the next activation. Stock profiles omitted from
+the declaration remain unmanaged and are not pruned; production intentionally
+manages `default` so interactive instruction and runtime policy are reviewed in
+this repository.
 
 At runtime, the Grafana bridge gets a Google-signed ID token from the Cloud Run
 metadata server, exchanges it at `/api/auth/federate`, and uses the resulting

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -161,6 +161,25 @@ def _optional_int(value: object, field: str, profile: str) -> int | None:
     return value
 
 
+def _profile_instructions(value: Mapping[str, object], profile: str) -> str:
+    inline = value.get("instructions")
+    source = value.get("instructionsFile")
+    if inline is not None and source is not None:
+        raise ValueError(f"profile {profile!r} must use only one of instructions or instructionsFile")
+    if source is None:
+        if inline is None:
+            return ""
+        if not isinstance(inline, str):
+            raise ValueError(f"profile {profile!r} instructions must be a string")
+        return inline.strip()
+    if not isinstance(source, str) or not source.strip():
+        raise ValueError(f"profile {profile!r} instructionsFile must be a relative path")
+    path = (ROOT / source).resolve()
+    if not path.is_relative_to(ROOT) or not path.is_file():
+        raise ValueError(f"profile {profile!r} instructionsFile must name a file under {ROOT}")
+    return path.read_text().strip()
+
+
 def _validated_string_tuple(value: object, field: str, pattern: re.Pattern[str]) -> tuple[str, ...]:
     if not isinstance(value, list) or not all(isinstance(item, str) and pattern.fullmatch(item) for item in value):
         raise ValueError(f"{field} must be a list of canonical resource names")
@@ -209,6 +228,7 @@ class ProfileConfig:
     max_concurrent: int
     turn_budget: int | None
     prelude: str
+    instructions: str
     restricted: bool
     allowed_tools: tuple[str, ...]
     mcp_access: McpAccessConfig
@@ -241,6 +261,7 @@ class ProfileConfig:
             max_concurrent=int(value.get("maxConcurrent", 0)),
             turn_budget=_optional_int(value.get("turnBudget"), "turnBudget", name),
             prelude=str(value.get("prelude", "weaver")),
+            instructions=_profile_instructions(value, name),
             restricted=bool(value.get("restricted", False)),
             allowed_tools=_string_tuple(value.get("allowedTools", []), "allowedTools", name),
             mcp_access=McpAccessConfig.parse(value.get("mcpAccess", {}), name),
@@ -264,6 +285,7 @@ class ProfileConfig:
             "max_concurrent": self.max_concurrent,
             "turn_budget": self.turn_budget,
             "prelude": self.prelude,
+            "instructions": self.instructions,
             "restricted": self.restricted,
             "allowed_tools": list(self.allowed_tools),
             "mcp_access": self.mcp_access.manifest(),
@@ -364,6 +386,7 @@ class DeploymentConfig:
     dotenv_secret_version: int
     snapshot_retention_days: int
     prune_deployment: bool = False
+    settings: tuple[tuple[str, str | int | bool], ...] = ()
     profiles: tuple[ProfileConfig, ...] = ()
     workloads: tuple[WorkloadIdentityConfig, ...] = ()
     github_federations: tuple[GitHubFederationConfig, ...] = ()
@@ -390,7 +413,7 @@ class DeploymentConfig:
             _validate_profile_reference(
                 "GitHub federation", federation.name, federation.profile, federation_names, profile_names
             )
-        if self.prune_deployment and not (self.profiles or self.workloads or self.github_federations):
+        if self.prune_deployment and not (self.settings or self.profiles or self.workloads or self.github_federations):
             raise ValueError("pruneDeployment requires a non-empty runtime policy")
 
     @property
@@ -413,6 +436,14 @@ class DeploymentConfig:
         raw_profiles = config.get_object("profiles") or {}
         if not isinstance(raw_profiles, dict):
             raise ValueError("profiles must be an object")
+        raw_settings = config.get_object("settings") or {}
+        if not isinstance(raw_settings, dict):
+            raise ValueError("settings must be an object")
+        settings: list[tuple[str, str | int | bool]] = []
+        for key, value in sorted(raw_settings.items()):
+            if not isinstance(key, str) or not key.strip() or not isinstance(value, (str, int, bool)):
+                raise ValueError("settings must map non-empty string keys to string, integer, or boolean values")
+            settings.append((key, value))
         raw_workloads = config.get_object("workloads") or []
         if not isinstance(raw_workloads, list):
             raise ValueError("workloads must be a list")
@@ -453,6 +484,7 @@ class DeploymentConfig:
             boot_disk_gb=config.require_int("bootDiskGb"),
             dotenv_secret_version=config.require_int("dotenvSecretVersion"),
             prune_deployment=config.get_bool("pruneDeployment") or False,
+            settings=tuple(settings),
             profiles=tuple(profiles),
             workloads=tuple(workloads),
             github_federations=tuple(github_federations),
@@ -726,6 +758,7 @@ def _create_runtime_policy(
     def render(workload_values: list[dict[str, Any]]) -> str:
         return json.dumps(
             {
+                "settings": dict(config.settings),
                 "profiles": profiles,
                 "federations": github_mappings + workload_values,
                 "prune": config.prune_deployment,

--- a/infra/loom/profiles/github/AGENTS.md
+++ b/infra/loom/profiles/github/AGENTS.md
@@ -1,0 +1,13 @@
+# Marin GitHub sessions
+
+Read the full issue or pull-request thread before acting, then follow the target
+repository's `AGENTS.md` and applicable skills.
+
+- Answer a simple question on the originating thread without creating a
+  repository change. Carry an explicit implementation or fix request through
+  the repository's pull-request workflow.
+- On a pull request, update its existing branch. For issue work, open a pull
+  request that links the issue according to the repository's conventions.
+- Prefix agent-authored GitHub comments with `🤖` and add the
+  `agent-generated` label to every pull request or issue you create.
+- Make the final thread comment self-contained and include links to the result.

--- a/infra/loom/profiles/ops/AGENTS.md
+++ b/infra/loom/profiles/ops/AGENTS.md
@@ -1,0 +1,13 @@
+# Marin operations sessions
+
+Operate as Marin's durable alert coordinator. Follow repository operational
+guides and applicable skills before changing live infrastructure.
+
+- Triage each alert with concrete evidence. Delegate independent investigation
+  when useful, and keep one durable session responsible for the incident arc.
+- Reply in the alert's routed Slack thread when an operator needs a conclusion,
+  question, or action item.
+- Publish durable incident investigations through the `write-ops-log` workflow
+  and link the canonical record from any associated issue or pull request.
+- Do not restart or otherwise disrupt live infrastructure without the explicit
+  authorization required by the owning repository's operational guide.

--- a/infra/loom/profiles/slack/AGENTS.md
+++ b/infra/loom/profiles/slack/AGENTS.md
@@ -1,0 +1,13 @@
+# Marin Slack sessions
+
+Treat the Slack request and surrounding thread as the source conversation.
+Follow the target repository's `AGENTS.md` and applicable skills.
+
+- Answer a simple question directly in Slack without creating a repository
+  change. Carry an explicit implementation or fix request through the
+  repository's pull-request workflow.
+- Keep the final Slack reply concise and self-contained. Include links to any
+  pull request, issue, or durable artifact created for the request.
+- Add the `agent-generated` label to every pull request or issue you create.
+- Use the repository's commit/landing skill for changes and remain with CI for
+  as long as that workflow requires.

--- a/infra/loom/profiles/user/AGENTS.md
+++ b/infra/loom/profiles/user/AGENTS.md
@@ -1,0 +1,13 @@
+# Marin interactive sessions
+
+Follow the target repository's `AGENTS.md` and applicable skills for the task,
+validation, and landing workflow.
+
+- Answer a simple question in its originating conversation without creating a
+  repository change. Carry an explicit implementation or fix request through
+  the repository's pull-request workflow.
+- Add the `agent-generated` label to every pull request or issue you create.
+- Apply Marin's writing-style rules to GitHub titles and bodies, and use the
+  repository's commit skill when committing, pushing, or opening a pull request.
+- When you create a pull request or issue, include its URL in the final Weaver
+  status and result.

--- a/infra/loom/tests/test_infrastructure.py
+++ b/infra/loom/tests/test_infrastructure.py
@@ -12,6 +12,7 @@ import yaml
 from pulumi.runtime import MockCallArgs, MockResourceArgs, Mocks
 
 from infra.loom.infrastructure import (
+    ROOT,
     DeploymentConfig,
     GitHubFederationConfig,
     ProfileConfig,
@@ -79,6 +80,7 @@ def deployment_config() -> DeploymentConfig:
                     "class": "automation",
                     "strict": True,
                     "envClear": True,
+                    "instructionsFile": "profiles/ops/AGENTS.md",
                     "env": {"KUBECONFIG": {"secretRef": "projects/example/secrets/ops-kubeconfig/versions/latest"}},
                 },
             ),
@@ -173,6 +175,20 @@ def test_profile_manifest_accepts_secret_references_but_rejects_values() -> None
     assert references == [("example", "ops-token")]
     with pytest.raises(ValueError, match="full secretRef"):
         ProfileConfig.parse("ops", {"agent": "codex", "env": {"OPS_TOKEN": "plaintext"}})
+
+
+def test_profile_instructions_reject_ambiguous_or_external_sources() -> None:
+    with pytest.raises(ValueError, match="only one"):
+        ProfileConfig.parse(
+            "slack",
+            {
+                "agent": "codex",
+                "instructions": "inline",
+                "instructionsFile": "profiles/slack/AGENTS.md",
+            },
+        )
+    with pytest.raises(ValueError, match="under"):
+        ProfileConfig.parse("slack", {"agent": "codex", "instructionsFile": "../../AGENTS.md"})
 
 
 @pytest.mark.parametrize(
@@ -295,13 +311,19 @@ def test_release_rollout_pins_metadata_to_the_built_image_digest():
 
 @pulumi.runtime.test
 def test_profiles_and_workloads_render_to_vm_metadata():
-    infrastructure, mocks = infrastructure_and_mocks()
+    mocks = RecordingMocks()
+    pulumi.runtime.set_mocks(mocks, project="marin-loom", stack="test", preview=False)
+    infrastructure = create_infrastructure(replace(deployment_config(), settings=(("slack.profile", "ops"),)))
 
     def check(_: object) -> None:
         assert by_name(mocks, "loom-workload-marin-ops").typ == "gcp:serviceaccount/account:Account"
         manifest = json.loads(by_name(mocks, "loom").inputs["metadata"]["loom-deployment"])
         assert manifest["prune"] is True
+        assert manifest["settings"] == {"slack.profile": "ops"}
         assert manifest["profiles"][0]["profile"]["name"] == "ops"
+        assert manifest["profiles"][0]["profile"]["instructions"] == (
+            (ROOT / "profiles/ops/AGENTS.md").read_text().strip()
+        )
         assert manifest["federations"][0]["subject"] == "11223344556677889900"
 
     return infrastructure.instance.id.apply(check)


### PR DESCRIPTION
Manage production Loom's default, Slack, GitHub, and ops profiles from Pulumi, with their opening instructions sourced from checked-in `AGENTS.md` files. Add deployment-managed `slack.profile` and `github.profile` settings so each trigger gets Marin-specific workflow and response conventions.

This depends on marin-community/loom#286 for profile instructions and trigger profile selection.
