### PR TITLE
[levanter] Pin the b-tiled backward gradient test to HIGHEST precision

### DIFF
--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -948,9 +948,17 @@ def test_batched_xla_full_vocab_b_tiled_forward_matches_reference():
 
 
 def test_batched_xla_backward_b_tiled_from_lse_matches_reference_gradients():
+    """Gradient algebra of the b-tiled backward, against autodiff through the dense reference.
+
+    Both sides are pinned to HIGHEST because they contract in different orders. Under the
+    default precision, TF32 on GPU rounds the two paths apart by ~5e-4 while float32 inputs
+    imply a ~1e-7 answer, which failed this test's 1e-5 tolerance on every TF32 device. That
+    measured matmul rounding rather than the algebra under test; HIGHEST measures the algebra.
+    """
     if jax.default_backend() == "tpu":
         pytest.skip("batched_xla custom backward helper is covered by CPU/GPU precision paths")
 
+    precision = jax.lax.Precision.HIGHEST
     key = jax.random.PRNGKey(43)
     key_x, key_w, key_y, key_loss, key_lse = jax.random.split(key, 5)
     x = jax.random.normal(key_x, (7, 5), dtype=jnp.float32)
@@ -959,7 +967,9 @@ def test_batched_xla_backward_b_tiled_from_lse_matches_reference_gradients():
     g_loss = jax.random.normal(key_loss, (7,), dtype=jnp.float32)
     g_lse = jax.random.normal(key_lse, (7,), dtype=jnp.float32)
 
-    _, lse = linear_softmax_cross_entropy_loss_reference(x, y, w, dtype=jnp.float32, logit_soft_cap=1.7)
+    _, lse = linear_softmax_cross_entropy_loss_reference(
+        x, y, w, dtype=jnp.float32, logit_soft_cap=1.7, precision=precision
+    )
 
     def reference_cotangent_loss(x_raw: jax.Array, w_raw: jax.Array) -> jax.Array:
         loss, logsumexp = linear_softmax_cross_entropy_loss_reference(
@@ -968,6 +978,7 @@ def test_batched_xla_backward_b_tiled_from_lse_matches_reference_gradients():
             w_raw,
             dtype=jnp.float32,
             logit_soft_cap=1.7,
+            precision=precision,
         )
         return jnp.sum(loss * g_loss + logsumexp * g_lse)
 
@@ -981,7 +992,7 @@ def test_batched_xla_backward_b_tiled_from_lse_matches_reference_gradients():
         g_lse,
         b_block_size=4,
         logit_soft_cap=1.7,
-        precision=None,
+        precision=precision,
     )
 
     np.testing.assert_allclose(actual_x, expected_x, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
Pin both sides of `test_batched_xla_backward_b_tiled_from_lse_matches_reference_gradients` to `Precision.HIGHEST`. It compares `_backward_b_tiled_from_lse` against autodiff through the dense reference, and the two contract in different orders, so at the default precision it measured TF32 rounding rather than the gradient algebra it names.

On GB200 the paths diverged by 5.44e-4 on `grad_x` and 5.72e-4 on `grad_w` against the test's 1e-5 tolerance, so it failed on every TF32 device while passing on CPU. Pinning HIGHEST drops the gap to 2.38e-7 and 3.06e-7, float32 epsilon for this problem, which confirms the algebra is correct. The tolerance is unchanged, and the kernel is untouched: `_backward_b_tiled_from_lse` still takes precision from its caller, so training behavior does not change.

CI runs on CPU, where float32 matmuls are already exact, which is why this failure never surfaced there. With this change the fused cross-entropy kernel test file passes on GB200 at 79 passed and 9 skipped; it previously carried this one failure.
