### PR TITLE
[iris] Pack accelerator-free Pods into a configured topology domain

### DIFF
--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -141,6 +141,11 @@ kubernetes_provider:
     # Pulumi owns the cluster-scoped ClusterQueue and cw-tas ResourceFlavor;
     # Iris reconciles the namespaced LocalQueue bound to it at controller start.
     cluster_queue: iris-cq
+    # Gangs hard-bind to one nvlink.domain, so a domain holed by a single CPU Pod can no longer
+    # host one. Pack accelerator-free Pods at that level instead of letting them spread. Safe to
+    # name here only because this cluster binds multinode-nvlink-ib, which has the level; the
+    # H100 clusters bind `infiniband`, which does not, and must leave this unset.
+    cpu_pack_topology: ds.coreweave.com/nvlink.domain
   # CoreWeave's node health checker runs preemptible (priority -1) GPU
   # verification pods on idle nodes. Kueue TAS counts them as fixed node usage
   # and cannot preempt non-Kueue pods, so gangs queue behind every NHC sweep;

--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -154,10 +154,23 @@ that release with an ad hoc cluster-wide install.
 
 All Iris Pods use the topology-aware `cw-tas` ResourceFlavor. Its
 `iris.kueue=true` selector covers every Iris-managed NodePool. Accelerator-free
-Pods request unconstrained TAS, so Kueue records their per-node CPU reservations
-in the same flavor as GPU gangs. `preemption.withinClusterQueue: LowerPriority`
-can then remove a lower-priority CPU Workload from the topology snapshot before
-retrying a blocked GPU gang's fit.
+Pods request TAS, so Kueue records their per-node CPU reservations in the same
+flavor as GPU gangs. `preemption.withinClusterQueue: LowerPriority` can then
+remove a lower-priority CPU Workload from the topology snapshot before retrying
+a blocked GPU gang's fit.
+
+By default that request is unconstrained, which Kueue resolves to the Topology's
+lowest level (hostname): placement is decided per node, so nothing keeps CPU
+Pods off the domains gangs hard-bind to, and a domain holed by one CPU Pod can
+no longer host such a gang
+([#8247](https://github.com/marin-community/marin/issues/8247)). Setting
+`kubernetes_provider.kueue.cpu_pack_topology` to a node label sends a soft
+preference for that level instead, so Kueue scores domains and packs. The label
+**must** be a level of the Topology bound to the flavor — Kueue rejects a
+workload whose topology request names an absent level, which would leave every
+CPU Pod on the cluster unschedulable. Only `cw-us-east-08a` sets it today
+(`ds.coreweave.com/nvlink.domain`, a level of `multinode-nvlink-ib`); the H100
+clusters bind `infiniband`, which has no such level, and leave it unset.
 
 Each Iris band has three Kueue admission tiers. The controller reconciles the
 nine `WorkloadPriorityClass` objects at startup.
@@ -215,8 +228,16 @@ requests exclude CPU nodes without an additional selector.
 Kueue requires every node in a TAS flavor to carry every level in the referenced
 Topology. CoreWeave supplies the physical hierarchy on accelerator nodes. Iris
 labels CPU NodePools with a synthetic `iris-cpu-only` fabric, superpod,
-leafgroup, and NVLink domain so unconstrained TAS can assign them at the hostname
-level. The synthetic values do not advertise GPU or RDMA resources.
+leafgroup, and NVLink domain so TAS can assign them at the hostname level. The
+synthetic values do not advertise GPU or RDMA resources.
+
+Because that synthetic value is shared, every CPU NodePool collapses into a
+single domain at each multinode level. Under `cpu_pack_topology` the whole CPU
+pool is therefore scored as one domain against individual racks, and Kueue's
+best-fit picks the smallest domain that still fits: once the pool's aggregate
+free capacity exceeds a rack's, an idle rack is the smaller domain and wins.
+The preference reliably packs CPU Pods that only accelerator nodes can hold; it
+does not by itself keep small CPU Pods off idle racks.
 
 This layout replaces the selectorless, non-TAS `cw-cpu` flavor that caused
 [#7916](https://github.com/marin-community/marin/issues/7916). Kueue v0.18 could

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -498,6 +498,11 @@ class PodConfig:
     # coscheduling group_by -> KueueTopologyBinding. Defaults to CoreWeave
     # conventions; a group_by with no entry carries no topology annotation.
     kueue_topologies: dict[str, KueueTopologyBinding] = field(default_factory=lambda: dict(_CW_DEFAULT_TOPOLOGIES))
+    # Node label accelerator-free Pods softly prefer, so Kueue packs them instead of holing the
+    # domains gangs need whole. Empty leaves them unconstrained (the default: naming a level the
+    # cluster's bound Topology lacks makes Kueue reject every CPU Pod). Set per cluster via
+    # kubernetes_provider.kueue.cpu_pack_topology.
+    cpu_pack_topology: str = ""
     # PriorityBand -> Kubernetes PriorityClass name. Sets spec.priorityClassName.
     # UNSPECIFIED is treated as INTERACTIVE. Defaults to the iris-{band} classes
     # Iris creates at startup; override via kubernetes_provider.priority_classes.
@@ -945,11 +950,27 @@ def _build_pod_manifest(
         # A non-coscheduled GPU pod has no gang to colocate, so ask only for the
         # finest, always-satisfiable level as a soft preference.
         metadata["annotations"][_KUEUE_PREFERRED_TOPOLOGY] = _KUEUE_SINGLE_POD_TOPOLOGY
-    else:
-        # Accelerator-free Pods remain in TAS without requesting colocation. This
-        # records their per-node CPU usage in the same flavor as GPU gangs, so a
-        # higher-priority gang can simulate reclaiming it before topology fit.
+    elif has_accelerator or not config.cpu_pack_topology:
+        # Accelerator-free Pods (and standalone TPU Pods, which have no NVLink hierarchy to
+        # pack into) remain in TAS without requesting colocation. This records their per-node
+        # CPU usage in the same flavor as GPU gangs, so a higher-priority gang can simulate
+        # reclaiming it before topology fit.
         metadata["annotations"][_KUEUE_UNCONSTRAINED_TOPOLOGY] = "true"
+    else:
+        # Same TAS accounting as above, plus a soft domain preference. Unconstrained resolves to
+        # the topology's lowest level (hostname), so Kueue decides placement per node and never
+        # scores domains -- and a domain holed by one CPU Pod can no longer host a gang that
+        # hard-binds to it. Naming a level makes Kueue score domains and take the one whose
+        # leftover capacity, counted in copies of this Pod, is smallest among those that fit.
+        #
+        # That approximates "already occupied" rather than measuring it, and CPU NodePools share
+        # one synthetic value per multinode level (nodepool_manifests.CPU_TOPOLOGY_NODE_LABELS),
+        # so the whole CPU pool is scored as a single domain against individual racks. It packs
+        # Pods only accelerator nodes can hold; it does not by itself keep small CPU Pods off
+        # idle racks. Preferred, never required: a Pod that does not fit here falls back to
+        # coarser levels instead of pending. The level must exist in the Topology bound to the
+        # flavor, which is why it is configured per cluster rather than inferred.
+        metadata["annotations"][_KUEUE_PREFERRED_TOPOLOGY] = config.cpu_pack_topology
 
     # Native log-shipping sidecar: ships the task container's node-side CRI log
     # file to finelog. As an initContainer with restartPolicy: Always it is

--- a/lib/iris/src/iris/cluster/composer.py
+++ b/lib/iris/src/iris/cluster/composer.py
@@ -133,6 +133,7 @@ def make_task_backend(
                 env_secret_name=env_secret_name,
                 local_queue=local_queue,
                 kueue_topologies=topologies or dict(_CW_DEFAULT_TOPOLOGIES),
+                cpu_pack_topology=kp.kueue.cpu_pack_topology,
                 priority_class_names=pod_priority_classes,
             ),
             preempt_namespaces=list(kp.preempt_namespaces),

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -619,6 +619,11 @@ class KueueTopology(_Config):
 class KueueConfig(_Config):
     cluster_queue: str = ""  # setting this ENABLES Kueue gang admission
     topologies: dict[str, KueueTopology] = Field(default_factory=dict)  # group_by -> topo
+    # Node label accelerator-free Pods softly prefer, so Kueue packs them rather than spreading
+    # them across domains that gangs need whole. Empty leaves them unconstrained. Must name a
+    # level of the Topology bound to this cluster's ResourceFlavor -- Kueue rejects a workload
+    # whose topology request names an absent level, which would strand every CPU Pod here.
+    cpu_pack_topology: str = ""
 
 
 class KubernetesProviderConfig(_Config):

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -13,6 +13,8 @@ from iris.cluster.backends.k8s.tasks import (
     K8sTaskProvider,
     PodConfig,
 )
+from iris.cluster.composer import make_task_backend
+from iris.cluster.config import IrisClusterConfig, KubernetesProviderConfig, KueueConfig
 from iris.cluster.controller.reconcile.snapshot import TaskUpdate
 from iris.cluster.controller.task_state import RunningTaskEntry
 from iris.cluster.platforms.k8s.coreweave_topology import (
@@ -30,6 +32,7 @@ from iris.cluster.runtime.types import MountKind
 from iris.cluster.types import JobName
 from iris.rpc import job_pb2
 from iris.testing.k8s import add_eq_constraint, common_env_from_req, make_batch, make_pod, make_run_req, pod_config
+from rigging.timing import Duration
 
 INFRASTRUCTURE_FAILURE_REASONS = ("DeadlineExceeded", "Evicted", "Preempting")
 KUEUE_POD_GROUP_NAME = "kueue.x-k8s.io/pod-group-name"
@@ -1614,16 +1617,21 @@ def test_cpu_job_is_unconstrained_when_no_pack_level_is_configured():
     assert "nodeSelector" not in manifest["spec"]
 
 
-def test_cpu_job_prefers_the_configured_pack_level():
-    """A configured level becomes a soft preference, so Kueue scores domains instead of placing
-    per-node and packs CPU work rather than holing the domains gangs hard-bind to."""
-    manifest = _build_pod_manifest(
-        make_run_req("/cpu-job/task/0", num_tasks=1),
-        pod_config(local_queue="iris-lq", cpu_pack_topology=CW_LABEL_NVLINK_DOMAIN),
+def test_configured_cpu_pack_level_reaches_the_pod_as_a_soft_preference():
+    """A level set on the cluster config has to survive composition to change anything, so this
+    runs from IrisClusterConfig through to the annotations Kueue admits the Pod on. Soft, never
+    required: a CPU Pod that fits no domain at this level falls back to coarser ones."""
+    backend = make_task_backend(
+        IrisClusterConfig(
+            kubernetes_provider=KubernetesProviderConfig(
+                kueue=KueueConfig(cluster_queue="iris-cq", cpu_pack_topology=CW_LABEL_NVLINK_DOMAIN)
+            )
+        ),
+        unreachable_grace=Duration.from_seconds(1),
     )
+    manifest = _build_pod_manifest(make_run_req("/cpu-job/task/0", num_tasks=1), backend.pods)
     annotations = manifest["metadata"]["annotations"]
     assert annotations[_KUEUE_PREFERRED_TOPOLOGY] == CW_LABEL_NVLINK_DOMAIN
-    # Preferred, never required: a CPU Pod falls back to coarser levels instead of pending.
     assert _KUEUE_REQUIRED_TOPOLOGY not in annotations
     assert _KUEUE_UNCONSTRAINED_TOPOLOGY not in annotations
 

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -16,6 +16,7 @@ from iris.cluster.backends.k8s.tasks import (
 from iris.cluster.controller.reconcile.snapshot import TaskUpdate
 from iris.cluster.controller.task_state import RunningTaskEntry
 from iris.cluster.platforms.k8s.coreweave_topology import (
+    CW_LABEL_NVLINK_DOMAIN,
     NVL72_GPUS_PER_NODE,
     RACK_SIZE,
     SCHEDULABLE_RACK_NODES,
@@ -40,6 +41,7 @@ KUEUE_QUEUE_NAME = "kueue.x-k8s.io/queue-name"
 KUEUE_REQUIRED_TOPOLOGY = "kueue.x-k8s.io/podset-required-topology"
 KUEUE_SLICE_REQUIRED_TOPOLOGY = "kueue.x-k8s.io/podset-slice-required-topology"
 KUEUE_SLICE_SIZE = "kueue.x-k8s.io/podset-slice-size"
+KUEUE_UNCONSTRAINED_TOPOLOGY = "kueue.x-k8s.io/podset-unconstrained-topology"
 LABEL_JOB_ID = "iris.job_id"
 LABEL_TASK_HASH = "iris.task_hash"
 LABEL_TASK_ID = "iris.task_id"
@@ -56,6 +58,7 @@ _KUEUE_QUEUE_NAME = KUEUE_QUEUE_NAME
 _KUEUE_REQUIRED_TOPOLOGY = KUEUE_REQUIRED_TOPOLOGY
 _KUEUE_SLICE_REQUIRED_TOPOLOGY = KUEUE_SLICE_REQUIRED_TOPOLOGY
 _KUEUE_SLICE_SIZE = KUEUE_SLICE_SIZE
+_KUEUE_UNCONSTRAINED_TOPOLOGY = KUEUE_UNCONSTRAINED_TOPOLOGY
 _LABEL_JOB_ID = LABEL_JOB_ID
 _LABEL_TASK_HASH = LABEL_TASK_HASH
 
@@ -1600,11 +1603,59 @@ def test_single_pod_gpu_job_routed_through_kueue():
     assert _KUEUE_POD_GROUP_TOTAL not in annotations
 
 
-def test_single_pod_cpu_job_uses_unconstrained_topology():
-    """CPU work uses TAS so Kueue can reclaim its accelerator-node capacity."""
+def test_cpu_job_is_unconstrained_when_no_pack_level_is_configured():
+    """CPU work uses TAS so Kueue can reclaim its accelerator-node capacity. Without a configured
+    level it stays unconstrained: naming a level absent from the flavor's Topology makes Kueue
+    reject the workload, so this cannot be inferred from the coscheduling bindings."""
     manifest = _build_pod_manifest(make_run_req("/cpu-job/task/0", num_tasks=1), pod_config(local_queue="iris-lq"))
-    assert manifest["metadata"]["annotations"]["kueue.x-k8s.io/podset-unconstrained-topology"] == "true"
+    annotations = manifest["metadata"]["annotations"]
+    assert annotations[_KUEUE_UNCONSTRAINED_TOPOLOGY] == "true"
+    assert _KUEUE_PREFERRED_TOPOLOGY not in annotations
     assert "nodeSelector" not in manifest["spec"]
+
+
+def test_cpu_job_prefers_the_configured_pack_level():
+    """A configured level becomes a soft preference, so Kueue scores domains instead of placing
+    per-node and packs CPU work rather than holing the domains gangs hard-bind to."""
+    manifest = _build_pod_manifest(
+        make_run_req("/cpu-job/task/0", num_tasks=1),
+        pod_config(local_queue="iris-lq", cpu_pack_topology=CW_LABEL_NVLINK_DOMAIN),
+    )
+    annotations = manifest["metadata"]["annotations"]
+    assert annotations[_KUEUE_PREFERRED_TOPOLOGY] == CW_LABEL_NVLINK_DOMAIN
+    # Preferred, never required: a CPU Pod falls back to coarser levels instead of pending.
+    assert _KUEUE_REQUIRED_TOPOLOGY not in annotations
+    assert _KUEUE_UNCONSTRAINED_TOPOLOGY not in annotations
+
+
+def test_standalone_tpu_job_ignores_the_pack_level():
+    """A TPU Pod is not accelerator-free and has no NVLink hierarchy to pack into, so it keeps
+    the unconstrained request even where a pack level is configured."""
+    req = make_run_req("/tpu-job/task/0", num_tasks=1)
+    req.resources.device.tpu.CopyFrom(job_pb2.TpuDevice(variant="v4", count=4))
+    annotations = _build_pod_manifest(req, pod_config(local_queue="iris-lq", cpu_pack_topology=CW_LABEL_NVLINK_DOMAIN))[
+        "metadata"
+    ]["annotations"]
+    assert annotations[_KUEUE_UNCONSTRAINED_TOPOLOGY] == "true"
+    assert _KUEUE_PREFERRED_TOPOLOGY not in annotations
+
+
+def test_configured_pack_level_does_not_leak_into_accelerator_requests():
+    """A configured pack level must not reach Pods that carry their own topology request. A GPU
+    Pod would lose its finest-level hint to a coarser domain, and a gang would gain a whole-PodSet
+    preference competing with the hard binding it already has."""
+    config = pod_config(local_queue="iris-lq", cpu_pack_topology="rack.example.com/hall")
+
+    gpu_req = make_run_req("/gpu-job/task/0", num_tasks=1)
+    gpu_req.resources.device.gpu.CopyFrom(job_pb2.GpuDevice(variant="H100", count=8))
+    gpu_annotations = _build_pod_manifest(gpu_req, config)["metadata"]["annotations"]
+    assert gpu_annotations[_KUEUE_PREFERRED_TOPOLOGY] == "kubernetes.io/hostname"
+
+    gang_annotations = _build_pod_manifest(
+        _cosched_req("/job/task/0", num_tasks=SCHEDULABLE_RACK_NODES, group_by="nvlink.domain"), config
+    )["metadata"]["annotations"]
+    assert gang_annotations[_KUEUE_REQUIRED_TOPOLOGY] == CW_LABEL_NVLINK_DOMAIN
+    assert _KUEUE_PREFERRED_TOPOLOGY not in gang_annotations
 
 
 def test_kueue_topologies_override_config():

--- a/lib/iris/tests/cluster/backends/test_config.py
+++ b/lib/iris/tests/cluster/backends/test_config.py
@@ -2189,6 +2189,27 @@ def test_make_task_backend_requires_kueue_for_k8s_backend():
         make_task_backend(config, unreachable_grace=Duration.from_seconds(1))
 
 
+def test_cpu_pack_topology_defaults_off_and_is_plumbed_when_set():
+    """The pack level must reach PodConfig from cluster config, and must stay empty when unset:
+    it names a Topology level, and a cluster whose flavor lacks that level rejects every CPU Pod.
+    Only clusters binding a Topology that has the level may opt in."""
+    unset = make_task_backend(
+        IrisClusterConfig(kubernetes_provider=KubernetesProviderConfig(kueue=KueueConfig(cluster_queue="iris-cq"))),
+        unreachable_grace=Duration.from_seconds(1),
+    )
+    assert unset.pods.cpu_pack_topology == ""
+
+    configured = make_task_backend(
+        IrisClusterConfig(
+            kubernetes_provider=KubernetesProviderConfig(
+                kueue=KueueConfig(cluster_queue="iris-cq", cpu_pack_topology="ds.coreweave.com/nvlink.domain")
+            )
+        ),
+        unreachable_grace=Duration.from_seconds(1),
+    )
+    assert configured.pods.cpu_pack_topology == "ds.coreweave.com/nvlink.domain"
+
+
 def test_k8s_backend_uses_canonical_default_task_image():
     config = IrisClusterConfig(
         defaults=DefaultsConfig(worker=WorkerConfig(default_task_image="registry.example/iris-task:abc1234")),

--- a/lib/iris/tests/cluster/backends/test_config.py
+++ b/lib/iris/tests/cluster/backends/test_config.py
@@ -2189,27 +2189,6 @@ def test_make_task_backend_requires_kueue_for_k8s_backend():
         make_task_backend(config, unreachable_grace=Duration.from_seconds(1))
 
 
-def test_cpu_pack_topology_defaults_off_and_is_plumbed_when_set():
-    """The pack level must reach PodConfig from cluster config, and must stay empty when unset:
-    it names a Topology level, and a cluster whose flavor lacks that level rejects every CPU Pod.
-    Only clusters binding a Topology that has the level may opt in."""
-    unset = make_task_backend(
-        IrisClusterConfig(kubernetes_provider=KubernetesProviderConfig(kueue=KueueConfig(cluster_queue="iris-cq"))),
-        unreachable_grace=Duration.from_seconds(1),
-    )
-    assert unset.pods.cpu_pack_topology == ""
-
-    configured = make_task_backend(
-        IrisClusterConfig(
-            kubernetes_provider=KubernetesProviderConfig(
-                kueue=KueueConfig(cluster_queue="iris-cq", cpu_pack_topology="ds.coreweave.com/nvlink.domain")
-            )
-        ),
-        unreachable_grace=Duration.from_seconds(1),
-    )
-    assert configured.pods.cpu_pack_topology == "ds.coreweave.com/nvlink.domain"
-
-
 def test_k8s_backend_uses_canonical_default_task_image():
     config = IrisClusterConfig(
         defaults=DefaultsConfig(worker=WorkerConfig(default_task_image="registry.example/iris-task:abc1234")),


### PR DESCRIPTION
Accelerator-free Pods carry podset-unconstrained-topology. Kueue resolves that to the Topology's lowest level, kubernetes.io/hostname, so it scores individual nodes and never scores domains. On NVL72 hardware a gang hard-binds to one nvlink.domain and needs a whole domain of free nodes, so a CPU Pod that leaves a node short of CPU or memory costs that domain a gang slot while using no GPUs. On cw-us-east-08a one CPU-only job held 64 GB200 nodes spread across nine of twelve domains, three of them entirely, leaving 256 idle GPUs unreachable to 29 queued gangs.

Add kubernetes_provider.kueue.cpu_pack_topology, a node label accelerator-free Pods softly prefer. Kueue then scores domains and takes the one whose leftover capacity is smallest among those that fit, so CPU work lands in domains that are already occupied and whole domains stay available to gangs. The request stays preferred, so a Pod that fits no domain at that level falls back to coarser levels instead of pending. Both annotations are TAS requests, leaving the reclaim accounting from #7928 unchanged.

The level is configured per cluster because the coscheduling bindings cannot supply it: they are a static CoreWeave default spanning GB200 and H100 conventions, while the levels that exist come from the Topology bound to the flavor. Deriving it would stamp ds.coreweave.com/nvlink.domain on the three H100 clusters, whose infiniband Topology has no such level; Kueue rejects a workload naming an absent level, so every CPU Pod there would stop scheduling. Only cw-us-east-08a sets it.

Two limits remain. Leftover capacity approximates occupancy. CPU NodePools share one synthetic value per multinode level, so the whole CPU pool is scored as a single domain against individual racks. The preference packs CPU Pods that only accelerator nodes can hold; small CPU Pods can still land on idle racks.

Kueue behavior here is read from v0.18.0 source; the packing has not been observed on a live cluster.

Fixes #8247
