### PR TITLE
[rigging] Improve fsutil object-store operations

### DIFF
--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -54,7 +54,7 @@ that touch its buckets; the rest keep working.
 | `du URL` | Total bytes and object count beneath a prefix |
 | `find PATTERN` | Paths matching a glob, e.g. `gs://marin-us-central2/x/**/*.json` |
 | `cp SRC DST [-r]` | Copy between any two locations, including across backends |
-| `rm URL [-r]` | Remove an object. `-r` or `-R` recursively removes a prefix with object-count progress |
+| `rm URL [-r]` | Remove an object. `-r` or `-R` recursively removes a prefix; remote prefixes show object-count progress |
 | `browse [URL]` | The interactive browser |
 
 `du` scans prefixes with up to 32 concurrent metadata-bearing listings. Recursive `rm`

--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -1,6 +1,6 @@
 # fsutil: browsing Marin's buckets
 
-`fsutil` lists, reads, sizes, and copies objects across every bucket declared in
+`fsutil` lists, reads, sizes, copies, and removes objects across every bucket declared in
 `config/*.yaml` — GCS, CoreWeave AI Object Storage, and R2 — from one command, and opens
 an interactive browser over all of them.
 
@@ -8,9 +8,11 @@ an interactive browser over all of them.
 uv run fsutil                        # interactive browser, starting at the bucket list
 uv run fsutil buckets                # what is declared, and whether credentials are set
 uv run fsutil ls -l gs://marin-us-central2/scratch
+uv run fsutil ls 's3://marin-us-east-02a/*/config.json'
 uv run fsutil cat s3://marin-us-east-02a/iris/my-job/config.json
 uv run fsutil du s3://marin-us-east-02a/iris/my-job
 uv run fsutil cp -r s3://marin-us-east-02a/iris/my-job/logs /tmp/logs
+uv run fsutil rm -R s3://marin-us-east-02a/tmp/expired-prefix
 ```
 
 Paths are always full URLs — `gs://bucket/key`, `s3://bucket/key`, or a local path.
@@ -45,14 +47,19 @@ that touch its buckets; the rest keep working.
 
 | Command | What it does |
 |---------|--------------|
-| `ls [URL] [-l]` | Immediate children; with no URL, the declared buckets. `-l` adds size and modification time |
+| `ls [URL] [-l]` | Immediate children or glob matches; with no URL, the declared buckets. `-l` adds size and modification time |
 | `cat URL [--raw]` | Print a file. Tabular JSON, JSONL, and parquet render as a table, and `--raw` writes stored bytes to stdout |
 | `head URL [-n N]` | Print the first N lines, or the first N rows of a parquet file |
 | `stat URL` | The object's metadata as the backend reports it |
 | `du URL` | Total bytes and object count beneath a prefix |
 | `find PATTERN` | Paths matching a glob, e.g. `gs://marin-us-central2/x/**/*.json` |
 | `cp SRC DST [-r]` | Copy between any two locations, including across backends |
+| `rm URL [-r]` | Remove an object. `-r` or `-R` recursively removes a prefix with object-count progress |
 | `browse [URL]` | The interactive browser |
+
+`du` scans prefixes with up to 32 concurrent metadata-bearing listings. Recursive `rm`
+uses S3's 1,000-key bulk delete and GCS's 20-key batch delete, with up to eight batches
+in flight.
 
 `cat`, `head`, and the browser decompress `.gz`, `.bz2`, `.xz`, and `.lzma` files by
 suffix. A `data.json.gz` preview uses the JSON table view. `cat --raw` writes the compressed

--- a/lib/rigging/src/rigging/fsutil/cli.py
+++ b/lib/rigging/src/rigging/fsutil/cli.py
@@ -12,9 +12,9 @@ import logging
 import shutil
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any
 
 import click
+from fsspec import AbstractFileSystem
 from gcsfs import GCSFileSystem
 from s3fs import S3FileSystem
 
@@ -77,7 +77,7 @@ def buckets() -> None:
 @click.argument("url", default=ROOT)
 @click.option("-l", "--long", is_flag=True, help="Show size and modification time.")
 def list_command(url: str, long: bool) -> None:
-    """List the immediate children of URL. With no URL, list the known buckets."""
+    """List URL's immediate children or glob matches. With no URL, list the known buckets."""
     entries = list_entries(url)
     if not long:
         for entry in entries:
@@ -205,7 +205,7 @@ def rm(url: str, recursive: bool) -> None:
     click.echo(url)
 
 
-def _delete_batches(fs: Any, files: list[str]) -> list[list[str]]:
+def _delete_batches(fs: AbstractFileSystem, files: list[str]) -> list[list[str]]:
     if isinstance(fs, S3FileSystem):
         batch_size = _S3_DELETE_BATCH
     elif isinstance(fs, GCSFileSystem):
@@ -215,7 +215,7 @@ def _delete_batches(fs: Any, files: list[str]) -> list[list[str]]:
     return [files[start : start + batch_size] for start in range(0, len(files), batch_size)]
 
 
-def _remove_batch(fs: Any, files: list[str]) -> None:
+def _remove_batch(fs: AbstractFileSystem, files: list[str]) -> None:
     if not isinstance(fs, S3FileSystem):
         fs.rm(files)
         return

--- a/lib/rigging/src/rigging/fsutil/cli.py
+++ b/lib/rigging/src/rigging/fsutil/cli.py
@@ -1,7 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""The ``fsutil`` command line: list, read, size, and copy across Marin's buckets.
+"""The ``fsutil`` command line: list, read, size, copy, and remove across Marin's buckets.
 
 Every path is a full URL (``gs://``, ``s3://``, or a local path). There is no implicit
 current bucket, so the same command means the same thing from any shell, and a copy can
@@ -11,8 +11,12 @@ name two different backends. Bare ``fsutil`` opens the interactive browser.
 import logging
 import shutil
 import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any
 
 import click
+from gcsfs import GCSFileSystem
+from s3fs import S3FileSystem
 
 from rigging.filesystem.buckets import MissingCredentials, filesystem_for
 from rigging.filesystem.cluster_config import StoreType, data_buckets
@@ -36,6 +40,9 @@ logger = logging.getLogger(__name__)
 # Streaming chunk for cross-backend copies, which cannot use a filesystem's own
 # server-side copy.
 _COPY_CHUNK = 8 * 1024 * 1024
+_RM_WORKERS = 8
+_S3_DELETE_BATCH = 1000
+_GCS_DELETE_BATCH = 20
 
 
 @click.group(invoke_without_command=True)
@@ -160,6 +167,78 @@ def cp(src: str, dst: str, recursive: bool) -> None:
         _copy_file(src_fs, match, dst_fs, _destination(match, src_path, dst_path))
         copied += 1
     click.echo(f"{src} -> {dst} ({copied} objects)")
+
+
+@cli.command()
+@click.argument("url")
+@click.option("-r", "-R", "--recursive", is_flag=True, help="Remove a prefix and everything under it.")
+def rm(url: str, recursive: bool) -> None:
+    """Remove an object, or recursively remove a prefix."""
+    fs, path = filesystem_for(url)
+    is_dir = fs.isdir(path)
+    if is_dir and not recursive:
+        raise click.ClickException(f"{url} is a directory; pass -r to remove it recursively")
+    if not is_dir:
+        fs.rm(path)
+        click.echo(url)
+        return
+
+    click.echo(f"Scanning {url} ...", err=True)
+    entries = fs.find(path, detail=True)
+    files = list(entries)
+    total_bytes = sum(entry.get("size", 0) or 0 for entry in entries.values())
+    batches = _delete_batches(fs, files)
+    with ThreadPoolExecutor(max_workers=_RM_WORKERS) as executor:
+        label = f"Removing {len(files)} objects ({format_size(total_bytes)})"
+        with click.progressbar(length=len(files), label=label, show_pos=True) as progress:
+            for start in range(0, len(batches), _RM_WORKERS):
+                removals = {
+                    executor.submit(_remove_batch, fs, batch): len(batch)
+                    for batch in batches[start : start + _RM_WORKERS]
+                }
+                for removal in as_completed(removals):
+                    removal.result()
+                    progress.update(removals[removal])
+    fs.invalidate_cache()
+    if StoragePath(url).is_local:
+        fs.rm(path, recursive=True)
+    click.echo(url)
+
+
+def _delete_batches(fs: Any, files: list[str]) -> list[list[str]]:
+    if isinstance(fs, S3FileSystem):
+        batch_size = _S3_DELETE_BATCH
+    elif isinstance(fs, GCSFileSystem):
+        batch_size = _GCS_DELETE_BATCH
+    else:
+        batch_size = 1
+    return [files[start : start + batch_size] for start in range(0, len(files), batch_size)]
+
+
+def _remove_batch(fs: Any, files: list[str]) -> None:
+    if not isinstance(fs, S3FileSystem):
+        fs.rm(files)
+        return
+
+    objects = []
+    buckets = set()
+    for path in files:
+        bucket, key, version = fs.split_path(path)
+        buckets.add(bucket)
+        item = {"Key": key}
+        if version is not None:
+            item["VersionId"] = version
+        objects.append(item)
+    assert len(buckets) == 1
+    response = fs.call_s3(
+        "delete_objects",
+        Bucket=buckets.pop(),
+        Delete={"Objects": objects, "Quiet": True},
+    )
+    errors = response.get("Errors", [])
+    if errors:
+        details = ", ".join(f"{error['Key']}: {error['Code']}" for error in errors)
+        raise RuntimeError(f"S3 bulk delete failed: {details}")
 
 
 @cli.command()

--- a/lib/rigging/src/rigging/fsutil/cli.py
+++ b/lib/rigging/src/rigging/fsutil/cli.py
@@ -182,6 +182,13 @@ def rm(url: str, recursive: bool) -> None:
         fs.rm(path)
         click.echo(url)
         return
+    if StoragePath(url).is_local:
+        if fs.info(path).get("islink"):
+            fs.rm_file(path)
+        else:
+            fs.rm(path, recursive=True)
+        click.echo(url)
+        return
 
     click.echo(f"Scanning {url} ...", err=True)
     entries = fs.find(path, detail=True)
@@ -200,8 +207,6 @@ def rm(url: str, recursive: bool) -> None:
                     removal.result()
                     progress.update(removals[removal])
     fs.invalidate_cache()
-    if StoragePath(url).is_local:
-        fs.rm(path, recursive=True)
     click.echo(url)
 
 

--- a/lib/rigging/src/rigging/fsutil/listing.py
+++ b/lib/rigging/src/rigging/fsutil/listing.py
@@ -10,7 +10,11 @@ an ordinary object-store listing routed through
 """
 
 import dataclasses
+import glob
+from collections import deque
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from datetime import datetime
+from typing import Any
 
 from rigging.filesystem.buckets import filesystem_for
 from rigging.filesystem.cluster_config import StoreType, data_buckets
@@ -26,6 +30,10 @@ _SCHEME_FOR_STORE = {StoreType.GCS: "gs", StoreType.R2: "s3", StoreType.COREWEAV
 # Preview reads are bounded: browsing should never pull a multi-gigabyte shard down a home
 # connection because someone pressed enter on it. `fsutil cp` fetches whole objects.
 MAX_PREVIEW_BYTES = 10 * 1024 * 1024
+
+# Bucket listings are network-bound, so a modest pool hides request latency without
+# creating enough concurrent requests to overwhelm an object-store endpoint.
+_DU_WORKERS = 32
 
 
 @dataclasses.dataclass(frozen=True)
@@ -65,11 +73,11 @@ def bucket_url(bucket: str) -> str:
 
 
 def list_entries(url: str) -> list[Entry]:
-    """List the immediate children of *url*, directories first then names ascending.
+    """List *url*'s immediate children or the entries matching a glob pattern.
 
     ``url`` may be :data:`ROOT`, in which case the declared buckets are the children.
-    The listed location itself is never included, so a listing is always strictly a
-    level down.
+    Glob matches are named relative to the non-pattern prefix, so matches remain
+    distinguishable when their basenames are the same.
     """
     if url == ROOT:
         return [
@@ -78,9 +86,33 @@ def list_entries(url: str) -> list[Entry]:
 
     parsed = StoragePath(url)
     fs, path = filesystem_for(url)
-    entries = [_entry(parsed, item) for item in fs.ls(path, detail=True) if _is_child(path, item["name"])]
+    if glob.has_magic(path):
+        root = _glob_root(path)
+        entries = [
+            _entry(parsed, item, name=_relative_name(root, item["name"]), url=_qualified_url(parsed, item["name"]))
+            for item in fs.glob(path, detail=True).values()
+        ]
+    else:
+        entries = [_entry(parsed, item) for item in fs.ls(path, detail=True) if _is_child(path, item["name"])]
     entries.sort(key=lambda e: (not e.is_dir, e.name.lower()))
     return entries
+
+
+def _glob_root(pattern: str) -> str:
+    first_magic = min(pattern.find(character) for character in "*?[" if character in pattern)
+    return pattern[:first_magic].rpartition("/")[0]
+
+
+def _relative_name(root: str, name: str) -> str:
+    if root and name.startswith(f"{root}/"):
+        return name[len(root) + 1 :].rstrip("/")
+    return name.rstrip("/")
+
+
+def _qualified_url(parsed: StoragePath, path: str) -> str:
+    if parsed.scheme is None or "://" in path:
+        return path
+    return f"{parsed.scheme}://{path}"
 
 
 def _is_child(listed: str, name: str) -> bool:
@@ -92,11 +124,12 @@ def _is_child(listed: str, name: str) -> bool:
     return name.strip("/") != listed.strip("/")
 
 
-def _entry(parsed: StoragePath, item: dict) -> Entry:
-    name = item["name"].rstrip("/").rsplit("/", 1)[-1]
+def _entry(parsed: StoragePath, item: dict, *, name: str | None = None, url: str | None = None) -> Entry:
+    item_name = item["name"].rstrip("/")
+    name = name or item_name.rsplit("/", 1)[-1]
     is_dir = item["type"] == "directory"
     return Entry(
-        url=str(parsed / name),
+        url=url or str(parsed / name),
         name=name,
         size=None if is_dir else item.get("size", 0),
         mtime=_mtime(item),
@@ -147,15 +180,47 @@ def _read_preview(fs, path: str, *, compression: str | None, full_size: int | No
 
 
 def total_size(url: str) -> tuple[int, int]:
-    """Return ``(bytes, object_count)`` under *url*, walking every prefix beneath it."""
+    """Return ``(bytes, object_count)`` under *url* using parallel detailed listings."""
     fs, path = filesystem_for(url)
-    if fs.isfile(path):
-        return fs.size(path), 1
+    root_entries = fs.ls(path, detail=True)
+    if len(root_entries) == 1 and not _is_child(path, root_entries[0]["name"]):
+        entry = root_entries[0]
+        if entry["type"] != "directory":
+            return entry.get("size", 0) or 0, 1
 
+    total, count, directories = _listing_size(path, root_entries)
+    queued = deque(directories)
+    if not queued:
+        return total, count
+
+    with ThreadPoolExecutor(max_workers=_DU_WORKERS) as executor:
+        pending = {}
+        while queued or pending:
+            while queued and len(pending) < _DU_WORKERS:
+                directory = queued.popleft()
+                pending[executor.submit(fs.ls, directory, detail=True)] = directory
+
+            completed, _ = wait(pending, return_when=FIRST_COMPLETED)
+            for future in completed:
+                directory = pending.pop(future)
+                subtotal, subcount, subdirectories = _listing_size(directory, future.result())
+                total += subtotal
+                count += subcount
+                queued.extend(subdirectories)
+    return total, count
+
+
+def _listing_size(listed: str, entries: list[dict[str, Any]]) -> tuple[int, int, list[str]]:
     total = 0
     count = 0
-    for _, _, files in fs.walk(path, detail=True):
-        for info in files.values():
-            total += info.get("size", 0) or 0
-            count += 1
-    return total, count
+    directories = []
+    for entry in entries:
+        name = entry["name"]
+        if not _is_child(listed, name):
+            continue
+        if entry["type"] == "directory":
+            directories.append(name)
+            continue
+        total += entry.get("size", 0) or 0
+        count += 1
+    return total, count, directories

--- a/lib/rigging/src/rigging/fsutil/listing.py
+++ b/lib/rigging/src/rigging/fsutil/listing.py
@@ -26,6 +26,7 @@ from rigging.fsutil.compression import compression_for
 ROOT = ""
 
 _SCHEME_FOR_STORE = {StoreType.GCS: "gs", StoreType.R2: "s3", StoreType.COREWEAVE: "s3"}
+_DIRECTORY_TYPE = "directory"
 
 # Preview reads are bounded: browsing should never pull a multi-gigabyte shard down a home
 # connection because someone pressed enter on it. `fsutil cp` fetches whole objects.
@@ -62,6 +63,13 @@ class Preview:
     full_size: int | None
 
 
+@dataclasses.dataclass(frozen=True)
+class _ListingStats:
+    size: int
+    count: int
+    directories: list[str]
+
+
 def bucket_url(bucket: str) -> str:
     """The URL of *bucket*, with the scheme its declared backend is served by.
 
@@ -88,10 +96,12 @@ def list_entries(url: str) -> list[Entry]:
     fs, path = filesystem_for(url)
     if glob.has_magic(path):
         root = _glob_root(path)
-        entries = [
-            _entry(parsed, item, name=_relative_name(root, item["name"]), url=_qualified_url(parsed, item["name"]))
-            for item in fs.glob(path, detail=True).values()
-        ]
+        base = StoragePath(_qualified_url(parsed, root))
+        entries = []
+        for item in fs.glob(path, detail=True).values():
+            qualified_url = _qualified_url(parsed, item["name"])
+            name = StoragePath(qualified_url).relative_to(base)
+            entries.append(_entry(parsed, item, name=name, url=qualified_url))
     else:
         entries = [_entry(parsed, item) for item in fs.ls(path, detail=True) if _is_child(path, item["name"])]
     entries.sort(key=lambda e: (not e.is_dir, e.name.lower()))
@@ -101,12 +111,6 @@ def list_entries(url: str) -> list[Entry]:
 def _glob_root(pattern: str) -> str:
     first_magic = min(pattern.find(character) for character in "*?[" if character in pattern)
     return pattern[:first_magic].rpartition("/")[0]
-
-
-def _relative_name(root: str, name: str) -> str:
-    if root and name.startswith(f"{root}/"):
-        return name[len(root) + 1 :].rstrip("/")
-    return name.rstrip("/")
 
 
 def _qualified_url(parsed: StoragePath, path: str) -> str:
@@ -127,7 +131,7 @@ def _is_child(listed: str, name: str) -> bool:
 def _entry(parsed: StoragePath, item: dict, *, name: str | None = None, url: str | None = None) -> Entry:
     item_name = item["name"].rstrip("/")
     name = name or item_name.rsplit("/", 1)[-1]
-    is_dir = item["type"] == "directory"
+    is_dir = item["type"] == _DIRECTORY_TYPE
     return Entry(
         url=url or str(parsed / name),
         name=name,
@@ -180,16 +184,18 @@ def _read_preview(fs, path: str, *, compression: str | None, full_size: int | No
 
 
 def total_size(url: str) -> tuple[int, int]:
-    """Return ``(bytes, object_count)`` under *url* using parallel detailed listings."""
+    """Return ``(bytes, object_count)`` under *url*."""
     fs, path = filesystem_for(url)
     root_entries = fs.ls(path, detail=True)
     if len(root_entries) == 1 and not _is_child(path, root_entries[0]["name"]):
         entry = root_entries[0]
-        if entry["type"] != "directory":
+        if entry["type"] != _DIRECTORY_TYPE:
             return entry.get("size", 0) or 0, 1
 
-    total, count, directories = _listing_size(path, root_entries)
-    queued = deque(directories)
+    root_stats = _listing_stats(path, root_entries)
+    total = root_stats.size
+    count = root_stats.count
+    queued = deque(root_stats.directories)
     if not queued:
         return total, count
 
@@ -203,14 +209,14 @@ def total_size(url: str) -> tuple[int, int]:
             completed, _ = wait(pending, return_when=FIRST_COMPLETED)
             for future in completed:
                 directory = pending.pop(future)
-                subtotal, subcount, subdirectories = _listing_size(directory, future.result())
-                total += subtotal
-                count += subcount
-                queued.extend(subdirectories)
+                stats = _listing_stats(directory, future.result())
+                total += stats.size
+                count += stats.count
+                queued.extend(stats.directories)
     return total, count
 
 
-def _listing_size(listed: str, entries: list[dict[str, Any]]) -> tuple[int, int, list[str]]:
+def _listing_stats(listed: str, entries: list[dict[str, Any]]) -> _ListingStats:
     total = 0
     count = 0
     directories = []
@@ -218,9 +224,9 @@ def _listing_size(listed: str, entries: list[dict[str, Any]]) -> tuple[int, int,
         name = entry["name"]
         if not _is_child(listed, name):
             continue
-        if entry["type"] == "directory":
+        if entry["type"] == _DIRECTORY_TYPE:
             directories.append(name)
             continue
         total += entry.get("size", 0) or 0
         count += 1
-    return total, count, directories
+    return _ListingStats(size=total, count=count, directories=directories)

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -67,11 +67,24 @@ def test_rm_requires_recursive_for_directories(tree):
     result = run(cli, ["rm", "-R", str(tree / "sub")])
     assert result.exit_code == 0, result.output
     assert not (tree / "sub").exists()
-    assert "Removing 1 objects" in result.output
 
     result = run(cli, ["rm", str(tree / "b.txt")])
     assert result.exit_code == 0, result.output
     assert not (tree / "b.txt").exists()
+
+
+def test_rm_recursive_unlinks_local_directory_symlink_without_deleting_target(tmp_path):
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "keep.txt").write_text("keep")
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=True)
+
+    result = CliRunner().invoke(cli, ["rm", "-R", str(link)])
+
+    assert result.exit_code == 0, result.output
+    assert not link.is_symlink()
+    assert (target / "keep.txt").read_text() == "keep"
 
 
 def test_rm_uses_s3_bulk_delete_batches(monkeypatch):

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -61,7 +61,7 @@ def test_rm_requires_recursive_for_directories(tree):
     run = CliRunner().invoke
 
     result = run(cli, ["rm", str(tree / "sub")])
-    assert result.exit_code != 0 and "-r" in result.output
+    assert result.exit_code != 0
     assert (tree / "sub" / "c.txt").exists()
 
     result = run(cli, ["rm", "-R", str(tree / "sub")])

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -8,8 +8,10 @@ import bz2
 import gzip
 import json
 import lzma
+import threading
 
 import pytest
+import rigging.fsutil.cli as cli_module
 from click.testing import CliRunner
 from rigging.fsutil import listing
 from rigging.fsutil.cli import cli
@@ -53,6 +55,63 @@ def test_cp_handles_the_awkward_destination_shapes(tree, tmp_path, monkeypatch):
     result = run(cli, ["cp", str(tree / "b.txt"), "bare.txt"])
     assert result.exit_code == 0, result.output
     assert (tmp_path / "bare.txt").read_text() == "hello"
+
+
+def test_rm_requires_recursive_for_directories(tree):
+    run = CliRunner().invoke
+
+    result = run(cli, ["rm", str(tree / "sub")])
+    assert result.exit_code != 0 and "-r" in result.output
+    assert (tree / "sub" / "c.txt").exists()
+
+    result = run(cli, ["rm", "-R", str(tree / "sub")])
+    assert result.exit_code == 0, result.output
+    assert not (tree / "sub").exists()
+    assert "Removing 1 objects" in result.output
+
+    result = run(cli, ["rm", str(tree / "b.txt")])
+    assert result.exit_code == 0, result.output
+    assert not (tree / "b.txt").exists()
+
+
+def test_rm_uses_s3_bulk_delete_batches(monkeypatch):
+    class RecordingS3FileSystem:
+        def __init__(self):
+            self.requests = []
+
+        def isdir(self, _path):
+            return True
+
+        def find(self, path, *, detail):
+            assert path == "bucket/prefix"
+            assert detail is True
+            return {
+                f"bucket/prefix/{index}": {"name": f"bucket/prefix/{index}", "size": 1, "type": "file"}
+                for index in range(1001)
+            }
+
+        def split_path(self, path):
+            bucket, key = path.split("/", 1)
+            return bucket, key, None
+
+        def call_s3(self, method, **kwargs):
+            assert method == "delete_objects"
+            self.requests.append(kwargs)
+            return {}
+
+        def invalidate_cache(self):
+            pass
+
+    fs = RecordingS3FileSystem()
+    monkeypatch.setattr(cli_module, "S3FileSystem", RecordingS3FileSystem)
+    monkeypatch.setattr(cli_module, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+
+    result = CliRunner().invoke(cli, ["rm", "-R", "s3://bucket/prefix"])
+
+    assert result.exit_code == 0, result.output
+    batches = [request["Delete"]["Objects"] for request in fs.requests]
+    assert sorted(map(len, batches)) == [1, 1000]
+    assert {item["Key"] for batch in batches for item in batch} == {f"prefix/{index}" for index in range(1001)}
 
 
 def test_json_previews_render_as_tables_and_degrade_safely():
@@ -138,3 +197,53 @@ def test_ls_long_renders_local_directory(tree):
     assert lines[0].split() == ["size", "modified", "name"]
     assert any(line.endswith("b.txt") for line in lines)
     assert any(line.endswith("sub/") for line in lines)
+
+
+def test_ls_glob_renders_matches_with_listing_metadata(monkeypatch):
+    class GlobFileSystem:
+        def glob(self, path, *, detail):
+            assert path == "bucket/*/foo"
+            assert detail is True
+            return {
+                "bucket/first/foo": {"name": "bucket/first/foo", "size": 3, "type": "file"},
+                "bucket/second/foo": {"name": "bucket/second/foo", "size": 5, "type": "file"},
+            }
+
+    monkeypatch.setattr(listing, "filesystem_for", lambda _url: (GlobFileSystem(), "bucket/*/foo"))
+
+    result = CliRunner().invoke(cli, ["ls", "s3://bucket/*/foo"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.splitlines() == ["first/foo", "second/foo"]
+
+
+def test_du_scans_directories_in_parallel_using_listing_metadata(monkeypatch):
+    class ParallelListingFileSystem:
+        def __init__(self):
+            self.child_listings_started = threading.Barrier(2)
+
+        def ls(self, path, *, detail):
+            assert detail is True
+            if path == "bucket/root":
+                return [
+                    {"name": "bucket/root/recon", "size": 0, "type": "directory"},
+                    {"name": "bucket/root/top", "size": 5, "type": "file"},
+                ]
+            if path in ("bucket/root/recon/a", "bucket/root/recon/b"):
+                self.child_listings_started.wait(timeout=2)
+            return {
+                "bucket/root/recon": [
+                    {"name": "bucket/root/recon/a", "size": 0, "type": "directory"},
+                    {"name": "bucket/root/recon/b", "size": 0, "type": "directory"},
+                ],
+                "bucket/root/recon/a": [
+                    {"name": "bucket/root/recon/a/nested", "size": 0, "type": "directory"},
+                    {"name": "bucket/root/recon/a/one", "size": 7, "type": "file"},
+                ],
+                "bucket/root/recon/b": [{"name": "bucket/root/recon/b/two", "size": 11, "type": "file"}],
+                "bucket/root/recon/a/nested": [{"name": "bucket/root/recon/a/nested/three", "size": 13, "type": "file"}],
+            }[path]
+
+    monkeypatch.setattr(listing, "filesystem_for", lambda _url: (ParallelListingFileSystem(), "bucket/root"))
+
+    assert listing.total_size("s3://bucket/root") == (36, 4)


### PR DESCRIPTION
Allow `fsutil ls` to accept glob URLs while preserving metadata for long listings. Scan `du` prefixes with up to 32 concurrent `ls(detail=True)` calls and total sizes from the returned metadata.

Add `fsutil rm` with explicit `-r`/`-R` prefix removal. Remote removal enumerates once with detail metadata, reports object-count progress, sends S3 `DeleteObjects` requests in 1,000-key batches and GCS deletes in 20-key batches, and runs up to eight batches concurrently. Local directory symlinks are unlinked without traversing their targets.
