### PR TITLE
[iris] Isolate federation I/O stalls

### DIFF
--- a/lib/iris/src/iris/cluster/bundle.py
+++ b/lib/iris/src/iris/cluster/bundle.py
@@ -18,6 +18,9 @@ import threading
 import time
 import zipfile
 from collections import OrderedDict
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.request import urlopen
 
@@ -28,6 +31,12 @@ logger = logging.getLogger(__name__)
 # Maximum size (bytes) of a submitted workspace bundle. Enforced by the client
 # when creating the zip and re-checked by the controller when receiving it.
 MAX_BUNDLE_SIZE_BYTES = 25 * 1024 * 1024
+
+
+@dataclass
+class _ContentLock:
+    lock: threading.RLock
+    users: int = 0
 
 
 def content_id(data: bytes) -> str:
@@ -47,7 +56,9 @@ class BundleStore:
         self._controller_address = controller_address.rstrip("/") if controller_address else ""
         self._max_cache_items = max_cache_items
         self._max_cache_bytes = max_cache_bytes
-        self._lock = threading.RLock()
+        self._cache_lock = threading.RLock()
+        self._content_locks_guard = threading.Lock()
+        self._content_locks: dict[str, _ContentLock] = {}
 
         self._fs, self._fs_path = fsspec.core.url_to_fs(storage_dir)
         self._fs.mkdirs(self._fs_path, exist_ok=True)
@@ -59,8 +70,32 @@ class BundleStore:
     def _path_for(self, cid: str) -> str:
         return f"{self._fs_path}/{cid}"
 
+    @contextmanager
+    def _content_lock(self, cid: str) -> Iterator[None]:
+        with self._content_locks_guard:
+            state = self._content_locks.get(cid)
+            if state is None:
+                state = _ContentLock(threading.RLock())
+                self._content_locks[cid] = state
+            state.users += 1
+        try:
+            with state.lock:
+                yield
+        finally:
+            with self._content_locks_guard:
+                state.users -= 1
+                if state.users == 0:
+                    del self._content_locks[cid]
+
+    def _cached(self, cid: str) -> bytes | None:
+        with self._cache_lock:
+            data = self._cache.get(cid)
+            if data is not None:
+                self._cache.move_to_end(cid)
+            return data
+
     def _cache_put(self, cid: str, data: bytes) -> None:
-        """Insert into in-memory cache and evict if needed. Caller must hold _lock."""
+        """Insert into in-memory cache and evict if needed. Caller must hold ``_cache_lock``."""
         if cid in self._cache:
             self._cache.move_to_end(cid)
             return
@@ -79,31 +114,35 @@ class BundleStore:
         """Write bytes if absent and return canonical content id."""
         cid = content_id(data)
         path = self._path_for(cid)
-        with self._lock:
+        with self._content_lock(cid):
             # Always ensure disk has the bytes: a cache hit without disk write
             # would leave workers unable to fetch this id after a restart.
             if not self._fs.exists(path):
                 with self._fs.open(path, "wb") as f:
                     f.write(data)
-            self._cache_put(cid, data)
+            with self._cache_lock:
+                self._cache_put(cid, data)
         return cid
 
     def get(self, cid: str) -> bytes:
         """Read bytes by content id. Falls back to controller on workers."""
         path = self._path_for(cid)
-        with self._lock:
-            if cid in self._cache:
-                self._cache.move_to_end(cid)
-                return self._cache[cid]
+        cached = self._cached(cid)
+        if cached is not None:
+            return cached
+        with self._content_lock(cid):
+            cached = self._cached(cid)
+            if cached is not None:
+                return cached
             if self._fs.exists(path):
                 with self._fs.open(path, "rb") as f:
                     data = f.read()
-                self._cache_put(cid, data)
+                with self._cache_lock:
+                    self._cache_put(cid, data)
                 return data
-        # Outside lock: fetch from controller and persist locally.
-        data = self._fetch_from_controller(cid)
-        self.write(data)
-        return data
+            data = self._fetch_from_controller(cid)
+            self.write(data)
+            return data
 
     def _fetch_from_controller(self, cid: str) -> bytes:
         """Fetch content over HTTP and verify hash. Retries up to 3 times."""

--- a/lib/iris/src/iris/cluster/bundle.py
+++ b/lib/iris/src/iris/cluster/bundle.py
@@ -87,7 +87,7 @@ class BundleStore:
                 if state.users == 0:
                     del self._content_locks[cid]
 
-    def _cached(self, cid: str) -> bytes | None:
+    def _cache_get(self, cid: str) -> bytes | None:
         with self._cache_lock:
             data = self._cache.get(cid)
             if data is not None:
@@ -127,11 +127,11 @@ class BundleStore:
     def get(self, cid: str) -> bytes:
         """Read bytes by content id. Falls back to controller on workers."""
         path = self._path_for(cid)
-        cached = self._cached(cid)
+        cached = self._cache_get(cid)
         if cached is not None:
             return cached
         with self._content_lock(cid):
-            cached = self._cached(cid)
+            cached = self._cache_get(cid)
             if cached is not None:
                 return cached
             if self._fs.exists(path):

--- a/lib/iris/src/iris/cluster/federation/manager.py
+++ b/lib/iris/src/iris/cluster/federation/manager.py
@@ -383,12 +383,7 @@ class FederationManager:
             peer.probe()
 
     def sync_once(self) -> None:
-        """Run one delivery pass followed by one status-sync pass per peer.
-
-        Tests and synchronous callers use this deterministic combined pass. The
-        background manager runs delivery and status sync independently so a slow
-        LaunchJob request cannot delay status updates. A no-op without a store.
-        """
+        """Deliver pending work and mirror one status batch from each peer."""
         if self._store is None or not self._peers:
             return
         with ThreadPoolExecutor(max_workers=len(self._peers), thread_name_prefix="federation-once") as executor:

--- a/lib/iris/src/iris/cluster/federation/manager.py
+++ b/lib/iris/src/iris/cluster/federation/manager.py
@@ -5,9 +5,9 @@
 
 The controller composes one manager. It owns the peer registry, the submit-time
 :class:`~iris.cluster.federation.router.PeerRouter`, a capability heartbeat loop,
-and independent delivery and delta-sync loops per peer. Background delivery also
-runs a bounded set of handoffs to the same peer concurrently. A slow LaunchJob
-request therefore does not delay unrelated background handoffs or status updates.
+and one sync loop per peer. Each sync pass delivers pending handoffs and cancels,
+then mirrors the peer's jobs into the local projection. Handoffs to one peer run
+with bounded concurrency. A slow LaunchJob delays only that peer's sync pass.
 Every durable mutation goes through an injected
 :class:`~iris.cluster.federation.store.FederationStore`, so the manager stays a
 self-contained module.
@@ -133,13 +133,12 @@ class FederationManager:
         # successive ticks between heartbeats do not each re-spend the same number.
         self._ledger = ReservationLedger()
         self._heartbeat_thread: ManagedThread | None = None
-        self._delivery_threads: dict[str, ManagedThread] = {}
         self._sync_threads: dict[str, ManagedThread] = {}
 
     # -- lifecycle -----------------------------------------------------------
 
     def start(self) -> None:
-        """Start heartbeat and, when a store is wired, per-peer delivery and sync loops.
+        """Start heartbeat and, when a store is wired, one sync loop per peer.
 
         A no-op when no peers are configured, so a single-cluster deployment is
         unchanged.
@@ -149,11 +148,6 @@ class FederationManager:
         self._heartbeat_thread = self._threads.spawn(self._run_heartbeat_loop, name="federation-heartbeat")
         if self._store is not None:
             for peer_id, peer in self._peers.items():
-                self._delivery_threads[peer_id] = self._threads.spawn(
-                    self._run_peer_delivery_loop,
-                    name=f"federation-delivery-{peer_id}",
-                    args=(peer,),
-                )
                 self._sync_threads[peer_id] = self._threads.spawn(
                     self._run_peer_sync_loop,
                     name=f"federation-sync-{peer_id}",
@@ -162,17 +156,12 @@ class FederationManager:
 
     def stop(self) -> None:
         """Stop all loops and release peer connections. Idempotent."""
-        threads = [
-            thread
-            for thread in [self._heartbeat_thread, *self._delivery_threads.values(), *self._sync_threads.values()]
-            if thread is not None
-        ]
+        threads = [thread for thread in [self._heartbeat_thread, *self._sync_threads.values()] if thread is not None]
         for thread in threads:
             thread.stop()
         for thread in threads:
             thread.join(timeout=_JOIN_TIMEOUT)
         self._heartbeat_thread = None
-        self._delivery_threads.clear()
         self._sync_threads.clear()
         for peer in self._peers.values():
             peer.close()
@@ -216,7 +205,7 @@ class FederationManager:
         In one local transaction the store persists the ``jobs``/``job_config``/
         ``federated_jobs`` handle (no task rows, no cluster) queued on the parent. The
         control tick's federation pass later picks a peer that has room and promotes
-        the handle to ``PENDING_HANDOFF``, and the delivery loop sends it. ``pinned_peer_id``
+        the handle to ``PENDING_HANDOFF``, and the sync loop delivers it. ``pinned_peer_id``
         is "" for an unpinned candidate, or the peer a ``cluster=<peer>`` pin named (the
         tick then only ever assigns it there). An idempotent resubmit is a no-op.
 
@@ -290,8 +279,8 @@ class FederationManager:
         Bumps ``cancel_intent_version`` (so a cancelled pending handoff is never
         delivered and a retried cancel is a no-op) and routes the idempotent
         ``TerminateJob(local_job_id)`` (the peer runs the same id). A transient
-        failure is not fatal — the delivery loop re-drives the cancel until the peer
-        acks or sync observes the job terminal/pruned.
+        failure is not fatal — the sync loop re-drives the cancel until the peer acks
+        or observes the job terminal/pruned.
         """
         if self._store is None:
             raise RuntimeError("federation cancel requires a store")
@@ -304,7 +293,7 @@ class FederationManager:
 
         A peer ``NOT_FOUND`` means the job is already gone (terminal-and-pruned),
         which satisfies the cancel — terminalize the local mirror so the re-drive
-        stops. Any other RPC error is left for the next delivery pass to retry.
+        stops. Any other RPC error is left for the next sync pass to retry.
         """
         assert self._store is not None
         peer = self._peers.get(target.peer_id)
@@ -364,17 +353,10 @@ class FederationManager:
     def _run_heartbeat_loop(self, stop_event: threading.Event) -> None:
         self._run_loop(stop_event, self._probe_all_peers, self._heartbeat_interval.to_seconds())
 
-    def _run_peer_delivery_loop(self, stop_event: threading.Event, peer: FederationPeer) -> None:
-        self._run_loop(
-            stop_event,
-            lambda: self._deliver_peer_once(peer),
-            self._sync_interval.to_seconds(),
-        )
-
     def _run_peer_sync_loop(self, stop_event: threading.Event, peer: FederationPeer) -> None:
         self._run_loop(
             stop_event,
-            lambda: self._sync_peer(peer),
+            lambda: self._sync_peer_once(peer),
             self._sync_interval.to_seconds(),
         )
 
@@ -387,14 +369,11 @@ class FederationManager:
         if self._store is None or not self._peers:
             return
         with ThreadPoolExecutor(max_workers=len(self._peers), thread_name_prefix="federation-once") as executor:
-            futures = [executor.submit(self._deliver_peer_once, peer) for peer in self._peers.values()]
-            for future in futures:
-                future.result()
-            futures = [executor.submit(self._sync_peer, peer) for peer in self._peers.values()]
+            futures = [executor.submit(self._sync_peer_once, peer) for peer in self._peers.values()]
             for future in futures:
                 future.result()
 
-    def _deliver_peer_once(self, peer: FederationPeer) -> None:
+    def _sync_peer_once(self, peer: FederationPeer) -> None:
         assert self._store is not None
         handoffs = [spec for spec in self._store.pending_handoffs() if spec.peer_id == peer.peer_id]
         if handoffs:
@@ -409,6 +388,7 @@ class FederationManager:
         for target in self._store.pending_cancels():
             if target.peer_id == peer.peer_id:
                 self._deliver_cancel(target)
+        self._sync_peer(peer)
 
     def _redrive_pending_handoffs(self) -> None:
         """Re-deliver every handle still awaiting its peer (boot recovery + retry)."""
@@ -421,7 +401,7 @@ class FederationManager:
 
         A rejection marks the handle ``HANDOFF_REJECTED`` so the re-drive stops; the
         user learns the peer's verdict from the failed job. Retryable RPC failures
-        leave the handle pending for the next delivery pass.
+        leave the handle pending for the next sync pass.
         """
         assert self._store is not None
         peer = self._peers.get(spec.peer_id)

--- a/lib/iris/src/iris/cluster/federation/manager.py
+++ b/lib/iris/src/iris/cluster/federation/manager.py
@@ -375,11 +375,12 @@ class FederationManager:
 
     def _sync_peer_once(self, peer: FederationPeer) -> None:
         assert self._store is not None
-        handoffs = [spec for spec in self._store.pending_handoffs() if spec.peer_id == peer.peer_id]
+        handoffs = [spec for spec in self._store.pending_handoffs() if spec.peer_id == peer.peer_id][
+            : self._max_handoffs_per_cycle
+        ]
         if handoffs:
-            max_workers = max(1, min(len(handoffs), self._max_handoffs_per_cycle))
             with ThreadPoolExecutor(
-                max_workers=max_workers,
+                max_workers=len(handoffs),
                 thread_name_prefix=f"federation-handoff-{peer.peer_id}",
             ) as executor:
                 futures = [executor.submit(self._deliver_handoff, spec) for spec in handoffs]

--- a/lib/iris/src/iris/cluster/federation/manager.py
+++ b/lib/iris/src/iris/cluster/federation/manager.py
@@ -4,13 +4,15 @@
 """The federation manager: peer registry, handoff, delta-sync, and cancel.
 
 The controller composes one manager. It owns the peer registry, the submit-time
-:class:`~iris.cluster.federation.router.PeerRouter`, and two background loops —
-the capability heartbeat and the delta-sync loop that mirrors each peer's handed-
-off jobs back into the local projection. Every durable mutation goes through an
-injected :class:`~iris.cluster.federation.store.FederationStore`, so the manager
-stays a self-contained module.
+:class:`~iris.cluster.federation.router.PeerRouter`, a capability heartbeat loop,
+and independent delivery and delta-sync loops per peer. Delivery also runs a
+bounded set of handoffs to the same peer concurrently. A slow LaunchJob request
+therefore does not delay unrelated handoffs or status updates.
+Every durable mutation goes through an injected
+:class:`~iris.cluster.federation.store.FederationStore`, so the manager stays a
+self-contained module.
 
-With no peers configured it is inert: neither loop starts and every view is
+With no peers configured it is inert: no loops start and every view is
 empty, so a single-cluster deployment is unchanged. A ``store`` is required only
 to hand a job off or run the sync loop; the observability slice (heartbeat,
 ``ListPeers``) works without one.
@@ -19,6 +21,7 @@ to hand a job off or run the sync loop; the observability slice (heartbeat,
 import logging
 import threading
 from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from typing import TypeVar
 
 from connectrpc.code import Code
@@ -130,12 +133,13 @@ class FederationManager:
         # successive ticks between heartbeats do not each re-spend the same number.
         self._ledger = ReservationLedger()
         self._heartbeat_thread: ManagedThread | None = None
-        self._sync_thread: ManagedThread | None = None
+        self._delivery_threads: dict[str, ManagedThread] = {}
+        self._sync_threads: dict[str, ManagedThread] = {}
 
     # -- lifecycle -----------------------------------------------------------
 
     def start(self) -> None:
-        """Start the heartbeat and (when a store is wired) the sync loop.
+        """Start heartbeat and, when a store is wired, per-peer delivery and sync loops.
 
         A no-op when no peers are configured, so a single-cluster deployment is
         unchanged.
@@ -144,16 +148,32 @@ class FederationManager:
             return
         self._heartbeat_thread = self._threads.spawn(self._run_heartbeat_loop, name="federation-heartbeat")
         if self._store is not None:
-            self._sync_thread = self._threads.spawn(self._run_sync_loop, name="federation-sync")
+            for peer_id, peer in self._peers.items():
+                self._delivery_threads[peer_id] = self._threads.spawn(
+                    self._run_peer_delivery_loop,
+                    name=f"federation-delivery-{peer_id}",
+                    args=(peer,),
+                )
+                self._sync_threads[peer_id] = self._threads.spawn(
+                    self._run_peer_sync_loop,
+                    name=f"federation-sync-{peer_id}",
+                    args=(peer,),
+                )
 
     def stop(self) -> None:
-        """Stop both loops and release peer connections. Idempotent."""
-        for thread in (self._heartbeat_thread, self._sync_thread):
-            if thread is not None:
-                thread.stop()
-                thread.join(timeout=_JOIN_TIMEOUT)
+        """Stop all loops and release peer connections. Idempotent."""
+        threads = [
+            thread
+            for thread in [self._heartbeat_thread, *self._delivery_threads.values(), *self._sync_threads.values()]
+            if thread is not None
+        ]
+        for thread in threads:
+            thread.stop()
+        for thread in threads:
+            thread.join(timeout=_JOIN_TIMEOUT)
         self._heartbeat_thread = None
-        self._sync_thread = None
+        self._delivery_threads.clear()
+        self._sync_threads.clear()
         for peer in self._peers.values():
             peer.close()
 
@@ -344,37 +364,62 @@ class FederationManager:
     def _run_heartbeat_loop(self, stop_event: threading.Event) -> None:
         self._run_loop(stop_event, self._probe_all_peers, self._heartbeat_interval.to_seconds())
 
-    def _run_sync_loop(self, stop_event: threading.Event) -> None:
-        self._run_loop(stop_event, self.sync_once, self._sync_interval.to_seconds())
+    def _run_peer_delivery_loop(self, stop_event: threading.Event, peer: FederationPeer) -> None:
+        self._run_loop(
+            stop_event,
+            lambda: self._deliver_peer_once(peer),
+            self._sync_interval.to_seconds(),
+        )
+
+    def _run_peer_sync_loop(self, stop_event: threading.Event, peer: FederationPeer) -> None:
+        self._run_loop(
+            stop_event,
+            lambda: self._sync_peer(peer),
+            self._sync_interval.to_seconds(),
+        )
 
     def _probe_all_peers(self) -> None:
         for peer in self._peers.values():
             peer.probe()
 
     def sync_once(self) -> None:
-        """One sync pass: re-drive pending handoffs and cancels, then pull each peer.
+        """Run one delivery pass followed by one status-sync pass per peer.
 
-        The unit the sync loop repeats; a no-op without a store.
+        Tests and synchronous callers use this deterministic combined pass. The
+        background manager runs delivery and status sync independently so a slow
+        LaunchJob request cannot delay status updates. A no-op without a store.
         """
-        if self._store is None:
+        if self._store is None or not self._peers:
             return
-        self._redrive_pending_handoffs()
-        self._redrive_pending_cancels()
-        for peer in self._peers.values():
-            self._sync_peer(peer)
+        with ThreadPoolExecutor(max_workers=len(self._peers), thread_name_prefix="federation-once") as executor:
+            futures = [executor.submit(self._deliver_peer_once, peer) for peer in self._peers.values()]
+            for future in futures:
+                future.result()
+            futures = [executor.submit(self._sync_peer, peer) for peer in self._peers.values()]
+            for future in futures:
+                future.result()
+
+    def _deliver_peer_once(self, peer: FederationPeer) -> None:
+        assert self._store is not None
+        handoffs = [spec for spec in self._store.pending_handoffs() if spec.peer_id == peer.peer_id]
+        if handoffs:
+            max_workers = max(1, min(len(handoffs), self._max_handoffs_per_cycle))
+            with ThreadPoolExecutor(
+                max_workers=max_workers,
+                thread_name_prefix=f"federation-handoff-{peer.peer_id}",
+            ) as executor:
+                futures = [executor.submit(self._deliver_handoff, spec) for spec in handoffs]
+                for future in futures:
+                    future.result()
+        for target in self._store.pending_cancels():
+            if target.peer_id == peer.peer_id:
+                self._deliver_cancel(target)
 
     def _redrive_pending_handoffs(self) -> None:
         """Re-deliver every handle still awaiting its peer (boot recovery + retry)."""
         assert self._store is not None
         for spec in self._store.pending_handoffs():
             self._deliver_handoff(spec)
-
-    def _redrive_pending_cancels(self) -> None:
-        """Re-route ``TerminateJob`` for every cancel intent the peer has not yet
-        acknowledged (a transient failure left it undelivered)."""
-        assert self._store is not None
-        for target in self._store.pending_cancels():
-            self._deliver_cancel(target)
 
     def _deliver_handoff(self, spec: HandoffSpec) -> None:
         """Deliver one handle to its peer, terminalizing a rejection the peer will repeat.

--- a/lib/iris/src/iris/cluster/federation/manager.py
+++ b/lib/iris/src/iris/cluster/federation/manager.py
@@ -5,9 +5,9 @@
 
 The controller composes one manager. It owns the peer registry, the submit-time
 :class:`~iris.cluster.federation.router.PeerRouter`, a capability heartbeat loop,
-and independent delivery and delta-sync loops per peer. Delivery also runs a
-bounded set of handoffs to the same peer concurrently. A slow LaunchJob request
-therefore does not delay unrelated handoffs or status updates.
+and independent delivery and delta-sync loops per peer. Background delivery also
+runs a bounded set of handoffs to the same peer concurrently. A slow LaunchJob
+request therefore does not delay unrelated background handoffs or status updates.
 Every durable mutation goes through an injected
 :class:`~iris.cluster.federation.store.FederationStore`, so the manager stays a
 self-contained module.
@@ -216,7 +216,7 @@ class FederationManager:
         In one local transaction the store persists the ``jobs``/``job_config``/
         ``federated_jobs`` handle (no task rows, no cluster) queued on the parent. The
         control tick's federation pass later picks a peer that has room and promotes
-        the handle to ``PENDING_HANDOFF``, and the sync loop delivers it. ``pinned_peer_id``
+        the handle to ``PENDING_HANDOFF``, and the delivery loop sends it. ``pinned_peer_id``
         is "" for an unpinned candidate, or the peer a ``cluster=<peer>`` pin named (the
         tick then only ever assigns it there). An idempotent resubmit is a no-op.
 
@@ -290,8 +290,8 @@ class FederationManager:
         Bumps ``cancel_intent_version`` (so a cancelled pending handoff is never
         delivered and a retried cancel is a no-op) and routes the idempotent
         ``TerminateJob(local_job_id)`` (the peer runs the same id). A transient
-        failure is not fatal — the sync loop re-drives the cancel until the peer acks
-        or sync observes the job terminal/pruned.
+        failure is not fatal — the delivery loop re-drives the cancel until the peer
+        acks or sync observes the job terminal/pruned.
         """
         if self._store is None:
             raise RuntimeError("federation cancel requires a store")
@@ -304,7 +304,7 @@ class FederationManager:
 
         A peer ``NOT_FOUND`` means the job is already gone (terminal-and-pruned),
         which satisfies the cancel — terminalize the local mirror so the re-drive
-        stops. Any other RPC error is left for the next sync to retry.
+        stops. Any other RPC error is left for the next delivery pass to retry.
         """
         assert self._store is not None
         peer = self._peers.get(target.peer_id)
@@ -420,9 +420,8 @@ class FederationManager:
         """Deliver one handle to its peer, terminalizing a rejection the peer will repeat.
 
         A rejection marks the handle ``HANDOFF_REJECTED`` so the re-drive stops; the
-        user learns the peer's verdict from the failed job. Never raises on a peer's
-        answer: the re-drive loop calls this on the sync thread, which dies on an
-        uncaught exception.
+        user learns the peer's verdict from the failed job. Retryable RPC failures
+        leave the handle pending for the next delivery pass.
         """
         assert self._store is not None
         peer = self._peers.get(spec.peer_id)

--- a/lib/iris/tests/cluster/controller/test_bundle_store.py
+++ b/lib/iris/tests/cluster/controller/test_bundle_store.py
@@ -11,6 +11,8 @@ import pytest
 from fsspec.implementations.local import LocalFileSystem
 from iris.cluster.bundle import BundleStore
 
+_THREAD_TIMEOUT = 5
+
 
 @pytest.fixture
 def store(tmp_path):
@@ -122,7 +124,7 @@ def test_blocked_write_does_not_delay_unrelated_content(tmp_path, monkeypatch):
     def blocking_open(filesystem, path, mode="rb", *args, **kwargs):
         if "w" in mode and path.endswith(blocked_id):
             blocked_opened.set()
-            assert release_blocked.wait(timeout=5)
+            assert release_blocked.wait(timeout=_THREAD_TIMEOUT)
         elif "w" in mode:
             ready_opened.set()
         return original_open(filesystem, path, mode, *args, **kwargs)
@@ -130,14 +132,14 @@ def test_blocked_write_does_not_delay_unrelated_content(tmp_path, monkeypatch):
     monkeypatch.setattr(LocalFileSystem, "open", blocking_open)
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
         blocked = pool.submit(store.write, blocked_data)
-        assert blocked_opened.wait(timeout=5)
+        assert blocked_opened.wait(timeout=_THREAD_TIMEOUT)
         ready = pool.submit(store.write, ready_data)
         try:
-            assert ready_opened.wait(timeout=5)
-            assert ready.result(timeout=5) == hashlib.sha256(ready_data).hexdigest()
+            assert ready_opened.wait(timeout=_THREAD_TIMEOUT)
+            assert ready.result(timeout=_THREAD_TIMEOUT) == hashlib.sha256(ready_data).hexdigest()
         finally:
             release_blocked.set()
-        assert blocked.result(timeout=5) == blocked_id
+        assert blocked.result(timeout=_THREAD_TIMEOUT) == blocked_id
 
 
 def test_concurrent_writes_of_same_content_persist_once(tmp_path, monkeypatch):
@@ -155,16 +157,16 @@ def test_concurrent_writes_of_same_content_persist_once(tmp_path, monkeypatch):
             write_count += 1
             if write_count == 1:
                 first_opened.set()
-                assert release_first.wait(timeout=5)
+                assert release_first.wait(timeout=_THREAD_TIMEOUT)
         return original_open(filesystem, path, mode, *args, **kwargs)
 
     monkeypatch.setattr(LocalFileSystem, "open", blocking_open)
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
         first = pool.submit(store.write, data)
-        assert first_opened.wait(timeout=5)
+        assert first_opened.wait(timeout=_THREAD_TIMEOUT)
         second = pool.submit(store.write, data)
         release_first.set()
-        assert first.result(timeout=5) == content_hash
-        assert second.result(timeout=5) == content_hash
+        assert first.result(timeout=_THREAD_TIMEOUT) == content_hash
+        assert second.result(timeout=_THREAD_TIMEOUT) == content_hash
 
     assert write_count == 1

--- a/lib/iris/tests/cluster/controller/test_bundle_store.py
+++ b/lib/iris/tests/cluster/controller/test_bundle_store.py
@@ -3,7 +3,9 @@
 
 """Tests for controller-side BundleStore behavior."""
 
+import concurrent.futures
 import hashlib
+import threading
 
 import pytest
 from fsspec.implementations.local import LocalFileSystem
@@ -105,3 +107,64 @@ def test_write_when_cached_file_is_missing_restores_persistent_content(tmp_path)
     # Fresh store (cold cache) should still load from disk.
     store2 = BundleStore(storage_dir=storage_dir)
     assert store2.get(cid) == data
+
+
+def test_blocked_write_does_not_delay_unrelated_content(tmp_path, monkeypatch):
+    store = BundleStore(storage_dir=str(tmp_path / "bundles"))
+    blocked_data = b"blocked bundle"
+    ready_data = b"unrelated bundle"
+    blocked_id = hashlib.sha256(blocked_data).hexdigest()
+    blocked_opened = threading.Event()
+    release_blocked = threading.Event()
+    ready_opened = threading.Event()
+    original_open = LocalFileSystem.open
+
+    def blocking_open(filesystem, path, mode="rb", *args, **kwargs):
+        if "w" in mode and path.endswith(blocked_id):
+            blocked_opened.set()
+            assert release_blocked.wait(timeout=5)
+        elif "w" in mode:
+            ready_opened.set()
+        return original_open(filesystem, path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(LocalFileSystem, "open", blocking_open)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        blocked = pool.submit(store.write, blocked_data)
+        assert blocked_opened.wait(timeout=5)
+        ready = pool.submit(store.write, ready_data)
+        try:
+            assert ready_opened.wait(timeout=5)
+            assert ready.result(timeout=5) == hashlib.sha256(ready_data).hexdigest()
+        finally:
+            release_blocked.set()
+        assert blocked.result(timeout=5) == blocked_id
+
+
+def test_concurrent_writes_of_same_content_persist_once(tmp_path, monkeypatch):
+    store = BundleStore(storage_dir=str(tmp_path / "bundles"))
+    data = b"shared bundle"
+    content_hash = hashlib.sha256(data).hexdigest()
+    first_opened = threading.Event()
+    release_first = threading.Event()
+    original_open = LocalFileSystem.open
+    write_count = 0
+
+    def blocking_open(filesystem, path, mode="rb", *args, **kwargs):
+        nonlocal write_count
+        if "w" in mode and path.endswith(content_hash):
+            write_count += 1
+            if write_count == 1:
+                first_opened.set()
+                assert release_first.wait(timeout=5)
+        return original_open(filesystem, path, mode, *args, **kwargs)
+
+    monkeypatch.setattr(LocalFileSystem, "open", blocking_open)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(store.write, data)
+        assert first_opened.wait(timeout=5)
+        second = pool.submit(store.write, data)
+        release_first.set()
+        assert first.result(timeout=5) == content_hash
+        assert second.result(timeout=5) == content_hash
+
+    assert write_count == 1

--- a/lib/iris/tests/cluster/test_federation.py
+++ b/lib/iris/tests/cluster/test_federation.py
@@ -143,7 +143,7 @@ class _LaunchConnection(_StubConnection):
             assert self.release.wait(timeout=5)
         return controller_pb2.Controller.LaunchJobResponse(job_id=request.name)
 
-    def federation_sync(self, request):
+    def federation_sync(self, _request):
         self.synced.set()
         return controller_pb2.Controller.FederationSyncResponse()
 
@@ -168,7 +168,7 @@ class _SelectiveLaunchConnection(_StubConnection):
             self.ready_launched.set()
         return controller_pb2.Controller.LaunchJobResponse(job_id=request.name)
 
-    def federation_sync(self, request):
+    def federation_sync(self, _request):
         self.synced.set()
         return controller_pb2.Controller.FederationSyncResponse()
 
@@ -187,11 +187,11 @@ class _PendingHandoffStore:
     def pending_cancels(self):
         return []
 
-    def read_cursor(self, peer_id: str) -> str:
+    def read_cursor(self, _peer_id: str) -> str:
         return ""
 
     def apply_sync_batch(self, peer_id, deltas, *, next_cursor, cursor_stale, endpoints):
-        pass
+        del peer_id, deltas, next_cursor, cursor_stale, endpoints
 
 
 def _peer(peer_id: str, connection: _StubConnection) -> FederationPeer:

--- a/lib/iris/tests/cluster/test_federation.py
+++ b/lib/iris/tests/cluster/test_federation.py
@@ -8,8 +8,6 @@ live backends, the ListPeers view, and the submit router's decision matrix
 (prefer-local, hand off when locally infeasible, explicit ``cluster`` pin).
 """
 
-import threading
-
 import pydantic
 import pytest
 from iris.cluster.backends.rpc.backend import EXEC_IN_CONTAINER_MAX_TIMEOUT
@@ -20,8 +18,6 @@ from iris.cluster.federation.availability import AVAILABILITY_METRIC_VERSION
 from iris.cluster.federation.manager import FederationManager
 from iris.cluster.federation.peer import FederationPeer, build_peers
 from iris.cluster.federation.router import PeerRouter, RoutingRequest, SubmitDisposition
-from iris.cluster.federation.store import HandoffSpec
-from iris.cluster.types import JobName
 from iris.managed_thread import get_thread_container, thread_container_scope
 from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Duration, ExponentialBackoff
@@ -125,73 +121,6 @@ class _StubConnection:
 
     def shutdown(self) -> None:
         self.shutdown_count += 1
-
-
-class _LaunchConnection(_StubConnection):
-    def __init__(self, *, blocked: threading.Event | None = None, release: threading.Event | None = None):
-        super().__init__(())
-        self.blocked = blocked
-        self.release = release
-        self.launched = threading.Event()
-        self.synced = threading.Event()
-
-    def launch_job(self, request):
-        self.launched.set()
-        if self.blocked is not None:
-            self.blocked.set()
-            assert self.release is not None
-            assert self.release.wait(timeout=5)
-        return controller_pb2.Controller.LaunchJobResponse(job_id=request.name)
-
-    def federation_sync(self, _request):
-        self.synced.set()
-        return controller_pb2.Controller.FederationSyncResponse()
-
-
-class _SelectiveLaunchConnection(_StubConnection):
-    def __init__(self, blocked_job: JobName, ready_job: JobName, release: threading.Event):
-        super().__init__(())
-        self.blocked_job = blocked_job
-        self.ready_job = ready_job
-        self.release = release
-        self.blocked = threading.Event()
-        self.ready_launched = threading.Event()
-        self.synced = threading.Event()
-
-    def launch_job(self, request):
-        job = JobName.from_wire(request.name)
-        if job == self.blocked_job:
-            self.blocked.set()
-            assert self.release.wait(timeout=5)
-        else:
-            assert job == self.ready_job
-            self.ready_launched.set()
-        return controller_pb2.Controller.LaunchJobResponse(job_id=request.name)
-
-    def federation_sync(self, _request):
-        self.synced.set()
-        return controller_pb2.Controller.FederationSyncResponse()
-
-
-class _PendingHandoffStore:
-    def __init__(self, specs: list[HandoffSpec]):
-        self.specs = specs
-        self.delivered: set[JobName] = set()
-
-    def pending_handoffs(self) -> list[HandoffSpec]:
-        return [spec for spec in self.specs if spec.local_job_id not in self.delivered]
-
-    def mark_handed_off(self, local_job_id: JobName) -> None:
-        self.delivered.add(local_job_id)
-
-    def pending_cancels(self):
-        return []
-
-    def read_cursor(self, _peer_id: str) -> str:
-        return ""
-
-    def apply_sync_batch(self, peer_id, deltas, *, next_cursor, cursor_stale, endpoints):
-        del peer_id, deltas, next_cursor, cursor_stale, endpoints
 
 
 def _peer(peer_id: str, connection: _StubConnection) -> FederationPeer:
@@ -326,102 +255,6 @@ def test_heartbeat_loop_refreshes_backends_and_stop_releases_connections():
         finally:
             manager.stop()
     assert connection.shutdown_count == 1
-
-
-def test_sync_loop_delivers_to_ready_peer_while_another_peer_is_blocked():
-    slow_started = threading.Event()
-    release_slow = threading.Event()
-    slow_connection = _LaunchConnection(blocked=slow_started, release=release_slow)
-    ready_connection = _LaunchConnection()
-    slow_job = JobName.root("user", "slow")
-    ready_job = JobName.root("user", "ready")
-    store = _PendingHandoffStore(
-        [
-            HandoffSpec(
-                local_job_id=slow_job,
-                peer_id="slow",
-                owner_principal="user",
-                submitting_user="user",
-                request=controller_pb2.Controller.LaunchJobRequest(name=slow_job.to_wire()),
-            ),
-            HandoffSpec(
-                local_job_id=ready_job,
-                peer_id="ready",
-                owner_principal="user",
-                submitting_user="user",
-                request=controller_pb2.Controller.LaunchJobRequest(name=ready_job.to_wire()),
-            ),
-        ]
-    )
-    with thread_container_scope() as threads:
-        manager = FederationManager(
-            [_peer("slow", slow_connection), _peer("ready", ready_connection)],
-            threads=threads,
-            store=store,
-            cluster_id="parent",
-        )
-        manager.start()
-        try:
-            assert slow_started.wait(timeout=5)
-            assert ready_connection.launched.wait(timeout=3)
-            assert ready_connection.synced.wait(timeout=3)
-            release_slow.set()
-            assert ExponentialBackoff(initial=0.01, maximum=0.1).wait_until(
-                lambda: store.delivered == {slow_job, ready_job}, timeout=Duration.from_seconds(3)
-            )
-        finally:
-            release_slow.set()
-            manager.stop()
-
-    assert store.delivered == {slow_job, ready_job}
-
-
-def test_sync_loop_delivers_same_peer_jobs_and_status_while_one_launch_is_blocked():
-    release_slow = threading.Event()
-    slow_job = JobName.root("user", "slow")
-    ready_job = JobName.root("user", "ready")
-    connection = _SelectiveLaunchConnection(slow_job, ready_job, release_slow)
-    store = _PendingHandoffStore(
-        [
-            HandoffSpec(
-                local_job_id=slow_job,
-                peer_id="cw",
-                owner_principal="user",
-                submitting_user="user",
-                request=controller_pb2.Controller.LaunchJobRequest(name=slow_job.to_wire()),
-            ),
-            HandoffSpec(
-                local_job_id=ready_job,
-                peer_id="cw",
-                owner_principal="user",
-                submitting_user="user",
-                request=controller_pb2.Controller.LaunchJobRequest(name=ready_job.to_wire()),
-            ),
-        ]
-    )
-    with thread_container_scope() as threads:
-        manager = FederationManager(
-            [_peer("cw", connection)],
-            threads=threads,
-            store=store,
-            cluster_id="parent",
-            sync_interval=Duration.from_seconds(0.02),
-        )
-        manager.start()
-        try:
-            assert connection.blocked.wait(timeout=5)
-            assert connection.ready_launched.wait(timeout=3)
-            connection.synced.clear()
-            assert connection.synced.wait(timeout=3)
-            release_slow.set()
-            assert ExponentialBackoff(initial=0.01, maximum=0.1).wait_until(
-                lambda: store.delivered == {slow_job, ready_job}, timeout=Duration.from_seconds(3)
-            )
-        finally:
-            release_slow.set()
-            manager.stop()
-
-    assert store.delivered == {slow_job, ready_job}
 
 
 def test_manager_without_peers_is_inert():

--- a/lib/iris/tests/cluster/test_federation.py
+++ b/lib/iris/tests/cluster/test_federation.py
@@ -8,6 +8,8 @@ live backends, the ListPeers view, and the submit router's decision matrix
 (prefer-local, hand off when locally infeasible, explicit ``cluster`` pin).
 """
 
+import threading
+
 import pydantic
 import pytest
 from iris.cluster.backends.rpc.backend import EXEC_IN_CONTAINER_MAX_TIMEOUT
@@ -18,6 +20,8 @@ from iris.cluster.federation.availability import AVAILABILITY_METRIC_VERSION
 from iris.cluster.federation.manager import FederationManager
 from iris.cluster.federation.peer import FederationPeer, build_peers
 from iris.cluster.federation.router import PeerRouter, RoutingRequest, SubmitDisposition
+from iris.cluster.federation.store import HandoffSpec
+from iris.cluster.types import JobName
 from iris.managed_thread import get_thread_container, thread_container_scope
 from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Duration, ExponentialBackoff
@@ -121,6 +125,73 @@ class _StubConnection:
 
     def shutdown(self) -> None:
         self.shutdown_count += 1
+
+
+class _LaunchConnection(_StubConnection):
+    def __init__(self, *, blocked: threading.Event | None = None, release: threading.Event | None = None):
+        super().__init__(())
+        self.blocked = blocked
+        self.release = release
+        self.launched = threading.Event()
+        self.synced = threading.Event()
+
+    def launch_job(self, request):
+        self.launched.set()
+        if self.blocked is not None:
+            self.blocked.set()
+            assert self.release is not None
+            assert self.release.wait(timeout=5)
+        return controller_pb2.Controller.LaunchJobResponse(job_id=request.name)
+
+    def federation_sync(self, request):
+        self.synced.set()
+        return controller_pb2.Controller.FederationSyncResponse()
+
+
+class _SelectiveLaunchConnection(_StubConnection):
+    def __init__(self, blocked_job: JobName, ready_job: JobName, release: threading.Event):
+        super().__init__(())
+        self.blocked_job = blocked_job
+        self.ready_job = ready_job
+        self.release = release
+        self.blocked = threading.Event()
+        self.ready_launched = threading.Event()
+        self.synced = threading.Event()
+
+    def launch_job(self, request):
+        job = JobName.from_wire(request.name)
+        if job == self.blocked_job:
+            self.blocked.set()
+            assert self.release.wait(timeout=5)
+        else:
+            assert job == self.ready_job
+            self.ready_launched.set()
+        return controller_pb2.Controller.LaunchJobResponse(job_id=request.name)
+
+    def federation_sync(self, request):
+        self.synced.set()
+        return controller_pb2.Controller.FederationSyncResponse()
+
+
+class _PendingHandoffStore:
+    def __init__(self, specs: list[HandoffSpec]):
+        self.specs = specs
+        self.delivered: set[JobName] = set()
+
+    def pending_handoffs(self) -> list[HandoffSpec]:
+        return [spec for spec in self.specs if spec.local_job_id not in self.delivered]
+
+    def mark_handed_off(self, local_job_id: JobName) -> None:
+        self.delivered.add(local_job_id)
+
+    def pending_cancels(self):
+        return []
+
+    def read_cursor(self, peer_id: str) -> str:
+        return ""
+
+    def apply_sync_batch(self, peer_id, deltas, *, next_cursor, cursor_stale, endpoints):
+        pass
 
 
 def _peer(peer_id: str, connection: _StubConnection) -> FederationPeer:
@@ -255,6 +326,102 @@ def test_heartbeat_loop_refreshes_backends_and_stop_releases_connections():
         finally:
             manager.stop()
     assert connection.shutdown_count == 1
+
+
+def test_sync_loop_delivers_to_ready_peer_while_another_peer_is_blocked():
+    slow_started = threading.Event()
+    release_slow = threading.Event()
+    slow_connection = _LaunchConnection(blocked=slow_started, release=release_slow)
+    ready_connection = _LaunchConnection()
+    slow_job = JobName.root("user", "slow")
+    ready_job = JobName.root("user", "ready")
+    store = _PendingHandoffStore(
+        [
+            HandoffSpec(
+                local_job_id=slow_job,
+                peer_id="slow",
+                owner_principal="user",
+                submitting_user="user",
+                request=controller_pb2.Controller.LaunchJobRequest(name=slow_job.to_wire()),
+            ),
+            HandoffSpec(
+                local_job_id=ready_job,
+                peer_id="ready",
+                owner_principal="user",
+                submitting_user="user",
+                request=controller_pb2.Controller.LaunchJobRequest(name=ready_job.to_wire()),
+            ),
+        ]
+    )
+    with thread_container_scope() as threads:
+        manager = FederationManager(
+            [_peer("slow", slow_connection), _peer("ready", ready_connection)],
+            threads=threads,
+            store=store,
+            cluster_id="parent",
+        )
+        manager.start()
+        try:
+            assert slow_started.wait(timeout=5)
+            assert ready_connection.launched.wait(timeout=3)
+            assert ready_connection.synced.wait(timeout=3)
+            release_slow.set()
+            assert ExponentialBackoff(initial=0.01, maximum=0.1).wait_until(
+                lambda: store.delivered == {slow_job, ready_job}, timeout=Duration.from_seconds(3)
+            )
+        finally:
+            release_slow.set()
+            manager.stop()
+
+    assert store.delivered == {slow_job, ready_job}
+
+
+def test_sync_loop_delivers_same_peer_jobs_and_status_while_one_launch_is_blocked():
+    release_slow = threading.Event()
+    slow_job = JobName.root("user", "slow")
+    ready_job = JobName.root("user", "ready")
+    connection = _SelectiveLaunchConnection(slow_job, ready_job, release_slow)
+    store = _PendingHandoffStore(
+        [
+            HandoffSpec(
+                local_job_id=slow_job,
+                peer_id="cw",
+                owner_principal="user",
+                submitting_user="user",
+                request=controller_pb2.Controller.LaunchJobRequest(name=slow_job.to_wire()),
+            ),
+            HandoffSpec(
+                local_job_id=ready_job,
+                peer_id="cw",
+                owner_principal="user",
+                submitting_user="user",
+                request=controller_pb2.Controller.LaunchJobRequest(name=ready_job.to_wire()),
+            ),
+        ]
+    )
+    with thread_container_scope() as threads:
+        manager = FederationManager(
+            [_peer("cw", connection)],
+            threads=threads,
+            store=store,
+            cluster_id="parent",
+            sync_interval=Duration.from_seconds(0.02),
+        )
+        manager.start()
+        try:
+            assert connection.blocked.wait(timeout=5)
+            assert connection.ready_launched.wait(timeout=3)
+            connection.synced.clear()
+            assert connection.synced.wait(timeout=3)
+            release_slow.set()
+            assert ExponentialBackoff(initial=0.01, maximum=0.1).wait_until(
+                lambda: store.delivered == {slow_job, ready_job}, timeout=Duration.from_seconds(3)
+            )
+        finally:
+            release_slow.set()
+            manager.stop()
+
+    assert store.delivered == {slow_job, ready_job}
 
 
 def test_manager_without_peers_is_inert():


### PR DESCRIPTION
Run one federation sync loop per peer. Each pass delivers pending handoffs and cancels before pulling status, with same-peer handoffs concurrent up to the existing per-cycle cap. During the cw-us-east-08a incident, one `LaunchJob` took 120.977 seconds and queued three later requests; those requests were accepted within four seconds after the first returned. A slow launch can delay that peer's status sync, but independent peer loops prevent it from holding unrelated peer work.

Serialize `BundleStore` persistence by content hash and protect the in-memory cache separately. Remote I/O for different bundles can proceed independently, while concurrent writes of identical content remain coalesced.

This change limits the effect of slow object storage but does not restore provider capacity. Storage-heavy jobs should remain paused until writes to `marin-us-east-02a` succeed.

Incident: https://echo.oa.dev/wiki/147

Related: #8162
