### PR TITLE
[zephyr] Bound scatter Parquet row groups

### DIFF
--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -107,6 +107,10 @@ _PROGRESS_LOG_INTERVAL_SECONDS = 60.0
 _POLARS_STREAMING_CHUNK_SIZE = 10000
 # Maximum run files that Polars merges at one time during an external sort.
 _EXTERNAL_SORT_MAX_MERGE_FAN_IN = 32
+# Bound Parquet footer size when a shuffle has thousands of target shards. One
+# row group per target gives ideal predicate pruning, but makes every reducer
+# read multi-megabyte footers from every mapper chunk before it can read data.
+_SCATTER_MAX_ROW_GROUPS_PER_CHUNK = 512
 
 # Helper column names injected by _items_to_dataframe and stripped before
 # writing to disk.  Both are internal implementation details; user schemas must
@@ -526,8 +530,9 @@ class ScatterWriter:
     keeps the interface ready for DataFrame/RecordBatch-native pipelines.
 
     Each flush writes a single ``c{chunk:04d}.parquet`` file sorted by
-    ``[_SHARD_COL, _SORT_KEY_COL]`` with row groups sized so Polars predicate
-    pushdown skips non-target row groups on the read side.
+    ``[_SHARD_COL, _SORT_KEY_COL]`` with bounded, target-local row groups so
+    Polars predicate pushdown skips most unrelated data without creating
+    unbounded Parquet footers.
 
     Flushing is estimated-size-based: when the sum of ``DataFrame.estimated_size()``
     across buffered frames exceeds ``_SCATTER_FLUSH_THRESHOLD * _ESTIMATED_SIZE_CORRECTION_FACTOR``
@@ -608,10 +613,12 @@ class ScatterWriter:
         for shard_val, nbytes in shard_sizes.iter_rows():
             self._shard_bytes[shard_val] += int(nbytes)
 
-        # Size row groups so each target shard fits in roughly one row group,
-        # enabling Polars predicate pushdown to skip non-matching groups.
+        # Keep target shards local to as few row groups as practical so Polars
+        # predicate pushdown can skip unrelated data. Cap the group count because
+        # every reducer must read every chunk footer before applying that filter.
         num_targets = buffer_sorted[_SHARD_COL].n_unique()
-        row_group_size = max(1, len(buffer_sorted) // num_targets)
+        num_row_groups = min(num_targets, _SCATTER_MAX_ROW_GROUPS_PER_CHUNK)
+        row_group_size = max(1, math.ceil(len(buffer_sorted) / num_row_groups))
         chunk_path = f"{self._data_path}c{self._n_chunks_written:04d}.parquet"
         # Ideally we'd call write_parquet directly with the GCS path, but it occationally fails with a generic error.
         buf = io.BytesIO()

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 import cloudpickle
 import polars as pl
+import pyarrow.parquet as pq
 import pytest
 from iris.env_resources import TaskResources
 from zephyr.external_sort import external_sort_merge
@@ -22,6 +23,7 @@ from zephyr.runners import _InProcessWorkerContext
 from zephyr.shard_keys import deterministic_hash
 from zephyr.shuffle import (
     _PAYLOAD_COL,
+    _SCATTER_MAX_ROW_GROUPS_PER_CHUNK,
     _SHARD_COL,
     _SORT_KEY_COL,
     ScatterReader,
@@ -386,6 +388,32 @@ def test_scatter_byte_budget_preserves_all_items(tmp_path):
         recovered.extend(_read_shard(shard))
 
     assert sorted(recovered, key=lambda x: x["v"]) == sorted(items, key=lambda x: x["v"])
+
+
+def test_scatter_bounds_parquet_row_groups(tmp_path):
+    num_targets = 1024
+    data_path = f"{tmp_path}/shard-0000/scatter/"
+    frame = pl.DataFrame(
+        {
+            _PAYLOAD_COL: pl.Series(
+                [cloudpickle.dumps({"k": target}) for target in range(num_targets)],
+                dtype=pl.Binary,
+            ),
+            _SHARD_COL: pl.Series(range(num_targets), dtype=pl.Int32),
+            _SORT_KEY_COL: [
+                OrderedDict([("key", target.to_bytes(4, "big")), ("sort_value", None)]) for target in range(num_targets)
+            ],
+        }
+    )
+    writer = ScatterWriter(data_path=data_path, key_fn=_key, source_shard=0)
+    writer.write(frame)
+    writer.close()
+
+    parquet = pq.ParquetFile(f"{data_path}c0000.parquet")
+    assert parquet.metadata.num_row_groups <= _SCATTER_MAX_ROW_GROUPS_PER_CHUNK
+
+    reader = ScatterReader(files=[(data_path, [f"{data_path}c0000.parquet"])], target_shard=513, avg_item_bytes=1)
+    assert _read_shard(reader) == [{"k": 513}]
 
 
 def test_scatter_auto_flush_uses_task_memory_budget(tmp_path):


### PR DESCRIPTION
Cap each shuffle chunk at 512 Parquet row groups. Rows remain ordered by
destination shard so predicate pushdown can skip most unrelated data. Fixed
64 MiB row groups would make each reducer scan many other target shards.

The 8,192-way fuzzy verification wrote a representative 281.2 MB chunk with
8,192 row groups and a 5,617,004-byte footer. Every reducer collected schemas
for 8,230 chunks, multiplying footer reads to about 46 GB before payload reads.
Several reducers then failed in Polars with `parquet: File out of
specification: Unexpected struct field type 15`. The retained object now
parses in Polars and PyArrow, so the source of the transient invalid Thrift
bytes remains unknown.

The failed run contained the fuzzy-dedup changes through `0214eec05b`, but its
physical plan still used 8,192 shards and did not contain the 512-shard bulk
verification change in `2283528709`. The new bound covers generic Zephyr jobs
whose target fanout exceeds that pipeline-specific limit.

Incident: https://echo.oa.dev/wiki/150
