### PR TITLE
[eval] Resume Harbor evaluations from durable results

### DIFF
--- a/docs/tutorials/run-lm-evals.md
+++ b/docs/tutorials/run-lm-evals.md
@@ -31,7 +31,7 @@ uv run python -m experiments.evaluation.cli launch \
 
 Run the resolved plan before submitting an unfamiliar model or suite. `--dry-run` prints the model
 location, serving backend, accelerator, target cluster or region, priority band, task names, and
-records prefix:
+records and results paths:
 
 ```bash
 uv run python -m experiments.evaluation.cli launch \
@@ -169,6 +169,19 @@ uv run python -m experiments.evaluation.cli launch \
 
 `agentic` runs seven full Harbor datasets and can consume substantial Daytona and inference
 capacity. Use `tb2-lite`, `swebench-lite`, `aime-smoke`, or `--limit N` for validation runs.
+
+Resume an interrupted Harbor evaluation from its existing results tree:
+
+```bash
+uv run python -m experiments.evaluation.cli launch \
+  --model qwen3-32b \
+  --evals tb2 \
+  --resume-results-path s3://marin-us-east-02a/marin/evals/<run-id>/results \
+  --no-wait
+```
+
+The resume option accepts exactly one Harbor evaluation. Marin verifies the dataset identity before
+submission; Harbor keeps compatible completed trials and applies its resume policy to the rest.
 
 Run one Grug/OpenCode trial with the model and agent policy registered for that benchmark:
 

--- a/experiments/evaluation/README.md
+++ b/experiments/evaluation/README.md
@@ -175,6 +175,19 @@ all selected YAML and JSON files against Marin's pinned Harbor `JobConfig` befor
 File-backed launches support one agent and one dataset; multiple agents, multiple datasets, and
 explicit `tasks` are rejected.
 
+Resume an interrupted Harbor evaluation by selecting its existing results root:
+
+```bash
+uv run python -m experiments.evaluation.cli launch \
+  --model qwen3-8b \
+  --evals tb2 \
+  --resume-results-path s3://marin-us-east-02a/marin/evals/<run-id>/results
+```
+
+`--resume-results-path` requires exactly one Harbor evaluation. Marin verifies that the root belongs
+to the selected dataset before submitting; Harbor retains compatible completed trials and schedules
+the remaining trials according to its resume policy.
+
 The pinned subprocess returns deterministic policy JSON, a SHA-256 digest, and dataset/agent/environment
 metadata. Marin treats the JSON as opaque. At execution it supplies a separate overlay for `job_name`,
 `jobs_dir`, the served model, endpoint, materialized dataset path, model-catalog kwargs, and `--limit`.

--- a/experiments/evaluation/cli.py
+++ b/experiments/evaluation/cli.py
@@ -76,7 +76,8 @@ def _print_plan(spec: LaunchSpec, batch: EvaluationBatch) -> None:
             f"backend={batch.model.serve.backend.value}  accel={batch.accelerator.label}  "
             f"region_or_cluster={batch.accelerator.target_cluster or batch.accelerator.region}  "
             f"tasks={tasks}  "
-            f"records={batch.records_prefix}"
+            f"records={batch.records_prefix}  "
+            f"results={evaluation.identity.output_dir}"
         )
 
 
@@ -126,6 +127,11 @@ def cli() -> None:
     help="Human version label for this launch, e.g. '2026.07.20' or 'rl-fix-sweep'.",
 )
 @click.option("--description", default=None, help="Free-text note on why this launch was run.")
+@click.option(
+    "--resume-results-path",
+    default=None,
+    help="Existing object-store results path for a single Harbor evaluation.",
+)
 @click.option("--no-wait", is_flag=True, help="Submit and return without waiting for results.")
 @click.option("--dry-run", is_flag=True, help="Print the resolved plan without submitting.")
 @click.option(
@@ -155,6 +161,7 @@ def launch(
     limit: int | None,
     version: str | None,
     description: str | None,
+    resume_results_path: str | None,
     no_wait: bool,
     dry_run: bool,
     records_prefix: str | None,
@@ -197,11 +204,15 @@ def launch(
         priority_band=(job_pb2.PRIORITY_BAND_INHERIT if priority is None else priority_band_value(priority)),
         version=version,
         description=description,
+        resume_results_path=resume_results_path,
     )
     try:
         batch = prepare_evaluation_batch(spec)
     except ValueError as exc:
-        param_hint = "--evalchemy-config/--harbor-config" if evalchemy_config or harbor_config else "--evals"
+        if resume_results_path is not None:
+            param_hint = "--resume-results-path"
+        else:
+            param_hint = "--evalchemy-config/--harbor-config" if evalchemy_config or harbor_config else "--evals"
         raise click.BadParameter(str(exc), param_hint=param_hint) from exc
     if dry_run:
         _print_plan(spec, batch)

--- a/experiments/evaluation/launch.py
+++ b/experiments/evaluation/launch.py
@@ -23,7 +23,7 @@ from marin.evaluation.harbor.driver_config import (
     ValidatedHarborConfig,
     preflight_harbor_configs,
 )
-from marin.evaluation.harbor.runner import canonical_served_name
+from marin.evaluation.harbor.runner import HarborExecutor, canonical_served_name, validate_harbor_resume_root
 from marin.evaluation.hardware import AcceleratorChoice, Platform
 from marin.evaluation.model_config import ModelConfig
 from marin.evaluation.records import (
@@ -72,6 +72,7 @@ class LaunchSpec:
     priority_band: int
     version: str | None = None
     description: str | None = None
+    resume_results_path: str | None = None
 
 
 def _git_sha() -> str:
@@ -201,6 +202,12 @@ def build_evaluation_batch(
             raise ValueError("--federated_cluster requires a GPU accelerator")
         accelerator = replace(accelerator, target_cluster=spec.federated_cluster)
     definitions = _resolve_definitions(_evaluation_definitions(spec), model, spec.limit)
+    if spec.resume_results_path is not None:
+        if len(definitions) != 1 or not isinstance(definitions[0][1].executor, HarborExecutor):
+            raise ValueError("--resume-results-path requires exactly one Harbor evaluation")
+        if "://" not in spec.resume_results_path:
+            raise ValueError("--resume-results-path must be an object-store path")
+        validate_harbor_resume_root(spec.resume_results_path, definitions[0][1].executor.config)
     records_prefix = records_prefix_for(accelerator, spec)
     created_at = datetime.now(UTC).isoformat()
     evaluations: list[Evaluation] = []
@@ -211,7 +218,7 @@ def build_evaluation_batch(
                 raise ValueError(f"evaluations declare conflicting secret specifications for {name}")
             secret_env[name] = spec_value
         run_id = _run_id(model.name, eval_key)
-        output_dir = prefix_join(records_prefix, f"{run_id}/results")
+        output_dir = spec.resume_results_path or prefix_join(records_prefix, f"{run_id}/results")
         evaluations.append(
             Evaluation(
                 identity=EvaluationIdentity(

--- a/lib/marin/src/marin/evaluation/harbor/runner.py
+++ b/lib/marin/src/marin/evaluation/harbor/runner.py
@@ -34,7 +34,7 @@ from marin.evaluation.harbor.driver_config import (
     ValidatedHarborConfig,
     run_harbor_driver,
 )
-from marin.evaluation.records import RunStatus, TaskCoverage
+from marin.evaluation.records import RECORD_FILE, RunStatus, TaskCoverage
 from marin.evaluation.runner import EvaluationError, EvaluationOutcome
 from marin.inference.iris import RemoteInferenceSession
 from marin.inference.types import RunningModel
@@ -227,6 +227,21 @@ def validate_harbor_resume_root(output_dir: str, config: ValidatedHarborConfig) 
         identity = _read_resume_json(identity_path, output_dir)
         if identity != _resume_identity(config):
             _raise_resume_identity_mismatch(output_dir, config, f"declares {identity!r}")
+        return
+
+    record_path = root.parent / RECORD_FILE
+    if record_path.exists():
+        record = _read_resume_json(record_path, output_dir)
+        evaluation = record.get("eval") if isinstance(record, Mapping) else None
+        harbor = evaluation.get("harbor") if isinstance(evaluation, Mapping) else None
+        record_dataset = harbor.get("dataset") if isinstance(harbor, Mapping) else None
+        record_results_path = record.get("results_path") if isinstance(record, Mapping) else None
+        if record_dataset != config.record_dataset or record_results_path != str(root):
+            _raise_resume_identity_mismatch(
+                output_dir,
+                config,
+                f"has sibling record for dataset {record_dataset!r} and results path {record_results_path!r}",
+            )
         return
 
     result_path = root / _HARBOR_RESULT_FILE

--- a/lib/marin/src/marin/evaluation/harbor/runner.py
+++ b/lib/marin/src/marin/evaluation/harbor/runner.py
@@ -51,6 +51,10 @@ _HARBOR_JOBS_SUBDIR = "harbor_jobs"
 _TRIAL_READ_WORKERS = 16
 _JOB_DATASET_LENGTH = 32
 _JOB_DIGEST_LENGTH = 12
+_HARBOR_RESULT_FILE = "harbor_result.json"
+_RESUME_IDENTITY_FILE = "harbor_resume_identity.json"
+_RESUME_IDENTITY_SCHEMA_VERSION = 1
+_JOB_PREFIX = "harbor_"
 
 # The reward at or above which a Harbor trial counts as solved (rewards are typically 0.0 / 1.0; the
 # margin tolerates float noise).
@@ -159,12 +163,28 @@ def canonical_served_name(name: str) -> str:
     return candidate
 
 
+def _safe_job_dataset(dataset: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_-]", "_", dataset)
+
+
+def _job_dataset_prefix(dataset: str) -> str:
+    return f"{_JOB_PREFIX}{_safe_job_dataset(dataset)[:_JOB_DATASET_LENGTH]}_"
+
+
+def _dataset_from_job_name(job_name: str) -> str | None:
+    if not job_name.startswith(_JOB_PREFIX):
+        return None
+    dataset, separator, digest = job_name.removeprefix(_JOB_PREFIX).rpartition("_")
+    if separator and len(digest) == _JOB_DIGEST_LENGTH and all(character in "0123456789abcdef" for character in digest):
+        return dataset
+    return None
+
+
 def _job_name(dataset: str, identity: tuple[object, ...]) -> str:
     """A deterministic Harbor job name so a re-run resumes the previous job's completed trials."""
     key = "|".join(str(value) for value in identity)
     digest = hashlib.sha256(key.encode()).hexdigest()[:_JOB_DIGEST_LENGTH]
-    safe = re.sub(r"[^A-Za-z0-9_-]", "_", dataset)[:_JOB_DATASET_LENGTH]
-    return f"harbor_{safe}_{digest}"
+    return f"{_job_dataset_prefix(dataset)}{digest}"
 
 
 def _jobs_dir(output_dir: str) -> StoragePath:
@@ -175,6 +195,75 @@ def _jobs_dir(output_dir: str) -> StoragePath:
 def _job_dir(output_dir: str, job_name: str) -> StoragePath:
     """The durable tree for one job: ``output_dir/harbor_jobs/<job_name>`` (Harbor appends the name)."""
     return _jobs_dir(output_dir) / job_name
+
+
+def _resume_identity(config: ValidatedHarborConfig) -> dict[str, object]:
+    return {
+        "schema_version": _RESUME_IDENTITY_SCHEMA_VERSION,
+        "dataset": config.record_dataset,
+    }
+
+
+def _read_resume_json(path: StoragePath, output_dir: str) -> object:
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Harbor results root {output_dir!r} has an unreadable {path.name}") from exc
+
+
+def _raise_resume_identity_mismatch(output_dir: str, config: ValidatedHarborConfig, existing: str) -> None:
+    raise ValueError(
+        f"Harbor results root {output_dir!r} {existing}; this launch requires dataset "
+        f"{config.record_dataset!r}. Use the Harbor config that created this root, or omit "
+        "--resume-results-path to start a clean run."
+    )
+
+
+def validate_harbor_resume_root(output_dir: str, config: ValidatedHarborConfig) -> None:
+    """Verify that an existing results root belongs to the planned Harbor dataset."""
+    root = StoragePath.parse(output_dir)
+    identity_path = root / _RESUME_IDENTITY_FILE
+    if identity_path.exists():
+        identity = _read_resume_json(identity_path, output_dir)
+        if identity != _resume_identity(config):
+            _raise_resume_identity_mismatch(output_dir, config, f"declares {identity!r}")
+        return
+
+    result_path = root / _HARBOR_RESULT_FILE
+    completed_dataset: object | None = None
+    if result_path.exists():
+        result = _read_resume_json(result_path, output_dir)
+        completed_dataset = result.get("dataset") if isinstance(result, Mapping) else None
+        if completed_dataset != config.record_dataset:
+            _raise_resume_identity_mismatch(output_dir, config, f"contains completed dataset {completed_dataset!r}")
+
+    job_configs = tuple((_jobs_dir(output_dir) / "*/config.json").glob())
+    safe_dataset = _safe_job_dataset(config.record_dataset)
+    if len(safe_dataset) > _JOB_DATASET_LENGTH and completed_dataset is None:
+        raise ValueError(
+            f"Harbor results root {output_dir!r} predates exact dataset identity metadata, and dataset "
+            f"{config.record_dataset!r} is too long to verify from its job names. Omit "
+            "--resume-results-path to start a clean run."
+        )
+    job_names = tuple(path.parent.name for path in job_configs)
+    if not job_names and completed_dataset is None:
+        raise ValueError(
+            f"Harbor results root {output_dir!r} has no dataset identity or resumable jobs. "
+            "Choose the original results root, or omit --resume-results-path to start a clean run."
+        )
+    incompatible = tuple(name for name in job_names if _dataset_from_job_name(name) != safe_dataset)
+    if incompatible:
+        _raise_resume_identity_mismatch(output_dir, config, f"contains incompatible jobs {incompatible!r}")
+
+
+def _bind_harbor_results_root(output_dir: str, config: ValidatedHarborConfig) -> None:
+    """Persist dataset identity, upgrading a compatible existing root on first use."""
+    root = StoragePath.parse(output_dir)
+    identity_path = root / _RESUME_IDENTITY_FILE
+    if tuple((root / "*").glob()):
+        validate_harbor_resume_root(output_dir, config)
+    if not identity_path.exists():
+        identity_path.write_text(json.dumps(_resume_identity(config), indent=2))
 
 
 def _read_trial(result_file: StoragePath) -> HarborTrial:
@@ -371,7 +460,7 @@ def _run_harbor_job(
     trials = _read_trials(job_dir)
     archive_path = _write_archive(trials, dataset, output_dir)
     result = _aggregate(trials, dataset, archive_path, _attempted_trials(job_dir))
-    StoragePath(prefix_join(output_dir, "harbor_result.json")).write_text(
+    StoragePath(prefix_join(output_dir, _HARBOR_RESULT_FILE)).write_text(
         json.dumps(
             {
                 "dataset": result.dataset,
@@ -473,6 +562,7 @@ class HarborExecutor:
         driver_env: Mapping[str, str],
         inference_session: RemoteInferenceSession,
     ) -> HarborRunResult:
+        _bind_harbor_results_root(output_dir, self.config)
         dataset = self.config.record_dataset
         job_name = _job_name(
             dataset,

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -794,6 +794,53 @@ def test_launch_accepts_registry_ifeval_and_repeated_harbor_configs(tmp_path, mo
     assert "eval=second-policy" in result.output
 
 
+def test_launch_reuses_compatible_harbor_results_path(tmp_path, monkeypatch):
+    _install_fake_harbor_preflight(monkeypatch)
+    policy = _write_harbor_config(tmp_path / "aime-policy.yaml")
+    output_dir = "memory://existing-harbor-results"
+    (StoragePath(output_dir) / "harbor_jobs" / "harbor_aime_0123456789ab" / "config.json").write_text("{}")
+    monkeypatch.setattr("experiments.evaluation.launch._capability_origin", lambda _cluster: "https://iris.example")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "launch",
+            "--model",
+            "qwen3-8b",
+            "--harbor-config",
+            str(policy),
+            "--resume-results-path",
+            output_dir,
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert f"results={output_dir}" in result.output
+
+
+def test_launch_rejects_resume_for_multiple_evaluations(monkeypatch):
+    _install_fake_harbor_preflight(monkeypatch)
+    monkeypatch.setattr("experiments.evaluation.launch._capability_origin", lambda _cluster: "https://iris.example")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "launch",
+            "--model",
+            "qwen3-8b",
+            "--evals",
+            "aime-harbor,tb2",
+            "--resume-results-path",
+            "memory://existing-harbor-results",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "requires exactly one Harbor evaluation" in result.output
+
+
 def test_build_evaluation_batch_defaults_results_to_eval_root(monkeypatch):
     monkeypatch.setattr("experiments.evaluation.launch._capability_origin", lambda _cluster: "https://iris.example")
     spec = LaunchSpec(

--- a/tests/evaluation/test_harbor_runner.py
+++ b/tests/evaluation/test_harbor_runner.py
@@ -20,6 +20,7 @@ from marin.evaluation.harbor.runner import (
     HarborTrial,
     _read_trials,
     _write_archive,
+    validate_harbor_resume_root,
 )
 from marin.evaluation.records import RunStatus
 from marin.evaluation.runner import EvaluationError
@@ -454,6 +455,31 @@ def test_harbor_executor_passes_opaque_policy_and_runtime_overlay_to_driver(tmp_
     assert captured["env"]["DAYTONA_API_KEY"] == "daytona-key"
     assert "OPENAI_API_KEY" not in captured["env"]
     assert outcome.metrics[f"toy-{tmp_path.name}"]["accuracy"] == 1.0
+    assert json.loads((tmp_path / "harbor_resume_identity.json").read_text()) == {
+        "schema_version": 1,
+        "dataset": f"toy-{tmp_path.name}",
+    }
+
+
+def test_validate_harbor_resume_root_rejects_different_dataset(tmp_path):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    (output_dir / "harbor_resume_identity.json").write_text(
+        json.dumps({"schema_version": 1, "dataset": "other-dataset"})
+    )
+
+    with pytest.raises(ValueError, match="requires dataset 'aime'"):
+        validate_harbor_resume_root(str(output_dir), _validated_config(dataset_selector="aime"))
+
+
+def test_validate_harbor_resume_root_rejects_job_name_prefix_collision(tmp_path):
+    output_dir = tmp_path / "results"
+    job_dir = output_dir / "harbor_jobs" / "harbor_aime_extended_0123456789ab"
+    job_dir.mkdir(parents=True)
+    (job_dir / "config.json").write_text("{}")
+
+    with pytest.raises(ValueError, match="requires dataset 'aime'"):
+        validate_harbor_resume_root(str(output_dir), _validated_config(dataset_selector="aime"))
 
 
 def _harbor_executor(dataset: str) -> HarborExecutor:

--- a/tests/evaluation/test_harbor_runner.py
+++ b/tests/evaluation/test_harbor_runner.py
@@ -472,6 +472,22 @@ def test_validate_harbor_resume_root_rejects_different_dataset(tmp_path):
         validate_harbor_resume_root(str(output_dir), _validated_config(dataset_selector="aime"))
 
 
+def test_validate_harbor_resume_root_uses_legacy_run_record(tmp_path):
+    dataset = "hf://open-thoughts/OpenThoughts-TBLite"
+    output_dir = tmp_path / "run" / "results"
+    output_dir.mkdir(parents=True)
+    (output_dir.parent / "record.json").write_text(
+        json.dumps(
+            {
+                "results_path": str(output_dir),
+                "eval": {"mechanism": "harbor", "harbor": {"dataset": dataset}},
+            }
+        )
+    )
+
+    validate_harbor_resume_root(str(output_dir), _validated_config(dataset_selector=dataset))
+
+
 def test_validate_harbor_resume_root_rejects_job_name_prefix_collision(tmp_path):
     output_dir = tmp_path / "results"
     job_dir = output_dir / "harbor_jobs" / "harbor_aime_extended_0123456789ab"


### PR DESCRIPTION
Allow one Harbor evaluation launch to reuse an existing object-store results root. Marin validates the selected dataset against durable identity metadata, completed aggregates, or deterministic Harbor job names before submission. New result trees record exact dataset identity for later resumes.

Harbor retains compatible completed trials and applies its current resume policy to the remaining trials. This extracts the selective-resume seam from draft #7837.

Follow-up to #7789.
