### PR TITLE
[grug] Default ladder rungs to histogram QB quantile estimation

### DIFF
--- a/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
+++ b/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
@@ -520,7 +520,8 @@ def build_small_run(
     # at neutral loss (1.32% -> 1.25% at capacity factor 2.0) and +0.9% median tok/s.
     default=True,
     show_default=True,
-    help="Estimate the QB quantile with the histogram estimator instead of the top-k mean (the hero default).",
+    help="Estimate the QB quantile with the histogram estimator instead of the top-k mean "
+    "(the d6144 hero template's default, unchanged by this flag).",
 )
 @click.option(
     "--qb-hist-bins",

--- a/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
+++ b/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
@@ -516,7 +516,9 @@ def build_small_run(
 )
 @click.option(
     "--qb-histogram/--no-qb-histogram",
-    default=False,
+    # The #8062 ladder's EP arms ran the histogram estimator; it measures lower drops
+    # at neutral loss (1.32% -> 1.25% at capacity factor 2.0) and +0.9% median tok/s.
+    default=True,
     show_default=True,
     help="Estimate the QB quantile with the histogram estimator instead of the top-k mean (the hero default).",
 )


### PR DESCRIPTION
Default the small-scale ablation rungs to the histogram QB quantile estimator, matching how the #8062 ladder's EP arms actually ran. The hero default (top-k mean) is unchanged; `--no-qb-histogram` restores the old behavior.

| estimator | median step, d1024 EP64 rung (CF 2.0) | tokens/s | drop mean, last 50 |
|---|---|---|---|
| top-k mean (current) | 0.6519 s | baseline | 1.32% |
| histogram (this PR) | **0.6460 s** | **+0.9%** | **1.25%** |

Runs: [top-k](https://wandb.ai/marin-community/marin_moe/runs/ar8062-2-9f5a58d7c) vs [histogram](https://wandb.ai/marin-community/marin_moe/runs/ar8062-3-3efaecaad), loss-neutral. The drop reduction is the more useful property: it is routing headroom under a fixed drop budget. Raising the bin count from 1000 to 4000 measured null, so the default bin count stays.
