### PR TITLE
[grug] Raise the collective overlap limit to 4 for hero EP runs

### DIFF
--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -59,11 +59,11 @@ HERO_EP_RUNTIME_ENV = {
 }
 _XLA_FLAG_DEFAULTS = ("--xla_gpu_enable_latency_hiding_scheduler=true",)
 XLA_COLLECTIVE_OVERLAP_FLAG = "--xla_gpu_experimental_parallel_collective_overlap_limit"
-DEFAULT_COLLECTIVE_OVERLAP_LIMIT = 4
 # 4 measured +0.5% median tok/s over 1 on the d1024 EP64 rung (two draws) with the
-# production interval-10 watch; 8 regresses. A FULL inline norm watch once failed at
-# overlap 4 and completed at 1 -- if a full-watch gate is rerun, drop this back to 1.
-INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT = 4
+# production interval-10 inline watch; 8 regresses. A FULL inline norm watch once
+# failed at overlap 4 and completed at 1 -- a rerun of a full-watch gate needs a
+# lower limit reintroduced for that mode.
+COLLECTIVE_OVERLAP_LIMIT = 4
 # TODO(https://github.com/marin-community/marin/issues/5675): Re-enable XLA GPU
 # command buffers after the CUDA graph failure is fixed.
 XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG = "--xla_gpu_enable_command_buffer="
@@ -76,7 +76,7 @@ class WatchMode(StrEnum):
     DIAGNOSTIC = "diagnostic"
 
 
-def _apply_hero_ep_runtime_defaults(*, inline_watch_enabled: bool, processes_per_task: int = 1) -> None:
+def _apply_hero_ep_runtime_defaults(*, processes_per_task: int = 1) -> None:
     env_defaults = dict(HERO_EP_RUNTIME_ENV)
     if processes_per_task > 1:
         # With one process per GPU, the per-process CUPTI sessions collide with each
@@ -86,9 +86,8 @@ def _apply_hero_ep_runtime_defaults(*, inline_watch_enabled: bool, processes_per
     for name, value in env_defaults.items():
         os.environ.setdefault(name, value)
     xla_flags = os.environ.get("XLA_FLAGS", "").split()
-    overlap_limit = INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT if inline_watch_enabled else DEFAULT_COLLECTIVE_OVERLAP_LIMIT
     flag_defaults = (
-        f"{XLA_COLLECTIVE_OVERLAP_FLAG}={overlap_limit}",
+        f"{XLA_COLLECTIVE_OVERLAP_FLAG}={COLLECTIVE_OVERLAP_LIMIT}",
         *_XLA_FLAG_DEFAULTS,
         XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG,
     )
@@ -859,10 +858,7 @@ def run_grug(config: GrugRunConfig) -> None:
         raise ValueError("trainer.id must be set before dispatching grug training.")
 
     # Dispatch snapshots os.environ for the child task, so apply the hero defaults first.
-    inline_watch_enabled = trainer.watch.is_enabled and config.trainer.watch_mode == WatchMode.INLINE
-    _apply_hero_ep_runtime_defaults(
-        inline_watch_enabled=inline_watch_enabled, processes_per_task=config.processes_per_task
-    )
+    _apply_hero_ep_runtime_defaults(processes_per_task=config.processes_per_task)
     dispatch_grug_training_run(
         run_id=trainer.id,
         config=config,

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -60,8 +60,10 @@ HERO_EP_RUNTIME_ENV = {
 _XLA_FLAG_DEFAULTS = ("--xla_gpu_enable_latency_hiding_scheduler=true",)
 XLA_COLLECTIVE_OVERLAP_FLAG = "--xla_gpu_experimental_parallel_collective_overlap_limit"
 DEFAULT_COLLECTIVE_OVERLAP_LIMIT = 4
-# Full inline norm watch failed with overlap 4. Overlap 1 completed the selected full-watch gate.
-INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT = 1
+# 4 measured +0.5% median tok/s over 1 on the d1024 EP64 rung (two draws) with the
+# production interval-10 watch; 8 regresses. A FULL inline norm watch once failed at
+# overlap 4 and completed at 1 -- if a full-watch gate is rerun, drop this back to 1.
+INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT = 4
 # TODO(https://github.com/marin-community/marin/issues/5675): Re-enable XLA GPU
 # command buffers after the CUDA graph failure is fixed.
 XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG = "--xla_gpu_enable_command_buffer="

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -213,21 +213,12 @@ def test_run_grug_keeps_explicit_ep_runtime_values(monkeypatch):
     assert os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] == "platform"
 
 
-@pytest.mark.parametrize(
-    ("watch_mode", "watch_interval", "expected_overlap_limit"),
-    [
-        (train.WatchMode.INLINE, 1, train.INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT),
-        (train.WatchMode.DIAGNOSTIC, 1, train.DEFAULT_COLLECTIVE_OVERLAP_LIMIT),
-        (train.WatchMode.INLINE, 0, train.DEFAULT_COLLECTIVE_OVERLAP_LIMIT),
-    ],
-)
-def test_run_grug_reduces_collective_overlap_only_for_inline_watch(
-    monkeypatch, watch_mode, watch_interval, expected_overlap_limit
-):
+@pytest.mark.parametrize("watch_mode", [train.WatchMode.INLINE, train.WatchMode.DIAGNOSTIC])
+def test_run_grug_applies_collective_overlap_limit(monkeypatch, watch_mode):
     monkeypatch.delenv("XLA_FLAGS", raising=False)
     config = SimpleNamespace(
         trainer=SimpleNamespace(
-            trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=watch_interval)),
+            trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=1)),
             watch_mode=watch_mode,
         ),
         resources=object(),
@@ -238,7 +229,7 @@ def test_run_grug_reduces_collective_overlap_only_for_inline_watch(
         train.run_grug(config)
 
     flags = os.environ["XLA_FLAGS"].split()
-    assert f"{train.XLA_COLLECTIVE_OVERLAP_FLAG}={expected_overlap_limit}" in flags
+    assert f"{train.XLA_COLLECTIVE_OVERLAP_FLAG}={train.COLLECTIVE_OVERLAP_LIMIT}" in flags
 
 
 def test_ep_newton_schulz_returns_to_expert_sharding():


### PR DESCRIPTION
Raise the collective overlap limit from 1 to 4 for hero EP runs, and fold the inline-watch and non-watch constants into one now that they agree.

| overlap limit | Δ median tokens/s, d1024 EP64 rung |
|---|---|
| 1 (current) | baseline |
| 4 (this PR) | **+0.29% / +0.65%** (two draws) |
| 8 | −1.1% |

Measured with the production interval-10 inline watch ([draw 1](https://wandb.ai/marin-community/marin_moe/runs/ar8062-9-0818d7c32), [draw 2](https://wandb.ai/marin-community/marin_moe/runs/ar8062-10-0818d7c32); noise floor ±0.25%), so 4 is the measured peak. The previous limit of 1 came from a full inline norm watch gate that failed at 4; that exception stays documented at the constant, and rerunning a full-watch gate needs a lower limit reintroduced for that mode. The rung is not memory-bound, so the d6144 hero — where memory pressure is real — deserves a re-check before relying on the gain there.
