### PR TITLE
Size task scratch for external-sort spill

### DIFF
--- a/experiments/datakit/scripts/verify_fuzzy_dups_testbed.py
+++ b/experiments/datakit/scripts/verify_fuzzy_dups_testbed.py
@@ -42,6 +42,7 @@ from marin.processing.classification.deduplication.fuzzy_verification import (
 )
 from marin.processing.classification.deduplication.verify_fuzzy_dups import (
     REFERENCE_LOCAL_REPRESENTATIVE_PARAMS,
+    VERIFICATION_WORKER_SCRATCH,
     FuzzyVerificationStoreConfig,
     LocalRepresentativeParams,
     VerifiedFuzzyDupsAttrData,
@@ -61,10 +62,8 @@ DEFAULT_MAX_WORKERS = 64
 DEFAULT_MAX_CONCURRENT = 8
 DEFAULT_INSPECTION_LIMIT = 10_000
 TEXT_PREVIEW_CHARS = 500
-# A single external-sort shard was measured holding 8 GiB of spill in /tmp, so the
-# worker's scratch request has to clear that with room for concurrent shards.
-WORKER_RESOURCES = ResourceConfig(cpu=2, ram="64g", disk="256g")
-VERIFICATION_TASK_RESOURCES = ResourceConfig(cpu=2, ram="60g", disk="256g")
+WORKER_RESOURCES = ResourceConfig(cpu=2, ram="64g", disk=VERIFICATION_WORKER_SCRATCH)
+VERIFICATION_TASK_RESOURCES = ResourceConfig(cpu=2, ram="60g", disk=VERIFICATION_WORKER_SCRATCH)
 COORDINATOR_RESOURCES = ResourceConfig(cpu=1, ram="4g", disk="16g", preemptible=False)
 STORE_CONFIG = FuzzyVerificationStoreConfig(
     recovery_timeout=1_800,

--- a/experiments/datakit/scripts/verify_fuzzy_dups_testbed.py
+++ b/experiments/datakit/scripts/verify_fuzzy_dups_testbed.py
@@ -61,8 +61,10 @@ DEFAULT_MAX_WORKERS = 64
 DEFAULT_MAX_CONCURRENT = 8
 DEFAULT_INSPECTION_LIMIT = 10_000
 TEXT_PREVIEW_CHARS = 500
-WORKER_RESOURCES = ResourceConfig(cpu=2, ram="64g", disk="8g")
-VERIFICATION_TASK_RESOURCES = ResourceConfig(cpu=2, ram="60g", disk="8g")
+# A single external-sort shard was measured holding 8 GiB of spill in /tmp, so the
+# worker's scratch request has to clear that with room for concurrent shards.
+WORKER_RESOURCES = ResourceConfig(cpu=2, ram="64g", disk="256g")
+VERIFICATION_TASK_RESOURCES = ResourceConfig(cpu=2, ram="60g", disk="256g")
 COORDINATOR_RESOURCES = ResourceConfig(cpu=1, ram="4g", disk="16g", preemptible=False)
 STORE_CONFIG = FuzzyVerificationStoreConfig(
     recovery_timeout=1_800,

--- a/experiments/datakit/testbed/variants.py
+++ b/experiments/datakit/testbed/variants.py
@@ -41,6 +41,7 @@ from marin.processing.classification.deduplication.fuzzy_minhash import MinHashA
 from marin.processing.classification.deduplication.fuzzy_verification import FuzzyVerificationParams
 from marin.processing.classification.deduplication.verify_fuzzy_dups import (
     REFERENCE_LOCAL_REPRESENTATIVE_PARAMS,
+    VERIFICATION_WORKER_SCRATCH,
     VERIFIED_FUZZY_DUPS_ATTR_DATA_VERSION,
     FuzzyVerificationStoreConfig,
     VerifiedFuzzyDupsAttrData,
@@ -74,10 +75,7 @@ _FUZZY_DUPS_MAX_PARALLELISM = 128
 _EXACT_DUPS_WORKER_RESOURCES = ResourceConfig(cpu=2, ram="5g")
 _MINHASH_WORKER_RESOURCES = ResourceConfig(cpu=2, ram="5g")
 _FUZZY_DUPS_WORKER_RESOURCES = ResourceConfig(cpu=2, ram="5g")
-# Verification reduces via zephyr's external sort, which spills run files to /tmp
-# and only deletes them once the merge finishes. Spill volume tracks shard size
-# rather than worker RAM, so scratch is requested explicitly here.
-_FUZZY_VERIFICATION_WORKER_RESOURCES = ResourceConfig(cpu=2, ram="8g", disk="256g")
+_FUZZY_VERIFICATION_WORKER_RESOURCES = ResourceConfig(cpu=2, ram="8g", disk=VERIFICATION_WORKER_SCRATCH)
 _FUZZY_VERIFICATION_STORE_CONFIG = FuzzyVerificationStoreConfig(
     recovery_timeout=1_800,
     ready_timeout=1_800,

--- a/experiments/datakit/testbed/variants.py
+++ b/experiments/datakit/testbed/variants.py
@@ -74,7 +74,10 @@ _FUZZY_DUPS_MAX_PARALLELISM = 128
 _EXACT_DUPS_WORKER_RESOURCES = ResourceConfig(cpu=2, ram="5g")
 _MINHASH_WORKER_RESOURCES = ResourceConfig(cpu=2, ram="5g")
 _FUZZY_DUPS_WORKER_RESOURCES = ResourceConfig(cpu=2, ram="5g")
-_FUZZY_VERIFICATION_WORKER_RESOURCES = ResourceConfig(cpu=2, ram="8g")
+# Verification reduces via zephyr's external sort, which spills run files to /tmp
+# and only deletes them once the merge finishes. Spill volume tracks shard size
+# rather than worker RAM, so scratch is requested explicitly here.
+_FUZZY_VERIFICATION_WORKER_RESOURCES = ResourceConfig(cpu=2, ram="8g", disk="256g")
 _FUZZY_VERIFICATION_STORE_CONFIG = FuzzyVerificationStoreConfig(
     recovery_timeout=1_800,
     ready_timeout=1_800,

--- a/lib/fray/src/fray/types.py
+++ b/lib/fray/src/fray/types.py
@@ -430,7 +430,10 @@ class ResourceConfig:
 
     cpu: float = 1
     ram: str = "4g"
-    disk: str = "16g"
+    # Scratch budget for the task. On Kubernetes this becomes the pod's
+    # ephemeral-storage request and limit, which bills disk-backed emptyDir
+    # usage -- including /tmp -- and evicts the pod when the sum exceeds it.
+    disk: str = "64g"
     device: DeviceConfig = field(default_factory=CpuConfig)
     preemptible: bool = True
     # Region state: UNSET (None, default) inherits the parent job's region; PINNED (a

--- a/lib/marin/src/marin/processing/classification/deduplication/verify_fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/verify_fuzzy_dups.py
@@ -60,6 +60,11 @@ _LOCAL_LINE_COUNT_REJECTION = "local_line_count_ratio_below_threshold"
 # effectively every cluster while a pathological one stays bounded.
 ANCHOR_SCAN_RECORDS = 64
 ANCHOR_SCAN_CHARS = 2_000_000
+# The reduce spills to /tmp through zephyr's external sort, and the run files live
+# until the merge finishes. One shard was measured holding 8 GiB, and a worker runs
+# several shards at once, so scratch is sized well above worker RAM. On Kubernetes
+# this becomes the pod's ephemeral-storage limit, and exceeding it evicts the pod.
+VERIFICATION_WORKER_SCRATCH = "256g"
 
 
 class RepresentativeKind(StrEnum):
@@ -804,9 +809,7 @@ def verify_fuzzy_dups(
     if not shards:
         raise ValueError("verify_fuzzy_dups found no normalized Parquet shards")
 
-    # The reduce spills to /tmp through zephyr's external sort, and the run files
-    # live until the merge finishes, so scratch is sized well above worker RAM.
-    resources = worker_resources or ResourceConfig(cpu=2, ram="16g", disk="256g")
+    resources = worker_resources or ResourceConfig(cpu=2, ram="16g", disk=VERIFICATION_WORKER_SCRATCH)
     # The document store loads onto the worker pool, which must know its size,
     # so an unset worker count falls back to one worker per shard.
     if max_workers is None:

--- a/lib/marin/src/marin/processing/classification/deduplication/verify_fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/verify_fuzzy_dups.py
@@ -804,7 +804,9 @@ def verify_fuzzy_dups(
     if not shards:
         raise ValueError("verify_fuzzy_dups found no normalized Parquet shards")
 
-    resources = worker_resources or ResourceConfig(cpu=2, ram="16g", disk="16g")
+    # The reduce spills to /tmp through zephyr's external sort, and the run files
+    # live until the merge finishes, so scratch is sized well above worker RAM.
+    resources = worker_resources or ResourceConfig(cpu=2, ram="16g", disk="256g")
     # The document store loads onto the worker pool, which must know its size,
     # so an unset worker count falls back to one worker per shard.
     if max_workers is None:


### PR DESCRIPTION
Zephyr's external sort spills run files to /tmp and keeps them until the merge finishes. On Kubernetes /tmp is a disk-backed emptyDir, so its usage is billed against the pod's ephemeral-storage limit and a spill burst past that limit makes kubelet evict the pod. The container exits 137 with terminated reason Error and carries no DisruptionTarget condition, so Iris records it as an ordinary application failure and the disk cause is invisible from every Iris-side surface.

A fuzzy-dedup verification job on cw-us-east-08a lost two worker tasks this way over twelve hours against a 16 GiB limit. Polling all 64 workers every 30 seconds caught one shard holding 7.96 GiB of spill while the other 63 sat at 0.02 GiB. The bursts are rare and the run files are deleted once the merge completes, which is why steady-state usage reads as 1% of the limit and the failure looks like an OOM.

Raise fray's default disk request from 16g to 64g, and request 256g explicitly on the fuzzy-verification workers that run the external sort. On Kubernetes the request is a quota against node-local NVMe that already exists — the CoreWeave nodes carry 14 TB with 12 TB free — so it costs nothing there. On the VM path `job_feasibility` gates a request against per-VM disk capacity and the GCE scale groups declare 100 GB, so the new 64g default still fits, while the 256g verification workers become schedulable only on Kubernetes clusters.

This does not address the underlying sizing gap: `_tasks_per_worker` packs by cpu and ram only, so a worker's flat disk request is shared by every concurrent shard task and does not scale when the worker is scaled up.
