### PR TITLE
[datakit] Register the Harrier domain assignment

### DIFF
--- a/experiments/datakit/hero_data.py
+++ b/experiments/datakit/hero_data.py
@@ -27,7 +27,7 @@ as the registry moves. :func:`tokenized` pins the artifact version instead,
 because the tokenize hash includes one and it has changed under the runs that
 produced this data: each tokenizer was applied to the whole registry in a single
 fleet run, and each of those runs wrote a different version. The dedup stages
-are pinned to a specific run outright.
+and domain cluster assignment are pinned to specific runs outright.
 
 All paths resolve against ``MARIN_PREFIX``. CoreWeave Datakit has one storage
 root, ``s3://marin-us-east-02a/marin``; use it regardless of worker placement.
@@ -178,6 +178,14 @@ def fuzzy_dups() -> StepSpec:
     return _frozen_step("hero/fuzzy_dups", f"datakit/{FUZZY_DUPS_ID}")
 
 
+def domain_cluster_assignment() -> StepSpec:
+    """Return the pinned Harrier domain cluster assignment."""
+    return _frozen_step(
+        "hero/domain_cluster_assignment",
+        "datakit/cluster/domain/v1/harrier-all-sources-10m/train_fe81b456",
+    )
+
+
 def harrier(source: str) -> str:
     """Return the fixed complete Harrier path for ``source``."""
     return prefix_join(marin_prefix(), harrier_paths()[source])
@@ -193,6 +201,7 @@ def all_paths() -> dict[str, str]:
     sources = select_sources(None)
     minhash_steps = zephyr_datakit_steps(sources).minhash
     paths = {
+        "domain_cluster_assignment": domain_cluster_assignment().output_path,
         "exact_dups": exact_dups().output_path,
         "fuzzy_dups": fuzzy_dups().output_path,
     }

--- a/experiments/datakit/hero_data.py
+++ b/experiments/datakit/hero_data.py
@@ -100,6 +100,8 @@ NEMOTRON_TOKENIZER = TokenizerPin(
 # source whose outputs sit at the current version, under either tokenizer.
 _ARTIFACT_VERSION_OVERRIDES = {"common-crawl-focus-2026-22": 4}
 
+DOMAIN_CLUSTER_ASSIGNMENT_PATH = "datakit/cluster/domain/v1/harrier-all-sources-10m/train_fe81b456"
+
 # Pinned dedup runs. Both cover all 292 registered sources, and both key the
 # focus crawl under its pre-#8111 extraction, so their attributes do not join
 # against today's normalize for that one source. Exported because consumers
@@ -180,10 +182,7 @@ def fuzzy_dups() -> StepSpec:
 
 def domain_cluster_assignment() -> StepSpec:
     """Return the pinned Harrier domain cluster assignment."""
-    return _frozen_step(
-        "hero/domain_cluster_assignment",
-        "datakit/cluster/domain/v1/harrier-all-sources-10m/train_fe81b456",
-    )
+    return _frozen_step("hero/domain_cluster_assignment", DOMAIN_CLUSTER_ASSIGNMENT_PATH)
 
 
 def harrier(source: str) -> str:

--- a/experiments/datakit/hero_data_paths.json
+++ b/experiments/datakit/hero_data_paths.json
@@ -1,4 +1,5 @@
 {
+ "domain_cluster_assignment": "datakit/cluster/domain/v1/harrier-all-sources-10m/train_fe81b456",
  "exact_dups": "datakit/global_exact_dedup_af4c6c3e",
  "fuzzy_dups": "datakit/dedup_709f5997",
  "harrier/agenttrove": "datakit/embed/harrier-all/agenttrove_3c15a580",

--- a/tests/datakit/test_hero_data.py
+++ b/tests/datakit/test_hero_data.py
@@ -70,6 +70,7 @@ def test_steps_refuse_to_run():
         hero_data.minhash("stack-v3"),
         hero_data.exact_dups(),
         hero_data.fuzzy_dups(),
+        hero_data.domain_cluster_assignment(),
     ]
     for step in steps:
         with pytest.raises(AssertionError, match="must never execute"):


### PR DESCRIPTION
Expose the completed all-source Harrier domain cluster assignment through
`hero_data`. The pinned artifact holds the 5,000 fine centroids and the
5,000-to-40 lookup used by downstream label materialization.

The accessor returns a frozen `StepSpec`, so consumers inherit the artifact
path in their dependency identity and cannot execute it.

Follows #8242.
