### PR TITLE
Add pooled-wave MoE transport

### DIFF
--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -5,23 +5,24 @@ data-parallel rack uses one 64-device expert mesh.
 
 ## Configuration
 
-- Model: d6144, 48 layers, 192 routed experts of width 6144 (hidden-wide), top-4 routing, latent
-  width 3072, and two shared experts of width 3072. This is 535.420 B total parameters and 24.454 B
-  active per token. Depth rounds up to the nearest even count.
+- Model: d6144, 48 layers, 384 routed experts of width 3072, top-8 routing, latent width 3072, and
+  two shared experts of width 3072. Depth rounds up to the nearest even count.
 - Attention: 48 heads, 12 local and 6 global KV heads, head dimension 128, sequence length 4096,
   sliding window 2048, and every fourth layer full-causal with the final layer also global. SConv
   and fused RoPE are on.
 - Mesh: 64-way expert parallelism across 16 workers with four GB200 GPUs each. Additional racks use
-  the `replica_dcn` axis. Three whole experts land on each device in each rack.
+  the `replica_dcn` axis. Six experts are on each GPU in each rack.
 - Batch: 1024 global sequences. The launcher does not scale the batch with the rack count.
-- Router: top-4 quantile balancing with next-step, stop-gradient expert biases and no auxiliary
+- Router: top-8 quantile balancing with next-step, stop-gradient expert biases and no auxiliary
   balancing loss.
-- MoE backend: `fixed_all_to_all` by default, with `ragged_all_to_all` as the `ep-ragged` flavor.
-  The default backend uses gather dispatch, structured custom VJPs, and capacity factor 1.33.
+- MoE backend: `fixed_pooled_wave_all_to_all` by default. Each sender uses one fixed pool per
+  destination and stripes it over three static waves. The receiver runs all six local experts in
+  each wave and drops rows above the fixed expert capacity. Expert IDs travel in the activation
+  payload, so the method does not use a metadata collective. The receiver capacity factor is 1.33,
+  the sender capacity factor is 1.05, and each wave uses at most two full expert buffers.
 - Optimizer: MuonH, with its state offloaded to pinned host memory.
-- Runtime: one JAX process per GPU, GPU command buffers at the XLA default capture set, `cuda_async`, PGLE off (the
-  per-process CUPTI sessions cannot profile concurrently; an explicit `JAX_ENABLE_PGLE` env
-  setting still wins), and collective overlap limit 4.
+- Runtime: one JAX process per four-GPU worker, BF16 parameters and compute, GPU command buffers
+  off, `cuda_async`, PGLE off, and collective overlap limit 4.
 - Output: Metrics only by default. `--save-checkpoints` writes checkpoints, but restore with the
   pinned-host optimizer state has a known memory-kind mismatch. Do not use these checkpoints to
   restart a run.
@@ -31,15 +32,12 @@ The attention, shared-expert, language-model-head, and optimizer states use the 
 
 ## Result
 
-The capacity factor 1.33 default passed a five-step, full-watch gate with all 76 norm fields finite
-on each step. The highest confirmed routing cell capacity is 1,829, and 1.33 keeps a small margin
-below it; this cell load scales with the expert count and top-k, not the expert width, so it holds
-as the width moves. Capacity factor 1.34 ran out of CUDA memory at the prior expert width 6272.
-
-The matched 200-step throughput and loss were measured at the prior expert width 6272 with capacity
-factor 1.30 and automatic PGLE: a last-50 mean of 262,683 tokens/s at 3.9642% drops, a drop-adjusted
-252,271 tokens/s, and a mean loss of 3.2417. The narrower 6144 width lowers per-expert compute and
-memory below these figures.
+The selected configuration completed 200 steps on one rack. Over steps 150 through 199, median
+throughput was 256,818 tokens/s and median MFU was 24.03%. Median routing drop rate was 2.41%, and
+the final drop rate was 2.21%. The final loss was 3.2510. All 16 workers completed without an OOM,
+nonfinite value, failure, or preemption. See the
+[W&B run](https://wandb.ai/marin-community/rav_moe/runs/mhep-103-bf16params-pooled-striped-wave2-send105-recv133-200-20260814)
+and the [XProf trace](https://iris.oa.dev/proxy/xprof/open?uri=s3%3A%2F%2Fmarin-us-east-02a%2Ftmp%2Fttl%3D30d%2Fxprof%2Fmhep-101-bf16params-pooled-striped-wave2-send105-recv133-profile-20260814&tool=trace_viewer).
 
 ### EP ablation ladder (4k context)
 
@@ -71,20 +69,14 @@ compute-scaled optimizer values stay constant across a sweep.
 | `--latent-dim` | routed input and output width |
 | `--capacity-factor` | fixed all-to-all capacity factor |
 
-Three quantities move independently, which sets what a sweep can afford on one rack:
+Three quantities set what a sweep can fit on one rack:
 
 - Active routed neurons are top-k multiplied by width.
 - Parameters are expert count multiplied by width.
-- The all-to-all buffers are tokens multiplied by top-k.
+- The sender pool is token assignments multiplied by the sender capacity factor and divided across
+  three waves.
 
-Width appears in the first two and not the third, thus width is the cheap way to buy active compute
-and top-k is the expensive way. Six buffers scale with top-k, and one of them is float32: top-6
-costs 30.75 GiB against 20.50 GiB for top-4 at this shape.
-
-The selected E192 model runs at expert width 6144 and capacity factor 1.33. Width 6400 failed at
-capacity factor 1.30 in the size search. The
-[experiment record](../../../.agents/logbooks/7279-moe-hero-ep.md) contains the size and capacity
-searches.
+The selected E384 model runs at expert width 3072 and capacity factor 1.33.
 
 ## Run Controls
 
@@ -93,7 +85,7 @@ searches.
 | `--dp-racks` | sets the data-parallel rack count; `--batch-size` stays global |
 | `--batch-size` | sets global sequences per step and the optimizer token budget |
 | `--schedule-steps` | sizes the learning-rate schedule while `--num-steps` bounds the run |
-| `--flavor` | selects `ep` or `ep-ragged` |
+| `--flavor` | selects `ep-pooled-wave`, `ep`, or `ep-ragged` |
 | `--eval-every` | adds Paloma evaluation at the selected interval |
 | `--save-checkpoints` | writes checkpoints with the restore limitation above |
 | `--watch-interval`, `--watch-mode` | select inline or diagnostic norm collection |
@@ -108,23 +100,15 @@ Print the plan without a GPU run:
 
 ```bash
 python -m experiments.grug.moe_hero_ep.launch \
-  --run-id mhep-017-200 \
-  --dp-racks 1 \
+  --run-id mhep-pooled-wave \
   --num-steps 200 \
-  --version 2026.08.05
-
-python -m experiments.grug.moe_hero_ep.launch \
-  --run-id mhep-011-e256-i2560 \
-  --dp-racks 1 \
-  --num-steps 25 \
-  --num-experts 256 --intermediate-dim 2560 \
-  --version 2026.08.05
+  --version 2026.08.14
 ```
 
 Submit the one-rack gate through the Marin Iris controller:
 
 ```bash
-run_id="mhep-017-200"
+run_id="mhep-pooled-wave"
 uv run iris --config lib/iris/config/marin.yaml job run --no-wait --enable-extra-resources \
   --target-cluster cw-us-east-08a --priority interactive \
   --cpu 2 --memory 8GB --disk 32GB \
@@ -132,7 +116,7 @@ uv run iris --config lib/iris/config/marin.yaml job run --no-wait --enable-extra
   -e WANDB_API_KEY "$WANDB_API_KEY" -e WANDB_PROJECT "$WANDB_PROJECT" \
   -e IRIS_PORT_JAX 32575 \
   -- python -m experiments.grug.moe_hero_ep.launch \
-    --run-id "$run_id" --dp-racks 1 --num-steps 200 --version 2026.08.05 --run
+    --run-id "$run_id" --num-steps 200 --version 2026.08.14 --run
 ```
 
 W&B uses the `WANDB_PROJECT` environment variable, or project `marin_moe` when it is unset, with

--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -15,11 +15,12 @@ data-parallel rack uses one 64-device expert mesh.
 - Batch: 1024 global sequences. The launcher does not scale the batch with the rack count.
 - Router: top-8 quantile balancing with next-step, stop-gradient expert biases and no auxiliary
   balancing loss.
-- MoE backend: `fixed_pooled_wave_all_to_all` by default. Each sender uses one fixed pool per
+- MoE backend: `fixed_pooled_wave_all_to_all`. Each sender uses one fixed pool per
   destination and stripes it over three static waves. The receiver runs all six local experts in
   each wave and drops rows above the fixed expert capacity. Expert IDs travel in the activation
   payload, so the method does not use a metadata collective. The receiver capacity factor is 1.33,
-  the sender capacity factor is 1.05, and each wave uses at most two full expert buffers.
+  and the sender capacity factor is 1.05. Each wave has receiver capacity equal to two full expert
+  buffers.
 - Optimizer: MuonH, with its state offloaded to pinned host memory.
 - Runtime: one JAX process per four-GPU worker, BF16 parameters and compute, GPU command buffers
   off, `cuda_async`, PGLE off, and collective overlap limit 4.
@@ -67,7 +68,7 @@ compute-scaled optimizer values stay constant across a sweep.
 | `--intermediate-dim` | routed expert width |
 | `--num-experts-per-token` | routed top-k |
 | `--latent-dim` | routed input and output width |
-| `--capacity-factor` | fixed all-to-all capacity factor |
+| `--capacity-factor` | pooled receiver capacity factor |
 
 Three quantities set what a sweep can fit on one rack:
 
@@ -85,7 +86,6 @@ The selected E384 model runs at expert width 3072 and capacity factor 1.33.
 | `--dp-racks` | sets the data-parallel rack count; `--batch-size` stays global |
 | `--batch-size` | sets global sequences per step and the optimizer token budget |
 | `--schedule-steps` | sizes the learning-rate schedule while `--num-steps` bounds the run |
-| `--flavor` | selects `ep-pooled-wave`, `ep`, or `ep-ragged` |
 | `--eval-every` | adds Paloma evaluation at the selected interval |
 | `--save-checkpoints` | writes checkpoints with the restore limitation above |
 | `--watch-interval`, `--watch-mode` | select inline or diagnostic norm collection |
@@ -124,10 +124,10 @@ group `moe-hero-ep` and the supplied run ID. The run output includes the durable
 artifact. Give each concurrent gang its own `IRIS_PORT_JAX`: rank 0 binds and registers that port
 for the JAX coordinator, and the default 8476 is shared by every run on the cluster.
 
-### Small-scale ablations
+### Legacy small-scale ablations
 
-`small_scale_abl_launch.py` runs a downsized hero shape (`--size` in `d768`…`d2048`) on one GB200
-rack. It fixes the batch at ~4M tokens per step to hold the fixed-all-to-all drop dynamics, and
+`small_scale_abl_launch.py` runs the earlier E192, top-4 shape (`--size` in `d768`…`d2048`) on one
+GB200 rack. It fixes the batch at ~4M tokens per step to hold the fixed-all-to-all drop dynamics, and
 sizes the step count from the model's active-parameter count: `num_steps` trains
 `--tokens-per-active-param` (default 750) tokens per active parameter. `--flavor ep` keeps the
 64-way expert axis; `--flavor fsdp-nodrop` runs the same shape dropless, and `--flavor fsdp-chunk4`

--- a/experiments/grug/moe_hero_ep/heuristic.py
+++ b/experiments/grug/moe_hero_ep/heuristic.py
@@ -8,11 +8,9 @@ Adam learning rates, epsilon, and beta2 from the token budget and batch size. ``
 pairs it with the fixed hero model spec so a launcher gets both configs back from a single
 ``(num_train_steps, batch_size)`` call, keeping the hero self-contained.
 
-The hero model is d6144 with 48 layers, 192 routed latent experts of width 6,144 (hidden-wide) at
-top-4, and two shared experts. The routed experts use a latent width of 3,072 (half the hidden dim)
-and capacity factor 1.33. This gives 535.420 B total parameters and 24.454 B active per token. The
-launcher can override the expert count, expert width, routed top-k, latent width, and capacity
-factor from this spec.
+The hero model is d6144 with 48 layers and 384 routed experts. Each expert has width 3,072, and
+the router selects eight experts per token. The pooled transport uses three static waves. The
+receiver capacity factor is 1.33, and the sender capacity factor is 1.05.
 """
 
 import math
@@ -88,13 +86,11 @@ _HERO_HIDDEN = 6144
 HERO_MODEL = GrugModelConfig(
     vocab_size=128_256,
     hidden_dim=_HERO_HIDDEN,
-    # Routed experts are hidden-wide; the LatentMoE latent is half that. Deriving both from the
-    # hidden dim keeps the relationship fixed as the launcher resizes the shape.
-    intermediate_dim=_HERO_HIDDEN,
+    intermediate_dim=_HERO_HIDDEN // 2,
     shared_expert_intermediate_dim=_HERO_HIDDEN // 2,
     num_shared_experts=2,
-    num_experts=192,
-    num_experts_per_token=4,
+    num_experts=384,
+    num_experts_per_token=8,
     num_layers=48,
     num_heads=48,
     num_kv_heads=12,
@@ -109,7 +105,9 @@ HERO_MODEL = GrugModelConfig(
     qk_mult=1.3,
     sconv=True,
     attention_implementation="gpu_fa4_cute",
-    moe_implementation="fixed_all_to_all",
+    moe_implementation="fixed_pooled_wave_all_to_all",
+    pooled_transport_capacity_factor=1.05,
+    num_expert_waves=3,
     expert_chunks=1,
     report_capacity_overflow=True,
     rope_fused=True,

--- a/experiments/grug/moe_hero_ep/launch.py
+++ b/experiments/grug/moe_hero_ep/launch.py
@@ -36,16 +36,17 @@ HERO_EP_BATCH_SIZE = 1024
 HERO_EP_NODES = 16
 HERO_GPUS_PER_NODE = 4
 HERO_EP_EXPERT_AXIS_SIZE = HERO_EP_NODES * HERO_GPUS_PER_NODE
-# One JAX process per GPU. The old one-process-per-node layout has two reproducible
-# failure modes on this stack, both from auto-PGLE (which only engages per-node):
-# a profiling-session collision that kills the gang during early dispatch
-# (ALREADY_EXISTS: Another profiling session active), and a silent wedge at the
-# FDO-recompile clique re-initialization (#7344). Per-GPU also matches the FSDP
-# hero (#8040) and is required by the ragged EP backend (#8081).
-HERO_PROCESSES_PER_TASK = HERO_GPUS_PER_NODE
+HERO_PROCESSES_PER_TASK = 1
 HERO_MIXED_PRECISION = "params=float32,compute=bfloat16,output=bfloat16"
-# The hero shape keeps its MuonH state on pinned host memory: 24.59 GiB of parameters and 27.78 GiB
-# of optimizer state per device leave too little room for the fixed all-to-all buffers otherwise.
+HERO_SELECTED_MIXED_PRECISION = "params=bfloat16,compute=bfloat16,output=bfloat16"
+HERO_SELECTED_FLAVOR = "ep-pooled-wave"
+HERO_SELECTED_NUM_EXPERTS = 384
+HERO_SELECTED_NUM_EXPERTS_PER_TOKEN = 8
+HERO_SELECTED_INTERMEDIATE_DIM = 3072
+HERO_SELECTED_CAPACITY_FACTOR = 1.33
+HERO_SELECTED_TRANSPORT_CAPACITY_FACTOR = 1.05
+HERO_SELECTED_MAX_EXPERTS_PER_WAVE = 2
+# Keep MuonH state on pinned host memory to leave room for the pooled all-to-all buffers.
 HERO_OFFLOAD_OPT_STATE = True
 HERO_WATCH_INTERVAL = 0
 HERO_CHECKPOINT_INTERVAL = timedelta(minutes=15)
@@ -56,6 +57,7 @@ _SLIMPAJAMA_SHUFFLE = BlockShuffleConfig(io_block_size=256, window_blocks=256, p
 
 FLAVORS: dict[str, str] = {
     "ep": "fixed_all_to_all",
+    HERO_SELECTED_FLAVOR: "fixed_pooled_wave_all_to_all",
     # The upstream transport. Its capacity factor scales one pooled receiver buffer per device
     # rather than a per-(sender, expert) cell, so at the same factor it buys the same bytes and
     # drops far less -- every expert on a device draws from one pool. `fixed_all_to_all` exists
@@ -103,12 +105,12 @@ def build_hero_run(
     schedule_steps: int | None = None,
     seed: int = 0,
     batch_size: int = HERO_EP_BATCH_SIZE,
-    num_experts: int | None = None,
-    num_experts_per_token: int | None = None,
-    intermediate_dim: int | None = None,
-    capacity_factor: float | None = None,
+    num_experts: int | None = HERO_SELECTED_NUM_EXPERTS,
+    num_experts_per_token: int | None = HERO_SELECTED_NUM_EXPERTS_PER_TOKEN,
+    intermediate_dim: int | None = HERO_SELECTED_INTERMEDIATE_DIM,
+    capacity_factor: float | None = HERO_SELECTED_CAPACITY_FACTOR,
     latent_dim: int | None = None,
-    flavor: str = "ep",
+    flavor: str = HERO_SELECTED_FLAVOR,
     eval_every: int = 0,
     save_checkpoints: bool = False,
     checkpoint_interval: timedelta = HERO_CHECKPOINT_INTERVAL,
@@ -178,6 +180,10 @@ def build_hero_run(
         model,
         moe_implementation=moe_implementation,
         expert_chunks=1,
+        pooled_transport_capacity_factor=(
+            HERO_SELECTED_TRANSPORT_CAPACITY_FACTOR if flavor == HERO_SELECTED_FLAVOR else None
+        ),
+        max_experts_per_wave=HERO_SELECTED_MAX_EXPERTS_PER_WAVE,
     )
     # A bank that does not divide the expert axis fails inside `moe_mlp`, which is after the rack is
     # already allocated and the workspace is built. Reject it here instead.
@@ -185,6 +191,11 @@ def build_hero_run(
         raise ValueError(f"num_experts={model.num_experts} must divide the expert axis {HERO_EP_EXPERT_AXIS_SIZE}")
     backend_tag = moe_implementation.replace("_", "-")
     capacity_tag = f"capacity-{model.capacity_factor:g}"
+    transport_capacity_tag = (
+        None
+        if model.pooled_transport_capacity_factor is None
+        else f"transport-capacity-{model.pooled_transport_capacity_factor:g}"
+    )
     size_tag = f"e{model.num_experts}-i{model.intermediate_dim}"
     wandb_project = os.environ.get("WANDB_PROJECT") or DEFAULT_WANDB_PROJECT
     grug_trainer = GrugTrainerConfig(
@@ -228,7 +239,7 @@ def build_hero_run(
                 process_index=0,
                 profile_options=ProfileOptionsConfig(enable_hlo_proto=True),
             ),
-            mp=jmp.get_policy(HERO_MIXED_PRECISION),
+            mp=jmp.get_policy(HERO_SELECTED_MIXED_PRECISION if flavor == HERO_SELECTED_FLAVOR else HERO_MIXED_PRECISION),
             tracker=WandbConfig(
                 entity="marin-community",
                 project=wandb_project,
@@ -240,6 +251,7 @@ def build_hero_run(
                     backend_tag,
                     f"flavor-{flavor}",
                     capacity_tag,
+                    *(() if transport_capacity_tag is None else (transport_capacity_tag,)),
                     size_tag,
                     "gb200",
                     "MHEP",
@@ -295,7 +307,8 @@ def build_hero_run(
 @click.option(
     "--dp-racks",
     type=click.IntRange(min=1),
-    required=True,
+    default=1,
+    show_default=True,
     help="Data-parallel NVL72 rack count. --batch-size stays global across all racks.",
 )
 @click.option(
@@ -324,19 +337,22 @@ def build_hero_run(
 @click.option(
     "--num-experts",
     type=click.IntRange(min=1),
-    default=None,
+    default=HERO_SELECTED_NUM_EXPERTS,
+    show_default=True,
     help=f"Override the routed expert count. Must be divisible by {HERO_EP_EXPERT_AXIS_SIZE}.",
 )
 @click.option(
     "--num-experts-per-token",
     type=click.IntRange(min=1),
-    default=None,
+    default=HERO_SELECTED_NUM_EXPERTS_PER_TOKEN,
+    show_default=True,
     help="Override the routed top-k. Scales both active parameters and the EP dispatch buffers.",
 )
 @click.option(
     "--intermediate-dim",
     type=click.IntRange(min=1),
-    default=None,
+    default=HERO_SELECTED_INTERMEDIATE_DIM,
+    show_default=True,
     help="Override the routed expert width.",
 )
 @click.option(
@@ -355,7 +371,7 @@ def build_hero_run(
 @click.option(
     "--flavor",
     type=click.Choice(sorted(FLAVORS)),
-    default="ep",
+    default=HERO_SELECTED_FLAVOR,
     show_default=True,
     help="Expert-parallel MoE implementation.",
 )
@@ -415,7 +431,8 @@ def build_hero_run(
 @click.option(
     "--capacity-factor",
     type=click.FloatRange(min=0, min_open=True),
-    default=None,
+    default=HERO_SELECTED_CAPACITY_FACTOR,
+    show_default=True,
     help="Override the fixed all-to-all capacity factor.",
 )
 @build_options

--- a/experiments/grug/moe_hero_ep/launch.py
+++ b/experiments/grug/moe_hero_ep/launch.py
@@ -27,7 +27,14 @@ from rigging.filesystem import prefix_join
 
 from experiments.datasets.paloma import paloma_datasets
 from experiments.grug.moe_hero_ep.heuristic import HERO_MODEL, build_hero_configs
-from experiments.grug.moe_hero_ep.train import GrugEvalConfig, GrugRunConfig, GrugTrainerConfig, WatchMode, run_grug
+from experiments.grug.moe_hero_ep.train import (
+    GrugEvalConfig,
+    GrugRunConfig,
+    GrugTrainerConfig,
+    MasterParamMode,
+    WatchMode,
+    run_grug,
+)
 from experiments.llama import llama3_tokenizer
 
 DEFAULT_HERO_STEPS = 25
@@ -178,6 +185,7 @@ def build_hero_run(
         ema_beta=None,
         z_loss_weight=1e-4,
         offload_opt_state=HERO_OFFLOAD_OPT_STATE,
+        master_param_mode=MasterParamMode.FP32_PINNED_HOST,
         watch_mode=watch_mode,
         # The default offloaded optimizer state has a known memory-kind mismatch during restore.
         save_checkpoints=save_checkpoints,

--- a/experiments/grug/moe_hero_ep/launch.py
+++ b/experiments/grug/moe_hero_ep/launch.py
@@ -26,7 +26,7 @@ from marin.processing.tokenize.tokenize import TokenizedCache
 from rigging.filesystem import prefix_join
 
 from experiments.datasets.paloma import paloma_datasets
-from experiments.grug.moe_hero_ep.heuristic import build_hero_configs
+from experiments.grug.moe_hero_ep.heuristic import HERO_MODEL, build_hero_configs
 from experiments.grug.moe_hero_ep.train import GrugEvalConfig, GrugRunConfig, GrugTrainerConfig, WatchMode, run_grug
 from experiments.llama import llama3_tokenizer
 
@@ -37,15 +37,7 @@ HERO_EP_NODES = 16
 HERO_GPUS_PER_NODE = 4
 HERO_EP_EXPERT_AXIS_SIZE = HERO_EP_NODES * HERO_GPUS_PER_NODE
 HERO_PROCESSES_PER_TASK = 1
-HERO_MIXED_PRECISION = "params=float32,compute=bfloat16,output=bfloat16"
-HERO_SELECTED_MIXED_PRECISION = "params=bfloat16,compute=bfloat16,output=bfloat16"
-HERO_SELECTED_FLAVOR = "ep-pooled-wave"
-HERO_SELECTED_NUM_EXPERTS = 384
-HERO_SELECTED_NUM_EXPERTS_PER_TOKEN = 8
-HERO_SELECTED_INTERMEDIATE_DIM = 3072
-HERO_SELECTED_CAPACITY_FACTOR = 1.33
-HERO_SELECTED_TRANSPORT_CAPACITY_FACTOR = 1.05
-HERO_SELECTED_MAX_EXPERTS_PER_WAVE = 2
+HERO_MIXED_PRECISION = "params=bfloat16,compute=bfloat16,output=bfloat16"
 # Keep MuonH state on pinned host memory to leave room for the pooled all-to-all buffers.
 HERO_OFFLOAD_OPT_STATE = True
 HERO_WATCH_INTERVAL = 0
@@ -53,17 +45,6 @@ HERO_CHECKPOINT_INTERVAL = timedelta(minutes=15)
 
 _SLIMPAJAMA_TOKENIZE_RESOURCES = ResourceConfig(ram="64g", disk="64g")
 _SLIMPAJAMA_SHUFFLE = BlockShuffleConfig(io_block_size=256, window_blocks=256, perm_type="feistel")
-
-
-FLAVORS: dict[str, str] = {
-    "ep": "fixed_all_to_all",
-    HERO_SELECTED_FLAVOR: "fixed_pooled_wave_all_to_all",
-    # The upstream transport. Its capacity factor scales one pooled receiver buffer per device
-    # rather than a per-(sender, expert) cell, so at the same factor it buys the same bytes and
-    # drops far less -- every expert on a device draws from one pool. `fixed_all_to_all` exists
-    # because this path measured slow, which is what a same-shape run is for.
-    "ep-ragged": "ragged_all_to_all",
-}
 
 
 # Held-out sets, added at weight 0 so they surface as tagged eval sets. The hero trains on
@@ -105,12 +86,11 @@ def build_hero_run(
     schedule_steps: int | None = None,
     seed: int = 0,
     batch_size: int = HERO_EP_BATCH_SIZE,
-    num_experts: int | None = HERO_SELECTED_NUM_EXPERTS,
-    num_experts_per_token: int | None = HERO_SELECTED_NUM_EXPERTS_PER_TOKEN,
-    intermediate_dim: int | None = HERO_SELECTED_INTERMEDIATE_DIM,
-    capacity_factor: float | None = HERO_SELECTED_CAPACITY_FACTOR,
+    num_experts: int | None = None,
+    num_experts_per_token: int | None = None,
+    intermediate_dim: int | None = None,
+    capacity_factor: float | None = None,
     latent_dim: int | None = None,
-    flavor: str = HERO_SELECTED_FLAVOR,
     eval_every: int = 0,
     save_checkpoints: bool = False,
     checkpoint_interval: timedelta = HERO_CHECKPOINT_INTERVAL,
@@ -144,9 +124,6 @@ def build_hero_run(
         raise ValueError(f"profile_start_step must be non-negative, got {profile_start_step}")
     if profile_steps > 0 and profile_start_step >= num_steps:
         raise ValueError(f"profile_start_step must be less than num_steps={num_steps}, got {profile_start_step}")
-    if flavor not in FLAVORS:
-        raise ValueError(f"flavor must be one of {sorted(FLAVORS)}, got {flavor!r}")
-    moe_implementation = FLAVORS[flavor]
     # `schedule_steps` sets the whole learning-rate schedule; `num_steps` sets how far the run goes.
     # Both matter, and they enter in different places. The optimizer heuristic scales learning rate,
     # adam_lr, and epsilon from a token budget (`num_train_steps * batch * seq`), which fixes the
@@ -176,26 +153,23 @@ def build_hero_run(
     }
     if overrides:
         model = dataclasses.replace(model, **overrides)
-    model = dataclasses.replace(
-        model,
-        moe_implementation=moe_implementation,
-        expert_chunks=1,
-        pooled_transport_capacity_factor=(
-            HERO_SELECTED_TRANSPORT_CAPACITY_FACTOR if flavor == HERO_SELECTED_FLAVOR else None
-        ),
-        max_experts_per_wave=HERO_SELECTED_MAX_EXPERTS_PER_WAVE,
-    )
-    # A bank that does not divide the expert axis fails inside `moe_mlp`, which is after the rack is
-    # already allocated and the workspace is built. Reject it here instead.
+    # A bank that is not divisible by the expert axis fails inside `moe_mlp`, which is after the rack
+    # is already allocated and the workspace is built. Reject it here instead.
     if model.num_experts % HERO_EP_EXPERT_AXIS_SIZE != 0:
-        raise ValueError(f"num_experts={model.num_experts} must divide the expert axis {HERO_EP_EXPERT_AXIS_SIZE}")
-    backend_tag = moe_implementation.replace("_", "-")
+        raise ValueError(f"num_experts={model.num_experts} must be divisible by {HERO_EP_EXPERT_AXIS_SIZE}")
+    local_experts = model.num_experts // HERO_EP_EXPERT_AXIS_SIZE
+    if local_experts % model.num_expert_waves != 0:
+        raise ValueError(
+            f"local expert count={local_experts} must be divisible by num_expert_waves={model.num_expert_waves}"
+        )
+    if model.moe_implementation != "fixed_pooled_wave_all_to_all":
+        raise AssertionError(f"unexpected hero MoE implementation: {model.moe_implementation}")
+    if model.pooled_transport_capacity_factor is None:
+        raise AssertionError("the pooled-wave hero requires a transport capacity factor")
+    backend_tag = model.moe_implementation.replace("_", "-")
     capacity_tag = f"capacity-{model.capacity_factor:g}"
-    transport_capacity_tag = (
-        None
-        if model.pooled_transport_capacity_factor is None
-        else f"transport-capacity-{model.pooled_transport_capacity_factor:g}"
-    )
+    transport_capacity_tag = f"transport-capacity-{model.pooled_transport_capacity_factor:g}"
+    wave_tag = f"expert-waves-{model.num_expert_waves}"
     size_tag = f"e{model.num_experts}-i{model.intermediate_dim}"
     wandb_project = os.environ.get("WANDB_PROJECT") or DEFAULT_WANDB_PROJECT
     grug_trainer = GrugTrainerConfig(
@@ -239,7 +213,7 @@ def build_hero_run(
                 process_index=0,
                 profile_options=ProfileOptionsConfig(enable_hlo_proto=True),
             ),
-            mp=jmp.get_policy(HERO_SELECTED_MIXED_PRECISION if flavor == HERO_SELECTED_FLAVOR else HERO_MIXED_PRECISION),
+            mp=jmp.get_policy(HERO_MIXED_PRECISION),
             tracker=WandbConfig(
                 entity="marin-community",
                 project=wandb_project,
@@ -249,9 +223,9 @@ def build_hero_run(
                     "hero",
                     "ep",
                     backend_tag,
-                    f"flavor-{flavor}",
                     capacity_tag,
-                    *(() if transport_capacity_tag is None else (transport_capacity_tag,)),
+                    transport_capacity_tag,
+                    wave_tag,
                     size_tag,
                     "gb200",
                     "MHEP",
@@ -337,21 +311,24 @@ def build_hero_run(
 @click.option(
     "--num-experts",
     type=click.IntRange(min=1),
-    default=HERO_SELECTED_NUM_EXPERTS,
+    default=HERO_MODEL.num_experts,
     show_default=True,
-    help=f"Override the routed expert count. Must be divisible by {HERO_EP_EXPERT_AXIS_SIZE}.",
+    help=(
+        f"Override the routed expert count. The count must be divisible by {HERO_EP_EXPERT_AXIS_SIZE}, "
+        f"and the local expert count must support {HERO_MODEL.num_expert_waves} waves."
+    ),
 )
 @click.option(
     "--num-experts-per-token",
     type=click.IntRange(min=1),
-    default=HERO_SELECTED_NUM_EXPERTS_PER_TOKEN,
+    default=HERO_MODEL.num_experts_per_token,
     show_default=True,
     help="Override the routed top-k. Scales both active parameters and the EP dispatch buffers.",
 )
 @click.option(
     "--intermediate-dim",
     type=click.IntRange(min=1),
-    default=HERO_SELECTED_INTERMEDIATE_DIM,
+    default=HERO_MODEL.intermediate_dim,
     show_default=True,
     help="Override the routed expert width.",
 )
@@ -367,13 +344,6 @@ def build_hero_run(
     type=click.IntRange(min=1),
     default=None,
     help="LatentMoE: run routed experts at this width. Divides all-to-all traffic by hidden/latent.",
-)
-@click.option(
-    "--flavor",
-    type=click.Choice(sorted(FLAVORS)),
-    default=HERO_SELECTED_FLAVOR,
-    show_default=True,
-    help="Expert-parallel MoE implementation.",
 )
 @click.option(
     "--save-checkpoints/--no-save-checkpoints",
@@ -431,9 +401,9 @@ def build_hero_run(
 @click.option(
     "--capacity-factor",
     type=click.FloatRange(min=0, min_open=True),
-    default=HERO_SELECTED_CAPACITY_FACTOR,
+    default=HERO_MODEL.capacity_factor,
     show_default=True,
-    help="Override the fixed all-to-all capacity factor.",
+    help="Override the pooled receiver capacity factor.",
 )
 @build_options
 def main(
@@ -448,7 +418,6 @@ def main(
     intermediate_dim: int | None,
     capacity_factor: float | None,
     latent_dim: int | None,
-    flavor: str,
     save_checkpoints: bool,
     checkpoint_minutes: float,
     checkpoint_path: str | None,
@@ -470,7 +439,6 @@ def main(
         intermediate_dim=intermediate_dim,
         capacity_factor=capacity_factor,
         latent_dim=latent_dim,
-        flavor=flavor,
         save_checkpoints=save_checkpoints,
         checkpoint_interval=timedelta(minutes=checkpoint_minutes),
         checkpoint_path=checkpoint_path,

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -179,7 +179,7 @@ class GrugModelConfig:
     moe_implementation: MoeImplementation | None = None
     expert_chunks: int = 1
     pooled_transport_capacity_factor: float | None = None
-    max_experts_per_wave: int = 2
+    num_expert_waves: int = 1
     report_capacity_overflow: bool = False
     remat_mode: RematMode = "recompute_all"
     """Per-block gradient checkpointing. "recompute_all" reruns the whole block in
@@ -231,8 +231,8 @@ class GrugModelConfig:
         if self.moe_implementation == "fixed_pooled_wave_all_to_all":
             if self.pooled_transport_capacity_factor is None:
                 raise ValueError("fixed_pooled_wave_all_to_all requires pooled_transport_capacity_factor")
-        if self.max_experts_per_wave <= 0:
-            raise ValueError("max_experts_per_wave must be positive")
+        if self.num_expert_waves <= 0:
+            raise ValueError("num_expert_waves must be positive")
         if self.num_shared_experts <= 0:
             raise ValueError("num_shared_experts must be positive")
         resolve_moe_implementation(self.moe_implementation)
@@ -868,7 +868,7 @@ class MoEMLP(eqx.Module):
                 capacity_factor=cfg.capacity_factor,
                 pooled_transport_capacity_factor=cfg.pooled_transport_capacity_factor,
                 expert_chunks=cfg.expert_chunks,
-                max_experts_per_wave=cfg.max_experts_per_wave,
+                num_expert_waves=cfg.num_expert_waves,
             ),
             cfg=cfg,
         )

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -178,6 +178,8 @@ class GrugModelConfig:
     attention_implementation: GrugAttentionImplementation | None = None
     moe_implementation: MoeImplementation | None = None
     expert_chunks: int = 1
+    pooled_transport_capacity_factor: float | None = None
+    max_experts_per_wave: int = 2
     report_capacity_overflow: bool = False
     remat_mode: RematMode = "recompute_all"
     """Per-block gradient checkpointing. "recompute_all" reruns the whole block in
@@ -224,6 +226,13 @@ class GrugModelConfig:
             raise ValueError("capacity_factor must be positive")
         if self.expert_chunks <= 0:
             raise ValueError("expert_chunks must be positive")
+        if self.pooled_transport_capacity_factor is not None and self.pooled_transport_capacity_factor <= 0:
+            raise ValueError("pooled_transport_capacity_factor must be positive")
+        if self.moe_implementation == "fixed_pooled_wave_all_to_all":
+            if self.pooled_transport_capacity_factor is None:
+                raise ValueError("fixed_pooled_wave_all_to_all requires pooled_transport_capacity_factor")
+        if self.max_experts_per_wave <= 0:
+            raise ValueError("max_experts_per_wave must be positive")
         if self.num_shared_experts <= 0:
             raise ValueError("num_shared_experts must be positive")
         resolve_moe_implementation(self.moe_implementation)
@@ -857,7 +866,9 @@ class MoEMLP(eqx.Module):
                 implementation=cfg.moe_implementation,
                 activation=ActivationFunctionEnum.silu,
                 capacity_factor=cfg.capacity_factor,
+                pooled_transport_capacity_factor=cfg.pooled_transport_capacity_factor,
                 expert_chunks=cfg.expert_chunks,
+                max_experts_per_wave=cfg.max_experts_per_wave,
             ),
             cfg=cfg,
         )

--- a/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
+++ b/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
@@ -1,14 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Small-scale hero-shape ablation: d768 / d1024 / d1280 / d1536.
+"""Legacy E192 small-scale ablation: d768 / d1024 / d1280 / d1536.
 
-Downsized copies of the ``moe_hero_ep`` hero shape (hidden-wide routed experts, top-4, two shared,
-SConv, hybrid GQA, ``fixed_all_to_all`` EP MoE) at the small sweep widths, each trained to 750 tokens
-per active parameter (the EP sweep budget). The architecture, data (datakit two-phase mixture),
-evals (paloma + uncheatable every 1k), and per-size step counts match the Aug hero LR sweep grid
-(issue #7856) so these one-rack EP runs are comparable to the FSDP sweep points; only the
-width/depth/head split and the token budget shrink relative to the d6144 shape.
+These runs use hidden-wide experts, top-4 routing, two shared experts, and fixed all-to-all EP.
+Each run uses the small sweep width and 750 tokens per active parameter. The data, evaluations,
+and step counts match the Aug hero learning-rate sweep from issue #7856.
 
 Each ``--size`` submits one job on the fleet ``--target`` names: a GB200 rack (EP64), 8 H100 nodes
 (EP64), or 2 H100 nodes (EP16). The expert axis spans the fleet, and it sets cell size, so the
@@ -44,7 +41,6 @@ from experiments.grug.moe_hero_ep.launch import (
     DEFAULT_WANDB_PROJECT,
     HERO_EP_NODES,
     HERO_GPUS_PER_NODE,
-    HERO_MIXED_PRECISION,
     HeroThroughputResult,
 )
 from experiments.grug.moe_hero_ep.model import GrugModelConfig, QbEstimator
@@ -66,6 +62,7 @@ EVAL_BATCH_SIZE = 256
 # checkpoint, and an interrupted run would otherwise restart at step 0. A d1280 checkpoint is about
 # 38 GB, against 2.7 TiB at the d6144 hero shape.
 CHECKPOINT_INTERVAL = timedelta(minutes=30)
+SMALL_SCALE_MIXED_PRECISION = "params=float32,compute=bfloat16,output=bfloat16"
 
 # Paloma + uncheatable held-out sets (marin_tokenizer), added as zero-train-weight datakit components
 # so they surface as tagged eval sets -- matching the FSDP sweep.
@@ -185,11 +182,9 @@ def _small_model(
     qb_use_histogram: bool = False,
     qb_hist_bins: int = 1000,
 ) -> GrugModelConfig:
-    """The hero shape (moe_hero_ep ``HERO_MODEL``) downsized to this width.
+    """Build the legacy E192, top-4 ablation at the selected width.
 
-    Every routing/MoE/attention-kernel field is kept from the d6144 hero shape; only the width,
-    depth, head split, and intermediate width shrink. ``fixed_all_to_all`` is the EP MoE backend, so
-    ``num_experts`` (192, the hero bank) still divides the EP64 expert axis.
+    The function keeps the routing and attention fields from the completed small-scale sweep.
     """
     return GrugModelConfig(
         vocab_size=128_256,
@@ -371,7 +366,7 @@ def build_small_run(
             train_batch_size=batch_size,
             num_train_steps=num_steps,
             profiler=ProfilerConfig(enabled=False),
-            mp=jmp.get_policy(HERO_MIXED_PRECISION),
+            mp=jmp.get_policy(SMALL_SCALE_MIXED_PRECISION),
             tracker=WandbConfig(
                 entity="marin-community",
                 project=os.environ.get("WANDB_PROJECT") or DEFAULT_WANDB_PROJECT,

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -55,6 +55,7 @@ logger = logging.getLogger(__name__)
 
 HERO_EP_RUNTIME_ENV = {
     "JAX_ENABLE_PGLE": "false",
+    "XLA_PJRT_GPU_HOST_MEMORY_LIMIT_GB": "192",
     "XLA_PYTHON_CLIENT_ALLOCATOR": "cuda_async",
 }
 _XLA_FLAG_DEFAULTS = ("--xla_gpu_enable_latency_hiding_scheduler=true",)

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -62,13 +62,10 @@ XLA_COLLECTIVE_OVERLAP_FLAG = "--xla_gpu_experimental_parallel_collective_overla
 DEFAULT_COLLECTIVE_OVERLAP_LIMIT = 4
 # Full inline norm watch failed with overlap 4. Overlap 1 completed the selected full-watch gate.
 INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT = 1
-# The verified-safe command-buffer capture set: jaxlib 0.11's default, pinned so a
-# jaxlib upgrade cannot silently change it. Do not add COLLECTIVES: capturing
-# collectives wedges the gang mid-run -- the #5675 hang follows that capture type
-# specifically, not command buffers in general.
-XLA_COMMAND_BUFFER_FLAG = (
-    "--xla_gpu_enable_command_buffer=" "CONDITIONAL,CUBLAS,CUBLASLT,CUDNN,CUSTOM_CALL,DYNAMIC_SLICE_FUSION,FUSION"
-)
+# TODO(https://github.com/marin-community/marin/issues/5675): Re-enable XLA GPU
+# command buffers after the CUDA graph failure is fixed.
+XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG = "--xla_gpu_enable_command_buffer="
+_FP32_POLICY = jmp.get_policy("params=float32,compute=float32,output=float32")
 
 
 class WatchMode(StrEnum):
@@ -76,6 +73,13 @@ class WatchMode(StrEnum):
 
     INLINE = "inline"
     DIAGNOSTIC = "diagnostic"
+
+
+class MasterParamMode(StrEnum):
+    """Storage mode for optimizer master parameters."""
+
+    DISABLED = "disabled"
+    FP32_PINNED_HOST = "fp32_pinned_host"
 
 
 def _apply_hero_ep_runtime_defaults(*, inline_watch_enabled: bool, processes_per_task: int = 1) -> None:
@@ -92,7 +96,7 @@ def _apply_hero_ep_runtime_defaults(*, inline_watch_enabled: bool, processes_per
     flag_defaults = (
         f"{XLA_COLLECTIVE_OVERLAP_FLAG}={overlap_limit}",
         *_XLA_FLAG_DEFAULTS,
-        XLA_COMMAND_BUFFER_FLAG,
+        XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG,
     )
     explicit_names = {flag.partition("=")[0] for flag in xla_flags}
     xla_flags.extend(flag for flag in flag_defaults if flag.partition("=")[0] not in explicit_names)
@@ -111,6 +115,7 @@ class GrugTrainerConfig:
     # Keep disabled except on model sizes where Grace-Blackwell host offload has been measured.
     # The d6144 EP64 runs used it; d5120 required a 135 GiB pinned-host arena and regressed.
     offload_opt_state: bool = False
+    master_param_mode: MasterParamMode = MasterParamMode.DISABLED
     # Inline watch computes statistics on every step and uses the watch interval only for logging.
     # This keeps one training executable resident. A diagnostic watch repeats forward and backward
     # in a separate executable, which costs compute but shortens gradient liveness.
@@ -372,6 +377,7 @@ def _make_mixture_stage_callback(train_dataset: MixtureDataset, batch_schedule: 
 class GrugTrainState:
     step: jax.Array
     params: Transformer
+    master_params: Transformer | None
     opt_state: optax.OptState
     ema_params: Transformer | None
     pending_qb_betas: jax.Array
@@ -384,8 +390,8 @@ def _apply_qb_betas(model: Transformer, qb_betas: jax.Array) -> Transformer:
     return eqx.tree_at(lambda t: t.stacked_blocks.stacked.mlp.router_bias, model, new_bias)
 
 
-def _optimizer_state_to_memory_kind(tree, memory_kind: str):
-    """Move named-sharded optimizer arrays to a JAX memory kind."""
+def _tree_to_memory_kind(tree, memory_kind: str):
+    """Move named-sharded arrays to a JAX memory kind."""
 
     def _move(leaf):
         if not isinstance(leaf, jax.Array):
@@ -408,15 +414,23 @@ def initial_state(
     key: PRNGKeyArray,
     ema_beta: float | None,
     offload_opt_state: bool = False,
+    master_param_mode: MasterParamMode = MasterParamMode.DISABLED,
 ) -> GrugTrainState:
     params = mp.cast_to_param(Transformer.init(model_config, key=key))
     num_moe_layers = model_config.num_layers
-    opt_state = optimizer.init(params)
+    if master_param_mode == MasterParamMode.FP32_PINNED_HOST:
+        master_params = _FP32_POLICY.cast_to_param(params)
+        opt_state = optimizer.init(master_params)
+        master_params = _tree_to_memory_kind(master_params, "pinned_host")
+    else:
+        master_params = None
+        opt_state = optimizer.init(params)
     if offload_opt_state:
-        opt_state = _optimizer_state_to_memory_kind(opt_state, "pinned_host")
+        opt_state = _tree_to_memory_kind(opt_state, "pinned_host")
     return GrugTrainState(
         step=jnp.array(0, dtype=jnp.int32),
         params=params,
+        master_params=master_params,
         opt_state=opt_state,
         ema_params=params if ema_beta is not None else None,
         pending_qb_betas=jnp.zeros((num_moe_layers, model_config.num_experts)),
@@ -497,6 +511,7 @@ def _make_train_step(
     ema_beta: float | None,
     watch_config: WatchConfig | None = None,
     offload_opt_state: bool = False,
+    master_param_mode: MasterParamMode = MasterParamMode.DISABLED,
 ):
     one = jnp.array(1, dtype=jnp.int32)
     z_loss = z_loss_weight if z_loss_weight > 0 else None
@@ -520,11 +535,21 @@ def _make_train_step(
 
         (loss, summarized_metrics), grads = _loss_and_grads(qb_params, batch, mp, z_loss)
         metrics = {"train/loss": loss, **summarized_metrics}
-        opt_state_in = (
-            _optimizer_state_to_memory_kind(state.opt_state, "device") if offload_opt_state else state.opt_state
-        )
-        updates, opt_state = optimizer.update(grads, opt_state_in, qb_params)
-        params = optax.apply_updates(qb_params, updates)
+        opt_state_in = _tree_to_memory_kind(state.opt_state, "device") if offload_opt_state else state.opt_state
+        if master_param_mode == MasterParamMode.FP32_PINNED_HOST:
+            if state.master_params is None:
+                raise ValueError("master_params must be initialized for an FP32 pinned-host master.")
+            master_params_in = _tree_to_memory_kind(state.master_params, "device")
+            master_params_in = _apply_qb_betas(master_params_in, state.pending_qb_betas)
+            master_grads = _FP32_POLICY.cast_to_param(grads)
+            updates, opt_state = optimizer.update(master_grads, opt_state_in, master_params_in)
+            master_params = optax.apply_updates(master_params_in, updates)
+            params = mp.cast_to_param(master_params)
+            master_params = _tree_to_memory_kind(master_params, "pinned_host")
+        else:
+            updates, opt_state = optimizer.update(grads, opt_state_in, qb_params)
+            params = optax.apply_updates(qb_params, updates)
+            master_params = None
 
         if ema_beta is None:
             ema_params = None
@@ -553,12 +578,13 @@ def _make_train_step(
             )
 
         if offload_opt_state:
-            opt_state = _optimizer_state_to_memory_kind(opt_state, "pinned_host")
+            opt_state = _tree_to_memory_kind(opt_state, "pinned_host")
 
         next_state = dataclasses.replace(
             state,
             step=state.step + one,
             params=params,
+            master_params=master_params,
             opt_state=opt_state,
             ema_params=ema_params,
             pending_qb_betas=metrics["qb_beta_per_layer"],
@@ -597,6 +623,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         ema_beta=config.trainer.ema_beta,
         watch_config=inline_watch_config,
         offload_opt_state=config.trainer.offload_opt_state,
+        master_param_mode=config.trainer.master_param_mode,
     )
 
     data_key, model_key = jax.random.split(jax.random.PRNGKey(trainer.seed), 2)
@@ -635,6 +662,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 key=model_rng,
                 ema_beta=config.trainer.ema_beta,
                 offload_opt_state=config.trainer.offload_opt_state,
+                master_param_mode=config.trainer.master_param_mode,
             )
 
         state = _init_state(model_key)
@@ -879,6 +907,7 @@ __all__ = [
     "GrugRunConfig",
     "GrugTrainState",
     "GrugTrainerConfig",
+    "MasterParamMode",
     "initial_state",
     "run_grug",
 ]

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -54,7 +54,7 @@ from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
 logger = logging.getLogger(__name__)
 
 HERO_EP_RUNTIME_ENV = {
-    "JAX_ENABLE_PGLE": "true",
+    "JAX_ENABLE_PGLE": "false",
     "XLA_PYTHON_CLIENT_ALLOCATOR": "cuda_async",
 }
 _XLA_FLAG_DEFAULTS = ("--xla_gpu_enable_latency_hiding_scheduler=true",)

--- a/lib/levanter/src/levanter/grug/_moe/common.py
+++ b/lib/levanter/src/levanter/grug/_moe/common.py
@@ -24,13 +24,20 @@ MoeImplementation: TypeAlias = Literal[
     "ring",  # Expert-parallel all-gather + psum-scatter backend.
     "ragged_all_to_all",  # Expert-parallel ragged all-to-all backend.
     "fixed_all_to_all",  # Expert-parallel all-to-all with fixed sender/expert cells.
+    "fixed_pooled_wave_all_to_all",  # Destination-pooled static waves with fixed receiver buffers.
     "deepep",  # Expert-parallel DeepEP intranode dispatch/combine backend.
     "scatter",  # Single-process grouped GMM with scatter-add combine.
     "sonic",  # Single-process raw Sonic Triton gather/combine backend.
     "sonic_cute",  # Single-process QuACK SM100 (Blackwell/B200) grouped-GEMM backend.
 ]
 _VALID_MOE_IMPLEMENTATIONS = get_args(MoeImplementation)
-_EP_MOE_IMPLEMENTATIONS = ("ring", "ragged_all_to_all", "fixed_all_to_all", "deepep")
+_EP_MOE_IMPLEMENTATIONS = (
+    "ring",
+    "ragged_all_to_all",
+    "fixed_all_to_all",
+    "fixed_pooled_wave_all_to_all",
+    "deepep",
+)
 # Local means no collectives over an expert axis. These backends can still run
 # under ordinary data/model sharding through the no-EP shard_map path.
 _LOCAL_MOE_IMPLEMENTATIONS = (

--- a/lib/levanter/src/levanter/grug/_moe/ep_common.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_common.py
@@ -37,6 +37,45 @@ def _sort_activations_custom_bwd(
 _sort_activations_custom.defvjp(_sort_activations_custom_fwd, _sort_activations_custom_bwd)
 
 
+def _ranks_within_groups(group_ids: Int[Array, "N"], *, num_groups: int) -> Int[Array, "N"]:
+    """Return the zero-based rank of each item in its group."""
+    order = jnp.argsort(group_ids, stable=True)
+    inverse_order = jnp.argsort(order)
+    counts = jnp.bincount(group_ids, length=num_groups).astype(jnp.int32)
+    starts = jnp.cumsum(counts) - counts
+    sorted_ranks = jnp.arange(group_ids.shape[0], dtype=jnp.int32) - starts[group_ids[order]]
+    return sorted_ranks[inverse_order]
+
+
+def _assignment_sources(
+    linear_indices: Int[Array, "N"],
+    *,
+    send_size: int,
+) -> Int[Array, "send"]:
+    """Map each fixed send slot to its source assignment."""
+    assignments = linear_indices.shape[0]
+    return (
+        jnp.full((send_size,), assignments, dtype=jnp.int32)
+        .at[linear_indices]
+        .set(jnp.arange(assignments, dtype=jnp.int32), mode="drop")
+    )
+
+
+def _token_sources(
+    assignment_sources: Int[Array, "send"],
+    *,
+    assignments: int,
+    topk: int,
+    tokens: int,
+) -> Int[Array, "send"]:
+    """Map send slots to token rows and use the padding row for empty slots."""
+    return jnp.where(
+        assignment_sources < assignments,
+        assignment_sources // topk,
+        tokens,
+    )
+
+
 def _prefix_cap_counts(counts: Int[Array, "E"], *, capacity: int) -> Int[Array, "E"]:
     accepted = []
     remaining = jnp.array(capacity, dtype=jnp.int32)

--- a/lib/levanter/src/levanter/grug/_moe/ep_fixed_pooled_wave_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_fixed_pooled_wave_all_to_all.py
@@ -1,0 +1,566 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fixed all-to-all with destination-pooled static waves."""
+
+import math
+from collections.abc import Callable
+from functools import partial
+from typing import NamedTuple
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float, Int
+
+from levanter.grug._moe.ep_common import _assignment_sources, _ranks_within_groups, _token_sources
+from levanter.grug._moe.sonic import sonic_gather_sum_available, sonic_gather_sum_masked
+from levanter.grug.sharding import _batch_axes
+
+
+class _PooledDispatch(NamedTuple):
+    compacted_x: Float[Array, "E R H"]
+    receiver_linear_indices: Int[Array, " received"]
+    receiver_keep: Array
+    sender_linear_indices: Int[Array, " assignments"]
+    sender_keep: Array
+    assignment_sources: Int[Array, " send"]
+    receiver_dropped: Int[Array, ""]
+
+
+class _PooledOutput(NamedTuple):
+    compacted_output: Float[Array, "E R H"]
+    receiver_linear_indices: Int[Array, " received"]
+    receiver_keep: Array
+    sender_linear_indices: Int[Array, " assignments"]
+    sender_keep: Array
+    assignment_sources: Int[Array, " send"]
+    receiver_dropped: Int[Array, ""]
+
+
+def _use_sonic_gather_sum() -> bool:
+    return sonic_gather_sum_available() and jax.default_backend() == "gpu"
+
+
+def _dispatch_gather_input_grad(
+    cotangent: Float[Array, "send H"],
+    linear_indices: Int[Array, " assignments"],
+    keep: Array,
+    tokens_per_shard: int,
+) -> Float[Array, "Tlocal H"]:
+    send_size, hidden_dim = cotangent.shape
+    topk = linear_indices.shape[0] // tokens_per_shard
+    linear_indices = linear_indices.reshape(tokens_per_shard, topk)
+    keep = keep.reshape(tokens_per_shard, topk)
+
+    if _use_sonic_gather_sum():
+        return sonic_gather_sum_masked(cotangent, linear_indices, keep.astype(jnp.float32))
+
+    grad_x = jnp.zeros((tokens_per_shard, hidden_dim), dtype=jnp.float32)
+
+    def add_route(route_index, grad_x):
+        rows = cotangent[jnp.minimum(linear_indices[:, route_index], send_size - 1)]
+        rows = jnp.where(keep[:, route_index, None], rows, 0).astype(jnp.float32)
+        return grad_x + rows
+
+    grad_x = jax.lax.fori_loop(0, topk, add_route, grad_x)
+    return grad_x.astype(cotangent.dtype)
+
+
+def _combine_gather_sum_impl(
+    send_output: Float[Array, "send H"],
+    gather_indices: Int[Array, " assignments"],
+    keep: Array,
+    combine_weights: Float[Array, "Tlocal K"],
+) -> Float[Array, "Tlocal H"]:
+    tokens_per_shard, topk = combine_weights.shape
+    hidden_dim = send_output.shape[1]
+    gather_indices = gather_indices.reshape(tokens_per_shard, topk)
+    keep = keep.reshape(tokens_per_shard, topk)
+
+    if _use_sonic_gather_sum():
+        weights = jnp.where(keep, combine_weights, 0)
+        return sonic_gather_sum_masked(send_output, gather_indices, weights, output_dtype=jnp.float32)
+
+    out = jnp.zeros((tokens_per_shard, hidden_dim), dtype=jnp.float32)
+
+    def add_route(route_index, out):
+        rows = send_output[jnp.minimum(gather_indices[:, route_index], send_output.shape[0] - 1)]
+        rows = jnp.where(keep[:, route_index, None], rows, 0)
+        weight = combine_weights[:, route_index, None].astype(jnp.float32)
+        return out + rows.astype(jnp.float32) * weight
+
+    return jax.lax.fori_loop(0, topk, add_route, out)
+
+
+@jax.custom_vjp
+def _combine_gather_sum(
+    send_output: Float[Array, "send H"],
+    gather_indices: Int[Array, " assignments"],
+    keep: Array,
+    assignment_sources: Int[Array, " send"],
+    combine_weights: Float[Array, "Tlocal K"],
+) -> Float[Array, "Tlocal H"]:
+    return _combine_gather_sum_impl(send_output, gather_indices, keep, combine_weights)
+
+
+def _combine_gather_sum_fwd(send_output, gather_indices, keep, assignment_sources, combine_weights):
+    out = _combine_gather_sum_impl(send_output, gather_indices, keep, combine_weights)
+    return out, (send_output, gather_indices, keep, assignment_sources, combine_weights)
+
+
+def _combine_gather_sum_bwd(residual, cotangent):
+    send_output, gather_indices, keep, assignment_sources, combine_weights = residual
+    tokens_per_shard, topk = combine_weights.shape
+    assignments_per_shard = tokens_per_shard * topk
+    valid = assignment_sources < assignments_per_shard
+    sources = jnp.minimum(assignment_sources, assignments_per_shard - 1)
+    source_tokens = sources // topk
+    source_weights = combine_weights.reshape(-1)[sources].astype(jnp.float32)
+    d_send_output = cotangent[source_tokens].astype(jnp.float32) * source_weights[:, None]
+    d_send_output = jnp.where(valid[:, None], d_send_output, 0).astype(send_output.dtype)
+
+    gather_indices = gather_indices.reshape(tokens_per_shard, topk)
+    keep = keep.reshape(tokens_per_shard, topk)
+    d_combine_weights = jnp.zeros_like(combine_weights)
+
+    def set_route(route_index, d_combine_weights):
+        rows = send_output[jnp.minimum(gather_indices[:, route_index], send_output.shape[0] - 1)]
+        d_weight = jnp.sum(cotangent.astype(jnp.float32) * rows.astype(jnp.float32), axis=1)
+        d_weight = jnp.where(keep[:, route_index], d_weight, 0).astype(combine_weights.dtype)
+        return jax.lax.dynamic_update_slice_in_dim(
+            d_combine_weights,
+            d_weight[:, None],
+            route_index,
+            axis=1,
+        )
+
+    d_combine_weights = jax.lax.fori_loop(0, topk, set_route, d_combine_weights)
+    return d_send_output, None, None, None, d_combine_weights
+
+
+_combine_gather_sum.defvjp(_combine_gather_sum_fwd, _combine_gather_sum_bwd)
+
+
+def _compact_received_impl(
+    received_x: Float[Array, "N H"],
+    receiver_linear_indices: Int[Array, " N"],
+    local_experts: int,
+    receiver_capacity: int,
+) -> Float[Array, "E R H"]:
+    compact_size = local_experts * receiver_capacity
+    compact_sources = _assignment_sources(receiver_linear_indices, send_size=compact_size)
+    source_valid = compact_sources < received_x.shape[0]
+    source_indices = jnp.minimum(compact_sources, received_x.shape[0] - 1)
+    compacted_x = jnp.where(source_valid[:, None], received_x[source_indices], 0)
+    return compacted_x.reshape(local_experts, receiver_capacity, received_x.shape[1])
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(3, 4))
+def _compact_received(
+    received_x: Float[Array, "N H"],
+    receiver_linear_indices: Int[Array, " N"],
+    receiver_keep: Array,
+    local_experts: int,
+    receiver_capacity: int,
+) -> Float[Array, "E R H"]:
+    """Compact received rows with a one-to-one gather backward pass."""
+    return _compact_received_impl(
+        received_x,
+        receiver_linear_indices,
+        local_experts,
+        receiver_capacity,
+    )
+
+
+def _compact_received_fwd(
+    received_x,
+    receiver_linear_indices,
+    receiver_keep,
+    local_experts,
+    receiver_capacity,
+):
+    compacted_x = _compact_received_impl(
+        received_x,
+        receiver_linear_indices,
+        local_experts,
+        receiver_capacity,
+    )
+    return compacted_x, (receiver_linear_indices, receiver_keep, received_x.shape)
+
+
+def _compact_received_bwd(local_experts, receiver_capacity, residual, cotangent):
+    receiver_linear_indices, receiver_keep, received_shape = residual
+    compact_size = local_experts * receiver_capacity
+    flat_cotangent = cotangent.reshape(compact_size, received_shape[1])
+    source_indices = jnp.minimum(receiver_linear_indices, compact_size - 1)
+    received_grad = flat_cotangent[source_indices]
+    received_grad = jnp.where(receiver_keep[:, None], received_grad, 0)
+    return received_grad, None, None
+
+
+_compact_received.defvjp(_compact_received_fwd, _compact_received_bwd)
+
+
+def _pooled_dispatch_payload_impl(
+    x_local: Float[Array, "Tlocal H"],
+    header: Float[Array, "S M H"],
+    token_sources: Int[Array, " send"],
+) -> Float[Array, "S payload H"]:
+    expert_shards, metadata_rows, hidden_dim = header.shape
+    pool_capacity = token_sources.shape[0] // expert_shards
+    tokens_per_shard = x_local.shape[0]
+    padding_source = tokens_per_shard + expert_shards * metadata_rows
+
+    source_rows = jnp.concatenate(
+        [x_local, header.reshape(-1, hidden_dim), jnp.zeros((1, hidden_dim), dtype=x_local.dtype)],
+        axis=0,
+    )
+    header_sources = jnp.arange(
+        tokens_per_shard,
+        tokens_per_shard + expert_shards * metadata_rows,
+        dtype=jnp.int32,
+    ).reshape(expert_shards, metadata_rows)
+    activation_sources = jnp.where(token_sources < tokens_per_shard, token_sources, padding_source).reshape(
+        expert_shards, pool_capacity
+    )
+    payload_sources = jnp.concatenate([header_sources, activation_sources], axis=1)
+    return source_rows[payload_sources.reshape(-1)].reshape(expert_shards, metadata_rows + pool_capacity, hidden_dim)
+
+
+@jax.custom_vjp
+def _pooled_dispatch_payload(
+    x_local: Float[Array, "Tlocal H"],
+    header: Float[Array, "S M H"],
+    token_sources: Int[Array, " send"],
+    linear_indices: Int[Array, " assignments"],
+    keep: Array,
+) -> Float[Array, "S payload H"]:
+    """Build the header and activation payload with one output gather."""
+    return _pooled_dispatch_payload_impl(x_local, header, token_sources)
+
+
+def _pooled_dispatch_payload_fwd(x_local, header, token_sources, linear_indices, keep):
+    payload = _pooled_dispatch_payload_impl(x_local, header, token_sources)
+    return payload, (linear_indices, keep, x_local.shape[0], header.shape[1])
+
+
+def _pooled_dispatch_payload_bwd(residual, cotangent):
+    linear_indices, keep, tokens_per_shard, metadata_rows = residual
+    activation_cotangent = cotangent[:, metadata_rows:].reshape(-1, cotangent.shape[-1])
+    grad_x = _dispatch_gather_input_grad(activation_cotangent, linear_indices, keep, tokens_per_shard)
+    return grad_x, None, None, None, None
+
+
+_pooled_dispatch_payload.defvjp(_pooled_dispatch_payload_fwd, _pooled_dispatch_payload_bwd)
+
+
+def _expand_compacted_impl(
+    compacted_output: Float[Array, "E R H"],
+    receiver_linear_indices: Int[Array, " N"],
+    receiver_keep: Array,
+) -> Float[Array, "N H"]:
+    flat_output = compacted_output.reshape(-1, compacted_output.shape[-1])
+    output_indices = jnp.minimum(receiver_linear_indices, flat_output.shape[0] - 1)
+    received_output = flat_output[output_indices]
+    return jnp.where(receiver_keep[:, None], received_output, 0)
+
+
+@jax.custom_vjp
+def _expand_compacted(
+    compacted_output: Float[Array, "E R H"],
+    receiver_linear_indices: Int[Array, " N"],
+    receiver_keep: Array,
+) -> Float[Array, "N H"]:
+    """Expand expert rows with a one-to-one set backward pass."""
+    return _expand_compacted_impl(compacted_output, receiver_linear_indices, receiver_keep)
+
+
+def _expand_compacted_fwd(compacted_output, receiver_linear_indices, receiver_keep):
+    received_output = _expand_compacted_impl(compacted_output, receiver_linear_indices, receiver_keep)
+    return received_output, (receiver_linear_indices, receiver_keep, compacted_output.shape)
+
+
+def _expand_compacted_bwd(residual, cotangent):
+    receiver_linear_indices, receiver_keep, compacted_shape = residual
+    compact_size = compacted_shape[0] * compacted_shape[1]
+    compacted_grad = (
+        jnp.zeros((compact_size + 1, compacted_shape[2]), dtype=cotangent.dtype)
+        .at[receiver_linear_indices]
+        .set(jnp.where(receiver_keep[:, None], cotangent, 0), mode="drop")
+    )
+    return compacted_grad[:compact_size].reshape(compacted_shape), None, None
+
+
+_expand_compacted.defvjp(_expand_compacted_fwd, _expand_compacted_bwd)
+
+
+def _in_band_expert_header(
+    encoded_experts: Int[Array, " send"],
+    *,
+    expert_shards: int,
+    pool_capacity: int,
+    hidden_dim: int,
+    dtype: jnp.dtype,
+) -> Float[Array, "S M H"]:
+    """Pack static expert IDs into full-width rows for the activation collective."""
+    metadata_rows = math.ceil(pool_capacity / hidden_dim)
+    padded_size = metadata_rows * hidden_dim
+    encoded_experts = encoded_experts.reshape(expert_shards, pool_capacity)
+    padding = jnp.zeros((expert_shards, padded_size - pool_capacity), dtype=encoded_experts.dtype)
+    return (
+        jnp.concatenate([encoded_experts, padding], axis=1)
+        .reshape(expert_shards, metadata_rows, hidden_dim)
+        .astype(dtype)
+    )
+
+
+def _receiver_ranks(
+    received_experts: Int[Array, " N"],
+    *,
+    local_experts: int,
+) -> Int[Array, " N"]:
+    expert_indicators = jax.nn.one_hot(received_experts, local_experts, dtype=jnp.int32)
+    inclusive_counts = jnp.cumsum(expert_indicators, axis=0, dtype=jnp.int32)
+    return jnp.sum((inclusive_counts - 1) * expert_indicators, axis=1, dtype=jnp.int32)
+
+
+def _dispatch_pooled(
+    *,
+    x_local: Float[Array, "Tlocal H"],
+    local_expert_indices: Int[Array, " assignments"],
+    destination_shards: Int[Array, " assignments"],
+    pool_ranks: Int[Array, " assignments"],
+    sender_keep: Array,
+    local_experts: int,
+    expert_shards: int,
+    pool_capacity: int,
+    receiver_capacity: int,
+    assignments_per_shard: int,
+    topk: int,
+) -> _PooledDispatch:
+    tokens_per_shard, hidden_dim = x_local.shape
+    send_size = expert_shards * pool_capacity
+    sender_linear_indices = jnp.where(
+        sender_keep,
+        destination_shards * pool_capacity + pool_ranks,
+        send_size,
+    )
+    assignment_sources = _assignment_sources(sender_linear_indices, send_size=send_size)
+    token_sources = _token_sources(
+        assignment_sources,
+        assignments=assignments_per_shard,
+        topk=topk,
+        tokens=tokens_per_shard,
+    )
+    source_indices = jnp.minimum(assignment_sources, assignments_per_shard - 1)
+    source_valid = assignment_sources < assignments_per_shard
+    encoded_experts = jnp.where(source_valid, local_expert_indices[source_indices] + 1, 0).astype(jnp.int32)
+
+    with jax.named_scope("dispatch"):
+        header = _in_band_expert_header(
+            encoded_experts,
+            expert_shards=expert_shards,
+            pool_capacity=pool_capacity,
+            hidden_dim=hidden_dim,
+            dtype=x_local.dtype,
+        )
+        metadata_rows = header.shape[1]
+        payload = _pooled_dispatch_payload(
+            x_local,
+            header,
+            token_sources,
+            sender_linear_indices,
+            sender_keep,
+        )
+        received_payload = jax.lax.all_to_all(
+            payload,
+            "expert",
+            split_axis=0,
+            concat_axis=0,
+            tiled=True,
+        ).reshape(expert_shards, metadata_rows + pool_capacity, hidden_dim)
+        received_header = received_payload[:, :metadata_rows]
+        received_x = received_payload[:, metadata_rows:].reshape(send_size, hidden_dim)
+        received_encoded_experts = received_header.reshape(expert_shards, -1)[:, :pool_capacity].reshape(send_size)
+        received_experts = received_encoded_experts.astype(jnp.int32) - 1
+
+        receiver_ranks = _receiver_ranks(received_experts, local_experts=local_experts)
+        receiver_valid = received_experts >= 0
+        receiver_keep = receiver_valid & (receiver_ranks < receiver_capacity)
+        compact_size = local_experts * receiver_capacity
+        receiver_linear_indices = jnp.where(
+            receiver_keep,
+            received_experts * receiver_capacity + receiver_ranks,
+            compact_size,
+        )
+        compacted_x = _compact_received(
+            received_x,
+            receiver_linear_indices,
+            receiver_keep,
+            local_experts,
+            receiver_capacity,
+        )
+
+    receiver_dropped = jnp.sum(receiver_valid & ~receiver_keep, dtype=jnp.int32)
+    return _PooledDispatch(
+        compacted_x,
+        receiver_linear_indices,
+        receiver_keep,
+        sender_linear_indices,
+        sender_keep,
+        assignment_sources,
+        receiver_dropped,
+    )
+
+
+def _compute_pooled(
+    dispatch: _PooledDispatch,
+    *,
+    moe_w13_local: Float[Array, "Elocal H I2"],
+    moe_w2_local: Float[Array, "Elocal I H"],
+    activation_fn: Callable[[jax.Array], jax.Array],
+) -> _PooledOutput:
+    with jax.named_scope("moe_up_down"):
+        moe_dim = moe_w2_local.shape[1]
+        hidden = jnp.einsum("erh,ehi->eri", dispatch.compacted_x, moe_w13_local)
+        gate, up = jnp.split(hidden, [moe_dim], axis=-1)
+        compacted_output = jnp.einsum("eri,eih->erh", activation_fn(gate) * up, moe_w2_local)
+
+    return _PooledOutput(
+        compacted_output,
+        dispatch.receiver_linear_indices,
+        dispatch.receiver_keep,
+        dispatch.sender_linear_indices,
+        dispatch.sender_keep,
+        dispatch.assignment_sources,
+        dispatch.receiver_dropped,
+    )
+
+
+def _combine_pooled(
+    output: _PooledOutput,
+    *,
+    combine_weights_local: Float[Array, "Tlocal K"],
+    expert_shards: int,
+    pool_capacity: int,
+) -> Float[Array, "Tlocal H"]:
+    send_size = expert_shards * pool_capacity
+    hidden_dim = output.compacted_output.shape[-1]
+    with jax.named_scope("combine"):
+        received_output = _expand_compacted(
+            output.compacted_output,
+            output.receiver_linear_indices,
+            output.receiver_keep,
+        )
+        returned = jax.lax.all_to_all(
+            received_output.reshape(expert_shards, pool_capacity, hidden_dim),
+            "expert",
+            split_axis=0,
+            concat_axis=0,
+            tiled=True,
+        ).reshape(send_size, hidden_dim)
+        return _combine_gather_sum(
+            returned,
+            output.sender_linear_indices,
+            output.sender_keep,
+            output.assignment_sources,
+            combine_weights_local,
+        )
+
+
+def _moe_mlp_ep_fixed_pooled_wave_a2a_local(
+    x_local: Float[Array, "Tlocal H"],
+    selected_experts_local: Int[Array, "Tlocal K"],
+    combine_weights_local: Float[Array, "Tlocal K"],
+    moe_w13_local: Float[Array, "Elocal H I2"],
+    moe_w2_local: Float[Array, "Elocal I H"],
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+    transport_capacity_factor: float,
+    max_experts_per_wave: int,
+) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
+    """Stripe each destination pool over fixed waves with bounded receiver buffers."""
+    local_experts = moe_w13_local.shape[0]
+    if num_experts % local_experts != 0:
+        raise ValueError(f"num_experts={num_experts} must be divisible by local expert count={local_experts}")
+    if capacity_factor <= 0:
+        raise ValueError("capacity_factor must be positive")
+    if transport_capacity_factor <= 0:
+        raise ValueError("transport_capacity_factor must be positive")
+    if max_experts_per_wave <= 0:
+        raise ValueError(f"max_experts_per_wave must be positive, got {max_experts_per_wave}")
+
+    experts_per_wave = min(max_experts_per_wave, local_experts)
+    while local_experts % experts_per_wave != 0:
+        experts_per_wave -= 1
+
+    tokens_per_shard, hidden_dim = x_local.shape
+    expert_shards = num_experts // local_experts
+    topk = selected_experts_local.shape[1]
+    assignments_per_shard = tokens_per_shard * topk
+    num_waves = local_experts // experts_per_wave
+    pool_capacity = max(
+        math.ceil(transport_capacity_factor * assignments_per_shard / (expert_shards * num_waves)),
+        1,
+    )
+    receiver_capacity = max(
+        math.ceil(capacity_factor * assignments_per_shard / (local_experts * num_waves)),
+        1,
+    )
+
+    flat_experts = selected_experts_local.reshape(-1).astype(jnp.int32)
+    local_expert_indices = (flat_experts % local_experts).astype(jnp.int32)
+    destination_shards = (flat_experts // local_experts).astype(jnp.int32)
+    # The quotient keeps one logical capacity pool per destination. The remainder
+    # stripes that pool over equal static waves without a metadata collective.
+    destination_ranks = _ranks_within_groups(destination_shards, num_groups=expert_shards)
+    assignment_waves = destination_ranks % num_waves
+    pool_ranks = destination_ranks // num_waves
+    sender_keep = pool_ranks < pool_capacity
+
+    remat = partial(
+        jax.checkpoint,
+        prevent_cse=False,
+        policy=jax.checkpoint_policies.nothing_saveable,
+    )
+    out_local = jnp.zeros((tokens_per_shard, hidden_dim), dtype=jnp.float32)
+    receiver_dropped = jnp.array(0, dtype=jnp.int32)
+    for wave_index in range(num_waves):
+        wave_sender_keep = sender_keep & (assignment_waves == wave_index)
+        dispatch = partial(
+            _dispatch_pooled,
+            x_local=x_local,
+            local_expert_indices=local_expert_indices,
+            destination_shards=destination_shards,
+            pool_ranks=pool_ranks,
+            sender_keep=wave_sender_keep,
+            local_experts=local_experts,
+            expert_shards=expert_shards,
+            pool_capacity=pool_capacity,
+            receiver_capacity=receiver_capacity,
+            assignments_per_shard=assignments_per_shard,
+            topk=topk,
+        )
+        compute = partial(
+            _compute_pooled,
+            moe_w13_local=moe_w13_local,
+            moe_w2_local=moe_w2_local,
+            activation_fn=activation_fn,
+        )
+        combine = partial(
+            _combine_pooled,
+            combine_weights_local=combine_weights_local,
+            expert_shards=expert_shards,
+            pool_capacity=pool_capacity,
+        )
+        pooled_dispatch = remat(dispatch)()
+        pooled_output = remat(compute)(pooled_dispatch)
+        out_local = out_local + remat(combine)(pooled_output)
+        receiver_dropped = receiver_dropped + pooled_dispatch.receiver_dropped
+
+    sender_dropped = assignments_per_shard - jnp.sum(sender_keep, dtype=jnp.int32)
+    dropped_local = sender_dropped + receiver_dropped
+    dropped_total = jax.lax.psum(dropped_local, _batch_axes(jax.sharding.get_abstract_mesh()))
+    return out_local.astype(x_local.dtype), dropped_total

--- a/lib/levanter/src/levanter/grug/_moe/ep_fixed_pooled_wave_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_fixed_pooled_wave_all_to_all.py
@@ -479,7 +479,7 @@ def _moe_mlp_ep_fixed_pooled_wave_a2a_local(
     num_experts: int,
     capacity_factor: float,
     transport_capacity_factor: float,
-    max_experts_per_wave: int,
+    num_expert_waves: int,
 ) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
     """Stripe each destination pool over fixed waves with bounded receiver buffers."""
     local_experts = moe_w13_local.shape[0]
@@ -489,18 +489,18 @@ def _moe_mlp_ep_fixed_pooled_wave_a2a_local(
         raise ValueError("capacity_factor must be positive")
     if transport_capacity_factor <= 0:
         raise ValueError("transport_capacity_factor must be positive")
-    if max_experts_per_wave <= 0:
-        raise ValueError(f"max_experts_per_wave must be positive, got {max_experts_per_wave}")
-
-    experts_per_wave = min(max_experts_per_wave, local_experts)
-    while local_experts % experts_per_wave != 0:
-        experts_per_wave -= 1
+    if num_expert_waves <= 0:
+        raise ValueError(f"num_expert_waves must be positive, got {num_expert_waves}")
+    if local_experts % num_expert_waves != 0:
+        raise ValueError(
+            f"local expert count={local_experts} must be divisible by num_expert_waves={num_expert_waves}"
+        )
 
     tokens_per_shard, hidden_dim = x_local.shape
     expert_shards = num_experts // local_experts
     topk = selected_experts_local.shape[1]
     assignments_per_shard = tokens_per_shard * topk
-    num_waves = local_experts // experts_per_wave
+    num_waves = num_expert_waves
     pool_capacity = max(
         math.ceil(transport_capacity_factor * assignments_per_shard / (expert_shards * num_waves)),
         1,

--- a/lib/levanter/src/levanter/grug/_moe/sonic.py
+++ b/lib/levanter/src/levanter/grug/_moe/sonic.py
@@ -16,6 +16,7 @@ import jax
 import jax.numpy as jnp
 from haliax.jax_utils import tree_checkpoint_name
 from haliax.nn.ragged_dot import ragged_dot
+from jax.typing import DTypeLike
 from jaxtyping import Array, Float, Int
 
 from levanter.grug._moe.common import (
@@ -153,6 +154,14 @@ def _require_sonic_deps() -> None:
         os.environ["TRITON_CACHE_DIR"] = _DEFAULT_TRITON_CACHE_DIR
 
 
+def sonic_gather_sum_available() -> bool:
+    return (
+        jt is not None
+        and _sonic_token_gather_sum_kernel is not None
+        and _sonic_token_gather_sum_bwd_kernel is not None
+    )
+
+
 def _next_power_of_2(value: int) -> int:
     if value < 1:
         raise ValueError(f"value must be positive, got {value}")
@@ -178,11 +187,15 @@ def _sonic_gather_sum_impl(
     *,
     tokens: int,
     topk: int,
+    output_dtype: DTypeLike | None = None,
 ) -> Float[Array, "T H"]:
     _require_sonic_deps()
     hidden_dim = dispatch_output.shape[1]
     block_h, block_k, num_warps = _sonic_kernel_config(hidden_dim)
-    out_shape = jax.ShapeDtypeStruct((tokens, hidden_dim), dispatch_output.dtype)
+    out_shape = jax.ShapeDtypeStruct(
+        (tokens, hidden_dim),
+        dispatch_output.dtype if output_dtype is None else output_dtype,
+    )
     return jt.triton_call(
         dispatch_output,
         weights_flat,
@@ -204,6 +217,30 @@ def _sonic_gather_sum_impl(
         block_k=block_k,
         w_is_none=False,
         is_varlen_k=False,
+    )
+
+
+def sonic_gather_sum_masked(
+    dispatch_output: Float[Array, "M H"],
+    dispatch_positions: Int[Array, "T K"],
+    combine_weights: Float[Array, "T K"],
+    *,
+    output_dtype: DTypeLike | None = None,
+) -> Float[Array, "T H"]:
+    """Gather weighted rows and ignore positions outside ``dispatch_output``."""
+    tokens, topk = combine_weights.shape
+    valid = (dispatch_positions >= 0) & (dispatch_positions < dispatch_output.shape[0])
+    positions_flat = jnp.clip(dispatch_positions, 0, dispatch_output.shape[0] - 1).reshape(tokens * topk)
+    weights_flat = jnp.where(valid, combine_weights, 0).reshape(tokens * topk).astype(jnp.float32)
+    offsets = _sonic_fixed_k_offsets(tokens=tokens, topk=topk)
+    return _sonic_gather_sum_impl(
+        dispatch_output,
+        weights_flat,
+        positions_flat,
+        offsets,
+        tokens=tokens,
+        topk=topk,
+        output_dtype=output_dtype,
     )
 
 

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -45,6 +45,7 @@ from levanter.grug._moe.ep_common import (
 )
 from levanter.grug._moe.ep_deepep import _moe_mlp_ep_deepep_local
 from levanter.grug._moe.ep_fixed_all_to_all import _moe_mlp_ep_fixed_a2a_local
+from levanter.grug._moe.ep_fixed_pooled_wave_all_to_all import _moe_mlp_ep_fixed_pooled_wave_a2a_local
 from levanter.grug._moe.ep_ragged_all_to_all import _moe_mlp_ep_ragged_a2a_local
 from levanter.grug._moe.ep_ring import _moe_mlp_ep_ring_local
 from levanter.grug._moe.local import _moe_mlp_local
@@ -70,7 +71,9 @@ class MoEExpertMlp(eqx.Module):
     implementation: MoeImplementation = eqx.field(static=True)
     activation: MoeActivation = eqx.field(static=True)
     capacity_factor: float = eqx.field(static=True)
+    pooled_transport_capacity_factor: float | None = eqx.field(static=True, default=None)
     expert_chunks: int = eqx.field(static=True, default=1)
+    max_experts_per_wave: int = eqx.field(static=True, default=2)
 
     @staticmethod
     def init(
@@ -84,7 +87,9 @@ class MoEExpertMlp(eqx.Module):
         implementation: MoeImplementation | str | None = None,
         activation: MoeActivation = ActivationFunctionEnum.silu,
         capacity_factor: float = _DEFAULT_EP_CAPACITY_FACTOR,
+        pooled_transport_capacity_factor: float | None = None,
         expert_chunks: int = 1,
+        max_experts_per_wave: int = 2,
         pspecs: MoEExpertMlpPspecs = MoEExpertMlpPspecs(),
     ) -> "MoEExpertMlp":
         resolved_implementation = resolve_moe_implementation(implementation)
@@ -105,7 +110,9 @@ class MoEExpertMlp(eqx.Module):
             implementation=resolved_implementation,
             activation=activation,
             capacity_factor=capacity_factor,
+            pooled_transport_capacity_factor=pooled_transport_capacity_factor,
             expert_chunks=expert_chunks,
+            max_experts_per_wave=max_experts_per_wave,
         )
 
     @named_call
@@ -129,8 +136,10 @@ class MoEExpertMlp(eqx.Module):
             implementation=self.implementation,
             mesh=mesh,
             capacity_factor=self.capacity_factor,
+            pooled_transport_capacity_factor=self.pooled_transport_capacity_factor,
             report_capacity_overflow=report_capacity_overflow,
             expert_chunks=self.expert_chunks,
+            max_experts_per_wave=self.max_experts_per_wave,
         )
 
 
@@ -146,8 +155,10 @@ def moe_mlp(
     implementation: MoeImplementation | str | None = None,
     mesh: jax.sharding.Mesh | jax.sharding.AbstractMesh | None = None,
     capacity_factor: float = _DEFAULT_EP_CAPACITY_FACTOR,
+    pooled_transport_capacity_factor: float | None = None,
     report_capacity_overflow: bool = False,
     expert_chunks: int = 1,
+    max_experts_per_wave: int = 2,
 ) -> Float[Array, "T D"] | tuple[Float[Array, "T D"], Int[Array, ""]]:
     """Functional routed MoE MLP core used by Grug modules and benchmarks.
 
@@ -160,6 +171,10 @@ def moe_mlp(
 
     `expert_chunks` applies only to the local `sonic_cute` FSDP path. Values
     greater than one split the expert bank into equal, statically sized chunks.
+
+    `pooled_transport_capacity_factor` sets the sender capacity for each
+    destination pool. `max_experts_per_wave` bounds the receiver-buffer memory
+    for the fixed pooled-wave implementation.
     """
     resolved_implementation = resolve_moe_implementation(implementation)
 
@@ -231,6 +246,14 @@ def moe_mlp(
             shard_local_fn = _moe_mlp_ep_ragged_a2a_local
         elif resolved_implementation == "fixed_all_to_all":
             shard_local_fn = _moe_mlp_ep_fixed_a2a_local
+        elif resolved_implementation == "fixed_pooled_wave_all_to_all":
+            if pooled_transport_capacity_factor is None:
+                raise ValueError("fixed_pooled_wave_all_to_all requires pooled_transport_capacity_factor")
+            shard_local_fn = partial(
+                _moe_mlp_ep_fixed_pooled_wave_a2a_local,
+                transport_capacity_factor=pooled_transport_capacity_factor,
+                max_experts_per_wave=max_experts_per_wave,
+            )
         elif resolved_implementation == "deepep":
             shard_local_fn = _moe_mlp_ep_deepep_local
         else:

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -73,7 +73,7 @@ class MoEExpertMlp(eqx.Module):
     capacity_factor: float = eqx.field(static=True)
     pooled_transport_capacity_factor: float | None = eqx.field(static=True, default=None)
     expert_chunks: int = eqx.field(static=True, default=1)
-    max_experts_per_wave: int = eqx.field(static=True, default=2)
+    num_expert_waves: int = eqx.field(static=True, default=1)
 
     @staticmethod
     def init(
@@ -89,7 +89,7 @@ class MoEExpertMlp(eqx.Module):
         capacity_factor: float = _DEFAULT_EP_CAPACITY_FACTOR,
         pooled_transport_capacity_factor: float | None = None,
         expert_chunks: int = 1,
-        max_experts_per_wave: int = 2,
+        num_expert_waves: int = 1,
         pspecs: MoEExpertMlpPspecs = MoEExpertMlpPspecs(),
     ) -> "MoEExpertMlp":
         resolved_implementation = resolve_moe_implementation(implementation)
@@ -112,7 +112,7 @@ class MoEExpertMlp(eqx.Module):
             capacity_factor=capacity_factor,
             pooled_transport_capacity_factor=pooled_transport_capacity_factor,
             expert_chunks=expert_chunks,
-            max_experts_per_wave=max_experts_per_wave,
+            num_expert_waves=num_expert_waves,
         )
 
     @named_call
@@ -139,7 +139,7 @@ class MoEExpertMlp(eqx.Module):
             pooled_transport_capacity_factor=self.pooled_transport_capacity_factor,
             report_capacity_overflow=report_capacity_overflow,
             expert_chunks=self.expert_chunks,
-            max_experts_per_wave=self.max_experts_per_wave,
+            num_expert_waves=self.num_expert_waves,
         )
 
 
@@ -158,7 +158,7 @@ def moe_mlp(
     pooled_transport_capacity_factor: float | None = None,
     report_capacity_overflow: bool = False,
     expert_chunks: int = 1,
-    max_experts_per_wave: int = 2,
+    num_expert_waves: int = 1,
 ) -> Float[Array, "T D"] | tuple[Float[Array, "T D"], Int[Array, ""]]:
     """Functional routed MoE MLP core used by Grug modules and benchmarks.
 
@@ -173,8 +173,8 @@ def moe_mlp(
     greater than one split the expert bank into equal, statically sized chunks.
 
     `pooled_transport_capacity_factor` sets the sender capacity for each
-    destination pool. `max_experts_per_wave` bounds the receiver-buffer memory
-    for the fixed pooled-wave implementation.
+    destination pool. `num_expert_waves` sets the static wave count for the
+    fixed pooled-wave implementation.
     """
     resolved_implementation = resolve_moe_implementation(implementation)
 
@@ -252,7 +252,7 @@ def moe_mlp(
             shard_local_fn = partial(
                 _moe_mlp_ep_fixed_pooled_wave_a2a_local,
                 transport_capacity_factor=pooled_transport_capacity_factor,
-                max_experts_per_wave=max_experts_per_wave,
+                num_expert_waves=num_expert_waves,
             )
         elif resolved_implementation == "deepep":
             shard_local_fn = _moe_mlp_ep_deepep_local

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -502,7 +502,7 @@ def test_moe_ep_path_lowers_on_abstract_mesh(implementation: MoeImplementation):
                 implementation=implementation,
                 mesh=mesh,
                 pooled_transport_capacity_factor=(1.05 if implementation == "fixed_pooled_wave_all_to_all" else None),
-                max_experts_per_wave=2,
+                num_expert_waves=1,
             )
 
         platform = jax.devices()[0].platform if jax.devices() else jax.default_backend()
@@ -629,7 +629,7 @@ def test_fixed_pooled_wave_all_to_all_matches_dense_value_and_gradients():
             num_experts=num_experts,
             capacity_factor=4.0,
             transport_capacity_factor=4.0,
-            max_experts_per_wave=2,
+            num_expert_waves=3,
         )[0]
 
     sharded_pooled_output = jax.shard_map(
@@ -705,7 +705,7 @@ def test_fixed_pooled_wave_all_to_all_reports_sender_and_receiver_drops():
             num_experts=num_experts,
             capacity_factor=1.33,
             transport_capacity_factor=0.75,
-            max_experts_per_wave=2,
+            num_expert_waves=3,
         )
 
     sharded_pooled_output = jax.shard_map(

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -20,6 +20,7 @@ import levanter.grug.grug_moe as grug_moe
 from levanter.grug._moe.common import _prepare_moe_dispatch, _prepare_moe_dispatch_indices_with_assignment_ids
 from levanter.grug._moe.ep_deepep import _pack_deepep_local_assignments
 from levanter.grug._moe.ep_fixed_all_to_all import _moe_mlp_ep_fixed_a2a_local
+from levanter.grug._moe.ep_fixed_pooled_wave_all_to_all import _moe_mlp_ep_fixed_pooled_wave_a2a_local
 from levanter.grug._moe.sonic import sonic_gather_sum
 from levanter.grug.grug_moe import (
     MoEExpertMlp,
@@ -62,6 +63,14 @@ def _make_abstract_moe_mesh(*, data: int, expert: int, model: int) -> AbstractMe
         axis_sizes=(data, expert, model),
         axis_names=("data", "expert", "model"),
         axis_types=(AxisType.Explicit, AxisType.Explicit, AxisType.Explicit),
+    )
+
+
+def _make_single_expert_mesh() -> Mesh:
+    return Mesh(
+        np.asarray([jax.devices()[0]]),
+        axis_names=("expert",),
+        axis_types=(AxisType.Explicit,),
     )
 
 
@@ -442,7 +451,10 @@ def test_moe_expert_mlp_init_uses_logical_weight_pspecs():
     assert mlp.w_down.sharding.spec == P(None, "model", "data")
 
 
-@pytest.mark.parametrize("implementation", ["ring", "ragged_all_to_all", "fixed_all_to_all"])
+@pytest.mark.parametrize(
+    "implementation",
+    ["ring", "ragged_all_to_all", "fixed_all_to_all", "fixed_pooled_wave_all_to_all"],
+)
 def test_moe_ep_path_lowers_on_abstract_mesh(implementation: MoeImplementation):
     mesh = _make_abstract_moe_mesh(data=2, expert=2, model=1)
 
@@ -489,6 +501,8 @@ def test_moe_ep_path_lowers_on_abstract_mesh(implementation: MoeImplementation):
                 activation=ActivationFunctionEnum.silu,
                 implementation=implementation,
                 mesh=mesh,
+                pooled_transport_capacity_factor=(1.05 if implementation == "fixed_pooled_wave_all_to_all" else None),
+                max_experts_per_wave=2,
             )
 
         platform = jax.devices()[0].platform if jax.devices() else jax.default_backend()
@@ -580,6 +594,143 @@ def test_fixed_all_to_all_drops_assignments_over_capacity():
             atol=1e-5,
         )
     assert int(dropped) == 4
+
+
+@pytest.mark.timeout(180)
+def test_fixed_pooled_wave_all_to_all_matches_dense_value_and_gradients():
+    mesh = _make_single_expert_mesh()
+    tokens = 6
+    hidden_dim = 4
+    intermediate_dim = 3
+    num_experts = 6
+    topk = 2
+    x, _, combine_weights, w_up_gate, w_down = _make_inputs(
+        key=jax.random.key(49),
+        tokens=tokens,
+        hidden_dim=hidden_dim,
+        intermediate_dim=intermediate_dim,
+        num_experts=num_experts,
+        topk=topk,
+    )
+    selected_experts = jnp.asarray(
+        [[0, 1], [2, 3], [4, 5], [0, 2], [1, 3], [4, 5]],
+        dtype=jnp.int32,
+    )
+    cotangent = jax.random.normal(jax.random.key(50), x.shape)
+
+    def pooled_output(x, combine_weights, w_up_gate, w_down):
+        return _moe_mlp_ep_fixed_pooled_wave_a2a_local(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=jax.nn.silu,
+            num_experts=num_experts,
+            capacity_factor=4.0,
+            transport_capacity_factor=4.0,
+            max_experts_per_wave=2,
+        )[0]
+
+    sharded_pooled_output = jax.shard_map(
+        pooled_output,
+        mesh=mesh,
+        in_specs=(P(), P(), P(), P()),
+        out_specs=P(),
+        check_vma=False,
+    )
+
+    def dense_output(x, combine_weights, w_up_gate, w_down):
+        selected_w13 = w_up_gate[selected_experts]
+        hidden = jnp.einsum("th,tkhi->tki", x, selected_w13)
+        gate, up = jnp.split(hidden, [intermediate_dim], axis=-1)
+        expert_output = jnp.einsum(
+            "tki,tkih->tkh",
+            jax.nn.silu(gate) * up,
+            w_down[selected_experts],
+        )
+        return jnp.einsum("tkh,tk->th", expert_output, combine_weights)
+
+    with jax.set_mesh(mesh):
+        actual = sharded_pooled_output(x, combine_weights, w_up_gate, w_down)
+        actual_gradients = jax.grad(
+            lambda x, combine_weights, w_up_gate, w_down: jnp.sum(
+                sharded_pooled_output(x, combine_weights, w_up_gate, w_down) * cotangent
+            ),
+            argnums=(0, 1, 2, 3),
+        )(x, combine_weights, w_up_gate, w_down)
+    expected = dense_output(x, combine_weights, w_up_gate, w_down)
+    expected_gradients = jax.grad(
+        lambda x, combine_weights, w_up_gate, w_down: jnp.sum(
+            dense_output(x, combine_weights, w_up_gate, w_down) * cotangent
+        ),
+        argnums=(0, 1, 2, 3),
+    )(x, combine_weights, w_up_gate, w_down)
+
+    np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-5)
+    for actual_gradient, expected_gradient in zip(actual_gradients, expected_gradients, strict=True):
+        np.testing.assert_allclose(
+            np.asarray(actual_gradient),
+            np.asarray(expected_gradient),
+            rtol=1e-5,
+            atol=1e-5,
+        )
+
+
+def test_fixed_pooled_wave_all_to_all_reports_sender_and_receiver_drops():
+    mesh = _make_single_expert_mesh()
+    tokens = 6
+    hidden_dim = 4
+    intermediate_dim = 3
+    num_experts = 6
+    topk = 2
+    x, _, combine_weights, w_up_gate, w_down = _make_inputs(
+        key=jax.random.key(51),
+        tokens=tokens,
+        hidden_dim=hidden_dim,
+        intermediate_dim=intermediate_dim,
+        num_experts=num_experts,
+        topk=topk,
+    )
+    selected_experts = jnp.tile(jnp.arange(topk, dtype=jnp.int32), (tokens, 1))
+
+    def pooled_output(x, combine_weights, w_up_gate, w_down):
+        return _moe_mlp_ep_fixed_pooled_wave_a2a_local(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=jax.nn.silu,
+            num_experts=num_experts,
+            capacity_factor=1.33,
+            transport_capacity_factor=0.75,
+            max_experts_per_wave=2,
+        )
+
+    sharded_pooled_output = jax.shard_map(
+        pooled_output,
+        mesh=mesh,
+        in_specs=(P(), P(), P(), P()),
+        out_specs=(P(), P()),
+        check_vma=False,
+    )
+    with jax.set_mesh(mesh):
+        actual, dropped = sharded_pooled_output(x, combine_weights, w_up_gate, w_down)
+
+    selected_w13 = w_up_gate[selected_experts]
+    hidden = jnp.einsum("th,tkhi->tki", x, selected_w13)
+    gate, up = jnp.split(hidden, [intermediate_dim], axis=-1)
+    expert_output = jnp.einsum(
+        "tki,tkih->tkh",
+        jax.nn.silu(gate) * up,
+        w_down[selected_experts],
+    )
+    keep = jnp.arange(tokens)[:, None] < 3
+    expected = jnp.einsum("tkh,tk->th", expert_output, combine_weights * keep)
+
+    np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-5)
+    assert int(dropped) == 6
 
 
 def test_fixed_all_to_all_matches_dense_cross_shard_value_and_gradients():

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -554,7 +554,7 @@ def test_fixed_all_to_all_drops_assignments_over_capacity():
         out_specs=(P(), P()),
         check_vma=False,
     )
-    with jax.set_mesh(mesh):
+    with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
         actual, dropped = sharded_fixed_a2a(x, selected_experts, combine_weights, w_up_gate, w_down)
 
     keep = jnp.asarray([[True, True], [True, True], [False, False], [False, False]])
@@ -571,7 +571,7 @@ def test_fixed_all_to_all_drops_assignments_over_capacity():
         return jnp.einsum("tkh,tk->th", expert_output, combine_weights * keep)
 
     cotangent = jax.random.normal(jax.random.key(42), x.shape)
-    with jax.set_mesh(mesh):
+    with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
         actual_gradients = jax.grad(
             lambda x, w_up_gate, w_down: jnp.sum(
                 sharded_fixed_a2a(x, selected_experts, combine_weights, w_up_gate, w_down)[0] * cotangent
@@ -579,11 +579,11 @@ def test_fixed_all_to_all_drops_assignments_over_capacity():
             argnums=(0, 1, 2),
         )(x, w_up_gate, w_down)
 
-    expected = dense_output(x, w_up_gate, w_down)
-    expected_gradients = jax.grad(
-        lambda x, w_up_gate, w_down: jnp.sum(dense_output(x, w_up_gate, w_down) * cotangent),
-        argnums=(0, 1, 2),
-    )(x, w_up_gate, w_down)
+        expected = dense_output(x, w_up_gate, w_down)
+        expected_gradients = jax.grad(
+            lambda x, w_up_gate, w_down: jnp.sum(dense_output(x, w_up_gate, w_down) * cotangent),
+            argnums=(0, 1, 2),
+        )(x, w_up_gate, w_down)
 
     np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-5)
     for actual_gradient, expected_gradient in zip(actual_gradients, expected_gradients, strict=True):
@@ -651,7 +651,7 @@ def test_fixed_pooled_wave_all_to_all_matches_dense_value_and_gradients():
         )
         return jnp.einsum("tkh,tk->th", expert_output, combine_weights)
 
-    with jax.set_mesh(mesh):
+    with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
         actual = sharded_pooled_output(x, combine_weights, w_up_gate, w_down)
         actual_gradients = jax.grad(
             lambda x, combine_weights, w_up_gate, w_down: jnp.sum(
@@ -659,13 +659,13 @@ def test_fixed_pooled_wave_all_to_all_matches_dense_value_and_gradients():
             ),
             argnums=(0, 1, 2, 3),
         )(x, combine_weights, w_up_gate, w_down)
-    expected = dense_output(x, combine_weights, w_up_gate, w_down)
-    expected_gradients = jax.grad(
-        lambda x, combine_weights, w_up_gate, w_down: jnp.sum(
-            dense_output(x, combine_weights, w_up_gate, w_down) * cotangent
-        ),
-        argnums=(0, 1, 2, 3),
-    )(x, combine_weights, w_up_gate, w_down)
+        expected = dense_output(x, combine_weights, w_up_gate, w_down)
+        expected_gradients = jax.grad(
+            lambda x, combine_weights, w_up_gate, w_down: jnp.sum(
+                dense_output(x, combine_weights, w_up_gate, w_down) * cotangent
+            ),
+            argnums=(0, 1, 2, 3),
+        )(x, combine_weights, w_up_gate, w_down)
 
     np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-5)
     for actual_gradient, expected_gradient in zip(actual_gradients, expected_gradients, strict=True):

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -38,9 +38,31 @@ def test_hero_run_without_shape_overrides_uses_the_selected_model():
         config.model.num_experts_per_token,
         config.model.latent_dim,
         config.model.capacity_factor,
+        config.model.pooled_transport_capacity_factor,
+        config.model.max_experts_per_wave,
+        config.model.moe_implementation,
         config.trainer.trainer.train_batch_size,
         config.model.max_seq_len,
-    ) == (6144, 48, 192, 6144, 4, 3072, 1.33, 1024, 4096)
+        config.processes_per_task,
+        config.trainer.trainer.mp.param_dtype,
+        config.trainer.trainer.mp.compute_dtype,
+    ) == (
+        6144,
+        48,
+        384,
+        3072,
+        8,
+        3072,
+        1.33,
+        1.05,
+        2,
+        "fixed_pooled_wave_all_to_all",
+        1024,
+        4096,
+        1,
+        jnp.bfloat16,
+        jnp.bfloat16,
+    )
 
 
 def test_full_bank_top_k_is_rejected_before_launch():
@@ -160,9 +182,8 @@ def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch)
     assert explicit_overlap in flags
     assert "--xla_gpu_experimental_parallel_collective_overlap_limit=4" not in flags
     assert "--xla_gpu_enable_latency_hiding_scheduler=true" in flags
-    assert train.XLA_COMMAND_BUFFER_FLAG in flags
-    assert "COLLECTIVES" not in train.XLA_COMMAND_BUFFER_FLAG
-    assert os.environ["JAX_ENABLE_PGLE"] == "true"
+    assert train.XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG in flags
+    assert os.environ["JAX_ENABLE_PGLE"] == "false"
     assert os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] == "cuda_async"
 
 

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -46,6 +46,7 @@ def test_hero_run_without_shape_overrides_uses_the_selected_model():
         config.processes_per_task,
         config.trainer.trainer.mp.param_dtype,
         config.trainer.trainer.mp.compute_dtype,
+        config.trainer.master_param_mode,
     ) == (
         6144,
         48,
@@ -62,6 +63,7 @@ def test_hero_run_without_shape_overrides_uses_the_selected_model():
         1,
         jnp.bfloat16,
         jnp.bfloat16,
+        train.MasterParamMode.FP32_PINNED_HOST,
     )
 
 
@@ -729,6 +731,7 @@ def test_inline_watch_computes_stats_on_every_train_step(monkeypatch):
     state = train.GrugTrainState(
         step=jnp.array(0, dtype=jnp.int32),
         params=params,
+        master_params=None,
         opt_state=optimizer.init(params),
         ema_params=None,
         pending_qb_betas=jnp.zeros((1, 1)),
@@ -758,3 +761,44 @@ def test_inline_watch_computes_stats_on_every_train_step(monkeypatch):
     assert step_one_stats is not None
     np.testing.assert_allclose(step_zero_stats["grad/norm/total"], 4.0)
     np.testing.assert_allclose(step_one_stats["grad/norm/total"], 3.2)
+
+
+def test_fp32_host_master_accumulates_updates_before_bfloat16_cast(monkeypatch):
+    params = _TinyWatchModel(weight=jnp.array(1.0, dtype=jnp.bfloat16))
+    master_params = _TinyWatchModel(weight=jnp.array(1.0, dtype=jnp.float32))
+    optimizer = optax.sgd(0.1)
+    state = train.GrugTrainState(
+        step=jnp.array(0, dtype=jnp.int32),
+        params=params,
+        master_params=master_params,
+        opt_state=optimizer.init(master_params),
+        ema_params=None,
+        pending_qb_betas=jnp.zeros((1, 1)),
+    )
+
+    def loss_and_grads(current_params, batch, mp, z_loss):
+        del current_params, batch, mp, z_loss
+        loss = jnp.array(0.0)
+        grads = _TinyWatchModel(weight=jnp.array(0.01, dtype=jnp.bfloat16))
+        metrics = {"qb_beta_per_layer": jnp.zeros((1, 1))}
+        return (loss, metrics), grads
+
+    monkeypatch.setattr(train, "_apply_qb_betas", lambda model, qb_betas: model)
+    monkeypatch.setattr(train, "_loss_and_grads", loss_and_grads)
+    train_step = train._make_train_step(
+        optimizer,
+        jmp.get_policy("params=bfloat16,compute=bfloat16,output=bfloat16"),
+        z_loss_weight=0,
+        ema_beta=None,
+        master_param_mode=train.MasterParamMode.FP32_PINNED_HOST,
+    )
+
+    for _ in range(10):
+        state, _, _ = train_step(state, jnp.array(0))
+
+    assert state.master_params is not None
+    assert state.master_params.weight.dtype == jnp.float32
+    assert state.params.weight.dtype == jnp.bfloat16
+    expected_master = 1.0 - 10 * 0.1 * float(jnp.array(0.01, dtype=jnp.bfloat16))
+    np.testing.assert_allclose(state.master_params.weight, expected_master, rtol=1e-6)
+    np.testing.assert_allclose(state.params.weight, jnp.asarray(expected_master, dtype=jnp.bfloat16))

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -39,7 +39,7 @@ def test_hero_run_without_shape_overrides_uses_the_selected_model():
         config.model.latent_dim,
         config.model.capacity_factor,
         config.model.pooled_transport_capacity_factor,
-        config.model.max_experts_per_wave,
+        config.model.num_expert_waves,
         config.model.moe_implementation,
         config.trainer.trainer.train_batch_size,
         config.model.max_seq_len,
@@ -55,7 +55,7 @@ def test_hero_run_without_shape_overrides_uses_the_selected_model():
         3072,
         1.33,
         1.05,
-        2,
+        3,
         "fixed_pooled_wave_all_to_all",
         1024,
         4096,
@@ -154,11 +154,16 @@ def test_schedule_steps_do_not_extend_the_run():
     assert config.stop_after_steps == 5
 
 
-def test_expert_bank_override_must_divide_the_expert_axis():
+def test_expert_bank_override_must_be_divisible_by_the_expert_axis():
     # `moe_mlp` raises on an indivisible bank only once the 16-node gang is already allocated and
     # its workspace is built, so the launcher has to reject it while it is still free to do so.
-    with pytest.raises(ValueError, match="must divide the expert axis"):
+    with pytest.raises(ValueError, match="must be divisible by 64"):
         launch.build_hero_run(run_id="bad-bank", dp_racks=1, num_steps=1, num_experts=200, version="dev")
+
+
+def test_expert_bank_override_must_support_three_waves():
+    with pytest.raises(ValueError, match="local expert count=4 must be divisible by num_expert_waves=3"):
+        launch.build_hero_run(run_id="bad-waves", dp_racks=1, num_steps=1, num_experts=256, version="dev")
 
 
 def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch):

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -191,6 +191,7 @@ def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch)
     assert "--xla_gpu_enable_latency_hiding_scheduler=true" in flags
     assert train.XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG in flags
     assert os.environ["JAX_ENABLE_PGLE"] == "false"
+    assert os.environ["XLA_PJRT_GPU_HOST_MEMORY_LIMIT_GB"] == "192"
     assert os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] == "cuda_async"
 
 


### PR DESCRIPTION
* Part of https://github.com/marin-community/marin/issues/7279.
* Add `fixed_pooled_wave_all_to_all` for the `E384/top8/I3072` one-rack shape.
  * Divide each destination pool across three static waves.
  * Send expert IDs in the BF16 activation payload without a metadata collective.
  * Apply receiver CF `1.33` and sender CF `1.05`.
* Use one JAX process for each four-GPU worker.
* Keep BF16 compute parameters on the GPU. Keep the FP32 master and FP32 optimizer state in pinned host memory.
  * Move the FP32 master to the GPU for each optimizer update. Then return the master to host memory.
  * Set the JAX host allocator limit to 192 GB.
* The 200-step BF16 control reached 256,818 median tokens/s and a 2.41% median drop rate for steps 150 through 199.
  * [Run metrics](https://wandb.ai/marin-community/rav_moe/runs/mhep-103-bf16params-pooled-striped-wave2-send105-recv133-200-20260814).
  * [XProf trace](https://iris.oa.dev/proxy/xprof/open?uri=s3%3A%2F%2Fmarin-us-east-02a%2Ftmp%2Fttl%3D30d%2Fxprof%2Fmhep-101-bf16params-pooled-striped-wave2-send105-recv133-profile-20260814&tool=trace_viewer).
* The five-step FP32 host-master run reached 246,376 median tokens/s for steps 2 through 4. All 16 workers succeeded without an OOM.
  * [FP32 host-master metrics](https://wandb.ai/marin-community/rav_moe/runs/mhep-108-fp32-host-master-192g-smoke).
* A full FP32 device-parameter control failed before step 0 with an NCCL CUDA OOM.
  * [FP32 device-parameter control](https://wandb.ai/marin-community/rav_moe/runs/mhep-105-fp32params-pooled-wave-smoke).
