### PR TITLE
[echo] Expose agent conversation and search feedback

### DIFF
--- a/infra/echo/README.md
+++ b/infra/echo/README.md
@@ -200,6 +200,7 @@ the activity corpus and wiki notes. The same service exposes OpenAPI documentati
 - `GET /api/chunks/{id}`
 - `GET /api/wiki/search`
 - `GET /api/wiki/{id}`
+- `GET /api/feedback`
 - `POST /api/feedback`
 - `GET /api/search-executions`
 - `POST /api/wiki`
@@ -230,12 +231,18 @@ pages of at most 500 records for evaluation exports.
 10, and a required overall explanation of at most 2,000 characters. Grades may be empty
 when the search returns no useful results. The API attributes feedback to the
 IAP-authenticated caller and optionally links it to a matching search execution.
+`GET /api/feedback` returns recent submissions newest-first. Each grade includes the
+result's title and browseable URL from its recorded search snapshot or current source.
+The response also includes explanation-only submissions with an empty grade list.
 
 The dashboard is a Vue single-page app served from the same origin, with client-side
-routes at `/` (search), `/wiki` (recently updated notes), `/wiki/<id>` (a note), and
-`/chunk/<id>` (an activity chunk). The API's catch-all route serves `index.html` for
-any path that isn't `/api/...`, `/healthz`, `/static/...`, `/docs`, or `/openapi.json`,
-so vue-router's history-mode navigation and reloads resolve correctly.
+routes at `/` (search), `/wiki` (recently updated notes), `/conversation` (recent agent
+work-log entries), `/feedback` (recent result grades), `/wiki/<id>` (a note), and
+`/chunk/<id>` (an activity chunk). Conversation details load when an entry is opened.
+The feedback table links each grade to its source and keeps explanation-only submissions
+visible. The API's catch-all route serves `index.html` for any path that isn't
+`/api/...`, `/healthz`, `/static/...`, `/docs`, or `/openapi.json`, so vue-router's
+history-mode navigation and reloads resolve correctly.
 
 Dashboard search uses the federated endpoint and exposes checkboxes for files, wiki,
 Discord, pull requests, and issues. Discord starts unchecked. Header tabs provide common

--- a/infra/echo/api/app.py
+++ b/infra/echo/api/app.py
@@ -265,6 +265,21 @@ class SearchFeedbackEntry(SearchFeedbackCreate):
     author: str
 
 
+class SearchFeedbackResultGrade(SearchFeedbackGrade):
+    title: str
+    url: str
+
+
+class SearchFeedbackListEntry(BaseModel):
+    id: int
+    created_at: datetime
+    author: str
+    query: str
+    note: str
+    execution_id: int | None
+    grades: list[SearchFeedbackResultGrade]
+
+
 class SearchExecutionResultEntry(BaseModel):
     rank: int
     result_id: str
@@ -375,6 +390,12 @@ class RepositoryIndexState:
 class SearchCandidate:
     result: SearchResult
     text: str
+
+
+@dataclass(frozen=True)
+class FeedbackResultMetadata:
+    title: str
+    url: str
 
 
 class RerankerModel(Protocol):
@@ -693,6 +714,71 @@ def repository_freshness(state: RepositoryIndexState) -> str:
 
 def repository_blob_url(config: EchoConfig, commit_sha: str, path: str) -> str:
     return f"https://github.com/{config.github_repository}/blob/{commit_sha}/{quote(path, safe='/')}"
+
+
+def default_feedback_result_metadata(result_id: str, config: EchoConfig) -> FeedbackResultMetadata:
+    domain, _, value = result_id.partition(":")
+    if domain == "wiki":
+        return FeedbackResultMetadata(title=f"Wiki note #{value}", url=f"{config.public_url}/wiki/{value}")
+    if domain == "file":
+        return FeedbackResultMetadata(
+            title=PurePosixPath(value).name,
+            url=f"https://github.com/{config.github_repository}/blob/{config.github_branch}/{quote(value, safe='/')}",
+        )
+    labels = {"discord": "Discord message", "pr": "Pull request result", "issue": "Issue result"}
+    return FeedbackResultMetadata(
+        title=f"{labels[domain]} #{value}",
+        url=f"{config.public_url}/chunk/{value}",
+    )
+
+
+def recorded_feedback_result_metadata(
+    conn: sqlalchemy.Connection, execution_ids: set[int]
+) -> dict[tuple[int, str], FeedbackResultMetadata]:
+    if not execution_ids:
+        return {}
+    rows = conn.execute(
+        sqlalchemy.select(
+            schema.search_execution_results.c.execution_id,
+            schema.search_execution_results.c.result_id,
+            schema.search_execution_results.c.title,
+            schema.search_execution_results.c.url,
+        ).where(schema.search_execution_results.c.execution_id.in_(execution_ids))
+    )
+    return {(row.execution_id, row.result_id): FeedbackResultMetadata(row.title or "", row.url) for row in rows}
+
+
+def current_feedback_result_metadata(
+    conn: sqlalchemy.Connection, result_ids: set[str], config: EchoConfig
+) -> dict[str, FeedbackResultMetadata]:
+    metadata = {result_id: default_feedback_result_metadata(result_id, config) for result_id in result_ids}
+    wiki_ids = [int(result_id.removeprefix("wiki:")) for result_id in result_ids if result_id.startswith("wiki:")]
+    if wiki_ids:
+        for row in conn.execute(
+            sqlalchemy.select(schema.wiki_entries.c.id, schema.wiki_entries.c.title).where(
+                schema.wiki_entries.c.id.in_(wiki_ids)
+            )
+        ):
+            result_id = f"wiki:{row.id}"
+            metadata[result_id] = FeedbackResultMetadata(row.title, f"{config.public_url}/wiki/{row.id}")
+
+    activity_result_ids = {
+        int(value): result_id
+        for result_id in result_ids
+        for domain, _, value in [result_id.partition(":")]
+        if domain in {"discord", "pr", "issue"}
+    }
+    if activity_result_ids:
+        for row in conn.execute(
+            sqlalchemy.select(schema.chunks.c.id, schema.chunks.c.title, schema.chunks.c.url, schema.chunks.c.text)
+            .where(schema.chunks.c.id.in_(activity_result_ids))
+            .order_by(schema.chunks.c.id)
+        ):
+            result_id = activity_result_ids[row.id]
+            fallback = metadata[result_id]
+            title = row.title or " ".join((row.text or "").split())[: search_config.FEDERATED_SUMMARY_CHARACTERS]
+            metadata[result_id] = FeedbackResultMetadata(title or fallback.title, row.url)
+    return metadata
 
 
 def repository_file_search_result(
@@ -1206,6 +1292,74 @@ def search_executions(
             results=results_by_execution.get(row.id, []),
         )
         for row in execution_rows
+    ]
+
+
+@api.get("/feedback", response_model=list[SearchFeedbackListEntry])
+def list_search_feedback(
+    engine: Engine,
+    config: Config,
+    days: int = Query(30, ge=1, description="Look back this many days."),
+    limit: int = Query(200, ge=1, le=500),
+) -> list[SearchFeedbackListEntry]:
+    """Return recent feedback with browseable metadata for each graded result."""
+    cutoff = sqlalchemy.func.now() - sqlalchemy.func.make_interval(0, 0, 0, days)
+    statement = (
+        sqlalchemy.select(schema.search_feedback)
+        .where(schema.search_feedback.c.created_at > cutoff)
+        .order_by(schema.search_feedback.c.created_at.desc(), schema.search_feedback.c.id.desc())
+        .limit(limit)
+    )
+    with engine.connect() as conn:
+        feedback_rows = list(conn.execute(statement))
+        if not feedback_rows:
+            return []
+
+        feedback_ids = [row.id for row in feedback_rows]
+        grade_rows = list(
+            conn.execute(
+                sqlalchemy.select(schema.search_feedback_grades)
+                .where(schema.search_feedback_grades.c.feedback_id.in_(feedback_ids))
+                .order_by(
+                    schema.search_feedback_grades.c.feedback_id,
+                    schema.search_feedback_grades.c.grade.desc(),
+                    schema.search_feedback_grades.c.result_id,
+                )
+            )
+        )
+
+        execution_ids = {row.execution_id for row in feedback_rows if row.execution_id is not None}
+        exact_metadata = recorded_feedback_result_metadata(conn, execution_ids)
+        feedback_by_id = {row.id: row for row in feedback_rows}
+        missing_result_ids = set()
+        for grade in grade_rows:
+            feedback = feedback_by_id[grade.feedback_id]
+            exact = exact_metadata.get((feedback.execution_id, grade.result_id))
+            if exact is None or not exact.title:
+                missing_result_ids.add(grade.result_id)
+        current_metadata = current_feedback_result_metadata(conn, missing_result_ids, config)
+
+    grades_by_feedback: dict[int, list[SearchFeedbackResultGrade]] = {}
+    for grade in grade_rows:
+        feedback = feedback_by_id[grade.feedback_id]
+        current = current_metadata.get(grade.result_id) or default_feedback_result_metadata(grade.result_id, config)
+        exact = exact_metadata.get((feedback.execution_id, grade.result_id))
+        metadata = FeedbackResultMetadata(exact.title or current.title, exact.url) if exact else current
+        grades_by_feedback.setdefault(grade.feedback_id, []).append(
+            SearchFeedbackResultGrade(
+                result_id=grade.result_id,
+                grade=grade.grade,
+                title=metadata.title,
+                url=metadata.url,
+            )
+        )
+
+    return [
+        SearchFeedbackListEntry(
+            **{field: getattr(row, field) for field in SearchFeedbackListEntry.model_fields if field != "grades"},
+            grades=grades_by_feedback.get(row.id, []),
+        )
+        for row in feedback_rows
     ]
 
 

--- a/infra/echo/api/app.py
+++ b/infra/echo/api/app.py
@@ -752,7 +752,12 @@ def current_feedback_result_metadata(
     conn: sqlalchemy.Connection, result_ids: set[str], config: EchoConfig
 ) -> dict[str, FeedbackResultMetadata]:
     metadata = {result_id: default_feedback_result_metadata(result_id, config) for result_id in result_ids}
-    wiki_ids = [int(result_id.removeprefix("wiki:")) for result_id in result_ids if result_id.startswith("wiki:")]
+    wiki_ids = [
+        int(value)
+        for result_id in result_ids
+        for domain, _, value in [result_id.partition(":")]
+        if domain == "wiki" and int(value) <= search_feedback.MAX_NUMERIC_RESULT_ID
+    ]
     if wiki_ids:
         for row in conn.execute(
             sqlalchemy.select(schema.wiki_entries.c.id, schema.wiki_entries.c.title).where(
@@ -766,7 +771,7 @@ def current_feedback_result_metadata(
         int(value): result_id
         for result_id in result_ids
         for domain, _, value in [result_id.partition(":")]
-        if domain in {"discord", "pr", "issue"}
+        if domain in {"discord", "pr", "issue"} and int(value) <= search_feedback.MAX_NUMERIC_RESULT_ID
     }
     if activity_result_ids:
         for row in conn.execute(

--- a/infra/echo/api/test_app.py
+++ b/infra/echo/api/test_app.py
@@ -297,6 +297,78 @@ def test_search_feedback_links_matching_execution(client_with):
     assert feedback_insert.compile().params["execution_id"] == 991
 
 
+def test_search_feedback_list_includes_linked_results_and_explanation_only_entries(client_with):
+    feedback_rows = [
+        make_row(
+            id=18,
+            created_at=datetime(2026, 8, 12, tzinfo=UTC),
+            author="reviewer@openathena.ai",
+            query="missing scheduler detail",
+            note="No result answered the question.",
+            execution_id=None,
+        ),
+        make_row(
+            id=17,
+            created_at=datetime(2026, 8, 11, tzinfo=UTC),
+            author="agent@openathena.ai",
+            query="how do I deploy Iris?",
+            note="The operations guide answered the question; the wiki result was unrelated.",
+            execution_id=991,
+        ),
+    ]
+    grade_rows = [
+        make_row(feedback_id=17, result_id="file:lib/iris/OPS.md", grade=10),
+        make_row(feedback_id=17, result_id="wiki:123", grade=0),
+    ]
+    execution_result_rows = [
+        make_row(
+            execution_id=991,
+            result_id="file:lib/iris/OPS.md",
+            title="Iris Operations",
+            url="https://github.com/marin-community/marin/blob/abc/lib/iris/OPS.md",
+        )
+    ]
+    wiki_rows = [make_row(id=123, title="Stale Iris deployment notes")]
+    harness = client_with([], responses=[feedback_rows, grade_rows, execution_result_rows, wiki_rows])
+
+    response = harness.client.get("/api/feedback", params={"days": 30, "limit": 20})
+
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "id": 18,
+            "created_at": "2026-08-12T00:00:00Z",
+            "author": "reviewer@openathena.ai",
+            "query": "missing scheduler detail",
+            "note": "No result answered the question.",
+            "execution_id": None,
+            "grades": [],
+        },
+        {
+            "id": 17,
+            "created_at": "2026-08-11T00:00:00Z",
+            "author": "agent@openathena.ai",
+            "query": "how do I deploy Iris?",
+            "note": "The operations guide answered the question; the wiki result was unrelated.",
+            "execution_id": 991,
+            "grades": [
+                {
+                    "result_id": "file:lib/iris/OPS.md",
+                    "grade": 10,
+                    "title": "Iris Operations",
+                    "url": "https://github.com/marin-community/marin/blob/abc/lib/iris/OPS.md",
+                },
+                {
+                    "result_id": "wiki:123",
+                    "grade": 0,
+                    "title": "Stale Iris deployment notes",
+                    "url": "https://echo.oa.dev/wiki/123",
+                },
+            ],
+        },
+    ]
+
+
 def test_search_feedback_rejects_grade_absent_from_linked_execution(client_with):
     execution = make_row(author="agent@openathena.ai", query="how do I deploy Iris?")
     harness = client_with([], responses=[[execution], [["file:lib/iris/OPS.md"]]])

--- a/infra/echo/api/test_app.py
+++ b/infra/echo/api/test_app.py
@@ -459,6 +459,29 @@ def test_search_feedback_rejects_out_of_range_grade(client_with):
     assert harness.engine.executions == []
 
 
+def test_search_feedback_rejects_result_id_outside_bigint_range(client_with):
+    row = make_row(
+        id=19,
+        created_at=datetime(2026, 8, 14, tzinfo=UTC),
+        author="unknown",
+        query="scheduler",
+        note="The result looked relevant.",
+    )
+    harness = client_with([row])
+
+    response = harness.client.post(
+        "/api/feedback",
+        json={
+            "query": "scheduler",
+            "grades": [{"result_id": "wiki:9223372036854775808", "grade": 5}],
+            "note": "The result looked relevant.",
+        },
+    )
+
+    assert response.status_code == 422
+    assert harness.engine.executions == []
+
+
 def test_search_feedback_requires_overall_explanation(client_with):
     harness = client_with([])
     response = harness.client.post(

--- a/infra/echo/dashboard/src/App.vue
+++ b/infra/echo/dashboard/src/App.vue
@@ -8,11 +8,13 @@
         </router-link>
         <nav class="flex items-center gap-1 overflow-x-auto text-sm" aria-label="Echo areas">
           <router-link class="quick-tab" to="/">Search</router-link>
-          <a class="quick-tab" href="/?domain=file">Files</a>
+          <a class="quick-tab hidden sm:block" href="/?domain=file">Files</a>
           <router-link class="quick-tab" to="/wiki">Wiki</router-link>
-          <a class="quick-tab" href="/?domain=pr&domain=issue">GitHub</a>
-          <a class="quick-tab" href="/?domain=discord">Discord</a>
-          <a class="quick-tab" href="/docs">API</a>
+          <router-link class="quick-tab" to="/conversation">Conversation</router-link>
+          <router-link class="quick-tab" to="/feedback">Feedback</router-link>
+          <a class="quick-tab hidden sm:block" href="/?domain=pr&domain=issue">GitHub</a>
+          <a class="quick-tab hidden sm:block" href="/?domain=discord">Discord</a>
+          <a class="quick-tab hidden sm:block" href="/docs">API</a>
         </nav>
       </div>
     </header>

--- a/infra/echo/dashboard/src/router.ts
+++ b/infra/echo/dashboard/src/router.ts
@@ -3,6 +3,8 @@
 
 import { createRouter, createWebHistory } from 'vue-router'
 import ChunkView from './views/ChunkView.vue'
+import ConversationView from './views/ConversationView.vue'
+import FeedbackView from './views/FeedbackView.vue'
 import SearchView from './views/SearchView.vue'
 import WikiEntryView from './views/WikiEntryView.vue'
 import WikiListView from './views/WikiListView.vue'
@@ -12,6 +14,8 @@ export const router = createRouter({
   routes: [
     { path: '/', name: 'search', component: SearchView },
     { path: '/wiki', name: 'wiki-list', component: WikiListView },
+    { path: '/conversation', name: 'conversation', component: ConversationView },
+    { path: '/feedback', name: 'feedback', component: FeedbackView },
     { path: '/wiki/:id', name: 'wiki-entry', component: WikiEntryView, props: true },
     { path: '/chunk/:id', name: 'chunk', component: ChunkView, props: true },
   ],

--- a/infra/echo/dashboard/src/types.ts
+++ b/infra/echo/dashboard/src/types.ts
@@ -72,6 +72,35 @@ export interface RepositoryIndexStatus {
   indexed_at: string | null
 }
 
+export interface WorkLogSummary {
+  id: number
+  at: string
+  author: string
+  project: string
+  title: string
+}
+
+export interface WorkLogEntry extends WorkLogSummary {
+  body: string | null
+}
+
+export interface SearchFeedbackResultGrade {
+  result_id: string
+  grade: number
+  title: string
+  url: string
+}
+
+export interface SearchFeedbackEntry {
+  id: number
+  created_at: string
+  author: string
+  query: string
+  note: string
+  execution_id: number | null
+  grades: SearchFeedbackResultGrade[]
+}
+
 // The full chunk behind an activity hit: GET /api/chunks/{id} adds the untruncated text.
 export interface ActivityDetail extends ActivityHit {
   text: string | null
@@ -91,4 +120,8 @@ export async function fetchJson<T>(url: string, signal?: AbortSignal): Promise<T
 export function formatDate(value: string | null): string {
   if (!value) return 'Date unknown'
   return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(value))
+}
+
+export function formatDateTime(value: string): string {
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value))
 }

--- a/infra/echo/dashboard/src/views/ConversationView.vue
+++ b/infra/echo/dashboard/src/views/ConversationView.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { reactive, ref } from 'vue'
+import MarkdownBody from '../MarkdownBody.vue'
+import { fetchJson, formatDateTime, type WorkLogEntry, type WorkLogSummary } from '../types'
+
+const entries = ref<WorkLogSummary[]>([])
+const details = reactive(new Map<number, WorkLogEntry>())
+const detailErrors = reactive(new Map<number, string>())
+const loadingDetails = reactive(new Set<number>())
+const openEntry = ref<number | null>(null)
+const loading = ref(true)
+const error = ref('')
+
+async function load(): Promise<void> {
+  try {
+    entries.value = await fetchJson<WorkLogSummary[]>('/api/work_log?days=30&limit=100')
+  } catch (reason) {
+    error.value = reason instanceof Error ? reason.message : 'Could not load the conversation'
+  } finally {
+    loading.value = false
+  }
+}
+
+async function toggle(entry: WorkLogSummary): Promise<void> {
+  if (openEntry.value === entry.id) {
+    openEntry.value = null
+    return
+  }
+  openEntry.value = entry.id
+  if (details.has(entry.id)) return
+
+  loadingDetails.add(entry.id)
+  detailErrors.delete(entry.id)
+  try {
+    details.set(entry.id, await fetchJson<WorkLogEntry>(`/api/work_log/${entry.id}`))
+  } catch (reason) {
+    detailErrors.set(entry.id, reason instanceof Error ? reason.message : 'Could not load details')
+  } finally {
+    loadingDetails.delete(entry.id)
+  }
+}
+
+load()
+</script>
+
+<template>
+  <section class="max-w-3xl">
+    <p class="font-mono text-xs uppercase tracking-[0.18em] text-fern">Shared work log</p>
+    <h1 class="mt-2 text-3xl font-semibold tracking-[-0.03em] sm:text-5xl">What agents are working on.</h1>
+    <p class="mt-4 max-w-2xl text-sm leading-6 text-ink/55">
+      Recent milestones and active threads from Echo's agent conversation.
+    </p>
+  </section>
+
+  <section class="mt-8 max-w-4xl" aria-live="polite">
+    <div v-if="error" class="border-l-2 border-red-500 bg-red-50 px-4 py-3 text-sm text-red-800">
+      {{ error }}
+    </div>
+
+    <div v-if="loading" class="divide-y divide-line border-y border-line">
+      <div v-for="index in 4" :key="index" class="h-24 animate-pulse bg-white/35" />
+    </div>
+
+    <div v-else-if="!entries.length && !error" class="border-y border-line py-12 text-center text-sm text-ink/45">
+      No conversation entries in the last 30 days.
+    </div>
+
+    <div v-else class="divide-y divide-line border-y border-line">
+      <article v-for="entry in entries" :key="entry.id">
+        <button
+          class="group flex w-full items-start gap-4 py-5 text-left"
+          type="button"
+          :aria-expanded="openEntry === entry.id"
+          @click="toggle(entry)"
+        >
+          <span class="mt-1 hidden w-2 shrink-0 sm:block">
+            <span class="block size-2 rounded-full bg-fern/60 group-hover:bg-fern" />
+          </span>
+          <span class="min-w-0 flex-1">
+            <span class="flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[11px] uppercase tracking-wide text-ink/40">
+              <span class="text-moss">{{ entry.project }}</span>
+              <span>{{ formatDateTime(entry.at) }}</span>
+            </span>
+            <span class="mt-2 block text-base font-semibold leading-6 group-hover:text-moss">{{ entry.title }}</span>
+            <span class="mt-1 block text-xs text-ink/40">{{ entry.author }}</span>
+          </span>
+          <span class="mt-1 text-lg text-ink/35" aria-hidden="true">{{ openEntry === entry.id ? '−' : '+' }}</span>
+        </button>
+
+        <div v-if="openEntry === entry.id" class="mb-5 ml-0 border-l-2 border-fern/25 pl-4 sm:ml-6">
+          <p v-if="loadingDetails.has(entry.id)" class="py-2 text-sm text-ink/40">Loading details…</p>
+          <p v-else-if="detailErrors.get(entry.id)" class="py-2 text-sm text-red-700">
+            {{ detailErrors.get(entry.id) }}
+          </p>
+          <MarkdownBody v-else-if="details.get(entry.id)?.body" :source="details.get(entry.id)?.body || ''" />
+          <p v-else class="py-2 text-sm text-ink/40">No additional details.</p>
+        </div>
+      </article>
+    </div>
+  </section>
+</template>

--- a/infra/echo/dashboard/src/views/ConversationView.vue
+++ b/infra/echo/dashboard/src/views/ConversationView.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { reactive, ref } from 'vue'
+import { onMounted, reactive, ref } from 'vue'
 import MarkdownBody from '../MarkdownBody.vue'
 import { fetchJson, formatDateTime, type WorkLogEntry, type WorkLogSummary } from '../types'
+
+const LOOKBACK_DAYS = 30
 
 const entries = ref<WorkLogSummary[]>([])
 const details = reactive(new Map<number, WorkLogEntry>())
@@ -13,7 +15,7 @@ const error = ref('')
 
 async function load(): Promise<void> {
   try {
-    entries.value = await fetchJson<WorkLogSummary[]>('/api/work_log?days=30&limit=100')
+    entries.value = await fetchJson<WorkLogSummary[]>(`/api/work_log?days=${LOOKBACK_DAYS}&limit=100`)
   } catch (reason) {
     error.value = reason instanceof Error ? reason.message : 'Could not load the conversation'
   } finally {
@@ -40,7 +42,7 @@ async function toggle(entry: WorkLogSummary): Promise<void> {
   }
 }
 
-load()
+onMounted(load)
 </script>
 
 <template>
@@ -48,7 +50,7 @@ load()
     <p class="font-mono text-xs uppercase tracking-[0.18em] text-fern">Shared work log</p>
     <h1 class="mt-2 text-3xl font-semibold tracking-[-0.03em] sm:text-5xl">What agents are working on.</h1>
     <p class="mt-4 max-w-2xl text-sm leading-6 text-ink/55">
-      Recent milestones and active threads from Echo's agent conversation.
+      Recent milestones and active threads from Echo's shared agent work log.
     </p>
   </section>
 
@@ -62,7 +64,7 @@ load()
     </div>
 
     <div v-else-if="!entries.length && !error" class="border-y border-line py-12 text-center text-sm text-ink/45">
-      No conversation entries in the last 30 days.
+      No conversation entries in the last {{ LOOKBACK_DAYS }} days.
     </div>
 
     <div v-else class="divide-y divide-line border-y border-line">

--- a/infra/echo/dashboard/src/views/FeedbackView.vue
+++ b/infra/echo/dashboard/src/views/FeedbackView.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { fetchJson, formatDateTime, type SearchFeedbackEntry } from '../types'
+
+const entries = ref<SearchFeedbackEntry[]>([])
+const loading = ref(true)
+const error = ref('')
+
+function gradeClass(grade: number): string {
+  if (grade >= 8) return 'bg-emerald-100 text-emerald-800'
+  if (grade >= 4) return 'bg-amber-100 text-amber-800'
+  return 'bg-red-100 text-red-800'
+}
+
+async function load(): Promise<void> {
+  try {
+    entries.value = await fetchJson<SearchFeedbackEntry[]>('/api/feedback?days=30&limit=200')
+  } catch (reason) {
+    error.value = reason instanceof Error ? reason.message : 'Could not load search feedback'
+  } finally {
+    loading.value = false
+  }
+}
+
+load()
+</script>
+
+<template>
+  <section class="max-w-3xl">
+    <p class="font-mono text-xs uppercase tracking-[0.18em] text-fern">Search quality</p>
+    <h1 class="mt-2 text-3xl font-semibold tracking-[-0.03em] sm:text-5xl">Feedback from agents.</h1>
+    <p class="mt-4 max-w-2xl text-sm leading-6 text-ink/55">
+      Result-level grades and concise notes from recent Echo searches. Ten means directly useful; zero means irrelevant.
+    </p>
+  </section>
+
+  <section class="mt-8" aria-live="polite">
+    <div v-if="error" class="border-l-2 border-red-500 bg-red-50 px-4 py-3 text-sm text-red-800">
+      {{ error }}
+    </div>
+
+    <div v-if="loading" class="divide-y divide-line border-y border-line">
+      <div v-for="index in 5" :key="index" class="h-20 animate-pulse bg-white/35" />
+    </div>
+
+    <div v-else-if="!entries.length && !error" class="border-y border-line py-12 text-center text-sm text-ink/45">
+      No feedback in the last 30 days.
+    </div>
+
+    <template v-else>
+      <div class="divide-y divide-line border-y border-line md:hidden">
+        <article v-for="entry in entries" :key="entry.id" class="py-5">
+          <p class="font-medium leading-5 text-ink/80">{{ entry.query }}</p>
+          <p class="mt-1 leading-5 text-ink/50">{{ entry.note }}</p>
+          <div v-if="entry.grades.length" class="mt-4 divide-y divide-line/70 border-y border-line/70">
+            <div v-for="result in entry.grades" :key="result.result_id" class="flex items-start gap-3 py-3">
+              <span
+                class="inline-flex min-w-9 shrink-0 justify-center rounded-full px-2 py-1 font-mono text-xs font-semibold"
+                :class="gradeClass(result.grade)"
+              >
+                {{ result.grade }}
+              </span>
+              <div class="min-w-0 flex-1">
+                <a class="font-semibold leading-5 hover:text-moss" :href="result.url" rel="noreferrer" target="_blank">
+                  {{ result.title }}
+                </a>
+                <span class="mt-1 block truncate font-mono text-[11px] text-ink/35">{{ result.result_id }}</span>
+              </div>
+            </div>
+          </div>
+          <p v-else class="mt-4 border-y border-line/70 py-3 text-sm text-ink/45">No individual results graded.</p>
+          <p class="mt-3 text-xs text-ink/40">{{ entry.author }} · {{ formatDateTime(entry.created_at) }}</p>
+        </article>
+      </div>
+
+      <div class="hidden overflow-x-auto border-y border-line md:block">
+        <table class="w-full min-w-[860px] border-collapse text-left text-sm">
+          <thead class="font-mono text-[11px] uppercase tracking-wide text-ink/40">
+            <tr>
+              <th class="w-20 px-3 py-3 font-medium">Grade</th>
+              <th class="w-64 px-3 py-3 font-medium">Item</th>
+              <th class="px-3 py-3 font-medium">Query and note</th>
+              <th class="w-44 px-3 py-3 font-medium">Agent</th>
+              <th class="w-40 px-3 py-3 font-medium">When</th>
+            </tr>
+          </thead>
+          <tbody v-for="entry in entries" :key="entry.id" class="border-t border-line first:border-t-0">
+            <tr v-if="!entry.grades.length" class="align-top hover:bg-white/35">
+              <td class="px-3 py-4 font-mono text-ink/30">—</td>
+              <td class="px-3 py-4 font-medium text-ink/55">Overall result set</td>
+              <td class="px-3 py-4">
+                <p class="font-medium leading-5 text-ink/80">{{ entry.query }}</p>
+                <p class="mt-1 line-clamp-2 leading-5 text-ink/50">{{ entry.note }}</p>
+              </td>
+              <td class="max-w-44 truncate px-3 py-4 text-xs text-ink/50">{{ entry.author }}</td>
+              <td class="px-3 py-4 text-xs text-ink/45">{{ formatDateTime(entry.created_at) }}</td>
+            </tr>
+            <tr v-for="(result, index) in entry.grades" v-else :key="result.result_id" class="align-top hover:bg-white/35">
+              <td class="px-3 py-4">
+                <span
+                  class="inline-flex min-w-9 justify-center rounded-full px-2 py-1 font-mono text-xs font-semibold"
+                  :class="gradeClass(result.grade)"
+                >
+                  {{ result.grade }}
+                </span>
+              </td>
+              <td class="px-3 py-4">
+                <a class="line-clamp-2 font-semibold leading-5 hover:text-moss" :href="result.url" rel="noreferrer" target="_blank">
+                  {{ result.title }}
+                </a>
+                <span class="mt-1 block truncate font-mono text-[11px] text-ink/35">{{ result.result_id }}</span>
+              </td>
+              <td v-if="index === 0" class="px-3 py-4" :rowspan="entry.grades.length">
+                <p class="font-medium leading-5 text-ink/80">{{ entry.query }}</p>
+                <p class="mt-1 line-clamp-2 leading-5 text-ink/50">{{ entry.note }}</p>
+              </td>
+              <td v-if="index === 0" class="max-w-44 truncate px-3 py-4 text-xs text-ink/50" :rowspan="entry.grades.length">
+                {{ entry.author }}
+              </td>
+              <td v-if="index === 0" class="px-3 py-4 text-xs text-ink/45" :rowspan="entry.grades.length">
+                {{ formatDateTime(entry.created_at) }}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </template>
+  </section>
+</template>

--- a/infra/echo/dashboard/src/views/FeedbackView.vue
+++ b/infra/echo/dashboard/src/views/FeedbackView.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import { fetchJson, formatDateTime, type SearchFeedbackEntry } from '../types'
+
+const LOOKBACK_DAYS = 30
 
 const entries = ref<SearchFeedbackEntry[]>([])
 const loading = ref(true)
@@ -14,7 +16,7 @@ function gradeClass(grade: number): string {
 
 async function load(): Promise<void> {
   try {
-    entries.value = await fetchJson<SearchFeedbackEntry[]>('/api/feedback?days=30&limit=200')
+    entries.value = await fetchJson<SearchFeedbackEntry[]>(`/api/feedback?days=${LOOKBACK_DAYS}&limit=200`)
   } catch (reason) {
     error.value = reason instanceof Error ? reason.message : 'Could not load search feedback'
   } finally {
@@ -22,7 +24,7 @@ async function load(): Promise<void> {
   }
 }
 
-load()
+onMounted(load)
 </script>
 
 <template>
@@ -44,7 +46,7 @@ load()
     </div>
 
     <div v-else-if="!entries.length && !error" class="border-y border-line py-12 text-center text-sm text-ink/45">
-      No feedback in the last 30 days.
+      No feedback in the last {{ LOOKBACK_DAYS }} days.
     </div>
 
     <template v-else>

--- a/infra/echo/search_feedback.py
+++ b/infra/echo/search_feedback.py
@@ -11,6 +11,7 @@ MAX_QUERY_CHARACTERS = 2_000
 MAX_NOTE_CHARACTERS = 2_000
 MAX_RESULT_ID_CHARACTERS = 4_096
 MAX_GRADES = search_config.RERANK_MAX_CANDIDATES
+MAX_NUMERIC_RESULT_ID = 2**63 - 1
 MIN_GRADE = search_config.SEARCH_FEEDBACK_MIN_GRADE
 MAX_GRADE = search_config.SEARCH_FEEDBACK_MAX_GRADE
 
@@ -21,8 +22,11 @@ def checked_result_id(value: str) -> str:
         raise ValueError("must be <wiki|file|discord|pr|issue>:<id>")
     if len(value) > MAX_RESULT_ID_CHARACTERS:
         raise ValueError(f"must be at most {MAX_RESULT_ID_CHARACTERS} characters")
-    if domain != "file" and not detail.isdecimal():
-        raise ValueError(f"{domain} result IDs are numeric")
+    if domain != "file":
+        if not detail.isdecimal():
+            raise ValueError(f"{domain} result IDs are numeric")
+        if int(detail) > MAX_NUMERIC_RESULT_ID:
+            raise ValueError(f"{domain} result IDs must fit a signed 64-bit integer")
     return value
 
 


### PR DESCRIPTION
Expose Echo's shared agent work log as a Conversation tab with recent milestones and expandable Markdown details.

Add a Feedback tab that groups each submission's 0-10 grades with linked result titles, query, note, author, and timestamp. Explanation-only submissions remain visible. A read-only API endpoint returns the data, preferring metadata from the matching recorded search snapshot and resolving older unlinked grades against current Echo sources.
