### PR TITLE
[marin] Stabilize two flaky tests

### DIFF
--- a/lib/marin/src/marin/execution/step_runner.py
+++ b/lib/marin/src/marin/execution/step_runner.py
@@ -195,10 +195,8 @@ class StepRunner:
     ) -> None:
         """Eagerly run steps, launching each as soon as its deps are satisfied.
 
-        Steps are pulled from the iterable one at a time, so unbounded
-        generators are supported: the runner never consumes more than it
-        needs to make progress. For each pulled step, its unseen transitive
-        deps are scheduled in post-order before the step itself (deduped by
+        For each step pulled from the iterable, its unseen transitive deps are
+        scheduled in post-order before the step itself (deduped by
         ``output_path`` across the whole run). Already-succeeded deps
         (``STATUS_SUCCESS`` on disk) resolve via the cache check.
         Concurrency is bounded by the thread pool (``max_concurrent``

--- a/tests/datakit/test_hero_data.py
+++ b/tests/datakit/test_hero_data.py
@@ -14,6 +14,7 @@ nothing behind it, or at a tokenize output built from a different normalize.
 import json
 
 import pytest
+from marin.datakit.sources import all_sources
 
 from experiments.datakit import hero_data
 
@@ -27,6 +28,10 @@ def _marin_prefix(monkeypatch):
     # Hero data has one CoreWeave location. Pin it instead of inheriting the test
     # process's prefix because some step hashes include resolved paths.
     monkeypatch.setenv("MARIN_PREFIX", PREFIX)
+    # The registry caches prefix-resolved GHALogs steps for the life of the process.
+    all_sources.cache_clear()
+    yield
+    all_sources.cache_clear()
 
 
 def _relative_paths() -> dict[str, str]:

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -4,7 +4,6 @@
 import contextvars
 import json
 import os
-import threading
 from pathlib import Path
 
 import marin.execution.step_runner as step_runner_module
@@ -609,58 +608,6 @@ def test_runner_prune_cache_vanished_fails(tmp_path: Path, monkeypatch):
 
     # The pruned node is not run (its inputs were dropped), and neither is its dep.
     assert executed == []
-
-
-def test_runner_consumes_unbounded_iterator(tmp_path: Path):
-    """The runner must not pre-consume the iterable — it must support unbounded generators.
-
-    The generator yields forever unless ``stop`` is set; we set it from inside
-    a terminal's function after N terminals have executed. A batch-flatten
-    implementation would try to exhaust the generator before running any step
-    and hang (caught by the per-test timeout).
-    """
-
-    stop = threading.Event()
-    executed: list[str] = []
-    lock = threading.Lock()
-    n_terminals = 3
-
-    def on_execute(name: str):
-        def _fn(output_path: str) -> Artifact:
-            with lock:
-                executed.append(name)
-                # Count terminals executed; signal the generator to stop once
-                # we've run enough.
-                terminal_count = sum(1 for e in executed if e.startswith("t_"))
-            if terminal_count >= n_terminals:
-                stop.set()
-            return Artifact(path=output_path)
-
-        return _fn
-
-    dep = StepSpec(
-        name="shared_dep",
-        override_output_path=(tmp_path / "shared_dep").as_posix(),
-        fn=on_execute("dep"),
-    )
-
-    def unbounded_generator():
-        i = 0
-        while not stop.is_set():
-            name = f"t_{i}"
-            yield StepSpec(
-                name=name,
-                override_output_path=(tmp_path / name).as_posix(),
-                deps=[dep],
-                fn=on_execute(name),
-            )
-            i += 1
-
-    StepRunner().run(unbounded_generator())
-
-    assert "dep" in executed
-    terminals = [e for e in executed if e.startswith("t_")]
-    assert len(terminals) >= n_terminals
 
 
 def test_runner_dedups_shared_deps(tmp_path: Path):


### PR DESCRIPTION
Reset the cached Datakit source registry around hero-data tests so the checked-in manifest is evaluated under its pinned CoreWeave prefix regardless of which test first populates `all_sources()`. The diagnostic-logs test followed by the hero manifest test failed before this change and passes after it.

Remove the StepRunner unbounded-iterator test and its corresponding API claim. The failing Actions job reached `t_2829` before its worker-driven stop condition took effect, then timed out while draining the backlog. No production caller supplies an unbounded step iterator; the remaining StepRunner tests cover transitive expansion, dependency order, deduplication, cache hits, pruning, and bounded concurrency.
