### PR TITLE
[grug] Point ladder rungs at the surviving legacy datakit store

### DIFF
--- a/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
+++ b/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
@@ -241,11 +241,20 @@ def _active_params(cfg: GrugModelConfig) -> int:
     return cfg.num_layers * (attn + router + routed + latent_proj + shared)
 
 
+# The MARIN_PREFIX-rooted store copy (marin/datakit/store_8ac06c74) lost cluster=0 and
+# most of cluster=1 in the 2026-08-13 storage-limit purge. The same data in the legacy
+# store format survives at the bucket root; point components there until the rooted copy
+# is recomputed (#marin-eng thread 2026-08-14, confirmed working by Will and Rafal).
+_LEGACY_STORE_ROOT = "s3://marin-us-east-02a/"
+
+
 def _root_component(component: DatasetComponent | ConcatDatasetComponent) -> DatasetComponent | ConcatDatasetComponent:
     """Root a datakit component's relative cache_dir against MARIN_PREFIX (recursing into concat
     children); absolute paths -- e.g. the paloma/uncheatable caches -- pass through unchanged."""
     if isinstance(component, ConcatDatasetComponent):
         return dataclasses.replace(component, children={n: _root_component(c) for n, c in component.children.items()})
+    if component.cache_dir.startswith("datakit/store_8ac06c74"):
+        return dataclasses.replace(component, cache_dir=_LEGACY_STORE_ROOT + component.cache_dir)
     return dataclasses.replace(component, cache_dir=datakit_source_path(component.cache_dir))
 
 


### PR DESCRIPTION
Point the small-scale ablation rungs' mixture components at the legacy datakit store at the bucket root (`s3://marin-us-east-02a/datakit/store_8ac06c74`), bypassing the `MARIN_PREFIX`-rooted copy.

The 2026-08-13 storage-limit purge deleted `cluster=0` entirely and all of `cluster=1` except `quality=4` from the rooted copy ([#marin-eng thread](https://openathena.slack.com/archives/C0AHF5KV11Q/p1786671980136459)); a probe today confirms it is still unrestored. Every ladder rung launched from main since then fails at data loading with `Cache ledger not found`. The legacy-format copy at the bucket root holds the same data with all 200 buckets present, and about ten rung runs have trained on it since the purge with matching drop dynamics and loss curves (median step cost of the legacy layout is ~1.2%, applied equally to all arms).

This is a stopgap with two natural expirations: the rooted copy being recomputed, or #8263 moving the rungs to the Harrier mix — whichever lands first deletes this. Until then it keeps the #8062-ladder-comparable mixture runnable.
