### PR TITLE
[loom] Add interactive GitHub App fallback

### DIFF
--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -31,7 +31,7 @@ config:
       class: interactive
       prelude: weaver
       instructionsFile: profiles/user/AGENTS.md
-      githubRepositories:
+      githubRepositories: &interactiveGithubRepositories
         - Open-Athena/marinmirror
         - Open-Athena/mumwelt
         - marin-community/MarinSkyRL
@@ -54,16 +54,7 @@ config:
       class: interactive
       prelude: weaver
       instructionsFile: profiles/github/AGENTS.md
-      githubRepositories:
-        - Open-Athena/marinmirror
-        - Open-Athena/mumwelt
-        - marin-community/MarinSkyRL
-        - marin-community/evalchemy
-        - marin-community/harbor
-        - marin-community/loom
-        - marin-community/marin
-        - marin-community/marin-style
-        - marin-community/vllm
+      githubRepositories: *interactiveGithubRepositories
       mcpAccess:
         mode: all
         groups: []
@@ -125,16 +116,7 @@ config:
       class: interactive
       prelude: weaver
       instructionsFile: profiles/slack/AGENTS.md
-      githubRepositories:
-        - Open-Athena/marinmirror
-        - Open-Athena/mumwelt
-        - marin-community/MarinSkyRL
-        - marin-community/evalchemy
-        - marin-community/harbor
-        - marin-community/loom
-        - marin-community/marin
-        - marin-community/marin-style
-        - marin-community/vllm
+      githubRepositories: *interactiveGithubRepositories
       mcpAccess:
         mode: all
         groups: []

--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -31,6 +31,16 @@ config:
       class: interactive
       prelude: weaver
       instructionsFile: profiles/user/AGENTS.md
+      githubRepositories:
+        - Open-Athena/marinmirror
+        - Open-Athena/mumwelt
+        - marin-community/MarinSkyRL
+        - marin-community/evalchemy
+        - marin-community/harbor
+        - marin-community/loom
+        - marin-community/marin
+        - marin-community/marin-style
+        - marin-community/vllm
       mcpAccess:
         mode: all
         groups: []
@@ -44,6 +54,16 @@ config:
       class: interactive
       prelude: weaver
       instructionsFile: profiles/github/AGENTS.md
+      githubRepositories:
+        - Open-Athena/marinmirror
+        - Open-Athena/mumwelt
+        - marin-community/MarinSkyRL
+        - marin-community/evalchemy
+        - marin-community/harbor
+        - marin-community/loom
+        - marin-community/marin
+        - marin-community/marin-style
+        - marin-community/vllm
       mcpAccess:
         mode: all
         groups: []
@@ -105,6 +125,16 @@ config:
       class: interactive
       prelude: weaver
       instructionsFile: profiles/slack/AGENTS.md
+      githubRepositories:
+        - Open-Athena/marinmirror
+        - Open-Athena/mumwelt
+        - marin-community/MarinSkyRL
+        - marin-community/evalchemy
+        - marin-community/harbor
+        - marin-community/loom
+        - marin-community/marin
+        - marin-community/marin-style
+        - marin-community/vllm
       mcpAccess:
         mode: all
         groups: []

--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -105,6 +105,13 @@ ordinary sessions use the deployment-managed `default` profile, while workload
 and future GitHub Actions callers select the automation profile authorized by
 their federation mapping.
 
+The `default`, `github`, and `slack` profiles allowlist the repositories where
+interactive sessions may fall back to the `loom-oa-dev` GitHub App. Loom stamps
+only the session's current repository and brokers a short-lived installation
+token when the launching user has not stored a personal token. A personal token
+continues to take precedence. Keep these lists aligned with the repositories
+registered in production and the App's installations.
+
 The Pulumi declaration is authoritative at activation time. An unchanged
 profile keeps its database revision; a changed declaration overwrites the
 current row and advances the revision. UI or API edits persist only until the


### PR DESCRIPTION
Give Marin's default, GitHub, and Slack profiles the shared repository allowlist used for Loom's short-lived GitHub App fallback. Sessions use a stored personal token when present; otherwise Loom brokers an installation token scoped to the current repository. This restores PR creation for GitHub and Slack sessions without storing a shared `GH_TOKEN` in deployment-managed profile environments.

Deploy marin-community/loom#291 before activating this stack. Older Loom versions reject GitHub repository credentials on interactive profiles.
