### PR TITLE
[fray] Exit cleanly when actor registration is rejected

### DIFF
--- a/lib/fray/src/fray/iris_backend.py
+++ b/lib/fray/src/fray/iris_backend.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import cloudpickle
+from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 from iris.actor.client import ActorClient
 from iris.actor.resolver import Resolver
@@ -329,7 +330,15 @@ def _host_actor(actor_class: type, args: tuple, kwargs: dict, name_prefix: str) 
     # XXX: this should be handled by the actor server?
     address = f"http://{advertise_host}:{actual_port}"
     logger.info(f"Registering endpoint: {actor_name} -> {address}")
-    ctx.registry.register(actor_name, address)
+    try:
+        ctx.registry.register(actor_name, address)
+    except ConnectError as exc:
+        if exc.code == Code.FAILED_PRECONDITION:
+            logger.error("Actor %s stopped before endpoint registration: %s", actor_name, exc)
+            server.stop()
+            return
+        server.stop()
+        raise
     logger.info(f"Actor {actor_name} ready and listening")
 
     # Block until the actor signals shutdown via shutdown_event

--- a/lib/fray/tests/test_iris.py
+++ b/lib/fray/tests/test_iris.py
@@ -7,6 +7,7 @@ Tests type conversions and handle serialization without requiring an Iris cluste
 Integration tests that need a running cluster are marked with @pytest.mark.iris.
 """
 
+import logging
 import pickle
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -210,7 +211,7 @@ def test_actor_startup_after_task_termination_stops_server_without_error(monkeyp
     iris_backend._host_actor(object, (), {}, "actor")
 
     assert stopped
-    assert "Actor /user/job/actor-0 stopped before endpoint registration" in caplog.text
+    assert any(record.levelno == logging.ERROR for record in caplog.records)
 
 
 class TestResourceConfigScale:

--- a/lib/fray/tests/test_iris.py
+++ b/lib/fray/tests/test_iris.py
@@ -13,6 +13,8 @@ from unittest.mock import MagicMock
 
 import fray.iris_backend as iris_backend
 import pytest
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
 from fray.iris_backend import (
     FrayIrisClient,
     IrisActorHandle,
@@ -31,7 +33,7 @@ from fray.types import (
 )
 from iris.cluster.constraints import ConstraintOp
 from iris.cluster.types import Entrypoint as IrisEntrypoint
-from iris.cluster.types import ResourceSpec, gpu_device
+from iris.cluster.types import JobName, ResourceSpec, gpu_device
 
 
 class TestConvertConstraints:
@@ -183,6 +185,32 @@ def test_iris_job_handle_returns_a_globally_bounded_tail():
 
     assert lines == ("task-0 earlier", "task-1 latest")
     job.logs.assert_called_once_with(max_lines=2, tail=True)
+
+
+def test_actor_startup_after_task_termination_stops_server_without_error(monkeypatch, caplog):
+    def reject_registration(_name, _address):
+        raise ConnectError(
+            Code.FAILED_PRECONDITION,
+            "Task /user/job/0 is already terminal; endpoint not registered",
+        )
+
+    stopped = []
+    server = SimpleNamespace(
+        register=lambda _name, _instance: None,
+        serve_background=lambda: 1234,
+        stop=lambda: stopped.append(True),
+    )
+    registry = SimpleNamespace(register=reject_registration)
+    ctx = SimpleNamespace(job_id=JobName.from_wire("/user/job"), registry=registry, get_port=lambda _name: 1234)
+    job_info = SimpleNamespace(task_index=0, advertise_host="worker")
+    monkeypatch.setattr(iris_backend, "ActorServer", lambda **_kwargs: server)
+    monkeypatch.setattr(iris_backend, "iris_ctx", lambda: ctx)
+    monkeypatch.setattr(iris_backend, "get_job_info", lambda: job_info)
+
+    iris_backend._host_actor(object, (), {}, "actor")
+
+    assert stopped
+    assert "Actor /user/job/actor-0 stopped before endpoint registration" in caplog.text
 
 
 class TestResourceConfigScale:


### PR DESCRIPTION
Exit a Fray actor task cleanly when endpoint registration returns
`FAILED_PRECONDITION`. Iris uses this response after the task becomes terminal
or its attempt becomes stale, so Fray logs the rejection, stops the actor
server, and returns from the task entrypoint. Transient controller and transport
errors keep the endpoint client's existing retry behavior.

The triggering fuzzy-dedup job first failed with `ArrowInvalid` because an input
Parquet file lacked `dup_cluster_id`. Iris terminated its Zephyr descendants at
00:56:41 UTC; several workers reached actor registration seven to eight seconds
later and added secondary tracebacks. The investigation is recorded at
https://echo.oa.dev/wiki/156.
