### PR TITLE
ops: fail the CoreWeave storage collector when its token is missing

### DIFF
--- a/.github/workflows/ops-coreweave-storage.yaml
+++ b/.github/workflows/ops-coreweave-storage.yaml
@@ -24,53 +24,49 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      # A run that collects nothing must be red. A green run here is the signal that
+      # the Grafana staleness rule trusts, so skipping the collector on a missing
+      # secret would leave the dashboard silently frozen.
       - name: Check CoreWeave token
-        id: coreweave-token
         env:
           COREWEAVE_API_TOKEN: ${{ secrets.COREWEAVE_API_TOKEN }}
         run: |
           if [[ -z "$COREWEAVE_API_TOKEN" ]]; then
-            echo "::notice::COREWEAVE_API_TOKEN is not set. The storage collector is inactive."
-            echo "available=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "::error::COREWEAVE_API_TOKEN is not set, so the storage collector cannot run."
+            exit 1
           fi
 
       - name: Checkout repository
-        if: steps.coreweave-token.outputs.available == 'true'
         uses: actions/checkout@v5
 
       - name: Set up Python
-        if: steps.coreweave-token.outputs.available == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Install uv
-        if: steps.coreweave-token.outputs.available == 'true'
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: Sync uv environment
-        if: steps.coreweave-token.outputs.available == 'true'
         run: uv sync --all-packages --extra=cpu --no-default-groups
 
       - name: Authenticate to Google Cloud
-        if: steps.coreweave-token.outputs.available == 'true' && !inputs.dry_run
+        if: ${{ !inputs.dry_run }}
         uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
 
       - name: Set up Google Cloud SDK
-        if: steps.coreweave-token.outputs.available == 'true' && !inputs.dry_run
+        if: ${{ !inputs.dry_run }}
         uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Install SSH key
-        if: steps.coreweave-token.outputs.available == 'true' && !inputs.dry_run
+        if: ${{ !inputs.dry_run }}
         env:
           SSH_KEY: ${{ secrets.IRIS_CI_GCP_SSH_KEY }}
           SSH_KEY_PUB: ${{ secrets.IRIS_CI_GCP_SSH_KEY_PUB }}
@@ -82,7 +78,6 @@ jobs:
           chmod 644 ~/.ssh/google_compute_engine.pub
 
       - name: Record CoreWeave storage telemetry
-        if: steps.coreweave-token.outputs.available == 'true'
         env:
           COREWEAVE_API_TOKEN: ${{ secrets.COREWEAVE_API_TOKEN }}
         run: |

--- a/scripts/ops/storage/README.md
+++ b/scripts/ops/storage/README.md
@@ -82,8 +82,8 @@ COREWEAVE_API_TOKEN=... \
 
 `.github/workflows/ops-coreweave-storage.yaml` runs the collector each hour.
 The workflow writes to the `marin` Finelog server through the standard GCP SSH
-tunnel. Set the repository secret `COREWEAVE_API_TOKEN` to activate it. The
-workflow writes a notice and stops when this secret is not set.
+tunnel. It needs the repository secret `COREWEAVE_API_TOKEN` and fails without
+it, because a green run that collects nothing hides a frozen dashboard.
 
 The Grafana `Storage` dashboard shows bucket bytes and quota use for each zone.
 The `CoreWeaveStorageCapacity` rule sends a Slack warning after quota use stays
@@ -92,9 +92,13 @@ warning above 720 TiB. The rule reads the quota metric, so it also follows a
 later quota change.
 
 The `CoreWeaveStorageTelemetryStale` rule sends a Slack warning when a known
-storage series is more than three hours old. Both rules stay normal before the
-first collector result. For a stale-data warning, check the hourly workflow and
-the token first. For a quota warning, check the zone values in the Storage
-dashboard and in the [CoreWeave quota page].
+storage series is more than three hours old. For a stale-data warning, check the
+hourly workflow and the token first. For a quota warning, check the zone values
+in the Storage dashboard and in the [CoreWeave quota page].
+
+Both rules read the `storage.usage` namespace, which exists only after the
+collector writes its first rows. Until then the query fails, and because both
+rules set `execErrState: Alerting`, each one pages with `[no value]` labels. Run
+the collector once when you add a rule that reads a new namespace.
 
 [CoreWeave quota page]: https://docs.coreweave.com/products/storage/object-storage/manage-quotas


### PR DESCRIPTION
The hourly collector skipped every real step when `COREWEAVE_API_TOKEN` was absent and still reported success. A dispatched run finished in six seconds, green, having collected nothing. That is why the alerts added in #8238 sat on an unregistered `storage.usage` namespace without anyone noticing.

The token check now fails the job. A green run is the signal the staleness rule trusts, so a run that collects nothing must be red.

The README claimed both rules stay normal before the first collector result. They do not: the query fails on a namespace that does not exist yet, and `execErrState: Alerting` turns that into a page with `[no value]` labels. The README now says so.

The secret is set and the collector has run, so `storage.usage` holds real rows and both rule queries execute clean. `marin-us-east-02a` reads 858.63 TiB against a 910 TiB quota (94.4%), so CoreWeaveStorageCapacity now fires on real data with a real `region` label — a true positive that stays firing until the quota rises or the bucket shrinks.

A first-run page is accepted behavior, so this does not try to suppress it.