### PR TITLE
[iris] Disable same-band production preemption

### DIFF
--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -166,14 +166,16 @@ nine `WorkloadPriorityClass` objects at startup.
 | --- | ---: | ---: | ---: |
 | batch | 0 | 1 | 2 |
 | interactive | 10 | 11 | 12 |
-| production | 1000 | 1001 | 1002 |
+| production | 1000 | 1000 | 1000 |
 
-The ordering is CPU < accelerator < co-scheduled group within a band. Kueue can
-therefore reclaim same-band CPU reservations for one accelerator Pod, or both
-lower tiers for a co-scheduled GPU group. A user-selected higher band still
-outranks every tier in the band below it. Pod `priorityClassName` remains the
-ordinary Iris band, so this ordering affects Kueue admission and preemption but
-does not change kube-scheduler priority within an admitted workload.
+Batch and interactive workloads are ordered CPU < accelerator < co-scheduled
+group within their band. Kueue can reclaim same-band CPU reservations for one
+accelerator Pod, or both lower tiers for a co-scheduled GPU group. Production
+workloads share one Kueue priority, so request shape cannot cause one production
+workload to preempt another. A user-selected higher band still outranks every
+tier in the band below it. Pod `priorityClassName` remains the ordinary Iris
+band, so this ordering affects Kueue admission and preemption but does not change
+kube-scheduler priority within an admitted workload.
 
 For example, a `batch` CPU coordinator uses tier `0`, its separately admitted
 accelerator child uses tier `1`, and a co-scheduled CPU/GPU group uses tier `2`.
@@ -185,18 +187,16 @@ Kubernetes priority `-1`, and Iris batch Pods retain Kubernetes priority `0`.
 Kueue Workload priority and Kubernetes Pod priority are separate scheduling
 domains, but neither representation places Iris work below the health checker.
 
-Workloads created before this mapping use the native band value, equal to the
-new CPU tier. During rollout, a new accelerator or co-scheduled Workload can
-therefore preempt older same-band work. Drain older same-band accelerator and
-co-scheduled Workloads before deployment when they must not be interrupted.
-
 ```mermaid
 flowchart TD
-    request[RunTaskRequest] --> gang{Co-scheduled group?}
+    request[RunTaskRequest] --> production{Production band?}
+    production -- Yes --> prod[Use production priority 1000]
+    production -- No --> gang
     gang -- Yes --> native[Use band plus 2<br/>co-scheduled tier]
     gang -- No --> accelerator{Accelerator requested?}
     accelerator -- Yes --> gpu[Use band plus 1<br/>accelerator tier]
     accelerator -- No --> cpu[Use native Iris band<br/>CPU tier]
+    prod --> queue[Kueue LocalQueue and shared ClusterQueue]
     native --> queue[Kueue LocalQueue and shared ClusterQueue]
     gpu --> queue
     cpu --> queue

--- a/lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/kueue_manifests.py
@@ -20,7 +20,11 @@ from iris.cluster.platforms.k8s.coreweave_topology import (
     CW_MULTINODE_TOPOLOGY_LABELS,
 )
 from iris.cluster.platforms.k8s.nodepool_manifests import KUEUE_NODE_LABEL
-from iris.cluster.platforms.k8s.types import IRIS_PRIORITY_CLASS_SYSTEM, IRIS_PRIORITY_CLASSES
+from iris.cluster.platforms.k8s.types import (
+    IRIS_PRIORITY_CLASS_PRODUCTION,
+    IRIS_PRIORITY_CLASS_SYSTEM,
+    IRIS_PRIORITY_CLASSES,
+)
 
 # --------------------------------------------------------------------------
 # Variants
@@ -119,11 +123,12 @@ NON_BINDING_QUOTA = {
 COVERED_RESOURCES = list(NON_BINDING_QUOTA)
 
 
-# Kueue-only priorities within each Iris band. Ordinary, standalone-accelerator,
-# and co-scheduled Workloads occupy consecutive values starting at the native
-# band. This keeps the lowest batch Workload priority at 0, above CoreWeave's
-# priority -1 node-health-check Pods even though Kueue and Pod priority are
-# separate scheduling domains.
+# Kueue-only priorities within each Iris band. Batch and interactive Workloads
+# order ordinary, standalone-accelerator, and co-scheduled work consecutively.
+# Production Workloads share one value so their request shape cannot preempt
+# other production work. The lowest batch Workload priority remains 0, above
+# CoreWeave's priority -1 node-health-check Pods even though Kueue and Pod
+# priority are separate scheduling domains.
 class WorkloadPriorityKind(StrEnum):
     CPU = "cpu"
     ACCELERATOR = "accelerator"
@@ -147,7 +152,7 @@ IRIS_WORKLOAD_PRIORITY_CLASSES = tuple(
         band=class_name.removeprefix("iris-"),
         kind=kind,
         name=workload_priority_class_name(class_name.removeprefix("iris-"), kind),
-        value=value + offset,
+        value=value if class_name == IRIS_PRIORITY_CLASS_PRODUCTION else value + offset,
     )
     for class_name, value, _ in IRIS_PRIORITY_CLASSES
     if class_name != IRIS_PRIORITY_CLASS_SYSTEM

--- a/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
@@ -319,8 +319,8 @@ def test_start_controller_creates_controller_resources():
         "iris-accelerator-interactive": 11,
         "iris-coscheduled-interactive": 12,
         "iris-cpu-production": 1000,
-        "iris-accelerator-production": 1001,
-        "iris-coscheduled-production": 1002,
+        "iris-accelerator-production": 1000,
+        "iris-coscheduled-production": 1000,
     }
 
     agent_spec = node_agent["spec"]["template"]["spec"]


### PR DESCRIPTION
Give CPU, standalone accelerator, and coscheduled production Kueue workloads
the same numeric priority. A production GPU gang can no longer evict CPU-only
production work based on request shape.

Keep the existing CPU, accelerator, and coscheduled ordering within the
interactive and batch bands, and keep cross-band preemption unchanged.
