### PR TITLE
[eval] Preserve benchmark generation limits

### DIFF
--- a/experiments/evaluation/configs/evalchemy/olympiadbench.yaml
+++ b/experiments/evaluation/configs/evalchemy/olympiadbench.yaml
@@ -4,5 +4,5 @@ task_options:
     num_fewshot: 0
     task_alias: olympiadbench
     generation: true
-max_tokens: 8192
+max_tokens: 32768
 runtime_extras: [olympiadbench]

--- a/experiments/evaluation/evals.py
+++ b/experiments/evaluation/evals.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -25,6 +26,8 @@ from marin.evaluation.records import EvalchemyRef, EvalRef, EvalTaskRef, HarborR
 from marin.evaluation.runner import EvalExecutor
 from marin.external_dependencies import EVALCHEMY
 from rigging.secrets import SecretSpec
+
+logger = logging.getLogger(__name__)
 
 _DAYTONA_ENVIRONMENT_TYPE = "daytona"
 _EVALCHEMY_CONFIG_DIR = Path(__file__).with_name("configs") / "evalchemy"
@@ -76,14 +79,25 @@ class EvalchemyDefinition:
     def config_for(self, source: EvalchemyConfig, model: ModelConfig, limit: int | None) -> EvalchemyRunConfig:
         config = evalchemy_run_config(self.name, source)
         effective_limit = config.max_eval_instances if limit is None else limit
+        model_max_gen_toks = model.generation.max_gen_toks
+        max_gen_toks = config.max_gen_toks
+        if model_max_gen_toks is not None:
+            if source.max_tokens is None or model_max_gen_toks < max_gen_toks:
+                max_gen_toks = model_max_gen_toks
+            elif model_max_gen_toks > max_gen_toks:
+                logger.warning(
+                    "Model generation limit %d exceeds the %s benchmark limit %d; using the benchmark limit. "
+                    "Pass an Evalchemy config with a larger max_tokens value to evaluate longer generations.",
+                    model_max_gen_toks,
+                    self.name,
+                    max_gen_toks,
+                )
         return replace(
             config,
             apply_chat_template=(
                 model.apply_chat_template if source.apply_chat_template is None else source.apply_chat_template
             ),
-            max_gen_toks=(
-                model.generation.max_gen_toks if model.generation.max_gen_toks is not None else config.max_gen_toks
-            ),
+            max_gen_toks=max_gen_toks,
             max_eval_instances=effective_limit,
             extra_gen_kwargs={
                 **config.extra_gen_kwargs,

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -5,6 +5,7 @@
 
 import hashlib
 import json
+import logging
 from collections.abc import Mapping
 from dataclasses import asdict, replace
 from pathlib import Path
@@ -19,7 +20,7 @@ from marin.evaluation.evalchemy.runner import EvalchemyExecutor, EvalchemyRunCon
 from marin.evaluation.evaluation_config import EvalTaskConfig
 from marin.evaluation.harbor.driver_config import HARBOR_RUNTIME, HarborDatasetKind, ValidatedHarborConfig
 from marin.evaluation.hardware import AcceleratorChoice, Platform
-from marin.evaluation.model_config import ModelConfig, ResourceHint
+from marin.evaluation.model_config import GenerationConfig, ModelConfig, ResourceHint
 from marin.evaluation.records import EvalRef, RunStatus, read_record
 from marin.evaluation.runner import (
     Evaluation,
@@ -455,6 +456,52 @@ def test_file_evalchemy_chat_template_overrides_model_default(monkeypatch):
     evalchemy = batch.evaluations[0].identity.eval_ref.evalchemy
     assert evalchemy is not None
     assert evalchemy.apply_chat_template is True
+
+
+@pytest.mark.parametrize(
+    ("benchmark_limit", "model_limit", "expected_limit", "expected_warnings"),
+    [
+        (128, 8192, 128, 1),
+        (8192, 2048, 2048, 0),
+        (None, 8192, 8192, 0),
+    ],
+)
+def test_evalchemy_generation_budget_preserves_benchmark_protocol(
+    tmp_path,
+    monkeypatch,
+    caplog,
+    benchmark_limit,
+    model_limit,
+    expected_limit,
+    expected_warnings,
+):
+    config_path = tmp_path / "generation.yaml"
+    max_tokens = "" if benchmark_limit is None else f"max_tokens: {benchmark_limit}\n"
+    config_path.write_text(f"tasks: [triviaqa]\n{max_tokens}")
+    model = replace(models()["qwen3-8b"], generation=GenerationConfig(max_gen_toks=model_limit))
+    monkeypatch.setattr("experiments.evaluation.launch._capability_origin", lambda _cluster: "https://iris.example")
+    caplog.set_level(logging.WARNING, logger="experiments.evaluation.evals")
+    spec = LaunchSpec(
+        model=model,
+        evals=(),
+        evalchemy_definitions=(EvalchemyDefinition(name="generation", config_path=config_path),),
+        harbor_definitions=(),
+        platform=Platform.TPU,
+        accelerator=None,
+        limit=1,
+        records_prefix="memory://records",
+        submission_cluster="marin",
+        federated_cluster=None,
+        priority_band=job_pb2.PRIORITY_BAND_INHERIT,
+    )
+
+    batch = build_evaluation_batch(spec, LaunchProvenance(git_sha="abc", launch_host="host"), "tester")
+
+    evalchemy = batch.evaluations[0].identity.eval_ref.evalchemy
+    assert evalchemy is not None
+    assert evalchemy.max_gen_toks == expected_limit
+    warnings = [record for record in caplog.records if record.name == "experiments.evaluation.evals"]
+    assert len(warnings) == expected_warnings
 
 
 def test_build_evaluation_batch_rejects_conflicting_secret_specs(monkeypatch):


### PR DESCRIPTION
Honor explicit Evalchemy `max_tokens` values when resolving model configs. A lower model generation limit remains a hard cap; a higher model limit emits a warning and requires an explicit benchmark config to opt into longer generations.

This prevents a model-wide 8,192-token limit from silently replacing TriviaQA's 128-token protocol while retaining model limits for configs that omit `max_tokens`.

Set OlympiadBench's benchmark budget to 32,768 tokens. Qwen3.5-9B truncated before its boxed answer and scored zero under the previous 8,192-token cap.
