### PR TITLE
[infra] Route GitHub alerts to marin-alerts

### DIFF
--- a/infra/pulumi/github/Pulumi.marin-community.yaml
+++ b/infra/pulumi/github/Pulumi.marin-community.yaml
@@ -63,10 +63,10 @@ config:
       scope: organization
       presence: present
       visibility: all
-      source_kind: manual
-      source_ref: owner-recovery:slack-webhook
+      source_kind: gcp-secret
+      source_ref: gcp-secret://projects/hai-gcp-models/secrets/marin-grafana-slack-webhook/versions/1
       disposition: keep
-      note: Shadowed in marin by the repository secret of the same name.
+      note: Routes GitHub Actions alerts to #marin-alerts; shadowed in marin by the repository secret of the same name.
     - name: CW_KUBECONFIG
       scope: repository
       repository: marin-community/marin
@@ -264,10 +264,10 @@ config:
       scope: repository
       repository: marin-community/marin
       presence: present
-      source_kind: manual
-      source_ref: owner-recovery:slack-webhook
+      source_kind: gcp-secret
+      source_ref: gcp-secret://projects/hai-gcp-models/secrets/marin-grafana-slack-webhook/versions/1
       disposition: keep
-      note: Overrides the organization secret of the same name.
+      note: Routes GitHub Actions alerts to #marin-alerts and overrides the organization secret of the same name.
     - name: SPEEDRUN_LEADERBOARD_PAT
       scope: repository
       repository: marin-community/marin

--- a/scripts/cost_manager/README.md
+++ b/scripts/cost_manager/README.md
@@ -71,7 +71,7 @@ var is unset, so local runs and environments without the secret stay silent. A
 POST failure is logged and never fails the run. The webhook (a standard Slack
 incoming webhook, same `{"text": …}` contract as the repo's `notify-slack`
 action) determines the channel — point `webhook_url_env` at a webhook bound to
-`#marin-eng`. Remove the `alerts` block (or its `rules`) to disable.
+`#marin-alerts`. Remove the `alerts` block (or its `rules`) to disable.
 
 ## Providers and required secrets
 

--- a/scripts/cost_manager/config.yaml
+++ b/scripts/cost_manager/config.yaml
@@ -23,7 +23,7 @@ lookback_days: 3
 # max_usd. Pinging is best-effort: a breach is always logged, but the POST is
 # skipped on --dry-run and when `webhook_url_env` is unset, so local runs and
 # environments without the secret stay silent. The webhook decides the channel
-# (the repo's SLACK_WEBHOOK_URL); point webhook_url_env at a #marin-eng webhook.
+# (the repo's SLACK_WEBHOOK_URL); point webhook_url_env at a #marin-alerts webhook.
 alerts:
   webhook_url_env: SLACK_WEBHOOK_URL
   rules:


### PR DESCRIPTION
Route organization-wide GitHub Actions notifications and Marin's
repository override to #marin-alerts. The live secrets were rotated to version
1 of `marin-grafana-slack-webhook`, replacing values that sent evalchemy,
Harbor, and Marin canary failures and cost-threshold notifications to
#marin-eng.

Record the same pinned Secret Manager version as the recovery source for both
GitHub secrets. Update the cost-manager documentation to match the shared
destination.
