### PR TITLE
Provision shared Loom home files from Secret Manager

### DIFF
--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -65,7 +65,7 @@ checks readiness. It does not clone a repository or build images on the VM.
 
 Machine-wide files required by every trusted interactive session belong in the
 stack's `homeFiles` map. Each entry maps a path relative to `/home/app` to a
-numbered Secret Manager version and a restrictive file mode:
+numbered Secret Manager version and an explicit restrictive file mode:
 
 ```yaml
 config:
@@ -77,11 +77,15 @@ config:
 
 The secret reference and target path appear in Pulumi state and VM metadata;
 the payload does not. The startup unit fetches all declared versions before
-changing the shared `loom_loom_home` volume, replaces each file atomically, and
-records the paths it manages. Removing a declaration removes that managed file
-on the next activation without pruning user-created files. Paths must be
-relative, Secret Manager versions must be numeric, and modes must be `0400` or
-`0600`.
+changing the shared `loom_loom_home` volume, stops the Loom and Caddy Compose
+services, replaces each file atomically, and starts the services with the new
+state. A failure leaves those serving containers stopped instead of continuing
+with stale credentials. Detached sessions remain running and see an atomic
+rename: open file descriptors retain the old payload while later opens see the
+new one. Removing a declaration removes that managed file on the next
+activation without pruning user-created files. Paths must be relative, Secret
+Manager versions must be numeric, and every declaration must set `0400` or
+`0600` explicitly.
 
 The managed-path ledger lives under root-owned `/var/lib/loom/home-files`, not
 in the session-writable volume. This prevents a session from adding arbitrary

--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -83,6 +83,13 @@ on the next activation without pruning user-created files. Paths must be
 relative, Secret Manager versions must be numeric, and modes must be `0400` or
 `0600`.
 
+The managed-path ledger lives under root-owned `/var/lib/loom/home-files`, not
+in the session-writable volume. This prevents a session from adding arbitrary
+paths to the next activation's deletion set. Managed paths also cannot overlap;
+activation safely removes a stale managed file when a later declaration needs
+that path to become a directory, or vice versa, but stops if unmanaged content
+blocks the transition.
+
 This mechanism is intentionally deployment-wide. The Loom control plane and
 ordinary session containers share `/home/app`, so every session using that
 volume can read files permitted to the `app` user. Do not use `homeFiles` for a

--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -61,6 +61,42 @@ startup unit stores Docker state on the persistent root disk, reads one numbered
 `docker compose up -d`, applies the configured Loom deployment policy, and
 checks readiness. It does not clone a repository or build images on the VM.
 
+## Shared session-home files
+
+Machine-wide files required by every trusted interactive session belong in the
+stack's `homeFiles` map. Each entry maps a path relative to `/home/app` to a
+numbered Secret Manager version and a restrictive file mode:
+
+```yaml
+config:
+  marin-loom:homeFiles:
+    .kube/coreweave-iris:
+      secretRef: projects/hai-gcp-models/secrets/loom-coreweave-iris-kubeconfig/versions/1
+      mode: "0600"
+```
+
+The secret reference and target path appear in Pulumi state and VM metadata;
+the payload does not. The startup unit fetches all declared versions before
+changing the shared `loom_loom_home` volume, replaces each file atomically, and
+records the paths it manages. Removing a declaration removes that managed file
+on the next activation without pruning user-created files. Paths must be
+relative, Secret Manager versions must be numeric, and modes must be `0400` or
+`0600`.
+
+This mechanism is intentionally deployment-wide. The Loom control plane and
+ordinary session containers share `/home/app`, so every session using that
+volume can read files permitted to the `app` user. Do not use `homeFiles` for a
+credential that should be limited to one profile or one user. Put user identity
+credentials in Loom Settings → Access and profile-scoped secrets in the profile's
+write-only environment instead.
+
+Migrate a manually installed CoreWeave kubeconfig in a separate deployment
+change: create a dedicated Secret Manager secret, upload the reviewed file as a
+new version, add the pinned reference above, preview, and deploy. Do not remove
+the current file until the deployed version has been exercised from a new
+session. Never add a `homeFiles` declaration before its referenced secret
+version exists.
+
 ## Update secrets
 
 Do not put secret values in Pulumi configuration or state. Upload a reviewed

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -42,6 +42,7 @@ SSH_FIREWALL_TAG = "loom-ssh"
 FIREWALL_PRIORITY = 1000
 GIT_COMMIT = re.compile(r"^[0-9a-f]{40}$")
 STARTUP_SCRIPT = (ROOT / "startup-script.sh").read_text()
+HOME_FILE_MATERIALIZER = (ROOT / "materialize_home_files.py").read_text()
 DOCKER_DAEMON_CONFIG = (
     json.dumps(
         {
@@ -94,8 +95,12 @@ def _git_context_at_revision(revision: str) -> str:
 
 
 SECRET_REF = re.compile(
-    r"^projects/(?P<project>[a-z0-9-]+)/secrets/(?P<secret>[A-Za-z0-9_-]+)/versions/(?:latest|[0-9]+)$"
+    r"^projects/(?P<project>[a-z0-9-]+)/secrets/(?P<secret>[A-Za-z0-9_-]+)/versions/(?P<version>latest|[0-9]+)$"
 )
+HOME_FILE_PATH = re.compile(r"(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+")
+DEFAULT_HOME_FILE_MODE = "0600"
+HOME_FILE_MODES = frozenset({"0400", DEFAULT_HOME_FILE_MODE})
+HOME_FILE_LEDGER = ".loom-managed-home-files.json"
 
 
 @dataclass(frozen=True)
@@ -147,6 +152,45 @@ class ProfileSecretConfig:
 
     def manifest(self) -> dict[str, str]:
         return {"name": self.name, "secret_ref": self.secret_ref}
+
+
+@dataclass(frozen=True)
+class HomeFileConfig:
+    path: str
+    project: str
+    secret: str
+    version: str
+    mode: str
+
+    @classmethod
+    def parse(cls, path: str, value: object) -> HomeFileConfig:
+        if not HOME_FILE_PATH.fullmatch(path) or any(part in {".", ".."} for part in path.split("/")):
+            raise ValueError(f"homeFiles has invalid relative path {path!r}")
+        if path == HOME_FILE_LEDGER:
+            raise ValueError(f"homeFiles path {path!r} is reserved")
+        if not isinstance(value, dict):
+            raise ValueError(f"homeFiles entry {path!r} must use a full secretRef")
+        secret_ref = str(value.get("secretRef", "")).strip()
+        match = SECRET_REF.fullmatch(secret_ref)
+        if not match or match.group("version") == "latest":
+            raise ValueError(f"homeFiles entry {path!r} must use a numbered full secretRef")
+        mode = str(value.get("mode", DEFAULT_HOME_FILE_MODE))
+        if mode not in HOME_FILE_MODES:
+            raise ValueError(f"homeFiles entry {path!r} mode must be 0400 or 0600")
+        return cls(path, match.group("project"), match.group("secret"), match.group("version"), mode)
+
+    def manifest(self) -> dict[str, str]:
+        return {
+            "path": self.path,
+            "project": self.project,
+            "secret": self.secret,
+            "version": self.version,
+            "mode": self.mode,
+        }
+
+    @property
+    def secret_target(self) -> tuple[str, str]:
+        return self.project, self.secret
 
 
 def _string_tuple(value: object, field: str, profile: str) -> tuple[str, ...]:
@@ -393,6 +437,7 @@ class DeploymentConfig:
     prune_deployment: bool = False
     settings: tuple[tuple[str, str | int | bool], ...] = ()
     profiles: tuple[ProfileConfig, ...] = ()
+    home_files: tuple[HomeFileConfig, ...] = ()
     workloads: tuple[WorkloadIdentityConfig, ...] = ()
     github_federations: tuple[GitHubFederationConfig, ...] = ()
     vm_project_roles: tuple[str, ...] = ()
@@ -449,6 +494,10 @@ class DeploymentConfig:
             if not isinstance(key, str) or not key.strip() or not isinstance(value, (str, int, bool)):
                 raise ValueError("settings must map non-empty string keys to string, integer, or boolean values")
             settings.append((key, value))
+        raw_home_files = config.get_object("homeFiles") or {}
+        if not isinstance(raw_home_files, dict):
+            raise ValueError("homeFiles must be an object")
+        home_files = tuple(HomeFileConfig.parse(str(path), value) for path, value in sorted(raw_home_files.items()))
         raw_workloads = config.get_object("workloads") or []
         if not isinstance(raw_workloads, list):
             raise ValueError("workloads must be a list")
@@ -491,6 +540,7 @@ class DeploymentConfig:
             prune_deployment=config.get_bool("pruneDeployment") or False,
             settings=tuple(settings),
             profiles=tuple(profiles),
+            home_files=home_files,
             workloads=tuple(workloads),
             github_federations=tuple(github_federations),
             snapshot_retention_days=config.require_int("snapshotRetentionDays"),
@@ -709,6 +759,14 @@ class RuntimePolicyResources:
     profile_secret_refs: list[tuple[str, str]]
 
 
+def _home_files_manifest(home_files: tuple[HomeFileConfig, ...]) -> str:
+    return json.dumps(
+        [home_file.manifest() for home_file in home_files],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
 def _workload_service_account(
     config: DeploymentConfig,
     workload: WorkloadIdentityConfig,
@@ -796,7 +854,7 @@ def _create_runtime_policy(
 class SecretResources:
     secret: gcp.secretmanager.Secret
     vm_reader: gcp.secretmanager.SecretIamMember
-    profile_readers: list[gcp.secretmanager.SecretIamMember]
+    runtime_readers: list[gcp.secretmanager.SecretIamMember]
 
 
 def _create_secrets(
@@ -804,7 +862,7 @@ def _create_secrets(
     apis: list[gcp.projects.Service],
     api_options: pulumi.ResourceOptions,
     vm_account: gcp.serviceaccount.Account,
-    profile_secret_refs: list[tuple[str, str]],
+    runtime_secret_refs: list[tuple[str, str]],
 ) -> SecretResources:
     secret = gcp.secretmanager.Secret(
         "loom-dotenv",
@@ -820,12 +878,12 @@ def _create_secrets(
         role=SECRET_ACCESSOR_ROLE,
         member=pulumi.Output.format(SERVICE_ACCOUNT_MEMBER, vm_account.email),
     )
-    profile_readers = []
-    for secret_project, secret_name in sorted(set(profile_secret_refs)):
+    runtime_readers = []
+    for secret_project, secret_name in sorted(set(runtime_secret_refs)):
         suffix = hashlib.sha256(f"{secret_project}/{secret_name}".encode()).hexdigest()[:RESOURCE_HASH_LENGTH]
-        profile_readers.append(
+        runtime_readers.append(
             gcp.secretmanager.SecretIamMember(
-                f"loom-profile-secret-{suffix}",
+                f"loom-runtime-secret-{suffix}",
                 project=secret_project,
                 secret_id=secret_name,
                 role=SECRET_ACCESSOR_ROLE,
@@ -833,7 +891,7 @@ def _create_secrets(
                 opts=api_options,
             )
         )
-    return SecretResources(secret, vm_reader, profile_readers)
+    return SecretResources(secret, vm_reader, runtime_readers)
 
 
 @dataclass(frozen=True)
@@ -860,6 +918,8 @@ def _create_instance(
         "dotenv-secret-id": DOTENV_SECRET_ID,
         "loom-port": str(LOOM_PORT),
         "loom-deployment": runtime_policy.manifest,
+        "loom-home-files": _home_files_manifest(config.home_files),
+        "loom-home-file-materializer": HOME_FILE_MATERIALIZER,
         "docker-daemon-config": DOCKER_DAEMON_CONFIG,
         "loom-compose": RUNTIME_COMPOSE,
         "loom-caddyfile": RUNTIME_CADDYFILE,
@@ -875,7 +935,7 @@ def _create_instance(
         image.vm_reader,
         vm_log_writer,
         *vm_permissions,
-        *secrets.profile_readers,
+        *secrets.runtime_readers,
     ]
     instance = gcp.compute.Instance(
         "loom",
@@ -1013,7 +1073,10 @@ def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
     image = _create_image(config, apis, vm_account)
     network = _create_network(config, apis)
     root_disk = _create_root_disk(config, apis)
-    secrets = _create_secrets(config, apis, api_options, vm_account, runtime_policy.profile_secret_refs)
+    runtime_secret_refs = runtime_policy.profile_secret_refs + [
+        home_file.secret_target for home_file in config.home_files
+    ]
+    secrets = _create_secrets(config, apis, api_options, vm_account, runtime_secret_refs)
     instance = _create_instance(
         config,
         vm_account,

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -98,8 +98,7 @@ SECRET_REF = re.compile(
     r"^projects/(?P<project>[a-z0-9-]+)/secrets/(?P<secret>[A-Za-z0-9_-]+)/versions/(?P<version>latest|[0-9]+)$"
 )
 HOME_FILE_PATH = re.compile(r"(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+")
-DEFAULT_HOME_FILE_MODE = "0600"
-HOME_FILE_MODES = frozenset({"0400", DEFAULT_HOME_FILE_MODE})
+HOME_FILE_MODES = frozenset({"0400", "0600"})
 
 
 @dataclass(frozen=True)
@@ -171,8 +170,8 @@ class HomeFileConfig:
         match = SECRET_REF.fullmatch(secret_ref)
         if not match or match.group("version") == "latest":
             raise ValueError(f"homeFiles entry {path!r} must use a numbered full secretRef")
-        mode = str(value.get("mode", DEFAULT_HOME_FILE_MODE))
-        if mode not in HOME_FILE_MODES:
+        mode = value.get("mode")
+        if not isinstance(mode, str) or mode not in HOME_FILE_MODES:
             raise ValueError(f"homeFiles entry {path!r} mode must be 0400 or 0600")
         return cls(path, match.group("project"), match.group("secret"), match.group("version"), mode)
 

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -100,7 +100,6 @@ SECRET_REF = re.compile(
 HOME_FILE_PATH = re.compile(r"(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+")
 DEFAULT_HOME_FILE_MODE = "0600"
 HOME_FILE_MODES = frozenset({"0400", DEFAULT_HOME_FILE_MODE})
-HOME_FILE_LEDGER = ".loom-managed-home-files.json"
 
 
 @dataclass(frozen=True)
@@ -166,8 +165,6 @@ class HomeFileConfig:
     def parse(cls, path: str, value: object) -> HomeFileConfig:
         if not HOME_FILE_PATH.fullmatch(path) or any(part in {".", ".."} for part in path.split("/")):
             raise ValueError(f"homeFiles has invalid relative path {path!r}")
-        if path == HOME_FILE_LEDGER:
-            raise ValueError(f"homeFiles path {path!r} is reserved")
         if not isinstance(value, dict):
             raise ValueError(f"homeFiles entry {path!r} must use a full secretRef")
         secret_ref = str(value.get("secretRef", "")).strip()
@@ -191,6 +188,16 @@ class HomeFileConfig:
     @property
     def secret_target(self) -> tuple[str, str]:
         return self.project, self.secret
+
+
+def _validate_home_file_paths(home_files: tuple[HomeFileConfig, ...]) -> None:
+    paths: set[str] = set()
+    for home_file in home_files:
+        if home_file.path in paths or any(
+            home_file.path.startswith(f"{path}/") or path.startswith(f"{home_file.path}/") for path in paths
+        ):
+            raise ValueError(f"homeFiles has duplicate or overlapping path {home_file.path!r}")
+        paths.add(home_file.path)
 
 
 def _string_tuple(value: object, field: str, profile: str) -> tuple[str, ...]:
@@ -454,6 +461,7 @@ class DeploymentConfig:
             _positive_config_int(value, name)
         _validated_string_tuple(list(self.vm_project_roles), "vmProjectRoles", IAM_ROLE)
         _validated_string_tuple(list(self.vm_pulumi_kms_keys), "vmPulumiKmsKeys", KMS_CRYPTO_KEY)
+        _validate_home_file_paths(self.home_files)
         profile_names = {profile.name for profile in self.profiles}
         workload_names: set[str] = set()
         for workload in self.workloads:
@@ -883,7 +891,7 @@ def _create_secrets(
         suffix = hashlib.sha256(f"{secret_project}/{secret_name}".encode()).hexdigest()[:RESOURCE_HASH_LENGTH]
         runtime_readers.append(
             gcp.secretmanager.SecretIamMember(
-                f"loom-runtime-secret-{suffix}",
+                f"loom-profile-secret-{suffix}",
                 project=secret_project,
                 secret_id=secret_name,
                 role=SECRET_ACCESSOR_ROLE,

--- a/infra/loom/materialize_home_files.py
+++ b/infra/loom/materialize_home_files.py
@@ -1,0 +1,329 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Materialize Secret Manager values into Loom's shared session home."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import secrets
+import shutil
+import stat
+import subprocess
+import tempfile
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+SESSION_HOME = Path("/home/app")
+STAGING_MOUNT = Path("/run/loom-home-files")
+LEDGER_NAME = ".loom-managed-home-files.json"
+PATH_PATTERN = re.compile(r"(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+")
+PROJECT_PATTERN = re.compile(r"[a-z0-9-]+")
+SECRET_PATTERN = re.compile(r"[A-Za-z0-9_-]+")
+VERSION_PATTERN = re.compile(r"[0-9]+")
+ALLOWED_MODES = frozenset({"0400", "0600"})
+VOLUME_NAME = "loom_loom_home"
+
+
+@dataclass(frozen=True)
+class SecretHomeFile:
+    path: str
+    project: str
+    secret: str
+    version: str
+    mode: str
+
+
+@dataclass(frozen=True)
+class StagedHomeFile:
+    path: str
+    source: str
+    mode: int
+
+
+def _validated_path(value: object) -> str:
+    if not isinstance(value, str) or not PATH_PATTERN.fullmatch(value):
+        raise ValueError(f"invalid managed home path {value!r}")
+    if value == LEDGER_NAME or any(part in {".", ".."} for part in value.split("/")):
+        raise ValueError(f"invalid managed home path {value!r}")
+    return value
+
+
+def _load_secret_manifest(path: Path) -> tuple[SecretHomeFile, ...]:
+    raw = json.loads(path.read_text())
+    if not isinstance(raw, list):
+        raise ValueError("home-file manifest must be a list")
+    result: list[SecretHomeFile] = []
+    seen: set[str] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError("home-file manifest entries must be objects")
+        target = _validated_path(item.get("path"))
+        project = item.get("project")
+        secret = item.get("secret")
+        version = item.get("version")
+        mode = item.get("mode")
+        if not isinstance(project, str) or not PROJECT_PATTERN.fullmatch(project):
+            raise ValueError(f"invalid Secret Manager project for {target!r}")
+        if not isinstance(secret, str) or not SECRET_PATTERN.fullmatch(secret):
+            raise ValueError(f"invalid Secret Manager secret for {target!r}")
+        if not isinstance(version, str) or not VERSION_PATTERN.fullmatch(version):
+            raise ValueError(f"invalid Secret Manager version for {target!r}")
+        if not isinstance(mode, str) or mode not in ALLOWED_MODES:
+            raise ValueError(f"invalid mode for {target!r}")
+        if target in seen:
+            raise ValueError(f"duplicate managed home path {target!r}")
+        seen.add(target)
+        result.append(SecretHomeFile(target, project, secret, version, mode))
+    return tuple(result)
+
+
+def _load_staged_plan(path: Path) -> tuple[StagedHomeFile, ...]:
+    raw = json.loads(path.read_text())
+    if not isinstance(raw, list):
+        raise ValueError("staged home-file plan must be a list")
+    result: list[StagedHomeFile] = []
+    seen: set[str] = set()
+    for item in raw:
+        if not isinstance(item, dict):
+            raise ValueError("staged home-file entries must be objects")
+        target = _validated_path(item.get("path"))
+        source = item.get("source")
+        mode = item.get("mode")
+        if not isinstance(source, str) or not VERSION_PATTERN.fullmatch(source):
+            raise ValueError(f"invalid staged source for {target!r}")
+        if not isinstance(mode, str) or mode not in ALLOWED_MODES:
+            raise ValueError(f"invalid mode for {target!r}")
+        if target in seen:
+            raise ValueError(f"duplicate managed home path {target!r}")
+        seen.add(target)
+        result.append(StagedHomeFile(target, source, int(mode, 8)))
+    return tuple(result)
+
+
+def prepare_home_files(manifest_path: Path, image: str) -> None:
+    """Fetch every declared secret, then apply the complete plan in the session image."""
+    entries = _load_secret_manifest(manifest_path)
+    with tempfile.TemporaryDirectory(prefix="loom-home-files-", dir="/run") as staging_value:
+        staging = Path(staging_value)
+        plan: list[dict[str, str]] = []
+        for index, entry in enumerate(entries):
+            source = str(index)
+            payload = staging / source
+            with payload.open("wb") as output:
+                subprocess.run(
+                    [
+                        "gcloud",
+                        "secrets",
+                        "versions",
+                        "access",
+                        entry.version,
+                        f"--project={entry.project}",
+                        f"--secret={entry.secret}",
+                    ],
+                    check=True,
+                    stdout=output,
+                )
+            payload.chmod(0o600)
+            plan.append({"path": entry.path, "source": source, "mode": entry.mode})
+        plan_path = staging / "plan.json"
+        plan_path.write_text(json.dumps(plan, sort_keys=True, separators=(",", ":")))
+        plan_path.chmod(0o600)
+        subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--network=none",
+                "--user=0:0",
+                "--entrypoint=python3",
+                "--mount",
+                f"type=volume,source={VOLUME_NAME},target={SESSION_HOME}",
+                "--mount",
+                f"type=bind,source={staging},target={STAGING_MOUNT},readonly",
+                "--mount",
+                f"type=bind,source={Path(__file__).resolve()},target=/run/materialize-home-files.py,readonly",
+                image,
+                "/run/materialize-home-files.py",
+                "apply",
+                f"--plan={STAGING_MOUNT / 'plan.json'}",
+            ],
+            check=True,
+        )
+
+
+def _open_directory(parent_fd: int, name: str, owner: tuple[int, int]) -> int:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    try:
+        return os.open(name, flags, dir_fd=parent_fd)
+    except FileNotFoundError:
+        os.mkdir(name, 0o700, dir_fd=parent_fd)
+        os.chown(name, *owner, dir_fd=parent_fd, follow_symlinks=False)
+        return os.open(name, flags, dir_fd=parent_fd)
+
+
+def _target_directory(home_fd: int, path: str, owner: tuple[int, int]) -> tuple[int, str]:
+    parts = path.split("/")
+    current_fd = os.dup(home_fd)
+    try:
+        for part in parts[:-1]:
+            next_fd = _open_directory(current_fd, part, owner)
+            os.close(current_fd)
+            current_fd = next_fd
+        return current_fd, parts[-1]
+    except BaseException:
+        os.close(current_fd)
+        raise
+
+
+def _regular_target_or_missing(parent_fd: int, name: str) -> None:
+    try:
+        status = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return
+    if not stat.S_ISREG(status.st_mode):
+        raise ValueError(f"managed home target {name!r} is not a regular file")
+
+
+def _temporary_file(parent_fd: int, name: str, mode: int, owner: tuple[int, int]) -> tuple[str, int]:
+    _regular_target_or_missing(parent_fd, name)
+    temporary = f".{name}.loom-{secrets.token_hex(8)}"
+    output_fd = os.open(
+        temporary,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+        0o600,
+        dir_fd=parent_fd,
+    )
+    os.fchmod(output_fd, mode)
+    os.fchown(output_fd, *owner)
+    return temporary, output_fd
+
+
+def _stage_file(
+    parent_fd: int,
+    name: str,
+    source: Path,
+    mode: int,
+    owner: tuple[int, int],
+) -> str:
+    temporary, output_fd = _temporary_file(parent_fd, name, mode, owner)
+    try:
+        with source.open("rb") as input_file, os.fdopen(output_fd, "wb", closefd=False) as output_file:
+            shutil.copyfileobj(input_file, output_file)
+            output_file.flush()
+            os.fsync(output_fd)
+    except BaseException:
+        os.unlink(temporary, dir_fd=parent_fd)
+        raise
+    finally:
+        os.close(output_fd)
+    return temporary
+
+
+def _managed_paths(home_fd: int) -> set[str]:
+    try:
+        ledger_fd = os.open(LEDGER_NAME, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=home_fd)
+    except FileNotFoundError:
+        return set()
+    try:
+        status = os.fstat(ledger_fd)
+        if not stat.S_ISREG(status.st_mode):
+            raise ValueError("managed home-file ledger is not a regular file")
+        with os.fdopen(ledger_fd, closefd=False) as ledger:
+            raw = json.load(ledger)
+    finally:
+        os.close(ledger_fd)
+    if not isinstance(raw, list):
+        raise ValueError("managed home-file ledger must be a list")
+    return {_validated_path(item) for item in raw}
+
+
+def _write_ledger(home_fd: int, paths: set[str], owner: tuple[int, int]) -> None:
+    payload = (json.dumps(sorted(paths), separators=(",", ":")) + "\n").encode()
+    temporary, ledger_fd = _temporary_file(home_fd, LEDGER_NAME, 0o600, owner)
+    try:
+        with os.fdopen(ledger_fd, "wb", closefd=False) as ledger:
+            ledger.write(payload)
+            ledger.flush()
+            os.fsync(ledger_fd)
+    except BaseException:
+        os.unlink(temporary, dir_fd=home_fd)
+        raise
+    finally:
+        os.close(ledger_fd)
+    os.replace(temporary, LEDGER_NAME, src_dir_fd=home_fd, dst_dir_fd=home_fd)
+
+
+def apply_home_files(plan_path: Path, home: Path = SESSION_HOME, staging: Path = STAGING_MOUNT) -> None:
+    """Atomically replace declared files and remove only previously managed paths."""
+    entries = _load_staged_plan(plan_path)
+    home_status = home.stat(follow_symlinks=False)
+    if not stat.S_ISDIR(home_status.st_mode):
+        raise ValueError(f"session home {home} is not a directory")
+    owner = home_status.st_uid, home_status.st_gid
+    home_fd = os.open(home, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    staged: list[tuple[int, str, str]] = []
+    try:
+        previous_paths = _managed_paths(home_fd)
+        next_paths = {entry.path for entry in entries}
+        for entry in entries:
+            source = staging / entry.source
+            source_status = source.stat(follow_symlinks=False)
+            if not stat.S_ISREG(source_status.st_mode):
+                raise ValueError(f"staged source for {entry.path!r} is not a regular file")
+            parent_fd, name = _target_directory(home_fd, entry.path, owner)
+            try:
+                temporary = _stage_file(parent_fd, name, source, entry.mode, owner)
+            except BaseException:
+                os.close(parent_fd)
+                raise
+            staged.append((parent_fd, temporary, name))
+
+        for parent_fd, temporary, name in staged:
+            os.replace(temporary, name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+        for removed_path in previous_paths - next_paths:
+            parent_fd, name = _target_directory(home_fd, removed_path, owner)
+            try:
+                _regular_target_or_missing(parent_fd, name)
+                try:
+                    os.unlink(name, dir_fd=parent_fd)
+                except FileNotFoundError:
+                    pass
+            finally:
+                os.close(parent_fd)
+        _write_ledger(home_fd, next_paths, owner)
+    finally:
+        for parent_fd, temporary, _ in staged:
+            try:
+                os.unlink(temporary, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+            os.close(parent_fd)
+        os.close(home_fd)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("--manifest", type=Path, required=True)
+    prepare.add_argument("--image", required=True)
+    apply = subparsers.add_parser("apply")
+    apply.add_argument("--plan", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = _parser().parse_args(argv)
+    if args.command == "prepare":
+        prepare_home_files(args.manifest, args.image)
+    else:
+        apply_home_files(args.plan)
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/loom/materialize_home_files.py
+++ b/infra/loom/materialize_home_files.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import json
 import os
 import re
@@ -20,7 +21,8 @@ from pathlib import Path
 
 SESSION_HOME = Path("/home/app")
 STAGING_MOUNT = Path("/run/loom-home-files")
-LEDGER_NAME = ".loom-managed-home-files.json"
+STATE_MOUNT = Path("/run/loom-home-file-state")
+LEDGER_NAME = "managed-paths.json"
 PATH_PATTERN = re.compile(r"(?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]+")
 PROJECT_PATTERN = re.compile(r"[a-z0-9-]+")
 SECRET_PATTERN = re.compile(r"[A-Za-z0-9_-]+")
@@ -48,7 +50,7 @@ class StagedHomeFile:
 def _validated_path(value: object) -> str:
     if not isinstance(value, str) or not PATH_PATTERN.fullmatch(value):
         raise ValueError(f"invalid managed home path {value!r}")
-    if value == LEDGER_NAME or any(part in {".", ".."} for part in value.split("/")):
+    if any(part in {".", ".."} for part in value.split("/")):
         raise ValueError(f"invalid managed home path {value!r}")
     return value
 
@@ -75,8 +77,8 @@ def _load_secret_manifest(path: Path) -> tuple[SecretHomeFile, ...]:
             raise ValueError(f"invalid Secret Manager version for {target!r}")
         if not isinstance(mode, str) or mode not in ALLOWED_MODES:
             raise ValueError(f"invalid mode for {target!r}")
-        if target in seen:
-            raise ValueError(f"duplicate managed home path {target!r}")
+        if target in seen or any(target.startswith(f"{path}/") or path.startswith(f"{target}/") for path in seen):
+            raise ValueError(f"duplicate or overlapping managed home path {target!r}")
         seen.add(target)
         result.append(SecretHomeFile(target, project, secret, version, mode))
     return tuple(result)
@@ -98,16 +100,21 @@ def _load_staged_plan(path: Path) -> tuple[StagedHomeFile, ...]:
             raise ValueError(f"invalid staged source for {target!r}")
         if not isinstance(mode, str) or mode not in ALLOWED_MODES:
             raise ValueError(f"invalid mode for {target!r}")
-        if target in seen:
-            raise ValueError(f"duplicate managed home path {target!r}")
+        if target in seen or any(target.startswith(f"{path}/") or path.startswith(f"{target}/") for path in seen):
+            raise ValueError(f"duplicate or overlapping managed home path {target!r}")
         seen.add(target)
         result.append(StagedHomeFile(target, source, int(mode, 8)))
     return tuple(result)
 
 
-def prepare_home_files(manifest_path: Path, image: str) -> None:
+def prepare_home_files(manifest_path: Path, image: str, state_dir: Path) -> None:
     """Fetch every declared secret, then apply the complete plan in the session image."""
     entries = _load_secret_manifest(manifest_path)
+    state_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    state_status = state_dir.stat(follow_symlinks=False)
+    if not stat.S_ISDIR(state_status.st_mode):
+        raise ValueError(f"home-file state {state_dir} is not a directory")
+    state_dir.chmod(0o700)
     with tempfile.TemporaryDirectory(prefix="loom-home-files-", dir="/run") as staging_value:
         staging = Path(staging_value)
         plan: list[dict[str, str]] = []
@@ -146,6 +153,8 @@ def prepare_home_files(manifest_path: Path, image: str) -> None:
                 "--mount",
                 f"type=bind,source={staging},target={STAGING_MOUNT},readonly",
                 "--mount",
+                f"type=bind,source={state_dir.resolve()},target={STATE_MOUNT}",
+                "--mount",
                 f"type=bind,source={Path(__file__).resolve()},target=/run/materialize-home-files.py,readonly",
                 image,
                 "/run/materialize-home-files.py",
@@ -178,6 +187,46 @@ def _target_directory(home_fd: int, path: str, owner: tuple[int, int]) -> tuple[
     except BaseException:
         os.close(current_fd)
         raise
+
+
+def _remove_managed_file(home_fd: int, path: str, prune_empty_parents: bool) -> None:
+    parts = path.split("/")
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    current_fd = os.dup(home_fd)
+    open_fds = {current_fd}
+    directories: list[tuple[int, str, int]] = []
+    try:
+        for part in parts[:-1]:
+            try:
+                child_fd = os.open(part, directory_flags, dir_fd=current_fd)
+            except FileNotFoundError:
+                return
+            open_fds.add(child_fd)
+            directories.append((current_fd, part, child_fd))
+            current_fd = child_fd
+
+        try:
+            status = os.stat(parts[-1], dir_fd=current_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            status = None
+        if status is not None:
+            if not stat.S_ISREG(status.st_mode):
+                raise ValueError(f"managed home target {path!r} is not a regular file")
+            os.unlink(parts[-1], dir_fd=current_fd)
+
+        if prune_empty_parents:
+            for parent_fd, name, child_fd in reversed(directories):
+                os.close(child_fd)
+                open_fds.remove(child_fd)
+                try:
+                    os.rmdir(name, dir_fd=parent_fd)
+                except OSError as error:
+                    if error.errno in {errno.EEXIST, errno.ENOTEMPTY}:
+                        break
+                    raise
+    finally:
+        for open_fd in open_fds:
+            os.close(open_fd)
 
 
 def _regular_target_or_missing(parent_fd: int, name: str) -> None:
@@ -224,9 +273,9 @@ def _stage_file(
     return temporary
 
 
-def _managed_paths(home_fd: int) -> set[str]:
+def _managed_paths(state_fd: int) -> set[str]:
     try:
-        ledger_fd = os.open(LEDGER_NAME, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=home_fd)
+        ledger_fd = os.open(LEDGER_NAME, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=state_fd)
     except FileNotFoundError:
         return set()
     try:
@@ -242,34 +291,58 @@ def _managed_paths(home_fd: int) -> set[str]:
     return {_validated_path(item) for item in raw}
 
 
-def _write_ledger(home_fd: int, paths: set[str], owner: tuple[int, int]) -> None:
+def _write_ledger(state_fd: int, paths: set[str], owner: tuple[int, int]) -> None:
     payload = (json.dumps(sorted(paths), separators=(",", ":")) + "\n").encode()
-    temporary, ledger_fd = _temporary_file(home_fd, LEDGER_NAME, 0o600, owner)
+    temporary, ledger_fd = _temporary_file(state_fd, LEDGER_NAME, 0o600, owner)
     try:
         with os.fdopen(ledger_fd, "wb", closefd=False) as ledger:
             ledger.write(payload)
             ledger.flush()
             os.fsync(ledger_fd)
     except BaseException:
-        os.unlink(temporary, dir_fd=home_fd)
+        os.unlink(temporary, dir_fd=state_fd)
         raise
     finally:
         os.close(ledger_fd)
-    os.replace(temporary, LEDGER_NAME, src_dir_fd=home_fd, dst_dir_fd=home_fd)
+    os.replace(temporary, LEDGER_NAME, src_dir_fd=state_fd, dst_dir_fd=state_fd)
 
 
-def apply_home_files(plan_path: Path, home: Path = SESSION_HOME, staging: Path = STAGING_MOUNT) -> None:
+def apply_home_files(
+    plan_path: Path,
+    home: Path = SESSION_HOME,
+    staging: Path = STAGING_MOUNT,
+    state: Path = STATE_MOUNT,
+) -> None:
     """Atomically replace declared files and remove only previously managed paths."""
     entries = _load_staged_plan(plan_path)
     home_status = home.stat(follow_symlinks=False)
     if not stat.S_ISDIR(home_status.st_mode):
         raise ValueError(f"session home {home} is not a directory")
     owner = home_status.st_uid, home_status.st_gid
+    state_status = state.stat(follow_symlinks=False)
+    if not stat.S_ISDIR(state_status.st_mode):
+        raise ValueError(f"home-file state {state} is not a directory")
+    state_owner = state_status.st_uid, state_status.st_gid
     home_fd = os.open(home, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        state_fd = os.open(state, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    except BaseException:
+        os.close(home_fd)
+        raise
     staged: list[tuple[int, str, str]] = []
     try:
-        previous_paths = _managed_paths(home_fd)
+        previous_paths = _managed_paths(state_fd)
         next_paths = {entry.path for entry in entries}
+        topology_blockers = {
+            previous_path
+            for previous_path in previous_paths - next_paths
+            if any(
+                previous_path.startswith(f"{next_path}/") or next_path.startswith(f"{previous_path}/")
+                for next_path in next_paths
+            )
+        }
+        for removed_path in sorted(topology_blockers, key=lambda item: item.count("/"), reverse=True):
+            _remove_managed_file(home_fd, removed_path, prune_empty_parents=True)
         for entry in entries:
             source = staging / entry.source
             source_status = source.stat(follow_symlinks=False)
@@ -285,17 +358,9 @@ def apply_home_files(plan_path: Path, home: Path = SESSION_HOME, staging: Path =
 
         for parent_fd, temporary, name in staged:
             os.replace(temporary, name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
-        for removed_path in previous_paths - next_paths:
-            parent_fd, name = _target_directory(home_fd, removed_path, owner)
-            try:
-                _regular_target_or_missing(parent_fd, name)
-                try:
-                    os.unlink(name, dir_fd=parent_fd)
-                except FileNotFoundError:
-                    pass
-            finally:
-                os.close(parent_fd)
-        _write_ledger(home_fd, next_paths, owner)
+        for removed_path in previous_paths - next_paths - topology_blockers:
+            _remove_managed_file(home_fd, removed_path, prune_empty_parents=False)
+        _write_ledger(state_fd, next_paths, state_owner)
     finally:
         for parent_fd, temporary, _ in staged:
             try:
@@ -304,6 +369,7 @@ def apply_home_files(plan_path: Path, home: Path = SESSION_HOME, staging: Path =
                 pass
             os.close(parent_fd)
         os.close(home_fd)
+        os.close(state_fd)
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -312,6 +378,7 @@ def _parser() -> argparse.ArgumentParser:
     prepare = subparsers.add_parser("prepare")
     prepare.add_argument("--manifest", type=Path, required=True)
     prepare.add_argument("--image", required=True)
+    prepare.add_argument("--state-dir", type=Path, required=True)
     apply = subparsers.add_parser("apply")
     apply.add_argument("--plan", type=Path, required=True)
     return parser
@@ -320,7 +387,7 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> None:
     args = _parser().parse_args(argv)
     if args.command == "prepare":
-        prepare_home_files(args.manifest, args.image)
+        prepare_home_files(args.manifest, args.image, args.state_dir)
     else:
         apply_home_files(args.plan)
 

--- a/infra/loom/startup-script.sh
+++ b/infra/loom/startup-script.sh
@@ -18,6 +18,7 @@ HEALTH_URL="http://127.0.0.1:${LOOM_PORT}/api/health"
 STARTUP_SUCCESS=/run/loom-startup-succeeded
 HOME_FILES_MANIFEST=/run/loom-home-files.json
 HOME_FILE_MATERIALIZER="${RUNTIME_DIR}/materialize-home-files.py"
+HOME_FILE_STATE_DIR=/var/lib/loom/home-files
 
 echo "== loom startup-script: ${LOOM_DOMAIN} =="
 rm -f "$STARTUP_SUCCESS"
@@ -80,6 +81,7 @@ if [ "${docker_config_changed:-false}" = true ]; then
 fi
 
 install -d -m 0755 "$RUNTIME_DIR"
+install -d -m 0700 "$HOME_FILE_STATE_DIR"
 meta instance/attributes/loom-compose >"$COMPOSE_FILE"
 meta instance/attributes/loom-caddyfile >"${RUNTIME_DIR}/Caddyfile"
 meta instance/attributes/loom-home-file-materializer >"$HOME_FILE_MATERIALIZER"
@@ -119,7 +121,8 @@ docker compose -f "$COMPOSE_FILE" pull
 meta instance/attributes/loom-home-files >"$HOME_FILES_MANIFEST"
 python3 "$HOME_FILE_MATERIALIZER" prepare \
   --manifest="$HOME_FILES_MANIFEST" \
-  --image="$LOOM_IMAGE"
+  --image="$LOOM_IMAGE" \
+  --state-dir="$HOME_FILE_STATE_DIR"
 rm -f "$HOME_FILES_MANIFEST"
 docker compose -f "$COMPOSE_FILE" up -d
 

--- a/infra/loom/startup-script.sh
+++ b/infra/loom/startup-script.sh
@@ -16,6 +16,8 @@ COMPOSE_FILE="${RUNTIME_DIR}/docker-compose.yml"
 DOCKER_CONFIG=/etc/docker/daemon.json
 HEALTH_URL="http://127.0.0.1:${LOOM_PORT}/api/health"
 STARTUP_SUCCESS=/run/loom-startup-succeeded
+HOME_FILES_MANIFEST=/run/loom-home-files.json
+HOME_FILE_MATERIALIZER="${RUNTIME_DIR}/materialize-home-files.py"
 
 echo "== loom startup-script: ${LOOM_DOMAIN} =="
 rm -f "$STARTUP_SUCCESS"
@@ -56,6 +58,9 @@ if ! command -v gcloud >/dev/null 2>&1; then
     /etc/apt/sources.list.d/google-cloud-sdk.list
   packages+=(google-cloud-cli)
 fi
+if ! command -v python3 >/dev/null 2>&1; then
+  packages+=(python3)
+fi
 if [ "${#packages[@]}" -gt 0 ]; then
   apt-get update
   apt-get install -y --no-install-recommends "${packages[@]}"
@@ -77,6 +82,8 @@ fi
 install -d -m 0755 "$RUNTIME_DIR"
 meta instance/attributes/loom-compose >"$COMPOSE_FILE"
 meta instance/attributes/loom-caddyfile >"${RUNTIME_DIR}/Caddyfile"
+meta instance/attributes/loom-home-file-materializer >"$HOME_FILE_MATERIALIZER"
+chmod 0700 "$HOME_FILE_MATERIALIZER"
 
 ENV_FILE="${RUNTIME_DIR}/.env"
 umask 077
@@ -109,6 +116,11 @@ chmod 0600 "$ENV_FILE"
 registry="${LOOM_IMAGE%%/*}"
 gcloud auth configure-docker "$registry" --quiet
 docker compose -f "$COMPOSE_FILE" pull
+meta instance/attributes/loom-home-files >"$HOME_FILES_MANIFEST"
+python3 "$HOME_FILE_MATERIALIZER" prepare \
+  --manifest="$HOME_FILES_MANIFEST" \
+  --image="$LOOM_IMAGE"
+rm -f "$HOME_FILES_MANIFEST"
 docker compose -f "$COMPOSE_FILE" up -d
 
 for _ in $(seq 1 60); do

--- a/infra/loom/startup-script.sh
+++ b/infra/loom/startup-script.sh
@@ -119,6 +119,7 @@ registry="${LOOM_IMAGE%%/*}"
 gcloud auth configure-docker "$registry" --quiet
 docker compose -f "$COMPOSE_FILE" pull
 meta instance/attributes/loom-home-files >"$HOME_FILES_MANIFEST"
+docker compose -f "$COMPOSE_FILE" stop loom caddy
 python3 "$HOME_FILE_MATERIALIZER" prepare \
   --manifest="$HOME_FILES_MANIFEST" \
   --image="$LOOM_IMAGE" \

--- a/infra/loom/tests/test_infrastructure.py
+++ b/infra/loom/tests/test_infrastructure.py
@@ -198,7 +198,6 @@ def test_profile_manifest_renders_github_repositories_and_secret_references() ->
     [
         ("/root/.kube/config", {"secretRef": "projects/example/secrets/kube/versions/1"}),
         (".kube/../config", {"secretRef": "projects/example/secrets/kube/versions/1"}),
-        (".loom-managed-home-files.json", {"secretRef": "projects/example/secrets/kube/versions/1"}),
         (".kube/config", {"secretRef": "projects/example/secrets/kube/versions/latest"}),
         (".kube/config", {"secretRef": "projects/example/secrets/kube/versions/1", "mode": "0644"}),
     ],
@@ -206,6 +205,13 @@ def test_profile_manifest_renders_github_repositories_and_secret_references() ->
 def test_home_files_reject_unsafe_paths_unpinned_versions_and_open_modes(path: str, value: object) -> None:
     with pytest.raises(ValueError, match="homeFiles"):
         HomeFileConfig.parse(path, value)
+
+
+def test_home_files_reject_overlapping_targets() -> None:
+    base = deployment_config()
+    nested = replace(base.home_files[0], path=".kube/coreweave-iris/context")
+    with pytest.raises(ValueError, match="overlapping path"):
+        replace(base, home_files=(*base.home_files, nested))
 
 
 def test_deployment_manifest_preserves_unicode_profile_instructions() -> None:
@@ -294,7 +300,7 @@ def test_deployment_models_durable_resources_without_secret_payloads():
         secret_reader = by_name(mocks, "loom-vm-secret-reader")
         assert secret_reader.inputs["role"] == "roles/secretmanager.secretAccessor"
         runtime_secret_readers = [
-            resource for resource in mocks.resources if resource.name.startswith("loom-runtime-secret-")
+            resource for resource in mocks.resources if resource.name.startswith("loom-profile-secret-")
         ]
         assert {field(resource.inputs, "secret_id", "secretId") for resource in runtime_secret_readers} == {
             "coreweave-iris-kubeconfig",

--- a/infra/loom/tests/test_infrastructure.py
+++ b/infra/loom/tests/test_infrastructure.py
@@ -199,6 +199,7 @@ def test_profile_manifest_renders_github_repositories_and_secret_references() ->
         ("/root/.kube/config", {"secretRef": "projects/example/secrets/kube/versions/1"}),
         (".kube/../config", {"secretRef": "projects/example/secrets/kube/versions/1"}),
         (".kube/config", {"secretRef": "projects/example/secrets/kube/versions/latest"}),
+        (".kube/config", {"secretRef": "projects/example/secrets/kube/versions/1"}),
         (".kube/config", {"secretRef": "projects/example/secrets/kube/versions/1", "mode": "0644"}),
     ],
 )

--- a/infra/loom/tests/test_infrastructure.py
+++ b/infra/loom/tests/test_infrastructure.py
@@ -15,6 +15,7 @@ from infra.loom.infrastructure import (
     ROOT,
     DeploymentConfig,
     GitHubFederationConfig,
+    HomeFileConfig,
     ProfileConfig,
     WorkloadIdentityConfig,
     _deployment_manifest,
@@ -83,6 +84,15 @@ def deployment_config() -> DeploymentConfig:
                     "envClear": True,
                     "instructionsFile": "profiles/ops/AGENTS.md",
                     "env": {"KUBECONFIG": {"secretRef": "projects/example/secrets/ops-kubeconfig/versions/latest"}},
+                },
+            ),
+        ),
+        home_files=(
+            HomeFileConfig.parse(
+                ".kube/coreweave-iris",
+                {
+                    "secretRef": "projects/example/secrets/coreweave-iris-kubeconfig/versions/4",
+                    "mode": "0600",
                 },
             ),
         ),
@@ -183,6 +193,21 @@ def test_profile_manifest_renders_github_repositories_and_secret_references() ->
         ProfileConfig.parse("ops", {"agent": "codex", "env": {"OPS_TOKEN": "plaintext"}})
 
 
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        ("/root/.kube/config", {"secretRef": "projects/example/secrets/kube/versions/1"}),
+        (".kube/../config", {"secretRef": "projects/example/secrets/kube/versions/1"}),
+        (".loom-managed-home-files.json", {"secretRef": "projects/example/secrets/kube/versions/1"}),
+        (".kube/config", {"secretRef": "projects/example/secrets/kube/versions/latest"}),
+        (".kube/config", {"secretRef": "projects/example/secrets/kube/versions/1", "mode": "0644"}),
+    ],
+)
+def test_home_files_reject_unsafe_paths_unpinned_versions_and_open_modes(path: str, value: object) -> None:
+    with pytest.raises(ValueError, match="homeFiles"):
+        HomeFileConfig.parse(path, value)
+
+
 def test_deployment_manifest_preserves_unicode_profile_instructions() -> None:
     profile = ProfileConfig.parse("github", {"agent": "codex", "instructions": "Prefix comments with 🤖"})
     config = replace(deployment_config(), profiles=(profile,), workloads=(), github_federations=())
@@ -252,12 +277,29 @@ def test_deployment_models_durable_resources_without_secret_payloads():
         assert "startup-script" in metadata
         assert "loom-compose" in metadata
         assert "loom-caddyfile" in metadata
+        assert "loom-home-file-materializer" in metadata
+        assert json.loads(metadata["loom-home-files"]) == [
+            {
+                "mode": "0600",
+                "path": ".kube/coreweave-iris",
+                "project": "example",
+                "secret": "coreweave-iris-kubeconfig",
+                "version": "4",
+            }
+        ]
         assert "metadataStartupScript" not in vm.inputs
         assert "metadata_startup_script" not in vm.inputs
         assert field(vm.inputs, "allow_stopping_for_update", "allowStoppingForUpdate") is False
 
         secret_reader = by_name(mocks, "loom-vm-secret-reader")
         assert secret_reader.inputs["role"] == "roles/secretmanager.secretAccessor"
+        runtime_secret_readers = [
+            resource for resource in mocks.resources if resource.name.startswith("loom-runtime-secret-")
+        ]
+        assert {field(resource.inputs, "secret_id", "secretId") for resource in runtime_secret_readers} == {
+            "coreweave-iris-kubeconfig",
+            "ops-kubeconfig",
+        }
         log_writer = by_name(mocks, "loom-vm-log-writer")
         assert log_writer.inputs["role"] == "roles/logging.logWriter"
         assert log_writer.inputs["member"] == "serviceAccount:loom-vm@example.iam.gserviceaccount.com"

--- a/infra/loom/tests/test_materialize_home_files.py
+++ b/infra/loom/tests/test_materialize_home_files.py
@@ -13,33 +13,38 @@ from infra.loom.materialize_home_files import apply_home_files
 def test_apply_home_files_reconciles_managed_files_without_touching_user_files(tmp_path: Path) -> None:
     home = tmp_path / "home"
     staging = tmp_path / "staging"
+    state = tmp_path / "state"
     home.mkdir()
     staging.mkdir()
+    state.mkdir()
     kube = home / ".kube"
     kube.mkdir()
     (kube / "old-context").write_text("old")
     (kube / "user-created").write_text("keep")
-    (home / ".loom-managed-home-files.json").write_text('[".kube/old-context"]')
+    (state / "managed-paths.json").write_text('[".kube/old-context"]')
     (staging / "0").write_text("apiVersion: v1\n")
     plan = staging / "plan.json"
     plan.write_text(json.dumps([{"path": ".kube/coreweave-iris", "source": "0", "mode": "0600"}]))
 
-    apply_home_files(plan, home, staging)
+    apply_home_files(plan, home, staging, state)
 
     target = kube / "coreweave-iris"
     assert target.read_text() == "apiVersion: v1\n"
     assert stat.S_IMODE(target.stat().st_mode) == 0o600
     assert not (kube / "old-context").exists()
     assert (kube / "user-created").read_text() == "keep"
-    assert json.loads((home / ".loom-managed-home-files.json").read_text()) == [".kube/coreweave-iris"]
+    assert json.loads((state / "managed-paths.json").read_text()) == [".kube/coreweave-iris"]
+    assert not (home / "managed-paths.json").exists()
 
 
 def test_apply_home_files_rejects_symlinked_parent(tmp_path: Path) -> None:
     home = tmp_path / "home"
     staging = tmp_path / "staging"
+    state = tmp_path / "state"
     outside = tmp_path / "outside"
     home.mkdir()
     staging.mkdir()
+    state.mkdir()
     outside.mkdir()
     (home / ".kube").symlink_to(outside, target_is_directory=True)
     (staging / "0").write_text("secret")
@@ -47,5 +52,36 @@ def test_apply_home_files_rejects_symlinked_parent(tmp_path: Path) -> None:
     plan.write_text(json.dumps([{"path": ".kube/config", "source": "0", "mode": "0600"}]))
 
     with pytest.raises(OSError):
-        apply_home_files(plan, home, staging)
+        apply_home_files(plan, home, staging, state)
     assert not (outside / "config").exists()
+
+
+def test_apply_home_files_transitions_between_file_and_directory_paths(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    staging = tmp_path / "staging"
+    state = tmp_path / "state"
+    home.mkdir()
+    staging.mkdir()
+    state.mkdir()
+    (staging / "0").write_text("parent")
+    (staging / "1").write_text("child")
+    plan = staging / "plan.json"
+
+    plan.write_text(json.dumps([{"path": "credential", "source": "0", "mode": "0600"}]))
+    apply_home_files(plan, home, staging, state)
+    assert (home / "credential").read_text() == "parent"
+
+    plan.write_text(json.dumps([{"path": "credential/config", "source": "1", "mode": "0600"}]))
+    apply_home_files(plan, home, staging, state)
+    assert (home / "credential/config").read_text() == "child"
+
+    unmanaged = home / "credential/user-created"
+    unmanaged.write_text("keep")
+    plan.write_text(json.dumps([{"path": "credential", "source": "0", "mode": "0600"}]))
+    with pytest.raises(ValueError, match="not a regular file"):
+        apply_home_files(plan, home, staging, state)
+    assert unmanaged.read_text() == "keep"
+
+    unmanaged.unlink()
+    apply_home_files(plan, home, staging, state)
+    assert (home / "credential").read_text() == "parent"

--- a/infra/loom/tests/test_materialize_home_files.py
+++ b/infra/loom/tests/test_materialize_home_files.py
@@ -1,0 +1,51 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from infra.loom.materialize_home_files import apply_home_files
+
+
+def test_apply_home_files_reconciles_managed_files_without_touching_user_files(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    staging = tmp_path / "staging"
+    home.mkdir()
+    staging.mkdir()
+    kube = home / ".kube"
+    kube.mkdir()
+    (kube / "old-context").write_text("old")
+    (kube / "user-created").write_text("keep")
+    (home / ".loom-managed-home-files.json").write_text('[".kube/old-context"]')
+    (staging / "0").write_text("apiVersion: v1\n")
+    plan = staging / "plan.json"
+    plan.write_text(json.dumps([{"path": ".kube/coreweave-iris", "source": "0", "mode": "0600"}]))
+
+    apply_home_files(plan, home, staging)
+
+    target = kube / "coreweave-iris"
+    assert target.read_text() == "apiVersion: v1\n"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert not (kube / "old-context").exists()
+    assert (kube / "user-created").read_text() == "keep"
+    assert json.loads((home / ".loom-managed-home-files.json").read_text()) == [".kube/coreweave-iris"]
+
+
+def test_apply_home_files_rejects_symlinked_parent(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    staging = tmp_path / "staging"
+    outside = tmp_path / "outside"
+    home.mkdir()
+    staging.mkdir()
+    outside.mkdir()
+    (home / ".kube").symlink_to(outside, target_is_directory=True)
+    (staging / "0").write_text("secret")
+    plan = staging / "plan.json"
+    plan.write_text(json.dumps([{"path": ".kube/config", "source": "0", "mode": "0600"}]))
+
+    with pytest.raises(OSError):
+        apply_home_files(plan, home, staging)
+    assert not (outside / "config").exists()


### PR DESCRIPTION
Loom sessions share a persistent `/home/app` volume, but machine credentials placed there currently have no declared source or rotation path. Add a deployment `homeFiles` map that accepts only non-overlapping relative paths, explicit restrictive modes, and pinned Secret Manager versions.

Startup pulls the pinned image, reads the manifest, and stops the Loom and Caddy services before fetching every declared version into a root-only temporary directory. A network-disabled container installs files through symlink-safe directory handles, preserves the session-home owner, atomically replaces targets, and records managed paths in root-owned host state outside the session-writable volume. If preparation fails, the serving services remain stopped; detached session containers continue running, and readers follow atomic rename semantics. Later removals cannot prune user-created files, and file-to-directory transitions stop when unmanaged content blocks the change. Pulumi state, VM metadata, process arguments, logs, and the ledger contain references rather than payloads. The VM service account receives access only to the referenced secrets while retaining existing Pulumi resource identities.

This mechanism is deployment-wide because ordinary Loom sessions share the volume. It is unsuitable for a credential that requires user or profile isolation. Migrating the existing CoreWeave kubeconfig remains a separate deployment change after a dedicated secret and numbered version exist.