### PR TITLE
Define Loom configuration ownership and secret preloading

### DIFF
--- a/.agents/projects/loom_session_credentials/design.md
+++ b/.agents/projects/loom_session_credentials/design.md
@@ -49,17 +49,21 @@ marin-loom:homeFiles:
     mode: "0600"
 ```
 
-Paths must be relative to `/home/app`, normalized, and free of `..`. Secret references must use numbered versions. Modes are limited to owner-readable files (`0400` or `0600`). Pulumi stores only the reference, grants the Loom VM service account access to the named secret, and places the redacted manifest in VM metadata.
+Paths must be relative to `/home/app`, normalized, and free of `..`. `secretRef` is the only secret input: it must name a numbered version and is decomposed into project, secret, and version fields for IAM and the redacted manifest. Every declaration explicitly selects an owner-readable mode (`0400` or `0600`). Pulumi stores only the reference, grants the Loom VM service account access to the named secret, and places the redacted manifest in VM metadata.
 
-Before starting Compose, the activation script resolves every declared secret into a root-only temporary directory, then starts a network-disabled one-shot container with the shared home volume. The container installs each payload through directory file descriptors that reject symlinks, atomically replaces the target, and restores the session-home owner's uid and gid. It records only managed paths in root-owned host state outside the session-writable volume. Removing a declaration deletes only a regular file previously recorded there. Managed paths cannot overlap; file-to-directory transitions remove only stale managed blockers and stop if unmanaged content prevents the change. Secret values never enter metadata, Pulumi state, command arguments, logs, or the ledger.
+`infra/loom/startup-script.sh` pulls the pinned image, reads the manifest, stops the `loom` and `caddy` Compose services, and then resolves every declared secret into a root-only temporary directory. It starts a network-disabled one-shot container with the shared home volume and root-owned state directory. The container installs each payload through directory file descriptors that reject symlinks, atomically replaces the target, and restores the uid and gid read from `/home/app`. Docker seeds a fresh named volume from that directory in the pinned Loom image; materialization fails if the mounted home is absent or is not a directory. It records only managed paths in a mode-`0600` ledger outside the session-writable volume. Removing a declaration deletes only a regular file previously recorded there. Managed paths cannot overlap; file-to-directory transitions remove only stale managed blockers and stop if unmanaged content prevents the change. Secret values never enter metadata, Pulumi state, command arguments, logs, or the ledger.
 
-The production migration creates a dedicated Secret Manager secret, uploads the current kubeconfig as version 1, adds the declaration, previews the IAM and metadata changes, and activates Loom. Rotation adds a numbered version and updates the reference in the stack. The existing manually copied file remains until the first successful managed activation replaces it atomically.
+Only after materialization succeeds does the startup script run `docker compose up -d`. A validation, access, or installation failure leaves Loom and Caddy stopped, including during later activations; detached session containers continue running. Readers with an open file descriptor retain the previous payload across the atomic rename, while later opens see the new version.
+
+The production migration creates a dedicated Secret Manager secret, uploads the current kubeconfig as version 1, adds the declaration, previews the IAM and metadata changes, and activates Loom. Rotation adds a numbered version and updates the reference in the stack, using the same stop, materialize, and start sequence. The existing manually copied file remains until the first successful managed activation replaces it atomically.
 
 ## Testing
 
 Loom's existing Settings Playwright journey verifies the GitHub App editor under `Connections`, the personal token under `Access`, the permission-prefilled PAT URL, and the renamed session environment tab. The frontend typecheck, unit suite, formatter, Rust formatter, and Clippy remain part of the repository gate.
 
 Marin unit tests validate paths, modes, pinned secret references, redacted metadata, Secret Manager IAM grants, and the generated home-file manifest. Filesystem tests run the container-side applicator against a temporary home and root-owned state directory. They cover atomic creation, permissions, managed-file pruning, preservation of unmanaged files, symlink rejection, and file-to-directory transitions. A production preview must show only IAM and VM metadata changes before the kubeconfig version is selected.
+
+This change lands as separate Loom UI/docs and Marin provisioner PRs. Loom's frontend gates run on the Loom PR; Marin's Python and IaC gates run on the Marin implementation PR.
 
 ## Open Questions
 

--- a/.agents/projects/loom_session_credentials/design.md
+++ b/.agents/projects/loom_session_credentials/design.md
@@ -51,7 +51,7 @@ marin-loom:homeFiles:
 
 Paths must be relative to `/home/app`, normalized, and free of `..`. Secret references must use numbered versions. Modes are limited to owner-readable files (`0400` or `0600`). Pulumi stores only the reference, grants the Loom VM service account access to the named secret, and places the redacted manifest in VM metadata.
 
-Before starting Compose, the activation script resolves every declared secret into a root-only temporary directory, then starts a network-disabled one-shot container with the shared home volume. The container installs each payload through directory file descriptors that reject symlinks, atomically replaces the target, and restores the session-home owner's uid and gid. It records only managed paths in a mode-0600 ledger. Removing a declaration deletes only a regular file previously recorded in that ledger. Secret values never enter metadata, Pulumi state, command arguments, logs, or the ledger.
+Before starting Compose, the activation script resolves every declared secret into a root-only temporary directory, then starts a network-disabled one-shot container with the shared home volume. The container installs each payload through directory file descriptors that reject symlinks, atomically replaces the target, and restores the session-home owner's uid and gid. It records only managed paths in root-owned host state outside the session-writable volume. Removing a declaration deletes only a regular file previously recorded there. Managed paths cannot overlap; file-to-directory transitions remove only stale managed blockers and stop if unmanaged content prevents the change. Secret values never enter metadata, Pulumi state, command arguments, logs, or the ledger.
 
 The production migration creates a dedicated Secret Manager secret, uploads the current kubeconfig as version 1, adds the declaration, previews the IAM and metadata changes, and activates Loom. Rotation adds a numbered version and updates the reference in the stack. The existing manually copied file remains until the first successful managed activation replaces it atomically.
 
@@ -59,7 +59,7 @@ The production migration creates a dedicated Secret Manager secret, uploads the 
 
 Loom's existing Settings Playwright journey verifies the GitHub App editor under `Connections`, the personal token under `Access`, the permission-prefilled PAT URL, and the renamed session environment tab. The frontend typecheck, unit suite, formatter, Rust formatter, and Clippy remain part of the repository gate.
 
-Marin unit tests validate paths, modes, pinned secret references, redacted metadata, Secret Manager IAM grants, and the generated home-file manifest. Filesystem tests run the container-side applicator against a temporary home and cover atomic creation, permissions, managed-file pruning, preservation of unmanaged files, and symlink rejection. A production preview must show only IAM and VM metadata changes before the kubeconfig version is selected.
+Marin unit tests validate paths, modes, pinned secret references, redacted metadata, Secret Manager IAM grants, and the generated home-file manifest. Filesystem tests run the container-side applicator against a temporary home and root-owned state directory. They cover atomic creation, permissions, managed-file pruning, preservation of unmanaged files, symlink rejection, and file-to-directory transitions. A production preview must show only IAM and VM metadata changes before the kubeconfig version is selected.
 
 ## Open Questions
 

--- a/.agents/projects/loom_session_credentials/design.md
+++ b/.agents/projects/loom_session_credentials/design.md
@@ -1,0 +1,68 @@
+# Make Loom configuration ownership explicit
+
+Loom should tell a user which identity or policy they are changing, who owns it, and which future sessions receive it. Marin's production deployment should declare shared session files such as the CoreWeave kubeconfig instead of relying on manual copies into `/home/app`. This removes the two failure modes seen in the current setup: a valid personal token with the wrong permission set silently wins credential selection, and a credential file exists only because someone copied it onto the VM.
+
+The detailed current-state review and source ledger are in [research.md](research.md).
+
+## Challenges
+
+Loom has several configuration systems because their security and lifecycle requirements differ. Registered non-secret settings have runtime, deployment, and built-in layers. Profiles hold launch policy and write-only environment values. Personal GitHub tokens belong to one user. The GitHub App belongs to the deployment. Repository config belongs in source control. These boundaries are useful, but the Settings information architecture currently groups personal and deployment GitHub credentials together and labels only one of two profile-environment views as `Environment`.
+
+Files add another boundary. Marin's production control plane and ordinary session containers share `/home/app`. A file written there is durable and immediately available to every trusted interactive session, regardless of profile. Declarative provisioning can improve provenance and rotation, but it cannot claim per-profile isolation.
+
+## Costs / Risks
+
+- Moving controls between Settings tabs changes a familiar screen and requires UI journey updates.
+- The shared-home provisioner gives every ordinary session access to each declared file. It must be limited to credentials already accepted as machine-wide in this single-tenant deployment.
+- A bad secret reference or unsafe path must fail activation before Loom starts. This makes a configuration error visible and may delay a rollout.
+- Kubeconfig migration needs an out-of-band one-time secret upload. A code PR cannot safely manufacture or recover that payload.
+
+## Design
+
+Use four ownership classes everywhere Loom explains configuration:
+
+| Owner | Set it in | Appropriate contents |
+|---|---|---|
+| User | `Settings → Access` | Personal sign-in/password and personal GitHub PAT used by that user's interactive sessions |
+| Session profile | `Settings → Agents → Profiles`, preferably deployment IaC in production | Agent/model policy, instructions, repository allowlist, and write-only session secrets |
+| Deployment | `Settings → Connections` for status/manual setup; operator IaC and Secret Manager as the production source | Loom GitHub App, Slack App, federations, and shared machine credentials/files |
+| Repository | `.weaver/config.toml`, `WEAVER.md`, and `AGENTS.md` | Non-secret setup, repository environment, and workflow instructions |
+
+`Settings → Environment` becomes `Session environment`. Its description states that it is the readable, non-secret environment of the default profile and applies only to future sessions. Write-only values remain under each profile because they have a different disclosure policy.
+
+The GitHub App editor moves from `Access` to `Connections`. `Access` keeps the current user, password, personal GitHub token, approved users, and Loom API tokens. The personal-token card names the interactive order:
+
+1. the launching user's PAT, when configured;
+2. the selected profile's explicit `GH_TOKEN`, when configured;
+3. a short-lived GitHub App installation token when the profile allowlists the current repository.
+
+The create-token link preselects `Contents: write`, `Pull requests: write`, and `Issues: write`. The copy explains that repository selection and permissions are separate. Loom does not request `Administration: write`, because direct branch pushes are the normal path and creating a fork is a separate operation.
+
+Add a short `Configuration ownership` section to Loom's configuration reference. It becomes the canonical answer to “where does this go?” and links to the credential-specific details. The UI uses the same terms.
+
+Marin's `infra/loom` stack gains a `homeFiles` map:
+
+```yaml
+marin-loom:homeFiles:
+  .kube/coreweave-iris:
+    secretRef: projects/hai-gcp-models/secrets/loom-coreweave-iris-kubeconfig/versions/1
+    mode: "0600"
+```
+
+Paths must be relative to `/home/app`, normalized, and free of `..`. Secret references must use numbered versions. Modes are limited to owner-readable files (`0400` or `0600`). Pulumi stores only the reference, grants the Loom VM service account access to the named secret, and places the redacted manifest in VM metadata.
+
+Before starting Compose, the activation script resolves every declared secret into a root-only temporary directory, then starts a network-disabled one-shot container with the shared home volume. The container installs each payload through directory file descriptors that reject symlinks, atomically replaces the target, and restores the session-home owner's uid and gid. It records only managed paths in a mode-0600 ledger. Removing a declaration deletes only a regular file previously recorded in that ledger. Secret values never enter metadata, Pulumi state, command arguments, logs, or the ledger.
+
+The production migration creates a dedicated Secret Manager secret, uploads the current kubeconfig as version 1, adds the declaration, previews the IAM and metadata changes, and activates Loom. Rotation adds a numbered version and updates the reference in the stack. The existing manually copied file remains until the first successful managed activation replaces it atomically.
+
+## Testing
+
+Loom's existing Settings Playwright journey verifies the GitHub App editor under `Connections`, the personal token under `Access`, the permission-prefilled PAT URL, and the renamed session environment tab. The frontend typecheck, unit suite, formatter, Rust formatter, and Clippy remain part of the repository gate.
+
+Marin unit tests validate paths, modes, pinned secret references, redacted metadata, Secret Manager IAM grants, and the generated home-file manifest. Filesystem tests run the container-side applicator against a temporary home and cover atomic creation, permissions, managed-file pruning, preservation of unmanaged files, and symlink rejection. A production preview must show only IAM and VM metadata changes before the kubeconfig version is selected.
+
+## Open Questions
+
+- Should per-profile file mounts become a Loom feature after sessions have isolated homes, or remain deployment-specific?
+- Should Loom add an optional repository probe when saving a PAT, even though GitHub does not provide complete fine-grained permission introspection?
+- The initial kubeconfig declaration should land in a short deployment follow-up after an operator creates version 1; the mechanism PR must not activate against a missing secret.

--- a/.agents/projects/loom_session_credentials/research.md
+++ b/.agents/projects/loom_session_credentials/research.md
@@ -1,0 +1,92 @@
+# Background Research Brief
+
+- Effort: medium
+- Stop rule: stop when repository history, current code, and deployment code agree on the existing ownership boundaries and no new source changes the proposed split
+- Date: 2026-08-15
+
+## Question
+
+Where should a Loom user or operator configure GitHub identity, service credentials, session environment, repository defaults, and files such as a kubeconfig? How should the Marin deployment preload shared session state without copying secrets into Pulumi state?
+
+## Current Loom Context
+
+Loom exposes eight Settings categories. `Agents` owns launch profiles and their write-only environment. `Environment` is a readable compatibility view over the default profile. `Access` currently combines the signed-in user, password, personal GitHub token, the deployment GitHub App, approved users, and API tokens. `Connections` contains GitHub/Slack runtime settings and Slack connection state, but the GitHub App editor remains under `Access` ([Settings.vue](https://github.com/marin-community/loom/blob/f5ef7f2373913d738e093ca744b78bc5f2bed8c9/crates/loom/frontend/src/views/Settings.vue#L20-L88), [AccountPanel.vue](https://github.com/marin-community/loom/blob/f5ef7f2373913d738e093ca744b78bc5f2bed8c9/crates/loom/frontend/src/components/AccountPanel.vue#L265-L365)).
+
+Registered non-secret settings already have a sound precedence rule: runtime override, deployment value, then built-in default. The API and UI expose that provenance. The rule does not cover credentials, profile environment, or files in the shared home volume ([configuration.md](https://github.com/marin-community/loom/blob/f5ef7f2373913d738e093ca744b78bc5f2bed8c9/docs/configuration.md#L1-L22)).
+
+Interactive GitHub access has three credential sources. The launching user's PAT is exported as `GH_TOKEN` when set. Otherwise a profile `GH_TOKEN` or lower environment layer can supply a long-lived credential. Profiles with a repository allowlist can instead broker a short-lived GitHub App token scoped to the current repository. The same shell variable therefore hides several owners and lifetimes. Loom issue [#195](https://github.com/marin-community/loom/issues/195) identified this ambiguity and recommended purpose-specific labels and source diagnostics. PRs [#289](https://github.com/marin-community/loom/pull/289) and [#291](https://github.com/marin-community/loom/pull/291) added repository-scoped App tokens but did not reorganize Settings.
+
+## Current Marin Deployment Context
+
+`infra/loom/Pulumi.marin-loom.yaml` declares global settings, profiles, GitHub repository allowlists, federations, and profile secret references. `infra/loom/infrastructure.py` renders those into Loom's deployment manifest and grants the VM service account Secret Manager access. Profile environment entries currently accept only `secretRef` values.
+
+The Loom control plane and every ordinary session container mount the same Docker volume at `/home/app` ([docker-compose.yml](https://github.com/marin-community/marin/blob/deee9eabb335772460de9237e17362ce094c127c/infra/loom/runtime/docker-compose.yml#L1-L63)). The CoreWeave kubeconfig was copied manually to `/home/app/.kube/coreweave-iris`, so it persists across sessions and deploys but has no IaC provenance, rotation contract, or restore path. The startup script already resolves a pinned `LOOM_DOTENV` Secret Manager version without placing the payload in Pulumi state ([startup-script.sh](https://github.com/marin-community/marin/blob/deee9eabb335772460de9237e17362ce094c127c/infra/loom/startup-script.sh#L77-L112)). This is the closest reusable mechanism.
+
+The `hai-gcp-models` project has no general CoreWeave Iris kubeconfig secret as of 2026-08-15. It has a Marinfold-specific kubeconfig secret, which should not be reused without confirming its scope. The existing `CW_KUBECONFIG` GitHub Actions recovery declaration is write-only and cannot supply a GCE startup payload.
+
+## Internal Prior Work
+
+- Loom issue [#195](https://github.com/marin-community/loom/issues/195) proposed purpose-aware GitHub credentials, explicit labels, and source diagnostics. It is closed without a single implementing PR; the App-token work landed only part of the proposal.
+- Loom issue [#174](https://github.com/marin-community/loom/issues/174) established deployment-managed profiles and Secret Manager references. Its sample sets `KUBECONFIG` directly from a secret payload, but Kubernetes clients expect a file path, so that shape does not materialize a usable kubeconfig.
+- Loom PR [#113](https://github.com/marin-community/loom/pull/113) introduced the personal PAT store and deliberately exports it as `GH_TOKEN` for unrestricted interactive sessions.
+- Loom PR [#177](https://github.com/marin-community/loom/pull/177) introduced write-only profile environments and deployment-managed automation policy.
+- Marin PR [#8300](https://github.com/marin-community/marin/pull/8300) configured interactive profiles to use the GitHub App fallback when a user PAT is absent.
+
+## External Prior Art
+
+GitHub fine-grained PAT repository selection and permission selection are independent. A token that targets every repository can still lack `Contents: write`. GitHub's create-token URL accepts query parameters that preselect permissions, so Loom can link users to a safer starting configuration. Fork creation has a different permission set and is not required for Loom's normal direct-branch workflow.
+
+Google Secret Manager recommends granting access to individual secrets and pinning versions for reproducible consumers. Pulumi state should contain resource references, never kubeconfig contents.
+
+## Negative / Failed Leads
+
+- A profile `KUBECONFIG` secret reference sets the variable to the kubeconfig contents, not a filesystem path.
+- Committing the kubeconfig or putting it in `.weaver/config.toml` would expose a credential to the repository.
+- Reusing the daemon dotenv would couple an independently rotated cluster credential to all Loom application secrets.
+- A generic Loom profile-file feature would imply profile isolation that the shared `/home/app` volume does not provide. The first change should stay deployment-scoped and name the shared trust boundary.
+- Echo found the App-token rollout and current deployment docs but no prior shared-home-file implementation.
+
+## Evidence Map
+
+### Claim: configuration needs an ownership vocabulary
+
+- Support: Settings places personal and deployment GitHub credentials in one component; issue #195 records the resulting source ambiguity.
+- Contradictions: the registered non-secret settings registry already exposes provenance and should remain unchanged.
+- Directness to Marin: high; the reported PAT incident followed this ambiguity exactly.
+- Confidence: high.
+- Action: organize help and labels around personal, profile, deployment, and repository ownership.
+
+### Claim: shared home files belong in Marin deployment IaC
+
+- Support: production sessions already share `/home/app`; the startup script already retrieves pinned secret versions; the kubeconfig is already treated as a shared interactive credential.
+- Contradictions: files are visible to every session sharing the volume and cannot enforce profile isolation.
+- Directness to Marin: high; this replaces the existing manual copy with a reviewed declaration.
+- Confidence: high for trusted interactive sessions, low for restricted or multi-tenant use.
+- Action: add deployment `homeFiles` declarations backed by pinned Secret Manager references and document the boundary.
+
+## Recommended Changes
+
+1. Reorganize Loom Settings labels and help around four owners, move the GitHub App editor to `Connections`, rename the default environment surface, and show the interactive GitHub credential order.
+2. Prefill required fine-grained PAT permissions in Loom's create-token link.
+3. Add `homeFiles` to the Marin Loom Pulumi program. Materialize pinned Secret Manager versions into the shared home volume before Loom starts and grant access only to declared secrets.
+4. Document the current settings and credential map in Loom and the production preload/rotation procedure in `infra/loom/README.md`.
+5. Migrate `/home/app/.kube/coreweave-iris` after a dedicated Secret Manager secret and numbered version exist. Do not create or upload the credential in a code PR.
+
+## Source Ledger
+
+| Source | Type | Location | Claim used for | Confidence | Notes |
+|---|---|---|---|---|---|
+| Loom Settings | code | `crates/loom/frontend/src/views/Settings.vue` | current tabs | high | SHA pinned above |
+| Loom Account | code | `crates/loom/frontend/src/components/AccountPanel.vue` | credential placement | high | SHA pinned above |
+| Loom configuration policy | docs | `docs/configuration.md` | setting precedence | high | current main |
+| Loom #195 | issue | https://github.com/marin-community/loom/issues/195 | credential ambiguity | high | direct prior design |
+| Loom #174 | issue | https://github.com/marin-community/loom/issues/174 | profiles and secret refs | medium | sample conflates file and env |
+| Marin Loom Pulumi | code | `infra/loom/infrastructure.py` | IaC capabilities | high | current checkout |
+| Marin Compose | code | `infra/loom/runtime/docker-compose.yml` | shared home boundary | high | current checkout |
+| Secret inventory | live metadata | `gcloud secrets list` on 2026-08-15 | migration prerequisite | high | names only; no values read |
+
+## Handoff
+
+- Open question: should a later Loom release add per-profile file mounts after session homes are isolated, or keep file materialization deployment-specific?
+- Open question: should Loom validate a PAT against one selected repository at save time, given that fine-grained permission introspection is incomplete?
+- Stop reason: repository history and current code converge on a small UX change plus a Marin-only shared-file provisioner; further searching did not change that boundary.

--- a/.agents/projects/loom_session_credentials/spec.md
+++ b/.agents/projects/loom_session_credentials/spec.md
@@ -54,8 +54,8 @@ home_files: tuple[HomeFileConfig, ...] = ()
 
 Pulumi key `homeFiles` maps a relative path to an object with:
 
-- `secretRef`: required full GCP Secret Manager version resource with a numeric version;
-- `mode`: optional four-digit octal string, default `0600`, allowed values `0400` and `0600`.
+- `secretRef`: the sole secret input, a required full GCP Secret Manager version resource with a numeric version; parsing decomposes it into the dataclass's `project`, `secret`, and `version` fields;
+- `mode`: required four-digit octal string, allowed values `0400` and `0600`.
 
 Paths use POSIX separators, are relative to `/home/app`, and reject empty segments, `.`, `..`, NUL, a leading slash, duplicates, and ancestor/descendant overlap within one manifest.
 
@@ -78,21 +78,23 @@ The VM metadata key `loom-home-files` contains sorted JSON entries:
 `infra/loom/materialize_home_files.py` has a host-side prepare command:
 
 ```text
-materialize_home_files.py prepare --image=<digest> --manifest=<manifest-file>
+materialize_home_files.py prepare --image=<digest> --manifest=<manifest-file> --state-dir=/var/lib/loom/home-files
 ```
 
 The prepare command:
 
 1. validates the complete manifest before changing the volume;
 2. resolves each Secret Manager version into a mode-0600 temporary host file;
-3. runs the pinned Loom image as root, without a network, with the target volume mounted at `/home/app`;
+3. runs the pinned Loom image as root, without a network, with the target volume mounted at `/home/app`; Docker seeds a new named volume from the image's `/home/app`, and the command fails when the mounted path is absent or is not a directory;
 4. uses directory file descriptors with `O_NOFOLLOW` to reject a target path that crosses a symlink;
-5. copies through a temporary file, restores the session-home uid and gid, and atomically renames it with the declared mode;
+5. copies through a temporary file, restores the uid and gid read from the mounted `/home/app`, and atomically renames it with the declared mode;
 6. removes only regular files present in the previous ledger and absent from the new manifest;
-7. writes `/var/lib/loom/home-files/managed-paths.json` atomically with managed paths only; the root-owned state directory is mounted into the applicator but not ordinary sessions;
+7. writes `/var/lib/loom/home-files/managed-paths.json` atomically with mode `0600` and managed paths only; the root-owned state directory is mounted into the applicator but not ordinary sessions;
 8. deletes all host temporary payloads on exit.
 
-An empty manifest prunes all previously managed files and leaves all unmanaged home contents unchanged. A stale managed file that blocks a new managed directory, or vice versa, is removed before staging; empty ancestors are pruned only as needed, and unmanaged content makes the transition fail closed. Any validation, Secret Manager, or install failure leaves Compose stopped and the activation unsuccessful. Payload bytes never appear in command arguments, stdout, metadata, or the ledger.
+`infra/loom/startup-script.sh` pulls the pinned image, reads the manifest, stops the `loom` and `caddy` Compose services, runs `prepare`, and calls `docker compose up -d` only after preparation succeeds. An empty manifest prunes all previously managed files and leaves all unmanaged home contents unchanged. A stale managed file that blocks a new managed directory, or vice versa, is removed before staging; empty ancestors are pruned only as needed, and unmanaged content makes the transition fail closed. Any validation, Secret Manager, or install failure leaves Loom and Caddy stopped and the activation unsuccessful.
+
+Detached session containers are not stopped. During rotation, readers holding an open file descriptor continue reading the previous payload after the atomic rename; later opens see the new version. Payload bytes never appear in command arguments, stdout, metadata, or the ledger.
 
 ## IAM
 

--- a/.agents/projects/loom_session_credentials/spec.md
+++ b/.agents/projects/loom_session_credentials/spec.md
@@ -57,7 +57,7 @@ Pulumi key `homeFiles` maps a relative path to an object with:
 - `secretRef`: required full GCP Secret Manager version resource with a numeric version;
 - `mode`: optional four-digit octal string, default `0600`, allowed values `0400` and `0600`.
 
-Paths use POSIX separators, are relative to `/home/app`, and reject empty segments, `.`, `..`, NUL, a leading slash, and duplicates after normalization. `.loom-managed-home-files.json` is reserved.
+Paths use POSIX separators, are relative to `/home/app`, and reject empty segments, `.`, `..`, NUL, a leading slash, duplicates, and ancestor/descendant overlap within one manifest.
 
 The VM metadata key `loom-home-files` contains sorted JSON entries:
 
@@ -89,10 +89,10 @@ The prepare command:
 4. uses directory file descriptors with `O_NOFOLLOW` to reject a target path that crosses a symlink;
 5. copies through a temporary file, restores the session-home uid and gid, and atomically renames it with the declared mode;
 6. removes only regular files present in the previous ledger and absent from the new manifest;
-7. writes `.loom-managed-home-files.json` atomically with managed paths only;
+7. writes `/var/lib/loom/home-files/managed-paths.json` atomically with managed paths only; the root-owned state directory is mounted into the applicator but not ordinary sessions;
 8. deletes all host temporary payloads on exit.
 
-An empty manifest prunes all previously managed files and leaves all unmanaged home contents unchanged. Any validation, Secret Manager, or install failure leaves Compose stopped and the activation unsuccessful. Payload bytes never appear in command arguments, stdout, metadata, or the ledger.
+An empty manifest prunes all previously managed files and leaves all unmanaged home contents unchanged. A stale managed file that blocks a new managed directory, or vice versa, is removed before staging; empty ancestors are pruned only as needed, and unmanaged content makes the transition fail closed. Any validation, Secret Manager, or install failure leaves Compose stopped and the activation unsuccessful. Payload bytes never appear in command arguments, stdout, metadata, or the ledger.
 
 ## IAM
 

--- a/.agents/projects/loom_session_credentials/spec.md
+++ b/.agents/projects/loom_session_credentials/spec.md
@@ -1,0 +1,117 @@
+# Loom configuration ownership contract
+
+## Loom Settings surface
+
+The existing route query ids remain stable. Only labels and component placement change.
+
+| Query id | Label | Contents |
+|---|---|---|
+| `agents` | Agents | Profiles, profile environment, MCPs, custom agents, metadata settings |
+| `sessions` | Sessions | Server and session lifecycle settings |
+| `github` | Connections | GitHub App, GitHub behavior, Slack connection and behavior |
+| `watches` | Watches | Watch settings |
+| `workspace` | Workspace | Editor and terminal appearance |
+| `environment` | Session environment | Readable non-secret values on the default profile |
+| `access` | Access | Current user, password, personal GitHub PAT, approved users, Loom API tokens, authentication settings |
+| `diagnostics` | Diagnostics | Logs, background tasks, and build information |
+
+`GithubConnectionPanel.vue` owns GitHub App configuration. `AccountPanel.vue` no longer reads or writes deployment GitHub App configuration.
+
+The personal PAT creation URL is:
+
+```text
+https://github.com/settings/personal-access-tokens/new?name=Loom&description=Interactive%20Loom%20sessions&contents=write&issues=write&pull_requests=write
+```
+
+The URL is guidance, not validation. Token storage remains write-only. Existing sessions are unchanged after token save or removal.
+
+## Documentation contract
+
+`docs/configuration.md` defines the four owners: user, profile, deployment, and repository. It separately documents registered-setting precedence. Credential docs use `personal GitHub token`, `profile GH_TOKEN`, and `GitHub App installation token`; they do not call all three “the GitHub token.”
+
+## Marin Pulumi input
+
+```python
+@dataclass(frozen=True)
+class HomeFileConfig:
+    path: str
+    project: str
+    secret: str
+    version: str
+    mode: str
+
+    @classmethod
+    def parse(cls, path: str, value: object) -> "HomeFileConfig": ...
+
+    def manifest(self) -> dict[str, str]: ...
+```
+
+`DeploymentConfig` adds:
+
+```python
+home_files: tuple[HomeFileConfig, ...] = ()
+```
+
+Pulumi key `homeFiles` maps a relative path to an object with:
+
+- `secretRef`: required full GCP Secret Manager version resource with a numeric version;
+- `mode`: optional four-digit octal string, default `0600`, allowed values `0400` and `0600`.
+
+Paths use POSIX separators, are relative to `/home/app`, and reject empty segments, `.`, `..`, NUL, a leading slash, and duplicates after normalization. `.loom-managed-home-files.json` is reserved.
+
+The VM metadata key `loom-home-files` contains sorted JSON entries:
+
+```json
+[
+  {
+    "mode": "0600",
+    "path": ".kube/coreweave-iris",
+    "project": "hai-gcp-models",
+    "secret": "loom-coreweave-iris-kubeconfig",
+    "version": "1"
+  }
+]
+```
+
+## Materialization contract
+
+`infra/loom/materialize_home_files.py` has a host-side prepare command:
+
+```text
+materialize_home_files.py prepare --image=<digest> --manifest=<manifest-file>
+```
+
+The prepare command:
+
+1. validates the complete manifest before changing the volume;
+2. resolves each Secret Manager version into a mode-0600 temporary host file;
+3. runs the pinned Loom image as root, without a network, with the target volume mounted at `/home/app`;
+4. uses directory file descriptors with `O_NOFOLLOW` to reject a target path that crosses a symlink;
+5. copies through a temporary file, restores the session-home uid and gid, and atomically renames it with the declared mode;
+6. removes only regular files present in the previous ledger and absent from the new manifest;
+7. writes `.loom-managed-home-files.json` atomically with managed paths only;
+8. deletes all host temporary payloads on exit.
+
+An empty manifest prunes all previously managed files and leaves all unmanaged home contents unchanged. Any validation, Secret Manager, or install failure leaves Compose stopped and the activation unsuccessful. Payload bytes never appear in command arguments, stdout, metadata, or the ledger.
+
+## IAM
+
+The Loom VM service account receives `roles/secretmanager.secretAccessor` on each distinct `(project, secret)` referenced by a profile or home file. The Pulumi program does not create secret versions.
+
+## Production kubeconfig migration
+
+The code PR does not upload the kubeconfig. After review, an operator creates `loom-coreweave-iris-kubeconfig`, uploads the existing `/home/app/.kube/coreweave-iris` as numbered version 1, and adds the `homeFiles` entry. A preview must show the secret IAM member and `loom-home-files` metadata. Activation replaces the existing path atomically.
+
+## Errors
+
+- Invalid paths, modes, or unpinned references raise `ValueError` during Pulumi program evaluation.
+- Missing or inaccessible secret versions fail the startup script with the reference and target path but no payload.
+- A symlink in the target path fails activation without following or deleting it.
+
+## Out of scope
+
+- Per-profile filesystem isolation or file visibility.
+- Creating, reading, or rotating secret payloads from Pulumi.
+- Validating all GitHub fine-grained PAT permissions.
+- Removing existing profile or daemon `GH_TOKEN` fallbacks.
+- Changing registered-setting precedence or route query ids.


### PR DESCRIPTION
Define a four-part ownership model for Loom configuration: user credentials under Access, session policy and write-only secrets under profiles, deployment integrations and shared files in operator IaC, and non-secret repository behavior in source control.

The proposal maps the current Settings surfaces and GitHub credential precedence, records the shared `/home/app` trust boundary, and specifies a Secret Manager-backed `homeFiles` contract for machine-wide credentials such as the CoreWeave kubeconfig. The startup contract stops Loom and Caddy before materialization and restarts them only after success, while detached sessions continue through atomic file replacement. Authoritative managed-path state remains root-owned outside the session-writable volume, and path-topology transitions fail closed when unmanaged content blocks them. Secret payloads stay out of Pulumi state, and the mechanism remains separate from the production credential migration, which can occur only after a dedicated numbered secret version exists.

The accompanying research brief links the prior Loom credential and profile work, documents rejected alternatives, and records that the current GCP project has no suitable general CoreWeave kubeconfig secret. Loom UI and documentation changes land in a separate Loom PR with their own frontend and Rust gates.