### PR TITLE
[levanter] Add depthwise causal convolution kernel

### DIFF
--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/__init__.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/__init__.py
@@ -6,10 +6,8 @@
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures
 # **************************************************
 
-from .op import IMPLEMENTATIONS, Implementation, depthwise_causal_convolution
-
-__all__ = [
-    "IMPLEMENTATIONS",
-    "Implementation",
-    "depthwise_causal_convolution",
-]
+from .op import (
+    IMPLEMENTATIONS as IMPLEMENTATIONS,
+    Implementation as Implementation,
+    depthwise_causal_convolution as depthwise_causal_convolution,
+)

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/__init__.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/__init__.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/__init__.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/__init__.py
@@ -1,0 +1,12 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+from .op import IMPLEMENTATIONS, Implementation, depthwise_causal_convolution
+
+__all__ = [
+    "IMPLEMENTATIONS",
+    "Implementation",
+    "depthwise_causal_convolution",
+]

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
@@ -254,7 +254,10 @@ def _backward_core(
             pl.BlockSpec(block_shape=(None, PAD, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, 0, 0)),
         ),
         scratch_shapes=[pltpu.VMEM((PAD, H), jnp.float32), pltpu.VMEM((PAD, H), jnp.float32)],
-        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "arbitrary")),
+        # dW_ref/db_ref alias the same output block across every BLOCK_ID_B and accumulate via
+        # non-atomic +=, so the B dimension must run in program order like S, not in parallel
+        # (megacore could otherwise race two batch programs on the same accumulator).
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("arbitrary", "arbitrary")),
     )
 
     dx, dW, db, dh0 = kernel(x, W, b, h, dy, dht)

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
@@ -1,0 +1,259 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+from functools import partial
+
+import jax
+import jax.experimental.pallas as pl
+import jax.experimental.pallas.tpu as pltpu
+import jax.numpy as jnp
+from .forward_kernel import _ceil_div
+
+
+def _backward_kernel(
+    x_ref,
+    W_ref,
+    b_ref,
+    h_ref,
+    dy_ref,
+    dht_ref,
+    dx_ref,
+    dW_ref,
+    db_ref,
+    dh0_ref,
+    dy_scratch,
+    dht_scratch,
+    BLOCK_SIZE_S: int,
+    S: int,
+    K: int,
+    PAD: int,
+    NUM_BLOCKS_S: int,
+    ACTIVATION: str | None,
+) -> None:
+    BLOCK_ID_B = pl.program_id(0)
+    BLOCK_ID_S_REVERSE = pl.program_id(1)
+    BLOCK_ID_S = NUM_BLOCKS_S - 1 - BLOCK_ID_S_REVERSE
+
+    H = x_ref.shape[-1]
+    dtype = x_ref.dtype
+    offset = PAD - K + 1
+
+    @pl.when(BLOCK_ID_S_REVERSE == 0)
+    def _():
+        dy_scratch[...] = jnp.zeros_like(dy_scratch)
+        dht_scratch[...] = jnp.zeros_like(dht_scratch)
+        if dht_ref is not None:
+            dht_scratch[offset:, :] = dht_ref[...].astype(jnp.float32)
+
+    @pl.when((BLOCK_ID_B == 0) & (BLOCK_ID_S_REVERSE == 0))
+    def _():
+        dW_ref[...] = jnp.zeros(dW_ref.shape, dtype=dW_ref.dtype)
+        db_ref[...] = jnp.zeros(db_ref.shape, dtype=db_ref.dtype)
+
+    BLOCK_S = jax.lax.broadcasted_iota(jnp.int32, (BLOCK_SIZE_S, 1), 0)
+    PATCH_R = jax.lax.broadcasted_iota(jnp.int32, (PAD, 1), 0)
+    MASK_S = (BLOCK_ID_S * BLOCK_SIZE_S + BLOCK_S) < S
+
+    MASKED = S % BLOCK_SIZE_S != 0
+    if MASKED:
+        dy = jnp.where(MASK_S, dy_ref[...], 0).astype(jnp.float32)
+        x = jnp.where(MASK_S, x_ref[...], 0).astype(jnp.float32)
+    else:
+        dy = dy_ref[...].astype(jnp.float32)
+        x = x_ref[...].astype(jnp.float32)
+
+    hist = h_ref[0].astype(jnp.float32)  # hist[PAD + j] == x[j] for j < 0
+
+    def x_tap(k: int):
+        shift = K - 1 - k
+        return pltpu.roll(x, shift, axis=0) if shift > 0 else x
+
+    if ACTIVATION in ["silu", "swish"]:
+        y = jnp.zeros((BLOCK_SIZE_S, H), dtype=jnp.float32)
+        if b_ref is not None:
+            y += b_ref[...].astype(jnp.float32)
+
+        for k in range(K):
+            y += W_ref[k, :].astype(jnp.float32)[None, :] * x_tap(k)
+
+        x_head = x[:PAD, :]
+        y_head = jnp.zeros((PAD, H), dtype=jnp.float32)
+        if b_ref is not None:
+            y_head += b_ref[...].astype(jnp.float32)
+
+        for k in range(K):
+            shift = K - 1 - k
+            if shift == 0:
+                y_head += W_ref[k, :].astype(jnp.float32)[None, :] * x_head
+            else:
+                W = W_ref[k, :].astype(jnp.float32)[None, :]
+                y_head += W * jnp.where(PATCH_R >= shift, pltpu.roll(x_head, shift, axis=0), 0)
+                y_head += W * jnp.where(PATCH_R < shift, pltpu.roll(hist, shift, axis=0), 0)
+
+        y = jnp.where(BLOCK_S < K - 1, jnp.pad(y_head, ((0, BLOCK_SIZE_S - PAD), (0, 0))), y)
+
+        sigmoid = jax.nn.sigmoid(y)
+        dy = dy * sigmoid * (1 + y * (1 - sigmoid))
+
+    dy_bf = dy.astype(dtype)
+    dx = jnp.zeros((BLOCK_SIZE_S, H), dtype=dtype)
+    for k in range(K):
+        W = W_ref[k, :]
+
+        shift = K - 1 - k
+        if shift == 0:
+            dx += W[None, :] * dy_bf
+        else:
+            dx += W[None, :] * pltpu.roll(dy_bf, (BLOCK_SIZE_S - shift) % BLOCK_SIZE_S, axis=0)
+
+    dy_tail = dy[BLOCK_SIZE_S - PAD :, :]
+    carry = dy_scratch[...]
+    dx_tail = jnp.zeros((PAD, H), dtype=jnp.float32)
+    for k in range(K):
+        W = W_ref[k, :].astype(jnp.float32)[None, :]
+
+        shift = K - 1 - k
+        if shift == 0:
+            dx_tail += W * dy_tail
+        else:
+            up = PAD - shift
+            dx_tail += W * jnp.where(
+                PATCH_R < PAD - shift, pltpu.roll(dy_tail, up, axis=0), pltpu.roll(carry, up, axis=0)
+            )
+
+    dx = jnp.where(
+        BLOCK_S >= BLOCK_SIZE_S - (K - 1),
+        jnp.pad(dx_tail, ((BLOCK_SIZE_S - PAD, 0), (0, 0))).astype(dtype),
+        dx,
+    )
+
+    ones_row = jnp.ones((1, BLOCK_SIZE_S), dtype=dtype)
+    db_ref[...] += jax.lax.dot(ones_row, dy_bf, preferred_element_type=jnp.float32)
+
+    d_head = dy[:PAD, :]
+    for k in range(K):
+        shift = K - 1 - k
+        tap = x_tap(k)
+        acc = jax.lax.dot(ones_row, (dy * tap).astype(dtype), preferred_element_type=jnp.float32)[0]
+        if shift > 0:
+            acc += jnp.sum(
+                jnp.where(PATCH_R < shift, d_head * (pltpu.roll(hist, shift, axis=0) - tap[:PAD, :]), 0),
+                axis=0,
+            )
+        dW_ref[k, :] += acc
+
+    dx_ref[...] = (jnp.where(MASK_S, dx, 0) if MASKED else dx).astype(dtype)
+
+    state_prefix = max(K - 1 - S, 0)
+    x_state_start = max(S - (K - 1), 0)
+
+    if dht_ref is not None:
+        dht_rows = {}
+        for p in range(state_prefix, K - 1):
+            block_index, row_in_block = divmod(x_state_start + p - state_prefix, BLOCK_SIZE_S)
+            dht_rows.setdefault(block_index, []).append((p, row_in_block))
+
+        for block_index, rows in dht_rows.items():
+
+            @pl.when(BLOCK_ID_S == block_index)
+            def _(rows=rows):
+                update = jnp.zeros((BLOCK_SIZE_S, H), dtype=jnp.float32)
+                for p, row_in_block in rows:
+                    update += jnp.where(BLOCK_S == row_in_block, dht_scratch[offset + p, :], 0)
+
+                dx_ref[...] += update.astype(dtype)
+
+    @pl.when(BLOCK_ID_S == 0)
+    def _():
+        dh0 = jnp.zeros((BLOCK_SIZE_S, H), dtype=jnp.float32)
+        for k in range(K):
+            W = W_ref[k, :].astype(jnp.float32)
+            dh0 += W[None, :] * jnp.where(BLOCK_S < k, 0, pltpu.roll(dy, k, axis=0))
+
+        dh0_ref[...] = pltpu.roll(dh0[:PAD, :], offset, axis=0)
+
+        for p in range(state_prefix):
+            dh0_ref[offset + S + p, :] += dht_scratch[offset + p, :]
+
+    dy_scratch[...] = dy[:PAD, :]
+
+
+@partial(jax.jit, static_argnames=("BLOCK_SIZE_S", "K", "ACTIVATION"))
+def _backward_core(
+    x: jax.Array,
+    W: jax.Array,
+    b: jax.Array | None,
+    h: jax.Array,
+    dy: jax.Array,
+    dht: jax.Array | None,
+    BLOCK_SIZE_S: int,
+    K: int,
+    ACTIVATION: str | None = None,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    B, S, H = x.shape
+    NUM_BLOCKS_S = _ceil_div(S, BLOCK_SIZE_S)
+    PAD = _ceil_div(K - 1, 8) * 8
+    state_size = K - 1
+
+    # a block has to be long enough to carry the whole history in its leading/trailing PAD rows
+    assert BLOCK_SIZE_S >= PAD, f"BLOCK_SIZE_S ({BLOCK_SIZE_S}) must be >= {PAD} for kernel_size ({K})"
+
+    kernel = pl.pallas_call(
+        partial(
+            _backward_kernel,
+            BLOCK_SIZE_S=BLOCK_SIZE_S,
+            S=S,
+            K=K,
+            PAD=PAD,
+            NUM_BLOCKS_S=NUM_BLOCKS_S,
+            ACTIVATION=ACTIVATION,
+        ),
+        out_shape=(
+            jax.ShapeDtypeStruct((B, S, H), x.dtype),
+            jax.ShapeDtypeStruct((K, H), jnp.float32),
+            jax.ShapeDtypeStruct((1, H), jnp.float32),
+            jax.ShapeDtypeStruct((B, PAD, H), jnp.float32),
+        ),
+        grid=(B, NUM_BLOCKS_S),
+        in_specs=(
+            pl.BlockSpec(
+                block_shape=(None, BLOCK_SIZE_S, H),
+                index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, NUM_BLOCKS_S - 1 - BLOCK_ID_S, 0),
+            ),
+            pl.BlockSpec(block_shape=(K, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (0, 0)),
+            None if b is None else pl.BlockSpec(block_shape=(1, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (0, 0)),
+            pl.BlockSpec(
+                block_shape=(None, 1, PAD, H),
+                index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, NUM_BLOCKS_S - 1 - BLOCK_ID_S, 0, 0),
+            ),
+            pl.BlockSpec(
+                block_shape=(None, BLOCK_SIZE_S, H),
+                index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, NUM_BLOCKS_S - 1 - BLOCK_ID_S, 0),
+            ),
+            (
+                None
+                if dht is None
+                else pl.BlockSpec(
+                    block_shape=(None, state_size, H),
+                    index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, 0, 0),
+                )
+            ),
+        ),
+        out_specs=(
+            pl.BlockSpec(
+                block_shape=(None, BLOCK_SIZE_S, H),
+                index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, NUM_BLOCKS_S - 1 - BLOCK_ID_S, 0),
+            ),
+            pl.BlockSpec(block_shape=(K, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (0, 0)),
+            pl.BlockSpec(block_shape=(1, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (0, 0)),
+            pl.BlockSpec(block_shape=(None, PAD, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, 0, 0)),
+        ),
+        scratch_shapes=[pltpu.VMEM((PAD, H), jnp.float32), pltpu.VMEM((PAD, H), jnp.float32)],
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "arbitrary")),
+    )
+
+    dx, dW, db, dh0 = kernel(x, W, b, h, dy, dht)
+
+    return dx, dW, db, dh0

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
@@ -12,7 +12,7 @@ import jax
 import jax.experimental.pallas as pl
 import jax.experimental.pallas.tpu as pltpu
 import jax.numpy as jnp
-from .forward_kernel import _ceil_div
+from .forward_kernel import _ceil_div, _pad_size
 
 
 def _backward_kernel(
@@ -197,7 +197,7 @@ def _backward_core(
 ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
     B, S, H = x.shape
     NUM_BLOCKS_S = _ceil_div(S, BLOCK_SIZE_S)
-    PAD = _ceil_div(K - 1, 8) * 8
+    PAD = _pad_size(K)
     state_size = K - 1
 
     # a block has to be long enough to carry the whole history in its leading/trailing PAD rows

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/forward_kernel.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/forward_kernel.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/forward_kernel.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/forward_kernel.py
@@ -18,6 +18,11 @@ def _ceil_div(n: int, d: int) -> int:
     return (n + d - 1) // d
 
 
+def _pad_size(K: int) -> int:
+    """Sublane-aligned width of the `K - 1` history a block must carry."""
+    return _ceil_div(K - 1, 8) * 8
+
+
 def _forward_kernel(
     x_ref,
     W_ref,
@@ -82,7 +87,7 @@ def _forward_core(
 ) -> jax.Array | tuple[jax.Array, jax.Array]:
     B, S, H = x.shape
     K = W.shape[0]
-    PAD = _ceil_div(K - 1, 8) * 8
+    PAD = _pad_size(K)
     NUM_BLOCKS_S = _ceil_div(S, BLOCK_SIZE_S)
 
     x_spec = pl.BlockSpec(

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/forward_kernel.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/forward_kernel.py
@@ -1,0 +1,119 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+from functools import partial
+
+import jax
+import jax.experimental.pallas as pl
+import jax.experimental.pallas.tpu as pltpu
+import jax.numpy as jnp
+
+
+def _ceil_div(n: int, d: int) -> int:
+    return (n + d - 1) // d
+
+
+def _forward_kernel(
+    x_ref,
+    W_ref,
+    b_ref,
+    h0_ref,
+    y_ref,
+    h_ref,
+    h_scratch,
+    BLOCK_SIZE_S: int,
+    S: int,
+    K: int,
+    PAD: int,
+    ACTIVATION: str | None,
+) -> None:
+    BLOCK_ID_S = pl.program_id(1)
+
+    @pl.when(BLOCK_ID_S == 0)
+    def _():
+        if h0_ref is None:
+            h_scratch[...] = jnp.zeros_like(h_scratch)
+        else:
+            h_scratch[...] = h0_ref[...]
+
+    if h_ref is not None:
+        h_ref[...] = h_scratch[...][None]
+
+    dtype = x_ref.dtype
+    H = x_ref.shape[-1]
+
+    BLOCK_S = jax.lax.broadcasted_iota(jnp.int32, (BLOCK_SIZE_S, 1), 0)
+    MASK_S = (BLOCK_ID_S * BLOCK_SIZE_S + BLOCK_S) < S
+
+    x = jnp.where(MASK_S, x_ref[...], 0).astype(dtype)
+    x_f32 = x.astype(jnp.float32)
+    b = jnp.zeros((1, H), dtype=jnp.float32) if b_ref is None else b_ref[...].astype(jnp.float32)
+
+    hist_padded = jnp.pad(h_scratch[...].astype(jnp.float32), ((BLOCK_SIZE_S - PAD, 0), (0, 0)))
+
+    taps = [
+        jnp.where(BLOCK_S < shift, pltpu.roll(hist_padded, shift, axis=0), pltpu.roll(x_f32, shift, axis=0))
+        for shift in (K - 1 - k for k in range(K))
+    ]
+
+    W = W_ref[...].astype(jnp.float32)
+    y = jnp.sum(jnp.stack(taps, axis=0) * W[:, None, :], axis=0) + b
+
+    if ACTIVATION in ["silu", "swish"]:
+        y = y * jax.nn.sigmoid(y)
+
+    y_ref[...] = y.astype(dtype)
+    h_scratch[...] = x_f32[BLOCK_SIZE_S - PAD :, :].astype(dtype)
+
+
+@partial(jax.jit, static_argnames=("BLOCK_SIZE_S", "ACTIVATION"))
+def _forward_core(
+    x: jax.Array,
+    W: jax.Array,
+    b: jax.Array | None,
+    h0: jax.Array | None,
+    BLOCK_SIZE_S: int,
+    ACTIVATION: str | None = None,
+) -> jax.Array | tuple[jax.Array, jax.Array]:
+    B, S, H = x.shape
+    K = W.shape[0]
+    PAD = _ceil_div(K - 1, 8) * 8
+    NUM_BLOCKS_S = _ceil_div(S, BLOCK_SIZE_S)
+
+    x_spec = pl.BlockSpec(
+        block_shape=(None, BLOCK_SIZE_S, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, BLOCK_ID_S, 0)
+    )
+
+    kernel = pl.pallas_call(
+        partial(_forward_kernel, BLOCK_SIZE_S=BLOCK_SIZE_S, S=S, K=K, PAD=PAD, ACTIVATION=ACTIVATION),
+        out_shape=(
+            jax.ShapeDtypeStruct((B, S, H), x.dtype),
+            jax.ShapeDtypeStruct((B, NUM_BLOCKS_S, PAD, H), x.dtype),
+        ),
+        grid=(B, NUM_BLOCKS_S),
+        in_specs=(
+            x_spec,
+            pl.BlockSpec(block_shape=(K, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (0, 0)),
+            None if b is None else pl.BlockSpec(block_shape=(1, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (0, 0)),
+            (
+                None
+                if h0 is None
+                else pl.BlockSpec(
+                    block_shape=(None, PAD, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, 0, 0)
+                )
+            ),
+        ),
+        out_specs=(
+            x_spec,
+            pl.BlockSpec(
+                block_shape=(None, 1, PAD, H),
+                index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, BLOCK_ID_S, 0, 0),
+            ),
+        ),
+        scratch_shapes=[pltpu.VMEM((PAD, H), x.dtype)],
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "arbitrary")),
+    )
+
+    return kernel(x, W, b, h0)

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
@@ -203,7 +203,7 @@ def depthwise_causal_convolution(
     if input_state is not None:
         assert input_state.shape == (B, H, K - 1)
 
-    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+    if attention_mask is not None:
         input = (input * attention_mask[:, :, None]).astype(input.dtype)
 
     if implementation is None:
@@ -229,5 +229,8 @@ def depthwise_causal_convolution(
         )
     else:
         raise ValueError(f"unexpected implementation ({implementation})")
+
+    if attention_mask is not None:
+        input = (input * attention_mask[:, :, None]).astype(input.dtype)
 
     return input, input_state

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
@@ -13,7 +13,7 @@ import jax
 import jax.numpy as jnp
 
 from .backward_kernel import _backward_core
-from .forward_kernel import _ceil_div, _forward_core
+from .forward_kernel import _forward_core, _pad_size
 from .reference import _depthwise_causal_convolution_reference
 
 Implementation: TypeAlias = Literal["pallas_tpu", "xla"]
@@ -29,9 +29,8 @@ def _get_block_size_s(H: int) -> int:
 
 
 def _pad_h0(h0: jax.Array, K: int) -> jax.Array:
-    state_size = K - 1
-    pad = _ceil_div(state_size, 8) * 8
-    return jnp.pad(h0, ((0, 0), (pad - state_size, 0), (0, 0)))
+    pad = _pad_size(K)
+    return jnp.pad(h0, ((0, 0), (pad - (K - 1), 0), (0, 0)))
 
 
 def _forward_run(

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
@@ -1,0 +1,231 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+from functools import lru_cache, partial
+from typing import Literal, TypeAlias
+
+import jax
+import jax.numpy as jnp
+
+from .backward_kernel import _backward_core
+from .forward_kernel import _ceil_div, _forward_core
+from .reference import _depthwise_causal_convolution_reference
+
+Implementation: TypeAlias = Literal["pallas_tpu", "xla"]
+
+
+def _get_block_size_s(H: int) -> int:
+    # the kernel stack holds several (BLOCK_SIZE_S, H) fp32 tiles and vmem overflows once
+    # BLOCK_SIZE_S * H exceeds 2**19 (measured), so shrink the block for wide H. Narrow H
+    # wants the block as big as possible instead: more rows per program means fewer HBM
+    # round-trips, which is what sets the kernel's bandwidth at small hidden sizes
+    block_size = 1 << ((1 << 19) // H).bit_length() - 1
+    return min(1024, max(8, block_size))
+
+
+def _pad_h0(h0: jax.Array, K: int) -> jax.Array:
+    state_size = K - 1
+    pad = _ceil_div(state_size, 8) * 8
+    return jnp.pad(h0, ((0, 0), (pad - state_size, 0), (0, 0)))
+
+
+def _forward_run(
+    x: jax.Array,
+    W: jax.Array,
+    b: jax.Array | None,
+    h0: jax.Array | None,
+    output_state: bool,
+    ACTIVATION: str | None,
+) -> tuple[jax.Array, jax.Array | None, jax.Array]:
+    W = jnp.transpose(W, (1, 0))
+    b = None if b is None else b[None, :]
+
+    if h0 is not None:
+        h0 = jnp.transpose(h0, (0, 2, 1)).astype(x.dtype)
+        h0 = _pad_h0(h0, K=W.shape[0])
+
+    # the per-block input states are saved from the forward as vjp residuals (a small
+    # (B, ceil(S / BLOCK_SIZE_S), PAD, H) tensor) so the backward can consume them directly
+    # instead of re-deriving them with an extra pass over the input
+    y, h = _forward_core(x=x, W=W, b=b, h0=h0, BLOCK_SIZE_S=_get_block_size_s(x.shape[-1]), ACTIVATION=ACTIVATION)
+
+    if output_state:
+        state_size = W.shape[0] - 1
+        if h0 is None:
+            ht = (
+                jnp.pad(x, ((0, 0), (state_size - x.shape[1], 0), (0, 0)))
+                if x.shape[1] < state_size
+                else x[:, -state_size:, :]
+            )
+        else:
+            ht = jnp.concatenate([h0.astype(x.dtype), x], axis=1)[:, -state_size:, :]
+
+        ht = jnp.transpose(ht, (0, 2, 1))
+    else:
+        ht = None
+
+    return y, ht, h
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(4, 5))
+def _depthwise_causal_convolution_pallas(
+    x: jax.Array,
+    W: jax.Array,
+    b: jax.Array | None,
+    h0: jax.Array | None,
+    output_state: bool,
+    ACTIVATION: str | None,
+) -> tuple[jax.Array, jax.Array | None]:
+    y, ht, _ = _forward_run(x=x, W=W, b=b, h0=h0, output_state=output_state, ACTIVATION=ACTIVATION)
+    return y, ht
+
+
+def _depthwise_causal_convolution_forward(
+    x: jax.Array,
+    W: jax.Array,
+    b: jax.Array | None,
+    h0: jax.Array | None,
+    output_state: bool,
+    ACTIVATION: str | None,
+) -> tuple[tuple[jax.Array, jax.Array | None], tuple]:
+    y, ht, h = _forward_run(x=x, W=W, b=b, h0=h0, output_state=output_state, ACTIVATION=ACTIVATION)
+    return (y, ht), (x, W, b, h0, h)
+
+
+def _depthwise_causal_convolution_backward(
+    output_state: bool, ACTIVATION: str | None, residuals: tuple, cotangents: tuple
+) -> tuple:
+    x, W, b, h0, h_states = residuals
+    dy, dht = cotangents
+
+    K = W.shape[-1]
+    W = jnp.transpose(W, (1, 0))
+
+    dht = None if dht is None or not output_state else jnp.transpose(dht, (0, 2, 1))
+
+    dx, dW, db, dh0 = _backward_core(
+        x=x,
+        W=W,
+        b=None if b is None else b[None, :],
+        h=h_states,
+        dy=dy,
+        dht=dht,
+        BLOCK_SIZE_S=_get_block_size_s(x.shape[-1]),
+        K=K,
+        ACTIVATION=ACTIVATION,
+    )
+
+    dW = jnp.transpose(dW, (1, 0))
+    db = None if b is None else db[0]
+    dh0 = None if h0 is None else jnp.transpose(dh0[:, 1 - K :, :], (0, 2, 1))
+
+    return dx, dW, db, dh0
+
+
+_depthwise_causal_convolution_pallas.defvjp(
+    _depthwise_causal_convolution_forward, _depthwise_causal_convolution_backward
+)
+
+
+IMPLEMENTATIONS = {
+    "pallas_tpu": _depthwise_causal_convolution_pallas,
+    "xla": _depthwise_causal_convolution_reference,
+}
+
+
+@lru_cache(maxsize=1)
+def _default_implementation() -> Implementation:
+    return "pallas_tpu" if jax.default_backend() == "tpu" else "xla"
+
+
+def depthwise_causal_convolution(
+    input: jax.Array,
+    weight: jax.Array,
+    bias: jax.Array | None = None,
+    input_state: jax.Array | None = None,
+    attention_mask: jax.Array | None = None,
+    output_state: bool = False,
+    activation_function: str | None = None,
+    *,
+    implementation: Implementation | None = None,
+) -> tuple[jax.Array, jax.Array | None]:
+    """
+    computes depthwise causal 1D convolution: `output[b, t, h] = act(bias[h] + sum_k weight[h, k] *
+    z[b, t + k, h])` where `z` is `input` preceded by `kernel_size - 1` raw history positions taken from
+    `input_state` (or 0 if `input_state` is None), i.e. `output[b, t]` only depends on
+    `input[b, t - kernel_size + 1 : t + 1]`.
+
+    :param input: input tensor of shape (B, S, H)
+    :type input: jax.Array
+    :param weight: depthwise convolution weight of shape (H, K), K being the kernel size
+    :type weight: jax.Array
+    :param bias: bias tensor of shape (H,). None means no bias is added. Defaults to None.
+    :type bias: jax.Array | None
+    :param input_state: the `K - 1` raw (pre-convolution) input positions preceding `input`, of shape
+        (B, H, K - 1). None is equivalent to a 0 tensor. Defaults to None.
+    :type input_state: jax.Array | None
+    :param attention_mask: mask of shape (B, S), zeroing out padding positions before and after the
+        convolution. Defaults to None.
+    :type attention_mask: jax.Array | None
+    :param output_state: whether to also return the trailing `K - 1` raw input positions (taken from `input`,
+        falling back to `input_state` if `input` is shorter than `K - 1`) for use as `input_state` in a
+        subsequent call. Defaults to False.
+    :type output_state: bool
+    :param activation_function: activation applied after the convolution + bias, fused into the kernel.
+        Either "silu", its alias "swish", or None (no activation). Defaults to None.
+    :type activation_function: str | None
+    :param implementation: "pallas_tpu" uses a hand-written VPU-only Pallas TPU kernel (avoids the
+        MXU/systolic array, which a tiny `kernel_size` reduction dimension underutilizes badly). "xla" uses
+        the plain `jax.lax.conv_general_dilated`-based reference. None auto-detects based on the
+        accelerator ("pallas_tpu" on TPU, "xla" otherwise). Defaults to None.
+    :type implementation: Implementation | None
+    :return: output tensor of shape (B, S, H), and the output state of shape (B, H, K - 1) if `output_state`
+        is True else None.
+    :rtype: tuple[jax.Array, jax.Array | None]
+    """
+
+    B, _, H = input.shape
+    K = weight.shape[-1]
+
+    assert weight.ndim == 2
+    assert weight.shape[0] == H
+    assert K > 1
+
+    assert activation_function in [None, "silu", "swish"]
+
+    if bias is not None:
+        assert bias.shape == (H,)
+
+    if input_state is not None:
+        assert input_state.shape == (B, H, K - 1)
+
+    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+        input = (input * attention_mask[:, :, None]).astype(input.dtype)
+
+    if implementation is None:
+        implementation = _default_implementation()
+
+    if implementation == "pallas_tpu":
+        input, input_state = _depthwise_causal_convolution_pallas(
+            x=input,
+            W=weight,
+            b=bias,
+            h0=input_state,
+            output_state=output_state,
+            ACTIVATION=activation_function,
+        )
+    elif implementation == "xla":
+        input, input_state = _depthwise_causal_convolution_reference(
+            x=input,
+            W=weight,
+            b=bias,
+            h0=input_state,
+            output_state=output_state,
+            activation_function=activation_function,
+        )
+    else:
+        raise ValueError(f"unexpected implementation ({implementation})")
+
+    return input, input_state

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/reference.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/reference.py
@@ -1,0 +1,54 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+import jax
+import jax.numpy as jnp
+
+
+def _depthwise_causal_convolution_reference(
+    x: jax.Array,
+    W: jax.Array,
+    b: jax.Array | None,
+    h0: jax.Array | None,
+    output_state: bool,
+    activation_function: str | None,
+) -> tuple[jax.Array, jax.Array | None]:
+    _, S, H = x.shape
+    K = W.shape[-1]
+    state_size = K - 1
+
+    x = jnp.transpose(x, (0, 2, 1))
+    ht = None
+
+    if h0 is None:
+        padding = [(K - 1, 0)]
+
+        if output_state:
+            ht = jnp.pad(x, ((0, 0), (0, 0), (state_size - S, 0))) if S < state_size else x[:, :, -state_size:]
+    else:
+        padding = [(0, 0)]
+
+        x = jnp.concatenate([h0.astype(x.dtype), x], axis=-1)
+
+        if output_state:
+            ht = x[:, :, -state_size:]
+
+    x = jax.lax.conv_general_dilated(
+        lhs=x,
+        rhs=W[:, None, :],
+        window_strides=(1,),
+        padding=padding,
+        feature_group_count=H,
+        dimension_numbers=("NCH", "OIH", "NCH"),
+    )
+
+    if b is not None:
+        x = x + b[None, :, None]
+
+    x = jnp.transpose(x, (0, 2, 1))
+    if activation_function in ["silu", "swish"]:
+        x = jax.nn.silu(x.astype(jnp.float32)).astype(x.dtype)
+
+    return x, ht

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/reference.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/reference.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures

--- a/lib/levanter/src/levanter/layers/depthwise_causal_convolution.py
+++ b/lib/levanter/src/levanter/layers/depthwise_causal_convolution.py
@@ -1,0 +1,65 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+import equinox as eqx
+import jax
+from jaxtyping import PRNGKeyArray
+
+from levanter.kernels.pallas.depthwise_causal_convolution import depthwise_causal_convolution
+
+
+class DepthwiseCausalConvolution(eqx.Module):
+    weight: jax.Array
+    bias: jax.Array | None
+
+    hidden_size: int = eqx.field(static=True)
+    kernel_size: int = eqx.field(static=True)
+    state_size: int = eqx.field(static=True)
+    activation_function: str | None = eqx.field(static=True)
+
+    @staticmethod
+    def init(
+        hidden_size: int,
+        kernel_size: int,
+        activation_function: str | None,
+        add_bias: bool,
+        *,
+        key: PRNGKeyArray,
+    ) -> "DepthwiseCausalConvolution":
+        assert kernel_size > 1
+
+        weight_key, bias_key = jax.random.split(key, 2)
+        bound = kernel_size**-0.5
+
+        weight = jax.random.uniform(weight_key, (hidden_size, kernel_size), minval=-bound, maxval=bound)
+        bias = jax.random.uniform(bias_key, (hidden_size,), minval=-bound, maxval=bound) if add_bias else None
+
+        return DepthwiseCausalConvolution(
+            weight=weight,
+            bias=bias,
+            hidden_size=hidden_size,
+            kernel_size=kernel_size,
+            state_size=kernel_size - 1,
+            activation_function=activation_function,
+        )
+
+    def __call__(
+        self,
+        input: jax.Array,
+        input_state: jax.Array | None = None,
+        attention_mask: jax.Array | None = None,
+        output_state: bool = False,
+    ) -> tuple[jax.Array, jax.Array | None]:
+        input, input_state = depthwise_causal_convolution(
+            input=input,
+            weight=self.weight,
+            bias=self.bias,
+            input_state=input_state,
+            attention_mask=attention_mask,
+            output_state=output_state,
+            activation_function=self.activation_function,
+        )
+
+        return input, input_state

--- a/lib/levanter/src/levanter/layers/depthwise_causal_convolution.py
+++ b/lib/levanter/src/levanter/layers/depthwise_causal_convolution.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures

--- a/lib/levanter/src/levanter/layers/depthwise_causal_convolution.py
+++ b/lib/levanter/src/levanter/layers/depthwise_causal_convolution.py
@@ -7,24 +7,30 @@ import equinox as eqx
 import jax
 from jaxtyping import PRNGKeyArray
 
+import haliax as hax
+from haliax import Axis, AxisSelector, NamedArray
+
 from levanter.kernels.pallas.depthwise_causal_convolution import depthwise_causal_convolution
 
 
 class DepthwiseCausalConvolution(eqx.Module):
-    weight: jax.Array
-    bias: jax.Array | None
+    Embed: Axis = eqx.field(static=True)
+    weight: NamedArray  # [Embed, Kernel]
+    bias: NamedArray | None  # [Embed]
 
-    hidden_size: int = eqx.field(static=True)
     kernel_size: int = eqx.field(static=True)
-    state_size: int = eqx.field(static=True)
     activation_function: str | None = eqx.field(static=True)
+
+    @property
+    def State(self) -> Axis:
+        return Axis("state", self.kernel_size - 1)
 
     @staticmethod
     def init(
-        hidden_size: int,
+        Embed: Axis,
         kernel_size: int,
         activation_function: str | None,
-        add_bias: bool,
+        use_bias: bool,
         *,
         key: PRNGKeyArray,
     ) -> "DepthwiseCausalConvolution":
@@ -32,34 +38,71 @@ class DepthwiseCausalConvolution(eqx.Module):
 
         weight_key, bias_key = jax.random.split(key, 2)
         bound = kernel_size**-0.5
+        Kernel = Axis("kernel", kernel_size)
 
-        weight = jax.random.uniform(weight_key, (hidden_size, kernel_size), minval=-bound, maxval=bound)
-        bias = jax.random.uniform(bias_key, (hidden_size,), minval=-bound, maxval=bound) if add_bias else None
+        weight = hax.random.uniform(weight_key, (Embed, Kernel), minval=-bound, maxval=bound)
+        bias = hax.random.uniform(bias_key, (Embed,), minval=-bound, maxval=bound) if use_bias else None
 
         return DepthwiseCausalConvolution(
+            Embed=Embed,
             weight=weight,
             bias=bias,
-            hidden_size=hidden_size,
             kernel_size=kernel_size,
-            state_size=kernel_size - 1,
             activation_function=activation_function,
         )
 
     def __call__(
         self,
-        input: jax.Array,
-        input_state: jax.Array | None = None,
-        attention_mask: jax.Array | None = None,
+        input: NamedArray,
+        input_state: NamedArray | None = None,
+        attention_mask: NamedArray | None = None,
         output_state: bool = False,
-    ) -> tuple[jax.Array, jax.Array | None]:
-        input, input_state = depthwise_causal_convolution(
-            input=input,
-            weight=self.weight,
-            bias=self.bias,
-            input_state=input_state,
-            attention_mask=attention_mask,
+        *,
+        Pos: AxisSelector = "position",
+    ) -> tuple[NamedArray, NamedArray | None]:
+        """Apply the depthwise causal convolution.
+
+        Args:
+            input: [Batch, Pos, Embed], Batch being whatever single axis remains once Pos and
+                Embed are accounted for.
+            input_state: [Batch, Embed, State], the `kernel_size - 1` raw positions preceding
+                `input`. None is equivalent to a 0 tensor.
+            attention_mask: [Batch, Pos], zeroing out padding positions before and after the
+                convolution.
+            output_state: whether to also return the trailing `kernel_size - 1` raw input
+                positions for use as `input_state` in a subsequent call.
+            Pos: the axis (or its name) identifying the sequence dimension in `input`.
+
+        Returns:
+            output: [Batch, Pos, Embed].
+            output_state: [Batch, Embed, State] if `output_state` is True else None.
+        """
+        input = hax.rearrange(input, (..., Pos, self.Embed))
+        if len(input.axes) != 3:
+            raise ValueError(f"expected exactly one batch axis alongside {Pos} and {self.Embed}, got {input.axes}")
+        Batch = input.axes[0]
+
+        input_state_array = None
+        if input_state is not None:
+            input_state_array = hax.rearrange(input_state, (Batch, self.Embed, self.State)).array
+
+        attention_mask_array = None
+        if attention_mask is not None:
+            attention_mask_array = hax.rearrange(attention_mask, (Batch, Pos)).array
+
+        output_array, output_state_array = depthwise_causal_convolution(
+            input=input.array,
+            weight=self.weight.array,
+            bias=None if self.bias is None else self.bias.array,
+            input_state=input_state_array,
+            attention_mask=attention_mask_array,
             output_state=output_state,
             activation_function=self.activation_function,
         )
 
-        return input, input_state
+        output = hax.named(output_array, input.axes)
+        output_state_named = (
+            None if output_state_array is None else hax.named(output_state_array, (Batch, self.Embed, self.State))
+        )
+
+        return output, output_state_named

--- a/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
+++ b/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
@@ -3,8 +3,6 @@
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures
 # **************************************************
 
-from __future__ import annotations
-
 from itertools import product
 
 import jax

--- a/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
+++ b/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures

--- a/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
+++ b/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
@@ -129,21 +129,53 @@ def test_depthwise_causal_convolution_xla_grad_runs(kernel_size: int) -> None:
         assert bool(jnp.all(jnp.isfinite(grad))), name
 
 
+@pytest.mark.parametrize("B,S", [(1, 6), (2, 1), (1, 1)])
+def test_depthwise_causal_convolution_masks_singleton_batch_and_sequence(B: int, S: int) -> None:
+    H, kernel_size = 3, 3
+    std = 0.1
+
+    key_x, key_w, key_b = jax.random.split(jax.random.PRNGKey(4), 3)
+
+    x = jax.random.normal(key_x, (B, S, H), dtype=jnp.float32) * std
+    weight = jax.random.normal(key_w, (H, kernel_size), dtype=jnp.float32) * std
+    bias = jax.random.normal(key_b, (H,), dtype=jnp.float32) * std
+
+    # mask out the last position of every batch row; masking must still take effect when the
+    # batch or sequence dimension is a singleton
+    attention_mask = jnp.ones((B, S), dtype=jnp.float32).at[:, -1].set(0.0)
+
+    y, _ = depthwise_causal_convolution(x, weight, bias, attention_mask=attention_mask, implementation="xla")
+
+    assert_allclose(np.asarray(y[:, -1, :]), np.zeros((B, H)), atol=0, rtol=0)
+
+
 def _generate_pallas_args() -> list:
-    return list(
-        product(
+    # A full cross product of every axis (kernel_size x S x has_input_state x add_bias x
+    # output_state x dtype x activation_function) would compile 576 forward+backward Pallas/XLA
+    # pairs, which doesn't fit the TPU CI job's time budget. Shape and state handling is where a
+    # hand-written indexing bug is most likely, so that axis gets the full cross product at fixed
+    # dtype/activation/bias; dtype/activation/bias only need one representative shape.
+    shape_args = [
+        (kernel_size, S, has_input_state, True, output_state, jnp.float32, None)
+        for kernel_size, S, has_input_state, output_state in product(
             [2, 4],  # kernel_size: the pallas_tpu implementation assumes kernel_size > 1
-            # sequence length: shorter than, equal to, or not a multiple of the internal block size.
-            # 1 and 2 also cover S < kernel_size - 1, where ht keeps part of input_state rather than
-            # being filled entirely from input.
+            # sequence length: shorter than, equal to, or not a multiple of the internal block
+            # size. 1 and 2 also cover S < kernel_size - 1, where ht keeps part of input_state
+            # rather than being filled entirely from input.
             [1, 2, 3, 16, 37, 130],
             [False, True],  # has_input_state
-            [False, True],  # add_bias
             [False, True],  # output_state
+        )
+    ]
+    option_args = [
+        (4, 37, True, add_bias, True, dtype, activation_function)
+        for dtype, activation_function, add_bias in product(
             [jnp.float32, jnp.bfloat16],
             [None, "silu", "swish"],
+            [False, True],  # add_bias
         )
-    )
+    ]
+    return shape_args + option_args
 
 
 @pytest.mark.parametrize(

--- a/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
+++ b/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
@@ -1,0 +1,244 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+from __future__ import annotations
+
+from itertools import product
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from levanter.kernels.pallas.depthwise_causal_convolution import depthwise_causal_convolution
+
+
+_TOLERANCE = {"atol": 2e-4, "rtol": 0}
+_PALLAS_TOLERANCE = {jnp.float32: {"atol": 2e-4, "rtol": 0}, jnp.bfloat16: {"atol": 2e-2, "rtol": 0}}
+_PALLAS_GRAD_TOLERANCE = {jnp.float32: {"atol": 1e-2, "rtol": 0}, jnp.bfloat16: {"atol": 5e-2, "rtol": 0}}
+
+
+def _reference_numpy(
+    x: np.ndarray,
+    weight: np.ndarray,
+    bias: np.ndarray | None,
+    input_state: np.ndarray | None,
+    output_state: bool,
+) -> tuple[np.ndarray, np.ndarray | None]:
+    B, S, H = x.shape
+    K = weight.shape[-1]
+
+    xt = np.transpose(x, (0, 2, 1))
+    state = np.zeros((B, H, K - 1), dtype=np.float32) if input_state is None else input_state.astype(np.float32)
+    full = np.concatenate([state, xt.astype(np.float32)], axis=-1)
+
+    y = np.zeros((B, H, S), dtype=np.float32)
+    for j in range(S):
+        window = full[:, :, j : j + K]
+        y[:, :, j] = (window * weight[None, :, :].astype(np.float32)).sum(-1)
+
+    if bias is not None:
+        y = y + bias[None, :, None].astype(np.float32)
+
+    y = np.transpose(y, (0, 2, 1)).astype(x.dtype)
+    final_state = full[:, :, 1 - K :].astype(x.dtype) if output_state else None
+
+    return y, final_state
+
+
+def _generate_args() -> list:
+    return list(
+        product(
+            [2, 4],  # kernel_size; K == 1 is intentionally unsupported
+            [1, 2, 6, 9],  # sequence length: shorter than, equal to, or longer than kernel_size
+            [False, True],  # has_input_state
+            [False, True],  # add_bias
+            [False, True],  # output_state
+        )
+    )
+
+
+@pytest.mark.parametrize("kernel_size,S,has_input_state,add_bias,output_state", _generate_args())
+def test_depthwise_causal_convolution_xla_matches_reference(
+    kernel_size: int, S: int, has_input_state: bool, add_bias: bool, output_state: bool
+) -> None:
+    B, H = 2, 5
+    std = 0.1
+
+    key_x, key_w, key_b, key_h0 = jax.random.split(jax.random.PRNGKey(0), 4)
+
+    x = jax.random.normal(key_x, (B, S, H), dtype=jnp.float32) * std
+    weight = jax.random.normal(key_w, (H, kernel_size), dtype=jnp.float32) * std
+    bias = jax.random.normal(key_b, (H,), dtype=jnp.float32) * std if add_bias else None
+    input_state = (
+        jax.random.normal(key_h0, (B, H, kernel_size - 1), dtype=jnp.float32) * std if has_input_state else None
+    )
+
+    y, final_state = depthwise_causal_convolution(
+        x, weight, bias, input_state, output_state=output_state, implementation="xla"
+    )
+
+    y_ref, final_state_ref = _reference_numpy(
+        np.asarray(x),
+        np.asarray(weight),
+        np.asarray(bias) if bias is not None else None,
+        np.asarray(input_state) if input_state is not None else None,
+        output_state,
+    )
+
+    assert_allclose(np.asarray(y), y_ref, **_TOLERANCE)
+
+    if output_state:
+        assert final_state is not None
+        assert final_state.shape == (B, H, kernel_size - 1)
+        assert_allclose(np.asarray(final_state), final_state_ref, **_TOLERANCE)
+    else:
+        assert final_state is None
+
+
+@pytest.mark.parametrize("kernel_size", [2, 4])
+def test_depthwise_causal_convolution_xla_grad_runs(kernel_size: int) -> None:
+    B, S, H = 2, 6, 5
+    std = 0.1
+
+    key_x, key_w, key_b, key_h0 = jax.random.split(jax.random.PRNGKey(1), 4)
+
+    x = jax.random.normal(key_x, (B, S, H), dtype=jnp.float32) * std
+    weight = jax.random.normal(key_w, (H, kernel_size), dtype=jnp.float32) * std
+    bias = jax.random.normal(key_b, (H,), dtype=jnp.float32) * std
+    input_state = jax.random.normal(key_h0, (B, H, kernel_size - 1), dtype=jnp.float32) * std
+
+    def f(x, weight, bias, input_state):
+        y, _ = depthwise_causal_convolution(x, weight, bias, input_state, output_state=False, implementation="xla")
+
+        return y.sum()
+
+    dx, dweight, dbias, dinput_state = jax.grad(f, argnums=(0, 1, 2, 3))(x, weight, bias, input_state)
+
+    for name, grad, expected_shape in [
+        ("dx", dx, x.shape),
+        ("dweight", dweight, weight.shape),
+        ("dbias", dbias, bias.shape),
+        ("dinput_state", dinput_state, input_state.shape),
+    ]:
+        assert grad.shape == expected_shape, name
+        assert bool(jnp.all(jnp.isfinite(grad))), name
+
+
+def _generate_pallas_args() -> list:
+    return list(
+        product(
+            [2, 4],  # kernel_size: the pallas_tpu implementation assumes kernel_size > 1
+            # sequence length: shorter than, equal to, or not a multiple of the internal block size.
+            # 1 and 2 also cover S < kernel_size - 1, where ht keeps part of input_state rather than
+            # being filled entirely from input.
+            [1, 2, 3, 16, 37, 130],
+            [False, True],  # has_input_state
+            [False, True],  # add_bias
+            [False, True],  # output_state
+            [jnp.float32, jnp.bfloat16],
+            [None, "silu", "swish"],
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "kernel_size,S,has_input_state,add_bias,output_state,dtype,activation_function", _generate_pallas_args()
+)
+def test_depthwise_causal_convolution_pallas_tpu_matches_xla(
+    kernel_size: int,
+    S: int,
+    has_input_state: bool,
+    add_bias: bool,
+    output_state: bool,
+    dtype: jnp.dtype,
+    activation_function: str | None,
+) -> None:
+    if jax.default_backend() != "tpu":
+        pytest.skip("pallas_tpu implementation is only supported on TPU")
+
+    B, H = 2, 5
+    std = 0.1
+    tolerance = _PALLAS_TOLERANCE[dtype]
+    grad_tolerance = _PALLAS_GRAD_TOLERANCE[dtype]
+
+    key_x, key_w, key_b, key_h0, key_dy = jax.random.split(jax.random.PRNGKey(3), 5)
+
+    x = (jax.random.normal(key_x, (B, S, H), dtype=jnp.float32) * std).astype(dtype)
+    weight = (jax.random.normal(key_w, (H, kernel_size), dtype=jnp.float32) * std).astype(dtype)
+    bias = (jax.random.normal(key_b, (H,), dtype=jnp.float32) * std).astype(dtype) if add_bias else None
+    input_state = (
+        (jax.random.normal(key_h0, (B, H, kernel_size - 1), dtype=jnp.float32) * std).astype(dtype)
+        if has_input_state
+        else None
+    )
+
+    def _run(implementation: str, x: jax.Array, weight: jax.Array, bias, input_state):
+        return depthwise_causal_convolution(
+            x,
+            weight,
+            bias,
+            input_state,
+            output_state=output_state,
+            activation_function=activation_function,
+            implementation=implementation,
+        )
+
+    def _run_vjp(implementation: str, x: jax.Array, weight: jax.Array, bias, input_state):
+        return jax.vjp(
+            lambda x, weight, bias, input_state: _run(implementation, x, weight, bias, input_state),
+            x,
+            weight,
+            bias,
+            input_state,
+        )
+
+    (y_kernel, ht_kernel), vjp_kernel = _run_vjp("pallas_tpu", x, weight, bias, input_state)
+    (y_expected, ht_expected), vjp_expected = _run_vjp("xla", x, weight, bias, input_state)
+
+    assert_allclose(np.asarray(y_kernel, dtype=np.float32), np.asarray(y_expected, dtype=np.float32), **tolerance)
+
+    if output_state:
+        assert ht_kernel is not None
+        assert ht_expected is not None
+        assert ht_kernel.shape == (B, H, kernel_size - 1)
+        assert_allclose(
+            np.asarray(ht_kernel, dtype=np.float32), np.asarray(ht_expected, dtype=np.float32), **tolerance
+        )
+    else:
+        assert ht_kernel is None
+        assert ht_expected is None
+
+    dy = (jax.random.normal(key_dy, y_kernel.shape, dtype=jnp.float32) * std).astype(dtype)
+    dht = (jax.random.normal(key_dy, ht_kernel.shape, dtype=jnp.float32) * std).astype(dtype) if output_state else None
+
+    dx_kernel, dweight_kernel, dbias_kernel, dinput_state_kernel = vjp_kernel((dy, dht))
+    dx_expected, dweight_expected, dbias_expected, dinput_state_expected = vjp_expected((dy, dht))
+
+    assert_allclose(
+        np.asarray(dx_kernel, dtype=np.float32), np.asarray(dx_expected, dtype=np.float32), **grad_tolerance
+    )
+    assert_allclose(
+        np.asarray(dweight_kernel, dtype=np.float32), np.asarray(dweight_expected, dtype=np.float32), **grad_tolerance
+    )
+
+    if add_bias:
+        assert_allclose(
+            np.asarray(dbias_kernel, dtype=np.float32), np.asarray(dbias_expected, dtype=np.float32), **grad_tolerance
+        )
+    else:
+        assert dbias_kernel is None
+        assert dbias_expected is None
+
+    if has_input_state:
+        assert_allclose(
+            np.asarray(dinput_state_kernel, dtype=np.float32),
+            np.asarray(dinput_state_expected, dtype=np.float32),
+            **grad_tolerance,
+        )
+    else:
+        assert dinput_state_kernel is None
+        assert dinput_state_expected is None

--- a/lib/levanter/tests/test_depthwise_causal_convolution_layer.py
+++ b/lib/levanter/tests/test_depthwise_causal_convolution_layer.py
@@ -1,0 +1,97 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import haliax as hax
+from haliax import Axis
+
+from levanter.kernels.pallas.depthwise_causal_convolution import depthwise_causal_convolution
+from levanter.layers.depthwise_causal_convolution import DepthwiseCausalConvolution
+
+
+Batch = Axis("batch", 2)
+Pos = Axis("position", 6)
+Embed = Axis("embed", 5)
+
+
+@pytest.mark.parametrize("use_bias", [False, True])
+@pytest.mark.parametrize("output_state", [False, True])
+def test_depthwise_causal_convolution_layer_matches_raw_op(use_bias: bool, output_state: bool) -> None:
+    kernel_size = 4
+    key_init, key_x, key_h0 = jax.random.split(jax.random.PRNGKey(0), 3)
+
+    layer = DepthwiseCausalConvolution.init(
+        Embed, kernel_size=kernel_size, activation_function=None, use_bias=use_bias, key=key_init
+    )
+
+    x = hax.random.normal(key_x, (Batch, Pos, Embed))
+    input_state = hax.random.normal(key_h0, (Batch, Embed, layer.State))
+
+    output, output_state_named = layer(x, input_state=input_state, output_state=output_state)
+
+    assert output.axes == (Batch, Pos, Embed)
+
+    output_ref, output_state_ref = depthwise_causal_convolution(
+        input=hax.rearrange(x, (Batch, Pos, Embed)).array,
+        weight=layer.weight.array,
+        bias=None if layer.bias is None else layer.bias.array,
+        input_state=hax.rearrange(input_state, (Batch, Embed, layer.State)).array,
+        output_state=output_state,
+        activation_function=None,
+    )
+
+    assert_allclose(np.asarray(hax.rearrange(output, (Batch, Pos, Embed)).array), np.asarray(output_ref))
+
+    if output_state:
+        assert output_state_named is not None
+        assert output_state_named.axes == (Batch, Embed, layer.State)
+        assert_allclose(
+            np.asarray(hax.rearrange(output_state_named, (Batch, Embed, layer.State)).array),
+            np.asarray(output_state_ref),
+        )
+    else:
+        assert output_state_named is None
+
+
+def test_depthwise_causal_convolution_layer_without_input_state() -> None:
+    kernel_size = 3
+    key_init, key_x = jax.random.split(jax.random.PRNGKey(1), 2)
+
+    layer = DepthwiseCausalConvolution.init(
+        Embed, kernel_size=kernel_size, activation_function="silu", use_bias=True, key=key_init
+    )
+
+    x = hax.random.normal(key_x, (Batch, Pos, Embed))
+    output, output_state = layer(x, output_state=True)
+
+    assert output.axes == (Batch, Pos, Embed)
+    assert output_state is not None
+    assert output_state.axes == (Batch, Embed, layer.State)
+
+
+def test_depthwise_causal_convolution_layer_grad_runs() -> None:
+    kernel_size = 3
+    key_init, key_x = jax.random.split(jax.random.PRNGKey(2), 2)
+
+    layer = DepthwiseCausalConvolution.init(
+        Embed, kernel_size=kernel_size, activation_function=None, use_bias=True, key=key_init
+    )
+    x = hax.random.normal(key_x, (Batch, Pos, Embed))
+
+    def loss(layer, x):
+        output, _ = layer(x)
+        return hax.sum(output).scalar()
+
+    grad_layer, grad_x = jax.grad(loss, argnums=(0, 1))(layer, x)
+
+    assert jnp.all(jnp.isfinite(grad_layer.weight.array))
+    assert jnp.all(jnp.isfinite(grad_x.array))

--- a/lib/levanter/tests/test_depthwise_causal_convolution_layer.py
+++ b/lib/levanter/tests/test_depthwise_causal_convolution_layer.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures


### PR DESCRIPTION
Add a depthwise causal 1D convolution op for Levanter: a hand-written Pallas
TPU kernel (forward and backward), an XLA reference implementation, and a
`DepthwiseCausalConvolution` Haliax layer wrapping both behind one
`implementation` switch that defaults to Pallas on TPU and XLA elsewhere.

The Pallas kernel stays on the VPU and skips the MXU entirely, since a
`kernel_size` this small underutilizes the systolic array badly. It supports
carrying/returning cross-call convolution state (`input_state`/`output_state`)
for streaming/chunked decoding, an optional fused SiLU activation, and an
attention mask that zeroes padding before and after the convolution.

Ported from open-lm-engine/accelerated-model-architectures. XLA-reference
parity is covered by parameterized tests across kernel size, sequence length,
and the state/bias/activation/mask options; the Pallas TPU path runs in the
dedicated TPU CI suite.
