### PR TITLE
[draft] [levanter] Open sharded cache shards without blocking the read loop

### DIFF
--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -157,8 +157,10 @@ class TreeCache(AsyncDataset[T_co]):
         self.ledger = ledger
         self._exemplar = exemplar
         self._shard_stores: Dict[str, TreeStore[T_co]] = {}
+        self._pending_shard_stores: Dict[str, "asyncio.Future[TreeStore[T_co]]"] = {}
         self._shard_row_offsets: Optional[np.ndarray] = None
         self._shard_field_stores: Dict[Tuple[str, str], Any] = {}
+        self._pending_shard_field_stores: Dict[Tuple[str, str], "asyncio.Future[Any]"] = {}
         self._shard_field_offsets: Dict[str, np.ndarray] = {}
         self._flat_field_offsets: Dict[str, np.ndarray] = {}
         self._flat_field_offset_futures: Dict[str, concurrent.futures.Future[np.ndarray]] = {}
@@ -328,24 +330,52 @@ class TreeCache(AsyncDataset[T_co]):
             self._shard_stores[shard_name] = store
         return store
 
-    def _shard_field_store(self, shard_name: str, field: str):
-        key = (shard_name, field)
-        store = self._shard_field_stores.get(key)
-        if store is None:
-            tree_store = TreeStore.open(
-                _field_exemplar(self._exemplar, field),
-                self._layout.shard(shard_name),
-                mode="r",
-                cache_metadata=True,
+    async def _shard_store_async(self, shard_name: str) -> TreeStore[T_co]:
+        """Open a shard store, sharing one open between concurrent first touches."""
+        store = self._shard_stores.get(shard_name)
+        if store is not None:
+            return store
+
+        loop = asyncio.get_running_loop()
+        pending = self._pending_shard_stores.get(shard_name)
+        if pending is None or pending.get_loop() is not loop:
+            pending = loop.create_task(self._open_shard_store(shard_name))
+            self._pending_shard_stores[shard_name] = pending
+        return await asyncio.shield(pending)
+
+    async def _open_shard_store(self, shard_name: str) -> TreeStore[T_co]:
+        try:
+            store = await TreeStore.open_async(
+                self._exemplar, self._layout.shard(shard_name), mode="r", cache_metadata=True
             )
-            store = _tree_field(tree_store.tree, field)
-            self._shard_field_stores[key] = store
-        return store
+            self._shard_stores[shard_name] = store
+            return store
+        finally:
+            self._pending_shard_stores.pop(shard_name, None)
 
     async def _shard_field_store_async(self, shard_name: str, field: str):
+        """Open a shard's field store, sharing one open between concurrent first touches.
+
+        Readers fan out over many shards at once, so an unshared open would issue the same
+        metadata request once per concurrent reader that misses the cache.
+        """
         key = (shard_name, field)
         store = self._shard_field_stores.get(key)
-        if store is None:
+        if store is not None:
+            return store
+
+        loop = asyncio.get_running_loop()
+        pending = self._pending_shard_field_stores.get(key)
+        # Futures belong to the loop that created them, and a TreeCache outlives the
+        # per-iterator loops that read it, so a foreign-loop future is not awaitable here.
+        if pending is None or pending.get_loop() is not loop:
+            pending = loop.create_task(self._open_shard_field_store(shard_name, field))
+            self._pending_shard_field_stores[key] = pending
+        return await asyncio.shield(pending)
+
+    async def _open_shard_field_store(self, shard_name: str, field: str):
+        key = (shard_name, field)
+        try:
             tree_store = await TreeStore.open_async(
                 _field_exemplar(self._exemplar, field),
                 self._layout.shard(shard_name),
@@ -354,7 +384,9 @@ class TreeCache(AsyncDataset[T_co]):
             )
             store = _tree_field(tree_store.tree, field)
             self._shard_field_stores[key] = store
-        return store
+            return store
+        finally:
+            self._pending_shard_field_stores.pop(key, None)
 
     async def _get_sharded_batch(self, indices: Sequence[int]) -> List[T_co]:
         if len(indices) == 0:
@@ -375,7 +407,8 @@ class TreeCache(AsyncDataset[T_co]):
 
         async def read_shard(shard_index: int, batch: List[Tuple[int, int]]) -> None:
             local_indices = [local_index for _, local_index in batch]
-            shard_batch = await self._shard_store(shard_names[shard_index]).get_batch(local_indices)
+            store = await self._shard_store_async(shard_names[shard_index])
+            shard_batch = await store.get_batch(local_indices)
             for (output_index, _), row in zip(batch, shard_batch, strict=True):
                 output[output_index] = row
 
@@ -421,7 +454,7 @@ class TreeCache(AsyncDataset[T_co]):
         shard_names, shard_offsets = self._ensure_shard_field_offsets(field)
         remaining = length
         position = offset
-        reads = []
+        slices = []
 
         while remaining > 0:
             shard_index = int(np.searchsorted(shard_offsets, position, side="right"))
@@ -432,12 +465,15 @@ class TreeCache(AsyncDataset[T_co]):
             local_start = position - shard_start
             available = int(shard_offsets[shard_index] - position)
             take = min(remaining, available)
-            field_store = self._shard_field_store(shard_names[shard_index], field)
-            reads.append(field_store.data[local_start : local_start + take].read())
+            slices.append((shard_names[shard_index], local_start, take))
             position += take
             remaining -= take
 
-        chunks = await asyncio.gather(*reads)
+        async def read_slice(shard_name: str, local_start: int, take: int) -> np.ndarray:
+            field_store = await self._shard_field_store_async(shard_name, field)
+            return await field_store.data[local_start : local_start + take].read()
+
+        chunks = await asyncio.gather(*[read_slice(*s) for s in slices])
         if len(chunks) == 1:
             return chunks[0]
         return np.concatenate(chunks)

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -340,6 +340,7 @@ class TreeCache(AsyncDataset[T_co]):
         pending = self._pending_shard_stores.get(shard_name)
         if pending is None or pending.get_loop() is not loop:
             pending = loop.create_task(self._open_shard_store(shard_name))
+            pending.add_done_callback(_retrieve_task_exception)
             self._pending_shard_stores[shard_name] = pending
         return await asyncio.shield(pending)
 
@@ -351,7 +352,7 @@ class TreeCache(AsyncDataset[T_co]):
             self._shard_stores[shard_name] = store
             return store
         finally:
-            self._pending_shard_stores.pop(shard_name, None)
+            self._discard_pending(self._pending_shard_stores, shard_name)
 
     async def _shard_field_store_async(self, shard_name: str, field: str):
         """Open a shard's field store, sharing one open between concurrent first touches.
@@ -370,6 +371,7 @@ class TreeCache(AsyncDataset[T_co]):
         # per-iterator loops that read it, so a foreign-loop future is not awaitable here.
         if pending is None or pending.get_loop() is not loop:
             pending = loop.create_task(self._open_shard_field_store(shard_name, field))
+            pending.add_done_callback(_retrieve_task_exception)
             self._pending_shard_field_stores[key] = pending
         return await asyncio.shield(pending)
 
@@ -386,7 +388,18 @@ class TreeCache(AsyncDataset[T_co]):
             self._shard_field_stores[key] = store
             return store
         finally:
-            self._pending_shard_field_stores.pop(key, None)
+            self._discard_pending(self._pending_shard_field_stores, key)
+
+    @staticmethod
+    def _discard_pending(pending_opens: Dict[Any, "asyncio.Future"], key) -> None:
+        """Drop ``key`` only if it still maps to the calling task.
+
+        A reader on a second event loop replaces the entry with its own task, so an
+        unconditional discard would evict a live open and cost the readers behind it a
+        duplicate. Clearing on failure is what lets the next reader retry the open.
+        """
+        if pending_opens.get(key) is asyncio.current_task():
+            del pending_opens[key]
 
     async def _get_sharded_batch(self, indices: Sequence[int]) -> List[T_co]:
         if len(indices) == 0:
@@ -727,6 +740,16 @@ def _validate_sharded_ledger(ledger: CacheLedger) -> None:
             "Sharded cache ledger field count mismatch: "
             f"sum(finished shard field counts)={field_counts}, field_counts={ledger.field_counts}"
         )
+
+
+def _retrieve_task_exception(task: "asyncio.Task") -> None:
+    """Consume a shared open's exception so a fully cancelled wait set does not lose it.
+
+    Readers await the shared open through ``asyncio.shield``, so cancelling all of them
+    leaves the task itself running with nobody to retrieve its result.
+    """
+    if not task.cancelled() and task.exception() is not None:
+        logger.debug("Shared shard open failed; the next reader will retry it.", exc_info=task.exception())
 
 
 def _tree_field(tree, field: str):

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -639,12 +639,9 @@ async def test_sharded_flat_field_batch_opens_shards_concurrently(tmp_path, monk
     assert tracker.max_active == num_shards
 
 
-@pytest.mark.asyncio
-async def test_sharded_shard_open_is_shared_between_concurrent_readers(tmp_path, monkeypatch):
-    """Concurrent first touches of one shard must issue a single open, not one per reader."""
-    cache = _build_sharded_cache(tmp_path, num_shards=1, rows_per_shard=8, seq_len=16)
-
-    opens = []
+def _count_opens(monkeypatch) -> list[str]:
+    """Record the path of every async shard open, yielding once so concurrent readers race."""
+    opens: list[str] = []
     real_open_async = TreeStore.open_async
 
     async def counted_open_async(exemplar, path, **kwargs):
@@ -653,8 +650,57 @@ async def test_sharded_shard_open_is_shared_between_concurrent_readers(tmp_path,
         return await real_open_async(exemplar, path, **kwargs)
 
     monkeypatch.setattr(TreeStore, "open_async", staticmethod(counted_open_async))
+    return opens
+
+
+@pytest.mark.asyncio
+async def test_sharded_field_open_is_shared_between_concurrent_readers(tmp_path, monkeypatch):
+    """Concurrent first touches of one shard must issue a single open, not one per reader."""
+    cache = _build_sharded_cache(tmp_path, num_shards=1, rows_per_shard=8, seq_len=16)
+    opens = _count_opens(monkeypatch)
 
     results = await asyncio.gather(*[cache.get_flat_field_batch("input_ids", [row * 16], 16) for row in range(8)])
 
     assert len(results) == 8
     assert opens == [str(Path(cache.cache_dir) / "shard_0")]
+
+
+@pytest.mark.asyncio
+async def test_sharded_row_batch_shares_and_overlaps_shard_opens(tmp_path, monkeypatch):
+    """`get_batch` reaches shard stores by a separate path than `get_flat_field_batch`."""
+    num_shards, rows_per_shard, seq_len = 4, 4, 16
+    cache = _build_sharded_cache(tmp_path, num_shards, rows_per_shard, seq_len)
+    opens = _count_opens(monkeypatch)
+
+    rows = await cache.get_batch(list(range(num_shards * rows_per_shard)))
+
+    assert len(rows) == num_shards * rows_per_shard
+    for row in rows:
+        np.testing.assert_array_equal(row["input_ids"], np.arange(seq_len, dtype=np.int32))
+    # one open per shard, even though every shard serves several of the requested rows
+    assert sorted(opens) == sorted(str(Path(cache.cache_dir) / f"shard_{i}") for i in range(num_shards))
+
+
+@pytest.mark.asyncio
+async def test_failed_shard_open_is_retried_by_the_next_reader(tmp_path, monkeypatch):
+    """A shared open that fails must not poison the shard for every later reader."""
+    cache = _build_sharded_cache(tmp_path, num_shards=1, rows_per_shard=4, seq_len=16)
+
+    real_open_async = TreeStore.open_async
+    attempts = []
+
+    async def flaky_open_async(exemplar, path, **kwargs):
+        attempts.append(path)
+        await asyncio.sleep(0)
+        if len(attempts) == 1:
+            raise TimeoutError("simulated stalled open")
+        return await real_open_async(exemplar, path, **kwargs)
+
+    monkeypatch.setattr(TreeStore, "open_async", staticmethod(flaky_open_async))
+
+    with pytest.raises(TimeoutError):
+        await cache.get_flat_field_batch("input_ids", [0], 16)
+
+    batch = await cache.get_flat_field_batch("input_ids", [0], 16)
+    np.testing.assert_array_equal(batch[0], np.arange(16, dtype=np.int32))
+    assert len(attempts) == 2

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -14,9 +14,11 @@ from levanter.data._preprocessor import BatchProcessor
 from levanter.data.sharded_datasource import ShardedDataSource
 from levanter.data.utils import batched
 from levanter.data.sharded_datasource import TextUrlDataSource
+from levanter.store import jagged_array
 from levanter.store.cache import (
     CACHE_LAYOUT_SHARDED,
     CacheLedger,
+    consolidate_shard_cache_ledgers,
     SerialCacheWriter,
     ShardedCacheLayout,
     TreeCache,
@@ -572,3 +574,87 @@ def test_write_levanter_cache_end_to_end():
         assert len(store) == len(records)
         assert store[0]["input_ids"].tolist() == records[0]["input_ids"]
         assert store[len(records) - 1]["input_ids"].tolist() == records[len(records) - 1]["input_ids"]
+
+
+def _build_sharded_cache(root: Path, num_shards: int, rows_per_shard: int, seq_len: int) -> TreeCache:
+    """Write ``num_shards`` shard caches under ``root`` and consolidate them into one sharded cache."""
+    exemplar = {"input_ids": np.array([0], dtype=np.int32)}
+    shard_paths = []
+    for shard in range(num_shards):
+        shard_path = str(root / f"shard_{shard}")
+        with SerialCacheWriter(shard_path, exemplar) as writer:
+            writer.write_batch([{"input_ids": np.arange(seq_len, dtype=np.int32)} for _ in range(rows_per_shard)])
+        shard_paths.append(shard_path)
+
+    consolidate_shard_cache_ledgers(shard_paths, str(root), exemplar)
+    return TreeCache.load(str(root), exemplar)
+
+
+class _OpenTracker:
+    """Counts tensorstore opens and the high-water mark of concurrent ones."""
+
+    def __init__(self):
+        self.total = 0
+        self.active = 0
+        self.max_active = 0
+
+    def wrap(self, monkeypatch):
+        real = jagged_array._ts_open_async
+
+        async def tracked(*args, **kwargs):
+            self.total += 1
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+            try:
+                # yield twice so a serialized caller cannot overlap by luck of scheduling
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                return await real(*args, **kwargs)
+            finally:
+                self.active -= 1
+
+        monkeypatch.setattr(jagged_array, "_ts_open_async", tracked)
+
+
+@pytest.mark.asyncio
+async def test_sharded_flat_field_batch_opens_shards_concurrently(tmp_path, monkeypatch):
+    """Regression for #7474.
+
+    A cold read spanning many shards must open them concurrently. Opening them from the
+    synchronous helper blocked the event loop, so one fetch window paid the shard-open
+    latency once per shard in series.
+    """
+    num_shards, rows_per_shard, seq_len = 8, 4, 16
+    cache = _build_sharded_cache(tmp_path, num_shards, rows_per_shard, seq_len)
+
+    tracker = _OpenTracker()
+    tracker.wrap(monkeypatch)
+
+    offsets = [row * seq_len for row in range(num_shards * rows_per_shard)]
+    batch = await cache.get_flat_field_batch("input_ids", offsets, seq_len)
+
+    assert len(batch) == len(offsets)
+    for row in batch:
+        np.testing.assert_array_equal(row, np.arange(seq_len, dtype=np.int32))
+    assert tracker.max_active == num_shards
+
+
+@pytest.mark.asyncio
+async def test_sharded_shard_open_is_shared_between_concurrent_readers(tmp_path, monkeypatch):
+    """Concurrent first touches of one shard must issue a single open, not one per reader."""
+    cache = _build_sharded_cache(tmp_path, num_shards=1, rows_per_shard=8, seq_len=16)
+
+    opens = []
+    real_open_async = TreeStore.open_async
+
+    async def counted_open_async(exemplar, path, **kwargs):
+        opens.append(path)
+        await asyncio.sleep(0)
+        return await real_open_async(exemplar, path, **kwargs)
+
+    monkeypatch.setattr(TreeStore, "open_async", staticmethod(counted_open_async))
+
+    results = await asyncio.gather(*[cache.get_flat_field_batch("input_ids", [row * 16], 16) for row in range(8)])
+
+    assert len(results) == 8
+    assert opens == [str(Path(cache.cache_dir) / "shard_0")]


### PR DESCRIPTION
The sharded cache reader resolved each shard's tensorstore through the synchronous `TreeStore.open`, which calls `ts.open(...).result()`. Those opens run inside the data loader's asyncio producer loop, so a cold read spanning N shards paid the open latency N times in series instead of overlapping them. `TreeStore.open_async` and `_shard_field_store_async` already existed and were used only by the offset prefetch, not by the read path.

This routes the two async read paths through the async open, and shares one in-flight open between concurrent first touches of the same shard so the fan-out does not multiply the metadata requests it saves by overlapping. The synchronous `_get_sharded_batch_sync` path keeps the blocking open. The now-unused synchronous `_shard_field_store` is deleted. A shared open is discarded only when the pending entry still maps to the completing task, so a reader on a second event loop cannot evict another loop's live open, and a failed open's exception is retrieved so the next reader retries against a clear slot.

The gain scales with per-open latency, so quote both ends of it. On a local sharded cache of 32 shards with a 20 ms per-open delay standing in for a metadata round trip, one cold `get_flat_field_batch` spanning every shard took 1.33 s before and 0.06 s after, against 1.28 s for fully serial opens and 0.02 s for fully overlapped ones. With no injected delay at all on local disk, where an open costs microseconds, 64 shards took 29.7 ms before and 24.4 ms after, which is close to noise. Warm reads are unchanged. Real per-open latency against a datakit store on CoreWeave has not been measured, so the production gain is bounded by that number and is not established here. Both new tests fail against unpatched `cache.py`.

Motivation is #7474. Affected runs pay a large cost at consecutive `prefetch_size` window boundaries that decays monotonically and then stops: `rav-ladder-d768-v2` spikes at 55 of its first 58 boundaries, averaging 81.3 s falling to 7.7 s, then logs 9564 steps with a 0.357 s maximum. Three other datakit runs follow the same arc, and `ii2r-l1-20260807-165117` on the single-component consolidated slimpajama store logs no spike across 20000 steps. A decaying first-touch cost is what lazily opened per-shard tensorstores produce, and the shard open is the only per-shard network first touch on this path, since `_ensure_shard_field_offsets` resolves from the ledger without I/O.

That correspondence is why this is worth landing, not a demonstration that it accounts for the warm-up. Tensorstore's own cache pool amortizes on the same curve, and nothing here has run against a real store. Two other candidates are untouched: the sharded reader omits the `ts.Batch()` scope its consolidated counterpart uses, which measured about 8% fewer kvstore reads on this geometry, and a per-sequence read pulls a 262,144-element inner chunk to return 4,096 tokens. The change also converts a serialized trickle of metadata requests into a concurrent burst, which is neutral at best if the real constraint is store-side rate rather than latency.

Out of scope: runs on 2026-08-18 show MFU dipping at every prefetch boundary while `loading_time` is zero, which is a second cost at the same period that this change does not address.

Keeping this in draft until it runs against a real store.
