### PR TITLE
[infra] Stop shadowing GitHub alert webhook

### DIFF
--- a/infra/pulumi/github/Pulumi.marin-community.yaml
+++ b/infra/pulumi/github/Pulumi.marin-community.yaml
@@ -66,7 +66,7 @@ config:
       source_kind: gcp-secret
       source_ref: gcp-secret://projects/hai-gcp-models/secrets/marin-grafana-slack-webhook/versions/1
       disposition: keep
-      note: Routes GitHub Actions alerts to #marin-alerts; shadowed in marin by the repository secret of the same name.
+      note: Routes GitHub Actions alerts, including marin workflows, to #marin-alerts.
     - name: CW_KUBECONFIG
       scope: repository
       repository: marin-community/marin
@@ -260,14 +260,6 @@ config:
       source_kind: gcp-secret
       source_ref: gcp-secret://projects/hai-gcp-models/secrets/RAY_AUTH_TOKEN/versions/1
       disposition: remove-candidate
-    - name: SLACK_WEBHOOK_URL
-      scope: repository
-      repository: marin-community/marin
-      presence: present
-      source_kind: gcp-secret
-      source_ref: gcp-secret://projects/hai-gcp-models/secrets/marin-grafana-slack-webhook/versions/1
-      disposition: keep
-      note: Routes GitHub Actions alerts to #marin-alerts and overrides the organization secret of the same name.
     - name: SPEEDRUN_LEADERBOARD_PAT
       scope: repository
       repository: marin-community/marin

--- a/infra/pulumi/github/README.md
+++ b/infra/pulumi/github/README.md
@@ -25,6 +25,9 @@ To add a secret, create or rotate it through an approved external path, then add
 declaration. Record a pinned Secret Manager version when one exists; it is recovery metadata and is
 never dereferenced by this program.
 
+GitHub resolves a repository secret before an organization secret with the same name. Keep each
+secret name at one scope unless a repository override has a separate owner and rotation path.
+
 To remove a secret, first confirm it is an unreferenced `remove-candidate` with the live audit. Delete
 it externally, then remove its declaration. For example:
 

--- a/infra/pulumi/tests/test_github_credentials.py
+++ b/infra/pulumi/tests/test_github_credentials.py
@@ -63,10 +63,7 @@ def test_committed_stack_covers_workflow_references_and_isolates_removal_candida
         "repository:marin-community/marin:COREWEAVE_API_TOKEN",
         "repository:marin-community/marin:OPENAI_ADMIN_KEY",
     }
-    assert set(report.shadowed) == {
-        "organization:GCP_PROJECT_ID",
-        "organization:SLACK_WEBHOOK_URL",
-    }
+    assert set(report.shadowed) == {"organization:GCP_PROJECT_ID"}
 
 
 def test_committed_stack_models_every_present_external_secret_as_a_read_only_resource() -> None:


### PR DESCRIPTION
Let Marin workflows resolve the organization-wide `SLACK_WEBHOOK_URL`. The
repository copy takes precedence and continued sending failure notifications to
`#marin-eng` as `loombot` after the organization credential moved to
`#marin-alerts`.

Keep the webhook at organization scope, backed by version 1 of
`marin-grafana-slack-webhook`. GitHub secrets are externally owned by this
Pulumi project, so an administrator must delete the live repository secret when
this lands; the organization secret then becomes effective.
