### PR TITLE
Migrate Loom host to C4D Hyperdisk

### DIFF
--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -11,8 +11,11 @@ config:
   marin-loom:vmProjectRoles: []
   marin-loom:vmPulumiKmsKeys:
     - projects/hai-gcp-models/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key
-  marin-loom:machineType: e2-highmem-4
+  marin-loom:machineType: c4d-highmem-4
+  marin-loom:bootDiskName: loom-hyperdisk
+  marin-loom:bootDiskType: hyperdisk-balanced
   marin-loom:bootDiskGb: "1000"
+  marin-loom:bootDiskSnapshot: loom-pre-c4d-hyperdisk-20260816
   marin-loom:dotenvSecretVersion: "4"
   marin-loom:pruneDeployment: "true"
   marin-loom:snapshotRetentionDays: "14"

--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -15,10 +15,11 @@ config:
   marin-loom:bootDiskName: loom-hyperdisk
   marin-loom:bootDiskType: hyperdisk-balanced
   marin-loom:bootDiskGb: "1000"
+  marin-loom:bootDiskIops: "3000"
+  marin-loom:bootDiskThroughput: "140"
   marin-loom:bootDiskSnapshot: loom-pre-c4d-hyperdisk-20260816
   marin-loom:dotenvSecretVersion: "4"
   marin-loom:pruneDeployment: "true"
-  marin-loom:snapshotRetentionDays: "14"
   marin-loom:settings:
     github.profile: github
     slack.effort: agent-default

--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -2,11 +2,11 @@
 
 The `marin-loom` Pulumi stack manages `loom.oa.dev`: its GCE host with a
 retained Hyperdisk root disk, Artifact Registry repository, Secret Manager
-access, Cloudflare DNS, and scheduled root-disk snapshots. The production host
-is an on-demand C4D VM with an AMD Turin CPU. It uses NVMe for its boot disk and
-gVNIC for networking, as required by the machine family. The runtime is built
-from the operator's local Loom worktree and runs as a Docker Compose application
-on the GCE host.
+access, and Cloudflare DNS. The production host is an on-demand C4D VM with an
+AMD Turin CPU. It uses NVMe for its boot disk and gVNIC for networking, as
+required by the machine family. Hyperdisk performance is pinned to the included
+3,000 IOPS and 140 MB/s baseline. The runtime is built from the operator's local
+Loom worktree and runs as a Docker Compose application on the GCE host.
 
 ## Prerequisites
 
@@ -173,6 +173,6 @@ sessions are live because it removes their shared network.
 To roll back an application release, check out the prior Loom tree, restore its
 numbered `dotenvSecretVersion` when necessary, and run the normal preview and
 update. The separately managed root disk is protected, retained if removed from
-Pulumi, not auto-deleted with the VM, and covered by scheduled snapshots. A
-replacement root disk must use an explicit `bootDiskSnapshot`; keep that source
-snapshot until a newer rollback point has been verified.
+Pulumi, and not auto-deleted with the VM. A replacement root disk must use an
+explicit `bootDiskSnapshot`; keep that source snapshot until a newer rollback
+point has been verified.

--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -1,10 +1,12 @@
 # Loom production deployment
 
 The `marin-loom` Pulumi stack manages `loom.oa.dev`: its GCE host with a
-persistent root disk, Artifact Registry repository, Secret Manager access,
-Cloudflare DNS, and scheduled root-disk snapshots. The runtime is built from
-the operator's local Loom worktree and runs as a Docker Compose application on
-the GCE host.
+retained Hyperdisk root disk, Artifact Registry repository, Secret Manager
+access, Cloudflare DNS, and scheduled root-disk snapshots. The production host
+is an on-demand C4D VM with an AMD Turin CPU. It uses NVMe for its boot disk and
+gVNIC for networking, as required by the machine family. The runtime is built
+from the operator's local Loom worktree and runs as a Docker Compose application
+on the GCE host.
 
 ## Prerequisites
 
@@ -168,7 +170,9 @@ Recreating the control-plane service preserves those containers, and the new
 control plane discovers and adopts them. Do not run `docker compose down` while
 sessions are live because it removes their shared network.
 
-To roll back, check out the prior Loom tree, restore its numbered
-`dotenvSecretVersion` when necessary, and run the normal preview and update.
-The separately managed persistent root disk is protected, is not auto-deleted
-with the VM, and has scheduled snapshots.
+To roll back an application release, check out the prior Loom tree, restore its
+numbered `dotenvSecretVersion` when necessary, and run the normal preview and
+update. The separately managed root disk is protected, retained if removed from
+Pulumi, not auto-deleted with the VM, and covered by scheduled snapshots. A
+replacement root disk must use an explicit `bootDiskSnapshot`; keep that source
+snapshot until a newer rollback point has been verified.

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -22,7 +22,6 @@ import pulumi_github as github
 from iac.gcp.firewall import FirewallPort, GcpFirewallRuleArgs, create_firewall_rule
 
 ROOT = Path(__file__).resolve().parent
-DEFAULT_DISK_TYPE = "pd-balanced"
 REPOSITORY_OWNER = "marin-community"
 REPOSITORY_NAME = "loom"
 REPOSITORY_BRANCH = "main"
@@ -387,7 +386,10 @@ class DeploymentConfig:
     instance_name: str
     vm_service_account_name: str
     machine_type: str
+    boot_disk_name: str
+    boot_disk_type: str
     boot_disk_gb: int
+    boot_disk_snapshot: str
     dotenv_secret_version: int
     snapshot_retention_days: int
     prune_deployment: bool = False
@@ -486,7 +488,10 @@ class DeploymentConfig:
             instance_name=config.require("instanceName"),
             vm_service_account_name=config.require("vmServiceAccountName"),
             machine_type=config.require("machineType"),
+            boot_disk_name=config.require("bootDiskName"),
+            boot_disk_type=config.require("bootDiskType"),
             boot_disk_gb=config.require_int("bootDiskGb"),
+            boot_disk_snapshot=config.require("bootDiskSnapshot"),
             dotenv_secret_version=config.require_int("dotenvSecretVersion"),
             prune_deployment=config.get_bool("pruneDeployment") or False,
             settings=tuple(settings),
@@ -602,14 +607,14 @@ def _create_network(config: DeploymentConfig, apis: list[gcp.projects.Service]) 
 
 def _create_root_disk(config: DeploymentConfig, apis: list[gcp.projects.Service]) -> gcp.compute.Disk:
     return gcp.compute.Disk(
-        "loom-root",
+        "loom-primary-root",
         project=config.project,
         zone=config.zone,
-        name=config.instance_name,
-        image="debian-cloud/debian-12",
-        type=DEFAULT_DISK_TYPE,
+        name=config.boot_disk_name,
+        snapshot=config.boot_disk_snapshot,
+        type=config.boot_disk_type,
         size=config.boot_disk_gb,
-        opts=pulumi.ResourceOptions(depends_on=apis, protect=True, ignore_changes=["image"]),
+        opts=pulumi.ResourceOptions(depends_on=apis, protect=True, retain_on_delete=True),
     )
 
 
@@ -886,11 +891,13 @@ def _create_instance(
         tags=[WEB_FIREWALL_TAG, SSH_FIREWALL_TAG],
         boot_disk={
             "auto_delete": False,
+            "interface": "NVME",
             "source": root_disk.id,
         },
         network_interfaces=[
             {
                 "network": config.network,
+                "nic_type": "GVNIC",
                 "access_configs": [{"nat_ip": network.address.address}],
             }
         ],
@@ -899,10 +906,18 @@ def _create_instance(
             "email": vm_account.email,
             "scopes": ["cloud-platform"],
         },
+        reservation_affinity={"type": "NO_RESERVATION"},
+        scheduling={
+            "automatic_restart": True,
+            "on_host_maintenance": "MIGRATE",
+            "preemptible": False,
+            "provisioning_model": "STANDARD",
+        },
         allow_stopping_for_update=False,
         deletion_protection=True,
         opts=pulumi.ResourceOptions(
             depends_on=dependencies,
+            delete_before_replace=True,
             protect=True,
             ignore_changes=['metadata["ssh-keys"]', 'metadata["enable-osconfig"]'],
         ),

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -389,9 +389,10 @@ class DeploymentConfig:
     boot_disk_name: str
     boot_disk_type: str
     boot_disk_gb: int
+    boot_disk_iops: int
+    boot_disk_throughput: int
     boot_disk_snapshot: str
     dotenv_secret_version: int
-    snapshot_retention_days: int
     prune_deployment: bool = False
     settings: tuple[tuple[str, str | int | bool], ...] = ()
     profiles: tuple[ProfileConfig, ...] = ()
@@ -405,7 +406,8 @@ class DeploymentConfig:
             raise ValueError("domain must be a canonical hostname without a scheme, path, or trailing dot")
         for name, value in (
             ("bootDiskGb", self.boot_disk_gb),
-            ("snapshotRetentionDays", self.snapshot_retention_days),
+            ("bootDiskIops", self.boot_disk_iops),
+            ("bootDiskThroughput", self.boot_disk_throughput),
             ("dotenvSecretVersion", self.dotenv_secret_version),
         ):
             _positive_config_int(value, name)
@@ -491,6 +493,8 @@ class DeploymentConfig:
             boot_disk_name=config.require("bootDiskName"),
             boot_disk_type=config.require("bootDiskType"),
             boot_disk_gb=config.require_int("bootDiskGb"),
+            boot_disk_iops=config.require_int("bootDiskIops"),
+            boot_disk_throughput=config.require_int("bootDiskThroughput"),
             boot_disk_snapshot=config.require("bootDiskSnapshot"),
             dotenv_secret_version=config.require_int("dotenvSecretVersion"),
             prune_deployment=config.get_bool("pruneDeployment") or False,
@@ -498,7 +502,6 @@ class DeploymentConfig:
             profiles=tuple(profiles),
             workloads=tuple(workloads),
             github_federations=tuple(github_federations),
-            snapshot_retention_days=config.require_int("snapshotRetentionDays"),
             vm_project_roles=vm_project_roles,
             vm_pulumi_kms_keys=vm_pulumi_kms_keys,
         )
@@ -614,37 +617,9 @@ def _create_root_disk(config: DeploymentConfig, apis: list[gcp.projects.Service]
         snapshot=config.boot_disk_snapshot,
         type=config.boot_disk_type,
         size=config.boot_disk_gb,
+        provisioned_iops=config.boot_disk_iops,
+        provisioned_throughput=config.boot_disk_throughput,
         opts=pulumi.ResourceOptions(depends_on=apis, protect=True, retain_on_delete=True),
-    )
-
-
-def _create_boot_disk_snapshots(
-    config: DeploymentConfig,
-    apis: list[gcp.projects.Service],
-    root_disk: gcp.compute.Disk,
-) -> gcp.compute.DiskResourcePolicyAttachment:
-    snapshot_policy = gcp.compute.ResourcePolicy(
-        "loom-snapshots",
-        project=config.project,
-        region=config.region,
-        name=f"{config.instance_name}-daily",
-        snapshot_schedule_policy={
-            "schedule": {"daily_schedule": {"days_in_cycle": 1, "start_time": "04:00"}},
-            "retention_policy": {
-                "max_retention_days": config.snapshot_retention_days,
-                "on_source_disk_delete": "KEEP_AUTO_SNAPSHOTS",
-            },
-            "snapshot_properties": {"storage_locations": config.region},
-        },
-        opts=pulumi.ResourceOptions(depends_on=apis),
-    )
-    return gcp.compute.DiskResourcePolicyAttachment(
-        "loom-snapshot-policy",
-        project=config.project,
-        zone=config.zone,
-        disk=root_disk.name,
-        name=snapshot_policy.name,
-        opts=pulumi.ResourceOptions(depends_on=[root_disk]),
     )
 
 
@@ -929,7 +904,6 @@ def _create_activation(
     config: DeploymentConfig,
     instance: InstanceResources,
     dns_record: cloudflare.DnsRecord,
-    snapshot_attachment: gcp.compute.DiskResourcePolicyAttachment,
 ) -> command.local.Command:
     return command.local.Command(
         "loom-activate",
@@ -943,7 +917,7 @@ def _create_activation(
             "LOOM_DOMAIN": config.domain,
         },
         triggers=[instance.instance.id, pulumi.Output.json_dumps(instance.metadata)],
-        opts=pulumi.ResourceOptions(depends_on=[instance.instance, dns_record, snapshot_attachment]),
+        opts=pulumi.ResourceOptions(depends_on=[instance.instance, dns_record]),
     )
 
 
@@ -1040,7 +1014,6 @@ def create_infrastructure(config: DeploymentConfig) -> Infrastructure:
         runtime_policy,
         vm_permissions,
     )
-    snapshot_attachment = _create_boot_disk_snapshots(config, apis, root_disk)
-    activation = _create_activation(config, instance, network.dns_record, snapshot_attachment)
+    activation = _create_activation(config, instance, network.dns_record)
     _export_outputs(config, instance.instance, network, image, runtime_policy)
     return Infrastructure(instance.instance, activation)

--- a/infra/loom/tests/test_infrastructure.py
+++ b/infra/loom/tests/test_infrastructure.py
@@ -63,8 +63,11 @@ def deployment_config() -> DeploymentConfig:
         network="default",
         instance_name="loom",
         vm_service_account_name="loom-vm",
-        machine_type="e2-highmem-4",
+        machine_type="c4d-highmem-4",
+        boot_disk_name="loom-hyperdisk",
+        boot_disk_type="hyperdisk-balanced",
         boot_disk_gb=100,
+        boot_disk_snapshot="loom-pre-c4d-hyperdisk-20260816",
         dotenv_secret_version=3,
         snapshot_retention_days=14,
         vm_project_roles=("roles/cloudsql.client", "roles/cloudsql.instanceUser"),
@@ -235,12 +238,24 @@ def test_deployment_models_durable_resources_without_secret_payloads():
         boot_disk = field(vm.inputs, "boot_disk", "bootDisk")
         assert boot_disk is not None
         assert field(boot_disk, "auto_delete", "autoDelete") is False
-        root_disk = by_name(mocks, "loom-root")
+        assert field(boot_disk, "interface", "interface") == "NVME"
+        root_disk = by_name(mocks, "loom-primary-root")
         assert root_disk.typ == "gcp:compute/disk:Disk"
-        assert root_disk.inputs["name"] == "loom"
-        assert boot_disk["source"] == "loom-root_id"
+        assert root_disk.inputs["name"] == "loom-hyperdisk"
+        assert root_disk.inputs["type"] == "hyperdisk-balanced"
+        assert root_disk.inputs["snapshot"] == "loom-pre-c4d-hyperdisk-20260816"
+        assert boot_disk["source"] == "loom-primary-root_id"
         snapshot_attachment = by_name(mocks, "loom-snapshot-policy")
-        assert snapshot_attachment.inputs["disk"] == "loom"
+        assert snapshot_attachment.inputs["disk"] == "loom-hyperdisk"
+        network_interface = field(vm.inputs, "network_interfaces", "networkInterfaces")[0]
+        assert field(network_interface, "nic_type", "nicType") == "GVNIC"
+        assert field(vm.inputs, "machine_type", "machineType") == "c4d-highmem-4"
+        assert field(vm.inputs, "reservation_affinity", "reservationAffinity")["type"] == "NO_RESERVATION"
+        scheduling = field(vm.inputs, "scheduling", "scheduling")
+        assert field(scheduling, "automatic_restart", "automaticRestart") is True
+        assert field(scheduling, "on_host_maintenance", "onHostMaintenance") == "MIGRATE"
+        assert scheduling["preemptible"] is False
+        assert field(scheduling, "provisioning_model", "provisioningModel") == "STANDARD"
         metadata = vm.inputs["metadata"]
         assert metadata["dotenv-secret-version"] == "3"
         assert json.loads(metadata["docker-daemon-config"]) == {

--- a/infra/loom/tests/test_infrastructure.py
+++ b/infra/loom/tests/test_infrastructure.py
@@ -67,9 +67,10 @@ def deployment_config() -> DeploymentConfig:
         boot_disk_name="loom-hyperdisk",
         boot_disk_type="hyperdisk-balanced",
         boot_disk_gb=100,
+        boot_disk_iops=3000,
+        boot_disk_throughput=140,
         boot_disk_snapshot="loom-pre-c4d-hyperdisk-20260816",
         dotenv_secret_version=3,
-        snapshot_retention_days=14,
         vm_project_roles=("roles/cloudsql.client", "roles/cloudsql.instanceUser"),
         vm_pulumi_kms_keys=(
             "projects/example/locations/us-central1/keyRings/marin-iac-keyring/cryptoKeys/marin-iac-key",
@@ -231,6 +232,8 @@ def test_deployment_models_durable_resources_without_secret_payloads():
         assert "gcp:secretmanager/secretVersion:SecretVersion" not in resource_types
         assert "gcp:iam/workloadIdentityPool:WorkloadIdentityPool" not in resource_types
         assert "gcp:iam/workloadIdentityPoolProvider:WorkloadIdentityPoolProvider" not in resource_types
+        assert "gcp:compute/resourcePolicy:ResourcePolicy" not in resource_types
+        assert "gcp:compute/diskResourcePolicyAttachment:DiskResourcePolicyAttachment" not in resource_types
 
         vm = by_name(mocks, "loom")
         attached = field(vm.inputs, "attached_disks", "attachedDisks")
@@ -243,10 +246,10 @@ def test_deployment_models_durable_resources_without_secret_payloads():
         assert root_disk.typ == "gcp:compute/disk:Disk"
         assert root_disk.inputs["name"] == "loom-hyperdisk"
         assert root_disk.inputs["type"] == "hyperdisk-balanced"
+        assert field(root_disk.inputs, "provisioned_iops", "provisionedIops") == 3000
+        assert field(root_disk.inputs, "provisioned_throughput", "provisionedThroughput") == 140
         assert root_disk.inputs["snapshot"] == "loom-pre-c4d-hyperdisk-20260816"
         assert boot_disk["source"] == "loom-primary-root_id"
-        snapshot_attachment = by_name(mocks, "loom-snapshot-policy")
-        assert snapshot_attachment.inputs["disk"] == "loom-hyperdisk"
         network_interface = field(vm.inputs, "network_interfaces", "networkInterfaces")[0]
         assert field(network_interface, "nic_type", "nicType") == "GVNIC"
         assert field(vm.inputs, "machine_type", "machineType") == "c4d-highmem-4"


### PR DESCRIPTION
Move loom.oa.dev from e2-highmem-4 on Intel Broadwell to c4d-highmem-4 on AMD Turin. The production cutover stopped the VM, captured `loom-pre-c4d-hyperdisk-20260816`, restored the 1 TB root volume to Hyperdisk Balanced, and preserved the existing static IP and image digest.

Use NVMe and gVNIC as required by C4D. Keep the VM on STANDARD on-demand provisioning with no reservation, and pin Hyperdisk performance to the included 3,000 IOPS and 140 MB/s baseline. Protect the VM and root disk from deletion; keep the disk non-auto-deleting and retained independently of the VM.

The old Persistent Disk and recurring snapshot policy were removed after validation. The migration snapshot remains as the rollback point. The production stack previews with 23 unchanged resources, and Loom reports its database ready, all migrations current, and no degraded components.