### PR TITLE
[datakit] Fit tier2 verification workers on GCE

### DIFF
--- a/experiments/ferries/datakit_tier2_skewed_ferry.py
+++ b/experiments/ferries/datakit_tier2_skewed_ferry.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 
+from fray.types import ResourceConfig
 from marin.datakit.download.huggingface import download_hf_step
 from marin.datakit.normalize import NormalizedData, normalize_step
 from marin.execution.artifact import read_artifact
@@ -129,6 +130,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
             verification_params=verification_params,
             local_representative_params=REFERENCE_LOCAL_REPRESENTATIVE_PARAMS,
             store_config=FUZZY_VERIFICATION_STORE_CONFIG,
+            worker_resources=ResourceConfig(cpu=2, ram="16g", disk="64g"),
         ),
         override_output_path=prefix_join(ttl_base, "verify_fuzzy_dups"),
     )


### PR DESCRIPTION
Request 64g of scratch for the datakit tier2 skewed ferry's fuzzy-verification workers. The 256g library default added in #8282 exceeds the canary GCE pool's 100 GB per-VM disk and prevents worker scheduling.

The existing verification smoke runner also uses 64g. Production callers continue using the 256g default required for external-sort spill.

Fixes #8330
