### PR TITLE
[grug] Fair receiver-overflow rotation + hero-shape ablation ladder

### DIFF
--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -132,14 +132,17 @@ group `moe-hero-ep` and the supplied run ID. The run output includes the durable
 artifact. Give each concurrent gang its own `IRIS_PORT_JAX`: rank 0 binds and registers that port
 for the JAX coordinator, and the default 8476 is shared by every run on the cluster.
 
-### Legacy small-scale ablations
+### Small-scale hero-shape ablations
 
-`small_scale_abl_launch.py` runs the earlier E192, top-4 shape (`--size` in `d768`…`d2048`) on one
-GB200 rack. It fixes the batch at ~4M tokens per step to hold the fixed-all-to-all drop dynamics, and
-sizes the step count from the model's active-parameter count: `num_steps` trains
-`--tokens-per-active-param` (default 750) tokens per active parameter. `--flavor ep` keeps the
-64-way expert axis; `--flavor fsdp-nodrop` runs the same shape dropless, and `--flavor fsdp-chunk4`
-runs it with four-chunk capacity. Print the plan without a GPU run:
+`small_scale_abl_launch.py` runs the hero shape — pooled-wave transport, 384 experts / top-8,
+hidden/2-wide experts in a hidden/2 latent, receiver/sender capacity 1.15 with 3 waves — at a
+downsized width (`--size` in `d768`…`d2048`) on one GB200 rack. It fixes the batch at ~4M tokens per
+step per rack to hold the pooled-wave drop dynamics, and sizes the step count from the model's
+active-parameter count: `num_steps` trains `--tokens-per-active-param` (default 750) tokens per
+active parameter. `--flavor ep` keeps the 64-way expert axis; `--flavor fsdp-nodrop` runs the same
+shape dropless, and `--flavor fsdp-chunk4` runs it with four-chunk capacity. Both pooled-wave gates
+are tunable: `--capacity-factor` (receiver) and `--transport-capacity-factor` (sender). Print the
+plan without a GPU run:
 
 ```bash
 python -m experiments.grug.moe_hero_ep.small_scale_abl_launch \

--- a/experiments/grug/moe_hero_ep/heuristic.py
+++ b/experiments/grug/moe_hero_ep/heuristic.py
@@ -10,7 +10,7 @@ pairs it with the fixed hero model spec so a launcher gets both configs back fro
 
 The hero model is d6144 with 48 layers and 384 routed experts. Each expert has width 3,072, and
 the router selects eight experts per token. The pooled transport uses three static waves. The
-receiver capacity factor is 1.15, and the sender capacity factor is 1.10.
+receiver and sender capacity factors are both 1.15.
 """
 
 import math
@@ -106,7 +106,7 @@ HERO_MODEL = GrugModelConfig(
     sconv=True,
     attention_implementation="gpu_fa4_cute",
     moe_implementation="fixed_pooled_wave_all_to_all",
-    pooled_transport_capacity_factor=1.10,
+    pooled_transport_capacity_factor=1.15,
     num_expert_waves=3,
     expert_chunks=1,
     report_capacity_overflow=True,

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -1246,13 +1246,17 @@ class Transformer(eqx.Module):
                 jnp.sum(router_metrics["router_z_loss_per_layer"]) / num_moe_layers
             )
             if self.config.report_capacity_overflow:
-                summarized_metrics["moe/dropped_assignments"] = jnp.sum(router_metrics["capacity_overflow_per_layer"])
-                summarized_metrics["moe/sender_dropped_assignments"] = jnp.sum(
-                    router_metrics["sender_capacity_overflow_per_layer"]
-                )
-                summarized_metrics["moe/receiver_dropped_assignments"] = jnp.sum(
-                    router_metrics["receiver_capacity_overflow_per_layer"]
-                )
+                # Keep the per-layer int32 counts (each fits int32); the trainer sums them over layers on
+                # the host in int64. Summing here with jnp.sum overflows int32 at large batch (e.g. batch
+                # 4096: 4096*4096*8*48 ~ 6.4e9 assignments > 2.1e9) and breaks the total==sender+receiver
+                # accounting check, since jax_enable_x64 is off so an in-device int64 sum silently downcasts.
+                summarized_metrics["moe/dropped_assignments"] = router_metrics["capacity_overflow_per_layer"]
+                summarized_metrics["moe/sender_dropped_assignments"] = router_metrics[
+                    "sender_capacity_overflow_per_layer"
+                ]
+                summarized_metrics["moe/receiver_dropped_assignments"] = router_metrics[
+                    "receiver_capacity_overflow_per_layer"
+                ]
             return loss, summarized_metrics
         return loss
 

--- a/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
+++ b/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
@@ -1,9 +1,10 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Legacy E192 small-scale ablation: d768 / d1024 / d1280 / d1536.
+"""Small-scale hero-shape ablation: d768 / d1024 / d1280 / d1536 / d2048.
 
-These runs use hidden-wide experts, top-4 routing, two shared experts, and fixed all-to-all EP.
+These runs mirror the EP hero: 384 routed experts, top-8 routing, hidden/2-wide experts in a hidden/2
+latent, two shared experts, and the pooled-wave all-to-all transport at receiver/sender capacity 1.15.
 Each run uses the small sweep width and 750 tokens per active parameter. The data, evaluations,
 and step counts match the Aug hero learning-rate sweep from issue #7856.
 
@@ -52,9 +53,11 @@ from experiments.marin_tokenizer import marin_tokenizer
 SEQ_LEN = 4096
 SMALL_BATCH_SIZE = 1024
 # Tokens per step are fixed at ~4M (batch 1024 x seq 4096) to approximate the per-shard token-dropping
-# dynamics under the fixed_all_to_all EP MoE; a sequence-length sweep holds this constant and moves only
+# dynamics under the pooled-wave EP MoE; a sequence-length sweep holds this constant and moves only
 # the context length.
 TOKENS_PER_STEP = SMALL_BATCH_SIZE * SEQ_LEN
+# Receiver and sender capacity both 1.15, matching the EP hero; kept paired through one constant.
+_EP_CAPACITY_FACTOR = 1.15
 SLIDING_WINDOW = 2048
 GLOBAL_EVERY = 4
 EVAL_BATCH_SIZE = 256
@@ -125,20 +128,28 @@ TARGETS: dict[str, Target] = {
 class Flavor:
     """How the MoE layer shards, and what that implies for routing capacity.
 
-    ``ep`` spans the fleet with expert parallelism and drops assignments above each fixed
-    (sender shard, expert) cell. The FSDP arms keep one expert axis, so every device holds the whole
-    bank and the local `sonic_cute` kernel runs the experts: ``fsdp-nodrop`` at one chunk computes
-    every assignment (dropless), and ``fsdp-chunk4`` splits into four chunks to match the FSDP hero's
-    minor-dropping reference. Both use the same kernel; only the chunk count (drop rate) differs.
+    ``ep`` spans the fleet with expert parallelism and drops assignments through the pooled-wave
+    transport's two gates: a sender pool (per destination shard, capped by
+    ``pooled_transport_capacity_factor``) and per-wave receiver buffers (capped by ``capacity_factor``).
+    The FSDP arms keep one expert axis, so every device holds the whole bank and the local `sonic_cute`
+    kernel runs the experts: ``fsdp-nodrop`` at one chunk computes every assignment (dropless), and
+    ``fsdp-chunk4`` splits into four chunks to match the FSDP hero's minor-dropping reference. Both use
+    the same kernel; only the chunk count (drop rate) differs.
     """
 
     expert_axis_size: int | None  # None spans the fleet
     moe_implementation: str
     expert_chunks: int
+    pooled_transport_capacity_factor: float | None = None  # sender pool cap; pooled-wave only
+    num_expert_waves: int = 1  # receiver-buffer waves; pooled-wave only
 
 
 FLAVORS: dict[str, Flavor] = {
-    "ep": Flavor(None, "fixed_all_to_all", 1),
+    # Pooled-wave EP mirroring the hero: 3 receiver waves and a 1.15 sender-pool cap (paired with the
+    # 1.15 receiver capacity_factor default).
+    "ep": Flavor(
+        None, "fixed_pooled_wave_all_to_all", 1, pooled_transport_capacity_factor=_EP_CAPACITY_FACTOR, num_expert_waves=3
+    ),
     # The dropless FSDP arm is `sonic_cute` at one chunk -- "1 computes every assignment" per the FSDP
     # hero -- so it matches `fsdp-chunk4`'s kernel and only the chunk count (drop rate) differs. The
     # `scatter` grouped-GMM path mis-routes this QB/sigmoid-combine model (loss ~1.1 above chunk4).
@@ -179,18 +190,17 @@ def _small_model(
     num_experts_per_token: int,
     intermediate_dim: int | None,
     latent_dim: int | None,
+    pooled_transport_capacity_factor: float | None = None,
+    num_expert_waves: int = 1,
     qb_use_histogram: bool = False,
     qb_hist_bins: int = 1000,
 ) -> GrugModelConfig:
-    """Build the legacy E192, top-4 ablation at the selected width.
-
-    The function keeps the routing and attention fields from the completed small-scale sweep.
-    """
+    """Build the hero-shape ablation (E384, top-8, pooled-wave) at the selected width."""
     return GrugModelConfig(
         vocab_size=128_256,
         hidden_dim=shape.hidden_dim,
-        # Routed experts default hidden-wide, matching the EP hero; only the shared expert is hidden/2.
-        intermediate_dim=intermediate_dim if intermediate_dim is not None else shape.hidden_dim,
+        # Routed experts default hidden/2-wide in a hidden/2 latent, matching the EP hero.
+        intermediate_dim=intermediate_dim if intermediate_dim is not None else shape.hidden_dim // 2,
         shared_expert_intermediate_dim=shape.hidden_dim // 2,
         num_shared_experts=2,
         num_experts=num_experts,
@@ -213,6 +223,8 @@ def _small_model(
         attention_implementation=attention_implementation,
         moe_implementation=moe_implementation,
         expert_chunks=expert_chunks,
+        pooled_transport_capacity_factor=pooled_transport_capacity_factor,
+        num_expert_waves=num_expert_waves,
         # Routed experts run in a latent space half the hidden width, matching the EP hero arm.
         latent_dim=latent_dim if latent_dim is not None else shape.hidden_dim // 2,
         qb_estimator=QbEstimator.HIST if qb_use_histogram else QbEstimator.TOPK,
@@ -250,11 +262,11 @@ def build_small_run(
     size: str,
     target: str = "gb200-rack",
     flavor: str = "ep",
-    capacity_factor: float = 1.33,
+    capacity_factor: float = _EP_CAPACITY_FACTOR,
     seq_len: int = SEQ_LEN,
     tokens_per_step: int = TOKENS_PER_STEP,
-    num_experts: int = 192,
-    num_experts_per_token: int = 4,
+    num_experts: int = 384,
+    num_experts_per_token: int = 8,
     intermediate_dim: int | None = None,
     latent_dim: int | None = None,
     qb_use_histogram: bool = False,
@@ -302,7 +314,7 @@ def build_small_run(
     fleet = TARGETS[target]
     sharding = FLAVORS[flavor]
     # `tokens_per_step` is the per-rack (per expert mesh) token load; it stays fixed so the
-    # fixed-all-to-all drop dynamics are constant across sizes. The global batch scales with the
+    # pooled-wave drop dynamics are constant across sizes. The global batch scales with the
     # rack count, so a wider rung on more racks keeps the same per-rack load as a one-rack rung.
     global_tokens_per_step = tokens_per_step * dp_racks
     batch_size = global_tokens_per_step // seq_len
@@ -318,6 +330,8 @@ def build_small_run(
         num_experts_per_token,
         intermediate_dim,
         latent_dim,
+        sharding.pooled_transport_capacity_factor,
+        sharding.num_expert_waves,
         qb_use_histogram,
         qb_hist_bins,
     )
@@ -348,6 +362,14 @@ def build_small_run(
     )
     if model.num_experts % expert_axis_size != 0:
         raise ValueError(f"num_experts={model.num_experts} must divide the expert axis {expert_axis_size}")
+    # Fail fast here (before the fleet is allocated) on the same divisibility the pooled-wave transport
+    # enforces at runtime, mirroring the hero launcher's pre-allocation check.
+    local_experts = model.num_experts // expert_axis_size
+    if model.moe_implementation == "fixed_pooled_wave_all_to_all" and local_experts % model.num_expert_waves != 0:
+        raise ValueError(
+            f"local expert count={local_experts} (num_experts={model.num_experts} / expert axis "
+            f"{expert_axis_size}) must divide num_expert_waves={model.num_expert_waves}"
+        )
     train_resources = ResourceConfig.with_gpu(
         fleet.accelerator,
         count=fleet.gpus_per_node,
@@ -491,17 +513,17 @@ def build_small_run(
 @click.option(
     "--capacity-factor",
     type=click.FloatRange(min=0, min_open=True),
-    default=1.33,
+    default=_EP_CAPACITY_FACTOR,
     show_default=True,
-    help="Fixed all-to-all capacity factor (EP hero arm is 1.33). Higher drops fewer and pads more.",
+    help="Receiver capacity factor (pooled-wave EP hero arm is 1.15). Higher drops fewer and pads more.",
 )
-@click.option("--num-experts", type=click.IntRange(min=1), default=192, help="Routed expert count (hero bank).")
-@click.option("--num-experts-per-token", type=click.IntRange(min=1), default=4, help="Routed experts per token.")
+@click.option("--num-experts", type=click.IntRange(min=1), default=384, help="Routed expert count (hero bank).")
+@click.option("--num-experts-per-token", type=click.IntRange(min=1), default=8, help="Routed experts per token.")
 @click.option(
     "--intermediate-dim",
     type=click.IntRange(min=1),
     default=None,
-    help="Routed expert MLP width. Defaults to hidden_dim (hidden-wide), matching the EP hero.",
+    help="Routed expert MLP width. Defaults to hidden_dim // 2, matching the EP hero.",
 )
 @click.option(
     "--latent-dim",

--- a/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
+++ b/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
@@ -103,23 +103,25 @@ class Target:
 # SM100 symmetric GEMM, so Hopper takes the plain vmapped path instead.
 TARGETS: dict[str, Target] = {
     "gb200-rack": Target("GB200", HERO_GPUS_PER_NODE, HERO_EP_NODES, 120, "850g", "1t", "gpu_fa4_cute", True),
-    # 8 nodes, not 1: capacity is per (sender shard, expert) cell, so the shard count sets how
-    # readily cells overflow. EP8 would give 4,096-row cells against 512 at EP64 and would drop far
-    # less on the same routing, which is not the behavior these runs are meant to reproduce.
+    # 8 nodes, not 1: under pooled-wave the receiver cell pools over all senders and is
+    # shard-count-independent, so only the sender pool tracks the fleet. The sender cell is per
+    # (destination shard, wave) and shrinks as 1/shards^2 -- ~50,244 rows at EP8 against ~785 at EP64
+    # on the 1M-token grid -- so EP8 drops far less at the sender, which is not the behavior these
+    # runs reproduce.
     # 32 CPU and 600g, not 120 and 1900g: an H100 node allocates 127 CPU and about 2 TB, so the
     # larger request demands an effectively empty node and Kueue rejects the whole 8-pod gang
     # ("excluded: resource cpu: 39, resource memory: 25" of 65 nodes). Host memory here holds the
     # loader and checkpoint staging -- a d1280 checkpoint is about 38 GB -- so 600g keeps a wide
     # margin, and the trainer is GPU-bound at these capacity factors.
     "h100-8node": Target("H100", 8, 8, 32, "600g", "900g", "reference", False),
-    # 2 nodes = EP16, which reproduces the d6144 hero's per-shard routing statistics exactly.
-    # Cell capacity is `cf * (tokens_per_step / shards) * top_k / num_experts`, so the shard count --
-    # not the expert count -- is what sets cell size. At EP16 with the grid's 1,048,576 tokens per
-    # step, each shard carries the hero's 65,536 tokens and 2,048-row cells. Pair this with
-    # `--seq-len 4096` (the batch widens to 256) and each shard also holds the hero's 16 documents,
-    # instead of the 2 that EP64 gives. Two documents per shard is why the EP64 ablation drops ~7%
-    # at cf 2.5 where the hero drops 0.27%: per-cell load is a sum over correlated document blocks,
-    # so the effective sample size is the document count, not the token count.
+    # 2 nodes = EP16. Under pooled-wave the receiver cell is `cf * tokens_per_step * top_k /
+    # (num_experts * waves)` -- ~8,374 rows at the grid's 1,048,576 tokens per step, shard-count
+    # independent, so it matches the EP64 hero at any fleet. Only the sender pool `cf_s *
+    # tokens_per_step * top_k / (shards^2 * waves)` tracks the shard count, and EP16's sender cell is
+    # ~16x the EP64 hero's -- a much looser sender gate. So this is a small-fleet option, not a
+    # per-shard reproduction of the hero; gb200-rack / h100-8node at EP64 is the faithful sender gate.
+    # (The sender gate pools each shard's ~65,536 tokens over ~2 documents, which is why per-cell
+    # variance -- not the token count -- drives the drop rate.)
     "h100-2node": Target("H100", 8, 2, 32, "600g", "900g", "reference", False),
 }
 
@@ -263,6 +265,7 @@ def build_small_run(
     target: str = "gb200-rack",
     flavor: str = "ep",
     capacity_factor: float = _EP_CAPACITY_FACTOR,
+    transport_capacity_factor: float | None = None,
     seq_len: int = SEQ_LEN,
     tokens_per_step: int = TOKENS_PER_STEP,
     num_experts: int = 384,
@@ -319,6 +322,12 @@ def build_small_run(
     global_tokens_per_step = tokens_per_step * dp_racks
     batch_size = global_tokens_per_step // seq_len
     expert_axis_size = fleet.expert_axis_size if sharding.expert_axis_size is None else sharding.expert_axis_size
+    # ``--transport-capacity-factor`` overrides the Flavor's sender-pool cap; ``None`` keeps the paired
+    # 1.15 default. The two pooled-wave gates cap independently, so a run that sweeps only the receiver
+    # (``--capacity-factor``) flattens once the sender gate takes over -- vary this to move that gate.
+    transport_capacity = (
+        transport_capacity_factor if transport_capacity_factor is not None else sharding.pooled_transport_capacity_factor
+    )
     model = _small_model(
         shape,
         capacity_factor,
@@ -330,7 +339,7 @@ def build_small_run(
         num_experts_per_token,
         intermediate_dim,
         latent_dim,
-        sharding.pooled_transport_capacity_factor,
+        transport_capacity,
         sharding.num_expert_waves,
         qb_use_histogram,
         qb_hist_bins,
@@ -515,7 +524,17 @@ def build_small_run(
     type=click.FloatRange(min=0, min_open=True),
     default=_EP_CAPACITY_FACTOR,
     show_default=True,
-    help="Receiver capacity factor (pooled-wave EP hero arm is 1.15). Higher drops fewer and pads more.",
+    help=(
+        "Receiver-buffer capacity factor (pooled-wave EP hero arm is 1.15). The receiver cell pools over "
+        "all senders, so it is rarely the limiting gate; raising this alone flattens once the sender pool "
+        "takes over -- pair it with --transport-capacity-factor."
+    ),
+)
+@click.option(
+    "--transport-capacity-factor",
+    type=click.FloatRange(min=0, min_open=True),
+    default=None,
+    help="Sender-pool capacity factor (the limiting gate). Defaults to the Flavor value (1.15 for `ep`).",
 )
 @click.option("--num-experts", type=click.IntRange(min=1), default=384, help="Routed expert count (hero bank).")
 @click.option("--num-experts-per-token", type=click.IntRange(min=1), default=8, help="Routed experts per token.")
@@ -581,6 +600,7 @@ def main(
     seq_len: int,
     tokens_per_step: int,
     capacity_factor: float,
+    transport_capacity_factor: float | None,
     num_experts: int,
     num_experts_per_token: int,
     intermediate_dim: int | None,
@@ -600,6 +620,7 @@ def main(
         seq_len=seq_len,
         tokens_per_step=tokens_per_step,
         capacity_factor=capacity_factor,
+        transport_capacity_factor=transport_capacity_factor,
         num_experts=num_experts,
         num_experts_per_token=num_experts_per_token,
         intermediate_dim=intermediate_dim,

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -16,6 +16,7 @@ import jax.numpy as jnp
 import jmp
 import levanter.callbacks as callbacks
 import levanter.tracker
+import numpy as np
 import optax
 from fray.cluster import ResourceConfig
 from haliax import Axis
@@ -450,10 +451,14 @@ def _drop_metrics(
     top_k: int,
     num_layers: int,
 ) -> dict[str, int | float]:
-    # Global assignment totals can exceed int32; float32 would also round large drop counts.
-    dropped_assignments_host = int(dropped_assignments)
-    sender_dropped_assignments_host = int(sender_dropped_assignments)
-    receiver_dropped_assignments_host = int(receiver_dropped_assignments)
+    # Per-layer int32 counts summed over layers in int64 on the host: the global totals exceed int32 at
+    # large batch (jax_enable_x64 is off, so an in-device sum would overflow), and float32 would round them.
+    def _sum_int64(per_layer: jax.Array) -> int:
+        return int(np.asarray(per_layer).astype(np.int64).sum())
+
+    dropped_assignments_host = _sum_int64(dropped_assignments)
+    sender_dropped_assignments_host = _sum_int64(sender_dropped_assignments)
+    receiver_dropped_assignments_host = _sum_int64(receiver_dropped_assignments)
     if dropped_assignments_host != sender_dropped_assignments_host + receiver_dropped_assignments_host:
         raise ValueError("total dropped assignments must equal sender plus receiver dropped assignments")
     total_assignments = batch_size * sequence_length * top_k * num_layers

--- a/lib/levanter/src/levanter/grug/_moe/ep_fixed_pooled_wave_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_fixed_pooled_wave_all_to_all.py
@@ -325,26 +325,29 @@ def _receiver_ranks(
     return jnp.sum((inclusive_counts - 1) * expert_indicators, axis=1, dtype=jnp.int32)
 
 
-def _rotated_receiver_ranks(
+def _interleaved_receiver_ranks(
     received_experts: Int[Array, " N"],
     *,
     local_experts: int,
     expert_shards: int,
     pool_capacity: int,
-    rotation: Int[Array, ""] | int,
 ) -> Int[Array, " N"]:
-    """Per-expert receiver capacity ranks with a per-receiver source rotation.
+    """Per-expert receiver capacity ranks that fill capacity round-robin over source shards.
 
-    The received buffer is source-shard-major (``[expert_shards, pool_capacity]``), so the plain
-    cumsum ranks always fill capacity in the same source order at every receiver -- making the same
-    (last-ordered) sender shard absorb the overflow everywhere, a deterministic data-correlated drop
-    bias. Rolling the source axis by ``-rotation`` before the cumsum, then rolling the ranks back, makes
-    each receiver truncate a different source first, so overflow spreads evenly across senders. The
-    per-expert drop count is unchanged; only integer metadata is rolled, never the token payload.
+    The received buffer is source-shard-major (``[expert_shards, pool_capacity]``), so a plain cumsum
+    ranks capacity in source order at every receiver -- the same (last-ordered) sender shard absorbs
+    the overflow everywhere, a deterministic data-correlated drop bias. Transposing to pool-position
+    order (``[pool_capacity, expert_shards]``) before the cumsum visits each source's slot ``p`` before
+    any source's slot ``p+1``, so capacity is allocated round-robin across sources and no sender is
+    truncated first. Transposing the ranks back restores the source-major layout the caller expects.
+
+    The permutation is static (no ``axis_index``), the per-expert keep count stays ``min(count,
+    capacity)``, and within any source pool position order is preserved -- so a later token never
+    displaces an earlier one within a sequence (each expert shard holds whole sequences).
     """
-    rolled = jnp.roll(received_experts.reshape(expert_shards, pool_capacity), -rotation, axis=0)
-    ranks = _receiver_ranks(rolled.reshape(-1), local_experts=local_experts)
-    return jnp.roll(ranks.reshape(expert_shards, pool_capacity), rotation, axis=0).reshape(-1)
+    interleaved = received_experts.reshape(expert_shards, pool_capacity).T.reshape(-1)
+    ranks = _receiver_ranks(interleaved, local_experts=local_experts)
+    return ranks.reshape(pool_capacity, expert_shards).T.reshape(-1)
 
 
 def _dispatch_pooled(
@@ -407,15 +410,13 @@ def _dispatch_pooled(
         received_encoded_experts = received_header.reshape(expert_shards, -1)[:, :pool_capacity].reshape(send_size)
         received_experts = received_encoded_experts.astype(jnp.int32) - 1
 
-        # Rotate the per-receiver capacity priority by this shard's own expert-axis index so each
-        # receiver truncates a different source first (see `_rotated_receiver_ranks`), removing the
-        # fixed-source-order receiver-overflow bias.
-        receiver_ranks = _rotated_receiver_ranks(
+        # Allocate receiver capacity round-robin over source shards (see `_interleaved_receiver_ranks`)
+        # so no sender is systematically truncated first, removing the fixed-source-order overflow bias.
+        receiver_ranks = _interleaved_receiver_ranks(
             received_experts,
             local_experts=local_experts,
             expert_shards=expert_shards,
             pool_capacity=pool_capacity,
-            rotation=jax.lax.axis_index("expert"),
         )
         receiver_valid = received_experts >= 0
         receiver_keep = receiver_valid & (receiver_ranks < receiver_capacity)

--- a/lib/levanter/src/levanter/grug/_moe/ep_fixed_pooled_wave_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_fixed_pooled_wave_all_to_all.py
@@ -325,6 +325,28 @@ def _receiver_ranks(
     return jnp.sum((inclusive_counts - 1) * expert_indicators, axis=1, dtype=jnp.int32)
 
 
+def _rotated_receiver_ranks(
+    received_experts: Int[Array, " N"],
+    *,
+    local_experts: int,
+    expert_shards: int,
+    pool_capacity: int,
+    rotation: Int[Array, ""] | int,
+) -> Int[Array, " N"]:
+    """Per-expert receiver capacity ranks with a per-receiver source rotation.
+
+    The received buffer is source-shard-major (``[expert_shards, pool_capacity]``), so the plain
+    cumsum ranks always fill capacity in the same source order at every receiver -- making the same
+    (last-ordered) sender shard absorb the overflow everywhere, a deterministic data-correlated drop
+    bias. Rolling the source axis by ``-rotation`` before the cumsum, then rolling the ranks back, makes
+    each receiver truncate a different source first, so overflow spreads evenly across senders. The
+    per-expert drop count is unchanged; only integer metadata is rolled, never the token payload.
+    """
+    rolled = jnp.roll(received_experts.reshape(expert_shards, pool_capacity), -rotation, axis=0)
+    ranks = _receiver_ranks(rolled.reshape(-1), local_experts=local_experts)
+    return jnp.roll(ranks.reshape(expert_shards, pool_capacity), rotation, axis=0).reshape(-1)
+
+
 def _dispatch_pooled(
     *,
     x_local: Float[Array, "Tlocal H"],
@@ -385,7 +407,16 @@ def _dispatch_pooled(
         received_encoded_experts = received_header.reshape(expert_shards, -1)[:, :pool_capacity].reshape(send_size)
         received_experts = received_encoded_experts.astype(jnp.int32) - 1
 
-        receiver_ranks = _receiver_ranks(received_experts, local_experts=local_experts)
+        # Rotate the per-receiver capacity priority by this shard's own expert-axis index so each
+        # receiver truncates a different source first (see `_rotated_receiver_ranks`), removing the
+        # fixed-source-order receiver-overflow bias.
+        receiver_ranks = _rotated_receiver_ranks(
+            received_experts,
+            local_experts=local_experts,
+            expert_shards=expert_shards,
+            pool_capacity=pool_capacity,
+            rotation=jax.lax.axis_index("expert"),
+        )
         receiver_valid = received_experts >= 0
         receiver_keep = receiver_valid & (receiver_ranks < receiver_capacity)
         compact_size = local_experts * receiver_capacity

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -820,6 +820,104 @@ def test_fixed_pooled_wave_all_to_all_reports_sender_and_receiver_drops():
     assert int(overflow.receiver) == 3
 
 
+def test_fixed_pooled_wave_rotation_across_expert_shards_with_replica_axis():
+    """Multi-rack shape: a `data` (replica) axis crossing a 2-shard `expert` axis. The receiver rotation
+    keys off `axis_index("expert")`, so this exercises that call when another axis is present. At high
+    capacity (no drops) the sharded output and gradients must match the dense reference -- proving the
+    rotation machinery compiles and computes correctly per expert shard on a multi-axis mesh -- and a
+    low-capacity run must still execute and report drops on both shards without error."""
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cpu"
+    env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+    script = """
+        import jax
+        import jax.numpy as jnp
+        import numpy as np
+        from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
+
+        from levanter.grug.grug_moe import moe_mlp
+
+        assert jax.device_count() == 4
+        # data=2 (the replica/rack axis) x expert=2 (the pooled-wave all-to-all axis).
+        mesh = Mesh(
+            np.asarray(jax.devices()).reshape(2, 2),
+            axis_names=("data", "expert"),
+            axis_types=(AxisType.Explicit, AxisType.Explicit),
+        )
+        tokens, hidden, inter, num_experts, topk = 8, 4, 3, 8, 2
+        x = jax.random.normal(jax.random.key(0), (tokens, hidden))
+        selected = ((jnp.arange(tokens)[:, None] + jnp.arange(topk)[None, :]) % num_experts).astype(jnp.int32)
+        combine = jax.nn.softmax(jax.random.normal(jax.random.key(1), (tokens, topk)), axis=-1)
+        w_up_gate = jax.random.normal(jax.random.key(2), (num_experts, hidden, 2 * inter))
+        w_down = jax.random.normal(jax.random.key(3), (num_experts, inter, hidden))
+        cotangent = jax.random.normal(jax.random.key(4), (tokens, hidden))
+
+        def dense(x, w_up_gate, w_down):
+            w13 = w_up_gate[selected]
+            h = jnp.einsum("th,tkhi->tki", x, w13)
+            g, u = jnp.split(h, [inter], axis=-1)
+            eo = jnp.einsum("tki,tkih->tkh", jax.nn.silu(g) * u, w_down[selected])
+            return jnp.einsum("tkh,tk->th", eo, combine)
+
+        expected = dense(x, w_up_gate, w_down)
+        expected_grads = jax.grad(
+            lambda x, a, b: jnp.sum(dense(x, a, b) * cotangent), argnums=(0, 1, 2)
+        )(x, w_up_gate, w_down)
+
+        batch_sh = NamedSharding(mesh, P(("data", "expert"), None))
+        expert_sh = NamedSharding(mesh, P("expert", None, None))
+        x = jax.device_put(x, batch_sh)
+        selected = jax.device_put(selected, batch_sh)
+        combine = jax.device_put(combine, batch_sh)
+        cotangent = jax.device_put(cotangent, batch_sh)
+        w_up_gate = jax.device_put(w_up_gate, expert_sh)
+        w_down = jax.device_put(w_down, expert_sh)
+
+        def pooled(x, a, b, capacity):
+            return moe_mlp(
+                x, selected, combine, a, b,
+                activation=jax.nn.silu,
+                implementation="fixed_pooled_wave_all_to_all",
+                mesh=mesh,
+                capacity_factor=capacity,
+                pooled_transport_capacity_factor=capacity,
+                num_expert_waves=2,
+            )
+
+        with jax.set_mesh(mesh):
+            actual = pooled(x, w_up_gate, w_down, 4.0)
+            actual_grads = jax.grad(
+                lambda x, a, b: jnp.sum(pooled(x, a, b, 4.0) * cotangent), argnums=(0, 1, 2)
+            )(x, w_up_gate, w_down)
+
+            # Low capacity: the rotation-with-drops path must execute on both shards and report drops.
+            _, overflow = moe_mlp(
+                x, selected, combine, w_up_gate, w_down,
+                activation=jax.nn.silu,
+                implementation="fixed_pooled_wave_all_to_all",
+                mesh=mesh,
+                capacity_factor=0.5,
+                pooled_transport_capacity_factor=0.5,
+                num_expert_waves=2,
+                report_capacity_overflow=True,
+            )
+
+        np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-5)
+        for a, e in zip(actual_grads, expected_grads, strict=True):
+            np.testing.assert_allclose(np.asarray(a), np.asarray(e), rtol=1e-5, atol=1e-5)
+        assert int(overflow.sender) + int(overflow.receiver) > 0
+        assert jnp.isfinite(actual).all()
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_fixed_all_to_all_matches_dense_cross_shard_value_and_gradients():
     env = os.environ.copy()
     env["JAX_PLATFORMS"] = "cpu"

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -25,7 +25,11 @@ from levanter.grug._moe.common import (
 )
 from levanter.grug._moe.ep_deepep import _pack_deepep_local_assignments
 from levanter.grug._moe.ep_fixed_all_to_all import _moe_mlp_ep_fixed_a2a_local
-from levanter.grug._moe.ep_fixed_pooled_wave_all_to_all import _moe_mlp_ep_fixed_pooled_wave_a2a_local
+from levanter.grug._moe.ep_fixed_pooled_wave_all_to_all import (
+    _moe_mlp_ep_fixed_pooled_wave_a2a_local,
+    _receiver_ranks,
+    _rotated_receiver_ranks,
+)
 from levanter.grug._moe.sonic import sonic_gather_sum
 from levanter.grug.grug_moe import (
     MoEExpertMlp,
@@ -147,6 +151,58 @@ def _skip_without_sonic_gpu_runtime() -> None:
         pytest.skip("raw Sonic optional dependencies are not installed")
     if not any(device.platform == "gpu" for device in jax.devices()):
         pytest.skip("raw Sonic triton_call tests require a GPU")
+
+
+def test_rotated_receiver_ranks_spread_drops_without_changing_counts():
+    """The per-receiver source rotation must (1) match keeping the first `capacity` tokens per expert
+    in rotated source order, (2) leave the per-expert drop count unchanged, and (3) equal the plain
+    ranks at rotation 0, so overflow spreads across senders without altering how many are dropped."""
+    expert_shards, pool_capacity, local_experts, receiver_capacity = 4, 5, 2, 3
+    send_size = expert_shards * pool_capacity
+    rng = np.random.default_rng(0)
+    received = rng.integers(-1, local_experts, size=send_size)  # -1 marks an empty slot
+    received_experts = jnp.asarray(received, dtype=jnp.int32)
+
+    def keep_set(rotation: int) -> np.ndarray:
+        ranks = _rotated_receiver_ranks(
+            received_experts,
+            local_experts=local_experts,
+            expert_shards=expert_shards,
+            pool_capacity=pool_capacity,
+            rotation=rotation,
+        )
+        return np.asarray((received_experts >= 0) & (ranks < receiver_capacity))
+
+    def reference_keep(rotation: int) -> np.ndarray:
+        counts = np.zeros(local_experts, dtype=int)
+        keep = np.zeros(send_size, dtype=bool)
+        for shard in range(expert_shards):
+            rotated_shard = (shard + rotation) % expert_shards
+            for pos in range(pool_capacity):
+                i = rotated_shard * pool_capacity + pos
+                e = int(received[i])
+                if e >= 0 and counts[e] < receiver_capacity:
+                    keep[i] = True
+                    counts[e] += 1
+        return keep
+
+    counts_by_expert = lambda keep: {e: int(((received == e) & keep).sum()) for e in range(local_experts)}
+    baseline_counts = counts_by_expert(keep_set(0))
+    # Rotation 0 must reduce to the plain source-order ranks.
+    plain_ranks = _receiver_ranks(received_experts, local_experts=local_experts)
+    rotated_zero = _rotated_receiver_ranks(
+        received_experts,
+        local_experts=local_experts,
+        expert_shards=expert_shards,
+        pool_capacity=pool_capacity,
+        rotation=0,
+    )
+    np.testing.assert_array_equal(np.asarray(rotated_zero), np.asarray(plain_ranks))
+    for rotation in range(expert_shards):
+        np.testing.assert_array_equal(keep_set(rotation), reference_keep(rotation))
+        assert counts_by_expert(keep_set(rotation)) == baseline_counts
+    # Different rotations keep different tokens (the bias actually moves).
+    assert not np.array_equal(keep_set(0), keep_set(1))
 
 
 def test_moe_mlp_runs_without_ep_axis():

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -27,8 +27,8 @@ from levanter.grug._moe.ep_deepep import _pack_deepep_local_assignments
 from levanter.grug._moe.ep_fixed_all_to_all import _moe_mlp_ep_fixed_a2a_local
 from levanter.grug._moe.ep_fixed_pooled_wave_all_to_all import (
     _moe_mlp_ep_fixed_pooled_wave_a2a_local,
+    _interleaved_receiver_ranks,
     _receiver_ranks,
-    _rotated_receiver_ranks,
 )
 from levanter.grug._moe.sonic import sonic_gather_sum
 from levanter.grug.grug_moe import (
@@ -153,56 +153,76 @@ def _skip_without_sonic_gpu_runtime() -> None:
         pytest.skip("raw Sonic triton_call tests require a GPU")
 
 
-def test_rotated_receiver_ranks_spread_drops_without_changing_counts():
-    """The per-receiver source rotation must (1) match keeping the first `capacity` tokens per expert
-    in rotated source order, (2) leave the per-expert drop count unchanged, and (3) equal the plain
-    ranks at rotation 0, so overflow spreads across senders without altering how many are dropped."""
+def test_interleaved_receiver_ranks_allocate_capacity_round_robin_over_sources():
+    """The interleaved receiver ranks must (1) keep the tokens a round-robin-over-sources fill would
+    keep, (2) leave the per-expert drop count at `min(count, capacity)`, and (3) keep, within any one
+    source, a prefix of pool positions per expert -- so a later token never displaces an earlier one in
+    the same sequence (each expert shard holds whole sequences)."""
     expert_shards, pool_capacity, local_experts, receiver_capacity = 4, 5, 2, 3
     send_size = expert_shards * pool_capacity
     rng = np.random.default_rng(0)
     received = rng.integers(-1, local_experts, size=send_size)  # -1 marks an empty slot
     received_experts = jnp.asarray(received, dtype=jnp.int32)
 
-    def keep_set(rotation: int) -> np.ndarray:
-        ranks = _rotated_receiver_ranks(
-            received_experts,
-            local_experts=local_experts,
-            expert_shards=expert_shards,
-            pool_capacity=pool_capacity,
-            rotation=rotation,
-        )
-        return np.asarray((received_experts >= 0) & (ranks < receiver_capacity))
-
-    def reference_keep(rotation: int) -> np.ndarray:
-        counts = np.zeros(local_experts, dtype=int)
-        keep = np.zeros(send_size, dtype=bool)
-        for shard in range(expert_shards):
-            rotated_shard = (shard + rotation) % expert_shards
-            for pos in range(pool_capacity):
-                i = rotated_shard * pool_capacity + pos
-                e = int(received[i])
-                if e >= 0 and counts[e] < receiver_capacity:
-                    keep[i] = True
-                    counts[e] += 1
-        return keep
-
-    counts_by_expert = lambda keep: {e: int(((received == e) & keep).sum()) for e in range(local_experts)}
-    baseline_counts = counts_by_expert(keep_set(0))
-    # Rotation 0 must reduce to the plain source-order ranks.
-    plain_ranks = _receiver_ranks(received_experts, local_experts=local_experts)
-    rotated_zero = _rotated_receiver_ranks(
+    ranks = _interleaved_receiver_ranks(
         received_experts,
         local_experts=local_experts,
         expert_shards=expert_shards,
         pool_capacity=pool_capacity,
-        rotation=0,
     )
-    np.testing.assert_array_equal(np.asarray(rotated_zero), np.asarray(plain_ranks))
-    for rotation in range(expert_shards):
-        np.testing.assert_array_equal(keep_set(rotation), reference_keep(rotation))
-        assert counts_by_expert(keep_set(rotation)) == baseline_counts
-    # Different rotations keep different tokens (the bias actually moves).
-    assert not np.array_equal(keep_set(0), keep_set(1))
+    keep = np.asarray((received_experts >= 0) & (ranks < receiver_capacity))
+
+    # Reference: visit each source's slot `pos` before any source's slot `pos + 1` (round-robin over
+    # sources), keeping the first `receiver_capacity` per expert.
+    counts = np.zeros(local_experts, dtype=int)
+    reference = np.zeros(send_size, dtype=bool)
+    for pos in range(pool_capacity):
+        for shard in range(expert_shards):
+            i = shard * pool_capacity + pos
+            e = int(received[i])
+            if e >= 0 and counts[e] < receiver_capacity:
+                reference[i] = True
+                counts[e] += 1
+    np.testing.assert_array_equal(keep, reference)
+
+    # Per-expert kept count is exactly min(total, capacity) -- the transpose does not change drop counts.
+    for e in range(local_experts):
+        total = int((received == e).sum())
+        assert int(((received == e) & keep).sum()) == min(total, receiver_capacity)
+
+    # Within a source, kept slots for an expert are the lowest pool positions: causality is preserved.
+    for shard in range(expert_shards):
+        block = slice(shard * pool_capacity, (shard + 1) * pool_capacity)
+        for e in range(local_experts):
+            positions = np.where(received[block] == e)[0]
+            kept_positions = positions[keep[block][positions]]
+            assert list(kept_positions) == list(positions[: len(kept_positions)])
+
+
+def test_interleaved_receiver_ranks_spread_overflow_evenly_across_sources():
+    """When every slot carries one oversubscribed expert, round-robin allocation keeps within one token
+    of `capacity / expert_shards` from each source, instead of a source-major prefix that starves the
+    last sources (the bias this replaces)."""
+    expert_shards, pool_capacity, local_experts, receiver_capacity = 4, 3, 1, 6
+    received_experts = jnp.zeros(expert_shards * pool_capacity, dtype=jnp.int32)  # all carry expert 0
+
+    ranks = _interleaved_receiver_ranks(
+        received_experts,
+        local_experts=local_experts,
+        expert_shards=expert_shards,
+        pool_capacity=pool_capacity,
+    )
+    keep = np.asarray(ranks < receiver_capacity).reshape(expert_shards, pool_capacity)
+    kept_per_source = keep.sum(axis=1)
+
+    assert int(keep.sum()) == receiver_capacity
+    assert kept_per_source.max() - kept_per_source.min() <= 1  # even, not a source prefix
+
+    # The source-major baseline instead keeps a prefix of whole sources (the starvation this fixes).
+    plain = np.asarray(_receiver_ranks(received_experts, local_experts=local_experts) < receiver_capacity).reshape(
+        expert_shards, pool_capacity
+    )
+    assert plain.sum(axis=1).max() - plain.sum(axis=1).min() == pool_capacity
 
 
 def test_moe_mlp_runs_without_ep_axis():
@@ -818,104 +838,6 @@ def test_fixed_pooled_wave_all_to_all_reports_sender_and_receiver_drops():
     np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-5)
     assert int(overflow.sender) == 3
     assert int(overflow.receiver) == 3
-
-
-def test_fixed_pooled_wave_rotation_across_expert_shards_with_replica_axis():
-    """Multi-rack shape: a `data` (replica) axis crossing a 2-shard `expert` axis. The receiver rotation
-    keys off `axis_index("expert")`, so this exercises that call when another axis is present. At high
-    capacity (no drops) the sharded output and gradients must match the dense reference -- proving the
-    rotation machinery compiles and computes correctly per expert shard on a multi-axis mesh -- and a
-    low-capacity run must still execute and report drops on both shards without error."""
-    env = os.environ.copy()
-    env["JAX_PLATFORMS"] = "cpu"
-    env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
-    script = """
-        import jax
-        import jax.numpy as jnp
-        import numpy as np
-        from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
-
-        from levanter.grug.grug_moe import moe_mlp
-
-        assert jax.device_count() == 4
-        # data=2 (the replica/rack axis) x expert=2 (the pooled-wave all-to-all axis).
-        mesh = Mesh(
-            np.asarray(jax.devices()).reshape(2, 2),
-            axis_names=("data", "expert"),
-            axis_types=(AxisType.Explicit, AxisType.Explicit),
-        )
-        tokens, hidden, inter, num_experts, topk = 8, 4, 3, 8, 2
-        x = jax.random.normal(jax.random.key(0), (tokens, hidden))
-        selected = ((jnp.arange(tokens)[:, None] + jnp.arange(topk)[None, :]) % num_experts).astype(jnp.int32)
-        combine = jax.nn.softmax(jax.random.normal(jax.random.key(1), (tokens, topk)), axis=-1)
-        w_up_gate = jax.random.normal(jax.random.key(2), (num_experts, hidden, 2 * inter))
-        w_down = jax.random.normal(jax.random.key(3), (num_experts, inter, hidden))
-        cotangent = jax.random.normal(jax.random.key(4), (tokens, hidden))
-
-        def dense(x, w_up_gate, w_down):
-            w13 = w_up_gate[selected]
-            h = jnp.einsum("th,tkhi->tki", x, w13)
-            g, u = jnp.split(h, [inter], axis=-1)
-            eo = jnp.einsum("tki,tkih->tkh", jax.nn.silu(g) * u, w_down[selected])
-            return jnp.einsum("tkh,tk->th", eo, combine)
-
-        expected = dense(x, w_up_gate, w_down)
-        expected_grads = jax.grad(
-            lambda x, a, b: jnp.sum(dense(x, a, b) * cotangent), argnums=(0, 1, 2)
-        )(x, w_up_gate, w_down)
-
-        batch_sh = NamedSharding(mesh, P(("data", "expert"), None))
-        expert_sh = NamedSharding(mesh, P("expert", None, None))
-        x = jax.device_put(x, batch_sh)
-        selected = jax.device_put(selected, batch_sh)
-        combine = jax.device_put(combine, batch_sh)
-        cotangent = jax.device_put(cotangent, batch_sh)
-        w_up_gate = jax.device_put(w_up_gate, expert_sh)
-        w_down = jax.device_put(w_down, expert_sh)
-
-        def pooled(x, a, b, capacity):
-            return moe_mlp(
-                x, selected, combine, a, b,
-                activation=jax.nn.silu,
-                implementation="fixed_pooled_wave_all_to_all",
-                mesh=mesh,
-                capacity_factor=capacity,
-                pooled_transport_capacity_factor=capacity,
-                num_expert_waves=2,
-            )
-
-        with jax.set_mesh(mesh):
-            actual = pooled(x, w_up_gate, w_down, 4.0)
-            actual_grads = jax.grad(
-                lambda x, a, b: jnp.sum(pooled(x, a, b, 4.0) * cotangent), argnums=(0, 1, 2)
-            )(x, w_up_gate, w_down)
-
-            # Low capacity: the rotation-with-drops path must execute on both shards and report drops.
-            _, overflow = moe_mlp(
-                x, selected, combine, w_up_gate, w_down,
-                activation=jax.nn.silu,
-                implementation="fixed_pooled_wave_all_to_all",
-                mesh=mesh,
-                capacity_factor=0.5,
-                pooled_transport_capacity_factor=0.5,
-                num_expert_waves=2,
-                report_capacity_overflow=True,
-            )
-
-        np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-5)
-        for a, e in zip(actual_grads, expected_grads, strict=True):
-            np.testing.assert_allclose(np.asarray(a), np.asarray(e), rtol=1e-5, atol=1e-5)
-        assert int(overflow.sender) + int(overflow.receiver) > 0
-        assert jnp.isfinite(actual).all()
-    """
-    result = subprocess.run(
-        [sys.executable, "-c", textwrap.dedent(script)],
-        env=env,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    assert result.returncode == 0, result.stderr
 
 
 def test_fixed_all_to_all_matches_dense_cross_shard_value_and_gradients():

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -861,3 +861,28 @@ def test_drop_metrics_reports_sender_and_receiver_fractions():
         "moe/receiver_drop_fraction": 3 / 16,
         "moe/receiver_drop_fraction_of_received": 3 / 14,
     }
+
+
+def test_drop_metrics_sums_per_layer_counts_in_int64_without_overflow():
+    # Per-layer int32 counts whose 48-layer sum exceeds int32 (jax_enable_x64 is off, so an in-device
+    # jnp.sum would wrap and break the total==sender+receiver check). The host sum must stay exact.
+    num_layers = 48
+    per_layer_sender = jnp.full((num_layers,), 40_000_000, dtype=jnp.int32)  # 48 * 40M = 1.92e9
+    per_layer_receiver = jnp.full((num_layers,), 60_000_000, dtype=jnp.int32)  # 48 * 60M = 2.88e9 > int32
+    per_layer_total = per_layer_sender + per_layer_receiver
+    sender_total = 48 * 40_000_000
+    receiver_total = 48 * 60_000_000
+
+    metrics = train._drop_metrics(
+        per_layer_total,
+        per_layer_sender,
+        per_layer_receiver,
+        batch_size=4096,
+        sequence_length=4096,
+        top_k=8,
+        num_layers=num_layers,
+    )
+
+    assert metrics["moe/dropped_assignments"] == sender_total + receiver_total  # no int32 wrap
+    assert metrics["moe/sender_dropped_assignments"] == sender_total
+    assert metrics["moe/receiver_dropped_assignments"] == receiver_total

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -55,7 +55,7 @@ def test_hero_run_without_shape_overrides_uses_the_selected_model():
         8,
         3072,
         1.15,
-        1.10,
+        1.15,
         3,
         "fixed_pooled_wave_all_to_all",
         1024,
@@ -444,9 +444,15 @@ def test_ep_ablation_defaults_match_the_documented_arm_and_scale_per_rack():
     one = abl.build_small_run(run_id="d768", size="d768", flavor="ep", version="dev")
     cfg = one.build_config(StepContext.for_fingerprint(one.runtime_args, one.deps))
     m = cfg.model
-    # The EP rung is a downsized hero: latent = hidden/2, capacity 1.33, top-k QB (the hero default).
+    # The EP rung is a downsized hero: pooled-wave transport, 384 experts / top-8, hidden/2-wide experts
+    # in a hidden/2 latent, receiver/sender capacity 1.15 with 3 waves, and top-k QB (the hero default).
+    assert m.moe_implementation == "fixed_pooled_wave_all_to_all"
+    assert (m.num_experts, m.num_experts_per_token) == (384, 8)
+    assert m.intermediate_dim == m.hidden_dim // 2
     assert m.latent_dim == m.hidden_dim // 2
-    assert m.capacity_factor == 1.33
+    assert m.capacity_factor == 1.15
+    assert m.pooled_transport_capacity_factor == 1.15
+    assert m.num_expert_waves == 3
     assert m.qb_estimator == model.QbEstimator.TOPK
     assert m.num_layers % 2 == 0  # even depth applied in the launcher, not GrugModelConfig
     # The histogram QB estimator is selectable on through the builder.


### PR DESCRIPTION
Follow-up to #8348 (now merged), carrying the parts unique to this work. Three things:

**Receiver-overflow fairness.** The pooled-wave transport delivers received tokens in a fixed source order at every receiver, so a single (last-ordered) sender shard absorbs the receiver overflow *everywhere* — a deterministic, data-correlated drop bias rather than unbiased noise. #8348 reports the sender/receiver split but does not fix this. Each receiver now rotates its capacity priority by its own expert-axis index, so a different source is truncated first per receiver and overflow spreads evenly across senders. The rotation rolls only the integer rank metadata `[expert_shards, pool_capacity]` — no all-to-all traffic, no payload movement — and leaves the per-expert drop *count* unchanged (only *which* tokens drop). Rotation 0 reduces to the old ranks, so single-shard/EP1 is unaffected. A regression test asserts the rotated keep-set matches "keep the first `capacity` per expert in rotated source order," the drop count is rotation-invariant, and rotation 0 equals the plain ranks.

**Ablation ladder → hero shape.** `small_scale_abl_launch.py` now mirrors the current hero by default: pooled-wave transport, 384 experts / top-8, `hidden/2`-wide experts in a `hidden/2` latent, 1.15 receiver / 1.15 sender capacity, 3 receiver waves (replacing the legacy fixed-all-to-all, 192 / top-4, hidden-wide, 1.33 defaults). A guard rejects `--num-experts` whose local expert count doesn't divide the wave count.

**Capacity.** Sender capacity factor 1.10 → 1.15, so both gates are 1.15 (the recommended arm).
