### PR TITLE
Refine pooled-wave MoE transport

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -616,14 +616,14 @@ class MoEMLP(eqx.Module):
             out_specs=P(),
         )(s_minus_alpha)
 
-        routed_flat, dropped_assignments = self.expert_mlp(
+        routed_flat, capacity_overflow = self.expert_mlp(
             x_flat,
             selected_experts.astype(jnp.int32),
             combine_weights,
             mesh=get_abstract_mesh(),
             report_capacity_overflow=True,
         )
-        router_stats["capacity_overflow"] = dropped_assignments.astype(jnp.float32)
+        router_stats["capacity_overflow"] = capacity_overflow.total.astype(jnp.float32)
 
         routed = rearrange(routed_flat, "(b s) d -> b s d", b=b, s=s)
         routed = reshard(routed, _batch_spec())

--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -18,25 +18,33 @@ data-parallel rack uses one 64-device expert mesh.
 - MoE backend: `fixed_pooled_wave_all_to_all`. Each sender uses one fixed pool per
   destination and stripes it over three static waves. The receiver runs all six local experts in
   each wave and drops rows above the fixed expert capacity. Expert IDs travel in the activation
-  payload, so the method does not use a metadata collective. The receiver capacity factor is 1.33,
-  and the sender capacity factor is 1.05. Each wave has receiver capacity equal to two full expert
-  buffers.
+  payload, so the method does not use a metadata collective. The receiver capacity factor is 1.15,
+  and the sender capacity factor is 1.10.
 - Optimizer: MuonH, with its state offloaded to pinned host memory.
 - Runtime: one JAX process per four-GPU worker, BF16 parameters and compute, GPU command buffers
   off, `cuda_async`, PGLE off, and collective overlap limit 4.
 - Output: Metrics only by default. `--save-checkpoints` writes checkpoints, but restore with the
   pinned-host optimizer state has a known memory-kind mismatch. Do not use these checkpoints to
-  restart a run.
+  restart a run. Drop metrics include the sender and receiver shares of all assignments. The
+  receiver also reports its drop share of assignments that reached it.
 
 The attention, shared-expert, language-model-head, and optimizer states use the combined `data` and
 `expert` axes. The expert axis stays sharded during Newton-Schulz.
 
-## Result
+## Results
 
-The selected configuration completed 200 steps on one rack. Over steps 150 through 199, median
-throughput was 256,818 tokens/s and median MFU was 24.03%. Median routing drop rate was 2.41%, and
-the final drop rate was 2.21%. The final loss was 3.2510. All 16 workers completed without an OOM,
-nonfinite value, failure, or preemption. See the
+The current 1.10 sender and 1.15 receiver configuration completed a 20-step, one-rack gate. Median
+throughput over steps 2 through 19 was 250,691 tokens/s, and final throughput was 246,947 tokens/s.
+The final loss was 6.3224. The final total drop rate was 19.33%: 7.14% at the sender and 12.19% at
+the receiver. The receiver dropped 13.12% of assignments that reached it. This short gate validates
+memory use and metric reporting. It does not estimate the steady drop rate. All 16 workers completed
+without an OOM, nonfinite value, failure, or preemption. See the
+[W&B run](https://wandb.ai/marin-community/rav_moe/runs/mhep-118-recv-metrics-send110-recv115-smoke).
+
+The prior 1.05 sender and 1.33 receiver configuration completed 200 steps on one rack. Over steps
+150 through 199, median throughput was 256,818 tokens/s and median MFU was 24.03%. Median routing
+drop rate was 2.41%, and the final drop rate was 2.21%. The final loss was 3.2510. All 16 workers
+completed without an OOM, nonfinite value, failure, or preemption. See the
 [W&B run](https://wandb.ai/marin-community/rav_moe/runs/mhep-103-bf16params-pooled-striped-wave2-send105-recv133-200-20260814)
 and the [XProf trace](https://iris.oa.dev/proxy/xprof/open?uri=s3%3A%2F%2Fmarin-us-east-02a%2Ftmp%2Fttl%3D30d%2Fxprof%2Fmhep-101-bf16params-pooled-striped-wave2-send105-recv133-profile-20260814&tool=trace_viewer).
 
@@ -77,7 +85,7 @@ Three quantities set what a sweep can fit on one rack:
 - The sender pool is token assignments multiplied by the sender capacity factor and divided across
   three waves.
 
-The selected E384 model runs at expert width 3072 and capacity factor 1.33.
+The selected E384 model runs at expert width 3072 and receiver capacity factor 1.15.
 
 ## Run Controls
 

--- a/experiments/grug/moe_hero_ep/heuristic.py
+++ b/experiments/grug/moe_hero_ep/heuristic.py
@@ -10,7 +10,7 @@ pairs it with the fixed hero model spec so a launcher gets both configs back fro
 
 The hero model is d6144 with 48 layers and 384 routed experts. Each expert has width 3,072, and
 the router selects eight experts per token. The pooled transport uses three static waves. The
-receiver capacity factor is 1.33, and the sender capacity factor is 1.05.
+receiver capacity factor is 1.15, and the sender capacity factor is 1.10.
 """
 
 import math
@@ -100,13 +100,13 @@ HERO_MODEL = GrugModelConfig(
     max_seq_len=4096,
     sliding_window=2048,
     global_every=4,
-    capacity_factor=1.33,
+    capacity_factor=1.15,
     initializer_std=0.5 / math.sqrt(_HERO_HIDDEN),
     qk_mult=1.3,
     sconv=True,
     attention_implementation="gpu_fa4_cute",
     moe_implementation="fixed_pooled_wave_all_to_all",
-    pooled_transport_capacity_factor=1.05,
+    pooled_transport_capacity_factor=1.10,
     num_expert_waves=3,
     expert_chunks=1,
     report_capacity_overflow=True,

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -712,11 +712,15 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
     load_balancing_loss = router_metrics["load_balancing_loss_per_layer"]
     router_z_loss = router_metrics["router_z_loss_per_layer"]
     capacity_overflow = router_metrics["capacity_overflow_per_layer"]
+    sender_capacity_overflow = router_metrics["sender_capacity_overflow_per_layer"]
+    receiver_capacity_overflow = router_metrics["receiver_capacity_overflow_per_layer"]
     num_layers = int(routing_entropy.shape[0])
 
     # Per-layer total assignments = sum of routing_counts over experts (= tokens * k).
     assignments_per_layer = jnp.sum(routing_counts.astype(jnp.float32), axis=-1)
     capacity_overflow_rate = capacity_overflow.astype(jnp.float32) / jnp.maximum(assignments_per_layer, 1.0)
+    sender_overflow_rate = sender_capacity_overflow.astype(jnp.float32) / jnp.maximum(assignments_per_layer, 1.0)
+    receiver_overflow_rate = receiver_capacity_overflow.astype(jnp.float32) / jnp.maximum(assignments_per_layer, 1.0)
 
     out: dict[str, jax.Array | SummaryStats] = {
         "train/router/routing_entropy_mean": jnp.mean(routing_entropy),
@@ -724,6 +728,8 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
         "train/router/router_z_loss": jnp.mean(router_z_loss),
         "train/router/routing_counts_per_layer": routing_counts,
         "train/router/capacity_overflow_rate_mean": jnp.mean(capacity_overflow_rate),
+        "train/router/sender_overflow_rate_mean": jnp.mean(sender_overflow_rate),
+        "train/router/receiver_overflow_rate_mean": jnp.mean(receiver_overflow_rate),
         "qb_beta_per_layer": router_metrics.get("qb_beta_per_layer"),
     }
     for i in range(num_layers):
@@ -953,11 +959,18 @@ class MoEMLP(eqx.Module):
             report_capacity_overflow=self.cfg.report_capacity_overflow,
         )
         if self.cfg.report_capacity_overflow:
-            routed_flat, dropped_assignments = moe_out
+            routed_flat, capacity_overflow = moe_out
+            dropped_assignments = capacity_overflow.total
+            sender_dropped_assignments = capacity_overflow.sender
+            receiver_dropped_assignments = capacity_overflow.receiver
         else:
             routed_flat = moe_out
             dropped_assignments = _zero_dropped_assignments()
+            sender_dropped_assignments = _zero_dropped_assignments()
+            receiver_dropped_assignments = _zero_dropped_assignments()
         router_stats["capacity_overflow"] = dropped_assignments
+        router_stats["sender_capacity_overflow"] = sender_dropped_assignments
+        router_stats["receiver_capacity_overflow"] = receiver_dropped_assignments
 
         # Expand after the combine: `expert_mlp` already returns the weight-summed expert output,
         # which is the vector the paper's W_up acts on.
@@ -1178,6 +1191,8 @@ class Transformer(eqx.Module):
             "router_z_loss_per_layer": stacked_router_stats["router_z_loss"],
             "qb_beta_per_layer": stacked_router_stats["qb_beta"],
             "capacity_overflow_per_layer": stacked_router_stats["capacity_overflow"],
+            "sender_capacity_overflow_per_layer": stacked_router_stats["sender_capacity_overflow"],
+            "receiver_capacity_overflow_per_layer": stacked_router_stats["receiver_capacity_overflow"],
         }
         hidden = self.final_gated_norm(self.final_norm(hidden))
         return hidden, router_metrics
@@ -1232,6 +1247,12 @@ class Transformer(eqx.Module):
             )
             if self.config.report_capacity_overflow:
                 summarized_metrics["moe/dropped_assignments"] = jnp.sum(router_metrics["capacity_overflow_per_layer"])
+                summarized_metrics["moe/sender_dropped_assignments"] = jnp.sum(
+                    router_metrics["sender_capacity_overflow_per_layer"]
+                )
+                summarized_metrics["moe/receiver_dropped_assignments"] = jnp.sum(
+                    router_metrics["receiver_capacity_overflow_per_layer"]
+                )
             return loss, summarized_metrics
         return loss
 

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -417,13 +417,15 @@ def initial_state(
     offload_opt_state: bool = False,
     master_param_mode: MasterParamMode = MasterParamMode.DISABLED,
 ) -> GrugTrainState:
-    params = mp.cast_to_param(Transformer.init(model_config, key=key))
+    initialized_params = Transformer.init(model_config, key=key)
     num_moe_layers = model_config.num_layers
     if master_param_mode == MasterParamMode.FP32_PINNED_HOST:
-        master_params = _FP32_POLICY.cast_to_param(params)
+        master_params = _FP32_POLICY.cast_to_param(initialized_params)
+        params = mp.cast_to_param(master_params)
         opt_state = optimizer.init(master_params)
         master_params = _tree_to_memory_kind(master_params, "pinned_host")
     else:
+        params = mp.cast_to_param(initialized_params)
         master_params = None
         opt_state = optimizer.init(params)
     if offload_opt_state:
@@ -440,6 +442,8 @@ def initial_state(
 
 def _drop_metrics(
     dropped_assignments: jax.Array,
+    sender_dropped_assignments: jax.Array,
+    receiver_dropped_assignments: jax.Array,
     *,
     batch_size: int,
     sequence_length: int,
@@ -448,10 +452,20 @@ def _drop_metrics(
 ) -> dict[str, int | float]:
     # Global assignment totals can exceed int32; float32 would also round large drop counts.
     dropped_assignments_host = int(dropped_assignments)
+    sender_dropped_assignments_host = int(sender_dropped_assignments)
+    receiver_dropped_assignments_host = int(receiver_dropped_assignments)
+    if dropped_assignments_host != sender_dropped_assignments_host + receiver_dropped_assignments_host:
+        raise ValueError("total dropped assignments must equal sender plus receiver dropped assignments")
     total_assignments = batch_size * sequence_length * top_k * num_layers
+    receiver_assignments = total_assignments - sender_dropped_assignments_host
     return {
         "moe/dropped_assignments": dropped_assignments_host,
         "moe/drop_fraction": dropped_assignments_host / total_assignments,
+        "moe/sender_dropped_assignments": sender_dropped_assignments_host,
+        "moe/sender_drop_fraction": sender_dropped_assignments_host / total_assignments,
+        "moe/receiver_dropped_assignments": receiver_dropped_assignments_host,
+        "moe/receiver_drop_fraction": receiver_dropped_assignments_host / total_assignments,
+        "moe/receiver_drop_fraction_of_received": receiver_dropped_assignments_host / max(receiver_assignments, 1),
     }
 
 
@@ -843,6 +857,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                     if "moe/dropped_assignments" in metrics:
                         drop_metrics = _drop_metrics(
                             metrics["moe/dropped_assignments"],
+                            metrics["moe/sender_dropped_assignments"],
+                            metrics["moe/receiver_dropped_assignments"],
                             batch_size=batch.tokens.shape[0],
                             sequence_length=batch.tokens.shape[1],
                             top_k=config.model.num_experts_per_token,

--- a/experiments/grug/moe_hero_fsdp/model.py
+++ b/experiments/grug/moe_hero_fsdp/model.py
@@ -837,7 +837,8 @@ class MoEMLP(eqx.Module):
             report_capacity_overflow=self.cfg.report_capacity_overflow,
         )
         if self.cfg.report_capacity_overflow:
-            routed_flat, dropped_assignments = moe_out
+            routed_flat, capacity_overflow = moe_out
+            dropped_assignments = capacity_overflow.total
         else:
             routed_flat = moe_out
             dropped_assignments = _zero_dropped_assignments()

--- a/experiments/june_tpu_67b_a2b/moe/model.py
+++ b/experiments/june_tpu_67b_a2b/moe/model.py
@@ -588,14 +588,14 @@ class MoEMLP(eqx.Module):
             out_specs=P(),
         )(s_minus_alpha)
 
-        routed_flat, dropped_assignments = self.expert_mlp(
+        routed_flat, capacity_overflow = self.expert_mlp(
             x_flat,
             selected_experts.astype(jnp.int32),
             combine_weights,
             mesh=get_abstract_mesh(),
             report_capacity_overflow=True,
         )
-        router_stats["capacity_overflow"] = dropped_assignments.astype(jnp.float32)
+        router_stats["capacity_overflow"] = capacity_overflow.total.astype(jnp.float32)
 
         routed = rearrange(routed_flat, "(b s) d -> b s d", b=b, s=s)
         routed = reshard(routed, _batch_spec())

--- a/lib/levanter/src/levanter/grug/_moe/common.py
+++ b/lib/levanter/src/levanter/grug/_moe/common.py
@@ -5,7 +5,7 @@
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Literal, TypeAlias, cast, get_args
+from typing import Literal, NamedTuple, TypeAlias, cast, get_args
 
 import jax
 import jax.numpy as jnp
@@ -61,6 +61,17 @@ MOE_REMAT_SAVE_NAMES = (
     _CHECKPOINT_DISPATCH_OUTPUT,
     _CHECKPOINT_MOE_OUTPUT,
 )
+
+
+class CapacityOverflow(NamedTuple):
+    """Expert assignments dropped before and after transport."""
+
+    sender: Int[Array, ""]
+    receiver: Int[Array, ""]
+
+    @property
+    def total(self) -> Int[Array, ""]:
+        return self.sender + self.receiver
 
 
 @dataclass(frozen=True)

--- a/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
@@ -19,6 +19,7 @@ from levanter.grug._moe.common import (
     _CHECKPOINT_DISPATCH_INPUT,
     _CHECKPOINT_DISPATCH_OUTPUT,
     _CHECKPOINT_EXPERT_HIDDEN,
+    CapacityOverflow,
     split_moe_w13_output,
 )
 from levanter.kernels.deepep import deepep_combine_intranode, deepep_dispatch_intranode, deepep_get_dispatch_layout
@@ -107,7 +108,7 @@ def _moe_mlp_ep_deepep_local(
     activation_fn: Callable[[jax.Array], jax.Array],
     num_experts: int,
     capacity_factor: float,
-) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
+) -> tuple[Float[Array, "Tlocal H"], CapacityOverflow]:
     """DeepEP dispatch/combine path for an intranode expert mesh."""
     del capacity_factor
     local_experts = moe_w13_local.shape[0]
@@ -192,4 +193,7 @@ def _moe_mlp_ep_deepep_local(
                 is_token_in_rank,
             )
         dropped_total = jnp.array(0, dtype=jnp.int32)
-    return out_local.astype(x_local.dtype), dropped_total
+    return out_local.astype(x_local.dtype), CapacityOverflow(
+        sender=dropped_total,
+        receiver=jnp.zeros_like(dropped_total),
+    )

--- a/lib/levanter/src/levanter/grug/_moe/ep_fixed_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_fixed_all_to_all.py
@@ -11,7 +11,7 @@ import jax.numpy as jnp
 from jaxtyping import Array, Float, Int
 
 from haliax.jax_utils import tree_checkpoint_name
-from levanter.grug._moe.common import _CHECKPOINT_DISPATCH_INPUT, _CHECKPOINT_MOE_OUTPUT
+from levanter.grug._moe.common import _CHECKPOINT_DISPATCH_INPUT, _CHECKPOINT_MOE_OUTPUT, CapacityOverflow
 from levanter.grug.sharding import _batch_axes
 
 
@@ -84,7 +84,7 @@ def _moe_mlp_ep_fixed_a2a_local(
     activation_fn: Callable[[jax.Array], jax.Array],
     num_experts: int,
     capacity_factor: float,
-) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
+) -> tuple[Float[Array, "Tlocal H"], CapacityOverflow]:
     """Run fixed-capacity all-to-all dispatch, expert MLPs, and combine.
 
     ``capacity_factor`` scales each fixed (sender shard, global expert) cell as
@@ -178,4 +178,4 @@ def _moe_mlp_ep_fixed_a2a_local(
         ).astype(x_local.dtype)
         dropped_local = assignments_per_shard - jnp.sum(keep, dtype=jnp.int32)
         dropped_total = jax.lax.psum(dropped_local, _batch_axes(jax.sharding.get_abstract_mesh()))
-    return out_local, dropped_total
+    return out_local, CapacityOverflow(sender=dropped_total, receiver=jnp.zeros_like(dropped_total))

--- a/lib/levanter/src/levanter/grug/_moe/ep_fixed_pooled_wave_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_fixed_pooled_wave_all_to_all.py
@@ -12,6 +12,7 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float, Int
 
+from levanter.grug._moe.common import CapacityOverflow
 from levanter.grug._moe.ep_common import _assignment_sources, _ranks_within_groups, _token_sources
 from levanter.grug._moe.sonic import sonic_gather_sum_available, sonic_gather_sum_masked
 from levanter.grug.sharding import _batch_axes
@@ -480,8 +481,8 @@ def _moe_mlp_ep_fixed_pooled_wave_a2a_local(
     capacity_factor: float,
     transport_capacity_factor: float,
     num_expert_waves: int,
-) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
-    """Stripe each destination pool over fixed waves with bounded receiver buffers."""
+) -> tuple[Float[Array, "Tlocal H"], CapacityOverflow]:
+    """Stripe each destination pool over fixed waves and report drops at each transport stage."""
     local_experts = moe_w13_local.shape[0]
     if num_experts % local_experts != 0:
         raise ValueError(f"num_experts={num_experts} must be divisible by local expert count={local_experts}")
@@ -555,12 +556,13 @@ def _moe_mlp_ep_fixed_pooled_wave_a2a_local(
             expert_shards=expert_shards,
             pool_capacity=pool_capacity,
         )
-        pooled_dispatch = remat(dispatch)()
+        pooled_dispatch = dispatch()
         pooled_output = remat(compute)(pooled_dispatch)
         out_local = out_local + remat(combine)(pooled_output)
         receiver_dropped = receiver_dropped + pooled_dispatch.receiver_dropped
 
     sender_dropped = assignments_per_shard - jnp.sum(sender_keep, dtype=jnp.int32)
-    dropped_local = sender_dropped + receiver_dropped
-    dropped_total = jax.lax.psum(dropped_local, _batch_axes(jax.sharding.get_abstract_mesh()))
-    return out_local.astype(x_local.dtype), dropped_total
+    dropped_by_stage_local = jnp.stack((sender_dropped, receiver_dropped))
+    dropped_by_stage = jax.lax.psum(dropped_by_stage_local, _batch_axes(jax.sharding.get_abstract_mesh()))
+    overflow = CapacityOverflow(sender=dropped_by_stage[0], receiver=dropped_by_stage[1])
+    return out_local.astype(x_local.dtype), overflow

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 from jaxtyping import Array, Float, Int
 
 from haliax.nn.ragged_dot import ragged_dot
+from levanter.grug._moe.common import CapacityOverflow
 from levanter.grug._moe.ep_common import (
     _clip_receiver_group_sizes,
     _compact_by_keep_mask,
@@ -35,7 +36,7 @@ def _moe_mlp_ep_ragged_a2a_local(
     activation_fn: Callable[[jax.Array], jax.Array],
     num_experts: int,
     capacity_factor: float,
-) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
+) -> tuple[Float[Array, "Tlocal H"], CapacityOverflow]:
     local_experts = moe_w13_local.shape[0]
     if num_experts % local_experts != 0:
         raise ValueError(
@@ -121,4 +122,4 @@ def _moe_mlp_ep_ragged_a2a_local(
         ).astype(x_local.dtype)
         dropped_local = jnp.sum(group_sizes, dtype=jnp.int32) - jnp.sum(sender_group_sizes, dtype=jnp.int32)
         dropped_total = jax.lax.psum(dropped_local, _batch_axes(jax.sharding.get_abstract_mesh()))
-    return out_local, dropped_total
+    return out_local, CapacityOverflow(sender=dropped_total, receiver=jnp.zeros_like(dropped_total))

--- a/lib/levanter/src/levanter/grug/_moe/ep_ring.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ring.py
@@ -16,6 +16,7 @@ from levanter.grug._moe.common import (
     _CHECKPOINT_DISPATCH_INPUT,
     _CHECKPOINT_DISPATCH_OUTPUT,
     _CHECKPOINT_EXPERT_HIDDEN,
+    CapacityOverflow,
 )
 from levanter.grug._moe.ep_common import _prefix_cap_counts
 from levanter.grug.sharding import _batch_axes
@@ -31,7 +32,7 @@ def _moe_mlp_ep_ring_local(
     activation_fn: Callable[[jax.Array], jax.Array],
     num_experts: int,
     capacity_factor: float,
-) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
+) -> tuple[Float[Array, "Tlocal H"], CapacityOverflow]:
     """Ring-style EP routed path: all-gather dispatch + psum-scatter collect."""
     # #2710 ring EP strategy: gather tokens and their selected-expert routing
     # assignments across expert shards, then psum-scatter back to local tokens.
@@ -113,4 +114,4 @@ def _moe_mlp_ep_ring_local(
         # reducing contributions from experts across the EP mesh.
         out_local = jax.lax.psum_scatter(out_global, "expert", scatter_dimension=0, tiled=True)
         dropped_total = jax.lax.psum(dropped_local, _batch_axes(jax.sharding.get_abstract_mesh()))
-    return out_local, dropped_total
+    return out_local, CapacityOverflow(sender=jnp.zeros_like(dropped_total), receiver=dropped_total)

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -29,6 +29,7 @@ from levanter.grug._moe.common import (
     _DEFAULT_EP_CAPACITY_FACTOR,
     _EP_MOE_IMPLEMENTATIONS,
     _init_weight,
+    CapacityOverflow,
     MOE_REMAT_SAVE_NAMES as MOE_REMAT_SAVE_NAMES,
     MoEExpertMlpPspecs,
     MoeActivation,
@@ -124,7 +125,7 @@ class MoEExpertMlp(eqx.Module):
         *,
         mesh: jax.sharding.AbstractMesh | None = None,
         report_capacity_overflow: bool = False,
-    ) -> Float[Array, "T D"] | tuple[Float[Array, "T D"], Int[Array, ""]]:
+    ) -> Float[Array, "T D"] | tuple[Float[Array, "T D"], CapacityOverflow]:
         w_gate_up = jnp.concatenate([self.w_gate, self.w_up], axis=-1)
         return moe_mlp(
             x,
@@ -159,15 +160,15 @@ def moe_mlp(
     report_capacity_overflow: bool = False,
     expert_chunks: int = 1,
     num_expert_waves: int = 1,
-) -> Float[Array, "T D"] | tuple[Float[Array, "T D"], Int[Array, ""]]:
+) -> Float[Array, "T D"] | tuple[Float[Array, "T D"], CapacityOverflow]:
     """Functional routed MoE MLP core used by Grug modules and benchmarks.
 
     This helper handles dispatch/permute/unpermute (+EP collectives) from
     precomputed token-to-expert assignments. Routing logits/top-k selection
     stays in the caller (e.g. model MLP block).
 
-    Set `report_capacity_overflow=True` to also return a scalar count of
-    dropped expert assignments from EP capacity clipping.
+    Set `report_capacity_overflow=True` to also return sender and receiver
+    counts for expert assignments dropped by EP capacity clipping.
 
     `expert_chunks` applies only to the local `sonic_cute` FSDP path. Values
     greater than one split the expert bank into equal, statically sized chunks.
@@ -223,7 +224,7 @@ def moe_mlp(
             expert_chunks=expert_chunks,
         )
         if report_capacity_overflow:
-            return out, dropped
+            return out, CapacityOverflow(sender=dropped, receiver=jnp.zeros_like(dropped))
         return out
 
     batch_spec = _batch_spec_from_x(x, mesh)
@@ -283,12 +284,12 @@ def moe_mlp(
                 w_up_gate_spec,
                 w_down_spec,
             ),
-            out_specs=(batch_spec, P()),
+            out_specs=(batch_spec, CapacityOverflow(sender=P(), receiver=P())),
             check_vma=False,
         )
-        out, dropped = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        out, overflow = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
         if report_capacity_overflow:
-            return out, dropped
+            return out, overflow
         return out
 
     # Fallback path for no expert axis (or expert axis size 1) keeps routing
@@ -353,11 +354,12 @@ def moe_mlp(
     )
     out, dropped = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
     if report_capacity_overflow:
-        return out, dropped
+        return out, CapacityOverflow(sender=dropped, receiver=jnp.zeros_like(dropped))
     return out
 
 
 __all__ = [
+    "CapacityOverflow",
     "MoeActivation",
     "MoEExpertMlp",
     "MoEExpertMlpPspecs",

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -13,11 +13,16 @@ import pytest
 import jax
 import jax.numpy as jnp
 from jax._src import config as jax_config
+from jax.extend import core as jax_core
 from jax.sharding import AbstractMesh, AxisType, Mesh, NamedSharding, PartitionSpec as P, use_abstract_mesh
 from haliax.nn.ragged_dot import ragged_dot
 
 import levanter.grug.grug_moe as grug_moe
-from levanter.grug._moe.common import _prepare_moe_dispatch, _prepare_moe_dispatch_indices_with_assignment_ids
+from levanter.grug._moe.common import (
+    _prepare_moe_dispatch,
+    _prepare_moe_dispatch_indices_with_assignment_ids,
+    CapacityOverflow,
+)
 from levanter.grug._moe.ep_deepep import _pack_deepep_local_assignments
 from levanter.grug._moe.ep_fixed_all_to_all import _moe_mlp_ep_fixed_a2a_local
 from levanter.grug._moe.ep_fixed_pooled_wave_all_to_all import _moe_mlp_ep_fixed_pooled_wave_a2a_local
@@ -72,6 +77,18 @@ def _make_single_expert_mesh() -> Mesh:
         axis_names=("expert",),
         axis_types=(AxisType.Explicit,),
     )
+
+
+def _count_jaxpr_primitives(value, primitive_name: str) -> int:
+    if isinstance(value, jax_core.Jaxpr):
+        return sum(eqn.primitive.name == primitive_name for eqn in value.eqns) + sum(
+            _count_jaxpr_primitives(param, primitive_name) for eqn in value.eqns for param in eqn.params.values()
+        )
+    if isinstance(value, dict):
+        return sum(_count_jaxpr_primitives(item, primitive_name) for item in value.values())
+    if isinstance(value, (tuple, list)):
+        return sum(_count_jaxpr_primitives(item, primitive_name) for item in value)
+    return 0
 
 
 class _reset_abstract_mesh:
@@ -551,11 +568,11 @@ def test_fixed_all_to_all_drops_assignments_over_capacity():
         fixed_a2a,
         mesh=mesh,
         in_specs=(P(), P(), P(), P(), P()),
-        out_specs=(P(), P()),
+        out_specs=(P(), CapacityOverflow(sender=P(), receiver=P())),
         check_vma=False,
     )
     with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
-        actual, dropped = sharded_fixed_a2a(x, selected_experts, combine_weights, w_up_gate, w_down)
+        actual, overflow = sharded_fixed_a2a(x, selected_experts, combine_weights, w_up_gate, w_down)
 
     keep = jnp.asarray([[True, True], [True, True], [False, False], [False, False]])
 
@@ -593,7 +610,8 @@ def test_fixed_all_to_all_drops_assignments_over_capacity():
             rtol=1e-5,
             atol=1e-5,
         )
-    assert int(dropped) == 4
+    assert int(overflow.sender) == 4
+    assert int(overflow.receiver) == 0
 
 
 @pytest.mark.timeout(180)
@@ -604,6 +622,7 @@ def test_fixed_pooled_wave_all_to_all_matches_dense_value_and_gradients():
     intermediate_dim = 3
     num_experts = 6
     topk = 2
+    num_expert_waves = 3
     x, _, combine_weights, w_up_gate, w_down = _make_inputs(
         key=jax.random.key(49),
         tokens=tokens,
@@ -629,7 +648,7 @@ def test_fixed_pooled_wave_all_to_all_matches_dense_value_and_gradients():
             num_experts=num_experts,
             capacity_factor=4.0,
             transport_capacity_factor=4.0,
-            num_expert_waves=3,
+            num_expert_waves=num_expert_waves,
         )[0]
 
     sharded_pooled_output = jax.shard_map(
@@ -639,6 +658,7 @@ def test_fixed_pooled_wave_all_to_all_matches_dense_value_and_gradients():
         out_specs=P(),
         check_vma=False,
     )
+    rematerialized_pooled_output = jax.checkpoint(sharded_pooled_output)
 
     def dense_output(x, combine_weights, w_up_gate, w_down):
         selected_w13 = w_up_gate[selected_experts]
@@ -653,12 +673,20 @@ def test_fixed_pooled_wave_all_to_all_matches_dense_value_and_gradients():
 
     with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
         actual = sharded_pooled_output(x, combine_weights, w_up_gate, w_down)
-        actual_gradients = jax.grad(
+        actual_gradient_fn = jax.grad(
             lambda x, combine_weights, w_up_gate, w_down: jnp.sum(
                 sharded_pooled_output(x, combine_weights, w_up_gate, w_down) * cotangent
             ),
             argnums=(0, 1, 2, 3),
-        )(x, combine_weights, w_up_gate, w_down)
+        )
+        actual_gradients = actual_gradient_fn(x, combine_weights, w_up_gate, w_down)
+        rematerialized_gradient_fn = jax.grad(
+            lambda x, combine_weights, w_up_gate, w_down: jnp.sum(
+                rematerialized_pooled_output(x, combine_weights, w_up_gate, w_down) * cotangent
+            ),
+            argnums=(0, 1, 2, 3),
+        )
+        gradient_jaxpr = jax.make_jaxpr(rematerialized_gradient_fn)(x, combine_weights, w_up_gate, w_down)
         expected = dense_output(x, combine_weights, w_up_gate, w_down)
         expected_gradients = jax.grad(
             lambda x, combine_weights, w_up_gate, w_down: jnp.sum(
@@ -675,6 +703,7 @@ def test_fixed_pooled_wave_all_to_all_matches_dense_value_and_gradients():
             rtol=1e-5,
             atol=1e-5,
         )
+    assert _count_jaxpr_primitives(gradient_jaxpr, "all_to_all") == 6 * num_expert_waves
 
 
 def test_fixed_pooled_wave_all_to_all_reports_sender_and_receiver_drops():
@@ -712,11 +741,11 @@ def test_fixed_pooled_wave_all_to_all_reports_sender_and_receiver_drops():
         pooled_output,
         mesh=mesh,
         in_specs=(P(), P(), P(), P()),
-        out_specs=(P(), P()),
+        out_specs=(P(), CapacityOverflow(sender=P(), receiver=P())),
         check_vma=False,
     )
     with jax.set_mesh(mesh):
-        actual, dropped = sharded_pooled_output(x, combine_weights, w_up_gate, w_down)
+        actual, overflow = sharded_pooled_output(x, combine_weights, w_up_gate, w_down)
 
     selected_w13 = w_up_gate[selected_experts]
     hidden = jnp.einsum("th,tkhi->tki", x, selected_w13)
@@ -730,7 +759,8 @@ def test_fixed_pooled_wave_all_to_all_reports_sender_and_receiver_drops():
     expected = jnp.einsum("tkh,tk->th", expert_output, combine_weights * keep)
 
     np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-5)
-    assert int(dropped) == 6
+    assert int(overflow.sender) == 3
+    assert int(overflow.receiver) == 3
 
 
 def test_fixed_all_to_all_matches_dense_cross_shard_value_and_gradients():
@@ -902,7 +932,7 @@ def test_moe_mlp_ragged_matches_ring_with_ep_axis_when_available():
         )
 
     np.testing.assert_allclose(np.asarray(ragged_out), np.asarray(ring_out), rtol=1e-5, atol=1e-5)
-    assert int(ragged_dropped) == int(ring_dropped)
+    assert int(ragged_dropped.total) == int(ring_dropped.total)
 
 
 def test_moe_mlp_runs_with_ep_axis_when_available():
@@ -1096,8 +1126,8 @@ def test_moe_mlp_reports_positive_drop_count_in_ring_ep_when_over_capacity():
         )
 
     assert out.shape == (tokens, hidden_dim)
-    assert dropped.shape == ()
-    assert int(dropped) > 0
+    assert dropped.total.shape == ()
+    assert int(dropped.total) > 0
 
 
 def test_moe_mlp_reports_positive_drop_count_in_ragged_a2a_when_over_capacity():
@@ -1141,8 +1171,8 @@ def test_moe_mlp_reports_positive_drop_count_in_ragged_a2a_when_over_capacity():
         )
 
     assert out.shape == (tokens, hidden_dim)
-    assert dropped.shape == ()
-    assert int(dropped) > 0
+    assert dropped.total.shape == ()
+    assert int(dropped.total) > 0
 
 
 def test_ragged_a2a_receiver_clipping_respects_capacity():

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -80,9 +80,10 @@ def _make_single_expert_mesh() -> Mesh:
 
 
 def _count_jaxpr_primitives(value, primitive_name: str) -> int:
-    if isinstance(value, jax_core.Jaxpr):
-        return sum(eqn.primitive.name == primitive_name for eqn in value.eqns) + sum(
-            _count_jaxpr_primitives(param, primitive_name) for eqn in value.eqns for param in eqn.params.values()
+    jaxpr = getattr(value, "jaxpr", value)
+    if isinstance(jaxpr, jax_core.Jaxpr):
+        return sum(eqn.primitive.name == primitive_name for eqn in jaxpr.eqns) + sum(
+            _count_jaxpr_primitives(param, primitive_name) for eqn in jaxpr.eqns for param in eqn.params.values()
         )
     if isinstance(value, dict):
         return sum(_count_jaxpr_primitives(item, primitive_name) for item in value.values())

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -54,8 +54,8 @@ def test_hero_run_without_shape_overrides_uses_the_selected_model():
         3072,
         8,
         3072,
-        1.33,
-        1.05,
+        1.15,
+        1.10,
         3,
         "fixed_pooled_wave_all_to_all",
         1024,
@@ -803,3 +803,55 @@ def test_fp32_host_master_accumulates_updates_before_bfloat16_cast(monkeypatch):
     expected_master = 1.0 - 10 * 0.1 * float(jnp.array(0.01, dtype=jnp.bfloat16))
     np.testing.assert_allclose(state.master_params.weight, expected_master, rtol=1e-6)
     np.testing.assert_allclose(state.params.weight, jnp.asarray(expected_master, dtype=jnp.bfloat16))
+
+
+def test_fp32_host_master_preserves_float32_initialization(monkeypatch):
+    config = _latent_config()
+    key = jax.random.key(17)
+    mesh = _explicit_mesh(1, 1, 1, 1)
+    monkeypatch.setattr(train, "_tree_to_memory_kind", lambda tree, memory_kind: tree)
+
+    with set_mesh(mesh):
+        expected = model.Transformer.init(config, key=key)
+        state = train.initial_state(
+            config,
+            optimizer=optax.sgd(0.1),
+            mp=jmp.get_policy("params=bfloat16,compute=bfloat16,output=bfloat16"),
+            key=key,
+            ema_beta=None,
+            master_param_mode=train.MasterParamMode.FP32_PINNED_HOST,
+        )
+
+    assert state.master_params is not None
+    expected_leaves = jax.tree.leaves(expected)
+    master_leaves = jax.tree.leaves(state.master_params)
+    param_leaves = jax.tree.leaves(state.params)
+    for expected_leaf, master_leaf, param_leaf in zip(expected_leaves, master_leaves, param_leaves, strict=True):
+        np.testing.assert_array_equal(master_leaf, expected_leaf)
+        np.testing.assert_array_equal(param_leaf, expected_leaf.astype(jnp.bfloat16))
+    assert any(
+        not np.array_equal(master_leaf, param_leaf.astype(jnp.float32))
+        for master_leaf, param_leaf in zip(master_leaves, param_leaves, strict=True)
+    )
+
+
+def test_drop_metrics_reports_sender_and_receiver_fractions():
+    metrics = train._drop_metrics(
+        jnp.array(5, dtype=jnp.int32),
+        jnp.array(2, dtype=jnp.int32),
+        jnp.array(3, dtype=jnp.int32),
+        batch_size=2,
+        sequence_length=4,
+        top_k=2,
+        num_layers=1,
+    )
+
+    assert metrics == {
+        "moe/dropped_assignments": 5,
+        "moe/drop_fraction": 5 / 16,
+        "moe/sender_dropped_assignments": 2,
+        "moe/sender_drop_fraction": 2 / 16,
+        "moe/receiver_dropped_assignments": 3,
+        "moe/receiver_drop_fraction": 3 / 16,
+        "moe/receiver_drop_fraction_of_received": 3 / 14,
+    }


### PR DESCRIPTION
* Part of https://github.com/marin-community/marin/issues/7279.
* Preserve FP32 parameter initialization before the BF16 runtime copy for pinned-host master parameters.
* Keep pooled dispatch results across rematerialization so backward execution does not repeat the dispatch all-to-all.
* Report sender and receiver overflow as separate counts.
  * Report the receiver share of all assignments so the sender and receiver rates add to the total rate.
  * Also report the receiver share of assignments that reached the receiver.
* Set the selected E384 top-8 model to sender CF `1.10` and receiver CF `1.15`.
  * Per @ClassicLarry recommendation in https://github.com/marin-community/marin/pull/8289
* A 20-step test completed on one GB200 rack.
  * Median throughput for steps 2 through 19 was 250,691 tokens/s. Final throughput was 246,947 tokens/s.
  * Final loss was 6.3224.
  * Final drop rate was 19.33%: 7.14% at the sender and 12.19% at the receiver. The receiver dropped 13.12% of assignments that reached it (⚠️  these are not steady state numbers)
  * This short test checks memory use and metric reporting. A longer run is still required to measure the final drop rate against the 3% goal.
  * All 16 workers completed without an OOM, nonfinite value, failure, or preemption.
  * [Run metrics](https://wandb.ai/marin-community/rav_moe/runs/mhep-118-recv-metrics-send110-recv115-smoke).
* Local affected-test run: 98 passed and 7 skipped. The lint review had no findings.
