### PR TITLE
[iris] Correct CoreWeave scale group disk declarations

### DIFF
--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -173,7 +173,7 @@ scale_groups:
     resources:
       cpu: 192        # turin-gp-l: AMD Turin 9655P (96 cores / 192 vCPUs), high storage
       ram: 1536GB     # ~1.5 TiB allocatable on the live node
-      disk: 30.72TB   # 30.72 TB local NVMe (8x 3.84 TB)
+      disk: 27.94TiB   # 30.72 TB local NVMe (8x 3.84 TB)
       device_type: cpu
       capacity_type: on-demand
     worker:
@@ -193,7 +193,7 @@ scale_groups:
     resources:
       cpu: 128
       ram: 2048GB
-      disk: 30.72TB  # 30.72 TB local NVMe (8x 3.84 TB)
+      disk: 27.94TiB  # 30.72 TB local NVMe (8x 3.84 TB)
       device_type: gpu
       device_variant: H100
       device_count: 8

--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -173,7 +173,7 @@ scale_groups:
     resources:
       cpu: 192        # turin-gp-l: AMD Turin 9655P (96 cores / 192 vCPUs), high storage
       ram: 1536GB     # ~1.5 TiB allocatable on the live node
-      disk: 29TB      # allocatable ephemeral-storage on the live node
+      disk: 30.72TB   # 30.72 TB local NVMe (8x 3.84 TB)
       device_type: cpu
       capacity_type: on-demand
     worker:
@@ -193,7 +193,7 @@ scale_groups:
     resources:
       cpu: 128
       ram: 2048GB
-      disk: 1TB
+      disk: 30.72TB  # 30.72 TB local NVMe (8x 3.84 TB)
       device_type: gpu
       device_variant: H100
       device_count: 8

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -172,7 +172,7 @@ scale_groups:
     resources:
       cpu: 192       # cd-gp-a192-genoa: 192 vCPUs (96 physical Genoa 9454 cores)
       ram: 1536GB    # 1.5 TB on-node RAM (8 GB per vCPU)
-      disk: 7.68TB   # 7.68 TB local NVMe
+      disk: 6.98TiB   # 7.68 TB local NVMe (2x 3.84 TB)
       device_type: cpu
       capacity_type: on-demand
     worker:
@@ -192,7 +192,7 @@ scale_groups:
     resources:
       cpu: 128
       ram: 2048GB
-      disk: 30.72TB  # 30.72 TB local NVMe (8x 3.84 TB)
+      disk: 27.94TiB  # 30.72 TB local NVMe (8x 3.84 TB)
       device_type: gpu
       device_variant: H100
       device_count: 8

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -192,7 +192,7 @@ scale_groups:
     resources:
       cpu: 128
       ram: 2048GB
-      disk: 1TB
+      disk: 30.72TB  # 30.72 TB local NVMe (8x 3.84 TB)
       device_type: gpu
       device_variant: H100
       device_count: 8

--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -196,7 +196,7 @@ scale_groups:
     resources:
       cpu: 64        # cd-gp-i64-erapids: 64 vCPUs (32 physical Emerald Rapids 8562Y+ cores)
       ram: 512GB     # 512 GB on-node RAM (8 GB per vCPU)
-      disk: 7.68TB   # 7.68 TB local NVMe (2x 3.84 TB)
+      disk: 6.98TiB   # 7.68 TB local NVMe (2x 3.84 TB)
       device_type: cpu
       capacity_type: on-demand
     worker:
@@ -216,7 +216,7 @@ scale_groups:
     resources:
       cpu: 144       # gb200-4x: 144 vCPUs (2x NVIDIA Grace Arm v9)
       ram: 960GB     # 960 GB system (LPDDR5X) RAM
-      disk: 15.36TB  # 15.36 TB local NVMe (4x 3.84 TB)
+      disk: 13.97TiB  # 15.36 TB local NVMe (4x 3.84 TB)
       device_type: gpu
       device_variant: GB200
       device_count: 4        # 4 Blackwell GPUs per gb200-4x node

--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -196,7 +196,7 @@ scale_groups:
     resources:
       cpu: 64        # cd-gp-i64-erapids: 64 vCPUs (32 physical Emerald Rapids 8562Y+ cores)
       ram: 512GB     # 512 GB on-node RAM (8 GB per vCPU)
-      disk: 15.36TB  # 15.36 TB local NVMe
+      disk: 7.68TB   # 7.68 TB local NVMe (2x 3.84 TB)
       device_type: cpu
       capacity_type: on-demand
     worker:
@@ -216,7 +216,7 @@ scale_groups:
     resources:
       cpu: 144       # gb200-4x: 144 vCPUs (2x NVIDIA Grace Arm v9)
       ram: 960GB     # 960 GB system (LPDDR5X) RAM
-      disk: 30.72TB  # 30.72 TB local NVMe
+      disk: 15.36TB  # 15.36 TB local NVMe (4x 3.84 TB)
       device_type: gpu
       device_variant: GB200
       device_count: 4        # 4 Blackwell GPUs per gb200-4x node

--- a/lib/iris/config/cw-us-west-04a.yaml
+++ b/lib/iris/config/cw-us-west-04a.yaml
@@ -124,7 +124,7 @@ scale_groups:
     resources:
       cpu: 64        # cd-gp-i64-erapids: 64 vCPUs (32 physical Emerald Rapids 8562Y+ cores)
       ram: 512GB     # 512 GB on-node RAM (8 GB per vCPU)
-      disk: 15.36TB  # 15.36 TB local NVMe
+      disk: 7.68TB   # 7.68 TB local NVMe (2x 3.84 TB)
       device_type: cpu
       capacity_type: on-demand
     worker:
@@ -144,7 +144,7 @@ scale_groups:
     resources:
       cpu: 128
       ram: 2048GB
-      disk: 1TB
+      disk: 30.72TB  # 30.72 TB local NVMe (8x 3.84 TB)
       device_type: gpu
       device_variant: H100
       device_count: 8

--- a/lib/iris/config/cw-us-west-04a.yaml
+++ b/lib/iris/config/cw-us-west-04a.yaml
@@ -124,7 +124,7 @@ scale_groups:
     resources:
       cpu: 64        # cd-gp-i64-erapids: 64 vCPUs (32 physical Emerald Rapids 8562Y+ cores)
       ram: 512GB     # 512 GB on-node RAM (8 GB per vCPU)
-      disk: 7.68TB   # 7.68 TB local NVMe (2x 3.84 TB)
+      disk: 6.98TiB   # 7.68 TB local NVMe (2x 3.84 TB)
       device_type: cpu
       capacity_type: on-demand
     worker:
@@ -144,7 +144,7 @@ scale_groups:
     resources:
       cpu: 128
       ram: 2048GB
-      disk: 30.72TB  # 30.72 TB local NVMe (8x 3.84 TB)
+      disk: 27.94TiB  # 30.72 TB local NVMe (8x 3.84 TB)
       device_type: gpu
       device_variant: H100
       device_count: 8


### PR DESCRIPTION
Three of the five CoreWeave scale groups declared local NVMe that does not match
the hardware. Read against node ephemeral-storage capacity on the live clusters:
h100-8x declared 1TB against 30.72 TB, gb200 declared 30.72 TB against 15.36 TB,
and cpu-erapids declared 15.36 TB against 7.68 TB. The two over-declarations look
like the correct figures written one row off, since every CoreWeave SKU here is a
multiple of a 3.84 TB drive.

The values are written in TiB. parse_memory_string calls
humanfriendly.parse_size(binary=True), so a value spelled TB is read as TiB and
would have parsed 9.95% above the hardware; explicit binary units make the unit
and the parsed byte count agree. All five groups now parse within 0.07% of node
capacity, including cpu-genoa and cpu-turin, which carried that skew before this
branch. The ram declarations have the same TB-as-TiB skew, about 1.7% high, and
are left for a separate change.

Nothing on the CoreWeave path reads this field today, so no scheduling behavior
changes, and the IaC preview is clean on all four stacks. K8sTaskProvider.schedule
and .autoscale are no-ops because Kueue owns placement, so the autoscaler
bin-packing in autoscaler/routing.py:180 that consumes disk_bytes never runs; a
pod's ephemeral-storage request comes from the task's --disk instead. The values
still matter because these files are the capacity reference an operator reads, and
because config.py:409 maps disk_bytes to slice_template.disk_size_gb on the
VM-backed clusters, where the field is live.

The h100-8x correction is the one with practical consequence: 30 TB of node-local
NVMe per H100 node was documented as 1 TB, so spill-heavy jobs had no reason to
know it was there.
