### PR TITLE
[fsutil] Stream recursive rm

### DIFF
--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -85,9 +85,10 @@ destination directories may not overlap.
 `hash` reads each complete object. Its columns are `url` and `md5`; digests use base64
 by default. `--hex` selects hexadecimal output.
 
-`du` scans prefixes with up to 128 concurrent metadata-bearing listings. S3 prefixes
-that exceed one listing page are split at the next `/` through three directory levels,
-then paginated flat.
+`du` scans prefixes with up to 128 concurrent metadata-bearing listings. A prefix that
+exceeds one listing page is split at the next `/` through three directory levels, then
+paginated flat. Both object stores drive their own paging call, so a prefix with millions
+of objects directly below it arrives one page at a time.
 
 Recursive `rm` on a remote prefix runs on that same parallel page scanner and deletes
 each page as it lands, rather than scanning the whole prefix first. Deletes start
@@ -97,15 +98,13 @@ documented maximum: 1,000 keys for S3 `DeleteObjects`, 100 sub-requests for the 
 batch endpoint. `--workers` sets the requests in flight, defaulting to 16 and accepting
 up to 256. Failed S3 batches are retried with backoff on transient errors.
 
-Raising `--workers` past the default helps only until the bucket throttles. A GCS bucket
-admits roughly 1,000 writes per second before it returns 429, and deletes count as
-writes, so 60M objects need about 17 hours whatever the client does. At that scale an
-object lifecycle rule costs nothing and needs no listing. It is the better tool, and it
-is why throwaway data belongs under a `ttl=` prefix that a rule already covers.
-
-One case still lists serially: a GCS prefix whose objects sit directly under it, with no
-sub-prefixes to split across threads. gcsfs pages such a listing in one call, so the
-scanner cannot fan out. Nested layouts, and all S3 prefixes, parallelize.
+`--workers` is worth raising on S3, which serves a much higher write rate, and worth
+lowering to delete politely beside a running job. On GCS the default is already at the
+bucket's ceiling: it admits roughly 1,000 writes per second before it returns 429, and
+deletes count as writes. 60M objects therefore need about 17 hours whatever the client
+does. At that scale an object lifecycle rule costs nothing and needs no listing. It is
+the better tool, and it is why throwaway data belongs under a `ttl=` prefix that a rule
+already covers.
 
 `usage` uses the same parallel metadata-page scanner as `du`, defaults to 128 workers,
 accepts up to 1,024 workers, and writes a Markdown report. Starting at the bucket root,

--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -63,7 +63,7 @@ that touch its buckets; the rest keep working.
 | `mv SRC ... DST [-r]` | Move or rename one or more sources. Sources are removed after every copy succeeds |
 | `rsync SRC DST [--delete] [--dry-run] [--checksum]` | Synchronize the files beneath two directories or prefixes |
 | `hash URL ... [--hex]` | Stream complete files and print MD5 digests in base64 or hexadecimal |
-| `rm URL ... [-r]` | Remove one or more objects. `-r` or `-R` recursively removes every prefix; remote prefixes show object-count progress |
+| `rm URL ... [-r] [--workers N]` | Remove one or more objects. `-r` or `-R` recursively removes every prefix; remote prefixes delete while they list and show progress |
 | `browse [URL]` | The interactive browser |
 
 `cp` and `mv` append each source basename when the destination is an existing directory,
@@ -87,8 +87,25 @@ by default. `--hex` selects hexadecimal output.
 
 `du` scans prefixes with up to 128 concurrent metadata-bearing listings. S3 prefixes
 that exceed one listing page are split at the next `/` through three directory levels,
-then paginated flat. Recursive `rm` uses S3's 1,000-key bulk delete and GCS's 20-key
-batch delete, with up to eight batches in flight.
+then paginated flat.
+
+Recursive `rm` on a remote prefix runs on that same parallel page scanner and deletes
+each page as it lands, rather than scanning the whole prefix first. Deletes start
+immediately, and the objects held in memory are bounded by the requests in flight
+instead of by the size of the prefix. One batch is one request, at each backend's
+documented maximum: 1,000 keys for S3 `DeleteObjects`, 100 sub-requests for the GCS
+batch endpoint. `--workers` sets the requests in flight, defaulting to 16 and accepting
+up to 256. Failed S3 batches are retried with backoff on transient errors.
+
+Raising `--workers` past the default helps only until the bucket throttles. A GCS bucket
+admits roughly 1,000 writes per second before it returns 429, and deletes count as
+writes, so 60M objects need about 17 hours whatever the client does. At that scale an
+object lifecycle rule costs nothing and needs no listing. It is the better tool, and it
+is why throwaway data belongs under a `ttl=` prefix that a rule already covers.
+
+One case still lists serially: a GCS prefix whose objects sit directly under it, with no
+sub-prefixes to split across threads. gcsfs pages such a listing in one call, so the
+scanner cannot fan out. Nested layouts, and all S3 prefixes, parallelize.
 
 `usage` uses the same parallel metadata-page scanner as `du`, defaults to 128 workers,
 accepts up to 1,024 workers, and writes a Markdown report. Starting at the bucket root,

--- a/lib/rigging/src/rigging/filesystem/buckets.py
+++ b/lib/rigging/src/rigging/filesystem/buckets.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import s3fs
 
+from rigging.filesystem.bulk_deletion import with_bulk_deletion
 from rigging.filesystem.cluster_config import BucketSpec, StoreType, data_buckets
 from rigging.filesystem.factory import url_to_fs
 from rigging.filesystem.paged_listing import with_listing
@@ -49,7 +50,8 @@ def filesystem_for(url: str) -> tuple[Any, str]:
     kwargs-keyed cache. Everything else — GCS, local paths, ``mirror://``, and
     ``s3://`` buckets no config declares — goes through the guarded
     :func:`rigging.filesystem.factory.url_to_fs`, which reads the ambient environment.
-    S3 and GCS results expose paged object operations through ``fs.listing``.
+    S3 and GCS results expose paged listing and bulk deletion through
+    ``fs.listing`` and ``fs.deletion``.
 
     Raises:
         MissingCredentials: if the routed backend has no credentials configured.
@@ -57,14 +59,18 @@ def filesystem_for(url: str) -> tuple[Any, str]:
     parsed = StoragePath(url)
     if parsed.scheme != "s3":
         fs, path = url_to_fs(url)
-        return with_listing(fs), path
+        return _with_object_store_operations(fs), path
 
     spec = data_buckets().get(parsed.bucket)
     if spec is None or spec.store not in (StoreType.R2, StoreType.COREWEAVE):
         fs, path = url_to_fs(url)
-        return with_listing(fs), path
+        return _with_object_store_operations(fs), path
 
-    return with_listing(_s3_filesystem(spec)), _s3_path(parsed)
+    return _with_object_store_operations(_s3_filesystem(spec)), _s3_path(parsed)
+
+
+def _with_object_store_operations(fs: Any) -> Any:
+    return with_bulk_deletion(with_listing(fs))
 
 
 def _s3_path(parsed: StoragePath) -> str:

--- a/lib/rigging/src/rigging/filesystem/bulk_deletion.py
+++ b/lib/rigging/src/rigging/filesystem/bulk_deletion.py
@@ -1,0 +1,141 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend-aware bulk deletion attached to bucket-routed filesystems."""
+
+from collections.abc import Callable
+from functools import partial
+from typing import Any, NotRequired, Protocol, TypedDict, cast
+
+from rigging.filesystem.protocols import normalize_protocols
+from rigging.filesystem.s3_errors import is_transient_s3_error, is_transient_s3_error_code
+from rigging.timing import ExponentialBackoff, retry_with_backoff
+
+_S3_BATCH_SIZE = 1000
+_GCS_BATCH_SIZE = 100
+_GCS_CONNECTION_LIMIT = 100
+_DELETE_MAX_ATTEMPTS = 4
+_DELETE_BACKOFF = ExponentialBackoff(initial=0.5, maximum=5.0, factor=2.0)
+
+
+class _S3DeleteError(TypedDict):
+    Key: str
+    Code: str
+
+
+class _S3DeleteObject(TypedDict):
+    Key: str
+    VersionId: NotRequired[str]
+
+
+class _S3DeleteResponse(TypedDict):
+    Errors: NotRequired[list[_S3DeleteError]]
+
+
+class _S3BulkDeleteFilesystem(Protocol):
+    def split_path(self, path: str) -> tuple[str, str, str | None]: ...
+
+    def call_s3(self, method: str, **kwargs: object) -> _S3DeleteResponse: ...
+
+
+class _GCSBulkDeleteFilesystem(Protocol):
+    def rm(self, path: list[str], recursive: bool = False, maxdepth: int | None = None, batchsize: int = 20) -> None: ...
+
+
+class _ThrottledBulkDelete(Exception):
+    """Every key in one bulk delete failed with a transient code."""
+
+
+class _BulkDeleteFailed(Exception):
+    """At least one key in a bulk delete failed with a permanent code."""
+
+
+class _BulkDeletion:
+    """One backend's bulk-delete operation and request limits."""
+
+    def __init__(
+        self,
+        batch_size: int,
+        delete: Callable[[list[str]], None],
+        *,
+        shared_connection_limit: int | None = None,
+    ) -> None:
+        self.batch_size = batch_size
+        self._delete = delete
+        self._shared_connection_limit = shared_connection_limit
+
+    def delete(self, paths: list[str]) -> None:
+        """Delete one request-sized batch of protocol-stripped paths."""
+        self._delete(paths)
+
+    def listing_workers(self, delete_workers: int, requested: int | None, default: int) -> int:
+        """Return listing concurrency alongside the active delete requests."""
+        if requested is not None:
+            return requested
+        if self._shared_connection_limit is None:
+            return default
+        return max(1, self._shared_connection_limit - delete_workers)
+
+
+def _is_retryable_delete(error: BaseException) -> bool:
+    if isinstance(error, _ThrottledBulkDelete):
+        return True
+    if isinstance(error, _BulkDeleteFailed):
+        return False
+    return is_transient_s3_error(error)
+
+
+def _delete_s3_objects(fs: _S3BulkDeleteFilesystem, paths: list[str]) -> None:
+    objects: list[_S3DeleteObject] = []
+    buckets = set()
+    for path in paths:
+        bucket, key, version = fs.split_path(path)
+        buckets.add(bucket)
+        item = {"Key": key}
+        if version is not None:
+            item["VersionId"] = version
+        objects.append(item)
+    assert len(buckets) == 1
+    bucket = buckets.pop()
+    retry_with_backoff(
+        lambda: _delete_s3_batch(fs, bucket, objects),
+        retryable=_is_retryable_delete,
+        max_attempts=_DELETE_MAX_ATTEMPTS,
+        backoff=_DELETE_BACKOFF,
+        operation=f"DeleteObjects {bucket}",
+    )
+
+
+def _delete_s3_batch(fs: _S3BulkDeleteFilesystem, bucket: str, objects: list[_S3DeleteObject]) -> None:
+    """Delete one S3 batch and surface failures reported inside a 200 response."""
+    response = fs.call_s3("delete_objects", Bucket=bucket, Delete={"Objects": objects, "Quiet": True})
+    errors = response.get("Errors", [])
+    if not errors:
+        return
+    details = ", ".join(f"{error['Key']}: {error['Code']}" for error in errors)
+    if all(is_transient_s3_error_code(error.get("Code")) for error in errors):
+        raise _ThrottledBulkDelete(f"S3 bulk delete throttled: {details}")
+    raise _BulkDeleteFailed(f"S3 bulk delete failed: {details}")
+
+
+def _delete_gcs_objects(fs: _GCSBulkDeleteFilesystem, paths: list[str]) -> None:
+    fs.rm(paths, batchsize=_GCS_BATCH_SIZE)
+
+
+def with_bulk_deletion(fs: Any) -> Any:
+    """Attach backend-aware bulk deletion at ``fs.deletion``."""
+    protocols = normalize_protocols(getattr(fs, "protocol", ()))
+    if "s3" in protocols:
+        fs.deletion = _BulkDeletion(
+            _S3_BATCH_SIZE,
+            partial(_delete_s3_objects, cast(_S3BulkDeleteFilesystem, fs)),
+        )
+    elif any(item in ("gs", "gcs") for item in protocols):
+        fs.deletion = _BulkDeletion(
+            _GCS_BATCH_SIZE,
+            partial(_delete_gcs_objects, cast(_GCSBulkDeleteFilesystem, fs)),
+            shared_connection_limit=_GCS_CONNECTION_LIMIT,
+        )
+    else:
+        fs.deletion = _BulkDeletion(1, fs.rm)
+    return fs

--- a/lib/rigging/src/rigging/filesystem/cross_region.py
+++ b/lib/rigging/src/rigging/filesystem/cross_region.py
@@ -283,7 +283,7 @@ class CrossRegionGuardedFS:
             process-global singleton.
     """
 
-    __slots__ = ("_budget", "_cross_region_checker", "_current_region", "_fs", "listing")
+    __slots__ = ("_budget", "_cross_region_checker", "_current_region", "_fs", "deletion", "listing")
 
     def __init__(
         self,

--- a/lib/rigging/src/rigging/filesystem/paged_listing.py
+++ b/lib/rigging/src/rigging/filesystem/paged_listing.py
@@ -11,6 +11,8 @@ scans at ``fs.listing``:
 - ``flat_pages(path)`` returns a flat (recursive) listing as pages of object detail
   dicts covering every object beneath *path*, so a whole subtree can be measured
   or streamed without descending prefix by prefix.
+- ``page(path, continuation_token, delimiter)`` returns one backend page for
+  adaptive consumers that choose between flat and level listings.
 
 Paths are the protocol-stripped ``bucket/key`` form the filesystems themselves
 use, and every listing excludes the listed prefix's own marker object.
@@ -20,6 +22,7 @@ from collections.abc import Callable, Iterator
 from functools import partial
 from typing import Any
 
+from rigging.filesystem.protocols import normalize_protocols
 from rigging.filesystem.s3_errors import is_transient_s3_error
 from rigging.timing import ExponentialBackoff, retry_with_backoff
 
@@ -34,12 +37,15 @@ _GCS_PAGE_SIZE = 5000
 
 
 def is_child(listed: str, name: str) -> bool:
-    """Whether *name* differs from *listed* after trimming separator markers.
+    """Whether *name* differs from *listed* after trimming one separator marker.
 
     Object stores commonly report a zero-byte marker object for the prefix being
     listed; it carries no information and would render as an empty-named row.
+    A second trailing separator is an empty path segment and must be preserved.
     """
-    return name.strip("/") != listed.strip("/")
+    listed = listed[:-1] if listed.endswith("/") else listed
+    name = name[:-1] if name.endswith("/") else name
+    return name != listed
 
 
 def s3_listing_page(
@@ -118,6 +124,10 @@ class _PagedListing:
     def __init__(self, listing_page: Callable[[str, str | None, str], tuple[list[dict[str, Any]], str | None]]) -> None:
         self._listing_page = listing_page
 
+    def page(self, path: str, continuation_token: str | None, delimiter: str) -> tuple[list[dict[str, Any]], str | None]:
+        """Return one backend listing page and its next continuation token."""
+        return self._listing_page(path, continuation_token, delimiter)
+
     def level_pages(self, path: str) -> Iterator[tuple[list[dict[str, Any]], list[str]]]:
         for entries in self._pages(path, "/"):
             yield _split_level(path, entries)
@@ -129,7 +139,7 @@ class _PagedListing:
     def _pages(self, path: str, delimiter: str) -> Iterator[list[dict[str, Any]]]:
         token: str | None = None
         while True:
-            entries, token = self._listing_page(path, token, delimiter)
+            entries, token = self.page(path, token, delimiter)
             yield entries
             if token is None:
                 return
@@ -137,8 +147,7 @@ class _PagedListing:
 
 def with_listing(fs: Any) -> Any:
     """Attach backend-aware paged listing operations to a cloud filesystem."""
-    protocol = getattr(fs, "protocol", ())
-    protocols = (protocol,) if isinstance(protocol, str) else protocol
+    protocols = normalize_protocols(getattr(fs, "protocol", ()))
     if "s3" in protocols:
         fs.listing = _PagedListing(partial(s3_listing_page, fs))
     elif any(item in ("gs", "gcs") for item in protocols):

--- a/lib/rigging/src/rigging/filesystem/protocols.py
+++ b/lib/rigging/src/rigging/filesystem/protocols.py
@@ -1,0 +1,13 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Normalization for fsspec filesystem protocols."""
+
+from collections.abc import Iterable
+
+
+def normalize_protocols(protocol: str | Iterable[str]) -> tuple[str, ...]:
+    """Return fsspec's scalar or iterable protocol declaration as a tuple."""
+    if isinstance(protocol, str):
+        return (protocol,)
+    return tuple(protocol)

--- a/lib/rigging/src/rigging/filesystem/s3_errors.py
+++ b/lib/rigging/src/rigging/filesystem/s3_errors.py
@@ -51,3 +51,12 @@ def is_transient_s3_error(error: BaseException) -> bool:
             return True
     message = str(error)
     return any(fragment in message for fragment in _TRANSIENT_S3_MESSAGE_FRAGMENTS)
+
+
+def is_transient_s3_error_code(code: str | None) -> bool:
+    """Return whether an error code reported in a response body can be retried.
+
+    A bulk operation answers 200 and names each failed key in its body, so a throttled
+    key never raises and never reaches :func:`is_transient_s3_error`.
+    """
+    return code in _TRANSIENT_S3_ERROR_CODES

--- a/lib/rigging/src/rigging/filesystem/s3_errors.py
+++ b/lib/rigging/src/rigging/filesystem/s3_errors.py
@@ -54,9 +54,5 @@ def is_transient_s3_error(error: BaseException) -> bool:
 
 
 def is_transient_s3_error_code(code: str | None) -> bool:
-    """Return whether an error code reported in a response body can be retried.
-
-    A bulk operation answers 200 and names each failed key in its body, so a throttled
-    key never raises and never reaches :func:`is_transient_s3_error`.
-    """
+    """Return whether an S3 response error code is transient."""
     return code in _TRANSIENT_S3_ERROR_CODES

--- a/lib/rigging/src/rigging/fsutil/cli.py
+++ b/lib/rigging/src/rigging/fsutil/cli.py
@@ -65,6 +65,33 @@ _ACTIVITY_BAR_WIDTH = 8
 _MAX_PROGRESS_PATH_LENGTH = 60
 
 
+class _ProgressDisplay:
+    """Throttled stderr output shared by long-running commands."""
+
+    def __init__(self) -> None:
+        self._interactive = click.get_text_stream("stderr").isatty()
+        self._last_update = time.monotonic()
+        self._rendered_width = 0
+
+    def update(self, line: str, *, complete: bool = False) -> None:
+        now = time.monotonic()
+        interval = _INTERACTIVE_PROGRESS_INTERVAL if self._interactive else _LOG_PROGRESS_INTERVAL
+        if not complete and now - self._last_update < interval:
+            return
+        if self._interactive:
+            self._rendered_width = max(self._rendered_width, len(line))
+            click.echo(f"\r{line.ljust(self._rendered_width)}", nl=False, err=True)
+        else:
+            click.echo(line, err=True)
+        self._last_update = now
+
+    def finish(self, line: str) -> None:
+        if self._interactive and self._rendered_width:
+            click.echo(f"\r{line.ljust(max(self._rendered_width, len(line)))}", err=True)
+        else:
+            click.echo(line, err=True)
+
+
 @click.group(invoke_without_command=True)
 @click.option("-v", "--verbose", is_flag=True, help="Log fsspec/botocore activity.")
 @click.pass_context
@@ -190,37 +217,21 @@ def usage(url: str, prefix_threshold: str, prefix_depth: int, workers: int, outp
         raise click.BadParameter(str(error), param_hint="--prefix-threshold") from error
 
     click.echo(f"Scanning object metadata under {url} ...", err=True)
-    last_update = time.monotonic()
-    rendered_width = 0
+    display = _ProgressDisplay()
     latest_progress: ScanProgress | None = None
-    interactive = click.get_text_stream("stderr").isatty()
 
     def show_progress(progress: ScanProgress) -> None:
-        nonlocal last_update, latest_progress, rendered_width
+        nonlocal latest_progress
         latest_progress = progress
-        now = time.monotonic()
-        interval = _INTERACTIVE_PROGRESS_INTERVAL if interactive else _LOG_PROGRESS_INTERVAL
         complete = progress.prefixes_completed == progress.prefixes_discovered
-        if not complete and now - last_update < interval:
-            return
-        line = _scan_progress_line(progress)
-        if interactive:
-            rendered_width = max(rendered_width, len(line))
-            click.echo(f"\r{line.ljust(rendered_width)}", nl=False, err=True)
-        else:
-            click.echo(line, err=True)
-        last_update = now
+        display.update(_scan_progress_line(progress), complete=complete)
 
     try:
         scan = scan_usage(url, workers=workers, prefix_depth=prefix_depth, progress=show_progress)
     except MissingCredentials as error:
         raise click.ClickException(str(error)) from error
     if latest_progress is not None:
-        line = _finished_scan_line(latest_progress)
-        if interactive:
-            click.echo(f"\r{line.ljust(max(rendered_width, len(line)))}", err=True)
-        else:
-            click.echo(line, err=True)
+        display.finish(_finished_scan_line(latest_progress))
     report = render_usage_report(scan, threshold_bytes=threshold_bytes, generated_at=datetime.now(UTC))
     if output is None:
         click.echo(report)
@@ -386,33 +397,17 @@ def _remove(url: str, recursive: bool, workers: int) -> None:
         return
 
     click.echo(f"Removing objects under {url} ...", err=True)
-    last_update = time.monotonic()
-    rendered_width = 0
-    interactive = click.get_text_stream("stderr").isatty()
+    display = _ProgressDisplay()
 
     def show_progress(progress: DeleteProgress) -> None:
-        nonlocal last_update, rendered_width
-        now = time.monotonic()
-        interval = _INTERACTIVE_PROGRESS_INTERVAL if interactive else _LOG_PROGRESS_INTERVAL
-        if now - last_update < interval:
-            return
-        line = _delete_progress_line(progress)
-        if interactive:
-            rendered_width = max(rendered_width, len(line))
-            click.echo(f"\r{line.ljust(rendered_width)}", nl=False, err=True)
-        else:
-            click.echo(line, err=True)
-        last_update = now
+        display.update(_delete_progress_line(progress))
 
     result = delete_prefix(url, workers=workers, progress=show_progress)
     summary = (
         f"Removed {result.objects_deleted:,} objects ({format_size(result.bytes_deleted)}) "
         f"in {result.elapsed_seconds:.1f}s"
     )
-    if interactive and rendered_width:
-        click.echo(f"\r{summary.ljust(rendered_width)}", err=True)
-    else:
-        click.echo(summary, err=True)
+    display.finish(summary)
     click.echo(url)
 
 

--- a/lib/rigging/src/rigging/fsutil/cli.py
+++ b/lib/rigging/src/rigging/fsutil/cli.py
@@ -11,19 +11,21 @@ name two different backends. Bare ``fsutil`` opens the interactive browser.
 import logging
 import sys
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
 from pathlib import Path
 
 import click
-from fsspec import AbstractFileSystem
-from gcsfs import GCSFileSystem
-from s3fs import S3FileSystem
 
 from rigging.filesystem.buckets import MissingCredentials, filesystem_for
 from rigging.filesystem.cluster_config import StoreType, data_buckets
 from rigging.filesystem.s3_compat import s3_credentials, s3_endpoint
 from rigging.filesystem.storage_path import StoragePath
+from rigging.fsutil.deletion import (
+    DEFAULT_DELETE_WORKERS,
+    MAX_DELETE_WORKERS,
+    DeleteProgress,
+    delete_prefix,
+)
 from rigging.fsutil.hashing import file_md5, format_digest
 from rigging.fsutil.listing import (
     ROOT,
@@ -57,9 +59,6 @@ from rigging.fsutil.usage import (
 
 logger = logging.getLogger(__name__)
 
-_RM_WORKERS = 8
-_S3_DELETE_BATCH = 1000
-_GCS_DELETE_BATCH = 20
 _INTERACTIVE_PROGRESS_INTERVAL = 0.2
 _LOG_PROGRESS_INTERVAL = 10.0
 _ACTIVITY_BAR_WIDTH = 8
@@ -356,13 +355,20 @@ def hash_command(urls: tuple[str, ...], hexadecimal: bool) -> None:
 @click.command()
 @click.argument("urls", nargs=-1, required=True)
 @click.option("-r", "-R", "--recursive", is_flag=True, help="Remove a prefix and everything under it.")
-def rm(urls: tuple[str, ...], recursive: bool) -> None:
+@click.option(
+    "--workers",
+    default=DEFAULT_DELETE_WORKERS,
+    show_default=True,
+    type=click.IntRange(min=1, max=MAX_DELETE_WORKERS),
+    help="Delete requests in flight at one time.",
+)
+def rm(urls: tuple[str, ...], recursive: bool, workers: int) -> None:
     """Remove objects, or recursively remove prefixes."""
     for url in urls:
-        _remove(url, recursive)
+        _remove(url, recursive, workers)
 
 
-def _remove(url: str, recursive: bool) -> None:
+def _remove(url: str, recursive: bool, workers: int) -> None:
     fs, path = filesystem_for(url)
     is_dir = fs.isdir(path)
     if is_dir and not recursive:
@@ -379,60 +385,47 @@ def _remove(url: str, recursive: bool) -> None:
         click.echo(url)
         return
 
-    click.echo(f"Scanning {url} ...", err=True)
-    entries = fs.find(path, detail=True)
-    files = list(entries)
-    total_bytes = sum(entry.get("size", 0) or 0 for entry in entries.values())
-    batches = _delete_batches(fs, files)
-    with ThreadPoolExecutor(max_workers=_RM_WORKERS) as executor:
-        label = f"Removing {len(files)} objects ({format_size(total_bytes)})"
-        with click.progressbar(length=len(files), label=label, show_pos=True) as progress:
-            for start in range(0, len(batches), _RM_WORKERS):
-                removals = {
-                    executor.submit(_remove_batch, fs, batch): len(batch)
-                    for batch in batches[start : start + _RM_WORKERS]
-                }
-                for removal in as_completed(removals):
-                    removal.result()
-                    progress.update(removals[removal])
-    fs.invalidate_cache()
+    click.echo(f"Removing objects under {url} ...", err=True)
+    last_update = time.monotonic()
+    rendered_width = 0
+    interactive = click.get_text_stream("stderr").isatty()
+
+    def show_progress(progress: DeleteProgress) -> None:
+        nonlocal last_update, rendered_width
+        now = time.monotonic()
+        interval = _INTERACTIVE_PROGRESS_INTERVAL if interactive else _LOG_PROGRESS_INTERVAL
+        if now - last_update < interval:
+            return
+        line = _delete_progress_line(progress)
+        if interactive:
+            rendered_width = max(rendered_width, len(line))
+            click.echo(f"\r{line.ljust(rendered_width)}", nl=False, err=True)
+        else:
+            click.echo(line, err=True)
+        last_update = now
+
+    result = delete_prefix(url, workers=workers, progress=show_progress)
+    summary = (
+        f"Removed {result.objects_deleted:,} objects ({format_size(result.bytes_deleted)}) "
+        f"in {result.elapsed_seconds:.1f}s"
+    )
+    if interactive and rendered_width:
+        click.echo(f"\r{summary.ljust(rendered_width)}", err=True)
+    else:
+        click.echo(summary, err=True)
     click.echo(url)
 
 
-def _delete_batches(fs: AbstractFileSystem, files: list[str]) -> list[list[str]]:
-    if isinstance(fs, S3FileSystem):
-        batch_size = _S3_DELETE_BATCH
-    elif isinstance(fs, GCSFileSystem):
-        batch_size = _GCS_DELETE_BATCH
-    else:
-        batch_size = 1
-    return [files[start : start + batch_size] for start in range(0, len(files), batch_size)]
-
-
-def _remove_batch(fs: AbstractFileSystem, files: list[str]) -> None:
-    if not isinstance(fs, S3FileSystem):
-        fs.rm(files)
-        return
-
-    objects = []
-    buckets = set()
-    for path in files:
-        bucket, key, version = fs.split_path(path)
-        buckets.add(bucket)
-        item = {"Key": key}
-        if version is not None:
-            item["VersionId"] = version
-        objects.append(item)
-    assert len(buckets) == 1
-    response = fs.call_s3(
-        "delete_objects",
-        Bucket=buckets.pop(),
-        Delete={"Objects": objects, "Quiet": True},
+def _delete_progress_line(progress: DeleteProgress) -> str:
+    rate = progress.objects_deleted / progress.elapsed_seconds if progress.elapsed_seconds else 0.0
+    filled = max(1, round(_ACTIVITY_BAR_WIDTH * progress.requests_active / progress.requests_total))
+    activity = f"[{'█' * filled}{'░' * (_ACTIVITY_BAR_WIDTH - filled)}]"
+    queued = max(0, progress.objects_listed - progress.objects_deleted)
+    return (
+        f"{activity} {progress.requests_active}/{progress.requests_total} requests | "
+        f"{progress.listing_pages:,} pages | {progress.objects_deleted:,} deleted | "
+        f"{queued:,} queued | {format_size(progress.bytes_deleted)} | {rate:,.0f} obj/s"
     )
-    errors = response.get("Errors", [])
-    if errors:
-        details = ", ".join(f"{error['Key']}: {error['Code']}" for error in errors)
-        raise RuntimeError(f"S3 bulk delete failed: {details}")
 
 
 @click.command()

--- a/lib/rigging/src/rigging/fsutil/deletion.py
+++ b/lib/rigging/src/rigging/fsutil/deletion.py
@@ -16,66 +16,15 @@ import dataclasses
 import time
 from collections.abc import Callable, Iterator
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
-from typing import Protocol, cast
-
-from fsspec import AbstractFileSystem
 
 from rigging.filesystem.buckets import filesystem_for
-from rigging.filesystem.protocols import is_gcs_filesystem, is_s3_filesystem
-from rigging.filesystem.s3_errors import is_transient_s3_error, is_transient_s3_error_code
 from rigging.fsutil.listing import DEFAULT_LISTING_WORKERS, DIRECTORY_TYPE, metadata_listing_pages
-from rigging.timing import ExponentialBackoff, retry_with_backoff
 
 # Deletes are network-bound, but a bucket enforces its own write ceiling: GCS admits
 # roughly a thousand writes per second before it throttles. Sixteen requests in flight
 # saturates that without spending the run inside backoff.
 DEFAULT_DELETE_WORKERS = 16
 MAX_DELETE_WORKERS = 256
-
-# Objects per request, at each backend's documented maximum: DeleteObjects accepts a
-# thousand keys, and the GCS batch endpoint accepts a hundred sub-requests.
-S3_DELETE_BATCH = 1000
-GCS_DELETE_BATCH = 100
-
-_DELETE_MAX_ATTEMPTS = 4
-_DELETE_BACKOFF = ExponentialBackoff(initial=0.5, maximum=5.0, factor=2.0)
-
-# gcsfs serves listings and deletes from one session, whose aiohttp connector admits 100
-# sockets by default. A listing sized for its own command would hold most of the pool and
-# leave the deletes queued behind it. s3fs sizes its pool per command, so it needs no cap.
-_GCS_CONNECTION_LIMIT = 100
-
-
-class _ThrottledBulkDelete(Exception):
-    """Every key in one bulk delete failed with a transient code."""
-
-
-class _BulkDeleteFailed(Exception):
-    """At least one key in a bulk delete failed with a permanent code."""
-
-
-def _is_retryable_delete(error: BaseException) -> bool:
-    """Classify a bulk delete failure.
-
-    The two outcomes this module raises are decided by type. Anything else came from the
-    transport, which :func:`is_transient_s3_error` classifies. That classifier falls back
-    to a substring scan, so a permanent failure whose message quotes a throttling code
-    would otherwise read as transient and re-send the whole batch.
-    """
-    if isinstance(error, _ThrottledBulkDelete):
-        return True
-    if isinstance(error, _BulkDeleteFailed):
-        return False
-    return is_transient_s3_error(error)
-
-
-class _BatchDeleteFilesystem(Protocol):
-    """gcsfs's delete signature, which fsspec's base class does not declare.
-
-    ``batchsize`` is the number of sub-requests gcsfs puts in one batch HTTP round trip.
-    """
-
-    def rm(self, path: list[str], recursive: bool = False, maxdepth: int | None = None, batchsize: int = 20) -> None: ...
 
 
 @dataclasses.dataclass(frozen=True)
@@ -139,8 +88,7 @@ def delete_prefix(
         The totals for the removal.
     """
     fs, _ = filesystem_for(url)
-    batch_size = _delete_batch_size(fs)
-    listing_workers = _resolve_listing_workers(fs, workers, listing_workers)
+    listing_workers = fs.deletion.listing_workers(workers, listing_workers, DEFAULT_LISTING_WORKERS)
     listed = _Listed()
     deleted = _Deleted()
     started = time.monotonic()
@@ -162,10 +110,10 @@ def delete_prefix(
 
     with ThreadPoolExecutor(max_workers=workers) as executor:
         pending: dict[Future, _Batch] = {}
-        for batch in _object_batches(url, batch_size, listing_workers, listed):
+        for batch in _object_batches(url, fs.deletion.batch_size, listing_workers, listed):
             while len(pending) >= workers:
                 _drain(pending, deleted, report)
-            pending[executor.submit(_delete_batch, fs, batch.paths)] = batch
+            pending[executor.submit(fs.deletion.delete, batch.paths)] = batch
         while pending:
             _drain(pending, deleted, report)
 
@@ -207,71 +155,3 @@ def _drain(pending: dict[Future, _Batch], deleted: _Deleted, report: Callable[[i
         deleted.objects += len(batch.paths)
         deleted.size_bytes += batch.size_bytes
         report(len(pending))
-
-
-def _resolve_listing_workers(fs: AbstractFileSystem, workers: int, requested: int | None) -> int:
-    """How many threads may list while *workers* delete requests are in flight."""
-    if requested is not None:
-        return requested
-    if is_gcs_filesystem(fs):
-        return max(1, _GCS_CONNECTION_LIMIT - workers)
-    return DEFAULT_LISTING_WORKERS
-
-
-def _delete_batch_size(fs: AbstractFileSystem) -> int:
-    """Objects per delete request, so that one batch costs one request."""
-    if is_s3_filesystem(fs):
-        return S3_DELETE_BATCH
-    if is_gcs_filesystem(fs):
-        return GCS_DELETE_BATCH
-    return 1
-
-
-def _delete_batch(fs: AbstractFileSystem, paths: list[str]) -> None:
-    if is_s3_filesystem(fs):
-        _delete_s3_objects(fs, paths)
-        return
-    if is_gcs_filesystem(fs):
-        # gcsfs splits the list into batch sub-requests of its own, so sending a whole
-        # batch keeps the call to a single round trip.
-        cast(_BatchDeleteFilesystem, fs).rm(paths, batchsize=GCS_DELETE_BATCH)
-        return
-    fs.rm(paths)
-
-
-def _delete_s3_objects(fs: AbstractFileSystem, paths: list[str]) -> None:
-    objects = []
-    buckets = set()
-    for path in paths:
-        bucket, key, version = fs.split_path(path)
-        buckets.add(bucket)
-        item = {"Key": key}
-        if version is not None:
-            item["VersionId"] = version
-        objects.append(item)
-    assert len(buckets) == 1
-    bucket = buckets.pop()
-    retry_with_backoff(
-        lambda: _delete_s3_batch(fs, bucket, objects),
-        retryable=_is_retryable_delete,
-        max_attempts=_DELETE_MAX_ATTEMPTS,
-        backoff=_DELETE_BACKOFF,
-        operation=f"DeleteObjects {bucket}",
-    )
-
-
-def _delete_s3_batch(fs: AbstractFileSystem, bucket: str, objects: list[dict[str, str]]) -> None:
-    """Delete one batch, treating a throttled key as a failure of the whole request.
-
-    S3 answers 200 and names each failed key in ``Errors``, so throttling never raises on
-    its own. The retry repeats the whole batch, which is safe because deleting a key that
-    is already gone succeeds.
-    """
-    response = fs.call_s3("delete_objects", Bucket=bucket, Delete={"Objects": objects, "Quiet": True})
-    errors = response.get("Errors", [])
-    if not errors:
-        return
-    details = ", ".join(f"{error['Key']}: {error['Code']}" for error in errors)
-    if all(is_transient_s3_error_code(error.get("Code")) for error in errors):
-        raise _ThrottledBulkDelete(f"S3 bulk delete throttled: {details}")
-    raise _BulkDeleteFailed(f"S3 bulk delete failed: {details}")

--- a/lib/rigging/src/rigging/fsutil/deletion.py
+++ b/lib/rigging/src/rigging/fsutil/deletion.py
@@ -21,7 +21,7 @@ from typing import Protocol, cast
 from fsspec import AbstractFileSystem
 
 from rigging.filesystem.buckets import filesystem_for
-from rigging.filesystem.s3_errors import is_transient_s3_error
+from rigging.filesystem.s3_errors import is_transient_s3_error, is_transient_s3_error_code
 from rigging.fsutil.listing import (
     DEFAULT_LISTING_WORKERS,
     DIRECTORY_TYPE,
@@ -44,6 +44,10 @@ GCS_DELETE_BATCH = 100
 
 _DELETE_MAX_ATTEMPTS = 4
 _DELETE_BACKOFF = ExponentialBackoff(initial=0.5, maximum=5.0, factor=2.0)
+
+
+class _ThrottledBulkDelete(Exception):
+    """Every key in one bulk delete failed with a transient code."""
 
 
 class _BatchDeleteFilesystem(Protocol):
@@ -223,14 +227,27 @@ def _delete_s3_objects(fs: AbstractFileSystem, paths: list[str]) -> None:
         objects.append(item)
     assert len(buckets) == 1
     bucket = buckets.pop()
-    response = retry_with_backoff(
-        lambda: fs.call_s3("delete_objects", Bucket=bucket, Delete={"Objects": objects, "Quiet": True}),
-        retryable=is_transient_s3_error,
+    retry_with_backoff(
+        lambda: _delete_s3_batch(fs, bucket, objects),
+        retryable=lambda error: isinstance(error, _ThrottledBulkDelete) or is_transient_s3_error(error),
         max_attempts=_DELETE_MAX_ATTEMPTS,
         backoff=_DELETE_BACKOFF,
         operation=f"DeleteObjects {bucket}",
     )
+
+
+def _delete_s3_batch(fs: AbstractFileSystem, bucket: str, objects: list[dict[str, str]]) -> None:
+    """Delete one batch, treating a throttled key as a failure of the whole request.
+
+    S3 answers 200 and names each failed key in ``Errors``, so throttling never raises on
+    its own. The retry repeats the whole batch, which is safe because deleting a key that
+    is already gone succeeds.
+    """
+    response = fs.call_s3("delete_objects", Bucket=bucket, Delete={"Objects": objects, "Quiet": True})
     errors = response.get("Errors", [])
-    if errors:
-        details = ", ".join(f"{error['Key']}: {error['Code']}" for error in errors)
-        raise RuntimeError(f"S3 bulk delete failed: {details}")
+    if not errors:
+        return
+    details = ", ".join(f"{error['Key']}: {error['Code']}" for error in errors)
+    if all(is_transient_s3_error_code(error.get("Code")) for error in errors):
+        raise _ThrottledBulkDelete(f"S3 bulk delete throttled: {details}")
+    raise RuntimeError(f"S3 bulk delete failed: {details}")

--- a/lib/rigging/src/rigging/fsutil/deletion.py
+++ b/lib/rigging/src/rigging/fsutil/deletion.py
@@ -21,14 +21,9 @@ from typing import Protocol, cast
 from fsspec import AbstractFileSystem
 
 from rigging.filesystem.buckets import filesystem_for
+from rigging.filesystem.protocols import is_gcs_filesystem, is_s3_filesystem
 from rigging.filesystem.s3_errors import is_transient_s3_error, is_transient_s3_error_code
-from rigging.fsutil.listing import (
-    DEFAULT_LISTING_WORKERS,
-    DIRECTORY_TYPE,
-    is_gcs_filesystem,
-    is_s3_filesystem,
-    metadata_listing_pages,
-)
+from rigging.fsutil.listing import DEFAULT_LISTING_WORKERS, DIRECTORY_TYPE, metadata_listing_pages
 from rigging.timing import ExponentialBackoff, retry_with_backoff
 
 # Deletes are network-bound, but a bucket enforces its own write ceiling: GCS admits
@@ -45,9 +40,33 @@ GCS_DELETE_BATCH = 100
 _DELETE_MAX_ATTEMPTS = 4
 _DELETE_BACKOFF = ExponentialBackoff(initial=0.5, maximum=5.0, factor=2.0)
 
+# gcsfs serves listings and deletes from one session, whose aiohttp connector admits 100
+# sockets by default. A listing sized for its own command would hold most of the pool and
+# leave the deletes queued behind it. s3fs sizes its pool per command, so it needs no cap.
+_GCS_CONNECTION_LIMIT = 100
+
 
 class _ThrottledBulkDelete(Exception):
     """Every key in one bulk delete failed with a transient code."""
+
+
+class _BulkDeleteFailed(Exception):
+    """At least one key in a bulk delete failed with a permanent code."""
+
+
+def _is_retryable_delete(error: BaseException) -> bool:
+    """Classify a bulk delete failure.
+
+    The two outcomes this module raises are decided by type. Anything else came from the
+    transport, which :func:`is_transient_s3_error` classifies. That classifier falls back
+    to a substring scan, so a permanent failure whose message quotes a throttling code
+    would otherwise read as transient and re-send the whole batch.
+    """
+    if isinstance(error, _ThrottledBulkDelete):
+        return True
+    if isinstance(error, _BulkDeleteFailed):
+        return False
+    return is_transient_s3_error(error)
 
 
 class _BatchDeleteFilesystem(Protocol):
@@ -67,7 +86,6 @@ class DeleteProgress:
     bytes_deleted: int
     objects_listed: int
     listing_pages: int
-    requests_completed: int
     requests_active: int
     requests_total: int
     elapsed_seconds: float
@@ -80,7 +98,6 @@ class DeleteResult:
     url: str
     objects_deleted: int
     bytes_deleted: int
-    listing_pages: int
     elapsed_seconds: float
 
 
@@ -100,14 +117,13 @@ class _Listed:
 class _Deleted:
     objects: int = 0
     size_bytes: int = 0
-    requests: int = 0
 
 
 def delete_prefix(
     url: str,
     *,
     workers: int = DEFAULT_DELETE_WORKERS,
-    listing_workers: int = DEFAULT_LISTING_WORKERS,
+    listing_workers: int | None = None,
     progress: Callable[[DeleteProgress], None] | None = None,
 ) -> DeleteResult:
     """Remove every object below *url*, deleting while the listing streams.
@@ -115,14 +131,16 @@ def delete_prefix(
     Args:
         url: Prefix to empty.
         workers: Delete requests in flight at one time.
-        listing_workers: Threads that list prefixes.
+        listing_workers: Threads that list prefixes. Derived from the backend's
+            connection pool when omitted.
         progress: Called as each delete request completes.
 
     Returns:
         The totals for the removal.
     """
     fs, _ = filesystem_for(url)
-    batch_size = delete_batch_size(fs)
+    batch_size = _delete_batch_size(fs)
+    listing_workers = _resolve_listing_workers(fs, workers, listing_workers)
     listed = _Listed()
     deleted = _Deleted()
     started = time.monotonic()
@@ -136,7 +154,6 @@ def delete_prefix(
                 bytes_deleted=deleted.size_bytes,
                 objects_listed=listed.objects,
                 listing_pages=listed.pages,
-                requests_completed=deleted.requests,
                 requests_active=requests_active,
                 requests_total=workers,
                 elapsed_seconds=time.monotonic() - started,
@@ -157,7 +174,6 @@ def delete_prefix(
         url=url,
         objects_deleted=deleted.objects,
         bytes_deleted=deleted.size_bytes,
-        listing_pages=listed.pages,
         elapsed_seconds=time.monotonic() - started,
     )
 
@@ -190,11 +206,19 @@ def _drain(pending: dict[Future, _Batch], deleted: _Deleted, report: Callable[[i
         future.result()
         deleted.objects += len(batch.paths)
         deleted.size_bytes += batch.size_bytes
-        deleted.requests += 1
         report(len(pending))
 
 
-def delete_batch_size(fs: AbstractFileSystem) -> int:
+def _resolve_listing_workers(fs: AbstractFileSystem, workers: int, requested: int | None) -> int:
+    """How many threads may list while *workers* delete requests are in flight."""
+    if requested is not None:
+        return requested
+    if is_gcs_filesystem(fs):
+        return max(1, _GCS_CONNECTION_LIMIT - workers)
+    return DEFAULT_LISTING_WORKERS
+
+
+def _delete_batch_size(fs: AbstractFileSystem) -> int:
     """Objects per delete request, so that one batch costs one request."""
     if is_s3_filesystem(fs):
         return S3_DELETE_BATCH
@@ -229,7 +253,7 @@ def _delete_s3_objects(fs: AbstractFileSystem, paths: list[str]) -> None:
     bucket = buckets.pop()
     retry_with_backoff(
         lambda: _delete_s3_batch(fs, bucket, objects),
-        retryable=lambda error: isinstance(error, _ThrottledBulkDelete) or is_transient_s3_error(error),
+        retryable=_is_retryable_delete,
         max_attempts=_DELETE_MAX_ATTEMPTS,
         backoff=_DELETE_BACKOFF,
         operation=f"DeleteObjects {bucket}",
@@ -250,4 +274,4 @@ def _delete_s3_batch(fs: AbstractFileSystem, bucket: str, objects: list[dict[str
     details = ", ".join(f"{error['Key']}: {error['Code']}" for error in errors)
     if all(is_transient_s3_error_code(error.get("Code")) for error in errors):
         raise _ThrottledBulkDelete(f"S3 bulk delete throttled: {details}")
-    raise RuntimeError(f"S3 bulk delete failed: {details}")
+    raise _BulkDeleteFailed(f"S3 bulk delete failed: {details}")

--- a/lib/rigging/src/rigging/fsutil/deletion.py
+++ b/lib/rigging/src/rigging/fsutil/deletion.py
@@ -1,0 +1,236 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Streamed parallel removal of object-store prefixes.
+
+Deletion is driven by :func:`rigging.fsutil.listing.metadata_listing_pages`, which lists
+prefixes in parallel and yields each page as it lands. Objects are removed as the listing
+discovers them, so the first delete leaves before a large prefix finishes listing and
+memory stays bounded by the requests in flight rather than by the size of the namespace.
+
+Each submitted batch is exactly one delete request, so ``workers`` means concurrent
+delete requests on every backend.
+"""
+
+import dataclasses
+import time
+from collections.abc import Callable, Iterator
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from typing import Protocol, cast
+
+from fsspec import AbstractFileSystem
+
+from rigging.filesystem.buckets import filesystem_for
+from rigging.filesystem.s3_errors import is_transient_s3_error
+from rigging.fsutil.listing import (
+    DEFAULT_LISTING_WORKERS,
+    DIRECTORY_TYPE,
+    is_gcs_filesystem,
+    is_s3_filesystem,
+    metadata_listing_pages,
+)
+from rigging.timing import ExponentialBackoff, retry_with_backoff
+
+# Deletes are network-bound, but a bucket enforces its own write ceiling: GCS admits
+# roughly a thousand writes per second before it throttles. Sixteen requests in flight
+# saturates that without spending the run inside backoff.
+DEFAULT_DELETE_WORKERS = 16
+MAX_DELETE_WORKERS = 256
+
+# Objects per request, at each backend's documented maximum: DeleteObjects accepts a
+# thousand keys, and the GCS batch endpoint accepts a hundred sub-requests.
+S3_DELETE_BATCH = 1000
+GCS_DELETE_BATCH = 100
+
+_DELETE_MAX_ATTEMPTS = 4
+_DELETE_BACKOFF = ExponentialBackoff(initial=0.5, maximum=5.0, factor=2.0)
+
+
+class _BatchDeleteFilesystem(Protocol):
+    """gcsfs's delete signature, which fsspec's base class does not declare.
+
+    ``batchsize`` is the number of sub-requests gcsfs puts in one batch HTTP round trip.
+    """
+
+    def rm(self, path: list[str], recursive: bool = False, maxdepth: int | None = None, batchsize: int = 20) -> None: ...
+
+
+@dataclasses.dataclass(frozen=True)
+class DeleteProgress:
+    """Monotonic progress observed as delete requests complete."""
+
+    objects_deleted: int
+    bytes_deleted: int
+    objects_listed: int
+    listing_pages: int
+    requests_completed: int
+    requests_active: int
+    requests_total: int
+    elapsed_seconds: float
+
+
+@dataclasses.dataclass(frozen=True)
+class DeleteResult:
+    """Totals for one completed prefix removal."""
+
+    url: str
+    objects_deleted: int
+    bytes_deleted: int
+    listing_pages: int
+    elapsed_seconds: float
+
+
+@dataclasses.dataclass(frozen=True)
+class _Batch:
+    paths: list[str]
+    size_bytes: int
+
+
+@dataclasses.dataclass
+class _Listed:
+    pages: int = 0
+    objects: int = 0
+
+
+@dataclasses.dataclass
+class _Deleted:
+    objects: int = 0
+    size_bytes: int = 0
+    requests: int = 0
+
+
+def delete_prefix(
+    url: str,
+    *,
+    workers: int = DEFAULT_DELETE_WORKERS,
+    listing_workers: int = DEFAULT_LISTING_WORKERS,
+    progress: Callable[[DeleteProgress], None] | None = None,
+) -> DeleteResult:
+    """Remove every object below *url*, deleting while the listing streams.
+
+    Args:
+        url: Prefix to empty.
+        workers: Delete requests in flight at one time.
+        listing_workers: Threads that list prefixes.
+        progress: Called as each delete request completes.
+
+    Returns:
+        The totals for the removal.
+    """
+    fs, _ = filesystem_for(url)
+    batch_size = delete_batch_size(fs)
+    listed = _Listed()
+    deleted = _Deleted()
+    started = time.monotonic()
+
+    def report(requests_active: int) -> None:
+        if progress is None:
+            return
+        progress(
+            DeleteProgress(
+                objects_deleted=deleted.objects,
+                bytes_deleted=deleted.size_bytes,
+                objects_listed=listed.objects,
+                listing_pages=listed.pages,
+                requests_completed=deleted.requests,
+                requests_active=requests_active,
+                requests_total=workers,
+                elapsed_seconds=time.monotonic() - started,
+            )
+        )
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        pending: dict[Future, _Batch] = {}
+        for batch in _object_batches(url, batch_size, listing_workers, listed):
+            while len(pending) >= workers:
+                _drain(pending, deleted, report)
+            pending[executor.submit(_delete_batch, fs, batch.paths)] = batch
+        while pending:
+            _drain(pending, deleted, report)
+
+    fs.invalidate_cache()
+    return DeleteResult(
+        url=url,
+        objects_deleted=deleted.objects,
+        bytes_deleted=deleted.size_bytes,
+        listing_pages=listed.pages,
+        elapsed_seconds=time.monotonic() - started,
+    )
+
+
+def _object_batches(url: str, batch_size: int, listing_workers: int, listed: _Listed) -> Iterator[_Batch]:
+    """Yield full delete batches as the streamed listing fills them."""
+    paths: list[str] = []
+    size_bytes = 0
+    for page in metadata_listing_pages(url, workers=listing_workers):
+        listed.pages = page.pages_completed
+        for entry in page.entries:
+            if entry["type"] == DIRECTORY_TYPE:
+                continue
+            paths.append(entry["name"])
+            size_bytes += entry.get("size", 0) or 0
+            listed.objects += 1
+            if len(paths) == batch_size:
+                yield _Batch(paths=paths, size_bytes=size_bytes)
+                paths = []
+                size_bytes = 0
+    if paths:
+        yield _Batch(paths=paths, size_bytes=size_bytes)
+
+
+def _drain(pending: dict[Future, _Batch], deleted: _Deleted, report: Callable[[int], None]) -> None:
+    """Retire the first finished requests, freeing their slots for new batches."""
+    finished, _ = wait(pending, return_when=FIRST_COMPLETED)
+    for future in finished:
+        batch = pending.pop(future)
+        future.result()
+        deleted.objects += len(batch.paths)
+        deleted.size_bytes += batch.size_bytes
+        deleted.requests += 1
+        report(len(pending))
+
+
+def delete_batch_size(fs: AbstractFileSystem) -> int:
+    """Objects per delete request, so that one batch costs one request."""
+    if is_s3_filesystem(fs):
+        return S3_DELETE_BATCH
+    if is_gcs_filesystem(fs):
+        return GCS_DELETE_BATCH
+    return 1
+
+
+def _delete_batch(fs: AbstractFileSystem, paths: list[str]) -> None:
+    if is_s3_filesystem(fs):
+        _delete_s3_objects(fs, paths)
+        return
+    if is_gcs_filesystem(fs):
+        # gcsfs splits the list into batch sub-requests of its own, so sending a whole
+        # batch keeps the call to a single round trip.
+        cast(_BatchDeleteFilesystem, fs).rm(paths, batchsize=GCS_DELETE_BATCH)
+        return
+    fs.rm(paths)
+
+
+def _delete_s3_objects(fs: AbstractFileSystem, paths: list[str]) -> None:
+    objects = []
+    buckets = set()
+    for path in paths:
+        bucket, key, version = fs.split_path(path)
+        buckets.add(bucket)
+        item = {"Key": key}
+        if version is not None:
+            item["VersionId"] = version
+        objects.append(item)
+    assert len(buckets) == 1
+    bucket = buckets.pop()
+    response = retry_with_backoff(
+        lambda: fs.call_s3("delete_objects", Bucket=bucket, Delete={"Objects": objects, "Quiet": True}),
+        retryable=is_transient_s3_error,
+        max_attempts=_DELETE_MAX_ATTEMPTS,
+        backoff=_DELETE_BACKOFF,
+        operation=f"DeleteObjects {bucket}",
+    )
+    errors = response.get("Errors", [])
+    if errors:
+        details = ", ".join(f"{error['Key']}: {error['Code']}" for error in errors)
+        raise RuntimeError(f"S3 bulk delete failed: {details}")

--- a/lib/rigging/src/rigging/fsutil/listing.py
+++ b/lib/rigging/src/rigging/fsutil/listing.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from rigging.filesystem.buckets import filesystem_for
 from rigging.filesystem.cluster_config import StoreType, data_buckets
-from rigging.filesystem.paged_listing import DIRECTORY_TYPE, is_child, s3_listing_page
+from rigging.filesystem.paged_listing import DIRECTORY_TYPE, is_child
 from rigging.filesystem.storage_path import StoragePath
 from rigging.fsutil.compression import compression_for
 
@@ -36,7 +36,7 @@ MAX_PREVIEW_BYTES = 10 * 1024 * 1024
 
 # Bucket listings are network-bound.
 DEFAULT_LISTING_WORKERS = 128
-_S3_MAX_SPLIT_DEPTH = 3
+_MAX_SPLIT_DEPTH = 3
 
 
 @dataclasses.dataclass(frozen=True)
@@ -92,16 +92,16 @@ class _CompletedDirectoryListing:
     workers_active: int
 
 
-class _S3ListingMode(StrEnum):
+class _ListingMode(StrEnum):
     PROBE = "probe"
     EXPAND = "expand"
     FLAT = "flat"
 
 
 @dataclasses.dataclass(frozen=True)
-class _S3ListingTask:
+class _ListingTask:
     path: str
-    mode: _S3ListingMode
+    mode: _ListingMode
     depth: int = 0
     continuation_token: str | None = None
 
@@ -252,15 +252,10 @@ def metadata_listing_pages(url: str, *, workers: int = DEFAULT_LISTING_WORKERS) 
     yield from _metadata_listing_pages(fs, path, workers)
 
 
-def _is_s3_filesystem(fs) -> bool:
-    protocol = getattr(fs, "protocol", ())
-    protocols = (protocol,) if isinstance(protocol, str) else protocol
-    return "s3" in protocols
-
-
 def _metadata_listing_pages(fs, path: str, workers: int) -> Iterator[ListingPage]:
-    if _is_s3_filesystem(fs):
-        yield from _s3_listing_pages(fs, path, workers)
+    paged_listing = getattr(fs, "listing", None)
+    if paged_listing is not None:
+        yield from _paged_listing_pages(paged_listing, path, workers)
         return
 
     root_entries = fs.ls(path, detail=True)
@@ -311,8 +306,8 @@ def _directory_listing_pages(fs, directories: Iterable[str], workers: int) -> It
                 yield _CompletedDirectoryListing(directory, entries, workers_active)
 
 
-def _s3_listing_pages(fs, path: str, workers: int) -> Iterator[ListingPage]:
-    queued = deque([_S3ListingTask(path, _S3ListingMode.PROBE)])
+def _paged_listing_pages(paged_listing, path: str, workers: int) -> Iterator[ListingPage]:
+    queued = deque([_ListingTask(path, _ListingMode.PROBE)])
     scheduled_prefixes = {path}
     pages_completed = 0
     prefixes_completed = 0
@@ -321,8 +316,8 @@ def _s3_listing_pages(fs, path: str, workers: int) -> Iterator[ListingPage]:
         while queued or pending:
             while queued and len(pending) < workers:
                 task = queued.popleft()
-                delimiter = "/" if task.mode == _S3ListingMode.EXPAND else ""
-                future = executor.submit(s3_listing_page, fs, task.path, task.continuation_token, delimiter)
+                delimiter = "/" if task.mode == _ListingMode.EXPAND else ""
+                future = executor.submit(paged_listing.page, task.path, task.continuation_token, delimiter)
                 pending[future] = task
 
             completed, _ = wait(pending, return_when=FIRST_COMPLETED)
@@ -330,17 +325,17 @@ def _s3_listing_pages(fs, path: str, workers: int) -> Iterator[ListingPage]:
                 task = pending.pop(future)
                 entries, continuation_token = future.result()
                 pages_completed += 1
-                if task.mode == _S3ListingMode.PROBE:
+                if task.mode == _ListingMode.PROBE:
                     if continuation_token is None:
                         prefixes_completed += 1
-                    elif task.depth < _S3_MAX_SPLIT_DEPTH:
+                    elif task.depth < _MAX_SPLIT_DEPTH:
                         entries = []
-                        queued.appendleft(_S3ListingTask(task.path, _S3ListingMode.EXPAND, depth=task.depth))
+                        queued.appendleft(_ListingTask(task.path, _ListingMode.EXPAND, depth=task.depth))
                     else:
                         queued.appendleft(
-                            _S3ListingTask(
+                            _ListingTask(
                                 task.path,
-                                _S3ListingMode.FLAT,
+                                _ListingMode.FLAT,
                                 depth=task.depth,
                                 continuation_token=continuation_token,
                             )
@@ -350,18 +345,18 @@ def _s3_listing_pages(fs, path: str, workers: int) -> Iterator[ListingPage]:
                         prefixes_completed += 1
                     else:
                         queued.appendleft(
-                            _S3ListingTask(
+                            _ListingTask(
                                 task.path,
                                 task.mode,
                                 depth=task.depth,
                                 continuation_token=continuation_token,
                             )
                         )
-                    if task.mode == _S3ListingMode.EXPAND:
+                    if task.mode == _ListingMode.EXPAND:
                         for directory in _listing_stats(task.path, entries).directories:
                             if directory not in scheduled_prefixes:
                                 scheduled_prefixes.add(directory)
-                                queued.append(_S3ListingTask(directory, _S3ListingMode.PROBE, depth=task.depth + 1))
+                                queued.append(_ListingTask(directory, _ListingMode.PROBE, depth=task.depth + 1))
 
                 yield ListingPage(
                     path=task.path,

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -413,6 +413,64 @@ def test_rm_uses_s3_bulk_delete_batches(monkeypatch):
     assert {item["Key"] for batch in batches for item in batch} == {f"prefix/{index}" for index in range(1001)}
 
 
+class _BulkDeleteS3FileSystem:
+    """An S3 stub whose bulk delete reports per-key failures in the response body."""
+
+    protocol = "s3"
+
+    def __init__(self, failures):
+        self.failures = list(failures)
+        self.attempts = 0
+        self.config_kwargs = {}
+
+    def isdir(self, _path):
+        return True
+
+    def split_path(self, path):
+        bucket, key = path.split("/", 1)
+        return bucket, key, None
+
+    def call_s3(self, method, **kwargs):
+        if method == "list_objects_v2":
+            return {"Contents": [{"Key": "prefix/0", "Size": 1}]}
+        self.attempts += 1
+        errors = self.failures.pop(0) if self.failures else []
+        return {"Errors": errors}
+
+    def invalidate_cache(self):
+        pass
+
+
+def test_rm_retries_a_throttled_bulk_delete(monkeypatch):
+    """S3 answers 200 and reports throttling per key, so it never raises on its own.
+
+    A large removal provokes exactly this, and treating it as fatal aborts the run after
+    a partial delete.
+    """
+    fs = _BulkDeleteS3FileSystem([[{"Key": "prefix/0", "Code": "SlowDown"}], []])
+    monkeypatch.setattr(deletion, "_DELETE_BACKOFF", timing.ExponentialBackoff(initial=0.001, maximum=0.001))
+    monkeypatch.setattr(deletion, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+    monkeypatch.setattr(listing, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+    monkeypatch.setattr(cli_module, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+
+    result = CliRunner().invoke(cli, ["rm", "-R", "s3://bucket/prefix"])
+
+    assert result.exit_code == 0, result.output
+    assert fs.attempts == 2
+
+
+def test_rm_fails_on_a_permanent_bulk_delete_error(monkeypatch):
+    fs = _BulkDeleteS3FileSystem([[{"Key": "prefix/0", "Code": "AccessDenied"}]])
+    monkeypatch.setattr(deletion, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+    monkeypatch.setattr(listing, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+    monkeypatch.setattr(cli_module, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+
+    result = CliRunner().invoke(cli, ["rm", "-R", "s3://bucket/prefix"])
+
+    assert result.exit_code != 0
+    assert fs.attempts == 1
+
+
 def test_rm_batches_through_a_filesystem_wrapper(monkeypatch):
     """Backend dispatch must survive a proxy that forwards the protocol but not the class.
 

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -14,11 +14,14 @@ import threading
 from datetime import UTC, datetime
 
 import pytest
+import rigging.filesystem.bulk_deletion as bulk_deletion
 import rigging.fsutil.cli as cli_module
 import rigging.fsutil.transfer as transfer_module
 import rigging.timing as timing
 from botocore.exceptions import EndpointConnectionError
 from click.testing import CliRunner
+from rigging.filesystem.cross_region import CrossRegionGuardedFS
+from rigging.filesystem.paged_listing import with_listing
 from rigging.fsutil import deletion, listing
 from rigging.fsutil.cli import cli
 from rigging.fsutil.listing import MAX_PREVIEW_BYTES, read_decompressed_preview
@@ -373,6 +376,13 @@ def test_rm_recursive_unlinks_local_directory_symlink_without_deleting_target(tm
     assert (target / "keep.txt").read_text() == "keep"
 
 
+def _install_object_store_filesystem(monkeypatch, fs):
+    fs = bulk_deletion.with_bulk_deletion(with_listing(fs))
+    for module in (deletion, listing, cli_module):
+        monkeypatch.setattr(module, "filesystem_for", lambda _url, fs=fs: (fs, "bucket/prefix"))
+    return fs
+
+
 def test_rm_uses_s3_bulk_delete_batches(monkeypatch):
     class RecordingS3FileSystem:
         protocol = "s3"
@@ -400,10 +410,7 @@ def test_rm_uses_s3_bulk_delete_batches(monkeypatch):
         def invalidate_cache(self):
             pass
 
-    fs = RecordingS3FileSystem()
-    monkeypatch.setattr(deletion, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
-    monkeypatch.setattr(listing, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
-    monkeypatch.setattr(cli_module, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+    fs = _install_object_store_filesystem(monkeypatch, RecordingS3FileSystem())
 
     result = CliRunner().invoke(cli, ["rm", "-R", "s3://bucket/prefix"])
 
@@ -447,11 +454,11 @@ def test_rm_retries_a_throttled_bulk_delete(monkeypatch):
     A large removal provokes exactly this, and treating it as fatal aborts the run after
     a partial delete.
     """
-    fs = _BulkDeleteS3FileSystem([[{"Key": "prefix/0", "Code": "SlowDown"}], []])
-    monkeypatch.setattr(deletion, "_DELETE_BACKOFF", timing.ExponentialBackoff(initial=0.001, maximum=0.001))
-    monkeypatch.setattr(deletion, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
-    monkeypatch.setattr(listing, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
-    monkeypatch.setattr(cli_module, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+    fs = _install_object_store_filesystem(
+        monkeypatch,
+        _BulkDeleteS3FileSystem([[{"Key": "prefix/0", "Code": "SlowDown"}], []]),
+    )
+    monkeypatch.setattr(bulk_deletion, "_DELETE_BACKOFF", timing.ExponentialBackoff(initial=0.001, maximum=0.001))
 
     result = CliRunner().invoke(cli, ["rm", "-R", "s3://bucket/prefix"])
 
@@ -459,11 +466,17 @@ def test_rm_retries_a_throttled_bulk_delete(monkeypatch):
     assert fs.attempts == 2
 
 
-def test_rm_fails_on_a_permanent_bulk_delete_error(monkeypatch):
-    fs = _BulkDeleteS3FileSystem([[{"Key": "prefix/0", "Code": "AccessDenied"}]])
-    monkeypatch.setattr(deletion, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
-    monkeypatch.setattr(listing, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
-    monkeypatch.setattr(cli_module, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+def test_rm_does_not_retry_a_batch_holding_a_permanent_error(monkeypatch):
+    failures = [
+        [
+            {"Key": "prefix/0", "Code": "SlowDown"},
+            {"Key": "prefix/1", "Code": "AccessDenied"},
+        ]
+    ]
+    fs = _install_object_store_filesystem(
+        monkeypatch,
+        _BulkDeleteS3FileSystem(failures),
+    )
 
     result = CliRunner().invoke(cli, ["rm", "-R", "s3://bucket/prefix"])
 
@@ -471,14 +484,7 @@ def test_rm_fails_on_a_permanent_bulk_delete_error(monkeypatch):
     assert fs.attempts == 1
 
 
-def test_rm_batches_through_a_filesystem_wrapper(monkeypatch):
-    """Backend dispatch must survive a proxy that forwards the protocol but not the class.
-
-    `filesystem_for` hands back a `CrossRegionGuardedFS` for every GCS URL, which does not
-    subclass `GCSFileSystem`. An `isinstance` check misses it, and the batch size silently
-    collapses to one object per request.
-    """
-
+def test_rm_pages_and_batches_through_a_filesystem_wrapper(monkeypatch):
     class RecordingGCSFileSystem:
         protocol = ("gs", "gcs")
 
@@ -488,33 +494,35 @@ def test_rm_batches_through_a_filesystem_wrapper(monkeypatch):
         def isdir(self, _path):
             return True
 
-        def ls(self, path, detail):
-            assert detail is True
-            return [{"name": f"{path}/{index}", "size": 1, "type": "file"} for index in range(250)]
+        def split_path(self, path):
+            bucket, key = path.split("/", 1)
+            return bucket, key, None
 
-        def rm(self, paths, **_kwargs):
-            self.batch_sizes.append(len(paths))
+        def call(self, _method, _template, _bucket, *, pageToken=None, **_kwargs):
+            start = int(pageToken or 0)
+            end = min(start + 100, 250)
+            page = {"items": [{"name": f"prefix/{index}", "size": "1"} for index in range(start, end)]}
+            if end < 250:
+                page["nextPageToken"] = str(end)
+            return page
+
+        def _process_object(self, bucket, item):
+            return {"name": f"{bucket}/{item['name']}", "size": int(item["size"]), "type": "file"}
+
+        def rm(self, paths, **kwargs):
+            self.batch_sizes.append((len(paths), kwargs["batchsize"]))
 
         def invalidate_cache(self):
             pass
 
-    class GuardWrapper:
-        def __init__(self, fs):
-            self._fs = fs
-
-        def __getattr__(self, name):
-            return getattr(self._fs, name)
-
     inner = RecordingGCSFileSystem()
-    fs = GuardWrapper(inner)
-    monkeypatch.setattr(deletion, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
-    monkeypatch.setattr(listing, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
-    monkeypatch.setattr(cli_module, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+    guarded = CrossRegionGuardedFS(inner, cross_region_checker=lambda _bucket: False)
+    _install_object_store_filesystem(monkeypatch, guarded)
 
     result = CliRunner().invoke(cli, ["rm", "-R", "gs://bucket/prefix"])
 
     assert result.exit_code == 0, result.output
-    assert sorted(inner.batch_sizes) == [50, 100, 100]
+    assert sorted(inner.batch_sizes) == [(50, 100), (100, 100), (100, 100)]
 
 
 def test_rm_deletes_while_the_listing_still_streams(monkeypatch):
@@ -561,10 +569,7 @@ def test_rm_deletes_while_the_listing_still_streams(monkeypatch):
         def invalidate_cache(self):
             pass
 
-    fs = BlockingS3FileSystem()
-    monkeypatch.setattr(deletion, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
-    monkeypatch.setattr(listing, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
-    monkeypatch.setattr(cli_module, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+    fs = _install_object_store_filesystem(monkeypatch, BlockingS3FileSystem())
 
     result = CliRunner().invoke(cli, ["rm", "-R", "s3://bucket/prefix", "--workers", "1"])
 
@@ -835,7 +840,7 @@ def test_usage_scan_splits_large_s3_prefixes_to_bounded_depth(monkeypatch):
             assert prefix == "scratch//"
             return {"Contents": [{"Key": "scratch//data", "Size": 40, "LastModified": modified}]}
 
-    fs = PagedS3FileSystem()
+    fs = with_listing(PagedS3FileSystem())
     monkeypatch.setattr(listing, "filesystem_for", lambda _url: (fs, "bucket"))
 
     progress = []
@@ -878,7 +883,7 @@ def test_usage_scan_retries_transient_s3_page_failures(monkeypatch):
                 raise EndpointConnectionError(endpoint_url="https://bucket.example.com")
             return {"Contents": [{"Key": "data", "Size": 10}]}
 
-    fs = ResettingS3FileSystem()
+    fs = with_listing(ResettingS3FileSystem())
     monkeypatch.setattr(listing, "filesystem_for", lambda _url: (fs, "bucket"))
     monkeypatch.setattr(timing.time, "sleep", lambda _delay: None)
 

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -19,7 +19,7 @@ import rigging.fsutil.transfer as transfer_module
 import rigging.timing as timing
 from botocore.exceptions import EndpointConnectionError
 from click.testing import CliRunner
-from rigging.fsutil import listing
+from rigging.fsutil import deletion, listing
 from rigging.fsutil.cli import cli
 from rigging.fsutil.listing import MAX_PREVIEW_BYTES, read_decompressed_preview
 from rigging.fsutil.render import file_lines
@@ -375,25 +375,24 @@ def test_rm_recursive_unlinks_local_directory_symlink_without_deleting_target(tm
 
 def test_rm_uses_s3_bulk_delete_batches(monkeypatch):
     class RecordingS3FileSystem:
+        protocol = "s3"
+
         def __init__(self):
             self.requests = []
+            self.config_kwargs = {}
 
         def isdir(self, _path):
             return True
-
-        def find(self, path, *, detail):
-            assert path == "bucket/prefix"
-            assert detail is True
-            return {
-                f"bucket/prefix/{index}": {"name": f"bucket/prefix/{index}", "size": 1, "type": "file"}
-                for index in range(1001)
-            }
 
         def split_path(self, path):
             bucket, key = path.split("/", 1)
             return bucket, key, None
 
         def call_s3(self, method, **kwargs):
+            if method == "list_objects_v2":
+                assert kwargs["Prefix"] == "prefix/"
+                contents = [{"Key": f"prefix/{index}", "Size": 1} for index in range(1001)]
+                return {"Contents": contents}
             assert method == "delete_objects"
             self.requests.append(kwargs)
             return {}
@@ -402,7 +401,8 @@ def test_rm_uses_s3_bulk_delete_batches(monkeypatch):
             pass
 
     fs = RecordingS3FileSystem()
-    monkeypatch.setattr(cli_module, "S3FileSystem", RecordingS3FileSystem)
+    monkeypatch.setattr(deletion, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+    monkeypatch.setattr(listing, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
     monkeypatch.setattr(cli_module, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
 
     result = CliRunner().invoke(cli, ["rm", "-R", "s3://bucket/prefix"])
@@ -411,6 +411,108 @@ def test_rm_uses_s3_bulk_delete_batches(monkeypatch):
     batches = [request["Delete"]["Objects"] for request in fs.requests]
     assert sorted(map(len, batches)) == [1, 1000]
     assert {item["Key"] for batch in batches for item in batch} == {f"prefix/{index}" for index in range(1001)}
+
+
+def test_rm_batches_through_a_filesystem_wrapper(monkeypatch):
+    """Backend dispatch must survive a proxy that forwards the protocol but not the class.
+
+    `filesystem_for` hands back a `CrossRegionGuardedFS` for every GCS URL, which does not
+    subclass `GCSFileSystem`. An `isinstance` check misses it, and the batch size silently
+    collapses to one object per request.
+    """
+
+    class RecordingGCSFileSystem:
+        protocol = ("gs", "gcs")
+
+        def __init__(self):
+            self.batch_sizes = []
+
+        def isdir(self, _path):
+            return True
+
+        def ls(self, path, detail):
+            assert detail is True
+            return [{"name": f"{path}/{index}", "size": 1, "type": "file"} for index in range(250)]
+
+        def rm(self, paths, **_kwargs):
+            self.batch_sizes.append(len(paths))
+
+        def invalidate_cache(self):
+            pass
+
+    class GuardWrapper:
+        def __init__(self, fs):
+            self._fs = fs
+
+        def __getattr__(self, name):
+            return getattr(self._fs, name)
+
+    inner = RecordingGCSFileSystem()
+    fs = GuardWrapper(inner)
+    monkeypatch.setattr(deletion, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+    monkeypatch.setattr(listing, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+    monkeypatch.setattr(cli_module, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+
+    result = CliRunner().invoke(cli, ["rm", "-R", "gs://bucket/prefix"])
+
+    assert result.exit_code == 0, result.output
+    assert sorted(inner.batch_sizes) == [50, 100, 100]
+
+
+def test_rm_deletes_while_the_listing_still_streams(monkeypatch):
+    """A prefix wider than one page must not wait for the whole scan before deleting.
+
+    The first delete has to land while later pages are still outstanding; otherwise a
+    prefix with tens of millions of objects buys a full scan, and the memory to hold it,
+    before it removes anything.
+    """
+
+    class BlockingS3FileSystem:
+        protocol = "s3"
+        pages = 3
+
+        def __init__(self):
+            self.first_delete = threading.Event()
+            self.streamed = False
+            self.deleted_keys = set()
+            self.config_kwargs = {}
+
+        def isdir(self, _path):
+            return True
+
+        def split_path(self, path):
+            bucket, key = path.split("/", 1)
+            return bucket, key, None
+
+        def call_s3(self, method, **kwargs):
+            if method == "delete_objects":
+                self.deleted_keys.update(item["Key"] for item in kwargs["Delete"]["Objects"])
+                self.first_delete.set()
+                return {}
+            page = int((kwargs.get("ContinuationToken") or "token-0").removeprefix("token-"))
+            start = page * 1000
+            contents = [{"Key": f"prefix/{index}", "Size": 1} for index in range(start, start + 1000)]
+            if page < self.pages - 1:
+                return {"Contents": contents, "NextContinuationToken": f"token-{page + 1}"}
+            # The final page is served only once an earlier batch has already been
+            # deleted, so a scan-then-delete implementation deadlocks here instead of
+            # quietly passing.
+            self.streamed = self.first_delete.wait(timeout=30)
+            return {"Contents": contents}
+
+        def invalidate_cache(self):
+            pass
+
+    fs = BlockingS3FileSystem()
+    monkeypatch.setattr(deletion, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+    monkeypatch.setattr(listing, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+    monkeypatch.setattr(cli_module, "filesystem_for", lambda _url: (fs, "bucket/prefix"))
+
+    result = CliRunner().invoke(cli, ["rm", "-R", "s3://bucket/prefix", "--workers", "1"])
+
+    assert result.exit_code == 0, result.output
+    assert fs.streamed, "the last listing page was reached before any object was deleted"
+    assert fs.deleted_keys == {f"prefix/{index}" for index in range(3000)}
 
 
 def test_json_previews_render_as_tables_and_degrade_safely():

--- a/lib/rigging/tests/test_paged_listing.py
+++ b/lib/rigging/tests/test_paged_listing.py
@@ -75,6 +75,15 @@ def test_s3_flat_pages_resume_by_token_and_drop_self_marker(monkeypatch):
     assert calls == [("root/", None), ("root/", "page-2")]
 
 
+def test_s3_level_pages_preserve_an_empty_path_segment(monkeypatch):
+    responses = {None: {"CommonPrefixes": [{"Prefix": "root/a//"}]}}
+    fs, _ = _s3_filesystem(monkeypatch, responses, expected_delimiter="/")
+
+    pages = list(fs.listing.level_pages("bucket/root/a/"))
+
+    assert pages == [([], ["bucket/root/a//"])]
+
+
 def test_gcs_level_pages_split_files_from_subdirs_and_drop_self_marker(monkeypatch):
     fs = GCSFileSystem(token="anon", skip_instance_cache=True)
 


### PR DESCRIPTION
Recursive `fsutil rm` now deletes remote prefixes while their paged listing is still running. The previous `find` materialized every object and its metadata before the first delete; a 60M-object prefix needed over 60 GB and failed before removing anything.

This extends #8382's filesystem-construction boundary. `filesystem_for` attaches backend-selected paging and deletion as `fs.listing` and `fs.deletion`, and `fsutil` schedules both without inspecting backend protocols. S3 and GCS drive continuation tokens directly, so flat prefixes arrive page by page. Object keys containing empty path segments remain distinct from prefix marker objects.

S3 sends up to 1,000 keys per `DeleteObjects`; GCS sends 100 subrequests per batch. `--workers` controls concurrent delete requests and defaults to 16. S3 response-body errors retry when every reported key failure is transient, while a batch containing a permanent error fails immediately. GCS listing concurrency shares its 100-connection session with active deletes.

Measured against `gs://marin-us-central2`:

| shape | before | after |
| --- | ---: | ---: |
| 3,000 objects across 20 sub-prefixes | 83.3s | 3.9s |
| 2,500 objects in one flat prefix | listed in one response | 4.8s |

At 60M objects, a bucket lifecycle rule remains the better tool. GCS admits roughly 1,000 writes per second and counts deletes as writes, so the floor is about 17 hours regardless of client concurrency.
