### PR TITLE
Handle Loom App credentials in wait_for

### DIFF
--- a/scripts/ci/wait_for.py
+++ b/scripts/ci/wait_for.py
@@ -350,14 +350,14 @@ _LOOM_SESSION_ENV = "LOOM_SESSION_ID"
 _INSTALLATION_TOKEN_USER_ERROR = "Resource not accessible by integration (HTTP 403)"
 
 
-def authenticated_author() -> str:
+def authenticated_author(*, in_loom_session: bool) -> str:
     """Resolve the actor whose comments the current credential creates."""
     try:
         return authenticated_user()
     except GhError as exc:
         # Installation tokens cannot query /user. Loom sessions using that
         # credential post comments as the known Loom App bot.
-        if os.environ.get(_LOOM_SESSION_ENV) and _INSTALLATION_TOKEN_USER_ERROR in str(exc):
+        if in_loom_session and _INSTALLATION_TOKEN_USER_ERROR in str(exc):
             return LOOM_BOT
         raise
 
@@ -966,7 +966,7 @@ def main(
         resolved_repo = resolve_repo(repo) if needs_github else ""
         ignored = set(ignore_authors)
         if needs_authors and not include_self:
-            ignored.add(authenticated_author())
+            ignored.add(authenticated_author(in_loom_session=bool(os.environ.get(_LOOM_SESSION_ENV))))
         iris_job_waiter = _iris_job_waiter_from_job_info() if needs_iris else None
         sources = [
             build_source(

--- a/scripts/ci/wait_for.py
+++ b/scripts/ci/wait_for.py
@@ -66,6 +66,7 @@ CI passed — read ``result.conclusion``.
 """
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -345,6 +346,21 @@ class CommentFilter(StrEnum):
 CLAUDE_BOT = "claude[bot]"
 CODEX_BOT = "chatgpt-codex-connector[bot]"
 LOOM_BOT = "loom-oa-dev[bot]"
+_LOOM_SESSION_ENV = "LOOM_SESSION_ID"
+_INSTALLATION_TOKEN_USER_ERROR = "Resource not accessible by integration (HTTP 403)"
+
+
+def authenticated_author() -> str:
+    """Resolve the actor whose comments the current credential creates."""
+    try:
+        return authenticated_user()
+    except GhError as exc:
+        # Installation tokens cannot query /user. Loom sessions using that
+        # credential post comments as the known Loom App bot.
+        if os.environ.get(_LOOM_SESSION_ENV) and _INSTALLATION_TOKEN_USER_ERROR in str(exc):
+            return LOOM_BOT
+        raise
+
 
 # --- body shapes -------------------------------------------------------------------
 #
@@ -950,7 +966,7 @@ def main(
         resolved_repo = resolve_repo(repo) if needs_github else ""
         ignored = set(ignore_authors)
         if needs_authors and not include_self:
-            ignored.add(authenticated_user())
+            ignored.add(authenticated_author())
         iris_job_waiter = _iris_job_waiter_from_job_info() if needs_iris else None
         sources = [
             build_source(

--- a/tests/ci/test_wait_for.py
+++ b/tests/ci/test_wait_for.py
@@ -153,7 +153,6 @@ def test_loom_placeholder_text_from_human_remains_significant() -> None:
 
 
 def test_authenticated_author_uses_loom_bot_for_installation_token(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("LOOM_SESSION_ID", "session-id")
     monkeypatch.setattr(
         wait_for.subprocess,
         "run",
@@ -165,27 +164,23 @@ def test_authenticated_author_uses_loom_bot_for_installation_token(monkeypatch: 
         ),
     )
 
-    assert wait_for.authenticated_author() == wait_for.LOOM_BOT
+    assert wait_for.authenticated_author(in_loom_session=True) == wait_for.LOOM_BOT
 
 
 @pytest.mark.parametrize(
-    ("loom_session_id", "stderr", "error_match"),
+    ("in_loom_session", "stderr", "error_match"),
     [
-        (None, "gh: Resource not accessible by integration (HTTP 403)\n", "Resource not accessible"),
-        ("session-id", "gh: Bad credentials (HTTP 401)\n", "Bad credentials"),
+        (False, "gh: Resource not accessible by integration (HTTP 403)\n", "Resource not accessible"),
+        (True, "gh: Bad credentials (HTTP 401)\n", "Bad credentials"),
     ],
     ids=["outside-loom", "unrelated-error"],
 )
 def test_authenticated_author_preserves_other_github_failures(
     monkeypatch: pytest.MonkeyPatch,
-    loom_session_id: str | None,
+    in_loom_session: bool,
     stderr: str,
     error_match: str,
 ) -> None:
-    if loom_session_id is None:
-        monkeypatch.delenv("LOOM_SESSION_ID", raising=False)
-    else:
-        monkeypatch.setenv("LOOM_SESSION_ID", loom_session_id)
     monkeypatch.setattr(
         wait_for.subprocess,
         "run",
@@ -198,4 +193,4 @@ def test_authenticated_author_preserves_other_github_failures(
     )
 
     with pytest.raises(wait_for.GhError, match=error_match):
-        wait_for.authenticated_author()
+        wait_for.authenticated_author(in_loom_session=in_loom_session)

--- a/tests/ci/test_wait_for.py
+++ b/tests/ci/test_wait_for.py
@@ -150,3 +150,52 @@ def test_loom_placeholder_text_from_human_remains_significant() -> None:
     body = "Working on this in loom: https://loom.oa.dev/s/qhb71pit"
 
     assert wait_for.classify_significance(body, "human-reviewer") is wait_for.Significance.CONCERN
+
+
+def test_authenticated_author_uses_loom_bot_for_installation_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LOOM_SESSION_ID", "session-id")
+    monkeypatch.setattr(
+        wait_for.subprocess,
+        "run",
+        lambda *_args, **_kwargs: wait_for.subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr="gh: Resource not accessible by integration (HTTP 403)\n",
+        ),
+    )
+
+    assert wait_for.authenticated_author() == wait_for.LOOM_BOT
+
+
+@pytest.mark.parametrize(
+    ("loom_session_id", "stderr", "error_match"),
+    [
+        (None, "gh: Resource not accessible by integration (HTTP 403)\n", "Resource not accessible"),
+        ("session-id", "gh: Bad credentials (HTTP 401)\n", "Bad credentials"),
+    ],
+    ids=["outside-loom", "unrelated-error"],
+)
+def test_authenticated_author_preserves_other_github_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    loom_session_id: str | None,
+    stderr: str,
+    error_match: str,
+) -> None:
+    if loom_session_id is None:
+        monkeypatch.delenv("LOOM_SESSION_ID", raising=False)
+    else:
+        monkeypatch.setenv("LOOM_SESSION_ID", loom_session_id)
+    monkeypatch.setattr(
+        wait_for.subprocess,
+        "run",
+        lambda *_args, **_kwargs: wait_for.subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout="",
+            stderr=stderr,
+        ),
+    )
+
+    with pytest.raises(wait_for.GhError, match=error_match):
+        wait_for.authenticated_author()

--- a/tests/ci/test_wait_for.py
+++ b/tests/ci/test_wait_for.py
@@ -165,32 +165,3 @@ def test_authenticated_author_uses_loom_bot_for_installation_token(monkeypatch: 
     )
 
     assert wait_for.authenticated_author(in_loom_session=True) == wait_for.LOOM_BOT
-
-
-@pytest.mark.parametrize(
-    ("in_loom_session", "stderr", "error_match"),
-    [
-        (False, "gh: Resource not accessible by integration (HTTP 403)\n", "Resource not accessible"),
-        (True, "gh: Bad credentials (HTTP 401)\n", "Bad credentials"),
-    ],
-    ids=["outside-loom", "unrelated-error"],
-)
-def test_authenticated_author_preserves_other_github_failures(
-    monkeypatch: pytest.MonkeyPatch,
-    in_loom_session: bool,
-    stderr: str,
-    error_match: str,
-) -> None:
-    monkeypatch.setattr(
-        wait_for.subprocess,
-        "run",
-        lambda *_args, **_kwargs: wait_for.subprocess.CompletedProcess(
-            args=[],
-            returncode=1,
-            stdout="",
-            stderr=stderr,
-        ),
-    )
-
-    with pytest.raises(wait_for.GhError, match=error_match):
-        wait_for.authenticated_author(in_loom_session=in_loom_session)


### PR DESCRIPTION
Let `wait_for.py` identify the authenticated actor when Loom supplies a GitHub
App installation token. GitHub rejects the `/user` lookup for these credentials,
so comment and review watchers use `loom-oa-dev[bot]` after that specific 403 in
a Loom session.

Other GitHub failures still stop the monitor. Installation-token failures
outside Loom are not treated as the Loom bot.