### PR TITLE
[levanter] Accumulate FP8 state across microbatches

### DIFF
--- a/lib/haliax/docs/fp8.md
+++ b/lib/haliax/docs/fp8.md
@@ -142,6 +142,10 @@ you will get the gradient computation as normal, but you'll also get the updated
 This updated state needs to directly replace the state in the module (rather than be used for a gradient step), which is
 why you need to use the [haliax.quantization.partition_for_grad_overwrite][]
 
+During microbatch gradient accumulation, [haliax.quantization.accumulate_gradients][] sums ordinary gradients and
+delegates gradient-carried state to [haliax.quantization.CustomGradientAccumulation.accumulate][]. FP8 accumulation
+takes the maximum of the amax histories observed across microbatches and does not average scale or history state.
+
 The FP8 `dot_general` module is implemented in [haliax.quantization.Fp8DotGeneralOp][]. It's actually not that complicated:
 
 1) It holds a scaling factor and history of maximum values for each of (lhs, rhs, output) and updates them based on the
@@ -164,13 +168,14 @@ information on how it works.
 ## Functions
 
 ::: haliax.quantization.quantize_linear_layers
+::: haliax.quantization.accumulate_gradients
 ::: haliax.quantization.partition_for_grad_overwrite
 ::: haliax.quantization.apply_updates
 
 
 ## Interfaces
 ::: haliax.quantization.DotGeneralOp
-::: haliax.quantization.OverwriteWithGradient
+::: haliax.quantization.CustomGradientAccumulation
 
 ## Modules
 

--- a/lib/haliax/src/haliax/_src/fp8.py
+++ b/lib/haliax/src/haliax/_src/fp8.py
@@ -114,7 +114,7 @@ def in_q_fwd(compute_dtype, q_dtype, inp, scale, amax_history):
 def in_q_bwd(compute_dtype, q_dtype, res, _):
     new_scale, new_history = res
     # No gradient flows to inp/scale/amax_history; pass the updated scale and
-    # history through as the cotangents so that OverwriteWithGradient overwrites
+    # history through as the cotangents so that CustomGradientAccumulation overwrites
     # the persisted state with them.
     return None, new_scale, new_history
 

--- a/lib/haliax/src/haliax/quantization.py
+++ b/lib/haliax/src/haliax/quantization.py
@@ -10,7 +10,7 @@ import functools
 import re
 import warnings
 from dataclasses import dataclass
-from typing import Protocol, TypeVar
+from typing import Protocol, Self, TypeVar
 
 import aqt.jax.v2.config as aqt_config
 import equinox as eqx
@@ -33,18 +33,19 @@ from .hof import vmap
 T = TypeVar("T")
 
 
-class OverwriteWithGradient(eqx.Module):
-    """
-    Sometimes there is state that must be computed in the backward pass which we want to
-    persist for subsequent passes. Typically, we see this with quantization, particularly
-    FP8. This module is a marker that indicates to [haliax.quantization.apply_updates][] that the
-    gradient should be used to overwrite the state rather than added to it.
+class CustomGradientAccumulation(eqx.Module):
+    """State carried through gradients with a custom microbatch reduction.
 
-    Typically this is used in conjunction with [haliax.quantization.partition_for_grad_overwrite][]
-    and the types are kinds of DotGeneralOp.
+    Subclasses must implement an associative
+    [accumulate][haliax.quantization.CustomGradientAccumulation.accumulate] operation. These objects
+    bypass the optimizer and overwrite the corresponding model state when passed through
+    [haliax.quantization.apply_updates][]. The first call receives a zero-like ``self``, which the
+    implementation must treat as an identity.
     """
 
-    pass
+    def accumulate(self, other: Self) -> Self:
+        """Combines state produced by two gradient evaluations."""
+        raise NotImplementedError
 
 
 def partition_for_grad_overwrite(grad: T) -> tuple[T, T]:
@@ -64,14 +65,37 @@ def partition_for_grad_overwrite(grad: T) -> tuple[T, T]:
 
     """
 
-    def is_overwrite_with_gradient(v):
-        return isinstance(v, OverwriteWithGradient)
+    def is_custom_gradient_accumulation(v):
+        return isinstance(v, CustomGradientAccumulation)
 
     def is_leaf(v):
-        return isinstance(v, (OverwriteWithGradient, NamedArray))
+        return isinstance(v, (CustomGradientAccumulation, NamedArray))
 
-    x, y = eqx.partition(grad, is_overwrite_with_gradient, is_leaf=is_leaf)
+    x, y = eqx.partition(grad, is_custom_gradient_accumulation, is_leaf=is_leaf)
     return x, y
+
+
+def accumulate_gradients(accumulated: T, gradient: T) -> T:
+    """Accumulates additive gradients and custom gradient-carried state."""
+
+    def _accumulate(accumulated_leaf, gradient_leaf):
+        if isinstance(accumulated_leaf, CustomGradientAccumulation):
+            if type(accumulated_leaf) is not type(gradient_leaf):
+                raise ValueError(
+                    "Custom gradient accumulation requires matching types, got "
+                    f"{type(accumulated_leaf).__name__} and {type(gradient_leaf).__name__}"
+                )
+            return accumulated_leaf.accumulate(gradient_leaf)
+        if accumulated_leaf is None:
+            return gradient_leaf
+        if gradient_leaf is None:
+            return accumulated_leaf
+        return accumulated_leaf + gradient_leaf
+
+    def is_leaf(value):
+        return value is None or isinstance(value, (CustomGradientAccumulation, NamedArray))
+
+    return jax.tree_util.tree_map(_accumulate, accumulated, gradient, is_leaf=is_leaf)
 
 
 def apply_updates(tree, updates, overwrites):
@@ -94,7 +118,7 @@ def apply_updates(tree, updates, overwrites):
         return eqx.apply_updates(tree, update)
 
     def is_leaf(x):
-        return x is None or isinstance(x, OverwriteWithGradient) or isinstance(x, NamedArray)
+        return x is None or isinstance(x, CustomGradientAccumulation) or isinstance(x, NamedArray)
 
     return jax.tree_util.tree_map(_apply_update, tree, updates, overwrites, is_leaf=is_leaf)
 
@@ -151,7 +175,7 @@ class DefaultDotGeneralOp(eqx.Module):
         return DefaultDotGeneralOp._instance
 
 
-class Fp8DotGeneralOp(OverwriteWithGradient):
+class Fp8DotGeneralOp(CustomGradientAccumulation):
     """Direct-quantization FP8 ``dot_general`` op for [haliax.nn.Linear][].
 
     Casts both operands to FP8 and contracts them, then dequantizes the result,
@@ -160,7 +184,7 @@ class Fp8DotGeneralOp(OverwriteWithGradient):
     Output gradients are quantized to FP8 in the custom VJP of
     [fp8_scaled_dot_general][], which also carries the delayed-scaling state
     (per-tensor scale + amax history for the input, kernel and output gradient)
-    updated as an [OverwriteWithGradient][].
+    updated as a [CustomGradientAccumulation][].
 
     The forward-operand (``fwd_dtype``) and output-gradient (``rev_dtype``)
     quantization dtypes default to E4M3 and E5M2.
@@ -233,8 +257,18 @@ class Fp8DotGeneralOp(OverwriteWithGradient):
             rev_dtype=self.rev_dtype,
         )
 
+    def accumulate(self, other: Self) -> Self:
+        # Every microbatch starts from the same persisted state, so its scale values and the rolled
+        # history tail match. Keep the latest copy and reduce the new amax entry across microbatches.
+        return dataclasses.replace(
+            other,
+            input_amax_history=jnp.maximum(self.input_amax_history, other.input_amax_history),
+            output_grad_amax_history=jnp.maximum(self.output_grad_amax_history, other.output_grad_amax_history),
+            kernel_amax_history=jnp.maximum(self.kernel_amax_history, other.kernel_amax_history),
+        )
 
-class Int8DotGeneralOp(OverwriteWithGradient):
+
+class Int8DotGeneralOp(CustomGradientAccumulation):
 
     cfg: DotGeneral
 
@@ -254,6 +288,9 @@ class Int8DotGeneralOp(OverwriteWithGradient):
     ):
         cfg = aqt_config.set_context(self.cfg, jrandom.PRNGKey(42), train_step=None)
         return cfg(lhs, rhs, dimension_numbers, precision, preferred_element_type)
+
+    def accumulate(self, other: Self) -> Self:
+        return other
 
     def to_state_dict(tree: PyTree, prefix: str | None = None) -> StateDict:
         warnings.warn("Ignore all int8 states (if any) for now.")

--- a/lib/haliax/src/haliax/quantization.py
+++ b/lib/haliax/src/haliax/quantization.py
@@ -80,7 +80,9 @@ def accumulate_gradients(accumulated: T, gradient: T) -> T:
 
     def _accumulate(accumulated_leaf, gradient_leaf):
         if isinstance(accumulated_leaf, CustomGradientAccumulation):
-            if type(accumulated_leaf) is not type(gradient_leaf):
+            if not isinstance(gradient_leaf, CustomGradientAccumulation) or type(accumulated_leaf) is not type(
+                gradient_leaf
+            ):
                 raise ValueError(
                     "Custom gradient accumulation requires matching types, got "
                     f"{type(accumulated_leaf).__name__} and {type(gradient_leaf).__name__}"

--- a/lib/levanter/src/levanter/grad_accum.py
+++ b/lib/levanter/src/levanter/grad_accum.py
@@ -41,8 +41,9 @@ def microbatched(
 
     ``fn`` must return ``((loss, metrics), grads)`` (i.e. the output of
     ``eqx.filter_value_and_grad(loss_fn, has_aux=True)`` where ``loss_fn`` returns
-    ``(loss, metrics)``). The batch axis is split into microbatches; the loss and grads are summed
-    then averaged over the microbatches, while ``metrics`` are folded with their own reductions.
+    ``(loss, metrics)``). The batch axis is split into microbatches; the loss and ordinary gradients
+    are summed then averaged, custom gradient state uses its own reduction without averaging, and
+    ``metrics`` are folded with their own reductions.
     Named arrays with ``Batch`` and plain arrays whose leading dimension is ``Batch.size`` are split;
     other inputs are reused for every microbatch.
 

--- a/lib/levanter/src/levanter/grad_accum.py
+++ b/lib/levanter/src/levanter/grad_accum.py
@@ -43,6 +43,8 @@ def microbatched(
     ``eqx.filter_value_and_grad(loss_fn, has_aux=True)`` where ``loss_fn`` returns
     ``(loss, metrics)``). The batch axis is split into microbatches; the loss and grads are summed
     then averaged over the microbatches, while ``metrics`` are folded with their own reductions.
+    Named arrays with ``Batch`` and plain arrays whose leading dimension is ``Batch.size`` are split;
+    other inputs are reused for every microbatch.
 
     Args:
         fn: the value-and-grad function to wrap.
@@ -102,10 +104,20 @@ def microbatched(
             kwargs = kwargs.copy()
             kwargs.pop(patch_in_rng_key)
 
-        args = _reshape_for_microbatch(Batch, Microbatch, AccumStep, args, compute_axis_mapping)
+        def is_batched(value):
+            if isinstance(value, hax.NamedArray):
+                return value.has_axis(Batch.name)
+            return isinstance(value, jnp.ndarray) and value.ndim > 0 and value.shape[0] == Batch.size
+
+        def is_input_leaf(value):
+            return is_named_array(value) or isinstance(value, hq.CustomGradientAccumulation)
+
+        batched_inputs, unbatched_inputs = eqx.partition((args, kwargs), is_batched, is_leaf=is_input_leaf)
+        batched_inputs = _reshape_for_microbatch(Batch, Microbatch, AccumStep, batched_inputs, compute_axis_mapping)
 
         def loop(acc, microbatch_and_key):
-            microbatch, microbatch_kwargs, key = microbatch_and_key
+            microbatch_inputs, key = microbatch_and_key
+            microbatch, microbatch_kwargs = eqx.combine(microbatch_inputs, unbatched_inputs, is_leaf=is_input_leaf)
             with jax.named_scope("compute"):
                 microbatch_kwargs = microbatch_kwargs.copy()
                 if key is not None:
@@ -127,10 +139,7 @@ def microbatched(
                     is_leaf=lambda x: isinstance(x, Metric),
                 )
 
-                # Accumulate gradients with quantization
-                # TODO: this uses the latest value for the scale for fp8, which seems not ideal but probably ok?
-                overwrites, updates = hq.partition_for_grad_overwrite(this_grads)
-                new_grads = hq.apply_updates(acc_grads, updates, overwrites)
+                new_grads = hq.accumulate_gradients(acc_grads, this_grads)
 
                 # Repack and shard
                 acc = ((new_loss, new_metrics), new_grads)
@@ -139,12 +148,16 @@ def microbatched(
             return acc
 
         with jax.named_scope("microbatched"):
-            acc = hax.fold(loop, AccumStep)(acc, (args, kwargs, key))
+            acc = hax.fold(loop, AccumStep)(acc, (batched_inputs, key))
 
             # Average loss and grads over microbatches. Metrics handle their own reduction internally.
             (loss, metrics), grads = acc
             loss = loss / num_micro_steps
-            grads = jax.tree_util.tree_map(lambda x: x / num_micro_steps, grads)
+            grads = jax.tree_util.tree_map(
+                lambda x: x if isinstance(x, hq.CustomGradientAccumulation) else x / num_micro_steps,
+                grads,
+                is_leaf=lambda x: isinstance(x, hq.CustomGradientAccumulation),
+            )
             acc = ((loss, metrics), grads)
 
         return cast(R, acc)
@@ -159,7 +172,7 @@ def _reshape_for_microbatch(Batch: Axis, Microbatch: Axis, AccumStep: Axis, inpu
                 return x
             x = x.unflatten_axis(Batch, (AccumStep, Microbatch))
             return hax.shard(x, axis_mapping)
-        elif isinstance(x, jnp.ndarray):
+        elif isinstance(x, jnp.ndarray) and x.ndim > 0 and x.shape[0] == Batch.size:
             x = x.reshape((AccumStep.size, Microbatch.size) + x.shape[1:])
             return with_sharding_constraint(x, PartitionSpec(None, ResourceAxis.DATA, *(None,) * (len(x.shape) - 2)))
         else:

--- a/lib/levanter/tests/test_grad_accum.py
+++ b/lib/levanter/tests/test_grad_accum.py
@@ -85,6 +85,7 @@ def test_accumulate_gradients_sharded(parallelism, accum_steps):
 def test_accumulate_fp8_gradients_preserves_largest_amax_and_scale():
     microbatch_size = len(jax.devices())
     Batch = hax.Axis("Batch", 2 * microbatch_size)
+    Microbatch = Batch.resize(microbatch_size)
     In = hax.Axis("In", 8)
     Out = hax.Axis("Out", 4)
     linear = hnn.Linear.init(
@@ -117,11 +118,17 @@ def test_accumulate_fp8_gradients_preserves_largest_amax_and_scale():
         linear = hax.shard(linear, axis_mapping)
         x = jax.device_put(x, NamedSharding(mesh, PartitionSpec(ResourceAxis.DATA, None)))
         grads = accumulated_grads(linear, x)
-        full_batch_grads = eqx.filter_value_and_grad(loss_fn, has_aux=True)(linear, x)[1]
+        grad_fn = eqx.filter_value_and_grad(loss_fn, has_aux=True)
+        large_grads = grad_fn(linear, hax.full((Microbatch, In), 32.0))[1]
+        small_grads = grad_fn(linear, hax.ones((Microbatch, In)))[1]
 
     assert_trees_all_close(
         grads.dot_general.input_amax_history,
-        full_batch_grads.dot_general.input_amax_history,
+        jnp.maximum(
+            large_grads.dot_general.input_amax_history,
+            small_grads.dot_general.input_amax_history,
+        ),
     )
-    assert_trees_all_close(grads.dot_general.input_scale, full_batch_grads.dot_general.input_scale)
-    assert_trees_all_close(grads.weight, full_batch_grads.weight, atol=1e-3, rtol=1e-3)
+    assert_trees_all_close(grads.dot_general.input_scale, large_grads.dot_general.input_scale)
+    expected_weight_grads = (large_grads.weight + small_grads.weight) / 2
+    assert_trees_all_close(grads.weight, expected_weight_grads, atol=1e-3, rtol=1e-3)

--- a/lib/levanter/tests/test_grad_accum.py
+++ b/lib/levanter/tests/test_grad_accum.py
@@ -6,9 +6,11 @@ import haliax
 import haliax as hax
 import haliax.nn as hnn
 import jax
+import jax.numpy as jnp
 import pytest
 from chex import assert_trees_all_close
 from haliax.partitioning import ResourceAxis
+from haliax.quantization import Fp8DotGeneralOp
 from jax.sharding import NamedSharding, PartitionSpec
 from levanter.testing.helpers import use_test_mesh
 
@@ -78,3 +80,48 @@ def test_accumulate_gradients_sharded(parallelism, accum_steps):
 
         for l1, l2 in zip(jax.tree_util.tree_leaves(acc_g), jax.tree_util.tree_leaves(g)):
             assert_trees_all_close(l1, l2, atol=1e-3, rtol=1e-3)
+
+
+def test_accumulate_fp8_gradients_preserves_largest_amax_and_scale():
+    microbatch_size = len(jax.devices())
+    Batch = hax.Axis("Batch", 2 * microbatch_size)
+    In = hax.Axis("In", 8)
+    Out = hax.Axis("Out", 4)
+    linear = hnn.Linear.init(
+        In,
+        Out,
+        key=jax.random.PRNGKey(0),
+        dot_general=Fp8DotGeneralOp.init(amax_history_length=4),
+    )
+    x = hax.named(
+        jnp.concatenate(
+            [
+                jnp.full((microbatch_size, In.size), 32.0),
+                jnp.ones((microbatch_size, In.size)),
+            ]
+        ),
+        (Batch, In),
+    )
+    axis_mapping = {"Batch": ResourceAxis.DATA}
+
+    def loss_fn(model, inputs):
+        return hax.mean(model(inputs) ** 2).scalar(), {}
+
+    @hax.partitioning.named_jit(axis_resources=axis_mapping)
+    def accumulated_grads(model, inputs):
+        grad_fn = eqx.filter_value_and_grad(loss_fn, has_aux=True)
+        grad_fn = microbatched(grad_fn, Batch, microbatch_size, axis_mapping, axis_mapping)
+        return grad_fn(model, inputs)[1]
+
+    with use_test_mesh() as mesh:
+        linear = hax.shard(linear, axis_mapping)
+        x = jax.device_put(x, NamedSharding(mesh, PartitionSpec(ResourceAxis.DATA, None)))
+        grads = accumulated_grads(linear, x)
+        full_batch_grads = eqx.filter_value_and_grad(loss_fn, has_aux=True)(linear, x)[1]
+
+    assert_trees_all_close(
+        grads.dot_general.input_amax_history,
+        full_batch_grads.dot_general.input_amax_history,
+    )
+    assert_trees_all_close(grads.dot_general.input_scale, full_batch_grads.dot_general.input_scale)
+    assert_trees_all_close(grads.weight, full_batch_grads.weight, atol=1e-3, rtol=1e-3)


### PR DESCRIPTION
Accumulate gradient-carried state with a type-defined reduction instead of replacing it with the last microbatch. FP8 delayed scaling now takes the maximum amax history across microbatches and leaves scales and histories out of ordinary gradient averaging, preventing earlier activation maxima from being discarded or divided by the accumulation count.

Rename `OverwriteWithGradient` to `CustomGradientAccumulation` and require an associative `accumulate()` implementation. The microbatch scan keeps custom state among unbatched inputs so raw FP8 scale and history arrays are reused instead of reshaped as batch data.

Fixes #7659
