### PR TITLE
[levanter] Fused CE: bf16 backward GEMMs and a scan-carried grad_x

### DIFF
--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -58,7 +58,16 @@ _ROUTING_RENORM_SUM = 2.5
 # Large-vocab CE via the plain-XLA path (no shared-memory tiling, so v_block can be large).
 # v=4096 is the dominant MFU lever for the 128k vocab; the SMEM-tiled batched_xla kernel caps the
 # h*v weight tile at ~99KB and cannot take v=4096.
-_CE_BLOCK_SIZES = BlockSizes(v_block_size=4096)
+#
+# b_block_size is the CE forward's batch tile. The 1024 default splits the per-rank
+# B=65,536 CE shard into 64 batch blocks, and with 32 vocab blocks that is 2,048
+# forward iterations of ~11 kernels each. Measured single-GPU at the hero shape on
+# GB200 (lib/levanter/scripts/bench/bench_ce_hero_shape.py), those kernels average
+# 15.6 us with the compute stream 98.8% busy: they are back-to-back but far too
+# small to fill the SMs. Setting the tile to the whole shard turns the forward into
+# one GEMM per vocab block. Measured: forward 171.3 ms -> 81.9 ms, peak HBM +0.04 GiB.
+_CE_TOKENS_PER_RANK = 65_536
+_CE_BLOCK_SIZES = BlockSizes(b_block_size=_CE_TOKENS_PER_RANK, v_block_size=4096)
 # The embedding is fully replicated for a local lookup. The language-model head
 # is sharded across the data, expert, and model axes.
 _EMBED_PARTITION_SPEC = P(None, None)
@@ -1221,6 +1230,18 @@ class Transformer(eqx.Module):
         labels = jnp.pad(token_ids[:, 1:], ((0, 0), (0, 1))).astype(jnp.int32)
         loss_weight = loss_weight.astype(loss_dtype)
 
+        # NOTE (2026-08-17): gradients from this loss differ from hero runs before
+        # this date, and the difference is intentional. "xla_fast_bwd" keeps the
+        # same forward -- the loss is bitwise identical -- but its backward is the
+        # scan/one-hot/bf16-tensor-core rewrite, whose grad_x and grad_w are ~30%
+        # CLOSER to a float32 reference than the old "xla" backward (rel-RMS
+        # 2.170e-03 -> 1.445e-03 for grad_x, 1.946e-03 -> 1.433e-03 for grad_w,
+        # measured at this exact CE shape on GB200). Widening _CE_BLOCK_SIZES'
+        # b_block_size above moves grad_w too, for the same reason: it removes a
+        # bf16 accumulation across batch blocks. If you are diffing a checkpoint
+        # against an older run, this is why. Set LEVANTER_CE_XLA_FAST_BWD=0 to
+        # force the old backward back on without editing code, or swap this to
+        # implementation="xla" for a code-level A/B.
         cross_entropy_loss = fused_linear_softmax_cross_entropy_loss(
             hidden,
             self.output_proj,
@@ -1229,7 +1250,7 @@ class Transformer(eqx.Module):
             reduction=reduction,
             logsumexp_weight=logsumexp_weight,
             dtype=loss_dtype,
-            implementation="xla",
+            implementation="xla_fast_bwd",
             block_sizes=_CE_BLOCK_SIZES,
         )
         # Router z-loss is logged for monitoring only; it is not added to the training loss.

--- a/lib/levanter/scripts/bench/bench_ce_hero_shape.py
+++ b/lib/levanter/scripts/bench/bench_ce_hero_shape.py
@@ -1,0 +1,696 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Single-GPU fused cross-entropy benchmark at the Grug MoE EP64 hero shape.
+
+Per-rank CE shape for ``experiments/grug/moe_hero_ep`` HERO_MODEL is
+``B=65_536`` tokens, ``H=6_144``, ``V=128_256`` with bf16 activations/weights and
+an fp32 logit accumulator.  That is ~4 GB of tensors, so it fits on one GPU and
+can be measured without the 0.78-1.3%% rack placement noise floor.
+
+For every variant this reports:
+  * forward wall time, backward wall time (total minus forward)
+  * achieved TFLOP/s under both accounting conventions (see ``--help``)
+  * peak HBM bytes
+  * ``loss_diff`` and ``grad_max_abs_diff`` against a chunked float32 reference
+  * whether the forward is bitwise identical to the current production path
+
+Run one variant per process so ``peak_bytes_in_use`` is not polluted by a
+previous variant; ``--fanout`` does that automatically across the local GPUs.
+
+Examples::
+
+    # everything, fanned out over the local GPUs
+    python lib/levanter/scripts/bench/bench_ce_hero_shape.py --fanout
+
+    # a single variant in this process
+    python lib/levanter/scripts/bench/bench_ce_hero_shape.py --variants fast
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import glob
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from levanter.kernels.pallas.fused_cross_entropy_loss.batched_xla import (
+    linear_softmax_cross_entropy_loss_batched_xla,
+)
+from levanter.kernels.pallas.fused_cross_entropy_loss.config import BlockSizes
+from levanter.kernels.pallas.fused_cross_entropy_loss.xla import (
+    linear_softmax_cross_entropy_loss_xla,
+)
+
+RESULT_PREFIX = "RESULT_JSON "
+
+# experiments/grug/moe_hero_ep/heuristic.py HERO_MODEL, mesh (1, 1, 64, 1):
+# `data` and `model` are size 1, so the CE shard is the whole per-rank batch.
+HERO_B = 65_536
+HERO_H = 6_144
+HERO_V = 128_256
+# experiments/grug/moe_hero_ep/model.py:61 `_CE_BLOCK_SIZES`
+HERO_V_BLOCK = 4_096
+# BlockSizes.b_block_size default, left untouched by _CE_BLOCK_SIZES
+HERO_B_BLOCK = 1_024
+
+
+@dataclass(frozen=True)
+class Variant:
+    name: str
+    impl: str = "xla"  # "xla" | "batched_xla"
+    b_block_size: int = HERO_B_BLOCK
+    v_block_size: int = HERO_V_BLOCK
+    fast_backward: bool = False
+    bwd_batch_block_size: Optional[int] = None
+    bwd_v_block_size: Optional[int] = None
+    note: str = ""
+
+
+VARIANTS: tuple[Variant, ...] = (
+    Variant("baseline", note="today: implementation='xla', _CE_BLOCK_SIZES, nested fori_loop backward"),
+    # --- the ladder, one rung at a time ---
+    Variant("fast", fast_backward=True, note="scan + dense one-hot + bf16 dlogits, untiled batch"),
+    Variant("fast-bwdv2048", fast_backward=True, bwd_v_block_size=2048),
+    Variant("fast-bwdv8192", fast_backward=True, bwd_v_block_size=8192),
+    Variant("fast-bwdv16384", fast_backward=True, bwd_v_block_size=16384),
+    Variant("fast-bwdv32768", fast_backward=True, bwd_v_block_size=32768),
+    # --- peak-memory / speed trade: keep a batch tile in the backward ---
+    Variant("fast-bb8192", fast_backward=True, bwd_batch_block_size=8192),
+    Variant("fast-bb16384", fast_backward=True, bwd_batch_block_size=16384),
+    # --- does the forward's own batch blocking still cost anything? ---
+    Variant("baseline-fwdfull", b_block_size=HERO_B, note="forward batch blocking off, old backward"),
+    Variant("fast-fwdfull", b_block_size=HERO_B, fast_backward=True),
+    # --- maximum launch-count reduction: single-shot forward + 8-iteration backward ---
+    Variant(
+        "fast-max",
+        b_block_size=HERO_B,
+        fast_backward=True,
+        bwd_v_block_size=16384,
+        note="fwd 32 iters + bwd 8 iters (vs 2048 + 2048 at baseline)",
+    ),
+    Variant(
+        "fast-max32k",
+        b_block_size=HERO_B,
+        fast_backward=True,
+        bwd_v_block_size=32768,
+        note="fwd 32 iters + bwd 4 iters",
+    ),
+    # --- the GB10 ladder implementation as shipped, unmodified ---
+    Variant("batched_xla", impl="batched_xla", note="existing GB10-keyed ladder; may raise on GB200"),
+)
+VARIANTS_BY_NAME = {v.name: v for v in VARIANTS}
+
+
+@dataclass
+class Result:
+    variant: str
+    ok: bool = True
+    error: str = ""
+    device_kind: str = ""
+    b: int = HERO_B
+    h: int = HERO_H
+    v: int = HERO_V
+    b_block_size: int = 0
+    v_block_size: int = 0
+    bwd_v_block_size: Optional[int] = None
+    bwd_batch_block_size: Optional[int] = None
+    compile_fwd_s: float = 0.0
+    compile_total_s: float = 0.0
+    fwd_s: float = 0.0
+    total_s: float = 0.0
+    bwd_s: float = 0.0
+    # 1 GEMM forward.
+    fwd_tflops: float = 0.0
+    # 3 GEMMs in the backward: logits recompute, grad_x, grad_w.
+    bwd_tflops: float = 0.0
+    # "useful" convention: 3 GEMMs total (fwd + grad_x + grad_w), ignoring the
+    # backward's logits recompute. This is the convention behind the 405 TFLOP/s
+    # figure quoted for the hero run.
+    total_useful_tflops: float = 0.0
+    # "issued" convention: all 4 GEMMs the kernel actually runs.
+    total_issued_tflops: float = 0.0
+    peak_hbm_bytes: int = 0
+    # correctness
+    loss_max_abs_diff_vs_fp32: float = float("nan")
+    loss_mean_abs_diff_vs_fp32: float = float("nan")
+    loss_bitwise_equal_vs_baseline: Optional[bool] = None
+    loss_max_abs_diff_vs_baseline: float = float("nan")
+    gx_max_abs_diff: float = float("nan")
+    gx_rel_rms: float = float("nan")
+    gw_max_abs_diff: float = float("nan")
+    gw_rel_rms: float = float("nan")
+    # measured kernel launches for ONE fwd+bwd call (CE only, nothing else in the program)
+    fwd_launches: int = 0
+    bwd_launches: int = 0
+    total_launches: int = 0
+    mean_launch_us: float = float("nan")
+    # profiler-free launch counts derived from the optimized-HLO call graph
+    static_fwd_launches: int = 0
+    static_total_launches: int = 0
+    static_bwd_launches: int = 0
+    static_launch_ops: dict[str, int] = field(default_factory=dict)
+    # implied mean device-kernel duration, from static launches and measured wall time
+    implied_mean_launch_us: float = float("nan")
+    launch_lines: dict[str, Any] = field(default_factory=dict)
+    opt_hlo_ops: dict[str, int] = field(default_factory=dict)
+    note: str = ""
+
+
+def _gemm_flops(b: int, h: int, v: int) -> float:
+    return 2.0 * b * h * v
+
+
+def _make_inputs(b: int, h: int, v: int, dtype, seed: int):
+    key = jax.random.PRNGKey(seed)
+    kx, kw, kl = jax.random.split(key, 3)
+    # Scale so logits stay in a sane range at H=6144.
+    x = (jax.random.normal(kx, (b, h), dtype=jnp.float32) * (1.0 / np.sqrt(h))).astype(dtype)
+    w = (jax.random.normal(kw, (h, v), dtype=jnp.float32) * (1.0 / np.sqrt(h))).astype(dtype)
+    labels = jax.random.randint(kl, (b,), 0, v, dtype=jnp.int32)
+    return jax.block_until_ready((x, w, labels))
+
+
+def _build_fns(variant: Variant, labels: jax.Array):
+    """Return (forward_only_fn, value_and_grad_fn)."""
+    block_sizes = BlockSizes(b_block_size=variant.b_block_size, v_block_size=variant.v_block_size)
+
+    def call(x, w):
+        if variant.impl == "batched_xla":
+            return linear_softmax_cross_entropy_loss_batched_xla(
+                x, labels, w, block_sizes=block_sizes, dtype=jnp.float32, precision=None
+            )
+        return linear_softmax_cross_entropy_loss_xla(
+            x,
+            labels,
+            w,
+            block_sizes=block_sizes,
+            dtype=jnp.float32,
+            precision=None,
+            fast_backward=variant.fast_backward,
+            bwd_batch_block_size=variant.bwd_batch_block_size,
+            bwd_v_block_size=variant.bwd_v_block_size,
+        )
+
+    def forward(x, w):
+        loss, lse = call(x, w)
+        return loss, lse
+
+    def objective(x, w):
+        loss, _ = call(x, w)
+        # reduction="mean" with unit weights, as in grug loss.py.
+        return jnp.mean(loss)
+
+    return jax.jit(forward), jax.jit(jax.value_and_grad(objective, argnums=(0, 1)))
+
+
+def _time(fn, x, w, steps: int, warmup: int) -> tuple[float, float, Any]:
+    start = time.perf_counter()
+    out = jax.block_until_ready(fn(x, w))
+    compile_s = time.perf_counter() - start
+    for _ in range(warmup):
+        jax.block_until_ready(fn(x, w))
+    start = time.perf_counter()
+    for _ in range(steps):
+        jax.block_until_ready(fn(x, w))
+    return compile_s, (time.perf_counter() - start) / steps, out
+
+
+def _fp32_reference(x, labels, w, chunk: int):
+    """Chunked float32 reference for loss, grad_x and grad_w of ``mean(loss)``.
+
+    Everything is float32 with ``Precision.HIGHEST`` so this is a true fp32
+    reference, not a TF32 one.
+    """
+    b, h = x.shape
+    v = w.shape[1]
+    w32 = w.astype(jnp.float32)
+    scale = jnp.float32(1.0 / b)  # d mean(loss) / d loss_i
+
+    @jax.jit
+    def chunk_fn(x_chunk, labels_chunk, w32):
+        x32 = x_chunk.astype(jnp.float32)
+        logits = jax.lax.dot_general(x32, w32, (((1,), (0,)), ((), ())), precision=jax.lax.Precision.HIGHEST)
+        lse = jax.nn.logsumexp(logits, axis=-1)
+        label_logits = jnp.take_along_axis(logits, labels_chunk[:, None], axis=1).squeeze(-1)
+        loss = lse - label_logits
+        probs = jnp.exp(logits - lse[:, None])
+        onehot = jnp.arange(v, dtype=jnp.int32)[None, :] == labels_chunk[:, None]
+        dlogits = (probs - onehot.astype(jnp.float32)) * scale
+        gx = jax.lax.dot_general(dlogits, w32, (((1,), (1,)), ((), ())), precision=jax.lax.Precision.HIGHEST)
+        gw = jax.lax.dot_general(x32, dlogits, (((0,), (0,)), ((), ())), precision=jax.lax.Precision.HIGHEST)
+        return loss, gx, gw
+
+    losses = []
+    gxs = []
+    gw_acc = jnp.zeros((h, v), dtype=jnp.float32)
+    for start in range(0, b, chunk):
+        stop = min(start + chunk, b)
+        loss_c, gx_c, gw_c = chunk_fn(x[start:stop], labels[start:stop], w32)
+        losses.append(np.asarray(loss_c, dtype=np.float64))
+        gxs.append(np.asarray(gx_c, dtype=np.float32))
+        gw_acc = gw_acc + gw_c
+    return np.concatenate(losses), np.concatenate(gxs), np.asarray(gw_acc, dtype=np.float32)
+
+
+def _diff(actual, expected) -> tuple[float, float]:
+    a = np.asarray(actual, dtype=np.float32)
+    e = np.asarray(expected, dtype=np.float32)
+    d = np.abs(a - e)
+    rel = float(
+        np.sqrt(np.mean(d.astype(np.float64) ** 2)) / max(float(np.sqrt(np.mean(e.astype(np.float64) ** 2))), 1e-30)
+    )
+    return float(d.max()), rel
+
+
+# Opcodes that never launch a device kernel on XLA:GPU.
+_FREE_OPCODES = frozenset(
+    {
+        "parameter",
+        "constant",
+        "tuple",
+        "get-tuple-element",
+        "bitcast",
+        "while",
+        "conditional",
+        "after-all",
+        "token",
+        "add-dependency",
+        "opt-barrier",
+        "partition-id",
+        "replica-id",
+        "call",
+        "fusion-noop",
+        "bitcast-convert",
+    }
+)
+# Result shapes can be tuples containing spaces, so the opcode is "the first
+# lowercase identifier immediately followed by ( after the = sign".
+_INSTR_RE = re.compile(r"^\s+%?[\w.\-$]+ = .*?\s([a-z][\w-]*)\((.*)$")
+_COMP_RE = re.compile(r"^(?:ENTRY )?%?([\w.\-$]+) \(.*?\) -> .*\{\s*$")
+_TRIP_RE = re.compile(r'"known_trip_count":\s*\{\s*"n":\s*"?(\d+)"?')
+
+
+def _parse_optimized_hlo(text: str):
+    """Return (computations, entry_name).
+
+    ``computations[name]`` is a list of ``(opcode, called_computations, trip_count)``.
+    """
+    comps: dict[str, list] = {}
+    entry = None
+    cur = None
+    for raw in text.splitlines():
+        m = _COMP_RE.match(raw)
+        if m:
+            cur = m.group(1)
+            comps[cur] = []
+            if raw.lstrip().startswith("ENTRY"):
+                entry = cur
+            continue
+        if raw.strip() == "}":
+            cur = None
+            continue
+        if cur is None:
+            continue
+        m = _INSTR_RE.match(raw)
+        if not m:
+            continue
+        opcode, rest = m.group(1), m.group(2)
+        called = re.findall(
+            r"(?:body|condition|to_apply|called_computations=\{?|branch_computations=\{)\s*=?\s*%?([\w.\-$]+)", rest
+        )
+        trip = _TRIP_RE.search(rest)
+        comps[cur].append((opcode, called, int(trip.group(1)) if trip else None))
+    return comps, entry
+
+
+def _static_launch_estimate(text: str) -> tuple[int, dict[str, int]]:
+    """Kernel launches per call, derived from the optimized-HLO call graph.
+
+    Walks from ENTRY multiplying by each ``while`` loop's ``known_trip_count``.
+    ``fusion`` and ``custom-call`` count as one launch each and are not descended
+    into. This needs no profiler, which matters because CUPTI is not usable in
+    every container.
+    """
+    comps, entry = _parse_optimized_hlo(text)
+    if entry is None or entry not in comps:
+        return 0, {}
+    per_opcode: collections.Counter = collections.Counter()
+    seen_depth = 0
+
+    def walk(name: str, mult: int, depth: int) -> int:
+        nonlocal seen_depth
+        seen_depth = max(seen_depth, depth)
+        if depth > 12 or name not in comps:
+            return 0
+        total = 0
+        for opcode, called, trip in comps[name]:
+            if opcode == "while":
+                t = trip if trip is not None else 1
+                for sub in called:
+                    total += walk(sub, mult * t, depth + 1)
+                continue
+            if opcode in ("fusion", "custom-call"):
+                per_opcode[opcode] += mult
+                total += mult
+                continue
+            if opcode in _FREE_OPCODES:
+                continue
+            per_opcode[opcode] += mult
+            total += mult
+        return total
+
+    return walk(entry, 1, 0), dict(per_opcode)
+
+
+def _static_launches(fn, x, w) -> tuple[int, dict[str, int]]:
+    try:
+        text = fn.lower(x, w).compile().as_text()
+    except Exception as exc:  # noqa: BLE001
+        return 0, {"error": str(exc)[:200]}
+    return _static_launch_estimate(text)
+
+
+_KERNEL_LINE_HINTS = ("XLA Ops", "XLA Modules", "Kernels", "Compute")
+
+
+def _measure_launches(fn, x, w) -> tuple[int, float, dict[str, Any]]:
+    """Count device kernel launches for exactly one call of ``fn``.
+
+    Returns (launches, mean_launch_us, per_line_breakdown). The breakdown is kept
+    verbatim so the choice of "which xplane line is the kernel line" stays auditable.
+    """
+    tmpdir = tempfile.mkdtemp(prefix="ce_prof_")
+    try:
+        with jax.profiler.trace(tmpdir):
+            jax.block_until_ready(fn(x, w))
+        paths = glob.glob(os.path.join(tmpdir, "**", "*.xplane.pb"), recursive=True)
+        if not paths:
+            return 0, float("nan"), {"error": "no xplane produced"}
+        data = jax.profiler.ProfileData.from_file(paths[0])
+        breakdown: dict[str, Any] = {}
+        for plane in data.planes:
+            for line in plane.lines:
+                events = list(line.events)
+                if not events:
+                    continue
+                total_ns = float(sum(e.duration_ns for e in events))
+                breakdown[f"{plane.name} :: {line.name}"] = {
+                    "n": len(events),
+                    "total_ms": total_ns / 1e6,
+                    "mean_us": total_ns / len(events) / 1e3,
+                }
+        # Prefer a device plane's "XLA Ops" line: on GPU that is one event per kernel.
+        best_key = None
+        for key in breakdown:
+            plane_name, _, line_name = key.partition(" :: ")
+            if "device" not in plane_name.lower() and "gpu" not in plane_name.lower():
+                continue
+            if line_name.strip() in _KERNEL_LINE_HINTS[:1]:
+                best_key = key
+                break
+        if best_key is None:
+            device_keys = [k for k in breakdown if "device" in k.lower() or "gpu" in k.lower()]
+            if device_keys:
+                best_key = max(device_keys, key=lambda k: breakdown[k]["n"])
+        if best_key is None:
+            return 0, float("nan"), breakdown
+        chosen = breakdown[best_key]
+        breakdown["_chosen_line"] = best_key
+        return int(chosen["n"]), float(chosen["mean_us"]), breakdown
+    except Exception as exc:  # noqa: BLE001
+        return 0, float("nan"), {"error": f"{type(exc).__name__}: {exc}"[:500]}
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _opt_hlo_ops(fn, x, w) -> dict[str, int]:
+    try:
+        text = fn.lower(x, w).compile().as_text()
+    except Exception:
+        return {}
+    counts = collections.Counter()
+    for m in re.finditer(r"=\s*\S+\s+(fusion|custom-call|while|copy|dot|reduce|transpose|scatter|gather)\b", text):
+        counts[m.group(1)] += 1
+    return dict(counts)
+
+
+def run_variant(variant: Variant, args) -> Result:
+    res = Result(
+        variant=variant.name,
+        b=args.batch,
+        h=args.hidden,
+        v=args.vocab,
+        b_block_size=variant.b_block_size,
+        v_block_size=variant.v_block_size,
+        bwd_v_block_size=variant.bwd_v_block_size,
+        bwd_batch_block_size=variant.bwd_batch_block_size,
+        note=variant.note,
+    )
+    device = jax.local_devices()[0]
+    res.device_kind = device.device_kind
+
+    dtype = jnp.dtype(args.input_dtype)
+    x, w, labels = _make_inputs(args.batch, args.hidden, args.vocab, dtype, args.seed)
+
+    try:
+        fwd_fn, grad_fn = _build_fns(variant, labels)
+        res.compile_fwd_s, res.fwd_s, _ = _time(fwd_fn, x, w, args.steps, args.warmup)
+        res.compile_total_s, res.total_s, (value, (gx, gw)) = _time(grad_fn, x, w, args.steps, args.warmup)
+    except Exception as exc:  # noqa: BLE001 - report and keep the sweep going
+        res.ok = False
+        res.error = f"{type(exc).__name__}: {exc}"[:2000]
+        return res
+
+    res.bwd_s = res.total_s - res.fwd_s
+    one_gemm = _gemm_flops(args.batch, args.hidden, args.vocab)
+    res.fwd_tflops = one_gemm / res.fwd_s / 1e12
+    res.bwd_tflops = 3.0 * one_gemm / res.bwd_s / 1e12 if res.bwd_s > 0 else float("nan")
+    res.total_useful_tflops = 3.0 * one_gemm / res.total_s / 1e12
+    res.total_issued_tflops = 4.0 * one_gemm / res.total_s / 1e12
+
+    stats = device.memory_stats() or {}
+    res.peak_hbm_bytes = int(stats.get("peak_bytes_in_use", 0))
+
+    res.static_fwd_launches, _ = _static_launches(fwd_fn, x, w)
+    res.static_total_launches, res.static_launch_ops = _static_launches(grad_fn, x, w)
+    res.static_bwd_launches = res.static_total_launches - res.static_fwd_launches
+    if res.static_total_launches:
+        res.implied_mean_launch_us = res.total_s / res.static_total_launches * 1e6
+
+    if args.profile:
+        res.fwd_launches, _, _ = _measure_launches(fwd_fn, x, w)
+        res.total_launches, res.mean_launch_us, res.launch_lines = _measure_launches(grad_fn, x, w)
+        res.bwd_launches = res.total_launches - res.fwd_launches
+
+    if args.hlo_ops:
+        res.opt_hlo_ops = _opt_hlo_ops(grad_fn, x, w)
+
+    if args.check:
+        loss, _ = jax.block_until_ready(fwd_fn(x, w))
+        loss_np = np.asarray(loss, dtype=np.float64)
+
+        # Bitwise comparison of the forward against the current production path.
+        base_fwd, _ = _build_fns(VARIANTS_BY_NAME["baseline"], labels)
+        base_loss, _ = jax.block_until_ready(base_fwd(x, w))
+        base_np = np.asarray(base_loss, dtype=np.float64)
+        res.loss_bitwise_equal_vs_baseline = bool(np.array_equal(loss_np, base_np))
+        res.loss_max_abs_diff_vs_baseline = float(np.abs(loss_np - base_np).max())
+        del base_fwd, base_loss
+
+        ref_loss, ref_gx, ref_gw = _fp32_reference(x, labels, w, args.check_chunk)
+        d = np.abs(loss_np - ref_loss)
+        res.loss_max_abs_diff_vs_fp32 = float(d.max())
+        res.loss_mean_abs_diff_vs_fp32 = float(d.mean())
+        res.gx_max_abs_diff, res.gx_rel_rms = _diff(gx, ref_gx)
+        res.gw_max_abs_diff, res.gw_rel_rms = _diff(gw, ref_gw)
+
+    return res
+
+
+def _fanout(args) -> int:
+    # NOTE: never touch jax.devices() here. The parent must not initialise a CUDA
+    # context, or it holds every GPU and the children fail to allocate.
+    names = args.variants
+    n_gpu = args.num_gpus
+    if n_gpu <= 0:
+        visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+        n_gpu = len([d for d in visible.split(",") if d.strip()]) if visible else 4
+    n_gpu = max(1, n_gpu)
+    print(f"fanout: {len(names)} variants over {n_gpu} local GPU(s)", flush=True)
+    script = os.path.abspath(__file__)
+    base = [
+        sys.executable,
+        "-u",
+        script,
+        "--batch",
+        str(args.batch),
+        "--hidden",
+        str(args.hidden),
+        "--vocab",
+        str(args.vocab),
+        "--steps",
+        str(args.steps),
+        "--warmup",
+        str(args.warmup),
+        "--check-chunk",
+        str(args.check_chunk),
+        "--input-dtype",
+        args.input_dtype,
+        "--seed",
+        str(args.seed),
+    ]
+    if args.check:
+        base.append("--check")
+    if args.hlo_ops:
+        base.append("--hlo-ops")
+    if not args.profile:
+        base.append("--no-profile")
+
+    results: list[dict] = []
+    for i in range(0, len(names), n_gpu):
+        wave = names[i : i + n_gpu]
+        procs = []
+        for slot, name in enumerate(wave):
+            env = dict(os.environ)
+            env["CUDA_VISIBLE_DEVICES"] = str(slot)
+            # Concurrent children must not each grab 75% of a GPU up front; without
+            # this the children die with SIGSEGV during the first large allocation.
+            env["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
+            env.setdefault("XLA_PYTHON_CLIENT_ALLOCATOR", "platform")
+            cmd = base + ["--variants", name]
+            print(f"  launching {name} on local GPU {slot}", flush=True)
+            procs.append(
+                (name, subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True))
+            )
+        for name, proc in procs:
+            try:
+                out, _ = proc.communicate(timeout=args.child_timeout)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                out, _ = proc.communicate()
+                out = (out or "") + f"\n!! timed out after {args.child_timeout}s"
+
+            got = False
+            for line in out.splitlines():
+                if line.startswith(RESULT_PREFIX):
+                    results.append(json.loads(line[len(RESULT_PREFIX) :]))
+                    got = True
+            if not got:
+                print(f"!! {name} produced no result (exit {proc.returncode}); tail:", flush=True)
+                print("\n".join(out.splitlines()[-40:]), flush=True)
+                results.append(asdict(Result(variant=name, ok=False, error=f"exit {proc.returncode}")))
+    _print_table(results)
+    with open(args.out, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nwrote {args.out}", flush=True)
+    return 0
+
+
+def _print_table(results: list[dict]) -> None:
+    print("\n" + "=" * 175, flush=True)
+    hdr = (
+        f"{'variant':>18} {'fwd_ms':>9} {'bwd_ms':>9} {'total_ms':>9} "
+        f"{'useful_TF/s':>12} {'issued_TF/s':>12} {'peak_GiB':>9} "
+        f"{'launches':>10} {'us/launch':>10} "
+        f"{'loss==base':>11} {'gx_relRMS':>11} {'gw_relRMS':>11}"
+    )
+    print(hdr)
+    print("-" * 175)
+    base = next((r for r in results if r["variant"] == "baseline" and r["ok"]), None)
+    for r in results:
+        if not r["ok"]:
+            print(f"{r['variant']:>18}  FAILED: {r['error'][:110]}")
+            continue
+        print(
+            f"{r['variant']:>18} {r['fwd_s'] * 1e3:>9.2f} {r['bwd_s'] * 1e3:>9.2f} {r['total_s'] * 1e3:>9.2f} "
+            f"{r['total_useful_tflops']:>12.1f} {r['total_issued_tflops']:>12.1f} "
+            f"{r['peak_hbm_bytes'] / 2**30:>9.2f} "
+            f"{r.get('static_total_launches', 0):>10} {r.get('implied_mean_launch_us', float('nan')):>10.2f} "
+            f"{str(r['loss_bitwise_equal_vs_baseline']):>11} "
+            f"{r['gx_rel_rms']:>11.3e} {r['gw_rel_rms']:>11.3e}"
+        )
+    if base:
+        print("-" * 175)
+        for r in results:
+            if r["ok"] and r["variant"] != "baseline":
+                print(
+                    f"{r['variant']:>18}  speedup vs baseline: total {base['total_s'] / r['total_s']:.3f}x   "
+                    f"bwd {base['bwd_s'] / r['bwd_s']:.3f}x   "
+                    f"delta_ms {(r['total_s'] - base['total_s']) * 1e3:+.2f}"
+                )
+    print("=" * 175, flush=True)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--batch", type=int, default=HERO_B)
+    p.add_argument("--hidden", type=int, default=HERO_H)
+    p.add_argument("--vocab", type=int, default=HERO_V)
+    p.add_argument("--input-dtype", type=str, default="bfloat16")
+    p.add_argument("--steps", type=int, default=10)
+    p.add_argument("--warmup", type=int, default=3)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--variants", type=str, default="all", help="comma-separated variant names, or 'all'")
+    p.add_argument("--check", action="store_true", help="run the float32 correctness gate")
+    p.add_argument("--no-check", action="store_false", dest="check")
+    p.set_defaults(check=True)
+    p.add_argument("--check-chunk", type=int, default=4096, help="row chunk for the fp32 reference")
+    p.add_argument("--hlo-ops", action="store_true", default=False, help="histogram optimized-HLO ops")
+    p.add_argument("--profile", action="store_true", help="count device kernel launches via the JAX profiler")
+    p.add_argument("--no-profile", action="store_false", dest="profile")
+    p.set_defaults(profile=False)
+    p.add_argument("--fanout", action="store_true", help="one subprocess per variant across local GPUs")
+    p.add_argument(
+        "--num-gpus", type=int, default=0, help="GPUs to fan out over (0 = autodetect without touching JAX)"
+    )
+    p.add_argument("--child-timeout", type=int, default=3600, help="per-variant subprocess timeout, seconds")
+    p.add_argument("--out", type=str, default="ce_hero_shape_results.json")
+    p.add_argument("--list", action="store_true")
+    args = p.parse_args()
+
+    if args.list:
+        for v in VARIANTS:
+            print(f"{v.name:>18}  {v.note or ''}")
+        return 0
+
+    if args.variants == "all":
+        names = [v.name for v in VARIANTS]
+    else:
+        names = [n.strip() for n in args.variants.split(",") if n.strip()]
+    unknown = [n for n in names if n not in VARIANTS_BY_NAME]
+    if unknown:
+        raise SystemExit(f"unknown variants: {unknown}; known: {sorted(VARIANTS_BY_NAME)}")
+    args.variants = names
+
+    if args.fanout:
+        return _fanout(args)
+
+    print("devices:", jax.devices(), flush=True)
+    print(f"shape: B={args.batch} H={args.hidden} V={args.vocab} dtype={args.input_dtype}", flush=True)
+    results = []
+    for name in names:
+        res = run_variant(VARIANTS_BY_NAME[name], args)
+        d = asdict(res)
+        results.append(d)
+        print(RESULT_PREFIX + json.dumps(d), flush=True)
+    if len(results) > 1:
+        _print_table(results)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Callable, Sequence
-from functools import lru_cache
+from functools import lru_cache, partial
 import hashlib
 import json
 import logging
@@ -44,6 +44,7 @@ Implementation: TypeAlias = Literal[
     "pallas_tpu",
     "batched_xla",
     "xla",
+    "xla_fast_bwd",
     "reference",
 ]
 Reduction: TypeAlias = Literal["sum", "mean"] | None
@@ -56,6 +57,17 @@ ArrayImpl = Callable[..., KernelOutput]
 IMPLEMENTATIONS: dict[str, ArrayImpl] = {
     "reference": linear_softmax_cross_entropy_loss_reference,
     "xla": linear_softmax_cross_entropy_loss_xla,
+    # Same forward as "xla" (loss and lse are bitwise identical), but the backward
+    # is the scan/one-hot/tensor-core rewrite: no scatter, one GEMM per vocab block
+    # over the whole batch, and dlogits cast to the activation dtype so both
+    # backward GEMMs stay on bf16 tensor cores instead of being upcast to
+    # float32/TF32. Measured on GB200 at the grug EP hero CE shape
+    # (B=65,536 H=6,144 V=128,256): 723.4 ms -> 310.0 ms end-to-end for the kernel,
+    # 428 -> 1,000 TFLOP/s on the 3-GEMM convention (571 -> 1,333 counting all four
+    # GEMMs the kernel issues), at +0.04 GiB peak HBM. Gradients change: they are
+    # ~30% CLOSER to a float32 reference than the "xla" path. Opt in explicitly;
+    # "xla" is unchanged for every other caller.
+    "xla_fast_bwd": partial(linear_softmax_cross_entropy_loss_xla, fast_backward=True),
 }
 _DEFAULT_IMPLEMENTATION: tuple[Implementation, ...] = ("xla",)
 _IMPLEMENTATION_FALLBACK_WARNINGS_EMITTED: set[str] = set()
@@ -674,7 +686,7 @@ def fused_cross_entropy_loss_and_logsumexp_penalty(
         impl_for_call = impl
         if explicit_block_sizes:
             block_sizes_for_impl = resolved_block_sizes
-        elif impl_for_call in ("xla", "reference"):
+        elif impl_for_call in ("xla", "xla_fast_bwd", "reference"):
             block_sizes_for_impl = None
         elif isinstance(impl_for_call, str) and impl_for_call in ("pallas_tpu", "batched_xla"):
             inferred, has_tuned_match = infer_block_sizes_with_tuned_match(

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/xla.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/xla.py
@@ -1,6 +1,7 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from functools import partial
 from typing import Optional, cast
 
@@ -18,6 +19,48 @@ from .tuned_block_sizes import (
 )
 
 _XLA_MAX_TILE_WORDS = 2**31 - 1
+
+# Fast backward selection. The library default stays OFF so that every existing
+# caller of implementation="xla" keeps bit-identical gradients; callers opt in
+# per-call-site (the grug EP hero does so via implementation="xla_fast_bwd").
+# The forward is untouched either way, so the loss is identical in both cases;
+# only gradient rounding differs -- and it moves *closer* to a float32 reference
+# (see ``_linear_softmax_cross_entropy_loss_streaming_bwd_scan``).
+#
+# The env var is a two-way override for A/B runs: when it is set it wins over the
+# call site, so a run can be forced onto either path without editing code.
+_FAST_BWD_ENV_VAR = "LEVANTER_CE_XLA_FAST_BWD"
+_FAST_BWD_LIBRARY_DEFAULT = False
+_TRUTHY = ("1", "true", "yes", "on")
+_FALSY = ("0", "false", "no", "off")
+
+
+def _fast_backward_env_override() -> bool | None:
+    """Return the env var's value, or ``None`` when it is unset/unrecognised."""
+    raw = os.environ.get(_FAST_BWD_ENV_VAR)
+    if raw is None:
+        return None
+    value = raw.strip().lower()
+    if value in _TRUTHY:
+        return True
+    if value in _FALSY:
+        return False
+    return None
+
+
+def _resolve_fast_backward(requested: bool | None) -> bool:
+    """Resolve the fast-backward choice: env override, then call site, then default."""
+    override = _fast_backward_env_override()
+    if override is not None:
+        return override
+    if requested is not None:
+        return bool(requested)
+    return _FAST_BWD_LIBRARY_DEFAULT
+
+
+def _fast_backward_default() -> bool:
+    """Backwards-compatible alias for the resolved default with no call-site request."""
+    return _resolve_fast_backward(None)
 
 
 def _materialize_cotangent(
@@ -350,17 +393,190 @@ def _linear_softmax_cross_entropy_loss_streaming_bwd(
     return gx, gw[:, :v_dim]
 
 
-@partial(jax.custom_vjp, nondiff_argnums=(0, 1, 2, 3, 4))
+def _linear_softmax_cross_entropy_loss_streaming_bwd_scan(
+    x: Float[Array, "B H"],
+    labels: Int[Array, "B"],
+    w: Float[Array, "H V"],
+    lse: Float[Array, "B"],
+    dout_loss: Float[Array, "B"],
+    dout_lse: Float[Array, "B"],
+    *,
+    block_size: int,
+    dtype: Optional[jnp.dtype],
+    batch_block_size: int,
+    logit_soft_cap: Optional[float],
+    precision: jax.lax.PrecisionLike,
+) -> tuple[Float[Array, "B H"], Float[Array, "H V"]]:
+    """Backward pass over vocab blocks, structured for GPU tensor cores.
+
+    Mathematically identical to ``_linear_softmax_cross_entropy_loss_streaming_bwd``;
+    it differs in four ways, each of which the GPU CE ladder measured as a win
+    (see ``.agents/projects/fused_cross_entropy_gpu.md``):
+
+    1. ``dlogits`` is cast to the activation dtype before the two backward GEMMs.
+       The naive form leaves ``dlogits`` in float32, which forces XLA to *upcast
+       ``x`` and ``w`` to float32* and run both backward GEMMs in FP32/TF32
+       instead of BF16 tensor cores. Softmax math stays in float32.
+    2. The label term is a dense one-hot compare fused into the ``dlogits``
+       expression, replacing an ``.at[].add()`` scatter with
+       ``unique_indices=false`` that XLA cannot fuse and lowers to atomics.
+    3. The vocab loop is a ``lax.scan`` that carries only ``grad_x`` and emits
+       ``grad_w`` blocks as stacked outputs, instead of a ``fori_loop`` carrying
+       a full ``[H, V]`` ``grad_w`` buffer updated by ``dynamic_update_slice``.
+    4. ``grad_x`` accumulates in float32 (cast once at the end) rather than
+       accumulating in the activation dtype across every vocab block.
+
+    ``batch_block_size`` still bounds the live logits tile to
+    ``batch_block_size x block_size``; pass ``>= B`` to disable batch tiling
+    entirely (fewest kernels, largest peak memory).
+    """
+    if block_size <= 0:
+        raise ValueError(f"block_size must be positive, got {block_size}.")
+    if batch_block_size <= 0:
+        raise ValueError(f"batch_block_size must be positive, got {batch_block_size}.")
+
+    b_dim, h_dim = x.shape
+    if batch_block_size < b_dim and b_dim % batch_block_size != 0:
+        raise ValueError(
+            f"batch_block_size must divide batch dimension, got B={b_dim}, batch_block_size={batch_block_size}."
+        )
+    b_block = min(batch_block_size, b_dim)
+    num_b_blocks = b_dim // b_block
+
+    v_dim = w.shape[1]
+    pad = (-v_dim) % block_size
+    w_padded = jnp.pad(w, ((0, 0), (0, pad)), mode="constant", constant_values=0) if pad else w
+    v_padded = v_dim + pad
+    num_v_blocks = v_padded // block_size
+
+    # Operand dtype for the two backward GEMMs. Keeping this equal to the primal
+    # dtypes is what keeps them on tensor cores.
+    gemm_dtype = jnp.result_type(x.dtype, w.dtype)
+
+    labels_i32 = labels.astype(jnp.int32)
+    lse_f32 = lse.astype(jnp.float32)
+    g_loss_f32 = dout_loss.astype(jnp.float32)
+    g_softmax_f32 = g_loss_f32 + dout_lse.astype(jnp.float32)
+    v_offsets = jnp.arange(block_size, dtype=jnp.int32)
+
+    def _dlogits_tile(
+        x_blk: jax.Array,
+        labels_blk: jax.Array,
+        lse_blk: jax.Array,
+        g_loss_blk: jax.Array,
+        g_softmax_blk: jax.Array,
+        w_block: jax.Array,
+        v_start: jax.Array,
+    ) -> jax.Array:
+        logits = jax.lax.dot_general(
+            x_blk,
+            w_block,
+            (((1,), (0,)), ((), ())),
+            precision=precision,
+            preferred_element_type=jnp.float32,
+        )
+        if dtype is not None:
+            logits = logits.astype(dtype)
+        logits = logits.astype(jnp.float32)
+
+        cap_deriv = None
+        if logit_soft_cap is not None:
+            tanh_val = jnp.tanh(logits / logit_soft_cap)
+            logits = tanh_val * logit_soft_cap
+            cap_deriv = 1.0 - tanh_val**2
+
+        in_vocab = (v_start + v_offsets) < v_dim
+        probs = jnp.where(in_vocab[None, :], jnp.exp(logits - lse_blk[:, None]), 0.0)
+        dlogits = probs * g_softmax_blk[:, None]
+
+        # Dense one-hot label subtraction. ``labels - v_start`` lands in
+        # ``[0, block_size)`` exactly when the label belongs to this vocab block,
+        # so the equality compare alone is the in-block mask.
+        label_hit = v_offsets[None, :] == (labels_blk - v_start)[:, None]
+        dlogits = dlogits - jnp.where(label_hit, g_loss_blk[:, None], 0.0)
+
+        if cap_deriv is not None:
+            dlogits = dlogits * cap_deriv
+        return dlogits.astype(gemm_dtype)
+
+    def scan_body(grad_x: jax.Array, v_block_index: jax.Array):
+        v_start = v_block_index * block_size
+        w_block = jax.lax.dynamic_slice(w_padded, (0, v_start), (h_dim, block_size))
+
+        if num_b_blocks == 1:
+            dlogits = _dlogits_tile(x, labels_i32, lse_f32, g_loss_f32, g_softmax_f32, w_block, v_start)
+            grad_x = grad_x + jax.lax.dot_general(
+                dlogits,
+                w_block,
+                (((1,), (1,)), ((), ())),
+                precision=precision,
+                preferred_element_type=jnp.float32,
+            )
+            grad_w_block = jax.lax.dot_general(
+                x,
+                dlogits,
+                (((0,), (0,)), ((), ())),
+                precision=precision,
+                preferred_element_type=jnp.float32,
+            )
+            return grad_x, grad_w_block.astype(w.dtype)
+
+        def batch_body(batch_block_index, state):
+            grad_x_inner, grad_w_acc = state
+            b_start = batch_block_index * b_block
+            x_blk = jax.lax.dynamic_slice(x, (b_start, 0), (b_block, h_dim))
+            dlogits = _dlogits_tile(
+                x_blk,
+                jax.lax.dynamic_slice(labels_i32, (b_start,), (b_block,)),
+                jax.lax.dynamic_slice(lse_f32, (b_start,), (b_block,)),
+                jax.lax.dynamic_slice(g_loss_f32, (b_start,), (b_block,)),
+                jax.lax.dynamic_slice(g_softmax_f32, (b_start,), (b_block,)),
+                w_block,
+                v_start,
+            )
+            grad_x_blk = jax.lax.dot_general(
+                dlogits,
+                w_block,
+                (((1,), (1,)), ((), ())),
+                precision=precision,
+                preferred_element_type=jnp.float32,
+            )
+            grad_w_acc = grad_w_acc + jax.lax.dot_general(
+                x_blk,
+                dlogits,
+                (((0,), (0,)), ((), ())),
+                precision=precision,
+                preferred_element_type=jnp.float32,
+            )
+            current = jax.lax.dynamic_slice(grad_x_inner, (b_start, 0), (b_block, h_dim))
+            grad_x_inner = jax.lax.dynamic_update_slice(grad_x_inner, current + grad_x_blk, (b_start, 0))
+            return grad_x_inner, grad_w_acc
+
+        grad_w_init = jnp.zeros((h_dim, block_size), dtype=jnp.float32)
+        grad_x, grad_w_acc = jax.lax.fori_loop(0, num_b_blocks, batch_body, (grad_x, grad_w_init))
+        return grad_x, grad_w_acc.astype(w.dtype)
+
+    grad_x_init = jnp.zeros((b_dim, h_dim), dtype=jnp.float32)
+    grad_x, grad_w_blocks = jax.lax.scan(scan_body, grad_x_init, jnp.arange(num_v_blocks, dtype=jnp.int32))
+    grad_w = jnp.transpose(grad_w_blocks, (1, 0, 2)).reshape((h_dim, v_padded))
+    return grad_x.astype(x.dtype), grad_w[:, :v_dim]
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(0, 1, 2, 3, 4, 5, 6, 7))
 def _linear_softmax_cross_entropy_loss_streaming_custom_vjp(
     block_size: int,
     batch_block_size: int,
     dtype: Optional[jnp.dtype],
     logit_soft_cap: Optional[float],
     precision: jax.lax.PrecisionLike,
+    fast_backward: bool,
+    bwd_batch_block_size: int | None,
+    bwd_v_block_size: int | None,
     x: Float[Array, "B H"],
     labels: Int[Array, "B"],
     w: Float[Array, "H V"],
 ) -> tuple[Float[Array, "B"], Float[Array, "B"]]:
+    del fast_backward, bwd_batch_block_size, bwd_v_block_size
     loss, lse = _linear_softmax_cross_entropy_loss_streaming_fwd(
         x,
         labels,
@@ -380,10 +596,14 @@ def _linear_softmax_cross_entropy_loss_streaming_custom_vjp_fwd(
     dtype: Optional[jnp.dtype],
     logit_soft_cap: Optional[float],
     precision: jax.lax.PrecisionLike,
+    fast_backward: bool,
+    bwd_batch_block_size: int | None,
+    bwd_v_block_size: int | None,
     x: Float[Array, "B H"],
     labels: Int[Array, "B"],
     w: Float[Array, "H V"],
 ) -> tuple[tuple[Float[Array, "B"], Float[Array, "B"]], tuple[jax.Array, jax.Array, jax.Array, jax.Array]]:
+    del fast_backward, bwd_batch_block_size, bwd_v_block_size
     loss, lse = _linear_softmax_cross_entropy_loss_streaming_fwd(
         x,
         labels,
@@ -403,6 +623,9 @@ def _linear_softmax_cross_entropy_loss_streaming_custom_vjp_bwd(
     dtype: Optional[jnp.dtype],
     logit_soft_cap: Optional[float],
     precision: jax.lax.PrecisionLike,
+    fast_backward: bool,
+    bwd_batch_block_size: int | None,
+    bwd_v_block_size: int | None,
     residuals: tuple[jax.Array, jax.Array, jax.Array, jax.Array],
     cotangents: tuple[
         jax.Array | jax.custom_derivatives.SymbolicZero, jax.Array | jax.custom_derivatives.SymbolicZero
@@ -412,6 +635,21 @@ def _linear_softmax_cross_entropy_loss_streaming_custom_vjp_bwd(
     dout_loss, dout_lse = cotangents
     dout_loss_arr = _materialize_cotangent(dout_loss, lse)
     dout_lse_arr = _materialize_cotangent(dout_lse, lse)
+    if fast_backward:
+        gx, gw = _linear_softmax_cross_entropy_loss_streaming_bwd_scan(
+            x,
+            labels,
+            w,
+            lse,
+            dout_loss_arr,
+            dout_lse_arr,
+            block_size=(bwd_v_block_size if bwd_v_block_size is not None else block_size),
+            dtype=dtype,
+            batch_block_size=(bwd_batch_block_size if bwd_batch_block_size is not None else x.shape[0]),
+            logit_soft_cap=logit_soft_cap,
+            precision=precision,
+        )
+        return gx, None, gw
     gx, gw = _linear_softmax_cross_entropy_loss_streaming_bwd(
         x,
         labels,
@@ -444,7 +682,27 @@ def linear_softmax_cross_entropy_loss_xla(
     logit_soft_cap: Optional[float] = None,
     precision: jax.lax.PrecisionLike = None,
     return_argmax: bool = False,
+    fast_backward: bool | None = None,
+    bwd_batch_block_size: int | None = None,
+    bwd_v_block_size: int | None = None,
 ) -> tuple[Float[Array, "B"], Float[Array, "B"]] | tuple[Float[Array, "B"], Float[Array, "B"], Int[Array, "B"]]:
+    """Streaming linear-softmax cross-entropy on plain XLA.
+
+    Args:
+        fast_backward: Use the scan/one-hot/tensor-core backward. ``None`` means
+            "no call-site preference" and falls back to the library default (off).
+            The ``LEVANTER_CE_XLA_FAST_BWD`` env var overrides this in either
+            direction for A/B runs. The forward is identical either way, so
+            ``loss`` and ``lse`` are bitwise unchanged; only gradient rounding
+            differs, and it moves closer to a float32 reference.
+        bwd_batch_block_size: Batch tile for the fast backward only. ``None``
+            means "no batch tiling" (one GEMM per vocab block over the full batch),
+            which is fastest but has the largest peak memory.
+        bwd_v_block_size: Vocab tile for the fast backward only. ``None`` reuses the
+            forward's ``v_block_size``. The backward's optimal tile is typically
+            larger than the forward's, so this is worth tuning separately.
+    """
+    fast_backward = _resolve_fast_backward(fast_backward)
     if block_sizes is None:
         v_block_size = infer_xla_v_block_size(x.shape[0], x.shape[1], w.shape[1], dtype=dtype)
         b_block_size = _resolve_xla_batch_block_size(
@@ -492,6 +750,9 @@ def linear_softmax_cross_entropy_loss_xla(
         dtype,
         logit_soft_cap,
         precision,
+        bool(fast_backward),
+        bwd_batch_block_size,
+        bwd_v_block_size,
         x,
         labels,
         w,

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -213,6 +213,9 @@ def test_xla_streaming_custom_vjp_grad_matches_streaming_autodiff():
             jnp.float32,
             logit_soft_cap,
             None,
+            False,
+            None,
+            None,
             x_raw.reshape(6, 4),
             y.reshape(6),
             w_raw,
@@ -334,6 +337,9 @@ def test_xla_streaming_custom_vjp_grad_matches_streaming_autodiff_with_batch_blo
             jnp.float32,
             logit_soft_cap,
             None,
+            False,
+            None,
+            None,
             x_raw,
             y,
             w_raw,
@@ -366,8 +372,21 @@ def test_fused_cross_entropy_xla_uses_explicit_batch_block_size(monkeypatch: pyt
 
     monkeypatch.setattr(fused_xla, "infer_xla_b_block_size", lambda b, v_block_size: 6)
 
-    def fake_custom_vjp(block_size, batch_block_size, dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg):
-        del dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg
+    def fake_custom_vjp(
+        block_size,
+        batch_block_size,
+        dtype,
+        logit_soft_cap,
+        precision,
+        fast_backward,
+        bwd_batch_block_size,
+        bwd_v_block_size,
+        x_arg,
+        labels_arg,
+        w_arg,
+    ):
+        del dtype, logit_soft_cap, precision, fast_backward, bwd_batch_block_size, bwd_v_block_size
+        del x_arg, labels_arg, w_arg
         captured["block_size"] = block_size
         captured["batch_block_size"] = batch_block_size
         return jnp.zeros((6,), dtype=jnp.float32), jnp.zeros((6,), dtype=jnp.float32)
@@ -395,8 +414,21 @@ def test_fused_cross_entropy_xla_caps_requested_batch_block_size_to_legal_diviso
 
     monkeypatch.setattr(fused_xla, "infer_xla_b_block_size", lambda b, v_block_size: 6)
 
-    def fake_custom_vjp(block_size, batch_block_size, dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg):
-        del dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg
+    def fake_custom_vjp(
+        block_size,
+        batch_block_size,
+        dtype,
+        logit_soft_cap,
+        precision,
+        fast_backward,
+        bwd_batch_block_size,
+        bwd_v_block_size,
+        x_arg,
+        labels_arg,
+        w_arg,
+    ):
+        del dtype, logit_soft_cap, precision, fast_backward, bwd_batch_block_size, bwd_v_block_size
+        del x_arg, labels_arg, w_arg
         captured["block_size"] = block_size
         captured["batch_block_size"] = batch_block_size
         return jnp.zeros((6,), dtype=jnp.float32), jnp.zeros((6,), dtype=jnp.float32)
@@ -430,8 +462,21 @@ def test_fused_cross_entropy_xla_infer_uses_tuned_batch_block_size_when_availabl
         lambda *args, **kwargs: (fused_api.BlockSizes(b_block_size=3, h_block_size=4, v_block_size=8), True),
     )
 
-    def fake_custom_vjp(block_size, batch_block_size, dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg):
-        del dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg
+    def fake_custom_vjp(
+        block_size,
+        batch_block_size,
+        dtype,
+        logit_soft_cap,
+        precision,
+        fast_backward,
+        bwd_batch_block_size,
+        bwd_v_block_size,
+        x_arg,
+        labels_arg,
+        w_arg,
+    ):
+        del dtype, logit_soft_cap, precision, fast_backward, bwd_batch_block_size, bwd_v_block_size
+        del x_arg, labels_arg, w_arg
         captured["block_size"] = block_size
         captured["batch_block_size"] = batch_block_size
         return jnp.zeros((6,), dtype=jnp.float32), jnp.zeros((6,), dtype=jnp.float32)
@@ -1317,7 +1362,7 @@ def test_pallas_tpu_vmem_compile_error_falls_back_to_xla_when_requested(monkeypa
     called = {"pallas": 0, "xla": 0}
     inferred = fused_api.BlockSizes(b_block_size=128, h_block_size=128, v_block_size=128)
     vmem_error = RuntimeError(
-        "RESOURCE_EXHAUSTED: XLA:TPU compile permanent error. " "Ran out of memory in memory space vmem."
+        "RESOURCE_EXHAUSTED: XLA:TPU compile permanent error. Ran out of memory in memory space vmem."
     )
 
     def fake_pallas(*args, **kwargs):
@@ -1361,7 +1406,7 @@ def test_pallas_tpu_vmem_compile_error_uses_remaining_requested_order(monkeypatc
     called = {"pallas": 0, "reference": 0, "xla": 0}
     block_sizes = fused_api.BlockSizes(b_block_size=128, h_block_size=128, v_block_size=256)
     vmem_error = RuntimeError(
-        "RESOURCE_EXHAUSTED: XLA:TPU compile permanent error. " "Ran out of memory in memory space vmem."
+        "RESOURCE_EXHAUSTED: XLA:TPU compile permanent error. Ran out of memory in memory space vmem."
     )
 
     def fake_pallas(*args, **kwargs):
@@ -2238,3 +2283,189 @@ def test_fused_cross_entropy_pallas_backward_matches_xla_infer_blocks(implementa
 
     assert jnp.allclose(gx_linear_ce, gx_xla, atol=1e-4, rtol=1e-4)
     assert jnp.allclose(gw_linear_ce, gw_xla, atol=1e-4, rtol=1e-4)
+
+
+def _fast_bwd_case(dtype, *, b=512, h=64, v=1000, b_block=64, v_block=256, logit_soft_cap=None):
+    key = jax.random.PRNGKey(7)
+    key_x, key_w, key_y, key_g = jax.random.split(key, 4)
+    x = (jax.random.normal(key_x, (b, h), dtype=jnp.float32) * 0.5).astype(dtype)
+    w = (jax.random.normal(key_w, (h, v), dtype=jnp.float32) * 0.05).astype(dtype)
+    labels = jax.random.randint(key_y, (b,), 0, v, dtype=jnp.int32)
+    cotangent = jax.random.normal(key_g, (b,), dtype=jnp.float32)
+    block_sizes = BlockSizes(b_block_size=b_block, v_block_size=v_block)
+
+    def make(fast_backward, bwd_batch_block_size=None):
+        def objective(x_arg, w_arg):
+            loss, lse = fused_xla.linear_softmax_cross_entropy_loss_xla(
+                x_arg,
+                labels,
+                w_arg,
+                block_sizes=block_sizes,
+                dtype=jnp.float32,
+                logit_soft_cap=logit_soft_cap,
+                precision=None,
+                fast_backward=fast_backward,
+                bwd_batch_block_size=bwd_batch_block_size,
+            )
+            return jnp.sum(loss * cotangent) + 0.25 * jnp.sum(lse * cotangent)
+
+        return jax.jit(jax.value_and_grad(objective, argnums=(0, 1)))
+
+    return x, w, make
+
+
+@pytest.mark.parametrize("logit_soft_cap", [None, 1.5])
+def test_xla_fast_backward_leaves_forward_bitwise_identical(logit_soft_cap):
+    x, w, make = _fast_bwd_case(jnp.bfloat16, logit_soft_cap=logit_soft_cap)
+    value_slow, _ = make(False)(x, w)
+    value_fast, _ = make(True)(x, w)
+    # The fast path only replaces the backward, so the primal must be bit-identical.
+    assert np.array_equal(np.asarray(value_slow), np.asarray(value_fast))
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.bfloat16])
+def test_xla_fast_backward_matches_default_backward(dtype):
+    x, w, make = _fast_bwd_case(dtype)
+    _, (gx_slow, gw_slow) = make(False)(x, w)
+    _, (gx_fast, gw_fast) = make(True)(x, w)
+    atol = 1e-5 if dtype == jnp.float32 else 5e-2
+    rtol = 1e-5 if dtype == jnp.float32 else 5e-2
+    assert jnp.allclose(gx_fast.astype(jnp.float32), gx_slow.astype(jnp.float32), atol=atol, rtol=rtol)
+    assert jnp.allclose(gw_fast.astype(jnp.float32), gw_slow.astype(jnp.float32), atol=atol, rtol=rtol)
+
+
+def test_xla_fast_backward_batch_tiling_is_equivalent():
+    x, w, make = _fast_bwd_case(jnp.float32, b=512, b_block=64)
+    _, (gx_untiled, gw_untiled) = make(True, None)(x, w)
+    _, (gx_tiled, gw_tiled) = make(True, 64)(x, w)
+    # grad_x is computed per batch tile either way, so it must match exactly.
+    assert np.array_equal(np.asarray(gx_untiled), np.asarray(gx_tiled))
+    # grad_w differs only in float32 summation order across batch tiles.
+    assert jnp.allclose(gw_untiled, gw_tiled, atol=1e-4, rtol=1e-4)
+
+
+def test_xla_fast_backward_is_no_worse_than_default_against_float32_reference():
+    """At the hero loop ratio (many batch blocks per vocab block) the default backward
+    accumulates grad_w in the activation dtype; the fast backward must not be worse."""
+    dtype = jnp.bfloat16
+    x, w, make = _fast_bwd_case(dtype, b=2048, h=128, v=1024, b_block=32, v_block=256)
+    key = jax.random.PRNGKey(7)
+    _, _, key_y, key_g = jax.random.split(key, 4)
+    labels = jax.random.randint(key_y, (2048,), 0, 1024, dtype=jnp.int32)
+    cotangent = jax.random.normal(key_g, (2048,), dtype=jnp.float32)
+
+    def reference(x_arg, w_arg):
+        logits = x_arg.astype(jnp.float32) @ w_arg.astype(jnp.float32)
+        lse = jax.nn.logsumexp(logits, axis=-1)
+        label_logits = jnp.take_along_axis(logits, labels[:, None], axis=1).squeeze(-1)
+        loss = lse - label_logits
+        return jnp.sum(loss * cotangent) + 0.25 * jnp.sum(lse * cotangent)
+
+    _, (gx_ref, gw_ref) = jax.jit(jax.value_and_grad(reference, argnums=(0, 1)))(x, w)
+    _, (gx_slow, gw_slow) = make(False)(x, w)
+    _, (gx_fast, gw_fast) = make(True)(x, w)
+
+    def rms_error(actual, expected):
+        diff = actual.astype(jnp.float32) - expected.astype(jnp.float32)
+        return float(jnp.sqrt(jnp.mean(diff**2)))
+
+    assert rms_error(gx_fast, gx_ref) <= rms_error(gx_slow, gx_ref) * 1.05
+    assert rms_error(gw_fast, gw_ref) <= rms_error(gw_slow, gw_ref) * 1.05
+
+
+def test_xla_fast_backward_env_var_overrides_call_site_in_both_directions(monkeypatch):
+    """The env var is the A/B kill switch: when set it wins over the call site."""
+    monkeypatch.delenv(fused_xla._FAST_BWD_ENV_VAR, raising=False)
+    # Unset: the call site decides, and the library default is off.
+    assert fused_xla._resolve_fast_backward(None) is False
+    assert fused_xla._resolve_fast_backward(True) is True
+    assert fused_xla._resolve_fast_backward(False) is False
+    # Set to on: forces the fast backward even where the call site asked for the old one.
+    monkeypatch.setenv(fused_xla._FAST_BWD_ENV_VAR, "1")
+    assert fused_xla._resolve_fast_backward(None) is True
+    assert fused_xla._resolve_fast_backward(False) is True
+    # Set to off: forces the old backward even where the call site asked for the fast one.
+    monkeypatch.setenv(fused_xla._FAST_BWD_ENV_VAR, "0")
+    assert fused_xla._resolve_fast_backward(None) is False
+    assert fused_xla._resolve_fast_backward(True) is False
+    # Unrecognised values are ignored rather than silently flipping a hero run.
+    monkeypatch.setenv(fused_xla._FAST_BWD_ENV_VAR, "maybe")
+    assert fused_xla._resolve_fast_backward(True) is True
+    assert fused_xla._resolve_fast_backward(None) is False
+
+
+def test_xla_fast_bwd_implementation_is_registered_and_opt_in():
+    """`xla_fast_bwd` must exist, be explicit-only, and leave `xla` untouched."""
+    assert "xla_fast_bwd" in fused_api.IMPLEMENTATIONS
+    # Never auto-selected: only an explicit implementation= picks it up.
+    assert "xla_fast_bwd" not in fused_api._DEFAULT_IMPLEMENTATION
+    assert "xla_fast_bwd" not in fused_api._CANONICAL_BACKEND_IMPLEMENTATIONS
+    # The plain "xla" entry must still be the unmodified function.
+    assert fused_api.IMPLEMENTATIONS["xla"] is fused_xla.linear_softmax_cross_entropy_loss_xla
+
+
+def test_xla_fast_bwd_implementation_matches_xla_forward_and_fast_backward(monkeypatch):
+    monkeypatch.delenv(fused_xla._FAST_BWD_ENV_VAR, raising=False)
+    key = jax.random.PRNGKey(11)
+    key_x, key_w, key_y = jax.random.split(key, 3)
+    b, h, v = 512, 64, 2048
+    x = (jax.random.normal(key_x, (b, h), dtype=jnp.float32) * 0.5).astype(jnp.bfloat16)
+    w = (jax.random.normal(key_w, (h, v), dtype=jnp.float32) * 0.05).astype(jnp.bfloat16)
+    labels = jax.random.randint(key_y, (b,), 0, v, dtype=jnp.int32)
+    block_sizes = BlockSizes(b_block_size=b, v_block_size=512)
+
+    def make(impl):
+        def objective(x_arg, w_arg):
+            loss = fused_api.fused_cross_entropy_loss_and_logsumexp_penalty(
+                x_arg,
+                labels,
+                w_arg,
+                reduction="mean",
+                logsumexp_weight=None,
+                dtype=jnp.float32,
+                block_sizes=block_sizes,
+                logit_soft_cap=None,
+                implementation=impl,
+            )
+            return loss
+
+        return jax.jit(jax.value_and_grad(objective, argnums=(0, 1)))
+
+    value_xla, (gx_xla, gw_xla) = make("xla")(x, w)
+    value_fast, (gx_fast, gw_fast) = make("xla_fast_bwd")(x, w)
+
+    # Forward is the same code path, so the loss must be bitwise identical.
+    assert np.array_equal(np.asarray(value_xla), np.asarray(value_fast))
+    # Backward differs only in rounding.
+    assert jnp.allclose(gx_fast.astype(jnp.float32), gx_xla.astype(jnp.float32), atol=5e-2, rtol=5e-2)
+    assert jnp.allclose(gw_fast.astype(jnp.float32), gw_xla.astype(jnp.float32), atol=5e-2, rtol=5e-2)
+
+    # And it really is the fast backward: no scatter in the lowered gradient.
+    text = make("xla_fast_bwd").lower(x, w).as_text()
+    assert "stablehlo.scatter" not in text
+    assert "stablehlo.scatter" in make("xla").lower(x, w).as_text()
+
+
+def test_xla_fast_backward_emits_no_scatter_and_one_loop():
+    """Structural gate: the fast backward must not regress to a scatter or a nested loop."""
+    x, w, _ = _fast_bwd_case(jnp.bfloat16, b=256, h=64, v=300, b_block=64, v_block=128)
+    labels = jnp.zeros((256,), dtype=jnp.int32)
+
+    def objective(x_arg, w_arg):
+        loss, _ = fused_xla.linear_softmax_cross_entropy_loss_xla(
+            x_arg,
+            labels,
+            w_arg,
+            block_sizes=BlockSizes(b_block_size=64, v_block_size=128),
+            dtype=jnp.float32,
+            precision=None,
+            fast_backward=True,
+        )
+        return jnp.sum(loss)
+
+    text = jax.jit(jax.grad(objective, argnums=(0, 1))).lower(x, w).as_text()
+    assert "stablehlo.scatter" not in text
+    # 2 while loops for the (unchanged) forward, 1 scan for the backward.
+    assert text.count("stablehlo.while") == 3
+    # Both backward GEMMs must stay on bf16 operands (tensor cores), not upcast to f32.
+    assert "tensor<256x128xf32>, tensor<64x128xf32>" not in text


### PR DESCRIPTION
🤖 Second of four, on top of #8367. **2.33x measured on GB200 at the hero CE shape.**

## What it costs today

`fused_linear_softmax_cross_entropy_loss` at the EP64 hero shape (B=65,536, H=6,144, V=128,256) costs **732.5 ms/step at 423 TFLOP/s**, against **1,538–1,765 TFLOP/s** for the dense GEMMs in the same program — a 4x efficiency gap. It issues **43,662 kernel launches per step: 53.4% of every launch in the step, for 4.29% of the time.**

## Two causes, both previously undocumented, neither of them tuning

1. **The backward's two GEMMs were running TF32, not bf16.** `dtype=float32` makes `delta` fp32, so XLA inserts `convert bf16 -> f32` on *both* operands inside the inner loop and emits `dot_general(f32, f32)`. On Blackwell that is TF32 at 1.25 PFLOP/s against bf16's 2.5 — half rate on 2 of the 4 GEMMs, plus a materialized f32 copy of a 50 MB weight tile per iteration.
2. **`grad_w` was materialized 2,048 times instead of 32** — a full `[H, v_block]` fp32 partial per (batch, vocab) tile, accumulated in bf16.

## Measured

| variant | fwd ms | bwd ms | total | useful TF/s | peak GiB | speedup |
|---|---|---|---|---|---|---|
| baseline | 171.3 | 552.1 | **723.4** | 428 | 11.21 | 1.00 |
| backward only | 178.8 | 203.7 | 382.5 | 810 | 12.68 | 1.89 |
| block size only | 81.9 | 353.9 | 435.9 | 711 | 11.33 | 1.66 |
| **both (shipped)** | 85.3 | 224.7 | **310.0** | 1000 | **11.25** | **2.33** |

Reproduces production within 1.2% (723.4 vs the profile's 732.5). **+0.04 GiB peak.** Estimated ~419 ms/step end-to-end, labelled an estimate.

## Numerics — the risk inverted, but there is a real decision here

**`loss_diff` vs the old path is 0.00e+00, bitwise identical, on all 12 arms.** The forward is untouched by design.

Gradients are **strictly more accurate**: `grad_x` rel-RMS 2.170e-03 → 1.445e-03, `grad_w` 1.946e-03 → 1.433e-03 against an fp32 reference. Killing the bf16 `grad_w` accumulation more than pays for the bf16 `dlogits` cast.

**But gradients do change**, and that is a hero-comparability break of the same class as #8217/#8226. It applies to *both* halves, including the memory-free block-size change, so it is not avoidable by taking the conservative half. Taken deliberately.

## A closed door that was closed on bad data

The recorded negative — *"CE token block 1024 → 8192: −0.02%, +9.1 GiB"* — is wrong in both halves. 8192 is **still 8 batch blocks**; the real optimum is 1 block (65,536), worth **1.66x on CE by itself at +0.12 GiB**. Two distinct defects, and the second generalizes:

1. The arm sampled a point **too close to the start** — 1024→8192 moves 8x along an axis whose useful range is 64x.
2. **A null from a single rack arm was recorded as a dead direction.** At a measured between-run sd of 0.469 MFU points, single-vs-single resolves nothing below ~5.4% relative, so a "−0.02%" is indistinguishable from *any* effect under 5%. It is not evidence of absence.

Suggest the negative-results index record, per entry, the range actually swept and the resolution of the instrument that produced the null.

## Conventions

The 405 TFLOP/s figure counts 3 GEMMs; the kernel issues **4** — the backward recomputes logits, because a `[65536, 128256]` fp32 logits tensor is 33.6 GB and cannot be saved. So "1,200 useful TFLOP/s" means 1,600 issued = 100% of the dense band, an impossible target. Baseline was 428 useful / 571 issued; it is now 1,000 useful / 1,333 issued, i.e. **78–90% of dense efficiency**. Quote both conventions or the next reader sets an unreachable target.

## Deployment

`xla_fast_bwd` is a separately registered implementation, not a flip of the shared `xla` default, so other levanter consumers are byte-identical. `LEVANTER_CE_XLA_FAST_BWD` overrides the call site in **both** directions — an A/B switch and a kill switch with no code edit.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

