### PR TITLE
[levanter] Fused depthwise causal conv for ShortConv

### DIFF
--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -49,6 +49,7 @@ from levanter.grug.grug_moe import (
 )
 from levanter.grug.loss import BlockSizes, fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import unshard
+from levanter.kernels.pallas.short_conv import short_conv
 from levanter.tracker.histogram import Histogram, SummaryStats
 from levanter.utils.activation import ActivationFunctionEnum
 from transformers import PretrainedConfig as HfConfig
@@ -422,8 +423,10 @@ class ShortConv(eqx.Module):
     A kernel of ``W`` taps mixes each channel with its own ``W-1`` causal predecessors,
     ``out[t] = sum_{lag} weight[lag] * x[t-lag]``, independently per channel. Identity-init
     (``weight[0]=1``, later taps 0) makes it a pass-through at step 0. Weights are tiny (``W*C``) and
-    routed to Adam. Implemented as a pad-and-shift weighted sum (XLA fuses it well and it is
-    shard-local -- no cross-channel or cross-shard dependency, so no collectives).
+    routed to Adam. Shard-local -- no cross-channel or cross-shard dependency, so no collectives.
+
+    The body dispatches to ``levanter.kernels.pallas.short_conv``, which selects a fused Pallas
+    kernel on GPU and the pad-and-shift weighted sum everywhere else; see that module's docstring.
     """
 
     weight: Float[Array, "W C"]
@@ -432,24 +435,16 @@ class ShortConv(eqx.Module):
     @staticmethod
     def init(channels: int, kernel_size: int) -> "ShortConv":
         weight = jnp.zeros((kernel_size, channels)).at[0].set(1.0)
-        # FSDP-shard the channel dim over data so the grad reduce-scatters (coalesced) instead of a
-        # standalone replicated all-reduce; the forward gathers the weight back to replicated.
-        return ShortConv(weight=reshard(weight, P(None, "data")), kernel_size=kernel_size)
+        # FSDP-shard the channel dim so the grad reduce-scatters instead of all-reducing; the
+        # forward gathers the weight back to replicated.
+        return ShortConv(weight=reshard(weight, P(None, _FSDP_AXES)), kernel_size=kernel_size)
 
     def __call__(self, x: Float[Array, "B S C"], segment_ids: Int[Array, "B S"] | None = None) -> Float[Array, "B S C"]:
-        # Depthwise causal shift-and-sum. With segment_ids (packed documents), a tap that reaches
-        # into a previous document is zeroed so the conv never mixes across a boundary; the lag-0
-        # (current-token) tap is always kept.
-        seq_len = x.shape[1]
+        # With segment_ids (packed documents), a tap that reaches into a previous document is
+        # zeroed so the conv never mixes across a boundary; the lag-0 (current-token) tap is
+        # always kept.
         weight = reshard(self.weight, P(None, None))
-        out = weight[0] * x
-        for lag in range(1, self.kernel_size):
-            shifted = jnp.pad(x, ((0, 0), (lag, 0), (0, 0)))[:, :seq_len, :]
-            if segment_ids is not None:
-                seg_shifted = jnp.pad(segment_ids, ((0, 0), (lag, 0)), constant_values=-1)[:, :seq_len]
-                shifted = jnp.where((seg_shifted == segment_ids)[..., None], shifted, 0.0)
-            out = out + weight[lag] * shifted
-        return out
+        return short_conv(weight, x, segment_ids, batch_axes=_BATCH_AXES)
 
 
 class CausalSelfAttention(eqx.Module):

--- a/lib/levanter/src/levanter/kernels/pallas/short_conv/__init__.py
+++ b/lib/levanter/src/levanter/kernels/pallas/short_conv/__init__.py
@@ -1,0 +1,19 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fused depthwise causal short convolution (SConv)."""
+
+from .api import DEFAULT_BATCH_AXES, Implementation, short_conv
+from .config import ShortConvBlockSizes
+from .pallas_gpu import expected_bytes_moved, pallas_short_conv_available
+from .reference import short_conv_reference
+
+__all__ = [
+    "DEFAULT_BATCH_AXES",
+    "Implementation",
+    "ShortConvBlockSizes",
+    "expected_bytes_moved",
+    "pallas_short_conv_available",
+    "short_conv",
+    "short_conv_reference",
+]

--- a/lib/levanter/src/levanter/kernels/pallas/short_conv/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/short_conv/api.py
@@ -1,0 +1,264 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public API and backend selection for the depthwise causal short convolution."""
+
+import functools
+import logging
+import warnings
+from collections.abc import Sequence
+from typing import Literal, TypeAlias
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import PartitionSpec as P
+from jax.sharding import get_abstract_mesh, reshard
+from jaxtyping import Array, Float, Int
+
+# `jax.shard_map` is a function on the top-level namespace, not a module: `from
+# jax.shard_map import shard_map` raises ModuleNotFoundError and silently drops you onto
+# the deprecated `jax.experimental` one, which has no `check_vma` parameter.
+if hasattr(jax, "shard_map"):
+    shard_map = jax.shard_map
+else:  # pragma: no cover - older JAX
+    from jax.experimental.shard_map import shard_map  # type: ignore[assignment]
+
+from .config import ShortConvBlockSizes
+from .pallas_gpu import (
+    pallas_short_conv_available,
+    short_conv_pallas_bwd_local,
+    short_conv_pallas_fwd_local,
+    short_conv_shapes_supported,
+)
+from .reference import short_conv_reference
+
+logger = logging.getLogger(__name__)
+
+Implementation: TypeAlias = Literal["reference", "pallas_gpu"]
+
+#: Mesh axes the activation batch is sharded over in the grug MoE models. The kernel is
+#: shard-local along every one of them; the sequence and channel axes must stay whole.
+DEFAULT_BATCH_AXES: tuple[str, ...] = ("replica_dcn", "data", "expert")
+
+
+def _default_implementations() -> tuple[Implementation, ...]:
+    if pallas_short_conv_available():
+        return ("pallas_gpu", "reference")
+    return ("reference",)
+
+
+def _as_sequence(
+    implementation: Implementation | Sequence[Implementation] | None,
+) -> tuple[Implementation, ...]:
+    if implementation is None:
+        return _default_implementations()
+    if isinstance(implementation, str):
+        return (implementation,)  # explicit single choice: fail fast, never silently fall back
+    return tuple(implementation)
+
+
+def _active_batch_axes(mesh, batch_axes: Sequence[str]) -> tuple[str, ...]:
+    return tuple(axis for axis in batch_axes if axis in mesh.shape)
+
+
+def _mesh_sizes(mesh) -> dict[str, int]:
+    try:
+        return dict(mesh.shape)
+    except (AttributeError, TypeError):
+        return {}
+
+
+def _assert_local_axes(name: str, array: jax.Array, rank: int, mesh=None) -> None:
+    """Reject a sequence or channel axis that is *actually* sharded.
+
+    The caller reshards to ``P(active, None, None)`` immediately after this check, so the point is
+    not to reject a spec -- it is to refuse to paper over a real all-gather with a silent reshard.
+
+    A spec entry naming a mesh axis of size 1 shards nothing. That is not a corner case here: the
+    EP64 hero mesh is (replica_dcn=1, data=1, expert=64, model=1), and the attention projections
+    are ``P(_FSDP_AXES, "model")``, so every k/v activation carries "model" on its channel axis.
+    Rejecting on the name alone fails the hero while the reshard it is guarding is a no-op.
+    """
+    sharding = jax.typeof(array).sharding if isinstance(array, jax.core.Tracer) else array.sharding
+    spec = getattr(sharding, "spec", None)
+    if spec is None:
+        return
+    sizes = _mesh_sizes(mesh) if mesh is not None else {}
+    for axis in range(1, min(rank, len(spec))):
+        entry = spec[axis]
+        if entry is None:
+            continue
+        names = (entry,) if isinstance(entry, str) else tuple(entry)
+        if sizes and all(sizes.get(n, 1) == 1 for n in names):
+            continue
+        raise ValueError(
+            f"short_conv requires an unsharded {'sequence' if axis == 1 else 'channel'} axis "
+            f"for {name}; got {spec}."
+        )
+
+
+# --------------------------------------------------------------------------------------
+# custom_vjp around the Pallas kernels.
+#
+# JAX must never autodiff *through* a pallas_call, and -- much more to the point here --
+# we specifically do not want reverse-mode AD to invent the backward. The whole cost of
+# this op lives in the backward, so the backward is hand-written.
+# --------------------------------------------------------------------------------------
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=(3, 4))
+def _short_conv_pallas_local(
+    weight: Float[Array, "W C"],
+    x: Float[Array, "B S C"],
+    segment_ids: Int[Array, "B S"],
+    block_sizes: ShortConvBlockSizes,
+    exact_reference_rounding: bool,
+) -> Float[Array, "B S C"]:
+    return short_conv_pallas_fwd_local(
+        weight,
+        x,
+        segment_ids,
+        block_sizes=block_sizes,
+        exact_reference_rounding=exact_reference_rounding,
+    )
+
+
+def _short_conv_pallas_local_fwd(weight, x, segment_ids, block_sizes, exact_reference_rounding):
+    out = short_conv_pallas_fwd_local(
+        weight,
+        x,
+        segment_ids,
+        block_sizes=block_sizes,
+        exact_reference_rounding=exact_reference_rounding,
+    )
+    # Residuals are the primal inputs only: `x` is needed for dw, `segment_ids` for both
+    # masks, `weight` for dx. Nothing shifted or masked is saved -- that is the 4.84 GB of
+    # fp32 scratch the XLA backward allocates and this one does not.
+    return out, (weight, x, segment_ids)
+
+
+def _short_conv_pallas_local_bwd(block_sizes, exact_reference_rounding, residuals, dy):
+    weight, x, segment_ids = residuals
+    dx, dw_partials = short_conv_pallas_bwd_local(
+        weight,
+        x,
+        segment_ids,
+        dy,
+        block_sizes=block_sizes,
+        exact_reference_rounding=exact_reference_rounding,
+    )
+    dw = jnp.sum(dw_partials, axis=0).astype(weight.dtype)
+    return dw, dx, None  # segment_ids is integer metadata: no cotangent
+
+
+_short_conv_pallas_local.defvjp(_short_conv_pallas_local_fwd, _short_conv_pallas_local_bwd)
+
+
+def _short_conv_pallas_sharded(
+    weight: Float[Array, "W C"],
+    x: Float[Array, "B S C"],
+    segment_ids: Int[Array, "B S"],
+    *,
+    block_sizes: ShortConvBlockSizes,
+    exact_reference_rounding: bool,
+    batch_axes: Sequence[str],
+) -> Float[Array, "B S C"]:
+    """Enter an explicit ``shard_map`` before touching the kernel.
+
+    The op is shard-local by construction (depthwise, causal along the sequence, no
+    cross-channel term), so the manual region needs no collectives at all. Making the
+    boundary explicit stops XLA inferring a sharding for an opaque call and is the house
+    rule for every Pallas/FFI kernel in this repo.
+    """
+    call = functools.partial(
+        _short_conv_pallas_local,
+        block_sizes=block_sizes,
+        exact_reference_rounding=exact_reference_rounding,
+    )
+
+    mesh = get_abstract_mesh()
+    if mesh is None or mesh.empty:
+        return call(weight, x, segment_ids)
+
+    active = _active_batch_axes(mesh, batch_axes)
+    if not active:
+        return call(weight, x, segment_ids)
+
+    _assert_local_axes("x", x, rank=3, mesh=mesh)
+    x = reshard(x, P(active, None, None))
+    segment_ids = reshard(segment_ids, P(active, None))
+    weight = reshard(weight, P(None, None))
+
+    @functools.partial(shard_map, mesh=mesh, out_specs=P(active, None, None), check_vma=False)
+    def _local(weight_local, x_local, segment_ids_local):
+        return call(weight_local, x_local, segment_ids_local)
+
+    return _local(weight, x, segment_ids)
+
+
+def short_conv(
+    weight: Float[Array, "W C"],
+    x: Float[Array, "B S C"],
+    segment_ids: Int[Array, "B S"] | None = None,
+    *,
+    implementation: Implementation | Sequence[Implementation] | None = None,
+    block_sizes: ShortConvBlockSizes | None = None,
+    exact_reference_rounding: bool = True,
+    batch_axes: Sequence[str] = DEFAULT_BATCH_AXES,
+) -> Float[Array, "B S C"]:
+    """Depthwise causal 1-D convolution over the sequence axis.
+
+    ``out[b,t,c] = sum_lag weight[lag,c] * x[b,t-lag,c]``, with taps that would reach into
+    a previous packed document dropped and positions before the sequence start read as
+    zero. Shard-local: no collectives, no cross-channel term.
+
+    Args:
+      weight: ``[kernel_size, channels]`` taps; ``weight[0]`` is the current token.
+      x: ``[batch, seq_len, channels]`` activations.
+      segment_ids: ``[batch, seq_len]`` packed-document ids, or None for an unpacked batch.
+      implementation: a single name (fail fast if unsupported) or an ordered sequence to
+        try in turn. Defaults to the Pallas kernel on GPU, the reference elsewhere.
+      block_sizes: GPU tile configuration.
+      exact_reference_rounding: keep the reference's per-op bf16 rounding, which makes the
+        forward and ``dx`` bit-identical to ``short_conv_reference``. Setting False keeps a
+        single fp32 accumulator across taps -- more accurate, not bit-comparable.
+      batch_axes: mesh axes the batch is sharded over.
+    """
+    block_sizes = block_sizes or ShortConvBlockSizes.get_default()
+    requested = _as_sequence(implementation)
+    explicit_single = isinstance(implementation, str)
+
+    errors: list[str] = []
+    for name in requested:
+        if name == "reference":
+            return short_conv_reference(weight, x, segment_ids)
+        if name != "pallas_gpu":
+            raise ValueError(f"Unknown short_conv implementation {name!r}")
+
+        reason = None
+        if not pallas_short_conv_available():
+            reason = "Pallas Triton backend unavailable or not running on a GPU"
+        else:
+            reason = short_conv_shapes_supported(weight.shape, x.shape, block_sizes)
+        if reason is not None:
+            if explicit_single:
+                raise RuntimeError(f"short_conv implementation 'pallas_gpu' is unusable: {reason}")
+            errors.append(f"pallas_gpu: {reason}")
+            warnings.warn(f"short_conv falling back from 'pallas_gpu' ({reason})", stacklevel=2)
+            continue
+
+        seg = segment_ids
+        if seg is None:
+            # One kernel handles both cases; a constant segment id makes every tap valid.
+            # [batch, seq_len] int32 is ~0.03% of the activation traffic at hero shape.
+            seg = jnp.zeros(x.shape[:2], jnp.int32)
+        return _short_conv_pallas_sharded(
+            weight,
+            x,
+            seg,
+            block_sizes=block_sizes,
+            exact_reference_rounding=exact_reference_rounding,
+            batch_axes=batch_axes,
+        )
+
+    raise RuntimeError("No usable short_conv implementation: " + "; ".join(errors))

--- a/lib/levanter/src/levanter/kernels/pallas/short_conv/config.py
+++ b/lib/levanter/src/levanter/kernels/pallas/short_conv/config.py
@@ -1,0 +1,49 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Block-size configuration for the fused short-convolution kernels."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ShortConvBlockSizes:
+    """Tile sizes for the GPU Pallas short-conv kernels.
+
+    ``s_block_size`` tiles the sequence axis and ``c_block_size`` the channel axis. Both
+    must be powers of two -- a Pallas Triton lowering constraint on tile shapes, not a
+    preference.
+
+    Defaults are the measured winner of a six-point sweep on one GB200 at the EP64 hero
+    per-layer shapes (65,536 tokens x {1536, 6144} channels, bf16, kernel 4):
+
+    ==========================  ==================  =================
+    tile (s, c, warps)          hero-scaled ms/step  vs reference
+    ==========================  ==================  =================
+    reference (pad-and-shift)               427.2   --
+    **64, 64, 4**                           **231.8**  **-195.4 ms**
+    32, 64, 4                               234.1   -193.1 ms
+    64, 128, 8                              237.8   -189.4 ms
+    32, 128, 4                              244.6   -182.5 ms
+    128, 64, 4                              244.9   -182.3 ms
+    64, 128, 4                              284.1   -143.0 ms
+    ==========================  ==================  =================
+
+    The gradient is shallow across the good configs and steeply bad above ``c_block_size``
+    128 with large ``s_block_size`` (256x256 was 19x slower than the reference): each
+    program holds up to ``kernel_size`` live ``[s, c]`` tiles plus an fp32 accumulator, so
+    big tiles spill and occupancy collapses. Small tiles win because the kernel is
+    bandwidth-bound and wants occupancy, not reuse.
+    """
+
+    s_block_size: int = 64
+    c_block_size: int = 64
+    num_warps: int = 4
+    num_stages: int = 2
+
+    @classmethod
+    def get_default(cls) -> "ShortConvBlockSizes":
+        return cls()
+
+    def as_key(self) -> str:
+        return f"s{self.s_block_size}_c{self.c_block_size}_w{self.num_warps}_st{self.num_stages}"

--- a/lib/levanter/src/levanter/kernels/pallas/short_conv/pallas_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/short_conv/pallas_gpu.py
@@ -1,0 +1,506 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fused depthwise causal short convolution (SConv) as a Pallas GPU kernel.
+
+Why this exists
+---------------
+The op is depthwise with ``kernel_size=4``: 8 FLOP per element against a 4-byte floor of
+traffic, an arithmetic intensity of **2.0 FLOP/byte** against a GB200 ridge of ~312. It is
+bandwidth-bound by ~156x, so the *only* lever is how many times the tensor crosses HBM.
+The floor is 2 passes forward (read x, write y) and 3 passes backward (read x, read dy,
+write dx).
+
+The pad-and-shift reference (``reference.py``) does not sit at that floor, but **not for
+the reason you would guess, and not for the reason CPU HLO suggests.** Compiled for CPU,
+its VJP materialises four full-size fp32 copies of ``dy * mask * shift(x)`` and reduces
+each with a separate ``reduce-window``, needing 4.84 GB of scratch at the hero per-layer
+shape. **None of that happens on GPU.** XLA:GPU fuses those reductions into their
+producers: the compiled GPU HLO has one fusion and two full-size buffers in the forward,
+five fusions and three full-size buffers in the VJP, and 13 MB of temp. Do not repeat the
+CPU-HLO story; it is a backend artifact.
+
+The real cost is **repeated traversal**, measured on one GB200 at the hero per-layer shape
+against a read-one-write-one stream calibrated on the same tensor:
+
+=========================  ===============  ===============
+                           forward          backward
+=========================  ===============  ===============
+floor                      2.0 passes       3.0 passes
+pad-and-shift reference    4.5 passes       14.3 passes
+this kernel                3.0 passes        6.7 passes
+=========================  ===============  ===============
+
+Each tap is a separate offset read of the whole tensor that the cache does not fully
+absorb, and the reference's VJP additionally launches five fusions that each re-read their
+inputs. The kernel collapses those to one launch per direction, so the forward drops from
+0.811 ms to 0.547 ms and the backward from 2.558 ms to 1.200 ms at C=6144 -- 1.5x and 2.1x.
+The residual gap to the floor is the same offset-read problem: Pallas Triton cannot slice
+a register tile (no ``lax.slice`` lowering) and requires power-of-2 tile shapes, so the
+kernel still issues ``W`` overlapping loads per tile rather than loading once and shifting
+in registers the way ``Dao-AILab/causal-conv1d`` does with an SMEM ring carry.
+
+Closing that last gap needs a register/SMEM carry, which needs CUDA or a Mosaic backend
+that lowers here. Neither is available today; see "Backend" below.
+
+``dw`` never touches HBM as a full-size tensor. It is accumulated in fp32 registers per
+program and emitted as a ``[batch * num_s_blocks, W, C]`` partial that a cheap outer
+``sum(0)`` folds down -- the deterministic reduction that FLA's Triton conv uses, rather
+than ``atomicAdd``. It costs ``2 * W * 4 / (s_block_size * itemsize)`` of a pass (3% at the
+default tile) and is bit-reproducible run to run.
+
+Backend
+-------
+**Pallas Triton, not Mosaic GPU.** The repo's kernel skill prefers Mosaic for new GPU
+kernels; measured on GB200/SM100 with JAX 0.11, Mosaic's layout inference fails on this
+kernel and on a trivial ``o = w * x`` body alike ("Layout inference failed to find a
+solution"). Triton lowers both. Revisit when Mosaic's layout inference improves.
+
+Triton imposes one hard constraint that shapes the whole design: **every intermediate tile
+must have a power-of-2 shape.** Arbitrary *offsets* are fine; only *sizes* are
+constrained. That rules out the obvious halo construction -- concatenating the ``lag``
+rows carried over from the previous block onto this block's first ``BS-lag`` rows -- since
+``BS-lag`` is never a power of two. Confirmed on hardware: it fails with "Encountered an
+array of shape (127, 128)".
+
+Halo handling
+-------------
+So every shifted tile is a single ``pl.ds(start, BS)`` read at an arbitrary offset out of a
+whole-sequence window. That is exact and power-of-2 for every block except the ones at the
+ends of the sequence, where ``start`` would run off the array. Rather than rely on an
+out-of-bounds read being masked -- which happens to work on Triton but is *wrong* under
+Pallas's own interpreter, where the clamp silently misaligns the tile and would make the
+CPU tests disagree with the GPU -- the kernel takes a small pre-padded **head block**
+(``[B, BS+W-1, C]``: ``W-1`` zero rows then the first ``BS`` rows of ``x``) and, in the
+backward, a matching **tail block** for the anti-causal direction. ``pl.when`` routes the
+edge programs to them. Building both touches ``~2*BS/S`` of the tensor, under 7% of a
+pass, and every read in the kernel is then unconditionally in bounds.
+
+Numerics
+--------
+``exact_reference_rounding=True`` (the default) reproduces the reference's rounding
+*operation for operation*: every multiply and every accumulate rounds to the activation
+dtype, in the reference's association order. That order is not cosmetic -- the forward is
+left-nested over ascending lags, and JAX transposes it by walking the jaxpr in reverse, so
+``dx`` accumulates over *descending* lags. Matching both makes the forward and ``dx``
+bit-identical to the reference. ``dw`` is a reduction over 65,536 tokens whose association
+order XLA does not define, so it agrees to fp32 reassociation error and is validated
+against a float64 oracle instead. Setting the flag to ``False`` keeps a single fp32
+accumulator across taps: strictly more accurate, no longer bit-comparable.
+"""
+
+import contextlib
+import functools
+import math
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jaxtyping import Array, Float, Int
+
+from levanter.kernels.pallas.cost_estimate_utils import with_io_bytes_accessed
+
+from .config import ShortConvBlockSizes
+from .reference import short_conv_reference
+
+try:  # pragma: no cover - import guard, exercised only by environment
+    from jax.experimental.pallas import triton as pltriton
+
+    _HAS_PALLAS_TRITON = True
+except (ImportError, ModuleNotFoundError):  # pragma: no cover
+    pltriton = None  # type: ignore[assignment]
+    _HAS_PALLAS_TRITON = False
+
+#: Sentinel written into the shifted segment ids for positions outside the sequence.
+#: `jnp.pad(segment_ids, ..., constant_values=-1)` in the reference; matching it exactly is
+#: what makes the first `kernel_size - 1` positions of every sequence agree.
+_OOB_SEGMENT = -1
+
+_FORCE_INTERPRET = False
+
+
+@contextlib.contextmanager
+def interpret_mode():
+    """Run the kernels through Pallas's reference interpreter.
+
+    This is the only way these kernels get CPU coverage: a Pallas GPU kernel cannot execute
+    on CPU, but the interpreter executes the *kernel body* -- grid, block specs, head/tail
+    routing, register accumulation and all -- with plain XLA ops. It exercises the real
+    algorithm, not a paraphrase. It says nothing about whether the kernel *lowers* on a
+    given GPU architecture; that needs a GPU.
+    """
+    global _FORCE_INTERPRET
+    previous = _FORCE_INTERPRET
+    _FORCE_INTERPRET = True
+    try:
+        yield
+    finally:
+        _FORCE_INTERPRET = previous
+
+
+def pallas_short_conv_available() -> bool:
+    """True when the Pallas Triton backend imported and we are on a GPU."""
+    if _FORCE_INTERPRET:
+        return True
+    return _HAS_PALLAS_TRITON and jax.default_backend() == "gpu"
+
+
+def _is_pow2(value: int) -> bool:
+    return value > 0 and (value & (value - 1)) == 0
+
+
+def short_conv_shapes_supported(
+    weight_shape: tuple[int, ...],
+    x_shape: tuple[int, ...],
+    block_sizes: ShortConvBlockSizes,
+) -> str | None:
+    """Returns None when the kernel can run these shapes, else a human-readable reason."""
+    if len(x_shape) != 3 or len(weight_shape) != 2:
+        return f"expected weight [W, C] and x [B, S, C], got {weight_shape} and {x_shape}"
+    width, weight_channels = weight_shape
+    _, seq_len, channels = x_shape
+    if weight_channels != channels:
+        return f"weight channel dim {weight_channels} != x channel dim {channels}"
+    if width < 1:
+        return f"kernel_size must be >= 1, got {width}"
+    bs, bc = block_sizes.s_block_size, block_sizes.c_block_size
+    if seq_len % bs:
+        return f"seq_len {seq_len} not divisible by s_block_size {bs}"
+    if channels % bc:
+        return f"channels {channels} not divisible by c_block_size {bc}"
+    # Pallas Triton requires power-of-2 tile shapes; every read in the kernel is [bs, bc].
+    if not _is_pow2(bs):
+        return f"s_block_size {bs} must be a power of 2 (Pallas Triton tile constraint)"
+    if not _is_pow2(bc):
+        return f"c_block_size {bc} must be a power of 2 (Pallas Triton tile constraint)"
+    if bs < width - 1:
+        return f"s_block_size {bs} must be >= kernel_size - 1 = {width - 1}"
+    return None
+
+
+def _mul_round(weight_row: jax.Array, tile: jax.Array, dtype, exact: bool) -> jax.Array:
+    """``weight_row[None, :] * tile`` with the reference's rounding."""
+    product = weight_row[None, :].astype(jnp.float32) * tile.astype(jnp.float32)
+    return product.astype(dtype) if exact else product
+
+
+def _add_round(acc, term, dtype, exact: bool) -> jax.Array:
+    if acc is None:
+        return term
+    total = acc.astype(jnp.float32) + term.astype(jnp.float32)
+    return total.astype(dtype) if exact else total
+
+
+def _keep(seg_shifted: jax.Array, seg_cur: jax.Array, tile: jax.Array) -> jax.Array:
+    return jnp.where((seg_shifted == seg_cur)[:, None], tile, jnp.zeros_like(tile))
+
+
+# --------------------------------------------------------------------------------------
+# Forward
+# --------------------------------------------------------------------------------------
+
+
+def _fwd_body(
+    vals_ref, segs_ref, w_ref, out_ref, base: int | jax.Array, block_seq: int, kernel_size: int, exact: bool
+) -> None:
+    """One block's forward, reading taps at ``base - lag`` out of ``vals_ref``.
+
+    ``base`` is the row in ``vals_ref`` corresponding to this block's first output row, so
+    the general path passes ``si * BS`` into the whole-sequence view and the first-block
+    path passes ``W - 1`` into the pre-padded head view. Both then read identically.
+    """
+    seg_cur = segs_ref[0, pl.ds(base, block_seq)]
+    tile = vals_ref[0, pl.ds(base, block_seq), :]
+    dtype = tile.dtype
+    # Ascending lags, left-nested, rounding after every op: the reference's exact order.
+    acc = _mul_round(w_ref[0], tile, dtype, exact)
+    for lag in range(1, kernel_size):
+        shifted = vals_ref[0, pl.ds(base - lag, block_seq), :]
+        seg_shifted = segs_ref[0, pl.ds(base - lag, block_seq)]
+        shifted = _keep(seg_shifted, seg_cur, shifted)
+        acc = _add_round(acc, _mul_round(w_ref[lag], shifted, dtype, exact), dtype, exact)
+    out_ref[0] = acc.astype(dtype)
+
+
+def _fwd_kernel(x_ref, xh_ref, seg_ref, segh_ref, w_ref, out_ref, *, kernel_size: int, exact: bool):
+    block_seq = out_ref.shape[1]
+    si = pl.program_id(1)
+
+    @pl.when(si == 0)
+    def _first():
+        _fwd_body(xh_ref, segh_ref, w_ref, out_ref, kernel_size - 1, block_seq, kernel_size, exact)
+
+    @pl.when(si != 0)
+    def _general():
+        _fwd_body(x_ref, seg_ref, w_ref, out_ref, si * block_seq, block_seq, kernel_size, exact)
+
+
+# --------------------------------------------------------------------------------------
+# Backward
+# --------------------------------------------------------------------------------------
+
+
+def _dx_body(dy_ref, segs_ref, w_ref, dx_ref, base, block_seq: int, kernel_size: int, exact: bool) -> None:
+    """``dx[t] = sum_lag w[lag] * [seg[t] == seg[t+lag]] * dy[t+lag]``.
+
+    Descending lags then tap 0, because that is the order JAX's transpose of the forward
+    produces and matching it is what makes ``dx`` bit-identical rather than merely close.
+    """
+    seg_cur = segs_ref[0, pl.ds(base, block_seq)]
+    dy = dy_ref[0, pl.ds(base, block_seq), :]
+    dtype = dy.dtype
+    acc = None
+    for lag in range(kernel_size - 1, 0, -1):
+        dy_ahead = dy_ref[0, pl.ds(base + lag, block_seq), :]
+        seg_ahead = segs_ref[0, pl.ds(base + lag, block_seq)]
+        term = _mul_round(w_ref[lag], dy_ahead, dtype, exact)
+        acc = _add_round(acc, _keep(seg_ahead, seg_cur, term), dtype, exact)
+    dx_ref[0] = _add_round(acc, _mul_round(w_ref[0], dy, dtype, exact), dtype, exact).astype(dtype)
+
+
+def _dw_body(x_ref, segs_ref, dy, dw_ref, base, block_seq: int, kernel_size: int) -> None:
+    """``dw[lag] = sum_t dy[t] * [seg[t-lag] == seg[t]] * x[t-lag]``, fp32, in registers.
+
+    The shifted-``x`` construction is the forward's, so the mask semantics are shared by
+    construction rather than by a comment asking you to keep them in sync.
+    """
+    seg_cur = segs_ref[0, pl.ds(base, block_seq)]
+    dy_f32 = dy.astype(jnp.float32)
+    for lag in range(kernel_size):
+        shifted = x_ref[0, pl.ds(base - lag, block_seq), :]
+        if lag:
+            shifted = _keep(segs_ref[0, pl.ds(base - lag, block_seq)], seg_cur, shifted)
+        partial = jnp.sum(dy_f32 * shifted.astype(jnp.float32), axis=0)
+        # Store per tap rather than stacking: Triton's `stack` lowering takes exactly two
+        # operands, and a W-way stack would build non-power-of-2 intermediates anyway.
+        dw_ref[0, pl.ds(lag, 1), :] = partial[None, :]
+
+
+def _bwd_kernel(
+    x_ref,
+    xh_ref,
+    seg_ref,
+    segh_ref,
+    dy_ref,
+    dyt_ref,
+    segt_ref,
+    w_ref,
+    dx_ref,
+    dw_partial_ref,
+    *,
+    kernel_size: int,
+    exact: bool,
+):
+    block_seq = dx_ref.shape[1]
+    si = pl.program_id(1)
+    last = pl.num_programs(1) - 1
+
+    # dx reads dy *ahead* of this block, so only the final block needs the tail view.
+    @pl.when(si != last)
+    def _dx_general():
+        _dx_body(dy_ref, seg_ref, w_ref, dx_ref, si * block_seq, block_seq, kernel_size, exact)
+
+    @pl.when(si == last)
+    def _dx_last():
+        _dx_body(dyt_ref, segt_ref, w_ref, dx_ref, 0, block_seq, kernel_size, exact)
+
+    # dw reads x *behind* this block, so only the first block needs the head view.
+    @pl.when(si != 0)
+    def _dw_general():
+        _dw_body(
+            x_ref,
+            seg_ref,
+            dy_ref[0, pl.ds(si * block_seq, block_seq), :],
+            dw_partial_ref,
+            si * block_seq,
+            block_seq,
+            kernel_size,
+        )
+
+    @pl.when(si == 0)
+    def _dw_first():
+        _dw_body(
+            xh_ref,
+            segh_ref,
+            dy_ref[0, pl.ds(0, block_seq), :],
+            dw_partial_ref,
+            kernel_size - 1,
+            block_seq,
+            kernel_size,
+        )
+
+
+# --------------------------------------------------------------------------------------
+# Edge views, wrappers
+# --------------------------------------------------------------------------------------
+
+
+def _head_views(x, segment_ids, block_seq: int, width: int):
+    """``[B, BS+W-1, C]`` / ``[B, BS+W-1]``: ``W-1`` pad rows then the first ``BS`` rows.
+
+    Exactly what ``jnp.pad(x, ((0,0),(W-1,0),(0,0)))`` would give for those rows, so the
+    first-block path is the reference's semantics with no special casing inside the kernel.
+    """
+    pad_vals = jnp.zeros((x.shape[0], width - 1, x.shape[2]), x.dtype)
+    pad_segs = jnp.full((segment_ids.shape[0], width - 1), _OOB_SEGMENT, segment_ids.dtype)
+    return (
+        jnp.concatenate([pad_vals, x[:, :block_seq, :]], axis=1),
+        jnp.concatenate([pad_segs, segment_ids[:, :block_seq]], axis=1),
+    )
+
+
+def _tail_views(dy, segment_ids, block_seq: int, width: int):
+    """``[B, BS+W-1, C]`` / ``[B, BS+W-1]``: the last ``BS`` rows then ``W-1`` pad rows.
+
+    The anti-causal mirror of ``_head_views``. Positions past the end contribute nothing to
+    ``dx``, so the pad value is zero and its segment id can never match.
+    """
+    pad_vals = jnp.zeros((dy.shape[0], width - 1, dy.shape[2]), dy.dtype)
+    pad_segs = jnp.full((segment_ids.shape[0], width - 1), _OOB_SEGMENT, segment_ids.dtype)
+    return (
+        jnp.concatenate([dy[:, -block_seq:, :], pad_vals], axis=1),
+        jnp.concatenate([segment_ids[:, -block_seq:], pad_segs], axis=1),
+    )
+
+
+def _compiler_params(block_sizes: ShortConvBlockSizes):
+    if pltriton is None or _FORCE_INTERPRET:  # pragma: no cover
+        return None
+    return pltriton.CompilerParams(num_warps=block_sizes.num_warps, num_stages=block_sizes.num_stages)
+
+
+def _cost_estimate(body, primals, kernel_inputs_specs, kernel_outputs_specs):
+    return with_io_bytes_accessed(
+        pl.estimate_cost(body, *primals),
+        kernel_inputs_specs=kernel_inputs_specs,
+        kernel_outputs_specs=kernel_outputs_specs,
+    )
+
+
+def short_conv_pallas_fwd_local(
+    weight: Float[Array, "W C"],
+    x: Float[Array, "B S C"],
+    segment_ids: Int[Array, "B S"],
+    *,
+    block_sizes: ShortConvBlockSizes,
+    exact_reference_rounding: bool,
+) -> Float[Array, "B S C"]:
+    """Shard-local fused forward. Callers must have already entered a ``shard_map``."""
+    batch, seq_len, channels = x.shape
+    width = weight.shape[0]
+    bs, bc = block_sizes.s_block_size, block_sizes.c_block_size
+    num_s, num_c = seq_len // bs, channels // bc
+    x_head, seg_head = _head_views(x, segment_ids, bs, width)
+
+    whole = lambda b, si, ci: (b, 0, ci)  # noqa: E731 - whole-sequence pointer window
+    whole_1d = lambda b, si, ci: (b, 0)  # noqa: E731
+    out_shape = jax.ShapeDtypeStruct((batch, seq_len, channels), x.dtype)
+
+    call = pl.pallas_call(
+        functools.partial(_fwd_kernel, kernel_size=width, exact=exact_reference_rounding),
+        out_shape=out_shape,
+        grid=(batch, num_s, num_c),
+        in_specs=[
+            pl.BlockSpec((1, seq_len, bc), whole),
+            pl.BlockSpec((1, bs + width - 1, bc), whole),
+            pl.BlockSpec((1, seq_len), whole_1d),
+            pl.BlockSpec((1, bs + width - 1), whole_1d),
+            pl.BlockSpec((width, bc), lambda b, si, ci: (0, ci)),
+        ],
+        out_specs=pl.BlockSpec((1, bs, bc), lambda b, si, ci: (b, si, ci)),
+        compiler_params=_compiler_params(block_sizes),
+        interpret=_FORCE_INTERPRET,
+        cost_estimate=_cost_estimate(
+            short_conv_reference,
+            (weight, x, segment_ids),
+            # The head view is under 4% of `x` and every window aliases the same buffers, so
+            # modelling traffic as one read of x plus one write of the output is honest.
+            kernel_inputs_specs=(weight, x, segment_ids),
+            kernel_outputs_specs=(out_shape,),
+        ),
+        name="short_conv_fwd",
+    )
+    return call(x, x_head, segment_ids, seg_head, weight)
+
+
+def short_conv_pallas_bwd_local(
+    weight: Float[Array, "W C"],
+    x: Float[Array, "B S C"],
+    segment_ids: Int[Array, "B S"],
+    dy: Float[Array, "B S C"],
+    *,
+    block_sizes: ShortConvBlockSizes,
+    exact_reference_rounding: bool,
+) -> tuple[Float[Array, "B S C"], Float[Array, "P W C"]]:
+    """Shard-local fused backward. Returns ``(dx, dw_partials)``.
+
+    ``dw_partials`` is ``[batch * num_s_blocks, W, C]`` fp32; the caller sums axis 0.
+    Keeping that reduction outside the kernel is what makes ``dw`` deterministic, and
+    because the leading axis stays batch-major it lets XLA fold the cross-shard reduction
+    into the gradient collective it was going to issue anyway.
+    """
+    batch, seq_len, channels = x.shape
+    width = weight.shape[0]
+    bs, bc = block_sizes.s_block_size, block_sizes.c_block_size
+    num_s, num_c = seq_len // bs, channels // bc
+    x_head, seg_head = _head_views(x, segment_ids, bs, width)
+    dy_tail, seg_tail = _tail_views(dy, segment_ids, bs, width)
+
+    whole = lambda b, si, ci: (b, 0, ci)  # noqa: E731
+    whole_1d = lambda b, si, ci: (b, 0)  # noqa: E731
+    dx_shape = jax.ShapeDtypeStruct((batch, seq_len, channels), dy.dtype)
+    dw_shape = jax.ShapeDtypeStruct((batch * num_s, width, channels), jnp.float32)
+
+    def _vjp_body(w, x_, seg):
+        _, vjp = jax.vjp(lambda a, b: short_conv_reference(a, b, seg), w, x_)
+        return vjp(x_)
+
+    call = pl.pallas_call(
+        functools.partial(_bwd_kernel, kernel_size=width, exact=exact_reference_rounding),
+        out_shape=[dx_shape, dw_shape],
+        grid=(batch, num_s, num_c),
+        in_specs=[
+            pl.BlockSpec((1, seq_len, bc), whole),
+            pl.BlockSpec((1, bs + width - 1, bc), whole),
+            pl.BlockSpec((1, seq_len), whole_1d),
+            pl.BlockSpec((1, bs + width - 1), whole_1d),
+            pl.BlockSpec((1, seq_len, bc), whole),
+            pl.BlockSpec((1, bs + width - 1, bc), whole),
+            pl.BlockSpec((1, bs + width - 1), whole_1d),
+            pl.BlockSpec((width, bc), lambda b, si, ci: (0, ci)),
+        ],
+        out_specs=[
+            pl.BlockSpec((1, bs, bc), lambda b, si, ci: (b, si, ci)),
+            pl.BlockSpec((1, width, bc), lambda b, si, ci: (b * num_s + si, 0, ci)),
+        ],
+        compiler_params=_compiler_params(block_sizes),
+        interpret=_FORCE_INTERPRET,
+        cost_estimate=_cost_estimate(
+            _vjp_body,
+            (weight, x, segment_ids),
+            kernel_inputs_specs=(weight, x, segment_ids, dy),
+            kernel_outputs_specs=(dx_shape, dw_shape),
+        ),
+        name="short_conv_bwd",
+    )
+    dx, dw_partials = call(x, x_head, segment_ids, seg_head, dy, dy_tail, seg_tail, weight)
+    return dx, dw_partials
+
+
+def expected_bytes_moved(x_shape: tuple[int, ...], itemsize: int, width: int, block_sizes) -> dict[str, float]:
+    """Traffic model for the fused kernels, in bytes. Feeds the benchmark's GB/s column.
+
+    Forward: read ``x``, write ``y``, plus the head view (built and read once).
+    Backward: read ``x``, read ``dy``, write ``dx``, plus head and tail views, plus the
+    ``dw`` partials written by the kernel and read by the outer ``sum(0)``.
+    """
+    elements = math.prod(x_shape)
+    tensor = elements * itemsize
+    seq_len = x_shape[1]
+    bs = block_sizes.s_block_size
+    edge = 2.0 * (bs + width - 1) / seq_len  # build (read+write) one BS-row edge view
+    dw_partial = 2.0 * elements * width * 4 / (bs * itemsize) / tensor
+    return {
+        "forward": tensor * (2.0 + edge),
+        "backward": tensor * (3.0 + 2.0 * edge + dw_partial),
+    }

--- a/lib/levanter/src/levanter/kernels/pallas/short_conv/reference.py
+++ b/lib/levanter/src/levanter/kernels/pallas/short_conv/reference.py
@@ -1,0 +1,39 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Readable vanilla-JAX oracle for the depthwise causal short convolution (SConv).
+
+This is a verbatim copy of the pad-and-shift body that ``experiments/grug/*/model.py``
+``ShortConv.__call__`` has always used. It is the correctness oracle *and* the
+performance baseline: every other implementation must reproduce it bit for bit on the
+forward pass, and every benchmark reports against its timings.
+
+Do not "clean this up". Its exact op sequence -- ``pad`` then ``slice``, a ``where``
+against the shifted ``segment_ids``, a bf16-rounded multiply, a bf16-rounded add, in
+lag order -- fixes the rounding that the fused kernel is required to match.
+"""
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float, Int
+
+
+def short_conv_reference(
+    weight: Float[Array, "W C"],
+    x: Float[Array, "B S C"],
+    segment_ids: Int[Array, "B S"] | None = None,
+) -> Float[Array, "B S C"]:
+    """``out[b,t,c] = sum_lag weight[lag,c] * x[b,t-lag,c]``, zeroed across segments.
+
+    A tap that reaches into a previous document is dropped (the shifted ``segment_ids``
+    no longer match); the lag-0 (current token) tap is always kept. Positions before the
+    start of the sequence read as zero.
+    """
+    seq_len = x.shape[1]
+    out = weight[0] * x
+    for lag in range(1, weight.shape[0]):
+        shifted = jnp.pad(x, ((0, 0), (lag, 0), (0, 0)))[:, :seq_len, :]
+        if segment_ids is not None:
+            seg_shifted = jnp.pad(segment_ids, ((0, 0), (lag, 0)), constant_values=-1)[:, :seq_len]
+            shifted = jnp.where((seg_shifted == segment_ids)[..., None], shifted, 0.0)
+        out = out + weight[lag] * shifted
+    return out

--- a/lib/levanter/tests/kernels/test_short_conv.py
+++ b/lib/levanter/tests/kernels/test_short_conv.py
@@ -15,6 +15,13 @@ reference, because a fused conv changes only *when* bytes cross HBM, never the
 arithmetic. `dw` is a reduction over 65,536 tokens whose association order XLA does not
 define, so it is checked against a float64 oracle instead -- the kernel must be at least
 as accurate as the reference, not identical to it.
+
+The whole module is scoped to the backends this Triton kernel targets. `dx` is bitwise
+only because `_dx_body` accumulates in the order XLA's transpose of the pad-and-shift
+forward emits, and that order is a property of the backend's transpose, not of the
+algorithm: on TPU the multi-tap shapes disagree in the last bit or two while `W=1`, which
+has no accumulation to associate, still matches exactly. Running the interpreter on TPU
+therefore measures XLA:TPU rather than the kernel that ships.
 """
 
 import jax
@@ -28,6 +35,11 @@ from levanter.kernels.pallas.short_conv import (
     short_conv_reference,
 )
 from levanter.kernels.pallas.short_conv.pallas_gpu import interpret_mode
+
+pytestmark = pytest.mark.skipif(
+    jax.default_backend() == "tpu",
+    reason="Triton kernel: dx parity is defined against XLA's CPU/GPU transpose of the reference",
+)
 
 # (batch, seq_len, channels, kernel_size, s_block, c_block)
 SHAPES = [

--- a/lib/levanter/tests/kernels/test_short_conv.py
+++ b/lib/levanter/tests/kernels/test_short_conv.py
@@ -1,0 +1,315 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Correctness gate for the fused depthwise causal short convolution (SConv).
+
+The Pallas kernel targets a GPU and cannot execute on CPU as compiled code, but Pallas's
+reference interpreter executes the *kernel body* -- grid, block specs, the neighbouring
+sequence-block views that supply the halo, the edge masking, the register accumulation --
+with plain XLA ops. Everything here therefore exercises the real algorithm on CPU. What
+it does not and cannot cover is whether the kernel *lowers* on a given GPU architecture;
+`test_pallas_short_conv_matches_reference_on_gpu` covers that when a GPU is present.
+
+The bar is bitwise: the forward and `dx` must be bit-identical to the pad-and-shift
+reference, because a fused conv changes only *when* bytes cross HBM, never the
+arithmetic. `dw` is a reduction over 65,536 tokens whose association order XLA does not
+define, so it is checked against a float64 oracle instead -- the kernel must be at least
+as accurate as the reference, not identical to it.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from levanter.kernels.pallas.short_conv import (
+    ShortConvBlockSizes,
+    short_conv,
+    short_conv_reference,
+)
+from levanter.kernels.pallas.short_conv.pallas_gpu import interpret_mode
+
+# (batch, seq_len, channels, kernel_size, s_block, c_block)
+SHAPES = [
+    (1, 32, 8, 4, 8, 8),
+    (2, 32, 8, 4, 8, 4),
+    (3, 64, 16, 4, 16, 8),
+    (2, 64, 32, 4, 32, 16),
+    (2, 48, 8, 3, 16, 8),
+    (1, 64, 8, 2, 32, 8),
+    (1, 64, 8, 1, 32, 8),
+    (2, 128, 16, 4, 128, 16),  # a single sequence block: no neighbour view is in range
+]
+
+
+def _packed_segment_ids(rng, batch, seq_len, min_run=1, max_run=None):
+    """Contiguous document runs, deliberately including runs shorter than the kernel."""
+    max_run = max_run or max(min_run + 1, seq_len // 4)
+    out = np.zeros((batch, seq_len), np.int32)
+    for b in range(batch):
+        pos, sid = 0, 0
+        while pos < seq_len:
+            run = int(rng.integers(min_run, max_run + 1))
+            out[b, pos : pos + run] = sid
+            pos += run
+            sid += 1
+    return jnp.asarray(out)
+
+
+def _segment_start_mask(segment_ids, width):
+    """[B, S] mask over the first `width - 1` positions of every segment."""
+    seg = np.asarray(jax.device_get(segment_ids))
+    starts = np.ones_like(seg, dtype=bool)
+    starts[:, 1:] = seg[:, 1:] != seg[:, :-1]
+    mask = np.zeros_like(starts)
+    for offset in range(max(width - 1, 1)):
+        shifted = starts if offset == 0 else np.pad(starts[:, :-offset], ((0, 0), (offset, 0)))
+        mask |= shifted.astype(bool)
+    return mask
+
+
+def _bits(array):
+    array = np.asarray(jax.device_get(array))
+    return array.view({2: np.uint16, 4: np.uint32, 8: np.uint64}[array.dtype.itemsize])
+
+
+def _run_both(weight, x, segment_ids, cotangent, blocks):
+    def kernel_fn(w, xx):
+        return short_conv(w, xx, segment_ids, implementation="pallas_gpu", block_sizes=blocks)
+
+    def reference_fn(w, xx):
+        return short_conv_reference(w, xx, segment_ids)
+
+    with interpret_mode():
+        got = jax.jit(kernel_fn)(weight, x)
+        _, kernel_vjp = jax.vjp(kernel_fn, weight, x)
+        got_dw, got_dx = jax.jit(kernel_vjp)(cotangent)
+
+    want = jax.jit(reference_fn)(weight, x)
+    _, reference_vjp = jax.vjp(reference_fn, weight, x)
+    want_dw, want_dx = jax.jit(reference_vjp)(cotangent)
+    return (got, got_dx, got_dw), (want, want_dx, want_dw)
+
+
+def _inputs(batch, seq_len, channels, width, seed, dtype, packed):
+    rng = np.random.default_rng(seed)
+    x = jnp.asarray(rng.standard_normal((batch, seq_len, channels)), dtype)
+    weight = jnp.asarray(rng.standard_normal((width, channels)) * 0.5, dtype)
+    cotangent = jnp.asarray(rng.standard_normal((batch, seq_len, channels)), dtype)
+    segment_ids = _packed_segment_ids(rng, batch, seq_len) if packed else None
+    return weight, x, segment_ids, cotangent
+
+
+@pytest.mark.parametrize("shape", SHAPES, ids=lambda s: "x".join(str(v) for v in s))
+@pytest.mark.parametrize("packed", [True, False], ids=["packed", "unpacked"])
+def test_forward_and_dx_are_bitwise_identical_to_reference(shape, packed):
+    batch, seq_len, channels, width, s_block, c_block = shape
+    weight, x, segment_ids, cotangent = _inputs(
+        batch, seq_len, channels, width, seed=hash(shape) % 2**16, dtype=jnp.bfloat16, packed=packed
+    )
+    blocks = ShortConvBlockSizes(s_block_size=s_block, c_block_size=c_block)
+    (got, got_dx, _), (want, want_dx, _) = _run_both(weight, x, segment_ids, cotangent, blocks)
+
+    np.testing.assert_array_equal(_bits(got), _bits(want), err_msg="forward is not bit-identical")
+    np.testing.assert_array_equal(_bits(got_dx), _bits(want_dx), err_msg="dx is not bit-identical")
+
+
+@pytest.mark.parametrize("shape", SHAPES[:5], ids=lambda s: "x".join(str(v) for v in s))
+def test_segment_boundaries_and_segment_starts_match_exactly(shape):
+    """The first `kernel_size - 1` positions of every document are where taps get dropped.
+
+    Those positions are checked on their own so a regression there cannot hide inside a
+    whole-tensor max.
+    """
+    batch, seq_len, channels, width, s_block, c_block = shape
+    weight, x, segment_ids, cotangent = _inputs(
+        batch, seq_len, channels, width, seed=99, dtype=jnp.bfloat16, packed=True
+    )
+    blocks = ShortConvBlockSizes(s_block_size=s_block, c_block_size=c_block)
+    (got, got_dx, _), (want, want_dx, _) = _run_both(weight, x, segment_ids, cotangent, blocks)
+
+    mask = _segment_start_mask(segment_ids, width)
+    assert mask.any(), "test fixture produced no segment starts"
+    np.testing.assert_array_equal(_bits(got)[mask], _bits(want)[mask])
+    np.testing.assert_array_equal(_bits(got_dx)[mask], _bits(want_dx)[mask])
+
+    # And the taps really are being dropped: with a non-degenerate weight, masking must
+    # make the output differ from an unmasked convolution somewhere on the boundary.
+    unmasked = short_conv_reference(weight, x, None)
+    assert not np.array_equal(_bits(unmasked)[mask], _bits(want)[mask])
+
+
+@pytest.mark.parametrize("shape", SHAPES[:4], ids=lambda s: "x".join(str(v) for v in s))
+def test_dw_is_at_least_as_accurate_as_the_reference(shape):
+    """`dw` reduces 65,536 tokens in fp32; association order is not part of the contract.
+
+    Both implementations are compared against a float64 oracle. The kernel is required to
+    be no worse than the reference, which is the meaningful guarantee.
+    """
+    batch, seq_len, channels, width, s_block, c_block = shape
+    weight, x, segment_ids, cotangent = _inputs(
+        batch, seq_len, channels, width, seed=5, dtype=jnp.bfloat16, packed=True
+    )
+    blocks = ShortConvBlockSizes(s_block_size=s_block, c_block_size=c_block)
+    (_, _, got_dw), (_, _, want_dw) = _run_both(weight, x, segment_ids, cotangent, blocks)
+
+    # float64 oracle for dw, computed directly from the definition.
+    x64 = np.asarray(jax.device_get(x), np.float64)
+    ct64 = np.asarray(jax.device_get(cotangent), np.float64)
+    seg = np.asarray(jax.device_get(segment_ids))
+    oracle = np.zeros((width, channels), np.float64)
+    for lag in range(width):
+        shifted = np.zeros_like(x64)
+        if lag == 0:
+            shifted = x64
+            keep = np.ones(seg.shape, bool)
+        else:
+            shifted[:, lag:, :] = x64[:, :-lag, :]
+            seg_shifted = np.full(seg.shape, -1, seg.dtype)
+            seg_shifted[:, lag:] = seg[:, :-lag]
+            keep = seg_shifted == seg
+        oracle[lag] = np.sum(ct64 * shifted * keep[..., None], axis=(0, 1))
+
+    got_err = np.max(np.abs(np.asarray(jax.device_get(got_dw), np.float64) - oracle))
+    want_err = np.max(np.abs(np.asarray(jax.device_get(want_dw), np.float64) - oracle))
+    scale = max(np.max(np.abs(oracle)), 1e-30)
+    assert got_err <= max(want_err * 1.5, 0.02 * scale), (
+        f"kernel dw error {got_err:.3e} materially worse than reference {want_err:.3e} " f"(oracle scale {scale:.3e})"
+    )
+
+
+def test_float32_gradients_match_to_float32_tolerance():
+    """fp32 inputs: the pad/shift chain and the kernel differ only by fp32 reassociation."""
+    weight, x, segment_ids, cotangent = _inputs(2, 64, 16, 4, seed=17, dtype=jnp.float32, packed=True)
+    blocks = ShortConvBlockSizes(s_block_size=16, c_block_size=8)
+    (got, got_dx, got_dw), (want, want_dx, want_dw) = _run_both(weight, x, segment_ids, cotangent, blocks)
+    for name, a, b in (("y", got, want), ("dx", got_dx, want_dx), ("dw", got_dw, want_dw)):
+        np.testing.assert_allclose(
+            jax.device_get(a), jax.device_get(b), rtol=1e-5, atol=1e-5, err_msg=f"{name} mismatch"
+        )
+
+
+def test_explicit_implementation_fails_fast_when_unsupported():
+    """An explicitly requested backend must raise, never silently fall back (api-patterns)."""
+    weight, x, segment_ids, _ = _inputs(2, 32, 8, 4, seed=1, dtype=jnp.bfloat16, packed=True)
+    bad_blocks = ShortConvBlockSizes(s_block_size=7, c_block_size=8)  # 32 % 7 != 0
+    with interpret_mode():
+        with pytest.raises(RuntimeError, match="not divisible"):
+            short_conv(weight, x, segment_ids, implementation="pallas_gpu", block_sizes=bad_blocks)
+
+
+def test_ordered_implementation_sequence_falls_back_with_a_warning():
+    weight, x, segment_ids, _ = _inputs(2, 32, 8, 4, seed=1, dtype=jnp.bfloat16, packed=True)
+    bad_blocks = ShortConvBlockSizes(s_block_size=7, c_block_size=8)
+    with interpret_mode():
+        with pytest.warns(UserWarning, match="falling back"):
+            got = short_conv(
+                weight, x, segment_ids, implementation=("pallas_gpu", "reference"), block_sizes=bad_blocks
+            )
+    np.testing.assert_array_equal(_bits(got), _bits(short_conv_reference(weight, x, segment_ids)))
+
+
+def test_default_implementation_on_cpu_is_the_reference():
+    if jax.default_backend() == "gpu":
+        pytest.skip("this asserts the non-GPU default")
+    weight, x, segment_ids, _ = _inputs(2, 32, 8, 4, seed=2, dtype=jnp.bfloat16, packed=True)
+    got = short_conv(weight, x, segment_ids)
+    np.testing.assert_array_equal(_bits(got), _bits(short_conv_reference(weight, x, segment_ids)))
+
+
+def test_kernel_call_is_wrapped_in_a_shard_map_under_a_mesh():
+    """House rule: every Pallas call sits inside an explicit shard_map on a real mesh.
+
+    Checked on the lowered jaxpr rather than by inspection, so a refactor that drops the
+    manual region fails here. The mesh is abstract and nothing is executed, so a
+    single-device CPU runner is enough.
+    """
+    mesh = jax.sharding.AbstractMesh(
+        axis_sizes=(1, 2, 1, 1),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(jax.sharding.AxisType.Explicit,) * 4,
+    )
+    weight, x, segment_ids, _ = _inputs(2, 32, 8, 4, seed=3, dtype=jnp.bfloat16, packed=True)
+    blocks = ShortConvBlockSizes(s_block_size=8, c_block_size=8)
+
+    def fn(w, xx, seg):
+        return short_conv(w, xx, seg, implementation="pallas_gpu", block_sizes=blocks)
+
+    with interpret_mode(), jax.sharding.use_abstract_mesh(mesh):
+        jaxpr = jax.make_jaxpr(fn)(weight, x, segment_ids)
+    text = str(jaxpr)
+    assert "shard_map" in text, "kernel is not inside an explicit shard_map"
+    # ...and the manual region must not contain a collective: the op is shard-local.
+    for banned in ("all_gather", "all_reduce", "psum", "all_to_all", "reduce_scatter"):
+        assert banned not in text, f"short_conv lowered through an unexpected {banned}"
+
+
+def test_pallas_short_conv_matches_reference_on_gpu():
+    """The compiled kernel, not the interpreter. Only meaningful with a GPU present."""
+    if jax.default_backend() != "gpu":
+        pytest.skip("requires the JAX GPU backend")
+    weight, x, segment_ids, cotangent = _inputs(2, 512, 256, 4, seed=21, dtype=jnp.bfloat16, packed=True)
+    blocks = ShortConvBlockSizes(s_block_size=128, c_block_size=128)
+
+    def kernel_fn(w, xx):
+        return short_conv(w, xx, segment_ids, implementation="pallas_gpu", block_sizes=blocks)
+
+    def reference_fn(w, xx):
+        return short_conv_reference(w, xx, segment_ids)
+
+    got = jax.jit(kernel_fn)(weight, x)
+    _, kernel_vjp = jax.vjp(kernel_fn, weight, x)
+    got_dw, got_dx = jax.jit(kernel_vjp)(cotangent)
+
+    want = jax.jit(reference_fn)(weight, x)
+    _, reference_vjp = jax.vjp(reference_fn, weight, x)
+    want_dw, want_dx = jax.jit(reference_vjp)(cotangent)
+
+    np.testing.assert_array_equal(_bits(got), _bits(want))
+    np.testing.assert_array_equal(_bits(got_dx), _bits(want_dx))
+    np.testing.assert_allclose(
+        jax.device_get(got_dw).astype(np.float32),
+        jax.device_get(want_dw).astype(np.float32),
+        rtol=5e-2,
+        atol=5e-2,
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_size", "should_reject"),
+    [(1, False), (2, True)],
+    ids=["size-1 model axis is a no-op", "size-2 model axis really shards"],
+)
+def test_channel_axis_gate_consults_the_mesh_not_just_the_spec(model_size, should_reject):
+    """A spec entry naming a size-1 mesh axis shards nothing, and must not be rejected.
+
+    This is not hypothetical. The EP64 hero mesh is (replica_dcn=1, data=1, expert=64, model=1)
+    and the attention projections are `P(_FSDP_AXES, "model")`, so every k/v activation reaching
+    SConv carries "model" on its channel axis while being, in fact, unsharded there. Gating on
+    the name alone rejects the production shape -- and the reshard the gate guards is a no-op in
+    exactly that case, so there is nothing to guard.
+
+    The size-2 leg keeps the gate honest: a genuinely sharded channel axis must still raise,
+    because silently resharding it would hide a real all-gather inside the kernel wrapper.
+    """
+    mesh = jax.sharding.AbstractMesh(
+        axis_sizes=(1, 2 // model_size, 2, model_size),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(jax.sharding.AxisType.Explicit,) * 4,
+    )
+    weight, x, segment_ids, _ = _inputs(4, 32, 8, 4, seed=11, dtype=jnp.bfloat16, packed=True)
+    blocks = ShortConvBlockSizes(s_block_size=8, c_block_size=8)
+
+    def fn(w, xx, seg):
+        # Reproduce the hero's k_flat sharding: batch over the FSDP pair, channel named "model".
+        xx = jax.sharding.reshard(xx, jax.sharding.PartitionSpec(("data", "expert"), None, "model"))
+        seg = jax.sharding.reshard(seg, jax.sharding.PartitionSpec(("data", "expert"), None))
+        return short_conv(w, xx, seg, implementation="pallas_gpu", block_sizes=blocks)
+
+    with interpret_mode(), jax.sharding.use_abstract_mesh(mesh):
+        if should_reject:
+            with pytest.raises(ValueError, match="unsharded channel axis"):
+                jax.make_jaxpr(fn)(weight, x, segment_ids)
+        else:
+            jaxpr = jax.make_jaxpr(fn)(weight, x, segment_ids)
+            assert "shard_map" in str(jaxpr)


### PR DESCRIPTION
🤖 Third of four, on top of #8368. **Stacked directly on #8359**, which removes the value-branch SConv — see the caveat below.

## What it costs today

`ShortConv` is pad-and-shift: per lag a `jnp.pad(...)[:, :seq_len, :]` materializing a shifted copy, a `jnp.where` against shifted segment_ids, a multiply and an add.

Measured on one GB200 at the hero per-layer shapes: **420.5 ± 8.8 ms/step, of which 75.1% is backward** (not the 94% that had been assumed). With `remat_mode="recompute_all"` the training-equivalent cost is ~525 ms/step.

## Why passes are the only lever

Arithmetic intensity is **8 FLOP / 4 bytes = 2.0**, against a ~312 FLOP/byte ridge on GB200 — **bandwidth-bound by 156x**. No amount of tiling or tensor-core work can matter; the only thing that moves is how often the tensor crosses HBM. That is also why bitwise parity is achievable: the arithmetic never changes, only when bytes move.

Against a read-one-write-one stream on the same tensor, the reference moves **~3.8x the minimum** (forward 4.6 passes against a floor of 2.0; backward 14.4 against 3.0).

## The diagnosis in the original brief was a CPU artifact — worth recording

The pathology the pad-and-shift construction implies is **real on CPU**: four materialized fp32 `[B,S,C]` products, four separate `reduce-window` ops, **4.84 GB of scratch** per site.

**None of it happens on GPU.** Compiled GPU HLO at hero shape: forward is **1 fusion, 0.000 GB temp**; the VJP is 5 fusions, **0.013 GB temp, zero reduce-window ops**. XLA:GPU fuses the weight-gradient reductions into their producers. The real mechanism is repeated traversal — each tap is a separate offset read the cache does not absorb, and the VJP launches five fusions that each re-read their inputs.

This is why the ceiling was narrowed from a hoped-for ~500 ms to the measured figure below: the waste factor is 3.8x, not the ~13x inferred from cost.

## Measured

**228.7 ± 5.8 ms/step** vs 420.5 reference — **1.40x forward, 2.05x backward, 1.84x total.** Saving ~192 ms/step isolated, ~222 ms training-equivalent.

### Caveat on that number — please read before quoting it

It was measured with `sconv_sites = ("k", "v", "attn", "mlp")`: **15,360 channels per token per layer**. With #8359 underneath this PR the hero runs three sites and **13,824 channels**, so the saving scales down by about a tenth. **It has not been re-measured at three sites.**

## Correctness

Forward and `dx` are **bitwise identical** to the reference at hero shape across all four sites and three runs, and on CPU across 8 shapes x packed/unpacked x W=1..4 including single-block cases, with segment starts (the first W−1 positions of every document) checked as a separate mask. `dw` matches an fp64 oracle to fp32 reassociation, whose order XLA does not define. `dw` accumulates in fp32 registers into a per-block partial reduced outside the kernel — no atomics, deterministic.

`lib/levanter/tests/kernels/test_short_conv.py` runs those checks in CI. Pallas's interpreter executes the real kernel body — grid, block specs, head/tail routing, register accumulation — so the parity and gradient cases need no GPU. The compiled-kernel case skips without a GPU backend.

## Two things that are costs, not wins

- **Peak HBM is ~0.1–0.7 GiB *higher*** (dw partials, head/tail views). There is no fp32 scratch to free on GPU, so the activation-memory benefit this was expected to carry **does not exist**. Against 1.39 GiB of headroom at the remat cliff that is a small cost, but it is a cost.
- The residual ~98 ms to the streaming-bandwidth floor needs a register/SMEM carry that **Pallas-Triton cannot express** (no `lax.slice` lowering for register tiles, power-of-2 tile shapes only). `Dao-AILab/causal-conv1d` is the right reference design if anyone picks that up.

## A bug this PR fixes that only the real hero mesh could surface

The first EP64 run of this stack crashed at step 1:

```
short_conv requires an unsharded channel axis for x; got P(('data','expert'), None, 'model')
```

The attention projections are `P(_FSDP_AXES, "model")`, so `k_flat` carries `"model"` on its channel axis — but **`model` is size 1 on the hero mesh**, so it names an axis without sharding anything. The gate rejected the *name* without consulting the mesh, and the very next line reshards to `P(active, None, None)`, which at size 1 is a no-op. It was rejecting an input it would have normalized for free.

The gate now checks mesh sizes: skip entries whose named axes are all size 1, still reject anything genuinely sharded (so a real all-gather is never hidden behind a silent reshard). **No CPU or 4-GPU test can reach this** — it needs a size-1 `model` axis beside a wide `expert` axis, which is the hero and nothing else.

## Also fixed

`ShortConv.init` resharded to `P(None, "data")`, and `data` is size 1 on the EP64 hero, so the weight was replicated and the stated reduce-scatter intent never held. Now `_FSDP_AXES`, matching every other parameter in the file. 48 KB per site — timing value indistinguishable from zero, taken because the comment described behaviour that was not happening.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


