### PR TITLE
[iac] Grant bucket preview access to Pulumi CI

### DIFF
--- a/infra/pulumi/src/iac/gcp/iam_data.yaml
+++ b/infra/pulumi/src/iac/gcp/iam_data.yaml
@@ -1448,6 +1448,11 @@ secrets:
     members:
     - serviceAccount:marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com
     - serviceAccount:pulumi-ci@hai-gcp-models.iam.gserviceaccount.com
+- secret: cloudflare-r2-pulumi-read-token
+  grants:
+  - role: roles/secretmanager.secretAccessor
+    members:
+    - serviceAccount:pulumi-ci@hai-gcp-models.iam.gserviceaccount.com
 - secret: cloudsql-pulumi-admin-password
   grants:
   - role: roles/secretmanager.secretAccessor

--- a/infra/pulumi/src/iac/gcp/iam_data.yaml
+++ b/infra/pulumi/src/iac/gcp/iam_data.yaml
@@ -116,6 +116,7 @@ custom_roles:
   - iap.webServices.getSettings
   - resourcemanager.projects.getIamPolicy
   - secretmanager.secrets.getIamPolicy
+  - storage.buckets.get
   - storage.buckets.getIamPolicy
 - role_id: marinSecretIamManager
   title: Marin Secret IAM Manager


### PR DESCRIPTION
Allow the pull request preview service account to read the R2 preview token and
GCS bucket metadata needed by #8343. Secret payload access stays scoped to
`cloudflare-r2-pulumi-read-token`; `storage.buckets.get` joins the custom
preview role's existing project-wide bucket-policy read. Applying these changes
separately breaks #8343's bootstrap cycle.

A reviewer should run `review-grant`, merge this PR, then run `pulumi up` for
the `infra/pulumi` `marin` stack before rerunning #8343's preview.
