### PR TITLE
[ops] Fix Loom automation capacity and alert routing

### DIFF
--- a/docs/dev-guide/forking-policy.md
+++ b/docs/dev-guide/forking-policy.md
@@ -28,7 +28,9 @@ revision directly. There are three pin kinds:
 `.github/workflows/ops-fork-ferry.yaml` runs every Monday at 08:00 UTC. It has one
 matrix leg per fork unit (`tpu-vllm`, `vllm-gpu`, `evalchemy`, `harbor`). Each leg
 mints a GitHub OIDC token, exchanges it for a short-lived Loom token, and launches
-one Weaver session for that unit. There is no stored PAT.
+one Weaver session for that unit. The `fork-ferry` Loom profile admits all four
+scheduled units; a test keeps its concurrency limit at or above the matrix size.
+There is no stored PAT.
 
 `MarinSkyRL` is pinned and refreshable through the skill on demand, but is not yet
 in the weekly rotation. A human runs the skill for a single fork the same way.

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -266,7 +266,8 @@ redeploy.
 
 Critical rules notify operators immediately: an unreachable cluster or
 federation peer, a crash-looping watched component, an admission webhook with no ready endpoints, a
-dead production Iris controller, or an unhealthy finelog hub or mirror.
+dead production Iris controller, an unhealthy finelog hub or mirror, or CoreWeave
+storage above 80 percent of quota.
 Warning rules remain in Grafana's home alert list without sending email, Slack,
 or Loom notifications: a degraded component, a failed infra probe, a GPU
 pod that stays node-bound and
@@ -283,6 +284,8 @@ stage start or shard completion, then remains pending for five minutes. The
 execution ID separates concurrent pipelines under one root job. The stuck-pod
 rule groups by node and links the cordon-first
 recovery skill; terminal, unbound, and finalizer-held pods stay dashboard-only.
+The CoreWeave storage-telemetry freshness warning carries the explicit
+`notification=slack` exception, so it announces without launching an ops agent.
 Other workload-tier signals (gated pods, Kueue backlog, workload crashloops) are
 dashboard panels rather than alert rules because they have expected benign
 causes. `severity=critical` routes to `ops-critical` (email

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -399,8 +399,7 @@ groups:
         noDataState: OK
         execErrState: Alerting
         labels:
-          severity: warning
-          notification: slack
+          severity: critical
         annotations:
           summary: "{{ $labels.region }}: CoreWeave storage exceeds 80% of quota"
           runbook_url: https://github.com/marin-community/marin/blob/main/scripts/ops/storage/README.md

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -227,14 +227,14 @@ def test_warning_alerts_remain_visible_without_notifications():
     ]
 
 
-def test_coreweave_storage_alert_compares_latest_finelog_usage_to_zone_quota_and_notifies_slack():
+def test_coreweave_storage_capacity_pages_critical_ops():
     (rule,) = [rule for rule in _rules() if rule["uid"] == "coreweave-storage-capacity"]
     source, threshold = rule["data"]
     sql = next(param["value"] for param in source["model"]["url_options"]["params"] if param["key"] == "sql")
 
     assert rule["for"] == "5m"
     assert rule["noDataState"] == "OK"
-    assert rule["labels"] == {"severity": "warning", "notification": "slack"}
+    assert rule["labels"] == {"severity": "critical"}
     assert source["datasourceUid"] == "finelog-marin"
     assert 'FROM "storage.usage"' in sql
     assert "metric IN ('used_bytes', 'quota_bytes')" in sql
@@ -252,11 +252,9 @@ def test_coreweave_storage_alert_compares_latest_finelog_usage_to_zone_quota_and
 
     (policy,) = _load(ALERTING / "policies.yaml")["policies"]
     routes = policy["routes"]
-    route = next(route for route in routes if route["object_matchers"] == [["notification", "=", "slack"]])
-    muted_warning = next(route for route in routes if route["object_matchers"] == [["severity", "=", "warning"]])
-    assert route["receiver"] == "ops-slack"
+    route = next(route for route in routes if route["object_matchers"] == [["severity", "=", "critical"]])
+    assert route["receiver"] == "ops-critical"
     assert "mute_time_intervals" not in route
-    assert routes.index(route) < routes.index(muted_warning)
 
 
 def test_coreweave_storage_alert_notifies_slack_when_a_known_series_is_stale():

--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -74,7 +74,7 @@ config:
       envClear: true
       ambientAllowlist: []
       idleArchiveSeconds: 3600
-      maxConcurrent: 3
+      maxConcurrent: 4
       turnBudget: 100
       prelude: weaver
       instructionsFile: profiles/fork-ferry/AGENTS.md

--- a/infra/loom/tests/test_infrastructure.py
+++ b/infra/loom/tests/test_infrastructure.py
@@ -153,6 +153,15 @@ def test_github_federations_require_unique_names_and_known_profiles() -> None:
         replace(base, github_federations=(duplicate, duplicate))
 
 
+def test_fork_ferry_workflow_stays_within_loom_profile_capacity() -> None:
+    stack = yaml.safe_load((ROOT / "Pulumi.marin-loom.yaml").read_text())
+    workflow = yaml.safe_load((ROOT.parent.parent / ".github/workflows/ops-fork-ferry.yaml").read_text())
+    max_concurrent = stack["config"]["marin-loom:profiles"]["fork-ferry"]["maxConcurrent"]
+    units = workflow["jobs"]["ferry"]["strategy"]["matrix"]["include"]
+
+    assert len(units) <= max_concurrent
+
+
 def test_release_reference_must_be_the_expected_registry_digest() -> None:
     canonical = "us-central1-docker.pkg.dev/example/loom/loom@sha256:" + "a" * 64
     tagged = "us-central1-docker.pkg.dev/example/loom/loom:latest@sha256:" + "a" * 64

--- a/scripts/ops/storage/README.md
+++ b/scripts/ops/storage/README.md
@@ -86,10 +86,11 @@ tunnel. It needs the repository secret `COREWEAVE_API_TOKEN` and fails without
 it, because a green run that collects nothing hides a frozen dashboard.
 
 The Grafana `Storage` dashboard shows bucket bytes and quota use for each zone.
-The `CoreWeaveStorageCapacity` rule sends a Slack warning after quota use stays
-above 80 percent for five minutes. For example, a 900 TiB live quota starts the
-warning above 720 TiB. The rule reads the quota metric, so it also follows a
-later quota change.
+The `CoreWeaveStorageCapacity` rule pages after quota use stays above 80 percent
+for five minutes. The critical notification reaches Slack and opens the Loom ops
+agent on that alert thread. For example, a 900 TiB live quota starts the alert
+above 720 TiB. The rule reads the quota metric, so it also follows a later quota
+change.
 
 The `CoreWeaveStorageTelemetryStale` rule sends a Slack warning when a known
 storage series is more than three hours old. For a stale-data warning, check the


### PR DESCRIPTION
Allow all four fork-ferry matrix units to launch by raising the profile limit from three to four. The 2026-08-17 weekly run admitted three units and left tpu-vllm as an unmatched waiting reservation; a cross-file test requires the matrix size to fit the profile.

Route CoreWeaveStorageCapacity through ops-critical by setting severity=critical and removing the notification=slack override. The critical receiver announces in Slack and creates the Loom ops run, while CoreWeaveStorageTelemetryStale remains Slack-only.