### PR TITLE
Disable scheduled experiment TLDR scrub

### DIFF
--- a/.agents/skills/scrub-experiment-issue-tldrs/SKILL.md
+++ b/.agents/skills/scrub-experiment-issue-tldrs/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: scrub-experiment-issue-tldrs
 description: "Scheduled scrub: TL;DR blocks on experiment issues."
-schedule_cron: "0 8 * * *"
-schedule_tz: America/New_York
 ---
 
 # scrub-experiment-issue-tldrs


### PR DESCRIPTION
Remove the cron metadata from the experiment issue TLDR scrub skill so harness treats it as manual-only and stops scheduling new runs.