### PR TITLE
[iris] Upgrade Kubernetes client to v36.0.3

### DIFF
--- a/lib/iris/pyproject.toml
+++ b/lib/iris/pyproject.toml
@@ -45,7 +45,8 @@ dependencies = [
 
 [project.optional-dependencies]
 controller = [
-    "kubernetes>=31.0.0,<36",
+    # v36.0.0 omits bearer-token auth: https://github.com/kubernetes-client/python/pull/2585
+    "kubernetes>=31.0.0,!=36.0.0,<37",
     # The controller resolves `gcp-secret://` config references (e.g. the auth
     # signing key) at startup via rigging.secrets, which imports the Secret
     # Manager client. Only the controller runs resolve_config_secrets, so this
@@ -72,7 +73,8 @@ test = [
     # Keep the test environment on the workspace runtime pin. The node-local
     # XLA autotune cache requires JAX's cache-key exclusion for its directory.
     "jax==0.11.0",
-    "kubernetes>=31.0.0,<36",
+    # v36.0.0 omits bearer-token auth: https://github.com/kubernetes-client/python/pull/2585
+    "kubernetes>=31.0.0,!=36.0.0,<37",
     "memray>=1.19.3",
     "playwright>=1.49.0",
     "pytest-asyncio",

--- a/uv.lock
+++ b/uv.lock
@@ -3130,9 +3130,10 @@ wheels = [
 
 [[package]]
 name = "kubernetes"
-version = "35.0.0"
+version = "36.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "aiohttp" },
     { name = "certifi" },
     { name = "durationpy" },
     { name = "python-dateutil" },
@@ -3143,9 +3144,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", size = 1094642, upload-time = "2026-01-16T01:05:27.76Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/57/b07b96353f902aa1bdbe00e878e3a12a137977d03a962479785576aa8ec9/kubernetes-36.0.3.tar.gz", hash = "sha256:36993ed25ce59b789c9341473a228fcf268504a2fec7c2b2b1531d73072e5ce7", size = 2337528, upload-time = "2026-07-13T20:38:12.128Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/70/05b685ea2dffcb2adbf3cdcea5d8865b7bc66f67249084cf845012a0ff13/kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d", size = 2017602, upload-time = "2026-01-16T01:05:25.991Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/30/a96d47df739689ac0001ade0afefc16e3b477fc2fb426b568515fdc8afce/kubernetes-36.0.3-py2.py3-none-any.whl", hash = "sha256:8fde9241c4b298e6374a069dcf728359b4e72c2fb29489a975ba4e1c047cf10f", size = 4618066, upload-time = "2026-07-13T20:38:10.172Z" },
 ]
 
 [[package]]
@@ -4123,7 +4124,7 @@ requires-dist = [
     { name = "grpcio", specifier = ">=1.76.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "humanfriendly", specifier = ">=10.0" },
-    { name = "kubernetes", marker = "extra == 'controller'", specifier = ">=31.0.0,<36" },
+    { name = "kubernetes", marker = "extra == 'controller'", specifier = ">=31.0.0,!=36.0.0,<37" },
     { name = "marin-finelog", editable = "lib/finelog" },
     { name = "marin-finelog-server", specifier = ">=0.2.28.dev31271949117" },
     { name = "marin-finestore", editable = "lib/finestore" },
@@ -4150,7 +4151,7 @@ dev = [
     { name = "ipykernel", specifier = ">=7.1.0" },
     { name = "jax", specifier = "==0.11.0" },
     { name = "jupyter", specifier = ">=1.1.1" },
-    { name = "kubernetes", specifier = ">=31.0.0,<36" },
+    { name = "kubernetes", specifier = ">=31.0.0,!=36.0.0,<37" },
     { name = "memray", specifier = ">=1.19.3" },
     { name = "nbconvert", specifier = ">=7.16.6" },
     { name = "nbformat", specifier = ">=5.10.4" },
@@ -4170,7 +4171,7 @@ examples = [
 ]
 test = [
     { name = "jax", specifier = "==0.11.0" },
-    { name = "kubernetes", specifier = ">=31.0.0,<36" },
+    { name = "kubernetes", specifier = ">=31.0.0,!=36.0.0,<37" },
     { name = "memray", specifier = ">=1.19.3" },
     { name = "playwright", specifier = ">=1.49.0" },
     { name = "pytest", specifier = ">=8.4" },


### PR DESCRIPTION
## Summary

Allow Iris controller and test environments to use kubernetes-client v36 while excluding broken v36.0.0. Lock v36.0.3, which contains kubernetes-client/python#2585's bearer-token fix. The v36 lock also adds aiohttp to the existing dependency closure.

## Testing

- A temporary in-cluster config loaded v36.0.3 from the lock and produced its bearer authorization header without network access.
- 50 focused Kubernetes service tests passed.
- 1,502 affected safe tests passed.
- The Dockerfile's exact frozen controller sync installed v36.0.3.
- CoreWeave live smoke passed on this head: the controller image built, deployed, exercised Kubernetes API operations, and completed the integration pipeline.
- Iris unit, lint, integration, CodeQL, docs, Rust, and all ordinary unit shards passed.

Opening the draft triggered the first live CoreWeave smoke before that mutation was intended; the current-head rerun was deliberate.

## Non-green CI

- Levanter TPU reproduced the same pre-existing FP8 gradient assertion as #8360 (1,369 passed, 1 failed); aggregate `unit-tests` reflects it. Tracked in #8403.
- GCP brought up a healthy controller, but both TPU zones reported no capacity. No workers became healthy, so smoke tests did not run. Cleanup passed, deleted the controller VM, and issued deletion requests for the remaining labeled TPUs.
- Iris E2E hit its 10-minute cap while apt fetched Playwright dependencies, before tests. Levanter Torch hit its 15-minute cap after FFmpeg setup consumed most of the budget; tests reached 33% with no reported failure before cancellation. Tracked in #8404.

Fixes #5924
