### PR TITLE
[grug] moe_hero_ep: log peak HBM, live bytes and allocator limit

### DIFF
--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -174,7 +174,7 @@ class GrugModelConfig:
     qk_mult: float = 1.3
     sconv: bool = False
     sconv_kernel: int = 4
-    sconv_sites: tuple[str, ...] = ("k", "v", "attn", "mlp")
+    sconv_sites: tuple[str, ...] = ("k", "attn", "mlp")
     attention_implementation: GrugAttentionImplementation | None = None
     moe_implementation: MoeImplementation | None = None
     expert_chunks: int = 1
@@ -313,7 +313,7 @@ class GrugModelConfig:
             rope_fused=bool(_hf_config_attr(hf_config, ("rope_fused",), False)),
             sconv=bool(_hf_config_attr(hf_config, ("sconv",), False)),
             sconv_kernel=int(_hf_config_attr(hf_config, ("sconv_kernel",), 4)),
-            sconv_sites=tuple(_hf_config_attr(hf_config, ("sconv_sites",), ("k", "v", "attn", "mlp"))),
+            sconv_sites=tuple(_hf_config_attr(hf_config, ("sconv_sites",), ("k", "attn", "mlp"))),
         )
 
     def to_hf_config(self, vocab_size: int, config_overrides: dict[str, Any] | None = None) -> GrugMoeHfConfig:
@@ -450,7 +450,6 @@ class CausalSelfAttention(eqx.Module):
     w_o: Float[Array, "NH D"]
     attn_gate: Float[Array, "D N"]
     sconv_k: "ShortConv | None"  # SConv after the K projection (cfg.sconv)
-    sconv_v: "ShortConv | None"  # SConv after the V projection (cfg.sconv)
     cfg: GrugModelConfig = eqx.field(static=True)
 
     @staticmethod
@@ -464,7 +463,6 @@ class CausalSelfAttention(eqx.Module):
             w_o=reshard(_init_weight(k_o, (n * h, d), cfg.initializer_std), P("model", _FSDP_AXES)),
             attn_gate=reshard(jnp.zeros((d, n)), P(None, None)),
             sconv_k=(ShortConv.init(m * h, cfg.sconv_kernel) if cfg.sconv and "k" in cfg.sconv_sites else None),
-            sconv_v=(ShortConv.init(m * h, cfg.sconv_kernel) if cfg.sconv and "v" in cfg.sconv_sites else None),
             cfg=cfg,
         )
 
@@ -483,14 +481,12 @@ class CausalSelfAttention(eqx.Module):
         q_flat = jnp.einsum("bsh,hd->bsd", x, self.w_q)
         k_flat = jnp.einsum("bsh,hd->bsd", x, self.w_k)
         v_flat = jnp.einsum("bsh,hd->bsd", x, self.w_v)
-        # SConv: depthwise causal conv after the K/V projections. segment_ids (packed-document
+        # SConv: depthwise causal conv after the K projection. segment_ids (packed-document
         # boundaries) come from the mask so the conv never mixes across a document boundary.
         _seg = mask.segment_ids if isinstance(mask, AttentionMask) else None
         sconv_segment_ids = _seg[0] if _seg is not None else None
         if self.sconv_k is not None:
             k_flat = self.sconv_k(k_flat, sconv_segment_ids)
-        if self.sconv_v is not None:
-            v_flat = self.sconv_v(v_flat, sconv_segment_ids)
         q = rearrange(q_flat, "... (n d) -> ... n d", d=head_dim)
         k = rearrange(k_flat, "... (m d) -> ... m d", d=head_dim)
         v = rearrange(v_flat, "... (m d) -> ... m d", d=head_dim)
@@ -1345,7 +1341,6 @@ def grugmoe_inference_state_dict(model: Transformer, prefix: str | None = None) 
         # SConv weights are learned; export them per site so the checkpoint reconstructs an sconv model.
         for site_name, conv in (
             ("self_attn.sconv_k", block.attn.sconv_k),
-            ("self_attn.sconv_v", block.attn.sconv_v),
             ("sconv_attn", block.sconv_attn),
             ("sconv_mlp", block.sconv_mlp),
         ):

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -354,6 +354,30 @@ def _compute_flops(
     return flops_per_example, flops_summary
 
 
+def log_device_memory(step_info) -> None:
+    """Log this process's local-device HBM peak, live bytes, and allocator limit in GiB.
+
+    The EP hero had no peak-HBM telemetry, which makes a whole class of result unreadable: XLA's
+    ``HloRematerialization`` engages only when peak crosses the allocator limit, so a config change
+    that moves peak across that boundary produces an MFU step change that has nothing to do with the
+    change itself. Issue #8054 traced its own +9.08% headline to exactly this -- 3.69 GiB of peak
+    took it under the limit and switched remat off -- and the win fell to +3.31% once one process
+    per GPU put 8.79 GiB back. Any ablation that moves activation memory needs this logged, or its
+    rungs cannot be told apart from allocator-limit crossings.
+
+    Ported from ``experiments/grug/moe_hero_fsdp/train.py``.
+    """
+    stats = jax.local_devices()[0].memory_stats()
+    levanter.tracker.log(
+        {
+            "memory/peak_gib": stats["peak_bytes_in_use"] / 1024**3,
+            "memory/in_use_gib": stats["bytes_in_use"] / 1024**3,
+            "memory/limit_gib": stats["bytes_limit"] / 1024**3,
+        },
+        step=step_info.step,
+    )
+
+
 def _make_mixture_stage_callback(train_dataset: MixtureDataset, batch_schedule: BatchSchedule):
     last_mixture_stage = -1
 
@@ -776,6 +800,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 every=1,
             )
         state_callbacks.add_hook(_make_mixture_stage_callback(train_dataset, batch_schedule), every=1)
+        state_callbacks.add_hook(log_device_memory, every=1)
         if evaluator is not None and eval_cfg is not None:
             interval = eval_cfg.steps_per_eval
             eval_ema = eval_cfg.eval_ema and config.trainer.ema_beta is not None


### PR DESCRIPTION
🤖 Bottom of a four-PR stack sitting on top of #8359. Six lines, ported verbatim from `moe_hero_fsdp/train.py`.

## Why this is in the stack rather than standalone

The EP hero had no peak-HBM telemetry, which makes a whole class of result unreadable. XLA's `HloRematerialization` engages only when peak crosses the allocator limit, so a change that moves peak across that boundary produces an MFU step that has nothing to do with the change itself. #8054 traced its own +9.08% headline to exactly this — 3.69 GiB took it under the limit and switched remat off — and the win fell to +3.31% once one process per GPU put 8.79 GiB back.

The three PRs above this one all move memory. Without this instrument their rack arms cannot be told apart from allocator-limit crossings.

It earned its keep immediately: on the EP64 A/B for this stack, the arms reported 151.760 and 151.791 GiB against a 138.225 GiB limit — both on the *same side*, so remat was engaged identically in both and the comparison is uncontaminated. That is a one-line check that replaces a paragraph of argument.

## Note

This is a cherry-pick of `952f7cc26` from `mark/n4-shape-ladder`, which is not on `main`. **If that branch lands first, drop this PR** — nothing above it depends on the code, only on having had the instrument.


🤖 Generated with [Claude Code](https://claude.com/claude-code)




---

🤖 Recreated from #8367 to retarget onto `main`: the original was the bottom of a native stack based on the already-merged `drop_value_sconv` branch, which GitHub would not let us restack. Same commit, same place in the stack.
