### PR TITLE
[grug] EP64 hero: peak-HBM telemetry, fused CE bf16 backward, fused ShortConv, hoisted router all-reduces

### DIFF
--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -174,7 +174,7 @@ class GrugModelConfig:
     qk_mult: float = 1.3
     sconv: bool = False
     sconv_kernel: int = 4
-    sconv_sites: tuple[str, ...] = ("k", "v", "attn", "mlp")
+    sconv_sites: tuple[str, ...] = ("k", "attn", "mlp")
     attention_implementation: GrugAttentionImplementation | None = None
     moe_implementation: MoeImplementation | None = None
     expert_chunks: int = 1
@@ -313,7 +313,7 @@ class GrugModelConfig:
             rope_fused=bool(_hf_config_attr(hf_config, ("rope_fused",), False)),
             sconv=bool(_hf_config_attr(hf_config, ("sconv",), False)),
             sconv_kernel=int(_hf_config_attr(hf_config, ("sconv_kernel",), 4)),
-            sconv_sites=tuple(_hf_config_attr(hf_config, ("sconv_sites",), ("k", "v", "attn", "mlp"))),
+            sconv_sites=tuple(_hf_config_attr(hf_config, ("sconv_sites",), ("k", "attn", "mlp"))),
         )
 
     def to_hf_config(self, vocab_size: int, config_overrides: dict[str, Any] | None = None) -> GrugMoeHfConfig:
@@ -450,7 +450,6 @@ class CausalSelfAttention(eqx.Module):
     w_o: Float[Array, "NH D"]
     attn_gate: Float[Array, "D N"]
     sconv_k: "ShortConv | None"  # SConv after the K projection (cfg.sconv)
-    sconv_v: "ShortConv | None"  # SConv after the V projection (cfg.sconv)
     cfg: GrugModelConfig = eqx.field(static=True)
 
     @staticmethod
@@ -464,7 +463,6 @@ class CausalSelfAttention(eqx.Module):
             w_o=reshard(_init_weight(k_o, (n * h, d), cfg.initializer_std), P("model", _FSDP_AXES)),
             attn_gate=reshard(jnp.zeros((d, n)), P(None, None)),
             sconv_k=(ShortConv.init(m * h, cfg.sconv_kernel) if cfg.sconv and "k" in cfg.sconv_sites else None),
-            sconv_v=(ShortConv.init(m * h, cfg.sconv_kernel) if cfg.sconv and "v" in cfg.sconv_sites else None),
             cfg=cfg,
         )
 
@@ -483,14 +481,12 @@ class CausalSelfAttention(eqx.Module):
         q_flat = jnp.einsum("bsh,hd->bsd", x, self.w_q)
         k_flat = jnp.einsum("bsh,hd->bsd", x, self.w_k)
         v_flat = jnp.einsum("bsh,hd->bsd", x, self.w_v)
-        # SConv: depthwise causal conv after the K/V projections. segment_ids (packed-document
+        # SConv: depthwise causal conv after the K projection. segment_ids (packed-document
         # boundaries) come from the mask so the conv never mixes across a document boundary.
         _seg = mask.segment_ids if isinstance(mask, AttentionMask) else None
         sconv_segment_ids = _seg[0] if _seg is not None else None
         if self.sconv_k is not None:
             k_flat = self.sconv_k(k_flat, sconv_segment_ids)
-        if self.sconv_v is not None:
-            v_flat = self.sconv_v(v_flat, sconv_segment_ids)
         q = rearrange(q_flat, "... (n d) -> ... n d", d=head_dim)
         k = rearrange(k_flat, "... (m d) -> ... m d", d=head_dim)
         v = rearrange(v_flat, "... (m d) -> ... m d", d=head_dim)
@@ -1345,7 +1341,6 @@ def grugmoe_inference_state_dict(model: Transformer, prefix: str | None = None) 
         # SConv weights are learned; export them per site so the checkpoint reconstructs an sconv model.
         for site_name, conv in (
             ("self_attn.sconv_k", block.attn.sconv_k),
-            ("self_attn.sconv_v", block.attn.sconv_v),
             ("sconv_attn", block.sconv_attn),
             ("sconv_mlp", block.sconv_mlp),
         ):

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -49,6 +49,7 @@ from levanter.grug.grug_moe import (
 )
 from levanter.grug.loss import BlockSizes, fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import unshard
+from levanter.kernels.pallas.short_conv import short_conv
 from levanter.tracker.histogram import Histogram, SummaryStats
 from levanter.utils.activation import ActivationFunctionEnum
 from transformers import PretrainedConfig as HfConfig
@@ -422,8 +423,10 @@ class ShortConv(eqx.Module):
     A kernel of ``W`` taps mixes each channel with its own ``W-1`` causal predecessors,
     ``out[t] = sum_{lag} weight[lag] * x[t-lag]``, independently per channel. Identity-init
     (``weight[0]=1``, later taps 0) makes it a pass-through at step 0. Weights are tiny (``W*C``) and
-    routed to Adam. Implemented as a pad-and-shift weighted sum (XLA fuses it well and it is
-    shard-local -- no cross-channel or cross-shard dependency, so no collectives).
+    routed to Adam. Shard-local -- no cross-channel or cross-shard dependency, so no collectives.
+
+    The body dispatches to ``levanter.kernels.pallas.short_conv``, which selects a fused Pallas
+    kernel on GPU and the pad-and-shift weighted sum everywhere else; see that module's docstring.
     """
 
     weight: Float[Array, "W C"]
@@ -432,24 +435,16 @@ class ShortConv(eqx.Module):
     @staticmethod
     def init(channels: int, kernel_size: int) -> "ShortConv":
         weight = jnp.zeros((kernel_size, channels)).at[0].set(1.0)
-        # FSDP-shard the channel dim over data so the grad reduce-scatters (coalesced) instead of a
-        # standalone replicated all-reduce; the forward gathers the weight back to replicated.
-        return ShortConv(weight=reshard(weight, P(None, "data")), kernel_size=kernel_size)
+        # FSDP-shard the channel dim so the grad reduce-scatters instead of all-reducing; the
+        # forward gathers the weight back to replicated.
+        return ShortConv(weight=reshard(weight, P(None, _FSDP_AXES)), kernel_size=kernel_size)
 
     def __call__(self, x: Float[Array, "B S C"], segment_ids: Int[Array, "B S"] | None = None) -> Float[Array, "B S C"]:
-        # Depthwise causal shift-and-sum. With segment_ids (packed documents), a tap that reaches
-        # into a previous document is zeroed so the conv never mixes across a boundary; the lag-0
-        # (current-token) tap is always kept.
-        seq_len = x.shape[1]
+        # With segment_ids (packed documents), a tap that reaches into a previous document is
+        # zeroed so the conv never mixes across a boundary; the lag-0 (current-token) tap is
+        # always kept.
         weight = reshard(self.weight, P(None, None))
-        out = weight[0] * x
-        for lag in range(1, self.kernel_size):
-            shifted = jnp.pad(x, ((0, 0), (lag, 0), (0, 0)))[:, :seq_len, :]
-            if segment_ids is not None:
-                seg_shifted = jnp.pad(segment_ids, ((0, 0), (lag, 0)), constant_values=-1)[:, :seq_len]
-                shifted = jnp.where((seg_shifted == segment_ids)[..., None], shifted, 0.0)
-            out = out + weight[lag] * shifted
-        return out
+        return short_conv(weight, x, segment_ids, batch_axes=_BATCH_AXES)
 
 
 class CausalSelfAttention(eqx.Module):

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -678,32 +678,96 @@ class DenseMLP(eqx.Module):
         return _batch_reshard(rearrange(out_flat, "(b s) d -> b s d", b=b, s=s))
 
 
-def _routing_stats(
+def _local_routing_stats(
     selected_experts: Int[Array, "T K"],
     router_probs: Float[Array, "T E"],
     router_logits: Float[Array, "T E"],
+    mesh: jax.sharding.AbstractMesh,
+    *,
+    num_experts: int,
+) -> dict[str, jax.Array]:
+    """Per-shard partial sums for the router metrics, with the cross-device reduction left undone.
+
+    Every router metric bottoms out in a *linear* reduction over tokens -- an expert count, a
+    probability sum, a sum of squared logsumexps -- followed by pointwise algebra on the reduced
+    values. Reducing over the batch axes here, inside the layer, costs one ~1.5 KB single-block
+    ``ncclDevKernel_AllReduce_Sum_f32_RING_LL`` per MoE layer (48 per step at hero scale, fully
+    exposed) and buys nothing, because nothing inside the layer reads the reduced value: entropy,
+    the load-balance term and the z-loss are logging-only (``next_token_loss`` sets
+    ``loss = cross_entropy_loss``) and ``qb_beta`` reaches the router bias only on the *next* step,
+    via the trainer's ``pending_qb_betas``.
+
+    So return the unreduced per-shard partials and let ``_reduce_router_stats`` do the collective
+    once, on the stacked ``[num_layers, num_shards, ...]`` scan outputs. The returned arrays carry a
+    leading shard axis that stays sharded over ``_BATCH_AXES``; per device they are the same size as
+    the replicated per-layer metrics they replace.
+    """
+
+    def _local(sel: jax.Array, probs: jax.Array, logits: jax.Array) -> dict[str, jax.Array]:
+        probs_f = probs.astype(jnp.float32)
+        logits_f = logits.astype(jnp.float32)
+        counts = jnp.sum(jax.nn.one_hot(sel, num_experts, dtype=jnp.float32), axis=(0, 1))
+        z = jsp.special.logsumexp(logits_f, axis=-1)
+        return {
+            "routing_counts_local": counts[None, :],
+            "router_prob_sum_local": jnp.sum(probs_f, axis=0)[None, :],
+            "router_z_sq_sum_local": jnp.sum(z**2)[None],
+        }
+
+    return shard_map(
+        _local,
+        mesh=mesh,
+        in_specs=(P(_BATCH_AXES, None), P(_BATCH_AXES, None), P(_BATCH_AXES, None)),
+        out_specs={
+            "routing_counts_local": P(_BATCH_AXES, None),
+            "router_prob_sum_local": P(_BATCH_AXES, None),
+            "router_z_sq_sum_local": P(_BATCH_AXES),
+        },
+    )(selected_experts, router_probs, router_logits)
+
+
+def _reduce_router_stats(
+    stacked: dict[str, jax.Array],
     *,
     num_experts: int,
     num_experts_per_token: int,
+    num_tokens: int,
 ) -> dict[str, jax.Array]:
-    router_probs_f = router_probs.astype(jnp.float32)
-    router_logits_f = router_logits.astype(jnp.float32)
-    expert_counts = jnp.sum(jax.nn.one_hot(selected_experts, num_experts, dtype=jnp.float32), axis=(0, 1))
-    total_assignments = jnp.maximum(jnp.sum(expert_counts), 1.0)
-    assignment_fraction = expert_counts / total_assignments
-    routing_entropy = -jnp.sum(assignment_fraction * jnp.log(assignment_fraction + 1e-6))
-    token_fraction = assignment_fraction * num_experts_per_token
-    p = jnp.mean(router_probs_f, axis=0)
-    load_balancing_loss = num_experts * jnp.sum(token_fraction * p)
-    z = jsp.special.logsumexp(router_logits_f, axis=-1)
-    router_z_loss = jnp.mean(z**2)
+    """Reduce the stacked per-shard router partials across devices once, after the layer scan.
 
-    return {
-        "routing_counts": expert_counts,
+    ``stacked`` holds the scan's ``ys``: a leading ``[num_layers]`` axis over a shard axis that is
+    still sharded over ``_BATCH_AXES``. Summing that shard axis is one all-reduce for the whole
+    stack rather than one per layer; XLA's all-reduce combiner then merges the four into a single
+    tupled collective, so the layer scan emits none at all. The pointwise algebra below is
+    identical to what the old per-layer ``_routing_stats`` did, just vectorized over the layer axis.
+
+    ``num_tokens`` is the global (batch x seq) token count, the denominator the per-layer
+    ``jnp.mean(..., axis=0)`` used to carry.
+    """
+    counts = jnp.sum(stacked["routing_counts_local"], axis=1)
+    prob_sum = jnp.sum(stacked["router_prob_sum_local"], axis=1)
+    z_sq_sum = jnp.sum(stacked["router_z_sq_sum_local"], axis=1)
+
+    total_assignments = jnp.maximum(jnp.sum(counts, axis=-1, keepdims=True), 1.0)
+    assignment_fraction = counts / total_assignments
+    routing_entropy = -jnp.sum(assignment_fraction * jnp.log(assignment_fraction + 1e-6), axis=-1)
+    token_fraction = assignment_fraction * num_experts_per_token
+    p = prob_sum / num_tokens
+    load_balancing_loss = num_experts * jnp.sum(token_fraction * p, axis=-1)
+
+    out = {
+        "routing_counts": counts,
         "routing_entropy": routing_entropy,
         "load_balancing_loss": load_balancing_loss,
-        "router_z_loss": router_z_loss,
+        "router_z_loss": z_sq_sum / num_tokens,
     }
+    # The TOPK estimator defers its `pmean`; the HIST estimator cannot (its bin grid needs a global
+    # pmin/pmax before binning), so it arrives already reduced.
+    if "qb_beta_local" in stacked:
+        out["qb_beta"] = jnp.mean(stacked["qb_beta_local"], axis=1)
+    else:
+        out["qb_beta"] = stacked["qb_beta"]
+    return out
 
 
 def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str, jax.Array | SummaryStats]:
@@ -901,15 +965,16 @@ class MoEMLP(eqx.Module):
         denom = jnp.sum(combine_weights_f, axis=-1, keepdims=True)
         combine_weights_f = combine_weights_f * (_ROUTING_RENORM_SUM / (denom + 1e-9))
         combine_weights = combine_weights_f.astype(x.dtype)
-        router_stats = _routing_stats(
-            selected_experts,
-            router_probs,
-            router_logits,
+        mesh = get_abstract_mesh()
+        # Per-shard partials only; the cross-device reduction happens once after the layer scan.
+        router_stats = _local_routing_stats(
+            reshard(selected_experts, P(_BATCH_AXES, None)),
+            reshard(router_probs, P(_BATCH_AXES, None)),
+            reshard(router_logits, P(_BATCH_AXES, None)),
+            mesh,
             num_experts=self.cfg.num_experts,
-            num_experts_per_token=self.cfg.num_experts_per_token,
         )
         # Sharded QB: estimate each expert's threshold beta from the margins `s - alpha`.
-        mesh = get_abstract_mesh()
         s_minus_alpha = reshard(router_logits - qb_alpha, P(_BATCH_AXES, None))
         if self.cfg.qb_estimator == QbEstimator.HIST:
             router_stats["qb_beta"] = _qb_beta_hist(
@@ -928,14 +993,16 @@ class MoEMLP(eqx.Module):
 
             def _local_qb_beta(s_ma):
                 topk_vals, _ = jax.lax.top_k(s_ma.T, qb_count)
-                beta = topk_vals[:, -1]
-                return jax.lax.pmean(beta, axis_name=_BATCH_AXES)
+                # The `pmean` that used to live here is deferred to `_reduce_router_stats`: the
+                # mean of the per-shard betas is the same number whether it is taken per layer or
+                # once over the stacked layers, and beta is not read until the *next* step.
+                return topk_vals[:, -1][None, :]
 
-            router_stats["qb_beta"] = shard_map(
+            router_stats["qb_beta_local"] = shard_map(
                 _local_qb_beta,
                 mesh=mesh,
                 in_specs=(P(_BATCH_AXES, None),),
-                out_specs=P(),
+                out_specs=P(_BATCH_AXES, None),
             )(s_minus_alpha)
 
         # LatentMoE: compress before dispatch so the expert-parallel all-to-all carries
@@ -1184,12 +1251,20 @@ class Transformer(eqx.Module):
         hidden, stacked_router_stats = jax.lax.scan(
             _scan_layers, hidden, xs=(self.stacked_blocks.stacked, mask_schedule)
         )
+        # One cross-device reduction for the whole stack of layers, instead of one inside every
+        # scan iteration. See `_local_routing_stats`.
+        reduced_router_stats = _reduce_router_stats(
+            stacked_router_stats,
+            num_experts=cfg.num_experts,
+            num_experts_per_token=cfg.num_experts_per_token,
+            num_tokens=batch_size * seq_len,
+        )
         router_metrics = {
-            "routing_entropy_per_layer": stacked_router_stats["routing_entropy"],
-            "routing_counts_per_layer": stacked_router_stats["routing_counts"],
-            "load_balancing_loss_per_layer": stacked_router_stats["load_balancing_loss"],
-            "router_z_loss_per_layer": stacked_router_stats["router_z_loss"],
-            "qb_beta_per_layer": stacked_router_stats["qb_beta"],
+            "routing_entropy_per_layer": reduced_router_stats["routing_entropy"],
+            "routing_counts_per_layer": reduced_router_stats["routing_counts"],
+            "load_balancing_loss_per_layer": reduced_router_stats["load_balancing_loss"],
+            "router_z_loss_per_layer": reduced_router_stats["router_z_loss"],
+            "qb_beta_per_layer": reduced_router_stats["qb_beta"],
             "capacity_overflow_per_layer": stacked_router_stats["capacity_overflow"],
             "sender_capacity_overflow_per_layer": stacked_router_stats["sender_capacity_overflow"],
             "receiver_capacity_overflow_per_layer": stacked_router_stats["receiver_capacity_overflow"],

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -58,7 +58,16 @@ _ROUTING_RENORM_SUM = 2.5
 # Large-vocab CE via the plain-XLA path (no shared-memory tiling, so v_block can be large).
 # v=4096 is the dominant MFU lever for the 128k vocab; the SMEM-tiled batched_xla kernel caps the
 # h*v weight tile at ~99KB and cannot take v=4096.
-_CE_BLOCK_SIZES = BlockSizes(v_block_size=4096)
+#
+# b_block_size is the CE forward's batch tile. The 1024 default splits the per-rank
+# B=65,536 CE shard into 64 batch blocks, and with 32 vocab blocks that is 2,048
+# forward iterations of ~11 kernels each. Measured single-GPU at the hero shape on
+# GB200 (lib/levanter/scripts/bench/bench_ce_hero_shape.py), those kernels average
+# 15.6 us with the compute stream 98.8% busy: they are back-to-back but far too
+# small to fill the SMs. Setting the tile to the whole shard turns the forward into
+# one GEMM per vocab block. Measured: forward 171.3 ms -> 81.9 ms, peak HBM +0.04 GiB.
+_CE_TOKENS_PER_RANK = 65_536
+_CE_BLOCK_SIZES = BlockSizes(b_block_size=_CE_TOKENS_PER_RANK, v_block_size=4096)
 # The embedding is fully replicated for a local lookup. The language-model head
 # is sharded across the data, expert, and model axes.
 _EMBED_PARTITION_SPEC = P(None, None)
@@ -1221,6 +1230,18 @@ class Transformer(eqx.Module):
         labels = jnp.pad(token_ids[:, 1:], ((0, 0), (0, 1))).astype(jnp.int32)
         loss_weight = loss_weight.astype(loss_dtype)
 
+        # NOTE (2026-08-17): gradients from this loss differ from hero runs before
+        # this date, and the difference is intentional. "xla_fast_bwd" keeps the
+        # same forward -- the loss is bitwise identical -- but its backward is the
+        # scan/one-hot/bf16-tensor-core rewrite, whose grad_x and grad_w are ~30%
+        # CLOSER to a float32 reference than the old "xla" backward (rel-RMS
+        # 2.170e-03 -> 1.445e-03 for grad_x, 1.946e-03 -> 1.433e-03 for grad_w,
+        # measured at this exact CE shape on GB200). Widening _CE_BLOCK_SIZES'
+        # b_block_size above moves grad_w too, for the same reason: it removes a
+        # bf16 accumulation across batch blocks. If you are diffing a checkpoint
+        # against an older run, this is why. Set LEVANTER_CE_XLA_FAST_BWD=0 to
+        # force the old backward back on without editing code, or swap this to
+        # implementation="xla" for a code-level A/B.
         cross_entropy_loss = fused_linear_softmax_cross_entropy_loss(
             hidden,
             self.output_proj,
@@ -1229,7 +1250,7 @@ class Transformer(eqx.Module):
             reduction=reduction,
             logsumexp_weight=logsumexp_weight,
             dtype=loss_dtype,
-            implementation="xla",
+            implementation="xla_fast_bwd",
             block_sizes=_CE_BLOCK_SIZES,
         )
         # Router z-loss is logged for monitoring only; it is not added to the training loss.

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -354,6 +354,30 @@ def _compute_flops(
     return flops_per_example, flops_summary
 
 
+def log_device_memory(step_info) -> None:
+    """Log this process's local-device HBM peak, live bytes, and allocator limit in GiB.
+
+    The EP hero had no peak-HBM telemetry, which makes a whole class of result unreadable: XLA's
+    ``HloRematerialization`` engages only when peak crosses the allocator limit, so a config change
+    that moves peak across that boundary produces an MFU step change that has nothing to do with the
+    change itself. Issue #8054 traced its own +9.08% headline to exactly this -- 3.69 GiB of peak
+    took it under the limit and switched remat off -- and the win fell to +3.31% once one process
+    per GPU put 8.79 GiB back. Any ablation that moves activation memory needs this logged, or its
+    rungs cannot be told apart from allocator-limit crossings.
+
+    Ported from ``experiments/grug/moe_hero_fsdp/train.py``.
+    """
+    stats = jax.local_devices()[0].memory_stats()
+    levanter.tracker.log(
+        {
+            "memory/peak_gib": stats["peak_bytes_in_use"] / 1024**3,
+            "memory/in_use_gib": stats["bytes_in_use"] / 1024**3,
+            "memory/limit_gib": stats["bytes_limit"] / 1024**3,
+        },
+        step=step_info.step,
+    )
+
+
 def _make_mixture_stage_callback(train_dataset: MixtureDataset, batch_schedule: BatchSchedule):
     last_mixture_stage = -1
 
@@ -776,6 +800,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 every=1,
             )
         state_callbacks.add_hook(_make_mixture_stage_callback(train_dataset, batch_schedule), every=1)
+        state_callbacks.add_hook(log_device_memory, every=1)
         if evaluator is not None and eval_cfg is not None:
             interval = eval_cfg.steps_per_eval
             eval_ema = eval_cfg.eval_ema and config.trainer.ema_beta is not None

--- a/lib/levanter/scripts/bench/bench_ce_hero_shape.py
+++ b/lib/levanter/scripts/bench/bench_ce_hero_shape.py
@@ -1,0 +1,696 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Single-GPU fused cross-entropy benchmark at the Grug MoE EP64 hero shape.
+
+Per-rank CE shape for ``experiments/grug/moe_hero_ep`` HERO_MODEL is
+``B=65_536`` tokens, ``H=6_144``, ``V=128_256`` with bf16 activations/weights and
+an fp32 logit accumulator.  That is ~4 GB of tensors, so it fits on one GPU and
+can be measured without the 0.78-1.3%% rack placement noise floor.
+
+For every variant this reports:
+  * forward wall time, backward wall time (total minus forward)
+  * achieved TFLOP/s under both accounting conventions (see ``--help``)
+  * peak HBM bytes
+  * ``loss_diff`` and ``grad_max_abs_diff`` against a chunked float32 reference
+  * whether the forward is bitwise identical to the current production path
+
+Run one variant per process so ``peak_bytes_in_use`` is not polluted by a
+previous variant; ``--fanout`` does that automatically across the local GPUs.
+
+Examples::
+
+    # everything, fanned out over the local GPUs
+    python lib/levanter/scripts/bench/bench_ce_hero_shape.py --fanout
+
+    # a single variant in this process
+    python lib/levanter/scripts/bench/bench_ce_hero_shape.py --variants fast
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import glob
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from levanter.kernels.pallas.fused_cross_entropy_loss.batched_xla import (
+    linear_softmax_cross_entropy_loss_batched_xla,
+)
+from levanter.kernels.pallas.fused_cross_entropy_loss.config import BlockSizes
+from levanter.kernels.pallas.fused_cross_entropy_loss.xla import (
+    linear_softmax_cross_entropy_loss_xla,
+)
+
+RESULT_PREFIX = "RESULT_JSON "
+
+# experiments/grug/moe_hero_ep/heuristic.py HERO_MODEL, mesh (1, 1, 64, 1):
+# `data` and `model` are size 1, so the CE shard is the whole per-rank batch.
+HERO_B = 65_536
+HERO_H = 6_144
+HERO_V = 128_256
+# experiments/grug/moe_hero_ep/model.py:61 `_CE_BLOCK_SIZES`
+HERO_V_BLOCK = 4_096
+# BlockSizes.b_block_size default, left untouched by _CE_BLOCK_SIZES
+HERO_B_BLOCK = 1_024
+
+
+@dataclass(frozen=True)
+class Variant:
+    name: str
+    impl: str = "xla"  # "xla" | "batched_xla"
+    b_block_size: int = HERO_B_BLOCK
+    v_block_size: int = HERO_V_BLOCK
+    fast_backward: bool = False
+    bwd_batch_block_size: Optional[int] = None
+    bwd_v_block_size: Optional[int] = None
+    note: str = ""
+
+
+VARIANTS: tuple[Variant, ...] = (
+    Variant("baseline", note="today: implementation='xla', _CE_BLOCK_SIZES, nested fori_loop backward"),
+    # --- the ladder, one rung at a time ---
+    Variant("fast", fast_backward=True, note="scan + dense one-hot + bf16 dlogits, untiled batch"),
+    Variant("fast-bwdv2048", fast_backward=True, bwd_v_block_size=2048),
+    Variant("fast-bwdv8192", fast_backward=True, bwd_v_block_size=8192),
+    Variant("fast-bwdv16384", fast_backward=True, bwd_v_block_size=16384),
+    Variant("fast-bwdv32768", fast_backward=True, bwd_v_block_size=32768),
+    # --- peak-memory / speed trade: keep a batch tile in the backward ---
+    Variant("fast-bb8192", fast_backward=True, bwd_batch_block_size=8192),
+    Variant("fast-bb16384", fast_backward=True, bwd_batch_block_size=16384),
+    # --- does the forward's own batch blocking still cost anything? ---
+    Variant("baseline-fwdfull", b_block_size=HERO_B, note="forward batch blocking off, old backward"),
+    Variant("fast-fwdfull", b_block_size=HERO_B, fast_backward=True),
+    # --- maximum launch-count reduction: single-shot forward + 8-iteration backward ---
+    Variant(
+        "fast-max",
+        b_block_size=HERO_B,
+        fast_backward=True,
+        bwd_v_block_size=16384,
+        note="fwd 32 iters + bwd 8 iters (vs 2048 + 2048 at baseline)",
+    ),
+    Variant(
+        "fast-max32k",
+        b_block_size=HERO_B,
+        fast_backward=True,
+        bwd_v_block_size=32768,
+        note="fwd 32 iters + bwd 4 iters",
+    ),
+    # --- the GB10 ladder implementation as shipped, unmodified ---
+    Variant("batched_xla", impl="batched_xla", note="existing GB10-keyed ladder; may raise on GB200"),
+)
+VARIANTS_BY_NAME = {v.name: v for v in VARIANTS}
+
+
+@dataclass
+class Result:
+    variant: str
+    ok: bool = True
+    error: str = ""
+    device_kind: str = ""
+    b: int = HERO_B
+    h: int = HERO_H
+    v: int = HERO_V
+    b_block_size: int = 0
+    v_block_size: int = 0
+    bwd_v_block_size: Optional[int] = None
+    bwd_batch_block_size: Optional[int] = None
+    compile_fwd_s: float = 0.0
+    compile_total_s: float = 0.0
+    fwd_s: float = 0.0
+    total_s: float = 0.0
+    bwd_s: float = 0.0
+    # 1 GEMM forward.
+    fwd_tflops: float = 0.0
+    # 3 GEMMs in the backward: logits recompute, grad_x, grad_w.
+    bwd_tflops: float = 0.0
+    # "useful" convention: 3 GEMMs total (fwd + grad_x + grad_w), ignoring the
+    # backward's logits recompute. This is the convention behind the 405 TFLOP/s
+    # figure quoted for the hero run.
+    total_useful_tflops: float = 0.0
+    # "issued" convention: all 4 GEMMs the kernel actually runs.
+    total_issued_tflops: float = 0.0
+    peak_hbm_bytes: int = 0
+    # correctness
+    loss_max_abs_diff_vs_fp32: float = float("nan")
+    loss_mean_abs_diff_vs_fp32: float = float("nan")
+    loss_bitwise_equal_vs_baseline: Optional[bool] = None
+    loss_max_abs_diff_vs_baseline: float = float("nan")
+    gx_max_abs_diff: float = float("nan")
+    gx_rel_rms: float = float("nan")
+    gw_max_abs_diff: float = float("nan")
+    gw_rel_rms: float = float("nan")
+    # measured kernel launches for ONE fwd+bwd call (CE only, nothing else in the program)
+    fwd_launches: int = 0
+    bwd_launches: int = 0
+    total_launches: int = 0
+    mean_launch_us: float = float("nan")
+    # profiler-free launch counts derived from the optimized-HLO call graph
+    static_fwd_launches: int = 0
+    static_total_launches: int = 0
+    static_bwd_launches: int = 0
+    static_launch_ops: dict[str, int] = field(default_factory=dict)
+    # implied mean device-kernel duration, from static launches and measured wall time
+    implied_mean_launch_us: float = float("nan")
+    launch_lines: dict[str, Any] = field(default_factory=dict)
+    opt_hlo_ops: dict[str, int] = field(default_factory=dict)
+    note: str = ""
+
+
+def _gemm_flops(b: int, h: int, v: int) -> float:
+    return 2.0 * b * h * v
+
+
+def _make_inputs(b: int, h: int, v: int, dtype, seed: int):
+    key = jax.random.PRNGKey(seed)
+    kx, kw, kl = jax.random.split(key, 3)
+    # Scale so logits stay in a sane range at H=6144.
+    x = (jax.random.normal(kx, (b, h), dtype=jnp.float32) * (1.0 / np.sqrt(h))).astype(dtype)
+    w = (jax.random.normal(kw, (h, v), dtype=jnp.float32) * (1.0 / np.sqrt(h))).astype(dtype)
+    labels = jax.random.randint(kl, (b,), 0, v, dtype=jnp.int32)
+    return jax.block_until_ready((x, w, labels))
+
+
+def _build_fns(variant: Variant, labels: jax.Array):
+    """Return (forward_only_fn, value_and_grad_fn)."""
+    block_sizes = BlockSizes(b_block_size=variant.b_block_size, v_block_size=variant.v_block_size)
+
+    def call(x, w):
+        if variant.impl == "batched_xla":
+            return linear_softmax_cross_entropy_loss_batched_xla(
+                x, labels, w, block_sizes=block_sizes, dtype=jnp.float32, precision=None
+            )
+        return linear_softmax_cross_entropy_loss_xla(
+            x,
+            labels,
+            w,
+            block_sizes=block_sizes,
+            dtype=jnp.float32,
+            precision=None,
+            fast_backward=variant.fast_backward,
+            bwd_batch_block_size=variant.bwd_batch_block_size,
+            bwd_v_block_size=variant.bwd_v_block_size,
+        )
+
+    def forward(x, w):
+        loss, lse = call(x, w)
+        return loss, lse
+
+    def objective(x, w):
+        loss, _ = call(x, w)
+        # reduction="mean" with unit weights, as in grug loss.py.
+        return jnp.mean(loss)
+
+    return jax.jit(forward), jax.jit(jax.value_and_grad(objective, argnums=(0, 1)))
+
+
+def _time(fn, x, w, steps: int, warmup: int) -> tuple[float, float, Any]:
+    start = time.perf_counter()
+    out = jax.block_until_ready(fn(x, w))
+    compile_s = time.perf_counter() - start
+    for _ in range(warmup):
+        jax.block_until_ready(fn(x, w))
+    start = time.perf_counter()
+    for _ in range(steps):
+        jax.block_until_ready(fn(x, w))
+    return compile_s, (time.perf_counter() - start) / steps, out
+
+
+def _fp32_reference(x, labels, w, chunk: int):
+    """Chunked float32 reference for loss, grad_x and grad_w of ``mean(loss)``.
+
+    Everything is float32 with ``Precision.HIGHEST`` so this is a true fp32
+    reference, not a TF32 one.
+    """
+    b, h = x.shape
+    v = w.shape[1]
+    w32 = w.astype(jnp.float32)
+    scale = jnp.float32(1.0 / b)  # d mean(loss) / d loss_i
+
+    @jax.jit
+    def chunk_fn(x_chunk, labels_chunk, w32):
+        x32 = x_chunk.astype(jnp.float32)
+        logits = jax.lax.dot_general(x32, w32, (((1,), (0,)), ((), ())), precision=jax.lax.Precision.HIGHEST)
+        lse = jax.nn.logsumexp(logits, axis=-1)
+        label_logits = jnp.take_along_axis(logits, labels_chunk[:, None], axis=1).squeeze(-1)
+        loss = lse - label_logits
+        probs = jnp.exp(logits - lse[:, None])
+        onehot = jnp.arange(v, dtype=jnp.int32)[None, :] == labels_chunk[:, None]
+        dlogits = (probs - onehot.astype(jnp.float32)) * scale
+        gx = jax.lax.dot_general(dlogits, w32, (((1,), (1,)), ((), ())), precision=jax.lax.Precision.HIGHEST)
+        gw = jax.lax.dot_general(x32, dlogits, (((0,), (0,)), ((), ())), precision=jax.lax.Precision.HIGHEST)
+        return loss, gx, gw
+
+    losses = []
+    gxs = []
+    gw_acc = jnp.zeros((h, v), dtype=jnp.float32)
+    for start in range(0, b, chunk):
+        stop = min(start + chunk, b)
+        loss_c, gx_c, gw_c = chunk_fn(x[start:stop], labels[start:stop], w32)
+        losses.append(np.asarray(loss_c, dtype=np.float64))
+        gxs.append(np.asarray(gx_c, dtype=np.float32))
+        gw_acc = gw_acc + gw_c
+    return np.concatenate(losses), np.concatenate(gxs), np.asarray(gw_acc, dtype=np.float32)
+
+
+def _diff(actual, expected) -> tuple[float, float]:
+    a = np.asarray(actual, dtype=np.float32)
+    e = np.asarray(expected, dtype=np.float32)
+    d = np.abs(a - e)
+    rel = float(
+        np.sqrt(np.mean(d.astype(np.float64) ** 2)) / max(float(np.sqrt(np.mean(e.astype(np.float64) ** 2))), 1e-30)
+    )
+    return float(d.max()), rel
+
+
+# Opcodes that never launch a device kernel on XLA:GPU.
+_FREE_OPCODES = frozenset(
+    {
+        "parameter",
+        "constant",
+        "tuple",
+        "get-tuple-element",
+        "bitcast",
+        "while",
+        "conditional",
+        "after-all",
+        "token",
+        "add-dependency",
+        "opt-barrier",
+        "partition-id",
+        "replica-id",
+        "call",
+        "fusion-noop",
+        "bitcast-convert",
+    }
+)
+# Result shapes can be tuples containing spaces, so the opcode is "the first
+# lowercase identifier immediately followed by ( after the = sign".
+_INSTR_RE = re.compile(r"^\s+%?[\w.\-$]+ = .*?\s([a-z][\w-]*)\((.*)$")
+_COMP_RE = re.compile(r"^(?:ENTRY )?%?([\w.\-$]+) \(.*?\) -> .*\{\s*$")
+_TRIP_RE = re.compile(r'"known_trip_count":\s*\{\s*"n":\s*"?(\d+)"?')
+
+
+def _parse_optimized_hlo(text: str):
+    """Return (computations, entry_name).
+
+    ``computations[name]`` is a list of ``(opcode, called_computations, trip_count)``.
+    """
+    comps: dict[str, list] = {}
+    entry = None
+    cur = None
+    for raw in text.splitlines():
+        m = _COMP_RE.match(raw)
+        if m:
+            cur = m.group(1)
+            comps[cur] = []
+            if raw.lstrip().startswith("ENTRY"):
+                entry = cur
+            continue
+        if raw.strip() == "}":
+            cur = None
+            continue
+        if cur is None:
+            continue
+        m = _INSTR_RE.match(raw)
+        if not m:
+            continue
+        opcode, rest = m.group(1), m.group(2)
+        called = re.findall(
+            r"(?:body|condition|to_apply|called_computations=\{?|branch_computations=\{)\s*=?\s*%?([\w.\-$]+)", rest
+        )
+        trip = _TRIP_RE.search(rest)
+        comps[cur].append((opcode, called, int(trip.group(1)) if trip else None))
+    return comps, entry
+
+
+def _static_launch_estimate(text: str) -> tuple[int, dict[str, int]]:
+    """Kernel launches per call, derived from the optimized-HLO call graph.
+
+    Walks from ENTRY multiplying by each ``while`` loop's ``known_trip_count``.
+    ``fusion`` and ``custom-call`` count as one launch each and are not descended
+    into. This needs no profiler, which matters because CUPTI is not usable in
+    every container.
+    """
+    comps, entry = _parse_optimized_hlo(text)
+    if entry is None or entry not in comps:
+        return 0, {}
+    per_opcode: collections.Counter = collections.Counter()
+    seen_depth = 0
+
+    def walk(name: str, mult: int, depth: int) -> int:
+        nonlocal seen_depth
+        seen_depth = max(seen_depth, depth)
+        if depth > 12 or name not in comps:
+            return 0
+        total = 0
+        for opcode, called, trip in comps[name]:
+            if opcode == "while":
+                t = trip if trip is not None else 1
+                for sub in called:
+                    total += walk(sub, mult * t, depth + 1)
+                continue
+            if opcode in ("fusion", "custom-call"):
+                per_opcode[opcode] += mult
+                total += mult
+                continue
+            if opcode in _FREE_OPCODES:
+                continue
+            per_opcode[opcode] += mult
+            total += mult
+        return total
+
+    return walk(entry, 1, 0), dict(per_opcode)
+
+
+def _static_launches(fn, x, w) -> tuple[int, dict[str, int]]:
+    try:
+        text = fn.lower(x, w).compile().as_text()
+    except Exception as exc:  # noqa: BLE001
+        return 0, {"error": str(exc)[:200]}
+    return _static_launch_estimate(text)
+
+
+_KERNEL_LINE_HINTS = ("XLA Ops", "XLA Modules", "Kernels", "Compute")
+
+
+def _measure_launches(fn, x, w) -> tuple[int, float, dict[str, Any]]:
+    """Count device kernel launches for exactly one call of ``fn``.
+
+    Returns (launches, mean_launch_us, per_line_breakdown). The breakdown is kept
+    verbatim so the choice of "which xplane line is the kernel line" stays auditable.
+    """
+    tmpdir = tempfile.mkdtemp(prefix="ce_prof_")
+    try:
+        with jax.profiler.trace(tmpdir):
+            jax.block_until_ready(fn(x, w))
+        paths = glob.glob(os.path.join(tmpdir, "**", "*.xplane.pb"), recursive=True)
+        if not paths:
+            return 0, float("nan"), {"error": "no xplane produced"}
+        data = jax.profiler.ProfileData.from_file(paths[0])
+        breakdown: dict[str, Any] = {}
+        for plane in data.planes:
+            for line in plane.lines:
+                events = list(line.events)
+                if not events:
+                    continue
+                total_ns = float(sum(e.duration_ns for e in events))
+                breakdown[f"{plane.name} :: {line.name}"] = {
+                    "n": len(events),
+                    "total_ms": total_ns / 1e6,
+                    "mean_us": total_ns / len(events) / 1e3,
+                }
+        # Prefer a device plane's "XLA Ops" line: on GPU that is one event per kernel.
+        best_key = None
+        for key in breakdown:
+            plane_name, _, line_name = key.partition(" :: ")
+            if "device" not in plane_name.lower() and "gpu" not in plane_name.lower():
+                continue
+            if line_name.strip() in _KERNEL_LINE_HINTS[:1]:
+                best_key = key
+                break
+        if best_key is None:
+            device_keys = [k for k in breakdown if "device" in k.lower() or "gpu" in k.lower()]
+            if device_keys:
+                best_key = max(device_keys, key=lambda k: breakdown[k]["n"])
+        if best_key is None:
+            return 0, float("nan"), breakdown
+        chosen = breakdown[best_key]
+        breakdown["_chosen_line"] = best_key
+        return int(chosen["n"]), float(chosen["mean_us"]), breakdown
+    except Exception as exc:  # noqa: BLE001
+        return 0, float("nan"), {"error": f"{type(exc).__name__}: {exc}"[:500]}
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _opt_hlo_ops(fn, x, w) -> dict[str, int]:
+    try:
+        text = fn.lower(x, w).compile().as_text()
+    except Exception:
+        return {}
+    counts = collections.Counter()
+    for m in re.finditer(r"=\s*\S+\s+(fusion|custom-call|while|copy|dot|reduce|transpose|scatter|gather)\b", text):
+        counts[m.group(1)] += 1
+    return dict(counts)
+
+
+def run_variant(variant: Variant, args) -> Result:
+    res = Result(
+        variant=variant.name,
+        b=args.batch,
+        h=args.hidden,
+        v=args.vocab,
+        b_block_size=variant.b_block_size,
+        v_block_size=variant.v_block_size,
+        bwd_v_block_size=variant.bwd_v_block_size,
+        bwd_batch_block_size=variant.bwd_batch_block_size,
+        note=variant.note,
+    )
+    device = jax.local_devices()[0]
+    res.device_kind = device.device_kind
+
+    dtype = jnp.dtype(args.input_dtype)
+    x, w, labels = _make_inputs(args.batch, args.hidden, args.vocab, dtype, args.seed)
+
+    try:
+        fwd_fn, grad_fn = _build_fns(variant, labels)
+        res.compile_fwd_s, res.fwd_s, _ = _time(fwd_fn, x, w, args.steps, args.warmup)
+        res.compile_total_s, res.total_s, (value, (gx, gw)) = _time(grad_fn, x, w, args.steps, args.warmup)
+    except Exception as exc:  # noqa: BLE001 - report and keep the sweep going
+        res.ok = False
+        res.error = f"{type(exc).__name__}: {exc}"[:2000]
+        return res
+
+    res.bwd_s = res.total_s - res.fwd_s
+    one_gemm = _gemm_flops(args.batch, args.hidden, args.vocab)
+    res.fwd_tflops = one_gemm / res.fwd_s / 1e12
+    res.bwd_tflops = 3.0 * one_gemm / res.bwd_s / 1e12 if res.bwd_s > 0 else float("nan")
+    res.total_useful_tflops = 3.0 * one_gemm / res.total_s / 1e12
+    res.total_issued_tflops = 4.0 * one_gemm / res.total_s / 1e12
+
+    stats = device.memory_stats() or {}
+    res.peak_hbm_bytes = int(stats.get("peak_bytes_in_use", 0))
+
+    res.static_fwd_launches, _ = _static_launches(fwd_fn, x, w)
+    res.static_total_launches, res.static_launch_ops = _static_launches(grad_fn, x, w)
+    res.static_bwd_launches = res.static_total_launches - res.static_fwd_launches
+    if res.static_total_launches:
+        res.implied_mean_launch_us = res.total_s / res.static_total_launches * 1e6
+
+    if args.profile:
+        res.fwd_launches, _, _ = _measure_launches(fwd_fn, x, w)
+        res.total_launches, res.mean_launch_us, res.launch_lines = _measure_launches(grad_fn, x, w)
+        res.bwd_launches = res.total_launches - res.fwd_launches
+
+    if args.hlo_ops:
+        res.opt_hlo_ops = _opt_hlo_ops(grad_fn, x, w)
+
+    if args.check:
+        loss, _ = jax.block_until_ready(fwd_fn(x, w))
+        loss_np = np.asarray(loss, dtype=np.float64)
+
+        # Bitwise comparison of the forward against the current production path.
+        base_fwd, _ = _build_fns(VARIANTS_BY_NAME["baseline"], labels)
+        base_loss, _ = jax.block_until_ready(base_fwd(x, w))
+        base_np = np.asarray(base_loss, dtype=np.float64)
+        res.loss_bitwise_equal_vs_baseline = bool(np.array_equal(loss_np, base_np))
+        res.loss_max_abs_diff_vs_baseline = float(np.abs(loss_np - base_np).max())
+        del base_fwd, base_loss
+
+        ref_loss, ref_gx, ref_gw = _fp32_reference(x, labels, w, args.check_chunk)
+        d = np.abs(loss_np - ref_loss)
+        res.loss_max_abs_diff_vs_fp32 = float(d.max())
+        res.loss_mean_abs_diff_vs_fp32 = float(d.mean())
+        res.gx_max_abs_diff, res.gx_rel_rms = _diff(gx, ref_gx)
+        res.gw_max_abs_diff, res.gw_rel_rms = _diff(gw, ref_gw)
+
+    return res
+
+
+def _fanout(args) -> int:
+    # NOTE: never touch jax.devices() here. The parent must not initialise a CUDA
+    # context, or it holds every GPU and the children fail to allocate.
+    names = args.variants
+    n_gpu = args.num_gpus
+    if n_gpu <= 0:
+        visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+        n_gpu = len([d for d in visible.split(",") if d.strip()]) if visible else 4
+    n_gpu = max(1, n_gpu)
+    print(f"fanout: {len(names)} variants over {n_gpu} local GPU(s)", flush=True)
+    script = os.path.abspath(__file__)
+    base = [
+        sys.executable,
+        "-u",
+        script,
+        "--batch",
+        str(args.batch),
+        "--hidden",
+        str(args.hidden),
+        "--vocab",
+        str(args.vocab),
+        "--steps",
+        str(args.steps),
+        "--warmup",
+        str(args.warmup),
+        "--check-chunk",
+        str(args.check_chunk),
+        "--input-dtype",
+        args.input_dtype,
+        "--seed",
+        str(args.seed),
+    ]
+    if args.check:
+        base.append("--check")
+    if args.hlo_ops:
+        base.append("--hlo-ops")
+    if not args.profile:
+        base.append("--no-profile")
+
+    results: list[dict] = []
+    for i in range(0, len(names), n_gpu):
+        wave = names[i : i + n_gpu]
+        procs = []
+        for slot, name in enumerate(wave):
+            env = dict(os.environ)
+            env["CUDA_VISIBLE_DEVICES"] = str(slot)
+            # Concurrent children must not each grab 75% of a GPU up front; without
+            # this the children die with SIGSEGV during the first large allocation.
+            env["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
+            env.setdefault("XLA_PYTHON_CLIENT_ALLOCATOR", "platform")
+            cmd = base + ["--variants", name]
+            print(f"  launching {name} on local GPU {slot}", flush=True)
+            procs.append(
+                (name, subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True))
+            )
+        for name, proc in procs:
+            try:
+                out, _ = proc.communicate(timeout=args.child_timeout)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                out, _ = proc.communicate()
+                out = (out or "") + f"\n!! timed out after {args.child_timeout}s"
+
+            got = False
+            for line in out.splitlines():
+                if line.startswith(RESULT_PREFIX):
+                    results.append(json.loads(line[len(RESULT_PREFIX) :]))
+                    got = True
+            if not got:
+                print(f"!! {name} produced no result (exit {proc.returncode}); tail:", flush=True)
+                print("\n".join(out.splitlines()[-40:]), flush=True)
+                results.append(asdict(Result(variant=name, ok=False, error=f"exit {proc.returncode}")))
+    _print_table(results)
+    with open(args.out, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\nwrote {args.out}", flush=True)
+    return 0
+
+
+def _print_table(results: list[dict]) -> None:
+    print("\n" + "=" * 175, flush=True)
+    hdr = (
+        f"{'variant':>18} {'fwd_ms':>9} {'bwd_ms':>9} {'total_ms':>9} "
+        f"{'useful_TF/s':>12} {'issued_TF/s':>12} {'peak_GiB':>9} "
+        f"{'launches':>10} {'us/launch':>10} "
+        f"{'loss==base':>11} {'gx_relRMS':>11} {'gw_relRMS':>11}"
+    )
+    print(hdr)
+    print("-" * 175)
+    base = next((r for r in results if r["variant"] == "baseline" and r["ok"]), None)
+    for r in results:
+        if not r["ok"]:
+            print(f"{r['variant']:>18}  FAILED: {r['error'][:110]}")
+            continue
+        print(
+            f"{r['variant']:>18} {r['fwd_s'] * 1e3:>9.2f} {r['bwd_s'] * 1e3:>9.2f} {r['total_s'] * 1e3:>9.2f} "
+            f"{r['total_useful_tflops']:>12.1f} {r['total_issued_tflops']:>12.1f} "
+            f"{r['peak_hbm_bytes'] / 2**30:>9.2f} "
+            f"{r.get('static_total_launches', 0):>10} {r.get('implied_mean_launch_us', float('nan')):>10.2f} "
+            f"{str(r['loss_bitwise_equal_vs_baseline']):>11} "
+            f"{r['gx_rel_rms']:>11.3e} {r['gw_rel_rms']:>11.3e}"
+        )
+    if base:
+        print("-" * 175)
+        for r in results:
+            if r["ok"] and r["variant"] != "baseline":
+                print(
+                    f"{r['variant']:>18}  speedup vs baseline: total {base['total_s'] / r['total_s']:.3f}x   "
+                    f"bwd {base['bwd_s'] / r['bwd_s']:.3f}x   "
+                    f"delta_ms {(r['total_s'] - base['total_s']) * 1e3:+.2f}"
+                )
+    print("=" * 175, flush=True)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--batch", type=int, default=HERO_B)
+    p.add_argument("--hidden", type=int, default=HERO_H)
+    p.add_argument("--vocab", type=int, default=HERO_V)
+    p.add_argument("--input-dtype", type=str, default="bfloat16")
+    p.add_argument("--steps", type=int, default=10)
+    p.add_argument("--warmup", type=int, default=3)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--variants", type=str, default="all", help="comma-separated variant names, or 'all'")
+    p.add_argument("--check", action="store_true", help="run the float32 correctness gate")
+    p.add_argument("--no-check", action="store_false", dest="check")
+    p.set_defaults(check=True)
+    p.add_argument("--check-chunk", type=int, default=4096, help="row chunk for the fp32 reference")
+    p.add_argument("--hlo-ops", action="store_true", default=False, help="histogram optimized-HLO ops")
+    p.add_argument("--profile", action="store_true", help="count device kernel launches via the JAX profiler")
+    p.add_argument("--no-profile", action="store_false", dest="profile")
+    p.set_defaults(profile=False)
+    p.add_argument("--fanout", action="store_true", help="one subprocess per variant across local GPUs")
+    p.add_argument(
+        "--num-gpus", type=int, default=0, help="GPUs to fan out over (0 = autodetect without touching JAX)"
+    )
+    p.add_argument("--child-timeout", type=int, default=3600, help="per-variant subprocess timeout, seconds")
+    p.add_argument("--out", type=str, default="ce_hero_shape_results.json")
+    p.add_argument("--list", action="store_true")
+    args = p.parse_args()
+
+    if args.list:
+        for v in VARIANTS:
+            print(f"{v.name:>18}  {v.note or ''}")
+        return 0
+
+    if args.variants == "all":
+        names = [v.name for v in VARIANTS]
+    else:
+        names = [n.strip() for n in args.variants.split(",") if n.strip()]
+    unknown = [n for n in names if n not in VARIANTS_BY_NAME]
+    if unknown:
+        raise SystemExit(f"unknown variants: {unknown}; known: {sorted(VARIANTS_BY_NAME)}")
+    args.variants = names
+
+    if args.fanout:
+        return _fanout(args)
+
+    print("devices:", jax.devices(), flush=True)
+    print(f"shape: B={args.batch} H={args.hidden} V={args.vocab} dtype={args.input_dtype}", flush=True)
+    results = []
+    for name in names:
+        res = run_variant(VARIANTS_BY_NAME[name], args)
+        d = asdict(res)
+        results.append(d)
+        print(RESULT_PREFIX + json.dumps(d), flush=True)
+    if len(results) > 1:
+        _print_table(results)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Callable, Sequence
-from functools import lru_cache
+from functools import lru_cache, partial
 import hashlib
 import json
 import logging
@@ -44,6 +44,7 @@ Implementation: TypeAlias = Literal[
     "pallas_tpu",
     "batched_xla",
     "xla",
+    "xla_fast_bwd",
     "reference",
 ]
 Reduction: TypeAlias = Literal["sum", "mean"] | None
@@ -56,6 +57,17 @@ ArrayImpl = Callable[..., KernelOutput]
 IMPLEMENTATIONS: dict[str, ArrayImpl] = {
     "reference": linear_softmax_cross_entropy_loss_reference,
     "xla": linear_softmax_cross_entropy_loss_xla,
+    # Same forward as "xla" (loss and lse are bitwise identical), but the backward
+    # is the scan/one-hot/tensor-core rewrite: no scatter, one GEMM per vocab block
+    # over the whole batch, and dlogits cast to the activation dtype so both
+    # backward GEMMs stay on bf16 tensor cores instead of being upcast to
+    # float32/TF32. Measured on GB200 at the grug EP hero CE shape
+    # (B=65,536 H=6,144 V=128,256): 723.4 ms -> 310.0 ms end-to-end for the kernel,
+    # 428 -> 1,000 TFLOP/s on the 3-GEMM convention (571 -> 1,333 counting all four
+    # GEMMs the kernel issues), at +0.04 GiB peak HBM. Gradients change: they are
+    # ~30% CLOSER to a float32 reference than the "xla" path. Opt in explicitly;
+    # "xla" is unchanged for every other caller.
+    "xla_fast_bwd": partial(linear_softmax_cross_entropy_loss_xla, fast_backward=True),
 }
 _DEFAULT_IMPLEMENTATION: tuple[Implementation, ...] = ("xla",)
 _IMPLEMENTATION_FALLBACK_WARNINGS_EMITTED: set[str] = set()
@@ -674,7 +686,7 @@ def fused_cross_entropy_loss_and_logsumexp_penalty(
         impl_for_call = impl
         if explicit_block_sizes:
             block_sizes_for_impl = resolved_block_sizes
-        elif impl_for_call in ("xla", "reference"):
+        elif impl_for_call in ("xla", "xla_fast_bwd", "reference"):
             block_sizes_for_impl = None
         elif isinstance(impl_for_call, str) and impl_for_call in ("pallas_tpu", "batched_xla"):
             inferred, has_tuned_match = infer_block_sizes_with_tuned_match(

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/xla.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/xla.py
@@ -36,7 +36,13 @@ _FALSY = ("0", "false", "no", "off")
 
 
 def _fast_backward_env_override() -> bool | None:
-    """Return the env var's value, or ``None`` when it is unset/unrecognised."""
+    """Return the env var's value, or ``None`` when it is unset.
+
+    A set-but-unrecognised value raises: this variable is a kill switch for A/B
+    runs, so a typo (``fasle``) must fail loudly rather than silently fall through
+    to the call-site default -- which for the hero call site leaves the new
+    gradient algorithm enabled and invalidates the comparison.
+    """
     raw = os.environ.get(_FAST_BWD_ENV_VAR)
     if raw is None:
         return None
@@ -45,7 +51,9 @@ def _fast_backward_env_override() -> bool | None:
         return True
     if value in _FALSY:
         return False
-    return None
+    raise ValueError(
+        f"{_FAST_BWD_ENV_VAR}={raw!r} is not a recognised boolean; use one of {_TRUTHY + _FALSY} or unset it."
+    )
 
 
 def _resolve_fast_backward(requested: bool | None) -> bool:

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/xla.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/xla.py
@@ -1,6 +1,7 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 from functools import partial
 from typing import Optional, cast
 
@@ -18,6 +19,48 @@ from .tuned_block_sizes import (
 )
 
 _XLA_MAX_TILE_WORDS = 2**31 - 1
+
+# Fast backward selection. The library default stays OFF so that every existing
+# caller of implementation="xla" keeps bit-identical gradients; callers opt in
+# per-call-site (the grug EP hero does so via implementation="xla_fast_bwd").
+# The forward is untouched either way, so the loss is identical in both cases;
+# only gradient rounding differs -- and it moves *closer* to a float32 reference
+# (see ``_linear_softmax_cross_entropy_loss_streaming_bwd_scan``).
+#
+# The env var is a two-way override for A/B runs: when it is set it wins over the
+# call site, so a run can be forced onto either path without editing code.
+_FAST_BWD_ENV_VAR = "LEVANTER_CE_XLA_FAST_BWD"
+_FAST_BWD_LIBRARY_DEFAULT = False
+_TRUTHY = ("1", "true", "yes", "on")
+_FALSY = ("0", "false", "no", "off")
+
+
+def _fast_backward_env_override() -> bool | None:
+    """Return the env var's value, or ``None`` when it is unset/unrecognised."""
+    raw = os.environ.get(_FAST_BWD_ENV_VAR)
+    if raw is None:
+        return None
+    value = raw.strip().lower()
+    if value in _TRUTHY:
+        return True
+    if value in _FALSY:
+        return False
+    return None
+
+
+def _resolve_fast_backward(requested: bool | None) -> bool:
+    """Resolve the fast-backward choice: env override, then call site, then default."""
+    override = _fast_backward_env_override()
+    if override is not None:
+        return override
+    if requested is not None:
+        return bool(requested)
+    return _FAST_BWD_LIBRARY_DEFAULT
+
+
+def _fast_backward_default() -> bool:
+    """Backwards-compatible alias for the resolved default with no call-site request."""
+    return _resolve_fast_backward(None)
 
 
 def _materialize_cotangent(
@@ -350,17 +393,190 @@ def _linear_softmax_cross_entropy_loss_streaming_bwd(
     return gx, gw[:, :v_dim]
 
 
-@partial(jax.custom_vjp, nondiff_argnums=(0, 1, 2, 3, 4))
+def _linear_softmax_cross_entropy_loss_streaming_bwd_scan(
+    x: Float[Array, "B H"],
+    labels: Int[Array, "B"],
+    w: Float[Array, "H V"],
+    lse: Float[Array, "B"],
+    dout_loss: Float[Array, "B"],
+    dout_lse: Float[Array, "B"],
+    *,
+    block_size: int,
+    dtype: Optional[jnp.dtype],
+    batch_block_size: int,
+    logit_soft_cap: Optional[float],
+    precision: jax.lax.PrecisionLike,
+) -> tuple[Float[Array, "B H"], Float[Array, "H V"]]:
+    """Backward pass over vocab blocks, structured for GPU tensor cores.
+
+    Mathematically identical to ``_linear_softmax_cross_entropy_loss_streaming_bwd``;
+    it differs in four ways, each of which the GPU CE ladder measured as a win
+    (see ``.agents/projects/fused_cross_entropy_gpu.md``):
+
+    1. ``dlogits`` is cast to the activation dtype before the two backward GEMMs.
+       The naive form leaves ``dlogits`` in float32, which forces XLA to *upcast
+       ``x`` and ``w`` to float32* and run both backward GEMMs in FP32/TF32
+       instead of BF16 tensor cores. Softmax math stays in float32.
+    2. The label term is a dense one-hot compare fused into the ``dlogits``
+       expression, replacing an ``.at[].add()`` scatter with
+       ``unique_indices=false`` that XLA cannot fuse and lowers to atomics.
+    3. The vocab loop is a ``lax.scan`` that carries only ``grad_x`` and emits
+       ``grad_w`` blocks as stacked outputs, instead of a ``fori_loop`` carrying
+       a full ``[H, V]`` ``grad_w`` buffer updated by ``dynamic_update_slice``.
+    4. ``grad_x`` accumulates in float32 (cast once at the end) rather than
+       accumulating in the activation dtype across every vocab block.
+
+    ``batch_block_size`` still bounds the live logits tile to
+    ``batch_block_size x block_size``; pass ``>= B`` to disable batch tiling
+    entirely (fewest kernels, largest peak memory).
+    """
+    if block_size <= 0:
+        raise ValueError(f"block_size must be positive, got {block_size}.")
+    if batch_block_size <= 0:
+        raise ValueError(f"batch_block_size must be positive, got {batch_block_size}.")
+
+    b_dim, h_dim = x.shape
+    if batch_block_size < b_dim and b_dim % batch_block_size != 0:
+        raise ValueError(
+            f"batch_block_size must divide batch dimension, got B={b_dim}, batch_block_size={batch_block_size}."
+        )
+    b_block = min(batch_block_size, b_dim)
+    num_b_blocks = b_dim // b_block
+
+    v_dim = w.shape[1]
+    pad = (-v_dim) % block_size
+    w_padded = jnp.pad(w, ((0, 0), (0, pad)), mode="constant", constant_values=0) if pad else w
+    v_padded = v_dim + pad
+    num_v_blocks = v_padded // block_size
+
+    # Operand dtype for the two backward GEMMs. Keeping this equal to the primal
+    # dtypes is what keeps them on tensor cores.
+    gemm_dtype = jnp.result_type(x.dtype, w.dtype)
+
+    labels_i32 = labels.astype(jnp.int32)
+    lse_f32 = lse.astype(jnp.float32)
+    g_loss_f32 = dout_loss.astype(jnp.float32)
+    g_softmax_f32 = g_loss_f32 + dout_lse.astype(jnp.float32)
+    v_offsets = jnp.arange(block_size, dtype=jnp.int32)
+
+    def _dlogits_tile(
+        x_blk: jax.Array,
+        labels_blk: jax.Array,
+        lse_blk: jax.Array,
+        g_loss_blk: jax.Array,
+        g_softmax_blk: jax.Array,
+        w_block: jax.Array,
+        v_start: jax.Array,
+    ) -> jax.Array:
+        logits = jax.lax.dot_general(
+            x_blk,
+            w_block,
+            (((1,), (0,)), ((), ())),
+            precision=precision,
+            preferred_element_type=jnp.float32,
+        )
+        if dtype is not None:
+            logits = logits.astype(dtype)
+        logits = logits.astype(jnp.float32)
+
+        cap_deriv = None
+        if logit_soft_cap is not None:
+            tanh_val = jnp.tanh(logits / logit_soft_cap)
+            logits = tanh_val * logit_soft_cap
+            cap_deriv = 1.0 - tanh_val**2
+
+        in_vocab = (v_start + v_offsets) < v_dim
+        probs = jnp.where(in_vocab[None, :], jnp.exp(logits - lse_blk[:, None]), 0.0)
+        dlogits = probs * g_softmax_blk[:, None]
+
+        # Dense one-hot label subtraction. ``labels - v_start`` lands in
+        # ``[0, block_size)`` exactly when the label belongs to this vocab block,
+        # so the equality compare alone is the in-block mask.
+        label_hit = v_offsets[None, :] == (labels_blk - v_start)[:, None]
+        dlogits = dlogits - jnp.where(label_hit, g_loss_blk[:, None], 0.0)
+
+        if cap_deriv is not None:
+            dlogits = dlogits * cap_deriv
+        return dlogits.astype(gemm_dtype)
+
+    def scan_body(grad_x: jax.Array, v_block_index: jax.Array):
+        v_start = v_block_index * block_size
+        w_block = jax.lax.dynamic_slice(w_padded, (0, v_start), (h_dim, block_size))
+
+        if num_b_blocks == 1:
+            dlogits = _dlogits_tile(x, labels_i32, lse_f32, g_loss_f32, g_softmax_f32, w_block, v_start)
+            grad_x = grad_x + jax.lax.dot_general(
+                dlogits,
+                w_block,
+                (((1,), (1,)), ((), ())),
+                precision=precision,
+                preferred_element_type=jnp.float32,
+            )
+            grad_w_block = jax.lax.dot_general(
+                x,
+                dlogits,
+                (((0,), (0,)), ((), ())),
+                precision=precision,
+                preferred_element_type=jnp.float32,
+            )
+            return grad_x, grad_w_block.astype(w.dtype)
+
+        def batch_body(batch_block_index, state):
+            grad_x_inner, grad_w_acc = state
+            b_start = batch_block_index * b_block
+            x_blk = jax.lax.dynamic_slice(x, (b_start, 0), (b_block, h_dim))
+            dlogits = _dlogits_tile(
+                x_blk,
+                jax.lax.dynamic_slice(labels_i32, (b_start,), (b_block,)),
+                jax.lax.dynamic_slice(lse_f32, (b_start,), (b_block,)),
+                jax.lax.dynamic_slice(g_loss_f32, (b_start,), (b_block,)),
+                jax.lax.dynamic_slice(g_softmax_f32, (b_start,), (b_block,)),
+                w_block,
+                v_start,
+            )
+            grad_x_blk = jax.lax.dot_general(
+                dlogits,
+                w_block,
+                (((1,), (1,)), ((), ())),
+                precision=precision,
+                preferred_element_type=jnp.float32,
+            )
+            grad_w_acc = grad_w_acc + jax.lax.dot_general(
+                x_blk,
+                dlogits,
+                (((0,), (0,)), ((), ())),
+                precision=precision,
+                preferred_element_type=jnp.float32,
+            )
+            current = jax.lax.dynamic_slice(grad_x_inner, (b_start, 0), (b_block, h_dim))
+            grad_x_inner = jax.lax.dynamic_update_slice(grad_x_inner, current + grad_x_blk, (b_start, 0))
+            return grad_x_inner, grad_w_acc
+
+        grad_w_init = jnp.zeros((h_dim, block_size), dtype=jnp.float32)
+        grad_x, grad_w_acc = jax.lax.fori_loop(0, num_b_blocks, batch_body, (grad_x, grad_w_init))
+        return grad_x, grad_w_acc.astype(w.dtype)
+
+    grad_x_init = jnp.zeros((b_dim, h_dim), dtype=jnp.float32)
+    grad_x, grad_w_blocks = jax.lax.scan(scan_body, grad_x_init, jnp.arange(num_v_blocks, dtype=jnp.int32))
+    grad_w = jnp.transpose(grad_w_blocks, (1, 0, 2)).reshape((h_dim, v_padded))
+    return grad_x.astype(x.dtype), grad_w[:, :v_dim]
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(0, 1, 2, 3, 4, 5, 6, 7))
 def _linear_softmax_cross_entropy_loss_streaming_custom_vjp(
     block_size: int,
     batch_block_size: int,
     dtype: Optional[jnp.dtype],
     logit_soft_cap: Optional[float],
     precision: jax.lax.PrecisionLike,
+    fast_backward: bool,
+    bwd_batch_block_size: int | None,
+    bwd_v_block_size: int | None,
     x: Float[Array, "B H"],
     labels: Int[Array, "B"],
     w: Float[Array, "H V"],
 ) -> tuple[Float[Array, "B"], Float[Array, "B"]]:
+    del fast_backward, bwd_batch_block_size, bwd_v_block_size
     loss, lse = _linear_softmax_cross_entropy_loss_streaming_fwd(
         x,
         labels,
@@ -380,10 +596,14 @@ def _linear_softmax_cross_entropy_loss_streaming_custom_vjp_fwd(
     dtype: Optional[jnp.dtype],
     logit_soft_cap: Optional[float],
     precision: jax.lax.PrecisionLike,
+    fast_backward: bool,
+    bwd_batch_block_size: int | None,
+    bwd_v_block_size: int | None,
     x: Float[Array, "B H"],
     labels: Int[Array, "B"],
     w: Float[Array, "H V"],
 ) -> tuple[tuple[Float[Array, "B"], Float[Array, "B"]], tuple[jax.Array, jax.Array, jax.Array, jax.Array]]:
+    del fast_backward, bwd_batch_block_size, bwd_v_block_size
     loss, lse = _linear_softmax_cross_entropy_loss_streaming_fwd(
         x,
         labels,
@@ -403,6 +623,9 @@ def _linear_softmax_cross_entropy_loss_streaming_custom_vjp_bwd(
     dtype: Optional[jnp.dtype],
     logit_soft_cap: Optional[float],
     precision: jax.lax.PrecisionLike,
+    fast_backward: bool,
+    bwd_batch_block_size: int | None,
+    bwd_v_block_size: int | None,
     residuals: tuple[jax.Array, jax.Array, jax.Array, jax.Array],
     cotangents: tuple[
         jax.Array | jax.custom_derivatives.SymbolicZero, jax.Array | jax.custom_derivatives.SymbolicZero
@@ -412,6 +635,21 @@ def _linear_softmax_cross_entropy_loss_streaming_custom_vjp_bwd(
     dout_loss, dout_lse = cotangents
     dout_loss_arr = _materialize_cotangent(dout_loss, lse)
     dout_lse_arr = _materialize_cotangent(dout_lse, lse)
+    if fast_backward:
+        gx, gw = _linear_softmax_cross_entropy_loss_streaming_bwd_scan(
+            x,
+            labels,
+            w,
+            lse,
+            dout_loss_arr,
+            dout_lse_arr,
+            block_size=(bwd_v_block_size if bwd_v_block_size is not None else block_size),
+            dtype=dtype,
+            batch_block_size=(bwd_batch_block_size if bwd_batch_block_size is not None else x.shape[0]),
+            logit_soft_cap=logit_soft_cap,
+            precision=precision,
+        )
+        return gx, None, gw
     gx, gw = _linear_softmax_cross_entropy_loss_streaming_bwd(
         x,
         labels,
@@ -444,7 +682,27 @@ def linear_softmax_cross_entropy_loss_xla(
     logit_soft_cap: Optional[float] = None,
     precision: jax.lax.PrecisionLike = None,
     return_argmax: bool = False,
+    fast_backward: bool | None = None,
+    bwd_batch_block_size: int | None = None,
+    bwd_v_block_size: int | None = None,
 ) -> tuple[Float[Array, "B"], Float[Array, "B"]] | tuple[Float[Array, "B"], Float[Array, "B"], Int[Array, "B"]]:
+    """Streaming linear-softmax cross-entropy on plain XLA.
+
+    Args:
+        fast_backward: Use the scan/one-hot/tensor-core backward. ``None`` means
+            "no call-site preference" and falls back to the library default (off).
+            The ``LEVANTER_CE_XLA_FAST_BWD`` env var overrides this in either
+            direction for A/B runs. The forward is identical either way, so
+            ``loss`` and ``lse`` are bitwise unchanged; only gradient rounding
+            differs, and it moves closer to a float32 reference.
+        bwd_batch_block_size: Batch tile for the fast backward only. ``None``
+            means "no batch tiling" (one GEMM per vocab block over the full batch),
+            which is fastest but has the largest peak memory.
+        bwd_v_block_size: Vocab tile for the fast backward only. ``None`` reuses the
+            forward's ``v_block_size``. The backward's optimal tile is typically
+            larger than the forward's, so this is worth tuning separately.
+    """
+    fast_backward = _resolve_fast_backward(fast_backward)
     if block_sizes is None:
         v_block_size = infer_xla_v_block_size(x.shape[0], x.shape[1], w.shape[1], dtype=dtype)
         b_block_size = _resolve_xla_batch_block_size(
@@ -492,6 +750,9 @@ def linear_softmax_cross_entropy_loss_xla(
         dtype,
         logit_soft_cap,
         precision,
+        bool(fast_backward),
+        bwd_batch_block_size,
+        bwd_v_block_size,
         x,
         labels,
         w,

--- a/lib/levanter/src/levanter/kernels/pallas/short_conv/__init__.py
+++ b/lib/levanter/src/levanter/kernels/pallas/short_conv/__init__.py
@@ -1,0 +1,19 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fused depthwise causal short convolution (SConv)."""
+
+from .api import DEFAULT_BATCH_AXES, Implementation, short_conv
+from .config import ShortConvBlockSizes
+from .pallas_gpu import expected_bytes_moved, pallas_short_conv_available
+from .reference import short_conv_reference
+
+__all__ = [
+    "DEFAULT_BATCH_AXES",
+    "Implementation",
+    "ShortConvBlockSizes",
+    "expected_bytes_moved",
+    "pallas_short_conv_available",
+    "short_conv",
+    "short_conv_reference",
+]

--- a/lib/levanter/src/levanter/kernels/pallas/short_conv/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/short_conv/api.py
@@ -11,17 +11,10 @@ from typing import Literal, TypeAlias
 
 import jax
 import jax.numpy as jnp
+from jax import shard_map
 from jax.sharding import PartitionSpec as P
 from jax.sharding import get_abstract_mesh, reshard
 from jaxtyping import Array, Float, Int
-
-# `jax.shard_map` is a function on the top-level namespace, not a module: `from
-# jax.shard_map import shard_map` raises ModuleNotFoundError and silently drops you onto
-# the deprecated `jax.experimental` one, which has no `check_vma` parameter.
-if hasattr(jax, "shard_map"):
-    shard_map = jax.shard_map
-else:  # pragma: no cover - older JAX
-    from jax.experimental.shard_map import shard_map  # type: ignore[assignment]
 
 from .config import ShortConvBlockSizes
 from .pallas_gpu import (
@@ -193,6 +186,7 @@ def _short_conv_pallas_sharded(
     def _local(weight_local, x_local, segment_ids_local):
         return call(weight_local, x_local, segment_ids_local)
 
+    # pyrefly: ignore[bad-argument-count]  # jax.shard_map decorator erases _local's real signature
     return _local(weight, x, segment_ids)
 
 
@@ -224,6 +218,15 @@ def short_conv(
         single fp32 accumulator across taps -- more accurate, not bit-comparable.
       batch_axes: mesh axes the batch is sharded over.
     """
+    if weight.dtype != x.dtype:
+        # The reference promotes mixed dtypes via standard JAX rules (fp32 for fp32 weight /
+        # bf16 x) while the Pallas kernel outputs x.dtype, so mixed inputs would give
+        # backend-dependent dtypes and values. Normalise at the boundary instead.
+        raise ValueError(
+            f"short_conv requires weight and x to share a dtype; got weight={weight.dtype}, "
+            f"x={x.dtype}. Cast to a common dtype before calling."
+        )
+
     block_sizes = block_sizes or ShortConvBlockSizes.get_default()
     requested = _as_sequence(implementation)
     explicit_single = isinstance(implementation, str)

--- a/lib/levanter/src/levanter/kernels/pallas/short_conv/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/short_conv/api.py
@@ -1,0 +1,264 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public API and backend selection for the depthwise causal short convolution."""
+
+import functools
+import logging
+import warnings
+from collections.abc import Sequence
+from typing import Literal, TypeAlias
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import PartitionSpec as P
+from jax.sharding import get_abstract_mesh, reshard
+from jaxtyping import Array, Float, Int
+
+# `jax.shard_map` is a function on the top-level namespace, not a module: `from
+# jax.shard_map import shard_map` raises ModuleNotFoundError and silently drops you onto
+# the deprecated `jax.experimental` one, which has no `check_vma` parameter.
+if hasattr(jax, "shard_map"):
+    shard_map = jax.shard_map
+else:  # pragma: no cover - older JAX
+    from jax.experimental.shard_map import shard_map  # type: ignore[assignment]
+
+from .config import ShortConvBlockSizes
+from .pallas_gpu import (
+    pallas_short_conv_available,
+    short_conv_pallas_bwd_local,
+    short_conv_pallas_fwd_local,
+    short_conv_shapes_supported,
+)
+from .reference import short_conv_reference
+
+logger = logging.getLogger(__name__)
+
+Implementation: TypeAlias = Literal["reference", "pallas_gpu"]
+
+#: Mesh axes the activation batch is sharded over in the grug MoE models. The kernel is
+#: shard-local along every one of them; the sequence and channel axes must stay whole.
+DEFAULT_BATCH_AXES: tuple[str, ...] = ("replica_dcn", "data", "expert")
+
+
+def _default_implementations() -> tuple[Implementation, ...]:
+    if pallas_short_conv_available():
+        return ("pallas_gpu", "reference")
+    return ("reference",)
+
+
+def _as_sequence(
+    implementation: Implementation | Sequence[Implementation] | None,
+) -> tuple[Implementation, ...]:
+    if implementation is None:
+        return _default_implementations()
+    if isinstance(implementation, str):
+        return (implementation,)  # explicit single choice: fail fast, never silently fall back
+    return tuple(implementation)
+
+
+def _active_batch_axes(mesh, batch_axes: Sequence[str]) -> tuple[str, ...]:
+    return tuple(axis for axis in batch_axes if axis in mesh.shape)
+
+
+def _mesh_sizes(mesh) -> dict[str, int]:
+    try:
+        return dict(mesh.shape)
+    except (AttributeError, TypeError):
+        return {}
+
+
+def _assert_local_axes(name: str, array: jax.Array, rank: int, mesh=None) -> None:
+    """Reject a sequence or channel axis that is *actually* sharded.
+
+    The caller reshards to ``P(active, None, None)`` immediately after this check, so the point is
+    not to reject a spec -- it is to refuse to paper over a real all-gather with a silent reshard.
+
+    A spec entry naming a mesh axis of size 1 shards nothing. That is not a corner case here: the
+    EP64 hero mesh is (replica_dcn=1, data=1, expert=64, model=1), and the attention projections
+    are ``P(_FSDP_AXES, "model")``, so every k/v activation carries "model" on its channel axis.
+    Rejecting on the name alone fails the hero while the reshard it is guarding is a no-op.
+    """
+    sharding = jax.typeof(array).sharding if isinstance(array, jax.core.Tracer) else array.sharding
+    spec = getattr(sharding, "spec", None)
+    if spec is None:
+        return
+    sizes = _mesh_sizes(mesh) if mesh is not None else {}
+    for axis in range(1, min(rank, len(spec))):
+        entry = spec[axis]
+        if entry is None:
+            continue
+        names = (entry,) if isinstance(entry, str) else tuple(entry)
+        if sizes and all(sizes.get(n, 1) == 1 for n in names):
+            continue
+        raise ValueError(
+            f"short_conv requires an unsharded {'sequence' if axis == 1 else 'channel'} axis "
+            f"for {name}; got {spec}."
+        )
+
+
+# --------------------------------------------------------------------------------------
+# custom_vjp around the Pallas kernels.
+#
+# JAX must never autodiff *through* a pallas_call, and -- much more to the point here --
+# we specifically do not want reverse-mode AD to invent the backward. The whole cost of
+# this op lives in the backward, so the backward is hand-written.
+# --------------------------------------------------------------------------------------
+
+
+@functools.partial(jax.custom_vjp, nondiff_argnums=(3, 4))
+def _short_conv_pallas_local(
+    weight: Float[Array, "W C"],
+    x: Float[Array, "B S C"],
+    segment_ids: Int[Array, "B S"],
+    block_sizes: ShortConvBlockSizes,
+    exact_reference_rounding: bool,
+) -> Float[Array, "B S C"]:
+    return short_conv_pallas_fwd_local(
+        weight,
+        x,
+        segment_ids,
+        block_sizes=block_sizes,
+        exact_reference_rounding=exact_reference_rounding,
+    )
+
+
+def _short_conv_pallas_local_fwd(weight, x, segment_ids, block_sizes, exact_reference_rounding):
+    out = short_conv_pallas_fwd_local(
+        weight,
+        x,
+        segment_ids,
+        block_sizes=block_sizes,
+        exact_reference_rounding=exact_reference_rounding,
+    )
+    # Residuals are the primal inputs only: `x` is needed for dw, `segment_ids` for both
+    # masks, `weight` for dx. Nothing shifted or masked is saved -- that is the 4.84 GB of
+    # fp32 scratch the XLA backward allocates and this one does not.
+    return out, (weight, x, segment_ids)
+
+
+def _short_conv_pallas_local_bwd(block_sizes, exact_reference_rounding, residuals, dy):
+    weight, x, segment_ids = residuals
+    dx, dw_partials = short_conv_pallas_bwd_local(
+        weight,
+        x,
+        segment_ids,
+        dy,
+        block_sizes=block_sizes,
+        exact_reference_rounding=exact_reference_rounding,
+    )
+    dw = jnp.sum(dw_partials, axis=0).astype(weight.dtype)
+    return dw, dx, None  # segment_ids is integer metadata: no cotangent
+
+
+_short_conv_pallas_local.defvjp(_short_conv_pallas_local_fwd, _short_conv_pallas_local_bwd)
+
+
+def _short_conv_pallas_sharded(
+    weight: Float[Array, "W C"],
+    x: Float[Array, "B S C"],
+    segment_ids: Int[Array, "B S"],
+    *,
+    block_sizes: ShortConvBlockSizes,
+    exact_reference_rounding: bool,
+    batch_axes: Sequence[str],
+) -> Float[Array, "B S C"]:
+    """Enter an explicit ``shard_map`` before touching the kernel.
+
+    The op is shard-local by construction (depthwise, causal along the sequence, no
+    cross-channel term), so the manual region needs no collectives at all. Making the
+    boundary explicit stops XLA inferring a sharding for an opaque call and is the house
+    rule for every Pallas/FFI kernel in this repo.
+    """
+    call = functools.partial(
+        _short_conv_pallas_local,
+        block_sizes=block_sizes,
+        exact_reference_rounding=exact_reference_rounding,
+    )
+
+    mesh = get_abstract_mesh()
+    if mesh is None or mesh.empty:
+        return call(weight, x, segment_ids)
+
+    active = _active_batch_axes(mesh, batch_axes)
+    if not active:
+        return call(weight, x, segment_ids)
+
+    _assert_local_axes("x", x, rank=3, mesh=mesh)
+    x = reshard(x, P(active, None, None))
+    segment_ids = reshard(segment_ids, P(active, None))
+    weight = reshard(weight, P(None, None))
+
+    @functools.partial(shard_map, mesh=mesh, out_specs=P(active, None, None), check_vma=False)
+    def _local(weight_local, x_local, segment_ids_local):
+        return call(weight_local, x_local, segment_ids_local)
+
+    return _local(weight, x, segment_ids)
+
+
+def short_conv(
+    weight: Float[Array, "W C"],
+    x: Float[Array, "B S C"],
+    segment_ids: Int[Array, "B S"] | None = None,
+    *,
+    implementation: Implementation | Sequence[Implementation] | None = None,
+    block_sizes: ShortConvBlockSizes | None = None,
+    exact_reference_rounding: bool = True,
+    batch_axes: Sequence[str] = DEFAULT_BATCH_AXES,
+) -> Float[Array, "B S C"]:
+    """Depthwise causal 1-D convolution over the sequence axis.
+
+    ``out[b,t,c] = sum_lag weight[lag,c] * x[b,t-lag,c]``, with taps that would reach into
+    a previous packed document dropped and positions before the sequence start read as
+    zero. Shard-local: no collectives, no cross-channel term.
+
+    Args:
+      weight: ``[kernel_size, channels]`` taps; ``weight[0]`` is the current token.
+      x: ``[batch, seq_len, channels]`` activations.
+      segment_ids: ``[batch, seq_len]`` packed-document ids, or None for an unpacked batch.
+      implementation: a single name (fail fast if unsupported) or an ordered sequence to
+        try in turn. Defaults to the Pallas kernel on GPU, the reference elsewhere.
+      block_sizes: GPU tile configuration.
+      exact_reference_rounding: keep the reference's per-op bf16 rounding, which makes the
+        forward and ``dx`` bit-identical to ``short_conv_reference``. Setting False keeps a
+        single fp32 accumulator across taps -- more accurate, not bit-comparable.
+      batch_axes: mesh axes the batch is sharded over.
+    """
+    block_sizes = block_sizes or ShortConvBlockSizes.get_default()
+    requested = _as_sequence(implementation)
+    explicit_single = isinstance(implementation, str)
+
+    errors: list[str] = []
+    for name in requested:
+        if name == "reference":
+            return short_conv_reference(weight, x, segment_ids)
+        if name != "pallas_gpu":
+            raise ValueError(f"Unknown short_conv implementation {name!r}")
+
+        reason = None
+        if not pallas_short_conv_available():
+            reason = "Pallas Triton backend unavailable or not running on a GPU"
+        else:
+            reason = short_conv_shapes_supported(weight.shape, x.shape, block_sizes)
+        if reason is not None:
+            if explicit_single:
+                raise RuntimeError(f"short_conv implementation 'pallas_gpu' is unusable: {reason}")
+            errors.append(f"pallas_gpu: {reason}")
+            warnings.warn(f"short_conv falling back from 'pallas_gpu' ({reason})", stacklevel=2)
+            continue
+
+        seg = segment_ids
+        if seg is None:
+            # One kernel handles both cases; a constant segment id makes every tap valid.
+            # [batch, seq_len] int32 is ~0.03% of the activation traffic at hero shape.
+            seg = jnp.zeros(x.shape[:2], jnp.int32)
+        return _short_conv_pallas_sharded(
+            weight,
+            x,
+            seg,
+            block_sizes=block_sizes,
+            exact_reference_rounding=exact_reference_rounding,
+            batch_axes=batch_axes,
+        )
+
+    raise RuntimeError("No usable short_conv implementation: " + "; ".join(errors))

--- a/lib/levanter/src/levanter/kernels/pallas/short_conv/config.py
+++ b/lib/levanter/src/levanter/kernels/pallas/short_conv/config.py
@@ -1,0 +1,49 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Block-size configuration for the fused short-convolution kernels."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ShortConvBlockSizes:
+    """Tile sizes for the GPU Pallas short-conv kernels.
+
+    ``s_block_size`` tiles the sequence axis and ``c_block_size`` the channel axis. Both
+    must be powers of two -- a Pallas Triton lowering constraint on tile shapes, not a
+    preference.
+
+    Defaults are the measured winner of a six-point sweep on one GB200 at the EP64 hero
+    per-layer shapes (65,536 tokens x {1536, 6144} channels, bf16, kernel 4):
+
+    ==========================  ==================  =================
+    tile (s, c, warps)          hero-scaled ms/step  vs reference
+    ==========================  ==================  =================
+    reference (pad-and-shift)               427.2   --
+    **64, 64, 4**                           **231.8**  **-195.4 ms**
+    32, 64, 4                               234.1   -193.1 ms
+    64, 128, 8                              237.8   -189.4 ms
+    32, 128, 4                              244.6   -182.5 ms
+    128, 64, 4                              244.9   -182.3 ms
+    64, 128, 4                              284.1   -143.0 ms
+    ==========================  ==================  =================
+
+    The gradient is shallow across the good configs and steeply bad above ``c_block_size``
+    128 with large ``s_block_size`` (256x256 was 19x slower than the reference): each
+    program holds up to ``kernel_size`` live ``[s, c]`` tiles plus an fp32 accumulator, so
+    big tiles spill and occupancy collapses. Small tiles win because the kernel is
+    bandwidth-bound and wants occupancy, not reuse.
+    """
+
+    s_block_size: int = 64
+    c_block_size: int = 64
+    num_warps: int = 4
+    num_stages: int = 2
+
+    @classmethod
+    def get_default(cls) -> "ShortConvBlockSizes":
+        return cls()
+
+    def as_key(self) -> str:
+        return f"s{self.s_block_size}_c{self.c_block_size}_w{self.num_warps}_st{self.num_stages}"

--- a/lib/levanter/src/levanter/kernels/pallas/short_conv/pallas_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/short_conv/pallas_gpu.py
@@ -1,0 +1,506 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fused depthwise causal short convolution (SConv) as a Pallas GPU kernel.
+
+Why this exists
+---------------
+The op is depthwise with ``kernel_size=4``: 8 FLOP per element against a 4-byte floor of
+traffic, an arithmetic intensity of **2.0 FLOP/byte** against a GB200 ridge of ~312. It is
+bandwidth-bound by ~156x, so the *only* lever is how many times the tensor crosses HBM.
+The floor is 2 passes forward (read x, write y) and 3 passes backward (read x, read dy,
+write dx).
+
+The pad-and-shift reference (``reference.py``) does not sit at that floor, but **not for
+the reason you would guess, and not for the reason CPU HLO suggests.** Compiled for CPU,
+its VJP materialises four full-size fp32 copies of ``dy * mask * shift(x)`` and reduces
+each with a separate ``reduce-window``, needing 4.84 GB of scratch at the hero per-layer
+shape. **None of that happens on GPU.** XLA:GPU fuses those reductions into their
+producers: the compiled GPU HLO has one fusion and two full-size buffers in the forward,
+five fusions and three full-size buffers in the VJP, and 13 MB of temp. Do not repeat the
+CPU-HLO story; it is a backend artifact.
+
+The real cost is **repeated traversal**, measured on one GB200 at the hero per-layer shape
+against a read-one-write-one stream calibrated on the same tensor:
+
+=========================  ===============  ===============
+                           forward          backward
+=========================  ===============  ===============
+floor                      2.0 passes       3.0 passes
+pad-and-shift reference    4.5 passes       14.3 passes
+this kernel                3.0 passes        6.7 passes
+=========================  ===============  ===============
+
+Each tap is a separate offset read of the whole tensor that the cache does not fully
+absorb, and the reference's VJP additionally launches five fusions that each re-read their
+inputs. The kernel collapses those to one launch per direction, so the forward drops from
+0.811 ms to 0.547 ms and the backward from 2.558 ms to 1.200 ms at C=6144 -- 1.5x and 2.1x.
+The residual gap to the floor is the same offset-read problem: Pallas Triton cannot slice
+a register tile (no ``lax.slice`` lowering) and requires power-of-2 tile shapes, so the
+kernel still issues ``W`` overlapping loads per tile rather than loading once and shifting
+in registers the way ``Dao-AILab/causal-conv1d`` does with an SMEM ring carry.
+
+Closing that last gap needs a register/SMEM carry, which needs CUDA or a Mosaic backend
+that lowers here. Neither is available today; see "Backend" below.
+
+``dw`` never touches HBM as a full-size tensor. It is accumulated in fp32 registers per
+program and emitted as a ``[batch * num_s_blocks, W, C]`` partial that a cheap outer
+``sum(0)`` folds down -- the deterministic reduction that FLA's Triton conv uses, rather
+than ``atomicAdd``. It costs ``2 * W * 4 / (s_block_size * itemsize)`` of a pass (3% at the
+default tile) and is bit-reproducible run to run.
+
+Backend
+-------
+**Pallas Triton, not Mosaic GPU.** The repo's kernel skill prefers Mosaic for new GPU
+kernels; measured on GB200/SM100 with JAX 0.11, Mosaic's layout inference fails on this
+kernel and on a trivial ``o = w * x`` body alike ("Layout inference failed to find a
+solution"). Triton lowers both. Revisit when Mosaic's layout inference improves.
+
+Triton imposes one hard constraint that shapes the whole design: **every intermediate tile
+must have a power-of-2 shape.** Arbitrary *offsets* are fine; only *sizes* are
+constrained. That rules out the obvious halo construction -- concatenating the ``lag``
+rows carried over from the previous block onto this block's first ``BS-lag`` rows -- since
+``BS-lag`` is never a power of two. Confirmed on hardware: it fails with "Encountered an
+array of shape (127, 128)".
+
+Halo handling
+-------------
+So every shifted tile is a single ``pl.ds(start, BS)`` read at an arbitrary offset out of a
+whole-sequence window. That is exact and power-of-2 for every block except the ones at the
+ends of the sequence, where ``start`` would run off the array. Rather than rely on an
+out-of-bounds read being masked -- which happens to work on Triton but is *wrong* under
+Pallas's own interpreter, where the clamp silently misaligns the tile and would make the
+CPU tests disagree with the GPU -- the kernel takes a small pre-padded **head block**
+(``[B, BS+W-1, C]``: ``W-1`` zero rows then the first ``BS`` rows of ``x``) and, in the
+backward, a matching **tail block** for the anti-causal direction. ``pl.when`` routes the
+edge programs to them. Building both touches ``~2*BS/S`` of the tensor, under 7% of a
+pass, and every read in the kernel is then unconditionally in bounds.
+
+Numerics
+--------
+``exact_reference_rounding=True`` (the default) reproduces the reference's rounding
+*operation for operation*: every multiply and every accumulate rounds to the activation
+dtype, in the reference's association order. That order is not cosmetic -- the forward is
+left-nested over ascending lags, and JAX transposes it by walking the jaxpr in reverse, so
+``dx`` accumulates over *descending* lags. Matching both makes the forward and ``dx``
+bit-identical to the reference. ``dw`` is a reduction over 65,536 tokens whose association
+order XLA does not define, so it agrees to fp32 reassociation error and is validated
+against a float64 oracle instead. Setting the flag to ``False`` keeps a single fp32
+accumulator across taps: strictly more accurate, no longer bit-comparable.
+"""
+
+import contextlib
+import functools
+import math
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jaxtyping import Array, Float, Int
+
+from levanter.kernels.pallas.cost_estimate_utils import with_io_bytes_accessed
+
+from .config import ShortConvBlockSizes
+from .reference import short_conv_reference
+
+try:  # pragma: no cover - import guard, exercised only by environment
+    from jax.experimental.pallas import triton as pltriton
+
+    _HAS_PALLAS_TRITON = True
+except (ImportError, ModuleNotFoundError):  # pragma: no cover
+    pltriton = None  # type: ignore[assignment]
+    _HAS_PALLAS_TRITON = False
+
+#: Sentinel written into the shifted segment ids for positions outside the sequence.
+#: `jnp.pad(segment_ids, ..., constant_values=-1)` in the reference; matching it exactly is
+#: what makes the first `kernel_size - 1` positions of every sequence agree.
+_OOB_SEGMENT = -1
+
+_FORCE_INTERPRET = False
+
+
+@contextlib.contextmanager
+def interpret_mode():
+    """Run the kernels through Pallas's reference interpreter.
+
+    This is the only way these kernels get CPU coverage: a Pallas GPU kernel cannot execute
+    on CPU, but the interpreter executes the *kernel body* -- grid, block specs, head/tail
+    routing, register accumulation and all -- with plain XLA ops. It exercises the real
+    algorithm, not a paraphrase. It says nothing about whether the kernel *lowers* on a
+    given GPU architecture; that needs a GPU.
+    """
+    global _FORCE_INTERPRET
+    previous = _FORCE_INTERPRET
+    _FORCE_INTERPRET = True
+    try:
+        yield
+    finally:
+        _FORCE_INTERPRET = previous
+
+
+def pallas_short_conv_available() -> bool:
+    """True when the Pallas Triton backend imported and we are on a GPU."""
+    if _FORCE_INTERPRET:
+        return True
+    return _HAS_PALLAS_TRITON and jax.default_backend() == "gpu"
+
+
+def _is_pow2(value: int) -> bool:
+    return value > 0 and (value & (value - 1)) == 0
+
+
+def short_conv_shapes_supported(
+    weight_shape: tuple[int, ...],
+    x_shape: tuple[int, ...],
+    block_sizes: ShortConvBlockSizes,
+) -> str | None:
+    """Returns None when the kernel can run these shapes, else a human-readable reason."""
+    if len(x_shape) != 3 or len(weight_shape) != 2:
+        return f"expected weight [W, C] and x [B, S, C], got {weight_shape} and {x_shape}"
+    width, weight_channels = weight_shape
+    _, seq_len, channels = x_shape
+    if weight_channels != channels:
+        return f"weight channel dim {weight_channels} != x channel dim {channels}"
+    if width < 1:
+        return f"kernel_size must be >= 1, got {width}"
+    bs, bc = block_sizes.s_block_size, block_sizes.c_block_size
+    if seq_len % bs:
+        return f"seq_len {seq_len} not divisible by s_block_size {bs}"
+    if channels % bc:
+        return f"channels {channels} not divisible by c_block_size {bc}"
+    # Pallas Triton requires power-of-2 tile shapes; every read in the kernel is [bs, bc].
+    if not _is_pow2(bs):
+        return f"s_block_size {bs} must be a power of 2 (Pallas Triton tile constraint)"
+    if not _is_pow2(bc):
+        return f"c_block_size {bc} must be a power of 2 (Pallas Triton tile constraint)"
+    if bs < width - 1:
+        return f"s_block_size {bs} must be >= kernel_size - 1 = {width - 1}"
+    return None
+
+
+def _mul_round(weight_row: jax.Array, tile: jax.Array, dtype, exact: bool) -> jax.Array:
+    """``weight_row[None, :] * tile`` with the reference's rounding."""
+    product = weight_row[None, :].astype(jnp.float32) * tile.astype(jnp.float32)
+    return product.astype(dtype) if exact else product
+
+
+def _add_round(acc, term, dtype, exact: bool) -> jax.Array:
+    if acc is None:
+        return term
+    total = acc.astype(jnp.float32) + term.astype(jnp.float32)
+    return total.astype(dtype) if exact else total
+
+
+def _keep(seg_shifted: jax.Array, seg_cur: jax.Array, tile: jax.Array) -> jax.Array:
+    return jnp.where((seg_shifted == seg_cur)[:, None], tile, jnp.zeros_like(tile))
+
+
+# --------------------------------------------------------------------------------------
+# Forward
+# --------------------------------------------------------------------------------------
+
+
+def _fwd_body(
+    vals_ref, segs_ref, w_ref, out_ref, base: int | jax.Array, block_seq: int, kernel_size: int, exact: bool
+) -> None:
+    """One block's forward, reading taps at ``base - lag`` out of ``vals_ref``.
+
+    ``base`` is the row in ``vals_ref`` corresponding to this block's first output row, so
+    the general path passes ``si * BS`` into the whole-sequence view and the first-block
+    path passes ``W - 1`` into the pre-padded head view. Both then read identically.
+    """
+    seg_cur = segs_ref[0, pl.ds(base, block_seq)]
+    tile = vals_ref[0, pl.ds(base, block_seq), :]
+    dtype = tile.dtype
+    # Ascending lags, left-nested, rounding after every op: the reference's exact order.
+    acc = _mul_round(w_ref[0], tile, dtype, exact)
+    for lag in range(1, kernel_size):
+        shifted = vals_ref[0, pl.ds(base - lag, block_seq), :]
+        seg_shifted = segs_ref[0, pl.ds(base - lag, block_seq)]
+        shifted = _keep(seg_shifted, seg_cur, shifted)
+        acc = _add_round(acc, _mul_round(w_ref[lag], shifted, dtype, exact), dtype, exact)
+    out_ref[0] = acc.astype(dtype)
+
+
+def _fwd_kernel(x_ref, xh_ref, seg_ref, segh_ref, w_ref, out_ref, *, kernel_size: int, exact: bool):
+    block_seq = out_ref.shape[1]
+    si = pl.program_id(1)
+
+    @pl.when(si == 0)
+    def _first():
+        _fwd_body(xh_ref, segh_ref, w_ref, out_ref, kernel_size - 1, block_seq, kernel_size, exact)
+
+    @pl.when(si != 0)
+    def _general():
+        _fwd_body(x_ref, seg_ref, w_ref, out_ref, si * block_seq, block_seq, kernel_size, exact)
+
+
+# --------------------------------------------------------------------------------------
+# Backward
+# --------------------------------------------------------------------------------------
+
+
+def _dx_body(dy_ref, segs_ref, w_ref, dx_ref, base, block_seq: int, kernel_size: int, exact: bool) -> None:
+    """``dx[t] = sum_lag w[lag] * [seg[t] == seg[t+lag]] * dy[t+lag]``.
+
+    Descending lags then tap 0, because that is the order JAX's transpose of the forward
+    produces and matching it is what makes ``dx`` bit-identical rather than merely close.
+    """
+    seg_cur = segs_ref[0, pl.ds(base, block_seq)]
+    dy = dy_ref[0, pl.ds(base, block_seq), :]
+    dtype = dy.dtype
+    acc = None
+    for lag in range(kernel_size - 1, 0, -1):
+        dy_ahead = dy_ref[0, pl.ds(base + lag, block_seq), :]
+        seg_ahead = segs_ref[0, pl.ds(base + lag, block_seq)]
+        term = _mul_round(w_ref[lag], dy_ahead, dtype, exact)
+        acc = _add_round(acc, _keep(seg_ahead, seg_cur, term), dtype, exact)
+    dx_ref[0] = _add_round(acc, _mul_round(w_ref[0], dy, dtype, exact), dtype, exact).astype(dtype)
+
+
+def _dw_body(x_ref, segs_ref, dy, dw_ref, base, block_seq: int, kernel_size: int) -> None:
+    """``dw[lag] = sum_t dy[t] * [seg[t-lag] == seg[t]] * x[t-lag]``, fp32, in registers.
+
+    The shifted-``x`` construction is the forward's, so the mask semantics are shared by
+    construction rather than by a comment asking you to keep them in sync.
+    """
+    seg_cur = segs_ref[0, pl.ds(base, block_seq)]
+    dy_f32 = dy.astype(jnp.float32)
+    for lag in range(kernel_size):
+        shifted = x_ref[0, pl.ds(base - lag, block_seq), :]
+        if lag:
+            shifted = _keep(segs_ref[0, pl.ds(base - lag, block_seq)], seg_cur, shifted)
+        partial = jnp.sum(dy_f32 * shifted.astype(jnp.float32), axis=0)
+        # Store per tap rather than stacking: Triton's `stack` lowering takes exactly two
+        # operands, and a W-way stack would build non-power-of-2 intermediates anyway.
+        dw_ref[0, pl.ds(lag, 1), :] = partial[None, :]
+
+
+def _bwd_kernel(
+    x_ref,
+    xh_ref,
+    seg_ref,
+    segh_ref,
+    dy_ref,
+    dyt_ref,
+    segt_ref,
+    w_ref,
+    dx_ref,
+    dw_partial_ref,
+    *,
+    kernel_size: int,
+    exact: bool,
+):
+    block_seq = dx_ref.shape[1]
+    si = pl.program_id(1)
+    last = pl.num_programs(1) - 1
+
+    # dx reads dy *ahead* of this block, so only the final block needs the tail view.
+    @pl.when(si != last)
+    def _dx_general():
+        _dx_body(dy_ref, seg_ref, w_ref, dx_ref, si * block_seq, block_seq, kernel_size, exact)
+
+    @pl.when(si == last)
+    def _dx_last():
+        _dx_body(dyt_ref, segt_ref, w_ref, dx_ref, 0, block_seq, kernel_size, exact)
+
+    # dw reads x *behind* this block, so only the first block needs the head view.
+    @pl.when(si != 0)
+    def _dw_general():
+        _dw_body(
+            x_ref,
+            seg_ref,
+            dy_ref[0, pl.ds(si * block_seq, block_seq), :],
+            dw_partial_ref,
+            si * block_seq,
+            block_seq,
+            kernel_size,
+        )
+
+    @pl.when(si == 0)
+    def _dw_first():
+        _dw_body(
+            xh_ref,
+            segh_ref,
+            dy_ref[0, pl.ds(0, block_seq), :],
+            dw_partial_ref,
+            kernel_size - 1,
+            block_seq,
+            kernel_size,
+        )
+
+
+# --------------------------------------------------------------------------------------
+# Edge views, wrappers
+# --------------------------------------------------------------------------------------
+
+
+def _head_views(x, segment_ids, block_seq: int, width: int):
+    """``[B, BS+W-1, C]`` / ``[B, BS+W-1]``: ``W-1`` pad rows then the first ``BS`` rows.
+
+    Exactly what ``jnp.pad(x, ((0,0),(W-1,0),(0,0)))`` would give for those rows, so the
+    first-block path is the reference's semantics with no special casing inside the kernel.
+    """
+    pad_vals = jnp.zeros((x.shape[0], width - 1, x.shape[2]), x.dtype)
+    pad_segs = jnp.full((segment_ids.shape[0], width - 1), _OOB_SEGMENT, segment_ids.dtype)
+    return (
+        jnp.concatenate([pad_vals, x[:, :block_seq, :]], axis=1),
+        jnp.concatenate([pad_segs, segment_ids[:, :block_seq]], axis=1),
+    )
+
+
+def _tail_views(dy, segment_ids, block_seq: int, width: int):
+    """``[B, BS+W-1, C]`` / ``[B, BS+W-1]``: the last ``BS`` rows then ``W-1`` pad rows.
+
+    The anti-causal mirror of ``_head_views``. Positions past the end contribute nothing to
+    ``dx``, so the pad value is zero and its segment id can never match.
+    """
+    pad_vals = jnp.zeros((dy.shape[0], width - 1, dy.shape[2]), dy.dtype)
+    pad_segs = jnp.full((segment_ids.shape[0], width - 1), _OOB_SEGMENT, segment_ids.dtype)
+    return (
+        jnp.concatenate([dy[:, -block_seq:, :], pad_vals], axis=1),
+        jnp.concatenate([segment_ids[:, -block_seq:], pad_segs], axis=1),
+    )
+
+
+def _compiler_params(block_sizes: ShortConvBlockSizes):
+    if pltriton is None or _FORCE_INTERPRET:  # pragma: no cover
+        return None
+    return pltriton.CompilerParams(num_warps=block_sizes.num_warps, num_stages=block_sizes.num_stages)
+
+
+def _cost_estimate(body, primals, kernel_inputs_specs, kernel_outputs_specs):
+    return with_io_bytes_accessed(
+        pl.estimate_cost(body, *primals),
+        kernel_inputs_specs=kernel_inputs_specs,
+        kernel_outputs_specs=kernel_outputs_specs,
+    )
+
+
+def short_conv_pallas_fwd_local(
+    weight: Float[Array, "W C"],
+    x: Float[Array, "B S C"],
+    segment_ids: Int[Array, "B S"],
+    *,
+    block_sizes: ShortConvBlockSizes,
+    exact_reference_rounding: bool,
+) -> Float[Array, "B S C"]:
+    """Shard-local fused forward. Callers must have already entered a ``shard_map``."""
+    batch, seq_len, channels = x.shape
+    width = weight.shape[0]
+    bs, bc = block_sizes.s_block_size, block_sizes.c_block_size
+    num_s, num_c = seq_len // bs, channels // bc
+    x_head, seg_head = _head_views(x, segment_ids, bs, width)
+
+    whole = lambda b, si, ci: (b, 0, ci)  # noqa: E731 - whole-sequence pointer window
+    whole_1d = lambda b, si, ci: (b, 0)  # noqa: E731
+    out_shape = jax.ShapeDtypeStruct((batch, seq_len, channels), x.dtype)
+
+    call = pl.pallas_call(
+        functools.partial(_fwd_kernel, kernel_size=width, exact=exact_reference_rounding),
+        out_shape=out_shape,
+        grid=(batch, num_s, num_c),
+        in_specs=[
+            pl.BlockSpec((1, seq_len, bc), whole),
+            pl.BlockSpec((1, bs + width - 1, bc), whole),
+            pl.BlockSpec((1, seq_len), whole_1d),
+            pl.BlockSpec((1, bs + width - 1), whole_1d),
+            pl.BlockSpec((width, bc), lambda b, si, ci: (0, ci)),
+        ],
+        out_specs=pl.BlockSpec((1, bs, bc), lambda b, si, ci: (b, si, ci)),
+        compiler_params=_compiler_params(block_sizes),
+        interpret=_FORCE_INTERPRET,
+        cost_estimate=_cost_estimate(
+            short_conv_reference,
+            (weight, x, segment_ids),
+            # The head view is under 4% of `x` and every window aliases the same buffers, so
+            # modelling traffic as one read of x plus one write of the output is honest.
+            kernel_inputs_specs=(weight, x, segment_ids),
+            kernel_outputs_specs=(out_shape,),
+        ),
+        name="short_conv_fwd",
+    )
+    return call(x, x_head, segment_ids, seg_head, weight)
+
+
+def short_conv_pallas_bwd_local(
+    weight: Float[Array, "W C"],
+    x: Float[Array, "B S C"],
+    segment_ids: Int[Array, "B S"],
+    dy: Float[Array, "B S C"],
+    *,
+    block_sizes: ShortConvBlockSizes,
+    exact_reference_rounding: bool,
+) -> tuple[Float[Array, "B S C"], Float[Array, "P W C"]]:
+    """Shard-local fused backward. Returns ``(dx, dw_partials)``.
+
+    ``dw_partials`` is ``[batch * num_s_blocks, W, C]`` fp32; the caller sums axis 0.
+    Keeping that reduction outside the kernel is what makes ``dw`` deterministic, and
+    because the leading axis stays batch-major it lets XLA fold the cross-shard reduction
+    into the gradient collective it was going to issue anyway.
+    """
+    batch, seq_len, channels = x.shape
+    width = weight.shape[0]
+    bs, bc = block_sizes.s_block_size, block_sizes.c_block_size
+    num_s, num_c = seq_len // bs, channels // bc
+    x_head, seg_head = _head_views(x, segment_ids, bs, width)
+    dy_tail, seg_tail = _tail_views(dy, segment_ids, bs, width)
+
+    whole = lambda b, si, ci: (b, 0, ci)  # noqa: E731
+    whole_1d = lambda b, si, ci: (b, 0)  # noqa: E731
+    dx_shape = jax.ShapeDtypeStruct((batch, seq_len, channels), dy.dtype)
+    dw_shape = jax.ShapeDtypeStruct((batch * num_s, width, channels), jnp.float32)
+
+    def _vjp_body(w, x_, seg):
+        _, vjp = jax.vjp(lambda a, b: short_conv_reference(a, b, seg), w, x_)
+        return vjp(x_)
+
+    call = pl.pallas_call(
+        functools.partial(_bwd_kernel, kernel_size=width, exact=exact_reference_rounding),
+        out_shape=[dx_shape, dw_shape],
+        grid=(batch, num_s, num_c),
+        in_specs=[
+            pl.BlockSpec((1, seq_len, bc), whole),
+            pl.BlockSpec((1, bs + width - 1, bc), whole),
+            pl.BlockSpec((1, seq_len), whole_1d),
+            pl.BlockSpec((1, bs + width - 1), whole_1d),
+            pl.BlockSpec((1, seq_len, bc), whole),
+            pl.BlockSpec((1, bs + width - 1, bc), whole),
+            pl.BlockSpec((1, bs + width - 1), whole_1d),
+            pl.BlockSpec((width, bc), lambda b, si, ci: (0, ci)),
+        ],
+        out_specs=[
+            pl.BlockSpec((1, bs, bc), lambda b, si, ci: (b, si, ci)),
+            pl.BlockSpec((1, width, bc), lambda b, si, ci: (b * num_s + si, 0, ci)),
+        ],
+        compiler_params=_compiler_params(block_sizes),
+        interpret=_FORCE_INTERPRET,
+        cost_estimate=_cost_estimate(
+            _vjp_body,
+            (weight, x, segment_ids),
+            kernel_inputs_specs=(weight, x, segment_ids, dy),
+            kernel_outputs_specs=(dx_shape, dw_shape),
+        ),
+        name="short_conv_bwd",
+    )
+    dx, dw_partials = call(x, x_head, segment_ids, seg_head, dy, dy_tail, seg_tail, weight)
+    return dx, dw_partials
+
+
+def expected_bytes_moved(x_shape: tuple[int, ...], itemsize: int, width: int, block_sizes) -> dict[str, float]:
+    """Traffic model for the fused kernels, in bytes. Feeds the benchmark's GB/s column.
+
+    Forward: read ``x``, write ``y``, plus the head view (built and read once).
+    Backward: read ``x``, read ``dy``, write ``dx``, plus head and tail views, plus the
+    ``dw`` partials written by the kernel and read by the outer ``sum(0)``.
+    """
+    elements = math.prod(x_shape)
+    tensor = elements * itemsize
+    seq_len = x_shape[1]
+    bs = block_sizes.s_block_size
+    edge = 2.0 * (bs + width - 1) / seq_len  # build (read+write) one BS-row edge view
+    dw_partial = 2.0 * elements * width * 4 / (bs * itemsize) / tensor
+    return {
+        "forward": tensor * (2.0 + edge),
+        "backward": tensor * (3.0 + 2.0 * edge + dw_partial),
+    }

--- a/lib/levanter/src/levanter/kernels/pallas/short_conv/reference.py
+++ b/lib/levanter/src/levanter/kernels/pallas/short_conv/reference.py
@@ -1,0 +1,39 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Readable vanilla-JAX oracle for the depthwise causal short convolution (SConv).
+
+This is a verbatim copy of the pad-and-shift body that ``experiments/grug/*/model.py``
+``ShortConv.__call__`` has always used. It is the correctness oracle *and* the
+performance baseline: every other implementation must reproduce it bit for bit on the
+forward pass, and every benchmark reports against its timings.
+
+Do not "clean this up". Its exact op sequence -- ``pad`` then ``slice``, a ``where``
+against the shifted ``segment_ids``, a bf16-rounded multiply, a bf16-rounded add, in
+lag order -- fixes the rounding that the fused kernel is required to match.
+"""
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float, Int
+
+
+def short_conv_reference(
+    weight: Float[Array, "W C"],
+    x: Float[Array, "B S C"],
+    segment_ids: Int[Array, "B S"] | None = None,
+) -> Float[Array, "B S C"]:
+    """``out[b,t,c] = sum_lag weight[lag,c] * x[b,t-lag,c]``, zeroed across segments.
+
+    A tap that reaches into a previous document is dropped (the shifted ``segment_ids``
+    no longer match); the lag-0 (current token) tap is always kept. Positions before the
+    start of the sequence read as zero.
+    """
+    seq_len = x.shape[1]
+    out = weight[0] * x
+    for lag in range(1, weight.shape[0]):
+        shifted = jnp.pad(x, ((0, 0), (lag, 0), (0, 0)))[:, :seq_len, :]
+        if segment_ids is not None:
+            seg_shifted = jnp.pad(segment_ids, ((0, 0), (lag, 0)), constant_values=-1)[:, :seq_len]
+            shifted = jnp.where((seg_shifted == segment_ids)[..., None], shifted, 0.0)
+        out = out + weight[lag] * shifted
+    return out

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -2388,20 +2388,36 @@ def test_xla_fast_backward_env_var_overrides_call_site_in_both_directions(monkey
     monkeypatch.setenv(fused_xla._FAST_BWD_ENV_VAR, "0")
     assert fused_xla._resolve_fast_backward(None) is False
     assert fused_xla._resolve_fast_backward(True) is False
-    # Unrecognised values are ignored rather than silently flipping a hero run.
-    monkeypatch.setenv(fused_xla._FAST_BWD_ENV_VAR, "maybe")
-    assert fused_xla._resolve_fast_backward(True) is True
-    assert fused_xla._resolve_fast_backward(None) is False
+    # A set-but-unrecognised value raises rather than silently falling through to the
+    # call-site default -- a typo in the kill switch must not leave the hero on the new
+    # gradient path when the operator meant to disable it.
+    monkeypatch.setenv(fused_xla._FAST_BWD_ENV_VAR, "fasle")
+    with pytest.raises(ValueError, match="not a recognised boolean"):
+        fused_xla._resolve_fast_backward(True)
+    with pytest.raises(ValueError, match="not a recognised boolean"):
+        fused_xla._resolve_fast_backward(None)
 
 
-def test_xla_fast_bwd_implementation_is_registered_and_opt_in():
+def test_xla_fast_bwd_implementation_is_registered_and_opt_in(monkeypatch):
     """`xla_fast_bwd` must exist, be explicit-only, and leave `xla` untouched."""
+    monkeypatch.delenv(fused_xla._FAST_BWD_ENV_VAR, raising=False)
     assert "xla_fast_bwd" in fused_api.IMPLEMENTATIONS
-    # Never auto-selected: only an explicit implementation= picks it up.
-    assert "xla_fast_bwd" not in fused_api._DEFAULT_IMPLEMENTATION
-    assert "xla_fast_bwd" not in fused_api._CANONICAL_BACKEND_IMPLEMENTATIONS
     # The plain "xla" entry must still be the unmodified function.
     assert fused_api.IMPLEMENTATIONS["xla"] is fused_xla.linear_softmax_cross_entropy_loss_xla
+
+    # Never auto-selected: with no implementation= the default path is the old scatter
+    # backward, so the new (scatter-free) gradient is not silently in force.
+    x, w, _ = _fast_bwd_case(jnp.bfloat16, b=256, h=64, v=300, b_block=64, v_block=128)
+    labels = jnp.zeros((256,), dtype=jnp.int32)
+
+    def objective(x_arg, w_arg):
+        loss = fused_api.fused_cross_entropy_loss_and_logsumexp_penalty(
+            x_arg, labels, w_arg, reduction="mean", logsumexp_weight=None, dtype=jnp.float32
+        )
+        return jnp.sum(loss)
+
+    default_text = jax.jit(jax.grad(objective, argnums=(0, 1))).lower(x, w).as_text()
+    assert "stablehlo.scatter" in default_text
 
 
 def test_xla_fast_bwd_implementation_matches_xla_forward_and_fast_backward(monkeypatch):
@@ -2446,8 +2462,8 @@ def test_xla_fast_bwd_implementation_matches_xla_forward_and_fast_backward(monke
     assert "stablehlo.scatter" in make("xla").lower(x, w).as_text()
 
 
-def test_xla_fast_backward_emits_no_scatter_and_one_loop():
-    """Structural gate: the fast backward must not regress to a scatter or a nested loop."""
+def test_xla_fast_backward_emits_no_scatter():
+    """Structural gate: the fast backward must not regress to a scatter or upcast its GEMMs."""
     x, w, _ = _fast_bwd_case(jnp.bfloat16, b=256, h=64, v=300, b_block=64, v_block=128)
     labels = jnp.zeros((256,), dtype=jnp.int32)
 
@@ -2464,8 +2480,8 @@ def test_xla_fast_backward_emits_no_scatter_and_one_loop():
         return jnp.sum(loss)
 
     text = jax.jit(jax.grad(objective, argnums=(0, 1))).lower(x, w).as_text()
+    # The one-hot rewrite must not regress to a scatter; this is a stable semantic
+    # distinction (unlike an exact loop count, which pins the forward's lowering).
     assert "stablehlo.scatter" not in text
-    # 2 while loops for the (unchanged) forward, 1 scan for the backward.
-    assert text.count("stablehlo.while") == 3
     # Both backward GEMMs must stay on bf16 operands (tensor cores), not upcast to f32.
     assert "tensor<256x128xf32>, tensor<64x128xf32>" not in text

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -213,6 +213,9 @@ def test_xla_streaming_custom_vjp_grad_matches_streaming_autodiff():
             jnp.float32,
             logit_soft_cap,
             None,
+            False,
+            None,
+            None,
             x_raw.reshape(6, 4),
             y.reshape(6),
             w_raw,
@@ -334,6 +337,9 @@ def test_xla_streaming_custom_vjp_grad_matches_streaming_autodiff_with_batch_blo
             jnp.float32,
             logit_soft_cap,
             None,
+            False,
+            None,
+            None,
             x_raw,
             y,
             w_raw,
@@ -366,8 +372,21 @@ def test_fused_cross_entropy_xla_uses_explicit_batch_block_size(monkeypatch: pyt
 
     monkeypatch.setattr(fused_xla, "infer_xla_b_block_size", lambda b, v_block_size: 6)
 
-    def fake_custom_vjp(block_size, batch_block_size, dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg):
-        del dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg
+    def fake_custom_vjp(
+        block_size,
+        batch_block_size,
+        dtype,
+        logit_soft_cap,
+        precision,
+        fast_backward,
+        bwd_batch_block_size,
+        bwd_v_block_size,
+        x_arg,
+        labels_arg,
+        w_arg,
+    ):
+        del dtype, logit_soft_cap, precision, fast_backward, bwd_batch_block_size, bwd_v_block_size
+        del x_arg, labels_arg, w_arg
         captured["block_size"] = block_size
         captured["batch_block_size"] = batch_block_size
         return jnp.zeros((6,), dtype=jnp.float32), jnp.zeros((6,), dtype=jnp.float32)
@@ -395,8 +414,21 @@ def test_fused_cross_entropy_xla_caps_requested_batch_block_size_to_legal_diviso
 
     monkeypatch.setattr(fused_xla, "infer_xla_b_block_size", lambda b, v_block_size: 6)
 
-    def fake_custom_vjp(block_size, batch_block_size, dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg):
-        del dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg
+    def fake_custom_vjp(
+        block_size,
+        batch_block_size,
+        dtype,
+        logit_soft_cap,
+        precision,
+        fast_backward,
+        bwd_batch_block_size,
+        bwd_v_block_size,
+        x_arg,
+        labels_arg,
+        w_arg,
+    ):
+        del dtype, logit_soft_cap, precision, fast_backward, bwd_batch_block_size, bwd_v_block_size
+        del x_arg, labels_arg, w_arg
         captured["block_size"] = block_size
         captured["batch_block_size"] = batch_block_size
         return jnp.zeros((6,), dtype=jnp.float32), jnp.zeros((6,), dtype=jnp.float32)
@@ -430,8 +462,21 @@ def test_fused_cross_entropy_xla_infer_uses_tuned_batch_block_size_when_availabl
         lambda *args, **kwargs: (fused_api.BlockSizes(b_block_size=3, h_block_size=4, v_block_size=8), True),
     )
 
-    def fake_custom_vjp(block_size, batch_block_size, dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg):
-        del dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg
+    def fake_custom_vjp(
+        block_size,
+        batch_block_size,
+        dtype,
+        logit_soft_cap,
+        precision,
+        fast_backward,
+        bwd_batch_block_size,
+        bwd_v_block_size,
+        x_arg,
+        labels_arg,
+        w_arg,
+    ):
+        del dtype, logit_soft_cap, precision, fast_backward, bwd_batch_block_size, bwd_v_block_size
+        del x_arg, labels_arg, w_arg
         captured["block_size"] = block_size
         captured["batch_block_size"] = batch_block_size
         return jnp.zeros((6,), dtype=jnp.float32), jnp.zeros((6,), dtype=jnp.float32)
@@ -1317,7 +1362,7 @@ def test_pallas_tpu_vmem_compile_error_falls_back_to_xla_when_requested(monkeypa
     called = {"pallas": 0, "xla": 0}
     inferred = fused_api.BlockSizes(b_block_size=128, h_block_size=128, v_block_size=128)
     vmem_error = RuntimeError(
-        "RESOURCE_EXHAUSTED: XLA:TPU compile permanent error. " "Ran out of memory in memory space vmem."
+        "RESOURCE_EXHAUSTED: XLA:TPU compile permanent error. Ran out of memory in memory space vmem."
     )
 
     def fake_pallas(*args, **kwargs):
@@ -1361,7 +1406,7 @@ def test_pallas_tpu_vmem_compile_error_uses_remaining_requested_order(monkeypatc
     called = {"pallas": 0, "reference": 0, "xla": 0}
     block_sizes = fused_api.BlockSizes(b_block_size=128, h_block_size=128, v_block_size=256)
     vmem_error = RuntimeError(
-        "RESOURCE_EXHAUSTED: XLA:TPU compile permanent error. " "Ran out of memory in memory space vmem."
+        "RESOURCE_EXHAUSTED: XLA:TPU compile permanent error. Ran out of memory in memory space vmem."
     )
 
     def fake_pallas(*args, **kwargs):
@@ -2238,3 +2283,189 @@ def test_fused_cross_entropy_pallas_backward_matches_xla_infer_blocks(implementa
 
     assert jnp.allclose(gx_linear_ce, gx_xla, atol=1e-4, rtol=1e-4)
     assert jnp.allclose(gw_linear_ce, gw_xla, atol=1e-4, rtol=1e-4)
+
+
+def _fast_bwd_case(dtype, *, b=512, h=64, v=1000, b_block=64, v_block=256, logit_soft_cap=None):
+    key = jax.random.PRNGKey(7)
+    key_x, key_w, key_y, key_g = jax.random.split(key, 4)
+    x = (jax.random.normal(key_x, (b, h), dtype=jnp.float32) * 0.5).astype(dtype)
+    w = (jax.random.normal(key_w, (h, v), dtype=jnp.float32) * 0.05).astype(dtype)
+    labels = jax.random.randint(key_y, (b,), 0, v, dtype=jnp.int32)
+    cotangent = jax.random.normal(key_g, (b,), dtype=jnp.float32)
+    block_sizes = BlockSizes(b_block_size=b_block, v_block_size=v_block)
+
+    def make(fast_backward, bwd_batch_block_size=None):
+        def objective(x_arg, w_arg):
+            loss, lse = fused_xla.linear_softmax_cross_entropy_loss_xla(
+                x_arg,
+                labels,
+                w_arg,
+                block_sizes=block_sizes,
+                dtype=jnp.float32,
+                logit_soft_cap=logit_soft_cap,
+                precision=None,
+                fast_backward=fast_backward,
+                bwd_batch_block_size=bwd_batch_block_size,
+            )
+            return jnp.sum(loss * cotangent) + 0.25 * jnp.sum(lse * cotangent)
+
+        return jax.jit(jax.value_and_grad(objective, argnums=(0, 1)))
+
+    return x, w, make
+
+
+@pytest.mark.parametrize("logit_soft_cap", [None, 1.5])
+def test_xla_fast_backward_leaves_forward_bitwise_identical(logit_soft_cap):
+    x, w, make = _fast_bwd_case(jnp.bfloat16, logit_soft_cap=logit_soft_cap)
+    value_slow, _ = make(False)(x, w)
+    value_fast, _ = make(True)(x, w)
+    # The fast path only replaces the backward, so the primal must be bit-identical.
+    assert np.array_equal(np.asarray(value_slow), np.asarray(value_fast))
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.bfloat16])
+def test_xla_fast_backward_matches_default_backward(dtype):
+    x, w, make = _fast_bwd_case(dtype)
+    _, (gx_slow, gw_slow) = make(False)(x, w)
+    _, (gx_fast, gw_fast) = make(True)(x, w)
+    atol = 1e-5 if dtype == jnp.float32 else 5e-2
+    rtol = 1e-5 if dtype == jnp.float32 else 5e-2
+    assert jnp.allclose(gx_fast.astype(jnp.float32), gx_slow.astype(jnp.float32), atol=atol, rtol=rtol)
+    assert jnp.allclose(gw_fast.astype(jnp.float32), gw_slow.astype(jnp.float32), atol=atol, rtol=rtol)
+
+
+def test_xla_fast_backward_batch_tiling_is_equivalent():
+    x, w, make = _fast_bwd_case(jnp.float32, b=512, b_block=64)
+    _, (gx_untiled, gw_untiled) = make(True, None)(x, w)
+    _, (gx_tiled, gw_tiled) = make(True, 64)(x, w)
+    # grad_x is computed per batch tile either way, so it must match exactly.
+    assert np.array_equal(np.asarray(gx_untiled), np.asarray(gx_tiled))
+    # grad_w differs only in float32 summation order across batch tiles.
+    assert jnp.allclose(gw_untiled, gw_tiled, atol=1e-4, rtol=1e-4)
+
+
+def test_xla_fast_backward_is_no_worse_than_default_against_float32_reference():
+    """At the hero loop ratio (many batch blocks per vocab block) the default backward
+    accumulates grad_w in the activation dtype; the fast backward must not be worse."""
+    dtype = jnp.bfloat16
+    x, w, make = _fast_bwd_case(dtype, b=2048, h=128, v=1024, b_block=32, v_block=256)
+    key = jax.random.PRNGKey(7)
+    _, _, key_y, key_g = jax.random.split(key, 4)
+    labels = jax.random.randint(key_y, (2048,), 0, 1024, dtype=jnp.int32)
+    cotangent = jax.random.normal(key_g, (2048,), dtype=jnp.float32)
+
+    def reference(x_arg, w_arg):
+        logits = x_arg.astype(jnp.float32) @ w_arg.astype(jnp.float32)
+        lse = jax.nn.logsumexp(logits, axis=-1)
+        label_logits = jnp.take_along_axis(logits, labels[:, None], axis=1).squeeze(-1)
+        loss = lse - label_logits
+        return jnp.sum(loss * cotangent) + 0.25 * jnp.sum(lse * cotangent)
+
+    _, (gx_ref, gw_ref) = jax.jit(jax.value_and_grad(reference, argnums=(0, 1)))(x, w)
+    _, (gx_slow, gw_slow) = make(False)(x, w)
+    _, (gx_fast, gw_fast) = make(True)(x, w)
+
+    def rms_error(actual, expected):
+        diff = actual.astype(jnp.float32) - expected.astype(jnp.float32)
+        return float(jnp.sqrt(jnp.mean(diff**2)))
+
+    assert rms_error(gx_fast, gx_ref) <= rms_error(gx_slow, gx_ref) * 1.05
+    assert rms_error(gw_fast, gw_ref) <= rms_error(gw_slow, gw_ref) * 1.05
+
+
+def test_xla_fast_backward_env_var_overrides_call_site_in_both_directions(monkeypatch):
+    """The env var is the A/B kill switch: when set it wins over the call site."""
+    monkeypatch.delenv(fused_xla._FAST_BWD_ENV_VAR, raising=False)
+    # Unset: the call site decides, and the library default is off.
+    assert fused_xla._resolve_fast_backward(None) is False
+    assert fused_xla._resolve_fast_backward(True) is True
+    assert fused_xla._resolve_fast_backward(False) is False
+    # Set to on: forces the fast backward even where the call site asked for the old one.
+    monkeypatch.setenv(fused_xla._FAST_BWD_ENV_VAR, "1")
+    assert fused_xla._resolve_fast_backward(None) is True
+    assert fused_xla._resolve_fast_backward(False) is True
+    # Set to off: forces the old backward even where the call site asked for the fast one.
+    monkeypatch.setenv(fused_xla._FAST_BWD_ENV_VAR, "0")
+    assert fused_xla._resolve_fast_backward(None) is False
+    assert fused_xla._resolve_fast_backward(True) is False
+    # Unrecognised values are ignored rather than silently flipping a hero run.
+    monkeypatch.setenv(fused_xla._FAST_BWD_ENV_VAR, "maybe")
+    assert fused_xla._resolve_fast_backward(True) is True
+    assert fused_xla._resolve_fast_backward(None) is False
+
+
+def test_xla_fast_bwd_implementation_is_registered_and_opt_in():
+    """`xla_fast_bwd` must exist, be explicit-only, and leave `xla` untouched."""
+    assert "xla_fast_bwd" in fused_api.IMPLEMENTATIONS
+    # Never auto-selected: only an explicit implementation= picks it up.
+    assert "xla_fast_bwd" not in fused_api._DEFAULT_IMPLEMENTATION
+    assert "xla_fast_bwd" not in fused_api._CANONICAL_BACKEND_IMPLEMENTATIONS
+    # The plain "xla" entry must still be the unmodified function.
+    assert fused_api.IMPLEMENTATIONS["xla"] is fused_xla.linear_softmax_cross_entropy_loss_xla
+
+
+def test_xla_fast_bwd_implementation_matches_xla_forward_and_fast_backward(monkeypatch):
+    monkeypatch.delenv(fused_xla._FAST_BWD_ENV_VAR, raising=False)
+    key = jax.random.PRNGKey(11)
+    key_x, key_w, key_y = jax.random.split(key, 3)
+    b, h, v = 512, 64, 2048
+    x = (jax.random.normal(key_x, (b, h), dtype=jnp.float32) * 0.5).astype(jnp.bfloat16)
+    w = (jax.random.normal(key_w, (h, v), dtype=jnp.float32) * 0.05).astype(jnp.bfloat16)
+    labels = jax.random.randint(key_y, (b,), 0, v, dtype=jnp.int32)
+    block_sizes = BlockSizes(b_block_size=b, v_block_size=512)
+
+    def make(impl):
+        def objective(x_arg, w_arg):
+            loss = fused_api.fused_cross_entropy_loss_and_logsumexp_penalty(
+                x_arg,
+                labels,
+                w_arg,
+                reduction="mean",
+                logsumexp_weight=None,
+                dtype=jnp.float32,
+                block_sizes=block_sizes,
+                logit_soft_cap=None,
+                implementation=impl,
+            )
+            return loss
+
+        return jax.jit(jax.value_and_grad(objective, argnums=(0, 1)))
+
+    value_xla, (gx_xla, gw_xla) = make("xla")(x, w)
+    value_fast, (gx_fast, gw_fast) = make("xla_fast_bwd")(x, w)
+
+    # Forward is the same code path, so the loss must be bitwise identical.
+    assert np.array_equal(np.asarray(value_xla), np.asarray(value_fast))
+    # Backward differs only in rounding.
+    assert jnp.allclose(gx_fast.astype(jnp.float32), gx_xla.astype(jnp.float32), atol=5e-2, rtol=5e-2)
+    assert jnp.allclose(gw_fast.astype(jnp.float32), gw_xla.astype(jnp.float32), atol=5e-2, rtol=5e-2)
+
+    # And it really is the fast backward: no scatter in the lowered gradient.
+    text = make("xla_fast_bwd").lower(x, w).as_text()
+    assert "stablehlo.scatter" not in text
+    assert "stablehlo.scatter" in make("xla").lower(x, w).as_text()
+
+
+def test_xla_fast_backward_emits_no_scatter_and_one_loop():
+    """Structural gate: the fast backward must not regress to a scatter or a nested loop."""
+    x, w, _ = _fast_bwd_case(jnp.bfloat16, b=256, h=64, v=300, b_block=64, v_block=128)
+    labels = jnp.zeros((256,), dtype=jnp.int32)
+
+    def objective(x_arg, w_arg):
+        loss, _ = fused_xla.linear_softmax_cross_entropy_loss_xla(
+            x_arg,
+            labels,
+            w_arg,
+            block_sizes=BlockSizes(b_block_size=64, v_block_size=128),
+            dtype=jnp.float32,
+            precision=None,
+            fast_backward=True,
+        )
+        return jnp.sum(loss)
+
+    text = jax.jit(jax.grad(objective, argnums=(0, 1))).lower(x, w).as_text()
+    assert "stablehlo.scatter" not in text
+    # 2 while loops for the (unchanged) forward, 1 scan for the backward.
+    assert text.count("stablehlo.while") == 3
+    # Both backward GEMMs must stay on bf16 operands (tensor cores), not upcast to f32.
+    assert "tensor<256x128xf32>, tensor<64x128xf32>" not in text

--- a/lib/levanter/tests/kernels/test_short_conv.py
+++ b/lib/levanter/tests/kernels/test_short_conv.py
@@ -15,6 +15,13 @@ reference, because a fused conv changes only *when* bytes cross HBM, never the
 arithmetic. `dw` is a reduction over 65,536 tokens whose association order XLA does not
 define, so it is checked against a float64 oracle instead -- the kernel must be at least
 as accurate as the reference, not identical to it.
+
+The whole module is scoped to the backends this Triton kernel targets. `dx` is bitwise
+only because `_dx_body` accumulates in the order XLA's transpose of the pad-and-shift
+forward emits, and that order is a property of the backend's transpose, not of the
+algorithm: on TPU the multi-tap shapes disagree in the last bit or two while `W=1`, which
+has no accumulation to associate, still matches exactly. Running the interpreter on TPU
+therefore measures XLA:TPU rather than the kernel that ships.
 """
 
 import jax
@@ -28,6 +35,11 @@ from levanter.kernels.pallas.short_conv import (
     short_conv_reference,
 )
 from levanter.kernels.pallas.short_conv.pallas_gpu import interpret_mode
+
+pytestmark = pytest.mark.skipif(
+    jax.default_backend() == "tpu",
+    reason="Triton kernel: dx parity is defined against XLA's CPU/GPU transpose of the reference",
+)
 
 # (batch, seq_len, channels, kernel_size, s_block, c_block)
 SHAPES = [

--- a/lib/levanter/tests/kernels/test_short_conv.py
+++ b/lib/levanter/tests/kernels/test_short_conv.py
@@ -1,0 +1,315 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Correctness gate for the fused depthwise causal short convolution (SConv).
+
+The Pallas kernel targets a GPU and cannot execute on CPU as compiled code, but Pallas's
+reference interpreter executes the *kernel body* -- grid, block specs, the neighbouring
+sequence-block views that supply the halo, the edge masking, the register accumulation --
+with plain XLA ops. Everything here therefore exercises the real algorithm on CPU. What
+it does not and cannot cover is whether the kernel *lowers* on a given GPU architecture;
+`test_pallas_short_conv_matches_reference_on_gpu` covers that when a GPU is present.
+
+The bar is bitwise: the forward and `dx` must be bit-identical to the pad-and-shift
+reference, because a fused conv changes only *when* bytes cross HBM, never the
+arithmetic. `dw` is a reduction over 65,536 tokens whose association order XLA does not
+define, so it is checked against a float64 oracle instead -- the kernel must be at least
+as accurate as the reference, not identical to it.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from levanter.kernels.pallas.short_conv import (
+    ShortConvBlockSizes,
+    short_conv,
+    short_conv_reference,
+)
+from levanter.kernels.pallas.short_conv.pallas_gpu import interpret_mode
+
+# (batch, seq_len, channels, kernel_size, s_block, c_block)
+SHAPES = [
+    (1, 32, 8, 4, 8, 8),
+    (2, 32, 8, 4, 8, 4),
+    (3, 64, 16, 4, 16, 8),
+    (2, 64, 32, 4, 32, 16),
+    (2, 48, 8, 3, 16, 8),
+    (1, 64, 8, 2, 32, 8),
+    (1, 64, 8, 1, 32, 8),
+    (2, 128, 16, 4, 128, 16),  # a single sequence block: no neighbour view is in range
+]
+
+
+def _packed_segment_ids(rng, batch, seq_len, min_run=1, max_run=None):
+    """Contiguous document runs, deliberately including runs shorter than the kernel."""
+    max_run = max_run or max(min_run + 1, seq_len // 4)
+    out = np.zeros((batch, seq_len), np.int32)
+    for b in range(batch):
+        pos, sid = 0, 0
+        while pos < seq_len:
+            run = int(rng.integers(min_run, max_run + 1))
+            out[b, pos : pos + run] = sid
+            pos += run
+            sid += 1
+    return jnp.asarray(out)
+
+
+def _segment_start_mask(segment_ids, width):
+    """[B, S] mask over the first `width - 1` positions of every segment."""
+    seg = np.asarray(jax.device_get(segment_ids))
+    starts = np.ones_like(seg, dtype=bool)
+    starts[:, 1:] = seg[:, 1:] != seg[:, :-1]
+    mask = np.zeros_like(starts)
+    for offset in range(max(width - 1, 1)):
+        shifted = starts if offset == 0 else np.pad(starts[:, :-offset], ((0, 0), (offset, 0)))
+        mask |= shifted.astype(bool)
+    return mask
+
+
+def _bits(array):
+    array = np.asarray(jax.device_get(array))
+    return array.view({2: np.uint16, 4: np.uint32, 8: np.uint64}[array.dtype.itemsize])
+
+
+def _run_both(weight, x, segment_ids, cotangent, blocks):
+    def kernel_fn(w, xx):
+        return short_conv(w, xx, segment_ids, implementation="pallas_gpu", block_sizes=blocks)
+
+    def reference_fn(w, xx):
+        return short_conv_reference(w, xx, segment_ids)
+
+    with interpret_mode():
+        got = jax.jit(kernel_fn)(weight, x)
+        _, kernel_vjp = jax.vjp(kernel_fn, weight, x)
+        got_dw, got_dx = jax.jit(kernel_vjp)(cotangent)
+
+    want = jax.jit(reference_fn)(weight, x)
+    _, reference_vjp = jax.vjp(reference_fn, weight, x)
+    want_dw, want_dx = jax.jit(reference_vjp)(cotangent)
+    return (got, got_dx, got_dw), (want, want_dx, want_dw)
+
+
+def _inputs(batch, seq_len, channels, width, seed, dtype, packed):
+    rng = np.random.default_rng(seed)
+    x = jnp.asarray(rng.standard_normal((batch, seq_len, channels)), dtype)
+    weight = jnp.asarray(rng.standard_normal((width, channels)) * 0.5, dtype)
+    cotangent = jnp.asarray(rng.standard_normal((batch, seq_len, channels)), dtype)
+    segment_ids = _packed_segment_ids(rng, batch, seq_len) if packed else None
+    return weight, x, segment_ids, cotangent
+
+
+@pytest.mark.parametrize("shape", SHAPES, ids=lambda s: "x".join(str(v) for v in s))
+@pytest.mark.parametrize("packed", [True, False], ids=["packed", "unpacked"])
+def test_forward_and_dx_are_bitwise_identical_to_reference(shape, packed):
+    batch, seq_len, channels, width, s_block, c_block = shape
+    weight, x, segment_ids, cotangent = _inputs(
+        batch, seq_len, channels, width, seed=hash(shape) % 2**16, dtype=jnp.bfloat16, packed=packed
+    )
+    blocks = ShortConvBlockSizes(s_block_size=s_block, c_block_size=c_block)
+    (got, got_dx, _), (want, want_dx, _) = _run_both(weight, x, segment_ids, cotangent, blocks)
+
+    np.testing.assert_array_equal(_bits(got), _bits(want), err_msg="forward is not bit-identical")
+    np.testing.assert_array_equal(_bits(got_dx), _bits(want_dx), err_msg="dx is not bit-identical")
+
+
+@pytest.mark.parametrize("shape", SHAPES[:5], ids=lambda s: "x".join(str(v) for v in s))
+def test_segment_boundaries_and_segment_starts_match_exactly(shape):
+    """The first `kernel_size - 1` positions of every document are where taps get dropped.
+
+    Those positions are checked on their own so a regression there cannot hide inside a
+    whole-tensor max.
+    """
+    batch, seq_len, channels, width, s_block, c_block = shape
+    weight, x, segment_ids, cotangent = _inputs(
+        batch, seq_len, channels, width, seed=99, dtype=jnp.bfloat16, packed=True
+    )
+    blocks = ShortConvBlockSizes(s_block_size=s_block, c_block_size=c_block)
+    (got, got_dx, _), (want, want_dx, _) = _run_both(weight, x, segment_ids, cotangent, blocks)
+
+    mask = _segment_start_mask(segment_ids, width)
+    assert mask.any(), "test fixture produced no segment starts"
+    np.testing.assert_array_equal(_bits(got)[mask], _bits(want)[mask])
+    np.testing.assert_array_equal(_bits(got_dx)[mask], _bits(want_dx)[mask])
+
+    # And the taps really are being dropped: with a non-degenerate weight, masking must
+    # make the output differ from an unmasked convolution somewhere on the boundary.
+    unmasked = short_conv_reference(weight, x, None)
+    assert not np.array_equal(_bits(unmasked)[mask], _bits(want)[mask])
+
+
+@pytest.mark.parametrize("shape", SHAPES[:4], ids=lambda s: "x".join(str(v) for v in s))
+def test_dw_is_at_least_as_accurate_as_the_reference(shape):
+    """`dw` reduces 65,536 tokens in fp32; association order is not part of the contract.
+
+    Both implementations are compared against a float64 oracle. The kernel is required to
+    be no worse than the reference, which is the meaningful guarantee.
+    """
+    batch, seq_len, channels, width, s_block, c_block = shape
+    weight, x, segment_ids, cotangent = _inputs(
+        batch, seq_len, channels, width, seed=5, dtype=jnp.bfloat16, packed=True
+    )
+    blocks = ShortConvBlockSizes(s_block_size=s_block, c_block_size=c_block)
+    (_, _, got_dw), (_, _, want_dw) = _run_both(weight, x, segment_ids, cotangent, blocks)
+
+    # float64 oracle for dw, computed directly from the definition.
+    x64 = np.asarray(jax.device_get(x), np.float64)
+    ct64 = np.asarray(jax.device_get(cotangent), np.float64)
+    seg = np.asarray(jax.device_get(segment_ids))
+    oracle = np.zeros((width, channels), np.float64)
+    for lag in range(width):
+        shifted = np.zeros_like(x64)
+        if lag == 0:
+            shifted = x64
+            keep = np.ones(seg.shape, bool)
+        else:
+            shifted[:, lag:, :] = x64[:, :-lag, :]
+            seg_shifted = np.full(seg.shape, -1, seg.dtype)
+            seg_shifted[:, lag:] = seg[:, :-lag]
+            keep = seg_shifted == seg
+        oracle[lag] = np.sum(ct64 * shifted * keep[..., None], axis=(0, 1))
+
+    got_err = np.max(np.abs(np.asarray(jax.device_get(got_dw), np.float64) - oracle))
+    want_err = np.max(np.abs(np.asarray(jax.device_get(want_dw), np.float64) - oracle))
+    scale = max(np.max(np.abs(oracle)), 1e-30)
+    assert got_err <= max(want_err * 1.5, 0.02 * scale), (
+        f"kernel dw error {got_err:.3e} materially worse than reference {want_err:.3e} " f"(oracle scale {scale:.3e})"
+    )
+
+
+def test_float32_gradients_match_to_float32_tolerance():
+    """fp32 inputs: the pad/shift chain and the kernel differ only by fp32 reassociation."""
+    weight, x, segment_ids, cotangent = _inputs(2, 64, 16, 4, seed=17, dtype=jnp.float32, packed=True)
+    blocks = ShortConvBlockSizes(s_block_size=16, c_block_size=8)
+    (got, got_dx, got_dw), (want, want_dx, want_dw) = _run_both(weight, x, segment_ids, cotangent, blocks)
+    for name, a, b in (("y", got, want), ("dx", got_dx, want_dx), ("dw", got_dw, want_dw)):
+        np.testing.assert_allclose(
+            jax.device_get(a), jax.device_get(b), rtol=1e-5, atol=1e-5, err_msg=f"{name} mismatch"
+        )
+
+
+def test_explicit_implementation_fails_fast_when_unsupported():
+    """An explicitly requested backend must raise, never silently fall back (api-patterns)."""
+    weight, x, segment_ids, _ = _inputs(2, 32, 8, 4, seed=1, dtype=jnp.bfloat16, packed=True)
+    bad_blocks = ShortConvBlockSizes(s_block_size=7, c_block_size=8)  # 32 % 7 != 0
+    with interpret_mode():
+        with pytest.raises(RuntimeError, match="not divisible"):
+            short_conv(weight, x, segment_ids, implementation="pallas_gpu", block_sizes=bad_blocks)
+
+
+def test_ordered_implementation_sequence_falls_back_with_a_warning():
+    weight, x, segment_ids, _ = _inputs(2, 32, 8, 4, seed=1, dtype=jnp.bfloat16, packed=True)
+    bad_blocks = ShortConvBlockSizes(s_block_size=7, c_block_size=8)
+    with interpret_mode():
+        with pytest.warns(UserWarning, match="falling back"):
+            got = short_conv(
+                weight, x, segment_ids, implementation=("pallas_gpu", "reference"), block_sizes=bad_blocks
+            )
+    np.testing.assert_array_equal(_bits(got), _bits(short_conv_reference(weight, x, segment_ids)))
+
+
+def test_default_implementation_on_cpu_is_the_reference():
+    if jax.default_backend() == "gpu":
+        pytest.skip("this asserts the non-GPU default")
+    weight, x, segment_ids, _ = _inputs(2, 32, 8, 4, seed=2, dtype=jnp.bfloat16, packed=True)
+    got = short_conv(weight, x, segment_ids)
+    np.testing.assert_array_equal(_bits(got), _bits(short_conv_reference(weight, x, segment_ids)))
+
+
+def test_kernel_call_is_wrapped_in_a_shard_map_under_a_mesh():
+    """House rule: every Pallas call sits inside an explicit shard_map on a real mesh.
+
+    Checked on the lowered jaxpr rather than by inspection, so a refactor that drops the
+    manual region fails here. The mesh is abstract and nothing is executed, so a
+    single-device CPU runner is enough.
+    """
+    mesh = jax.sharding.AbstractMesh(
+        axis_sizes=(1, 2, 1, 1),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(jax.sharding.AxisType.Explicit,) * 4,
+    )
+    weight, x, segment_ids, _ = _inputs(2, 32, 8, 4, seed=3, dtype=jnp.bfloat16, packed=True)
+    blocks = ShortConvBlockSizes(s_block_size=8, c_block_size=8)
+
+    def fn(w, xx, seg):
+        return short_conv(w, xx, seg, implementation="pallas_gpu", block_sizes=blocks)
+
+    with interpret_mode(), jax.sharding.use_abstract_mesh(mesh):
+        jaxpr = jax.make_jaxpr(fn)(weight, x, segment_ids)
+    text = str(jaxpr)
+    assert "shard_map" in text, "kernel is not inside an explicit shard_map"
+    # ...and the manual region must not contain a collective: the op is shard-local.
+    for banned in ("all_gather", "all_reduce", "psum", "all_to_all", "reduce_scatter"):
+        assert banned not in text, f"short_conv lowered through an unexpected {banned}"
+
+
+def test_pallas_short_conv_matches_reference_on_gpu():
+    """The compiled kernel, not the interpreter. Only meaningful with a GPU present."""
+    if jax.default_backend() != "gpu":
+        pytest.skip("requires the JAX GPU backend")
+    weight, x, segment_ids, cotangent = _inputs(2, 512, 256, 4, seed=21, dtype=jnp.bfloat16, packed=True)
+    blocks = ShortConvBlockSizes(s_block_size=128, c_block_size=128)
+
+    def kernel_fn(w, xx):
+        return short_conv(w, xx, segment_ids, implementation="pallas_gpu", block_sizes=blocks)
+
+    def reference_fn(w, xx):
+        return short_conv_reference(w, xx, segment_ids)
+
+    got = jax.jit(kernel_fn)(weight, x)
+    _, kernel_vjp = jax.vjp(kernel_fn, weight, x)
+    got_dw, got_dx = jax.jit(kernel_vjp)(cotangent)
+
+    want = jax.jit(reference_fn)(weight, x)
+    _, reference_vjp = jax.vjp(reference_fn, weight, x)
+    want_dw, want_dx = jax.jit(reference_vjp)(cotangent)
+
+    np.testing.assert_array_equal(_bits(got), _bits(want))
+    np.testing.assert_array_equal(_bits(got_dx), _bits(want_dx))
+    np.testing.assert_allclose(
+        jax.device_get(got_dw).astype(np.float32),
+        jax.device_get(want_dw).astype(np.float32),
+        rtol=5e-2,
+        atol=5e-2,
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_size", "should_reject"),
+    [(1, False), (2, True)],
+    ids=["size-1 model axis is a no-op", "size-2 model axis really shards"],
+)
+def test_channel_axis_gate_consults_the_mesh_not_just_the_spec(model_size, should_reject):
+    """A spec entry naming a size-1 mesh axis shards nothing, and must not be rejected.
+
+    This is not hypothetical. The EP64 hero mesh is (replica_dcn=1, data=1, expert=64, model=1)
+    and the attention projections are `P(_FSDP_AXES, "model")`, so every k/v activation reaching
+    SConv carries "model" on its channel axis while being, in fact, unsharded there. Gating on
+    the name alone rejects the production shape -- and the reshard the gate guards is a no-op in
+    exactly that case, so there is nothing to guard.
+
+    The size-2 leg keeps the gate honest: a genuinely sharded channel axis must still raise,
+    because silently resharding it would hide a real all-gather inside the kernel wrapper.
+    """
+    mesh = jax.sharding.AbstractMesh(
+        axis_sizes=(1, 2 // model_size, 2, model_size),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(jax.sharding.AxisType.Explicit,) * 4,
+    )
+    weight, x, segment_ids, _ = _inputs(4, 32, 8, 4, seed=11, dtype=jnp.bfloat16, packed=True)
+    blocks = ShortConvBlockSizes(s_block_size=8, c_block_size=8)
+
+    def fn(w, xx, seg):
+        # Reproduce the hero's k_flat sharding: batch over the FSDP pair, channel named "model".
+        xx = jax.sharding.reshard(xx, jax.sharding.PartitionSpec(("data", "expert"), None, "model"))
+        seg = jax.sharding.reshard(seg, jax.sharding.PartitionSpec(("data", "expert"), None))
+        return short_conv(w, xx, seg, implementation="pallas_gpu", block_sizes=blocks)
+
+    with interpret_mode(), jax.sharding.use_abstract_mesh(mesh):
+        if should_reject:
+            with pytest.raises(ValueError, match="unsharded channel axis"):
+                jax.make_jaxpr(fn)(weight, x, segment_ids)
+        else:
+            jaxpr = jax.make_jaxpr(fn)(weight, x, segment_ids)
+            assert "shard_map" in str(jaxpr)

--- a/lib/levanter/tests/kernels/test_short_conv.py
+++ b/lib/levanter/tests/kernels/test_short_conv.py
@@ -325,3 +325,13 @@ def test_channel_axis_gate_consults_the_mesh_not_just_the_spec(model_size, shoul
         else:
             jaxpr = jax.make_jaxpr(fn)(weight, x, segment_ids)
             assert "shard_map" in str(jaxpr)
+
+
+def test_short_conv_rejects_mixed_dtypes():
+    """Mixed weight/activation dtypes are rejected at the boundary. The reference promotes
+    (fp32) while the Pallas kernel outputs ``x.dtype``, so accepting mixed inputs would make
+    the same call backend-dependent; the dtype gate runs before dispatch on every backend."""
+    weight = jnp.ones((4, 8), dtype=jnp.float32)
+    x = jnp.ones((1, 16, 8), dtype=jnp.bfloat16)
+    with pytest.raises(ValueError, match="share a dtype"):
+        short_conv(weight, x)


### PR DESCRIPTION
Combines the four-PR EP64 hero stack into a single PR onto `main`. The stack was based on the already-merged `drop_value_sconv` branch, which GitHub would not let us restack; this PR carries the same commits (`nek-collective-hoist` tip) and lands them clean on `main`. Verified conflict-free with `git merge-tree` against current main.

The four changes, bottom to top (originals closed in favor of this PR — see them for full measurement detail):

- **Peak-HBM telemetry** (was #8384/#8367) — `moe_hero_ep/train.py`: log peak HBM, live bytes and the allocator limit. Without this, a change that moves peak across the `HloRematerialization` limit produces an MFU step unrelated to the change. Six lines, ported from `moe_hero_fsdp/train.py`.

- **Fused CE: bf16 backward GEMMs** (was #8368) — new `implementation="xla_fast_bwd"`, opt-in and isolated (`xla` stays byte-identical for every other caller). Forward is untouched so the loss is bitwise identical; the backward casts `dlogits` to the activation dtype (both backward GEMMs stay on bf16 tensor cores), replaces the label scatter with a dense one-hot, and accumulates `grad_x` in f32. Gradients change but move ~30% closer to an fp32 reference. 2.33x on the hero CE shape at GB200. `LEVANTER_CE_XLA_FAST_BWD` is a two-way kill switch.

- **Fused ShortConv kernel** (was #8369) — Pallas Triton depthwise causal conv for ShortConv. Forward and `dx` bitwise vs reference; `dw` as accurate as the reference (fp32 reassociation). Correctness tests cover values, `dx`, segment boundaries, `dw` fp64 oracle, and the shard_map boundary; CPU + GPU scoped.

- **Hoist router/QB all-reduces out of the scan** (was #8370) — replaces four per-layer cross-device all-reduces with one reduction after the layer scan (`_local_routing_stats` partials + `_reduce_router_stats`). Algebraically identity; TOPK's `pmean` is deferred (β is read next step), HIST passes through (its bin grid needs a global pmin/pmax). 150.6 ms/step at EP64.

Parity: this stack vs `main` on the d768 EP-hero ablation (4×GB200 FSDP) tracks to within run-to-run noise at step 1k (paloma macro_loss 3.9417 vs 3.9463, train CE 2.8681 vs 2.8747). The fused-CE gradient change is an intentional hero-comparability break, flagged in a dated NOTE at the call site.
