### PR TITLE
[grug] Evaluate Pallas SConv scaling

### DIFF
--- a/.agents/logbooks/moe-pallas-sconv-v5p8.md
+++ b/.agents/logbooks/moe-pallas-sconv-v5p8.md
@@ -1,7 +1,7 @@
 ---
 topic: moe-pallas-sconv-v5p8
 issue: https://github.com/marin-community/marin/issues/8377
-description: Verify the Pallas depthwise causal convolution in the Grug MoE recipe on v5p-8.
+description: Evaluate Pallas SConv with the Grug MoE two-gate scaling workflow on v5p-8.
 author: held
 ---
 
@@ -9,13 +9,13 @@ author: held
 
 ## Current TL;DR
 
-`MOE-PSC-001` completed 25 d512 training steps on one v5p-8. Iris and W&B finished successfully, final loss was 9.7629, steady-state throughput was approximately 349k tokens/s, and the step-25 checkpoint was published.
+`MOE-PSC-001` completed the 25-step integration smoke. Gate 1 launchers are validated for the fixed-budget d512 and d768 cells; the quality and effective-speedup decision is pending those runs.
 
 ## Scope
 
-- Goal: verify that the #8331 Pallas convolution compiles and trains in the four-site Inkling SConv configuration on one v5p-8.
-- Primary metrics: terminal Iris state, finite training loss, `throughput/tokens_per_second`, and final W&B state.
-- Constraints: d512 May Recipe shape, kernel size 4, K/V/attention-output/MLP-output sites, identity initialization, packed-document boundary masking, 25 training steps.
+- Goal: run the two-gate scaling workflow in `experiments/grug/moe/agent.md` for the #8331 Pallas convolution in the four-site Inkling SConv configuration.
+- Primary metrics: final Paloma macro loss, mean throughput over the final 100 steps, final total tokens, terminal Iris state, and final W&B state.
+- Constraints: fixed baseline compute budgets, kernel size 4, K/V/attention-output/MLP-output sites, identity initialization, packed-document boundary masking, and v5p-8 resources.
 - Coordinating issue: https://github.com/marin-community/marin/issues/8377
 
 ## Baseline
@@ -28,7 +28,8 @@ author: held
 
 ### Active
 
-None.
+- `MOE-PSC-101`: d512 Gate 1 has effective speedup greater than 1 against the published baseline.
+- `MOE-PSC-102`: d768 Gate 1 has effective speedup greater than 1 against the published baseline.
 
 ### Blocked
 
@@ -162,3 +163,12 @@ Inkling uses short causal convolutions with kernel size 4 in the K stream, V str
 - Checkpoint: `gs://marin-us-central1/users/held/grug/moe_pallas_sconv_smoke/dev/checkpoints/step-25/metadata.json`
 - Interpretation: the four-site Pallas SConv forward and backward kernels compile and train successfully in the d512 Grug MoE recipe on v5p-8. This smoke establishes integration viability; it does not measure a quality delta against a control.
 - Next action: use this variant for a controlled quality or throughput comparison if the SConv line is promoted beyond integration testing.
+
+### 2026-08-18 - Gate 1 launch snapshot
+
+- Hypothesis: the Pallas SConv variant has effective speedup greater than 1 at the fixed d512 and d768 baseline compute budgets.
+- Run IDs: `MOE-PSC-101-d512-v5p8-gate1` and `MOE-PSC-102-d768-v5p8-gate1`.
+- Config: d512 uses 6 layers, batch 32, sequence length 8192, and 3,494 steps; d768 uses 8 layers, batch 32, sequence length 8192, and 11,430 steps. Both use the Nemotron, StarCoder, and ProofPile mixture with final Paloma and uncheatable evaluation.
+- Baseline: d512 loss 3.5422 at 433,986 tokens/s and d768 loss 3.2273 at 294,726 tokens/s. These published cells used the prior sequence-length, PKO, long-RoPE, and z-loss defaults, so the gate is a historical-recipe comparison rather than a single-variable ablation.
+- Validation: both Gate 1 and conditional Gate 2 experiment graphs resolve; 75 targeted model, optimizer, and convolution tests pass with 60 TPU-dependent cases skipped.
+- Next action: publish the snapshot, submit Gate 1 in us-central1-a, and monitor both cells through final W&B metrics and checkpoints.

--- a/.agents/logbooks/moe-pallas-sconv-v5p8.md
+++ b/.agents/logbooks/moe-pallas-sconv-v5p8.md
@@ -9,7 +9,7 @@ author: held
 
 ## Current TL;DR
 
-The implementation and v5p-8 smoke run are in progress. No runtime result is available yet.
+`MOE-PSC-001` completed 25 d512 training steps on one v5p-8. Iris and W&B finished successfully, final loss was 9.7629, steady-state throughput was approximately 349k tokens/s, and the step-25 checkpoint was published.
 
 ## Scope
 
@@ -28,7 +28,7 @@ The implementation and v5p-8 smoke run are in progress. No runtime result is ava
 
 ### Active
 
-- `MOE-PSC-001`: the four-site Pallas SConv compiles and completes 25 d512 training steps on v5p-8 with finite loss. Next test: submit the smoke run.
+None.
 
 ### Blocked
 
@@ -40,7 +40,7 @@ None.
 
 ### Promoted
 
-None.
+- `MOE-PSC-001`: the four-site Pallas SConv compiled and completed 25 d512 training steps on v5p-8 with finite loss. The implementation is ready for a controlled quality or throughput comparison.
 
 ## Background Research Brief
 
@@ -151,3 +151,14 @@ Inkling uses short causal convolutions with kernel size 4 in the K stream, V str
 - Capacity: a pinned us-east5-a attempt could not provision a v5p-8 because the zone had no capacity. Subsequent smoke retries use us-central1-a.
 - Validation: the mixed-precision explicit-mesh regression and six targeted numerical, gradient, mask, and optimizer tests passed.
 - Next action: publish the dtype fix and resubmit in us-central1-a.
+
+### 2026-08-17 19:02 PDT - v5p-8 smoke succeeded
+
+- Commit Hash: `fca2870b85`
+- Coordinator: `/held/moe-pallas-sconv-smoke-8377-r3-central1`
+- Training child: `/held/moe-pallas-sconv-smoke-8377-r3-central1/grug-train-MOE-PSC-001-d512-v5p8-smoke`
+- W&B: https://wandb.ai/marin-community/marin_moe/runs/MOE-PSC-001-d512-v5p8-smoke
+- Result: the child completed 25 steps in 5 minutes 18 seconds with no failures or preemptions. W&B finished at logged step index 24 with loss 9.7629, throughput 349,192 tokens/s, and 6,553,600 total tokens.
+- Checkpoint: `gs://marin-us-central1/users/held/grug/moe_pallas_sconv_smoke/dev/checkpoints/step-25/metadata.json`
+- Interpretation: the four-site Pallas SConv forward and backward kernels compile and train successfully in the d512 Grug MoE recipe on v5p-8. This smoke establishes integration viability; it does not measure a quality delta against a control.
+- Next action: use this variant for a controlled quality or throughput comparison if the SConv line is promoted beyond integration testing.

--- a/.agents/logbooks/moe-pallas-sconv-v5p8.md
+++ b/.agents/logbooks/moe-pallas-sconv-v5p8.md
@@ -140,3 +140,14 @@ Inkling uses short causal convolutions with kernel size 4 in the K stream, V str
 - Action: stopped the coordinator, wrapped the Pallas implementation in `shard_map`, sharded convolution channels over the model axis, and added an abstract-mesh lowering regression.
 - Validation: the lowering regression and six targeted numerical, gradient, mask, and optimizer tests passed. The full targeted kernel and variant selection also passed.
 - Next action: publish the fix snapshot and resubmit the smoke run.
+
+### 2026-08-17 18:40 PDT - Mixed-precision gradient failure
+
+- Commit Hash: `19488ef108`
+- Coordinator: `/held/moe-pallas-sconv-smoke-8377-r2-central1`
+- Result: the explicit-mesh fix allowed the training child to initialize W&B, load the caches, and enter the 25-step training loop. The first value-and-gradient trace then failed because the custom VJP returned an fp32 weight cotangent for a bf16 weight primal.
+- Interpretation: `ShortConv` cast its fp32 parameter to the bf16 activation dtype before calling the Pallas kernel, while the kernel accumulates parameter gradients in fp32.
+- Action: stopped the coordinator before its automatic retry, preserved fp32 convolution parameters at the call site, cast custom-VJP cotangents back to their primal dtypes, and extended the explicit-mesh regression through a mixed-precision value-and-gradient trace.
+- Capacity: a pinned us-east5-a attempt could not provision a v5p-8 because the zone had no capacity. Subsequent smoke retries use us-central1-a.
+- Validation: the mixed-precision explicit-mesh regression and six targeted numerical, gradient, mask, and optimizer tests passed.
+- Next action: publish the dtype fix and resubmit in us-central1-a.

--- a/.agents/logbooks/moe-pallas-sconv-v5p8.md
+++ b/.agents/logbooks/moe-pallas-sconv-v5p8.md
@@ -9,7 +9,7 @@ author: held
 
 ## Current TL;DR
 
-`MOE-PSC-001` completed the 25-step integration smoke. Gate 1 launchers are validated for the fixed-budget d512 and d768 cells; the quality and effective-speedup decision is pending those runs.
+`MOE-PSC-001` completed the 25-step integration smoke. Gate 1 is submitted for the fixed-budget d512 and d768 cells; both tasks are waiting for replacement v5p-8 workers after one startup preemption each.
 
 ## Scope
 
@@ -172,3 +172,19 @@ Inkling uses short causal convolutions with kernel size 4 in the K stream, V str
 - Baseline: d512 loss 3.5422 at 433,986 tokens/s and d768 loss 3.2273 at 294,726 tokens/s. These published cells used the prior sequence-length, PKO, long-RoPE, and z-loss defaults, so the gate is a historical-recipe comparison rather than a single-variable ablation.
 - Validation: both Gate 1 and conditional Gate 2 experiment graphs resolve; 75 targeted model, optimizer, and convolution tests pass with 60 TPU-dependent cases skipped.
 - Next action: publish the snapshot, submit Gate 1 in us-central1-a, and monitor both cells through final W&B metrics and checkpoints.
+
+### 2026-08-18 12:21 PDT - Gate 1 worker recycle
+
+- Snapshot: `d668d60059`.
+- Coordinator: `/held/moe-pallas-sconv-gate1-8377`.
+- W&B: https://wandb.ai/marin-community/marin_moe/runs/MOE-PSC-101-d512-v5p8-gate1 and https://wandb.ai/marin-community/marin_moe/runs/MOE-PSC-102-d768-v5p8-gate1.
+- Result: both runs initialized W&B and loaded the training and validation caches, then their fresh us-central1-a v5p-8 workers crossed the Iris reconcile-failure threshold before the first optimizer step. Iris returned both tasks to pending with one preemption and no failure.
+- Interpretation: the task events report parent preemption rather than a TPU-init error. None of the bad-node signatures (`No accelerator found`, `FAILED_PRECONDITION`, or `Device or resource busy`) appeared, so worker deletion is not indicated; Iris is recycling capacity automatically.
+- Next action: keep both tasks queued on v5p-8. A v5p-16 would make throughput incomparable with the published v5p-8 baseline.
+
+### 2026-08-18 12:26 PDT - Standalone TPU CI fixed
+
+- Result: the TPU check exposed that ordinary TPU arrays carry a named sharding with an empty abstract mesh. The explicit-mesh wrapper attempted to reshard those arrays and made every direct Pallas test fail before kernel execution.
+- Action: bypass the wrapper for empty meshes and use explicit `NamedSharding` values when a real mesh is present. Added a lowering regression for the empty-mesh case.
+- Validation: the fresh Levanter TPU check passed all 138 selected tests. Local kernel selection passed 72 tests with 60 TPU-only cases skipped.
+- Interpretation: this was a wrapper regression introduced while adapting the kernel to Grug's explicit mesh, not a numerical failure in the Pallas convolution core.

--- a/.agents/logbooks/moe-pallas-sconv-v5p8.md
+++ b/.agents/logbooks/moe-pallas-sconv-v5p8.md
@@ -1,0 +1,125 @@
+---
+topic: moe-pallas-sconv-v5p8
+issue: https://github.com/marin-community/marin/issues/8377
+description: Verify the Pallas depthwise causal convolution in the Grug MoE recipe on v5p-8.
+author: held
+---
+
+# MoE Pallas SConv v5p-8: Task Logbook
+
+## Current TL;DR
+
+The implementation and v5p-8 smoke run are in progress. No runtime result is available yet.
+
+## Scope
+
+- Goal: verify that the #8331 Pallas convolution compiles and trains in the four-site Inkling SConv configuration on one v5p-8.
+- Primary metrics: terminal Iris state, finite training loss, `throughput/tokens_per_second`, and final W&B state.
+- Constraints: d512 May Recipe shape, kernel size 4, K/V/attention-output/MLP-output sites, identity initialization, packed-document boundary masking, 25 training steps.
+- Coordinating issue: https://github.com/marin-community/marin/issues/8377
+
+## Baseline
+
+- Date: 2026-08-17
+- Code refs: #7585 and #8331.
+- Prior result: the d1024 four-site shift-and-sum SConv run reached Paloma macro loss 3.0378 versus 3.0610 without convolution. This smoke test has no quality comparator.
+
+## Hypothesis Queue
+
+### Active
+
+- `MOE-PSC-001`: the four-site Pallas SConv compiles and completes 25 d512 training steps on v5p-8 with finite loss. Next test: submit the smoke run.
+
+### Blocked
+
+None.
+
+### Falsified / Dead End
+
+None.
+
+### Promoted
+
+None.
+
+## Background Research Brief
+
+- Effort: low
+- Stop rule: stop after the prior Marin ablation, kernel PR, and primary architecture source agree on the placement and kernel width.
+- Date: 2026-08-17
+
+### Question
+
+Can Mayank's Pallas TPU depthwise causal convolution replace the prior shift-and-sum SConv implementation without changing the four-site ablation semantics?
+
+### Current Marin Context
+
+#7585 found a positive quality signal for kernel-size-4 SConv at K, V, attention output, and MLP output. #8331 provides a TPU-specific forward/backward kernel and an XLA reference, but its binary attention mask does not encode packed-document boundaries.
+
+### External Prior Art
+
+Inkling uses short causal convolutions with kernel size 4 in the K stream, V stream, attention output, and MLP output. The public model and architecture description are available from [Thinking Machines](https://huggingface.co/thinkingmachines/Inkling) and the [LMSYS implementation overview](https://www.lmsys.org/blog/2026-07-15-inkling-day0-support).
+
+### Negative / Failed Leads
+
+- A binary per-token mask cannot remove every cross-document tap while preserving valid tokens near an internal packed-document boundary. The variant subtracts only the invalid lag contributions after the fused convolution.
+
+### Evidence Map
+
+#### Claim: four-site kernel-size-4 SConv is the correct smoke configuration
+
+- Support:
+  - #7585: completed Marin loss ablation across sites and depths.
+  - Thinking Machines Inkling model: public architecture uses short convolution.
+  - LMSYS Inkling overview: identifies the four sites and kernel size 4.
+- Contradictions:
+  - #7585 found V-only had the smallest single-site gain, and the latest recipe drops V. This smoke retains V to match the completed four-site comparator.
+- Directness to Marin: #7585 uses the same Grug MoE family; #8331 targets TPU.
+- Confidence: exploratory until the v5p-8 run completes.
+- Action: run `MOE-PSC-001` before any full Gate 1 cells.
+
+### Recommended Next Experiments
+
+#### 1. v5p-8 integration smoke
+
+- Minimum experiment: 25 d512 training steps with all four SConv sites.
+- Baseline/control: successful compilation and finite loss; quality comparison is out of scope.
+- Expected signal: terminal success with advancing W&B steps and nonzero throughput.
+- Falsifier: compilation, forward/backward, non-finite loss, or checkpoint failure.
+- Cost/risk: one short v5p-8 allocation; TPU capacity may delay scheduling.
+- Sources: #7585, #8331.
+
+### Hypothesis Queue Update
+
+- Add: `MOE-PSC-001` integration smoke.
+- Revise: none.
+- Falsify / stop: none.
+- Promote: full d512/d768 Gate 1 only after smoke success.
+
+### Source Ledger
+
+| Source | Type | Location | Claim used for | Confidence | Notes |
+|---|---|---|---|---|---|
+| Marin SConv ablation | GitHub issue | https://github.com/marin-community/marin/issues/7585 | placement, width, prior quality | high | Direct Marin experiment |
+| Pallas convolution | PR | https://github.com/marin-community/marin/pull/8331 | TPU implementation and mask contract | high | Exact branch under test |
+| Inkling model | model card | https://huggingface.co/thinkingmachines/Inkling | architecture origin | medium | Public primary model artifact |
+| Inkling implementation overview | official engineering post | https://www.lmsys.org/blog/2026-07-15-inkling-day0-support | four sites and kernel width | medium | External implementation description |
+
+### Handoff
+
+- Suggested issue `Prior work` block: #7585 established the quality signal; #8331 supplies the TPU kernel.
+- Suggested logbook entry: record the exact Iris command, job ID, W&B run, loss, throughput, and terminal state.
+- Open questions: TPU compile behavior and net throughput.
+- Stop reason: the sources agree on the minimum integration experiment.
+
+## Entry Log
+
+### 2026-08-17 16:45 PDT - v5p-8 smoke snapshot
+
+- Hypothesis: `MOE-PSC-001` completes 25 d512 training steps on one v5p-8 with finite loss.
+- Commit Hash: `07c6833f4d`
+- Command: `.venv/bin/iris --cluster=marin job run --no-wait --preemptible --reserve v5p-8 --job-name moe-pallas-sconv-smoke-8377 -e WANDB_API_KEY "$WANDB_API_KEY" -- python -m experiments.grug.moe_pallas_sconv.launch --version dev --run`
+- Config: d512, 6 layers, batch 32, sequence length 8192, 25 steps, 256 experts/top-4, MuonH, kernel-size-4 SConv at K/V/attention-output/MLP-output, v5p-8 child resources, W&B group `MOE-PSC-issue-8377`.
+- Result: four segmented value/gradient and optimizer tests passed; 67 XLA reference tests passed; the two Grug variant contract cases passed; the lazy experiment graph resolves with the intended shape, resources, tracker, and step count.
+- Interpretation: CPU/XLA behavior and explicit-sharding lowering are validated. TPU compilation and training remain untested until Iris submission.
+- Next action: push the snapshot and submit `MOE-PSC-001` to Iris.

--- a/.agents/logbooks/moe-pallas-sconv-v5p8.md
+++ b/.agents/logbooks/moe-pallas-sconv-v5p8.md
@@ -123,3 +123,20 @@ Inkling uses short causal convolutions with kernel size 4 in the K stream, V str
 - Result: four segmented value/gradient and optimizer tests passed; 67 XLA reference tests passed; the two Grug variant contract cases passed; the lazy experiment graph resolves with the intended shape, resources, tracker, and step count.
 - Interpretation: CPU/XLA behavior and explicit-sharding lowering are validated. TPU compilation and training remain untested until Iris submission.
 - Next action: push the snapshot and submit `MOE-PSC-001` to Iris.
+
+### 2026-08-17 18:10 PDT - Iris submission
+
+- Commit Hash: `1619d1cf90`
+- Coordinator: `/held/moe-pallas-sconv-smoke-8377`
+- Training child: `/held/moe-pallas-sconv-smoke-8377/grug-train-MOE-PSC-001-d512-v5p8-smoke`
+- W&B: https://wandb.ai/marin-community/marin_moe/runs/MOE-PSC-001-d512-v5p8-smoke
+- Status: the child acquired one v5p-8 in us-central1-a, initialized JAX across four chips, authenticated to W&B, and began loading the training cache.
+- Next action: monitor compilation, all 25 steps, final checkpoint publication, Iris success, and W&B completion.
+
+### 2026-08-17 18:12 PDT - Explicit-mesh lowering failure
+
+- Result: the first attempt failed before compilation with `AssertionError: (2, P(('replica_dcn', 'data', 'expert'), None, 'model'))`. Iris retried once after the process aborted.
+- Interpretation: the Pallas call received globally sharded arrays under an explicit mesh. Its block mapping operates on shard-local ranks and requires a manual-axis `shard_map` boundary.
+- Action: stopped the coordinator, wrapped the Pallas implementation in `shard_map`, sharded convolution channels over the model axis, and added an abstract-mesh lowering regression.
+- Validation: the lowering regression and six targeted numerical, gradient, mask, and optimizer tests passed. The full targeted kernel and variant selection also passed.
+- Next action: publish the fix snapshot and resubmit the smoke run.

--- a/docs/reports/grug-archive.md
+++ b/docs/reports/grug-archive.md
@@ -47,6 +47,7 @@ goes stale on the next commit.
 - Path: `experiments/grug/moe_pallas_sconv/`
 - Origin: `moe` at `1b7f389d47`
 - Introduced: 07c6833f4d
+- Last known-good: fca2870b85
 - Status: active
 - Purpose: v5p-8 integration smoke for the four-site Inkling SConv using the Pallas TPU kernel from #8331.
 - Issue: https://github.com/marin-community/marin/issues/8377

--- a/docs/reports/grug-archive.md
+++ b/docs/reports/grug-archive.md
@@ -43,6 +43,14 @@ goes stale on the next commit.
 - Purpose: canonical Mixture-of-Experts variant; carries its own model, optimizer, train loop, and launch wiring so it can iterate independently of the dense template.
 - Issue: https://github.com/marin-community/marin/pull/3046
 
+### grug-moe-pallas-sconv
+- Path: `experiments/grug/moe_pallas_sconv/`
+- Origin: `moe` at `1b7f389d47`
+- Introduced: 07c6833f4d
+- Status: active
+- Purpose: v5p-8 integration smoke for the four-site Inkling SConv using the Pallas TPU kernel from #8331.
+- Issue: https://github.com/marin-community/marin/issues/8377
+
 ### grug-moe-hero-ep
 - Path: `experiments/grug/moe_hero_ep/`
 - Origin: `moe_hero_fsdp` at PR 7876

--- a/experiments/grug/moe_pallas_sconv/README.md
+++ b/experiments/grug/moe_pallas_sconv/README.md
@@ -1,0 +1,7 @@
+# Grug MoE Pallas SConv smoke
+
+This variant copies `experiments/grug/moe` and adds kernel-size-4 depthwise causal convolutions after the K and V projections and on the attention and MoE branch outputs. It uses the Pallas TPU kernel from #8331, identity-initializes every convolution, and removes cross-document tap contributions for packed examples.
+
+`launch.py` runs `MOE-PSC-001`, a 25-step d512 smoke test on one v5p-8. It verifies TPU compilation and training before the full two-scale Gate 1 comparison in `experiments/grug/moe/agent.md`.
+
+Tracking issue: https://github.com/marin-community/marin/issues/8377

--- a/experiments/grug/moe_pallas_sconv/README.md
+++ b/experiments/grug/moe_pallas_sconv/README.md
@@ -2,6 +2,6 @@
 
 This variant copies `experiments/grug/moe` and adds kernel-size-4 depthwise causal convolutions after the K and V projections and on the attention and MoE branch outputs. It uses the Pallas TPU kernel from #8331, identity-initializes every convolution, and removes cross-document tap contributions for packed examples.
 
-`launch.py` runs `MOE-PSC-001`, a 25-step d512 smoke test on one v5p-8. It verifies TPU compilation and training before the full two-scale Gate 1 comparison in `experiments/grug/moe/agent.md`.
+`launch.py` runs `MOE-PSC-001`, a 25-step d512 smoke test on one v5p-8. It verifies TPU compilation and training before a controlled quality or throughput comparison.
 
 Tracking issue: https://github.com/marin-community/marin/issues/8377

--- a/experiments/grug/moe_pallas_sconv/__init__.py
+++ b/experiments/grug/moe_pallas_sconv/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/experiments/grug/moe_pallas_sconv/adamh.py
+++ b/experiments/grug/moe_pallas_sconv/adamh.py
@@ -1,0 +1,78 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Local copy of AdamH for iteration without modifying Levanter.
+# Adapted from levanter.optim.adamh.
+
+from typing import Any, NamedTuple
+
+import chex
+import jax
+import jax.numpy as jnp
+import optax
+from optax import tree_utils as otu
+
+
+class ScaleByAdamHState(NamedTuple):
+    count: chex.Array
+    mu: optax.Updates
+    nu: optax.Updates
+
+
+def scale_by_adamh(
+    b1: float = 0.9,
+    b2: float = 0.999,
+    eps: float = 1e-8,
+    learning_rate: float = 0.02,
+    mu_dtype: Any | None = None,
+) -> optax.GradientTransformation:
+    mu_dtype = jax.dtypes.canonicalize_dtype(mu_dtype)
+
+    def init_fn(params):
+        mu = otu.tree_zeros_like(params, dtype=mu_dtype)
+        nu = otu.tree_zeros_like(params)
+        return ScaleByAdamHState(count=jnp.zeros([], jnp.int32), mu=mu, nu=nu)
+
+    def update_fn(updates, state, params):
+        mu = otu.tree_update_moment(updates, state.mu, b1, 1)
+        nu = otu.tree_update_moment_per_elem_norm(updates, state.nu, b2, 2)
+        count_inc = optax.safe_increment(state.count)
+        mu_hat = otu.tree_bias_correction(mu, b1, count_inc)
+        nu_hat = otu.tree_bias_correction(nu, b2, count_inc)
+
+        adam_updates = jax.tree.map(
+            lambda m, v: None if m is None else m / (jnp.sqrt(v) + eps),
+            mu_hat,
+            nu_hat,
+            is_leaf=lambda x: x is None,
+        )
+        mu = otu.tree_cast(mu, mu_dtype)
+
+        def _scale_invariant_2d(p, u):
+            """Core update for a 2-D (matrix) parameter."""
+            p_norm = jnp.linalg.norm(p)
+            u_norm = jnp.linalg.norm(u)
+            new_p = p - learning_rate * u * p_norm / jnp.maximum(u_norm, 1e-10)
+            return new_p / jnp.linalg.norm(new_p) * p_norm - p
+
+        def scale_invariant_update(p, u):
+            if p is None:
+                return None
+            if p.ndim <= 2:
+                return _scale_invariant_2d(p, u)
+            # For higher-rank tensors, vmap the 2-D logic over the leading axis.
+            return jax.vmap(_scale_invariant_2d)(p, u)
+
+        adamh_updates = jax.tree_util.tree_map(
+            scale_invariant_update,
+            params,
+            adam_updates,
+            is_leaf=lambda x: x is None,
+        )
+
+        return adamh_updates, ScaleByAdamHState(count=count_inc, mu=mu, nu=nu)
+
+    return optax.GradientTransformation(init_fn, update_fn)
+
+
+__all__ = ["ScaleByAdamHState", "scale_by_adamh"]

--- a/experiments/grug/moe_pallas_sconv/heuristic.py
+++ b/experiments/grug/moe_pallas_sconv/heuristic.py
@@ -1,0 +1,264 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compute-scaling heuristic for MoE — May Recipe (MuonH, 256 experts).
+
+Refit on the May Recipe LR sweep (issue #5951: 17 cells across
+d ∈ {512, 768, 1024, 1280}, MuonH optimizer, R²=0.996), and is the
+current default for compute-optimal cells and ablation comparisons.
+All empirical fits were measured on runs with seq_len=4096; the
+formulas are written in terms of ``tokens_per_batch = batch_size *
+seq_len`` so they generalise to other sequence lengths, though the
+coefficients are an extrapolation beyond 4096.
+
+For the earlier AdamH-tuned heuristic (64 experts), see the pre-rename
+``experiments/grug/moe/heuristic.py`` on main:
+https://github.com/marin-community/marin/blob/8586719b524bf7743ec5034403c7e834505fe73e/experiments/grug/moe/heuristic.py
+
+Formulas:
+- Adam LR: ``adam_lr = lr_coeff * tokens^lr_tokens_exp * dim^lr_dim_exp * sqrt(B)``
+  (``lr_coeff = 0.06602``, ``lr_tokens_exp = -0.395``, ``lr_dim_exp = -0.150``)
+- MuonH/AdamH LR: ``lr = (13/3) * adam_lr``
+- Compute budget convention: ``C = 3 * flops_per_token(no_lm_head) * tokens``
+- Epsilon: ``epsilon = epsilon_base * sqrt(r0/r)`` where ``r = (B*T0)/(B0*T)``
+- Beta1: fixed at ``0.9062``
+- Beta2: ``beta2 = clip(beta2_base^(B/B0), min_beta2, max_beta2)``
+"""
+
+import math
+from dataclasses import dataclass
+
+from levanter.utils.flop_utils import lm_flops_per_token
+
+from experiments.grug.moe_pallas_sconv.model import GrugModelConfig
+from experiments.grug.moe_pallas_sconv.optimizer import GrugMoeMuonHConfig
+
+SEQ_LEN: int = 8192
+MIN_BATCH_SIZE: int = 32
+DEFAULT_TARGET_STEPS: int = 2**14
+
+
+def _round_to_power_of_two(x: float) -> int:
+    if x <= 1:
+        return 1
+    return 2 ** math.ceil(math.log2(x))
+
+
+def compute_flops_per_token(cfg: GrugModelConfig) -> float:
+    """Non-embedding FLOPs per token (excludes lm_head)."""
+    fpt_with_lm_head = lm_flops_per_token(
+        hidden_dim=cfg.hidden_dim,
+        intermediate_dim=cfg.intermediate_dim,
+        num_layers=cfg.num_layers,
+        num_kv_heads=cfg.num_kv_heads,
+        num_heads=cfg.num_heads,
+        seq_len=cfg.max_seq_len,
+        vocab_size=cfg.vocab_size,
+        glu=True,
+        num_experts=cfg.num_experts,
+        num_shared_experts=1 if cfg.shared_expert_intermediate_dim > 0 else 0,
+        num_experts_per_tok=cfg.num_experts_per_token,
+        shared_intermediate_dim=cfg.shared_expert_intermediate_dim,
+    )
+    return fpt_with_lm_head - 2 * cfg.hidden_dim * cfg.vocab_size
+
+
+def compute_tokens_and_batch(
+    budget: float,
+    flops_per_token: float,
+    target_steps: int = DEFAULT_TARGET_STEPS,
+    min_batch_size: int = MIN_BATCH_SIZE,
+    seq_len: int = SEQ_LEN,
+) -> tuple[float, int, int]:
+    """Derive (tokens, batch_size, num_steps) from a compute budget and FLOPs-per-token.
+
+    ``seq_len`` controls the sequence length used to convert between batch_size
+    (sequences) and tokens_per_batch (tokens per step). All downstream formulas
+    that depend on batch size use ``tokens_per_batch = batch_size * seq_len``
+    so they work correctly at any sequence length.
+    """
+    tokens = budget / (3 * flops_per_token)
+    batch_exact = tokens / (target_steps * seq_len)
+    batch_size = max(min_batch_size, _round_to_power_of_two(batch_exact))
+    train_steps = max(1, round(tokens / (batch_size * seq_len)))
+    return tokens, batch_size, train_steps
+
+
+@dataclass(frozen=True)
+class MoeHeuristic:
+    """Compute-scaling heuristic for MoE models (May Recipe refit).
+
+    Returns a ``MuonH`` optimizer config via ``build_optimizer_config``.
+
+    ``adam_lr  = lr_coeff * tokens^lr_tokens_exp * dim^lr_dim_exp * sqrt(tokens_per_batch)``
+    ``muonh_lr = muonh_ratio * adam_lr``
+    ``C       = 3 * flops_per_token * tokens``  (flops_per_token excludes lm_head)
+    """
+
+    # --- LR scaling ---
+    # May Recipe refit (issue #5951; 17 cells across d{512,768,1024,1280},
+    # R^2=0.996):  muonh_lr = 18.31 * tokens^-0.395 * dim^-0.150 * sqrt(B).
+    lr_coeff: float = 0.06602
+    lr_tokens_exp: float = -0.395
+    lr_dim_exp: float = -0.150
+    muonh_ratio: float = 13 / 3
+
+    # --- Base hyperparameters ---
+    epsilon_coeff: float = 9.676e-18
+    beta1: float = 0.9062
+    beta2_base: float = 0.999
+    beta2_reference_tpb: int = 131_072  # beta2 = beta2_base^(tpb / beta2_reference_tpb)
+
+    # --- Fixed hyperparameters ---
+    max_grad_norm: float = 1.0
+
+    # --- Schedule ---
+    min_lr_ratio: float = 0.05
+    lr_schedule: str = "linear"
+    decay: float | None = None
+
+    # --- Architecture ---
+    vocab_size: int = 128_256
+    hidden_head_ratio: int = 128
+    gqa_ratio: int | None = 4  # None = MHA, 4 = 4:1 GQA, etc.
+    base_hidden_layer_ratio: int = 64
+    layer_scaling_factor: float = 4.0
+    layer_formula_offset: int = 9
+
+    # --- Constraints ---
+    max_learning_rate: float = 0.05
+    min_beta2: float = 0.95
+    max_beta2: float = 0.9999
+
+    def _compute_adam_lr(self, tokens_per_batch: int, tokens: float, hidden_dim: int) -> float:
+        """adam_lr = lr_coeff * tokens^lr_tokens_exp * dim^lr_dim_exp * sqrt(tokens_per_batch)"""
+        adam_lr = (
+            self.lr_coeff * (tokens**self.lr_tokens_exp) * (hidden_dim**self.lr_dim_exp) * math.sqrt(tokens_per_batch)
+        )
+        return min(self.max_learning_rate, adam_lr)
+
+    def _compute_learning_rate(self, tokens_per_batch: int, tokens: float, hidden_dim: int) -> float:
+        """muonh_lr = muonh_ratio * adam_lr"""
+        adam_lr = self._compute_adam_lr(tokens_per_batch, tokens, hidden_dim)
+        return min(self.max_learning_rate, self.muonh_ratio * adam_lr)
+
+    def _compute_epsilon(self, tokens_per_batch: int, tokens: float) -> float:
+        """epsilon = epsilon_coeff * sqrt(tokens / tokens_per_batch)"""
+        return self.epsilon_coeff * math.sqrt(tokens / tokens_per_batch)
+
+    def _compute_beta2(self, tokens_per_batch: int) -> float:
+        """beta2 = clip(beta2_0^(tpb/tpb0), min_beta2, max_beta2). Constant token half-life."""
+        exponent = tokens_per_batch / self.beta2_reference_tpb
+        return max(self.min_beta2, min(self.max_beta2, self.beta2_base**exponent))
+
+    def build_optimizer_config(
+        self, batch_size: int, tokens: float, hidden_dim: int, seq_len: int = SEQ_LEN
+    ) -> GrugMoeMuonHConfig:
+        """Return a ``GrugMoeMuonHConfig`` with May Recipe 1pct-noclip defaults.
+
+        MuonH optimizer (3 LR groups — muonh / adamh / adam) with
+        ``warmup=0.01`` and ``max_grad_norm=None``. LR / beta / epsilon
+        scaling is the May Recipe refit (see module docstring).
+        """
+        tokens_per_batch = batch_size * seq_len
+        lr = self._compute_learning_rate(tokens_per_batch, tokens, hidden_dim)
+        adam_lr = self._compute_adam_lr(tokens_per_batch, tokens, hidden_dim)
+        epsilon = self._compute_epsilon(tokens_per_batch, tokens)
+        beta2 = self._compute_beta2(tokens_per_batch)
+        return GrugMoeMuonHConfig(
+            learning_rate=lr,
+            adam_lr=adam_lr,
+            min_lr_ratio=self.min_lr_ratio,
+            warmup=0.01,  # 1pct-noclip schedule
+            beta1=self.beta1,
+            beta2=beta2,
+            epsilon=epsilon,
+            max_grad_norm=None,  # no clipping
+            lr_schedule=self.lr_schedule,
+            decay=self.decay,
+        )
+
+    def _compute_num_layers(self, hidden_size: int) -> int:
+        hs_pow = math.log2(hidden_size)
+        return round(
+            hidden_size
+            / (self.base_hidden_layer_ratio + (hs_pow * self.layer_scaling_factor) - self.layer_formula_offset)
+        )
+
+    def _get_step_size(self, budget: float) -> int:
+        if budget > self.budget_step_threshold:
+            return self.large_budget_step_size
+        return self.small_budget_step_size
+
+    def _max_params_for_budget(self, budget: float) -> float:
+        scaling = self.base_max_params * math.sqrt(budget / self.base_max_params_budget)
+        return min(max(self.base_max_params, scaling), self.global_max_params)
+
+    @staticmethod
+    def _compute_kv_heads(num_heads: int, gqa_ratio: int | None) -> int:
+        """Compute num_kv_heads for a given GQA ratio.
+
+        If gqa_ratio is None, returns num_heads (MHA).
+        Otherwise returns the largest divisor of num_heads <= num_heads // gqa_ratio.
+        """
+        if gqa_ratio is None:
+            return num_heads
+        target = num_heads // gqa_ratio
+        for k in range(target, 0, -1):
+            if num_heads % k == 0:
+                return k
+        return 1
+
+    def build_model_config(self, hidden_size: int, seq_len: int = SEQ_LEN) -> GrugModelConfig:
+        if hidden_size % self.hidden_head_ratio != 0:
+            raise ValueError(
+                f"hidden_size ({hidden_size}) must be divisible by hidden_head_ratio ({self.hidden_head_ratio})."
+            )
+        num_layers = self._compute_num_layers(hidden_size)
+        num_heads = max(1, hidden_size // self.hidden_head_ratio)
+        num_kv_heads = self._compute_kv_heads(num_heads, self.gqa_ratio)
+
+        return GrugModelConfig(
+            vocab_size=self.vocab_size,
+            hidden_dim=hidden_size,
+            # Round up to nearest 128 for Pallas TPU MoE kernel compatibility
+            intermediate_dim=math.ceil(hidden_size / 2 / 128) * 128,
+            shared_expert_intermediate_dim=hidden_size,
+            num_layers=num_layers,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            max_seq_len=seq_len,
+            sliding_window=2048,
+            initializer_std=0.5 / math.sqrt(hidden_size),
+            qk_mult=1.3,
+        )
+
+
+def build_from_heuristic(
+    *,
+    budget: float,
+    hidden_dim: int,
+    heuristic: MoeHeuristic | None = None,
+    target_steps: int = DEFAULT_TARGET_STEPS,
+    min_batch_size: int = MIN_BATCH_SIZE,
+    seq_len: int = SEQ_LEN,
+) -> tuple[GrugModelConfig, GrugMoeMuonHConfig, int, int]:
+    """Construct (model, optimizer, batch_size, num_steps) for a compute budget.
+
+    Uses ``MoeHeuristic`` to size the model (from ``hidden_dim``) and to set
+    the MuonH hyperparameters (scaled by tokens_per_batch = batch_size * seq_len).
+    Callers who want manual control should continue passing ``GrugModelConfig`` /
+    ``GrugMoeMuonHConfig`` directly to ``GrugMoeLaunchConfig``.
+    """
+    h = heuristic or MoeHeuristic()
+    model_cfg = h.build_model_config(hidden_dim, seq_len=seq_len)
+    fpt = compute_flops_per_token(model_cfg)
+    tokens, batch_size, num_steps = compute_tokens_and_batch(
+        budget,
+        fpt,
+        target_steps=target_steps,
+        min_batch_size=min_batch_size,
+        seq_len=seq_len,
+    )
+    optimizer_cfg = h.build_optimizer_config(batch_size, tokens, hidden_dim, seq_len=seq_len)
+    return model_cfg, optimizer_cfg, batch_size, num_steps

--- a/experiments/grug/moe_pallas_sconv/launch.py
+++ b/experiments/grug/moe_pallas_sconv/launch.py
@@ -198,6 +198,33 @@ _smoke_model, _smoke_optimizer, _smoke_batch, _ = build_from_heuristic(
 GRUG_MOE_TRIAL_MODEL: GrugModelConfig = _smoke_model
 
 
+@dataclass(frozen=True)
+class _ScaleConfig:
+    experiment_id: str
+    gate: int
+    hidden_dim: int
+    budget: float
+    target_steps: int
+
+    @property
+    def label(self) -> str:
+        return f"d{self.hidden_dim}"
+
+    @property
+    def run_id(self) -> str:
+        return f"{self.experiment_id}-{self.label}-v5p8-gate{self.gate}"
+
+
+_GATE_1_SCALES = (
+    _ScaleConfig("MOE-PSC-101", 1, 512, 3.82e17, 10_980),
+    _ScaleConfig("MOE-PSC-102", 1, 768, 2.81e18, 16_875),
+)
+_GATE_2_SCALES = (
+    _ScaleConfig("MOE-PSC-201", 2, 1024, 1.16e19, 16_080),
+    _ScaleConfig("MOE-PSC-202", 2, 1280, 3.46e19, 14_325),
+)
+
+
 def grug_moe_pallas_sconv_smoke(*, version: str | None = None) -> ArtifactStep[LevanterCheckpoint]:
     """Run the d512 four-site Pallas SConv smoke test on the Nemotron mix.
 
@@ -248,6 +275,73 @@ def grug_moe_pallas_sconv_smoke(*, version: str | None = None) -> ArtifactStep[L
         deps=(*train, *validation),
         runtime_args={"train_resources": _TRAIN_RESOURCES},
     )
+
+
+def _grug_moe_pallas_sconv_scale(scale: _ScaleConfig, *, version: str | None = None) -> ArtifactStep[LevanterCheckpoint]:
+    name = f"grug/moe_pallas_sconv_gate{scale.gate}_{scale.label}"
+    version = resolve_version(name, version)
+    model, optimizer, batch_size, steps = build_from_heuristic(
+        budget=scale.budget,
+        hidden_dim=scale.hidden_dim,
+        target_steps=scale.target_steps,
+    )
+    nem = nemotron_datasets(tokenizer=llama3_tokenizer)
+    train = {nem[split]: weight for split, weight in _NEMOTRON_WEIGHTS.items()}
+    train[starcoder_dataset(tokenizer=llama3_tokenizer)] = _STARCODER_WEIGHT
+    train[proofpile_dataset(tokenizer=llama3_tokenizer)] = _PROOFPILE_WEIGHT
+    validation = [
+        *paloma_datasets(tokenizer=llama3_tokenizer).values(),
+        *uncheatable_datasets(tokenizer=llama3_tokenizer).values(),
+    ]
+
+    def build_config(ctx: StepContext) -> GrugMoeLaunchConfig:
+        return GrugMoeLaunchConfig(
+            model=model,
+            data=mixture(ctx, train, validation=validation),
+            output_path=ctx.output_path,
+            run_id=scale.run_id,
+            resources=ctx.runtime_arg("train_resources"),
+            steps=steps,
+            batch_size=batch_size,
+            seed=0,
+            mp="params=float32,compute=bfloat16,output=bfloat16",
+            tracker=WandbConfig(
+                entity="marin-community",
+                project="marin_moe",
+                tags=["MOE-PSC", "issue-8377", f"gate-{scale.gate}", scale.label, "pallas-sconv"],
+                group="MOE-PSC-gates-issue-8377",
+                name=None,
+            ),
+            optimizer=optimizer,
+            grug_trainer=GrugTrainerConfig(z_loss_weight=1e-4, ema_beta=None, log_every=1),
+            eval=GrugEvalConfig(
+                eval_batch_size=512,
+                steps_per_eval=1000,
+                max_eval_batches=8,
+                eval_current=True,
+                eval_ema=False,
+            ),
+        )
+
+    return ArtifactStep(
+        name=user_namespaced_name(name, version),
+        version=version,
+        artifact_type=LevanterCheckpoint,
+        run=run_grug_moe_trial,
+        build_config=build_config,
+        deps=(*train, *validation),
+        runtime_args={"train_resources": _TRAIN_RESOURCES},
+    )
+
+
+def grug_moe_pallas_sconv_gate1(*, version: str | None = None) -> dict[str, ArtifactStep[LevanterCheckpoint]]:
+    """Build the d512 and d768 Gate 1 experiments."""
+    return {scale.label: _grug_moe_pallas_sconv_scale(scale, version=version) for scale in _GATE_1_SCALES}
+
+
+def grug_moe_pallas_sconv_gate2(*, version: str | None = None) -> dict[str, ArtifactStep[LevanterCheckpoint]]:
+    """Build the d1024 and d1280 Gate 2 experiments."""
+    return {scale.label: _grug_moe_pallas_sconv_scale(scale, version=version) for scale in _GATE_2_SCALES}
 
 
 if __name__ == "__main__":

--- a/experiments/grug/moe_pallas_sconv/launch.py
+++ b/experiments/grug/moe_pallas_sconv/launch.py
@@ -1,0 +1,254 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""grug-moe trial run, authored as a lazy artifact.
+
+The run is a function that returns a typed :class:`Checkpoint` handle addressed by an
+explicit ``name@version``. The model, optimizer, data mixture, token budget, z-loss,
+and evals are all stated inline; the output path is ``ctx.output_path`` and the TPU is a
+run-arg, so neither bears on the artifact's identity.
+
+The grug-moe training mechanism (``GrugMoeLaunchConfig`` + ``run_grug_moe_trial`` ->
+``run_grug``) is grug-specific compute and is kept as-is: the recipe's ``fn`` is
+``run_grug_moe_trial``, which builds the Levanter trainer and dispatches the training
+job to Fray. Only the data/validation wiring around it is assembled lazily from
+dataset handles.
+"""
+
+import dataclasses
+import os
+from dataclasses import dataclass, field
+from datetime import timedelta
+
+import jmp
+from fray.cluster import ResourceConfig
+from levanter.callbacks.profiler import ProfilerConfig
+from levanter.checkpoint import CheckpointerConfig, latest_checkpoint_path
+from levanter.data.text.datasets import LmDataConfig
+from levanter.optim.config import OptimizerConfig
+from levanter.tracker import TrackerConfig
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
+from marin.execution.build_context import resolve_version
+from marin.execution.lazy import ArtifactStep, StepContext
+from marin.experiment.cli import experiment_main
+from marin.experiment.data import mixture, tokenized
+from marin.experiment.namespacing import user_namespaced_name
+from marin.processing.tokenize.tokenize import TokenizedCache
+from marin.training.training import LevanterCheckpoint, resolve_checkpointer_output_path
+
+from experiments.datasets.nemotron import nemotron_datasets
+from experiments.datasets.paloma import paloma_datasets
+from experiments.datasets.proofpile import proofpile_dataset
+from experiments.datasets.starcoder import starcoder_dataset
+from experiments.datasets.uncheatable import uncheatable_datasets
+from experiments.grug.moe_pallas_sconv.heuristic import build_from_heuristic
+from experiments.grug.moe_pallas_sconv.model import GrugModelConfig
+from experiments.grug.moe_pallas_sconv.train import GrugEvalConfig, GrugRunConfig, GrugTrainerConfig, run_grug
+from experiments.llama import llama3_tokenizer
+
+# SlimPajama-6B tokenization OOMs at the default 10g worker resources.
+_SLIMPAJAMA_TOKENIZE_RESOURCES = ResourceConfig(ram="64g", disk="64g")
+
+# The TPU the training job is dispatched onto. A run-arg, not part of the config's
+# identity: re-running on a different TPU is the same checkpoint. The launcher step
+# runs inline (run_grug dispatches its own Fray job).
+_TRAIN_RESOURCES = ResourceConfig.with_tpu("v5p-8")
+
+# Nemotron CC mixture weights: the corpus's TiB proportions, plus starcoder and
+# proof-pile at their published weights. Policy lives here, in the experiment.
+_NEMOTRON_WEIGHTS = {
+    "hq_actual": 0.91351,
+    "hq_synth": 2.72,
+    "medium_high": 0.82471,
+    "medium": 3.38,
+    "medium_low": 1.54,
+    "low_actual": 0.70123,
+    "low_synth": 0.62771,
+}
+_STARCODER_WEIGHT = 0.25
+_PROOFPILE_WEIGHT = 0.055
+
+
+@dataclass(frozen=True)
+class GrugMoeLaunchConfig:
+    """Last-mile run config for the MoE grug template.
+
+    Keep this as the main entry point for day-to-day edits (model/data/optimizer/trainer/eval knobs).
+    """
+
+    model: GrugModelConfig
+    data: LmDataConfig
+    output_path: str
+    run_id: str
+    resources: ResourceConfig
+    steps: int
+    batch_size: int
+    seed: int
+    mp: str  # jmp policy string, e.g. "params=float32,compute=bfloat16,output=bfloat16".
+    tracker: TrackerConfig
+    optimizer: OptimizerConfig
+    profiler: ProfilerConfig = field(default_factory=ProfilerConfig)
+    grug_trainer: GrugTrainerConfig = field(default_factory=GrugTrainerConfig)
+    eval: GrugEvalConfig | None = field(default_factory=GrugEvalConfig)
+    processes_per_task: int = 1
+    """GPU processes per task. > 1 fans each node into one JAX process per GPU
+    (multi-controller) via the iris.hooks.multigpu_main supervisor; 1 keeps the
+    single-process-per-node model."""
+    checkpointer: CheckpointerConfig | None = None
+    """Override the checkpointer. None builds the default (periodic + final saves
+    under output_path). Throughput experiments point this at node-local disk so a
+    slow object-store commit can't wedge the end-of-run barrier."""
+    init_from: str | None = None
+    """Checkpoint base directory to initialize weights from (the latest checkpoint
+    under it is loaded). None trains from scratch. Used to chain training phases —
+    a midtrain/SFT/RL run points this at the prior phase's ``checkpoints`` directory."""
+
+
+def env_int(key: str, default: int) -> int:
+    """Read an int from ``os.environ[key]``, falling back to ``default`` when unset/empty."""
+    raw = os.environ.get(key, "")
+    return int(raw) if raw else default
+
+
+def slimpajama_6b_dataset() -> ArtifactStep[TokenizedCache]:
+    """SlimPajama-6B, llama3-tokenized — a small corpus for GPU smoke/scale runs.
+
+    Returns the tokenized :class:`TokenizedCache` handle; the launcher assembles it into an
+    ``LmDataConfig`` with :func:`~marin.experiment.data.mixture`. Tokenization runs as
+    its own Fray job (a production pretraining mixture would instead pin an already
+    materialized cache to avoid a cross-region tokenize).
+    """
+    return tokenized(
+        "slimpajama-6b",
+        source="DKYoon/SlimPajama-6B",
+        tokenizer=llama3_tokenizer,
+        resources=_SLIMPAJAMA_TOKENIZE_RESOURCES,
+        version="2026.06.28",
+    )
+
+
+def _resolve_run_id(default_run_id: str) -> str:
+    """Resolve run id and append `FERRY_DATE` when launching from ferry workflows."""
+    run_id = os.environ.get("GRUG_RUN_ID", default_run_id)
+    ferry_date = os.environ.get("FERRY_DATE")
+    if ferry_date:
+        run_id = f"{run_id}-{ferry_date}"
+    return run_id
+
+
+def _resolve_tracker(tracker: TrackerConfig, run_id: str) -> TrackerConfig:
+    if isinstance(tracker, WandbConfig):
+        return dataclasses.replace(tracker, name=run_id)
+    return tracker
+
+
+def run_grug_moe_trial(config: GrugMoeLaunchConfig) -> None:
+    """Map template launch knobs onto a full Levanter trainer and dispatch the run.
+
+    Runs inline on the launcher; ``run_grug`` submits the training job to Fray and
+    blocks until it completes.
+    """
+    initialize_from = latest_checkpoint_path(config.init_from) if config.init_from is not None else None
+    trainer = TrainerConfig(
+        id=config.run_id,
+        seed=config.seed,
+        train_batch_size=config.batch_size,
+        num_train_steps=config.steps,
+        profiler=config.profiler,
+        mp=jmp.get_policy(config.mp),
+        tracker=_resolve_tracker(config.tracker, config.run_id),
+        use_explicit_mesh_axes=True,
+        require_accelerator=True,
+        allow_nondivisible_batch_size=False,
+        initialize_from=initialize_from,
+        checkpointer=config.checkpointer
+        or resolve_checkpointer_output_path(
+            CheckpointerConfig(save_interval=timedelta(minutes=10), keep=None),
+            config.output_path,
+        ),
+    )
+
+    grug_trainer = dataclasses.replace(config.grug_trainer, trainer=trainer)
+
+    run_config = GrugRunConfig(
+        model=config.model,
+        data=config.data,
+        resources=config.resources,
+        optimizer=config.optimizer,
+        trainer=grug_trainer,
+        eval=config.eval,
+        processes_per_task=config.processes_per_task,
+    )
+    run_grug(run_config)
+
+
+RESOLVED_RUN_ID = _resolve_run_id("MOE-PSC-001-d512-v5p8-smoke")
+
+_SMOKE_BUDGET: float = 3.82e17
+_SMOKE_HIDDEN_DIM: int = 512
+_SMOKE_TARGET_STEPS: int = 10_980
+_SMOKE_STEPS: int = 25
+_smoke_model, _smoke_optimizer, _smoke_batch, _ = build_from_heuristic(
+    budget=_SMOKE_BUDGET,
+    hidden_dim=_SMOKE_HIDDEN_DIM,
+    target_steps=_SMOKE_TARGET_STEPS,
+)
+
+GRUG_MOE_TRIAL_MODEL: GrugModelConfig = _smoke_model
+
+
+def grug_moe_pallas_sconv_smoke(*, version: str | None = None) -> ArtifactStep[LevanterCheckpoint]:
+    """Run the d512 four-site Pallas SConv smoke test on the Nemotron mix.
+
+    Every component is a :class:`Dataset` handle, so the whole graph lowers via
+    :func:`~marin.execution.lazy.lower`. Pinned components never re-tokenize; the
+    paloma/uncheatable suites are validation (weight 0).
+    """
+    name = "grug/moe_pallas_sconv_smoke"
+    version = resolve_version(name, version)
+    nem = nemotron_datasets(tokenizer=llama3_tokenizer)
+    train = {nem[split]: weight for split, weight in _NEMOTRON_WEIGHTS.items()}
+    train[starcoder_dataset(tokenizer=llama3_tokenizer)] = _STARCODER_WEIGHT
+    train[proofpile_dataset(tokenizer=llama3_tokenizer)] = _PROOFPILE_WEIGHT
+    validation = [
+        *paloma_datasets(tokenizer=llama3_tokenizer).values(),
+        *uncheatable_datasets(tokenizer=llama3_tokenizer).values(),
+    ]
+
+    def build_config(ctx: StepContext) -> GrugMoeLaunchConfig:
+        return GrugMoeLaunchConfig(
+            model=_smoke_model,
+            data=mixture(ctx, train, validation=validation),
+            output_path=ctx.output_path,
+            run_id=RESOLVED_RUN_ID,
+            resources=ctx.runtime_arg("train_resources"),
+            steps=_SMOKE_STEPS,
+            batch_size=_smoke_batch,
+            seed=0,
+            mp="params=float32,compute=bfloat16,output=bfloat16",
+            tracker=WandbConfig(
+                entity="marin-community",
+                project="marin_moe",
+                tags=["MOE-PSC", "issue-8377", "smoke", "pallas-sconv"],
+                group="MOE-PSC-issue-8377",
+                name=None,
+            ),
+            optimizer=_smoke_optimizer,
+            grug_trainer=GrugTrainerConfig(z_loss_weight=1e-4, ema_beta=None, log_every=1),
+            eval=None,
+        )
+
+    return ArtifactStep(
+        name=user_namespaced_name(name, version),
+        version=version,
+        artifact_type=LevanterCheckpoint,
+        run=run_grug_moe_trial,
+        build_config=build_config,
+        deps=(*train, *validation),
+        runtime_args={"train_resources": _TRAIN_RESOURCES},
+    )
+
+
+if __name__ == "__main__":
+    experiment_main(grug_moe_pallas_sconv_smoke)()

--- a/experiments/grug/moe_pallas_sconv/launch_gate1.py
+++ b/experiments/grug/moe_pallas_sconv/launch_gate1.py
@@ -1,0 +1,9 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from marin.experiment.cli import experiment_main
+
+from experiments.grug.moe_pallas_sconv.launch import grug_moe_pallas_sconv_gate1
+
+if __name__ == "__main__":
+    experiment_main(grug_moe_pallas_sconv_gate1)()

--- a/experiments/grug/moe_pallas_sconv/launch_gate2.py
+++ b/experiments/grug/moe_pallas_sconv/launch_gate2.py
@@ -1,0 +1,9 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from marin.experiment.cli import experiment_main
+
+from experiments.grug.moe_pallas_sconv.launch import grug_moe_pallas_sconv_gate2
+
+if __name__ == "__main__":
+    experiment_main(grug_moe_pallas_sconv_gate2)()

--- a/experiments/grug/moe_pallas_sconv/model.py
+++ b/experiments/grug/moe_pallas_sconv/model.py
@@ -280,7 +280,7 @@ class ShortConv(eqx.Module):
     @staticmethod
     def init(channels: int, kernel_size: int) -> "ShortConv":
         weight = jnp.zeros((channels, kernel_size), dtype=jnp.float32).at[:, -1].set(1.0)
-        return ShortConv(weight=reshard(weight, P(None, None)), kernel_size=kernel_size)
+        return ShortConv(weight=reshard(weight, P("model", None)), kernel_size=kernel_size)
 
     def __call__(
         self,

--- a/experiments/grug/moe_pallas_sconv/model.py
+++ b/experiments/grug/moe_pallas_sconv/model.py
@@ -1,0 +1,985 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""MoE grug variant model.
+
+Architecture: QB-routed MoE with GatedNorm, XSA, sigmoid combine weights.
+No load-balancing loss; router z-loss only. All layers are MoE (no dense layers).
+"""
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.scipy as jsp
+from einops import rearrange
+from haliax import Axis
+from haliax.jax_utils import named_call
+from jax import core, random
+from jax.sharding import NamedSharding, get_abstract_mesh, reshard
+from jax.sharding import PartitionSpec as P
+
+try:
+    from jax.shard_map import shard_map
+except ModuleNotFoundError:
+    from jax.experimental.shard_map import shard_map
+from jaxtyping import Array, Float, Int, PRNGKeyArray
+from levanter.compat.hf_checkpoints import HFCheckpointConverter
+from levanter.grug.attention import (
+    AttentionMask,
+    GrugAttentionImplementation,
+    RotaryConfig,
+    align_kv_heads,
+    apply_rotary_embedding,
+    attention,
+)
+from levanter.grug.grug_moe import (
+    MOE_REMAT_SAVE_NAMES,
+    MoeActivation,
+    MoEExpertMlp,
+    MoeImplementation,
+    resolve_moe_implementation,
+)
+from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
+from levanter.grug.sharding import Pembed_vocab, Plm_head, unshard
+from levanter.kernels.pallas.depthwise_causal_convolution import depthwise_causal_convolution
+from levanter.tracker.histogram import Histogram, SummaryStats
+from levanter.utils.activation import ActivationFunctionEnum
+from transformers import PretrainedConfig as HfConfig
+
+_GATED_NORM_RANK = 128
+_ROUTING_RENORM_SUM = 2.5
+GRUG_MOE_MODEL_TYPE = "grug_moe"
+GRUG_MOE_ARCHITECTURE = "GrugMoeForCausalLM"
+GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY = "grugmoe_artifact_schema_version"
+GRUG_MOE_ARTIFACT_SCHEMA_VERSION = 1
+
+
+_BATCH_AXES: tuple[str, ...] = ("replica_dcn", "data", "expert")
+
+
+def _mesh_axis_size(mesh: jax.sharding.AbstractMesh | None, axis_name: str) -> int:
+    if mesh is None or mesh.empty:
+        raise ValueError("grug/moe requires a non-empty abstract mesh")
+    if axis_name not in mesh.shape:
+        # compact_grug_mesh standardizes on (replica_dcn, data, expert, model) with length-1
+        # axes kept, so any missing axis is a caller bug rather than a "size 1" shortcut.
+        raise ValueError(f"grug/moe requires an abstract mesh with axis '{axis_name}'")
+    return int(mesh.shape[axis_name])
+
+
+RematMode = Literal["recompute_all", "save_moe"]
+
+
+def _batch_spec() -> P:
+    return P(_BATCH_AXES)
+
+
+def _batch_reshard(x: jax.Array) -> jax.Array:
+    return reshard(x, _batch_spec())
+
+
+def _partition_spec_of(x: jax.Array) -> P | None:
+    sharding = jax.typeof(x).sharding if isinstance(x, core.Tracer) else x.sharding
+    if isinstance(sharding, NamedSharding):
+        return sharding.spec
+    return None
+
+
+def _layer_attention_masks(mask: AttentionMask, *, sliding_window: int) -> tuple[AttentionMask, AttentionMask]:
+    return mask.with_sliding_window(sliding_window // 2), mask.with_sliding_window(sliding_window)
+
+
+class GrugMoeHfConfig(HfConfig):
+    model_type = GRUG_MOE_MODEL_TYPE
+
+
+def _hf_config_attr(config: HfConfig, names: tuple[str, ...], default: Any = None) -> Any:
+    for name in names:
+        if hasattr(config, name):
+            return getattr(config, name)
+    return default
+
+
+@dataclass(frozen=True)
+class GrugModelConfig:
+    """Hyperparameters for the grug MoE transformer.
+
+    Architecture choices (GatedNorm, XSA, QB routing) are hardcoded.
+    Only shape/size knobs live here. All layers are MoE.
+    """
+
+    vocab_size: int
+    hidden_dim: int = 512
+    intermediate_dim: int = 256
+    shared_expert_intermediate_dim: int = 512
+    num_experts: int = 256
+    num_experts_per_token: int = 4
+    num_layers: int = 6
+    num_heads: int = 4
+    num_kv_heads: int = 1
+    head_dim: int | None = None
+    max_seq_len: int = 8192
+    sliding_window: int = 2048
+    layer_norm_eps: float = 1e-5
+    initializer_std: float = 0.02
+    qk_mult: float = 1.3
+    router_z_loss_coef: float = 0.0
+    disable_pko: bool = True
+    """When True (default), the every-4th + last 'long' layers skip Partial
+    Key Offset (no shift of the second half of K, no doc-start zeroing). Short
+    layers never had PKO. Set to False to re-enable PKO on long layers."""
+    disable_long_rope: bool = True
+    """When True (default), the every-4th + last 'long' layers skip rotary
+    embedding entirely (Q and K go into attention un-rotated). Short layers
+    still apply half-RoPE. Set to False to keep RoPE on long layers."""
+    attention_implementation: GrugAttentionImplementation | None = None
+    moe_implementation: MoeImplementation | None = None
+    capacity_factor: float = 1.0
+    sconv_kernel: int = 4
+    remat_mode: RematMode = "recompute_all"
+    """Per-block gradient checkpointing. "recompute_all" reruns the whole block in
+    backward (lowest memory); "save_moe" keeps the tagged MoE dispatch tensors so
+    backward skips re-running expert dispatch and its EP collectives."""
+    rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
+
+    def __post_init__(self) -> None:
+        _ = self.inferred_head_dim
+        if self.num_heads % self.num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads for grouped-query attention")
+        if self.vocab_size <= 0:
+            raise ValueError("vocab_size must be positive")
+        if self.max_seq_len <= 0:
+            raise ValueError("max_seq_len must be positive")
+        if self.num_experts <= 0:
+            raise ValueError("num_experts must be positive")
+        if self.num_experts_per_token <= 0:
+            raise ValueError("num_experts_per_token must be positive")
+        if self.num_experts_per_token > self.num_experts:
+            raise ValueError("num_experts_per_token must be <= num_experts")
+        if self.shared_expert_intermediate_dim < 0:
+            raise ValueError("shared_expert_intermediate_dim must be non-negative")
+        if self.capacity_factor <= 0:
+            raise ValueError("capacity_factor must be positive")
+        if self.sconv_kernel <= 1:
+            raise ValueError("sconv_kernel must be greater than 1")
+        resolve_moe_implementation(self.moe_implementation)
+
+    @property
+    def Embed(self) -> Axis:
+        return Axis("embed", self.hidden_dim)
+
+    @property
+    def model_type(self) -> type["Transformer"]:
+        return Transformer
+
+    @property
+    def inferred_head_dim(self) -> int:
+        if self.head_dim is not None:
+            return self.head_dim
+        if self.hidden_dim % self.num_heads != 0:
+            raise ValueError(
+                f"hidden_dim={self.hidden_dim} is not divisible by num_heads={self.num_heads}; set head_dim explicitly"
+            )
+        return self.hidden_dim // self.num_heads
+
+    def build(self, Vocab: Axis, *, key: PRNGKeyArray) -> "Transformer":
+        cfg = self if Vocab.size == self.vocab_size else dataclasses.replace(self, vocab_size=Vocab.size)
+        return Transformer.init(cfg, key=key)
+
+    def hf_checkpoint_converter(
+        self,
+        ref_checkpoint: str | None = None,
+    ) -> HFCheckpointConverter["GrugModelConfig"]:  # type: ignore[type-var]
+        return HFCheckpointConverter(
+            self.__class__,
+            reference_checkpoint=ref_checkpoint,
+            HfConfigClass=GrugMoeHfConfig,
+            tokenizer=ref_checkpoint,
+        )
+
+    @classmethod
+    def from_hf_config(cls, hf_config: HfConfig) -> "GrugModelConfig":
+        rope = RotaryConfig(theta=float(_hf_config_attr(hf_config, ("rope_theta",), 10000.0)))
+        return cls(
+            vocab_size=int(_hf_config_attr(hf_config, ("vocab_size",))),
+            hidden_dim=int(_hf_config_attr(hf_config, ("hidden_dim", "hidden_size"), 2048)),
+            intermediate_dim=int(
+                _hf_config_attr(hf_config, ("intermediate_dim", "moe_intermediate_size", "intermediate_size"), 5632)
+            ),
+            shared_expert_intermediate_dim=int(
+                _hf_config_attr(
+                    hf_config,
+                    ("shared_expert_intermediate_dim", "shared_expert_intermediate_size"),
+                    5632,
+                )
+            ),
+            num_experts=int(_hf_config_attr(hf_config, ("num_experts", "num_local_experts"), 8)),
+            num_experts_per_token=int(_hf_config_attr(hf_config, ("num_experts_per_token", "num_experts_per_tok"), 2)),
+            num_layers=int(_hf_config_attr(hf_config, ("num_layers", "num_hidden_layers"), 24)),
+            num_heads=int(_hf_config_attr(hf_config, ("num_heads", "num_attention_heads"), 16)),
+            num_kv_heads=int(_hf_config_attr(hf_config, ("num_kv_heads", "num_key_value_heads"), 16)),
+            head_dim=_hf_config_attr(hf_config, ("head_dim", "attention_head_dim")),
+            max_seq_len=int(_hf_config_attr(hf_config, ("max_seq_len", "max_position_embeddings"), 4096)),
+            sliding_window=int(_hf_config_attr(hf_config, ("sliding_window",), 4096)),
+            layer_norm_eps=float(_hf_config_attr(hf_config, ("layer_norm_eps", "rms_norm_eps"), 1e-5)),
+            initializer_std=float(_hf_config_attr(hf_config, ("initializer_std", "initializer_range"), 0.02)),
+            qk_mult=float(_hf_config_attr(hf_config, ("qk_mult",), 1.0)),
+            sconv_kernel=int(_hf_config_attr(hf_config, ("sconv_kernel",), 4)),
+            rope=rope,
+        )
+
+    def to_hf_config(self, vocab_size: int, config_overrides: dict[str, Any] | None = None) -> GrugMoeHfConfig:
+        # One name per field: core fields take the universal transformers spelling, MoE fields the
+        # most common public spelling, and grug-specific extras keep their bare names. from_hf_config
+        # stays tolerant of the older spellings so existing artifacts keep loading.
+        config = {
+            "architectures": [GRUG_MOE_ARCHITECTURE],
+            "vocab_size": vocab_size,
+            # core — universal transformers names
+            "hidden_size": self.hidden_dim,
+            "num_hidden_layers": self.num_layers,
+            "num_attention_heads": self.num_heads,
+            "num_key_value_heads": self.num_kv_heads,
+            "head_dim": self.inferred_head_dim,
+            "max_position_embeddings": self.max_seq_len,
+            "sliding_window": self.sliding_window,
+            "rms_norm_eps": self.layer_norm_eps,
+            "initializer_range": self.initializer_std,
+            "rope_theta": self.rope.theta,
+            "tie_word_embeddings": False,
+            # MoE — most common public spelling per field
+            "num_experts": self.num_experts,
+            "num_experts_per_tok": self.num_experts_per_token,
+            "moe_intermediate_size": self.intermediate_dim,
+            "shared_expert_intermediate_size": self.shared_expert_intermediate_dim,
+            # grug-specific (no public equivalent)
+            "qk_mult": self.qk_mult,
+            "sconv_kernel": self.sconv_kernel,
+            "grugmoe_attention_mode": "production",
+            GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY: GRUG_MOE_ARTIFACT_SCHEMA_VERSION,
+        }
+        if config_overrides is not None:
+            config.update(config_overrides)
+        return GrugMoeHfConfig(**config)
+
+
+def rms_norm(x: jax.Array, eps: float = 1e-6) -> jax.Array:
+    """Non-parametric RMS norm over the last dimension."""
+    variance = jnp.mean(jnp.square(x.astype(jnp.float32)), axis=-1, keepdims=True)
+    return (x * jax.lax.rsqrt(variance + eps)).astype(x.dtype)
+
+
+class ShortConv(eqx.Module):
+    weight: Float[Array, "C K"]
+    kernel_size: int = eqx.field(static=True)
+
+    @staticmethod
+    def init(channels: int, kernel_size: int) -> "ShortConv":
+        weight = jnp.zeros((channels, kernel_size), dtype=jnp.float32).at[:, -1].set(1.0)
+        return ShortConv(weight=reshard(weight, P(None, None)), kernel_size=kernel_size)
+
+    def __call__(
+        self,
+        x: Float[Array, "B S C"],
+        segment_ids: Int[Array, "B S"] | None,
+    ) -> Float[Array, "B S C"]:
+        attention_mask = None if segment_ids is None else segment_ids >= 0
+        output, _ = depthwise_causal_convolution(
+            input=x,
+            weight=self.weight.astype(x.dtype),
+            attention_mask=attention_mask,
+        )
+
+        if segment_ids is None:
+            return reshard(output, _batch_spec())
+
+        seq_len = x.shape[1]
+        valid = segment_ids >= 0
+        for lag in range(1, self.kernel_size):
+            shifted = jnp.pad(x, ((0, 0), (lag, 0), (0, 0)))[:, :seq_len, :]
+            shifted_ids = jnp.pad(segment_ids, ((0, 0), (lag, 0)), constant_values=-1)[:, :seq_len]
+            crosses_boundary = valid & (shifted_ids >= 0) & (shifted_ids != segment_ids)
+            tap_weight = self.weight[:, -1 - lag].astype(x.dtype)
+            output = output - jnp.where(crosses_boundary[..., None], shifted * tap_weight, 0)
+        return reshard(output, _batch_spec())
+
+
+class CausalSelfAttention(eqx.Module):
+    w_q: Float[Array, "D NH"]
+    w_k: Float[Array, "D MH"]
+    w_v: Float[Array, "D MH"]
+    w_o: Float[Array, "NH D"]
+    attn_gate: Float[Array, "D N"]
+    sconv_k: ShortConv
+    sconv_v: ShortConv
+    cfg: GrugModelConfig = eqx.field(static=True)
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "CausalSelfAttention":
+        k_q, k_k, k_v, k_o = random.split(key, 4)
+        d, n, m, h = cfg.hidden_dim, cfg.num_heads, cfg.num_kv_heads, cfg.inferred_head_dim
+        return CausalSelfAttention(
+            w_q=reshard(_init_weight(k_q, (d, n * h), cfg.initializer_std), P("data", "model")),
+            w_k=reshard(_init_weight(k_k, (d, m * h), cfg.initializer_std), P("data", "model")),
+            w_v=reshard(_init_weight(k_v, (d, m * h), cfg.initializer_std), P("data", "model")),
+            w_o=reshard(_init_weight(k_o, (n * h, d), cfg.initializer_std), P("model", "data")),
+            attn_gate=reshard(jnp.zeros((d, n)), P(None, None)),
+            sconv_k=ShortConv.init(m * h, cfg.sconv_kernel),
+            sconv_v=ShortConv.init(m * h, cfg.sconv_kernel),
+            cfg=cfg,
+        )
+
+    @named_call
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+        mask: AttentionMask | jax.Array,
+        use_pko: bool = False,
+        disable_rope: bool = False,
+    ) -> Float[Array, "B S D"]:
+        head_dim = self.cfg.inferred_head_dim
+        seq_len = x.shape[1]
+        batch_spec = _batch_spec()
+
+        q = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_q), "... (n d) -> ... n d", d=head_dim)
+        k_flat = jnp.einsum("bsh,hd->bsd", x, self.w_k)
+        v_flat = jnp.einsum("bsh,hd->bsd", x, self.w_v)
+        segment_ids = mask.segment_ids[0] if isinstance(mask, AttentionMask) and mask.segment_ids is not None else None
+        k = rearrange(self.sconv_k(k_flat, segment_ids), "... (m d) -> ... m d", d=head_dim)
+        v = rearrange(self.sconv_v(v_flat, segment_ids), "... (m d) -> ... m d", d=head_dim)
+
+        # Shift the second half of K's head_dim back by one position so the
+        # query at position i sees K[i] on head_dim[:half] but K[i-1] on
+        # head_dim[half:]. Zero the shifted half at document starts so the
+        # cross-half look-back does not leak across docs. Runs before the
+        # rms_norm on Q/K below.
+        if use_pko:
+            half = head_dim // 2
+            k_stationary = k[..., half:]
+            k_shifted = jnp.concatenate([k_stationary[:, :1, :, :], k_stationary[:, :-1, :, :]], axis=1)
+            segment_ids = mask.segment_ids if isinstance(mask, AttentionMask) else None
+            if segment_ids is None:
+                # No segment info (raw-mask or unsegmented eval path): only position 0 is a doc start.
+                is_doc_start_seq = jnp.zeros((seq_len,), dtype=bool).at[0].set(True)
+                is_doc_start = jnp.broadcast_to(is_doc_start_seq, k_shifted.shape[:2])
+            else:
+                q_seg = segment_ids[0]
+                if q_seg.ndim == 1:
+                    is_doc_start_seq = jnp.concatenate([jnp.ones((1,), dtype=bool), q_seg[1:] != q_seg[:-1]])
+                    is_doc_start = jnp.broadcast_to(is_doc_start_seq, k_shifted.shape[:2])
+                else:
+                    is_doc_start = jnp.concatenate(
+                        [jnp.ones_like(q_seg[:, :1], dtype=bool), q_seg[:, 1:] != q_seg[:, :-1]],
+                        axis=1,
+                    )
+            k_shifted = jnp.where(is_doc_start[..., None, None], jnp.zeros_like(k_shifted), k_shifted)
+            k = jnp.concatenate([k[..., :half], k_shifted], axis=-1)
+
+        q = rms_norm(q)
+        k = rms_norm(k)
+        # Half-RoPE: apply rotary embedding only to first half of Q/K head_dim
+        # (second half is rope-free on every layer). ``disable_rope`` skips
+        # the RoPE step entirely on this layer — used to opt long layers out
+        # of rotary embedding when ``cfg.disable_long_rope`` is set.
+        if not disable_rope:
+            half = head_dim // 2
+            q_rot, k_rot = apply_rotary_embedding(
+                q[..., :half], k[..., :half], seq_len=seq_len, head_dim=half, rope=self.cfg.rope
+            )
+            q = jnp.concatenate([q_rot, q[..., half:]], axis=-1)
+            k = jnp.concatenate([k_rot, k[..., half:]], axis=-1)
+        q = q * self.cfg.qk_mult
+        attn_out = attention(q, k, v, mask, implementation=self.cfg.attention_implementation)
+        aligned_v = align_kv_heads(v, num_q_heads=attn_out.shape[2])
+        # GPU XSA with GQA can give attn_out a backend-specific head sharding;
+        # match v to that dynamic sharding before the per-head projection math.
+        aligned_v = reshard(aligned_v, _partition_spec_of(attn_out) or P(_BATCH_AXES, None, None, "model"))
+        # Exclusive Self Attention: subtract the component of yᵢ parallel to vᵢ.
+        # zᵢ = yᵢ - (yᵢᵀvᵢ / ‖vᵢ‖²) vᵢ, per head.
+        dot = jnp.sum(attn_out * aligned_v, axis=-1, keepdims=True)
+        v_norm_sq = jnp.sum(aligned_v * aligned_v, axis=-1, keepdims=True)
+        attn_out = attn_out - (dot / (v_norm_sq + 1e-6)) * aligned_v
+        # Headwise gating: sigmoid(x @ attn_gate) produces one scalar per head.
+        gate = 2 * jax.nn.sigmoid(jnp.einsum("bsd,dn->bsn", x, self.attn_gate))[..., None]
+        attn_out = gate * attn_out
+        # Merge heads into hidden dim while keeping model-axis sharding for w_o.
+        attn_out = jnp.reshape(
+            attn_out,
+            (*attn_out.shape[:-2], attn_out.shape[-2] * attn_out.shape[-1]),
+            out_sharding=P(_BATCH_AXES, None, "model"),
+        )
+        return jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=batch_spec)
+
+
+class RMSNorm(eqx.Module):
+    weight: jax.Array
+    eps: float = eqx.field(static=True)
+
+    @staticmethod
+    def init(dim: int, eps: float) -> "RMSNorm":
+        return RMSNorm(weight=jnp.ones((dim,), dtype=jnp.float32), eps=eps)
+
+    @named_call
+    def __call__(self, x: Float[Array, "... D"]) -> Float[Array, "... D"]:
+        weight = unshard(self.weight)
+        dtype = x.dtype
+        x = x.astype(jnp.float32)
+        variance = jnp.mean(jnp.square(x), axis=-1, keepdims=True)
+        normed = x * jax.lax.rsqrt(variance + self.eps)
+        return (normed * weight).astype(dtype)
+
+
+class GatedNorm(eqx.Module):
+    """Learnable per-dimension gating. Compensates for AdamH's bounded activation norms.
+    See https://arxiv.org/abs/2601.22966v1"""
+
+    w_down: jax.Array
+    w_up: jax.Array
+
+    @staticmethod
+    def init(hidden_dim: int, initializer_std: float, *, key: PRNGKeyArray) -> "GatedNorm":
+        k_down, k_up = random.split(key)
+        return GatedNorm(
+            w_down=reshard(_init_weight(k_down, (hidden_dim, _GATED_NORM_RANK), initializer_std), P(None, None)),
+            w_up=reshard(_init_weight(k_up, (_GATED_NORM_RANK, hidden_dim), initializer_std), P(None, None)),
+        )
+
+    @named_call
+    def __call__(self, x: Float[Array, "... D"]) -> Float[Array, "... D"]:
+        gate_hidden = jnp.einsum("...d,dr->...r", x, self.w_down)
+        # TODO: silu activation here isn't explored, just cargo-culted from Qwen. Likely low-hanging ablation fruit
+        # (e.g. compare no activation, relu, etc.).
+        gate_hidden = jax.nn.silu(gate_hidden)
+        gate = jax.nn.sigmoid(jnp.einsum("...r,rd->...d", gate_hidden, self.w_up))
+        return x * gate.astype(x.dtype)
+
+
+class DenseMLP(eqx.Module):
+    w_gate: jax.Array
+    w_up: jax.Array
+    w_down: jax.Array
+
+    @staticmethod
+    def init(hidden_dim: int, intermediate_dim: int, initializer_std: float, *, key: PRNGKeyArray) -> "DenseMLP":
+        k_gate, k_up, k_down = random.split(key, 3)
+        return DenseMLP(
+            w_gate=reshard(_init_weight(k_gate, (hidden_dim, intermediate_dim), initializer_std), P("data", "model")),
+            w_up=reshard(_init_weight(k_up, (hidden_dim, intermediate_dim), initializer_std), P("data", "model")),
+            w_down=reshard(_init_weight(k_down, (intermediate_dim, hidden_dim), initializer_std), P("model", "data")),
+        )
+
+    @named_call
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+        *,
+        activation: MoeActivation = ActivationFunctionEnum.silu,
+    ) -> Float[Array, "B S D"]:
+        if isinstance(activation, ActivationFunctionEnum):
+            activation_fn = activation.to_jax_fn()
+        else:
+            activation_fn = activation
+
+        b, s, _ = x.shape
+        x_flat = rearrange(x, "b s d -> (b s) d")
+        gate = jnp.einsum("td,dm->tm", x_flat, self.w_gate)
+        up = jnp.einsum("td,dm->tm", x_flat, self.w_up)
+        out_flat = jnp.einsum("tm,md->td", activation_fn(gate) * up, self.w_down, out_sharding=_batch_spec())
+        # Reshard after the reshape so the shared-expert output carries the same
+        # canonical batch sharding as the routed MoE output (MoEMLP reshards its
+        # routed result identically). Splitting the fused
+        # ("replica_dcn", "data", "expert") token axis back into (b, s) otherwise
+        # leaks the `expert` mesh axis onto the seq dim, so the shared+routed
+        # residual add fails with a ShardingTypeError on a multi-node mesh.
+        return _batch_reshard(rearrange(out_flat, "(b s) d -> b s d", b=b, s=s))
+
+
+def _routing_stats(
+    selected_experts: Int[Array, "T K"],
+    router_probs: Float[Array, "T E"],
+    router_logits: Float[Array, "T E"],
+    *,
+    num_experts: int,
+    num_experts_per_token: int,
+) -> dict[str, jax.Array]:
+    router_probs_f = router_probs.astype(jnp.float32)
+    router_logits_f = router_logits.astype(jnp.float32)
+    expert_counts = jnp.sum(jax.nn.one_hot(selected_experts, num_experts, dtype=jnp.float32), axis=(0, 1))
+    total_assignments = jnp.maximum(jnp.sum(expert_counts), 1.0)
+    assignment_fraction = expert_counts / total_assignments
+    routing_entropy = -jnp.sum(assignment_fraction * jnp.log(assignment_fraction + 1e-6))
+    token_fraction = assignment_fraction * num_experts_per_token
+    p = jnp.mean(router_probs_f, axis=0)
+    load_balancing_loss = num_experts * jnp.sum(token_fraction * p)
+    z = jsp.special.logsumexp(router_logits_f, axis=-1)
+    router_z_loss = jnp.mean(z**2)
+
+    return {
+        "routing_counts": expert_counts,
+        "routing_entropy": routing_entropy,
+        "load_balancing_loss": load_balancing_loss,
+        "router_z_loss": router_z_loss,
+    }
+
+
+def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str, jax.Array | SummaryStats]:
+    routing_entropy = router_metrics["routing_entropy_per_layer"]
+    routing_counts = router_metrics["routing_counts_per_layer"]
+    load_balancing_loss = router_metrics["load_balancing_loss_per_layer"]
+    router_z_loss = router_metrics["router_z_loss_per_layer"]
+    capacity_overflow = router_metrics["capacity_overflow_per_layer"]
+    num_layers = int(routing_entropy.shape[0])
+
+    # Per-layer total assignments = sum of routing_counts over experts (= tokens * k).
+    assignments_per_layer = jnp.sum(routing_counts.astype(jnp.float32), axis=-1)
+    capacity_overflow_rate = capacity_overflow.astype(jnp.float32) / jnp.maximum(assignments_per_layer, 1.0)
+
+    out: dict[str, jax.Array | SummaryStats] = {
+        "train/router/routing_entropy_mean": jnp.mean(routing_entropy),
+        "train/router/load_balancing_loss": jnp.mean(load_balancing_loss),
+        "train/router/router_z_loss": jnp.mean(router_z_loss),
+        "train/router/routing_counts_per_layer": routing_counts,
+        "train/router/capacity_overflow_rate_mean": jnp.mean(capacity_overflow_rate),
+        "qb_beta_per_layer": router_metrics.get("qb_beta_per_layer"),
+    }
+    for i in range(num_layers):
+        out[f"train/router/layer_{i}/routing_entropy"] = routing_entropy[i]
+        out[f"train/router/layer_{i}/load_balancing_loss"] = load_balancing_loss[i]
+        out[f"train/router/layer_{i}/router_z_loss"] = router_z_loss[i]
+        out[f"train/router/layer_{i}/routing_hist"] = _histogram_from_expert_counts(routing_counts[i])
+        out[f"train/router/layer_{i}/capacity_overflow_rate"] = capacity_overflow_rate[i]
+    return out
+
+
+def _histogram_from_expert_counts(expert_counts: jax.Array) -> SummaryStats:
+    counts = jnp.asarray(expert_counts, dtype=jnp.float32)
+    num_experts = counts.shape[0]
+    expert_ids = jnp.arange(num_experts, dtype=jnp.float32)
+    num = jnp.sum(counts)
+    sum_values = jnp.sum(counts * expert_ids)
+    sum_squares = jnp.sum(counts * expert_ids * expert_ids)
+    nonzero = counts > 0
+    min_value = jnp.where(nonzero, expert_ids, jnp.inf).min()
+    max_value = jnp.where(nonzero, expert_ids, -jnp.inf).max()
+    min_value = jnp.where(num > 0, min_value, 0.0)
+    max_value = jnp.where(num > 0, max_value, 0.0)
+    bucket_limits = jnp.arange(num_experts + 1, dtype=jnp.float32)
+    histogram = Histogram(bucket_limits=bucket_limits, bucket_counts=counts)
+    return SummaryStats.from_reduced_values(
+        min=min_value,
+        max=max_value,
+        num=num,
+        nonzero_count=jnp.sum(nonzero),
+        sum=sum_values,
+        sum_squares=sum_squares,
+        histogram=histogram,
+    )
+
+
+class MoEMLP(eqx.Module):
+    """QB-routed MoE with sigmoid combine weights."""
+
+    router: jax.Array
+    router_bias: jax.Array
+    expert_mlp: MoEExpertMlp
+    cfg: GrugModelConfig = eqx.field(static=True)
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "MoEMLP":
+        k_router, k_expert = random.split(key, 2)
+        mesh = get_abstract_mesh()
+
+        expert_axis_size = _mesh_axis_size(mesh, "expert")
+        if cfg.num_experts % expert_axis_size != 0:
+            raise ValueError(f"num_experts={cfg.num_experts} must be divisible by expert axis size={expert_axis_size}")
+
+        d, e = cfg.hidden_dim, cfg.num_experts
+        return MoEMLP(
+            router=reshard(_init_weight(k_router, (d, e), cfg.initializer_std), P(None, None)),
+            router_bias=jnp.zeros((e,)),
+            expert_mlp=MoEExpertMlp.init(
+                num_experts=cfg.num_experts,
+                hidden_dim=cfg.hidden_dim,
+                intermediate_dim=cfg.intermediate_dim,
+                initializer_std=cfg.initializer_std,
+                key=k_expert,
+                implementation=cfg.moe_implementation,
+                activation=ActivationFunctionEnum.silu,
+                capacity_factor=cfg.capacity_factor,
+            ),
+            cfg=cfg,
+        )
+
+    @named_call
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+    ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+        b, s, _ = x.shape
+        x_flat = rearrange(x, "b s d -> (b s) d")
+        # Keep the router path in fp32 before top-k, softmax, and QB statistics.
+        router_logits = jnp.einsum("td,de->te", x_flat, reshard(self.router, P(None, None))).astype(jnp.float32)
+        biased_logits = router_logits + jax.lax.stop_gradient(self.router_bias)
+        router_probs = jax.nn.softmax(router_logits, axis=-1)
+        # Select top-(K+1) on biased logits; the (K+1)-th is the QB threshold alpha.
+        _topk_logits, selected_experts = jax.lax.top_k(biased_logits, self.cfg.num_experts_per_token + 1)
+        qb_alpha = _topk_logits[:, -1:]
+        selected_experts = selected_experts[:, :-1]
+        # Sigmoid combine weights on unbiased logits for selected experts.
+        unbiased_topk = jnp.take_along_axis(router_logits, selected_experts, axis=-1)
+        combine_weights_f = jax.nn.sigmoid(unbiased_topk)
+        # Renormalize K combine weights to sum to ``_ROUTING_RENORM_SUM`` (baked in).
+        denom = jnp.sum(combine_weights_f, axis=-1, keepdims=True)
+        combine_weights_f = combine_weights_f * (_ROUTING_RENORM_SUM / (denom + 1e-9))
+        combine_weights = combine_weights_f.astype(x.dtype)
+        router_stats = _routing_stats(
+            selected_experts,
+            router_probs,
+            router_logits,
+            num_experts=self.cfg.num_experts,
+            num_experts_per_token=self.cfg.num_experts_per_token,
+        )
+        # Sharded QB: compute beta locally per device, then average.
+        mesh = get_abstract_mesh()
+        s_minus_alpha = reshard(router_logits - qb_alpha, P(_BATCH_AXES, None))
+        num_devices = 1
+        for a in _BATCH_AXES:
+            num_devices *= mesh.shape[a]
+        local_tokens = s_minus_alpha.shape[0] // num_devices
+        qb_count = max(1, local_tokens * self.cfg.num_experts_per_token // self.cfg.num_experts)
+
+        def _local_qb_beta(s_ma):
+            topk_vals, _ = jax.lax.top_k(s_ma.T, qb_count)
+            beta = topk_vals[:, -1]
+            return jax.lax.pmean(beta, axis_name=_BATCH_AXES)
+
+        router_stats["qb_beta"] = shard_map(
+            _local_qb_beta,
+            mesh=mesh,
+            in_specs=(P(_BATCH_AXES, None),),
+            out_specs=P(),
+        )(s_minus_alpha)
+
+        routed_flat, dropped_assignments = self.expert_mlp(
+            x_flat,
+            selected_experts.astype(jnp.int32),
+            combine_weights,
+            mesh=get_abstract_mesh(),
+            report_capacity_overflow=True,
+        )
+        router_stats["capacity_overflow"] = dropped_assignments.astype(jnp.float32)
+
+        routed = rearrange(routed_flat, "(b s) d -> b s d", b=b, s=s)
+        routed = reshard(routed, _batch_spec())
+        return routed, router_stats
+
+
+class Block(eqx.Module):
+    rms_attn: RMSNorm
+    attn_gated_norm: GatedNorm
+    attn: CausalSelfAttention
+    rms_mlp: RMSNorm
+    mlp_gated_norm: GatedNorm
+    mlp: MoEMLP
+    shared: DenseMLP | None
+    sconv_attn: ShortConv
+    sconv_mlp: ShortConv
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "Block":
+        attn_key, mlp_key, shared_key, gn_attn_key, gn_mlp_key = random.split(key, 5)
+        shared = None
+        if cfg.shared_expert_intermediate_dim > 0:
+            shared = DenseMLP.init(
+                cfg.hidden_dim, cfg.shared_expert_intermediate_dim, cfg.initializer_std, key=shared_key
+            )
+        return Block(
+            rms_attn=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            attn_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=gn_attn_key),
+            attn=CausalSelfAttention.init(cfg, key=attn_key),
+            rms_mlp=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            mlp_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=gn_mlp_key),
+            mlp=MoEMLP.init(cfg, key=mlp_key),
+            shared=shared,
+            sconv_attn=ShortConv.init(cfg.hidden_dim, cfg.sconv_kernel),
+            sconv_mlp=ShortConv.init(cfg.hidden_dim, cfg.sconv_kernel),
+        )
+
+    @named_call
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+        mask: AttentionMask | jax.Array,
+        use_pko: bool = False,
+        disable_rope: bool = False,
+    ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+        segment_ids = mask.segment_ids[0] if isinstance(mask, AttentionMask) and mask.segment_ids is not None else None
+        attn_in = self.attn_gated_norm(self.rms_attn(x))
+        attn_out = self.attn(attn_in, mask, use_pko=use_pko, disable_rope=disable_rope)
+        x = x + self.sconv_attn(attn_out, segment_ids)
+        mlp_in = self.mlp_gated_norm(self.rms_mlp(x))
+        mlp_out, router_stats = self.mlp(mlp_in)
+        if self.shared is not None:
+            mlp_out = mlp_out + self.shared(mlp_in, activation=ActivationFunctionEnum.silu)
+        x = x + self.sconv_mlp(mlp_out, segment_ids)
+        return x, router_stats
+
+
+class Transformer(eqx.Module):
+    token_embed: jax.Array
+    embed_norm: RMSNorm
+    embed_gated_norm: GatedNorm
+    output_proj: jax.Array
+    blocks: tuple[Block, ...]
+    final_norm: RMSNorm
+    final_gated_norm: GatedNorm
+    config: GrugModelConfig = eqx.field(static=True)
+
+    @staticmethod
+    def init(
+        cfg_or_vocab: GrugModelConfig | Axis,
+        config: GrugModelConfig | None = None,
+        *,
+        key: PRNGKeyArray,
+    ) -> "Transformer":
+        if isinstance(cfg_or_vocab, Axis):
+            if config is None:
+                raise ValueError("config must be provided when initializing with a Vocab axis")
+            cfg = (
+                config
+                if cfg_or_vocab.size == config.vocab_size
+                else dataclasses.replace(config, vocab_size=cfg_or_vocab.size)
+            )
+        else:
+            if config is not None:
+                raise ValueError("config must not be provided when initializing directly from GrugModelConfig")
+            cfg = cfg_or_vocab
+
+        embed_key, out_key, embed_gn_key, final_gn_key, *block_keys = random.split(key, cfg.num_layers + 4)
+        token_embed = reshard(
+            _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), cfg.initializer_std), Pembed_vocab
+        )
+        output_proj = reshard(_init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head)
+        blocks = tuple(Block.init(cfg, key=block_keys[i]) for i in range(cfg.num_layers))
+        return Transformer(
+            token_embed=token_embed,
+            embed_norm=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            embed_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=embed_gn_key),
+            output_proj=output_proj,
+            blocks=blocks,
+            final_norm=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            final_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=final_gn_key),
+            config=cfg,
+        )
+
+    @property
+    def Vocab(self) -> Axis:
+        return Axis("vocab", self.config.vocab_size)
+
+    @named_call
+    def __call__(
+        self,
+        token_ids: Int[Array, "B S"],
+        mask: AttentionMask | jax.Array | None = None,
+    ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+        if mask is None:
+            mask = AttentionMask.causal()
+
+        batch_spec = _batch_spec()
+        cfg = self.config
+        hidden = self.token_embed.at[token_ids].get(out_sharding=batch_spec)
+        hidden = self.embed_gated_norm(self.embed_norm(hidden))
+
+        # Short layers: sliding window. Long layers (every 4th + last): full causal.
+        segment_ids = mask.segment_ids if isinstance(mask, AttentionMask) else None
+        short_mask = AttentionMask(is_causal=True, sliding_window=cfg.sliding_window, segment_ids=segment_ids)
+        long_mask = AttentionMask(is_causal=True, sliding_window=None, segment_ids=segment_ids)
+
+        if cfg.remat_mode == "save_moe":
+            remat_policy = jax.checkpoint_policies.save_only_these_names(*MOE_REMAT_SAVE_NAMES)
+        else:
+            remat_policy = None
+
+        num_blocks = len(self.blocks)
+        moe_router_stats: list[dict[str, jax.Array]] = []
+        for i, block in enumerate(self.blocks):
+            is_last = i == num_blocks - 1
+            is_long = i % 4 == 3 or is_last
+            layer_mask = long_mask if is_long else short_mask
+            use_pko = is_long and not cfg.disable_pko
+            disable_rope = is_long and cfg.disable_long_rope
+            hidden, router_stats = eqx.filter_checkpoint(block, policy=remat_policy)(
+                hidden, layer_mask, use_pko, disable_rope
+            )
+            moe_router_stats.append(router_stats)
+
+        router_metrics = {
+            "routing_entropy_per_layer": jnp.stack([s["routing_entropy"] for s in moe_router_stats], axis=0),
+            "routing_counts_per_layer": jnp.stack([s["routing_counts"] for s in moe_router_stats], axis=0),
+            "load_balancing_loss_per_layer": jnp.stack([s["load_balancing_loss"] for s in moe_router_stats], axis=0),
+            "router_z_loss_per_layer": jnp.stack([s["router_z_loss"] for s in moe_router_stats], axis=0),
+            "qb_beta_per_layer": jnp.stack([s["qb_beta"] for s in moe_router_stats], axis=0),
+            "capacity_overflow_per_layer": jnp.stack([s["capacity_overflow"] for s in moe_router_stats], axis=0),
+        }
+        hidden = self.final_gated_norm(self.final_norm(hidden))
+        return hidden, router_metrics
+
+    @named_call
+    def logits(
+        self,
+        token_ids: Int[Array, "B S"],
+        mask: AttentionMask | jax.Array | None = None,
+    ) -> Float[Array, "B S V"]:
+        batch_spec = _batch_spec()
+        hidden, _ = self(token_ids, mask=mask)
+        return jnp.einsum("bsh,hd->bsd", hidden, self.output_proj, out_sharding=batch_spec)
+
+    def to_state_dict(self, prefix: str | None = None) -> dict[str, jax.Array]:
+        return grugmoe_inference_state_dict(self, prefix=prefix)
+
+    def next_token_loss(
+        self,
+        token_ids: Int[Array, "B S"],
+        loss_weight: Float[Array, "B S"],
+        *,
+        mask: AttentionMask | jax.Array | None = None,
+        reduction: str = "mean",
+        logsumexp_weight: float | None = None,
+        loss_dtype: jnp.dtype = jnp.float32,
+        return_router_metrics: bool = False,
+    ) -> jax.Array | tuple[jax.Array, dict[str, jax.Array | SummaryStats]]:
+        hidden, router_metrics = self(token_ids, mask=mask)
+        labels = jnp.pad(token_ids[:, 1:], ((0, 0), (0, 1))).astype(jnp.int32)
+        loss_weight = loss_weight.astype(loss_dtype)
+
+        cross_entropy_loss = fused_linear_softmax_cross_entropy_loss(
+            hidden,
+            self.output_proj,
+            labels,
+            weight=loss_weight,
+            reduction=reduction,
+            logsumexp_weight=logsumexp_weight,
+            dtype=loss_dtype,
+        )
+        # No load-balancing loss; router z-loss only.
+        num_moe_layers = router_metrics["router_z_loss_per_layer"].shape[0]
+        rzl = jnp.sum(router_metrics["router_z_loss_per_layer"]) / num_moe_layers
+        aux_loss = self.config.router_z_loss_coef * rzl
+        loss = cross_entropy_loss + aux_loss if reduction != "none" else cross_entropy_loss
+        if return_router_metrics:
+            summarized_metrics = _summarize_router_metrics(router_metrics)
+            summarized_metrics["train/cross_entropy_loss"] = cross_entropy_loss
+            summarized_metrics["train/router/aux_loss_weighted"] = aux_loss
+            return loss, summarized_metrics
+        return loss
+
+
+def _init_weight(key: PRNGKeyArray, shape: tuple[int, ...], std: float) -> Float[Array, "..."]:
+    return std * random.truncated_normal(key, -3, 3, shape)
+
+
+def debug_mesh_and_token_pspec(num_devices: int) -> tuple[jax.sharding.AbstractMesh, P]:
+    """Return a small abstract mesh and token sharding for lowering contract tests."""
+    if num_devices <= 0:
+        raise ValueError(f"num_devices must be positive, got {num_devices}")
+    expert = 2 if num_devices % 2 == 0 else 1
+    data = max(1, num_devices // expert)
+    mesh = jax.sharding.AbstractMesh(
+        axis_sizes=(1, data, expert, 1),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(
+            jax.sharding.AxisType.Explicit,
+            jax.sharding.AxisType.Explicit,
+            jax.sharding.AxisType.Explicit,
+            jax.sharding.AxisType.Explicit,
+        ),
+    )
+    return mesh, P(("replica_dcn", "data", "expert"), None)
+
+
+def _with_state_dict_prefix(prefix: str | None, name: str) -> str:
+    return name if prefix is None else f"{prefix}.{name}"
+
+
+def _linear_inference_tensor(value: jax.Array) -> jax.Array:
+    return jnp.swapaxes(value, -1, -2)
+
+
+def grugmoe_inference_state_dict(model: Transformer, prefix: str | None = None) -> dict[str, jax.Array]:
+    tensors: dict[str, jax.Array] = {
+        "model.embed_tokens.weight": model.token_embed,
+        "model.embed_norm.weight": model.embed_norm.weight,
+        "model.embed_gated_norm.down_proj.weight": _linear_inference_tensor(model.embed_gated_norm.w_down),
+        "model.embed_gated_norm.up_proj.weight": _linear_inference_tensor(model.embed_gated_norm.w_up),
+        "model.norm.weight": model.final_norm.weight,
+        "model.final_gated_norm.down_proj.weight": _linear_inference_tensor(model.final_gated_norm.w_down),
+        "model.final_gated_norm.up_proj.weight": _linear_inference_tensor(model.final_gated_norm.w_up),
+        "lm_head.weight": _linear_inference_tensor(model.output_proj),
+    }
+
+    for layer_index, block in enumerate(model.blocks):
+        layer_prefix = f"model.layers.{layer_index}"
+        tensors.update(
+            {
+                f"{layer_prefix}.input_layernorm.weight": block.rms_attn.weight,
+                f"{layer_prefix}.attn_gated_norm.down_proj.weight": _linear_inference_tensor(
+                    block.attn_gated_norm.w_down
+                ),
+                f"{layer_prefix}.attn_gated_norm.up_proj.weight": _linear_inference_tensor(block.attn_gated_norm.w_up),
+                f"{layer_prefix}.self_attn.q_proj.weight": _linear_inference_tensor(block.attn.w_q),
+                f"{layer_prefix}.self_attn.k_proj.weight": _linear_inference_tensor(block.attn.w_k),
+                f"{layer_prefix}.self_attn.v_proj.weight": _linear_inference_tensor(block.attn.w_v),
+                f"{layer_prefix}.self_attn.o_proj.weight": _linear_inference_tensor(block.attn.w_o),
+                f"{layer_prefix}.self_attn.attn_gate.weight": _linear_inference_tensor(block.attn.attn_gate),
+                f"{layer_prefix}.post_attention_layernorm.weight": block.rms_mlp.weight,
+                f"{layer_prefix}.mlp_gated_norm.down_proj.weight": _linear_inference_tensor(block.mlp_gated_norm.w_down),
+                f"{layer_prefix}.mlp_gated_norm.up_proj.weight": _linear_inference_tensor(block.mlp_gated_norm.w_up),
+                f"{layer_prefix}.mlp.router.weight": _linear_inference_tensor(block.mlp.router),
+                f"{layer_prefix}.mlp.router.bias": block.mlp.router_bias,
+                f"{layer_prefix}.mlp.experts.gate_proj.weight": _linear_inference_tensor(block.mlp.expert_mlp.w_gate),
+                f"{layer_prefix}.mlp.experts.up_proj.weight": _linear_inference_tensor(block.mlp.expert_mlp.w_up),
+                f"{layer_prefix}.mlp.experts.down_proj.weight": _linear_inference_tensor(block.mlp.expert_mlp.w_down),
+            }
+        )
+        if block.shared is not None:
+            tensors.update(
+                {
+                    f"{layer_prefix}.shared_expert.gate_proj.weight": _linear_inference_tensor(block.shared.w_gate),
+                    f"{layer_prefix}.shared_expert.up_proj.weight": _linear_inference_tensor(block.shared.w_up),
+                    f"{layer_prefix}.shared_expert.down_proj.weight": _linear_inference_tensor(block.shared.w_down),
+                }
+            )
+        for site_name, conv in (
+            ("self_attn.sconv_k", block.attn.sconv_k),
+            ("self_attn.sconv_v", block.attn.sconv_v),
+            ("sconv_attn", block.sconv_attn),
+            ("sconv_mlp", block.sconv_mlp),
+        ):
+            tensors[f"{layer_prefix}.{site_name}.weight"] = conv.weight
+
+    return {_with_state_dict_prefix(prefix, name): value for name, value in tensors.items()}
+
+
+__all__ = [
+    "GRUG_MOE_ARCHITECTURE",
+    "GRUG_MOE_ARTIFACT_SCHEMA_VERSION",
+    "GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY",
+    "GRUG_MOE_MODEL_TYPE",
+    "Block",
+    "CausalSelfAttention",
+    "DenseMLP",
+    "GatedNorm",
+    "GrugModelConfig",
+    "GrugMoeHfConfig",
+    "MoEMLP",
+    "MoeActivation",
+    "RMSNorm",
+    "ShortConv",
+    "Transformer",
+    "debug_mesh_and_token_pspec",
+    "grugmoe_inference_state_dict",
+]

--- a/experiments/grug/moe_pallas_sconv/model.py
+++ b/experiments/grug/moe_pallas_sconv/model.py
@@ -290,7 +290,7 @@ class ShortConv(eqx.Module):
         attention_mask = None if segment_ids is None else segment_ids >= 0
         output, _ = depthwise_causal_convolution(
             input=x,
-            weight=self.weight.astype(x.dtype),
+            weight=self.weight,
             attention_mask=attention_mask,
         )
 

--- a/experiments/grug/moe_pallas_sconv/optimizer.py
+++ b/experiments/grug/moe_pallas_sconv/optimizer.py
@@ -1,0 +1,320 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+import optax
+from levanter.optim.config import OptimizerConfig
+from levanter.optim.grugmuon import _grug_scale_with_muon
+from levanter.optim.util import CoefficientType
+from levanter.utils.jax_utils import leaf_key_paths
+
+from experiments.grug.moe_pallas_sconv.adamh import scale_by_adamh
+
+
+def _target_named_sharding(array) -> jax.sharding.NamedSharding | None:
+    if array is None or not hasattr(array, "shape"):
+        return None
+    sharding = getattr(array, "sharding", None)
+    if sharding is None:
+        aval = jax.typeof(array)
+        sharding = getattr(aval, "sharding", None)
+    if isinstance(sharding, jax.sharding.NamedSharding):
+        return sharding
+    return None
+
+
+def _match_named_update_sharding() -> optax.GradientTransformation:
+    """Restore named mesh sharding without touching single-device arrays."""
+
+    def init_fn(params):
+        del params
+        return optax.EmptyState()
+
+    def update_fn(updates, state, params=None):
+        if params is None:
+            return updates, state
+
+        def match_sharding(update, param):
+            if update is None:
+                return None
+            target_sharding = _target_named_sharding(param)
+            if target_sharding is None:
+                return update
+            return jax.sharding.reshard(update, target_sharding)
+
+        updates = jax.tree.map(match_sharding, updates, params, is_leaf=lambda x: x is None)
+        return updates, state
+
+    return optax.GradientTransformation(init_fn, update_fn)
+
+
+def _match_named_sharding_to_params(updates, params):
+    def match_sharding(update, param):
+        if update is None:
+            return None
+        target_sharding = _target_named_sharding(param)
+        if target_sharding is None:
+            return update
+        return jax.sharding.reshard(update, target_sharding)
+
+    return jax.tree.map(match_sharding, updates, params, is_leaf=lambda x: x is None)
+
+
+def _scale_invariant_hyperball_updates(params, direction_updates, learning_rate: float):
+    direction_updates = _match_named_sharding_to_params(direction_updates, params)
+
+    def scale_invariant_update(param, update):
+        if update is None:
+            return None
+        if not hasattr(param, "ndim"):
+            return update
+        if param.ndim == 2:
+            param_norm = jnp.linalg.norm(param)
+            update_norm = jnp.linalg.norm(update)
+            new_param = param - learning_rate * update * param_norm / jnp.maximum(update_norm, 1e-10)
+            new_param_norm = jnp.linalg.norm(new_param)
+            return new_param / jnp.maximum(new_param_norm, 1e-10) * param_norm - param
+
+        axes = tuple(range(1, param.ndim))
+        param_norm = jnp.sqrt(jnp.sum(jnp.square(param), axis=axes, keepdims=True))
+        update_norm = jnp.sqrt(jnp.sum(jnp.square(update), axis=axes, keepdims=True))
+        new_param = param - learning_rate * update * param_norm / jnp.maximum(update_norm, 1e-10)
+        new_param_norm = jnp.sqrt(jnp.sum(jnp.square(new_param), axis=axes, keepdims=True))
+        return new_param / jnp.maximum(new_param_norm, 1e-10) * param_norm - param
+
+    return jax.tree.map(
+        scale_invariant_update,
+        params,
+        direction_updates,
+        is_leaf=lambda x: x is None,
+    )
+
+
+def scale_with_grug_muonh(
+    momentum: float = 0.95,
+    nesterov: bool = True,
+    steps: int = 5,
+    muon_eps: float = 1e-8,
+    learning_rate: float = 0.02,
+    coefficient_type: CoefficientType = "quintic",
+) -> optax.GradientTransformation:
+    """MuonH transform for raw Grug arrays with matrix-shaped trailing dims."""
+    muon_transform = _grug_scale_with_muon(
+        momentum=momentum,
+        nesterov=nesterov,
+        steps=steps,
+        muon_eps=muon_eps,
+        use_kimi_scaling=False,
+        coefficient_type=coefficient_type,
+    )
+
+    def init_fn(params):
+        return muon_transform.init(params)
+
+    def update_fn(updates, state, params=None):
+        if params is None:
+            raise ValueError("scale_with_grug_muonh requires params for norm-preserving updates")
+
+        muon_updates, next_state = muon_transform.update(updates, state, params)
+        muonh_updates = _scale_invariant_hyperball_updates(params, muon_updates, learning_rate)
+        return muonh_updates, next_state
+
+    return optax.GradientTransformation(init_fn, update_fn)
+
+
+@OptimizerConfig.register_subclass("grug_moe_pallas_sconv_adamh_v1")
+@dataclass(frozen=True)
+class GrugMoeAdamHConfig(OptimizerConfig):
+    """AdamH for Grug MoE. Four optimizer groups, no flags.
+
+    - adamh: attention weights, dense MLP weights (2D matrices)
+    - adamh_expert: expert MLP weights (mlp.expert_mlp.w_gate,
+      mlp.expert_mlp.w_up, mlp.expert_mlp.w_down, shared.w_*)
+    - adam: norms, biases, router, embeddings, attention gates (1D / small params)
+    """
+
+    beta1: float = 0.9
+    beta2: float = 0.95
+    epsilon: float = 1e-8
+    max_grad_norm: float | None = 1.0
+    adam_lr: float = 6e-4
+    expert_lr: float | None = None
+
+    def build(self, num_train_steps):
+        learning_rate_schedule = self.lr_scheduler(num_train_steps)
+        adam_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=self.adam_lr)
+        expert_lr_val = self.expert_lr if self.expert_lr is not None else self.learning_rate
+        expert_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=expert_lr_val)
+
+        def optimizer(learning_rate, adam_lr, expert_lr):
+            def adamh_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(scale_by_adamh(self.beta1, self.beta2, self.epsilon, learning_rate))
+                return optax.chain(*components)
+
+            def adamh_expert_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(scale_by_adamh(self.beta1, self.beta2, self.epsilon, expert_lr))
+                return optax.chain(*components)
+
+            def adam_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(optax.scale_by_adam(self.beta1, self.beta2, self.epsilon))
+                components.append(optax.scale(-adam_lr))
+                return optax.chain(*components)
+
+            return optax.multi_transform(
+                {
+                    "adamh": adamh_transform(),
+                    "adamh_expert": adamh_expert_transform(),
+                    "adam": adam_transform(),
+                },
+                self.create_mask,
+            )
+
+        return optax.inject_hyperparams(optimizer)(
+            learning_rate=learning_rate_schedule,
+            adam_lr=adam_lr_schedule,
+            expert_lr=expert_lr_schedule,
+        )
+
+    def create_mask(self, params):
+        paths = leaf_key_paths(params)
+
+        def mask_fn(param, path):
+            path_str = ".".join(path) if isinstance(path, (list, tuple)) else str(path)
+            path_lower = path_str.lower()
+            if "token_embed" in path_lower:
+                return "adam"
+            if (
+                "router_bias" in path_lower
+                or "attn_gate" in path_lower
+                or ".router" in path_lower
+                or "sconv" in path_lower
+            ):
+                return "adam"
+            if ".mlp.expert_mlp.w_" in path_lower or ".mlp.w_" in path_lower or ".shared.w_" in path_lower:
+                return "adamh_expert"
+            if hasattr(param, "ndim") and param.ndim >= 2:
+                return "adamh"
+            return "adam"
+
+        return jax.tree.map(mask_fn, params, paths)
+
+
+@OptimizerConfig.register_subclass("grug_moe_pallas_sconv_muonh_v1")
+@dataclass(frozen=True)
+class GrugMoeMuonHConfig(OptimizerConfig):
+    """May Recipe MuonH optimizer: 3 LR groups (muonh / adamh / adam).
+
+    Three LR groups:
+    - ``muonh``: matrices (attn, MoE MLP, shared) **and** all GatedNorms.
+      Newton-Schulz orthogonalisation + Frobenius hyperball scale-invariant step.
+    - ``adamh``: ``lm_head`` / ``output_proj``.
+    - ``adam``: ``token_embed`` / ``router`` / ``router_bias`` / ``attn_gate``
+      / 1-D norm weights.
+
+    ``max_grad_norm`` defaults to ``None`` here (no clipping) for the 1pct-noclip
+    schedule used by the May Recipe baseline.
+    """
+
+    adam_lr: float = 6e-4
+    momentum: float = 0.95
+    nesterov: bool = True
+    backend_steps: int = 5
+    beta1: float = 0.9
+    beta2: float = 0.95
+    epsilon: float = 1e-8
+    muon_epsilon: float = 1e-8
+    max_grad_norm: float | None = None
+    coefficient_type: CoefficientType = "quintic"
+
+    def build(self, num_train_steps):
+        learning_rate_schedule = self.lr_scheduler(num_train_steps)
+        adam_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=self.adam_lr)
+
+        def optimizer(learning_rate, adam_lr):
+            def muonh_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(
+                    scale_with_grug_muonh(
+                        momentum=self.momentum,
+                        nesterov=self.nesterov,
+                        steps=self.backend_steps,
+                        muon_eps=self.muon_epsilon,
+                        learning_rate=learning_rate,
+                        coefficient_type=self.coefficient_type,
+                    )
+                )
+                components.append(_match_named_update_sharding())
+                return optax.chain(*components)
+
+            def adamh_transform_at(lr):
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(scale_by_adamh(self.beta1, self.beta2, self.epsilon, lr))
+                return optax.chain(*components)
+
+            def adam_transform_at(lr):
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(optax.scale_by_adam(self.beta1, self.beta2, self.epsilon))
+                components.append(optax.scale(-lr))
+                return optax.chain(*components)
+
+            transforms = {
+                "muonh": muonh_transform(),
+                "adamh": adamh_transform_at(learning_rate),
+                "adam": adam_transform_at(adam_lr),
+            }
+            return optax.multi_transform(transforms, self.create_mask)
+
+        return optax.inject_hyperparams(optimizer)(
+            learning_rate=learning_rate_schedule,
+            adam_lr=adam_lr_schedule,
+        )
+
+    def create_mask(self, params):
+        paths = leaf_key_paths(params)
+
+        def mask_fn(param, path):
+            path_str = ".".join(path) if isinstance(path, (list, tuple)) else str(path)
+            path_lower = path_str.lower()
+            if (
+                "token_embed" in path_lower
+                or "router_bias" in path_lower
+                or path_lower.endswith(".attn_gate")
+                or ".router" in path_lower
+                or "sconv" in path_lower
+            ):
+                return "adam"
+            if "output_proj" in path_lower or "lm_head" in path_lower:
+                return "adamh"
+            # GatedNorms route to muonh (NS + Frobenius hyperball), same as matrices.
+            if "gated_norm" in path_lower:
+                return "muonh"
+            if hasattr(param, "ndim") and param.ndim in (2, 3):
+                return "muonh"
+            return "adam"
+
+        return jax.tree.map(mask_fn, params, paths)
+
+
+__all__ = [
+    "GrugMoeAdamHConfig",
+    "GrugMoeMuonHConfig",
+    "scale_with_grug_muonh",
+]

--- a/experiments/grug/moe_pallas_sconv/test_model.py
+++ b/experiments/grug/moe_pallas_sconv/test_model.py
@@ -1,0 +1,74 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import AxisType, Mesh, set_mesh
+from numpy.testing import assert_allclose
+
+from experiments.grug.moe_pallas_sconv.model import ShortConv
+
+
+def _single_device_mesh() -> Mesh:
+    devices = np.asarray(jax.devices()[:1]).reshape((1, 1, 1, 1))
+    return Mesh(
+        devices,
+        ("replica_dcn", "data", "expert", "model"),
+        axis_types=(AxisType.Explicit,) * 4,
+    )
+
+
+def _short_conv_reference(x: jax.Array, weight: jax.Array, segment_ids: jax.Array) -> jax.Array:
+    seq_len = x.shape[1]
+    output = jnp.zeros_like(x)
+    for lag in range(weight.shape[1]):
+        shifted = jnp.pad(x, ((0, 0), (lag, 0), (0, 0)))[:, :seq_len, :]
+        shifted_ids = jnp.pad(segment_ids, ((0, 0), (lag, 0)), constant_values=-1)[:, :seq_len]
+        same_segment = (segment_ids >= 0) & (shifted_ids == segment_ids)
+        output = output + jnp.where(same_segment[..., None], shifted * weight[:, -1 - lag], 0)
+    return output
+
+
+def test_short_conv_matches_segmented_reference_value_and_gradients():
+    x = jnp.arange(2 * 7 * 3, dtype=jnp.float32).reshape(2, 7, 3) / 10
+    weight = jnp.array(
+        [
+            [0.1, -0.2, 0.3, 0.8],
+            [-0.4, 0.2, 0.1, 0.9],
+            [0.25, 0.15, -0.1, 1.1],
+        ],
+        dtype=jnp.float32,
+    )
+    segment_ids = jnp.array(
+        [
+            [0, 0, 0, 1, 1, 2, 2],
+            [3, 3, 4, 4, 4, -1, -1],
+        ],
+        dtype=jnp.int32,
+    )
+
+    def actual_loss(weight, x):
+        return jnp.sum(ShortConv(weight=weight, kernel_size=4)(x, segment_ids) ** 2)
+
+    def reference_loss(weight, x):
+        return jnp.sum(_short_conv_reference(x, weight, segment_ids) ** 2)
+
+    with set_mesh(_single_device_mesh()):
+        actual_value, actual_grads = jax.value_and_grad(actual_loss, argnums=(0, 1))(weight, x)
+    reference_value, reference_grads = jax.value_and_grad(reference_loss, argnums=(0, 1))(weight, x)
+
+    assert_allclose(np.asarray(actual_value), np.asarray(reference_value), rtol=1e-5, atol=1e-5)
+    assert_allclose(np.asarray(actual_grads[0]), np.asarray(reference_grads[0]), rtol=1e-5, atol=1e-5)
+    assert_allclose(np.asarray(actual_grads[1]), np.asarray(reference_grads[1]), rtol=1e-5, atol=1e-5)
+
+
+def test_short_conv_identity_initialization_preserves_valid_tokens():
+    x = jax.random.normal(jax.random.PRNGKey(0), (2, 6, 4))
+    segment_ids = jnp.array([[0, 0, 1, 1, 2, 2], [3, 3, 3, 4, -1, -1]], dtype=jnp.int32)
+
+    with set_mesh(_single_device_mesh()):
+        output = ShortConv.init(channels=4, kernel_size=4)(x, segment_ids)
+
+    expected = jnp.where((segment_ids >= 0)[..., None], x, 0)
+    assert_allclose(np.asarray(output), np.asarray(expected), rtol=1e-6, atol=1e-6)

--- a/experiments/grug/moe_pallas_sconv/test_optimizer.py
+++ b/experiments/grug/moe_pallas_sconv/test_optimizer.py
@@ -1,0 +1,49 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import jax.numpy as jnp
+
+from experiments.grug.moe_pallas_sconv.optimizer import GrugMoeAdamHConfig, GrugMoeMuonHConfig
+
+
+def test_grug_moe_adamh_mask_routes_expert_mlp_weights_to_expert_group():
+    params = {
+        "blocks": {
+            "0": {
+                "mlp": {
+                    "router": jnp.ones((8, 4), dtype=jnp.float32),
+                    "expert_mlp": {
+                        "w_gate": jnp.ones((4, 8, 16), dtype=jnp.float32),
+                        "w_up": jnp.ones((4, 8, 16), dtype=jnp.float32),
+                        "w_down": jnp.ones((4, 16, 8), dtype=jnp.float32),
+                    },
+                },
+                "shared": {
+                    "w_gate": jnp.ones((8, 16), dtype=jnp.float32),
+                },
+                "sconv_attn": {
+                    "weight": jnp.ones((8, 4), dtype=jnp.float32),
+                },
+            },
+        },
+        "token_embed": jnp.ones((128, 8), dtype=jnp.float32),
+    }
+
+    mask = GrugMoeAdamHConfig().create_mask(params)
+
+    block_mask = mask["blocks"]["0"]
+    assert block_mask["mlp"]["router"] == "adam"
+    assert block_mask["mlp"]["expert_mlp"]["w_gate"] == "adamh_expert"
+    assert block_mask["mlp"]["expert_mlp"]["w_up"] == "adamh_expert"
+    assert block_mask["mlp"]["expert_mlp"]["w_down"] == "adamh_expert"
+    assert block_mask["shared"]["w_gate"] == "adamh_expert"
+    assert block_mask["sconv_attn"]["weight"] == "adam"
+    assert mask["token_embed"] == "adam"
+
+
+def test_grug_moe_muonh_mask_routes_sconv_weights_to_adam():
+    params = {"blocks": {"0": {"attn": {"sconv_k": {"weight": jnp.ones((8, 4))}}}}}
+
+    mask = GrugMoeMuonHConfig().create_mask(params)
+
+    assert mask["blocks"]["0"]["attn"]["sconv_k"]["weight"] == "adam"

--- a/experiments/grug/moe_pallas_sconv/train.py
+++ b/experiments/grug/moe_pallas_sconv/train.py
@@ -1,0 +1,603 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+import functools
+import logging
+import time
+from dataclasses import dataclass, field
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jmp
+import levanter.callbacks as callbacks
+import levanter.tracker
+import optax
+from fray.cluster import ResourceConfig
+from haliax import Axis
+from haliax.partitioning import set_mesh
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+from jax.tree_util import register_dataclass
+from jaxtyping import PRNGKeyArray
+from levanter.callbacks.state_adapter import StateCallbackRunner
+from levanter.callbacks.watch import WatchConfig, compute_watch_stats
+from levanter.data.dataset import AsyncDataset
+from levanter.data.loader import DataLoader
+from levanter.data.mixture import MixtureDataset, rescale_mixture_schedule_for_batch_schedule
+from levanter.data.text.datasets import LmDataConfig
+from levanter.data.text.examples import GrugLmExample, grug_lm_example_from_named
+from levanter.eval import TaggedEvaluator, cb_tagged_evaluate
+from levanter.grug.sharding import compact_grug_mesh
+from levanter.models.lm_model import LmExample
+from levanter.optim.config import AdamConfig, OptimizerConfig
+from levanter.schedule import BatchSchedule
+from levanter.trainer import TrainerConfig
+from levanter.utils.flop_utils import lm_flops_per_token
+from levanter.utils.jax_utils import parameter_count
+from levanter.utils.logging import LoadingTimeTrackerIterator
+
+from experiments.grug.checkpointing import init_weights_only_from_checkpoint, restore_grug_state_from_checkpoint
+from experiments.grug.dispatch import dispatch_grug_training_run
+from experiments.grug.moe_pallas_sconv.model import GrugModelConfig, Transformer
+from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
+
+# This file intentionally mirrors `experiments/grug/base/train.py` with
+# variant-specific model/loss/FLOP wiring, per the grug copy-first workflow in
+# `.agents/skills/change-grug/`.
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GrugTrainerConfig:
+    """Runtime knobs for grug training."""
+
+    trainer: TrainerConfig = field(default_factory=lambda: TrainerConfig(use_explicit_mesh_axes=True))
+    data_seed: int | None = None
+    log_every: int = 1
+    ema_beta: float | None = None  # EMA coefficient for eval/checkpoint model; None disables EMA.
+    z_loss_weight: float = 1e-4  # Weight on final-logit logsumexp z-loss stabilization term.
+
+    # Grug builds its own compact (replica_dcn, data, expert, model) mesh instead of using
+    # the Trainer's logical axis mapping; `data` absorbs whatever these two leave free.
+    # Defaults reproduce the historical layout: no expert parallelism and full replication
+    # across slices (replica_axis_size=None -> jax.process_count()), i.e. parameters
+    # replicated per slice and sharded only over the intra-slice `data` axis. For a model
+    # too large to replicate within one slice, set replica_axis_size=1 (FSDP across every
+    # slice) and expert_axis_size>1 (expert parallelism over the intra-slice devices).
+    expert_axis_size: int = 1
+    replica_axis_size: int | None = None
+    sharding_dump_path: str | None = None
+
+
+@dataclass(frozen=True)
+class GrugEvalConfig:
+    """Perplexity eval settings for grug training."""
+
+    eval_batch_size: int = 512
+    steps_per_eval: int | None = 1000
+    max_eval_batches: int | None = None
+    prefix: str = "eval"
+    eval_current: bool = True
+    eval_ema: bool = True
+    compute_bpb: bool = True
+    shuffle: bool = True  # Mix eval domains within batches to reduce expert-capacity drops.
+
+
+@dataclass(frozen=True)
+class GrugRunConfig:
+    """Top-level config for grug training."""
+
+    model: GrugModelConfig
+    data: LmDataConfig
+    resources: ResourceConfig
+    optimizer: OptimizerConfig = field(default_factory=AdamConfig)
+    trainer: GrugTrainerConfig = field(default_factory=GrugTrainerConfig)
+    eval: GrugEvalConfig | None = field(default_factory=GrugEvalConfig)
+    # GPU processes per task: > 1 runs one JAX process per GPU (multi-controller)
+    # via the iris.hooks.multigpu_main supervisor instead of one process per node.
+    processes_per_task: int = 1
+
+
+def build_train_dataset(
+    data_config: LmDataConfig,
+    *,
+    max_seq_len: int,
+    batch_schedule: BatchSchedule,
+    key: PRNGKeyArray,
+) -> MixtureDataset[GrugLmExample]:
+    pos = Axis("position", max_seq_len)
+    mix_key, shuffle_key = jax.random.split(key)
+    weights = data_config.train_weights
+    if isinstance(weights, list):
+        weights = rescale_mixture_schedule_for_batch_schedule(weights, batch_schedule)
+
+    initial_batch_size = batch_schedule.batch_size_at_step(0)
+    datasets = data_config.train_sets(pos, key=shuffle_key, initial_batch_size=initial_batch_size)
+    return MixtureDataset(
+        datasets=datasets,
+        weights=weights,
+        stop_strategy=data_config.stop_strategy,
+        key=mix_key,
+        block_size=data_config.mixture_block_size,
+    )
+
+
+_BATCH_AXES: tuple[str, ...] = ("replica_dcn", "data", "expert")
+
+
+def build_train_loader(
+    dataset: AsyncDataset[GrugLmExample],
+    *,
+    batch_schedule: BatchSchedule,
+    mesh: Mesh,
+) -> DataLoader[GrugLmExample]:
+    # DataLoader uses this batch axis mapping to shard batches across the distributed mesh.
+    # `compact_grug_mesh` always carries (replica_dcn, data, expert, model); length-1 axes
+    # are kept so we can name "expert" unconditionally.
+    return DataLoader(
+        dataset,
+        batch_schedule.schedule,
+        mesh=mesh,
+        axis_resources={"__BATCH__": _BATCH_AXES},
+        batch_axis_name="__BATCH__",
+        allow_nondivisible_batch_size=False,
+    )
+
+
+def build_tagged_evaluator(
+    *,
+    data_config: LmDataConfig,
+    max_seq_len: int,
+    mesh: Mesh,
+    eval_cfg: GrugEvalConfig,
+) -> TaggedEvaluator[LmExample | GrugLmExample, Transformer] | None:
+    pos = Axis("position", max_seq_len)
+    tagged_eval_sets = data_config.tagged_eval_sets(pos)
+    if len(tagged_eval_sets) == 0:
+        logger.warning("No evaluation datasets provided.")
+        return None
+
+    max_examples_per_dataset = None
+    if eval_cfg.max_eval_batches is not None:
+        max_examples_per_dataset = eval_cfg.max_eval_batches * eval_cfg.eval_batch_size
+
+    tokenizer = data_config.the_tokenizer if eval_cfg.compute_bpb else None
+    # `compact_grug_mesh` always carries (replica_dcn, data, expert, model); length-1 axes
+    # are kept so we can name "expert" unconditionally.
+    eval_axis_mapping = {"batch": _BATCH_AXES}
+    eval_batch = Axis("batch", eval_cfg.eval_batch_size)
+    eval_array_sharding = NamedSharding(mesh, P(_BATCH_AXES, None))
+
+    def eval_loss_fn(model: Transformer, batch: LmExample | GrugLmExample) -> tuple[jax.Array, jax.Array, jax.Array]:
+        if isinstance(batch, LmExample):
+            batch = grug_lm_example_from_named(batch)
+        per_pos_loss = model.next_token_loss(
+            batch.tokens,
+            batch.loss_weight,
+            mask=batch.attn_mask,
+            reduction="none",
+            logsumexp_weight=None,
+        )
+        per_pos_loss = jax.sharding.reshard(per_pos_loss, eval_array_sharding)
+        per_pos_weight = jax.sharding.reshard(batch.loss_weight, eval_array_sharding)
+        per_pos_token_id = jnp.pad(batch.tokens[:, 1:], ((0, 0), (0, 1)))
+        return per_pos_loss, per_pos_weight, per_pos_token_id
+
+    return TaggedEvaluator(
+        EvalBatch=eval_batch,
+        tagged_eval_sets=tagged_eval_sets,
+        loss_fn=eval_loss_fn,
+        tokenizer=tokenizer,
+        device_mesh=mesh,
+        axis_mapping=eval_axis_mapping,
+        max_examples_per_dataset=max_examples_per_dataset,
+        shuffle=eval_cfg.shuffle,
+    )
+
+
+def _compute_flops(
+    *,
+    model_config: GrugModelConfig,
+) -> tuple[float, dict[str, float]]:
+    flops_per_token = lm_flops_per_token(
+        hidden_dim=model_config.hidden_dim,
+        intermediate_dim=model_config.intermediate_dim,
+        shared_intermediate_dim=model_config.shared_expert_intermediate_dim,
+        num_layers=model_config.num_layers,
+        num_kv_heads=model_config.num_kv_heads,
+        num_heads=model_config.num_heads,
+        seq_len=model_config.max_seq_len,
+        vocab_size=model_config.vocab_size,
+        glu=True,
+        num_experts=model_config.num_experts,
+        num_shared_experts=1 if model_config.shared_expert_intermediate_dim > 0 else 0,
+        num_experts_per_tok=model_config.num_experts_per_token,
+    )
+    flops_per_example = 3 * flops_per_token * model_config.max_seq_len
+
+    flops_summary: dict[str, float] = {
+        "throughput/flops_per_token_analytic": flops_per_token,
+        "throughput/flops_per_example_analytic": flops_per_example,
+    }
+
+    return flops_per_example, flops_summary
+
+
+def _make_mixture_stage_callback(train_dataset: MixtureDataset, batch_schedule: BatchSchedule):
+    last_mixture_stage = -1
+
+    def log_mixture_stage(step_info):
+        nonlocal last_mixture_stage
+        seq_index = batch_schedule.global_data_offset_by_step(step_info.step)
+        block_id = seq_index // train_dataset.block_size
+        stage = train_dataset._get_stage_for_block(block_id)
+        if stage == last_mixture_stage:
+            return
+
+        weights = train_dataset.weight_stages[stage][1]
+        mixture_log = {f"mixture/weight/{name}": weight for name, weight in weights.items()}
+        mixture_log["mixture/stage"] = stage
+        levanter.tracker.log(mixture_log, step=step_info.step)
+        last_mixture_stage = stage
+
+    return log_mixture_stage
+
+
+@register_dataclass
+@dataclass(frozen=True)
+class GrugTrainState:
+    step: jax.Array
+    params: Transformer
+    opt_state: optax.OptState
+    ema_params: Transformer | None
+    pending_qb_betas: jax.Array
+
+
+def _apply_qb_betas(model: Transformer, qb_betas: jax.Array) -> Transformer:
+    """Set router biases from QB betas (computed on previous step)."""
+    new_blocks = list(model.blocks)
+    moe_idx = 0
+    for i, block in enumerate(model.blocks):
+        if block.mlp is None:
+            continue
+        new_bias = -qb_betas[moe_idx]
+        new_bias = new_bias - jnp.mean(new_bias)
+        new_mlp = eqx.tree_at(lambda m: m.router_bias, block.mlp, new_bias)
+        new_blocks[i] = eqx.tree_at(lambda b: b.mlp, block, new_mlp)
+        moe_idx += 1
+    return eqx.tree_at(lambda t: t.blocks, model, tuple(new_blocks))
+
+
+def initial_state(
+    model_config: GrugModelConfig,
+    *,
+    optimizer: optax.GradientTransformation,
+    mp: jmp.Policy,
+    key: PRNGKeyArray,
+    ema_beta: float | None,
+) -> GrugTrainState:
+    params = mp.cast_to_param(Transformer.init(model_config, key=key))
+    num_moe_layers = sum(1 for b in params.blocks if b.mlp is not None)
+    return GrugTrainState(
+        step=jnp.array(0, dtype=jnp.int32),
+        params=params,
+        opt_state=optimizer.init(params),
+        ema_params=params if ema_beta is not None else None,
+        pending_qb_betas=jnp.zeros((num_moe_layers, model_config.num_experts)),
+    )
+
+
+def _make_train_step(
+    optimizer: optax.GradientTransformation,
+    mp: jmp.Policy,
+    *,
+    z_loss_weight: float,
+    ema_beta: float | None,
+    watch_config: WatchConfig | None = None,
+):
+    one = jnp.array(1, dtype=jnp.int32)
+    z_loss = z_loss_weight if z_loss_weight > 0 else None
+    if watch_config is not None:
+        if isinstance(watch_config.watch_targets, str):
+            watch_targets = tuple(t.strip() for t in watch_config.watch_targets.split(","))
+        else:
+            watch_targets = tuple(watch_config.watch_targets)
+    else:
+        watch_targets = ()
+
+    @functools.partial(jax.jit, donate_argnums=(0,), static_argnames=("compute_watch",))
+    def train_step(state: GrugTrainState, batch, *, compute_watch: bool = False):
+        # Apply pending QB betas to router biases inside JIT (avoids eager
+        # host-side TPU kernel launches that can cause SPMD sync issues).
+        qb_params = _apply_qb_betas(state.params, state.pending_qb_betas)
+        if ema_beta is not None:
+            qb_ema_params = _apply_qb_betas(state.ema_params, state.pending_qb_betas)
+        else:
+            qb_ema_params = None
+
+        def loss_fn(params):
+            compute_params = mp.cast_to_compute(params)
+            return compute_params.next_token_loss(
+                batch.tokens,
+                batch.loss_weight,
+                mask=batch.attn_mask,
+                reduction="mean",
+                logsumexp_weight=z_loss,
+                return_router_metrics=True,
+            )
+
+        (loss, summarized_metrics), grads = jax.value_and_grad(loss_fn, has_aux=True)(qb_params)
+        metrics = {"train/loss": loss, **summarized_metrics}
+        updates, opt_state = optimizer.update(grads, state.opt_state, qb_params)
+        params = optax.apply_updates(qb_params, updates)
+
+        if ema_beta is None:
+            ema_params = None
+        else:
+            if qb_ema_params is None:
+                raise ValueError("ema_params must be initialized when ema_beta is set.")
+            ema_params = jax.tree_util.tree_map(
+                lambda old, new: ema_beta * old + (1.0 - ema_beta) * new,
+                qb_ema_params,
+                params,
+            )
+
+        watch_stats = None
+        if watch_config is not None and compute_watch:
+            watch_stats = compute_watch_stats(
+                watch_targets=watch_targets,
+                include_norms=watch_config.include_norms,
+                include_per_parameter_norms=watch_config.include_per_parameter_norms,
+                include_histogram=watch_config.include_histograms,
+                split_scan_layers=watch_config.split_scan_layers,
+                params=qb_params,
+                grads=grads,
+                updates=updates,
+                opt_state=state.opt_state,
+                model_tree_type=type(state.params),
+            )
+
+        next_state = dataclasses.replace(
+            state,
+            step=state.step + one,
+            params=params,
+            opt_state=opt_state,
+            ema_params=ema_params,
+            pending_qb_betas=metrics["qb_beta_per_layer"],
+        )
+
+        return next_state, metrics, watch_stats
+
+    return train_step
+
+
+def _run_grug_local(config: GrugRunConfig) -> None:
+    """Entry point for the grug template training loop."""
+    trainer = config.trainer.trainer
+    trainer.initialize()
+    levanter.tracker.log_configuration(config)
+
+    run_id = trainer.id
+    if run_id is None:
+        raise ValueError("trainer.id was not initialized")
+
+    optimizer = config.optimizer.build(trainer.num_train_steps)
+    watch_config = trainer.watch
+    train_step = _make_train_step(
+        optimizer,
+        trainer.mp,
+        z_loss_weight=config.trainer.z_loss_weight,
+        ema_beta=config.trainer.ema_beta,
+        watch_config=watch_config if watch_config.is_enabled else None,
+    )
+
+    data_key, model_key = jax.random.split(jax.random.PRNGKey(trainer.seed), 2)
+    if config.trainer.data_seed is not None:
+        data_key = jax.random.PRNGKey(config.trainer.data_seed)
+
+    # Grug uses raw PartitionSpecs rather than Trainer's logical axis mapping.
+    # Keep the mesh compact so the batch pspec derived by `_batch_spec(mesh)` spans slices directly.
+    # replica_axis_size=None lets compact_grug_mesh default to jax.process_count() (full
+    # cross-slice replication); set it to 1 on GrugTrainerConfig for cross-slice FSDP.
+    mesh = compact_grug_mesh(
+        expert_axis_size=config.trainer.expert_axis_size,
+        replica_axis_size=config.trainer.replica_axis_size,
+    )
+    with set_mesh(mesh):
+        batch_schedule = trainer.batch_schedule
+
+        train_dataset = build_train_dataset(
+            config.data,
+            max_seq_len=config.model.max_seq_len,
+            batch_schedule=batch_schedule,
+            key=data_key,
+        )
+        train_loader = build_train_loader(
+            train_dataset,
+            batch_schedule=batch_schedule,
+            mesh=mesh,
+        )
+
+        @jax.jit
+        def _init_state(model_rng):
+            return initial_state(
+                config.model,
+                optimizer=optimizer,
+                mp=trainer.mp,
+                key=model_rng,
+                ema_beta=config.trainer.ema_beta,
+            )
+
+        state = _init_state(model_key)
+
+        checkpointer = trainer.checkpointer.create(run_id)
+        state = restore_grug_state_from_checkpoint(
+            state,
+            checkpoint_search_paths=trainer.checkpoint_search_paths(run_id),
+            load_checkpoint_setting=trainer.load_checkpoint,
+            mesh=mesh,
+            allow_partial=trainer.allow_partial_checkpoint,
+        )
+        if trainer.initialize_from is not None:
+            state = init_weights_only_from_checkpoint(
+                state,
+                trainer.initialize_from,
+                mesh=mesh,
+                allow_partial=trainer.allow_partial_checkpoint,
+                additional_weight_fields=("pending_qb_betas",),
+            )
+        dump_grug_state_sharding_run_artifact(
+            state,
+            log_dir=trainer.log_dir,
+            run_id=run_id,
+            path_override=config.trainer.sharding_dump_path,
+        )
+
+        levanter.tracker.log_summary({"parameter_count": parameter_count(state.params)})
+
+        flops_per_example, flops_summary = _compute_flops(model_config=config.model)
+        levanter.tracker.log_summary(flops_summary)
+
+        eval_cfg = config.eval
+        evaluator = None
+        if eval_cfg is not None:
+            evaluator = build_tagged_evaluator(
+                data_config=config.data,
+                max_seq_len=config.model.max_seq_len,
+                mesh=mesh,
+                eval_cfg=eval_cfg,
+            )
+
+        profiler_cfg = trainer.profiler
+        profiler_num_steps = profiler_cfg.resolve_num_profile_steps(num_train_steps=trainer.num_train_steps)
+        profiler_enabled = profiler_cfg.is_enabled and profiler_num_steps > 0
+
+        log_every = max(1, config.trainer.log_every)
+        iterator = LoadingTimeTrackerIterator(train_loader.iter_from_step(int(state.step)))
+
+        state_callbacks = StateCallbackRunner[GrugTrainState](
+            step_getter=lambda s: s.step,
+            model_getter=lambda s: s.params,
+            eval_model_getter=lambda s: s.ema_params if s.ema_params is not None else s.params,
+            opt_state_getter=lambda s: s.opt_state,
+        )
+        state_callbacks.add_hook(
+            callbacks.log_performance_stats(config.model.max_seq_len, batch_schedule, flops_per_example),
+            every=log_every,
+        )
+        state_callbacks.add_hook(callbacks.pbar_logger(total=trainer.num_train_steps), every=log_every)
+        state_callbacks.add_hook(callbacks.log_step_info(trainer.num_train_steps), every=log_every)
+        if profiler_enabled:
+            state_callbacks.add_hook(
+                profiler_cfg.build(
+                    str(trainer.log_dir / run_id / "profiler"),
+                    run_id=run_id,
+                    num_steps=profiler_num_steps,
+                ),
+                every=1,
+            )
+        state_callbacks.add_hook(_make_mixture_stage_callback(train_dataset, batch_schedule), every=1)
+        if evaluator is not None and eval_cfg is not None:
+            interval = eval_cfg.steps_per_eval
+            eval_ema = eval_cfg.eval_ema and config.trainer.ema_beta is not None
+            if interval is not None and interval > 0 and (eval_cfg.eval_current or eval_ema):
+                state_callbacks.add_hook(
+                    cb_tagged_evaluate(
+                        evaluator,
+                        prefix=eval_cfg.prefix,
+                        eval_current=eval_cfg.eval_current,
+                        eval_ema=eval_ema,
+                    ),
+                    every=interval,
+                )
+
+        last_loss: float | jax.Array = 0.0
+        last_step_duration = 0.0
+
+        # Main optimization loop.
+        try:
+            while int(state.step) < trainer.num_train_steps:
+                with jax.profiler.TraceAnnotation("load_batch"):
+                    batch = next(iterator)
+                step_start = time.perf_counter()
+                current_step = int(state.step)
+                # grad_watch runs only on its configured interval.
+                compute_watch = (
+                    watch_config.is_enabled and watch_config.interval > 0 and current_step % watch_config.interval == 0
+                )
+                state, metrics, watch_stats = train_step(state, batch, compute_watch=compute_watch)
+                step = int(state.step) - 1
+
+                jax.block_until_ready(metrics["train/loss"])
+
+                if jnp.isnan(metrics["train/loss"]):
+                    logger.error(f"NaN loss at step {int(state.step)}. Stopping training.")
+                    break
+                duration = time.perf_counter() - step_start
+                hook_start = time.perf_counter()
+                with jax.profiler.TraceAnnotation("callbacks"):
+                    state_callbacks.run(state, loss=metrics["train/loss"], step_duration=duration)
+                    last_loss = metrics["train/loss"]
+                    last_step_duration = duration
+                    levanter.tracker.log({"throughput/hook_time": time.perf_counter() - hook_start}, step=step)
+                    levanter.tracker.log({"throughput/loading_time": iterator.this_load_time}, step=step)
+                    router_metrics = {
+                        key: value
+                        for key, value in metrics.items()
+                        if (key.startswith("train/router/") or key.startswith("moe_bias/"))
+                        and key not in ("train/router/routing_counts_per_layer", "qb_beta_per_layer")
+                    }
+                    if router_metrics:
+                        levanter.tracker.log(router_metrics, step=step)
+                    if "train/cross_entropy_loss" in metrics:
+                        levanter.tracker.log(
+                            {"train/cross_entropy_loss": metrics["train/cross_entropy_loss"]},
+                            step=step,
+                        )
+
+                    if watch_stats is not None:
+                        levanter.tracker.log(watch_stats, step=step)
+
+                if checkpointer is not None:
+                    checkpointer.on_step(tree=state, step=int(state.step))
+        except BaseException:
+            logger.exception(
+                "Fatal error in grug training loop; skipping final callbacks/checkpoint to preserve root cause"
+            )
+            raise
+        else:
+            # Mirror classic trainer behavior: force callbacks on the last completed step.
+            state_callbacks.run(state, loss=last_loss, step_duration=last_step_duration, force=True)
+            if checkpointer is not None:
+                checkpointer.on_step(tree=state, step=int(state.step), force=True)
+                checkpointer.wait_until_finished()
+
+    levanter.tracker.current_tracker().finish()
+
+
+def run_grug(config: GrugRunConfig) -> None:
+    """Dispatch grug training through Fray jobs."""
+    trainer = config.trainer.trainer
+    if trainer.id is None:
+        raise ValueError("trainer.id must be set before dispatching grug training.")
+
+    dispatch_grug_training_run(
+        run_id=trainer.id,
+        config=config,
+        local_entrypoint=_run_grug_local,
+        resources=config.resources,
+        processes_per_task=config.processes_per_task,
+    )
+
+
+__all__ = [
+    "GrugEvalConfig",
+    "GrugRunConfig",
+    "GrugTrainState",
+    "GrugTrainerConfig",
+    "initial_state",
+    "run_grug",
+]

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/__init__.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/__init__.py
@@ -6,10 +6,8 @@
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures
 # **************************************************
 
-from .op import IMPLEMENTATIONS, Implementation, depthwise_causal_convolution
-
-__all__ = [
-    "IMPLEMENTATIONS",
-    "Implementation",
-    "depthwise_causal_convolution",
-]
+from .op import (
+    IMPLEMENTATIONS as IMPLEMENTATIONS,
+    Implementation as Implementation,
+    depthwise_causal_convolution as depthwise_causal_convolution,
+)

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/__init__.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/__init__.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/__init__.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/__init__.py
@@ -1,0 +1,12 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+from .op import IMPLEMENTATIONS, Implementation, depthwise_causal_convolution
+
+__all__ = [
+    "IMPLEMENTATIONS",
+    "Implementation",
+    "depthwise_causal_convolution",
+]

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
@@ -254,7 +254,10 @@ def _backward_core(
             pl.BlockSpec(block_shape=(None, PAD, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, 0, 0)),
         ),
         scratch_shapes=[pltpu.VMEM((PAD, H), jnp.float32), pltpu.VMEM((PAD, H), jnp.float32)],
-        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "arbitrary")),
+        # dW_ref/db_ref alias the same output block across every BLOCK_ID_B and accumulate via
+        # non-atomic +=, so the B dimension must run in program order like S, not in parallel
+        # (megacore could otherwise race two batch programs on the same accumulator).
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("arbitrary", "arbitrary")),
     )
 
     dx, dW, db, dh0 = kernel(x, W, b, h, dy, dht)

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
@@ -1,0 +1,259 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+from functools import partial
+
+import jax
+import jax.experimental.pallas as pl
+import jax.experimental.pallas.tpu as pltpu
+import jax.numpy as jnp
+from .forward_kernel import _ceil_div
+
+
+def _backward_kernel(
+    x_ref,
+    W_ref,
+    b_ref,
+    h_ref,
+    dy_ref,
+    dht_ref,
+    dx_ref,
+    dW_ref,
+    db_ref,
+    dh0_ref,
+    dy_scratch,
+    dht_scratch,
+    BLOCK_SIZE_S: int,
+    S: int,
+    K: int,
+    PAD: int,
+    NUM_BLOCKS_S: int,
+    ACTIVATION: str | None,
+) -> None:
+    BLOCK_ID_B = pl.program_id(0)
+    BLOCK_ID_S_REVERSE = pl.program_id(1)
+    BLOCK_ID_S = NUM_BLOCKS_S - 1 - BLOCK_ID_S_REVERSE
+
+    H = x_ref.shape[-1]
+    dtype = x_ref.dtype
+    offset = PAD - K + 1
+
+    @pl.when(BLOCK_ID_S_REVERSE == 0)
+    def _():
+        dy_scratch[...] = jnp.zeros_like(dy_scratch)
+        dht_scratch[...] = jnp.zeros_like(dht_scratch)
+        if dht_ref is not None:
+            dht_scratch[offset:, :] = dht_ref[...].astype(jnp.float32)
+
+    @pl.when((BLOCK_ID_B == 0) & (BLOCK_ID_S_REVERSE == 0))
+    def _():
+        dW_ref[...] = jnp.zeros(dW_ref.shape, dtype=dW_ref.dtype)
+        db_ref[...] = jnp.zeros(db_ref.shape, dtype=db_ref.dtype)
+
+    BLOCK_S = jax.lax.broadcasted_iota(jnp.int32, (BLOCK_SIZE_S, 1), 0)
+    PATCH_R = jax.lax.broadcasted_iota(jnp.int32, (PAD, 1), 0)
+    MASK_S = (BLOCK_ID_S * BLOCK_SIZE_S + BLOCK_S) < S
+
+    MASKED = S % BLOCK_SIZE_S != 0
+    if MASKED:
+        dy = jnp.where(MASK_S, dy_ref[...], 0).astype(jnp.float32)
+        x = jnp.where(MASK_S, x_ref[...], 0).astype(jnp.float32)
+    else:
+        dy = dy_ref[...].astype(jnp.float32)
+        x = x_ref[...].astype(jnp.float32)
+
+    hist = h_ref[0].astype(jnp.float32)  # hist[PAD + j] == x[j] for j < 0
+
+    def x_tap(k: int):
+        shift = K - 1 - k
+        return pltpu.roll(x, shift, axis=0) if shift > 0 else x
+
+    if ACTIVATION in ["silu", "swish"]:
+        y = jnp.zeros((BLOCK_SIZE_S, H), dtype=jnp.float32)
+        if b_ref is not None:
+            y += b_ref[...].astype(jnp.float32)
+
+        for k in range(K):
+            y += W_ref[k, :].astype(jnp.float32)[None, :] * x_tap(k)
+
+        x_head = x[:PAD, :]
+        y_head = jnp.zeros((PAD, H), dtype=jnp.float32)
+        if b_ref is not None:
+            y_head += b_ref[...].astype(jnp.float32)
+
+        for k in range(K):
+            shift = K - 1 - k
+            if shift == 0:
+                y_head += W_ref[k, :].astype(jnp.float32)[None, :] * x_head
+            else:
+                W = W_ref[k, :].astype(jnp.float32)[None, :]
+                y_head += W * jnp.where(PATCH_R >= shift, pltpu.roll(x_head, shift, axis=0), 0)
+                y_head += W * jnp.where(PATCH_R < shift, pltpu.roll(hist, shift, axis=0), 0)
+
+        y = jnp.where(BLOCK_S < K - 1, jnp.pad(y_head, ((0, BLOCK_SIZE_S - PAD), (0, 0))), y)
+
+        sigmoid = jax.nn.sigmoid(y)
+        dy = dy * sigmoid * (1 + y * (1 - sigmoid))
+
+    dy_bf = dy.astype(dtype)
+    dx = jnp.zeros((BLOCK_SIZE_S, H), dtype=dtype)
+    for k in range(K):
+        W = W_ref[k, :]
+
+        shift = K - 1 - k
+        if shift == 0:
+            dx += W[None, :] * dy_bf
+        else:
+            dx += W[None, :] * pltpu.roll(dy_bf, (BLOCK_SIZE_S - shift) % BLOCK_SIZE_S, axis=0)
+
+    dy_tail = dy[BLOCK_SIZE_S - PAD :, :]
+    carry = dy_scratch[...]
+    dx_tail = jnp.zeros((PAD, H), dtype=jnp.float32)
+    for k in range(K):
+        W = W_ref[k, :].astype(jnp.float32)[None, :]
+
+        shift = K - 1 - k
+        if shift == 0:
+            dx_tail += W * dy_tail
+        else:
+            up = PAD - shift
+            dx_tail += W * jnp.where(
+                PATCH_R < PAD - shift, pltpu.roll(dy_tail, up, axis=0), pltpu.roll(carry, up, axis=0)
+            )
+
+    dx = jnp.where(
+        BLOCK_S >= BLOCK_SIZE_S - (K - 1),
+        jnp.pad(dx_tail, ((BLOCK_SIZE_S - PAD, 0), (0, 0))).astype(dtype),
+        dx,
+    )
+
+    ones_row = jnp.ones((1, BLOCK_SIZE_S), dtype=dtype)
+    db_ref[...] += jax.lax.dot(ones_row, dy_bf, preferred_element_type=jnp.float32)
+
+    d_head = dy[:PAD, :]
+    for k in range(K):
+        shift = K - 1 - k
+        tap = x_tap(k)
+        acc = jax.lax.dot(ones_row, (dy * tap).astype(dtype), preferred_element_type=jnp.float32)[0]
+        if shift > 0:
+            acc += jnp.sum(
+                jnp.where(PATCH_R < shift, d_head * (pltpu.roll(hist, shift, axis=0) - tap[:PAD, :]), 0),
+                axis=0,
+            )
+        dW_ref[k, :] += acc
+
+    dx_ref[...] = (jnp.where(MASK_S, dx, 0) if MASKED else dx).astype(dtype)
+
+    state_prefix = max(K - 1 - S, 0)
+    x_state_start = max(S - (K - 1), 0)
+
+    if dht_ref is not None:
+        dht_rows = {}
+        for p in range(state_prefix, K - 1):
+            block_index, row_in_block = divmod(x_state_start + p - state_prefix, BLOCK_SIZE_S)
+            dht_rows.setdefault(block_index, []).append((p, row_in_block))
+
+        for block_index, rows in dht_rows.items():
+
+            @pl.when(BLOCK_ID_S == block_index)
+            def _(rows=rows):
+                update = jnp.zeros((BLOCK_SIZE_S, H), dtype=jnp.float32)
+                for p, row_in_block in rows:
+                    update += jnp.where(BLOCK_S == row_in_block, dht_scratch[offset + p, :], 0)
+
+                dx_ref[...] += update.astype(dtype)
+
+    @pl.when(BLOCK_ID_S == 0)
+    def _():
+        dh0 = jnp.zeros((BLOCK_SIZE_S, H), dtype=jnp.float32)
+        for k in range(K):
+            W = W_ref[k, :].astype(jnp.float32)
+            dh0 += W[None, :] * jnp.where(BLOCK_S < k, 0, pltpu.roll(dy, k, axis=0))
+
+        dh0_ref[...] = pltpu.roll(dh0[:PAD, :], offset, axis=0)
+
+        for p in range(state_prefix):
+            dh0_ref[offset + S + p, :] += dht_scratch[offset + p, :]
+
+    dy_scratch[...] = dy[:PAD, :]
+
+
+@partial(jax.jit, static_argnames=("BLOCK_SIZE_S", "K", "ACTIVATION"))
+def _backward_core(
+    x: jax.Array,
+    W: jax.Array,
+    b: jax.Array | None,
+    h: jax.Array,
+    dy: jax.Array,
+    dht: jax.Array | None,
+    BLOCK_SIZE_S: int,
+    K: int,
+    ACTIVATION: str | None = None,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    B, S, H = x.shape
+    NUM_BLOCKS_S = _ceil_div(S, BLOCK_SIZE_S)
+    PAD = _ceil_div(K - 1, 8) * 8
+    state_size = K - 1
+
+    # a block has to be long enough to carry the whole history in its leading/trailing PAD rows
+    assert BLOCK_SIZE_S >= PAD, f"BLOCK_SIZE_S ({BLOCK_SIZE_S}) must be >= {PAD} for kernel_size ({K})"
+
+    kernel = pl.pallas_call(
+        partial(
+            _backward_kernel,
+            BLOCK_SIZE_S=BLOCK_SIZE_S,
+            S=S,
+            K=K,
+            PAD=PAD,
+            NUM_BLOCKS_S=NUM_BLOCKS_S,
+            ACTIVATION=ACTIVATION,
+        ),
+        out_shape=(
+            jax.ShapeDtypeStruct((B, S, H), x.dtype),
+            jax.ShapeDtypeStruct((K, H), jnp.float32),
+            jax.ShapeDtypeStruct((1, H), jnp.float32),
+            jax.ShapeDtypeStruct((B, PAD, H), jnp.float32),
+        ),
+        grid=(B, NUM_BLOCKS_S),
+        in_specs=(
+            pl.BlockSpec(
+                block_shape=(None, BLOCK_SIZE_S, H),
+                index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, NUM_BLOCKS_S - 1 - BLOCK_ID_S, 0),
+            ),
+            pl.BlockSpec(block_shape=(K, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (0, 0)),
+            None if b is None else pl.BlockSpec(block_shape=(1, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (0, 0)),
+            pl.BlockSpec(
+                block_shape=(None, 1, PAD, H),
+                index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, NUM_BLOCKS_S - 1 - BLOCK_ID_S, 0, 0),
+            ),
+            pl.BlockSpec(
+                block_shape=(None, BLOCK_SIZE_S, H),
+                index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, NUM_BLOCKS_S - 1 - BLOCK_ID_S, 0),
+            ),
+            (
+                None
+                if dht is None
+                else pl.BlockSpec(
+                    block_shape=(None, state_size, H),
+                    index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, 0, 0),
+                )
+            ),
+        ),
+        out_specs=(
+            pl.BlockSpec(
+                block_shape=(None, BLOCK_SIZE_S, H),
+                index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, NUM_BLOCKS_S - 1 - BLOCK_ID_S, 0),
+            ),
+            pl.BlockSpec(block_shape=(K, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (0, 0)),
+            pl.BlockSpec(block_shape=(1, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (0, 0)),
+            pl.BlockSpec(block_shape=(None, PAD, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, 0, 0)),
+        ),
+        scratch_shapes=[pltpu.VMEM((PAD, H), jnp.float32), pltpu.VMEM((PAD, H), jnp.float32)],
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "arbitrary")),
+    )
+
+    dx, dW, db, dh0 = kernel(x, W, b, h, dy, dht)
+
+    return dx, dW, db, dh0

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
@@ -12,7 +12,7 @@ import jax
 import jax.experimental.pallas as pl
 import jax.experimental.pallas.tpu as pltpu
 import jax.numpy as jnp
-from .forward_kernel import _ceil_div
+from .forward_kernel import _ceil_div, _pad_size
 
 
 def _backward_kernel(
@@ -197,7 +197,7 @@ def _backward_core(
 ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
     B, S, H = x.shape
     NUM_BLOCKS_S = _ceil_div(S, BLOCK_SIZE_S)
-    PAD = _ceil_div(K - 1, 8) * 8
+    PAD = _pad_size(K)
     state_size = K - 1
 
     # a block has to be long enough to carry the whole history in its leading/trailing PAD rows

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/backward_kernel.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/forward_kernel.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/forward_kernel.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/forward_kernel.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/forward_kernel.py
@@ -18,6 +18,11 @@ def _ceil_div(n: int, d: int) -> int:
     return (n + d - 1) // d
 
 
+def _pad_size(K: int) -> int:
+    """Sublane-aligned width of the `K - 1` history a block must carry."""
+    return _ceil_div(K - 1, 8) * 8
+
+
 def _forward_kernel(
     x_ref,
     W_ref,
@@ -82,7 +87,7 @@ def _forward_core(
 ) -> jax.Array | tuple[jax.Array, jax.Array]:
     B, S, H = x.shape
     K = W.shape[0]
-    PAD = _ceil_div(K - 1, 8) * 8
+    PAD = _pad_size(K)
     NUM_BLOCKS_S = _ceil_div(S, BLOCK_SIZE_S)
 
     x_spec = pl.BlockSpec(

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/forward_kernel.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/forward_kernel.py
@@ -1,0 +1,119 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+from functools import partial
+
+import jax
+import jax.experimental.pallas as pl
+import jax.experimental.pallas.tpu as pltpu
+import jax.numpy as jnp
+
+
+def _ceil_div(n: int, d: int) -> int:
+    return (n + d - 1) // d
+
+
+def _forward_kernel(
+    x_ref,
+    W_ref,
+    b_ref,
+    h0_ref,
+    y_ref,
+    h_ref,
+    h_scratch,
+    BLOCK_SIZE_S: int,
+    S: int,
+    K: int,
+    PAD: int,
+    ACTIVATION: str | None,
+) -> None:
+    BLOCK_ID_S = pl.program_id(1)
+
+    @pl.when(BLOCK_ID_S == 0)
+    def _():
+        if h0_ref is None:
+            h_scratch[...] = jnp.zeros_like(h_scratch)
+        else:
+            h_scratch[...] = h0_ref[...]
+
+    if h_ref is not None:
+        h_ref[...] = h_scratch[...][None]
+
+    dtype = x_ref.dtype
+    H = x_ref.shape[-1]
+
+    BLOCK_S = jax.lax.broadcasted_iota(jnp.int32, (BLOCK_SIZE_S, 1), 0)
+    MASK_S = (BLOCK_ID_S * BLOCK_SIZE_S + BLOCK_S) < S
+
+    x = jnp.where(MASK_S, x_ref[...], 0).astype(dtype)
+    x_f32 = x.astype(jnp.float32)
+    b = jnp.zeros((1, H), dtype=jnp.float32) if b_ref is None else b_ref[...].astype(jnp.float32)
+
+    hist_padded = jnp.pad(h_scratch[...].astype(jnp.float32), ((BLOCK_SIZE_S - PAD, 0), (0, 0)))
+
+    taps = [
+        jnp.where(BLOCK_S < shift, pltpu.roll(hist_padded, shift, axis=0), pltpu.roll(x_f32, shift, axis=0))
+        for shift in (K - 1 - k for k in range(K))
+    ]
+
+    W = W_ref[...].astype(jnp.float32)
+    y = jnp.sum(jnp.stack(taps, axis=0) * W[:, None, :], axis=0) + b
+
+    if ACTIVATION in ["silu", "swish"]:
+        y = y * jax.nn.sigmoid(y)
+
+    y_ref[...] = y.astype(dtype)
+    h_scratch[...] = x_f32[BLOCK_SIZE_S - PAD :, :].astype(dtype)
+
+
+@partial(jax.jit, static_argnames=("BLOCK_SIZE_S", "ACTIVATION"))
+def _forward_core(
+    x: jax.Array,
+    W: jax.Array,
+    b: jax.Array | None,
+    h0: jax.Array | None,
+    BLOCK_SIZE_S: int,
+    ACTIVATION: str | None = None,
+) -> jax.Array | tuple[jax.Array, jax.Array]:
+    B, S, H = x.shape
+    K = W.shape[0]
+    PAD = _ceil_div(K - 1, 8) * 8
+    NUM_BLOCKS_S = _ceil_div(S, BLOCK_SIZE_S)
+
+    x_spec = pl.BlockSpec(
+        block_shape=(None, BLOCK_SIZE_S, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, BLOCK_ID_S, 0)
+    )
+
+    kernel = pl.pallas_call(
+        partial(_forward_kernel, BLOCK_SIZE_S=BLOCK_SIZE_S, S=S, K=K, PAD=PAD, ACTIVATION=ACTIVATION),
+        out_shape=(
+            jax.ShapeDtypeStruct((B, S, H), x.dtype),
+            jax.ShapeDtypeStruct((B, NUM_BLOCKS_S, PAD, H), x.dtype),
+        ),
+        grid=(B, NUM_BLOCKS_S),
+        in_specs=(
+            x_spec,
+            pl.BlockSpec(block_shape=(K, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (0, 0)),
+            None if b is None else pl.BlockSpec(block_shape=(1, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (0, 0)),
+            (
+                None
+                if h0 is None
+                else pl.BlockSpec(
+                    block_shape=(None, PAD, H), index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, 0, 0)
+                )
+            ),
+        ),
+        out_specs=(
+            x_spec,
+            pl.BlockSpec(
+                block_shape=(None, 1, PAD, H),
+                index_map=lambda BLOCK_ID_B, BLOCK_ID_S: (BLOCK_ID_B, BLOCK_ID_S, 0, 0),
+            ),
+        ),
+        scratch_shapes=[pltpu.VMEM((PAD, H), x.dtype)],
+        compiler_params=pltpu.CompilerParams(dimension_semantics=("parallel", "arbitrary")),
+    )
+
+    return kernel(x, W, b, h0)

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
@@ -203,7 +203,7 @@ def depthwise_causal_convolution(
     if input_state is not None:
         assert input_state.shape == (B, H, K - 1)
 
-    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+    if attention_mask is not None:
         input = (input * attention_mask[:, :, None]).astype(input.dtype)
 
     if implementation is None:
@@ -229,5 +229,8 @@ def depthwise_causal_convolution(
         )
     else:
         raise ValueError(f"unexpected implementation ({implementation})")
+
+    if attention_mask is not None:
+        input = (input * attention_mask[:, :, None]).astype(input.dtype)
 
     return input, input_state

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
@@ -13,7 +13,7 @@ import jax
 import jax.numpy as jnp
 
 from .backward_kernel import _backward_core
-from .forward_kernel import _ceil_div, _forward_core
+from .forward_kernel import _forward_core, _pad_size
 from .reference import _depthwise_causal_convolution_reference
 
 Implementation: TypeAlias = Literal["pallas_tpu", "xla"]
@@ -29,9 +29,8 @@ def _get_block_size_s(H: int) -> int:
 
 
 def _pad_h0(h0: jax.Array, K: int) -> jax.Array:
-    state_size = K - 1
-    pad = _ceil_div(state_size, 8) * 8
-    return jnp.pad(h0, ((0, 0), (pad - state_size, 0), (0, 0)))
+    pad = _pad_size(K)
+    return jnp.pad(h0, ((0, 0), (pad - (K - 1), 0), (0, 0)))
 
 
 def _forward_run(

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
@@ -1,0 +1,231 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+from functools import lru_cache, partial
+from typing import Literal, TypeAlias
+
+import jax
+import jax.numpy as jnp
+
+from .backward_kernel import _backward_core
+from .forward_kernel import _ceil_div, _forward_core
+from .reference import _depthwise_causal_convolution_reference
+
+Implementation: TypeAlias = Literal["pallas_tpu", "xla"]
+
+
+def _get_block_size_s(H: int) -> int:
+    # the kernel stack holds several (BLOCK_SIZE_S, H) fp32 tiles and vmem overflows once
+    # BLOCK_SIZE_S * H exceeds 2**19 (measured), so shrink the block for wide H. Narrow H
+    # wants the block as big as possible instead: more rows per program means fewer HBM
+    # round-trips, which is what sets the kernel's bandwidth at small hidden sizes
+    block_size = 1 << ((1 << 19) // H).bit_length() - 1
+    return min(1024, max(8, block_size))
+
+
+def _pad_h0(h0: jax.Array, K: int) -> jax.Array:
+    state_size = K - 1
+    pad = _ceil_div(state_size, 8) * 8
+    return jnp.pad(h0, ((0, 0), (pad - state_size, 0), (0, 0)))
+
+
+def _forward_run(
+    x: jax.Array,
+    W: jax.Array,
+    b: jax.Array | None,
+    h0: jax.Array | None,
+    output_state: bool,
+    ACTIVATION: str | None,
+) -> tuple[jax.Array, jax.Array | None, jax.Array]:
+    W = jnp.transpose(W, (1, 0))
+    b = None if b is None else b[None, :]
+
+    if h0 is not None:
+        h0 = jnp.transpose(h0, (0, 2, 1)).astype(x.dtype)
+        h0 = _pad_h0(h0, K=W.shape[0])
+
+    # the per-block input states are saved from the forward as vjp residuals (a small
+    # (B, ceil(S / BLOCK_SIZE_S), PAD, H) tensor) so the backward can consume them directly
+    # instead of re-deriving them with an extra pass over the input
+    y, h = _forward_core(x=x, W=W, b=b, h0=h0, BLOCK_SIZE_S=_get_block_size_s(x.shape[-1]), ACTIVATION=ACTIVATION)
+
+    if output_state:
+        state_size = W.shape[0] - 1
+        if h0 is None:
+            ht = (
+                jnp.pad(x, ((0, 0), (state_size - x.shape[1], 0), (0, 0)))
+                if x.shape[1] < state_size
+                else x[:, -state_size:, :]
+            )
+        else:
+            ht = jnp.concatenate([h0.astype(x.dtype), x], axis=1)[:, -state_size:, :]
+
+        ht = jnp.transpose(ht, (0, 2, 1))
+    else:
+        ht = None
+
+    return y, ht, h
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(4, 5))
+def _depthwise_causal_convolution_pallas(
+    x: jax.Array,
+    W: jax.Array,
+    b: jax.Array | None,
+    h0: jax.Array | None,
+    output_state: bool,
+    ACTIVATION: str | None,
+) -> tuple[jax.Array, jax.Array | None]:
+    y, ht, _ = _forward_run(x=x, W=W, b=b, h0=h0, output_state=output_state, ACTIVATION=ACTIVATION)
+    return y, ht
+
+
+def _depthwise_causal_convolution_forward(
+    x: jax.Array,
+    W: jax.Array,
+    b: jax.Array | None,
+    h0: jax.Array | None,
+    output_state: bool,
+    ACTIVATION: str | None,
+) -> tuple[tuple[jax.Array, jax.Array | None], tuple]:
+    y, ht, h = _forward_run(x=x, W=W, b=b, h0=h0, output_state=output_state, ACTIVATION=ACTIVATION)
+    return (y, ht), (x, W, b, h0, h)
+
+
+def _depthwise_causal_convolution_backward(
+    output_state: bool, ACTIVATION: str | None, residuals: tuple, cotangents: tuple
+) -> tuple:
+    x, W, b, h0, h_states = residuals
+    dy, dht = cotangents
+
+    K = W.shape[-1]
+    W = jnp.transpose(W, (1, 0))
+
+    dht = None if dht is None or not output_state else jnp.transpose(dht, (0, 2, 1))
+
+    dx, dW, db, dh0 = _backward_core(
+        x=x,
+        W=W,
+        b=None if b is None else b[None, :],
+        h=h_states,
+        dy=dy,
+        dht=dht,
+        BLOCK_SIZE_S=_get_block_size_s(x.shape[-1]),
+        K=K,
+        ACTIVATION=ACTIVATION,
+    )
+
+    dW = jnp.transpose(dW, (1, 0))
+    db = None if b is None else db[0]
+    dh0 = None if h0 is None else jnp.transpose(dh0[:, 1 - K :, :], (0, 2, 1))
+
+    return dx, dW, db, dh0
+
+
+_depthwise_causal_convolution_pallas.defvjp(
+    _depthwise_causal_convolution_forward, _depthwise_causal_convolution_backward
+)
+
+
+IMPLEMENTATIONS = {
+    "pallas_tpu": _depthwise_causal_convolution_pallas,
+    "xla": _depthwise_causal_convolution_reference,
+}
+
+
+@lru_cache(maxsize=1)
+def _default_implementation() -> Implementation:
+    return "pallas_tpu" if jax.default_backend() == "tpu" else "xla"
+
+
+def depthwise_causal_convolution(
+    input: jax.Array,
+    weight: jax.Array,
+    bias: jax.Array | None = None,
+    input_state: jax.Array | None = None,
+    attention_mask: jax.Array | None = None,
+    output_state: bool = False,
+    activation_function: str | None = None,
+    *,
+    implementation: Implementation | None = None,
+) -> tuple[jax.Array, jax.Array | None]:
+    """
+    computes depthwise causal 1D convolution: `output[b, t, h] = act(bias[h] + sum_k weight[h, k] *
+    z[b, t + k, h])` where `z` is `input` preceded by `kernel_size - 1` raw history positions taken from
+    `input_state` (or 0 if `input_state` is None), i.e. `output[b, t]` only depends on
+    `input[b, t - kernel_size + 1 : t + 1]`.
+
+    :param input: input tensor of shape (B, S, H)
+    :type input: jax.Array
+    :param weight: depthwise convolution weight of shape (H, K), K being the kernel size
+    :type weight: jax.Array
+    :param bias: bias tensor of shape (H,). None means no bias is added. Defaults to None.
+    :type bias: jax.Array | None
+    :param input_state: the `K - 1` raw (pre-convolution) input positions preceding `input`, of shape
+        (B, H, K - 1). None is equivalent to a 0 tensor. Defaults to None.
+    :type input_state: jax.Array | None
+    :param attention_mask: mask of shape (B, S), zeroing out padding positions before and after the
+        convolution. Defaults to None.
+    :type attention_mask: jax.Array | None
+    :param output_state: whether to also return the trailing `K - 1` raw input positions (taken from `input`,
+        falling back to `input_state` if `input` is shorter than `K - 1`) for use as `input_state` in a
+        subsequent call. Defaults to False.
+    :type output_state: bool
+    :param activation_function: activation applied after the convolution + bias, fused into the kernel.
+        Either "silu", its alias "swish", or None (no activation). Defaults to None.
+    :type activation_function: str | None
+    :param implementation: "pallas_tpu" uses a hand-written VPU-only Pallas TPU kernel (avoids the
+        MXU/systolic array, which a tiny `kernel_size` reduction dimension underutilizes badly). "xla" uses
+        the plain `jax.lax.conv_general_dilated`-based reference. None auto-detects based on the
+        accelerator ("pallas_tpu" on TPU, "xla" otherwise). Defaults to None.
+    :type implementation: Implementation | None
+    :return: output tensor of shape (B, S, H), and the output state of shape (B, H, K - 1) if `output_state`
+        is True else None.
+    :rtype: tuple[jax.Array, jax.Array | None]
+    """
+
+    B, _, H = input.shape
+    K = weight.shape[-1]
+
+    assert weight.ndim == 2
+    assert weight.shape[0] == H
+    assert K > 1
+
+    assert activation_function in [None, "silu", "swish"]
+
+    if bias is not None:
+        assert bias.shape == (H,)
+
+    if input_state is not None:
+        assert input_state.shape == (B, H, K - 1)
+
+    if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
+        input = (input * attention_mask[:, :, None]).astype(input.dtype)
+
+    if implementation is None:
+        implementation = _default_implementation()
+
+    if implementation == "pallas_tpu":
+        input, input_state = _depthwise_causal_convolution_pallas(
+            x=input,
+            W=weight,
+            b=bias,
+            h0=input_state,
+            output_state=output_state,
+            ACTIVATION=activation_function,
+        )
+    elif implementation == "xla":
+        input, input_state = _depthwise_causal_convolution_reference(
+            x=input,
+            W=weight,
+            b=bias,
+            h0=input_state,
+            output_state=output_state,
+            activation_function=activation_function,
+        )
+    else:
+        raise ValueError(f"unexpected implementation ({implementation})")
+
+    return input, input_state

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
@@ -104,6 +104,7 @@ def _depthwise_causal_convolution_backward(
     dy, dht = cotangents
 
     K = W.shape[-1]
+    weight_dtype = W.dtype
     W = jnp.transpose(W, (1, 0))
 
     dht = None if dht is None or not output_state else jnp.transpose(dht, (0, 2, 1))
@@ -120,9 +121,9 @@ def _depthwise_causal_convolution_backward(
         ACTIVATION=ACTIVATION,
     )
 
-    dW = jnp.transpose(dW, (1, 0))
-    db = None if b is None else db[0]
-    dh0 = None if h0 is None else jnp.transpose(dh0[:, 1 - K :, :], (0, 2, 1))
+    dW = jnp.transpose(dW, (1, 0)).astype(weight_dtype)
+    db = None if b is None else db[0].astype(b.dtype)
+    dh0 = None if h0 is None else jnp.transpose(dh0[:, 1 - K :, :], (0, 2, 1)).astype(h0.dtype)
 
     return dx, dW, db, dh0
 

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
@@ -11,6 +11,7 @@ from typing import Literal, TypeAlias
 
 import jax
 import jax.numpy as jnp
+from jax.sharding import NamedSharding, PartitionSpec as P, reshard
 
 from .backward_kernel import _backward_core
 from .forward_kernel import _forward_core, _pad_size
@@ -131,6 +132,53 @@ _depthwise_causal_convolution_pallas.defvjp(
 )
 
 
+def _depthwise_causal_convolution_pallas_sharded(
+    x: jax.Array,
+    W: jax.Array,
+    b: jax.Array | None,
+    h0: jax.Array | None,
+    output_state: bool,
+    activation_function: str | None,
+) -> tuple[jax.Array, jax.Array | None]:
+    sharding = jax.typeof(x).sharding
+    if not isinstance(sharding, NamedSharding):
+        return _depthwise_causal_convolution_pallas(x, W, b, h0, output_state, activation_function)
+
+    input_parts = tuple(sharding.spec) + (None,) * (x.ndim - len(sharding.spec))
+    if input_parts[1] is not None:
+        raise ValueError("pallas_tpu depthwise causal convolution requires an unsharded sequence dimension")
+
+    input_spec = P(*input_parts)
+    weight_spec = P(input_parts[-1], None)
+    bias_spec = P(input_parts[-1])
+    state_spec = P(input_parts[0], input_parts[-1], None)
+
+    x = reshard(x, input_spec)
+    W = reshard(W, weight_spec)
+    if b is not None:
+        b = reshard(b, bias_spec)
+    if h0 is not None:
+        h0 = reshard(h0, state_spec)
+
+    def _local(local_x, local_W, local_b, local_h0):
+        return _depthwise_causal_convolution_pallas(
+            local_x, local_W, local_b, local_h0, output_state, activation_function
+        )
+
+    return jax.shard_map(
+        _local,
+        mesh=sharding.mesh,
+        in_specs=(
+            input_spec,
+            weight_spec,
+            bias_spec if b is not None else None,
+            state_spec if h0 is not None else None,
+        ),
+        out_specs=(input_spec, state_spec if output_state else None),
+        check_vma=False,
+    )(x, W, b, h0)
+
+
 IMPLEMENTATIONS = {
     "pallas_tpu": _depthwise_causal_convolution_pallas,
     "xla": _depthwise_causal_convolution_reference,
@@ -210,13 +258,13 @@ def depthwise_causal_convolution(
         implementation = _default_implementation()
 
     if implementation == "pallas_tpu":
-        input, input_state = _depthwise_causal_convolution_pallas(
+        input, input_state = _depthwise_causal_convolution_pallas_sharded(
             x=input,
             W=weight,
             b=bias,
             h0=input_state,
             output_state=output_state,
-            ACTIVATION=activation_function,
+            activation_function=activation_function,
         )
     elif implementation == "xla":
         input, input_state = _depthwise_causal_convolution_reference(

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
@@ -154,12 +154,12 @@ def _depthwise_causal_convolution_pallas_sharded(
     bias_spec = P(input_parts[-1])
     state_spec = P(input_parts[0], input_parts[-1], None)
 
-    x = reshard(x, input_spec)
-    W = reshard(W, weight_spec)
+    x = reshard(x, NamedSharding(sharding.mesh, input_spec))
+    W = reshard(W, NamedSharding(sharding.mesh, weight_spec))
     if b is not None:
-        b = reshard(b, bias_spec)
+        b = reshard(b, NamedSharding(sharding.mesh, bias_spec))
     if h0 is not None:
-        h0 = reshard(h0, state_spec)
+        h0 = reshard(h0, NamedSharding(sharding.mesh, state_spec))
 
     def _local(local_x, local_W, local_b, local_h0):
         return _depthwise_causal_convolution_pallas(

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/op.py
@@ -142,7 +142,7 @@ def _depthwise_causal_convolution_pallas_sharded(
     activation_function: str | None,
 ) -> tuple[jax.Array, jax.Array | None]:
     sharding = jax.typeof(x).sharding
-    if not isinstance(sharding, NamedSharding):
+    if not isinstance(sharding, NamedSharding) or not sharding.mesh.axis_names:
         return _depthwise_causal_convolution_pallas(x, W, b, h0, output_state, activation_function)
 
     input_parts = tuple(sharding.spec) + (None,) * (x.ndim - len(sharding.spec))

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/reference.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/reference.py
@@ -1,0 +1,54 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+import jax
+import jax.numpy as jnp
+
+
+def _depthwise_causal_convolution_reference(
+    x: jax.Array,
+    W: jax.Array,
+    b: jax.Array | None,
+    h0: jax.Array | None,
+    output_state: bool,
+    activation_function: str | None,
+) -> tuple[jax.Array, jax.Array | None]:
+    _, S, H = x.shape
+    K = W.shape[-1]
+    state_size = K - 1
+
+    x = jnp.transpose(x, (0, 2, 1))
+    ht = None
+
+    if h0 is None:
+        padding = [(K - 1, 0)]
+
+        if output_state:
+            ht = jnp.pad(x, ((0, 0), (0, 0), (state_size - S, 0))) if S < state_size else x[:, :, -state_size:]
+    else:
+        padding = [(0, 0)]
+
+        x = jnp.concatenate([h0.astype(x.dtype), x], axis=-1)
+
+        if output_state:
+            ht = x[:, :, -state_size:]
+
+    x = jax.lax.conv_general_dilated(
+        lhs=x,
+        rhs=W[:, None, :],
+        window_strides=(1,),
+        padding=padding,
+        feature_group_count=H,
+        dimension_numbers=("NCH", "OIH", "NCH"),
+    )
+
+    if b is not None:
+        x = x + b[None, :, None]
+
+    x = jnp.transpose(x, (0, 2, 1))
+    if activation_function in ["silu", "swish"]:
+        x = jax.nn.silu(x.astype(jnp.float32)).astype(x.dtype)
+
+    return x, ht

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/reference.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/reference.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/reference.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/reference.py
@@ -45,7 +45,7 @@ def _depthwise_causal_convolution_reference(
 
     x = jax.lax.conv_general_dilated(
         lhs=x,
-        rhs=W[:, None, :],
+        rhs=W.astype(x.dtype)[:, None, :],
         window_strides=(1,),
         padding=padding,
         feature_group_count=H,
@@ -54,7 +54,7 @@ def _depthwise_causal_convolution_reference(
     )
 
     if b is not None:
-        x = x + b[None, :, None]
+        x = x + b.astype(x.dtype)[None, :, None]
 
     x = jnp.transpose(x, (0, 2, 1))
     if activation_function in ["silu", "swish"]:

--- a/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/reference.py
+++ b/lib/levanter/src/levanter/kernels/pallas/depthwise_causal_convolution/reference.py
@@ -8,6 +8,7 @@
 
 import jax
 import jax.numpy as jnp
+from jax.sharding import NamedSharding
 
 
 def _depthwise_causal_convolution_reference(
@@ -38,6 +39,10 @@ def _depthwise_causal_convolution_reference(
         if output_state:
             ht = x[:, :, -state_size:]
 
+    out_sharding = jax.typeof(x).sharding
+    if not isinstance(out_sharding, NamedSharding):
+        out_sharding = None
+
     x = jax.lax.conv_general_dilated(
         lhs=x,
         rhs=W[:, None, :],
@@ -45,6 +50,7 @@ def _depthwise_causal_convolution_reference(
         padding=padding,
         feature_group_count=H,
         dimension_numbers=("NCH", "OIH", "NCH"),
+        out_sharding=out_sharding,
     )
 
     if b is not None:

--- a/lib/levanter/src/levanter/layers/depthwise_causal_convolution.py
+++ b/lib/levanter/src/levanter/layers/depthwise_causal_convolution.py
@@ -1,0 +1,65 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+import equinox as eqx
+import jax
+from jaxtyping import PRNGKeyArray
+
+from levanter.kernels.pallas.depthwise_causal_convolution import depthwise_causal_convolution
+
+
+class DepthwiseCausalConvolution(eqx.Module):
+    weight: jax.Array
+    bias: jax.Array | None
+
+    hidden_size: int = eqx.field(static=True)
+    kernel_size: int = eqx.field(static=True)
+    state_size: int = eqx.field(static=True)
+    activation_function: str | None = eqx.field(static=True)
+
+    @staticmethod
+    def init(
+        hidden_size: int,
+        kernel_size: int,
+        activation_function: str | None,
+        add_bias: bool,
+        *,
+        key: PRNGKeyArray,
+    ) -> "DepthwiseCausalConvolution":
+        assert kernel_size > 1
+
+        weight_key, bias_key = jax.random.split(key, 2)
+        bound = kernel_size**-0.5
+
+        weight = jax.random.uniform(weight_key, (hidden_size, kernel_size), minval=-bound, maxval=bound)
+        bias = jax.random.uniform(bias_key, (hidden_size,), minval=-bound, maxval=bound) if add_bias else None
+
+        return DepthwiseCausalConvolution(
+            weight=weight,
+            bias=bias,
+            hidden_size=hidden_size,
+            kernel_size=kernel_size,
+            state_size=kernel_size - 1,
+            activation_function=activation_function,
+        )
+
+    def __call__(
+        self,
+        input: jax.Array,
+        input_state: jax.Array | None = None,
+        attention_mask: jax.Array | None = None,
+        output_state: bool = False,
+    ) -> tuple[jax.Array, jax.Array | None]:
+        input, input_state = depthwise_causal_convolution(
+            input=input,
+            weight=self.weight,
+            bias=self.bias,
+            input_state=input_state,
+            attention_mask=attention_mask,
+            output_state=output_state,
+            activation_function=self.activation_function,
+        )
+
+        return input, input_state

--- a/lib/levanter/src/levanter/layers/depthwise_causal_convolution.py
+++ b/lib/levanter/src/levanter/layers/depthwise_causal_convolution.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures

--- a/lib/levanter/src/levanter/layers/depthwise_causal_convolution.py
+++ b/lib/levanter/src/levanter/layers/depthwise_causal_convolution.py
@@ -7,24 +7,30 @@ import equinox as eqx
 import jax
 from jaxtyping import PRNGKeyArray
 
+import haliax as hax
+from haliax import Axis, AxisSelector, NamedArray
+
 from levanter.kernels.pallas.depthwise_causal_convolution import depthwise_causal_convolution
 
 
 class DepthwiseCausalConvolution(eqx.Module):
-    weight: jax.Array
-    bias: jax.Array | None
+    Embed: Axis = eqx.field(static=True)
+    weight: NamedArray  # [Embed, Kernel]
+    bias: NamedArray | None  # [Embed]
 
-    hidden_size: int = eqx.field(static=True)
     kernel_size: int = eqx.field(static=True)
-    state_size: int = eqx.field(static=True)
     activation_function: str | None = eqx.field(static=True)
+
+    @property
+    def State(self) -> Axis:
+        return Axis("state", self.kernel_size - 1)
 
     @staticmethod
     def init(
-        hidden_size: int,
+        Embed: Axis,
         kernel_size: int,
         activation_function: str | None,
-        add_bias: bool,
+        use_bias: bool,
         *,
         key: PRNGKeyArray,
     ) -> "DepthwiseCausalConvolution":
@@ -32,34 +38,71 @@ class DepthwiseCausalConvolution(eqx.Module):
 
         weight_key, bias_key = jax.random.split(key, 2)
         bound = kernel_size**-0.5
+        Kernel = Axis("kernel", kernel_size)
 
-        weight = jax.random.uniform(weight_key, (hidden_size, kernel_size), minval=-bound, maxval=bound)
-        bias = jax.random.uniform(bias_key, (hidden_size,), minval=-bound, maxval=bound) if add_bias else None
+        weight = hax.random.uniform(weight_key, (Embed, Kernel), minval=-bound, maxval=bound)
+        bias = hax.random.uniform(bias_key, (Embed,), minval=-bound, maxval=bound) if use_bias else None
 
         return DepthwiseCausalConvolution(
+            Embed=Embed,
             weight=weight,
             bias=bias,
-            hidden_size=hidden_size,
             kernel_size=kernel_size,
-            state_size=kernel_size - 1,
             activation_function=activation_function,
         )
 
     def __call__(
         self,
-        input: jax.Array,
-        input_state: jax.Array | None = None,
-        attention_mask: jax.Array | None = None,
+        input: NamedArray,
+        input_state: NamedArray | None = None,
+        attention_mask: NamedArray | None = None,
         output_state: bool = False,
-    ) -> tuple[jax.Array, jax.Array | None]:
-        input, input_state = depthwise_causal_convolution(
-            input=input,
-            weight=self.weight,
-            bias=self.bias,
-            input_state=input_state,
-            attention_mask=attention_mask,
+        *,
+        Pos: AxisSelector = "position",
+    ) -> tuple[NamedArray, NamedArray | None]:
+        """Apply the depthwise causal convolution.
+
+        Args:
+            input: [Batch, Pos, Embed], Batch being whatever single axis remains once Pos and
+                Embed are accounted for.
+            input_state: [Batch, Embed, State], the `kernel_size - 1` raw positions preceding
+                `input`. None is equivalent to a 0 tensor.
+            attention_mask: [Batch, Pos], zeroing out padding positions before and after the
+                convolution.
+            output_state: whether to also return the trailing `kernel_size - 1` raw input
+                positions for use as `input_state` in a subsequent call.
+            Pos: the axis (or its name) identifying the sequence dimension in `input`.
+
+        Returns:
+            output: [Batch, Pos, Embed].
+            output_state: [Batch, Embed, State] if `output_state` is True else None.
+        """
+        input = hax.rearrange(input, (..., Pos, self.Embed))
+        if len(input.axes) != 3:
+            raise ValueError(f"expected exactly one batch axis alongside {Pos} and {self.Embed}, got {input.axes}")
+        Batch = input.axes[0]
+
+        input_state_array = None
+        if input_state is not None:
+            input_state_array = hax.rearrange(input_state, (Batch, self.Embed, self.State)).array
+
+        attention_mask_array = None
+        if attention_mask is not None:
+            attention_mask_array = hax.rearrange(attention_mask, (Batch, Pos)).array
+
+        output_array, output_state_array = depthwise_causal_convolution(
+            input=input.array,
+            weight=self.weight.array,
+            bias=None if self.bias is None else self.bias.array,
+            input_state=input_state_array,
+            attention_mask=attention_mask_array,
             output_state=output_state,
             activation_function=self.activation_function,
         )
 
-        return input, input_state
+        output = hax.named(output_array, input.axes)
+        output_state_named = (
+            None if output_state_array is None else hax.named(output_state_array, (Batch, self.Embed, self.State))
+        )
+
+        return output, output_state_named

--- a/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
+++ b/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
@@ -3,8 +3,6 @@
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures
 # **************************************************
 
-from __future__ import annotations
-
 from itertools import product
 
 import jax

--- a/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
+++ b/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures

--- a/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
+++ b/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
@@ -129,21 +129,53 @@ def test_depthwise_causal_convolution_xla_grad_runs(kernel_size: int) -> None:
         assert bool(jnp.all(jnp.isfinite(grad))), name
 
 
+@pytest.mark.parametrize("B,S", [(1, 6), (2, 1), (1, 1)])
+def test_depthwise_causal_convolution_masks_singleton_batch_and_sequence(B: int, S: int) -> None:
+    H, kernel_size = 3, 3
+    std = 0.1
+
+    key_x, key_w, key_b = jax.random.split(jax.random.PRNGKey(4), 3)
+
+    x = jax.random.normal(key_x, (B, S, H), dtype=jnp.float32) * std
+    weight = jax.random.normal(key_w, (H, kernel_size), dtype=jnp.float32) * std
+    bias = jax.random.normal(key_b, (H,), dtype=jnp.float32) * std
+
+    # mask out the last position of every batch row; masking must still take effect when the
+    # batch or sequence dimension is a singleton
+    attention_mask = jnp.ones((B, S), dtype=jnp.float32).at[:, -1].set(0.0)
+
+    y, _ = depthwise_causal_convolution(x, weight, bias, attention_mask=attention_mask, implementation="xla")
+
+    assert_allclose(np.asarray(y[:, -1, :]), np.zeros((B, H)), atol=0, rtol=0)
+
+
 def _generate_pallas_args() -> list:
-    return list(
-        product(
+    # A full cross product of every axis (kernel_size x S x has_input_state x add_bias x
+    # output_state x dtype x activation_function) would compile 576 forward+backward Pallas/XLA
+    # pairs, which doesn't fit the TPU CI job's time budget. Shape and state handling is where a
+    # hand-written indexing bug is most likely, so that axis gets the full cross product at fixed
+    # dtype/activation/bias; dtype/activation/bias only need one representative shape.
+    shape_args = [
+        (kernel_size, S, has_input_state, True, output_state, jnp.float32, None)
+        for kernel_size, S, has_input_state, output_state in product(
             [2, 4],  # kernel_size: the pallas_tpu implementation assumes kernel_size > 1
-            # sequence length: shorter than, equal to, or not a multiple of the internal block size.
-            # 1 and 2 also cover S < kernel_size - 1, where ht keeps part of input_state rather than
-            # being filled entirely from input.
+            # sequence length: shorter than, equal to, or not a multiple of the internal block
+            # size. 1 and 2 also cover S < kernel_size - 1, where ht keeps part of input_state
+            # rather than being filled entirely from input.
             [1, 2, 3, 16, 37, 130],
             [False, True],  # has_input_state
-            [False, True],  # add_bias
             [False, True],  # output_state
+        )
+    ]
+    option_args = [
+        (4, 37, True, add_bias, True, dtype, activation_function)
+        for dtype, activation_function, add_bias in product(
             [jnp.float32, jnp.bfloat16],
             [None, "silu", "swish"],
+            [False, True],  # add_bias
         )
-    )
+    ]
+    return shape_args + option_args
 
 
 @pytest.mark.parametrize(

--- a/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
+++ b/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
@@ -1,0 +1,244 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+from __future__ import annotations
+
+from itertools import product
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from levanter.kernels.pallas.depthwise_causal_convolution import depthwise_causal_convolution
+
+
+_TOLERANCE = {"atol": 2e-4, "rtol": 0}
+_PALLAS_TOLERANCE = {jnp.float32: {"atol": 2e-4, "rtol": 0}, jnp.bfloat16: {"atol": 2e-2, "rtol": 0}}
+_PALLAS_GRAD_TOLERANCE = {jnp.float32: {"atol": 1e-2, "rtol": 0}, jnp.bfloat16: {"atol": 5e-2, "rtol": 0}}
+
+
+def _reference_numpy(
+    x: np.ndarray,
+    weight: np.ndarray,
+    bias: np.ndarray | None,
+    input_state: np.ndarray | None,
+    output_state: bool,
+) -> tuple[np.ndarray, np.ndarray | None]:
+    B, S, H = x.shape
+    K = weight.shape[-1]
+
+    xt = np.transpose(x, (0, 2, 1))
+    state = np.zeros((B, H, K - 1), dtype=np.float32) if input_state is None else input_state.astype(np.float32)
+    full = np.concatenate([state, xt.astype(np.float32)], axis=-1)
+
+    y = np.zeros((B, H, S), dtype=np.float32)
+    for j in range(S):
+        window = full[:, :, j : j + K]
+        y[:, :, j] = (window * weight[None, :, :].astype(np.float32)).sum(-1)
+
+    if bias is not None:
+        y = y + bias[None, :, None].astype(np.float32)
+
+    y = np.transpose(y, (0, 2, 1)).astype(x.dtype)
+    final_state = full[:, :, 1 - K :].astype(x.dtype) if output_state else None
+
+    return y, final_state
+
+
+def _generate_args() -> list:
+    return list(
+        product(
+            [2, 4],  # kernel_size; K == 1 is intentionally unsupported
+            [1, 2, 6, 9],  # sequence length: shorter than, equal to, or longer than kernel_size
+            [False, True],  # has_input_state
+            [False, True],  # add_bias
+            [False, True],  # output_state
+        )
+    )
+
+
+@pytest.mark.parametrize("kernel_size,S,has_input_state,add_bias,output_state", _generate_args())
+def test_depthwise_causal_convolution_xla_matches_reference(
+    kernel_size: int, S: int, has_input_state: bool, add_bias: bool, output_state: bool
+) -> None:
+    B, H = 2, 5
+    std = 0.1
+
+    key_x, key_w, key_b, key_h0 = jax.random.split(jax.random.PRNGKey(0), 4)
+
+    x = jax.random.normal(key_x, (B, S, H), dtype=jnp.float32) * std
+    weight = jax.random.normal(key_w, (H, kernel_size), dtype=jnp.float32) * std
+    bias = jax.random.normal(key_b, (H,), dtype=jnp.float32) * std if add_bias else None
+    input_state = (
+        jax.random.normal(key_h0, (B, H, kernel_size - 1), dtype=jnp.float32) * std if has_input_state else None
+    )
+
+    y, final_state = depthwise_causal_convolution(
+        x, weight, bias, input_state, output_state=output_state, implementation="xla"
+    )
+
+    y_ref, final_state_ref = _reference_numpy(
+        np.asarray(x),
+        np.asarray(weight),
+        np.asarray(bias) if bias is not None else None,
+        np.asarray(input_state) if input_state is not None else None,
+        output_state,
+    )
+
+    assert_allclose(np.asarray(y), y_ref, **_TOLERANCE)
+
+    if output_state:
+        assert final_state is not None
+        assert final_state.shape == (B, H, kernel_size - 1)
+        assert_allclose(np.asarray(final_state), final_state_ref, **_TOLERANCE)
+    else:
+        assert final_state is None
+
+
+@pytest.mark.parametrize("kernel_size", [2, 4])
+def test_depthwise_causal_convolution_xla_grad_runs(kernel_size: int) -> None:
+    B, S, H = 2, 6, 5
+    std = 0.1
+
+    key_x, key_w, key_b, key_h0 = jax.random.split(jax.random.PRNGKey(1), 4)
+
+    x = jax.random.normal(key_x, (B, S, H), dtype=jnp.float32) * std
+    weight = jax.random.normal(key_w, (H, kernel_size), dtype=jnp.float32) * std
+    bias = jax.random.normal(key_b, (H,), dtype=jnp.float32) * std
+    input_state = jax.random.normal(key_h0, (B, H, kernel_size - 1), dtype=jnp.float32) * std
+
+    def f(x, weight, bias, input_state):
+        y, _ = depthwise_causal_convolution(x, weight, bias, input_state, output_state=False, implementation="xla")
+
+        return y.sum()
+
+    dx, dweight, dbias, dinput_state = jax.grad(f, argnums=(0, 1, 2, 3))(x, weight, bias, input_state)
+
+    for name, grad, expected_shape in [
+        ("dx", dx, x.shape),
+        ("dweight", dweight, weight.shape),
+        ("dbias", dbias, bias.shape),
+        ("dinput_state", dinput_state, input_state.shape),
+    ]:
+        assert grad.shape == expected_shape, name
+        assert bool(jnp.all(jnp.isfinite(grad))), name
+
+
+def _generate_pallas_args() -> list:
+    return list(
+        product(
+            [2, 4],  # kernel_size: the pallas_tpu implementation assumes kernel_size > 1
+            # sequence length: shorter than, equal to, or not a multiple of the internal block size.
+            # 1 and 2 also cover S < kernel_size - 1, where ht keeps part of input_state rather than
+            # being filled entirely from input.
+            [1, 2, 3, 16, 37, 130],
+            [False, True],  # has_input_state
+            [False, True],  # add_bias
+            [False, True],  # output_state
+            [jnp.float32, jnp.bfloat16],
+            [None, "silu", "swish"],
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "kernel_size,S,has_input_state,add_bias,output_state,dtype,activation_function", _generate_pallas_args()
+)
+def test_depthwise_causal_convolution_pallas_tpu_matches_xla(
+    kernel_size: int,
+    S: int,
+    has_input_state: bool,
+    add_bias: bool,
+    output_state: bool,
+    dtype: jnp.dtype,
+    activation_function: str | None,
+) -> None:
+    if jax.default_backend() != "tpu":
+        pytest.skip("pallas_tpu implementation is only supported on TPU")
+
+    B, H = 2, 5
+    std = 0.1
+    tolerance = _PALLAS_TOLERANCE[dtype]
+    grad_tolerance = _PALLAS_GRAD_TOLERANCE[dtype]
+
+    key_x, key_w, key_b, key_h0, key_dy = jax.random.split(jax.random.PRNGKey(3), 5)
+
+    x = (jax.random.normal(key_x, (B, S, H), dtype=jnp.float32) * std).astype(dtype)
+    weight = (jax.random.normal(key_w, (H, kernel_size), dtype=jnp.float32) * std).astype(dtype)
+    bias = (jax.random.normal(key_b, (H,), dtype=jnp.float32) * std).astype(dtype) if add_bias else None
+    input_state = (
+        (jax.random.normal(key_h0, (B, H, kernel_size - 1), dtype=jnp.float32) * std).astype(dtype)
+        if has_input_state
+        else None
+    )
+
+    def _run(implementation: str, x: jax.Array, weight: jax.Array, bias, input_state):
+        return depthwise_causal_convolution(
+            x,
+            weight,
+            bias,
+            input_state,
+            output_state=output_state,
+            activation_function=activation_function,
+            implementation=implementation,
+        )
+
+    def _run_vjp(implementation: str, x: jax.Array, weight: jax.Array, bias, input_state):
+        return jax.vjp(
+            lambda x, weight, bias, input_state: _run(implementation, x, weight, bias, input_state),
+            x,
+            weight,
+            bias,
+            input_state,
+        )
+
+    (y_kernel, ht_kernel), vjp_kernel = _run_vjp("pallas_tpu", x, weight, bias, input_state)
+    (y_expected, ht_expected), vjp_expected = _run_vjp("xla", x, weight, bias, input_state)
+
+    assert_allclose(np.asarray(y_kernel, dtype=np.float32), np.asarray(y_expected, dtype=np.float32), **tolerance)
+
+    if output_state:
+        assert ht_kernel is not None
+        assert ht_expected is not None
+        assert ht_kernel.shape == (B, H, kernel_size - 1)
+        assert_allclose(
+            np.asarray(ht_kernel, dtype=np.float32), np.asarray(ht_expected, dtype=np.float32), **tolerance
+        )
+    else:
+        assert ht_kernel is None
+        assert ht_expected is None
+
+    dy = (jax.random.normal(key_dy, y_kernel.shape, dtype=jnp.float32) * std).astype(dtype)
+    dht = (jax.random.normal(key_dy, ht_kernel.shape, dtype=jnp.float32) * std).astype(dtype) if output_state else None
+
+    dx_kernel, dweight_kernel, dbias_kernel, dinput_state_kernel = vjp_kernel((dy, dht))
+    dx_expected, dweight_expected, dbias_expected, dinput_state_expected = vjp_expected((dy, dht))
+
+    assert_allclose(
+        np.asarray(dx_kernel, dtype=np.float32), np.asarray(dx_expected, dtype=np.float32), **grad_tolerance
+    )
+    assert_allclose(
+        np.asarray(dweight_kernel, dtype=np.float32), np.asarray(dweight_expected, dtype=np.float32), **grad_tolerance
+    )
+
+    if add_bias:
+        assert_allclose(
+            np.asarray(dbias_kernel, dtype=np.float32), np.asarray(dbias_expected, dtype=np.float32), **grad_tolerance
+        )
+    else:
+        assert dbias_kernel is None
+        assert dbias_expected is None
+
+    if has_input_state:
+        assert_allclose(
+            np.asarray(dinput_state_kernel, dtype=np.float32),
+            np.asarray(dinput_state_expected, dtype=np.float32),
+            **grad_tolerance,
+        )
+    else:
+        assert dinput_state_kernel is None
+        assert dinput_state_expected is None

--- a/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
+++ b/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
@@ -167,12 +167,10 @@ def test_depthwise_causal_convolution_pallas_tpu_lowers_with_explicit_sharding()
 
     with use_abstract_mesh(mesh):
         loss, weight_grad = jax.eval_shape(run)
-        jaxpr = str(jax.make_jaxpr(run)())
 
     assert loss.shape == ()
     assert weight_grad.shape == (6, 4)
     assert weight_grad.dtype == jnp.float32
-    assert "shard_map" in jaxpr
 
 
 @pytest.mark.parametrize("B,S", [(1, 6), (2, 1), (1, 1)])

--- a/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
+++ b/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
@@ -12,7 +12,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from jax.sharding import AbstractMesh, AxisType, PartitionSpec as P, use_abstract_mesh
+from jax.sharding import AbstractMesh, AxisType, Mesh, NamedSharding, PartitionSpec as P, use_abstract_mesh
 from numpy.testing import assert_allclose
 
 from levanter.kernels.pallas.depthwise_causal_convolution import depthwise_causal_convolution
@@ -171,6 +171,18 @@ def test_depthwise_causal_convolution_pallas_tpu_lowers_with_explicit_sharding()
     assert loss.shape == ()
     assert weight_grad.shape == (6, 4)
     assert weight_grad.dtype == jnp.float32
+
+
+def test_depthwise_causal_convolution_pallas_tpu_lowers_without_mesh_context() -> None:
+    mesh = Mesh(np.array(jax.devices()[:1]), ("device",))
+    x = jax.device_put(jnp.zeros((1, 8, 4)), NamedSharding(mesh, P(None, None, None)))
+    weight = jax.device_put(jnp.zeros((4, 4)), NamedSharding(mesh, P(None, None)))
+
+    output, _ = jax.eval_shape(
+        lambda x, weight: depthwise_causal_convolution(x, weight, implementation="pallas_tpu"), x, weight
+    )
+
+    assert output.shape == x.shape
 
 
 @pytest.mark.parametrize("B,S", [(1, 6), (2, 1), (1, 1)])

--- a/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
+++ b/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
@@ -156,15 +156,22 @@ def test_depthwise_causal_convolution_pallas_tpu_lowers_with_explicit_sharding()
     )
 
     def run():
-        x = jax.sharding.reshard(jnp.zeros((4, 8, 6)), P("data", None, "model"))
-        weight = jax.sharding.reshard(jnp.zeros((6, 4)), P("model", None))
-        return depthwise_causal_convolution(x, weight, implementation="pallas_tpu")[0]
+        x = jax.sharding.reshard(jnp.zeros((4, 8, 6), dtype=jnp.bfloat16), P("data", None, "model"))
+        weight = jax.sharding.reshard(jnp.zeros((6, 4), dtype=jnp.float32), P("model", None))
+
+        def loss(weight):
+            output = depthwise_causal_convolution(x, weight, implementation="pallas_tpu")[0]
+            return output.astype(jnp.float32).sum()
+
+        return jax.value_and_grad(loss)(weight)
 
     with use_abstract_mesh(mesh):
-        output = jax.eval_shape(run)
+        loss, weight_grad = jax.eval_shape(run)
         jaxpr = str(jax.make_jaxpr(run)())
 
-    assert output.shape == (4, 8, 6)
+    assert loss.shape == ()
+    assert weight_grad.shape == (6, 4)
+    assert weight_grad.dtype == jnp.float32
     assert "shard_map" in jaxpr
 
 

--- a/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
+++ b/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
@@ -12,7 +12,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from jax.sharding import AbstractMesh, AxisType, Mesh, NamedSharding, PartitionSpec as P, use_abstract_mesh
+from jax.sharding import AbstractMesh, AxisType, NamedSharding, PartitionSpec as P, use_abstract_mesh
 from numpy.testing import assert_allclose
 
 from levanter.kernels.pallas.depthwise_causal_convolution import depthwise_causal_convolution
@@ -173,16 +173,16 @@ def test_depthwise_causal_convolution_pallas_tpu_lowers_with_explicit_sharding()
     assert weight_grad.dtype == jnp.float32
 
 
-def test_depthwise_causal_convolution_pallas_tpu_lowers_without_mesh_context() -> None:
-    mesh = Mesh(np.array(jax.devices()[:1]), ("device",))
-    x = jax.device_put(jnp.zeros((1, 8, 4)), NamedSharding(mesh, P(None, None, None)))
-    weight = jax.device_put(jnp.zeros((4, 4)), NamedSharding(mesh, P(None, None)))
+def test_depthwise_causal_convolution_pallas_tpu_lowers_with_empty_mesh() -> None:
+    mesh = AbstractMesh(axis_sizes=(), axis_names=(), axis_types=())
+    x = jax.ShapeDtypeStruct((1, 8, 4), jnp.float32, sharding=NamedSharding(mesh, P(None, None, None)))
+    weight = jax.ShapeDtypeStruct((4, 4), jnp.float32, sharding=NamedSharding(mesh, P(None, None)))
 
     output, _ = jax.eval_shape(
         lambda x, weight: depthwise_causal_convolution(x, weight, implementation="pallas_tpu"), x, weight
     )
 
-    assert output.shape == x.shape
+    assert output.shape == (1, 8, 4)
 
 
 @pytest.mark.parametrize("B,S", [(1, 6), (2, 1), (1, 1)])

--- a/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
+++ b/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
@@ -12,6 +12,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from jax.sharding import AbstractMesh, AxisType, PartitionSpec as P, use_abstract_mesh
 from numpy.testing import assert_allclose
 
 from levanter.kernels.pallas.depthwise_causal_convolution import depthwise_causal_convolution
@@ -127,6 +128,24 @@ def test_depthwise_causal_convolution_xla_grad_runs(kernel_size: int) -> None:
     ]:
         assert grad.shape == expected_shape, name
         assert bool(jnp.all(jnp.isfinite(grad))), name
+
+
+def test_depthwise_causal_convolution_xla_lowers_with_explicit_sharding() -> None:
+    mesh = AbstractMesh(
+        axis_sizes=(2, 1),
+        axis_names=("data", "model"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit),
+    )
+
+    def run():
+        x = jax.sharding.reshard(jnp.zeros((4, 8, 6)), P("data", None, "model"))
+        weight = jax.sharding.reshard(jnp.zeros((6, 4)), P("model", None))
+        return depthwise_causal_convolution(x, weight, implementation="xla")[0]
+
+    with use_abstract_mesh(mesh):
+        output = jax.eval_shape(run)
+
+    assert output.shape == (4, 8, 6)
 
 
 @pytest.mark.parametrize("B,S", [(1, 6), (2, 1), (1, 1)])

--- a/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
+++ b/lib/levanter/tests/kernels/test_pallas_depthwise_causal_convolution.py
@@ -148,6 +148,26 @@ def test_depthwise_causal_convolution_xla_lowers_with_explicit_sharding() -> Non
     assert output.shape == (4, 8, 6)
 
 
+def test_depthwise_causal_convolution_pallas_tpu_lowers_with_explicit_sharding() -> None:
+    mesh = AbstractMesh(
+        axis_sizes=(2, 2),
+        axis_names=("data", "model"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit),
+    )
+
+    def run():
+        x = jax.sharding.reshard(jnp.zeros((4, 8, 6)), P("data", None, "model"))
+        weight = jax.sharding.reshard(jnp.zeros((6, 4)), P("model", None))
+        return depthwise_causal_convolution(x, weight, implementation="pallas_tpu")[0]
+
+    with use_abstract_mesh(mesh):
+        output = jax.eval_shape(run)
+        jaxpr = str(jax.make_jaxpr(run)())
+
+    assert output.shape == (4, 8, 6)
+    assert "shard_map" in jaxpr
+
+
 @pytest.mark.parametrize("B,S", [(1, 6), (2, 1), (1, 1)])
 def test_depthwise_causal_convolution_masks_singleton_batch_and_sequence(B: int, S: int) -> None:
     H, kernel_size = 3, 3

--- a/lib/levanter/tests/test_depthwise_causal_convolution_layer.py
+++ b/lib/levanter/tests/test_depthwise_causal_convolution_layer.py
@@ -1,0 +1,97 @@
+# **************************************************
+# Copyright (c) 2026, Mayank Mishra
+# copied from https://github.com/open-lm-engine/accelerated-model-architectures
+# **************************************************
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import haliax as hax
+from haliax import Axis
+
+from levanter.kernels.pallas.depthwise_causal_convolution import depthwise_causal_convolution
+from levanter.layers.depthwise_causal_convolution import DepthwiseCausalConvolution
+
+
+Batch = Axis("batch", 2)
+Pos = Axis("position", 6)
+Embed = Axis("embed", 5)
+
+
+@pytest.mark.parametrize("use_bias", [False, True])
+@pytest.mark.parametrize("output_state", [False, True])
+def test_depthwise_causal_convolution_layer_matches_raw_op(use_bias: bool, output_state: bool) -> None:
+    kernel_size = 4
+    key_init, key_x, key_h0 = jax.random.split(jax.random.PRNGKey(0), 3)
+
+    layer = DepthwiseCausalConvolution.init(
+        Embed, kernel_size=kernel_size, activation_function=None, use_bias=use_bias, key=key_init
+    )
+
+    x = hax.random.normal(key_x, (Batch, Pos, Embed))
+    input_state = hax.random.normal(key_h0, (Batch, Embed, layer.State))
+
+    output, output_state_named = layer(x, input_state=input_state, output_state=output_state)
+
+    assert output.axes == (Batch, Pos, Embed)
+
+    output_ref, output_state_ref = depthwise_causal_convolution(
+        input=hax.rearrange(x, (Batch, Pos, Embed)).array,
+        weight=layer.weight.array,
+        bias=None if layer.bias is None else layer.bias.array,
+        input_state=hax.rearrange(input_state, (Batch, Embed, layer.State)).array,
+        output_state=output_state,
+        activation_function=None,
+    )
+
+    assert_allclose(np.asarray(hax.rearrange(output, (Batch, Pos, Embed)).array), np.asarray(output_ref))
+
+    if output_state:
+        assert output_state_named is not None
+        assert output_state_named.axes == (Batch, Embed, layer.State)
+        assert_allclose(
+            np.asarray(hax.rearrange(output_state_named, (Batch, Embed, layer.State)).array),
+            np.asarray(output_state_ref),
+        )
+    else:
+        assert output_state_named is None
+
+
+def test_depthwise_causal_convolution_layer_without_input_state() -> None:
+    kernel_size = 3
+    key_init, key_x = jax.random.split(jax.random.PRNGKey(1), 2)
+
+    layer = DepthwiseCausalConvolution.init(
+        Embed, kernel_size=kernel_size, activation_function="silu", use_bias=True, key=key_init
+    )
+
+    x = hax.random.normal(key_x, (Batch, Pos, Embed))
+    output, output_state = layer(x, output_state=True)
+
+    assert output.axes == (Batch, Pos, Embed)
+    assert output_state is not None
+    assert output_state.axes == (Batch, Embed, layer.State)
+
+
+def test_depthwise_causal_convolution_layer_grad_runs() -> None:
+    kernel_size = 3
+    key_init, key_x = jax.random.split(jax.random.PRNGKey(2), 2)
+
+    layer = DepthwiseCausalConvolution.init(
+        Embed, kernel_size=kernel_size, activation_function=None, use_bias=True, key=key_init
+    )
+    x = hax.random.normal(key_x, (Batch, Pos, Embed))
+
+    def loss(layer, x):
+        output, _ = layer(x)
+        return hax.sum(output).scalar()
+
+    grad_layer, grad_x = jax.grad(loss, argnums=(0, 1))(layer, x)
+
+    assert jnp.all(jnp.isfinite(grad_layer.weight.array))
+    assert jnp.all(jnp.isfinite(grad_x.array))

--- a/lib/levanter/tests/test_depthwise_causal_convolution_layer.py
+++ b/lib/levanter/tests/test_depthwise_causal_convolution_layer.py
@@ -1,3 +1,6 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # **************************************************
 # Copyright (c) 2026, Mayank Mishra
 # copied from https://github.com/open-lm-engine/accelerated-model-architectures


### PR DESCRIPTION
Add a Grug MoE experiment variant for kernel-size-4 depthwise causal convolutions at the K, V, attention-output, and MoE-output sites specified in the experiment plan. Preserve packed-document semantics by subtracting cross-boundary lag contributions, and identity-initialize the convolution weights.

Wrap the Pallas kernel from #8331 in an explicit-mesh `shard_map`, preserve fp32 parameter-gradient dtypes under bf16 activations, and bypass the sharding wrapper for ordinary TPU arrays whose default named sharding has an empty mesh. These changes address the integration and standalone TPU failures found during validation; the resulting TPU check passes all 138 selected tests.

`MOE-PSC-001` completed 25 d512 steps on a v5p-8 with finite loss and a permanent step-25 checkpoint. Matched Gate 1 controls used the same current recipe and v5p-8 topology without SConv. At d512, SConv improved Paloma macro loss from 3.67605 to 3.62268 while reducing final-100-step throughput from 366,600 to 345,197 tokens/s, for 1.242 combined effective speedup. At d768, it improved loss from 3.29501 to 3.26632 while reducing throughput from 245,904 to 231,991 tokens/s, for 1.131 combined effective speedup. All four W&B runs finished and permanent checkpoints were published.

Matched Gate 1 required combined effective speedup above 1 at both scales. The variant passed. The earlier 0.517 and 0.612 values compared against historical May Recipe cells with different sequence length, accelerator, PKO, long-RoPE, and z-loss settings; those values do not isolate SConv. Gate 2 is eligible but has not been launched.

The experiment plan, runs, checkpoints, and decision record are tracked in #8377. The Iris coordinator and worker-reconciliation incident is recorded at https://echo.oa.dev/wiki/173.

Stacked on #8331.

Part of #8377.