### PR TITLE
[iac] Manage the GitHub alert webhook

### DIFF
--- a/infra/pulumi/github/Pulumi.marin-community.yaml
+++ b/infra/pulumi/github/Pulumi.marin-community.yaml
@@ -62,11 +62,14 @@ config:
     - name: SLACK_WEBHOOK_URL
       scope: organization
       presence: present
+      management: sealed
       visibility: all
+      key_id: "3380204578043523366"
+      value_encrypted: Bn8tmYyhY6dqEM+JVYC6vOS6D0ZQEY5fhviyarZDViCnl/Rr82WxHfIk624aJJ02zZ3rawmDNDuUuPL37BzoDGj05e10DuLZkW78xcEqAdj3AFpa0PFAQ/01KDGKccpD/BTQD0Drts/DvGvBa7OlcPLvX0BtmhCsGTMGMCTwl04B
       source_kind: gcp-secret
-      source_ref: gcp-secret://projects/hai-gcp-models/secrets/marin-grafana-slack-webhook/versions/1
+      source_ref: gcp-secret://projects/hai-gcp-models/secrets/marin-github-alerts-slack-webhook/versions/1
       disposition: keep
-      note: Routes GitHub Actions alerts, including marin workflows, to #marin-alerts.
+      note: Routes GitHub Actions alerts to #marin-alerts.
     - name: CW_KUBECONFIG
       scope: repository
       repository: marin-community/marin

--- a/infra/pulumi/github/README.md
+++ b/infra/pulumi/github/README.md
@@ -5,9 +5,10 @@ secrets as external resources. Declarations live in
 [`Pulumi.marin-community.yaml`](Pulumi.marin-community.yaml); plaintext values do not.
 
 Most secret resources use Pulumi lookups. The stack can read their metadata, but cannot create,
-update, delete, or rotate them. The dedicated updater's environment secret is managed from
-GitHub-sealed ciphertext. The audit checks both forms against workflow references and live GitHub
-scope metadata.
+update, delete, or rotate them. Credentials with `management: sealed` are managed from ciphertext
+sealed to the destination's GitHub Actions public key. `management: pulumi` records a secret owned
+by another resource in this program, such as the dependency updater's environment secret.
+The audit checks all three forms against workflow references and live GitHub scope metadata.
 
 ```bash
 uv run --package marin-iac python infra/pulumi/github/audit.py
@@ -21,12 +22,55 @@ pulumi up
 
 The provider reads `GITHUB_TOKEN`; the stack config sets `github:owner`.
 
-To add a secret, create or rotate it through an approved external path, then add a `present`
-declaration. Record a pinned Secret Manager version when one exists; it is recovery metadata and is
-never dereferenced by this program.
+To add an externally managed secret, create or rotate it through an approved external path, then add
+a `present` declaration. Record a pinned Secret Manager version when one exists; it is recovery
+metadata and is never dereferenced by this program.
+
+Use `management: sealed` when Pulumi should restore the declared value after GitHub-side drift.
+Record `key_id` and `value_encrypted` from the same GitHub Actions public key. The ciphertext is safe
+to commit because only GitHub can decrypt it. Keep a recoverable plaintext copy in Secret Manager;
+do not put plaintext in Pulumi config, resource arguments, or state.
 
 GitHub resolves a repository secret before an organization secret with the same name. Keep each
 secret name at one scope unless a repository override has a separate owner and rotation path.
+
+## Slack alert webhook
+
+`SLACK_WEBHOOK_URL` uses a dedicated incoming webhook bound to `#marin-alerts`. Its recoverable
+plaintext is `marin-github-alerts-slack-webhook` in Secret Manager; Pulumi stores only ciphertext
+sealed to the organization Actions public key. Do not reuse `marin-grafana-slack-webhook`: that
+retired webhook is bound to `#marin-eng`.
+
+To rotate the webhook, add a Secret Manager version and seal that version to the organization
+Actions public key without writing plaintext to disk:
+
+```bash
+gh api orgs/marin-community/actions/secrets/public-key --jq .key_id
+gcloud secrets versions access <version> \
+  --project=hai-gcp-models \
+  --secret=marin-github-alerts-slack-webhook \
+  | gh secret set SLACK_WEBHOOK_URL --org marin-community --no-store
+```
+
+Update the organization credential declaration with the printed public-key ID, ciphertext, and
+pinned Secret Manager version:
+
+```yaml
+- name: SLACK_WEBHOOK_URL
+  scope: organization
+  presence: present
+  management: sealed
+  visibility: all
+  key_id: <public-key-id>
+  value_encrypted: <sealed-ciphertext>
+  source_kind: gcp-secret
+  source_ref: gcp-secret://projects/hai-gcp-models/secrets/marin-github-alerts-slack-webhook/versions/1
+  disposition: keep
+  note: Routes GitHub Actions alerts to #marin-alerts.
+```
+
+Run `pulumi preview`, `pulumi up`, and the live audit. A GitHub-side edit changes
+`remote_updated_at`; the next update reapplies the sealed value.
 
 To remove a secret, first confirm it is an unreferenced `remove-candidate` with the live audit. Delete
 it externally, then remove its declaration. For example:

--- a/infra/pulumi/src/iac/github/credentials.py
+++ b/infra/pulumi/src/iac/github/credentials.py
@@ -39,6 +39,7 @@ class Presence(StrEnum):
 class Management(StrEnum):
     EXTERNAL = "external"
     PULUMI = "pulumi"
+    SEALED = "sealed"
 
 
 class SourceKind(StrEnum):
@@ -93,6 +94,8 @@ class Credential(BaseModel):
     name: str = Field(pattern=SECRET_NAME)
     presence: Presence
     management: Management = Management.EXTERNAL
+    key_id: str | None = Field(default=None, min_length=1)
+    value_encrypted: str | None = Field(default=None, min_length=1)
     source: ValueSource
     disposition: Disposition
     note: str = ""
@@ -101,6 +104,19 @@ class Credential(BaseModel):
     def validate_disposition(self) -> Self:
         if self.disposition is Disposition.REMOVE_CANDIDATE and self.presence is not Presence.PRESENT:
             raise ValueError("cannot remove a credential that is not present")
+        return self
+
+    @model_validator(mode="after")
+    def validate_management(self) -> Self:
+        sealed_value_is_complete = self.key_id is not None and self.value_encrypted is not None
+        sealed_value_is_absent = self.key_id is None and self.value_encrypted is None
+        if self.management is Management.SEALED:
+            if self.presence is not Presence.PRESENT:
+                raise ValueError("sealed credentials must be present")
+            if not sealed_value_is_complete:
+                raise ValueError("sealed credentials require key_id and value_encrypted")
+        elif not sealed_value_is_absent:
+            raise ValueError("only sealed credentials can declare key_id or value_encrypted")
         return self
 
     @property

--- a/infra/pulumi/src/iac/github/resources.py
+++ b/infra/pulumi/src/iac/github/resources.py
@@ -39,37 +39,81 @@ def _logical_name(credential: Credential) -> str:
     return "-".join(credential.key).replace("/", "-").replace("_", "-").lower()
 
 
+def _credential_resource_plan(manifest: CredentialManifest, credential: Credential) -> CredentialResourcePlan:
+    if isinstance(credential, OrganizationCredential):
+        resource_id = credential.name
+    elif isinstance(credential, RepositoryCredential):
+        repository = repository_name(manifest.organization, credential.repository)
+        resource_id = f"{repository}:{credential.name}"
+    else:
+        assert isinstance(credential, EnvironmentCredential)
+        repository = repository_name(manifest.organization, credential.repository)
+        resource_id = f"{repository}:{quote(credential.environment, safe='')}:{credential.name}"
+    return CredentialResourcePlan(
+        credential=credential,
+        logical_name=_logical_name(credential),
+        resource_id=resource_id,
+    )
+
+
 def credential_resource_plans(manifest: CredentialManifest) -> tuple[CredentialResourcePlan, ...]:
     """Compute lookup IDs for present credentials managed outside Pulumi."""
-    plans: list[CredentialResourcePlan] = []
-    for credential in manifest.credentials:
-        if credential.presence is not Presence.PRESENT or credential.management is Management.PULUMI:
-            continue
-        if isinstance(credential, OrganizationCredential):
-            resource_id = credential.name
-        elif isinstance(credential, RepositoryCredential):
-            repository = repository_name(manifest.organization, credential.repository)
-            resource_id = f"{repository}:{credential.name}"
-        else:
-            assert isinstance(credential, EnvironmentCredential)
-            repository = repository_name(manifest.organization, credential.repository)
-            resource_id = f"{repository}:{quote(credential.environment, safe='')}:{credential.name}"
-        plans.append(
-            CredentialResourcePlan(
-                credential=credential,
-                logical_name=_logical_name(credential),
-                resource_id=resource_id,
-            )
+    return tuple(
+        _credential_resource_plan(manifest, credential)
+        for credential in manifest.credentials
+        if credential.presence is Presence.PRESENT and credential.management is Management.EXTERNAL
+    )
+
+
+def _managed_secret(plan: CredentialResourcePlan, organization: str) -> pulumi.CustomResource:
+    credential = plan.credential
+    assert credential.key_id is not None
+    assert credential.value_encrypted is not None
+    opts = pulumi.ResourceOptions(import_=plan.resource_id)
+    if isinstance(credential, OrganizationCredential):
+        return github.ActionsOrganizationSecret(
+            plan.logical_name,
+            secret_name=credential.name,
+            visibility=credential.visibility,
+            key_id=credential.key_id,
+            value_encrypted=credential.value_encrypted,
+            opts=opts,
         )
-    return tuple(plans)
+    repository = repository_name(organization, credential.repository)
+    if isinstance(credential, RepositoryCredential):
+        return github.ActionsSecret(
+            plan.logical_name,
+            repository=repository,
+            secret_name=credential.name,
+            key_id=credential.key_id,
+            value_encrypted=credential.value_encrypted,
+            opts=opts,
+        )
+    assert isinstance(credential, EnvironmentCredential)
+    return github.ActionsEnvironmentSecret(
+        plan.logical_name,
+        repository=repository,
+        environment=credential.environment,
+        secret_name=credential.name,
+        key_id=credential.key_id,
+        value_encrypted=credential.value_encrypted,
+        opts=opts,
+    )
 
 
 def register_credentials(manifest: CredentialManifest) -> tuple[pulumi.CustomResource, ...]:
-    """Register existing secrets as external, read-only resources."""
+    """Register declared external lookups and Pulumi-managed sealed secrets."""
     resources: list[pulumi.CustomResource] = []
-    for plan in credential_resource_plans(manifest):
+    plans = [
+        _credential_resource_plan(manifest, credential)
+        for credential in manifest.credentials
+        if credential.presence is Presence.PRESENT and credential.management is not Management.PULUMI
+    ]
+    for plan in plans:
         credential = plan.credential
-        if isinstance(credential, OrganizationCredential):
+        if credential.management is Management.SEALED:
+            secret = _managed_secret(plan, manifest.organization)
+        elif isinstance(credential, OrganizationCredential):
             secret: pulumi.CustomResource = github.ActionsOrganizationSecret.get(
                 plan.logical_name,
                 id=plan.resource_id,
@@ -82,10 +126,20 @@ def register_credentials(manifest: CredentialManifest) -> tuple[pulumi.CustomRes
         resources.append(secret)
 
         if isinstance(credential, OrganizationCredential) and credential.visibility is OrganizationVisibility.SELECTED:
-            resources.append(
-                github.ActionsOrganizationSecretRepositories.get(
+            if credential.management is Management.SEALED:
+                repository_ids = [
+                    github.get_repository(full_name=repository).repo_id for repository in credential.repositories
+                ]
+                access = github.ActionsOrganizationSecretRepositories(
+                    f"{plan.logical_name}-repositories",
+                    secret_name=credential.name,
+                    selected_repository_ids=repository_ids,
+                    opts=pulumi.ResourceOptions(import_=credential.name, depends_on=[secret]),
+                )
+            else:
+                access = github.ActionsOrganizationSecretRepositories.get(
                     f"{plan.logical_name}-repositories",
                     id=credential.name,
                 )
-            )
+            resources.append(access)
     return tuple(resources)

--- a/infra/pulumi/tests/test_github_credentials.py
+++ b/infra/pulumi/tests/test_github_credentials.py
@@ -92,6 +92,10 @@ def test_registers_each_present_secret_and_selected_repository_access(monkeypatc
             calls.append((f"read-{self.kind}", resource_name, kwargs))
             return object.__new__(pulumi.CustomResource)
 
+        def __call__(self, resource_name: str, **kwargs):
+            calls.append((f"manage-{self.kind}", resource_name, kwargs))
+            return object.__new__(pulumi.CustomResource)
+
     monkeypatch.setattr(github_resources.github, "ActionsSecret", ResourceType("repository"))
     monkeypatch.setattr(github_resources.github, "ActionsOrganizationSecret", ResourceType("organization"))
     monkeypatch.setattr(github_resources.github, "ActionsEnvironmentSecret", ResourceType("environment"))
@@ -104,24 +108,97 @@ def test_registers_each_present_secret_and_selected_repository_access(monkeypatc
 
     registered = register_credentials(manifest)
 
-    present = [
+    registered_credentials = [
         credential
         for credential in manifest.credentials
-        if credential.presence is Presence.PRESENT and credential.management is Management.EXTERNAL
+        if credential.presence is Presence.PRESENT and credential.management is not Management.PULUMI
     ]
-    scope_counts = Counter(credential.scope for credential in present)
+    external = [credential for credential in registered_credentials if credential.management is Management.EXTERNAL]
+    scope_counts = Counter(credential.scope for credential in external)
     selected_organization_credentials = [
         credential
-        for credential in present
+        for credential in registered_credentials
         if isinstance(credential, OrganizationCredential) and credential.visibility is OrganizationVisibility.SELECTED
     ]
-    assert len(registered) == len(present) + len(selected_organization_credentials)
+    assert len(registered) == len(registered_credentials) + len(selected_organization_credentials)
     assert [kind for kind, _, _ in calls].count("read-organization") == scope_counts[CredentialScope.ORGANIZATION]
     assert [kind for kind, _, _ in calls].count("read-repository") == scope_counts[CredentialScope.REPOSITORY]
     assert [kind for kind, _, _ in calls].count("read-environment") == scope_counts[CredentialScope.ENVIRONMENT]
+    assert [kind for kind, _, _ in calls].count("manage-organization") == 1
     assert [kind for kind, _, _ in calls].count("read-organization-access") == len(selected_organization_credentials)
     selected_access = next(kwargs for kind, _, kwargs in calls if kind == "read-organization-access")
     assert selected_access["id"] == "LOOM_TRIGGER_GH_TOKEN"
+
+
+def test_registers_pulumi_managed_organization_secret_from_sealed_value(monkeypatch) -> None:
+    calls: list[tuple[str, dict]] = []
+
+    class ManagedOrganizationSecret:
+        def __init__(self, resource_name: str, **kwargs):
+            calls.append((resource_name, kwargs))
+
+    monkeypatch.setattr(github_resources.github, "ActionsOrganizationSecret", ManagedOrganizationSecret)
+    manifest = CredentialManifest(
+        organization="example",
+        repositories=(),
+        credentials=(
+            OrganizationCredential(
+                name="SLACK_WEBHOOK_URL",
+                presence=Presence.PRESENT,
+                management=Management.SEALED,
+                source=ValueSource(
+                    kind=SourceKind.GCP_SECRET,
+                    ref="gcp-secret://projects/example/secrets/slack-webhook/versions/1",
+                ),
+                disposition=Disposition.KEEP,
+                visibility=OrganizationVisibility.ALL,
+                key_id="github-actions-key-id",
+                value_encrypted="github-sealed-ciphertext",
+            ),
+        ),
+    )
+
+    registered = register_credentials(manifest)
+
+    assert len(registered) == 1
+    assert len(calls) == 1
+    resource_name, kwargs = calls[0]
+    assert resource_name == "organization-slack-webhook-url"
+    assert kwargs["secret_name"] == "SLACK_WEBHOOK_URL"
+    assert kwargs["visibility"] == "all"
+    assert kwargs["key_id"] == "github-actions-key-id"
+    assert kwargs["value_encrypted"] == "github-sealed-ciphertext"
+    assert kwargs["opts"].import_ == "SLACK_WEBHOOK_URL"
+
+
+@pytest.mark.parametrize(
+    "sealed_value",
+    [
+        {},
+        {"key_id": "github-actions-key-id"},
+        {"value_encrypted": "github-sealed-ciphertext"},
+    ],
+)
+def test_manifest_requires_complete_sealed_value_for_pulumi_managed_credentials(sealed_value: dict[str, str]) -> None:
+    credential = {
+        "name": "TOKEN",
+        "scope": "organization",
+        "presence": "present",
+        "management": "sealed",
+        "source_kind": "gcp-secret",
+        "source_ref": "gcp-secret://projects/example/secrets/token/versions/1",
+        "disposition": "keep",
+        "visibility": "all",
+        **sealed_value,
+    }
+
+    with pytest.raises(ValueError):
+        credential_manifest(
+            schema_version=CREDENTIAL_SCHEMA_VERSION,
+            organization="example",
+            repositories=[],
+            credentials=[credential],
+        )
 
 
 def test_live_audit_reports_missing_unmanaged_and_scope_drift() -> None:


### PR DESCRIPTION
Route organization-wide GitHub Actions failure notifications to `#marin-alerts` through a dedicated incoming webhook. The previous recovery declaration pointed at the retired Grafana webhook bound to `#marin-eng`, and a lingering Marin repository secret could also shadow the organization value.

Manage the replacement as ciphertext sealed to GitHub's Actions public key, with Secret Manager version 1 as the plaintext recovery source. Pulumi can restore GitHub-side drift without receiving or storing the webhook URL.

The live organization secret was rotated and imported into Pulumi, the repository override was deleted, and a labeled Slack test confirmed delivery. The converged preview reported 11 unchanged resources.

Incident: https://echo.oa.dev/wiki/162
