### PR TITLE
[finelog] Isolate forwarding failures by namespace

### DIFF
--- a/lib/finelog/AGENTS.md
+++ b/lib/finelog/AGENTS.md
@@ -66,9 +66,12 @@ the hub a convenience copy. A backlog is a durable cursor into the sender's boun
 local retention rather than a separate queue, so the forwarder drains it without an
 age or row-count cap. Non-log chunks from one read turn may wait for hub durability
 concurrently; log chunks stay serial to preserve line order. Rows are skipped only
-after local eviction makes them unreadable or the hub permanently rejects a malformed
-batch. A hub outage therefore cannot consume extra sender memory, but a long enough
-outage can still outlive local retention.
+after local eviction makes them unreadable. A rejected write preserves its cursor and
+invalidates the cached hub registration; the next sweep re-registers the current source
+schema and retries while other namespaces continue forwarding. Transient failures get
+three attempts before the namespace yields for the sweep, without advancing its cursor.
+A hub outage therefore cannot consume extra sender memory, but a long enough outage can
+still outlive local retention.
 
 Only the k8s backend can forward — it projects the key through a Secret. The gcp
 backend refuses, because its only channel to the server is world-readable

--- a/lib/finelog/OPS.md
+++ b/lib/finelog/OPS.md
@@ -268,7 +268,9 @@ Interpret the pair as follows:
 The forwarder gives every live namespace one batch-sized turn per round and
 starts another round immediately while work remains. A large telemetry backlog
 therefore does not monopolize forwarding ahead of new log rows. Hub or network
-failures can still delay a turn because forwarding is best effort.
+failures get three attempts, then leave the affected cursor in place and yield to
+the next namespace. The same batch is retried on the next sweep; exhaustion does
+not discard it.
 
 Inspect the sender's forwarder messages without changing the deployment. Read
 the deployment name and Kubernetes connection details from
@@ -284,8 +286,10 @@ Warnings name the affected namespace. `backlog exceeds the warning threshold`
 reports pressure but does not change the forwarding cursor; the sender continues
 draining every locally retained row. `rows evicted before they were forwarded`
 means that local retention has already made source sequence positions unreadable.
-The cumulative `skipped_seqs` progress counter also includes permanently rejected
-malformed batches and does not by itself prove that `log` rows were dropped.
+`hub rejected the batch; preserving the cursor` means the sender will re-register
+the namespace's current schema on the next sweep and retry the same rows. The
+cumulative `skipped_seqs` progress counter reports only sequence positions lost to
+local retention; filtered foreign-origin rows may make it an upper bound on lost rows.
 
 To rotate a key, add the new Secret Manager version, add its public key alongside
 the old one under the same `keys[].cluster` (the hub accepts either), roll the

--- a/lib/finelog/rust/src/main.rs
+++ b/lib/finelog/rust/src/main.rs
@@ -186,8 +186,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing::info!("finelog-server draining background tasks");
 
     // Stop the forwarder first: it reads the store, so it must be off the segments
-    // before the namespaces drain. It latches on the watch and interrupts its own
-    // retry backoff, so the join is prompt; the bound is defense in depth.
+    // before the namespaces drain. It observes the latch between bounded outbound
+    // requests and interrupts retry delays; the join timeout is defense in depth.
     if let (Some(stop), Some(task)) = (forward_stop, forward_task) {
         let _ = stop.send(true);
         let _ = tokio::time::timeout(Duration::from_secs(10), task).await;

--- a/lib/finelog/rust/src/server/forwarding.rs
+++ b/lib/finelog/rust/src/server/forwarding.rs
@@ -34,17 +34,16 @@
 //!   rather than backfilling a retention window.
 //! - It materializes at most [`FORWARD_BATCH_ROWS`] rows per read, and packs them into
 //!   requests of at most [`FORWARD_BATCH_BYTES`] unless one row alone exceeds the limit.
-//! - It advances a namespace's cursor past a batch only once that batch can never be
-//!   sent again: the hub acked it, or the forwarder gave it up. A crash mid-batch
-//!   re-forwards it (at-least-once; tolerable for logs and append-only stats).
+//! - It advances a namespace's cursor only after the hub acks the batch. A crash or
+//!   rejection re-forwards it (at-least-once; tolerable for logs and append-only stats).
 //! - A backlog is only a cursor into the source's already-bounded local retention, not a
 //!   separate in-memory queue. The forwarder drains it without an age or row-count cap.
-//!   It skips only when eviction has already removed the cursor's segments or when the
-//!   hub permanently refuses a malformed batch.
+//!   It skips only when eviction has already removed the cursor's segments.
 //!
-//! A push failure backs off and retries; nothing here can take the store down.
+//! A push failure leaves the cursor in place and yields to the next namespace; nothing
+//! here can take the store down.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -116,10 +115,11 @@ const FORWARD_LAG_WARNING_SEQS: i64 = 2_000_000;
 const TOKEN_TTL: Duration = Duration::from_secs(3600);
 const TOKEN_REFRESH_MARGIN: Duration = Duration::from_secs(300);
 
-/// Deadline for one outbound request, and the retry backoff bounds.
+/// Deadline for one outbound request. Transient failures receive a few local retries
+/// before the namespace yields, bounding how long one broken target can delay others.
 const PUSH_TIMEOUT: Duration = Duration::from_secs(60);
-const BACKOFF_MIN: Duration = Duration::from_secs(1);
-const BACKOFF_MAX: Duration = Duration::from_secs(60);
+const PUSH_ATTEMPTS_PER_TURN: usize = 3;
+const PUSH_RETRY_BACKOFF: Duration = Duration::from_secs(1);
 
 /// Emit a progress line at most this often, so a healthy forwarder is observable
 /// without flooding the logs it forwards.
@@ -280,9 +280,9 @@ pub struct Forwarder<T = HttpsTransport> {
     /// Backlog size that emits a warning. It never changes the cursor.
     lag_warning_seqs: i64,
     warned_lag: Mutex<HashSet<String>>,
-    /// Namespaces already created on the hub this process, so `RegisterTable` runs at
-    /// most once each.
-    registered: Mutex<HashSet<String>>,
+    /// The last source schema registered for each namespace. A local additive schema
+    /// change must be sent to the hub before rows using its new columns are written.
+    registered: Mutex<HashMap<String, Schema>>,
 }
 
 impl Forwarder<HttpsTransport> {
@@ -315,7 +315,7 @@ where
             config,
             lag_warning_seqs: FORWARD_LAG_WARNING_SEQS,
             warned_lag: Mutex::new(HashSet::new()),
-            registered: Mutex::new(HashSet::new()),
+            registered: Mutex::new(HashMap::new()),
         }
     }
 
@@ -473,8 +473,8 @@ where
             FORWARD_CHUNK_CONCURRENCY
         };
         let pushes = chunks.into_iter().map(|(ipc, last_seq)| {
-            let mut chunk_stop = (*stop).clone();
-            async move { (last_seq, self.push(name, ipc, &mut chunk_stop).await) }
+            let chunk_stop = (*stop).clone();
+            async move { (last_seq, self.push(name, ipc, chunk_stop).await) }
         });
         // `buffered` polls several pushes at once but yields their results in input
         // order. The durable cursor therefore never advances past an earlier chunk that
@@ -487,19 +487,23 @@ where
                     tracing::warn!(namespace = name, cursor, error = %e, "finelog forwarder: push interrupted");
                     return ForwardTurn::Wait;
                 }
-                // The hub refused these bytes and always will, so retrying is a
-                // livelock that strands every later row too. Skip past them and count
-                // the gap: the rows remain queryable in this store.
+                Err(PushError::Retryable(e)) => {
+                    tracing::warn!(namespace = name, cursor, error = %e, "finelog forwarder: push failed; retrying next sweep");
+                    return ForwardTurn::Wait;
+                }
                 Err(PushError::Rejected(e)) => {
-                    progress.skipped_seqs += last_seq - cursor;
+                    // InvalidArgument also covers a stale hub schema. Forget the last
+                    // registration so the next sweep evolves the hub before retrying
+                    // these same rows. Namespace fairness prevents a genuine poison
+                    // batch from blocking unrelated tables.
+                    self.registered.lock().unwrap().remove(name);
                     tracing::warn!(
                         namespace = name,
                         cursor,
-                        skipped = last_seq - cursor,
-                        resume_at = last_seq,
                         error = %e,
-                        "finelog forwarder: the hub rejected this batch as malformed; skipping it"
+                        "finelog forwarder: hub rejected the batch; preserving the cursor and refreshing the schema next sweep"
                     );
+                    return ForwardTurn::Wait;
                 }
             }
             cursor = last_seq;
@@ -678,11 +682,11 @@ where
         Ok(Some((ship, seqs)))
     }
 
-    /// Create `name` on the hub if this process has not already, so a later [`WriteRows`]
-    /// resolves. The reserved `log` namespace exists on every finelog, so it is never
-    /// registered. Returns whether the hub is ready to take rows for `name`.
+    /// Create or evolve `name` on the hub when this process has not registered its
+    /// current source schema. The reserved `log` namespace exists on every finelog, so
+    /// it is never registered. Returns whether the hub is ready to take rows for `name`.
     async fn ensure_registered(&self, name: &str, schema: &Schema) -> bool {
-        if name == LOG_NAMESPACE_NAME || self.registered.lock().unwrap().contains(name) {
+        if name == LOG_NAMESPACE_NAME || self.registered.lock().unwrap().get(name) == Some(schema) {
             return true;
         }
         let bearer = match self.minter.bearer() {
@@ -708,7 +712,10 @@ where
             .await
         {
             Ok(_) => {
-                self.registered.lock().unwrap().insert(name.to_string());
+                self.registered
+                    .lock()
+                    .unwrap()
+                    .insert(name.to_string(), schema.clone());
                 true
             }
             Err(e) => {
@@ -718,63 +725,70 @@ where
         }
     }
 
-    /// Ship one encoded chunk to `name` on the hub and wait for it to durably ack,
-    /// retrying transient failures — auth failures among them — with an exponential
-    /// backoff.
+    /// Ship one encoded chunk to `name` on the hub and wait for it to durably ack.
+    /// Retry transient failures at most [`PUSH_ATTEMPTS_PER_TURN`] times, then return the
+    /// chunk still owed so the caller can give the next namespace its turn.
     ///
-    /// Returns [`PushError::Rejected`] only when the hub refuses the chunk's content, and
-    /// [`PushError::Stopping`] when `stop` latches, which also interrupts the backoff so a
-    /// SIGTERM never waits one out.
+    /// Returns [`PushError::Rejected`] only when the hub refuses the chunk's content,
+    /// [`PushError::Retryable`] for a condition that may clear, and
+    /// [`PushError::Stopping`] when `stop` latches.
     async fn push(
         &self,
         name: &str,
         arrow_ipc: Vec<u8>,
-        stop: &mut watch::Receiver<bool>,
+        mut stop: watch::Receiver<bool>,
     ) -> Result<(), PushError> {
         let request = WriteRowsRequest::default()
             .with_namespace(name)
             .with_arrow_ipc(arrow_ipc);
 
-        let mut backoff = BACKOFF_MIN;
-        loop {
-            let bearer = match self.minter.bearer() {
-                Ok(bearer) => bearer,
-                // The key parsed at startup, so this is not a config error we can resolve
-                // by skipping the batch. Back off and try again.
-                Err(e) => {
-                    tracing::warn!(error = %e, "finelog forwarder: minting a bearer failed");
-                    if wait_or_stop(backoff, stop).await {
-                        return Err(PushError::Stopping(e));
+        let mut backoff = PUSH_RETRY_BACKOFF;
+        for attempt in 1..=PUSH_ATTEMPTS_PER_TURN {
+            if *stop.borrow() {
+                return Err(PushError::Stopping("shutdown requested".to_string()));
+            }
+            let result = match self.minter.bearer() {
+                Ok(bearer) => {
+                    let options = CallOptions::default()
+                        .with_timeout(PUSH_TIMEOUT)
+                        .with_header("authorization", format!("Bearer {bearer}"));
+                    match self
+                        .client
+                        .write_rows_with_options(request.clone(), options)
+                        .await
+                    {
+                        Ok(_) => {
+                            tracing::debug!(namespace = name, "finelog forwarder: batch delivered");
+                            return Ok(());
+                        }
+                        Err(e) if is_content_rejection(&e) => {
+                            Err(PushError::Rejected(e.to_string()))
+                        }
+                        Err(e) if *stop.borrow() => Err(PushError::Stopping(e.to_string())),
+                        Err(e) => Err(PushError::Retryable(e.to_string())),
                     }
-                    backoff = (backoff * 2).min(BACKOFF_MAX);
-                    continue;
                 }
+                Err(e) => Err(PushError::Retryable(e)),
             };
-            let options = CallOptions::default()
-                .with_timeout(PUSH_TIMEOUT)
-                .with_header("authorization", format!("Bearer {bearer}"));
-            match self
-                .client
-                .write_rows_with_options(request.clone(), options)
-                .await
-            {
-                Ok(_) => {
-                    tracing::debug!(namespace = name, "finelog forwarder: batch delivered");
-                    return Ok(());
-                }
-                Err(e) if is_permanent_rejection(&e) => {
-                    return Err(PushError::Rejected(e.to_string()))
-                }
-                Err(e) if *stop.borrow() => return Err(PushError::Stopping(e.to_string())),
-                Err(e) => {
-                    tracing::warn!(namespace = name, error = %e, backoff_seconds = backoff.as_secs(), "finelog forwarder: push failed");
-                    if wait_or_stop(backoff, stop).await {
-                        return Err(PushError::Stopping(e.to_string()));
+            match result {
+                Err(PushError::Retryable(error)) if attempt < PUSH_ATTEMPTS_PER_TURN => {
+                    tracing::warn!(
+                        namespace = name,
+                        error = %error,
+                        attempt,
+                        max_attempts = PUSH_ATTEMPTS_PER_TURN,
+                        backoff_seconds = backoff.as_secs(),
+                        "finelog forwarder: push failed; retrying"
+                    );
+                    if wait_or_stop(backoff, &mut stop).await {
+                        return Err(PushError::Stopping(error));
                     }
-                    backoff = (backoff * 2).min(BACKOFF_MAX);
+                    backoff *= 2;
                 }
+                result => return result,
             }
         }
+        unreachable!("the bounded push loop always returns on its last attempt")
     }
 }
 
@@ -789,27 +803,29 @@ enum ForwardTurn {
 /// Why a push gave up.
 #[derive(Debug)]
 enum PushError {
-    /// The forwarder is shutting down mid-retry. The chunk is still owed; the cursor
-    /// stays where it is and the next process re-reads it.
+    /// The forwarder is shutting down. The chunk is still owed; the cursor stays where
+    /// it is and the next process re-reads it.
     Stopping(String),
-    /// The hub refused the chunk's *content*, so no retry of the same bytes can succeed.
-    /// The caller skips past it rather than stalling the whole stream.
+    /// The request may succeed later. The chunk is still owed, and the next namespace
+    /// must receive its turn before this one retries.
+    Retryable(String),
+    /// The hub refused the chunk's content. This may be a stale registered schema, so
+    /// the caller preserves the cursor and refreshes registration before retrying.
     Rejected(String),
 }
 
-/// Whether the hub's answer means "these bytes are unacceptable" rather than "not right
-/// now".
+/// Whether the hub rejected the request's content rather than reporting a transient
+/// service condition.
 ///
-/// Only `invalid_argument` qualifies: the hub returns it for a structurally bad batch
-/// (a schema the namespace does not accept), which is a poison pill — re-sending it
-/// forever would strand every row behind it. Everything else, auth failures included,
-/// describes a condition that can change without the chunk changing.
-fn is_permanent_rejection(error: &connectrpc::ConnectError) -> bool {
+/// `invalid_argument` includes both structurally bad batches and a batch whose columns
+/// have not reached the hub's registered schema. The caller distinguishes neither:
+/// both remain owed while other namespaces continue making progress.
+fn is_content_rejection(error: &connectrpc::ConnectError) -> bool {
     error.code == connectrpc::error::ErrorCode::InvalidArgument
 }
 
-/// Sleep for `backoff`, or wake early if `stop` latches. Returns whether it latched, so
-/// shutdown never waits out a full backoff.
+/// Sleep between transient attempts. Returns `true` when shutdown latches or its sender
+/// closes, and `false` when the delay elapses.
 async fn wait_or_stop(backoff: Duration, stop: &mut watch::Receiver<bool>) -> bool {
     tokio::select! {
         _ = stop.changed() => true,
@@ -915,8 +931,7 @@ fn chunk_by_bytes(
 struct Progress {
     /// Requests the hub accepted, across every namespace. Counted in batches, not rows.
     batches: u64,
-    /// `seq` positions the forwarder passed over and will never send — evicted before
-    /// they shipped or in a batch the hub permanently refused.
+    /// `seq` positions the forwarder passed over because local retention evicted them.
     /// An upper bound on rows lost: some positions held rows the scan would have filtered
     /// out anyway.
     skipped_seqs: i64,

--- a/lib/finelog/rust/src/server/forwarding_tests.rs
+++ b/lib/finelog/rust/src/server/forwarding_tests.rs
@@ -13,8 +13,8 @@ use crate::proto::finelog::logging::{FetchLogsRequest, LogEntry, MatchScope, Pus
 use crate::proto::finelog::stats::ColumnType;
 use crate::server::auth::{AuthIdentity, AuthPolicy};
 use crate::server::test_support::{
-    client, disk_store, serve, serve_rejecting, stats_client, RequestStats, TestTransport, PRIV_A,
-    PRIV_UNTRUSTED, PUB_A,
+    client, disk_store, serve, serve_rejecting, serve_unavailable, stats_client, RequestStats,
+    TestTransport, PRIV_A, PRIV_UNTRUSTED, PUB_A,
 };
 use crate::store::policy::StoragePolicy;
 use crate::store::schema::{Column, Schema};
@@ -84,6 +84,11 @@ impl Fixture {
     /// keeps no store, so only the source and the request count are observable.
     async fn with_rejecting_hub(tag: &str) -> Self {
         let (target_addr, target_requests) = serve_rejecting().await;
+        Self::with_hub(tag, None, target_addr, target_requests).await
+    }
+
+    async fn with_unavailable_hub(tag: &str) -> Self {
+        let (target_addr, target_requests) = serve_unavailable().await;
         Self::with_hub(tag, None, target_addr, target_requests).await
     }
 
@@ -345,8 +350,8 @@ impl RunningForwarder {
         }
     }
 
-    /// Latch the stop signal and join. Bounded, so a forwarder wedged in a backoff fails
-    /// the test rather than hanging it.
+    /// Latch the stop signal and join. Bounded, so an outbound request that does not
+    /// return fails the test instead of hanging it.
     async fn finish(self) {
         self.stop.send(true).unwrap();
         tokio::time::timeout(Duration::from_secs(5), self.task)
@@ -631,25 +636,52 @@ async fn a_bearer_the_hub_does_not_trust_forwards_nothing_and_loses_nothing() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn a_batch_the_hub_calls_malformed_is_skipped_rather_than_retried_forever() {
-    // invalid_argument means the hub refuses these bytes and always will. Retrying would
-    // strand every row behind them, so the forwarder counts the batch as skipped and
-    // moves its cursor past it. The rows are still in the local store.
+async fn a_batch_the_hub_calls_malformed_preserves_its_cursor_for_retry() {
     let fx = Fixture::with_rejecting_hub("poison").await;
     push(&fx.source_client, "/user/job/t", &["hello"]).await;
     fx.forward_from_start(LOG_NAMESPACE_NAME);
-    let tip = fx.tip(LOG_NAMESPACE_NAME);
-    fx.drain(PRIV_A, LOG_NAMESPACE_NAME).await;
+
+    let forwarder = fx.forwarder(PRIV_A);
+    let mut progress = Progress::new();
+    let (_stop_tx, mut stop) = watch::channel(false);
+    forwarder.forward_round(&mut progress, &mut stop).await;
 
     assert_eq!(
         fx.cursor(LOG_NAMESPACE_NAME),
-        Some(tip),
-        "the cursor must advance past a batch the hub will never accept"
+        Some(0),
+        "a rejected batch stays owed because a later schema registration may make it valid"
     );
     assert_eq!(
         fx.requests(),
         1,
-        "a permanently rejected batch is sent once, not retried"
+        "one namespace receives only one attempt in a forwarding sweep"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn three_retryable_push_failures_yield_to_the_next_namespace() {
+    let fx = Fixture::with_unavailable_hub("unavailable").await;
+    push(&fx.source_client, "/user/job/t", &["hello"]).await;
+    write_id_rows(&fx.source, "events", 1).await;
+    fx.forward_from_start(LOG_NAMESPACE_NAME);
+    fx.forward_from_start("events");
+
+    let forwarder = fx.forwarder(PRIV_A);
+    let mut progress = Progress::new();
+    let (_stop_tx, mut stop) = watch::channel(false);
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        forwarder.forward_round(&mut progress, &mut stop),
+    )
+    .await
+    .expect("a retryable failure must yield instead of monopolizing the sweep");
+
+    assert_eq!(fx.cursor(LOG_NAMESPACE_NAME), Some(0));
+    assert_eq!(fx.target_requests.write_rows_requests(), 3);
+    assert_eq!(
+        fx.target_requests.register_table_requests(),
+        1,
+        "the namespace after the failed log batch must receive its registration turn"
     );
 }
 
@@ -869,4 +901,64 @@ async fn a_non_log_table_is_registered_on_the_hub_and_stamped_with_its_origin() 
         ],
         "the forwarder stamps the origin cluster onto a table that never declared it"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn schema_evolution_is_registered_before_forwarding_new_rows() {
+    let fx = Fixture::new("schema-evolution").await;
+    write_id_rows(&fx.source, "events", 1).await;
+    fx.forward_from_start("events");
+
+    let forwarder = fx.forwarder(PRIV_A);
+    let mut progress = Progress::new();
+    let (_stop_tx, mut stop) = watch::channel(false);
+    forwarder.forward_round(&mut progress, &mut stop).await;
+
+    let evolved_schema = Schema::new(
+        vec![
+            Column::new("id", ColumnType::COLUMN_TYPE_STRING, false),
+            Column::new("run_id", ColumnType::COLUMN_TYPE_STRING, true),
+        ],
+        "id",
+    );
+    let source = Arc::clone(&fx.source);
+    tokio::task::spawn_blocking(move || {
+        source.register_table("events", evolved_schema, StoragePolicy::default())
+    })
+    .await
+    .unwrap()
+    .unwrap();
+    let arrow_schema = Arc::new(ArrowSchema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("run_id", DataType::Utf8, true),
+    ]));
+    let batch = RecordBatch::try_new(
+        arrow_schema,
+        vec![
+            Arc::new(StringArray::from(vec!["1"])),
+            Arc::new(StringArray::from(vec![Some("run-1")])),
+        ],
+    )
+    .unwrap();
+    let ipc = encode_ipc(&batch.schema(), &[batch]).unwrap();
+    let (_, last_seq) = fx.source.write_rows("events", &ipc, None).unwrap();
+    fx.source
+        .await_persisted("events", last_seq, Duration::from_secs(5))
+        .await
+        .unwrap();
+
+    forwarder.forward_round(&mut progress, &mut stop).await;
+
+    let target_schema = fx.target_store().get_table_schema("events").unwrap();
+    assert!(target_schema.column("run_id").is_some());
+    let target_rows = fx
+        .target_store()
+        .list_namespaces_with_stats()
+        .unwrap()
+        .into_iter()
+        .find(|(name, _, _, _)| name == "events")
+        .unwrap()
+        .2
+        .row_count;
+    assert_eq!(target_rows, 2);
 }

--- a/lib/finelog/rust/src/server/test_support.rs
+++ b/lib/finelog/rust/src/server/test_support.rs
@@ -42,6 +42,8 @@ pub type TestTransport = ServiceTransport<HyperClient<HttpConnector, ClientBody>
 pub struct RequestStats {
     total: AtomicUsize,
     zstd: AtomicUsize,
+    register_table: AtomicUsize,
+    write_rows: AtomicUsize,
     in_flight: AtomicUsize,
     max_in_flight: AtomicUsize,
 }
@@ -61,6 +63,12 @@ impl RequestStats {
         {
             self.zstd.fetch_add(1, Ordering::SeqCst);
         }
+        if request.uri().path().ends_with("/RegisterTable") {
+            self.register_table.fetch_add(1, Ordering::SeqCst);
+        }
+        if request.uri().path().ends_with("/WriteRows") {
+            self.write_rows.fetch_add(1, Ordering::SeqCst);
+        }
         let in_flight = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
         self.max_in_flight.fetch_max(in_flight, Ordering::SeqCst);
         true
@@ -76,6 +84,14 @@ impl RequestStats {
 
     pub fn zstd_requests(&self) -> usize {
         self.zstd.load(Ordering::SeqCst)
+    }
+
+    pub fn register_table_requests(&self) -> usize {
+        self.register_table.load(Ordering::SeqCst)
+    }
+
+    pub fn write_rows_requests(&self) -> usize {
+        self.write_rows.load(Ordering::SeqCst)
     }
 
     pub fn max_in_flight(&self) -> usize {
@@ -154,10 +170,33 @@ pub async fn serve(store: Arc<Store>, policy: AuthPolicy) -> (SocketAddr, Arc<Re
 }
 
 /// A hub that answers every RPC with `invalid_argument`, as the real one does for a
-/// structurally malformed entry (an empty key). Retrying such a request can never
-/// succeed, so this fixture lets a test prove the forwarder skips the batch instead of
-/// livelocking on it. Returns the address and a count of the requests it served.
+/// structurally malformed entry or a batch whose columns are missing from the hub's
+/// registered schema. Returns the address and a count of the requests it served.
 pub async fn serve_rejecting() -> (SocketAddr, Arc<RequestStats>) {
+    serve_error(
+        connectrpc::ErrorCode::InvalidArgument,
+        axum::http::StatusCode::BAD_REQUEST,
+        "empty key",
+    )
+    .await
+}
+
+/// A hub that answers every RPC with `unavailable`, modeling an outage that may clear
+/// without changing the request.
+pub async fn serve_unavailable() -> (SocketAddr, Arc<RequestStats>) {
+    serve_error(
+        connectrpc::ErrorCode::Unavailable,
+        axum::http::StatusCode::SERVICE_UNAVAILABLE,
+        "hub unavailable",
+    )
+    .await
+}
+
+async fn serve_error(
+    code: connectrpc::ErrorCode,
+    status: axum::http::StatusCode,
+    message: &'static str,
+) -> (SocketAddr, Arc<RequestStats>) {
     let requests = Arc::new(RequestStats::default());
     let counted = Arc::clone(&requests);
     let app = axum::Router::new().fallback(axum::routing::any(
@@ -165,12 +204,9 @@ pub async fn serve_rejecting() -> (SocketAddr, Arc<RequestStats>) {
             let counted = Arc::clone(&counted);
             async move {
                 let observed = counted.begin(&request);
-                let error = connectrpc::ConnectError::new(
-                    connectrpc::ErrorCode::InvalidArgument,
-                    "empty key",
-                );
+                let error = connectrpc::ConnectError::new(code, message);
                 let response = (
-                    axum::http::StatusCode::BAD_REQUEST,
+                    status,
                     [(axum::http::header::CONTENT_TYPE, "application/json")],
                     error.to_json(),
                 );


### PR DESCRIPTION
Bound each namespace's forwarding turn to three transient attempts before yielding, while keeping the batch cursor unchanged for the next sweep. Retry delays use 1s/2s backoff and shutdown interrupts them.

Refresh hub registration whenever the source schema evolves or a content rejection indicates that the cached schema may be stale. Hub rejections no longer advance the cursor; only local retention eviction can skip sequence positions.

Reno exposed both hazards: the pre-restart forwarder stopped advancing log and worker cursors near 03:08 UTC, and its unbounded per-namespace retry loop could strand all later tables. The old pod's logs were deleted by the deployment's Recreate strategy, so this mechanism remains the strongest supported explanation rather than a confirmed initiating error. After restart, stale telemetry registration caused `invalid_argument` responses and 21,440,768 skipped sequence positions while the hub stored zero Reno telemetry rows.

Incident: https://echo.oa.dev/wiki/163
