### PR TITLE
[zephyr] Reuse one object-store client per process

### DIFF
--- a/lib/rigging/src/rigging/filesystem/s3_compat.py
+++ b/lib/rigging/src/rigging/filesystem/s3_compat.py
@@ -48,7 +48,7 @@ VIRTUAL_HOST_ONLY_S3_DOMAINS = ("cwobject.com", "cwlota.com")
 
 _S3_CONNECT_TIMEOUT = 30
 _S3_READ_TIMEOUT = 120
-_S3_RETRY_MAX_ATTEMPTS = 5
+S3_RETRY_MAX_ATTEMPTS = 5
 
 # botocore's default pool of 10 serializes any caller fanning listing or transfer
 # threads over one filesystem. Connections are created on demand, so a high cap
@@ -57,7 +57,7 @@ _S3_MAX_POOL_CONNECTIONS = 128
 # Whole-request ceiling. It spans pool wait, connect, body upload, and response
 # download, so it bounds every S3 request rather than only a stalled one: a
 # genuine transfer slower than 600s now fails and is retried from byte zero, up
-# to _S3_RETRY_MAX_ATTEMPTS times. 600 leaves ample headroom for the largest
+# to S3_RETRY_MAX_ATTEMPTS times. 600 leaves ample headroom for the largest
 # request we issue (a 50 MiB multipart part needs ~90 KiB/s to fit), while still
 # failing a wedged request inside a shard's useful lifetime. Single-object reads
 # of many GB through this filesystem are the case to re-check if this bites.
@@ -103,7 +103,7 @@ def s3_request_bounds_config_kwargs() -> dict[str, Any]:
     return {
         "connect_timeout": _S3_CONNECT_TIMEOUT,
         "read_timeout": _S3_READ_TIMEOUT,
-        "retries": {"max_attempts": _S3_RETRY_MAX_ATTEMPTS, "mode": "standard"},
+        "retries": {"max_attempts": S3_RETRY_MAX_ATTEMPTS, "mode": "standard"},
         "max_pool_connections": _S3_MAX_POOL_CONNECTIONS,
     }
 

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -38,7 +38,7 @@ import os
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 from urllib.parse import urlparse
 
 import cloudpickle
@@ -277,7 +277,20 @@ class _SidecarSlice:
     target_bytes: int
 
 
-def _read_sidecar_slice(fs: Any, path: str, target_shard: int) -> _SidecarSlice | None:
+class _SidecarFilesystem(Protocol):
+    """The filesystem surface a sidecar read uses.
+
+    ``url_to_fs`` hands back a bare fsspec filesystem for ``s3://`` and a
+    ``CrossRegionGuardedFS`` wrapper for ``gs://``. The two share no base class,
+    so the reader names the methods it calls instead.
+    """
+
+    def _strip_protocol(self, path: str) -> str: ...
+
+    def cat_file(self, path: str) -> bytes: ...
+
+
+def _read_sidecar_slice(fs: _SidecarFilesystem, path: str, target_shard: int) -> _SidecarSlice | None:
     """Read one sidecar and return its file list plus the target shard's payload bytes.
 
     Returns ``None`` if the sidecar has no files (empty writer).

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -278,12 +278,9 @@ class _SidecarSlice:
 
 
 class _SidecarFilesystem(Protocol):
-    """The filesystem surface a sidecar read uses.
-
-    ``url_to_fs`` hands back a bare fsspec filesystem for ``s3://`` and a
-    ``CrossRegionGuardedFS`` wrapper for ``gs://``. The two share no base class,
-    so the reader names the methods it calls instead.
-    """
+    """A protocol because ``url_to_fs`` returns a bare fsspec filesystem for
+    ``s3://`` and a ``CrossRegionGuardedFS`` wrapper for ``gs://``, which share
+    no base class."""
 
     def _strip_protocol(self, path: str) -> str: ...
 
@@ -291,17 +288,12 @@ class _SidecarFilesystem(Protocol):
 
 
 def _read_sidecar_slice(fs: _SidecarFilesystem, path: str, target_shard: int) -> _SidecarSlice | None:
-    """Read one sidecar and return its file list plus the target shard's payload bytes.
+    """Read one sidecar and return its file list plus the target shard's payload
+    bytes, or ``None`` if the writer wrote no files.
 
-    Returns ``None`` if the sidecar has no files (empty writer).
-
-    Takes the filesystem from the caller rather than resolving one: fsspec keys
-    its instance cache on the calling thread, so a resolve inside a pool worker
-    builds a client — and a connection pool — per thread (#8402).
-
-    Uses ``fs.cat_file`` rather than ``open_url`` — one direct GET returning
-    bytes is ~25% faster than going through ``TextIOWrapper(BufferedFile)``
-    for small sidecars, and msgpack decodes bytes directly.
+    ``fs`` comes from the caller because fsspec keys its instance cache on the
+    calling thread, so resolving here builds a client per pool worker (#8402).
+    ``cat_file`` beats ``open_url`` by ~25% on small sidecars.
     """
     meta_path = fs._strip_protocol(_scatter_meta_path(path))
     meta = _sidecar_decoder().decode(fs.cat_file(meta_path))

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -93,8 +93,10 @@ _SCATTER_METADATA_FILENAME = "metadata.msgpack"
 
 # Number of parallel small-file reads (sidecars, parquet schema footers) each
 # reducer issues while building its ScatterReader. These reads are GCS
-# GET-bound, so a modest pool keeps latency low without thrashing.
-_SIDECAR_READ_CONCURRENCY = 32
+# GET-bound, so a modest pool keeps latency low without thrashing. The bound is
+# per task, and a wave multiplies it: 2,048 reducers at 32 offered ~65,000
+# simultaneous connections, more than a pod has ephemeral ports (#8402).
+_SIDECAR_READ_CONCURRENCY = 8
 # Fraction of available memory available for merging.
 _SCATTER_READ_MEMORY_FRACTION = 0.4
 
@@ -275,18 +277,21 @@ class _SidecarSlice:
     target_bytes: int
 
 
-def _read_sidecar_slice(path: str, target_shard: int) -> _SidecarSlice | None:
+def _read_sidecar_slice(fs: Any, path: str, target_shard: int) -> _SidecarSlice | None:
     """Read one sidecar and return its file list plus the target shard's payload bytes.
 
     Returns ``None`` if the sidecar has no files (empty writer).
+
+    Takes the filesystem from the caller rather than resolving one: fsspec keys
+    its instance cache on the calling thread, so a resolve inside a pool worker
+    builds a client — and a connection pool — per thread (#8402).
 
     Uses ``fs.cat_file`` rather than ``open_url`` — one direct GET returning
     bytes is ~25% faster than going through ``TextIOWrapper(BufferedFile)``
     for small sidecars, and msgpack decodes bytes directly.
     """
-    meta_path = _scatter_meta_path(path)
-    fs, fs_path = url_to_fs(meta_path)
-    meta = _sidecar_decoder().decode(fs.cat_file(fs_path))
+    meta_path = fs._strip_protocol(_scatter_meta_path(path))
+    meta = _sidecar_decoder().decode(fs.cat_file(meta_path))
     files = meta.get("files", [])
     if not files:
         return None
@@ -301,11 +306,16 @@ def _read_sidecar_slice(path: str, target_shard: int) -> _SidecarSlice | None:
 def _read_sidecar_slices_parallel(scatter_paths: list[str], target_shard: int) -> list[_SidecarSlice]:
     """Read every sidecar concurrently and return slices in input order.
 
-    Empty sidecars (no files written) are dropped from the result.
+    Empty sidecars (no files written) are dropped from the result. All sidecars
+    of one scatter live under the same root, so one filesystem resolved here
+    serves the whole pool.
     """
+    if not scatter_paths:
+        return []
     ordered: list[_SidecarSlice | None] = [None] * len(scatter_paths)
+    fs, _ = url_to_fs(_scatter_meta_path(scatter_paths[0]))
     with concurrent.futures.ThreadPoolExecutor(max_workers=_SIDECAR_READ_CONCURRENCY) as pool:
-        futures = {pool.submit(_read_sidecar_slice, p, target_shard): i for i, p in enumerate(scatter_paths)}
+        futures = {pool.submit(_read_sidecar_slice, fs, p, target_shard): i for i, p in enumerate(scatter_paths)}
         for fut in concurrent.futures.as_completed(futures):
             idx = futures[fut]
             ordered[idx] = fut.result()

--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -3,6 +3,7 @@
 
 """Writers for common output formats."""
 
+import functools
 import itertools
 import logging
 import os
@@ -269,6 +270,10 @@ def _accumulate_tables(
 # upload forever instead of failing it into a retry.
 _S3_NATIVE_CONNECT_TIMEOUT = 30
 _S3_NATIVE_REQUEST_TIMEOUT = 120
+# Matches the attempt budget ``s3_request_bounds_config_kwargs`` gives s3fs.
+# Without it the AWS C++ SDK applies its own default, which no Marin setting
+# reaches.
+_S3_NATIVE_RETRY_MAX_ATTEMPTS = 5
 
 
 def _s3_filesystem_kwargs() -> dict[str, str | bool | int]:
@@ -299,6 +304,34 @@ def _s3_filesystem_kwargs() -> dict[str, str | bool | int]:
     return kwargs
 
 
+@functools.cache
+def _native_s3_filesystem(kwargs: tuple[tuple[str, str | bool | int], ...]) -> pa_fs.S3FileSystem:
+    """One S3 filesystem per configuration, held for the life of the process.
+
+    Every pyarrow filesystem owns a connection pool that dies with the object,
+    so a filesystem per file reuses nothing: each closed connection parks a
+    local port in ``TIME_WAIT`` for 60 s, and a stage writing tens of files per
+    task drains its pod's ephemeral port range until ``connect()`` returns
+    ``EADDRNOTAVAIL`` (#8402). pyarrow filesystems are thread-safe, so one
+    instance serves every writer in the process. The key is the resolved
+    kwargs, so a changed endpoint still builds its own filesystem.
+    """
+    return pa_fs.S3FileSystem(
+        retry_strategy=pa_fs.AwsStandardS3RetryStrategy(max_attempts=_S3_NATIVE_RETRY_MAX_ATTEMPTS),
+        **dict(kwargs),
+    )
+
+
+@functools.cache
+def _native_gcs_filesystem() -> pa_fs.GcsFileSystem:
+    return pa_fs.GcsFileSystem()
+
+
+@functools.cache
+def _native_local_filesystem() -> pa_fs.LocalFileSystem:
+    return pa_fs.LocalFileSystem()
+
+
 def _pyarrow_filesystem(path: str) -> tuple[pa_fs.FileSystem, str] | None:
     """Resolve ``path`` to a native pyarrow ``(filesystem, path)``, or ``None``.
 
@@ -310,13 +343,13 @@ def _pyarrow_filesystem(path: str) -> tuple[pa_fs.FileSystem, str] | None:
     in tests); those fall back to an fsspec handle.
     """
     if "://" not in path:
-        return pa_fs.LocalFileSystem(), path
+        return _native_local_filesystem(), path
     if path.startswith("file://"):
-        return pa_fs.LocalFileSystem(), path[len("file://") :]
+        return _native_local_filesystem(), path[len("file://") :]
     if path.startswith("gs://"):
-        return pa_fs.GcsFileSystem(), path[len("gs://") :]
+        return _native_gcs_filesystem(), path[len("gs://") :]
     if path.startswith("s3://"):
-        return pa_fs.S3FileSystem(**_s3_filesystem_kwargs()), path[len("s3://") :]
+        return _native_s3_filesystem(tuple(sorted(_s3_filesystem_kwargs().items()))), path[len("s3://") :]
     return None
 
 

--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -23,6 +23,7 @@ import zstandard as zstd
 from pyarrow import fs as pa_fs
 from rigging.filesystem.atomic import atomic_rename
 from rigging.filesystem.factory import url_to_fs
+from rigging.filesystem.s3_compat import S3_RETRY_MAX_ATTEMPTS
 from rigging.filesystem.storage_path import StoragePath
 
 from zephyr import counters
@@ -270,10 +271,6 @@ def _accumulate_tables(
 # upload forever instead of failing it into a retry.
 _S3_NATIVE_CONNECT_TIMEOUT = 30
 _S3_NATIVE_REQUEST_TIMEOUT = 120
-# Matches the attempt budget ``s3_request_bounds_config_kwargs`` gives s3fs.
-# Without it the AWS C++ SDK applies its own default, which no Marin setting
-# reaches.
-_S3_NATIVE_RETRY_MAX_ATTEMPTS = 5
 
 
 def _s3_filesystem_kwargs() -> dict[str, str | bool | int]:
@@ -315,9 +312,12 @@ def _native_s3_filesystem(kwargs: tuple[tuple[str, str | bool | int], ...]) -> p
     ``EADDRNOTAVAIL`` (#8402). pyarrow filesystems are thread-safe, so one
     instance serves every writer in the process. The key is the resolved
     kwargs, so a changed endpoint still builds its own filesystem.
+
+    The retry strategy is explicit because pyarrow otherwise falls back to the
+    AWS C++ SDK default, which no Marin setting reaches.
     """
     return pa_fs.S3FileSystem(
-        retry_strategy=pa_fs.AwsStandardS3RetryStrategy(max_attempts=_S3_NATIVE_RETRY_MAX_ATTEMPTS),
+        retry_strategy=pa_fs.AwsStandardS3RetryStrategy(max_attempts=S3_RETRY_MAX_ATTEMPTS),
         **dict(kwargs),
     )
 

--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -305,16 +305,10 @@ def _s3_filesystem_kwargs() -> dict[str, str | bool | int]:
 def _native_s3_filesystem(kwargs: tuple[tuple[str, str | bool | int], ...]) -> pa_fs.S3FileSystem:
     """One S3 filesystem per configuration, held for the life of the process.
 
-    Every pyarrow filesystem owns a connection pool that dies with the object,
-    so a filesystem per file reuses nothing: each closed connection parks a
-    local port in ``TIME_WAIT`` for 60 s, and a stage writing tens of files per
-    task drains its pod's ephemeral port range until ``connect()`` returns
-    ``EADDRNOTAVAIL`` (#8402). pyarrow filesystems are thread-safe, so one
-    instance serves every writer in the process. The key is the resolved
-    kwargs, so a changed endpoint still builds its own filesystem.
-
-    The retry strategy is explicit because pyarrow otherwise falls back to the
-    AWS C++ SDK default, which no Marin setting reaches.
+    Each filesystem owns a connection pool that dies with it, so one per file
+    exhausts the pod's ephemeral ports via ``TIME_WAIT`` (#8402). The retry
+    strategy is explicit because pyarrow otherwise uses the AWS C++ SDK
+    default.
     """
     return pa_fs.S3FileSystem(
         retry_strategy=pa_fs.AwsStandardS3RetryStrategy(max_attempts=S3_RETRY_MAX_ATTEMPTS),

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -14,12 +14,12 @@ from collections.abc import Iterator
 from unittest.mock import patch
 
 import cloudpickle
+import fsspec
 import polars as pl
 import pyarrow.parquet as pq
 import pytest
 from fsspec.implementations.local import LocalFileSystem
 from iris.env_resources import TaskResources
-from rigging.filesystem.factory import url_to_fs
 from zephyr.external_sort import external_sort_merge
 from zephyr.runners import _InProcessWorkerContext
 from zephyr.shard_keys import deterministic_hash
@@ -584,26 +584,47 @@ def test_external_sort_merge_across_source_shards(tmp_path):
     assert [r["k"] for r in rows] == [1, 2, 3]
 
 
-def test_sidecar_reads_share_one_filesystem(tmp_path):
-    """Concurrent sidecar reads use the caller's filesystem client (#8402).
+class _CountingFileSystem(LocalFileSystem):
+    """Local filesystem under its own protocol that counts the clients built.
+
+    Every real object-store client carries a connection pool, so the number of
+    clients a read fans out to is the quantity that decides whether a pod keeps
+    its ephemeral ports.
+    """
+
+    protocol = "counting"
+    clients_built = 0
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        type(self).clients_built += 1
+
+    @classmethod
+    def _strip_protocol(cls, path):
+        return super()._strip_protocol(str(path).removeprefix("counting://"))
+
+
+def test_sidecar_reads_build_one_client(tmp_path):
+    """Reading many sidecars concurrently builds one client (#8402).
 
     fsspec keys its instance cache on the calling thread, so a filesystem
     resolved inside a pool worker is a client -- and a connection pool -- per
     thread. Every reducer does this against thousands of sidecars, and the
     closed connections park local ports in TIME_WAIT until the pod runs out.
     """
+    fsspec.register_implementation("counting", _CountingFileSystem, clobber=True)
     paths = []
-    for shard_idx in range(4):
+    for shard_idx in range(8):
         data_path = f"{tmp_path}/shard-{shard_idx:04d}/scatter/"
-        paths.append(data_path)
         writer = ScatterWriter(data_path=data_path, key_fn=_key, source_shard=shard_idx)
         writer.write(_items_to_dataframe([{"k": shard_idx}], _key, None, 1))
         writer.close()
+        paths.append(f"counting://{data_path}")
 
-    url_to_fs(paths[0])  # the instance the caller thread already holds
-    cached_clients = len(LocalFileSystem._cache)
+    _CountingFileSystem.clear_instance_cache()
+    _CountingFileSystem.clients_built = 0
 
     slices = _read_sidecar_slices_parallel(paths, target_shard=0)
 
     assert [s.path for s in slices] == paths
-    assert len(LocalFileSystem._cache) == cached_clients
+    assert _CountingFileSystem.clients_built == 1

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -17,7 +17,9 @@ import cloudpickle
 import polars as pl
 import pyarrow.parquet as pq
 import pytest
+from fsspec.implementations.local import LocalFileSystem
 from iris.env_resources import TaskResources
+from rigging.filesystem.factory import url_to_fs
 from zephyr.external_sort import external_sort_merge
 from zephyr.runners import _InProcessWorkerContext
 from zephyr.shard_keys import deterministic_hash
@@ -30,6 +32,7 @@ from zephyr.shuffle import (
     ScatterWriter,
     _dataframe_to_items,
     _items_to_dataframe,
+    _read_sidecar_slices_parallel,
     _write_scatter,
 )
 from zephyr.worker_context import _worker_ctx_var
@@ -579,3 +582,28 @@ def test_external_sort_merge_across_source_shards(tmp_path):
         shard=0,
     )
     assert [r["k"] for r in rows] == [1, 2, 3]
+
+
+def test_sidecar_reads_share_one_filesystem(tmp_path):
+    """Concurrent sidecar reads use the caller's filesystem client (#8402).
+
+    fsspec keys its instance cache on the calling thread, so a filesystem
+    resolved inside a pool worker is a client -- and a connection pool -- per
+    thread. Every reducer does this against thousands of sidecars, and the
+    closed connections park local ports in TIME_WAIT until the pod runs out.
+    """
+    paths = []
+    for shard_idx in range(4):
+        data_path = f"{tmp_path}/shard-{shard_idx:04d}/scatter/"
+        paths.append(data_path)
+        writer = ScatterWriter(data_path=data_path, key_fn=_key, source_shard=shard_idx)
+        writer.write(_items_to_dataframe([{"k": shard_idx}], _key, None, 1))
+        writer.close()
+
+    url_to_fs(paths[0])  # the instance the caller thread already holds
+    cached_clients = len(LocalFileSystem._cache)
+
+    slices = _read_sidecar_slices_parallel(paths, target_shard=0)
+
+    assert [s.path for s in slices] == paths
+    assert len(LocalFileSystem._cache) == cached_clients

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -585,12 +585,7 @@ def test_external_sort_merge_across_source_shards(tmp_path):
 
 
 class _CountingFileSystem(LocalFileSystem):
-    """Local filesystem under its own protocol that counts the clients built.
-
-    Every real object-store client carries a connection pool, so the number of
-    clients a read fans out to is the quantity that decides whether a pod keeps
-    its ephemeral ports.
-    """
+    """Counts how many filesystem instances a read builds."""
 
     protocol = "counting"
     clients_built = 0
@@ -607,10 +602,8 @@ class _CountingFileSystem(LocalFileSystem):
 def test_sidecar_reads_build_one_client(tmp_path):
     """Reading many sidecars concurrently builds one client (#8402).
 
-    fsspec keys its instance cache on the calling thread, so a filesystem
-    resolved inside a pool worker is a client -- and a connection pool -- per
-    thread. Every reducer does this against thousands of sidecars, and the
-    closed connections park local ports in TIME_WAIT until the pod runs out.
+    fsspec keys its instance cache on the calling thread, so resolving inside
+    a pool worker builds a client, and a connection pool, per thread.
     """
     fsspec.register_implementation("counting", _CountingFileSystem, clobber=True)
     paths = []

--- a/lib/zephyr/tests/test_writers.py
+++ b/lib/zephyr/tests/test_writers.py
@@ -267,6 +267,31 @@ def test_pyarrow_filesystem_selection():
     assert _pyarrow_filesystem("memory://bucket/out.parquet") is None
 
 
+def test_pyarrow_filesystem_cached_per_config(monkeypatch):
+    """One S3 filesystem per process, not one per file (#8402).
+
+    Each filesystem owns a connection pool that dies with the object, so a
+    per-file client parks a local port in TIME_WAIT for every file a task
+    writes. A changed endpoint must still build a new filesystem.
+    """
+    monkeypatch.setitem(
+        fsspec.config.conf,
+        "s3",
+        {"endpoint_url": "https://object.example.com", "client_kwargs": {"region_name": "auto"}},
+    )
+    first, path = _pyarrow_filesystem("s3://bucket/a.parquet")
+    second, _ = _pyarrow_filesystem("s3://bucket/b.parquet")
+    assert path == "bucket/a.parquet"
+    assert first is second
+
+    monkeypatch.setitem(
+        fsspec.config.conf,
+        "s3",
+        {"endpoint_url": "https://other.example.com", "client_kwargs": {"region_name": "auto"}},
+    )
+    assert _pyarrow_filesystem("s3://bucket/a.parquet")[0] is not first
+
+
 def test_s3_filesystem_kwargs_from_fsspec_conf(monkeypatch):
     """The iris-exported FSSPEC_S3 block maps onto native S3FileSystem kwargs.
 


### PR DESCRIPTION
Cache the native pyarrow filesystem per process, and pass one fsspec filesystem
into the sidecar read pool. Both paths built a client per unit of work:
parquet_sink resolved a fresh S3FileSystem for every file it wrote, and
_read_sidecar_slice resolved inside a pool worker, where fsspec's instance cache
keys on the thread id. Each client owns a connection pool that dies with it, so
a closed connection parked a local port in TIME_WAIT for 60 s. One worker
mid-run held 27,612 sockets in TIME_WAIT against 55,296 available ports, after
which every S3 client in the process failed connect() with EADDRNOTAVAIL while
the endpoint was healthy. Fuzzy verification lost three production runs to this.

The native S3 filesystem now takes an explicit retry strategy, reading its
attempt budget from rigging's S3_RETRY_MAX_ATTEMPTS. It previously took only
timeouts and the endpoint and fell back to the AWS C++ SDK default.

Sidecar read concurrency drops from 32 to 8. The bound is per task and a wave
multiplies it: 2,048 reducers at 32 offered ~65,000 simultaneous connections.
The same constant bounds the Polars footer-schema pool, so a reducer reading
thousands of chunk footers spends proportionally longer there.

#8195 refactors the same sidecar functions into a _Sidecar class and #8269 adds
constants beside _SIDECAR_READ_CONCURRENCY; whichever of the three merges later
rebases.

Fixes #8402
