### PR TITLE
[grug] Increase ladder data loader prefetch capacity

### DIFF
--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -214,8 +214,10 @@ def build_train_loader(
     return DataLoader(
         dataset,
         batch_schedule.schedule,
+        max_buffered_batches=512,
         mesh=mesh,
         axis_resources={"__BATCH__": _BATCH_AXES},
+        prefetch_size=256,
         batch_axis_name="__BATCH__",
         allow_nondivisible_batch_size=False,
     )

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -697,10 +697,10 @@ class Trainer:
         return DataLoader(
             dataset,
             batch_size=batch_size,
-            max_buffered_batches=128,
+            max_buffered_batches=512,
             mesh=self.device_mesh,
             axis_resources=self.compute_axis_mapping,
-            prefetch_size=32,
+            prefetch_size=256,
             batch_axis_name=batch_name,
             allow_nondivisible_batch_size=self.config.allow_nondivisible_batch_size,
         )

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -697,10 +697,10 @@ class Trainer:
         return DataLoader(
             dataset,
             batch_size=batch_size,
-            max_buffered_batches=512,
+            max_buffered_batches=128,
             mesh=self.device_mesh,
             axis_resources=self.compute_axis_mapping,
-            prefetch_size=256,
+            prefetch_size=32,
             batch_axis_name=batch_name,
             allow_nondivisible_batch_size=self.config.allow_nondivisible_batch_size,
         )


### PR DESCRIPTION
Increase the buffered queue for the Grug hero-EP training data loader from 64 to 512 batches and its prefetch window from 32 to 256 batches. Scaling-ladder runs will keep more training batches in flight; shared Trainer and evaluation loaders are unchanged.
