### PR TITLE
[echo] Add stable grading keys to search results

### DIFF
--- a/.agents/skills/consult-echo/SKILL.md
+++ b/.agents/skills/consult-echo/SKILL.md
@@ -38,11 +38,11 @@ uv run infra/echo/cli.py get <domain:id>
 ```
 
 When a result materially helps, is irrelevant, or the result set fails the task,
-submit a compact judgment using the exact query and printed result IDs:
+submit a compact judgment using the exact query and printed grading keys:
 
 ```bash
 uv run infra/echo/cli.py feedback --query "stalled TPU collective" \
-  --grade wiki:123=0 --grade file:lib/iris/OPS.md=10 \
+  --grade wiki:730=0 --grade file:731=10 \
   <<< "The file result answered the task; wiki results were off-topic."
 ```
 

--- a/infra/echo/README.md
+++ b/infra/echo/README.md
@@ -15,11 +15,12 @@ provides an IAP-gated HTTP interface and browser dashboard.
   indexes the prose fields and can filter by tags.
 - `work_log` is an append-only agent logbook with one row per distilled milestone.
 - `search_feedback` records the query, IAP-authenticated caller, and short overall
-  explanation. `search_feedback_grades` stores its result IDs and 0–10 grades.
+  explanation. `search_feedback_grades` links 0–10 grades to exact stored search-result
+  rows.
 - `search_executions` permanently records every API search, including its normalized
   query, mode, selected domains and filters, result count, latency, indexed repository
-  commit, and service revision. `search_execution_results` snapshots the returned rank,
-  metadata, and snippets so later evaluations reproduce what the caller saw.
+  commit, and service revision. Each `search_execution_results` row has an identity key
+  and snapshots the returned rank, metadata, snippet, and raw reranker score.
 
 ## CLI
 
@@ -30,7 +31,7 @@ uv run infra/echo/cli.py search "expert parallel MoE MFU on B200" --limit 10
 uv run infra/echo/cli.py search "ragged_all_to_all" --domain file --domain pr
 uv run infra/echo/cli.py get file:lib/iris/OPS.md
 uv run infra/echo/cli.py feedback --query "how do I deploy Iris?" \
-  --execution-id 1234 --grade wiki:123=0 --grade file:lib/iris/OPS.md=10 <<'EOF'
+  --execution-id 1234 --grade wiki:730=0 --grade file:731=10 <<'EOF'
 The file result answered the question; the wiki result did not.
 EOF
 uv run infra/echo/cli.py history export > echo-search-history.jsonl
@@ -90,13 +91,18 @@ BGE semantic retrieval.
 The API retrieves at least 20 candidates from each selected domain, takes the best 20
 after first-stage fusion, and reranks their complete indexed chunks with the INT8 ONNX
 build of `ms-marco-MiniLM-L-6-v2`. Final rank is reciprocal-rank fusion of the
-first-stage rank (weight 0.2) and cross-encoder rank (weight 0.8). Candidates with a
-raw cross-encoder score below -2 are omitted. The threshold is an empirical relevance
-floor, not a calibrated probability. Because every returned result must be reranked,
-a search can return fewer than the requested limit and returns at most 20 results.
-`grep` remains a case-insensitive literal substring scan over activity, newest first.
+first-stage rank (weight 0.2) and cross-encoder rank (weight 0.8). Wiki candidates need
+a raw cross-encoder score of at least -1; other domains retain the -2 floor. These are
+empirical relevance floors, not calibrated probabilities. The wiki cutoff retains 93%
+of graded results scoring at least 4 while removing 22% of results below 4 in the 155
+execution-linked wiki grades available on 2026-08-18. Raw reranker scores are retained
+with new result snapshots so other domain cutoffs can use stable data. A search can
+return fewer than the requested limit and returns at most 20 results. `grep` remains a
+case-insensitive literal substring scan over activity, newest first.
 
-CLI search prints one table with stable result ID, title, and source-derived detail.
+CLI search prints one table with an execution-specific grading key, source ID, title,
+and source-derived detail. Grading keys use `<domain>:<numeric-key>` and remain attached
+to the stored row even when a later corpus sync replaces an activity chunk ID.
 Run `uv run infra/echo/cli.py get <domain:id>` to fetch the full indexed wiki body,
 repository file, pull request or issue chunk, or Discord message and its canonical URL.
 Wiki summaries use the `use_when` hint; files and activity use the matching source
@@ -111,7 +117,7 @@ reranking, and response decoding: the time the caller waited for Echo.
 
 Submit useful or poor results with `feedback`. A search prints its durable execution ID;
 pass it with `--execution-id` so each judgment is tied to the exact ranked result set.
-Repeat `--grade <result-id>=<0-10>` for
+Repeat `--grade <result-key>=<0-10>` for
 the results you evaluated, where 0 means irrelevant and 10 means directly useful to the
 task. The exact query makes each judgment replayable against a future search version.
 A short overall explanation is required on stdin. Capture the result set's gestalt
@@ -121,9 +127,10 @@ match and every graded result must have appeared in that recorded execution.
 
 Search history is retained indefinitely for internal search-quality work. The service
 does not persist request headers, user agents, or network addresses in these tables.
-`history export` pages through the durable records as JSONL, including ranked result
-snapshots. Historical query manifests can be replayed through normal search so each
-record captures current results under the same contract as future traffic.
+`history export` pages through the durable records as JSONL, including result-row IDs,
+ranked snapshots, and raw reranker scores. Historical query manifests can be replayed
+through normal search so each record captures current results under the same contract
+as future traffic.
 
 Use the durable export for retrieval analysis. Cloud Logging request lines are operational
 telemetry and do not preserve the execution-to-result relationship:
@@ -227,12 +234,13 @@ Every successful search response includes `X-Echo-Search-Execution-ID` and is st
 with its returned result snapshot. `GET /api/search-executions` returns stable ID-ordered
 pages of at most 500 records for evaluation exports.
 
-`POST /api/feedback` accepts an exact query, up to 20 unique result grades from 0 through
-10, and a required overall explanation of at most 2,000 characters. Grades may be empty
+`POST /api/feedback` accepts an exact query, up to 20 unique `{key, grade}` records from
+0 through 10, and a required overall explanation of at most 2,000 characters. Grades may be empty
 when the search returns no useful results. The API attributes feedback to the
 IAP-authenticated caller and optionally links it to a matching search execution.
-`GET /api/feedback` returns recent submissions newest-first. Each grade includes the
-result's title and browseable URL from its recorded search snapshot or current source.
+`GET /api/feedback` returns recent submissions newest-first. Each grade includes its
+grading key, source ID, title, and browseable URL from the recorded search snapshot or
+current source.
 The response also includes explanation-only submissions with an empty grade list.
 
 The dashboard is a Vue single-page app served from the same origin, with client-side

--- a/infra/echo/api/app.py
+++ b/infra/echo/api/app.py
@@ -183,6 +183,7 @@ class SearchReference(BaseModel):
 
 
 class SearchResult(BaseModel):
+    key: str | None = Field(default=None, description="Execution-specific key for grading this returned row.")
     id: str
     domain: search_config.SearchDomain
     title: str
@@ -219,13 +220,13 @@ class SearchConfiguration(BaseModel):
 
 
 class SearchFeedbackGrade(BaseModel):
-    result_id: str = Field(min_length=1, max_length=search_feedback.MAX_RESULT_ID_CHARACTERS)
+    key: str = Field(min_length=1, max_length=search_feedback.MAX_RESULT_KEY_CHARACTERS)
     grade: int = Field(ge=search_feedback.MIN_GRADE, le=search_feedback.MAX_GRADE)
 
-    @field_validator("result_id")
+    @field_validator("key")
     @classmethod
-    def validate_result_id(cls, result_id: str) -> str:
-        return search_feedback.checked_result_id(result_id)
+    def validate_key(cls, key: str) -> str:
+        return search_feedback.checked_result_key(key)
 
 
 class SearchFeedbackCreate(BaseModel):
@@ -245,8 +246,8 @@ class SearchFeedbackCreate(BaseModel):
     @field_validator("grades")
     @classmethod
     def reject_duplicate_results(cls, grades: list[SearchFeedbackGrade]) -> list[SearchFeedbackGrade]:
-        result_ids = [grade.result_id for grade in grades]
-        if len(result_ids) != len(set(result_ids)):
+        keys = [grade.key for grade in grades]
+        if len(keys) != len(set(keys)):
             raise ValueError("each result may be graded once per feedback submission")
         return grades
 
@@ -265,7 +266,10 @@ class SearchFeedbackEntry(SearchFeedbackCreate):
     author: str
 
 
-class SearchFeedbackResultGrade(SearchFeedbackGrade):
+class SearchFeedbackResultGrade(BaseModel):
+    key: str | None
+    source_id: str
+    grade: int
     title: str
     url: str
 
@@ -281,6 +285,7 @@ class SearchFeedbackListEntry(BaseModel):
 
 
 class SearchExecutionResultEntry(BaseModel):
+    id: int
     rank: int
     result_id: str
     domain: search_config.SearchDomain
@@ -290,6 +295,7 @@ class SearchExecutionResultEntry(BaseModel):
     score: float
     distance: float | None
     lexical_score: float | None
+    rerank_score: float | None
 
 
 class SearchExecutionEntry(BaseModel):
@@ -395,6 +401,16 @@ class SearchCandidate:
 @dataclass(frozen=True)
 class FeedbackResultMetadata:
     title: str
+    url: str
+
+
+@dataclass(frozen=True)
+class StoredFeedbackResult:
+    id: int
+    execution_id: int
+    source_id: str
+    domain: str
+    title: str | None
     url: str
 
 
@@ -549,6 +565,7 @@ def recorded_search_result(result: SearchResult) -> search_history.SearchResultR
         score=result.score,
         distance=result.distance,
         lexical_score=result.lexical_score,
+        rerank_score=result.rerank_score,
     )
 
 
@@ -563,6 +580,7 @@ def recorded_hit(result: Hit) -> search_history.SearchResultRecord:
         score=result.score,
         distance=result.distance,
         lexical_score=result.lexical_score,
+        rerank_score=None,
     )
 
 
@@ -587,7 +605,9 @@ def database_error_code(error: sqlalchemy.exc.DBAPIError) -> str | None:
     return None
 
 
-def record_live_search(engine: sqlalchemy.Engine, record: search_history.SearchExecutionRecord) -> int | None:
+def record_live_search(
+    engine: sqlalchemy.Engine, record: search_history.SearchExecutionRecord
+) -> search_history.StoredSearchExecution | None:
     """Persist a search, returning ``None`` only while its additive schema is unavailable."""
     try:
         with engine.begin() as conn:
@@ -603,10 +623,11 @@ def attach_search_execution(
     response: Response,
     engine: sqlalchemy.Engine,
     record: search_history.SearchExecutionRecord,
-) -> None:
-    execution_id = record_live_search(engine, record)
-    if execution_id is not None:
-        response.headers[SEARCH_EXECUTION_HEADER] = str(execution_id)
+) -> search_history.StoredSearchExecution | None:
+    execution = record_live_search(engine, record)
+    if execution is not None:
+        response.headers[SEARCH_EXECUTION_HEADER] = str(execution.id)
+    return execution
 
 
 def wiki_search_result(row: sqlalchemy.Row, config: EchoConfig) -> SearchResult:
@@ -732,20 +753,30 @@ def default_feedback_result_metadata(result_id: str, config: EchoConfig) -> Feed
     )
 
 
-def recorded_feedback_result_metadata(
-    conn: sqlalchemy.Connection, execution_ids: set[int]
-) -> dict[tuple[int, str], FeedbackResultMetadata]:
-    if not execution_ids:
+def stored_feedback_results(conn: sqlalchemy.Connection, search_result_ids: set[int]) -> dict[int, StoredFeedbackResult]:
+    if not search_result_ids:
         return {}
     rows = conn.execute(
         sqlalchemy.select(
+            schema.search_execution_results.c.id,
             schema.search_execution_results.c.execution_id,
             schema.search_execution_results.c.result_id,
+            schema.search_execution_results.c.domain,
             schema.search_execution_results.c.title,
             schema.search_execution_results.c.url,
-        ).where(schema.search_execution_results.c.execution_id.in_(execution_ids))
+        ).where(schema.search_execution_results.c.id.in_(search_result_ids))
     )
-    return {(row.execution_id, row.result_id): FeedbackResultMetadata(row.title or "", row.url) for row in rows}
+    return {
+        row.id: StoredFeedbackResult(
+            id=row.id,
+            execution_id=row.execution_id,
+            source_id=row.result_id,
+            domain=row.domain,
+            title=row.title,
+            url=row.url,
+        )
+        for row in rows
+    }
 
 
 def current_feedback_result_metadata(
@@ -873,7 +904,8 @@ def rerank_candidates(
     reranked = [
         result
         for result in reranked
-        if result.rerank_score is not None and result.rerank_score >= search_config.MIN_RERANK_SCORE
+        if result.rerank_score is not None
+        and result.rerank_score >= search_config.MIN_RERANK_SCORE_BY_DOMAIN[result.domain]
     ]
     reranked.sort(key=lambda result: (-result.score, result.domain, result.id))
     return reranked[:limit]
@@ -1099,7 +1131,7 @@ def federated_search_endpoint(
     domains = list(dict.fromkeys(domain or search_config.DEFAULT_SEARCH_DOMAINS))
     started_at = time.perf_counter()
     results = federated_search(engine, model, reranker, config, query, domains, limit)
-    attach_search_execution(
+    execution = attach_search_execution(
         response,
         engine,
         search_history.SearchExecutionRecord(
@@ -1116,7 +1148,13 @@ def federated_search_endpoint(
             results=tuple(recorded_search_result(result) for result in results),
         ),
     )
-    return results
+    if execution is None:
+        return results
+    assert len(execution.search_result_ids) == len(results)
+    return [
+        result.model_copy(update={"key": f"{result.domain}:{result_id}"})
+        for result, result_id in zip(results, execution.search_result_ids, strict=True)
+    ]
 
 
 @api.get("/grep", response_model=list[Hit])
@@ -1333,26 +1371,24 @@ def list_search_feedback(
             )
         )
 
-        execution_ids = {row.execution_id for row in feedback_rows if row.execution_id is not None}
-        exact_metadata = recorded_feedback_result_metadata(conn, execution_ids)
-        feedback_by_id = {row.id: row for row in feedback_rows}
-        missing_result_ids = set()
+        search_result_ids = {row.search_result_id for row in grade_rows if row.search_result_id is not None}
+        stored_results = stored_feedback_results(conn, search_result_ids)
+        missing_result_ids: set[str] = set()
         for grade in grade_rows:
-            feedback = feedback_by_id[grade.feedback_id]
-            exact = exact_metadata.get((feedback.execution_id, grade.result_id))
-            if exact is None or not exact.title:
+            stored = stored_results.get(grade.search_result_id)
+            if stored is None or not stored.title:
                 missing_result_ids.add(grade.result_id)
         current_metadata = current_feedback_result_metadata(conn, missing_result_ids, config)
 
     grades_by_feedback: dict[int, list[SearchFeedbackResultGrade]] = {}
     for grade in grade_rows:
-        feedback = feedback_by_id[grade.feedback_id]
+        stored = stored_results.get(grade.search_result_id)
         current = current_metadata.get(grade.result_id) or default_feedback_result_metadata(grade.result_id, config)
-        exact = exact_metadata.get((feedback.execution_id, grade.result_id))
-        metadata = FeedbackResultMetadata(exact.title or current.title, exact.url) if exact else current
+        metadata = FeedbackResultMetadata(stored.title or current.title, stored.url) if stored else current
         grades_by_feedback.setdefault(grade.feedback_id, []).append(
             SearchFeedbackResultGrade(
-                result_id=grade.result_id,
+                key=f"{stored.domain}:{stored.id}" if stored else None,
+                source_id=grade.result_id,
                 grade=grade.grade,
                 title=metadata.title,
                 url=metadata.url,
@@ -1376,50 +1412,61 @@ def add_search_feedback(
 ) -> SearchFeedbackEntry:
     """Store one query's optional note and per-result relevance grades."""
     author = iap_caller(x_goog_authenticated_user_email)
-    statement = (
-        schema.search_feedback.insert()
-        .values(
-            author=author,
-            query=feedback.query,
-            note=feedback.note,
-            execution_id=feedback.execution_id,
-        )
-        .returning(schema.search_feedback)
-    )
     with engine.begin() as conn:
-        if feedback.execution_id is not None:
+        parsed_keys = [search_feedback.result_key_parts(grade.key) for grade in feedback.grades]
+        stored_results = stored_feedback_results(conn, {result_id for _, result_id in parsed_keys})
+        invalid_keys = [
+            grade.key
+            for grade, (domain, result_id) in zip(feedback.grades, parsed_keys, strict=True)
+            if result_id not in stored_results or stored_results[result_id].domain != domain
+        ]
+        if invalid_keys:
+            raise HTTPException(422, "unknown search result keys: " + ", ".join(sorted(invalid_keys)))
+
+        execution_id = feedback.execution_id
+        graded_execution_ids = {result.execution_id for result in stored_results.values()}
+        if len(graded_execution_ids) > 1:
+            raise HTTPException(422, "graded search results must come from one execution")
+        if graded_execution_ids:
+            graded_execution_id = graded_execution_ids.pop()
+            if execution_id is not None and execution_id != graded_execution_id:
+                raise HTTPException(422, "graded search results were not returned by the linked search execution")
+            execution_id = graded_execution_id
+
+        if execution_id is not None:
             execution = conn.execute(
                 sqlalchemy.select(schema.search_executions.c.author, schema.search_executions.c.query).where(
-                    schema.search_executions.c.id == feedback.execution_id
+                    schema.search_executions.c.id == execution_id
                 )
             ).first()
             if execution is None:
-                raise HTTPException(422, f"no search execution {feedback.execution_id}")
+                raise HTTPException(422, f"no search execution {execution_id}")
             if execution.author != author or execution.query != feedback.query:
                 raise HTTPException(422, "execution_id must identify this caller's exact query")
-            if feedback.grades:
-                recorded_result_ids = set(
-                    conn.execute(
-                        sqlalchemy.select(schema.search_execution_results.c.result_id).where(
-                            schema.search_execution_results.c.execution_id == feedback.execution_id
-                        )
-                    ).scalars()
-                )
-                unrecorded_result_ids = {grade.result_id for grade in feedback.grades} - recorded_result_ids
-                if unrecorded_result_ids:
-                    raise HTTPException(
-                        422,
-                        "graded results were not returned by the linked search execution: "
-                        + ", ".join(sorted(unrecorded_result_ids)),
-                    )
+
+        statement = (
+            schema.search_feedback.insert()
+            .values(
+                author=author,
+                query=feedback.query,
+                note=feedback.note,
+                execution_id=execution_id,
+            )
+            .returning(schema.search_feedback)
+        )
         row = conn.execute(statement).first()
         assert row is not None
         if feedback.grades:
             conn.execute(
                 schema.search_feedback_grades.insert().values(
                     [
-                        {"feedback_id": row.id, "result_id": grade.result_id, "grade": grade.grade}
-                        for grade in feedback.grades
+                        {
+                            "feedback_id": row.id,
+                            "result_id": stored_results[result_id].source_id,
+                            "search_result_id": result_id,
+                            "grade": grade.grade,
+                        }
+                        for grade, (_, result_id) in zip(feedback.grades, parsed_keys, strict=True)
                     ]
                 )
             )
@@ -1430,7 +1477,7 @@ def add_search_feedback(
         query=feedback.query,
         grades=feedback.grades,
         note=feedback.note,
-        execution_id=feedback.execution_id,
+        execution_id=execution_id,
     )
 
 

--- a/infra/echo/api/app.py
+++ b/infra/echo/api/app.py
@@ -414,6 +414,12 @@ class StoredFeedbackResult:
     url: str
 
 
+@dataclass(frozen=True)
+class StoredFeedbackGrade:
+    result: StoredFeedbackResult
+    grade: int
+
+
 class RerankerModel(Protocol):
     def rerank(self, query: str, documents: Iterable[str], batch_size: int) -> Iterable[float]: ...
 
@@ -777,6 +783,53 @@ def stored_feedback_results(conn: sqlalchemy.Connection, search_result_ids: set[
         )
         for row in rows
     }
+
+
+def resolve_feedback_grades(
+    conn: sqlalchemy.Connection,
+    grades: list[SearchFeedbackGrade],
+    execution_id: int | None,
+) -> tuple[tuple[StoredFeedbackGrade, ...], int | None]:
+    parsed = [(grade, *search_feedback.result_key_parts(grade.key)) for grade in grades]
+    stored_results = stored_feedback_results(conn, {result_id for _, _, result_id in parsed})
+    invalid_keys = [
+        grade.key
+        for grade, domain, result_id in parsed
+        if result_id not in stored_results or stored_results[result_id].domain != domain
+    ]
+    if invalid_keys:
+        raise HTTPException(422, "unknown search result keys: " + ", ".join(sorted(invalid_keys)))
+
+    resolved = tuple(StoredFeedbackGrade(stored_results[result_id], grade.grade) for grade, _, result_id in parsed)
+    graded_execution_ids = {grade.result.execution_id for grade in resolved}
+    if len(graded_execution_ids) > 1:
+        raise HTTPException(422, "graded search results must come from one execution")
+    if not graded_execution_ids:
+        return resolved, execution_id
+
+    graded_execution_id = graded_execution_ids.pop()
+    if execution_id is not None and execution_id != graded_execution_id:
+        raise HTTPException(422, "graded search results were not returned by the linked search execution")
+    return resolved, graded_execution_id
+
+
+def validate_feedback_execution(
+    conn: sqlalchemy.Connection,
+    execution_id: int | None,
+    author: str,
+    query: str,
+) -> None:
+    if execution_id is None:
+        return
+    execution = conn.execute(
+        sqlalchemy.select(schema.search_executions.c.author, schema.search_executions.c.query).where(
+            schema.search_executions.c.id == execution_id
+        )
+    ).first()
+    if execution is None:
+        raise HTTPException(422, f"no search execution {execution_id}")
+    if execution.author != author or execution.query != query:
+        raise HTTPException(422, "execution_id must identify this caller's exact query")
 
 
 def current_feedback_result_metadata(
@@ -1413,36 +1466,8 @@ def add_search_feedback(
     """Store one query's optional note and per-result relevance grades."""
     author = iap_caller(x_goog_authenticated_user_email)
     with engine.begin() as conn:
-        parsed_keys = [search_feedback.result_key_parts(grade.key) for grade in feedback.grades]
-        stored_results = stored_feedback_results(conn, {result_id for _, result_id in parsed_keys})
-        invalid_keys = [
-            grade.key
-            for grade, (domain, result_id) in zip(feedback.grades, parsed_keys, strict=True)
-            if result_id not in stored_results or stored_results[result_id].domain != domain
-        ]
-        if invalid_keys:
-            raise HTTPException(422, "unknown search result keys: " + ", ".join(sorted(invalid_keys)))
-
-        execution_id = feedback.execution_id
-        graded_execution_ids = {result.execution_id for result in stored_results.values()}
-        if len(graded_execution_ids) > 1:
-            raise HTTPException(422, "graded search results must come from one execution")
-        if graded_execution_ids:
-            graded_execution_id = graded_execution_ids.pop()
-            if execution_id is not None and execution_id != graded_execution_id:
-                raise HTTPException(422, "graded search results were not returned by the linked search execution")
-            execution_id = graded_execution_id
-
-        if execution_id is not None:
-            execution = conn.execute(
-                sqlalchemy.select(schema.search_executions.c.author, schema.search_executions.c.query).where(
-                    schema.search_executions.c.id == execution_id
-                )
-            ).first()
-            if execution is None:
-                raise HTTPException(422, f"no search execution {execution_id}")
-            if execution.author != author or execution.query != feedback.query:
-                raise HTTPException(422, "execution_id must identify this caller's exact query")
+        resolved_grades, execution_id = resolve_feedback_grades(conn, feedback.grades, feedback.execution_id)
+        validate_feedback_execution(conn, execution_id, author, feedback.query)
 
         statement = (
             schema.search_feedback.insert()
@@ -1456,17 +1481,17 @@ def add_search_feedback(
         )
         row = conn.execute(statement).first()
         assert row is not None
-        if feedback.grades:
+        if resolved_grades:
             conn.execute(
                 schema.search_feedback_grades.insert().values(
                     [
                         {
                             "feedback_id": row.id,
-                            "result_id": stored_results[result_id].source_id,
-                            "search_result_id": result_id,
+                            "result_id": grade.result.source_id,
+                            "search_result_id": grade.result.id,
                             "grade": grade.grade,
                         }
-                        for grade, (_, result_id) in zip(feedback.grades, parsed_keys, strict=True)
+                        for grade in resolved_grades
                     ]
                 )
             )

--- a/infra/echo/api/test_app.py
+++ b/infra/echo/api/test_app.py
@@ -911,6 +911,7 @@ def test_reranker_applies_stricter_wiki_quality_floor():
 
     class WeakReranker:
         def rerank(self, _query, documents, batch_size):
+            del batch_size
             return [-1.5 for _ in documents]
 
     results = echo.rerank_candidates(candidates, "how do i deploy iris", WeakReranker(), 2)

--- a/infra/echo/api/test_app.py
+++ b/infra/echo/api/test_app.py
@@ -46,7 +46,8 @@ class FakeConn:
         if getattr(statement, "is_insert", False) and statement.table.name == "search_executions":
             return FakeResult([make_row(id=991)])
         if getattr(statement, "is_insert", False) and statement.table.name == "search_execution_results":
-            return FakeResult([])
+            ranks = sorted(value for key, value in statement.compile().params.items() if key.startswith("rank_m"))
+            return FakeResult([make_row(id=1000 + rank, rank=rank) for rank in ranks])
         if self._responses:
             return FakeResult(self._responses.pop(0))
         return FakeResult(self._rows)
@@ -221,15 +222,35 @@ def test_add_search_feedback_persists_authenticated_replayable_judgments(client_
         author="agent@openathena.ai",
         query="how do I deploy Iris?",
         note="Wiki result was unrelated.",
+        execution_id=991,
     )
-    harness = client_with([row])
+    stored_results = [
+        make_row(
+            id=730,
+            execution_id=991,
+            result_id="wiki:123",
+            domain="wiki",
+            title="Stale Iris deployment notes",
+            url="https://echo.oa.dev/wiki/123",
+        ),
+        make_row(
+            id=731,
+            execution_id=991,
+            result_id="file:lib/iris/OPS.md",
+            domain="file",
+            title="Iris Operations",
+            url="https://example.com/OPS.md",
+        ),
+    ]
+    execution = make_row(author="agent@openathena.ai", query="how do I deploy Iris?")
+    harness = client_with([row], responses=[stored_results, [execution]])
     response = harness.client.post(
         "/api/feedback",
         json={
             "query": "  how do I deploy Iris?  ",
             "grades": [
-                {"result_id": "wiki:123", "grade": 0},
-                {"result_id": "file:lib/iris/OPS.md", "grade": 10},
+                {"key": "wiki:730", "grade": 0},
+                {"key": "file:731", "grade": 10},
             ],
             "note": "  Wiki result was unrelated.  ",
         },
@@ -243,11 +264,11 @@ def test_add_search_feedback_persists_authenticated_replayable_judgments(client_
         "author": "agent@openathena.ai",
         "query": "how do I deploy Iris?",
         "grades": [
-            {"result_id": "wiki:123", "grade": 0},
-            {"result_id": "file:lib/iris/OPS.md", "grade": 10},
+            {"key": "wiki:730", "grade": 0},
+            {"key": "file:731", "grade": 10},
         ],
         "note": "Wiki result was unrelated.",
-        "execution_id": None,
+        "execution_id": 991,
     }
     feedback_params = harness.engine.executions[-2].compile().params
     assert feedback_params["author"] == "agent@openathena.ai"
@@ -257,9 +278,11 @@ def test_add_search_feedback_persists_authenticated_replayable_judgments(client_
     assert grade_params == {
         "feedback_id_m0": 17,
         "result_id_m0": "wiki:123",
+        "search_result_id_m0": 730,
         "grade_m0": 0,
         "feedback_id_m1": 17,
         "result_id_m1": "file:lib/iris/OPS.md",
+        "search_result_id_m1": 731,
         "grade_m1": 10,
     }
 
@@ -274,14 +297,22 @@ def test_search_feedback_links_matching_execution(client_with):
         note="The file answered it.",
         execution_id=991,
     )
-    harness = client_with([feedback], responses=[[execution], [["file:lib/iris/OPS.md"]]])
+    stored_result = make_row(
+        id=731,
+        execution_id=991,
+        result_id="file:lib/iris/OPS.md",
+        domain="file",
+        title="Iris Operations",
+        url="https://example.com/OPS.md",
+    )
+    harness = client_with([feedback], responses=[[stored_result], [execution]])
 
     response = harness.client.post(
         "/api/feedback",
         json={
             "query": "how do I deploy Iris?",
             "execution_id": 991,
-            "grades": [{"result_id": "file:lib/iris/OPS.md", "grade": 10}],
+            "grades": [{"key": "file:731", "grade": 10}],
             "note": "The file answered it.",
         },
         headers={"X-Goog-Authenticated-User-Email": "accounts.google.com:agent@openathena.ai"},
@@ -317,19 +348,28 @@ def test_search_feedback_list_includes_linked_results_and_explanation_only_entri
         ),
     ]
     grade_rows = [
-        make_row(feedback_id=17, result_id="file:lib/iris/OPS.md", grade=10),
-        make_row(feedback_id=17, result_id="wiki:123", grade=0),
+        make_row(feedback_id=17, result_id="file:lib/iris/OPS.md", search_result_id=731, grade=10),
+        make_row(feedback_id=17, result_id="wiki:123", search_result_id=730, grade=0),
     ]
     execution_result_rows = [
         make_row(
+            id=731,
             execution_id=991,
             result_id="file:lib/iris/OPS.md",
+            domain="file",
             title="Iris Operations",
             url="https://github.com/marin-community/marin/blob/abc/lib/iris/OPS.md",
-        )
+        ),
+        make_row(
+            id=730,
+            execution_id=991,
+            result_id="wiki:123",
+            domain="wiki",
+            title="Stale Iris deployment notes",
+            url="https://echo.oa.dev/wiki/123",
+        ),
     ]
-    wiki_rows = [make_row(id=123, title="Stale Iris deployment notes")]
-    harness = client_with([], responses=[feedback_rows, grade_rows, execution_result_rows, wiki_rows])
+    harness = client_with([], responses=[feedback_rows, grade_rows, execution_result_rows])
 
     response = harness.client.get("/api/feedback", params={"days": 30, "limit": 20})
 
@@ -353,13 +393,15 @@ def test_search_feedback_list_includes_linked_results_and_explanation_only_entri
             "execution_id": 991,
             "grades": [
                 {
-                    "result_id": "file:lib/iris/OPS.md",
+                    "key": "file:731",
+                    "source_id": "file:lib/iris/OPS.md",
                     "grade": 10,
                     "title": "Iris Operations",
                     "url": "https://github.com/marin-community/marin/blob/abc/lib/iris/OPS.md",
                 },
                 {
-                    "result_id": "wiki:123",
+                    "key": "wiki:730",
+                    "source_id": "wiki:123",
                     "grade": 0,
                     "title": "Stale Iris deployment notes",
                     "url": "https://echo.oa.dev/wiki/123",
@@ -370,15 +412,14 @@ def test_search_feedback_list_includes_linked_results_and_explanation_only_entri
 
 
 def test_search_feedback_rejects_grade_absent_from_linked_execution(client_with):
-    execution = make_row(author="agent@openathena.ai", query="how do I deploy Iris?")
-    harness = client_with([], responses=[[execution], [["file:lib/iris/OPS.md"]]])
+    harness = client_with([], responses=[[]])
 
     response = harness.client.post(
         "/api/feedback",
         json={
             "query": "how do I deploy Iris?",
             "execution_id": 991,
-            "grades": [{"result_id": "wiki:123", "grade": 0}],
+            "grades": [{"key": "wiki:730", "grade": 0}],
             "note": "This was not in the recorded result set.",
         },
         headers={"X-Goog-Authenticated-User-Email": "accounts.google.com:agent@openathena.ai"},
@@ -409,6 +450,7 @@ def test_search_execution_export_preserves_result_rank(client_with):
     )
     result_rows = [
         make_row(
+            id=731,
             execution_id=41,
             rank=1,
             result_id="file:lib/iris/OPS.md",
@@ -419,8 +461,10 @@ def test_search_execution_export_preserves_result_rank(client_with):
             score=0.9,
             distance=0.1,
             lexical_score=1.2,
+            rerank_score=4.2,
         ),
         make_row(
+            id=732,
             execution_id=41,
             rank=2,
             result_id="wiki:12",
@@ -431,6 +475,7 @@ def test_search_execution_export_preserves_result_rank(client_with):
             score=0.8,
             distance=0.2,
             lexical_score=None,
+            rerank_score=-0.5,
         ),
     ]
     harness = client_with([], responses=[[execution], result_rows])
@@ -442,6 +487,7 @@ def test_search_execution_export_preserves_result_rank(client_with):
         (1, "file:lib/iris/OPS.md"),
         (2, "wiki:12"),
     ]
+    assert [(result.id, result.rerank_score) for result in entries[0].results] == [(731, 4.2), (732, -0.5)]
 
 
 def test_search_feedback_rejects_out_of_range_grade(client_with):
@@ -450,7 +496,7 @@ def test_search_feedback_rejects_out_of_range_grade(client_with):
         "/api/feedback",
         json={
             "query": "scheduler",
-            "grades": [{"result_id": "wiki:123", "grade": 11}],
+            "grades": [{"key": "wiki:730", "grade": 11}],
             "note": "The result looked relevant.",
         },
     )
@@ -459,7 +505,7 @@ def test_search_feedback_rejects_out_of_range_grade(client_with):
     assert harness.engine.executions == []
 
 
-def test_search_feedback_rejects_result_id_outside_bigint_range(client_with):
+def test_search_feedback_rejects_result_key_outside_bigint_range(client_with):
     row = make_row(
         id=19,
         created_at=datetime(2026, 8, 14, tzinfo=UTC),
@@ -473,7 +519,7 @@ def test_search_feedback_rejects_result_id_outside_bigint_range(client_with):
         "/api/feedback",
         json={
             "query": "scheduler",
-            "grades": [{"result_id": "wiki:9223372036854775808", "grade": 5}],
+            "grades": [{"key": "wiki:9223372036854775808", "grade": 5}],
             "note": "The result looked relevant.",
         },
     )
@@ -486,7 +532,7 @@ def test_search_feedback_requires_overall_explanation(client_with):
     harness = client_with([])
     response = harness.client.post(
         "/api/feedback",
-        json={"query": "scheduler", "grades": [{"result_id": "wiki:123", "grade": 5}]},
+        json={"query": "scheduler", "grades": [{"key": "wiki:730", "grade": 5}]},
     )
 
     assert response.status_code == 422
@@ -616,6 +662,7 @@ def test_federated_search_classifies_github_comment_domain(client_with):
     )
     assert [result.model_dump(mode="json") for result in results] == [
         {
+            "key": None,
             "id": "pr:8",
             "domain": "pr",
             "title": "Scheduler discussion",
@@ -659,6 +706,7 @@ def test_federated_file_result_names_exact_indexed_head(client_with):
     assert response.headers[echo.SEARCH_EXECUTION_HEADER] == "991"
     assert response.json() == [
         {
+            "key": "file:1001",
             "id": "file:lib/iris/src/iris/scheduler.py",
             "domain": "file",
             "title": "scheduler.py",
@@ -712,6 +760,7 @@ def test_federated_file_result_names_exact_indexed_head(client_with):
     )
     assert result_insert.compile().params["result_id_m0"] == "file:lib/iris/src/iris/scheduler.py"
     assert result_insert.compile().params["rank_m0"] == 1
+    assert result_insert.compile().params["rerank_score_m0"] == 0.0
 
 
 def test_file_summary_skips_license_boilerplate_for_filename_match():
@@ -839,6 +888,34 @@ def test_reranker_suppresses_all_candidates_below_the_quality_floor(monkeypatch)
     ]
 
     assert echo.rerank_candidates(candidates, "how do i deploy iris", RejectingReranker(), 3) == []
+
+
+def test_reranker_applies_stricter_wiki_quality_floor():
+    candidates = [
+        echo.SearchCandidate(
+            echo.SearchResult(
+                id=f"{domain}:123",
+                domain=domain,
+                title="Related result",
+                subtitle="",
+                url="https://example.com/result",
+                snippet="Related result",
+                score=0.1,
+                distance=0.2,
+                lexical_score=None,
+            ),
+            "Only weakly related to the query.",
+        )
+        for domain in ("wiki", "file")
+    ]
+
+    class WeakReranker:
+        def rerank(self, _query, documents, batch_size):
+            return [-1.5 for _ in documents]
+
+    results = echo.rerank_candidates(candidates, "how do i deploy iris", WeakReranker(), 2)
+
+    assert [result.domain for result in results] == ["file"]
 
 
 def test_file_artifact_reconstructs_overlapping_indexed_chunks(client_with):

--- a/infra/echo/cli.py
+++ b/infra/echo/cli.py
@@ -15,7 +15,7 @@ ambient service-account credentials with no login. See ``infra/echo/README.md``.
 
     uv run infra/echo/cli.py search "expert parallel MoE MFU on B200" --limit 10
     uv run infra/echo/cli.py get file:lib/iris/OPS.md
-    uv run infra/echo/cli.py feedback --query "deploy iris" --grade file:lib/iris/OPS.md=10
+    uv run infra/echo/cli.py feedback --query "deploy iris" --grade file:731=10
     uv run infra/echo/cli.py grep ragged_all_to_all --source discord
     uv run infra/echo/cli.py wiki search "grafana access" --tag ops
     uv run infra/echo/cli.py wiki add --file note.md          # OKF: frontmatter title/use_when + body
@@ -170,20 +170,22 @@ def print_search_results(results: list[SearchResult]) -> None:
         print("No results.")
         return
 
+    keys = [result.key or "unavailable" for result in results]
     ids = [result.id for result in results]
     titles = [one_line(result.title) for result in results]
+    key_width = max(len("KEY"), *(len(value) for value in keys))
     id_width = max(len("ID"), *(len(value) for value in ids))
-    available = max(40, shutil.get_terminal_size(fallback=(160, 24)).columns - id_width - 4)
+    available = max(40, shutil.get_terminal_size(fallback=(160, 24)).columns - key_width - id_width - 6)
     title_width = min(max(len("TITLE"), *(len(value) for value in titles)), 36, max(16, available // 3))
     detail_width = max(20, available - title_width)
-    print(f"{'ID':<{id_width}}  {'TITLE':<{title_width}}  DETAIL")
-    for result in results:
+    print(f"{'KEY':<{key_width}}  {'ID':<{id_width}}  {'TITLE':<{title_width}}  DETAIL")
+    for result, key in zip(results, keys, strict=True):
         if result.references:
             detail = " · ".join(f"L{reference.line} {reference.text}" for reference in result.references)
         else:
             detail = result.subtitle if result.domain == "wiki" else result.snippet
         print(
-            f"{result.id:<{id_width}}  "
+            f"{key:<{key_width}}  {result.id:<{id_width}}  "
             f"{truncate_cell(one_line(result.title), title_width):<{title_width}}  "
             f"{truncate_cell(one_line(detail), detail_width)}"
         )
@@ -237,7 +239,7 @@ def cmd_search(args: argparse.Namespace) -> None:
     print(
         "Feedback: uv run infra/echo/cli.py feedback "
         f"--query {shlex.quote(args.query)} {execution_flag}"
-        f"--grade '<id>=<{search_feedback.MIN_GRADE}-{search_feedback.MAX_GRADE}>' "
+        f"--grade '<key>=<{search_feedback.MIN_GRADE}-{search_feedback.MAX_GRADE}>' "
         "<<< 'brief overall assessment'"
     )
 
@@ -261,7 +263,7 @@ def cmd_feedback(args: argparse.Namespace) -> None:
         raise SystemExit("provide a short overall explanation on stdin")
     body = {
         "query": args.query,
-        "grades": [{"result_id": grade.result_id, "grade": grade.grade} for grade in args.grade],
+        "grades": [{"key": grade.key, "grade": grade.grade} for grade in args.grade],
         "note": note,
     }
     if args.execution_id is not None:
@@ -405,7 +407,7 @@ def nonblank(value: str) -> str:
 
 def artifact_id(value: str) -> str:
     try:
-        return search_feedback.checked_result_id(value)
+        return search_feedback.checked_artifact_id(value)
     except ValueError as error:
         raise argparse.ArgumentTypeError(str(error)) from error
 
@@ -445,7 +447,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         type=feedback_grade,
         default=[],
-        metavar=f"<result-id>=<{search_feedback.MIN_GRADE}-{search_feedback.MAX_GRADE}>",
+        metavar=f"<result-key>=<{search_feedback.MIN_GRADE}-{search_feedback.MAX_GRADE}>",
         help="grade one result; repeat as needed (a short overall explanation is read from stdin)",
     )
     feedback.add_argument("--execution-id", type=int, help="execution ID printed by the corresponding search")

--- a/infra/echo/dashboard/src/types.ts
+++ b/infra/echo/dashboard/src/types.ts
@@ -43,6 +43,7 @@ export interface SearchConfiguration {
 }
 
 export interface FederatedResult {
+  key: string | null
   id: string
   domain: SearchDomain
   title: string
@@ -85,7 +86,8 @@ export interface WorkLogEntry extends WorkLogSummary {
 }
 
 export interface SearchFeedbackResultGrade {
-  result_id: string
+  key: string | null
+  source_id: string
   grade: number
   title: string
   url: string

--- a/infra/echo/dashboard/src/views/FeedbackView.vue
+++ b/infra/echo/dashboard/src/views/FeedbackView.vue
@@ -55,7 +55,7 @@ onMounted(load)
           <p class="font-medium leading-5 text-ink/80">{{ entry.query }}</p>
           <p class="mt-1 leading-5 text-ink/50">{{ entry.note }}</p>
           <div v-if="entry.grades.length" class="mt-4 divide-y divide-line/70 border-y border-line/70">
-            <div v-for="result in entry.grades" :key="result.result_id" class="flex items-start gap-3 py-3">
+            <div v-for="result in entry.grades" :key="result.key || result.source_id" class="flex items-start gap-3 py-3">
               <span
                 class="inline-flex min-w-9 shrink-0 justify-center rounded-full px-2 py-1 font-mono text-xs font-semibold"
                 :class="gradeClass(result.grade)"
@@ -66,7 +66,7 @@ onMounted(load)
                 <a class="font-semibold leading-5 hover:text-moss" :href="result.url" rel="noreferrer" target="_blank">
                   {{ result.title }}
                 </a>
-                <span class="mt-1 block truncate font-mono text-[11px] text-ink/35">{{ result.result_id }}</span>
+                <span class="mt-1 block truncate font-mono text-[11px] text-ink/35">{{ result.key || result.source_id }}</span>
               </div>
             </div>
           </div>
@@ -97,7 +97,12 @@ onMounted(load)
               <td class="max-w-44 truncate px-3 py-4 text-xs text-ink/50">{{ entry.author }}</td>
               <td class="px-3 py-4 text-xs text-ink/45">{{ formatDateTime(entry.created_at) }}</td>
             </tr>
-            <tr v-for="(result, index) in entry.grades" v-else :key="result.result_id" class="align-top hover:bg-white/35">
+            <tr
+              v-for="(result, index) in entry.grades"
+              v-else
+              :key="result.key || result.source_id"
+              class="align-top hover:bg-white/35"
+            >
               <td class="px-3 py-4">
                 <span
                   class="inline-flex min-w-9 justify-center rounded-full px-2 py-1 font-mono text-xs font-semibold"
@@ -110,7 +115,7 @@ onMounted(load)
                 <a class="line-clamp-2 font-semibold leading-5 hover:text-moss" :href="result.url" rel="noreferrer" target="_blank">
                   {{ result.title }}
                 </a>
-                <span class="mt-1 block truncate font-mono text-[11px] text-ink/35">{{ result.result_id }}</span>
+                <span class="mt-1 block truncate font-mono text-[11px] text-ink/35">{{ result.key || result.source_id }}</span>
               </td>
               <td v-if="index === 0" class="px-3 py-4" :rowspan="entry.grades.length">
                 <p class="font-medium leading-5 text-ink/80">{{ entry.query }}</p>

--- a/infra/echo/migrations/m0012_search_result_keys.py
+++ b/infra/echo/migrations/m0012_search_result_keys.py
@@ -1,0 +1,41 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Give stored search results durable grading keys and retain reranker scores."""
+
+import sqlalchemy
+
+DDL = """
+ALTER TABLE search_execution_results
+    ADD COLUMN id BIGINT GENERATED ALWAYS AS IDENTITY;
+ALTER TABLE search_execution_results
+    DROP CONSTRAINT search_execution_results_pkey;
+ALTER TABLE search_execution_results
+    ADD PRIMARY KEY (id);
+ALTER TABLE search_execution_results
+    ADD CONSTRAINT search_execution_results_execution_rank UNIQUE (execution_id, rank);
+ALTER TABLE search_execution_results
+    ADD COLUMN rerank_score DOUBLE PRECISION;
+
+ALTER TABLE search_feedback_grades
+    ADD COLUMN search_result_id BIGINT REFERENCES search_execution_results(id) ON DELETE SET NULL;
+UPDATE search_feedback_grades AS grade
+SET search_result_id = result.id
+FROM search_feedback AS feedback, search_execution_results AS result
+WHERE feedback.id = grade.feedback_id
+  AND result.execution_id = feedback.execution_id
+  AND result.result_id = grade.result_id;
+ALTER TABLE search_feedback_grades
+    ADD CONSTRAINT search_feedback_grades_search_result UNIQUE (feedback_id, search_result_id);
+CREATE INDEX idx_search_feedback_grades_search_result_id
+    ON search_feedback_grades (search_result_id);
+
+GRANT USAGE, SELECT ON SEQUENCE search_execution_results_id_seq
+    TO "echo-api@hai-gcp-models.iam";
+"""
+
+
+def upgrade(conn: sqlalchemy.Connection) -> None:
+    for statement in DDL.strip().split(";"):
+        if statement.strip():
+            conn.execute(sqlalchemy.text(statement))

--- a/infra/echo/schema.py
+++ b/infra/echo/schema.py
@@ -205,13 +205,14 @@ search_executions = Table(
 search_execution_results = Table(
     "search_execution_results",
     metadata,
+    Column("id", BigInteger, Identity(always=True), primary_key=True),
     Column(
         "execution_id",
         BigInteger,
         ForeignKey("search_executions.id", ondelete="CASCADE"),
-        primary_key=True,
+        nullable=False,
     ),
-    Column("rank", SmallInteger, primary_key=True),
+    Column("rank", SmallInteger, nullable=False),
     Column("result_id", Text, nullable=False),
     Column("domain", Text, nullable=False),
     Column("title", Text),
@@ -220,6 +221,8 @@ search_execution_results = Table(
     Column("score", Float, nullable=False),
     Column("distance", Float),
     Column("lexical_score", Float),
+    Column("rerank_score", Float),
+    UniqueConstraint("execution_id", "rank", name="search_execution_results_execution_rank"),
     CheckConstraint("rank > 0", name="search_execution_results_rank_positive"),
     CheckConstraint(
         "domain IN ('wiki', 'file', 'discord', 'pr', 'issue')",
@@ -246,12 +249,19 @@ search_feedback_grades = Table(
     metadata,
     Column("feedback_id", BigInteger, ForeignKey("search_feedback.id", ondelete="CASCADE"), primary_key=True),
     Column("result_id", Text, primary_key=True),
+    Column(
+        "search_result_id",
+        BigInteger,
+        ForeignKey("search_execution_results.id", ondelete="SET NULL"),
+    ),
     Column("grade", SmallInteger, nullable=False),
     CheckConstraint(
         f"grade BETWEEN {SEARCH_FEEDBACK_MIN_GRADE} AND {SEARCH_FEEDBACK_MAX_GRADE}",
         name="search_feedback_grades_range",
     ),
     Index("idx_search_feedback_grades_result_id", "result_id"),
+    UniqueConstraint("feedback_id", "search_result_id", name="search_feedback_grades_search_result"),
+    Index("idx_search_feedback_grades_search_result_id", "search_result_id"),
 )
 
 wiki_entries = Table(

--- a/infra/echo/search_config.py
+++ b/infra/echo/search_config.py
@@ -52,7 +52,15 @@ RERANK_MAX_CANDIDATES = 20
 RERANK_BATCH_SIZE = 4
 RERANK_BASE_WEIGHT = 0.2
 RERANK_MODEL_WEIGHT = 0.8
-MIN_RERANK_SCORE = -2.0
+MIN_RERANK_SCORE_BY_DOMAIN: Mapping[SearchDomain, float] = MappingProxyType(
+    {
+        "wiki": -1.0,
+        "file": -2.0,
+        "discord": -2.0,
+        "pr": -2.0,
+        "issue": -2.0,
+    }
+)
 PROSE_FILE_SUFFIXES = (".md", ".rst")
 IDENTIFIER_QUERY_PATTERN = re.compile(r"[/_.:]|(?:[a-z][A-Z])|(?:^|\s)--?[a-z0-9]")
 QUERY_WORD_PATTERN = re.compile(r"[a-z0-9]+")

--- a/infra/echo/search_feedback.py
+++ b/infra/echo/search_feedback.py
@@ -9,19 +9,20 @@ import search_config
 
 MAX_QUERY_CHARACTERS = 2_000
 MAX_NOTE_CHARACTERS = 2_000
-MAX_RESULT_ID_CHARACTERS = 4_096
+MAX_RESULT_KEY_CHARACTERS = 32
+MAX_ARTIFACT_ID_CHARACTERS = 4_096
 MAX_GRADES = search_config.RERANK_MAX_CANDIDATES
 MAX_NUMERIC_RESULT_ID = 2**63 - 1
 MIN_GRADE = search_config.SEARCH_FEEDBACK_MIN_GRADE
 MAX_GRADE = search_config.SEARCH_FEEDBACK_MAX_GRADE
 
 
-def checked_result_id(value: str) -> str:
+def checked_artifact_id(value: str) -> str:
     domain, separator, detail = value.partition(":")
     if not separator or domain not in search_config.SEARCH_DOMAINS or not detail:
         raise ValueError("must be <wiki|file|discord|pr|issue>:<id>")
-    if len(value) > MAX_RESULT_ID_CHARACTERS:
-        raise ValueError(f"must be at most {MAX_RESULT_ID_CHARACTERS} characters")
+    if len(value) > MAX_ARTIFACT_ID_CHARACTERS:
+        raise ValueError(f"must be at most {MAX_ARTIFACT_ID_CHARACTERS} characters")
     if domain != "file":
         if not detail.isdecimal():
             raise ValueError(f"{domain} result IDs are numeric")
@@ -30,21 +31,40 @@ def checked_result_id(value: str) -> str:
     return value
 
 
+def checked_result_key(value: str) -> str:
+    domain, separator, detail = value.partition(":")
+    if not separator or domain not in search_config.SEARCH_DOMAINS or not detail:
+        raise ValueError("must be <wiki|file|discord|pr|issue>:<numeric-key>")
+    if len(value) > MAX_RESULT_KEY_CHARACTERS:
+        raise ValueError(f"must be at most {MAX_RESULT_KEY_CHARACTERS} characters")
+    if not detail.isdecimal():
+        raise ValueError("search result keys are numeric")
+    if not 0 < int(detail) <= MAX_NUMERIC_RESULT_ID:
+        raise ValueError("search result keys must be positive signed 64-bit integers")
+    return value
+
+
+def result_key_parts(value: str) -> tuple[str, int]:
+    checked_result_key(value)
+    domain, _, detail = value.partition(":")
+    return domain, int(detail)
+
+
 @dataclass(frozen=True)
 class FeedbackGrade:
-    result_id: str
+    key: str
     grade: int
 
     @classmethod
     def from_spec(cls, value: str) -> "FeedbackGrade":
-        result_id, separator, grade_text = value.rpartition("=")
+        key, separator, grade_text = value.rpartition("=")
         if not separator:
-            raise ValueError(f"must be <result-id>=<{MIN_GRADE}-{MAX_GRADE}>")
-        checked_result_id(result_id)
+            raise ValueError(f"must be <result-key>=<{MIN_GRADE}-{MAX_GRADE}>")
+        checked_result_key(key)
         try:
             grade = int(grade_text)
         except ValueError as error:
             raise ValueError(f"grade must be an integer from {MIN_GRADE} through {MAX_GRADE}") from error
         if not MIN_GRADE <= grade <= MAX_GRADE:
             raise ValueError(f"grade must be an integer from {MIN_GRADE} through {MAX_GRADE}")
-        return cls(result_id=result_id, grade=grade)
+        return cls(key=key, grade=grade)

--- a/infra/echo/search_history.py
+++ b/infra/echo/search_history.py
@@ -23,6 +23,13 @@ class SearchResultRecord:
     score: float
     distance: float | None
     lexical_score: float | None
+    rerank_score: float | None
+
+
+@dataclass(frozen=True)
+class StoredSearchExecution:
+    id: int
+    search_result_ids: tuple[int, ...]
 
 
 @dataclass(frozen=True)
@@ -56,20 +63,22 @@ def execution_values(record: SearchExecutionRecord) -> dict[str, object]:
     }
 
 
-def insert_execution(conn: sqlalchemy.Connection, record: SearchExecutionRecord) -> int:
+def insert_execution(conn: sqlalchemy.Connection, record: SearchExecutionRecord) -> StoredSearchExecution:
     """Insert one execution and its ranked result snapshot.
 
     Returns:
-        The new search execution ID.
+        The new search execution and its result-row IDs in rank order.
     """
     row = conn.execute(
         schema.search_executions.insert().values(**execution_values(record)).returning(schema.search_executions.c.id)
     ).first()
     assert row is not None
     execution_id = row.id
+    search_result_ids: tuple[int, ...] = ()
     if record.results:
-        conn.execute(
-            schema.search_execution_results.insert().values(
+        stored_results = conn.execute(
+            schema.search_execution_results.insert()
+            .values(
                 [
                     {
                         "execution_id": execution_id,
@@ -82,9 +91,12 @@ def insert_execution(conn: sqlalchemy.Connection, record: SearchExecutionRecord)
                         "score": result.score,
                         "distance": result.distance,
                         "lexical_score": result.lexical_score,
+                        "rerank_score": result.rerank_score,
                     }
                     for rank, result in enumerate(record.results, start=1)
                 ]
             )
-        )
-    return execution_id
+            .returning(schema.search_execution_results.c.id, schema.search_execution_results.c.rank)
+        ).all()
+        search_result_ids = tuple(row.id for row in sorted(stored_results, key=lambda row: row.rank))
+    return StoredSearchExecution(execution_id, search_result_ids)

--- a/infra/echo/search_result.py
+++ b/infra/echo/search_result.py
@@ -33,6 +33,7 @@ class SearchResult:
     score: float
     distance: float | None
     lexical_score: float | None
+    key: str | None = None
     references: tuple[SearchReference, ...] = ()
 
     @classmethod
@@ -50,6 +51,7 @@ class SearchResult:
                 score=float(value["score"]),
                 distance=optional_float(value.get("distance")),
                 lexical_score=optional_float(value.get("lexical_score")),
+                key=str(value["key"]) if value.get("key") is not None else None,
                 references=tuple(SearchReference.from_json(reference) for reference in value.get("references", [])),
             )
         except (KeyError, TypeError, ValueError) as error:

--- a/infra/echo/test_cli.py
+++ b/infra/echo/test_cli.py
@@ -21,6 +21,7 @@ def json_response(value, headers=None):
 
 def test_search_sends_selected_domains_to_federated_endpoint(monkeypatch, capsys):
     remote_result = {
+        "key": "file:731",
         "id": "file:lib/iris/src/iris/scheduler.py",
         "domain": "file",
         "title": "scheduler.py",
@@ -61,6 +62,7 @@ def test_search_sends_selected_domains_to_federated_endpoint(monkeypatch, capsys
     output = capsys.readouterr().out
     assert "1 result in 1.23s" in output
     assert cli.SEARCH_DETAIL_INSTRUCTION in output
+    assert "file:731" in output
     assert "L42 raise FAILED_PRECONDITION" in output
 
 
@@ -138,9 +140,9 @@ def test_feedback_submits_replayable_grades_and_stdin_note(monkeypatch, capsys):
             "--query",
             "how do I deploy Iris?",
             "--grade",
-            "wiki:123=0",
+            "wiki:730=0",
             "--grade",
-            "file:lib/iris/OPS.md=10",
+            "file:731=10",
         ]
     )
     args.func(args)
@@ -153,8 +155,8 @@ def test_feedback_submits_replayable_grades_and_stdin_note(monkeypatch, capsys):
                 "body": {
                     "query": "how do I deploy Iris?",
                     "grades": [
-                        {"result_id": "wiki:123", "grade": 0},
-                        {"result_id": "file:lib/iris/OPS.md", "grade": 10},
+                        {"key": "wiki:730", "grade": 0},
+                        {"key": "file:731", "grade": 10},
                     ],
                     "note": "Wiki result was unrelated.",
                 }
@@ -181,7 +183,7 @@ def test_feedback_links_execution_when_provided(monkeypatch):
             "--execution-id",
             "991",
             "--grade",
-            "file:lib/iris/OPS.md=10",
+            "file:731=10",
         ]
     )
 


### PR DESCRIPTION
Give every persisted search result an identity-backed, domain-qualified key such as `file:731`, and print it beside the source ID in CLI output. Feedback resolves keys to exact stored rows and derives and validates their search execution, preventing later corpus syncs from retargeting activity grades. Backfill exact row links for existing execution-linked grades; unlinked historical grades retain source metadata without a key.

Persist raw cross-encoder scores with ranked snapshots. Analysis of 752 execution-linked grades found 53% of wiki grades and 33% of issue grades below 4. Raising the wiki raw-score floor from -2 to -1 retained 93% of useful wiki grades and removed 22% of low-value wiki grades across 155 samples.

Keep other domain floors at -2. Activity chunk IDs recycle during sync, so historical issue inputs cannot be reconstructed reliably. New row identities and stored scores provide stable data for later per-domain calibration.
