### PR TITLE
[zephyr] Write subprocess stats from worker actors

### DIFF
--- a/lib/zephyr/src/zephyr/runners.py
+++ b/lib/zephyr/src/zephyr/runners.py
@@ -51,6 +51,7 @@ from zephyr.stage_io import (
     _write_stage_output,
 )
 from zephyr.stats import (
+    WORKER_STATS_INTERVAL,
     ZEPHYR_STAGE_BYTES_PROCESSED_KEY,
     ZEPHYR_STAGE_ITEM_COUNT_KEY,
     ZEPHYR_WORKER_CPU_PCT_AVERAGE_KEY,
@@ -68,17 +69,16 @@ logger = logging.getLogger(__name__)
 __all__ = ["InlineRunner", "StageRunner", "SubprocessRunner"]
 
 
-SUBPROCESS_STATS_INTERVAL = 5.0
-"""How often runners sample resource use and flush subprocess counters.
-
-Matches the parent's heartbeat cadence so each beat reads at most one stale
-snapshot before a fresh flush lands.
-"""
-
 _ACCUMULATED_RESOURCE_COUNTER_KEYS = (
     ZEPHYR_WORKER_CPU_PCT_AVERAGE_KEY,
     ZEPHYR_WORKER_MEM_AVERAGE_KEY,
     ZEPHYR_WORKER_MEM_PEAK_KEY,
+)
+_RESOURCE_COUNTER_AGGREGATIONS = (
+    (ZEPHYR_WORKER_CPU_PCT_AVERAGE_KEY, Aggregation.AVERAGE),
+    (ZEPHYR_WORKER_CPU_TIME_KEY, Aggregation.SUM),
+    (ZEPHYR_WORKER_MEM_AVERAGE_KEY, Aggregation.AVERAGE),
+    (ZEPHYR_WORKER_MEM_PEAK_KEY, Aggregation.MAX),
 )
 
 # ---------------------------------------------------------------------------
@@ -169,7 +169,7 @@ def _wrap_stage_stats(gen: Iterator[_T]) -> Iterator[_T]:
 
 
 def _sample_process_stats(
-    cpu_s_at_start: float,
+    cpu_time_at_start: float,
     proc: psutil.Process,
     ctx: _InProcessWorkerContext,
 ) -> None:
@@ -177,7 +177,7 @@ def _sample_process_stats(
 
     Uses set_counter (not increment) because these are point-in-time metrics.
     Peak memory is tracked as a monotonically increasing max across calls.
-    ``cpu_s_at_start`` is subtracted from cumulative CPU time to give per-shard delta.
+    ``cpu_time_at_start`` is subtracted from cumulative CPU time to give per-shard delta.
     ``proc`` must be the same object across calls so cpu_percent() has a
     prior measurement to diff against; prime it once before the first sample.
     The context is explicit because sampler threads do not inherit ContextVars.
@@ -188,7 +188,11 @@ def _sample_process_stats(
     stage = ctx.current_stage_name()
     ctx.set_counter(ZEPHYR_WORKER_CPU_PCT_CURRENT_KEY, cpu_pct, stage=stage)
     ctx.update_counter(ZEPHYR_WORKER_CPU_PCT_AVERAGE_KEY, cpu_pct, stage=stage)
-    ctx.set_counter(ZEPHYR_WORKER_CPU_TIME_KEY, cpu_times.user + cpu_times.system - cpu_s_at_start, stage=stage)
+    ctx.set_counter(
+        ZEPHYR_WORKER_CPU_TIME_KEY,
+        cpu_times.user + cpu_times.system - cpu_time_at_start,
+        stage=stage,
+    )
     ctx.set_counter(ZEPHYR_WORKER_MEM_CURRENT_KEY, rss, stage=stage)
     ctx.update_counter(ZEPHYR_WORKER_MEM_AVERAGE_KEY, rss, stage=stage)
     ctx.update_counter(ZEPHYR_WORKER_MEM_PEAK_KEY, rss, stage=stage)
@@ -201,13 +205,11 @@ def _set_counter_aggregations() -> None:
     so that AVERAGE/MAX counters are reduced correctly.  SUM is the default
     and listed only for documentation.
     """
-    sc = counters.current_stage()
-    sc.set_aggregation(ZEPHYR_STAGE_ITEM_COUNT_KEY, Aggregation.SUM)
-    sc.set_aggregation(ZEPHYR_STAGE_BYTES_PROCESSED_KEY, Aggregation.SUM)
-    sc.set_aggregation(ZEPHYR_WORKER_CPU_PCT_AVERAGE_KEY, Aggregation.AVERAGE)
-    sc.set_aggregation(ZEPHYR_WORKER_CPU_TIME_KEY, Aggregation.SUM)
-    sc.set_aggregation(ZEPHYR_WORKER_MEM_AVERAGE_KEY, Aggregation.AVERAGE)
-    sc.set_aggregation(ZEPHYR_WORKER_MEM_PEAK_KEY, Aggregation.MAX)
+    stage_counters = counters.current_stage()
+    stage_counters.set_aggregation(ZEPHYR_STAGE_ITEM_COUNT_KEY, Aggregation.SUM)
+    stage_counters.set_aggregation(ZEPHYR_STAGE_BYTES_PROCESSED_KEY, Aggregation.SUM)
+    for name, aggregation in _RESOURCE_COUNTER_AGGREGATIONS:
+        stage_counters.set_aggregation(name, aggregation)
 
 
 def _periodic_sampler(
@@ -215,13 +217,13 @@ def _periodic_sampler(
     ctx: _InProcessWorkerContext,
     interval: float,
     *,
-    cpu_s_at_start: float,
+    cpu_time_at_start: float,
     proc: psutil.Process,
 ) -> None:
     """Periodically sample process stats into the shard context."""
     while not stop_event.wait(timeout=interval):
         try:
-            _sample_process_stats(cpu_s_at_start, proc, ctx)
+            _sample_process_stats(cpu_time_at_start, proc, ctx)
         except Exception:
             logger.warning("Failed to sample process stats", exc_info=True)
 
@@ -237,7 +239,7 @@ def _shard_counter_session(
     proc = psutil.Process()
     proc.cpu_percent()  # prime so subsequent calls have a baseline
     cpu_times_at_start = proc.cpu_times()
-    cpu_s_at_start = cpu_times_at_start.user + cpu_times_at_start.system
+    cpu_time_at_start = cpu_times_at_start.user + cpu_times_at_start.system
     start_time = time.monotonic()
 
     stop_event = threading.Event()
@@ -250,7 +252,7 @@ def _shard_counter_session(
                 "stop_event": stop_event,
                 "ctx": ctx,
                 "interval": sample_interval,
-                "cpu_s_at_start": cpu_s_at_start,
+                "cpu_time_at_start": cpu_time_at_start,
                 "proc": proc,
             },
             daemon=True,
@@ -266,7 +268,7 @@ def _shard_counter_session(
             sampler.join(timeout=2.0)
         if sampler is None or not sampler.is_alive():
             try:
-                _sample_process_stats(cpu_s_at_start, proc, ctx)
+                _sample_process_stats(cpu_time_at_start, proc, ctx)
             except Exception:
                 logger.warning("Failed to take final process stats sample", exc_info=True)
 
@@ -337,7 +339,7 @@ class InlineRunner:
         try:
             with _shard_counter_session(
                 ctx,
-                sample_interval=SUBPROCESS_STATS_INTERVAL,
+                sample_interval=WORKER_STATS_INTERVAL,
                 sampler_thread_name="zephyr-inline-stats-sampler",
             ):
                 result = _run_stage_with_ctx(task, chunk_prefix, execution_id)
@@ -372,9 +374,49 @@ class SubprocessRunner:
         self._counter_file: str | None = None
         self._process: psutil.Process | None = None
         self._process_stats: _InProcessWorkerContext | None = None
-        self._cpu_s_at_start = 0.0
+        self._cpu_time_at_start = 0.0
         self._last_counters: dict[str, CounterEntry] = {}
         self._state_lock = threading.Lock()
+
+    def _child_returncode(
+        self,
+        command: list[str],
+        child_env: dict[str, str],
+        execution_id: str,
+        stage_name: str,
+    ) -> int:
+        with sp.Popen(
+            command,
+            env=child_env,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+        ) as proc:
+            process = psutil.Process(proc.pid)
+            process.cpu_percent()
+            cpu_times_at_start = process.cpu_times()
+            process_stats = _InProcessWorkerContext("", execution_id, stage_name)
+            for name, aggregation in _RESOURCE_COUNTER_AGGREGATIONS:
+                process_stats.set_aggregation(name, aggregation)
+            with self._state_lock:
+                self._process = process
+                self._process_stats = process_stats
+                self._cpu_time_at_start = cpu_times_at_start.user + cpu_times_at_start.system
+            try:
+                return proc.wait()
+            finally:
+                with self._state_lock:
+                    self._process = None
+
+    def _final_counters(self, child_counters: dict[str, CounterEntry]) -> dict[str, CounterEntry]:
+        with self._state_lock:
+            process_counters = dict(self._process_stats._counters) if self._process_stats is not None else {}
+        final_counters = dict(child_counters)
+        for name in _ACCUMULATED_RESOURCE_COUNTER_KEYS:
+            entries = [(name, entry) for entry in (process_counters.get(name), final_counters.get(name)) if entry]
+            if entries:
+                merged, _ = merge_counter_entries(entries)
+                final_counters[name] = merged[name]
+        return final_counters
 
     def execute(
         self,
@@ -398,27 +440,12 @@ class SubprocessRunner:
             child_env = os.environ.copy()
             child_env["POLARS_MAX_THREADS"] = str(max(1, math.ceil(task.cost.cpu)))
             with tempfile.TemporaryDirectory(prefix=f"zephyr-external-sort-{task.shard_idx:04d}-") as sort_dir:
-                with sp.Popen(
+                returncode = self._child_returncode(
                     [sys.executable, "-u", "-m", "zephyr.shard_subprocess", task_file, result_file, sort_dir],
-                    env=child_env,
-                    stdout=sys.stdout,
-                    stderr=sys.stderr,
-                ) as proc:
-                    process = psutil.Process(proc.pid)
-                    process.cpu_percent()
-                    cpu_times_at_start = process.cpu_times()
-                    process_stats = _InProcessWorkerContext("", execution_id, task.stage_name)
-                    process_stats.set_aggregation(ZEPHYR_WORKER_CPU_PCT_AVERAGE_KEY, Aggregation.AVERAGE)
-                    process_stats.set_aggregation(ZEPHYR_WORKER_MEM_AVERAGE_KEY, Aggregation.AVERAGE)
-                    process_stats.set_aggregation(ZEPHYR_WORKER_MEM_PEAK_KEY, Aggregation.MAX)
-                    cpu_s_at_start = cpu_times_at_start.user + cpu_times_at_start.system
-                    with self._state_lock:
-                        self._process = process
-                        self._process_stats = process_stats
-                        self._cpu_s_at_start = cpu_s_at_start
-                    returncode = proc.wait()
-                    with self._state_lock:
-                        self._process = None
+                    child_env,
+                    execution_id,
+                    task.stage_name,
+                )
 
             if returncode != 0:
                 # Linux OOM-killer sends SIGKILL → returncode == -9. Distinguish
@@ -436,14 +463,7 @@ class SubprocessRunner:
             with open(result_file, "rb") as f:
                 result_or_error, child_counters = cloudpickle.load(f)
 
-            with self._state_lock:
-                process_counters = dict(self._process_stats._counters) if self._process_stats is not None else {}
-            final_counters = dict(child_counters)
-            for name in _ACCUMULATED_RESOURCE_COUNTER_KEYS:
-                entries = [(name, entry) for entry in (process_counters.get(name), final_counters.get(name)) if entry]
-                if entries:
-                    merged, _ = merge_counter_entries(entries)
-                    final_counters[name] = merged[name]
+            final_counters = self._final_counters(child_counters)
             self._last_counters = final_counters
 
             # Switch heartbeat reads to the final snapshot before returning.
@@ -478,9 +498,11 @@ class SubprocessRunner:
         with self._state_lock:
             if self._process is not None and self._process_stats is not None:
                 try:
-                    _sample_process_stats(self._cpu_s_at_start, self._process, self._process_stats)
-                except psutil.Error:
+                    _sample_process_stats(self._cpu_time_at_start, self._process, self._process_stats)
+                except psutil.NoSuchProcess:
                     pass
+                except psutil.Error:
+                    logger.warning("Failed to sample subprocess resource use", exc_info=True)
                 counters.update(self._process_stats._counters)
         if counters:
             self._last_counters = dict(counters)

--- a/lib/zephyr/src/zephyr/runners.py
+++ b/lib/zephyr/src/zephyr/runners.py
@@ -59,10 +59,8 @@ from zephyr.stats import (
     ZEPHYR_WORKER_MEM_AVERAGE_KEY,
     ZEPHYR_WORKER_MEM_CURRENT_KEY,
     ZEPHYR_WORKER_MEM_PEAK_KEY,
-    StatsWriter,
-    ZephyrWorkerStatStatus,
 )
-from zephyr.worker_context import Aggregation, CounterEntry, CounterSnapshot, _worker_ctx_var
+from zephyr.worker_context import Aggregation, CounterEntry, CounterSnapshot, _worker_ctx_var, merge_counter_entries
 
 logger = logging.getLogger(__name__)
 
@@ -71,13 +69,17 @@ __all__ = ["InlineRunner", "StageRunner", "SubprocessRunner"]
 
 
 SUBPROCESS_STATS_INTERVAL = 5.0
-"""How often the subprocess child samples and emits its stats to finelog and
-flushes its counters.
+"""How often runners sample resource use and flush subprocess counters.
 
 Matches the parent's heartbeat cadence so each beat reads at most one stale
 snapshot before a fresh flush lands.
 """
 
+_ACCUMULATED_RESOURCE_COUNTER_KEYS = (
+    ZEPHYR_WORKER_CPU_PCT_AVERAGE_KEY,
+    ZEPHYR_WORKER_MEM_AVERAGE_KEY,
+    ZEPHYR_WORKER_MEM_PEAK_KEY,
+)
 
 # ---------------------------------------------------------------------------
 # Shared worker context + stats wrapping (used by both runners)
@@ -214,100 +216,59 @@ def _periodic_sampler(
     interval: float,
     *,
     cpu_s_at_start: float,
-    stats_writer: StatsWriter,
-    task: ShardTask,
-    execution_id: str,
-    start_time: float,
     proc: psutil.Process,
 ) -> None:
-    """Periodically sample process stats and emit RUNNING rows to finelog.
-
-    ``stats_writer.emit_worker_stat`` is itself a no-op when finelog is
-    unavailable, so no gating is needed here.
-    """
+    """Periodically sample process stats into the shard context."""
     while not stop_event.wait(timeout=interval):
         try:
             _sample_process_stats(cpu_s_at_start, proc, ctx)
-            stats_writer.emit_worker_stat(
-                task.stage_name,
-                task.shard_idx,
-                execution_id,
-                ZephyrWorkerStatStatus.RUNNING,
-                start_time,
-                ctx.get_counters(),
-            )
         except Exception:
-            logger.warning("Failed to sample/emit process stats", exc_info=True)
+            logger.warning("Failed to sample process stats", exc_info=True)
 
 
 @contextmanager
-def _shard_stats_session(
+def _shard_counter_session(
     ctx: _InProcessWorkerContext,
-    task: ShardTask,
-    execution_id: str,
-    stats_writer: StatsWriter,
     *,
-    sampler_thread_name: str,
+    sample_interval: float | None,
+    sampler_thread_name: str | None,
 ) -> Iterator[float]:
-    """Emit START/END worker stats and run the resource sampler for one shard.
-
-    Shared by ``InlineRunner.execute`` and the ``SubprocessRunner`` child: both
-    need the same lifecycle around the shard body — prime ``psutil`` so
-    ``cpu_percent`` has a baseline, record the CPU-time origin so samples are
-    per-shard deltas, emit the START row, run the periodic sampler, then take a
-    final sample and emit END (or FAILED if the body raised).
-
-    Yields the shard's monotonic start time, which callers reuse for their own
-    elapsed-time reporting.
-    """
+    """Sample shard resource counters periodically and once at completion."""
     proc = psutil.Process()
     proc.cpu_percent()  # prime so subsequent calls have a baseline
     cpu_times_at_start = proc.cpu_times()
     cpu_s_at_start = cpu_times_at_start.user + cpu_times_at_start.system
     start_time = time.monotonic()
 
-    stats_writer.emit_worker_stat(
-        task.stage_name, task.shard_idx, execution_id, ZephyrWorkerStatStatus.START, start_time, ctx.get_counters()
-    )
-
     stop_event = threading.Event()
-    sampler = threading.Thread(
-        target=_periodic_sampler,
-        kwargs={
-            "stop_event": stop_event,
-            "ctx": ctx,
-            "interval": SUBPROCESS_STATS_INTERVAL,
-            "cpu_s_at_start": cpu_s_at_start,
-            "stats_writer": stats_writer,
-            "task": task,
-            "execution_id": execution_id,
-            "start_time": start_time,
-            "proc": proc,
-        },
-        daemon=True,
-        name=sampler_thread_name,
-    )
-    sampler.start()
+    sampler: threading.Thread | None = None
+    if sample_interval is not None:
+        assert sampler_thread_name is not None
+        sampler = threading.Thread(
+            target=_periodic_sampler,
+            kwargs={
+                "stop_event": stop_event,
+                "ctx": ctx,
+                "interval": sample_interval,
+                "cpu_s_at_start": cpu_s_at_start,
+                "proc": proc,
+            },
+            daemon=True,
+            name=sampler_thread_name,
+        )
+        sampler.start()
 
-    failed = True  # cleared only when the body completes without raising
     try:
         yield start_time
-        failed = False
     finally:
         stop_event.set()
-        sampler.join(timeout=2.0)
-        if not sampler.is_alive():
-            # Final reading so the END row reflects the shard's true peak rather
-            # than the last periodic tick. Telemetry must not fail a shard that
-            # already produced its result, so a sampling error is logged only.
+        if sampler is not None:
+            sampler.join(timeout=2.0)
+        if sampler is None or not sampler.is_alive():
             try:
                 _sample_process_stats(cpu_s_at_start, proc, ctx)
             except Exception:
                 logger.warning("Failed to take final process stats sample", exc_info=True)
-        status = ZephyrWorkerStatStatus.FAILED if failed else ZephyrWorkerStatStatus.END
-        stats_writer.emit_worker_stat(
-            task.stage_name, task.shard_idx, execution_id, status, start_time, ctx.get_counters()
-        )
 
 
 def _run_stage_with_ctx(
@@ -360,6 +321,7 @@ class InlineRunner:
 
     def __init__(self) -> None:
         self._ctx: _InProcessWorkerContext | None = None
+        self._last_counters: dict[str, CounterEntry] = {}
 
     def execute(
         self,
@@ -369,23 +331,25 @@ class InlineRunner:
     ) -> tuple[TaskResult, dict[str, CounterEntry]]:
         ctx = _InProcessWorkerContext(chunk_prefix, execution_id, task.stage_name, task_memory_bytes=task.cost.memory)
         self._ctx = ctx
+        self._last_counters = {}
         worker_token = _worker_ctx_var.set(ctx)
         _set_counter_aggregations()
-        stats_writer = StatsWriter.connect()
         try:
-            with _shard_stats_session(
-                ctx, task, execution_id, stats_writer, sampler_thread_name="zephyr-inline-stats-sampler"
+            with _shard_counter_session(
+                ctx,
+                sample_interval=SUBPROCESS_STATS_INTERVAL,
+                sampler_thread_name="zephyr-inline-stats-sampler",
             ):
                 result = _run_stage_with_ctx(task, chunk_prefix, execution_id)
         finally:
-            stats_writer.close()
+            self._last_counters = dict(ctx._counters)
             _worker_ctx_var.reset(worker_token)
             self._ctx = None
         return result, dict(ctx._counters)
 
     def live_counters(self) -> dict[str, CounterEntry]:
         ctx = self._ctx
-        return dict(ctx._counters) if ctx is not None else {}
+        return dict(ctx._counters) if ctx is not None else dict(self._last_counters)
 
 
 # ---------------------------------------------------------------------------
@@ -406,6 +370,11 @@ class SubprocessRunner:
 
     def __init__(self) -> None:
         self._counter_file: str | None = None
+        self._process: psutil.Process | None = None
+        self._process_stats: _InProcessWorkerContext | None = None
+        self._cpu_s_at_start = 0.0
+        self._last_counters: dict[str, CounterEntry] = {}
+        self._state_lock = threading.Lock()
 
     def execute(
         self,
@@ -413,14 +382,14 @@ class SubprocessRunner:
         chunk_prefix: str,
         execution_id: str,
     ) -> tuple[TaskResult, dict[str, CounterEntry]]:
-        finelog_url = StatsWriter.resolve_url()  # Requires Iris context, so called here and passed to subprocess
         with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
-            cloudpickle.dump((task, chunk_prefix, execution_id, finelog_url), f)
+            cloudpickle.dump((task, chunk_prefix, execution_id), f)
             task_file = f.name
         with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
             result_file = f.name
         counter_file = f"{result_file}.counters"
         self._counter_file = counter_file
+        self._last_counters = {}
 
         try:
             # ``-u`` keeps the child's stdout/stderr unbuffered so any
@@ -429,48 +398,66 @@ class SubprocessRunner:
             child_env = os.environ.copy()
             child_env["POLARS_MAX_THREADS"] = str(max(1, math.ceil(task.cost.cpu)))
             with tempfile.TemporaryDirectory(prefix=f"zephyr-external-sort-{task.shard_idx:04d}-") as sort_dir:
-                proc = sp.run(
-                    [
-                        sys.executable,
-                        "-u",
-                        "-m",
-                        "zephyr.shard_subprocess",
-                        task_file,
-                        result_file,
-                        sort_dir,
-                    ],
+                with sp.Popen(
+                    [sys.executable, "-u", "-m", "zephyr.shard_subprocess", task_file, result_file, sort_dir],
                     env=child_env,
                     stdout=sys.stdout,
                     stderr=sys.stderr,
-                )
+                ) as proc:
+                    process = psutil.Process(proc.pid)
+                    process.cpu_percent()
+                    cpu_times_at_start = process.cpu_times()
+                    process_stats = _InProcessWorkerContext("", execution_id, task.stage_name)
+                    process_stats.set_aggregation(ZEPHYR_WORKER_CPU_PCT_AVERAGE_KEY, Aggregation.AVERAGE)
+                    process_stats.set_aggregation(ZEPHYR_WORKER_MEM_AVERAGE_KEY, Aggregation.AVERAGE)
+                    process_stats.set_aggregation(ZEPHYR_WORKER_MEM_PEAK_KEY, Aggregation.MAX)
+                    cpu_s_at_start = cpu_times_at_start.user + cpu_times_at_start.system
+                    with self._state_lock:
+                        self._process = process
+                        self._process_stats = process_stats
+                        self._cpu_s_at_start = cpu_s_at_start
+                    returncode = proc.wait()
+                    with self._state_lock:
+                        self._process = None
 
-            if proc.returncode != 0:
+            if returncode != 0:
                 # Linux OOM-killer sends SIGKILL → returncode == -9. Distinguish
                 # so callers/retries can react to memory pressure specifically.
-                if proc.returncode == -signal.SIGKILL:
+                if returncode == -signal.SIGKILL:
                     raise MemoryError(
                         f"Subprocess for shard {task.shard_idx} was killed by SIGKILL "
-                        f"(returncode {proc.returncode}); most likely OOM-killed by the kernel."
+                        f"(returncode {returncode}); most likely OOM-killed by the kernel."
                     )
                 raise RuntimeError(
-                    f"Subprocess for shard {task.shard_idx} exited with code {proc.returncode}; "
+                    f"Subprocess for shard {task.shard_idx} exited with code {returncode}; "
                     "see worker stderr above for the faulthandler traceback."
                 )
 
             with open(result_file, "rb") as f:
                 result_or_error, child_counters = cloudpickle.load(f)
 
-            # Clear counter pointer BEFORE returning so a heartbeat racing
-            # this and ``report_result`` reads {} rather than re-shipping
-            # values the caller is about to send as final.
+            with self._state_lock:
+                process_counters = dict(self._process_stats._counters) if self._process_stats is not None else {}
+            final_counters = dict(child_counters)
+            for name in _ACCUMULATED_RESOURCE_COUNTER_KEYS:
+                entries = [(name, entry) for entry in (process_counters.get(name), final_counters.get(name)) if entry]
+                if entries:
+                    merged, _ = merge_counter_entries(entries)
+                    final_counters[name] = merged[name]
+            self._last_counters = final_counters
+
+            # Switch heartbeat reads to the final snapshot before returning.
             self._counter_file = None
 
             if isinstance(result_or_error, Exception):
                 raise result_or_error
 
-            return result_or_error, dict(child_counters)
+            return result_or_error, dict(final_counters)
         finally:
             self._counter_file = None
+            with self._state_lock:
+                self._process = None
+                self._process_stats = None
             for p in (task_file, result_file, counter_file, f"{counter_file}.tmp"):
                 with suppress(FileNotFoundError):
                     os.unlink(p)
@@ -478,13 +465,23 @@ class SubprocessRunner:
     def live_counters(self) -> dict[str, CounterEntry]:
         cf = self._counter_file
         if cf is None:
-            return {}
+            return dict(self._last_counters)
+        counters: dict[str, CounterEntry] = {}
         try:
             with open(cf, "rb") as f:
-                return cloudpickle.load(f)
+                counters = cloudpickle.load(f)
         except (FileNotFoundError, EOFError):
-            # Race against atomic rename, or task already cleaned up its file.
-            return {}
+            pass
         except Exception:
             logger.warning("Failed to read counter file %s", cf, exc_info=True)
-            return {}
+
+        with self._state_lock:
+            if self._process is not None and self._process_stats is not None:
+                try:
+                    _sample_process_stats(self._cpu_s_at_start, self._process, self._process_stats)
+                except psutil.Error:
+                    pass
+                counters.update(self._process_stats._counters)
+        if counters:
+            self._last_counters = dict(counters)
+        return counters

--- a/lib/zephyr/src/zephyr/shard_subprocess.py
+++ b/lib/zephyr/src/zephyr/shard_subprocess.py
@@ -34,10 +34,9 @@ from zephyr.runners import (
     _InProcessWorkerContext,
     _run_stage_with_ctx,
     _set_counter_aggregations,
-    _shard_stats_session,
+    _shard_counter_session,
 )
 from zephyr.stage_io import _ensure_picklable_exception, _stage_throughput
-from zephyr.stats import StatsWriter
 from zephyr.worker_context import _worker_ctx_var
 
 logger = logging.getLogger(__name__)
@@ -107,61 +106,51 @@ def _execute_shard_subprocess(task_file: str, result_file: str, external_sort_di
     ctx: _InProcessWorkerContext | None = None
     try:
         with open(task_file, "rb") as f:
-            task, chunk_prefix, execution_id, finelog_url = cloudpickle.load(f)
+            task, chunk_prefix, execution_id = cloudpickle.load(f)
 
-        stats_writer = StatsWriter.connect(finelog_url) if finelog_url else StatsWriter(None)
-        try:
-            ctx = _InProcessWorkerContext(
-                chunk_prefix, execution_id, task.stage_name, task_memory_bytes=task.cost.memory
+        ctx = _InProcessWorkerContext(chunk_prefix, execution_id, task.stage_name, task_memory_bytes=task.cost.memory)
+        _worker_ctx_var.set(ctx)
+        _set_counter_aggregations()
+
+        with _shard_counter_session(ctx, sample_interval=None, sampler_thread_name=None) as start_time:
+            # The parent polls the counter file for live heartbeat counters.
+            stop_event = threading.Event()
+            flusher = threading.Thread(
+                target=_periodic_counter_writer,
+                args=(stop_event, ctx, counter_file, SUBPROCESS_STATS_INTERVAL),
+                daemon=True,
+                name="zephyr-subprocess-counter-flusher",
             )
-            _worker_ctx_var.set(ctx)
-            _set_counter_aggregations()
+            flusher.start()
 
-            with _shard_stats_session(
-                ctx, task, execution_id, stats_writer, sampler_thread_name="zephyr-subprocess-stats-sampler"
-            ) as start_time:
-                # Threads unique to the child: the parent polls the counter file
-                # for live heartbeat counters, and the shard has no coordinator
-                # of its own to log progress.
-                stop_event = threading.Event()
-                flusher = threading.Thread(
-                    target=_periodic_counter_writer,
-                    args=(stop_event, ctx, counter_file, SUBPROCESS_STATS_INTERVAL),
-                    daemon=True,
-                    name="zephyr-subprocess-counter-flusher",
+            status_logger = threading.Thread(
+                target=_periodic_status_logger,
+                args=(
+                    stop_event,
+                    ctx,
+                    task.stage_name,
+                    execution_id,
+                    task.shard_idx,
+                    task.total_shards,
+                    start_time,
+                    SUBPROCESS_STATS_INTERVAL,
+                ),
+                daemon=True,
+                name="zephyr-subprocess-status-logger",
+            )
+            status_logger.start()
+
+            try:
+                result_or_error = _run_stage_with_ctx(
+                    task,
+                    chunk_prefix,
+                    execution_id,
+                    external_sort_dir=external_sort_dir,
                 )
-                flusher.start()
-
-                status_logger = threading.Thread(
-                    target=_periodic_status_logger,
-                    args=(
-                        stop_event,
-                        ctx,
-                        task.stage_name,
-                        execution_id,
-                        task.shard_idx,
-                        task.total_shards,
-                        start_time,
-                        SUBPROCESS_STATS_INTERVAL,
-                    ),
-                    daemon=True,
-                    name="zephyr-subprocess-status-logger",
-                )
-                status_logger.start()
-
-                try:
-                    result_or_error = _run_stage_with_ctx(
-                        task,
-                        chunk_prefix,
-                        execution_id,
-                        external_sort_dir=external_sort_dir,
-                    )
-                finally:
-                    stop_event.set()
-                    flusher.join(timeout=2.0)
-                    status_logger.join(timeout=2.0)
-        finally:
-            stats_writer.close()
+            finally:
+                stop_event.set()
+                flusher.join(timeout=2.0)
+                status_logger.join(timeout=2.0)
     except Exception as e:
         # Cloudpickling an exception drops ``__traceback__``, so a naive
         # parent re-raise would otherwise show only the parent stack at the

--- a/lib/zephyr/src/zephyr/shard_subprocess.py
+++ b/lib/zephyr/src/zephyr/shard_subprocess.py
@@ -30,13 +30,13 @@ import pyarrow as pa
 from rigging.log_setup import configure_logging
 
 from zephyr.runners import (
-    SUBPROCESS_STATS_INTERVAL,
     _InProcessWorkerContext,
     _run_stage_with_ctx,
     _set_counter_aggregations,
     _shard_counter_session,
 )
 from zephyr.stage_io import _ensure_picklable_exception, _stage_throughput
+from zephyr.stats import WORKER_STATS_INTERVAL
 from zephyr.worker_context import _worker_ctx_var
 
 logger = logging.getLogger(__name__)
@@ -117,7 +117,7 @@ def _execute_shard_subprocess(task_file: str, result_file: str, external_sort_di
             stop_event = threading.Event()
             flusher = threading.Thread(
                 target=_periodic_counter_writer,
-                args=(stop_event, ctx, counter_file, SUBPROCESS_STATS_INTERVAL),
+                args=(stop_event, ctx, counter_file, WORKER_STATS_INTERVAL),
                 daemon=True,
                 name="zephyr-subprocess-counter-flusher",
             )
@@ -133,7 +133,7 @@ def _execute_shard_subprocess(task_file: str, result_file: str, external_sort_di
                     task.shard_idx,
                     task.total_shards,
                     start_time,
-                    SUBPROCESS_STATS_INTERVAL,
+                    WORKER_STATS_INTERVAL,
                 ),
                 daemon=True,
                 name="zephyr-subprocess-status-logger",

--- a/lib/zephyr/src/zephyr/stats.py
+++ b/lib/zephyr/src/zephyr/stats.py
@@ -8,12 +8,10 @@ Two namespaces are written:
 - ``zephyr.stage`` — one row per stage at completion, emitted by the
   coordinator. Contains throughput and aggregated resource usage.
 - ``zephyr.worker`` — one row per shard at START, each sample interval
-  (RUNNING), and END, emitted directly by each runner.
+  (RUNNING), and END, emitted by the long-lived worker actor.
 
-Resource counters (cpu, memory) are sampled by runner background threads
-via :func:`zephyr.runners._sample_process_stats` and stored with
-:meth:`~zephyr.runners._InProcessWorkerContext.set_counter`. Counters are also
-sent to the coordinator via heartbeats for aggregation into stage stats.
+Runners sample CPU and memory counters. Worker heartbeats write per-shard rows
+and send aggregated counters to the coordinator for stage stats.
 """
 
 import enum
@@ -41,7 +39,7 @@ ZEPHYR_STAGE_ITEM_COUNT_KEY = "zephyr/item_count"
 ZEPHYR_STAGE_BYTES_PROCESSED_KEY = "zephyr/bytes_processed"
 """Counter key for bytes processed"""
 
-# Counter keys written by runner sampler threads using set_counter().
+# Counter keys written by runner resource sampling.
 # Read by the coordinator from completed task snapshots for stage stat aggregation.
 ZEPHYR_WORKER_CPU_PCT_CURRENT_KEY = "zephyr/worker/cpu_pct_current"
 """Current CPU percentage"""
@@ -114,7 +112,7 @@ class ZephyrStageStat:
 
 @dataclass
 class ZephyrWorkerStat:
-    """One row per shard per sample interval, written by each runner."""
+    """One row per shard per sample interval, written by its worker actor."""
 
     key_column: ClassVar[str] = "execution_id"
 
@@ -139,8 +137,8 @@ class StatsWriter:
     """Manages finelog connections and emits Zephyr stat rows.
 
     Call ``connect()`` to get a live instance; pass a pre-resolved URL when
-    an Iris context is not available (e.g. in a subprocess).  All emit
-    methods are no-ops when the log client is unavailable.
+    an Iris context is not available. All emit methods are no-ops when the
+    log client is unavailable.
     """
 
     def __init__(self, log_client: LogClient | None) -> None:

--- a/lib/zephyr/src/zephyr/stats.py
+++ b/lib/zephyr/src/zephyr/stats.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 ZEPHYR_STAGE_STATS_NAMESPACE = "zephyr.stage"
 ZEPHYR_WORKER_STATS_NAMESPACE = "zephyr.worker"
+WORKER_STATS_INTERVAL = 5.0
 
 ZEPHYR_STAGE_ITEM_COUNT_KEY = "zephyr/item_count"
 """Counter key for items processed"""

--- a/lib/zephyr/src/zephyr/worker.py
+++ b/lib/zephyr/src/zephyr/worker.py
@@ -23,7 +23,13 @@ from zephyr.memory_store import (
     MemoryTableStatsResult,
 )
 from zephyr.stage_io import ShardTask, StageRunner, TaskResult, ZephyrTaskResources, _stage_throughput
-from zephyr.stats import ZEPHYR_WORKER_MEM_CURRENT_KEY, StatsWriter, ZephyrWorkerStatStatus, _push_iris_task_status
+from zephyr.stats import (
+    WORKER_STATS_INTERVAL,
+    ZEPHYR_WORKER_MEM_CURRENT_KEY,
+    StatsWriter,
+    ZephyrWorkerStatStatus,
+    _push_iris_task_status,
+)
 from zephyr.worker_context import CounterEntry, CounterSnapshot, merge_counter_entries
 
 logger = logging.getLogger(__name__)
@@ -34,7 +40,6 @@ logger = logging.getLogger(__name__)
 RPC_POLL_INTERVAL = 0.5
 REGISTER_WARN_AFTER = 60.0
 PULL_TASK_WARN_AFTER = 30.0
-HEARTBEAT_INTERVAL = 5.0
 
 
 @dataclass
@@ -107,7 +112,7 @@ class ZephyrWorker:
 
         self._heartbeat_thread = threading.Thread(
             target=self._heartbeat_loop,
-            args=(coordinator_handle, HEARTBEAT_INTERVAL),
+            args=(coordinator_handle, WORKER_STATS_INTERVAL),
             daemon=True,
             name=f"zephyr-hb-{self._worker_id}",
         )

--- a/lib/zephyr/src/zephyr/worker.py
+++ b/lib/zephyr/src/zephyr/worker.py
@@ -9,6 +9,7 @@ import time
 import traceback
 from collections.abc import Callable, Hashable
 from contextlib import suppress
+from dataclasses import dataclass, field
 
 from fray.actor import ActorFuture, ActorHandle, current_actor
 from rigging.timing import ExponentialBackoff, RateLimiter
@@ -22,7 +23,7 @@ from zephyr.memory_store import (
     MemoryTableStatsResult,
 )
 from zephyr.stage_io import ShardTask, StageRunner, TaskResult, ZephyrTaskResources, _stage_throughput
-from zephyr.stats import _push_iris_task_status
+from zephyr.stats import ZEPHYR_WORKER_MEM_CURRENT_KEY, StatsWriter, ZephyrWorkerStatStatus, _push_iris_task_status
 from zephyr.worker_context import CounterEntry, CounterSnapshot, merge_counter_entries
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,20 @@ logger = logging.getLogger(__name__)
 RPC_POLL_INTERVAL = 0.5
 REGISTER_WARN_AFTER = 60.0
 PULL_TASK_WARN_AFTER = 30.0
+HEARTBEAT_INTERVAL = 5.0
+
+
+@dataclass
+class _ActiveShard:
+    runner: StageRunner
+    task: ShardTask
+    execution_id: str
+    start_time: float
+    last_counters: dict[str, CounterEntry] = field(default_factory=dict)
+
+
+def _counter_values(counters: dict[str, CounterEntry]) -> dict[str, int | float]:
+    return {name: entry.value for name, entry in counters.items()}
 
 
 def _format_worker_status_md(active_tasks: int, stage: str) -> tuple[str, str]:
@@ -65,9 +80,7 @@ class ZephyrWorker:
         self._shutdown_event = threading.Event()
         self._counter_generation: int = 0
         self._last_reported_counters: dict[str, CounterEntry] = {}
-        # Runners and sub-IDs for currently active slots — written by _stage_manager,
-        # read (snapshotted) by heartbeat thread.
-        self._active_runners: list[StageRunner] = []
+        self._active_shards: list[_ActiveShard] = []
         self._active_task_count: int = 0
         self._current_stage_name: str = ""
 
@@ -90,10 +103,11 @@ class ZephyrWorker:
         self._worker_id = f"{self._actor_ctx.group_name}-{self._actor_ctx.index}"
         self._actor_handle = self._actor_ctx.handle
         self._memory_store = MemoryStoreService(self._actor_ctx.index)
+        self._stats_writer = StatsWriter.connect()
 
         self._heartbeat_thread = threading.Thread(
             target=self._heartbeat_loop,
-            args=(coordinator_handle,),
+            args=(coordinator_handle, HEARTBEAT_INTERVAL),
             daemon=True,
             name=f"zephyr-hb-{self._worker_id}",
         )
@@ -168,6 +182,7 @@ class ZephyrWorker:
         # Registration must land before polling: it returns the memory-table
         # registrations that tasks read through memory_store.
         if not self._register():
+            self._stats_writer.close()
             return
 
         backoff = ExponentialBackoff(initial=0.1, maximum=5.0)
@@ -225,18 +240,30 @@ class ZephyrWorker:
             backoff.reset()
             assert work is not None
 
+            runner = self._stage_runner_factory()
+            active_shard = _ActiveShard(
+                runner=runner,
+                task=work.task,
+                execution_id=work.execution_id,
+                start_time=time.monotonic(),
+            )
             with self._resources_lock:
                 self._available = self._available - work.task.cost
-
-            runner = self._stage_runner_factory()
-            with self._resources_lock:
-                self._active_runners.append(runner)
+                self._active_shards.append(active_shard)
+                self._stats_writer.emit_worker_stat(
+                    work.task.stage_name,
+                    work.task.shard_idx,
+                    work.execution_id,
+                    ZephyrWorkerStatStatus.START,
+                    active_shard.start_time,
+                    {},
+                )
             self._active_task_count += 1
             self._current_stage_name = work.task.stage_name
 
             t = threading.Thread(
                 target=self._task_thread,
-                args=(work, runner),
+                args=(work, active_shard),
                 daemon=True,
                 name=f"zephyr-task-{self._worker_id}-s{work.task.shard_idx}",
             )
@@ -246,6 +273,7 @@ class ZephyrWorker:
         # Drain in-flight tasks before deregistering.
         for t in in_flight_threads:
             t.join()
+        self._stats_writer.close()
 
         logger.info("[%s] Poll loop exiting", self._worker_id)
         with suppress(Exception):
@@ -287,13 +315,19 @@ class ZephyrWorker:
     def _task_thread(
         self,
         work: PullTask,
-        runner: StageRunner,
+        active_shard: _ActiveShard,
     ) -> None:
         """Execute one shard task, report the result, and restore task.cost to the pool."""
-        task_start = time.monotonic()
+        task_start = active_shard.start_time
         task = work.task
+        runner = active_shard.runner
         try:
-            result, task_counters = self._execute_shard(task, work.chunk_prefix, work.execution_id, runner)
+            try:
+                result, task_counters = self._execute_shard(task, work.chunk_prefix, work.execution_id, runner)
+            except Exception:
+                self._finish_active_shard(active_shard, ZephyrWorkerStatStatus.FAILED, runner.live_counters())
+                raise
+            self._finish_active_shard(active_shard, ZephyrWorkerStatStatus.END, task_counters)
             logger.info("[%s] Shard %d done in %.2fs", self._worker_id, task.shard_idx, time.monotonic() - task_start)
             # Block until coordinator records result — prevents _in_flight races.
             self._counter_generation += 1
@@ -319,10 +353,28 @@ class ZephyrWorker:
         finally:
             with self._resources_lock:
                 self._available = self._available + task.cost
-                if runner in self._active_runners:
-                    self._active_runners.remove(runner)
             self._active_task_count = max(0, self._active_task_count - 1)
             self._task_completed_event.set()
+
+    def _finish_active_shard(
+        self,
+        active_shard: _ActiveShard,
+        status: ZephyrWorkerStatStatus,
+        counters: dict[str, CounterEntry],
+    ) -> None:
+        with self._resources_lock:
+            if not counters:
+                counters = active_shard.last_counters
+            active_shard.last_counters = dict(counters)
+            self._stats_writer.emit_worker_stat(
+                active_shard.task.stage_name,
+                active_shard.task.shard_idx,
+                active_shard.execution_id,
+                status,
+                active_shard.start_time,
+                _counter_values(counters),
+            )
+            self._active_shards.remove(active_shard)
 
     def _report_worker_iris_status(self) -> None:
         """Push worker status text to Iris for UI display. Called on each heartbeat."""
@@ -340,8 +392,21 @@ class ZephyrWorker:
     def _heartbeat_counter_snapshot(self) -> CounterSnapshot | None:
         """Aggregate live counters from all active runners; return None if unchanged."""
         with self._resources_lock:
-            runners = list(self._active_runners)
-        current, _ = merge_counter_entries((name, entry) for r in runners for name, entry in r.live_counters().items())
+            entries: list[tuple[str, CounterEntry]] = []
+            for active_shard in self._active_shards:
+                counters = active_shard.runner.live_counters()
+                active_shard.last_counters = dict(counters)
+                if ZEPHYR_WORKER_MEM_CURRENT_KEY in counters:
+                    self._stats_writer.emit_worker_stat(
+                        active_shard.task.stage_name,
+                        active_shard.task.shard_idx,
+                        active_shard.execution_id,
+                        ZephyrWorkerStatStatus.RUNNING,
+                        active_shard.start_time,
+                        _counter_values(counters),
+                    )
+                entries.extend(counters.items())
+        current, _ = merge_counter_entries(entries)
         if current == self._last_reported_counters:
             return None
         self._last_reported_counters = current

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -1571,7 +1571,7 @@ def test_heartbeat_failures_fail_actor_context():
     worker = ZephyrWorker.__new__(ZephyrWorker)
     worker._actor_ctx = actor_ctx
     worker._shutdown_event = threading.Event()
-    worker._active_runners = []
+    worker._active_shards = []
     worker._resources_lock = threading.Lock()
     worker._last_reported_counters = {}
     worker._counter_generation = 0

--- a/lib/zephyr/tests/test_runners.py
+++ b/lib/zephyr/tests/test_runners.py
@@ -13,21 +13,22 @@ import pytest
 from finelog.client import LogClient
 from finelog.embedded import EmbeddedServer
 from fray.types import ResourceConfig
-from zephyr import counters, runners
+from zephyr import counters, runners, worker
 from zephyr.dataset import Dataset
 from zephyr.execution import ZephyrContext, ZephyrWorkerError
 from zephyr.runners import InlineRunner, SubprocessRunner
 from zephyr.stats import (
     ZEPHYR_STAGE_STATS_NAMESPACE,
+    ZEPHYR_WORKER_MEM_PEAK_KEY,
     ZEPHYR_WORKER_STATS_NAMESPACE,
     StatsWriter,
 )
 
 
-def _ctx(local_client, tmp_path, *, stage_runner_factory) -> ZephyrContext:
+def _ctx(local_client, tmp_path, *, stage_runner_factory, max_workers: int = 2) -> ZephyrContext:
     return ZephyrContext(
         client=local_client,
-        max_workers=2,
+        max_workers=max_workers,
         resources=ResourceConfig(cpu=1, ram="512m"),
         chunk_storage_prefix=str(tmp_path / "chunks"),
         name=f"test-runner-{uuid.uuid4().hex[:8]}",
@@ -208,6 +209,7 @@ def test_finelog_stats_emitted(local_client, tmp_path, finelog_server, monkeypat
 
     monkeypatch.setattr(StatsWriter, "connect", staticmethod(make_writer))
     monkeypatch.setattr(runners, "SUBPROCESS_STATS_INTERVAL", 0.01)
+    monkeypatch.setattr(worker, "HEARTBEAT_INTERVAL", 0.01)
 
     def slow_identity(x: int) -> int:
         # Keep the shard alive long enough for the background sampler to emit.
@@ -221,7 +223,7 @@ def test_finelog_stats_emitted(local_client, tmp_path, finelog_server, monkeypat
     finally:
         ctx.shutdown()
 
-    # ctx.shutdown() closes the coordinator's writer; close any runner writers too.
+    # Close is idempotent; this also covers writers retained by the test factory.
     for w in writers:
         with suppress(Exception):
             w.close()
@@ -334,3 +336,48 @@ def test_finelog_stats_emitted(local_client, tmp_path, finelog_server, monkeypat
     # aggregate must therefore lie within the final per-shard averages.
     assert min(end_cpu_avg_pct) <= stage["cpu_pct_avg"] <= max(end_cpu_avg_pct)
     assert min(end_mem_avg_bytes) <= stage["mem_bytes_avg"] <= max(end_mem_avg_bytes)
+
+
+def test_subprocess_finelog_stats_use_worker_connection(local_client, tmp_path, monkeypatch):
+    class RecordingStatsWriter:
+        def __init__(self) -> None:
+            self.worker_rows: list[tuple[str, dict[str, int | float]]] = []
+
+        def emit_stage_stat(self, *args, **kwargs) -> None:
+            pass
+
+        def emit_worker_stat(self, stage_name, shard_idx, execution_id, status, start_time, counters) -> None:
+            self.worker_rows.append((status, counters))
+
+        def close(self) -> None:
+            pass
+
+    writers: list[RecordingStatsWriter] = []
+
+    def make_writer() -> RecordingStatsWriter:
+        writer = RecordingStatsWriter()
+        writers.append(writer)
+        return writer
+
+    monkeypatch.setattr(StatsWriter, "connect", staticmethod(make_writer))
+    monkeypatch.setattr(worker, "HEARTBEAT_INTERVAL", 0.01)
+
+    ctx = _ctx(local_client, tmp_path, stage_runner_factory=lambda: SubprocessRunner(), max_workers=1)
+    try:
+        ctx.execute(Dataset.from_list([1, 2, 3]).map(lambda value: value + 1))
+    finally:
+        ctx.shutdown()
+
+    worker_writers = [writer for writer in writers if writer.worker_rows]
+    assert len(worker_writers) == 1
+    worker_rows = worker_writers[0].worker_rows
+    statuses = [status for status, _ in worker_rows]
+    assert statuses.count("START") == 3
+    assert statuses.count("END") == 3
+    assert statuses[0] == "START"
+    assert "RUNNING" in statuses
+    assert statuses[-1] == "END"
+    assert "FAILED" not in statuses
+    running_counters = [counters for status, counters in worker_rows if status == "RUNNING"]
+    assert any(counters[ZEPHYR_WORKER_MEM_PEAK_KEY] > 0 for counters in running_counters)
+    assert worker_rows[-1][1][ZEPHYR_WORKER_MEM_PEAK_KEY] > 0

--- a/lib/zephyr/tests/test_runners.py
+++ b/lib/zephyr/tests/test_runners.py
@@ -208,8 +208,8 @@ def test_finelog_stats_emitted(local_client, tmp_path, finelog_server, monkeypat
         return w
 
     monkeypatch.setattr(StatsWriter, "connect", staticmethod(make_writer))
-    monkeypatch.setattr(runners, "SUBPROCESS_STATS_INTERVAL", 0.01)
-    monkeypatch.setattr(worker, "HEARTBEAT_INTERVAL", 0.01)
+    monkeypatch.setattr(runners, "WORKER_STATS_INTERVAL", 0.01)
+    monkeypatch.setattr(worker, "WORKER_STATS_INTERVAL", 0.01)
 
     def slow_identity(x: int) -> int:
         # Keep the shard alive long enough for the background sampler to emit.
@@ -343,10 +343,18 @@ def test_subprocess_finelog_stats_use_worker_connection(local_client, tmp_path, 
         def __init__(self) -> None:
             self.worker_rows: list[tuple[str, dict[str, int | float]]] = []
 
-        def emit_stage_stat(self, *args, **kwargs) -> None:
+        def emit_stage_stat(self, *_args, **_kwargs) -> None:
             pass
 
-        def emit_worker_stat(self, stage_name, shard_idx, execution_id, status, start_time, counters) -> None:
+        def emit_worker_stat(
+            self,
+            _stage_name,
+            _shard_idx,
+            _execution_id,
+            status,
+            _start_time,
+            counters,
+        ) -> None:
             self.worker_rows.append((status, counters))
 
         def close(self) -> None:
@@ -360,7 +368,7 @@ def test_subprocess_finelog_stats_use_worker_connection(local_client, tmp_path, 
         return writer
 
     monkeypatch.setattr(StatsWriter, "connect", staticmethod(make_writer))
-    monkeypatch.setattr(worker, "HEARTBEAT_INTERVAL", 0.01)
+    monkeypatch.setattr(worker, "WORKER_STATS_INTERVAL", 0.01)
 
     ctx = _ctx(local_client, tmp_path, stage_runner_factory=lambda: SubprocessRunner(), max_workers=1)
     try:

--- a/lib/zephyr/tests/test_runners.py
+++ b/lib/zephyr/tests/test_runners.py
@@ -19,16 +19,15 @@ from zephyr.execution import ZephyrContext, ZephyrWorkerError
 from zephyr.runners import InlineRunner, SubprocessRunner
 from zephyr.stats import (
     ZEPHYR_STAGE_STATS_NAMESPACE,
-    ZEPHYR_WORKER_MEM_PEAK_KEY,
     ZEPHYR_WORKER_STATS_NAMESPACE,
     StatsWriter,
 )
 
 
-def _ctx(local_client, tmp_path, *, stage_runner_factory, max_workers: int = 2) -> ZephyrContext:
+def _ctx(local_client, tmp_path, *, stage_runner_factory) -> ZephyrContext:
     return ZephyrContext(
         client=local_client,
-        max_workers=max_workers,
+        max_workers=2,
         resources=ResourceConfig(cpu=1, ram="512m"),
         chunk_storage_prefix=str(tmp_path / "chunks"),
         name=f"test-runner-{uuid.uuid4().hex[:8]}",
@@ -336,56 +335,3 @@ def test_finelog_stats_emitted(local_client, tmp_path, finelog_server, monkeypat
     # aggregate must therefore lie within the final per-shard averages.
     assert min(end_cpu_avg_pct) <= stage["cpu_pct_avg"] <= max(end_cpu_avg_pct)
     assert min(end_mem_avg_bytes) <= stage["mem_bytes_avg"] <= max(end_mem_avg_bytes)
-
-
-def test_subprocess_finelog_stats_use_worker_connection(local_client, tmp_path, monkeypatch):
-    class RecordingStatsWriter:
-        def __init__(self) -> None:
-            self.worker_rows: list[tuple[str, dict[str, int | float]]] = []
-
-        def emit_stage_stat(self, *_args, **_kwargs) -> None:
-            pass
-
-        def emit_worker_stat(
-            self,
-            _stage_name,
-            _shard_idx,
-            _execution_id,
-            status,
-            _start_time,
-            counters,
-        ) -> None:
-            self.worker_rows.append((status, counters))
-
-        def close(self) -> None:
-            pass
-
-    writers: list[RecordingStatsWriter] = []
-
-    def make_writer() -> RecordingStatsWriter:
-        writer = RecordingStatsWriter()
-        writers.append(writer)
-        return writer
-
-    monkeypatch.setattr(StatsWriter, "connect", staticmethod(make_writer))
-    monkeypatch.setattr(worker, "WORKER_STATS_INTERVAL", 0.01)
-
-    ctx = _ctx(local_client, tmp_path, stage_runner_factory=lambda: SubprocessRunner(), max_workers=1)
-    try:
-        ctx.execute(Dataset.from_list([1, 2, 3]).map(lambda value: value + 1))
-    finally:
-        ctx.shutdown()
-
-    worker_writers = [writer for writer in writers if writer.worker_rows]
-    assert len(worker_writers) == 1
-    worker_rows = worker_writers[0].worker_rows
-    statuses = [status for status, _ in worker_rows]
-    assert statuses.count("START") == 3
-    assert statuses.count("END") == 3
-    assert statuses[0] == "START"
-    assert "RUNNING" in statuses
-    assert statuses[-1] == "END"
-    assert "FAILED" not in statuses
-    running_counters = [counters for status, counters in worker_rows if status == "RUNNING"]
-    assert any(counters[ZEPHYR_WORKER_MEM_PEAK_KEY] > 0 for counters in running_counters)
-    assert worker_rows[-1][1][ZEPHYR_WORKER_MEM_PEAK_KEY] > 0


### PR DESCRIPTION
Write shard worker-stat rows through one Finelog client owned by each Zephyr
worker actor. Subprocess shards previously resolved the log endpoint and
created a client for every shard, producing a `LogClient resolved` message and
client lifecycle for each map task.

Sample subprocess CPU and RSS from the worker heartbeat using the child PID
when it reads sidecar counters. Merge periodic parent samples with the child's
terminal resource snapshot, preserving final CPU and memory values for shards
that finish before the first heartbeat.
