### PR TITLE
[agents] Keep design docs in their own workflow

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -126,7 +126,8 @@ Do not recursively rerun `--review` after small, targeted touch-ups made in
 response to its findings. Validate behavioral edits with the normal mechanical
 checks and relevant tests. For a formatter-only mechanical edit, rerun formatting
 and lint checks only. Rerun the advisory review only when the follow-up materially
-changes the branch's design or scope, or when the user asks for another pass.
+changes the branch's implementation approach or scope, or when the user asks for
+another pass.
 
 Each run writes the raw per-arm prompts and outputs, the combined findings, and a
 summary under `/tmp/marin-linter/<branch>/<timestamp>-<uniq>/` (the path is printed at the end) —
@@ -163,10 +164,6 @@ Fixes #1234
 **Issue linking.** If the work came from a GitHub issue, add `Fixes #NNNN`
 (auto-closes on merge) or `Part of #NNNN` (partial work). Do not invent an issue
 just to satisfy this — omit the link when none exists.
-
-**Specifications (>500 LOC only).** A genuinely large PR must link a spec in an
-issue or design doc. Name the important design decisions in the PR body and link
-the spec for module maps, code excerpts, and detailed rationale.
 
 **Inspect the payload.** Draft the body in a uniquely named temporary file and
 use `--body-file`. Re-open that file and apply the final compression pass before

--- a/.agents/skills/fix-issue/SKILL.md
+++ b/.agents/skills/fix-issue/SKILL.md
@@ -13,6 +13,11 @@ Read first:
 
 @AGENTS.md
 
+After fetching the issue, inspect its requested deliverable. If it explicitly
+asks for a design doc, one-pager, or proposal, stop this workflow and invoke
+`write-design-doc`. Do not infer this handoff from issue complexity or
+implementation scope.
+
 Complete tasks in order; the task list is at the end of this document. If you
 cannot complete a task, write a Github comment with your last status and why.
 

--- a/.agents/skills/fix-issue/SKILL.md
+++ b/.agents/skills/fix-issue/SKILL.md
@@ -62,21 +62,14 @@ Example:
 
 Title: `# Proposed Fix`
 
-There are 2 cases:
+State the root cause or missing behavior, then describe the smallest fix. For a
+bug, show the call chain that triggers the error. Include a code snippet only if
+the fix is non-obvious.
 
-* **Bug fix**: Show the call chain that triggers the error, then state the fix
-  in one sentence. Include a code snippet only if the fix is non-obvious.
+> `env.run()` returns a tuple; `foo()` assumes an object and calls `.abc()`.
+> Fix: unwrap the tuple in `RolloutWorker._step()` before passing to `foo()`.
 
-  > `env.run()` returns a tuple; `foo()` assumes an object and calls `.abc()`.
-  > Fix: unwrap the tuple in `RolloutWorker._step()` before passing to `foo()`.
-
-* **Design change**: The design doc replaces the `# Proposed Fix` section.
-  Write it per `.agents/skills/write-design-doc/SKILL.md` directly in the issue comment
-  (agents cannot commit files before the PR). The 3-4 sentence prose cap
-  applies to `# Research`; the design doc follows its own length guidelines.
-  Keep everything in one comment.
-
-In both cases: find the minimally disruptive fix. Do not over-engineer.
+Find the minimally disruptive fix. Do not over-engineer.
 
 ## Implementation
 
@@ -120,7 +113,7 @@ The tasks for this skill:
 - [ ] Fetch issue information
 - [ ] Research codebase for all relevant source files
 - [ ] Run duplicate-work preflight against open PRs/issues
-- [ ] Formulate fix and post Research + Proposed Fix comment
+- [ ] Post Research and Proposed Fix
 - [ ] Create branch for the changes
 - [ ] Write a test case as needed for changes
 - [ ] Implement changes until all tests pass

--- a/.agents/skills/fix-issue/SKILL.md
+++ b/.agents/skills/fix-issue/SKILL.md
@@ -13,11 +13,6 @@ Read first:
 
 @AGENTS.md
 
-After fetching the issue, inspect its requested deliverable. If it explicitly
-asks for a design doc, one-pager, or proposal, stop this workflow and invoke
-`write-design-doc`. Do not infer this handoff from issue complexity or
-implementation scope.
-
 Complete tasks in order; the task list is at the end of this document. If you
 cannot complete a task, write a Github comment with your last status and why.
 

--- a/.agents/skills/write-design-doc/SKILL.md
+++ b/.agents/skills/write-design-doc/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: write-design-doc
-description: Produce a 1-page design proposal for an explicit design task or a design-level change identified by another change workflow. Do not use to answer or evaluate an idea inline.
+description: Produce a 1-page design proposal when the user explicitly asks for one. Do not use to answer or evaluate an idea inline.
 ---
 
 # Skill: Design Doc Workflow
 
 ## Purpose
 
-A design doc in Marin is a ~1-page document posted as a PR for early feedback. It surfaces design issues *before* implementation, not to gate work — area owners LGTM or comment quickly, and the author implements in parallel. See [issue #5210](https://github.com/marin-community/marin/issues/5210) for rationale.
+A design doc in Marin is a ~1-page proposal for early feedback before
+implementation. Area owners LGTM or comment quickly, and the author implements
+in parallel. See [issue #5210](https://github.com/marin-community/marin/issues/5210)
+for rationale.
 
 This skill is **interactive**: ask the user questions when you genuinely don't know, but make reasonable inferences and proceed when you can.
 
@@ -22,33 +25,22 @@ The template lives at `.agents/projects/design-template.md`. New docs go to a sl
 ## When to use this skill
 
 This is a change-mode design workflow. Use it only when the user explicitly
-asks for a design doc/one-pager/proposal, or when another change-mode playbook
-such as `fix-issue` identifies a design-level change and invokes this skill.
-Follow the calling playbook's delivery target: `fix-issue` embeds the proposal
-in its issue comment, while a standalone design task uses the repository files
-and publishing steps below. Do **not** use this skill for questions,
-walkthroughs, informal architecture reviews, or requests to assess whether an
-idea is reasonable. Investigate those requests and answer inline; start a
-standalone design workflow only after an explicit follow-up asks to publish a
-design.
+asks to create a design doc, one-pager, or proposal. Diff size, complexity,
+duration, and cross-subproject scope do not invoke this skill. This skill owns
+the repository files and publishing workflow for design artifacts.
 
-- A task will likely take more than a day, or is load-bearing for other work.
-- A change crosses subproject boundaries (e.g. iris ↔ levanter, marin ↔ zephyr).
-- A change introduces a new service, package, or persistent data shape.
-
-If the explicit design request meets none of these criteria, confirm that a
-design artifact is actually wanted. For an ordinary small change, use the
-normal implementation workflow instead of manufacturing a design doc.
+Do **not** use this skill for questions, walkthroughs, informal architecture
+reviews, or requests to assess whether an idea is reasonable. Investigate those
+requests and answer inline. Start this workflow only after the user explicitly
+asks for a design.
 
 ---
 
 # Workflow
 
-The standalone workflow has seven phases. A calling change-mode playbook may
-reuse the design guidance while overriding persistence and publication, as
-`fix-issue` does for a single issue comment. Confirm with the user at natural
-decision points (after Research, Draft, Spec, before Publish), but don't ask
-permission when the next step is obvious.
+The workflow has seven phases. Confirm with the user at natural decision points
+(after Research, Draft, Spec, before Publish), but don't ask permission when the
+next step is obvious.
 
 ## 1. Frame
 

--- a/.agents/skills/writing-style/pull-requests.md
+++ b/.agents/skills/writing-style/pull-requests.md
@@ -31,9 +31,9 @@ Prefer `[sft] Add the OpenCode chat template` over
   explain the change or affect the review decision. State them once and link
   detailed evidence when the full record belongs elsewhere.
 - End with `Fixes #NNNN` or `Part of #NNNN` when applicable.
-- Put specifications, extended raw benchmark output, and research history in an
-  issue, design doc, logbook, or artifact and link it. Keep the reproduction
-  detail and result summary needed to evaluate the change.
+- Put extended raw benchmark output and research history in an issue, logbook,
+  or artifact and link it. Keep the reproduction detail and result summary
+  needed to evaluate the change.
 
 The body must stand alone, but it does not need to reproduce the diff. Delete:
 
@@ -42,7 +42,7 @@ The body must stand alone, but it does not need to reproduce the diff. Delete:
 - `Testing`, `Validation`, `Verification`, `What`, `Changes`, or `Summary`
   scaffolds;
 - claims framed as verdicts, such as `why this is correct`, `cleaner`, or
-  `provably`, when a measured result or explicit design choice says more;
+  `provably`, when a measured result or explicit technical choice says more;
 - boldface, all-caps emphasis, checkboxes, emoji, and attribution or session
   trailers;
 - filler openers such as `This PR`, `In this change`, or `Summary of changes`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ uv run --no-project infra/ci/run_tests.py
 - Run this once before opening or updating a PR, and fix or respond to every
   finding it reports (see the `commit` skill). Do not rerun it after small,
   targeted touch-ups made in response to its findings. Rerun only when the
-  follow-up materially changes the design or scope.
+  follow-up materially changes the implementation approach or scope.
 ```
 
 - Python >=3.12. Use `uv run` for entry points.
@@ -108,7 +108,7 @@ uv run --no-project infra/ci/run_tests.py
   reader needs to understand the behavior and rationale, including measured
   results and caveats when they affect review. Remove headings, diff narration,
   and implementation inventories; put extended history in a linked issue,
-  design doc, logbook, or artifact. Follow the `commit` skill
+  logbook, or artifact. Follow the `commit` skill
   (`.agents/skills/commit/SKILL.md`) when committing, pushing, or opening a PR.
 - PR monitoring is part of the `commit` skill. After opening or updating a PR,
   follow its `wait_for.py` loop through an exit condition. Do not substitute
@@ -203,6 +203,9 @@ Watch for and eliminate these patterns in generated code:
 
 ## Planning
 
+- The `write-design-doc` skill owns design-doc creation and runs only when the
+  user explicitly asks for one. Diff size and implementation complexity do not
+  require a design artifact.
 - Planning applies to change-mode work. Produce a detailed plan, with code
   snippets when they clarify a concrete implementation, for non-trivial
   changes. Resolve context from the repository and prior work first; ask only

--- a/docs/explanations/guidelines.md
+++ b/docs/explanations/guidelines.md
@@ -34,8 +34,7 @@ guidelines.
 # GitHub pull requests
 
 Agents can use the `commit` skill for PR
-description style, testing requirements, self-review, and specification
-guidelines.
+description style, testing requirements, and self-review.
 
 ## General code style
 


### PR DESCRIPTION
Run the design-doc workflow only when a user explicitly requests a design
artifact. Remove the >500-LOC specification gate and automatic design
classification from ordinary change workflows.
