### PR TITLE
[grafana] Add cluster capacity packing view

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -42,7 +42,8 @@ GET /overview/provisioning                         latest fleet and resource-poo
 GET /k8s/control_plane | crashloops | pending     CW control-plane state, all clusters
 GET /k8s/termination_candidates | kueue | events | health
                                                     ... one response, `cluster` column
-GET /k8s/nodes                                    node inventory, topology, readiness, lifecycle state
+GET /k8s/workloads                                live Iris task placement and requested resources
+GET /k8s/nodes                                    node inventory, allocatable resources, readiness, lifecycle state
 GET /k8s/node_pools                               NodePool capacity, autoscaling policy, conditions
 GET /k8s/finelog | finelog_events                 mirror pods/PVCs and matching warnings
 GET /k8s/overview                                 explicit pending/crashloop counts
@@ -199,6 +200,7 @@ Each dashboard answers one question, and they link to each other in a fixed nav 
 | `nodes.json` | What is happening on one physical GPU node? | cluster, node |
 | `node_pools.json` | Is CoreWeave capacity at target? | cluster |
 | `jobs.json` | What is running, queued, and stuck — and why? | cluster, job |
+| `cluster_capacity.json` | What jobs and requests occupy one cluster and node? | cluster |
 | `runs.json` | How is each Levanter training run doing? | cluster, run |
 | `clusters.json` | Is the infrastructure under the jobs healthy? | cluster |
 | `pipelines.json` | How is one Zephyr execution moving? | cluster, execution |
@@ -226,6 +228,16 @@ TPU hosts report no power, so this dashboard covers the GPU clusters only.
 Power is attributed to a run by joining the node agent's `node_name` to the
 `node_name` on Levanter's resource attributes, per time bucket — the residue is
 `(idle / unattributed)`, which is the number worth driving down.
+
+`cluster_capacity.json` is the quick occupancy view for one cluster. It combines
+live `/k8s/workloads` placement and scheduler requests with `/k8s/nodes`
+allocatable CPU, memory, and GPU capacity. The custom panel rolls tasks up by
+root job and renders each GPU node as a block-packing card, with unallocated GPU
+slots left visible. Recent `iris.task` samples supply per-job CPU and working-set
+memory; `iris-node-agent` telemetry supplies host CPU/memory and aggregate GPU/HBM
+pressure. Scheduler requests and observed utilization are labeled separately
+because neither is a substitute for the other. The default cluster is
+`cw-us-east-02a`; the selector is single-valued to keep placement legible.
 
 `nodes.json` is the selected-node view. Its live row reads `/k8s/nodes`; bounded
 Finelog panels retain per-GPU utilization, SM/tensor activity, HBM, core/HBM

--- a/infra/grafana/dashboards/cluster_capacity.json
+++ b/infra/grafana/dashboards/cluster_capacity.json
@@ -1,0 +1,425 @@
+{
+  "uid": "marin-cluster-capacity",
+  "title": "Cluster capacity",
+  "description": "What is tying up one cluster right now: live Iris jobs, Kubernetes placement and requested resources, node capacity, and recent observed CPU, memory, GPU, and HBM utilization. GPU blocks show scheduler allocation; live percentages come from the node-agent telemetry stream.",
+  "tags": [
+    "marin",
+    "generated"
+  ],
+  "timezone": "utc",
+  "editable": false,
+  "schemaVersion": 42,
+  "refresh": "30s",
+  "time": {
+    "from": "now-10m",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "cluster",
+        "label": "Cluster",
+        "type": "custom",
+        "description": "One cluster at a time so the packing diagram remains legible. CoreWeave clusters expose live Kubernetes placement; marin and marin-dev currently render an empty placement view.",
+        "query": "cw-rno2a,cw-us-east-02a,cw-us-east-08a,marin,marin-dev",
+        "options": [
+          {
+            "selected": false,
+            "text": "cw-rno2a",
+            "value": "cw-rno2a"
+          },
+          {
+            "selected": true,
+            "text": "cw-us-east-02a",
+            "value": "cw-us-east-02a"
+          },
+          {
+            "selected": false,
+            "text": "cw-us-east-08a",
+            "value": "cw-us-east-08a"
+          },
+          {
+            "selected": false,
+            "text": "marin",
+            "value": "marin"
+          },
+          {
+            "selected": false,
+            "text": "marin-dev",
+            "value": "marin-dev"
+          }
+        ],
+        "current": {
+          "selected": true,
+          "text": "cw-us-east-02a",
+          "value": "cw-us-east-02a"
+        },
+        "includeAll": false,
+        "multi": false,
+        "hide": 0,
+        "refresh": 0
+      }
+    ]
+  },
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Home",
+      "type": "link",
+      "url": "/d/marin-home"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Jobs",
+      "type": "link",
+      "url": "/d/marin-jobs"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Fleet health",
+      "type": "link",
+      "url": "/d/marin-clusters"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Node details",
+      "type": "link",
+      "url": "/d/marin-nodes"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Accelerators",
+      "type": "link",
+      "url": "/d/marin-accel"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Infra",
+      "type": "link",
+      "url": "/d/infra"
+    }
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "type": "marin-infra-panel",
+      "title": "",
+      "transparent": true,
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "status"
+      },
+      "gridPos": {
+        "h": 40,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "view": "cluster"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "W",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/k8s/workloads",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "cluster",
+                "value": "${cluster}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "namespace",
+              "text": "namespace",
+              "type": "string"
+            },
+            {
+              "selector": "pod",
+              "text": "pod",
+              "type": "string"
+            },
+            {
+              "selector": "node",
+              "text": "node",
+              "type": "string"
+            },
+            {
+              "selector": "job",
+              "text": "job",
+              "type": "string"
+            },
+            {
+              "selector": "task",
+              "text": "task",
+              "type": "string"
+            },
+            {
+              "selector": "phase",
+              "text": "phase",
+              "type": "string"
+            },
+            {
+              "selector": "ready",
+              "text": "ready",
+              "type": "boolean"
+            },
+            {
+              "selector": "priority_class",
+              "text": "priority_class",
+              "type": "string"
+            },
+            {
+              "selector": "age_seconds",
+              "text": "age_seconds",
+              "type": "number"
+            },
+            {
+              "selector": "cpu_request_millicores",
+              "text": "cpu_request_millicores",
+              "type": "number"
+            },
+            {
+              "selector": "memory_request_bytes",
+              "text": "memory_request_bytes",
+              "type": "number"
+            },
+            {
+              "selector": "gpu_request_count",
+              "text": "gpu_request_count",
+              "type": "number"
+            },
+            {
+              "selector": "gpu_variant",
+              "text": "gpu_variant",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "refId": "N",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/k8s/nodes",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "cluster",
+                "value": "${cluster}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "node",
+              "text": "node",
+              "type": "string"
+            },
+            {
+              "selector": "instance_type",
+              "text": "instance_type",
+              "type": "string"
+            },
+            {
+              "selector": "node_pool",
+              "text": "node_pool",
+              "type": "string"
+            },
+            {
+              "selector": "gpu_model",
+              "text": "gpu_model",
+              "type": "string"
+            },
+            {
+              "selector": "gpu_capacity",
+              "text": "gpu_capacity",
+              "type": "number"
+            },
+            {
+              "selector": "gpu_allocatable",
+              "text": "gpu_allocatable",
+              "type": "number"
+            },
+            {
+              "selector": "cpu_allocatable",
+              "text": "cpu_allocatable",
+              "type": "string"
+            },
+            {
+              "selector": "memory_allocatable",
+              "text": "memory_allocatable",
+              "type": "string"
+            },
+            {
+              "selector": "ready",
+              "text": "ready",
+              "type": "boolean"
+            },
+            {
+              "selector": "unschedulable",
+              "text": "unschedulable",
+              "type": "boolean"
+            }
+          ]
+        },
+        {
+          "refId": "T",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/finelog/marin/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "WITH latest AS ( SELECT COALESCE(NULLIF(\"cluster\", ''), 'marin') AS source_cluster, task_id AS task, worker_id AS pod, cpu_millicores, memory_mb * 1048576 AS memory_bytes, ts AS sampled_at, ROW_NUMBER() OVER (PARTITION BY COALESCE(NULLIF(\"cluster\", ''), 'marin'), task_id, worker_id ORDER BY ts DESC) AS row_number FROM \"iris.task\" WHERE COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND ts >= {{from}} AND ts < {{to}} ) SELECT source_cluster AS \"cluster\", task, pod, cpu_millicores, memory_bytes, sampled_at FROM latest WHERE row_number = 1 ORDER BY task, pod"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "task",
+              "text": "task",
+              "type": "string"
+            },
+            {
+              "selector": "pod",
+              "text": "pod",
+              "type": "string"
+            },
+            {
+              "selector": "cpu_millicores",
+              "text": "cpu_millicores",
+              "type": "number"
+            },
+            {
+              "selector": "memory_bytes",
+              "text": "memory_bytes",
+              "type": "number"
+            },
+            {
+              "selector": "sampled_at",
+              "text": "sampled_at",
+              "type": "timestamp_epoch"
+            }
+          ]
+        },
+        {
+          "refId": "H",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/finelog/marin/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "WITH latest AS ( SELECT COALESCE(NULLIF(\"cluster\", ''), 'marin') AS source_cluster, json_get(attributes_json, 'node_name') AS node, name, COALESCE(json_get(attributes_json, 'gpu_uuid'), '') AS gpu, value, timestamp_ms, ROW_NUMBER() OVER (PARTITION BY COALESCE(NULLIF(\"cluster\", ''), 'marin'), json_get(attributes_json, 'node_name'), name, COALESCE(json_get(attributes_json, 'gpu_uuid'), '') ORDER BY timestamp_ms DESC) AS row_number FROM \"telemetry_v1\" WHERE service = 'iris-node-agent' AND name IN ('node_cpu_utilization_percent', 'node_memory_used_bytes', 'node_memory_total_bytes', 'gpu_utilization_percent', 'gpu_memory_used_bytes', 'gpu_memory_total_bytes') AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) ) SELECT source_cluster AS \"cluster\", node, name, CASE WHEN name IN ('gpu_memory_used_bytes', 'gpu_memory_total_bytes') THEN SUM(value) ELSE AVG(value) END AS value, MAX(timestamp_ms) AS sampled_at FROM latest WHERE row_number = 1 AND node <> '' GROUP BY source_cluster, node, name ORDER BY node, name"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "node",
+              "text": "node",
+              "type": "string"
+            },
+            {
+              "selector": "name",
+              "text": "name",
+              "type": "string"
+            },
+            {
+              "selector": "value",
+              "text": "value",
+              "type": "number"
+            },
+            {
+              "selector": "sampled_at",
+              "text": "sampled_at",
+              "type": "timestamp_epoch"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/infra/grafana/dashboards/clusters.json
+++ b/infra/grafana/dashboards/clusters.json
@@ -82,6 +82,16 @@
       "includeVars": true,
       "keepTime": true,
       "targetBlank": false,
+      "title": "Cluster capacity",
+      "type": "link",
+      "url": "/d/marin-cluster-capacity"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
       "title": "Accelerators",
       "type": "link",
       "url": "/d/marin-accel"

--- a/infra/grafana/dashboards/clusters.json
+++ b/infra/grafana/dashboards/clusters.json
@@ -77,14 +77,7 @@
       "url": "/d/marin-home"
     },
     {
-      "asDropdown": false,
-      "icon": "dashboard",
-      "includeVars": true,
-      "keepTime": true,
-      "targetBlank": false,
-      "title": "Cluster capacity",
-      "type": "link",
-      "url": "/d/marin-cluster-capacity"
+      "linkRef": "cluster_capacity"
     },
     {
       "asDropdown": false,

--- a/infra/grafana/dashboards/home.json
+++ b/infra/grafana/dashboards/home.json
@@ -132,6 +132,16 @@
       "includeVars": true,
       "keepTime": true,
       "targetBlank": false,
+      "title": "Cluster capacity",
+      "type": "link",
+      "url": "/d/marin-cluster-capacity"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
       "title": "Pipelines",
       "type": "link",
       "url": "/d/marin-pipelines"

--- a/infra/grafana/dashboards/home.json
+++ b/infra/grafana/dashboards/home.json
@@ -127,14 +127,7 @@
       "url": "/d/marin-clusters"
     },
     {
-      "asDropdown": false,
-      "icon": "dashboard",
-      "includeVars": true,
-      "keepTime": true,
-      "targetBlank": false,
-      "title": "Cluster capacity",
-      "type": "link",
-      "url": "/d/marin-cluster-capacity"
+      "linkRef": "cluster_capacity"
     },
     {
       "asDropdown": false,

--- a/infra/grafana/dashboards/infra.json
+++ b/infra/grafana/dashboards/infra.json
@@ -88,14 +88,7 @@
       "url": "/d/marin-clusters"
     },
     {
-      "asDropdown": false,
-      "icon": "dashboard",
-      "includeVars": false,
-      "keepTime": true,
-      "targetBlank": false,
-      "title": "Cluster capacity",
-      "type": "link",
-      "url": "/d/marin-cluster-capacity"
+      "linkRef": "cluster_capacity_without_vars"
     },
     {
       "asDropdown": false,

--- a/infra/grafana/dashboards/infra.json
+++ b/infra/grafana/dashboards/infra.json
@@ -93,6 +93,16 @@
       "includeVars": false,
       "keepTime": true,
       "targetBlank": false,
+      "title": "Cluster capacity",
+      "type": "link",
+      "url": "/d/marin-cluster-capacity"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "targetBlank": false,
       "title": "Pipelines",
       "type": "link",
       "url": "/d/marin-pipelines"

--- a/infra/grafana/dashboards/jobs.json
+++ b/infra/grafana/dashboards/jobs.json
@@ -195,6 +195,16 @@
       "includeVars": true,
       "keepTime": true,
       "targetBlank": false,
+      "title": "Cluster capacity",
+      "type": "link",
+      "url": "/d/marin-cluster-capacity"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
       "title": "Pipelines",
       "type": "link",
       "url": "/d/marin-pipelines"

--- a/infra/grafana/dashboards/jobs.json
+++ b/infra/grafana/dashboards/jobs.json
@@ -190,14 +190,7 @@
       "url": "/d/marin-clusters"
     },
     {
-      "asDropdown": false,
-      "icon": "dashboard",
-      "includeVars": true,
-      "keepTime": true,
-      "targetBlank": false,
-      "title": "Cluster capacity",
-      "type": "link",
-      "url": "/d/marin-cluster-capacity"
+      "linkRef": "cluster_capacity"
     },
     {
       "asDropdown": false,

--- a/infra/grafana/dashboards/nodes.json
+++ b/infra/grafana/dashboards/nodes.json
@@ -81,6 +81,16 @@
       "includeVars": true,
       "keepTime": true,
       "targetBlank": false,
+      "title": "Cluster capacity",
+      "type": "link",
+      "url": "/d/marin-cluster-capacity"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
       "title": "Pipelines",
       "type": "link",
       "url": "/d/marin-pipelines"

--- a/infra/grafana/dashboards/nodes.json
+++ b/infra/grafana/dashboards/nodes.json
@@ -76,14 +76,7 @@
       "url": "/d/marin-clusters"
     },
     {
-      "asDropdown": false,
-      "icon": "dashboard",
-      "includeVars": true,
-      "keepTime": true,
-      "targetBlank": false,
-      "title": "Cluster capacity",
-      "type": "link",
-      "url": "/d/marin-cluster-capacity"
+      "linkRef": "cluster_capacity"
     },
     {
       "asDropdown": false,

--- a/infra/grafana/marin-infra-panel/src/components/ClusterCapacity.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/ClusterCapacity.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/css';
 import { DataFrame } from '@grafana/data';
 import { useTheme2 } from '@grafana/ui';
 import { clusterNodes, frameByRefId, nodeMetrics, taskUsage, workloadAllocations } from '../data';
+import { formatBytes } from '../format';
 import { ClusterNode, NodeMetric, TaskUsage, WorkloadAllocation } from '../types';
 import { SERIES_COLORS } from './palette';
 
@@ -26,6 +27,9 @@ interface JobSummary {
 
 const REF = { workloads: 'W', nodes: 'N', tasks: 'T', host: 'H' } as const;
 const KIB = 1024;
+const MILLICORES_PER_CORE = 1000;
+const SECONDS_PER_MINUTE = 60;
+const SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE;
 
 function frameRows<T>(frames: DataFrame[], refId: string, read: (frame: DataFrame) => T[]): T[] {
   const frame = frameByRefId(frames, refId);
@@ -33,33 +37,24 @@ function frameRows<T>(frames: DataFrame[], refId: string, read: (frame: DataFram
 }
 
 function formatCores(millicores: number): string {
-  const cores = millicores / 1000;
+  const cores = millicores / MILLICORES_PER_CORE;
   return cores >= 100 ? Math.round(cores).toString() : cores.toFixed(cores >= 10 ? 1 : 2);
 }
 
-function formatBytes(bytes: number): string {
-  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
-  let value = bytes;
-  let unit = 0;
-  while (value >= KIB && unit < units.length - 1) {
-    value /= KIB;
-    unit += 1;
-  }
-  return `${value >= 100 ? Math.round(value) : value.toFixed(1)} ${units[unit]}`;
-}
-
 function formatAge(seconds: number): string {
-  if (seconds < 3600) {
-    return `${Math.max(1, Math.round(seconds / 60))}m`;
+  if (seconds < SECONDS_PER_HOUR) {
+    return `${Math.max(1, Math.round(seconds / SECONDS_PER_MINUTE))}m`;
   }
-  return `${(seconds / 3600).toFixed(1)}h`;
+  return `${(seconds / SECONDS_PER_HOUR).toFixed(1)}h`;
 }
 
 function parseCpu(quantity: string): number {
   if (!quantity) {
     return 0;
   }
-  return quantity.endsWith('m') ? Number(quantity.slice(0, -1)) : Number(quantity) * 1000;
+  return quantity.endsWith('m')
+    ? Number(quantity.slice(0, -1))
+    : Number(quantity) * MILLICORES_PER_CORE;
 }
 
 function parseMemory(quantity: string): number {
@@ -71,7 +66,7 @@ function parseMemory(quantity: string): number {
   return Number(match[1]) * KIB ** units.indexOf(match[2] ?? '');
 }
 
-function percent(value?: number): string {
+function formatPercent(value?: number): string {
   return value === undefined ? '—' : `${Math.round(value)}%`;
 }
 
@@ -138,7 +133,7 @@ function ResourceBar({ label, used, capacity, actual }: { label: string; used: n
       <div className={css`height:6px;border-radius:4px;background:${theme.colors.background.canvas};overflow:hidden;`}>
         <div className={css`width:${reserved}%;height:100%;background:${theme.colors.primary.main};`} />
       </div>
-      <span>{Math.round(reserved)}% req{actual === undefined ? '' : ` · ${percent(actual)} live`}</span>
+      <span>{Math.round(reserved)}% req{actual === undefined ? '' : ` · ${formatPercent(actual)} live`}</span>
     </div>
   );
 }
@@ -185,7 +180,7 @@ function NodeCard({ node, workloads, metrics, jobs }: {
               return <div role="listitem" aria-label={workload ? `${workload.job} GPU` : 'Unallocated GPU'} title={workload?.task ?? 'Unallocated'} key={index} className={css`height:25px;border-radius:3px;border:1px solid ${workload ? jobColor(workload.job, jobs) : theme.colors.border.weak};background:${workload ? `${jobColor(workload.job, jobs)}33` : theme.colors.background.canvas};overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:4px;box-sizing:border-box;font-size:9px;`}>{workload ? shortJob(workload.job) : ''}</div>;
             })}
           </div>
-          <div className={css`font-size:11px;color:${theme.colors.text.secondary};margin-top:4px;`}>GPU {percent(metric('gpu_utilization_percent'))} live · HBM {percent(gpuMemoryPercent)}</div>
+          <div className={css`font-size:11px;color:${theme.colors.text.secondary};margin-top:4px;`}>GPU {formatPercent(metric('gpu_utilization_percent'))} live · HBM {formatPercent(gpuMemoryPercent)}</div>
         </div>
       )}
       <ResourceBar label="CPU" used={cpuRequested} capacity={cpuCapacity} actual={metric('node_cpu_utilization_percent')} />

--- a/infra/grafana/marin-infra-panel/src/components/ClusterCapacity.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/ClusterCapacity.tsx
@@ -1,0 +1,265 @@
+import React, { useMemo } from 'react';
+import { css } from '@emotion/css';
+import { DataFrame } from '@grafana/data';
+import { useTheme2 } from '@grafana/ui';
+import { clusterNodes, frameByRefId, nodeMetrics, taskUsage, workloadAllocations } from '../data';
+import { ClusterNode, NodeMetric, TaskUsage, WorkloadAllocation } from '../types';
+import { SERIES_COLORS } from './palette';
+
+interface Props {
+  frames: DataFrame[];
+  width: number;
+  height: number;
+}
+
+interface JobSummary {
+  job: string;
+  tasks: number;
+  ready: number;
+  observed: number;
+  cpuRequestMillicores: number;
+  memoryRequestBytes: number;
+  gpuRequestCount: number;
+  cpuMillicores: number;
+  memoryBytes: number;
+}
+
+const REF = { workloads: 'W', nodes: 'N', tasks: 'T', host: 'H' } as const;
+const KIB = 1024;
+
+function frameRows<T>(frames: DataFrame[], refId: string, read: (frame: DataFrame) => T[]): T[] {
+  const frame = frameByRefId(frames, refId);
+  return frame ? read(frame) : [];
+}
+
+function formatCores(millicores: number): string {
+  const cores = millicores / 1000;
+  return cores >= 100 ? Math.round(cores).toString() : cores.toFixed(cores >= 10 ? 1 : 2);
+}
+
+function formatBytes(bytes: number): string {
+  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB'];
+  let value = bytes;
+  let unit = 0;
+  while (value >= KIB && unit < units.length - 1) {
+    value /= KIB;
+    unit += 1;
+  }
+  return `${value >= 100 ? Math.round(value) : value.toFixed(1)} ${units[unit]}`;
+}
+
+function formatAge(seconds: number): string {
+  if (seconds < 3600) {
+    return `${Math.max(1, Math.round(seconds / 60))}m`;
+  }
+  return `${(seconds / 3600).toFixed(1)}h`;
+}
+
+function parseCpu(quantity: string): number {
+  if (!quantity) {
+    return 0;
+  }
+  return quantity.endsWith('m') ? Number(quantity.slice(0, -1)) : Number(quantity) * 1000;
+}
+
+function parseMemory(quantity: string): number {
+  const match = quantity.match(/^([0-9.]+)([KMGTEP]i)?$/);
+  if (!match) {
+    return 0;
+  }
+  const units = ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi'];
+  return Number(match[1]) * KIB ** units.indexOf(match[2] ?? '');
+}
+
+function percent(value?: number): string {
+  return value === undefined ? '—' : `${Math.round(value)}%`;
+}
+
+function shortJob(job: string): string {
+  return job.split('/').filter(Boolean).slice(-2).join('/');
+}
+
+function jobColor(job: string, jobs: string[]): string {
+  return SERIES_COLORS[jobs.indexOf(job) % SERIES_COLORS.length];
+}
+
+function metricMap(metrics: NodeMetric[]): Map<string, number> {
+  return new Map(metrics.map((metric) => [`${metric.node}\u0000${metric.name}`, metric.value]));
+}
+
+function usageMap(usage: TaskUsage[]): Map<string, TaskUsage> {
+  return new Map(usage.flatMap((row) => [[row.pod, row], [row.task, row]]));
+}
+
+function summarizeJobs(workloads: WorkloadAllocation[], usage: Map<string, TaskUsage>): JobSummary[] {
+  const summaries = new Map<string, JobSummary>();
+  for (const workload of workloads) {
+    const observed = usage.get(workload.pod) ?? usage.get(workload.task);
+    const summary = summaries.get(workload.job) ?? {
+      job: workload.job,
+      tasks: 0,
+      ready: 0,
+      observed: 0,
+      cpuRequestMillicores: 0,
+      memoryRequestBytes: 0,
+      gpuRequestCount: 0,
+      cpuMillicores: 0,
+      memoryBytes: 0,
+    };
+    summary.tasks += 1;
+    summary.ready += Number(workload.ready);
+    summary.observed += Number(observed !== undefined);
+    summary.cpuRequestMillicores += workload.cpuRequestMillicores;
+    summary.memoryRequestBytes += workload.memoryRequestBytes;
+    summary.gpuRequestCount += workload.gpuRequestCount;
+    summary.cpuMillicores += observed?.cpuMillicores ?? 0;
+    summary.memoryBytes += observed?.memoryBytes ?? 0;
+    summaries.set(workload.job, summary);
+  }
+  return [...summaries.values()].sort((a, b) => b.gpuRequestCount - a.gpuRequestCount || a.job.localeCompare(b.job));
+}
+
+function Stat({ value, label }: { value: React.ReactNode; label: string }) {
+  const theme = useTheme2();
+  return (
+    <div className={css`min-width:112px;padding:10px 12px;border:1px solid ${theme.colors.border.weak};border-radius:6px;background:${theme.colors.background.secondary};`}>
+      <strong className={css`display:block;font-size:20px;line-height:1.2;`}>{value}</strong>
+      <span className={css`font-size:12px;color:${theme.colors.text.secondary};`}>{label}</span>
+    </div>
+  );
+}
+
+function ResourceBar({ label, used, capacity, actual }: { label: string; used: number; capacity: number; actual?: number }) {
+  const theme = useTheme2();
+  const reserved = capacity > 0 ? Math.min(100, used / capacity * 100) : 0;
+  return (
+    <div className={css`display:grid;grid-template-columns:44px 1fr auto;gap:7px;align-items:center;font-size:11px;`}>
+      <span className={css`color:${theme.colors.text.secondary};`}>{label}</span>
+      <div className={css`height:6px;border-radius:4px;background:${theme.colors.background.canvas};overflow:hidden;`}>
+        <div className={css`width:${reserved}%;height:100%;background:${theme.colors.primary.main};`} />
+      </div>
+      <span>{Math.round(reserved)}% req{actual === undefined ? '' : ` · ${percent(actual)} live`}</span>
+    </div>
+  );
+}
+
+function NodeCard({ node, workloads, metrics, jobs }: {
+  node: ClusterNode;
+  workloads: WorkloadAllocation[];
+  metrics: Map<string, number>;
+  jobs: string[];
+}) {
+  const theme = useTheme2();
+  const gpuCapacity = node.gpuAllocatable || node.gpuCapacity;
+  const assigned = workloads.flatMap((workload) =>
+    Array.from({ length: workload.gpuRequestCount }, () => workload)
+  );
+  const cpuRequested = workloads.reduce((sum, workload) => sum + workload.cpuRequestMillicores, 0);
+  const memoryRequested = workloads.reduce((sum, workload) => sum + workload.memoryRequestBytes, 0);
+  const cpuCapacity = parseCpu(node.cpuAllocatable);
+  const memoryCapacity = parseMemory(node.memoryAllocatable);
+  const metric = (name: string) => metrics.get(`${node.node}\u0000${name}`);
+  const memoryUsed = metric('node_memory_used_bytes');
+  const memoryTotal = metric('node_memory_total_bytes');
+  const memoryPercent = memoryUsed !== undefined && memoryTotal ? memoryUsed / memoryTotal * 100 : undefined;
+  const gpuMemoryUsed = metric('gpu_memory_used_bytes');
+  const gpuMemoryTotal = metric('gpu_memory_total_bytes');
+  const gpuMemoryPercent = gpuMemoryUsed !== undefined && gpuMemoryTotal ? gpuMemoryUsed / gpuMemoryTotal * 100 : undefined;
+  const unhealthy = !node.ready || node.unschedulable;
+  const detailUrl = `/d/marin-nodes?var-cluster=${encodeURIComponent(node.cluster)}&var-node=${encodeURIComponent(node.node)}`;
+  return (
+    <article aria-label={`Node ${node.node}`} className={css`border:1px solid ${unhealthy ? theme.colors.error.border : theme.colors.border.weak};border-radius:7px;background:${theme.colors.background.secondary};padding:11px;display:flex;flex-direction:column;gap:9px;`}>
+      <header className={css`display:flex;justify-content:space-between;gap:10px;`}>
+        <div>
+          <a href={detailUrl} className={css`font-family:${theme.typography.fontFamilyMonospace};font-weight:600;`}>{node.node}</a>
+          <div className={css`font-size:11px;color:${theme.colors.text.secondary};`}>{node.nodePool || node.instanceType || 'unclassified'} · {node.gpuModel || 'CPU'}</div>
+        </div>
+        <span className={css`font-size:11px;color:${unhealthy ? theme.colors.error.text : theme.colors.text.secondary};`}>{unhealthy ? (node.ready ? 'cordoned' : 'not ready') : 'ready'}</span>
+      </header>
+      {gpuCapacity > 0 && (
+        <div>
+          <div className={css`display:flex;justify-content:space-between;font-size:11px;margin-bottom:5px;`}><span>GPU packing</span><strong>{assigned.length}/{gpuCapacity}</strong></div>
+          <div role="list" aria-label={`GPU slots on ${node.node}`} className={css`display:grid;grid-template-columns:repeat(${Math.min(gpuCapacity, 8)},minmax(0,1fr));gap:3px;`}>
+            {Array.from({ length: Math.max(gpuCapacity, assigned.length) }, (_, index) => {
+              const workload = assigned[index];
+              return <div role="listitem" aria-label={workload ? `${workload.job} GPU` : 'Unallocated GPU'} title={workload?.task ?? 'Unallocated'} key={index} className={css`height:25px;border-radius:3px;border:1px solid ${workload ? jobColor(workload.job, jobs) : theme.colors.border.weak};background:${workload ? `${jobColor(workload.job, jobs)}33` : theme.colors.background.canvas};overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:4px;box-sizing:border-box;font-size:9px;`}>{workload ? shortJob(workload.job) : ''}</div>;
+            })}
+          </div>
+          <div className={css`font-size:11px;color:${theme.colors.text.secondary};margin-top:4px;`}>GPU {percent(metric('gpu_utilization_percent'))} live · HBM {percent(gpuMemoryPercent)}</div>
+        </div>
+      )}
+      <ResourceBar label="CPU" used={cpuRequested} capacity={cpuCapacity} actual={metric('node_cpu_utilization_percent')} />
+      <ResourceBar label="Memory" used={memoryRequested} capacity={memoryCapacity} actual={memoryPercent} />
+    </article>
+  );
+}
+
+export function ClusterCapacity({ frames, width, height }: Props) {
+  const theme = useTheme2();
+  const workloads = useMemo(() => frameRows(frames, REF.workloads, workloadAllocations), [frames]);
+  const nodes = useMemo(() => frameRows(frames, REF.nodes, clusterNodes), [frames]);
+  const usage = useMemo(() => usageMap(frameRows(frames, REF.tasks, taskUsage)), [frames]);
+  const metrics = useMemo(() => metricMap(frameRows(frames, REF.host, nodeMetrics)), [frames]);
+  const summaries = useMemo(() => summarizeJobs(workloads, usage), [workloads, usage]);
+  const jobs = summaries.map((summary) => summary.job);
+  const cluster = nodes[0]?.cluster ?? workloads[0]?.cluster ?? 'selected cluster';
+  const totalGpus = nodes.reduce((sum, node) => sum + (node.gpuAllocatable || node.gpuCapacity), 0);
+  const allocatedGpus = workloads.filter((workload) => workload.node).reduce(
+    (sum, workload) => sum + workload.gpuRequestCount,
+    0
+  );
+  const bound = new Map<string, WorkloadAllocation[]>();
+  for (const workload of workloads.filter((row) => row.node)) {
+    const rows = bound.get(workload.node) ?? [];
+    rows.push(workload);
+    bound.set(workload.node, rows);
+  }
+  const unbound = workloads.filter((workload) => !workload.node);
+  const orderedNodes = [...nodes].sort((a, b) => {
+    const aUnavailable = Number(!a.ready || a.unschedulable);
+    const bUnavailable = Number(!b.ready || b.unschedulable);
+    const aGpus = (bound.get(a.node) ?? []).reduce((sum, workload) => sum + workload.gpuRequestCount, 0);
+    const bGpus = (bound.get(b.node) ?? []).reduce((sum, workload) => sum + workload.gpuRequestCount, 0);
+    return bUnavailable - aUnavailable || bGpus - aGpus || a.node.localeCompare(b.node);
+  });
+  return (
+    <main aria-label="Cluster capacity" className={css`width:${width}px;height:${height}px;padding:14px 16px 24px;box-sizing:border-box;color:${theme.colors.text.primary};background:${theme.colors.background.canvas};overflow:auto;`}>
+      <header className={css`display:flex;align-items:baseline;justify-content:space-between;gap:20px;margin-bottom:14px;`}>
+        <div>
+          <h1 className={css`font-size:24px;line-height:1.2;margin:0;`}>Cluster capacity · {cluster}</h1>
+          <span className={css`font-size:12px;color:${theme.colors.text.secondary};`}>Live Kubernetes placement; observed CPU and memory from the latest node-agent samples</span>
+        </div>
+        <nav className={css`display:flex;gap:14px;font-size:13px;`}><a href="/d/marin-jobs">Jobs</a><a href="/d/marin-clusters">Fleet health</a><a href="/d/marin-nodes">Node details</a></nav>
+      </header>
+      <section aria-label="Cluster totals" className={css`display:flex;flex-wrap:wrap;gap:8px;margin-bottom:16px;`}>
+        <Stat value={summaries.length} label="active jobs" />
+        <Stat value={workloads.length} label="live tasks" />
+        <Stat value={`${allocatedGpus}/${totalGpus}`} label="GPUs allocated" />
+        <Stat value={nodes.length} label="nodes" />
+        <Stat value={unbound.length} label="tasks waiting" />
+        <Stat value={nodes.filter((node) => !node.ready || node.unschedulable).length} label="nodes unavailable" />
+      </section>
+      <section aria-label="Active jobs" className={css`margin-bottom:18px;`}>
+        <h2 className={css`font-size:15px;margin:0 0 7px;`}>Live jobs and requests</h2>
+        {summaries.length === 0 ? <p>No live Iris jobs reported.</p> : (
+          <div className={css`border:1px solid ${theme.colors.border.weak};border-radius:7px;overflow:auto;`}>
+            <table className={css`border-collapse:collapse;width:100%;font-size:12px;& th,& td{padding:7px 9px;border-bottom:1px solid ${theme.colors.border.weak};text-align:right;white-space:nowrap;}& th:first-child,& td:first-child{text-align:left;}`}>
+              <thead><tr><th>Job</th><th>Ready tasks</th><th>Live samples</th><th>GPU</th><th>CPU requested</th><th>CPU live</th><th>Memory requested</th><th>Memory live</th></tr></thead>
+              <tbody>{summaries.map((summary) => <tr key={summary.job}>
+                <td><span className={css`display:inline-block;width:8px;height:8px;border-radius:2px;background:${jobColor(summary.job, jobs)};margin-right:7px;`} /><a href={`/d/marin-jobs?var-cluster=${encodeURIComponent(cluster)}&var-job=${encodeURIComponent(summary.job)}`}>{summary.job}</a></td>
+                <td>{summary.ready}/{summary.tasks}</td><td>{summary.observed}/{summary.tasks}</td><td>{summary.gpuRequestCount}</td><td>{formatCores(summary.cpuRequestMillicores)} cores</td><td>{summary.observed ? `${formatCores(summary.cpuMillicores)} cores` : '—'}</td><td>{formatBytes(summary.memoryRequestBytes)}</td><td>{summary.observed ? formatBytes(summary.memoryBytes) : '—'}</td>
+              </tr>)}</tbody>
+            </table>
+          </div>
+        )}
+      </section>
+      <section aria-label="Node packing">
+        <h2 className={css`font-size:15px;margin:0 0 7px;`}>Node packing</h2>
+        {nodes.length === 0 ? <p>No Kubernetes node inventory reported.</p> : <div className={css`display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:9px;`}>
+          {orderedNodes.map((node) => <NodeCard key={node.node} node={node} workloads={bound.get(node.node) ?? []} metrics={metrics} jobs={jobs} />)}
+        </div>}
+      </section>
+      {unbound.length > 0 && <section aria-label="Unbound tasks" className={css`margin-top:18px;`}><h2 className={css`font-size:15px;margin:0 0 7px;`}>Waiting for placement</h2><ul>{unbound.map((workload) => <li key={workload.pod}><code>{workload.task}</code> · {workload.phase} for {formatAge(workload.ageSeconds)} · {workload.gpuRequestCount} GPU · {formatCores(workload.cpuRequestMillicores)} cores · {formatBytes(workload.memoryRequestBytes)}</li>)}</ul></section>}
+    </main>
+  );
+}

--- a/infra/grafana/marin-infra-panel/src/components/InfraPanel.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/InfraPanel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { PanelProps } from '@grafana/data';
 import { CommitStrip } from './CommitStrip';
+import { ClusterCapacity } from './ClusterCapacity';
 import { NightlyMatrix } from './NightlyMatrix';
 import { StatusPage } from './StatusPage';
 import { WandbChart } from './WandbChart';
@@ -9,6 +10,9 @@ import { InfraPanelOptions } from '../types';
 export function InfraPanel({ options, data, width, height }: PanelProps<InfraPanelOptions>) {
   if (options.view === 'status') {
     return <StatusPage frames={data.series} width={width} height={height} />;
+  }
+  if (options.view === 'cluster') {
+    return <ClusterCapacity frames={data.series} width={width} height={height} />;
   }
   if (options.view === 'commits') {
     return <CommitStrip frames={data.series} width={width} height={height} />;

--- a/infra/grafana/marin-infra-panel/src/components/StatusPage.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/StatusPage.tsx
@@ -314,7 +314,7 @@ export function StatusPage({ frames, width, height }: Props) {
         </div>
         <nav className={css`display:flex;flex-wrap:wrap;justify-content:flex-end;gap:5px 14px;font-size:13px;`}>
           <a href="/d/marin-home">Home</a><a href="/d/marin-accel">Accelerators</a><a href="/d/marin-jobs">Jobs</a>
-          <a href="/d/marin-runs">Runs</a><a href="/d/marin-clusters">Clusters</a>
+          <a href="/d/marin-runs">Runs</a><a href="/d/marin-clusters">Clusters</a><a href="/d/marin-cluster-capacity">Capacity</a>
           <a href="https://github.com/marin-community/marin/actions" target="_blank" rel="noreferrer">GitHub Actions ↗</a>
         </nav>
       </header>

--- a/infra/grafana/marin-infra-panel/src/components/StatusPage.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/StatusPage.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/css';
 import { DataFrame } from '@grafana/data';
 import { useTheme2 } from '@grafana/ui';
 import { frameByRefId, provisioningRegions, provisioningStatus, seriesPoints, workerRegions } from '../data';
+import { formatBytes } from '../format';
 import { SeriesPoint } from '../types';
 import { CommitStrip } from './CommitStrip';
 import { NightlyMatrix } from './NightlyMatrix';
@@ -48,17 +49,6 @@ function one(frames: DataFrame[], refId: string): DataFrame[] {
 function formatCores(millicores: number): string {
   const cores = millicores / 1000;
   return cores >= 1000 ? `${(cores / 1000).toFixed(1)}k` : Math.round(cores).toString();
-}
-
-function formatBytes(bytes: number): string {
-  const units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'];
-  let value = bytes;
-  let unit = 0;
-  while (value >= 1024 && unit < units.length - 1) {
-    value /= 1024;
-    unit += 1;
-  }
-  return `${value >= 100 ? Math.round(value) : value.toFixed(1)} ${units[unit]}`;
 }
 
 function formatPercent(value?: number): string {

--- a/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
+++ b/infra/grafana/marin-infra-panel/src/components/panels.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { toDataFrame } from '@grafana/data';
 import { render, screen, within } from '@testing-library/react';
 import { CommitStrip } from './CommitStrip';
+import { ClusterCapacity } from './ClusterCapacity';
 import { NightlyMatrix } from './NightlyMatrix';
 import { StatusPage } from './StatusPage';
 import { WandbChart } from './WandbChart';
@@ -18,6 +19,9 @@ test('every view renders a placeholder instead of throwing on empty data', () =>
 
   rerender(<WandbChart frames={[]} width={480} height={200} />);
   expect(screen.getByText('No W&B data')).toBeInTheDocument();
+
+  rerender(<ClusterCapacity frames={[]} width={1200} height={800} />);
+  expect(screen.getByText('No Kubernetes node inventory reported.')).toBeInTheDocument();
 });
 
 function frame(refId: string, rows: Array<Record<string, unknown>>) {
@@ -26,6 +30,47 @@ function frame(refId: string, rows: Array<Record<string, unknown>>) {
     fields: Object.keys(rows[0]).map((name) => ({ name, values: rows.map((row) => row[name]) })),
   });
 }
+
+test('cluster capacity rolls tasks into jobs and packs requested GPUs onto their nodes', () => {
+  const frames = [
+    frame('W', [{
+      cluster: 'cw-us-east-02a', namespace: 'iris', pod: 'train-0', node: 'gpu-1', job: '/alice/train',
+      task: '/alice/train/0', phase: 'Running', ready: true, priority_class: 'production', age_seconds: 120,
+      cpu_request_millicores: 8000, memory_request_bytes: 68719476736, gpu_request_count: 2, gpu_variant: 'H100',
+    }, {
+      cluster: 'cw-us-east-02a', namespace: 'iris', pod: 'eval-0', node: '', job: '/bob/eval',
+      task: '/bob/eval/0', phase: 'Pending', ready: false, priority_class: '', age_seconds: 60,
+      cpu_request_millicores: 2000, memory_request_bytes: 8589934592, gpu_request_count: 1, gpu_variant: 'H100',
+    }]),
+    frame('N', [{
+      cluster: 'cw-us-east-02a', node: 'gpu-1', instance_type: 'h100-4', node_pool: 'train', gpu_model: 'H100',
+      gpu_capacity: 4, gpu_allocatable: 4, cpu_allocatable: '32', memory_allocatable: '256Gi', ready: true,
+      unschedulable: false,
+    }]),
+    frame('T', [{
+      cluster: 'cw-us-east-02a', task: '/alice/train/0', pod: 'train-0', cpu_millicores: 3500,
+      memory_bytes: 34359738368, sampled_at: Date.now(),
+    }]),
+    frame('H', [
+      { cluster: 'cw-us-east-02a', node: 'gpu-1', name: 'node_cpu_utilization_percent', value: 44, sampled_at: Date.now() },
+      { cluster: 'cw-us-east-02a', node: 'gpu-1', name: 'gpu_utilization_percent', value: 78, sampled_at: Date.now() },
+    ]),
+  ];
+
+  render(<ClusterCapacity frames={frames} width={1400} height={1000} />);
+
+  expect(screen.getByRole('main', { name: 'Cluster capacity' })).toHaveTextContent('cw-us-east-02a');
+  const totals = screen.getByRole('region', { name: 'Cluster totals' });
+  expect(within(totals).getByText('2/4')).toBeInTheDocument();
+  expect(within(totals).getByText('tasks waiting').parentElement).toHaveTextContent('1');
+  const jobs = screen.getByRole('region', { name: 'Active jobs' });
+  expect(within(jobs).getByText('/alice/train')).toBeInTheDocument();
+  expect(within(jobs).getByText('3.50 cores')).toBeInTheDocument();
+  const slots = screen.getByRole('list', { name: 'GPU slots on gpu-1' });
+  expect(within(slots).getAllByRole('listitem', { name: '/alice/train GPU' })).toHaveLength(2);
+  expect(within(slots).getAllByRole('listitem', { name: 'Unallocated GPU' })).toHaveLength(2);
+  expect(screen.getByRole('region', { name: 'Unbound tasks' })).toHaveTextContent('/bob/eval/0');
+});
 
 test('status page keeps worker and provisioning status visible when another source has no data', () => {
   const frames = [

--- a/infra/grafana/marin-infra-panel/src/data.test.ts
+++ b/infra/grafana/marin-infra-panel/src/data.test.ts
@@ -1,12 +1,16 @@
 import { toDataFrame } from '@grafana/data';
 import {
   frameByRefId,
+  clusterNodes,
   frameWithField,
   nightlyCells,
+  nodeMetrics,
   provisioningRegions,
   provisioningStatus,
   seriesPoints,
+  taskUsage,
   workerRegions,
+  workloadAllocations,
 } from './data';
 
 function frame(rows: Array<Record<string, unknown>>, refId?: string) {
@@ -89,4 +93,29 @@ test('frameByRefId isolates one status source', () => {
   const workers = frame([{ healthy: 12 }], 'W');
   expect(frameByRefId([nightly, workers], 'W')).toBe(workers);
   expect(frameByRefId([nightly], 'W')).toBeUndefined();
+});
+
+test('cluster capacity contracts read placement, inventory, and observed usage by field name', () => {
+  expect(workloadAllocations(frame([{
+    cluster: 'cw-us-east-02a', namespace: 'iris', pod: 'train-0', node: 'gpu-1', job: '/alice/train',
+    task: '/alice/train/0', phase: 'Running', ready: true, priority_class: 'production', age_seconds: 120,
+    cpu_request_millicores: 8000, memory_request_bytes: 64, gpu_request_count: 4, gpu_variant: 'H100',
+  }]))[0]).toMatchObject({ job: '/alice/train', gpuRequestCount: 4, cpuRequestMillicores: 8000 });
+
+  expect(clusterNodes(frame([{
+    cluster: 'cw-us-east-02a', node: 'gpu-1', instance_type: 'h100-8', node_pool: 'train', gpu_model: 'H100',
+    gpu_capacity: 8, gpu_allocatable: 8, cpu_allocatable: '96', memory_allocatable: '1Ti', ready: true,
+    unschedulable: false,
+  }]))[0]).toMatchObject({ node: 'gpu-1', gpuAllocatable: 8, cpuAllocatable: '96' });
+
+  expect(taskUsage(frame([{
+    cluster: 'cw-us-east-02a', task: '/alice/train/0', pod: 'train-0', cpu_millicores: 3200,
+    memory_bytes: 32, sampled_at: 1000,
+  }]))[0]).toMatchObject({ pod: 'train-0', cpuMillicores: 3200, memoryBytes: 32 });
+
+  expect(nodeMetrics(frame([{
+    cluster: 'cw-us-east-02a', node: 'gpu-1', name: 'gpu_utilization_percent', value: 82, sampled_at: 1000,
+  }]))).toEqual([{
+    cluster: 'cw-us-east-02a', node: 'gpu-1', name: 'gpu_utilization_percent', value: 82, sampledAt: 1000,
+  }]);
 });

--- a/infra/grafana/marin-infra-panel/src/data.ts
+++ b/infra/grafana/marin-infra-panel/src/data.ts
@@ -1,11 +1,15 @@
 import { DataFrame, Field } from '@grafana/data';
 import {
   CommitRow,
+  ClusterNode,
   NightlyCell,
+  NodeMetric,
   ProvisioningRegion,
   ProvisioningRow,
   SeriesPoint,
+  TaskUsage,
   WandbPoint,
+  WorkloadAllocation,
   WorkerRegion,
 } from './types';
 
@@ -176,6 +180,62 @@ export function frameByRefId(frames: DataFrame[], refId: string): DataFrame | un
     throw new Error(`Expected one data frame for ${refId}; received ${matching.length}`);
   }
   return matching[0];
+}
+
+export function workloadAllocations(frame: DataFrame): WorkloadAllocation[] {
+  return rows(frame).filter((row) => optionalString(row, 'task')).map((row) => ({
+    cluster: requiredString(row, 'cluster'),
+    namespace: requiredString(row, 'namespace'),
+    pod: requiredString(row, 'pod'),
+    node: optionalString(row, 'node') ?? '',
+    job: requiredString(row, 'job'),
+    task: requiredString(row, 'task'),
+    phase: requiredString(row, 'phase'),
+    ready: booleanValue(row, 'ready'),
+    priorityClass: optionalString(row, 'priority_class') ?? '',
+    ageSeconds: requiredNumber(row, 'age_seconds'),
+    cpuRequestMillicores: requiredNumber(row, 'cpu_request_millicores'),
+    memoryRequestBytes: requiredNumber(row, 'memory_request_bytes'),
+    gpuRequestCount: requiredNumber(row, 'gpu_request_count'),
+    gpuVariant: optionalString(row, 'gpu_variant') ?? '',
+  }));
+}
+
+export function clusterNodes(frame: DataFrame): ClusterNode[] {
+  return rows(frame).filter((row) => optionalString(row, 'node')).map((row) => ({
+    cluster: requiredString(row, 'cluster'),
+    node: requiredString(row, 'node'),
+    instanceType: optionalString(row, 'instance_type') ?? '',
+    nodePool: optionalString(row, 'node_pool') ?? '',
+    gpuModel: optionalString(row, 'gpu_model') ?? '',
+    gpuCapacity: requiredNumber(row, 'gpu_capacity'),
+    gpuAllocatable: requiredNumber(row, 'gpu_allocatable'),
+    cpuAllocatable: optionalString(row, 'cpu_allocatable') ?? '',
+    memoryAllocatable: optionalString(row, 'memory_allocatable') ?? '',
+    ready: booleanValue(row, 'ready'),
+    unschedulable: booleanValue(row, 'unschedulable'),
+  }));
+}
+
+export function taskUsage(frame: DataFrame): TaskUsage[] {
+  return rows(frame).filter((row) => optionalString(row, 'task')).map((row) => ({
+    cluster: requiredString(row, 'cluster'),
+    task: requiredString(row, 'task'),
+    pod: requiredString(row, 'pod'),
+    cpuMillicores: requiredNumber(row, 'cpu_millicores'),
+    memoryBytes: requiredNumber(row, 'memory_bytes'),
+    sampledAt: requiredNumber(row, 'sampled_at'),
+  }));
+}
+
+export function nodeMetrics(frame: DataFrame): NodeMetric[] {
+  return rows(frame).filter((row) => optionalString(row, 'node')).map((row) => ({
+    cluster: requiredString(row, 'cluster'),
+    node: requiredString(row, 'node'),
+    name: requiredString(row, 'name'),
+    value: requiredNumber(row, 'value'),
+    sampledAt: requiredNumber(row, 'sampled_at'),
+  }));
 }
 
 /**

--- a/infra/grafana/marin-infra-panel/src/format.ts
+++ b/infra/grafana/marin-infra-panel/src/format.ts
@@ -1,0 +1,12 @@
+const KIBIBYTE = 1024;
+const BYTE_UNITS = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB'];
+
+export function formatBytes(bytes: number): string {
+  let value = bytes;
+  let unit = 0;
+  while (value >= KIBIBYTE && unit < BYTE_UNITS.length - 1) {
+    value /= KIBIBYTE;
+    unit += 1;
+  }
+  return `${value >= 100 ? Math.round(value) : value.toFixed(1)} ${BYTE_UNITS[unit]}`;
+}

--- a/infra/grafana/marin-infra-panel/src/module.ts
+++ b/infra/grafana/marin-infra-panel/src/module.ts
@@ -10,6 +10,7 @@ export const plugin = new PanelPlugin<InfraPanelOptions>(InfraPanel).setPanelOpt
     settings: {
       options: [
         { value: 'status', label: 'Status page' },
+        { value: 'cluster', label: 'Cluster capacity' },
         { value: 'nightlies', label: 'Nightly matrix' },
         { value: 'commits', label: 'Commit strip' },
         { value: 'wandb', label: 'W&B chart' },

--- a/infra/grafana/marin-infra-panel/src/types.ts
+++ b/infra/grafana/marin-infra-panel/src/types.ts
@@ -1,4 +1,4 @@
-export type InfraPanelView = 'status' | 'nightlies' | 'commits' | 'wandb';
+export type InfraPanelView = 'status' | 'cluster' | 'nightlies' | 'commits' | 'wandb';
 
 export interface InfraPanelOptions {
   view: InfraPanelView;
@@ -80,4 +80,52 @@ export interface SeriesPoint {
   time: number;
   series: string;
   value: number;
+}
+
+export interface WorkloadAllocation {
+  cluster: string;
+  namespace: string;
+  pod: string;
+  node: string;
+  job: string;
+  task: string;
+  phase: string;
+  ready: boolean;
+  priorityClass: string;
+  ageSeconds: number;
+  cpuRequestMillicores: number;
+  memoryRequestBytes: number;
+  gpuRequestCount: number;
+  gpuVariant: string;
+}
+
+export interface ClusterNode {
+  cluster: string;
+  node: string;
+  instanceType: string;
+  nodePool: string;
+  gpuModel: string;
+  gpuCapacity: number;
+  gpuAllocatable: number;
+  cpuAllocatable: string;
+  memoryAllocatable: string;
+  ready: boolean;
+  unschedulable: boolean;
+}
+
+export interface TaskUsage {
+  cluster: string;
+  task: string;
+  pod: string;
+  cpuMillicores: number;
+  memoryBytes: number;
+  sampledAt: number;
+}
+
+export interface NodeMetric {
+  cluster: string;
+  node: string;
+  name: string;
+  value: number;
+  sampledAt: number;
 }

--- a/infra/grafana/marin-infra-panel/tests/dashboard.spec.ts
+++ b/infra/grafana/marin-infra-panel/tests/dashboard.spec.ts
@@ -17,3 +17,14 @@ test('infra status page renders regressions, CI, capacity, provisioning, and the
   await expect(page.getByRole('link', { name: 'W&B report ↗' }).first()).toBeVisible();
   await page.screenshot({ path: 'artifacts/infra-hero-training.png' });
 });
+
+test('cluster capacity page shows job rollups and GPU packing for one cluster', async ({ page }) => {
+  await page.goto('/d/marin-cluster-capacity/cluster-capacity?orgId=1&kiosk');
+  await expect(page.getByRole('main', { name: 'Cluster capacity' })).toBeVisible();
+  await expect(page.getByText('Cluster capacity · cw-us-east-02a')).toBeVisible();
+  await expect(page.getByRole('region', { name: 'Active jobs' }).getByText('/alice/llama')).toBeVisible();
+  await expect(page.getByRole('article', { name: 'Node gpu-a' })).toBeVisible();
+  await expect(page.getByRole('list', { name: 'GPU slots on gpu-b' })).toBeVisible();
+  await expect(page.getByRole('region', { name: 'Unbound tasks' }).getByText('/dave/train/0')).toBeVisible();
+  await page.screenshot({ path: 'artifacts/cluster-capacity.png', fullPage: true });
+});

--- a/infra/grafana/src/dashboard_stitch.py
+++ b/infra/grafana/src/dashboard_stitch.py
@@ -1,7 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Stitch shared panel fragments into dashboard JSON at image build time.
+"""Stitch shared panel and link fragments into dashboard JSON at image build time.
 
 A dashboard's ``panels`` array can hold a stitch marker instead of a full panel
 body: ``{"id": N, "gridPos": {...}, "panelRef": "<fragment-name>"}``. Every other
@@ -13,6 +13,8 @@ dashboard-local: they are the only two things that legitimately vary by placemen
 This keeps ``dashboards/*.json`` file-provisioned and git-reviewable end to end —
 no Grafana library-panel API, no runtime sync, no new credential — while killing
 copy-pasted panel bodies that drift out of sync with the bridge's actual schema.
+Dashboard links use ``{"linkRef": "<fragment-name>"}`` markers resolved from
+``SHARED_LINKS`` for the same reason.
 """
 
 import argparse
@@ -20,6 +22,22 @@ import json
 from pathlib import Path
 
 PANEL_REF_KEY = "panelRef"
+LINK_REF_KEY = "linkRef"
+
+_CLUSTER_CAPACITY_LINK = {
+    "asDropdown": False,
+    "icon": "dashboard",
+    "includeVars": True,
+    "keepTime": True,
+    "targetBlank": False,
+    "title": "Cluster capacity",
+    "type": "link",
+    "url": "/d/marin-cluster-capacity",
+}
+_SHARED_LINKS = {
+    "cluster_capacity": _CLUSTER_CAPACITY_LINK,
+    "cluster_capacity_without_vars": {**_CLUSTER_CAPACITY_LINK, "includeVars": False},
+}
 
 
 def load_panel_fragments(panels_dir: Path) -> dict[str, dict]:
@@ -47,13 +65,29 @@ def _stitch_panels(panels: list[dict], fragments: dict[str, dict]) -> list[dict]
     return resolved
 
 
+def _stitch_links(links: list[dict]) -> list[dict]:
+    resolved = []
+    for link in links:
+        ref = link.get(LINK_REF_KEY)
+        if ref is None:
+            resolved.append(link)
+            continue
+        if ref not in _SHARED_LINKS:
+            raise KeyError(f"unknown dashboard link fragment {ref!r}")
+        resolved.append(_SHARED_LINKS[ref])
+    return resolved
+
+
 def stitch_dashboard(source: dict, fragments: dict[str, dict]) -> dict:
-    """Replace every panelRef marker in source's panels with its fragment body.
+    """Replace panelRef and linkRef markers with their fragment bodies.
 
     Raises:
-        KeyError: A panel references a fragment name missing from ``fragments``.
+        KeyError: A panel or link references an unknown fragment.
     """
-    return {**source, "panels": _stitch_panels(source["panels"], fragments)}
+    dashboard = {**source, "panels": _stitch_panels(source["panels"], fragments)}
+    if "links" in source:
+        dashboard["links"] = _stitch_links(source["links"])
+    return dashboard
 
 
 def stitch_all(src_dir: Path, panels_dir: Path) -> dict[str, dict]:

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -8,10 +8,11 @@ GETs and the CW read-role bearer token — no kubernetes client. K8sFleet fans a
 query out across every cluster and stamps a ``cluster`` column, so one response
 covers the fleet.
 
-The pod-level scans (crashloops, pending, termination candidates) cover every namespace except the
-provider-managed prefixes in PROVIDER_NAMESPACE_PREFIXES: CoreWeave's per-node
-daemons are thousands of pods of someone else's infrastructure, while the
-namespaces we operate hold about a hundred.
+The pod-level scans (crashloops, pending, workload allocations, termination
+candidates) cover every namespace except the provider-managed prefixes in
+PROVIDER_NAMESPACE_PREFIXES: CoreWeave's per-node daemons are thousands of
+pods of someone else's infrastructure, while the namespaces we operate hold
+about a hundred.
 
 Failure semantics: a cluster that cannot be queried becomes labeled rows inside
 the aggregate response — never an empty result — so healthy clusters keep
@@ -25,6 +26,7 @@ webhook rule — deliberate, because unknown admission state is exactly the
 failure class it watches.
 """
 
+import json
 import logging
 import time
 from collections.abc import Callable, Sequence
@@ -60,6 +62,9 @@ STUCK_TERMINATION_OVERDUE_SECONDS = 120
 
 _GPU_RESOURCE = "nvidia.com/gpu"
 _IRIS_TASK_ID_ENV = "IRIS_TASK_ID"
+_IRIS_TASK_RESOURCES_ENV = "IRIS_TASK_RESOURCES"
+_IRIS_MANAGED_LABEL = "iris.managed"
+_IRIS_TASK_ID_ANNOTATION = "iris.task_id"
 _TERMINAL_POD_PHASES = frozenset(("Succeeded", "Failed"))
 _FINELOG_CONTAINER = "finelog"
 _FINELOG_FALLBACK_SERVER = "finelog-mirror"
@@ -579,6 +584,43 @@ class K8sSource:
         rows.sort(key=lambda row: row["age_seconds"] or 0, reverse=True)
         return rows
 
+    def workload_allocations(self) -> list[dict]:
+        """Live Iris task placement and requested resources, one row per pod."""
+        rows = []
+        for pod in self._scan_pods("status.phase!=Succeeded,status.phase!=Failed"):
+            metadata = pod.get("metadata") or {}
+            labels = metadata.get("labels") or {}
+            if labels.get(_IRIS_MANAGED_LABEL) != "true":
+                continue
+            status = pod.get("status") or {}
+            phase = status.get("phase") or ""
+            if phase in _TERMINAL_POD_PHASES:
+                continue
+            task = (metadata.get("annotations") or {}).get(_IRIS_TASK_ID_ANNOTATION) or _iris_task_attempt(pod)
+            if not task:
+                continue
+            resources = _iris_task_resources(pod)
+            gpu = (resources.get("device") or {}).get("gpu") or {}
+            spec = pod.get("spec") or {}
+            rows.append(
+                {
+                    "namespace": metadata.get("namespace") or "",
+                    "pod": metadata.get("name") or "",
+                    "node": spec.get("nodeName") or "",
+                    "job": _root_job_id(task, labels.get("iris.job_id") or ""),
+                    "task": task,
+                    "phase": phase,
+                    "ready": _pod_condition(pod, "Ready").get("status") == "True",
+                    "priority_class": spec.get("priorityClassName") or "",
+                    "age_seconds": _age_seconds(metadata.get("creationTimestamp")) or 0,
+                    "cpu_request_millicores": int(resources.get("cpu_millicores") or 0),
+                    "memory_request_bytes": int(resources.get("memory_bytes") or 0),
+                    "gpu_request_count": int(gpu.get("count") or 0),
+                    "gpu_variant": gpu.get("variant") or "",
+                }
+            )
+        return sorted(rows, key=lambda row: (row["node"], row["job"], row["task"]))
+
     def node_architectures(self) -> dict[str, str]:
         architectures = {}
         for node in self._list("/api/v1/nodes"):
@@ -711,6 +753,7 @@ class K8sSource:
             metadata = node.get("metadata") or {}
             annotations = metadata.get("annotations") or {}
             labels = metadata.get("labels") or {}
+            allocatable = (node.get("status") or {}).get("allocatable") or {}
             conditions = {
                 condition.get("type"): condition
                 for condition in (node.get("status") or {}).get("conditions") or []
@@ -726,6 +769,9 @@ class K8sSource:
                     "compute_class": labels.get(_COMPUTE_CLASS_LABEL, ""),
                     "gpu_model": labels.get(_GPU_MODEL_LABEL, ""),
                     "gpu_capacity": _node_gpu_capacity(node),
+                    "cpu_allocatable": allocatable.get("cpu", ""),
+                    "memory_allocatable": allocatable.get("memory", ""),
+                    "gpu_allocatable": _node_gpu_allocatable(node),
                     "rack": labels.get(_RACK_LABEL, ""),
                     "rack_name": labels.get(_RACK_NAME_LABEL, ""),
                     "rack_slot": labels.get(_RACK_SLOT_LABEL, ""),
@@ -837,6 +883,14 @@ def _node_gpu_capacity(node: dict) -> int:
         raise ValueError(f"invalid {_GPU_RESOURCE} capacity quantity: {raw!r}") from err
 
 
+def _node_gpu_allocatable(node: dict) -> int:
+    raw = ((node.get("status") or {}).get("allocatable") or {}).get(_GPU_RESOURCE, 0)
+    try:
+        return int(raw)
+    except (TypeError, ValueError) as err:
+        raise ValueError(f"invalid {_GPU_RESOURCE} allocatable quantity: {raw!r}") from err
+
+
 def _node_ready(node: dict) -> bool:
     conditions = (node.get("status") or {}).get("conditions") or []
     return any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions)
@@ -930,6 +984,23 @@ def _iris_task_attempt(pod: dict) -> str:
     return ""
 
 
+def _iris_task_resources(pod: dict) -> dict:
+    for container in (pod.get("spec") or {}).get("containers") or []:
+        if container.get("name") != "task":
+            continue
+        for item in container.get("env") or []:
+            if item.get("name") == _IRIS_TASK_RESOURCES_ENV:
+                return json.loads(item.get("value") or "{}")
+    return {}
+
+
+def _root_job_id(task: str, fallback: str) -> str:
+    parts = task.removeprefix("/").split("/")
+    if task.startswith("/") and len(parts) >= 2:
+        return f"/{parts[0]}/{parts[1]}"
+    return fallback or task
+
+
 def _termination_class(pod: dict, overdue_seconds: int | None) -> TerminationClass:
     metadata = pod.get("metadata") or {}
     if overdue_seconds is None:
@@ -991,6 +1062,9 @@ class K8sFleet:
 
     def pending(self) -> list[dict]:
         return self._fan_out(lambda s: s.pending(), self._error_row)
+
+    def workload_allocations(self) -> list[dict]:
+        return self._fan_out(lambda s: s.workload_allocations(), self._error_row)
 
     def termination_candidates(self) -> list[TerminatingPodResult]:
         return self._collect(

--- a/infra/grafana/src/k8s_source.py
+++ b/infra/grafana/src/k8s_source.py
@@ -31,7 +31,7 @@ import logging
 import time
 from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 from typing import TypeVar
@@ -64,7 +64,9 @@ _GPU_RESOURCE = "nvidia.com/gpu"
 _IRIS_TASK_ID_ENV = "IRIS_TASK_ID"
 _IRIS_TASK_RESOURCES_ENV = "IRIS_TASK_RESOURCES"
 _IRIS_MANAGED_LABEL = "iris.managed"
+_IRIS_JOB_ID_LABEL = "iris.job_id"
 _IRIS_TASK_ID_ANNOTATION = "iris.task_id"
+_IRIS_TASK_CONTAINER = "task"
 _TERMINAL_POD_PHASES = frozenset(("Succeeded", "Failed"))
 _FINELOG_CONTAINER = "finelog"
 _FINELOG_FALLBACK_SERVER = "finelog-mirror"
@@ -166,6 +168,25 @@ class TerminationClass(StrEnum):
     TERMINAL = "terminal"
     UNBOUND = "unbound"
     NODE_CLEANUP = "node_cleanup"
+
+
+@dataclass(frozen=True)
+class WorkloadAllocation:
+    """Current placement and resource request for one Iris task pod."""
+
+    namespace: str
+    pod: str
+    node: str
+    job: str
+    task: str
+    phase: str
+    ready: bool
+    priority_class: str
+    age_seconds: int
+    cpu_request_millicores: int
+    memory_request_bytes: int
+    gpu_request_count: int
+    gpu_variant: str
 
 
 @dataclass(frozen=True)
@@ -457,7 +478,7 @@ class K8sSource:
 
     def finelog_pods(self) -> list[FinelogPod]:
         """Report each finelog Deployment, including a Missing row when it has no pod."""
-        rows = []
+        rows: list[FinelogPod] = []
         for deployment in self._finelog_deployments():
             metadata = deployment.get("metadata") or {}
             namespace = metadata.get("namespace") or "default"
@@ -584,9 +605,9 @@ class K8sSource:
         rows.sort(key=lambda row: row["age_seconds"] or 0, reverse=True)
         return rows
 
-    def workload_allocations(self) -> list[dict]:
+    def workload_allocations(self) -> list[WorkloadAllocation]:
         """Live Iris task placement and requested resources, one row per pod."""
-        rows = []
+        rows: list[WorkloadAllocation] = []
         for pod in self._scan_pods("status.phase!=Succeeded,status.phase!=Failed"):
             metadata = pod.get("metadata") or {}
             labels = metadata.get("labels") or {}
@@ -603,23 +624,23 @@ class K8sSource:
             gpu = (resources.get("device") or {}).get("gpu") or {}
             spec = pod.get("spec") or {}
             rows.append(
-                {
-                    "namespace": metadata.get("namespace") or "",
-                    "pod": metadata.get("name") or "",
-                    "node": spec.get("nodeName") or "",
-                    "job": _root_job_id(task, labels.get("iris.job_id") or ""),
-                    "task": task,
-                    "phase": phase,
-                    "ready": _pod_condition(pod, "Ready").get("status") == "True",
-                    "priority_class": spec.get("priorityClassName") or "",
-                    "age_seconds": _age_seconds(metadata.get("creationTimestamp")) or 0,
-                    "cpu_request_millicores": int(resources.get("cpu_millicores") or 0),
-                    "memory_request_bytes": int(resources.get("memory_bytes") or 0),
-                    "gpu_request_count": int(gpu.get("count") or 0),
-                    "gpu_variant": gpu.get("variant") or "",
-                }
+                WorkloadAllocation(
+                    namespace=metadata.get("namespace") or "",
+                    pod=metadata.get("name") or "",
+                    node=spec.get("nodeName") or "",
+                    job=_root_job_id(task, labels.get(_IRIS_JOB_ID_LABEL) or ""),
+                    task=task,
+                    phase=phase,
+                    ready=_pod_condition(pod, "Ready").get("status") == "True",
+                    priority_class=spec.get("priorityClassName") or "",
+                    age_seconds=_age_seconds(metadata.get("creationTimestamp")) or 0,
+                    cpu_request_millicores=int(resources.get("cpu_millicores") or 0),
+                    memory_request_bytes=int(resources.get("memory_bytes") or 0),
+                    gpu_request_count=int(gpu.get("count") or 0),
+                    gpu_variant=gpu.get("variant") or "",
+                )
             )
-        return sorted(rows, key=lambda row: (row["node"], row["job"], row["task"]))
+        return sorted(rows, key=lambda row: (row.node, row.job, row.task))
 
     def node_architectures(self) -> dict[str, str]:
         architectures = {}
@@ -698,7 +719,7 @@ class K8sSource:
                     gpu_count=_pod_gpu_count(pod),
                     task_attempt=_iris_task_attempt(pod),
                     task_label=labels.get("iris.task_id") or "",
-                    job_label=labels.get("iris.job_id") or "",
+                    job_label=labels.get(_IRIS_JOB_ID_LABEL) or "",
                     priority_class=spec.get("priorityClassName") or "",
                     finalizers=",".join(finalizers),
                     classification=_termination_class(pod, overdue_seconds),
@@ -876,19 +897,19 @@ class K8sSource:
 
 
 def _node_gpu_capacity(node: dict) -> int:
-    raw = ((node.get("status") or {}).get("capacity") or {}).get(_GPU_RESOURCE, 0)
-    try:
-        return int(raw)
-    except (TypeError, ValueError) as err:
-        raise ValueError(f"invalid {_GPU_RESOURCE} capacity quantity: {raw!r}") from err
+    return _node_gpu_quantity(node, "capacity")
 
 
 def _node_gpu_allocatable(node: dict) -> int:
-    raw = ((node.get("status") or {}).get("allocatable") or {}).get(_GPU_RESOURCE, 0)
+    return _node_gpu_quantity(node, "allocatable")
+
+
+def _node_gpu_quantity(node: dict, field: str) -> int:
+    raw = ((node.get("status") or {}).get(field) or {}).get(_GPU_RESOURCE, 0)
     try:
         return int(raw)
     except (TypeError, ValueError) as err:
-        raise ValueError(f"invalid {_GPU_RESOURCE} allocatable quantity: {raw!r}") from err
+        raise ValueError(f"invalid {_GPU_RESOURCE} {field} quantity: {raw!r}") from err
 
 
 def _node_ready(node: dict) -> bool:
@@ -975,23 +996,21 @@ def _pod_gpu_count(pod: dict) -> int:
 
 
 def _iris_task_attempt(pod: dict) -> str:
+    return _iris_task_environment_value(pod, _IRIS_TASK_ID_ENV)
+
+
+def _iris_task_environment_value(pod: dict, variable: str) -> str:
     for container in (pod.get("spec") or {}).get("containers") or []:
-        if container.get("name") != "task":
+        if container.get("name") != _IRIS_TASK_CONTAINER:
             continue
         for item in container.get("env") or []:
-            if item.get("name") == _IRIS_TASK_ID_ENV:
+            if item.get("name") == variable:
                 return item.get("value") or ""
     return ""
 
 
 def _iris_task_resources(pod: dict) -> dict:
-    for container in (pod.get("spec") or {}).get("containers") or []:
-        if container.get("name") != "task":
-            continue
-        for item in container.get("env") or []:
-            if item.get("name") == _IRIS_TASK_RESOURCES_ENV:
-                return json.loads(item.get("value") or "{}")
-    return {}
+    return json.loads(_iris_task_environment_value(pod, _IRIS_TASK_RESOURCES_ENV) or "{}")
 
 
 def _root_job_id(task: str, fallback: str) -> str:
@@ -1064,7 +1083,7 @@ class K8sFleet:
         return self._fan_out(lambda s: s.pending(), self._error_row)
 
     def workload_allocations(self) -> list[dict]:
-        return self._fan_out(lambda s: s.workload_allocations(), self._error_row)
+        return self._fan_out(lambda source: [asdict(row) for row in source.workload_allocations()], self._error_row)
 
     def termination_candidates(self) -> list[TerminatingPodResult]:
         return self._collect(

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -30,6 +30,7 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /k8s/control_plane                       watched components + webhook endpoints, all clusters
     GET /k8s/crashloops                          containers in backoff waiting states
     GET /k8s/pending                             Pending / SchedulingGated pods with age
+    GET /k8s/workloads                           live Iris jobs, placement, and requested resources
     GET /k8s/termination_candidates             pods overdue past their deletion deadline
     GET /k8s/kueue                               unadmitted Kueue workloads per queue
     GET /k8s/events                              recent Warning events
@@ -568,6 +569,9 @@ def create_app(
     def k8s_pending(_: Request) -> JSONResponse:
         return k8s_endpoint("pending", k8s_fleet.pending)
 
+    def k8s_workloads(request: Request) -> JSONResponse:
+        return filtered_k8s_endpoint("workloads", k8s_fleet.workload_allocations, request, ("cluster", "job"))
+
     def k8s_termination_candidates(_: Request) -> JSONResponse:
         rows = k8s_cache.get_or_compute(_K8S_TERMINATION_CANDIDATES_CACHE_KEY, k8s_fleet.termination_candidates)
         return JSONResponse([asdict(row) for row in rows])
@@ -709,6 +713,7 @@ def create_app(
             Route("/k8s/control_plane", k8s_control_plane),
             Route("/k8s/crashloops", k8s_crashloops),
             Route("/k8s/pending", k8s_pending),
+            Route("/k8s/workloads", k8s_workloads),
             Route("/k8s/termination_candidates", k8s_termination_candidates),
             Route("/k8s/kueue", k8s_kueue),
             Route("/k8s/events", k8s_events),

--- a/infra/grafana/tests/fixture_bridge.py
+++ b/infra/grafana/tests/fixture_bridge.py
@@ -165,6 +165,63 @@ def _provisioning() -> list[dict]:
 
 def _finelog(query: str) -> list[dict]:
     sql = parse_qs(query).get("sql", [""])[0]
+    if 'FROM "iris.task"' in sql:
+        return [
+            {
+                "cluster": "cw-us-east-02a",
+                "task": task,
+                "pod": pod,
+                "cpu_millicores": cpu,
+                "memory_bytes": memory,
+                "sampled_at": round((_NOW - timedelta(seconds=20)).timestamp() * 1000),
+            }
+            for task, pod, cpu, memory in (
+                ("/alice/llama/0", "llama-0", 29_000, 310_000_000_000),
+                ("/alice/llama/1", "llama-1", 14_000, 180_000_000_000),
+                ("/bob/eval/0", "eval-0", 9_500, 92_000_000_000),
+                ("/carol/embed/0", "embed-0", 5_200, 48_000_000_000),
+                ("/ops/loader/0", "loader-0", 1_800, 12_000_000_000),
+            )
+        ]
+    if "gpu_memory_total_bytes" in sql and "ROW_NUMBER" in sql:
+        sampled_at = round((_NOW - timedelta(seconds=15)).timestamp() * 1000)
+        values = {
+            "gpu-a": {
+                "node_cpu_utilization_percent": 61,
+                "node_memory_used_bytes": 760_000_000_000,
+                "node_memory_total_bytes": 1_100_000_000_000,
+                "gpu_utilization_percent": 88,
+                "gpu_memory_used_bytes": 590_000_000_000,
+                "gpu_memory_total_bytes": 640_000_000_000,
+            },
+            "gpu-b": {
+                "node_cpu_utilization_percent": 44,
+                "node_memory_used_bytes": 430_000_000_000,
+                "node_memory_total_bytes": 1_100_000_000_000,
+                "gpu_utilization_percent": 55,
+                "gpu_memory_used_bytes": 350_000_000_000,
+                "gpu_memory_total_bytes": 640_000_000_000,
+            },
+            "gpu-c": {
+                "node_cpu_utilization_percent": 28,
+                "node_memory_used_bytes": 190_000_000_000,
+                "node_memory_total_bytes": 550_000_000_000,
+                "gpu_utilization_percent": 36,
+                "gpu_memory_used_bytes": 91_000_000_000,
+                "gpu_memory_total_bytes": 320_000_000_000,
+            },
+        }
+        return [
+            {
+                "cluster": "cw-us-east-02a",
+                "node": node,
+                "name": name,
+                "value": value,
+                "sampled_at": sampled_at,
+            }
+            for node, metrics in values.items()
+            for name, value in metrics.items()
+        ]
     if "probe_latency_ms" in sql and "ROW_NUMBER" not in sql:
         return [
             {
@@ -374,11 +431,18 @@ def _rows(path: str, query: str) -> list[dict] | dict:
             for component in ("iris/iris-controller", "kueue-system/kueue-controller-manager")
         ]
     if path == "/k8s/nodes":
-        return [
+        selected = parse_qs(query).get("cluster", [""])[0]
+        rows = [
             {
                 "cluster": cluster,
-                "node": "g8fd930" if cluster == _CW_NODE_WITH_DEADLOCK else f"{cluster}-node-1",
-                "instance_type": "cd-gp-i64-erapids",
+                "node": node_name,
+                "instance_type": instance_type,
+                "node_pool": "training",
+                "gpu_model": gpu_model,
+                "gpu_capacity": gpu_count,
+                "gpu_allocatable": gpu_count,
+                "cpu_allocatable": cpu,
+                "memory_allocatable": memory,
                 "ready": True,
                 "unschedulable": cluster == _CW_NODE_WITH_DEADLOCK,
                 "kernel_deadlock": cluster == _CW_NODE_WITH_DEADLOCK,
@@ -387,8 +451,44 @@ def _rows(path: str, query: str) -> list[dict] | dict:
                 "pending_phase": "production-reboot" if cluster == _CW_NODE_WITH_DEADLOCK else "",
                 "deadlock_message": "watchdog: CPU stuck" if cluster == _CW_NODE_WITH_DEADLOCK else "",
             }
-            for cluster in _CW_K8S_CLUSTERS
+            for cluster, node_name, instance_type, gpu_model, gpu_count, cpu, memory in (
+                ("cw-us-east-02a", "gpu-a", "h100-8", "NVIDIA H100 80GB HBM3", 8, "96", "1Ti"),
+                ("cw-us-east-02a", "gpu-b", "h100-8", "NVIDIA H100 80GB HBM3", 8, "96", "1Ti"),
+                ("cw-us-east-02a", "gpu-c", "h100-4", "NVIDIA H100 80GB HBM3", 4, "48", "512Gi"),
+                ("cw-us-east-08a", "g8fd930", "gb200-4", "NVIDIA GB200", 4, "72", "768Gi"),
+                ("cw-rno2a", "cw-rno2a-node-1", "h100-8", "NVIDIA H100 80GB HBM3", 8, "96", "1Ti"),
+            )
         ]
+        return [row for row in rows if not selected or row["cluster"] == selected]
+    if path == "/k8s/workloads":
+        selected = parse_qs(query).get("cluster", [""])[0]
+        rows = [
+            {
+                "cluster": "cw-us-east-02a",
+                "namespace": "iris",
+                "pod": pod,
+                "node": node_name,
+                "job": job,
+                "task": task,
+                "phase": phase,
+                "ready": phase == "Running",
+                "priority_class": "iris-production",
+                "age_seconds": age,
+                "cpu_request_millicores": cpu,
+                "memory_request_bytes": memory,
+                "gpu_request_count": gpu,
+                "gpu_variant": "H100" if gpu else "",
+            }
+            for pod, node_name, job, task, phase, age, cpu, memory, gpu in (
+                ("llama-0", "gpu-a", "/alice/llama", "/alice/llama/0", "Running", 7300, 32_000, 343_597_383_680, 8),
+                ("llama-1", "gpu-b", "/alice/llama", "/alice/llama/1", "Running", 7200, 16_000, 206_158_430_208, 4),
+                ("eval-0", "gpu-b", "/bob/eval", "/bob/eval/0", "Running", 2800, 12_000, 103_079_215_104, 2),
+                ("embed-0", "gpu-c", "/carol/embed", "/carol/embed/0", "Running", 1500, 8000, 68_719_476_736, 2),
+                ("loader-0", "gpu-a", "/ops/loader", "/ops/loader/0", "Running", 600, 4000, 17_179_869_184, 0),
+                ("train-queued", "", "/dave/train", "/dave/train/0", "Pending", 420, 16_000, 137_438_953_472, 4),
+            )
+        ]
+        return [row for row in rows if not selected or row["cluster"] == selected]
     if path == "/k8s/pending":
         return [
             {

--- a/infra/grafana/tests/test_dashboard_stitch.py
+++ b/infra/grafana/tests/test_dashboard_stitch.py
@@ -27,6 +27,16 @@ def test_stitch_dashboard_leaves_non_ref_panels_untouched():
     assert stitch_dashboard(source, {})["panels"] == [inline_panel]
 
 
+def test_stitch_dashboard_resolves_shared_links():
+    source = {"links": [{"linkRef": "cluster_capacity"}], "panels": []}
+
+    (link,) = stitch_dashboard(source, {})["links"]
+
+    assert link["title"] == "Cluster capacity"
+    assert link["url"] == "/d/marin-cluster-capacity"
+    assert link["includeVars"] is True
+
+
 def test_stitch_dashboard_rejects_an_unknown_fragment_name():
     source = {"panels": [{"id": 7, "gridPos": {}, "panelRef": "missing"}]}
     with pytest.raises(KeyError, match="missing"):

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -521,8 +521,9 @@ def test_workload_allocations_report_live_iris_jobs_and_requested_resources():
 
     (row,) = make_k8s_source(k8s_api(routes)).workload_allocations()
 
-    age_seconds = row.pop("age_seconds")
-    assert row == {
+    row_dict = asdict(row)
+    age_seconds = row_dict.pop("age_seconds")
+    assert row_dict == {
         "namespace": "iris",
         "pod": "train-worker-0",
         "node": "gpu-a",
@@ -1017,7 +1018,6 @@ def test_k8s_routes_serve_fleet_rows():
         "/k8s/control_plane",
         "/k8s/crashloops",
         "/k8s/pending",
-        "/k8s/workloads",
         "/k8s/kueue",
         "/k8s/events",
         "/k8s/gpu_racks",

--- a/infra/grafana/tests/test_k8s_source.py
+++ b/infra/grafana/tests/test_k8s_source.py
@@ -447,6 +447,9 @@ def test_nodes_report_coreweave_kernel_deadlock_and_pending_reboot():
             "compute_class": "default",
             "gpu_model": "NVIDIA H100 80GB HBM3",
             "gpu_capacity": 0,
+            "cpu_allocatable": "",
+            "memory_allocatable": "",
+            "gpu_allocatable": 0,
             "rack": "14",
             "rack_name": "dh1-r014-us-east-02a",
             "rack_slot": "dh1-r014-node-01",
@@ -463,6 +466,77 @@ def test_nodes_report_coreweave_kernel_deadlock_and_pending_reboot():
             "pending_phase": "production-reboot",
         }
     ]
+
+
+def test_workload_allocations_report_live_iris_jobs_and_requested_resources():
+    workload = {
+        "metadata": {
+            "namespace": "iris",
+            "name": "train-worker-0",
+            "creationTimestamp": "2026-07-19T00:00:00Z",
+            "labels": {"iris.managed": "true", "iris.job_id": "alice-train"},
+            "annotations": {"iris.task_id": "/alice/train/0"},
+        },
+        "spec": {
+            "nodeName": "gpu-a",
+            "priorityClassName": "iris-production",
+            "containers": [
+                {
+                    "name": "task",
+                    "env": [
+                        {
+                            "name": "IRIS_TASK_RESOURCES",
+                            "value": (
+                                '{"cpu_millicores": 8000, "memory_bytes": "68719476736", '
+                                '"device": {"gpu": {"count": 4, "variant": "H100"}}}'
+                            ),
+                        }
+                    ],
+                }
+            ],
+        },
+        "status": {
+            "phase": "Running",
+            "conditions": [{"type": "Ready", "status": "True"}],
+        },
+    }
+    terminal = {
+        **workload,
+        "metadata": {**workload["metadata"], "name": "finished-worker"},
+        "status": {"phase": "Succeeded"},
+    }
+    unmanaged = {
+        **workload,
+        "metadata": {
+            **workload["metadata"],
+            "name": "other-workload",
+            "labels": {},
+            "annotations": {},
+        },
+    }
+    routes = {
+        "/api/v1/namespaces": [_namespace("iris")],
+        "/api/v1/namespaces/iris/pods": [workload, terminal, unmanaged],
+    }
+
+    (row,) = make_k8s_source(k8s_api(routes)).workload_allocations()
+
+    age_seconds = row.pop("age_seconds")
+    assert row == {
+        "namespace": "iris",
+        "pod": "train-worker-0",
+        "node": "gpu-a",
+        "job": "/alice/train",
+        "task": "/alice/train/0",
+        "phase": "Running",
+        "ready": True,
+        "priority_class": "iris-production",
+        "cpu_request_millicores": 8000,
+        "memory_request_bytes": 68719476736,
+        "gpu_request_count": 4,
+        "gpu_variant": "H100",
+    }
+    assert age_seconds > 0
 
 
 def test_node_pools_project_capacity_policy_and_problem_conditions():
@@ -943,6 +1017,7 @@ def test_k8s_routes_serve_fleet_rows():
         "/k8s/control_plane",
         "/k8s/crashloops",
         "/k8s/pending",
+        "/k8s/workloads",
         "/k8s/kueue",
         "/k8s/events",
         "/k8s/gpu_racks",
@@ -966,7 +1041,9 @@ def test_k8s_routes_serve_fleet_rows():
 def test_node_routes_filter_cached_fleet_rows():
     routes_a = healthy_k8s_routes()
     routes_b = healthy_k8s_routes()
-    routes_b["/api/v1/nodes"] = [node("g2", gpu_capacity=8)]
+    gpu_node = node("g2", gpu_capacity=8)
+    gpu_node["status"]["allocatable"] = {"cpu": "94", "memory": "1000Gi", "nvidia.com/gpu": "7"}
+    routes_b["/api/v1/nodes"] = [gpu_node]
     routes_b[NODE_POOLS] = [
         {
             "metadata": {"name": "h100"},
@@ -993,6 +1070,9 @@ def test_node_routes_filter_cached_fleet_rows():
             "compute_class": "",
             "gpu_model": "",
             "gpu_capacity": 8,
+            "cpu_allocatable": "94",
+            "memory_allocatable": "1000Gi",
+            "gpu_allocatable": 7,
             "rack": "",
             "rack_name": "",
             "rack_slot": "",
@@ -1014,6 +1094,25 @@ def test_node_routes_filter_cached_fleet_rows():
     assert error_row["cluster"] == "cw-c"
     assert error_row["error_class"] == "http"
     assert "node" not in error_row
+
+
+def test_workload_route_filters_cached_fleet_rows_by_cluster_and_job():
+    routes_a = healthy_k8s_routes()
+    routes_b = healthy_k8s_routes()
+    for routes, task in ((routes_a, "/alice/train/0"), (routes_b, "/bob/eval/0")):
+        routes["/api/v1/namespaces"] = [_namespace("iris")]
+        workload = pod("iris", task.replace("/", "-").strip("-"))
+        workload["metadata"]["labels"] = {"iris.managed": "true"}
+        workload["metadata"]["annotations"] = {"iris.task_id": task}
+        workload["spec"]["containers"] = [{"name": "task", "env": []}]
+        workload["status"]["phase"] = "Running"
+        routes["/api/v1/namespaces/iris/pods"] = [workload]
+
+    client = _client(_fleet(("cw-a", k8s_api(routes_a)), ("cw-b", k8s_api(routes_b))))
+
+    assert [
+        row["task"] for row in client.get("/k8s/workloads", params={"cluster": "cw-b", "job": "/bob/eval"}).json()
+    ] == ["/bob/eval/0"]
 
 
 def test_finelog_route_serializes_pod_diagnostics():

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -518,6 +518,31 @@ def test_status_page_has_each_required_source():
     }
 
 
+def test_cluster_capacity_page_joins_live_placement_with_recent_resource_usage():
+    dashboard = _stitched_dashboards()["cluster_capacity.json"]
+    (panel,) = dashboard["panels"]
+    targets = {target["refId"]: target for target in panel["targets"]}
+
+    assert panel["datasource"]["uid"] == "status"
+    assert panel["options"]["view"] == "cluster"
+    assert {ref_id: target["url"] for ref_id, target in targets.items()} == {
+        "W": "/k8s/workloads",
+        "N": "/k8s/nodes",
+        "T": "/finelog/marin/query",
+        "H": "/finelog/marin/query",
+    }
+    workload_columns = {column["selector"] for column in targets["W"]["columns"]}
+    assert {"job", "task", "node", "cpu_request_millicores", "memory_request_bytes", "gpu_request_count"} <= (
+        workload_columns
+    )
+    node_columns = {column["selector"] for column in targets["N"]["columns"]}
+    assert {"cpu_allocatable", "memory_allocatable", "gpu_allocatable", "ready", "unschedulable"} <= node_columns
+    sql = "\n".join(_panel_sql(dashboard))
+    assert 'FROM "iris.task"' in sql
+    assert "node_cpu_utilization_percent" in sql
+    assert "gpu_memory_total_bytes" in sql
+
+
 def test_status_page_queries_provisioning_snapshot_and_region_history():
     dashboard = _stitched_dashboards()["infra.json"]
     (panel,) = dashboard["panels"]

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -518,31 +518,6 @@ def test_status_page_has_each_required_source():
     }
 
 
-def test_cluster_capacity_page_joins_live_placement_with_recent_resource_usage():
-    dashboard = _stitched_dashboards()["cluster_capacity.json"]
-    (panel,) = dashboard["panels"]
-    targets = {target["refId"]: target for target in panel["targets"]}
-
-    assert panel["datasource"]["uid"] == "status"
-    assert panel["options"]["view"] == "cluster"
-    assert {ref_id: target["url"] for ref_id, target in targets.items()} == {
-        "W": "/k8s/workloads",
-        "N": "/k8s/nodes",
-        "T": "/finelog/marin/query",
-        "H": "/finelog/marin/query",
-    }
-    workload_columns = {column["selector"] for column in targets["W"]["columns"]}
-    assert {"job", "task", "node", "cpu_request_millicores", "memory_request_bytes", "gpu_request_count"} <= (
-        workload_columns
-    )
-    node_columns = {column["selector"] for column in targets["N"]["columns"]}
-    assert {"cpu_allocatable", "memory_allocatable", "gpu_allocatable", "ready", "unschedulable"} <= node_columns
-    sql = "\n".join(_panel_sql(dashboard))
-    assert 'FROM "iris.task"' in sql
-    assert "node_cpu_utilization_percent" in sql
-    assert "gpu_memory_total_bytes" in sql
-
-
 def test_status_page_queries_provisioning_snapshot_and_region_history():
     dashboard = _stitched_dashboards()["infra.json"]
     (panel,) = dashboard["panels"]


### PR DESCRIPTION
Add a single-cluster capacity view that joins live Iris pod placement and
scheduler requests with node allocatable capacity and recent Finelog usage.
The view rolls tasks up by root job, reports live sample coverage, separates
pending requests from bound capacity, and renders GPU slots by node so occupied
and idle capacity are visible together.

Expose current Iris workload placement and allocatable node resources through
the existing read-only Kubernetes bridge. CPU and memory usage comes from the
latest `iris.task` samples; host and GPU pressure comes from node-agent
telemetry. The default selection is `cw-us-east-02a`.

CoreWeave selections include Kubernetes placement. The `marin` and `marin-dev`
selections currently render an empty placement view because that source is not
available for those clusters.
