### PR TITLE
[iris] Filter dashboard events by task incarnation

### DIFF
--- a/lib/iris/dashboard/src/components/controller/TaskDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/TaskDetail.vue
@@ -78,6 +78,12 @@ const isActive = computed(() => {
 // Drives the Events panel so it follows the same attempt as the log viewer.
 const selectedAttemptId = ref<number | undefined>(undefined)
 const effectiveAttemptId = computed(() => selectedAttemptId.value ?? task.value?.currentAttemptId)
+const effectiveAttemptUid = computed(() => {
+  const attempts = task.value?.attempts ?? []
+  const attemptId = effectiveAttemptId.value
+  if (attemptId === undefined) return attempts[attempts.length - 1]?.attemptUid
+  return attempts.find((attempt) => (attempt.attemptId ?? 0) === attemptId)?.attemptUid
+})
 
 const startedMs = computed(() => timestampMs(task.value?.startedAt))
 const finishedMs = computed(() => timestampMs(task.value?.finishedAt))
@@ -159,10 +165,10 @@ const statusTextDetail = computed<string>(() => {
 // --- Scheduling / lifecycle events from finelog stats (iris.task_event) ---
 //
 // One row per Kubernetes event the worker relayed for this task (pod, kueue,
-// container). Newest-first and filtered by attempt so a retry does not show the
-// prior attempt's events. This is the primary signal for a task wedged in
-// BUILDING/pending: it surfaces the k8s reasons (SchedulingGated,
-// ImagePullBackOff, quota/topology denials) behind the wait.
+// container). Newest-first and filtered by attempt UID so a recreated task does
+// not show events retained from an earlier job incarnation. This is the primary
+// signal for a task wedged in BUILDING/pending: it surfaces the k8s reasons
+// (SchedulingGated, ImagePullBackOff, quota/topology denials) behind the wait.
 const TASK_EVENT_NAMESPACE = 'iris.task_event'
 
 interface TaskEventRow {
@@ -174,13 +180,12 @@ interface TaskEventRow {
   count?: number
 }
 
-function buildTaskEventsSql(taskId: string, attemptId: number | undefined): string {
+function buildTaskEventsSql(taskId: string, attemptUid: string | undefined): string {
   // QueryRequest has no param binding; manual DuckDB single-quote escape.
   const escaped = taskId.replace(/'/g, "''")
-  const attemptPredicate =
-    attemptId !== undefined && attemptId !== null
-      ? `AND attempt_id = ${Number(attemptId)}`
-      : ''
+  const attemptPredicate = attemptUid
+    ? `AND attempt_uid = '${attemptUid.replace(/'/g, "''")}'`
+    : 'AND 1 = 0'
   return `
 SELECT ts, type, reason, message, source, count
 FROM "${TASK_EVENT_NAMESPACE}"
@@ -193,7 +198,7 @@ LIMIT 200
 
 const { data: taskEventsData, refresh: fetchTaskEvents } = useLogServerStatsRpc<QueryResponse>(
   'Query',
-  () => ({ sql: buildTaskEventsSql(props.taskId, effectiveAttemptId.value) }),
+  () => ({ sql: buildTaskEventsSql(props.taskId, effectiveAttemptUid.value) }),
 )
 
 const taskEvents = computed<TaskEventRow[]>(() => {
@@ -281,7 +286,7 @@ const { start: startEndpointsRefresh, stop: stopEndpointsRefresh } = useAutoRefr
 
 // Re-query events as soon as the focused attempt changes so a manual attempt
 // pick (or a new attempt appearing) reflects immediately, not on the next poll.
-watch(effectiveAttemptId, () => {
+watch(effectiveAttemptUid, () => {
   fetchTaskEvents()
 })
 

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -8,12 +8,14 @@ submits its own jobs and is independently runnable. In local mode the cluster
 has workers across CPU, TPU coscheduling, and multi-region scale groups.
 """
 
+import contextlib
 import logging
 import os
 import uuid
 from pathlib import Path
 
 import pytest
+from finelog.client import FlushResult, LogClient
 from finelog.rpc import logging_pb2
 from finelog.rpc.logging_connect import LogServiceClientSync
 from iris.client.client import IrisClient, iris_ctx
@@ -29,6 +31,7 @@ from iris.cluster.config import (
 from iris.cluster.constraints import Constraint, ConstraintOp, WellKnownAttribute, region_constraint
 from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME
 from iris.cluster.lifecycle import connect_cluster
+from iris.cluster.stats.tables import TASK_EVENT_NAMESPACE, TASK_EVENT_STORAGE_POLICY, TaskEventRow
 from iris.cluster.types import AcceleratorType, CapacityType, Entrypoint, EnvironmentSpec, ResourceSpec
 from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
@@ -45,7 +48,7 @@ from iris.testing.e2e import (
 )
 from iris.testing.e2e_helpers import TestJobs
 from rigging.connect import proxy_path
-from rigging.timing import Duration, ExponentialBackoff
+from rigging.timing import Duration, ExponentialBackoff, Timestamp
 
 logger = logging.getLogger(__name__)
 
@@ -417,6 +420,60 @@ def _wait_for_task_log_marker(
         timeout=Duration.from_seconds(timeout),
         error_message=f"log marker {marker!r} for {source} not queryable within {timeout:.0f}s",
     )
+
+
+def test_dashboard_task_events_exclude_prior_incarnations(smoke_cluster, smoke_page):
+    """The task timeline excludes retained events from a prior run with reused IDs."""
+    job = smoke_cluster.submit(TestJobs.quick, "smoke-event-incarnation")
+    smoke_cluster.wait(job, timeout=smoke_cluster.job_timeout)
+    task_status = smoke_cluster.task_status(job)
+    task_id = task_status.task_id
+    job_id = job.job_id.to_wire()
+    current_attempt = next(
+        attempt for attempt in task_status.attempts if attempt.attempt_id == task_status.current_attempt_id
+    )
+
+    log_server_url = f"{smoke_cluster.url.rstrip('/')}{proxy_path(LOG_SERVER_ENDPOINT_NAME)}"
+    with contextlib.closing(LogClient.connect(log_server_url)) as log_client:
+        table = log_client.get_table(
+            TASK_EVENT_NAMESPACE,
+            TaskEventRow,
+            storage_policy=TASK_EVENT_STORAGE_POLICY,
+        )
+        now = Timestamp.now()
+        table.write(
+            [
+                TaskEventRow(
+                    task_id=task_id,
+                    attempt_id=current_attempt.attempt_id,
+                    attempt_uid="prior-incarnation",
+                    ts=now.add_ms(-1_000).as_naive_utc(),
+                    type="Warning",
+                    reason="PriorIncarnationEvent",
+                    message="This retained event belongs to an earlier run.",
+                    source="iris/controller",
+                    count=1,
+                ),
+                TaskEventRow(
+                    task_id=task_id,
+                    attempt_id=current_attempt.attempt_id,
+                    attempt_uid=current_attempt.attempt_uid,
+                    ts=now.as_naive_utc(),
+                    type="Normal",
+                    reason="CurrentIncarnationEvent",
+                    message="This event belongs to the task shown by the controller.",
+                    source="iris/controller",
+                    count=1,
+                ),
+            ]
+        )
+        assert table.flush(timeout=5) == FlushResult.SUCCEEDED
+
+    dashboard_goto(smoke_page, f"{smoke_cluster.url}/job/{job_id}/task/{task_id}")
+    wait_for_dashboard_ready(smoke_page)
+    smoke_page.get_by_text("CurrentIncarnationEvent", exact=True).wait_for(timeout=10_000)
+
+    assert smoke_page.get_by_text("PriorIncarnationEvent", exact=True).count() == 0
 
 
 def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_screenshot):

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -441,6 +441,7 @@ def test_dashboard_task_events_exclude_prior_incarnations(smoke_cluster, smoke_p
             storage_policy=TASK_EVENT_STORAGE_POLICY,
         )
         now = Timestamp.now()
+        event_source = "iris/controller"
         table.write(
             [
                 TaskEventRow(
@@ -451,7 +452,7 @@ def test_dashboard_task_events_exclude_prior_incarnations(smoke_cluster, smoke_p
                     type="Warning",
                     reason="PriorIncarnationEvent",
                     message="This retained event belongs to an earlier run.",
-                    source="iris/controller",
+                    source=event_source,
                     count=1,
                 ),
                 TaskEventRow(
@@ -462,7 +463,7 @@ def test_dashboard_task_events_exclude_prior_incarnations(smoke_cluster, smoke_p
                     type="Normal",
                     reason="CurrentIncarnationEvent",
                     message="This event belongs to the task shown by the controller.",
-                    source="iris/controller",
+                    source=event_source,
                     count=1,
                 ),
             ]


### PR DESCRIPTION
Repeated task events from earlier job runs no longer appear in the current
task timeline. Recreated jobs reuse task and attempt numbers, which previously
mixed all retained Finelog rows for those identifiers.

Filter the task-detail event query by the selected attempt UID. Resolve the
default selection from the controller's attempt list and return an empty event
set until a UID is available. This matches `iris task events`, which already
treats attempt UIDs as the job-incarnation boundary.
