### PR TITLE
[grug] Disable simulated epoching above 1e23 FLOPs

### DIFF
--- a/experiments/grug/moe/launch_datakit_moe_mix.py
+++ b/experiments/grug/moe/launch_datakit_moe_mix.py
@@ -313,6 +313,26 @@ def _simulated_experiment_budget(*, total_steps: int, batch_size: int, max_seq_l
     return total_steps * batch_size * max_seq_len
 
 
+def _simulated_epoching_budgets(
+    *,
+    total_steps: int,
+    batch_size: int,
+    max_seq_len: int,
+    target_budget: int,
+    enable_simulated_epoching: bool,
+) -> tuple[int | None, int | None]:
+    if not enable_simulated_epoching:
+        return None, None
+    experiment_budget = _simulated_experiment_budget(
+        total_steps=total_steps,
+        batch_size=batch_size,
+        max_seq_len=max_seq_len,
+    )
+    if experiment_budget > target_budget:
+        raise ValueError(f"experiment_budget {experiment_budget} exceeds target_budget {target_budget}")
+    return target_budget, experiment_budget
+
+
 def _two_phase_data_config(
     *,
     tokenizer: str,
@@ -351,17 +371,13 @@ def _datakit_data_config(
     val_components: dict[str, DatasetComponent | ConcatDatasetComponent],
 ) -> LmDataConfig:
     phase_1_start = _phase_1_start_step(total_steps, batch_size)
-    target_budget = None
-    experiment_budget = None
-    if enable_simulated_epoching:
-        experiment_budget = _simulated_experiment_budget(
-            total_steps=total_steps,
-            batch_size=batch_size,
-            max_seq_len=max_seq_len,
-        )
-        if experiment_budget > _TARGET_BUDGET_TOKENS:
-            raise ValueError(f"experiment_budget {experiment_budget} exceeds target_budget {_TARGET_BUDGET_TOKENS}")
-        target_budget = _TARGET_BUDGET_TOKENS
+    target_budget, experiment_budget = _simulated_epoching_budgets(
+        total_steps=total_steps,
+        batch_size=batch_size,
+        max_seq_len=max_seq_len,
+        target_budget=_TARGET_BUDGET_TOKENS,
+        enable_simulated_epoching=enable_simulated_epoching,
+    )
 
     return _two_phase_data_config(
         tokenizer=marin_tokenizer,

--- a/experiments/grug/moe_hero_ep/harrier_mix_2026_08_18.py
+++ b/experiments/grug/moe_hero_ep/harrier_mix_2026_08_18.py
@@ -25,7 +25,7 @@ from rigging.filesystem.storage_path import prefix_join
 
 from experiments.grug.moe.launch_datakit_moe_mix import (
     _phase_1_start_step,
-    _simulated_experiment_budget,
+    _simulated_epoching_budgets,
     _two_phase_data_config,
     _val_component,
 )
@@ -125,17 +125,13 @@ def harrier_mix_2026_08_18_data_config(
     collisions = components.keys() & val_components.keys()
     if collisions:
         raise ValueError(f"validation components collide with Harrier buckets: {sorted(collisions)}")
-    target_budget = None
-    experiment_budget = None
-    if enable_simulated_epoching:
-        experiment_budget = _simulated_experiment_budget(
-            total_steps=total_steps,
-            batch_size=batch_size,
-            max_seq_len=max_seq_len,
-        )
-        if experiment_budget > TOTAL_TOKENS:
-            raise ValueError(f"experiment budget {experiment_budget} exceeds target budget {TOTAL_TOKENS}")
-        target_budget = TOTAL_TOKENS
+    target_budget, experiment_budget = _simulated_epoching_budgets(
+        total_steps=total_steps,
+        batch_size=batch_size,
+        max_seq_len=max_seq_len,
+        target_budget=TOTAL_TOKENS,
+        enable_simulated_epoching=enable_simulated_epoching,
+    )
 
     return _two_phase_data_config(
         tokenizer=marin_tokenizer,

--- a/experiments/grug/moe_hero_ep/harrier_mix_2026_08_18.py
+++ b/experiments/grug/moe_hero_ep/harrier_mix_2026_08_18.py
@@ -35,6 +35,10 @@ PRETRAIN_TOKENS = 15_000_000_000_000
 COOLDOWN_TOKENS = 3_750_000_000_000
 TOTAL_TOKENS = PRETRAIN_TOKENS + COOLDOWN_TOKENS
 HARRIER_MIX_2026_08_18_TAG = "harrier-mix-2026.08.18"
+# Simulated epoching stretches a short run's mixture as if it were a larger budget. Above this analytic
+# training-FLOP budget the run is expensive enough that we want maximally-real data over a simulated
+# larger run, so it trains on the raw mixture instead.
+SIMULATED_EPOCHING_MAX_FLOPS = 1e23
 
 HARRIER_MIX_2026_08_18_STORE = ArtifactStep.adopt(
     "datakit/store/harrier-all-sources-k40-q5-fuzzy-dedup",
@@ -99,10 +103,15 @@ def harrier_mix_2026_08_18_data_config(
     total_steps: int,
     batch_size: int,
     max_seq_len: int,
-    enable_simulated_epoching: bool,
+    experiment_flops: float,
     validation: Sequence[ArtifactStep[TokenizedCache]],
 ) -> LmDataConfig:
-    """Build the evaluated two-phase mixture, optionally with simulated epoching."""
+    """Build the evaluated two-phase mixture.
+
+    Simulated epoching is on by default; it is dropped once ``experiment_flops`` (the run's analytic
+    training-FLOP budget) exceeds ``SIMULATED_EPOCHING_MAX_FLOPS``, so an expensive run trains on the
+    raw mixture rather than a simulated larger budget.
+    """
     available_tokens = dict(_SPEC.available_tokens)
     phase_weights = tuple(dict(weights) for weights in _SPEC.phase_weights)
     components = {
@@ -130,7 +139,7 @@ def harrier_mix_2026_08_18_data_config(
         batch_size=batch_size,
         max_seq_len=max_seq_len,
         target_budget=TOTAL_TOKENS,
-        enable_simulated_epoching=enable_simulated_epoching,
+        enable_simulated_epoching=experiment_flops <= SIMULATED_EPOCHING_MAX_FLOPS,
     )
 
     return _two_phase_data_config(

--- a/experiments/grug/moe_hero_ep/harrier_mix_2026_08_18.py
+++ b/experiments/grug/moe_hero_ep/harrier_mix_2026_08_18.py
@@ -99,9 +99,10 @@ def harrier_mix_2026_08_18_data_config(
     total_steps: int,
     batch_size: int,
     max_seq_len: int,
+    enable_simulated_epoching: bool,
     validation: Sequence[ArtifactStep[TokenizedCache]],
 ) -> LmDataConfig:
-    """Build the evaluated two-phase mixture for a simulated experiment budget."""
+    """Build the evaluated two-phase mixture, optionally with simulated epoching."""
     available_tokens = dict(_SPEC.available_tokens)
     phase_weights = tuple(dict(weights) for weights in _SPEC.phase_weights)
     components = {
@@ -124,13 +125,17 @@ def harrier_mix_2026_08_18_data_config(
     collisions = components.keys() & val_components.keys()
     if collisions:
         raise ValueError(f"validation components collide with Harrier buckets: {sorted(collisions)}")
-    experiment_budget = _simulated_experiment_budget(
-        total_steps=total_steps,
-        batch_size=batch_size,
-        max_seq_len=max_seq_len,
-    )
-    if experiment_budget > TOTAL_TOKENS:
-        raise ValueError(f"experiment budget {experiment_budget} exceeds target budget {TOTAL_TOKENS}")
+    target_budget = None
+    experiment_budget = None
+    if enable_simulated_epoching:
+        experiment_budget = _simulated_experiment_budget(
+            total_steps=total_steps,
+            batch_size=batch_size,
+            max_seq_len=max_seq_len,
+        )
+        if experiment_budget > TOTAL_TOKENS:
+            raise ValueError(f"experiment budget {experiment_budget} exceeds target budget {TOTAL_TOKENS}")
+        target_budget = TOTAL_TOKENS
 
     return _two_phase_data_config(
         tokenizer=marin_tokenizer,
@@ -138,6 +143,6 @@ def harrier_mix_2026_08_18_data_config(
         phase_weights=phase_weights,
         phase_1_start=_phase_1_start_step(total_steps, batch_size),
         val_components=val_components,
-        target_budget=TOTAL_TOKENS,
+        target_budget=target_budget,
         experiment_budget=experiment_budget,
     )

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -68,6 +68,7 @@ from experiments.grug.moe_hero_ep.train import (
     GrugTrainerConfig,
     MasterParamMode,
     WatchMode,
+    _compute_flops,
     run_grug,
 )
 
@@ -80,6 +81,7 @@ WATCH_INTERVAL = 10
 # 791 tokens per active parameter sets the step budget: it lands the d6144 hero at 18T tokens and
 # scales every narrower rung by the same ratio.
 TOKENS_PER_ACTIVE_PARAM = 791
+SIMULATED_EPOCHING_MAX_FLOPS = 1e23
 
 
 def _ladder_model(size: str):
@@ -139,6 +141,9 @@ def build_ladder_run(
         num_steps = max(1, round(TOKENS_PER_ACTIVE_PARAM * _active_params(model) / global_tokens_per_step))
     elif num_steps <= 0:
         raise ValueError(f"num_steps must be positive, got {num_steps}")
+    flops_per_example, _ = _compute_flops(model_config=model)
+    run_flops = flops_per_example * batch_size * num_steps
+    enable_simulated_epoching = run_flops <= SIMULATED_EPOCHING_MAX_FLOPS
 
     # The narrow rungs are short: eval every 5% of the run and keep only the forced final checkpoint.
     # The d6144 hero is long: eval every 3000 steps and keep a permanent checkpoint every 6000.
@@ -249,6 +254,7 @@ def build_ladder_run(
                 total_steps=num_steps,
                 batch_size=batch_size,
                 max_seq_len=model.max_seq_len,
+                enable_simulated_epoching=enable_simulated_epoching,
                 validation=validation,
             ),
             resources=ctx.runtime_arg("train_resources"),

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -81,7 +81,6 @@ WATCH_INTERVAL = 10
 # 791 tokens per active parameter sets the step budget: it lands the d6144 hero at 18T tokens and
 # scales every narrower rung by the same ratio.
 TOKENS_PER_ACTIVE_PARAM = 791
-SIMULATED_EPOCHING_MAX_FLOPS = 1e23
 
 
 def _ladder_model(size: str):
@@ -143,7 +142,6 @@ def build_ladder_run(
         raise ValueError(f"num_steps must be positive, got {num_steps}")
     flops_per_example, _ = _compute_flops(model_config=model)
     run_flops = flops_per_example * batch_size * num_steps
-    enable_simulated_epoching = run_flops <= SIMULATED_EPOCHING_MAX_FLOPS
 
     # The narrow rungs are short: eval every 5% of the run and keep only the forced final checkpoint.
     # The d6144 hero is long: eval every 3000 steps and keep a permanent checkpoint every 6000.
@@ -254,7 +252,7 @@ def build_ladder_run(
                 total_steps=num_steps,
                 batch_size=batch_size,
                 max_seq_len=model.max_seq_len,
-                enable_simulated_epoching=enable_simulated_epoching,
+                experiment_flops=run_flops,
                 validation=validation,
             ),
             resources=ctx.runtime_arg("train_resources"),

--- a/tests/test_grug_hero_scaling_ladder.py
+++ b/tests/test_grug_hero_scaling_ladder.py
@@ -1,0 +1,21 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from marin.execution.lazy import StepContext
+
+from experiments.grug.moe_hero_ep.launch_scaling_ladder import build_ladder_run
+
+
+@pytest.mark.parametrize(
+    ("size", "num_steps", "expected_simulated_epoching"),
+    [("d2048", None, True), ("d6144", 1, True), ("d6144", None, False)],
+)
+def test_scaling_ladder_disables_simulated_epoching_above_flop_limit(size, num_steps, expected_simulated_epoching):
+    step = build_ladder_run(run_id=f"test-{size}", size=size, num_steps=num_steps, version="2026.08.18")
+    ctx = StepContext.for_fingerprint(runtime_arg_keys=step.runtime_args, deps=step.deps)
+
+    data = step.build_config(ctx).data
+
+    assert (data.target_budget is not None) is expected_simulated_epoching
+    assert (data.experiment_budget is not None) is expected_simulated_epoching


### PR DESCRIPTION
Disable simulated epoching for scaling-ladder runs whose analytic training
budget exceeds 1e23 FLOPs. The current d2048 rung is 9.20e21 FLOPs and d6144 is
2.70e24 FLOPs, so the default ladder changes only at d6144. Short d6144 runs
below the threshold continue to simulate epochs.

Use one budget calculation for the shared datakit launcher and the Harrier
mixture so disabled runs omit both simulated-epoch fields consistently.


edit: closes #8414 