### PR TITLE
[inference] Document the TPU vLLM release refresh

### DIFF
--- a/.agents/skills/refresh-fork/SKILL.md
+++ b/.agents/skills/refresh-fork/SKILL.md
@@ -107,9 +107,9 @@ temporary source descriptor or add a second tpu-inference requirement.
 7. Run focused Marin checks, then run the sole physical gate in **Validate**.
    Open one draft Marin PR with the release and validation receipt. Do not add a
    second physical qualification or exact-byte protocol.
-8. After validation, mark the same GitHub release final without rebuilding or
-   replacing either asset. Read back the unchanged asset IDs and digests before
-   landing the Marin consumer.
+8. After validation and the producer change merges, mark the same GitHub release
+   final without rebuilding or replacing either asset. Read back the unchanged
+   asset IDs and digests before landing the Marin consumer.
 
 Rebuild and rerun the physical gate only after a change that can affect the
 wheel bytes or metadata, selected assets, producer path, Marin requirement, or

--- a/.agents/skills/refresh-fork/SKILL.md
+++ b/.agents/skills/refresh-fork/SKILL.md
@@ -90,10 +90,11 @@ temporary source descriptor or add a second tpu-inference requirement.
 2. Record the full vLLM and tpu-inference commits. Inspect their dependency files
    together, including the tpu-inference torch constraints and vLLM TPU
    requirements. These commits are release evidence, not Marin inputs.
-3. Freeze the vLLM workflow producer commit, both source commits, the dependency
-   cutoff, and the Marin consumer head. Dispatch the TPU lane of
-   `marin-gpu-candidate.yaml` at that producer commit with the two source commits
-   and cutoff as explicit inputs. Dispatch it once.
+3. Select one unused full `marin-vllm-tpu-...` release tag. Freeze that tag, the
+   vLLM workflow producer commit, both source commits, the dependency cutoff, and
+   the Marin consumer head. Dispatch the TPU lane of `marin-gpu-candidate.yaml`
+   at that producer commit with the tag, two source commits, and cutoff as
+   explicit inputs. Dispatch it once.
 4. Read back the public prerelease. It must contain exactly the vLLM wheel and its
    tpu-inference companion. Inspect the built vLLM wheel's `METADATA` and confirm
    its direct requirement names the companion's public release URL. Record the

--- a/.agents/skills/refresh-fork/SKILL.md
+++ b/.agents/skills/refresh-fork/SKILL.md
@@ -124,8 +124,8 @@ The bases are inputs to the replay. The source tips are the producer inputs.
    tpu-inference torch constraints and vLLM TPU requirements. These commits are
    release evidence, not separate Marin runtime inputs.
 6. Select one unused full `marin-vllm-tpu-...` release tag. Freeze that tag, the
-   vLLM workflow producer commit, both source tips, the dependency cutoff, and
-   the Marin consumer head. Dispatch the TPU lane of `marin-gpu-candidate.yaml`
+   vLLM workflow producer commit, both source tips, and the dependency cutoff.
+   Dispatch the TPU lane of `marin-gpu-candidate.yaml`
    at that producer commit with `vllm_source_tip`, `tpu_source_tip`, the tag, and
    the cutoff as explicit inputs. Dispatch it once.
 7. Read back the public prerelease. It must contain exactly the vLLM wheel and its
@@ -145,11 +145,12 @@ The bases are inputs to the replay. The source tips are the producer inputs.
    uv run config/update-external.py vllm --check
    ```
 
-10. Run focused Marin checks, then run the sole physical gate in **Validate**.
-    Skip **Select the base**, **Rebase the overlay**, **Pin at the staged tip**,
-    and **Prepare the protected-branch promotion**. Resume at **Review and Open
-    the PR** with the TPU release and validation receipt. Do not add a second
-    physical qualification or exact-byte protocol.
+10. Run focused Marin checks, commit the final consumer diff, and freeze its full
+    SHA as the Marin consumer head. Run the sole physical gate in **Validate**
+    against that exact SHA. Skip **Select the base**, **Rebase the overlay**,
+    **Pin at the staged tip**, and **Prepare the protected-branch promotion**.
+    Resume at **Review and Open the PR** with the TPU release and validation
+    receipt. Do not add a second physical qualification or exact-byte protocol.
 11. After validation and the producer change merges, mark the same GitHub release
     final without rebuilding or replacing either asset. Read back the unchanged
     asset IDs and digests before landing the Marin consumer.
@@ -357,8 +358,8 @@ refresh, and no text overclaims validation evidence.
 
 Open one draft `marin-community/marin` PR via `.agents/skills/commit/SKILL.md`,
 request the descriptor's `blocker_assignee` as reviewer, then read back its title,
-body, labels, base, head, and draft state. Take one non-blocking snapshot of CI,
-comments, and reviews; do not start a monitoring loop.
+body, labels, base, head, and draft state. Follow the commit skill's required
+monitoring behavior, then read back CI, comments, and reviews.
 
 For TPU, keep the body to the upstream bases, reviewed source tips, producer and
 release tag, dependency cutoff, immutable asset evidence, e2e outcome, and

--- a/.agents/skills/refresh-fork/SKILL.md
+++ b/.agents/skills/refresh-fork/SKILL.md
@@ -114,10 +114,9 @@ temporary source descriptor or add a second tpu-inference requirement.
 7. Run focused Marin checks, then run the sole physical gate in **Validate**.
    Open one draft Marin PR with the release and validation receipt. Do not add a
    second physical qualification or exact-byte protocol.
-8. After the producer change merges, mark the same GitHub release final without
-   rebuilding or replacing either asset. Read back the unchanged asset IDs and
-   digests. Land the Marin consumer with any tpu-inference compatibility change,
-   then land this refresh procedure.
+8. After validation, mark the same GitHub release final without rebuilding or
+   replacing either asset. Read back the unchanged asset IDs and digests before
+   landing the Marin consumer.
 
 Rebuild and rerun the physical gate only after a change that can affect the
 wheel bytes or metadata, selected assets, producer path, Marin requirement, or
@@ -158,13 +157,10 @@ suffix). Single-pin forks and the vLLM GPU pin use `main-next`. This staging bra
 force-updates it — and is distinct from the protected stable `<branch>`, which the
 unattended refresh leaves unchanged.
 
-Find the base our commits currently sit on: `old_base` is the descriptor's
-`upstream_base` (descriptor pins) or `git merge-base <fork>/<branch> upstream/HEAD`
-(isolated and release pins, where it is not recorded). `old_tip` is the head of our
-patches: the fork's `main` for isolated pins (Marin's recorded pin may lag `main`, so
-rebase from `main` to cover the full patch set), or the pin's stable `<branch>` tip for
-descriptor and release pins (the descriptor's `commit`, or `gpu.toml`'s
-`source_commit`). Then, onto `new_base`:
+Find the base our commits currently sit on. For an isolated pin, `old_tip` is the
+fork's `main` because Marin's recorded lock may lag the fork. For the `vllm-gpu`
+release pin, `old_tip` is `gpu.toml`'s `source_commit`. Resolve `old_base` with
+`git merge-base <old_tip> upstream/HEAD`. Then, onto `new_base`:
 
 1. Inventory our commits in order: `git log --reverse --no-merges old_base..old_tip`.
    Merge commits (especially merges of `upstream` into a feature branch) are not

--- a/.agents/skills/refresh-fork/SKILL.md
+++ b/.agents/skills/refresh-fork/SKILL.md
@@ -17,6 +17,8 @@ issue. The required end-to-end test needs no extra confirmation.
 
 Read the target fork's section in `config/external/migration.toml`. It gives:
 
+- `repository` — the Marin fork cloned as `origin`. When omitted, derive it from
+  the pin source.
 - `upstream` — the repo we rebase onto. Every fork has one.
 - `group` — if present, refresh every section in the group together in one PR
   (read them all now); if absent, this pin refreshes alone.
@@ -57,9 +59,10 @@ revision.
 - Scratch dir: `/tmp/marin-fork-refresh/<run-id>` (run id:
   `${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}` in Actions, else a UTC timestamp plus a
   short label).
-- Clone the fork and add its `upstream` remote. The fork URL is the
+- Clone the section's `repository` as `origin` and add the section's canonical
+  `upstream` as a separate remote. If `repository` is omitted, derive it from the
   `[tool.uv.sources]` git entry for isolated projects or the release-asset host
-  for release pins; `<upstream>` is this section's `upstream`.
+  for release pins.
 
 ```sh
 git clone <repository> <fork>
@@ -73,31 +76,68 @@ git -C <fork> remote set-head upstream -a                # so upstream/HEAD reso
 
 ## Refresh the TPU vLLM release
 
-This is the complete procedure for the `tpu-vllm` group. Do not stage a
-temporary source descriptor or add a second tpu-inference requirement.
+This is the source-selection and release procedure for the `tpu-vllm` group. Do
+not stage a temporary source descriptor, add a second tpu-inference requirement,
+or promote a TPU stable branch.
 
-1. Select the newest stable tpu-inference release. Resolve its exact fork commit
-   and read its `.buildkite/vllm_lkg.version`. Resolve that exact vLLM commit in
-   `marin-community/vllm`. If either fork needs an overlay change, review and land
-   that change through `docs/overlay-only-pr.md` before selecting the commit.
-2. Record the full vLLM and tpu-inference commits. Inspect their dependency files
-   together, including the tpu-inference torch constraints and vLLM TPU
-   requirements. These commits are release evidence, not Marin inputs.
-3. Select one unused full `marin-vllm-tpu-...` release tag. Freeze that tag, the
-   vLLM workflow producer commit, both source commits, the dependency cutoff, and
+Use these names throughout:
+
+```text
+tpu_base       = selected stable upstream tpu-inference release
+tpu_source_tip = reviewed tpu-inference overlay replayed onto tpu_base
+
+vllm_base       = LKG selected by that tpu-inference release
+vllm_source_tip = reviewed vLLM overlay replayed onto vllm_base
+```
+
+The bases are inputs to the replay. The source tips are the producer inputs.
+
+1. Read `config/external/vllm/tpu.toml`, then read the currently selected GitHub
+   release notes and producer receipt. Record the exact current
+   `tpu_source_tip` and `vllm_source_tip`, and verify each resolves in its Marin
+   fork. Identify and verify the exact upstream base beneath each current source
+   tip. Stop with a blocker if the current source tips or their bases cannot be
+   established exactly; do not reconstruct an overlay from a net diff.
+2. Select the newest stable release from canonical upstream tpu-inference as
+   `tpu_base`. Read `.buildkite/vllm_lkg.version` at that base and resolve the
+   named commit in canonical upstream vLLM as `vllm_base`.
+3. Replay each current Marin overlay onto its corresponding new base:
+   - Inventory `current_base..current_source_tip` in logical order with
+     `git log --reverse --no-merges`, retaining the original SHAs.
+   - Classify every meaningful delta as `carry`, `drop`, or `fix`. Compare it
+     with the new base first: drop changes upstream absorbed or made obsolete;
+     carry changes still needed; rewrite a `fix` when the intent remains but the
+     upstream API or layout moved. Merge commits are not replayed.
+   - Replay only `carry` and `fix` in logical order. Audit every touched API and
+     dependency against the new base, resolve incompatibilities, and run that
+     fork's ordinary checks before proceeding.
+   - Run `git range-diff` from the old overlay range to the new one. Record every
+     original commit and its carry/drop/fix result, with the reason for each drop
+     or rewrite. If an independent fixed-base overlay change is needed, land its
+     review through `docs/overlay-only-pr.md` before freezing either source tip;
+     that workflow is not a substitute for this replay.
+4. Review both replayed ranges and preserve their exact commits on reviewable
+   branches in the Marin forks. Record the resulting full SHAs as
+   `tpu_source_tip` and `vllm_source_tip`. Do not substitute the bare
+   `tpu_base` or `vllm_base` commits.
+5. Inspect the two source tips' dependency files together, including the
+   tpu-inference torch constraints and vLLM TPU requirements. These commits are
+   release evidence, not separate Marin runtime inputs.
+6. Select one unused full `marin-vllm-tpu-...` release tag. Freeze that tag, the
+   vLLM workflow producer commit, both source tips, the dependency cutoff, and
    the Marin consumer head. Dispatch the TPU lane of `marin-gpu-candidate.yaml`
-   at that producer commit with the tag, two source commits, and cutoff as
-   explicit inputs. Dispatch it once.
-4. Read back the public prerelease. It must contain exactly the vLLM wheel and its
+   at that producer commit with `vllm_source_tip`, `tpu_source_tip`, the tag, and
+   the cutoff as explicit inputs. Dispatch it once.
+7. Read back the public prerelease. It must contain exactly the vLLM wheel and its
    tpu-inference companion. Inspect the built vLLM wheel's `METADATA` and confirm
    its direct requirement names the companion's public release URL. Record the
-   workflow run, producer commit, source commits, cutoff, tag, asset names, sizes,
-   and digests as evidence.
-5. Before using hardware, resolve the public vLLM requirement in a fresh uv tool
+   workflow run, producer commit, source tips, upstream bases, cutoff, tag, asset
+   names, sizes, and digests as evidence.
+8. Before using hardware, resolve the public vLLM requirement in a fresh uv tool
    environment. Confirm it installs both selected wheel versions. Repeat with an
    explicit `tpu-inference @ git+https://github.com/marin-community/tpu-inference@<head>`
    override and confirm uv selects that HEAD instead of the transitive release.
-6. Edit only `config/external/vllm/tpu.toml`: the public release tag, dependency
+9. Edit only `config/external/vllm/tpu.toml`: the public release tag, dependency
    cutoff, and one vLLM requirement. Regenerate and check the typed object:
 
    ```sh
@@ -105,12 +145,14 @@ temporary source descriptor or add a second tpu-inference requirement.
    uv run config/update-external.py vllm --check
    ```
 
-7. Run focused Marin checks, then run the sole physical gate in **Validate**.
-   Open one draft Marin PR with the release and validation receipt. Do not add a
-   second physical qualification or exact-byte protocol.
-8. After validation and the producer change merges, mark the same GitHub release
-   final without rebuilding or replacing either asset. Read back the unchanged
-   asset IDs and digests before landing the Marin consumer.
+10. Run focused Marin checks, then run the sole physical gate in **Validate**.
+    Skip **Select the base**, **Rebase the overlay**, **Pin at the staged tip**,
+    and **Prepare the protected-branch promotion**. Resume at **Review and Open
+    the PR** with the TPU release and validation receipt. Do not add a second
+    physical qualification or exact-byte protocol.
+11. After validation and the producer change merges, mark the same GitHub release
+    final without rebuilding or replacing either asset. Read back the unchanged
+    asset IDs and digests before landing the Marin consumer.
 
 Rebuild and rerun the physical gate only after a change that can affect the
 wheel bytes or metadata, selected assets, producer path, Marin requirement, or
@@ -198,8 +240,8 @@ blocker issue.
 
 ## Pin at the staged tip
 
-This section applies only to non-TPU refreshes. The TPU group already stopped
-after **Refresh the TPU vLLM release**.
+This section applies only to non-TPU refreshes. The TPU group skips it and the
+protected-branch promotion section, then resumes at **Review and Open the PR**.
 
 Point Marin at `<branch>-next` so the e2e runs against the replayed code, then run
 `uv run config/update-external.py` to regenerate
@@ -316,8 +358,12 @@ refresh, and no text overclaims validation evidence.
 Open one draft `marin-community/marin` PR via `.agents/skills/commit/SKILL.md`,
 request the descriptor's `blocker_assignee` as reviewer, then read back its title,
 body, labels, base, head, and draft state. Take one non-blocking snapshot of CI,
-comments, and reviews; do not start a monitoring loop. PR body: above the fold, the fork,
-selected base, the staged tip SHA, its rollback and date tags, the pending admin
-promotion (and the wheel release tag for `vllm-gpu`), e2e outcome, and unresolved
-risks; in `<details>`, the base-selection evidence and the carry/drop/fix table with
-dropped-patch reasons.
+comments, and reviews; do not start a monitoring loop.
+
+For TPU, keep the body to the upstream bases, reviewed source tips, producer and
+release tag, dependency cutoff, immutable asset evidence, e2e outcome, and
+unresolved risks. Include the carry/drop/fix record without branch-promotion,
+rollback-tag, or staged-tip fields. For another refresh, put the fork, selected
+base, staged tip SHA, rollback and date tags, pending admin promotion (and wheel
+release tag for `vllm-gpu`), e2e outcome, and unresolved risks above the fold;
+put detailed base-selection evidence and the carry/drop/fix table in `<details>`.

--- a/.agents/skills/refresh-fork/SKILL.md
+++ b/.agents/skills/refresh-fork/SKILL.md
@@ -107,10 +107,9 @@ temporary source descriptor or add a second tpu-inference requirement.
 7. Run focused Marin checks, then run the sole physical gate in **Validate**.
    Open one draft Marin PR with the release and validation receipt. Do not add a
    second physical qualification or exact-byte protocol.
-8. After the producer change merges, mark the same GitHub release final without
-   rebuilding or replacing either asset. Read back the unchanged asset IDs and
-   digests. Land the Marin consumer with any tpu-inference compatibility change,
-   then land this refresh procedure.
+8. After validation, mark the same GitHub release final without rebuilding or
+   replacing either asset. Read back the unchanged asset IDs and digests before
+   landing the Marin consumer.
 
 Rebuild and rerun the physical gate only after a change that can affect the
 wheel bytes or metadata, selected assets, producer path, Marin requirement, or
@@ -149,13 +148,10 @@ suffix). Single-pin forks and the vLLM GPU pin use `main-next`. This staging bra
 force-updates it — and is distinct from the protected stable `<branch>`, which the
 unattended refresh leaves unchanged.
 
-Find the base our commits currently sit on: `old_base` is the descriptor's
-`upstream_base` (descriptor pins) or `git merge-base <fork>/<branch> upstream/HEAD`
-(isolated and release pins, where it is not recorded). `old_tip` is the head of our
-patches: the fork's `main` for isolated pins (Marin's recorded pin may lag `main`, so
-rebase from `main` to cover the full patch set), or the pin's stable `<branch>` tip for
-descriptor and release pins (the descriptor's `commit`, or `gpu.toml`'s
-`source_commit`). Then, onto `new_base`:
+Find the base our commits currently sit on. For an isolated pin, `old_tip` is the
+fork's `main` because Marin's recorded lock may lag the fork. For the `vllm-gpu`
+release pin, `old_tip` is `gpu.toml`'s `source_commit`. Resolve `old_base` with
+`git merge-base <old_tip> upstream/HEAD`. Then, onto `new_base`:
 
 1. Inventory our commits in order: `git log --reverse --no-merges old_base..old_tip`.
    Merge commits (especially merges of `upstream` into a feature branch) are not

--- a/.agents/skills/refresh-fork/SKILL.md
+++ b/.agents/skills/refresh-fork/SKILL.md
@@ -5,12 +5,7 @@ description: Refresh a named Marin external fork pin onto a newer upstream base 
 
 # Refresh a fork
 
-Read `AGENTS.md`. Rebase the fork overlay onto `<branch>-next`, validate that
-staged tip, re-pin Marin, and prepare protected-branch promotion. An unattended
-run opens a draft Marin PR and names the required admin promotion; it never
-force-moves the stable branch.
-
-Refresh a `group` as one unit and one PR. Per-fork guidance lives beside this
+Read `AGENTS.md`. Refresh a `group` as one unit and one PR. Per-fork guidance lives beside this
 file: `docs/vllm.md` covers the `vllm`/`tpu-inference` group and the GPU release
 pipeline, and `docs/xla.md` covers the XLA PJRT fork, which is pinned outside
 `migration.toml` entirely.
@@ -26,12 +21,13 @@ Read the target fork's section in `config/external/migration.toml`. It gives:
 - `group` — if present, refresh every section in the group together in one PR
   (read them all now); if absent, this pin refreshes alone.
 - `base_select` (+ `derived_from`) — how to choose the new upstream base.
-- `pin` — where the resolved pin is recorded (`isolated_project` uv.lock,
-  `descriptor:<path>#<section>` SHA, or `release:<path>` prebuilt wheel); drives the
-  re-pin step.
-- `branch` — the fork branch this pin tracks (`main` for a single-pin fork and for the
-  vllm GPU pin; `tpu` for the vllm fork's TPU pin). The refresh stages on `<branch>-next`;
-  an admin promotes that validated tip after reviewing the draft Marin PR.
+- `pin` — where the resolved pin is recorded (`isolated_project` uv.lock or
+  `release:<path>` public wheel); drives the re-pin step. Two grouped source
+  sections may name the same release descriptor when one artifact selects the
+  complete environment.
+- `branch` — for a branch-based refresh, the stable fork branch. The refresh
+  stages on `<branch>-next`; an admin promotes that validated tip after reviewing
+  the draft Marin PR.
 - `e2e` — the Marin end-to-end that validates the refresh.
 - `blocker_assignee` — who owns the "can't migrate" issue.
 - `nuances` — constraints a human must respect (torch pins, known-good ceilings).
@@ -43,13 +39,13 @@ revision.
 
 - If no newer base is selected and no pin metadata needs repair, exit successfully
   with a no-op summary.
-- On success, create the rollback and date tags described in
-  `docs/promotion-protocol.md`, then open exactly one draft PR in
-  `marin-community/marin` for the fork or group after the e2e passes. A grouped
-  refresh re-pins every group section at its staged tip in that single PR. State the
-  exact `<branch>-next` to `<branch>` admin promotion still required, request the
-  descriptor's `blocker_assignee` as reviewer, and monitor the PR per
-  `.agents/skills/commit/SKILL.md`.
+- On a successful TPU vLLM refresh, open one draft Marin PR with the selected
+  public vLLM requirement after the e2e passes. The release notes carry the
+  producer and both source commits; Marin does not pin those commits separately.
+- On another successful refresh, create the rollback and date tags described in
+  `docs/promotion-protocol.md`, then open exactly one draft Marin PR after the e2e
+  passes. State the exact `<branch>-next` to `<branch>` admin promotion still
+  required and request the descriptor's `blocker_assignee` as reviewer.
 - On an unresolved blocker, do not open a PR. Create or update one
   `marin-community/marin` issue assigned to `blocker_assignee`, titled
   `Fork refresh blocked: <fork> — <short reason>`, with current pins, the selected
@@ -61,11 +57,9 @@ revision.
 - Scratch dir: `/tmp/marin-fork-refresh/<run-id>` (run id:
   `${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}` in Actions, else a UTC timestamp plus a
   short label).
-- Clone the fork and add its `upstream` remote. The fork URL is `repository` in the
-  pin source (`vllm/tpu.toml` for descriptor pins, the `[tool.uv.sources]` git
-  entry for isolated projects, the release-asset host in `vllm/gpu.toml` for the
-  `vllm-gpu` release pin — the same `marin-community/vllm` repo); `<upstream>` is this
-  section's `upstream`.
+- Clone the fork and add its `upstream` remote. The fork URL is the
+  `[tool.uv.sources]` git entry for isolated projects or the release-asset host
+  for release pins; `<upstream>` is this section's `upstream`.
 
 ```sh
 git clone <repository> <fork>
@@ -77,12 +71,57 @@ git -C <fork> remote set-head upstream -a                # so upstream/HEAD reso
 - Record selected bases, branch SHAs, carry/drop/fix decisions, validation, and
   unresolved risks for the PR.
 
+## Refresh the TPU vLLM release
+
+This is the complete procedure for the `tpu-vllm` group. Do not stage a
+temporary source descriptor or add a second tpu-inference requirement.
+
+1. Select the newest stable tpu-inference release. Resolve its exact fork commit
+   and read its `.buildkite/vllm_lkg.version`. Resolve that exact vLLM commit in
+   `marin-community/vllm`. If either fork needs an overlay change, review and land
+   that change through `docs/overlay-only-pr.md` before selecting the commit.
+2. Record the full vLLM and tpu-inference commits. Inspect their dependency files
+   together, including the tpu-inference torch constraints and vLLM TPU
+   requirements. These commits are release evidence, not Marin inputs.
+3. Freeze the vLLM workflow producer commit, both source commits, the dependency
+   cutoff, and the Marin consumer head. Dispatch the TPU lane of
+   `marin-gpu-candidate.yaml` at that producer commit with the two source commits
+   and cutoff as explicit inputs. Dispatch it once.
+4. Read back the public prerelease. It must contain exactly the vLLM wheel and its
+   tpu-inference companion. Inspect the built vLLM wheel's `METADATA` and confirm
+   its direct requirement names the companion's public release URL. Record the
+   workflow run, producer commit, source commits, cutoff, tag, asset names, sizes,
+   and digests as evidence.
+5. Before using hardware, resolve the public vLLM requirement in a fresh uv tool
+   environment. Confirm it installs both selected wheel versions. Repeat with an
+   explicit `tpu-inference @ git+https://github.com/marin-community/tpu-inference@<head>`
+   override and confirm uv selects that HEAD instead of the transitive release.
+6. Edit only `config/external/vllm/tpu.toml`: the public release tag, dependency
+   cutoff, and one vLLM requirement. Regenerate and check the typed object:
+
+   ```sh
+   uv run config/update-external.py vllm
+   uv run config/update-external.py vllm --check
+   ```
+
+7. Run focused Marin checks, then run the sole physical gate in **Validate**.
+   Open one draft Marin PR with the release and validation receipt. Do not add a
+   second physical qualification or exact-byte protocol.
+8. After the producer change merges, mark the same GitHub release final without
+   rebuilding or replacing either asset. Read back the unchanged asset IDs and
+   digests. Land the Marin consumer with any tpu-inference compatibility change,
+   then land this refresh procedure.
+
+Rebuild and rerun the physical gate only after a change that can affect the
+wheel bytes or metadata, selected assets, producer path, Marin requirement, or
+launcher. Documentation, tests, and PR-body edits do not invalidate the receipt.
+
 ## Select the base
 
 - `base_select = upstream_main` (`evalchemy`, `harbor`, `MarinSkyRL`, `vllm-gpu`): the base is the
   tip of the `upstream` default branch. These pins rebase onto upstream `main`; there is no
-  release to gate on. `vllm-gpu` tracks vLLM head this way, distinct from the TPU `vllm` pin's
-  tpu-inference-blessed base.
+  release to gate on. `vllm-gpu` tracks vLLM head this way, distinct from the
+  tpu-inference-blessed source selected for the TPU release.
 - `base_select = latest_release` (`tpu-inference`): use GitHub Releases of the
   fork's `upstream`; do not use raw tags or branches. Select the newest release
   where `draft == false`, `prerelease == false`, and the tag is exactly
@@ -103,9 +142,10 @@ there is a newer upstream base to rebase onto.
 
 ## Rebase the overlay
 
+This section applies only to non-TPU refreshes.
+
 Branch from the selected base as `<branch>-next` (the pin's `branch` with a `-next`
-suffix). Use `tpu-next` for the vllm TPU pin and `main-next` otherwise; single-pin
-forks and the vllm GPU pin both track `main`. This staging branch is disposable — a re-run
+suffix). Single-pin forks and the vLLM GPU pin use `main-next`. This staging branch is disposable — a re-run
 force-updates it — and is distinct from the protected stable `<branch>`, which the
 unattended refresh leaves unchanged.
 
@@ -161,6 +201,9 @@ blocker issue.
 
 ## Pin at the staged tip
 
+This section applies only to non-TPU refreshes. The TPU group already stopped
+after **Refresh the TPU vLLM release**.
+
 Point Marin at `<branch>-next` so the e2e runs against the replayed code, then run
 `uv run config/update-external.py` to regenerate
 `lib/marin/src/marin/external_dependencies.py`; confirm only the intended pins change.
@@ -168,9 +211,6 @@ The stable `<branch>` remains at the old tip until an admin hard-swaps it after 
 the draft PR. Because `<branch>-next` and the eventual `<branch>` are the same commit,
 the pin set here needs no change after that promotion.
 
-- `pin = descriptor:<path>#<section>` (`vllm`, `tpu-inference`): push `<branch>-next` to
-  the fork and record its tip and the selected base in the descriptor file. The
-  section-by-section mechanics are in `docs/vllm.md`.
 - `pin = release:<path>` (`vllm-gpu`): the pin is a prebuilt wheel, so the refresh builds
   and promotes one through the fork's own release pipeline, then re-pins from the promoted
   manifest. The candidate/promote/re-pin commands and the CUDA/torch ABI-boundary caveat
@@ -249,15 +289,16 @@ uv run python -m experiments.evaluation.cli launch --model qwen3-0.6b --limit 8 
 uv run python -m experiments.post_training.iceball_micro --stage evaluation --version dev --run
 ```
 
-When an e2e fails, rerun the same workload against Marin's current pins on the old
-fork stack, same target and priority. Fix only failures that pass on the old stack
-and fail on the refreshed one. If the old stack is already broken, the fork's e2e
-cannot gate this refresh: do not open a PR on an unvalidated pin — file or link a
-blocker for the broken e2e and hold the refresh until it is fixed.
+For a non-TPU refresh, when an e2e fails, rerun the same workload against Marin's
+current pin on the old stack, with the same target and priority. Fix only failures
+that pass on the old stack and regress on the refreshed one. For TPU, preserve the
+single physical receipt. Rerun only after a relevant producer, asset, requirement,
+or launcher change, or when the first run failed before it exercised the release.
 
 ## Prepare the protected-branch promotion
 
-Once the e2e passes on `<branch>-next`, create the rollback tag for the current stable
+This section applies only to non-TPU refreshes. Once the e2e passes on
+`<branch>-next`, create the rollback tag for the current stable
 tip and the date tag for the validated staged tip per `docs/promotion-protocol.md`.
 Push and verify those tags, then leave the protected stable `<branch>` unchanged. The
 draft Marin PR must identify each `<branch>-next` to `<branch>` hard swap that an admin
@@ -276,8 +317,9 @@ condition, each dropped patch is truly obsolete, Marin edits are scoped to the
 refresh, and no text overclaims validation evidence.
 
 Open one draft `marin-community/marin` PR via `.agents/skills/commit/SKILL.md`,
-request the descriptor's `blocker_assignee` as reviewer, and follow the commit
-skill's monitoring loop to an exit condition. PR body: above the fold, the fork,
+request the descriptor's `blocker_assignee` as reviewer, then read back its title,
+body, labels, base, head, and draft state. Take one non-blocking snapshot of CI,
+comments, and reviews; do not start a monitoring loop. PR body: above the fold, the fork,
 selected base, the staged tip SHA, its rollback and date tags, the pending admin
 promotion (and the wheel release tag for `vllm-gpu`), e2e outcome, and unresolved
 risks; in `<details>`, the base-selection evidence and the carry/drop/fix table with

--- a/.agents/skills/refresh-fork/SKILL.md
+++ b/.agents/skills/refresh-fork/SKILL.md
@@ -114,9 +114,9 @@ temporary source descriptor or add a second tpu-inference requirement.
 7. Run focused Marin checks, then run the sole physical gate in **Validate**.
    Open one draft Marin PR with the release and validation receipt. Do not add a
    second physical qualification or exact-byte protocol.
-8. After validation, mark the same GitHub release final without rebuilding or
-   replacing either asset. Read back the unchanged asset IDs and digests before
-   landing the Marin consumer.
+8. After validation and the producer change merges, mark the same GitHub release
+   final without rebuilding or replacing either asset. Read back the unchanged
+   asset IDs and digests before landing the Marin consumer.
 
 Rebuild and rerun the physical gate only after a change that can affect the
 wheel bytes or metadata, selected assets, producer path, Marin requirement, or

--- a/.agents/skills/refresh-fork/SKILL.md
+++ b/.agents/skills/refresh-fork/SKILL.md
@@ -5,15 +5,17 @@ description: Refresh a named Marin external fork pin onto a newer upstream base 
 
 # Refresh a fork
 
-Read `AGENTS.md`. Rebase the fork overlay onto `<branch>-next`, validate that
-staged tip, re-pin Marin, and prepare protected-branch promotion. An unattended
-run opens a draft Marin PR and names the required admin promotion; it never
-force-moves the stable branch.
+Read `AGENTS.md`. Refresh a `group` as one unit and one PR.
 
-Refresh a `group` as one unit and one PR. The only current group is
-`vllm`/`tpu-inference`; `vllm-gpu` tracks the fork's independent `main` branch.
-The TPU launcher installs both grouped pins, and vLLM's TPU base derives from
-the tpu-inference release; splitting them can produce an unvalidated stack.
+The `vllm`/`tpu-inference` group is release-based. Select its two exact source
+commits, build one public vLLM release whose metadata installs the companion
+tpu-inference wheel, and put that one vLLM requirement in Marin. Follow
+**Refresh the TPU vLLM release** below and then stop; the generic fork-promotion
+procedure does not apply to this group.
+
+Other overlay forks stage on `<branch>-next`, validate that tip, re-pin Marin,
+and prepare protected-branch promotion. The independent `vllm-gpu` pin keeps
+its existing release workflow.
 
 In local mode, ask before pushing fork branches, opening the PR, or filing an
 issue. The required end-to-end test needs no extra confirmation.
@@ -26,12 +28,13 @@ Read the target fork's section in `config/external/migration.toml`. It gives:
 - `group` — if present, refresh every section in the group together in one PR
   (read them all now); if absent, this pin refreshes alone.
 - `base_select` (+ `derived_from`) — how to choose the new upstream base.
-- `pin` — where the resolved pin is recorded (`isolated_project` uv.lock,
-  `descriptor:<path>#<section>` SHA, or `release:<path>` prebuilt wheel); drives the
-  re-pin step.
-- `branch` — the fork branch this pin tracks (`main` for a single-pin fork and for the
-  vllm GPU pin; `tpu` for the vllm fork's TPU pin). The refresh stages on `<branch>-next`;
-  an admin promotes that validated tip after reviewing the draft Marin PR.
+- `pin` — where the resolved pin is recorded (`isolated_project` uv.lock or
+  `release:<path>` public wheel); drives the re-pin step. Two grouped source
+  sections may name the same release descriptor when one artifact selects the
+  complete environment.
+- `branch` — for a branch-based refresh, the stable fork branch. The refresh
+  stages on `<branch>-next`; an admin promotes that validated tip after reviewing
+  the draft Marin PR.
 - `e2e` — the Marin end-to-end that validates the refresh.
 - `blocker_assignee` — who owns the "can't migrate" issue.
 - `nuances` — constraints a human must respect (torch pins, known-good ceilings).
@@ -43,13 +46,13 @@ revision.
 
 - If no newer base is selected and no pin metadata needs repair, exit successfully
   with a no-op summary.
-- On success, create the rollback and date tags described in
-  `docs/promotion-protocol.md`, then open exactly one draft PR in
-  `marin-community/marin` for the fork or group after the e2e passes. A grouped
-  refresh re-pins every group section at its staged tip in that single PR. State the
-  exact `<branch>-next` to `<branch>` admin promotion still required, request the
-  descriptor's `blocker_assignee` as reviewer, and monitor the PR per
-  `.agents/skills/commit/SKILL.md`.
+- On a successful TPU vLLM refresh, open one draft Marin PR with the selected
+  public vLLM requirement after the e2e passes. The release notes carry the
+  producer and both source commits; Marin does not pin those commits separately.
+- On another successful refresh, create the rollback and date tags described in
+  `docs/promotion-protocol.md`, then open exactly one draft Marin PR after the e2e
+  passes. State the exact `<branch>-next` to `<branch>` admin promotion still
+  required and request the descriptor's `blocker_assignee` as reviewer.
 - On an unresolved blocker, do not open a PR. Create or update one
   `marin-community/marin` issue assigned to `blocker_assignee`, titled
   `Fork refresh blocked: <fork> — <short reason>`, with current pins, the selected
@@ -61,11 +64,9 @@ revision.
 - Scratch dir: `/tmp/marin-fork-refresh/<run-id>` (run id:
   `${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}` in Actions, else a UTC timestamp plus a
   short label).
-- Clone the fork and add its `upstream` remote. The fork URL is `repository` in the
-  pin source (`vllm/tpu.toml` for descriptor pins, the `[tool.uv.sources]` git
-  entry for isolated projects, the release-asset host in `vllm/gpu.toml` for the
-  `vllm-gpu` release pin — the same `marin-community/vllm` repo); `<upstream>` is this
-  section's `upstream`.
+- Clone the fork and add its `upstream` remote. The fork URL is the
+  `[tool.uv.sources]` git entry for isolated projects or the release-asset host
+  for release pins; `<upstream>` is this section's `upstream`.
 
 ```sh
 git clone <repository> <fork>
@@ -77,12 +78,57 @@ git -C <fork> remote set-head upstream -a                # so upstream/HEAD reso
 - Record selected bases, branch SHAs, carry/drop/fix decisions, validation, and
   unresolved risks for the PR.
 
+## Refresh the TPU vLLM release
+
+This is the complete procedure for the `tpu-vllm` group. Do not stage a
+temporary source descriptor or add a second tpu-inference requirement.
+
+1. Select the newest stable tpu-inference release. Resolve its exact fork commit
+   and read its `.buildkite/vllm_lkg.version`. Resolve that exact vLLM commit in
+   `marin-community/vllm`. If either fork needs an overlay change, review and land
+   that change through `docs/overlay-only-pr.md` before selecting the commit.
+2. Record the full vLLM and tpu-inference commits. Inspect their dependency files
+   together, including the tpu-inference torch constraints and vLLM TPU
+   requirements. These commits are release evidence, not Marin inputs.
+3. Freeze the vLLM workflow producer commit, both source commits, the dependency
+   cutoff, and the Marin consumer head. Dispatch the TPU lane of
+   `marin-gpu-candidate.yaml` at that producer commit with the two source commits
+   and cutoff as explicit inputs. Dispatch it once.
+4. Read back the public prerelease. It must contain exactly the vLLM wheel and its
+   tpu-inference companion. Inspect the built vLLM wheel's `METADATA` and confirm
+   its direct requirement names the companion's public release URL. Record the
+   workflow run, producer commit, source commits, cutoff, tag, asset names, sizes,
+   and digests as evidence.
+5. Before using hardware, resolve the public vLLM requirement in a fresh uv tool
+   environment. Confirm it installs both selected wheel versions. Repeat with an
+   explicit `tpu-inference @ git+https://github.com/marin-community/tpu-inference@<head>`
+   override and confirm uv selects that HEAD instead of the transitive release.
+6. Edit only `config/external/vllm/tpu.toml`: the public release tag, dependency
+   cutoff, and one vLLM requirement. Regenerate and check the typed object:
+
+   ```sh
+   uv run config/update-external.py vllm
+   uv run config/update-external.py vllm --check
+   ```
+
+7. Run focused Marin checks, then run the sole physical gate in **Validate**.
+   Open one draft Marin PR with the release and validation receipt. Do not add a
+   second physical qualification or exact-byte protocol.
+8. After the producer change merges, mark the same GitHub release final without
+   rebuilding or replacing either asset. Read back the unchanged asset IDs and
+   digests. Land the Marin consumer with any tpu-inference compatibility change,
+   then land this refresh procedure.
+
+Rebuild and rerun the physical gate only after a change that can affect the
+wheel bytes or metadata, selected assets, producer path, Marin requirement, or
+launcher. Documentation, tests, and PR-body edits do not invalidate the receipt.
+
 ## Select the base
 
 - `base_select = upstream_main` (`evalchemy`, `harbor`, `MarinSkyRL`, `vllm-gpu`): the base is the
   tip of the `upstream` default branch. These pins rebase onto upstream `main`; there is no
-  release to gate on. `vllm-gpu` tracks vLLM head this way, distinct from the TPU `vllm` pin's
-  tpu-inference-blessed base.
+  release to gate on. `vllm-gpu` tracks vLLM head this way, distinct from the
+  tpu-inference-blessed source selected for the TPU release.
 - `base_select = latest_release` (`tpu-inference`): use GitHub Releases of the
   fork's `upstream`; do not use raw tags or branches. Select the newest release
   where `draft == false`, `prerelease == false`, and the tag is exactly
@@ -105,9 +151,10 @@ there is a newer upstream base to rebase onto.
 
 ## Rebase the overlay
 
+This section applies only to non-TPU refreshes.
+
 Branch from the selected base as `<branch>-next` (the pin's `branch` with a `-next`
-suffix). Use `tpu-next` for the vllm TPU pin and `main-next` otherwise; single-pin
-forks and the vllm GPU pin both track `main`. This staging branch is disposable — a re-run
+suffix). Single-pin forks and the vLLM GPU pin use `main-next`. This staging branch is disposable — a re-run
 force-updates it — and is distinct from the protected stable `<branch>`, which the
 unattended refresh leaves unchanged.
 
@@ -163,6 +210,9 @@ blocker issue.
 
 ## Pin at the staged tip
 
+This section applies only to non-TPU refreshes. The TPU group already stopped
+after **Refresh the TPU vLLM release**.
+
 Point Marin at `<branch>-next` so the e2e runs against the replayed code, then run
 `uv run config/update-external.py` to regenerate
 `lib/marin/src/marin/external_dependencies.py`; confirm only the intended pins change.
@@ -170,12 +220,6 @@ The stable `<branch>` remains at the old tip until an admin hard-swaps it after 
 the draft PR. Because `<branch>-next` and the eventual `<branch>` are the same commit,
 the pin set here needs no change after that promotion.
 
-- `pin = descriptor:<path>#<section>` (`vllm`, `tpu-inference`): push `<branch>-next` to
-  the fork. Set the section's `commit` to its tip and `upstream_base` to the selected
-  base in `vllm/tpu.toml`. This stack resolves entirely inside the `uvx` env from
-  the two forks, so there are no `uv.lock` changes and `jax`/`jaxlib`/`libtpu`/`torch`
-  come from the forks' own dependencies — do not touch `marin-core`, `marin-levanter`,
-  or `marin-fray`.
 - `pin = release:<path>` (`vllm-gpu`): the pin is a prebuilt wheel, so the refresh builds
   and promotes one through the fork's own release pipeline, then re-pins from the promoted
   manifest. Dispatching fork workflows needs `actions:write` on `marin-community/vllm`,
@@ -247,16 +291,19 @@ and verify it in one CI run with logs as artifacts.
 Run the descriptor's `e2e` before opening the PR:
 
 - **`experiments/evals/served_qwen3.py::QWEN3_TPU_INFERENCE`** (`vllm`,
-  `tpu-inference`) — a bounded brokered TPU serve+eval smoke. Run TPU workloads
-  through Iris on the `marin` cluster at interactive priority, `v6e-4` in GCP
-  `europe-west4`. Confirm the proxy served completions, lm-eval wrote metrics and
-  sample outputs, and no TPU/vLLM build, import, or runtime tracebacks occurred:
+  `tpu-inference`) — the one physical gate for the selected public release. Run
+  Qwen3-0.6B at tensor parallel size 8 on one `v6e-8` through Iris `marin`, in
+  `us-east5`, at production priority on both the launcher and worker. Use a fresh
+  run version so the worker cold-installs through `uvx`. Confirm the public
+  requirement installs, the server becomes healthy, and a real request succeeds.
+  Record the Iris job and child task IDs, release assets, all three frozen commits,
+  probe result, and successful resource release:
 
 ```sh
 uv run iris --config lib/iris/config/marin.yaml job run \
   --job-name served-qwen3-<run-id> --cpu 1 --memory 2G --extra cpu \
-  --priority interactive --no-wait -- python -c \
-  "from dataclasses import replace; from fray.types import ResourceConfig; from marin.execution.lazy import lower; from marin.execution.step_runner import StepRunner; from experiments.evals.lm_eval_suite import lm_eval_suite; from experiments.evals.served_qwen3 import QWEN3_TPU_INFERENCE; inference = replace(QWEN3_TPU_INFERENCE, iris=replace(QWEN3_TPU_INFERENCE.iris, worker_resources=ResourceConfig.with_tpu('v6e-4', ram='96g', regions=['europe-west4']))); StepRunner().run([lower(lm_eval_suite(inference, model_name='qwen3-0.6b-refresh-smoke', version='<run-id>-dev', limit=8))])"
+  --priority production --no-wait -- python -c \
+  "from dataclasses import replace; from fray.types import ResourceConfig; from iris.rpc import job_pb2; from marin.execution.lazy import lower; from marin.execution.step_runner import StepRunner; from experiments.evals.lm_eval_suite import lm_eval_suite; from experiments.evals.served_qwen3 import QWEN3_TPU_INFERENCE; inference = replace(QWEN3_TPU_INFERENCE, model=replace(QWEN3_TPU_INFERENCE.model, tensor_parallel_size=8), iris=replace(QWEN3_TPU_INFERENCE.iris, worker_resources=ResourceConfig.with_tpu('v6e-8', ram='96g', regions=['us-east5']), priority=job_pb2.PRIORITY_BAND_PRODUCTION)); StepRunner().run([lower(lm_eval_suite(inference, model_name='qwen3-0.6b-refresh-smoke', version='<run-id>', limit=8))])"
 ```
 
 - **`tests/cluster/vllm/test_snowball_backend_parity.py`** (`vllm-gpu`) — the
@@ -298,20 +345,20 @@ uv run python -m experiments.evaluation.cli launch --model qwen3-0.6b --limit 8 
 uv run python -m experiments.post_training.iceball_micro --stage evaluation --version dev --run
 ```
 
-When an e2e fails, rerun the same workload against Marin's current pins on the old
-fork stack, same target and priority. Fix only failures that pass on the old stack
-and fail on the refreshed one. If the old stack is already broken, the fork's e2e
-cannot gate this refresh: do not open a PR on an unvalidated pin — file or link a
-blocker for the broken e2e and hold the refresh until it is fixed.
+For a non-TPU refresh, when an e2e fails, rerun the same workload against Marin's
+current pin on the old stack, with the same target and priority. Fix only failures
+that pass on the old stack and regress on the refreshed one. For TPU, preserve the
+single physical receipt. Rerun only after a relevant producer, asset, requirement,
+or launcher change, or when the first run failed before it exercised the release.
 
 ## Prepare the protected-branch promotion
 
-Once the e2e passes on `<branch>-next`, create the rollback tag for the current stable
+This section applies only to non-TPU refreshes. Once the e2e passes on
+`<branch>-next`, create the rollback tag for the current stable
 tip and the date tag for the validated staged tip per `docs/promotion-protocol.md`.
 Push and verify those tags, then leave the protected stable `<branch>` unchanged. The
 draft Marin PR must identify each `<branch>-next` to `<branch>` hard swap that an admin
-must complete before merge. On the vllm fork the GPU and TPU pins promote onto their own
-stable branches (`main` and `tpu`) independently.
+must complete before merge.
 
 Keep the Marin PR draft until every required admin promotion is complete. After an
 `isolated_project` promotion, restore its uv source from `main-next` to `main`, relock,
@@ -326,8 +373,9 @@ condition, each dropped patch is truly obsolete, Marin edits are scoped to the
 refresh, and no text overclaims validation evidence.
 
 Open one draft `marin-community/marin` PR via `.agents/skills/commit/SKILL.md`,
-request the descriptor's `blocker_assignee` as reviewer, and follow the commit
-skill's monitoring loop to an exit condition. PR body: above the fold, the fork,
+request the descriptor's `blocker_assignee` as reviewer, then read back its title,
+body, labels, base, head, and draft state. Take one non-blocking snapshot of CI,
+comments, and reviews; do not start a monitoring loop. PR body: above the fold, the fork,
 selected base, the staged tip SHA, its rollback and date tags, the pending admin
 promotion (and the wheel release tag for `vllm-gpu`), e2e outcome, and unresolved
 risks; in `<details>`, the base-selection evidence and the carry/drop/fix table with

--- a/.agents/skills/refresh-fork/SKILL.md
+++ b/.agents/skills/refresh-fork/SKILL.md
@@ -83,10 +83,11 @@ temporary source descriptor or add a second tpu-inference requirement.
 2. Record the full vLLM and tpu-inference commits. Inspect their dependency files
    together, including the tpu-inference torch constraints and vLLM TPU
    requirements. These commits are release evidence, not Marin inputs.
-3. Freeze the vLLM workflow producer commit, both source commits, the dependency
-   cutoff, and the Marin consumer head. Dispatch the TPU lane of
-   `marin-gpu-candidate.yaml` at that producer commit with the two source commits
-   and cutoff as explicit inputs. Dispatch it once.
+3. Select one unused full `marin-vllm-tpu-...` release tag. Freeze that tag, the
+   vLLM workflow producer commit, both source commits, the dependency cutoff, and
+   the Marin consumer head. Dispatch the TPU lane of `marin-gpu-candidate.yaml`
+   at that producer commit with the tag, two source commits, and cutoff as
+   explicit inputs. Dispatch it once.
 4. Read back the public prerelease. It must contain exactly the vLLM wheel and its
    tpu-inference companion. Inspect the built vLLM wheel's `METADATA` and confirm
    its direct requirement names the companion's public release URL. Record the

--- a/.agents/skills/refresh-fork/SKILL.md
+++ b/.agents/skills/refresh-fork/SKILL.md
@@ -5,10 +5,10 @@ description: Refresh a named Marin external fork pin onto a newer upstream base 
 
 # Refresh a fork
 
-Read `AGENTS.md`. Refresh a `group` as one unit and one PR. Per-fork guidance lives beside this
-file: `docs/vllm.md` covers the `vllm`/`tpu-inference` group and the GPU release
-pipeline, and `docs/xla.md` covers the XLA PJRT fork, which is pinned outside
-`migration.toml` entirely.
+Read `AGENTS.md`. Refresh a `group` as one unit and one PR. Per-fork guidance
+lives beside this file: `docs/vllm.md` covers the `vllm`/`tpu-inference` group
+and the GPU release pipeline, and `docs/xla.md` covers the XLA PJRT fork, which
+is pinned outside `migration.toml` entirely.
 
 In local mode, ask before pushing fork branches, opening the PR, or filing an
 issue. The required end-to-end test needs no extra confirmation.
@@ -41,13 +41,12 @@ revision.
 
 - If no newer base is selected and no pin metadata needs repair, exit successfully
   with a no-op summary.
-- On a successful TPU vLLM refresh, open one draft Marin PR with the selected
-  public vLLM requirement after the e2e passes. The release notes carry the
-  producer and both source commits; Marin does not pin those commits separately.
-- On another successful refresh, create the rollback and date tags described in
+- On a successful branch-staged refresh, create the rollback and date tags described in
   `docs/promotion-protocol.md`, then open exactly one draft Marin PR after the e2e
   passes. State the exact `<branch>-next` to `<branch>` admin promotion still
   required and request the descriptor's `blocker_assignee` as reviewer.
+- For a fork-specific release workflow, follow its guide, then return here for
+  the common review and draft-PR closeout.
 - On an unresolved blocker, do not open a PR. Create or update one
   `marin-community/marin` issue assigned to `blocker_assignee`, titled
   `Fork refresh blocked: <fork> — <short reason>`, with current pins, the selected
@@ -74,104 +73,15 @@ git -C <fork> remote set-head upstream -a                # so upstream/HEAD reso
 - Record selected bases, branch SHAs, carry/drop/fix decisions, validation, and
   unresolved risks for the PR.
 
-## Refresh the TPU vLLM release
-
-This is the source-selection and release procedure for the `tpu-vllm` group. Do
-not stage a temporary source descriptor, add a second tpu-inference requirement,
-or promote a TPU stable branch.
-
-Use these names throughout:
-
-```text
-tpu_base       = selected stable upstream tpu-inference release
-tpu_source_tip = reviewed tpu-inference overlay replayed onto tpu_base
-
-vllm_base       = LKG selected by that tpu-inference release
-vllm_source_tip = reviewed vLLM overlay replayed onto vllm_base
-```
-
-The bases are inputs to the replay. The source tips are the producer inputs.
-
-1. Read `config/external/vllm/tpu.toml`, then read the currently selected GitHub
-   release notes and producer receipt. Record the exact current
-   `tpu_source_tip` and `vllm_source_tip`, and verify each resolves in its Marin
-   fork. Identify and verify the exact upstream base beneath each current source
-   tip. Stop with a blocker if the current source tips or their bases cannot be
-   established exactly; do not reconstruct an overlay from a net diff.
-2. Select the newest stable release from canonical upstream tpu-inference as
-   `tpu_base`. Read `.buildkite/vllm_lkg.version` at that base and resolve the
-   named commit in canonical upstream vLLM as `vllm_base`.
-3. Replay each current Marin overlay onto its corresponding new base:
-   - Inventory `current_base..current_source_tip` in logical order with
-     `git log --reverse --no-merges`, retaining the original SHAs.
-   - Classify every meaningful delta as `carry`, `drop`, or `fix`. Compare it
-     with the new base first: drop changes upstream absorbed or made obsolete;
-     carry changes still needed; rewrite a `fix` when the intent remains but the
-     upstream API or layout moved. Merge commits are not replayed.
-   - Replay only `carry` and `fix` in logical order. Audit every touched API and
-     dependency against the new base, resolve incompatibilities, and run that
-     fork's ordinary checks before proceeding.
-   - Run `git range-diff` from the old overlay range to the new one. Record every
-     original commit and its carry/drop/fix result, with the reason for each drop
-     or rewrite. If an independent fixed-base overlay change is needed, land its
-     review through `docs/overlay-only-pr.md` before freezing either source tip;
-     that workflow is not a substitute for this replay.
-4. Review both replayed ranges and preserve their exact commits on reviewable
-   branches in the Marin forks. Record the resulting full SHAs as
-   `tpu_source_tip` and `vllm_source_tip`. Do not substitute the bare
-   `tpu_base` or `vllm_base` commits.
-5. Inspect the two source tips' dependency files together, including the
-   tpu-inference torch constraints and vLLM TPU requirements. These commits are
-   release evidence, not separate Marin runtime inputs.
-6. Select one unused full `marin-vllm-tpu-...` release tag. Freeze that tag, the
-   vLLM workflow producer commit, both source tips, and the dependency cutoff.
-   Dispatch the TPU lane of `marin-gpu-candidate.yaml`
-   at that producer commit with `vllm_source_tip`, `tpu_source_tip`, the tag, and
-   the cutoff as explicit inputs. Dispatch it once.
-7. Read back the public prerelease. It must contain exactly the vLLM wheel and its
-   tpu-inference companion. Inspect the built vLLM wheel's `METADATA` and confirm
-   its direct requirement names the companion's public release URL. Record the
-   workflow run, producer commit, source tips, upstream bases, cutoff, tag, asset
-   names, sizes, and digests as evidence.
-8. Before using hardware, resolve the public vLLM requirement in a fresh uv tool
-   environment. Confirm it installs both selected wheel versions. Repeat with an
-   explicit `tpu-inference @ git+https://github.com/marin-community/tpu-inference@<head>`
-   override and confirm uv selects that HEAD instead of the transitive release.
-9. Edit only `config/external/vllm/tpu.toml`: the public release tag, dependency
-   cutoff, and one vLLM requirement. Regenerate and check the typed object:
-
-   ```sh
-   uv run config/update-external.py vllm
-   uv run config/update-external.py vllm --check
-   ```
-
-10. Run focused Marin checks, commit the final consumer diff, and freeze its full
-    SHA as the Marin consumer head. Run the sole physical gate in **Validate**
-    against that exact SHA. Skip **Select the base**, **Rebase the overlay**,
-    **Pin at the staged tip**, and **Prepare the protected-branch promotion**.
-    Resume at **Review and Open the PR** with the TPU release and validation
-    receipt. Do not add a second physical qualification or exact-byte protocol.
-11. After validation and the producer change merges, mark the same GitHub release
-    final without rebuilding or replacing either asset. Read back the unchanged
-    asset IDs and digests before landing the Marin consumer.
-
-Rebuild and rerun the physical gate only after a change that can affect the
-wheel bytes or metadata, selected assets, producer path, Marin requirement, or
-launcher. Documentation, tests, and PR-body edits do not invalidate the receipt.
-
 ## Select the base
 
-- `base_select = upstream_main` (`evalchemy`, `harbor`, `MarinSkyRL`, `vllm-gpu`): the base is the
-  tip of the `upstream` default branch. These pins rebase onto upstream `main`; there is no
-  release to gate on. `vllm-gpu` tracks vLLM head this way, distinct from the
-  tpu-inference-blessed source selected for the TPU release.
-- `base_select = latest_release` (`tpu-inference`): use GitHub Releases of the
-  fork's `upstream`; do not use raw tags or branches. Select the newest release
-  where `draft == false`, `prerelease == false`, and the tag is exactly
-  `vMAJOR.MINOR.PATCH`. Resolve it to a commit SHA.
-- `base_select = derived` (`vllm`): read the SHA at `derived_from` from the
-  release it names, verify it resolves in the fork's `upstream`, and use it as
-  the base. See `docs/vllm.md` for the vllm-specific derivation detail.
+- `base_select = upstream_main`: use the tip of the `upstream` default branch.
+- `base_select = latest_release`: use GitHub Releases of the fork's `upstream`;
+  do not use raw tags or branches. Select the newest stable release matching the
+  descriptor's constraints and resolve it to a commit SHA.
+- `base_select = derived`: read the SHA at `derived_from` from the release it
+  names, verify it resolves in the fork's `upstream`, and use it as the base.
+  Read the fork-specific guide for derivation details.
 
 If the selected base matches the current one and no pin metadata needs repair, exit
 no-op. Do not walk back to older releases when the latest eligible one fails; fix
@@ -185,10 +95,11 @@ there is a newer upstream base to rebase onto.
 
 ## Rebase the overlay
 
-This section applies only to non-TPU refreshes.
+This section applies to branch-staged refreshes. A fork-specific release guide
+may replace it with its own source replay.
 
 Branch from the selected base as `<branch>-next` (the pin's `branch` with a `-next`
-suffix). Single-pin forks and the vLLM GPU pin use `main-next`. This staging branch is disposable — a re-run
+suffix). A pin on `main` uses `main-next`. This staging branch is disposable — a re-run
 force-updates it — and is distinct from the protected stable `<branch>`, which the
 unattended refresh leaves unchanged.
 
@@ -241,8 +152,8 @@ blocker issue.
 
 ## Pin at the staged tip
 
-This section applies only to non-TPU refreshes. The TPU group skips it and the
-protected-branch promotion section, then resumes at **Review and Open the PR**.
+This section applies to branch-staged refreshes. A fork-specific release guide
+may replace it with its own pinning step.
 
 Point Marin at `<branch>-next` so the e2e runs against the replayed code, then run
 `uv run config/update-external.py` to regenerate
@@ -329,15 +240,14 @@ uv run python -m experiments.evaluation.cli launch --model qwen3-0.6b --limit 8 
 uv run python -m experiments.post_training.iceball_micro --stage evaluation --version dev --run
 ```
 
-For a non-TPU refresh, when an e2e fails, rerun the same workload against Marin's
-current pin on the old stack, with the same target and priority. Fix only failures
-that pass on the old stack and regress on the refreshed one. For TPU, preserve the
-single physical receipt. Rerun only after a relevant producer, asset, requirement,
-or launcher change, or when the first run failed before it exercised the release.
+When an e2e fails, rerun the same workload against Marin's current pin on the old
+stack, with the same target and priority. Fix only failures that pass on the old
+stack and regress on the refreshed one. A fork-specific guide may define stricter
+rules for reusing or invalidating an existing physical receipt.
 
 ## Prepare the protected-branch promotion
 
-This section applies only to non-TPU refreshes. Once the e2e passes on
+This section applies to branch-staged refreshes. Once the e2e passes on
 `<branch>-next`, create the rollback tag for the current stable
 tip and the date tag for the validated staged tip per `docs/promotion-protocol.md`.
 Push and verify those tags, then leave the protected stable `<branch>` unchanged. The
@@ -356,15 +266,14 @@ fix or answer every finding. Check that each retained patch has a reason and a d
 condition, each dropped patch is truly obsolete, Marin edits are scoped to the
 refresh, and no text overclaims validation evidence.
 
-Open one draft `marin-community/marin` PR via `.agents/skills/commit/SKILL.md`,
-request the descriptor's `blocker_assignee` as reviewer, then read back its title,
-body, labels, base, head, and draft state. Follow the commit skill's required
-monitoring behavior, then read back CI, comments, and reviews.
+Open one draft `marin-community/marin` PR via `.agents/skills/commit/SKILL.md` and
+request the descriptor's `blocker_assignee` as reviewer. For a newly opened draft,
+verify its title, body, labels, base, head, and draft state. Take one non-blocking
+snapshot of CI, issue comments, inline comments, and submitted reviews; address
+anything already actionable; then return. Run the commit skill's monitoring loop
+only when the caller explicitly requests monitoring, waiting, or babysitting.
 
-For TPU, keep the body to the upstream bases, reviewed source tips, producer and
-release tag, dependency cutoff, immutable asset evidence, e2e outcome, and
-unresolved risks. Include the carry/drop/fix record without branch-promotion,
-rollback-tag, or staged-tip fields. For another refresh, put the fork, selected
-base, staged tip SHA, rollback and date tags, pending admin promotion (and wheel
-release tag for `vllm-gpu`), e2e outcome, and unresolved risks above the fold;
-put detailed base-selection evidence and the carry/drop/fix table in `<details>`.
+Use the fork-specific guide for any additional body fields. Otherwise put the
+fork, selected base, staged tip SHA, rollback and date tags, pending admin
+promotion, e2e outcome, and unresolved risks above the fold; put detailed
+base-selection evidence and the carry/drop/fix table in `<details>`.

--- a/.agents/skills/refresh-fork/docs/overlay-only-pr.md
+++ b/.agents/skills/refresh-fork/docs/overlay-only-pr.md
@@ -10,7 +10,7 @@ and what upstream change will let us drop it.
 
 For a TPU vLLM or tpu-inference overlay, do not put a temporary source SHA in
 Marin. Freeze the exact reviewed fork commit and use it as one source input to the
-TPU release procedure in `../SKILL.md`. Marin changes only after that procedure
+TPU release procedure in `vllm.md`. Marin changes only after that procedure
 selects one public vLLM requirement. A later source edit invalidates the release
 receipt and must be reviewed before any rebuild.
 

--- a/.agents/skills/refresh-fork/docs/overlay-only-pr.md
+++ b/.agents/skills/refresh-fork/docs/overlay-only-pr.md
@@ -1,27 +1,20 @@
 # Fixed-Base Overlay Fork PR Protocol
 
 Use this when adding or fixing a Marin overlay commit while keeping the current
-upstream base fixed. Do not use it for automated release/LKG refreshes.
+upstream base fixed. Do not use it for an upstream-base refresh.
 
-Because the base does not move, the new commit sits on top of the pin's current tip
-and history stays linear — so unlike a rebase refresh, a fork PR that fast-forwards
-the pin's stable branch is fine here. Work on the descriptor's `branch` for the pin: on
-the vllm fork the GPU pin builds from `main` and the TPU pin lives on `tpu`; a single-pin
-fork (tpu-inference) uses `main`.
+Because the base does not move, the new commit sits on the current fork tip and
+history stays linear. Branch from that tip, add the smallest overlay, run the
+fork's ordinary checks, and open a fork PR. Record why the patch is still needed
+and what upstream change will let us drop it.
 
-1. Branch from the pin's stable `branch`, add the overlay commit(s), and open a fork
-   PR against that branch.
-2. If Marin validation is needed, open a Marin draft PR that pins the fork PR head SHA
-   as `commit` in `config/external/vllm/tpu.toml` and regenerates
-   `external_dependencies.py` (`uv run config/update-external.py`). Treat this pin as
-   temporary.
-3. Run the required Marin validation from the draft PR.
-4. Merge the fork PR into the stable `branch`, fetch it, and read the landed SHA. Do
-   not assume it matches the pre-merge PR head SHA.
-5. Update the Marin draft PR to pin the landed `branch` SHA in `tpu.toml`,
-   regenerate the pins and fix `upstream_base` if needed, rerun focused validation,
-   then undraft.
+For a TPU vLLM or tpu-inference overlay, do not put a temporary source SHA in
+Marin. Freeze the exact reviewed fork commit and use it as one source input to the
+TPU release procedure in `../SKILL.md`. Marin changes only after that procedure
+selects one public vLLM requirement. A later source edit invalidates the release
+receipt and must be reviewed before any rebuild.
 
-Final check: `git ls-remote <fork-url> <branch>` must match the relevant
-`config/external/vllm/tpu.toml` `commit`. Repeat per pin when an overlay spans
-both forks.
+For another fork, follow its pin kind in the refresh skill. A branch-based pin
+may stage the exact PR head for validation and then must read back the landed
+commit; never assume a GitHub merge preserves the PR head SHA. A release-based
+pin must use its existing producer and artifact validation path.

--- a/.agents/skills/refresh-fork/docs/promotion-protocol.md
+++ b/.agents/skills/refresh-fork/docs/promotion-protocol.md
@@ -11,8 +11,10 @@ therefore a **hard swap** (a backed-up force-update), not a merge or fast-forwar
 PR/merge would splice two upstream bases into a merge commit and break the linear
 history the fork depends on.
 
-Marin pins exact SHAs and wheels, never a bare branch name, so the branch pointer can
-move without changing what Marin resolves. That is what makes the swap safe.
+Branch-based Marin pins resolve an exact SHA, never a bare branch name, so the
+branch pointer can move without changing what Marin resolves. That is what makes
+the swap safe. The TPU vLLM group selects a public release instead and does not
+use this protocol.
 
 ## Prepare the refs
 
@@ -46,21 +48,15 @@ promotes each pin:
 - Verify remote `<branch>` resolves to the validated tip. Delete `<branch>-next` or
   leave it for the next cycle; the next refresh force-updates it.
 
-Descriptor and release pins need no edit after this swap because they already record
-the exact validated SHA or wheel. For an `isolated_project`, restore the uv source
+Release pins need no edit after this swap because they already record the exact
+validated wheel. For an `isolated_project`, restore the uv source
 from `main-next` to `main`, rerun `uv run config/update-external.py <fork>`, and verify
 the lock still records the validated SHA. Commit and push that follow-up to the draft
 Marin PR before marking it ready or merging it.
 
-## The two-branch vllm fork
-
-The vllm fork carries two pins on different upstream bases, so they cannot share one
-branch. It splits them across two stable branches: the GPU wheel builds from `main`
-(the release candidate triggers on `push: main`), and the TPU source pin lives on
-`tpu`. Each promotes on its own: `main-next` to `main` for the GPU pin, `tpu-next` to
-`tpu` for the TPU pin. A partial failure leaves the other pin correct because Marin
-resolves an exact wheel or SHA either way. Single-pin forks track `main` directly, so
-for them `<branch>` is `main`.
+The vLLM GPU overlay uses this protocol on `main`. The TPU release selects its
+exact source commits independently and records them in release evidence, so it
+does not expose a source branch or promotion state through Marin.
 
 ## Partial failure
 

--- a/.agents/skills/refresh-fork/docs/vllm.md
+++ b/.agents/skills/refresh-fork/docs/vllm.md
@@ -1,58 +1,145 @@
-# The vllm forks: group, pins, release pipeline, e2e
+# The vLLM forks: TPU release, GPU release, and e2e
 
-Fork-specific guidance for the `vllm` (TPU), `tpu-inference`, and `vllm-gpu` pins.
-The generic workflow lives in `../SKILL.md`; this file holds what is particular to
-these forks.
+Fork-specific guidance for the `vllm` (TPU), `tpu-inference`, and `vllm-gpu`
+pins. The generic workflow lives in `../SKILL.md`; this file holds what is
+particular to these forks.
 
-## The vllm/tpu-inference group
+## The TPU vLLM release
 
-Refresh the `vllm`/`tpu-inference` group as one unit and one PR; `vllm-gpu` tracks
-the fork's independent `main` branch. The TPU launcher installs both grouped pins,
-and vLLM's TPU base derives from the tpu-inference release; splitting them can
-produce an unvalidated stack.
+Refresh the `vllm`/`tpu-inference` group as one unit and one PR. This group is
+release-based: select its two upstream bases, replay the retained Marin overlays
+to produce two reviewed source tips, build one public vLLM release whose metadata
+installs the companion tpu-inference wheel, and put that one vLLM requirement in
+Marin. The independent `vllm-gpu` pin keeps its existing release workflow.
 
-On the vllm fork the GPU and TPU pins promote onto their own stable branches
-(`main` and `tpu`) independently.
+Use **Read the Descriptor** and **Scratch setup** from `../SKILL.md`, then follow
+this section instead of its generic **Select the base**, **Rebase the overlay**,
+**Pin at the staged tip**, and **Prepare the protected-branch promotion** sections.
+Resume at **Check the fork's own suite**, **Validate**, and **Review and Open the
+PR**. Do not stage a temporary source descriptor, add a second tpu-inference
+requirement, or promote a TPU stable branch.
 
-## Base selection detail
+The repositories have distinct roles:
 
-For `base_select = derived` (`vllm`): read the SHA at `derived_from`
-(`tpu-inference:.buildkite/vllm_lkg.version`) from the selected `tpu-inference`
-release. That exact SHA is the base; verify it resolves in the fork's `upstream`.
-Inspect its TPU build metadata (`requirements/tpu.txt`, `pyproject.toml`,
-`setup.py`) for dependency implications.
+| Source | `origin` (Marin fork) | `upstream` (canonical) |
+|---|---|---|
+| tpu-inference | `https://github.com/marin-community/tpu-inference.git` | `https://github.com/vllm-project/tpu-inference.git` |
+| vLLM | `https://github.com/marin-community/vllm.git` | `https://github.com/vllm-project/vllm.git` |
 
-## Pinning
+Use these names throughout:
 
-- `pin = descriptor:<path>#<section>` (`vllm`, `tpu-inference`): push `<branch>-next` to
-  the fork. Set the section's `commit` to its tip and `upstream_base` to the selected
-  base in `vllm/tpu.toml`. This stack resolves entirely inside the `uvx` env from
-  the two forks, so there are no `uv.lock` changes and `jax`/`jaxlib`/`libtpu`/`torch`
-  come from the forks' own dependencies — do not touch `marin-core`, `marin-levanter`,
-  or `marin-fray`.
-- `pin = release:<path>` (`vllm-gpu`): the pin is a prebuilt wheel, so the refresh builds
-  and promotes one through the fork's own release pipeline, then re-pins from the promoted
-  manifest. Dispatching fork workflows needs `actions:write` on `marin-community/vllm`,
-  which the fork-ferry profile grants.
-  1. Push `main-next` to the fork.
-  2. Build the candidate on that ref:
-     `gh workflow run marin-gpu-candidate.yaml --repo marin-community/vllm --ref main-next`.
-     The workflow otherwise builds on `push: main`; dispatching on `main-next` compiles the
-     staged tip into both arches under a `marin-vllm-gpu-candidate-<sha>` prerelease.
-  3. Once the candidate prerelease exists, promote it:
-     `gh workflow run marin-gpu-release.yaml --repo marin-community/vllm --ref main-next -f candidate_tag=<tag>`.
-     The release job validates the exact wheel bytes on real GPUs and publishes an immutable
-     release carrying `marin-vllm-gpu-manifest.json`.
-  4. Download that manifest and re-pin without hand-editing `gpu.toml`:
-     `gh release download <release_tag> --repo marin-community/vllm --pattern marin-vllm-gpu-manifest.json`,
-     then `uv run config/update-external.py --promote-gpu-release marin-vllm-gpu-manifest.json`.
-     The helper writes `gpu.toml` (release tag, source commit, version, torch backend,
-     per-arch url+sha256) and regenerates `external_dependencies.py`; it re-encodes the wheel
-     URLs the way the pin loader validates, which a hand copy gets wrong.
+```text
+tpu_base       = selected stable upstream tpu-inference release
+tpu_source_tip = reviewed tpu-inference overlay replayed onto tpu_base
 
-A base that crosses a CUDA/torch or vLLM stable-ABI boundary is a migration. Re-audit the
-wheel verifier and the fork's release gate for the extension name (`vllm._C_stable_libtorch`
-on CUDA 13) when the base moves across such a boundary.
+vllm_base       = LKG selected by that tpu-inference release
+vllm_source_tip = reviewed vLLM overlay replayed onto vllm_base
+```
+
+The bases are inputs to the replay. The source tips are the producer inputs.
+
+1. Read `config/external/vllm/tpu.toml`, then read the currently selected GitHub
+   release notes and producer receipt. Record the exact current
+   `tpu_source_tip` and `vllm_source_tip`, and verify each resolves in its Marin
+   fork. Identify and verify the exact upstream base beneath each current source
+   tip. Stop with a blocker if the current source tips or their bases cannot be
+   established exactly; do not reconstruct an overlay from a net diff.
+2. Select the newest canonical upstream tpu-inference release whose tag is
+   exactly `vMAJOR.MINOR.PATCH` and whose GitHub release is neither draft nor
+   prerelease as `tpu_base`. Read `.buildkite/vllm_lkg.version` at that base and
+   resolve the named commit in canonical upstream vLLM as `vllm_base`. Inspect
+   its TPU build metadata (`requirements/tpu.txt`, `pyproject.toml`, and
+   `setup.py`) for dependency implications.
+3. Replay each current Marin overlay onto its corresponding new base:
+   - Inventory `current_base..current_source_tip` in logical order with
+     `git log --reverse --no-merges`, retaining the original SHAs.
+   - Classify every meaningful delta as `carry`, `drop`, or `fix`. Compare it
+     with the new base first: drop changes upstream absorbed or made obsolete;
+     carry changes still needed; rewrite a `fix` when the intent remains but the
+     upstream API or layout moved. Merge commits are not replayed.
+   - Replay only `carry` and `fix` in logical order. Audit every touched API and
+     dependency against the new base, resolve incompatibilities, and run that
+     fork's ordinary checks before proceeding.
+   - Run `git range-diff` from the old overlay range to the new one. Record every
+     original commit and its carry/drop/fix result, with the reason for each drop
+     or rewrite. If an independent fixed-base overlay change is needed, land its
+     review through `overlay-only-pr.md` before freezing either source tip; that
+     workflow is not a substitute for this replay.
+4. Review both replayed ranges and preserve their exact commits on reviewable
+   branches in the Marin forks. Record the resulting full SHAs as
+   `tpu_source_tip` and `vllm_source_tip`. Do not substitute the bare
+   `tpu_base` or `vllm_base` commits.
+5. Inspect the two source tips' dependency files together, including the
+   tpu-inference torch constraints and vLLM TPU requirements. These commits are
+   release evidence, not separate Marin runtime inputs.
+6. Select one unused full `marin-vllm-tpu-...` release tag. Freeze that tag, the
+   vLLM workflow producer commit, both source tips, and the dependency cutoff.
+   Dispatch the TPU lane of `marin-gpu-candidate.yaml` at that producer commit
+   with `vllm_source_tip`, `tpu_source_tip`, the tag, and the cutoff as explicit
+   inputs. Dispatch it once.
+7. Read back the public prerelease. It must contain exactly the vLLM wheel and its
+   tpu-inference companion. Inspect the built vLLM wheel's `METADATA` and confirm
+   its direct requirement names the companion's public release URL. Record the
+   workflow run, producer commit, source tips, upstream bases, cutoff, tag, asset
+   names, sizes, and digests as evidence.
+8. Before using hardware, resolve the public vLLM requirement in a fresh uv tool
+   environment. Confirm it installs both selected wheel versions. Repeat with an
+   explicit `tpu-inference @ git+https://github.com/marin-community/tpu-inference@<head>`
+   override and confirm uv selects that HEAD instead of the transitive release.
+9. Edit only `config/external/vllm/tpu.toml`: the public release tag, dependency
+   cutoff, and one vLLM requirement. Regenerate and check the typed object:
+
+   ```sh
+   uv run config/update-external.py vllm
+   uv run config/update-external.py vllm --check
+   ```
+
+10. Run focused Marin checks, commit the final consumer diff, and freeze its full
+    SHA as the Marin consumer head. Run the sole physical gate below against that
+    exact SHA. Resume at **Review and Open the PR** in `../SKILL.md` with the TPU
+    release and validation receipt. Do not add a second physical qualification or
+    exact-byte protocol.
+11. After validation and the producer change merges, mark the same GitHub release
+    final without rebuilding or replacing either asset. Read back the unchanged
+    asset IDs and digests before landing the Marin consumer.
+
+Rebuild and rerun the physical gate only after a change that can affect the wheel
+bytes or metadata, selected assets, producer path, Marin requirement, or launcher.
+Documentation, tests, and PR-body edits do not invalidate the receipt.
+
+For the draft PR body, record the upstream bases, reviewed source tips, producer
+and release tag, dependency cutoff, immutable asset evidence, e2e outcome, and
+unresolved risks. Include the carry/drop/fix record without branch-promotion,
+rollback-tag, or staged-tip fields.
+
+## The vLLM GPU release pipeline
+
+The `vllm-gpu` pin tracks upstream vLLM head independently on the fork's `main`.
+It is a prebuilt wheel, so the refresh stages its overlay on `main-next`, builds
+and promotes one release through the fork's existing pipeline, and re-pins from
+the promoted manifest. Dispatching fork workflows needs `actions:write` on
+`marin-community/vllm`, which the fork-ferry profile grants.
+
+1. Push `main-next` to the fork.
+2. Build the candidate on that ref:
+   `gh workflow run marin-gpu-candidate.yaml --repo marin-community/vllm --ref main-next`.
+   The workflow otherwise builds on `push: main`; dispatching on `main-next`
+   compiles the staged tip into both arches under a
+   `marin-vllm-gpu-candidate-<sha>` prerelease.
+3. Once the candidate prerelease exists, promote it:
+   `gh workflow run marin-gpu-release.yaml --repo marin-community/vllm --ref main-next -f candidate_tag=<tag>`.
+   The release job validates the exact wheel bytes on real GPUs and publishes an
+   immutable release carrying `marin-vllm-gpu-manifest.json`.
+4. Download that manifest and re-pin without hand-editing `gpu.toml`:
+   `gh release download <release_tag> --repo marin-community/vllm --pattern marin-vllm-gpu-manifest.json`,
+   then `uv run config/update-external.py --promote-gpu-release marin-vllm-gpu-manifest.json`.
+   The helper writes `gpu.toml` (release tag, source commit, version, torch backend,
+   per-arch URL and SHA-256) and regenerates `external_dependencies.py`; it
+   re-encodes the wheel URLs the way the pin loader validates.
+
+A base that crosses a CUDA/torch or vLLM stable-ABI boundary is a migration.
+Re-audit the wheel verifier and the fork's release gate for the extension name
+(`vllm._C_stable_libtorch` on CUDA 13) when the base moves across such a boundary.
 
 ## Fork suite caveat
 
@@ -62,25 +149,31 @@ structural checks only for vLLM; do not call them behavioral validation.
 ## End-to-end validation
 
 - **`experiments/evals/served_qwen3.py::QWEN3_TPU_INFERENCE`** (`vllm`,
-  `tpu-inference`) — a bounded brokered TPU serve+eval smoke. Run TPU workloads
-  through Iris on the `marin` cluster at interactive priority, `v6e-4` in GCP
-  `europe-west4`. Confirm the proxy served completions, lm-eval wrote metrics and
-  sample outputs, and no TPU/vLLM build, import, or runtime tracebacks occurred:
+  `tpu-inference`) — the one physical gate for the selected public release. Run
+  Qwen3-0.6B at tensor parallel size 8 on one `v6e-8` through Iris `marin`, in
+  `us-east5`, at production priority on both the launcher and worker. Use a fresh
+  run version so the worker cold-installs through `uvx`. Confirm the public
+  requirement installs, the server becomes healthy, and a real request succeeds.
+  Record the Iris job and child task IDs, release assets, all three frozen commits,
+  probe result, and successful resource release:
 
 ```sh
 uv run iris --config lib/iris/config/marin.yaml job run \
   --job-name served-qwen3-<run-id> --cpu 1 --memory 2G --extra cpu \
-  --priority interactive --no-wait -- python -c \
-  "from dataclasses import replace; from fray.types import ResourceConfig; from marin.execution.lazy import lower; from marin.execution.step_runner import StepRunner; from experiments.evals.lm_eval_suite import lm_eval_suite; from experiments.evals.served_qwen3 import QWEN3_TPU_INFERENCE; inference = replace(QWEN3_TPU_INFERENCE, iris=replace(QWEN3_TPU_INFERENCE.iris, worker_resources=ResourceConfig.with_tpu('v6e-4', ram='96g', regions=['europe-west4']))); StepRunner().run([lower(lm_eval_suite(inference, model_name='qwen3-0.6b-refresh-smoke', version='<run-id>-dev', limit=8))])"
+  --priority production --no-wait -- python -c \
+  "from dataclasses import replace; from fray.types import ResourceConfig; from iris.rpc import job_pb2; from marin.execution.lazy import lower; from marin.execution.step_runner import StepRunner; from experiments.evals.lm_eval_suite import lm_eval_suite; from experiments.evals.served_qwen3 import QWEN3_TPU_INFERENCE; inference = replace(QWEN3_TPU_INFERENCE, model=replace(QWEN3_TPU_INFERENCE.model, tensor_parallel_size=8), iris=replace(QWEN3_TPU_INFERENCE.iris, worker_resources=ResourceConfig.with_tpu('v6e-8', ram='96g', regions=['us-east5']), priority=job_pb2.PRIORITY_BAND_PRODUCTION)); StepRunner().run([lower(lm_eval_suite(inference, model_name='qwen3-0.6b-refresh-smoke', version='<run-id>', limit=8))])"
 ```
 
+Preserve this single physical receipt under the invalidation rule above.
+
 - **`tests/cluster/vllm/test_snowball_backend_parity.py`** (`vllm-gpu`) — the
-  Snowball-67B next-token logprob parity gate on H100s. It is `-m cluster` marked, so
-  run it with `-o addopts= --import-mode=importlib`; the H100s live on CoreWeave and are
-  reached through the marin federation hub (`target_cluster`), not a direct controller.
-  Confirm the Levanter reference and `vllm-gpu-pp1` (single-node 8×H100) match the
-  goldens within `max_probability_error` (`pp2` is a 16×H100 multi-node variant). Pair
-  it with a bounded qwen3-0.6B GPU serve+eval to exercise the brokered serving path:
+  Snowball-67B next-token logprob parity gate on H100s. It is `-m cluster` marked,
+  so run it with `-o addopts= --import-mode=importlib`; the H100s live on CoreWeave
+  and are reached through the Marin federation hub (`target_cluster`), not a
+  direct controller. Confirm the Levanter reference and `vllm-gpu-pp1`
+  (single-node 8xH100) match the goldens within `max_probability_error` (`pp2` is
+  a 16xH100 multi-node variant). Pair it with a bounded qwen3-0.6B GPU serve+eval
+  to exercise the brokered serving path:
 
 ```sh
 uv run pytest tests/cluster/vllm/test_snowball_backend_parity.py \

--- a/.github/workflows/ops-fork-ferry.yaml
+++ b/.github/workflows/ops-fork-ferry.yaml
@@ -72,7 +72,7 @@ jobs:
 
           # Launch one visible, self-reporting Weaver session for this fork unit. idempotency_key
           # keeps a rerun of the same weekly job from opening a second session.
-          goal="Use the refresh-fork skill to refresh ${FORKS} toward upstream. For tpu-vllm, publish and select one public vLLM release whose metadata installs its companion. For another unit, follow its existing branch or release pin. Run the declared e2e and on green open one draft Marin PR, or file the descriptor's blocker issue for a real external blocker."
+          goal="Use the refresh-fork skill to refresh ${FORKS} toward upstream. For tpu-vllm, publish and select one public vLLM release whose metadata installs its companion. For another unit, follow its existing branch or release pin. Finish with exactly one visible result in the final Loom response: link one draft Marin PR after a green e2e; link the descriptor's blocker issue for a real external blocker; or report an explicit no-op naming the current and selected upstream SHAs when no newer base or metadata repair exists."
           curl -sS --fail-with-body -X POST "${LOOM_URL}/api/runs" \
             -H "Authorization: Bearer $loom_token" \
             -H 'Content-Type: application/json' \

--- a/.github/workflows/ops-fork-ferry.yaml
+++ b/.github/workflows/ops-fork-ferry.yaml
@@ -66,4 +66,7 @@ jobs:
             selects its companion. For another unit, follow its existing branch
             or release pin. Run the declared e2e and on green open one draft
             Marin PR, or file the descriptor's blocker issue for a real external
-            blocker.
+            blocker. Finish with exactly one visible result in the final Loom
+            response: link the draft PR after a green e2e; link the blocker
+            issue; or report an explicit no-op naming the current and selected
+            upstream SHAs when no newer base or metadata repair exists.

--- a/.github/workflows/ops-fork-ferry.yaml
+++ b/.github/workflows/ops-fork-ferry.yaml
@@ -72,7 +72,7 @@ jobs:
 
           # Launch one visible, self-reporting Weaver session for this fork unit. idempotency_key
           # keeps a rerun of the same weekly job from opening a second session.
-          goal="Use the refresh-fork skill to refresh ${FORKS} toward upstream: stage the refresh, pin Marin as the descriptor directs (a fork branch tip, or a promoted release wheel re-pinned from its manifest), run the fork's e2e, and on green open the Marin pin PR (or file the descriptor's blocker issue on a real external blocker)."
+          goal="Use the refresh-fork skill to refresh ${FORKS} toward upstream. For tpu-vllm, publish and select one public vLLM release whose metadata installs its companion. For another unit, follow its existing branch or release pin. Run the declared e2e and on green open one draft Marin PR, or file the descriptor's blocker issue for a real external blocker."
           curl -sS --fail-with-body -X POST "${LOOM_URL}/api/runs" \
             -H "Authorization: Bearer $loom_token" \
             -H 'Content-Type: application/json' \

--- a/.github/workflows/ops-fork-ferry.yaml
+++ b/.github/workflows/ops-fork-ferry.yaml
@@ -60,7 +60,10 @@ jobs:
           title: Fork ferry ${{ matrix.unit }}
           goal: >-
             Use the refresh-fork skill to refresh ${{ matrix.forks }} toward
-            upstream: stage the refresh, pin Marin as the descriptor directs (a
-            fork branch tip, or a promoted release wheel re-pinned from its
-            manifest), run the fork's e2e, and on green open the Marin pin PR
-            (or file the descriptor's blocker issue on a real external blocker).
+            upstream. For tpu-vllm, select compatible upstream bases, replay
+            and review every retained Marin overlay to produce two exact fork
+            source tips, then publish one public vLLM wheel whose metadata
+            selects its companion. For another unit, follow its existing branch
+            or release pin. Run the declared e2e and on green open one draft
+            Marin PR, or file the descriptor's blocker issue for a real external
+            blocker.

--- a/config/external/migration.toml
+++ b/config/external/migration.toml
@@ -8,10 +8,11 @@
 #
 # Migrating a pin rebases our commits onto a newer upstream base on a `<branch>-next` staging branch,
 # validates with the fork's e2e against that branch, re-pins Marin at the exact staged tip, and opens
-# a draft PR. The refresh creates rollback and date tags; an admin promotes the protected stable
-# `branch` before merging the Marin PR. Some forks have drifted too far for a mechanical rebase (see
-# their nuances); a refresh files a blocker for those until a one-time manual catch-up brings them
-# close to upstream again.
+# a draft PR. Branch-based refreshes create rollback and date tags before an admin promotion. The
+# TPU vLLM group instead publishes one public release from two exact source commits; those commits
+# stay in release evidence while Marin records only the vLLM requirement. Some forks have drifted
+# too far for a mechanical rebase (see their nuances); a refresh files a blocker for those until a
+# one-time manual catch-up brings them close to upstream again.
 #
 # The `refresh-fork` skill reads a section to drive one pin's refresh. `ops-fork-ferry.yaml` asks
 # Weaver to run that skill weekly for each supported pin or group. Keep every section consistent with
@@ -21,20 +22,17 @@
 # fork with more than one pin has one section per pin (the vllm fork has `vllm` and `vllm-gpu`).
 # Fields:
 #   upstream         Repo we rebase our commits onto. Every fork has one.
-#   group            Sections sharing a group refresh together and land in one atomic Marin PR (each
-#                    still rebases onto its own base). The vllm/tpu-inference pair must move together:
-#                    the TPU launcher installs both pins at once and vllm's base derives from the
-#                    tpu-inference release, so a split refresh could pin a mixed, unblessed stack.
+#   group            Sections sharing a refresh move together and land in one Marin PR. The
+#                    vllm/tpu-inference pair produces one vLLM release: vLLM's base derives from the
+#                    tpu-inference release, and the vLLM wheel selects the exact companion.
 #                    Omitted for pins that refresh alone.
 #   pin              Where the resolved pin is recorded: "isolated_project" (config/external/<name>/
-#                    uv.lock, follows the fork's main branch), "descriptor:<path>#<section>" (a SHA in a
-#                    vllm/*.toml section), or "release:<path>" (a prebuilt-wheel release: a release tag +
-#                    source commit + per-arch wheels, for a pin too expensive to build at job time).
-#   branch           The fork branch this pin tracks. A single-pin fork tracks "main". The vllm fork
-#                    carries two pins on different upstream bases, so it splits them across two stable
-#                    branches: the GPU wheel builds from "main" and the TPU source pin lives on "tpu".
-#                    The refresh stages on "<branch>-next"; an admin promotes it onto "<branch>" after
-#                    reviewing the draft Marin PR.
+#                    uv.lock, follows the fork's main branch), or "release:<path>" (a public prebuilt
+#                    wheel selection). Grouped sources may share one release path when one wheel's
+#                    metadata selects the complete environment.
+#   branch           The fork branch that supplies a selected source or branch pin. For the TPU
+#                    release, its resolved commit is release evidence rather than a Marin input. Other
+#                    refreshes stage on "<branch>-next" for admin promotion after review.
 #   base_select      Which upstream base to rebase onto: "upstream_main" (upstream default branch),
 #                    "latest_release" (newest stable GitHub release), or "derived" (a SHA read from
 #                    another fork, with `derived_from`).
@@ -49,7 +47,7 @@
 [tpu-inference]
 upstream = "https://github.com/vllm-project/tpu-inference.git"
 group = "tpu-vllm"
-pin = "descriptor:vllm/tpu.toml#tpu-inference"
+pin = "release:vllm/tpu.toml"
 branch = "main"
 base_select = "latest_release"
 e2e = "experiments/evals/served_qwen3.py::QWEN3_TPU_INFERENCE"
@@ -61,7 +59,7 @@ nuances = [
 [vllm]
 upstream = "https://github.com/vllm-project/vllm.git"
 group = "tpu-vllm"
-pin = "descriptor:vllm/tpu.toml#vllm"
+pin = "release:vllm/tpu.toml"
 branch = "tpu"
 base_select = "derived"
 derived_from = "tpu-inference:.buildkite/vllm_lkg.version"
@@ -70,7 +68,8 @@ e2e = "experiments/evals/served_qwen3.py::QWEN3_TPU_INFERENCE"
 blocker_assignee = "yonromai"
 nuances = [
     "Do not advance past the vLLM known-good commit the selected tpu-inference release blessed.",
-    "The vllm fork carries a second, independent pin (vllm-gpu). Keep this one on its own `tpu` branch; the fork's `main` carries the vllm-gpu overlay.",
+    "Build one public vLLM wheel whose metadata selects the exact tpu-inference companion; record both source commits as release evidence, not separate Marin pins.",
+    "The vllm fork carries a second, independent GPU release pin. Do not change it during this TPU refresh.",
 ]
 
 [vllm-gpu]
@@ -82,7 +81,7 @@ e2e = "tests/cluster/vllm/test_snowball_backend_parity.py"
 blocker_assignee = "yonromai"
 nuances = [
     "The pin is a prebuilt wheel. The fork's release pipeline compiles `main` into an immutable wheel under a release tag; gpu.toml records the tag, source commit, and per-arch url+sha256. A refresh rebuilds and re-promotes the wheel, then re-pins with `uv run config/update-external.py --promote-gpu-release <manifest>`, which reads the promoted marin-vllm-gpu-manifest.json.",
-    "This GPU pin refreshes on its own (no shared group). It tracks upstream head on `main`, which the release candidate build triggers on. The [vllm] pin tracks the tpu-inference-blessed base on the separate `tpu` branch.",
+    "This GPU pin refreshes on its own (no shared group). It tracks upstream head on `main`; the TPU release selects its sources independently.",
     "A base that crosses a CUDA/torch or vLLM stable-ABI boundary is a migration. The wheel verifier and the fork release gate both name the extension (vllm._C_stable_libtorch on CUDA 13); audit them when the base moves across such a boundary.",
 ]
 

--- a/config/external/migration.toml
+++ b/config/external/migration.toml
@@ -117,6 +117,6 @@ e2e = "experiments/post_training/iceball_micro.py"
 blocker_assignee = "yonromai"
 nuances = [
     "Shares history with NovaSky-AI/SkyRL (merge-base 8e132edc, Dec 2025), but NovaSky's later monolith->package restructure (skyrl-train/ -> skyrl/) moved or deleted 684 of the 718 files Marin touched, so a mechanical rebase is intractable.",
-    "Needs a one-time re-fork onto current NovaSky main with Marin's work re-homed into the new package layout (#7920) before it can auto-migrate; until then a refresh files a blocker.",
+    "Needs a one-time re-fork onto current NovaSky main with Marin's work re-homed into the new package layout (#7920). Until that lands, any explicitly requested on-demand refresh is blocked.",
     "Marin consumes only the root marinskyrl package; the forked skyrl-train is unused. The GitHub compare API 404s because the repo was pushed as a standalone (its fork network is unlinked), which does not affect git-level rebasing.",
 ]

--- a/config/external/migration.toml
+++ b/config/external/migration.toml
@@ -18,9 +18,11 @@
 # Weaver to run that skill weekly for each supported pin or group. Keep every section consistent with
 # its pin source and with EXTERNAL_PROJECTS in config/update-external.py.
 #
-# A section's name is the pin; its pin source holds the fork's repository URL and pinned revision. A
-# fork with more than one pin has one section per pin (the vllm fork has `vllm` and `vllm-gpu`).
+# A section's name is the pin; `repository` or its pin source identifies the Marin fork, while the
+# pin source holds the selected revision. A fork with more than one pin has one section per pin (the
+# vllm fork has `vllm` and `vllm-gpu`).
 # Fields:
+#   repository       Marin fork cloned as `origin`. If omitted, derive it from the pin source.
 #   upstream         Repo we rebase our commits onto. Every fork has one.
 #   group            Sections sharing a refresh move together and land in one Marin PR. The
 #                    vllm/tpu-inference pair produces one vLLM release: vLLM's base derives from the
@@ -45,6 +47,7 @@
 #   nuances          Migration constraints a human must respect (torch pins, known-good ceilings, etc.).
 
 [tpu-inference]
+repository = "https://github.com/marin-community/tpu-inference.git"
 upstream = "https://github.com/vllm-project/tpu-inference.git"
 group = "tpu-vllm"
 pin = "release:vllm/tpu.toml"
@@ -57,6 +60,7 @@ nuances = [
 ]
 
 [vllm]
+repository = "https://github.com/marin-community/vllm.git"
 upstream = "https://github.com/vllm-project/vllm.git"
 group = "tpu-vllm"
 pin = "release:vllm/tpu.toml"

--- a/docs/dev-guide/forking-policy.md
+++ b/docs/dev-guide/forking-policy.md
@@ -88,11 +88,13 @@ needs one requirement. Before the physical gate, resolve that requirement in a
 fresh uv environment and repeat with an explicit tpu-inference HEAD override;
 the latter is the nightly compatibility shape.
 
-The refresh freezes the vLLM producer commit, both source commits, the dependency
-cutoff, and the Marin consumer head before it builds. It publishes the pair once
-as a prerelease and records the workflow, assets, commits, and digests. After the
-producer change merges, mark that same release final without rebuilding or
-replacing its assets.
+The refresh selects a stable tpu-inference upstream release and the vLLM LKG it
+names, then replays and reviews each fork's retained Marin overlay. Those two
+exact source tips, not the bare upstream bases, are passed to the producer. The
+refresh freezes the producer commit, source tips, dependency cutoff, and Marin
+consumer head before it builds. It publishes the pair once as a prerelease and
+records the workflow, assets, commits, and digests. After the producer change
+merges, mark that same release final without rebuilding or replacing its assets.
 
 ## The vLLM GPU release pipeline
 

--- a/docs/dev-guide/forking-policy.md
+++ b/docs/dev-guide/forking-policy.md
@@ -11,17 +11,14 @@ how Marin pins a fork and how the refresh runs.
 Every fork is pinned under `config/external/`. The pins feed
 `config/update-external.py`, which regenerates
 `lib/marin/src/marin/external_dependencies.py`; nothing else imports a fork
-revision directly. There are three pin kinds:
+revision directly. There are two pin kinds:
 
 - Isolated uv lock (`evalchemy`, `harbor`, `MarinSkyRL`): the fork is a git
   dependency in `config/external/<fork>/uv.lock`. `uv run
   config/update-external.py <fork>` advances the lock and regenerates the pins.
-- Descriptor SHA (`vllm` TPU stack, `tpu-inference`): the fork tips live in
-  `config/external/vllm/tpu.toml`. This stack runs from an isolated `uvx`
-  environment, so its `jax`/`jaxlib`/`libtpu`/`torch` come from the forks' own
-  dependencies and there is no workspace lock change.
-- Release wheel (`vllm` GPU): `config/external/vllm/gpu.toml` records a
-  promoted, immutable wheel per architecture. See the GPU release pipeline below.
+- Release wheel (`vllm` TPU and GPU): `config/external/vllm/tpu.toml` records one
+  public vLLM requirement whose metadata selects its tpu-inference companion.
+  `gpu.toml` independently records the promoted GPU wheel per architecture.
 
 ## The weekly refresh
 
@@ -42,6 +39,12 @@ result on a `<branch>-next` branch, re-pin Marin, run the fork's declared
 end-to-end test, and on green open one draft Marin PR requesting the descriptor's
 reviewer. On an unresolved external blocker it files a "can't migrate" issue
 instead of a PR.
+
+The TPU vLLM group is the exception to branch staging. The session selects exact
+vLLM and tpu-inference source commits, builds one public prerelease from a frozen
+vLLM producer commit, verifies that the vLLM wheel depends on the companion, and
+updates Marin's one vLLM requirement. The source commits remain release evidence;
+they are not separate Marin pins.
 
 `config/external/migration.toml` is the per-fork descriptor. It records the
 upstream repository, the pin kind, the fork branch the pin tracks, how to select a
@@ -66,6 +69,27 @@ pins on the old fork stack. It fixes only failures that pass on the old stack an
 regress on the refreshed one. A workload already broken on the old stack is
 recorded as a baseline failure and left for its own fix.
 
+For the TPU vLLM release, this table names the sole physical gate. It uses
+Qwen3-0.6B at TP8 on one `v6e-8` in `us-east5` through Iris `marin`, with
+production priority on the launcher and worker. A fresh run must cold-install
+through `uvx`, start the server, and pass a real request. Rerun only when a change
+can affect the producer path, wheel bytes or metadata, selected assets, Marin
+requirement, or launcher.
+
+## The TPU vLLM release
+
+The TPU release is one public vLLM wheel plus one public tpu-inference wheel. The
+vLLM wheel declares the exact companion URL in its package metadata, so Marin
+needs one requirement. Before the physical gate, resolve that requirement in a
+fresh uv environment and repeat with an explicit tpu-inference HEAD override;
+the latter is the nightly compatibility shape.
+
+The refresh freezes the vLLM producer commit, both source commits, the dependency
+cutoff, and the Marin consumer head before it builds. It publishes the pair once
+as a prerelease and records the workflow, assets, commits, and digests. After the
+producer change merges, mark that same release final without rebuilding or
+replacing its assets.
+
 ## The vLLM GPU release pipeline
 
 The GPU pin resolves to a prebuilt wheel. The `marin-community/vllm`
@@ -89,7 +113,8 @@ loader validates.
 
 ## Promotion
 
-The refresh never force-moves a fork's stable branch. It stages on `<branch>-next`
+For branch-based refreshes, the refresh never force-moves a fork's stable branch.
+It stages on `<branch>-next`
 and leaves the protected stable branch at the old tip; the draft Marin PR names
 the `<branch>-next` to `<branch>` hard swap an admin performs after review. Because
 the staged tip and the eventual stable tip are the same commit, the pins need no
@@ -99,9 +124,9 @@ change after promotion.
 
 | Fork | Repository | Tracks upstream | Pin |
 |------|-----------|-----------------|-----|
-| vllm (TPU) | [`marin-community/vllm`](https://github.com/marin-community/vllm) | [`vllm-project/vllm`](https://github.com/vllm-project/vllm) | descriptor SHA on the `tpu` branch (`tpu.toml`) |
+| vllm (TPU) | [`marin-community/vllm`](https://github.com/marin-community/vllm) | [`vllm-project/vllm`](https://github.com/vllm-project/vllm) | public release requirement (`tpu.toml`) |
 | vllm (GPU) | [`marin-community/vllm`](https://github.com/marin-community/vllm) | [`vllm-project/vllm`](https://github.com/vllm-project/vllm) | release wheel from `main` (`gpu.toml`) |
-| tpu-inference | [`marin-community/tpu-inference`](https://github.com/marin-community/tpu-inference) | [`vllm-project/tpu-inference`](https://github.com/vllm-project/tpu-inference) | descriptor SHA (`tpu.toml`) |
+| tpu-inference | [`marin-community/tpu-inference`](https://github.com/marin-community/tpu-inference) | [`vllm-project/tpu-inference`](https://github.com/vllm-project/tpu-inference) | selected transitively by the TPU vLLM release |
 | evalchemy | [`marin-community/evalchemy`](https://github.com/marin-community/evalchemy) | [`mlfoundations/evalchemy`](https://github.com/mlfoundations/evalchemy) | isolated uv lock |
 | harbor | [`marin-community/harbor`](https://github.com/marin-community/harbor) | [`harbor-framework/harbor`](https://github.com/harbor-framework/harbor) | isolated uv lock |
 | MarinSkyRL | [`marin-community/MarinSkyRL`](https://github.com/marin-community/MarinSkyRL) | [`NovaSky-AI/SkyRL`](https://github.com/NovaSky-AI/SkyRL) | isolated uv lock |

--- a/docs/dev-guide/forking-policy.md
+++ b/docs/dev-guide/forking-policy.md
@@ -11,7 +11,7 @@ how Marin pins a fork and how the refresh runs.
 Every fork is pinned under `config/external/`. The pins feed
 `config/update-external.py`, which regenerates
 `lib/marin/src/marin/external_dependencies.py`; nothing else imports a fork
-revision directly. There are two pin kinds:
+revision directly. There are three pin kinds:
 
 - Isolated uv lock (`evalchemy`, `harbor`, `MarinSkyRL`): the fork is a git
   dependency in `config/external/<fork>/uv.lock`. `uv run
@@ -33,8 +33,9 @@ one Weaver session for that unit. The `fork-ferry` Loom profile admits all four
 scheduled units; a test keeps its concurrency limit at or above the matrix size.
 There is no stored PAT.
 
-`MarinSkyRL` is pinned and refreshable through the skill on demand, but is not yet
-in the weekly rotation. A human runs the skill for a single fork the same way.
+`MarinSkyRL` is intentionally excluded from the weekly rotation. Refresh it only
+when a caller explicitly requests that on-demand path; its current one-time
+re-fork blocker still applies.
 
 The session runs the `refresh-fork` skill
 (`.agents/skills/refresh-fork/SKILL.md`), which owns the migration procedure:

--- a/docs/dev-guide/forking-policy.md
+++ b/docs/dev-guide/forking-policy.md
@@ -11,17 +11,14 @@ how Marin pins a fork and how the refresh runs.
 Every fork is pinned under `config/external/`. The pins feed
 `config/update-external.py`, which regenerates
 `lib/marin/src/marin/external_dependencies.py`; nothing else imports a fork
-revision directly. There are three pin kinds:
+revision directly. There are two pin kinds:
 
 - Isolated uv lock (`evalchemy`, `harbor`, `MarinSkyRL`): the fork is a git
   dependency in `config/external/<fork>/uv.lock`. `uv run
   config/update-external.py <fork>` advances the lock and regenerates the pins.
-- Descriptor SHA (`vllm` TPU stack, `tpu-inference`): the fork tips live in
-  `config/external/vllm/tpu.toml`. This stack runs from an isolated `uvx`
-  environment, so its `jax`/`jaxlib`/`libtpu`/`torch` come from the forks' own
-  dependencies and there is no workspace lock change.
-- Release wheel (`vllm` GPU): `config/external/vllm/gpu.toml` records a
-  promoted, immutable wheel per architecture. See the GPU release pipeline below.
+- Release wheel (`vllm` TPU and GPU): `config/external/vllm/tpu.toml` records one
+  public vLLM requirement whose metadata selects its tpu-inference companion.
+  `gpu.toml` independently records the promoted GPU wheel per architecture.
 - Pinned wheel URL (`xla`): the `gpu` extra's `jax-cuda13-pjrt` source in
   `lib/marin/pyproject.toml` points at a promoted wheel from the fork's release,
   and `uv.lock` records its hash. This fork sits outside the weekly refresh; see
@@ -47,6 +44,12 @@ end-to-end test, and on green open one draft Marin PR requesting the descriptor'
 reviewer. On an unresolved external blocker it files a "can't migrate" issue
 instead of a PR.
 
+The TPU vLLM group is the exception to branch staging. The session selects exact
+vLLM and tpu-inference source commits, builds one public prerelease from a frozen
+vLLM producer commit, verifies that the vLLM wheel depends on the companion, and
+updates Marin's one vLLM requirement. The source commits remain release evidence;
+they are not separate Marin pins.
+
 `config/external/migration.toml` is the per-fork descriptor. It records the
 upstream repository, the pin kind, the fork branch the pin tracks, how to select a
 new base, the validating e2e, the blocker assignee, and the nuances a refresh must
@@ -69,6 +72,27 @@ When an e2e fails, the refresh reruns the same workload against Marin's current
 pins on the old fork stack. It fixes only failures that pass on the old stack and
 regress on the refreshed one. A workload already broken on the old stack is
 recorded as a baseline failure and left for its own fix.
+
+For the TPU vLLM release, this table names the sole physical gate. It uses
+Qwen3-0.6B at TP8 on one `v6e-8` in `us-east5` through Iris `marin`, with
+production priority on the launcher and worker. A fresh run must cold-install
+through `uvx`, start the server, and pass a real request. Rerun only when a change
+can affect the producer path, wheel bytes or metadata, selected assets, Marin
+requirement, or launcher.
+
+## The TPU vLLM release
+
+The TPU release is one public vLLM wheel plus one public tpu-inference wheel. The
+vLLM wheel declares the exact companion URL in its package metadata, so Marin
+needs one requirement. Before the physical gate, resolve that requirement in a
+fresh uv environment and repeat with an explicit tpu-inference HEAD override;
+the latter is the nightly compatibility shape.
+
+The refresh freezes the vLLM producer commit, both source commits, the dependency
+cutoff, and the Marin consumer head before it builds. It publishes the pair once
+as a prerelease and records the workflow, assets, commits, and digests. After the
+producer change merges, mark that same release final without rebuilding or
+replacing its assets.
 
 ## The vLLM GPU release pipeline
 
@@ -93,7 +117,8 @@ loader validates.
 
 ## Promotion
 
-The refresh never force-moves a fork's stable branch. It stages on `<branch>-next`
+For branch-based refreshes, the refresh never force-moves a fork's stable branch.
+It stages on `<branch>-next`
 and leaves the protected stable branch at the old tip; the draft Marin PR names
 the `<branch>-next` to `<branch>` hard swap an admin performs after review. Because
 the staged tip and the eventual stable tip are the same commit, the pins need no
@@ -103,9 +128,9 @@ change after promotion.
 
 | Fork | Repository | Tracks upstream | Pin |
 |------|-----------|-----------------|-----|
-| vllm (TPU) | [`marin-community/vllm`](https://github.com/marin-community/vllm) | [`vllm-project/vllm`](https://github.com/vllm-project/vllm) | descriptor SHA on the `tpu` branch (`tpu.toml`) |
+| vllm (TPU) | [`marin-community/vllm`](https://github.com/marin-community/vllm) | [`vllm-project/vllm`](https://github.com/vllm-project/vllm) | public release requirement (`tpu.toml`) |
 | vllm (GPU) | [`marin-community/vllm`](https://github.com/marin-community/vllm) | [`vllm-project/vllm`](https://github.com/vllm-project/vllm) | release wheel from `main` (`gpu.toml`) |
-| tpu-inference | [`marin-community/tpu-inference`](https://github.com/marin-community/tpu-inference) | [`vllm-project/tpu-inference`](https://github.com/vllm-project/tpu-inference) | descriptor SHA (`tpu.toml`) |
+| tpu-inference | [`marin-community/tpu-inference`](https://github.com/marin-community/tpu-inference) | [`vllm-project/tpu-inference`](https://github.com/vllm-project/tpu-inference) | selected transitively by the TPU vLLM release |
 | evalchemy | [`marin-community/evalchemy`](https://github.com/marin-community/evalchemy) | [`mlfoundations/evalchemy`](https://github.com/mlfoundations/evalchemy) | isolated uv lock |
 | harbor | [`marin-community/harbor`](https://github.com/marin-community/harbor) | [`harbor-framework/harbor`](https://github.com/harbor-framework/harbor) | isolated uv lock |
 | MarinSkyRL | [`marin-community/MarinSkyRL`](https://github.com/marin-community/MarinSkyRL) | [`NovaSky-AI/SkyRL`](https://github.com/NovaSky-AI/SkyRL) | isolated uv lock |


### PR DESCRIPTION
Document the recurring TPU vLLM refresh as one public release built from two reviewed fork source tips and selected through #8430's generator. The procedure chooses distinct upstream bases, replays every retained Marin overlay, reviews the resulting exact source tips, and passes those tips rather than bare bases to the producer.

Each migration entry names the Marin fork cloned as `origin` and its separate canonical `upstream`, while both keep the shared `release:vllm/tpu.toml` selector. The TPU path skips branch staging and promotion, freezes the committed Marin consumer before its physical gate, and then rejoins the common review path. A new draft gets one non-blocking metadata, CI, comment, and review snapshot; continued monitoring requires an explicit request.

This restack preserves #8684's XLA/PJRT policy and fork-specific guide split. The generic refresh skill stays generic; TPU source selection, replay, publication, and qualification live in `docs/vllm.md`. MarinSkyRL is explicitly on-demand and remains blocked on its one-time re-fork. Harbor's still-unpromoted catch-up remains outside this PR.

This PR is stacked exactly on #8430 head `0894f64a4c572f16234df20449d87369d9e5625b`; its final head is `bc1a1f0baa7c0d08433cf2a3d59585587811584a`. The generated selector check, focused fork-ferry capacity test, changed-file pre-commit, advisory review, range-diff, and `git diff --check` pass. The TPU smoke command is unchanged from the prior #8431 head.

The August 27 receipt exercised the publisher, immutable wheel metadata, clean and exact-HEAD resolver paths, Marin consumer, and the [TP8 `v6e-8` physical gate](https://iris.oa.dev/#/job/%2Fromain%2Fserved-qwen3-20260827-0352) against [the public prerelease](https://github.com/marin-community/vllm/releases/tag/marin-vllm-tpu-20260827-5b69c198a2cc-e8f28a4ef357-r1). It did not exercise the newly documented newest-stable-base selection and overlay replay. No producer input, wheel byte or metadata, Marin requirement, launcher, or smoke command changed here, so this documentation repair does not require another hardware run.

Landing order: merge [vLLM #52](https://github.com/marin-community/vllm/pull/52), finalize the same release without rebuilding, land #8430 with [tpu-inference #23](https://github.com/marin-community/tpu-inference/pull/23), then land this PR.

Part of #8323.
