### PR TITLE
[loom] Run Slack sessions at medium reasoning effort

### DIFF
--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -114,7 +114,7 @@ config:
       agent: codex
       description: Slack-triggered Marin conversations and repository work
       model: gpt-5.6-sol
-      effort: high
+      effort: medium
       protocol: acp
       mode: auto
       class: interactive


### PR DESCRIPTION
The deployment pins slack.effort to agent-default, so Slack-origin sessions inherit the slack profile's reasoning effort, which was high. Slack threads mostly carry quick questions where a prompt answer matters more than depth, so the profile now declares medium.

The setting reaches production at the next activation; the profile row is overwritten and its revision advances.
