### PR TITLE
[fsutil] Add a show command that pages through parquet rows

### DIFF
--- a/docs/references/fsutil.md
+++ b/docs/references/fsutil.md
@@ -6,11 +6,13 @@ an interactive browser over all of them.
 
 ```bash
 uv run fsutil                        # interactive browser, starting at the bucket list
+uv run fsutil gs://marin-us-central2/scratch   # bare URL: browser on a directory, viewer on a file
 uv run fsutil buckets                # what is declared, and whether credentials are set
 uv run fsutil ls -l gs://marin-us-central2/scratch
 uv run fsutil ls -R gs://marin-us-central2/scratch/checkpoints
 uv run fsutil ls 's3://marin-us-east-02a/*/config.json'
 uv run fsutil cat s3://marin-us-east-02a/iris/my-job/config.json
+uv run fsutil show gs://marin-us-central2/documents/shard-00000.parquet
 uv run fsutil du s3://marin-us-east-02a/iris/my-job
 uv run fsutil usage s3://marin-us-east-02a -o usage-report.md
 uv run fsutil cp -r s3://marin-us-east-02a/iris/my-job/logs /tmp/logs
@@ -65,6 +67,7 @@ that touch its buckets; the rest keep working.
 | `hash URL ... [--hex]` | Stream complete files and print MD5 digests in base64 or hexadecimal |
 | `rm URL ... [-r] [--workers N]` | Remove one or more objects. `-r` or `-R` recursively removes every prefix; remote prefixes delete while they list and show progress |
 | `browse [URL]` | The interactive browser |
+| `show URL` | The interactive viewer on one file; page-down scans through a parquet's rows |
 
 `cp` and `mv` append each source basename when the destination is an existing directory,
 ends in `/`, receives multiple sources, or receives a glob expression. A single literal source
@@ -132,12 +135,14 @@ Formatted file previews are capped at 10 MB after decompression. `cat --raw` is 
 at 10 MB of stored bytes. Use `cp` to fetch a whole object.
 
 A `.parquet` file is read through its footer rather than from the head of the object,
-so `cat`, `head`, and the browser show its schema, its row count, and its first rows.
-`head -n` bounds the rows, not the printed lines. Parquet's smallest readable unit is a
-whole column chunk, so the rows come out of the first row group alone, and a first row
-group that decodes to more than 10 MB is reported instead of read — copy that file to
-read it. The footer itself is read whatever its size, so the 10 MB cap above bounds the
-column data rather than the whole preview.
+so `cat`, `head`, `show`, and the browser show its schema, its row count, and its rows.
+`head -n` bounds the rows, not the printed lines, and `cat` and `head` read from the
+first row group alone. `show` and the browser's viewer instead page through the whole
+file: page-down decodes the next batch of rows, row group by row group. Parquet's
+smallest readable unit is a whole column chunk, so a row group that decodes to more
+than 10 MB is reported and skipped instead of read — copy that file to read it. The
+footer itself is read whatever its size, so the 10 MB cap above bounds the column data
+rather than the whole preview.
 
 Parquet previews need pyarrow in the environment. It is not a `marin-rigging`
 dependency, because rigging sits under every other package, but the marin workspace
@@ -146,7 +151,8 @@ installs it.
 ## The browser
 
 `fsutil browse` starts at the bucket list, so descending into GCS or CoreWeave is the
-same keystroke.
+same keystroke. A bare `fsutil URL` skips the command name: a directory opens in the
+browser and anything else in the viewer.
 
 | Key | Action |
 |-----|--------|
@@ -159,6 +165,10 @@ same keystroke.
 | `y` | Show the highlighted entry's full URL |
 | `r` | Re-list |
 | `q` | Quit, or close the file viewer |
+
+Opening a file — from the browser or with `fsutil show URL` — pages with `j` / `k`,
+page-up / page-down, and `g` / `G`. Paging down a parquet file keeps decoding rows
+until the file ends; other formats show the bounded preview.
 
 ## Where the bucket list comes from
 

--- a/lib/rigging/src/rigging/fsutil/cli.py
+++ b/lib/rigging/src/rigging/fsutil/cli.py
@@ -5,7 +5,8 @@
 
 Every path is a full URL (``gs://``, ``s3://``, or a local path). There is no implicit
 current bucket, so the same command means the same thing from any shell, and a copy can
-name two different backends. Bare ``fsutil`` opens the interactive browser.
+name two different backends. Bare ``fsutil`` opens the interactive browser, and
+``fsutil URL`` opens the browser on a directory or the file viewer on anything else.
 """
 
 import logging
@@ -47,6 +48,7 @@ from rigging.fsutil.transfer import (
     sync_plan,
 )
 from rigging.fsutil.tui import run as run_browser
+from rigging.fsutil.tui import show as show_viewer
 from rigging.fsutil.usage import (
     DEFAULT_PREFIX_DEPTH,
     DEFAULT_USAGE_WORKERS,
@@ -92,13 +94,31 @@ class _ProgressDisplay:
             click.echo(line, err=True)
 
 
-@click.group(invoke_without_command=True)
+class _AutoOpenGroup(click.Group):
+    """A group where a URL in command position opens the browser or the file viewer.
+
+    Only tokens that read as paths — a URL scheme, a slash, or an existing local name —
+    take the fallback, so a mistyped command still fails as one.
+    """
+
+    def resolve_command(self, ctx: click.Context, args: list[str]):
+        try:
+            return super().resolve_command(ctx, args)
+        except click.UsageError:
+            name = args[0]
+            if "://" in name or "/" in name or Path(name).exists():
+                return open_command.name, open_command, args
+            raise
+
+
+@click.group(cls=_AutoOpenGroup, invoke_without_command=True)
 @click.option("-v", "--verbose", is_flag=True, help="Log fsspec/botocore activity.")
 @click.pass_context
 def cli(ctx: click.Context, verbose: bool) -> None:
     """Browse and manipulate Marin's object storage (GCS, CoreWeave, R2).
 
     Paths are full URLs: gs://bucket/key, s3://bucket/key, or a local path.
+    A bare URL opens the browser on a directory or the viewer on a file.
     """
     logging.basicConfig(level=logging.DEBUG if verbose else logging.WARNING)
     if ctx.invoked_subcommand is None:
@@ -430,6 +450,36 @@ def browse(url: str) -> None:
     run_browser(url)
 
 
+@click.command()
+@click.argument("url")
+def show(url: str) -> None:
+    """Open the interactive viewer on one file; page-down scans through a parquet's rows."""
+    fs, path = filesystem_for(url)
+    if fs.isdir(path):
+        raise click.ClickException(f"{url} is a directory; use `fsutil browse {url}`")
+    _run_viewer(url)
+
+
+@click.command("open", hidden=True)
+@click.argument("url")
+def open_command(url: str) -> None:
+    """Open the browser on a directory or the viewer on a file; `fsutil URL` lands here."""
+    fs, path = filesystem_for(url)
+    if fs.isdir(path):
+        run_browser(url)
+        return
+    _run_viewer(url)
+
+
+def _run_viewer(url: str) -> None:
+    try:
+        show_viewer(url)
+    except MissingParquetReader as error:
+        raise click.ClickException(str(error)) from error
+    except FileNotFoundError as error:
+        raise click.ClickException(f"{url}: not found") from error
+
+
 def _print_long_entries(entries: list[Entry]) -> None:
     rows = []
     for entry in entries:
@@ -486,7 +536,24 @@ def _transfer_arguments(urls: tuple[str, ...]) -> tuple[tuple[str, ...], str]:
     return urls[:-1], urls[-1]
 
 
-_COMMANDS = (buckets, list_command, cat, head, stat, du, usage, find, cp, mv, rsync, hash_command, rm, browse)
+_COMMANDS = (
+    buckets,
+    list_command,
+    cat,
+    head,
+    stat,
+    du,
+    usage,
+    find,
+    cp,
+    mv,
+    rsync,
+    hash_command,
+    rm,
+    browse,
+    show,
+    open_command,
+)
 
 for _command in _COMMANDS:
     cli.add_command(_command)

--- a/lib/rigging/src/rigging/fsutil/parquet.py
+++ b/lib/rigging/src/rigging/fsutil/parquet.py
@@ -5,20 +5,44 @@
 
 Parquet keeps its schema and its row-group index in a footer, so the bounded head read
 that serves every other format returns nothing a reader can parse. These helpers seek
-instead: the footer gives the schema and the statistics, and the rows come out of the
-first row group, which is decoded only when it stays inside the preview limit.
+instead: the footer gives the schema and the statistics, and rows decode a row group at
+a time — :func:`parquet_lines` from the first group alone for ``cat`` and ``head``, and
+:class:`ParquetViewSource` batch by batch as the interactive viewer pages forward. A
+row group above the preview limit is reported instead of decoded either way.
 """
 
 from rigging.filesystem.buckets import filesystem_for
 from rigging.fsutil.listing import MAX_PREVIEW_BYTES
-from rigging.fsutil.render import aligned_lines, format_size, record_lines, table_lines
+from rigging.fsutil.render import (
+    aligned_lines,
+    cell,
+    column_widths,
+    format_size,
+    header_lines,
+    record_lines,
+    row_line,
+    table_lines,
+)
 
 # Rows rendered when the caller asks for no particular count.
 PREVIEW_ROWS = 20
 
+# Rows decoded per fetch when the interactive viewer pages through a file.
+VIEW_BATCH_ROWS = 100
+
 
 class MissingParquetReader(RuntimeError):
     """Raised when a preview runs where no parquet reader is installed."""
+
+
+def _pyarrow_parquet():
+    # pyarrow is deliberately absent from marin-rigging's dependencies: rigging sits under
+    # every other package, and one more requirement there re-resolves the workspace lock.
+    try:
+        import pyarrow.parquet as pq  # noqa: PLC0415  # optional dep
+    except ImportError as exc:
+        raise MissingParquetReader("reading parquet requires pyarrow; install it with `pip install pyarrow`") from exc
+    return pq
 
 
 def is_parquet(name: str) -> bool:
@@ -32,13 +56,7 @@ def is_parquet(name: str) -> bool:
 
 def parquet_lines(url: str, rows: int = PREVIEW_ROWS) -> list[str]:
     """Render *url* as its schema, its footer statistics, and its first *rows* rows."""
-    # pyarrow is deliberately absent from marin-rigging's dependencies: rigging sits under
-    # every other package, and one more requirement there re-resolves the workspace lock.
-    try:
-        import pyarrow.parquet as pq  # noqa: PLC0415  # optional dep
-    except ImportError as exc:
-        raise MissingParquetReader("reading parquet requires pyarrow; install it with `pip install pyarrow`") from exc
-
+    pq = _pyarrow_parquet()
     fs, path = filesystem_for(url)
     file_size = fs.size(path)
     with fs.open(path, "rb") as file:
@@ -91,3 +109,81 @@ def _row_lines(parquet_file, metadata, rows: int) -> list[str]:
     if metadata.num_rows > batch.num_rows:
         lines.append(f"[showing {batch.num_rows} of {metadata.num_rows} rows]")
     return lines
+
+
+class ParquetViewSource:
+    """Feeds the interactive viewer one batch of parquet rows at a time.
+
+    The viewer scans forward, so rows decode row group by row group and never hold more
+    than one batch. A row group above the preview limit is reported and skipped rather
+    than decoded, because parquet's smallest readable unit is a column chunk. Column
+    widths freeze on the first batch so later batches align with the rendered header.
+    """
+
+    def __init__(self, url: str, batch_rows: int = VIEW_BATCH_ROWS):
+        pq = _pyarrow_parquet()
+        fs, path = filesystem_for(url)
+        self._file_size = fs.size(path)
+        self._file = fs.open(path, "rb")
+        self._parquet = pq.ParquetFile(self._file)
+        self._batch_rows = batch_rows
+        self._headers = [field.name for field in self._parquet.schema_arrow]
+        self._widths: list[int] | None = None
+        self._group = 0
+        self._batches = None
+        self._rows_rendered = 0
+        self._finished = False
+
+    def __enter__(self) -> "ParquetViewSource":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self._file.close()
+
+    def head_lines(self) -> list[str]:
+        """The schema and footer statistics shown above the rows."""
+        metadata = self._parquet.metadata
+        return [
+            "schema:",
+            *_schema_lines(self._parquet.schema_arrow),
+            "",
+            *_summary_lines(metadata, self._file_size),
+            "",
+        ]
+
+    def more_lines(self) -> list[str]:
+        """Render the next batch of rows, then a closing marker, then nothing."""
+        metadata = self._parquet.metadata
+        while not self._finished:
+            if self._batches is not None:
+                batch = next(self._batches, None)
+                if batch is not None:
+                    return self._render(batch)
+                self._batches = None
+                self._group += 1
+            if self._group >= metadata.num_row_groups:
+                self._finished = True
+                if self._rows_rendered == metadata.num_rows:
+                    return [f"[end of {metadata.num_rows} rows]"]
+                return [f"[end: showed {self._rows_rendered} of {metadata.num_rows} rows]"]
+            group = metadata.row_group(self._group)
+            if group.total_byte_size > MAX_PREVIEW_BYTES:
+                skipped = self._group
+                self._group += 1
+                return [
+                    f"[row group {skipped} not read: {format_size(group.total_byte_size)} uncompressed, "
+                    f"above the {format_size(MAX_PREVIEW_BYTES)} preview limit]"
+                ]
+            self._batches = self._parquet.iter_batches(batch_size=self._batch_rows, row_groups=[self._group])
+        return []
+
+    def _render(self, batch) -> list[str]:
+        rows = [[cell(record.get(header)) for header in self._headers] for record in batch.to_pylist()]
+        self._rows_rendered += len(rows)
+        if self._widths is None:
+            self._widths = column_widths(self._headers, rows)
+            return [*header_lines(self._headers, self._widths), *(row_line(row, self._widths) for row in rows)]
+        return [row_line(row, self._widths) for row in rows]

--- a/lib/rigging/src/rigging/fsutil/render.py
+++ b/lib/rigging/src/rigging/fsutil/render.py
@@ -79,7 +79,7 @@ def _json_lines(name: str, text: str) -> list[str]:
 def record_lines(records: list[dict]) -> list[str]:
     """Render records as a table with a column per key, truncating oversized cells."""
     headers = list({key: None for row in records for key in row})
-    rows = [[_cell(row.get(header)) for header in headers] for row in records]
+    rows = [[cell(row.get(header)) for header in headers] for row in records]
     return table_lines(headers, rows)
 
 
@@ -88,23 +88,37 @@ def _json_table_lines(data: object) -> list[str]:
     if isinstance(data, list) and data and all(isinstance(row, dict) for row in data):
         return record_lines(data)
     if isinstance(data, dict):
-        return table_lines(["key", "value"], [[key, _cell(value)] for key, value in data.items()])
+        return table_lines(["key", "value"], [[key, cell(value)] for key, value in data.items()])
     return json.dumps(data, indent=2, default=str).splitlines()
 
 
-def _cell(value: object) -> str:
+def cell(value: object) -> str:
+    """Render one value as a single table cell, truncating oversized text."""
     text = value if isinstance(value, str) else json.dumps(value, default=str)
     return text if len(text) <= _MAX_CELL else text[: _MAX_CELL - 3] + "..."
 
 
-def table_lines(headers: list[str], rows: list[list[str]]) -> list[str]:
-    """Render rows as a plain-text table with a header separator."""
-    widths = [
+def column_widths(headers: list[str], rows: list[list[str]]) -> list[int]:
+    """The width of each column when *rows* render under *headers*."""
+    return [
         max(len(header), *(len(row[i]) for row in rows)) if rows else len(header) for i, header in enumerate(headers)
     ]
-    lines = [_row(headers, widths), _row(["-" * width for width in widths], widths)]
-    lines.extend(_row(row, widths) for row in rows)
-    return lines
+
+
+def header_lines(headers: list[str], widths: list[int]) -> list[str]:
+    """The header row and its separator, padded to *widths*."""
+    return [row_line(headers, widths), row_line(["-" * width for width in widths], widths)]
+
+
+def row_line(cells: list[str], widths: list[int]) -> str:
+    """One table row padded to *widths*; a longer cell overflows its column."""
+    return "  ".join(text.ljust(width) for text, width in zip(cells, widths, strict=True)).rstrip()
+
+
+def table_lines(headers: list[str], rows: list[list[str]]) -> list[str]:
+    """Render rows as a plain-text table with a header separator."""
+    widths = column_widths(headers, rows)
+    return [*header_lines(headers, widths), *(row_line(row, widths) for row in rows)]
 
 
 def aligned_lines(rows: list[list[str]]) -> list[str]:
@@ -112,8 +126,4 @@ def aligned_lines(rows: list[list[str]]) -> list[str]:
     if not rows:
         return []
     widths = [max(len(row[i]) for row in rows) for i in range(len(rows[0]))]
-    return [_row(row, widths) for row in rows]
-
-
-def _row(cells: list[str], widths: list[int]) -> str:
-    return "  ".join(cell.ljust(width) for cell, width in zip(cells, widths, strict=True)).rstrip()
+    return [row_line(row, widths) for row in rows]

--- a/lib/rigging/src/rigging/fsutil/tui.py
+++ b/lib/rigging/src/rigging/fsutil/tui.py
@@ -1,11 +1,13 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""The interactive ``fsutil browse`` screen.
+"""The interactive ``fsutil browse`` and ``fsutil show`` screens.
 
 A curses browser over the whole bucket tree: the root lists every declared bucket, and
-descending crosses backends without ceremony because each listing routes itself. Reads
-are bounded by the same preview cap the CLI uses, so opening a file is always cheap.
+descending crosses backends without ceremony because each listing routes itself.
+``show`` opens the same file viewer on one URL without the browser around it. Opening a
+file reads at most the CLI's preview cap; a parquet file can page past it, but only one
+batch of rows decodes per page-down, so each read stays cheap.
 """
 
 import curses

--- a/lib/rigging/src/rigging/fsutil/tui.py
+++ b/lib/rigging/src/rigging/fsutil/tui.py
@@ -9,15 +9,17 @@ are bounded by the same preview cap the CLI uses, so opening a file is always ch
 """
 
 import curses
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from rigging.filesystem.buckets import MissingCredentials
+from rigging.filesystem.storage_path import StoragePath
 from rigging.fsutil.listing import ROOT, Entry, list_entries, parent_url, read_decompressed_preview, total_size
-from rigging.fsutil.parquet import is_parquet, parquet_lines
+from rigging.fsutil.parquet import ParquetViewSource, is_parquet
 from rigging.fsutil.render import file_lines, format_size, format_time
 
 _HELP = "[enter] open  [backspace] up  [/] filter  [s] sort  [d] size  [y] print URL  [q] quit"
-_VIEWER_HELP = "[q] close  [j/k] scroll  [g/G] top/bottom"
+_VIEWER_HELP = "[q] close  [j/k] scroll  [g/G] top/bottom  [pgup/pgdn] page"
 
 # Sort orders cycled by `s`, in cycle order.
 _SORTS = ("name", "size", "modified")
@@ -51,6 +53,18 @@ class Screen:
 def run(url: str = ROOT) -> None:
     """Open the browser at *url* and block until the user quits."""
     curses.wrapper(lambda stdscr: _loop(stdscr, url))
+
+
+def show(url: str) -> None:
+    """Open the standalone file viewer on *url* and block until the user quits."""
+
+    def _show(stdscr: "curses.window") -> None:
+        curses.curs_set(0)
+        curses.use_default_colors()
+        curses.init_pair(1, curses.COLOR_CYAN, -1)
+        _view_url(stdscr, StoragePath(url).name, url)
+
+    curses.wrapper(_show)
 
 
 def _loop(stdscr: "curses.window", url: str) -> None:
@@ -133,19 +147,23 @@ def _open(stdscr: "curses.window", screen: Screen) -> None:
         return
 
     try:
-        if is_parquet(selected.name):
-            # Parquet is read through its footer rather than from the head of the object,
-            # so it takes the URL and reports its own limits in the rendered lines.
-            lines = parquet_lines(selected.url)
-            truncated_bytes = None
-        else:
-            preview = read_decompressed_preview(selected.url)
-            lines = file_lines(selected.name, preview.data)
-            truncated_bytes = len(preview.data) if preview.truncated else None
+        _view_url(stdscr, selected.name, selected.url)
     except Exception as e:
         screen.status = f"error: {e}"
+
+
+def _view_url(stdscr: "curses.window", name: str, url: str) -> None:
+    """Open the pager on one file, paging parquet rows in on demand."""
+    if is_parquet(name):
+        # Parquet is read through its footer rather than from the head of the object;
+        # the source decodes one batch of rows per fetch as the viewer pages down.
+        with ParquetViewSource(url) as source:
+            lines = [*source.head_lines(), *source.more_lines()]
+            _view(stdscr, name, lines, None, more=source.more_lines)
         return
-    _view(stdscr, selected.name, lines, truncated_bytes)
+    preview = read_decompressed_preview(url)
+    lines = file_lines(name, preview.data)
+    _view(stdscr, name, lines, len(preview.data) if preview.truncated else None)
 
 
 def _measure(stdscr: "curses.window", screen: Screen) -> None:
@@ -191,8 +209,18 @@ def _draw(stdscr: "curses.window", screen: Screen) -> None:
     stdscr.refresh()
 
 
-def _view(stdscr: "curses.window", name: str, lines: list[str], truncated_bytes: int | None) -> None:
-    """Scrollable read-only pager for one file's rendered lines."""
+def _view(
+    stdscr: "curses.window",
+    name: str,
+    lines: list[str],
+    truncated_bytes: int | None,
+    more: Callable[[], list[str]] | None = None,
+) -> None:
+    """Scrollable read-only pager for one file's rendered lines.
+
+    Paging down past the loaded lines pulls the next batch from *more* until it comes
+    back empty, so a parquet file streams in as the user scans it.
+    """
     scroll = 0
     while True:
         stdscr.erase()
@@ -200,7 +228,7 @@ def _view(stdscr: "curses.window", name: str, lines: list[str], truncated_bytes:
         body_height = max(1, height - 3)
 
         stdscr.addnstr(0, 0, name, width - 1, curses.color_pair(1) | curses.A_BOLD)
-        subtitle = f"{len(lines)} lines"
+        subtitle = f"{len(lines)} lines" + ("  (more below)" if more is not None else "")
         if truncated_bytes is not None:
             subtitle += f"  preview truncated at {format_size(truncated_bytes)}"
         stdscr.addnstr(1, 0, subtitle, width - 1, curses.A_DIM)
@@ -210,10 +238,17 @@ def _view(stdscr: "curses.window", name: str, lines: list[str], truncated_bytes:
         stdscr.refresh()
 
         key = stdscr.getch()
-        max_scroll = max(0, len(lines) - body_height)
         if key in (ord("q"), 27, curses.KEY_BACKSPACE, 127, 8, curses.KEY_LEFT, ord("h")):
             return
-        elif key in (curses.KEY_DOWN, ord("j")):
+        if key in (curses.KEY_NPAGE, curses.KEY_DOWN, ord("j")):
+            while more is not None and len(lines) < scroll + 2 * body_height:
+                fetched = more()
+                if fetched:
+                    lines.extend(fetched)
+                else:
+                    more = None
+        max_scroll = max(0, len(lines) - body_height)
+        if key in (curses.KEY_DOWN, ord("j")):
             scroll = min(max_scroll, scroll + 1)
         elif key in (curses.KEY_UP, ord("k")):
             scroll = max(0, scroll - 1)

--- a/lib/rigging/tests/test_fsutil.py
+++ b/lib/rigging/tests/test_fsutil.py
@@ -653,6 +653,38 @@ def test_cat_reports_full_size_when_uncompressed_preview_is_truncated(tmp_path, 
     assert result.stderr == "[truncated: read 4 B of 6 B]\n"
 
 
+def test_bare_url_opens_browser_for_directories_and_viewer_for_files(tree, monkeypatch):
+    """A URL in command position needs no command name: directories open in the
+    browser and files in the viewer."""
+    opened = []
+    monkeypatch.setattr(cli_module, "run_browser", lambda url: opened.append(("browse", url)))
+    monkeypatch.setattr(cli_module, "show_viewer", lambda url: opened.append(("show", url)))
+
+    assert CliRunner().invoke(cli, [str(tree)]).exit_code == 0
+    assert CliRunner().invoke(cli, [str(tree / "b.txt")]).exit_code == 0
+    assert opened == [("browse", str(tree)), ("show", str(tree / "b.txt"))]
+
+
+def test_command_typos_still_fail_as_commands(tmp_path, monkeypatch):
+    """Only path-shaped tokens take the URL fallback, so a mistyped command name is
+    reported rather than opened as a missing file."""
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["catt"])
+
+    assert result.exit_code != 0
+    assert "No such command" in result.output
+
+
+def test_show_rejects_directories(tree):
+    """The viewer holds one file; a directory belongs to the browser, and saying so
+    beats opening curses on an unreadable path."""
+    result = CliRunner().invoke(cli, ["show", str(tree)])
+
+    assert result.exit_code != 0
+    assert "use `fsutil browse" in result.output
+
+
 def test_ls_long_renders_local_directory(tree):
     result = CliRunner().invoke(cli, ["ls", "-l", str(tree)])
 

--- a/lib/rigging/tests/test_fsutil_parquet.py
+++ b/lib/rigging/tests/test_fsutil_parquet.py
@@ -11,7 +11,7 @@ import pytest
 from click.testing import CliRunner
 from rigging.fsutil import parquet
 from rigging.fsutil.cli import cli
-from rigging.fsutil.parquet import parquet_lines
+from rigging.fsutil.parquet import ParquetViewSource, parquet_lines
 
 pa = pytest.importorskip("pyarrow")
 pq = pytest.importorskip("pyarrow.parquet")
@@ -46,6 +46,45 @@ def test_parquet_preview_skips_rows_when_the_first_row_group_is_too_large(shard,
 
     assert lines[-1].startswith("[rows not read: row group 0 holds ")
     assert not any("row 0" in line for line in lines)
+
+
+def test_view_source_pages_rows_across_row_groups(shard):
+    """The viewer scans forward one batch at a time: a fetch never decodes past its
+    batch, row groups chain seamlessly, and the file closes with an end marker."""
+    with ParquetViewSource(str(shard), batch_rows=2) as source:
+        assert "rows        6" in source.head_lines()
+
+        first = source.more_lines()
+        assert first[0].split() == ["step", "text"]
+        assert [line.split() for line in first[2:]] == [["0", "row", "0"], ["1", "row", "1"]]
+
+        remaining = [source.more_lines() for _ in range(4)]
+        rendered = [line for batch in remaining[:3] for line in batch]
+        assert [line.split()[0] for line in rendered] == ["2", "3", "4", "5"]
+        assert remaining[3] == ["[end of 6 rows]"]
+        assert source.more_lines() == []
+
+
+def test_view_source_keeps_first_batch_column_widths(shard):
+    """Later batches pad to the widths of the first, so the table stays aligned as the
+    viewer appends lines without re-rendering what is already on screen."""
+    with ParquetViewSource(str(shard), batch_rows=3) as source:
+        first = source.more_lines()
+        second = source.more_lines()
+    assert second[0].index("row 3") == first[2].index("row 0")
+
+
+def test_view_source_skips_oversized_row_groups(shard, monkeypatch):
+    """A row group above the preview limit is reported and stepped over, and the end
+    marker admits the rows that were never shown."""
+    monkeypatch.setattr(parquet, "MAX_PREVIEW_BYTES", 8)
+
+    with ParquetViewSource(str(shard)) as source:
+        batches = [source.more_lines() for _ in range(3)]
+
+    assert batches[0][0].startswith("[row group 0 not read: ")
+    assert batches[1][0].startswith("[row group 1 not read: ")
+    assert batches[2] == ["[end: showed 0 of 6 rows]"]
 
 
 def test_cat_and_head_route_parquet_to_the_footer_reader(shard):


### PR DESCRIPTION
`fsutil show URL` opens the interactive file viewer directly, and a bare
`fsutil URL` opens the browser on a directory or the viewer on a file. Only
path-shaped tokens (a scheme, a slash, or an existing local name) take the
bare-URL fallback, so a mistyped command still fails as an unknown command.

The viewer previously showed only a parquet file's first 20 rows. Page-down
now decodes the next 100-row batch, row group by row group, holding one batch
at a time and skipping any row group above the 10 MB preview limit. Column
widths freeze on the first batch so appended rows stay aligned with the
rendered header. The browser's enter-to-preview path uses the same paging
viewer; text and tabular JSON/JSONL keep the bounded preview.
