### PR TITLE
[grug] Bound hero TensorStore read locality

### DIFF
--- a/experiments/grug/dispatch.py
+++ b/experiments/grug/dispatch.py
@@ -27,7 +27,7 @@ PRODUCTION_PRIORITY = priority_band_value("production")
 # given (e.g. `iris job run -e XLA_FLAGS ...`) must be re-exported explicitly.
 # JAX_PLATFORMS is excluded: the dispatcher runs CPU-only and its value must
 # not leak onto accelerator tasks.
-_FORWARDED_ENV_PREFIXES = ("XLA_", "LIBTPU_INIT_ARGS", "NCCL_", "JAX_")
+_FORWARDED_ENV_PREFIXES = ("XLA_", "LIBTPU_INIT_ARGS", "NCCL_", "JAX_", "LEVANTER_")
 _FORWARDED_ENV_EXCLUDE = ("JAX_PLATFORMS",)
 
 

--- a/experiments/grug/dispatch.py
+++ b/experiments/grug/dispatch.py
@@ -27,7 +27,7 @@ PRODUCTION_PRIORITY = priority_band_value("production")
 # given (e.g. `iris job run -e XLA_FLAGS ...`) must be re-exported explicitly.
 # JAX_PLATFORMS is excluded: the dispatcher runs CPU-only and its value must
 # not leak onto accelerator tasks.
-_FORWARDED_ENV_PREFIXES = ("XLA_", "LIBTPU_INIT_ARGS", "NCCL_", "JAX_", "LEVANTER_")
+_FORWARDED_ENV_PREFIXES = ("XLA_", "LIBTPU_INIT_ARGS", "NCCL_", "JAX_")
 _FORWARDED_ENV_EXCLUDE = ("JAX_PLATFORMS",)
 
 
@@ -51,6 +51,7 @@ def dispatch_grug_training_run(
     max_retries_failure: int = 3,
     processes_per_task: int = 1,
     priority: int = INHERIT_PRIORITY,
+    env_vars: dict[str, str] | None = None,
 ) -> None:
     """Submit a grug train entrypoint through Fray and wait for completion.
 
@@ -58,12 +59,14 @@ def dispatch_grug_training_run(
     not itself an Iris job -- which is the case for a launcher run from a dev box.
     """
     safe_run_id = _safe_job_suffix(run_id)
-    env_vars = resolve_training_env(base_env=_forwarded_env_vars(), resources=resources)
+    base_env = _forwarded_env_vars()
+    base_env.update(env_vars or {})
+    training_env = resolve_training_env(base_env=base_env, resources=resources)
     request = JobRequest(
         name=f"grug-train-{safe_run_id}",
         entrypoint=Entrypoint.from_callable(local_entrypoint, args=[config]),
         resources=resources,
-        environment=create_environment(env_vars=env_vars, extras=extras_for_resources(resources)),
+        environment=create_environment(env_vars=training_env, extras=extras_for_resources(resources)),
         max_retries_failure=max_retries_failure,
         max_task_failures=10,
         processes_per_task=processes_per_task,

--- a/experiments/grug/moe_hero_ep/harrier_mix_2026_08_18.py
+++ b/experiments/grug/moe_hero_ep/harrier_mix_2026_08_18.py
@@ -13,13 +13,14 @@ eight-epoch cap still holds.
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import math
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from levanter.data.text.datasets import DatasetComponent, LmDataConfig
+from levanter.data.text.datasets import BlockShuffleConfig, DatasetComponent, LmDataConfig
 from levanter.data.text.formats import TextLmDatasetFormat
 from marin.execution.lazy import ArtifactStep, StepContext
 from marin.processing.tokenize.tokenize import TokenizedCache
@@ -41,6 +42,7 @@ HARRIER_MIX_2026_08_18_TAG = "harrier-mix-2026.08.18"
 # training-FLOP budget the run is expensive enough that we want maximally-real data over a simulated
 # larger run, so it trains on the raw mixture instead.
 SIMULATED_EPOCHING_MAX_FLOPS = 1e23
+_SHUFFLE = BlockShuffleConfig(io_block_size=256, window_blocks=8, perm_type="feistel")
 
 HARRIER_MIX_2026_08_18_STORE = ArtifactStep.adopt(
     "datakit/store/harrier-all-sources-k40-q5-fuzzy-dedup-exempt16",
@@ -144,12 +146,15 @@ def harrier_mix_2026_08_18_data_config(
         enable_simulated_epoching=experiment_flops <= SIMULATED_EPOCHING_MAX_FLOPS,
     )
 
-    return _two_phase_data_config(
-        tokenizer=marin_tokenizer,
-        components=components,
-        phase_weights=phase_weights,
-        phase_1_start=_phase_1_start_step(total_steps, batch_size),
-        val_components=val_components,
-        target_budget=target_budget,
-        experiment_budget=experiment_budget,
+    return dataclasses.replace(
+        _two_phase_data_config(
+            tokenizer=marin_tokenizer,
+            components=components,
+            phase_weights=phase_weights,
+            phase_1_start=_phase_1_start_step(total_steps, batch_size),
+            val_components=val_components,
+            target_budget=target_budget,
+            experiment_budget=experiment_budget,
+        ),
+        shuffle=_SHUFFLE,
     )

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -83,6 +83,7 @@ WATCH_INTERVAL = 10
 # 791 tokens per active parameter sets the step budget: it lands the d6144 hero at 18T tokens and
 # scales every narrower rung by the same ratio.
 TOKENS_PER_ACTIVE_PARAM = 791
+TENSORSTORE_CACHE_BYTES = 10_000_000_000
 
 
 def _ladder_model(size: str):
@@ -258,6 +259,7 @@ def build_ladder_run(
                 validation=validation,
             ),
             resources=ctx.runtime_arg("train_resources"),
+            tensorstore_cache_bytes=TENSORSTORE_CACHE_BYTES,
             optimizer=optimizer,
             trainer=dataclasses.replace(grug_trainer, trainer=trainer),
             eval=GrugEvalConfig(

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -56,6 +56,7 @@ logger = logging.getLogger(__name__)
 
 HERO_EP_RUNTIME_ENV = {
     "JAX_ENABLE_PGLE": "false",
+    "LEVANTER_TS_CACHE_LIMIT": "10000000000",
     "XLA_PJRT_GPU_HOST_MEMORY_LIMIT_GB": "192",
     "XLA_PYTHON_CLIENT_ALLOCATOR": "cuda_async",
 }
@@ -214,10 +215,10 @@ def build_train_loader(
     return DataLoader(
         dataset,
         batch_schedule.schedule,
-        max_buffered_batches=512,
+        max_buffered_batches=128,
         mesh=mesh,
         axis_resources={"__BATCH__": _BATCH_AXES},
-        prefetch_size=256,
+        prefetch_size=32,
         batch_axis_name="__BATCH__",
         allow_nondivisible_batch_size=False,
     )

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -938,10 +938,11 @@ def run_grug(config: GrugRunConfig) -> None:
     if trainer.id is None:
         raise ValueError("trainer.id must be set before dispatching grug training.")
 
+    env_vars: dict[str, str] = {}
     if config.tensorstore_cache_bytes is not None:
         if config.tensorstore_cache_bytes <= 0:
             raise ValueError("tensorstore_cache_bytes must be positive")
-        os.environ["LEVANTER_TS_CACHE_LIMIT"] = str(config.tensorstore_cache_bytes)
+        env_vars["LEVANTER_TS_CACHE_LIMIT"] = str(config.tensorstore_cache_bytes)
 
     # Dispatch snapshots os.environ for the child task, so apply the hero defaults first.
     inline_watch_enabled = trainer.watch.is_enabled and config.trainer.watch_mode == WatchMode.INLINE
@@ -958,6 +959,7 @@ def run_grug(config: GrugRunConfig) -> None:
         # a failure that lands late therefore discards the whole run and repeats it. Make failures
         # terminal and keep the written checkpoint; preemption retries are a separate counter.
         max_retries_failure=0,
+        env_vars=env_vars,
     )
 
 

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -56,7 +56,6 @@ logger = logging.getLogger(__name__)
 
 HERO_EP_RUNTIME_ENV = {
     "JAX_ENABLE_PGLE": "false",
-    "LEVANTER_TS_CACHE_LIMIT": "10000000000",
     "XLA_PJRT_GPU_HOST_MEMORY_LIMIT_GB": "192",
     "XLA_PYTHON_CLIENT_ALLOCATOR": "cuda_async",
 }
@@ -164,6 +163,7 @@ class GrugRunConfig:
     model: GrugModelConfig
     data: LmDataConfig
     resources: ResourceConfig
+    tensorstore_cache_bytes: int | None = None
     optimizer: OptimizerConfig = field(default_factory=AdamConfig)
     trainer: GrugTrainerConfig = field(default_factory=GrugTrainerConfig)
     eval: GrugEvalConfig | None = field(default_factory=GrugEvalConfig)
@@ -937,6 +937,11 @@ def run_grug(config: GrugRunConfig) -> None:
     trainer = config.trainer.trainer
     if trainer.id is None:
         raise ValueError("trainer.id must be set before dispatching grug training.")
+
+    if config.tensorstore_cache_bytes is not None:
+        if config.tensorstore_cache_bytes <= 0:
+            raise ValueError("tensorstore_cache_bytes must be positive")
+        os.environ["LEVANTER_TS_CACHE_LIMIT"] = str(config.tensorstore_cache_bytes)
 
     # Dispatch snapshots os.environ for the child task, so apply the hero defaults first.
     inline_watch_enabled = trainer.watch.is_enabled and config.trainer.watch_mode == WatchMode.INLINE

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -184,7 +184,7 @@ def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch)
         processes_per_task=1,
     )
 
-    with patch.object(train, "dispatch_grug_training_run"):
+    with patch.object(train, "dispatch_grug_training_run") as dispatch:
         train.run_grug(config)
 
     flags = os.environ["XLA_FLAGS"].split()
@@ -193,9 +193,9 @@ def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch)
     assert "--xla_gpu_enable_latency_hiding_scheduler=true" in flags
     assert train.XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG in flags
     assert os.environ["JAX_ENABLE_PGLE"] == "false"
-    assert os.environ["LEVANTER_TS_CACHE_LIMIT"] == "10000000000"
     assert os.environ["XLA_PJRT_GPU_HOST_MEMORY_LIMIT_GB"] == "192"
     assert os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] == "cuda_async"
+    assert dispatch.call_args.kwargs["env_vars"] == {"LEVANTER_TS_CACHE_LIMIT": "10000000000"}
 
 
 def test_run_grug_defaults_pgle_off_for_per_gpu_processes(monkeypatch):

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -175,6 +175,7 @@ def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch)
     for name in train.HERO_EP_RUNTIME_ENV:
         monkeypatch.delenv(name, raising=False)
     config = SimpleNamespace(
+        tensorstore_cache_bytes=10_000_000_000,
         trainer=SimpleNamespace(
             trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=1)),
             watch_mode=train.WatchMode.INLINE,
@@ -206,6 +207,7 @@ def test_run_grug_defaults_pgle_off_for_per_gpu_processes(monkeypatch):
         monkeypatch.delenv(name, raising=False)
     monkeypatch.delenv("XLA_FLAGS", raising=False)
     config = SimpleNamespace(
+        tensorstore_cache_bytes=None,
         trainer=SimpleNamespace(
             trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=1)),
             watch_mode=train.WatchMode.INLINE,
@@ -230,6 +232,7 @@ def test_run_grug_keeps_explicit_ep_runtime_values(monkeypatch):
     monkeypatch.setenv("XLA_PYTHON_CLIENT_ALLOCATOR", "platform")
     monkeypatch.delenv("XLA_FLAGS", raising=False)
     config = SimpleNamespace(
+        tensorstore_cache_bytes=None,
         trainer=SimpleNamespace(
             trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=1)),
             watch_mode=train.WatchMode.INLINE,
@@ -258,6 +261,7 @@ def test_run_grug_reduces_collective_overlap_only_for_inline_watch(
 ):
     monkeypatch.delenv("XLA_FLAGS", raising=False)
     config = SimpleNamespace(
+        tensorstore_cache_bytes=None,
         trainer=SimpleNamespace(
             trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=watch_interval)),
             watch_mode=watch_mode,

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -192,6 +192,7 @@ def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch)
     assert "--xla_gpu_enable_latency_hiding_scheduler=true" in flags
     assert train.XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG in flags
     assert os.environ["JAX_ENABLE_PGLE"] == "false"
+    assert os.environ["LEVANTER_TS_CACHE_LIMIT"] == "10000000000"
     assert os.environ["XLA_PJRT_GPU_HOST_MEMORY_LIMIT_GB"] == "192"
     assert os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] == "cuda_async"
 

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -17,11 +17,13 @@ import jmp
 import numpy as np
 import optax
 import pytest
+from fray.cluster import ResourceConfig
 from jax.sharding import AbstractMesh, AxisType, Mesh, NamedSharding, set_mesh, use_abstract_mesh
 from jax.sharding import PartitionSpec as P
 from levanter.callbacks.watch import WatchConfig, compute_watch_stats
 from marin.execution.lazy import StepContext
 
+from experiments.grug import dispatch as grug_dispatch
 from experiments.grug.moe_hero_ep import grugmuon_hero, model, train
 from experiments.grug.moe_hero_ep import launch_mfu_test as launch
 from experiments.grug.moe_hero_ep import small_scale_abl_launch as abl
@@ -174,17 +176,24 @@ def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch)
     monkeypatch.setenv("XLA_FLAGS", explicit_overlap)
     for name in train.HERO_EP_RUNTIME_ENV:
         monkeypatch.delenv(name, raising=False)
+    requests = []
+
+    class Client:
+        def submit(self, request):
+            requests.append(request)
+            return SimpleNamespace(wait=lambda **_kwargs: None)
+
     config = SimpleNamespace(
         tensorstore_cache_bytes=10_000_000_000,
         trainer=SimpleNamespace(
             trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=1)),
             watch_mode=train.WatchMode.INLINE,
         ),
-        resources=object(),
+        resources=ResourceConfig.with_cpu(),
         processes_per_task=1,
     )
 
-    with patch.object(train, "dispatch_grug_training_run") as dispatch:
+    with patch.object(grug_dispatch, "current_client", return_value=Client()):
         train.run_grug(config)
 
     flags = os.environ["XLA_FLAGS"].split()
@@ -195,7 +204,7 @@ def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch)
     assert os.environ["JAX_ENABLE_PGLE"] == "false"
     assert os.environ["XLA_PJRT_GPU_HOST_MEMORY_LIMIT_GB"] == "192"
     assert os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] == "cuda_async"
-    assert dispatch.call_args.kwargs["env_vars"] == {"LEVANTER_TS_CACHE_LIMIT": "10000000000"}
+    assert requests[0].environment.env_vars["LEVANTER_TS_CACHE_LIMIT"] == "10000000000"
 
 
 def test_run_grug_defaults_pgle_off_for_per_gpu_processes(monkeypatch):


### PR DESCRIPTION
Give each scaling-ladder training process a fingerprinted 10 GB TensorStore cache and use a 256-sample I/O block with an eight-block Feistel shuffle window for the 2026.08.18 Harrier mix. With 4,096-token int32 samples, this bounds the per-component shuffle working set to 32 MiB, or 6.25 GiB across the 200 training cells; the inherited 512-block window exposed roughly 400 GiB against the previous 1 GB cache.

Reduce hero loader refills from 256 to 32 batches and retain four refills in the buffer. The [256-batch run](https://wandb.ai/marin-community/marin_moe/runs/rav-ladder-d768-v2-semantic-pi-56rows-candidate1-pr8427) saw 431–1,347 second cold refills, while the [32-batch baseline](https://wandb.ai/marin-community/marin_moe/runs/rav-ladder-d768-v2) had similar steady training throughput. This reduces each rank's refill from 16,384 to 2,048 sample reads. The combined cache and locality configuration has not yet been benchmarked.

The cache limit travels through explicit Grug run configuration into the worker environment.
