### PR TITLE
[grug] Run scaling ladder with one process per GPU

### DIFF
--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -268,6 +268,7 @@ def build_ladder_run(
                 dropless_eval=True,
             ),
             stop_after_steps=num_steps,
+            processes_per_task=HERO_GPUS_PER_NODE,
         )
 
     return ArtifactStep(


### PR DESCRIPTION
Run each scaling-ladder GPU in its own JAX process by setting the task process count from the four-GPU node shape.

#8209 established per-GPU processes for the EP hero after one-process-per-node runs hit PGLE profiling collisions and a recompile wedge. #8407 added the scaling ladder without carrying that setting, so ladder jobs currently launch 16 four-GPU processes instead of 64 one-GPU processes.

The existing multi-controller path disables PGLE by default and keeps each node's processes in one pod for NVLink.
