### PR TITLE
[levanter] Restore checkpoints that hold pinned-host state

### DIFF
--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -659,7 +659,9 @@ def _sharding_from_leaf(leaf, axis_mapping, mesh) -> Optional[jax.sharding.Shard
                 concrete_mesh = get_concrete_mesh()
 
             if concrete_mesh is not None and not concrete_mesh.empty:
-                return jax.sharding.NamedSharding(concrete_mesh, sharding.spec)
+                # Preserve memory_kind: an offloaded run's leaves carry `pinned_host`, and dropping it
+                # here would silently reload the state into device memory.
+                return jax.sharding.NamedSharding(concrete_mesh, sharding.spec, memory_kind=sharding.memory_kind)
         return sharding
 
     if is_named_array(leaf):
@@ -679,6 +681,45 @@ def _sharding_from_leaf(leaf, axis_mapping, mesh) -> Optional[jax.sharding.Shard
 
 def _fully_replicated_sharding(mesh):
     return hax.partitioning.sharding_for_axis((), {}, mesh)
+
+
+def _device_shardings_for_load(shardings: list) -> tuple[list, list]:
+    """Split target shardings into device-memory-kind loaders plus per-leaf move-back targets.
+
+    JAX materializes tensorstore shards as ``device`` buffers, then assembles them under the
+    requested sharding. When that sharding carries a non-device memory kind -- as it does for a run
+    with ``offload_opt_state``/``FP32_PINNED_HOST``, whose master and optimizer leaves live on
+    ``pinned_host`` -- assembly fails the memory-kind check, so a checkpoint that was written cannot
+    be read back. Deserialize onto ``device`` and move each such leaf to its target afterwards.
+
+    Returns ``(device_shardings, move_targets)`` where ``move_targets[i]`` is the original sharding
+    for a leaf that must be relocated after deserialization, or ``None`` when it already loads in the
+    right place.
+    """
+    device_shardings = []
+    move_targets: list = []
+    for sharding in shardings:
+        memory_kind = getattr(sharding, "memory_kind", None)
+        with_memory_kind = getattr(sharding, "with_memory_kind", None)
+        if memory_kind is not None and memory_kind != "device" and with_memory_kind is not None:
+            device_shardings.append(with_memory_kind("device"))
+            move_targets.append(sharding)
+        else:
+            device_shardings.append(sharding)
+            move_targets.append(None)
+    return device_shardings, move_targets
+
+
+def _move_leaves_to_target_memory_kind(leaves: list, move_targets: list) -> list:
+    """Relocate leaves deserialized onto ``device`` back to a non-device target memory kind.
+
+    Done per leaf so the sharded state never has to sit whole in device memory at once -- the shards
+    for a leaf move to (pinned) host before the next leaf is placed, matching why the state was
+    offloaded in the first place.
+    """
+    if not any(target is not None for target in move_targets):
+        return leaves
+    return [jax.device_put(leaf, target) if target is not None else leaf for leaf, target in zip(leaves, move_targets)]
 
 
 def _restore_ocdbt(
@@ -736,7 +777,9 @@ def _restore_ocdbt(
         spec = _create_ocdbt_spec(checkpoint_root, path)
         tspecs_to_load.append(spec)
 
-    deser_leaves = manager.deserialize(shardings=shardings_to_load, tensorstore_specs=tspecs_to_load)
+    device_shardings, move_targets = _device_shardings_for_load(shardings_to_load)
+    deser_leaves = manager.deserialize(shardings=device_shardings, tensorstore_specs=tspecs_to_load)
+    deser_leaves = _move_leaves_to_target_memory_kind(deser_leaves, move_targets)
     return deser_leaves, indices_to_load
 
 
@@ -782,7 +825,9 @@ def _restore_old_ts(
                 to_log += f"\n  - {leaf_paths[i]}"
             logger.warning(to_log)
 
-    deser_leaves = manager.deserialize_with_paths(shardings=shardings_to_load, paths=paths_to_load, concurrent_gb=300)
+    device_shardings, move_targets = _device_shardings_for_load(shardings_to_load)
+    deser_leaves = manager.deserialize_with_paths(shardings=device_shardings, paths=paths_to_load, concurrent_gb=300)
+    deser_leaves = _move_leaves_to_target_memory_kind(deser_leaves, move_targets)
     return deser_leaves, indices_to_load
 
 

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -688,9 +688,9 @@ def _fully_replicated_sharding(mesh):
 def _device_shardings_for_load(shardings: list) -> tuple[list, list]:
     """Split target shardings into device-memory-kind loaders plus per-leaf move-back targets.
 
-    JAX materializes tensorstore shards as ``device`` buffers, then assembles them under the
-    requested sharding. When that sharding carries a non-device memory kind -- as it does for a run
-    with ``offload_opt_state``/``FP32_PINNED_HOST``, whose master and optimizer leaves live on
+    JAX reads tensorstore shards into ``device`` buffers, then assembles them under the requested
+    sharding. When that sharding carries a non-device memory kind -- as it does for a run with
+    ``offload_opt_state``/``FP32_PINNED_HOST``, whose master and optimizer leaves live on
     ``pinned_host`` -- assembly fails the memory-kind check, so a checkpoint that was written cannot
     be read back. Deserialize onto ``device`` and move each such leaf to its target afterwards.
 
@@ -711,11 +711,16 @@ def _device_shardings_for_load(shardings: list) -> tuple[list, list]:
 
 
 def _move_leaves_to_target_memory_kind(leaves: list, move_targets: list) -> list:
-    """Relocate leaves deserialized onto ``device`` to the target sharding in ``move_targets``."""
+    """Relocate leaves deserialized onto ``device`` to the non-device target in ``move_targets``.
+
+    Holding the whole offloaded state on device here is safe: the jitted step already shuttles the
+    entire ``opt_state`` and ``master_params`` onto device every update (see the training step's
+    ``_tree_to_memory_kind(..., "device")`` calls), alongside gradients and updates. Restore rebuilds
+    only that state -- no gradients, updates, or activations -- so its device footprint is strictly
+    smaller than a training step's, and the move targets are host memory rather than more HBM.
+    """
     if not any(target is not None for target in move_targets):
         return leaves
-    # Move one leaf at a time: each leaf's shards reach (pinned) host before the next is placed, so
-    # the offloaded state never has to sit whole in device memory.
     return [jax.device_put(leaf, target) if target is not None else leaf for leaf, target in zip(leaves, move_targets)]
 
 

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -44,6 +44,8 @@ ARRAY_DRIVER = "zarr3"
 KVSTORE_DRIVER = "ocdbt"
 # JAX's memory kind for host memory a device can address. Offloaded optimizer state lives here.
 _HOST_MEMORY_KIND = "pinned_host"
+# JAX's default memory kind: buffers live in device (HBM) memory.
+_DEVICE_MEMORY_KIND = "device"
 # Chunks a save stages at once. Four processes at 32 GiB each exhausted a GB200 node.
 _DEFAULT_STAGED_CHUNKS = 32
 # Host memory a staged byte occupies while its write is in flight, for reporting only.
@@ -699,10 +701,8 @@ def _device_shardings_for_load(shardings: list) -> tuple[list, list]:
     device_shardings = []
     move_targets: list = []
     for sharding in shardings:
-        memory_kind = getattr(sharding, "memory_kind", None)
-        with_memory_kind = getattr(sharding, "with_memory_kind", None)
-        if memory_kind is not None and memory_kind != "device" and with_memory_kind is not None:
-            device_shardings.append(with_memory_kind("device"))
+        if sharding.memory_kind not in (None, _DEVICE_MEMORY_KIND):
+            device_shardings.append(sharding.with_memory_kind(_DEVICE_MEMORY_KIND))
             move_targets.append(sharding)
         else:
             device_shardings.append(sharding)
@@ -711,14 +711,11 @@ def _device_shardings_for_load(shardings: list) -> tuple[list, list]:
 
 
 def _move_leaves_to_target_memory_kind(leaves: list, move_targets: list) -> list:
-    """Relocate leaves deserialized onto ``device`` back to a non-device target memory kind.
-
-    Done per leaf so the sharded state never has to sit whole in device memory at once -- the shards
-    for a leaf move to (pinned) host before the next leaf is placed, matching why the state was
-    offloaded in the first place.
-    """
+    """Relocate leaves deserialized onto ``device`` to the target sharding in ``move_targets``."""
     if not any(target is not None for target in move_targets):
         return leaves
+    # Move one leaf at a time: each leaf's shards reach (pinned) host before the next is placed, so
+    # the offloaded state never has to sit whole in device memory.
     return [jax.device_put(leaf, target) if target is not None else leaf for leaf, target in zip(leaves, move_targets)]
 
 

--- a/lib/levanter/tests/test_tensorstore_serialization.py
+++ b/lib/levanter/tests/test_tensorstore_serialization.py
@@ -90,6 +90,27 @@ def test_tensorstore_checkpoint_eval_shape_concretizes_named_sharding_mesh():
             assert jnp.allclose(restored["x"], arr)
 
 
+def test_tensorstore_checkpoint_restores_pinned_host_memory_kind():
+    # Regression for #8441. A run with offload_opt_state/FP32_PINNED_HOST holds its master and
+    # optimizer leaves on `pinned_host`, so the restore template (produced by eval_shape, hence an
+    # abstract mesh) carries that memory kind. Passing it straight to tensorstore materializes device
+    # buffers and fails the memory-kind check on assembly, so the checkpoint could not be read back.
+    with use_test_mesh() as mesh:
+        arr = jax.random.normal(jax.random.PRNGKey(0), (8,), dtype=jnp.float32)
+        abs_mesh = jax.sharding.get_abstract_mesh()
+        for spec in (P(), P("data")):
+            pinned = NamedSharding(abs_mesh, spec).with_memory_kind("pinned_host")
+            template = jax.ShapeDtypeStruct(arr.shape, arr.dtype, sharding=pinned)
+            with TemporaryDirectory() as tmpdir:
+                tree_serialize_leaves_tensorstore(tmpdir, {"x": arr})
+                restored = tree_deserialize_leaves_tensorstore(tmpdir, {"x": template})["x"]
+
+            assert restored.sharding.memory_kind == "pinned_host"
+            # allclose refuses to compare across memory spaces, so pull the host copy to device first.
+            on_device = jax.device_put(restored, NamedSharding(mesh, P()))
+            assert jnp.allclose(on_device, arr)
+
+
 def test_checkpoint_steps():
     with use_test_mesh():
         key0 = jax.random.PRNGKey(0)


### PR DESCRIPTION
A run with `offload_opt_state` and `FP32_PINNED_HOST` keeps its master and optimizer leaves on `pinned_host`, so those leaves are checkpointed with a pinned-host memory kind. Restoring failed: the deserialize path passed that sharding straight to tensorstore, which materializes each shard as a device buffer and then fails the memory-kind check while assembling the array (`memory kind 'pinned_host' ... buffer with memory_kind 'device'`). The run could write checkpoints it could not read back.

Deserialize each such leaf onto `device`, then move it to its target memory kind one leaf at a time so the sharded state never sits whole in device memory. Also preserve `memory_kind` when concretizing an abstract-mesh sharding — `eval_shape` produces that sharding for the restore template, and dropping the kind there would silently reload offloaded state into device memory.

Fixes #8441
