### PR TITLE
iris: fix log viewer text selection and column alignment

### DIFF
--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -874,22 +874,22 @@ defineExpose({ selectedAttemptId })
           >
             <button
               v-if="row.seq > 0"
-              class="shrink-0 w-4 text-text-muted opacity-0 group-hover:opacity-100
+              class="shrink-0 w-4 select-none text-text-muted opacity-0 group-hover:opacity-100
                      focus-visible:opacity-100 hover:text-accent disabled:opacity-40"
               :title="`Show the ${CONTEXT_LINES} lines either side of this one, unfiltered`"
               :disabled="contextPending"
               @click="loadContext(row.seq)"
             >⋯</button>
-            <span v-else class="shrink-0 w-4" />
+            <span v-else class="shrink-0 w-4 select-none" />
             <RouterLink
               v-if="row.taskRef && props.taskId"
               :to="`/job/${encodeURIComponent(props.taskId)}/task/${encodeURIComponent(row.taskRef.taskId)}`"
-              class="shrink-0 text-accent hover:underline"
+              class="shrink-0 select-none text-accent hover:underline"
               :title="row.taskRef.taskId"
             >
               T{{ row.taskRef.taskIndex }}
             </RouterLink>
-            <span class="shrink-0 inline-flex items-center gap-1">
+            <span class="shrink-0 select-none inline-flex items-center gap-1">
               <button
                 data-log-permalink
                 class="text-text-muted tabular-nums hover:text-accent hover:underline"
@@ -904,6 +904,9 @@ defineExpose({ selectedAttemptId })
                 @click="setStartTime(row.entry)"
               >▶</button>
             </span>
+            <!-- Every gutter item above is a flex item, so a browser copies each of
+                 them onto its own line. Marking them select-none keeps a drag
+                 selection to the messages alone: one clean line per log line. -->
             <span
               :class="wrap ? 'whitespace-pre-wrap break-words flex-1' : 'whitespace-pre'"
             ><template

--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -881,14 +881,17 @@ defineExpose({ selectedAttemptId })
               @click="loadContext(row.seq)"
             >⋯</button>
             <span v-else class="shrink-0 w-4 select-none" />
-            <RouterLink
-              v-if="row.taskRef && props.taskId"
-              :to="`/job/${encodeURIComponent(props.taskId)}/task/${encodeURIComponent(row.taskRef.taskId)}`"
-              class="shrink-0 select-none text-accent hover:underline"
-              :title="row.taskRef.taskId"
-            >
-              T{{ row.taskRef.taskIndex }}
-            </RouterLink>
+            <!-- Fixed width, right-aligned: task indices vary in digit count, and a
+                 column that sizes to its content ragged-edges every row after it. -->
+            <template v-if="showTaskLinks">
+              <RouterLink
+                v-if="row.taskRef && props.taskId"
+                :to="`/job/${encodeURIComponent(props.taskId)}/task/${encodeURIComponent(row.taskRef.taskId)}`"
+                class="shrink-0 w-12 select-none text-right tabular-nums text-accent hover:underline"
+                :title="row.taskRef.taskId"
+              >T{{ row.taskRef.taskIndex }}</RouterLink>
+              <span v-else class="shrink-0 w-12 select-none" />
+            </template>
             <span class="shrink-0 select-none inline-flex items-center gap-1">
               <button
                 data-log-permalink

--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -881,13 +881,12 @@ defineExpose({ selectedAttemptId })
               @click="loadContext(row.seq)"
             >⋯</button>
             <span v-else class="shrink-0 w-4 select-none" />
-            <!-- Fixed width, right-aligned: task indices vary in digit count, and a
-                 column that sizes to its content ragged-edges every row after it. -->
             <template v-if="showTaskLinks">
               <RouterLink
                 v-if="row.taskRef && props.taskId"
                 :to="`/job/${encodeURIComponent(props.taskId)}/task/${encodeURIComponent(row.taskRef.taskId)}`"
-                class="shrink-0 w-12 select-none text-right tabular-nums text-accent hover:underline"
+                class="shrink-0 w-12 overflow-hidden select-none text-right tabular-nums
+                       text-accent hover:underline"
                 :title="row.taskRef.taskId"
               >T{{ row.taskRef.taskIndex }}</RouterLink>
               <span v-else class="shrink-0 w-12 select-none" />
@@ -907,9 +906,8 @@ defineExpose({ selectedAttemptId })
                 @click="setStartTime(row.entry)"
               >▶</button>
             </span>
-            <!-- Every gutter item above is a flex item, so a browser copies each of
-                 them onto its own line. Marking them select-none keeps a drag
-                 selection to the messages alone: one clean line per log line. -->
+            <!-- The gutter is select-none: each item is a flex item, so a browser
+                 would otherwise copy every one of them onto its own line. -->
             <span
               :class="wrap ? 'whitespace-pre-wrap break-words flex-1' : 'whitespace-pre'"
             ><template


### PR DESCRIPTION
* drag-selecting log lines now copies the message text alone, and the columns line up across rows
* every log row is a flex container, so the gutter items (`⋯`, the `T<n>` task link, the timestamp, `▶`) are block-level boxes — a browser serializes each one onto its own line, so a drag across 3 lines copied 12 [^1]
* mark the whole gutter `select-none`, so a selection covers only the message column
  * `Copy JSON` is unchanged and still carries the full records
* give the task-link column a fixed `w-12`, right-aligned — it used to size to its content, so a `T18` row and a `T150` row started their timestamp and message at different offsets
  * rows with no task ref hold the same slot with a spacer
  * `overflow-hidden` clips an index too wide for the column instead of letting it paint over its neighbors; the `title` still has the full task id

[^1]: only the message spans carry text worth copying; the gutter is navigation controls.
