### PR TITLE
[loom] Allowlist owners, not repositories, for interactive profiles

### DIFF
--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -36,15 +36,8 @@ config:
       prelude: weaver
       instructionsFile: profiles/user/AGENTS.md
       githubRepositories: &interactiveGithubRepositories
-        - Open-Athena/marinmirror
-        - Open-Athena/mumwelt
-        - marin-community/MarinSkyRL
-        - marin-community/evalchemy
-        - marin-community/harbor
-        - marin-community/loom
-        - marin-community/marin
-        - marin-community/marin-style
-        - marin-community/vllm
+        - Open-Athena/*
+        - marin-community/*
       mcpAccess:
         mode: all
         groups: []

--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -107,12 +107,19 @@ ordinary sessions use the deployment-managed `default` profile, while workload
 and future GitHub Actions callers select the automation profile authorized by
 their federation mapping.
 
-The `default`, `github`, and `slack` profiles allowlist the repositories where
-interactive sessions may fall back to the `loom-oa-dev` GitHub App. Loom stamps
-only the session's current repository and brokers a short-lived installation
-token when the launching user has not stored a personal token. A personal token
-continues to take precedence. Keep these lists aligned with the repositories
-registered in production and the App's installations.
+An interactive session always brokers the `loom-oa-dev` GitHub App for its own
+repository, and a stored personal token still takes precedence over it. The
+`default`, `github`, and `slack` profiles therefore allowlist owners rather than
+repositories: an `owner/*` entry lets a session expand into any repository under
+that owner without waiting for a human decision. Each expansion is still
+validated against the App's installations and recorded as a revocable grant, so
+the App's installation list is what actually bounds this. Removing an owner here
+does not withdraw access a session already holds.
+
+The `fork-ferry` automation profile keeps an explicit repository list: an
+automation session is stamped with its profile's entries verbatim and needs
+concrete repositories to mint the cross-repository token its workflow depends
+on.
 
 The Pulumi declaration is authoritative at activation time. An unchanged
 profile keeps its database revision; a changed declaration overwrites the


### PR DESCRIPTION
The default, github, and slack profiles listed nine repositories across two orgs. An interactive session is stamped with only its own repository, so those entries never widened a session's token; reaching any other repository required a human to approve the expansion in the Loom UI. Agents that hit this told users to run a CLI command on the Loom host instead, which nobody has a shell for.

Replace the list with the owner patterns `Open-Athena/*` and `marin-community/*`. A pattern scopes no token by itself. It records a standing decision for that owner, so a session's expansion request applies immediately rather than waiting on a person. Each expansion is still validated against the `loom-oa-dev` App installation, still recorded as a revocable grant, and still scoped only to the repositories actually requested; the App's installation list is what bounds this in practice.

This widens interactive access from nine named repositories to any repository under either owner where the App is installed. That is the reviewable decision here. Narrowing to `marin-community/*` alone still fixes the reported failure, at the cost of leaving Open-Athena sessions without standing expansion.

fork-ferry keeps its explicit list. An automation session is stamped with its profile's entries verbatim and needs concrete repositories to mint the cross-repository token its workflow depends on.

Cross-owner expansion remains unavailable: an installation token covers one owner, and an interactive session's effective set is its own repository, so a session under one owner cannot reach the other. That predates this change and a pattern does not alter it.

Merge after marin-community/loom#318 and its image reaches production. `loom deployment apply` rejects a pattern entry on the current image, and `startup-script.sh` applies the manifest after the new image is healthy, so activating this before that lands fails loudly at startup rather than degrading silently.
