### PR TITLE
[grug] Add synthetic batches for hero diagnostics

### DIFF
--- a/experiments/grug/moe_hero_ep/launch_mfu_test.py
+++ b/experiments/grug/moe_hero_ep/launch_mfu_test.py
@@ -35,6 +35,7 @@ from experiments.grug.moe_hero_ep.train import (
     GrugRunConfig,
     GrugTrainerConfig,
     MasterParamMode,
+    TrainingDataMode,
     WatchMode,
     run_grug,
 )
@@ -88,6 +89,7 @@ def build_hero_run(
     watch_mode: WatchMode = WatchMode.INLINE,
     profile_steps: int = 0,
     profile_start_step: int = 5,
+    training_data_mode: TrainingDataMode = TrainingDataMode.MIXTURE,
     version: str | None = None,
 ) -> ArtifactStep[HeroThroughputResult]:
     """Build the EP64 hero throughput run.
@@ -168,6 +170,7 @@ def build_hero_run(
         z_loss_weight=1e-4,
         offload_opt_state=HERO_OFFLOAD_OPT_STATE,
         master_param_mode=MasterParamMode.FP32_PINNED_HOST,
+        training_data_mode=training_data_mode,
         watch_mode=watch_mode,
         # The default offloaded optimizer state has a known memory-kind mismatch during restore.
         save_checkpoints=save_checkpoints,
@@ -396,6 +399,13 @@ def build_hero_run(
     help="First traced step. Keep it past compile and warmup.",
 )
 @click.option(
+    "--training-data",
+    type=click.Choice([mode.value for mode in TrainingDataMode]),
+    default=TrainingDataMode.MIXTURE.value,
+    show_default=True,
+    help="Use the configured mixture or reuse a deterministic synthetic batch without opening TensorStore.",
+)
+@click.option(
     "--capacity-factor",
     type=click.FloatRange(min=0, min_open=True),
     default=HERO_MODEL.capacity_factor,
@@ -423,6 +433,7 @@ def main(
     watch_mode: str,
     profile_steps: int,
     profile_start_step: int,
+    training_data: str,
 ) -> ArtifactStep[HeroThroughputResult]:
     return build_hero_run(
         run_id=run_id,
@@ -444,6 +455,7 @@ def main(
         watch_mode=WatchMode(watch_mode),
         profile_steps=profile_steps,
         profile_start_step=profile_start_step,
+        training_data_mode=TrainingDataMode(training_data),
     )
 
 

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -3,6 +3,7 @@
 
 import dataclasses
 import functools
+import itertools
 import logging
 import os
 import time
@@ -85,6 +86,13 @@ class MasterParamMode(StrEnum):
     FP32_PINNED_HOST = "fp32_pinned_host"
 
 
+class TrainingDataMode(StrEnum):
+    """Source of training batches."""
+
+    MIXTURE = "mixture"
+    SYNTHETIC = "synthetic"
+
+
 def _apply_hero_ep_runtime_defaults(*, inline_watch_enabled: bool, processes_per_task: int = 1) -> None:
     env_defaults = dict(HERO_EP_RUNTIME_ENV)
     if processes_per_task > 1:
@@ -119,6 +127,7 @@ class GrugTrainerConfig:
     # The d6144 EP64 runs used it; d5120 required a 135 GiB pinned-host arena and regressed.
     offload_opt_state: bool = False
     master_param_mode: MasterParamMode = MasterParamMode.DISABLED
+    training_data_mode: TrainingDataMode = TrainingDataMode.MIXTURE
     # Inline watch computes statistics on every step and uses the watch interval only for logging.
     # This keeps one training executable resident. A diagnostic watch repeats forward and backward
     # in a separate executable, which costs compute but shortens gradient liveness.
@@ -202,6 +211,44 @@ def build_train_dataset(
 
 
 _BATCH_AXES: tuple[str, ...] = ("replica_dcn", "data", "expert")
+
+
+def _make_synthetic_batch(
+    *,
+    batch_size: int,
+    max_seq_len: int,
+    vocab_size: int,
+    seed: int,
+    mesh: Mesh,
+) -> GrugLmExample:
+    """Build one deterministic batch directly on the global batch sharding."""
+    sharding = NamedSharding(mesh, P(_BATCH_AXES, None))
+
+    def tokens_for_slice(index):
+        batch_slice, position_slice = index
+        batch_start, batch_stop, batch_stride = batch_slice.indices(batch_size)
+        position_start, position_stop, position_stride = position_slice.indices(max_seq_len)
+        if batch_stride != 1 or position_stride != 1:
+            raise ValueError("synthetic batch sharding requires contiguous slices")
+        batch_indices = np.arange(batch_start, batch_stop, dtype=np.int64)[:, None]
+        position_indices = np.arange(position_start, position_stop, dtype=np.int64)[None, :]
+        return ((batch_indices * max_seq_len + position_indices + seed) % vocab_size).astype(np.int32)
+
+    def loss_weight_for_slice(index):
+        batch_slice, position_slice = index
+        batch_start, batch_stop, batch_stride = batch_slice.indices(batch_size)
+        position_start, position_stop, position_stride = position_slice.indices(max_seq_len)
+        if batch_stride != 1 or position_stride != 1:
+            raise ValueError("synthetic batch sharding requires contiguous slices")
+        loss_weight = np.ones((batch_stop - batch_start, position_stop - position_start), dtype=np.float32)
+        if position_start <= max_seq_len - 1 < position_stop:
+            loss_weight[:, max_seq_len - 1 - position_start] = 0
+        return loss_weight
+
+    shape = (batch_size, max_seq_len)
+    tokens = jax.make_array_from_callback(shape, sharding, tokens_for_slice)
+    loss_weight = jax.make_array_from_callback(shape, sharding, loss_weight_for_slice)
+    return GrugLmExample(tokens=tokens, loss_weight=loss_weight)
 
 
 def build_train_loader(
@@ -692,17 +739,20 @@ def _run_grug_local(config: GrugRunConfig) -> None:
     with set_mesh(mesh):
         batch_schedule = trainer.batch_schedule
 
-        train_dataset = build_train_dataset(
-            config.data,
-            max_seq_len=config.model.max_seq_len,
-            batch_schedule=batch_schedule,
-            key=data_key,
-        )
-        train_loader = build_train_loader(
-            train_dataset,
-            batch_schedule=batch_schedule,
-            mesh=mesh,
-        )
+        train_dataset = None
+        train_loader = None
+        if config.trainer.training_data_mode == TrainingDataMode.MIXTURE:
+            train_dataset = build_train_dataset(
+                config.data,
+                max_seq_len=config.model.max_seq_len,
+                batch_schedule=batch_schedule,
+                key=data_key,
+            )
+            train_loader = build_train_loader(
+                train_dataset,
+                batch_schedule=batch_schedule,
+                mesh=mesh,
+            )
 
         @jax.jit
         def _init_state(model_rng):
@@ -783,7 +833,19 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         profiler_enabled = profiler_cfg.is_enabled and profiler_num_steps > 0
 
         log_every = max(1, config.trainer.log_every)
-        iterator = LoadingTimeTrackerIterator(train_loader.iter_from_step(int(state.step)))
+        if config.trainer.training_data_mode == TrainingDataMode.SYNTHETIC:
+            synthetic_batch = _make_synthetic_batch(
+                batch_size=batch_schedule.batch_size_at_step(int(state.step)),
+                max_seq_len=config.model.max_seq_len,
+                vocab_size=config.model.vocab_size,
+                seed=trainer.seed + 1 if config.trainer.data_seed is None else config.trainer.data_seed,
+                mesh=mesh,
+            )
+            batch_source = itertools.repeat(synthetic_batch)
+        else:
+            assert train_loader is not None
+            batch_source = train_loader.iter_from_step(int(state.step))
+        iterator = LoadingTimeTrackerIterator(batch_source)
 
         state_callbacks = StateCallbackRunner[GrugTrainState](
             step_getter=lambda s: s.step,
@@ -806,7 +868,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 ),
                 every=1,
             )
-        state_callbacks.add_hook(_make_mixture_stage_callback(train_dataset, batch_schedule), every=1)
+        if train_dataset is not None:
+            state_callbacks.add_hook(_make_mixture_stage_callback(train_dataset, batch_schedule), every=1)
         state_callbacks.add_hook(log_device_memory, every=1)
         if evaluator is not None and eval_cfg is not None:
             interval = eval_cfg.steps_per_eval

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -157,6 +157,27 @@ def test_schedule_steps_do_not_extend_the_run():
     assert config.stop_after_steps == 5
 
 
+def test_synthetic_training_data_builds_a_reusable_global_batch():
+    device_count = len(jax.devices())
+    mesh = Mesh(
+        np.asarray(jax.devices()).reshape(1, device_count, 1, 1),
+        ("replica_dcn", "data", "expert", "model"),
+    )
+    batch = train._make_synthetic_batch(
+        batch_size=device_count,
+        max_seq_len=8,
+        vocab_size=11,
+        seed=3,
+        mesh=mesh,
+    )
+
+    expected_tokens = (np.arange(device_count * 8).reshape(device_count, 8) + 3) % 11
+    np.testing.assert_array_equal(batch.tokens, expected_tokens)
+    np.testing.assert_array_equal(batch.loss_weight[:, :-1], 1)
+    np.testing.assert_array_equal(batch.loss_weight[:, -1], 0)
+    assert batch.tokens.sharding == NamedSharding(mesh, P(train._BATCH_AXES, None))
+
+
 def test_expert_bank_override_must_be_divisible_by_the_expert_axis():
     # `moe_mlp` raises on an indivisible bank only once the 16-node gang is already allocated and
     # its workspace is built, so the launcher has to reject it while it is still free to do so.


### PR DESCRIPTION
Allow the EP hero throughput launcher to reuse one deterministic global batch instead of opening the configured mixture and TensorStore-backed loader. Rack-scale compiler and memory diagnostics can reach the first train step without depending on remote data startup. Mixture-backed training remains the default.

The synthetic batch is built directly with the production global batch placement, masks the final token's loss weight, and is reused across steps. A one-rack `cw-us-east-08a` run with 64 process-per-GPU ranks reached step 50 while using this path.

Part of #7279.
