### PR TITLE
[levanter] Complete an Iris job only after an explicit success mark

### DIFF
--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -38,6 +38,7 @@ from levanter.data.loader import DataLoader
 from levanter.data.mixture import MixtureDataset, rescale_mixture_schedule_for_batch_schedule
 from levanter.data.text.datasets import LmDataConfig
 from levanter.data.text.examples import GrugLmExample, grug_lm_example_from_named
+from levanter.distributed import mark_run_succeeded
 from levanter.eval import TaggedEvaluator, cb_tagged_evaluate
 from levanter.grug.sharding import compact_grug_mesh
 from levanter.models.lm_model import LmExample
@@ -640,6 +641,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 checkpointer.wait_until_finished()
 
     levanter.tracker.current_tracker().finish()
+
+    mark_run_succeeded()
 
 
 def run_grug(config: GrugRunConfig) -> None:

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -28,6 +28,7 @@ from levanter.data.loader import DataLoader
 from levanter.data.mixture import MixtureDataset, rescale_mixture_schedule_for_batch_schedule
 from levanter.data.text.datasets import LmDataConfig
 from levanter.data.text.examples import GrugLmExample, grug_lm_example_from_named
+from levanter.distributed import mark_run_succeeded
 from levanter.eval import TaggedEvaluator, cb_tagged_evaluate
 from levanter.grug.sharding import compact_grug_mesh
 from levanter.models.lm_model import LmExample
@@ -576,6 +577,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 checkpointer.wait_until_finished()
 
     levanter.tracker.current_tracker().finish()
+
+    mark_run_succeeded()
 
 
 def run_grug(config: GrugRunConfig) -> None:

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -33,6 +33,7 @@ from levanter.data.loader import DataLoader
 from levanter.data.mixture import MixtureDataset, rescale_mixture_schedule_for_batch_schedule
 from levanter.data.text.datasets import LmDataConfig
 from levanter.data.text.examples import GrugLmExample, grug_lm_example_from_named
+from levanter.distributed import mark_run_succeeded
 from levanter.eval import TaggedEvaluator, cb_tagged_evaluate, eval_model
 from levanter.grug.sharding import compact_grug_mesh
 from levanter.models.lm_model import LmExample
@@ -929,6 +930,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             state_callbacks.emit_event(callbacks.ProgressEvent.TRAINING_FINISHED)
 
     levanter.tracker.current_tracker().finish()
+
+    mark_run_succeeded()
 
 
 def run_grug(config: GrugRunConfig) -> None:

--- a/experiments/grug/moe_hero_fsdp/train.py
+++ b/experiments/grug/moe_hero_fsdp/train.py
@@ -30,6 +30,7 @@ from levanter.data.loader import DataLoader
 from levanter.data.mixture import MixtureDataset, rescale_mixture_schedule_for_batch_schedule
 from levanter.data.text.datasets import LmDataConfig
 from levanter.data.text.examples import GrugLmExample, grug_lm_example_from_named
+from levanter.distributed import mark_run_succeeded
 from levanter.eval import TaggedEvaluator, cb_tagged_evaluate
 from levanter.grug.sharding import compact_grug_mesh
 from levanter.models.lm_model import LmExample
@@ -707,6 +708,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             state_callbacks.emit_event(callbacks.ProgressEvent.TRAINING_FINISHED)
 
     levanter.tracker.current_tracker().finish()
+
+    mark_run_succeeded()
 
 
 def _run_grug_supervised_local(config: GrugRunConfig) -> None:

--- a/lib/levanter/src/levanter/distributed.py
+++ b/lib/levanter/src/levanter/distributed.py
@@ -6,7 +6,6 @@ import itertools
 import logging
 import os
 import re
-import sys
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
@@ -32,15 +31,35 @@ _VISIBLE_DEVICES = "CUDA_VISIBLE_DEVICES"
 _NODE_NAME = "SLURMD_NODENAME"
 
 
-def _complete_iris_job_after_clean_exit(client: IrisClient, job_id: JobName) -> None:
-    # Preserve retries for genuine failures; the successful rank-0 exit owns completed-job teardown.
-    if getattr(sys, "last_exc", None) is not None:
+# ``mark_run_succeeded`` sets this flag. The process-exit hook reads it.
+_run_succeeded = False
+
+
+def _complete_iris_job_after_successful_run(client: IrisClient, job_id: JobName) -> None:
+    """Complete this task's Iris job at process exit, but only after an explicit success mark.
+
+    The exit state does not tell the difference between success and failure. The
+    Iris callable runner changes every training exception into ``sys.exit(1)``.
+    That call still runs the exit hooks, and ``sys.last_exc`` stays unset. Thus an
+    exit with no mark does not complete the job, and Iris sets the job state from
+    the task exit codes.
+    """
+    if not _run_succeeded:
         return
     client.complete(job_id)
 
 
-def _unregister_iris_job_completion() -> None:
-    atexit.unregister(_complete_iris_job_after_clean_exit)
+def mark_run_succeeded() -> None:
+    """Record that this process completed its training run and wrote every artifact.
+
+    Call this as the last statement of a training entry point. On JAX process 0 of
+    an Iris job, the process-exit hook then completes the job. Completion marks the
+    job terminal and stops the remaining tasks, before a coordinator teardown race
+    can retry a completed gang. No other process installs that hook, so the mark
+    has no effect there.
+    """
+    global _run_succeeded
+    _run_succeeded = True
 
 
 class LevanterSlurmCluster(clusters.SlurmCluster):
@@ -246,7 +265,7 @@ class DistributedConfig:
                 if ctx.client is None:
                     raise RuntimeError("Iris context has no client for completing the current job")
                 # Tracker exit hooks register later and therefore run before job completion.
-                atexit.register(_complete_iris_job_after_clean_exit, ctx.client, job_info.job_id)
+                atexit.register(_complete_iris_job_after_successful_run, ctx.client, job_info.job_id)
         elif self._is_distributed():
             device_ids = self.local_device_ids
             coordinator_address = self.coordinator_address

--- a/lib/levanter/src/levanter/distributed.py
+++ b/lib/levanter/src/levanter/distributed.py
@@ -31,12 +31,22 @@ _VISIBLE_DEVICES = "CUDA_VISIBLE_DEVICES"
 _NODE_NAME = "SLURMD_NODENAME"
 
 
-# ``mark_run_succeeded`` sets this flag. The process-exit hook reads it.
-_run_succeeded = False
+@dataclass
+class _IrisJobCompletion:
+    """The Iris job to complete at process exit, and whether the run earned it."""
+
+    client: IrisClient
+    job_id: JobName
+    run_succeeded: bool = False
 
 
-def _complete_iris_job_after_successful_run(client: IrisClient, job_id: JobName) -> None:
-    """Complete this task's Iris job at process exit, but only after an explicit success mark.
+# Only JAX process 0 of an Iris job installs the exit hook, so only that process
+# holds a completion. ``initialize`` creates it, and ``mark_run_succeeded`` arms it.
+_iris_job_completion: _IrisJobCompletion | None = None
+
+
+def _complete_iris_job_after_successful_run() -> None:
+    """Complete this task's Iris job at exit, but only after an explicit success mark.
 
     The exit state does not tell the difference between success and failure. The
     Iris callable runner changes every training exception into ``sys.exit(1)``.
@@ -44,9 +54,10 @@ def _complete_iris_job_after_successful_run(client: IrisClient, job_id: JobName)
     exit with no mark does not complete the job, and Iris sets the job state from
     the task exit codes.
     """
-    if not _run_succeeded:
+    completion = _iris_job_completion
+    if completion is None or not completion.run_succeeded:
         return
-    client.complete(job_id)
+    completion.client.complete(completion.job_id)
 
 
 def mark_run_succeeded() -> None:
@@ -58,8 +69,8 @@ def mark_run_succeeded() -> None:
     can retry a completed gang. No other process installs that hook, so the mark
     has no effect there.
     """
-    global _run_succeeded
-    _run_succeeded = True
+    if _iris_job_completion is not None:
+        _iris_job_completion.run_succeeded = True
 
 
 class LevanterSlurmCluster(clusters.SlurmCluster):
@@ -264,8 +275,10 @@ class DistributedConfig:
                 ctx = iris_ctx()
                 if ctx.client is None:
                     raise RuntimeError("Iris context has no client for completing the current job")
+                global _iris_job_completion
+                _iris_job_completion = _IrisJobCompletion(ctx.client, job_info.job_id)
                 # Tracker exit hooks register later and therefore run before job completion.
-                atexit.register(_complete_iris_job_after_successful_run, ctx.client, job_info.job_id)
+                atexit.register(_complete_iris_job_after_successful_run)
         elif self._is_distributed():
             device_ids = self.local_device_ids
             coordinator_address = self.coordinator_address

--- a/lib/levanter/src/levanter/main/lora_lm.py
+++ b/lib/levanter/src/levanter/main/lora_lm.py
@@ -18,6 +18,7 @@ from levanter import callbacks
 from levanter.callbacks._iris_status import iris_status_reporter
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.data.text.datasets import LmDataConfig
+from levanter.distributed import mark_run_succeeded
 from levanter.adaptor.lora import (
     LoraConfig,
     lora_trainable_params_filter,
@@ -175,6 +176,8 @@ def main(config: LoraLmConfig):
 
         ## OK, actually run training!
         trainer.train(state, iter_data)
+
+    mark_run_succeeded()
 
 
 if __name__ == "__main__":

--- a/lib/levanter/src/levanter/main/train_asr.py
+++ b/lib/levanter/src/levanter/main/train_asr.py
@@ -21,6 +21,7 @@ from levanter import callbacks
 from levanter.callbacks._iris_status import iris_status_reporter
 from levanter.compat.hf_checkpoints import HFCompatConfig, ModelWithHfSerializationMixin, save_hf_checkpoint_callback
 from levanter.data.audio import AudioIODatasetConfig, AudioMixtureDatasetConfig, AudioTextDataset
+from levanter.distributed import mark_run_succeeded
 from levanter.models.asr_model import ASRConfig, AudioTextExample
 from levanter.models.whisper import WhisperConfig
 from levanter.optim.config import AdamConfig, OptimizerConfig
@@ -210,6 +211,8 @@ def main(config: TrainASRConfig):
 
         ## OK, actually run training!
         trainer.train(state, train_loader)
+
+    mark_run_succeeded()
 
 
 if __name__ == "__main__":

--- a/lib/levanter/src/levanter/main/train_dpo.py
+++ b/lib/levanter/src/levanter/main/train_dpo.py
@@ -50,6 +50,7 @@ from levanter.dpo import (
     reference_eval_cache_metadata,
     reference_eval_cache_path,
 )
+from levanter.distributed import mark_run_succeeded
 from levanter.main.model_init import load_model_from_source, prepare_model_init_context
 from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel
@@ -899,6 +900,8 @@ def main(config: TrainDpoConfig):
             checkpointer.wait_until_finished()
 
     trainer.tracker.finish()
+
+    mark_run_succeeded()
 
 
 if __name__ == "__main__":

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -31,6 +31,7 @@ from levanter.checkpoint import latest_checkpoint_path, load_checkpoint
 from levanter.compat.hf_checkpoints import HFCompatConfig, build_generation_config
 from levanter.data.mixture import MixtureDataset
 from levanter.data.text.datasets import LmDataConfig
+from levanter.distributed import mark_run_succeeded
 from levanter.eval_harness import LmEvalHarnessConfig
 from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmExample, LmHeadModel, split_activations
@@ -460,6 +461,8 @@ def main(config: TrainLmConfig):
 
     # This isn't necessary except when Levanter is run in a subprocess (as happens under Iris/Fray)
     trainer.tracker.finish()
+
+    mark_run_succeeded()
 
 
 if __name__ == "__main__":

--- a/lib/levanter/src/levanter/recovery/child.py
+++ b/lib/levanter/src/levanter/recovery/child.py
@@ -22,7 +22,6 @@ import logging
 import pickle
 import sys
 
-from levanter.distributed import _unregister_iris_job_completion
 from levanter.recovery.detection import classify_exception
 from levanter.recovery.types import EXIT_STALL, EXIT_STICKY_FAULT, ChildSpec, FaultClass
 
@@ -51,7 +50,6 @@ def main() -> None:
     try:
         entrypoint(spec.config)
     except BaseException as exc:  # noqa: BLE001 - map to the exit-code contract, then re-signal
-        _unregister_iris_job_completion()
         fault_class = classify_exception(exc)
         logger.exception("trainer subprocess raised; classified as %s", fault_class)
         if fault_class is FaultClass.STICKY:

--- a/lib/levanter/tests/test_distributed.py
+++ b/lib/levanter/tests/test_distributed.py
@@ -42,26 +42,33 @@ class _RecordingIrisClient:
 
 
 @pytest.fixture
-def unmarked_run(monkeypatch):
-    """Reset the success mark, so one test cannot arm another."""
-    monkeypatch.setattr(distributed, "_run_succeeded", False)
+def iris_job(monkeypatch):
+    """Install an unmarked completion, as JAX process 0 of an Iris job does."""
+    completion = distributed._IrisJobCompletion(_RecordingIrisClient(), JobName.root("alice", "train"))
+    monkeypatch.setattr(distributed, "_iris_job_completion", completion)
+    return completion
 
 
-def test_exit_without_a_success_mark_keeps_the_iris_job_open(unmarked_run):
+def test_exit_without_a_success_mark_keeps_the_iris_job_open(iris_job):
     # A training failure exits through the Iris callable runner's `sys.exit(1)`, which
     # runs this hook. The job must stay open for Iris to fail it from the exit codes.
-    client = _RecordingIrisClient()
+    distributed._complete_iris_job_after_successful_run()
 
-    distributed._complete_iris_job_after_successful_run(client, JobName.root("alice", "train"))
-
-    assert client.completed == []
+    assert iris_job.client.completed == []
 
 
-def test_exit_after_a_success_mark_completes_the_iris_job(unmarked_run):
-    client = _RecordingIrisClient()
-    job_id = JobName.root("alice", "train")
+def test_exit_after_a_success_mark_completes_the_iris_job(iris_job):
+    distributed.mark_run_succeeded()
+    distributed._complete_iris_job_after_successful_run()
+
+    assert iris_job.client.completed == [iris_job.job_id]
+
+
+def test_success_mark_outside_an_iris_job_completes_nothing(monkeypatch):
+    # Every local run and every non-zero JAX process takes this path.
+    monkeypatch.setattr(distributed, "_iris_job_completion", None)
 
     distributed.mark_run_succeeded()
-    distributed._complete_iris_job_after_successful_run(client, job_id)
+    distributed._complete_iris_job_after_successful_run()
 
-    assert client.completed == [job_id]
+    assert distributed._iris_job_completion is None

--- a/lib/levanter/tests/test_distributed.py
+++ b/lib/levanter/tests/test_distributed.py
@@ -1,6 +1,10 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+from iris.cluster.types import JobName
+
+from levanter import distributed
 from levanter.distributed import _square_brace_expand
 
 
@@ -25,3 +29,39 @@ def test_square_brace_expand():
     custom_sequence_3 = "node[1-11,21]suffix"
     expanded_nodes_3 = _square_brace_expand(custom_sequence_3)
     assert expanded_nodes_3 == [f"node{i}suffix" for i in range(1, 12)] + ["node21suffix"]
+
+
+class _RecordingIrisClient:
+    """Records the jobs that the process-exit hook completes."""
+
+    def __init__(self):
+        self.completed: list[JobName] = []
+
+    def complete(self, job_id: JobName) -> None:
+        self.completed.append(job_id)
+
+
+@pytest.fixture
+def unmarked_run(monkeypatch):
+    """Reset the success mark, so one test cannot arm another."""
+    monkeypatch.setattr(distributed, "_run_succeeded", False)
+
+
+def test_exit_without_a_success_mark_keeps_the_iris_job_open(unmarked_run):
+    # A training failure exits through the Iris callable runner's `sys.exit(1)`, which
+    # runs this hook. The job must stay open for Iris to fail it from the exit codes.
+    client = _RecordingIrisClient()
+
+    distributed._complete_iris_job_after_successful_run(client, JobName.root("alice", "train"))
+
+    assert client.completed == []
+
+
+def test_exit_after_a_success_mark_completes_the_iris_job(unmarked_run):
+    client = _RecordingIrisClient()
+    job_id = JobName.root("alice", "train")
+
+    distributed.mark_run_succeeded()
+    distributed._complete_iris_job_after_successful_run(client, job_id)
+
+    assert client.completed == [job_id]


### PR DESCRIPTION
A failed training run showed its Iris job as succeeded. #8400 completes the job from an atexit hook on JAX process 0, and it made that call whenever `sys.last_exc` was unset. Iris runs a task's callable under a runner that catches every exception, prints the traceback, and calls `sys.exit(1)`. That path still runs the exit hooks and never sets `sys.last_exc`, so the hook completed the job. The controller then marked the job succeeded and changed every non-terminal task to succeeded with exit code 0, which hid the failure and killed the gang. Marin dispatches training through `Entrypoint.from_callable`, so this covered every Levanter and grug training job, not only the one observed.

Replace the exit-state guess with `mark_run_succeeded()`, which each Levanter and grug training entry point calls as its last statement. The flag lives on the completion handle that the exit hook owns. An exit with no mark leaves the job open, and Iris sets the job state from the task exit codes as it did before #8400. The recovery child no longer removes the hook, because a failure never arms it.

On `grug-train-mhep-d6144-ppg-namedstate-step2-20260819-202741`, rank 0 got a `JaxRuntimeError` from `jit_train_step` at 20:38:05, Iris stopped the gang five seconds later, and all 16 tasks recorded succeeded with exit code 0 and identical durations.
