### PR TITLE
[grug] Reshard the TOPK margin placeholder onto the run's mesh

### DIFF
--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -778,6 +778,8 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
     capacity_overflow = router_metrics["capacity_overflow_per_layer"]
     sender_capacity_overflow = router_metrics["sender_capacity_overflow_per_layer"]
     receiver_capacity_overflow = router_metrics["receiver_capacity_overflow_per_layer"]
+    margin_min = router_metrics["margin_min_per_layer"]  # HIST estimator's live grid lo per layer (0 under TOPK)
+    margin_max = router_metrics["margin_max_per_layer"]  # HIST estimator's live grid hi per layer (0 under TOPK)
     qb_beta = router_metrics.get("qb_beta_per_layer")  # per-layer per-expert beta; router_bias = -qb_beta
     num_layers = int(routing_entropy.shape[0])
 
@@ -795,6 +797,9 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
         "train/router/capacity_overflow_rate_mean": jnp.mean(capacity_overflow_rate),
         "train/router/sender_overflow_rate_mean": jnp.mean(sender_overflow_rate),
         "train/router/receiver_overflow_rate_mean": jnp.mean(receiver_overflow_rate),
+        # QB HIST margin range: min over layers and max over layers, plus per-layer below.
+        "train/router/margin_min": jnp.min(margin_min),
+        "train/router/margin_max": jnp.max(margin_max),
         "qb_beta_per_layer": qb_beta,
     }
     if qb_beta is not None:
@@ -807,6 +812,8 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
         out[f"train/router/layer_{i}/router_z_loss"] = router_z_loss[i]
         out[f"train/router/layer_{i}/routing_hist"] = _histogram_from_expert_counts(routing_counts[i])
         out[f"train/router/layer_{i}/capacity_overflow_rate"] = capacity_overflow_rate[i]
+        out[f"train/router/layer_{i}/margin_min"] = margin_min[i]
+        out[f"train/router/layer_{i}/margin_max"] = margin_max[i]
     return out
 
 
@@ -986,7 +993,7 @@ class MoEMLP(eqx.Module):
         # Sharded QB: estimate each expert's threshold beta from the margins `s - alpha`.
         s_minus_alpha = reshard(router_logits - qb_alpha, P(_BATCH_AXES, None))
         if self.cfg.qb_estimator == QbEstimator.HIST:
-            beta, _, _ = _qb_beta_hist(
+            beta, margin_min, margin_max = _qb_beta_hist(
                 s_minus_alpha,
                 mesh,
                 num_experts_per_token=self.cfg.num_experts_per_token,
@@ -994,6 +1001,8 @@ class MoEMLP(eqx.Module):
                 n_bins=self.cfg.qb_hist_bins,
             )
             router_stats["qb_beta"] = beta
+            router_stats["margin_min"] = margin_min
+            router_stats["margin_max"] = margin_max
         else:
             num_devices = 1
             for a in _BATCH_AXES:
@@ -1014,6 +1023,13 @@ class MoEMLP(eqx.Module):
                 in_specs=(P(_BATCH_AXES, None),),
                 out_specs=P(_BATCH_AXES, None),
             )(s_minus_alpha)
+            # TOPK has no histogram grid, so no live margin range to surface. Reshard the
+            # placeholder onto the run's mesh: a bare constant carries an empty-mesh sharding,
+            # and stacking that through the router stats leaves the train step's inputs placed
+            # inconsistently with the compiled executable under offloaded pinned-host state.
+            zero = reshard(jnp.zeros((), dtype=jnp.float32), P())
+            router_stats["margin_min"] = zero
+            router_stats["margin_max"] = zero
 
         # LatentMoE: compress before dispatch so the expert-parallel all-to-all carries
         # `latent_dim`-wide rows in both directions. The router above already read the full-width
@@ -1278,6 +1294,8 @@ class Transformer(eqx.Module):
             "capacity_overflow_per_layer": stacked_router_stats["capacity_overflow"],
             "sender_capacity_overflow_per_layer": stacked_router_stats["sender_capacity_overflow"],
             "receiver_capacity_overflow_per_layer": stacked_router_stats["receiver_capacity_overflow"],
+            "margin_min_per_layer": stacked_router_stats["margin_min"],
+            "margin_max_per_layer": stacked_router_stats["margin_max"],
         }
         hidden = self.final_gated_norm(self.final_norm(hidden))
         return hidden, router_metrics

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -778,8 +778,6 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
     capacity_overflow = router_metrics["capacity_overflow_per_layer"]
     sender_capacity_overflow = router_metrics["sender_capacity_overflow_per_layer"]
     receiver_capacity_overflow = router_metrics["receiver_capacity_overflow_per_layer"]
-    margin_min = router_metrics["margin_min_per_layer"]  # HIST estimator's live grid lo per layer (0 under TOPK)
-    margin_max = router_metrics["margin_max_per_layer"]  # HIST estimator's live grid hi per layer (0 under TOPK)
     qb_beta = router_metrics.get("qb_beta_per_layer")  # per-layer per-expert beta; router_bias = -qb_beta
     num_layers = int(routing_entropy.shape[0])
 
@@ -797,9 +795,6 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
         "train/router/capacity_overflow_rate_mean": jnp.mean(capacity_overflow_rate),
         "train/router/sender_overflow_rate_mean": jnp.mean(sender_overflow_rate),
         "train/router/receiver_overflow_rate_mean": jnp.mean(receiver_overflow_rate),
-        # QB HIST margin range: min over layers and max over layers, plus per-layer below.
-        "train/router/margin_min": jnp.min(margin_min),
-        "train/router/margin_max": jnp.max(margin_max),
         "qb_beta_per_layer": qb_beta,
     }
     if qb_beta is not None:
@@ -812,8 +807,6 @@ def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str,
         out[f"train/router/layer_{i}/router_z_loss"] = router_z_loss[i]
         out[f"train/router/layer_{i}/routing_hist"] = _histogram_from_expert_counts(routing_counts[i])
         out[f"train/router/layer_{i}/capacity_overflow_rate"] = capacity_overflow_rate[i]
-        out[f"train/router/layer_{i}/margin_min"] = margin_min[i]
-        out[f"train/router/layer_{i}/margin_max"] = margin_max[i]
     return out
 
 
@@ -993,7 +986,7 @@ class MoEMLP(eqx.Module):
         # Sharded QB: estimate each expert's threshold beta from the margins `s - alpha`.
         s_minus_alpha = reshard(router_logits - qb_alpha, P(_BATCH_AXES, None))
         if self.cfg.qb_estimator == QbEstimator.HIST:
-            beta, margin_min, margin_max = _qb_beta_hist(
+            beta, _, _ = _qb_beta_hist(
                 s_minus_alpha,
                 mesh,
                 num_experts_per_token=self.cfg.num_experts_per_token,
@@ -1001,8 +994,6 @@ class MoEMLP(eqx.Module):
                 n_bins=self.cfg.qb_hist_bins,
             )
             router_stats["qb_beta"] = beta
-            router_stats["margin_min"] = margin_min
-            router_stats["margin_max"] = margin_max
         else:
             num_devices = 1
             for a in _BATCH_AXES:
@@ -1023,10 +1014,6 @@ class MoEMLP(eqx.Module):
                 in_specs=(P(_BATCH_AXES, None),),
                 out_specs=P(_BATCH_AXES, None),
             )(s_minus_alpha)
-            # TOPK has no histogram grid, so no live margin range to surface.
-            zero = jnp.zeros((), dtype=jnp.float32)
-            router_stats["margin_min"] = zero
-            router_stats["margin_max"] = zero
 
         # LatentMoE: compress before dispatch so the expert-parallel all-to-all carries
         # `latent_dim`-wide rows in both directions. The router above already read the full-width
@@ -1291,8 +1278,6 @@ class Transformer(eqx.Module):
             "capacity_overflow_per_layer": stacked_router_stats["capacity_overflow"],
             "sender_capacity_overflow_per_layer": stacked_router_stats["sender_capacity_overflow"],
             "receiver_capacity_overflow_per_layer": stacked_router_stats["receiver_capacity_overflow"],
-            "margin_min_per_layer": stacked_router_stats["margin_min"],
-            "margin_max_per_layer": stacked_router_stats["margin_max"],
         }
         hidden = self.final_gated_norm(self.final_norm(hidden))
         return hidden, router_metrics


### PR DESCRIPTION
The d6144 EP hero fails before its first training step whenever it runs with one JAX process per GPU. Every rank aborts at dispatch with

    INVALID_ARGUMENT: E0102: RuntimeProgramInputMismatch:
    Executable(jit_train_step) got a parameter buffer for parameter 71 in an unexpected memory space 'device'

after a full nine-minute compile, so the run dies having done no work. This blocks the scaling ladder's d6144 rung, which moved to one process per GPU in #8442.

#8407 added margin_min/margin_max router metrics. Under the TOPK estimator the MoE layer builds them as a bare `jnp.zeros(())`. With explicit mesh axes that constant carries a sharding on an empty mesh rather than replication over the run's mesh; both forms print as `spec=P()`, so the difference does not show up in a sharding dump. Stacking the placeholder across all 48 layers and reducing it alongside mesh-carrying values leaves the train step's inputs placed inconsistently with the compiled executable, and the mismatch surfaces on the offloaded FP32_PINNED_HOST master parameters. The HIST estimator was never affected: it takes its margins from `shard_map(..., out_specs=P())`, which is already replicated over the real mesh.

The fix reshards the placeholder onto that same mesh. Every margin diagnostic is retained under both estimators.

Bisected to 7a19cc7f36 with five one-rack probes at the full hero shape, each forced to one process per GPU and run for 100 steps: 291889b408, dc663c4667, 65a8b43b21, 954a5251a2 and 567b681a52 all train, while 7a19cc7f36 and every later commit including current main fail. Ancestry checks confirm #8385 is contained in three of the passing probes, so it is excluded. Within #8407, reverting model.py alone restores training and reverting the dataloader change does not; removing only the margin plumbing restores training at both 7a19cc7f36 and main, while removing only the qb_beta bias logging still fails. That isolates these metrics as the sole cause. The natural experiment across estimators agrees: at the same shape, layout and rack count, a HIST run reached step 8 while every TOPK run died at step 0, and the two paths differ only in how the margin values are produced.

Validated on main at the full hero shape, one rack, 64-way expert parallelism, one process per GPU, FP32_PINNED_HOST master parameters and offloaded optimizer state.

Two things are not settled here. A HIST run of the ladder's d6144 rung at 11 racks also died at step 0; its logs could not be retrieved, so whether that shares this cause or is a separate rack-scale problem is unknown. Separately, every failing run in this investigation was reported by Iris as `succeeded` with `exit=0` on all 16 tasks despite 64 fatal errors and SIGKILLs, which would silently pass a gate; that deserves its own issue.

Local checks: `./infra/pre-commit.py` passes. The test suite was not run locally because the branch worktree could not resolve `pytest_timeout`; CI covers it.
