### PR TITLE
[loom] Fail activation when the Compute Engine SSH key is missing

### DIFF
--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -32,6 +32,15 @@ gcloud auth configure-docker us-central1-docker.pkg.dev
 
 The local Docker builder must support `linux/amd64`.
 
+Activation restarts the host's startup script over SSH. Create the Compute
+Engine key pair once so the key is present and propagated before deploying;
+activation fails immediately when `~/.ssh/google_compute_engine` is missing
+rather than stalling while `gcloud` generates and propagates a new key.
+
+```sh
+gcloud compute ssh loom --zone=us-central1-a --project=hai-gcp-models
+```
+
 ## Deploy
 
 By default, Pulumi resolves the HEAD of Loom's default branch to its full commit

--- a/infra/loom/activate.sh
+++ b/infra/loom/activate.sh
@@ -6,20 +6,47 @@ set -euo pipefail
 : "${LOOM_INSTANCE:?LOOM_INSTANCE is required}"
 : "${LOOM_DOMAIN:?LOOM_DOMAIN is required}"
 
-gcloud --project="$LOOM_PROJECT" compute ssh "$LOOM_INSTANCE" \
+SSH_KEY="${HOME}/.ssh/google_compute_engine"
+SSH_CONNECT_TIMEOUT=15
+RESTART_TIMEOUT=600
+READY_ATTEMPTS=90
+READY_INTERVAL=10
+
+# gcloud --quiet generates a missing key and then blocks until metadata
+# propagation lets it connect. Require an existing key so activation fails
+# immediately instead of stalling the rollout.
+if [ ! -r "$SSH_KEY" ] || [ ! -r "${SSH_KEY}.pub" ]; then
+  echo "no Compute Engine SSH key at ${SSH_KEY}; run 'gcloud compute ssh ${LOOM_INSTANCE} --zone=${LOOM_ZONE} --project=${LOOM_PROJECT}' once to create and propagate one" >&2
+  exit 1
+fi
+
+restart_status=0
+timeout "$RESTART_TIMEOUT" gcloud --project="$LOOM_PROJECT" compute ssh "$LOOM_INSTANCE" \
   --zone="$LOOM_ZONE" --quiet \
+  --ssh-key-file="$SSH_KEY" \
+  --ssh-flag="-oBatchMode=yes" \
+  --ssh-flag="-oConnectTimeout=${SSH_CONNECT_TIMEOUT}" \
   --command='
     set -euo pipefail
     sudo rm -f /run/loom-startup-succeeded
     sudo systemctl restart google-startup-scripts.service
     sudo test -f /run/loom-startup-succeeded
-  '
+  ' || restart_status=$?
 
-for _ in $(seq 1 90); do
+if [ "$restart_status" -eq 124 ]; then
+  echo "startup-script restart on ${LOOM_INSTANCE} exceeded ${RESTART_TIMEOUT}s; ${SSH_KEY} is likely not propagated to the instance" >&2
+  exit 1
+fi
+if [ "$restart_status" -ne 0 ]; then
+  echo "startup-script restart on ${LOOM_INSTANCE} failed with exit ${restart_status}" >&2
+  exit "$restart_status"
+fi
+
+for _ in $(seq 1 "$READY_ATTEMPTS"); do
   if curl -fsS "https://${LOOM_DOMAIN}/api/ready" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"ready"'; then
     exit 0
   fi
-  sleep 10
+  sleep "$READY_INTERVAL"
 done
 
 echo "Loom did not become publicly ready after activation" >&2


### PR DESCRIPTION
Activation now requires an existing ~/.ssh/google_compute_engine key pair and
bounds the SSH step with a 600-second timeout. gcloud compute ssh --quiet
generates a missing key and then blocks until metadata propagation lets it
connect. That stalled a production rollout for 878 seconds with no output and
left a stale state lock and a pending loom-activate operation behind, while the
host kept serving the previous image. OS Login is disabled on hai-gcp-models,
so key distribution goes through project metadata and can lag past a usable
deploy window.

BatchMode and ConnectTimeout stop ssh from waiting on a prompt or an
unreachable host. The readiness poll keeps its 900-second ceiling.
