### PR TITLE
[levanter] Lower the checkpoint staging budget to 4 GiB per process

### DIFF
--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -46,8 +46,11 @@ KVSTORE_DRIVER = "ocdbt"
 _HOST_MEMORY_KIND = "pinned_host"
 # JAX's default memory kind: buffers live in device (HBM) memory.
 _DEVICE_MEMORY_KIND = "device"
-# Chunks a save stages at once. Four processes at 32 GiB each exhausted a GB200 node.
-_DEFAULT_STAGED_CHUNKS = 32
+# Chunks a save stages at once. The budget is per process, so a node holds it once per local
+# process. Four processes at 32 GiB each exhausted a GB200 node, and 16 GiB each still did: a
+# process carries about four times its budget in flight (_STAGED_BYTE_OVERHEAD) on top of its
+# resident shard of the offloaded state.
+_DEFAULT_STAGED_CHUNKS = 8
 # Host memory a staged byte occupies while its write is in flight, for reporting only.
 _STAGED_BYTE_OVERHEAD = 4
 


### PR DESCRIPTION
The checkpoint staging budget is per process, so a node holds it once per local
process. At four processes per GB200 node the 16 GiB budget put a node at roughly
556 GiB during a save: each process carried about 61 GiB in flight (four times its
budget, per `_STAGED_BYTE_OVERHEAD`) on top of its 78 GiB resident shard of the
offloaded pinned-host state. Saving a 5.36 TB d6144 checkpoint from one rack
OOM-killed a node partway through at 3.99 TB written, and gang scheduling bounced
its fifteen siblings. The same save at one process per node had completed fine,
which is why this surfaced only after the ladder moved to one process per GPU.

At 8 chunks the save completes. Peak staged bytes per process fall from 15.19 GiB
to 10.12 GiB, in flight from about 61 GiB to 40 GiB, and the node total to roughly
472 GiB. One rack wrote all 5.36 TB in 6m14s with all sixteen tasks healthy.
Measured on d6144 at one rack, 64 GB200s, four processes per node, with a
synthetic token source so no data-pipeline failure could precede the save.

Peak exceeds the budget because a snapshot larger than the whole budget proceeds
alone, so the floor is set by the largest single array and lowering the budget
further buys little. This also slows saves for topologies that were not at risk,
since a smaller budget rolls through more write batches. The durable fix is to
make the budget node-aware rather than per process, so a change in processes per
node cannot silently multiply host pressure again; this change buys headroom at
the current hero shape while that is designed.
