### PR TITLE
[grug] Retry and resume a hero scaling-ladder run after a fault

### DIFF
--- a/experiments/grug/dispatch.py
+++ b/experiments/grug/dispatch.py
@@ -49,6 +49,7 @@ def dispatch_grug_training_run(
     local_entrypoint: Callable[[ConfigT], None],
     resources: ResourceConfig,
     max_retries_failure: int = 3,
+    max_task_failures: int = 10,
     processes_per_task: int = 1,
     priority: int = INHERIT_PRIORITY,
 ) -> None:
@@ -56,6 +57,10 @@ def dispatch_grug_training_run(
 
     ``INHERIT_PRIORITY`` takes the submitting job's band, or ``interactive`` when the submitter is
     not itself an Iris job -- which is the case for a launcher run from a dev box.
+
+    ``max_retries_failure`` is the per-task retry budget and ``max_task_failures`` is the
+    cumulative one. The job fails when either is exhausted, so raise the two together: a large
+    per-task budget under a small cumulative one still ends the job at the cumulative limit.
     """
     safe_run_id = _safe_job_suffix(run_id)
     env_vars = resolve_training_env(base_env=_forwarded_env_vars(), resources=resources)
@@ -65,7 +70,7 @@ def dispatch_grug_training_run(
         resources=resources,
         environment=create_environment(env_vars=env_vars, extras=extras_for_resources(resources)),
         max_retries_failure=max_retries_failure,
-        max_task_failures=10,
+        max_task_failures=max_task_failures,
         processes_per_task=processes_per_task,
         priority=priority,
     )

--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -189,8 +189,13 @@ cadence, and checkpoint policy all follow `--size`:
 | d6144 | 11 | 11264 | 390,251 | every 3000 | every 6k |
 
 Train batch is 1024 × racks; eval batch is 64 × racks (one sequence per device). The step budget is
-791 tokens per active parameter (18T at d6144); pass `--num-steps` to override. Checkpoints are
-output-only — an offloaded run cannot restore from one, so a preempted run restarts at step 0.
+791 tokens per active parameter (18T at d6144); pass `--num-steps` to override.
+
+A rung resumes from the newest checkpoint it finds. The permanent checkpoints above go to the
+durable output root, and a rolling temporary checkpoint every 30 minutes goes to region-local temp
+storage with a 30-day lifecycle TTL. One temporary checkpoint is kept. A hardware fault, a host
+out-of-memory, or a preemption thus costs at most 30 minutes of training. The training job retries
+1000 times on failure and 100 times on preemption.
 
 ```bash
 python -m experiments.grug.moe_hero_ep.launch_scaling_ladder \

--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -192,9 +192,9 @@ Train batch is 1024 × racks; eval batch is 64 × racks (one sequence per device
 791 tokens per active parameter (18T at d6144); pass `--num-steps` to override.
 
 A rung resumes from the newest checkpoint it finds. The permanent checkpoints above go to the
-durable output root, and a rolling temporary checkpoint every 30 minutes goes to region-local temp
+durable output root, and a rolling temporary checkpoint every hour goes to region-local temp
 storage with the shared 14-day lifecycle TTL. One temporary checkpoint is kept. A hardware fault, a
-host out-of-memory, or a preemption thus costs at most 30 minutes of training. The training job
+host out-of-memory, or a preemption thus costs at most one hour of training. The training job
 retries 1000 times on failure and 100 times on preemption.
 
 ```bash

--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -193,9 +193,9 @@ Train batch is 1024 × racks; eval batch is 64 × racks (one sequence per device
 
 A rung resumes from the newest checkpoint it finds. The permanent checkpoints above go to the
 durable output root, and a rolling temporary checkpoint every 30 minutes goes to region-local temp
-storage with a 30-day lifecycle TTL. One temporary checkpoint is kept. A hardware fault, a host
-out-of-memory, or a preemption thus costs at most 30 minutes of training. The training job retries
-1000 times on failure and 100 times on preemption.
+storage with the shared 14-day lifecycle TTL. One temporary checkpoint is kept. A hardware fault, a
+host out-of-memory, or a preemption thus costs at most 30 minutes of training. The training job
+retries 1000 times on failure and 100 times on preemption.
 
 ```bash
 python -m experiments.grug.moe_hero_ep.launch_scaling_ladder \

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -134,8 +134,9 @@ def build_ladder_run(
     parameter at the rung's (rack-scaled) batch. Every eval scores the held-out set both as-trained
     and dropless. The narrow rungs eval every 5% of the run and keep only the forced final
     checkpoint; the d6144 hero evals every 3000 steps and keeps a permanent checkpoint every 6000.
-    ``checkpoint_every`` overrides that cadence for any rung. Checkpoints are output-only: an
-    offloaded run cannot restore from one, so they serve analysis rather than crash recovery.
+    ``checkpoint_every`` overrides that cadence for any rung. A rolling temporary checkpoint every
+    ``RESUME_SAVE_INTERVAL`` on region-local storage covers a crash or a preemption, and a rung
+    resumes from the newest checkpoint it finds.
     """
     if not run_id.strip():
         raise ValueError("run_id must not be empty")
@@ -307,8 +308,9 @@ def build_ladder_run(
     "--checkpoint-every",
     type=click.IntRange(min=1),
     default=None,
-    help="Keep a permanent checkpoint every N steps. Default follows the rung (6000 at d6144, "
-    "final only elsewhere). Checkpoints are output-only; an offloaded run cannot restore from one.",
+    help="Keep a permanent checkpoint every N steps on the durable output root. Default follows "
+    "the rung (6000 at d6144, final only elsewhere). Resume uses the rolling temporary checkpoint "
+    "and is not affected by this option.",
 )
 @build_options
 def main(

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -88,7 +88,7 @@ TOKENS_PER_ACTIVE_PARAM = 791
 TENSORSTORE_CACHE_BYTES = 125_000_000_000
 # A crash costs at most this much training time. A hero checkpoint is several TB, thus a shorter
 # interval would spend a large part of the run inside a checkpoint write.
-RESUME_SAVE_INTERVAL = timedelta(minutes=30)
+RESUME_SAVE_INTERVAL = timedelta(hours=1)
 # A rung runs up to 176 tasks for hundreds of GPU-days, where a hardware fault or a host
 # out-of-memory on one task is routine. A rung resumes from its newest checkpoint, thus a retry
 # continues the run instead of repeating it. Retry deeply so one bad task does not end a rung.

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -23,6 +23,7 @@ analytic estimate (forward+backward, including attention and the latent-MoE corr
 
 import dataclasses
 import os
+from datetime import timedelta
 
 import click
 import jmp
@@ -36,6 +37,7 @@ from marin.execution.build_context import resolve_version
 from marin.execution.lazy import ArtifactStep, StepContext
 from marin.experiment.cli import build_options
 from marin.experiment.namespacing import user_namespaced_name
+from rigging.filesystem.cluster_config import marin_temp_bucket
 from rigging.filesystem.storage_path import prefix_join
 
 from experiments.datasets.uncheatable import uncheatable_datasets
@@ -84,6 +86,10 @@ WATCH_INTERVAL = 10
 # scales every narrower rung by the same ratio.
 TOKENS_PER_ACTIVE_PARAM = 791
 TENSORSTORE_CACHE_BYTES = 125_000_000_000
+# Rolling resume checkpoints go to region-local storage that expires after 30 days. A crash thus
+# costs at most this much training time, against a hero checkpoint that is several TB.
+RESUME_SAVE_INTERVAL = timedelta(minutes=30)
+RESUME_CHECKPOINT_TTL_DAYS = 30
 
 
 def _ladder_model(size: str):
@@ -231,17 +237,16 @@ def build_ladder_run(
             use_explicit_mesh_axes=True,
             require_accelerator=True,
             allow_nondivisible_batch_size=False,
-            # Checkpoints are output-only: an offloaded run cannot restore from one (its pinned-host
-            # master/opt state comes back device-kind and mismatches the jitted step). load_checkpoint
-            # is forced False so a retry after a checkpoint starts fresh instead of crashing on the
-            # broken restore. A preempted run therefore restarts at step 0.
-            load_checkpoint=False,
-            # No time-based temporary checkpoints -- they would only exist to enable that broken
-            # restore. Keep just the permanent step-interval checkpoints below plus the forced final.
+            # load_checkpoint stays None (resume from the newest checkpoint that exists), so a retry
+            # after a hardware or memory fault continues the run. Levanter 8443 made a pinned-host
+            # restore work: it deserializes each offloaded leaf onto device and then moves it to its
+            # target memory kind, one leaf at a time.
             checkpointer=CheckpointerConfig(
                 base_path=prefix_join(ctx.output_path, "checkpoints"),
-                temporary_base_path=None,
-                save_interval=None,
+                # Rolling resume checkpoints go to region-local temp storage with a lifecycle TTL.
+                # The durable output root keeps only the permanent milestones and the final one.
+                temporary_base_path=ctx.runtime_arg("resume_checkpoint_path"),
+                save_interval=RESUME_SAVE_INTERVAL,
                 keep=keep_permanent,
                 append_run_id_to_base_path=False,
                 delete_old_temp_checkpoints=True,
@@ -280,7 +285,12 @@ def build_ladder_run(
         run=run_grug,
         build_config=build_config,
         deps=(HARRIER_MIX_2026_08_18_STORE, *validation),
-        runtime_args={"train_resources": train_resources},
+        runtime_args={
+            "train_resources": train_resources,
+            # A runtime arg, not a config field: the resolved bucket is regional, thus it would
+            # otherwise put the launching cluster into the step's fingerprint.
+            "resume_checkpoint_path": marin_temp_bucket(RESUME_CHECKPOINT_TTL_DAYS, f"grug/{run_id}/resume"),
+        },
     )
 
 

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -89,6 +89,12 @@ TENSORSTORE_CACHE_BYTES = 125_000_000_000
 # A crash costs at most this much training time. A hero checkpoint is several TB, thus a shorter
 # interval would spend a large part of the run inside a checkpoint write.
 RESUME_SAVE_INTERVAL = timedelta(minutes=30)
+# A rung runs up to 176 tasks for hundreds of GPU-days, where a hardware fault or a host
+# out-of-memory on one task is routine. A rung resumes from its newest checkpoint, thus a retry
+# continues the run instead of repeating it. Retry deeply so one bad task does not end a rung.
+# The two counters are separate gates and the job fails when either one trips.
+LADDER_MAX_RETRIES_FAILURE = 1000
+LADDER_MAX_TASK_FAILURES = 1000
 
 
 def _ladder_model(size: str):
@@ -273,6 +279,8 @@ def build_ladder_run(
             ),
             stop_after_steps=num_steps,
             processes_per_task=HERO_GPUS_PER_NODE,
+            max_retries_failure=LADDER_MAX_RETRIES_FAILURE,
+            max_task_failures=LADDER_MAX_TASK_FAILURES,
         )
 
     return ArtifactStep(

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -37,7 +37,7 @@ from marin.execution.build_context import resolve_version
 from marin.execution.lazy import ArtifactStep, StepContext
 from marin.experiment.cli import build_options
 from marin.experiment.namespacing import user_namespaced_name
-from rigging.filesystem.cluster_config import marin_temp_bucket
+from marin.training.training import temporary_checkpoint_base_path
 from rigging.filesystem.storage_path import prefix_join
 
 from experiments.datasets.uncheatable import uncheatable_datasets
@@ -86,10 +86,9 @@ WATCH_INTERVAL = 10
 # scales every narrower rung by the same ratio.
 TOKENS_PER_ACTIVE_PARAM = 791
 TENSORSTORE_CACHE_BYTES = 125_000_000_000
-# Rolling resume checkpoints go to region-local storage that expires after 30 days. A crash thus
-# costs at most this much training time, against a hero checkpoint that is several TB.
+# A crash costs at most this much training time. A hero checkpoint is several TB, thus a shorter
+# interval would spend a large part of the run inside a checkpoint write.
 RESUME_SAVE_INTERVAL = timedelta(minutes=30)
-RESUME_CHECKPOINT_TTL_DAYS = 30
 
 
 def _ladder_model(size: str):
@@ -237,15 +236,13 @@ def build_ladder_run(
             use_explicit_mesh_axes=True,
             require_accelerator=True,
             allow_nondivisible_batch_size=False,
-            # load_checkpoint stays None (resume from the newest checkpoint that exists), so a retry
-            # after a hardware or memory fault continues the run. Levanter 8443 made a pinned-host
-            # restore work: it deserializes each offloaded leaf onto device and then moves it to its
-            # target memory kind, one leaf at a time.
+            # load_checkpoint stays None: the trainer resumes from the newest checkpoint that
+            # exists, so a retry after a hardware or memory fault continues the run.
             checkpointer=CheckpointerConfig(
                 base_path=prefix_join(ctx.output_path, "checkpoints"),
                 # Rolling resume checkpoints go to region-local temp storage with a lifecycle TTL.
                 # The durable output root keeps only the permanent milestones and the final one.
-                temporary_base_path=ctx.runtime_arg("resume_checkpoint_path"),
+                temporary_base_path=temporary_checkpoint_base_path(ctx.output_path),
                 save_interval=RESUME_SAVE_INTERVAL,
                 keep=keep_permanent,
                 append_run_id_to_base_path=False,
@@ -285,12 +282,7 @@ def build_ladder_run(
         run=run_grug,
         build_config=build_config,
         deps=(HARRIER_MIX_2026_08_18_STORE, *validation),
-        runtime_args={
-            "train_resources": train_resources,
-            # A runtime arg, not a config field: the resolved bucket is regional, thus it would
-            # otherwise put the launching cluster into the step's fingerprint.
-            "resume_checkpoint_path": marin_temp_bucket(RESUME_CHECKPOINT_TTL_DAYS, f"grug/{run_id}/resume"),
-        },
+        runtime_args={"train_resources": train_resources},
     )
 
 

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -175,6 +175,12 @@ class GrugRunConfig:
     # GPU processes per task: > 1 runs one JAX process per GPU (multi-controller)
     # via the iris.hooks.multigpu_main supervisor instead of one process per node.
     processes_per_task: int = 1
+    # Retry budgets for the training job. The two are separate gates and the job fails when either
+    # one trips, thus raise them together. The defaults make a failure terminal, which is what a run
+    # that cannot resume wants: a retry would repeat it from step 0. Only a run that both saves and
+    # restores checkpoints benefits from a deep budget.
+    max_retries_failure: int = 0
+    max_task_failures: int = 10
 
 
 def build_train_dataset(
@@ -953,13 +959,8 @@ def run_grug(config: GrugRunConfig) -> None:
         local_entrypoint=_run_grug_local,
         resources=config.resources,
         processes_per_task=config.processes_per_task,
-        # A hero run spans hundreds of GPU-days across hundreds of tasks, where a hardware fault or
-        # a host out-of-memory on one task is routine. Retry deeply so one bad task does not end the
-        # run. Both counters are raised together, because the cumulative one caps the per-task one.
-        # A retry restarts from the newest checkpoint, thus a deep budget only pays off while
-        # load_checkpoint is on; with restore off, every retry repeats the run from step 0.
-        max_retries_failure=1000,
-        max_task_failures=1000,
+        max_retries_failure=config.max_retries_failure,
+        max_task_failures=config.max_task_failures,
     )
 
 

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -953,10 +953,13 @@ def run_grug(config: GrugRunConfig) -> None:
         local_entrypoint=_run_grug_local,
         resources=config.resources,
         processes_per_task=config.processes_per_task,
-        # A hero EP run forces load_checkpoint=False, so a retry always restarts at step 0. Retrying
-        # a failure that lands late therefore discards the whole run and repeats it. Make failures
-        # terminal and keep the written checkpoint; preemption retries are a separate counter.
-        max_retries_failure=0,
+        # A hero run spans hundreds of GPU-days across hundreds of tasks, where a hardware fault or
+        # a host out-of-memory on one task is routine. Retry deeply so one bad task does not end the
+        # run. Both counters are raised together, because the cumulative one caps the per-task one.
+        # A retry restarts from the newest checkpoint, thus a deep budget only pays off while
+        # load_checkpoint is on; with restore off, every retry repeats the run from step 0.
+        max_retries_failure=1000,
+        max_task_failures=1000,
     )
 
 

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -169,19 +169,26 @@ def test_expert_bank_override_must_support_three_waves():
         launch.build_hero_run(run_id="bad-waves", dp_racks=1, num_steps=1, num_experts=256, version="dev")
 
 
+def _runtime_env_config(*, processes_per_task=1, watch_mode=train.WatchMode.INLINE, watch_interval=1):
+    """A stand-in for GrugRunConfig holding only the fields ``run_grug``'s env setup and dispatch read."""
+    return SimpleNamespace(
+        trainer=SimpleNamespace(
+            trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=watch_interval)),
+            watch_mode=watch_mode,
+        ),
+        resources=object(),
+        processes_per_task=processes_per_task,
+        max_retries_failure=0,
+        max_task_failures=10,
+    )
+
+
 def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch):
     explicit_overlap = "--xla_gpu_experimental_parallel_collective_overlap_limit=2"
     monkeypatch.setenv("XLA_FLAGS", explicit_overlap)
     for name in train.HERO_EP_RUNTIME_ENV:
         monkeypatch.delenv(name, raising=False)
-    config = SimpleNamespace(
-        trainer=SimpleNamespace(
-            trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=1)),
-            watch_mode=train.WatchMode.INLINE,
-        ),
-        resources=object(),
-        processes_per_task=1,
-    )
+    config = _runtime_env_config()
 
     with patch.object(train, "dispatch_grug_training_run"):
         train.run_grug(config)
@@ -204,14 +211,7 @@ def test_run_grug_defaults_pgle_off_for_per_gpu_processes(monkeypatch):
     for name in train.HERO_EP_RUNTIME_ENV:
         monkeypatch.delenv(name, raising=False)
     monkeypatch.delenv("XLA_FLAGS", raising=False)
-    config = SimpleNamespace(
-        trainer=SimpleNamespace(
-            trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=1)),
-            watch_mode=train.WatchMode.INLINE,
-        ),
-        resources=object(),
-        processes_per_task=4,
-    )
+    config = _runtime_env_config(processes_per_task=4)
 
     with patch.object(train, "dispatch_grug_training_run"):
         train.run_grug(config)
@@ -228,14 +228,7 @@ def test_run_grug_keeps_explicit_ep_runtime_values(monkeypatch):
     monkeypatch.setenv("JAX_ENABLE_PGLE", "false")
     monkeypatch.setenv("XLA_PYTHON_CLIENT_ALLOCATOR", "platform")
     monkeypatch.delenv("XLA_FLAGS", raising=False)
-    config = SimpleNamespace(
-        trainer=SimpleNamespace(
-            trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=1)),
-            watch_mode=train.WatchMode.INLINE,
-        ),
-        resources=object(),
-        processes_per_task=1,
-    )
+    config = _runtime_env_config()
 
     with patch.object(train, "dispatch_grug_training_run"):
         train.run_grug(config)
@@ -256,14 +249,7 @@ def test_run_grug_reduces_collective_overlap_only_for_inline_watch(
     monkeypatch, watch_mode, watch_interval, expected_overlap_limit
 ):
     monkeypatch.delenv("XLA_FLAGS", raising=False)
-    config = SimpleNamespace(
-        trainer=SimpleNamespace(
-            trainer=SimpleNamespace(id="test-run", watch=WatchConfig(interval=watch_interval)),
-            watch_mode=watch_mode,
-        ),
-        resources=object(),
-        processes_per_task=1,
-    )
+    config = _runtime_env_config(watch_mode=watch_mode, watch_interval=watch_interval)
 
     with patch.object(train, "dispatch_grug_training_run"):
         train.run_grug(config)


### PR DESCRIPTION
A d6144 rung runs 176 tasks for hundreds of GPU-days, where a hardware fault or a host
out-of-memory on one task is routine. Such a fault ended the whole run: the per-task retry budget
was 0, and the trainer forced load_checkpoint=False, so a retry could not have resumed anyway.

Raise both retry counters to 1000 for the ladder. They are separate gates and the job fails when
either one trips, so a large per-task budget under the previous cumulative cap of 10 would still
have ended the run at the eleventh failure. The budgets live on GrugRunConfig and default to the
previous terminal-on-failure behavior, because run_grug is shared with launch_mfu_test and
small_scale_abl_launch, which do not save checkpoints and would only repeat a deterministic failure
from step 0.

Levanter 8443 made a pinned-host restore work: it deserializes each offloaded leaf onto device and
then moves it to its target memory kind, one leaf at a time. Drop the forced load_checkpoint=False
and add a rolling temporary checkpoint every hour through
marin.training.temporary_checkpoint_base_path, which keys region-local storage off the run's output
path. The durable output root keeps only the permanent milestones and the final checkpoint. A
d6144 checkpoint is several TB, so a shorter interval would spend a large part of the run inside a
checkpoint write. A fault now costs at most one hour of training.

The d6144 save path completed on a one-rack test at current main. The restore path has unit coverage
from 8443 and has not run at d6144.

Run hero-20260819 launched before this branch and keeps the old policy. It needs a relaunch to pick
the change up.
