### PR TITLE
[grug] moe_hero_ep: run the baseline eval through a one-shot hook

### DIFF
--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -277,8 +277,9 @@ def build_ladder_run(
                 eval_ema=False,
                 compute_bpb=True,
                 dropless_eval=True,
-                # The hero is the run whose full loss curve we report, so give it a step-0 baseline.
-                eval_at_step_0=size == "d6144",
+                # The hero is the run whose full loss curve we report, so give it an early baseline
+                # point a few steps in (past first-step warmup); other rungs eval every 5% already.
+                baseline_eval_step=10 if size == "d6144" else 0,
             ),
             stop_after_steps=num_steps,
             processes_per_task=HERO_GPUS_PER_NODE,

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -277,9 +277,9 @@ def build_ladder_run(
                 eval_ema=False,
                 compute_bpb=True,
                 dropless_eval=True,
-                # The hero is the run whose full loss curve we report, so give it an early baseline
-                # point a few steps in (past first-step warmup); other rungs eval every 5% already.
-                baseline_eval_step=10 if size == "d6144" else 0,
+                # The hero is the run whose full loss curve we report, so give it a baseline point
+                # at the start of the curve.
+                eval_at_first_step=size == "d6144",
             ),
             stop_after_steps=num_steps,
             processes_per_task=HERO_GPUS_PER_NODE,

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -271,12 +271,10 @@ def _first_step_only(hook: Callable[..., None]) -> Callable[..., None]:
     ``StateCallbackRunner`` dispatches on ``next_step % every``, thus ``every=1`` is the only
     interval that covers the first step. The gate makes that registration one-shot. A resumed run
     starts above step 1 and never fires it.
-
-    ``functools.wraps`` keeps the wrapped hook's signature, which ``LambdaCallback`` reads to decide
-    whether to pass ``force``. Without it the ``**kwargs`` here advertises a ``force`` parameter that
-    the wrapped hook can lack.
     """
 
+    # `LambdaCallback` reads the signature to decide whether to pass `force`, and the `**kwargs`
+    # below would otherwise advertise a `force` parameter that the wrapped hook can lack.
     @functools.wraps(hook)
     def gated(step, *args, **kwargs):
         if step.next_step != 1:

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -155,12 +155,9 @@ class GrugEvalConfig:
     # expert-collapsed mesh, logging a separate `eval_dropless` macro loss alongside the
     # as-trained (with-drop) eval. No-op when the mesh has no expert parallelism.
     dropless_eval: bool = False
-    # Run one early baseline eval right after this step (0 disables), for a point on the loss curve
-    # before the periodic cadence's first eval (which lands at steps_per_eval). Running it a few
-    # steps in -- rather than before the loop -- keeps the train executable compiled and the offloaded
-    # optimizer state on host, so the eval stays in the periodic-eval HBM regime instead of colliding
-    # with the first train-step compile; a small value (e.g. 10) is past any first-step warmup.
-    baseline_eval_step: int = 0
+    # Run the evals once after the first optimization step, for a baseline at the start of the loss
+    # curve. The periodic cadence first fires at `steps_per_eval`, thus it leaves that start bare.
+    eval_at_first_step: bool = False
 
 
 @dataclass(frozen=True)
@@ -266,6 +263,27 @@ def _to_dropless_local(model: Transformer) -> Transformer:
     expert_mlp = model.stacked_blocks.stacked.mlp.expert_mlp
     dropless = dataclasses.replace(expert_mlp, implementation="sonic_cute", expert_chunks=1)
     return eqx.tree_at(lambda m: m.stacked_blocks.stacked.mlp.expert_mlp, model, dropless)
+
+
+def _first_step_only(hook: Callable[..., None]) -> Callable[..., None]:
+    """Wrap ``hook`` so that it runs one time only, after the first optimization step.
+
+    ``StateCallbackRunner`` dispatches on ``next_step % every``, thus ``every=1`` is the only
+    interval that covers the first step. The gate makes that registration one-shot. A resumed run
+    starts above step 1 and never fires it.
+
+    ``functools.wraps`` keeps the wrapped hook's signature, which ``LambdaCallback`` reads to decide
+    whether to pass ``force``. Without it the ``**kwargs`` here advertises a ``force`` parameter that
+    the wrapped hook can lack.
+    """
+
+    @functools.wraps(hook)
+    def gated(step, *args, **kwargs):
+        if step.next_step != 1:
+            return
+        hook(step, *args, **kwargs)
+
+    return gated
 
 
 def build_tagged_evaluator(
@@ -823,16 +841,14 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         if evaluator is not None and eval_cfg is not None:
             interval = eval_cfg.steps_per_eval
             eval_ema = eval_cfg.eval_ema and config.trainer.ema_beta is not None
-            if interval is not None and interval > 0 and (eval_cfg.eval_current or eval_ema):
-                state_callbacks.add_hook(
-                    cb_tagged_evaluate(
-                        evaluator,
-                        prefix=eval_cfg.prefix,
-                        eval_current=eval_cfg.eval_current,
-                        eval_ema=eval_ema,
-                    ),
-                    every=interval,
+            if eval_cfg.eval_current or eval_ema:
+                tagged_eval_hook = cb_tagged_evaluate(
+                    evaluator,
+                    prefix=eval_cfg.prefix,
+                    eval_current=eval_cfg.eval_current,
+                    eval_ema=eval_ema,
                 )
+                eval_hooks: list[Callable[..., None]] = [tagged_eval_hook]
                 if dropless_evaluator is not None and dropless_eval_mesh is not None:
                     # The training loop runs under `set_mesh(mesh)` (expert-parallel). The dropless
                     # evaluator runs under the expert-collapsed mesh, so the model params -- sharded on
@@ -847,24 +863,33 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                         step_count = int(step.step)
                         if step_count < 0:
                             return
+                        # `model` must stay a local. The eval mesh has expert=1, so a leaf sharded on
+                        # the expert axis lands replicated, and the copy is much larger than the
+                        # train-mesh params. The train step needs almost the whole device budget for
+                        # its temporary buffer, thus this copy must die before the next step.
                         with set_mesh(_mesh):
                             model = _reshard_tree_to_mesh(step.model, _mesh)
                             with jax_config.enable_pgle(False):
                                 log_dict = eval_model(_ev, model, prefix=_prefix)
                             levanter.tracker.log(log_dict, step=step_count)
 
-                    state_callbacks.add_hook(dropless_eval_hook, every=interval)
+                    eval_hooks.append(dropless_eval_hook)
 
-        # Early baseline eval a few steps into the run (see the loop body). Only on a fresh run -- a
-        # resume starts at a nonzero step and already has earlier points -- and only when there is an
-        # evaluator to run.
-        baseline_eval_pending = (
-            eval_cfg is not None
-            and eval_cfg.baseline_eval_step > 0
-            and eval_cfg.eval_current
-            and evaluator is not None
-            and int(state.step) == 0
-        )
+                if interval is not None and interval > 0:
+                    for hook in eval_hooks:
+                        state_callbacks.add_hook(hook, every=interval)
+
+                # Baseline point at the start of the loss curve. The periodic cadence first fires at
+                # `steps_per_eval` (step 3000 on the hero), thus a fresh run gets no early point.
+                # These run after the first optimization step, not before it: the first train step
+                # then allocates against a clean pool, and the eval-to-train handoff gets a gate at
+                # step 2 instead of first at step 3000. `every=1` is the only interval that covers
+                # the first step, and `_first_step_only` makes the hook fire once. A resumed run
+                # starts above step 1, thus it never fires. The hooks log at `StepInfo.step`, which
+                # is 0 there, so the point lands at step 0 on the curve.
+                if eval_cfg.eval_at_first_step:
+                    for hook in eval_hooks:
+                        state_callbacks.add_hook(_first_step_only(hook), every=1)
 
         last_loss: float | jax.Array = 0.0
         last_step_duration = 0.0
@@ -928,24 +953,6 @@ def _run_grug_local(config: GrugRunConfig) -> None:
 
                     if watch_stats is not None:
                         levanter.tracker.log(watch_stats, step=step)
-
-                # One-shot early baseline eval once the run reaches baseline_eval_step. Runs in the
-                # same post-step context as the periodic eval hooks (train executable compiled,
-                # offloaded state on host), so it does not collide with the first train-step compile
-                # the way a pre-loop eval would. Mirrors the hook bodies: as-trained plus the dropless.
-                if baseline_eval_pending and int(state.step) == eval_cfg.baseline_eval_step:
-                    baseline_eval_pending = False
-                    levanter.tracker.log(
-                        eval_model(evaluator, state.params, prefix=eval_cfg.prefix), step=int(state.step)
-                    )
-                    if dropless_evaluator is not None and dropless_eval_mesh is not None:
-                        with set_mesh(dropless_eval_mesh):
-                            baseline_model = _reshard_tree_to_mesh(state.params, dropless_eval_mesh)
-                            with jax_config.enable_pgle(False):
-                                baseline_dropless = eval_model(
-                                    dropless_evaluator, baseline_model, prefix=f"{eval_cfg.prefix}_dropless"
-                                )
-                        levanter.tracker.log(baseline_dropless, step=int(state.step))
 
                 if checkpointer is not None:
                     with callbacks.progress_event_scope(

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -155,9 +155,12 @@ class GrugEvalConfig:
     # expert-collapsed mesh, logging a separate `eval_dropless` macro loss alongside the
     # as-trained (with-drop) eval. No-op when the mesh has no expert parallelism.
     dropless_eval: bool = False
-    # Eval the initialized model once before the first optimization step, for a step-0 baseline on
-    # the loss curve. The periodic cadence never covers step 0 (its dispatch gates on next_step > 0).
-    eval_at_step_0: bool = False
+    # Run one early baseline eval right after this step (0 disables), for a point on the loss curve
+    # before the periodic cadence's first eval (which lands at steps_per_eval). Running it a few
+    # steps in -- rather than before the loop -- keeps the train executable compiled and the offloaded
+    # optimizer state on host, so the eval stays in the periodic-eval HBM regime instead of colliding
+    # with the first train-step compile; a small value (e.g. 10) is past any first-step warmup.
+    baseline_eval_step: int = 0
 
 
 @dataclass(frozen=True)
@@ -852,22 +855,16 @@ def _run_grug_local(config: GrugRunConfig) -> None:
 
                     state_callbacks.add_hook(dropless_eval_hook, every=interval)
 
-        # Baseline eval on the initialized model, before the first optimization step. The periodic
-        # eval hooks never fire at step 0 -- their dispatch gates on `next_step > 0`, and the loop
-        # only runs hooks after a step -- so a fresh run gets no step-0 point without this. It runs
-        # only at step 0, so a resumed run (nonzero step) skips it. Mirrors the hook bodies above:
-        # the as-trained eval plus, for expert-parallel runs, the dropless eval on the collapsed mesh.
-        step0_eval = eval_cfg is not None and eval_cfg.eval_at_step_0 and eval_cfg.eval_current
-        if step0_eval and evaluator is not None and int(state.step) == 0:
-            levanter.tracker.log(eval_model(evaluator, state.params, prefix=eval_cfg.prefix), step=0)
-            if dropless_evaluator is not None and dropless_eval_mesh is not None:
-                with set_mesh(dropless_eval_mesh):
-                    step0_model = _reshard_tree_to_mesh(state.params, dropless_eval_mesh)
-                    with jax_config.enable_pgle(False):
-                        step0_dropless = eval_model(
-                            dropless_evaluator, step0_model, prefix=f"{eval_cfg.prefix}_dropless"
-                        )
-                levanter.tracker.log(step0_dropless, step=0)
+        # Early baseline eval a few steps into the run (see the loop body). Only on a fresh run -- a
+        # resume starts at a nonzero step and already has earlier points -- and only when there is an
+        # evaluator to run.
+        baseline_eval_pending = (
+            eval_cfg is not None
+            and eval_cfg.baseline_eval_step > 0
+            and eval_cfg.eval_current
+            and evaluator is not None
+            and int(state.step) == 0
+        )
 
         last_loss: float | jax.Array = 0.0
         last_step_duration = 0.0
@@ -931,6 +928,24 @@ def _run_grug_local(config: GrugRunConfig) -> None:
 
                     if watch_stats is not None:
                         levanter.tracker.log(watch_stats, step=step)
+
+                # One-shot early baseline eval once the run reaches baseline_eval_step. Runs in the
+                # same post-step context as the periodic eval hooks (train executable compiled,
+                # offloaded state on host), so it does not collide with the first train-step compile
+                # the way a pre-loop eval would. Mirrors the hook bodies: as-trained plus the dropless.
+                if baseline_eval_pending and int(state.step) == eval_cfg.baseline_eval_step:
+                    baseline_eval_pending = False
+                    levanter.tracker.log(
+                        eval_model(evaluator, state.params, prefix=eval_cfg.prefix), step=int(state.step)
+                    )
+                    if dropless_evaluator is not None and dropless_eval_mesh is not None:
+                        with set_mesh(dropless_eval_mesh):
+                            baseline_model = _reshard_tree_to_mesh(state.params, dropless_eval_mesh)
+                            with jax_config.enable_pgle(False):
+                                baseline_dropless = eval_model(
+                                    dropless_evaluator, baseline_model, prefix=f"{eval_cfg.prefix}_dropless"
+                                )
+                        levanter.tracker.log(baseline_dropless, step=int(state.step))
 
                 if checkpointer is not None:
                     with callbacks.progress_event_scope(

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -19,6 +19,7 @@ import optax
 import pytest
 from jax.sharding import AbstractMesh, AxisType, Mesh, NamedSharding, set_mesh, use_abstract_mesh
 from jax.sharding import PartitionSpec as P
+from levanter.callbacks.state_adapter import StateCallbackRunner
 from levanter.callbacks.watch import WatchConfig, compute_watch_stats
 from marin.execution.lazy import StepContext
 
@@ -873,3 +874,32 @@ def test_drop_metrics_sums_per_layer_counts_in_int64_without_overflow():
     assert metrics["moe/dropped_assignments"] == sender_total + receiver_total  # no int32 wrap
     assert metrics["moe/sender_dropped_assignments"] == sender_total
     assert metrics["moe/receiver_dropped_assignments"] == receiver_total
+
+
+def test_baseline_eval_hook_runs_once_after_the_first_step():
+    # The baseline eval must fire on the first completed step and never again: it reshards the
+    # params onto the expert-collapsed mesh, and that copy competes with the train step's temporary
+    # buffer. A resumed run starts above step 1 and must skip it.
+    fired = []
+    runner = StateCallbackRunner[SimpleNamespace](
+        step_getter=lambda s: s.step,
+        model_getter=lambda s: s.params,
+        eval_model_getter=lambda s: s.params,
+        opt_state_getter=lambda s: s.opt_state,
+    )
+    runner.add_hook(train._first_step_only(lambda info: fired.append(info.step)), every=1)
+
+    def run_steps(next_steps):
+        for next_step in next_steps:
+            runner.run(
+                SimpleNamespace(step=jnp.int32(next_step), params=None, opt_state=None),
+                loss=0.0,
+                step_duration=0.0,
+            )
+
+    run_steps([1, 2, 3, 3000])
+    assert fired == [0]  # StepInfo.step is next_step - 1, so the point lands at 0 on the curve
+
+    fired.clear()
+    run_steps([5001, 5002])  # a resumed run
+    assert fired == []


### PR DESCRIPTION
Run the hero's early baseline eval through a second registration of the existing eval hooks, gated to fire one time after the first optimization step, instead of through a separate inline eval body.

The step-0 eval added in #8474 bound the params resharded onto the dropless eval mesh in `_run_grug_local`, and a `while` body is not a scope, so that copy stayed resident for the rest of the run. The eval mesh sets expert=1 and `_reshard_tree_to_mesh` keeps each leaf's PartitionSpec, thus an expert-sharded leaf lands replicated and the copy is far larger than the train-mesh params. On the d6144 hero it left `InUse` at 35.34 GiB against a 138.22 GiB limit, and the first `jit_train_step` could not get its 125.67 GiB buffer (`RESOURCE_EXHAUSTED`, `/rav/hero-84579c80-072503-coord`). The run before #8474 trained 387 steps at 20 s/step on the same 11-rack mesh, which bounds the true persistent state at 12.55 GiB or less.

The periodic `dropless_eval_hook` never had this problem, because its copy is a nested-function local that frees on return. Reusing it removes the second eval body.

`GrugEvalConfig.eval_at_step_0` becomes `eval_at_first_step`. The gate fires at `next_step == 1`, and the hooks log at `StepInfo.step`, so the point still lands at step 0 on the curve. A resumed run starts above step 1 and skips it. Running the eval after the first step rather than before it also gates the eval-to-train handoff at step 2. That transition is otherwise untested on the hero: the pre-#8474 run reached step 387, and the periodic cadence first fires at 3000.
