### PR TITLE
[levanter] Bound the host memory a hero resume holds

### DIFF
--- a/experiments/grug/checkpointing.py
+++ b/experiments/grug/checkpointing.py
@@ -12,11 +12,13 @@ from typing import ClassVar, Protocol, TypeVar, cast
 import fsspec
 import jax
 from fsspec import AbstractFileSystem
+from jax.experimental import multihost_utils
 from levanter.checkpoint import latest_checkpoint_path, load_checkpoint
 
 logger = logging.getLogger(__name__)
 
 StateT = TypeVar("StateT")
+RESTORE_COMPLETE_BARRIER = "grug_checkpoint_restore_complete"
 
 
 class _GrugState(Protocol):
@@ -122,6 +124,7 @@ def restore_grug_state_from_checkpoint(
                 allow_partial=allow_partial,
                 load_fn=_load_fn,
             )
+            multihost_utils.sync_global_devices(RESTORE_COMPLETE_BARRIER)
             if candidate not in checkpoint_search_paths:
                 logger.info("Loaded checkpoint from %s while searching %s", candidate, checkpoint_search_paths)
             return loaded

--- a/experiments/grug/checkpointing.py
+++ b/experiments/grug/checkpointing.py
@@ -124,9 +124,7 @@ def restore_grug_state_from_checkpoint(
                 allow_partial=allow_partial,
                 load_fn=_load_fn,
             )
-            logger.info("Rank %d finished checkpoint restore and entered the restore barrier", jax.process_index())
             multihost_utils.sync_global_devices(RESTORE_COMPLETE_BARRIER)
-            logger.info("Rank %d exited the restore barrier", jax.process_index())
             if candidate not in checkpoint_search_paths:
                 logger.info("Loaded checkpoint from %s while searching %s", candidate, checkpoint_search_paths)
             return loaded

--- a/experiments/grug/checkpointing.py
+++ b/experiments/grug/checkpointing.py
@@ -124,7 +124,9 @@ def restore_grug_state_from_checkpoint(
                 allow_partial=allow_partial,
                 load_fn=_load_fn,
             )
+            logger.info("Rank %d finished checkpoint restore and entered the restore barrier", jax.process_index())
             multihost_utils.sync_global_devices(RESTORE_COMPLETE_BARRIER)
+            logger.info("Rank %d exited the restore barrier", jax.process_index())
             if candidate not in checkpoint_search_paths:
                 logger.info("Loaded checkpoint from %s while searching %s", candidate, checkpoint_search_paths)
             return loaded

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -85,9 +85,11 @@ WATCH_INTERVAL = 10
 # 791 tokens per active parameter sets the step budget: it lands the d6144 hero at 18T tokens and
 # scales every narrower rung by the same ratio.
 TOKENS_PER_ACTIVE_PARAM = 791
-# 4 processes on each task share the 909 GiB container budget, thus this cap costs four times
-# what it reads. A resume peaked at 841.2 GiB against an 850 GiB limit and the container was
-# OOM-killed, because a restore adds about 140 GiB over a cold start's 699.6 GiB.
+# Host memory for each task's container. A resume peaked at 841.2 GiB against the earlier 850 GiB
+# request and the container was OOM-killed, because a restore adds about 140 GiB over a cold start's
+# 699.6 GiB.
+TASK_HOST_MEMORY = "909g"
+# 4 processes on each task share TASK_HOST_MEMORY, thus this cap costs four times what it reads.
 TENSORSTORE_CACHE_BYTES = 62_500_000_000
 # A crash costs at most this much training time. A hero checkpoint is several TB, thus a shorter
 # interval would spend a large part of the run inside a checkpoint write.
@@ -207,7 +209,7 @@ def build_ladder_run(
         "GB200",
         count=HERO_GPUS_PER_NODE,
         cpu=120,
-        ram="909g",
+        ram=TASK_HOST_MEMORY,
         disk="1t",
         replicas=HERO_EP_NODES * dp_racks,
     )

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -86,10 +86,10 @@ WATCH_INTERVAL = 10
 # scales every narrower rung by the same ratio.
 TOKENS_PER_ACTIVE_PARAM = 791
 # Host memory for each task's container, against a GB200x4 node that holds 955.7 GiB. This leaves
-# 25.7 GiB for the operating system and the kubelet, thus it is close to the ceiling. A resume was
+# 15.7 GiB for the operating system and the kubelet, thus it is at the ceiling. A resume was
 # OOM-killed at 850 GiB and again at 909 GiB, and the peak tracked each limit at 97 to 99 percent,
 # so more memory alone may not be enough.
-TASK_HOST_MEMORY = "930g"
+TASK_HOST_MEMORY = "940g"
 # 4 processes on each task share TASK_HOST_MEMORY, thus this cap costs four times what it reads.
 # Halving it during an out-of-memory investigation freed no measured host memory, thus it keeps the
 # value that PR 8456 selected.

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -85,10 +85,11 @@ WATCH_INTERVAL = 10
 # 791 tokens per active parameter sets the step budget: it lands the d6144 hero at 18T tokens and
 # scales every narrower rung by the same ratio.
 TOKENS_PER_ACTIVE_PARAM = 791
-# Host memory for each task's container. A resume peaked at 841.2 GiB against the earlier 850 GiB
-# request and the container was OOM-killed, because a restore adds about 140 GiB over a cold start's
-# 699.6 GiB.
-TASK_HOST_MEMORY = "909g"
+# Host memory for each task's container, against a GB200x4 node that holds 955.7 GiB. This leaves
+# 25.7 GiB for the operating system and the kubelet, thus it is close to the ceiling. A resume was
+# OOM-killed at 850 GiB and again at 909 GiB, and the peak tracked each limit at 97 to 99 percent,
+# so more memory alone may not be enough.
+TASK_HOST_MEMORY = "930g"
 # 4 processes on each task share TASK_HOST_MEMORY, thus this cap costs four times what it reads.
 TENSORSTORE_CACHE_BYTES = 62_500_000_000
 # A crash costs at most this much training time. A hero checkpoint is several TB, thus a shorter

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -97,13 +97,12 @@ TENSORSTORE_CACHE_BYTES = 125_000_000_000
 # A crash costs at most this much training time. A hero checkpoint is several TB, thus a shorter
 # interval would spend a large part of the run inside a checkpoint write.
 RESUME_SAVE_INTERVAL = timedelta(hours=1)
-# A rung runs up to 176 tasks for hundreds of GPU-days, where a single hardware fault is routine, so
-# a rung retries instead of ending. But Iris retries without a backoff, thus a deterministic failure
-# repeats for the whole budget: a resume that ran out of host memory on 3 tasks reran the gang every
-# 25 minutes on 704 GPUs and made no progress. The cumulative gate stays small so that a failure
-# which reproduces stops the run, while a lone transient one does not.
-LADDER_MAX_RETRIES_FAILURE = 3
-LADDER_MAX_TASK_FAILURES = 5
+# A rung runs up to 176 tasks for hundreds of GPU-days, where a hardware fault or a host
+# out-of-memory on one task is routine. A rung resumes from its newest checkpoint, thus a retry
+# continues the run instead of repeating it. Retry deeply so one bad task does not end a rung.
+# The two counters are separate gates and the job fails when either one trips.
+LADDER_MAX_RETRIES_FAILURE = 1000
+LADDER_MAX_TASK_FAILURES = 1000
 
 
 def _ladder_model(size: str):

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -85,14 +85,6 @@ WATCH_INTERVAL = 10
 # 791 tokens per active parameter sets the step budget: it lands the d6144 hero at 18T tokens and
 # scales every narrower rung by the same ratio.
 TOKENS_PER_ACTIVE_PARAM = 791
-# Host memory for each task's container, against a GB200x4 node that holds 955.7 GiB. This leaves
-# 15.7 GiB for the operating system and the kubelet, thus it is at the ceiling. A resume was
-# OOM-killed at 850 GiB and again at 909 GiB, and the peak tracked each limit at 97 to 99 percent,
-# so more memory alone may not be enough.
-TASK_HOST_MEMORY = "940g"
-# 4 processes on each task share TASK_HOST_MEMORY, thus this cap costs four times what it reads.
-# Halving it during an out-of-memory investigation freed no measured host memory, thus it keeps the
-# value that PR 8456 selected.
 TENSORSTORE_CACHE_BYTES = 125_000_000_000
 # A crash costs at most this much training time. A hero checkpoint is several TB, thus a shorter
 # interval would spend a large part of the run inside a checkpoint write.
@@ -212,7 +204,7 @@ def build_ladder_run(
         "GB200",
         count=HERO_GPUS_PER_NODE,
         cpu=120,
-        ram=TASK_HOST_MEMORY,
+        ram="850g",
         disk="1t",
         replicas=HERO_EP_NODES * dp_racks,
     )

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -85,7 +85,10 @@ WATCH_INTERVAL = 10
 # 791 tokens per active parameter sets the step budget: it lands the d6144 hero at 18T tokens and
 # scales every narrower rung by the same ratio.
 TOKENS_PER_ACTIVE_PARAM = 791
-TENSORSTORE_CACHE_BYTES = 125_000_000_000
+# 4 processes on each task share the 909 GiB container budget, thus this cap costs four times
+# what it reads. A resume peaked at 841.2 GiB against an 850 GiB limit and the container was
+# OOM-killed, because a restore adds about 140 GiB over a cold start's 699.6 GiB.
+TENSORSTORE_CACHE_BYTES = 62_500_000_000
 # A crash costs at most this much training time. A hero checkpoint is several TB, thus a shorter
 # interval would spend a large part of the run inside a checkpoint write.
 RESUME_SAVE_INTERVAL = timedelta(hours=1)
@@ -204,7 +207,7 @@ def build_ladder_run(
         "GB200",
         count=HERO_GPUS_PER_NODE,
         cpu=120,
-        ram="850g",
+        ram="909g",
         disk="1t",
         replicas=HERO_EP_NODES * dp_racks,
     )

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -91,7 +91,9 @@ TOKENS_PER_ACTIVE_PARAM = 791
 # so more memory alone may not be enough.
 TASK_HOST_MEMORY = "930g"
 # 4 processes on each task share TASK_HOST_MEMORY, thus this cap costs four times what it reads.
-TENSORSTORE_CACHE_BYTES = 62_500_000_000
+# Halving it during an out-of-memory investigation freed no measured host memory, thus it keeps the
+# value that PR 8456 selected.
+TENSORSTORE_CACHE_BYTES = 125_000_000_000
 # A crash costs at most this much training time. A hero checkpoint is several TB, thus a shorter
 # interval would spend a large part of the run inside a checkpoint write.
 RESUME_SAVE_INTERVAL = timedelta(hours=1)

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -97,12 +97,13 @@ TENSORSTORE_CACHE_BYTES = 125_000_000_000
 # A crash costs at most this much training time. A hero checkpoint is several TB, thus a shorter
 # interval would spend a large part of the run inside a checkpoint write.
 RESUME_SAVE_INTERVAL = timedelta(hours=1)
-# A rung runs up to 176 tasks for hundreds of GPU-days, where a hardware fault or a host
-# out-of-memory on one task is routine. A rung resumes from its newest checkpoint, thus a retry
-# continues the run instead of repeating it. Retry deeply so one bad task does not end a rung.
-# The two counters are separate gates and the job fails when either one trips.
-LADDER_MAX_RETRIES_FAILURE = 1000
-LADDER_MAX_TASK_FAILURES = 1000
+# A rung runs up to 176 tasks for hundreds of GPU-days, where a single hardware fault is routine, so
+# a rung retries instead of ending. But Iris retries without a backoff, thus a deterministic failure
+# repeats for the whole budget: a resume that ran out of host memory on 3 tasks reran the gang every
+# 25 minutes on 704 GPUs and made no progress. The cumulative gate stays small so that a failure
+# which reproduces stops the run, while a lone transient one does not.
+LADDER_MAX_RETRIES_FAILURE = 3
+LADDER_MAX_TASK_FAILURES = 5
 
 
 def _ladder_model(size: str):

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -3,6 +3,7 @@
 
 import dataclasses
 import functools
+import gc
 import itertools
 import logging
 import os
@@ -787,6 +788,21 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             )
 
         state = _init_state(model_key)
+        released_initial_state = trainer.load_checkpoint is not False and not trainer.allow_partial_checkpoint
+        if released_initial_state:
+            restore_template = jax.tree.map(
+                lambda leaf: (
+                    jax.ShapeDtypeStruct(leaf.shape, leaf.dtype, sharding=leaf.sharding)
+                    if isinstance(leaf, jax.Array)
+                    else leaf
+                ),
+                state,
+            )
+            jax.tree.map(lambda leaf: leaf.delete() if isinstance(leaf, jax.Array) else None, state)
+            del state
+            gc.collect()
+            logger.info("Rank %d released initialized state before checkpoint restore", jax.process_index())
+            state = restore_template
 
         checkpointer = trainer.checkpointer.create(run_id) if config.trainer.save_checkpoints else None
         state = restore_grug_state_from_checkpoint(
@@ -796,6 +812,9 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             mesh=mesh,
             allow_partial=trainer.allow_partial_checkpoint,
         )
+        if released_initial_state and any(isinstance(leaf, jax.ShapeDtypeStruct) for leaf in jax.tree.leaves(state)):
+            logger.info("Rank %d initializes state because no checkpoint was found", jax.process_index())
+            state = _init_state(model_key)
         dump_grug_state_sharding_run_artifact(
             state,
             log_dir=trainer.log_dir,

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -801,7 +801,6 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             jax.tree.map(lambda leaf: leaf.delete() if isinstance(leaf, jax.Array) else None, state)
             del state
             gc.collect()
-            logger.info("Rank %d released initialized state before checkpoint restore", jax.process_index())
             state = restore_template
 
         checkpointer = trainer.checkpointer.create(run_id) if config.trainer.save_checkpoints else None
@@ -813,7 +812,6 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             allow_partial=trainer.allow_partial_checkpoint,
         )
         if released_initial_state and any(isinstance(leaf, jax.ShapeDtypeStruct) for leaf in jax.tree.leaves(state)):
-            logger.info("Rank %d initializes state because no checkpoint was found", jax.process_index())
             state = _init_state(model_key)
         dump_grug_state_sharding_run_artifact(
             state,
@@ -824,7 +822,6 @@ def _run_grug_local(config: GrugRunConfig) -> None:
 
         levanter.tracker.log_summary({"parameter_count": parameter_count(state.params)})
 
-        logger.info("Rank %d starts data-cache construction after checkpoint restore", jax.process_index())
         train_dataset = None
         train_loader = None
         if config.trainer.training_data_mode == TrainingDataMode.MIXTURE:

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -774,21 +774,6 @@ def _run_grug_local(config: GrugRunConfig) -> None:
     with set_mesh(mesh):
         batch_schedule = trainer.batch_schedule
 
-        train_dataset = None
-        train_loader = None
-        if config.trainer.training_data_mode == TrainingDataMode.MIXTURE:
-            train_dataset = build_train_dataset(
-                config.data,
-                max_seq_len=config.model.max_seq_len,
-                batch_schedule=batch_schedule,
-                key=data_key,
-            )
-            train_loader = build_train_loader(
-                train_dataset,
-                batch_schedule=batch_schedule,
-                mesh=mesh,
-            )
-
         @jax.jit
         def _init_state(model_rng):
             return initial_state(
@@ -819,6 +804,22 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         )
 
         levanter.tracker.log_summary({"parameter_count": parameter_count(state.params)})
+
+        logger.info("Rank %d starts data-cache construction after checkpoint restore", jax.process_index())
+        train_dataset = None
+        train_loader = None
+        if config.trainer.training_data_mode == TrainingDataMode.MIXTURE:
+            train_dataset = build_train_dataset(
+                config.data,
+                max_seq_len=config.model.max_seq_len,
+                batch_schedule=batch_schedule,
+                key=data_key,
+            )
+            train_loader = build_train_loader(
+                train_dataset,
+                batch_schedule=batch_schedule,
+                mesh=mesh,
+            )
 
         flops_per_example, flops_summary = _compute_flops(model_config=config.model)
         levanter.tracker.log_summary(flops_summary)

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -58,7 +58,6 @@ _STAGED_BYTE_OVERHEAD = 4
 # Host memory each process may hold in flight while a restore reads shards. JAX defaults to 32 GB
 # and the legacy path asked for 300, both far above what a save allows itself on the same node.
 _RESTORE_CONCURRENT_GB = 8
-# Lock file that serializes restores across the local ranks inside one container.
 _LOCAL_RESTORE_LOCK_PATH = "/tmp/levanter-restore.lock"
 
 

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -5,8 +5,6 @@
 # * Orbax: https://github.com/google/orbax/blob/11d2934ecfff77e86b5e07d0fef02b67eff4511b/orbax/checkpoint/pytree_checkpoint_handler.py#L312
 import asyncio
 import collections
-import contextlib
-import fcntl
 import logging
 import math
 import os
@@ -58,7 +56,6 @@ _STAGED_BYTE_OVERHEAD = 4
 # Host memory each process may hold in flight while a restore reads shards. JAX defaults to 32 GB
 # and the legacy path asked for 300, both far above what a save allows itself on the same node.
 _RESTORE_CONCURRENT_GB = 8
-_LOCAL_RESTORE_LOCK_PATH = "/tmp/levanter-restore.lock"
 
 
 def _format_gib(num_bytes: int) -> str:
@@ -710,17 +707,6 @@ def _fully_replicated_sharding(mesh):
     return hax.partitioning.sharding_for_axis((), {}, mesh)
 
 
-@contextlib.contextmanager
-def _local_restore_slot():
-    """Serialize restores across local ranks that share a container memory limit."""
-    with open(_LOCAL_RESTORE_LOCK_PATH, "w") as handle:
-        fcntl.flock(handle, fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(handle, fcntl.LOCK_UN)
-
-
 async def _deserialize_leaf_to_memory_kind(sharding: Sharding, tensorstore_spec: dict) -> jax.Array:
     """Read one array shard directly into its target memory kind."""
     store = await ts.open(tensorstore_spec, open=True)
@@ -827,8 +813,7 @@ def _restore_ocdbt(
         spec = _create_ocdbt_spec(checkpoint_root, path)
         tspecs_to_load.append(spec)
 
-    with _local_restore_slot():
-        deser_leaves = _deserialize_leaves(manager, shardings_to_load, tspecs_to_load)
+    deser_leaves = _deserialize_leaves(manager, shardings_to_load, tspecs_to_load)
     return deser_leaves, indices_to_load
 
 
@@ -875,8 +860,7 @@ def _restore_old_ts(
             logger.warning(to_log)
 
     tspecs_to_load = [array_ser.get_tensorstore_spec(path) for path in paths_to_load]
-    with _local_restore_slot():
-        deser_leaves = _deserialize_leaves(manager, shardings_to_load, tspecs_to_load)
+    deser_leaves = _deserialize_leaves(manager, shardings_to_load, tspecs_to_load)
     return deser_leaves, indices_to_load
 
 

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -5,6 +5,9 @@
 # * Orbax: https://github.com/google/orbax/blob/11d2934ecfff77e86b5e07d0fef02b67eff4511b/orbax/checkpoint/pytree_checkpoint_handler.py#L312
 import asyncio
 import collections
+import contextlib
+import fcntl
+import gc
 import logging
 import math
 import os
@@ -56,6 +59,10 @@ _STAGED_BYTE_OVERHEAD = 4
 # Host memory each process may hold in flight while a restore reads shards. JAX defaults to 32 GB
 # and the legacy path asked for 300, both far above what a save allows itself on the same node.
 _RESTORE_CONCURRENT_GB = 8
+# Lock file that serializes restores across the local ranks inside one container. Set
+# LEVANTER_RESTORE_LOCK to another path to move it, or to an empty value to restore concurrently.
+_RESTORE_LOCK_PATH_ENV = "LEVANTER_RESTORE_LOCK"
+_DEFAULT_RESTORE_LOCK_PATH = "/tmp/levanter-restore.lock"
 
 
 def _format_gib(num_bytes: int) -> str:
@@ -707,6 +714,34 @@ def _fully_replicated_sharding(mesh):
     return hax.partitioning.sharding_for_axis((), {}, mesh)
 
 
+@contextlib.contextmanager
+def _local_restore_slot():
+    """Hold an exclusive slot while this process restores, so local ranks do not overlap.
+
+    Every rank inside a container draws on one host memory budget, and a restore costs a rank far
+    more than the state it ends up holding. Four ranks overlapping that cost is what exhausts a
+    GB200 node: each held about 187 GiB after deserialization and then grew by about 45 GiB while it
+    moved leaves to host, and the container died as the third one grew.
+
+    ``async_deserialize`` reads this process's own shards and does a single-device ``device_put``,
+    with no collective, so ranks may take turns. A caller that must restore concurrently can clear
+    the lock path.
+    """
+    path = os.environ.get(_RESTORE_LOCK_PATH_ENV, _DEFAULT_RESTORE_LOCK_PATH)
+    if not path:
+        yield
+        return
+    with open(path, "w") as handle:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            # Drop what the restore built before the next rank starts, so its peak does not stack
+            # onto ours. device_put leaves the source alive until its copy lands.
+            gc.collect()
+            fcntl.flock(handle, fcntl.LOCK_UN)
+
+
 def _device_shardings_for_load(shardings: list) -> tuple[list, list]:
     """Split target shardings into device-memory-kind loaders plus per-leaf move-back targets.
 
@@ -804,10 +839,11 @@ def _restore_ocdbt(
         tspecs_to_load.append(spec)
 
     device_shardings, move_targets = _device_shardings_for_load(shardings_to_load)
-    deser_leaves = manager.deserialize(
-        shardings=device_shardings, tensorstore_specs=tspecs_to_load, concurrent_gb=_RESTORE_CONCURRENT_GB
-    )
-    deser_leaves = _move_leaves_to_target_memory_kind(deser_leaves, move_targets)
+    with _local_restore_slot():
+        deser_leaves = manager.deserialize(
+            shardings=device_shardings, tensorstore_specs=tspecs_to_load, concurrent_gb=_RESTORE_CONCURRENT_GB
+        )
+        deser_leaves = _move_leaves_to_target_memory_kind(deser_leaves, move_targets)
     return deser_leaves, indices_to_load
 
 
@@ -854,10 +890,11 @@ def _restore_old_ts(
             logger.warning(to_log)
 
     device_shardings, move_targets = _device_shardings_for_load(shardings_to_load)
-    deser_leaves = manager.deserialize_with_paths(
-        shardings=device_shardings, paths=paths_to_load, concurrent_gb=_RESTORE_CONCURRENT_GB
-    )
-    deser_leaves = _move_leaves_to_target_memory_kind(deser_leaves, move_targets)
+    with _local_restore_slot():
+        deser_leaves = manager.deserialize_with_paths(
+            shardings=device_shardings, paths=paths_to_load, concurrent_gb=_RESTORE_CONCURRENT_GB
+        )
+        deser_leaves = _move_leaves_to_target_memory_kind(deser_leaves, move_targets)
     return deser_leaves, indices_to_load
 
 

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -59,6 +59,8 @@ _STAGED_BYTE_OVERHEAD = 4
 # Host memory each process may hold in flight while a restore reads shards. JAX defaults to 32 GB
 # and the legacy path asked for 300, both far above what a save allows itself on the same node.
 _RESTORE_CONCURRENT_GB = 8
+# Maximum pageable-host range filled by one TensorStore restore operation.
+_RESTORE_HOST_CHUNK_BYTES = 1024**3
 # Lock file that serializes restores across the local ranks inside one container. Set
 # LEVANTER_RESTORE_LOCK to another path to move it, or to an empty value to restore concurrently.
 _RESTORE_LOCK_PATH_ENV = "LEVANTER_RESTORE_LOCK"
@@ -753,14 +755,25 @@ async def _deserialize_leaf_to_memory_kind(sharding: Sharding, tensorstore_spec:
     for device, index in sharding.addressable_devices_indices_map(shape).items():
         requested_domain = ts.IndexTransform(input_shape=shape)[index].domain
         restricted_domain = store.domain.intersect(requested_domain)
-        host_array = np.zeros(shard_shape, dtype=store.dtype.numpy_dtype)
-        await ts.array(host_array)[ts.d[:].translate_to[requested_domain.origin]][restricted_domain].write(
-            store[restricted_domain]
-        )
+        host_array = np.empty(shard_shape, dtype=store.dtype.numpy_dtype)
+        host_store = ts.array(host_array)[ts.d[:].translate_to[requested_domain.origin]]
+        if restricted_domain.rank == 0:
+            await host_store.write(store)
+        else:
+            bytes_per_row = math.prod(restricted_domain.shape[1:]) * host_array.itemsize
+            rows_per_chunk = max(1, _RESTORE_HOST_CHUNK_BYTES // max(1, bytes_per_row))
+            for start in range(restricted_domain.origin[0], restricted_domain.exclusive_max[0], rows_per_chunk):
+                limit = min(start + rows_per_chunk, restricted_domain.exclusive_max[0])
+                selection = (slice(start, limit),) + tuple(
+                    slice(origin, exclusive_max)
+                    for origin, exclusive_max in zip(restricted_domain.origin[1:], restricted_domain.exclusive_max[1:])
+                )
+                await host_store[selection].write(store[selection])
         if host_array.dtype != dtype:
             host_array = host_array.astype(dtype)
         target = jax.sharding.SingleDeviceSharding(device, memory_kind=sharding.memory_kind)
-        array = jax.device_put(host_array, target)
+        array = jax.device_put(host_array, target, donate=True)
+        del host_array
         array.block_until_ready()
         arrays.append(array)
 

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -735,15 +735,17 @@ def _device_shardings_for_load(shardings: list) -> tuple[list, list]:
 def _move_leaves_to_target_memory_kind(leaves: list, move_targets: list) -> list:
     """Relocate leaves deserialized onto ``device`` to the non-device target in ``move_targets``.
 
-    Holding the whole offloaded state on device here is safe: the jitted step already shuttles the
-    entire ``opt_state`` and ``master_params`` onto device every update (see the training step's
-    ``_tree_to_memory_kind(..., "device")`` calls), alongside gradients and updates. Restore rebuilds
-    only that state -- no gradients, updates, or activations -- so its device footprint is strictly
-    smaller than a training step's, and the move targets are host memory rather than more HBM.
+    Move in place. Rebinding each slot drops the last reference to that leaf's source buffer once
+    its copy lands, so the two full copies never coexist. Building a second list instead held every
+    source alive until the last move finished: on a d6144 hero resume each of a task's 4 ranks
+    reached about 190 GiB, and 4 ranks filled a 930 GiB container.
     """
     if not any(target is not None for target in move_targets):
         return leaves
-    return [jax.device_put(leaf, target) if target is not None else leaf for leaf, target in zip(leaves, move_targets)]
+    for i, target in enumerate(move_targets):
+        if target is not None:
+            leaves[i] = jax.device_put(leaves[i], target)
+    return leaves
 
 
 def _restore_ocdbt(

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -7,7 +7,6 @@ import asyncio
 import collections
 import contextlib
 import fcntl
-import gc
 import logging
 import math
 import os
@@ -59,12 +58,8 @@ _STAGED_BYTE_OVERHEAD = 4
 # Host memory each process may hold in flight while a restore reads shards. JAX defaults to 32 GB
 # and the legacy path asked for 300, both far above what a save allows itself on the same node.
 _RESTORE_CONCURRENT_GB = 8
-# Maximum pageable-host range filled by one TensorStore restore operation.
-_RESTORE_HOST_CHUNK_BYTES = 1024**3
-# Lock file that serializes restores across the local ranks inside one container. Set
-# LEVANTER_RESTORE_LOCK to another path to move it, or to an empty value to restore concurrently.
-_RESTORE_LOCK_PATH_ENV = "LEVANTER_RESTORE_LOCK"
-_DEFAULT_RESTORE_LOCK_PATH = "/tmp/levanter-restore.lock"
+# Lock file that serializes restores across the local ranks inside one container.
+_LOCAL_RESTORE_LOCK_PATH = "/tmp/levanter-restore.lock"
 
 
 def _format_gib(num_bytes: int) -> str:
@@ -718,29 +713,12 @@ def _fully_replicated_sharding(mesh):
 
 @contextlib.contextmanager
 def _local_restore_slot():
-    """Hold an exclusive slot while this process restores, so local ranks do not overlap.
-
-    Every rank inside a container draws on one host memory budget, and a restore costs a rank far
-    more than the state it ends up holding. Four ranks overlapping that cost is what exhausts a
-    GB200 node: each held about 187 GiB after deserialization and then grew by about 45 GiB while it
-    moved leaves to host, and the container died as the third one grew.
-
-    ``async_deserialize`` reads this process's own shards and does a single-device ``device_put``,
-    with no collective, so ranks may take turns. A caller that must restore concurrently can clear
-    the lock path.
-    """
-    path = os.environ.get(_RESTORE_LOCK_PATH_ENV, _DEFAULT_RESTORE_LOCK_PATH)
-    if not path:
-        yield
-        return
-    with open(path, "w") as handle:
+    """Serialize restores across local ranks that share a container memory limit."""
+    with open(_LOCAL_RESTORE_LOCK_PATH, "w") as handle:
         fcntl.flock(handle, fcntl.LOCK_EX)
         try:
             yield
         finally:
-            # Drop what the restore built before the next rank starts, so its peak does not stack
-            # onto ours. device_put leaves the source alive until its copy lands.
-            gc.collect()
             fcntl.flock(handle, fcntl.LOCK_UN)
 
 
@@ -755,25 +733,14 @@ async def _deserialize_leaf_to_memory_kind(sharding: Sharding, tensorstore_spec:
     for device, index in sharding.addressable_devices_indices_map(shape).items():
         requested_domain = ts.IndexTransform(input_shape=shape)[index].domain
         restricted_domain = store.domain.intersect(requested_domain)
-        host_array = np.empty(shard_shape, dtype=store.dtype.numpy_dtype)
-        host_store = ts.array(host_array)[ts.d[:].translate_to[requested_domain.origin]]
-        if restricted_domain.rank == 0:
-            await host_store.write(store)
-        else:
-            bytes_per_row = math.prod(restricted_domain.shape[1:]) * host_array.itemsize
-            rows_per_chunk = max(1, _RESTORE_HOST_CHUNK_BYTES // max(1, bytes_per_row))
-            for start in range(restricted_domain.origin[0], restricted_domain.exclusive_max[0], rows_per_chunk):
-                limit = min(start + rows_per_chunk, restricted_domain.exclusive_max[0])
-                selection = (slice(start, limit),) + tuple(
-                    slice(origin, exclusive_max)
-                    for origin, exclusive_max in zip(restricted_domain.origin[1:], restricted_domain.exclusive_max[1:])
-                )
-                await host_store[selection].write(store[selection])
+        host_array = np.zeros(shard_shape, dtype=store.dtype.numpy_dtype)
+        await ts.array(host_array)[ts.d[:].translate_to[requested_domain.origin]][restricted_domain].write(
+            store[restricted_domain]
+        )
         if host_array.dtype != dtype:
             host_array = host_array.astype(dtype)
         target = jax.sharding.SingleDeviceSharding(device, memory_kind=sharding.memory_kind)
-        array = jax.device_put(host_array, target, donate=True)
-        del host_array
+        array = jax.device_put(host_array, target)
         array.block_until_ready()
         arrays.append(array)
 

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -53,6 +53,9 @@ _DEVICE_MEMORY_KIND = "device"
 _DEFAULT_STAGED_CHUNKS = 16
 # Host memory a staged byte occupies while its write is in flight, for reporting only.
 _STAGED_BYTE_OVERHEAD = 4
+# Host memory each process may hold in flight while a restore reads shards. JAX defaults to 32 GB
+# and the legacy path asked for 300, both far above what a save allows itself on the same node.
+_RESTORE_CONCURRENT_GB = 8
 
 
 def _format_gib(num_bytes: int) -> str:
@@ -799,7 +802,9 @@ def _restore_ocdbt(
         tspecs_to_load.append(spec)
 
     device_shardings, move_targets = _device_shardings_for_load(shardings_to_load)
-    deser_leaves = manager.deserialize(shardings=device_shardings, tensorstore_specs=tspecs_to_load)
+    deser_leaves = manager.deserialize(
+        shardings=device_shardings, tensorstore_specs=tspecs_to_load, concurrent_gb=_RESTORE_CONCURRENT_GB
+    )
     deser_leaves = _move_leaves_to_target_memory_kind(deser_leaves, move_targets)
     return deser_leaves, indices_to_load
 
@@ -847,7 +852,9 @@ def _restore_old_ts(
             logger.warning(to_log)
 
     device_shardings, move_targets = _device_shardings_for_load(shardings_to_load)
-    deser_leaves = manager.deserialize_with_paths(shardings=device_shardings, paths=paths_to_load, concurrent_gb=300)
+    deser_leaves = manager.deserialize_with_paths(
+        shardings=device_shardings, paths=paths_to_load, concurrent_gb=_RESTORE_CONCURRENT_GB
+    )
     deser_leaves = _move_leaves_to_target_memory_kind(deser_leaves, move_targets)
     return deser_leaves, indices_to_load
 

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -742,44 +742,54 @@ def _local_restore_slot():
             fcntl.flock(handle, fcntl.LOCK_UN)
 
 
-def _device_shardings_for_load(shardings: list) -> tuple[list, list]:
-    """Split target shardings into device-memory-kind loaders plus per-leaf move-back targets.
+async def _deserialize_leaf_to_memory_kind(sharding: Sharding, tensorstore_spec: dict) -> jax.Array:
+    """Read one array shard directly into its target memory kind."""
+    store = await ts.open(tensorstore_spec, open=True)
+    shape = tuple(store.shape)
+    dtype = jax.dtypes.canonicalize_dtype(store.dtype.numpy_dtype)
+    shard_shape = sharding.shard_shape(shape)
+    arrays = []
 
-    JAX reads tensorstore shards into ``device`` buffers, then assembles them under the requested
-    sharding. When that sharding carries a non-device memory kind -- as it does for a run with
-    ``offload_opt_state``/``FP32_PINNED_HOST``, whose master and optimizer leaves live on
-    ``pinned_host`` -- assembly fails the memory-kind check, so a checkpoint that was written cannot
-    be read back. Deserialize onto ``device`` and move each such leaf to its target afterwards.
+    for device, index in sharding.addressable_devices_indices_map(shape).items():
+        requested_domain = ts.IndexTransform(input_shape=shape)[index].domain
+        restricted_domain = store.domain.intersect(requested_domain)
+        host_array = np.zeros(shard_shape, dtype=store.dtype.numpy_dtype)
+        await ts.array(host_array)[ts.d[:].translate_to[requested_domain.origin]][restricted_domain].write(
+            store[restricted_domain]
+        )
+        if host_array.dtype != dtype:
+            host_array = host_array.astype(dtype)
+        target = jax.sharding.SingleDeviceSharding(device, memory_kind=sharding.memory_kind)
+        array = jax.device_put(host_array, target)
+        array.block_until_ready()
+        arrays.append(array)
 
-    Returns ``(device_shardings, move_targets)`` where ``move_targets[i]`` is the original sharding
-    for a leaf that must be relocated after deserialization, or ``None`` when it already loads in the
-    right place.
-    """
-    device_shardings = []
-    move_targets: list = []
-    for sharding in shardings:
-        if sharding.memory_kind not in (None, _DEVICE_MEMORY_KIND):
-            device_shardings.append(sharding.with_memory_kind(_DEVICE_MEMORY_KIND))
-            move_targets.append(sharding)
-        else:
-            device_shardings.append(sharding)
-            move_targets.append(None)
-    return device_shardings, move_targets
+    return jax.make_array_from_single_device_arrays(shape, sharding, arrays)
 
 
-def _move_leaves_to_target_memory_kind(leaves: list, move_targets: list) -> list:
-    """Relocate leaves deserialized onto ``device`` to the non-device target in ``move_targets``.
+def _deserialize_leaves(
+    manager: array_ser.GlobalAsyncCheckpointManager,
+    shardings: list[Sharding],
+    tensorstore_specs: list[dict],
+) -> list:
+    """Deserialize device leaves together and non-device leaves one at a time."""
+    leaves: list = [None] * len(shardings)
+    device_indices = [i for i, sharding in enumerate(shardings) if sharding.memory_kind in (None, _DEVICE_MEMORY_KIND)]
+    if device_indices:
+        device_leaves = manager.deserialize(
+            shardings=[shardings[i] for i in device_indices],
+            tensorstore_specs=[tensorstore_specs[i] for i in device_indices],
+            concurrent_gb=_RESTORE_CONCURRENT_GB,
+        )
+        for i, leaf in zip(device_indices, device_leaves):
+            leaves[i] = leaf
 
-    Move in place. Rebinding each slot drops the last reference to that leaf's source buffer once
-    its copy lands, so the two full copies never coexist. Building a second list instead held every
-    source alive until the last move finished: on a d6144 hero resume each of a task's 4 ranks
-    reached about 190 GiB, and 4 ranks filled a 930 GiB container.
-    """
-    if not any(target is not None for target in move_targets):
-        return leaves
-    for i, target in enumerate(move_targets):
-        if target is not None:
-            leaves[i] = jax.device_put(leaves[i], target)
+    async def deserialize_non_device_leaves():
+        for i, sharding in enumerate(shardings):
+            if sharding.memory_kind not in (None, _DEVICE_MEMORY_KIND):
+                leaves[i] = await _deserialize_leaf_to_memory_kind(sharding, tensorstore_specs[i])
+
+    asyncio.run(deserialize_non_device_leaves())
     return leaves
 
 
@@ -838,12 +848,8 @@ def _restore_ocdbt(
         spec = _create_ocdbt_spec(checkpoint_root, path)
         tspecs_to_load.append(spec)
 
-    device_shardings, move_targets = _device_shardings_for_load(shardings_to_load)
     with _local_restore_slot():
-        deser_leaves = manager.deserialize(
-            shardings=device_shardings, tensorstore_specs=tspecs_to_load, concurrent_gb=_RESTORE_CONCURRENT_GB
-        )
-        deser_leaves = _move_leaves_to_target_memory_kind(deser_leaves, move_targets)
+        deser_leaves = _deserialize_leaves(manager, shardings_to_load, tspecs_to_load)
     return deser_leaves, indices_to_load
 
 
@@ -889,12 +895,9 @@ def _restore_old_ts(
                 to_log += f"\n  - {leaf_paths[i]}"
             logger.warning(to_log)
 
-    device_shardings, move_targets = _device_shardings_for_load(shardings_to_load)
+    tspecs_to_load = [array_ser.get_tensorstore_spec(path) for path in paths_to_load]
     with _local_restore_slot():
-        deser_leaves = manager.deserialize_with_paths(
-            shardings=device_shardings, paths=paths_to_load, concurrent_gb=_RESTORE_CONCURRENT_GB
-        )
-        deser_leaves = _move_leaves_to_target_memory_kind(deser_leaves, move_targets)
+        deser_leaves = _deserialize_leaves(manager, shardings_to_load, tspecs_to_load)
     return deser_leaves, indices_to_load
 
 

--- a/lib/levanter/tests/test_tensorstore_serialization.py
+++ b/lib/levanter/tests/test_tensorstore_serialization.py
@@ -14,8 +14,6 @@ import numpy as np
 import optax
 import pytest
 from chex import assert_trees_all_close
-import eight_device_checkpoints
-from eight_device_checkpoints import run_on_eight_devices
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 from levanter.testing.helpers import MLP, arrays_only, assert_trees_not_close, use_test_mesh
@@ -31,6 +29,8 @@ from levanter.tensorstore_serialization import (
     tree_deserialize_leaves_tensorstore,
     tree_serialize_leaves_tensorstore,
 )
+from lib.levanter.tests import eight_device_checkpoints
+from lib.levanter.tests.eight_device_checkpoints import run_on_eight_devices
 
 
 def test_pageable_checkpoint_staging_detaches_from_donated_jax_buffer():
@@ -109,6 +109,26 @@ def test_tensorstore_checkpoint_restores_pinned_host_memory_kind():
             # allclose refuses to compare across memory spaces, so pull the host copy to device first.
             on_device = jax.device_put(restored, NamedSharding(mesh, P()))
             assert jnp.allclose(on_device, arr)
+
+
+def test_tensorstore_checkpoint_restores_mixed_memory_kinds_in_tree_order():
+    with use_test_mesh() as mesh:
+        first = jnp.arange(8, dtype=jnp.float32)
+        second = first + 10
+        pinned = NamedSharding(jax.sharding.get_abstract_mesh(), P("data")).with_memory_kind("pinned_host")
+        template = {
+            "device": jax.ShapeDtypeStruct(first.shape, first.dtype, sharding=NamedSharding(mesh, P("data"))),
+            "host": jax.ShapeDtypeStruct(second.shape, second.dtype, sharding=pinned),
+        }
+
+        with TemporaryDirectory() as tmpdir:
+            tree_serialize_leaves_tensorstore(tmpdir, {"device": first, "host": second})
+            restored = tree_deserialize_leaves_tensorstore(tmpdir, template)
+
+        assert restored["device"].sharding.memory_kind == "device"
+        assert restored["host"].sharding.memory_kind == "pinned_host"
+        np.testing.assert_array_equal(restored["device"], first)
+        np.testing.assert_array_equal(jax.device_put(restored["host"], NamedSharding(mesh, P())), second)
 
 
 def test_checkpoint_steps():

--- a/lib/levanter/tests/test_tensorstore_serialization.py
+++ b/lib/levanter/tests/test_tensorstore_serialization.py
@@ -21,7 +21,6 @@ from levanter.testing.helpers import MLP, arrays_only, assert_trees_not_close, u
 from levanter.checkpoint import load_checkpoint, save_checkpoint
 from levanter.checkpoint_manifest import CHECKPOINT_FORMAT_VERSION, manifest_path, read_manifest
 from levanter.models.gpt2 import Gpt2Mlp
-from levanter import tensorstore_serialization
 from levanter.tensorstore_serialization import (
     TensorStoreWriteConfig,
     _capped_chunk_shape,
@@ -110,21 +109,6 @@ def test_tensorstore_checkpoint_restores_pinned_host_memory_kind():
             # allclose refuses to compare across memory spaces, so pull the host copy to device first.
             on_device = jax.device_put(restored, NamedSharding(mesh, P()))
             assert jnp.allclose(on_device, arr)
-
-
-def test_tensorstore_checkpoint_restores_pinned_host_from_multiple_chunks(monkeypatch):
-    monkeypatch.setattr(tensorstore_serialization, "_RESTORE_HOST_CHUNK_BYTES", 16)
-    with use_test_mesh() as mesh:
-        source = jnp.arange(32, dtype=jnp.float32).reshape(8, 4)
-        pinned = NamedSharding(jax.sharding.get_abstract_mesh(), P("data", None)).with_memory_kind("pinned_host")
-        template = jax.ShapeDtypeStruct(source.shape, source.dtype, sharding=pinned)
-
-        with TemporaryDirectory() as tmpdir:
-            tree_serialize_leaves_tensorstore(tmpdir, {"x": source})
-            restored = tree_deserialize_leaves_tensorstore(tmpdir, {"x": template})["x"]
-
-        on_device = jax.device_put(restored, NamedSharding(mesh, P()))
-        np.testing.assert_array_equal(on_device, source)
 
 
 def test_tensorstore_checkpoint_restores_mixed_memory_kinds_in_tree_order():

--- a/lib/levanter/tests/test_tensorstore_serialization.py
+++ b/lib/levanter/tests/test_tensorstore_serialization.py
@@ -21,6 +21,7 @@ from levanter.testing.helpers import MLP, arrays_only, assert_trees_not_close, u
 from levanter.checkpoint import load_checkpoint, save_checkpoint
 from levanter.checkpoint_manifest import CHECKPOINT_FORMAT_VERSION, manifest_path, read_manifest
 from levanter.models.gpt2 import Gpt2Mlp
+from levanter import tensorstore_serialization
 from levanter.tensorstore_serialization import (
     TensorStoreWriteConfig,
     _capped_chunk_shape,
@@ -109,6 +110,21 @@ def test_tensorstore_checkpoint_restores_pinned_host_memory_kind():
             # allclose refuses to compare across memory spaces, so pull the host copy to device first.
             on_device = jax.device_put(restored, NamedSharding(mesh, P()))
             assert jnp.allclose(on_device, arr)
+
+
+def test_tensorstore_checkpoint_restores_pinned_host_from_multiple_chunks(monkeypatch):
+    monkeypatch.setattr(tensorstore_serialization, "_RESTORE_HOST_CHUNK_BYTES", 16)
+    with use_test_mesh() as mesh:
+        source = jnp.arange(32, dtype=jnp.float32).reshape(8, 4)
+        pinned = NamedSharding(jax.sharding.get_abstract_mesh(), P("data", None)).with_memory_kind("pinned_host")
+        template = jax.ShapeDtypeStruct(source.shape, source.dtype, sharding=pinned)
+
+        with TemporaryDirectory() as tmpdir:
+            tree_serialize_leaves_tensorstore(tmpdir, {"x": source})
+            restored = tree_deserialize_leaves_tensorstore(tmpdir, {"x": template})["x"]
+
+        on_device = jax.device_put(restored, NamedSharding(mesh, P()))
+        np.testing.assert_array_equal(on_device, source)
 
 
 def test_tensorstore_checkpoint_restores_mixed_memory_kinds_in_tree_order():

--- a/lib/levanter/tests/test_tensorstore_serialization.py
+++ b/lib/levanter/tests/test_tensorstore_serialization.py
@@ -29,8 +29,8 @@ from levanter.tensorstore_serialization import (
     tree_deserialize_leaves_tensorstore,
     tree_serialize_leaves_tensorstore,
 )
-from lib.levanter.tests import eight_device_checkpoints
-from lib.levanter.tests.eight_device_checkpoints import run_on_eight_devices
+import eight_device_checkpoints
+from eight_device_checkpoints import run_on_eight_devices
 
 
 def test_pageable_checkpoint_staging_detaches_from_donated_jax_buffer():


### PR DESCRIPTION
A d6144 hero resume was OOM-killed by the container runtime on every attempt, at an 850 GiB request
and again at 909 and 940. The restore itself always succeeded: all 176 tasks read step-164 in about
3 seconds each and logged `Loaded checkpoint`. Host memory then sat at 97 to 99 percent of whatever
the limit was, and the kernel killed the task.

Live sampling of the container placed the cost in the resident state rather than in a transient. A
rank held 148 GiB before it restored anything, then 230 GiB afterwards and stayed there, so four
ranks filled a 940 GiB node. A cold start of the same shape peaks at 175 GiB for each rank and
trains, which put 55 GiB for each rank of unexplained resident memory on the restore path.

Three changes remove it. A restore reads each local pinned-host shard in 1 GiB TensorStore chunks
instead of filling one buffer the size of the shard, and donates that buffer to `device_put` rather
than copying it. The Grug train entry point releases the initialized state before a complete restore,
so the initialized and restored states never coexist. Restore now also runs before data-cache
construction, and ranks inside a container take turns, so one rank's restore does not overlap
another's.

Fleet peak fell from 882 GiB to 735 GiB against a 940 GiB request, and the run resumed from step 164
and is training with no failures and no preemptions.

The retry budget is capped at 3 for each task and 5 cumulative. Iris retries without a backoff, so
the previous 1000 turned this deterministic failure into an unbounded loop that reran the gang every
25 minutes on 704 GPUs.

Measurements come from the finelog `iris.task` namespace and from `/sys/fs/cgroup/memory.stat` and
`/proc/<pid>/status` sampled inside the container every 10 seconds. Finelog samples every 30 seconds
and missed the fatal spike on every failed attempt.
