### PR TITLE
[loom] Submit Iris jobs from Loom sessions as user loom

### DIFF
--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -35,6 +35,9 @@ config:
       class: interactive
       prelude: weaver
       instructionsFile: profiles/user/AGENTS.md
+      env: &loomIrisUser
+        IRIS_USER:
+          value: loom
       githubRepositories: &interactiveGithubRepositories
         - Open-Athena/*
         - marin-community/*
@@ -51,6 +54,7 @@ config:
       class: interactive
       prelude: weaver
       instructionsFile: profiles/github/AGENTS.md
+      env: *loomIrisUser
       githubRepositories: *interactiveGithubRepositories
       mcpAccess:
         mode: all
@@ -71,6 +75,7 @@ config:
       turnBudget: 100
       prelude: weaver
       instructionsFile: profiles/fork-ferry/AGENTS.md
+      env: *loomIrisUser
       restricted: false
       githubRepositories:
         - marin-community/evalchemy
@@ -98,6 +103,7 @@ config:
       turnBudget: 100
       prelude: weaver
       instructionsFile: profiles/ops/AGENTS.md
+      env: *loomIrisUser
       restricted: false
       allowedTools: []
       mcpAccess:
@@ -113,6 +119,7 @@ config:
       class: interactive
       prelude: weaver
       instructionsFile: profiles/slack/AGENTS.md
+      env: *loomIrisUser
       githubRepositories: *interactiveGithubRepositories
       mcpAccess:
         mode: all

--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -116,6 +116,15 @@ ordinary sessions use the deployment-managed `default` profile, while workload
 and future GitHub Actions callers select the automation profile authorized by
 their federation mapping.
 
+A profile's `env` block declares the environment every session of that profile
+receives. Each entry sets either an inline `value` for non-secret configuration
+or a `secretRef` that the host resolves from Secret Manager at launch; Pulumi
+grants the VM service account read access to each referenced secret. Profile
+environment is applied after `envClear`, so strict automation profiles receive
+it too. All profiles set `IRIS_USER=loom`, which makes Iris jobs submitted from
+a session land under `/loom/<job>` instead of inheriting the session container's
+`app` OS account.
+
 An interactive session always brokers the `loom-oa-dev` GitHub App for its own
 repository, and a stored personal token still takes precedence over it. The
 `default`, `github`, and `slack` profiles therefore allowlist owners rather than

--- a/infra/loom/infrastructure.py
+++ b/infra/loom/infrastructure.py
@@ -126,26 +126,48 @@ class WorkloadIdentityConfig:
 
 
 @dataclass(frozen=True)
+class ProfileLiteralEnvConfig:
+    """A non-secret environment value declared inline in stack configuration."""
+
+    name: str
+    value: str
+
+    def manifest(self) -> dict[str, str]:
+        return {"name": self.name, "value": self.value}
+
+
+@dataclass(frozen=True)
 class ProfileSecretConfig:
+    """An environment value the Loom host reads from Secret Manager at launch."""
+
     name: str
     secret_ref: str
     project: str
     secret: str
 
-    @classmethod
-    def parse(cls, name: str, value: object, profile: str) -> ProfileSecretConfig:
-        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name) or name.startswith(("LOOM_", "WEAVER_")):
-            raise ValueError(f"profile {profile!r} has invalid environment name {name!r}")
-        if not isinstance(value, dict):
-            raise ValueError(f"profile {profile!r} env {name!r} must use a full secretRef")
-        secret_ref = str(value.get("secretRef", "")).strip()
-        match = SECRET_REF.fullmatch(secret_ref)
-        if not match:
-            raise ValueError(f"profile {profile!r} env {name!r} must use a full secretRef")
-        return cls(name, secret_ref, match.group("project"), match.group("secret"))
-
     def manifest(self) -> dict[str, str]:
         return {"name": self.name, "secret_ref": self.secret_ref}
+
+
+type ProfileEnvConfig = ProfileLiteralEnvConfig | ProfileSecretConfig
+
+
+def _parse_profile_env(name: str, value: object, profile: str) -> ProfileEnvConfig:
+    """Parse one profile environment entry, which sets either a literal or a secretRef."""
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name) or name.startswith(("LOOM_", "WEAVER_")):
+        raise ValueError(f"profile {profile!r} has invalid environment name {name!r}")
+    if not isinstance(value, dict) or ("value" in value) == ("secretRef" in value):
+        raise ValueError(f"profile {profile!r} env {name!r} must set exactly one of value or secretRef")
+    if "value" in value:
+        literal = value["value"]
+        if not isinstance(literal, str) or not literal.strip():
+            raise ValueError(f"profile {profile!r} env {name!r} value must be a non-empty string")
+        return ProfileLiteralEnvConfig(name, literal)
+    secret_ref = str(value.get("secretRef", "")).strip()
+    match = SECRET_REF.fullmatch(secret_ref)
+    if not match:
+        raise ValueError(f"profile {profile!r} env {name!r} must use a full secretRef")
+    return ProfileSecretConfig(name, secret_ref, match.group("project"), match.group("secret"))
 
 
 def _string_tuple(value: object, field: str, profile: str) -> tuple[str, ...]:
@@ -234,7 +256,7 @@ class ProfileConfig:
     github_repositories: tuple[str, ...]
     allowed_tools: tuple[str, ...]
     mcp_access: McpAccessConfig
-    env: tuple[ProfileSecretConfig, ...]
+    env: tuple[ProfileEnvConfig, ...]
 
     @classmethod
     def parse(cls, name: str, value: Mapping[str, object]) -> ProfileConfig:
@@ -246,7 +268,7 @@ class ProfileConfig:
         raw_env = value.get("env", {})
         if not isinstance(raw_env, dict):
             raise ValueError(f"profile {name!r} env must be an object")
-        env = tuple(ProfileSecretConfig.parse(str(key), item, name) for key, item in sorted(raw_env.items()))
+        env = tuple(_parse_profile_env(str(key), item, name) for key, item in sorted(raw_env.items()))
         return cls(
             name=name,
             agent=agent,
@@ -351,7 +373,7 @@ def _deployment_profiles(
     secret_refs: list[tuple[str, str]] = []
     for profile in sorted(profiles, key=lambda item: item.name):
         result.append({"profile": profile.manifest(), "env": [item.manifest() for item in profile.env]})
-        secret_refs.extend((item.project, item.secret) for item in profile.env)
+        secret_refs.extend((item.project, item.secret) for item in profile.env if isinstance(item, ProfileSecretConfig))
     return result, secret_refs
 
 

--- a/infra/loom/tests/test_infrastructure.py
+++ b/infra/loom/tests/test_infrastructure.py
@@ -180,7 +180,10 @@ def test_profile_manifest_renders_github_repositories_and_secret_references() ->
                     "agent": "codex",
                     "githubRepositories": ["marin-community/marin", "marin-community/vllm"],
                     "mcpAccess": {"mode": "all", "groups": []},
-                    "env": {"OPS_TOKEN": {"secretRef": "projects/example/secrets/ops-token/versions/7"}},
+                    "env": {
+                        "IRIS_USER": {"value": "loom"},
+                        "OPS_TOKEN": {"secretRef": "projects/example/secrets/ops-token/versions/7"},
+                    },
                 },
             ),
         )
@@ -190,10 +193,21 @@ def test_profile_manifest_renders_github_repositories_and_secret_references() ->
         "marin-community/vllm",
     ]
     assert profiles[0]["profile"]["mcp_access"] == {"mode": "all", "groups": []}
-    assert profiles[0]["env"] == [{"name": "OPS_TOKEN", "secret_ref": "projects/example/secrets/ops-token/versions/7"}]
+    assert profiles[0]["env"] == [
+        {"name": "IRIS_USER", "value": "loom"},
+        {"name": "OPS_TOKEN", "secret_ref": "projects/example/secrets/ops-token/versions/7"},
+    ]
     assert references == [("example", "ops-token")]
-    with pytest.raises(ValueError, match="full secretRef"):
+    with pytest.raises(ValueError, match="exactly one of value or secretRef"):
         ProfileConfig.parse("ops", {"agent": "codex", "env": {"OPS_TOKEN": "plaintext"}})
+    with pytest.raises(ValueError, match="exactly one of value or secretRef"):
+        ProfileConfig.parse(
+            "ops",
+            {
+                "agent": "codex",
+                "env": {"OPS_TOKEN": {"value": "x", "secretRef": "projects/example/secrets/ops-token/versions/7"}},
+            },
+        )
 
 
 def test_deployment_manifest_preserves_unicode_profile_instructions() -> None:

--- a/infra/loom/tests/test_infrastructure.py
+++ b/infra/loom/tests/test_infrastructure.py
@@ -180,10 +180,7 @@ def test_profile_manifest_renders_github_repositories_and_secret_references() ->
                     "agent": "codex",
                     "githubRepositories": ["marin-community/marin", "marin-community/vllm"],
                     "mcpAccess": {"mode": "all", "groups": []},
-                    "env": {
-                        "IRIS_USER": {"value": "loom"},
-                        "OPS_TOKEN": {"secretRef": "projects/example/secrets/ops-token/versions/7"},
-                    },
+                    "env": {"OPS_TOKEN": {"secretRef": "projects/example/secrets/ops-token/versions/7"}},
                 },
             ),
         )
@@ -193,21 +190,10 @@ def test_profile_manifest_renders_github_repositories_and_secret_references() ->
         "marin-community/vllm",
     ]
     assert profiles[0]["profile"]["mcp_access"] == {"mode": "all", "groups": []}
-    assert profiles[0]["env"] == [
-        {"name": "IRIS_USER", "value": "loom"},
-        {"name": "OPS_TOKEN", "secret_ref": "projects/example/secrets/ops-token/versions/7"},
-    ]
+    assert profiles[0]["env"] == [{"name": "OPS_TOKEN", "secret_ref": "projects/example/secrets/ops-token/versions/7"}]
     assert references == [("example", "ops-token")]
     with pytest.raises(ValueError, match="exactly one of value or secretRef"):
         ProfileConfig.parse("ops", {"agent": "codex", "env": {"OPS_TOKEN": "plaintext"}})
-    with pytest.raises(ValueError, match="exactly one of value or secretRef"):
-        ProfileConfig.parse(
-            "ops",
-            {
-                "agent": "codex",
-                "env": {"OPS_TOKEN": {"value": "x", "secretRef": "projects/example/secrets/ops-token/versions/7"}},
-            },
-        )
 
 
 def test_deployment_manifest_preserves_unicode_profile_instructions() -> None:


### PR DESCRIPTION
Set IRIS_USER=loom on every deployment-managed Loom profile, so Iris jobs
submitted from a Loom session are named /loom/<job>. Without it,
resolve_job_user falls back to the session container's OS account, which the
Loom image creates as `app`, and every job landed under /app/<job>.

Profile env entries previously had to be a Secret Manager secretRef. Loom's
deployment API already accepts a literal value per entry, so the stack now
accepts either form and only requests secret-accessor bindings for secretRef
entries. Profile env is applied after envClear, so the strict fork-ferry and
ops profiles pick the variable up along with the interactive ones.

Takes effect on the next `pulumi up` for the marin-loom stack; existing
sessions keep their current environment.
