### PR TITLE
[grug] Hold the EP hero allocator pool above its step high-water mark

### DIFF
--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -59,6 +59,13 @@ HERO_EP_RUNTIME_ENV = {
     "JAX_ENABLE_PGLE": "false",
     "XLA_PJRT_GPU_HOST_MEMORY_LIMIT_GB": "192",
     "XLA_PYTHON_CLIENT_ALLOCATOR": "cuda_async",
+    # `cuda_async` uses this fraction as the mempool release threshold. JAX's 0.75 default is
+    # 138.2 GiB of the 184.3 GiB part, below the 143.8 GiB the step reaches, so the pool unmaps
+    # after every step and has to re-form the 125.7 GiB train-step slab against the ~12 GiB the
+    # run leaves free. 0.83 is 153.0 GiB: it holds the high-water mark and still leaves 31.3 GiB
+    # outside the pool for NCCL, cuBLAS, and the CUDA context. Rematerialization is budgeted by
+    # `--xla_gpu_memory_limit_slop_factor` against physical memory, not by this ceiling.
+    "XLA_PYTHON_CLIENT_MEM_FRACTION": "0.83",
 }
 _XLA_FLAG_DEFAULTS = ("--xla_gpu_enable_latency_hiding_scheduler=true",)
 XLA_COLLECTIVE_OVERLAP_FLAG = "--xla_gpu_experimental_parallel_collective_overlap_limit"


### PR DESCRIPTION
The moe_hero_ep hero gang aborted roughly every one to two hours with a
CUDA OOM in jit_train_step, on a different node each time. All 704
processes reported identical memory: an allocator limit of 138.22 GiB
(JAX's 0.75 default over the 184.29 GiB GB200 part), 18.05 GiB steady
in-use, and a 143.72 GiB peak. Under cuda_async that fraction is the
mempool release threshold, so CU_MEMPOOL_ATTR_RESERVED_MEM_CURRENT sat
at exactly 138.2245 GiB against a 143.84 GiB high-water mark: the pool
was unmapping after every step and then re-forming the step's single
125.67 GiB temp slab against the ~11.8 GiB the run leaves free once
NCCL, cuBLAS, and the CUDA context take their ~28.6 GiB. Over 704
processes and ~380 steps per attempt, one of those re-forms loses the
race about once per attempt.

Raising the fraction to 0.83 (152.96 GiB) puts the release threshold
above the high-water mark, so the pool keeps the slab mapped. The floor
is 0.781 to clear the 143.84 GiB peak and the ceiling is 0.845 to leave
the non-pool 28.6 GiB room. Rematerialization is budgeted by
--xla_gpu_memory_limit_slop_factor against physical memory rather than
by this ceiling, which the failing run confirms: it compiled a 143.72
GiB peak while the allocator limit was 138.22 GiB. Confirm
memory/peak_gib stays near 143.7 after relaunch; a jump would mean the
larger ceiling turned rematerialization off.

The failures were not evals, checkpoints, or NCCL. Evals run every 3000
steps and the aborts landed at steps 806, 832, 1052, and 1209;
checkpoints are hourly and the last one preceded the step-1209 abort by
50 minutes; NCCL RAS reported communicator_state=1 on every sample with
no stall captures.

