### PR TITLE
[agents] Narrow skill activation

### DIFF
--- a/.agents/skills/ab-test-zephyr/SKILL.md
+++ b/.agents/skills/ab-test-zephyr/SKILL.md
@@ -1,18 +1,9 @@
 ---
 name: ab-test-zephyr
-description: Run a Zephyr control and treatment on pre-normalized data and compare per-stage Finelog CPU, elapsed-time, and memory stats. Use for ad hoc comparisons and PR performance gates; add named treatments only when requested.
+description: Run an explicitly requested Zephyr control/treatment benchmark on the same pre-normalized sample and compare Finelog stage metrics.
 ---
 
-# A/B Test Zephyr Changes
-
-Use one workflow for ad hoc comparisons and PR performance gates:
-
-1. Run one control and one treatment with
-   `experiments.datakit.zephyr_benchmark` on the same pre-normalized sample.
-2. Collect every execution's `zephyr.stage` rows from Finelog.
-3. Compare CPU, elapsed time, and memory per stage.
-4. Publish the workload fingerprint, data-equivalence checks, infrastructure
-   noise, and result in one report.
+# A/B test Zephyr changes
 
 ## Signals
 
@@ -30,16 +21,10 @@ The coordinator writes one `zephyr.stage` row per completed stage and
 | `cpu_pct_avg` | weighted interpretation only | CPU saturation context |
 | `item_rate`, `byte_rate` | do not aggregate | Derived from noisy elapsed time |
 
-`cpu_time_total` is the sum of process user and system CPU-seconds across
-completed shards. It is the default signal for code efficiency because worker
-count and queue delay do not directly change it. Normalize it as CPU-seconds
-per item or byte when a control and treatment processed slightly different
-amounts of data.
-
-`elapsed` measures a stage barrier. It captures startup, I/O, concurrency, and
-straggler behavior that CPU time misses. It also moves with worker availability,
-preemption, retries, autoscaling, and data skew. Report it, but repeat a result
-when elapsed time is the only signal that changed.
+Use `cpu_time_total` as the primary efficiency signal and normalize per item or
+byte when accepted workload sizes differ. `elapsed` includes startup, I/O,
+concurrency, queueing, and stragglers; repeat an elapsed-only result under
+comparable scheduling conditions.
 
 Keep CPU and elapsed time as separate outcomes:
 
@@ -47,15 +32,13 @@ Keep CPU and elapsed time as separate outcomes:
   compute cost.
 - CPU higher and elapsed lower: faster and more expensive.
 - CPU lower and elapsed higher: cheaper and slower.
-- Wall-only change from one control/treatment comparison: inconclusive until
-  repeated under comparable scheduling conditions.
+- Wall-only change from one comparison: inconclusive until repeated.
 - Topology or batching change: report the latency/compute tradeoff; do not
   describe wall-time gains as equivalent per-core efficiency gains.
 
-Do not apply fixed wall-time thresholds to every benchmark. Calibrate CPU/item
-and elapsed thresholds from same-code repeats for the selected sample and pool
+Calibrate thresholds from same-code repeats for the selected sample and pool
 shape. A new OOM, application failure, or memory peak above the worker limit is
-a regression regardless of CPU time.
+a regression regardless of CPU.
 
 ## Choose the comparison
 
@@ -112,10 +95,8 @@ git worktree add --detach "$WORKTREE_ROOT/control" "$BASELINE_SHA"
 git worktree add --detach "$WORKTREE_ROOT/treatment" "$TREATMENT_SHA"
 ```
 
-Record both SHAs. If the experiment changes configuration without changing
-code, use two worktrees or commits that preserve the exact control and
-treatment configurations. Add one detached worktree per additional treatment
-SHA or configuration explicitly requested.
+Record both SHAs. Preserve configuration-only arms in separate worktrees or
+commits. Add arms only when explicitly requested.
 
 ## Launch the download-free benchmark
 
@@ -182,9 +163,9 @@ explicitly requested treatments launched in the same scheduling window. If the
 decision depends on elapsed time, interleave additional control trials among
 the treatments to measure scheduling noise.
 
-Delegate monitoring to `babysit-zephyr`. A failed or preempted arm is evidence
-about infrastructure reliability, not a performance verdict. Diagnose repeated
-failures with `debug`.
+If the request includes continuous monitoring, use `babysit-zephyr`. A failed
+or preempted arm measures infrastructure reliability and carries no performance
+result. Use `debug` only for a stated repeated fault.
 
 ## Collect execution IDs
 
@@ -308,11 +289,9 @@ Infrastructure: <preemptions, retries, failures, stragglers, or none>
 Interpretation: <efficiency result, latency result, and any tradeoff>
 ```
 
-Lead with CPU change, then elapsed time and memory. State whether elapsed time
-came from one control/treatment comparison or repeated interleaved trials.
-Label summed stage elapsed as such. Iris launcher duration and summed task wall
-time may help diagnose queueing or topology, but they do not replace the
-Finelog stage metrics.
+Lead with CPU change, then elapsed time and memory. State whether elapsed came
+from one comparison or repeated interleaved trials and label summed stage
+elapsed. Launcher duration and task wall time do not replace stage metrics.
 
 ## Clean up
 

--- a/.agents/skills/ab-test-zephyr/SKILL.md
+++ b/.agents/skills/ab-test-zephyr/SKILL.md
@@ -21,8 +21,10 @@ The coordinator writes one `zephyr.stage` row per completed stage and
 | `cpu_pct_avg` | weighted interpretation only | CPU saturation context |
 | `item_rate`, `byte_rate` | do not aggregate | Derived from noisy elapsed time |
 
-Use `cpu_time_total` as the primary efficiency signal and normalize per item or
-byte when accepted workload sizes differ. `elapsed` includes startup, I/O,
+`cpu_time_total` sums process user and system CPU-seconds across completed
+shards, so worker count and queue delay do not directly change it. Use it as the
+primary efficiency signal and normalize per item or byte when accepted workload
+sizes differ. `elapsed` measures the stage barrier and includes startup, I/O,
 concurrency, queueing, and stragglers; repeat an elapsed-only result under
 comparable scheduling conditions.
 

--- a/.agents/skills/add-dataset/SKILL.md
+++ b/.agents/skills/add-dataset/SKILL.md
@@ -1,111 +1,38 @@
 ---
 name: add-dataset
-description: Register or inspect a Hugging Face dataset for Marin pipelines.
+description: Register a named Hugging Face dataset for Marin by inspecting its schema and adding the appropriate experiments/datasets module.
 ---
 
-# Skill: Dataset Schema Inspection and Registration
+# Register a Hugging Face dataset
 
-## Overview
-Inspect a Hugging Face dataset schema with Marin's schema inspection tool, then
-add a dataset module under
-[`experiments/datasets/`](https://github.com/marin-community/marin/blob/main/experiments/datasets/__init__.py)
-so the dataset can be tokenized and consumed in Marin pipelines. Each leaf module
-exposes `<name>_dataset()` (one corpus) or `<name>_datasets() -> dict[str, ...]`
-(a keyed family) built with the lazy data builders in `marin.experiment.data`.
-- Single-corpus datasets: add a small leaf module (e.g.
-  [`experiments/datasets/svg.py`](https://github.com/marin-community/marin/blob/main/experiments/datasets/svg.py))
-  exposing a `<name>_dataset()`.
-- Multipart/complex datasets: create a dedicated file (e.g.
-  [`experiments/datasets/nemotron.py`](https://github.com/marin-community/marin/blob/main/experiments/datasets/nemotron.py))
-  exposing `<name>_datasets()`.
-- Datasets with HF-exposed subsets/splits: pattern-match on `nemotron.py`,
-  keying one handle per subset in the returned dict.
+Inspect the schema without downloading the full dataset:
 
-## Prerequisites
-- Prefer repo-managed dependencies over ad hoc `pip install`.
-- For repeated work in a checked-out Marin repo, install the synced environment
-  with `uv sync --all-packages`, then run
-  `uv run lib/marin/tools/get_hf_dataset_schema.py`.
-- For one-off schema inspection without a provisioned environment, use
-  ephemeral deps:
-  `uv run --with datasets --with pyyaml lib/marin/tools/get_hf_dataset_schema.py ...`
-- Ensure access to the dataset (Hugging Face Hub ID, local path, or other
-  supported format).
-
-## Usage
-
-Command line:
 ```sh
 uv run lib/marin/tools/get_hf_dataset_schema.py <dataset_name> [options]
 ```
 
-Python import:
-```python
-from marin.tools.get_hf_dataset_schema import get_schema
-schema = get_schema(dataset_name="wikitext", config_name="wikitext-103-v1")
-```
+Use repo-managed dependencies. For a one-off inspection without a provisioned
+environment, add `--with datasets --with pyyaml` to `uv run`.
 
-## Rules
-1. **Config handling**: always check whether a dataset requires a config first.
-   If required, the tool returns
-   `{"error": "Config name is required.", "available_configs": [...]}` — select
-   an appropriate config from the list and retry with `--config_name`.
-2. **Text field selection**: prioritize a field named exactly `text`; fall back
-   to fields containing `text`; consider string-type fields if no obvious text
-   field exists. Examine `sample_row` to verify field contents.
-3. **Error handling**: handle missing config, dataset not found, and remote
-   code execution required. Retry with appropriate parameters (e.g.
-   `--trust_remote_code`).
-4. **Performance**: the tool streams to avoid full downloads; expect quick
-   responses. `sample_row` may be empty for some datasets.
+If the result says a config is required, select one of `available_configs` and
+retry with `--config_name`. Add `--trust_remote_code` only after inspecting the
+dataset repository and accepting its code-execution boundary. The tool streams;
+do not replace it with a full dataset download.
 
-## Output Format
-The tool returns a JSON object:
-```json
-{
-  "splits": ["train", "validation", ...],
-  "text_field_candidates": ["text", "content", ...],
-  "features": {
-    "text": "string",
-    "label": "int64",
-    ...
-  },
-  "sample_row": {
-    "text": "Example content...",
-    ...
-  }
-}
-```
+If the dataset cannot be found, stop and report the identifier, path, or access
+failure instead of guessing a replacement.
 
-## Example: dataset requiring a config
-```sh
-$ uv run lib/marin/tools/get_hf_dataset_schema.py wikitext
-{
-  "error": "Config name is required.",
-  "available_configs": ["wikitext-103-raw-v1", "wikitext-103-v1", ...]
-}
+Choose the text field from the reported schema. Prefer an exact `text` field,
+then a field containing `text`, then another string field. Inspect `sample_row`
+to verify the content; it may be empty for some datasets.
 
-$ uv run lib/marin/tools/get_hf_dataset_schema.py wikitext --config_name wikitext-103-v1
-{
-  "splits": ["train", "validation", "test"],
-  "text_field_candidates": ["text"],
-  "features": {"text": "string"},
-  "sample_row": {"text": "Article content..."}
-}
-```
+Add a leaf module under `experiments/datasets/` using the lazy builders in
+`marin.experiment.data`:
 
-For datasets needing remote code, add `--trust_remote_code`.
+- expose `<name>_dataset()` for one corpus;
+- expose `<name>_datasets() -> dict[str, ...]` for a keyed family;
+- for Hugging Face subsets, follow `experiments/datasets/nemotron.py` and return
+  one keyed handle per subset.
 
-## Next Steps
-Once the schema is inspected and the dataset is registered, cargo-cult existing
-dataset configs for tokenization:
-- Apply transformations (e.g. field mapping).
-- Estimate token counts and file sizes.
-- Find similar dataset configurations in Marin's existing experiments.
-- Copy and adapt tokenization configs from similar datasets.
-- Run ablations or trials.
-
-## See Also
-- `lib/marin/tools/get_hf_dataset_schema.py`
-- [Hugging Face datasets documentation](https://huggingface.co/docs/datasets/)
-</content>
+Validate the selected config, splits, text mapping, and one sample before adding
+tokenization or downstream experiment configuration.

--- a/.agents/skills/add-dataset/SKILL.md
+++ b/.agents/skills/add-dataset/SKILL.md
@@ -11,6 +11,14 @@ Inspect the schema without downloading the full dataset:
 uv run lib/marin/tools/get_hf_dataset_schema.py <dataset_name> [options]
 ```
 
+For programmatic inspection:
+
+```python
+from marin.tools.get_hf_dataset_schema import get_schema
+
+schema = get_schema(dataset_name="wikitext", config_name="wikitext-103-v1")
+```
+
 Use repo-managed dependencies. For a one-off inspection without a provisioned
 environment, add `--with datasets --with pyyaml` to `uv run`.
 
@@ -24,7 +32,8 @@ failure instead of guessing a replacement.
 
 Choose the text field from the reported schema. Prefer an exact `text` field,
 then a field containing `text`, then another string field. Inspect `sample_row`
-to verify the content; it may be empty for some datasets.
+to verify the content; it may be empty for some datasets. The result also
+reports `splits`, `text_field_candidates`, and `features`.
 
 Add a leaf module under `experiments/datasets/` using the lazy builders in
 `marin.experiment.data`:

--- a/.agents/skills/add-grant/SKILL.md
+++ b/.agents/skills/add-grant/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-grant
-description: Add a GCP IAM or IAP user grant to the marin-iac Pulumi stacks, encrypting human principals. Use when someone needs access to a project role, bucket/secret/service account, or an IAP-gated web service (evaldash, grafana), whether requested locally or on a GitHub issue.
+description: Implement a fully specified request for a GCP IAM resource grant or Cloud Run IAP viewer in marin-iac.
 ---
 
 # Skill: Add a user grant

--- a/.agents/skills/add-pallas-kernel/SKILL.md
+++ b/.agents/skills/add-pallas-kernel/SKILL.md
@@ -1,20 +1,13 @@
 ---
 name: add-pallas-kernel
-description: Add, modify, or autotune a TPU/GPU Pallas kernel.
+description: Add or change a named Pallas/Mosaic kernel, including its reference implementation, correctness tests, wrapper, or requested tuning.
 ---
 
-# Skill: Add or Update a Pallas Kernel
-
-Use this skill to build or change Pallas kernels with explicit standards for
-reference numerics, gradient safety, backend/fallback API design, performance
-measurement, and block-size autotuning.
+# Add or update a Pallas kernel
 
 ## How to apply this skill
 
-1. For long-running kernel research, load `.agents/skills/run-research/SKILL.md`
-   first.
-2. Apply the core workflow in this file.
-3. Load only the detail files needed for the task:
+Load only the detail files needed for the requested work:
    - [Kernel sources](docs/kernel-sources.md): read when choosing an in-repo or
      external kernel to imitate.
    - [Performance workflow](docs/performance-workflow.md): read before
@@ -26,27 +19,21 @@ measurement, and block-size autotuning.
    - [GPU tips](docs/gpu-tips.md): read for GPU Pallas/Mosaic work.
    - Deep references live under `docs/reference/`; read them only when the
      routed detail files point there.
-4. For atomic kernel changes, use only the task skills needed for the work.
+
+Use `run-research` only when the user explicitly requests its multi-session
+research workflow.
 
 ## Kernel Deliverables
 
 For a kernel `K`, produce:
 
-- A readable vanilla JAX reference with the target public API.
-- A correctness harness validating value parity vs reference, gradient parity on
-  small shapes, and CPU + accelerator numerics where applicable.
-- A Pallas kernel implementation plus wrapper with the same API.
-- A roofline estimate for the relevant hardware type(s).
-- A performance harness with steady-state timing on representative shape/dtype
-  grids and progress against the roofline.
-- Autotuned block/tile sizes for requested hardware/shape regimes.
-- A checked-in tuned table module for runtime selection, with explicit fallback
-  behavior.
-- An autotune-on-miss fallback path that sweeps a bounded candidate set and
-  caches winning configs.
-
-The general flow is: make it right, make it fast, make it usable, make it easy
-to use.
+- Vanilla JAX reference and Pallas wrapper with the same public API.
+- Value, gradient, CPU, and applicable accelerator parity harness.
+- Explicit backend and shape validation, with tests for ordered implementation
+  selection and each fallback path.
+- Roofline estimate and steady-state benchmark on representative shapes/dtypes.
+- When tuning is requested, bounded autotuning, a checked-in tuned table,
+  explicit fallback, and cached autotune-on-miss results.
 
 ## Correctness Workflow
 
@@ -160,17 +147,3 @@ def _cost_estimate(
 - Tuned table is checked in for requested hardware/shape regimes.
 - Research artifacts, issue summaries, and snapshot links follow the
   `run-research` workflow when the task is long-running.
-
-## PR Checklist
-
-- Reference implementation and public wrapper are in place.
-- Correctness tests cover values, gradients, and relevant backend paths.
-- Pallas implementation has explicit backend/shape validation.
-- Pallas, Mosaic, and FFI calls use an explicit `shard_map` boundary when
-  operating on sharded inputs.
-- Fallback behavior is tested for explicit and ordered implementation choices.
-- Cost estimates are attached to Pallas calls.
-- Benchmark or tuning script emits machine-readable rows.
-- Tuned table and autotune-on-miss behavior are checked in when tuning is part
-  of the task.
-- Long-running work has the required logbook/artifact/snapshot updates.

--- a/.agents/skills/archive-experiments/SKILL.md
+++ b/.agents/skills/archive-experiments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: archive-experiments
-description: Retire legacy experiment scripts behind a dated archive tag.
+description: Archive explicitly named legacy experiment files by publishing a dated tag and canonical issue breadcrumbs.
 ---
 
 # Skill: Archive Legacy Experiments

--- a/.agents/skills/babysit-job/SKILL.md
+++ b/.agents/skills/babysit-job/SKILL.md
@@ -141,7 +141,9 @@ part of the setup. The state file allows resume after context reset.
    - Resolve `<exact_max>` from the launched config/code, not from progress-bar display text.
 6. EVALUATE (terminal? error? stalled? -> recover or continue)
 
-7. RECOVER (STOP -> RESUBMIT)
+7. RECOVER (STOP -> RESUBMIT, ONLY WHEN AUTHORIZED IN THE CURRENT THREAD)
+   - If stop/resubmit is not authorized, report the failure and wait for the
+     user. Do not cancel or resubmit.
    - If current job is still non-terminal, stop it first:
      uv run iris --config <CONFIG> job cancel --exact <JOB_ID>
    - Then resubmit:

--- a/.agents/skills/babysit-job/SKILL.md
+++ b/.agents/skills/babysit-job/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: babysit-job
-description: Monitor and, when authorized, recover a specified non-Zephyr Iris job by stopping and resubmitting it.
+description: Continuously monitor a specified non-Zephyr Iris job only when asked to babysit it; stop and resubmit only with authorization.
 ---
 
 # Babysit an Iris job

--- a/.agents/skills/babysit-job/SKILL.md
+++ b/.agents/skills/babysit-job/SKILL.md
@@ -1,25 +1,20 @@
 ---
 name: babysit-job
-description: Monitor an Iris job and recover it on failure. Use when asked to babysit or watch a job or run.
+description: Monitor and, when authorized, recover a specified non-Zephyr Iris job by stopping and resubmitting it.
 ---
 
-# Skill: Babysit Job
+# Babysit an Iris job
 
-Monitor a job continuously and recover on failure. For **Zephyr pipelines**,
-delegate to **babysit-zephyr** instead. Otherwise, follow this skill — Iris is
-the execution backend.
+Use `babysit-zephyr` only when the requested target is a Zephyr pipeline.
 
 ## Required Info
 
-1. `job_id` — Iris job ID in canonical format `/<user>/<job>` (e.g., `/dlwh/iris-run-train_tiny_model-20260302-185630`)
-2. `config` — Iris config path (e.g., `lib/iris/config/marin.yaml`). When the user
-   refers to a cluster by shorthand name (e.g., "marin_dev", "marin-dev", "marin",
-   "coreweave"), resolve it to the matching config file under `lib/iris/config/`.
-   Common mappings:
+1. `job_id` in canonical `/<user>/<job>` format.
+2. Iris config path. Resolve shorthand against `lib/iris/config/`; common mappings:
    - `marin` / `marin_prod` -> `lib/iris/config/marin.yaml`
    - `marin_dev` / `marin-dev` -> `lib/iris/config/marin-dev.yaml`
    - `coreweave` / `cw-us-east-02a` -> `lib/iris/config/cw-us-east-02a.yaml`; `cw-rno2a` -> `lib/iris/config/cw-rno2a.yaml`
-3. `resubmit_command` — exact Iris submit command for resubmission; must include `--no-wait`
+3. Exact resubmit command, including `--no-wait`.
 4. For Marin TPU training jobs, use `--extra marin-core:tpu` (not `--extra marin-core:cpu`)
 5. For TPU jobs, the resubmit command must request TPU resources with `--tpu <variant>`.
    `--reserve <variant>` only holds capacity; it does not attach TPU devices to the task container.
@@ -27,7 +22,7 @@ the execution backend.
 Example resubmit command:
 `uv run iris --config lib/iris/config/marin.yaml job run --no-wait --extra marin-core:tpu --tpu v5litepod-16 -- python -m experiments.tutorials.train_tiny_model --device v5litepod-16 --dataset tinystories`
 
-If any required field is missing, ask for it before proceeding.
+Ask for any missing field before monitoring.
 
 ## Scope
 
@@ -39,13 +34,8 @@ If any required field is missing, ask for it before proceeding.
 ## Monitoring Ownership and Duration
 
 - Assign a single monitoring owner when the loop starts.
-- Keep the loop running until: the job reaches a terminal state and the user has
-  acknowledged next action; a user-specified stopping point is reached; or an
-  unrecoverable error is found and reported.
-- Do not stop early after first loss lines, first eval, or first W&B link.
-- Ferry-scale runs commonly take 4-5 hours.
-- Do not end the turn for a status update while continuous monitoring is active;
-  continue until terminal state, a stopping point, or an unrecoverable error.
+- Continue until terminal state and acknowledged next action, a requested stop,
+  or a reported unrecoverable error. First loss, eval, or W&B link is not an exit.
 - For handoff, transfer ownership explicitly with: current `job_id`, latest
   error/signal, W&B link(s), and resubmission metadata.
 
@@ -53,13 +43,11 @@ If any required field is missing, ask for it before proceeding.
 
 - After submit/resubmit: sleep `120` once, check for immediate failure; if still
   alive, switch to the normal `570` cadence.
-- Tool-runtime workaround: keep one long-running monitor session; poll it in
-  ~30s chunks as tool limits require — repeated no-output polls are expected
-  while waiting for the next 570s check.
+- Keep one long-running monitor session. Resume that session across tool yields;
+  repeated no-output waits are expected.
 - Run only one active monitor loop per job (duplicate loops cause SSH tunnel and
   port-binding conflicts).
-- Sleep must be foreground (max ~10 min due to tool timeout). Loop control is at
-  agent level, not bash.
+- Sleep in the foreground; keep loop control at the agent level.
 - Screen/process alive is not enough. Check state-file freshness plus
   stdout/event-log mtime when a monitor writes them; if no monitor state or
   event update occurs for more than 2 cadences, report `monitor stale`
@@ -73,9 +61,8 @@ If any required field is missing, ask for it before proceeding.
 When using `marin-mcp-babysitter`, keep the MCP server resident and verify the
 job through MCP tools, not only Iris CLI commands.
 
-- Keep the controller tunnel and MCP server in named, restartable sessions
-  (`screen`, `tmux`, or one long-running exec session). Record session names,
-  ports, and log paths in the state file.
+- Keep the controller tunnel and MCP server in named, restartable sessions and
+  record their names, ports, and logs in the state file.
 - Start MCP with a stable local controller URL and streamable HTTP transport:
   `uv run --package marin-core marin-mcp-babysitter --controller-url <URL> --cluster <CLUSTER> --transport streamable-http --host 127.0.0.1 --port <PORT>`
 - Verify with `iris_job_summary` and `iris_tail_logs`. For heartbeat monitoring,
@@ -85,10 +72,8 @@ job through MCP tools, not only Iris CLI commands.
   the Iris cluster.
 - If a sandbox blocks localhost TCP probes, run the probe inside an existing
   long-lived session and write a small JSON result under `scratch/`.
-- For bounded smoke tests, create a thread heartbeat only after the job is
-  submitted, MCP is reachable, and one expected log/progress line has appeared.
-  Delete the heartbeat and stop smoke-test sessions when the job reaches the
-  expected terminal state.
+- For a bounded smoke test, start a heartbeat only after submission, MCP
+  reachability, and one expected progress line. Delete it at terminal state.
 
 ## State File
 
@@ -170,24 +155,18 @@ part of the setup. The state file allows resume after context reset.
    - Go to step 1.
 ```
 
-## Fixing Small Bugs
+## Error handling
 
-When EVALUATE detects an error, before recovery:
-
-1. Analyze logs for `Traceback`, `Error`, `Exception`. Identify file and line.
-2. Small fix (`NameError`, `ImportError`, `SyntaxError`, obvious `KeyError`):
-   fix it, then RECOVER.
-3. Complex (OOM, TPU/XLA HBM exhaustion, distributed-training failures, data
-   loading, unclear multi-file stack traces): report to user, exit loop.
-
-## Error Patterns
+Before recovery, identify the failing file and line. Fix and recover only a
+small obvious `NameError`, `ImportError`, `SyntaxError`, or `KeyError`. Report
+OOM/HBM, distributed, data-loading, or unclear multi-file failures and stop.
 
 - Treat TPU/XLA HBM reports as failure even without literal OOM:
   - `Program hbm requirement ...`
   - `Largest program allocations in hbm`
 - If progress stalls across multiple intervals with `OwnerDiedError`, dead node,
   or unsatisfied resources -> mark `degraded` and notify user.
-- If same error repeats after one fix attempt, do not retry blindly; report to user.
+- If an error repeats after one fix attempt, report it; do not retry blindly.
 - Noisy shutdown traces are not decisive by themselves. Terminal Iris/orchestrator
   status, driver/process exit code, final checkpoint state, and W&B state
   determine whether a run succeeded.
@@ -206,12 +185,9 @@ Before declaring the job complete:
 - Stop/delete monitor heartbeats and resident monitoring sessions that are no
   longer needed.
 
-## When to Escalate
-
-- Zephyr pipeline issues, TPU bad-node errors, or debugging running tasks with
-  `iris task exec` -> **debug**
-
 ## Notes
 
 - Iris `job list --prefix` requires canonical job names (`/<user>/<job>`), not short names.
 - Iris monitoring is job-level; cluster updates are not part of normal recovery.
+- Use `debug` only for a stated TPU bad-node fault or a request to inspect a
+  running task; use `babysit-zephyr` for Zephyr.

--- a/.agents/skills/babysit-zephyr/SKILL.md
+++ b/.agents/skills/babysit-zephyr/SKILL.md
@@ -1,45 +1,33 @@
 ---
 name: babysit-zephyr
-description: Launch and babysit Zephyr pipeline jobs on Iris.
+description: Launch or continuously monitor a specified Zephyr pipeline job on Iris, and restart it only after explicit approval.
 ---
 
-# Skill: Babysit Zephyr Job
-
-Start, monitor, and keep Zephyr pipeline jobs running on Iris. Escalate deeper investigations to **debug**.
+# Babysit a Zephyr job
 
 ## Zephyr Job Structure
 
-A zephyr pipeline job spawns child Iris jobs:
-- **`*-coord`** — coordinator (1 task). Orchestrates pipeline stages, queues tasks, tracks progress.
-- **`*-workers`** — worker pool (many tasks). Workers poll the coordinator for shards.
-
-A single job may execute **multiple pipelines sequentially** (e.g. fuzzy dedup runs connected components iteratively, each iteration a separate pipeline). These show as different `p<N>` values in child job names — normal, not failed retries.
-
-Failed retries show as different **hashes** with the same `p0`. Stale coordinators from previous attempts may linger (#3705).
-
-Child job naming: `<hash>-p<pipeline>-a<attempt>-{coord,workers}`.
+A job has a one-task `*-coord` coordinator and a `*-workers` pool. Sequential
+pipelines produce different `p<N>` child names; retries produce different hashes
+with the same `p0`. Child names follow
+`<hash>-p<pipeline>-a<attempt>-{coord,workers}`. Old coordinators may linger.
 
 ## Iris Config
 
-All Iris commands below use `--config <CONFIG>`. Resolve the cluster name the user gives to the matching file under `lib/iris/config/` (see **babysit-job** for the full mapping). Examples use `marin.yaml` — substitute the actual config (e.g., `marin-dev.yaml`) as needed.
-
-## Dashboard
-
-```bash
-# Connect to the Iris dashboard (establishes SSH tunnel, prints URL with port)
-uv run iris --config lib/iris/config/marin.yaml cluster dashboard
-```
+Resolve the requested cluster to its file under `lib/iris/config/`; substitute
+that file for `<CONFIG>` below. See `lib/zephyr/OPS.md` for the dashboard and
+coordinator query reference.
 
 ## Starting a Job
 
-Get the run command from the user. Typical pattern:
+Get the run command from the user:
 ```bash
-uv run iris --config lib/iris/config/marin.yaml job run --region <REGION> --no-wait -- python <SCRIPT>
+uv run iris --config <CONFIG> job run --region <REGION> --no-wait -- python <SCRIPT>
 ```
 
 The entrypoint container defaults to 1GB memory. For long-running pipelines that accumulate state (GCS clients, logging), increase with `--memory`:
 ```bash
-uv run iris --config lib/iris/config/marin.yaml job run --region <REGION> --memory 5GB --no-wait -- python <SCRIPT>
+uv run iris --config <CONFIG> job run --region <REGION> --memory 5GB --no-wait -- python <SCRIPT>
 ```
 
 The command prints a job ID on success. Note it for monitoring.
@@ -48,7 +36,7 @@ The command prints a job ID on success. Note it for monitoring.
 
 Always ask the user before stopping. Stopping kills all child jobs (coordinators, workers).
 ```bash
-uv run iris --config lib/iris/config/marin.yaml job cancel <JOB_ID>
+uv run iris --config <CONFIG> job cancel <JOB_ID>
 ```
 
 ## Monitoring
@@ -58,7 +46,7 @@ uv run iris --config lib/iris/config/marin.yaml job cancel <JOB_ID>
 Check child job states via the Iris CLI (returns per-task state and resourceUsage):
 ```bash
 # diskMb is updated every ~60s. On K8s it is always 0 (workdir lives inside the pod).
-uv run iris --config lib/iris/config/marin.yaml rpc controller list-tasks --job-id <JOB_ID>
+uv run iris --config <CONFIG> rpc controller list-tasks --job-id <JOB_ID>
 ```
 
 A healthy zephyr job has:
@@ -67,31 +55,20 @@ A healthy zephyr job has:
 
 ### Stage Progress
 
-The coordinator logs a progress line every 5s:
-```
-[stage0-Map → Scatter] 347/1964 complete, 1617 in-flight, 0 queued, 1828/1891 workers alive, 63 dead
-```
-
-Fetch via the Iris CLI:
+The coordinator logs stage, completed, in-flight, queued, and worker counts:
 ```bash
-uv run iris --config lib/iris/config/marin.yaml rpc controller get-task-logs \
+uv run iris --config <CONFIG> rpc controller get-task-logs \
   --id <COORD_JOB_ID> --max-total-lines 5000 --attempt-id -1 --tail
 ```
 
-**Caveat**: With large worker pools, `pull_task` operations flood the log buffer (#3707). Filter when parsing:
-```python
-for entry in task_logs:
-    msg = entry.get('data', '')
-    if 'pull_task' in msg or 'Started operation' in msg or 'report_result' in msg or 'registered' in msg or 'tasks completed' in msg:
-        continue
-    print(msg)
-```
+Large pools can flood the log with `pull_task`, `Started operation`,
+`report_result`, `registered`, and `tasks completed`; filter those entries.
 
 ### Coordinator Thread Dump
 
 When logs are flooded, a thread dump tells you if the coordinator is alive and working:
 ```bash
-uv run iris --config lib/iris/config/marin.yaml rpc controller profile-task \
+uv run iris --config <CONFIG> rpc controller profile-task \
   --json '{"target":"<COORD_JOB_ID>/0","durationSeconds":1,"profileType":{"threads":{}}}'
 ```
 

--- a/.agents/skills/babysit-zephyr/SKILL.md
+++ b/.agents/skills/babysit-zephyr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: babysit-zephyr
-description: Launch or continuously monitor a specified Zephyr pipeline job on Iris, and restart it only after explicit approval.
+description: Launch or continuously monitor a specified Zephyr pipeline on Iris only when asked to babysit it; restart only after explicit approval.
 ---
 
 # Babysit a Zephyr job

--- a/.agents/skills/background-research/SKILL.md
+++ b/.agents/skills/background-research/SKILL.md
@@ -13,7 +13,7 @@ decision is expensive enough to justify it.
 
 - `low` (3-7 min): current issue/logbook, obvious local refs, and a few external
   sources. Use for small follow-ups or when the user provides strong context.
-- `medium` (10-15 min): search internal Marin sources plus targeted
+- `medium` (10-15 min): default. Search internal Marin sources plus targeted
   external literature/code, include a contradiction pass, and produce a source
   ledger plus ranked next experiments.
 - `high` (30-60 min): for expensive runs, architecture changes, data/eval
@@ -72,13 +72,44 @@ where the category is novel to this repo rather than novel to the world.
 ## Output Contract
 
 Write the compact brief in the parent workflow's logbook, issue, or
-`.agents/projects/<slug>/research.md`. Record effort, stop rule, question,
-current Marin context, internal and external prior work, negative leads, and a
-source ledger. For each decision-relevant claim, give support, contradiction,
-directness, confidence, and action. Rank next experiments by falsifiable
-hypothesis, minimum test, control, expected signal, falsifier, cost/risk, and
-sources. Include hypothesis-queue changes, open questions, and stop reason. If
-an experiment issue exists, add a short issue-ready `Prior work` block.
+`.agents/projects/<slug>/research.md`. Use this structure, omitting empty
+sections:
+
+```md
+## Background Research Brief
+- Effort / stop rule / date:
+
+### Question
+### Current Marin Context
+### Internal Prior Work
+### External Prior Art
+### Negative / Failed Leads
+
+### Evidence Map
+#### Claim: <short claim>
+- Support:
+- Contradictions:
+- Directness to Marin:
+- Confidence:
+- Action:
+
+### Recommended Next Experiments
+#### 1. <falsifiable hypothesis>
+- Minimum experiment / baseline:
+- Expected signal / falsifier:
+- Cost or risk / sources:
+
+### Hypothesis Queue Update
+### Source Ledger
+| Source | Type | Location | Claim used for | Confidence | Notes |
+|---|---|---|---|---|---|
+### Handoff
+- Issue `Prior work` block:
+- Logbook entry / open questions / stop reason:
+```
+
+If an experiment issue exists, include the short issue-ready `Prior work`
+block.
 
 Use source types such as `paper`, `external code`, `official docs`, `GitHub
 issue`, `PR`, `report`, `logbook`, `W&B`, `Data Browser`, and `Marin code`.

--- a/.agents/skills/background-research/SKILL.md
+++ b/.agents/skills/background-research/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: background-research
-description: "Forage prior work before or during Marin research threads: search internal Marin artifacts and external literature/code; produce a cited brief with negative results and ranked experiment hypotheses."
+description: Perform an explicitly requested prior-work search for a Marin research, design, or experiment decision and produce a cited brief.
 ---
 
-# Skill: Background Research
-
-Use this when a research, design, or experiment thread needs a compact prior-work
-pass before choosing hypotheses, drafting a design, or launching runs.
+# Background research
 
 ## Effort
 
@@ -16,7 +13,7 @@ decision is expensive enough to justify it.
 
 - `low` (3-7 min): current issue/logbook, obvious local refs, and a few external
   sources. Use for small follow-ups or when the user provides strong context.
-- `medium` (10-15 min): default. Search internal Marin sources plus targeted
+- `medium` (10-15 min): search internal Marin sources plus targeted
   external literature/code, include a contradiction pass, and produce a source
   ledger plus ranked next experiments.
 - `high` (30-60 min): for expensive runs, architecture changes, data/eval
@@ -52,17 +49,9 @@ When `write-design-doc` uses this skill, the output usually lands in
 `.agents/projects/<slug>/research.md`. Keep it focused on design inputs, not
 experiment execution.
 
-Include:
-
-- Relevant code paths. Use pinned GitHub links for claims tied to a fixed
-  revision; use paths or section links for draft-local notes.
-- Related designs in `.agents/projects/`, with overlap and differences.
-- Related GitHub issues/PRs when known or discoverable.
-- Existing utilities or abstractions the proposal might reuse.
-- Prior-art shape when the proposal reinvents a category of system such as a
-  logger, stats store, queue, scheduler, KV store, service-discovery layer, or
-  workflow engine.
-- What surprised you and what remains unclear.
+Include relevant code paths, related designs and GitHub work, reusable
+abstractions, external prior art for a known system category, surprises, and
+open questions. Pin links for claims tied to a fixed revision.
 
 For design-doc prior art, use `low` or `medium` effort by default. Skip
 external prior art for narrow in-repo refactors, internal API tweaks, or designs
@@ -82,64 +71,14 @@ where the category is novel to this repo rather than novel to the world.
 
 ## Output Contract
 
-Write a compact brief in the research logbook, issue comment, or
-`.agents/projects/<slug>/research.md`, depending on the parent workflow. If an
-experiment issue exists, also provide a short issue-ready `Prior work` block.
-
-```md
-## Background Research Brief
-
-- Effort:
-- Stop rule:
-- Date:
-
-### Question
-
-### Current Marin Context
-
-### Internal Prior Work
-
-### External Prior Art
-
-### Negative / Failed Leads
-
-### Evidence Map
-
-#### Claim: <short claim>
-- Support:
-  - <source>: <one-line evidence>
-- Contradictions:
-  - <source>: <one-line caveat or failed result>
-- Directness to Marin:
-- Confidence:
-- Action:
-
-### Recommended Next Experiments
-
-#### 1. <hypothesis>
-- Minimum experiment:
-- Baseline/control:
-- Expected signal:
-- Falsifier:
-- Cost/risk:
-- Sources:
-
-### Hypothesis Queue Update
-- Add:
-- Revise:
-- Falsify / stop:
-- Promote:
-
-### Source Ledger
-| Source | Type | Location | Claim used for | Confidence | Notes |
-|---|---|---|---|---|---|
-
-### Handoff
-- Suggested issue `Prior work` block:
-- Suggested logbook entry:
-- Open questions:
-- Stop reason:
-```
+Write the compact brief in the parent workflow's logbook, issue, or
+`.agents/projects/<slug>/research.md`. Record effort, stop rule, question,
+current Marin context, internal and external prior work, negative leads, and a
+source ledger. For each decision-relevant claim, give support, contradiction,
+directness, confidence, and action. Rank next experiments by falsifiable
+hypothesis, minimum test, control, expected signal, falsifier, cost/risk, and
+sources. Include hypothesis-queue changes, open questions, and stop reason. If
+an experiment issue exists, add a short issue-ready `Prior work` block.
 
 Use source types such as `paper`, `external code`, `official docs`, `GitHub
 issue`, `PR`, `report`, `logbook`, `W&B`, `Data Browser`, and `Marin code`.
@@ -150,20 +89,6 @@ cell likely to contain prose, use block-style cards so GitHub remains readable.
 For research threads with a logbook, treat the hypothesis queue as a living
 index derived from append-only entries. Link each queue change to the supporting
 logbook entry, issue comment, W&B run, commit, tag, or pinned source.
-
-## Hypothesis Quality
-
-Recommended experiments should be actionable without re-reading the full source
-set. Each candidate needs:
-
-- A falsifiable hypothesis.
-- The smallest experiment that could change the decision.
-- Baseline or control.
-- Primary metric and expected direction.
-- Cost/risk.
-- Source links.
-- Confidence: `exploratory`, `replicated`, or `stable` when evidence supports
-  those labels; otherwise say why confidence is weak.
 
 ## What To Skip
 

--- a/.agents/skills/change-grug/SKILL.md
+++ b/.agents/skills/change-grug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: change-grug
-description: Modify model or training behavior in a Grug/Grugformer experiment variant, or upstream a proven variant change.
+description: Modify or upstream behavior in a named Grug/Grugformer experiment variant.
 ---
 
 # Skill: Changing Grug (Template-First)

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: commit
-description: Lint, run the pre-PR checks, commit, push, and author or update the branch's pull request in the required plain-text format. Use when committing, pushing, or creating/updating a PR.
+description: Use only when a change is ready to commit, push, or open or update its pull request; do not activate during implementation.
 ---
 
-# Skill: Commit & PR
-
-Get the branch clean, commit it, run the advisory lint review over the committed
-diff, then — when it is ready — open or update the pull request.
+# Commit and PR
 
 Before authoring a commit or PR title or body, read:
 
@@ -14,46 +11,20 @@ Before authoring a commit or PR title or body, read:
 - `.agents/skills/writing-style/pull-requests.md`
 - `.agents/skills/writing-style/ai-writing-donts.md`
 
-**Order matters.** Your own cleanups and the mechanical fixes come first, then the
-commit, and only *then* the `--review` pass. Committing before the review gives
-you a clean checkpoint to review against (the review reads the whole branch diff
-versus the merge base) and a natural place to land any follow-up fixes as a new
-commit. The review is read-only: it never edits, commits, or pushes for you.
-
-## Checklist
-
-Work top to bottom. For a quick work-in-progress checkpoint, do **1, 2, 4, 5,
-7** (clean up, lint, stage, commit, push) and stop. The changed-test cleanup in
-step 1 is a PR-readiness gate, not required for disposable WIP checkpoints. Run
-the whole list for PR-ready work.
-
-1. Clean up your own diff (self-review).
-2. Mechanical lint & format — `./infra/pre-commit.py --changed-files --fix`.
-3. Tests & docs checks, when relevant.
-4. Stage the specific files for this work.
-5. Commit. ← natural checkpoint; the working tree is now clean.
-6. Lint-catalog review — run `./infra/pre-commit.py --review` once; fix or answer every finding.
-7. Push (maybe).
-8. Open or update the PR.
-9. Monitor the PR with `wait_for.py` until an exit condition.
+Clean and validate the diff, commit it, run the advisory review over the
+committed branch, push, update the PR, then monitor it. A WIP checkpoint may
+stop after clean-up, lint, staging, commit, and push.
 
 ## 1. Clean up your own diff
 
-Read your own `git diff` before anything else. Drop dead code, debugging
-leftovers, and stale comments; tighten names; make the change say only what it
-means to. The review in step 6 is advisory and read-only — it will not clean up
-for you.
+Read the complete branch diff and remove dead code, weak tests, stale prose,
+debugging artifacts, and unrelated changes.
 
 If the diff touches tests and this commit is intended for a PR or review, read
 root `TESTING.md` and the relevant module-specific `AGENTS.md` or testing docs
-as part of this self-review. Review every changed test for slop: tautological
-assertions, disposable smoke probes left as pytest tests, internal call-count
-assertions, incidental string or command-fragment assertions, over-mocking,
-weakened tolerances, sleeps, skipped tests, and local marker/fake/mock
-violations.
-
-Fix or delete low-value tests before a PR-ready commit. Scratch probes are fine
-during development and WIP checkpointing, but they must not survive into a PR.
+as part of this self-review. Apply `TESTING.md`'s behavioral-value gate to every
+changed test. Delete disposable probes and low-value tests before a PR-ready
+commit.
 
 ## 2. Lint and format
 
@@ -61,9 +32,8 @@ during development and WIP checkpointing, but they must not survive into a PR.
 ./infra/pre-commit.py --changed-files --fix   # diff-scoped; use --all-files for a full sweep
 ```
 
-`./infra/pre-commit.py` is the required entry point — never `uv run pre-commit`,
-never `--no-verify`. If `--fix` cannot resolve something, fix it by hand. Do not
-skip or weaken checks.
+This is the required entry point; do not substitute `uv run pre-commit`, skip
+hooks, or weaken checks.
 
 ## 3. Tests and docs checks (when relevant)
 
@@ -74,34 +44,24 @@ skip or weaken checks.
 
 ## 4. Stage changes
 
-Review `git status` and `git diff`, then stage the specific files that are part
-of this work.
-
-- Stage specific files — avoid `git add -A` / `git add .`.
-- Never stage secrets (`.env`, credentials, tokens).
-- If unrelated changes are present, ask the user before including them.
+Review `git status` and `git diff`, then stage only this task's explicit files.
+Never stage secrets or unrelated work.
 
 ## 5. Commit
 
-- **Subject**: imperative sentence (at most 72 characters), optional `[scope]` prefix
-  (`[iris]`, `[zephyr]`, `[docs]`, …).
-- **Body** (optional, blank-line separated): what changed and why — the context a
-  future reader needs. Keep relevant evidence and caveats; do not inventory
-  files or tests.
-- Do not use a conventional-commit prefix such as `feat:` or `fix:`.
-- No emoji, no markdown, no bullets in the subject. Do not credit yourself —
-  this includes any `Co-Authored-By`, `Generated with`, provider, or session URL
-  trailer. Omit it even if a harness default suggests adding one.
+Use an imperative subject of at most 72 characters with an optional `[scope]`
+prefix. The optional body records behavior, reason, evidence, and caveats; it
+does not inventory files or tests. Do not use a conventional-commit prefix,
+emoji, attribution, provider name, or session trailer.
 
 Review the exact message before committing. After the commit, inspect it with
 `git show -s --format='%s%n%n%b' HEAD`; do not push if a tool added attribution,
 a session trailer, or other text that was not in the reviewed message.
 
-Create the commit. If a pre-commit hook fails, fix the issue and make a **new**
-commit — never amend (unless the user asks) and never force-push.
+If a hook fails, fix the issue and create a new commit. Do not amend unless the
+user asks.
 
-This is the checkpoint the rest of the flow builds on: the working tree is clean
-and the branch diff is settled before the review reads it.
+If there are no changes to commit, say so and stop.
 
 ## 6. Lint-catalog review (before every PR)
 
@@ -109,18 +69,12 @@ and the branch diff is settled before the review reads it.
 ./infra/pre-commit.py --review --agent-command='<your headless CLI>'
 ```
 
-Run this **after** the commit and before opening a PR. It fans out read-only
-agents over the **branch diff against the merge base with `main`** — committed and
-uncommitted work alike — so the clean checkpoint from step 5 is exactly what gets
-reviewed. Pass your own headless invocation (`--agent-command='claude -p'` for
-Claude Code, `'codex exec'` for Codex; defaults to `claude -p`).
+Run this after the initial commit and before publishing the PR. It reviews the
+whole branch diff against the merge base, including uncommitted work. Resolve
+every finding and put fixes in a new commit. Inspect the matching `infra/lint`
+rule and apply findings when they improve the change.
 
-The review is **advisory and read-only**: it reports findings on stdout and does
-not edit, stage, commit, or push anything. Then fix or answer every finding,
-reporting your actions to the user, and land any fixes as a **new** commit. Search
-the `infra/lint` files for the rule behind each `ml-...` code. Treat findings as
-guidelines — apply them when they make the code *better*; the goal is
-high-quality code, not blind adherence.
+The advisory review is read-only: it does not edit, stage, commit, or push.
 
 Do not recursively rerun `--review` after small, targeted touch-ups made in
 response to its findings. Validate behavioral edits with the normal mechanical
@@ -129,41 +83,20 @@ and lint checks only. Rerun the advisory review only when the follow-up material
 changes the branch's implementation approach or scope, or when the user asks for
 another pass.
 
-Each run writes the raw per-arm prompts and outputs, the combined findings, and a
-summary under `/tmp/marin-linter/<branch>/<timestamp>-<uniq>/` (the path is printed at the end) —
-read it when a lane is slow or a run looks wrong.
+Artifacts are written under `/tmp/marin-linter/<branch>/<timestamp>-<uniq>/`.
 
 ## 7. Push
 
-If asked, or if the branch has an upstream, push to the remote tracking branch (`git push -u origin HEAD` if no upstream is
-set). If the push is rejected (diverged history), stop and ask the user — do not
-force-push.
+Push when requested or when the branch has an upstream. Use
+`git push -u origin HEAD` when needed. Stop on rejection; do not force-push
+without explicit authorization.
 
 ## 8. Open or update the PR
 
-Do this once the branch is ready for review. The PR description becomes the
-squash-merge commit message. Follow
-`.agents/skills/writing-style/pull-requests.md` exactly: an imperative title of
-at most 72 characters and an information-dense body. Most bodies are a few plain
-paragraphs. They state what changes and why; they do not reproduce the diff,
-test plan, or implementation notes.
+The PR body becomes the squash-merge commit message. Follow
+`.agents/skills/writing-style/pull-requests.md`.
 
-Example:
-
-```
-Title: [RL] Normalize DAPO loss over global tokens
-
-Body:
-Normalize DAPO loss over all response tokens instead of normalizing each
-example separately. Per-example normalization over-weights short responses,
-hurting math tasks where correct answers need longer derivations.
-
-Fixes #1234
-```
-
-**Issue linking.** If the work came from a GitHub issue, add `Fixes #NNNN`
-(auto-closes on merge) or `Part of #NNNN` (partial work). Do not invent an issue
-just to satisfy this — omit the link when none exists.
+Add `Fixes #NNNN` or `Part of #NNNN` only when an existing issue applies.
 
 **Inspect the payload.** Draft the body in a uniquely named temporary file and
 use `--body-file`. Re-open that file and apply the final compression pass before
@@ -171,9 +104,8 @@ publishing. After creating or editing the PR, fetch the
 exact `title,body` with `gh pr view --json` and immediately correct text inserted
 by a tool or stale template.
 
-**Create it.** Unless the user says otherwise and permissions allow, push to a
-branch on the main repository and open the PR from it (use a fork only when
-direct push is unavailable or the user asks):
+Push to the main repository unless direct access is unavailable or the user
+asks for a fork:
 
 ```bash
 gh pr create --title "<title>" --body-file "<body-file>" --label agent-generated
@@ -182,12 +114,10 @@ gh pr create --title "<title>" --body-file "<body-file>" --label agent-generated
 - Always add the `agent-generated` label.
 - Never credit yourself in commits or PR descriptions.
 - Include `Fixes #NNNN` when addressing a pre-existing issue.
-- If you have a specific github tool, you may use it.
 
 ## 9. Monitor the PR
 
-Opening the PR starts the integration phase. Green CI is not an exit condition:
-reviews and comments can arrive after checks pass. Monitor every PR until it
+Green CI is not an exit condition. Monitor every PR until it
 merges or closes, the user tells you to stop, or a 12-hour wait times out.
 
 Before the first wait, read every current issue comment, inline review comment,
@@ -195,10 +125,10 @@ and submitted review once, then address anything actionable. This is a one-time
 inspection, not a monitoring loop. The comment and review arms establish a
 baseline when they start and wake only for later new or edited feedback.
 
-Set one honest status immediately before waiting, for example:
+If Loom is available, set one honest status immediately before waiting:
 
 ```bash
-weaver status ok "waiting for PR #<N> events"
+loom status set --tag ok --message "waiting for PR #<N> events"
 ```
 
 Do not refresh that status while nothing changes. Invoke one `wait_for.py`
@@ -268,12 +198,3 @@ new baseline without being handled.
 A question requiring user input pauses monitoring: raise `attention`, ask the
 question, and resume after the answer. Otherwise the only exit conditions are a
 merged or closed PR, an explicit request to stop, or a 12-hour timeout.
-
-## Rules
-
-- `./infra/pre-commit.py` is the only pre-commit entry point.
-- Commit before the initial `--review`; do not rerun it for minor findings-only touch-ups.
-- Never amend a commit unless the user explicitly asks.
-- If there are no changes to commit, say so and stop.
-- `.agents/skills/fix-issue/SKILL.md` — end-to-end issue-fix workflow.
-- `AGENTS.md` — coding guidelines.

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -49,10 +49,7 @@ Never stage secrets or unrelated work.
 
 ## 5. Commit
 
-Use an imperative subject of at most 72 characters with an optional `[scope]`
-prefix. The optional body records behavior, reason, evidence, and caveats; it
-does not inventory files or tests. Do not use a conventional-commit prefix,
-emoji, attribution, provider name, or session trailer.
+Follow `writing-style/pull-requests.md` for the commit subject and body.
 
 Review the exact message before committing. After the commit, inspect it with
 `git show -s --format='%s%n%n%b' HEAD`; do not push if a tool added attribution,

--- a/.agents/skills/consult-echo/SKILL.md
+++ b/.agents/skills/consult-echo/SKILL.md
@@ -46,7 +46,8 @@ uv run infra/echo/cli.py feedback --query "stalled TPU collective" \
 Use 0 for irrelevant and 10 for directly useful. Grade only evaluated results
 and always explain overall quality on stdin, including for an empty result set.
 
-Use `grep` for exact strings in GitHub or Discord activity:
+Use `grep` for exact strings in GitHub or Discord activity, narrowing with
+`--source` or `--kind` when needed:
 
 ```bash
 uv run infra/echo/cli.py grep "FAILED_PRECONDITION" --source github

--- a/.agents/skills/consult-echo/SKILL.md
+++ b/.agents/skills/consult-echo/SKILL.md
@@ -1,30 +1,23 @@
 ---
 name: consult-echo
-description: Search and cite Marin's Echo activity and wiki, then capture incident records or reusable shared knowledge. Use when looking for prior discussions, decisions, workflows, incident patterns, exact errors, tags, or identifiers; when prior context could shorten debugging; or when an investigation reaches resolution and its record or lessons may belong in Echo, docs, or OPS.md.
+description: Search or cite Echo when explicitly requested or required by repository policy or another selected workflow; do not invoke for routine repository research.
 ---
 
-# Skill: Consult Echo
+# Consult Echo
 
 Search Echo before rediscovering prior work. Cite canonical Echo, GitHub, or
 Discord URLs for the evidence you use.
 
 ## Search
 
-Use federated search when prior decisions, incidents, workflows, current GitHub
-work, or indexed repository documentation could inform the task. Natural-language
-questions work:
+Use a natural-language federated search:
 
 ```bash
 uv run infra/echo/cli.py search "how do I diagnose a stalled TPU collective" --limit 10
 ```
 
 Search covers `wiki`, `file`, `pr`, and `issue` by default. Repeat `--domain` to
-select a subset:
-
-```bash
-uv run infra/echo/cli.py search "stalled TPU collective" \
-  --domain wiki --domain file --domain issue
-```
+select a subset.
 
 File search infers the configured Marin-community repository from the current
 Git checkout, including ordinary contributor forks. Pass `--repository
@@ -36,15 +29,13 @@ Discord is excluded by default because messages may be noisy or untrusted. Add
 `--domain discord` only when discussion history is relevant, and open the
 canonical URL when surrounding thread context matters.
 
-Search output is deliberately compact. Fetch any result's complete indexed or
-raw-source detail with the printed ID:
+Fetch a result's full detail with its printed ID:
 
 ```bash
 uv run infra/echo/cli.py get <domain:id>
 ```
 
-When a result materially helps, is irrelevant, or the result set fails the task,
-submit a compact judgment using the exact query and printed grading keys:
+Grade evaluated results with the exact query and printed keys:
 
 ```bash
 uv run infra/echo/cli.py feedback --query "stalled TPU collective" \
@@ -52,13 +43,10 @@ uv run infra/echo/cli.py feedback --query "stalled TPU collective" \
   <<< "The file result answered the task; wiki results were off-topic."
 ```
 
-Use 0 for an irrelevant result and 10 for one that directly changes or answers the
-task. Grade only results you evaluated. Always add a short stdin explanation of the
-overall result quality without restating each score. Explanation-only feedback is valid
-for an empty result set.
+Use 0 for irrelevant and 10 for directly useful. Grade only evaluated results
+and always explain overall quality on stdin, including for an empty result set.
 
-Use `grep` for exact strings in GitHub or Discord activity, with `--source` or
-`--kind` when needed:
+Use `grep` for exact strings in GitHub or Discord activity:
 
 ```bash
 uv run infra/echo/cli.py grep "FAILED_PRECONDITION" --source github
@@ -71,9 +59,7 @@ than federated relevance, define the desired synthesis. Authentication reuses
 the shared Marin login via `iris login`; see
 [Echo setup and access](../../../infra/echo/README.md).
 
-Run this search sequence before adding or editing a wiki note. Use it at the
-start of an investigation when prior context could materially shorten
-debugging.
+Run this search sequence before adding or editing a wiki note.
 
 ## Choose the durable home
 
@@ -91,30 +77,22 @@ At resolution, choose the narrowest durable home:
   has no single repository home.
 - Add a wiki note only when the searches find no near-duplicate.
 
-Create one incident entry per incident, and edit that entry only when the same
-incident continues. Keep raw logs and commit diffs in their source systems; the
-incident entry records the investigation and links the evidence. A fixed bug can
-also justify a separate cross-incident synthesis when several incidents support
-a reusable diagnostic pattern. Edit a near-duplicate synthesis instead of
-adding another.
+Create one incident entry per incident and edit it while the same incident
+continues. Keep raw logs and diffs in their source systems. Edit a near-duplicate
+synthesis instead of adding another.
 
 ## Write or revise a wiki note
 
-Write for future action, not for exhaustiveness. Echo results are loaded into
-limited model context, so every unnecessary detail makes later work slower and
-more expensive. Prefer the shortest entry that changes what a future reader
-will do:
+Write the shortest entry that changes a future action:
 
 - Lead with an actionable value: a decision, command, diagnostic discriminator,
   guardrail, or recovery step.
 - Include only the facts needed to support or apply that action. Link to the
   canonical PR, issue, dashboard, log bundle, or report for chronology and raw
   evidence instead of copying it into Echo.
-- Put the action in the title, `use_when`, or opening paragraph so a search
-  result is useful before the full entry is fetched.
-- Keep investigation history outside the wiki when it provides no reusable
-  decision or procedure. An issue, logbook, or source artifact is a better home
-  for a record whose only value is completeness.
+- Put the action in the title, `use_when`, or opening paragraph.
+- Keep chronology without a reusable decision in an issue, logbook, or source
+  artifact.
 
 Write an Open Knowledge Format document:
 

--- a/.agents/skills/consult-echo/SKILL.md
+++ b/.agents/skills/consult-echo/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: consult-echo
-description: Search or cite Echo when explicitly requested or required by repository policy or another selected workflow; do not invoke for routine repository research.
+description: Search or cite Echo when Marin's prior-work policy applies, another selected workflow requires it, or the user explicitly asks; do not substitute it for local code search.
 ---
 
 # Consult Echo
@@ -64,16 +64,14 @@ Run this search sequence before adding or editing a wiki note.
 
 ## Choose the durable home
 
-At resolution, choose the narrowest durable home:
+Every incident gets a standalone Echo record through `write-ops-log`, linked
+from its associated PR or issue. Also use the narrowest reusable home when the
+incident or other work changes durable guidance:
 
 - Update `OPS.md` for a recurring operational procedure, diagnostic workflow,
   or guardrail in one subsystem.
 - Update `docs/` for reusable product or user guidance that belongs with the
   repository.
-- Add one Echo entry for the evidence, decisions, and outcome of a specific
-  incident. Tag it `incident`, `debugging`, the subsystem, severity, and
-  resolution; add `ops` for infrastructure incidents. Link its canonical Echo
-  URL from the associated PR or issue.
 - Edit an existing Echo wiki note for a cross-cutting pattern or synthesis that
   has no single repository home.
 - Add a wiki note only when the searches find no near-duplicate.

--- a/.agents/skills/debug/SKILL.md
+++ b/.agents/skills/debug/SKILL.md
@@ -1,23 +1,14 @@
 ---
 name: debug
-description: Debug code bugs or Iris/Zephyr/TPU infrastructure faults with a structured incident record.
+description: Diagnose an explicit code, JAX, Marin, Iris, Zephyr, or TPU fault or startup/performance regression; do not activate for ordinary implementation or optimization without a stated symptom.
 ---
 
-# Skill: Debug
+# Debug
 
-Systematic debugging for code-level bugs and Marin infrastructure faults.
-For infrastructure symptoms, route to the right `OPS.md` section first. Publish
-durable investigation records to Echo with `write-ops-log`.
-
-Do not add repository debug-log files. Use `write-ops-log` to finish an
-infrastructure or other multi-step incident as a standalone Echo postmortem.
-
-## Consult Echo
-
-Invoke `consult-echo` at the start when prior discussions, decisions, or
-incident patterns could materially shorten debugging. At resolution, always
-invoke it to search before deciding whether the reusable lesson belongs in
-`OPS.md`, `docs/`, the Echo incident record, or an existing or new synthesis.
+Keep working notes in the active task. Do not add repository debug-log files.
+Use `consult-echo` only when repository policy requires prior-work search, and
+use `write-ops-log` when an infrastructure or durable multi-step incident needs
+a standalone Echo record.
 
 ## Infrastructure faults
 
@@ -31,36 +22,13 @@ the matching `OPS.md` section:
 | Zephyr pipeline slow / stragglers / data skew / worker failures | `lib/zephyr/OPS.md` → Diagnostic Patterns, Observability |
 | TPU bad node (`No accelerator found`, `FAILED_PRECONDITION`, `Device or resource busy`) | `lib/iris/OPS.md` → TPU Bad-Node Recovery |
 
-Operational guardrails (never modify the controller DB, prefer
-`iris process profile` over SSH, never run a full `iris cluster restart`
-without approval) live next to the relevant commands in `OPS.md` — read those
-sections. After a TPU recovery or zephyr fix, return to the active babysit
-loop (`babysit-job` or `babysit-zephyr`).
+Read the guardrails beside the commands. Never modify the controller database,
+prefer `iris process profile` over SSH, and never run a full
+`iris cluster restart` without approval. After a TPU recovery or Zephyr fix,
+return to the active `babysit-job` or `babysit-zephyr` loop.
 
 ## Code bugs
 
-For code-level bugs that are not infrastructure faults, keep working notes in
-the active task. A contained fix may use the lightweight structure below.
-Publish the complete `write-ops-log` structure to Echo when the investigation
-exposes a durable operational lesson:
-
-```
-# <System or component>: <symptom>
-
-<goal>
-
-## Initial status
-<initial status, as reported or observed>
-
-## <Hypothesis N>
-The suspected source of the bug, or a change needed to isolate it.
-
-## Changes to make
-Which files you are altering and how.
-
-## Results
-Test results and any new hypotheses. Repeat the Hypothesis/Results cycle as needed.
-
-## Future work
-- [ ] Cleanups observed along the way
-```
+For code bugs, reproduce the failure, identify the smallest falsifiable
+hypothesis, change one cause at a time, and test the behavior that failed. Let
+exceptions propagate unless added context changes the diagnosis.

--- a/.agents/skills/debug/SKILL.md
+++ b/.agents/skills/debug/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: debug
-description: Diagnose an explicit code, JAX, Marin, Iris, Zephyr, or TPU fault or startup/performance regression; do not activate for ordinary implementation or optimization without a stated symptom.
+description: Diagnose a stated code, JAX, Marin, Iris, Zephyr, or TPU fault or startup/performance regression; do not activate for ordinary implementation or optimization without a symptom.
 ---
 
 # Debug
 
 Keep working notes in the active task. Do not add repository debug-log files.
-Use `consult-echo` only when repository policy requires prior-work search, and
-use `write-ops-log` when an infrastructure or durable multi-step incident needs
-a standalone Echo record.
+Use `consult-echo` when repository policy requires prior-work search. After
+every incident handled by this workflow, use `write-ops-log` to publish its
+standalone Echo record and link it from the associated PR or issue.
 
 ## Infrastructure faults
 

--- a/.agents/skills/deploy-iris-controllers/SKILL.md
+++ b/.agents/skills/deploy-iris-controllers/SKILL.md
@@ -1,21 +1,17 @@
 ---
 name: deploy-iris-controllers
-description: Deploy the Iris controller to one cluster or across the fleet, with automatic progress through passed gates. Use when restarting, rolling out, or rolling back a controller.
+description: Deploy, restart, or roll back the Iris controller for an explicitly named cluster set.
 ---
 
-# Skill: Deploy Iris controllers
+# Deploy Iris controllers
 
-Roll the controller in your working tree out to one cluster or to the whole
-fleet. Process one cluster at a time. Continue automatically after each passed
-gate. Stop when a gate is blocked. The reference for every command is
+Process one cluster at a time, continue after passed gates, and stop the fleet
+at the first blocked gate. The command reference is
 `lib/iris/OPS.md` ("Controller Restart", "Rolling back a controller deploy",
 "Controller Checkpoint Rollback").
 
-**A restart deploys your working tree, not `main`.** `iris cluster controller
-restart` builds images from HEAD plus staged and unstaged changes
-(`get_git_sha()` hashes tree content) and pins the deploy to that hash. Update
-the checkout first: a stale checkout ships stale code, which once cost ~5
-red-canary days ([incident record](https://echo.oa.dev/wiki/14)).
+`iris cluster controller restart` deploys the working tree, including staged
+and unstaged changes; it does not deploy `main`. Update the checkout first.
 
 ## Rules
 
@@ -24,39 +20,24 @@ red-canary days ([incident record](https://echo.oa.dev/wiki/14)).
    control-plane downtime, workers unaffected.
    It does not reconcile Pulumi-managed Kueue charts, ResourceFlavors,
    ClusterQueues, or CoreWeave NodePools.
-2. Treat an explicit rollout request as approval for its cluster set. Use its
-   order when given. Otherwise, use the order from `plan`. Ask only when the
-   scope is missing or ambiguous.
-3. Evaluate each gate from the command evidence. Report a passed gate and
-   continue without operator input.
-4. Stop the whole rollout at the first blocked gate. Report the cause. After a
+2. An explicit rollout request approves its named cluster set and order. Use
+   `plan` order when none is given; ask only when scope is ambiguous.
+3. Report each passed gate and continue without more operator input.
+4. Stop the fleet at the first blocked gate. After a
    restart, offer `--rollback` for that cluster. Do not continue to other
    clusters. Do not retry a restart to "see if it sticks".
 5. Never modify the controller database. Never take an action outside the
    approved rollout scope.
-6. Continuously monitor the stdout and stderr of each command until it exits. If
-   a tool yields, poll the same task and read each new output block. Do not pipe
-   a command to `tail -25` or an equivalent last-lines command. Such a pipeline
-   hides earlier output and gives no useful progress while the command runs.
+6. Monitor each command through exit. If it yields, resume the same task and
+   read new output. Do not pipe to `tail`; it hides earlier evidence.
 7. Run every controller lifecycle command through Iris's `controller` extra:
    `uv run --package marin-iris --extra controller iris ...`. The base
    environment omits the Kubernetes client and can misreport every CoreWeave
    prerequisite as missing.
 
-## How to gate
-
-A passed gate does not require operator input. Show the evidence, then continue
-to the next step or cluster. Use `AskUserQuestion` only when a blocked gate
-requires operator input. Show the snapshot, verify samples, smoke result, and
-blocker. Silence is not approval for a blocked gate.
-
-Process each gate from its evidence:
-
-- **Passed:** Report the evidence and continue within the approved scope.
-- **Blocked before restart:** Report the cause. Ask for the necessary input or
-  stop.
-- **Blocked after restart:** Stop or ask for rollback approval. Never offer to
-  skip ahead.
+For a blocked gate, show the snapshot, verify samples, smoke result, and cause.
+Ask for missing input before restart or rollback approval after restart. Silence
+is not approval, and skipping ahead is never an option.
 
 ## Helper
 
@@ -76,41 +57,31 @@ Write the snapshot files to the session scratchpad, one per cluster.
 
 ## Step 0 — Scope gate
 
-1. Run `plan`. Without `--clusters` it prints the default order: `marin-dev`,
-   `marin`, then the CoreWeave clusters smallest capacity first. With
-   `--clusters` it uses the operator's list verbatim, in that order.
-2. Print `git log -1 --oneline` and the tree image tag that `plan` reports.
-   `preflight` reports the tree state in full at the next step.
-3. If the rollout request gives the cluster set, continue without another
-   confirmation. Use its order when given. Otherwise, use the `plan` order. If
-   the cluster set is missing or ambiguous, ask the operator.
+Run `plan`. Without `--clusters` it orders `marin-dev`, `marin`, then CoreWeave
+clusters by increasing capacity; with `--clusters` it preserves the operator's
+order. Show `git log -1 --oneline` and the reported tree image tag. Ask only if
+the cluster set is ambiguous.
 
 Do not resolve the cluster list from memory. Cluster names come from `plan` or
 from the operator.
 
 ## Step 1 — Tree and credential gate
 
-Run `preflight` for the selected clusters *before* any restart. It reports two
-things.
-
-**What this tree would ship.** The first block prints the tree hash, the branch,
+Run `preflight` before any restart. Its first block prints the tree hash, branch,
 the uncommitted file count, and how far HEAD is from `origin/main` (fetched
 first, so "behind" is current). Each of these raises a `[WARN]`:
 
 - a dirty tree — the deploy ships files that are in no commit
-- a tree behind `origin/main` — the deploy ships stale code, the failure mode
-  that once cost ~5 red-canary days
+- a tree behind `origin/main` — the deploy ships stale code
 - a tree ahead of `origin/main` — the deploy ships unmerged code
 
 An untracked file is dirty but does **not** change the tree hash, while the Docker
 build still copies it into the image — so two different images can carry one tag
 and verify cannot tell them apart. Commit or remove the file before deploying.
 
-On any warning `preflight` **exits non-zero and deploys nothing**. Show the
-warnings to the operator and ask whether to deploy this exact tree. A dirty tree
-is normal for a controller fix under test and reckless for a routine fleet
-rollout, so let the operator decide rather than guessing. Only after they confirm,
-re-run with `--accept-tree-state`. Never pass that flag on your own initiative.
+On any warning, `preflight` exits non-zero and deploys nothing. Show the warning
+and ask whether to deploy that exact tree. Only after confirmation, rerun with
+`--accept-tree-state`; never pass it on your own initiative.
 
 **What the deploy reads from this session.** Requirements are derived from each
 cluster config, so they cannot drift: `defaults.inject_env` names, the CoreWeave

--- a/.agents/skills/file-issue/SKILL.md
+++ b/.agents/skills/file-issue/SKILL.md
@@ -1,20 +1,11 @@
 ---
 name: file-issue
-description: File a GitHub issue for a bug or improvement found this session.
+description: File a GitHub issue only when explicitly requested or delegated by another selected workflow; do not create issues merely because a problem was found.
 ---
 
-# Skill: File GitHub Issue
+# File a GitHub issue
 
-Create a GitHub issue in `marin-community/marin` from bugs, regressions, or
-improvements identified in the current conversation.
-
-## Background
-
-Read first:
-
-@AGENTS.md
-
-Before drafting, read:
+Before drafting, read `AGENTS.md` and:
 
 - `.agents/skills/writing-style/SKILL.md`
 - `.agents/skills/writing-style/issues.md`
@@ -22,8 +13,7 @@ Before drafting, read:
 
 ## Issue Kinds and Body Structure
 
-Pick the kind, then use the matching body structure below. There are no GitHub
-issue templates — these structures live here.
+Pick the smallest matching structure.
 
 | Kind | When to use | Labels |
 |---|---|---|
@@ -86,23 +76,12 @@ Done when:
 
 ## Workflow
 
-### 1. Gather Context from Conversation
+### 1. Gather and classify
 
-Extract from the conversation:
+Extract the symptom or desired outcome, impact, location, reproduction, known
+cause, and severity. Ask when the issue or its kind is ambiguous.
 
-- **What is broken or missing** -- concrete symptoms, error messages, failing test output.
-- **Where it happens** -- file paths, line numbers, module names.
-- **How to reproduce** -- steps, commands, or minimal config that triggers it.
-- **Root cause** (if known).
-- **Severity** -- blocks work, causes data loss, or cosmetic?
-
-If it's ambiguous what to file, ask the user before proceeding.
-
-### 2. Classify the Issue
-
-Pick the kind (bug, task, or experiment). If unsure, ask the user.
-
-### 3. Duplicate Check
+### 2. Check duplicates
 
 Search for existing issues first:
 
@@ -112,7 +91,7 @@ gh issue list --repo marin-community/marin --state open --search "<keyword>"
 
 If a match exists, tell the user and offer to comment on it instead.
 
-### 4. Draft the Issue
+### 3. Draft
 
 **Title**: At most 80 characters, optionally prefixed with a scope tag. State a
 factual symptom for a bug (e.g. `[levanter] Gradient accumulation drops the last
@@ -120,25 +99,12 @@ microbatch`) and an imperative outcome for a task (e.g. `[levanter] Handle
 partial accumulation steps`). Do not add `bug:`, `task:`, or another type
 prefix.
 
-**Body**: Use the section structure for the chosen kind (see above).
+Use the body structure above. Keep the facts needed to act; link code with
+`file:line`, trim errors to relevant frames, and omit filler, repeated titles,
+diff inventories, and unnecessary implementation narration. Bugs need numbered
+reproduction steps; tasks need testable completion criteria.
 
-**Rules for the body:**
-
-- No filler ("I noticed...", "During our conversation...").
-- No markdown images or tables.
-- Reference code with `file:line` links, not inline dumps.
-- Keep every fact needed to understand and act on the issue. Remove history,
-  repetition, and implementation narration that does not define the problem or
-  completion criteria; experiment issues may retain more tracking context.
-- Do not repeat the title in a `Description` section.
-- Do not inventory files, functions, or proposed implementation steps that are
-  not required to define the problem or completion criteria.
-- Include error messages or stack traces in code blocks, trimmed to the
-  relevant frames.
-- For task issues: include concrete `Done when` criteria.
-- For bug issues: include numbered reproduction steps.
-
-### 5. Compress and Inspect the Payload
+### 4. Inspect the payload
 
 Apply the writing-style final compression pass to the exact title and body that
 will be sent to GitHub. For a bug or task, verify the title is at most 80
@@ -146,16 +112,13 @@ characters. Every remaining sentence must add
 a symptom, impact, reproduction step, observation, expected behavior, or
 completion criterion.
 
-This review is required even when the user explicitly asked to file the issue.
-It is an author self-check, not a request for approval.
-
-### 6. Confirm or File Directly
+### 5. Apply the approval boundary
 
 If the user explicitly asked to file an issue, skip the preview — file it and
 share the link. If the agent surfaced the issue (not explicitly requested),
 show the drafted title and body and wait for approval or edits.
 
-### 7. File the Issue
+### 6. File the issue
 
 Write the body to a uniquely named temp file, then pass it with `--body-file`.
 Do not inline the body with shell substitution (`--body "$(cat <<'EOF' ...)"`)
@@ -189,34 +152,6 @@ After creating the issue, fetch its published text with
 `gh issue view "$issue_url" --json title,body` and correct any text added or
 altered by the publishing tool.
 
-### 8. Report Back
+### 7. Report
 
 Print the issue URL.
-
-## Writing Style
-
-Follow the terse style from `fix-issue`: every sentence conveys new
-information; no preamble or editorializing; no restating code a link covers;
-annotate code links, don't narrate them.
-
-## Tasks
-
-- [ ] Extract bug/issue details from conversation
-- [ ] Classify as bug, task, or experiment
-- [ ] Run duplicate check against open issues
-- [ ] Draft issue title and body using the matching kind structure
-- [ ] Compress and inspect the exact title and body
-- [ ] Show draft to user for confirmation when required
-- [ ] File issue with `gh issue create`
-- [ ] Report issue URL to user
-
-## Rules
-
-0. Never credit yourself in the issue.
-1. Always add the `agent-generated` label.
-2. Confirm with the user before filing only when the agent surfaced the issue
-   (not when the user explicitly asked to file).
-3. If the conversation does not contain a clear bug or actionable improvement,
-   say so and ask the user what they want to file.
-4. Use the smallest matching body structure. Omit optional context and headings
-   that add no information.

--- a/.agents/skills/fix-docs/SKILL.md
+++ b/.agents/skills/fix-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fix-docs
-description: De-rot markdown docs in lib/iris, lib/zephyr, and lib/fray.
+description: De-rot Markdown under lib/iris, lib/zephyr, or lib/fray only when explicitly requested.
 ---
 
 Fix the markdown docs within `lib/iris`, `lib/zephyr` and `lib/fray` so they

--- a/.agents/skills/fix-issue/SKILL.md
+++ b/.agents/skills/fix-issue/SKILL.md
@@ -1,37 +1,19 @@
 ---
 name: fix-issue
-description: End-to-end workflow to fix a GitHub issue in marin-community/marin.
+description: Implement and land a fix for an explicitly identified marin-community/marin GitHub issue.
 ---
 
-# Skill: Fix GitHub Issue
+# Fix a GitHub issue
 
-Fix the Github issue indicated by the user.
-
-## Background
-
-Read first:
-
-@AGENTS.md
-
-Complete tasks in order; the task list is at the end of this document. If you
-cannot complete a task, write a Github comment with your last status and why.
-
-## Writing Style for All GitHub Comments
-
-**Be terse.** Every sentence must convey new information:
-
-- No preamble, filler, or editorializing ("I've thoroughly investigated...").
-- No repeating the issue body.
-- No restating what code does when a link suffices.
-- Max 3-4 sentences of prose per comment section. Use links and code, not words.
-- Annotate code links, don't narrate them. Bad: "The transfer happens in
-  arrow_flight.py where the implementation copies data from TPU to CPU".
-  Good: `arrow_flight.py#L384` - TPU→CPU copy.
+Read `AGENTS.md` and the issue guidance in `writing-style`. Keep issue comments
+terse: omit filler and repetition, use annotated links, and keep each prose
+section to three or four sentences. Complete the workflow in order. If blocked,
+comment on the issue with the last completed state and the blocker.
 
 ## Research
 
 Use `gh` to fetch the issue. Read the codebase for all relevant source files.
-Post a single comment with two sections: **Research** and **Proposed Fix**.
+Post one concise comment with `Research` and `Proposed Fix` sections.
 
 Before writing code, run a duplicate-work preflight:
 
@@ -41,53 +23,20 @@ Before writing code, run a duplicate-work preflight:
   short issue comment summarizing what you found, and either hand off to the
   existing PR or scope your change to non-overlapping follow-up work.
 
-### Research section
-
-Title: `# Research`
-
-- 2-3 sentences: what's broken/missing and why (root cause, not symptoms).
-- A `**Relevant code**` list: max 5 links, each with a short (<10 word) annotation.
-
-Example:
-
-> `jax.device_get()` produces non-contiguous memory layout, limiting TPU→CPU
-> transfer to ~1GB/s (expect 4-7GB/s). No parallelization across shards.
->
-> **Relevant code**
-> - [`arrow_flight.py#L384`](https://github.com/marin-community/marin/blob/main/lib/marin/src/marin/rl/weight_transfer/arrow_flight.py#L384) - TPU→CPU copy
-> - [`jax.py#L394-L402`](https://github.com/marin-community/marin/blob/main/lib/marin/src/marin/rl/weight_transfer/jax.py#L394-L402) - transfer impl
-> - [`base.py#L32-L35`](https://github.com/marin-community/marin/blob/main/lib/marin/src/marin/rl/weight_transfer/base.py#L32-L35) - transfer mode defs
-
-### Proposed Fix section
-
-Title: `# Proposed Fix`
-
-State the root cause or missing behavior, then describe the smallest fix. For a
-bug, show the call chain that triggers the error. Include a code snippet only if
-the fix is non-obvious.
-
-> `env.run()` returns a tuple; `foo()` assumes an object and calls `.abc()`.
-> Fix: unwrap the tuple in `RolloutWorker._step()` before passing to `foo()`.
-
-Find the minimally disruptive fix. Do not over-engineer.
+In `Research`, state the cause in two or three sentences and link at most five
+relevant code locations with short annotations. In `Proposed Fix`, name the
+smallest fix and include the failing call chain or a snippet only when needed.
 
 ## Implementation
 
-Implement changes in a branch named `agent/{YYYYMMDD}-fix-{issue-id}`. You may
-create branches on github and submit PRs from them.
+Implement on `agent/{YYYYMMDD}-fix-{issue-id}`.
 
 ## Testing
 
-* Write the test _before_ the fix, then validate the fix works.
-* Use an existing test file in `tests/` if appropriate.
-* Never use mocks.
-* Keep tests simple and minimal. Do not test obvious behavior like "object has an attr".
-* Run `./infra/pre-commit.py --all-files --fix` and resolve all reported issues.
-* Run the default local test suite for the touched package and ensure it passes
-  before uploading. Use `uv run pytest` for root or mixed changes; do not
-  override the configured marker expression. Slow, integration, live-cluster,
-  Docker, and manual tests run in dedicated CI jobs unless the task explicitly
-  requires one.
+Follow `write-tests` and `TESTING.md`. Prefer a regression test that fails before
+the fix, extend an existing file, run the narrow test and affected safe suite,
+then run `./infra/pre-commit.py --all-files --fix`. Do not override the configured
+marker expression.
 
 ## Uploading
 
@@ -103,29 +52,4 @@ exactly. Its `wait_for.py` loop owns CI, review feedback, and lifecycle events.
 Do not start a separate `gh pr view` or `gh pr checks` polling loop. Investigate
 failures, push fixes, and re-arm the wait as that skill specifies.
 
-Key checks: **unit tests** (must pass), **lint-and-format** (must pass),
-**build-docs** (should pass if you modified documentation).
-
-# Tasks
-
-The tasks for this skill:
-
-- [ ] Fetch issue information
-- [ ] Research codebase for all relevant source files
-- [ ] Run duplicate-work preflight against open PRs/issues
-- [ ] Post Research and Proposed Fix
-- [ ] Create branch for the changes
-- [ ] Write a test case as needed for changes
-- [ ] Implement changes until all tests pass
-- [ ] Run `./infra/pre-commit.py --all-files --fix` and resolve all issues
-- [ ] Upload branch to github
-- [ ] Open pull request
-- [ ] Monitor CI, feedback, and PR lifecycle with `wait_for.py` through an exit condition
-- [ ] Update comment with final status
-
-If at any point you are unable to proceed, you must add a comment to the Github
-issue with your last status.
-
-# RULES
-
-0. Never credit yourself in commits or comments.
+Post a final issue comment with the landed PR or the last terminal state.

--- a/.agents/skills/lint-review/SKILL.md
+++ b/.agents/skills/lint-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lint-review
-description: In CI, run the infra/lint catalog review over a PR.
+description: Run the infra/lint catalog review only when invoked by CI or explicitly requested for a pull request.
 allowed-tools: Bash(./infra/pre-commit.py:*), Bash(gh pr comment:*), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh api:*), Bash(git diff:*), Bash(git log:*), Bash(git show:*), Bash(git merge-base:*), Bash(git rev-parse:*), Bash(git status:*), mcp__github_inline_comment__create_inline_comment
 ---
 

--- a/.agents/skills/lint-review/SKILL.md
+++ b/.agents/skills/lint-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lint-review
-description: Run the infra/lint catalog review only when invoked by CI or explicitly requested for a pull request.
+description: Run the read-only infra/lint PR reporter only when invoked by CI or explicitly requested; do not select it for the commit workflow's fix-and-respond review.
 allowed-tools: Bash(./infra/pre-commit.py:*), Bash(gh pr comment:*), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh api:*), Bash(git diff:*), Bash(git log:*), Bash(git show:*), Bash(git merge-base:*), Bash(git rev-parse:*), Bash(git status:*), mcp__github_inline_comment__create_inline_comment
 ---
 

--- a/.agents/skills/manage-hero-run/SKILL.md
+++ b/.agents/skills/manage-hero-run/SKILL.md
@@ -5,9 +5,11 @@ description: Launch, resume, monitor, hand off, or seal an explicitly requested 
 
 # Manage Hero Run
 
-Use this skill for expensive or production-critical runs where a bad launch, stale worktree, weak handoff, or confused resume can waste significant compute.
-
-As a rule of thumb, use this skill for runs that are expected to run for 1e22 model flops or more. (6ND heuristic is fine.) You should also use this skill if asked.
+Use this skill only when the request names a hero or production-critical run, or
+another selected workflow explicitly delegates its management here. Within this
+workflow, about 1e22 model FLOPs (using a 6ND estimate) is the normal threshold
+for classifying a run as production rather than bounded diagnostic work; it is
+not an activation trigger by itself.
 
 ## Operating Model
 

--- a/.agents/skills/manage-hero-run/SKILL.md
+++ b/.agents/skills/manage-hero-run/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: manage-hero-run
-description: Launch, monitor, hand off, resume, rollback, or babysit expensive Marin production. Typically >=1e22 model flops.
+description: Launch, resume, monitor, hand off, or seal an explicitly requested production-critical Marin run, normally at least 1e22 FLOPs.
 ---
 
 # Manage Hero Run

--- a/.agents/skills/noslop/SKILL.md
+++ b/.agents/skills/noslop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: noslop
-description: Clean a branch with strict gates for low-value tests and agentic prose. Use when asked to deslop, simplify, clean up, make a diff minimal, review test quality, tighten comments/docs/PR text, or remove AI-writing patterns such as rhetorical "X, not Y" contrasts.
+description: Deslop, simplify, or review low-value tests and prose only when explicitly requested for a branch or diff.
 ---
 
 # No-Slop Review

--- a/.agents/skills/organize-experiments/SKILL.md
+++ b/.agents/skills/organize-experiments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: organize-experiments
-description: Curate the experiment report index at docs/reports/index.md.
+description: Curate docs/reports/index.md only when explicitly requested after experiment reports have been harvested.
 ---
 
 # Skill: Organize Experiment Reports

--- a/.agents/skills/organize-experiments/SKILL.md
+++ b/.agents/skills/organize-experiments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: organize-experiments
-description: Curate docs/reports/index.md only when explicitly requested after experiment reports have been harvested.
+description: Harvest experiment issue reports and curate docs/reports/index.md only when explicitly requested.
 ---
 
 # Skill: Organize Experiment Reports

--- a/.agents/skills/profile-training/SKILL.md
+++ b/.agents/skills/profile-training/SKILL.md
@@ -1,18 +1,9 @@
 ---
 name: profile-training
-description: Profile JAX training and analyze hotspots. Use when profiling or optimizing training throughput.
+description: Profile a named JAX, Levanter, or Marin run, or investigate a measured startup, compilation, initialization, or throughput bottleneck.
 ---
 
-# Skill: Agent-Driven Profiling (XPlane/xprof/TensorBoard/Perfetto)
-
-## Overview
-Turn a Levanter profile directory into a deterministic, agent-consumable
-summary and a concrete optimization workflow:
-1. capture a representative profile,
-2. ingest to `profile_summary.v1`,
-3. query hotspots and bottlenecks,
-4. patch/configure,
-5. re-profile and compare.
+# Profile JAX training
 
 ## Scope
 Ingestion sources:
@@ -64,16 +55,8 @@ HLO metadata increases artifact size, so keep these profile windows short. The
 `--trainer.profiler.upload.enabled false` for local-only capture. Do not copy
 profiles to another GCS region for inspection.
 
-Known-good TensorBoard scope recipe from CoreWeave Grug MoE profiling:
-`trainer.profiler.enabled=true`, `trainer.profiler.start_step=3`,
-`trainer.profiler.num_steps=2`, `trainer.profiler.perfetto_link=false`,
-`trainer.profiler.profile_options.host_tracer_level=1`,
-`trainer.profiler.profile_options.python_tracer_level=0`, and
-`trainer.profiler.profile_options.enable_hlo_proto=true` preserved useful
-`jax.named_scope` / `named_call` regions in TensorBoard for
-`GM2560-MAY-120S4096-W2048-B8-R1-E8M1-FA4PROFILE-S3B-N1-cw-20260617-2353`.
-Leave `device_tracer_level` unset unless device timelines are specifically
-needed; this profile still had useful hierarchical host/XLA metadata.
+Leave `device_tracer_level` unset unless device timelines are needed; host and
+HLO metadata preserve useful named-scope regions without it.
 
 On GPU, command buffers can collapse or suppress the visible name stack in
 TensorBoard/Perfetto. For profile-readability runs, disable command buffers:
@@ -104,8 +87,8 @@ Reference:
   <https://docs.jax.dev/en/latest/gpu_performance_tips.html>
 
 ## Ingest to Structured Summary
-Pick a download location for pulled profile artifacts: `/tmp` for
-ephemeral/local, `scratch/` for an in-repo working area.
+Use `/tmp` for ephemeral downloads. Use `scratch/` only when the working tree
+must retain an uncommitted analysis artifact.
 
 ```bash
 # /tmp (ephemeral)
@@ -115,13 +98,6 @@ uv run python lib/marin/tools/profile_summary.py summarize \
   --breakdown-mode exclusive_global \
   --output /tmp/profile_summary.json
 
-# in-repo scratch (kept with your workspace)
-mkdir -p scratch/profiles
-uv run python lib/marin/tools/profile_summary.py summarize \
-  --run-target marin-community/marin/<run_id> \
-  --download-root scratch/profiles \
-  --breakdown-mode exclusive_global \
-  --output scratch/profile_summary.json
 ```
 
 ### Option A: From a W&B artifact reference
@@ -133,20 +109,11 @@ uv run python lib/marin/tools/profile_summary.py summarize \
   --output /tmp/profile_summary.json
 ```
 
-### Option B: From a W&B run target
-
-```bash
-uv run python lib/marin/tools/profile_summary.py summarize \
-  --run-target marin-community/marin/grug-125m-profile-apples-pallas_tpu-20260217-225239-055ab2 \
-  --download-root /tmp/marin-profiles \
-  --output /tmp/profile_summary.json
-```
-
 `--run-target` accepts: a bare run id (requires `--entity` and `--project`),
 `entity/project/run_id`, or a full W&B run URL. The profiler directory is
 resolved from `trainer.log_dir` in the run config.
 
-### Option C: From a local artifact directory
+### Option B: From a local artifact directory
 
 ```bash
 uv run python lib/marin/tools/profile_summary.py summarize \
@@ -159,7 +126,7 @@ automatically. When both `*.xplane.pb` and Perfetto trace JSON are present,
 `--profile-dir` reads the XPlane protobuf by default (Perfetto exports are often
 capped). Use `--trace-file` to force a specific Perfetto JSON file.
 
-### Option D: From a specific trace file
+### Option C: From a specific trace file
 
 ```bash
 uv run python lib/marin/tools/profile_summary.py summarize \
@@ -167,7 +134,7 @@ uv run python lib/marin/tools/profile_summary.py summarize \
   --output /tmp/profile_summary.json
 ```
 
-### Option E: From a specific XPlane protobuf
+### Option D: From a specific XPlane protobuf
 
 Direct XPlane timeline parsing uses `protobuf` and does not require
 TensorFlow-generated `xplane_pb2` modules. If `xprof` is installed, ingestion
@@ -206,59 +173,22 @@ Trace quality checks are surfaced in `trace_overview`:
 - `suspected_truncation`: `true` when event counts match a known export cap.
 - `quality_warnings`: warnings to treat hotspot/gap attribution with caution.
 
-## Agent Queries
-Top ops:
+## Query the summary
 
 ```bash
 uv run python lib/marin/tools/profile_summary.py query \
   --summary /tmp/profile_summary.json \
-  --question "What are the top 10 ops by exclusive time?"
+  --question "<top ops, compute vs communication, gap, region, or op context>"
 ```
 
-Compute vs comm and collective bottlenecks:
-
-```bash
-uv run python lib/marin/tools/profile_summary.py query \
-  --summary /tmp/profile_summary.json \
-  --question "Is comm or compute dominating? Which collective is worst?"
-```
-
-Specific pre-op gap lookup:
-
-```bash
-uv run python lib/marin/tools/profile_summary.py query \
-  --summary /tmp/profile_summary.json \
-  --question "gap before _linear_softmax_cross_entropy_loss_bwd_pallas_mosaic_tpu_combined.1"
-```
+Query top exclusive-time ops, compute/communication balance and collectives,
+specific pre-op gaps, hierarchical regions, noisy-op context, and suggested
+optimizations.
 
 Pre-op gap attribution is marker-aware:
 - `gap_before_ops[].payload_op`: op where useful work starts after the idle period.
 - `gap_before_ops[].marker_op`: first op observed after the gap (often
   lightweight setup like `iota.*`).
-
-Hierarchical semantic regions (derived from `tf_op` paths when available):
-
-```bash
-uv run python lib/marin/tools/profile_summary.py query \
-  --summary /tmp/profile_summary.json \
-  --question "show hierarchical regions"
-```
-
-Contextualize a noisy op:
-
-```bash
-uv run python lib/marin/tools/profile_summary.py query \
-  --summary /tmp/profile_summary.json \
-  --question "show context for op copy.564"
-```
-
-Suggested optimizations from evidence:
-
-```bash
-uv run python lib/marin/tools/profile_summary.py query \
-  --summary /tmp/profile_summary.json \
-  --question "What should we try next?"
-```
 
 ## Optimization Workflow
 Use a strict workflow:
@@ -315,13 +245,3 @@ The comparison reports: steady-state step-time delta, step class deltas
 (light/heavy when detected), compute/comm/host/stall share deltas, semantic
 family deltas with workload-normalized metrics, provenance checks (trace
 hash/run identity), and regressed/improved ops by exclusive duration.
-
-## Success Metrics
-MVP is successful when:
-- one representative profile is summarized reproducibly into `profile_summary.v1`,
-- queries produce deterministic structured answers for top ops and comm/compute
-  breakdown,
-- one end-to-end before/after comparison bundle is completed and either
-  throughput improves measurably or a clear root-cause report is produced with
-  profile evidence.
-</content>

--- a/.agents/skills/profile-training/SKILL.md
+++ b/.agents/skills/profile-training/SKILL.md
@@ -55,8 +55,16 @@ HLO metadata increases artifact size, so keep these profile windows short. The
 `--trainer.profiler.upload.enabled false` for local-only capture. Do not copy
 profiles to another GCS region for inspection.
 
-Leave `device_tracer_level` unset unless device timelines are needed; host and
-HLO metadata preserve useful named-scope regions without it.
+Known-good TensorBoard scope recipe from CoreWeave Grug MoE profiling:
+`trainer.profiler.enabled=true`, `trainer.profiler.start_step=3`,
+`trainer.profiler.num_steps=2`, `trainer.profiler.perfetto_link=false`,
+`trainer.profiler.profile_options.host_tracer_level=1`,
+`trainer.profiler.profile_options.python_tracer_level=0`, and
+`trainer.profiler.profile_options.enable_hlo_proto=true` preserved useful
+`jax.named_scope` / `named_call` regions in TensorBoard for
+`GM2560-MAY-120S4096-W2048-B8-R1-E8M1-FA4PROFILE-S3B-N1-cw-20260617-2353`.
+Leave `device_tracer_level` unset unless device timelines are specifically
+needed; this profile retained useful hierarchical host/XLA metadata without it.
 
 On GPU, command buffers can collapse or suppress the visible name stack in
 TensorBoard/Perfetto. For profile-readability runs, disable command buffers:
@@ -184,6 +192,15 @@ uv run python lib/marin/tools/profile_summary.py query \
 Query top exclusive-time ops, compute/communication balance and collectives,
 specific pre-op gaps, hierarchical regions, noisy-op context, and suggested
 optimizations.
+
+Useful query forms include:
+
+- `What are the top 10 ops by exclusive time?`
+- `Is comm or compute dominating? Which collective is worst?`
+- `gap before _linear_softmax_cross_entropy_loss_bwd_pallas_mosaic_tpu_combined.1`
+- `show hierarchical regions`
+- `show context for op copy.564`
+- `What should we try next?`
 
 Pre-op gap attribution is marker-aware:
 - `gap_before_ops[].payload_op`: op where useful work starts after the idle period.

--- a/.agents/skills/query-inference-metrics/SKILL.md
+++ b/.agents/skills/query-inference-metrics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: query-inference-metrics
-description: Investigate a vLLM serve's performance (throughput, TTFT/TPOT latency, queue depth, KV-cache usage) from durable Finelog telemetry with SQL. Use when asked how an inference or eval serve performed, or why it was slow. For kernel-level JAX profiling, use profile-training instead.
+description: Query Finelog telemetry to measure or diagnose a specified vLLM serve's throughput, latency, queue, or KV-cache behavior.
 ---
 
 # Query inference telemetry

--- a/.agents/skills/recover-stuck-k8s-pod/SKILL.md
+++ b/.agents/skills/recover-stuck-k8s-pod/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recover-stuck-k8s-pod
-description: Diagnose and safely recover stuck terminating Kubernetes pods on Marin CoreWeave clusters, especially node-bound GPU pods. Use for deletion hangs, suspected uninterruptible GPU/NCCL waits, node cordoning or reboot decisions, and force-deletion requests.
+description: Recover a specified stuck-terminating CoreWeave Kubernetes pod after read-only diagnosis and explicit approval for node or workload changes.
 ---
 
 # Recover a stuck Kubernetes pod

--- a/.agents/skills/refresh-fork/SKILL.md
+++ b/.agents/skills/refresh-fork/SKILL.md
@@ -12,6 +12,8 @@ force-moves the stable branch.
 
 Refresh a `group` as one unit and one PR. The only current group is
 `vllm`/`tpu-inference`; `vllm-gpu` tracks the fork's independent `main` branch.
+The TPU launcher installs both grouped pins, and vLLM's TPU base derives from
+the tpu-inference release; splitting them can produce an unvalidated stack.
 
 In local mode, ask before pushing fork branches, opening the PR, or filing an
 issue. The required end-to-end test needs no extra confirmation.
@@ -144,7 +146,8 @@ descriptor and release pins (the descriptor's `commit`, or `gpu.toml`'s
    overlay imports or calls still exist: on a fast-moving fork a class becomes a
    factory function, a helper is deleted, a signature gains a required argument.
    Cross-check every touched constructor, signature, attribute, helper, and test
-   against `new_base` before a multi-hour build.
+   against `new_base` before a multi-hour build. A prior vLLM refresh caught
+   `FusedMoE` becoming `FusedMoEFactory` and removal of `is_interleaved` this way.
 7. Keep history reviewable — no conflict artifacts, unrelated refactors, or
    preserved commits whose behavior is now `drop`. Collapse fork-infra churn
    (CI, workflow, or prose commits that adopt then revise then disable) to its final
@@ -224,17 +227,20 @@ green while most of the suite never ran. CI steps run in order under an implicit
 earlier one is green, so its regressions stay hidden behind the first failure. Run
 every step's marker in order.
 
-If Docker bind mounts or compiled dependencies prevent a behavioral local run,
-use fork CI. Confirm the workflow supports `workflow_dispatch` on the staged ref;
-otherwise it may silently skip a non-`main` review branch.
+On this VM, Docker bind mounts do not propagate into containers, so Harbor's
+DOCKER-env golden tests must run in fork CI. Confirm the workflow supports
+`workflow_dispatch` on the staged ref; otherwise it may silently skip a
+non-`main` review branch.
 
 For vLLM without its compiled CUDA/TPU stack, `py_compile` and a conflict-marker
 sweep are structural checks only; do not call them behavioral validation.
 
 For a version-sensitive golden, inspect the deciding code path and distinguish a
-new dependency floor from a port defect. Never downgrade below the floor. Make
-the fixture dependency-independent when possible; otherwise regenerate and
-verify it in one CI run with logs as artifacts.
+new dependency floor from a port defect. An upstream `litellm>=1.92` floor, for
+example, can stale a golden without a fork-source change. Never downgrade below
+the floor. Prefer a dependency-independent fixture that patches every seam the
+trigger reads, such as both sync and async token counters. Otherwise regenerate
+and verify it in one CI run with logs as artifacts.
 
 ## Validate
 

--- a/.agents/skills/refresh-fork/SKILL.md
+++ b/.agents/skills/refresh-fork/SKILL.md
@@ -1,37 +1,20 @@
 ---
 name: refresh-fork
-description: Rebase one Marin fork onto newer upstream per its config/external/migration.toml descriptor, run the fork's e2e, and open the Marin PR or file a blocker issue.
+description: Refresh a named Marin external fork pin onto a newer upstream base using its configured descriptor and required end-to-end test.
 ---
 
-# Skill: Refresh a Fork
+# Refresh a fork
 
-Read first:
+Read `AGENTS.md`. Rebase the fork overlay onto `<branch>-next`, validate that
+staged tip, re-pin Marin, and prepare protected-branch promotion. An unattended
+run opens a draft Marin PR and names the required admin promotion; it never
+force-moves the stable branch.
 
-@AGENTS.md
+Refresh a `group` as one unit and one PR. The only current group is
+`vllm`/`tpu-inference`; `vllm-gpu` tracks the fork's independent `main` branch.
 
-## Mission
-
-Every fork Marin pins under `config/external/` is a `marin-community` fork: our
-commits on top of an upstream project. Refreshing a pin means rebasing our commits
-onto a newer upstream base on a `<branch>-next` staging branch, validating with the
-fork's e2e against that branch, re-pinning Marin at the exact staged tip, and
-preparing the stable-branch promotion with rollback and date tags. Fork stable
-branches are protected. An unattended run stops after opening the draft Marin PR
-and identifies the admin promotion it needs; it never force-moves the stable branch.
-
-Each pin refreshes independently. The one exception is a `group`, which refreshes as a
-unit: its sections refresh together on one run and re-pin in one PR (each still rebases
-onto its own base). Only the vllm/tpu-inference pair is grouped, because the TPU
-launcher installs both pins at once and vllm's TPU base derives from the tpu-inference
-release; splitting them could pin a mixed, unblessed stack. The vllm fork's GPU pin is
-not in that group — it tracks upstream head on the fork's `main`, independent of the
-`tpu` branch that carries the TPU pin. The weekly `ops-fork-ferry` workflow sends Weaver one request per
-supported pin or group. That request names this skill and the forks to update; this
-file owns the migration procedure.
-
-Use the same algorithm in CI and local runs. In local/manual mode, ask before
-external mutations: pushing fork branches, opening the Marin PR, or filing a GitHub
-issue. Do not ask before the fork's required e2e.
+In local mode, ask before pushing fork branches, opening the PR, or filing an
+issue. The required end-to-end test needs no extra confirmation.
 
 ## Read the Descriptor
 
@@ -89,10 +72,8 @@ git -C <fork> fetch --tags --multiple origin upstream   # --multiple fetches bot
 git -C <fork> remote set-head upstream -a                # so upstream/HEAD resolves
 ```
 
-- Keep working notes as you go — decisions, selected bases, branch SHAs, validation
-  outcomes, and sharp edges (surprising failures, compatibility traps). They feed the
-  PR body: base-selection evidence and the carry/drop/fix table in `<details>`, and
-  the unresolved risks above the fold.
+- Record selected bases, branch SHAs, carry/drop/fix decisions, validation, and
+  unresolved risks for the PR.
 
 ## Select the base
 
@@ -144,11 +125,8 @@ descriptor and release pins (the descriptor's `commit`, or `gpu.toml`'s
    implementation must change — re-author against the current layout when upstream
    moved or refactored the files it touches). Before carrying anything, check whether
    the new base already did it: grep the base for the symbols, APIs, or dependency
-   pins the patch introduces. If they are present it is a `drop` — a backport that has
-   landed, or a version ceiling the base now exceeds (a stale `<X` pin silently
-   downgrades upstream). On a fast-moving fork this "did upstream absorb this?" pass is
-   the highest-value step; it is what keeps the fork converging rather than re-adding
-   duplicate or obsolete code.
+   pins the patch introduces. Drop an absorbed backport or stale version ceiling;
+   do not re-add duplicate or obsolete code.
 3. Replay only `carry` and `fix` onto `new_base` in the old logical order: clean
    cherry-picks for carries; rewrite fixes as new commits referencing the original
    SHA(s). Separate genuine conflicts from cascade artifacts: a file the overlay
@@ -165,29 +143,20 @@ descriptor and release pins (the descriptor's `commit`, or `gpu.toml`'s
    clean cherry-pick applies textually but does not prove the upstream symbols the
    overlay imports or calls still exist: on a fast-moving fork a class becomes a
    factory function, a helper is deleted, a signature gains a required argument.
-   Statically cross-check every upstream symbol the overlay touches — constructor
-   kwargs, function signatures, attributes, removed helpers — against `new_base`,
-   including the overlay's tests. A vLLM refresh caught two breaks this way: a
-   `FusedMoE` class replaced by a `FusedMoEFactory` function, and a removed
-   `is_interleaved` config helper. A textual replay left both in place, and only a
-   multi-hour GPU build would otherwise have surfaced them.
+   Cross-check every touched constructor, signature, attribute, helper, and test
+   against `new_base` before a multi-hour build.
 7. Keep history reviewable — no conflict artifacts, unrelated refactors, or
    preserved commits whose behavior is now `drop`. Collapse fork-infra churn
    (CI, workflow, or prose commits that adopt then revise then disable) to its final
    state rather than replaying each hop.
 
-Stop and file a blocker instead of forcing a PR when the rebase is not a mechanical
-replay: our overlay is non-linear (merge commits weaving upstream in), upstream
-renamed or refactored files our `fix` commits touch (so they need re-authoring against
-the new layout), or conflicts hit many core files at once. A fork hundreds of commits
-behind upstream is usually in this state. The weekly cadence keeps a fork from ever
-drifting this far; one that already has (see `nuances`) needs a one-time manual
-catch-up outside this skill before it can be auto-migrated. That catch-up replays
-the fork's real commits onto the new base; it never reconstructs the overlay from a
-single net diff, which silently invents drift the fork never carried. Diff each
-hand-ported `fix` file against the fork's `main` to confirm it matches intent. The
-blocker issue carries the carry/drop/fix inventory, the conflict map, and how far
-behind the fork is.
+Stop and file a blocker when the overlay is non-linear, upstream refactored
+touched files that need substantial re-authoring, or many core files conflict.
+A fork hundreds of commits behind also needs a one-time manual catch-up outside
+this workflow. That catch-up replays the real commits; never reconstruct the
+overlay from a net diff. Diff each hand-ported `fix` against the fork's stable
+branch. Put the inventory, conflict map, and distance behind upstream in the
+blocker issue.
 
 ## Pin at the staged tip
 
@@ -244,10 +213,8 @@ workflow; see `docs/overlay-only-pr.md`.
 
 ## Check the fork's own suite
 
-Run the fork's own test suite on the rebased branch before the marin e2e. The e2e
-exercises one path; the fork suite is what catches re-porting drift across the whole
-patch set. Run it locally where the runner supports it, otherwise dispatch it on the
-fork's CI.
+Run the fork's suite before the Marin end-to-end test, locally when supported or
+through fork CI.
 
 Derive the command from the fork's CI config verbatim; do not invent a marker
 subset. A narrow marker such as `-m unit` can silently skip the thousands of unmarked
@@ -257,30 +224,17 @@ green while most of the suite never ran. CI steps run in order under an implicit
 earlier one is green, so its regressions stay hidden behind the first failure. Run
 every step's marker in order.
 
-Probe the runner before trusting a local run. This VM runs docker but its bind-mounts
-do not propagate into containers, so a container-environment trial (harbor's
-DOCKER-env golden tests) cannot complete here and has to run on the fork's CI. To
-dispatch the suite there when the review PR sits on an `upstream-base/<sha>` branch:
-gate workflows commonly filter `branches: ["main"]`, so such a PR gets no automatic
-CI; only a workflow declaring `workflow_dispatch` and present on the default branch
-can be dispatched against the branch ref; a workflow with neither `workflow_dispatch`
-nor a matching push trigger never runs on that PR, so verify it locally.
+If Docker bind mounts or compiled dependencies prevent a behavioral local run,
+use fork CI. Confirm the workflow supports `workflow_dispatch` on the staged ref;
+otherwise it may silently skip a non-`main` review branch.
 
-A build-heavy fork raises a second ceiling. vLLM's suite needs its compiled CUDA/TPU
-stack, and `import` fails outright when the runner has no torch, so the pre-e2e check
-there is structural only: `py_compile` the replayed tree and sweep for leftover
-conflict markers. A green structural pass is not behavioral validation — say so.
+For vLLM without its compiled CUDA/TPU stack, `py_compile` and a conflict-marker
+sweep are structural checks only; do not call them behavioral validation.
 
-Deterministic golden tests are dependency-version fragile: an upstream-mandated
-dependency floor (an upstream `litellm>=1.92` bump) can stale a golden even when the
-fork source is byte-identical. Read the deciding code path rather than the golden
-diff, and separate the dependency floor from a real port defect — never downgrade
-below the floor to make a golden pass. Prefer making the fixture dependency-independent
-by patching every version-sensitive seam the trigger reads (the sync and async token
-counters both, not just one) over re-tuning the golden to a single version. Regenerate
-in one CI run: a `workflow_dispatch` that runs the suite in update mode and then a
-comparison-mode verify step, both non-failing, uploading the regenerated goldens and
-logs as artifacts.
+For a version-sensitive golden, inspect the deciding code path and distinguish a
+new dependency floor from a port defect. Never downgrade below the floor. Make
+the fixture dependency-independent when possible; otherwise regenerate and
+verify it in one CI run with logs as artifacts.
 
 ## Validate
 
@@ -372,18 +326,3 @@ selected base, the staged tip SHA, its rollback and date tags, the pending admin
 promotion (and the wheel release tag for `vllm-gpu`), e2e outcome, and unresolved
 risks; in `<details>`, the base-selection evidence and the carry/drop/fix table with
 dropped-patch reasons.
-
-## Done Means
-
-- The pin source named by `pin` carries the new revision (descriptor pins also carry
-  `upstream_base`); `external_dependencies.py` is regenerated.
-- `<branch>-next` points at the validated tip, the current stable tip has a rollback
-  tag, and the validated tip has a date tag. The stable branch is unchanged, and the
-  PR names the admin hard swap still required.
-- A draft PR that temporarily follows `main-next` stays draft. After the admin
-  promotion, its source follows `main` again and its lock still records the validated
-  SHA before the PR is marked ready or merged.
-- Retained patches explain why they exist; dropped patches are called out.
-- The fork's e2e passed before the promotion tags and PR were created, or the blocker
-  is in a Marin issue assigned to `blocker_assignee`.
-- An opened Marin PR reaches a `commit` skill monitoring exit condition.

--- a/.agents/skills/reserve-gpu/SKILL.md
+++ b/.agents/skills/reserve-gpu/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: reserve-gpu
-description: Reserve Iris-backed CoreWeave H100 or GB200 nodes with dev_gpu.py. Use for interactive GPU debugging, multi-node tests, or reconnecting to a dev GPU session.
+description: Reserve an Iris-backed GPU with scripts/iris/dev_gpu.py only when explicitly requested for an interactive dev GPU session.
 ---
 
 # Dev GPU
-
-Use a dev GPU for short interactive tests. Move to a full Iris job after the
-code works on the reserved node.
 
 `scripts/iris/dev_gpu.py` submits a holder job through Iris and uses
 `kubectl exec` internally to open a shell. It does not sync files or provide
@@ -46,9 +43,6 @@ background must call `release` from another shell. Session state is stored under
 The default is one whole H100 node. Pass `--gpu-variant GB200` for one GB200
 tray. Use `--nodes N` only when the test needs distributed topology; connect to
 each pod with `connect --node N`. Multi-node sessions require whole nodes.
-
-Run `uv run scripts/iris/dev_gpu.py <subcommand> --help` for current options
-and defaults.
 
 ## Sharp edges
 

--- a/.agents/skills/reserve-gpu/SKILL.md
+++ b/.agents/skills/reserve-gpu/SKILL.md
@@ -5,6 +5,9 @@ description: Reserve an Iris-backed GPU with scripts/iris/dev_gpu.py only when e
 
 # Dev GPU
 
+Use a dev GPU for short interactive tests. Move to a full Iris job after the
+code works on the reserved node.
+
 `scripts/iris/dev_gpu.py` submits a holder job through Iris and uses
 `kubectl exec` internally to open a shell. It does not sync files or provide
 SSH access.
@@ -43,6 +46,9 @@ background must call `release` from another shell. Session state is stored under
 The default is one whole H100 node. Pass `--gpu-variant GB200` for one GB200
 tray. Use `--nodes N` only when the test needs distributed topology; connect to
 each pod with `connect --node N`. Multi-node sessions require whole nodes.
+
+Run `uv run scripts/iris/dev_gpu.py <subcommand> --help` for current options
+and defaults.
 
 ## Sharp edges
 

--- a/.agents/skills/reserve-tpu/SKILL.md
+++ b/.agents/skills/reserve-tpu/SKILL.md
@@ -1,27 +1,15 @@
 ---
 name: reserve-tpu
-description: Reserve an Iris-backed TPU worker for fast debugging with dev_tpu.py.
+description: Reserve or operate an Iris-backed TPU worker with scripts/iris/dev_tpu.py only when explicitly requested for a dev TPU session.
 ---
 
-# Skill: Dev TPU
-
-Use this skill for the standard fast TPU debugging loop without wiring a full training job each time.
+# Dev TPU
 
 `scripts/iris/dev_tpu.py` reserves a TPU-backed worker through Iris, waits for the worker VM to come up, and lets you SSH into it or run commands directly against it. It uses `gcloud` SSH and SCP against the worker Iris assigned to the holder job. There is no persistent `~/.ssh/config` alias.
 
 ## Critical concurrency rule
 
 Run at most one TPU job at a time on a given dev TPU VM. Do not launch concurrent TPU commands on the same worker from multiple shells, tmux panes, or background jobs.
-
-## Commands
-
-- `allocate`: submit a TPU holder job, resolve the assigned worker VM(s), optionally sync the repo, block until release
-- `status`: show the active local session metadata
-- `connect`: open an interactive SSH session to one reserved worker
-- `setup_env`: sync the repo by default, then install/refresh the remote `uv` environment on one or all reserved workers
-- `execute`: sync local files to `~/marin` on the reserved worker(s), then run one command
-- `watch`: sync all reserved workers and rerun a command on the selected worker when local files change
-- `release`: terminate the holder job and remove the local session file
 
 ## Prerequisites
 
@@ -34,13 +22,11 @@ gcloud auth application-default login
 make dev_setup
 ```
 
-2. Ensure the Iris controller is running for your cluster. On shared Marin clusters this is usually already true; only start it yourself for a fresh or local cluster.
-
-3. Use a cluster config that can actually provision the TPU type you want.
+2. Use a cluster config that provisions the requested TPU. Shared clusters
+   normally already have a controller; never start or restart one without
+   explicit approval.
 
 ## Command pattern
-
-All invocations share this shape; only the subcommand and its flags change:
 
 ```bash
 uv run scripts/iris/dev_tpu.py \
@@ -91,7 +77,7 @@ uv run iris --config=lib/iris/config/marin.yaml cluster vm logs <worker-id>
 - If the `allocate` terminal dies unexpectedly, use `release` to terminate the holder job and clear the stale state file.
 - `execute` and `watch` already wrap the remote command in `bash -lc`; do not pass your own `bash -c`.
 
-## Agent Usage
+## Unique session name
 
 Always pass `--tpu-name` to avoid collisions with other agents:
 

--- a/.agents/skills/review-grant/SKILL.md
+++ b/.agents/skills/review-grant/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-grant
-description: Review a marin-iac user-grant PR by decrypting the changed principals into the real emails and grants, confirm with the user, then approve, merge, and drive pulumi up. Use when reviewing a PR that edits iam_data.yaml or a service's IAP viewers.
+description: Review an explicitly identified marin-iac grant PR, confirm its decrypted principals and roles, then apply only the confirmed grant.
 ---
 
 # Skill: Review a user grant

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-pr
-description: Multi-agent correctness review of a pull request.
+description: Run a multi-agent correctness review only when explicitly requested for a pull request.
 allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), Bash(uv run infra/codehealth/log_stats.py:*), mcp__github_inline_comment__create_inline_comment
 ---
 

--- a/.agents/skills/run-ferries/SKILL.md
+++ b/.agents/skills/run-ferries/SKILL.md
@@ -124,8 +124,16 @@ uv run python scripts/ferries/daily_analysis.py \
   --format markdown
 ```
 
-The terminal issue comment records status, Iris job ID, W&B link, final metrics,
-experiment link, and next recommendation.
+Use this terminal issue comment shape:
+
+```markdown
+Final status: <SUCCEEDED|FAILED|STOPPED>
+Iris job id: <job_id>
+W&B link: <url>
+Final eval summary: <key metrics>
+Experiment link: <experiment JSON/browser link>
+Recommendation / victory decision: <next action>
+```
 
 #### 7) Seal and open log-only PR
 - Create and push a sealing tag for the exact launch commit (the commit containing the `experiments/ferries/daily.py` used for the run).

--- a/.agents/skills/run-ferries/SKILL.md
+++ b/.agents/skills/run-ferries/SKILL.md
@@ -1,36 +1,23 @@
 ---
 name: run-ferries
-description: Launch, monitor, and seal Marin canary and daily ferry runs.
+description: Launch, monitor, or seal a Marin canary or daily ferry only when explicitly requested.
 ---
 
-# Skill: Ferries (Canary + Daily)
+# Ferries
 
-## Overview
-Two ferry lanes:
-- `canary`: fast, low-cost always-on health check
-- `daily`: higher-scale integration run with bounded changes
-
-Both keep core data assumptions aligned and share the same monitoring/triage discipline.
-
-## Ferry Lanes
-Templates:
 - `experiments/ferries/canary_ferry.py` (MoE canary, TPU and GPU via `CANARY_ACCELERATOR`)
 - `experiments/ferries/daily.py`
 
-Intent:
-- canary: catch infra/pretraining regressions early with a stable Grug MoE config (one TPU, one GPU)
-- daily: exercise a larger run envelope and test small, explicit changes
+Canary is the stable, low-cost health check. Daily exercises a larger envelope
+with one or two explicit changes.
 
 Shared baseline:
 - data: shared `nemotron_mix` baseline
 - default cluster: `us-central1` (zone `us-central1-a`)
 - run log: `docs/experiments/daily-ferry-log.md`
 
-Daily baseline defaults:
-- model size: Llama ~150M (`llama_150m`)
-- sequence length: 4096
-- train batch size: 512
-- FLOP target: ~1e19 (overrideable via env)
+Daily defaults to `llama_150m`, sequence length 4096, batch size 512, and about
+1e19 FLOPs unless its configuration says otherwise.
 
 ## Inputs Before Proposing (Daily Only)
 Canary runs normally do not require a proposal cycle or PR. For daily, collect:
@@ -137,16 +124,8 @@ uv run python scripts/ferries/daily_analysis.py \
   --format markdown
 ```
 
-Required terminal issue comment template:
-
-```markdown
-Final status: <SUCCEEDED|FAILED|STOPPED>
-Iris job id: <job_id>
-W&B link: <url>
-Final eval summary: <short summary + key metrics>
-Experiment link: <experiment JSON/browser link>
-Recommendation / victory decision: <next action>
-```
+The terminal issue comment records status, Iris job ID, W&B link, final metrics,
+experiment link, and next recommendation.
 
 #### 7) Seal and open log-only PR
 - Create and push a sealing tag for the exact launch commit (the commit containing the `experiments/ferries/daily.py` used for the run).
@@ -182,15 +161,11 @@ If canary fails: triage and identify root cause, only then open a focused PR if 
 - If the canary failed early, the profile may only cover warmup steps — check `step_time.all_steps.count` before drawing conclusions from steady-state stats.
 - `exclusive_per_track` (the default) can hide device stalls that overlap across tracks. Use `exclusive_global` when investigating stall-heavy profiles.
 
-## Promotion Rule (Daily)
-If a daily variant is clearly better holistically, promote it as the new default daily recipe/template.
+## Promotion rule
 
-Promotion signals:
-- eval losses are broadly better,
-- LM eval soft metrics improve in aggregate,
-- no reliability regressions.
-
-When promoting: open a follow-up PR updating `experiments/ferries/daily.py` and this skill; include a concise before/after metrics table.
+Promote a daily variant only when eval losses and aggregate LM metrics improve
+without a reliability regression. Open a follow-up PR for the recipe and this
+skill with a before/after metrics table.
 
 ## Validation Checklist
 - Diff is intentional and bounded for the selected lane.
@@ -198,9 +173,3 @@ When promoting: open a follow-up PR updating `experiments/ferries/daily.py` and 
 - Run-closure PR only updates `docs/experiments/daily-ferry-log.md`.
 - Ferry issue has updated launch metadata.
 - Monitoring loop ran until terminal state.
-
-## See Also
-- `docs/experiments/daily-ferry-log.md`
-- `.agents/skills/babysit-job/SKILL.md`
-- `.agents/projects/ferry_framework.md`
-- `.agents/skills/run-research/SKILL.md`

--- a/.agents/skills/run-research/SKILL.md
+++ b/.agents/skills/run-research/SKILL.md
@@ -31,11 +31,12 @@ research directly requires its workflow.
 ### 1. Prologue
 
 1. Keep an existing user-specified branch; otherwise create or use a long-lived
-   `research/<topic>` branch.
+   `research/<topic>` or `research/<user>/<issue>-<topic>` branch.
 2. Create or use the experiment issue and link it bidirectionally with the
-   logbook.
-3. Choose one short experiment ID prefix for entries, runs, and comments; use
-   two to four shared tags.
+   logbook. Confirm scope or visibility before creating it when either is
+   unclear.
+3. Choose one short experiment ID prefix and use IDs such as `MOE-HC-001` in
+   entries, runs, and comments; use two to four shared tags.
 4. Record the goal, success and stop criteria, baseline, initial hypothesis
    queue and experiment matrix, relevant code, and references.
 

--- a/.agents/skills/run-research/SKILL.md
+++ b/.agents/skills/run-research/SKILL.md
@@ -1,33 +1,17 @@
 ---
 name: run-research
-description: "Multi-session research workflow: compose logbooks, experiment issues, documentation updates, and snapshot discipline for long-running investigations."
+description: Run a coordinated multi-session research program only when explicitly requested with a logbook, experiment issue, and durable snapshots.
 ---
 
-# Skill: Agent-Directed Research
-
-Use this for long-running research where an agent iterates on benchmarks,
-experiments, and hypotheses over multiple sessions. Domain skills such as
-`add-pallas-kernel` may add constraints.
-
-## General Principle: Open Development
+# Multi-session research
 
 Long-lived work should leave a durable record: a logbook, coordinating issue
 updates, and enough commands/config to reproduce results. Do not publish secrets
 or private work the user asks to hold back.
 
-## Subskills
-
-- `.agents/skills/background-research/SKILL.md` for prior-work foraging,
-  source ledgers, contradiction passes, and ranked hypothesis candidates.
-- `.agents/skills/task-logbook/SKILL.md` for logbooks and issue updates.
-- `.agents/skills/wandb-reporting/SKILL.md` for W&B project selection, run
-  naming, report links, and artifact hygiene.
-- `.agents/skills/task-snapshot/SKILL.md` for commit/tag snapshots and stable
-  artifact links.
-- `.agents/skills/update-docs/SKILL.md` for updating durable docs, runbooks,
-  reports, or skill guidance when research changes behavior or practice.
-
-Layer domain skills on top for task-specific constraints.
+Use `background-research`, `task-logbook`, `wandb-reporting`, `task-snapshot`,
+and `update-docs` for their named artifacts. Add a domain skill only when the
+research directly requires its workflow.
 
 ## Core Artifacts
 
@@ -42,35 +26,18 @@ Layer domain skills on top for task-specific constraints.
 5. One or more commit or tag snapshots for meaningful milestones.
 6. Often a "production" branch that gets PR'd and merged.
 
-## Research Logbook
-
-Use the term **logbook** consistently. Follow `.agents/skills/task-logbook/SKILL.md` for
-formatting and issue-update rules.
-
-## Branches
-
-Use a research branch for the logbook, one-off scripts, harnesses, and small
-artifacts. Extract a clean production branch only when the final code/docs shape
-is clear.
-
 ## Standard Workflow
 
 ### 1. Prologue
 
-1. Create or switch to a long-lived research branch. You may already be on one, or the user may have requested a specific branch name. Otherwise, pick a descriptive name like `research/<topic>` or `research/<user>/<issue>-<topic>`.
-2. Create an experiment issue with `file-issue` unless scope or visibility needs
-   human confirmation. If the user provides one, use it.
-3. Start the logbook and link both ways: logbook to issue URL, issue body to logbook path. See the skill.
-4. Pick a short experiment ID prefix for the series, for example `MOE-HC-001`, and
-   use IDs like `MOE-HC-001` in logbook entries, run names, and issue comments.
-5. Pick a set of tags to use for all experiments, to be used with W&B, etc.
-   Typically this is the ID prefix (without the number), the issue number, and
-   anything else reasonable. Try to keep to 2-4 shared tags. You may use more
-   tags to distinguish runs within a project as useful.
-6. Record, as applicable: motivation, problem statement, context, success
-   metrics, the initial hypothesis queue, first experiment matrix, relevant
-   code paths, references, stop criteria, and the fixed baseline case for
-   repeated comparison.
+1. Keep an existing user-specified branch; otherwise create or use a long-lived
+   `research/<topic>` branch.
+2. Create or use the experiment issue and link it bidirectionally with the
+   logbook.
+3. Choose one short experiment ID prefix for entries, runs, and comments; use
+   two to four shared tags.
+4. Record the goal, success and stop criteria, baseline, initial hypothesis
+   queue and experiment matrix, relevant code, and references.
 
 ### 2. Research Loop
 
@@ -82,8 +49,6 @@ is clear.
 5. **Promote:** move only interesting, decision-relevant claims up the issue
    funnel.
 6. **Seal:** snapshot durable results or extract production work.
-
-Every cycle should leave the durable record better than it found it.
 
 ### 2.1 Forage: Background Research
 
@@ -114,7 +79,7 @@ For each non-trivial experiment:
 
 ### 3. Epilogue: Seal
 
-Sealing should ordinarily only happen if the user requests it or the research has reached the defined goal.
+Seal when requested or when the defined goal is reached.
 
 1. Update the issue body with the final TL;DR, conclusion, decision log, and negative-results index. Again, follow the `task-logbook` skill.
 2. Add a final issue comment covering what worked, what did not, confidence
@@ -125,16 +90,9 @@ Sealing should ordinarily only happen if the user requests it or the research ha
 5. Close the issue when the research thread is complete.
 
 If the research produced useful production changes, extract them into a clean
-branch that can link to the logbook but does not include it. Follow standard
-Marin development practices on that branch.
-
-Before closing the issue:
-
-- Final TL;DR is current.
-- Issue body includes a clear `Conclusion`.
-- Next steps are listed.
-- Final snapshot is linked.
-- If there's a final production PR, link to it from the issue summary.
+branch that links the research record without including it. Before closing,
+update the TL;DR and conclusion, list next steps, and link the final snapshot
+and production PR when one exists.
 
 ## Practical Rules
 
@@ -143,10 +101,3 @@ Before closing the issue:
 - Record exact command lines for every headline number.
 - Treat failures and negative results as first-class data. Record dead ends and
   excessive hyperparameter sensitivity; skip routine bugs or undertuning.
-
-## See Also
-
-- `.agents/skills/organize-experiments/SKILL.md`
-- `.agents/skills/add-pallas-kernel/SKILL.md`
-- `.agents/skills/task-logbook/SKILL.md`
-- `.agents/skills/update-docs/SKILL.md`

--- a/.agents/skills/scan-logs/SKILL.md
+++ b/.agents/skills/scan-logs/SKILL.md
@@ -43,7 +43,10 @@ uv run scripts/logscan.py grep log.txt "errors" \
 ```
 
 Behavior-changing options are `--chunk-tokens`, `--concurrency`, `--model`,
-`--stdin`, and `--verbose`; inspect `--help` for current defaults.
+`--stdin`, and `--verbose`. The defaults are 5,000-token `grep` chunks,
+50,000-token hierarchical `summarize` chunks, concurrency 16, and
+`gemini-2.5-flash-lite`. Smaller `grep` chunks favor precise line matching;
+large logs need no manual pre-split. Inspect `--help` before overriding them.
 
 ## Output
 

--- a/.agents/skills/scan-logs/SKILL.md
+++ b/.agents/skills/scan-logs/SKILL.md
@@ -1,42 +1,31 @@
 ---
 name: scan-logs
-description: Scan logs too large to read directly, using Gemini (scripts/logscan.py).
+description: Use scripts/logscan.py only when explicitly requested to scan an oversized log or to perform Gemini-backed log analysis.
 ---
 
-# Skill: Scan Logs
+# Scan large logs
 
-Use `scripts/logscan.py` to analyze large log files. Two composable modes —
-`grep` (find matching lines) and `summarize` (produce a markdown report) — used
-independently or piped together.
-
-## When to Use
-
-- Log files too large to read in context (>1000 lines)
-- Searching for errors, anomalies, or patterns in job/worker/controller logs
-- Triaging failures from Iris, Zephyr, or training jobs
+`grep` finds matching original lines; `summarize` produces a Markdown report.
+They can run independently or as a pipeline.
 
 ## Prerequisites
 
-`GEMINI_API_KEY` must be set.
+`GEMINI_API_KEY` must be set. The log is sent to an external Gemini API and
+incurs model usage; do not send secrets or sensitive logs without approval.
 
 ## Modes
 
 ### grep — find matching lines
 
-Returns original log lines (with line numbers) matching a natural-language
-query. Uses small chunks (~5k tokens) for precision.
+Returns line-numbered original lines matching a natural-language query.
 
 ```bash
 uv run scripts/logscan.py grep <logfile> "<query>"
 ```
 
-Output goes to stdout as `<line_number>: <line>`, one per match.
-
 ### summarize — produce a markdown report
 
-Summarizes the log into a coherent narrative focused on the query. Uses larger
-chunks (~50k tokens) and hierarchically reduces per-chunk summaries into a final
-report.
+Summarizes the log around the query, hierarchically reducing large inputs.
 
 ```bash
 uv run scripts/logscan.py summarize <logfile> "<query>"
@@ -46,59 +35,20 @@ Output is a markdown report on stdout.
 
 ### Piping modes together
 
-grep's stdout feeds directly into summarize via `--stdin` — narrow to relevant
-lines first, then summarize:
+Narrow first, then summarize through `--stdin`:
 
 ```bash
 uv run scripts/logscan.py grep log.txt "errors" \
   | uv run scripts/logscan.py summarize --stdin "summarize these errors"
 ```
 
-## Arguments
-
-| Argument | Description |
-|---|---|
-| `mode` | `grep` or `summarize` |
-| `logfile` | Path to the log file (optional if `--stdin`) |
-| `query` | Natural language description of what to look for |
-| `--chunk-tokens N` | Tokens per chunk (default: 5000 for grep, 50000 for summarize) |
-| `--concurrency N` | Max parallel requests (default: 16) |
-| `--model NAME` | Gemini model (default: `gemini-2.5-flash-lite`) |
-| `-v, --verbose` | Print per-chunk results to stderr |
-| `--stdin` | Read input from stdin instead of a file |
-
-## Examples
-
-```bash
-# Find OOM errors in a training log
-uv run scripts/logscan.py grep /tmp/train.log "out of memory errors or OOM kills"
-
-# Summarize TPU failures
-uv run scripts/logscan.py summarize /tmp/worker.log "TPU errors, device failures, or FAILED_PRECONDITION"
-
-# grep then summarize for focused analysis
-uv run scripts/logscan.py grep /tmp/controller.log "timeout" \
-  | uv run scripts/logscan.py summarize --stdin "what caused the timeouts?"
-
-# Use a more capable model for complex analysis
-uv run scripts/logscan.py summarize /tmp/big.log "race conditions or deadlocks" --model gemini-2.5-flash
-```
+Behavior-changing options are `--chunk-tokens`, `--concurrency`, `--model`,
+`--stdin`, and `--verbose`; inspect `--help` for current defaults.
 
 ## Output
 
 - **grep**: Line-numbered matching lines to stdout. Progress to stderr.
 - **summarize**: Markdown report to stdout. Progress and token usage to stderr.
 
-Both modes print token usage stats to stderr when complete.
-
-## Integration with Other Skills
-
-- **babysit-\***: analyze logs from failed jobs before deciding on recovery
-- **debug**: use `grep` to find the failure region, then `Read` specific line ranges
-- **triage-canary**: use `summarize` to scan canary ferry logs for the root cause
-
-## Tips
-
-- `grep` first to narrow down, then `summarize` the filtered output via `--stdin`
-- For very large files (>100k lines), `summarize` handles hierarchical reduction automatically
-- Add `-v` to see per-chunk results as they complete
+Both modes report progress and token usage to stderr. Read the matched source
+lines before accepting a generated diagnosis.

--- a/.agents/skills/scrub-docs-code-parity/SKILL.md
+++ b/.agents/skills/scrub-docs-code-parity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scrub-docs-code-parity
-description: "Scheduled scrub: docs and code parity."
+description: Run the docs/code-parity scrub only from its scheduler or an explicit request for that scrub.
 schedule_cron: "0 0 2 * * *"
 schedule_tz: America/New_York
 ---

--- a/.agents/skills/scrub-experiment-issue-tldrs/SKILL.md
+++ b/.agents/skills/scrub-experiment-issue-tldrs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scrub-experiment-issue-tldrs
-description: "Scheduled scrub: TL;DR blocks on experiment issues."
+description: Run the experiment-issue TL;DR scrub only from its scheduler or an explicit request for that scrub.
 ---
 
 # scrub-experiment-issue-tldrs

--- a/.agents/skills/scrub-reflection-self-improvement/SKILL.md
+++ b/.agents/skills/scrub-reflection-self-improvement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scrub-reflection-self-improvement
-description: "Scheduled scrub: repository self-improvement."
+description: Run the repository self-improvement scrub only from its scheduler or an explicit request for that scrub.
 schedule_cron: "0 10 2 * * *"
 schedule_tz: America/New_York
 ---

--- a/.agents/skills/task-logbook/SKILL.md
+++ b/.agents/skills/task-logbook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-logbook
-description: Maintain an append-only task logbook only when explicitly requested for durable cross-session notes, reproducible experiments, or a coordinating issue.
+description: Maintain a task logbook only when explicitly requested for durable cross-session notes, reproducible experiments, or a coordinating issue; entries are append-only while summary indices may change.
 ---
 
 # Task logbook

--- a/.agents/skills/task-logbook/SKILL.md
+++ b/.agents/skills/task-logbook/SKILL.md
@@ -1,29 +1,15 @@
 ---
 name: task-logbook
-description: "Maintain append-only task/research logbooks and publish the important parts upward into coordinating GitHub issues."
+description: Maintain an append-only task logbook only when explicitly requested for durable cross-session notes, reproducible experiments, or a coordinating issue.
 ---
 
-# Skill: Task Logbook
-
-Use this when a task needs durable context across sessions, reproducible
-experiment notes, or a compact handoff trail. For long-running research,
-`run-research` composes this skill with a more complete experimentation lifecycle.
+# Task logbook
 
 ## Concepts
 
-This skill has two modes:
-
-- No coordinating issue: append progress to the logbook.
-- Coordinating issue: update both the logbook and the GitHub issue.
-
-The core model is a funnel of interestingness:
-
-1. The logbook is maximally informative and append-only.
-2. Significant or interesting updates are posted to the coordinating GitHub issue or PR.
-3. The most important findings are promoted into the summary at the top of the issue.
-
-Keep the detailed record in the logbook. Keep the issue useful to someone who
-did not follow the live session.
+Keep the detailed append-only record in the logbook. If a coordinating issue
+exists, publish significant updates as comments and maintain its body as the
+current summary.
 
 ## Location and Naming
 
@@ -70,20 +56,14 @@ author:
 - Next action:
 ```
 
-In general, generate a lightweight/in-progress commit before each log if there
-have been interesting code changes that affect reproducibility. Include this
-commit hash in the entry.
+When code changes affect reproducibility, make a lightweight WIP commit and
+record its hash. Stage only the files needed for the result. Apply the full
+`commit` workflow when promoting the work to a production PR.
 
-Lightweight reproducibility commits are for research or WIP branches, not
-production extraction branches. Stage only the files needed to reproduce the
-entry, and leave unrelated local changes untouched. These commits are snapshots
-for traceability; they do not need to satisfy the full `commit` skill or
-pre-PR checklist until the work is promoted into a production PR.
+For a research series, use one short experiment ID consistently in logbook
+entries, W&B runs, and issue comments.
 
-For research series, add a short experiment ID prefix such as `MOE-HC` and use
-IDs like `MOE-HC-001` in logbook entries, W&B run names, and issue comments.
-
-The author should ordinarily be the user who asked you to make the logbook. If there is no GitHub issue, omit it.
+Use the requesting user as author. Omit `issue` when none exists.
 
 ### Write Rules
 
@@ -103,36 +83,17 @@ The author should ordinarily be the user who asked you to make the logbook. If t
 The entry log is append-only. Short index sections near the top may be edited as
 the current state changes.
 
-Use living indices for:
-
-- `Current TL;DR`
-- `Current baseline`
-- `Hypothesis queue`
-- `Decision log`
-- `Negative results index`
+Living indices may include `Current TL;DR`, `Current baseline`, `Hypothesis
+queue`, `Decision log`, and `Negative results index`.
 
 When updating a living index, preserve traceability by linking each item to the
 logbook entry, issue comment, W&B run, commit, or tag that supports it. Do not
 delete the underlying entry when a hypothesis is revised or falsified; update
 the queue status and point to the evidence.
 
-Hypothesis queue shape:
-
-```md
-## Hypothesis Queue
-
-### Active
-- `<ID>`: <hypothesis>. Evidence: <links>. Next test: <short action>.
-
-### Blocked
-- `<ID>`: <hypothesis>. Blocker: <reason>. Resume when: <condition>.
-
-### Falsified / Dead End
-- `<ID>`: <hypothesis>. Why stopped: <evidence links>.
-
-### Promoted
-- `<ID>`: <hypothesis>. Decision: <production branch/PR/report/issue link>.
-```
+Track hypotheses as active, blocked, falsified, or promoted. Each item needs an
+ID, evidence links, and either its next test, resume condition, stopping reason,
+or production decision.
 
 ## Coordinating Issue
 
@@ -143,33 +104,17 @@ Confirm timing with the human collaborator if scope or visibility is uncertain.
 Use the experiment body template in `.agents/skills/file-issue/SKILL.md` when
 creating a new coordinating experiment issue.
 
-### Issue summary
-
-Write the issue summary for readers who know Marin/LLM systems generally but
-not the specific thread. Keep it current with the problem, goal, status,
-evidence, and final outcome. Do not overclaim.
-
-Maintain the issue body as the public summary layer:
-
-- `TL;DR`
-- `Current baseline` when comparing behavior or metrics
-- `Decision log` with important decisions, evidence, date, and owner
-- `Negative results index` with links to comments/logbook entries
-- `Conclusion` as evidence solidifies
+Maintain the issue body for readers without thread context: current TL;DR,
+baseline when relevant, decisions with evidence/date/owner, linked negative
+results, and the conclusion. Do not overclaim.
 
 ### Promotion Rules
 
-Use this funnel after each meaningful logbook entry:
-
-- **Logbook only:** detailed commands, raw outputs, routine observations,
-  dead ends, local debugging notes, and dense analysis.
-- **Issue comment:** significant milestones, failures, relaunches of long-running experiments, baseline
-  changes, surprising observations, decisions, and periodic long-running research heartbeats.
-- **Issue summary/body:** durable conclusions, current TL;DR or major status, stable baseline,
-  decision log entries, negative-results index, and final outcome.
-
-Consider all updates since the last issue comment; several small logbook entries
-may add up to a useful issue update.
+Keep commands, raw output, routine observations, dead ends, and dense analysis
+in the logbook. Post milestones, failures, relaunches, baseline changes,
+surprises, and decisions as issue comments. Promote durable conclusions,
+baselines, decisions, negative results, and the final outcome into the issue
+body.
 
 For long-running research, post an issue update at each significant milestone
 or every 6 hours of active work (either experiments in progress or agent work), whichever comes first. If no milestone occurred by the cadence
@@ -192,51 +137,19 @@ Issue comment template:
 - Next:
 ```
 
-#### Issue comment style
-
 - Mostly append-only; edit only for formatting, escaping, or factual errors.
 - Agent-authored issue comments begin with `🤖` unless the text was explicitly approved by the user.
 - Leave issue references like #1234 as plain text so GitHub cross-links them.
 - Link artifacts to pinned commits or tags when result reproducibility matters.
 - Keep the issue concise; move full analysis into the logbook.
 
-
-#### Issue Reader Check
-
-For nontrivial updates, a context-isolated subagent can check whether the update
-is understandable without thread or branch context.
-
-If available, start a subagent **without current thread context** (e.g. using
-`fork_context: false`). Use this prompt:
-
-```markdown
-You are reviewing this GitHub issue update as a technically literate Marin contributor who can see only the issue body, recent issue comments, and the proposed update below.
-
-Task: decide whether the proposed update is understandable from that visible context alone.
-
-Flag:
-- undefined terms, acronyms, run names, branch names, or experiment IDs
-- references like “this”, “that”, “the previous result”, or “the baseline” whose referent is not visible
-- claims without enough visible evidence, config, baseline, metric, or links to evaluate them
-- links that appear necessary but are missing
-
-You may also assume knowledge of project documentation, AGENTS.md but otherwise do not use outside knowledge beyond general knowledge of Marin and the field. Do not infer from missing context. Do not read the logbook. Suggest only edits that make the update self-contained from the visible issue context.
-
-Issue: <issue link/id>
-Update:
-
-<...>
-```
-
-You may skip this check for trivial updates.
-
-When updating the issue body with a new summary, use a suitable variant.
+When an isolated reader is available, use it for nontrivial updates to check for
+undefined terms, ambiguous references, unsupported claims, missing baselines,
+and missing links. Give it only the issue context and proposed update; skip this
+for trivial updates.
 
 ## Finish
 
-Close the issue when what the logbook was tracking is complete.
-
-Before closing the coordinating issue, ensure the final logbook entry and issue
-summary agree. The final issue comment should say what worked, what did not,
-confidence level and limitations, ordered next steps, and an explicit conclusion
-explaining the outcome.
+Before closing the issue, make the final logbook entry and issue summary agree.
+The final comment records what worked, what did not, confidence and limitations,
+ordered next steps, and the conclusion.

--- a/.agents/skills/task-logbook/SKILL.md
+++ b/.agents/skills/task-logbook/SKILL.md
@@ -95,6 +95,18 @@ Track hypotheses as active, blocked, falsified, or promoted. Each item needs an
 ID, evidence links, and either its next test, resume condition, stopping reason,
 or production decision.
 
+```md
+## Hypothesis Queue
+### Active
+- `<ID>`: <hypothesis>. Evidence: <links>. Next test: <action>.
+### Blocked
+- `<ID>`: <hypothesis>. Blocker: <reason>. Resume when: <condition>.
+### Falsified / Dead End
+- `<ID>`: <hypothesis>. Why stopped: <evidence links>.
+### Promoted
+- `<ID>`: <hypothesis>. Decision: <production artifact link>.
+```
+
 ## Coordinating Issue
 
 Create or use a coordinating GitHub issue when the work needs durable public
@@ -148,7 +160,19 @@ undefined terms, ambiguous references, unsupported claims, missing baselines,
 and missing links. Give it only the issue context and proposed update; skip this
 for trivial updates.
 
+Prompt the reader with only the issue body, recent comments, and proposed
+update:
+
+```text
+Decide whether this update is understandable from visible issue context alone.
+Flag undefined names or IDs, ambiguous references, claims without visible
+evidence, config, baseline, or metrics, and missing necessary links. Do not read
+the logbook or infer missing context.
+```
+
 ## Finish
+
+Close the issue when the tracked work is complete.
 
 Before closing the issue, make the final logbook entry and issue summary agree.
 The final comment records what worked, what did not, confidence and limitations,

--- a/.agents/skills/task-snapshot/SKILL.md
+++ b/.agents/skills/task-snapshot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-snapshot
-description: "Create stable commit or tag snapshots for task milestones, experiment results, and reproducible artifact links."
+description: Create a commit or tag snapshot only when explicitly requested for a milestone, reproducibility checkpoint, handoff, or pinned artifact.
 ---
 
 # Skill: Task Snapshot

--- a/.agents/skills/triage-canary/SKILL.md
+++ b/.agents/skills/triage-canary/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: triage-canary
-description: Triage a failed canary ferry run (CI-invoked).
+description: Triage a failed canary ferry run only when invoked by CI with the required CANARY context.
 ---
 
 # Skill: Triage Canary

--- a/.agents/skills/update-docs/SKILL.md
+++ b/.agents/skills/update-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-docs
-description: Update durable docs when explicitly requested or when completed implementation changes make an authoritative procedure stale.
+description: Update durable docs when explicitly requested or when current work changes behavior, exposes stale instructions, establishes an operational pattern, or yields reusable research guidance.
 ---
 
 # Skill: Update Docs

--- a/.agents/skills/update-docs/SKILL.md
+++ b/.agents/skills/update-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-docs
-description: "Update documentation, runbooks, and reusable task guidance when implementation work or experiments change behavior or operational practice."
+description: Update durable docs when explicitly requested or when completed implementation changes make an authoritative procedure stale.
 ---
 
 # Skill: Update Docs

--- a/.agents/skills/wandb-reporting/SKILL.md
+++ b/.agents/skills/wandb-reporting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wandb-reporting
-description: "Use W&B runs, reports, and artifacts consistently for experiments, benchmarks, and task results with dense numeric output."
+description: Publish W&B runs, reports, or artifacts only when explicitly requested or required for a requested experiment's dense numeric results.
 ---
 
 # Skill: W&B Reporting

--- a/.agents/skills/write-design-doc/SKILL.md
+++ b/.agents/skills/write-design-doc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-design-doc
-description: Produce a 1-page design proposal when the user explicitly asks for one. Do not use to answer or evaluate an idea inline.
+description: Create Marin design-doc artifacts only when explicitly asked for a design doc, one-pager, or proposal; do not use for inline architecture discussion.
 ---
 
 # Skill: Design Doc Workflow

--- a/.agents/skills/write-ops-log/SKILL.md
+++ b/.agents/skills/write-ops-log/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-ops-log
-description: Publish an Echo incident record only when explicitly requested or delegated after an infrastructure incident or durable debugging session.
+description: Publish a tagged Echo record after every incident, then link its canonical URL from the associated pull request or issue.
 ---
 
 # Skill: Write an Ops Log

--- a/.agents/skills/write-ops-log/SKILL.md
+++ b/.agents/skills/write-ops-log/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-ops-log
-description: Publish a tagged postmortem incident record to Echo. Use after an infrastructure or durable debugging session, then link the canonical Echo URL from the associated PR or issue.
+description: Publish an Echo incident record only when explicitly requested or delegated after an infrastructure incident or durable debugging session.
 ---
 
 # Skill: Write an Ops Log

--- a/.agents/skills/write-tests/SKILL.md
+++ b/.agents/skills/write-tests/SKILL.md
@@ -1,19 +1,11 @@
 ---
 name: write-tests
-description: Write or revise Marin tests with an emphasis on behavior, regression coverage, pytest style, and avoiding "slop tests." Use when adding tests, fixing failing tests, reviewing test quality, or deciding what test would catch a bug.
+description: Add, revise, or review Marin tests for an explicit behavior change, regression, or test-quality request.
 ---
 
 # Write Tests
 
-Use this skill when a change needs tests or when existing tests look too coupled
-to implementation details.
-
-Read root `TESTING.md` before writing or reviewing non-trivial tests. It is the
-shared project-wide testing policy used by `write-tests`, `review-pr`, and
-`commit`.
-
-Also read the relevant module-specific docs before choosing test style,
-fixtures, mocks, markers, or commands:
+Read these before choosing test style, fixtures, mocks, markers, or commands:
 
 - root `AGENTS.md`
 - root `TESTING.md`
@@ -29,7 +21,7 @@ fixtures, mocks, markers, or commands:
 3. Name the behavior that should fail if the code is wrong.
 4. Write the smallest test that observes that behavior through a public API,
    structured output, persisted state, or real side effect.
-5. Prefer a regression test before the fix when fixing a bug. Ensure the test fails before implementing the bug fix.
+5. For a bug, write the regression test before the fix and confirm it fails.
 6. Keep test setup realistic but small. Use fixtures and parameterization to
    remove duplication.
 7. Run the narrow test first, then the relevant package test command. Before a
@@ -43,6 +35,5 @@ fixtures, mocks, markers, or commands:
 - For package-specific commands, use the relevant `lib/*/AGENTS.md` or testing
   doc.
 
-For PR preparation, run `./infra/pre-commit.py --changed-files --fix` or
-`./infra/pre-commit.py --all-files --fix` as appropriate. Do not replace it
-with `uv run pre-commit`.
+Before a PR, run `./infra/pre-commit.py --changed-files --fix` or `--all-files`
+as appropriate. Do not substitute `uv run pre-commit`.

--- a/.agents/skills/writing-style/SKILL.md
+++ b/.agents/skills/writing-style/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: writing-style
-description: Marin house writing style. Use when drafting or revising Marin-authored prose, including commit messages and GitHub PR, issue, or comment text.
+description: Apply Marin house style when producing or revising commit, pull-request, issue, comment, documentation, report, or blog prose.
 ---
 
 # Marin House Style
 
-Start here for any non-trivial Marin-authored text. This file is the common layer; then read the medium-specific file that matches the deliverable.
+Read the medium-specific guide for the deliverable, then apply
+[ai-writing-donts.md](ai-writing-donts.md) as the final prose pass.
 
 ## Read The Right File
 
@@ -16,88 +17,34 @@ Start here for any non-trivial Marin-authored text. This file is the common laye
 - Read [issues.md](issues.md) for standard OSS issues and experiment issues.
 - Read [pull-requests.md](pull-requests.md) for commit messages and PR titles and bodies.
 - Read [discord.md](discord.md) for Discord summaries and tactical replies.
-- Read [ai-writing-donts.md](ai-writing-donts.md) for the final prose-only review pass that strips generic AI-writing patterns.
-- Apply this file first, then apply the medium-specific file. If a piece spans multiple media, keep the stricter rule.
+- If a piece spans media, use the stricter applicable rule.
 
-## Hold The Marin Positioning
+## Voice
 
-- Write from the stance of a rigorous, open-science lab building frontier-level foundation models.
-- Treat process as part of the work. Experiments, decisions, and mistakes all belong in the record.
-- Let the work speak. Do not substitute tone for evidence.
-
-## Keep The Core Vibe
-
-- Be sober, not flashy.
-- Project quiet confidence.
-- Keep an open door, not a megaphone.
-- Stay practical and hands-on.
-- Aim to be helpful and respectful.
-- Assume a baseline familiarity with ML systems.
-- Don’t dilute discussions to accommodate every level of experience. (Different media will be intended for different levels of experience.)
-- Don’t be overly formal; write like a technical peer, not an academic paper or a product blog.
-- Use technical language where it helps, but keep the tone natural and direct.
+Write as a rigorous open-science lab building foundation models. Treat
+experiments, decisions, and mistakes as part of the record. Use a sober,
+practical voice for technically capable peers. Be natural and direct; use
+specialized language when it improves precision.
 
 ## On Voice
 
-The above defines the default voice; we allow some flexibility by author. These rules are stricter for agent-written text than for human-written text.
+These rules are stricter for agents. Preserve harmless human flourishes when
+editing another person's prose.
 
-Researchers need not suppress their own voice. Some personality is fine, especially in retrospectives, blog posts, and narrative writeups, as long as the writing stays concrete, honest, and technically disciplined.
+## Evidence and scope
 
-Agents should err toward more discipline. When reviewing human prose, allow deviations and flourishes that do not conflict with core Marin values.
-
-## Enforce Hard Rules
-
-- Remove hype, marketing copy, and launch-tweet energy.
-- Use emoji very sparingly: for communication, not flair.
-- Remove grand claims that outrun the evidence.
-- Avoid AGI rhetoric and speculation.
-- Avoid adjectives that try to do the work of numbers.
-- If a sentence sounds like a product announcement, rewrite it.
-
-## Follow The Writing Principles
-
-- Show results instead of claiming them. Prefer concrete numbers, examples, and observed behavior.
-- Prefer the simplest framing that is still correct.
-- State uncertainty plainly. Use phrases like `we think`, `preliminary results suggest`, or `this seems to break down when...` when warranted.
-- Treat the reader as a capable collaborator. Do not condescend or over-explain basics.
-- Default to transparency. Include what worked, what failed, what surprised you, and what you would try next.
-- Cite the relevant prior work and artifacts. This includes Marin experiments, reports, issues, PRs, papers, and other external work when they materially inform the piece.
+- Lead with the result, decision, or changed behavior.
+- Support claims with numbers, examples, observations, and relevant artifacts.
+- State uncertainty and limitations plainly; do not imply broader evidence.
+- Remove hype, product-announcement language, AGI speculation, decorative
+  emoji, and adjectives standing in for evidence.
+- Explain non-standard terms. Add detail only when it helps the reader
+  reproduce, evaluate, or act.
 
 ## Add Structure For Longer-Form Writing
 
-- For longer-form writing, include an easy-to-scan doc-level TL;DR near the top.
-- For longer-form writing, add section-level takeaway lines or short TL;DRs where they help readers navigate.
+Long-form pieces may need a document-level TL;DR and section takeaways. Do not
+force them into short media.
 
-- Do not force these patterns into short-form media that do not benefit from them.
-
-## Set Audience By Default
-
-- Assume the reader works in ML or LLMs unless the medium says otherwise.
-- Do not assume deep specialization by default.
-- Introduce non-standard terms before using them heavily.
-- Add detail only when it helps the reader reproduce, evaluate, or act.
-
-## Use Sentence-Level Defaults
-
-- Prefer short, direct sentences.
-- Lead with the result or takeaway.
-- Follow with method or explanation.
-- End with caveats, limits, or open questions when needed.
-- Prefer phrases like `we found`, `this suggests`, `in practice`, and `one limitation is`.
-- Avoid phrases like `clearly`, `obviously`, `groundbreaking`, and `state-of-the-art` unless you define and defend them.
-
-## Review For AI-Writing Tells
-
-Do one editing pass that looks only for generic, over-smoothed, LLM-sounding prose. Then apply [ai-writing-donts.md](ai-writing-donts.md) as the detailed checklist for what to remove or rewrite.
-
-## Run A Quick Self-Check
-
-- Did you include concrete evidence?
-- Did you remove hype language?
-- Would this sound normal spoken aloud to a colleague?
-- Did you overstate certainty or scope?
-- Did you remove generic AI-writing templates and filler?
-
-## Keep The One-Line Summary
-
-Write clearly, honestly, and with enough evidence for the work to stand on its own.
+Before publishing, confirm the prose is factually current, sounds normal when
+spoken to a colleague, cites material evidence, and contains no generic filler.


### PR DESCRIPTION
Keep all 43 repository skill entrypoints while reducing their total context
from 5,971 to 5,092 lines, a 14.7% reduction.

Classify activation by task semantics. Direct task matches load without naming
the skill. Optional resource reservations, persistent monitoring, multi-session
research, durable artifacts, and costly benchmark workflows require explicit
requests. Scheduled scrubs and the read-only lint reporter run only from their
named harnesses or explicit requests. Commit, writing style, stale-document
updates, and Echo incident publication remain automatic companions or
postconditions; every incident produces a tagged Echo record linked from its
associated pull request or issue.

Remove duplicated repository policy, generic setup narration, and repeated
workflow explanation. Retain approval boundaries, costly or destructive
operation guards, behavior-changing commands and flags, source-of-truth rules,
and workflow state transitions. Preserve decision-relevant examples and
environment-specific caveats, including the known-good TensorBoard scope
settings, Finelog metric semantics, fork-refresh pitfalls, logscan defaults,
and terminal issue schemas.
