### PR TITLE
[inference] Link NVRTC in isolated CUDA toolchains

### DIFF
--- a/lib/marin/src/marin/inference/vllm_server.py
+++ b/lib/marin/src/marin/inference/vllm_server.py
@@ -56,6 +56,7 @@ _UPSTREAM_CUDA_TORCH_BACKEND = "cu130"
 _CUDA_TOOLCHAIN_REQUIREMENTS = (
     "nvidia-cuda-nvcc==13.0.88",
     "nvidia-cuda-crt==13.0.88",
+    "nvidia-cuda-nvrtc==13.0.88",
     "nvidia-nvvm==13.0.88",
 )
 _CUDA_NVCC_BOOTSTRAP = """\
@@ -76,6 +77,10 @@ cudart = cuda_lib / "libcudart.so.13"
 cudart_link = cuda_lib / "libcudart.so"
 if cudart.is_file() and not cudart_link.exists():
     cudart_link.symlink_to(cudart.name)
+nvrtc = cuda_lib / "libnvrtc.so.13"
+nvrtc_link = cuda_lib / "libnvrtc.so"
+if nvrtc.is_file() and not nvrtc_link.exists():
+    nvrtc_link.symlink_to(nvrtc.name)
 os.environ["CUDA_HOME"] = str(cuda_home)
 os.environ["PATH"] = os.pathsep.join((str(nvcc.parent), os.environ["PATH"]))
 os.execvp(sys.argv[1], sys.argv[1:])

--- a/tests/inference/test_serve.py
+++ b/tests/inference/test_serve.py
@@ -236,6 +236,8 @@ def test_isolated_cuda_vllm_bootstrap_exposes_wheel_nvcc(tmp_path):
     cuda_lib.mkdir()
     cudart = cuda_lib / "libcudart.so.13"
     cudart.touch()
+    nvrtc = cuda_lib / "libnvrtc.so.13"
+    nvrtc.touch()
     dist_info = site_packages / "nvidia_cuda_nvcc-13.0.88.dist-info"
     dist_info.mkdir()
     (dist_info / "METADATA").write_text("Metadata-Version: 2.4\nName: nvidia-cuda-nvcc\nVersion: 13.0.88\n")
@@ -259,6 +261,7 @@ def test_isolated_cuda_vllm_bootstrap_exposes_wheel_nvcc(tmp_path):
     assert set(requirements) >= {
         "nvidia-cuda-nvcc==13.0.88",
         "nvidia-cuda-crt==13.0.88",
+        "nvidia-cuda-nvrtc==13.0.88",
         "nvidia-nvvm==13.0.88",
     }
     assert "addressing_style = virtual" in Path(launcher.env()["AWS_CONFIG_FILE"]).read_text()
@@ -279,6 +282,7 @@ def test_isolated_cuda_vllm_bootstrap_exposes_wheel_nvcc(tmp_path):
     assert observed["path"].split(os.pathsep)[0] == str(nvcc.parent.resolve())
     assert (nvcc.parent.parent / "lib64").resolve() == cuda_lib.resolve()
     assert (cuda_lib / "libcudart.so").resolve() == cudart.resolve()
+    assert (cuda_lib / "libnvrtc.so").resolve() == nvrtc.resolve()
 
 
 def test_isolated_cuda_vllm_upstream_requires_version():


### PR DESCRIPTION
Pin NVRTC 13 with the isolated CUDA compiler packages and expose the unversioned `libnvrtc.so` linker name under `CUDA_HOME`. FlashInfer's FP8 block-scale warmup links with `-lnvrtc`, while the CUDA wheel provides only `libnvrtc.so.13`.

An upstream vLLM 0.25.1 serve for `Qwen/Qwen3.5-122B-A10B-FP8` on H100x8 reproduced the linker failure after model load. The repaired serve registered its Iris endpoint and completed a live chat request. The incident record is [Echo wiki 191](https://echo.oa.dev/wiki/191).

Part of #7373
