### PR TITLE
[levanter] Read checkpoint arrays concurrently on restore

### DIFF
--- a/experiments/grug/moe_hero_ep/restore_benchmark.py
+++ b/experiments/grug/moe_hero_ep/restore_benchmark.py
@@ -1,0 +1,249 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Time a hero checkpoint save and restore on one rack.
+
+Builds the hero train state, writes it to a one-day temporary prefix, and reads it back into
+the same exemplar a resume restores into -- offloaded optimizer state and FP32 pinned-host
+master params included. It trains nothing, so a run measures the checkpoint paths alone.
+
+The save timing is what a training step is blocked for. The first read is the only one that
+can miss the node-local cache.
+
+Dispatch needs an Iris task to submit from, so launch it as a coordinator job:
+
+    iris --config lib/iris/config/marin.yaml job run --no-wait \\
+        --enable-extra-resources --target-cluster cw-us-east-08a --priority production \\
+        --cpu 2 --memory 8GB --disk 32GB --job-name restore-bench-coord \\
+        -- python -m experiments.grug.moe_hero_ep.restore_benchmark --run-id restore-bench-1
+"""
+
+import dataclasses
+import gc
+import logging
+import time
+from dataclasses import dataclass, field
+
+import click
+import equinox
+import jax
+import jax.experimental.array_serialization.serialization as array_ser
+import jmp
+from fray.cluster import ResourceConfig
+from haliax.jax_utils import is_jax_array_like
+from haliax.partitioning import set_mesh
+from jax.experimental import multihost_utils
+from levanter.checkpoint import save_checkpoint
+from levanter.grug.sharding import compact_grug_mesh
+from levanter.optim.config import OptimizerConfig
+from levanter.tensorstore_serialization import (
+    TensorStoreReadConfig,
+    TensorStoreWriteConfig,
+    tree_deserialize_leaves_tensorstore,
+)
+from levanter.tracker.telemetry import TelemetryConfig
+from levanter.trainer import TrainerConfig
+from rigging.filesystem.cluster_config import marin_temp_bucket
+from rigging.filesystem.storage_path import prefix_join
+
+from experiments.grug.dispatch import dispatch_grug_training_run
+from experiments.grug.moe_hero_ep.heuristic import build_hero_configs
+from experiments.grug.moe_hero_ep.launch_mfu_test import (
+    HERO_EP_BATCH_SIZE,
+    HERO_EP_EXPERT_AXIS_SIZE,
+    HERO_EP_NODES,
+    HERO_GPUS_PER_NODE,
+    HERO_MIXED_PRECISION,
+)
+from experiments.grug.moe_hero_ep.model import GrugModelConfig, QbEstimator
+from experiments.grug.moe_hero_ep.train import (
+    MasterParamMode,
+    _apply_hero_ep_runtime_defaults,
+    initial_state,
+    restore_template_from,
+)
+
+logger = logging.getLogger(__name__)
+
+# The hero's own schedule length, so this pytree matches the one a hero resume restores into.
+HERO_SCHEDULE_STEPS = 390_251
+QB_HIST_BINS = 10_000
+CHECKPOINT_TTL_DAYS = 1
+GIB = 1024**3
+
+
+@dataclass(frozen=True)
+class RestoreBenchmarkConfig:
+    """What to restore, into what shape, and how many times."""
+
+    checkpoint_path: str
+    model: GrugModelConfig
+    optimizer: OptimizerConfig
+    trainer: TrainerConfig
+    read: TensorStoreReadConfig = field(default_factory=TensorStoreReadConfig)
+    write: TensorStoreWriteConfig = field(default_factory=TensorStoreWriteConfig)
+    repeats: int = 2
+    replica_axis_size: int = 1
+
+
+def _hero_state(config: RestoreBenchmarkConfig, mesh):
+    """The hero train state, offloaded exactly as a hero run builds it."""
+    optimizer = config.optimizer.build(config.trainer.num_train_steps)
+
+    @jax.jit
+    def build(key):
+        return initial_state(
+            config.model,
+            optimizer=optimizer,
+            mp=config.trainer.mp,
+            key=key,
+            ema_beta=None,
+            offload_opt_state=True,
+            master_param_mode=MasterParamMode.FP32_PINNED_HOST,
+        )
+
+    with set_mesh(mesh):
+        return build(jax.random.PRNGKey(config.trainer.seed))
+
+
+def _time_one_restore(config: RestoreBenchmarkConfig, template, mesh, attempt: int) -> None:
+    """Restore the checkpoint once and log the fleet-wide elapsed seconds."""
+    serializable, _ = equinox.partition(template, is_jax_array_like)
+    multihost_utils.sync_global_devices(f"restore-start-{attempt}")
+    started = time.time()
+    restored = tree_deserialize_leaves_tensorstore(
+        config.checkpoint_path, serializable, mesh=mesh, read_config=config.read
+    )
+    jax.block_until_ready(restored)
+    multihost_utils.sync_global_devices(f"restore-done-{attempt}")
+    elapsed = time.time() - started
+
+    jax.tree.map(lambda leaf: leaf.delete() if isinstance(leaf, jax.Array) else None, restored)
+    del restored
+    gc.collect()
+    logger.info(
+        "RESULT attempt=%d seconds=%.1f budget=%.0fGiB requests=%d",
+        attempt,
+        elapsed,
+        config.read.max_in_flight_bytes / GIB,
+        config.read.request_concurrency,
+    )
+
+
+def _run_restore_benchmark_local(config: RestoreBenchmarkConfig) -> None:
+    """Entry point that runs on every rank of the benchmark job."""
+    config.trainer.initialize()
+    mesh = compact_grug_mesh(
+        expert_axis_size=HERO_EP_EXPERT_AXIS_SIZE,
+        replica_axis_size=config.replica_axis_size,
+    )
+    state = _hero_state(config, mesh)
+    with set_mesh(mesh):
+        # A hero's rolling temporary checkpoint is pruned as soon as the next one commits, and
+        # a read racing that deletion fails on a zero-length OCDBT shard, so own the write.
+        # Handed no manager, `save_checkpoint` joins the commits itself; a training loop
+        # returns once its data is copied out. Only `blocked` is time a training step loses.
+        manager = array_ser.GlobalAsyncCheckpointManager()
+        multihost_utils.sync_global_devices("save-start")
+        started = time.time()
+        save_checkpoint(
+            state,
+            step=0,
+            checkpoint_path=config.checkpoint_path,
+            manager=manager,
+            is_temporary=True,
+            write_config=config.write,
+        )
+        blocked = time.time() - started
+        manager.wait_until_finished()
+        committed = time.time() - started
+        multihost_utils.sync_global_devices("save-done")
+        logger.info(
+            "RESULT save blocked=%.1fs committed=%.1fs stage_budget=%.0fGiB",
+            blocked,
+            committed,
+            config.write.max_staged_host_bytes / GIB,
+        )
+        template = restore_template_from(state)
+        for attempt in range(config.repeats):
+            _time_one_restore(config, template, mesh, attempt)
+
+
+@click.command()
+@click.option("--run-id", required=True, help="Run identifier for the benchmark job name.")
+@click.option(
+    "--dp-racks",
+    type=click.IntRange(min=1),
+    default=1,
+    show_default=True,
+    help="GB200 racks to spread the restore across, at 16 nodes per rack.",
+)
+@click.option("--repeats", type=click.IntRange(min=1), default=2, show_default=True, help="Restores to time.")
+@click.option(
+    "--budget-gib",
+    type=click.IntRange(min=1),
+    default=TensorStoreReadConfig.max_in_flight_bytes // GIB,
+    show_default=True,
+    help="Host memory a process may hold in shards awaiting transfer. 48 OOM-kills a GB200 node.",
+)
+@click.option(
+    "--stage-gib",
+    type=click.IntRange(min=1),
+    default=TensorStoreWriteConfig.max_staged_host_bytes // GIB,
+    show_default=True,
+    help="Host memory a process may hold in staged snapshots. A save blocks training until its "
+    "whole share has been admitted, so a share above this waits on commits.",
+)
+@click.option(
+    "--requests",
+    type=click.IntRange(min=1),
+    default=TensorStoreReadConfig.request_concurrency,
+    show_default=True,
+    help="Concurrent object-store requests.",
+)
+def main(run_id: str, dp_racks: int, repeats: int, budget_gib: int, stage_gib: int, requests: int) -> None:
+    batch_size = HERO_EP_BATCH_SIZE * dp_racks
+    model, optimizer = build_hero_configs(num_train_steps=HERO_SCHEDULE_STEPS, batch_size=batch_size)
+    config = RestoreBenchmarkConfig(
+        checkpoint_path=prefix_join(
+            marin_temp_bucket(ttl_days=CHECKPOINT_TTL_DAYS, prefix=f"restore-benchmark/{run_id}"), "checkpoint"
+        ),
+        model=dataclasses.replace(model, qb_estimator=QbEstimator.HIST, qb_hist_bins=QB_HIST_BINS),
+        optimizer=optimizer,
+        trainer=TrainerConfig(
+            id=run_id,
+            seed=0,
+            train_batch_size=batch_size,
+            num_train_steps=HERO_SCHEDULE_STEPS,
+            mp=jmp.get_policy(HERO_MIXED_PRECISION),
+            tracker=TelemetryConfig(),
+            use_explicit_mesh_axes=True,
+            require_accelerator=True,
+        ),
+        read=TensorStoreReadConfig(max_in_flight_bytes=budget_gib * GIB, request_concurrency=requests),
+        write=TensorStoreWriteConfig(max_staged_host_bytes=stage_gib * GIB),
+        repeats=repeats,
+        replica_axis_size=dp_racks,
+    )
+
+    _apply_hero_ep_runtime_defaults(inline_watch_enabled=False, processes_per_task=HERO_GPUS_PER_NODE)
+    dispatch_grug_training_run(
+        run_id=run_id,
+        config=config,
+        local_entrypoint=_run_restore_benchmark_local,
+        resources=ResourceConfig.with_gpu(
+            "GB200",
+            count=HERO_GPUS_PER_NODE,
+            cpu=120,
+            ram="890g",
+            disk="1t",
+            replicas=HERO_EP_NODES * dp_racks,
+        ),
+        processes_per_task=HERO_GPUS_PER_NODE,
+        max_retries_failure=0,
+        max_task_failures=0,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -101,6 +101,24 @@ class TrainingDataMode(StrEnum):
     SYNTHETIC = "synthetic"
 
 
+def restore_template_from(state):
+    """ShapeDtypeStructs carrying each leaf's concrete sharding, releasing the leaves.
+
+    `jax.eval_shape` drops the `pinned_host` memory kind that `initial_state` puts on
+    offloaded optimizer state, which is most of a hero checkpoint. Reading the sharding off a
+    built state keeps it.
+    """
+    template = jax.tree.map(
+        lambda leaf: (
+            jax.ShapeDtypeStruct(leaf.shape, leaf.dtype, sharding=leaf.sharding) if isinstance(leaf, jax.Array) else leaf
+        ),
+        state,
+    )
+    jax.tree.map(lambda leaf: leaf.delete() if isinstance(leaf, jax.Array) else None, state)
+    gc.collect()
+    return template
+
+
 def _apply_hero_ep_runtime_defaults(*, inline_watch_enabled: bool, processes_per_task: int = 1) -> None:
     env_defaults = dict(HERO_EP_RUNTIME_ENV)
     if processes_per_task > 1:
@@ -790,18 +808,7 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         state = _init_state(model_key)
         released_initial_state = trainer.load_checkpoint is not False and not trainer.allow_partial_checkpoint
         if released_initial_state:
-            restore_template = jax.tree.map(
-                lambda leaf: (
-                    jax.ShapeDtypeStruct(leaf.shape, leaf.dtype, sharding=leaf.sharding)
-                    if isinstance(leaf, jax.Array)
-                    else leaf
-                ),
-                state,
-            )
-            jax.tree.map(lambda leaf: leaf.delete() if isinstance(leaf, jax.Array) else None, state)
-            del state
-            gc.collect()
-            state = restore_template
+            state = restore_template_from(state)
 
         checkpointer = trainer.checkpointer.create(run_id) if config.trainer.save_checkpoints else None
         state = restore_grug_state_from_checkpoint(

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -8,6 +8,7 @@ import collections
 import logging
 import math
 import os
+import time
 import urllib.parse
 import zlib
 from dataclasses import dataclass
@@ -44,8 +45,6 @@ ARRAY_DRIVER = "zarr3"
 KVSTORE_DRIVER = "ocdbt"
 # JAX's memory kind for host memory a device can address. Offloaded optimizer state lives here.
 _HOST_MEMORY_KIND = "pinned_host"
-# JAX's default memory kind: buffers live in device (HBM) memory.
-_DEVICE_MEMORY_KIND = "device"
 # Chunks a save stages at once. The budget is per process, so a node holds it once per local
 # process. Four processes at 32 GiB each exhausted a GB200 node, and 16 GiB each still did: a
 # process carries about four times its budget in flight (_STAGED_BYTE_OVERHEAD) on top of its
@@ -53,9 +52,6 @@ _DEVICE_MEMORY_KIND = "device"
 _DEFAULT_STAGED_CHUNKS = 16
 # Host memory a staged byte occupies while its write is in flight, for reporting only.
 _STAGED_BYTE_OVERHEAD = 4
-# Host memory each process may hold in flight while a restore reads shards. JAX defaults to 32 GB
-# and the legacy path asked for 300, both far above what a save allows itself on the same node.
-_RESTORE_CONCURRENT_GB = 8
 
 
 def _format_gib(num_bytes: int) -> str:
@@ -170,6 +166,37 @@ class TensorStoreWriteConfig:
             raise ValueError(f"cache_pool_bytes must be non-negative, got {self.cache_pool_bytes}")
 
 
+# Every TensorStore concurrency knob a checkpoint read can reach, across kvstore drivers.
+_CONCURRENCY_RESOURCES = (
+    "data_copy_concurrency",
+    "s3_request_concurrency",
+    "gcs_request_concurrency",
+    "http_request_concurrency",
+    "file_io_concurrency",
+)
+
+
+@dataclass(frozen=True)
+class TensorStoreReadConfig:
+    """How a restore reads shards back."""
+
+    max_in_flight_bytes: int = 16 * 1024**3
+    """Host memory this process may hold in shards whose transfer has not drained."""
+
+    request_concurrency: int = 128
+    """Concurrent object-store requests. TensorStore defaults to 32, which on one GB200 rack
+    read a hero checkpoint in 125.6s against 96.9s at 128."""
+
+
+def _tensorstore_read_context(config: TensorStoreReadConfig) -> ts.Context:
+    """JAX's default context carrying this restore's concurrency."""
+    spec = ts_impl._TS_CONTEXT.spec.to_json()
+    # A driver ignores a resource it does not use, so set every store's knob together.
+    for resource in _CONCURRENCY_RESOURCES:
+        spec[resource] = {"limit": config.request_concurrency}
+    return ts.Context(spec)
+
+
 def _tensorstore_write_context(config: TensorStoreWriteConfig) -> ts.Context:
     spec = ts_impl._TS_CONTEXT.spec.to_json()
     spec["cache_pool"] = {"total_bytes_limit": config.cache_pool_bytes}
@@ -215,11 +242,12 @@ class _ShardWrite:
         return self.slice_axis, self.slice_start, self.slice_limit
 
 
-class _HostStagingGate:
-    """Track staged bytes until TensorStore has committed and released them.
+class _HostByteBudget:
+    """Bound the host memory one process holds in flight, for a save or a restore.
 
-    Shard writes pass ``can_reference_source_data_indefinitely=True``. The copy future
-    resolves while the snapshot is still referenced.
+    A save charges each staged snapshot until TensorStore commits it: shard writes pass
+    ``can_reference_source_data_indefinitely=True``, so the copy future resolves while the
+    snapshot is still referenced. A restore charges each shard until its transfer drains.
     """
 
     def __init__(self, limit_bytes: int):
@@ -234,7 +262,7 @@ class _HostStagingGate:
         return self._peak
 
     async def acquire(self, num_bytes: int) -> None:
-        # Built before the save's loop exists, so bind on first use.
+        # Built before its loop exists, so bind on first use.
         self._loop = asyncio.get_running_loop()
         # A snapshot larger than the whole budget proceeds alone; it can never be admitted.
         while self._in_flight and self._in_flight + num_bytes > self._limit:
@@ -608,7 +636,7 @@ def _serialize_arrays(
     # JAX's process-lifetime context accumulates caches across saves, since each save writes a
     # new OCDBT database (#6785). Give each save bounded caches and copy concurrency of its own.
     context = _tensorstore_write_context(config)
-    gate = _HostStagingGate(config.max_staged_host_bytes)
+    gate = _HostByteBudget(config.max_staged_host_bytes)
     commit_futures: list[ts.Future] = []
 
     async def issue_write(num_bytes: int, stage):
@@ -707,54 +735,87 @@ def _fully_replicated_sharding(mesh):
     return hax.partitioning.sharding_for_axis((), {}, mesh)
 
 
-async def _deserialize_leaf_to_memory_kind(sharding: Sharding, tensorstore_spec: dict) -> jax.Array:
-    """Read one array shard directly into its target memory kind."""
-    store = await ts.open(tensorstore_spec, open=True)
+async def _deserialize_leaf(
+    sharding: Sharding,
+    tensorstore_spec: dict,
+    *,
+    context: ts.Context,
+    budget: "_HostByteBudget",
+) -> jax.Array:
+    """Read every addressable shard of one array into its target memory kind."""
+    store = await ts.open(tensorstore_spec, open=True, context=context)
     shape = tuple(store.shape)
     dtype = jax.dtypes.canonicalize_dtype(store.dtype.numpy_dtype)
-    shard_shape = sharding.shard_shape(shape)
-    arrays = []
+    shard_shape = tuple(sharding.shard_shape(shape))
 
-    for device, index in sharding.addressable_devices_indices_map(shape).items():
+    async def read_shard(device: jax.Device, index) -> jax.Array:
         requested_domain = ts.IndexTransform(input_shape=shape)[index].domain
         restricted_domain = store.domain.intersect(requested_domain)
-        host_array = np.zeros(shard_shape, dtype=store.dtype.numpy_dtype)
-        await ts.array(host_array)[ts.d[:].translate_to[requested_domain.origin]][restricted_domain].write(
-            store[restricted_domain]
-        )
-        if host_array.dtype != dtype:
-            host_array = host_array.astype(dtype)
-        target = jax.sharding.SingleDeviceSharding(device, memory_kind=sharding.memory_kind)
-        array = jax.device_put(host_array, target)
-        array.block_until_ready()
-        arrays.append(array)
+        # Chunks arrive whole, so a shard off the chunk grid materializes more than its own size.
+        charge = ts_impl.estimate_read_memory_footprint(store, restricted_domain)
+        if store.dtype.numpy_dtype != dtype:
+            # The cast allocates a second buffer while the first is still alive.
+            charge += math.prod(shard_shape) * np.dtype(dtype).itemsize
 
-    return jax.make_array_from_single_device_arrays(shape, sharding, arrays)
+        await budget.acquire(charge)
+        try:
+            # The shard shape comes from the store's own shape, so the read covers every
+            # element and the buffer needs no fill first.
+            host_array = np.empty(shard_shape, dtype=store.dtype.numpy_dtype)
+            await ts.array(host_array)[ts.d[:].translate_to[requested_domain.origin]][restricted_domain].write(
+                store[restricted_domain]
+            )
+            if host_array.dtype != dtype:
+                host_array = host_array.astype(dtype)
+            target = jax.sharding.SingleDeviceSharding(device, memory_kind=sharding.memory_kind)
+            array = jax.device_put(host_array, target)
+            # Hold the charge until the transfer drains, so the budget bounds live host memory.
+            array.block_until_ready()
+            return array
+        finally:
+            budget.release(charge)
+
+    shards = await asyncio.gather(
+        *(read_shard(device, index) for device, index in sharding.addressable_devices_indices_map(shape).items())
+    )
+    return jax.make_array_from_single_device_arrays(shape, sharding, list(shards))
 
 
 def _deserialize_leaves(
-    manager: array_ser.GlobalAsyncCheckpointManager,
     shardings: list[Sharding],
     tensorstore_specs: list[dict],
+    config: TensorStoreReadConfig,
 ) -> list:
-    """Deserialize device leaves together and non-device leaves one at a time."""
-    leaves: list = [None] * len(shardings)
-    device_indices = [i for i, sharding in enumerate(shardings) if sharding.memory_kind in (None, _DEVICE_MEMORY_KIND)]
-    if device_indices:
-        device_leaves = manager.deserialize(
-            shardings=[shardings[i] for i in device_indices],
-            tensorstore_specs=[tensorstore_specs[i] for i in device_indices],
-            concurrent_gb=_RESTORE_CONCURRENT_GB,
+    """Read every leaf, concurrently, into the memory kind each leaf's sharding names.
+
+    One shared TensorStore context and one budget cover all the reads, so the budget bounds
+    this process's live shard bytes across the whole restore.
+    """
+    context = _tensorstore_read_context(config)
+    budget = _HostByteBudget(config.max_in_flight_bytes)
+
+    async def read_all():
+        return await asyncio.gather(
+            *(
+                _deserialize_leaf(sharding, spec, context=context, budget=budget)
+                for sharding, spec in zip(shardings, tensorstore_specs)
+            )
         )
-        for i, leaf in zip(device_indices, device_leaves):
-            leaves[i] = leaf
 
-    async def deserialize_non_device_leaves():
-        for i, sharding in enumerate(shardings):
-            if sharding.memory_kind not in (None, _DEVICE_MEMORY_KIND):
-                leaves[i] = await _deserialize_leaf_to_memory_kind(sharding, tensorstore_specs[i])
-
-    asyncio.run(deserialize_non_device_leaves())
+    started = time.time()
+    leaves = asyncio.run(read_all())
+    elapsed = time.time() - started
+    # `leaf.nbytes` is the global array; this process only read the shards it addresses.
+    read_bytes = sum(shard.data.nbytes for leaf in leaves for shard in leaf.addressable_shards)
+    logger.info(
+        "Restore read %s across %d arrays in %.1fs (%.2f GiB/s), peak %s of a %s budget",
+        _format_gib(read_bytes),
+        len(leaves),
+        elapsed,
+        read_bytes / 1024**3 / max(elapsed, 1e-9),
+        _format_gib(budget.peak_bytes),
+        _format_gib(config.max_in_flight_bytes),
+    )
     return leaves
 
 
@@ -764,7 +825,7 @@ def _restore_ocdbt(
     real_indices: list[int],
     shardings_leaves: list,
     leaf_key_paths,
-    manager: array_ser.GlobalAsyncCheckpointManager,
+    read_config: TensorStoreReadConfig,
     allow_missing: bool,
 ) -> tuple[list, list[int]]:
     """Restore arrays from an OCDBT checkpoint."""
@@ -813,7 +874,7 @@ def _restore_ocdbt(
         spec = _create_ocdbt_spec(checkpoint_root, path)
         tspecs_to_load.append(spec)
 
-    deser_leaves = _deserialize_leaves(manager, shardings_to_load, tspecs_to_load)
+    deser_leaves = _deserialize_leaves(shardings_to_load, tspecs_to_load, read_config)
     return deser_leaves, indices_to_load
 
 
@@ -823,7 +884,7 @@ def _restore_old_ts(
     real_indices: list[int],
     shardings_leaves: list,
     leaf_key_paths,
-    manager: array_ser.GlobalAsyncCheckpointManager,
+    read_config: TensorStoreReadConfig,
     allow_missing: bool,
 ) -> tuple[list, list[int]]:
     """Restore arrays from an old (non-OCDBT) tensorstore checkpoint."""
@@ -860,7 +921,7 @@ def _restore_old_ts(
             logger.warning(to_log)
 
     tspecs_to_load = [array_ser.get_tensorstore_spec(path) for path in paths_to_load]
-    deser_leaves = _deserialize_leaves(manager, shardings_to_load, tspecs_to_load)
+    deser_leaves = _deserialize_leaves(shardings_to_load, tspecs_to_load, read_config)
     return deser_leaves, indices_to_load
 
 
@@ -869,17 +930,16 @@ def tree_deserialize_leaves_tensorstore(
     pytree,
     axis_mapping: Optional[ResourceMapping] = None,
     mesh: Optional[Mesh] = None,
-    manager: Optional[array_ser.GlobalAsyncCheckpointManager] = None,
     *,
     allow_missing: bool = False,
+    read_config: Optional[TensorStoreReadConfig] = None,
 ):
     """Deserialize a checkpoint into the shape of ``pytree``.
 
     ``pytree`` may hold ShapeDtypeStructs from ``eval_shape``; ``axis_mapping`` and ``mesh``
     supply the shardings. ``allow_missing`` keeps absent leaves as they are.
     """
-    if manager is None:
-        manager = array_ser.GlobalAsyncCheckpointManager()
+    read_config = read_config or TensorStoreReadConfig()
 
     # Pre-charge the cross-region budget from the exemplar pytree, an upper bound under
     # `allow_missing=True`. See the save path.
@@ -936,11 +996,11 @@ def tree_deserialize_leaves_tensorstore(
             logger.info("Adjusting paths for OCDBT checkpoint with subpath: %s", subpath)
             paths = [os.path.join(subpath, p) for p in paths]
         deser_leaves, indices_to_load = _restore_ocdbt(
-            checkpoint_root, paths, real_indices, shardings_leaves, leaf_key_paths, manager, allow_missing
+            checkpoint_root, paths, real_indices, shardings_leaves, leaf_key_paths, read_config, allow_missing
         )
     else:
         deser_leaves, indices_to_load = _restore_old_ts(
-            checkpoint_dir, paths, real_indices, shardings_leaves, leaf_key_paths, manager, allow_missing
+            checkpoint_dir, paths, real_indices, shardings_leaves, leaf_key_paths, read_config, allow_missing
         )
 
     # now we need to recreate the original structure

--- a/lib/levanter/tests/test_tensorstore_serialization.py
+++ b/lib/levanter/tests/test_tensorstore_serialization.py
@@ -22,9 +22,10 @@ from levanter.checkpoint import load_checkpoint, save_checkpoint
 from levanter.checkpoint_manifest import CHECKPOINT_FORMAT_VERSION, manifest_path, read_manifest
 from levanter.models.gpt2 import Gpt2Mlp
 from levanter.tensorstore_serialization import (
+    TensorStoreReadConfig,
     TensorStoreWriteConfig,
     _capped_chunk_shape,
-    _HostStagingGate,
+    _HostByteBudget,
     _transfer_shard_to_pageable_host,
     tree_deserialize_leaves_tensorstore,
     tree_serialize_leaves_tensorstore,
@@ -279,7 +280,7 @@ def test_staged_bytes_stay_admitted_until_their_write_is_released():
     """TensorStore holds a shard snapshot until the commit, so admission must outlive the copy."""
 
     async def scenario():
-        gate = _HostStagingGate(100)
+        gate = _HostByteBudget(100)
         await gate.acquire(60)
 
         queued = asyncio.create_task(gate.acquire(60))
@@ -305,6 +306,33 @@ def test_a_save_larger_than_the_staging_budget_rolls_through_it():
                 tmpdir, state, write_config=TensorStoreWriteConfig(max_staged_host_bytes=32 * 1024)
             )
             restored = tree_deserialize_leaves_tensorstore(tmpdir, {name: hax.zeros(A) for name in state})
+
+        for name, expected in state.items():
+            assert hax.all(restored[name] == expected)
+
+
+@pytest.mark.parametrize(
+    "arrays, budget",
+    [
+        # One shard larger than the whole budget: it must be admitted anyway, or the read deadlocks.
+        (1, 1),
+        # Eight 16 KiB arrays through a budget admitting about two: the read rolls through it.
+        (8, 32 * 1024),
+    ],
+)
+def test_a_restore_completes_whatever_the_read_budget_admits(arrays, budget):
+    """Concurrent reads stay bounded by the budget and still return every array intact."""
+    with use_test_mesh():
+        A = hax.Axis("A", 4096)
+        state = {f"w{i}": hax.full(A, float(i)) for i in range(arrays)}
+
+        with TemporaryDirectory() as tmpdir:
+            tree_serialize_leaves_tensorstore(tmpdir, state)
+            restored = tree_deserialize_leaves_tensorstore(
+                tmpdir,
+                {name: hax.zeros(A) for name in state},
+                read_config=TensorStoreReadConfig(max_in_flight_bytes=budget),
+            )
 
         for name, expected in state.items():
             assert hax.all(restored[name] == expected)


### PR DESCRIPTION
A restore read one array at a time: offloaded leaves through a serial loop that reopened TensorStore per array, sharing neither cache nor request concurrency, and device leaves through JAX's path in a separate event loop. On the hero that is 80% of the checkpoint read serially at TensorStore's default of 32 concurrent requests.

Now every leaf reads at once against one shared context, bounded by a host-memory budget that holds each shard's charge until its device transfer drains. Defaults are 16 GiB in flight and 128 requests.

One GB200 rack, d6144 hero state, 91.19 GiB and 130 arrays per process, warm, fleet elapsed over 64 processes:

| read path | elapsed | host RSS/process |
| --- | --- | --- |
| one array at a time, 32 requests | 125.6s | 186.8 GiB |
| one array at a time, 128 requests | 96.9s | 186.8 GiB |
| all arrays, 16 GiB budget | 70.2s | 187.5 GiB |

1.8x for 0.7 GiB per process. A 48 GiB budget reaches 36.4s but OOM-killed a task at 219 GiB per process, so the budget stays at 16 GiB.

Cold reads are a different regime, 23m14s on the live hero against 1m55s warm, and are unchanged here.

`experiments/grug/moe_hero_ep/restore_benchmark.py` produced these numbers; `--budget-gib` and `--requests` sweep the knobs.