### PR TITLE
[rl] Quote SkyRL retention overrides so Hydra can parse them

### DIFF
--- a/lib/marin/src/marin/rl/skyrl.py
+++ b/lib/marin/src/marin/rl/skyrl.py
@@ -357,8 +357,8 @@ def skyrl_step(spec: SkyRLSpec, execution: IrisSkyRLExecution) -> ArtifactStep[S
         )
         retention_overrides = (
             f"++trainer.max_ckpts_to_keep={spec.retention.resume_checkpoint_count}",
-            f"++terminal_bench_config.trials_dir={prefix_join(attempts_root, 'trace_jobs')}",
-            f"++generator.trajectory_retention.output_path={prefix_join(attempts_root, 'trajectories')}",
+            f"++terminal_bench_config.trials_dir='{prefix_join(attempts_root, 'trace_jobs')}'",
+            f"++generator.trajectory_retention.output_path='{prefix_join(attempts_root, 'trajectories')}'",
         )
         request = SkyRLLaunchRequest(
             run_id=f"{step_name}-{spec.version}",

--- a/tests/rl/test_skyrl.py
+++ b/tests/rl/test_skyrl.py
@@ -186,10 +186,13 @@ def test_skyrl_step_routes_disposable_state_to_ttl_storage(
         resolved_config_uri=f"{output_path}/resolved-skyrl.json",
         terminal_manifest_uri=f"{output_path}/terminal.json",
     )
+    # The path values are single-quoted because they carry a ``ttl=<n>d`` segment and Hydra's
+    # override grammar rejects a bare value containing ``=``.
     assert config.request.overrides[-3:] == (
         "++trainer.max_ckpts_to_keep=2",
-        "++terminal_bench_config.trials_dir=" "s3://temp/ttl=14d/skyrl/users/alice/run/attempts/trace_jobs",
-        "++generator.trajectory_retention.output_path=" "s3://temp/ttl=14d/skyrl/users/alice/run/attempts/trajectories",
+        "++terminal_bench_config.trials_dir=" "'s3://temp/ttl=14d/skyrl/users/alice/run/attempts/trace_jobs'",
+        "++generator.trajectory_retention.output_path="
+        "'s3://temp/ttl=14d/skyrl/users/alice/run/attempts/trajectories'",
     )
 
 


### PR DESCRIPTION
The retention overrides are `++key=value` strings whose value is a temporary-storage path containing `ttl=14d`. Hydra sees the second `=` and refuses to parse it, so every SkyRL run launched from the Marin graph died just after its nodes were allocated. The value was never quoted.

```
++terminal_bench_config.trials_dir=s3://…/ttl=14d/…     mismatched input '=' expecting <EOF>
++terminal_bench_config.trials_dir='s3://…/ttl=14d/…'   parses, path unchanged
```

Confirmed on a live run: the RL stage failed with that error before the change and reached the training loop after it.

The existing test asserted the unquoted strings verbatim, which is why it stayed green. It now expects the quoted form.