### PR TITLE
grafana: separate hero retry loss and alert identity

### DIFF
--- a/docs/ops/training-loss-spike-alert.md
+++ b/docs/ops/training-loss-spike-alert.md
@@ -1,10 +1,10 @@
 # Hero training loss-spike alert
 
-`TrainingLossSpike` is a critical Grafana alert for active Iris root jobs named `hero-*-coord`. It posts one Slack message per root job and opens a Loom triage session on that thread, the same `notification=hero-run` route [`TrainingProgressStalled`](training-stall-alert-contract.md) uses. The alert does not kick, restart, or reconfigure a job; the decision it asks for is a person's, which is to keep training or to stop and resume from an earlier checkpoint.
+`TrainingLossSpike` is a critical Grafana alert for active Iris hero roots. It posts one Slack message per logical run. It uses the same `notification=hero-run` route as [`TrainingProgressStalled`](training-stall-alert-contract.md). The alert does not kick, restart, or configure a job. An operator decides whether to continue training or resume from an earlier checkpoint.
 
 It pages because a hero run diverging unwatched costs more than a false page does, and a silence answers a false page. Expect benign firings at mixture stage boundaries; silence the run for that window rather than widening the band for every run.
 
-Enrollment is the same contract as [`TrainingProgressStalled`](training-stall-alert-contract.md): a root job is eligible while its latest `iris.task_state` row is at most 90 seconds old, reports at least one running task, and matches `%/hero-%-coord`. Both rules read one enrollment query per bridge cache interval, so they share a single `iris.task_state` scan.
+Enrollment uses the [`TrainingProgressStalled`](training-stall-alert-contract.md) contract. A root matches `%/hero-%-coord` or `%/hero-%-coord-%`. The two rules share one `iris.task_state` query in each bridge cache interval.
 
 ## What fires it
 
@@ -23,11 +23,11 @@ The baseline is the run's own trailing history, so the band moves with training.
 
 A run reports `warming_up` with fewer than 20 baseline or 5 recent samples, and `healthy` otherwise. Both are zero-valued rows, which resolves a firing instance. With no eligible roots the bridge returns an explicit zero-valued `fleet` row; `noDataState: Alerting` is reserved for a malformed or unavailable response.
 
-`spiking` and `not_finite` are separate alert instances, but the route groups by root job and not by `reason`, so a run that spikes and then diverges to NaN threads under the message it already sent.
+`spiking` and `not_finite` are separate alert instances. The route groups by logical run. Thus, retries and reason changes use one notification group.
 
 ## When it fires
 
-1. Open the [Training run dashboard](https://grafana.oa.dev/d/marin-training) and select the run named in the alert. Its loss panel is the same `train_loss` series the rule reduces, and the spike panel puts the peak beside the optimizer's own rejection threshold and its skipped-step count.
+1. Open the [Training run dashboard](https://grafana.oa.dev/d/marin-training) and select the run in the alert. The step panel shows the continuous curve. The attempt panel shows restart gaps. The spike panel compares the peak, rejection threshold, and skipped-step count.
 2. Separate a data cause from a numerical one. A mixture stage boundary, a resumed run reading a different config, or a checkpoint restore all shift the level legitimately, and the run progress and optimizer panels date the change. A gradient norm climbing into the spike points at the optimizer.
 3. Check whether the optimizer absorbed it. Steps skipped during the window mean the update was rejected and the weights did not take the spike; a spike with no skipped steps entered the weights.
 4. Decide. Resuming from the last checkpoint before the rise costs the steps since it; letting a diverged run continue costs everything after it. `manage-hero-run` covers the rollback.

--- a/docs/ops/training-stall-alert-contract.md
+++ b/docs/ops/training-stall-alert-contract.md
@@ -15,7 +15,7 @@ An eligible job alerts when either condition holds:
 
 The first case is labeled `training_stalled`; the second is `initializing_stale`. Missing and stale optimizer progress share one label so a delayed sample cannot replace one firing alert instance with another. Finished and progressing jobs emit zero-valued rows, which removes the firing series and resolves its original fingerprint. An idle fleet also emits an explicit zero.
 
-The bridge derives `hero-20260819` from the root job, then queries the structured `telemetry_v1.run_id` column with exact equality. With concurrent hero runs it emits one `run_id IN (...)` predicate rather than a broad pattern scan. The newest `phase` row in the trailing hour selects one `execution_uid`; `step` and `progress_time_seconds` from older task attempts cannot keep the run healthy. Progress spans 30 minutes so a sample remains observable after crossing the 15-minute stall threshold.
+The bridge derives `hero-20260819` from the root job, then queries the structured `telemetry_v1.run_id` column with exact equality. With concurrent hero runs it emits one `run_id IN (...)` predicate rather than a broad pattern scan. The newest `phase` row in the trailing hour selects one `execution_uid`; `step` and `progress_time_seconds` from older task attempts cannot keep the run healthy. Iris derives `execution_uid` from the controller-minted `attempt_uid`, which stays unique if a new controller uses the same numeric task attempt. Progress spans 30 minutes so a sample remains observable after crossing the 15-minute stall threshold.
 
 Initialization and missing-progress grace start at the later of the current contiguous Iris running interval and the selected telemetry execution. A coordinator restart or trainer retry therefore receives a new initialization window. A hard hang retains its training execution anchor for one hour. All states remain instances of `TrainingProgressStalled`, and notification grouping excludes phase and reason, so later reclassification cannot open a second Slack group.
 
@@ -47,7 +47,7 @@ For an unsuffixed root, remove `-coord` to get `<hero-run-id>`. For a suffixed r
 
 Levanter republishes phase every minute. A current phase row binds progress to one execution. Finelog and telemetry health alerts cover loss of the durable telemetry path. Launcher-specific process watchdogs provide additional coverage where configured.
 
-Grafana routes `notification=hero-run` through `ops-critical`. It groups notifications by alert name and logical run. Thus, a new retry root stays in the same alert group. The bridge posts one Slack message and opens one Loom session. A four-hour repeat notification keeps the thread active. A resolution uses the same Slack thread. An idle fleet returns an explicit zero-valued `fleet/idle/healthy` row. The `noDataState: Alerting` state identifies an invalid or unavailable response.
+Grafana routes `notification=hero-run` through `ops-critical`. It groups notifications by alert name and logical run. Thus, a new retry root stays in the same alert group. The bridge keys the Slack thread on this group and retains it for six hours after a resolution. A replacement retry that finishes its pending period joins the existing thread. A four-hour repeat notification also keeps the thread active. An idle fleet returns an explicit zero-valued `fleet/idle/healthy` row. The `noDataState: Alerting` state identifies an invalid or unavailable response.
 
 ## NCCL RAS snapshots
 

--- a/docs/ops/training-stall-alert-contract.md
+++ b/docs/ops/training-stall-alert-contract.md
@@ -1,12 +1,12 @@
 # Hero training stall alert
 
-`TrainingProgressStalled` is a critical Grafana alert for active Iris root jobs named `hero-*-coord`. It posts one Slack message per root job and opens a Loom triage session on that thread. The alert does not kick, restart, or profile a job. Capture `iris process profile threads -t <task>` for the affected tasks before deciding whether to intervene.
+`TrainingProgressStalled` is a critical Grafana alert for active Iris hero roots. Permitted names are `<run-id>-coord` and `<run-id>-coord-<retry>`. It posts one Slack message per run and opens a Loom triage session on that thread. The alert does not kick, restart, or profile a job. Capture `iris process profile threads -t <task>` for the applicable tasks before an intervention.
 
 This alert watches whether a run is stepping. [`TrainingLossSpike`](training-loss-spike-alert.md) watches what those steps produce, over the same enrollment.
 
-The rule evaluates once a minute and waits five minutes before notifying. A root job is eligible while its latest `iris.task_state` row is at most 90 seconds old, reports at least one running task, and matches `%/hero-%-coord`. The namespace before the run name is unrestricted. `/rav/hero-20260819-coord` and `/another-user/hero-20260819-coord` therefore have the same enrollment behavior. Other Levanter runs remain visible in Grafana without sending hero-run notifications.
+The rule evaluates once a minute and waits five minutes before notification. An eligible root has a current `iris.task_state` row. The row is at most 90 seconds old and reports one or more running tasks. The root name matches `%/hero-%-coord` or `%/hero-%-coord-%`. The namespace before the run name is unrestricted.
 
-Hero alert enrollment is a launch naming contract: the coordinator root's last component must be `<run-id>-coord`, `<run-id>` must begin with `hero-`, and Levanter's trainer `id` must be the same `<run-id>`. The selector derives the exact structured telemetry key from that contract. Changing only the user namespace is safe; changing either identity independently opts the run out or prevents telemetry attribution.
+Hero alert enrollment is a launch naming contract. The last root component is `<run-id>-coord` or `<run-id>-coord-<retry>`. The `<run-id>` value begins with `hero-`. The Levanter trainer `id` is the same `<run-id>`. A retry suffix changes the Iris job identity only. It does not change the logical run identity.
 
 An eligible job alerts when either condition holds:
 
@@ -43,11 +43,11 @@ ORDER BY timestamp_ms DESC, seq DESC
 LIMIT 20;
 ```
 
-Use the root job's last path component without `-coord` as `<hero-run-id>`. An empty result indicates missing Levanter telemetry; the named root remains eligible and becomes `initializing_stale` after 45 minutes.
+For an unsuffixed root, remove `-coord` to get `<hero-run-id>`. For a suffixed root, also remove the retry suffix. An empty result identifies missing Levanter telemetry. The root becomes `initializing_stale` after 45 minutes.
 
 Levanter republishes phase every minute. A current phase row binds progress to one execution. Finelog and telemetry health alerts cover loss of the durable telemetry path. Launcher-specific process watchdogs provide additional coverage where configured.
 
-Grafana routes `notification=hero-run` through `ops-critical`, grouped by alert name, cluster, and root job. The bridge announces firing once in Slack, opens one Loom session, suppresses webhook retries, refreshes thread retention on four-hour repeat notifications, and posts resolution under the same Slack root. When there are no eligible roots, the bridge returns an explicit zero-valued `fleet/idle/healthy` row; `noDataState: Alerting` is reserved for a malformed or unavailable response. The critical contact point also includes email when SMTP is configured.
+Grafana routes `notification=hero-run` through `ops-critical`. It groups notifications by alert name and logical run. Thus, a new retry root stays in the same alert group. The bridge posts one Slack message and opens one Loom session. A four-hour repeat notification keeps the thread active. A resolution uses the same Slack thread. An idle fleet returns an explicit zero-valued `fleet/idle/healthy` row. The `noDataState: Alerting` state identifies an invalid or unavailable response.
 
 ## NCCL RAS snapshots
 

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -270,7 +270,9 @@ a run that moves between clusters keeps one set of series. The status strip is a
 single ten-field stat panel because a `telemetry_v1` scan costs what its window
 costs whatever it selects, and it carries both hero alert inputs — time since the
 last completed step and train loss — beside step time, throughput, schedule
-progress, skip-step rejections, eval loss, and device memory.
+progress, skip-step rejections, eval loss, and device memory. One loss panel uses
+step as its x-axis and keeps the newest sample for a repeated step. The wall-clock
+panel separates each `execution_uid` and disconnects gaps longer than five minutes.
 
 ## Alerting
 
@@ -291,13 +293,13 @@ nonterminal without finalizers for five minutes after the bridge's two-minute
 overdue threshold, and a GB200 rack with fewer than 16 trays Ready for five
 minutes (the NVL72 rack spec is 18; a floor rather than an outright outage —
 see `gpu_racks` above). The hero training rule selects fresh running
-`iris.task_state` roots named `hero-*-coord`, derives their run IDs, and reads exact
-matches from structured `service=levanter` telemetry. It waits 15 minutes for
+`iris.task_state` roots named `hero-*-coord` or `hero-*-coord-<retry>`. It derives
+their run IDs and reads exact matches from structured `service=levanter` telemetry. It waits 15 minutes for
 training progress or 45 minutes for initialization, then remains pending for five
 minutes. Its `notification=hero-run`
-route uses the critical receiver and groups each root job separately. It does not
-require task-to-node GPU attribution. The root suffix before `-coord` and the
-Levanter trainer ID must match; zero eligible roots produce an explicit healthy
+route uses the critical receiver and groups notifications by logical run. It does not
+require task-to-node GPU attribution. The run ID before `-coord` and the Levanter
+trainer ID must match; zero eligible roots produce an explicit healthy
 row. A second rule over the same enrolled roots watches their `train_loss`, firing
 when the lowest loss of the last five minutes clears the mean plus six standard
 deviations of the preceding 55, or when the loss stops being finite. Six sigma is

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -273,6 +273,9 @@ last completed step and train loss — beside step time, throughput, schedule
 progress, skip-step rejections, eval loss, and device memory. One loss panel uses
 step as its x-axis and keeps the newest sample for a repeated step. The wall-clock
 panel separates each `execution_uid` and disconnects gaps longer than five minutes.
+Iris forms this identity from the controller-minted `attempt_uid`. Thus, a new
+controller process cannot join loss from a prior process that used the same
+numeric task attempt.
 
 ## Alerting
 
@@ -377,17 +380,20 @@ The session link is threaded under the announcement.
 Distinct firing groups feed one live `Grafana operator` session; the operator can
 delegate independent incidents to child Loom sessions. Repeated notifications for
 the same alert fingerprint and start time reuse the same Loom run, and thread a
-short "still firing" note under the original announcement rather than posting
-again. Resolved notifications create no run and are noted on that same thread.
+short "still firing" note under the original announcement. The Slack thread key is
+the Grafana notification group key. A replacement alert instance in the same group
+therefore keeps the thread even when the prior instance first resolves. Resolved
+notifications create no run and are noted on that same thread.
 Ordering is deliberate: Slack first, so an alert reaches people even when Loom is
 unreachable, and that failure is reported into the thread instead of only into
 Grafana's notification history. A Slack failure is logged and still opens the
 triage session.
 
-Open threads are tracked in the bridge's memory, which is sound because Cloud Run
-runs this service at `min=max=1`. A revision rollover forgets them: the next
-notification for a still-firing alert announces afresh, and a resolution for an
-alert this revision never announced is dropped rather than posted bare.
+Open threads are tracked for six hours in the bridge's memory, which is sound
+because Cloud Run runs this service at `min=max=1`. A revision rollover forgets
+them: the next notification for a still-firing alert announces afresh, and a
+resolution for an alert this revision never announced is dropped rather than
+posted bare.
 
 The Loom Pulumi stack binds the exact `marin-grafana`
 service-account email and numeric subject to this profile. The Grafana stack

--- a/infra/grafana/dashboards/training.json
+++ b/infra/grafana/dashboards/training.json
@@ -455,8 +455,8 @@
     {
       "id": 2,
       "type": "timeseries",
-      "title": "Training loss",
-      "description": "Mean train loss per bucket. A step change up is a restart from an older checkpoint or a divergence; a flat line is a run that stopped stepping. The loss-spike alert reads the same metric, and fires when the lowest loss of the last five minutes clears the mean plus six standard deviations of the preceding 55, so a rise that lifts this whole curve for five minutes is what fires it.",
+      "title": "Training loss by attempt",
+      "description": "Wall-clock loss for each Iris execution. Grafana disconnects a series after five minutes without data. A new series identifies a restart. Compare the endpoints to find a resume loss change.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"
@@ -475,7 +475,8 @@
             "lineWidth": 2,
             "fillOpacity": 0,
             "showPoints": "never",
-            "spanNulls": false
+            "spanNulls": false,
+            "insertNulls": 300000
           }
         },
         "overrides": []
@@ -505,7 +506,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, AVG(value) AS train_loss FROM \"telemetry_v1\" WHERE service = 'levanter' AND name = 'train_loss' AND run_id IN (${run:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, execution_uid AS series, AVG(value) AS train_loss FROM \"telemetry_v1\" WHERE service = 'levanter' AND name = 'train_loss' AND run_id IN (${run:sqlstring}) AND execution_uid IS NOT NULL AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
               },
               {
                 "key": "from",
@@ -522,6 +523,92 @@
               "selector": "t",
               "text": "time",
               "type": "timestamp_epoch"
+            },
+            {
+              "selector": "series",
+              "text": "attempt",
+              "type": "string"
+            },
+            {
+              "selector": "train_loss",
+              "text": "train loss",
+              "type": "number"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "trend",
+      "title": "Training loss by step",
+      "description": "Training loss against Levanter step in the selected time range. For a repeated step, the newest sample wins. Use this panel for the continuous curve. Use the attempt panel for outages and restarts.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "showPoints": "never",
+            "spanNulls": false
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "xField": "step",
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "WITH paired AS (SELECT timestamp_ms, seq, execution_uid, name, value, MAX(CASE WHEN name = 'step' THEN value END) OVER (PARTITION BY execution_uid ORDER BY timestamp_ms, seq ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS step FROM \"telemetry_v1\" WHERE service = 'levanter' AND name IN ('step', 'train_loss') AND run_id IN (${run:sqlstring}) AND execution_uid IS NOT NULL AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT)), losses AS (SELECT step, value AS train_loss, timestamp_ms, seq, ROW_NUMBER() OVER (PARTITION BY step ORDER BY timestamp_ms DESC, seq DESC) AS rn FROM paired WHERE name = 'train_loss' AND step IS NOT NULL) SELECT step, train_loss FROM losses WHERE rn = 1 ORDER BY step"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "step",
+              "text": "step",
+              "type": "number"
             },
             {
               "selector": "train_loss",
@@ -544,8 +631,8 @@
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 12,
-        "y": 6
+        "x": 0,
+        "y": 15
       },
       "fieldConfig": {
         "defaults": {
@@ -680,7 +767,7 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
+        "x": 12,
         "y": 15
       },
       "fieldConfig": {
@@ -799,8 +886,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 15
+        "x": 0,
+        "y": 24
       },
       "fieldConfig": {
         "defaults": {
@@ -902,8 +989,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 23
+        "x": 12,
+        "y": 24
       },
       "fieldConfig": {
         "defaults": {
@@ -1005,8 +1092,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 23
+        "x": 0,
+        "y": 32
       },
       "fieldConfig": {
         "defaults": {
@@ -1104,8 +1191,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 31
+        "x": 12,
+        "y": 32
       },
       "fieldConfig": {
         "defaults": {
@@ -1189,8 +1276,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 31
+        "x": 0,
+        "y": 40
       },
       "fieldConfig": {
         "defaults": {

--- a/infra/grafana/provisioning/alerting/policies.yaml
+++ b/infra/grafana/provisioning/alerting/policies.yaml
@@ -20,7 +20,7 @@ policies:
         object_matchers:
           - ["notification", "=", "slack"]
       - receiver: ops-critical
-        group_by: ["alertname", "cluster", "job"]
+        group_by: ["alertname", "run"]
         object_matchers:
           - ["notification", "=", "hero-run"]
       - receiver: ops-slack

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -530,9 +530,9 @@ groups:
                 - evaluator: { type: gt, params: [0] }
 
   # Hero-run stalled-training detection. A fresh running task-state row whose
-  # root is named hero-*-coord enrolls the job. Structured run_id telemetry
-  # supplies current-execution progress; task-to-node GPU attribution is not
-  # required.
+  # root is named hero-*-coord or hero-*-coord-<retry> enrolls the job.
+  # Structured run_id telemetry supplies current-execution progress;
+  # task-to-node GPU attribution is not required.
   - orgId: 1
     name: training-progress
     folder: Alerts
@@ -566,6 +566,7 @@ groups:
               columns:
                 - { selector: cluster, text: cluster, type: string }
                 - { selector: job, text: job, type: string }
+                - { selector: run, text: run, type: string }
                 - { selector: phase, text: phase, type: string }
                 - { selector: reason, text: reason, type: string }
                 - { selector: value, text: value, type: number }

--- a/infra/grafana/src/hero_runs.py
+++ b/infra/grafana/src/hero_runs.py
@@ -3,11 +3,11 @@
 
 """Hero-run enrollment shared by the training alert projections.
 
-A root job is a hero run while its latest `iris.task_state` row is fresh, reports
-a running task, and its last path component is `<run-id>-coord` with `<run-id>`
-beginning with `hero-`. That naming contract also gives the exact `run_id` its
-Levanter telemetry carries, so an alert reads structured columns and never scans
-for a pattern. See docs/ops/training-stall-alert-contract.md.
+A root job is a hero run while its latest `iris.task_state` row is fresh and
+reports a running task. Its last path component is `<run-id>-coord` or
+`<run-id>-coord-<retry>`, and `<run-id>` begins with `hero-`. This naming
+contract also gives the exact `run_id` in its Levanter telemetry. See
+docs/ops/training-stall-alert-contract.md.
 """
 
 from dataclasses import dataclass
@@ -20,8 +20,11 @@ _TASK_STATE_FRESHNESS = timedelta(seconds=90)
 TASK_STATE_LOOKBACK = timedelta(hours=1)
 
 HERO_RUN_PREFIX = "hero-"
-_COORDINATOR_SUFFIX = "-coord"
-_HERO_ROOT_PATTERN = f"%/{HERO_RUN_PREFIX}%{_COORDINATOR_SUFFIX}"
+_COORDINATOR_MARKER = "-coord"
+_HERO_ROOT_PATTERNS = (
+    f"%/{HERO_RUN_PREFIX}%{_COORDINATOR_MARKER}",
+    f"%/{HERO_RUN_PREFIX}%{_COORDINATOR_MARKER}-%",
+)
 
 
 @dataclass(frozen=True)
@@ -50,11 +53,12 @@ def task_state_query(now: datetime) -> str:
     start = sql_timestamp(now - TASK_STATE_LOOKBACK)
     fresh = sql_timestamp(now - _TASK_STATE_FRESHNESS)
     end = sql_timestamp(now)
+    root_predicate = " OR ".join(f"root_job_id LIKE '{pattern}'" for pattern in _HERO_ROOT_PATTERNS)
     return (
         "WITH samples AS ("
         "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS cluster, root_job_id, ts, running "
         'FROM "iris.task_state" '
-        f"WHERE root_job_id LIKE '{_HERO_ROOT_PATTERN}' AND ts >= TIMESTAMP '{start}' "
+        f"WHERE ({root_predicate}) AND ts >= TIMESTAMP '{start}' "
         f"AND ts < TIMESTAMP '{end}'"
         "), segmented AS ("
         "SELECT cluster, root_job_id, ts, running, "
@@ -79,9 +83,11 @@ def task_state_query(now: datetime) -> str:
 
 def _run_id(root_job: str) -> str | None:
     root_name = root_job.rsplit("/", 1)[-1]
-    if not root_name.startswith(HERO_RUN_PREFIX) or not root_name.endswith(_COORDINATOR_SUFFIX):
+    run_id, marker, retry = root_name.rpartition(_COORDINATOR_MARKER)
+    if not marker or not run_id.startswith(HERO_RUN_PREFIX):
         return None
-    run_id = root_name.removesuffix(_COORDINATOR_SUFFIX)
+    if retry and not retry.startswith("-"):
+        return None
     return run_id if run_id != HERO_RUN_PREFIX else None
 
 

--- a/infra/grafana/src/loom_alerts.py
+++ b/infra/grafana/src/loom_alerts.py
@@ -5,9 +5,10 @@
 
 Every alert group arrives as a Grafana webhook and is announced with
 `chat.postMessage`, which returns the `channel`/`ts` naming a thread. One alert
-keeps one thread for its whole life: re-notifications and the resolution are
-posted under the original announcement, so a webhook retry adds nothing and a
-still-firing note appears only after the thread has been quiet.
+group keeps one thread while it is tracked: re-notifications, resolutions, and
+replacement alert instances are posted under the original announcement. Thus,
+a webhook retry adds nothing and a still-firing note appears only after the
+thread has been quiet.
 
 Two receivers share that behavior through `SlackAnnouncer` and differ in what
 follows. `LoomAlertClient` opens a Loom triage run naming the thread it just
@@ -79,10 +80,11 @@ class _Tracked:
     # alert creates a run, and Loom dedupes them to one session, so linking on
     # each would repeat the same line per retry and per re-notification.
     linked_session: str | None = None
+    resolved: bool = False
 
 
 class ThreadLog:
-    """Which Slack thread announced an alert, for the life of that alert.
+    """Which Slack thread announced a notification group while it is tracked.
 
     Entries expire after `ttl` and are capped at `max_entries`. Not safe for
     concurrent use from threads; callers are on one event loop.
@@ -119,17 +121,26 @@ class ThreadLog:
             tracked.posted_at = now
             tracked.expires_at = now + self._ttl
 
+    def mark_firing(self, key: str) -> None:
+        tracked = self._threads.get(key)
+        if tracked is not None:
+            tracked.resolved = False
+            self.mark_posted(key)
+
+    def mark_resolved(self, key: str) -> None:
+        tracked = self._threads.get(key)
+        if tracked is not None:
+            tracked.resolved = True
+            self.mark_posted(key)
+
     def mark_linked(self, key: str, session_id: str) -> None:
         tracked = self._threads.get(key)
         if tracked is not None:
             tracked.linked_session = session_id
 
-    def discard(self, key: str) -> None:
-        self._threads.pop(key, None)
-
 
 class SlackAnnouncer:
-    """Announce Grafana alert groups in one Slack channel, a thread per alert.
+    """Announce Grafana alert groups in one Slack channel, one thread per group.
 
     Owns the channel, the bot credential, and which thread announced which alert.
     One instance serves one receiver; two receivers keep separate thread logs
@@ -138,8 +149,8 @@ class SlackAnnouncer:
 
     def __init__(self, slack: SlackAlertConfig) -> None:
         self._slack = slack
-        # Alert identity to the thread announcing it. Keyed on identity rather
-        # than firing state so a resolution threads under the alert it resolves.
+        # A notification group maps to one thread through firing and resolved
+        # states, including a new alert instance from a replacement job.
         self._threads = ThreadLog(ttl=THREAD_TTL, max_entries=MAX_TRACKED_THREADS)
 
     async def announce(
@@ -157,6 +168,10 @@ class SlackAnnouncer:
         """
         tracked = self._threads.peek(thread_key)
         if tracked is not None:
+            if tracked.resolved:
+                await self.post(client, "Firing again after resolution.", thread=tracked.thread)
+                self._threads.mark_firing(thread_key)
+                return tracked.thread
             # Grafana retries a failed webhook within seconds, and re-notifies an
             # unresolved alert on its repeat_interval. Both land here; only the
             # second is news, so a quiet period separates them.
@@ -197,14 +212,17 @@ class SlackAnnouncer:
         "resolved" in the channel reads as noise.
         """
         tracked = self._threads.peek(thread_key)
-        if tracked is None:
+        if tracked is None or tracked.resolved:
             return
         await self.post(
             client,
             f"Resolved — {_alert_title(payload, _all_alerts(payload))}.",
             thread=tracked.thread,
         )
-        self._threads.discard(thread_key)
+        # A replacement job can remain pending after this alert instance
+        # resolves. Keep the group thread until its normal TTL so the new alert
+        # instance joins the same operator conversation.
+        self._threads.mark_resolved(thread_key)
 
     async def post(
         self,
@@ -449,20 +467,9 @@ def _idempotency_key(payload: object, alerts: list[Mapping[str, object]]) -> str
 
 
 def _thread_key(payload: object) -> str:
-    """Identify the alert group across its whole life, resolution included.
-
-    Names the thread every notification for the group shares, so it must not
-    depend on firing state. Grafana holds `fingerprint` and `startsAt` fixed for
-    as long as one alert instance lives, which is exactly that span.
-    """
+    """Identify the Grafana notification group, including replacement alerts."""
     assert isinstance(payload, Mapping)
-    identities = sorted(f"{alert.get('fingerprint', '')}@{alert.get('startsAt', '')}" for alert in _all_alerts(payload))
-    seed = json.dumps(
-        {"groupKey": str(payload.get("groupKey", "")), "alerts": identities},
-        sort_keys=True,
-        separators=(",", ":"),
-    )
-    return hashlib.sha256(seed.encode()).hexdigest()
+    return hashlib.sha256(str(payload.get("groupKey", "")).encode()).hexdigest()
 
 
 def _slack_escape(text: str) -> str:

--- a/infra/grafana/src/training_stalls.py
+++ b/infra/grafana/src/training_stalls.py
@@ -88,8 +88,8 @@ def _phase_name(phase: int | None) -> str:
     }.get(phase, "unknown")
 
 
-def _row(cluster: str, job: str, phase: str, reason: str, value: int) -> dict:
-    return {"cluster": cluster, "job": job, "phase": phase, "reason": reason, "value": value}
+def _row(cluster: str, job: str, run: str, phase: str, reason: str, value: int) -> dict:
+    return {"cluster": cluster, "job": job, "run": run, "phase": phase, "reason": reason, "value": value}
 
 
 @dataclass(frozen=True)
@@ -171,8 +171,9 @@ def training_stall_alert_rows(runs: tuple[HeroRun, ...], telemetry_metrics: pa.T
     observed = _metrics_by_job(runs, telemetry_metrics)
     now = as_utc(now)
     rows = [
-        _row(run.cluster, run.root_job, *_classify(run, observed.get((run.cluster, run.root_job)), now)) for run in runs
+        _row(run.cluster, run.root_job, run.run_id, *_classify(run, observed.get((run.cluster, run.root_job)), now))
+        for run in runs
     ]
     if rows:
         return rows
-    return [_row("fleet", "", "idle", "healthy", 0)]
+    return [_row("fleet", "", "", "idle", "healthy", 0)]

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -327,10 +327,10 @@ def test_hero_alerts_enroll_suffixed_retry_roots():
     )
 
     task_states = database.execute(task_state_query(now)).fetch_arrow_table()
-    assert [(run.root_job, run.run_id) for run in active_hero_runs(task_states)] == [
+    assert {(run.root_job, run.run_id) for run in active_hero_runs(task_states)} == {
         ("/power/hero-12d8b6f0-dee637-coord-slop85", "hero-12d8b6f0-dee637"),
         ("/power/hero-other-coord", "hero-other"),
-    ]
+    }
 
 
 def test_training_stall_alert_selects_named_hero_run_and_resolves_on_progress():

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -253,6 +253,7 @@ def test_training_stall_alerts_distinguish_stale_missing_and_healthy_progress():
         {
             "cluster": "cw-a",
             "job": "/u/hero-stale-coord",
+            "run": "hero-stale",
             "phase": "training",
             "reason": "training_stalled",
             "value": 1,
@@ -260,6 +261,7 @@ def test_training_stall_alerts_distinguish_stale_missing_and_healthy_progress():
         {
             "cluster": "cw-a",
             "job": "/u/hero-initializing-coord",
+            "run": "hero-initializing",
             "phase": "initializing",
             "reason": "initializing_stale",
             "value": 1,
@@ -267,6 +269,7 @@ def test_training_stall_alerts_distinguish_stale_missing_and_healthy_progress():
         {
             "cluster": "cw-b",
             "job": "/u/hero-healthy-coord",
+            "run": "hero-healthy",
             "phase": "training",
             "reason": "healthy",
             "value": 0,
@@ -274,6 +277,7 @@ def test_training_stall_alerts_distinguish_stale_missing_and_healthy_progress():
         {
             "cluster": "cw-b",
             "job": "/another-user/hero-starting-coord",
+            "run": "hero-starting",
             "phase": "initializing",
             "reason": "initializing",
             "value": 0,
@@ -283,7 +287,7 @@ def test_training_stall_alerts_distinguish_stale_missing_and_healthy_progress():
 
 def test_training_stall_alert_returns_explicit_zero_without_running_jobs():
     assert training_stall_alert_rows((), pa.table({}), datetime(2026, 7, 28, tzinfo=UTC)) == [
-        {"cluster": "fleet", "job": "", "phase": "idle", "reason": "healthy", "value": 0}
+        {"cluster": "fleet", "job": "", "run": "", "phase": "idle", "reason": "healthy", "value": 0}
     ]
 
 
@@ -305,6 +309,28 @@ def test_training_stall_task_state_resets_running_age_after_retry():
 
     (row,) = database.execute(task_state_query(now)).fetchall()
     assert row[3] == now.replace(tzinfo=None) - timedelta(minutes=5)
+
+
+def test_hero_alerts_enroll_suffixed_retry_roots():
+    now = datetime(2026, 8, 20, 23, 30, tzinfo=UTC)
+    database = duckdb.connect()
+    database.execute(
+        'CREATE TABLE "iris.task_state"(cluster VARCHAR, root_job_id VARCHAR, ts TIMESTAMP, running BIGINT)'
+    )
+    database.executemany(
+        'INSERT INTO "iris.task_state" VALUES (?, ?, ?, ?)',
+        [
+            ("cw-a", "/power/hero-12d8b6f0-dee637-coord-slop85", now - timedelta(seconds=30), 64),
+            ("cw-a", "/power/hero-other-coord", now - timedelta(seconds=30), 64),
+            ("cw-a", "/power/not-hero-coord-slop85", now - timedelta(seconds=30), 64),
+        ],
+    )
+
+    task_states = database.execute(task_state_query(now)).fetch_arrow_table()
+    assert [(run.root_job, run.run_id) for run in active_hero_runs(task_states)] == [
+        ("/power/hero-12d8b6f0-dee637-coord-slop85", "hero-12d8b6f0-dee637"),
+        ("/power/hero-other-coord", "hero-other"),
+    ]
 
 
 def test_training_stall_alert_selects_named_hero_run_and_resolves_on_progress():
@@ -397,6 +423,7 @@ def test_training_stall_alert_selects_named_hero_run_and_resolves_on_progress():
         {
             "cluster": "cw-a",
             "job": "/rav/hero-20260819-coord",
+            "run": "hero-20260819",
             "phase": "training",
             "reason": "training_stalled",
             "value": 1,
@@ -422,6 +449,7 @@ def test_training_stall_alert_selects_named_hero_run_and_resolves_on_progress():
         {
             "cluster": "cw-a",
             "job": "/rav/hero-20260819-coord",
+            "run": "hero-20260819",
             "phase": "training",
             "reason": "healthy",
             "value": 0,
@@ -450,6 +478,7 @@ def test_training_stall_alert_gives_a_new_execution_its_own_initialization_windo
         {
             "cluster": "cw-a",
             "job": "/u/hero-retry-coord",
+            "run": "hero-retry",
             "phase": "initializing",
             "reason": "initializing",
             "value": 0,

--- a/infra/grafana/tests/test_loom_alerts.py
+++ b/infra/grafana/tests/test_loom_alerts.py
@@ -136,21 +136,29 @@ def alert_payload(status: str = "firing") -> dict:
     }
 
 
-def hero_stall_payload(status: str = "firing") -> dict:
+def hero_stall_payload(
+    status: str = "firing",
+    *,
+    job: str = "/root/hero-run-coord",
+    fingerprint: str = "hero123",
+    starts_at: str = "2026-07-23T12:00:00Z",
+) -> dict:
     payload = alert_payload(status)
     labels = {
         "alertname": "TrainingProgressStalled",
         "cluster": "cw-a",
-        "job": "/root/hero-run",
+        "job": job,
         "reason": "training_stalled",
+        "run": "hero-run",
         "severity": "critical",
     }
-    payload["groupKey"] = '{}:{alertname="TrainingProgressStalled", cluster="cw-a", job="/root/hero-run"}'
+    payload["groupKey"] = '{}:{alertname="TrainingProgressStalled", run="hero-run"}'
     payload["commonLabels"] = labels
-    payload["commonAnnotations"] = {"summary": "cw-a: /root/hero-run has training_stalled"}
+    payload["commonAnnotations"] = {"summary": f"cw-a: {job} has training_stalled"}
     payload["alerts"][0]["labels"] = labels
-    payload["alerts"][0]["annotations"]["summary"] = "cw-a: /root/hero-run has training_stalled"
-    payload["alerts"][0]["fingerprint"] = "hero123"
+    payload["alerts"][0]["annotations"]["summary"] = f"cw-a: {job} has training_stalled"
+    payload["alerts"][0]["fingerprint"] = fingerprint
+    payload["alerts"][0]["startsAt"] = starts_at
     return payload
 
 
@@ -260,10 +268,40 @@ def test_hero_stall_repeats_keep_one_thread_until_resolution(monkeypatch):
 
     assert len(slack.roots) == 1
     assert "TrainingProgressStalled on cw-a" in slack.roots[0]["text"]
-    assert "/root/hero-run" in slack.roots[0]["text"]
+    assert "/root/hero-run-coord" in slack.roots[0]["text"]
     assert len(slack.replies) == 3
     assert any("Resolved" in text for text in slack.reply_texts)
     assert all(reply["thread_ts"] == "1700000000.000001" for reply in slack.replies)
+
+
+def test_hero_retry_replacement_reuses_thread_after_old_job_resolves(monkeypatch):
+    clock = [0.0]
+    monkeypatch.setattr(loom_alerts.time, "monotonic", lambda: clock[0])
+    runs: list[dict] = []
+    slack = FakeSlack()
+    client = client_for(slack, runs=runs)
+
+    old_job = hero_stall_payload()
+    asyncio.run(client.submit(old_job))
+    clock[0] = 60
+    asyncio.run(client.submit(hero_stall_payload(status="resolved")))
+    clock[0] = 6 * 60
+    asyncio.run(
+        client.submit(
+            hero_stall_payload(
+                job="/root/hero-run-coord-1",
+                fingerprint="hero456",
+                starts_at="2026-07-23T12:06:00Z",
+            )
+        )
+    )
+
+    assert len(slack.roots) == 1
+    assert any("Resolved" in text for text in slack.reply_texts)
+    assert "Firing again after resolution." in slack.reply_texts
+    assert all(reply["thread_ts"] == "1700000000.000001" for reply in slack.replies)
+    assert runs[1]["slack"] == runs[0]["slack"]
+    assert runs[1]["idempotency_key"] != runs[0]["idempotency_key"]
 
 
 def test_a_resolution_for_an_unannounced_alert_says_nothing():

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -7,9 +7,11 @@ dashboard datasources exist. These files only otherwise fail inside a deployed
 Grafana, which is the most expensive place to find out."""
 
 import re
+from datetime import UTC, datetime
 from pathlib import Path
 from urllib.parse import urlsplit
 
+import duckdb
 import pyarrow as pa
 import yaml
 from config import CLUSTERS, K8S_CLUSTERS, ClusterTarget
@@ -330,7 +332,8 @@ def test_training_stall_alert_pages_each_hero_run_after_five_minutes():
         )
     )
     assert route["receiver"] == "ops-critical"
-    assert route["group_by"] == ["alertname", "cluster", "job"]
+    assert route["group_by"] == ["alertname", "run"]
+    assert {column["selector"] for column in rule["data"][0]["model"]["columns"]} >= {"run", "job"}
 
 
 def test_clusters_dashboard_shows_finelog_fleet_health():
@@ -613,3 +616,69 @@ def test_cluster_series_keep_one_colour_across_dashboards():
                 (colour,) = [p["value"]["fixedColor"] for p in override["properties"] if p["id"] == "color"]
                 assert colours.setdefault(series, colour) == colour, f"{name}: {series} changes colour"
     assert len(colours) >= len(CLUSTERS)
+
+
+def test_training_dashboard_separates_attempt_loss_and_step_loss():
+    dashboard = _stitched_dashboards()["training.json"]
+    panels = {panel["title"]: panel for panel in _all_panels(dashboard)}
+
+    attempt_panel = panels["Training loss by attempt"]
+    attempt_sql = _panel_sql({**dashboard, "panels": [attempt_panel]})[0]
+    assert attempt_panel["type"] == "timeseries"
+    assert attempt_panel["fieldConfig"]["defaults"]["custom"]["insertNulls"] == 300_000
+    assert "execution_uid AS series" in attempt_sql
+    assert "GROUP BY 1, 2" in attempt_sql
+    assert {column["selector"] for column in attempt_panel["targets"][0]["columns"]} == {
+        "t",
+        "series",
+        "train_loss",
+    }
+
+    step_panel = panels["Training loss by step"]
+    step_sql = _panel_sql({**dashboard, "panels": [step_panel]})[0]
+    assert step_panel["type"] == "trend"
+    assert step_panel["options"]["xField"] == "step"
+    assert "PARTITION BY execution_uid" in step_sql
+    assert "PARTITION BY step ORDER BY timestamp_ms DESC, seq DESC" in step_sql
+    assert {column["selector"] for column in step_panel["targets"][0]["columns"]} == {
+        "step",
+        "train_loss",
+    }
+
+
+def test_training_loss_by_step_uses_the_newest_retry_sample():
+    dashboard = _stitched_dashboards()["training.json"]
+    panel = next(panel for panel in _all_panels(dashboard) if panel["title"] == "Training loss by step")
+    sql = _panel_sql({**dashboard, "panels": [panel]})[0]
+    sql = sql.replace("${run:sqlstring}", "'hero-run'")
+    sql = sql.replace("{{from}}", "TIMESTAMP '2026-08-20 00:00:00'")
+    sql = sql.replace("{{to}}", "TIMESTAMP '2026-08-21 00:00:00'")
+
+    database = duckdb.connect()
+    database.execute(
+        """
+        CREATE TABLE telemetry_v1(
+            service VARCHAR,
+            run_id VARCHAR,
+            execution_uid VARCHAR,
+            name VARCHAR,
+            value DOUBLE,
+            timestamp_ms BIGINT,
+            seq BIGINT
+        )
+        """
+    )
+    at = int(datetime(2026, 8, 20, 12, tzinfo=UTC).timestamp() * 1000)
+    database.executemany(
+        "INSERT INTO telemetry_v1 VALUES ('levanter', 'hero-run', ?, ?, ?, ?, ?)",
+        [
+            ("attempt-1", "step", 10, at, 1),
+            ("attempt-1", "train_loss", 2.0, at, 2),
+            ("attempt-1", "step", 11, at + 1_000, 3),
+            ("attempt-1", "train_loss", 1.9, at + 1_000, 4),
+            ("attempt-2", "step", 10, at + 2_000, 1),
+            ("attempt-2", "train_loss", 2.2, at + 2_000, 2),
+        ],
+    )
+
+    assert database.execute(sql).fetchall() == [(10.0, 2.2), (11.0, 1.9)]

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -618,28 +618,6 @@ def test_cluster_series_keep_one_colour_across_dashboards():
     assert len(colours) >= len(CLUSTERS)
 
 
-def test_training_dashboard_separates_attempt_loss_and_step_loss():
-    dashboard = _stitched_dashboards()["training.json"]
-    panels = {panel["title"]: panel for panel in _all_panels(dashboard)}
-
-    attempt_panel = panels["Training loss by attempt"]
-    assert attempt_panel["type"] == "timeseries"
-    assert attempt_panel["fieldConfig"]["defaults"]["custom"]["insertNulls"] == 300_000
-    assert {column["selector"] for column in attempt_panel["targets"][0]["columns"]} == {
-        "t",
-        "series",
-        "train_loss",
-    }
-
-    step_panel = panels["Training loss by step"]
-    assert step_panel["type"] == "trend"
-    assert step_panel["options"]["xField"] == "step"
-    assert {column["selector"] for column in step_panel["targets"][0]["columns"]} == {
-        "step",
-        "train_loss",
-    }
-
-
 def test_training_loss_by_attempt_separates_process_incarnations():
     dashboard = _stitched_dashboards()["training.json"]
     panel = next(panel for panel in _all_panels(dashboard) if panel["title"] == "Training loss by attempt")

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -623,11 +623,8 @@ def test_training_dashboard_separates_attempt_loss_and_step_loss():
     panels = {panel["title"]: panel for panel in _all_panels(dashboard)}
 
     attempt_panel = panels["Training loss by attempt"]
-    attempt_sql = _panel_sql({**dashboard, "panels": [attempt_panel]})[0]
     assert attempt_panel["type"] == "timeseries"
     assert attempt_panel["fieldConfig"]["defaults"]["custom"]["insertNulls"] == 300_000
-    assert "execution_uid AS series" in attempt_sql
-    assert "GROUP BY 1, 2" in attempt_sql
     assert {column["selector"] for column in attempt_panel["targets"][0]["columns"]} == {
         "t",
         "series",
@@ -635,15 +632,52 @@ def test_training_dashboard_separates_attempt_loss_and_step_loss():
     }
 
     step_panel = panels["Training loss by step"]
-    step_sql = _panel_sql({**dashboard, "panels": [step_panel]})[0]
     assert step_panel["type"] == "trend"
     assert step_panel["options"]["xField"] == "step"
-    assert "PARTITION BY execution_uid" in step_sql
-    assert "PARTITION BY step ORDER BY timestamp_ms DESC, seq DESC" in step_sql
     assert {column["selector"] for column in step_panel["targets"][0]["columns"]} == {
         "step",
         "train_loss",
     }
+
+
+def test_training_loss_by_attempt_separates_process_incarnations():
+    dashboard = _stitched_dashboards()["training.json"]
+    panel = next(panel for panel in _all_panels(dashboard) if panel["title"] == "Training loss by attempt")
+    sql = _panel_sql({**dashboard, "panels": [panel]})[0]
+    sql = sql.replace("${__interval_ms}", "60000")
+    sql = sql.replace("${run:sqlstring}", "'hero-run'")
+    sql = sql.replace("{{from}}", "TIMESTAMP '2026-08-20 00:00:00'")
+    sql = sql.replace("{{to}}", "TIMESTAMP '2026-08-21 00:00:00'")
+
+    database = duckdb.connect()
+    database.execute("CREATE MACRO to_timestamp_millis(value) AS epoch_ms(value)")
+    database.execute("CREATE MACRO date_bin(bucket, value) AS time_bucket(bucket, value)")
+    database.execute(
+        """
+        CREATE TABLE telemetry_v1(
+            service VARCHAR,
+            run_id VARCHAR,
+            execution_uid VARCHAR,
+            name VARCHAR,
+            value DOUBLE,
+            timestamp_ms BIGINT
+        )
+        """
+    )
+    at = int(datetime(2026, 8, 20, 12, tzinfo=UTC).timestamp() * 1000)
+    database.executemany(
+        "INSERT INTO telemetry_v1 VALUES ('levanter', 'hero-run', ?, 'train_loss', ?, ?)",
+        [
+            ("iris:controller-attempt-first", 2.0, at),
+            ("iris:controller-attempt-first", 1.8, at + 10_000),
+            ("iris:controller-attempt-second", 2.4, at + 20_000),
+        ],
+    )
+
+    assert database.execute(sql).fetchall() == [
+        (datetime(2026, 8, 20, 12), "iris:controller-attempt-first", 1.9),
+        (datetime(2026, 8, 20, 12), "iris:controller-attempt-second", 2.4),
+    ]
 
 
 def test_training_loss_by_step_uses_the_newest_retry_sample():

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -786,6 +786,7 @@ def _build_pod_manifest(
     iris_env = build_common_iris_env(
         task_id=run_req.task_id,
         attempt_id=run_req.attempt_id,
+        attempt_uid=run_req.attempt_uid,
         num_tasks=run_req.num_tasks,
         bundle_id=run_req.bundle_id,
         controller_address=config.controller_address,

--- a/lib/iris/src/iris/cluster/client/job_info.py
+++ b/lib/iris/src/iris/cluster/client/job_info.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass, field
 from google.protobuf import json_format
 
 from iris.cluster.constraints import Constraint
+from iris.cluster.runtime.env import IRIS_ATTEMPT_UID_ENV
 from iris.cluster.types import JobName, TaskAttempt
 from iris.rpc import job_pb2
 
@@ -29,6 +30,7 @@ class JobInfo:
     task_id: JobName
     num_tasks: int = 1
     attempt_id: int = 0
+    attempt_uid: str | None = None
     worker_id: str | None = None
     bundle_id: str | None = None
 
@@ -107,6 +109,7 @@ def get_job_info() -> JobInfo | None:
             task_id=task_id,
             num_tasks=int(os.environ.get("IRIS_NUM_TASKS", "1")),
             attempt_id=attempt_id,
+            attempt_uid=os.environ.get(IRIS_ATTEMPT_UID_ENV),
             worker_id=os.environ.get("IRIS_WORKER_ID"),
             controller_address=os.environ.get("IRIS_CONTROLLER_ADDRESS"),
             advertise_host=os.environ.get("IRIS_ADVERTISE_HOST", "127.0.0.1"),

--- a/lib/iris/src/iris/cluster/runtime/env.py
+++ b/lib/iris/src/iris/cluster/runtime/env.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 IRIS_SLICE_COUNT = "IRIS_SLICE_COUNT"
 IRIS_TASKS_PER_SLICE = "IRIS_TASKS_PER_SLICE"
+IRIS_ATTEMPT_UID_ENV = "IRIS_ATTEMPT_UID"
 IRIS_NODE_NAME_ENV = "IRIS_NODE_NAME"
 IRIS_NAMESPACE_ENV = "IRIS_NAMESPACE"
 
@@ -164,6 +165,7 @@ def build_common_iris_env(
     *,
     task_id: str,
     attempt_id: int,
+    attempt_uid: str,
     num_tasks: int,
     bundle_id: str,
     controller_address: str | None,
@@ -189,6 +191,8 @@ def build_common_iris_env(
     # backend.
     wire_task_id = f"{task_id}:{attempt_id}"
     env["IRIS_TASK_ID"] = wire_task_id
+    if attempt_uid:
+        env[IRIS_ATTEMPT_UID_ENV] = attempt_uid
     env["IRIS_NUM_TASKS"] = str(num_tasks)
     env["IRIS_BUNDLE_ID"] = bundle_id
 

--- a/lib/iris/src/iris/cluster/worker/task_attempt.py
+++ b/lib/iris/src/iris/cluster/worker/task_attempt.py
@@ -27,7 +27,7 @@ from iris.cluster.bundle import BundleStore
 from iris.cluster.log_keys import INJECTED_ERROR_SOURCE, STDERR_SOURCE, classify_log_level, task_log_key
 from iris.cluster.platforms.types import probe_outbound_ip
 from iris.cluster.runtime.docker import DockerContainerHandle
-from iris.cluster.runtime.env import STANDARD_MOUNTS, build_common_iris_env
+from iris.cluster.runtime.env import IRIS_ATTEMPT_UID_ENV, STANDARD_MOUNTS, build_common_iris_env
 from iris.cluster.runtime.types import (
     ContainerConfig,
     ContainerErrorKind,
@@ -713,6 +713,11 @@ class TaskAttempt:
 
         env.update(self._task_env)
         env.update(dict(self.request.environment.env_vars))
+        # The controller owns the process-incarnation identity. User and cluster
+        # env cannot replace it with a value shared by two attempts.
+        env.pop(IRIS_ATTEMPT_UID_ENV, None)
+        if attempt_uid := iris_env.get(IRIS_ATTEMPT_UID_ENV):
+            env[IRIS_ATTEMPT_UID_ENV] = attempt_uid
 
         # Get RuntimeEntrypoint proto directly
         rt_ep = self.request.entrypoint

--- a/lib/iris/src/iris/cluster/worker/task_attempt.py
+++ b/lib/iris/src/iris/cluster/worker/task_attempt.py
@@ -142,6 +142,7 @@ def build_iris_env(
     env = build_common_iris_env(
         task_id=req.task_id,
         attempt_id=task.attempt_id,
+        attempt_uid=str(task.attempt_uid),
         num_tasks=task.num_tasks,
         bundle_id=req.bundle_id,
         controller_address=controller_address,

--- a/lib/iris/src/iris/runtime/telemetry.py
+++ b/lib/iris/src/iris/runtime/telemetry.py
@@ -61,6 +61,8 @@ def _identity(job_info: JobInfo, process_index: int | None) -> dict[str, str]:
 
 
 def _execution_uid(job_info: JobInfo) -> str:
+    if job_info.attempt_uid:
+        return f"iris:{job_info.attempt_uid}"
     return f"iris:{job_info.task_id}:attempt:{job_info.attempt_id}"
 
 

--- a/lib/iris/src/iris/testing/k8s.py
+++ b/lib/iris/src/iris/testing/k8s.py
@@ -258,6 +258,7 @@ def common_env_from_req(
     return build_common_iris_env(
         task_id=req.task_id,
         attempt_id=req.attempt_id,
+        attempt_uid=req.attempt_uid,
         num_tasks=req.num_tasks,
         bundle_id=req.bundle_id,
         controller_address=controller_address,

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -1007,13 +1007,14 @@ def test_host_network_omitted_when_disabled():
 
 def test_iris_env_vars_injected():
     """Pod manifest includes IRIS_TASK_ID, IRIS_NUM_TASKS, and other system vars."""
-    req = make_run_req("/test-job/0")
+    req = make_run_req("/test-job/0", attempt_uid="controller-attempt-abc123")
     req.num_tasks = 4
     req.bundle_id = "bundle-abc"
     manifest = _build_pod_manifest(req, pod_config(controller_address="http://ctrl:8080"))
 
     env_by_name = {e["name"]: e for e in manifest["spec"]["containers"][0]["env"]}
     assert env_by_name["IRIS_TASK_ID"]["value"] == "/test-job/0:0"
+    assert env_by_name["IRIS_ATTEMPT_UID"]["value"] == "controller-attempt-abc123"
     assert env_by_name["IRIS_NUM_TASKS"]["value"] == "4"
     assert env_by_name["IRIS_BUNDLE_ID"]["value"] == "bundle-abc"
     assert env_by_name["IRIS_CONTROLLER_ADDRESS"]["value"] == "http://ctrl:8080"

--- a/lib/iris/tests/cluster/runtime/test_env_parity.py
+++ b/lib/iris/tests/cluster/runtime/test_env_parity.py
@@ -26,6 +26,7 @@ from iris.rpc import job_pb2
 def _make_req(
     task_id: str = "/my-job/task-0",
     attempt_id: int = 0,
+    attempt_uid: str = "attempt-uid-abc",
     num_tasks: int = 1,
     bundle_id: str = "bundle-abc",
     setup_scripts: list[str] | None = None,
@@ -39,6 +40,7 @@ def _make_req(
     req = job_pb2.RunTaskRequest()
     req.task_id = task_id
     req.attempt_id = attempt_id
+    req.attempt_uid = attempt_uid
     req.num_tasks = num_tasks
     req.bundle_id = bundle_id
     req.entrypoint.run_command.argv.extend(["python", "train.py"])
@@ -62,6 +64,7 @@ def _common_env(req: job_pb2.RunTaskRequest, controller_address: str | None = No
     return build_common_iris_env(
         task_id=req.task_id,
         attempt_id=req.attempt_id,
+        attempt_uid=req.attempt_uid,
         num_tasks=req.num_tasks,
         bundle_id=req.bundle_id,
         controller_address=controller_address,

--- a/lib/iris/tests/cluster/worker/test_worker.py
+++ b/lib/iris/tests/cluster/worker/test_worker.py
@@ -667,6 +667,7 @@ def test_env_merge_precedence(mock_bundle_store, mock_runtime, tmp_path):
     assert env["JOB_ONLY"] == "from_job"
     # Iris system vars are always injected.
     assert "IRIS_TASK_ID" in env
+    assert env["IRIS_ATTEMPT_UID"] == "uid-env-test"
 
 
 def test_task_image_override_uses_request_value(mock_bundle_store, mock_runtime, tmp_path):

--- a/lib/iris/tests/cluster/worker/test_worker.py
+++ b/lib/iris/tests/cluster/worker/test_worker.py
@@ -616,14 +616,15 @@ def test_port_env_vars_set(mock_worker, mock_runtime):
 
 
 def test_env_merge_precedence(mock_bundle_store, mock_runtime, tmp_path):
-    """Job-level env vars win over task_env, which wins over iris system vars.
+    """Job env wins over task defaults without replacing attempt identity.
 
     The merge order in _create_container is:
       1. iris system vars (IRIS_TASK_ID, etc.)
       2. task_env (worker-level defaults, overrides iris vars)
-      3. job-level env_vars (from the request, wins over everything user-visible)
+      3. job-level env_vars (from the request, wins over user-visible values)
+      4. controller-owned attempt identity
 
-    This test verifies the observable precedence: job > default > absent.
+    This test verifies the observable precedence and reserved identity.
     """
     config = WorkerConfig(
         port=0,
@@ -631,7 +632,11 @@ def test_env_merge_precedence(mock_bundle_store, mock_runtime, tmp_path):
         poll_interval=Duration.from_seconds(0.1),
         cache_dir=tmp_path / "cache",
         default_task_image="mock-image",
-        task_env={"SHARED_KEY": "default_value", "DEFAULT_ONLY": "from_default"},
+        task_env={
+            "SHARED_KEY": "default_value",
+            "DEFAULT_ONLY": "from_default",
+            "IRIS_ATTEMPT_UID": "stale-cluster-value",
+        },
     )
     w = Worker(config, bundle_store=mock_bundle_store, container_runtime=mock_runtime)
 
@@ -646,7 +651,11 @@ def test_env_merge_precedence(mock_bundle_store, mock_runtime, tmp_path):
         attempt_uid="uid-env-test",
         entrypoint=Entrypoint.from_callable(_fn).to_proto(),
         environment=job_pb2.EnvironmentConfig(
-            env_vars={"SHARED_KEY": "job_value", "JOB_ONLY": "from_job"},
+            env_vars={
+                "SHARED_KEY": "job_value",
+                "JOB_ONLY": "from_job",
+                "IRIS_ATTEMPT_UID": "shared-job-value",
+            },
         ),
         bundle_id="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=512 * 1024**2),

--- a/lib/iris/tests/runtime/test_telemetry.py
+++ b/lib/iris/tests/runtime/test_telemetry.py
@@ -108,6 +108,7 @@ def test_configure_stamps_canonical_resource_identity(
         task_id=JobName.from_wire("/alice/train/worker/3"),
         worker_id="w-7",
         attempt_id=1,
+        attempt_uid="controller-attempt-abc123",
     )
     with _iris_metadata(info, telemetry_receiver.endpoint):
         telemetry.configure(
@@ -129,9 +130,37 @@ def test_configure_stamps_canonical_resource_identity(
             "model_revision": "abc123",
             "role": "trainer",
             "run_id": "pretrain-42",
-            "execution_uid": "iris:/alice/train/worker/3:attempt:1",
+            "execution_uid": "iris:controller-attempt-abc123",
         },
     }
+
+
+def test_configure_separates_reused_numeric_attempts(telemetry_receiver: TelemetryReceiver) -> None:
+    first = JobInfo(
+        task_id=JobName.from_wire("/alice/train/0"),
+        attempt_id=0,
+        attempt_uid="controller-attempt-first",
+    )
+    with _iris_metadata(first, telemetry_receiver.endpoint):
+        telemetry.configure("levanter", run_id="run-42")
+        rigging_telemetry.gauge("identity_probe").set(1)
+    rigging_telemetry.shutdown(0.1)
+    first_execution_uid = telemetry_receiver.latest_resource()["attributes"]["execution_uid"]
+
+    telemetry_receiver.received.clear()
+    second = JobInfo(
+        task_id=JobName.from_wire("/alice/train/0"),
+        attempt_id=0,
+        attempt_uid="controller-attempt-second",
+    )
+    with _iris_metadata(second, telemetry_receiver.endpoint):
+        telemetry.configure("levanter", run_id="run-42")
+        rigging_telemetry.gauge("identity_probe").set(1)
+    rigging_telemetry.shutdown(0.1)
+    second_execution_uid = telemetry_receiver.latest_resource()["attributes"]["execution_uid"]
+
+    assert first_execution_uid == "iris:controller-attempt-first"
+    assert second_execution_uid == "iris:controller-attempt-second"
 
 
 def test_vllm_resource_exposes_serving_job_join(telemetry_receiver: TelemetryReceiver) -> None:


### PR DESCRIPTION
* part of #7795
* split wall-clock `train_loss` by process incarnation and disconnect gaps longer than five minutes
  * `hero-12d8b6f0-dee637` joined steps 1468 and 1469 across a 105-minute gap
  * pass the controller-minted `attempt_uid` into task telemetry so a controller restart cannot reuse an execution series
  * protect that identity from cluster and job environment overrides on worker-backed tasks
* add a step-axis loss curve that keeps the newest sample for each repeated step
* enroll `<run-id>-coord-<retry>` roots and group hero notifications by stable `run_id`
* retain the Slack notification-group thread when an old retry resolves before its replacement fires