### PR TITLE
[levanter] Raise the checkpoint staging budget to 16 GiB

### DIFF
--- a/lib/levanter/docs/reference/Configuration.md
+++ b/lib/levanter/docs/reference/Configuration.md
@@ -178,7 +178,7 @@ rolls through it.
 | `checkpointer.write.max_write_replicas`    | Cap on how many replicas of an array write part of it. `1` disables replica splitting. | 1024    |
 | `checkpointer.write.min_replica_slice_bytes` | Do not split an array when doing so would give each replica less than this.          | 16 MiB  |
 | `checkpointer.write.max_chunk_bytes`       | Upper bound on one zarr3 chunk, which bounds a single object store write.              | 512 MiB |
-| `checkpointer.write.max_staged_host_bytes` | Cap on host memory one process stages at once during a save.                           | 8 GiB   |
+| `checkpointer.write.max_staged_host_bytes` | Cap on host memory one process stages at once during a save.                           | 16 GiB  |
 | `checkpointer.write.cache_pool_bytes`      | Soft limit for each TensorStore write cache.                                            | 1 GiB   |
 | `checkpointer.write.data_copy_concurrency` | Maximum CPU concurrency TensorStore uses to copy and encode checkpoint data.           | 16      |
 

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -47,10 +47,11 @@ _HOST_MEMORY_KIND = "pinned_host"
 # JAX's default memory kind: buffers live in device (HBM) memory.
 _DEVICE_MEMORY_KIND = "device"
 # Chunks a save stages at once. The budget is per process, so a node holds it once per local
-# process. Four processes at 32 GiB each exhausted a GB200 node, and 16 GiB each still did: a
-# process carries about four times its budget in flight (_STAGED_BYTE_OVERHEAD) on top of its
-# resident shard of the offloaded state.
-_DEFAULT_STAGED_CHUNKS = 16
+# process, and a process carries about four times what it holds in flight
+# (_STAGED_BYTE_OVERHEAD) on top of its resident shard of the offloaded state. A save blocks
+# training only for the bytes it must stage past this budget. In-flight bytes are bounded by a
+# process's share of the write, so a budget above that share never binds.
+_DEFAULT_STAGED_CHUNKS = 32
 # Host memory a staged byte occupies while its write is in flight, for reporting only.
 _STAGED_BYTE_OVERHEAD = 4
 # Host memory each process may hold in flight while a restore reads shards. JAX defaults to 32 GB


### PR DESCRIPTION
A save blocks training until every staged write is admitted through a per-process host-memory budget, so it stalls for `(share - budget) / upload rate`. A process whose share fits under the budget never waits.

At hero scale the checkpoint is 4993 GiB and each array's write splits across 8 replicas rather than 11, since no dimension divides by 11. That leaves 512 of 704 processes staging 9.75 GiB against an 8 GiB budget, and the 1.75 GiB overhang blocked training for 9m15s at a ~64 minute interval, 14% of wall clock. A 16 GiB budget puts the whole share under it, taking commits off the blocking path.

In-flight bytes are bounded by the share, not the budget, so hero peak in-flight rises only from 8 to 9.75 GiB, about 28 GiB per node against the 890 GiB request from #8499. A config whose share exceeds 16 GiB holds the full budget, roughly 64 GiB per process with staging overhead, which is the regime #8469 lowered this constant for.

One rack has a 78 GiB share and cannot reach the target regime, so this rests on the model rather than a direct measurement: at an 8 GiB budget the save staged in 130.1s against 130s predicted, being 117s of overhang at 0.60 GiB/s plus about 13s of copy.