### PR TITLE
[grug] Keep offloaded optimizer scalars on the active mesh

### DIFF
--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -512,8 +512,13 @@ def _tree_to_memory_kind(tree, memory_kind: str):
         sharding = jax.typeof(leaf).sharding
         mesh = getattr(sharding, "mesh", None)
         if mesh is None or len(getattr(mesh, "axis_names", ())) == 0:
-            # Scalar optimizer metadata carries no named mesh and is negligible in HBM.
-            return leaf
+            if jax.sharding.get_abstract_mesh().empty:
+                return leaf
+            # Scalar optimizer metadata has no operand from which to inherit the active mesh.
+            # Bind it before changing memory kind so the initial and updated states have the
+            # same JIT input signature.
+            leaf = jax.sharding.reshard(leaf, P())
+            sharding = jax.typeof(leaf).sharding
         return jax.device_put(leaf, sharding.with_memory_kind(memory_kind))
 
     return jax.tree.map(_move, tree)

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -798,7 +798,10 @@ def test_offloaded_optimizer_scalar_state_uses_the_active_mesh():
             )
         )
 
-    assert state.opt_state[0].count.sharding == NamedSharding(mesh, P())
+    count_sharding = state.opt_state[0].count.sharding
+    assert isinstance(count_sharding, NamedSharding)
+    assert count_sharding.mesh == mesh
+    assert count_sharding.spec == P()
 
 
 def test_fp32_host_master_accumulates_updates_before_bfloat16_cast(monkeypatch):

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -779,6 +779,28 @@ def test_inline_watch_computes_stats_on_every_train_step(monkeypatch):
     np.testing.assert_allclose(step_one_stats["grad/norm/total"], 3.2)
 
 
+def test_offloaded_optimizer_scalar_state_uses_the_active_mesh():
+    mesh = AbstractMesh(
+        axis_sizes=(1, 1, 1, 1),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(AxisType.Explicit,) * 4,
+    )
+
+    with use_abstract_mesh(mesh):
+        state = eqx.filter_eval_shape(
+            lambda: train.initial_state(
+                _latent_config(),
+                optimizer=optax.adam(0.1),
+                mp=jmp.get_policy("f32"),
+                key=jax.random.key(0),
+                ema_beta=None,
+                offload_opt_state=True,
+            )
+        )
+
+    assert state.opt_state[0].count.sharding == NamedSharding(mesh, P())
+
+
 def test_fp32_host_master_accumulates_updates_before_bfloat16_cast(monkeypatch):
     params = _TinyWatchModel(weight=jnp.array(1.0, dtype=jnp.bfloat16))
     master_params = _TinyWatchModel(weight=jnp.array(1.0, dtype=jnp.float32))


### PR DESCRIPTION
Keep empty-mesh optimizer metadata on the active mesh before transferring offloaded state to pinned host memory.

The EP hero initialized Adam's scalar count on device, while the first train step returned it from pinned host. That input-memory-kind change forced a second train-step compile after every process restart. The observed d6144 resume spent about 90 seconds on the second compilation.

A one-H100, two-step reproduction had two cached train-step signatures before the change and one afterward; all train-state leaf signatures now remain stable.
