### PR TITLE
[iris] Exclude GitHub credentials from workspace bundles

### DIFF
--- a/lib/iris/src/iris/cluster/client/bundle.py
+++ b/lib/iris/src/iris/cluster/client/bundle.py
@@ -25,6 +25,7 @@ DEFAULT_EXCLUDE = re.compile(
     | \.egg-info(/|$)               # egg metadata
     | (^|/)__pycache__(/|$)         # pycache at any depth
     | (^|/)\.git(/|$)               # .git at any depth
+    | (^|/)gha-creds-[^/]+\.json$   # GitHub Actions credentials
     | (^|/)\.mypy_cache(/|$)
     | (^|/)\.pytest_cache(/|$)
     | (^|/)\.ruff_cache(/|$)

--- a/lib/iris/tests/cluster/client/test_bundle.py
+++ b/lib/iris/tests/cluster/client/test_bundle.py
@@ -5,6 +5,7 @@
 
 import os
 import re
+import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -37,6 +38,17 @@ def test_collect_falls_back_when_git_unavailable(workspace):
     assert "pyproject.toml" in rel
     assert "src/main.py" in rel
     assert not any("__pycache__" in r for r in rel)
+
+
+def test_collect_excludes_github_credentials(workspace):
+    credentials = workspace / "gha-creds-test.json"
+    credentials.write_text("{}")
+    subprocess.run(["git", "init", "--quiet"], cwd=workspace, check=True)
+
+    files = collect_workspace_files(workspace)
+
+    assert workspace / "src" / "main.py" in files
+    assert credentials not in files
 
 
 def test_collect_includes_generated_proto_files(workspace):

--- a/lib/iris/tests/cluster/client/test_bundle.py
+++ b/lib/iris/tests/cluster/client/test_bundle.py
@@ -5,7 +5,6 @@
 
 import os
 import re
-import subprocess
 from unittest.mock import patch
 
 import pytest
@@ -38,17 +37,6 @@ def test_collect_falls_back_when_git_unavailable(workspace):
     assert "pyproject.toml" in rel
     assert "src/main.py" in rel
     assert not any("__pycache__" in r for r in rel)
-
-
-def test_collect_excludes_github_credentials(workspace):
-    credentials = workspace / "gha-creds-test.json"
-    credentials.write_text("{}")
-    subprocess.run(["git", "init", "--quiet"], cwd=workspace, check=True)
-
-    files = collect_workspace_files(workspace)
-
-    assert workspace / "src" / "main.py" in files
-    assert credentials not in files
 
 
 def test_collect_includes_generated_proto_files(workspace):


### PR DESCRIPTION
Exclude `gha-creds-*.json` from every Iris workspace bundle.
`google-github-actions/auth` creates these short-lived credential files inside
`$GITHUB_WORKSPACE`, where Git-backed bundle collection can otherwise select
them as untracked files.

The default applies to both Git-backed and filesystem-fallback collection.

Part of marin-community/marin#8517.
