### PR TITLE
[levanter] Move the eight-device checkpoint helper onto the testing package

### DIFF
--- a/lib/levanter/src/levanter/testing/eight_device_checkpoints.py
+++ b/lib/levanter/src/levanter/testing/eight_device_checkpoints.py
@@ -4,9 +4,9 @@
 """Checkpoint-write scenarios that need more devices than the test process has.
 
 An array needs eight devices to have more than one replica, and the XLA device count is
-fixed for the life of a process, so :func:`run_on_eight_devices` spawns one. The scenarios
-live here because a spawned child imports the module its target came from, and the test
-module's name under xdist is not importable from a fresh interpreter.
+fixed for the life of a process, so :func:`run_on_eight_devices` spawns one. A spawned child
+imports the module its target came from, so the scenarios live on the installed package,
+where any interpreter can import them regardless of its working directory.
 """
 
 import multiprocessing

--- a/lib/levanter/tests/test_tensorstore_serialization.py
+++ b/lib/levanter/tests/test_tensorstore_serialization.py
@@ -29,8 +29,8 @@ from levanter.tensorstore_serialization import (
     tree_deserialize_leaves_tensorstore,
     tree_serialize_leaves_tensorstore,
 )
-import eight_device_checkpoints
-from eight_device_checkpoints import run_on_eight_devices
+from levanter.testing import eight_device_checkpoints
+from levanter.testing.eight_device_checkpoints import run_on_eight_devices
 
 
 def test_pageable_checkpoint_staging_detaches_from_donated_jax_buffer():


### PR DESCRIPTION
`tests/eight_device_checkpoints.py` was importable only when pytest's rootdir was `lib/levanter`, so `infra/ci/run_tests.py`, which runs from the repository root, failed to collect `test_tensorstore_serialization.py` with `ModuleNotFoundError: No module named 'eight_device_checkpoints'`.

It now sits in `levanter.testing` beside the other shared test support. That also removes the constraint the module documented: `run_on_eight_devices` pickles a scenario by qualified name and the spawned child imports the module it came from, which an installed package satisfies from any working directory.

Its 28 tests now pass from both roots.