### PR TITLE
[ci] Upload only package distributions

### DIFF
--- a/.github/workflows/marin-release-libs-wheels.yaml
+++ b/.github/workflows/marin-release-libs-wheels.yaml
@@ -151,7 +151,9 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: package-${{ matrix.package }}-${{ matrix.operation }}
-          path: dist/*
+          path: |
+            dist/*.whl
+            dist/*.tar.gz
           if-no-files-found: error
 
   publish:


### PR DESCRIPTION
Upload only wheels and source distributions from package build jobs. The Iris
build-stamp hook leaves a scratch `_build_info.py` in `dist/`; uploading it made
release verification reject the package family before publication in
[run 32339186318](https://github.com/marin-community/marin/actions/runs/32339186318).

The verifier still rejects unexpected files in the downloaded release artifact.

Part of #8517.
