### PR TITLE
[grafana] Stop gating Evalchemy health on duration

### DIFF
--- a/infra/grafana/src/nightly_config.py
+++ b/infra/grafana/src/nightly_config.py
@@ -187,8 +187,8 @@ NIGHTLY_LANES: tuple[NightlyLane, ...] = (
         active_from="2026-07-14",
         active_until=None,
         overdue_grace_minutes=240,
-        expected_min_seconds=14 * 60,
-        expected_max_seconds=20 * 60,
+        expected_min_seconds=None,
+        expected_max_seconds=None,
     ),
     NightlyLane(
         id="harbor",

--- a/infra/grafana/src/nightly_config.py
+++ b/infra/grafana/src/nightly_config.py
@@ -187,8 +187,8 @@ NIGHTLY_LANES: tuple[NightlyLane, ...] = (
         active_from="2026-07-14",
         active_until=None,
         overdue_grace_minutes=240,
-        expected_min_seconds=None,
-        expected_max_seconds=None,
+        expected_min_seconds=0,
+        expected_max_seconds=20 * 60,
     ),
     NightlyLane(
         id="harbor",


### PR DESCRIPTION
Treat a successful Evalchemy nightly as healthy regardless of wall-clock
duration. Iris may select different compatible TPUs, so the old 14-minute
minimum turned valid fast runs red.

Keep the 20-minute upper bound as a yellow performance warning. The Evalchemy
workflow retains its 60-minute timeout and strengthens its sample and score
gates in marin-community/evalchemy#91.
