### PR TITLE
[grafana] Accept fast Harbor nightlies

### DIFF
--- a/infra/grafana/src/nightly_config.py
+++ b/infra/grafana/src/nightly_config.py
@@ -205,7 +205,7 @@ NIGHTLY_LANES: tuple[NightlyLane, ...] = (
         active_from="2026-07-15",
         active_until=None,
         overdue_grace_minutes=240,
-        expected_min_seconds=6 * 60,
+        expected_min_seconds=0,
         expected_max_seconds=12 * 60,
     ),
     NightlyLane(


### PR DESCRIPTION
Treat successful Harbor runs as healthy regardless of how quickly they finish. [Harbor run 32464147831](https://github.com/marin-community/harbor/actions/runs/32464147831) completed in 333 seconds and passed its trial, verifier-reward, output-token, unexpected-error, and wall-clock gates. The six-minute dashboard floor marked it unhealthy.

Keep the 12-minute upper duration warning. Harbor's workflow continues to reject empty generations and incomplete evaluation runs.
