### PR TITLE
[finelog] Make CLI queries shell-safe and schemas discoverable

### DIFF
--- a/.agents/skills/query-inference-metrics/SKILL.md
+++ b/.agents/skills/query-inference-metrics/SKILL.md
@@ -10,7 +10,9 @@ Native vLLM `/metrics` snapshots are exported directly to Finelog every 15 secon
 Run SQL from a Marin checkout:
 
 ```sh
-uv run finelog query marin "<SQL>" --format table
+uv run finelog query marin --format table <<'SQL'
+<SQL>
+SQL
 ```
 
 Use the federated `marin` hub unless a task specifically requires a cluster-local view.

--- a/lib/finelog/OPS.md
+++ b/lib/finelog/OPS.md
@@ -38,6 +38,30 @@ sets `client_url`:
 uv run finelog query marin 'SELECT * FROM "iris.profile" LIMIT 10'
 ```
 
+`query` prints JSONL by default. Pass a short query as one shell-quoted
+argument. Feed multiline SQL on stdin so SQL quotes do not need shell escaping:
+
+```bash
+uv run finelog query cw-us-east-08a <<'SQL'
+SELECT task_id, attempt_id, max(memory_peak_mb) AS peak_mib
+FROM "iris.task"
+WHERE task_id LIKE '/power/example/%'
+GROUP BY task_id, attempt_id
+ORDER BY peak_mib DESC
+SQL
+```
+
+List every namespace with its schema, index policy, retention overrides, and
+current storage statistics as JSONL. Fetch one schema as formatted JSON:
+
+```bash
+uv run finelog namespaces cw-us-east-08a
+uv run finelog schema cw-us-east-08a iris.task
+```
+
+Schema output includes `seq` under `implicit_columns`. Finelog assigns this
+column to every row; producers do not declare it, but SQL queries can select it.
+
 ## Diagnosing query latency
 
 Inspect the namespace before changing its policy or resetting it. Record its row

--- a/lib/finelog/src/finelog/client/__init__.py
+++ b/lib/finelog/src/finelog/client/__init__.py
@@ -23,19 +23,3 @@ from finelog.errors import (
     StatsError,
 )
 from finelog.policy import StoragePolicy
-
-__all__ = [
-    "FlushResult",
-    "InvalidNamespaceError",
-    "LogClient",
-    "NamespaceInfo",
-    "NamespaceNotFoundError",
-    "QueryResultTooLargeError",
-    "RemoteLogHandler",
-    "SchemaConflictError",
-    "SchemaValidationError",
-    "StatsError",
-    "StoragePolicy",
-    "Table",
-    "schema_from_dataclass",
-]

--- a/lib/finelog/src/finelog/client/__init__.py
+++ b/lib/finelog/src/finelog/client/__init__.py
@@ -12,7 +12,7 @@ The error types live in :mod:`finelog.errors` and are re-exported here so
 callers can ``from finelog.client import SchemaConflictError`` etc.
 """
 
-from finelog.client.log_client import FlushResult, LogClient, Table, schema_from_dataclass
+from finelog.client.log_client import FlushResult, LogClient, NamespaceInfo, Table, schema_from_dataclass
 from finelog.client.remote_log_handler import RemoteLogHandler
 from finelog.errors import (
     InvalidNamespaceError,
@@ -28,6 +28,7 @@ __all__ = [
     "FlushResult",
     "InvalidNamespaceError",
     "LogClient",
+    "NamespaceInfo",
     "NamespaceNotFoundError",
     "QueryResultTooLargeError",
     "RemoteLogHandler",

--- a/lib/finelog/src/finelog/client/log_client.py
+++ b/lib/finelog/src/finelog/client/log_client.py
@@ -488,6 +488,7 @@ class Table:
 
 
 _ClientT = TypeVar("_ClientT")
+_ResponseT = TypeVar("_ResponseT")
 
 
 class LogClient:
@@ -614,16 +615,7 @@ class LogClient:
 
     def list_namespaces(self) -> list[NamespaceInfo]:
         """Return every queryable namespace with its schema and storage statistics."""
-        client = self._get_stats_client()
-        try:
-            response = client.list_namespaces(stats_pb2.ListNamespacesRequest())
-        except ConnectError as exc:
-            if is_retryable_error(exc):
-                self._invalidate(_format_exc_summary(exc))
-            raise _translate_connect_error(exc) from exc
-        except (ConnectionError, OSError, TimeoutError) as exc:
-            self._invalidate(_format_exc_summary(exc))
-            raise
+        response = self._stats_rpc(lambda client: client.list_namespaces(stats_pb2.ListNamespacesRequest()))
         return [
             NamespaceInfo(
                 namespace=info.namespace,
@@ -640,16 +632,9 @@ class LogClient:
 
     def get_table_schema(self, namespace: str) -> Schema:
         """Return the registered schema for ``namespace`` without creating a Table handle."""
-        client = self._get_stats_client()
-        try:
-            response = client.get_table_schema(stats_pb2.GetTableSchemaRequest(namespace=namespace))
-        except ConnectError as exc:
-            if is_retryable_error(exc):
-                self._invalidate(_format_exc_summary(exc))
-            raise _translate_connect_error(exc) from exc
-        except (ConnectionError, OSError, TimeoutError) as exc:
-            self._invalidate(_format_exc_summary(exc))
-            raise
+        response = self._stats_rpc(
+            lambda client: client.get_table_schema(stats_pb2.GetTableSchemaRequest(namespace=namespace))
+        )
         return schema_from_proto(response.schema)
 
     def flush(self, timeout: float | None = None) -> FlushResult:
@@ -846,9 +831,14 @@ class LogClient:
             log_service_client.close()
 
     def _stats_query(self, sql: str) -> pa.Table:
+        response = self._stats_rpc(lambda client: client.query(stats_pb2.QueryRequest(sql=sql)))
+        reader = paipc.open_stream(pa.BufferReader(bytes(response.arrow_ipc)))
+        return reader.read_all()
+
+    def _stats_rpc(self, call: Callable[[StatsServiceClientSync], _ResponseT]) -> _ResponseT:
         client = self._get_stats_client()
         try:
-            response = client.query(stats_pb2.QueryRequest(sql=sql))
+            return call(client)
         except ConnectError as exc:
             if is_retryable_error(exc):
                 self._invalidate(_format_exc_summary(exc))
@@ -856,8 +846,6 @@ class LogClient:
         except (ConnectionError, OSError, TimeoutError) as exc:
             self._invalidate(_format_exc_summary(exc))
             raise
-        reader = paipc.open_stream(pa.BufferReader(bytes(response.arrow_ipc)))
-        return reader.read_all()
 
     def _stats_flush(self, namespace: str, batch: pa.RecordBatch) -> None:
         sink = io.BytesIO()

--- a/lib/finelog/src/finelog/client/log_client.py
+++ b/lib/finelog/src/finelog/client/log_client.py
@@ -93,6 +93,20 @@ class FlushResult(StrEnum):
     TIMEOUT = "timeout"
 
 
+@dataclass(frozen=True)
+class NamespaceInfo:
+    """Registered namespace schema and current storage statistics."""
+
+    namespace: str
+    schema: Schema
+    row_count: int
+    byte_size: int
+    min_seq: int
+    max_seq: int
+    segment_count: int
+    storage_policy: StoragePolicy
+
+
 def _format_exc_summary(exc: BaseException) -> str:
     if isinstance(exc, ConnectError):
         # The server detail (e.g. "column \"ts\": nullable mismatch
@@ -597,6 +611,46 @@ class LogClient:
                 f"(add a LIMIT or pass a higher max_rows)"
             )
         return result
+
+    def list_namespaces(self) -> list[NamespaceInfo]:
+        """Return every queryable namespace with its schema and storage statistics."""
+        client = self._get_stats_client()
+        try:
+            response = client.list_namespaces(stats_pb2.ListNamespacesRequest())
+        except ConnectError as exc:
+            if is_retryable_error(exc):
+                self._invalidate(_format_exc_summary(exc))
+            raise _translate_connect_error(exc) from exc
+        except (ConnectionError, OSError, TimeoutError) as exc:
+            self._invalidate(_format_exc_summary(exc))
+            raise
+        return [
+            NamespaceInfo(
+                namespace=info.namespace,
+                schema=schema_from_proto(info.schema),
+                row_count=info.row_count,
+                byte_size=info.byte_size,
+                min_seq=info.min_seq,
+                max_seq=info.max_seq,
+                segment_count=info.segment_count,
+                storage_policy=StoragePolicy.from_proto(info.storage_policy),
+            )
+            for info in response.namespaces
+        ]
+
+    def get_table_schema(self, namespace: str) -> Schema:
+        """Return the registered schema for ``namespace`` without creating a Table handle."""
+        client = self._get_stats_client()
+        try:
+            response = client.get_table_schema(stats_pb2.GetTableSchemaRequest(namespace=namespace))
+        except ConnectError as exc:
+            if is_retryable_error(exc):
+                self._invalidate(_format_exc_summary(exc))
+            raise _translate_connect_error(exc) from exc
+        except (ConnectionError, OSError, TimeoutError) as exc:
+            self._invalidate(_format_exc_summary(exc))
+            raise
+        return schema_from_proto(response.schema)
 
     def flush(self, timeout: float | None = None) -> FlushResult:
         """Flush the ``log`` namespace's Table, if any."""

--- a/lib/finelog/src/finelog/deploy/cli.py
+++ b/lib/finelog/src/finelog/deploy/cli.py
@@ -23,11 +23,15 @@ from rigging.credentials import iap_edge_provider
 from rigging.log_setup import configure_logging
 from rigging.tunnel import open_tunnel
 
-from finelog.client.log_client import LogClient
+from finelog.client.log_client import LogClient, NamespaceInfo
 from finelog.deploy import _gcp, _k8s
 from finelog.deploy.build import DEFAULT_PLATFORM
 from finelog.deploy.build import build_image as build_finelog_image
 from finelog.deploy.config import FinelogConfig, load_finelog_config, tunnel_target_for
+from finelog.errors import StatsError
+from finelog.policy import StoragePolicy
+from finelog.rpc import finelog_stats_pb2 as stats_pb2
+from finelog.schema import IMPLICIT_SEQ_COLUMN, Column, GroupedExtrema, Schema
 
 _SEGMENT_FILENAME_RE = re.compile(r"seg_L\d+_\d+\.parquet$")
 
@@ -66,6 +70,18 @@ def _log_client(
                 yield client
             finally:
                 client.close()
+
+
+@contextmanager
+def _open_cli_client(name: str, tunnel_timeout: float, request_timeout: float) -> Generator[LogClient, None, None]:
+    """Open a configured client and present expected connection/query failures as CLI errors."""
+    configure_logging(level=logging.INFO)
+    cfg = load_finelog_config(name)
+    try:
+        with _log_client(cfg, name, tunnel_timeout, request_timeout) as client:
+            yield client
+    except (IapLoginRequired, StatsError, ConnectionError, OSError, TimeoutError) as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 def _require_gcp_mutation(cfg: FinelogConfig) -> None:
@@ -267,9 +283,94 @@ _PRINTERS = {
 }
 
 
+def _read_sql_argument(sql: str | None) -> str:
+    if sql not in (None, "-"):
+        return sql
+    if sys.stdin.isatty():
+        raise click.UsageError("pass SQL as an argument, pipe it on stdin, or use '-' to read stdin")
+    value = sys.stdin.read()
+    if not value.strip():
+        raise click.UsageError("SQL input is empty")
+    return value
+
+
+def _column_record(column: Column) -> dict[str, object]:
+    column_type = stats_pb2.ColumnType.Name(column.type).removeprefix("COLUMN_TYPE_").lower()
+    return {
+        "name": column.name,
+        "type": column_type,
+        "nullable": column.nullable,
+        "trigram_index": column.trigram_index,
+        "exact_values": list(column.exact_values),
+        "value_counts": column.value_counts,
+    }
+
+
+def _grouped_extrema_record(config: GroupedExtrema) -> dict[str, str]:
+    return {
+        "filter_column": config.filter_column,
+        "group_json_column": config.group_json_column,
+        "group_json_key": config.group_json_key,
+        "extrema_column": config.extrema_column,
+    }
+
+
+def _schema_record(schema: Schema) -> dict[str, object]:
+    return {
+        "columns": [_column_record(column) for column in schema.columns],
+        "implicit_columns": [
+            {
+                "name": IMPLICIT_SEQ_COLUMN,
+                "type": "int64",
+                "nullable": False,
+                "server_assigned": True,
+            }
+        ],
+        "key_column": schema.key_column,
+        "sort_columns": list(schema.sort_columns),
+        "max_row_group_rows": schema.max_row_group_rows,
+        "projections": [
+            {
+                "name": projection.name,
+                "predicate_column": projection.predicate_column,
+                "predicate_values": list(projection.predicate_values),
+                "columns": list(projection.columns),
+            }
+            for projection in schema.projections
+        ],
+        "grouped_extrema": [_grouped_extrema_record(config) for config in schema.grouped_extrema],
+    }
+
+
+def _storage_policy_record(policy: StoragePolicy) -> dict[str, int | None]:
+    return {
+        "max_segments": policy.max_segments,
+        "max_bytes": policy.max_bytes,
+        "max_age_seconds": policy.max_age_seconds,
+    }
+
+
+def _namespace_record(info: NamespaceInfo) -> dict[str, object]:
+    return {
+        "namespace": info.namespace,
+        "row_count": info.row_count,
+        "byte_size": info.byte_size,
+        "min_seq": info.min_seq,
+        "max_seq": info.max_seq,
+        "segment_count": info.segment_count,
+        "storage_policy": _storage_policy_record(info.storage_policy),
+        "schema": _schema_record(info.schema),
+    }
+
+
+def _print_record(record: dict[str, object], *, indent: int | None = None) -> None:
+    json.dump(record, sys.stdout, indent=indent)
+    sys.stdout.write("\n")
+
+
 @cli.command("query")
 @click.argument("name")
-@click.argument("sql")
+@click.argument("sql", required=False)
 @click.option(
     "--format",
     "output_format",
@@ -302,7 +403,7 @@ _PRINTERS = {
 )
 def query_cmd(
     name: str,
-    sql: str,
+    sql: str | None,
     output_format: str,
     max_rows: int,
     tunnel_timeout: float,
@@ -313,16 +414,38 @@ def query_cmd(
     Connects via the controller IAP proxy when ``client_url`` is configured in
     the finelog config, otherwise opens an SSH (GCP) or ``kubectl port-forward``
     (k8s) tunnel to the configured finelog server. Runs ``<sql>`` through
-    ``StatsService.Query`` and prints results in ``--format`` (table/json/csv).
+    ``StatsService.Query`` and prints results in ``--format``. Omit ``<sql>``
+    or pass ``-`` to read SQL from stdin, which is safest for multiline queries
+    and quoted namespace names.
     """
-    configure_logging(level=logging.INFO)
-    cfg = load_finelog_config(name)
-    try:
-        with _log_client(cfg, name, tunnel_timeout, request_timeout) as client:
-            table = client.query(sql, max_rows=max_rows)
-    except IapLoginRequired as exc:
-        raise click.ClickException(str(exc)) from exc
+    query = _read_sql_argument(sql)
+    with _open_cli_client(name, tunnel_timeout, request_timeout) as client:
+        table = client.query(query, max_rows=max_rows)
     _PRINTERS[OutputFormat(output_format)](table)
+
+
+@cli.command("namespaces")
+@click.argument("name")
+@click.option("--tunnel-timeout", type=float, default=60.0, show_default=True)
+@click.option("--timeout", "request_timeout", type=float, default=DEFAULT_REQUEST_TIMEOUT, show_default=True)
+def namespaces_cmd(name: str, tunnel_timeout: float, request_timeout: float) -> None:
+    """List queryable namespaces, schemas, indexes, and storage statistics as JSONL."""
+    with _open_cli_client(name, tunnel_timeout, request_timeout) as client:
+        namespaces = client.list_namespaces()
+    for namespace in namespaces:
+        _print_record(_namespace_record(namespace))
+
+
+@cli.command("schema")
+@click.argument("name")
+@click.argument("namespace")
+@click.option("--tunnel-timeout", type=float, default=60.0, show_default=True)
+@click.option("--timeout", "request_timeout", type=float, default=DEFAULT_REQUEST_TIMEOUT, show_default=True)
+def schema_cmd(name: str, namespace: str, tunnel_timeout: float, request_timeout: float) -> None:
+    """Print one registered namespace schema as JSON."""
+    with _open_cli_client(name, tunnel_timeout, request_timeout) as client:
+        schema = client.get_table_schema(namespace)
+    _print_record({"namespace": namespace, "schema": _schema_record(schema)}, indent=2)
 
 
 def _list_namespace_dirs(remote_log_dir: str, fs: fsspec.AbstractFileSystem) -> list[str]:

--- a/lib/finelog/src/finelog/deploy/cli.py
+++ b/lib/finelog/src/finelog/deploy/cli.py
@@ -39,6 +39,7 @@ _SEGMENT_FILENAME_RE = re.compile(r"seg_L\d+_\d+\.parquet$")
 # the server, which reports why, rather than by a client-side timeout that
 # reports only that time ran out.
 DEFAULT_REQUEST_TIMEOUT = 15.0
+DEFAULT_TUNNEL_TIMEOUT = 60.0
 
 
 @contextmanager
@@ -389,7 +390,7 @@ def _print_record(record: dict[str, object], *, indent: int | None = None) -> No
 @click.option(
     "--tunnel-timeout",
     type=float,
-    default=60.0,
+    default=DEFAULT_TUNNEL_TIMEOUT,
     show_default=True,
     help="Seconds to wait for the local tunnel to become reachable.",
 )
@@ -426,7 +427,7 @@ def query_cmd(
 
 @cli.command("namespaces")
 @click.argument("name")
-@click.option("--tunnel-timeout", type=float, default=60.0, show_default=True)
+@click.option("--tunnel-timeout", type=float, default=DEFAULT_TUNNEL_TIMEOUT, show_default=True)
 @click.option("--timeout", "request_timeout", type=float, default=DEFAULT_REQUEST_TIMEOUT, show_default=True)
 def namespaces_cmd(name: str, tunnel_timeout: float, request_timeout: float) -> None:
     """List queryable namespaces, schemas, indexes, and storage statistics as JSONL."""
@@ -439,7 +440,7 @@ def namespaces_cmd(name: str, tunnel_timeout: float, request_timeout: float) -> 
 @cli.command("schema")
 @click.argument("name")
 @click.argument("namespace")
-@click.option("--tunnel-timeout", type=float, default=60.0, show_default=True)
+@click.option("--tunnel-timeout", type=float, default=DEFAULT_TUNNEL_TIMEOUT, show_default=True)
 @click.option("--timeout", "request_timeout", type=float, default=DEFAULT_REQUEST_TIMEOUT, show_default=True)
 def schema_cmd(name: str, namespace: str, tunnel_timeout: float, request_timeout: float) -> None:
     """Print one registered namespace schema as JSON."""

--- a/lib/finelog/src/finelog/policy.py
+++ b/lib/finelog/src/finelog/policy.py
@@ -19,6 +19,7 @@ top of the existing size / count caps.
 """
 
 from dataclasses import dataclass
+from typing import Self
 
 from finelog.rpc import finelog_stats_pb2 as stats_pb2
 
@@ -49,4 +50,13 @@ class StoragePolicy:
             max_segments=self.max_segments or 0,
             max_bytes=self.max_bytes or 0,
             max_age_seconds=self.max_age_seconds or 0,
+        )
+
+    @classmethod
+    def from_proto(cls, policy: stats_pb2.StoragePolicy) -> Self:
+        """Decode proto3 zero values as inherited defaults."""
+        return cls(
+            max_segments=policy.max_segments or None,
+            max_bytes=policy.max_bytes or None,
+            max_age_seconds=policy.max_age_seconds or None,
         )

--- a/lib/finelog/tests/test_client.py
+++ b/lib/finelog/tests/test_client.py
@@ -18,6 +18,7 @@ from finelog.client import FlushResult, LogClient, RemoteLogHandler, StoragePoli
 from finelog.client import log_client as log_client_mod
 from finelog.errors import (
     InvalidNamespaceError,
+    NamespaceNotFoundError,
     QueryResultTooLargeError,
     SchemaValidationError,
 )
@@ -101,6 +102,7 @@ class _FakeStatsServiceClient:
         self.queries: list[str] = []
         self.errors: list[Exception] = []
         self.query_handler = None
+        self.namespaces: list[stats_pb2.NamespaceInfo] = []
 
     def register_table(self, request):
         self.registered[request.namespace] = request.schema
@@ -132,6 +134,16 @@ class _FakeStatsServiceClient:
         with paipc.new_stream(sink, table.schema) as writer:
             writer.write_table(table)
         return stats_pb2.QueryResponse(arrow_ipc=sink.getvalue(), row_count=table.num_rows)
+
+    def list_namespaces(self, request):
+        del request
+        return stats_pb2.ListNamespacesResponse(namespaces=self.namespaces)
+
+    def get_table_schema(self, request):
+        for info in self.namespaces:
+            if info.namespace == request.namespace:
+                return stats_pb2.GetTableSchemaResponse(schema=info.schema)
+        raise ConnectError(Code.NOT_FOUND, f"namespace {request.namespace!r} is not registered")
 
     def close(self):
         pass
@@ -656,6 +668,77 @@ def test_client_query_raises_on_too_large(tracked_clients):
         tracked_clients[0].query_handler = lambda _sql: pa.table({"x": list(range(5))})
         with pytest.raises(QueryResultTooLargeError):
             client.query('SELECT * FROM "iris.worker"', max_rows=2)
+    finally:
+        client.close()
+
+
+def test_client_lists_namespaces_with_schema_and_storage_stats(tracked_clients):
+    client = LogClient.connect("http://h:1")
+    try:
+        client.query("SELECT 1")  # construct the stats client
+        tracked_clients[0].namespaces = [
+            stats_pb2.NamespaceInfo(
+                namespace="iris.worker",
+                schema=stats_pb2.Schema(
+                    columns=[
+                        stats_pb2.Column(
+                            name="worker_id",
+                            type=stats_pb2.COLUMN_TYPE_STRING,
+                            nullable=False,
+                        )
+                    ],
+                    key_column="worker_id",
+                ),
+                row_count=12,
+                byte_size=345,
+                min_seq=2,
+                max_seq=13,
+                segment_count=4,
+                storage_policy=stats_pb2.StoragePolicy(max_bytes=1024),
+            )
+        ]
+
+        assert client.list_namespaces() == [
+            log_client_mod.NamespaceInfo(
+                namespace="iris.worker",
+                schema=Schema(
+                    columns=(
+                        Column(
+                            name="worker_id",
+                            type=stats_pb2.COLUMN_TYPE_STRING,
+                            nullable=False,
+                        ),
+                    ),
+                    key_column="worker_id",
+                ),
+                row_count=12,
+                byte_size=345,
+                min_seq=2,
+                max_seq=13,
+                segment_count=4,
+                storage_policy=StoragePolicy(max_bytes=1024),
+            )
+        ]
+    finally:
+        client.close()
+
+
+def test_client_gets_registered_schema_without_table_handle(tracked_clients):
+    client = LogClient.connect("http://h:1")
+    try:
+        client.query("SELECT 1")  # construct the stats client
+        tracked_clients[0].namespaces = [
+            stats_pb2.NamespaceInfo(
+                namespace="iris.task",
+                schema=stats_pb2.Schema(columns=[stats_pb2.Column(name="task_id", type=stats_pb2.COLUMN_TYPE_STRING)]),
+            )
+        ]
+
+        assert client.get_table_schema("iris.task") == Schema(
+            columns=(Column(name="task_id", type=stats_pb2.COLUMN_TYPE_STRING, nullable=False),)
+        )
+        with pytest.raises(NamespaceNotFoundError):
+            client.get_table_schema("missing")
     finally:
         client.close()
 

--- a/lib/finelog/tests/test_deploy_cli.py
+++ b/lib/finelog/tests/test_deploy_cli.py
@@ -104,7 +104,9 @@ def test_query_reports_sql_errors_without_python_traceback() -> None:
         result = CliRunner().invoke(cli, ["query", "marin", 'SELECT * FROM "iris.task"'])
 
     assert result.exit_code == 1
-    assert result.output == 'Error: query failed: table "iris.task" not found\n'
+    assert isinstance(result.exception, SystemExit)
+    assert result.output.startswith("Error: ")
+    assert "Traceback" not in result.output
 
 
 def test_namespaces_defaults_to_jsonl_with_schema_metadata() -> None:

--- a/lib/finelog/tests/test_deploy_cli.py
+++ b/lib/finelog/tests/test_deploy_cli.py
@@ -1,13 +1,15 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for namespace discovery + view registration in ``finelog gcs-query``.
+"""Tests for Finelog query and namespace-inspection commands.
 
-The CLI command itself opens a real connection (gcsfs in production); these
-tests cover the testable seams against a local parquet directory.
+RPC commands use a fake client at the network boundary. GCS query helpers run
+against a local parquet directory.
 """
 
+import json
 from contextlib import contextmanager
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -16,11 +18,18 @@ import fsspec
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from click.testing import CliRunner
+from finelog.client.log_client import NamespaceInfo
 from finelog.deploy.cli import (
     _list_namespace_dirs,
     _list_namespace_segments,
     _register_namespace_views,
+    cli,
 )
+from finelog.errors import SchemaValidationError
+from finelog.policy import StoragePolicy
+from finelog.rpc import finelog_stats_pb2 as stats_pb2
+from finelog.schema import Column, Schema
 
 
 def _write_segment(path: Path, level: int, seq: int, rows: list[dict[str, object]]) -> Path:
@@ -28,6 +37,108 @@ def _write_segment(path: Path, level: int, seq: int, rows: list[dict[str, object
     out = path / f"seg_L{level}_{seq:019d}.parquet"
     pq.write_table(pa.Table.from_pylist(rows), out)
     return out
+
+
+class _FakeLogClient:
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+        self.query_error: Exception | None = None
+
+    def query(self, sql: str, *, max_rows: int) -> pa.Table:
+        del max_rows
+        self.queries.append(sql)
+        if self.query_error is not None:
+            raise self.query_error
+        return pa.table({"task_id": ["task-1"], "memory_mb": [42]})
+
+    def list_namespaces(self) -> list[NamespaceInfo]:
+        task = NamespaceInfo(
+            namespace="iris.task",
+            schema=Schema(
+                columns=(
+                    Column(name="task_id", type=stats_pb2.COLUMN_TYPE_STRING, nullable=False),
+                    Column(name="memory_mb", type=stats_pb2.COLUMN_TYPE_INT64),
+                ),
+                key_column="task_id",
+            ),
+            row_count=7,
+            byte_size=128,
+            min_seq=1,
+            max_seq=7,
+            segment_count=2,
+            storage_policy=StoragePolicy(max_bytes=1024),
+        )
+        return [task, replace(task, namespace="iris.worker", row_count=3)]
+
+    def get_table_schema(self, namespace: str) -> Schema:
+        assert namespace == "iris.task"
+        return self.list_namespaces()[0].schema
+
+
+@contextmanager
+def _fake_log_client(client: _FakeLogClient):
+    yield client
+
+
+def _patch_cli_client(client: _FakeLogClient):
+    return patch("finelog.deploy.cli._log_client", return_value=_fake_log_client(client))
+
+
+def test_query_reads_multiline_sql_from_stdin_without_shell_escaping() -> None:
+    client = _FakeLogClient()
+    sql = "SELECT task_id, memory_mb\nFROM \"iris.task\"\nWHERE task_id = 'task-1'\n"
+
+    with _patch_cli_client(client):
+        result = CliRunner().invoke(cli, ["query", "marin"], input=sql)
+
+    assert result.exit_code == 0, result.output
+    assert client.queries == [sql]
+    assert result.output == '{"task_id": "task-1", "memory_mb": 42}\n'
+
+
+def test_query_reports_sql_errors_without_python_traceback() -> None:
+    client = _FakeLogClient()
+    client.query_error = SchemaValidationError('query failed: table "iris.task" not found')
+
+    with _patch_cli_client(client):
+        result = CliRunner().invoke(cli, ["query", "marin", 'SELECT * FROM "iris.task"'])
+
+    assert result.exit_code == 1
+    assert result.output == 'Error: query failed: table "iris.task" not found\n'
+
+
+def test_namespaces_defaults_to_jsonl_with_schema_metadata() -> None:
+    with _patch_cli_client(_FakeLogClient()):
+        result = CliRunner().invoke(cli, ["namespaces", "marin"])
+
+    assert result.exit_code == 0, result.output
+    records = [json.loads(line) for line in result.output.splitlines()]
+    assert [record["namespace"] for record in records] == ["iris.task", "iris.worker"]
+    payload = records[0]
+    assert payload["namespace"] == "iris.task"
+    assert payload["row_count"] == 7
+    assert payload["storage_policy"]["max_bytes"] == 1024
+    assert payload["schema"]["columns"][1]["type"] == "int64"
+    assert payload["schema"]["implicit_columns"] == [
+        {"name": "seq", "type": "int64", "nullable": False, "server_assigned": True}
+    ]
+
+
+def test_schema_returns_one_machine_readable_schema() -> None:
+    with _patch_cli_client(_FakeLogClient()):
+        result = CliRunner().invoke(cli, ["schema", "marin", "iris.task"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["namespace"] == "iris.task"
+    assert payload["schema"]["columns"][0] == {
+        "name": "task_id",
+        "type": "string",
+        "nullable": False,
+        "trigram_index": False,
+        "exact_values": [],
+        "value_counts": False,
+    }
 
 
 @contextmanager

--- a/lib/rigging/src/rigging/tunnel.py
+++ b/lib/rigging/src/rigging/tunnel.py
@@ -295,7 +295,7 @@ def open_tunnel(
             current = proc_ref[0]
         if current is not None:
             terminate_process_group(current)
-        raise RuntimeError(f"tunnel {label} did not open local port {local_port} within {timeout:.0f}s")
+        raise TimeoutError(f"tunnel {label} did not open local port {local_port} within {timeout:.0f}s")
 
     logger.info("Tunnel ready: 127.0.0.1:%d -> %s", local_port, label)
 

--- a/lib/rigging/tests/test_tunnel.py
+++ b/lib/rigging/tests/test_tunnel.py
@@ -1,0 +1,19 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+from rigging.tunnel import K8sPortForwardTarget, open_tunnel
+
+
+def test_open_tunnel_startup_timeout_raises_timeout_error() -> None:
+    process = MagicMock(spec=subprocess.Popen)
+    process.stderr = None
+    process.poll.return_value = 1
+    target = K8sPortForwardTarget(namespace="iris", service="finelog", port=9090)
+
+    with pytest.raises(TimeoutError):
+        with open_tunnel(target, local_port=12345, timeout=0, spawn=lambda _argv: process):
+            pass


### PR DESCRIPTION
Accept SQL on stdin so multiline Finelog queries preserve quoted dotted
namespace names through the shell. Queries keep JSONL as the default output,
and expected query and connection failures produce concise CLI errors.

Expose namespace and schema inspection through LogClient and the CLI. The
machine-readable output includes column and index metadata, retention
overrides, storage statistics, and the server-assigned `seq` column. This
removes the need for ad hoc RPC client setup before writing a query.
