### PR TITLE
[grug] Bound the post-restore barrier so one late rank cannot hold the gang

### DIFF
--- a/experiments/grug/checkpointing.py
+++ b/experiments/grug/checkpointing.py
@@ -12,13 +12,16 @@ from typing import ClassVar, Protocol, TypeVar, cast
 import fsspec
 import jax
 from fsspec import AbstractFileSystem
-from jax.experimental import multihost_utils
 from levanter.checkpoint import latest_checkpoint_path, load_checkpoint
+from levanter.utils.jax_utils import barrier_sync_named
 
 logger = logging.getLogger(__name__)
 
 StateT = TypeVar("StateT")
 RESTORE_COMPLETE_BARRIER = "grug_checkpoint_restore_complete"
+# Well clear of a cold restore, which reads for tens of minutes. Expiring aborts the attempt for
+# the scheduler to retry, rather than holding every rank behind one that may never arrive.
+RESTORE_BARRIER_TIMEOUT = 90 * 60
 
 
 class _GrugState(Protocol):
@@ -124,7 +127,7 @@ def restore_grug_state_from_checkpoint(
                 allow_partial=allow_partial,
                 load_fn=_load_fn,
             )
-            multihost_utils.sync_global_devices(RESTORE_COMPLETE_BARRIER)
+            barrier_sync_named(RESTORE_COMPLETE_BARRIER, timeout=RESTORE_BARRIER_TIMEOUT)
             if candidate not in checkpoint_search_paths:
                 logger.info("Loaded checkpoint from %s while searching %s", candidate, checkpoint_search_paths)
             return loaded

--- a/lib/levanter/src/levanter/utils/jax_utils.py
+++ b/lib/levanter/src/levanter/utils/jax_utils.py
@@ -181,12 +181,13 @@ def multihost_allgather_sync(obj: X, timeout: float = 200.0) -> list[X]:
     return gathered
 
 
-def barrier_sync(timeout: float = 200):
+def barrier_sync_named(barrier_id: str, timeout: float = 200):
+    """Wait for every process at ``barrier_id``, raising once ``timeout`` seconds elapse.
+
+    Barriers are one-shot, so a caller that barriers repeatedly must vary the id. Prefer this over
+    a device collective such as ``jax.experimental.multihost_utils.sync_global_devices``, which
+    cannot be cancelled and so waits indefinitely when one process is late.
     """
-    Uses jax's unpublished distributed api to wait for all processes to reach a barrier. This is useful for ensuring
-    that all processes have reached a certain point in the code before continuing.
-    """
-    global _sync_counter
     if jax.process_count() == 1:
         return
 
@@ -200,10 +201,25 @@ def barrier_sync(timeout: float = 200):
     client: Optional[DistributedRuntimeClient] = jax_distributed.global_state.client
 
     if client is None:
-        raise RuntimeError("barrier_sync requires jax distributed client to be initialized")
+        raise RuntimeError("barrier_sync_named requires jax distributed client to be initialized")
+
+    client.wait_at_barrier(barrier_id, timeout_in_ms=int(timeout * 1000.0))
+
+
+def barrier_sync(timeout: float = 200):
+    """
+    Uses jax's unpublished distributed api to wait for all processes to reach a barrier. This is useful for ensuring
+    that all processes have reached a certain point in the code before continuing.
+
+    The barrier id comes from a process-local counter, so every process must reach this call the
+    same number of times. Use :func:`barrier_sync_named` where that cannot be guaranteed.
+    """
+    global _sync_counter
+    if jax.process_count() == 1:
+        return
 
     _sync_counter += 1
-    client.wait_at_barrier(f"levanter_barrier_sync_{_sync_counter}", timeout_in_ms=int(timeout * 1000.0))
+    barrier_sync_named(f"levanter_barrier_sync_{_sync_counter}", timeout=timeout)
 
 
 # from https://stackoverflow.com/questions/2166818/how-to-check-if-an-object-is-an-instance-of-a-namedtuple

--- a/lib/levanter/tests/test_jax_utils.py
+++ b/lib/levanter/tests/test_jax_utils.py
@@ -9,8 +9,10 @@ import numpy as np
 import pytest
 from haliax.partitioning import ResourceAxis
 
+import levanter.utils.jax_utils as jax_utils
 from levanter.utils.jax_utils import (
     axis_resource_is_explicit,
+    barrier_sync,
     best_effort_sharding,
     move_tree_to_memory_kind,
     sharded_tree_size,
@@ -272,3 +274,28 @@ def test_move_tree_to_memory_kind_is_noop_inside_jit():
     y = move_inside_jit(x)
     np.testing.assert_array_equal(np.asarray(y), np.asarray(x))
     assert y.sharding.memory_kind == x.sharding.memory_kind
+
+
+class _RecordingClient:
+    def __init__(self):
+        self.calls = []
+
+    def wait_at_barrier(self, barrier_id, timeout_in_ms):
+        self.calls.append((barrier_id, timeout_in_ms))
+
+
+@pytest.fixture
+def multiprocess_client(monkeypatch):
+    client = _RecordingClient()
+    monkeypatch.setattr(jax, "process_count", lambda: 2)
+    monkeypatch.setattr(jax_utils.jax_distributed.global_state, "client", client, raising=False)
+    return client
+
+
+def test_barrier_sync_does_not_reuse_a_barrier_id(multiprocess_client):
+    """Barriers are one-shot, so repeated calls must not collide on an id."""
+    barrier_sync(timeout=1.0)
+    barrier_sync(timeout=1.0)
+
+    first, second = (barrier_id for barrier_id, _ in multiprocess_client.calls)
+    assert first != second


### PR DESCRIPTION
The barrier after checkpoint restore used `multihost_utils.sync_global_devices`, a pjit'd
device allgather with no timeout. On 2026-08-21 one rank of the 704-process EP hero stalled
in its TensorStore read and the other 175 tasks waited at that barrier for 4h34m past the
point where they had all finished reading, with no error and no log output, before the read
completed on its own. An in-flight XLA collective cannot be cancelled, so there was no way to
bound it.

`barrier_sync_named` waits on the JAX coordination service instead, which takes a timeout and
does not need the GPU. The restore barrier gets 90 minutes: cold 11-rack d6144 restores
measured 22 to 24 minutes across four reads on 2026-08-20 and 2026-08-21, so this expires only
well outside normal variation, and expiring aborts the attempt for Iris to reschedule rather
than holding 704 ranks indefinitely. The coordination service names the tasks that failed to
arrive in its timeout error, which the previous barrier could not report.

The barrier id is caller-supplied because `barrier_sync` derives its id from a process-local
counter shared with `multihost_broadcast_sync`. Ranks that reach those calls a different number
of times would wait at differently named barriers and all time out. `barrier_sync` keeps the
counter and now delegates.

Part of #8534
