### PR TITLE
[levanter] Release checkpoint heap pages after commits

### DIFF
--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -5,9 +5,12 @@
 # * Orbax: https://github.com/google/orbax/blob/11d2934ecfff77e86b5e07d0fef02b67eff4511b/orbax/checkpoint/pytree_checkpoint_handler.py#L312
 import asyncio
 import collections
+import ctypes
 import logging
 import math
 import os
+import sys
+import threading
 import time
 import urllib.parse
 import zlib
@@ -53,6 +56,37 @@ _HOST_MEMORY_KIND = "pinned_host"
 _DEFAULT_STAGED_CHUNKS = 32
 # Host memory a staged byte occupies while its write is in flight, for reporting only.
 _STAGED_BYTE_OVERHEAD = 4
+
+
+def _malloc_trim() -> bool:
+    """Return unused glibc heap pages to the OS."""
+    if sys.platform != "linux":
+        return False
+
+    libc = ctypes.CDLL("libc.so.6")
+    libc.malloc_trim.argtypes = [ctypes.c_size_t]
+    libc.malloc_trim.restype = ctypes.c_int
+    return bool(libc.malloc_trim(0))
+
+
+def _trim_host_memory_after_commits(commit_futures: Sequence[ts.Future]) -> None:
+    """Schedule one heap trim after every local TensorStore commit finishes."""
+    remaining = len(commit_futures)
+    if remaining == 0:
+        return
+
+    lock = threading.Lock()
+
+    def commit_finished(_: ts.Future) -> None:
+        nonlocal remaining
+        with lock:
+            remaining -= 1
+            all_finished = remaining == 0
+        if all_finished and _malloc_trim():
+            logger.info("Released unused host memory after checkpoint commits")
+
+    for future in commit_futures:
+        future.add_done_callback(commit_finished)
 
 
 def _format_gib(num_bytes: int) -> str:
@@ -695,6 +729,8 @@ def _serialize_arrays(
         len(commit_futures),
         _STAGED_BYTE_OVERHEAD * gate.peak_bytes / 1024**3,
     )
+
+    _trim_host_memory_after_commits(commit_futures)
 
     # Private to AsyncManager. Its own `serialize` calls these.
     manager._add_futures(commit_futures)

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -58,15 +58,16 @@ _DEFAULT_STAGED_CHUNKS = 32
 _STAGED_BYTE_OVERHEAD = 4
 
 
-def _malloc_trim() -> bool:
-    """Return unused glibc heap pages to the OS."""
+def _malloc_trim() -> None:
+    """Ask glibc to return unused heap pages to the OS."""
     if sys.platform != "linux":
-        return False
+        return
 
     libc = ctypes.CDLL("libc.so.6")
     libc.malloc_trim.argtypes = [ctypes.c_size_t]
     libc.malloc_trim.restype = ctypes.c_int
-    return bool(libc.malloc_trim(0))
+    released = libc.malloc_trim(0)
+    logger.info("malloc_trim after checkpoint commits returned %d", released)
 
 
 def _trim_host_memory_after_commits(commit_futures: Sequence[ts.Future]) -> None:
@@ -82,8 +83,8 @@ def _trim_host_memory_after_commits(commit_futures: Sequence[ts.Future]) -> None
         with lock:
             remaining -= 1
             all_finished = remaining == 0
-        if all_finished and _malloc_trim():
-            logger.info("Released unused host memory after checkpoint commits")
+        if all_finished:
+            _malloc_trim()
 
     for future in commit_futures:
         future.add_done_callback(commit_finished)


### PR DESCRIPTION
Release glibc-owned checkpoint staging pages after every local TensorStore
commit future completes. Scheduling the trim from the futures runs it on every
JAX process while preserving asynchronous checkpoint commits; the JAX manager
commit callback only runs on process 0.

A one-tray d6144-shaped reproduction without per-checkpoint trimming grew from
121.66 GiB settled after checkpoint 1 to 175.80 GiB after checkpoint 10. A
single final malloc_trim returned 61.71 GiB to the OS. Memray showed checkpoint
6 retained only 13.52 MiB, identifying the repeated-save growth as allocator
retention.

With this change and the 16 GiB staging budget, anonymous cgroup memory grew
from 102.96 GiB after checkpoint 1 to 103.90 GiB after checkpoint 10
(+0.94 GiB). A final manual trim changed cgroup memory by less than 0.01 GiB,
confirming that the commit callbacks had already released reclaimable pages.
The ten-save harness took 318.7 seconds. Reducing TensorStore chunks from
512 MiB to 128 MiB did not improve retention or wall time. The first-save
persistent JAX host cache remains and needs a separate fix.

The reproduction and allocation evidence are recorded in
https://echo.oa.dev/wiki/200.

Part of #6774
