### PR TITLE
[levanter] Prefetch S3 checkpoint objects after TensorStore commits

### DIFF
--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -32,6 +32,7 @@ from jax._src.sharding import IndivisibleError
 from jax.sharding import Mesh, Sharding
 from jaxtyping import PyTree
 
+from rigging import telemetry
 from rigging.filesystem.cross_region import record_transfer
 from rigging.filesystem.factory import url_to_fs
 from rigging.filesystem.storage_path import StoragePath, prefix_join
@@ -59,6 +60,7 @@ _STAGED_BYTE_OVERHEAD = 4
 # and the legacy path asked for 300, both far above what a save allows itself on the same node.
 _RESTORE_CONCURRENT_GB = 8
 _S3_PREFETCH_THREAD_NAME = "levanter-s3-checkpoint-prefetch"
+_S3_PREFETCH_FAILURES = telemetry.counter("levanter_s3_checkpoint_prefetch_failures", unit="{failure}")
 
 
 def _format_gib(num_bytes: int) -> str:
@@ -446,6 +448,7 @@ def _prefetch_s3_checkpoint(checkpoint_root: str) -> None:
         fs, path = url_to_fs(checkpoint_root)
         objects = fs.find(path)
     except Exception:
+        _S3_PREFETCH_FAILURES.add(attributes={"operation": "list"})
         logger.exception("Failed to list S3 checkpoint objects for cache prefetch: %s", checkpoint_root)
         return
 
@@ -460,6 +463,7 @@ def _prefetch_s3_checkpoint(checkpoint_root: str) -> None:
             failures += 1
 
     if failures:
+        _S3_PREFETCH_FAILURES.add(failures, attributes={"operation": "head"})
         logger.warning(
             "Failed to prefetch %d of %d S3 checkpoint objects under %s",
             failures,

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -56,6 +56,8 @@ _HOST_MEMORY_KIND = "pinned_host"
 _DEFAULT_STAGED_CHUNKS = 32
 # Host memory a staged byte occupies while its write is in flight, for reporting only.
 _STAGED_BYTE_OVERHEAD = 4
+_LOTA_ENDPOINT_HOST = "cwlota.com"
+_LOTA_PREFETCH_RANGE = "bytes=0-0"
 _S3_PREFETCH_THREAD_NAME = "levanter-s3-checkpoint-prefetch"
 _S3_PREFETCH_FAILURES = telemetry.counter("levanter_s3_checkpoint_prefetch_failures", unit="{failure}")
 
@@ -471,21 +473,25 @@ async def _list_ocdbt_keys(checkpoint_root: str) -> list[str]:
     return [key.decode("utf-8") for key in keys_bytes]
 
 
-def _prefetch_s3_checkpoint(checkpoint_root: str) -> None:
-    """Issue an S3 HEAD for every object in a completed checkpoint."""
+def _prefetch_s3_checkpoint(checkpoint_root: str, process_index: int, process_count: int) -> None:
+    """Pre-stage this process's shard of a completed checkpoint through LOTA."""
     try:
         fs, path = url_to_fs(checkpoint_root)
-        objects = fs.find(path)
+        objects = sorted(fs.find(path))
     except Exception:
         _S3_PREFETCH_FAILURES.add(attributes={"operation": "list"})
         logger.exception("Failed to list S3 checkpoint objects for cache prefetch: %s", checkpoint_root)
         return
 
     failures = 0
-    for object_path in objects:
+    assigned_objects = objects[process_index::process_count]
+    for object_path in assigned_objects:
         try:
-            # S3FS may satisfy info from its listing cache unless refresh is explicit.
-            fs.info(object_path, refresh=True)
+            bucket, key, version_id = fs.split_path(object_path)
+            kwargs = {"Bucket": bucket, "Key": key, "Range": _LOTA_PREFETCH_RANGE}
+            if version_id is not None:
+                kwargs["VersionId"] = version_id
+            fs.call_s3("head_object", **kwargs)
         except Exception:
             if failures == 0:
                 logger.exception("Failed to HEAD S3 checkpoint object %s; continuing prefetch", object_path)
@@ -494,23 +500,76 @@ def _prefetch_s3_checkpoint(checkpoint_root: str) -> None:
     if failures:
         _S3_PREFETCH_FAILURES.add(failures, attributes={"operation": "head"})
         logger.warning(
-            "Failed to prefetch %d of %d S3 checkpoint objects under %s",
+            "Failed to prefetch %d of %d assigned S3 checkpoint objects under %s on process %d",
             failures,
-            len(objects),
+            len(assigned_objects),
             checkpoint_root,
+            process_index,
         )
     else:
-        logger.info("Prefetched %d S3 checkpoint objects under %s", len(objects), checkpoint_root)
+        logger.info(
+            "Prefetched %d of %d S3 checkpoint objects under %s on process %d",
+            len(assigned_objects),
+            len(objects),
+            checkpoint_root,
+            process_index,
+        )
 
 
-def _start_s3_checkpoint_prefetch(checkpoint_root: str) -> None:
-    checkpoint_root = str(checkpoint_root)
-    if jax.process_index() != 0 or urllib.parse.urlparse(checkpoint_root).scheme != "s3":
+def _uses_lota_endpoint() -> bool:
+    endpoint = os.environ.get("AWS_ENDPOINT_URL_S3") or os.environ.get("AWS_ENDPOINT_URL", "")
+    hostname = urllib.parse.urlparse(endpoint).hostname or ""
+    return hostname == _LOTA_ENDPOINT_HOST or hostname.endswith(f".{_LOTA_ENDPOINT_HOST}")
+
+
+def _should_prefetch_s3_checkpoint(checkpoint_root: str) -> bool:
+    return urllib.parse.urlparse(checkpoint_root).scheme == "s3" and _uses_lota_endpoint()
+
+
+def _start_s3_checkpoint_prefetch(checkpoint_root: str, process_index: int, process_count: int) -> None:
+    if not _should_prefetch_s3_checkpoint(checkpoint_root):
         return
 
     threading.Thread(
         target=_prefetch_s3_checkpoint,
-        args=(checkpoint_root,),
+        args=(checkpoint_root, process_index, process_count),
+        name=_S3_PREFETCH_THREAD_NAME,
+        daemon=True,
+    ).start()
+
+
+def _wait_for_global_commit_and_prefetch(
+    checkpoint_root: str,
+    manager: array_ser.GlobalAsyncCheckpointManager,
+    process_index: int,
+    process_count: int,
+) -> None:
+    try:
+        assert manager._client is not None
+        assert manager._count is not None
+        # JAX runs the commit callback only on process 0, then publishes this key for the other processes.
+        success_key = array_ser._get_key(manager._count)
+        manager._client.blocking_key_value_get(success_key, manager._timeout_in_ms)
+    except Exception:
+        _S3_PREFETCH_FAILURES.add(attributes={"operation": "commit_wait"})
+        logger.exception("Failed waiting for global checkpoint commit before S3 cache prefetch: %s", checkpoint_root)
+        return
+
+    _prefetch_s3_checkpoint(checkpoint_root, process_index, process_count)
+
+
+def _start_s3_checkpoint_prefetch_waiter(
+    checkpoint_root: str,
+    manager: array_ser.GlobalAsyncCheckpointManager,
+    process_index: int,
+    process_count: int,
+) -> None:
+    if not _should_prefetch_s3_checkpoint(checkpoint_root):
+        return
+
+    threading.Thread(
+        target=_wait_for_global_commit_and_prefetch,
+        args=(checkpoint_root, manager, process_index, process_count),
         name=_S3_PREFETCH_THREAD_NAME,
         daemon=True,
     ).start()
@@ -616,9 +675,14 @@ def tree_serialize_leaves_tensorstore(
     if commit_callback is None:
         commit_callback = lambda: logger.info("Committed checkpoint to Tensorstore")  # noqa
 
+    checkpoint_root = str(checkpoint_dir)
+    process_index = jax.process_index()
+    process_count = jax.process_count()
+
     def commit_and_prefetch() -> None:
         commit_callback()
-        _start_s3_checkpoint_prefetch(checkpoint_dir)
+        if process_index == 0:
+            _start_s3_checkpoint_prefetch(checkpoint_root, process_index, process_count)
 
     if debug_checkpointer:
         logger.info(
@@ -644,7 +708,7 @@ def tree_serialize_leaves_tensorstore(
     ]
     tspecs = [_create_ocdbt_spec(checkpoint_dir, entry.path, entry=entry) for entry in entries]
 
-    if jax.process_index() == 0:
+    if process_index == 0:
         write_manifest(
             checkpoint_dir, build_manifest(entries, array_driver=ARRAY_DRIVER, kvstore_driver=KVSTORE_DRIVER)
         )
@@ -664,6 +728,8 @@ def tree_serialize_leaves_tensorstore(
         flush_debug_output(logger)
 
     _serialize_arrays(arrays, tspecs, plans, manager, write_config, commit_and_prefetch)
+    if process_index != 0:
+        _start_s3_checkpoint_prefetch_waiter(checkpoint_root, manager, process_index, process_count)
 
     if debug_checkpointer:
         logger.info("Checkpoint tensorstore serialize handed off async commit for %s", checkpoint_dir)

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -35,7 +35,6 @@ from jax._src.sharding import IndivisibleError
 from jax.sharding import Mesh, Sharding
 from jaxtyping import PyTree
 
-from rigging import telemetry
 from rigging.filesystem.cluster_config import StoreType
 from rigging.filesystem.cross_region import record_transfer
 from rigging.filesystem.factory import url_to_fs
@@ -62,15 +61,6 @@ _DEFAULT_STAGED_CHUNKS = 32
 _STAGED_BYTE_OVERHEAD = 4
 _LOTA_ENDPOINT_HOST = "cwlota.com"
 _LOTA_PREFETCH_RANGE = "bytes=0-0"
-_S3_PREFETCH_THREAD_NAME = "levanter-s3-checkpoint-prefetch"
-_S3_PREFETCH_FAILURES = telemetry.counter("levanter_s3_checkpoint_prefetch_failures", unit="{failure}")
-
-
-@dataclass(frozen=True)
-class _S3PrefetchShard:
-    checkpoint_root: str
-    process_index: int
-    process_count: int
 
 
 def _malloc_trim() -> None:
@@ -516,75 +506,36 @@ async def _list_ocdbt_keys(checkpoint_root: str) -> list[str]:
     return [key.decode("utf-8") for key in keys_bytes]
 
 
-def _prefetch_s3_checkpoint(shard: _S3PrefetchShard) -> None:
-    """Pre-stage this process's shard of a completed checkpoint through LOTA."""
+def _prefetch_s3_checkpoint(checkpoint_root: str) -> None:
     try:
-        fs, path = url_to_fs(shard.checkpoint_root)
+        fs, path = url_to_fs(checkpoint_root)
         objects = sorted(fs.find(path))
+        process_index = jax.process_index()
+        assigned_objects = objects[process_index :: jax.process_count()]
+        for object_path in assigned_objects:
+            try:
+                bucket, key, _ = fs.split_path(object_path)
+                fs.call_s3("head_object", Bucket=bucket, Key=key, Range=_LOTA_PREFETCH_RANGE)
+            except Exception:
+                logger.exception("Failed to prefetch S3 checkpoint object through LOTA: %s", object_path)
     except Exception:
-        _S3_PREFETCH_FAILURES.add(attributes={"operation": "list"})
-        logger.exception("Failed to list S3 checkpoint objects for cache prefetch: %s", shard.checkpoint_root)
-        return
-
-    failures = 0
-    assigned_objects = objects[shard.process_index :: shard.process_count]
-    for object_path in assigned_objects:
-        try:
-            bucket, key, version_id = fs.split_path(object_path)
-            kwargs = {"Bucket": bucket, "Key": key, "Range": _LOTA_PREFETCH_RANGE}
-            if version_id is not None:
-                kwargs["VersionId"] = version_id
-            fs.call_s3("head_object", **kwargs)
-        except Exception:
-            if failures == 0:
-                logger.exception("Failed to HEAD S3 checkpoint object %s; continuing prefetch", object_path)
-            failures += 1
-
-    if failures:
-        _S3_PREFETCH_FAILURES.add(failures, attributes={"operation": "head"})
-        logger.warning(
-            "Failed to prefetch %d of %d assigned S3 checkpoint objects under %s on process %d",
-            failures,
-            len(assigned_objects),
-            shard.checkpoint_root,
-            shard.process_index,
-        )
-    else:
-        logger.info(
-            "Prefetched %d of %d S3 checkpoint objects under %s on process %d",
-            len(assigned_objects),
-            len(objects),
-            shard.checkpoint_root,
-            shard.process_index,
-        )
+        logger.exception("Failed to prefetch S3 checkpoint through LOTA: %s", checkpoint_root)
 
 
-def _uses_lota_endpoint(endpoint: str) -> bool:
-    hostname = urllib.parse.urlparse(endpoint).hostname or ""
+def _uses_lota(checkpoint_root: str) -> bool:
+    if urllib.parse.urlparse(checkpoint_root).scheme != "s3":
+        return False
+    hostname = urllib.parse.urlparse(s3_endpoint(StoreType.COREWEAVE)).hostname or ""
     return hostname == _LOTA_ENDPOINT_HOST or hostname.endswith(f".{_LOTA_ENDPOINT_HOST}")
 
 
-def _s3_checkpoint_prefetch_shard(
-    checkpoint_root: str, process_index: int, process_count: int
-) -> _S3PrefetchShard | None:
-    if urllib.parse.urlparse(checkpoint_root).scheme != "s3":
-        return None
-    if not _uses_lota_endpoint(s3_endpoint(StoreType.COREWEAVE)):
-        return None
-    return _S3PrefetchShard(checkpoint_root, process_index, process_count)
-
-
 def _start_s3_checkpoint_prefetch(operation: Callable[[], None]) -> None:
-    threading.Thread(
-        target=operation,
-        name=_S3_PREFETCH_THREAD_NAME,
-        daemon=True,
-    ).start()
+    threading.Thread(target=operation, daemon=True).start()
 
 
 def _wait_for_global_commit_and_prefetch(
     manager: array_ser.GlobalAsyncCheckpointManager,
-    shard: _S3PrefetchShard,
+    checkpoint_root: str,
 ) -> None:
     try:
         assert manager._client is not None
@@ -593,13 +544,10 @@ def _wait_for_global_commit_and_prefetch(
         success_key = array_ser._get_key(manager._count)
         manager._client.blocking_key_value_get(success_key, manager._timeout_in_ms)
     except Exception:
-        _S3_PREFETCH_FAILURES.add(attributes={"operation": "commit_wait"})
-        logger.exception(
-            "Failed waiting for global checkpoint commit before S3 cache prefetch: %s", shard.checkpoint_root
-        )
+        logger.exception("Failed waiting for global checkpoint commit before LOTA prefetch: %s", checkpoint_root)
         return
 
-    _prefetch_s3_checkpoint(shard)
+    _prefetch_s3_checkpoint(checkpoint_root)
 
 
 def _is_named_or_none(x):
@@ -704,13 +652,12 @@ def tree_serialize_leaves_tensorstore(
 
     checkpoint_root = str(checkpoint_dir)
     process_index = jax.process_index()
-    process_count = jax.process_count()
-    prefetch_shard = _s3_checkpoint_prefetch_shard(checkpoint_root, process_index, process_count)
+    uses_lota = _uses_lota(checkpoint_root)
 
     def commit_and_prefetch() -> None:
         commit_callback()
-        if process_index == 0 and prefetch_shard is not None:
-            _start_s3_checkpoint_prefetch(partial(_prefetch_s3_checkpoint, prefetch_shard))
+        if process_index == 0 and uses_lota:
+            _start_s3_checkpoint_prefetch(partial(_prefetch_s3_checkpoint, checkpoint_root))
 
     if debug_checkpointer:
         logger.info(
@@ -756,8 +703,8 @@ def tree_serialize_leaves_tensorstore(
         flush_debug_output(logger)
 
     _serialize_arrays(arrays, tspecs, plans, manager, write_config, commit_and_prefetch)
-    if process_index != 0 and prefetch_shard is not None:
-        _start_s3_checkpoint_prefetch(partial(_wait_for_global_commit_and_prefetch, manager, prefetch_shard))
+    if process_index != 0 and uses_lota:
+        _start_s3_checkpoint_prefetch(partial(_wait_for_global_commit_and_prefetch, manager, checkpoint_root))
 
     if debug_checkpointer:
         logger.info("Checkpoint tensorstore serialize handed off async commit for %s", checkpoint_dir)

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -34,8 +34,10 @@ from jax.sharding import Mesh, Sharding
 from jaxtyping import PyTree
 
 from rigging import telemetry
+from rigging.filesystem.cluster_config import StoreType
 from rigging.filesystem.cross_region import record_transfer
 from rigging.filesystem.factory import url_to_fs
+from rigging.filesystem.s3_compat import s3_endpoint
 from rigging.filesystem.storage_path import StoragePath, prefix_join
 
 from levanter._debug_logging import flush_debug_output
@@ -60,6 +62,13 @@ _LOTA_ENDPOINT_HOST = "cwlota.com"
 _LOTA_PREFETCH_RANGE = "bytes=0-0"
 _S3_PREFETCH_THREAD_NAME = "levanter-s3-checkpoint-prefetch"
 _S3_PREFETCH_FAILURES = telemetry.counter("levanter_s3_checkpoint_prefetch_failures", unit="{failure}")
+
+
+@dataclass(frozen=True)
+class _S3PrefetchShard:
+    checkpoint_root: str
+    process_index: int
+    process_count: int
 
 
 def _format_gib(num_bytes: int) -> str:
@@ -473,18 +482,18 @@ async def _list_ocdbt_keys(checkpoint_root: str) -> list[str]:
     return [key.decode("utf-8") for key in keys_bytes]
 
 
-def _prefetch_s3_checkpoint(checkpoint_root: str, process_index: int, process_count: int) -> None:
+def _prefetch_s3_checkpoint(shard: _S3PrefetchShard) -> None:
     """Pre-stage this process's shard of a completed checkpoint through LOTA."""
     try:
-        fs, path = url_to_fs(checkpoint_root)
+        fs, path = url_to_fs(shard.checkpoint_root)
         objects = sorted(fs.find(path))
     except Exception:
         _S3_PREFETCH_FAILURES.add(attributes={"operation": "list"})
-        logger.exception("Failed to list S3 checkpoint objects for cache prefetch: %s", checkpoint_root)
+        logger.exception("Failed to list S3 checkpoint objects for cache prefetch: %s", shard.checkpoint_root)
         return
 
     failures = 0
-    assigned_objects = objects[process_index::process_count]
+    assigned_objects = objects[shard.process_index :: shard.process_count]
     for object_path in assigned_objects:
         try:
             bucket, key, version_id = fs.split_path(object_path)
@@ -503,46 +512,45 @@ def _prefetch_s3_checkpoint(checkpoint_root: str, process_index: int, process_co
             "Failed to prefetch %d of %d assigned S3 checkpoint objects under %s on process %d",
             failures,
             len(assigned_objects),
-            checkpoint_root,
-            process_index,
+            shard.checkpoint_root,
+            shard.process_index,
         )
     else:
         logger.info(
             "Prefetched %d of %d S3 checkpoint objects under %s on process %d",
             len(assigned_objects),
             len(objects),
-            checkpoint_root,
-            process_index,
+            shard.checkpoint_root,
+            shard.process_index,
         )
 
 
-def _uses_lota_endpoint() -> bool:
-    endpoint = os.environ.get("AWS_ENDPOINT_URL_S3") or os.environ.get("AWS_ENDPOINT_URL", "")
+def _uses_lota_endpoint(endpoint: str) -> bool:
     hostname = urllib.parse.urlparse(endpoint).hostname or ""
     return hostname == _LOTA_ENDPOINT_HOST or hostname.endswith(f".{_LOTA_ENDPOINT_HOST}")
 
 
-def _should_prefetch_s3_checkpoint(checkpoint_root: str) -> bool:
-    return urllib.parse.urlparse(checkpoint_root).scheme == "s3" and _uses_lota_endpoint()
+def _s3_checkpoint_prefetch_shard(
+    checkpoint_root: str, process_index: int, process_count: int
+) -> _S3PrefetchShard | None:
+    if urllib.parse.urlparse(checkpoint_root).scheme != "s3":
+        return None
+    if not _uses_lota_endpoint(s3_endpoint(StoreType.COREWEAVE)):
+        return None
+    return _S3PrefetchShard(checkpoint_root, process_index, process_count)
 
 
-def _start_s3_checkpoint_prefetch(checkpoint_root: str, process_index: int, process_count: int) -> None:
-    if not _should_prefetch_s3_checkpoint(checkpoint_root):
-        return
-
+def _start_s3_checkpoint_prefetch(operation: Callable[[], None]) -> None:
     threading.Thread(
-        target=_prefetch_s3_checkpoint,
-        args=(checkpoint_root, process_index, process_count),
+        target=operation,
         name=_S3_PREFETCH_THREAD_NAME,
         daemon=True,
     ).start()
 
 
 def _wait_for_global_commit_and_prefetch(
-    checkpoint_root: str,
     manager: array_ser.GlobalAsyncCheckpointManager,
-    process_index: int,
-    process_count: int,
+    shard: _S3PrefetchShard,
 ) -> None:
     try:
         assert manager._client is not None
@@ -552,27 +560,12 @@ def _wait_for_global_commit_and_prefetch(
         manager._client.blocking_key_value_get(success_key, manager._timeout_in_ms)
     except Exception:
         _S3_PREFETCH_FAILURES.add(attributes={"operation": "commit_wait"})
-        logger.exception("Failed waiting for global checkpoint commit before S3 cache prefetch: %s", checkpoint_root)
+        logger.exception(
+            "Failed waiting for global checkpoint commit before S3 cache prefetch: %s", shard.checkpoint_root
+        )
         return
 
-    _prefetch_s3_checkpoint(checkpoint_root, process_index, process_count)
-
-
-def _start_s3_checkpoint_prefetch_waiter(
-    checkpoint_root: str,
-    manager: array_ser.GlobalAsyncCheckpointManager,
-    process_index: int,
-    process_count: int,
-) -> None:
-    if not _should_prefetch_s3_checkpoint(checkpoint_root):
-        return
-
-    threading.Thread(
-        target=_wait_for_global_commit_and_prefetch,
-        args=(checkpoint_root, manager, process_index, process_count),
-        name=_S3_PREFETCH_THREAD_NAME,
-        daemon=True,
-    ).start()
+    _prefetch_s3_checkpoint(shard)
 
 
 def _is_named_or_none(x):
@@ -678,11 +671,12 @@ def tree_serialize_leaves_tensorstore(
     checkpoint_root = str(checkpoint_dir)
     process_index = jax.process_index()
     process_count = jax.process_count()
+    prefetch_shard = _s3_checkpoint_prefetch_shard(checkpoint_root, process_index, process_count)
 
     def commit_and_prefetch() -> None:
         commit_callback()
-        if process_index == 0:
-            _start_s3_checkpoint_prefetch(checkpoint_root, process_index, process_count)
+        if process_index == 0 and prefetch_shard is not None:
+            _start_s3_checkpoint_prefetch(partial(_prefetch_s3_checkpoint, prefetch_shard))
 
     if debug_checkpointer:
         logger.info(
@@ -728,8 +722,8 @@ def tree_serialize_leaves_tensorstore(
         flush_debug_output(logger)
 
     _serialize_arrays(arrays, tspecs, plans, manager, write_config, commit_and_prefetch)
-    if process_index != 0:
-        _start_s3_checkpoint_prefetch_waiter(checkpoint_root, manager, process_index, process_count)
+    if process_index != 0 and prefetch_shard is not None:
+        _start_s3_checkpoint_prefetch(partial(_wait_for_global_commit_and_prefetch, manager, prefetch_shard))
 
     if debug_checkpointer:
         logger.info("Checkpoint tensorstore serialize handed off async commit for %s", checkpoint_dir)

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -8,6 +8,7 @@ import collections
 import logging
 import math
 import os
+import threading
 import urllib.parse
 import zlib
 from dataclasses import dataclass
@@ -32,6 +33,7 @@ from jax.sharding import Mesh, Sharding
 from jaxtyping import PyTree
 
 from rigging.filesystem.cross_region import record_transfer
+from rigging.filesystem.factory import url_to_fs
 from rigging.filesystem.storage_path import StoragePath, prefix_join
 
 from levanter._debug_logging import flush_debug_output
@@ -56,6 +58,7 @@ _STAGED_BYTE_OVERHEAD = 4
 # Host memory each process may hold in flight while a restore reads shards. JAX defaults to 32 GB
 # and the legacy path asked for 300, both far above what a save allows itself on the same node.
 _RESTORE_CONCURRENT_GB = 8
+_S3_PREFETCH_THREAD_NAME = "levanter-s3-checkpoint-prefetch"
 
 
 def _format_gib(num_bytes: int) -> str:
@@ -437,6 +440,49 @@ async def _list_ocdbt_keys(checkpoint_root: str) -> list[str]:
     return [key.decode("utf-8") for key in keys_bytes]
 
 
+def _prefetch_s3_checkpoint(checkpoint_root: str) -> None:
+    """Issue an S3 HEAD for every object in a completed checkpoint."""
+    try:
+        fs, path = url_to_fs(checkpoint_root)
+        objects = fs.find(path)
+    except Exception:
+        logger.exception("Failed to list S3 checkpoint objects for cache prefetch: %s", checkpoint_root)
+        return
+
+    failures = 0
+    for object_path in objects:
+        try:
+            # S3FS may satisfy info from its listing cache unless refresh is explicit.
+            fs.info(object_path, refresh=True)
+        except Exception:
+            if failures == 0:
+                logger.exception("Failed to HEAD S3 checkpoint object %s; continuing prefetch", object_path)
+            failures += 1
+
+    if failures:
+        logger.warning(
+            "Failed to prefetch %d of %d S3 checkpoint objects under %s",
+            failures,
+            len(objects),
+            checkpoint_root,
+        )
+    else:
+        logger.info("Prefetched %d S3 checkpoint objects under %s", len(objects), checkpoint_root)
+
+
+def _start_s3_checkpoint_prefetch(checkpoint_root: str) -> None:
+    checkpoint_root = str(checkpoint_root)
+    if jax.process_index() != 0 or urllib.parse.urlparse(checkpoint_root).scheme != "s3":
+        return
+
+    threading.Thread(
+        target=_prefetch_s3_checkpoint,
+        args=(checkpoint_root,),
+        name=_S3_PREFETCH_THREAD_NAME,
+        daemon=True,
+    ).start()
+
+
 def _is_named_or_none(x):
     return x is None or is_named_array(x)
 
@@ -537,6 +583,10 @@ def tree_serialize_leaves_tensorstore(
     if commit_callback is None:
         commit_callback = lambda: logger.info("Committed checkpoint to Tensorstore")  # noqa
 
+    def commit_and_prefetch() -> None:
+        commit_callback()
+        _start_s3_checkpoint_prefetch(checkpoint_dir)
+
     if debug_checkpointer:
         logger.info(
             "Checkpoint tensorstore serialize start: dir=%s arrays=%d total=%s largest=%s (%s)",
@@ -580,7 +630,7 @@ def tree_serialize_leaves_tensorstore(
         )
         flush_debug_output(logger)
 
-    _serialize_arrays(arrays, tspecs, plans, manager, write_config, commit_callback)
+    _serialize_arrays(arrays, tspecs, plans, manager, write_config, commit_and_prefetch)
 
     if debug_checkpointer:
         logger.info("Checkpoint tensorstore serialize handed off async commit for %s", checkpoint_dir)

--- a/lib/levanter/tests/test_tensorstore_serialization.py
+++ b/lib/levanter/tests/test_tensorstore_serialization.py
@@ -65,7 +65,7 @@ def test_s3_checkpoint_prefetch_heads_every_object_from_a_daemon_thread(monkeypa
     monkeypatch.setattr(
         tensorstore_serialization,
         "url_to_fs",
-        lambda path: (RecordingS3FileSystem(), plain_path),
+        lambda _: (RecordingS3FileSystem(), plain_path),
     )
 
     tensorstore_serialization._start_s3_checkpoint_prefetch(checkpoint_path)

--- a/lib/levanter/tests/test_tensorstore_serialization.py
+++ b/lib/levanter/tests/test_tensorstore_serialization.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import json
+import threading
 from tempfile import TemporaryDirectory
 from typing import Any
 
@@ -18,6 +19,7 @@ from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 from levanter.testing.helpers import MLP, arrays_only, assert_trees_not_close, use_test_mesh
 
+import levanter.tensorstore_serialization as tensorstore_serialization
 from levanter.checkpoint import load_checkpoint, save_checkpoint
 from levanter.checkpoint_manifest import CHECKPOINT_FORMAT_VERSION, manifest_path, read_manifest
 from levanter.models.gpt2 import Gpt2Mlp
@@ -41,6 +43,35 @@ def test_pageable_checkpoint_staging_detaches_from_donated_jax_buffer():
     source_host = np.asarray(source)
     np.testing.assert_array_equal(staged, source_host)
     assert not np.shares_memory(staged, source_host)
+
+
+def test_s3_checkpoint_prefetch_heads_every_object_from_a_daemon_thread(monkeypatch):
+    checkpoint_path = "s3://checkpoints/run/step-10"
+    plain_path = "checkpoints/run/step-10"
+    objects = [f"{plain_path}/manifest.json", f"{plain_path}/d/0000000000000001"]
+    heads = []
+    completed = threading.Event()
+
+    class RecordingS3FileSystem:
+        def find(self, path):
+            assert path == plain_path
+            return objects
+
+        def info(self, path, *, refresh):
+            heads.append((path, refresh, threading.current_thread().daemon))
+            if len(heads) == len(objects):
+                completed.set()
+
+    monkeypatch.setattr(
+        tensorstore_serialization,
+        "url_to_fs",
+        lambda path: (RecordingS3FileSystem(), plain_path),
+    )
+
+    tensorstore_serialization._start_s3_checkpoint_prefetch(checkpoint_path)
+
+    assert completed.wait(timeout=5)
+    assert heads == [(path, True, True) for path in objects]
 
 
 def test_tensorstore_checkpoint_simple():

--- a/lib/levanter/tests/test_tensorstore_serialization.py
+++ b/lib/levanter/tests/test_tensorstore_serialization.py
@@ -46,10 +46,13 @@ def test_pageable_checkpoint_staging_detaches_from_donated_jax_buffer():
     assert not np.shares_memory(staged, source_host)
 
 
-def test_s3_checkpoint_prefetch_heads_every_object_from_a_daemon_thread(monkeypatch):
+@pytest.mark.parametrize("process_index", [0, 1])
+def test_s3_checkpoint_prefetch_shards_ranged_heads_after_commit(monkeypatch, process_index):
     checkpoint_path = "s3://checkpoints/run/step-10"
     plain_path = "checkpoints/run/step-10"
     objects = [f"{plain_path}/manifest.json", f"{plain_path}/d/0000000000000001"]
+    assigned_objects = sorted(objects)[process_index::2]
+    events = []
     heads = []
     completed = threading.Event()
 
@@ -58,21 +61,71 @@ def test_s3_checkpoint_prefetch_heads_every_object_from_a_daemon_thread(monkeypa
             assert path == plain_path
             return objects
 
-        def info(self, path, *, refresh):
-            heads.append((path, refresh, threading.current_thread().daemon))
-            if len(heads) == len(objects):
+        def split_path(self, path):
+            bucket, key = path.split("/", 1)
+            return bucket, key, None
+
+        def call_s3(self, method, **kwargs):
+            events.append("head")
+            heads.append((method, kwargs, threading.current_thread().daemon))
+            if len(heads) == len(assigned_objects):
                 completed.set()
 
+    class RecordingClient:
+        def blocking_key_value_get(self, key, timeout):
+            assert process_index == 1
+            assert key == "tensorstore_checkpoint_7"
+            assert timeout == 1_000
+            events.append("commit")
+
+    class RecordingManager:
+        _client = RecordingClient()
+        _count = 7
+        _timeout_in_ms = 1_000
+
+    def record_serialize(_arrays, _tspecs, _plans, _manager, _config, commit_callback):
+        events.append("serialize")
+        if process_index == 0:
+            commit_callback()
+
+    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "http://cwlota.com")
+    monkeypatch.setattr(tensorstore_serialization.jax, "process_index", lambda: process_index)
+    monkeypatch.setattr(tensorstore_serialization.jax, "process_count", lambda: 2)
+    monkeypatch.setattr(tensorstore_serialization, "write_manifest", lambda *_: None)
+    monkeypatch.setattr(tensorstore_serialization, "record_transfer", lambda *_: None)
+    monkeypatch.setattr(tensorstore_serialization, "_serialize_arrays", record_serialize)
     monkeypatch.setattr(
         tensorstore_serialization,
         "url_to_fs",
         lambda _: (RecordingS3FileSystem(), plain_path),
     )
 
-    tensorstore_serialization._start_s3_checkpoint_prefetch(checkpoint_path)
+    tree_serialize_leaves_tensorstore(
+        checkpoint_path,
+        {"weights": np.arange(4, dtype=np.float32)},
+        manager=RecordingManager(),
+        commit_callback=lambda: events.append("commit"),
+    )
 
     assert completed.wait(timeout=5)
-    assert heads == [(path, True, True) for path in objects]
+    assert events == ["serialize", "commit", "head"]
+    assert heads == [
+        (
+            "head_object",
+            {"Bucket": "checkpoints", "Key": object_path.removeprefix("checkpoints/"), "Range": "bytes=0-0"},
+            True,
+        )
+        for object_path in assigned_objects
+    ]
+
+
+def test_s3_checkpoint_prefetch_skips_non_lota_endpoint(monkeypatch):
+    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "https://cwobject.com")
+    monkeypatch.setattr(tensorstore_serialization, "url_to_fs", lambda _: pytest.fail("unexpected S3 request"))
+
+    tensorstore_serialization._start_s3_checkpoint_prefetch("s3://checkpoints/run/step-10", 0, 1)
 
 
 def test_tensorstore_checkpoint_simple():

--- a/lib/levanter/tests/test_tensorstore_serialization.py
+++ b/lib/levanter/tests/test_tensorstore_serialization.py
@@ -5,7 +5,9 @@ import asyncio
 import json
 import threading
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
 import equinox as eqx
 import haliax as hax
@@ -46,45 +48,33 @@ def test_pageable_checkpoint_staging_detaches_from_donated_jax_buffer():
     assert not np.shares_memory(staged, source_host)
 
 
-@pytest.mark.parametrize("process_index", [0, 1])
-def test_s3_checkpoint_prefetch_shards_ranged_heads_after_commit(monkeypatch, process_index):
+@pytest.mark.parametrize(
+    ("process_index", "object_name"),
+    [(0, "d/0000000000000001"), (1, "manifest.json")],
+)
+def test_s3_checkpoint_prefetch_shards_ranged_heads_after_commit(monkeypatch, process_index, object_name):
     checkpoint_path = "s3://checkpoints/run/step-10"
     plain_path = "checkpoints/run/step-10"
     objects = [f"{plain_path}/manifest.json", f"{plain_path}/d/0000000000000001"]
-    assigned_objects = sorted(objects)[process_index::2]
     events = []
     heads = []
     completed = threading.Event()
 
-    class RecordingS3FileSystem:
-        def find(self, path):
-            assert path == plain_path
-            return objects
+    fs = Mock()
+    fs.find.return_value = objects
+    fs.split_path.side_effect = lambda path: (*path.split("/", 1), None)
 
-        def split_path(self, path):
-            bucket, key = path.split("/", 1)
-            return bucket, key, None
+    def record_head(method, **kwargs):
+        events.append("head")
+        heads.append((method, kwargs, threading.current_thread().daemon))
+        completed.set()
 
-        def call_s3(self, method, **kwargs):
-            events.append("head")
-            heads.append((method, kwargs, threading.current_thread().daemon))
-            if len(heads) == len(assigned_objects):
-                completed.set()
-
-    class RecordingClient:
-        def blocking_key_value_get(self, key, timeout):
-            assert process_index == 1
-            assert key == "tensorstore_checkpoint_7"
-            assert timeout == 1_000
-            events.append("commit")
-
-    class RecordingManager:
-        _client = RecordingClient()
-        _count = 7
-        _timeout_in_ms = 1_000
+    fs.call_s3.side_effect = record_head
+    client = Mock()
+    client.blocking_key_value_get.side_effect = lambda *_: events.append("commit")
+    manager = SimpleNamespace(_client=client, _count=7, _timeout_in_ms=1_000)
 
     def record_serialize(_arrays, _tspecs, _plans, _manager, _config, commit_callback):
-        events.append("serialize")
         if process_index == 0:
             commit_callback()
 
@@ -97,35 +87,34 @@ def test_s3_checkpoint_prefetch_shards_ranged_heads_after_commit(monkeypatch, pr
     monkeypatch.setattr(
         tensorstore_serialization,
         "url_to_fs",
-        lambda _: (RecordingS3FileSystem(), plain_path),
+        lambda _: (fs, plain_path),
     )
 
     tree_serialize_leaves_tensorstore(
         checkpoint_path,
         {"weights": np.arange(4, dtype=np.float32)},
-        manager=RecordingManager(),
+        manager=manager,
         commit_callback=lambda: events.append("commit"),
     )
 
     assert completed.wait(timeout=5)
-    assert events == ["serialize", "commit", "head"]
+    assert events == ["commit", "head"]
     assert heads == [
         (
             "head_object",
-            {"Bucket": "checkpoints", "Key": object_path.removeprefix("checkpoints/"), "Range": "bytes=0-0"},
+            {"Bucket": "checkpoints", "Key": f"run/step-10/{object_name}", "Range": "bytes=0-0"},
             True,
         )
-        for object_path in assigned_objects
     ]
 
 
 def test_s3_checkpoint_prefetch_only_targets_lota_s3(monkeypatch):
     monkeypatch.setattr(tensorstore_serialization, "s3_endpoint", lambda _: "https://cwobject.com")
-    assert tensorstore_serialization._s3_checkpoint_prefetch_shard("s3://checkpoints/run", 0, 1) is None
+    assert not tensorstore_serialization._uses_lota("s3://checkpoints/run")
 
     monkeypatch.setattr(tensorstore_serialization, "s3_endpoint", lambda _: "http://cwlota.com")
-    assert tensorstore_serialization._s3_checkpoint_prefetch_shard("s3://checkpoints/run", 0, 1) is not None
-    assert tensorstore_serialization._s3_checkpoint_prefetch_shard("gs://checkpoints/run", 0, 1) is None
+    assert tensorstore_serialization._uses_lota("s3://checkpoints/run")
+    assert not tensorstore_serialization._uses_lota("gs://checkpoints/run")
 
 
 def test_tensorstore_checkpoint_simple():

--- a/lib/levanter/tests/test_tensorstore_serialization.py
+++ b/lib/levanter/tests/test_tensorstore_serialization.py
@@ -88,8 +88,7 @@ def test_s3_checkpoint_prefetch_shards_ranged_heads_after_commit(monkeypatch, pr
         if process_index == 0:
             commit_callback()
 
-    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
-    monkeypatch.setenv("AWS_ENDPOINT_URL", "http://cwlota.com")
+    monkeypatch.setattr(tensorstore_serialization, "s3_endpoint", lambda _: "http://cwlota.com")
     monkeypatch.setattr(tensorstore_serialization.jax, "process_index", lambda: process_index)
     monkeypatch.setattr(tensorstore_serialization.jax, "process_count", lambda: 2)
     monkeypatch.setattr(tensorstore_serialization, "write_manifest", lambda *_: None)
@@ -120,12 +119,13 @@ def test_s3_checkpoint_prefetch_shards_ranged_heads_after_commit(monkeypatch, pr
     ]
 
 
-def test_s3_checkpoint_prefetch_skips_non_lota_endpoint(monkeypatch):
-    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
-    monkeypatch.setenv("AWS_ENDPOINT_URL", "https://cwobject.com")
-    monkeypatch.setattr(tensorstore_serialization, "url_to_fs", lambda _: pytest.fail("unexpected S3 request"))
+def test_s3_checkpoint_prefetch_only_targets_lota_s3(monkeypatch):
+    monkeypatch.setattr(tensorstore_serialization, "s3_endpoint", lambda _: "https://cwobject.com")
+    assert tensorstore_serialization._s3_checkpoint_prefetch_shard("s3://checkpoints/run", 0, 1) is None
 
-    tensorstore_serialization._start_s3_checkpoint_prefetch("s3://checkpoints/run/step-10", 0, 1)
+    monkeypatch.setattr(tensorstore_serialization, "s3_endpoint", lambda _: "http://cwlota.com")
+    assert tensorstore_serialization._s3_checkpoint_prefetch_shard("s3://checkpoints/run", 0, 1) is not None
+    assert tensorstore_serialization._s3_checkpoint_prefetch_shard("gs://checkpoints/run", 0, 1) is None
 
 
 def test_tensorstore_checkpoint_simple():


### PR DESCRIPTION
Pre-stage S3 checkpoint objects through CoreWeave LOTA after each successful global TensorStore commit. Every JAX process lists the same sorted objects and issues `HeadObject` with `Range: bytes=0-0` for its rank-strided shard. Nonzero ranks wait for JAX's global checkpoint-success key before starting. The daemon work runs only when the CoreWeave endpoint resolves to `cwlota.com`; failures are logged without interrupting checkpointing.

An ad hoc remote benchmark ran from `cw-us-east-08a` through the Marin federation against `cwlota.com` with 100 MiB objects, 32-way writes and reads, ranged HEADs, and a five-minute cache wait. At 1 GiB per arm, treatment read at 1.413 GiB/s versus 0.743 GiB/s for control, a 1.90x speedup. At 10 GiB per arm, treatment read at 1.579 GiB/s versus 1.448 GiB/s, a 1.09x speedup. At 100 GiB per arm, treatment read at 1.551 GiB/s versus 1.562 GiB/s, a flat 0.99x result. Treatment was read before control, which may favor control through connection reuse, and the benchmark did not exercise a TensorStore restore.
