### PR TITLE
[grug] Give the progress watchdog a deadline that covers startup

### DIFF
--- a/experiments/grug/checkpointing.py
+++ b/experiments/grug/checkpointing.py
@@ -19,9 +19,13 @@ logger = logging.getLogger(__name__)
 
 StateT = TypeVar("StateT")
 RESTORE_COMPLETE_BARRIER = "grug_checkpoint_restore_complete"
-# Well clear of a cold restore, which reads for tens of minutes. Expiring aborts the attempt for
-# the scheduler to retry, rather than holding every rank behind one that may never arrive.
-RESTORE_BARRIER_TIMEOUT = 90 * 60
+# The barrier runs one clock, started by the first rank to arrive, so this bounds the spread
+# between arrivals rather than the length of a restore. A gang whose object-store caches are only
+# partly warm spreads widest, since re-reading a checkpoint is an order of magnitude faster than
+# reading it cold, and killing a stalled gang is what leaves a fleet in that state. Expiring
+# aborts the attempt for the scheduler to retry, rather than holding every rank behind one that
+# never arrives.
+RESTORE_BARRIER_TIMEOUT = 40 * 60
 
 
 class _GrugState(Protocol):

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -29,6 +29,7 @@ import click
 import jmp
 from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfilerConfig
+from levanter.callbacks.progress_watchdog import ProgressWatchdogConfig
 from levanter.callbacks.watch import WatchConfig
 from levanter.checkpoint import CheckpointerConfig
 from levanter.tracker.wandb import WandbConfig
@@ -41,6 +42,7 @@ from marin.training.training import temporary_checkpoint_base_path
 from rigging.filesystem.storage_path import prefix_join
 
 from experiments.datasets.uncheatable import uncheatable_datasets
+from experiments.grug.checkpointing import RESTORE_BARRIER_TIMEOUT
 from experiments.grug.moe_hero_ep.harrier_mix_2026_08_18 import (
     HARRIER_MIX_2026_08_18_STORE,
     HARRIER_MIX_2026_08_18_TAG,
@@ -78,6 +80,14 @@ from experiments.marin_tokenizer import marin_tokenizer
 
 # Ladder rungs, each pinned to the rack count that holds its batch. d6144 is the hero, reusing
 # HERO_MODEL; the narrower rungs reuse the ablation's `_small_model` at the same hero routing geometry.
+# Deadlines for the progress watchdog. A stalled process exits so the scheduler can replace the
+# gang rather than leaving every rank blocked on it.
+HERO_STEP_TIMEOUT = timedelta(minutes=15)
+HERO_PROCESS_STALL_TIMEOUT = timedelta(hours=1)
+# Twice the restore barrier, which keeps a barrier expiry ahead of this deadline: the barrier
+# names the ranks that never arrived, while this one only reports that nothing progressed.
+HERO_STARTUP_TIMEOUT = timedelta(seconds=2 * RESTORE_BARRIER_TIMEOUT)
+
 LADDER_RACKS: dict[str, int] = {"d768": 1, "d1024": 2, "d1536": 6, "d2048": 11, "d6144": 11}
 QB_HIST_BINS = 10_000
 # Gradient and parameter norm logs every 10 steps on every rung.
@@ -240,6 +250,11 @@ def build_ladder_run(
                 replicate_path=ctx.output_path,
             ),
             watch=WatchConfig(interval=WATCH_INTERVAL),
+            progress_watchdog=ProgressWatchdogConfig(
+                step_timeout=HERO_STEP_TIMEOUT,
+                process_timeout=HERO_PROCESS_STALL_TIMEOUT,
+                startup_timeout=HERO_STARTUP_TIMEOUT,
+            ),
             use_explicit_mesh_axes=True,
             require_accelerator=True,
             allow_nondivisible_batch_size=False,

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -806,6 +806,11 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         expert_axis_size=config.trainer.expert_axis_size,
         replica_axis_size=config.trainer.replica_axis_size,
     )
+    # Armed before the state is built or restored. The watchdog's step and process deadlines only
+    # arm once a step reports progress, so its startup deadline is the only thing bounding a stall
+    # in initialization, checkpoint restore, cache construction or compilation.
+    progress_watchdog = trainer.progress_watchdog.create(process_index=jax.process_index())
+
     with set_mesh(mesh):
         batch_schedule = trainer.batch_schedule
 
@@ -928,6 +933,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             eval_model_getter=lambda s: s.ema_params if s.ema_params is not None else s.params,
             opt_state_getter=lambda s: s.opt_state,
         )
+        if progress_watchdog is not None:
+            state_callbacks.add_hook(progress_watchdog, every=1)
         state_callbacks.add_hook(
             callbacks.log_performance_stats(config.model.max_seq_len, batch_schedule, flops_per_example),
             every=log_every,
@@ -1017,12 +1024,14 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 else:
                     watch_stats = None
                 step_start = time.perf_counter()
+                state_callbacks.emit_event(callbacks.ProgressEvent.TRAIN_STEP_STARTED)
                 state, metrics, inline_watch_stats = train_step(state, batch)
                 if inline_watch_stats is not None and watch_due:
                     watch_stats = inline_watch_stats
                 step = int(state.step) - 1
 
                 jax.block_until_ready(metrics["train/loss"])
+                state_callbacks.emit_event(callbacks.ProgressEvent.TRAIN_STEP_FINISHED)
 
                 if not jnp.isfinite(metrics["train/loss"]):
                     raise RuntimeError(f"Non-finite loss ({float(metrics['train/loss'])}) at step {int(state.step)}.")

--- a/experiments/grug/moe_hero_fsdp/launch.py
+++ b/experiments/grug/moe_hero_fsdp/launch.py
@@ -31,6 +31,7 @@ from marin.experiment.namespacing import user_namespaced_name
 from marin.processing.tokenize.tokenize import TokenizedCache
 from rigging.filesystem.storage_path import prefix_join
 
+from experiments.grug.checkpointing import RESTORE_BARRIER_TIMEOUT
 from experiments.grug.moe_hero_fsdp.heuristic import build_hero_configs
 from experiments.grug.moe_hero_fsdp.model import GrugModelConfig, RematMode, SmallParamSharding
 from experiments.grug.moe_hero_fsdp.optimizer import GrugMoeMuonHConfig
@@ -56,6 +57,9 @@ HERO_CHECKPOINT_INTERVAL = timedelta(minutes=30)
 HERO_TRAIN_STEP_TIMEOUT = timedelta(minutes=15)
 # Evaluation, checkpointing, and other hooks use this process-wide deadline.
 HERO_PROCESS_STALL_TIMEOUT = timedelta(hours=1)
+# Twice the restore barrier, which keeps a barrier expiry ahead of this deadline: the barrier
+# names the ranks that never arrived, while this one only reports that nothing progressed.
+HERO_STARTUP_TIMEOUT = timedelta(seconds=2 * RESTORE_BARRIER_TIMEOUT)
 HERO_STALL_DIAGNOSTIC_TIMEOUT = timedelta(seconds=20)
 # Grad/param norm reductions run outside the scanned step, cost a visible slice of a short run's
 # wall clock, and can require a 117 GiB temporary buffer on this model. The hero default leaves
@@ -136,6 +140,7 @@ def _hero_run_config(
         progress_watchdog=ProgressWatchdogConfig(
             step_timeout=HERO_TRAIN_STEP_TIMEOUT,
             process_timeout=HERO_PROCESS_STALL_TIMEOUT,
+            startup_timeout=HERO_STARTUP_TIMEOUT,
             diagnostic_timeout=HERO_STALL_DIAGNOSTIC_TIMEOUT,
         ),
         use_explicit_mesh_axes=True,

--- a/experiments/grug/moe_hero_fsdp/train.py
+++ b/experiments/grug/moe_hero_fsdp/train.py
@@ -513,6 +513,14 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         expert_axis_size=config.trainer.expert_axis_size,
         replica_axis_size=config.trainer.replica_axis_size,
     )
+    # Armed before the state is built or restored, so its startup deadline covers a stall in
+    # initialization, checkpoint restore, cache construction or compilation. The step and process
+    # deadlines only arm once a step reports progress.
+    progress_watchdog = trainer.progress_watchdog.create(
+        process_index=jax.process_index(),
+        diagnostic=capture_stall_diagnostics,
+    )
+
     with set_mesh(mesh):
         batch_schedule = trainer.batch_schedule
 
@@ -583,10 +591,6 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             model_getter=lambda s: s.params,
             eval_model_getter=lambda s: s.ema_params if s.ema_params is not None else s.params,
             opt_state_getter=lambda s: s.opt_state,
-        )
-        progress_watchdog = trainer.progress_watchdog.create(
-            process_index=jax.process_index(),
-            diagnostic=capture_stall_diagnostics,
         )
         if progress_watchdog is not None:
             state_callbacks.add_hook(progress_watchdog, every=1)

--- a/lib/levanter/src/levanter/callbacks/_core.py
+++ b/lib/levanter/src/levanter/callbacks/_core.py
@@ -23,6 +23,7 @@ CBInfo = TypeVar("CBInfo")
 class ProgressEvent(StrEnum):
     """Lifecycle events that represent forward progress through training."""
 
+    PROCESS_STARTED = "process_started"
     TRAIN_STEP_STARTED = "train_step_started"
     TRAIN_STEP_FINISHED = "train_step_finished"
     EVALUATION_STARTED = "evaluation_started"

--- a/lib/levanter/src/levanter/callbacks/progress_watchdog.py
+++ b/lib/levanter/src/levanter/callbacks/progress_watchdog.py
@@ -38,13 +38,16 @@ class ProgressWatchdog(Callback[Any]):
         *,
         step_timeout: timedelta | None,
         process_timeout: timedelta | None,
+        startup_timeout: timedelta | None = None,
         startup_grace_period: timedelta = _DEFAULT_STARTUP_GRACE_PERIOD,
         diagnostic: Callable[[ProgressTimeout], None] | None = None,
         diagnostic_timeout: timedelta | None = None,
         poll_interval: float = _WATCHDOG_POLL_INTERVAL,
     ) -> None:
-        if step_timeout is None and process_timeout is None:
+        if step_timeout is None and process_timeout is None and startup_timeout is None:
             raise ValueError("at least one watchdog timeout must be set")
+        if startup_timeout is not None and startup_timeout.total_seconds() <= 0:
+            raise ValueError("startup_timeout must be positive")
         if step_timeout is not None and step_timeout.total_seconds() <= 0:
             raise ValueError("step_timeout must be positive")
         if process_timeout is not None and process_timeout.total_seconds() <= 0:
@@ -58,6 +61,7 @@ class ProgressWatchdog(Callback[Any]):
         if poll_interval <= 0:
             raise ValueError("poll_interval must be positive")
 
+        self._startup_timeout = startup_timeout.total_seconds() if startup_timeout is not None else None
         self._step_timeout = step_timeout.total_seconds() if step_timeout is not None else None
         self._process_timeout = process_timeout.total_seconds() if process_timeout is not None else None
         self._startup_grace_period = startup_grace_period.total_seconds()
@@ -65,6 +69,7 @@ class ProgressWatchdog(Callback[Any]):
         self._diagnostic_timeout = diagnostic_timeout.total_seconds() if diagnostic_timeout is not None else None
         self._poll_interval = poll_interval
         self._lock = threading.Lock()
+        self._created_at = monotonic()
         self._completed_training_step = False
         self._training_started_at: float | None = None
         self._active_step_started_at: float | None = None
@@ -108,9 +113,20 @@ class ProgressWatchdog(Callback[Any]):
         while not self._stop.wait(self._poll_interval):
             now = monotonic()
             with self._lock:
+                completed_training_step = self._completed_training_step
                 training_started_at = self._training_started_at
                 active_step_started_at = self._active_step_started_at
                 last_progress = self._last_progress
+
+            if not completed_training_step:
+                # No step has completed, so the process is still restoring, building caches, or
+                # compiling its first step. Elapsed time is all that bounds this: the step deadline
+                # stays unarmed until a step completes, and the process deadline has no progress
+                # event to measure from.
+                if self._startup_timeout is not None and now - self._created_at >= self._startup_timeout:
+                    self._terminate(ProgressEvent.PROCESS_STARTED, now - self._created_at, self._startup_timeout)
+                    return
+                continue
 
             if training_started_at is None or now - training_started_at < self._startup_grace_period:
                 continue
@@ -168,12 +184,15 @@ class ProgressWatchdogConfig:
 
     step_timeout: timedelta | None = None
     process_timeout: timedelta | None = None
+    startup_timeout: timedelta | None = None
     startup_grace_period: timedelta = _DEFAULT_STARTUP_GRACE_PERIOD
     diagnostic_timeout: timedelta | None = None
 
     def __post_init__(self) -> None:
         if self.step_timeout is not None and self.step_timeout.total_seconds() <= 0:
             raise ValueError("step_timeout must be positive")
+        if self.startup_timeout is not None and self.startup_timeout.total_seconds() <= 0:
+            raise ValueError("startup_timeout must be positive")
         if self.process_timeout is not None and self.process_timeout.total_seconds() <= 0:
             raise ValueError("process_timeout must be positive")
         if self.startup_grace_period.total_seconds() < 0:
@@ -187,7 +206,7 @@ class ProgressWatchdogConfig:
         process_index: int = 0,
         diagnostic: Callable[[ProgressTimeout], None] | None = None,
     ) -> ProgressWatchdog | None:
-        if self.step_timeout is None and self.process_timeout is None:
+        if self.step_timeout is None and self.process_timeout is None and self.startup_timeout is None:
             return None
         if self.diagnostic_timeout is not None and process_index != 0:
             return None
@@ -196,6 +215,7 @@ class ProgressWatchdogConfig:
         return ProgressWatchdog(
             step_timeout=self.step_timeout,
             process_timeout=self.process_timeout,
+            startup_timeout=self.startup_timeout,
             startup_grace_period=self.startup_grace_period,
             diagnostic=diagnostic if self.diagnostic_timeout is not None else None,
             diagnostic_timeout=self.diagnostic_timeout,

--- a/lib/levanter/tests/test_progress_watchdog.py
+++ b/lib/levanter/tests/test_progress_watchdog.py
@@ -170,3 +170,74 @@ def test_watchdog_config_with_diagnostic_timeout_only_arms_process_zero() -> Non
     watchdog = config.create(process_index=0, diagnostic=lambda _timeout: None)
     assert watchdog is not None
     watchdog.stop()
+
+
+def test_watchdog_terminates_when_the_first_training_step_never_starts(monkeypatch):
+    """Restore, cache construction and compile precede any progress event.
+
+    The step and process deadlines only arm once a step has reported progress, so without a
+    startup deadline a process that never reaches its first step waits forever.
+    """
+    terminated = Event()
+    current_time = 0.0
+
+    monkeypatch.setattr(progress_watchdog_module.os, "_exit", lambda _exit_code: terminated.set())
+    monkeypatch.setattr(progress_watchdog_module, "monotonic", lambda: current_time)
+    watchdog = ProgressWatchdog(
+        step_timeout=timedelta(seconds=1),
+        process_timeout=timedelta(seconds=1),
+        startup_timeout=timedelta(hours=2),
+        poll_interval=0.005,
+    )
+
+    current_time = timedelta(hours=2).total_seconds() - 1
+    assert not terminated.wait(timeout=0.03)
+
+    current_time = timedelta(hours=2).total_seconds()
+    assert terminated.wait(timeout=1)
+    watchdog.stop()
+
+
+def test_watchdog_startup_deadline_covers_a_first_step_that_never_finishes(monkeypatch):
+    """The first step is exempt from the step deadline while it compiles, so if that compile hangs
+    the startup deadline is the only thing left to catch it."""
+    terminated = Event()
+    current_time = 0.0
+
+    monkeypatch.setattr(progress_watchdog_module.os, "_exit", lambda _exit_code: terminated.set())
+    monkeypatch.setattr(progress_watchdog_module, "monotonic", lambda: current_time)
+    watchdog = ProgressWatchdog(
+        step_timeout=timedelta(seconds=1),
+        process_timeout=timedelta(seconds=1),
+        startup_timeout=timedelta(hours=2),
+        poll_interval=0.005,
+    )
+    watchdog.on_event(ProgressEvent.TRAIN_STEP_STARTED)
+
+    current_time = timedelta(hours=2).total_seconds()
+
+    assert terminated.wait(timeout=1)
+    watchdog.stop()
+
+
+def test_watchdog_startup_deadline_lapses_once_a_step_completes(monkeypatch):
+    """A run that is training must not be killed for outliving the startup deadline."""
+    terminated = Event()
+    current_time = 0.0
+
+    monkeypatch.setattr(progress_watchdog_module.os, "_exit", lambda _exit_code: terminated.set())
+    monkeypatch.setattr(progress_watchdog_module, "monotonic", lambda: current_time)
+    watchdog = ProgressWatchdog(
+        step_timeout=timedelta(hours=10),
+        process_timeout=timedelta(hours=10),
+        startup_timeout=timedelta(hours=2),
+        startup_grace_period=timedelta(hours=1),
+        poll_interval=0.005,
+    )
+    watchdog.on_event(ProgressEvent.TRAIN_STEP_STARTED)
+    watchdog.on_event(ProgressEvent.TRAIN_STEP_FINISHED)
+
+    current_time = timedelta(hours=3).total_seconds()
+
+    assert not terminated.wait(timeout=0.05)
+    watchdog.stop()


### PR DESCRIPTION
`ProgressWatchdog` could not terminate a process that stalled before its first training step. `_run` returns early while `_training_started_at` is None, and that field is set only on `TRAIN_STEP_STARTED`, so restore, cache construction and compilation were unbounded. `startup_grace_period` does not help: it is measured from the first step, so it delays arming after training begins rather than bounding the wait before it.

`startup_timeout` bounds the time from watchdog construction to the first completed training step, and expires with `PROCESS_STARTED` as the event that last made progress. It lapses on that first completed step, not on the first step to start, because the first step is exempt from the step deadline while it compiles and the process deadline has no progress event to measure from; lapsing any earlier would leave a hanging first compile unbounded.

The watchdog was also constructed after the checkpoint restore in both hero entry points, so the object did not exist during the window this covers. It now starts before the state is built, and the callback hook is registered where it was.

`moe_hero_ep` had no watchdog at all, so the EP hero ran with none of these deadlines. It now configures one, and its training loop emits the paired `TRAIN_STEP_STARTED` and `TRAIN_STEP_FINISHED` events that the FSDP loop already emits. Without them no step ever reports progress, which left the step and process deadlines permanently unarmed and would have made the new startup deadline terminate healthy training. Its startup deadline is twice the restore barrier, so 80 minutes.

The restore barrier from #8538 comes down from 90 to 40 minutes in the same pass. Both deadlines were first sized when the restore was also going to retry reads in process, which added roughly half an hour that no longer exists. The barrier runs one clock for the whole barrier, started by its first arrival, so what it bounds is the spread between the first and last rank to arrive, not the length of a restore. Restore times are bimodal: five cold reads of the same checkpoint took 22, 22, 23, 24 and 26 minutes, while two re-reads about 45 minutes later took 1m46s and 1m50s. A uniform gang's arrivals fall inside one ten-minute profiling window, but a gang left partly warm by a crash mid-restore spreads across the full gap, about 24 minutes. That case is the one this timeout will meet most often, since killing a stalled gang is what leaves the fleet unevenly warm. Forty minutes covers it with about 1.7x of margin; below roughly 26 minutes a warm rank starting the clock would strand a healthy cold one.

The startup deadline is derived from the barrier rather than from its own worst case, because the two interact. The watchdog counts from process start, while a coordination-service barrier runs one clock for the whole barrier, started by its first arrival, and expiring fails every waiting rank at once. A uniformly cold fleet reaches its first arrival about 28 minutes in, so a barrier expiry lands near 68 minutes from process start. Doubling the barrier keeps the watchdog behind that, and stays correct if the barrier is retuned, since twice a barrier exceeds first arrival plus a barrier whenever the barrier itself exceeds the time to first arrival. Firing first would kill every rank with a generic no-progress error and lose the barrier's report of which ranks never arrived.

Not addressed here: `ProgressWatchdogConfig.create` returns None for every process other than zero whenever `diagnostic_timeout` is set, so on `moe_hero_fsdp` only rank 0 is armed. The `moe_hero_ep` configuration sets no `diagnostic_timeout`, so all of its processes arm.

Part of #8534
