### PR TITLE
[levanter] Add ad hoc training checkpoints

### DIFF
--- a/docs/tutorials/train-an-lm.md
+++ b/docs/tutorials/train-an-lm.md
@@ -188,8 +188,17 @@ W&B receives metrics throughout training. The run name defaults to the `run_id` 
 `{prefix}/{name}/{version}/checkpoints/`.
 
 Iris shows a private `training-control` endpoint for Marin `train_lm` jobs. It contains the run ID,
-resolved Levanter configuration, and redacted process environment. Select **Save checkpoint** to write a permanent
-checkpoint after the current training step.
+resolved Levanter configuration, and redacted process environment. Select **Save checkpoint** to write a temporary
+checkpoint after the current training step. Manual saves use `temporary_base_path` when it is configured. Otherwise,
+they use the main checkpoint path. Temporary retention applies in both cases.
+
+An authenticated client can request the same checkpoint without loading the dashboard page first:
+
+```bash
+curl -X POST \
+  -H 'X-Levanter-Training-Control: request-checkpoint' \
+  https://iris.oa.dev/proxy/<training-control-endpoint>/checkpoint
+```
 
 ## Memory pressure
 

--- a/docs/tutorials/train-an-lm.md
+++ b/docs/tutorials/train-an-lm.md
@@ -192,13 +192,21 @@ resolved Levanter configuration, and redacted process environment. Select **Save
 checkpoint after the current training step. Manual saves use `temporary_base_path` when it is configured. Otherwise,
 they use the main checkpoint path. Temporary retention applies in both cases.
 
-An authenticated client can request the same checkpoint without loading the dashboard page first:
+Use an Iris capability URL to request the same checkpoint from a CLI. First, set the root job ID:
 
 ```bash
+JOB_ID=/user/training-job
+ENDPOINT=$(uv run iris --config lib/iris/config/marin.yaml endpoints list "$JOB_ID" \
+  | awk '$1 ~ /training-control$/ {print $1}')
+CAPABILITY_URL=$(uv run iris --config lib/iris/config/marin.yaml endpoints mint "$ENDPOINT" \
+  | awk '$1 == "url" {print $2}')
+
 curl -X POST \
   -H 'X-Levanter-Training-Control: request-checkpoint' \
-  https://iris.oa.dev/proxy/<training-control-endpoint>/checkpoint
+  "${CAPABILITY_URL%/}/checkpoint"
 ```
+
+The capability URL is a credential for one endpoint. Do not share it. Iris sets an expiration time when it creates the URL.
 
 ## Memory pressure
 

--- a/docs/tutorials/train-an-lm.md
+++ b/docs/tutorials/train-an-lm.md
@@ -188,7 +188,8 @@ W&B receives metrics throughout training. The run name defaults to the `run_id` 
 `{prefix}/{name}/{version}/checkpoints/`.
 
 Iris shows a private `training-control` endpoint for Marin `train_lm` jobs. It contains the run ID,
-resolved Levanter configuration, and redacted process environment.
+resolved Levanter configuration, and redacted process environment. Select **Save checkpoint** to write a permanent
+checkpoint after the current training step.
 
 ## Memory pressure
 

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -44,6 +44,7 @@ from levanter.models.lm_model import LmExample
 from levanter.optim.config import AdamConfig, OptimizerConfig
 from levanter.schedule import BatchSchedule
 from levanter.trainer import TrainerConfig
+from levanter.training_control import TrainingDashboard
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.jax_utils import parameter_count
 from levanter.utils.logging import LoadingTimeTrackerIterator
@@ -446,7 +447,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
     # Grug uses raw PartitionSpecs rather than Trainer's logical axis mapping.
     # Keep the mesh compact so P(("replica_dcn", "data")) spans slices directly.
     mesh = compact_grug_mesh()
-    with set_mesh(mesh):
+    checkpointer = trainer.checkpointer.create(run_id)
+    with set_mesh(mesh), TrainingDashboard(config, checkpointer.request_checkpoint, run_id):
         batch_schedule = trainer.batch_schedule
 
         train_dataset = build_train_dataset(
@@ -474,7 +476,6 @@ def _run_grug_local(config: GrugRunConfig) -> None:
 
         state = _init_state(model_key)
 
-        checkpointer = trainer.checkpointer.create(run_id)
         state = restore_grug_state_from_checkpoint(
             state,
             checkpoint_search_paths=trainer.checkpoint_search_paths(run_id),

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -34,6 +34,7 @@ from levanter.models.lm_model import LmExample
 from levanter.optim.config import AdamConfig, OptimizerConfig
 from levanter.schedule import BatchSchedule
 from levanter.trainer import TrainerConfig
+from levanter.training_control import TrainingDashboard
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.jax_utils import parameter_count
 from levanter.utils.logging import LoadingTimeTrackerIterator
@@ -406,7 +407,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         expert_axis_size=config.trainer.expert_axis_size,
         replica_axis_size=config.trainer.replica_axis_size,
     )
-    with set_mesh(mesh):
+    checkpointer = trainer.checkpointer.create(run_id)
+    with set_mesh(mesh), TrainingDashboard(config, checkpointer.request_checkpoint, run_id):
         batch_schedule = trainer.batch_schedule
 
         train_dataset = build_train_dataset(
@@ -433,7 +435,6 @@ def _run_grug_local(config: GrugRunConfig) -> None:
 
         state = _init_state(model_key)
 
-        checkpointer = trainer.checkpointer.create(run_id)
         state = restore_grug_state_from_checkpoint(
             state,
             checkpoint_search_paths=trainer.checkpoint_search_paths(run_id),

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -9,6 +9,7 @@ import logging
 import os
 import time
 from collections.abc import Callable
+from contextlib import nullcontext
 from dataclasses import dataclass, field, replace
 from enum import StrEnum
 
@@ -42,6 +43,7 @@ from levanter.optim.config import AdamConfig, OptimizerConfig
 from levanter.schedule import BatchSchedule
 from levanter.store.jagged_array import set_jagged_array_read_cache_bytes
 from levanter.trainer import TrainerConfig
+from levanter.training_control import TrainingDashboard
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.jax_utils import parameter_count
 from levanter.utils.logging import LoadingTimeTrackerIterator
@@ -813,7 +815,11 @@ def _run_grug_local(config: GrugRunConfig) -> None:
     # in initialization, checkpoint restore, cache construction or compilation.
     progress_watchdog = trainer.progress_watchdog.create(process_index=jax.process_index())
 
-    with set_mesh(mesh):
+    checkpointer = trainer.checkpointer.create(run_id) if config.trainer.save_checkpoints else None
+    dashboard = (
+        TrainingDashboard(config, checkpointer.request_checkpoint, run_id) if checkpointer is not None else nullcontext()
+    )
+    with set_mesh(mesh), dashboard:
         batch_schedule = trainer.batch_schedule
 
         @jax.jit
@@ -833,7 +839,6 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         if released_initial_state:
             state = restore_template_from(state)
 
-        checkpointer = trainer.checkpointer.create(run_id) if config.trainer.save_checkpoints else None
         state = restore_grug_state_from_checkpoint(
             state,
             checkpoint_search_paths=trainer.checkpoint_search_paths(run_id),

--- a/experiments/grug/moe_hero_fsdp/train.py
+++ b/experiments/grug/moe_hero_fsdp/train.py
@@ -6,6 +6,7 @@ import functools
 import logging
 import os
 import time
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from enum import StrEnum
 
@@ -40,6 +41,7 @@ from levanter.recovery.types import AblationSpec, RunOutcome
 from levanter.schedule import BatchSchedule
 from levanter.tracker.telemetry import capture_stall_diagnostics
 from levanter.trainer import TrainerConfig
+from levanter.training_control import TrainingDashboard
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.jax_utils import parameter_count
 from levanter.utils.logging import LoadingTimeTrackerIterator
@@ -523,7 +525,11 @@ def _run_grug_local(config: GrugRunConfig) -> None:
         diagnostic=capture_stall_diagnostics,
     )
 
-    with set_mesh(mesh):
+    checkpointer = trainer.checkpointer.create(run_id) if config.trainer.save_checkpoints else None
+    dashboard = (
+        TrainingDashboard(config, checkpointer.request_checkpoint, run_id) if checkpointer is not None else nullcontext()
+    )
+    with set_mesh(mesh), dashboard:
         batch_schedule = trainer.batch_schedule
 
         train_dataset = build_train_dataset(
@@ -551,7 +557,6 @@ def _run_grug_local(config: GrugRunConfig) -> None:
 
         state = _init_state(model_key)
 
-        checkpointer = trainer.checkpointer.create(run_id) if config.trainer.save_checkpoints else None
         state = restore_grug_state_from_checkpoint(
             state,
             checkpoint_search_paths=trainer.checkpoint_search_paths(run_id),

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -569,15 +569,15 @@ class Checkpointer:
         # we fix by having process 0 make the decision
         checkpoint_requested = self._consume_checkpoint_request()
         my_should_save = force or checkpoint_requested
-        my_save_permanent_ckpt = force or checkpoint_requested
+        my_save_permanent_ckpt = force
 
-        if not force and not checkpoint_requested:
+        if not force:
             current_every = self._get_current_step_save_interval(step)
             last_save_time = self._dt_now_injection() - self._last_save_time
             if current_every is not None and step % current_every == 0:
                 my_should_save = True
                 my_save_permanent_ckpt = True
-            elif self.save_interval and last_save_time >= self.save_interval:
+            elif not checkpoint_requested and self.save_interval and last_save_time >= self.save_interval:
                 my_should_save = True
                 my_save_permanent_ckpt = False
 
@@ -623,7 +623,7 @@ class Checkpointer:
             )
 
     def request_checkpoint(self) -> None:
-        """Request a permanent checkpoint on the next step."""
+        """Request a temporary checkpoint on the next step."""
         with self._checkpoint_request_lock:
             self._checkpoint_requested = True
 

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -487,6 +487,8 @@ class Checkpointer:
         self.debug = debug or CheckpointDebugConfig()
         self.write_config = write_config or TensorStoreWriteConfig()
         self._temporary_checkpoints = []
+        self._checkpoint_request_lock = threading.Lock()
+        self._checkpoint_requested = False
 
         # ensure that the step_policies are sorted. We could sort, but instead we'll just insist that they are sorted
         # since it's probably a typo if they aren't
@@ -565,10 +567,11 @@ class Checkpointer:
         # then we could end up with a situation where one process saves a checkpoint, and then another process
         # saves a checkpoint for the next step, etc. This leads to partial checkpoints, no good.
         # we fix by having process 0 make the decision
-        my_should_save = force
-        my_save_permanent_ckpt = force
+        checkpoint_requested = self._consume_checkpoint_request()
+        my_should_save = force or checkpoint_requested
+        my_save_permanent_ckpt = force or checkpoint_requested
 
-        if not force:
+        if not force and not checkpoint_requested:
             current_every = self._get_current_step_save_interval(step)
             last_save_time = self._dt_now_injection() - self._last_save_time
             if current_every is not None and step % current_every == 0:
@@ -618,6 +621,17 @@ class Checkpointer:
                 is_temporary=not save_permanent_ckpt,
                 base_path_override=save_base_path,
             )
+
+    def request_checkpoint(self) -> None:
+        """Request a permanent checkpoint on the next step."""
+        with self._checkpoint_request_lock:
+            self._checkpoint_requested = True
+
+    def _consume_checkpoint_request(self) -> bool:
+        with self._checkpoint_request_lock:
+            requested = self._checkpoint_requested
+            self._checkpoint_requested = False
+        return requested
 
     def _discover_temporary_checkpoints(self) -> list["_TemporaryCheckpointRecord"]:
         search_paths = [self.base_path]

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -623,7 +623,7 @@ class Checkpointer:
             )
 
     def request_checkpoint(self) -> None:
-        """Request a temporary checkpoint on the next step."""
+        """Request a checkpoint on the next step, subject to the save policy."""
         with self._checkpoint_request_lock:
             self._checkpoint_requested = True
 

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -210,7 +210,7 @@ def main(config: TrainLmConfig):
     # 3. Sets the global metrics tracker
     with (
         Trainer(config.trainer, optimizer, loss_function) as trainer,
-        TrainingDashboard(config, trainer.request_checkpoint),
+        TrainingDashboard(config, trainer.request_checkpoint, config.trainer.id or "unknown"),
     ):
         # randomness in jax is tightly controlled by "keys" which are the states of the random number generators
         # this makes deterministic training pretty easy

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -208,7 +208,10 @@ def main(config: TrainLmConfig):
     # 1. Sets the device mesh
     # 2. Sets the axis mapping (for fsdp)
     # 3. Sets the global metrics tracker
-    with TrainingDashboard(config), Trainer(config.trainer, optimizer, loss_function) as trainer:
+    with (
+        Trainer(config.trainer, optimizer, loss_function) as trainer,
+        TrainingDashboard(config, trainer.request_checkpoint),
+    ):
         # randomness in jax is tightly controlled by "keys" which are the states of the random number generators
         # this makes deterministic training pretty easy
         seed = config.trainer.seed

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -359,6 +359,12 @@ class Trainer:
     def run_hooks(self, info: StepInfo, force: bool = False):
         self.hooks.run_hooks(info, force=force)
 
+    def request_checkpoint(self) -> None:
+        """Request a permanent checkpoint after the current training step."""
+        if self._checkpointer is None:
+            raise RuntimeError("Checkpointing is not configured")
+        self._checkpointer.request_checkpoint()
+
     @property
     def parameter_axis_mapping(self) -> ResourceMapping:
         return self.config.parameter_axis_mapping

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -360,7 +360,7 @@ class Trainer:
         self.hooks.run_hooks(info, force=force)
 
     def request_checkpoint(self) -> None:
-        """Request a temporary checkpoint after the current training step."""
+        """Request a checkpoint after the current step, subject to the save policy."""
         if self._checkpointer is None:
             raise RuntimeError("Checkpointing is not configured")
         self._checkpointer.request_checkpoint()

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -360,7 +360,7 @@ class Trainer:
         self.hooks.run_hooks(info, force=force)
 
     def request_checkpoint(self) -> None:
-        """Request a permanent checkpoint after the current training step."""
+        """Request a temporary checkpoint after the current training step."""
         if self._checkpointer is None:
             raise RuntimeError("Checkpointing is not configured")
         self._checkpointer.request_checkpoint()

--- a/lib/levanter/src/levanter/training_control.py
+++ b/lib/levanter/src/levanter/training_control.py
@@ -6,16 +6,19 @@
 from __future__ import annotations
 
 import html
+import hmac
 import json
 import logging
 import os
-from collections.abc import Iterator
+import secrets
+from collections.abc import Callable, Iterator
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from functools import partial
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from threading import Thread
 from typing import cast
+from urllib.parse import parse_qs
 
 import draccus
 import jax
@@ -64,7 +67,7 @@ class _TrainingSnapshot:
         )
 
 
-def _render_page(snapshot: _TrainingSnapshot) -> str:
+def _render_page(snapshot: _TrainingSnapshot, action_token: str) -> str:
     configuration = html.escape(snapshot.configuration)
     environment = html.escape(json.dumps(snapshot.environment, indent=2))
     return f"""<!doctype html>
@@ -85,6 +88,10 @@ def _render_page(snapshot: _TrainingSnapshot) -> str:
     <li>Iris job: {html.escape(snapshot.job_id)}</li>
     <li>Iris task: {html.escape(snapshot.task_id)}</li>
   </ul>
+  <form method="post">
+    <input type="hidden" name="token" value="{html.escape(action_token, quote=True)}">
+    <button type="submit">Save checkpoint</button>
+  </form>
   <h2>Resolved configuration</h2>
   <pre>{configuration}</pre>
   <h2>Environment</h2>
@@ -97,17 +104,46 @@ def _render_page(snapshot: _TrainingSnapshot) -> str:
 class _TrainingDashboardRequestHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
-    def __init__(self, *args, snapshot: _TrainingSnapshot, **kwargs):
+    def __init__(
+        self,
+        *args,
+        snapshot: _TrainingSnapshot,
+        request_checkpoint: Callable[[], None],
+        action_token: str,
+        **kwargs,
+    ):
         self._snapshot = snapshot
+        self._request_checkpoint = request_checkpoint
+        self._action_token = action_token
         super().__init__(*args, **kwargs)
 
     def do_GET(self) -> None:
-        body = _render_page(self._snapshot).encode()
+        body = _render_page(self._snapshot, self._action_token).encode()
         self.send_response(200)
         self.send_header("Content-Type", "text/html; charset=utf-8")
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")
-        self.send_header("Content-Security-Policy", "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'")
+        self.send_header(
+            "Content-Security-Policy",
+            "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'",
+        )
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        token = parse_qs(self.rfile.read(content_length).decode()).get("token", [""])[0]
+        if not hmac.compare_digest(token, self._action_token):
+            self.send_error(403)
+            return
+
+        self._request_checkpoint()
+        body = b"Checkpoint requested. The save will start after the current training step.\n"
+        self.send_response(202)
+        self.send_header("Content-Type", "text/plain; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
         self.send_header("X-Content-Type-Options", "nosniff")
         self.end_headers()
         self.wfile.write(body)
@@ -117,8 +153,14 @@ class _TrainingDashboardRequestHandler(BaseHTTPRequestHandler):
 
 
 @contextmanager
-def _serve_status_page(snapshot: _TrainingSnapshot) -> Iterator[int]:
-    handler = partial(_TrainingDashboardRequestHandler, snapshot=snapshot)
+def _serve_status_page(snapshot: _TrainingSnapshot, request_checkpoint: Callable[[], None]) -> Iterator[int]:
+    action_token = secrets.token_urlsafe(32)
+    handler = partial(
+        _TrainingDashboardRequestHandler,
+        snapshot=snapshot,
+        request_checkpoint=request_checkpoint,
+        action_token=action_token,
+    )
     with ThreadingHTTPServer(("0.0.0.0", 0), handler) as server:
         thread = Thread(
             target=server.serve_forever, name=f"training-dashboard-{server.server_address[1]}", daemon=True
@@ -134,8 +176,9 @@ def _serve_status_page(snapshot: _TrainingSnapshot) -> Iterator[int]:
 class TrainingDashboard:
     """Publish the process-zero training status page through Iris."""
 
-    def __init__(self, config: AllConfig):
+    def __init__(self, config: AllConfig, request_checkpoint: Callable[[], None]):
         self._config = config
+        self._request_checkpoint = request_checkpoint
         self._stack: ExitStack | None = None
 
     def __enter__(self) -> TrainingDashboard:
@@ -160,7 +203,7 @@ class TrainingDashboard:
         )
         stack = ExitStack()
         try:
-            port = stack.enter_context(_serve_status_page(snapshot))
+            port = stack.enter_context(_serve_status_page(snapshot, self._request_checkpoint))
             endpoint_name = f"{job_info.job_id}/{TRAINING_CONTROL_ENDPOINT}"
             address = f"http://{job_info.advertise_host}:{port}"
             stack.enter_context(

--- a/lib/levanter/src/levanter/training_control.py
+++ b/lib/levanter/src/levanter/training_control.py
@@ -28,7 +28,7 @@ from rigging.redaction import REDACTED_VALUE, redact_value
 from iris.client.client import get_iris_ctx
 from iris.cluster.client.job_info import get_job_info
 from iris.cluster.types import EndpointAccess
-from levanter.trainer import AllConfig
+
 
 logger = logging.getLogger(__name__)
 
@@ -47,8 +47,9 @@ class _TrainingSnapshot:
     @classmethod
     def capture(
         cls,
-        config: AllConfig,
+        config: object,
         *,
+        run_id: str,
         job_id: str,
         task_id: str,
     ) -> _TrainingSnapshot:
@@ -59,7 +60,7 @@ class _TrainingSnapshot:
         redacted_environment = cast(dict[str, str], redact_value(environment))
         encoded_config = redact_value(draccus.encode(config))
         return cls(
-            run_id=config.trainer.id or "unknown",
+            run_id=run_id,
             job_id=job_id,
             task_id=task_id,
             environment=dict(sorted(redacted_environment.items())),
@@ -176,9 +177,10 @@ def _serve_status_page(snapshot: _TrainingSnapshot, request_checkpoint: Callable
 class TrainingDashboard:
     """Publish the process-zero training status page through Iris."""
 
-    def __init__(self, config: AllConfig, request_checkpoint: Callable[[], None]):
+    def __init__(self, config: object, request_checkpoint: Callable[[], None], run_id: str):
         self._config = config
         self._request_checkpoint = request_checkpoint
+        self._run_id = run_id
         self._stack: ExitStack | None = None
 
     def __enter__(self) -> TrainingDashboard:
@@ -198,6 +200,7 @@ class TrainingDashboard:
             return
         snapshot = _TrainingSnapshot.capture(
             self._config,
+            run_id=self._run_id,
             job_id=str(job_info.job_id),
             task_id=str(job_info.task_id),
         )

--- a/lib/levanter/src/levanter/training_control.py
+++ b/lib/levanter/src/levanter/training_control.py
@@ -18,7 +18,7 @@ from functools import partial
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from threading import Thread
 from typing import Generic, TypeVar, cast
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, urlsplit
 
 import draccus
 import jax
@@ -34,6 +34,8 @@ logger = logging.getLogger(__name__)
 
 TRAINING_CONTROL_ENDPOINT = "training-control"
 _REDACTED_ENVIRONMENT_VARIABLES = ("IRIS_JOB_ENV", "IRIS_JOB_SETUP_SCRIPTS", "MARIN_PROVENANCE")
+_PROGRAMMATIC_ACTION_HEADER = "X-Levanter-Training-Control"
+_PROGRAMMATIC_ACTION_VALUE = "request-checkpoint"
 ConfigT = TypeVar("ConfigT")
 
 
@@ -134,10 +136,19 @@ class _TrainingDashboardRequestHandler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def do_POST(self) -> None:
-        content_length = int(self.headers.get("Content-Length", "0"))
-        token = parse_qs(self.rfile.read(content_length).decode()).get("token", [""])[0]
-        if not hmac.compare_digest(token, self._action_token):
-            self.send_error(403)
+        path = urlsplit(self.path).path.rstrip("/")
+        if path == "/checkpoint":
+            if self.headers.get(_PROGRAMMATIC_ACTION_HEADER) != _PROGRAMMATIC_ACTION_VALUE:
+                self.send_error(403)
+                return
+        elif path == "":
+            content_length = int(self.headers.get("Content-Length", "0"))
+            token = parse_qs(self.rfile.read(content_length).decode()).get("token", [""])[0]
+            if not hmac.compare_digest(token, self._action_token):
+                self.send_error(403)
+                return
+        else:
+            self.send_error(404)
             return
 
         self._request_checkpoint()

--- a/lib/levanter/src/levanter/training_control.py
+++ b/lib/levanter/src/levanter/training_control.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from functools import partial
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from threading import Thread
-from typing import cast
+from typing import Generic, TypeVar, cast
 from urllib.parse import parse_qs
 
 import draccus
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 TRAINING_CONTROL_ENDPOINT = "training-control"
 _REDACTED_ENVIRONMENT_VARIABLES = ("IRIS_JOB_ENV", "IRIS_JOB_SETUP_SCRIPTS", "MARIN_PROVENANCE")
+ConfigT = TypeVar("ConfigT")
 
 
 @dataclass(frozen=True)
@@ -47,7 +48,7 @@ class _TrainingSnapshot:
     @classmethod
     def capture(
         cls,
-        config: object,
+        config: ConfigT,
         *,
         run_id: str,
         job_id: str,
@@ -174,10 +175,10 @@ def _serve_status_page(snapshot: _TrainingSnapshot, request_checkpoint: Callable
             thread.join()
 
 
-class TrainingDashboard:
+class TrainingDashboard(Generic[ConfigT]):
     """Publish the process-zero training status page through Iris."""
 
-    def __init__(self, config: object, request_checkpoint: Callable[[], None], run_id: str):
+    def __init__(self, config: ConfigT, request_checkpoint: Callable[[], None], run_id: str):
         self._config = config
         self._request_checkpoint = request_checkpoint
         self._run_id = run_id

--- a/lib/levanter/src/levanter/training_control.py
+++ b/lib/levanter/src/levanter/training_control.py
@@ -225,7 +225,7 @@ class TrainingDashboard(Generic[ConfigT]):
                 context.registry.registered(
                     endpoint_name,
                     address,
-                    access=EndpointAccess.ENDPOINT_ACCESS_PRIVATE,
+                    access=EndpointAccess.ENDPOINT_ACCESS_LINK,
                 )
             )
         except Exception:

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -720,23 +720,38 @@ def test_checkpointer_force_save_uses_permanent_path_even_when_time_policy_elaps
         assert list(pathlib.Path(temporary_dir).iterdir()) == []
 
 
-def test_checkpointer_coalesces_requests_into_one_permanent_checkpoint(tmp_path):
-    now = datetime.datetime(2021, 1, 1)
+def test_checkpointer_coalesces_requests_into_one_temporary_checkpoint(tmp_path):
     permanent_path = tmp_path / "checkpoints"
     temporary_path = tmp_path / "temporary"
     checkpointer = Checkpointer(
         permanent_path,
-        timedelta(seconds=1),
+        None,
         [],
         temporary_base_path=temporary_path,
-        dt_now_injection=lambda: now,
     )
 
-    now += timedelta(seconds=1)
     checkpointer.request_checkpoint()
     checkpointer.request_checkpoint()
     _on_step(checkpointer, 1)
     _on_step(checkpointer, 2)
+    checkpointer.wait_until_finished()
+
+    assert _get_checkpoint_steps(temporary_path) == [1]
+    assert not permanent_path.exists()
+
+
+def test_requested_checkpoint_does_not_downgrade_scheduled_permanent_checkpoint(tmp_path):
+    permanent_path = tmp_path / "checkpoints"
+    temporary_path = tmp_path / "temporary"
+    checkpointer = Checkpointer(
+        permanent_path,
+        None,
+        [CheckpointInterval(every=1)],
+        temporary_base_path=temporary_path,
+    )
+
+    checkpointer.request_checkpoint()
+    _on_step(checkpointer, 1)
     checkpointer.wait_until_finished()
 
     assert _get_checkpoint_steps(permanent_path) == [1]

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -720,6 +720,29 @@ def test_checkpointer_force_save_uses_permanent_path_even_when_time_policy_elaps
         assert list(pathlib.Path(temporary_dir).iterdir()) == []
 
 
+def test_checkpointer_coalesces_requests_into_one_permanent_checkpoint(tmp_path):
+    now = datetime.datetime(2021, 1, 1)
+    permanent_path = tmp_path / "checkpoints"
+    temporary_path = tmp_path / "temporary"
+    checkpointer = Checkpointer(
+        permanent_path,
+        timedelta(seconds=1),
+        [],
+        temporary_base_path=temporary_path,
+        dt_now_injection=lambda: now,
+    )
+
+    now += timedelta(seconds=1)
+    checkpointer.request_checkpoint()
+    checkpointer.request_checkpoint()
+    _on_step(checkpointer, 1)
+    _on_step(checkpointer, 2)
+    checkpointer.wait_until_finished()
+
+    assert _get_checkpoint_steps(permanent_path) == [1]
+    assert not temporary_path.exists()
+
+
 def test_load_from_checkpoint_or_initialize():
     In = Axis("in", 2)
     Out = Axis("out", 1)

--- a/lib/levanter/tests/test_training_control.py
+++ b/lib/levanter/tests/test_training_control.py
@@ -89,7 +89,7 @@ def test_training_dashboard_registers_redacted_status_page(monkeypatch, tmp_path
         assert registry.name == "/alice/parent/train/training-control"
         assert registry.access == EndpointAccess.ENDPOINT_ACCESS_LINK
         assert headers["Cache-Control"] == "no-store"
-        assert "<li>Run ID: dashboard-run</li>" in body
+        assert "dashboard-run" in body
         assert "tiny-model" in body
         assert "VISIBLE_VALUE" in body
         assert "value &lt;script&gt;alert(1)&lt;/script&gt;" in body
@@ -98,6 +98,27 @@ def test_training_dashboard_registers_redacted_status_page(monkeypatch, tmp_path
         assert "environment-secret" not in body
         assert "nested-environment-secret" not in body
         assert "nested-provenance-secret" not in body
+
+    assert not registry.active
+
+
+def test_training_dashboard_requests_persist_temporary_checkpoints(monkeypatch, tmp_path):
+    config = _TrainingConfig(trainer=TrainerConfig(id="config-run"))
+    registry = _Registry()
+    job_info = JobInfo(
+        task_id=JobName.from_wire("/alice/parent/train/0"),
+        advertise_host="127.0.0.1",
+    )
+
+    monkeypatch.setattr(training_control.jax, "process_index", lambda: 0)
+    monkeypatch.setattr(training_control, "get_iris_ctx", lambda: SimpleNamespace(registry=registry))
+    monkeypatch.setattr(training_control, "get_job_info", lambda: job_info)
+    checkpointer = Checkpointer(tmp_path / "checkpoints", None, [])
+
+    with TrainingDashboard(config, checkpointer.request_checkpoint, "dashboard-run"):
+        assert registry.address is not None
+        with urlopen(registry.address, timeout=2) as response:
+            body = response.read().decode()
 
         token_match = re.search(r'name="token" value="([^"]+)"', body)
         assert token_match is not None

--- a/lib/levanter/tests/test_training_control.py
+++ b/lib/levanter/tests/test_training_control.py
@@ -109,14 +109,37 @@ def test_training_dashboard_registers_redacted_status_page(monkeypatch, tmp_path
 
         metadata = json.loads((tmp_path / "checkpoints" / "step-1" / "metadata.json").read_text())
         assert metadata["step"] == 1
-        assert metadata["is_temporary"] is False
+        assert metadata["is_temporary"] is True
+
+        programmatic_request = Request(
+            registry.address + "/checkpoint",
+            data=b"",
+            headers={"X-Levanter-Training-Control": "request-checkpoint"},
+            method="POST",
+        )
+        with urlopen(programmatic_request, timeout=2) as response:
+            assert response.status == 202
+        checkpointer.on_step(tree={"value": jnp.array(2)}, step=2)
+        checkpointer.wait_until_finished()
+        programmatic_metadata = json.loads((tmp_path / "checkpoints" / "step-2" / "metadata.json").read_text())
+        assert programmatic_metadata["step"] == 2
+        assert programmatic_metadata["is_temporary"] is True
 
         with pytest.raises(HTTPError) as error:
             urlopen(Request(registry.address, data=b"token=invalid", method="POST"), timeout=2)
         assert error.value.code == 403
-        checkpointer.on_step(tree={"value": jnp.array(2)}, step=2)
+        with pytest.raises(HTTPError) as error:
+            urlopen(Request(registry.address + "/checkpoint", data=b"", method="POST"), timeout=2)
+        assert error.value.code == 403
+        with pytest.raises(HTTPError) as error:
+            urlopen(
+                Request(registry.address + "/unknown", data=urlencode({"token": token_match.group(1)}).encode()),
+                timeout=2,
+            )
+        assert error.value.code == 404
+        checkpointer.on_step(tree={"value": jnp.array(3)}, step=3)
         checkpointer.wait_until_finished()
-        assert [path.name for path in (tmp_path / "checkpoints").iterdir()] == ["step-1"]
+        assert not (tmp_path / "checkpoints" / "step-3").exists()
     assert not registry.active
 
 

--- a/lib/levanter/tests/test_training_control.py
+++ b/lib/levanter/tests/test_training_control.py
@@ -87,7 +87,7 @@ def test_training_dashboard_registers_redacted_status_page(monkeypatch, tmp_path
             headers = response.headers
 
         assert registry.name == "/alice/parent/train/training-control"
-        assert registry.access == EndpointAccess.ENDPOINT_ACCESS_PRIVATE
+        assert registry.access == EndpointAccess.ENDPOINT_ACCESS_LINK
         assert headers["Cache-Control"] == "no-store"
         assert "<li>Run ID: dashboard-run</li>" in body
         assert "tiny-model" in body

--- a/lib/levanter/tests/test_training_control.py
+++ b/lib/levanter/tests/test_training_control.py
@@ -3,6 +3,7 @@
 
 from contextlib import contextmanager
 from dataclasses import dataclass
+import json
 import re
 from types import SimpleNamespace
 from urllib.error import HTTPError
@@ -10,10 +11,12 @@ from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 import pytest
+from jax import numpy as jnp
 
 import levanter.training_control as training_control
 from iris.cluster.client.job_info import JobInfo
 from iris.cluster.types import EndpointAccess, JobName
+from levanter.checkpoint import Checkpointer
 from levanter.training_control import TrainingDashboard
 from levanter.trainer import TrainerConfig
 
@@ -53,7 +56,7 @@ class _FailingRegistry:
         raise RuntimeError("controller unavailable")
 
 
-def test_training_dashboard_registers_redacted_status_page(monkeypatch):
+def test_training_dashboard_registers_redacted_status_page(monkeypatch, tmp_path):
     config = _TrainingConfig(trainer=TrainerConfig(id="config-run"))
     registry = _Registry()
     job_info = JobInfo(
@@ -74,13 +77,9 @@ def test_training_dashboard_registers_redacted_status_page(monkeypatch):
             "MARIN_PROVENANCE": '{"argv": ["--token", "nested-provenance-secret"]}',
         },
     )
-    checkpoint_requests = 0
+    checkpointer = Checkpointer(tmp_path / "checkpoints", None, [])
 
-    def request_checkpoint():
-        nonlocal checkpoint_requests
-        checkpoint_requests += 1
-
-    with TrainingDashboard(config, request_checkpoint, "dashboard-run"):
+    with TrainingDashboard(config, checkpointer.request_checkpoint, "dashboard-run"):
         assert registry.active
         assert registry.address is not None
         with urlopen(registry.address, timeout=2) as response:
@@ -105,12 +104,19 @@ def test_training_dashboard_registers_redacted_status_page(monkeypatch):
         request = Request(registry.address, data=urlencode({"token": token_match.group(1)}).encode(), method="POST")
         with urlopen(request, timeout=2) as response:
             assert response.status == 202
-        assert checkpoint_requests == 1
+        checkpointer.on_step(tree={"value": jnp.array(1)}, step=1)
+        checkpointer.wait_until_finished()
+
+        metadata = json.loads((tmp_path / "checkpoints" / "step-1" / "metadata.json").read_text())
+        assert metadata["step"] == 1
+        assert metadata["is_temporary"] is False
 
         with pytest.raises(HTTPError) as error:
             urlopen(Request(registry.address, data=b"token=invalid", method="POST"), timeout=2)
         assert error.value.code == 403
-        assert checkpoint_requests == 1
+        checkpointer.on_step(tree={"value": jnp.array(2)}, step=2)
+        checkpointer.wait_until_finished()
+        assert [path.name for path in (tmp_path / "checkpoints").iterdir()] == ["step-1"]
     assert not registry.active
 
 

--- a/lib/levanter/tests/test_training_control.py
+++ b/lib/levanter/tests/test_training_control.py
@@ -3,8 +3,13 @@
 
 from contextlib import contextmanager
 from dataclasses import dataclass
+import re
 from types import SimpleNamespace
-from urllib.request import urlopen
+from urllib.error import HTTPError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+import pytest
 
 import levanter.training_control as training_control
 from iris.cluster.client.job_info import JobInfo
@@ -69,7 +74,13 @@ def test_training_dashboard_registers_redacted_status_page(monkeypatch):
             "MARIN_PROVENANCE": '{"argv": ["--token", "nested-provenance-secret"]}',
         },
     )
-    with TrainingDashboard(config):
+    checkpoint_requests = 0
+
+    def request_checkpoint():
+        nonlocal checkpoint_requests
+        checkpoint_requests += 1
+
+    with TrainingDashboard(config, request_checkpoint):
         assert registry.active
         assert registry.address is not None
         with urlopen(registry.address, timeout=2) as response:
@@ -88,6 +99,18 @@ def test_training_dashboard_registers_redacted_status_page(monkeypatch):
         assert "environment-secret" not in body
         assert "nested-environment-secret" not in body
         assert "nested-provenance-secret" not in body
+
+        token_match = re.search(r'name="token" value="([^"]+)"', body)
+        assert token_match is not None
+        request = Request(registry.address, data=urlencode({"token": token_match.group(1)}).encode(), method="POST")
+        with urlopen(request, timeout=2) as response:
+            assert response.status == 202
+        assert checkpoint_requests == 1
+
+        with pytest.raises(HTTPError) as error:
+            urlopen(Request(registry.address, data=b"token=invalid", method="POST"), timeout=2)
+        assert error.value.code == 403
+        assert checkpoint_requests == 1
     assert not registry.active
 
 
@@ -103,7 +126,7 @@ def test_training_dashboard_failure_does_not_stop_training(monkeypatch):
     monkeypatch.setattr(training_control, "get_iris_ctx", lambda: SimpleNamespace(registry=registry))
     monkeypatch.setattr(training_control, "get_job_info", lambda: job_info)
 
-    with TrainingDashboard(config):
+    with TrainingDashboard(config, lambda: None):
         pass
 
     assert registry.called

--- a/lib/levanter/tests/test_training_control.py
+++ b/lib/levanter/tests/test_training_control.py
@@ -54,7 +54,7 @@ class _FailingRegistry:
 
 
 def test_training_dashboard_registers_redacted_status_page(monkeypatch):
-    config = _TrainingConfig(trainer=TrainerConfig(id="test-run"))
+    config = _TrainingConfig(trainer=TrainerConfig(id="config-run"))
     registry = _Registry()
     job_info = JobInfo(
         task_id=JobName.from_wire("/alice/parent/train/0"),
@@ -80,7 +80,7 @@ def test_training_dashboard_registers_redacted_status_page(monkeypatch):
         nonlocal checkpoint_requests
         checkpoint_requests += 1
 
-    with TrainingDashboard(config, request_checkpoint):
+    with TrainingDashboard(config, request_checkpoint, "dashboard-run"):
         assert registry.active
         assert registry.address is not None
         with urlopen(registry.address, timeout=2) as response:
@@ -90,7 +90,7 @@ def test_training_dashboard_registers_redacted_status_page(monkeypatch):
         assert registry.name == "/alice/parent/train/training-control"
         assert registry.access == EndpointAccess.ENDPOINT_ACCESS_PRIVATE
         assert headers["Cache-Control"] == "no-store"
-        assert "test-run" in body
+        assert "<li>Run ID: dashboard-run</li>" in body
         assert "tiny-model" in body
         assert "VISIBLE_VALUE" in body
         assert "value &lt;script&gt;alert(1)&lt;/script&gt;" in body
@@ -126,7 +126,7 @@ def test_training_dashboard_failure_does_not_stop_training(monkeypatch):
     monkeypatch.setattr(training_control, "get_iris_ctx", lambda: SimpleNamespace(registry=registry))
     monkeypatch.setattr(training_control, "get_job_info", lambda: job_info)
 
-    with TrainingDashboard(config, lambda: None):
+    with TrainingDashboard(config, lambda: None, "test-run"):
         pass
 
     assert registry.called


### PR DESCRIPTION
Add a checkpoint action to the Levanter training dashboard. A request waits for the current step. It then uses the distributed checkpoint path to write a temporary checkpoint. The dashboard is available for `train_lm` and all current Grug training loops when checkpoint saves are enabled.

The dashboard form uses a process-specific action token. CLI users can create an expiring Iris capability URL for the endpoint. They can then send one POST to `/checkpoint` with `X-Levanter-Training-Control: request-checkpoint`. The token gives access to only that endpoint. Callers in the training process can use `Trainer.request_checkpoint()` or `Checkpointer.request_checkpoint()`.

Repeated pending requests produce one save. A scheduled permanent checkpoint stays permanent when it is due on the same step.

A two-node H100 Grug smoke on `cw-us-east-02a` accepted the HTTP request across 16 processes. It saved temporary checkpoint metadata at step 31.

Extends #8512.
