### PR TITLE
[grug] Default hero runs to jemalloc

### DIFF
--- a/experiments/grug/dispatch.py
+++ b/experiments/grug/dispatch.py
@@ -27,13 +27,16 @@ PRODUCTION_PRIORITY = priority_band_value("production")
 # given (e.g. `iris job run -e XLA_FLAGS ...`) must be re-exported explicitly.
 # JAX_PLATFORMS is excluded: the dispatcher runs CPU-only and its value must
 # not leak onto accelerator tasks.
-_FORWARDED_ENV_PREFIXES = ("XLA_", "LIBTPU_INIT_ARGS", "NCCL_", "JAX_")
+_FORWARDED_ENV_PREFIXES = ("XLA_", "LIBTPU_INIT_ARGS", "NCCL_", "JAX_", "MALLOC_")
+_FORWARDED_ENV_NAMES = ("LD_PRELOAD",)
 _FORWARDED_ENV_EXCLUDE = ("JAX_PLATFORMS",)
 
 
 def _forwarded_env_vars() -> dict[str, str]:
     return {
-        k: v for k, v in os.environ.items() if k.startswith(_FORWARDED_ENV_PREFIXES) and k not in _FORWARDED_ENV_EXCLUDE
+        k: v
+        for k, v in os.environ.items()
+        if (k in _FORWARDED_ENV_NAMES or k.startswith(_FORWARDED_ENV_PREFIXES)) and k not in _FORWARDED_ENV_EXCLUDE
     }
 
 

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -58,6 +58,8 @@ from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
 logger = logging.getLogger(__name__)
 
 HERO_EP_RUNTIME_ENV = {
+    "LD_PRELOAD": "libjemalloc.so.2",
+    "MALLOC_CONF": "background_thread:true,dirty_decay_ms:0,muzzy_decay_ms:0,narenas:2",
     "JAX_ENABLE_PGLE": "false",
     "XLA_PJRT_GPU_HOST_MEMORY_LIMIT_GB": "192",
     "XLA_PYTHON_CLIENT_ALLOCATOR": "cuda_async",

--- a/experiments/grug/moe_hero_fsdp/train.py
+++ b/experiments/grug/moe_hero_fsdp/train.py
@@ -56,6 +56,8 @@ from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
 logger = logging.getLogger(__name__)
 
 HERO_FSDP_RUNTIME_ENV = {
+    "LD_PRELOAD": "libjemalloc.so.2",
+    "MALLOC_CONF": "background_thread:true,dirty_decay_ms:0,muzzy_decay_ms:0,narenas:2",
     "JAX_ENABLE_PGLE": "1",
     "XLA_PYTHON_CLIENT_ALLOCATOR": "cuda_async",
     # NVLink SHARP. Below the sweep's resolution alone; carried by the combined configuration.

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -56,6 +56,7 @@ _HOST_MEMORY_KIND = "pinned_host"
 _DEFAULT_STAGED_CHUNKS = 32
 # Host memory a staged byte occupies while its write is in flight, for reporting only.
 _STAGED_BYTE_OVERHEAD = 4
+_JEMALLOC_LIBRARY_NAME = "jemalloc"
 
 
 def _malloc_trim() -> None:
@@ -72,6 +73,9 @@ def _malloc_trim() -> None:
 
 def _trim_host_memory_after_commits(commit_futures: Sequence[ts.Future]) -> None:
     """Schedule one heap trim after every local TensorStore commit finishes."""
+    if _JEMALLOC_LIBRARY_NAME in os.environ.get("LD_PRELOAD", ""):
+        return
+
     remaining = len(commit_futures)
     if remaining == 0:
         return

--- a/lib/levanter/tests/test_tensorstore_serialization.py
+++ b/lib/levanter/tests/test_tensorstore_serialization.py
@@ -4,6 +4,7 @@
 import asyncio
 import json
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 from typing import Any
 
 import equinox as eqx
@@ -26,6 +27,7 @@ from levanter.tensorstore_serialization import (
     TensorStoreWriteConfig,
     _capped_chunk_shape,
     _HostByteBudget,
+    _trim_host_memory_after_commits,
     _transfer_shard_to_pageable_host,
     tree_deserialize_leaves_tensorstore,
     tree_serialize_leaves_tensorstore,
@@ -42,6 +44,19 @@ def test_pageable_checkpoint_staging_detaches_from_donated_jax_buffer():
     source_host = np.asarray(source)
     np.testing.assert_array_equal(staged, source_host)
     assert not np.shares_memory(staged, source_host)
+
+
+def test_jemalloc_checkpoint_skips_glibc_trim_callback(monkeypatch):
+    callbacks = []
+    future = SimpleNamespace(add_done_callback=callbacks.append)
+
+    monkeypatch.setenv("LD_PRELOAD", "libjemalloc.so.2")
+    _trim_host_memory_after_commits([future])
+    assert callbacks == []
+
+    monkeypatch.delenv("LD_PRELOAD")
+    _trim_host_memory_after_commits([future])
+    assert len(callbacks) == 1
 
 
 def test_tensorstore_checkpoint_simple():

--- a/tests/test_grug_dispatch.py
+++ b/tests/test_grug_dispatch.py
@@ -1,0 +1,31 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from fray.cluster import ResourceConfig
+
+from experiments.grug import dispatch
+
+
+def _noop(_: object) -> None:
+    pass
+
+
+def test_dispatch_forwards_allocator_environment(monkeypatch):
+    monkeypatch.setenv("LD_PRELOAD", "libjemalloc.so.2")
+    monkeypatch.setenv("MALLOC_CONF", "background_thread:true,narenas:2")
+    submitted = []
+    job = SimpleNamespace(wait=lambda **_: None)
+    client = SimpleNamespace(submit=lambda request: submitted.append(request) or job)
+    monkeypatch.setattr(dispatch, "current_client", lambda: client)
+
+    dispatch.dispatch_grug_training_run(
+        run_id="allocator-test",
+        config=object(),
+        local_entrypoint=_noop,
+        resources=ResourceConfig.with_cpu(),
+    )
+
+    assert submitted[0].environment.env_vars["LD_PRELOAD"] == "libjemalloc.so.2"
+    assert submitted[0].environment.env_vars["MALLOC_CONF"] == "background_thread:true,narenas:2"

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -223,6 +223,8 @@ def test_run_grug_applies_ep_xla_defaults_and_keeps_explicit_values(monkeypatch)
     assert os.environ["JAX_ENABLE_PGLE"] == "false"
     assert os.environ["XLA_PJRT_GPU_HOST_MEMORY_LIMIT_GB"] == "192"
     assert os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] == "cuda_async"
+    assert os.environ["LD_PRELOAD"] == "libjemalloc.so.2"
+    assert os.environ["MALLOC_CONF"] == "background_thread:true,dirty_decay_ms:0,muzzy_decay_ms:0,narenas:2"
 
 
 def test_run_grug_defaults_pgle_off_for_per_gpu_processes(monkeypatch):
@@ -249,6 +251,8 @@ def test_run_grug_defaults_pgle_off_for_per_gpu_processes(monkeypatch):
 def test_run_grug_keeps_explicit_ep_runtime_values(monkeypatch):
     monkeypatch.setenv("JAX_ENABLE_PGLE", "false")
     monkeypatch.setenv("XLA_PYTHON_CLIENT_ALLOCATOR", "platform")
+    monkeypatch.setenv("LD_PRELOAD", "/opt/custom/liballocator.so")
+    monkeypatch.setenv("MALLOC_CONF", "narenas:8")
     monkeypatch.delenv("XLA_FLAGS", raising=False)
     config = _runtime_env_config()
 
@@ -257,6 +261,8 @@ def test_run_grug_keeps_explicit_ep_runtime_values(monkeypatch):
 
     assert os.environ["JAX_ENABLE_PGLE"] == "false"
     assert os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] == "platform"
+    assert os.environ["LD_PRELOAD"] == "/opt/custom/liballocator.so"
+    assert os.environ["MALLOC_CONF"] == "narenas:8"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_moe_hero_fsdp.py
+++ b/tests/test_moe_hero_fsdp.py
@@ -21,8 +21,10 @@ def test_build_hero_run_uses_run_id_argument(monkeypatch):
     assert step.name == "grug/cli-run"
 
 
-def test_run_grug_applies_xla_command_buffer_default_and_keeps_override(monkeypatch):
+def test_run_grug_applies_runtime_defaults_and_keeps_overrides(monkeypatch):
     monkeypatch.setenv("XLA_FLAGS", "--xla_gpu_enable_latency_hiding_scheduler=true")
+    monkeypatch.delenv("LD_PRELOAD", raising=False)
+    monkeypatch.delenv("MALLOC_CONF", raising=False)
     config = SimpleNamespace(
         trainer=SimpleNamespace(trainer=SimpleNamespace(id="test-run")),
         resources=object(),
@@ -37,9 +39,15 @@ def test_run_grug_applies_xla_command_buffer_default_and_keeps_override(monkeypa
             "--xla_gpu_enable_latency_hiding_scheduler=true",
             train.XLA_DISABLE_GPU_COMMAND_BUFFER_FLAG,
         ]
+        assert os.environ["LD_PRELOAD"] == "libjemalloc.so.2"
+        assert os.environ["MALLOC_CONF"] == "background_thread:true,dirty_decay_ms:0,muzzy_decay_ms:0,narenas:2"
 
         explicit_flags = "--xla_gpu_enable_command_buffer=FUSION"
         monkeypatch.setenv("XLA_FLAGS", explicit_flags)
+        monkeypatch.setenv("LD_PRELOAD", "/opt/custom/liballocator.so")
+        monkeypatch.setenv("MALLOC_CONF", "narenas:8")
         train.run_grug(config)
 
         assert os.environ["XLA_FLAGS"] == explicit_flags
+        assert os.environ["LD_PRELOAD"] == "/opt/custom/liballocator.so"
+        assert os.environ["MALLOC_CONF"] == "narenas:8"


### PR DESCRIPTION
Run the FSDP and expert-parallel hero trainers with jemalloc 5.3.1, which is available in the Iris task image from #8547. Forward `LD_PRELOAD` and `MALLOC_CONF` from the Grug coordinator to worker tasks while preserving explicit launch overrides. Other Grug runs keep their existing allocator unless those variables are supplied.

Configure jemalloc with `background_thread:true,dirty_decay_ms:0,muzzy_decay_ms:0,narenas:2` and skip the glibc `malloc_trim` callback added in #8540 when jemalloc is preloaded. Glibc checkpoint jobs retain that fallback. In the ten-checkpoint, 16 GiB d6144 tray soak, tuned jemalloc retained 0.394 GiB from checkpoint 1 to 10 versus 1.572 GiB for default jemalloc, a 74.9% reduction. Checkpoint work was 99.45 seconds versus 108.39 seconds, 8.25% lower; peak memory above initialization was 108.69 GiB versus 109.35 GiB. Absolute cgroup levels were not compared because the trays began with different file-cache residency.

A one-tray validation then wrote 20 checkpoints and restored the last one from `marin_temp_bucket`. The 14-array, 8 GiB global slice staged 2 GiB per rank under the 16 GiB cap. Median blocked time was 0.7 seconds and mean commit time was 8.04 seconds. Cgroup memory stayed near 29.1 GiB through checkpoint 14, reached 37.64 GiB at checkpoint 20, and fell to 30.97 GiB after the restore, 1.82 GiB above checkpoint 1. A production-sized 30 GiB global probe, 7.5 GiB per rank, OOM-killed the single node during its first write; that aggregate staging load still requires rack sharding.

Part of #6774.
