### PR TITLE
[grafana] Add the reinforcement-learning run view

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -317,6 +317,16 @@ window to its floor is what separates a divergence from the single excursion
 skip-step already absorbs. It takes the `notification=hero-run` route as well: a
 hero run diverging unwatched costs more than a false page, which a silence
 answers. Both hero rules share one enrolment query per cache interval.
+A warning-only RL rule reads fresh `progress_time_seconds` rows
+from `service=marinskyrl` telemetry and waits 30 minutes, a threshold set above the hero
+rule's 15 because generation dominates an RL step and a single rollout phase can
+legitimately run for minutes. It keys on the promoted `run_id` column and the execution
+UID, so concurrent attempts of one run stay separate. Note what this implies: stall
+detection here is **per producer and opt-in**, not a fleet-wide service. The hero rules
+cover Levanter runs that opt in by job name and nothing else — an RL run would not have
+been covered by them even if MarinSkyRL adopted Levanter's entire metric vocabulary,
+because `hero_runs.task_state_query` selects candidates from `iris.task_state` by name
+before any metric is read. A new producer that wants alerting adds a reader.
 A warning-only Zephyr rule reads fresh
 `progress_time_seconds` rows from `service=zephyr` telemetry. It waits 45 minutes after a
 stage start or shard completion, then remains pending for five minutes. The

--- a/infra/grafana/dashboards/home.json
+++ b/infra/grafana/dashboards/home.json
@@ -110,6 +110,16 @@
       "url": "/d/marin-runs"
     },
     {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "RL runs",
+      "type": "link",
+      "url": "/d/marin-rl-runs"
+    },
+    {
       "linkRef": "fleet_health"
     },
     {

--- a/infra/grafana/dashboards/inference.json
+++ b/infra/grafana/dashboards/inference.json
@@ -951,6 +951,16 @@
       "url": "/d/marin-runs"
     },
     {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "RL runs",
+      "type": "link",
+      "url": "/d/marin-rl-runs"
+    },
+    {
       "linkRef": "fleet_health_without_vars"
     },
     {

--- a/infra/grafana/dashboards/rl_runs.json
+++ b/infra/grafana/dashboards/rl_runs.json
@@ -766,15 +766,15 @@
     {
       "id": 8,
       "type": "timeseries",
-      "title": "Engine generated tokens",
-      "description": "Tokens produced by the vLLM engines serving this run, from their cumulative /metrics snapshots. The serving path stamps job_id rather than run_id, so this is joined through the Iris job the run's own rows name.",
+      "title": "Engine throughput",
+      "description": "Prompt and generation tokens per second across the run's inference engines, from the stats the rollout callback reads by RPC. These rows come from the trainer's own process, so they carry the run's identity directly; `role` is read from the metric attributes because the process resource says driver or trainer while the series says inference.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 8,
         "x": 0,
         "y": 32
       },
@@ -787,7 +787,8 @@
             "showPoints": "never",
             "spanNulls": false
           },
-          "min": 0
+          "min": 0,
+          "unit": null
         },
         "overrides": []
       },
@@ -816,7 +817,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "WITH run_job AS ( SELECT DISTINCT job_id FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND run_id IN (${run:sqlstring}) AND job_id IS NOT NULL AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) ), engine AS ( SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, job_id, resource_attributes_json, attributes_json, timestamp_ms, seq, value FROM \"telemetry_v1\" WHERE service = 'vllm' AND name = 'generation_tokens_total' AND json_get(attributes_json, 'source_temporality') = 'cumulative_snapshot' AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) ), deltas AS ( SELECT t, value - LAG(value) OVER ( PARTITION BY job_id, resource_attributes_json, attributes_json ORDER BY timestamp_ms, seq) AS delta FROM engine WHERE job_id IN (SELECT job_id FROM run_job) ) SELECT t, SUM(CASE WHEN delta >= 0 THEN delta END) AS generated_tokens FROM deltas GROUP BY 1 ORDER BY 1"
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, AVG(CASE WHEN name = 'generation_throughput_tokens_per_second' THEN value END) AS generation, AVG(CASE WHEN name = 'prompt_throughput_tokens_per_second' THEN value END) AS prompt FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'role') = 'inference' AND json_get(attributes_json, 'engine') = 'all' AND json_get(attributes_json, 'statistic') = 'median' AND name IN ('generation_throughput_tokens_per_second', 'prompt_throughput_tokens_per_second') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
               },
               {
                 "key": "from",
@@ -835,8 +836,197 @@
               "type": "timestamp_epoch"
             },
             {
-              "selector": "generated_tokens",
-              "text": "generated_tokens",
+              "selector": "generation",
+              "text": "generation",
+              "type": "number"
+            },
+            {
+              "selector": "prompt",
+              "text": "prompt",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "interval": "1m"
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Engine queue and cache",
+      "description": "Requests running and waiting, KV-cache occupancy and prefix-cache hit rate, median across engines. Waiting climbing while running is flat is the engine saturated; a collapsing prefix hit rate after a weight sync is the cache being invalidated.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 32
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": null
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, AVG(CASE WHEN name = 'num_requests_running' THEN value END) AS running, AVG(CASE WHEN name = 'num_requests_waiting' THEN value END) AS waiting, AVG(CASE WHEN name = 'gpu_cache_usage_perc' THEN value END) AS kv_cache, AVG(CASE WHEN name = 'prefix_cache_hit_rate' THEN value END) AS prefix_hit_rate FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'role') = 'inference' AND json_get(attributes_json, 'engine') = 'all' AND json_get(attributes_json, 'statistic') = 'median' AND name IN ('num_requests_running', 'num_requests_waiting', 'gpu_cache_usage_perc', 'prefix_cache_hit_rate') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "running",
+              "text": "running",
+              "type": "number"
+            },
+            {
+              "selector": "waiting",
+              "text": "waiting",
+              "type": "number"
+            },
+            {
+              "selector": "kv_cache",
+              "text": "kv_cache",
+              "type": "number"
+            },
+            {
+              "selector": "prefix_hit_rate",
+              "text": "prefix_hit_rate",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "interval": "1m"
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Engine request latency (p90)",
+      "description": "Ninetieth-percentile latency by stage — queued, prefill, decode, time to first token, end to end. Queued dominating points at engine capacity; decode dominating points at generation length.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 32
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, json_get(attributes_json, 'stage') AS series, AVG(value) AS value FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'role') = 'inference' AND json_get(attributes_json, 'engine') = 'all' AND json_get(attributes_json, 'statistic') = 'p90' AND name = 'request_latency_seconds' AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "series",
+              "text": "series",
+              "type": "string"
+            },
+            {
+              "selector": "value",
+              "text": "value",
               "type": "number"
             }
           ]

--- a/infra/grafana/dashboards/rl_runs.json
+++ b/infra/grafana/dashboards/rl_runs.json
@@ -247,7 +247,7 @@
       "id": 2,
       "type": "timeseries",
       "title": "Critical-path phase duration",
-      "description": "Seconds the trainer spent waiting on rollouts or inference against seconds it spent in the optimizer step, both measured on the exclusive critical path. Rollout wait dominating is the trainer starved for generation, not slow at training.",
+      "description": "Seconds the trainer spent waiting on rollouts or inference against seconds in the optimizer step, on the exclusive critical path. Rollout wait dominating is the trainer starved for generation rather than slow at training. Outcome is part of the series because a phase that raised recorded how long it ran before failing, which is not how long the phase takes.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"
@@ -297,7 +297,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, AVG(CASE WHEN json_get(attributes_json, 'phase') = 'rollout_or_inference_wait' THEN value END) AS rollout_wait, AVG(CASE WHEN json_get(attributes_json, 'phase') = 'train_step' THEN value END) AS train_step FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND name = 'phase_duration_seconds' AND json_get(attributes_json, 'clock_domain') = 'critical_path' AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, json_get(attributes_json, 'phase') || ' · ' || json_get(attributes_json, 'outcome') AS series, AVG(value) AS value FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND name = 'phase_duration_seconds' AND json_get(attributes_json, 'clock_domain') = 'critical_path' AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
               },
               {
                 "key": "from",
@@ -316,13 +316,13 @@
               "type": "timestamp_epoch"
             },
             {
-              "selector": "rollout_wait",
-              "text": "rollout_wait",
-              "type": "number"
+              "selector": "series",
+              "text": "series",
+              "type": "string"
             },
             {
-              "selector": "train_step",
-              "text": "train_step",
+              "selector": "value",
+              "text": "value",
               "type": "number"
             }
           ]

--- a/infra/grafana/dashboards/rl_runs.json
+++ b/infra/grafana/dashboards/rl_runs.json
@@ -247,7 +247,7 @@
       "id": 2,
       "type": "timeseries",
       "title": "Critical-path phase duration",
-      "description": "Seconds the trainer spent waiting on rollouts or inference against seconds in the optimizer step, on the exclusive critical path. Rollout wait dominating is the trainer starved for generation rather than slow at training. Outcome is part of the series because a phase that raised recorded how long it ran before failing, which is not how long the phase takes.",
+      "description": "Seconds the trainer spent waiting on rollouts or inference against seconds in the optimizer step, on the exclusive critical path. Rollout wait dominating is the trainer starved for generation rather than slow at training. Outcome is part of the series because a phase that raised recorded how long it ran before failing, which is not how long the phase takes. The trainer's two phases are named explicitly: Harbor emits the same metric name with its own phase and outcome vocabularies, and would otherwise join here if its telemetry is ever routed through this service.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"
@@ -297,7 +297,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, json_get(attributes_json, 'phase') || ' · ' || json_get(attributes_json, 'outcome') AS series, AVG(value) AS value FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND name = 'phase_duration_seconds' AND json_get(attributes_json, 'clock_domain') = 'critical_path' AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, json_get(attributes_json, 'phase') || ' · ' || json_get(attributes_json, 'outcome') AS series, AVG(value) AS value FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND name = 'phase_duration_seconds' AND json_get(attributes_json, 'clock_domain') = 'critical_path' AND json_get(attributes_json, 'phase') IN ('rollout_or_inference_wait', 'train_step') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
               },
               {
                 "key": "from",
@@ -415,7 +415,7 @@
       "id": 4,
       "type": "timeseries",
       "title": "Work completed",
-      "description": "Rollouts, samples and generated tokens per bucket. A rollout is one completed trajectory; a sample is one generated response segment, so step-wise training counts only terminal segments as rollouts. These are native counter deltas and sum directly.",
+      "description": "Rollouts, samples and generated tokens per bucket. A rollout is one completed trajectory; a sample is one generated response segment, so step-wise training counts only terminal segments as rollouts. These are native counter deltas and sum directly. The three work kinds this panel plots are named explicitly. The trainer emits a fourth, `policy_step`, which is a counter under this metric and is distinct from the `policy_step` gauge the step panel reads. Harbor counts trials under the same metric name, and a trial is not a rollout.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"
@@ -464,7 +464,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, SUM(CASE WHEN json_get(attributes_json, 'work_kind') = 'rollout' THEN value END) AS rollouts, SUM(CASE WHEN json_get(attributes_json, 'work_kind') = 'sample' THEN value END) AS samples, SUM(CASE WHEN json_get(attributes_json, 'work_kind') = 'generated_token' THEN value END) AS generated_tokens FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND name = 'work_completed' AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, SUM(CASE WHEN json_get(attributes_json, 'work_kind') = 'rollout' THEN value END) AS rollouts, SUM(CASE WHEN json_get(attributes_json, 'work_kind') = 'sample' THEN value END) AS samples, SUM(CASE WHEN json_get(attributes_json, 'work_kind') = 'generated_token' THEN value END) AS generated_tokens FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND name = 'work_completed' AND json_get(attributes_json, 'work_kind') IN ('rollout', 'sample', 'generated_token') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
               },
               {
                 "key": "from",
@@ -1105,6 +1105,178 @@
             {
               "selector": "value",
               "text": "value",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "interval": "1m"
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Corrupted rollouts",
+      "description": "Share of returned requests the engine flagged as corrupted — NaNs in logits — per engine actor. A corrupted rollout that reaches the training batch is a correctness fault, not a slowdown, and nothing else records it. The counter reports zero on a clean batch, so a flat zero line means the engines are reporting and finding nothing; a gap means they stopped reporting.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "percentunit",
+          "max": 1,
+          "decimals": 4
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, COALESCE(json_get(resource_attributes_json, 'actor_uid'), 'unattributed') AS series, SUM(CASE WHEN name = 'corrupted_requests' THEN value END) / NULLIF(SUM(CASE WHEN name = 'requests_returned' THEN value END), 0) AS value FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'role') = 'inference' AND name IN ('corrupted_requests', 'requests_returned') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "series",
+              "text": "series",
+              "type": "string"
+            },
+            {
+              "selector": "value",
+              "text": "value",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "interval": "1m"
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Prefix cache hit share",
+      "description": "Cached prompt tokens as a share of all tokens the engines handled, counted exactly from each request's cached-token count rather than approximated from a hit rate against total queries. A collapse right after a weight sync is the cache being invalidated by the new policy.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "percentunit",
+          "max": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, SUM(CASE WHEN name = 'prefix_cache_hit_tokens' THEN value END) / NULLIF(SUM(CASE WHEN name = 'generation_tokens_total' THEN value END) + SUM(CASE WHEN name = 'prefix_cache_hit_tokens' THEN value END), 0) AS cached_fraction FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'role') = 'inference' AND name IN ('prefix_cache_hit_tokens', 'generation_tokens_total') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "cached_fraction",
+              "text": "cached_fraction",
               "type": "number"
             }
           ]

--- a/infra/grafana/dashboards/rl_runs.json
+++ b/infra/grafana/dashboards/rl_runs.json
@@ -1,0 +1,848 @@
+{
+  "uid": "marin-rl-runs",
+  "title": "RL runs",
+  "description": "One reinforcement-learning run, across every process that reports it. Runs are identified by run_id, which the MarinSkyRL driver, trainer and Ray controller all stamp. Accelerator and engine series carry no run_id of their own and are joined to the run through the nodes and the Iris job its own rows name. Everything here is read from telemetry_v1, so it answers after the run's pods are gone; W&B keeps the full-fidelity experiment record.",
+  "tags": [
+    "marin",
+    "generated"
+  ],
+  "timezone": "utc",
+  "editable": false,
+  "schemaVersion": 39,
+  "refresh": "1m",
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Home",
+      "type": "link",
+      "url": "/d/marin-home"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Runs",
+      "type": "link",
+      "url": "/d/marin-runs"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Inference",
+      "type": "link",
+      "url": "/d/marin-inference"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Jobs",
+      "type": "link",
+      "url": "/d/marin-jobs"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "Accelerators",
+      "type": "link",
+      "url": "/d/marin-accel"
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "cluster",
+        "label": "Cluster",
+        "type": "custom",
+        "query": "cw-rno2a,cw-us-east-02a,cw-us-east-08a,marin,marin-dev",
+        "multi": true,
+        "includeAll": true,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": []
+      },
+      {
+        "name": "run",
+        "label": "Run",
+        "type": "query",
+        "datasource": {
+          "type": "yesoreyeram-infinity-datasource",
+          "uid": "finelog-marin"
+        },
+        "multi": true,
+        "includeAll": false,
+        "refresh": 2,
+        "sort": 1,
+        "current": {},
+        "options": [],
+        "query": {
+          "queryType": "infinity",
+          "refId": "variable-run",
+          "infinityQuery": {
+            "refId": "variable-run",
+            "type": "json",
+            "source": "url",
+            "format": "table",
+            "parser": "backend",
+            "url": "/query",
+            "url_options": {
+              "method": "GET",
+              "params": [
+                {
+                  "key": "sql",
+                  "value": "SELECT DISTINCT run_id AS value FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND name = 'policy_step' AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) AND run_id IS NOT NULL ORDER BY 1"
+                },
+                {
+                  "key": "from",
+                  "value": "${__from}"
+                },
+                {
+                  "key": "to",
+                  "value": "${__to}"
+                }
+              ]
+            },
+            "columns": [
+              {
+                "selector": "value",
+                "text": "value",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "table",
+      "title": "Producers reporting this run",
+      "description": "Every process that put a row under this run_id, and when it last did. A run that trains but shows one producer is emitting without being joinable; a producer that stops reporting while the others continue is the first symptom of a partial failure.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "last_record_ms"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "dateTimeAsIso"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "SELECT service AS producer, COALESCE(json_get(resource_attributes_json, 'role'), '') AS role, COALESCE(json_get(attributes_json, 'metric_source'), '') AS metric_source, COUNT(DISTINCT name) AS signals, COUNT(*) AS records, MAX(timestamp_ms) AS last_record_ms FROM \"telemetry_v1\" WHERE run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2, 3 ORDER BY 1, 2, 3"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "producer",
+              "text": "producer",
+              "type": "string"
+            },
+            {
+              "selector": "role",
+              "text": "role",
+              "type": "string"
+            },
+            {
+              "selector": "metric_source",
+              "text": "metric_source",
+              "type": "string"
+            },
+            {
+              "selector": "signals",
+              "text": "signals",
+              "type": "number"
+            },
+            {
+              "selector": "records",
+              "text": "records",
+              "type": "number"
+            },
+            {
+              "selector": "last_record_ms",
+              "text": "last_record_ms",
+              "type": "number"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Critical-path phase duration",
+      "description": "Seconds the trainer spent waiting on rollouts or inference against seconds it spent in the optimizer step, both measured on the exclusive critical path. Rollout wait dominating is the trainer starved for generation, not slow at training.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, AVG(CASE WHEN json_get(attributes_json, 'phase') = 'rollout_or_inference_wait' THEN value END) AS rollout_wait, AVG(CASE WHEN json_get(attributes_json, 'phase') = 'train_step' THEN value END) AS train_step FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND name = 'phase_duration_seconds' AND json_get(attributes_json, 'clock_domain') = 'critical_path' AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "rollout_wait",
+              "text": "rollout_wait",
+              "type": "number"
+            },
+            {
+              "selector": "train_step",
+              "text": "train_step",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "interval": "1m"
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Policy step",
+      "description": "The optimizer step the policy has reached. Flat while phase duration keeps accruing is a run that is spending time without making progress.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, run_id AS series, MAX(value) AS value FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND name = 'policy_step' AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "series",
+              "text": "series",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "interval": "1m"
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Work completed",
+      "description": "Rollouts, samples and generated tokens per bucket. A rollout is one completed trajectory; a sample is one generated response segment, so step-wise training counts only terminal segments as rollouts. These are native counter deltas and sum directly.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, SUM(CASE WHEN json_get(attributes_json, 'work_kind') = 'rollout' THEN value END) AS rollouts, SUM(CASE WHEN json_get(attributes_json, 'work_kind') = 'sample' THEN value END) AS samples, SUM(CASE WHEN json_get(attributes_json, 'work_kind') = 'generated_token' THEN value END) AS generated_tokens FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND name = 'work_completed' AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "rollouts",
+              "text": "rollouts",
+              "type": "number"
+            },
+            {
+              "selector": "samples",
+              "text": "samples",
+              "type": "number"
+            },
+            {
+              "selector": "generated_tokens",
+              "text": "generated_tokens",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "interval": "1m"
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Rollout buffer occupancy",
+      "description": "Depth against capacity of the fully async rollout buffer. Depth pinned at capacity is generation outrunning training; depth at zero with the trainer waiting is the reverse.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, AVG(CASE WHEN name = 'queue_depth' THEN value END) AS depth, AVG(CASE WHEN name = 'capacity' THEN value END) AS capacity FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND name IN ('queue_depth', 'capacity') AND json_get(attributes_json, 'queue') = 'rollout_buffer' AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "depth",
+              "text": "depth",
+              "type": "number"
+            },
+            {
+              "selector": "capacity",
+              "text": "capacity",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "interval": "1m"
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Ray object store and spill",
+      "description": "Used, available and spilled bytes from the Ray scheduler snapshots each Iris controller forwards for this run. Spill climbing is the object store overflowing to disk, which shows up as rollout latency long before it shows up as a failure.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, AVG(CASE WHEN name = 'ray_object_store_used_memory' THEN value END) AS object_store_used, AVG(CASE WHEN name = 'ray_object_store_available_memory' THEN value END) AS object_store_available, AVG(CASE WHEN name = 'ray_spill_manager_objects_bytes' THEN value END) AS spilled FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'metric_source') = 'ray' AND name IN ('ray_object_store_used_memory', 'ray_object_store_available_memory', 'ray_spill_manager_objects_bytes') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "object_store_used",
+              "text": "object_store_used",
+              "type": "number"
+            },
+            {
+              "selector": "object_store_available",
+              "text": "object_store_available",
+              "type": "number"
+            },
+            {
+              "selector": "spilled",
+              "text": "spilled",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "interval": "1m"
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "GPU utilisation on this run's nodes",
+      "description": "Accelerator utilisation from the Iris node agent, attributed to the run occupying each node in each bucket. The node agent reports no run identity, so this is joined through node_name, the same way the Levanter run view does it.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "percent",
+          "max": 100
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "WITH raw AS ( SELECT COALESCE(NULLIF(\"cluster\", ''), 'marin') AS cl, date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, service, node_name AS node, run_id AS run, json_get(attributes_json, 'gpu_uuid') AS gpu, name, value FROM \"telemetry_v1\" WHERE ((service = 'iris-node-agent' AND name = 'gpu_utilization_percent') OR (service = 'marinskyrl' AND name = 'policy_step')) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) ), run_node AS ( SELECT cl, t, node, run FROM ( SELECT cl, t, node, run, ROW_NUMBER() OVER (PARTITION BY cl, t, node ORDER BY COUNT(*) DESC) AS rn FROM raw WHERE service = 'marinskyrl' AND node <> '' GROUP BY 1, 2, 3, 4) WHERE rn = 1 ), gpu AS ( SELECT cl, t, node, gpu, AVG(value) AS utilization FROM raw WHERE service = 'iris-node-agent' GROUP BY 1, 2, 3, 4 ) SELECT gpu.t AS t, run_node.run AS series, AVG(gpu.utilization) AS value FROM gpu JOIN run_node ON gpu.cl = run_node.cl AND gpu.t = run_node.t AND gpu.node = run_node.node WHERE run_node.run IN (${run:sqlstring}) GROUP BY 1, 2 ORDER BY 1"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "series",
+              "text": "series",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "interval": "1m"
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Engine generated tokens",
+      "description": "Tokens produced by the vLLM engines serving this run, from their cumulative /metrics snapshots. The serving path stamps job_id rather than run_id, so this is joined through the Iris job the run's own rows name.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "WITH run_job AS ( SELECT DISTINCT job_id FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND run_id IN (${run:sqlstring}) AND job_id IS NOT NULL AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) ), engine AS ( SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, job_id, resource_attributes_json, attributes_json, timestamp_ms, seq, value FROM \"telemetry_v1\" WHERE service = 'vllm' AND name = 'generation_tokens_total' AND json_get(attributes_json, 'source_temporality') = 'cumulative_snapshot' AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) ), deltas AS ( SELECT t, value - LAG(value) OVER ( PARTITION BY job_id, resource_attributes_json, attributes_json ORDER BY timestamp_ms, seq) AS delta FROM engine WHERE job_id IN (SELECT job_id FROM run_job) ) SELECT t, SUM(CASE WHEN delta >= 0 THEN delta END) AS generated_tokens FROM deltas GROUP BY 1 ORDER BY 1"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "generated_tokens",
+              "text": "generated_tokens",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "interval": "1m"
+    }
+  ]
+}

--- a/infra/grafana/dashboards/rl_runs.json
+++ b/infra/grafana/dashboards/rl_runs.json
@@ -672,7 +672,7 @@
       "interval": "1m"
     },
     {
-      "id": 11,
+      "id": 7,
       "type": "timeseries",
       "title": "Ray spilled objects by state",
       "description": "Bytes the Ray spill manager holds, split by its own state label. The states are distinct quantities and are never summed or averaged together.",
@@ -759,7 +759,7 @@
       "interval": "1m"
     },
     {
-      "id": 7,
+      "id": 8,
       "type": "timeseries",
       "title": "GPU utilisation on this run's nodes",
       "description": "Accelerator utilisation from the Iris node agent, attributed to the run occupying each node in each bucket. The node agent reports no run identity, so this is joined through node_name, the same way the Levanter run view does it.",
@@ -842,7 +842,7 @@
       "interval": "1m"
     },
     {
-      "id": 8,
+      "id": 9,
       "type": "timeseries",
       "title": "Engine throughput",
       "description": "Prompt and generation tokens per second across the run's inference engines, from the stats the rollout callback reads by RPC. These rows come from the trainer's own process, so they carry the run's identity directly; `role` is read from the metric attributes because the process resource says driver or trainer while the series says inference.",
@@ -929,7 +929,7 @@
       "interval": "1m"
     },
     {
-      "id": 9,
+      "id": 10,
       "type": "timeseries",
       "title": "Engine queue and cache",
       "description": "Requests running and waiting, KV-cache occupancy and prefix-cache hit rate, median across engines. Waiting climbing while running is flat is the engine saturated; a collapsing prefix hit rate after a weight sync is the cache being invalidated.",
@@ -1026,7 +1026,7 @@
       "interval": "1m"
     },
     {
-      "id": 10,
+      "id": 11,
       "type": "timeseries",
       "title": "Engine request latency (p90)",
       "description": "Ninetieth-percentile latency by stage — queued, prefill, decode, time to first token, end to end. Queued dominating points at engine capacity; decode dominating points at generation length.",
@@ -1105,178 +1105,6 @@
             {
               "selector": "value",
               "text": "value",
-              "type": "number"
-            }
-          ]
-        }
-      ],
-      "interval": "1m"
-    },
-    {
-      "id": 12,
-      "type": "timeseries",
-      "title": "Corrupted rollouts",
-      "description": "Share of returned requests the engine flagged as corrupted — NaNs in logits — per engine actor. A corrupted rollout that reaches the training batch is a correctness fault, not a slowdown, and nothing else records it. The counter reports zero on a clean batch, so a flat zero line means the engines are reporting and finding nothing; a gap means they stopped reporting.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 40
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "percentunit",
-          "max": 1,
-          "decimals": 4
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "showLegend": true,
-          "displayMode": "list",
-          "placement": "bottom",
-          "calcs": []
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "timeseries",
-          "parser": "backend",
-          "url": "/query",
-          "url_options": {
-            "method": "GET",
-            "params": [
-              {
-                "key": "sql",
-                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, COALESCE(json_get(resource_attributes_json, 'actor_uid'), 'unattributed') AS series, SUM(CASE WHEN name = 'corrupted_requests' THEN value END) / NULLIF(SUM(CASE WHEN name = 'requests_returned' THEN value END), 0) AS value FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'role') = 'inference' AND name IN ('corrupted_requests', 'requests_returned') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
-              },
-              {
-                "key": "from",
-                "value": "${__from}"
-              },
-              {
-                "key": "to",
-                "value": "${__to}"
-              }
-            ]
-          },
-          "columns": [
-            {
-              "selector": "t",
-              "text": "time",
-              "type": "timestamp_epoch"
-            },
-            {
-              "selector": "series",
-              "text": "series",
-              "type": "string"
-            },
-            {
-              "selector": "value",
-              "text": "value",
-              "type": "number"
-            }
-          ]
-        }
-      ],
-      "interval": "1m"
-    },
-    {
-      "id": 13,
-      "type": "timeseries",
-      "title": "Prefix cache hit share",
-      "description": "Cached prompt tokens as a share of all tokens the engines handled, counted exactly from each request's cached-token count rather than approximated from a hit rate against total queries. A collapse right after a weight sync is the cache being invalidated by the new policy.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 48
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "drawStyle": "line",
-            "lineWidth": 1,
-            "fillOpacity": 8,
-            "showPoints": "never",
-            "spanNulls": false
-          },
-          "min": 0,
-          "unit": "percentunit",
-          "max": 1
-        },
-        "overrides": []
-      },
-      "options": {
-        "legend": {
-          "showLegend": true,
-          "displayMode": "list",
-          "placement": "bottom",
-          "calcs": []
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "timeseries",
-          "parser": "backend",
-          "url": "/query",
-          "url_options": {
-            "method": "GET",
-            "params": [
-              {
-                "key": "sql",
-                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, SUM(CASE WHEN name = 'prefix_cache_hit_tokens' THEN value END) / NULLIF(SUM(CASE WHEN name = 'generation_tokens_total' THEN value END) + SUM(CASE WHEN name = 'prefix_cache_hit_tokens' THEN value END), 0) AS cached_fraction FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'role') = 'inference' AND name IN ('prefix_cache_hit_tokens', 'generation_tokens_total') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
-              },
-              {
-                "key": "from",
-                "value": "${__from}"
-              },
-              {
-                "key": "to",
-                "value": "${__to}"
-              }
-            ]
-          },
-          "columns": [
-            {
-              "selector": "t",
-              "text": "time",
-              "type": "timestamp_epoch"
-            },
-            {
-              "selector": "cached_fraction",
-              "text": "cached_fraction",
               "type": "number"
             }
           ]

--- a/infra/grafana/dashboards/rl_runs.json
+++ b/infra/grafana/dashboards/rl_runs.json
@@ -591,8 +591,8 @@
     {
       "id": 6,
       "type": "timeseries",
-      "title": "Ray object store and spill",
-      "description": "Used, available and spilled bytes from the Ray scheduler snapshots each Iris controller forwards for this run. Spill climbing is the object store overflowing to disk, which shows up as rollout latency long before it shows up as a failure.",
+      "title": "Ray object store occupancy",
+      "description": "Fraction of the Ray object store in use across the run's nodes. A ratio rather than bytes, so it does not move when the node count does. Climbing toward one is the store about to spill, which surfaces as rollout latency long before it surfaces as a failure.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"
@@ -602,6 +602,89 @@
         "w": 12,
         "x": 0,
         "y": 24
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 8,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "min": 0,
+          "unit": "percentunit",
+          "max": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "timeseries",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, SUM(CASE WHEN name = 'ray_object_store_used_memory' THEN value END) / NULLIF(SUM(CASE WHEN name IN ('ray_object_store_used_memory', 'ray_object_store_available_memory') THEN value END), 0) AS object_store_used_fraction FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'metric_source') = 'ray' AND json_get(attributes_json, 'source_temporality') = 'current_snapshot' AND name IN ('ray_object_store_used_memory', 'ray_object_store_available_memory') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
+              },
+              {
+                "key": "from",
+                "value": "${__from}"
+              },
+              {
+                "key": "to",
+                "value": "${__to}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "t",
+              "text": "time",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "object_store_used_fraction",
+              "text": "object_store_used_fraction",
+              "type": "number"
+            }
+          ]
+        }
+      ],
+      "interval": "1m"
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Ray spilled objects by state",
+      "description": "Bytes the Ray spill manager holds, split by its own state label. The states are distinct quantities and are never summed or averaged together.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
       },
       "fieldConfig": {
         "defaults": {
@@ -642,7 +725,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, AVG(CASE WHEN name = 'ray_object_store_used_memory' THEN value END) AS object_store_used, AVG(CASE WHEN name = 'ray_object_store_available_memory' THEN value END) AS object_store_available, AVG(CASE WHEN name = 'ray_spill_manager_objects_bytes' THEN value END) AS spilled FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'metric_source') = 'ray' AND name IN ('ray_object_store_used_memory', 'ray_object_store_available_memory', 'ray_spill_manager_objects_bytes') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, COALESCE(json_get(attributes_json, 'state'), 'unlabelled') AS series, AVG(value) AS value FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'metric_source') = 'ray' AND json_get(attributes_json, 'source_temporality') = 'current_snapshot' AND name = 'ray_spill_manager_objects_bytes' AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
               },
               {
                 "key": "from",
@@ -661,18 +744,13 @@
               "type": "timestamp_epoch"
             },
             {
-              "selector": "object_store_used",
-              "text": "object_store_used",
-              "type": "number"
+              "selector": "series",
+              "text": "series",
+              "type": "string"
             },
             {
-              "selector": "object_store_available",
-              "text": "object_store_available",
-              "type": "number"
-            },
-            {
-              "selector": "spilled",
-              "text": "spilled",
+              "selector": "value",
+              "text": "value",
               "type": "number"
             }
           ]

--- a/infra/grafana/dashboards/rl_runs.json
+++ b/infra/grafana/dashboards/rl_runs.json
@@ -845,7 +845,7 @@
       "id": 9,
       "type": "timeseries",
       "title": "Engine throughput",
-      "description": "Prompt and generation tokens per second across the run's inference engines, from the stats the rollout callback reads by RPC. These rows come from the trainer's own process, so they carry the run's identity directly; `role` is read from the metric attributes because the process resource says driver or trainer while the series says inference.",
+      "description": "Prompt and generation tokens per second across the run's inference engines, from the stats the rollout callback reads by RPC. These rows come from the trainer's own process, so they carry the run's identity directly; The metric names select the engine path on their own — no other MarinSkyRL producer emits them — so the series is identified by name rather than by a role attribute.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"
@@ -895,7 +895,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, AVG(CASE WHEN name = 'generation_throughput_tokens_per_second' THEN value END) AS generation, AVG(CASE WHEN name = 'prompt_throughput_tokens_per_second' THEN value END) AS prompt FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'role') = 'inference' AND json_get(attributes_json, 'engine') = 'all' AND json_get(attributes_json, 'statistic') = 'median' AND name IN ('generation_throughput_tokens_per_second', 'prompt_throughput_tokens_per_second') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, AVG(CASE WHEN name = 'generation_throughput_tokens_per_second' THEN value END) AS generation, AVG(CASE WHEN name = 'prompt_throughput_tokens_per_second' THEN value END) AS prompt FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'engine') = 'all' AND json_get(attributes_json, 'statistic') = 'median' AND name IN ('generation_throughput_tokens_per_second', 'prompt_throughput_tokens_per_second') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
               },
               {
                 "key": "from",
@@ -932,7 +932,7 @@
       "id": 10,
       "type": "timeseries",
       "title": "Engine queue and cache",
-      "description": "Requests running and waiting, KV-cache occupancy and prefix-cache hit rate, median across engines. Waiting climbing while running is flat is the engine saturated; a collapsing prefix hit rate after a weight sync is the cache being invalidated.",
+      "description": "Requests running and waiting, KV-cache occupancy and prefix-cache hit rate, median across engines. Waiting climbing while running is flat is the engine saturated; a collapsing prefix hit rate after a weight sync is the cache being invalidated. The metric names select the engine path on their own — no other MarinSkyRL producer emits them — so the series is identified by name rather than by a role attribute.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"
@@ -982,7 +982,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, AVG(CASE WHEN name = 'num_requests_running' THEN value END) AS running, AVG(CASE WHEN name = 'num_requests_waiting' THEN value END) AS waiting, AVG(CASE WHEN name = 'gpu_cache_usage_perc' THEN value END) AS kv_cache, AVG(CASE WHEN name = 'prefix_cache_hit_rate' THEN value END) AS prefix_hit_rate FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'role') = 'inference' AND json_get(attributes_json, 'engine') = 'all' AND json_get(attributes_json, 'statistic') = 'median' AND name IN ('num_requests_running', 'num_requests_waiting', 'gpu_cache_usage_perc', 'prefix_cache_hit_rate') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, AVG(CASE WHEN name = 'num_requests_running' THEN value END) AS running, AVG(CASE WHEN name = 'num_requests_waiting' THEN value END) AS waiting, AVG(CASE WHEN name = 'gpu_cache_usage_perc' THEN value END) AS kv_cache, AVG(CASE WHEN name = 'prefix_cache_hit_rate' THEN value END) AS prefix_hit_rate FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'engine') = 'all' AND json_get(attributes_json, 'statistic') = 'median' AND name IN ('num_requests_running', 'num_requests_waiting', 'gpu_cache_usage_perc', 'prefix_cache_hit_rate') AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1 ORDER BY 1"
               },
               {
                 "key": "from",
@@ -1029,7 +1029,7 @@
       "id": 11,
       "type": "timeseries",
       "title": "Engine request latency (p90)",
-      "description": "Ninetieth-percentile latency by stage — queued, prefill, decode, time to first token, end to end. Queued dominating points at engine capacity; decode dominating points at generation length.",
+      "description": "Ninetieth-percentile latency by stage — queued, prefill, decode, time to first token, end to end. Queued dominating points at engine capacity; decode dominating points at generation length. The metric names select the engine path on their own — no other MarinSkyRL producer emits them — so the series is identified by name rather than by a role attribute.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"
@@ -1079,7 +1079,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, json_get(attributes_json, 'stage') AS series, AVG(value) AS value FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'role') = 'inference' AND json_get(attributes_json, 'engine') = 'all' AND json_get(attributes_json, 'statistic') = 'p90' AND name = 'request_latency_seconds' AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
+                "value": "SELECT date_bin(INTERVAL '${__interval_ms} milliseconds', to_timestamp_millis(timestamp_ms)) AS t, json_get(attributes_json, 'stage') AS series, AVG(value) AS value FROM \"telemetry_v1\" WHERE service = 'marinskyrl' AND json_get(attributes_json, 'engine') = 'all' AND json_get(attributes_json, 'statistic') = 'p90' AND name = 'request_latency_seconds' AND run_id IN (${run:sqlstring}) AND COALESCE(NULLIF(\"cluster\", ''), 'marin') IN (${cluster:sqlstring}) AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT) GROUP BY 1, 2 ORDER BY 1"
               },
               {
                 "key": "from",

--- a/infra/grafana/dashboards/runs.json
+++ b/infra/grafana/dashboards/runs.json
@@ -204,6 +204,16 @@
       "title": "Infra",
       "type": "link",
       "url": "/d/infra"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": true,
+      "targetBlank": false,
+      "title": "RL runs",
+      "type": "link",
+      "url": "/d/marin-rl-runs"
     }
   ],
   "panels": [

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -628,9 +628,9 @@ groups:
                 - evaluator: { type: gt, params: [0] }
 
   # This warning finds a reporting RL run whose last rollout or policy step is 30
-  # minutes old. Stall detection in this repo is per-producer and opt-in: the
-  # training-stall rule covers Levanter runs that opt in by job name, and this one
-  # covers MarinSkyRL. The bridge removes expired producers, so a finished run stops
+  # minutes old. Stall detection in this repo is per-producer and opt-in: the hero
+  # rules cover Levanter runs that opt in by job name, and this one covers
+  # MarinSkyRL. The bridge removes expired producers, so a finished run stops
   # alerting rather than alerting forever.
   - orgId: 1
     name: rl-progress
@@ -644,11 +644,6 @@ groups:
         noDataState: Alerting
         execErrState: Alerting
         labels:
-          severity: critical
-          notification: hero-run
-        annotations:
-          summary: "{{ $labels.cluster }}: {{ $labels.run }} training loss is {{ $labels.reason }}"
-          runbook_url: https://github.com/marin-community/marin/blob/main/docs/ops/training-loss-spike-alert.md
           severity: warning
         annotations:
           summary: "{{ $labels.cluster }}: RL run {{ $labels.run }} execution {{ $labels.execution }} has stale rollout progress"
@@ -664,12 +659,6 @@ groups:
               source: url
               parser: backend
               format: table
-              url: /alerts/loss_spikes
-              url_options: { method: GET }
-              columns:
-                - { selector: cluster, text: cluster, type: string }
-                - { selector: job, text: job, type: string }
-                - { selector: run, text: run, type: string }
               url: /alerts/rl_stalls
               url_options: { method: GET }
               columns:

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -588,6 +588,18 @@ groups:
       # threads under the message it already sent.
       - uid: training-loss-spike
         title: TrainingLossSpike
+  # This warning finds a reporting RL run whose last rollout or policy step is 30
+  # minutes old. Stall detection in this repo is per-producer and opt-in: the
+  # training-stall rule covers Levanter runs that opt in by job name, and this one
+  # covers MarinSkyRL. The bridge removes expired producers, so a finished run stops
+  # alerting rather than alerting forever.
+  - orgId: 1
+    name: rl-progress
+    folder: Alerts
+    interval: 1m
+    rules:
+      - uid: rl-run-progress-stalled
+        title: RLRunProgressStalled
         condition: C
         for: 5m
         noDataState: Alerting
@@ -598,6 +610,10 @@ groups:
         annotations:
           summary: "{{ $labels.cluster }}: {{ $labels.run }} training loss is {{ $labels.reason }}"
           runbook_url: https://github.com/marin-community/marin/blob/main/docs/ops/training-loss-spike-alert.md
+          severity: warning
+        annotations:
+          summary: "{{ $labels.cluster }}: RL run {{ $labels.run }} execution {{ $labels.execution }} has stale rollout progress"
+          runbook_url: https://github.com/marin-community/marin/blob/main/infra/grafana/README.md#alerting
         data:
           - refId: A
             relativeTimeRange: { from: 300, to: 0 }
@@ -615,6 +631,12 @@ groups:
                 - { selector: cluster, text: cluster, type: string }
                 - { selector: job, text: job, type: string }
                 - { selector: run, text: run, type: string }
+              url: /alerts/rl_stalls
+              url_options: { method: GET }
+              columns:
+                - { selector: cluster, text: cluster, type: string }
+                - { selector: run, text: run, type: string }
+                - { selector: execution, text: execution, type: string }
                 - { selector: reason, text: reason, type: string }
                 - { selector: value, text: value, type: number }
           - refId: C

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -588,6 +588,45 @@ groups:
       # threads under the message it already sent.
       - uid: training-loss-spike
         title: TrainingLossSpike
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: critical
+          notification: hero-run
+        annotations:
+          summary: "{{ $labels.cluster }}: {{ $labels.run }} training loss is {{ $labels.reason }}"
+          runbook_url: https://github.com/marin-community/marin/blob/main/docs/ops/training-loss-spike-alert.md
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: finelog-marin
+            model:
+              refId: A
+              datasource: { type: yesoreyeram-infinity-datasource, uid: finelog-marin }
+              type: json
+              source: url
+              parser: backend
+              format: table
+              url: /alerts/loss_spikes
+              url_options: { method: GET }
+              columns:
+                - { selector: cluster, text: cluster, type: string }
+                - { selector: job, text: job, type: string }
+                - { selector: run, text: run, type: string }
+                - { selector: reason, text: reason, type: string }
+                - { selector: value, text: value, type: number }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
   # This warning finds a reporting RL run whose last rollout or policy step is 30
   # minutes old. Stall detection in this repo is per-producer and opt-in: the
   # training-stall rule covers Levanter runs that opt in by job name, and this one

--- a/infra/grafana/src/rl_stalls.py
+++ b/infra/grafana/src/rl_stalls.py
@@ -1,0 +1,109 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bounded finelog query and alert rows for stalled reinforcement-learning runs.
+
+Stall detection here is per-producer and opt-in: the hero rules cover Levanter runs whose
+root job opts in by being named `hero-*-coord`, and `zephyr_stalls.py` covers Zephyr. Nothing
+covered RL runs, and nothing would have even if MarinSkyRL adopted Levanter's whole vocabulary,
+because `hero_runs.task_state_query` selects candidates from `iris.task_state` by job name
+before a metric is read. This module is the RL producer's opt-in, modelled on the Zephyr one.
+
+It reads only `progress_time_seconds`, which MarinSkyRL already emits from `record_policy_step`
+and `record_generated_work`. An RL step is long — a rollout phase alone can run several
+minutes — so the stall threshold is well above the Levanter reader's.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pyarrow as pa
+
+# A producer that has stopped reporting must stop alerting rather than alert forever: a stale
+# row would otherwise pin the alert on indefinitely after the job is gone, and an alert nobody
+# can clear is one people learn to ignore.
+_PRODUCER_FRESHNESS = timedelta(seconds=90)
+# Generation dominates an RL step and a single rollout phase can legitimately run for minutes,
+# so this sits above the Levanter reader's fifteen. Long enough not to fire on a slow step,
+# short enough to catch a wedged engine within a step or two.
+_STALL_AGE = timedelta(minutes=30)
+_TELEMETRY_LOOKBACK = timedelta(minutes=5)
+
+_PROGRESS_TIME_METRIC = "progress_time_seconds"
+_SERVICE = "marinskyrl"
+
+
+def _sql_timestamp(at: datetime) -> str:
+    return at.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def rl_progress_query(now: datetime) -> str:
+    """Return the latest RL progress metric for each active run and task attempt.
+
+    Keyed on the `run_id` column rather than on a JSON attribute: MarinSkyRL stamps the run
+    identity as a promoted resource attribute, so it arrives as a typed, sorted column.
+    """
+    start = _sql_timestamp(now - _TELEMETRY_LOOKBACK)
+    end = _sql_timestamp(now)
+    return (
+        "WITH filtered AS ("
+        "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS origin_cluster, "
+        "run_id AS run, execution_uid AS execution, value AS progress_time, "
+        "timestamp_ms, seq, to_timestamp_millis(timestamp_ms) AS producer_at "
+        'FROM "telemetry_v1" '
+        f"WHERE service = '{_SERVICE}' AND name = '{_PROGRESS_TIME_METRIC}' "
+        f"AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '{start}') * 1000 AS BIGINT) "
+        f"AND timestamp_ms < CAST(EXTRACT(EPOCH FROM TIMESTAMP '{end}') * 1000 AS BIGINT)"
+        "), recent AS ("
+        "SELECT origin_cluster, run, execution, progress_time, producer_at, "
+        "ROW_NUMBER() OVER ("
+        "PARTITION BY origin_cluster, run, execution ORDER BY timestamp_ms DESC, seq DESC"
+        ") AS rn "
+        "FROM filtered WHERE run IS NOT NULL AND run <> '' AND execution IS NOT NULL AND execution <> ''"
+        ") "
+        "SELECT origin_cluster AS cluster, run, execution, progress_time, producer_at "
+        "FROM recent WHERE rn = 1 ORDER BY cluster, run, execution"
+    )
+
+
+def _as_utc(value: object) -> datetime:
+    if not isinstance(value, datetime):
+        raise ValueError(f"expected timestamp, got {value!r}")
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _row(cluster: str, run: str, execution: str, reason: str, value: int) -> dict:
+    return {
+        "cluster": cluster,
+        "run": run,
+        "execution": execution,
+        "reason": reason,
+        "value": value,
+    }
+
+
+def rl_stall_alert_rows(progress_metrics: pa.Table, now: datetime) -> list[dict]:
+    """Return warning rows for reporting RL runs whose last progress is too old."""
+    now = _as_utc(now)
+    rows: list[dict] = []
+    for metric in progress_metrics.to_pylist():
+        producer_at = _as_utc(metric["producer_at"])
+        if now - producer_at > _PRODUCER_FRESHNESS:
+            continue
+
+        progress_at = datetime.fromtimestamp(float(metric["progress_time"]), tz=UTC)
+        stale = now - progress_at >= _STALL_AGE
+        rows.append(
+            _row(
+                str(metric["cluster"]),
+                str(metric["run"]),
+                str(metric["execution"]),
+                "rollout_progress_stale" if stale else "healthy",
+                int(stale),
+            )
+        )
+
+    if rows:
+        return rows
+    return [_row("fleet", "", "", "healthy", 0)]

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -17,6 +17,7 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /finelog/marin/alerts/fleet_health       alert rows: server labels + value(0|1)
     GET /finelog/marin/alerts/training_stalls    active jobs + stalled-progress value(0|1)
     GET /finelog/marin/alerts/loss_spikes        active hero runs + loss-spike value(0|1)
+    GET /finelog/marin/alerts/rl_stalls          reporting RL runs + stalled-progress value(0|1)
     GET /finelog/marin/alerts/zephyr_stalls      active pipelines + stalled-progress value(0|1)
     GET /iris/{cluster}/jobs                     root-job counts by state (in-flight + 24h terminal)
     GET /iris/{cluster}/workers                  healthy worker counts + resource totals per region
@@ -98,6 +99,7 @@ from loom_alerts import (
 )
 from loss_spikes import loss_spike_alert_rows, loss_window_query
 from nightly_config import NIGHTLY_LANES
+from rl_stalls import rl_progress_query, rl_stall_alert_rows
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -485,6 +487,13 @@ def create_app(
 
         return finelog_alert_endpoint("loss_spikes", project)
 
+    def finelog_alerts_rl_stalls(_: Request) -> JSONResponse:
+        def project(target: ClusterTarget, now: datetime) -> list[dict]:
+            progress_metrics = finelog_sources[target.name].query(rl_progress_query(now), max_rows=config.max_rows)
+            return rl_stall_alert_rows(progress_metrics, now)
+
+        return finelog_alert_endpoint("rl_stalls", project)
+
     def finelog_alerts_zephyr_stalls(_: Request) -> JSONResponse:
         def project(target: ClusterTarget, now: datetime) -> list[dict]:
             progress_metrics = finelog_sources[target.name].query(zephyr_progress_query(now), max_rows=config.max_rows)
@@ -705,6 +714,7 @@ def create_app(
             Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/fleet_health", finelog_alerts_fleet_health),
             Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/training_stalls", finelog_alerts_training_stalls),
             Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/loss_spikes", finelog_alerts_loss_spikes),
+            Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/rl_stalls", finelog_alerts_rl_stalls),
             Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/zephyr_stalls", finelog_alerts_zephyr_stalls),
             Route("/iris/{cluster}/jobs", iris_jobs),
             Route("/iris/{cluster}/workers", iris_workers),

--- a/infra/grafana/tests/test_rl_runs_dashboard.py
+++ b/infra/grafana/tests/test_rl_runs_dashboard.py
@@ -103,7 +103,12 @@ def _run_rows() -> list[tuple]:
                     role="trainer",
                 )
             )
-        for phase, seconds in (("rollout_or_inference_wait", 44.0), ("train_step", 6.0)):
+        for phase, seconds, outcome in (
+            ("rollout_or_inference_wait", 44.0, "success"),
+            ("train_step", 6.0, "success"),
+            # A step that raised partway through. Its duration is a different quantity.
+            ("train_step", 0.5, "failure"),
+        ):
             rows.append(
                 _row(
                     service="marinskyrl",
@@ -115,7 +120,7 @@ def _run_rows() -> list[tuple]:
                     job_id=JOB_ID,
                     node_name=NODES[0],
                     role="trainer",
-                    attributes={"phase": phase, "clock_domain": "critical_path", "outcome": "success"},
+                    attributes={"phase": phase, "clock_domain": "critical_path", "outcome": outcome},
                 )
             )
         for work_kind, count in (("rollout", 64.0), ("sample", 512.0), ("generated_token", 131072.0)):
@@ -333,9 +338,13 @@ def test_three_producers_answer_under_one_run_id(store) -> None:
 
 
 def test_the_trainer_panels_render_for_that_run(store) -> None:
-    (phases,) = store.execute(_panel_sql("Critical-path phase duration")).fetchall()[:1]
-    assert phases[1] == pytest.approx(44.0)
-    assert phases[2] == pytest.approx(6.0)
+    # A failed step ran 0.5s before raising; a successful one takes 6s. Blending them would
+    # report 3.25s, which describes neither.
+    phases = store.execute(_panel_sql("Critical-path phase duration")).fetchall()
+    by_series = {row[1]: row[2] for row in phases}
+    assert by_series["rollout_or_inference_wait · success"] == pytest.approx(44.0)
+    assert by_series["train_step · success"] == pytest.approx(6.0)
+    assert by_series["train_step · failure"] == pytest.approx(0.5)
 
     work = store.execute(_panel_sql("Work completed")).fetchall()
     assert [row[1] for row in work] == [64.0] * 6

--- a/infra/grafana/tests/test_rl_runs_dashboard.py
+++ b/infra/grafana/tests/test_rl_runs_dashboard.py
@@ -248,7 +248,7 @@ def _run_rows() -> list[tuple]:
                     job_id=JOB_ID,
                     node_name=NODES[1],
                     role="driver",
-                    attributes={"role": "inference", "engine": "all", "statistic": "median"},
+                    attributes={"engine": "all", "statistic": "median"},
                 )
             )
         rows.append(
@@ -262,7 +262,7 @@ def _run_rows() -> list[tuple]:
                 job_id=JOB_ID,
                 node_name=NODES[1],
                 role="driver",
-                attributes={"role": "inference", "engine": "all", "statistic": "p90", "stage": "decode"},
+                attributes={"engine": "all", "statistic": "p90", "stage": "decode"},
             )
         )
     return rows
@@ -369,9 +369,10 @@ def test_the_node_agent_joins_through_node_name_without_a_run_id(store) -> None:
     assert rows[0][2] == pytest.approx(71.0)
 
 
-def test_the_engine_panels_read_role_from_the_series_not_the_resource(store) -> None:
-    # `role` is on both the resource and the series and they disagree: the process is a
-    # driver, the measurement is inference. A panel that reads the resource finds nothing.
+def test_the_engine_panels_select_by_metric_name_alone(store) -> None:
+    # No other MarinSkyRL producer emits these names, so the name identifies the engine path.
+    # A `role` predicate here would assert that a measurement is a kind of process, and `role`
+    # on the resource says `driver` for these very rows.
     throughput = store.execute(_panel_sql("Engine throughput")).fetchall()
     assert [row[1] for row in throughput] == [1024.0 + bucket for bucket in range(6)]
 
@@ -385,7 +386,10 @@ def test_the_engine_panels_read_role_from_the_series_not_the_resource(store) -> 
 def test_the_engines_inherit_the_run_id_rather_than_carrying_their_own(store) -> None:
     # The engine series exist only because the trainer process stamped the run identity onto
     # its own resource. Drop it and the engine panels go with it.
-    store.execute("UPDATE telemetry_v1 SET run_id = NULL " "WHERE json_get(attributes_json, 'role') = 'inference'")
+    store.execute(
+        "UPDATE telemetry_v1 SET run_id = NULL WHERE name IN "
+        "('generation_throughput_tokens_per_second', 'prompt_throughput_tokens_per_second')"
+    )
 
     assert store.execute(_panel_sql("Engine throughput")).fetchall() == []
 

--- a/infra/grafana/tests/test_rl_runs_dashboard.py
+++ b/infra/grafana/tests/test_rl_runs_dashboard.py
@@ -1,0 +1,317 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The RL run view's own SQL, executed against a run whose producers disagree on identity.
+
+The view claims one thing: given a run_id, it shows the trainer, the accelerators and the
+inference engines together, from telemetry_v1 alone. That claim rests on identity columns
+different producers do and do not stamp, so the test builds a run the way the store
+actually holds one — MarinSkyRL rows carrying run_id, iris-node-agent rows carrying only
+node_name, vllm rows carrying only job_id — and runs the dashboard's shipped queries over
+it. A producer that stops stamping a column it is joined on turns a panel blank, which is
+indistinguishable from an idle run when you are looking at a dashboard.
+"""
+
+import json
+import re
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import duckdb
+import pytest
+from dashboard_stitch import stitch_all
+
+ROOT = Path(__file__).resolve().parent.parent
+DASHBOARDS = ROOT / "dashboards"
+
+NOW = datetime(2026, 8, 20, 12, tzinfo=UTC)
+WINDOW_START = NOW - timedelta(hours=1)
+CLUSTER = "cw-rno2a"
+RUN_ID = "snowball-e6-muonh-0"
+JOB_ID = "/atqamar/snowball-e6-muonh-0-attempt-0"
+NODES = ("gb200-node-0", "gb200-node-1")
+
+_COLUMNS = (
+    "cluster",
+    "service",
+    "run_id",
+    "job_id",
+    "execution_uid",
+    "node_name",
+    "process_index",
+    "name",
+    "value",
+    "timestamp_ms",
+    "seq",
+    "resource_attributes_json",
+    "attributes_json",
+)
+
+
+def _millis(moment: datetime) -> int:
+    return int(moment.timestamp() * 1000)
+
+
+def _row(
+    *,
+    service: str,
+    name: str,
+    value: float,
+    moment: datetime,
+    seq: int,
+    run_id: str | None = None,
+    job_id: str | None = None,
+    node_name: str | None = None,
+    role: str = "",
+    attributes: dict[str, str] | None = None,
+) -> tuple:
+    resource = {"role": role} if role else {}
+    return (
+        CLUSTER,
+        service,
+        run_id,
+        job_id,
+        "iris:/atqamar/snowball-e6-muonh-0-attempt-0/0:attempt:0",
+        node_name,
+        "0",
+        name,
+        value,
+        _millis(moment),
+        seq,
+        json.dumps(resource),
+        json.dumps(attributes or {}),
+    )
+
+
+def _run_rows() -> list[tuple]:
+    """One RL run as the three producers actually record it."""
+    rows = []
+    for bucket in range(6):
+        moment = WINDOW_START + timedelta(minutes=5 * bucket)
+        # The trainer: run_id, job_id and the node it occupies.
+        for node in NODES:
+            rows.append(
+                _row(
+                    service="marinskyrl",
+                    name="policy_step",
+                    value=float(bucket),
+                    moment=moment,
+                    seq=bucket,
+                    run_id=RUN_ID,
+                    job_id=JOB_ID,
+                    node_name=node,
+                    role="trainer",
+                )
+            )
+        for phase, seconds in (("rollout_or_inference_wait", 44.0), ("train_step", 6.0)):
+            rows.append(
+                _row(
+                    service="marinskyrl",
+                    name="phase_duration_seconds",
+                    value=seconds,
+                    moment=moment,
+                    seq=bucket,
+                    run_id=RUN_ID,
+                    job_id=JOB_ID,
+                    node_name=NODES[0],
+                    role="trainer",
+                    attributes={"phase": phase, "clock_domain": "critical_path", "outcome": "success"},
+                )
+            )
+        for work_kind, count in (("rollout", 64.0), ("sample", 512.0), ("generated_token", 131072.0)):
+            rows.append(
+                _row(
+                    service="marinskyrl",
+                    name="work_completed",
+                    value=count,
+                    moment=moment,
+                    seq=bucket,
+                    run_id=RUN_ID,
+                    job_id=JOB_ID,
+                    node_name=NODES[0],
+                    role="trainer",
+                    attributes={"work_kind": work_kind},
+                )
+            )
+        for name, value in (("queue_depth", 12.0), ("capacity", 32.0)):
+            rows.append(
+                _row(
+                    service="marinskyrl",
+                    name=name,
+                    value=value,
+                    moment=moment,
+                    seq=bucket,
+                    run_id=RUN_ID,
+                    job_id=JOB_ID,
+                    node_name=NODES[0],
+                    role="trainer",
+                    attributes={"queue": "rollout_buffer"},
+                )
+            )
+        # The Ray controller, forwarded by the same service under a different role.
+        rows.append(
+            _row(
+                service="marinskyrl",
+                name="ray_object_store_used_memory",
+                value=4.0e9 + bucket * 1.0e8,
+                moment=moment,
+                seq=bucket,
+                run_id=RUN_ID,
+                job_id=JOB_ID,
+                node_name=NODES[0],
+                role="controller",
+                attributes={"metric_source": "ray"},
+            )
+        )
+        # The Iris node agent: node_name only. No run_id, no job_id, ever.
+        for node in NODES:
+            rows.append(
+                _row(
+                    service="iris-node-agent",
+                    name="gpu_utilization_percent",
+                    value=71.0 + bucket,
+                    moment=moment,
+                    seq=bucket,
+                    node_name=node,
+                    attributes={"gpu_uuid": f"GPU-{node}-0"},
+                )
+            )
+        # The inference engines: job_id only, cumulative snapshots.
+        rows.append(
+            _row(
+                service="vllm",
+                name="generation_tokens_total",
+                value=100000.0 * (bucket + 1),
+                moment=moment,
+                seq=bucket,
+                job_id=JOB_ID,
+                node_name=NODES[1],
+                role="inference",
+                attributes={"source_temporality": "cumulative_snapshot", "model_name": "grug-67b-a2b"},
+            )
+        )
+    return rows
+
+
+@pytest.fixture
+def store() -> duckdb.DuckDBPyConnection:
+    database = duckdb.connect()
+    database.execute(
+        """
+        CREATE TABLE telemetry_v1(
+            cluster VARCHAR,
+            service VARCHAR,
+            run_id VARCHAR,
+            job_id VARCHAR,
+            execution_uid VARCHAR,
+            node_name VARCHAR,
+            process_index VARCHAR,
+            name VARCHAR,
+            value DOUBLE,
+            timestamp_ms BIGINT,
+            seq BIGINT,
+            resource_attributes_json VARCHAR,
+            attributes_json VARCHAR
+        )
+        """
+    )
+    # finelog's SQL dialect, in the two spellings the dashboards use.
+    database.execute("CREATE MACRO to_timestamp_millis(value) AS to_timestamp(value / 1000.0)::TIMESTAMP")
+    database.execute("CREATE MACRO date_bin(width, moment) AS time_bucket(width, moment)")
+    database.execute("CREATE MACRO json_get(document, key) AS json_extract_string(document, '$.' || key)")
+    placeholders = ", ".join("?" for _ in _COLUMNS)
+    database.executemany(f"INSERT INTO telemetry_v1 VALUES ({placeholders})", _run_rows())
+    return database
+
+
+def _panel_sql(title: str) -> str:
+    """One panel's shipped SQL, with Grafana's macros resolved to this window."""
+    dashboard = stitch_all(DASHBOARDS, DASHBOARDS / "panels")["rl_runs.json"]
+    panels = {panel["title"]: panel for panel in dashboard["panels"]}
+    (parameter,) = [
+        param
+        for param in panels[title]["targets"][0]["url_options"]["params"]
+        if param["key"] == "sql"
+    ]
+    sql = parameter["value"]
+    sql = sql.replace("{{from}}", f"TIMESTAMP '{WINDOW_START.replace(tzinfo=None)}'")
+    sql = sql.replace("{{to}}", f"TIMESTAMP '{NOW.replace(tzinfo=None)}'")
+    sql = sql.replace("${__interval_ms} milliseconds", "5 minutes")
+    sql = sql.replace("${cluster:sqlstring}", f"'{CLUSTER}'")
+    sql = sql.replace("${run:sqlstring}", f"'{RUN_ID}'")
+    assert not re.search(r"\$\{|\{\{", sql), sql
+    return sql
+
+
+def test_the_run_variable_offers_a_run_the_trainer_reported(store) -> None:
+    dashboard = stitch_all(DASHBOARDS, DASHBOARDS / "panels")["rl_runs.json"]
+    (variable,) = [v for v in dashboard["templating"]["list"] if v["name"] == "run"]
+    (parameter,) = [
+        param
+        for param in variable["query"]["infinityQuery"]["url_options"]["params"]
+        if param["key"] == "sql"
+    ]
+    sql = parameter["value"]
+    sql = sql.replace("{{from}}", f"TIMESTAMP '{WINDOW_START.replace(tzinfo=None)}'")
+    sql = sql.replace("{{to}}", f"TIMESTAMP '{NOW.replace(tzinfo=None)}'")
+    sql = sql.replace("${cluster:sqlstring}", f"'{CLUSTER}'")
+
+    assert store.execute(sql).fetchall() == [(RUN_ID,)]
+
+
+def test_three_producers_answer_under_one_run_id(store) -> None:
+    rows = store.execute(_panel_sql("Producers reporting this run")).fetchall()
+
+    producers = {(row[0], row[1]) for row in rows}
+    assert ("marinskyrl", "trainer") in producers
+    assert ("marinskyrl", "controller") in producers
+    assert all(row[4] > 0 for row in rows), rows
+
+
+def test_the_trainer_panels_render_for_that_run(store) -> None:
+    (phases,) = store.execute(_panel_sql("Critical-path phase duration")).fetchall()[:1]
+    assert phases[1] == pytest.approx(44.0)
+    assert phases[2] == pytest.approx(6.0)
+
+    work = store.execute(_panel_sql("Work completed")).fetchall()
+    assert [row[1] for row in work] == [64.0] * 6
+
+    buffer = store.execute(_panel_sql("Rollout buffer occupancy")).fetchall()
+    assert [(row[1], row[2]) for row in buffer] == [(12.0, 32.0)] * 6
+
+    ray = store.execute(_panel_sql("Ray object store and spill")).fetchall()
+    assert ray[0][1] == pytest.approx(4.0e9)
+
+
+def test_the_node_agent_joins_through_node_name_without_a_run_id(store) -> None:
+    # The node agent stamps no run identity at all, so the run's own rows have to name
+    # its nodes. This is the join that breaks first if MarinSkyRL stops stamping
+    # node_name, and it breaks silently.
+    rows = store.execute(_panel_sql("GPU utilisation on this run's nodes")).fetchall()
+
+    assert rows, "no accelerator series joined to the run"
+    assert {row[1] for row in rows} == {RUN_ID}
+    assert rows[0][2] == pytest.approx(71.0)
+
+
+def test_the_engines_join_through_the_job_the_run_names(store) -> None:
+    # The serving path stamps job_id and not run_id, so the run reaches its engines only
+    # because MarinSkyRL stamps job_id too.
+    rows = store.execute(_panel_sql("Engine generated tokens")).fetchall()
+
+    deltas = [row[1] for row in rows if row[1] is not None]
+    assert deltas == [100000.0] * 5
+
+
+def test_a_trainer_that_stops_stamping_node_name_blanks_the_accelerator_panel(store) -> None:
+    # Guards the failure mode this dashboard cannot show you: an identity regression in
+    # the producer reads as an idle run.
+    store.execute("UPDATE telemetry_v1 SET node_name = NULL WHERE service = 'marinskyrl'")
+
+    assert store.execute(_panel_sql("GPU utilisation on this run's nodes")).fetchall() == []
+
+
+def test_a_trainer_that_stops_stamping_job_id_blanks_the_engine_panel(store) -> None:
+    store.execute("UPDATE telemetry_v1 SET job_id = NULL WHERE service = 'marinskyrl'")
+
+    assert store.execute(_panel_sql("Engine generated tokens")).fetchall() == []

--- a/infra/grafana/tests/test_rl_runs_dashboard.py
+++ b/infra/grafana/tests/test_rl_runs_dashboard.py
@@ -148,19 +148,64 @@ def _run_rows() -> list[tuple]:
                     attributes={"queue": "rollout_buffer"},
                 )
             )
-        # The Ray controller, forwarded by the same service under a different role.
+        # The Ray controller, forwarded by the same service under a different role. Forwarded
+        # snapshots always arrive with kind "gauge" whatever they really are, so the truth is in
+        # source_temporality -- and the allowlist carries cumulative counters alongside gauges.
+        for node in NODES:
+            for name, value in (
+                ("ray_object_store_used_memory", 3.0e9),
+                ("ray_object_store_available_memory", 1.0e9),
+            ):
+                rows.append(
+                    _row(
+                        service="marinskyrl",
+                        name=name,
+                        value=value,
+                        moment=moment,
+                        seq=bucket,
+                        run_id=RUN_ID,
+                        job_id=JOB_ID,
+                        node_name=node,
+                        role="controller",
+                        attributes={"metric_source": "ray", "source_temporality": "current_snapshot"},
+                    )
+                )
+            for state, value in (("Spilled", 2.0e9), ("Restored", 5.0e8)):
+                rows.append(
+                    _row(
+                        service="marinskyrl",
+                        name="ray_spill_manager_objects_bytes",
+                        value=value,
+                        moment=moment,
+                        seq=bucket,
+                        run_id=RUN_ID,
+                        job_id=JOB_ID,
+                        node_name=node,
+                        role="controller",
+                        attributes={
+                            "metric_source": "ray",
+                            "source_temporality": "current_snapshot",
+                            "state": state,
+                        },
+                    )
+                )
+        # A cumulative counter from the same allowlist, which must never be averaged in.
         rows.append(
             _row(
                 service="marinskyrl",
-                name="ray_object_store_used_memory",
-                value=4.0e9 + bucket * 1.0e8,
+                name="ray_spill_manager_objects_bytes",
+                value=9.9e12,
                 moment=moment,
                 seq=bucket,
                 run_id=RUN_ID,
                 job_id=JOB_ID,
                 node_name=NODES[0],
                 role="controller",
-                attributes={"metric_source": "ray"},
+                attributes={
+                    "metric_source": "ray",
+                    "source_temporality": "cumulative_snapshot",
+                    "state": "Spilled",
+                },
             )
         )
         # The Iris node agent: node_name only. No run_id, no job_id, ever.
@@ -298,8 +343,10 @@ def test_the_trainer_panels_render_for_that_run(store) -> None:
     buffer = store.execute(_panel_sql("Rollout buffer occupancy")).fetchall()
     assert [(row[1], row[2]) for row in buffer] == [(12.0, 32.0)] * 6
 
-    ray = store.execute(_panel_sql("Ray object store and spill")).fetchall()
-    assert ray[0][1] == pytest.approx(4.0e9)
+    # Occupancy is a ratio, so two nodes reporting 3 GB used of 4 GB still reads 0.75 rather
+    # than doubling. 6e9 used over 8e9 total.
+    occupancy = store.execute(_panel_sql("Ray object store occupancy")).fetchall()
+    assert [row[1] for row in occupancy] == [pytest.approx(0.75)] * 6
 
 
 def test_the_node_agent_joins_through_node_name_without_a_run_id(store) -> None:
@@ -362,3 +409,14 @@ def test_every_panel_has_a_distinct_title_id_and_slot() -> None:
     assert len(ids) == len(set(ids)), ids
     slots = [(panel["gridPos"]["x"], panel["gridPos"]["y"]) for panel in panels]
     assert len(slots) == len(set(slots)), slots
+
+
+def test_ray_panels_exclude_cumulative_snapshots_and_never_mix_states(store) -> None:
+    # A forwarded snapshot's `kind` column is always "gauge"; the real semantics are in
+    # source_temporality. The Ray allowlist carries cumulative counters, and averaging one in
+    # would be silently wrong rather than visibly empty. The spill states are distinct
+    # quantities and must stay distinct series.
+    rows = store.execute(_panel_sql("Ray spilled objects by state")).fetchall()
+
+    by_state = {row[1]: row[2] for row in rows}
+    assert by_state == {"Spilled": pytest.approx(2.0e9), "Restored": pytest.approx(5.0e8)}

--- a/infra/grafana/tests/test_rl_runs_dashboard.py
+++ b/infra/grafana/tests/test_rl_runs_dashboard.py
@@ -176,18 +176,43 @@ def _run_rows() -> list[tuple]:
                     attributes={"gpu_uuid": f"GPU-{node}-0"},
                 )
             )
-        # The inference engines: job_id only, cumulative snapshots.
+        # The inference engines. The rollout callback reads them by RPC from the trainer's
+        # own process, so these rows carry the trainer's resource — role says `driver` there
+        # and `inference` on the series, and the two disagree by design.
+        for name, value in (
+            ("generation_throughput_tokens_per_second", 1024.0 + bucket),
+            ("prompt_throughput_tokens_per_second", 256.0 + bucket),
+            ("num_requests_running", 48.0),
+            ("num_requests_waiting", 12.0),
+            ("gpu_cache_usage_perc", 0.71),
+            ("prefix_cache_hit_rate", 0.42),
+        ):
+            rows.append(
+                _row(
+                    service="marinskyrl",
+                    name=name,
+                    value=value,
+                    moment=moment,
+                    seq=bucket,
+                    run_id=RUN_ID,
+                    job_id=JOB_ID,
+                    node_name=NODES[1],
+                    role="driver",
+                    attributes={"role": "inference", "engine": "all", "statistic": "median"},
+                )
+            )
         rows.append(
             _row(
-                service="vllm",
-                name="generation_tokens_total",
-                value=100000.0 * (bucket + 1),
+                service="marinskyrl",
+                name="request_latency_seconds",
+                value=3.5,
                 moment=moment,
                 seq=bucket,
+                run_id=RUN_ID,
                 job_id=JOB_ID,
                 node_name=NODES[1],
-                role="inference",
-                attributes={"source_temporality": "cumulative_snapshot", "model_name": "grug-67b-a2b"},
+                role="driver",
+                attributes={"role": "inference", "engine": "all", "statistic": "p90", "stage": "decode"},
             )
         )
     return rows
@@ -228,11 +253,7 @@ def _panel_sql(title: str) -> str:
     """One panel's shipped SQL, with Grafana's macros resolved to this window."""
     dashboard = stitch_all(DASHBOARDS, DASHBOARDS / "panels")["rl_runs.json"]
     panels = {panel["title"]: panel for panel in dashboard["panels"]}
-    (parameter,) = [
-        param
-        for param in panels[title]["targets"][0]["url_options"]["params"]
-        if param["key"] == "sql"
-    ]
+    (parameter,) = [param for param in panels[title]["targets"][0]["url_options"]["params"] if param["key"] == "sql"]
     sql = parameter["value"]
     sql = sql.replace("{{from}}", f"TIMESTAMP '{WINDOW_START.replace(tzinfo=None)}'")
     sql = sql.replace("{{to}}", f"TIMESTAMP '{NOW.replace(tzinfo=None)}'")
@@ -247,9 +268,7 @@ def test_the_run_variable_offers_a_run_the_trainer_reported(store) -> None:
     dashboard = stitch_all(DASHBOARDS, DASHBOARDS / "panels")["rl_runs.json"]
     (variable,) = [v for v in dashboard["templating"]["list"] if v["name"] == "run"]
     (parameter,) = [
-        param
-        for param in variable["query"]["infinityQuery"]["url_options"]["params"]
-        if param["key"] == "sql"
+        param for param in variable["query"]["infinityQuery"]["url_options"]["params"] if param["key"] == "sql"
     ]
     sql = parameter["value"]
     sql = sql.replace("{{from}}", f"TIMESTAMP '{WINDOW_START.replace(tzinfo=None)}'")
@@ -294,13 +313,25 @@ def test_the_node_agent_joins_through_node_name_without_a_run_id(store) -> None:
     assert rows[0][2] == pytest.approx(71.0)
 
 
-def test_the_engines_join_through_the_job_the_run_names(store) -> None:
-    # The serving path stamps job_id and not run_id, so the run reaches its engines only
-    # because MarinSkyRL stamps job_id too.
-    rows = store.execute(_panel_sql("Engine generated tokens")).fetchall()
+def test_the_engine_panels_read_role_from_the_series_not_the_resource(store) -> None:
+    # `role` is on both the resource and the series and they disagree: the process is a
+    # driver, the measurement is inference. A panel that reads the resource finds nothing.
+    throughput = store.execute(_panel_sql("Engine throughput")).fetchall()
+    assert [row[1] for row in throughput] == [1024.0 + bucket for bucket in range(6)]
 
-    deltas = [row[1] for row in rows if row[1] is not None]
-    assert deltas == [100000.0] * 5
+    queue = store.execute(_panel_sql("Engine queue and cache")).fetchall()
+    assert [(row[1], row[2]) for row in queue] == [(48.0, 12.0)] * 6
+
+    latency = store.execute(_panel_sql("Engine request latency (p90)")).fetchall()
+    assert {row[1] for row in latency} == {"decode"}
+
+
+def test_the_engines_inherit_the_run_id_rather_than_carrying_their_own(store) -> None:
+    # The engine series exist only because the trainer process stamped the run identity onto
+    # its own resource. Drop it and the engine panels go with it.
+    store.execute("UPDATE telemetry_v1 SET run_id = NULL " "WHERE json_get(attributes_json, 'role') = 'inference'")
+
+    assert store.execute(_panel_sql("Engine throughput")).fetchall() == []
 
 
 def test_a_trainer_that_stops_stamping_node_name_blanks_the_accelerator_panel(store) -> None:
@@ -311,7 +342,23 @@ def test_a_trainer_that_stops_stamping_node_name_blanks_the_accelerator_panel(st
     assert store.execute(_panel_sql("GPU utilisation on this run's nodes")).fetchall() == []
 
 
-def test_a_trainer_that_stops_stamping_job_id_blanks_the_engine_panel(store) -> None:
-    store.execute("UPDATE telemetry_v1 SET job_id = NULL WHERE service = 'marinskyrl'")
+def test_the_producer_census_separates_the_engine_series_from_the_trainer(store) -> None:
+    # Both are `service = 'marinskyrl'`. The census has to show them as distinct producers or
+    # it reports one where there are two.
+    rows = store.execute(_panel_sql("Producers reporting this run")).fetchall()
 
-    assert store.execute(_panel_sql("Engine generated tokens")).fetchall() == []
+    assert {(row[0], row[1]) for row in rows} >= {("marinskyrl", "trainer"), ("marinskyrl", "driver")}
+
+
+def test_every_panel_has_a_distinct_title_id_and_slot() -> None:
+    # A duplicated panel renders twice and shares an id, and a test that looks panels up by
+    # title cannot see it: the lookup keeps one and the dashboard keeps both.
+    dashboard = stitch_all(DASHBOARDS, DASHBOARDS / "panels")["rl_runs.json"]
+    panels = dashboard["panels"]
+
+    titles = [panel["title"] for panel in panels]
+    assert len(titles) == len(set(titles)), titles
+    ids = [panel["id"] for panel in panels]
+    assert len(ids) == len(set(ids)), ids
+    slots = [(panel["gridPos"]["x"], panel["gridPos"]["y"]) for panel in panels]
+    assert len(slots) == len(set(slots)), slots

--- a/infra/grafana/tests/test_rl_runs_dashboard.py
+++ b/infra/grafana/tests/test_rl_runs_dashboard.py
@@ -431,46 +431,6 @@ def test_ray_panels_exclude_cumulative_snapshots_and_never_mix_states(store) -> 
     assert by_state == {"Spilled": pytest.approx(2.0e9), "Restored": pytest.approx(5.0e8)}
 
 
-def test_engine_correctness_and_cache_panels_report_per_actor(store) -> None:
-    # The four batch counters are native rigging counters, so every row is a delta and SUM is
-    # right. Each engine actor emits for itself, so actor_uid is the series and there is no
-    # `engine` attribute to group on.
-    for bucket in range(6):
-        moment = WINDOW_START + timedelta(minutes=5 * bucket)
-        for actor, corrupted in (("actor-a", 0.0), ("actor-b", 2.0)):
-            for name, value in (
-                ("requests_returned", 100.0),
-                ("corrupted_requests", corrupted),
-                ("prefix_cache_hit_tokens", 300.0),
-                ("generation_tokens_total", 700.0),
-            ):
-                row = list(
-                    _row(
-                        service="marinskyrl",
-                        name=name,
-                        value=value,
-                        moment=moment,
-                        seq=bucket,
-                        run_id=RUN_ID,
-                        job_id=JOB_ID,
-                        node_name=NODES[1],
-                        role="inference",
-                        attributes={"role": "inference"},
-                    )
-                )
-                row[11] = json.dumps({"role": "inference", "actor_uid": actor})
-                store.execute(f"INSERT INTO telemetry_v1 VALUES ({', '.join('?' for _ in row)})", row)
-
-    corruption = {row[1]: row[2] for row in store.execute(_panel_sql("Corrupted rollouts")).fetchall()}
-    # A clean actor reports a continuous zero rather than disappearing, which is what makes the
-    # panel distinguishable from an engine that stopped reporting.
-    assert corruption["actor-a"] == pytest.approx(0.0)
-    assert corruption["actor-b"] == pytest.approx(0.02)
-
-    cache = store.execute(_panel_sql("Prefix cache hit share")).fetchall()
-    assert [row[1] for row in cache] == [pytest.approx(0.3)] * 6
-
-
 def test_trainer_panels_exclude_harbors_vocabulary_under_the_same_service(store) -> None:
     # Harbor emits phase_duration_seconds and work_completed under its own phase, outcome and
     # work_kind vocabularies. If its telemetry is ever routed through the trainer's exporter it

--- a/infra/grafana/tests/test_rl_runs_dashboard.py
+++ b/infra/grafana/tests/test_rl_runs_dashboard.py
@@ -429,3 +429,77 @@ def test_ray_panels_exclude_cumulative_snapshots_and_never_mix_states(store) -> 
 
     by_state = {row[1]: row[2] for row in rows}
     assert by_state == {"Spilled": pytest.approx(2.0e9), "Restored": pytest.approx(5.0e8)}
+
+
+def test_engine_correctness_and_cache_panels_report_per_actor(store) -> None:
+    # The four batch counters are native rigging counters, so every row is a delta and SUM is
+    # right. Each engine actor emits for itself, so actor_uid is the series and there is no
+    # `engine` attribute to group on.
+    for bucket in range(6):
+        moment = WINDOW_START + timedelta(minutes=5 * bucket)
+        for actor, corrupted in (("actor-a", 0.0), ("actor-b", 2.0)):
+            for name, value in (
+                ("requests_returned", 100.0),
+                ("corrupted_requests", corrupted),
+                ("prefix_cache_hit_tokens", 300.0),
+                ("generation_tokens_total", 700.0),
+            ):
+                row = list(
+                    _row(
+                        service="marinskyrl",
+                        name=name,
+                        value=value,
+                        moment=moment,
+                        seq=bucket,
+                        run_id=RUN_ID,
+                        job_id=JOB_ID,
+                        node_name=NODES[1],
+                        role="inference",
+                        attributes={"role": "inference"},
+                    )
+                )
+                row[11] = json.dumps({"role": "inference", "actor_uid": actor})
+                store.execute(f"INSERT INTO telemetry_v1 VALUES ({', '.join('?' for _ in row)})", row)
+
+    corruption = {row[1]: row[2] for row in store.execute(_panel_sql("Corrupted rollouts")).fetchall()}
+    # A clean actor reports a continuous zero rather than disappearing, which is what makes the
+    # panel distinguishable from an engine that stopped reporting.
+    assert corruption["actor-a"] == pytest.approx(0.0)
+    assert corruption["actor-b"] == pytest.approx(0.02)
+
+    cache = store.execute(_panel_sql("Prefix cache hit share")).fetchall()
+    assert [row[1] for row in cache] == [pytest.approx(0.3)] * 6
+
+
+def test_trainer_panels_exclude_harbors_vocabulary_under_the_same_service(store) -> None:
+    # Harbor emits phase_duration_seconds and work_completed under its own phase, outcome and
+    # work_kind vocabularies. If its telemetry is ever routed through the trainer's exporter it
+    # arrives as service='marinskyrl', and these panels must not blend a trial into a rollout.
+    moment = WINDOW_START + timedelta(minutes=5)
+    for name, attributes, value in (
+        ("phase_duration_seconds", {"phase": "trial", "clock_domain": "critical_path", "outcome": "timeout"}, 900.0),
+        ("work_completed", {"work_kind": "trial"}, 512.0),
+    ):
+        store.execute(
+            f"INSERT INTO telemetry_v1 VALUES ({', '.join('?' for _ in _COLUMNS)})",
+            list(
+                _row(
+                    service="marinskyrl",
+                    name=name,
+                    value=value,
+                    moment=moment,
+                    seq=99,
+                    run_id=RUN_ID,
+                    job_id=JOB_ID,
+                    node_name=NODES[0],
+                    role="orchestrator",
+                    attributes=attributes,
+                )
+            ),
+        )
+
+    phases = {row[1] for row in store.execute(_panel_sql("Critical-path phase duration")).fetchall()}
+    assert not any("trial" in series for series in phases), phases
+
+    work = store.execute(_panel_sql("Work completed")).fetchall()
+    assert [row[1] for row in work] == [64.0] * 6

--- a/infra/grafana/tests/test_rl_stalls.py
+++ b/infra/grafana/tests/test_rl_stalls.py
@@ -1,0 +1,143 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The RL producer's stall reader.
+
+Stall detection in this repo is per-producer and opt-in. `training_stalls.py` selects its
+candidates from `iris.task_state` by job name before it reads a metric, so an RL run is never
+one no matter what it emits; this reader is MarinSkyRL's own opt-in. It reads only
+`progress_time_seconds`, which MarinSkyRL already emits, and keys on the promoted `run_id`
+column rather than on a JSON attribute.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import duckdb
+import pyarrow as pa
+import pytest
+from rl_stalls import rl_progress_query, rl_stall_alert_rows
+
+NOW = datetime(2026, 8, 20, 12, tzinfo=UTC)
+
+
+def _result(**columns: list) -> pa.Table:
+    return pa.table(dict(columns))
+
+
+def test_a_run_without_recent_progress_alerts_and_a_slow_one_does_not() -> None:
+    progress = _result(
+        cluster=["cw-rno2a", "cw-rno2a"],
+        run=["snowball-e6-muonh-0", "iceball-micro-rl"],
+        execution=["iris:/atqamar/e6/0:attempt:0", "iris:/atqamar/iceball/0:attempt:0"],
+        # An RL step is long. 31 minutes is a stall; 29 is a slow rollout phase.
+        progress_time=[NOW.timestamp() - 31 * 60, NOW.timestamp() - 29 * 60],
+        producer_at=[NOW - timedelta(seconds=20), NOW - timedelta(seconds=20)],
+    )
+
+    assert rl_stall_alert_rows(progress, NOW) == [
+        {
+            "cluster": "cw-rno2a",
+            "run": "snowball-e6-muonh-0",
+            "execution": "iris:/atqamar/e6/0:attempt:0",
+            "reason": "rollout_progress_stale",
+            "value": 1,
+        },
+        {
+            "cluster": "cw-rno2a",
+            "run": "iceball-micro-rl",
+            "execution": "iris:/atqamar/iceball/0:attempt:0",
+            "reason": "healthy",
+            "value": 0,
+        },
+    ]
+
+
+def test_a_producer_that_stopped_reporting_stops_alerting() -> None:
+    # The failure this guards is an alert nobody can clear: a finished run's last row would
+    # otherwise stay stale forever and pin the alert on, which teaches people to ignore it.
+    progress = _result(
+        cluster=["cw-rno2a"],
+        run=["finished-run"],
+        execution=["iris:/atqamar/done/0:attempt:0"],
+        progress_time=[NOW.timestamp() - 90 * 60],
+        producer_at=[NOW - timedelta(minutes=5)],
+    )
+
+    assert rl_stall_alert_rows(progress, NOW) == [
+        {"cluster": "fleet", "run": "", "execution": "", "reason": "healthy", "value": 0}
+    ]
+
+
+def test_no_reporting_runs_returns_an_explicit_zero() -> None:
+    # An empty result must be an explicit healthy row, not an absent series: `noDataState` is
+    # Alerting, so returning nothing would page rather than report a quiet fleet.
+    assert rl_stall_alert_rows(pa.table({}), NOW) == [
+        {"cluster": "fleet", "run": "", "execution": "", "reason": "healthy", "value": 0}
+    ]
+
+
+@pytest.fixture
+def store() -> duckdb.DuckDBPyConnection:
+    database = duckdb.connect()
+    database.execute(
+        """
+        CREATE TABLE telemetry_v1(
+            cluster VARCHAR, service VARCHAR, run_id VARCHAR, execution_uid VARCHAR,
+            name VARCHAR, value DOUBLE, timestamp_ms BIGINT, seq BIGINT,
+            resource_attributes_json VARCHAR, attributes_json VARCHAR
+        )
+        """
+    )
+    database.execute("CREATE MACRO to_timestamp_millis(value) AS to_timestamp(value / 1000.0)::TIMESTAMP")
+    return database
+
+
+def _insert(database, *, service, run_id, execution_uid, progress_time, at, seq):
+    database.execute(
+        "INSERT INTO telemetry_v1 VALUES ('cw-rno2a', ?, ?, ?, 'progress_time_seconds', ?, ?, ?, '{}', '{}')",
+        [service, run_id, execution_uid, progress_time, int(at.timestamp() * 1000), seq],
+    )
+
+
+def test_the_query_takes_the_latest_row_per_run_and_ignores_other_services(store) -> None:
+    execution = "iris:/atqamar/e6/0:attempt:0"
+    for minutes, progress, seq in ((4, 1000.0, 1), (1, 2000.0, 2)):
+        _insert(
+            store,
+            service="marinskyrl",
+            run_id="snowball-e6-muonh-0",
+            execution_uid=execution,
+            progress_time=progress,
+            at=NOW - timedelta(minutes=minutes),
+            seq=seq,
+        )
+    # Levanter reports the same metric name. It has its own reader and must not appear here.
+    _insert(
+        store,
+        service="levanter",
+        run_id="some-pretrain",
+        execution_uid="iris:/other/0:attempt:0",
+        progress_time=3000.0,
+        at=NOW - timedelta(minutes=1),
+        seq=3,
+    )
+
+    rows = store.execute(rl_progress_query(NOW)).fetchall()
+
+    assert [(row[1], row[3]) for row in rows] == [("snowball-e6-muonh-0", 2000.0)]
+
+
+def test_the_query_drops_rows_without_a_run_identity(store) -> None:
+    # A row that never got a run id cannot be attributed to a run, and alerting on it would
+    # name something nobody can look up.
+    _insert(
+        store,
+        service="marinskyrl",
+        run_id=None,
+        execution_uid="iris:/atqamar/e6/0:attempt:0",
+        progress_time=1000.0,
+        at=NOW - timedelta(minutes=1),
+        seq=1,
+    )
+
+    assert store.execute(rl_progress_query(NOW)).fetchall() == []

--- a/infra/grafana/tests/test_rl_stalls.py
+++ b/infra/grafana/tests/test_rl_stalls.py
@@ -11,12 +11,15 @@ column rather than on a JSON attribute.
 """
 
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import duckdb
 import pyarrow as pa
 import pytest
+import yaml
 from rl_stalls import rl_progress_query, rl_stall_alert_rows
 
+ROOT = Path(__file__).resolve().parent.parent
 NOW = datetime(2026, 8, 20, 12, tzinfo=UTC)
 
 
@@ -141,3 +144,62 @@ def test_the_query_drops_rows_without_a_run_identity(store) -> None:
     )
 
     assert store.execute(rl_progress_query(NOW)).fetchall() == []
+
+
+def _strict_rules() -> dict:
+    """Parse rules.yaml rejecting duplicate keys, the way Grafana's Go parser does.
+
+    PyYAML takes the last value for a repeated key and reports nothing. `yaml.v3` errors, so a
+    duplicate does not misconfigure one rule — it fails the whole file to load and takes every
+    other alert with it. A permissive parser is why a half-finished copy-paste survived review.
+    """
+
+    class _Strict(yaml.SafeLoader):
+        pass
+
+    def _no_duplicates(loader, node, deep=False):
+        seen = set()
+        for key_node, _ in node.value:
+            key = loader.construct_object(key_node, deep=deep)
+            if key in seen:
+                raise AssertionError(f"duplicate key {key!r} in rules.yaml")
+            seen.add(key)
+        return yaml.SafeLoader.construct_mapping(loader, node, deep)
+
+    _Strict.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_duplicates)
+    return yaml.load((ROOT / "provisioning" / "alerting" / "rules.yaml").read_text(), Loader=_Strict)
+
+
+def _rl_rule() -> dict:
+    rules = [rule for group in _strict_rules()["groups"] for rule in group["rules"]]
+    (rule,) = [rule for rule in rules if rule["uid"] == "rl-run-progress-stalled"]
+    return rule
+
+
+def test_the_rules_file_has_no_duplicate_keys() -> None:
+    _strict_rules()
+
+
+def test_the_rl_rule_is_warning_only_and_does_not_page() -> None:
+    # `notification: hero-run` routes to ops-critical — email, Slack and Loom. This rule fires on
+    # noDataState as well, so paging on it would page for an absent producer.
+    rule = _rl_rule()
+
+    assert rule["labels"] == {"severity": "warning"}
+    assert "notification" not in rule["labels"]
+
+
+def test_the_rl_rule_queries_its_own_endpoint() -> None:
+    rule = _rl_rule()
+
+    (query,) = [node for node in rule["data"] if node["refId"] == "A"]
+    assert query["model"]["url"] == "/alerts/rl_stalls"
+    assert [column["selector"] for column in query["model"]["columns"]] == [
+        "cluster",
+        "run",
+        "execution",
+        "reason",
+        "value",
+    ]
+    assert set(rule["annotations"]) == {"summary", "runbook_url"}
+    assert "loss" not in rule["annotations"]["summary"]


### PR DESCRIPTION
The Runs dashboard answers for Levanter pretraining — it filters service='levanter' at ten sites
and reads names an RL run never emits — and no dashboard reads service='marinskyrl' or 'harbor'.
This adds a second dashboard rather than widening those panels, because widening would teach each
one two vocabularies and leave a pretraining view showing rollout buffers. It also gives RL runs
stall detection, which they have never had.

- Three producers, three join keys, because they do not share one. The trainer joins on run_id.
  iris-node-agent stamps node_name and never run_id or job_id, so accelerator series are attributed
  through the nodes the run's own rows name — the join runs.json already uses for GPU power:
  https://github.com/marin-community/marin/blob/3e19f1de2e/infra/grafana/dashboards/runs.json#L863
  The engines report through the trainer's exporter and inherit its identity.
- Stall detection here is per-producer and opt-in. The hero rules select candidates from
  iris.task_state by job name before reading a metric, so an RL run was never a candidate whatever
  it emitted. rl_stalls.py is the RL producer's opt-in, modelled on zephyr_stalls.py, and reads
  only progress_time_seconds, which MarinSkyRL already emits. No producer change.
- 30 minutes against the hero rule's 15: generation dominates an RL step and one rollout phase can
  legitimately run for minutes.
- A producer that stops reporting stops alerting. Without that guard a finished run's last stale
  row pins the alert on with nothing able to clear it.
- Panels name the values they plot rather than relying on the service predicate. Harbor emits
  phase_duration_seconds and work_completed under its own phase, outcome and work-kind
  vocabularies, and if its telemetry is ever routed through the trainer's exporter a trial would
  otherwise blend into a rollout with no error and a plausible magnitude.
- Engine series are selected by metric name. role names what a process is, and those rows come from
  the trainer process, so a role='inference' predicate would assert that a measurement is a kind of
  process and would disagree with the resource on the same row. The one remaining role predicate
  reads the resource, where it is a process role.