### PR TITLE
[grafana] show training loss from the first retained step

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -287,11 +287,14 @@ monitor uses. The dashboard uses a 7% drop limit. The router limits are 5.92
 entropy and 400 bias.
 
 One loss panel uses step as its x-axis and keeps the newest sample for a repeated
-step. It ignores the Grafana time range and reads all retained samples for the
-selected run. The wall-clock loss panel separates each `execution_uid` and
-disconnects gaps longer than five minutes. Iris forms this identity from the
-controller-minted `attempt_uid`. Thus, a new controller process cannot join loss
-from a prior process with the same numeric task attempt.
+step. It reads the selected run without a Grafana time bound. The inner scan
+selects process 0 because Levanter publishes tracker metrics only from that
+process. For a series longer than 10,000 points, the query keeps the minimum and
+maximum loss in each group, plus the first and last points. The wall-clock loss
+panel separates each `execution_uid` and disconnects gaps longer than five
+minutes. Iris forms this identity from the controller-minted `attempt_uid`. Thus,
+a new controller process cannot join loss from a prior process with the same
+numeric task attempt.
 
 ## Alerting
 
@@ -660,15 +663,15 @@ Four things about the data will bite you:
   to remember which positions are safe.
 - **Give every `telemetry_v1` query a prunable scope.** For a time scope, write
   `timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT)`. The
-  loss-by-step panel is the only unbounded query. It selects one run and two
-  metric names, which follow the `(service, run_id, name, timestamp_ms)` sort.
-- **Cost tracks the window, not the rows.** A `telemetry_v1` panel costs roughly
-  3s over 3h and 10s over 24h no matter how selective its `name` filter is, so a
-  second scan of the same window nearly doubles a panel. Prefer one scan with
-  `CASE WHEN name = …` over joining two scans, and keep the accelerator and run
-  dashboards on a short default range. Per-row `json_get` is the other cost: the
-  host memory and disk ratios ran 8.6s grouped per node and 3.4s summed straight
-  to the cluster, for the same numbers to three decimal places.
+  loss-by-step panel is the only unbounded query. Its process-0 predicate selects
+  the `training-process-zero` projection. The run and metric-name predicates then
+  prune that data. On 2026-08-21, its full retained query for
+  `hero-12d8b6f0-dee637` took 3.785s from a new job and 1.019s on the next
+  request for approximately 2,600 points.
+- **Cost tracks selected history, not returned rows.** The loss query samples
+  after its window functions. This limits the response and Grafana render cost,
+  but it does not lower the Finelog scan cost. Prefer one scan with conditional
+  aggregation to several tidy single-metric queries.
 - **Clusters forward in bursts.** A cluster minutes behind makes the right edge of
   a fleet chart dip. That is why `accelerators.json` carries a freshness panel, and
   why the power stat reduces to the latest sample per GPU rather than a bucketed sum.

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -287,10 +287,11 @@ monitor uses. The dashboard uses a 7% drop limit. The router limits are 5.92
 entropy and 400 bias.
 
 One loss panel uses step as its x-axis and keeps the newest sample for a repeated
-step. The wall-clock loss panel separates each `execution_uid` and disconnects
-gaps longer than five minutes. Iris forms this identity from the controller-minted
-`attempt_uid`. Thus, a new controller process cannot join loss from a prior
-process with the same numeric task attempt.
+step. It ignores the Grafana time range and reads all retained samples for the
+selected run. The wall-clock loss panel separates each `execution_uid` and
+disconnects gaps longer than five minutes. Iris forms this identity from the
+controller-minted `attempt_uid`. Thus, a new controller process cannot join loss
+from a prior process with the same numeric task attempt.
 
 ## Alerting
 
@@ -657,10 +658,10 @@ Four things about the data will bite you:
   fails to parse. Qualifying or wrapping it is enough for the parser, but panels
   always write `"cluster"`, and a test rejects every other spelling so nobody has
   to remember which positions are safe.
-- **Bound every `telemetry_v1` query, and fold the boundary.** The namespace is
-  sorted on `timestamp_ms` alone, so write
-  `timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT)`, never
-  `timestamp_ms >= {{from}}`. An unbounded query exceeds the bridge's 20s deadline.
+- **Give every `telemetry_v1` query a prunable scope.** For a time scope, write
+  `timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT)`. The
+  loss-by-step panel is the only unbounded query. It selects one run and two
+  metric names, which follow the `(service, run_id, name, timestamp_ms)` sort.
 - **Cost tracks the window, not the rows.** A `telemetry_v1` panel costs roughly
   3s over 3h and 10s over 24h no matter how selective its `name` filter is, so a
   second scan of the same window nearly doubles a panel. Prefer one scan with

--- a/infra/grafana/dashboards/training.json
+++ b/infra/grafana/dashboards/training.json
@@ -528,7 +528,7 @@
       "id": 10,
       "type": "trend",
       "title": "Training loss by step",
-      "description": "Training loss against Levanter step in the selected time range. For a repeated step, the newest sample wins. Use this panel for the continuous curve. Use the attempt panel for outages and restarts.",
+      "description": "Training loss against Levanter step for all retained samples from the selected run. This panel ignores the Grafana time range. For a repeated step, the newest sample wins. Use this panel for the continuous curve. Use the attempt panel for outages and restarts.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"
@@ -578,15 +578,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "WITH paired AS (SELECT timestamp_ms, seq, execution_uid, name, value, MAX(CASE WHEN name = 'step' THEN value END) OVER (PARTITION BY execution_uid ORDER BY timestamp_ms, seq ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS step FROM \"telemetry_v1\" WHERE service = 'levanter' AND name IN ('step', 'train_loss') AND run_id IN (${run:sqlstring}) AND execution_uid IS NOT NULL AND process_index = '0' AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM {{to}}) * 1000 AS BIGINT)), losses AS (SELECT step, value AS train_loss, timestamp_ms, seq, ROW_NUMBER() OVER (PARTITION BY step ORDER BY timestamp_ms DESC, seq DESC) AS rn FROM paired WHERE name = 'train_loss' AND step IS NOT NULL) SELECT step, train_loss FROM losses WHERE rn = 1 ORDER BY step"
-              },
-              {
-                "key": "from",
-                "value": "${__from}"
-              },
-              {
-                "key": "to",
-                "value": "${__to}"
+                "value": "WITH paired AS (SELECT timestamp_ms, seq, execution_uid, name, value, MAX(CASE WHEN name = 'step' THEN value END) OVER (PARTITION BY execution_uid ORDER BY timestamp_ms, seq ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS step FROM \"telemetry_v1\" WHERE service = 'levanter' AND name IN ('step', 'train_loss') AND run_id IN (${run:sqlstring}) AND execution_uid IS NOT NULL AND process_index = '0'), losses AS (SELECT step, value AS train_loss, timestamp_ms, seq, ROW_NUMBER() OVER (PARTITION BY step ORDER BY timestamp_ms DESC, seq DESC) AS rn FROM paired WHERE name = 'train_loss' AND step IS NOT NULL) SELECT step, train_loss FROM losses WHERE rn = 1 ORDER BY step"
               }
             ]
           },

--- a/infra/grafana/dashboards/training.json
+++ b/infra/grafana/dashboards/training.json
@@ -528,7 +528,7 @@
       "id": 10,
       "type": "trend",
       "title": "Training loss by step",
-      "description": "Training loss against Levanter step for all retained samples from the selected run. This panel ignores the Grafana time range. For a repeated step, the newest sample wins. Use this panel for the continuous curve. Use the attempt panel for outages and restarts.",
+      "description": "Training loss against Levanter step for all retained samples from the selected run. This panel ignores the Grafana time range and keeps the minimum and maximum loss in each sample group for series longer than 10,000 points. For a repeated step, the newest sample wins. Use this panel for the continuous curve. Use the attempt panel for outages and restarts.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"
@@ -578,7 +578,7 @@
             "params": [
               {
                 "key": "sql",
-                "value": "WITH paired AS (SELECT timestamp_ms, seq, execution_uid, name, value, MAX(CASE WHEN name = 'step' THEN value END) OVER (PARTITION BY execution_uid ORDER BY timestamp_ms, seq ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS step FROM \"telemetry_v1\" WHERE service = 'levanter' AND name IN ('step', 'train_loss') AND run_id IN (${run:sqlstring}) AND execution_uid IS NOT NULL AND process_index = '0'), losses AS (SELECT step, value AS train_loss, timestamp_ms, seq, ROW_NUMBER() OVER (PARTITION BY step ORDER BY timestamp_ms DESC, seq DESC) AS rn FROM paired WHERE name = 'train_loss' AND step IS NOT NULL) SELECT step, train_loss FROM losses WHERE rn = 1 ORDER BY step"
+                "value": "WITH paired AS (SELECT timestamp_ms, seq, execution_uid, name, value, MAX(CASE WHEN name = 'step' THEN value END) OVER (PARTITION BY execution_uid ORDER BY timestamp_ms, seq ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS step FROM \"telemetry_v1\" WHERE service = 'levanter' AND name IN ('step', 'train_loss') AND run_id IN (${run:sqlstring}) AND execution_uid IS NOT NULL AND process_index = '0'), losses AS (SELECT step, value AS train_loss, timestamp_ms, seq, ROW_NUMBER() OVER (PARTITION BY step ORDER BY timestamp_ms DESC, seq DESC) AS rn FROM paired WHERE name = 'train_loss' AND step IS NOT NULL), numbered AS (SELECT step, train_loss, ROW_NUMBER() OVER (ORDER BY step) AS point_index, COUNT(*) OVER () AS point_count FROM losses WHERE rn = 1), bucketed AS (SELECT step, train_loss, point_index, point_count, CAST(FLOOR(CAST(point_index - 1 AS DOUBLE) * 4999.0 / CAST(point_count AS DOUBLE)) AS BIGINT) AS point_bucket FROM numbered), ranked AS (SELECT step, train_loss, point_index, point_count, ROW_NUMBER() OVER (PARTITION BY point_bucket ORDER BY train_loss, step) AS min_rank, ROW_NUMBER() OVER (PARTITION BY point_bucket ORDER BY train_loss DESC, step DESC) AS max_rank FROM bucketed) SELECT step, train_loss FROM ranked WHERE point_index = 1 OR point_index = point_count OR min_rank = 1 OR max_rank = 1 ORDER BY step"
               }
             ]
           },

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -556,17 +556,25 @@ def test_stat_panels_use_grafana_reduce_options_schema():
             assert reduce_options.get("calcs"), f"{name} panel {panel['id']}: missing reduction"
 
 
-def test_telemetry_queries_bound_their_window_with_foldable_macros():
-    # telemetry_v1 is sorted on timestamp_ms alone, so the boundary has to fold to a
-    # constant for segment pruning to happen at all. `timestamp_ms >= {{from}}` compares
-    # a bigint against a timestamp and turns every panel into a full namespace scan.
+def test_telemetry_queries_have_a_prunable_time_or_run_scope():
+    # Time bounds prune segments. The loss-by-step query instead follows the physical
+    # service/run/name sort to read all retained samples for one selected run.
+    unbounded: list[tuple[str, str]] = []
     for name, dashboard in _stitched_dashboards().items():
         for sql in _panel_sql(dashboard):
             if '"telemetry_v1"' not in sql:
                 continue
-            assert "timestamp_ms >= CAST(EXTRACT(EPOCH FROM" in sql, name
+            if "timestamp_ms >= CAST(EXTRACT(EPOCH FROM" not in sql:
+                unbounded.append((name, sql))
+                continue
             assert "timestamp_ms < CAST(EXTRACT(EPOCH FROM" in sql, name
             assert "timestamp_ms >= {{from}}" not in sql, name
+
+    [(name, sql)] = unbounded
+    assert name == "training.json"
+    assert "service = 'levanter'" in sql
+    assert "name IN ('step', 'train_loss')" in sql
+    assert "run_id IN (${run:sqlstring})" in sql
 
 
 def test_cluster_column_is_only_referenced_quoted_or_as_an_alias():
@@ -670,13 +678,13 @@ def test_training_loss_by_attempt_separates_process_incarnations():
     ]
 
 
-def test_training_loss_by_step_uses_the_newest_retry_sample():
+def test_training_loss_by_step_ignores_time_range_and_uses_newest_retry_sample():
     dashboard = _stitched_dashboards()["training.json"]
     panel = next(panel for panel in _all_panels(dashboard) if panel["title"] == "Training loss by step")
     sql = _panel_sql({**dashboard, "panels": [panel]})[0]
+    assert "{{from}}" not in sql
+    assert "{{to}}" not in sql
     sql = sql.replace("${run:sqlstring}", "'hero-run'")
-    sql = sql.replace("{{from}}", "TIMESTAMP '2026-08-20 00:00:00'")
-    sql = sql.replace("{{to}}", "TIMESTAMP '2026-08-21 00:00:00'")
 
     database = duckdb.connect()
     database.execute(

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -556,9 +556,12 @@ def test_stat_panels_use_grafana_reduce_options_schema():
             assert reduce_options.get("calcs"), f"{name} panel {panel['id']}: missing reduction"
 
 
-def test_telemetry_queries_have_a_prunable_time_or_run_scope():
-    # Time bounds prune segments. The loss-by-step query instead follows the physical
-    # service/run/name sort to read all retained samples for one selected run.
+def test_telemetry_queries_bound_their_window_with_foldable_macros():
+    # Time-scoped queries need foldable bounds for segment pruning. A direct bigint-to-
+    # timestamp comparison such as `timestamp_ms >= {{from}}` cannot prune segments.
+    training = _stitched_dashboards()["training.json"]
+    step_panel = next(panel for panel in _all_panels(training) if panel["id"] == 10)
+    (step_sql,) = _panel_sql({"panels": [step_panel]})
     unbounded: list[tuple[str, str]] = []
     for name, dashboard in _stitched_dashboards().items():
         for sql in _panel_sql(dashboard):
@@ -570,11 +573,7 @@ def test_telemetry_queries_have_a_prunable_time_or_run_scope():
             assert "timestamp_ms < CAST(EXTRACT(EPOCH FROM" in sql, name
             assert "timestamp_ms >= {{from}}" not in sql, name
 
-    [(name, sql)] = unbounded
-    assert name == "training.json"
-    assert "service = 'levanter'" in sql
-    assert "name IN ('step', 'train_loss')" in sql
-    assert "run_id IN (${run:sqlstring})" in sql
+    assert unbounded == [("training.json", step_sql)]
 
 
 def test_cluster_column_is_only_referenced_quoted_or_as_an_alias():
@@ -678,12 +677,10 @@ def test_training_loss_by_attempt_separates_process_incarnations():
     ]
 
 
-def test_training_loss_by_step_ignores_time_range_and_uses_newest_retry_sample():
+def test_training_loss_by_step_uses_the_newest_retry_sample():
     dashboard = _stitched_dashboards()["training.json"]
     panel = next(panel for panel in _all_panels(dashboard) if panel["title"] == "Training loss by step")
     sql = _panel_sql({**dashboard, "panels": [panel]})[0]
-    assert "{{from}}" not in sql
-    assert "{{to}}" not in sql
     sql = sql.replace("${run:sqlstring}", "'hero-run'")
 
     database = duckdb.connect()


### PR DESCRIPTION
* read all retained process-0 samples in `Training loss by step`
  * ignore the Grafana time range only for this step-axis panel
  * use the `training-process-zero` projection from #8552
* keep the newest loss for each repeated step
* cap long series at 10,000 points with the first and last points plus the minimum and maximum loss in each group
* measured on production Finelog with `hero-12d8b6f0-dee637`
  * the unfiltered full-run count took 10.878s and the full series exceeded the 10s deadline
  * the final process-0 query took 3.785s from a new job and 1.019s on the next request for approximately 2,600 points