### PR TITLE
[training] Derive a run id that identifies the run

### DIFF
--- a/experiments/sft/launcher.py
+++ b/experiments/sft/launcher.py
@@ -90,7 +90,7 @@ from marin.execution.step_runner import StepRunner
 from marin.experiment.checkpoints import HfToLevanterCheckpoint
 from marin.processing.tokenize.tokenize import TokenizeConfig, TokenizedCache
 from marin.processing.tokenize.tokenize import tokenize as run_tokenize
-from marin.training.training import LevanterCheckpoint, TrainLmOnPodConfig, run_levanter_train_lm
+from marin.training.training import LevanterCheckpoint, TrainLmOnPodConfig, derive_run_id, run_levanter_train_lm
 from rigging.filesystem.storage_path import prefix_join
 
 from experiments.datasets.instruction import (
@@ -174,6 +174,7 @@ class ModelSource(Protocol):
 def _levanter_train_config(
     spec: SFTSpec,
     *,
+    run_id: str,
     model_config: LmConfig,
     data_config: LmDataConfig,
     num_train_steps: int,
@@ -194,7 +195,7 @@ def _levanter_train_config(
         data=data_config,
         model=model_config,
         optimizer=spec.optimizer,
-        trainer=_trainer(spec, num_train_steps=num_train_steps, gpu_allocator=gpu_allocator),
+        trainer=_trainer(spec, run_id=run_id, num_train_steps=num_train_steps, gpu_allocator=gpu_allocator),
         train_seq_len=spec.seq_len,
         initialize_from_hf=initialize_from_hf,
         initialize_model_from_checkpoint_path=initialize_model_from_checkpoint_path,
@@ -233,6 +234,7 @@ def _levanter_pod_config(
     return TrainLmOnPodConfig(
         train_config=_levanter_train_config(
             spec,
+            run_id=derive_run_id(ctx),
             model_config=model_config,
             data_config=data_config,
             num_train_steps=num_train_steps,
@@ -636,7 +638,7 @@ def _prebuilt_chat_data_config(spec: SFTSpec, cache_paths: Sequence[str], tokeni
     )
 
 
-def _trainer(spec: SFTSpec, *, num_train_steps: int, gpu_allocator: bool) -> TrainerConfig:
+def _trainer(spec: SFTSpec, *, run_id: str, num_train_steps: int, gpu_allocator: bool) -> TrainerConfig:
     """Trainer config. ``gpu_allocator`` adds the GPU-only cuda_async PJRT allocator."""
     jax_config = dict(DEFAULT_JAX_CONFIG)
     if gpu_allocator:
@@ -644,6 +646,7 @@ def _trainer(spec: SFTSpec, *, num_train_steps: int, gpu_allocator: bool) -> Tra
         # allocator:... to PJRT_Client_Create aborts the TPU backend and JAX falls back to CPU.
         jax_config["jax_pjrt_client_create_options"] = "allocator:cuda_async"
     return TrainerConfig(
+        id=run_id,
         train_batch_size=spec.batch_size,
         num_train_steps=num_train_steps,
         steps_per_eval=500,

--- a/lib/marin/src/marin/experiment/train.py
+++ b/lib/marin/src/marin/experiment/train.py
@@ -46,6 +46,7 @@ from marin.processing.tokenize.tokenize import TokenizedCache
 from marin.training.training import (
     LevanterCheckpoint,
     TrainLmOnPodConfig,
+    derive_run_id,
     resolve_training_env,
     run_levanter_train_lm,
 )
@@ -196,7 +197,7 @@ def train_lm(
         inner = TrainLmConfig(
             data=mixture(ctx, datasets, validation=validation),
             trainer=TrainerConfig(
-                id=run_id,
+                id=run_id or derive_run_id(ctx),
                 tracker=WandbConfig(
                     project=wandb_project,
                     name=run_id,

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -27,6 +27,7 @@ from rigging.filesystem.factory import url_to_fs
 from rigging.filesystem.storage_path import StoragePath, prefix_join
 
 from marin.execution.artifact import Artifact
+from marin.execution.lazy import StepContext
 from marin.processing.tokenize import read_tokenized_cache_stats
 from marin.training.run_environment import add_run_env_variables
 
@@ -211,19 +212,25 @@ def apply_output_path(train_config: TrainConfigT, output_path: str) -> TrainConf
     return config
 
 
+def derive_run_id(ctx: StepContext) -> str:
+    """The step's prefix-relative storage address, as a run id. Pulled from the context, so it
+    stays out of the artifact's fingerprint."""
+    return ctx.output_path.removeprefix(ctx.prefix.rstrip("/")).strip("/").replace("/", "-")
+
+
 def _resolve_run_id(
     train_config: TrainConfigT, *, output_path: str | None, env_run_id: str | None
 ) -> tuple[TrainConfigT, str]:
     """Pick a stable run id and stamp it into ``train_config.trainer.id``.
 
-    A stable id is required so a run resumes into the same W&B run and checkpoint directory after
-    preemption. Priority: ``trainer.id`` already set by the caller, then ``env_run_id`` (from
-    ``env_vars["RUN_ID"]``), then the ``RUN_ID`` environment variable, then ``basename(output_path)``,
-    and finally a random UID as a last resort.
+    Priority: ``trainer.id`` set by the caller (a step sets it from :func:`derive_run_id`), then
+    ``env_run_id``, then ``RUN_ID``, then ``<name>-<version>`` from ``output_path``, then a random
+    UID. Output paths end ``<name>/<version>``, so the version alone cannot identify the run.
     """
     run_id = train_config.trainer.id or env_run_id or os.environ.get("RUN_ID")
-    if run_id is None and output_path is not None:
-        run_id = os.path.basename(output_path.rstrip("/"))
+    if not run_id and output_path is not None:
+        name, _, version = output_path.rstrip("/").rpartition("/")
+        run_id = f"{os.path.basename(name)}-{version}" if name else version
         logger.info("Imputing run ID from output path: %s", run_id)
     if not run_id:
         run_id = _cli_helpers_module().default_run_id()

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -17,6 +17,7 @@ from levanter.infra.cli_helpers import CliConfig
 from levanter.main import train_lm
 from levanter.main.train_dpo import TrainDpoConfig
 from levanter.trainer import TrainerConfig
+from marin.execution.lazy import StepContext
 from marin.processing.tokenize import tokenized_cache_stats_path
 from marin.training.training import (
     GPU_NCCL_TERMINATION_TIMEOUT_FLAG,
@@ -25,6 +26,7 @@ from marin.training.training import (
     _maybe_auto_resolve_dpo_schedule,
     _resolve_run_id,
     apply_output_path,
+    derive_run_id,
     doublecheck_paths,
     resolve_training_env,
     temporary_checkpoint_base_path,
@@ -204,11 +206,46 @@ def test_tokenized_cache_stats_path_handles_local_and_gcs_paths():
     )
 
 
-def test_resolve_run_id_imputes_basename_of_output_path(trainer_config):
+def test_resolve_run_id_imputes_name_and_version_from_output_path(trainer_config):
     config = train_lm.TrainLmConfig(trainer=dataclasses.replace(trainer_config, id=None))
-    updated, run_id = _resolve_run_id(config, output_path="gs://bucket/checkpoints/dpo/example-run", env_run_id=None)
-    assert run_id == "example-run"
-    assert updated.trainer.id == "example-run"
+    updated, run_id = _resolve_run_id(config, output_path="gs://bucket/checkpoints/dpo/2026.08.20", env_run_id=None)
+    assert run_id == "dpo-2026.08.20"
+    assert updated.trainer.id == "dpo-2026.08.20"
+
+
+def test_resolve_run_id_distinguishes_artifacts_built_at_one_version(trainer_config):
+    """Artifact output paths end ``<name>/<version>``, so every artifact built at a version shares
+    its final segment and an id taken from that segment alone cannot identify the run."""
+
+    def imputed(output_path: str) -> str:
+        config = train_lm.TrainLmConfig(trainer=dataclasses.replace(trainer_config, id=None))
+        return _resolve_run_id(config, output_path=output_path, env_run_id=None)[1]
+
+    assert imputed("gs://bucket/checkpoints/sft/2026.08.20") != imputed("gs://bucket/checkpoints/pretrain/2026.08.20")
+
+
+def test_derive_run_id_separates_two_authors_of_one_sweep():
+    """A mutable version namespaces the artifact by prefixing ``users/{username}/``, so an id taken
+    from the trailing name segment collapses two authors iterating the same sweep onto one run."""
+
+    def derived(name: str) -> str:
+        return derive_run_id(StepContext.for_run(output_path=f"gs://bucket/{name}/dev", prefix="gs://bucket"))
+
+    assert derived("users/alice/sweep-lr") != derived("users/bob/sweep-lr")
+
+
+def test_derive_run_id_is_constant_at_fingerprint_time():
+    """A run id that varied with the storage prefix would fork the artifact's identity."""
+    assert derive_run_id(StepContext.for_fingerprint()) == "<output_path>"
+
+
+def test_resolve_run_id_imputes_over_an_empty_run_id_env_var(monkeypatch):
+    """An empty ``RUN_ID`` is absent, not chosen: falling through to a random id would lose the
+    stable id that resumption after preemption depends on."""
+    monkeypatch.setenv("RUN_ID", "")
+    config = train_lm.TrainLmConfig(trainer=TrainerConfig(id=None, checkpointer=CheckpointerConfig()))
+    _, run_id = _resolve_run_id(config, output_path="gs://bucket/checkpoints/sft/2026.08.20", env_run_id=None)
+    assert run_id == "sft-2026.08.20"
 
 
 def test_resolve_run_id_prefers_explicit_id_over_output_path(trainer_config):


### PR DESCRIPTION
Every artifact built at the same version shares one run id. `_resolve_run_id` imputes from `basename(output_path)`, and artifact paths end `<name>/<version>`, so the id is just the version:

    checkpoints/sft/2026.08.21       -> 2026.08.21
    checkpoints/pretrain/2026.08.21  -> 2026.08.21   same id, unrelated runs

A step now sets `trainer.id` from its own prefix-relative storage address, which is unique because the address is:

    users/alice/checkpoints/sft/2026.08.21  -> users-alice-checkpoints-sft-2026.08.21

An explicit `run_id` still wins, so the hero and ferry experiments are unaffected. Imputation stays for callers that build a pod config outside a step and now uses the name as well as the version. An empty `RUN_ID` no longer falls through to a random id.

This separates artifacts that differ by name, user, or version; it does not yet separate repeat builds of one mutable `dev` version, which still share an id.

Fingerprints move once, `"id": null` to `"id": "<output_path>"` — a constant, so identity never varies per run. Against 9f8d5ea2b0, lowering `experiments/sft/configs/delphi_1e22` moves it from 37b9a2b4 to 9d0db0e7, and that one field is the whole payload diff. Nothing rebuilds: `check_drift` warns and serves the cached output, and no step in `experiments/` pins `expected_fingerprint`.

W&B, the Grafana run dashboards, and the GPU-hour attribution in `accelerators.json` all key on `run_id`. While ids collide, two runs' metrics merge and per-run attribution is wrong, so this is a prerequisite for RL observability rather than a preference.
