### PR TITLE
[finestore] Bound distributed cache write contention

### DIFF
--- a/lib/finestore/README.md
+++ b/lib/finestore/README.md
@@ -107,13 +107,15 @@ The core `DataStore` and `ReadView` APIs propagate storage and commit errors.
 
 ## Compaction
 
-The store's maintenance thread flushes on its configured interval and compacts a
-table after it crosses `compaction_shards` active files. `store.maintain()` exposes
-the same operation for deterministic callers. `compact(root, table)` performs one
-explicit compaction.
+The store's maintenance thread flushes on its configured interval and uses bounded
+leveled compaction. Level-zero shards are compacted after 16 active files, followed by
+limits of 4 shards at levels one and two. Level three is terminal, so one maintenance
+pass performs at most three compactions per table. `store.maintain()` exposes the same
+operation for deterministic callers. `compact(root, table)` compacts all active shards
+for explicit materialization and sealing.
 
 Compaction pins a manifest, streams an ordered merge of its exact input shards, writes
-one next-generation shard, and replaces those paths through the same `HEAD` compare
+one shard at the next level, and replaces those paths through the same `HEAD` compare
 and swap. If another compactor removes an input first, the losing output remains
 unreferenced and the operation is a benign no-op. If another writer adds a shard,
 the replacement can rebase while preserving the new shard.

--- a/lib/finestore/README.md
+++ b/lib/finestore/README.md
@@ -111,7 +111,7 @@ The store's maintenance thread flushes on its configured interval and uses bound
 leveled compaction. Level-zero shards are compacted after 16 active files, followed by
 limits of 4 shards at levels one and two. Level three is terminal, so one maintenance
 pass performs at most three compactions per table. `store.maintain()` exposes the same
-operation for deterministic callers. `compact(root, table)` compacts all active shards
+operation for deterministic callers. `compact_table(root, table)` compacts all active shards
 for explicit materialization and sealing.
 
 Compaction pins a manifest, streams an ordered merge of its exact input shards, writes

--- a/lib/finestore/src/finestore/cache.py
+++ b/lib/finestore/src/finestore/cache.py
@@ -25,10 +25,21 @@ logger = logging.getLogger(__name__)
 
 
 class PersistentKvCache:
-    """An in-process memory tier over best-effort FineStore named-object writes."""
+    """An in-process memory tier over best-effort FineStore named-object writes.
 
-    def __init__(self, resolve_root: Callable[[], str] | None = None) -> None:
+    ``is_writer`` is evaluated when storing so a distributed process can resolve its
+    rank after constructing the cache. Non-writers retain values in memory and keep
+    read-through access to the shared archive.
+    """
+
+    def __init__(
+        self,
+        resolve_root: Callable[[], str] | None = None,
+        *,
+        is_writer: Callable[[], bool] | None = None,
+    ) -> None:
         self._resolve_root = resolve_root
+        self._is_writer = is_writer or (lambda: True)
         self._root: str | None = None
         self._store: DataStore | None = None
         self._root_lock = threading.Lock()
@@ -48,8 +59,8 @@ class PersistentKvCache:
         return cls()
 
     @classmethod
-    def for_prefix(cls, prefix: str) -> PersistentKvCache:
-        return cls(lambda: marin_temp_bucket(_CACHE_TTL_DAYS, prefix))
+    def for_prefix(cls, prefix: str, *, is_writer: Callable[[], bool] | None = None) -> PersistentKvCache:
+        return cls(lambda: marin_temp_bucket(_CACHE_TTL_DAYS, prefix), is_writer=is_writer)
 
     def location(self) -> str | None:
         return self._resolve_root() if self._resolve_root is not None else None
@@ -77,7 +88,7 @@ class PersistentKvCache:
             if self._closed:
                 raise RuntimeError("cache is closed")
             self._memory[key] = value
-        if self._resolve_root is None:
+        if self._resolve_root is None or not self._is_writer():
             return
         if StoragePath(self._storage_root()).is_remote:
             self._queue_remote_write(key, value)

--- a/lib/finestore/src/finestore/commit.py
+++ b/lib/finestore/src/finestore/commit.py
@@ -6,12 +6,15 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import threading
+import time
 import uuid
 from dataclasses import dataclass, field
 
 from rigging.filesystem.conditional_object import ConditionalWriteError, conditional_object
 from rigging.filesystem.storage_path import StoragePath
+from rigging.timing import ExponentialBackoff
 
 from finestore.layout import (
     FORMAT_VERSION,
@@ -30,6 +33,9 @@ from finestore.layout import (
 
 _MAX_COMMIT_ATTEMPTS = 32
 _ROOT_COMMIT_ID = "root"
+_COMMIT_BACKOFF = ExponentialBackoff(initial=0.05, maximum=2.0, factor=2.0, jitter=0.25)
+
+logger = logging.getLogger(__name__)
 
 
 class CommitConflict(RuntimeError):
@@ -230,7 +236,8 @@ class CommitCoordinator:
         """Publish ``delta`` and return the new durable commit token."""
         with self._lock:
             current = base or read_snapshot(self._layout)
-            for _attempt in range(_MAX_COMMIT_ATTEMPTS):
+            backoff = _COMMIT_BACKOFF.copy()
+            for attempt in range(_MAX_COMMIT_ATTEMPTS):
                 manifest = _apply_delta(current.manifest, delta)
                 manifest_path = self._layout.manifest_path(manifest.commit_id)
                 StoragePath(manifest_path).write_text(manifest.model_dump_json(indent=2))
@@ -243,7 +250,18 @@ class CommitCoordinator:
                 try:
                     version = self._head.write(head.model_dump_json().encode(), expected_version=expected_version)
                 except ConditionalWriteError:
+                    if attempt + 1 == _MAX_COMMIT_ATTEMPTS:
+                        break
                     current = read_snapshot(self._layout)
+                    delay = backoff.next_interval()
+                    logger.info(
+                        "FineStore commit conflict at %s (attempt %d/%d); retrying in %.2fs",
+                        self._layout.root,
+                        attempt + 1,
+                        _MAX_COMMIT_ATTEMPTS,
+                        delay,
+                    )
+                    time.sleep(delay)
                     continue
                 return CommitToken(
                     commit_id=manifest.commit_id,

--- a/lib/finestore/src/finestore/commit.py
+++ b/lib/finestore/src/finestore/commit.py
@@ -6,15 +6,13 @@
 from __future__ import annotations
 
 import hashlib
-import logging
 import threading
-import time
 import uuid
 from dataclasses import dataclass, field
 
 from rigging.filesystem.conditional_object import ConditionalWriteError, conditional_object
 from rigging.filesystem.storage_path import StoragePath
-from rigging.timing import ExponentialBackoff
+from rigging.timing import ExponentialBackoff, retry_with_backoff
 
 from finestore.layout import (
     FORMAT_VERSION,
@@ -32,9 +30,9 @@ from finestore.layout import (
 )
 
 _MAX_COMMIT_ATTEMPTS = 32
+_COMMIT_BACKOFF_INITIAL = 1.0
+_COMMIT_BACKOFF_MAXIMUM = 10 * 60.0
 _ROOT_COMMIT_ID = "root"
-
-logger = logging.getLogger(__name__)
 
 
 class CommitConflict(RuntimeError):
@@ -235,8 +233,13 @@ class CommitCoordinator:
         """Publish ``delta`` and return the new durable commit token."""
         with self._lock:
             current = base or read_snapshot(self._layout)
-            backoff = ExponentialBackoff(initial=0.05, maximum=2.0, factor=2.0, jitter=0.25)
-            for attempt in range(_MAX_COMMIT_ATTEMPTS):
+            refresh = False
+
+            def publish() -> CommitToken:
+                nonlocal current, refresh
+                if refresh:
+                    current = read_snapshot(self._layout)
+                    refresh = False
                 manifest = _apply_delta(current.manifest, delta)
                 manifest_path = self._layout.manifest_path(manifest.commit_id)
                 StoragePath(manifest_path).write_text(manifest.model_dump_json(indent=2))
@@ -249,23 +252,29 @@ class CommitCoordinator:
                 try:
                     version = self._head.write(head.model_dump_json().encode(), expected_version=expected_version)
                 except ConditionalWriteError:
-                    if attempt + 1 == _MAX_COMMIT_ATTEMPTS:
-                        break
-                    current = read_snapshot(self._layout)
-                    delay = backoff.next_interval()
-                    logger.info(
-                        "FineStore commit conflict at %s (attempt %d/%d); retrying in %.2fs",
-                        self._layout.root,
-                        attempt + 1,
-                        _MAX_COMMIT_ATTEMPTS,
-                        delay,
-                    )
-                    time.sleep(delay)
-                    continue
+                    refresh = True
+                    raise
                 return CommitToken(
                     commit_id=manifest.commit_id,
                     sequence=manifest.sequence,
                     version=version,
                     manifest_path=manifest_path,
                 )
-        raise CommitConflict(f"HEAD at {self._layout.root} changed {_MAX_COMMIT_ATTEMPTS} consecutive times")
+
+            try:
+                return retry_with_backoff(
+                    publish,
+                    retryable=lambda exc: isinstance(exc, ConditionalWriteError),
+                    max_attempts=_MAX_COMMIT_ATTEMPTS,
+                    backoff=ExponentialBackoff(
+                        initial=_COMMIT_BACKOFF_INITIAL,
+                        maximum=_COMMIT_BACKOFF_MAXIMUM,
+                        factor=2.0,
+                        jitter=0.25,
+                    ),
+                    operation=f"FineStore commit at {self._layout.root}",
+                )
+            except ConditionalWriteError as exc:
+                raise CommitConflict(
+                    f"HEAD at {self._layout.root} changed {_MAX_COMMIT_ATTEMPTS} consecutive times"
+                ) from exc

--- a/lib/finestore/src/finestore/commit.py
+++ b/lib/finestore/src/finestore/commit.py
@@ -33,7 +33,6 @@ from finestore.layout import (
 
 _MAX_COMMIT_ATTEMPTS = 32
 _ROOT_COMMIT_ID = "root"
-_COMMIT_BACKOFF = ExponentialBackoff(initial=0.05, maximum=2.0, factor=2.0, jitter=0.25)
 
 logger = logging.getLogger(__name__)
 
@@ -236,7 +235,7 @@ class CommitCoordinator:
         """Publish ``delta`` and return the new durable commit token."""
         with self._lock:
             current = base or read_snapshot(self._layout)
-            backoff = _COMMIT_BACKOFF.copy()
+            backoff = ExponentialBackoff(initial=0.05, maximum=2.0, factor=2.0, jitter=0.25)
             for attempt in range(_MAX_COMMIT_ATTEMPTS):
                 manifest = _apply_delta(current.manifest, delta)
                 manifest_path = self._layout.manifest_path(manifest.commit_id)

--- a/lib/finestore/src/finestore/compaction.py
+++ b/lib/finestore/src/finestore/compaction.py
@@ -41,7 +41,7 @@ class CompactionResult:
     superseded: int = 0
 
 
-def compact(
+def compact_table(
     root: str,
     table: str,
     *,

--- a/lib/finestore/src/finestore/compaction.py
+++ b/lib/finestore/src/finestore/compaction.py
@@ -41,8 +41,14 @@ class CompactionResult:
     superseded: int = 0
 
 
-def compact(root: str, table: str, *, coordinator: CompactionCoordinator | None = None) -> CompactionResult:
-    """Replace the currently active shards for ``table`` through one manifest commit.
+def compact(
+    root: str,
+    table: str,
+    *,
+    generation: int | None = None,
+    coordinator: CompactionCoordinator | None = None,
+) -> CompactionResult:
+    """Replace one generation, or all active shards, through one manifest commit.
 
     Source objects remain immutable and reachable by older read views. Garbage collection is
     deliberately separate from compaction because the store does not yet track reader leases.
@@ -51,17 +57,22 @@ def compact(root: str, table: str, *, coordinator: CompactionCoordinator | None 
     commits = coordinator or CommitCoordinator(layout)
     snapshot = commits.snapshot()
     view = ReadView(root, snapshot)
-    shards = view.list_shards(table)
-    if not shards or (len(shards) == 1 and shards[0].primary_key_sorted):
+    active_shards = view.list_shards(table)
+    shards = active_shards if generation is None else tuple(s for s in active_shards if s.generation == generation)
+    if not shards:
+        return CompactionResult(written=0)
+    if len(shards) == 1 and shards[0].writer == _COMPACTOR:
         return CompactionResult(written=0)
     primary_key = view.primary_key(table)
     next_generation = max(shard.generation for shard in shards) + 1
     input_rows = sum(shard.rows for shard in shards)
     input_bytes = sum(shard.size_bytes for shard in shards)
     logger.info(
-        "FineStore compacting %s table=%s input_shards=%d input_rows=%d input_bytes=%d generation=%d",
+        "FineStore compacting %s table=%s input_generation=%s input_shards=%d input_rows=%d "
+        "input_bytes=%d output_generation=%d",
         root,
         table,
+        "all" if generation is None else generation,
         len(shards),
         input_rows,
         input_bytes,
@@ -135,9 +146,11 @@ def compact(root: str, table: str, *, coordinator: CompactionCoordinator | None 
         )
         return CompactionResult(written=0)
     logger.info(
-        "FineStore compacted %s table=%s input_shards=%d output_shards=1 generation=%d rows=%d superseded=%d",
+        "FineStore compacted %s table=%s input_generation=%s input_shards=%d output_shards=1 "
+        "output_generation=%d rows=%d superseded=%d",
         root,
         table,
+        "all" if generation is None else generation,
         len(shards),
         next_generation,
         written,

--- a/lib/finestore/src/finestore/compaction.py
+++ b/lib/finestore/src/finestore/compaction.py
@@ -52,10 +52,21 @@ def compact(root: str, table: str, *, coordinator: CompactionCoordinator | None 
     snapshot = commits.snapshot()
     view = ReadView(root, snapshot)
     shards = view.list_shards(table)
-    if not shards:
+    if not shards or (len(shards) == 1 and shards[0].primary_key_sorted):
         return CompactionResult(written=0)
     primary_key = view.primary_key(table)
     next_generation = max(shard.generation for shard in shards) + 1
+    input_rows = sum(shard.rows for shard in shards)
+    input_bytes = sum(shard.size_bytes for shard in shards)
+    logger.info(
+        "FineStore compacting %s table=%s input_shards=%d input_rows=%d input_bytes=%d generation=%d",
+        root,
+        table,
+        len(shards),
+        input_rows,
+        input_bytes,
+        next_generation,
+    )
 
     fs, _ = factory.url_to_fs(root)
     pa_fs = PyFileSystem(FSSpecHandler(fs))
@@ -76,7 +87,7 @@ def compact(root: str, table: str, *, coordinator: CompactionCoordinator | None 
     survivors = survivor_rows()
     first = next(survivors, None)
     if first is None:
-        return CompactionResult(written=0)
+        raise ValueError(f"FineStore table {table!r} has {len(shards)} non-empty shard descriptors but no rows")
 
     output_path = layout.shard_path(table, _COMPACTOR, next_generation, 0, uuid.uuid4().hex[:8])
     written = 0
@@ -116,11 +127,18 @@ def compact(root: str, table: str, *, coordinator: CompactionCoordinator | None 
             base=snapshot,
         )
     except CommitConflict:
-        logger.info("FineStore abandoned compaction for %s because its inputs changed", table)
+        logger.info(
+            "FineStore abandoned compaction for %s table=%s input_shards=%d because its inputs changed",
+            root,
+            table,
+            len(shards),
+        )
         return CompactionResult(written=0)
     logger.info(
-        "FineStore compacted %s to generation %d (%d rows, %d superseded)",
+        "FineStore compacted %s table=%s input_shards=%d output_shards=1 generation=%d rows=%d superseded=%d",
+        root,
         table,
+        len(shards),
         next_generation,
         written,
         superseded[0],

--- a/lib/finestore/src/finestore/store.py
+++ b/lib/finestore/src/finestore/store.py
@@ -47,7 +47,8 @@ DEFAULT_MAX_BUFFER_BYTES = ROW_GROUP_TARGET_BYTES
 DEFAULT_COMPACTION_SHARDS = 8
 OBJECT_PART_BYTES = 8 * 1024 * 1024
 _MAX_MAINTENANCE_ATTEMPTS = 5
-_MAINTENANCE_BACKOFF = ExponentialBackoff(initial=0.5, maximum=5.0, factor=2.0, jitter=0.25)
+_MAINTENANCE_BACKOFF_INITIAL = 0.5
+_MAINTENANCE_BACKOFF_MAXIMUM = 5.0
 
 _BLOB_SCHEMA = pa.schema(
     [
@@ -393,7 +394,12 @@ class DataStore:
             self._wake.clear()
             if self._stop.is_set():
                 return
-            backoff = _MAINTENANCE_BACKOFF.copy()
+            backoff = ExponentialBackoff(
+                initial=_MAINTENANCE_BACKOFF_INITIAL,
+                maximum=_MAINTENANCE_BACKOFF_MAXIMUM,
+                factor=2.0,
+                jitter=0.25,
+            )
             for attempt in range(_MAX_MAINTENANCE_ATTEMPTS):
                 try:
                     self.maintain()

--- a/lib/finestore/src/finestore/store.py
+++ b/lib/finestore/src/finestore/store.py
@@ -16,6 +16,8 @@ from types import TracebackType
 from typing import Protocol
 
 import pyarrow as pa
+from rigging.filesystem.s3_errors import is_transient_s3_error
+from rigging.timing import ExponentialBackoff
 
 from finestore.commit import ClearSeal, CommitCoordinator, CommitDelta, TableAddition, initialize_archive, write_schema
 from finestore.compaction import CompactionResult
@@ -44,6 +46,8 @@ DEFAULT_FLUSH_INTERVAL = 5.0
 DEFAULT_MAX_BUFFER_BYTES = ROW_GROUP_TARGET_BYTES
 DEFAULT_COMPACTION_SHARDS = 8
 OBJECT_PART_BYTES = 8 * 1024 * 1024
+_MAX_MAINTENANCE_ATTEMPTS = 5
+_MAINTENANCE_BACKOFF = ExponentialBackoff(initial=0.5, maximum=5.0, factor=2.0, jitter=0.25)
 
 _BLOB_SCHEMA = pa.schema(
     [
@@ -389,12 +393,31 @@ class DataStore:
             self._wake.clear()
             if self._stop.is_set():
                 return
-            try:
-                self.maintain()
-            except BaseException as exc:
-                self._error = exc
-                logger.exception("FineStore background maintenance failed")
-                return
+            backoff = _MAINTENANCE_BACKOFF.copy()
+            for attempt in range(_MAX_MAINTENANCE_ATTEMPTS):
+                try:
+                    self.maintain()
+                    break
+                except Exception as exc:
+                    final_attempt = attempt + 1 == _MAX_MAINTENANCE_ATTEMPTS
+                    if final_attempt or not is_transient_s3_error(exc):
+                        self._error = exc
+                        logger.exception(
+                            "FineStore background maintenance failed after %d attempt(s)",
+                            attempt + 1,
+                        )
+                        return
+                    delay = backoff.next_interval()
+                    logger.warning(
+                        "FineStore background maintenance failed for %s (attempt %d/%d); retrying in %.2fs: %s",
+                        self.root,
+                        attempt + 1,
+                        _MAX_MAINTENANCE_ATTEMPTS,
+                        delay,
+                        exc,
+                    )
+                    if self._stop.wait(delay):
+                        return
 
     def request_flush(self) -> None:
         self._wake.set()

--- a/lib/finestore/src/finestore/store.py
+++ b/lib/finestore/src/finestore/store.py
@@ -20,8 +20,7 @@ from rigging.filesystem.s3_errors import is_transient_s3_error
 from rigging.timing import ExponentialBackoff
 
 from finestore.commit import ClearSeal, CommitCoordinator, CommitDelta, TableAddition, initialize_archive, write_schema
-from finestore.compaction import CompactionResult
-from finestore.compaction import compact as compact_table
+from finestore.compaction import CompactionResult, compact_table
 from finestore.layout import (
     CHUNKED_BLOBS_FEATURE,
     RESERVED_COLUMNS,

--- a/lib/finestore/src/finestore/store.py
+++ b/lib/finestore/src/finestore/store.py
@@ -44,11 +44,10 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_FLUSH_INTERVAL = 5.0
 DEFAULT_MAX_BUFFER_BYTES = ROW_GROUP_TARGET_BYTES
-DEFAULT_COMPACTION_SHARDS = 8
+DEFAULT_COMPACTION_LEVELS = (16, 4, 4)
 OBJECT_PART_BYTES = 8 * 1024 * 1024
-_MAX_MAINTENANCE_ATTEMPTS = 5
-_MAINTENANCE_BACKOFF_INITIAL = 0.5
-_MAINTENANCE_BACKOFF_MAXIMUM = 5.0
+_MAINTENANCE_BACKOFF_INITIAL = 1.0
+_MAINTENANCE_BACKOFF_MAXIMUM = 10 * 60.0
 
 _BLOB_SCHEMA = pa.schema(
     [
@@ -159,7 +158,7 @@ class DataStore:
         writer_id: str | None = None,
         flush_interval: float = DEFAULT_FLUSH_INTERVAL,
         max_buffer_bytes: int = DEFAULT_MAX_BUFFER_BYTES,
-        compaction_shards: int = DEFAULT_COMPACTION_SHARDS,
+        compaction_levels: Sequence[int] = DEFAULT_COMPACTION_LEVELS,
     ) -> None:
         self.root = root
         self._layout = FineStoreLayout(self.root)
@@ -168,7 +167,9 @@ class DataStore:
         self.writer_id = writer_id or _default_writer_id()
         self._flush_interval = flush_interval
         self._max_buffer_bytes = max_buffer_bytes
-        self._compaction_shards = compaction_shards
+        self._compaction_levels = tuple(compaction_levels)
+        if not self._compaction_levels or any(limit < 1 for limit in self._compaction_levels):
+            raise ValueError("compaction_levels must contain positive shard limits")
         self._tables: dict[str, DataTable] = {}
         self._register_lock = threading.Lock()
         self._commit_lock = threading.Lock()
@@ -347,18 +348,21 @@ class DataStore:
                 return snapshot.token
             return self._commits.commit(_addition_delta(additions))
 
-    def compact(self, table: str) -> CompactionResult:
+    def compact(self, table: str, *, generation: int | None = None) -> CompactionResult:
         """Logically compact one table against the current manifest."""
         with self._commit_lock:
-            return compact_table(self.root, table, coordinator=self._commits)
+            return compact_table(self.root, table, generation=generation, coordinator=self._commits)
 
     def maintain(self) -> CommitToken | None:
-        """Flush pending rows and compact tables that crossed the shard threshold."""
+        """Flush pending rows and compact each overfull level once."""
         token = self.flush()
         view = self.read_view()
         for name in view.table_names():
-            if len(view.list_shards(name)) >= self._compaction_shards:
-                self.compact(name)
+            for generation, shard_limit in enumerate(self._compaction_levels):
+                level_shards = [shard for shard in view.list_shards(name) if shard.generation == generation]
+                if len(level_shards) <= shard_limit:
+                    continue
+                self.compact(name, generation=generation)
                 view = self.read_view()
                 token = view.token
         return token
@@ -400,25 +404,23 @@ class DataStore:
                 factor=2.0,
                 jitter=0.25,
             )
-            for attempt in range(_MAX_MAINTENANCE_ATTEMPTS):
+            failures = 0
+            while not self._stop.is_set():
                 try:
                     self.maintain()
                     break
                 except Exception as exc:
-                    final_attempt = attempt + 1 == _MAX_MAINTENANCE_ATTEMPTS
-                    if final_attempt or not is_transient_s3_error(exc):
+                    if not is_transient_s3_error(exc):
                         self._error = exc
-                        logger.exception(
-                            "FineStore background maintenance failed after %d attempt(s)",
-                            attempt + 1,
-                        )
+                        logger.exception("FineStore background maintenance failed")
                         return
+                    failures += 1
                     delay = backoff.next_interval()
                     logger.warning(
-                        "FineStore background maintenance failed for %s (attempt %d/%d); retrying in %.2fs: %s",
+                        "FineStore background maintenance failed for %s (consecutive_failures=%d); "
+                        "retrying in %.2fs: %s",
                         self.root,
-                        attempt + 1,
-                        _MAX_MAINTENANCE_ATTEMPTS,
+                        failures,
                         delay,
                         exc,
                     )

--- a/lib/finestore/tests/test_cache.py
+++ b/lib/finestore/tests/test_cache.py
@@ -100,6 +100,18 @@ def test_prefix_cache_uses_region_local_fine_store(tmp_path, monkeypatch):
     assert PersistentKvCache.for_prefix("cutlass-kernels").load("kernel") == b"value"
 
 
+def test_non_writer_cache_keeps_value_in_memory_without_persisting(tmp_path, monkeypatch):
+    root = tmp_path / "cutlass-kernels"
+    monkeypatch.setattr(cache_module, "marin_temp_bucket", lambda _ttl, _prefix: str(root))
+    cache = PersistentKvCache.for_prefix("cutlass-kernels", is_writer=lambda: False)
+
+    cache.store("kernel", b"value")
+    assert cache.load("kernel") == b"value"
+    cache.close()
+
+    assert PersistentKvCache.at(str(root)).load("kernel") is None
+
+
 def test_remote_cache_can_commit_object_larger_than_store_buffer(tmp_path, monkeypatch):
     root = str(tmp_path / "cache")
     open_store = DataStore.open

--- a/lib/finestore/tests/test_finestore.py
+++ b/lib/finestore/tests/test_finestore.py
@@ -16,7 +16,7 @@ from botocore.exceptions import ClientError
 from finestore import shard_writer
 from finestore import store as store_module
 from finestore.commit import CommitConflict, CommitCoordinator, CommitDelta
-from finestore.compaction import compact
+from finestore.compaction import CompactionResult, compact
 from finestore.layout import (
     CHUNKED_BLOBS_FEATURE,
     FORMAT_VERSION,
@@ -31,6 +31,8 @@ from finestore.layout import (
 from finestore.migrations import LegacyReadView, migrate
 from finestore.reader import BlobCorruptionError, ReadView
 from finestore.store import OBJECT_PART_BYTES, DataStore, DataTable, PrimaryKeyConflict, TransactionTooLarge
+from rigging import timing
+from rigging.filesystem.conditional_object import ConditionalWriteError
 from rigging.filesystem.storage_path import StoragePath
 
 
@@ -533,15 +535,20 @@ def test_recompaction_merges_all_generations(tmp_path):
     assert rows == {"0": 0.0, "1": 1.0, "2": 2.0, "3": 3.0, "4": 4.0}
 
 
-def test_compaction_of_stable_shard_is_a_noop(tmp_path):
+def test_compaction_deduplicates_one_level_zero_shard_then_becomes_stable(tmp_path):
     root = str(tmp_path / "run")
     with DataStore.open(root, writer_id="w1") as store:
-        store.table("samples", primary_key=("doc_id",)).append({"doc_id": "1"})
+        table = store.table("samples", primary_key=("doc_id",), on_conflict=OnConflict.SUPERSEDE)
+        table.append({"doc_id": "1", "score": 1})
+        table.append({"doc_id": "1", "score": 2})
         store.flush()
 
+    result = compact(root, "samples")
+    assert result == CompactionResult(written=1, superseded=1)
     stable = ReadView(root)
     stable_token = stable.token
     stable_shards = stable.list_shards("samples")
+    assert stable.scan("samples", columns=["doc_id", "score"]).to_pylist() == [{"doc_id": "1", "score": 2}]
 
     assert compact(root, "samples").written == 0
     unchanged = ReadView(root)
@@ -665,6 +672,43 @@ def test_required_feature_survives_commit_rebase(tmp_path):
     assert view.token is not None
     manifest = json.loads(StoragePath(view.token.manifest_path).read_text())
     assert manifest["required_features"] == [CHUNKED_BLOBS_FEATURE]
+
+
+def test_commit_refreshes_head_after_conflict_backoff(tmp_path, monkeypatch):
+    root = str(tmp_path / "run")
+    with DataStore.open(root, writer_id="initializer", flush_interval=3600):
+        pass
+
+    layout = FineStoreLayout(root)
+    coordinator = CommitCoordinator(layout)
+    competitor = CommitCoordinator(layout)
+    real_head = coordinator._head
+    head_type = type(real_head)
+    real_write = head_type.write
+    first_write = True
+
+    def first_write_conflicts(head, data, *, expected_version):
+        nonlocal first_write
+        if head is real_head and first_write:
+            first_write = False
+            raise ConditionalWriteError("injected conflict")
+        return real_write(head, data, expected_version=expected_version)
+
+    monkeypatch.setattr(head_type, "write", first_write_conflicts)
+    sleeps = 0
+
+    def advance_head(_delay):
+        nonlocal sleeps
+        sleeps += 1
+        if sleeps == 1:
+            competitor.commit(CommitDelta())
+
+    monkeypatch.setattr(timing.time, "sleep", advance_head)
+
+    token = coordinator.commit(CommitDelta())
+
+    assert sleeps == 1
+    assert token.sequence == 2
 
 
 def test_commit_preserves_unknown_optional_manifest_fields(tmp_path):
@@ -941,7 +985,7 @@ def test_failed_multi_table_flush_restores_every_buffer(tmp_path, monkeypatch):
 
 def test_maintenance_compacts_after_shard_threshold(tmp_path):
     root = str(tmp_path / "run")
-    with DataStore.open(root, writer_id="w1", flush_interval=3600, compaction_shards=3) as store:
+    with DataStore.open(root, writer_id="w1", flush_interval=3600, compaction_levels=(2,)) as store:
         table = store.table("samples", primary_key=("doc_id",))
         for index in range(3):
             table.append({"doc_id": str(index)})
@@ -954,26 +998,58 @@ def test_maintenance_compacts_after_shard_threshold(tmp_path):
         assert shards[0].generation == 1
 
 
+def test_maintenance_compaction_levels_are_terminal(tmp_path):
+    root = str(tmp_path / "run")
+    with DataStore.open(root, writer_id="w1", flush_interval=3600, compaction_levels=(2, 1, 1)) as store:
+        table = store.table("samples", primary_key=("doc_id",))
+        next_id = 0
+        for _ in range(4):
+            for _ in range(3):
+                table.append({"doc_id": str(next_id)})
+                next_id += 1
+                store.flush()
+            store.maintain()
+
+        terminal = ReadView(root)
+        terminal_token = terminal.token
+        terminal_shards = terminal.list_shards("samples")
+        assert len(terminal_shards) == 1
+        assert terminal_shards[0].generation == 3
+
+        store.maintain()
+        store.maintain()
+        stable = ReadView(root)
+        assert stable.token == terminal_token
+        assert stable.list_shards("samples") == terminal_shards
+
+
 def test_background_maintenance_recovers_from_transient_s3_failure(tmp_path, monkeypatch):
     root = str(tmp_path / "run")
-    completed = threading.Event()
+    persisted = threading.Event()
     attempts = 0
     slowdown = ClientError({"Error": {"Code": "SlowDown", "Message": "reduce request rate"}}, "PutObject")
     monkeypatch.setattr(store_module, "_MAINTENANCE_BACKOFF_INITIAL", 0.001)
     monkeypatch.setattr(store_module, "_MAINTENANCE_BACKOFF_MAXIMUM", 0.001)
 
     with DataStore.open(root, writer_id="w1", flush_interval=3600) as store:
+        table = store.table("samples", primary_key=("doc_id",))
+        head_type = type(store._commits._head)
+        real_write = head_type.write
 
-        def flaky_maintenance():
+        def flaky_write(head, data, *, expected_version):
             nonlocal attempts
             attempts += 1
             if attempts < 3:
                 raise slowdown
-            completed.set()
+            version = real_write(head, data, expected_version=expected_version)
+            persisted.set()
+            return version
 
-        monkeypatch.setattr(store, "maintain", flaky_maintenance)
+        monkeypatch.setattr(head_type, "write", flaky_write)
+        table.append({"doc_id": "1"})
         store.request_flush()
-        assert completed.wait(timeout=3)
+        assert persisted.wait(timeout=3)
+        assert ReadView(root).point("samples", doc_id="1") is not None
 
 
 def test_compaction_losing_an_input_race_is_a_benign_noop(tmp_path):

--- a/lib/finestore/tests/test_finestore.py
+++ b/lib/finestore/tests/test_finestore.py
@@ -32,7 +32,6 @@ from finestore.migrations import LegacyReadView, migrate
 from finestore.reader import BlobCorruptionError, ReadView
 from finestore.store import OBJECT_PART_BYTES, DataStore, DataTable, PrimaryKeyConflict, TransactionTooLarge
 from rigging.filesystem.storage_path import StoragePath
-from rigging.timing import ExponentialBackoff
 
 
 def _rows(reader: ReadView, table: str, **kwargs) -> list[dict]:
@@ -960,11 +959,8 @@ def test_background_maintenance_recovers_from_transient_s3_failure(tmp_path, mon
     completed = threading.Event()
     attempts = 0
     slowdown = ClientError({"Error": {"Code": "SlowDown", "Message": "reduce request rate"}}, "PutObject")
-    monkeypatch.setattr(
-        store_module,
-        "_MAINTENANCE_BACKOFF",
-        ExponentialBackoff(initial=0.001, maximum=0.001, jitter=0.0),
-    )
+    monkeypatch.setattr(store_module, "_MAINTENANCE_BACKOFF_INITIAL", 0.001)
+    monkeypatch.setattr(store_module, "_MAINTENANCE_BACKOFF_MAXIMUM", 0.001)
 
     with DataStore.open(root, writer_id="w1", flush_interval=3600) as store:
 

--- a/lib/finestore/tests/test_finestore.py
+++ b/lib/finestore/tests/test_finestore.py
@@ -7,11 +7,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import threading
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from botocore.exceptions import ClientError
 from finestore import shard_writer
+from finestore import store as store_module
 from finestore.commit import CommitConflict, CommitCoordinator, CommitDelta
 from finestore.compaction import compact
 from finestore.layout import (
@@ -29,6 +32,7 @@ from finestore.migrations import LegacyReadView, migrate
 from finestore.reader import BlobCorruptionError, ReadView
 from finestore.store import OBJECT_PART_BYTES, DataStore, DataTable, PrimaryKeyConflict, TransactionTooLarge
 from rigging.filesystem.storage_path import StoragePath
+from rigging.timing import ExponentialBackoff
 
 
 def _rows(reader: ReadView, table: str, **kwargs) -> list[dict]:
@@ -195,15 +199,18 @@ def test_later_commit_prevents_compaction_shadowing(tmp_path):
     # append. The user commit sequence ranks before compaction generation.
     root = str(tmp_path / "run")
     with DataStore.open(root, writer_id="w1") as store:
-        store.table("samples", primary_key=("task", "doc_id")).append({"task": "arc", "doc_id": "1", "score": 1.0})
+        table = store.table("samples", primary_key=("task", "doc_id"))
+        table.append({"task": "arc", "doc_id": "1", "score": 1.0})
+        store.flush()
+        table.append({"task": "arc", "doc_id": "2", "score": 1.0})
+        store.flush()
     compact(root, "samples")
     assert ReadView(root).list_shards("samples")[0].generation == 1
 
     with DataStore.open(root, writer_id="w2") as store:
         store.table("samples", primary_key=("task", "doc_id")).append({"task": "arc", "doc_id": "1", "score": 2.0})
     rows = _rows(ReadView(root), "samples")
-    assert len(rows) == 1
-    assert rows[0]["score"] == 2.0
+    assert {row["doc_id"]: row["score"] for row in rows} == {"1": 2.0, "2": 1.0}
 
 
 def test_keys_lists_deduped_primary_keys(tmp_path):
@@ -471,7 +478,10 @@ def test_compaction_replaces_sources_logically_and_retains_objects(tmp_path):
 def test_manifest_binds_flush_and_compaction_shard_bytes(tmp_path):
     root = str(tmp_path / "run")
     with DataStore.open(root, writer_id="w1") as store:
-        store.table("samples", primary_key=("doc_id",)).append({"doc_id": "1"})
+        table = store.table("samples", primary_key=("doc_id",))
+        table.append({"doc_id": "1"})
+        store.flush()
+        table.append({"doc_id": "2"})
         store.flush()
 
     level_zero = ReadView(root).list_shards("samples")[0]
@@ -490,7 +500,9 @@ def test_read_view_remains_valid_after_compaction(tmp_path):
     root = str(tmp_path / "run")
     with DataStore.open(root, writer_id="w1") as store:
         table = store.table("samples", primary_key=("task", "doc_id"))
-        table.extend([{"task": "arc", "doc_id": str(i)} for i in range(4)])
+        table.extend([{"task": "arc", "doc_id": str(i)} for i in range(2)])
+        store.flush()
+        table.extend([{"task": "arc", "doc_id": str(i)} for i in range(2, 4)])
         store.flush()
 
     pinned = ReadView(root)
@@ -501,20 +513,41 @@ def test_read_view_remains_valid_after_compaction(tmp_path):
 
 
 def test_recompaction_merges_all_generations(tmp_path):
-    # Recompaction must stream an already compacted shard and advance its generation without changing
-    # the visible rows.
+    # Recompaction must merge an already compacted shard with a later level-zero shard.
     root = str(tmp_path / "run")
     with DataStore.open(root, writer_id="w1") as store:
         table = store.table("samples", primary_key=("task", "doc_id"))
-        table.extend([{"task": "arc", "doc_id": str(i), "score": float(i)} for i in range(4)])
+        table.extend([{"task": "arc", "doc_id": str(i), "score": float(i)} for i in range(2)])
+        store.flush()
+        table.extend([{"task": "arc", "doc_id": str(i), "score": float(i)} for i in range(2, 4)])
         store.flush()
     compact(root, "samples")
     assert {s.generation for s in ReadView(root).list_shards("samples")} == {1}
 
-    assert compact(root, "samples").written == 4
+    with DataStore.open(root, writer_id="w2") as store:
+        store.table("samples", primary_key=("task", "doc_id")).append({"task": "arc", "doc_id": "4", "score": 4.0})
+        store.flush()
+
+    assert compact(root, "samples").written == 5
     assert {s.generation for s in ReadView(root).list_shards("samples")} == {2}
     rows = {r["doc_id"]: r["score"] for r in _rows(ReadView(root), "samples")}
-    assert rows == {"0": 0.0, "1": 1.0, "2": 2.0, "3": 3.0}
+    assert rows == {"0": 0.0, "1": 1.0, "2": 2.0, "3": 3.0, "4": 4.0}
+
+
+def test_compaction_of_stable_shard_is_a_noop(tmp_path):
+    root = str(tmp_path / "run")
+    with DataStore.open(root, writer_id="w1") as store:
+        store.table("samples", primary_key=("doc_id",)).append({"doc_id": "1"})
+        store.flush()
+
+    stable = ReadView(root)
+    stable_token = stable.token
+    stable_shards = stable.list_shards("samples")
+
+    assert compact(root, "samples").written == 0
+    unchanged = ReadView(root)
+    assert unchanged.token == stable_token
+    assert unchanged.list_shards("samples") == stable_shards
 
 
 def test_compaction_unifies_evolved_schema(tmp_path):
@@ -541,7 +574,9 @@ def test_compaction_streams_multiple_row_groups(tmp_path, monkeypatch):
     root = str(tmp_path / "run")
     with DataStore.open(root, writer_id="w1") as store:
         table = store.table("samples", primary_key=("task", "doc_id"))
-        table.extend([{"task": "arc", "doc_id": f"{i:03d}", "score": float(i)} for i in range(7)])
+        table.extend([{"task": "arc", "doc_id": f"{i:03d}", "score": float(i)} for i in range(4)])
+        store.flush()
+        table.extend([{"task": "arc", "doc_id": f"{i:03d}", "score": float(i)} for i in range(4, 7)])
         store.flush()
     compact(root, "samples")  # g1 spanning ceil(7/2) row groups
 
@@ -918,6 +953,31 @@ def test_maintenance_compacts_after_shard_threshold(tmp_path):
         shards = ReadView(root).list_shards("samples")
         assert len(shards) == 1
         assert shards[0].generation == 1
+
+
+def test_background_maintenance_recovers_from_transient_s3_failure(tmp_path, monkeypatch):
+    root = str(tmp_path / "run")
+    completed = threading.Event()
+    attempts = 0
+    slowdown = ClientError({"Error": {"Code": "SlowDown", "Message": "reduce request rate"}}, "PutObject")
+    monkeypatch.setattr(
+        store_module,
+        "_MAINTENANCE_BACKOFF",
+        ExponentialBackoff(initial=0.001, maximum=0.001, jitter=0.0),
+    )
+
+    with DataStore.open(root, writer_id="w1", flush_interval=3600) as store:
+
+        def flaky_maintenance():
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                raise slowdown
+            completed.set()
+
+        monkeypatch.setattr(store, "maintain", flaky_maintenance)
+        store.request_flush()
+        assert completed.wait(timeout=3)
 
 
 def test_compaction_losing_an_input_race_is_a_benign_noop(tmp_path):

--- a/lib/finestore/tests/test_finestore.py
+++ b/lib/finestore/tests/test_finestore.py
@@ -16,7 +16,7 @@ from botocore.exceptions import ClientError
 from finestore import shard_writer
 from finestore import store as store_module
 from finestore.commit import CommitConflict, CommitCoordinator, CommitDelta
-from finestore.compaction import CompactionResult, compact
+from finestore.compaction import CompactionResult, compact_table
 from finestore.layout import (
     CHUNKED_BLOBS_FEATURE,
     FORMAT_VERSION,
@@ -205,7 +205,7 @@ def test_later_commit_prevents_compaction_shadowing(tmp_path):
         store.flush()
         table.append({"task": "arc", "doc_id": "2", "score": 1.0})
         store.flush()
-    compact(root, "samples")
+    compact_table(root, "samples")
     assert ReadView(root).list_shards("samples")[0].generation == 1
 
     with DataStore.open(root, writer_id="w2") as store:
@@ -466,7 +466,7 @@ def test_compaction_replaces_sources_logically_and_retains_objects(tmp_path):
     before = ReadView(root).list_shards("samples")
     assert len(before) == 3
 
-    assert compact(root, "samples").written == 3
+    assert compact_table(root, "samples").written == 3
 
     after = ReadView(root).list_shards("samples")
     assert len(after) == 1
@@ -490,7 +490,7 @@ def test_manifest_binds_flush_and_compaction_shard_bytes(tmp_path):
     assert level_zero.size_bytes == len(level_zero_bytes)
     assert level_zero.content_sha256 == hashlib.sha256(level_zero_bytes).hexdigest()
 
-    compact(root, "samples")
+    compact_table(root, "samples")
     compacted = ReadView(root).list_shards("samples")[0]
     compacted_bytes = StoragePath(compacted.path).read_bytes()
     assert compacted.size_bytes == len(compacted_bytes)
@@ -507,7 +507,7 @@ def test_read_view_remains_valid_after_compaction(tmp_path):
         store.flush()
 
     pinned = ReadView(root)
-    compact(root, "samples")
+    compact_table(root, "samples")
     assert {s.generation for s in pinned.list_shards("samples")} == {0}
     assert {s.generation for s in ReadView(root).list_shards("samples")} == {1}
     assert {row["doc_id"] for row in _rows(pinned, "samples")} == {"0", "1", "2", "3"}
@@ -522,14 +522,14 @@ def test_recompaction_merges_all_generations(tmp_path):
         store.flush()
         table.extend([{"task": "arc", "doc_id": str(i), "score": float(i)} for i in range(2, 4)])
         store.flush()
-    compact(root, "samples")
+    compact_table(root, "samples")
     assert {s.generation for s in ReadView(root).list_shards("samples")} == {1}
 
     with DataStore.open(root, writer_id="w2") as store:
         store.table("samples", primary_key=("task", "doc_id")).append({"task": "arc", "doc_id": "4", "score": 4.0})
         store.flush()
 
-    assert compact(root, "samples").written == 5
+    assert compact_table(root, "samples").written == 5
     assert {s.generation for s in ReadView(root).list_shards("samples")} == {2}
     rows = {r["doc_id"]: r["score"] for r in _rows(ReadView(root), "samples")}
     assert rows == {"0": 0.0, "1": 1.0, "2": 2.0, "3": 3.0, "4": 4.0}
@@ -543,14 +543,14 @@ def test_compaction_deduplicates_one_level_zero_shard_then_becomes_stable(tmp_pa
         table.append({"doc_id": "1", "score": 2})
         store.flush()
 
-    result = compact(root, "samples")
+    result = compact_table(root, "samples")
     assert result == CompactionResult(written=1, superseded=1)
     stable = ReadView(root)
     stable_token = stable.token
     stable_shards = stable.list_shards("samples")
     assert stable.scan("samples", columns=["doc_id", "score"]).to_pylist() == [{"doc_id": "1", "score": 2}]
 
-    assert compact(root, "samples").written == 0
+    assert compact_table(root, "samples").written == 0
     unchanged = ReadView(root)
     assert unchanged.token == stable_token
     assert unchanged.list_shards("samples") == stable_shards
@@ -567,7 +567,7 @@ def test_compaction_unifies_evolved_schema(tmp_path):
         store.table("samples", primary_key=("task", "doc_id")).append({"task": "arc", "doc_id": "2", "b": 2})
         store.flush()
 
-    compact(root, "samples")
+    compact_table(root, "samples")
     rows = {r["doc_id"]: (r.get("a"), r.get("b")) for r in _rows(ReadView(root), "samples")}
     assert rows == {"1": (1, None), "2": (None, 2)}
 
@@ -584,7 +584,7 @@ def test_compaction_streams_multiple_row_groups(tmp_path, monkeypatch):
         store.flush()
         table.extend([{"task": "arc", "doc_id": f"{i:03d}", "score": float(i)} for i in range(4, 7)])
         store.flush()
-    compact(root, "samples")  # g1 spanning ceil(7/2) row groups
+    compact_table(root, "samples")  # g1 spanning ceil(7/2) row groups
 
     with DataStore.open(root, writer_id="w2") as store:
         store.table("samples", primary_key=("task", "doc_id")).extend(
@@ -592,7 +592,7 @@ def test_compaction_streams_multiple_row_groups(tmp_path, monkeypatch):
         )
         store.flush()
 
-    assert compact(root, "samples").written == 10
+    assert compact_table(root, "samples").written == 10
     assert {s.generation for s in ReadView(root).list_shards("samples")} == {2}
     rows = {r["doc_id"]: r["score"] for r in _rows(ReadView(root), "samples")}
     assert rows == {f"{i:03d}": float(i) for i in range(10)}
@@ -1070,7 +1070,7 @@ def test_compaction_losing_an_input_race_is_a_benign_noop(tmp_path):
         def commit(self, _delta, *, base=None):
             raise CommitConflict("inputs changed")
 
-    assert compact(root, "samples", coordinator=LosingCoordinator()).written == 0
+    assert compact_table(root, "samples", coordinator=LosingCoordinator()).written == 0
     assert len(ReadView(root).list_shards("samples")) == 2
 
 

--- a/lib/levanter/src/levanter/cutlass_kernel_cache.py
+++ b/lib/levanter/src/levanter/cutlass_kernel_cache.py
@@ -106,9 +106,10 @@ def cutlass_kernel_cache() -> PersistentKvCache:
     """The standard cache for compiled CuTeDSL kernel object code, addressed by key.
 
     Memory over region-local temp object storage, assembled by
-    :meth:`PersistentKvCache.for_prefix`. An unreachable store degrades to a compile.
+    :meth:`PersistentKvCache.for_prefix`. Every process reads the shared cache, while
+    only global process 0 publishes misses. An unreachable store degrades to a compile.
     """
-    return PersistentKvCache.for_prefix(_KERNEL_CACHE_PREFIX)
+    return PersistentKvCache.for_prefix(_KERNEL_CACHE_PREFIX, is_writer=lambda: jax.process_index() == 0)
 
 
 def install(cache: PersistentKvCache) -> None:

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
@@ -226,7 +226,9 @@ def _autotune_enabled() -> bool:
     return autotune_utils.env_flag(_AUTOTUNE_ON_MISS_ENV_VAR, default=True)
 
 
-_AUTOTUNE_CACHE = AutotuneBlockSizeCache(PersistentKvCache.for_prefix(_AUTOTUNE_BLOCK_SIZE_PREFIX))
+_AUTOTUNE_CACHE = AutotuneBlockSizeCache(
+    PersistentKvCache.for_prefix(_AUTOTUNE_BLOCK_SIZE_PREFIX, is_writer=lambda: jax.process_index() == 0)
+)
 
 
 def _autotune_jaxpr_hash(

--- a/lib/levanter/tests/test_cutlass_kernel_cache.py
+++ b/lib/levanter/tests/test_cutlass_kernel_cache.py
@@ -16,6 +16,7 @@ import types
 from typing import Any
 
 import pytest
+import finestore.cache as finestore_cache
 from finestore.cache import PersistentKvCache
 from finestore.layout import BlobTables
 from finestore.reader import ReadView
@@ -116,6 +117,17 @@ def test_a_restarted_process_loads_the_stored_object_instead_of_compiling(fake_c
     assert fake_cutlass.compiled == ["tile128-bf16"]
     assert warm.module == cold.module
     assert warm.fingerprint == hashlib.sha256(cold.module).digest()
+
+
+def test_non_primary_process_does_not_publish_compiled_kernel(fake_cutlass, tmp_path, monkeypatch):
+    root = tmp_path / "cutlass-kernels"
+    monkeypatch.setattr(finestore_cache, "marin_temp_bucket", lambda _ttl, _prefix: str(root))
+    monkeypatch.setattr(cutlass_kernel_cache.jax, "process_index", lambda: 1)
+
+    install(cutlass_kernel_cache.cutlass_kernel_cache())
+    fake_cutlass.compile_kernel(build_launcher(None, tile=128), FakeFunctionSpec(shape=(8, 16)))
+
+    assert not root.exists()
 
 
 def test_configuration_and_specification_both_discriminate_stored_kernels(fake_cutlass, tmp_path):

--- a/lib/rigging/src/rigging/filesystem/conditional_object.py
+++ b/lib/rigging/src/rigging/filesystem/conditional_object.py
@@ -25,10 +25,14 @@ from google.api_core.exceptions import NotFound, PreconditionFailed
 from google.cloud import storage
 
 import rigging.filesystem.factory as factory
+from rigging.filesystem.s3_errors import is_transient_s3_error
 from rigging.filesystem.storage_path import StoragePath
+from rigging.timing import ExponentialBackoff, retry_with_backoff
 
 _MAX_READ_ATTEMPTS = 8
+_MAX_S3_WRITE_ATTEMPTS = 4
 _S3_MISSING_CODES = frozenset({"NotFound", "NoSuchKey", "404"})
+_S3_WRITE_BACKOFF = ExponentialBackoff(initial=0.5, maximum=5.0, factor=2.0, jitter=0.25)
 
 
 class ConditionalWriteError(RuntimeError):
@@ -215,17 +219,27 @@ class S3ConditionalObject:
         client = self._client(self.endpoint_url)
         bucket, key = self._parts()
         condition = {"IfNoneMatch": "*"} if expected_version is None else {"IfMatch": expected_version}
-        try:
-            response = client.put_object(Bucket=bucket, Key=key, Body=data, **condition)
-        except ClientError as exc:
-            if exc.response["Error"]["Code"] in (
-                "PreconditionFailed",
-                "ConditionalRequestConflict",
-                "409",
-                "412",
-            ):
-                raise ConditionalWriteError(f"conditional write failed for {self.path}") from exc
-            raise
+
+        def put() -> dict:
+            try:
+                return client.put_object(Bucket=bucket, Key=key, Body=data, **condition)
+            except ClientError as exc:
+                if exc.response["Error"]["Code"] in (
+                    "PreconditionFailed",
+                    "ConditionalRequestConflict",
+                    "409",
+                    "412",
+                ):
+                    raise ConditionalWriteError(f"conditional write failed for {self.path}") from exc
+                raise
+
+        response = retry_with_backoff(
+            put,
+            retryable=is_transient_s3_error,
+            max_attempts=_MAX_S3_WRITE_ATTEMPTS,
+            backoff=_S3_WRITE_BACKOFF,
+            operation=f"conditional S3 write {self.path}",
+        )
         return response["ETag"]
 
 

--- a/lib/rigging/src/rigging/filesystem/conditional_object.py
+++ b/lib/rigging/src/rigging/filesystem/conditional_object.py
@@ -32,7 +32,6 @@ from rigging.timing import ExponentialBackoff, retry_with_backoff
 _MAX_READ_ATTEMPTS = 8
 _MAX_S3_WRITE_ATTEMPTS = 4
 _S3_MISSING_CODES = frozenset({"NotFound", "NoSuchKey", "404"})
-_S3_WRITE_BACKOFF = ExponentialBackoff(initial=0.5, maximum=5.0, factor=2.0, jitter=0.25)
 
 
 class ConditionalWriteError(RuntimeError):
@@ -237,7 +236,7 @@ class S3ConditionalObject:
             put,
             retryable=is_transient_s3_error,
             max_attempts=_MAX_S3_WRITE_ATTEMPTS,
-            backoff=_S3_WRITE_BACKOFF,
+            backoff=ExponentialBackoff(initial=0.5, maximum=5.0, factor=2.0, jitter=0.25),
             operation=f"conditional S3 write {self.path}",
         )
         return response["ETag"]

--- a/lib/rigging/src/rigging/filesystem/conditional_object.py
+++ b/lib/rigging/src/rigging/filesystem/conditional_object.py
@@ -30,7 +30,9 @@ from rigging.filesystem.storage_path import StoragePath
 from rigging.timing import ExponentialBackoff, retry_with_backoff
 
 _MAX_READ_ATTEMPTS = 8
-_MAX_S3_WRITE_ATTEMPTS = 4
+_MAX_S3_WRITE_ATTEMPTS = 8
+_S3_WRITE_BACKOFF_INITIAL = 1.0
+_S3_WRITE_BACKOFF_MAXIMUM = 10 * 60.0
 _S3_MISSING_CODES = frozenset({"NotFound", "NoSuchKey", "404"})
 
 
@@ -218,8 +220,18 @@ class S3ConditionalObject:
         client = self._client(self.endpoint_url)
         bucket, key = self._parts()
         condition = {"IfNoneMatch": "*"} if expected_version is None else {"IfMatch": expected_version}
+        reconcile = False
 
         def put() -> dict:
+            nonlocal reconcile
+            if reconcile:
+                current = self.read()
+                if current is not None and current.data == data:
+                    return {"ETag": current.version}
+                current_version = None if current is None else current.version
+                if current_version != expected_version:
+                    raise ConditionalWriteError(f"conditional write failed for {self.path}")
+                reconcile = False
             try:
                 return client.put_object(Bucket=bucket, Key=key, Body=data, **condition)
             except ClientError as exc:
@@ -230,13 +242,24 @@ class S3ConditionalObject:
                     "412",
                 ):
                     raise ConditionalWriteError(f"conditional write failed for {self.path}") from exc
+                if is_transient_s3_error(exc):
+                    reconcile = True
+                raise
+            except Exception as exc:
+                if is_transient_s3_error(exc):
+                    reconcile = True
                 raise
 
         response = retry_with_backoff(
             put,
             retryable=is_transient_s3_error,
             max_attempts=_MAX_S3_WRITE_ATTEMPTS,
-            backoff=ExponentialBackoff(initial=0.5, maximum=5.0, factor=2.0, jitter=0.25),
+            backoff=ExponentialBackoff(
+                initial=_S3_WRITE_BACKOFF_INITIAL,
+                maximum=_S3_WRITE_BACKOFF_MAXIMUM,
+                factor=2.0,
+                jitter=0.25,
+            ),
             operation=f"conditional S3 write {self.path}",
         )
         return response["ETag"]

--- a/lib/rigging/tests/test_conditional_object.py
+++ b/lib/rigging/tests/test_conditional_object.py
@@ -5,7 +5,6 @@ from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 import pytest
-import rigging.filesystem.conditional_object as conditional_object_module
 from botocore.exceptions import ClientError
 from rigging.filesystem.conditional_object import (
     ConditionalWriteError,
@@ -14,7 +13,6 @@ from rigging.filesystem.conditional_object import (
     UnsupportedConditionalWrite,
     conditional_object,
 )
-from rigging.timing import ExponentialBackoff
 
 
 def test_local_conditional_object_rejects_stale_version(tmp_path):
@@ -107,11 +105,6 @@ def test_s3_conditional_object_retries_slow_down(monkeypatch):
         {"ETag": '"v2"'},
     ]
     monkeypatch.setattr(S3ConditionalObject, "_client", staticmethod(lambda _path: client))
-    monkeypatch.setattr(
-        conditional_object_module,
-        "_S3_WRITE_BACKOFF",
-        ExponentialBackoff(initial=0.001, maximum=0.001, jitter=0.0),
-    )
     monkeypatch.setattr("rigging.timing.time.sleep", lambda _delay: None)
 
     version = S3ConditionalObject("s3://bucket/HEAD").write(b"two", expected_version='"v1"')

--- a/lib/rigging/tests/test_conditional_object.py
+++ b/lib/rigging/tests/test_conditional_object.py
@@ -100,6 +100,7 @@ def test_s3_conditional_object_maps_precondition_failure(monkeypatch):
 
 def test_s3_conditional_object_retries_slow_down(monkeypatch):
     client = MagicMock()
+    client.get_object.return_value = {"Body": BytesIO(b"one"), "ETag": '"v1"'}
     client.put_object.side_effect = [
         ClientError({"Error": {"Code": "SlowDown", "Message": "reduce request rate"}}, "PutObject"),
         {"ETag": '"v2"'},
@@ -111,3 +112,17 @@ def test_s3_conditional_object_retries_slow_down(monkeypatch):
 
     assert version == '"v2"'
     assert client.put_object.call_count == 2
+
+
+def test_s3_conditional_object_reconciles_accepted_put_after_transport_failure(monkeypatch):
+    client = MagicMock()
+    client.put_object.side_effect = TimeoutError("response lost")
+    client.get_object.return_value = {"Body": BytesIO(b"two"), "ETag": '"v2"'}
+    monkeypatch.setattr(S3ConditionalObject, "_client", staticmethod(lambda _path: client))
+    monkeypatch.setattr("rigging.timing.time.sleep", lambda _delay: None)
+
+    version = S3ConditionalObject("s3://bucket/HEAD").write(b"two", expected_version='"v1"')
+
+    assert version == '"v2"'
+    client.put_object.assert_called_once()
+    client.get_object.assert_called_once_with(Bucket="bucket", Key="HEAD")

--- a/lib/rigging/tests/test_conditional_object.py
+++ b/lib/rigging/tests/test_conditional_object.py
@@ -5,6 +5,7 @@ from io import BytesIO
 from unittest.mock import MagicMock, patch
 
 import pytest
+import rigging.filesystem.conditional_object as conditional_object_module
 from botocore.exceptions import ClientError
 from rigging.filesystem.conditional_object import (
     ConditionalWriteError,
@@ -13,6 +14,7 @@ from rigging.filesystem.conditional_object import (
     UnsupportedConditionalWrite,
     conditional_object,
 )
+from rigging.timing import ExponentialBackoff
 
 
 def test_local_conditional_object_rejects_stale_version(tmp_path):
@@ -96,3 +98,23 @@ def test_s3_conditional_object_maps_precondition_failure(monkeypatch):
     monkeypatch.setattr(S3ConditionalObject, "_client", staticmethod(lambda _path: client))
     with pytest.raises(ConditionalWriteError):
         S3ConditionalObject("s3://bucket/HEAD").write(b"two", expected_version='"v1"')
+
+
+def test_s3_conditional_object_retries_slow_down(monkeypatch):
+    client = MagicMock()
+    client.put_object.side_effect = [
+        ClientError({"Error": {"Code": "SlowDown", "Message": "reduce request rate"}}, "PutObject"),
+        {"ETag": '"v2"'},
+    ]
+    monkeypatch.setattr(S3ConditionalObject, "_client", staticmethod(lambda _path: client))
+    monkeypatch.setattr(
+        conditional_object_module,
+        "_S3_WRITE_BACKOFF",
+        ExponentialBackoff(initial=0.001, maximum=0.001, jitter=0.0),
+    )
+    monkeypatch.setattr("rigging.timing.time.sleep", lambda _delay: None)
+
+    version = S3ConditionalObject("s3://bucket/HEAD").write(b"two", expected_version='"v1"')
+
+    assert version == '"v2"'
+    assert client.put_object.call_count == 2


### PR DESCRIPTION
Let every Levanter rank read the shared Cutlass and Pallas caches while only global JAX process 0 publishes misses. The 704-rank [hero run](https://iris.oa.dev/#/job/%2Fpower%2Fhero-12d8b6f0-dee637-coord-trim16%2Fgrug-train-hero-12d8b6f0-dee637) logged 704 cache installations, 2,048 cold Cutlass misses, and 1,775 S3 SlowDown occurrences against one FineStore HEAD.

Use terminal 16/4/4 leveled compaction, and report input and output sizes for each operation. Manifest rebases and conditional S3 writes back off exponentially to ten minutes; background maintenance keeps retrying transient failures. Ambiguous conditional writes reconcile the stored value before retrying.

Incident record: https://echo.oa.dev/wiki/203