### PR TITLE
[training] Route hero resume checkpoints to region-local storage

### DIFF
--- a/config/coreweave.yaml
+++ b/config/coreweave.yaml
@@ -25,5 +25,4 @@ data:
       endpoint_env: R2_S3_ENDPOINT
       key_id_env: R2_KEY_ID
       key_secret_env: R2_KEY_SECRET
-  temp: { path: tmp, ttl_days: [1, 2, 3, 4, 5, 6, 7, 14, 30] }
   root: s3://marin-na/marin

--- a/config/coreweave.yaml
+++ b/config/coreweave.yaml
@@ -8,6 +8,7 @@ data:
   region_buckets:
     na:          { bucket: marin-na,          store: r2 }
     us-east-02a: { bucket: marin-us-east-02a, store: coreweave, signing_region: US-EAST-02A }
+    us-east-08a-hero-checkpoints: { bucket: hero-checkpoints, store: coreweave, signing_region: US-EAST-08A }
     us-west-04a: { bucket: marin-us-west-04a, store: coreweave, signing_region: US-WEST-04A }
   # How to reach each S3-compatible backend. `endpoint` is the account-level endpoint
   # reachable from outside the cluster; `*_env` name the environment variables that
@@ -24,5 +25,5 @@ data:
       endpoint_env: R2_S3_ENDPOINT
       key_id_env: R2_KEY_ID
       key_secret_env: R2_KEY_SECRET
-  temp: { path: tmp, ttl_days: [1, 2, 3, 7] }
+  temp: { path: tmp, ttl_days: [1, 2, 3, 4, 5, 6, 7, 14, 30] }
   root: s3://marin-na/marin

--- a/config/coreweave.yaml
+++ b/config/coreweave.yaml
@@ -8,7 +8,7 @@ data:
   region_buckets:
     na:          { bucket: marin-na,          store: r2 }
     us-east-02a: { bucket: marin-us-east-02a, store: coreweave, signing_region: US-EAST-02A }
-    us-east-08a-hero-checkpoints: { bucket: hero-checkpoints, store: coreweave, signing_region: US-EAST-08A }
+    us-east-08a: { bucket: hero-checkpoints, store: coreweave, signing_region: US-EAST-08A }
     us-west-04a: { bucket: marin-us-west-04a, store: coreweave, signing_region: US-WEST-04A }
   # How to reach each S3-compatible backend. `endpoint` is the account-level endpoint
   # reachable from outside the cluster; `*_env` name the environment variables that

--- a/docs/tutorials/cloud-gpu.md
+++ b/docs/tutorials/cloud-gpu.md
@@ -75,6 +75,9 @@ from rigging.filesystem.cluster_config import marin_temp_bucket
 scratch = marin_temp_bucket(ttl_days=1, prefix="my-experiment")
 ```
 
+Clusters may set `MARIN_TEMP_PREFIX`; when present, `marin_temp_bucket` routes
+every temporary write to that lifecycle-managed cluster-local bucket.
+
 Do not read or copy data from GCS while running on CoreWeave without explicit
 user approval. The transfer can incur egress charges.
 

--- a/docs/tutorials/storage-bucket.md
+++ b/docs/tutorials/storage-bucket.md
@@ -70,17 +70,17 @@ gcloud storage buckets describe "$BUCKET" \
 
 Clearing the policy ensures that once a training job deletes temporary files they disappear immediately, preventing runaway storage bills. You can still enable backups via lifecycle rules or replication if you need recovery.
 
-## Step 4: TTL Scratch Prefix on Main Buckets (`marin-{region}/tmp/ttl=Nd/`)
+## Step 4: TTL Scratch Prefixes (`tmp/ttl=Nd/`)
 
-For intermediate checkpoints and other short-lived data, Marin reserves a `tmp/` prefix on each `marin-{region}` bucket with lifecycle rules that delete objects based on a `tmp/ttl=Nd/` path prefix — for example, objects under `gs://marin-us-central2/tmp/ttl=3d/my-job/` are deleted three days after they are written.
+For intermediate checkpoints and other short-lived data, Marin reserves a `tmp/` prefix on each managed data bucket with lifecycle rules that delete objects based on a `tmp/ttl=Nd/` path prefix — for example, objects under `gs://marin-us-central2/tmp/ttl=3d/my-job/` are deleted three days after they are written.
 
-Supported TTLs: 1, 2, 3, 4, 5, 6, 7, 14, and 30 days. The canonical list lives in `config/marin.yaml` (`data.temp.ttl_days`); call `marin_temp_bucket(ttl_days=N, prefix=...)` to build a path.
+Supported TTLs: 1, 2, 3, 4, 5, 6, 7, 14, and 30 days. The canonical list lives in `config/marin.yaml` (`data.temp.ttl_days`). Use `marin_temp_bucket` for general scratch co-located with an input or output prefix. `marin_cluster_temp_bucket` is an explicit opt-in for specialized shared scratch such as the hero's rolling checkpoints; clusters advertise that bucket through `MARIN_CLUSTER_TEMP_PREFIX`.
 
-The shared `marin-*` buckets on GCS, CoreWeave, and R2 are declared by `DataBuckets` in
+The shared data buckets on GCS, CoreWeave, and R2 are declared by `DataBuckets` in
 [`infra/buckets`](https://github.com/marin-community/marin/blob/main/infra/buckets/README.md).
 Their names and regions come from `config/marin.yaml` and `config/coreweave.yaml`; Pulumi owns
 the complete lifecycle policy on every backend and GCS soft-delete disablement.
-To add a region, add its GCS bucket entry to the reviewed `data.region_buckets` map and preview
+To add a region or specialized bucket, add its entry to the reviewed `data.region_buckets` map and preview
 the manually operated `marin-buckets` stack:
 
 ```bash

--- a/docs/tutorials/storage-bucket.md
+++ b/docs/tutorials/storage-bucket.md
@@ -74,7 +74,7 @@ Clearing the policy ensures that once a training job deletes temporary files the
 
 For intermediate checkpoints and other short-lived data, Marin reserves a `tmp/` prefix on each managed data bucket with lifecycle rules that delete objects based on a `tmp/ttl=Nd/` path prefix — for example, objects under `gs://marin-us-central2/tmp/ttl=3d/my-job/` are deleted three days after they are written.
 
-Supported TTLs: 1, 2, 3, 4, 5, 6, 7, 14, and 30 days. The canonical list lives in `config/marin.yaml` (`data.temp.ttl_days`). Use `marin_temp_bucket` for general scratch co-located with an input or output prefix. `marin_cluster_temp_bucket` is an explicit opt-in for specialized shared scratch such as the hero's rolling checkpoints; clusters advertise that bucket through `MARIN_CLUSTER_TEMP_PREFIX`.
+Supported TTLs: 1, 2, 3, 4, 5, 6, 7, 14, and 30 days. The canonical list lives in `config/marin.yaml` (`data.temp.ttl_days`). Use `marin_temp_bucket` for lifecycle-managed scratch co-located with an input or output prefix. A cluster can set `MARIN_TEMP_PREFIX` to override that routing for every temporary write.
 
 The shared data buckets on GCS, CoreWeave, and R2 are declared by `DataBuckets` in
 [`infra/buckets`](https://github.com/marin-community/marin/blob/main/infra/buckets/README.md).

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -217,6 +217,9 @@ def build_ladder_run(
     wandb_project = os.environ.get("WANDB_PROJECT") or DEFAULT_WANDB_PROJECT
 
     def build_config(ctx: StepContext) -> GrugRunConfig:
+        permanent_checkpoint_path = prefix_join(ctx.output_path, "checkpoints")
+        temporary_checkpoint_path = temporary_checkpoint_base_path(ctx.output_path)
+        data_local_checkpoint_path = data_local_temporary_checkpoint_base_path(ctx.output_path)
         trainer = TrainerConfig(
             id=run_id,
             seed=0,
@@ -247,16 +250,18 @@ def build_ladder_run(
             require_accelerator=True,
             allow_nondivisible_batch_size=False,
             # Existing 02A temporaries remain valid resume candidates for this lineage.
-            load_checkpoint_fallback_paths=[
-                data_local_temporary_checkpoint_base_path(ctx.output_path),
+            load_checkpoint_path=[
+                permanent_checkpoint_path,
+                temporary_checkpoint_path,
+                data_local_checkpoint_path,
             ],
             # load_checkpoint stays None: the trainer resumes from the newest checkpoint that
             # exists, so a retry after a hardware or memory fault continues the run.
             checkpointer=CheckpointerConfig(
-                base_path=prefix_join(ctx.output_path, "checkpoints"),
+                base_path=permanent_checkpoint_path,
                 # Rolling resume checkpoints go to region-local temp storage with a lifecycle TTL.
                 # The durable output root keeps only the permanent milestones and the final one.
-                temporary_base_path=temporary_checkpoint_base_path(ctx.output_path),
+                temporary_base_path=temporary_checkpoint_path,
                 save_interval=RESUME_SAVE_INTERVAL,
                 keep=keep_permanent,
                 append_run_id_to_base_path=False,

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -246,6 +246,7 @@ def build_ladder_run(
             use_explicit_mesh_axes=True,
             require_accelerator=True,
             allow_nondivisible_batch_size=False,
+            # Existing 02A temporaries remain valid resume candidates for this lineage.
             load_checkpoint_fallback_paths=[
                 data_local_temporary_checkpoint_base_path(ctx.output_path),
             ],

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -37,7 +37,10 @@ from marin.execution.build_context import resolve_version
 from marin.execution.lazy import ArtifactStep, StepContext
 from marin.experiment.cli import build_options
 from marin.experiment.namespacing import user_namespaced_name
-from marin.training.training import temporary_checkpoint_base_path
+from marin.training.training import (
+    data_local_temporary_checkpoint_base_path,
+    temporary_checkpoint_base_path,
+)
 from rigging.filesystem.storage_path import prefix_join
 
 from experiments.datasets.uncheatable import uncheatable_datasets
@@ -243,6 +246,9 @@ def build_ladder_run(
             use_explicit_mesh_axes=True,
             require_accelerator=True,
             allow_nondivisible_batch_size=False,
+            load_checkpoint_fallback_paths=[
+                data_local_temporary_checkpoint_base_path(ctx.output_path),
+            ],
             # load_checkpoint stays None: the trainer resumes from the newest checkpoint that
             # exists, so a retry after a hardware or memory fault continues the run.
             checkpointer=CheckpointerConfig(

--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -167,11 +167,10 @@ defaults:
     scale_down_delay:
       milliseconds: 300000
   task_env:
-    # Durable outputs and general scratch remain in 02A. The explicit cluster-temp
-    # prefix is reserved for specialized region-local state such as the hero's
-    # rolling checkpoints; rigging adds lifecycle-managed tmp/ttl=Nd prefixes.
+    # Durable outputs remain in 02A. All lifecycle-managed temporary writes use
+    # the region-local 08A bucket; rigging adds the tmp/ttl=Nd prefixes.
     MARIN_PREFIX: s3://marin-us-east-02a/marin
-    MARIN_CLUSTER_TEMP_PREFIX: s3://hero-checkpoints
+    MARIN_TEMP_PREFIX: s3://hero-checkpoints
     # Task pods carry one CoreWeave endpoint/credential set valid for both buckets.
     # GB200 hostNetwork pods also see IB and SR-IOV link-local interfaces. Exclude
     # IB/IPoIB (ibs*, ibp*) and virtual interfaces so NCCL's bootstrap socket falls

--- a/lib/iris/config/cw-us-east-08a.yaml
+++ b/lib/iris/config/cw-us-east-08a.yaml
@@ -167,11 +167,12 @@ defaults:
     scale_down_delay:
       milliseconds: 300000
   task_env:
-    # The shared CoreWeave bucket (everything lives in marin-us-east-02a; LOTA
-    # caches reads locally). Task pods carry ONE endpoint/credential set, so R2
-    # data under s3://marin-na/ is not reachable from jobs unless they override
-    # AWS_ENDPOINT_URL and credentials themselves.
+    # Durable outputs and general scratch remain in 02A. The explicit cluster-temp
+    # prefix is reserved for specialized region-local state such as the hero's
+    # rolling checkpoints; rigging adds lifecycle-managed tmp/ttl=Nd prefixes.
     MARIN_PREFIX: s3://marin-us-east-02a/marin
+    MARIN_CLUSTER_TEMP_PREFIX: s3://hero-checkpoints
+    # Task pods carry one CoreWeave endpoint/credential set valid for both buckets.
     # GB200 hostNetwork pods also see IB and SR-IOV link-local interfaces. Exclude
     # IB/IPoIB (ibs*, ibp*) and virtual interfaces so NCCL's bootstrap socket falls
     # back to the host ethernet PF that carries the node IP. The exact PF name

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -909,8 +909,8 @@ class TrainerConfig:
     load_checkpoint_fallback_paths: list[str] = field(default_factory=list)
     """Additional checkpoint roots searched after the configured permanent and temporary roots.
 
-    Ignored when ``load_checkpoint_path`` pins one explicit checkpoint. Intended for storage
-    migrations where the previous temporary root must remain readable during a transition.
+    Ignored when ``load_checkpoint_path`` pins one explicit checkpoint. This keeps checkpoints
+    discoverable when one run lineage spans more than one storage root.
     """
 
     def checkpoint_search_paths(self, run_id: str) -> list[str]:

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -906,6 +906,12 @@ class TrainerConfig:
     """if None (default), we'll load a checkpoint if it exists. If true, we must load a checkpoint"""
     load_checkpoint_path: Optional[str] = None
     """can be a parent (to find latest) or a specific checkpoint. if None, will set to checkpointer.base_path."""
+    load_checkpoint_fallback_paths: list[str] = field(default_factory=list)
+    """Additional checkpoint roots searched after the configured permanent and temporary roots.
+
+    Ignored when ``load_checkpoint_path`` pins one explicit checkpoint. Intended for storage
+    migrations where the previous temporary root must remain readable during a transition.
+    """
 
     def checkpoint_search_paths(self, run_id: str) -> list[str]:
         if self.load_checkpoint_path is not None:
@@ -915,6 +921,7 @@ class TrainerConfig:
         temp_path = self.checkpointer.expanded_temporary_path(run_id)
         if temp_path is not None:
             paths.append(temp_path)
+        paths.extend(path for path in self.load_checkpoint_fallback_paths if path not in paths)
         return paths
 
     initialize_from: Optional[str] = None  # Levanter trainer checkpoint to initialize from

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -904,24 +904,22 @@ class TrainerConfig:
     checkpointer: CheckpointerConfig = field(default_factory=CheckpointerConfig)
     load_checkpoint: Optional[bool] = None
     """if None (default), we'll load a checkpoint if it exists. If true, we must load a checkpoint"""
-    load_checkpoint_path: Optional[str] = None
-    """can be a parent (to find latest) or a specific checkpoint. if None, will set to checkpointer.base_path."""
-    load_checkpoint_fallback_paths: list[str] = field(default_factory=list)
-    """Additional checkpoint roots searched after the configured permanent and temporary roots.
+    load_checkpoint_path: Optional[str | list[str]] = None
+    """One checkpoint root/path, or ordered roots searched for the newest checkpoint.
 
-    Ignored when ``load_checkpoint_path`` pins one explicit checkpoint. This keeps checkpoints
-    discoverable when one run lineage spans more than one storage root.
+    If None, search the checkpointer's permanent and temporary roots.
     """
 
     def checkpoint_search_paths(self, run_id: str) -> list[str]:
-        if self.load_checkpoint_path is not None:
+        if isinstance(self.load_checkpoint_path, str):
             return [self.load_checkpoint_path]
+        if self.load_checkpoint_path is not None:
+            return list(self.load_checkpoint_path)
 
         paths = [self.checkpointer.expanded_path(run_id)]
         temp_path = self.checkpointer.expanded_temporary_path(run_id)
         if temp_path is not None:
             paths.append(temp_path)
-        paths.extend(path for path in self.load_checkpoint_fallback_paths if path not in paths)
         return paths
 
     initialize_from: Optional[str] = None  # Levanter trainer checkpoint to initialize from

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -435,8 +435,13 @@ def test_trainer_config_checkpoint_search_paths():
             temporary_base_path="/tmp/test-temp",
             append_run_id_to_base_path=True,
         ),
+        load_checkpoint_fallback_paths=["/tmp/test-old-temp", "/tmp/test-temp/run1"],
     )
-    assert config.checkpoint_search_paths("run1") == ["/tmp/test-perm/run1", "/tmp/test-temp/run1"]
+    assert config.checkpoint_search_paths("run1") == [
+        "/tmp/test-perm/run1",
+        "/tmp/test-temp/run1",
+        "/tmp/test-old-temp",
+    ]
 
     pinned_config = dataclasses.replace(config, load_checkpoint_path="/tmp/test-perm/run1/step-100")
     assert pinned_config.checkpoint_search_paths("run1") == ["/tmp/test-perm/run1/step-100"]

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -435,9 +435,14 @@ def test_trainer_config_checkpoint_search_paths():
             temporary_base_path="/tmp/test-temp",
             append_run_id_to_base_path=True,
         ),
-        load_checkpoint_fallback_paths=["/tmp/test-old-temp", "/tmp/test-temp/run1"],
     )
-    assert config.checkpoint_search_paths("run1") == [
+    assert config.checkpoint_search_paths("run1") == ["/tmp/test-perm/run1", "/tmp/test-temp/run1"]
+
+    multi_config = dataclasses.replace(
+        config,
+        load_checkpoint_path=["/tmp/test-perm/run1", "/tmp/test-temp/run1", "/tmp/test-old-temp"],
+    )
+    assert multi_config.checkpoint_search_paths("run1") == [
         "/tmp/test-perm/run1",
         "/tmp/test-temp/run1",
         "/tmp/test-old-temp",

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -22,11 +22,7 @@ from levanter.main.train_lm import TrainLmConfig
 from levanter.schedule import BatchSchedule
 from mergedeep import mergedeep
 from pydantic import BaseModel
-from rigging.filesystem.cluster_config import (
-    check_gcs_paths_same_region,
-    marin_cluster_temp_bucket,
-    marin_temp_bucket,
-)
+from rigging.filesystem.cluster_config import check_gcs_paths_same_region, marin_temp_bucket
 from rigging.filesystem.factory import url_to_fs
 from rigging.filesystem.storage_path import StoragePath, prefix_join
 
@@ -167,21 +163,22 @@ def temporary_storage_base_path(output_path: str, *, ttl_days: int, category: st
 
 def temporary_checkpoint_base_path(output_path: str) -> str:
     """Return the region-local temporary checkpoint base for an executor output path."""
-    output_component = _output_path_temp_component(output_path)
-    temporary_root = marin_cluster_temp_bucket(
+    temporary_root = temporary_storage_base_path(
+        output_path,
         ttl_days=TEMPORARY_CHECKPOINT_TTL_DAYS,
-        prefix=prefix_join(TEMPORARY_CHECKPOINTS_PATH, output_component),
-        fallback_source_prefix=output_path,
+        category=TEMPORARY_CHECKPOINTS_PATH,
     )
     return prefix_join(temporary_root, DEFAULT_CHECKPOINTS_PATH)
 
 
 def data_local_temporary_checkpoint_base_path(output_path: str) -> str:
-    """Return the checkpoint temp path selected from the durable output location."""
-    temporary_root = temporary_storage_base_path(
-        output_path,
+    """Return the legacy data-local checkpoint path, bypassing the cluster temp override."""
+    output_component = _output_path_temp_component(output_path)
+    temporary_root = marin_temp_bucket(
         ttl_days=TEMPORARY_CHECKPOINT_TTL_DAYS,
-        category=TEMPORARY_CHECKPOINTS_PATH,
+        prefix=os.path.join(TEMPORARY_CHECKPOINTS_PATH, output_component),
+        source_prefix=output_path,
+        use_env_override=False,
     )
     return prefix_join(temporary_root, DEFAULT_CHECKPOINTS_PATH)
 

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -22,7 +22,11 @@ from levanter.main.train_lm import TrainLmConfig
 from levanter.schedule import BatchSchedule
 from mergedeep import mergedeep
 from pydantic import BaseModel
-from rigging.filesystem.cluster_config import check_gcs_paths_same_region, marin_temp_bucket
+from rigging.filesystem.cluster_config import (
+    check_gcs_paths_same_region,
+    marin_cluster_temp_bucket,
+    marin_temp_bucket,
+)
 from rigging.filesystem.factory import url_to_fs
 from rigging.filesystem.storage_path import StoragePath, prefix_join
 
@@ -161,8 +165,28 @@ def temporary_storage_base_path(output_path: str, *, ttl_days: int, category: st
     )
 
 
+def _cluster_temporary_storage_base_path(output_path: str, *, ttl_days: int, category: str) -> str:
+    """Return execution-cluster-local temporary storage keyed by an executor output path."""
+    output_component = _output_path_temp_component(output_path)
+    return marin_cluster_temp_bucket(
+        ttl_days=ttl_days,
+        prefix=os.path.join(category, output_component),
+        fallback_source_prefix=output_path,
+    )
+
+
 def temporary_checkpoint_base_path(output_path: str) -> str:
     """Return the region-local temporary checkpoint base for an executor output path."""
+    temporary_root = _cluster_temporary_storage_base_path(
+        output_path,
+        ttl_days=TEMPORARY_CHECKPOINT_TTL_DAYS,
+        category=TEMPORARY_CHECKPOINTS_PATH,
+    )
+    return prefix_join(temporary_root, DEFAULT_CHECKPOINTS_PATH)
+
+
+def data_local_temporary_checkpoint_base_path(output_path: str) -> str:
+    """Return the checkpoint temp path selected from the durable output location."""
     temporary_root = temporary_storage_base_path(
         output_path,
         ttl_days=TEMPORARY_CHECKPOINT_TTL_DAYS,
@@ -173,7 +197,7 @@ def temporary_checkpoint_base_path(output_path: str) -> str:
 
 def resolve_checkpointer_output_path(checkpointer: CheckpointerConfig, output_path: str) -> CheckpointerConfig:
     """Point ``checkpointer`` at ``output_path``: rolling checkpoints under ``<output_path>/checkpoints``
-    and time-policy (temporary) checkpoints on region-local storage keyed off ``output_path``.
+    and time-policy (temporary) checkpoints on region-local storage keyed by ``output_path``.
 
     ``append_run_id_to_base_path`` is ``False`` because ``output_path`` already encodes the run's
     identity, so a run id suffix would double it up. Every other checkpointer field is preserved.

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -165,22 +165,13 @@ def temporary_storage_base_path(output_path: str, *, ttl_days: int, category: st
     )
 
 
-def _cluster_temporary_storage_base_path(output_path: str, *, ttl_days: int, category: str) -> str:
-    """Return execution-cluster-local temporary storage keyed by an executor output path."""
-    output_component = _output_path_temp_component(output_path)
-    return marin_cluster_temp_bucket(
-        ttl_days=ttl_days,
-        prefix=os.path.join(category, output_component),
-        fallback_source_prefix=output_path,
-    )
-
-
 def temporary_checkpoint_base_path(output_path: str) -> str:
     """Return the region-local temporary checkpoint base for an executor output path."""
-    temporary_root = _cluster_temporary_storage_base_path(
-        output_path,
+    output_component = _output_path_temp_component(output_path)
+    temporary_root = marin_cluster_temp_bucket(
         ttl_days=TEMPORARY_CHECKPOINT_TTL_DAYS,
-        category=TEMPORARY_CHECKPOINTS_PATH,
+        prefix=prefix_join(TEMPORARY_CHECKPOINTS_PATH, output_component),
+        fallback_source_prefix=output_path,
     )
     return prefix_join(temporary_root, DEFAULT_CHECKPOINTS_PATH)
 

--- a/lib/rigging/src/rigging/filesystem/cluster_config.py
+++ b/lib/rigging/src/rigging/filesystem/cluster_config.py
@@ -10,9 +10,9 @@ region-to-bucket mirror set, the URL scheme, and the temp TTL policy.
 :func:`use_data_config`, else the cluster named by ``MARIN_CLUSTER`` (default
 ``marin``), loaded from ``config/<cluster>.yaml``. Every "where does data live"
 answer flows through it: :func:`marin_prefix` is ``data_config().resolved_root()``,
-while :func:`marin_temp_bucket` and :func:`marin_cluster_temp_bucket` resolve
-data-local and execution-cluster-local scratch respectively. Lifecycle rules on
-every configured data bucket are managed by ``infra/buckets``.
+while :func:`marin_temp_bucket` resolves region-local scratch, honoring a
+cluster-wide ``MARIN_TEMP_PREFIX`` override when configured. Lifecycle rules
+on every configured data bucket are managed by ``infra/buckets``.
 """
 
 import contextlib
@@ -79,7 +79,7 @@ MARIN_CLUSTER_CONFIG_DIRS: tuple[str, ...] = tuple(
 
 _MARIN_PREFIX_ENV = "MARIN_PREFIX"
 _MARIN_CLUSTER_ENV = "MARIN_CLUSTER"
-_MARIN_CLUSTER_TEMP_PREFIX_ENV = "MARIN_CLUSTER_TEMP_PREFIX"
+_MARIN_TEMP_PREFIX_ENV = "MARIN_TEMP_PREFIX"
 _GCP_METADATA_ZONE_URL = "http://metadata.google.internal/computeMetadata/v1/instance/zone"
 _DEFAULT_LOCAL_PREFIX = "/tmp/marin"
 
@@ -500,7 +500,13 @@ def _resolve_ttl_days(ttl_days: int, allowed: tuple[int, ...]) -> int:
     return capped
 
 
-def marin_temp_bucket(ttl_days: int, prefix: str = "", *, source_prefix: str | None = None) -> str:
+def marin_temp_bucket(
+    ttl_days: int,
+    prefix: str = "",
+    *,
+    source_prefix: str | None = None,
+    use_env_override: bool = True,
+) -> str:
     """Return a path on region-local temp storage. Never returns ``None``.
 
     For a GCS marin prefix with a known region, or an explicitly provided
@@ -521,6 +527,9 @@ def marin_temp_bucket(ttl_days: int, prefix: str = "", *, source_prefix: str | N
 
     Pulumi-managed lifecycle rules on every data bucket auto-delete objects
     under ``tmp/ttl=Nd/`` after *N* days.
+    When ``MARIN_TEMP_PREFIX`` is set, it overrides ambient and explicit source
+    prefixes so every temporary write in that cluster uses the configured
+    bucket.
 
     Args:
         ttl_days: Lifecycle TTL in days.  Values not in the active config's
@@ -531,18 +540,23 @@ def marin_temp_bucket(ttl_days: int, prefix: str = "", *, source_prefix: str | N
         source_prefix: Optional path used to choose the temp bucket region.
             Useful when configuring a remote job from a launcher that may be in
             a different region than the job output path.
+        use_env_override: Honor ``MARIN_TEMP_PREFIX`` when set. Disable only
+            when resolving a legacy data-local path for reads, never for writes.
     """
     cfg = data_config()
     ttl_days = _resolve_ttl_days(ttl_days, cfg.ttl_days)
 
-    mp = marin_prefix()
+    override_prefix = os.environ.get(_MARIN_TEMP_PREFIX_ENV) if use_env_override else None
+    mp = override_prefix or marin_prefix()
 
-    # An explicit source_prefix fully determines the backend and region, taking
-    # precedence over the ambient marin prefix and VM metadata so that an R2
-    # source_prefix yields an R2 temp path even on a GCP launcher. Only when
-    # source_prefix is absent do we derive the location from the marin prefix
-    # (and VM metadata for the GCS region).
-    if source_prefix is not None:
+    # A cluster temp override takes precedence over explicit source routing so
+    # all disposable writes from the cluster share one lifecycle-managed bucket.
+    # Otherwise source_prefix fully determines the backend and region, taking
+    # precedence over the ambient marin prefix and VM metadata.
+    if override_prefix is not None:
+        region = region_from_prefix(override_prefix)
+        s3_bucket = _s3_bucket_from_prefix(override_prefix)
+    elif source_prefix is not None:
         region = region_from_prefix(source_prefix)
         s3_bucket = _s3_bucket_from_prefix(source_prefix)
     else:
@@ -568,23 +582,6 @@ def marin_temp_bucket(ttl_days: int, prefix: str = "", *, source_prefix: str | N
         mp = f"file://{mp}"
     path = f"{mp}/{cfg.temp_path}"
     return _append_path_prefix(path, prefix)
-
-
-def marin_cluster_temp_bucket(
-    ttl_days: int,
-    prefix: str = "",
-    *,
-    fallback_source_prefix: str | None = None,
-) -> str:
-    """Return shared temporary storage local to the execution cluster.
-
-    ``MARIN_CLUSTER_TEMP_PREFIX`` selects the managed scratch bucket independently
-    of durable data location. When it is unset, ``fallback_source_prefix`` selects
-    the data-local temp bucket; an absent fallback uses ambient Marin storage.
-    """
-    cluster_prefix = os.environ.get(_MARIN_CLUSTER_TEMP_PREFIX_ENV)
-    source_prefix = cluster_prefix or fallback_source_prefix
-    return marin_temp_bucket(ttl_days, prefix, source_prefix=source_prefix)
 
 
 # ---------------------------------------------------------------------------

--- a/lib/rigging/src/rigging/filesystem/cluster_config.py
+++ b/lib/rigging/src/rigging/filesystem/cluster_config.py
@@ -10,8 +10,9 @@ region-to-bucket mirror set, the URL scheme, and the temp TTL policy.
 :func:`use_data_config`, else the cluster named by ``MARIN_CLUSTER`` (default
 ``marin``), loaded from ``config/<cluster>.yaml``. Every "where does data live"
 answer flows through it: :func:`marin_prefix` is ``data_config().resolved_root()``,
-and :func:`marin_temp_bucket` and the region helpers all read its fields.
-Lifecycle rules on every configured data bucket are managed by ``infra/buckets``.
+while :func:`marin_temp_bucket` and :func:`marin_cluster_temp_bucket` resolve
+data-local and execution-cluster-local scratch respectively. Lifecycle rules on
+every configured data bucket are managed by ``infra/buckets``.
 """
 
 import contextlib
@@ -78,6 +79,7 @@ MARIN_CLUSTER_CONFIG_DIRS: tuple[str, ...] = tuple(
 
 _MARIN_PREFIX_ENV = "MARIN_PREFIX"
 _MARIN_CLUSTER_ENV = "MARIN_CLUSTER"
+_MARIN_CLUSTER_TEMP_PREFIX_ENV = "MARIN_CLUSTER_TEMP_PREFIX"
 _GCP_METADATA_ZONE_URL = "http://metadata.google.internal/computeMetadata/v1/instance/zone"
 _DEFAULT_LOCAL_PREFIX = "/tmp/marin"
 
@@ -566,6 +568,30 @@ def marin_temp_bucket(ttl_days: int, prefix: str = "", *, source_prefix: str | N
         mp = f"file://{mp}"
     path = f"{mp}/{cfg.temp_path}"
     return _append_path_prefix(path, prefix)
+
+
+def marin_cluster_temp_bucket(
+    ttl_days: int,
+    prefix: str = "",
+    *,
+    fallback_source_prefix: str | None = None,
+) -> str:
+    """Return shared temporary storage local to the execution cluster.
+
+    A cluster advertises its shared scratch root through
+    ``MARIN_CLUSTER_TEMP_PREFIX``. This is intentionally distinct from
+    :func:`marin_temp_bucket`'s data-local routing: durable output may live in a
+    different region from the compute running the job. The advertised bucket
+    must be declared in ``data.region_buckets`` so its lifecycle rules,
+    endpoint, credentials, and signing region remain configuration-owned.
+
+    When the cluster has no explicit scratch root, ``fallback_source_prefix`` is
+    forwarded to :func:`marin_temp_bucket`. This preserves data-local routing
+    for callers that predate cluster-level scratch configuration.
+    """
+    cluster_prefix = os.environ.get(_MARIN_CLUSTER_TEMP_PREFIX_ENV)
+    source_prefix = cluster_prefix or fallback_source_prefix
+    return marin_temp_bucket(ttl_days, prefix, source_prefix=source_prefix)
 
 
 # ---------------------------------------------------------------------------

--- a/lib/rigging/src/rigging/filesystem/cluster_config.py
+++ b/lib/rigging/src/rigging/filesystem/cluster_config.py
@@ -578,16 +578,9 @@ def marin_cluster_temp_bucket(
 ) -> str:
     """Return shared temporary storage local to the execution cluster.
 
-    A cluster advertises its shared scratch root through
-    ``MARIN_CLUSTER_TEMP_PREFIX``. This is intentionally distinct from
-    :func:`marin_temp_bucket`'s data-local routing: durable output may live in a
-    different region from the compute running the job. The advertised bucket
-    must be declared in ``data.region_buckets`` so its lifecycle rules,
-    endpoint, credentials, and signing region remain configuration-owned.
-
-    When the cluster has no explicit scratch root, ``fallback_source_prefix`` is
-    forwarded to :func:`marin_temp_bucket`. This preserves data-local routing
-    for callers that predate cluster-level scratch configuration.
+    ``MARIN_CLUSTER_TEMP_PREFIX`` selects the managed scratch bucket independently
+    of durable data location. When it is unset, ``fallback_source_prefix`` selects
+    the data-local temp bucket; an absent fallback uses ambient Marin storage.
     """
     cluster_prefix = os.environ.get(_MARIN_CLUSTER_TEMP_PREFIX_ENV)
     source_prefix = cluster_prefix or fallback_source_prefix

--- a/lib/rigging/tests/test_cluster_config.py
+++ b/lib/rigging/tests/test_cluster_config.py
@@ -12,7 +12,6 @@ from rigging.filesystem.cluster_config import (
     StoreType,
     data_config,
     load_cluster_config,
-    marin_cluster_temp_bucket,
     marin_prefix,
     marin_temp_bucket,
     reset_data_config_cache,
@@ -179,21 +178,30 @@ def test_marin_temp_bucket_unknown_s3_bucket_falls_back(monkeypatch):
     assert path == "s3://random-bucket/marin/tmp"
 
 
-def test_marin_cluster_temp_bucket_prefers_cluster_scratch(monkeypatch):
+def test_marin_temp_bucket_prefers_cluster_override(monkeypatch):
     monkeypatch.setenv("MARIN_PREFIX", "s3://marin-us-east-02a/marin")
-    monkeypatch.setenv("MARIN_CLUSTER_TEMP_PREFIX", "s3://hero-checkpoints")
+    monkeypatch.setenv("MARIN_TEMP_PREFIX", "s3://hero-checkpoints")
     cfg = DataConfig(region_buckets={}, scheme="s3", ttl_days=(1, 14, 30))
     with use_data_config(cfg):
-        path = marin_cluster_temp_bucket(14, "checkpoints/run")
+        path = marin_temp_bucket(
+            14,
+            "checkpoints/run",
+            source_prefix="s3://marin-us-east-02a/marin",
+        )
     assert path == "s3://hero-checkpoints/tmp/ttl=14d/checkpoints/run"
 
 
-def test_marin_cluster_temp_bucket_falls_back_to_data_local_scratch(monkeypatch):
-    monkeypatch.delenv("MARIN_CLUSTER_TEMP_PREFIX", raising=False)
+def test_marin_temp_bucket_can_resolve_legacy_data_local_scratch(monkeypatch):
     monkeypatch.setenv("MARIN_PREFIX", "s3://marin-us-east-02a/marin")
+    monkeypatch.setenv("MARIN_TEMP_PREFIX", "s3://hero-checkpoints")
     cfg = DataConfig(region_buckets={}, scheme="s3", ttl_days=(1, 14, 30))
     with use_data_config(cfg):
-        path = marin_cluster_temp_bucket(14, "checkpoints/run")
+        path = marin_temp_bucket(
+            14,
+            "checkpoints/run",
+            source_prefix="s3://marin-us-east-02a/marin",
+            use_env_override=False,
+        )
     assert path == "s3://marin-us-east-02a/tmp/ttl=14d/checkpoints/run"
 
 

--- a/lib/rigging/tests/test_cluster_config.py
+++ b/lib/rigging/tests/test_cluster_config.py
@@ -12,6 +12,7 @@ from rigging.filesystem.cluster_config import (
     StoreType,
     data_config,
     load_cluster_config,
+    marin_cluster_temp_bucket,
     marin_prefix,
     marin_temp_bucket,
     reset_data_config_cache,
@@ -176,6 +177,26 @@ def test_marin_temp_bucket_unknown_s3_bucket_falls_back(monkeypatch):
     with use_data_config(cfg):
         path = marin_temp_bucket(3, source_prefix="s3://random-bucket/marin")
     assert path == "s3://random-bucket/marin/tmp"
+
+
+def test_marin_cluster_temp_bucket_prefers_cluster_scratch(monkeypatch):
+    """Execution-cluster scratch wins even when durable data lives in another region."""
+    monkeypatch.setenv("MARIN_PREFIX", "s3://marin-us-east-02a/marin")
+    monkeypatch.setenv("MARIN_CLUSTER_TEMP_PREFIX", "s3://hero-checkpoints")
+    cfg = DataConfig(region_buckets={}, scheme="s3", ttl_days=(1, 14, 30))
+    with use_data_config(cfg):
+        path = marin_cluster_temp_bucket(14, "checkpoints/run")
+    assert path == "s3://hero-checkpoints/tmp/ttl=14d/checkpoints/run"
+
+
+def test_marin_cluster_temp_bucket_falls_back_to_data_local_scratch(monkeypatch):
+    """Clusters without an advertised scratch root retain existing routing."""
+    monkeypatch.delenv("MARIN_CLUSTER_TEMP_PREFIX", raising=False)
+    monkeypatch.setenv("MARIN_PREFIX", "s3://marin-us-east-02a/marin")
+    cfg = DataConfig(region_buckets={}, scheme="s3", ttl_days=(1, 14, 30))
+    with use_data_config(cfg):
+        path = marin_cluster_temp_bucket(14, "checkpoints/run")
+    assert path == "s3://marin-us-east-02a/tmp/ttl=14d/checkpoints/run"
 
 
 # --- config-driven S3 bucket registry --------------------------------------

--- a/lib/rigging/tests/test_cluster_config.py
+++ b/lib/rigging/tests/test_cluster_config.py
@@ -180,7 +180,6 @@ def test_marin_temp_bucket_unknown_s3_bucket_falls_back(monkeypatch):
 
 
 def test_marin_cluster_temp_bucket_prefers_cluster_scratch(monkeypatch):
-    """Execution-cluster scratch wins even when durable data lives in another region."""
     monkeypatch.setenv("MARIN_PREFIX", "s3://marin-us-east-02a/marin")
     monkeypatch.setenv("MARIN_CLUSTER_TEMP_PREFIX", "s3://hero-checkpoints")
     cfg = DataConfig(region_buckets={}, scheme="s3", ttl_days=(1, 14, 30))
@@ -190,7 +189,6 @@ def test_marin_cluster_temp_bucket_prefers_cluster_scratch(monkeypatch):
 
 
 def test_marin_cluster_temp_bucket_falls_back_to_data_local_scratch(monkeypatch):
-    """Clusters without an advertised scratch root retain existing routing."""
     monkeypatch.delenv("MARIN_CLUSTER_TEMP_PREFIX", raising=False)
     monkeypatch.setenv("MARIN_PREFIX", "s3://marin-us-east-02a/marin")
     cfg = DataConfig(region_buckets={}, scheme="s3", ttl_days=(1, 14, 30))

--- a/tests/test_grug_hero_scaling_ladder.py
+++ b/tests/test_grug_hero_scaling_ladder.py
@@ -1,6 +1,8 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
+
 import pytest
 from marin.execution.lazy import StepContext
 
@@ -19,3 +21,21 @@ def test_scaling_ladder_disables_simulated_epoching_above_flop_limit(size, num_s
 
     assert (data.target_budget is not None) is expected_simulated_epoching
     assert (data.experiment_budget is not None) is expected_simulated_epoching
+
+
+def test_scaling_ladder_searches_data_local_temp_during_cluster_temp_migration(monkeypatch):
+    monkeypatch.setenv("MARIN_PREFIX", "s3://marin-us-east-02a/marin")
+    monkeypatch.setenv("MARIN_CLUSTER_TEMP_PREFIX", "s3://hero-checkpoints")
+    step = build_ladder_run(run_id="test-d6144", size="d6144", num_steps=1, version="2026.08.18")
+    output_path = "s3://marin-us-east-02a/marin/grug/test-d6144/v"
+    ctx = dataclasses.replace(
+        StepContext.for_fingerprint(runtime_arg_keys=step.runtime_args, deps=step.deps),
+        output_path=output_path,
+    )
+
+    trainer = step.build_config(ctx).trainer.trainer
+    assert trainer.checkpoint_search_paths("test-d6144") == [
+        f"{output_path}/checkpoints",
+        "s3://hero-checkpoints/tmp/ttl=14d/checkpoints-temp/marin-us-east-02a/marin/grug/test-d6144/v/checkpoints",
+        "s3://marin-us-east-02a/tmp/ttl=14d/checkpoints-temp/marin-us-east-02a/marin/grug/test-d6144/v/checkpoints",
+    ]

--- a/tests/test_grug_hero_scaling_ladder.py
+++ b/tests/test_grug_hero_scaling_ladder.py
@@ -23,7 +23,7 @@ def test_scaling_ladder_disables_simulated_epoching_above_flop_limit(size, num_s
     assert (data.experiment_budget is not None) is expected_simulated_epoching
 
 
-def test_scaling_ladder_searches_data_local_temp_during_cluster_temp_migration(monkeypatch):
+def test_scaling_ladder_searches_cluster_and_data_local_temp_roots(monkeypatch):
     monkeypatch.setenv("MARIN_PREFIX", "s3://marin-us-east-02a/marin")
     monkeypatch.setenv("MARIN_CLUSTER_TEMP_PREFIX", "s3://hero-checkpoints")
     step = build_ladder_run(run_id="test-d6144", size="d6144", num_steps=1, version="2026.08.18")

--- a/tests/test_grug_hero_scaling_ladder.py
+++ b/tests/test_grug_hero_scaling_ladder.py
@@ -25,7 +25,7 @@ def test_scaling_ladder_disables_simulated_epoching_above_flop_limit(size, num_s
 
 def test_scaling_ladder_searches_cluster_and_data_local_temp_roots(monkeypatch):
     monkeypatch.setenv("MARIN_PREFIX", "s3://marin-us-east-02a/marin")
-    monkeypatch.setenv("MARIN_CLUSTER_TEMP_PREFIX", "s3://hero-checkpoints")
+    monkeypatch.setenv("MARIN_TEMP_PREFIX", "s3://hero-checkpoints")
     step = build_ladder_run(run_id="test-d6144", size="d6144", num_steps=1, version="2026.08.18")
     output_path = "s3://marin-us-east-02a/marin/grug/test-d6144/v"
     ctx = dataclasses.replace(

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -84,7 +84,7 @@ def test_temporary_checkpoint_base_path_uses_cluster_local_scratch():
         os.environ,
         {
             "MARIN_PREFIX": "s3://marin-us-east-02a/marin",
-            "MARIN_CLUSTER_TEMP_PREFIX": "s3://hero-checkpoints",
+            "MARIN_TEMP_PREFIX": "s3://hero-checkpoints",
         },
     ):
         assert temporary_checkpoint_base_path("s3://marin-us-east-02a/experiments/grug/base-trial") == (
@@ -118,7 +118,7 @@ def test_apply_output_path_sets_run_specific_temp_checkpoints(trainer_config):
 
 def test_apply_output_path_does_not_enable_adapter_hf_export_without_steps(trainer_config):
     with patch(
-        "marin.training.training.marin_cluster_temp_bucket",
+        "marin.training.training.marin_temp_bucket",
         return_value="gs://tmp/ttl=14d/checkpoints-temp/example-run",
     ):
         updated = apply_output_path(
@@ -136,7 +136,7 @@ def test_apply_output_path_does_not_enable_adapter_hf_export_without_steps(train
 
 def test_apply_output_path_routes_adapter_hf_export_to_peft(trainer_config):
     with patch(
-        "marin.training.training.marin_cluster_temp_bucket",
+        "marin.training.training.marin_temp_bucket",
         return_value="gs://tmp/ttl=14d/checkpoints-temp/example-run",
     ):
         updated = apply_output_path(

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -25,6 +25,7 @@ from marin.training.training import (
     _maybe_auto_resolve_dpo_schedule,
     _resolve_run_id,
     apply_output_path,
+    data_local_temporary_checkpoint_base_path,
     doublecheck_paths,
     resolve_training_env,
     temporary_checkpoint_base_path,
@@ -78,13 +79,21 @@ def test_lm_config_with_train_urls_allowed_out_of_region(trainer_config):
         doublecheck_paths(config)
 
 
-def test_temporary_checkpoint_base_path_follows_output_path_region():
-    with (
-        patch("rigging.filesystem.cluster_config.urllib.request.urlopen", side_effect=OSError("not on GCP")),
-        patch.dict(os.environ, {"MARIN_PREFIX": "gs://marin-us-central1/scratch"}),
+def test_temporary_checkpoint_base_path_uses_cluster_local_scratch():
+    with patch.dict(
+        os.environ,
+        {
+            "MARIN_PREFIX": "s3://marin-us-east-02a/marin",
+            "MARIN_CLUSTER_TEMP_PREFIX": "s3://hero-checkpoints",
+        },
     ):
-        assert temporary_checkpoint_base_path("gs://marin-us-east5/experiments/grug/base-trial") == (
-            "gs://marin-us-east5/tmp/ttl=14d/checkpoints-temp/marin-us-east5/experiments/grug/base-trial/checkpoints"
+        assert temporary_checkpoint_base_path("s3://marin-us-east-02a/experiments/grug/base-trial") == (
+            "s3://hero-checkpoints/tmp/ttl=14d/checkpoints-temp/"
+            "marin-us-east-02a/experiments/grug/base-trial/checkpoints"
+        )
+        assert data_local_temporary_checkpoint_base_path("s3://marin-us-east-02a/experiments/grug/base-trial") == (
+            "s3://marin-us-east-02a/tmp/ttl=14d/checkpoints-temp/"
+            "marin-us-east-02a/experiments/grug/base-trial/checkpoints"
         )
 
 
@@ -109,7 +118,8 @@ def test_apply_output_path_sets_run_specific_temp_checkpoints(trainer_config):
 
 def test_apply_output_path_does_not_enable_adapter_hf_export_without_steps(trainer_config):
     with patch(
-        "marin.training.training.marin_temp_bucket", return_value="gs://tmp/ttl=14d/checkpoints-temp/example-run"
+        "marin.training.training.marin_cluster_temp_bucket",
+        return_value="gs://tmp/ttl=14d/checkpoints-temp/example-run",
     ):
         updated = apply_output_path(
             TrainDpoConfig(
@@ -126,7 +136,8 @@ def test_apply_output_path_does_not_enable_adapter_hf_export_without_steps(train
 
 def test_apply_output_path_routes_adapter_hf_export_to_peft(trainer_config):
     with patch(
-        "marin.training.training.marin_temp_bucket", return_value="gs://tmp/ttl=14d/checkpoints-temp/example-run"
+        "marin.training.training.marin_cluster_temp_bucket",
+        return_value="gs://tmp/ttl=14d/checkpoints-temp/example-run",
     ):
         updated = apply_output_path(
             TrainDpoConfig(


### PR DESCRIPTION
Route rolling hero checkpoints to dedicated 08A cluster-local temporary storage while permanent outputs and general scratch remain in 02A. The dedicated bucket uses the shared managed TTL lifecycle policy.

Keep the previous 02A temporary root in checkpoint discovery so the existing lineage resumes from the newest complete checkpoint across both locations during rollout.

Part of #8435
