### PR TITLE
[grug] Disable Blackwell eval kernel on H100

### DIFF
--- a/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
+++ b/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
@@ -68,6 +68,7 @@ EVAL_BATCH_SIZE = 256
 # 38 GB, against 2.7 TiB at the d6144 hero shape.
 CHECKPOINT_INTERVAL = timedelta(minutes=30)
 SMALL_SCALE_MIXED_PRECISION = "params=float32,compute=bfloat16,output=bfloat16"
+BLACKWELL_ACCELERATOR = "GB200"
 
 # Paloma + uncheatable held-out sets (marin_tokenizer), added as zero-train-weight datakit components
 # so they surface as tagged eval sets -- matching the FSDP sweep.
@@ -448,9 +449,8 @@ def build_small_run(
                 max_eval_batches=8,
                 eval_current=True,
                 eval_ema=False,
-                # EP rungs also log an `eval_dropless` macro loss (dropless local backend on an
-                # expert-collapsed mesh); a no-op for the FSDP flavors, which already run dropless.
-                dropless_eval=True,
+                # GB200 EP rungs also log an `eval_dropless` macro loss on an expert-collapsed mesh.
+                dropless_eval=fleet.accelerator == BLACKWELL_ACCELERATOR,
             ),
             # One process per GPU on every target: the H100 nodes hold 8 GPUs, not the
             # GB200 hero's 4, so the count follows the fleet rather than the hero constant.

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -481,6 +481,19 @@ def test_ep_ablation_defaults_match_the_documented_arm_and_scale_per_rack():
     assert four_cfg.trainer.trainer.train_batch_size == cfg.trainer.trainer.train_batch_size * 4
 
 
+def test_ep_ablation_uses_dropless_eval_only_on_blackwell():
+    gb200 = abl.build_small_run(run_id="gb200-eval", size="d768", target="gb200-rack", version="dev")
+    h100 = abl.build_small_run(run_id="h100-eval", size="d768", target="h100-2node", version="dev")
+
+    gb200_config = gb200.build_config(StepContext.for_fingerprint(gb200.runtime_args, gb200.deps))
+    h100_config = h100.build_config(StepContext.for_fingerprint(h100.runtime_args, h100.deps))
+
+    assert gb200_config.eval is not None
+    assert gb200_config.eval.dropless_eval is True
+    assert h100_config.eval is not None
+    assert h100_config.eval.dropless_eval is False
+
+
 def test_odd_depth_config_is_not_silently_rounded():
     # GrugModelConfig must preserve an odd depth so HF round-trips and odd configs stay faithful;
     # even-rounding is the launcher's job.


### PR DESCRIPTION
Disable the SM100-only dropless evaluation for H100 targets in the Grug small-scale launcher. The launcher sent H100 evaluation through `sonic_cute`, and CUTLASS rejected the Hopper `sm_90a` architecture.

Normal evaluation stays enabled on H100. GB200 targets keep the extra dropless evaluation. A two-node H100 smoke completed evaluation at step 1000 on all 16 processes, saved the checkpoint, and resumed training.
