### PR TITLE
[grafana] Read the loss-by-step curve from W&B

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -38,7 +38,9 @@ GET /finelog/marin/alerts/zephyr_stalls          active pipelines + stalled-prog
 GET /iris/{cluster}/jobs | workers | health      live controller RPCs
 GET /iris/{cluster}/query?sql=                    ad-hoc SELECT (admin/null-auth)
 GET /github/ferries | builds | nightlies          GitHub REST / GraphQL
-GET /wandb/{train-loss,paloma-macro-loss,mfu}      public report runset and sampled history
+GET /wandb/report/{train-loss,paloma-macro-loss,mfu}
+                                                    public report runset and sampled history
+GET /wandb/history?run=&metric=&project=          one run's whole logged history for one metric
 GET /k8s/control_plane | crashloops | pending     CW control-plane state, all clusters
 GET /k8s/termination_candidates | kueue | events | health
                                                     ... one response, `cluster` column
@@ -94,9 +96,14 @@ repos), classifies each (lane, day) cell server-side — health, overdue, and du
 and serves one linked, duration-aware row per lane and UTC day. The internal panel plugin
 groups those rows into the compact trailing-week matrix.
 
-W&B: the bridge reads the public hero-training report anonymously, follows the runset
-pinned in its report spec, and samples train cross-entropy, Paloma macro loss, and MFU
-against cumulative training tokens. Grafana receives flat rows and never needs a W&B key.
+W&B: the bridge reads public W&B anonymously, so Grafana never needs a W&B key. It
+serves two shapes. `/wandb/report/{chart}` follows the runset pinned in the public
+hero-training report spec and samples train cross-entropy, Paloma macro loss, and MFU
+against cumulative training tokens. `/wandb/history` samples one metric across one
+named run, keyed on W&B's own `_step`, which is the Levanter step because Levanter
+logs through `wandb.log(..., step=<training step>)`. Without an explicit `project`
+the bridge searches `RUN_HISTORY_PROJECTS` in order and fails with a 404 when no
+project holds the run.
 
 k8s: the bridge polls the three production CoreWeave clusters' public CKS API servers with plain
 httpx GETs (paginated LISTs, bounded timeouts, one 429 retry) and a single org-wide CW
@@ -169,7 +176,7 @@ src/server.py          the bridge routes (Starlette): finelog SQL, Iris, GitHub,
 src/finelog_source.py  finelog query over its internal IP (LogClient)
 src/iris_source.py     live controller RPCs: jobs, workers, health, federation peers, ad-hoc query
 src/github_source.py   ferry runs and CI build rollup, precomputed
-src/wandb_source.py    public W&B report runset and token-axis samples
+src/wandb_source.py    public W&B report runset, and whole-run history for one metric
 src/k8s_source.py      CW k8s API reads + the per-cluster fan-out and alert rows
 src/discovery.py       GCE label -> internal IP
 src/config.py          cluster targets, watched components, and bridge settings
@@ -286,15 +293,18 @@ The Token drops and Router health panels show the MoE signals that the hero
 monitor uses. The dashboard uses a 7% drop limit. The router limits are 5.92
 entropy and 400 bias.
 
-One loss panel uses step as its x-axis and keeps the newest sample for a repeated
-step. It reads the selected run without a Grafana time bound. The inner scan
-selects process 0 because Levanter publishes tracker metrics only from that
-process. For a series longer than 10,000 points, the query keeps the minimum and
-maximum loss in each group, plus the first and last points. The wall-clock loss
-panel separates each `execution_uid` and disconnects gaps longer than five
-minutes. Iris forms this identity from the controller-minted `attempt_uid`. Thus,
-a new controller process cannot join loss from a prior process with the same
-numeric task attempt.
+The two loss panels read different stores on purpose. The step-axis panel reads
+W&B through `/wandb/history`, because finelog evicts telemetry segments once
+`telemetry_v1` passes its storage policy and a finelog query only scans locally
+resident segments. A run that outlives that window therefore has no step 0 left in
+finelog, while its W&B run keeps the whole history and spans every restart under
+one id. W&B samples the series and the bridge caches it for a minute, so this
+panel lags the wall-clock panel and ignores the Grafana time range.
+
+The wall-clock loss panel stays on finelog for live detail. It separates each
+`execution_uid` and disconnects gaps longer than five minutes. Iris forms this
+identity from the controller-minted `attempt_uid`. Thus, a new controller process
+cannot join loss from a prior process with the same numeric task attempt.
 
 ## Alerting
 
@@ -661,17 +671,17 @@ Four things about the data will bite you:
   fails to parse. Qualifying or wrapping it is enough for the parser, but panels
   always write `"cluster"`, and a test rejects every other spelling so nobody has
   to remember which positions are safe.
-- **Give every `telemetry_v1` query a prunable scope.** For a time scope, write
-  `timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT)`. The
-  loss-by-step panel is the only unbounded query. Its process-0 predicate selects
-  the `training-process-zero` projection. The run and metric-name predicates then
-  prune that data. On 2026-08-21, its full retained query for
-  `hero-12d8b6f0-dee637` took 3.785s from a new job and 1.019s on the next
-  request for approximately 2,600 points.
-- **Cost tracks selected history, not returned rows.** The loss query samples
-  after its window functions. This limits the response and Grafana render cost,
-  but it does not lower the Finelog scan cost. Prefer one scan with conditional
-  aggregation to several tidy single-metric queries.
+- **Bound every `telemetry_v1` query, and fold the boundary.** Write
+  `timestamp_ms >= CAST(EXTRACT(EPOCH FROM {{from}}) * 1000 AS BIGINT)`, never
+  `timestamp_ms >= {{from}}`, which cannot prune segments. A test asserts that no
+  panel is exempt. An unbounded scan is both slow and a lie about coverage: on
+  2026-08-21 the full retained `hero-12d8b6f0-dee637` loss series took 3.785s
+  from a new job and still began at step 1050, because eviction had already taken
+  everything before it. Whole-run history belongs to `/wandb/history`.
+- **Cost tracks the selected window, not the returned rows.** Sampling after a
+  window function limits the response and the Grafana render, but it does not
+  lower the finelog scan. Prefer one scan with conditional aggregation to several
+  tidy single-metric queries.
 - **Clusters forward in bursts.** A cluster minutes behind makes the right edge of
   a fleet chart dip. That is why `accelerators.json` carries a freshness panel, and
   why the power stat reduces to the latest sample per GPU rather than a bucketed sum.

--- a/infra/grafana/dashboards/infra.json
+++ b/infra/grafana/dashboards/infra.json
@@ -339,7 +339,7 @@
           "source": "url",
           "format": "table",
           "parser": "backend",
-          "url": "/wandb/train-loss",
+          "url": "/wandb/report/train-loss",
           "url_options": {
             "method": "GET",
             "params": []
@@ -383,7 +383,7 @@
           "source": "url",
           "format": "table",
           "parser": "backend",
-          "url": "/wandb/paloma-macro-loss",
+          "url": "/wandb/report/paloma-macro-loss",
           "url_options": {
             "method": "GET",
             "params": []
@@ -427,7 +427,7 @@
           "source": "url",
           "format": "table",
           "parser": "backend",
-          "url": "/wandb/mfu",
+          "url": "/wandb/report/mfu",
           "url_options": {
             "method": "GET",
             "params": []

--- a/infra/grafana/dashboards/training.json
+++ b/infra/grafana/dashboards/training.json
@@ -528,10 +528,10 @@
       "id": 10,
       "type": "trend",
       "title": "Training loss by step",
-      "description": "Training loss against Levanter step for all retained samples from the selected run. This panel ignores the Grafana time range and keeps the minimum and maximum loss in each sample group for series longer than 10,000 points. For a repeated step, the newest sample wins. Use this panel for the continuous curve. Use the attempt panel for outages and restarts.",
+      "description": "Training loss against Levanter step for the whole run, read from W&B rather than finelog. Finelog evicts telemetry segments once the namespace passes its storage policy, so a finelog query starts at the oldest retained step; the W&B run spans every restart back to step 0. The series is sampled server-side and the bridge caches it for a minute, so it lags the attempt panel. This panel ignores the Grafana time range. Use it for the continuous curve, and the attempt panel for outages and restarts.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
+        "uid": "wandb"
       },
       "gridPos": {
         "h": 9,
@@ -572,13 +572,17 @@
           "source": "url",
           "format": "table",
           "parser": "backend",
-          "url": "/query",
+          "url": "/history",
           "url_options": {
             "method": "GET",
             "params": [
               {
-                "key": "sql",
-                "value": "WITH paired AS (SELECT timestamp_ms, seq, execution_uid, name, value, MAX(CASE WHEN name = 'step' THEN value END) OVER (PARTITION BY execution_uid ORDER BY timestamp_ms, seq ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS step FROM \"telemetry_v1\" WHERE service = 'levanter' AND name IN ('step', 'train_loss') AND run_id IN (${run:sqlstring}) AND execution_uid IS NOT NULL AND process_index = '0'), losses AS (SELECT step, value AS train_loss, timestamp_ms, seq, ROW_NUMBER() OVER (PARTITION BY step ORDER BY timestamp_ms DESC, seq DESC) AS rn FROM paired WHERE name = 'train_loss' AND step IS NOT NULL), numbered AS (SELECT step, train_loss, ROW_NUMBER() OVER (ORDER BY step) AS point_index, COUNT(*) OVER () AS point_count FROM losses WHERE rn = 1), bucketed AS (SELECT step, train_loss, point_index, point_count, CAST(FLOOR(CAST(point_index - 1 AS DOUBLE) * 4999.0 / CAST(point_count AS DOUBLE)) AS BIGINT) AS point_bucket FROM numbered), ranked AS (SELECT step, train_loss, point_index, point_count, ROW_NUMBER() OVER (PARTITION BY point_bucket ORDER BY train_loss, step) AS min_rank, ROW_NUMBER() OVER (PARTITION BY point_bucket ORDER BY train_loss DESC, step DESC) AS max_rank FROM bucketed) SELECT step, train_loss FROM ranked WHERE point_index = 1 OR point_index = point_count OR min_rank = 1 OR max_rank = 1 ORDER BY step"
+                "key": "run",
+                "value": "${run}"
+              },
+              {
+                "key": "metric",
+                "value": "train/loss"
               }
             ]
           },
@@ -589,7 +593,7 @@
               "type": "number"
             },
             {
-              "selector": "train_loss",
+              "selector": "value",
               "text": "train loss",
               "type": "number"
             }

--- a/infra/grafana/src/errors.py
+++ b/infra/grafana/src/errors.py
@@ -5,10 +5,11 @@
 
 
 class UpstreamError(Exception):
-    """An upstream (controller, GitHub) failed.
+    """An upstream (controller, GitHub, W&B) failed, or lacks what was asked for.
 
-    Surfaced as an HTTP 5xx with the source named, so an Infinity panel renders an
-    error rather than empty or stale data. The failed call is never cached.
+    Surfaced with the source named and `status_code` (a 5xx for a failure, 404 for
+    an absent object), so an Infinity panel renders an error rather than empty or
+    stale data.
     """
 
     def __init__(self, source: str, message: str, *, status_code: int = 502) -> None:

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -553,11 +553,12 @@ def create_app(
         return wandb_endpoint(("report", chart), lambda: wandb_source.points(chart))
 
     def wandb_run_history(request: Request) -> JSONResponse:
-        run = request.query_params.get("run", "")
-        metric = request.query_params.get("metric", "")
+        try:
+            run = _require(request.query_params, "run")
+            metric = _require(request.query_params, "metric")
+        except _BadRequest as err:
+            return JSONResponse({"error": str(err)}, status_code=400)
         project = request.query_params.get("project") or None
-        if not run or not metric:
-            return JSONResponse({"error": "run and metric are required"}, status_code=400)
         return wandb_endpoint(
             ("history", run, metric, project),
             lambda: wandb_source.run_history(run, metric=metric, project=project),

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -26,7 +26,8 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /github/ferries                          recent ferry runs per tier, with success rate
     GET /github/builds                           recent main commits with CI rollup state
     GET /github/nightlies                        7-day nightly-lane matrix (one row per lane/day)
-    GET /wandb/{chart}                           sampled public hero-report series by chart key
+    GET /wandb/report/{chart}                    sampled public hero-report series by chart key
+    GET /wandb/history?run=&metric=&project=     one run's full logged history for one metric
     GET /k8s/control_plane                       watched components + webhook endpoints, all clusters
     GET /k8s/crashloops                          containers in backoff waiting states
     GET /k8s/pending                             Pending / SchedulingGated pods with age
@@ -64,7 +65,7 @@ Loom one also exchanges tokens and creates a run over HTTP.
 
 import json
 import logging
-from collections.abc import Mapping
+from collections.abc import Hashable, Mapping
 from dataclasses import asdict
 from datetime import UTC, datetime
 
@@ -539,14 +540,28 @@ def create_app(
     def github_nightlies(_: Request) -> JSONResponse:
         return github_endpoint("nightlies", github_source.nightlies)
 
-    def wandb_chart(request: Request) -> JSONResponse:
-        chart = request.path_params["chart"]
+    def wandb_endpoint(key: Hashable, run) -> JSONResponse:
         try:
-            return JSONResponse(wandb_cache.get_or_compute(chart, lambda: wandb_source.points(chart)))
+            return JSONResponse(wandb_cache.get_or_compute(key, run))
         except ValueError as err:
             return JSONResponse({"error": str(err)}, status_code=400)
         except UpstreamError as err:
             return JSONResponse({"error": str(err), "source": err.source}, status_code=err.status_code)
+
+    def wandb_report_chart(request: Request) -> JSONResponse:
+        chart = request.path_params["chart"]
+        return wandb_endpoint(("report", chart), lambda: wandb_source.points(chart))
+
+    def wandb_run_history(request: Request) -> JSONResponse:
+        run = request.query_params.get("run", "")
+        metric = request.query_params.get("metric", "")
+        project = request.query_params.get("project") or None
+        if not run or not metric:
+            return JSONResponse({"error": "run and metric are required"}, status_code=400)
+        return wandb_endpoint(
+            ("history", run, metric, project),
+            lambda: wandb_source.run_history(run, metric=metric, project=project),
+        )
 
     def k8s_endpoint(key: str, run) -> JSONResponse:
         # Per-cluster failures are labeled rows inside the response; only a bridge
@@ -698,7 +713,8 @@ def create_app(
             Route("/github/ferries", github_ferries),
             Route("/github/builds", github_builds),
             Route("/github/nightlies", github_nightlies),
-            Route("/wandb/{chart}", wandb_chart),
+            Route("/wandb/history", wandb_run_history),
+            Route("/wandb/report/{chart}", wandb_report_chart),
             Route("/finelog/{cluster}/query", query),
             Route("/finelog/{cluster}/v1/vllm/overview", vllm_overview),
             Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/fleet_health", finelog_fleet_health),

--- a/infra/grafana/src/wandb_source.py
+++ b/infra/grafana/src/wandb_source.py
@@ -1,7 +1,14 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Public W&B report series as flat chart rows for Grafana."""
+"""W&B series as flat chart rows for Grafana.
+
+Two readers over the same public GraphQL API. `points` follows the runset pinned
+by Marin's public hero-run report. `run_history` reads one named run's whole
+logged history for one metric, which is what lets a step-axis panel start at step
+0: finelog evicts telemetry segments once the namespace passes its storage policy,
+while W&B keeps the run.
+"""
 
 import json
 
@@ -23,6 +30,17 @@ WANDB_CHARTS = {
     "mfu": ("MFU (%)", "throughput/mfu"),
 }
 
+_RUN_URL = "https://wandb.ai/{entity}/{project}/runs/{run}"
+_RUN_HISTORY_SAMPLES = 2000
+# W&B's own step counter. Levanter logs every training metric through
+# `wandb.log(..., step=<training step>)`, so this column is the Levanter step.
+_STEP_KEY = "_step"
+
+# The projects a run named by the training dashboard can live in, searched in this
+# order. The grug hero launchers default to marin_moe and marin.experiment.train
+# defaults to marin. A caller that knows the project pins it and skips the search.
+RUN_HISTORY_PROJECTS = ("marin_moe", "marin")
+
 _REPORT_QUERY = """
 query Report($id: ID!) {
   view(id: $id) { displayName spec }
@@ -39,7 +57,7 @@ query RunSampledHistory($entity: String!, $project: String!, $run: String!, $spe
 
 
 class WandbSource:
-    """Reads the runset pinned by Marin's public hero-run report."""
+    """Reads the public hero-run report's runset, and any single run's history."""
 
     def __init__(self, *, timeout: float) -> None:
         self._client = httpx.Client(timeout=timeout, headers={"content-type": "application/json"})
@@ -100,3 +118,43 @@ class WandbSource:
                         }
                     )
         return rows
+
+    def run_history(self, run: str, *, metric: str, project: str | None = None) -> list[dict]:
+        """Return one row per sampled point of `metric` across the whole of `run`.
+
+        `run` is the Levanter run id: marin names the W&B run after it, and
+        `resume="allow"` keeps one W&B run across restarts, so this covers the run
+        from step 0 however many times it was resumed. W&B samples server-side, so
+        the response stays small on a long run. A run absent from every searched
+        project fails loud rather than rendering as an empty panel.
+        """
+        projects = (project,) if project else RUN_HISTORY_PROJECTS
+        spec = json.dumps({"keys": [_STEP_KEY, metric], "samples": _RUN_HISTORY_SAMPLES})
+        for candidate in projects:
+            run_data = (
+                self._graphql(
+                    _HISTORY_QUERY,
+                    {"entity": _ENTITY, "project": candidate, "run": run, "specs": [spec]},
+                ).get("project")
+                or {}
+            ).get("run")
+            if not run_data:
+                continue
+            histories = run_data.get("sampledHistory") or []
+            run_url = _RUN_URL.format(entity=_ENTITY, project=candidate, run=run)
+            rows: list[dict] = []
+            for point in histories[0] if histories else []:
+                step = point.get(_STEP_KEY)
+                value = point.get(metric)
+                if isinstance(step, int | float) and isinstance(value, int | float):
+                    rows.append(
+                        {
+                            "run": run,
+                            "project": candidate,
+                            "run_url": run_url,
+                            "step": step,
+                            "value": value,
+                        }
+                    )
+            return rows
+        raise UpstreamError("wandb", f"run {run!r} not found in {', '.join(projects)}", status_code=404)

--- a/infra/grafana/src/wandb_source.py
+++ b/infra/grafana/src/wandb_source.py
@@ -83,40 +83,55 @@ class WandbSource:
             raise UpstreamError("wandb", "report pins no runs", status_code=502)
         return view.get("displayName") or "W&B report", runs
 
+    def _sampled_history(
+        self, *, project: str, run: str, x_key: str, y_key: str, samples: int
+    ) -> list[tuple[float, float]] | None:
+        """Numeric (x, y) pairs from one run's sampled history, or None if it is absent.
+
+        A point missing either key is dropped: W&B writes a null wherever a metric
+        was not logged on that step. Callers decide what an absent run means.
+        """
+        spec = json.dumps({"keys": [x_key, y_key], "samples": samples})
+        run_data = (
+            self._graphql(
+                _HISTORY_QUERY,
+                {"entity": _ENTITY, "project": project, "run": run, "specs": [spec]},
+            ).get("project")
+            or {}
+        ).get("run")
+        if not run_data:
+            return None
+        histories = run_data.get("sampledHistory") or []
+        pairs: list[tuple[float, float]] = []
+        for point in histories[0] if histories else []:
+            x_value = point.get(x_key)
+            y_value = point.get(y_key)
+            if isinstance(x_value, int | float) and isinstance(y_value, int | float):
+                pairs.append((x_value, y_value))
+        return pairs
+
     def points(self, chart_key: str) -> list[dict]:
         """Return one row per sampled point for a configured report chart."""
         if chart_key not in WANDB_CHARTS:
             raise ValueError(f"unknown W&B chart {chart_key!r}; configured: {sorted(WANDB_CHARTS)}")
         chart_title, metric = WANDB_CHARTS[chart_key]
         report_title, runs = self._report()
-        spec = json.dumps({"keys": [_X_KEY, metric], "samples": _SAMPLES})
         rows: list[dict] = []
         for run in runs:
-            project = (
-                self._graphql(
-                    _HISTORY_QUERY,
-                    {"entity": _ENTITY, "project": _PROJECT, "run": run, "specs": [spec]},
-                ).get("project")
-                or {}
-            )
-            run_data = project.get("run") or {}
-            if not run_data:
+            pairs = self._sampled_history(project=_PROJECT, run=run, x_key=_X_KEY, y_key=metric, samples=_SAMPLES)
+            if pairs is None:
                 raise UpstreamError("wandb", f"run {run!r} not found", status_code=502)
-            histories = run_data.get("sampledHistory") or []
-            for point in histories[0] if histories else []:
-                tokens = point.get(_X_KEY)
-                value = point.get(metric)
-                if isinstance(tokens, int | float) and isinstance(value, int | float):
-                    rows.append(
-                        {
-                            "chart": chart_title,
-                            "run": run,
-                            "tokens": tokens,
-                            "value": value,
-                            "report_title": report_title,
-                            "report_url": _REPORT_URL,
-                        }
-                    )
+            rows.extend(
+                {
+                    "chart": chart_title,
+                    "run": run,
+                    "tokens": tokens,
+                    "value": value,
+                    "report_title": report_title,
+                    "report_url": _REPORT_URL,
+                }
+                for tokens, value in pairs
+            )
         return rows
 
     def run_history(self, run: str, *, metric: str, project: str | None = None) -> list[dict]:
@@ -129,32 +144,15 @@ class WandbSource:
         project fails loud rather than rendering as an empty panel.
         """
         projects = (project,) if project else RUN_HISTORY_PROJECTS
-        spec = json.dumps({"keys": [_STEP_KEY, metric], "samples": _RUN_HISTORY_SAMPLES})
         for candidate in projects:
-            run_data = (
-                self._graphql(
-                    _HISTORY_QUERY,
-                    {"entity": _ENTITY, "project": candidate, "run": run, "specs": [spec]},
-                ).get("project")
-                or {}
-            ).get("run")
-            if not run_data:
+            pairs = self._sampled_history(
+                project=candidate, run=run, x_key=_STEP_KEY, y_key=metric, samples=_RUN_HISTORY_SAMPLES
+            )
+            if pairs is None:
                 continue
-            histories = run_data.get("sampledHistory") or []
             run_url = _RUN_URL.format(entity=_ENTITY, project=candidate, run=run)
-            rows: list[dict] = []
-            for point in histories[0] if histories else []:
-                step = point.get(_STEP_KEY)
-                value = point.get(metric)
-                if isinstance(step, int | float) and isinstance(value, int | float):
-                    rows.append(
-                        {
-                            "run": run,
-                            "project": candidate,
-                            "run_url": run_url,
-                            "step": step,
-                            "value": value,
-                        }
-                    )
-            return rows
+            return [
+                {"run": run, "project": candidate, "run_url": run_url, "step": step, "value": value}
+                for step, value in pairs
+            ]
         raise UpstreamError("wandb", f"run {run!r} not found in {', '.join(projects)}", status_code=404)

--- a/infra/grafana/tests/fixture_bridge.py
+++ b/infra/grafana/tests/fixture_bridge.py
@@ -105,6 +105,21 @@ def _wandb(chart: str) -> list[dict]:
     return rows
 
 
+def _wandb_history(params: dict[str, list[str]]) -> list[dict]:
+    """A whole-run curve: the point of the panel is that it starts at step 0."""
+    run = params.get("run", ["hero-preview"])[0]
+    return [
+        {
+            "run": run,
+            "project": "marin_moe",
+            "run_url": f"https://wandb.ai/marin-community/marin_moe/runs/{run}",
+            "step": step,
+            "value": 3.4 - 1.9 * (step / 40_000) ** 0.35,
+        }
+        for step in range(0, 40_000, 200)
+    ]
+
+
 def _finelog(query: str) -> list[dict]:
     sql = parse_qs(query).get("sql", [""])[0]
     if 'FROM "iris.task"' in sql:
@@ -459,7 +474,9 @@ def _rows(path: str, query: str) -> list[dict] | dict:
                 "last_seen": round(_NOW.timestamp() * 1000),
             }
         ]
-    if path.startswith("/wandb/"):
+    if path == "/wandb/history":
+        return _wandb_history(parse_qs(query))
+    if path.startswith("/wandb/report/"):
         return _wandb(path.rsplit("/", 1)[-1])
     if path == "/finelog/marin/query":
         return _finelog(query)

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -126,6 +126,15 @@ def test_query_substitutes_window_macros_before_running():
     ]
 
 
+def test_wandb_routes_reject_an_incomplete_request_without_calling_wandb():
+    # The two W&B routes are distinct paths, so a report chart key can never shadow
+    # the run-history route. Neither bad request reaches the network.
+    client = _client(FakeSource(_ONE_ROW))
+    assert client.get("/wandb/history", params={"metric": "train/loss"}).status_code == 400
+    assert client.get("/wandb/history", params={"run": "hero-run"}).status_code == 400
+    assert client.get("/wandb/report/nope").status_code == 400
+
+
 def test_missing_sql_is_a_400():
     resp = _client(FakeSource()).get("/finelog/marin/query", params={"from": FROM_MS, "to": TO_MS})
     assert resp.status_code == 400

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from urllib.parse import urlsplit
 
 import duckdb
+import httpx
 import pyarrow as pa
 import yaml
 from config import CLUSTERS, K8S_CLUSTERS, ClusterTarget
@@ -540,9 +541,9 @@ def test_status_page_has_each_required_source():
         "N": "/github/nightlies",
         "G": "/github/builds",
         "W": "/iris/marin/workers",
-        "T": "/wandb/train-loss",
-        "L": "/wandb/paloma-macro-loss",
-        "M": "/wandb/mfu",
+        "T": "/wandb/report/train-loss",
+        "L": "/wandb/report/paloma-macro-loss",
+        "M": "/wandb/report/mfu",
     }
 
 
@@ -558,10 +559,8 @@ def test_stat_panels_use_grafana_reduce_options_schema():
 
 def test_telemetry_queries_bound_their_window_with_foldable_macros():
     # Time-scoped queries need foldable bounds for segment pruning. A direct bigint-to-
-    # timestamp comparison such as `timestamp_ms >= {{from}}` cannot prune segments.
-    training = _stitched_dashboards()["training.json"]
-    step_panel = next(panel for panel in _all_panels(training) if panel["id"] == 10)
-    (step_sql,) = _panel_sql({"panels": [step_panel]})
+    # timestamp comparison such as `timestamp_ms >= {{from}}` cannot prune segments. No
+    # panel is exempt: whole-run history comes from W&B, not from an unbounded scan.
     unbounded: list[tuple[str, str]] = []
     for name, dashboard in _stitched_dashboards().items():
         for sql in _panel_sql(dashboard):
@@ -573,7 +572,7 @@ def test_telemetry_queries_bound_their_window_with_foldable_macros():
             assert "timestamp_ms < CAST(EXTRACT(EPOCH FROM" in sql, name
             assert "timestamp_ms >= {{from}}" not in sql, name
 
-    assert unbounded == [("training.json", step_sql)]
+    assert unbounded == []
 
 
 def test_cluster_column_is_only_referenced_quoted_or_as_an_alias():
@@ -677,43 +676,35 @@ def test_training_loss_by_attempt_separates_process_incarnations():
     ]
 
 
-def test_training_loss_by_step_uses_the_newest_retry_sample():
+def test_training_loss_by_step_reads_the_whole_run_from_wandb():
+    # finelog evicts telemetry segments once telemetry_v1 passes its storage policy, so
+    # no finelog query reaches step 0. Join the panel's datasource base path with its
+    # URL and GET it for real, against a stubbed W&B.
     dashboard = _stitched_dashboards()["training.json"]
     panel = next(panel for panel in _all_panels(dashboard) if panel["title"] == "Training loss by step")
-    sql = _panel_sql({**dashboard, "panels": [panel]})[0]
-    sql = sql.replace("${run:sqlstring}", "'hero-run'")
+    (target,) = panel["targets"]
+    params = {param["key"]: param["value"] for param in target["url_options"]["params"]}
+    params["run"] = "hero-run"  # Grafana interpolates ${run} before the request leaves it
 
-    database = duckdb.connect()
-    database.execute(
-        """
-        CREATE TABLE telemetry_v1(
-            service VARCHAR,
-            run_id VARCHAR,
-            execution_uid VARCHAR,
-            process_index VARCHAR,
-            name VARCHAR,
-            value DOUBLE,
-            timestamp_ms BIGINT,
-            seq BIGINT
-        )
-        """
+    history = {"data": {"project": {"run": {"sampledHistory": [[{"_step": 0, "train/loss": 3.1}]]}}}}
+    wandb_source = WandbSource(timeout=5.0)
+    wandb_source._client = httpx.Client(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, json=history)),
+        headers={"content-type": "application/json"},
     )
-    at = int(datetime(2026, 8, 20, 12, tzinfo=UTC).timestamp() * 1000)
-    database.executemany(
-        "INSERT INTO telemetry_v1 VALUES ('levanter', 'hero-run', ?, ?, ?, ?, ?, ?)",
-        [
-            ("attempt-1", "0", "step", 10, at, 1),
-            ("attempt-1", "0", "train_loss", 2.0, at, 2),
-            ("attempt-1", "0", "step", 11, at + 1_000, 3),
-            ("attempt-1", "0", "train_loss", 1.9, at + 1_000, 4),
-            ("attempt-2", "0", "step", 10, at + 2_000, 1),
-            ("attempt-2", "0", "train_loss", 2.2, at + 2_000, 2),
-            ("attempt-rank-1", "1", "step", 12, at + 3_000, 1),
-            ("attempt-rank-1", "1", "train_loss", 9.9, at + 3_000, 2),
-        ],
+    client = TestClient(
+        create_app(bridge_config(), {}, {}, GithubSource(auth=None, timeout=5.0), K8sFleet(()), wandb_source)
     )
 
-    assert database.execute(sql).fetchall() == [(10.0, 2.2), (11.0, 1.9)]
+    response = client.get(_datasources()[panel["datasource"]["uid"]] + target["url"], params=params)
+
+    assert response.status_code == 200
+    (row,) = response.json()
+    assert (row["run"], row["step"], row["value"]) == ("hero-run", 0, 3.1)
+    # Infinity renames each selector to its text, and the trend panel plots that name.
+    columns = {column["selector"]: column["text"] for column in target["columns"]}
+    assert set(columns) <= set(row)
+    assert panel["options"]["xField"] in columns.values()
 
 
 def test_training_execution_health_uses_the_current_attempt_and_iris_state():

--- a/infra/grafana/tests/test_sources.py
+++ b/infra/grafana/tests/test_sources.py
@@ -333,6 +333,64 @@ def test_wandb_rejects_unknown_chart_without_network():
         _wandb(lambda request: pytest.fail("unexpected request")).points("nope")
 
 
+def _history_handler(found_in: str, points: list[dict], asked: list[tuple[str, list[str]]]):
+    """Serve `points` from the project named `found_in`; record each project asked."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        variables = json.loads(request.content)["variables"]
+        asked.append((variables["project"], json.loads(variables["specs"][0])["keys"]))
+        if variables["project"] != found_in:
+            return httpx.Response(200, json={"data": {"project": None}})
+        return httpx.Response(
+            200,
+            json={"data": {"project": {"run": {"state": "running", "sampledHistory": [points]}}}},
+        )
+
+    return handler
+
+
+def test_wandb_run_history_searches_projects_and_drops_null_metric_rows():
+    asked: list[tuple[str, list[str]]] = []
+    points = [{"_step": 0, "train/loss": 3.1}, {"_step": 1, "train/loss": None}, {"_step": 2, "train/loss": 2.7}]
+
+    rows = _wandb(_history_handler("marin", points, asked)).run_history("hero-run", metric="train/loss")
+
+    # `_step` is the x axis because levanter logs through wandb.log(..., step=<step>).
+    assert asked == [("marin_moe", ["_step", "train/loss"]), ("marin", ["_step", "train/loss"])]
+    assert rows == [
+        {
+            "run": "hero-run",
+            "project": "marin",
+            "run_url": "https://wandb.ai/marin-community/marin/runs/hero-run",
+            "step": step,
+            "value": value,
+        }
+        for step, value in ((0, 3.1), (2, 2.7))
+    ]
+
+
+def test_wandb_run_history_pins_an_explicit_project_without_searching():
+    asked: list[tuple[str, list[str]]] = []
+    handler = _history_handler("marin_moe", [{"_step": 7, "train/loss": 2.5}], asked)
+
+    rows = _wandb(handler).run_history("hero-run", metric="train/loss", project="marin_moe")
+
+    assert [project for project, _ in asked] == ["marin_moe"]
+    assert [row["step"] for row in rows] == [7]
+
+
+def test_wandb_run_history_fails_loud_when_no_project_has_the_run():
+    asked: list[tuple[str, list[str]]] = []
+    handler = _history_handler("nowhere", [], asked)
+
+    with pytest.raises(UpstreamError) as excinfo:
+        _wandb(handler).run_history("hero-run", metric="train/loss")
+
+    assert excinfo.value.source == "wandb"
+    assert excinfo.value.status_code == 404
+    assert [project for project, _ in asked] == ["marin_moe", "marin"]
+
+
 # --- endpoint routing / fail-loud ------------------------------------------
 
 


### PR DESCRIPTION
Point the training dashboard's step-axis loss panel at W&B instead of finelog.
finelog queries only scan locally resident sealed segments, and `telemetry_v1` on
the marin hub inherits the default 15 GiB / 1000-segment cap, so a long run's
early steps are evicted to the GCS archive and stop being queryable. On
2026-08-21 the panel's own unbounded query for `hero-12d8b6f0-dee637` took 3.785s
and still began at step 1050. The same run's W&B history returns 2000 sampled
points from step 0 (loss 11.80) to step 3918 (loss 1.54).

Add `/wandb/history?run=&metric=&project=` to the bridge. It samples any metric
key over one run, keyed on W&B's `_step`, which is the Levanter step because
Levanter logs through `wandb.log(..., step=<training step>)`, and one W&B run
spans every restart under `resume="allow"`. Without an explicit project the
bridge searches `marin_moe` then `marin` and returns 404 when neither holds the
run. Nothing about the endpoint is loss-specific; `metric=throughput/mfu` or any
other logged key works without a bridge change.

The panel now depends on public W&B being reachable, and shows a sampled curve
cached for 60s, so it lags the wall-clock panel. That panel stays on finelog for
live per-attempt detail. A run whose tracker is telemetry-only renders the 404
instead of a curve.

`/wandb/{chart}` becomes `/wandb/report/{chart}` so a chart key cannot shadow the
new route. `telemetry_v1` now has no unbounded panel query, so the
bound-your-window test drops its one exemption.

Training scalars still share `telemetry_v1` with host, GPU, NCCL, and vLLM
telemetry, which is the volume that drives eviction. Giving them their own
namespace with an explicit `StoragePolicy`, as `ducky.query` and
`iris.task_event` already do, would keep the finelog copy for a whole run. That
is a separate change and does not recover any already-evicted run.
