### PR TITLE
[grafana] Alert on hero run health through Slack

### DIFF
--- a/docs/ops/hero-run-health-alerts.md
+++ b/docs/ops/hero-run-health-alerts.md
@@ -29,8 +29,8 @@ a training run with no signal that it happened. That is what `iris_state_stale` 
 
 | Reason | Condition | Metric |
 |---|---|---|
-| `telemetry_gone` | Newest sample over 10 minutes old while Iris still reports the tasks running | `phase` |
-| `run_down` | Newest sample over 10 minutes old and Iris no longer reports them running | `phase` |
+| `telemetry_gone` | Last phase was training, over 10 minutes old, while Iris still reports the tasks running | `phase` |
+| `run_down` | The same, and Iris no longer reports them running | `phase` |
 | `loss_jump` | Recent five-minute loss floor over 1.0 above the trailing floor of the same attempt, where the six-sigma band did not already catch it | `train_loss` |
 | `grad_norm_high` | Newest value above 2.0 | `grad_norm_total` |
 | `steps_skipped` | 3 or more skipped steps in 15 minutes | `optim_skipped_step` |
@@ -60,13 +60,18 @@ as a slow run. Fewer than 10 samples fires nothing.
 
 Silence pages either way; the Iris state only picks the reason. `telemetry_gone` means Iris still
 counts the tasks, so the telemetry path or the process is the suspect. `run_down` means it no longer
-does, so the job probably exited — the most severe case, and one neither this run's `phase` nor
-`TrainingProgressStalled` reports on its own, since both enrollments need running tasks. A finished
-tracker ended on purpose and pages for neither. A run that has published nothing at all stays with
-`TrainingProgressStalled`, which allows the full initialization budget.
+does, so the job probably exited — the most severe case, and one `TrainingProgressStalled` cannot
+report, since its enrollment needs running tasks.
 
-Levanter enrollment runs an hour so a silent run stays watched while the rule counts out its ten
-minutes and its five-minute pending period; the alert resolves when the run leaves that window.
+Both need the run's last phase to have been training. A finished tracker ended on purpose, and a run
+still initializing is `TrainingProgressStalled`'s, which allows the full startup budget. That
+exclusion carries most of the traffic: `hero-` names a smoke test as often as a production run, and
+40 hours of production telemetry held one production run against about 25 short dev runs, every one
+of which died during initialization.
+
+The phase heartbeat is read over a day rather than the hour the other metrics use, because an outage
+is measured from the last heartbeat however long ago it was. Levanter enrollment runs an hour, so a
+silent run stays watched while the rule counts out its threshold and pending period.
 
 Every other check needs fresh phase telemetry reporting the training phase, so an initializing,
 finished, or silent attempt announces nothing. `iris_state_stale` additionally needs a row that went

--- a/docs/ops/hero-run-health-alerts.md
+++ b/docs/ops/hero-run-health-alerts.md
@@ -1,0 +1,134 @@
+# Hero run health alerts
+
+Three Grafana alerts cover hero-run health beyond progress and loss:
+[`TrainingProgressStalled`](training-stall-alert-contract.md) watches whether a run steps, and
+[`TrainingLossSpike`](training-loss-spike-alert.md) watches what those steps produce. These watch
+the telemetry path itself, the optimizer, MoE routing, throughput, evaluation, and Iris retries.
+They carry the checks the standalone hero Pushover monitor applies, so an operator who reads Slack
+sees what the on-call phone sees.
+
+| Rule | Route | Fires on |
+|---|---|---|
+| `TrainingTelemetryGone` | `notification=hero-run`: Slack, a Loom triage session, and email | `telemetry_gone` |
+| `TrainingOptimizerUnstable` | `notification=hero-run` | `loss_jump`, `grad_norm_high`, `steps_skipped` |
+| `TrainingRunHealthDegraded` | `notification=slack`: one Slack message, no triage session | `token_drops`, `router_entropy`, `router_bias`, `throughput_low`, `mfu_low`, `eval_regressed`, `iris_state_stale`, `task_retried` |
+
+The first two page because the run is at risk within the hour. The third announces because an
+operator reads it beside the run dashboard and decides. Each rule evaluates once a minute and stays
+pending for five minutes. Each firing check is its own alert instance, labeled with its `reason`,
+and the hero-run route groups them by logical run.
+
+## Enrollment
+
+A run is watched while **either** side still reports it:
+
+- Iris: a fresh `iris.task_state` row that reports running tasks, the
+  [`TrainingProgressStalled`](training-stall-alert-contract.md) contract.
+- Levanter: a `phase` sample from `service=levanter` telemetry within the last 15 minutes, for a
+  `run_id` beginning with `hero-`.
+
+The stall and loss rules enroll from the Iris side alone. A break in that path therefore stops them
+watching a run that is plainly still training, with no signal that it happened. Watching the union
+means one path can report on the other, which is what `iris_state_stale` reports.
+
+The Levanter side names the root by taking the longest prefix of its telemetry `job_id` that is
+still a hero coordinator root, so `/rav/hero-20260819-coord/grug-train-hero-20260819` is watched as
+`/rav/hero-20260819-coord`.
+
+## What fires each check
+
+One bounded scan of `telemetry_v1` per bridge cache interval feeds all three rules. It reads the
+newest sample of each metric, the one before it, and the reductions the 15-minute health window
+needs. A check reads the newest sample only while that sample is under 15 minutes old, so a restart
+cannot fire an alert from the previous attempt's last value.
+
+| Reason | Condition | Metric |
+|---|---|---|
+| `telemetry_gone` | Newest sample over 10 minutes old while Iris still reports the tasks running | `phase` |
+| `loss_jump` | Recent five-minute loss floor over 1.0 above the trailing floor, where the six-sigma band did not already catch it | `train_loss` |
+| `grad_norm_high` | Newest value above 2.0 | `grad_norm_total` |
+| `steps_skipped` | 3 or more skipped steps in 15 minutes | `optim_skipped_step` |
+| `token_drops` | Newest value above 7% | `moe_drop_fraction` |
+| `router_entropy` | Newest value below 5.92 | `train_router_routing_entropy_mean` |
+| `router_bias` | Newest bound over 400 from zero | `train_router_bias_max`, `train_router_bias_min` |
+| `throughput_low` | Most of 15 minutes below 2.0M tokens per second | `throughput_tokens_per_second` |
+| `mfu_low` | Most of 15 minutes below 15% | `throughput_mfu` |
+| `eval_regressed` | Newest evaluation, within 30 minutes, worse than the one before it | `eval_paloma_macro_loss` |
+| `iris_state_stale` | Newest `iris.task_state` row for the root over 5 minutes old | `iris.task_state` |
+| `task_retried` | A controller retry or gang requeue in the last 15 minutes | `iris.task_event` |
+
+Uniform routing over the hero rung's experts is 5.951 entropy, so falling entropy is expert
+collapse. The 7% drop limit sits above the intermittent 5% spikes a healthy MoE run shows, and it is
+the band the [Training run dashboard](https://grafana.oa.dev/d/marin-training) draws.
+
+The throughput checks count how much of the window sat below the floor rather than averaging it.
+That is the median comparison the Pushover monitor makes, and it is what keeps one restart step at
+zero from reading as a slow run. A window with fewer than 10 samples says more about sampling than
+about the run, and fires nothing.
+
+`telemetry_gone` requires the Iris side to still report running tasks. Telemetry that stops when
+Iris also stops counting the tasks is a run that ended, not an incident. A run that has published
+nothing at all is left to `TrainingProgressStalled`, which allows the full initialization budget
+before it fires — that is the "Levanter never started" case, not a lost telemetry path.
+
+Every other check needs a fresh training phase from the run itself. An initializing run has
+published none of these metrics, a finished one leaves its last samples behind for a while, and a
+silent one is `TrainingTelemetryGone`'s, so none of the three announces. `iris_state_stale` also
+needs a state row that went stale rather than one that never existed: the GCE controllers publish no
+`iris.task_state` rollup at all, and a rollup that breaks leaves its last row readable for an hour.
+An outage longer than that stops being visible here, which is the limit of this check.
+
+Every quiet run emits a zero-valued `healthy` row and an empty fleet emits one `fleet` row, so a
+resolved check clears its instance and `noDataState: Alerting` stays reserved for a malformed or
+unavailable response.
+
+## When one fires
+
+1. Open the [Training run dashboard](https://grafana.oa.dev/d/marin-training) and select the run in
+   the alert. Execution health carries the attempt age, Iris task counts, and retry events. Token
+   drops and Router health carry the MoE signals against the same limits this rule uses.
+2. For `telemetry_gone`, separate a dead run from a dead telemetry path. Iris task counts on the
+   dashboard come from the same `iris.task_state` rollup that kept the run enrolled, so a healthy
+   count there with no Levanter samples points at the telemetry path or a wedged process. Check
+   `iris job describe` and the task logs.
+3. For `grad_norm_high` or `steps_skipped`, read the Optimizer and Loss spike panels together. A
+   gradient norm climbing while the schedule holds the learning rate flat is the shape that precedes
+   a spike. Skipped steps mean the optimizer rejected the update, so the weights did not take it.
+4. For `loss_jump`, date the change against Run progress. A mixture stage boundary, a resumed run
+   reading a different config, and a checkpoint restore all shift the level legitimately. This
+   check fires only where [`TrainingLossSpike`](training-loss-spike-alert.md) does not, so what it
+   catches is the level shift a wide trailing spread hides rather than a spike out of a quiet run.
+5. For `router_entropy` or `router_bias`, compare against the run's own history rather than the
+   limit alone. Both move slowly, so the shape over hours is the evidence.
+6. For `iris_state_stale`, treat the hero alerting path as degraded: `TrainingProgressStalled` and
+   `TrainingLossSpike` no longer enroll this run. Check the controller and its state telemetry.
+7. `task_retried` is information, not a fault. It explains a W&B gap and a loss discontinuity while
+   the new attempt redoes steps below the high-water mark.
+
+Verify what a rule saw with a bounded Finelog query:
+
+```sql
+SELECT
+  name,
+  value,
+  to_timestamp_millis(timestamp_ms) AS observed_at
+FROM "telemetry_v1"
+WHERE service = 'levanter'
+  AND run_id = '<hero-run-id>'
+  AND name IN ('phase', 'grad_norm_total', 'optim_skipped_step', 'moe_drop_fraction',
+               'train_router_routing_entropy_mean', 'throughput_mfu')
+  AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM now() - INTERVAL '15 minutes') * 1000 AS BIGINT)
+ORDER BY timestamp_ms DESC, seq DESC
+LIMIT 50;
+```
+
+## Tuning
+
+Every threshold and window is a constant at the top of `infra/grafana/src/hero_health.py`, and
+`TELEMETRY_GONE_AGE` is in `infra/grafana/src/hero_runs.py` because the stall rule defers on the
+same number. Changing one takes a redeploy of the Grafana service. Keep the drop and router limits
+equal to the bands `infra/grafana/dashboards/training.json` draws, so the panel an operator opens
+from the alert agrees with the alert.
+
+A benign firing that repeats across runs is the case for changing a constant. One run's stage
+boundary is the case for silencing that run.

--- a/docs/ops/hero-run-health-alerts.md
+++ b/docs/ops/hero-run-health-alerts.md
@@ -7,7 +7,7 @@ Pushover monitor applies.
 
 | Rule | Route | Fires on |
 |---|---|---|
-| `TrainingTelemetryGone` | `notification=hero-run`: Slack, a Loom triage session, email | `telemetry_gone` |
+| `TrainingTelemetryGone` | `notification=hero-run`: Slack, a Loom triage session, email | `telemetry_gone`, `run_down` |
 | `TrainingOptimizerUnstable` | `notification=hero-run` | `loss_jump`, `grad_norm_high`, `steps_skipped` |
 | `TrainingRunHealthDegraded` | `notification=slack`: one Slack message, no triage session | `token_drops`, `router_entropy`, `router_bias`, `throughput_low`, `mfu_low`, `eval_regressed`, `iris_state_stale`, `task_retried` |
 
@@ -18,7 +18,7 @@ instance labeled with its `reason`; the hero-run route groups them by logical ru
 
 A run is watched while either an `iris.task_state` row fresh within 90 seconds reports running tasks
 (the [`TrainingProgressStalled`](training-stall-alert-contract.md) contract) or a `hero-`-prefixed
-`run_id` published `phase` telemetry in the last 15 minutes. The Levanter side takes the longest
+`run_id` published `phase` telemetry in the last hour. The Levanter side takes the longest
 prefix of its `job_id` that is a hero coordinator root, so
 `/rav/hero-20260819-coord/grug-train-hero-20260819` is watched as `/rav/hero-20260819-coord`.
 
@@ -30,7 +30,8 @@ a training run with no signal that it happened. That is what `iris_state_stale` 
 | Reason | Condition | Metric |
 |---|---|---|
 | `telemetry_gone` | Newest sample over 10 minutes old while Iris still reports the tasks running | `phase` |
-| `loss_jump` | Recent five-minute loss floor over 1.0 above the trailing floor, where the six-sigma band did not already catch it | `train_loss` |
+| `run_down` | Newest sample over 10 minutes old and Iris no longer reports them running | `phase` |
+| `loss_jump` | Recent five-minute loss floor over 1.0 above the trailing floor of the same attempt, where the six-sigma band did not already catch it | `train_loss` |
 | `grad_norm_high` | Newest value above 2.0 | `grad_norm_total` |
 | `steps_skipped` | 3 or more skipped steps in 15 minutes | `optim_skipped_step` |
 | `token_drops` | Newest value above 7% | `moe_drop_fraction` |
@@ -46,7 +47,8 @@ Uniform routing over the hero rung's experts is 5.951 entropy, so falling entrop
 The 7% drop limit sits above the intermittent 5% spikes a healthy MoE run shows.
 
 One bounded `telemetry_v1` scan per bridge cache interval feeds all three rules, reduced over a
-single execution: the newest attempt JAX process zero reports. A retry keeps the run ID and takes a
+single execution: the newest attempt process zero reports. `loss_jump` reads its two loss windows
+against each other, so it filters them to that same execution. A retry keeps the run ID and takes a
 new `execution_uid`, so partitioning on the run alone would sum one attempt's skipped steps into the
 next and compare evaluations across a restore that redid steps. Process zero is the stable choice
 because Levanter publishes tracker metrics only from it. A check reads a newest sample only while it
@@ -56,9 +58,15 @@ The throughput checks count how much of the window sat below the floor rather th
 the median comparison the Pushover monitor makes, which keeps one restart step at zero from reading
 as a slow run. Fewer than 10 samples fires nothing.
 
-`telemetry_gone` requires Iris to still report running tasks; telemetry that stops when Iris also
-stops counting is a run that ended. A run that has published nothing at all stays with
+Silence pages either way; the Iris state only picks the reason. `telemetry_gone` means Iris still
+counts the tasks, so the telemetry path or the process is the suspect. `run_down` means it no longer
+does, so the job probably exited — the most severe case, and one neither this run's `phase` nor
+`TrainingProgressStalled` reports on its own, since both enrollments need running tasks. A finished
+tracker ended on purpose and pages for neither. A run that has published nothing at all stays with
 `TrainingProgressStalled`, which allows the full initialization budget.
+
+Levanter enrollment runs an hour so a silent run stays watched while the rule counts out its ten
+minutes and its five-minute pending period; the alert resolves when the run leaves that window.
 
 Every other check needs fresh phase telemetry reporting the training phase, so an initializing,
 finished, or silent attempt announces nothing. `iris_state_stale` additionally needs a row that went
@@ -74,9 +82,9 @@ Quiet runs emit zero-valued `healthy` rows and an empty fleet emits one `fleet` 
 1. Open the [Training run dashboard](https://grafana.oa.dev/d/marin-training) and select the run.
    Execution health carries the attempt age, Iris task counts, and retry events; Token drops and
    Router health draw the same limits these rules use.
-2. `telemetry_gone`: separate a dead run from a dead telemetry path. Healthy Iris task counts with no
-   Levanter samples point at the telemetry path or a wedged process — check `iris job describe` and
-   the task logs.
+2. `telemetry_gone` or `run_down`: start from `iris job describe` and the task logs. Healthy Iris
+   task counts with no Levanter samples point at the telemetry path or a wedged process; no running
+   tasks means the job exited and the question is why.
 3. `grad_norm_high` or `steps_skipped`: read the Optimizer and Loss spike panels together. A gradient
    norm climbing while the schedule holds the learning rate flat precedes a spike. Skipped steps mean
    the optimizer rejected the update, so the weights did not take it.

--- a/docs/ops/hero-run-health-alerts.md
+++ b/docs/ops/hero-run-health-alerts.md
@@ -1,49 +1,31 @@
 # Hero run health alerts
 
-Three Grafana alerts cover hero-run health beyond progress and loss:
-[`TrainingProgressStalled`](training-stall-alert-contract.md) watches whether a run steps, and
-[`TrainingLossSpike`](training-loss-spike-alert.md) watches what those steps produce. These watch
-the telemetry path itself, the optimizer, MoE routing, throughput, evaluation, and Iris retries.
-They carry the checks the standalone hero Pushover monitor applies, so an operator who reads Slack
-sees what the on-call phone sees.
+Three Grafana rules cover hero-run health beyond stepping
+([`TrainingProgressStalled`](training-stall-alert-contract.md)) and loss
+([`TrainingLossSpike`](training-loss-spike-alert.md)). They carry the checks the standalone hero
+Pushover monitor applies.
 
 | Rule | Route | Fires on |
 |---|---|---|
-| `TrainingTelemetryGone` | `notification=hero-run`: Slack, a Loom triage session, and email | `telemetry_gone` |
+| `TrainingTelemetryGone` | `notification=hero-run`: Slack, a Loom triage session, email | `telemetry_gone` |
 | `TrainingOptimizerUnstable` | `notification=hero-run` | `loss_jump`, `grad_norm_high`, `steps_skipped` |
 | `TrainingRunHealthDegraded` | `notification=slack`: one Slack message, no triage session | `token_drops`, `router_entropy`, `router_bias`, `throughput_low`, `mfu_low`, `eval_regressed`, `iris_state_stale`, `task_retried` |
 
-The first two page because the run is at risk within the hour. The third announces because an
-operator reads it beside the run dashboard and decides. Each rule evaluates once a minute and stays
-pending for five minutes. Each firing check is its own alert instance, labeled with its `reason`,
-and the hero-run route groups them by logical run.
+Each rule evaluates once a minute and stays pending for five. Each firing check is its own alert
+instance labeled with its `reason`; the hero-run route groups them by logical run.
 
 ## Enrollment
 
-A run is watched while **either** side still reports it:
+A run is watched while either an `iris.task_state` row fresh within 90 seconds reports running tasks
+(the [`TrainingProgressStalled`](training-stall-alert-contract.md) contract) or a `hero-`-prefixed
+`run_id` published `phase` telemetry in the last 15 minutes. The Levanter side takes the longest
+prefix of its `job_id` that is a hero coordinator root, so
+`/rav/hero-20260819-coord/grug-train-hero-20260819` is watched as `/rav/hero-20260819-coord`.
 
-- Iris: a fresh `iris.task_state` row that reports running tasks, the
-  [`TrainingProgressStalled`](training-stall-alert-contract.md) contract.
-- Levanter: a `phase` sample from `service=levanter` telemetry within the last 15 minutes, for a
-  `run_id` beginning with `hero-`.
-
-The stall and loss rules enroll from the Iris side alone. A break in that path therefore stops them
-watching a run that is plainly still training, with no signal that it happened. Watching the union
-means one path can report on the other, which is what `iris_state_stale` reports.
-
-The Levanter side names the root by taking the longest prefix of its telemetry `job_id` that is
-still a hero coordinator root, so `/rav/hero-20260819-coord/grug-train-hero-20260819` is watched as
-`/rav/hero-20260819-coord`.
+The stall and loss rules enroll from the Iris side alone, so a break in that path stops them watching
+a training run with no signal that it happened. That is what `iris_state_stale` reports.
 
 ## What fires each check
-
-One bounded scan of `telemetry_v1` per bridge cache interval feeds all three rules. It reads the
-newest sample of each metric, the one before it, and the reductions the 15-minute health window
-needs. Every reduction covers one execution: the newest attempt JAX process zero reports. A retry
-keeps the run ID and takes a new `execution_uid`, so a scan partitioned on the run alone would sum
-one attempt's skipped steps into the next and compare an evaluation across a checkpoint restore that
-redid steps. Process zero is the stable choice because Levanter publishes tracker metrics only from
-it. A check also reads the newest sample only while that sample is under 15 minutes old.
 
 | Reason | Condition | Metric |
 |---|---|---|
@@ -60,55 +42,52 @@ it. A check also reads the newest sample only while that sample is under 15 minu
 | `iris_state_stale` | Newest `iris.task_state` row for the root over 5 minutes old | `iris.task_state` |
 | `task_retried` | A controller retry or gang requeue in the last 15 minutes | `iris.task_event` |
 
-Uniform routing over the hero rung's experts is 5.951 entropy, so falling entropy is expert
-collapse. The 7% drop limit sits above the intermittent 5% spikes a healthy MoE run shows, and it is
-the band the [Training run dashboard](https://grafana.oa.dev/d/marin-training) draws.
+Uniform routing over the hero rung's experts is 5.951 entropy, so falling entropy is expert collapse.
+The 7% drop limit sits above the intermittent 5% spikes a healthy MoE run shows.
 
-The throughput checks count how much of the window sat below the floor rather than averaging it.
-That is the median comparison the Pushover monitor makes, and it is what keeps one restart step at
-zero from reading as a slow run. A window with fewer than 10 samples says more about sampling than
-about the run, and fires nothing.
+One bounded `telemetry_v1` scan per bridge cache interval feeds all three rules, reduced over a
+single execution: the newest attempt JAX process zero reports. A retry keeps the run ID and takes a
+new `execution_uid`, so partitioning on the run alone would sum one attempt's skipped steps into the
+next and compare evaluations across a restore that redid steps. Process zero is the stable choice
+because Levanter publishes tracker metrics only from it. A check reads a newest sample only while it
+is under 15 minutes old.
 
-`telemetry_gone` requires the Iris side to still report running tasks. Telemetry that stops when
-Iris also stops counting the tasks is a run that ended, not an incident. A run that has published
-nothing at all is left to `TrainingProgressStalled`, which allows the full initialization budget
-before it fires — that is the "Levanter never started" case, not a lost telemetry path.
+The throughput checks count how much of the window sat below the floor rather than averaging it —
+the median comparison the Pushover monitor makes, which keeps one restart step at zero from reading
+as a slow run. Fewer than 10 samples fires nothing.
 
-Every other check needs the run's own phase telemetry to be fresh and to report training. An
-initializing attempt has published none of these metrics, a finished one leaves its last samples
-behind for a while, and a silent one is `TrainingTelemetryGone`'s, so none of the three announces —
-including `task_retried`, so a gang that bounces before training starts stays quiet here and shows
-up on the dashboard's retry counter instead. `iris_state_stale` also
-needs a state row that went stale rather than one that never existed: the GCE controllers publish no
-`iris.task_state` rollup at all, and a rollup that breaks leaves its last row readable for an hour.
-An outage longer than that stops being visible here, which is the limit of this check.
+`telemetry_gone` requires Iris to still report running tasks; telemetry that stops when Iris also
+stops counting is a run that ended. A run that has published nothing at all stays with
+`TrainingProgressStalled`, which allows the full initialization budget.
 
-Every quiet run emits a zero-valued `healthy` row and an empty fleet emits one `fleet` row, so a
-resolved check clears its instance and `noDataState: Alerting` stays reserved for a malformed or
-unavailable response.
+Every other check needs fresh phase telemetry reporting the training phase, so an initializing,
+finished, or silent attempt announces nothing. `iris_state_stale` additionally needs a row that went
+stale rather than one that never existed: the GCE controllers publish no `iris.task_state` rollup at
+all, and a broken rollup leaves its last row readable for an hour. A longer outage stops being
+visible, which is the limit of this check.
+
+Quiet runs emit zero-valued `healthy` rows and an empty fleet emits one `fleet` row, so
+`noDataState: Alerting` stays reserved for a malformed or unavailable response.
 
 ## When one fires
 
-1. Open the [Training run dashboard](https://grafana.oa.dev/d/marin-training) and select the run in
-   the alert. Execution health carries the attempt age, Iris task counts, and retry events. Token
-   drops and Router health carry the MoE signals against the same limits this rule uses.
-2. For `telemetry_gone`, separate a dead run from a dead telemetry path. Iris task counts on the
-   dashboard come from the same `iris.task_state` rollup that kept the run enrolled, so a healthy
-   count there with no Levanter samples points at the telemetry path or a wedged process. Check
-   `iris job describe` and the task logs.
-3. For `grad_norm_high` or `steps_skipped`, read the Optimizer and Loss spike panels together. A
-   gradient norm climbing while the schedule holds the learning rate flat is the shape that precedes
-   a spike. Skipped steps mean the optimizer rejected the update, so the weights did not take it.
-4. For `loss_jump`, date the change against Run progress. A mixture stage boundary, a resumed run
-   reading a different config, and a checkpoint restore all shift the level legitimately. This
-   check fires only where [`TrainingLossSpike`](training-loss-spike-alert.md) does not, so what it
-   catches is the level shift a wide trailing spread hides rather than a spike out of a quiet run.
-5. For `router_entropy` or `router_bias`, compare against the run's own history rather than the
-   limit alone. Both move slowly, so the shape over hours is the evidence.
-6. For `iris_state_stale`, treat the hero alerting path as degraded: `TrainingProgressStalled` and
+1. Open the [Training run dashboard](https://grafana.oa.dev/d/marin-training) and select the run.
+   Execution health carries the attempt age, Iris task counts, and retry events; Token drops and
+   Router health draw the same limits these rules use.
+2. `telemetry_gone`: separate a dead run from a dead telemetry path. Healthy Iris task counts with no
+   Levanter samples point at the telemetry path or a wedged process — check `iris job describe` and
+   the task logs.
+3. `grad_norm_high` or `steps_skipped`: read the Optimizer and Loss spike panels together. A gradient
+   norm climbing while the schedule holds the learning rate flat precedes a spike. Skipped steps mean
+   the optimizer rejected the update, so the weights did not take it.
+4. `loss_jump`: date the change against Run progress. A mixture stage boundary, a resumed run reading
+   a different config, and a checkpoint restore all shift the level legitimately.
+5. `router_entropy` or `router_bias`: both move slowly, so the shape over hours is the evidence, not
+   the distance from the limit.
+6. `iris_state_stale`: the hero alerting path is degraded — `TrainingProgressStalled` and
    `TrainingLossSpike` no longer enroll this run. Check the controller and its state telemetry.
-7. `task_retried` is information, not a fault. It explains a W&B gap and a loss discontinuity while
-   the new attempt redoes steps below the high-water mark.
+7. `task_retried` is information, not a fault. It explains a W&B gap while the new attempt redoes
+   steps below the high-water mark.
 
 Verify what a rule saw with a bounded Finelog query:
 
@@ -129,11 +108,10 @@ LIMIT 50;
 
 ## Tuning
 
-Every threshold and window is a constant at the top of `infra/grafana/src/hero_health.py`, and
-`TELEMETRY_GONE_AGE` is in `infra/grafana/src/hero_runs.py` because the stall rule defers on the
-same number. Changing one takes a redeploy of the Grafana service. The drop and router limits are
-also drawn as bands by `infra/grafana/dashboards/training.json`; a test asserts the two agree, so
-tuning one without the other fails locally rather than after a deploy.
+Thresholds and windows are constants at the top of `infra/grafana/src/hero_health.py`;
+`TELEMETRY_GONE_AGE` is in `hero_runs.py` because the stall rule defers on the same number. Changing
+one takes a redeploy. `training.json` draws the drop and router limits as bands, and a test asserts
+the two agree.
 
 A benign firing that repeats across runs is the case for changing a constant. One run's stage
 boundary is the case for silencing that run.

--- a/docs/ops/hero-run-health-alerts.md
+++ b/docs/ops/hero-run-health-alerts.md
@@ -39,8 +39,11 @@ still a hero coordinator root, so `/rav/hero-20260819-coord/grug-train-hero-2026
 
 One bounded scan of `telemetry_v1` per bridge cache interval feeds all three rules. It reads the
 newest sample of each metric, the one before it, and the reductions the 15-minute health window
-needs. A check reads the newest sample only while that sample is under 15 minutes old, so a restart
-cannot fire an alert from the previous attempt's last value.
+needs. Every reduction covers one execution: the newest attempt JAX process zero reports. A retry
+keeps the run ID and takes a new `execution_uid`, so a scan partitioned on the run alone would sum
+one attempt's skipped steps into the next and compare an evaluation across a checkpoint restore that
+redid steps. Process zero is the stable choice because Levanter publishes tracker metrics only from
+it. A check also reads the newest sample only while that sample is under 15 minutes old.
 
 | Reason | Condition | Metric |
 |---|---|---|
@@ -71,9 +74,11 @@ Iris also stops counting the tasks is a run that ended, not an incident. A run t
 nothing at all is left to `TrainingProgressStalled`, which allows the full initialization budget
 before it fires — that is the "Levanter never started" case, not a lost telemetry path.
 
-Every other check needs a fresh training phase from the run itself. An initializing run has
-published none of these metrics, a finished one leaves its last samples behind for a while, and a
-silent one is `TrainingTelemetryGone`'s, so none of the three announces. `iris_state_stale` also
+Every other check needs the run's own phase telemetry to be fresh and to report training. An
+initializing attempt has published none of these metrics, a finished one leaves its last samples
+behind for a while, and a silent one is `TrainingTelemetryGone`'s, so none of the three announces —
+including `task_retried`, so a gang that bounces before training starts stays quiet here and shows
+up on the dashboard's retry counter instead. `iris_state_stale` also
 needs a state row that went stale rather than one that never existed: the GCE controllers publish no
 `iris.task_state` rollup at all, and a rollup that breaks leaves its last row readable for an hour.
 An outage longer than that stops being visible here, which is the limit of this check.
@@ -126,9 +131,9 @@ LIMIT 50;
 
 Every threshold and window is a constant at the top of `infra/grafana/src/hero_health.py`, and
 `TELEMETRY_GONE_AGE` is in `infra/grafana/src/hero_runs.py` because the stall rule defers on the
-same number. Changing one takes a redeploy of the Grafana service. Keep the drop and router limits
-equal to the bands `infra/grafana/dashboards/training.json` draws, so the panel an operator opens
-from the alert agrees with the alert.
+same number. Changing one takes a redeploy of the Grafana service. The drop and router limits are
+also drawn as bands by `infra/grafana/dashboards/training.json`; a test asserts the two agree, so
+tuning one without the other fails locally rather than after a deploy.
 
 A benign firing that repeats across runs is the case for changing a constant. One run's stage
 boundary is the case for silencing that run.

--- a/docs/ops/training-stall-alert-contract.md
+++ b/docs/ops/training-stall-alert-contract.md
@@ -15,6 +15,8 @@ An eligible job alerts when either condition holds:
 
 The first case is labeled `training_stalled`; the second is `initializing_stale`. Missing and stale optimizer progress share one label so a delayed sample cannot replace one firing alert instance with another. Finished and progressing jobs emit zero-valued rows, which removes the firing series and resolves its original fingerprint. An idle fleet also emits an explicit zero.
 
+A run whose newest sample of any of these metrics is more than ten minutes old is labeled `telemetry_gone` and emits a zero. Levanter republishes phase every minute, so silence that long is the telemetry path or the process rather than a slow step, and [`TrainingTelemetryGone`](hero-run-health-alerts.md) names it. Deferring keeps one incident to one page. A run that has published nothing at all is still this rule's `initializing_stale` case, which allows the full startup budget.
+
 The bridge derives `hero-20260819` from the root job, then queries the structured `telemetry_v1.run_id` column with exact equality. With concurrent hero runs it emits one `run_id IN (...)` predicate rather than a broad pattern scan. The newest `phase` row in the trailing hour selects one `execution_uid`; `step` and `progress_time_seconds` from older task attempts cannot keep the run healthy. Iris derives `execution_uid` from the controller-minted `attempt_uid`, which stays unique if a new controller uses the same numeric task attempt. Progress spans 30 minutes so a sample remains observable after crossing the 15-minute stall threshold.
 
 Initialization and missing-progress grace start at the later of the current contiguous Iris running interval and the selected telemetry execution. A coordinator restart or trainer retry therefore receives a new initialization window. A hard hang retains its training execution anchor for one hour. All states remain instances of `TrainingProgressStalled`, and notification grouping excludes phase and reason, so later reclassification cannot open a second Slack group.
@@ -45,7 +47,7 @@ LIMIT 20;
 
 For an unsuffixed root, remove `-coord` to get `<hero-run-id>`. For a suffixed root, also remove the retry suffix. An empty result identifies missing Levanter telemetry. The root becomes `initializing_stale` after 45 minutes.
 
-Levanter republishes phase every minute. A current phase row binds progress to one execution. Finelog and telemetry health alerts cover loss of the durable telemetry path. Launcher-specific process watchdogs provide additional coverage where configured.
+Levanter republishes phase every minute. A current phase row binds progress to one execution. [`TrainingTelemetryGone`](hero-run-health-alerts.md) covers loss of the telemetry path for an enrolled run, and the Finelog health alerts cover the durable path itself. Launcher-specific process watchdogs provide additional coverage where configured.
 
 Grafana routes `notification=hero-run` through `ops-critical`. It groups notifications by alert name and logical run. Thus, a new retry root stays in the same alert group. The bridge keys the Slack thread on this group and retains it for six hours after a resolution. A replacement retry that finishes its pending period joins the existing thread. A four-hour repeat notification also keeps the thread active. An idle fleet returns an explicit zero-valued `fleet/idle/healthy` row. The `noDataState: Alerting` state identifies an invalid or unavailable response.
 

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -350,10 +350,11 @@ Three more rules carry the rest of the hero on-call policy, the checks the
 standalone Pushover monitor applies — see
 [the run-health contract](../../docs/ops/hero-run-health-alerts.md).
 `TrainingTelemetryGone` and `TrainingOptimizerUnstable` page on the same
-`notification=hero-run` route: telemetry silent for ten minutes while Iris still
-counts the tasks running, a loss floor a whole unit above its trailing floor that
-the six-sigma band did not catch, a gradient norm above 2, or three skipped steps
-in fifteen minutes. `TrainingRunHealthDegraded` takes the announce-only
+`notification=hero-run` route: telemetry silent for ten minutes, labelled
+`telemetry_gone` while Iris still counts the tasks and `run_down` when it no
+longer does, a loss floor a whole unit above its trailing floor that the
+six-sigma band did not catch, a gradient norm above 2, or three skipped steps in
+fifteen minutes. `TrainingRunHealthDegraded` takes the announce-only
 `notification=slack` exception for token drops, router collapse, a throughput or
 MFU floor, a worse evaluation, a stale `iris.task_state` row, and retries.
 
@@ -362,7 +363,8 @@ Levanter `phase` telemetry reports. The stall and loss rules enroll from
 `iris.task_state` alone, so a break in that path stops them watching a training
 run with no signal that it happened, which is what `iris_state_stale` reports.
 One `telemetry_v1` scan per cache interval feeds all three, reduced over the
-newest execution process zero reports so a retry cannot mix two attempts.
+newest execution process zero reports so a retry cannot mix two attempts; the
+loss-jump check filters its two windows to that execution for the same reason.
 `TrainingProgressStalled` labels a silent run `telemetry_gone` and emits a zero
 rather than firing beside `TrainingTelemetryGone`, so one outage stays one page.
 A warning-only Zephyr rule reads fresh

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -350,28 +350,21 @@ Three more rules carry the rest of the hero on-call policy, the checks the
 standalone Pushover monitor applies — see
 [the run-health contract](../../docs/ops/hero-run-health-alerts.md).
 `TrainingTelemetryGone` and `TrainingOptimizerUnstable` page on the same
-`notification=hero-run` route: a run that published telemetry and then went silent
-for ten minutes while Iris still counts its tasks running, a loss floor a whole
-unit above its trailing floor that the six-sigma band did not already catch, a
-gradient norm above 2 on a run with no clipping, or three skipped steps in
-fifteen minutes. `TrainingRunHealthDegraded` takes the
-announce-only `notification=slack` exception for token drops above 7%, routing
-entropy below 5.92, a router bias past 400, a throughput or MFU floor, a worse
-evaluation, a stale `iris.task_state` row, and controller retries. The split is
-what the on-call policy asks: the first two put the run at risk within the hour,
-the third an operator reads beside the dashboard.
+`notification=hero-run` route: telemetry silent for ten minutes while Iris still
+counts the tasks running, a loss floor a whole unit above its trailing floor that
+the six-sigma band did not catch, a gradient norm above 2, or three skipped steps
+in fifteen minutes. `TrainingRunHealthDegraded` takes the announce-only
+`notification=slack` exception for token drops, router collapse, a throughput or
+MFU floor, a worse evaluation, a stale `iris.task_state` row, and retries.
 
 These three watch a wider enrolment: a run that either the Iris rollup or fresh
-Levanter `phase` telemetry still reports. The stall and loss rules enroll from
+Levanter `phase` telemetry reports. The stall and loss rules enroll from
 `iris.task_state` alone, so a break in that path stops them watching a training
-run with no signal that it happened — which is what `iris_state_stale` reports.
-One scan of `telemetry_v1` per cache interval feeds all three, and a check reads
-the newest sample only while it is under fifteen minutes old, so a restart cannot
-fire from the previous attempt's last value. The throughput checks count how much
-of the window sat below the floor instead of averaging it, which is the median
-comparison the Pushover monitor makes. `TrainingProgressStalled` labels a silent
-run `telemetry_gone` and emits a zero rather than firing beside
-`TrainingTelemetryGone`, so one outage stays one page.
+run with no signal that it happened, which is what `iris_state_stale` reports.
+One `telemetry_v1` scan per cache interval feeds all three, reduced over the
+newest execution process zero reports so a retry cannot mix two attempts.
+`TrainingProgressStalled` labels a silent run `telemetry_gone` and emits a zero
+rather than firing beside `TrainingTelemetryGone`, so one outage stays one page.
 A warning-only Zephyr rule reads fresh
 `progress_time_seconds` rows from `service=zephyr` telemetry. It waits 45 minutes after a
 stage start or shard completion, then remains pending for five minutes. The

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -34,6 +34,9 @@ GET /finelog/marin/fleet_health                  main query probe + k8s mirror r
 GET /finelog/marin/alerts/fleet_health           alert rows: server labels + value(0|1)
 GET /finelog/marin/alerts/training_stalls        active jobs + stalled-progress value(0|1)
 GET /finelog/marin/alerts/loss_spikes            active hero runs + loss-spike value(0|1)
+GET /finelog/marin/alerts/training_telemetry     watched hero runs + silent-telemetry value(0|1)
+GET /finelog/marin/alerts/training_optimizer     watched hero runs + optimizer-fault value(0|1)
+GET /finelog/marin/alerts/training_health        watched hero runs + degraded-signal value(0|1)
 GET /finelog/marin/alerts/zephyr_stalls          active pipelines + stalled-progress value(0|1)
 GET /iris/{cluster}/jobs | workers | health      live controller RPCs
 GET /iris/{cluster}/query?sql=                    ad-hoc SELECT (admin/null-auth)
@@ -174,6 +177,8 @@ is the exception — it returns `reachable=false` so the panel can render the ou
 ```
 src/server.py          the bridge routes (Starlette): finelog SQL, Iris, GitHub, k8s
 src/finelog_source.py  finelog query over its internal IP (LogClient)
+src/hero_runs.py       hero-run enrollment from Iris state and Levanter telemetry
+src/hero_health.py     run-health signal scan and the telemetry/optimizer/health projections
 src/iris_source.py     live controller RPCs: jobs, workers, health, federation peers, ad-hoc query
 src/github_source.py   ferry runs and CI build rollup, precomputed
 src/wandb_source.py    public W&B report runset, and whole-run history for one metric
@@ -317,8 +322,8 @@ redeploy.
 Critical rules notify operators immediately: an unreachable cluster or
 federation peer, a crash-looping watched component, an admission webhook with no ready endpoints, a
 dead production Iris controller, an unhealthy finelog hub or mirror, CoreWeave
-storage above 80 percent of quota, or stalled training or a loss spike on an
-enrolled hero run.
+storage above 80 percent of quota, or stalled training, a loss spike, silent
+telemetry, or an unstable optimizer on an enrolled hero run.
 Warning rules remain in Grafana's home alert list without sending email, Slack,
 or Loom notifications: a degraded component, a GPU pod that stays node-bound and
 nonterminal without finalizers for five minutes after the bridge's two-minute
@@ -340,14 +345,42 @@ window to its floor is what separates a divergence from the single excursion
 skip-step already absorbs. It takes the `notification=hero-run` route as well: a
 hero run diverging unwatched costs more than a false page, which a silence
 answers. Both hero rules share one enrolment query per cache interval.
+
+Three more rules carry the rest of the hero on-call policy, the checks the
+standalone Pushover monitor applies — see
+[the run-health contract](../../docs/ops/hero-run-health-alerts.md).
+`TrainingTelemetryGone` and `TrainingOptimizerUnstable` page on the same
+`notification=hero-run` route: a run that published telemetry and then went silent
+for ten minutes while Iris still counts its tasks running, a loss floor a whole
+unit above its trailing floor that the six-sigma band did not already catch, a
+gradient norm above 2 on a run with no clipping, or three skipped steps in
+fifteen minutes. `TrainingRunHealthDegraded` takes the
+announce-only `notification=slack` exception for token drops above 7%, routing
+entropy below 5.92, a router bias past 400, a throughput or MFU floor, a worse
+evaluation, a stale `iris.task_state` row, and controller retries. The split is
+what the on-call policy asks: the first two put the run at risk within the hour,
+the third an operator reads beside the dashboard.
+
+These three watch a wider enrolment: a run that either the Iris rollup or fresh
+Levanter `phase` telemetry still reports. The stall and loss rules enroll from
+`iris.task_state` alone, so a break in that path stops them watching a training
+run with no signal that it happened — which is what `iris_state_stale` reports.
+One scan of `telemetry_v1` per cache interval feeds all three, and a check reads
+the newest sample only while it is under fifteen minutes old, so a restart cannot
+fire from the previous attempt's last value. The throughput checks count how much
+of the window sat below the floor instead of averaging it, which is the median
+comparison the Pushover monitor makes. `TrainingProgressStalled` labels a silent
+run `telemetry_gone` and emits a zero rather than firing beside
+`TrainingTelemetryGone`, so one outage stays one page.
 A warning-only Zephyr rule reads fresh
 `progress_time_seconds` rows from `service=zephyr` telemetry. It waits 45 minutes after a
 stage start or shard completion, then remains pending for five minutes. The
 execution ID separates concurrent pipelines under one root job. The stuck-pod
 rule groups by node and links the cordon-first
 recovery skill; terminal, unbound, and finalizer-held pods stay dashboard-only.
-The CoreWeave storage-telemetry freshness warning carries the explicit
-`notification=slack` exception, so it announces without launching an ops agent.
+The CoreWeave storage-telemetry freshness warning and `TrainingRunHealthDegraded`
+carry the explicit `notification=slack` exception, so they announce without
+launching an ops agent.
 Other workload-tier signals (gated pods, Kueue backlog, workload crashloops) are
 dashboard panels rather than alert rules because they have expected benign
 causes. `severity=critical` routes to `ops-critical` (email

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -628,18 +628,17 @@ groups:
                 - evaluator: { type: gt, params: [0] }
 
   # Hero run health beyond progress and loss: the telemetry path, the optimizer,
-  # MoE routing, throughput, evaluation, and Iris retries. These rules watch every
-  # run the Iris rollup or Levanter telemetry reports, so an outage on one path
-  # leaves the other path watching. See docs/ops/hero-run-health-alerts.md.
+  # MoE routing, throughput, evaluation, and Iris retries. These watch every run
+  # the Iris rollup or Levanter telemetry reports, so an outage on one path
+  # leaves the other watching. See docs/ops/hero-run-health-alerts.md.
   - orgId: 1
     name: training-health
     folder: Alerts
     interval: 1m
     rules:
-      # A run that published telemetry, then went silent for ten minutes while
-      # Iris still reports its tasks running. Levanter publishes phase every
-      # minute, so this is the telemetry path or the process, not a slow step.
-      # TrainingProgressStalled defers to this rule rather than page again for it.
+      # Silent for ten minutes while Iris still reports the tasks running.
+      # Levanter publishes phase every minute, so this is the telemetry path or
+      # the process. TrainingProgressStalled defers rather than page again.
       - uid: training-telemetry-gone
         title: TrainingTelemetryGone
         condition: C
@@ -682,8 +681,8 @@ groups:
                 - evaluator: { type: gt, params: [0] }
 
       # The optimizer signals that precede a divergence TrainingLossSpike catches
-      # later: a loss floor a whole unit above its trailing floor, a gradient norm
-      # above the band this run has no clipping for, and skipped steps.
+      # later: a loss floor a whole unit above its trailing floor, a gradient
+      # norm above the band this run has no clipping for, and skipped steps.
       - uid: training-optimizer-unstable
         title: TrainingOptimizerUnstable
         condition: C
@@ -725,11 +724,10 @@ groups:
               conditions:
                 - evaluator: { type: gt, params: [0] }
 
-      # Token drops, router collapse, a throughput or MFU floor, an evaluation
-      # that came back worse, a stale Iris state row, and controller retries.
-      # These take the explicit notification=slack exception: an operator reads
-      # them beside the run dashboard, so they announce without opening a triage
-      # session and without waking anyone.
+      # Token drops, router collapse, a throughput or MFU floor, a worse
+      # evaluation, a stale Iris state row, and controller retries. These take
+      # the explicit notification=slack exception: an operator reads them beside
+      # the run dashboard, so they announce without opening a triage session.
       - uid: training-run-health-degraded
         title: TrainingRunHealthDegraded
         condition: C

--- a/infra/grafana/provisioning/alerting/rules.yaml
+++ b/infra/grafana/provisioning/alerting/rules.yaml
@@ -627,6 +627,150 @@ groups:
               conditions:
                 - evaluator: { type: gt, params: [0] }
 
+  # Hero run health beyond progress and loss: the telemetry path, the optimizer,
+  # MoE routing, throughput, evaluation, and Iris retries. These rules watch every
+  # run the Iris rollup or Levanter telemetry reports, so an outage on one path
+  # leaves the other path watching. See docs/ops/hero-run-health-alerts.md.
+  - orgId: 1
+    name: training-health
+    folder: Alerts
+    interval: 1m
+    rules:
+      # A run that published telemetry, then went silent for ten minutes while
+      # Iris still reports its tasks running. Levanter publishes phase every
+      # minute, so this is the telemetry path or the process, not a slow step.
+      # TrainingProgressStalled defers to this rule rather than page again for it.
+      - uid: training-telemetry-gone
+        title: TrainingTelemetryGone
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: critical
+          notification: hero-run
+        annotations:
+          summary: "{{ $labels.cluster }}: {{ $labels.run }} publishes no telemetry while Iris runs its tasks"
+          runbook_url: https://github.com/marin-community/marin/blob/main/docs/ops/hero-run-health-alerts.md
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: finelog-marin
+            model:
+              refId: A
+              datasource: { type: yesoreyeram-infinity-datasource, uid: finelog-marin }
+              type: json
+              source: url
+              parser: backend
+              format: table
+              url: /alerts/training_telemetry
+              url_options: { method: GET }
+              columns:
+                - { selector: cluster, text: cluster, type: string }
+                - { selector: job, text: job, type: string }
+                - { selector: run, text: run, type: string }
+                - { selector: reason, text: reason, type: string }
+                - { selector: value, text: value, type: number }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
+      # The optimizer signals that precede a divergence TrainingLossSpike catches
+      # later: a loss floor a whole unit above its trailing floor, a gradient norm
+      # above the band this run has no clipping for, and skipped steps.
+      - uid: training-optimizer-unstable
+        title: TrainingOptimizerUnstable
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: critical
+          notification: hero-run
+        annotations:
+          summary: "{{ $labels.cluster }}: {{ $labels.run }} optimizer reports {{ $labels.reason }}"
+          runbook_url: https://github.com/marin-community/marin/blob/main/docs/ops/hero-run-health-alerts.md
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: finelog-marin
+            model:
+              refId: A
+              datasource: { type: yesoreyeram-infinity-datasource, uid: finelog-marin }
+              type: json
+              source: url
+              parser: backend
+              format: table
+              url: /alerts/training_optimizer
+              url_options: { method: GET }
+              columns:
+                - { selector: cluster, text: cluster, type: string }
+                - { selector: job, text: job, type: string }
+                - { selector: run, text: run, type: string }
+                - { selector: reason, text: reason, type: string }
+                - { selector: value, text: value, type: number }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
+      # Token drops, router collapse, a throughput or MFU floor, an evaluation
+      # that came back worse, a stale Iris state row, and controller retries.
+      # These take the explicit notification=slack exception: an operator reads
+      # them beside the run dashboard, so they announce without opening a triage
+      # session and without waking anyone.
+      - uid: training-run-health-degraded
+        title: TrainingRunHealthDegraded
+        condition: C
+        for: 5m
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: warning
+          notification: slack
+        annotations:
+          summary: "{{ $labels.cluster }}: {{ $labels.run }} reports {{ $labels.reason }}"
+          runbook_url: https://github.com/marin-community/marin/blob/main/docs/ops/hero-run-health-alerts.md
+        data:
+          - refId: A
+            relativeTimeRange: { from: 300, to: 0 }
+            datasourceUid: finelog-marin
+            model:
+              refId: A
+              datasource: { type: yesoreyeram-infinity-datasource, uid: finelog-marin }
+              type: json
+              source: url
+              parser: backend
+              format: table
+              url: /alerts/training_health
+              url_options: { method: GET }
+              columns:
+                - { selector: cluster, text: cluster, type: string }
+                - { selector: job, text: job, type: string }
+                - { selector: run, text: run, type: string }
+                - { selector: reason, text: reason, type: string }
+                - { selector: value, text: value, type: number }
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              refId: C
+              datasource: { type: __expr__, uid: __expr__ }
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [0] }
+
   # This warning finds an active Zephyr producer that reports no shard
   # completion for 45 minutes. The bridge removes expired producers.
   - orgId: 1

--- a/infra/grafana/src/hero_health.py
+++ b/infra/grafana/src/hero_health.py
@@ -26,6 +26,7 @@ from hero_runs import (
     PHASE_METRIC,
     TASK_STATE_FRESHNESS,
     TELEMETRY_GONE_AGE,
+    TRAINING_PHASE,
     as_number,
     as_utc,
     hero_run_id,
@@ -119,7 +120,15 @@ Signals = dict[tuple[str, str], dict[str, MetricSignal]]
 
 
 def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
-    """Return the newest sample and health-window reductions per run and metric."""
+    """Return the newest sample and health-window reductions per run and metric.
+
+    Everything reduces over one execution: the newest attempt JAX process zero
+    reports. A retry keeps the run ID and takes a new `execution_uid`, so a scan
+    that partitioned on the run alone would sum one attempt's skipped steps into
+    the next and let the predecessor's last gradient norm fire against a fresh
+    phase. Process zero is the stable choice because Levanter publishes tracker
+    metrics only from it.
+    """
     run_predicate = run_id_predicate(runs)
     signal_since = sql_epoch_ms(now - _SIGNAL_LOOKBACK)
     eval_since = sql_epoch_ms(now - _EVAL_LOOKBACK)
@@ -128,14 +137,28 @@ def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
     metric_names = ", ".join(f"'{name}'" for name in _SIGNAL_METRICS)
     below_floor = " OR ".join(f"(name = '{name}' AND value < {floor})" for name, floor in _FLOORS.items())
     return (
-        "WITH samples AS ("
-        "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS origin_cluster, "
-        "run_id, name, value, timestamp_ms, seq "
+        "WITH attempts AS ("
+        "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS origin_cluster, run_id, execution_uid, "
+        "ROW_NUMBER() OVER ("
+        "PARTITION BY COALESCE(NULLIF(cluster,''),'unknown'), run_id "
+        "ORDER BY timestamp_ms DESC, seq DESC"
+        ") AS rn "
         'FROM "telemetry_v1" '
-        f"WHERE service = 'levanter' AND name IN ({metric_names}) "
-        f"AND {run_predicate} "
-        f"AND timestamp_ms >= {eval_since} AND timestamp_ms < {end} "
-        f"AND (name = '{_EVAL_LOSS}' OR timestamp_ms >= {signal_since})"
+        f"WHERE service = 'levanter' AND name = '{PHASE_METRIC}' AND process_index = '0' "
+        f"AND {run_predicate} AND execution_uid IS NOT NULL "
+        f"AND timestamp_ms >= {signal_since} AND timestamp_ms < {end}"
+        "), execution AS ("
+        "SELECT origin_cluster, run_id, execution_uid FROM attempts WHERE rn = 1"
+        "), samples AS ("
+        "SELECT execution.origin_cluster, execution.run_id, "
+        "telemetry.name, telemetry.value, telemetry.timestamp_ms, telemetry.seq "
+        'FROM "telemetry_v1" AS telemetry JOIN execution '
+        "ON COALESCE(NULLIF(telemetry.cluster,''),'unknown') = execution.origin_cluster "
+        "AND telemetry.run_id = execution.run_id "
+        "AND telemetry.execution_uid = execution.execution_uid "
+        f"WHERE telemetry.service = 'levanter' AND telemetry.name IN ({metric_names}) "
+        f"AND telemetry.timestamp_ms >= {eval_since} AND telemetry.timestamp_ms < {end} "
+        f"AND (telemetry.name = '{_EVAL_LOSS}' OR telemetry.timestamp_ms >= {signal_since})"
         "), ranked AS ("
         "SELECT origin_cluster, run_id, name, value, timestamp_ms, "
         "ROW_NUMBER() OVER ("
@@ -286,14 +309,14 @@ def telemetry_alert_rows(runs: tuple[WatchedRun, ...], signals: Signals, now: da
 
 
 def _is_training(metrics: dict[str, MetricSignal], now: datetime) -> bool:
-    """True while the run's own telemetry is fresh and its tracker is not finished.
+    """True while the run's own telemetry is fresh and reports the training phase.
 
-    Nothing below describes a run that is not training right now: an initializing
-    run has published none of it, a finished one leaves its last samples behind
-    for a while, and a silent one is TrainingTelemetryGone's.
+    Nothing below describes a run in another phase. An initializing attempt has
+    published none of these metrics, a finished one leaves its last samples
+    behind for a while, and a silent one is TrainingTelemetryGone's.
     """
     phase = _fresh(metrics.get(PHASE_METRIC), now, TELEMETRY_GONE_AGE)
-    return phase is not None and int(phase.latest) != FINISHED_PHASE
+    return phase is not None and int(phase.latest) == TRAINING_PHASE
 
 
 def optimizer_alert_rows(

--- a/infra/grafana/src/hero_health.py
+++ b/infra/grafana/src/hero_health.py
@@ -3,15 +3,11 @@
 
 """Bounded finelog queries and alert projections for hero-run health.
 
-`TrainingProgressStalled` and `TrainingLossSpike` watch whether a hero run makes
-progress and whether its loss diverges. These projections watch the rest of the
-hero on-call policy: the telemetry path itself, the optimizer, MoE routing,
-throughput, evaluation, and Iris retries. One scan of `telemetry_v1` per bridge
-cache interval feeds all three. See docs/ops/hero-run-health-alerts.md.
-
-The critical projections page. The health projection announces in Slack without
-opening a triage session, which is what the hero on-call policy asks of a signal
-an operator reads rather than acts on within the hour.
+Beyond the progress and loss rules: the telemetry path itself, the optimizer, MoE
+routing, throughput, evaluation, and Iris retries. One `telemetry_v1` scan per
+bridge cache interval feeds all three projections. The telemetry and optimizer
+ones page; the health one announces in Slack without opening a triage session.
+See docs/ops/hero-run-health-alerts.md.
 """
 
 from collections.abc import Callable
@@ -37,8 +33,7 @@ from hero_runs import (
 )
 from loss_spikes import LossWindows, loss_spike_reason, windows_by_run
 
-# Past this the `iris.task_state` rollup no longer enrolls a run, so every hero
-# rule that reads it goes blind.
+# Past this the rollup no longer enrolls a run, so the rules that read it go blind.
 IRIS_STATE_STALE_AGE = timedelta(minutes=5)
 
 LOSS_JUMP = 1.0
@@ -74,18 +69,15 @@ _SIGNAL_METRICS = (
     _MFU,
     _EVAL_LOSS,
 )
-# Metrics whose median the throughput checks read, with the floor each falls below.
+# The floor each throughput check compares its window against.
 _FLOORS = {_TOKENS_PER_SECOND: TOKENS_PER_SECOND_MIN, _MFU: MFU_MIN}
 
 _SIGNAL_LOOKBACK = timedelta(minutes=65)
 # Evaluations are hours apart, so the previous macro loss needs its own window.
 _EVAL_LOOKBACK = timedelta(hours=24)
-# The window the throughput medians and the skipped-step count cover.
 HEALTH_WINDOW = timedelta(minutes=15)
 # Below this a median says more about sampling than about the run.
 _MIN_HEALTH_SAMPLES = 10
-# A restart leaves the previous attempt's last sample behind; only a fresh one is
-# evidence about the run as it is now.
 _LATEST_FRESHNESS = HEALTH_WINDOW
 _EVAL_FRESHNESS = timedelta(minutes=30)
 RETRY_WINDOW = timedelta(minutes=15)
@@ -122,12 +114,10 @@ Signals = dict[tuple[str, str], dict[str, MetricSignal]]
 def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
     """Return the newest sample and health-window reductions per run and metric.
 
-    Everything reduces over one execution: the newest attempt JAX process zero
-    reports. A retry keeps the run ID and takes a new `execution_uid`, so a scan
-    that partitioned on the run alone would sum one attempt's skipped steps into
-    the next and let the predecessor's last gradient norm fire against a fresh
-    phase. Process zero is the stable choice because Levanter publishes tracker
-    metrics only from it.
+    Everything reduces over one execution: the newest attempt process zero
+    reports. A retry keeps the run ID and takes a new `execution_uid`, so
+    partitioning on the run alone would sum one attempt's skipped steps into the
+    next. Process zero because Levanter publishes tracker metrics only from it.
     """
     run_predicate = run_id_predicate(runs)
     signal_since = sql_epoch_ms(now - _SIGNAL_LOOKBACK)
@@ -206,8 +196,8 @@ def retry_event_query(now: datetime) -> str:
 def watched_runs(task_states: pa.Table, phase_runs: pa.Table, now: datetime) -> tuple[WatchedRun, ...]:
     """Return every hero run the Iris rollup or Levanter telemetry still reports.
 
-    Watching the union means an outage on one path does not also silence the
-    checks the other path can still answer.
+    Watching the union means an outage on one path does not silence the checks
+    the other path can still answer.
     """
     now = as_utc(now)
     states: dict[tuple[str, str], tuple[timedelta, bool]] = {}
@@ -279,8 +269,7 @@ def _row(run: WatchedRun | None, reason: str, value: int) -> dict:
 def _project(runs: tuple[WatchedRun, ...], reasons_for: Callable[[WatchedRun], list[str]]) -> list[dict]:
     """Return one row per firing reason, a healthy row per quiet run, and a fleet row.
 
-    Every row carries an explicit value, so a resolved check clears its instance
-    and an empty fleet still answers the rule rather than entering NoData.
+    The explicit zeros clear a resolved instance and keep an empty fleet out of NoData.
     """
     rows = []
     for run in runs:
@@ -297,8 +286,8 @@ def telemetry_alert_rows(runs: tuple[WatchedRun, ...], signals: Signals, now: da
 
     def reasons_for(run: WatchedRun) -> list[str]:
         phase = signals.get((run.cluster, run.run_id), {}).get(PHASE_METRIC)
-        # A run that has published nothing yet is TrainingProgressStalled's
-        # initialization case, which allows the full startup budget.
+        # A run that has published nothing yet is TrainingProgressStalled's, which
+        # allows the full startup budget.
         if phase is None or not isfinite(phase.latest) or int(phase.latest) == FINISHED_PHASE:
             return []
         if now - phase.observed_at <= TELEMETRY_GONE_AGE or not run.iris_running:
@@ -311,9 +300,8 @@ def telemetry_alert_rows(runs: tuple[WatchedRun, ...], signals: Signals, now: da
 def _is_training(metrics: dict[str, MetricSignal], now: datetime) -> bool:
     """True while the run's own telemetry is fresh and reports the training phase.
 
-    Nothing below describes a run in another phase. An initializing attempt has
-    published none of these metrics, a finished one leaves its last samples
-    behind for a while, and a silent one is TrainingTelemetryGone's.
+    An initializing attempt has published none of these metrics, a finished one
+    leaves its last samples behind, and a silent one is TrainingTelemetryGone's.
     """
     phase = _fresh(metrics.get(PHASE_METRIC), now, TELEMETRY_GONE_AGE)
     return phase is not None and int(phase.latest) == TRAINING_PHASE
@@ -347,9 +335,8 @@ def optimizer_alert_rows(
 def _loss_jumped(windows: LossWindows | None) -> bool:
     """True when the recent loss floor sits a whole unit above the trailing floor.
 
-    A run whose own six-sigma band already caught the rise is TrainingLossSpike's,
-    and a run still warming up has no floor worth comparing. What is left is the
-    level shift a wide trailing spread hides, which is what this catches.
+    A rise the six-sigma band already caught is TrainingLossSpike's. What is left
+    is the level shift a wide trailing spread hides.
     """
     if windows is None or loss_spike_reason(windows) != ("healthy", 0):
         return False
@@ -386,9 +373,8 @@ def health_alert_rows(
             reasons.append("mfu_low")
         if _evaluation_regressed(metrics.get(_EVAL_LOSS), now):
             reasons.append("eval_regressed")
-        # A run with no state row at all is on a controller that publishes no
-        # rollup, not one whose rollup broke, and the row it did publish stays
-        # readable for an hour. Both make the absence of a row uninformative.
+        # No row at all means a controller that publishes no rollup (the GCE
+        # clusters), not a rollup that broke.
         if run.iris_state_age is not None and run.iris_state_age > IRIS_STATE_STALE_AGE:
             reasons.append("iris_state_stale")
         if retries.get((run.cluster, run.root_job), 0) > 0:
@@ -422,8 +408,8 @@ def _router_bias_magnitude(metrics: dict[str, MetricSignal], now: datetime) -> f
 def _mostly_below_floor(signal: MetricSignal | None) -> bool:
     """True when most of the health window sat below the metric's floor.
 
-    This is the median comparison the hero monitor makes, expressed as a count so
-    one restart step at zero cannot drag the whole window under the floor.
+    A count rather than a mean, so one restart step at zero cannot drag the
+    window under.
     """
     if signal is None or signal.recent_samples < _MIN_HEALTH_SAMPLES:
         return False

--- a/infra/grafana/src/hero_health.py
+++ b/infra/grafana/src/hero_health.py
@@ -14,19 +14,24 @@ opening a triage session, which is what the hero on-call policy asks of a signal
 an operator reads rather than acts on within the hour.
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from math import isfinite
 
 import pyarrow as pa
 from hero_runs import (
+    FINISHED_PHASE,
     HERO_ROOT_PATTERNS,
+    PHASE_METRIC,
     TASK_STATE_FRESHNESS,
     TELEMETRY_GONE_AGE,
+    as_number,
     as_utc,
     hero_run_id,
     root_job_for,
     run_id_predicate,
+    sql_epoch_ms,
     sql_timestamp,
 )
 from loss_spikes import LossWindows, loss_spike_reason, windows_by_run
@@ -46,7 +51,6 @@ ROUTER_BIAS_MAX = 400.0
 TOKENS_PER_SECOND_MIN = 2.0e6
 MFU_MIN = 15.0
 
-_PHASE = "phase"
 _GRAD_NORM = "grad_norm_total"
 _SKIPPED_STEP = "optim_skipped_step"
 _DROP_FRACTION = "moe_drop_fraction"
@@ -58,7 +62,7 @@ _MFU = "throughput_mfu"
 _EVAL_LOSS = "eval_paloma_macro_loss"
 
 _SIGNAL_METRICS = (
-    _PHASE,
+    PHASE_METRIC,
     _GRAD_NORM,
     _SKIPPED_STEP,
     _DROP_FRACTION,
@@ -86,8 +90,6 @@ _EVAL_FRESHNESS = timedelta(minutes=30)
 RETRY_WINDOW = timedelta(minutes=15)
 
 _RETRY_REASONS = ("TaskRetryScheduled", "CoscheduledSiblingRequeued")
-
-_FINISHED_PHASE = 2
 
 
 @dataclass(frozen=True)
@@ -119,10 +121,10 @@ Signals = dict[tuple[str, str], dict[str, MetricSignal]]
 def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
     """Return the newest sample and health-window reductions per run and metric."""
     run_predicate = run_id_predicate(runs)
-    signal_since = _epoch_ms(now - _SIGNAL_LOOKBACK)
-    eval_since = _epoch_ms(now - _EVAL_LOOKBACK)
-    health_since = _epoch_ms(now - HEALTH_WINDOW)
-    end = _epoch_ms(now)
+    signal_since = sql_epoch_ms(now - _SIGNAL_LOOKBACK)
+    eval_since = sql_epoch_ms(now - _EVAL_LOOKBACK)
+    health_since = sql_epoch_ms(now - HEALTH_WINDOW)
+    end = sql_epoch_ms(now)
     metric_names = ", ".join(f"'{name}'" for name in _SIGNAL_METRICS)
     below_floor = " OR ".join(f"(name = '{name}' AND value < {floor})" for name, floor in _FLOORS.items())
     return (
@@ -178,10 +180,6 @@ def retry_event_query(now: datetime) -> str:
     )
 
 
-def _epoch_ms(at: datetime) -> str:
-    return f"CAST(EXTRACT(EPOCH FROM TIMESTAMP '{sql_timestamp(at)}') * 1000 AS BIGINT)"
-
-
 def watched_runs(task_states: pa.Table, phase_runs: pa.Table, now: datetime) -> tuple[WatchedRun, ...]:
     """Return every hero run the Iris rollup or Levanter telemetry still reports.
 
@@ -228,22 +226,18 @@ def signals_by_run(signal_rows: pa.Table) -> Signals:
     """Fold signal rows into one metric map per run."""
     signals: Signals = {}
     for row in signal_rows.to_pylist():
-        latest = _number(row["latest_value"])
+        latest = as_number(row["latest_value"])
         if latest is None:
             continue
         signals.setdefault((str(row["cluster"]), str(row["run_id"])), {})[str(row["name"])] = MetricSignal(
             latest=latest,
             observed_at=as_utc(row["observed_at"]),
-            previous=_number(row["previous_value"]),
+            previous=as_number(row["previous_value"]),
             recent_samples=int(row["recent_samples"] or 0),
             recent_total=float(row["recent_total"] or 0.0),
             recent_below_floor=int(row["recent_below_floor"] or 0),
         )
     return signals
-
-
-def _number(value: object) -> float | None:
-    return float(value) if isinstance(value, int | float) else None
 
 
 def _fresh(signal: MetricSignal | None, now: datetime, within: timedelta) -> MetricSignal | None:
@@ -259,7 +253,7 @@ def _row(run: WatchedRun | None, reason: str, value: int) -> dict:
     return {"cluster": run.cluster, "job": run.root_job, "run": run.run_id, "reason": reason, "value": value}
 
 
-def _project(runs: tuple[WatchedRun, ...], reasons_for) -> list[dict]:
+def _project(runs: tuple[WatchedRun, ...], reasons_for: Callable[[WatchedRun], list[str]]) -> list[dict]:
     """Return one row per firing reason, a healthy row per quiet run, and a fleet row.
 
     Every row carries an explicit value, so a resolved check clears its instance
@@ -279,10 +273,10 @@ def telemetry_alert_rows(runs: tuple[WatchedRun, ...], signals: Signals, now: da
     now = as_utc(now)
 
     def reasons_for(run: WatchedRun) -> list[str]:
-        phase = signals.get((run.cluster, run.run_id), {}).get(_PHASE)
+        phase = signals.get((run.cluster, run.run_id), {}).get(PHASE_METRIC)
         # A run that has published nothing yet is TrainingProgressStalled's
         # initialization case, which allows the full startup budget.
-        if phase is None or not isfinite(phase.latest) or int(phase.latest) == _FINISHED_PHASE:
+        if phase is None or not isfinite(phase.latest) or int(phase.latest) == FINISHED_PHASE:
             return []
         if now - phase.observed_at <= TELEMETRY_GONE_AGE or not run.iris_running:
             return []
@@ -298,8 +292,8 @@ def _is_training(metrics: dict[str, MetricSignal], now: datetime) -> bool:
     run has published none of it, a finished one leaves its last samples behind
     for a while, and a silent one is TrainingTelemetryGone's.
     """
-    phase = _fresh(metrics.get(_PHASE), now, TELEMETRY_GONE_AGE)
-    return phase is not None and int(phase.latest) != _FINISHED_PHASE
+    phase = _fresh(metrics.get(PHASE_METRIC), now, TELEMETRY_GONE_AGE)
+    return phase is not None and int(phase.latest) != FINISHED_PHASE
 
 
 def optimizer_alert_rows(

--- a/infra/grafana/src/hero_health.py
+++ b/infra/grafana/src/hero_health.py
@@ -1,0 +1,421 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bounded finelog queries and alert projections for hero-run health.
+
+`TrainingProgressStalled` and `TrainingLossSpike` watch whether a hero run makes
+progress and whether its loss diverges. These projections watch the rest of the
+hero on-call policy: the telemetry path itself, the optimizer, MoE routing,
+throughput, evaluation, and Iris retries. One scan of `telemetry_v1` per bridge
+cache interval feeds all three. See docs/ops/hero-run-health-alerts.md.
+
+The critical projections page. The health projection announces in Slack without
+opening a triage session, which is what the hero on-call policy asks of a signal
+an operator reads rather than acts on within the hour.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from math import isfinite
+
+import pyarrow as pa
+from hero_runs import (
+    HERO_ROOT_PATTERNS,
+    TASK_STATE_FRESHNESS,
+    TELEMETRY_GONE_AGE,
+    as_utc,
+    hero_run_id,
+    root_job_for,
+    run_id_predicate,
+    sql_timestamp,
+)
+from loss_spikes import LossWindows, loss_spike_reason, windows_by_run
+
+# Past this the `iris.task_state` rollup no longer enrolls a run, so every hero
+# rule that reads it goes blind.
+IRIS_STATE_STALE_AGE = timedelta(minutes=5)
+
+LOSS_JUMP = 1.0
+GRAD_NORM_MAX = 2.0
+SKIPPED_STEPS_MAX = 3
+# The dashboard band is 7%, above the intermittent 5% spikes a healthy MoE run shows.
+DROP_FRACTION_MAX = 0.07
+# Uniform routing over 384 experts is 5.951; falling entropy is expert collapse.
+ROUTER_ENTROPY_MIN = 5.92
+ROUTER_BIAS_MAX = 400.0
+TOKENS_PER_SECOND_MIN = 2.0e6
+MFU_MIN = 15.0
+
+_PHASE = "phase"
+_GRAD_NORM = "grad_norm_total"
+_SKIPPED_STEP = "optim_skipped_step"
+_DROP_FRACTION = "moe_drop_fraction"
+_ROUTER_ENTROPY = "train_router_routing_entropy_mean"
+_ROUTER_BIAS_MAX = "train_router_bias_max"
+_ROUTER_BIAS_MIN = "train_router_bias_min"
+_TOKENS_PER_SECOND = "throughput_tokens_per_second"
+_MFU = "throughput_mfu"
+_EVAL_LOSS = "eval_paloma_macro_loss"
+
+_SIGNAL_METRICS = (
+    _PHASE,
+    _GRAD_NORM,
+    _SKIPPED_STEP,
+    _DROP_FRACTION,
+    _ROUTER_ENTROPY,
+    _ROUTER_BIAS_MAX,
+    _ROUTER_BIAS_MIN,
+    _TOKENS_PER_SECOND,
+    _MFU,
+    _EVAL_LOSS,
+)
+# Metrics whose median the throughput checks read, with the floor each falls below.
+_FLOORS = {_TOKENS_PER_SECOND: TOKENS_PER_SECOND_MIN, _MFU: MFU_MIN}
+
+_SIGNAL_LOOKBACK = timedelta(minutes=65)
+# Evaluations are hours apart, so the previous macro loss needs its own window.
+_EVAL_LOOKBACK = timedelta(hours=24)
+# The window the throughput medians and the skipped-step count cover.
+HEALTH_WINDOW = timedelta(minutes=15)
+# Below this a median says more about sampling than about the run.
+_MIN_HEALTH_SAMPLES = 10
+# A restart leaves the previous attempt's last sample behind; only a fresh one is
+# evidence about the run as it is now.
+_LATEST_FRESHNESS = HEALTH_WINDOW
+_EVAL_FRESHNESS = timedelta(minutes=30)
+RETRY_WINDOW = timedelta(minutes=15)
+
+_RETRY_REASONS = ("TaskRetryScheduled", "CoscheduledSiblingRequeued")
+
+_FINISHED_PHASE = 2
+
+
+@dataclass(frozen=True)
+class WatchedRun:
+    """One hero run watched from the Iris side, the telemetry side, or both."""
+
+    cluster: str
+    root_job: str
+    run_id: str
+    iris_running: bool
+    iris_state_age: timedelta | None
+
+
+@dataclass(frozen=True)
+class MetricSignal:
+    """One metric's newest sample and the reductions the health window needs."""
+
+    latest: float
+    observed_at: datetime
+    previous: float | None
+    recent_samples: int
+    recent_total: float
+    recent_below_floor: int
+
+
+Signals = dict[tuple[str, str], dict[str, MetricSignal]]
+
+
+def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
+    """Return the newest sample and health-window reductions per run and metric."""
+    run_predicate = run_id_predicate(runs)
+    signal_since = _epoch_ms(now - _SIGNAL_LOOKBACK)
+    eval_since = _epoch_ms(now - _EVAL_LOOKBACK)
+    health_since = _epoch_ms(now - HEALTH_WINDOW)
+    end = _epoch_ms(now)
+    metric_names = ", ".join(f"'{name}'" for name in _SIGNAL_METRICS)
+    below_floor = " OR ".join(f"(name = '{name}' AND value < {floor})" for name, floor in _FLOORS.items())
+    return (
+        "WITH samples AS ("
+        "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS origin_cluster, "
+        "run_id, name, value, timestamp_ms, seq "
+        'FROM "telemetry_v1" '
+        f"WHERE service = 'levanter' AND name IN ({metric_names}) "
+        f"AND {run_predicate} "
+        f"AND timestamp_ms >= {eval_since} AND timestamp_ms < {end} "
+        f"AND (name = '{_EVAL_LOSS}' OR timestamp_ms >= {signal_since})"
+        "), ranked AS ("
+        "SELECT origin_cluster, run_id, name, value, timestamp_ms, "
+        "ROW_NUMBER() OVER ("
+        "PARTITION BY origin_cluster, run_id, name ORDER BY timestamp_ms DESC, seq DESC"
+        ") AS rn FROM samples"
+        "), newest AS ("
+        "SELECT origin_cluster, run_id, name, "
+        "MAX(CASE WHEN rn = 1 THEN value END) AS latest_value, "
+        "MAX(CASE WHEN rn = 1 THEN timestamp_ms END) AS latest_at, "
+        "MAX(CASE WHEN rn = 2 THEN value END) AS previous_value "
+        "FROM ranked WHERE rn <= 2 GROUP BY origin_cluster, run_id, name"
+        "), health_window AS ("
+        "SELECT origin_cluster, run_id, name, COUNT(*) AS recent_samples, "
+        "SUM(value) AS recent_total, "
+        f"SUM(CASE WHEN {below_floor} THEN 1 ELSE 0 END) AS recent_below_floor "
+        f"FROM samples WHERE timestamp_ms >= {health_since} "
+        "GROUP BY origin_cluster, run_id, name"
+        ") "
+        "SELECT newest.origin_cluster AS cluster, newest.run_id, newest.name, "
+        "newest.latest_value, to_timestamp_millis(newest.latest_at) AS observed_at, "
+        "newest.previous_value, "
+        "COALESCE(health_window.recent_samples, 0) AS recent_samples, "
+        "COALESCE(health_window.recent_total, 0) AS recent_total, "
+        "COALESCE(health_window.recent_below_floor, 0) AS recent_below_floor "
+        "FROM newest LEFT JOIN health_window "
+        "ON health_window.origin_cluster = newest.origin_cluster "
+        "AND health_window.run_id = newest.run_id AND health_window.name = newest.name"
+    )
+
+
+def retry_event_query(now: datetime) -> str:
+    """Return the controller's recent decisions to retry or requeue a hero task."""
+    start = sql_timestamp(now - RETRY_WINDOW)
+    end = sql_timestamp(now)
+    reasons = ", ".join(f"'{reason}'" for reason in _RETRY_REASONS)
+    hero_tasks = " OR ".join(f"task_id LIKE '{pattern}/%'" for pattern in HERO_ROOT_PATTERNS)
+    return (
+        "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS cluster, task_id "
+        'FROM "iris.task_event" '
+        f"WHERE reason IN ({reasons}) AND ({hero_tasks}) "
+        f"AND ts >= TIMESTAMP '{start}' AND ts < TIMESTAMP '{end}'"
+    )
+
+
+def _epoch_ms(at: datetime) -> str:
+    return f"CAST(EXTRACT(EPOCH FROM TIMESTAMP '{sql_timestamp(at)}') * 1000 AS BIGINT)"
+
+
+def watched_runs(task_states: pa.Table, phase_runs: pa.Table, now: datetime) -> tuple[WatchedRun, ...]:
+    """Return every hero run the Iris rollup or Levanter telemetry still reports.
+
+    Watching the union means an outage on one path does not also silence the
+    checks the other path can still answer.
+    """
+    now = as_utc(now)
+    states: dict[tuple[str, str], tuple[timedelta, bool]] = {}
+    for row in task_states.to_pylist():
+        root_job = str(row["job"])
+        if hero_run_id(root_job) is None:
+            continue
+        age = now - as_utc(row["state_at"])
+        states[(str(row["cluster"]), root_job)] = (age, int(row["running"] or 0) > 0)
+
+    enrolled = [key for key, (age, running) in states.items() if running and age <= TASK_STATE_FRESHNESS]
+    for row in phase_runs.to_pylist():
+        root_job = root_job_for(str(row["telemetry_job"]))
+        if root_job is None:
+            continue
+        key = (str(row["cluster"]), root_job)
+        if key not in enrolled:
+            enrolled.append(key)
+
+    runs = []
+    for cluster, root_job in enrolled:
+        run_id = hero_run_id(root_job)
+        if run_id is None:
+            continue
+        age, running = states.get((cluster, root_job), (None, False))
+        runs.append(
+            WatchedRun(
+                cluster=cluster,
+                root_job=root_job,
+                run_id=run_id,
+                iris_running=running and age is not None and age <= TASK_STATE_FRESHNESS,
+                iris_state_age=age,
+            )
+        )
+    return tuple(runs)
+
+
+def signals_by_run(signal_rows: pa.Table) -> Signals:
+    """Fold signal rows into one metric map per run."""
+    signals: Signals = {}
+    for row in signal_rows.to_pylist():
+        latest = _number(row["latest_value"])
+        if latest is None:
+            continue
+        signals.setdefault((str(row["cluster"]), str(row["run_id"])), {})[str(row["name"])] = MetricSignal(
+            latest=latest,
+            observed_at=as_utc(row["observed_at"]),
+            previous=_number(row["previous_value"]),
+            recent_samples=int(row["recent_samples"] or 0),
+            recent_total=float(row["recent_total"] or 0.0),
+            recent_below_floor=int(row["recent_below_floor"] or 0),
+        )
+    return signals
+
+
+def _number(value: object) -> float | None:
+    return float(value) if isinstance(value, int | float) else None
+
+
+def _fresh(signal: MetricSignal | None, now: datetime, within: timedelta) -> MetricSignal | None:
+    """Return the signal only when its newest sample still describes the run now."""
+    if signal is None or not isfinite(signal.latest) or now - signal.observed_at > within:
+        return None
+    return signal
+
+
+def _row(run: WatchedRun | None, reason: str, value: int) -> dict:
+    if run is None:
+        return {"cluster": "fleet", "job": "", "run": "", "reason": reason, "value": value}
+    return {"cluster": run.cluster, "job": run.root_job, "run": run.run_id, "reason": reason, "value": value}
+
+
+def _project(runs: tuple[WatchedRun, ...], reasons_for) -> list[dict]:
+    """Return one row per firing reason, a healthy row per quiet run, and a fleet row.
+
+    Every row carries an explicit value, so a resolved check clears its instance
+    and an empty fleet still answers the rule rather than entering NoData.
+    """
+    rows = []
+    for run in runs:
+        firing = reasons_for(run)
+        rows.extend(_row(run, reason, 1) for reason in firing)
+        if not firing:
+            rows.append(_row(run, "healthy", 0))
+    return rows or [_row(None, "healthy", 0)]
+
+
+def telemetry_alert_rows(runs: tuple[WatchedRun, ...], signals: Signals, now: datetime) -> list[dict]:
+    """Project runs that published telemetry and then went silent while Iris ran them."""
+    now = as_utc(now)
+
+    def reasons_for(run: WatchedRun) -> list[str]:
+        phase = signals.get((run.cluster, run.run_id), {}).get(_PHASE)
+        # A run that has published nothing yet is TrainingProgressStalled's
+        # initialization case, which allows the full startup budget.
+        if phase is None or not isfinite(phase.latest) or int(phase.latest) == _FINISHED_PHASE:
+            return []
+        if now - phase.observed_at <= TELEMETRY_GONE_AGE or not run.iris_running:
+            return []
+        return ["telemetry_gone"]
+
+    return _project(runs, reasons_for)
+
+
+def _is_training(metrics: dict[str, MetricSignal], now: datetime) -> bool:
+    """True while the run's own telemetry is fresh and its tracker is not finished.
+
+    Nothing below describes a run that is not training right now: an initializing
+    run has published none of it, a finished one leaves its last samples behind
+    for a while, and a silent one is TrainingTelemetryGone's.
+    """
+    phase = _fresh(metrics.get(_PHASE), now, TELEMETRY_GONE_AGE)
+    return phase is not None and int(phase.latest) != _FINISHED_PHASE
+
+
+def optimizer_alert_rows(
+    runs: tuple[WatchedRun, ...], signals: Signals, loss_windows: pa.Table, now: datetime
+) -> list[dict]:
+    """Project the optimizer signals that precede a divergence the loss rule catches later."""
+    now = as_utc(now)
+    windows = windows_by_run(loss_windows)
+
+    def reasons_for(run: WatchedRun) -> list[str]:
+        metrics = signals.get((run.cluster, run.run_id), {})
+        if not _is_training(metrics, now):
+            return []
+        reasons = []
+        if _loss_jumped(windows.get((run.cluster, run.run_id))):
+            reasons.append("loss_jump")
+        grad_norm = _fresh(metrics.get(_GRAD_NORM), now, _LATEST_FRESHNESS)
+        if grad_norm is not None and grad_norm.latest > GRAD_NORM_MAX:
+            reasons.append("grad_norm_high")
+        skipped = metrics.get(_SKIPPED_STEP)
+        if skipped is not None and skipped.recent_total >= SKIPPED_STEPS_MAX:
+            reasons.append("steps_skipped")
+        return reasons
+
+    return _project(runs, reasons_for)
+
+
+def _loss_jumped(windows: LossWindows | None) -> bool:
+    """True when the recent loss floor sits a whole unit above the trailing floor.
+
+    A run whose own six-sigma band already caught the rise is TrainingLossSpike's,
+    and a run still warming up has no floor worth comparing. What is left is the
+    level shift a wide trailing spread hides, which is what this catches.
+    """
+    if windows is None or loss_spike_reason(windows) != ("healthy", 0):
+        return False
+    if windows.baseline_floor is None or windows.recent_floor is None:
+        return False
+    if not isfinite(windows.baseline_floor) or not isfinite(windows.recent_floor):
+        return False
+    return windows.recent_floor - windows.baseline_floor > LOSS_JUMP
+
+
+def health_alert_rows(
+    runs: tuple[WatchedRun, ...], signals: Signals, retry_events: pa.Table, now: datetime
+) -> list[dict]:
+    """Project the routing, throughput, evaluation, and Iris signals an operator reads."""
+    now = as_utc(now)
+    retries = _retries_by_root(retry_events)
+
+    def reasons_for(run: WatchedRun) -> list[str]:
+        metrics = signals.get((run.cluster, run.run_id), {})
+        if not _is_training(metrics, now):
+            return []
+        reasons = []
+        drops = _fresh(metrics.get(_DROP_FRACTION), now, _LATEST_FRESHNESS)
+        if drops is not None and drops.latest > DROP_FRACTION_MAX:
+            reasons.append("token_drops")
+        entropy = _fresh(metrics.get(_ROUTER_ENTROPY), now, _LATEST_FRESHNESS)
+        if entropy is not None and entropy.latest < ROUTER_ENTROPY_MIN:
+            reasons.append("router_entropy")
+        if _router_bias_magnitude(metrics, now) > ROUTER_BIAS_MAX:
+            reasons.append("router_bias")
+        if _mostly_below_floor(metrics.get(_TOKENS_PER_SECOND)):
+            reasons.append("throughput_low")
+        if _mostly_below_floor(metrics.get(_MFU)):
+            reasons.append("mfu_low")
+        if _evaluation_regressed(metrics.get(_EVAL_LOSS), now):
+            reasons.append("eval_regressed")
+        # A run with no state row at all is on a controller that publishes no
+        # rollup, not one whose rollup broke, and the row it did publish stays
+        # readable for an hour. Both make the absence of a row uninformative.
+        if run.iris_state_age is not None and run.iris_state_age > IRIS_STATE_STALE_AGE:
+            reasons.append("iris_state_stale")
+        if retries.get((run.cluster, run.root_job), 0) > 0:
+            reasons.append("task_retried")
+        return reasons
+
+    return _project(runs, reasons_for)
+
+
+def _retries_by_root(retry_events: pa.Table) -> dict[tuple[str, str], int]:
+    counts: dict[tuple[str, str], int] = {}
+    for row in retry_events.to_pylist():
+        root_job = root_job_for(str(row["task_id"]))
+        if root_job is None:
+            continue
+        key = (str(row["cluster"]), root_job)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def _router_bias_magnitude(metrics: dict[str, MetricSignal], now: datetime) -> float:
+    """Return how far the router's per-expert bias has travelled from zero."""
+    bounds = [
+        signal.latest
+        for name in (_ROUTER_BIAS_MAX, _ROUTER_BIAS_MIN)
+        if (signal := _fresh(metrics.get(name), now, _LATEST_FRESHNESS)) is not None
+    ]
+    return max((abs(bound) for bound in bounds), default=0.0)
+
+
+def _mostly_below_floor(signal: MetricSignal | None) -> bool:
+    """True when most of the health window sat below the metric's floor.
+
+    This is the median comparison the hero monitor makes, expressed as a count so
+    one restart step at zero cannot drag the whole window under the floor.
+    """
+    if signal is None or signal.recent_samples < _MIN_HEALTH_SAMPLES:
+        return False
+    return signal.recent_below_floor * 2 > signal.recent_samples
+
+
+def _evaluation_regressed(signal: MetricSignal | None, now: datetime) -> bool:
+    """True when the newest evaluation is worse than the one before it."""
+    signal = _fresh(signal, now, _EVAL_FRESHNESS)
+    if signal is None or signal.previous is None or not isfinite(signal.previous):
+        return False
+    return signal.latest > signal.previous

--- a/infra/grafana/src/hero_health.py
+++ b/infra/grafana/src/hero_health.py
@@ -108,7 +108,15 @@ class MetricSignal:
     recent_below_floor: int
 
 
-Signals = dict[tuple[str, str], dict[str, MetricSignal]]
+@dataclass(frozen=True)
+class RunSignals:
+    """One run's metrics and the execution every reduction covers."""
+
+    execution_uid: str
+    metrics: dict[str, MetricSignal]
+
+
+Signals = dict[tuple[str, str], RunSignals]
 
 
 def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
@@ -140,7 +148,7 @@ def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
         "), execution AS ("
         "SELECT origin_cluster, run_id, execution_uid FROM attempts WHERE rn = 1"
         "), samples AS ("
-        "SELECT execution.origin_cluster, execution.run_id, "
+        "SELECT execution.origin_cluster, execution.run_id, execution.execution_uid, "
         "telemetry.name, telemetry.value, telemetry.timestamp_ms, telemetry.seq "
         'FROM "telemetry_v1" AS telemetry JOIN execution '
         "ON COALESCE(NULLIF(telemetry.cluster,''),'unknown') = execution.origin_cluster "
@@ -150,16 +158,16 @@ def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
         f"AND telemetry.timestamp_ms >= {eval_since} AND telemetry.timestamp_ms < {end} "
         f"AND (telemetry.name = '{_EVAL_LOSS}' OR telemetry.timestamp_ms >= {signal_since})"
         "), ranked AS ("
-        "SELECT origin_cluster, run_id, name, value, timestamp_ms, "
+        "SELECT origin_cluster, run_id, execution_uid, name, value, timestamp_ms, "
         "ROW_NUMBER() OVER ("
         "PARTITION BY origin_cluster, run_id, name ORDER BY timestamp_ms DESC, seq DESC"
         ") AS rn FROM samples"
         "), newest AS ("
-        "SELECT origin_cluster, run_id, name, "
+        "SELECT origin_cluster, run_id, execution_uid, name, "
         "MAX(CASE WHEN rn = 1 THEN value END) AS latest_value, "
         "MAX(CASE WHEN rn = 1 THEN timestamp_ms END) AS latest_at, "
         "MAX(CASE WHEN rn = 2 THEN value END) AS previous_value "
-        "FROM ranked WHERE rn <= 2 GROUP BY origin_cluster, run_id, name"
+        "FROM ranked WHERE rn <= 2 GROUP BY origin_cluster, run_id, execution_uid, name"
         "), health_window AS ("
         "SELECT origin_cluster, run_id, name, COUNT(*) AS recent_samples, "
         "SUM(value) AS recent_total, "
@@ -167,7 +175,7 @@ def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
         f"FROM samples WHERE timestamp_ms >= {health_since} "
         "GROUP BY origin_cluster, run_id, name"
         ") "
-        "SELECT newest.origin_cluster AS cluster, newest.run_id, newest.name, "
+        "SELECT newest.origin_cluster AS cluster, newest.run_id, newest.execution_uid, newest.name, "
         "newest.latest_value, to_timestamp_millis(newest.latest_at) AS observed_at, "
         "newest.previous_value, "
         "COALESCE(health_window.recent_samples, 0) AS recent_samples, "
@@ -242,7 +250,9 @@ def signals_by_run(signal_rows: pa.Table) -> Signals:
         latest = as_number(row["latest_value"])
         if latest is None:
             continue
-        signals.setdefault((str(row["cluster"]), str(row["run_id"])), {})[str(row["name"])] = MetricSignal(
+        key = (str(row["cluster"]), str(row["run_id"]))
+        run = signals.setdefault(key, RunSignals(execution_uid=str(row["execution_uid"]), metrics={}))
+        run.metrics[str(row["name"])] = MetricSignal(
             latest=latest,
             observed_at=as_utc(row["observed_at"]),
             previous=as_number(row["previous_value"]),
@@ -251,6 +261,11 @@ def signals_by_run(signal_rows: pa.Table) -> Signals:
             recent_below_floor=int(row["recent_below_floor"] or 0),
         )
     return signals
+
+
+def selected_executions(signals: Signals) -> tuple[str, ...]:
+    """The execution UIDs the signal scan selected, for a query that must match them."""
+    return tuple(sorted({run.execution_uid for run in signals.values()}))
 
 
 def _fresh(signal: MetricSignal | None, now: datetime, within: timedelta) -> MetricSignal | None:
@@ -281,20 +296,30 @@ def _project(runs: tuple[WatchedRun, ...], reasons_for: Callable[[WatchedRun], l
 
 
 def telemetry_alert_rows(runs: tuple[WatchedRun, ...], signals: Signals, now: datetime) -> list[dict]:
-    """Project runs that published telemetry and then went silent while Iris ran them."""
+    """Project runs that published telemetry and then went silent.
+
+    The reason separates the two causes an operator acts on differently: Iris
+    still counting the tasks points at the telemetry path or a wedged process,
+    while Iris no longer counting them points at a job that exited.
+    """
     now = as_utc(now)
 
     def reasons_for(run: WatchedRun) -> list[str]:
-        phase = signals.get((run.cluster, run.run_id), {}).get(PHASE_METRIC)
+        phase = _metrics(signals, run).get(PHASE_METRIC)
         # A run that has published nothing yet is TrainingProgressStalled's, which
-        # allows the full startup budget.
+        # allows the full startup budget. A finished tracker ended on purpose.
         if phase is None or not isfinite(phase.latest) or int(phase.latest) == FINISHED_PHASE:
             return []
-        if now - phase.observed_at <= TELEMETRY_GONE_AGE or not run.iris_running:
+        if now - phase.observed_at <= TELEMETRY_GONE_AGE:
             return []
-        return ["telemetry_gone"]
+        return ["telemetry_gone" if run.iris_running else "run_down"]
 
     return _project(runs, reasons_for)
+
+
+def _metrics(signals: Signals, run: WatchedRun) -> dict[str, MetricSignal]:
+    found = signals.get((run.cluster, run.run_id))
+    return found.metrics if found is not None else {}
 
 
 def _is_training(metrics: dict[str, MetricSignal], now: datetime) -> bool:
@@ -315,7 +340,7 @@ def optimizer_alert_rows(
     windows = windows_by_run(loss_windows)
 
     def reasons_for(run: WatchedRun) -> list[str]:
-        metrics = signals.get((run.cluster, run.run_id), {})
+        metrics = _metrics(signals, run)
         if not _is_training(metrics, now):
             return []
         reasons = []
@@ -355,7 +380,7 @@ def health_alert_rows(
     retries = _retries_by_root(retry_events)
 
     def reasons_for(run: WatchedRun) -> list[str]:
-        metrics = signals.get((run.cluster, run.run_id), {})
+        metrics = _metrics(signals, run)
         if not _is_training(metrics, now):
             return []
         reasons = []

--- a/infra/grafana/src/hero_health.py
+++ b/infra/grafana/src/hero_health.py
@@ -17,7 +17,6 @@ from math import isfinite
 
 import pyarrow as pa
 from hero_runs import (
-    FINISHED_PHASE,
     HERO_ROOT_PATTERNS,
     PHASE_METRIC,
     TASK_STATE_FRESHNESS,
@@ -73,8 +72,10 @@ _SIGNAL_METRICS = (
 _FLOORS = {_TOKENS_PER_SECOND: TOKENS_PER_SECOND_MIN, _MFU: MFU_MIN}
 
 _SIGNAL_LOOKBACK = timedelta(minutes=65)
-# Evaluations are hours apart, so the previous macro loss needs its own window.
-_EVAL_LOOKBACK = timedelta(hours=24)
+# The phase heartbeat and the evaluations need their own window: an outage is
+# measured from the last heartbeat however long ago it was, and evaluations are
+# hours apart. Both are one row at a time, so the wider scan stays cheap.
+_LIVENESS_LOOKBACK = timedelta(hours=24)
 HEALTH_WINDOW = timedelta(minutes=15)
 # Below this a median says more about sampling than about the run.
 _MIN_HEALTH_SAMPLES = 10
@@ -129,7 +130,7 @@ def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
     """
     run_predicate = run_id_predicate(runs)
     signal_since = sql_epoch_ms(now - _SIGNAL_LOOKBACK)
-    eval_since = sql_epoch_ms(now - _EVAL_LOOKBACK)
+    liveness_since = sql_epoch_ms(now - _LIVENESS_LOOKBACK)
     health_since = sql_epoch_ms(now - HEALTH_WINDOW)
     end = sql_epoch_ms(now)
     metric_names = ", ".join(f"'{name}'" for name in _SIGNAL_METRICS)
@@ -144,7 +145,7 @@ def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
         'FROM "telemetry_v1" '
         f"WHERE service = 'levanter' AND name = '{PHASE_METRIC}' AND process_index = '0' "
         f"AND {run_predicate} AND execution_uid IS NOT NULL "
-        f"AND timestamp_ms >= {signal_since} AND timestamp_ms < {end}"
+        f"AND timestamp_ms >= {liveness_since} AND timestamp_ms < {end}"
         "), execution AS ("
         "SELECT origin_cluster, run_id, execution_uid FROM attempts WHERE rn = 1"
         "), samples AS ("
@@ -155,8 +156,9 @@ def signal_query(now: datetime, runs: tuple[WatchedRun, ...]) -> str:
         "AND telemetry.run_id = execution.run_id "
         "AND telemetry.execution_uid = execution.execution_uid "
         f"WHERE telemetry.service = 'levanter' AND telemetry.name IN ({metric_names}) "
-        f"AND telemetry.timestamp_ms >= {eval_since} AND telemetry.timestamp_ms < {end} "
-        f"AND (telemetry.name = '{_EVAL_LOSS}' OR telemetry.timestamp_ms >= {signal_since})"
+        f"AND telemetry.timestamp_ms >= {liveness_since} AND telemetry.timestamp_ms < {end} "
+        f"AND (telemetry.name IN ('{PHASE_METRIC}', '{_EVAL_LOSS}') "
+        f"OR telemetry.timestamp_ms >= {signal_since})"
         "), ranked AS ("
         "SELECT origin_cluster, run_id, execution_uid, name, value, timestamp_ms, "
         "ROW_NUMBER() OVER ("
@@ -306,9 +308,13 @@ def telemetry_alert_rows(runs: tuple[WatchedRun, ...], signals: Signals, now: da
 
     def reasons_for(run: WatchedRun) -> list[str]:
         phase = _metrics(signals, run).get(PHASE_METRIC)
-        # A run that has published nothing yet is TrainingProgressStalled's, which
-        # allows the full startup budget. A finished tracker ended on purpose.
-        if phase is None or not isfinite(phase.latest) or int(phase.latest) == FINISHED_PHASE:
+        # Only a run whose last word was that it is training. A finished tracker
+        # ended on purpose, and one that never left initialization is
+        # TrainingProgressStalled's, which allows the full startup budget. That
+        # last case is most of the traffic: `hero-` names a smoke test as often
+        # as a production run, and a smoke test that dies in restore is not an
+        # incident.
+        if phase is None or not isfinite(phase.latest) or int(phase.latest) != TRAINING_PHASE:
             return []
         if now - phase.observed_at <= TELEMETRY_GONE_AGE:
             return []

--- a/infra/grafana/src/hero_runs.py
+++ b/infra/grafana/src/hero_runs.py
@@ -9,10 +9,9 @@ reports a running task. Its last path component is `<run-id>-coord` or
 contract also gives the exact `run_id` in its Levanter telemetry. See
 docs/ops/training-stall-alert-contract.md.
 
-`phase_enrollment_query` is the second, independent path: a run that still
-publishes Levanter `phase` telemetry. The run-health projections watch the union
-of the two, so an outage on either side leaves the other side watching. See
-docs/ops/hero-run-health-alerts.md.
+`phase_enrollment_query` is the second path: a run that still publishes Levanter
+`phase` telemetry. The run-health projections watch the union, so an outage on
+one side leaves the other watching. See docs/ops/hero-run-health-alerts.md.
 """
 
 from collections.abc import Sequence
@@ -26,9 +25,8 @@ from vllm_observability import sql_string
 TASK_STATE_FRESHNESS = timedelta(seconds=90)
 TASK_STATE_LOOKBACK = timedelta(hours=1)
 PHASE_ENROLLMENT_LOOKBACK = timedelta(minutes=15)
-# A run that published telemetry and then went silent this long has lost the
-# telemetry path or the process. `TrainingTelemetryGone` owns that case, and the
-# progress and health projections defer to it rather than page for it again.
+# Silence this long is the telemetry path or the process. `TrainingTelemetryGone`
+# owns that case; the other projections defer rather than page for it again.
 TELEMETRY_GONE_AGE = timedelta(minutes=10)
 
 HERO_RUN_PREFIX = "hero-"
@@ -87,8 +85,7 @@ def task_state_query(now: datetime) -> str:
     """Return the newest root-job state row for every run name that opts into hero alerts.
 
     `active_hero_runs` applies the freshness and running-task filters, so the
-    run-health projections can also read the age of a state row that has gone
-    stale.
+    run-health projections can also read the age of a row that went stale.
     """
     start = sql_timestamp(now - TASK_STATE_LOOKBACK)
     end = sql_timestamp(now)
@@ -157,8 +154,8 @@ def hero_run_id(root_job: str) -> str | None:
 def root_job_for(telemetry_job: str) -> str | None:
     """Return the hero coordinator root that owns a Levanter telemetry job ID.
 
-    Levanter reports the leaf task (`<root>/train`), so the root is its longest
-    prefix that still names a hero run.
+    Levanter reports the leaf task, so the root is the job's longest prefix that
+    still names a hero run.
     """
     parts = telemetry_job.split("/")
     for depth in range(len(parts), 0, -1):

--- a/infra/grafana/src/hero_runs.py
+++ b/infra/grafana/src/hero_runs.py
@@ -24,7 +24,9 @@ from vllm_observability import sql_string
 
 TASK_STATE_FRESHNESS = timedelta(seconds=90)
 TASK_STATE_LOOKBACK = timedelta(hours=1)
-PHASE_ENROLLMENT_LOOKBACK = timedelta(minutes=15)
+# Long enough that a run which goes silent stays watched while
+# `TrainingTelemetryGone` counts out its threshold and pending period.
+PHASE_ENROLLMENT_LOOKBACK = timedelta(minutes=60)
 # Silence this long is the telemetry path or the process. `TrainingTelemetryGone`
 # owns that case; the other projections defer rather than page for it again.
 TELEMETRY_GONE_AGE = timedelta(minutes=10)

--- a/infra/grafana/src/hero_runs.py
+++ b/infra/grafana/src/hero_runs.py
@@ -8,23 +8,44 @@ reports a running task. Its last path component is `<run-id>-coord` or
 `<run-id>-coord-<retry>`, and `<run-id>` begins with `hero-`. This naming
 contract also gives the exact `run_id` in its Levanter telemetry. See
 docs/ops/training-stall-alert-contract.md.
+
+`phase_enrollment_query` is the second, independent path: a run that still
+publishes Levanter `phase` telemetry. The run-health projections watch the union
+of the two, so an outage on either side leaves the other side watching. See
+docs/ops/hero-run-health-alerts.md.
 """
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from typing import Protocol
 
 import pyarrow as pa
 from vllm_observability import sql_string
 
-_TASK_STATE_FRESHNESS = timedelta(seconds=90)
+TASK_STATE_FRESHNESS = timedelta(seconds=90)
 TASK_STATE_LOOKBACK = timedelta(hours=1)
+PHASE_ENROLLMENT_LOOKBACK = timedelta(minutes=15)
+# A run that published telemetry and then went silent this long has lost the
+# telemetry path or the process. `TrainingTelemetryGone` owns that case, and the
+# progress and health projections defer to it rather than page for it again.
+TELEMETRY_GONE_AGE = timedelta(minutes=10)
 
 HERO_RUN_PREFIX = "hero-"
 _COORDINATOR_MARKER = "-coord"
-_HERO_ROOT_PATTERNS = (
+HERO_ROOT_PATTERNS = (
     f"%/{HERO_RUN_PREFIX}%{_COORDINATOR_MARKER}",
     f"%/{HERO_RUN_PREFIX}%{_COORDINATOR_MARKER}-%",
 )
+_PHASE_METRIC = "phase"
+
+
+class RunIdentity(Protocol):
+    """The cluster, root job, and run ID that name one enrolled hero run."""
+
+    cluster: str
+    root_job: str
+    run_id: str
 
 
 @dataclass(frozen=True)
@@ -49,11 +70,15 @@ def as_utc(value: object) -> datetime:
 
 
 def task_state_query(now: datetime) -> str:
-    """Return fresh active root jobs whose run name opts into hero alerts."""
+    """Return the newest root-job state row for every run name that opts into hero alerts.
+
+    `active_hero_runs` applies the freshness and running-task filters, so the
+    run-health projections can also read the age of a state row that has gone
+    stale.
+    """
     start = sql_timestamp(now - TASK_STATE_LOOKBACK)
-    fresh = sql_timestamp(now - _TASK_STATE_FRESHNESS)
     end = sql_timestamp(now)
-    root_predicate = " OR ".join(f"root_job_id LIKE '{pattern}'" for pattern in _HERO_ROOT_PATTERNS)
+    root_predicate = " OR ".join(f"root_job_id LIKE '{pattern}'" for pattern in HERO_ROOT_PATTERNS)
     return (
         "WITH samples AS ("
         "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS cluster, root_job_id, ts, running "
@@ -75,13 +100,38 @@ def task_state_query(now: datetime) -> str:
         ") AS rn "
         "FROM segmented"
         ") "
-        "SELECT cluster, root_job_id AS job, ts AS state_at, running_since "
+        "SELECT cluster, root_job_id AS job, ts AS state_at, running_since, running "
         "FROM history "
-        f"WHERE rn = 1 AND running > 0 AND ts >= TIMESTAMP '{fresh}'"
+        "WHERE rn = 1"
     )
 
 
-def _run_id(root_job: str) -> str | None:
+def phase_enrollment_query(now: datetime) -> str:
+    """Return each hero run that still publishes Levanter phase telemetry."""
+    start = sql_timestamp(now - PHASE_ENROLLMENT_LOOKBACK)
+    end = sql_timestamp(now)
+    return (
+        "WITH samples AS ("
+        "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS origin_cluster, "
+        "run_id, job_id, timestamp_ms, seq "
+        'FROM "telemetry_v1" '
+        f"WHERE service = 'levanter' AND name = '{_PHASE_METRIC}' "
+        f"AND run_id LIKE '{HERO_RUN_PREFIX}%' AND job_id IS NOT NULL "
+        f"AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '{start}') * 1000 AS BIGINT) "
+        f"AND timestamp_ms < CAST(EXTRACT(EPOCH FROM TIMESTAMP '{end}') * 1000 AS BIGINT)"
+        "), ranked AS ("
+        "SELECT origin_cluster, run_id, job_id, "
+        "ROW_NUMBER() OVER ("
+        "PARTITION BY origin_cluster, run_id ORDER BY timestamp_ms DESC, seq DESC"
+        ") AS rn FROM samples"
+        ") "
+        "SELECT origin_cluster AS cluster, run_id, job_id AS telemetry_job "
+        "FROM ranked WHERE rn = 1"
+    )
+
+
+def hero_run_id(root_job: str) -> str | None:
+    """Return the run ID a hero coordinator root job names, or None."""
     root_name = root_job.rsplit("/", 1)[-1]
     run_id, marker, retry = root_name.rpartition(_COORDINATOR_MARKER)
     if not marker or not run_id.startswith(HERO_RUN_PREFIX):
@@ -91,13 +141,28 @@ def _run_id(root_job: str) -> str | None:
     return run_id if run_id != HERO_RUN_PREFIX else None
 
 
-def active_hero_runs(task_states: pa.Table) -> tuple[HeroRun, ...]:
-    """Return structured run identities from task-state selector rows."""
+def root_job_for(telemetry_job: str) -> str | None:
+    """Return the hero coordinator root that owns a Levanter telemetry job ID.
+
+    Levanter reports the leaf task (`<root>/train`), so the root is its longest
+    prefix that still names a hero run.
+    """
+    parts = telemetry_job.split("/")
+    for depth in range(len(parts), 0, -1):
+        candidate = "/".join(parts[:depth])
+        if hero_run_id(candidate) is not None:
+            return candidate
+    return None
+
+
+def active_hero_runs(task_states: pa.Table, now: datetime) -> tuple[HeroRun, ...]:
+    """Return the run identities whose state row is fresh and reports a running task."""
+    fresh = as_utc(now) - TASK_STATE_FRESHNESS
     runs = []
     for row in task_states.to_pylist():
         root_job = str(row["job"])
-        run_id = _run_id(root_job)
-        if run_id is None:
+        run_id = hero_run_id(root_job)
+        if run_id is None or int(row["running"] or 0) <= 0 or as_utc(row["state_at"]) < fresh:
             continue
         runs.append(
             HeroRun(
@@ -110,7 +175,7 @@ def active_hero_runs(task_states: pa.Table) -> tuple[HeroRun, ...]:
     return tuple(runs)
 
 
-def run_id_predicate(runs: tuple[HeroRun, ...]) -> str:
+def run_id_predicate(runs: Sequence[RunIdentity]) -> str:
     """Return an exact-match `run_id` predicate over the enrolled runs."""
     run_ids = sorted({run.run_id for run in runs})
     if not run_ids:

--- a/infra/grafana/src/hero_runs.py
+++ b/infra/grafana/src/hero_runs.py
@@ -37,7 +37,11 @@ HERO_ROOT_PATTERNS = (
     f"%/{HERO_RUN_PREFIX}%{_COORDINATOR_MARKER}",
     f"%/{HERO_RUN_PREFIX}%{_COORDINATOR_MARKER}-%",
 )
-_PHASE_METRIC = "phase"
+# Levanter's tracker phase, republished every minute.
+PHASE_METRIC = "phase"
+INITIALIZING_PHASE = 0
+TRAINING_PHASE = 1
+FINISHED_PHASE = 2
 
 
 class RunIdentity(Protocol):
@@ -61,12 +65,22 @@ def sql_timestamp(at: datetime) -> str:
     return at.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S")
 
 
+def sql_epoch_ms(at: datetime) -> str:
+    """Return the epoch-millisecond expression finelog compares `timestamp_ms` against."""
+    return f"CAST(EXTRACT(EPOCH FROM TIMESTAMP '{sql_timestamp(at)}') * 1000 AS BIGINT)"
+
+
 def as_utc(value: object) -> datetime:
     if not isinstance(value, datetime):
         raise ValueError(f"expected timestamp, got {value!r}")
     if value.tzinfo is None:
         return value.replace(tzinfo=UTC)
     return value.astimezone(UTC)
+
+
+def as_number(value: object) -> float | None:
+    """Return a numeric cell as a float, or None when the reduction came back NULL."""
+    return float(value) if isinstance(value, int | float) else None
 
 
 def task_state_query(now: datetime) -> str:
@@ -108,17 +122,16 @@ def task_state_query(now: datetime) -> str:
 
 def phase_enrollment_query(now: datetime) -> str:
     """Return each hero run that still publishes Levanter phase telemetry."""
-    start = sql_timestamp(now - PHASE_ENROLLMENT_LOOKBACK)
-    end = sql_timestamp(now)
+    start = sql_epoch_ms(now - PHASE_ENROLLMENT_LOOKBACK)
+    end = sql_epoch_ms(now)
     return (
         "WITH samples AS ("
         "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS origin_cluster, "
         "run_id, job_id, timestamp_ms, seq "
         'FROM "telemetry_v1" '
-        f"WHERE service = 'levanter' AND name = '{_PHASE_METRIC}' "
+        f"WHERE service = 'levanter' AND name = '{PHASE_METRIC}' "
         f"AND run_id LIKE '{HERO_RUN_PREFIX}%' AND job_id IS NOT NULL "
-        f"AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '{start}') * 1000 AS BIGINT) "
-        f"AND timestamp_ms < CAST(EXTRACT(EPOCH FROM TIMESTAMP '{end}') * 1000 AS BIGINT)"
+        f"AND timestamp_ms >= {start} AND timestamp_ms < {end}"
         "), ranked AS ("
         "SELECT origin_cluster, run_id, job_id, "
         "ROW_NUMBER() OVER ("

--- a/infra/grafana/src/hero_runs.py
+++ b/infra/grafana/src/hero_runs.py
@@ -128,7 +128,7 @@ def phase_enrollment_query(now: datetime) -> str:
         "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS origin_cluster, "
         "run_id, job_id, timestamp_ms, seq "
         'FROM "telemetry_v1" '
-        f"WHERE service = 'levanter' AND name = '{PHASE_METRIC}' "
+        f"WHERE service = 'levanter' AND name = '{PHASE_METRIC}' AND process_index = '0' "
         f"AND run_id LIKE '{HERO_RUN_PREFIX}%' AND job_id IS NOT NULL "
         f"AND timestamp_ms >= {start} AND timestamp_ms < {end}"
         "), ranked AS ("

--- a/infra/grafana/src/loss_spikes.py
+++ b/infra/grafana/src/loss_spikes.py
@@ -17,6 +17,7 @@ from math import isfinite
 
 import pyarrow as pa
 from hero_runs import HeroRun, RunIdentity, as_number, run_id_predicate, sql_epoch_ms
+from vllm_observability import sql_string
 
 _LOSS_METRIC = "train_loss"
 
@@ -51,9 +52,18 @@ class LossWindows:
     recent_peak: float | None
 
 
-def loss_window_query(now: datetime, runs: Sequence[RunIdentity]) -> str:
-    """Return baseline and recent loss statistics for exact active hero run IDs."""
+def loss_window_query(now: datetime, runs: Sequence[RunIdentity], executions: Sequence[str] = ()) -> str:
+    """Return baseline and recent loss statistics for exact active hero run IDs.
+
+    `executions` narrows both windows to the given attempts. Without it the
+    windows span whatever the run published in the hour, which is what the spike
+    rule compares; a check that reads the two windows against each other needs
+    them to describe one attempt.
+    """
     run_predicate = run_id_predicate(runs)
+    execution_predicate = (
+        f"AND execution_uid IN ({', '.join(sql_string(uid) for uid in executions)}) " if executions else ""
+    )
     start = sql_epoch_ms(now - _BASELINE_LOOKBACK)
     end = sql_epoch_ms(now)
     recent_ms = sql_epoch_ms(now - _RECENT_WINDOW)
@@ -63,6 +73,7 @@ def loss_window_query(now: datetime, runs: Sequence[RunIdentity]) -> str:
         'FROM "telemetry_v1" '
         f"WHERE service = 'levanter' AND name = '{_LOSS_METRIC}' "
         f"AND {run_predicate} "
+        f"{execution_predicate}"
         f"AND timestamp_ms >= {start} AND timestamp_ms < {end}"
         ") "
         "SELECT origin_cluster AS cluster, run_id, "

--- a/infra/grafana/src/loss_spikes.py
+++ b/infra/grafana/src/loss_spikes.py
@@ -10,12 +10,13 @@ has to be above the band, so a single excursion, the case skip-step already
 discards, does not fire.
 """
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from math import isfinite
 
 import pyarrow as pa
-from hero_runs import HeroRun, run_id_predicate, sql_timestamp
+from hero_runs import HeroRun, RunIdentity, run_id_predicate, sql_timestamp
 
 _LOSS_METRIC = "train_loss"
 
@@ -43,13 +44,14 @@ class LossWindows:
     baseline_samples: int
     baseline_loss: float | None
     baseline_stddev: float | None
+    baseline_floor: float | None
     recent_samples: int
     recent_loss: float | None
     recent_floor: float | None
     recent_peak: float | None
 
 
-def loss_window_query(now: datetime, runs: tuple[HeroRun, ...]) -> str:
+def loss_window_query(now: datetime, runs: Sequence[RunIdentity]) -> str:
     """Return baseline and recent loss statistics for exact active hero run IDs."""
     run_predicate = run_id_predicate(runs)
     start = sql_timestamp(now - _BASELINE_LOOKBACK)
@@ -69,6 +71,7 @@ def loss_window_query(now: datetime, runs: tuple[HeroRun, ...]) -> str:
         f"SUM(CASE WHEN timestamp_ms < {recent_ms} THEN 1 ELSE 0 END) AS baseline_samples, "
         f"AVG(CASE WHEN timestamp_ms < {recent_ms} THEN value END) AS baseline_loss, "
         f"STDDEV(CASE WHEN timestamp_ms < {recent_ms} THEN value END) AS baseline_stddev, "
+        f"MIN(CASE WHEN timestamp_ms < {recent_ms} THEN value END) AS baseline_floor, "
         f"SUM(CASE WHEN timestamp_ms >= {recent_ms} THEN 1 ELSE 0 END) AS recent_samples, "
         f"AVG(CASE WHEN timestamp_ms >= {recent_ms} THEN value END) AS recent_loss, "
         f"MIN(CASE WHEN timestamp_ms >= {recent_ms} THEN value END) AS recent_floor, "
@@ -86,7 +89,8 @@ def _diverged(value: float | None) -> bool:
     return value is not None and not isfinite(value)
 
 
-def _windows_by_run(loss_windows: pa.Table) -> dict[tuple[str, str], LossWindows]:
+def windows_by_run(loss_windows: pa.Table) -> dict[tuple[str, str], LossWindows]:
+    """Return each run's loss windows, keyed by cluster and run ID."""
     windows = {}
     for row in loss_windows.to_pylist():
         key = (str(row["cluster"]), str(row["run_id"]))
@@ -94,6 +98,7 @@ def _windows_by_run(loss_windows: pa.Table) -> dict[tuple[str, str], LossWindows
             baseline_samples=int(row["baseline_samples"] or 0),
             baseline_loss=_number(row["baseline_loss"]),
             baseline_stddev=_number(row["baseline_stddev"]),
+            baseline_floor=_number(row["baseline_floor"]),
             recent_samples=int(row["recent_samples"] or 0),
             recent_loss=_number(row["recent_loss"]),
             recent_floor=_number(row["recent_floor"]),
@@ -102,7 +107,7 @@ def _windows_by_run(loss_windows: pa.Table) -> dict[tuple[str, str], LossWindows
     return windows
 
 
-def _classify(windows: LossWindows | None) -> tuple[str, int]:
+def loss_spike_reason(windows: LossWindows | None) -> tuple[str, int]:
     """Return the alert reason and firing value for one run's loss windows."""
     if windows is None:
         return "warming_up", 0
@@ -132,10 +137,10 @@ def _row(cluster: str, job: str, run: str, reason: str, value: int) -> dict:
 
 def loss_spike_alert_rows(runs: tuple[HeroRun, ...], loss_windows: pa.Table) -> list[dict]:
     """Project each enrolled hero run's loss windows into alert rows."""
-    windows = _windows_by_run(loss_windows)
+    windows = windows_by_run(loss_windows)
     rows: list[dict] = []
     for run in runs:
-        reason, value = _classify(windows.get((run.cluster, run.run_id)))
+        reason, value = loss_spike_reason(windows.get((run.cluster, run.run_id)))
         rows.append(_row(run.cluster, run.root_job, run.run_id, reason, value))
     if rows:
         return rows

--- a/infra/grafana/src/loss_spikes.py
+++ b/infra/grafana/src/loss_spikes.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta
 from math import isfinite
 
 import pyarrow as pa
-from hero_runs import HeroRun, RunIdentity, run_id_predicate, sql_timestamp
+from hero_runs import HeroRun, RunIdentity, as_number, run_id_predicate, sql_epoch_ms
 
 _LOSS_METRIC = "train_loss"
 
@@ -54,18 +54,16 @@ class LossWindows:
 def loss_window_query(now: datetime, runs: Sequence[RunIdentity]) -> str:
     """Return baseline and recent loss statistics for exact active hero run IDs."""
     run_predicate = run_id_predicate(runs)
-    start = sql_timestamp(now - _BASELINE_LOOKBACK)
-    recent = sql_timestamp(now - _RECENT_WINDOW)
-    end = sql_timestamp(now)
-    recent_ms = f"CAST(EXTRACT(EPOCH FROM TIMESTAMP '{recent}') * 1000 AS BIGINT)"
+    start = sql_epoch_ms(now - _BASELINE_LOOKBACK)
+    end = sql_epoch_ms(now)
+    recent_ms = sql_epoch_ms(now - _RECENT_WINDOW)
     return (
         "WITH samples AS ("
         "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS origin_cluster, run_id, value, timestamp_ms "
         'FROM "telemetry_v1" '
         f"WHERE service = 'levanter' AND name = '{_LOSS_METRIC}' "
         f"AND {run_predicate} "
-        f"AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '{start}') * 1000 AS BIGINT) "
-        f"AND timestamp_ms < CAST(EXTRACT(EPOCH FROM TIMESTAMP '{end}') * 1000 AS BIGINT)"
+        f"AND timestamp_ms >= {start} AND timestamp_ms < {end}"
         ") "
         "SELECT origin_cluster AS cluster, run_id, "
         f"SUM(CASE WHEN timestamp_ms < {recent_ms} THEN 1 ELSE 0 END) AS baseline_samples, "
@@ -80,10 +78,6 @@ def loss_window_query(now: datetime, runs: Sequence[RunIdentity]) -> str:
     )
 
 
-def _number(value: object) -> float | None:
-    return float(value) if isinstance(value, int | float) else None
-
-
 def _diverged(value: float | None) -> bool:
     """True when a reduction came back NaN or infinite. A missing one has not diverged."""
     return value is not None and not isfinite(value)
@@ -96,13 +90,13 @@ def windows_by_run(loss_windows: pa.Table) -> dict[tuple[str, str], LossWindows]
         key = (str(row["cluster"]), str(row["run_id"]))
         windows[key] = LossWindows(
             baseline_samples=int(row["baseline_samples"] or 0),
-            baseline_loss=_number(row["baseline_loss"]),
-            baseline_stddev=_number(row["baseline_stddev"]),
-            baseline_floor=_number(row["baseline_floor"]),
+            baseline_loss=as_number(row["baseline_loss"]),
+            baseline_stddev=as_number(row["baseline_stddev"]),
+            baseline_floor=as_number(row["baseline_floor"]),
             recent_samples=int(row["recent_samples"] or 0),
-            recent_loss=_number(row["recent_loss"]),
-            recent_floor=_number(row["recent_floor"]),
-            recent_peak=_number(row["recent_peak"]),
+            recent_loss=as_number(row["recent_loss"]),
+            recent_floor=as_number(row["recent_floor"]),
+            recent_peak=as_number(row["recent_peak"]),
         )
     return windows
 

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -96,6 +96,7 @@ from hero_health import (
     health_alert_rows,
     optimizer_alert_rows,
     retry_event_query,
+    selected_executions,
     signal_query,
     signals_by_run,
     telemetry_alert_rows,
@@ -483,15 +484,17 @@ def create_app(
         rows = hero_query("hero_signals", now, target, lambda: signal_query(now, runs))
         return signals_by_run(rows)
 
-    def hero_loss_windows(target: ClusterTarget, now: datetime, runs: Sequence[RunIdentity]) -> pa.Table:
-        """Loss windows for one run set, shared by the spike and optimizer rules."""
+    def hero_loss_windows(
+        target: ClusterTarget, now: datetime, runs: Sequence[RunIdentity], executions: tuple[str, ...] = ()
+    ) -> pa.Table:
+        """Loss windows for one run set, optionally narrowed to the given attempts."""
         run_ids = tuple(sorted({run.run_id for run in runs}))
         if not run_ids:
             return pa.table({})
         source = finelog_sources[target.name]
         return finelog_cache.get_or_compute(
-            ("hero_loss_windows", run_ids, _bucket(now, config.cache_ttl)),
-            lambda: source.query(loss_window_query(now, runs), max_rows=config.max_rows),
+            ("hero_loss_windows", run_ids, executions, _bucket(now, config.cache_ttl)),
+            lambda: source.query(loss_window_query(now, runs, executions), max_rows=config.max_rows),
         )
 
     def finelog_alert_endpoint(name: str, project) -> JSONResponse:
@@ -535,8 +538,11 @@ def create_app(
     def finelog_alerts_training_optimizer(_: Request) -> JSONResponse:
         def project(target: ClusterTarget, now: datetime) -> list[dict]:
             runs = hero_watched_runs(target, now)
-            loss_windows = hero_loss_windows(target, now, runs)
-            return optimizer_alert_rows(runs, hero_signals(target, now, runs), loss_windows, now)
+            signals = hero_signals(target, now, runs)
+            # The loss-jump check reads the two windows against each other, so
+            # both have to describe the attempt the signal scan selected.
+            loss_windows = hero_loss_windows(target, now, runs, selected_executions(signals))
+            return optimizer_alert_rows(runs, signals, loss_windows, now)
 
         return finelog_alert_endpoint("training_optimizer", project)
 

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -17,6 +17,9 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /finelog/marin/alerts/fleet_health       alert rows: server labels + value(0|1)
     GET /finelog/marin/alerts/training_stalls    active jobs + stalled-progress value(0|1)
     GET /finelog/marin/alerts/loss_spikes        active hero runs + loss-spike value(0|1)
+    GET /finelog/marin/alerts/training_telemetry watched hero runs + silent-telemetry value(0|1)
+    GET /finelog/marin/alerts/training_optimizer watched hero runs + optimizer-fault value(0|1)
+    GET /finelog/marin/alerts/training_health    watched hero runs + degraded-signal value(0|1)
     GET /finelog/marin/alerts/zephyr_stalls      active pipelines + stalled-progress value(0|1)
     GET /iris/{cluster}/jobs                     root-job counts by state (in-flight + 24h terminal)
     GET /iris/{cluster}/workers                  healthy worker counts + resource totals per region
@@ -65,7 +68,7 @@ Loom one also exchanges tokens and creates a run over HTTP.
 
 import json
 import logging
-from collections.abc import Hashable, Mapping
+from collections.abc import Hashable, Mapping, Sequence
 from dataclasses import asdict
 from datetime import UTC, datetime
 
@@ -87,7 +90,18 @@ from finelog_health import FinelogHealth
 from finelog_source import FinelogSource, MetricSource
 from github_app import GithubAppAuth
 from github_source import GithubSource
-from hero_runs import HeroRun, active_hero_runs, task_state_query
+from hero_health import (
+    Signals,
+    WatchedRun,
+    health_alert_rows,
+    optimizer_alert_rows,
+    retry_event_query,
+    signal_query,
+    signals_by_run,
+    telemetry_alert_rows,
+    watched_runs,
+)
+from hero_runs import HeroRun, RunIdentity, active_hero_runs, phase_enrollment_query, task_state_query
 from iris_source import IrisSource
 from k8s_source import K8sFleet, K8sSource
 from loom_alerts import (
@@ -441,13 +455,43 @@ def create_app(
         except _BadRequest as err:
             return JSONResponse({"error": str(err)}, status_code=400)
 
-    def hero_runs(target: ClusterTarget, now: datetime) -> tuple[HeroRun, ...]:
-        """Enrolled hero roots, computed once per TTL for every hero alert route."""
-        key = ("hero_runs", _bucket(now, config.cache_ttl))
+    def hero_query(name: str, now: datetime, target: ClusterTarget, sql) -> pa.Table:
+        """Run one hero alert query per cache interval, however many rules read it."""
         source = finelog_sources[target.name]
         return finelog_cache.get_or_compute(
-            key,
-            lambda: active_hero_runs(source.query(task_state_query(now), max_rows=config.max_rows)),
+            (name, _bucket(now, config.cache_ttl)),
+            lambda: source.query(sql(), max_rows=config.max_rows),
+        )
+
+    def hero_task_states(target: ClusterTarget, now: datetime) -> pa.Table:
+        """The newest `iris.task_state` row for every hero root, fresh or stale."""
+        return hero_query("hero_task_states", now, target, lambda: task_state_query(now))
+
+    def hero_runs(target: ClusterTarget, now: datetime) -> tuple[HeroRun, ...]:
+        """Hero roots Iris reports running, for the progress and loss-spike rules."""
+        return active_hero_runs(hero_task_states(target, now), now)
+
+    def hero_watched_runs(target: ClusterTarget, now: datetime) -> tuple[WatchedRun, ...]:
+        """Hero roots either Iris or Levanter still reports, for the run-health rules."""
+        phase_runs = hero_query("hero_phase_enrollment", now, target, lambda: phase_enrollment_query(now))
+        return watched_runs(hero_task_states(target, now), phase_runs, now)
+
+    def hero_signals(target: ClusterTarget, now: datetime, runs: tuple[WatchedRun, ...]) -> Signals:
+        """One telemetry scan behind every run-health rule."""
+        if not runs:
+            return {}
+        rows = hero_query("hero_signals", now, target, lambda: signal_query(now, runs))
+        return signals_by_run(rows)
+
+    def hero_loss_windows(target: ClusterTarget, now: datetime, runs: Sequence[RunIdentity]) -> pa.Table:
+        """Loss windows for one run set, shared by the spike and optimizer rules."""
+        run_ids = tuple(sorted({run.run_id for run in runs}))
+        if not run_ids:
+            return pa.table({})
+        source = finelog_sources[target.name]
+        return finelog_cache.get_or_compute(
+            ("hero_loss_windows", run_ids, _bucket(now, config.cache_ttl)),
+            lambda: source.query(loss_window_query(now, runs), max_rows=config.max_rows),
         )
 
     def finelog_alert_endpoint(name: str, project) -> JSONResponse:
@@ -477,14 +521,34 @@ def create_app(
     def finelog_alerts_loss_spikes(_: Request) -> JSONResponse:
         def project(target: ClusterTarget, now: datetime) -> list[dict]:
             runs = hero_runs(target, now)
-            loss_windows = (
-                finelog_sources[target.name].query(loss_window_query(now, runs), max_rows=config.max_rows)
-                if runs
-                else pa.table({})
-            )
-            return loss_spike_alert_rows(runs, loss_windows)
+            return loss_spike_alert_rows(runs, hero_loss_windows(target, now, runs))
 
         return finelog_alert_endpoint("loss_spikes", project)
+
+    def finelog_alerts_training_telemetry(_: Request) -> JSONResponse:
+        def project(target: ClusterTarget, now: datetime) -> list[dict]:
+            runs = hero_watched_runs(target, now)
+            return telemetry_alert_rows(runs, hero_signals(target, now, runs), now)
+
+        return finelog_alert_endpoint("training_telemetry", project)
+
+    def finelog_alerts_training_optimizer(_: Request) -> JSONResponse:
+        def project(target: ClusterTarget, now: datetime) -> list[dict]:
+            runs = hero_watched_runs(target, now)
+            loss_windows = hero_loss_windows(target, now, runs)
+            return optimizer_alert_rows(runs, hero_signals(target, now, runs), loss_windows, now)
+
+        return finelog_alert_endpoint("training_optimizer", project)
+
+    def finelog_alerts_training_health(_: Request) -> JSONResponse:
+        def project(target: ClusterTarget, now: datetime) -> list[dict]:
+            runs = hero_watched_runs(target, now)
+            retry_events = (
+                hero_query("hero_retry_events", now, target, lambda: retry_event_query(now)) if runs else pa.table({})
+            )
+            return health_alert_rows(runs, hero_signals(target, now, runs), retry_events, now)
+
+        return finelog_alert_endpoint("training_health", project)
 
     def finelog_alerts_zephyr_stalls(_: Request) -> JSONResponse:
         def project(target: ClusterTarget, now: datetime) -> list[dict]:
@@ -722,6 +786,9 @@ def create_app(
             Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/fleet_health", finelog_alerts_fleet_health),
             Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/training_stalls", finelog_alerts_training_stalls),
             Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/loss_spikes", finelog_alerts_loss_spikes),
+            Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/training_telemetry", finelog_alerts_training_telemetry),
+            Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/training_optimizer", finelog_alerts_training_optimizer),
+            Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/training_health", finelog_alerts_training_health),
             Route(f"/finelog/{_FINELOG_HUB_CLUSTER}/alerts/zephyr_stalls", finelog_alerts_zephyr_stalls),
             Route("/iris/{cluster}/jobs", iris_jobs),
             Route("/iris/{cluster}/workers", iris_workers),

--- a/infra/grafana/src/training_stalls.py
+++ b/infra/grafana/src/training_stalls.py
@@ -25,10 +25,11 @@ _TRAINING_STALL_AGE = timedelta(minutes=15)
 _INITIALIZING_STALL_AGE = timedelta(minutes=45)
 _PROGRESS_LOOKBACK = 2 * _TRAINING_STALL_AGE
 _EXECUTION_LOOKBACK = TASK_STATE_LOOKBACK
-# Keep the selected execution visible after its last heartbeat crosses the stall
-# threshold. The exact run predicate and training-status projection keep this
-# bounded scan below Finelog's deadline.
-_ENROLLMENT_LOOKBACK = _EXECUTION_LOOKBACK
+# The phase heartbeat reaches back a day so a run that went silent hours ago is
+# still recognisable as one that stopped publishing, which is TrainingTelemetryGone's
+# case. Without the reach this rule calls a silent training run `initializing_stale`
+# and pages beside it. Phase is one row a minute for one process.
+_PHASE_LOOKBACK = timedelta(hours=24)
 
 _STEP_METRIC = "step"
 _PROGRESS_TIME_METRIC = "progress_time_seconds"
@@ -37,9 +38,9 @@ _PROGRESS_TIME_METRIC = "progress_time_seconds"
 def telemetry_query(now: datetime, runs: tuple[HeroRun, ...]) -> str:
     """Return current execution metrics for exact active hero run IDs."""
     run_predicate = run_id_predicate(runs)
-    execution_since = sql_epoch_ms(now - _EXECUTION_LOOKBACK)
+    phase_since = sql_epoch_ms(now - _PHASE_LOOKBACK)
     progress_since = sql_epoch_ms(now - _PROGRESS_LOOKBACK)
-    enrolled_since = sql_timestamp(now - _ENROLLMENT_LOOKBACK)
+    enrolled_since = sql_timestamp(now - _PHASE_LOOKBACK)
     end = sql_epoch_ms(now)
     metric_names = f"'{PHASE_METRIC}', '{_STEP_METRIC}', '{_PROGRESS_TIME_METRIC}'"
     return (
@@ -51,7 +52,7 @@ def telemetry_query(now: datetime, runs: tuple[HeroRun, ...]) -> str:
         f"WHERE service = 'levanter' AND name IN ({metric_names}) "
         f"AND {run_predicate} "
         "AND job_id IS NOT NULL AND execution_uid IS NOT NULL "
-        f"AND timestamp_ms >= {execution_since} AND timestamp_ms < {end} "
+        f"AND timestamp_ms >= {phase_since} AND timestamp_ms < {end} "
         f"AND (name = '{PHASE_METRIC}' OR timestamp_ms >= {progress_since})"
         "), phase_history AS ("
         "SELECT origin_cluster, run_id, telemetry_job, execution_uid, ts, "

--- a/infra/grafana/src/training_stalls.py
+++ b/infra/grafana/src/training_stalls.py
@@ -7,7 +7,19 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 import pyarrow as pa
-from hero_runs import TASK_STATE_LOOKBACK, TELEMETRY_GONE_AGE, HeroRun, as_utc, run_id_predicate, sql_timestamp
+from hero_runs import (
+    FINISHED_PHASE,
+    INITIALIZING_PHASE,
+    PHASE_METRIC,
+    TASK_STATE_LOOKBACK,
+    TELEMETRY_GONE_AGE,
+    TRAINING_PHASE,
+    HeroRun,
+    as_utc,
+    run_id_predicate,
+    sql_epoch_ms,
+    sql_timestamp,
+)
 
 _TRAINING_STALL_AGE = timedelta(minutes=15)
 _INITIALIZING_STALL_AGE = timedelta(minutes=45)
@@ -20,21 +32,16 @@ _ENROLLMENT_LOOKBACK = _EXECUTION_LOOKBACK
 
 _STEP_METRIC = "step"
 _PROGRESS_TIME_METRIC = "progress_time_seconds"
-_PHASE_METRIC = "phase"
-
-_INITIALIZING_PHASE = 0
-_TRAINING_PHASE = 1
-_FINISHED_PHASE = 2
 
 
 def telemetry_query(now: datetime, runs: tuple[HeroRun, ...]) -> str:
     """Return current execution metrics for exact active hero run IDs."""
     run_predicate = run_id_predicate(runs)
-    execution_since = sql_timestamp(now - _EXECUTION_LOOKBACK)
-    progress_since = sql_timestamp(now - _PROGRESS_LOOKBACK)
+    execution_since = sql_epoch_ms(now - _EXECUTION_LOOKBACK)
+    progress_since = sql_epoch_ms(now - _PROGRESS_LOOKBACK)
     enrolled_since = sql_timestamp(now - _ENROLLMENT_LOOKBACK)
-    end = sql_timestamp(now)
-    metric_names = f"'{_PHASE_METRIC}', '{_STEP_METRIC}', '{_PROGRESS_TIME_METRIC}'"
+    end = sql_epoch_ms(now)
+    metric_names = f"'{PHASE_METRIC}', '{_STEP_METRIC}', '{_PROGRESS_TIME_METRIC}'"
     return (
         "WITH filtered AS ("
         "SELECT COALESCE(NULLIF(cluster,''),'unknown') AS origin_cluster, "
@@ -44,16 +51,14 @@ def telemetry_query(now: datetime, runs: tuple[HeroRun, ...]) -> str:
         f"WHERE service = 'levanter' AND name IN ({metric_names}) "
         f"AND {run_predicate} "
         "AND job_id IS NOT NULL AND execution_uid IS NOT NULL "
-        f"AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '{execution_since}') * 1000 AS BIGINT) "
-        f"AND timestamp_ms < CAST(EXTRACT(EPOCH FROM TIMESTAMP '{end}') * 1000 AS BIGINT) "
-        f"AND (name = '{_PHASE_METRIC}' OR timestamp_ms >= "
-        f"CAST(EXTRACT(EPOCH FROM TIMESTAMP '{progress_since}') * 1000 AS BIGINT))"
+        f"AND timestamp_ms >= {execution_since} AND timestamp_ms < {end} "
+        f"AND (name = '{PHASE_METRIC}' OR timestamp_ms >= {progress_since})"
         "), phase_history AS ("
         "SELECT origin_cluster, run_id, telemetry_job, execution_uid, ts, "
         "ROW_NUMBER() OVER ("
         "PARTITION BY origin_cluster, run_id, telemetry_job ORDER BY timestamp_ms DESC, seq DESC"
         ") AS rn FROM filtered "
-        f"WHERE name = '{_PHASE_METRIC}' AND ts >= TIMESTAMP '{enrolled_since}'"
+        f"WHERE name = '{PHASE_METRIC}' AND ts >= TIMESTAMP '{enrolled_since}'"
         "), enrolled AS ("
         "SELECT origin_cluster, run_id, telemetry_job, execution_uid FROM phase_history WHERE rn = 1"
         "), execution AS ("
@@ -62,7 +67,7 @@ def telemetry_query(now: datetime, runs: tuple[HeroRun, ...]) -> str:
         "ON filtered.origin_cluster = enrolled.origin_cluster AND filtered.run_id = enrolled.run_id "
         "AND filtered.telemetry_job = enrolled.telemetry_job "
         "AND filtered.execution_uid = enrolled.execution_uid "
-        f"WHERE filtered.name = '{_PHASE_METRIC}' "
+        f"WHERE filtered.name = '{PHASE_METRIC}' "
         "GROUP BY enrolled.origin_cluster, enrolled.run_id, enrolled.telemetry_job, enrolled.execution_uid"
         "), recent AS ("
         "SELECT filtered.origin_cluster, filtered.run_id, filtered.telemetry_job, "
@@ -82,9 +87,9 @@ def telemetry_query(now: datetime, runs: tuple[HeroRun, ...]) -> str:
 
 def _phase_name(phase: int | None) -> str:
     return {
-        _INITIALIZING_PHASE: "initializing",
-        _TRAINING_PHASE: "training",
-        _FINISHED_PHASE: "finished",
+        INITIALIZING_PHASE: "initializing",
+        TRAINING_PHASE: "training",
+        FINISHED_PHASE: "finished",
     }.get(phase, "unknown")
 
 
@@ -137,7 +142,7 @@ def _metrics_by_job(runs: tuple[HeroRun, ...], telemetry_metrics: pa.Table) -> d
 def _classify(run: HeroRun, observed: ExecutionMetrics | None, now: datetime) -> tuple[str, str, int]:
     """Return the phase name, alert reason, and firing value for one enrolled root."""
     metrics = observed.metrics if observed is not None else {}
-    raw_phase = metrics.get(_PHASE_METRIC)
+    raw_phase = metrics.get(PHASE_METRIC)
     phase = int(raw_phase) if raw_phase is not None else None
     step = metrics.get(_STEP_METRIC, 0.0)
     progress_time = metrics.get(_PROGRESS_TIME_METRIC, 0.0)
@@ -146,12 +151,12 @@ def _classify(run: HeroRun, observed: ExecutionMetrics | None, now: datetime) ->
 
     reason = "healthy"
     value = 0
-    is_training = phase == _TRAINING_PHASE or step > 0
+    is_training = phase == TRAINING_PHASE or step > 0
     if observed is not None and now - observed.observed_at > TELEMETRY_GONE_AGE:
         # A run that stopped publishing is TrainingTelemetryGone's, which names the
         # failure precisely. Reporting a stall as well would page twice for it.
         reason = "telemetry_gone"
-    elif phase == _FINISHED_PHASE:
+    elif phase == FINISHED_PHASE:
         reason = "finished"
     elif is_training and progress_time > 0:
         progress_age = now - datetime.fromtimestamp(progress_time, tz=UTC)

--- a/infra/grafana/src/training_stalls.py
+++ b/infra/grafana/src/training_stalls.py
@@ -23,6 +23,10 @@ from hero_runs import (
 
 _TRAINING_STALL_AGE = timedelta(minutes=15)
 _INITIALIZING_STALL_AGE = timedelta(minutes=45)
+# Every rank publishes `step` and `phase`, so an unfiltered scan of one hour of
+# the hero run reads about 1.4M rows a minute against the hub for the ~2k that
+# carry the tracker's own view. Process zero is that view, and the same replica
+# the training dashboard selects.
 _PROGRESS_LOOKBACK = 2 * _TRAINING_STALL_AGE
 _EXECUTION_LOOKBACK = TASK_STATE_LOOKBACK
 # The phase heartbeat reaches back a day so a run that went silent hours ago is
@@ -50,7 +54,7 @@ def telemetry_query(now: datetime, runs: tuple[HeroRun, ...]) -> str:
         "timestamp_ms, seq, to_timestamp_millis(timestamp_ms) AS ts "
         'FROM "telemetry_v1" '
         f"WHERE service = 'levanter' AND name IN ({metric_names}) "
-        f"AND {run_predicate} "
+        f"AND {run_predicate} AND process_index = '0' "
         "AND job_id IS NOT NULL AND execution_uid IS NOT NULL "
         f"AND timestamp_ms >= {phase_since} AND timestamp_ms < {end} "
         f"AND (name = '{PHASE_METRIC}' OR timestamp_ms >= {progress_since})"

--- a/infra/grafana/src/training_stalls.py
+++ b/infra/grafana/src/training_stalls.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
 import pyarrow as pa
-from hero_runs import TASK_STATE_LOOKBACK, HeroRun, as_utc, run_id_predicate, sql_timestamp
+from hero_runs import TASK_STATE_LOOKBACK, TELEMETRY_GONE_AGE, HeroRun, as_utc, run_id_predicate, sql_timestamp
 
 _TRAINING_STALL_AGE = timedelta(minutes=15)
 _INITIALIZING_STALL_AGE = timedelta(minutes=45)
@@ -98,6 +98,7 @@ class ExecutionMetrics:
 
     metrics: dict[str, float]
     execution_started: datetime | None
+    observed_at: datetime
 
 
 def _metrics_by_job(runs: tuple[HeroRun, ...], telemetry_metrics: pa.Table) -> dict[tuple[str, str], ExecutionMetrics]:
@@ -127,6 +128,7 @@ def _metrics_by_job(runs: tuple[HeroRun, ...], telemetry_metrics: pa.Table) -> d
         key: ExecutionMetrics(
             metrics={name: value for name, (_, value) in metrics.items()},
             execution_started=started.get(key),
+            observed_at=max(observed for observed, _ in metrics.values()),
         )
         for key, metrics in newest.items()
     }
@@ -145,7 +147,11 @@ def _classify(run: HeroRun, observed: ExecutionMetrics | None, now: datetime) ->
     reason = "healthy"
     value = 0
     is_training = phase == _TRAINING_PHASE or step > 0
-    if phase == _FINISHED_PHASE:
+    if observed is not None and now - observed.observed_at > TELEMETRY_GONE_AGE:
+        # A run that stopped publishing is TrainingTelemetryGone's, which names the
+        # failure precisely. Reporting a stall as well would page twice for it.
+        reason = "telemetry_gone"
+    elif phase == _FINISHED_PHASE:
         reason = "finished"
     elif is_training and progress_time > 0:
         progress_age = now - datetime.fromtimestamp(progress_time, tz=UTC)

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -375,6 +375,7 @@ def test_training_stall_alert_selects_named_hero_run_and_resolves_on_progress():
             run_id VARCHAR,
             job_id VARCHAR,
             execution_uid VARCHAR,
+            process_index VARCHAR,
             name VARCHAR,
             value DOUBLE,
             timestamp_ms BIGINT,
@@ -399,7 +400,7 @@ def test_training_stall_alert_selects_named_hero_run_and_resolves_on_progress():
         ],
     )
     database.executemany(
-        "INSERT INTO telemetry_v1 VALUES (?, 'levanter', ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO telemetry_v1 VALUES (?, 'levanter', ?, ?, ?, '0', ?, ?, ?, ?)",
         [
             (
                 "cw-a",
@@ -454,7 +455,7 @@ def test_training_stall_alert_selects_named_hero_run_and_resolves_on_progress():
     ]
 
     database.execute(
-        "INSERT INTO telemetry_v1 VALUES (?, 'levanter', ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO telemetry_v1 VALUES (?, 'levanter', ?, ?, ?, '0', ?, ?, ?, ?)",
         (
             "cw-a",
             "hero-20260819",

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -18,6 +18,7 @@ from finelog_health import FinelogHealth, FinelogRole
 from github_source import GithubSource
 from hero_health import (
     MetricSignal,
+    RunSignals,
     WatchedRun,
     health_alert_rows,
     optimizer_alert_rows,
@@ -653,7 +654,7 @@ def _signals(now: datetime, metrics: dict[str, dict], run_id: str = "hero-a") ->
         )
         for name, values in metrics.items()
     }
-    return {("cw-a", run_id): rows}
+    return {("cw-a", run_id): RunSignals(execution_uid="attempt-1", metrics=rows)}
 
 
 def _reasons(rows: list[dict]) -> set[str]:
@@ -681,13 +682,21 @@ def test_run_health_watches_a_run_whose_iris_state_row_went_stale():
     assert "iris_state_stale" in _reasons(health_alert_rows(runs, signals, pa.table({}), now))
 
 
-def test_telemetry_gone_pages_only_while_iris_still_runs_the_tasks():
-    # Telemetry that stops when Iris stops counting the tasks is a run that ended.
+def test_silent_telemetry_pages_whether_or_not_iris_still_runs_the_tasks():
+    # A crashed run stops publishing and stops being counted, which is the most
+    # severe case, so the Iris state picks the reason rather than the firing.
     now = datetime(2026, 8, 21, 12, tzinfo=UTC)
     silent = _signals(now, {"phase": {"latest": 1.0, "observed_at": now - timedelta(minutes=20)}})
 
     assert _reasons(telemetry_alert_rows((_watched(),), silent, now)) == {"telemetry_gone"}
-    assert _reasons(telemetry_alert_rows((_watched(iris_running=False),), silent, now)) == set()
+    assert _reasons(telemetry_alert_rows((_watched(iris_running=False),), silent, now)) == {"run_down"}
+
+
+def test_a_finished_run_going_quiet_is_not_a_page():
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    done = _signals(now, {"phase": {"latest": 2.0, "observed_at": now - timedelta(minutes=20)}})
+
+    assert _reasons(telemetry_alert_rows((_watched(iris_running=False),), done, now)) == set()
 
 
 def test_telemetry_alert_leaves_a_run_that_has_published_nothing_to_the_stall_rule():
@@ -757,6 +766,42 @@ def test_optimizer_alert_reads_the_loss_jump_gradient_norm_and_skipped_steps():
         "grad_norm_high",
         "steps_skipped",
     }
+
+
+def test_loss_jump_reads_one_attempt_so_a_restore_is_not_a_rise():
+    # A restore rewinds to a checkpoint, so the new attempt's loss sits above
+    # where the old one left off. Windows spanning both would read that as a jump.
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    database = duckdb.connect()
+    database.execute(
+        """
+        CREATE TABLE telemetry_v1(
+            cluster VARCHAR, service VARCHAR, run_id VARCHAR,
+            execution_uid VARCHAR, name VARCHAR, value DOUBLE, timestamp_ms BIGINT
+        )
+        """
+    )
+
+    def at(minutes: float) -> int:
+        return int((now - timedelta(minutes=minutes)).timestamp() * 1000)
+
+    database.executemany(
+        "INSERT INTO telemetry_v1 VALUES ('cw-a', 'levanter', 'hero-a', ?, 'train_loss', ?, ?)",
+        [
+            # The retry sits inside the hour, so both attempts land in the baseline.
+            *(("attempt-1", 2.1, at(50 - i * 0.5)) for i in range(30)),
+            *(("attempt-2", 3.4, at(20 - i * 0.5)) for i in range(30)),
+            *(("attempt-2", 3.4, at(4 - i * 0.15)) for i in range(25)),
+        ],
+    )
+    runs = (_watched(),)
+
+    mixed = database.execute(loss_window_query(now, runs)).fetch_arrow_table()
+    scoped = database.execute(loss_window_query(now, runs, ("attempt-2",))).fetch_arrow_table()
+    signals = _signals(now, {})
+
+    assert _reasons(optimizer_alert_rows(runs, signals, mixed, now)) == {"loss_jump"}
+    assert _reasons(optimizer_alert_rows(runs, signals, scoped, now)) == set()
 
 
 def test_loss_jump_defers_to_the_spike_rule_on_the_same_rise():
@@ -904,7 +949,8 @@ def test_signal_query_reduces_the_newest_sample_and_the_health_window():
         ]
     )
 
-    signals = signals_by_run(database.execute(signal_query(now, (_watched(),))).fetch_arrow_table())["cw-a", "hero-a"]
+    run = signals_by_run(database.execute(signal_query(now, (_watched(),))).fetch_arrow_table())["cw-a", "hero-a"]
+    signals = run.metrics
 
     throughput = signals["throughput_tokens_per_second"]
     assert (throughput.latest, throughput.recent_samples, throughput.recent_below_floor) == (2.6e6, 3, 2)
@@ -928,11 +974,12 @@ def test_signal_query_reduces_one_task_attempt_at_a_time():
         ]
     )
 
-    signals = signals_by_run(database.execute(signal_query(now, (_watched(),))).fetch_arrow_table())["cw-a", "hero-a"]
+    run = signals_by_run(database.execute(signal_query(now, (_watched(),))).fetch_arrow_table())["cw-a", "hero-a"]
 
-    assert signals["optim_skipped_step"].recent_total == 1.0
-    assert "grad_norm_total" not in signals
-    assert _reasons(optimizer_alert_rows((_watched(),), {("cw-a", "hero-a"): signals}, pa.table({}), now)) == set()
+    assert run.execution_uid == "attempt-2"
+    assert run.metrics["optim_skipped_step"].recent_total == 1.0
+    assert "grad_norm_total" not in run.metrics
+    assert _reasons(optimizer_alert_rows((_watched(),), {("cw-a", "hero-a"): run}, pa.table({}), now)) == set()
 
 
 def test_zephyr_stall_alert_distinguishes_stale_healthy_and_expired_producers():

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -1093,8 +1093,10 @@ def test_zephyr_alert_query_keeps_job_identity_across_the_schema_transition():
 def test_training_stall_query_bounds_each_metric_family_to_its_detection_window():
     """Wide scans read telemetry_v1 once a minute and can saturate Finelog.
 
-    Levanter republishes `phase` every 60s. Progress needs one extra stall window
-    so a metric that just became stale remains observable.
+    Progress needs one extra stall window so a metric that just became stale
+    remains observable. Levanter republishes `phase` every 60s, and it reaches
+    back a day so a run silent for hours is still recognisable as one that
+    stopped publishing rather than one that never started.
     """
     now = datetime(2026, 7, 28, 12, tzinfo=UTC)
     run = HeroRun("cw-a", "/u/hero-prod-coord", "hero-prod", now - timedelta(hours=1))
@@ -1103,12 +1105,12 @@ def test_training_stall_query_bounds_each_metric_family_to_its_detection_window(
     assert sql.count('FROM "telemetry_v1"') == 1
     assert "name IN ('phase', 'step', 'progress_time_seconds')" in sql
     assert "run_id = 'hero-prod'" in sql
-    assert "timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '2026-07-28 11:00:00') * 1000 AS BIGINT)" in sql
+    assert "timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '2026-07-27 12:00:00') * 1000 AS BIGINT)" in sql
     assert (
         "name = 'phase' OR timestamp_ms >= "
         "CAST(EXTRACT(EPOCH FROM TIMESTAMP '2026-07-28 11:30:00') * 1000 AS BIGINT)" in sql
     )
-    assert "WHERE name = 'phase' AND ts >= TIMESTAMP '2026-07-28 11:00:00'" in sql
+    assert "WHERE name = 'phase' AND ts >= TIMESTAMP '2026-07-27 12:00:00'" in sql
     assert "root_job_id LIKE '%/hero-%-coord'" in task_state_query(now)
 
 

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -16,6 +16,16 @@ from conftest import FINELOG_DEPLOYMENTS_PATH, bridge_config, deployment, health
 from finelog.errors import QueryResultTooLargeError
 from finelog_health import FinelogHealth, FinelogRole
 from github_source import GithubSource
+from hero_health import (
+    MetricSignal,
+    WatchedRun,
+    health_alert_rows,
+    optimizer_alert_rows,
+    signal_query,
+    signals_by_run,
+    telemetry_alert_rows,
+    watched_runs,
+)
 from hero_runs import HeroRun, active_hero_runs, task_state_query
 from k8s_source import K8sFleet
 from loom_alerts import (
@@ -235,6 +245,7 @@ def test_training_stall_alerts_distinguish_stale_missing_and_healthy_progress():
             now - timedelta(minutes=30),
             now - timedelta(hours=1),
         ],
+        running=[64] * 5,
     )
     telemetry_metrics = finelog_result(
         cluster=["cw-a", "cw-a", "cw-b", "cw-b", "cw-b"],
@@ -258,7 +269,7 @@ def test_training_stall_alerts_distinguish_stale_missing_and_healthy_progress():
         execution_started_at=[now - timedelta(hours=1)] * 5,
     )
 
-    assert training_stall_alert_rows(active_hero_runs(task_states), telemetry_metrics, now) == [
+    assert training_stall_alert_rows(active_hero_runs(task_states, now), telemetry_metrics, now) == [
         {
             "cluster": "cw-a",
             "job": "/u/hero-stale-coord",
@@ -336,7 +347,7 @@ def test_hero_alerts_enroll_suffixed_retry_roots():
     )
 
     task_states = database.execute(task_state_query(now)).fetch_arrow_table()
-    assert {(run.root_job, run.run_id) for run in active_hero_runs(task_states)} == {
+    assert {(run.root_job, run.run_id) for run in active_hero_runs(task_states, now)} == {
         ("/power/hero-12d8b6f0-dee637-coord-slop85", "hero-12d8b6f0-dee637"),
         ("/power/hero-other-coord", "hero-other"),
     }
@@ -373,7 +384,10 @@ def test_training_stall_alert_selects_named_hero_run_and_resolves_on_progress():
     database.execute("CREATE MACRO to_timestamp_millis(value) AS to_timestamp(value / 1000.0)")
 
     stalled_at = now - timedelta(minutes=20)
-    phase_at = stalled_at
+    # Levanter publishes phase every minute, so a wedged run keeps a fresh
+    # heartbeat while its progress timestamp ages. A run that stops publishing
+    # altogether is TrainingTelemetryGone's case, not this rule's.
+    phase_at = now - timedelta(seconds=30)
     progressing_at = now - timedelta(seconds=30)
     database.executemany(
         'INSERT INTO "iris.task_state" VALUES (?, ?, ?, ?)',
@@ -421,7 +435,7 @@ def test_training_stall_alert_selects_named_hero_run_and_resolves_on_progress():
     )
 
     task_states = database.execute(task_state_query(now)).fetch_arrow_table()
-    runs = active_hero_runs(task_states)
+    runs = active_hero_runs(task_states, now)
     assert [(run.cluster, run.root_job, run.run_id) for run in runs] == [
         ("cw-a", "/rav/hero-20260819-coord", "hero-20260819")
     ]
@@ -471,7 +485,9 @@ def test_training_stall_alert_gives_a_new_execution_its_own_initialization_windo
     task_states = finelog_result(
         cluster=["cw-a"],
         job=["/u/hero-retry-coord"],
+        state_at=[now],
         running_since=[now - timedelta(hours=1)],
+        running=[64],
     )
     telemetry_metrics = finelog_result(
         cluster=["cw-a"],
@@ -483,7 +499,7 @@ def test_training_stall_alert_gives_a_new_execution_its_own_initialization_windo
         execution_started_at=[now - timedelta(minutes=5)],
     )
 
-    assert training_stall_alert_rows(active_hero_runs(task_states), telemetry_metrics, now) == [
+    assert training_stall_alert_rows(active_hero_runs(task_states, now), telemetry_metrics, now) == [
         {
             "cluster": "cw-a",
             "job": "/u/hero-retry-coord",
@@ -603,6 +619,288 @@ def test_loss_spike_query_reads_one_bounded_window_per_evaluation():
     assert "timestamp_ms >= CAST(EXTRACT(EPOCH FROM TIMESTAMP '2026-07-28 11:00:00') * 1000 AS BIGINT)" in sql
     assert "timestamp_ms < CAST(EXTRACT(EPOCH FROM TIMESTAMP '2026-07-28 12:00:00') * 1000 AS BIGINT)" in sql
     assert "CAST(EXTRACT(EPOCH FROM TIMESTAMP '2026-07-28 11:55:00') * 1000 AS BIGINT)" in sql
+
+
+def _watched(
+    run_id: str = "hero-a",
+    *,
+    iris_running: bool = True,
+    iris_state_age: timedelta | None = timedelta(seconds=30),
+) -> WatchedRun:
+    return WatchedRun(
+        cluster="cw-a",
+        root_job=f"/u/{run_id}-coord",
+        run_id=run_id,
+        iris_running=iris_running,
+        iris_state_age=iris_state_age,
+    )
+
+
+def _signals(now: datetime, metrics: dict[str, dict], run_id: str = "hero-a") -> dict:
+    """Build the signal map the bridge folds out of one telemetry scan.
+
+    Every run carries a fresh training phase unless a test overrides it, since
+    the health checks describe a run that is training right now.
+    """
+    metrics = {"phase": {"latest": 1.0}} | metrics
+    rows = {
+        name: MetricSignal(
+            latest=values["latest"],
+            observed_at=values.get("observed_at", now - timedelta(seconds=30)),
+            previous=values.get("previous"),
+            recent_samples=values.get("recent_samples", 0),
+            recent_total=values.get("recent_total", 0.0),
+            recent_below_floor=values.get("recent_below_floor", 0),
+        )
+        for name, values in metrics.items()
+    }
+    return {("cw-a", run_id): rows}
+
+
+def _reasons(rows: list[dict]) -> set[str]:
+    return {row["reason"] for row in rows if row["value"] == 1}
+
+
+def test_run_health_watches_a_run_whose_iris_state_row_went_stale():
+    # The stall and loss rules enroll from iris.task_state alone, so a break in
+    # that path silently stops watching a run that is plainly still training.
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    task_states = finelog_result(
+        cluster=["cw-a"],
+        job=["/u/hero-a-coord"],
+        state_at=[now - timedelta(minutes=20)],
+        running_since=[now - timedelta(hours=3)],
+        running=[64],
+    )
+    phase_runs = finelog_result(cluster=["cw-a"], run_id=["hero-a"], telemetry_job=["/u/hero-a-coord/train"])
+
+    assert active_hero_runs(task_states, now) == ()
+    runs = watched_runs(task_states, phase_runs, now)
+    assert [(run.run_id, run.iris_running) for run in runs] == [("hero-a", False)]
+
+    signals = _signals(now, {"phase": {"latest": 1.0}})
+    assert "iris_state_stale" in _reasons(health_alert_rows(runs, signals, pa.table({}), now))
+
+
+def test_telemetry_gone_pages_only_while_iris_still_runs_the_tasks():
+    # Telemetry that stops when Iris also stops reporting the tasks is a run that
+    # ended. Telemetry that stops while Iris keeps counting them is an incident.
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    silent = _signals(now, {"phase": {"latest": 1.0, "observed_at": now - timedelta(minutes=20)}})
+
+    assert _reasons(telemetry_alert_rows((_watched(),), silent, now)) == {"telemetry_gone"}
+    assert _reasons(telemetry_alert_rows((_watched(iris_running=False),), silent, now)) == set()
+
+
+def test_telemetry_alert_leaves_a_run_that_has_published_nothing_to_the_stall_rule():
+    # Before Levanter's first sample there is no evidence of a lost telemetry
+    # path, and TrainingProgressStalled allows the full initialization budget.
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    rows = telemetry_alert_rows((_watched(),), {}, now)
+
+    assert rows == [{"cluster": "cw-a", "job": "/u/hero-a-coord", "run": "hero-a", "reason": "healthy", "value": 0}]
+
+
+def test_training_stall_alert_defers_a_silent_run_to_the_telemetry_rule():
+    # One outage, one page: the stall rule reports the silence without firing.
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    task_states = finelog_result(
+        cluster=["cw-a"],
+        job=["/u/hero-a-coord"],
+        state_at=[now],
+        running_since=[now - timedelta(hours=3)],
+        running=[64],
+    )
+    telemetry_metrics = finelog_result(
+        cluster=["cw-a"] * 2,
+        run_id=["hero-a"] * 2,
+        telemetry_job=["/u/hero-a-coord/train"] * 2,
+        name=["phase", "progress_time_seconds"],
+        value=[1.0, (now - timedelta(minutes=25)).timestamp()],
+        ts=[now - timedelta(minutes=25)] * 2,
+        execution_started_at=[now - timedelta(hours=3)] * 2,
+    )
+
+    (row,) = training_stall_alert_rows(active_hero_runs(task_states, now), telemetry_metrics, now)
+    assert (row["reason"], row["value"]) == ("telemetry_gone", 0)
+
+
+def _loss_window_row(*, stddev: float) -> pa.Table:
+    """A run whose loss floor climbed 1.2 between its trailing and recent windows."""
+    return finelog_result(
+        cluster=["cw-a"],
+        run_id=["hero-a"],
+        baseline_samples=[240],
+        baseline_loss=[2.4],
+        baseline_stddev=[stddev],
+        baseline_floor=[2.1],
+        recent_samples=[20],
+        recent_loss=[3.4],
+        recent_floor=[3.3],
+        recent_peak=[3.5],
+    )
+
+
+def test_optimizer_alert_reads_the_loss_jump_gradient_norm_and_skipped_steps():
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    runs = (_watched(),)
+    signals = _signals(
+        now,
+        {
+            "grad_norm_total": {"latest": 2.4},
+            "optim_skipped_step": {"latest": 1.0, "recent_samples": 4, "recent_total": 4.0},
+        },
+    )
+
+    # A trailing spread of 0.3 puts the six-sigma band at 4.2, well above the new
+    # floor, so this level shift is the one TrainingLossSpike cannot see.
+    assert _reasons(optimizer_alert_rows(runs, signals, _loss_window_row(stddev=0.3), now)) == {
+        "loss_jump",
+        "grad_norm_high",
+        "steps_skipped",
+    }
+
+
+def test_loss_jump_defers_to_the_spike_rule_on_the_same_rise():
+    # A tight trailing spread puts the same rise outside the six-sigma band, so
+    # TrainingLossSpike already pages for it and this rule stays quiet.
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    windows = _loss_window_row(stddev=0.02)
+
+    assert _reasons(optimizer_alert_rows((_watched(),), {}, windows, now)) == set()
+    assert _reasons(loss_spike_alert_rows((_hero_run("hero-a"),), windows)) == {"spiking"}
+
+
+def test_optimizer_alert_ignores_a_gradient_norm_the_previous_attempt_left_behind():
+    # A restarted run inherits its predecessor's last sample. Only a fresh one
+    # describes the attempt that is training now.
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    stale = _signals(now, {"grad_norm_total": {"latest": 9.0, "observed_at": now - timedelta(minutes=40)}})
+
+    assert _reasons(optimizer_alert_rows((_watched(),), stale, pa.table({}), now)) == set()
+
+
+def test_health_alert_reads_routing_throughput_and_evaluation():
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    signals = _signals(
+        now,
+        {
+            "moe_drop_fraction": {"latest": 0.09},
+            "train_router_routing_entropy_mean": {"latest": 5.4},
+            "train_router_bias_min": {"latest": -460.0},
+            "train_router_bias_max": {"latest": 120.0},
+            "throughput_tokens_per_second": {"latest": 1.4e6, "recent_samples": 100, "recent_below_floor": 62},
+            "throughput_mfu": {"latest": 31.0, "recent_samples": 100, "recent_below_floor": 4},
+            "eval_paloma_macro_loss": {"latest": 2.31, "previous": 2.17},
+        },
+    )
+
+    assert _reasons(health_alert_rows((_watched(),), signals, pa.table({}), now)) == {
+        "token_drops",
+        "router_entropy",
+        "router_bias",
+        "throughput_low",
+        "eval_regressed",
+    }
+
+
+def test_throughput_floor_needs_most_of_the_window_below_it():
+    # The hero monitor compares a median, so one restart step at zero must not
+    # read as a slow run, and a window too short to have a median says nothing.
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    one_slow_step = {"latest": 2.4e6, "recent_samples": 100, "recent_below_floor": 1}
+    barely_sampled = {"latest": 1.0e6, "recent_samples": 8, "recent_below_floor": 8}
+
+    for tokens_per_second in (one_slow_step, barely_sampled):
+        signals = _signals(now, {"throughput_tokens_per_second": tokens_per_second})
+        assert _reasons(health_alert_rows((_watched(),), signals, pa.table({}), now)) == set()
+
+
+def test_health_alert_announces_a_controller_retry_on_the_run_that_owns_the_task():
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    retries = finelog_result(
+        cluster=["cw-a", "cw-a"],
+        task_id=["/u/hero-a-coord/train/17", "/u/other-coord/train/0"],
+    )
+    signals = _signals(now, {"phase": {"latest": 1.0}})
+
+    assert _reasons(health_alert_rows((_watched(),), signals, retries, now)) == {"task_retried"}
+
+
+def test_run_health_alerts_stay_quiet_for_a_run_that_is_not_training():
+    # A finished run leaves its last samples behind for a while, and a run that
+    # went silent belongs to TrainingTelemetryGone. Neither is a health signal.
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    drops = {"moe_drop_fraction": {"latest": 0.4}}
+    finished = _signals(now, {"phase": {"latest": 2.0}, **drops})
+    silent = _signals(now, {"phase": {"latest": 1.0, "observed_at": now - timedelta(minutes=20)}, **drops})
+
+    for signals in (finished, silent):
+        assert _reasons(health_alert_rows((_watched(),), signals, pa.table({}), now)) == set()
+
+
+def test_iris_state_stale_needs_a_state_row_that_went_stale():
+    # A controller that publishes no task-state rollup at all, which is how the
+    # GCE clusters run, is not a rollup that broke.
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    signals = _signals(now, {})
+
+    never_published = _watched(iris_running=False, iris_state_age=None)
+    assert _reasons(health_alert_rows((never_published,), signals, pa.table({}), now)) == set()
+
+
+def test_run_health_alerts_return_an_explicit_zero_without_a_watched_run():
+    # Grafana reserves noDataState for a monitoring-path failure, so an empty
+    # fleet still answers each rule.
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    fleet = {"cluster": "fleet", "job": "", "run": "", "reason": "healthy", "value": 0}
+
+    assert telemetry_alert_rows((), {}, now) == [fleet]
+    assert optimizer_alert_rows((), {}, pa.table({}), now) == [fleet]
+    assert health_alert_rows((), {}, pa.table({}), now) == [fleet]
+
+
+def test_signal_query_reduces_the_newest_sample_and_the_health_window():
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    database = duckdb.connect()
+    database.execute(
+        """
+        CREATE TABLE telemetry_v1(
+            cluster VARCHAR,
+            service VARCHAR,
+            run_id VARCHAR,
+            name VARCHAR,
+            value DOUBLE,
+            timestamp_ms BIGINT,
+            seq BIGINT
+        )
+        """
+    )
+    database.execute("CREATE MACRO to_timestamp_millis(value) AS to_timestamp(value / 1000.0)")
+    samples = [
+        ("throughput_tokens_per_second", 1.0e6, now - timedelta(minutes=10), 1),
+        ("throughput_tokens_per_second", 1.2e6, now - timedelta(minutes=5), 2),
+        ("throughput_tokens_per_second", 2.6e6, now - timedelta(minutes=1), 3),
+        # Outside the fifteen-minute health window, so the reductions ignore it.
+        ("throughput_tokens_per_second", 0.1e6, now - timedelta(minutes=40), 0),
+        ("optim_skipped_step", 1.0, now - timedelta(minutes=9), 4),
+        ("optim_skipped_step", 1.0, now - timedelta(minutes=2), 5),
+        # Hours apart, so only the eval lookback keeps the previous value.
+        ("eval_paloma_macro_loss", 2.17, now - timedelta(hours=6), 6),
+        ("eval_paloma_macro_loss", 2.31, now - timedelta(minutes=12), 7),
+    ]
+    database.executemany(
+        "INSERT INTO telemetry_v1 VALUES ('cw-a', 'levanter', 'hero-a', ?, ?, ?, ?)",
+        [(name, value, int(at.timestamp() * 1000), seq) for name, value, at, seq in samples],
+    )
+
+    signals = signals_by_run(database.execute(signal_query(now, (_watched(),))).fetch_arrow_table())["cw-a", "hero-a"]
+
+    throughput = signals["throughput_tokens_per_second"]
+    assert (throughput.latest, throughput.recent_samples, throughput.recent_below_floor) == (2.6e6, 3, 2)
+    assert signals["optim_skipped_step"].recent_total == 2.0
+    evaluation = signals["eval_paloma_macro_loss"]
+    assert (evaluation.latest, evaluation.previous) == (2.31, 2.17)
 
 
 def test_zephyr_stall_alert_distinguishes_stale_healthy_and_expired_producers():

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -385,8 +385,7 @@ def test_training_stall_alert_selects_named_hero_run_and_resolves_on_progress():
 
     stalled_at = now - timedelta(minutes=20)
     # Levanter publishes phase every minute, so a wedged run keeps a fresh
-    # heartbeat while its progress timestamp ages. A run that stops publishing
-    # altogether is TrainingTelemetryGone's case, not this rule's.
+    # heartbeat while its progress timestamp ages.
     phase_at = now - timedelta(seconds=30)
     progressing_at = now - timedelta(seconds=30)
     database.executemany(
@@ -663,7 +662,7 @@ def _reasons(rows: list[dict]) -> set[str]:
 
 def test_run_health_watches_a_run_whose_iris_state_row_went_stale():
     # The stall and loss rules enroll from iris.task_state alone, so a break in
-    # that path silently stops watching a run that is plainly still training.
+    # that path silently stops watching a run that is still training.
     now = datetime(2026, 8, 21, 12, tzinfo=UTC)
     task_states = finelog_result(
         cluster=["cw-a"],
@@ -683,8 +682,7 @@ def test_run_health_watches_a_run_whose_iris_state_row_went_stale():
 
 
 def test_telemetry_gone_pages_only_while_iris_still_runs_the_tasks():
-    # Telemetry that stops when Iris also stops reporting the tasks is a run that
-    # ended. Telemetry that stops while Iris keeps counting them is an incident.
+    # Telemetry that stops when Iris stops counting the tasks is a run that ended.
     now = datetime(2026, 8, 21, 12, tzinfo=UTC)
     silent = _signals(now, {"phase": {"latest": 1.0, "observed_at": now - timedelta(minutes=20)}})
 
@@ -693,8 +691,8 @@ def test_telemetry_gone_pages_only_while_iris_still_runs_the_tasks():
 
 
 def test_telemetry_alert_leaves_a_run_that_has_published_nothing_to_the_stall_rule():
-    # Before Levanter's first sample there is no evidence of a lost telemetry
-    # path, and TrainingProgressStalled allows the full initialization budget.
+    # Before Levanter's first sample there is no lost path to report, and
+    # TrainingProgressStalled allows the full initialization budget.
     now = datetime(2026, 8, 21, 12, tzinfo=UTC)
     rows = telemetry_alert_rows((_watched(),), {}, now)
 
@@ -752,8 +750,8 @@ def test_optimizer_alert_reads_the_loss_jump_gradient_norm_and_skipped_steps():
         },
     )
 
-    # A trailing spread of 0.3 puts the six-sigma band at 4.2, well above the new
-    # floor, so this level shift is the one TrainingLossSpike cannot see.
+    # A trailing spread of 0.3 puts the six-sigma band at 4.2, above the new
+    # floor, so this is the level shift TrainingLossSpike cannot see.
     assert _reasons(optimizer_alert_rows(runs, signals, _loss_window_row(stddev=0.3), now)) == {
         "loss_jump",
         "grad_norm_high",
@@ -762,8 +760,8 @@ def test_optimizer_alert_reads_the_loss_jump_gradient_norm_and_skipped_steps():
 
 
 def test_loss_jump_defers_to_the_spike_rule_on_the_same_rise():
-    # A tight trailing spread puts the same rise outside the six-sigma band, so
-    # TrainingLossSpike already pages for it and this rule stays quiet.
+    # A tight trailing spread puts the same rise outside the band, so
+    # TrainingLossSpike pages for it and this rule stays quiet.
     now = datetime(2026, 8, 21, 12, tzinfo=UTC)
     windows = _loss_window_row(stddev=0.02)
 
@@ -772,8 +770,7 @@ def test_loss_jump_defers_to_the_spike_rule_on_the_same_rise():
 
 
 def test_optimizer_alert_ignores_a_gradient_norm_the_previous_attempt_left_behind():
-    # A restarted run inherits its predecessor's last sample. Only a fresh one
-    # describes the attempt that is training now.
+    # A restarted run inherits its predecessor's last sample.
     now = datetime(2026, 8, 21, 12, tzinfo=UTC)
     stale = _signals(now, {"grad_norm_total": {"latest": 9.0, "observed_at": now - timedelta(minutes=40)}})
 
@@ -805,8 +802,8 @@ def test_health_alert_reads_routing_throughput_and_evaluation():
 
 
 def test_throughput_floor_needs_most_of_the_window_below_it():
-    # The hero monitor compares a median, so one restart step at zero must not
-    # read as a slow run, and a window too short to have a median says nothing.
+    # One restart step at zero is not a slow run, and a window too short to have
+    # a median says nothing.
     now = datetime(2026, 8, 21, 12, tzinfo=UTC)
     one_slow_step = {"latest": 2.4e6, "recent_samples": 100, "recent_below_floor": 1}
     barely_sampled = {"latest": 1.0e6, "recent_samples": 8, "recent_below_floor": 8}
@@ -828,9 +825,8 @@ def test_health_alert_announces_a_controller_retry_on_the_run_that_owns_the_task
 
 
 def test_run_health_alerts_stay_quiet_for_a_run_that_is_not_training():
-    # A finished run leaves its last samples behind for a while, an initializing
-    # attempt has published none of these metrics, and a silent one belongs to
-    # TrainingTelemetryGone. None of the three is a health signal.
+    # A finished run leaves its last samples behind, an initializing attempt has
+    # published none, and a silent one belongs to TrainingTelemetryGone.
     now = datetime(2026, 8, 21, 12, tzinfo=UTC)
     drops = {"moe_drop_fraction": {"latest": 0.4}}
     phases = (
@@ -845,8 +841,8 @@ def test_run_health_alerts_stay_quiet_for_a_run_that_is_not_training():
 
 
 def test_iris_state_stale_needs_a_state_row_that_went_stale():
-    # A controller that publishes no task-state rollup at all, which is how the
-    # GCE clusters run, is not a rollup that broke.
+    # The GCE clusters publish no task-state rollup at all, which is not a
+    # rollup that broke.
     now = datetime(2026, 8, 21, 12, tzinfo=UTC)
     signals = _signals(now, {})
 
@@ -855,8 +851,7 @@ def test_iris_state_stale_needs_a_state_row_that_went_stale():
 
 
 def test_run_health_alerts_return_an_explicit_zero_without_a_watched_run():
-    # Grafana reserves noDataState for a monitoring-path failure, so an empty
-    # fleet still answers each rule.
+    # noDataState is reserved for a monitoring-path failure.
     now = datetime(2026, 8, 21, 12, tzinfo=UTC)
     fleet = {"cluster": "fleet", "job": "", "run": "", "reason": "healthy", "value": 0}
 
@@ -920,8 +915,7 @@ def test_signal_query_reduces_the_newest_sample_and_the_health_window():
 
 def test_signal_query_reduces_one_task_attempt_at_a_time():
     # A retry keeps the run ID and takes a new execution_uid. Summing across both
-    # would charge the new attempt with the skipped steps that killed the old one,
-    # and let the old attempt's last gradient norm fire against a fresh phase.
+    # would charge the new attempt with the steps the old one skipped.
     now = datetime(2026, 8, 21, 12, tzinfo=UTC)
     database = _signal_database(
         [

--- a/infra/grafana/tests/test_bridge.py
+++ b/infra/grafana/tests/test_bridge.py
@@ -828,14 +828,19 @@ def test_health_alert_announces_a_controller_retry_on_the_run_that_owns_the_task
 
 
 def test_run_health_alerts_stay_quiet_for_a_run_that_is_not_training():
-    # A finished run leaves its last samples behind for a while, and a run that
-    # went silent belongs to TrainingTelemetryGone. Neither is a health signal.
+    # A finished run leaves its last samples behind for a while, an initializing
+    # attempt has published none of these metrics, and a silent one belongs to
+    # TrainingTelemetryGone. None of the three is a health signal.
     now = datetime(2026, 8, 21, 12, tzinfo=UTC)
     drops = {"moe_drop_fraction": {"latest": 0.4}}
-    finished = _signals(now, {"phase": {"latest": 2.0}, **drops})
-    silent = _signals(now, {"phase": {"latest": 1.0, "observed_at": now - timedelta(minutes=20)}, **drops})
+    phases = (
+        {"phase": {"latest": 2.0}},
+        {"phase": {"latest": 0.0}},
+        {"phase": {"latest": 1.0, "observed_at": now - timedelta(minutes=20)}},
+    )
 
-    for signals in (finished, silent):
+    for phase in phases:
+        signals = _signals(now, {**phase, **drops})
         assert _reasons(health_alert_rows((_watched(),), signals, pa.table({}), now)) == set()
 
 
@@ -860,8 +865,8 @@ def test_run_health_alerts_return_an_explicit_zero_without_a_watched_run():
     assert health_alert_rows((), {}, pa.table({}), now) == [fleet]
 
 
-def test_signal_query_reduces_the_newest_sample_and_the_health_window():
-    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+def _signal_database(samples: list[tuple[str, str, float, datetime, int]]) -> duckdb.DuckDBPyConnection:
+    """A telemetry table of (execution_uid, name, value, observed_at, seq) rows for hero-a."""
     database = duckdb.connect()
     database.execute(
         """
@@ -869,6 +874,8 @@ def test_signal_query_reduces_the_newest_sample_and_the_health_window():
             cluster VARCHAR,
             service VARCHAR,
             run_id VARCHAR,
+            execution_uid VARCHAR,
+            process_index VARCHAR,
             name VARCHAR,
             value DOUBLE,
             timestamp_ms BIGINT,
@@ -877,21 +884,29 @@ def test_signal_query_reduces_the_newest_sample_and_the_health_window():
         """
     )
     database.execute("CREATE MACRO to_timestamp_millis(value) AS to_timestamp(value / 1000.0)")
-    samples = [
-        ("throughput_tokens_per_second", 1.0e6, now - timedelta(minutes=10), 1),
-        ("throughput_tokens_per_second", 1.2e6, now - timedelta(minutes=5), 2),
-        ("throughput_tokens_per_second", 2.6e6, now - timedelta(minutes=1), 3),
-        # Outside the fifteen-minute health window, so the reductions ignore it.
-        ("throughput_tokens_per_second", 0.1e6, now - timedelta(minutes=40), 0),
-        ("optim_skipped_step", 1.0, now - timedelta(minutes=9), 4),
-        ("optim_skipped_step", 1.0, now - timedelta(minutes=2), 5),
-        # Hours apart, so only the eval lookback keeps the previous value.
-        ("eval_paloma_macro_loss", 2.17, now - timedelta(hours=6), 6),
-        ("eval_paloma_macro_loss", 2.31, now - timedelta(minutes=12), 7),
-    ]
     database.executemany(
-        "INSERT INTO telemetry_v1 VALUES ('cw-a', 'levanter', 'hero-a', ?, ?, ?, ?)",
-        [(name, value, int(at.timestamp() * 1000), seq) for name, value, at, seq in samples],
+        "INSERT INTO telemetry_v1 VALUES ('cw-a', 'levanter', 'hero-a', ?, '0', ?, ?, ?, ?)",
+        [(execution, name, value, int(at.timestamp() * 1000), seq) for execution, name, value, at, seq in samples],
+    )
+    return database
+
+
+def test_signal_query_reduces_the_newest_sample_and_the_health_window():
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    database = _signal_database(
+        [
+            ("attempt-1", "phase", 1.0, now - timedelta(seconds=30), 8),
+            ("attempt-1", "throughput_tokens_per_second", 1.0e6, now - timedelta(minutes=10), 1),
+            ("attempt-1", "throughput_tokens_per_second", 1.2e6, now - timedelta(minutes=5), 2),
+            ("attempt-1", "throughput_tokens_per_second", 2.6e6, now - timedelta(minutes=1), 3),
+            # Outside the fifteen-minute health window, so the reductions ignore it.
+            ("attempt-1", "throughput_tokens_per_second", 0.1e6, now - timedelta(minutes=40), 0),
+            ("attempt-1", "optim_skipped_step", 1.0, now - timedelta(minutes=9), 4),
+            ("attempt-1", "optim_skipped_step", 1.0, now - timedelta(minutes=2), 5),
+            # Hours apart, so only the eval lookback keeps the previous value.
+            ("attempt-1", "eval_paloma_macro_loss", 2.17, now - timedelta(hours=6), 6),
+            ("attempt-1", "eval_paloma_macro_loss", 2.31, now - timedelta(minutes=12), 7),
+        ]
     )
 
     signals = signals_by_run(database.execute(signal_query(now, (_watched(),))).fetch_arrow_table())["cw-a", "hero-a"]
@@ -901,6 +916,29 @@ def test_signal_query_reduces_the_newest_sample_and_the_health_window():
     assert signals["optim_skipped_step"].recent_total == 2.0
     evaluation = signals["eval_paloma_macro_loss"]
     assert (evaluation.latest, evaluation.previous) == (2.31, 2.17)
+
+
+def test_signal_query_reduces_one_task_attempt_at_a_time():
+    # A retry keeps the run ID and takes a new execution_uid. Summing across both
+    # would charge the new attempt with the skipped steps that killed the old one,
+    # and let the old attempt's last gradient norm fire against a fresh phase.
+    now = datetime(2026, 8, 21, 12, tzinfo=UTC)
+    database = _signal_database(
+        [
+            ("attempt-1", "phase", 1.0, now - timedelta(minutes=9), 1),
+            ("attempt-1", "optim_skipped_step", 1.0, now - timedelta(minutes=10), 2),
+            ("attempt-1", "optim_skipped_step", 1.0, now - timedelta(minutes=9), 3),
+            ("attempt-1", "grad_norm_total", 9.0, now - timedelta(minutes=9), 4),
+            ("attempt-2", "phase", 1.0, now - timedelta(seconds=30), 5),
+            ("attempt-2", "optim_skipped_step", 1.0, now - timedelta(seconds=40), 6),
+        ]
+    )
+
+    signals = signals_by_run(database.execute(signal_query(now, (_watched(),))).fetch_arrow_table())["cw-a", "hero-a"]
+
+    assert signals["optim_skipped_step"].recent_total == 1.0
+    assert "grad_norm_total" not in signals
+    assert _reasons(optimizer_alert_rows((_watched(),), {("cw-a", "hero-a"): signals}, pa.table({}), now)) == set()
 
 
 def test_zephyr_stall_alert_distinguishes_stale_healthy_and_expired_producers():

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -337,6 +337,42 @@ def test_training_stall_alert_pages_each_hero_run_after_five_minutes():
     assert {column["selector"] for column in rule["data"][0]["model"]["columns"]} >= {"run", "job"}
 
 
+def test_run_health_alerts_split_paging_from_announcing():
+    # The hero on-call policy pages for a lost run or an unstable optimizer, and
+    # announces the routing, throughput, and Iris signals an operator reads.
+    rules = {rule["uid"]: rule for rule in _rules()}
+    paging = ("training-telemetry-gone", "training-optimizer-unstable")
+    for uid in paging:
+        assert rules[uid]["labels"] == {"severity": "critical", "notification": "hero-run"}
+        assert rules[uid]["for"] == "5m"
+    assert rules["training-run-health-degraded"]["labels"] == {"severity": "warning", "notification": "slack"}
+
+    urls = {uid: rules[uid]["data"][0]["model"]["url"] for uid in (*paging, "training-run-health-degraded")}
+    assert urls == {
+        "training-telemetry-gone": "/alerts/training_telemetry",
+        "training-optimizer-unstable": "/alerts/training_optimizer",
+        "training-run-health-degraded": "/alerts/training_health",
+    }
+
+
+def test_announcing_run_health_reaches_slack_without_a_triage_session():
+    # severity=warning alone is muted by dashboard-only, so the announcing rule
+    # needs the notification=slack route, which is matched first and unmuted.
+    (policy,) = _load(ALERTING / "policies.yaml")["policies"]
+    (rule,) = [rule for rule in _rules() if rule["uid"] == "training-run-health-degraded"]
+    route = next(
+        route
+        for route in policy["routes"]
+        if all(
+            operator == "=" and rule["labels"].get(label) == value for label, operator, value in route["object_matchers"]
+        )
+    )
+
+    assert route["object_matchers"] == [["notification", "=", "slack"]]
+    assert route["receiver"] == "ops-slack"
+    assert "mute_time_intervals" not in route
+
+
 def test_clusters_dashboard_shows_finelog_fleet_health():
     (panel,) = [
         panel

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -20,6 +20,7 @@ from conftest import bridge_config, healthy_k8s_routes, k8s_api, make_k8s_source
 from dashboard_stitch import stitch_all
 from finelog_health import FinelogHealth, FinelogRole
 from github_source import GithubSource
+from hero_health import DROP_FRACTION_MAX, ROUTER_BIAS_MAX, ROUTER_ENTROPY_MIN
 from k8s_source import K8sFleet
 from server import create_app
 from starlette.testclient import TestClient
@@ -369,6 +370,19 @@ def test_announcing_run_health_reaches_slack_without_a_triage_session():
     assert route["object_matchers"] == [["notification", "=", "slack"]]
     assert route["receiver"] == "ops-slack"
     assert "mute_time_intervals" not in route
+
+
+def test_run_health_dashboard_bands_match_the_alert_thresholds():
+    # The alert links the operator to these panels, so a limit tuned in one place
+    # and not the other would draw a band the rule does not fire on.
+    dashboard = _stitched_dashboards()["training.json"]
+    panels = {panel["title"]: panel for panel in _all_panels(dashboard)}
+    bands = " ".join(_panel_sql({**dashboard, "panels": [panels["Token drops"], panels["Router health"]]}))
+
+    assert f"CAST({DROP_FRACTION_MAX} AS DOUBLE) AS alert_threshold" in bands
+    assert f"CAST({ROUTER_ENTROPY_MIN} AS DOUBLE) AS entropy_minimum" in bands
+    assert f"CAST({ROUTER_BIAS_MAX} AS DOUBLE) AS bias_upper_limit" in bands
+    assert f"CAST({-ROUTER_BIAS_MAX} AS DOUBLE) AS bias_lower_limit" in bands
 
 
 def test_clusters_dashboard_shows_finelog_fleet_health():

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -81,6 +81,18 @@ def _rules() -> list[dict]:
     return [rule for group in _load(ALERTING / "rules.yaml")["groups"] for rule in group["rules"]]
 
 
+def _route_for(rule: dict) -> dict:
+    """The first notification-policy route whose matchers all hold for this rule's labels."""
+    (policy,) = _load(ALERTING / "policies.yaml")["policies"]
+    return next(
+        route
+        for route in policy["routes"]
+        if all(
+            operator == "=" and rule["labels"].get(label) == value for label, operator, value in route["object_matchers"]
+        )
+    )
+
+
 def test_alert_rules_have_resolvable_datasources_and_refids():
     datasource_uids = set(_datasources())
     for rule in _rules():
@@ -324,14 +336,7 @@ def test_training_stall_alert_pages_each_hero_run_after_five_minutes():
     assert rule["labels"] == {"severity": "critical", "notification": "hero-run"}
     assert rule["data"][0]["model"]["url"] == "/alerts/training_stalls"
 
-    (policy,) = _load(ALERTING / "policies.yaml")["policies"]
-    route = next(
-        route
-        for route in policy["routes"]
-        if all(
-            operator == "=" and rule["labels"].get(label) == value for label, operator, value in route["object_matchers"]
-        )
-    )
+    route = _route_for(rule)
     assert route["receiver"] == "ops-critical"
     assert route["group_by"] == ["alertname", "run"]
     assert {column["selector"] for column in rule["data"][0]["model"]["columns"]} >= {"run", "job"}
@@ -358,15 +363,8 @@ def test_run_health_alerts_split_paging_from_announcing():
 def test_announcing_run_health_reaches_slack_without_a_triage_session():
     # severity=warning alone is muted by dashboard-only, so the announcing rule
     # needs the notification=slack route, which is matched first and unmuted.
-    (policy,) = _load(ALERTING / "policies.yaml")["policies"]
     (rule,) = [rule for rule in _rules() if rule["uid"] == "training-run-health-degraded"]
-    route = next(
-        route
-        for route in policy["routes"]
-        if all(
-            operator == "=" and rule["labels"].get(label) == value for label, operator, value in route["object_matchers"]
-        )
-    )
+    route = _route_for(rule)
 
     assert route["object_matchers"] == [["notification", "=", "slack"]]
     assert route["receiver"] == "ops-slack"


### PR DESCRIPTION
Add three Grafana rules over the hero run-health signals #8548 put on the training
dashboard, so the checks that only ran in the standalone Pushover monitor (#8527) also reach
Slack. `TrainingTelemetryGone` and `TrainingOptimizerUnstable` page on the existing
`notification=hero-run` route. `TrainingRunHealthDegraded` takes the announce-only
`notification=slack` exception for token drops above 7%, routing entropy below 5.92, a router
bias past 400, a throughput or MFU floor, a worse Paloma macro loss, a stale `iris.task_state`
row, and controller retries.

The three watch a wider enrollment than `TrainingProgressStalled` and `TrainingLossSpike`: a run
that either the Iris rollup or fresh Levanter `phase` telemetry reports. Enrolling from
`iris.task_state` alone means a break in that path stops watching a training run with no signal
that it happened, which is what the new `iris_state_stale` check reports. One bounded
`telemetry_v1` scan per bridge cache interval feeds all three, reduced over the newest execution
process zero reports so a retry cannot sum two attempts together.

The throughput checks count how much of the window sat below the floor rather than averaging it —
the median comparison the Pushover monitor makes, which keeps one restart step at zero from
reading as a slow run. `loss_jump` fires only where the six-sigma band did not already catch the
rise. `TrainingProgressStalled` now labels a silent run `telemetry_gone` and emits a zero instead
of firing beside `TrainingTelemetryGone`, so one telemetry outage stays one page.

Two thresholds differ from the Pushover monitor: the drop limit is 7% to match the band the
dashboard draws rather than 5%, and `iris_state_stale` needs a row that went stale rather than one
that never existed, because the GCE controllers publish no rollup at all. An `iris.task_state`
outage longer than the one-hour retention stops being visible.

The contract is in `docs/ops/hero-run-health-alerts.md`.

Part of #8542
