### PR TITLE
[grafana] Separate request TPOT from inter-token latency

### DIFF
--- a/infra/grafana/dashboards/inference.json
+++ b/infra/grafana/dashboards/inference.json
@@ -729,7 +729,7 @@
       "id": 7,
       "type": "table",
       "title": "Reset-aware latency evidence",
-      "description": "TTFT, TPOT/inter-token, queue, and end-to-end means from _sum/_count deltas plus p50/p90/p99 upper-bound estimates from bucket deltas. A reset or missing predecessor in any stored component invalidates the complete replica/family sample; a null quantile means the stored finite buckets do not bound it.",
+      "description": "TTFT, request TPOT, inter-token latency, queue, and end-to-end means from _sum/_count deltas plus p50/p90/p99 upper-bound estimates from bucket deltas. A reset or missing predecessor in any stored component invalidates the complete replica/family sample; a null quantile means the stored finite buckets do not bound it.",
       "datasource": {
         "type": "yesoreyeram-infinity-datasource",
         "uid": "finelog-marin"

--- a/infra/grafana/src/vllm_observability.py
+++ b/infra/grafana/src/vllm_observability.py
@@ -67,8 +67,8 @@ _GAUGES = (
 )
 _HISTOGRAM_FAMILIES = (
     ("time_to_first_token_seconds", "ttft"),
-    ("inter_token_latency_seconds", "tpot"),
-    ("time_per_output_token_seconds", "tpot"),
+    ("request_time_per_output_token_seconds", "tpot"),
+    ("inter_token_latency_seconds", "inter_token_latency"),
     ("request_queue_time_seconds", "queue"),
     ("e2e_request_latency_seconds", "e2e"),
 )

--- a/infra/grafana/tests/test_vllm_observability.py
+++ b/infra/grafana/tests/test_vllm_observability.py
@@ -206,6 +206,7 @@ def _latency_records() -> list[TelemetryRow]:
         ),
     ]
     for family, total_sum, count in (
+        ("request_time_per_output_token_seconds", 0.9, 3),
         ("inter_token_latency_seconds", 0.4, 4),
         ("request_queue_time_seconds", 0.6, 3),
         ("e2e_request_latency_seconds", 4.5, 3),
@@ -293,7 +294,8 @@ def test_query_derives_histogram_means_and_only_bounded_quantiles(overview_rows)
     assert _one(overview_rows, "latency", "ttft", "mean")["value"] == pytest.approx(0.875)
     assert _one(overview_rows, "latency", "ttft", "p50")["value"] == pytest.approx(0.5)
     assert _one(overview_rows, "latency", "ttft", "p90")["value"] is None
-    assert _one(overview_rows, "latency", "tpot", "mean")["value"] == pytest.approx(0.1)
+    assert _one(overview_rows, "latency", "tpot", "mean")["value"] == pytest.approx(0.3)
+    assert _one(overview_rows, "latency", "inter_token_latency", "mean")["value"] == pytest.approx(0.1)
     assert _one(overview_rows, "latency", "queue", "mean")["value"] == pytest.approx(0.2)
     assert _one(overview_rows, "latency", "e2e", "mean")["value"] == pytest.approx(1.5)
 


### PR DESCRIPTION
Read request-level TPOT from vLLM's `request_time_per_output_token_seconds` histogram and report `inter_token_latency_seconds` under a separate canonical family. The former `tpot` row contained inter-token latency because the request-level source name did not match vLLM telemetry.

Request TPOT contributes one mean decode time per completed request; inter-token latency measures gaps between emitted tokens. Both retain the existing reset-aware aggregation and no-data behavior.

Fixes #8572
