### PR TITLE
fix(iris): decode kubelet resource metrics response

### DIFF
--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -776,11 +776,13 @@ class CloudK8sService:
         logger.debug("k8s: node resource metrics node=%s", node_name)
         with slow_log(logger, "node_resource_metrics", threshold_ms=_SLOW_THRESHOLD_MS):
             try:
-                return self._core_v1.connect_get_node_proxy_with_path(
+                response = self._core_v1.connect_get_node_proxy_with_path(
                     name=node_name,
                     path="metrics/resource",
+                    _preload_content=False,
                     **self._request_timeout_kwargs(),
                 )
+                return response.data.decode("utf-8")
             except ApiException as error:
                 raise KubectlError(
                     f"get nodes/{node_name}/proxy/metrics/resource failed ({error.status}): {error.reason}"

--- a/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
@@ -100,6 +100,23 @@ def test_crud_client_requires_kubernetes(monkeypatch, client_attr: str):
         getattr(svc, client_attr)
 
 
+def test_node_resource_metrics_decodes_raw_response():
+    metrics = b"# HELP container_cpu_usage_seconds_total CPU usage.\ncontainer_cpu_usage_seconds_total 1.5\n"
+    request: dict = {}
+
+    def get_metrics(**kwargs):
+        request.update(kwargs)
+        return SimpleNamespace(data=metrics)
+
+    svc = CloudK8sService(namespace="iris")
+    svc.__dict__["_core_v1"] = SimpleNamespace(connect_get_node_proxy_with_path=get_metrics)
+
+    assert svc.node_resource_metrics("worker-0") == metrics.decode()
+    assert request["name"] == "worker-0"
+    assert request["path"] == "metrics/resource"
+    assert request["_preload_content"] is False
+
+
 class _FakeApiServer:
     """Paginating stand-in for one DynamicClient resource handle.
 


### PR DESCRIPTION
The Iris node agent receives kubelet resource metrics through the generated Kubernetes client. Its string deserializer preserves the byte representation and escaped newlines, so the Prometheus parser sees one line and emits no iris.task CPU or memory samples.

Request the raw HTTP response and decode UTF-8 at the Kubernetes service boundary. This restores newline-delimited metrics for the existing task resource collector.

Validated with the focused Iris tests and the diff-selected suite: 962 tests passed.