### PR TITLE
[training] Retry stalled TensorStore requests

### DIFF
--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -414,6 +414,11 @@ GPU_NCCL_TERMINATION_TIMEOUT_FLAG = "xla_gpu_nccl_termination_timeout_seconds"
 # or data loading. Set above the longest legitimate collective (cross-rank skew on
 # a cold start, checkpoint/eval barriers). Override per run via XLA_FLAGS.
 DEFAULT_GPU_NCCL_TERMINATION_TIMEOUT = 600
+TENSORSTORE_CURL_LOW_SPEED_TIME_ENV = "TENSORSTORE_CURL_LOW_SPEED_TIME_SECONDS"
+TENSORSTORE_CURL_LOW_SPEED_LIMIT_ENV = "TENSORSTORE_CURL_LOW_SPEED_LIMIT_BYTES"
+DEFAULT_TENSORSTORE_CURL_LOW_SPEED_TIME = "60"
+# TensorStore passes this decimal bytes-per-second value directly to libcurl: 1 Mbit/s.
+DEFAULT_TENSORSTORE_CURL_LOW_SPEED_LIMIT = "125000"
 
 
 def _add_gpu_collective_watchdog_env(env: dict[str, str]) -> None:
@@ -440,8 +445,9 @@ def resolve_training_env(
     Combines the base env from the user (typically ``train_config.env_vars``)
     with hardware-specific defaults from ``levanter.infra.cli_helpers``, run
     metadata (GIT_COMMIT, FERRY_DATE, etc. via ``add_run_env_variables``), a
-    JAX compilation cache pointing at ``marin_temp_bucket``, and a guard
-    against XLA's autotune subcache when the cache lives on remote storage.
+    JAX compilation cache pointing at ``marin_temp_bucket``, a TensorStore
+    stalled-request watchdog, and a guard against XLA's autotune subcache when
+    the cache lives on remote storage.
     """
     default_launch_config = _cli_helpers_module().load_config()
 
@@ -456,6 +462,12 @@ def resolve_training_env(
 
     if isinstance(resources.device, GpuConfig):
         _add_gpu_collective_watchdog_env(env)
+
+    # TensorStore's S3 retry policy only activates after curl reports an error. Without this
+    # watchdog, a dead connection has no request deadline and can remain in flight until the
+    # operating system times it out.
+    env.setdefault(TENSORSTORE_CURL_LOW_SPEED_TIME_ENV, DEFAULT_TENSORSTORE_CURL_LOW_SPEED_TIME)
+    env.setdefault(TENSORSTORE_CURL_LOW_SPEED_LIMIT_ENV, DEFAULT_TENSORSTORE_CURL_LOW_SPEED_LIMIT)
 
     if "JAX_COMPILATION_CACHE_DIR" not in env:
         env["JAX_COMPILATION_CACHE_DIR"] = _normalize_jax_compilation_cache_dir(

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -336,3 +336,27 @@ def test_resolve_training_env_adds_collective_watchdog_for_gpu():
     assert "--xla_gpu_enable_latency_hiding_scheduler=true" in gpu_flags
     assert GPU_NCCL_TERMINATION_TIMEOUT_FLAG in gpu_flags
     assert cpu_flags == base["XLA_FLAGS"]
+
+
+@pytest.mark.parametrize(
+    "overrides, expected_time, expected_limit",
+    [
+        ({}, "60", "125000"),
+        (
+            {
+                "TENSORSTORE_CURL_LOW_SPEED_TIME_SECONDS": "300",
+                "TENSORSTORE_CURL_LOW_SPEED_LIMIT_BYTES": "1",
+            },
+            "300",
+            "1",
+        ),
+    ],
+)
+def test_resolve_training_env_bounds_stalled_tensorstore_requests(overrides, expected_time, expected_limit):
+    base = {"JAX_COMPILATION_CACHE_DIR": "/tmp/cache", **overrides}
+    with patch("marin.training.training._cli_helpers_module") as mod:
+        mod.return_value.load_config.return_value = CliConfig()
+        env = resolve_training_env(base, ResourceConfig.with_gpu("H100", count=8))
+
+    assert env["TENSORSTORE_CURL_LOW_SPEED_TIME_SECONDS"] == expected_time
+    assert env["TENSORSTORE_CURL_LOW_SPEED_LIMIT_BYTES"] == expected_limit


### PR DESCRIPTION
Set TensorStore curl low-speed handling to abort remote requests that stay below 1 Mbit/s for 60 seconds. Native S3 retries can then recover one stalled checkpoint read instead of leaving a restore blocked until the operating system closes the socket.

Preserve explicit environment overrides for jobs that need different thresholds.

Part of #8534