### PR TITLE
[infra] Preserve CoreWeave bucket access

### DIFF
--- a/infra/buckets/README.md
+++ b/infra/buckets/README.md
@@ -63,14 +63,17 @@ curl -fsS \
   -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" | jq .result.rules
 ```
 
-The declared policy preserves seven-day incomplete-multipart cleanup and the nine
+The declared R2 policy preserves seven-day incomplete-multipart cleanup and the nine
 `tmp/ttl=Nd/` expiration prefixes from `config/marin.yaml`.
 
-CoreWeave bucket access policies deny every principal the `s3:DeleteObject` and
-`s3:DeleteObjectVersion` actions under `marin/grug/hero-*`. This protects permanent hero run
-checkpoints while leaving other runs and temporary checkpoint staging paths deletable. Before the
-first policy update, audit each bucket's live access policy; Pulumi replaces the complete bucket
-policy.
+CoreWeave bucket lifecycle configurations apply the same nine expiration prefixes and abort
+incomplete multipart uploads after seven days.
+
+CoreWeave bucket access policies preserve S3 access for principals in the Open Athena organization
+and deny every principal the `s3:DeleteObject` and `s3:DeleteObjectVersion` actions under
+`marin/grug/hero-*`. This protects permanent hero run checkpoints while leaving other runs and
+temporary checkpoint staging paths deletable. Before the first policy update, audit each bucket's
+live access policy; Pulumi replaces the complete bucket policy.
 
 ## Automation boundary
 

--- a/infra/pulumi/src/iac/buckets/coreweave.py
+++ b/infra/pulumi/src/iac/buckets/coreweave.py
@@ -13,6 +13,9 @@ from iac.buckets.lifecycle import expiration_rules
 
 HERO_CHECKPOINT_PREFIX = "marin/grug/hero-"
 CHECKPOINT_DELETE_ACTIONS = ("s3:DeleteObject", "s3:DeleteObjectVersion")
+COREWEAVE_ORGANIZATION_ID = "208261"
+COREWEAVE_MULTIPART_ABORT_RULE_ID = "marin-abort-incomplete-mpu"
+COREWEAVE_MULTIPART_EXPIRATION = 7
 
 
 def hero_checkpoint_delete_policy(bucket_name: str) -> str:
@@ -22,12 +25,27 @@ def hero_checkpoint_delete_policy(bucket_name: str) -> str:
             "Version": "2012-10-17",
             "Statement": [
                 {
+                    "Sid": "AllowOrganizationS3Access",
+                    "Effect": "Allow",
+                    "Principal": {"CW": "*"},
+                    "Action": ["s3:*"],
+                    "Resource": [
+                        f"arn:aws:s3:::{bucket_name}",
+                        f"arn:aws:s3:::{bucket_name}/*",
+                    ],
+                    "Condition": {
+                        "StringEquals": {
+                            "cw:PrincipalOrgID": [COREWEAVE_ORGANIZATION_ID],
+                        }
+                    },
+                },
+                {
                     "Sid": "DenyHeroCheckpointDeletion",
                     "Effect": "Deny",
                     "Principal": {"CW": "*"},
                     "Action": list(CHECKPOINT_DELETE_ACTIONS),
                     "Resource": f"arn:aws:s3:::{bucket_name}/{HERO_CHECKPOINT_PREFIX}*",
-                }
+                },
             ],
         },
         sort_keys=True,
@@ -47,6 +65,27 @@ class CoreweaveDataBuckets(pulumi.ComponentResource):
         opts: pulumi.ResourceOptions | None = None,
     ) -> None:
         super().__init__("marin:buckets:CoreweaveDataBuckets", name, None, opts)
+        lifecycle_rules = [
+            coreweave.ObjectStorageBucketLifecycleConfigurationRuleArgs(
+                id=COREWEAVE_MULTIPART_ABORT_RULE_ID,
+                status="Enabled",
+                filter=coreweave.ObjectStorageBucketLifecycleConfigurationRuleFilterArgs(prefix=""),
+                abort_incomplete_multipart_upload=(
+                    coreweave.ObjectStorageBucketLifecycleConfigurationRuleAbortIncompleteMultipartUploadArgs(
+                        days_after_initiation=COREWEAVE_MULTIPART_EXPIRATION
+                    )
+                ),
+            )
+        ]
+        lifecycle_rules.extend(
+            coreweave.ObjectStorageBucketLifecycleConfigurationRuleArgs(
+                id=rule.id,
+                status="Enabled",
+                filter=coreweave.ObjectStorageBucketLifecycleConfigurationRuleFilterArgs(prefix=rule.prefix),
+                expiration=coreweave.ObjectStorageBucketLifecycleConfigurationRuleExpirationArgs(days=rule.days),
+            )
+            for rule in expiration_rules(lifecycle_config)
+        )
         for bucket in sorted(data_config.region_buckets.values(), key=lambda spec: spec.name):
             if bucket.store is not StoreType.COREWEAVE:
                 continue
@@ -68,15 +107,7 @@ class CoreweaveDataBuckets(pulumi.ComponentResource):
             coreweave.ObjectStorageBucketLifecycleConfiguration(
                 f"lifecycle-{bucket.name}",
                 bucket=resource.name,
-                rules=[
-                    coreweave.ObjectStorageBucketLifecycleConfigurationRuleArgs(
-                        id=rule.id,
-                        status="Enabled",
-                        filter=coreweave.ObjectStorageBucketLifecycleConfigurationRuleFilterArgs(prefix=rule.prefix),
-                        expiration=coreweave.ObjectStorageBucketLifecycleConfigurationRuleExpirationArgs(days=rule.days),
-                    )
-                    for rule in expiration_rules(lifecycle_config)
-                ],
+                rules=lifecycle_rules,
                 opts=pulumi.ResourceOptions(
                     parent=self,
                     provider=coreweave_provider,

--- a/infra/pulumi/src/iac/buckets/coreweave.py
+++ b/infra/pulumi/src/iac/buckets/coreweave.py
@@ -18,8 +18,8 @@ COREWEAVE_MULTIPART_ABORT_RULE_ID = "marin-abort-incomplete-mpu"
 COREWEAVE_MULTIPART_EXPIRATION = 7
 
 
-def hero_checkpoint_delete_policy(bucket_name: str) -> str:
-    """Return a bucket policy denying deletion from permanent hero run paths."""
+def coreweave_bucket_policy(bucket_name: str) -> str:
+    """Return organization access with permanent hero deletion denied."""
     return json.dumps(
         {
             "Version": "2012-10-17",
@@ -119,7 +119,7 @@ class CoreweaveDataBuckets(pulumi.ComponentResource):
             coreweave.ObjectStorageBucketPolicy(
                 f"policy-{bucket.name}",
                 bucket=resource.name,
-                policy=resource.name.apply(hero_checkpoint_delete_policy),
+                policy=resource.name.apply(coreweave_bucket_policy),
                 opts=pulumi.ResourceOptions(
                     parent=self,
                     provider=coreweave_provider,

--- a/infra/pulumi/src/iac/buckets/r2.py
+++ b/infra/pulumi/src/iac/buckets/r2.py
@@ -52,7 +52,7 @@ class R2DataBuckets(pulumi.ComponentResource):
                 ),
             )
         ]
-        for rule in expiration_rules(lifecycle_config):
+        for rule in sorted(expiration_rules(lifecycle_config), key=lambda rule: rule.id):
             lifecycle_rules.append(
                 cloudflare.R2BucketLifecycleRuleArgs(
                     id=rule.id,


### PR DESCRIPTION
Scope CoreWeave bucket policies to Open Athena organization `208261` while preserving full S3 access for its principals. Deny object and version deletion under `marin/grug/hero-*` on all three buckets.

The deny-only policy from #8504 caused CoreWeave's default deny to block S3 data access and lifecycle operations. Add seven-day incomplete multipart cleanup alongside the nine standard TTL rules, and remove the temporary east benchmark TTL probe. Order R2 lifecycle rules by ID to match provider refresh behavior.

The policy and lifecycle changes are live. Protected-prefix writes and reads succeed, deletion returns `AccessDenied`, and unsigned list, read, and write requests return `403` on all three buckets.

Incident record: https://echo.oa.dev/wiki/215
