### PR TITLE
[ci] Bound system dependency setup in special-test jobs

### DIFF
--- a/.github/workflows/unified-unit.yaml
+++ b/.github/workflows/unified-unit.yaml
@@ -214,9 +214,17 @@ jobs:
             "https://download.pytorch.org/whl/cpu/torch-${TORCH_CPU_VERSION/+/%2B}-${CP_TAG}-${CP_TAG}-manylinux_2_28_x86_64.whl"
 
       - name: Install FFmpeg runtime
+        # torchcodec, which datasets uses to decode the audio fixtures, dlopens FFmpeg's
+        # shared libraries at import time. It needs neither the ffmpeg CLI nor headers,
+        # so install just those libraries and skip recommends: the full `ffmpeg` package
+        # pulls in a far larger dependency set and has taken over 13 minutes of this
+        # job's 15-minute budget.
+        timeout-minutes: 5
         run: |
           sudo apt-get update
-          sudo apt-get install -y ffmpeg
+          sudo apt-get install -y --no-install-recommends \
+            libavcodec60 libavformat60 libavutil58 \
+            libavfilter9 libswresample4 libswscale7
 
       - name: Test torch-marked suite
         # Run directly on CPU to avoid GPU dependency issues.
@@ -336,9 +344,15 @@ jobs:
       - name: Install Playwright browsers
         # Always run: `playwright install` only downloads browsers it does not already
         # have, so a warm cache stays fast, while a partial or stale cache self-heals
-        # instead of leaving a missing browser binary. `--with-deps` reinstalls the system
-        # libraries that the browser cache cannot hold.
-        run: uv run --package marin-iris playwright install --with-deps chromium
+        # instead of leaving a missing browser binary.
+        #
+        # No `--with-deps`: it shells out to apt-get, which contends with the runner's
+        # unattended-upgrades dpkg lock and can stall past the whole-job timeout. The
+        # ubuntu-24.04 image already ships Chrome and Chromium, so Chromium's system
+        # libraries are present. If a future image drops them, chromium fails to launch
+        # with a missing-shared-library error rather than hanging here.
+        timeout-minutes: 3
+        run: uv run --package marin-iris playwright install chromium
 
       - name: Run E2E smoke tests
         env:

--- a/infra/ci/select_tests.py
+++ b/infra/ci/select_tests.py
@@ -146,8 +146,10 @@ DEFAULT_LEG_TIMEOUT = 15
 # Levanter's accelerator lanes use the ordinary import-selected Levanter files below;
 # only the browser smoke remains a directory-triggered suite.
 DEPENDENCY_MANIFESTS: tuple[str, ...] = ("uv.lock", "pyproject.toml")
+# The CI broad triggers are included so a change to the smoke job's own workflow steps
+# runs it, matching how the Levanter accelerator lanes below already select.
 EXTRA_SUITE_TRIGGERS: dict[str, tuple[str, ...]] = {
-    "iris-e2e-smoke": ("lib/iris/", *DEPENDENCY_MANIFESTS),
+    "iris-e2e-smoke": ("lib/iris/", *sorted(CI_BROAD_TRIGGERS), *DEPENDENCY_MANIFESTS),
 }
 
 LEVANTER_ACCELERATOR_TRIGGERS: tuple[str, ...] = (

--- a/tests/infra/ci/test_select_tests.py
+++ b/tests/infra/ci/test_select_tests.py
@@ -13,6 +13,7 @@ from infra.ci.select_tests import (
     UV_PACKAGE,
     MatrixLeg,
     classify,
+    extra_suites,
     matrix_leg,
     select_changed_tests,
     select_local_tests,
@@ -218,3 +219,9 @@ def test_broad_trigger_does_not_source_build(tmp_path: Path) -> None:
     matrix = select_matrix(["uv.lock"], tmp_path)
     assert matrix, "broad trigger emits the full matrix"
     assert all(leg.setup == "" for leg in matrix)
+
+
+def test_workflow_change_selects_the_browser_smoke() -> None:
+    """The smoke suite runs its own workflow edits; nothing else selects them for it."""
+    assert extra_suites([".github/workflows/unified-unit.yaml"]) == ["iris-e2e-smoke"]
+    assert extra_suites([".github/workflows/marin-integration.yaml"]) == []


### PR DESCRIPTION
The levanter-torch and iris-e2e-smoke jobs both ran unbounded apt-get work inside short whole-job timeouts, so a slow Ubuntu mirror or dpkg lock contention consumed the test budget and the job was cancelled before reporting a result. levanter-torch spent 13m41s installing FFmpeg under a 15-minute limit and reached 33% of its tests; iris-e2e-smoke exhausted its full 10 minutes in `playwright install --with-deps`.

levanter-torch needs FFmpeg only because torchcodec, which datasets uses to decode the audio fixtures in test_audio.py, dlopens libav* at import time. The ffmpeg CLI package and its recommends are not used, so this installs the six shared libraries directly. iris-e2e-smoke does not need `--with-deps` at all: the ubuntu-24.04 image ships Chrome and Chromium, so Chromium's system libraries are already present, and the browser binaries are already restored from cache. Dropping the flag removes apt from that job. Both steps now carry a step-level timeout, so setup either completes or fails within a bounded time and leaves a predictable test budget.

Across the last 45 unified-unit runs these steps have a median of 18s (levanter-torch) and 19s (iris-e2e-smoke), and none exceeded 31s. The failures in the issue are tail events, so the timeouts are sized well above normal cost rather than to trim the median.

Both suites pass on this branch in a fork run. iris-e2e-smoke installed Chromium in 13s with no apt step and its E2E smoke tests passed, confirming Chromium launches without the apt-installed libraries. levanter-torch installed the FFmpeg libraries in 16s and its torch-marked suite ran for 3m28s, so torchcodec loaded and test_audio.py decoded against the reduced set rather than collecting nothing.

The third case in the issue, the GCP smoke run, needs no change: iris-smoke-gcp.yaml was removed in #8408.

The second commit is what lets this change validate itself. select_tests.py already treats a unified-unit.yaml edit as a broad trigger so the matrix validates the orchestration, and the Levanter accelerator lanes list the workflow among their triggers, but iris-e2e-smoke was selected only by `lib/iris/` and the dependency manifests. A change to that job's own setup steps would otherwise ship without ever running it.

If a future runner image drops the Chromium libraries, chromium fails to launch with a missing-shared-library error instead of hanging in apt. The same applies to the FFmpeg library set: torchcodec reports which libav* soname it could not load.

Fixes #8404
