### PR TITLE
[levanter] Stage GPU checkpoints in pageable host memory

### DIFF
--- a/experiments/grug/moe_hero_ep/memory_soak.py
+++ b/experiments/grug/moe_hero_ep/memory_soak.py
@@ -1,0 +1,374 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fast end-to-end soak for the EP hero's periodic hooks.
+
+The hero host OOM appears after hours of training. Checkpoint, evaluation, watch, and data-loader
+hooks run on multi-thousand-step cadences, so a rack run takes a day to produce a few samples.
+This run puts the same hooks on a one-step cadence on up to two GB200 trays, so 100 steps exercise
+100 checkpoints, tagged evaluations, and dropless evaluations.
+
+The shape is downsized but the memory-relevant machinery is the hero's: MuonH optimizer state
+offloaded to pinned host memory, FP32 pinned-host master parameters, and the pooled-wave transport.
+Those decide what the checkpoint path has to move through host memory, which is what the soak measures.
+
+Checkpoints go to a one-day temporary prefix, never to the hero's own checkpoint root.
+
+    uv run experiments/grug/moe_hero_ep/memory_soak.py --run-id soak-1 --version dev --run
+"""
+
+import dataclasses
+import os
+from datetime import timedelta
+
+import click
+import jmp
+import numpy as np
+from fray.cluster import ResourceConfig
+from levanter.callbacks.profiler import ProfilerConfig
+from levanter.callbacks.watch import WatchConfig
+from levanter.checkpoint import CheckpointerConfig
+from levanter.data.dataset import ListAsyncDataset
+from levanter.data.text.datasets import DirectDatasetComponent, LmDataConfig
+from levanter.data.text.examples import GrugLmExample
+from levanter.optim.config import AdamConfig
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
+from marin.execution.build_context import resolve_version
+from marin.execution.lazy import ArtifactStep, StepContext
+from marin.experiment.cli import build_options
+from marin.experiment.namespacing import user_namespaced_name
+from rigging.filesystem.cluster_config import marin_temp_bucket
+from rigging.filesystem.storage_path import prefix_join
+
+from experiments.grug.moe_hero_ep.heuristic import HERO_MODEL, MoeHeuristic
+from experiments.grug.moe_hero_ep.launch_mfu_test import (
+    DEFAULT_WANDB_PROJECT,
+    HERO_GPUS_PER_NODE,
+    HERO_MIXED_PRECISION,
+    HeroThroughputResult,
+)
+from experiments.grug.moe_hero_ep.model import QbEstimator
+from experiments.grug.moe_hero_ep.small_scale_abl_launch import (
+    _EP_CAPACITY_FACTOR,
+    SMALL_SHAPES,
+    SmallShape,
+    _small_model,
+)
+from experiments.grug.moe_hero_ep.train import (
+    GrugEvalConfig,
+    GrugRunConfig,
+    GrugTrainerConfig,
+    MasterParamMode,
+    TrainingDataMode,
+    WatchMode,
+    run_grug,
+)
+
+# A narrow shape makes the checkpointed state small enough to finish a soak in minutes.
+#
+# Replica splitting changes the write path. `plan_array_write` sends an array with replicas down
+# its replica-split branch. Each process writes a slice of the shard it holds and stages through a
+# transient slice. An array without replicas takes the single-writer branch and stages the training
+# shard itself. The hero runs 11 racks, so every one of its arrays has 11 replicas and takes the first
+# branch. A soak at expert 4 / replica 1 takes the second, and measures a path the hero never runs.
+DEFAULT_EXPERT_AXIS = 1
+DEFAULT_DP_REPLICAS = 1
+DEFAULT_SIZE = "d384"
+# Twelve routed experts divide across the hero's three receiver waves while keeping the model near
+# 100M parameters once embeddings and shared layers are included.
+DEFAULT_NUM_EXPERTS = 12
+DEFAULT_BATCH_SIZE = 1
+DEFAULT_STEPS = 100
+DEFAULT_EVAL_BATCHES = 2
+DEFAULT_SEQ_LEN = 512
+MAX_SOAK_TRAYS = 2
+# The schedule the hero's optimizer heuristic was tuned against. The soak trains 100 steps of its
+# head, so the learning rates match the hero's early steps instead of a 100-step schedule's.
+SOAK_SCHEDULE_STEPS = 390_251
+CHECKPOINT_TTL_DAYS = 1
+# Falsy `timedelta(0)` disables time-policy saves outright. A microsecond is below even a compiled
+# no-op step, making every call a real temporary save without retaining 100 permanent checkpoints.
+EVERY_STEP = timedelta(microseconds=1)
+QB_HIST_BINS = 10_000
+SOAK_SHAPES = {**SMALL_SHAPES, "d384": SmallShape(384, 4, 3, 1, 1)}
+
+
+def _synthetic_data_config(*, seq_len: int, vocab_size: int, eval_examples: int) -> LmDataConfig:
+    tokens = np.arange(seq_len, dtype=np.int32) % vocab_size
+    loss_weight = np.ones(seq_len, dtype=np.float32)
+    loss_weight[-1] = 0
+    example = GrugLmExample(tokens=tokens, loss_weight=loss_weight)
+    validation = ListAsyncDataset([example] * eval_examples)
+    return LmDataConfig(
+        tokenizer="passthrough",
+        vocab_size=vocab_size,
+        shuffle=False,
+        components={
+            "synthetic": DirectDatasetComponent(
+                datasets={"validation": validation},
+                tags=["synthetic"],
+            )
+        },
+        train_weights={},
+    )
+
+
+def build_memory_soak_run(
+    *,
+    run_id: str,
+    size: str = DEFAULT_SIZE,
+    num_experts: int = DEFAULT_NUM_EXPERTS,
+    batch_size: int = DEFAULT_BATCH_SIZE,
+    seq_len: int = DEFAULT_SEQ_LEN,
+    num_steps: int = DEFAULT_STEPS,
+    eval_batches: int = DEFAULT_EVAL_BATCHES,
+    expert_axis: int = DEFAULT_EXPERT_AXIS,
+    dp_replicas: int = DEFAULT_DP_REPLICAS,
+    version: str | None = None,
+) -> ArtifactStep[HeroThroughputResult]:
+    """Build a short synthetic run with checkpoints and evaluators on every step."""
+    if not run_id.strip():
+        raise ValueError("run_id must not be empty")
+    if size not in SOAK_SHAPES:
+        raise ValueError(f"size must be one of {sorted(SOAK_SHAPES)}, got {size!r}")
+    if num_experts % expert_axis != 0:
+        raise ValueError(f"num_experts={num_experts} must divide the expert axis {expert_axis}")
+    devices = expert_axis * dp_replicas
+    if devices > MAX_SOAK_TRAYS * HERO_GPUS_PER_NODE:
+        raise ValueError(
+            f"expert_axis x dp_replicas = {devices} exceeds {MAX_SOAK_TRAYS} " f"{HERO_GPUS_PER_NODE}-GPU trays"
+        )
+    if devices > HERO_GPUS_PER_NODE and devices % HERO_GPUS_PER_NODE != 0:
+        raise ValueError(f"multi-tray soaks must use whole {HERO_GPUS_PER_NODE}-GPU trays, got {devices} devices")
+
+    model = _small_model(
+        shape=SOAK_SHAPES[size],
+        capacity_factor=_EP_CAPACITY_FACTOR,
+        # FA4's packed-segment helper gives equivalent size-one mesh axes distinct explicit
+        # shardings. Reference attention avoids that single-device-only mismatch; attention
+        # implementation does not participate in checkpoint host staging.
+        attention_implementation="reference" if devices == 1 else HERO_MODEL.attention_implementation,
+        moe_implementation=HERO_MODEL.moe_implementation,
+        expert_chunks=HERO_MODEL.expert_chunks,
+        seq_len=seq_len,
+        num_experts=num_experts,
+        num_experts_per_token=HERO_MODEL.num_experts_per_token,
+        intermediate_dim=None,
+        latent_dim=None,
+        pooled_transport_capacity_factor=HERO_MODEL.pooled_transport_capacity_factor,
+        num_expert_waves=HERO_MODEL.num_expert_waves,
+        qb_use_histogram=True,
+        qb_hist_bins=QB_HIST_BINS,
+    )
+    local_experts = num_experts // expert_axis
+    if local_experts % model.num_expert_waves != 0:
+        raise ValueError(f"local expert count={local_experts} must divide num_expert_waves={model.num_expert_waves}")
+    model = dataclasses.replace(model, qb_estimator=QbEstimator.HIST, qb_hist_bins=QB_HIST_BINS)
+
+    if devices == 1:
+        # MuonH's Newton--Schulz contraction expects a nontrivial model axis. Adam keeps the
+        # single-device soak on the same training/checkpoint path without introducing a fake axis.
+        optimizer = AdamConfig(learning_rate=1e-3, weight_decay=0.0)
+    else:
+        optimizer = MoeHeuristic().build_optimizer_config(
+            num_train_steps=SOAK_SCHEDULE_STEPS,
+            batch_size=batch_size,
+            hidden_dim=model.hidden_dim,
+            seq_len=seq_len,
+        )
+    grug_trainer = GrugTrainerConfig(
+        data_seed=None,
+        log_every=1,
+        ema_beta=None,
+        z_loss_weight=1e-4,
+        # Both match the hero. They decide which leaves the checkpoint reads out of pinned host
+        # memory, which is the path under suspicion, so a soak without them tests something else.
+        offload_opt_state=True,
+        master_param_mode=MasterParamMode.FP32_PINNED_HOST,
+        training_data_mode=TrainingDataMode.SYNTHETIC,
+        watch_mode=WatchMode.INLINE,
+        save_checkpoints=True,
+        expert_axis_size=expert_axis,
+        replica_axis_size=dp_replicas,
+        sharding_dump_path=None,
+    )
+    gpus_per_task = min(devices, HERO_GPUS_PER_NODE)
+    tasks = (devices + gpus_per_task - 1) // gpus_per_task
+    train_resources = ResourceConfig.with_gpu(
+        "GB200",
+        count=gpus_per_task,
+        cpu=120 if gpus_per_task == HERO_GPUS_PER_NODE else 32,
+        ram="890g" if gpus_per_task == HERO_GPUS_PER_NODE else "192g",
+        disk="1t" if gpus_per_task == HERO_GPUS_PER_NODE else "256g",
+        replicas=tasks,
+    )
+    name = f"grug/{run_id}"
+    version = resolve_version(name, version)
+
+    def build_config(ctx: StepContext) -> GrugRunConfig:
+        trainer = TrainerConfig(
+            id=run_id,
+            seed=0,
+            train_batch_size=batch_size,
+            num_train_steps=SOAK_SCHEDULE_STEPS,
+            profiler=ProfilerConfig(enabled=False),
+            mp=jmp.get_policy(HERO_MIXED_PRECISION),
+            tracker=WandbConfig(
+                entity="marin-community",
+                project=os.environ.get("WANDB_PROJECT") or DEFAULT_WANDB_PROJECT,
+                tags=["grug", "moe", "hero", "ep", "memory-soak", "gb200", f"shape-{size}"],
+                group="moe-hero-ep-memory-soak",
+                name=run_id,
+                replicate_path=ctx.output_path,
+            ),
+            watch=WatchConfig(interval=1),
+            # Size-one axes can carry distinct explicit PartitionSpecs even though they map to
+            # the same single device, which makes elementwise operations reject their operands.
+            use_explicit_mesh_axes=devices > 1,
+            require_accelerator=True,
+            allow_nondivisible_batch_size=False,
+            checkpointer=CheckpointerConfig(
+                # A disposable one-day prefix, kept away from the hero's checkpoint root. Only the
+                # newest temporary checkpoint is retained, so 100 saves cost one checkpoint of space.
+                base_path=prefix_join(
+                    marin_temp_bucket(
+                        ttl_days=CHECKPOINT_TTL_DAYS,
+                        prefix=f"memory-soak/{run_id}",
+                        source_prefix=ctx.output_path,
+                    ),
+                    "checkpoints",
+                ),
+                temporary_base_path=None,
+                save_interval=EVERY_STEP,
+                keep=None,
+                append_run_id_to_base_path=False,
+                delete_old_temp_checkpoints=True,
+                keep_last_temporary_checkpoints=1,
+            ),
+        )
+        data = _synthetic_data_config(
+            seq_len=seq_len,
+            vocab_size=model.vocab_size,
+            eval_examples=eval_batches * devices,
+        )
+        return GrugRunConfig(
+            model=model,
+            data=data,
+            resources=ctx.runtime_arg("train_resources"),
+            optimizer=optimizer,
+            trainer=dataclasses.replace(grug_trainer, trainer=trainer),
+            eval=GrugEvalConfig(
+                eval_batch_size=devices,
+                steps_per_eval=1,
+                max_eval_batches=eval_batches,
+                eval_current=True,
+                eval_ema=False,
+                dropless_eval=True,
+            ),
+            stop_after_steps=num_steps,
+            processes_per_task=gpus_per_task,
+            max_retries_failure=0,
+            max_task_failures=0,
+        )
+
+    return ArtifactStep(
+        name=user_namespaced_name(name, version),
+        version=version,
+        artifact_type=HeroThroughputResult,
+        run=run_grug,
+        build_config=build_config,
+        deps=(),
+        runtime_args={"train_resources": train_resources},
+    )
+
+
+@click.command()
+@click.option("--run-id", required=True, help="Run identifier for the artifact, job, and W&B names.")
+@click.option(
+    "--size",
+    type=click.Choice(sorted(SOAK_SHAPES)),
+    default=DEFAULT_SIZE,
+    show_default=True,
+    help="Model width. Wider raises the per-process checkpoint share, which is what the save path moves.",
+)
+@click.option(
+    "--seq-len",
+    type=click.IntRange(min=128),
+    default=DEFAULT_SEQ_LEN,
+    show_default=True,
+    help="Sequence length. Short sequences keep the soak quick.",
+)
+@click.option(
+    "--num-experts",
+    type=click.IntRange(min=1),
+    default=DEFAULT_NUM_EXPERTS,
+    show_default=True,
+    help="Routed experts. Must divide the expert axis, with the per-GPU count divisible by the wave count.",
+)
+@click.option(
+    "--batch-size",
+    type=click.IntRange(min=1),
+    default=DEFAULT_BATCH_SIZE,
+    show_default=True,
+    help="Sequences per step. Small keeps the step short so 100 steps of hooks run quickly.",
+)
+@click.option(
+    "--num-steps",
+    type=click.IntRange(min=1),
+    default=DEFAULT_STEPS,
+    show_default=True,
+    help="Steps to run. Each one saves a checkpoint and runs every evaluator.",
+)
+@click.option(
+    "--eval-batches",
+    type=click.IntRange(min=1),
+    default=DEFAULT_EVAL_BATCHES,
+    show_default=True,
+    help="Batches per tagged eval set. These exercise evaluator memory.",
+)
+@click.option(
+    "--expert-axis",
+    type=click.IntRange(min=1),
+    default=DEFAULT_EXPERT_AXIS,
+    show_default=True,
+    help="Devices in each expert-parallel group.",
+)
+@click.option(
+    "--dp-replicas",
+    type=click.IntRange(min=1),
+    default=DEFAULT_DP_REPLICAS,
+    show_default=True,
+    help=(
+        "Replica groups. Above 1 every array has replicas and a save takes the replica-split write "
+        "path the hero runs; at 1 every array takes the single-writer path instead. "
+        "--expert-axis x --dp-replicas may use at most two trays."
+    ),
+)
+@build_options
+def main(
+    run_id: str,
+    size: str,
+    num_experts: int,
+    batch_size: int,
+    seq_len: int,
+    num_steps: int,
+    eval_batches: int,
+    expert_axis: int,
+    dp_replicas: int,
+) -> ArtifactStep[HeroThroughputResult]:
+    return build_memory_soak_run(
+        run_id=run_id,
+        size=size,
+        num_experts=num_experts,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        num_steps=num_steps,
+        eval_batches=eval_batches,
+        expert_axis=expert_axis,
+        dp_replicas=dp_replicas,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -203,7 +203,7 @@ than a numbered Attempt.
 many in seconds, so a grep for anything earlier in the run comes back empty:
 
 ```bash
-iris job logs /user/job/child --max-lines 400000 --no-tail | grep "Saving checkpoint"
+iris job logs /user/job/child --max-lines 400000 --no-tail --substring "Saving checkpoint"
 ```
 
 ### Submitting a GPU gang from a workstation

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -38,7 +38,6 @@ from rigging.filesystem.storage_path import StoragePath
 from levanter._debug_logging import flush_debug_output
 from levanter.tensorstore_serialization import (
     TensorStoreWriteConfig,
-    release_commit_futures,
     tree_deserialize_leaves_tensorstore,
     tree_serialize_leaves_tensorstore,
 )
@@ -694,7 +693,6 @@ class Checkpointer:
 
     def wait_until_finished(self):
         self._manager.wait_until_finished()
-        release_commit_futures(self._manager)
         if jax.process_index() == 0:
             while self._checkpoint_being_removed is not None or not self._async_checkpoint_remover_queue.empty():
                 time.sleep(0.2)

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -38,6 +38,7 @@ from rigging.filesystem.storage_path import StoragePath
 from levanter._debug_logging import flush_debug_output
 from levanter.tensorstore_serialization import (
     TensorStoreWriteConfig,
+    release_commit_futures,
     tree_deserialize_leaves_tensorstore,
     tree_serialize_leaves_tensorstore,
 )
@@ -693,6 +694,7 @@ class Checkpointer:
 
     def wait_until_finished(self):
         self._manager.wait_until_finished()
+        release_commit_futures(self._manager)
         if jax.process_index() == 0:
             while self._checkpoint_being_removed is not None or not self._async_checkpoint_remover_queue.empty():
                 time.sleep(0.2)

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -49,6 +49,7 @@ ARRAY_DRIVER = "zarr3"
 KVSTORE_DRIVER = "ocdbt"
 # JAX's memory kind for host memory a device can address. Offloaded optimizer state lives here.
 _HOST_MEMORY_KIND = "pinned_host"
+_PAGEABLE_HOST_MEMORY_KIND = "unpinned_host"
 _GPU_PLATFORM = "gpu"
 # Chunks a save stages at once. The budget is per process, so a node holds it once per local
 # process, and a process carries about four times what it holds in flight
@@ -94,6 +95,14 @@ def _trim_host_memory_after_commits(commit_futures: Sequence[ts.Future]) -> None
 
     for future in commit_futures:
         future.add_done_callback(commit_finished)
+
+
+def release_commit_futures(manager: array_ser.GlobalAsyncCheckpointManager) -> None:
+    """Drop a save's joined commit futures after they finish.
+
+    JAX overwrites ``_commit_futures`` on each save and never clears it.
+    """
+    manager._commit_futures = None
 
 
 def _format_gib(num_bytes: int) -> str:
@@ -162,11 +171,9 @@ def _slice_shard_on_device(data, axis: int, start: int, limit: int):
 async def _transfer_shard_to_pageable_host(shard, local_slice: tuple[int, int, int] | None = None) -> np.ndarray:
     """Snapshot a shard into pageable host memory, restricted to ``local_slice``.
 
-    The TPU runtime never returns JAX's pinned staging to the OS (#6924). State already in
-    host memory is snapshotted in place.
-
-    GPU shards owned by training stage through a transient host array so checkpoint
-    materialization does not retain a host copy on the long-lived source array.
+    Unsliced GPU shards are training-owned. Staging them on a disposable pageable CPU array keeps
+    JAX's NumPy cache off the live shard without entering CUDA's pinned-host allocator. Sliced
+    shards are already disposable, and TPU keeps its direct path.
     """
     data = shard.data if local_slice is None else _slice_shard_on_device(shard.data, *local_slice)
 
@@ -175,11 +182,11 @@ async def _transfer_shard_to_pageable_host(shard, local_slice: tuple[int, int, i
         return np.array(data, copy=True)
 
     if local_slice is None and data.device.platform == _GPU_PLATFORM:
-        # Move the host-value cache onto a transient array instead of the source array held by
-        # training. TPU keeps the direct path because its pinned staging is not returned to the OS.
-        staged = jax.device_put(data, SingleDeviceSharding(data.device, memory_kind=_HOST_MEMORY_KIND))
+        cpu_device = jax.local_devices(backend="cpu")[0]
+        pageable_sharding = SingleDeviceSharding(cpu_device, memory_kind=_PAGEABLE_HOST_MEMORY_KIND)
+        staged = jax.device_put(data, pageable_sharding)
         try:
-            await asyncio.sleep(0)
+            # The private NumPy snapshot must outlive the disposable JAX staging array.
             return np.array(staged, copy=True)
         finally:
             staged.delete()
@@ -709,6 +716,7 @@ def _serialize_arrays(
     barriers on the other processes.
     """
     manager.wait_until_finished()
+    release_commit_futures(manager)
 
     # JAX's process-lifetime context accumulates caches across saves, since each save writes a
     # new OCDBT database (#6785). Give each save bounded caches and copy concurrency of its own.

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -178,6 +178,8 @@ async def _transfer_shard_to_pageable_host(shard, local_slice: tuple[int, int, i
         pageable_sharding = SingleDeviceSharding(cpu_device, memory_kind=_PAGEABLE_HOST_MEMORY_KIND)
         staged = jax.device_put(data, pageable_sharding)
         try:
+            # Let the other staging coroutines enqueue their transfers before materialization blocks.
+            await asyncio.sleep(0)
             # The private NumPy snapshot must outlive the disposable JAX staging array.
             return np.array(staged, copy=True)
         finally:

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -97,14 +97,6 @@ def _trim_host_memory_after_commits(commit_futures: Sequence[ts.Future]) -> None
         future.add_done_callback(commit_finished)
 
 
-def release_commit_futures(manager: array_ser.GlobalAsyncCheckpointManager) -> None:
-    """Drop a save's joined commit futures after they finish.
-
-    JAX overwrites ``_commit_futures`` on each save and never clears it.
-    """
-    manager._commit_futures = None
-
-
 def _format_gib(num_bytes: int) -> str:
     return f"{num_bytes / (1024**3):.2f}GiB"
 
@@ -716,7 +708,6 @@ def _serialize_arrays(
     barriers on the other processes.
     """
     manager.wait_until_finished()
-    release_commit_futures(manager)
 
     # JAX's process-lifetime context accumulates caches across saves, since each save writes a
     # new OCDBT database (#6785). Give each save bounded caches and copy concurrency of its own.


### PR DESCRIPTION
Stage unsliced GPU checkpoint shards through a disposable pageable CPU JAX array before creating the immutable NumPy snapshot. This keeps JAX's host-value cache off the donated training shard without activating CUDA's pinned-host BFC pool. Host-resident state, replica-sliced shards, and TPU retain their existing paths.

A synthetic d384/E24 soak ran train, checkpoint, tagged eval, and dropless eval on every step across two GB200 trays.

| Metric | Source staging | Pageable staging |
| --- | ---: | ---: |
| Summed process RSS, step 0 → 99 | 40.41 → 44.17 GiB | 40.40 → 43.71 GiB |
| JAX host cache at step 99 | 193.35 MiB | 7.84 MiB |
| Median checkpoint RSS increase | 1.16 GiB | 0.93 GiB |
| p95 task-cgroup peak | 41.40 GiB | 41.17 GiB |
| Step 60–99 RSS slope, 95% CI | +1.10 [-10.19, 12.40] MiB/step | +0.61 [-9.30, 10.52] MiB/step |

Pageable staging reduced final RSS by 0.46 GiB, the JAX cache by 185.5 MiB, and the median checkpoint transient by 0.23 GiB. The late slopes are statistically indistinguishable from zero. The stable envelope appeared around checkpoint 60; at checkpoint 11 the pageable run was still about 0.64 GiB below its final envelope, so this soak does not establish checkpoint-11 headroom for the production hero run.

A d1024/E384 validation exercised about 4.0B total parameters on eight GB200s. It completed 25 training steps, 25 per-step checkpoints plus the final save, and both evaluators on every step.

| Metric | Result |
| --- | ---: |
| Global checkpoint size | 38.06 GiB |
| Median / maximum staged bytes per rank | 4.75 / 4.78 GiB |
| Peak Kubernetes working set, tray 0 / tray 1 | 102.1 / 106.5 GiB |
| Post-warmup first → last sample, tray 0 | 102.1 → 101.1 GiB |
| Post-warmup first → last sample, tray 1 | 102.2 → 106.5 GiB |
| Training / task duration | 2m58s / 4m47s |

The 30-second working-set samples are phase-offset from the five-second checkpoint cadence. Tray 0 was flat after warmup; tray 1 added 4.3 GiB through its last sample. Twenty-five steps validate the transient headroom. They do not establish a long-run plateau. Both trays stayed below 13% of their memory limit and all checkpoint commits completed.

The matched commit-future ablation did not improve normalized memory growth and had a worse late slope in the clearing arm, so this change leaves JAX's future lifecycle unchanged.

The included launcher defaults to a roughly 100M-parameter, single-GPU synthetic run and exposes workload dimensions needed to scale the soak to two trays. Checkpoints and both evaluators run every step.

Experiment details and allocator findings are recorded in [Echo wiki 229](https://echo.oa.dev/wiki/229). The 4B validation is available in [Iris](https://iris.oa.dev/#/job/%2Fpower%2Fcodex-hostmem-pageable-4b-2tray-25step-r1-20260824-coord).
