### PR TITLE
iris: retain Kubernetes disruption evidence

### DIFF
--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -282,8 +282,11 @@ iris task exec /user/job/0 -- python -c "import jax; print(jax.devices())"
 garbage-collected. It queries `iris.task_event` across every retained attempt in
 the task's current job incarnation in one call and shows both backend
 observations (`k8s/kueue`, `k8s/container`) and controller decisions
-(`iris/controller`) in chronological order. Events are retained for up to seven
-days.
+(`iris/controller`) in chronological order. Events are retained for up to 30
+days. Kubernetes `DisruptionTarget` conditions are recorded as
+`k8s/disruption` events with the pod and node identity plus a snapshot of the
+node's taints, conditions, hardware/topology labels, and CoreWeave health
+annotations.
 
 Default timeout is 60s. Use `--timeout 300` for slow commands, `--timeout -1` for no timeout (last resort).
 
@@ -554,7 +557,7 @@ Namespaces:
   restart resets that peak. Kubelet resource metrics do not expose container
   filesystem usage, so Kubernetes rows report zero disk usage. The node-agent
   service account requires `get` on `nodes/proxy`.
-- `iris.task_event` — up to seven days of deduplicated backend verdicts and
+- `iris.task_event` — up to 30 days of deduplicated backend verdicts and
   state-changing controller actions per task attempt. Query all attempts with
   `iris task events /user/job/0`, or directly:
 
@@ -564,6 +567,24 @@ Namespaces:
   WHERE task_id='/user/job/0' AND attempt_uid='<uid from iris task describe>'
   ORDER BY ts ASC;
   ```
+
+  Kubernetes disruptions use `source='k8s/disruption'`. The row captures the
+  pod UID and enough node evidence to identify a physical machine across node
+  renames and reboots. To inspect taint-manager evictions across the fleet:
+
+  ```sql
+  SELECT cluster, ts, task_id, attempt_id, pod_name, node_name,
+         node_uid, node_provider_id, node_boot_id, node_system_uuid,
+         reason, message, pod_conditions_json, node_taints_json,
+         node_conditions_json
+  FROM "iris.task_event"
+  WHERE source='k8s/disruption' AND reason='DeletionByTaintManager'
+  ORDER BY ts DESC;
+  ```
+
+  One node drain can disrupt many pods. Treat rows with the same cluster,
+  `node_system_uuid`, `node_boot_id`, and nearby timestamps as one machine
+  incident before counting repeat offenders.
 - `iris.task_state` — controller-emitted (every 30s) task counts by state per root job, plus `oldest_pending_age_ms` / `oldest_building_age_ms` wait ages, keyed by `root_job_id`. The `root_job_id=""` row is the per-cluster rollup, written even when idle — its absence means the controller is down. Feeds fleet-wide stuck-BUILDING alerting and queue-depth history.
 - `iris.admission_probe` — on Kubernetes clusters, the outcome (every 60s) of a `dryRun=All` canary pod apply that traverses the full admission chain, keyed by `outcome` (`ok`/`failed` with `error_class`, latency, truncated message). `failed` rows (or silence) detect fail-closed admission webhooks before any task pod exists.
 - `iris.profile` — per-capture profile blobs (cpu/memory/thread, periodic or on-demand), keyed by `source` so the dashboard's per-source list query prunes via parquet row-group min/max. Filter on `source` (a task path like `/user/job/.../<index>`, `/system/worker/<id>`, or `/system/controller`) and `type` (`cpu`/`memory`/`thread`). `format` is the blob encoding — the GCE/TPU worker's periodic CPU captures are py-spy **speedscope** JSON; the k8s backend's periodic captures are py-spy **thread dumps** (`type=thread`), since a hung collective samples no CPU but a thread dump pinpoints where every rank is blocked. `vm_id` is the writer VM (worker id, `controller-self`, or `k8s/<node-or-pod>`). To find a hang, read the last periodic `thread` capture per `source` before the freeze.

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -1478,8 +1478,24 @@ def _workload_for_pod(pod: dict, workloads: _KueueWorkloadIndex) -> dict | None:
 
 # The layer that produced a task-event verdict, recorded as the event ``source``.
 _EVENT_SOURCE_CONTAINER = "k8s/container"
+_EVENT_SOURCE_DISRUPTION = "k8s/disruption"
 _EVENT_SOURCE_KUEUE = "k8s/kueue"
 _EVENT_SOURCE_SCHEDULER = "k8s/scheduler"
+
+_NODE_DIAGNOSTIC_LABEL_PREFIXES = (
+    "compute.coreweave.com/",
+    "gpu.coreweave.cloud/",
+    "gpu.nvidia.com/",
+    "ib.coreweave.cloud/",
+    "node.coreweave.cloud/",
+    "node.kubernetes.io/",
+    "topology.kubernetes.io/",
+)
+_NODE_DIAGNOSTIC_ANNOTATION_PREFIXES = (
+    "cwnc.coreweave.com/",
+    "gpu.coreweave.cloud/",
+    "node.coreweave.cloud/",
+)
 
 # Pod/container reasons that are always operator-actionable failures (rather than
 # a transient wait), surfaced as Warning-severity events.
@@ -1506,6 +1522,70 @@ class _PodEvent:
     reason: str
     message: str
     severity: TaskEventSeverity
+    pod_name: str | None = None
+    pod_uid: str | None = None
+    pod_deletion_timestamp: str | None = None
+    node_name: str | None = None
+    node_uid: str | None = None
+    node_provider_id: str | None = None
+    node_boot_id: str | None = None
+    node_system_uuid: str | None = None
+    node_unschedulable: bool | None = None
+    pod_tolerations_json: str | None = None
+    pod_conditions_json: str | None = None
+    node_taints_json: str | None = None
+    node_conditions_json: str | None = None
+    node_labels_json: str | None = None
+    node_annotations_json: str | None = None
+
+
+def _diagnostic_metadata(values: dict, prefixes: tuple[str, ...]) -> dict:
+    return {key: value for key, value in values.items() if key.startswith(prefixes)}
+
+
+def _diagnostic_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _disruption_event(pod: dict, node: dict | None, disruption: dict) -> _PodEvent:
+    pod_metadata = pod.get("metadata", {})
+    pod_spec = pod.get("spec", {})
+    node_metadata = node.get("metadata", {}) if node is not None else {}
+    node_spec = node.get("spec", {}) if node is not None else {}
+    node_status = node.get("status", {}) if node is not None else {}
+    node_info = node_status.get("nodeInfo", {})
+
+    return _PodEvent(
+        source=_EVENT_SOURCE_DISRUPTION,
+        reason=disruption.get("reason", "") or _DISRUPTION_TARGET_CONDITION,
+        message=disruption.get("message", ""),
+        severity=TaskEventSeverity.WARNING,
+        pod_name=pod_metadata.get("name") or None,
+        pod_uid=pod_metadata.get("uid") or None,
+        pod_deletion_timestamp=pod_metadata.get("deletionTimestamp") or None,
+        node_name=pod_spec.get("nodeName") or None,
+        node_uid=node_metadata.get("uid") or None,
+        node_provider_id=node_spec.get("providerID") or None,
+        node_boot_id=node_info.get("bootID") or None,
+        node_system_uuid=node_info.get("systemUUID") or None,
+        node_unschedulable=bool(node_spec.get("unschedulable")) if node is not None else None,
+        pod_tolerations_json=_diagnostic_json(pod_spec.get("tolerations", [])),
+        pod_conditions_json=_diagnostic_json(pod.get("status", {}).get("conditions", [])),
+        node_taints_json=_diagnostic_json(node_spec.get("taints", [])) if node is not None else None,
+        node_conditions_json=_diagnostic_json(node_status.get("conditions", [])) if node is not None else None,
+        node_labels_json=(
+            _diagnostic_json(_diagnostic_metadata(node_metadata.get("labels", {}), _NODE_DIAGNOSTIC_LABEL_PREFIXES))
+            if node is not None
+            else None
+        ),
+        node_annotations_json=(
+            _diagnostic_json(
+                _diagnostic_metadata(node_metadata.get("annotations", {}), _NODE_DIAGNOSTIC_ANNOTATION_PREFIXES)
+            )
+            if node is not None
+            else None
+        ),
+    )
 
 
 def _workload_admission_blocked(workload: dict | None) -> bool:
@@ -1524,7 +1604,7 @@ def _workload_admission_blocked(workload: dict | None) -> bool:
     return False
 
 
-def _pod_event(pod: dict, workload: dict | None) -> _PodEvent | None:
+def _pod_event(pod: dict, workload: dict | None, node: dict | None = None) -> _PodEvent | None:
     """The current actionable backend event for a pod.
 
     ``source`` attributes the verdict to the layer that produced it (the task
@@ -1534,6 +1614,8 @@ def _pod_event(pod: dict, workload: dict | None) -> _PodEvent | None:
     running or otherwise quiet pod.
     """
     disruption = _disruption_condition(pod)
+    if disruption is not None and disruption.get("type") == _DISRUPTION_TARGET_CONDITION:
+        return _disruption_event(pod, node, disruption)
     if disruption is not None and disruption.get("type") == _KUEUE_TERMINATION_TARGET_CONDITION:
         return _PodEvent(
             source=_EVENT_SOURCE_KUEUE,
@@ -1943,26 +2025,27 @@ class TaskEventLog:
     verdicts come from the pod/workload lists ``sync`` already fetches.
     ``observe`` is called once per tracked attempt per cycle with the attempt's
     current verdict (or ``None`` when the pod is running/quiet); a row is written
-    only when the ``(source, reason, severity)`` verdict *changes*, so a pod
-    wedged in one state produces a single row, not one per poll — but a severity
-    upgrade (e.g. a gated pod Kueue later declines flips Normal→Warning under the
-    same source/reason) is a change and does record the actionable row. ``retain``
-    drops dedup state for attempts no longer polled so a retried attempt (new
-    ``attempt_id``) starts clean and the map stays bounded.
+    only when the ``(source, reason, severity)`` verdict *changes*, or when a
+    disruption first gains its node snapshot, so a pod wedged in one state
+    produces a single row, not one per poll. A severity upgrade (e.g. a gated
+    pod Kueue later declines flips Normal→Warning under the same source/reason)
+    records the actionable row. ``retain`` drops dedup state for attempts no
+    longer polled so a retried attempt (new ``attempt_id``) starts clean and the
+    map stays bounded.
     """
 
     def __init__(self, task_event_table: Table):
         self._table = task_event_table
-        self._last_verdict: dict[RunningTaskEntry, tuple[str, str, TaskEventSeverity]] = {}
+        self._last_verdict: dict[RunningTaskEntry, tuple[str, str, TaskEventSeverity, bool]] = {}
 
     def observe(self, attempt: RunningTaskEntry, event: _PodEvent | None) -> None:
         """Record ``event`` for ``attempt`` if its verdict has changed."""
         if event is None:
             return
-        verdict = (event.source, event.reason, event.severity)
+        has_node_evidence = event.node_uid is not None or event.node_conditions_json is not None
+        verdict = (event.source, event.reason, event.severity, has_node_evidence)
         if self._last_verdict.get(attempt) == verdict:
             return
-        self._last_verdict[attempt] = verdict
         row = TaskEventRow(
             task_id=attempt.task_id.to_wire(),
             attempt_id=attempt.attempt_id,
@@ -1973,11 +2056,28 @@ class TaskEventLog:
             message=event.message,
             source=event.source,
             count=1,
+            pod_name=event.pod_name,
+            pod_uid=event.pod_uid,
+            pod_deletion_timestamp=event.pod_deletion_timestamp,
+            node_name=event.node_name,
+            node_uid=event.node_uid,
+            node_provider_id=event.node_provider_id,
+            node_boot_id=event.node_boot_id,
+            node_system_uuid=event.node_system_uuid,
+            node_unschedulable=event.node_unschedulable,
+            pod_tolerations_json=event.pod_tolerations_json,
+            pod_conditions_json=event.pod_conditions_json,
+            node_taints_json=event.node_taints_json,
+            node_conditions_json=event.node_conditions_json,
+            node_labels_json=event.node_labels_json,
+            node_annotations_json=event.node_annotations_json,
         )
         try:
             self._table.write([row])
         except Exception:
             logger.debug("TaskEventLog: write to iris.task_event failed", exc_info=True)
+            return
+        self._last_verdict[attempt] = verdict
 
     def retain(self, active: set[RunningTaskEntry]) -> None:
         """Forget verdicts for attempts not in ``active`` (terminal or gone)."""
@@ -2413,13 +2513,13 @@ class K8sTaskProvider:
             logger.warning("Failed to query Kueue workloads: %s", e)
             workloads = []
 
-        updates = apply_failures + self._poll_pods(request.running_tasks, managed_pods, workloads)
-
         try:
             nodes = self.kubectl.list_json(K8sResource.NODES)
         except Exception as e:
             logger.warning("Failed to query node resources: %s", e)
             nodes = []
+
+        updates = apply_failures + self._poll_pods(request.running_tasks, managed_pods, workloads, nodes)
 
         node_pools = _fetch_node_pools(self.kubectl, self.pods.managed_label)
         self._cluster_state.update(managed_pods, nodes, workloads, node_pools)
@@ -2946,7 +3046,11 @@ class K8sTaskProvider:
             )
 
     def _poll_pods(
-        self, running: list[RunningTaskEntry], cached_pods: list[dict], workloads: list[dict] | None = None
+        self,
+        running: list[RunningTaskEntry],
+        cached_pods: list[dict],
+        workloads: list[dict] | None = None,
+        nodes: list[dict] | None = None,
     ) -> list[TaskUpdate]:
         """Poll pod phases for all running tasks.
 
@@ -2971,6 +3075,7 @@ class K8sTaskProvider:
             return []
 
         pods_by_name: dict[str, dict] = {pod.get("metadata", {}).get("name", ""): pod for pod in cached_pods}
+        nodes_by_name = {node.get("metadata", {}).get("name", ""): node for node in nodes or []}
         workload_index = _kueue_workload_index(workloads or [])
         updates: list[TaskUpdate] = []
 
@@ -3068,7 +3173,8 @@ class K8sTaskProvider:
                     node_name=pod.get("spec", {}).get("nodeName", "") or "",
                 )
             if event_log is not None:
-                event_log.observe(entry, _pod_event(pod, workload))
+                node = nodes_by_name.get(pod.get("spec", {}).get("nodeName", ""))
+                event_log.observe(entry, _pod_event(pod, workload, node))
 
             updates.append(update)
 

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -18,7 +18,7 @@ import time
 from collections.abc import Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import ClassVar, NamedTuple
@@ -106,6 +106,7 @@ from iris.cluster.stats.emitter import PeriodicEmitter
 from iris.cluster.stats.tables import (
     IrisProfile,
     ProfileTrigger,
+    TaskEventDiagnostics,
     TaskEventRow,
     TaskEventSeverity,
     stats_timestamp,
@@ -1522,21 +1523,7 @@ class _PodEvent:
     reason: str
     message: str
     severity: TaskEventSeverity
-    pod_name: str | None = None
-    pod_uid: str | None = None
-    pod_deletion_timestamp: str | None = None
-    node_name: str | None = None
-    node_uid: str | None = None
-    node_provider_id: str | None = None
-    node_boot_id: str | None = None
-    node_system_uuid: str | None = None
-    node_unschedulable: bool | None = None
-    pod_tolerations_json: str | None = None
-    pod_conditions_json: str | None = None
-    node_taints_json: str | None = None
-    node_conditions_json: str | None = None
-    node_labels_json: str | None = None
-    node_annotations_json: str | None = None
+    diagnostics: TaskEventDiagnostics = field(default_factory=TaskEventDiagnostics)
 
 
 def _diagnostic_metadata(values: dict, prefixes: tuple[str, ...]) -> dict:
@@ -1560,30 +1547,32 @@ def _disruption_event(pod: dict, node: dict | None, disruption: dict) -> _PodEve
         reason=disruption.get("reason", "") or _DISRUPTION_TARGET_CONDITION,
         message=disruption.get("message", ""),
         severity=TaskEventSeverity.WARNING,
-        pod_name=pod_metadata.get("name") or None,
-        pod_uid=pod_metadata.get("uid") or None,
-        pod_deletion_timestamp=pod_metadata.get("deletionTimestamp") or None,
-        node_name=pod_spec.get("nodeName") or None,
-        node_uid=node_metadata.get("uid") or None,
-        node_provider_id=node_spec.get("providerID") or None,
-        node_boot_id=node_info.get("bootID") or None,
-        node_system_uuid=node_info.get("systemUUID") or None,
-        node_unschedulable=bool(node_spec.get("unschedulable")) if node is not None else None,
-        pod_tolerations_json=_diagnostic_json(pod_spec.get("tolerations", [])),
-        pod_conditions_json=_diagnostic_json(pod.get("status", {}).get("conditions", [])),
-        node_taints_json=_diagnostic_json(node_spec.get("taints", [])) if node is not None else None,
-        node_conditions_json=_diagnostic_json(node_status.get("conditions", [])) if node is not None else None,
-        node_labels_json=(
-            _diagnostic_json(_diagnostic_metadata(node_metadata.get("labels", {}), _NODE_DIAGNOSTIC_LABEL_PREFIXES))
-            if node is not None
-            else None
-        ),
-        node_annotations_json=(
-            _diagnostic_json(
-                _diagnostic_metadata(node_metadata.get("annotations", {}), _NODE_DIAGNOSTIC_ANNOTATION_PREFIXES)
-            )
-            if node is not None
-            else None
+        diagnostics=TaskEventDiagnostics(
+            pod_name=pod_metadata.get("name") or None,
+            pod_uid=pod_metadata.get("uid") or None,
+            pod_deletion_timestamp=pod_metadata.get("deletionTimestamp") or None,
+            node_name=pod_spec.get("nodeName") or None,
+            node_uid=node_metadata.get("uid") or None,
+            node_provider_id=node_spec.get("providerID") or None,
+            node_boot_id=node_info.get("bootID") or None,
+            node_system_uuid=node_info.get("systemUUID") or None,
+            node_unschedulable=bool(node_spec.get("unschedulable")) if node is not None else None,
+            pod_tolerations_json=_diagnostic_json(pod_spec.get("tolerations", [])),
+            pod_conditions_json=_diagnostic_json(pod.get("status", {}).get("conditions", [])),
+            node_taints_json=_diagnostic_json(node_spec.get("taints", [])) if node is not None else None,
+            node_conditions_json=_diagnostic_json(node_status.get("conditions", [])) if node is not None else None,
+            node_labels_json=(
+                _diagnostic_json(_diagnostic_metadata(node_metadata.get("labels", {}), _NODE_DIAGNOSTIC_LABEL_PREFIXES))
+                if node is not None
+                else None
+            ),
+            node_annotations_json=(
+                _diagnostic_json(
+                    _diagnostic_metadata(node_metadata.get("annotations", {}), _NODE_DIAGNOSTIC_ANNOTATION_PREFIXES)
+                )
+                if node is not None
+                else None
+            ),
         ),
     )
 
@@ -1607,11 +1596,11 @@ def _workload_admission_blocked(workload: dict | None) -> bool:
 def _pod_event(pod: dict, workload: dict | None, node: dict | None = None) -> _PodEvent | None:
     """The current actionable backend event for a pod.
 
-    ``source`` attributes the verdict to the layer that produced it (the task
-    container, the Kueue gate, or the scheduler); ``severity`` is Warning for an
-    actionable failure (image pull, config error, Kueue eviction) or a
-    Kueue-declined admission, Normal for a transient wait. Returns ``None`` for a
-    running or otherwise quiet pod.
+    ``source`` attributes the verdict to the layer that produced it (a Kubernetes
+    disruption, the task container, the Kueue gate, or the scheduler);
+    ``severity`` is Warning for an actionable failure (image pull, config error,
+    disruption, Kueue eviction) or a Kueue-declined admission, Normal for a
+    transient wait. Returns ``None`` for a healthy running or otherwise quiet pod.
     """
     disruption = _disruption_condition(pod)
     if disruption is not None and disruption.get("type") == _DISRUPTION_TARGET_CONDITION:
@@ -2042,7 +2031,7 @@ class TaskEventLog:
         """Record ``event`` for ``attempt`` if its verdict has changed."""
         if event is None:
             return
-        has_node_evidence = event.node_uid is not None or event.node_conditions_json is not None
+        has_node_evidence = event.diagnostics.node_uid is not None or event.diagnostics.node_conditions_json is not None
         verdict = (event.source, event.reason, event.severity, has_node_evidence)
         if self._last_verdict.get(attempt) == verdict:
             return
@@ -2056,21 +2045,7 @@ class TaskEventLog:
             message=event.message,
             source=event.source,
             count=1,
-            pod_name=event.pod_name,
-            pod_uid=event.pod_uid,
-            pod_deletion_timestamp=event.pod_deletion_timestamp,
-            node_name=event.node_name,
-            node_uid=event.node_uid,
-            node_provider_id=event.node_provider_id,
-            node_boot_id=event.node_boot_id,
-            node_system_uuid=event.node_system_uuid,
-            node_unschedulable=event.node_unschedulable,
-            pod_tolerations_json=event.pod_tolerations_json,
-            pod_conditions_json=event.pod_conditions_json,
-            node_taints_json=event.node_taints_json,
-            node_conditions_json=event.node_conditions_json,
-            node_labels_json=event.node_labels_json,
-            node_annotations_json=event.node_annotations_json,
+            **asdict(event.diagnostics),
         )
         try:
             self._table.write([row])

--- a/lib/iris/src/iris/cluster/controller/writes.py
+++ b/lib/iris/src/iris/cluster/controller/writes.py
@@ -1070,6 +1070,10 @@ def mirror_federated_attempts(
                 error=attempt.error or None,
                 attempt_uid=attempt_uid,
                 backend_id="",
+                pod_name=attempt.pod_name,
+                pod_uid=attempt.pod_uid,
+                node_name=attempt.node_name,
+                terminal_reason=attempt.terminal_reason,
             )
             .on_conflict_do_update(
                 index_elements=["task_id", "attempt_id"],
@@ -1079,6 +1083,10 @@ def mirror_federated_attempts(
                     "finished_at_ms": finished,
                     "exit_code": attempt.exit_code or None,
                     "error": attempt.error or None,
+                    "pod_name": attempt.pod_name,
+                    "pod_uid": attempt.pod_uid,
+                    "node_name": attempt.node_name,
+                    "terminal_reason": attempt.terminal_reason,
                 },
             )
         )

--- a/lib/iris/src/iris/cluster/stats/tables.py
+++ b/lib/iris/src/iris/cluster/stats/tables.py
@@ -181,8 +181,29 @@ class TaskStatusRow:
     status_text_summary_md: str
 
 
+@dataclass(kw_only=True)
+class TaskEventDiagnostics:
+    """Pod and node evidence captured while a Kubernetes disruption is observable."""
+
+    pod_name: str | None = None
+    pod_uid: str | None = None
+    pod_deletion_timestamp: str | None = None
+    node_name: str | None = None
+    node_uid: str | None = None
+    node_provider_id: str | None = None
+    node_boot_id: str | None = None
+    node_system_uuid: str | None = None
+    node_unschedulable: bool | None = None
+    pod_tolerations_json: str | None = None
+    pod_conditions_json: str | None = None
+    node_taints_json: str | None = None
+    node_conditions_json: str | None = None
+    node_labels_json: str | None = None
+    node_annotations_json: str | None = None
+
+
 @dataclass
-class TaskEventRow:
+class TaskEventRow(TaskEventDiagnostics):
     """One backend event or controller action for a task attempt.
 
     The "event log for every job": producers append a row each time a backend
@@ -209,21 +230,6 @@ class TaskEventRow:
     message: str
     source: str
     count: int
-    pod_name: str | None = None
-    pod_uid: str | None = None
-    pod_deletion_timestamp: str | None = None
-    node_name: str | None = None
-    node_uid: str | None = None
-    node_provider_id: str | None = None
-    node_boot_id: str | None = None
-    node_system_uuid: str | None = None
-    node_unschedulable: bool | None = None
-    pod_tolerations_json: str | None = None
-    pod_conditions_json: str | None = None
-    node_taints_json: str | None = None
-    node_conditions_json: str | None = None
-    node_labels_json: str | None = None
-    node_annotations_json: str | None = None
 
 
 class ProfileType(StrEnum):

--- a/lib/iris/src/iris/cluster/stats/tables.py
+++ b/lib/iris/src/iris/cluster/stats/tables.py
@@ -60,12 +60,12 @@ TASK_STATUS_STORAGE_POLICY = StoragePolicy(
 )
 
 # Backend events and controller actions are a compact diagnostic history. The
-# producers only append when a verdict or controller decision changes, so seven
+# producers only append when a verdict or controller decision changes, so 30
 # days gives operators time to investigate without retaining high-volume pod
 # telemetry.
 TASK_EVENT_STORAGE_POLICY = StoragePolicy(
     max_bytes=1024 * 1024 * 1024,
-    max_age_seconds=7 * 24 * 60 * 60,
+    max_age_seconds=30 * 24 * 60 * 60,
 )
 
 
@@ -193,7 +193,9 @@ class TaskEventRow:
     Fields mirror a Kubernetes event so a future producer can relay real events
     unchanged: ``type`` is the severity (``Warning``/``Normal``), ``reason`` the
     short code, ``source`` the emitting layer (e.g. ``k8s/kueue``), ``count`` the
-    repeat multiplicity.
+    repeat multiplicity. Kubernetes disruption rows also carry stable pod/node
+    identity and compact JSON snapshots of the evidence that disappears when
+    the pod or node is garbage-collected.
     """
 
     key_column: ClassVar[str] = "task_id"
@@ -207,6 +209,21 @@ class TaskEventRow:
     message: str
     source: str
     count: int
+    pod_name: str | None = None
+    pod_uid: str | None = None
+    pod_deletion_timestamp: str | None = None
+    node_name: str | None = None
+    node_uid: str | None = None
+    node_provider_id: str | None = None
+    node_boot_id: str | None = None
+    node_system_uuid: str | None = None
+    node_unschedulable: bool | None = None
+    pod_tolerations_json: str | None = None
+    pod_conditions_json: str | None = None
+    node_taints_json: str | None = None
+    node_conditions_json: str | None = None
+    node_labels_json: str | None = None
+    node_annotations_json: str | None = None
 
 
 class ProfileType(StrEnum):

--- a/lib/iris/tests/cluster/backends/k8s/test_task_event.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_task_event.py
@@ -7,8 +7,11 @@ The backend records changing scheduling, container, and terminal Kueue verdicts
 so the dashboard and CLI retain the cause after the Pod is gone.
 """
 
+import json
+
 from iris.cluster.backends.k8s.tasks import (
     _EVENT_SOURCE_CONTAINER,
+    _EVENT_SOURCE_DISRUPTION,
     _EVENT_SOURCE_KUEUE,
     _LABEL_ATTEMPT_ID,
     _LABEL_MANAGED,
@@ -42,6 +45,19 @@ _ATTEMPT = RunningTaskEntry(
     attempt_id=0,
     attempt_uid="attempt-a",
 )
+
+
+class _FailOnceStatsTable(FakeStatsTable):
+    def __init__(self) -> None:
+        super().__init__()
+        self._failed = False
+
+    def write(self, rows) -> None:
+        if not self._failed:
+            self._failed = True
+            raise RuntimeError("transient write failure")
+        super().write(rows)
+
 
 # --- _pod_event classification -------------------------------------------------
 
@@ -149,6 +165,19 @@ def test_event_log_retain_forgets_gone_attempts():
     assert len(rows) == 2
 
 
+def test_event_log_retries_a_failed_finelog_write():
+    table = _FailOnceStatsTable()
+    log = TaskEventLog(table)
+    event = _pod_event(gated_pod(), unadmitted_workload())
+
+    log.observe(_ATTEMPT, event)
+    log.observe(_ATTEMPT, event)
+
+    rows = [row for write in table.writes for row in write]
+    assert len(rows) == 1
+    assert rows[0].reason == "SchedulingGated"
+
+
 # --- end-to-end through sync() -------------------------------------------------
 
 
@@ -226,5 +255,127 @@ def test_sync_singleton_surfaces_kueue_verdict_on_task_and_event(k8s):
         assert len(rows) == 1
         assert rows[0].source == _EVENT_SOURCE_KUEUE
         assert rows[0].type == "Warning"
+    finally:
+        provider.close()
+
+
+def test_sync_records_disruption_target_with_pod_and_node_evidence(k8s):
+    event_table = FakeStatsTable()
+    provider = make_kueue_provider(k8s, task_event_table=event_table)
+    try:
+        task_id = JobName.from_wire("/job/0")
+        pod_name = _pod_name(task_id, 0)
+        pod = {
+            "kind": "Pod",
+            "metadata": {
+                "name": pod_name,
+                "uid": "pod-uid-a",
+                "deletionTimestamp": "2026-08-23T14:17:35Z",
+                "labels": {
+                    _LABEL_MANAGED: "true",
+                    _LABEL_RUNTIME: _RUNTIME_LABEL_VALUE,
+                    _LABEL_TASK_HASH: _task_hash(task_id.to_wire()),
+                    _LABEL_ATTEMPT_ID: "0",
+                },
+            },
+            "spec": {
+                "nodeName": "node-a",
+                "tolerations": [
+                    {"key": "node.kubernetes.io/unreachable", "effect": "NoExecute", "tolerationSeconds": 300}
+                ],
+            },
+            "status": {
+                "phase": "Running",
+                "conditions": [
+                    {
+                        "type": "DisruptionTarget",
+                        "status": "True",
+                        "reason": "DeletionByTaintManager",
+                        "message": "Taint manager: deleting due to NoExecute taint",
+                        "lastTransitionTime": "2026-08-23T14:17:35Z",
+                    }
+                ],
+                "containerStatuses": [{"name": "task", "state": {"running": {}}}],
+            },
+        }
+        node = {
+            "kind": "Node",
+            "metadata": {
+                "name": "node-a",
+                "uid": "node-uid-a",
+                "labels": {
+                    "node.kubernetes.io/instance-type": "gd-8xh100ib-i128",
+                    "topology.kubernetes.io/zone": "US-EAST-08A",
+                    "unrelated.example.com/large": "excluded",
+                },
+                "annotations": {
+                    "node.coreweave.cloud/reboot-reason": "GPUECCUncorrectableError",
+                    "unrelated.example.com/large": "excluded",
+                },
+            },
+            "spec": {
+                "providerID": "coreweave://node-a",
+                "unschedulable": True,
+                "taints": [{"key": "node.coreweave.cloud/evict", "effect": "NoExecute"}],
+            },
+            "status": {
+                "nodeInfo": {"bootID": "boot-a", "systemUUID": "system-a"},
+                "conditions": [
+                    {
+                        "type": "GPUECCUncorrectableError",
+                        "status": "True",
+                        "reason": "NvidiaXid48",
+                        "message": "Xid 48: uncorrectable double bit ECC error",
+                    }
+                ],
+            },
+        }
+        k8s.seed_resource(K8sResource.PODS, pod_name, pod)
+        entry = RunningTaskEntry(task_id=task_id, attempt_id=0, attempt_uid="attempt-a")
+        provider.sync(make_batch(running_tasks=[entry]))
+
+        rows = [row for write in event_table.writes for row in write]
+        assert len(rows) == 1
+        assert rows[0].pod_uid == "pod-uid-a"
+        assert rows[0].node_name == "node-a"
+        assert rows[0].node_uid is None
+
+        k8s.seed_resource(K8sResource.NODES, "node-a", node)
+        provider.sync(make_batch(running_tasks=[entry]))
+
+        rows = [row for write in event_table.writes for row in write]
+        assert len(rows) == 2
+        row = rows[1]
+        assert (row.source, row.reason, row.type) == (
+            _EVENT_SOURCE_DISRUPTION,
+            "DeletionByTaintManager",
+            "Warning",
+        )
+        assert (row.pod_name, row.pod_uid) == (pod_name, "pod-uid-a")
+        assert row.pod_deletion_timestamp == "2026-08-23T14:17:35Z"
+        assert (row.node_name, row.node_uid) == ("node-a", "node-uid-a")
+        assert (row.node_provider_id, row.node_boot_id, row.node_system_uuid) == (
+            "coreweave://node-a",
+            "boot-a",
+            "system-a",
+        )
+        assert row.node_unschedulable is True
+        assert row.pod_tolerations_json is not None
+        assert row.pod_conditions_json is not None
+        assert row.node_taints_json is not None
+        assert row.node_conditions_json is not None
+        assert row.node_labels_json is not None
+        assert row.node_annotations_json is not None
+        assert json.loads(row.pod_tolerations_json)[0]["tolerationSeconds"] == 300
+        assert json.loads(row.pod_conditions_json)[0]["lastTransitionTime"] == "2026-08-23T14:17:35Z"
+        assert json.loads(row.node_taints_json) == [{"effect": "NoExecute", "key": "node.coreweave.cloud/evict"}]
+        assert json.loads(row.node_conditions_json)[0]["reason"] == "NvidiaXid48"
+        assert json.loads(row.node_labels_json) == {
+            "node.kubernetes.io/instance-type": "gd-8xh100ib-i128",
+            "topology.kubernetes.io/zone": "US-EAST-08A",
+        }
+        assert json.loads(row.node_annotations_json) == {
+            "node.coreweave.cloud/reboot-reason": "GPUECCUncorrectableError"
+        }
     finally:
         provider.close()

--- a/lib/iris/tests/cluster/controller/test_federation_handoff.py
+++ b/lib/iris/tests/cluster/controller/test_federation_handoff.py
@@ -105,6 +105,35 @@ def _peer_status_of(service: ControllerServiceImpl, job_id: JobName) -> int:
     ).job.peer_status
 
 
+def _commit_peer_direct_update(
+    peer_state,
+    task,
+    worker,
+    *,
+    new_state: int,
+    error: str | None = None,
+    exit_code: int | None = None,
+    pod_name: str | None = None,
+    pod_uid: str | None = None,
+    node_name: str | None = None,
+    terminal_reason: str | None = None,
+) -> None:
+    assign_task(peer_state, task, worker)
+    update = TaskUpdate(
+        task_id=task.task_id,
+        attempt_id=query_task(peer_state, task.task_id).current_attempt_id,
+        new_state=new_state,
+        error=error,
+        exit_code=exit_code,
+        pod_name=pod_name,
+        pod_uid=pod_uid,
+        node_name=node_name,
+        terminal_reason=terminal_reason,
+    )
+    with peer_state._db.transaction() as cur:
+        commit_dispatch_updates(cur, [update], now=Timestamp.now())
+
+
 def _run_peer_task_to_success(
     peer_state: ControllerTestState,
     job_id: JobName,
@@ -119,22 +148,15 @@ def _run_peer_task_to_success(
     if pod_name is None:
         dispatch_task(peer_state, task, worker)
     else:
-        assign_task(peer_state, task, worker)
-        with peer_state._db.transaction() as cur:
-            commit_dispatch_updates(
-                cur,
-                [
-                    TaskUpdate(
-                        task_id=task.task_id,
-                        attempt_id=query_task(peer_state, task.task_id).current_attempt_id,
-                        new_state=job_pb2.TASK_STATE_RUNNING,
-                        pod_name=pod_name,
-                        pod_uid=pod_uid,
-                        node_name=node_name,
-                    )
-                ],
-                now=Timestamp.now(),
-            )
+        _commit_peer_direct_update(
+            peer_state,
+            task,
+            worker,
+            new_state=job_pb2.TASK_STATE_RUNNING,
+            pod_name=pod_name,
+            pod_uid=pod_uid,
+            node_name=node_name,
+        )
     transition_task(peer_state, task.task_id, job_pb2.TASK_STATE_SUCCEEDED)
 
 
@@ -151,22 +173,15 @@ def _run_peer_task_to_failure(
         dispatch_task(peer_state, task, worker)
         transition_task(peer_state, task.task_id, job_pb2.TASK_STATE_FAILED, error="boom", exit_code=1)
         return
-    assign_task(peer_state, task, worker)
-    with peer_state._db.transaction() as cur:
-        commit_dispatch_updates(
-            cur,
-            [
-                TaskUpdate(
-                    task_id=task.task_id,
-                    attempt_id=query_task(peer_state, task.task_id).current_attempt_id,
-                    new_state=job_pb2.TASK_STATE_FAILED,
-                    error=terminal_reason,
-                    exit_code=1,
-                    terminal_reason=terminal_reason,
-                )
-            ],
-            now=Timestamp.now(),
-        )
+    _commit_peer_direct_update(
+        peer_state,
+        task,
+        worker,
+        new_state=job_pb2.TASK_STATE_FAILED,
+        error=terminal_reason,
+        exit_code=1,
+        terminal_reason=terminal_reason,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/controller/test_federation_handoff.py
+++ b/lib/iris/tests/cluster/controller/test_federation_handoff.py
@@ -105,20 +105,68 @@ def _peer_status_of(service: ControllerServiceImpl, job_id: JobName) -> int:
     ).job.peer_status
 
 
-def _run_peer_task_to_success(peer_state: ControllerTestState, job_id: JobName) -> None:
+def _run_peer_task_to_success(
+    peer_state: ControllerTestState,
+    job_id: JobName,
+    *,
+    pod_name: str | None = None,
+    pod_uid: str | None = None,
+    node_name: str | None = None,
+) -> None:
     """Register a worker on the peer and drive the handed-off job's task to SUCCEEDED."""
     worker = register_worker(peer_state, "w1", "w1:8080", job_pb2.WorkerMetadata(hostname="w1"))
     (task,) = query_tasks_for_job(peer_state, job_id)
-    dispatch_task(peer_state, task, worker)
+    if pod_name is None:
+        dispatch_task(peer_state, task, worker)
+    else:
+        assign_task(peer_state, task, worker)
+        with peer_state._db.transaction() as cur:
+            commit_dispatch_updates(
+                cur,
+                [
+                    TaskUpdate(
+                        task_id=task.task_id,
+                        attempt_id=query_task(peer_state, task.task_id).current_attempt_id,
+                        new_state=job_pb2.TASK_STATE_RUNNING,
+                        pod_name=pod_name,
+                        pod_uid=pod_uid,
+                        node_name=node_name,
+                    )
+                ],
+                now=Timestamp.now(),
+            )
     transition_task(peer_state, task.task_id, job_pb2.TASK_STATE_SUCCEEDED)
 
 
-def _run_peer_task_to_failure(peer_state: ControllerTestState, job_id: JobName) -> None:
+def _run_peer_task_to_failure(
+    peer_state: ControllerTestState,
+    job_id: JobName,
+    *,
+    terminal_reason: str | None = None,
+) -> None:
     """Register a worker on the peer and drive the handed-off job's task to FAILED."""
     worker = register_worker(peer_state, "w1", "w1:8080", job_pb2.WorkerMetadata(hostname="w1"))
     (task,) = query_tasks_for_job(peer_state, job_id)
-    dispatch_task(peer_state, task, worker)
-    transition_task(peer_state, task.task_id, job_pb2.TASK_STATE_FAILED, error="boom", exit_code=1)
+    if terminal_reason is None:
+        dispatch_task(peer_state, task, worker)
+        transition_task(peer_state, task.task_id, job_pb2.TASK_STATE_FAILED, error="boom", exit_code=1)
+        return
+    assign_task(peer_state, task, worker)
+    with peer_state._db.transaction() as cur:
+        commit_dispatch_updates(
+            cur,
+            [
+                TaskUpdate(
+                    task_id=task.task_id,
+                    attempt_id=query_task(peer_state, task.task_id).current_attempt_id,
+                    new_state=job_pb2.TASK_STATE_FAILED,
+                    error=terminal_reason,
+                    exit_code=1,
+                    terminal_reason=terminal_reason,
+                )
+            ],
+            now=Timestamp.now(),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -377,7 +425,13 @@ def test_sync_mirrors_attempts_and_worker_identity_natively(tmp_path, log_client
         job_id = JobName.from_wire(response.job_id)
         promote_queued_federation(manager, parent_state)
 
-        _run_peer_task_to_success(peer_state, job_id)
+        _run_peer_task_to_success(
+            peer_state,
+            job_id,
+            pod_name="iris-fed-job-0-a1",
+            pod_uid="pod-uid-a",
+            node_name="node-a",
+        )
         manager.sync_once()
 
         (mirrored,) = query_tasks_for_job(parent_state, job_id)
@@ -392,6 +446,9 @@ def test_sync_mirrors_attempts_and_worker_identity_natively(tmp_path, log_client
         assert len(task.attempts) == 1
         assert task.attempts[0].state == job_pb2.TASK_STATE_SUCCEEDED
         assert task.attempts[0].worker_id == ""  # no local worker FK for a mirrored attempt
+        assert task.attempts[0].pod_name == "iris-fed-job-0-a1"
+        assert task.attempts[0].pod_uid == "pod-uid-a"
+        assert task.attempts[0].node_name == "node-a"
 
         # The mirrored uid is the peer's raw uid, written verbatim (no peer-prefix
         # rebasing — job ids are cluster-invariant). Because uid resolution is scoped
@@ -999,9 +1056,14 @@ def test_resubmit_of_a_failed_federated_job_replaces_and_reruns_on_the_peer(tmp_
         job_id = JobName.from_wire(response.job_id)
         promote_queued_federation(manager, parent_state)
         first_nonce = _handle(parent_state, job_id).handoff_nonce
-        _run_peer_task_to_failure(peer_state, job_id)
+        _run_peer_task_to_failure(peer_state, job_id, terminal_reason="init failed: disk corrupt")
         manager.sync_once()
         assert query_job(parent_state, job_id).state == job_pb2.JOB_STATE_FAILED
+        (mirrored_task,) = query_tasks_for_job(parent_state, job_id)
+        task_status = parent_service.get_task_status(
+            controller_pb2.Controller.GetTaskStatusRequest(task_id=mirrored_task.task_id.to_wire()), None
+        ).task
+        assert task_status.attempts[0].terminal_reason == "init failed: disk corrupt"
 
         # Resubmit the same id: the parent replaces its finished job with a fresh
         # handle carrying a NEW nonce, and delivery replaces the peer's finished


### PR DESCRIPTION
Kubernetes' `DeletionByTaintManager` reason identifies the eviction mechanism but loses the initiating node fault after the pod and node are garbage-collected. Record `DisruptionTarget` as `k8s/disruption` in `iris.task_event`, together with stable pod and node identity, deletion timing, tolerations, taints, health conditions, and selected hardware and provider metadata. Retry failed Finelog writes and emit an enriched row when a temporarily unavailable node snapshot appears. Retain task events for up to 30 days under the existing 1 GiB cap.

Federation now preserves the member controller's pod name, pod UID, node name, and terminal reason when mirroring attempt history, so the hub task view retains its backend evidence.

The fleet investigation found 17 attempts with this exact terminal text across 15 nodes. Three attempts on one node were evicted together during a single drain; no node had the exact eviction at multiple distinct times. The triggering incident and response guidance are recorded in [Echo](https://echo.oa.dev/wiki/221).
