### PR TITLE
iris: tighten disruption telemetry tests

### DIFF
--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -568,9 +568,9 @@ Namespaces:
   ORDER BY ts ASC;
   ```
 
-  Kubernetes disruptions use `source='k8s/disruption'`. The row captures the
-  pod UID and enough node evidence to identify a physical machine across node
-  renames and reboots. To inspect taint-manager evictions across the fleet:
+  Kubernetes disruptions use `source='k8s/disruption'`. `node_provider_id` and
+  `node_system_uuid` identify a physical machine; `node_boot_id` distinguishes
+  reboots. To inspect taint-manager evictions across the fleet:
 
   ```sql
   SELECT cluster, ts, task_id, attempt_id, pod_name, node_name,

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -1516,8 +1516,7 @@ _WARNING_EVENT_REASONS = frozenset(
 
 @dataclass(frozen=True)
 class _PodEvent:
-    """A scheduling/admission verdict for a not-yet-running pod, ready to record
-    as an ``iris.task_event`` row. ``severity`` is the k8s-style Normal/Warning."""
+    """A Kubernetes backend verdict ready to record in ``iris.task_event``."""
 
     source: str
     reason: str
@@ -1594,14 +1593,7 @@ def _workload_admission_blocked(workload: dict | None) -> bool:
 
 
 def _pod_event(pod: dict, workload: dict | None, node: dict | None = None) -> _PodEvent | None:
-    """The current actionable backend event for a pod.
-
-    ``source`` attributes the verdict to the layer that produced it (a Kubernetes
-    disruption, the task container, the Kueue gate, or the scheduler);
-    ``severity`` is Warning for an actionable failure (image pull, config error,
-    disruption, Kueue eviction) or a Kueue-declined admission, Normal for a
-    transient wait. Returns ``None`` for a healthy running or otherwise quiet pod.
-    """
+    """Return the pod's current actionable verdict, including disruptions."""
     disruption = _disruption_condition(pod)
     if disruption is not None and disruption.get("type") == _DISRUPTION_TARGET_CONDITION:
         return _disruption_event(pod, node, disruption)
@@ -2008,19 +2000,11 @@ class PeriodicProfiler:
 
 
 class TaskEventLog:
-    """Appends Kubernetes backend events to the ``iris.task_event`` namespace.
+    """Append changed Kubernetes verdicts to ``iris.task_event``.
 
-    Driven synchronously from the pod poll — no background thread, since the
-    verdicts come from the pod/workload lists ``sync`` already fetches.
-    ``observe`` is called once per tracked attempt per cycle with the attempt's
-    current verdict (or ``None`` when the pod is running/quiet); a row is written
-    only when the ``(source, reason, severity)`` verdict *changes*, or when a
-    disruption first gains its node snapshot, so a pod wedged in one state
-    produces a single row, not one per poll. A severity upgrade (e.g. a gated
-    pod Kueue later declines flips Normal→Warning under the same source/reason)
-    records the actionable row. ``retain`` drops dedup state for attempts no
-    longer polled so a retried attempt (new ``attempt_id``) starts clean and the
-    map stays bounded.
+    Verdicts are deduplicated per attempt by source, reason, severity, and node
+    evidence availability. A disruption first observed without its node snapshot
+    emits one enriched row when the snapshot becomes available.
     """
 
     def __init__(self, task_event_table: Table):

--- a/lib/iris/src/iris/cluster/stats/tables.py
+++ b/lib/iris/src/iris/cluster/stats/tables.py
@@ -183,7 +183,7 @@ class TaskStatusRow:
 
 @dataclass(kw_only=True)
 class TaskEventDiagnostics:
-    """Pod and node evidence captured while a Kubernetes disruption is observable."""
+    """Kubernetes disruption evidence retained after the Pod is deleted."""
 
     pod_name: str | None = None
     pod_uid: str | None = None
@@ -204,19 +204,11 @@ class TaskEventDiagnostics:
 
 @dataclass
 class TaskEventRow(TaskEventDiagnostics):
-    """One backend event or controller action for a task attempt.
+    """One retained backend verdict or controller action for a task attempt.
 
-    The "event log for every job": producers append a row each time a backend
-    diagnostic verdict changes or the controller makes a state-changing decision
-    (retry, gang bounce, finalization), so operators can reconstruct the task's
-    lifecycle after ephemeral Kubernetes objects are gone.
-
-    Fields mirror a Kubernetes event so a future producer can relay real events
-    unchanged: ``type`` is the severity (``Warning``/``Normal``), ``reason`` the
-    short code, ``source`` the emitting layer (e.g. ``k8s/kueue``), ``count`` the
-    repeat multiplicity. Kubernetes disruption rows also carry stable pod/node
-    identity and compact JSON snapshots of the evidence that disappears when
-    the pod or node is garbage-collected.
+    ``type``, ``reason``, ``source``, and ``count`` follow Kubernetes event
+    terminology. Disruption rows add stable pod/node identity and JSON snapshots
+    of the ephemeral Kubernetes evidence.
     """
 
     key_column: ClassVar[str] = "task_id"

--- a/lib/iris/tests/cluster/backends/k8s/test_task_event.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_task_event.py
@@ -1,11 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Kubernetes backend events in the ``iris.task_event`` task-action timeline.
-
-The backend records changing scheduling, container, and terminal Kueue verdicts
-so the dashboard and CLI retain the cause after the Pod is gone.
-"""
+"""Kubernetes backend event persistence in ``iris.task_event``."""
 
 import json
 
@@ -165,7 +161,7 @@ def test_event_log_retain_forgets_gone_attempts():
     assert len(rows) == 2
 
 
-def test_event_log_retries_a_failed_finelog_write():
+def test_event_log_retries_unchanged_verdict_after_write_failure():
     table = _FailOnceStatsTable()
     log = TaskEventLog(table)
     event = _pod_event(gated_pod(), unadmitted_workload())
@@ -174,8 +170,7 @@ def test_event_log_retries_a_failed_finelog_write():
     log.observe(_ATTEMPT, event)
 
     rows = [row for write in table.writes for row in write]
-    assert len(rows) == 1
-    assert rows[0].reason == "SchedulingGated"
+    assert [(row.source, row.reason) for row in rows] == [(_EVENT_SOURCE_KUEUE, "SchedulingGated")]
 
 
 # --- end-to-end through sync() -------------------------------------------------
@@ -259,7 +254,7 @@ def test_sync_singleton_surfaces_kueue_verdict_on_task_and_event(k8s):
         provider.close()
 
 
-def test_sync_records_disruption_target_with_pod_and_node_evidence(k8s):
+def test_sync_records_disruption_evidence_and_late_node_snapshot(k8s):
     event_table = FakeStatsTable()
     provider = make_kueue_provider(k8s, task_event_table=event_table)
     try:
@@ -336,9 +331,13 @@ def test_sync_records_disruption_target_with_pod_and_node_evidence(k8s):
 
         rows = [row for write in event_table.writes for row in write]
         assert len(rows) == 1
-        assert rows[0].pod_uid == "pod-uid-a"
-        assert rows[0].node_name == "node-a"
-        assert rows[0].node_uid is None
+        assert (
+            rows[0].source,
+            rows[0].reason,
+            rows[0].pod_uid,
+            rows[0].node_name,
+            rows[0].node_uid,
+        ) == (_EVENT_SOURCE_DISRUPTION, "DeletionByTaintManager", "pod-uid-a", "node-a", None)
 
         k8s.seed_resource(K8sResource.NODES, "node-a", node)
         provider.sync(make_batch(running_tasks=[entry]))
@@ -346,35 +345,25 @@ def test_sync_records_disruption_target_with_pod_and_node_evidence(k8s):
         rows = [row for write in event_table.writes for row in write]
         assert len(rows) == 2
         row = rows[1]
-        assert (row.source, row.reason, row.type) == (
-            _EVENT_SOURCE_DISRUPTION,
-            "DeletionByTaintManager",
-            "Warning",
-        )
-        assert (row.pod_name, row.pod_uid) == (pod_name, "pod-uid-a")
         assert row.pod_deletion_timestamp == "2026-08-23T14:17:35Z"
-        assert (row.node_name, row.node_uid) == ("node-a", "node-uid-a")
-        assert (row.node_provider_id, row.node_boot_id, row.node_system_uuid) == (
+        assert (row.node_uid, row.node_provider_id, row.node_boot_id, row.node_system_uuid) == (
+            "node-uid-a",
             "coreweave://node-a",
             "boot-a",
             "system-a",
         )
         assert row.node_unschedulable is True
-        assert row.pod_tolerations_json is not None
-        assert row.pod_conditions_json is not None
-        assert row.node_taints_json is not None
-        assert row.node_conditions_json is not None
-        assert row.node_labels_json is not None
-        assert row.node_annotations_json is not None
-        assert json.loads(row.pod_tolerations_json)[0]["tolerationSeconds"] == 300
-        assert json.loads(row.pod_conditions_json)[0]["lastTransitionTime"] == "2026-08-23T14:17:35Z"
-        assert json.loads(row.node_taints_json) == [{"effect": "NoExecute", "key": "node.coreweave.cloud/evict"}]
-        assert json.loads(row.node_conditions_json)[0]["reason"] == "NvidiaXid48"
-        assert json.loads(row.node_labels_json) == {
+        assert json.loads(row.pod_tolerations_json or "[]") == [
+            {"effect": "NoExecute", "key": "node.kubernetes.io/unreachable", "tolerationSeconds": 300}
+        ]
+        assert json.loads(row.pod_conditions_json or "[]")[0]["lastTransitionTime"] == "2026-08-23T14:17:35Z"
+        assert json.loads(row.node_taints_json or "[]") == [{"effect": "NoExecute", "key": "node.coreweave.cloud/evict"}]
+        assert json.loads(row.node_conditions_json or "[]")[0]["reason"] == "NvidiaXid48"
+        assert json.loads(row.node_labels_json or "{}") == {
             "node.kubernetes.io/instance-type": "gd-8xh100ib-i128",
             "topology.kubernetes.io/zone": "US-EAST-08A",
         }
-        assert json.loads(row.node_annotations_json) == {
+        assert json.loads(row.node_annotations_json or "{}") == {
             "node.coreweave.cloud/reboot-reason": "GPUECCUncorrectableError"
         }
     finally:

--- a/lib/iris/tests/cluster/controller/test_federation_handoff.py
+++ b/lib/iris/tests/cluster/controller/test_federation_handoff.py
@@ -105,10 +105,9 @@ def _peer_status_of(service: ControllerServiceImpl, job_id: JobName) -> int:
     ).job.peer_status
 
 
-def _commit_peer_direct_update(
-    peer_state,
-    task,
-    worker,
+def _report_peer_backend_task(
+    peer_state: ControllerTestState,
+    job_id: JobName,
     *,
     new_state: int,
     error: str | None = None,
@@ -118,6 +117,8 @@ def _commit_peer_direct_update(
     node_name: str | None = None,
     terminal_reason: str | None = None,
 ) -> None:
+    worker = register_worker(peer_state, "w1", "w1:8080", job_pb2.WorkerMetadata(hostname="w1"))
+    (task,) = query_tasks_for_job(peer_state, job_id)
     assign_task(peer_state, task, worker)
     update = TaskUpdate(
         task_id=task.task_id,
@@ -134,54 +135,20 @@ def _commit_peer_direct_update(
         commit_dispatch_updates(cur, [update], now=Timestamp.now())
 
 
-def _run_peer_task_to_success(
-    peer_state: ControllerTestState,
-    job_id: JobName,
-    *,
-    pod_name: str | None = None,
-    pod_uid: str | None = None,
-    node_name: str | None = None,
-) -> None:
+def _run_peer_task_to_success(peer_state: ControllerTestState, job_id: JobName) -> None:
     """Register a worker on the peer and drive the handed-off job's task to SUCCEEDED."""
     worker = register_worker(peer_state, "w1", "w1:8080", job_pb2.WorkerMetadata(hostname="w1"))
     (task,) = query_tasks_for_job(peer_state, job_id)
-    if pod_name is None:
-        dispatch_task(peer_state, task, worker)
-    else:
-        _commit_peer_direct_update(
-            peer_state,
-            task,
-            worker,
-            new_state=job_pb2.TASK_STATE_RUNNING,
-            pod_name=pod_name,
-            pod_uid=pod_uid,
-            node_name=node_name,
-        )
+    dispatch_task(peer_state, task, worker)
     transition_task(peer_state, task.task_id, job_pb2.TASK_STATE_SUCCEEDED)
 
 
-def _run_peer_task_to_failure(
-    peer_state: ControllerTestState,
-    job_id: JobName,
-    *,
-    terminal_reason: str | None = None,
-) -> None:
+def _run_peer_task_to_failure(peer_state: ControllerTestState, job_id: JobName) -> None:
     """Register a worker on the peer and drive the handed-off job's task to FAILED."""
     worker = register_worker(peer_state, "w1", "w1:8080", job_pb2.WorkerMetadata(hostname="w1"))
     (task,) = query_tasks_for_job(peer_state, job_id)
-    if terminal_reason is None:
-        dispatch_task(peer_state, task, worker)
-        transition_task(peer_state, task.task_id, job_pb2.TASK_STATE_FAILED, error="boom", exit_code=1)
-        return
-    _commit_peer_direct_update(
-        peer_state,
-        task,
-        worker,
-        new_state=job_pb2.TASK_STATE_FAILED,
-        error=terminal_reason,
-        exit_code=1,
-        terminal_reason=terminal_reason,
-    )
+    dispatch_task(peer_state, task, worker)
+    transition_task(peer_state, task.task_id, job_pb2.TASK_STATE_FAILED, error="boom", exit_code=1)
 
 
 # ---------------------------------------------------------------------------
@@ -426,11 +393,7 @@ def test_federation_sync_rejects_an_ordinary_user(tmp_path, log_client):
 # ---------------------------------------------------------------------------
 
 
-def test_sync_mirrors_attempts_and_worker_identity_natively(tmp_path, log_client):
-    """After sync-back the parent renders a federated task natively: the peer's
-    attempt history is mirrored and the peer-side worker identity is surfaced (as
-    display text — there is no local worker row), and the mirrored attempt stays
-    off the worker-routing fold (its namespaced uid never resolves)."""
+def test_sync_mirrors_attempt_history_and_backend_identity(tmp_path, log_client):
     with ExitStack() as stack:
         parent_service, parent_state = _make_service(stack, "parent", tmp_path, log_client)
         peer_service, peer_state = _make_service(stack, "peer", tmp_path, log_client)
@@ -440,13 +403,15 @@ def test_sync_mirrors_attempts_and_worker_identity_natively(tmp_path, log_client
         job_id = JobName.from_wire(response.job_id)
         promote_queued_federation(manager, parent_state)
 
-        _run_peer_task_to_success(
+        _report_peer_backend_task(
             peer_state,
             job_id,
+            new_state=job_pb2.TASK_STATE_RUNNING,
             pod_name="iris-fed-job-0-a1",
             pod_uid="pod-uid-a",
             node_name="node-a",
         )
+        transition_task(peer_state, job_id.task(0), job_pb2.TASK_STATE_SUCCEEDED)
         manager.sync_once()
 
         (mirrored,) = query_tasks_for_job(parent_state, job_id)
@@ -454,8 +419,6 @@ def test_sync_mirrors_attempts_and_worker_identity_natively(tmp_path, log_client
             controller_pb2.Controller.GetTaskStatusRequest(task_id=mirrored.task_id.to_wire()), None
         ).task
 
-        # The peer's attempt renders natively, and the worker identity is surfaced
-        # from the peer (the task has no local worker row, so it is display-only).
         assert task.cluster == "cw"
         assert task.worker_id == "w1"
         assert len(task.attempts) == 1
@@ -465,10 +428,7 @@ def test_sync_mirrors_attempts_and_worker_identity_natively(tmp_path, log_client
         assert task.attempts[0].pod_uid == "pod-uid-a"
         assert task.attempts[0].node_name == "node-a"
 
-        # The mirrored uid is the peer's raw uid, written verbatim (no peer-prefix
-        # rebasing — job ids are cluster-invariant). Because uid resolution is scoped
-        # to local_tasks, it never resolves — so reconcile's worker-routing can never
-        # act on a federated attempt.
+        # A mirrored attempt has no local worker row and cannot enter local routing.
         with peer_state._db.read_snapshot() as tx:
             (peer_attempt,) = reads.all_attempts_for_tasks(tx, [job_id.task(0)])[job_id.task(0)]
         with parent_state._db.read_snapshot() as tx:
@@ -476,6 +436,34 @@ def test_sync_mirrors_attempts_and_worker_identity_natively(tmp_path, log_client
             assert attempt_row.attempt_uid == peer_attempt.attempt_uid
             assert "~" not in attempt_row.attempt_uid
             assert reads.resolve_attempt_uids(tx, [AttemptUid(attempt_row.attempt_uid)]) == {}
+
+
+def test_sync_mirrors_attempt_terminal_reason(tmp_path, log_client):
+    with ExitStack() as stack:
+        parent_service, parent_state = _make_service(stack, "parent", tmp_path, log_client)
+        peer_service, peer_state = _make_service(stack, "peer", tmp_path, log_client)
+        manager = _attach_federation(parent_service, _InProcessPeerConnection(peer_service))
+
+        response = parent_service.launch_job(_cluster_pinned_request("fed-terminal-reason"), None)
+        job_id = JobName.from_wire(response.job_id)
+        promote_queued_federation(manager, parent_state)
+
+        terminal_reason = "init failed: disk corrupt"
+        _report_peer_backend_task(
+            peer_state,
+            job_id,
+            new_state=job_pb2.TASK_STATE_FAILED,
+            error=terminal_reason,
+            exit_code=1,
+            terminal_reason=terminal_reason,
+        )
+        manager.sync_once()
+
+        (mirrored,) = query_tasks_for_job(parent_state, job_id)
+        task = parent_service.get_task_status(
+            controller_pb2.Controller.GetTaskStatusRequest(task_id=mirrored.task_id.to_wire()), None
+        ).task
+        assert task.attempts[0].terminal_reason == terminal_reason
 
 
 def _dispatch_building(peer_state, task_id: JobName, attempt_id: int, status_message: str | None) -> None:
@@ -1071,14 +1059,9 @@ def test_resubmit_of_a_failed_federated_job_replaces_and_reruns_on_the_peer(tmp_
         job_id = JobName.from_wire(response.job_id)
         promote_queued_federation(manager, parent_state)
         first_nonce = _handle(parent_state, job_id).handoff_nonce
-        _run_peer_task_to_failure(peer_state, job_id, terminal_reason="init failed: disk corrupt")
+        _run_peer_task_to_failure(peer_state, job_id)
         manager.sync_once()
         assert query_job(parent_state, job_id).state == job_pb2.JOB_STATE_FAILED
-        (mirrored_task,) = query_tasks_for_job(parent_state, job_id)
-        task_status = parent_service.get_task_status(
-            controller_pb2.Controller.GetTaskStatusRequest(task_id=mirrored_task.task_id.to_wire()), None
-        ).task
-        assert task_status.attempts[0].terminal_reason == "init failed: disk corrupt"
 
         # Resubmit the same id: the parent replaces its finished job with a fresh
         # handle carrying a NEW nonce, and delivery replaces the peer's finished


### PR DESCRIPTION
The terminal-reason assertion added in #8601 was attached to a resubmission test, so a propagation regression would report as a replay failure. This gives terminal-reason mirroring its own federation sync test and returns the resubmission regression to replay and replacement only.

The same pass removes redundant disruption-field assertions, trims telemetry docstrings to their persisted contracts, and states how provider, system, and boot identifiers should be used during node-history triage.

Follow-up to [review feedback on #8601](https://github.com/marin-community/marin/pull/8601#discussion_r3838864918).