### PR TITLE
[echo] Show useful context for search results

### DIFF
--- a/infra/echo/README.md
+++ b/infra/echo/README.md
@@ -112,8 +112,12 @@ with new result snapshots so other domain cutoffs can use stable data. A search 
 return fewer than the requested limit and returns at most 24 results. `grep` remains a
 case-insensitive literal substring scan over activity, newest first.
 
-CLI search prints one table with an execution-specific grading key, source ID, title,
-and source-derived detail. Grading keys use `<domain>:<numeric-key>` and remain attached
+CLI search prints one result block with an execution-specific grading key, title,
+source ID, and one primary source excerpt of at most 240 characters. File results use
+their highest-ranked `path:line` reference, wiki results use `use_when`, and activity
+results use the matching source excerpt. The detail line is independent of terminal
+width, so long source IDs do not consume its display budget. Grading keys use
+`<domain>:<numeric-key>` and remain attached
 to the stored row even when a later corpus sync replaces an activity chunk ID.
 Run `uv run infra/echo/cli.py get <domain:id>` to fetch the full indexed wiki body,
 repository file, pull request or issue chunk, or Discord message and its canonical URL.

--- a/infra/echo/cli.py
+++ b/infra/echo/cli.py
@@ -29,7 +29,6 @@ import json
 import logging
 import os
 import shlex
-import shutil
 import subprocess
 import sys
 import time
@@ -67,6 +66,7 @@ KINDS = ("issue", "pr", "comment", "message")
 DOMAINS = search_config.SEARCH_DOMAINS
 DEFAULT_DOMAINS = search_config.DEFAULT_SEARCH_DOMAINS
 SEARCH_DETAIL_INSTRUCTION = "Detail: uv run infra/echo/cli.py get <domain:id>"
+SEARCH_DETAIL_MAX_CHARACTERS = 240
 MISSING_EMAIL_SCOPE_WARNING = "Not all requested scopes were granted by the authorization server, missing scopes email."
 DEFAULT_REQUEST_TIMEOUT = 30
 
@@ -173,35 +173,26 @@ def print_search_results(results: list[SearchResult]) -> None:
         print("No results.")
         return
 
-    keys = [result.key or "unavailable" for result in results]
-    ids = [result.id for result in results]
-    titles = [one_line(result.title) for result in results]
-    key_width = max(len("KEY"), *(len(value) for value in keys))
-    id_width = max(len("ID"), *(len(value) for value in ids))
-    available = max(40, shutil.get_terminal_size(fallback=(160, 24)).columns - key_width - id_width - 6)
-    title_width = min(max(len("TITLE"), *(len(value) for value in titles)), 36, max(16, available // 3))
-    detail_width = max(20, available - title_width)
-    print(f"{'KEY':<{key_width}}  {'ID':<{id_width}}  {'TITLE':<{title_width}}  DETAIL")
-    for result, key in zip(results, keys, strict=True):
+    print("KEY  TITLE  ID")
+    for result in results:
+        key = result.key or "unavailable"
         if result.references:
-            detail = " · ".join(f"L{reference.line} {reference.text}" for reference in result.references)
+            reference = result.references[0]
+            detail = f"L{reference.line} {reference.text}"
         else:
             detail = result.subtitle if result.domain == "wiki" else result.snippet
-        print(
-            f"{key:<{key_width}}  {result.id:<{id_width}}  "
-            f"{truncate_cell(one_line(result.title), title_width):<{title_width}}  "
-            f"{truncate_cell(one_line(detail), detail_width)}"
-        )
+        print(f"{key}  {one_line(result.title)}  {result.id}")
+        print(f"  {truncate_detail(one_line(detail))}")
 
 
 def one_line(value: str) -> str:
     return " ".join(value.split())
 
 
-def truncate_cell(value: str, width: int) -> str:
-    if len(value) <= width:
+def truncate_detail(value: str) -> str:
+    if len(value) <= SEARCH_DETAIL_MAX_CHARACTERS:
         return value
-    return f"{value[: width - 1]}…"
+    return f"{value[: SEARCH_DETAIL_MAX_CHARACTERS - 1]}…"
 
 
 def print_wiki(entries: list[dict]) -> None:

--- a/infra/echo/test_cli.py
+++ b/infra/echo/test_cli.py
@@ -22,6 +22,10 @@ def json_response(value, headers=None):
 
 
 def test_search_sends_selected_domains_to_federated_endpoint(monkeypatch, capsys):
+    reference_text = (
+        'raise SchedulerError("FAILED_PRECONDITION: pending queue cannot satisfy the requested TPU topology '
+        'and priority band")'
+    )
     remote_result = {
         "key": "file:731",
         "id": "file:marin-community/marin@main:lib/iris/src/iris/scheduler.py",
@@ -36,7 +40,7 @@ def test_search_sends_selected_domains_to_federated_endpoint(monkeypatch, capsys
         "references": [
             {
                 "line": 42,
-                "text": "raise FAILED_PRECONDITION",
+                "text": reference_text,
                 "url": "https://github.com/marin-community/marin/blob/abc1234/" "lib/iris/src/iris/scheduler.py#L42",
             }
         ],
@@ -83,7 +87,7 @@ def test_search_sends_selected_domains_to_federated_endpoint(monkeypatch, capsys
     assert "1 result in 1.23s" in output
     assert cli.SEARCH_DETAIL_INSTRUCTION in output
     assert "file:731" in output
-    assert "L42 raise FAILED_PRECONDITION" in output
+    assert f"L42 {reference_text}" in output
     assert output.count("File scope: marin-community/marin") == 1
 
 


### PR DESCRIPTION
Print each Echo search result as a header followed by one primary source
excerpt capped at 240 characters. The excerpt no longer shares a fixed-width
row with the grading key, qualified source ID, and title. Long identifiers
therefore cannot reduce useful context to the 20-character minimum.

The reported host-memory query still returns eight results. Its first issue
excerpt expands from `Full accounting of gr…` to about 200 source
characters, and the checkpoint host-memory wiki result shows its complete
applicability sentence.

A local replay captured 505 fixed results for all 80 checked-in benchmark
queries. Across 60 presentation judgments covering 46 unique cases, the
one-excerpt format was preferred 47 times and scored 4.45/5 for usefulness
and 4.20/5 for scanability. Two richer formats scored 4.70/5 for usefulness;
their scanability scores were 2.95 and 3.17. The
[Loom session](https://loom.rjp.io/s/326w47ik) contains the
`echo-result-detail-study` artifact with the local setup, variant definitions,
per-grader results, exact-query output, and limitations.
