### PR TITLE
[levanter] Avoid retaining checkpoint host copies

### DIFF
--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -49,6 +49,7 @@ ARRAY_DRIVER = "zarr3"
 KVSTORE_DRIVER = "ocdbt"
 # JAX's memory kind for host memory a device can address. Offloaded optimizer state lives here.
 _HOST_MEMORY_KIND = "pinned_host"
+_GPU_PLATFORM = "gpu"
 # Chunks a save stages at once. The budget is per process, so a node holds it once per local
 # process, and a process carries about four times what it holds in flight
 # (_STAGED_BYTE_OVERHEAD) on top of its resident shard of the offloaded state. A save blocks
@@ -163,8 +164,23 @@ async def _transfer_shard_to_pageable_host(shard, local_slice: tuple[int, int, i
 
     The TPU runtime never returns JAX's pinned staging to the OS (#6924). State already in
     host memory is snapshotted in place.
+
+    Materializing a shard runs ``ArrayImpl._value``, which caches the NumPy buffer it builds on
+    the array and holds it there for the array's lifetime. Materializing a shard training owns
+    leaves a second host copy behind until training replaces the array.
     """
     data = shard.data if local_slice is None else _slice_shard_on_device(shard.data, *local_slice)
+
+    if local_slice is None and data.device.platform == _GPU_PLATFORM:
+        # Move the host-value cache onto a transient array instead of the source array held by
+        # training. TPU keeps the direct path because its pinned staging is not returned to the OS.
+        staged = jax.device_put(data, SingleDeviceSharding(data.device, memory_kind=_HOST_MEMORY_KIND))
+        try:
+            await asyncio.sleep(0)
+            return np.array(staged, copy=True)
+        finally:
+            staged.delete()
+
     if getattr(data.sharding, "memory_kind", None) != _HOST_MEMORY_KIND:
         data.copy_to_host_async()
         # Yield so the remaining shards' copies can be enqueued before this one blocks.

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -170,6 +170,10 @@ async def _transfer_shard_to_pageable_host(shard, local_slice: tuple[int, int, i
     """
     data = shard.data if local_slice is None else _slice_shard_on_device(shard.data, *local_slice)
 
+    if getattr(data.sharding, "memory_kind", None) == _HOST_MEMORY_KIND:
+        # Already in host memory, and copying it to host again would alias rather than move.
+        return np.array(data, copy=True)
+
     if local_slice is None and data.device.platform == _GPU_PLATFORM:
         # Move the host-value cache onto a transient array instead of the source array held by
         # training. TPU keeps the direct path because its pinned staging is not returned to the OS.
@@ -180,10 +184,9 @@ async def _transfer_shard_to_pageable_host(shard, local_slice: tuple[int, int, i
         finally:
             staged.delete()
 
-    if getattr(data.sharding, "memory_kind", None) != _HOST_MEMORY_KIND:
-        data.copy_to_host_async()
-        # Yield so the remaining shards' copies can be enqueued before this one blocks.
-        await asyncio.sleep(0)
+    data.copy_to_host_async()
+    # Yield so the remaining shards' copies can be enqueued before this one blocks.
+    await asyncio.sleep(0)
     # TensorStore may retain this array. It must not reference the buffer training donates next.
     return np.array(data, copy=True)
 

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -165,9 +165,8 @@ async def _transfer_shard_to_pageable_host(shard, local_slice: tuple[int, int, i
     The TPU runtime never returns JAX's pinned staging to the OS (#6924). State already in
     host memory is snapshotted in place.
 
-    Materializing a shard runs ``ArrayImpl._value``, which caches the NumPy buffer it builds on
-    the array and holds it there for the array's lifetime. Materializing a shard training owns
-    leaves a second host copy behind until training replaces the array.
+    GPU shards owned by training stage through a transient host array so checkpoint
+    materialization does not retain a host copy on the long-lived source array.
     """
     data = shard.data if local_slice is None else _slice_shard_on_device(shard.data, *local_slice)
 


### PR DESCRIPTION
Stage unsliced GPU checkpoint shards through a transient pinned-host JAX array before materializing NumPy. This prevents checkpoint materialization from retaining a host-value cache on the training-owned source shard. Sliced shards and TPU keep their current paths.

A two-GB200, 100-step synthetic run saved a checkpoint and ran normal plus dropless evaluation every step. Across both ranks, the post-evaluation RSS floor slope fell from 11.0 to 3.6 MiB/step. The median floor increase between the first and last 15 measured steps fell from 0.93 to 0.27 GiB. [Control](https://iris.oa.dev/#/job/%2Fpower%2Fcodex-hostmem-micro-main-off-r1-20260823-coord) and [treatment](https://iris.oa.dev/#/job/%2Fpower%2Fcodex-hostmem-micro-fixed-off-r1-20260823-coord) retain the raw logs.

A matched unprofiled four-GB200 follow-up found similar checkpoint spikes relative to each run's floor: p95 was 3.77 GiB with transient staging and 3.04 GiB in the control; maxima were 7.14 and 7.54 GiB. The pinned-host allocator added a fixed plateau, however. Median post-warmup process RSS was 44.22 GiB with transient staging and 34.23 GiB in the control; absolute cgroup maxima were 57.47 and 48.69 GiB. [Full-tray control](https://iris.oa.dev/#/job/%2Fpower%2Fcodex-hostmem-fulltray-main-off-r1-20260823-coord) and [full-tray treatment](https://iris.oa.dev/#/job/%2Fpower%2Fcodex-hostmem-fulltray-fixed-off-r1-20260823-coord) retain the raw logs.

Native Memray attribution on a smaller matched arm found a 268.4 MiB-per-rank `CudaHostAllocator` / BFC pool associated with transient pinned-host staging. A transient device-array prototype avoided that pool and completed the matched tray run without increasing checkpoint peaks, but has not been proposed because production hero HBM headroom is unknown. The [durable investigation record](https://echo.oa.dev/wiki/226) contains the allocator breakdown and all experiment links; follow-up remains in #8599.
