### PR TITLE
[grug] Fix EP MoE edge bounds and capacity

### DIFF
--- a/lib/haliax/src/haliax/nn/ragged_dot.py
+++ b/lib/haliax/src/haliax/nn/ragged_dot.py
@@ -109,6 +109,7 @@ def _triton_ragged_dot_kernel(
     *,
     block_m: int,
     block_k: int,
+    n: int,
 ):
     """Pallas-Triton ragged dot kernel (no quantization)."""
     lo = lo_ref[()]
@@ -118,21 +119,34 @@ def _triton_ragged_dot_kernel(
     @pl.when(start_m < hi)
     def _compute():
         span_m = pl.ds(start_m, block_m)
+        start_n = pl.program_id(1) * out_ref.shape[1]
         acc = jnp.zeros((block_m, out_ref.shape[1]), dtype=jnp.float32)
         k = a_ref.shape[1]
 
         def body(i, acc):
             start_k = i * block_k
             span_k = pl.ds(start_k, block_k)
-            a = plgpu.load(a_ref.at[span_m, span_k])
-            b = plgpu.load(b_ref.at[span_k, pl.ds(0, b_ref.shape[1])])
+            if k % block_k:
+                contraction_mask = start_k + jnp.arange(block_k) < k
+                a = plgpu.load(a_ref.at[span_m, span_k], mask=contraction_mask[None, :], other=0.0)
+                b = plgpu.load(b_ref.at[span_k, pl.ds(0, b_ref.shape[1])], mask=contraction_mask[:, None], other=0.0)
+            else:
+                a = plgpu.load(a_ref.at[span_m, span_k])
+                b = plgpu.load(b_ref.at[span_k, pl.ds(0, b_ref.shape[1])])
             dtype = jnp.result_type(a, b)
             return acc + pl.dot(a.astype(dtype), b.astype(dtype))
 
         num_k_blocks = pl.cdiv(k, block_k)
         acc = jax.lax.fori_loop(0, num_k_blocks, body, acc)
-        mask = (start_m + jnp.arange(block_m)) < hi
-        plgpu.store(out_ref.at[span_m, pl.ds(0, out_ref.shape[1])], acc.astype(out_ref.dtype), mask=mask[:, None])
+        # Tokamax's BlockRef masks logical output edges; raw Pallas refs do not.
+        store_mask = (start_m + jnp.arange(block_m) < hi)[:, None]
+        if n % out_ref.shape[1]:
+            store_mask &= (start_n + jnp.arange(out_ref.shape[1]) < n)[None, :]
+        plgpu.store(
+            out_ref.at[span_m, pl.ds(0, out_ref.shape[1])],
+            acc.astype(out_ref.dtype),
+            mask=store_mask,
+        )
 
 
 def _triton_default_block_sizes(m: int, k: int, n: int) -> tuple[int, int, int]:
@@ -153,7 +167,16 @@ def _triton_default_matmul(m: int, k: int, n: int, num_groups: int, dtype) -> Ca
     """
     block_m, block_n, block_k = _triton_default_block_sizes(m, k, n)
     return pl.pallas_call(
-        lambda a, b, lo, hi, out: _triton_ragged_dot_kernel(a, b, lo, hi, out, block_m=block_m, block_k=block_k),
+        lambda a, b, lo, hi, out: _triton_ragged_dot_kernel(
+            a,
+            b,
+            lo,
+            hi,
+            out,
+            block_m=block_m,
+            block_k=block_k,
+            n=n,
+        ),
         out_shape=jax.ShapeDtypeStruct((m, n), dtype),
         in_specs=[
             pl.no_block_spec,
@@ -185,6 +208,8 @@ def _triton_ragged_contracting_dim_dot_kernel(
     *,
     block_m: int,
     block_k: int,
+    m: int,
+    n: int,
 ):
     """Pallas-Triton ragged dot where the ragged dimension is also contracting."""
     lo = lo_ref[()]
@@ -207,7 +232,13 @@ def _triton_ragged_contracting_dim_dot_kernel(
     acc = jnp.zeros((block_m, out_ref.shape[1]), dtype=jnp.float32)
     acc = jax.lax.fori_loop(0, num_k_blocks - 1, body, acc)
     acc = body(num_k_blocks - 1, acc, mask_k=True)
-    plgpu.store(out_ref, acc.astype(out_ref.dtype))
+    store_mask = None
+    if m % block_m:
+        store_mask = (pl.program_id(0) * block_m + jnp.arange(block_m) < m)[:, None]
+    if n % out_ref.shape[1]:
+        column_mask = (pl.program_id(1) * out_ref.shape[1] + jnp.arange(out_ref.shape[1]) < n)[None, :]
+        store_mask = column_mask if store_mask is None else store_mask & column_mask
+    plgpu.store(out_ref, acc.astype(out_ref.dtype), mask=store_mask)
 
 
 @functools.lru_cache(maxsize=None)
@@ -225,6 +256,8 @@ def _triton_ragged_contracting_dim_matmul(k: int, m: int, n: int, dtype) -> Call
             out,
             block_m=block_m,
             block_k=block_k,
+            m=m,
+            n=n,
         ),
         out_shape=jax.ShapeDtypeStruct((m, n), dtype),
         in_specs=[

--- a/lib/haliax/tests/test_ragged_dot_dispatch.py
+++ b/lib/haliax/tests/test_ragged_dot_dispatch.py
@@ -6,7 +6,6 @@ import importlib
 
 import jax
 import jax.numpy as jnp
-import pytest
 
 from haliax.nn import ragged_dot
 
@@ -14,8 +13,10 @@ ragged_dot_module = importlib.import_module("haliax.nn.ragged_dot")
 
 
 def _inputs():
-    lhs = jnp.arange(12, dtype=jnp.float32).reshape(3, 4)
-    rhs = jnp.arange(2 * 4 * 5, dtype=jnp.float32).reshape(2, 4, 5)
+    contraction_dim = 32
+    output_dim = 17
+    lhs = jnp.arange(3 * contraction_dim, dtype=jnp.float32).reshape(3, contraction_dim) / 100
+    rhs = jnp.arange(2 * contraction_dim * output_dim, dtype=jnp.float32).reshape(2, contraction_dim, output_dim) / 100
     group_sizes = jnp.array([2, 1], dtype=jnp.int32)
     return lhs, rhs, group_sizes
 
@@ -29,32 +30,18 @@ def test_ragged_dot_platform_default_is_close_to_xla_call():
     assert jnp.allclose(default_out, xla_out, rtol=1e-5, atol=1e-5)
 
 
-def test_triton_kernel_traces_with_jax_0_9_pallas_memory_api_on_cpu_interpreter():
-    if not ragged_dot_module._has_pallas_triton:
-        pytest.skip("Pallas Triton backend is not available")
+def test_ragged_dot_platform_default_gradients_are_close_to_xla_call():
+    lhs, rhs, group_sizes = _inputs()
 
-    lhs = jnp.arange(4, dtype=jnp.float32).reshape(2, 2)
-    rhs = jnp.arange(6, dtype=jnp.float32).reshape(2, 3)
-    lo = jnp.array(0, dtype=jnp.int32)
-    hi = jnp.array(lhs.shape[0], dtype=jnp.int32)
+    def loss(lhs, rhs, implementation):
+        return jnp.sum(ragged_dot(lhs, rhs, group_sizes, implementation=implementation) ** 2)
 
-    pallas_call = ragged_dot_module.pl.pallas_call(
-        lambda a, b, lo, hi, out: ragged_dot_module._triton_ragged_dot_kernel(
-            a, b, lo, hi, out, block_m=lhs.shape[0], block_k=lhs.shape[1]
-        ),
-        out_shape=jax.ShapeDtypeStruct((lhs.shape[0], rhs.shape[1]), lhs.dtype),
-        in_specs=[
-            ragged_dot_module.pl.no_block_spec,
-            ragged_dot_module.pl.no_block_spec,
-            ragged_dot_module.pl.no_block_spec,
-            ragged_dot_module.pl.no_block_spec,
-        ],
-        out_specs=ragged_dot_module.pl.no_block_spec,
-        grid=(1,),
-        interpret=True,
-    )
+    default_value, default_gradients = jax.value_and_grad(loss, argnums=(0, 1))(lhs, rhs, "auto")
+    xla_value, xla_gradients = jax.value_and_grad(loss, argnums=(0, 1))(lhs, rhs, "xla")
 
-    assert jnp.allclose(pallas_call(lhs, rhs, lo, hi), lhs @ rhs, rtol=1e-5, atol=1e-5)
+    assert jnp.allclose(default_value, xla_value, rtol=1e-5, atol=1e-5)
+    assert jnp.allclose(default_gradients[0], xla_gradients[0], rtol=1e-5, atol=1e-5)
+    assert jnp.allclose(default_gradients[1], xla_gradients[1], rtol=1e-5, atol=1e-5)
 
 
 def test_ragged_dot_gpu_auto_uses_triton_when_available(monkeypatch):

--- a/lib/haliax/tests/test_ragged_dot_dispatch.py
+++ b/lib/haliax/tests/test_ragged_dot_dispatch.py
@@ -3,9 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
+import pytest
 
 from haliax.nn import ragged_dot
 
@@ -21,30 +23,54 @@ def _inputs():
     return lhs, rhs, group_sizes
 
 
-def test_ragged_dot_platform_default_is_close_to_xla_call():
+def _accelerator_implementation() -> Literal["megablox", "triton"]:
+    backend = jax.default_backend()
+    if backend == "gpu" and ragged_dot_module._has_pallas_triton:
+        return "triton"
+    if backend == "tpu" and ragged_dot_module._gmm_megablox is not None:
+        return "megablox"
+    pytest.skip("requires a supported accelerator ragged-dot implementation")
+
+
+def test_accelerator_implementation_value_and_gradients_match_xla():
     lhs, rhs, group_sizes = _inputs()
-
-    default_out = ragged_dot(lhs, rhs, group_sizes, implementation="auto")
-    xla_out = ragged_dot(lhs, rhs, group_sizes, implementation="xla")
-
-    assert jnp.allclose(default_out, xla_out, rtol=1e-5, atol=1e-5)
-
-
-def test_ragged_dot_platform_default_gradients_are_close_to_xla_call():
-    lhs, rhs, group_sizes = _inputs()
+    implementation = _accelerator_implementation()
 
     def loss(lhs, rhs, implementation):
         return jnp.sum(ragged_dot(lhs, rhs, group_sizes, implementation=implementation) ** 2)
 
-    default_value, default_gradients = jax.value_and_grad(loss, argnums=(0, 1))(lhs, rhs, "auto")
-    xla_value, xla_gradients = jax.value_and_grad(loss, argnums=(0, 1))(lhs, rhs, "xla")
+    actual_value, actual_gradients = jax.value_and_grad(loss, argnums=(0, 1))(lhs, rhs, implementation)
+    expected_value, expected_gradients = jax.value_and_grad(loss, argnums=(0, 1))(lhs, rhs, "xla")
 
-    assert jnp.allclose(default_value, xla_value, rtol=1e-5, atol=1e-5)
-    assert jnp.allclose(default_gradients[0], xla_gradients[0], rtol=1e-5, atol=1e-5)
-    assert jnp.allclose(default_gradients[1], xla_gradients[1], rtol=1e-5, atol=1e-5)
+    assert jnp.allclose(actual_value, expected_value, rtol=1e-5, atol=1e-5)
+    assert jnp.allclose(actual_gradients[0], expected_gradients[0], rtol=1e-5, atol=1e-5)
+    assert jnp.allclose(actual_gradients[1], expected_gradients[1], rtol=1e-5, atol=1e-5)
 
 
-def test_ragged_dot_gpu_auto_uses_triton_when_available(monkeypatch):
+def test_triton_kernel_traces_with_jax_0_9_pallas_memory_api_on_cpu_interpreter():
+    if not ragged_dot_module._has_pallas_triton:
+        pytest.skip("Pallas Triton backend is not available")
+
+    lhs, grouped_rhs, _ = _inputs()
+    lhs = lhs[:2]
+    rhs = grouped_rhs[0]
+    lo = jnp.array(0, dtype=jnp.int32)
+    hi = jnp.array(lhs.shape[0], dtype=jnp.int32)
+    pallas_call = ragged_dot_module.pl.pallas_call(
+        lambda a, b, lo, hi, out: ragged_dot_module._triton_ragged_dot_kernel(
+            a, b, lo, hi, out, block_m=lhs.shape[0], block_k=lhs.shape[1], n=rhs.shape[1]
+        ),
+        out_shape=jax.ShapeDtypeStruct((lhs.shape[0], rhs.shape[1]), lhs.dtype),
+        in_specs=[ragged_dot_module.pl.no_block_spec] * 4,
+        out_specs=ragged_dot_module.pl.no_block_spec,
+        grid=(1, 1),
+        interpret=True,
+    )
+
+    assert jnp.allclose(pallas_call(lhs, rhs, lo, hi), lhs @ rhs, rtol=1e-5, atol=1e-5)
+
+
+def test_gpu_auto_selects_triton_instead_of_xla(monkeypatch):
     lhs, rhs, group_sizes = _inputs()
     expected = jnp.full((lhs.shape[0], rhs.shape[2]), 17.0, dtype=lhs.dtype)
     monkeypatch.setattr(ragged_dot_module.jax, "default_backend", lambda: "gpu")
@@ -53,7 +79,11 @@ def test_ragged_dot_gpu_auto_uses_triton_when_available(monkeypatch):
     def triton_result(lhs, rhs, group_sizes):
         return jnp.full((lhs.shape[0], rhs.shape[2]), expected[0, 0], dtype=lhs.dtype)
 
+    def unexpected_xla(*args):
+        raise AssertionError("GPU auto dispatch selected XLA instead of Triton")
+
     monkeypatch.setattr(ragged_dot_module, "_ragged_dot_triton_impl", triton_result)
+    monkeypatch.setattr(ragged_dot_module, "_ragged_dot_xla_impl", unexpected_xla)
 
     auto_out = ragged_dot(lhs, rhs, group_sizes, implementation="auto")
 

--- a/lib/levanter/src/levanter/grug/_moe/ep_ring.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ring.py
@@ -55,7 +55,7 @@ def _moe_mlp_ep_ring_local(
 
         ep_size = num_experts // local_experts
         local_capacity = int(math.ceil(capacity_factor * assignments / ep_size))
-        local_capacity = max(local_experts, local_capacity)
+        local_capacity = min(assignments, max(local_experts, local_capacity))
 
         expert_axis = jax.lax.axis_index("expert")
         expert_start = expert_axis * local_experts

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -43,6 +43,10 @@ from levanter.grug.grug_moe import (
 from levanter.utils.activation import ActivationFunctionEnum
 
 
+_BF16_MOE_RELATIVE_TOLERANCE = 0.02
+_FP32_MOE_RELATIVE_TOLERANCE = 1e-4
+
+
 def _make_dense_mesh() -> Mesh:
     devices = jax.devices()
     if not devices:
@@ -123,6 +127,25 @@ def _make_inputs(
     w_up_gate = jax.random.normal(k_w13, (num_experts, hidden_dim, 2 * intermediate_dim), dtype=jnp.float32)
     w_down = jax.random.normal(k_w2, (num_experts, intermediate_dim, hidden_dim), dtype=jnp.float32)
     return x, selected_experts, combine_weights, w_up_gate, w_down
+
+
+def _dense_moe_output(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+) -> jax.Array:
+    selected_w_up_gate = w_up_gate[selected_experts]
+    hidden = jnp.einsum("th,tkhi->tki", x, selected_w_up_gate)
+    intermediate_dim = w_down.shape[1]
+    gate, up = jnp.split(hidden, [intermediate_dim], axis=-1)
+    expert_output = jnp.einsum(
+        "tki,tkih->tkh",
+        jax.nn.silu(gate) * up,
+        w_down[selected_experts],
+    )
+    return jnp.einsum("tkh,tk->th", expert_output, combine_weights)
 
 
 def _make_unique_topk_experts(*, tokens: int, topk: int, num_experts: int) -> jax.Array:
@@ -840,7 +863,8 @@ def test_fixed_pooled_wave_all_to_all_reports_sender_and_receiver_drops():
     assert int(overflow.receiver) == 3
 
 
-def test_fixed_all_to_all_matches_dense_cross_shard_value_and_gradients():
+def test_ring_matches_dense_cross_shard_above_assignment_capacity():
+    implementation: MoeImplementation = "ring"
     env = os.environ.copy()
     env["JAX_PLATFORMS"] = "cpu"
     env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
@@ -854,9 +878,9 @@ def test_fixed_all_to_all_matches_dense_cross_shard_value_and_gradients():
 
         assert jax.device_count() == 4
         mesh = Mesh(
-            np.asarray(jax.devices()),
-            axis_names=("expert",),
-            axis_types=(AxisType.Explicit,),
+            np.asarray(jax.devices()).reshape(2, 2, 1),
+            axis_names=("data", "expert", "model"),
+            axis_types=(AxisType.Explicit, AxisType.Explicit, AxisType.Explicit),
         )
         x = jax.random.normal(jax.random.key(0), (4, 4))
         selected_experts = jnp.asarray(
@@ -885,7 +909,7 @@ def test_fixed_all_to_all_matches_dense_cross_shard_value_and_gradients():
             argnums=(0, 1, 2),
         )(x, w_up_gate, w_down)
 
-        batch_sharding = NamedSharding(mesh, P("expert", None))
+        batch_sharding = NamedSharding(mesh, P(("data", "expert"), None))
         expert_sharding = NamedSharding(mesh, P("expert", None, None))
         x = jax.device_put(x, batch_sharding)
         selected_experts = jax.device_put(selected_experts, batch_sharding)
@@ -894,7 +918,12 @@ def test_fixed_all_to_all_matches_dense_cross_shard_value_and_gradients():
         w_down = jax.device_put(w_down, expert_sharding)
         cotangent = jax.device_put(cotangent, batch_sharding)
 
-        def fixed_output(x, w_up_gate, w_down):
+        implementation = "__IMPLEMENTATION__"
+        extra = {}
+        if implementation == "fixed_pooled_wave_all_to_all":
+            extra["pooled_transport_capacity_factor"] = 4.0
+
+        def backend_output(x, w_up_gate, w_down):
             return moe_mlp(
                 x,
                 selected_experts,
@@ -902,15 +931,16 @@ def test_fixed_all_to_all_matches_dense_cross_shard_value_and_gradients():
                 w_up_gate,
                 w_down,
                 activation=jax.nn.silu,
-                implementation="fixed_all_to_all",
+                implementation=implementation,
                 mesh=mesh,
                 capacity_factor=4.0,
+                **extra,
             )
 
         with jax.set_mesh(mesh):
-            actual = fixed_output(x, w_up_gate, w_down)
+            actual = backend_output(x, w_up_gate, w_down)
             actual_gradients = jax.grad(
-                lambda x, w_up_gate, w_down: jnp.sum(fixed_output(x, w_up_gate, w_down) * cotangent),
+                lambda x, w_up_gate, w_down: jnp.sum(backend_output(x, w_up_gate, w_down) * cotangent),
                 argnums=(0, 1, 2),
             )(x, w_up_gate, w_down)
 
@@ -924,7 +954,7 @@ def test_fixed_all_to_all_matches_dense_cross_shard_value_and_gradients():
             )
     """
     result = subprocess.run(
-        [sys.executable, "-c", textwrap.dedent(script)],
+        [sys.executable, "-c", textwrap.dedent(script.replace("__IMPLEMENTATION__", implementation))],
         env=env,
         text=True,
         capture_output=True,
@@ -954,7 +984,8 @@ def test_shard_a2a_params_uses_sender_side_output_offsets():
     np.testing.assert_array_equal(np.asarray(output_offsets), np.array([1, 7, 2], dtype=np.int32))
 
 
-def test_moe_mlp_ragged_matches_ring_with_ep_axis_when_available():
+@pytest.mark.parametrize("implementation", ["ring", "ragged_all_to_all"])
+def test_moe_mlp_ep_backends_match_dense_value_and_gradients_when_available(implementation: MoeImplementation):
     mesh = _make_ep_mesh_or_none()
     if mesh is None:
         pytest.skip("requires an even number of >=2 devices")
@@ -962,54 +993,85 @@ def test_moe_mlp_ragged_matches_ring_with_ep_axis_when_available():
         pytest.skip("ragged_all_to_all is not implemented on XLA:CPU")
 
     tokens = len(jax.devices()) * 8
-    hidden_dim = 16
-    intermediate_dim = 24
+    gpu_runtime = jax.devices()[0].platform == "gpu"
+    hidden_dim = 16 if gpu_runtime else 128
+    intermediate_dim = 24 if gpu_runtime else 128
     num_experts = 4
     topk = 2
+    x, selected_experts, combine_weights, w_up_gate, w_down = _make_inputs(
+        key=jax.random.key(23),
+        tokens=tokens,
+        hidden_dim=hidden_dim,
+        intermediate_dim=intermediate_dim,
+        num_experts=num_experts,
+        topk=topk,
+    )
+    dtype = jnp.bfloat16 if gpu_runtime else jnp.float32
+    relative_tolerance = _BF16_MOE_RELATIVE_TOLERANCE if dtype == jnp.bfloat16 else _FP32_MOE_RELATIVE_TOLERANCE
+    x = x.astype(dtype)
+    combine_weights = combine_weights.astype(dtype)
+    w_up_gate = w_up_gate.astype(dtype)
+    w_down = w_down.astype(dtype)
+    cotangent = jax.random.normal(jax.random.key(24), x.shape, dtype=dtype)
+
+    x_reference = x.astype(jnp.float32)
+    combine_weights_reference = combine_weights.astype(jnp.float32)
+    w_up_gate_reference = w_up_gate.astype(jnp.float32)
+    w_down_reference = w_down.astype(jnp.float32)
+    cotangent_reference = cotangent.astype(jnp.float32)
+    expected = _dense_moe_output(
+        x_reference,
+        selected_experts,
+        combine_weights_reference,
+        w_up_gate_reference,
+        w_down_reference,
+    )
+    expected_gradients = jax.grad(
+        lambda x, w_up_gate, w_down: jnp.sum(
+            _dense_moe_output(x, selected_experts, combine_weights_reference, w_up_gate, w_down) * cotangent_reference
+        ),
+        argnums=(0, 1, 2),
+    )(x_reference, w_up_gate_reference, w_down_reference)
+
+    batch_sharding = NamedSharding(mesh, P(("data", "expert"), None))
+    expert_sharding = NamedSharding(mesh, P("expert", None, None))
+    x = jax.sharding.reshard(x, batch_sharding)
+    selected_experts = jax.sharding.reshard(selected_experts, batch_sharding)
+    combine_weights = jax.sharding.reshard(combine_weights, batch_sharding)
+    w_up_gate = jax.sharding.reshard(w_up_gate, expert_sharding)
+    w_down = jax.sharding.reshard(w_down, expert_sharding)
+    cotangent = jax.sharding.reshard(cotangent, batch_sharding)
+
+    def backend_output(x, w_up_gate, w_down):
+        return moe_mlp(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            implementation=implementation,
+            mesh=mesh,
+            report_capacity_overflow=True,
+            capacity_factor=2.0,
+        )
 
     with jax.set_mesh(mesh):
-        x, selected_experts, combine_weights, w_up_gate, w_down = _make_inputs(
-            key=jax.random.key(23),
-            tokens=tokens,
-            hidden_dim=hidden_dim,
-            intermediate_dim=intermediate_dim,
-            num_experts=num_experts,
-            topk=topk,
-        )
+        actual, overflow = backend_output(x, w_up_gate, w_down)
+        actual_gradients = jax.grad(
+            lambda x, w_up_gate, w_down: jnp.sum(backend_output(x, w_up_gate, w_down)[0] * cotangent),
+            argnums=(0, 1, 2),
+        )(x, w_up_gate, w_down)
 
-        batch_sharding = NamedSharding(mesh, P(("data", "expert"), None))
-        expert_sharding = NamedSharding(mesh, P("expert", None, None))
-        x = jax.sharding.reshard(x, batch_sharding)
-        selected_experts = jax.sharding.reshard(selected_experts, batch_sharding)
-        combine_weights = jax.sharding.reshard(combine_weights, batch_sharding)
-        w_up_gate = jax.sharding.reshard(w_up_gate, expert_sharding)
-        w_down = jax.sharding.reshard(w_down, expert_sharding)
+    def relative_max_error(actual, expected):
+        actual = np.asarray(actual, dtype=np.float32)
+        expected = np.asarray(expected, dtype=np.float32)
+        return np.max(np.abs(actual - expected)) / np.max(np.abs(expected))
 
-        ring_out, ring_dropped = moe_mlp(
-            x,
-            selected_experts,
-            combine_weights,
-            w_up_gate,
-            w_down,
-            implementation="ring",
-            mesh=None,
-            report_capacity_overflow=True,
-            capacity_factor=1.0,
-        )
-        ragged_out, ragged_dropped = moe_mlp(
-            x,
-            selected_experts,
-            combine_weights,
-            w_up_gate,
-            w_down,
-            implementation="ragged_all_to_all",
-            mesh=None,
-            report_capacity_overflow=True,
-            capacity_factor=1.0,
-        )
-
-    np.testing.assert_allclose(np.asarray(ragged_out), np.asarray(ring_out), rtol=1e-5, atol=1e-5)
-    assert int(ragged_dropped.total) == int(ring_dropped.total)
+    assert relative_max_error(actual, expected) < relative_tolerance
+    for actual_gradient, expected_gradient in zip(actual_gradients, expected_gradients, strict=True):
+        assert np.isfinite(np.asarray(actual_gradient)).all()
+        assert relative_max_error(actual_gradient, expected_gradient) < relative_tolerance
+    assert int(overflow.total) == 0
 
 
 def test_moe_mlp_runs_with_ep_axis_when_available():

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -677,15 +677,7 @@ def test_fixed_all_to_all_drops_assignments_over_capacity():
     keep = jnp.asarray([[True, True], [True, True], [False, False], [False, False]])
 
     def dense_output(x, w_up_gate, w_down):
-        selected_w13 = w_up_gate[selected_experts]
-        hidden = jnp.einsum("th,tkhi->tki", x, selected_w13)
-        gate, up = jnp.split(hidden, [intermediate_dim], axis=-1)
-        expert_output = jnp.einsum(
-            "tki,tkih->tkh",
-            jax.nn.silu(gate) * up,
-            w_down[selected_experts],
-        )
-        return jnp.einsum("tkh,tk->th", expert_output, combine_weights * keep)
+        return _dense_moe_output(x, selected_experts, combine_weights * keep, w_up_gate, w_down)
 
     cotangent = jax.random.normal(jax.random.key(42), x.shape)
     with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
@@ -761,15 +753,7 @@ def test_fixed_pooled_wave_all_to_all_matches_dense_value_and_gradients():
     rematerialized_pooled_output = jax.checkpoint(sharded_pooled_output)
 
     def dense_output(x, combine_weights, w_up_gate, w_down):
-        selected_w13 = w_up_gate[selected_experts]
-        hidden = jnp.einsum("th,tkhi->tki", x, selected_w13)
-        gate, up = jnp.split(hidden, [intermediate_dim], axis=-1)
-        expert_output = jnp.einsum(
-            "tki,tkih->tkh",
-            jax.nn.silu(gate) * up,
-            w_down[selected_experts],
-        )
-        return jnp.einsum("tkh,tk->th", expert_output, combine_weights)
+        return _dense_moe_output(x, selected_experts, combine_weights, w_up_gate, w_down)
 
     with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
         actual = sharded_pooled_output(x, combine_weights, w_up_gate, w_down)
@@ -847,24 +831,16 @@ def test_fixed_pooled_wave_all_to_all_reports_sender_and_receiver_drops():
     with jax.set_mesh(mesh):
         actual, overflow = sharded_pooled_output(x, combine_weights, w_up_gate, w_down)
 
-    selected_w13 = w_up_gate[selected_experts]
-    hidden = jnp.einsum("th,tkhi->tki", x, selected_w13)
-    gate, up = jnp.split(hidden, [intermediate_dim], axis=-1)
-    expert_output = jnp.einsum(
-        "tki,tkih->tkh",
-        jax.nn.silu(gate) * up,
-        w_down[selected_experts],
-    )
     keep = jnp.arange(tokens)[:, None] < 3
-    expected = jnp.einsum("tkh,tk->th", expert_output, combine_weights * keep)
+    expected = _dense_moe_output(x, selected_experts, combine_weights * keep, w_up_gate, w_down)
 
     np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-5)
     assert int(overflow.sender) == 3
     assert int(overflow.receiver) == 3
 
 
-def test_ring_matches_dense_cross_shard_above_assignment_capacity():
-    implementation: MoeImplementation = "ring"
+@pytest.mark.parametrize("implementation", ["ring", "fixed_all_to_all", "fixed_pooled_wave_all_to_all"])
+def test_portable_ep_backends_match_dense_cross_shard_value_and_gradients(implementation: MoeImplementation):
     env = os.environ.copy()
     env["JAX_PLATFORMS"] = "cpu"
     env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"


### PR DESCRIPTION
## Changes

- **Ragged-dot bounds:** Restore Tokamax-equivalent K-load and M/N-store masks on non-tile-aligned Triton edge tiles.
- **Ring capacity:** Cap local ring EP capacity at the gathered assignment count before calling `top_k`.
- **Regression coverage:** Compare EP values and gradients with a dense MoE reference, retain the CPU-interpreter Triton trace, and verify that GPU `auto` dispatch selects Triton.

## Context and motivation

Haliax adapted Tokamax's Triton ragged dot from bounds-aware `block.pallas_call` to raw `pl.pallas_call`. That adaptation lost the automatic bounds masks supplied by Tokamax's `BlockRef`. On GB200, an N=192 projection uses a physical N tile of 256, so accesses to logical padding corrupted values and gradients. The fix restores the Tokamax bounds contract only for dimensions with edge tiles; aligned paths remain unmasked. **This is a Haliax adaptation defect, not an upstream Tokamax defect.**

Ring EP had a separate failure: its capacity-factor calculation could produce a local capacity larger than the gathered selection pool. In the reported configuration, capacity factor 4.0 requested `top_k(k=512)` from 256 rows. The capacity is now limited to the number of gathered assignments.

The dense reference covers cross-shard values and gradients for ring, fixed all-to-all, and pooled-wave on CPU, plus supported accelerator backends. Accelerator parity names the implementation explicitly, while a separate dispatch test fails if GPU `implementation="auto"` falls through to XLA.

## Validation

- **Regression proof:** At tests-only commit `dc168c4ddd`, the [full unit workflow failed](https://github.com/marin-community/marin/actions/runs/32780486622) in CPU and TPU jobs when the ring test requested `top_k(k=8)` from four rows.
- **Fix verification:** The [same full unit workflow passed](https://github.com/marin-community/marin/actions/runs/32782477887) after the production fixes at `df5d8b48f6`.
- **GB200 reproduction:** Across four seeds on four GB200s, ring forward relative max error fell from 0.79–1.93 to 0.005–0.007; all gradients became finite and remained within 0.006 of the fp32 dense reference.
- **Local checks:** Haliax tests, targeted Levanter MoE tests, diff-selected repository tests, pre-commit, and Pyrefly passed.
- **Coverage limits:** Stock GB200 `main` segfaults inside XLA's ragged all-to-all before parity can run; #8549 tracks that transport rewrite. DeepEP still requires its external source tree and FFI build.

Fixes #8578
