### PR TITLE
[iac] Grant Echo CD service usage access

### DIFF
--- a/infra/pulumi/src/iac/gcp/iam_data.yaml
+++ b/infra/pulumi/src/iac/gcp/iam_data.yaml
@@ -1334,6 +1334,9 @@ project_grants:
 - role: roles/servicenetworking.serviceAgent
   members:
   - serviceAccount:748532799086-compute@developer.gserviceaccount.com
+- role: roles/serviceusage.serviceUsageConsumer
+  members:
+  - serviceAccount:marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com
 - role: roles/serviceusage.serviceUsageAdmin
   members:
   - principal: human-037


### PR DESCRIPTION
Grant the existing Echo deployment identity Service Usage Consumer on `hai-gcp-models`. Echo's migration pins that project as its Cloud SQL Connector quota project, but the deployment identity lacks `serviceusage.services.use`, so every Echo rollout fails before the migration can run.

Local validation passed all 10 IAM configuration tests and the full pre-commit sweep. The CI preview shows the intended additive member. It also carries two pending `infra-probes` grant deletions from merged PR #8473; they are unrelated to this three-line diff but would be included in a full stack apply.

A reviewer should run the `review-grant` workflow and confirm all three previewed changes. Merge does not apply them: after approval and merge, a human must apply the `marin` stack and rerun `Ops - Pulumi Rollout` with `service=echo` to verify the repair.

Incident record: https://echo.oa.dev/wiki/228

Refs #8611
