### PR TITLE
[grafana] Repair vLLM overview Finelog planning

### DIFF
--- a/infra/grafana/src/vllm_observability.py
+++ b/infra/grafana/src/vllm_observability.py
@@ -284,6 +284,7 @@ WITH base AS (
            resource_attributes_json,
            attributes_json,
            timestamp_ms,
+           timestamp_ms - timestamp_ms % {VLLM_SCRAPE_INTERVAL_MS} AS sample_t,
            name,
            {histogram_source_family} AS source_family,
            {histogram_family} AS family,
@@ -317,7 +318,7 @@ WITH base AS (
            samples.service,
            samples.resource_attributes_json,
            samples.source_family,
-           samples.timestamp_ms,
+           samples.sample_t,
            CASE
                WHEN MAX(samples.invalid_component) = 1 OR COUNT(*) < MAX(expected.expected_series) THEN 0
                ELSE 1
@@ -341,7 +342,7 @@ WITH base AS (
      AND samples.service = validity.service
      AND samples.resource_attributes_json = validity.resource_attributes_json
      AND samples.source_family = validity.source_family
-     AND samples.timestamp_ms = validity.timestamp_ms
+     AND samples.sample_t = validity.sample_t
     WHERE validity.valid_sample = 1
 ), histogram_means AS (
     SELECT family,
@@ -448,7 +449,7 @@ WITH base AS (
 ), freshness_summary AS (
     SELECT * FROM ranked_freshness WHERE freshness_rank = 1
 ), output AS (
-    SELECT t,
+    SELECT t AS t,
            'token_rate' AS section,
            CASE name
                WHEN 'prompt_tokens_total' THEN 'prompt_tokens'
@@ -459,7 +460,7 @@ WITH base AS (
                WHEN 'prompt_tokens_total' THEN 'prompt tokens/s'
                ELSE 'generated tokens/s'
            END AS series,
-           value,
+           value AS value,
            'tokens/s' AS unit,
            CAST(NULL AS VARCHAR) AS status,
            CAST(NULL AS BIGINT) AS samples,
@@ -468,137 +469,137 @@ WITH base AS (
 
     UNION ALL
 
-    SELECT CAST(NULL AS BIGINT),
-           'counter_total',
+    SELECT CAST(NULL AS BIGINT) AS t,
+           'counter_total' AS section,
            CASE name
                WHEN 'prompt_tokens_total' THEN 'prompt_tokens'
                WHEN 'generation_tokens_total' THEN 'generated_tokens'
                ELSE 'preemptions'
-           END,
-           'total',
+           END AS metric,
+           'total' AS stat,
            CASE name
                WHEN 'prompt_tokens_total' THEN 'prompt tokens'
                WHEN 'generation_tokens_total' THEN 'generated tokens'
                ELSE 'preemptions'
-           END,
-           value,
-           CASE WHEN name IN ({token_counters}) THEN 'tokens' ELSE 'requests' END,
-           CAST(NULL AS VARCHAR),
-           CAST(NULL AS BIGINT),
-           CAST(NULL AS DOUBLE)
+           END AS series,
+           value AS value,
+           CASE WHEN name IN ({token_counters}) THEN 'tokens' ELSE 'requests' END AS unit,
+           CAST(NULL AS VARCHAR) AS status,
+           CAST(NULL AS BIGINT) AS samples,
+           CAST(NULL AS DOUBLE) AS gap_seconds
     FROM counter_totals
 
     UNION ALL
 
-    SELECT t,
-           'saturation',
-           name,
-           'value',
-           name,
-           value,
-           CASE WHEN name = 'kv_cache_usage' THEN 'ratio' ELSE 'requests' END,
-           CAST(NULL AS VARCHAR),
-           CAST(NULL AS BIGINT),
-           CAST(NULL AS DOUBLE)
+    SELECT t AS t,
+           'saturation' AS section,
+           name AS metric,
+           'value' AS stat,
+           name AS series,
+           value AS value,
+           CASE WHEN name = 'kv_cache_usage' THEN 'ratio' ELSE 'requests' END AS unit,
+           CAST(NULL AS VARCHAR) AS status,
+           CAST(NULL AS BIGINT) AS samples,
+           CAST(NULL AS DOUBLE) AS gap_seconds
     FROM canonical_gauge_bins
 
     UNION ALL
 
-    SELECT CAST(NULL AS BIGINT),
-           'saturation_summary',
-           name,
-           'average',
-           name,
-           average,
-           CASE WHEN name = 'kv_cache_usage' THEN 'ratio' ELSE 'requests' END,
-           CAST(NULL AS VARCHAR),
-           CAST(NULL AS BIGINT),
-           CAST(NULL AS DOUBLE)
+    SELECT CAST(NULL AS BIGINT) AS t,
+           'saturation_summary' AS section,
+           name AS metric,
+           'average' AS stat,
+           name AS series,
+           average AS value,
+           CASE WHEN name = 'kv_cache_usage' THEN 'ratio' ELSE 'requests' END AS unit,
+           CAST(NULL AS VARCHAR) AS status,
+           CAST(NULL AS BIGINT) AS samples,
+           CAST(NULL AS DOUBLE) AS gap_seconds
     FROM gauge_stats
 
     UNION ALL
 
-    SELECT CAST(NULL AS BIGINT),
-           'saturation_summary',
-           name,
-           'peak',
-           name,
-           peak,
-           CASE WHEN name = 'kv_cache_usage' THEN 'ratio' ELSE 'requests' END,
-           CAST(NULL AS VARCHAR),
-           CAST(NULL AS BIGINT),
-           CAST(NULL AS DOUBLE)
+    SELECT CAST(NULL AS BIGINT) AS t,
+           'saturation_summary' AS section,
+           name AS metric,
+           'peak' AS stat,
+           name AS series,
+           peak AS value,
+           CASE WHEN name = 'kv_cache_usage' THEN 'ratio' ELSE 'requests' END AS unit,
+           CAST(NULL AS VARCHAR) AS status,
+           CAST(NULL AS BIGINT) AS samples,
+           CAST(NULL AS DOUBLE) AS gap_seconds
     FROM gauge_stats
 
     UNION ALL
 
-    SELECT CAST(NULL AS BIGINT),
-           'latency',
-           family,
-           stat,
-           family,
-           value,
-           's',
-           CAST(NULL AS VARCHAR),
-           CAST(NULL AS BIGINT),
-           CAST(NULL AS DOUBLE)
+    SELECT CAST(NULL AS BIGINT) AS t,
+           'latency' AS section,
+           family AS metric,
+           stat AS stat,
+           family AS series,
+           value AS value,
+           's' AS unit,
+           CAST(NULL AS VARCHAR) AS status,
+           CAST(NULL AS BIGINT) AS samples,
+           CAST(NULL AS DOUBLE) AS gap_seconds
     FROM histogram_evidence
 
     UNION ALL
 
-    SELECT CAST(NULL AS BIGINT),
-           'request_outcome',
-           'requests',
-           'total',
-           outcome,
-           value,
-           'requests',
-           CAST(NULL AS VARCHAR),
-           CAST(NULL AS BIGINT),
-           CAST(NULL AS DOUBLE)
+    SELECT CAST(NULL AS BIGINT) AS t,
+           'request_outcome' AS section,
+           'requests' AS metric,
+           'total' AS stat,
+           outcome AS series,
+           value AS value,
+           'requests' AS unit,
+           CAST(NULL AS VARCHAR) AS status,
+           CAST(NULL AS BIGINT) AS samples,
+           CAST(NULL AS DOUBLE) AS gap_seconds
     FROM outcome_totals
 
     UNION ALL
 
-    SELECT latest_timestamp_ms,
-           'freshness',
-           'telemetry',
-           'latest_sample_age',
-           origin_cluster || ':' || service || ':' || resource_attributes_json,
-           ({end_ms} - latest_timestamp_ms) / 1000.0,
-           's',
-           freshness_status,
-           CAST(samples AS BIGINT),
-           gap_seconds
+    SELECT latest_timestamp_ms AS t,
+           'freshness' AS section,
+           'telemetry' AS metric,
+           'latest_sample_age' AS stat,
+           origin_cluster || ':' || service || ':' || resource_attributes_json AS series,
+           ({end_ms} - latest_timestamp_ms) / 1000.0 AS value,
+           's' AS unit,
+           freshness_status AS status,
+           CAST(samples AS BIGINT) AS samples,
+           gap_seconds AS gap_seconds
     FROM freshness_summary
 
     UNION ALL
 
-    SELECT latest_timestamp_ms,
-           'freshness_detail',
-           'telemetry',
-           'latest_sample_age',
-           origin_cluster || ':' || service || ':' || resource_attributes_json,
-           ({end_ms} - latest_timestamp_ms) / 1000.0,
-           's',
-           freshness_status,
-           CAST(samples AS BIGINT),
-           gap_seconds
+    SELECT latest_timestamp_ms AS t,
+           'freshness_detail' AS section,
+           'telemetry' AS metric,
+           'latest_sample_age' AS stat,
+           origin_cluster || ':' || service || ':' || resource_attributes_json AS series,
+           ({end_ms} - latest_timestamp_ms) / 1000.0 AS value,
+           's' AS unit,
+           freshness_status AS status,
+           CAST(samples AS BIGINT) AS samples,
+           gap_seconds AS gap_seconds
     FROM ranked_freshness
     WHERE freshness_rank <= {VLLM_MAX_FRESHNESS_DETAILS}
 
     UNION ALL
 
-    SELECT CAST(NULL AS BIGINT),
-           'freshness',
-           'telemetry',
-           'latest_sample_age',
-           'telemetry',
-           CAST(NULL AS DOUBLE),
-           's',
-           'no_data',
-           CAST(0 AS BIGINT),
-           CAST(NULL AS DOUBLE)
+    SELECT CAST(NULL AS BIGINT) AS t,
+           'freshness' AS section,
+           'telemetry' AS metric,
+           'latest_sample_age' AS stat,
+           'telemetry' AS series,
+           CAST(NULL AS DOUBLE) AS value,
+           's' AS unit,
+           'no_data' AS status,
+           CAST(0 AS BIGINT) AS samples,
+           CAST(NULL AS DOUBLE) AS gap_seconds
     WHERE NOT EXISTS (SELECT 1 FROM producer_freshness)
 )
 SELECT t, section, metric, stat, series, value, unit, status, samples, gap_seconds

--- a/infra/grafana/tests/test_vllm_observability.py
+++ b/infra/grafana/tests/test_vllm_observability.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import re
 from pathlib import Path
 from typing import NamedTuple
 
@@ -139,6 +140,16 @@ def _one(rows: list[dict], section: str, metric: str, stat: str, series: str | N
     return matches[0]
 
 
+def test_query_names_every_output_projection_for_finelog():
+    query = vllm_overview_query(VllmIdentityField.JOB_ID, "/serve", START_MS, END_MS, BUCKET_MS)
+    output_cte = query.sql.split("), output AS (\n", 1)[1].split("\n)\nSELECT t, section", 1)[0]
+    output_columns = ("t", "section", "metric", "stat", "series", "value", "unit", "status", "samples", "gap_seconds")
+    output_alias = re.compile(rf"\bAS ({'|'.join(output_columns)})\b")
+
+    for branch in output_cte.split("\n\n    UNION ALL\n\n"):
+        assert output_alias.findall(branch) == list(output_columns)
+
+
 def _counter_records() -> list[TelemetryRow]:
     cumulative = _attributes("cumulative_snapshot")
     rows: list[TelemetryRow] = []
@@ -214,9 +225,9 @@ def _latency_records() -> list[TelemetryRow]:
         rows.extend(
             [
                 _record("a", f"{family}_sum", 0, 105_000, cumulative),
-                _record("a", f"{family}_count", 0, 105_000, cumulative),
+                _record("a", f"{family}_count", 0, 105_001, cumulative),
                 _record("a", f"{family}_sum", total_sum, 135_000, cumulative),
-                _record("a", f"{family}_count", count, 135_000, cumulative),
+                _record("a", f"{family}_count", count, 135_001, cumulative),
             ]
         )
     return rows


### PR DESCRIPTION
Finelog can plan the shared vLLM overview query again. Every output-union branch now names the endpoint's ten columns explicitly.

Production histogram components from one logical scrape can arrive on adjacent millisecond timestamps. An alias-only candidate planned successfully but produced 0 of 42 valid TPOT samples. The query now keys histogram completeness by its existing 15-second scrape interval. This keeps reset and incomplete-family filtering while restoring separate TPOT and inter-token-latency results. The endpoint schema and dashboard mappings do not change.

Fixes #8613
