### PR TITLE
[grug] Add the production hero trigger

### DIFF
--- a/experiments/grug/moe_hero_ep/trigger_hero.sh
+++ b/experiments/grug/moe_hero_ep/trigger_hero.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+if [[ $# -ne 0 ]]; then
+  echo "Usage: $0" >&2
+  exit 2
+fi
+
+: "${WANDB_API_KEY:?Set WANDB_API_KEY before you start the hero.}"
+
+short_uuid=$(uuidgen | tr '[:upper:]' '[:lower:]')
+short_uuid=${short_uuid:0:8}
+
+uv run iris --config lib/iris/config/marin.yaml job run --no-wait \
+  --target-cluster cw-us-east-08a \
+  --priority production \
+  --cpu 1 \
+  --memory 4g \
+  --max-retries 1000 \
+  --job-name "hero-12d8b6f0-dee637-coord-${short_uuid}" \
+  -e WANDB_API_KEY "$WANDB_API_KEY" \
+  -e WANDB_PROJECT marin_moe \
+  -e IRIS_PORT_JAX 32614 \
+  -e XLA_PYTHON_CLIENT_MEM_FRACTION 0.75 \
+  -e XLA_FLAGS "--xla_gpu_memory_limit_slop_factor=85" \
+  -- python -m experiments.grug.moe_hero_ep.launch_scaling_ladder \
+    --run-id hero-12d8b6f0-dee637 \
+    --size d6144 \
+    --version 2026.08.19.2 \
+    --run

--- a/experiments/grug/moe_hero_ep/trigger_hero.sh
+++ b/experiments/grug/moe_hero_ep/trigger_hero.sh
@@ -15,7 +15,7 @@ RUN_ID=hero-12d8b6f0-dee637
 short_uuid=$(uuidgen | tr '[:upper:]' '[:lower:]')
 short_uuid=${short_uuid:0:8}
 
-uv run iris --config lib/iris/config/marin.yaml job run --no-wait \
+uv run iris --config lib/iris/config/marin.yaml job run --no-wait --enable-extra-resources \
   --target-cluster cw-us-east-08a \
   --priority production \
   --cpu 1 \

--- a/experiments/grug/moe_hero_ep/trigger_hero.sh
+++ b/experiments/grug/moe_hero_ep/trigger_hero.sh
@@ -11,6 +11,7 @@ fi
 
 : "${WANDB_API_KEY:?Set WANDB_API_KEY before you start the hero.}"
 
+RUN_ID=hero-12d8b6f0-dee637
 short_uuid=$(uuidgen | tr '[:upper:]' '[:lower:]')
 short_uuid=${short_uuid:0:8}
 
@@ -20,14 +21,14 @@ uv run iris --config lib/iris/config/marin.yaml job run --no-wait \
   --cpu 1 \
   --memory 4g \
   --max-retries 1000 \
-  --job-name "hero-12d8b6f0-dee637-coord-${short_uuid}" \
+  --job-name "${RUN_ID}-coord-${short_uuid}" \
   -e WANDB_API_KEY "$WANDB_API_KEY" \
   -e WANDB_PROJECT marin_moe \
   -e IRIS_PORT_JAX 32614 \
   -e XLA_PYTHON_CLIENT_MEM_FRACTION 0.75 \
   -e XLA_FLAGS "--xla_gpu_memory_limit_slop_factor=85" \
   -- python -m experiments.grug.moe_hero_ep.launch_scaling_ladder \
-    --run-id hero-12d8b6f0-dee637 \
+    --run-id "$RUN_ID" \
     --size d6144 \
     --version 2026.08.19.2 \
     --run


### PR DESCRIPTION
Add a zero-argument trigger for the current d6144 production hero. It names each coordinator with a short UUID, requests 4 GB, and sets the failure retry budget to 1000 to match the GPU job.

The prior coordinator requested 2 GB and was OOM-killed after 9 hours and 51 minutes. Its zero failure retry budget then stopped the 176-task child job.
