### PR TITLE
[grafana] Show a training run's active time and its attempt links

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -44,6 +44,7 @@ GET /github/ferries | builds | nightlies          GitHub REST / GraphQL
 GET /wandb/report/{train-loss,paloma-macro-loss,mfu}
                                                     public report runset and sampled history
 GET /wandb/history?run=&metric=&project=          one run's whole logged history for one metric
+GET /wandb/activity?run=&project=                 one run's active, wall, and downtime seconds
 GET /k8s/control_plane | crashloops | pending     CW control-plane state, all clusters
 GET /k8s/termination_candidates | kueue | events | health
                                                     ... one response, `cluster` column
@@ -100,13 +101,19 @@ and serves one linked, duration-aware row per lane and UTC day. The internal pan
 groups those rows into the compact trailing-week matrix.
 
 W&B: the bridge reads public W&B anonymously, so Grafana never needs a W&B key. It
-serves two shapes. `/wandb/report/{chart}` follows the runset pinned in the public
+serves three shapes. `/wandb/report/{chart}` follows the runset pinned in the public
 hero-training report spec and samples train cross-entropy, Paloma macro loss, and MFU
 against cumulative training tokens. `/wandb/history` samples one metric across one
 named run, keyed on W&B's own `_step`, which is the Levanter step because Levanter
-logs through `wandb.log(..., step=<training step>)`. Without an explicit `project`
-the bridge searches `RUN_HISTORY_PROJECTS` in order and fails with a 404 when no
-project holds the run.
+logs through `wandb.log(..., step=<training step>)`. `/wandb/activity` reads the same
+run's clocks out of `summaryMetrics`, one small request rather than a history
+download: `_runtime` is the seconds the training process was alive, which
+`resume="allow"` restores at every restart, so it is the run's active execution time
+across every attempt. Wall time runs from the run's creation to its last heartbeat,
+which makes the remainder downtime. `_runtime` advances only when an attempt logs, so
+the total holds still while a restart initializes rather than counting the wait as
+work. Without an explicit `project` the bridge searches `RUN_HISTORY_PROJECTS` in
+order and fails with a 404 when no project holds the run.
 
 k8s: the bridge polls the three production CoreWeave clusters' public CKS API servers with plain
 httpx GETs (paginated LISTs, bounded timeouts, one 429 retry) and a single org-wide CW
@@ -286,7 +293,21 @@ single-value selector puts the newest hero run first. It uses `run_id` across
 clusters. The status strip uses one 15-minute `telemetry_v1` query for ten fields.
 It includes the two hero alert inputs: time since the last completed step and
 train loss. It also includes step time, throughput, schedule progress, and token
-count.
+count. Active execution and active share come from `/wandb/activity`, which makes
+the strip a mixed-datasource panel. Those two totals describe the whole run, and the
+eviction that keeps the step-axis loss panel on W&B bounds any finelog answer to the
+retained window. On 2026-08-24 `hero-12d8b6f0-dee637` read 93.5 hours active against
+105.0 hours of wall clock, an 89 percent active share, while finelog retained its
+last three days.
+
+The Attempts table carries the recent detail behind that total: one row per Iris
+execution over a fixed seven-day window, newest first, running or not, so the top row
+stays the last attempt after that attempt fails. Its job cell links to the attempt in
+the Iris dashboard. That link has to come from finelog, because W&B records neither
+the cluster nor the job root. The URL is built in SQL and carried in a column the
+table hides rather than draws. Hide it with `custom.hideFrom.viz`: Grafana 13's table
+ignores the legacy `custom.hidden`, and a transformation that dropped the column would
+take the data link with it.
 
 The execution-health strip shows the current attempt age, Iris task counts,
 task-state age, and retained retry events. Initialization age appears only before

--- a/infra/grafana/dashboards/training.json
+++ b/infra/grafana/dashboards/training.json
@@ -160,10 +160,10 @@
       "id": 1,
       "type": "stat",
       "title": "Run status",
-      "description": "Where the run is right now. The window is a fixed fifteen minutes; the dashboard time range does not reach this panel. One query serves every tile, because a telemetry_v1 scan costs what its window costs whatever it selects, and ten stat panels would cost ten scans. Time since last step is the stall alert's own input, the age of the wall-clock stamp Levanter writes after each completed step. Sample age is the age of any telemetry from the run, so the two together separate a stalled trainer from a broken telemetry path.",
+      "description": "Where the run is right now. The window is a fixed fifteen minutes; the dashboard time range does not reach this panel. One query serves every tile, because a telemetry_v1 scan costs what its window costs whatever it selects, and ten stat panels would cost ten scans. Time since last step is the stall alert's own input, the age of the wall-clock stamp Levanter writes after each completed step. Sample age is the age of any telemetry from the run, so the two together separate a stalled trainer from a broken telemetry path. Active execution and active share come from W&B, not from finelog: W&B counts the seconds each attempt was alive and carries that count across every restart, thus the total covers the whole run and no telemetry eviction truncates it. Active share divides that total by the time from the creation of the run to its last heartbeat, so the remainder is downtime. The total holds while an attempt restarts, because W&B advances it when the attempt logs its first step.",
       "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
+        "type": "datasource",
+        "uid": "-- Mixed --"
       },
       "gridPos": {
         "h": 6,
@@ -341,6 +341,38 @@
                 "value": 4
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "active execution"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "active share"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              }
+            ]
           }
         ]
       },
@@ -431,6 +463,43 @@
             {
               "selector": "sample_age_seconds",
               "text": "sample age",
+              "type": "number"
+            }
+          ],
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "finelog-marin"
+          }
+        },
+        {
+          "refId": "B",
+          "datasource": {
+            "type": "yesoreyeram-infinity-datasource",
+            "uid": "wandb"
+          },
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/activity",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "run",
+                "value": "${run}"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "active_seconds",
+              "text": "active execution",
+              "type": "number"
+            },
+            {
+              "selector": "active_share",
+              "text": "active share",
               "type": "number"
             }
           ]
@@ -1639,6 +1708,132 @@
       ]
     },
     {
+      "id": 15,
+      "type": "table",
+      "title": "Attempts",
+      "description": "One row for each Iris execution of this run in the last seven days, newest first, whether it is running or not: the top row stays the last attempt after that attempt fails. Active is the time from the first phase sample of the attempt to the last one, at process index zero. This is the recent detail behind the whole-run totals in the status strip, which W&B supplies and finelog eviction cannot reach. Select a job to open that attempt in the Iris dashboard.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "filterable": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "active"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "job"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Open in Iris",
+                    "url": "${__data.fields.iris_url}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "iris_url"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "WITH attempts AS (SELECT COALESCE(NULLIF(\"cluster\", ''), 'marin') AS origin_cluster, job_id, execution_uid, MIN(timestamp_ms) AS started_ms, MAX(timestamp_ms) AS last_ms FROM \"telemetry_v1\" WHERE service = 'levanter' AND name = 'phase' AND process_index = '0' AND run_id IN (${run:sqlstring}) AND job_id IS NOT NULL AND execution_uid IS NOT NULL AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM now() - INTERVAL '7 days') * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM now()) * 1000 AS BIGINT) GROUP BY 1, 2, 3) SELECT started_ms, origin_cluster AS \"cluster\", job_id AS job, (last_ms - started_ms) / 1000.0 AS active_seconds, CONCAT('https://iris.oa.dev/#/job/', REPLACE(job_id, '/', '%2F'), CASE WHEN origin_cluster = 'marin' THEN '' ELSE CONCAT('?cluster=', origin_cluster) END) AS iris_url FROM attempts ORDER BY started_ms DESC"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "started_ms",
+              "text": "started",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "job",
+              "text": "job",
+              "type": "string"
+            },
+            {
+              "selector": "active_seconds",
+              "text": "active",
+              "type": "number"
+            },
+            {
+              "selector": "iris_url",
+              "text": "iris_url",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": 12,
       "type": "timeseries",
       "title": "Token drops",
@@ -1651,7 +1846,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 48
+        "y": 55
       },
       "fieldConfig": {
         "defaults": {
@@ -1773,7 +1968,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 48
+        "y": 55
       },
       "fieldConfig": {
         "defaults": {
@@ -2020,7 +2215,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 56
+        "y": 63
       },
       "fieldConfig": {
         "defaults": {

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -31,6 +31,7 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /github/nightlies                        7-day nightly-lane matrix (one row per lane/day)
     GET /wandb/report/{chart}                    sampled public hero-report series by chart key
     GET /wandb/history?run=&metric=&project=     one run's full logged history for one metric
+    GET /wandb/activity?run=&project=            one run's active, wall, and downtime seconds
     GET /k8s/control_plane                       watched components + webhook endpoints, all clusters
     GET /k8s/crashloops                          containers in backoff waiting states
     GET /k8s/pending                             Pending / SchedulingGated pods with age
@@ -634,6 +635,17 @@ def create_app(
             lambda: wandb_source.run_history(run, metric=metric, project=project),
         )
 
+    def wandb_run_activity(request: Request) -> JSONResponse:
+        try:
+            run = _require(request.query_params, "run")
+        except _BadRequest as err:
+            return JSONResponse({"error": str(err)}, status_code=400)
+        project = request.query_params.get("project") or None
+        return wandb_endpoint(
+            ("activity", run, project),
+            lambda: wandb_source.run_activity(run, project=project),
+        )
+
     def k8s_endpoint(key: str, run) -> JSONResponse:
         # Per-cluster failures are labeled rows inside the response; only a bridge
         # bug raises here, and Starlette turns that into a 500.
@@ -785,6 +797,7 @@ def create_app(
             Route("/github/builds", github_builds),
             Route("/github/nightlies", github_nightlies),
             Route("/wandb/history", wandb_run_history),
+            Route("/wandb/activity", wandb_run_activity),
             Route("/wandb/report/{chart}", wandb_report_chart),
             Route("/finelog/{cluster}/query", query),
             Route("/finelog/{cluster}/v1/vllm/overview", vllm_overview),

--- a/infra/grafana/src/wandb_source.py
+++ b/infra/grafana/src/wandb_source.py
@@ -13,6 +13,7 @@ retains only a window of them.
 """
 
 import json
+from collections.abc import Callable
 from datetime import datetime
 
 import httpx
@@ -128,6 +129,18 @@ class WandbSource:
                 pairs.append((x_value, y_value))
         return pairs
 
+    def _search_projects(self, run: str, project: str | None, read: Callable[[str], list[dict] | None]) -> list[dict]:
+        """Return the first non-empty `read(candidate)` over the projects that may hold `run`.
+
+        A run in none of them fails loud rather than rendering as an empty panel.
+        """
+        projects = (project,) if project else RUN_HISTORY_PROJECTS
+        for candidate in projects:
+            rows = read(candidate)
+            if rows is not None:
+                return rows
+        raise UpstreamError("wandb", f"run {run!r} not found in {', '.join(projects)}", status_code=404)
+
     def points(self, chart_key: str) -> list[dict]:
         """Return one row per sampled point for a configured report chart."""
         if chart_key not in WANDB_CHARTS:
@@ -158,22 +171,22 @@ class WandbSource:
         `run` is the Levanter run id: marin names the W&B run after it, and
         `resume="allow"` keeps one W&B run across restarts, so this covers the run
         from step 0 however many times it was resumed. W&B samples server-side, so
-        the response stays small on a long run. A run absent from every searched
-        project fails loud rather than rendering as an empty panel.
+        the response stays small on a long run.
         """
-        projects = (project,) if project else RUN_HISTORY_PROJECTS
-        for candidate in projects:
+
+        def read(candidate: str) -> list[dict] | None:
             pairs = self._sampled_history(
                 project=candidate, run=run, x_key=_STEP_KEY, y_key=metric, samples=_RUN_HISTORY_SAMPLES
             )
             if pairs is None:
-                continue
+                return None
             run_url = _RUN_URL.format(entity=_ENTITY, project=candidate, run=run)
             return [
                 {"run": run, "project": candidate, "run_url": run_url, "step": step, "value": value}
                 for step, value in pairs
             ]
-        raise UpstreamError("wandb", f"run {run!r} not found in {', '.join(projects)}", status_code=404)
+
+        return self._search_projects(run, project, read)
 
     def run_activity(self, run: str, *, project: str | None = None) -> list[dict]:
         """Return one row of active and wall-clock time for the whole of `run`.
@@ -186,8 +199,8 @@ class WandbSource:
         remainder is downtime and the ratio is the share of the run that ran. A run
         that has logged nothing yet reports a null active time rather than a zero.
         """
-        projects = (project,) if project else RUN_HISTORY_PROJECTS
-        for candidate in projects:
+
+        def read(candidate: str) -> list[dict] | None:
             run_data = (
                 self._graphql(
                     _ACTIVITY_QUERY,
@@ -196,7 +209,7 @@ class WandbSource:
                 or {}
             ).get("run")
             if not run_data:
-                continue
+                return None
             summary = json.loads(run_data.get("summaryMetrics") or "{}")
             active = summary.get("_runtime")
             active = float(active) if isinstance(active, int | float) else None
@@ -213,4 +226,5 @@ class WandbSource:
                     "active_share": active / wall if active is not None and wall > 0 else None,
                 }
             ]
-        raise UpstreamError("wandb", f"run {run!r} not found in {', '.join(projects)}", status_code=404)
+
+        return self._search_projects(run, project, read)

--- a/infra/grafana/src/wandb_source.py
+++ b/infra/grafana/src/wandb_source.py
@@ -3,14 +3,17 @@
 
 """W&B series as flat chart rows for Grafana.
 
-Two readers over the same public GraphQL API. `points` follows the runset pinned
+Three readers over the same public GraphQL API. `points` follows the runset pinned
 by Marin's public hero-run report. `run_history` reads one named run's whole
 logged history for one metric, which is what lets a step-axis panel start at step
 0: finelog evicts telemetry segments once the namespace passes its storage policy,
-while W&B keeps the run.
+while W&B keeps the run. `run_activity` reads the same run's clocks, for the same
+reason: a run's total active time spans every attempt it ever had, and finelog
+retains only a window of them.
 """
 
 import json
+from datetime import datetime
 
 import httpx
 from errors import UpstreamError
@@ -55,9 +58,24 @@ query RunSampledHistory($entity: String!, $project: String!, $run: String!, $spe
 }
 """
 
+# `summaryMetrics` carries the last value logged for every key, `_runtime` among them.
+# Reading the clocks therefore costs one small request, not a history download.
+_ACTIVITY_QUERY = """
+query RunActivity($entity: String!, $project: String!, $run: String!) {
+  project(entityName: $entity, name: $project) {
+    run(name: $run) { state createdAt heartbeatAt summaryMetrics }
+  }
+}
+"""
+
+
+def _epoch_seconds(stamp: str) -> float:
+    """Epoch seconds for a W&B RFC-3339 stamp, whose zone is always `Z`."""
+    return datetime.fromisoformat(stamp.replace("Z", "+00:00")).timestamp()
+
 
 class WandbSource:
-    """Reads the public hero-run report's runset, and any single run's history."""
+    """Reads the public hero-run report's runset, and any single run's history and clocks."""
 
     def __init__(self, *, timeout: float) -> None:
         self._client = httpx.Client(timeout=timeout, headers={"content-type": "application/json"})
@@ -154,5 +172,45 @@ class WandbSource:
             return [
                 {"run": run, "project": candidate, "run_url": run_url, "step": step, "value": value}
                 for step, value in pairs
+            ]
+        raise UpstreamError("wandb", f"run {run!r} not found in {', '.join(projects)}", status_code=404)
+
+    def run_activity(self, run: str, *, project: str | None = None) -> list[dict]:
+        """Return one row of active and wall-clock time for the whole of `run`.
+
+        W&B's `_runtime` counts the seconds a process was alive: `resume="allow"`
+        restores it at each restart, so the wait between two attempts never enters
+        it. That makes it the run's active execution time across every attempt, and
+        unlike a `telemetry_v1` scan it does not stop where segment eviction does.
+        Wall time runs from the run's creation to its last heartbeat, thus the
+        remainder is downtime and the ratio is the share of the run that ran. A run
+        that has logged nothing yet reports a null active time rather than a zero.
+        """
+        projects = (project,) if project else RUN_HISTORY_PROJECTS
+        for candidate in projects:
+            run_data = (
+                self._graphql(
+                    _ACTIVITY_QUERY,
+                    {"entity": _ENTITY, "project": candidate, "run": run},
+                ).get("project")
+                or {}
+            ).get("run")
+            if not run_data:
+                continue
+            summary = json.loads(run_data.get("summaryMetrics") or "{}")
+            active = summary.get("_runtime")
+            active = float(active) if isinstance(active, int | float) else None
+            wall = _epoch_seconds(run_data["heartbeatAt"]) - _epoch_seconds(run_data["createdAt"])
+            return [
+                {
+                    "run": run,
+                    "project": candidate,
+                    "run_url": _RUN_URL.format(entity=_ENTITY, project=candidate, run=run),
+                    "state": run_data.get("state"),
+                    "active_seconds": active,
+                    "wall_seconds": wall,
+                    "downtime_seconds": None if active is None else wall - active,
+                    "active_share": active / wall if active is not None and wall > 0 else None,
+                }
             ]
         raise UpstreamError("wandb", f"run {run!r} not found in {', '.join(projects)}", status_code=404)

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -6,6 +6,7 @@ datasource UIDs and refIds, every rule's query URL answers on the bridge, and
 dashboard datasources exist. These files only otherwise fail inside a deployed
 Grafana, which is the most expensive place to find out."""
 
+import json
 import re
 from datetime import UTC, datetime
 from pathlib import Path
@@ -31,6 +32,8 @@ ALERTING = ROOT / "provisioning" / "alerting"
 DASHBOARDS = ROOT / "dashboards"
 
 EXPRESSION_UID = "__expr__"
+# Grafana's built-in fan-out datasource: the panel's targets each name a real one.
+MIXED_DATASOURCE = "-- Mixed --"
 VALID_SEVERITIES = {"critical", "warning"}
 STORAGE_ALERT_FRACTION = 0.8
 
@@ -570,10 +573,18 @@ def test_dashboard_filter_expressions_reference_selected_columns():
 
 
 def test_dashboard_datasource_uids_are_provisioned():
+    # A mixed panel names no datasource of its own; each of its targets carries one, and
+    # those are the ones that have to exist.
     uids = set(_datasources())
     for name, dashboard in _stitched_dashboards().items():
         for panel in _all_panels(dashboard):
             uid = (panel.get("datasource") or {}).get("uid")
+            if uid == MIXED_DATASOURCE:
+                targets = panel.get("targets", [])
+                named = [(target.get("datasource") or {}).get("uid") for target in targets]
+                assert all(named), f"{name} panel {panel.get('id')}: mixed target without a datasource"
+                assert set(named) <= uids, f"{name} panel {panel.get('id')}: unknown datasource in {named}"
+                continue
             if uid is None or uid.startswith("${"):  # row panels / template variables
                 continue
             assert uid in uids, f"{name} panel {panel.get('id')}: unknown datasource {uid!r}"
@@ -630,7 +641,9 @@ def test_cluster_column_is_only_referenced_quoted_or_as_an_alias():
     bare = re.compile(r'(?<![\w"])cluster(?![\w"])')
     for name, dashboard in _stitched_dashboards().items():
         for sql in _panel_sql(dashboard):
-            interpolated = re.sub(r"\$\{[^}]*\}", "?", sql)
+            # Only an identifier can reach the parser as the keyword. A string literal --
+            # the `?cluster=` a panel concatenates into a link URL -- never does.
+            interpolated = re.sub(r"'[^']*'", "''", re.sub(r"\$\{[^}]*\}", "?", sql))
             for match in bare.finditer(interpolated):
                 preceding = interpolated[: match.start()].rstrip()
                 assert preceding.endswith(" AS"), f"{name}: unquoted `cluster` in {sql[:160]!r}"
@@ -897,6 +910,113 @@ def test_training_execution_health_uses_the_current_attempt_and_iris_state():
 
     database.execute("UPDATE telemetry_v1 SET value = 0 WHERE execution_uid = 'attempt-current' AND seq = 3")
     assert database.execute(sql_by_ref["A"]).fetchall() == [(14_400.0, 14_400.0)]
+
+
+def test_training_status_reads_whole_run_active_time_from_wandb():
+    # Eviction bounds any finelog answer to the retained window, so the run totals come
+    # from W&B, whose `_runtime` carries across restarts. Join the target's datasource
+    # base path with its URL and GET it for real, against a stubbed W&B.
+    dashboard = _stitched_dashboards()["training.json"]
+    panel = next(panel for panel in _all_panels(dashboard) if panel["title"] == "Run status")
+    assert panel["datasource"]["uid"] == MIXED_DATASOURCE
+    target = next(target for target in panel["targets"] if target["refId"] == "B")
+    params = {param["key"]: param["value"] for param in target["url_options"]["params"]}
+    params["run"] = "hero-run"  # Grafana interpolates ${run} before the request leaves it
+
+    run = {
+        "state": "running",
+        "createdAt": "2026-08-20T02:00:00Z",
+        "heartbeatAt": "2026-08-24T02:00:00Z",
+        "summaryMetrics": json.dumps({"_runtime": 90 * 3_600, "_timestamp": 1_787_561_529}),
+    }
+    wandb_source = WandbSource(timeout=5.0)
+    wandb_source._client = httpx.Client(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, json={"data": {"project": {"run": run}}})),
+        headers={"content-type": "application/json"},
+    )
+    client = TestClient(
+        create_app(bridge_config(), {}, {}, GithubSource(auth=None, timeout=5.0), K8sFleet(()), wandb_source)
+    )
+
+    response = client.get(_datasources()[target["datasource"]["uid"]] + target["url"], params=params)
+
+    assert response.status_code == 200
+    (row,) = response.json()
+    # Four days of wall clock, ninety hours of them running.
+    assert (row["active_seconds"], row["active_share"]) == (324_000.0, 0.9375)
+    assert {column["selector"] for column in target["columns"]} <= set(row)
+
+
+def test_training_attempts_table_links_the_newest_attempt_to_iris():
+    dashboard = _stitched_dashboards()["training.json"]
+    panel = next(panel for panel in _all_panels(dashboard) if panel["title"] == "Attempts")
+    (target,) = panel["targets"]
+    overrides = {
+        override["matcher"]["options"]: {field["id"]: field["value"] for field in override["properties"]}
+        for override in panel["fieldConfig"]["overrides"]
+    }
+
+    # The link reads the URL out of a column the table keeps but does not draw; a
+    # transformation that dropped it would take the link with it.
+    (link,) = overrides["job"]["links"]
+    assert link["url"] == "${__data.fields.iris_url}"
+    assert overrides["iris_url"]["custom.hideFrom"]["viz"] is True
+    assert "iris_url" in {column["text"] for column in target["columns"]}
+
+    database = duckdb.connect()
+    database.execute(
+        """
+        CREATE TABLE telemetry_v1(
+            service VARCHAR,
+            run_id VARCHAR,
+            cluster VARCHAR,
+            job_id VARCHAR,
+            execution_uid VARCHAR,
+            process_index VARCHAR,
+            name VARCHAR,
+            value DOUBLE,
+            timestamp_ms BIGINT
+        )
+        """
+    )
+    hour = 3_600_000
+    at = int(datetime(2026, 8, 21, 12, tzinfo=UTC).timestamp() * 1000)
+    database.executemany(
+        "INSERT INTO telemetry_v1 VALUES ('levanter', ?, ?, ?, ?, ?, 'phase', 1, ?)",
+        [
+            # An attempt that ran two hours on a CoreWeave cluster and then failed.
+            ("hero-run", "cw-a", "/u/hero-run-coord/train", "attempt-one", "0", at - 6 * hour),
+            ("hero-run", "cw-a", "/u/hero-run-coord/train", "attempt-one", "0", at - 4 * hour),
+            # Its successor, a fresh job on the hub, whose rows carry no origin cluster.
+            ("hero-run", "", "/u/hero-run-coord-2/train", "attempt-two", "0", at - 2 * hour),
+            ("hero-run", "", "/u/hero-run-coord-2/train", "attempt-two", "0", at - hour),
+            # A replica of that attempt, and another run: neither is a row of this table.
+            ("hero-run", "", "/u/hero-run-coord-2/train", "attempt-two-replica", "1", at - hour),
+            ("other-run", "cw-a", "/u/other-run-coord/train", "other-attempt", "0", at - hour),
+        ],
+    )
+    sql = next(param["value"] for param in target["url_options"]["params"] if param["key"] == "sql")
+    sql = sql.replace("${run:sqlstring}", "'hero-run'").replace("now()", "TIMESTAMP '2026-08-21 12:00:00+00:00'")
+
+    # Newest first, so the top row is the last attempt whether or not it still runs. A
+    # peer cluster needs the `?cluster=` the Iris dashboard filters its backends by; the
+    # hub, which finelog leaves unlabeled, does not.
+    assert database.execute(sql).fetchall() == [
+        (
+            at - 2 * hour,
+            "marin",
+            "/u/hero-run-coord-2/train",
+            3_600.0,
+            "https://iris.oa.dev/#/job/%2Fu%2Fhero-run-coord-2%2Ftrain",
+        ),
+        (
+            at - 6 * hour,
+            "cw-a",
+            "/u/hero-run-coord/train",
+            7_200.0,
+            "https://iris.oa.dev/#/job/%2Fu%2Fhero-run-coord%2Ftrain?cluster=cw-a",
+        ),
+    ]
 
 
 def test_training_moe_health_queries_show_routing_signals():

--- a/infra/grafana/tests/test_sources.py
+++ b/infra/grafana/tests/test_sources.py
@@ -379,6 +379,74 @@ def test_wandb_run_history_pins_an_explicit_project_without_searching():
     assert [row["step"] for row in rows] == [7]
 
 
+def _activity_handler(found_in: str, run: dict, asked: list[str]):
+    """Serve `run` from the project named `found_in`; record each project asked."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        variables = json.loads(request.content)["variables"]
+        asked.append(variables["project"])
+        if variables["project"] != found_in:
+            return httpx.Response(200, json={"data": {"project": None}})
+        return httpx.Response(200, json={"data": {"project": {"run": run}}})
+
+    return handler
+
+
+def test_wandb_run_activity_separates_active_time_from_downtime():
+    # `_runtime` is W&B's own count of the seconds a process was alive, restored at each
+    # resume, so it is the run's active time across restarts and never includes the wait
+    # between two attempts. Wall clock here is four days, of which ninety hours ran.
+    asked: list[str] = []
+    run = {
+        "state": "running",
+        "createdAt": "2026-08-20T02:00:00Z",
+        "heartbeatAt": "2026-08-24T02:00:00Z",
+        "summaryMetrics": json.dumps({"_runtime": 90 * 3_600, "_timestamp": 1_787_561_529}),
+    }
+
+    (row,) = _wandb(_activity_handler("marin_moe", run, asked)).run_activity("hero-run")
+
+    assert asked == ["marin_moe"]
+    assert row == {
+        "run": "hero-run",
+        "project": "marin_moe",
+        "run_url": "https://wandb.ai/marin-community/marin_moe/runs/hero-run",
+        "state": "running",
+        "active_seconds": 324_000.0,
+        "wall_seconds": 345_600.0,
+        "downtime_seconds": 21_600.0,
+        "active_share": 0.9375,
+    }
+
+
+def test_wandb_run_activity_reports_no_active_time_before_the_first_log():
+    # A run that has been created but has logged nothing has no `_runtime` to read. The
+    # tile then shows no data, which is true, rather than zero, which reads as a stall.
+    asked: list[str] = []
+    run = {
+        "state": "running",
+        "createdAt": "2026-08-20T02:00:00Z",
+        "heartbeatAt": "2026-08-20T02:10:00Z",
+        "summaryMetrics": "{}",
+    }
+
+    (row,) = _wandb(_activity_handler("marin", run, asked)).run_activity("hero-run")
+
+    assert asked == ["marin_moe", "marin"]
+    assert (row["active_seconds"], row["downtime_seconds"], row["active_share"]) == (None, None, None)
+    assert row["wall_seconds"] == 600.0
+
+
+def test_wandb_run_activity_fails_loud_when_no_project_has_the_run():
+    asked: list[str] = []
+
+    with pytest.raises(UpstreamError) as excinfo:
+        _wandb(_activity_handler("nowhere", {}, asked)).run_activity("hero-run")
+
+    assert excinfo.value.status_code == 404
+    assert asked == ["marin_moe", "marin"]
+
+
 def test_wandb_run_history_fails_loud_when_no_project_has_the_run():
     asked: list[tuple[str, list[str]]] = []
     handler = _history_handler("nowhere", [], asked)


### PR DESCRIPTION
The training-run status strip gains active execution and active share, and a new
Attempts table lists each Iris execution of the run with a link to it in the Iris
dashboard.

The totals come from a new bridge route, `/wandb/activity`, rather than from
finelog. W&B's `_runtime` counts the seconds a training process was alive and
`resume="allow"` restores it at every restart, so it spans every attempt, while a
`telemetry_v1` scan stops where segment eviction does. On 2026-08-24
hero-12d8b6f0-dee637 read 93.5 hours active against 105.0 hours of wall clock, an
89 percent active share, out of a namespace that retained its last three days.
Over the window both sources could see, they agreed to within 1.8 percent (73.0
hours from W&B, 74.3 hours from finelog). Wall clock runs from the run's creation
to its last heartbeat, and `_runtime` advances when an attempt logs, so the total
holds still through a restart's initialization instead of counting the wait.
Reading it costs one `summaryMetrics` request, not a history download. The status
strip is now a mixed-datasource panel, since it keeps its 15-minute finelog query
for everything else.

The Attempts table stays on finelog over a fixed seven-day window, because the
per-attempt Iris link needs the cluster and job root that W&B never records. Rows
are newest first with no liveness filter, so the top one remains the last attempt
after that attempt fails. Its URL is built in SQL and carried in a column hidden
with `custom.hideFrom.viz`; Grafana 13's table ignores the legacy `custom.hidden`,
and dropping the column with a transformation would take the data link with it.

The panels appear after a Grafana redeploy from the `infra/grafana` Pulumi stack.
