### PR TITLE
[grafana] Fix the training attempt links and the crowded status strip

### DIFF
--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -298,16 +298,22 @@ the strip a mixed-datasource panel. Those two totals describe the whole run, and
 eviction that keeps the step-axis loss panel on W&B bounds any finelog answer to the
 retained window. On 2026-08-24 `hero-12d8b6f0-dee637` read 93.5 hours active against
 105.0 hours of wall clock, an 89 percent active share, while finelog retained its
-last three days.
+last three days. A mixed panel names each frame after its refId and Grafana prefixes
+every field label with it, so the strip renames `A `/`B ` away; it stands ten grid
+rows tall because the stat layout picks its tile grid from the aspect ratio, and
+twelve tiles in a shorter panel land in one unreadable row.
 
 The Attempts table carries the recent detail behind that total: one row per Iris
 execution over a fixed seven-day window, newest first, running or not, so the top row
 stays the last attempt after that attempt fails. Its job cell links to the attempt in
 the Iris dashboard. That link has to come from finelog, because W&B records neither
-the cluster nor the job root. The URL is built in SQL and carried in a column the
-table hides rather than draws. Hide it with `custom.hideFrom.viz`: Grafana 13's table
-ignores the legacy `custom.hidden`, and a transformation that dropped the column would
-take the data link with it.
+the cluster nor the job root. It interpolates the job cell itself plus a cluster
+column the table hides rather than draws. Leave the job root unencoded in SQL:
+Grafana percent-encodes an interpolated data-link value, which is what makes the root
+one path segment for the Iris route, and a pre-encoded path arrives there as a
+literal `%2F` that `ListTasks` rejects. Hide the cluster column with
+`custom.hideFrom.viz`: Grafana 13's table ignores the legacy `custom.hidden`, and a
+transformation that dropped the column would take half the link with it.
 
 The execution-health strip shows the current attempt age, Iris task counts,
 task-state age, and retained retry events. Initialization age appears only before

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -298,10 +298,13 @@ the strip a mixed-datasource panel. Those two totals describe the whole run, and
 eviction that keeps the step-axis loss panel on W&B bounds any finelog answer to the
 retained window. On 2026-08-24 `hero-12d8b6f0-dee637` read 93.5 hours active against
 105.0 hours of wall clock, an 89 percent active share, while finelog retained its
-last three days. A mixed panel names each frame after its refId and Grafana prefixes
-every field label with it, so the strip renames `A `/`B ` away; it stands ten grid
-rows tall because the stat layout picks its tile grid from the aspect ratio, and
-twelve tiles in a shorter panel land in one unreadable row.
+last three days. A mixed panel names each frame after its refId and prefixes every
+field label with it, which is why the strip's defaults set a display name of
+`${__field.name}`: a field with a display name of its own keeps the prefix off, while
+a `renameByRegex` transformation cannot, because it reads the raw field name and the
+prefix is added later. The strip stands ten grid rows tall because the stat layout
+picks its tile grid from the aspect ratio, and twelve tiles in a shorter panel land in
+one unreadable row.
 
 The Attempts table carries the recent detail behind that total: one row per Iris
 execution over a fixed seven-day window, newest first, running or not, so the top row

--- a/infra/grafana/dashboards/training.json
+++ b/infra/grafana/dashboards/training.json
@@ -173,6 +173,7 @@
       },
       "fieldConfig": {
         "defaults": {
+          "displayName": "${__field.name}",
           "unit": "short",
           "thresholds": {
             "mode": "absolute",
@@ -505,16 +506,7 @@
           ]
         }
       ],
-      "timeFrom": "15m",
-      "transformations": [
-        {
-          "id": "renameByRegex",
-          "options": {
-            "regex": "^[AB] (.+)$",
-            "renamePattern": "$1"
-          }
-        }
-      ]
+      "timeFrom": "15m"
     },
     {
       "id": 2,

--- a/infra/grafana/dashboards/training.json
+++ b/infra/grafana/dashboards/training.json
@@ -166,7 +166,7 @@
         "uid": "-- Mixed --"
       },
       "gridPos": {
-        "h": 6,
+        "h": 10,
         "w": 24,
         "x": 0,
         "y": 0
@@ -505,7 +505,16 @@
           ]
         }
       ],
-      "timeFrom": "15m"
+      "timeFrom": "15m",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "^[AB] (.+)$",
+            "renamePattern": "$1"
+          }
+        }
+      ]
     },
     {
       "id": 2,
@@ -520,7 +529,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 6
+        "y": 10
       },
       "fieldConfig": {
         "defaults": {
@@ -607,7 +616,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 6
+        "y": 10
       },
       "fieldConfig": {
         "defaults": {
@@ -698,7 +707,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 15
+        "y": 19
       },
       "fieldConfig": {
         "defaults": {
@@ -839,7 +848,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 15
+        "y": 19
       },
       "fieldConfig": {
         "defaults": {
@@ -958,7 +967,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 28
       },
       "fieldConfig": {
         "defaults": {
@@ -1061,7 +1070,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 28
       },
       "fieldConfig": {
         "defaults": {
@@ -1164,7 +1173,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 36
       },
       "fieldConfig": {
         "defaults": {
@@ -1263,7 +1272,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 36
       },
       "fieldConfig": {
         "defaults": {
@@ -1349,7 +1358,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 40
+        "y": 44
       },
       "fieldConfig": {
         "defaults": {
@@ -1466,7 +1475,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 40
+        "y": 44
       },
       "timeFrom": "90m",
       "fieldConfig": {
@@ -1708,132 +1717,6 @@
       ]
     },
     {
-      "id": 15,
-      "type": "table",
-      "title": "Attempts",
-      "description": "One row for each Iris execution of this run in the last seven days, newest first, whether it is running or not: the top row stays the last attempt after that attempt fails. Active is the time from the first phase sample of the attempt to the last one, at process index zero. This is the recent detail behind the whole-run totals in the status strip, which W&B supplies and finelog eviction cannot reach. Select a job to open that attempt in the Iris dashboard.",
-      "datasource": {
-        "type": "yesoreyeram-infinity-datasource",
-        "uid": "finelog-marin"
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 48
-      },
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "filterable": false
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "active"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              },
-              {
-                "id": "decimals",
-                "value": 0
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "job"
-            },
-            "properties": [
-              {
-                "id": "links",
-                "value": [
-                  {
-                    "targetBlank": true,
-                    "title": "Open in Iris",
-                    "url": "${__data.fields.iris_url}"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "iris_url"
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": true
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "options": {
-        "showHeader": true,
-        "cellHeight": "sm"
-      },
-      "targets": [
-        {
-          "refId": "A",
-          "type": "json",
-          "source": "url",
-          "format": "table",
-          "parser": "backend",
-          "url": "/query",
-          "url_options": {
-            "method": "GET",
-            "params": [
-              {
-                "key": "sql",
-                "value": "WITH attempts AS (SELECT COALESCE(NULLIF(\"cluster\", ''), 'marin') AS origin_cluster, job_id, execution_uid, MIN(timestamp_ms) AS started_ms, MAX(timestamp_ms) AS last_ms FROM \"telemetry_v1\" WHERE service = 'levanter' AND name = 'phase' AND process_index = '0' AND run_id IN (${run:sqlstring}) AND job_id IS NOT NULL AND execution_uid IS NOT NULL AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM now() - INTERVAL '7 days') * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM now()) * 1000 AS BIGINT) GROUP BY 1, 2, 3) SELECT started_ms, origin_cluster AS \"cluster\", job_id AS job, (last_ms - started_ms) / 1000.0 AS active_seconds, CONCAT('https://iris.oa.dev/#/job/', REPLACE(job_id, '/', '%2F'), CASE WHEN origin_cluster = 'marin' THEN '' ELSE CONCAT('?cluster=', origin_cluster) END) AS iris_url FROM attempts ORDER BY started_ms DESC"
-              }
-            ]
-          },
-          "columns": [
-            {
-              "selector": "started_ms",
-              "text": "started",
-              "type": "timestamp_epoch"
-            },
-            {
-              "selector": "cluster",
-              "text": "cluster",
-              "type": "string"
-            },
-            {
-              "selector": "job",
-              "text": "job",
-              "type": "string"
-            },
-            {
-              "selector": "active_seconds",
-              "text": "active",
-              "type": "number"
-            },
-            {
-              "selector": "iris_url",
-              "text": "iris_url",
-              "type": "string"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "id": 12,
       "type": "timeseries",
       "title": "Token drops",
@@ -1846,7 +1729,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 55
+        "y": 52
       },
       "fieldConfig": {
         "defaults": {
@@ -1968,7 +1851,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 55
+        "y": 52
       },
       "fieldConfig": {
         "defaults": {
@@ -2215,7 +2098,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 63
+        "y": 60
       },
       "fieldConfig": {
         "defaults": {
@@ -2295,6 +2178,132 @@
               "selector": "router_bias_norm",
               "text": "router bias norm",
               "type": "number"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "table",
+      "title": "Attempts",
+      "description": "One row for each Iris execution of this run in the last seven days, newest first, whether it is running or not: the top row stays the last attempt after that attempt fails. Active is the time from the first phase sample of the attempt to the last one, at process index zero. This is the recent detail behind the whole-run totals in the status strip, which W&B supplies and finelog eviction cannot reach. Select a job to open that attempt in the Iris dashboard.",
+      "datasource": {
+        "type": "yesoreyeram-infinity-datasource",
+        "uid": "finelog-marin"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 68
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "filterable": false
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "active"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "job"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Open in Iris",
+                    "url": "https://iris.oa.dev/#/job/${__data.fields.job}?cluster=${__data.fields.iris_cluster}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "iris_cluster"
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "type": "json",
+          "source": "url",
+          "format": "table",
+          "parser": "backend",
+          "url": "/query",
+          "url_options": {
+            "method": "GET",
+            "params": [
+              {
+                "key": "sql",
+                "value": "WITH attempts AS (SELECT COALESCE(NULLIF(\"cluster\", ''), 'marin') AS origin_cluster, job_id, execution_uid, MIN(timestamp_ms) AS started_ms, MAX(timestamp_ms) AS last_ms FROM \"telemetry_v1\" WHERE service = 'levanter' AND name = 'phase' AND process_index = '0' AND run_id IN (${run:sqlstring}) AND job_id IS NOT NULL AND execution_uid IS NOT NULL AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM now() - INTERVAL '7 days') * 1000 AS BIGINT) AND timestamp_ms < CAST(EXTRACT(EPOCH FROM now()) * 1000 AS BIGINT) GROUP BY 1, 2, 3) SELECT started_ms, origin_cluster AS \"cluster\", job_id AS job, (last_ms - started_ms) / 1000.0 AS active_seconds, CASE WHEN origin_cluster = 'marin' THEN 'local' ELSE origin_cluster END AS iris_cluster FROM attempts ORDER BY started_ms DESC"
+              }
+            ]
+          },
+          "columns": [
+            {
+              "selector": "started_ms",
+              "text": "started",
+              "type": "timestamp_epoch"
+            },
+            {
+              "selector": "cluster",
+              "text": "cluster",
+              "type": "string"
+            },
+            {
+              "selector": "job",
+              "text": "job",
+              "type": "string"
+            },
+            {
+              "selector": "active_seconds",
+              "text": "active",
+              "type": "number"
+            },
+            {
+              "selector": "iris_cluster",
+              "text": "iris_cluster",
+              "type": "string"
             }
           ]
         }

--- a/infra/grafana/tests/test_provisioning.py
+++ b/infra/grafana/tests/test_provisioning.py
@@ -641,9 +641,7 @@ def test_cluster_column_is_only_referenced_quoted_or_as_an_alias():
     bare = re.compile(r'(?<![\w"])cluster(?![\w"])')
     for name, dashboard in _stitched_dashboards().items():
         for sql in _panel_sql(dashboard):
-            # Only an identifier can reach the parser as the keyword. A string literal --
-            # the `?cluster=` a panel concatenates into a link URL -- never does.
-            interpolated = re.sub(r"'[^']*'", "''", re.sub(r"\$\{[^}]*\}", "?", sql))
+            interpolated = re.sub(r"\$\{[^}]*\}", "?", sql)
             for match in bare.finditer(interpolated):
                 preceding = interpolated[: match.start()].rstrip()
                 assert preceding.endswith(" AS"), f"{name}: unquoted `cluster` in {sql[:160]!r}"
@@ -956,12 +954,14 @@ def test_training_attempts_table_links_the_newest_attempt_to_iris():
         for override in panel["fieldConfig"]["overrides"]
     }
 
-    # The link reads the URL out of a column the table keeps but does not draw; a
-    # transformation that dropped it would take the link with it.
+    # Grafana percent-encodes an interpolated value, so the job root goes in raw and
+    # comes out as the single path segment the Iris route expects. The cluster rides in
+    # a column the table keeps but does not draw; a transformation that dropped it would
+    # take half the link with it.
     (link,) = overrides["job"]["links"]
-    assert link["url"] == "${__data.fields.iris_url}"
-    assert overrides["iris_url"]["custom.hideFrom"]["viz"] is True
-    assert "iris_url" in {column["text"] for column in target["columns"]}
+    assert link["url"] == "https://iris.oa.dev/#/job/${__data.fields.job}?cluster=${__data.fields.iris_cluster}"
+    assert overrides["iris_cluster"]["custom.hideFrom"]["viz"] is True
+    assert "iris_cluster" in {column["text"] for column in target["columns"]}
 
     database = duckdb.connect()
     database.execute(
@@ -998,24 +998,12 @@ def test_training_attempts_table_links_the_newest_attempt_to_iris():
     sql = next(param["value"] for param in target["url_options"]["params"] if param["key"] == "sql")
     sql = sql.replace("${run:sqlstring}", "'hero-run'").replace("now()", "TIMESTAMP '2026-08-21 12:00:00+00:00'")
 
-    # Newest first, so the top row is the last attempt whether or not it still runs. A
-    # peer cluster needs the `?cluster=` the Iris dashboard filters its backends by; the
-    # hub, which finelog leaves unlabeled, does not.
+    # Newest first, so the top row is the last attempt whether or not it still runs. The
+    # Iris dashboard filters backends by peer id and reserves `local` for its own, which
+    # is the hub finelog leaves unlabeled.
     assert database.execute(sql).fetchall() == [
-        (
-            at - 2 * hour,
-            "marin",
-            "/u/hero-run-coord-2/train",
-            3_600.0,
-            "https://iris.oa.dev/#/job/%2Fu%2Fhero-run-coord-2%2Ftrain",
-        ),
-        (
-            at - 6 * hour,
-            "cw-a",
-            "/u/hero-run-coord/train",
-            7_200.0,
-            "https://iris.oa.dev/#/job/%2Fu%2Fhero-run-coord%2Ftrain?cluster=cw-a",
-        ),
+        (at - 2 * hour, "marin", "/u/hero-run-coord-2/train", 3_600.0, "local"),
+        (at - 6 * hour, "cw-a", "/u/hero-run-coord/train", 7_200.0, "cw-a"),
     ]
 
 


### PR DESCRIPTION
The Attempts table's job link opened an Iris page that answered `ListTasks: 500 —
Job name must use canonical '/<user>/<job>[...]' format:
%2Frav%2Fhero-...%2Fgrug-train-...`. Grafana percent-encodes an interpolated
data-link value, so the root the SQL had already encoded arrived double-encoded and
the route decoded it back to a literal `%2F`. The link now interpolates the raw job
cell and a hidden cluster column, and lets Grafana do the encoding. The column
carries `local` for the hub, which is the coordinate the Iris dashboard reserves for
its own cluster.

The status strip is ten grid rows tall so its twelve tiles lay out six by two. The
stat panel picks its tile grid from the aspect ratio, and at six rows the same twelve
landed in a single row of unreadable values. Its mixed queries also prefixed every
label with a refId, reading `A MFU` and `B active share`, which a rename
transformation strips.

The Attempts table moves below the last chart.
