### PR TITLE
[grafana] Add a training run's progress efficiency to the status strip

### DIFF
--- a/infra/grafana/dashboards/training.json
+++ b/infra/grafana/dashboards/training.json
@@ -160,7 +160,7 @@
       "id": 1,
       "type": "stat",
       "title": "Run status",
-      "description": "Where the run is right now. The window is a fixed fifteen minutes; the dashboard time range does not reach this panel. One query serves every tile, because a telemetry_v1 scan costs what its window costs whatever it selects, and ten stat panels would cost ten scans. Time since last step is the stall alert's own input, the age of the wall-clock stamp Levanter writes after each completed step. Sample age is the age of any telemetry from the run, so the two together separate a stalled trainer from a broken telemetry path. Active execution and active share come from W&B, not from finelog: W&B counts the seconds each attempt was alive and carries that count across every restart, thus the total covers the whole run and no telemetry eviction truncates it. Active share divides that total by the time from the creation of the run to its last heartbeat, so the remainder is downtime. The total holds while an attempt restarts, because W&B advances it when the attempt logs its first step.",
+      "description": "Where the run is right now. The window is a fixed fifteen minutes; the dashboard time range does not reach this panel. One query serves every tile, because a telemetry_v1 scan costs what its window costs whatever it selects, and ten stat panels would cost ten scans. Time since last step is the stall alert's own input, the age of the wall-clock stamp Levanter writes after each completed step. Sample age is the age of any telemetry from the run, so the two together separate a stalled trainer from a broken telemetry path. Active execution and active share come from W&B, not from finelog: W&B counts the seconds each attempt was alive and carries that count across every restart, thus the total covers the whole run and no telemetry eviction truncates it. Active share divides that total by the time from the creation of the run to its last heartbeat, so the remainder is downtime. The total holds while an attempt restarts, because W&B advances it when the attempt logs its first step. Progress efficiency is stricter: it divides the tokens seen by what the run would have reached had it held its mean token rate from creation with no downtime, so it also counts the throughput lost to checkpoints, evals, and steps redone after a rollback, not only downtime.",
       "datasource": {
         "type": "datasource",
         "uid": "-- Mixed --"
@@ -374,6 +374,22 @@
                 "value": 1
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "progress efficiency"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "decimals",
+                "value": 1
+              }
+            ]
           }
         ]
       },
@@ -501,6 +517,11 @@
             {
               "selector": "active_share",
               "text": "active share",
+              "type": "number"
+            },
+            {
+              "selector": "progress_efficiency",
+              "text": "progress efficiency",
               "type": "number"
             }
           ]

--- a/infra/grafana/src/server.py
+++ b/infra/grafana/src/server.py
@@ -31,7 +31,7 @@ Routes, grouped by source (cluster is a path segment where it applies):
     GET /github/nightlies                        7-day nightly-lane matrix (one row per lane/day)
     GET /wandb/report/{chart}                    sampled public hero-report series by chart key
     GET /wandb/history?run=&metric=&project=     one run's full logged history for one metric
-    GET /wandb/activity?run=&project=            one run's active, wall, and downtime seconds
+    GET /wandb/activity?run=&project=            one run's active/wall/downtime seconds and progress efficiency
     GET /k8s/control_plane                       watched components + webhook endpoints, all clusters
     GET /k8s/crashloops                          containers in backoff waiting states
     GET /k8s/pending                             Pending / SchedulingGated pods with age

--- a/infra/grafana/src/wandb_source.py
+++ b/infra/grafana/src/wandb_source.py
@@ -40,6 +40,14 @@ _RUN_HISTORY_SAMPLES = 2000
 # `wandb.log(..., step=<training step>)`, so this column is the Levanter step.
 _STEP_KEY = "_step"
 
+# Reference speed for progress efficiency. `summaryMetrics` carries only the last
+# step's `throughput/tokens_per_second`, which a checkpoint or eval step drives
+# ~15x low, so the mean of a sampled history is used instead: it is stable across a
+# single bad step and matches the status strip's own AVG(tokens/s) tile.
+_TPS_KEY = "throughput/tokens_per_second"
+_TOKENS_SEEN_KEY = "throughput/total_tokens"
+_TPS_SAMPLES = 500
+
 # The projects a run named by the training dashboard can live in, searched in this
 # order. The grug hero launchers default to marin_moe and marin.experiment.train
 # defaults to marin. A caller that knows the project pins it and skips the search.
@@ -188,16 +196,34 @@ class WandbSource:
 
         return self._search_projects(run, project, read)
 
+    def _mean_tps(self, *, project: str, run: str) -> float | None:
+        """Mean per-step token rate over the whole run, the reference for progress efficiency.
+
+        A mean over a sampled history rather than the summary's last-step value, so a
+        checkpoint or eval step cannot skew it (see `_TPS_KEY`). None if the run has
+        logged no token rate yet.
+        """
+        pairs = self._sampled_history(project=project, run=run, x_key=_STEP_KEY, y_key=_TPS_KEY, samples=_TPS_SAMPLES)
+        if not pairs:
+            return None
+        rates = [rate for _, rate in pairs]
+        return sum(rates) / len(rates)
+
     def run_activity(self, run: str, *, project: str | None = None) -> list[dict]:
-        """Return one row of active and wall-clock time for the whole of `run`.
+        """Return one row of active time, wall-clock time, and progress efficiency for `run`.
 
         W&B's `_runtime` counts the seconds a process was alive: `resume="allow"`
         restores it at each restart, so the wait between two attempts never enters
         it. That makes it the run's active execution time across every attempt, and
         unlike a `telemetry_v1` scan it does not stop where segment eviction does.
         Wall time runs from the run's creation to its last heartbeat, thus the
-        remainder is downtime and the ratio is the share of the run that ran. A run
-        that has logged nothing yet reports a null active time rather than a zero.
+        remainder is downtime and the ratio is the share of the run that ran.
+
+        Progress efficiency is `tokens_seen / (reference_tps * wall)`: the fraction of
+        an ideal run that held its steady token rate from creation with no downtime.
+        It is stricter than active share, which sees only downtime -- this also counts
+        the throughput lost to checkpoints, evals, and steps redone after a rollback.
+        A run that has logged nothing yet reports nulls rather than zeros.
         """
 
         def read(candidate: str) -> list[dict] | None:
@@ -214,6 +240,12 @@ class WandbSource:
             active = summary.get("_runtime")
             active = float(active) if isinstance(active, int | float) else None
             wall = _epoch_seconds(run_data["heartbeatAt"]) - _epoch_seconds(run_data["createdAt"])
+            tokens_seen = summary.get(_TOKENS_SEEN_KEY)
+            tokens_seen = float(tokens_seen) if isinstance(tokens_seen, int | float) else None
+            reference_tps = self._mean_tps(project=candidate, run=run)
+            efficiency = (
+                tokens_seen / (reference_tps * wall) if tokens_seen is not None and reference_tps and wall > 0 else None
+            )
             return [
                 {
                     "run": run,
@@ -224,6 +256,9 @@ class WandbSource:
                     "wall_seconds": wall,
                     "downtime_seconds": None if active is None else wall - active,
                     "active_share": active / wall if active is not None and wall > 0 else None,
+                    "tokens_seen": tokens_seen,
+                    "reference_tps": reference_tps,
+                    "progress_efficiency": efficiency,
                 }
             ]
 

--- a/infra/grafana/src/wandb_source.py
+++ b/infra/grafana/src/wandb_source.py
@@ -25,7 +25,7 @@ _ENTITY = "marin-community"
 _PROJECT = "marin_moe"
 _REPORT_VIEW_ID = "VmlldzoxNzM1OTMxMQ=="
 _REPORT_URL = "https://wandb.ai/marin-community/marin_moe/reports/67B-A2B-MoE-on-10T-tokens--VmlldzoxNzM1OTMxMQ"
-_X_KEY = "throughput/total_tokens"
+_TOTAL_TOKENS_KEY = "throughput/total_tokens"
 _SAMPLES = 800
 
 WANDB_CHARTS = {
@@ -45,7 +45,6 @@ _STEP_KEY = "_step"
 # ~15x low, so the mean of a sampled history is used instead: it is stable across a
 # single bad step and matches the status strip's own AVG(tokens/s) tile.
 _TPS_KEY = "throughput/tokens_per_second"
-_TOKENS_SEEN_KEY = "throughput/total_tokens"
 _TPS_SAMPLES = 500
 
 # The projects a run named by the training dashboard can live in, searched in this
@@ -157,7 +156,9 @@ class WandbSource:
         report_title, runs = self._report()
         rows: list[dict] = []
         for run in runs:
-            pairs = self._sampled_history(project=_PROJECT, run=run, x_key=_X_KEY, y_key=metric, samples=_SAMPLES)
+            pairs = self._sampled_history(
+                project=_PROJECT, run=run, x_key=_TOTAL_TOKENS_KEY, y_key=metric, samples=_SAMPLES
+            )
             if pairs is None:
                 raise UpstreamError("wandb", f"run {run!r} not found", status_code=502)
             rows.extend(
@@ -240,7 +241,7 @@ class WandbSource:
             active = summary.get("_runtime")
             active = float(active) if isinstance(active, int | float) else None
             wall = _epoch_seconds(run_data["heartbeatAt"]) - _epoch_seconds(run_data["createdAt"])
-            tokens_seen = summary.get(_TOKENS_SEEN_KEY)
+            tokens_seen = summary.get(_TOTAL_TOKENS_KEY)
             tokens_seen = float(tokens_seen) if isinstance(tokens_seen, int | float) else None
             reference_tps = self._mean_tps(project=candidate, run=run)
             efficiency = (

--- a/infra/grafana/tests/test_sources.py
+++ b/infra/grafana/tests/test_sources.py
@@ -379,11 +379,21 @@ def test_wandb_run_history_pins_an_explicit_project_without_searching():
     assert [row["step"] for row in rows] == [7]
 
 
-def _activity_handler(found_in: str, run: dict, asked: list[str]):
-    """Serve `run` from the project named `found_in`; record each project asked."""
+def _activity_handler(found_in: str, run: dict, asked: list[str], tps_points: list[dict] = ()):
+    """Serve `run` for the activity query and `tps_points` for the reference-rate history.
+
+    Only the activity search is recorded in `asked`; the token-rate history read that
+    follows it asks the project the run was already found in, so it carries no new
+    routing information.
+    """
 
     def handler(request: httpx.Request) -> httpx.Response:
         variables = json.loads(request.content)["variables"]
+        if "specs" in variables:  # the reference-tps history read, not the activity search
+            if variables["project"] != found_in:
+                return httpx.Response(200, json={"data": {"project": None}})
+            history = {"state": "running", "sampledHistory": [list(tps_points)]}
+            return httpx.Response(200, json={"data": {"project": {"run": history}}})
         asked.append(variables["project"])
         if variables["project"] != found_in:
             return httpx.Response(200, json={"data": {"project": None}})
@@ -396,15 +406,23 @@ def test_wandb_run_activity_separates_active_time_from_downtime():
     # `_runtime` is W&B's own count of the seconds a process was alive, restored at each
     # resume, so it is the run's active time across restarts and never includes the wait
     # between two attempts. Wall clock here is four days, of which ninety hours ran.
+    # Progress efficiency divides the tokens seen by the mean token rate times wall clock:
+    # the reference rate is the mean over the history (2.5M here), not the summary's last
+    # step, so a checkpoint step logging a low rate cannot skew it. 648e9 / (2.5e6 * 345600)
+    # is 0.75.
     asked: list[str] = []
     run = {
         "state": "running",
         "createdAt": "2026-08-20T02:00:00Z",
         "heartbeatAt": "2026-08-24T02:00:00Z",
-        "summaryMetrics": json.dumps({"_runtime": 90 * 3_600, "_timestamp": 1_787_561_529}),
+        "summaryMetrics": json.dumps({"_runtime": 90 * 3_600, "throughput/total_tokens": 648_000_000_000}),
     }
+    tps_points = [
+        {"_step": 0, "throughput/tokens_per_second": 2_000_000},
+        {"_step": 1, "throughput/tokens_per_second": 3_000_000},
+    ]
 
-    (row,) = _wandb(_activity_handler("marin_moe", run, asked)).run_activity("hero-run")
+    (row,) = _wandb(_activity_handler("marin_moe", run, asked, tps_points)).run_activity("hero-run")
 
     assert asked == ["marin_moe"]
     assert row == {
@@ -416,12 +434,16 @@ def test_wandb_run_activity_separates_active_time_from_downtime():
         "wall_seconds": 345_600.0,
         "downtime_seconds": 21_600.0,
         "active_share": 0.9375,
+        "tokens_seen": 648_000_000_000.0,
+        "reference_tps": 2_500_000.0,
+        "progress_efficiency": 0.75,
     }
 
 
 def test_wandb_run_activity_reports_no_active_time_before_the_first_log():
     # A run that has been created but has logged nothing has no `_runtime` to read. The
     # tile then shows no data, which is true, rather than zero, which reads as a stall.
+    # With no token rate and no tokens seen, progress efficiency is null for the same reason.
     asked: list[str] = []
     run = {
         "state": "running",
@@ -435,6 +457,7 @@ def test_wandb_run_activity_reports_no_active_time_before_the_first_log():
     assert asked == ["marin_moe", "marin"]
     assert (row["active_seconds"], row["downtime_seconds"], row["active_share"]) == (None, None, None)
     assert row["wall_seconds"] == 600.0
+    assert (row["tokens_seen"], row["reference_tps"], row["progress_efficiency"]) == (None, None, None)
 
 
 def test_wandb_run_activity_fails_loud_when_no_project_has_the_run():


### PR DESCRIPTION
The training-run status strip gains a progress-efficiency tile beside active share:
`tokens_seen / (reference_tps * wall_since_creation)` — the fraction of an ideal run
that held its steady token rate from creation with no downtime. Active share sees only
downtime; progress efficiency also charges the throughput lost to checkpoints, evals,
and steps redone after a rollback, so it is the stricter "are we on schedule" number.

The reference rate is the mean of a sampled history of `throughput/tokens_per_second`,
not the value in `summaryMetrics`. The summary carries only the last step's rate, which
a checkpoint or eval step drives ~15x low (162K vs a ~2.49M norm on the current hero);
reading that raw would swing the ratio wildly whenever the dashboard loaded just after a
slow step. The mean over history is stable and matches the strip's existing `AVG(tokens/s)`
tile, so the two agree. `tokens_seen` and wall come from the same `summaryMetrics` the
activity route already reads, adding one sampled-history request for the reference rate.

Both inputs must come from W&B, not finelog: progress efficiency needs the run's true
creation time and full-run tokens, and finelog only retains a recent window (the reason
active time already lives on this route). For hero-12d8b6f0-dee637 it reads 0.64 against
a 0.90 active share.