### PR TITLE
[iac] Allow Echo quota use from GitHub main

### DIFF
--- a/infra/pulumi/src/iac/gcp/iam_data.yaml
+++ b/infra/pulumi/src/iac/gcp/iam_data.yaml
@@ -1336,6 +1336,7 @@ project_grants:
   - serviceAccount:748532799086-compute@developer.gserviceaccount.com
 - role: roles/serviceusage.serviceUsageConsumer
   members:
+  - principal://iam.googleapis.com/projects/748532799086/locations/global/workloadIdentityPools/github-pool/subject/repo:marin-community/marin:ref:refs/heads/main
   - serviceAccount:marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com
 - role: roles/serviceusage.serviceUsageAdmin
   members:


### PR DESCRIPTION
Allow the GitHub `main` Workload Identity principal to use `hai-gcp-models` as the quota project while Echo refreshes its federated deployment credential. This adds `roles/serviceusage.serviceUsageConsumer` to Marin's canonical project IAM data.

PR #8612 granted the same role to the impersonated deployment service account. The [exact merged-main rollout](https://github.com/marin-community/marin/actions/runs/32746184806) still failed before migration, showing that the source credential is checked first. This one-member grant covers that earlier check; it does not change Echo application code or resources.

The [redacted CI preview](https://github.com/marin-community/marin/pull/8625#issuecomment-5398459054) shows the intended IAM member creation and one expected cleanup: deletion of the live `infra-probes` Artifact Registry reader removed from configuration by merged PR #8473. The other 785 resources are unchanged.

A reviewer should run `review-grant`, then apply the `marin` Pulumi stack. Issue #8611 remains open until an exact-main Echo rollout completes successfully.

<details>
<summary>Local validation</summary>

- `uv run --group test --extra deploy pytest tests/test_iam_config.py` from `infra/pulumi` — 10 passed
- `./infra/pre-commit.py --changed-files --fix` — passed
- `./infra/pre-commit.py --review --agent-command='codex exec'` — no findings

</details>

Part of #8611
