### PR TITLE
[levanter] Stage replica checkpoint slices in pageable memory

### DIFF
--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -163,9 +163,9 @@ def _slice_shard_on_device(data, axis: int, start: int, limit: int):
 async def _transfer_shard_to_pageable_host(shard, local_slice: tuple[int, int, int] | None = None) -> np.ndarray:
     """Snapshot a shard into pageable host memory, restricted to ``local_slice``.
 
-    Unsliced GPU shards are training-owned. Staging them on a disposable pageable CPU array keeps
-    JAX's NumPy cache off the live shard without entering CUDA's pinned-host allocator. Sliced
-    shards are already disposable, and TPU keeps its direct path.
+    Staging GPU shards on a disposable pageable CPU array keeps JAX's NumPy cache off the source.
+    CUDA may use a pinned DMA bounce buffer internally, but the checkpoint snapshot remains pageable
+    and the staged JAX allocation is explicitly deleted. TPU keeps its direct path.
     """
     data = shard.data if local_slice is None else _slice_shard_on_device(shard.data, *local_slice)
 
@@ -173,7 +173,7 @@ async def _transfer_shard_to_pageable_host(shard, local_slice: tuple[int, int, i
         # Already in host memory, and copying it to host again would alias rather than move.
         return np.array(data, copy=True)
 
-    if local_slice is None and data.device.platform == _GPU_PLATFORM:
+    if data.device.platform == _GPU_PLATFORM:
         cpu_device = jax.local_devices(backend="cpu")[0]
         pageable_sharding = SingleDeviceSharding(cpu_device, memory_kind=_PAGEABLE_HOST_MEMORY_KIND)
         staged = jax.device_put(data, pageable_sharding)

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -161,18 +161,15 @@ def _slice_shard_on_device(data, axis: int, start: int, limit: int):
 
 
 async def _transfer_shard_to_pageable_host(shard, local_slice: tuple[int, int, int] | None = None) -> np.ndarray:
-    """Snapshot a shard into pageable host memory, restricted to ``local_slice``.
-
-    Staging GPU shards on a disposable pageable CPU array keeps JAX's NumPy cache off the source.
-    CUDA may use a pinned DMA bounce buffer internally, but the checkpoint snapshot remains pageable
-    and the staged JAX allocation is explicitly deleted. TPU keeps its direct path.
-    """
+    """Return a detached pageable-host snapshot, restricted to ``local_slice``."""
     data = shard.data if local_slice is None else _slice_shard_on_device(shard.data, *local_slice)
 
     if getattr(data.sharding, "memory_kind", None) == _HOST_MEMORY_KIND:
         # Already in host memory, and copying it to host again would alias rather than move.
         return np.array(data, copy=True)
 
+    # np.array(data) populates a GPU array's host cache, including for disposable slices. Going
+    # through a pageable CPU array lets the CUDA DMA pool reuse its internal pinned bounce buffer.
     if data.device.platform == _GPU_PLATFORM:
         cpu_device = jax.local_devices(backend="cpu")[0]
         pageable_sharding = SingleDeviceSharding(cpu_device, memory_kind=_PAGEABLE_HOST_MEMORY_KIND)


### PR DESCRIPTION
Replica-split checkpoints still sent sliced GPU shards through `copy_to_host_async`, which let JAX retain the transfer buffer on the sliced array. Send sliced shards through the disposable pageable CPU staging path already used by unsliced shards.

In a 3,000-step, two-GB200-tray run with a 108.77M-parameter model, real Harrier data, pinned optimizer and master state, and checkpoints plus regular and dropless Paloma evals every 1,000 steps, the control allocated a fresh 32 MiB CUDA host-pool chunk at checkpoint 2 and one tray's cgroup stepped up 141 MiB. The treatment reused its checkpoint-1 pool and had no checkpoint-aligned cgroup step. Both arms retained a smaller continuous training-floor drift, so this does not resolve the production leak. [Investigation and run links](https://echo.oa.dev/wiki/232).

Part of #8506
