### PR TITLE
[grafana] Lower the vLLM nightly duration floor

### DIFF
--- a/infra/grafana/src/nightly_config.py
+++ b/infra/grafana/src/nightly_config.py
@@ -223,7 +223,7 @@ NIGHTLY_LANES: tuple[NightlyLane, ...] = (
         active_from="2026-07-15",
         active_until=None,
         overdue_grace_minutes=240,
-        expected_min_seconds=6 * 60,
+        expected_min_seconds=2 * 60,
         expected_max_seconds=15 * 60,
     ),
     NightlyLane(


### PR DESCRIPTION
The vLLM nightly now fails closed on build and Iris errors and gates GPU tests, Qwen serving, output length, and throughput after marin-community/vllm#48. Three successful manual runs took [294](https://github.com/marin-community/vllm/actions/runs/32750767214), [330](https://github.com/marin-community/vllm/actions/runs/32684087808), and [352](https://github.com/marin-community/vllm/actions/runs/32752764570) seconds, so the six-minute Grafana floor marks valid runs unhealthy.

Use a two-minute floor as a coarse early-exit signal. Keep the 15-minute ceiling.
