### PR TITLE
[loom] Restore Grafana triage launches

### DIFF
--- a/infra/loom/Pulumi.marin-loom.yaml
+++ b/infra/loom/Pulumi.marin-loom.yaml
@@ -105,6 +105,8 @@ config:
       instructionsFile: profiles/ops/AGENTS.md
       env: *loomIrisUser
       restricted: false
+      githubRepositories:
+        - marin-community/marin
       allowedTools: []
       mcpAccess:
         mode: all

--- a/infra/loom/README.md
+++ b/infra/loom/README.md
@@ -94,7 +94,11 @@ Runtime profiles and workload federation mappings live in
 `Pulumi.marin-loom.yaml` and are applied through Loom's deployment API during
 activation. The `grafana-alerts` federation mapping authorizes the Google
 identity of the existing `marin-grafana` Cloud Run service account to select
-only the `ops` profile. Pulumi resolves that account's email and immutable
+only the `ops` profile. The profile names `marin-community/marin` in
+`githubRepositories` because Grafana launches the operator session in that
+repository and automation profiles receive only their configured repository
+credentials. Without that entry, Loom rejects the launch with HTTP 428 before
+creating a session. Pulumi resolves the service account's email and immutable
 numeric subject; it does not create or copy a Loom token.
 
 The `fork-ferry` mapping accepts OIDC tokens only from the `marin` repository's


### PR DESCRIPTION
Grant the deployment-managed `ops` automation profile access to `marin-community/marin`, the repository Grafana passes in every triage launch. Loom's repository credential preflight returns HTTP 428 when an automation profile does not name a concrete GitHub repository; recent Grafana alerts therefore created durable waiting attempts but no session.

Document the repository grant beside the workload federation contract. Apply the `marin-loom` stack after merge to reconcile the profile before expecting new alerts to launch.

The incident record is https://echo.oa.dev/wiki/233.
