### PR TITLE
[canary] Allow TPU ferry launcher on preemptible capacity

### DIFF
--- a/.github/workflows/marin-canary-ferry.yaml
+++ b/.github/workflows/marin-canary-ferry.yaml
@@ -89,6 +89,7 @@ jobs:
             job run --no-wait \
             --memory=2G --disk=4G --cpu=1 --extra=cpu \
             --priority production \
+            --preemptible \
             --reserve "$RESERVE_TPU_TYPE" \
             -e RUN_ID "$RUN_ID" \
             -e CANARY_ACCELERATOR "$CANARY_ACCELERATOR" \


### PR DESCRIPTION
Allow the TPU ferry's small CPU launcher to prefer preemptible capacity while retaining on-demand fallback.

[Scheduled run 32699287522](https://github.com/marin-community/marin/actions/runs/32699287522) requested v5p-8 availability. Iris also inferred a required non-preemptible constraint for the one-core launcher. The only two v5p-8 groups were preemptible, so no scaling group satisfied both constraints and submission ended before Iris returned a job ID.

The explicit preference suppresses that executor inference. The existing v5p-8 reservation continues to select a region where the TPU child can run. Changed-file checks and seven focused Iris constraint and scheduler tests pass.
