### PR TITLE
[agents] Make research issues optional

### DIFF
--- a/.agents/skills/file-issue/SKILL.md
+++ b/.agents/skills/file-issue/SKILL.md
@@ -1,9 +1,16 @@
 ---
 name: file-issue
-description: File a GitHub issue only when explicitly requested or delegated by another selected workflow; do not create issues merely because a problem was found.
+description: File a GitHub issue only when the user explicitly requests one or invokes a workflow whose stated purpose intrinsically requires a new issue; delegation from another skill alone is insufficient.
 ---
 
 # File a GitHub issue
+
+Creating an issue is an external publishing action. Do not activate this skill
+merely because an issue could help, a problem was found, or another skill lists
+an issue among its usual artifacts. A workflow may require issue creation only
+when its user-requested purpose depends on that issue, such as CI triage whose
+deliverable is a tracked bug. Research, benchmarking, implementation, and PR
+work do not imply issue creation.
 
 Before drafting, read `AGENTS.md` and:
 
@@ -114,9 +121,13 @@ completion criterion.
 
 ### 5. Apply the approval boundary
 
-If the user explicitly asked to file an issue, skip the preview — file it and
-share the link. If the agent surfaced the issue (not explicitly requested),
-show the drafted title and body and wait for approval or edits.
+If the user explicitly asked to file an issue, skip the preview, file it, and
+share the link. Do the same when the user invoked a workflow whose stated
+deliverable intrinsically requires a new issue.
+
+Otherwise, do not draft or file an issue. Continue the underlying work. If an
+issue would materially improve later coordination, mention that option at
+handoff without blocking the task.
 
 ### 6. File the issue
 

--- a/.agents/skills/file-issue/SKILL.md
+++ b/.agents/skills/file-issue/SKILL.md
@@ -1,16 +1,9 @@
 ---
 name: file-issue
-description: File a GitHub issue only when the user explicitly requests one or invokes a workflow whose stated purpose intrinsically requires a new issue; delegation from another skill alone is insufficient.
+description: File a GitHub issue only when explicitly requested or delegated by another selected workflow; do not create issues merely because a problem was found.
 ---
 
 # File a GitHub issue
-
-Creating an issue is an external publishing action. Do not activate this skill
-merely because an issue could help, a problem was found, or another skill lists
-an issue among its usual artifacts. A workflow may require issue creation only
-when its user-requested purpose depends on that issue, such as CI triage whose
-deliverable is a tracked bug. Research, benchmarking, implementation, and PR
-work do not imply issue creation.
 
 Before drafting, read `AGENTS.md` and:
 
@@ -121,13 +114,9 @@ completion criterion.
 
 ### 5. Apply the approval boundary
 
-If the user explicitly asked to file an issue, skip the preview, file it, and
-share the link. Do the same when the user invoked a workflow whose stated
-deliverable intrinsically requires a new issue.
-
-Otherwise, do not draft or file an issue. Continue the underlying work. If an
-issue would materially improve later coordination, mention that option at
-handoff without blocking the task.
+If the user explicitly asked to file an issue, skip the preview — file it and
+share the link. If the agent surfaced the issue (not explicitly requested),
+show the drafted title and body and wait for approval or edits.
 
 ### 6. File the issue
 

--- a/.agents/skills/run-research/SKILL.md
+++ b/.agents/skills/run-research/SKILL.md
@@ -93,8 +93,8 @@ Seal when requested or when the defined goal is reached.
 If the research produced useful production changes, extract them into a clean
 branch that links the research record without including it. Before finishing,
 update the TL;DR and conclusion, list next steps, and link the final snapshot
-and production PR. Add the same links to the coordinating issue when one
-exists.
+and production PR when one exists. Add the same links to the coordinating issue
+when one exists.
 
 ## Practical Rules
 

--- a/.agents/skills/run-research/SKILL.md
+++ b/.agents/skills/run-research/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: run-research
-description: Run a coordinated multi-session research program only when the user explicitly requests one or supplies an existing research logbook or experiment issue; do not activate for ordinary benchmarking, iteration, or investigation.
+description: Run a coordinated multi-session research program only when explicitly requested; maintain a logbook and durable snapshots.
 ---
 
 # Multi-session research
 
-Long-lived work should leave enough local state to resume and reproduce results.
-Use a GitHub issue only when public coordination is part of the request. Do not
-publish secrets or private work the user asks to hold back.
+Long-lived work should leave a durable record: a logbook and enough
+commands/config to reproduce results. When the work has a coordinating issue,
+keep its summary current. Do not publish secrets or private work the user asks
+to hold back.
 
 Use `background-research`, `task-logbook`, `wandb-reporting`, `task-snapshot`,
 and `update-docs` for their named artifacts. Add a domain skill only when the
@@ -24,25 +25,13 @@ research directly requires its workflow.
 4. One or more commit or tag snapshots for meaningful milestones.
 5. Often a "production" branch that gets PR'd and merged.
 
-A GitHub experiment issue is optional. Create one only when the user asks for
-it or when the request establishes GitHub as the coordination surface for
-multiple people or sessions. An existing issue, a request to keep collaborators
-updated on GitHub, or a production workflow that explicitly requires an issue
-meets this threshold. Calling the work a research program, running several
-benchmarks, planning a PR, or selecting this skill does not.
-
-If an issue might help but the threshold is not met, continue without one. The
-work should not pause for an issue decision. Mention the option at handoff only
-when it would materially improve future coordination.
-
 ## Standard Workflow
 
 ### 1. Prologue
 
 1. Keep an existing user-specified branch; otherwise create or use a long-lived
    `research/<topic>` or `research/<user>/<issue>-<topic>` branch.
-2. If a coordinating issue meets the threshold above, create or use it and link
-   it bidirectionally with the logbook. Follow `file-issue` for a new issue.
+2. If a coordinating issue exists, link it bidirectionally with the logbook.
 3. Choose one short experiment ID prefix and use IDs such as `MOE-HC-001` in
    entries, runs, and comments; use two to four shared tags.
 4. Record the goal, success and stop criteria, baseline, initial hypothesis
@@ -55,8 +44,8 @@ when it would materially improve future coordination.
 3. **Run:** implement the smallest useful experiment and collect evidence.
 4. **Interpret:** compare against baseline, decide confidence, and update the
    logbook.
-5. **Promote:** move decision-relevant claims into the current summary and any
-   established public coordination surface.
+5. **Promote:** move decision-relevant claims into the current summary and a
+   coordinating issue when one exists.
 6. **Seal:** snapshot durable results or extract production work.
 
 ### 2.1 Forage: Background Research

--- a/.agents/skills/run-research/SKILL.md
+++ b/.agents/skills/run-research/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: run-research
-description: Run a coordinated multi-session research program only when explicitly requested with a logbook, experiment issue, and durable snapshots.
+description: Run a coordinated multi-session research program only when the user explicitly requests one or supplies an existing research logbook or experiment issue; do not activate for ordinary benchmarking, iteration, or investigation.
 ---
 
 # Multi-session research
 
-Long-lived work should leave a durable record: a logbook, coordinating issue
-updates, and enough commands/config to reproduce results. Do not publish secrets
-or private work the user asks to hold back.
+Long-lived work should leave enough local state to resume and reproduce results.
+Use a GitHub issue only when public coordination is part of the request. Do not
+publish secrets or private work the user asks to hold back.
 
 Use `background-research`, `task-logbook`, `wandb-reporting`, `task-snapshot`,
 and `update-docs` for their named artifacts. Add a domain skill only when the
@@ -15,16 +15,25 @@ research directly requires its workflow.
 
 ## Core Artifacts
 
-1. A GitHub experiment issue. Agent-created experiment issues use the
-   `experiment` and `agent-generated` labels.
-2. A logbook at `.agents/logbooks/<topic>.md`.
-3. A living hypothesis queue in the logbook, derived from append-only entries
+1. A logbook at `.agents/logbooks/<topic>.md`.
+2. A living hypothesis queue in the logbook, derived from append-only entries
    and updated as hypotheses are proposed, blocked, falsified, or promoted.
-4. A long-lived branch, for example `research/<topic>` or
+3. A long-lived branch, for example `research/<topic>` or
    `research/<user>/<issue>-<topic>`, with the logbook, research code, configs,
    small artifacts, and test harnesses needed to reproduce results.
-5. One or more commit or tag snapshots for meaningful milestones.
-6. Often a "production" branch that gets PR'd and merged.
+4. One or more commit or tag snapshots for meaningful milestones.
+5. Often a "production" branch that gets PR'd and merged.
+
+A GitHub experiment issue is optional. Create one only when the user asks for
+it or when the request establishes GitHub as the coordination surface for
+multiple people or sessions. An existing issue, a request to keep collaborators
+updated on GitHub, or a production workflow that explicitly requires an issue
+meets this threshold. Calling the work a research program, running several
+benchmarks, planning a PR, or selecting this skill does not.
+
+If an issue might help but the threshold is not met, continue without one. The
+work should not pause for an issue decision. Mention the option at handoff only
+when it would materially improve future coordination.
 
 ## Standard Workflow
 
@@ -32,9 +41,8 @@ research directly requires its workflow.
 
 1. Keep an existing user-specified branch; otherwise create or use a long-lived
    `research/<topic>` or `research/<user>/<issue>-<topic>` branch.
-2. Create or use the experiment issue and link it bidirectionally with the
-   logbook. Confirm scope or visibility before creating it when either is
-   unclear.
+2. If a coordinating issue meets the threshold above, create or use it and link
+   it bidirectionally with the logbook. Follow `file-issue` for a new issue.
 3. Choose one short experiment ID prefix and use IDs such as `MOE-HC-001` in
    entries, runs, and comments; use two to four shared tags.
 4. Record the goal, success and stop criteria, baseline, initial hypothesis
@@ -47,8 +55,8 @@ research directly requires its workflow.
 3. **Run:** implement the smallest useful experiment and collect evidence.
 4. **Interpret:** compare against baseline, decide confidence, and update the
    logbook.
-5. **Promote:** move only interesting, decision-relevant claims up the issue
-   funnel.
+5. **Promote:** move decision-relevant claims into the current summary and any
+   established public coordination surface.
 6. **Seal:** snapshot durable results or extract production work.
 
 ### 2.1 Forage: Background Research
@@ -59,8 +67,8 @@ the decision is expensive.
 
 Use the background-research output to update the logbook's hypothesis queue:
 add new candidates, revise weak ones, mark known dead ends, and promote
-well-supported ideas into the next experiment matrix. Let `background-research`
-and `task-logbook` decide what belongs in the issue versus the logbook.
+well-supported ideas into the next experiment matrix. If a coordinating issue
+exists, let `background-research` and `task-logbook` decide what belongs there.
 
 ### 2.2 Propose / Run / Interpret: Dev Work and Experiments
 
@@ -74,7 +82,7 @@ For each non-trivial experiment:
 1. Do the dev work needed for the experiment.
 2. Run the benchmark or experiment. Use `babysit-job` for long-lived runs.
 3. Append exact commands, config, key outputs, interpretation, and next decision
-   to the logbook. Follow `task-logbook` for issue updates.
+   to the logbook. Follow `task-logbook` for issue updates when an issue exists.
 4. Push dense scalar series, plots, or raw artifacts to W&B or another store
    when they are too large for issue comments.
 
@@ -82,18 +90,22 @@ For each non-trivial experiment:
 
 Seal when requested or when the defined goal is reached.
 
-1. Update the issue body with the final TL;DR, conclusion, decision log, and negative-results index. Again, follow the `task-logbook` skill.
-2. Add a final issue comment covering what worked, what did not, confidence
-   level, limitations, and ordered next steps.
+1. Update the logbook's final TL;DR, conclusion, decision log, and
+   negative-results index.
+2. If a coordinating issue exists, update its body and add a final comment
+   covering what worked, what did not, confidence, limitations, and ordered
+   next steps. Follow `task-logbook`.
 3. Use `update-docs` when behavior, operational practice, reusable guidance, or
    durable research findings changed.
 4. Ensure the final logbook entry and snapshot links are present.
-5. Close the issue when the research thread is complete.
+5. Close the coordinating issue when one exists and the research thread is
+   complete.
 
 If the research produced useful production changes, extract them into a clean
-branch that links the research record without including it. Before closing,
+branch that links the research record without including it. Before finishing,
 update the TL;DR and conclusion, list next steps, and link the final snapshot
-and production PR when one exists.
+and production PR. Add the same links to the coordinating issue when one
+exists.
 
 ## Practical Rules
 

--- a/.agents/skills/task-logbook/SKILL.md
+++ b/.agents/skills/task-logbook/SKILL.md
@@ -110,15 +110,23 @@ or production decision.
 ## Coordinating Issue
 
 Create or use a coordinating GitHub issue when the work needs durable public
-coordination. The user, supervisor agent, or outer workflow may provide one.
-Confirm timing with the human collaborator if scope or visibility is uncertain.
+coordination and the user asked for it or established GitHub as the coordination
+surface. An outer workflow may require an issue only when its user-requested
+purpose intrinsically depends on public tracking. Selecting a research or
+logbook skill does not grant permission to create an issue.
+
+Continue with the logbook alone when no issue meets that threshold. Do not ask
+for an issue decision or draft an issue merely because one could be useful.
+Mention the option at handoff only when it would materially improve future
+coordination.
 
 Use the experiment body template in `.agents/skills/file-issue/SKILL.md` when
 creating a new coordinating experiment issue.
 
-Maintain the issue body for readers without thread context: current TL;DR,
-baseline when relevant, decisions with evidence/date/owner, linked negative
-results, and the conclusion. Do not overclaim.
+When a coordinating issue exists, maintain its body for readers without thread
+context: current TL;DR, baseline when relevant, decisions with
+evidence/date/owner, linked negative results, and the conclusion. Do not
+overclaim.
 
 ### Promotion Rules
 
@@ -128,9 +136,11 @@ surprises, and decisions as issue comments. Promote durable conclusions,
 baselines, decisions, negative results, and the final outcome into the issue
 body.
 
-For long-running research, post an issue update at each significant milestone
-or every 6 hours of active work (either experiments in progress or agent work), whichever comes first. If no milestone occurred by the cadence
-deadline, post a brief heartbeat with current status, blockers, and next ETA.
+When a coordinating issue exists for long-running research, post an update at
+each significant milestone or every 6 hours of active work (either experiments
+in progress or agent work), whichever comes first. If no milestone occurred by
+the cadence deadline, post a brief heartbeat with current status, blockers, and
+next ETA.
 
 ### Posting an update
 
@@ -172,8 +182,8 @@ the logbook or infer missing context.
 
 ## Finish
 
-Close the issue when the tracked work is complete.
+Close the coordinating issue when one exists and the tracked work is complete.
 
-Before closing the issue, make the final logbook entry and issue summary agree.
-The final comment records what worked, what did not, confidence and limitations,
+Before closing it, make the final logbook entry and issue summary agree. The
+final comment records what worked, what did not, confidence and limitations,
 ordered next steps, and the conclusion.

--- a/.agents/skills/task-logbook/SKILL.md
+++ b/.agents/skills/task-logbook/SKILL.md
@@ -109,8 +109,8 @@ or production decision.
 
 ## Coordinating Issue
 
-Use a coordinating GitHub issue when one exists. The user, supervisor agent, or
-outer workflow may provide one.
+When a coordinating GitHub issue exists, link it from the logbook and use this
+section. The user, supervisor agent, or outer workflow may provide one.
 
 Use the experiment body template in `.agents/skills/file-issue/SKILL.md` when
 creating a new coordinating experiment issue.
@@ -127,9 +127,11 @@ surprises, and decisions as issue comments. Promote durable conclusions,
 baselines, decisions, negative results, and the final outcome into the issue
 body.
 
-For long-running research, post an issue update at each significant milestone
-or every 6 hours of active work (either experiments in progress or agent work), whichever comes first. If no milestone occurred by the cadence
-deadline, post a brief heartbeat with current status, blockers, and next ETA.
+For long-running research with a coordinating issue, post an update at each
+significant milestone or every 6 hours of active work (either experiments in
+progress or agent work), whichever comes first. If no milestone occurred by the
+cadence deadline, post a brief heartbeat with current status, blockers, and next
+ETA.
 
 ### Posting an update
 

--- a/.agents/skills/task-logbook/SKILL.md
+++ b/.agents/skills/task-logbook/SKILL.md
@@ -109,24 +109,15 @@ or production decision.
 
 ## Coordinating Issue
 
-Create or use a coordinating GitHub issue when the work needs durable public
-coordination and the user asked for it or established GitHub as the coordination
-surface. An outer workflow may require an issue only when its user-requested
-purpose intrinsically depends on public tracking. Selecting a research or
-logbook skill does not grant permission to create an issue.
-
-Continue with the logbook alone when no issue meets that threshold. Do not ask
-for an issue decision or draft an issue merely because one could be useful.
-Mention the option at handoff only when it would materially improve future
-coordination.
+Use a coordinating GitHub issue when one exists. The user, supervisor agent, or
+outer workflow may provide one.
 
 Use the experiment body template in `.agents/skills/file-issue/SKILL.md` when
 creating a new coordinating experiment issue.
 
-When a coordinating issue exists, maintain its body for readers without thread
-context: current TL;DR, baseline when relevant, decisions with
-evidence/date/owner, linked negative results, and the conclusion. Do not
-overclaim.
+Maintain the issue body for readers without thread context: current TL;DR,
+baseline when relevant, decisions with evidence/date/owner, linked negative
+results, and the conclusion. Do not overclaim.
 
 ### Promotion Rules
 
@@ -136,11 +127,9 @@ surprises, and decisions as issue comments. Promote durable conclusions,
 baselines, decisions, negative results, and the final outcome into the issue
 body.
 
-When a coordinating issue exists for long-running research, post an update at
-each significant milestone or every 6 hours of active work (either experiments
-in progress or agent work), whichever comes first. If no milestone occurred by
-the cadence deadline, post a brief heartbeat with current status, blockers, and
-next ETA.
+For long-running research, post an issue update at each significant milestone
+or every 6 hours of active work (either experiments in progress or agent work), whichever comes first. If no milestone occurred by the cadence
+deadline, post a brief heartbeat with current status, blockers, and next ETA.
 
 ### Posting an update
 
@@ -182,8 +171,8 @@ the logbook or infer missing context.
 
 ## Finish
 
-Close the coordinating issue when one exists and the tracked work is complete.
+Close the issue when the tracked work is complete.
 
-Before closing it, make the final logbook entry and issue summary agree. The
-final comment records what worked, what did not, confidence and limitations,
+Before closing the issue, make the final logbook entry and issue summary agree.
+The final comment records what worked, what did not, confidence and limitations,
 ordered next steps, and the conclusion.

--- a/.agents/skills/writing-style/issues.md
+++ b/.agents/skills/writing-style/issues.md
@@ -49,7 +49,8 @@ reproduction step, observation, expected behavior, or completion criterion.
 
 Treat experiment issues as part of Marin's scientific record. Use them as a summary layer, a coordination surface, and a long-lived artifact.
 
-They are frequently created using the [run-research](../run-research/SKILL.md) skill.
+For experiment issues attached to a research program, follow the
+[run-research](../run-research/SKILL.md) workflow.
 
 ### Assume This Reader
 


### PR DESCRIPTION
Make a logbook and durable snapshots the core artifacts for explicitly
requested multi-session research. A coordinating GitHub issue is an optional
input; update and finalization steps apply when one is present.

`task-logbook` now begins its coordinating-issue workflow from an issue supplied
by the user, supervisor, or outer workflow. Experiment-issue writing guidance
references `run-research` only when an issue is attached to the program.
