### PR TITLE
[iac] Grant Cloud SQL, Run, and Scheduler viewer for state-migration preview

### DIFF
--- a/infra/pulumi/src/iac/gcp/iam_data.yaml
+++ b/infra/pulumi/src/iac/gcp/iam_data.yaml
@@ -968,6 +968,9 @@ project_grants:
   members:
   - serviceAccount:ravwojdyla@rav-openathena.iam.gserviceaccount.com
   - principal: human-012
+- role: roles/cloudsql.viewer
+  members:
+  - principal: human-070
 - role: roles/cloudtasks.enqueuer
   members:
   - serviceAccount:hai-gcp-models@appspot.gserviceaccount.com
@@ -1319,14 +1322,14 @@ project_grants:
 - role: roles/servicenetworking.serviceAgent
   members:
   - serviceAccount:748532799086-compute@developer.gserviceaccount.com
-- role: roles/serviceusage.serviceUsageConsumer
-  members:
-  - principal://iam.googleapis.com/projects/748532799086/locations/global/workloadIdentityPools/github-pool/subject/repo:marin-community/marin:ref:refs/heads/main
-  - serviceAccount:marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com
 - role: roles/serviceusage.serviceUsageAdmin
   members:
   - principal: human-037
   - principal: human-070
+- role: roles/serviceusage.serviceUsageConsumer
+  members:
+  - principal://iam.googleapis.com/projects/748532799086/locations/global/workloadIdentityPools/github-pool/subject/repo:marin-community/marin:ref:refs/heads/main
+  - serviceAccount:marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com
 - role: roles/storage.admin
   members:
   - serviceAccount:codalab-dev@hai-gcp-models.iam.gserviceaccount.com

--- a/infra/pulumi/src/iac/gcp/iam_data.yaml
+++ b/infra/pulumi/src/iac/gcp/iam_data.yaml
@@ -960,6 +960,9 @@ project_grants:
 - role: roles/cloudscheduler.serviceAgent
   members:
   - serviceAccount:service-748532799086@gcp-sa-cloudscheduler.iam.gserviceaccount.com
+- role: roles/cloudscheduler.viewer
+  members:
+  - principal: human-070
 - role: roles/cloudsql.client
   members:
   - serviceAccount:marin-cd-cloud-run-deploy@hai-gcp-models.iam.gserviceaccount.com

--- a/infra/pulumi/src/iac/gcp/iam_data.yaml
+++ b/infra/pulumi/src/iac/gcp/iam_data.yaml
@@ -1291,6 +1291,9 @@ project_grants:
 - role: roles/run.servicesInvoker
   members:
   - serviceAccount:hai-gcp-models@appspot.gserviceaccount.com
+- role: roles/run.viewer
+  members:
+  - principal: human-070
 - role: roles/secretmanager.admin
   members:
   - principal: human-033


### PR DESCRIPTION
Grant `roles/cloudsql.viewer`, `roles/run.viewer`, and `roles/cloudscheduler.viewer` on `hai-gcp-models` to an operator running the Echo/EvalDash/Grafana IAM state-migration runbook.

`pulumi preview --refresh` against these stacks reads live GCP resources that the runbook's documented KMS/bucket access does not cover. Against `marin-echo` it reads `gcp.sql.User` resources through the Cloud SQL Admin API (`cloudsql.viewer`) and the `echo-sync` Cloud Scheduler job (`cloudscheduler.viewer`). Against all three stacks it reads each service's `gcp.cloudrunv2.Service` and Cloud Run domain mapping, which need `run.services.get` and `run.domainmappings.get` (`run.viewer`).
