### PR TITLE
[grug] Bound the hero ladder's TensorStore decoded-chunk cache to 1 GB

### DIFF
--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -98,7 +98,10 @@ WATCH_INTERVAL = 10
 # 791 tokens per active parameter sets the step budget: it lands the d6144 hero at 18T tokens and
 # scales every narrower rung by the same ratio.
 TOKENS_PER_ACTIVE_PARAM = 791
-TENSORSTORE_CACHE_BYTES = 125_000_000_000
+# The decoded-chunk cache is process-local. A two-tray loader benchmark at the hero's global batch
+# and sequence length found 1 GB retained 18.6x throughput headroom while bounding the cache near
+# 0.923 GiB per process; 125 GB allowed native RSS to grow until the cache filled.
+TENSORSTORE_CACHE_BYTES = 1_000_000_000
 # A crash costs at most this much training time. A hero checkpoint is several TB, thus a shorter
 # interval would spend a large part of the run inside a checkpoint write.
 RESUME_SAVE_INTERVAL = timedelta(hours=1)


### PR DESCRIPTION
Cap the hero scaling ladder's process-local TensorStore decoded-chunk cache from 125 GB to 1 GB. Native mimalloc-pprof sampling attributed the retained heap to TensorStore's Zarr decode cache through `DecodeArrayEndian` and `ZarrLeafChunkCache::DecodeChunk`; at 125 GB anonymous RSS kept rising as new chunks entered the cache.

A two-tray loader benchmark on the real Harrier mixture at global batch 1024 and sequence length 4096, with the model and optimizer step omitted to measure loader capacity, gave 1.076 batches/s steady (batches 30-100) at 1 GB against 1.113 batches/s at 125 GB, or 96.6% of the larger cache's rate. The hero consumes 0.050 batches/s, so the 1 GB arm retains 18.6x headroom while bounding the decoded cache near 0.923 GiB per process.

This is the constant change from #8639, split out so it can land without the profiling tooling in that branch.

Cache attribution and throughput results: https://echo.oa.dev/wiki/235

Part of #8506
