### PR TITLE
[iris] Report a dispatched-but-unstarted job as BUILDING

### DIFF
--- a/lib/iris/README.md
+++ b/lib/iris/README.md
@@ -204,7 +204,7 @@ job-state rollup rules, see [`docs/task-states.md`](docs/task-states.md).
 | State | Description |
 |-------|-------------|
 | **PENDING** | Job submitted, waiting for worker assignment |
-| **BUILDING** | Job bundle being built/transferred (future use) |
+| **BUILDING** | Tasks dispatched but none executing yet -- awaiting admission, image pull, or setup. Never started, so no duration |
 | **RUNNING** | At least one task is actively executing |
 | **SUCCEEDED** | All tasks completed successfully |
 | **FAILED** | Job failed (exceeded max task failures or retry limit) |

--- a/lib/iris/dashboard/src/components/controller/AccountTab.vue
+++ b/lib/iris/dashboard/src/components/controller/AccountTab.vue
@@ -22,6 +22,13 @@ function activeJobCount(summary: UserSummary): number {
     .reduce((acc, [, count]) => acc + count, 0)
 }
 
+// 'building' is dispatched but not executing, so it counts as waiting. Without this
+// row Active would exceed Running with nothing on screen explaining the difference.
+function pendingJobCount(summary: UserSummary): number {
+  const counts = summary.jobStateCounts ?? {}
+  return (counts['pending'] ?? 0) + (counts['building'] ?? 0) + (counts['unschedulable'] ?? 0)
+}
+
 function countByStates(counts?: Record<string, number>): number {
   if (!counts) return 0
   return Object.values(counts).reduce((a, b) => a + b, 0)
@@ -75,6 +82,11 @@ onMounted(async () => {
           <InfoRow label="Running Jobs">
             <span class="font-mono tabular-nums" :class="(userSummary.jobStateCounts?.['running'] ?? 0) > 0 ? 'text-accent font-semibold' : ''">
               {{ userSummary.jobStateCounts?.['running'] ?? 0 }}
+            </span>
+          </InfoRow>
+          <InfoRow label="Pending Jobs">
+            <span class="font-mono tabular-nums" :class="pendingJobCount(userSummary) > 0 ? 'text-status-warning' : ''">
+              {{ pendingJobCount(userSummary) }}
             </span>
           </InfoRow>
           <InfoRow label="Total Tasks">

--- a/lib/iris/dashboard/src/components/controller/CapacityTab.vue
+++ b/lib/iris/dashboard/src/components/controller/CapacityTab.vue
@@ -22,7 +22,7 @@ import type {
   JobStatus,
   JobQuery,
 } from '@/types/rpc'
-import { timestampMs, formatRelativeTime, bandDisplayName, bandColor } from '@/utils/formatting'
+import { timestampMs, formatRelativeTime, bandDisplayName, bandColor, jobDiagnostic } from '@/utils/formatting'
 import { buildSliceView, type SliceJob, type SliceStatus, type SliceView } from '@/utils/slices'
 import SliceList from '@/components/controller/SliceList.vue'
 import FleetOverview from '@/components/controller/FleetOverview.vue'
@@ -714,7 +714,9 @@ const mergedUsers = computed<MergedUser[]>(() => {
       userId,
       activeJobs,
       runningJobs: jobCounts['running'] ?? 0,
-      pendingJobs: (jobCounts['pending'] ?? 0) + (jobCounts['unschedulable'] ?? 0),
+      // 'building' is dispatched but not executing, so it counts as waiting. Without it
+    // Running + Pending would not sum to Active for a job stuck in admission/image pull.
+    pendingJobs: (jobCounts['pending'] ?? 0) + (jobCounts['building'] ?? 0) + (jobCounts['unschedulable'] ?? 0),
       runningTasks: taskCounts['running'] ?? 0,
       totalTasks: Object.values(taskCounts).reduce((a, b) => a + b, 0),
       budgetSpent: budget?.budgetSpent ?? '-',
@@ -1217,8 +1219,8 @@ function sliceIdShort(sliceId?: string): string {
                 </button>
                 <span v-else class="text-text-muted">—</span>
               </td>
-              <td class="px-3 py-2 text-[13px] text-status-warning max-w-md truncate" :title="job.pendingReason ?? ''">
-                {{ job.pendingReason || '-' }}
+              <td class="px-3 py-2 text-[13px] text-status-warning max-w-md truncate" :title="jobDiagnostic(job)">
+                {{ jobDiagnostic(job) || '-' }}
               </td>
               <td class="px-3 py-2 text-[13px] font-mono text-text-secondary">
                 {{ job.submittedAt ? formatRelativeTime(timestampMs(job.submittedAt)) : '-' }}

--- a/lib/iris/dashboard/src/components/controller/JobDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/JobDetail.vue
@@ -12,7 +12,7 @@ import {
   type GetJobStatusResponse, type GetTaskStatusResponse, type ListTasksResponse, type ListJobsResponse,
   type EndpointInfo, type ListEndpointsResponse,
 } from '@/types/rpc'
-import { timestampMs, formatTimestamp, formatDuration, formatRelativeTime, formatBytes, formatCpuMillicores, formatDeviceConfig, bandDisplayName, bandColor } from '@/utils/formatting'
+import { timestampMs, formatTimestamp, formatDuration, formatRelativeTime, formatBytes, formatCpuMillicores, formatDeviceConfig, bandDisplayName, bandColor, jobDiagnostic } from '@/utils/formatting'
 import { decodeArrowIpc } from '@/utils/arrow'
 import { getLeafJobName } from '@/utils/jobTree'
 import { batchSummarySql } from '@/utils/taskStatus'
@@ -446,6 +446,9 @@ const childJobComparator = computed<((a: JobStatus, b: JobStatus) => number) | u
         break
       case 'duration':
         cmp = childJobDurationMs(a) - childJobDurationMs(b)
+        // A job that never started has no duration (0). Order those by how long they
+        // have been waiting rather than leaving them in one arbitrary bucket.
+        if (cmp === 0) cmp = timestampMs(a.submittedAt) - timestampMs(b.submittedAt)
         break
     }
     return cmp * dir
@@ -803,6 +806,8 @@ const filteredTasks = computed(() => {
         break
       case 'duration':
         cmp = taskDurationMs(a) - taskDurationMs(b)
+        // Same as the child-job sort: tasks that never started share duration 0.
+        if (cmp === 0) cmp = timestampMs(a.submittedAt) - timestampMs(b.submittedAt)
         break
     }
     return cmp * dir
@@ -1383,8 +1388,8 @@ async function handleProfile(taskId: string, profilerType: string, format: strin
                   </span>
                 </div>
               </td>
-              <td class="hidden lg:table-cell px-2 sm:px-3 py-2 text-xs text-text-muted max-w-xs truncate" :title="node.job.pendingReason ?? ''">
-                {{ node.job.pendingReason || '—' }}
+              <td class="hidden lg:table-cell px-2 sm:px-3 py-2 text-xs text-text-muted max-w-xs truncate" :title="jobDiagnostic(node.job)">
+                {{ jobDiagnostic(node.job) || '—' }}
               </td>
             </tr>
           </tbody>

--- a/lib/iris/dashboard/src/components/controller/JobsTab.vue
+++ b/lib/iris/dashboard/src/components/controller/JobsTab.vue
@@ -7,7 +7,7 @@ import { useAutoRefresh, DEFAULT_REFRESH_MS } from '@/composables/useAutoRefresh
 import { SEGMENT_COLORS, stateDisplayName } from '@/types/status'
 import type { JobState } from '@/types/status'
 import { LOCAL_CLUSTER, type JobStatus, type JobQuery, type ListJobsResponse } from '@/types/rpc'
-import { timestampMs, formatDuration, formatRelativeTime } from '@/utils/formatting'
+import { timestampMs, formatDuration, formatRelativeTime, jobDiagnostic } from '@/utils/formatting'
 import { flattenLoadedJobTree, getLeafJobName } from '@/utils/jobTree'
 import StatusBadge from '@/components/shared/StatusBadge.vue'
 import EmptyState from '@/components/shared/EmptyState.vue'
@@ -692,9 +692,9 @@ function sortIndicator(field: SortField): string {
           <!-- Diagnostic -->
           <td
             class="hidden lg:table-cell px-2 sm:px-3 py-2 text-xs text-text-muted max-w-xs truncate"
-            :title="node.job.pendingReason ?? ''"
+            :title="jobDiagnostic(node.job)"
           >
-            {{ node.job.pendingReason || '—' }}
+            {{ jobDiagnostic(node.job) || '—' }}
           </td>
         </tr>
       </tbody>

--- a/lib/iris/dashboard/src/components/controller/UsersOverview.vue
+++ b/lib/iris/dashboard/src/components/controller/UsersOverview.vue
@@ -81,7 +81,9 @@ function toRow(summary: UserSummary): UserRow {
     role: summary.role ?? '',
     activeJobs,
     runningJobs: jobCounts['running'] ?? 0,
-    pendingJobs: (jobCounts['pending'] ?? 0) + (jobCounts['unschedulable'] ?? 0),
+    // 'building' is dispatched but not executing, so it counts as waiting. Without it
+    // Running + Pending would not sum to Active for a job stuck in admission/image pull.
+    pendingJobs: (jobCounts['pending'] ?? 0) + (jobCounts['building'] ?? 0) + (jobCounts['unschedulable'] ?? 0),
     runningTasks: taskCounts['running'] ?? 0,
     totalTasks: Object.values(taskCounts).reduce((a, b) => a + b, 0),
     starred: starredUsers.value.has(summary.user),

--- a/lib/iris/dashboard/src/utils/formatting.ts
+++ b/lib/iris/dashboard/src/utils/formatting.ts
@@ -13,6 +13,17 @@ export function formatTimestamp(ts?: ProtoTimestamp): string {
   return new Date(ms).toLocaleString()
 }
 
+/**
+ * Why a job is not progressing, for a Diagnostic column.
+ *
+ * `pendingReason` is scheduler diagnostics and is only populated while PENDING, so a
+ * BUILDING job — dispatched, waiting on admission or an image pull — has its only
+ * explanation in `statusMessage` (the backend's one-liner). Mirrors `cli/job.py`.
+ */
+export function jobDiagnostic(job: { pendingReason?: string; statusMessage?: string }): string {
+  return job.pendingReason || job.statusMessage || ''
+}
+
 /** Format epoch ms as relative time ("5s ago", "3m ago", etc). */
 export function formatRelativeTime(ms: number): string {
   if (!ms) return '-'

--- a/lib/iris/docs/task-states.md
+++ b/lib/iris/docs/task-states.md
@@ -340,8 +340,15 @@ Job state is computed from task state counts in `_compute_job_state()`:
 2. **FAILED**: Count of `TASK_STATE_FAILED` tasks exceeds `max_task_failures`.
 3. **UNSCHEDULABLE**: Any task is `TASK_STATE_UNSCHEDULABLE`.
 4. **KILLED**: Any task is `TASK_STATE_KILLED` (and job is not already terminal).
-5. **RUNNING**: Any task is `ASSIGNED`, `BUILDING`, or `RUNNING`.
-6. **PENDING**: Default (no tasks have started).
+5. **RUNNING**: Any task is `RUNNING`, or the job has already started (its
+   `started_at` is set, so a retry bounce or re-dispatch keeps it RUNNING).
+6. **BUILDING**: Any task is `ASSIGNED` or `BUILDING` and the job has never
+   started. A gang awaiting Kueue admission sits here, with no `started_at` and
+   so no elapsed time.
+7. **PENDING**: Default (no tasks have started).
 
 The ordering matters -- earlier rules take priority. A job with one succeeded
-task and one failed task (beyond tolerance) is `FAILED`, not `RUNNING`.
+task and one failed task (beyond tolerance) is `FAILED`, not `RUNNING`. Rule 5
+precedes rule 6 for the same reason: `started_at` is first-wins, so a started job
+that dropped back to `BUILDING` would keep its original stamp and report a
+duration that never stops climbing. `BUILDING` therefore implies no `started_at`.

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -1184,7 +1184,7 @@ def list_jobs(ctx, state: str | None, prefix: str | None, limit: int) -> None:
         state_name = j.state.value
         submitted = j.submitted_at.as_formatted_date() if j.submitted_at is not None else "-"
 
-        reason = j.error_message or j.pending_reason or ""
+        reason = j.error_message or j.pending_reason or j.status_message or ""
         if reason:
             has_reasons = True
             reason = (reason[:60] + "...") if len(reason) > 63 else reason

--- a/lib/iris/src/iris/cluster/controller/ops/task.py
+++ b/lib/iris/src/iris/cluster/controller/ops/task.py
@@ -115,7 +115,7 @@ def assign(
                 worker=ww,
             )
         )
-    writes.mark_jobs_running(cur, jobs_to_update, now_ms)
+    writes.mark_jobs_building(cur, jobs_to_update)
 
 
 def apply_dispatch_updates(

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -141,6 +141,8 @@ class TaskJobSummary:
     failure_count: int = 0
     preemption_count: int = 0
     task_state_counts: dict[int, int] = field(default_factory=dict)
+    # One task's backend status one-liner, standing in for the job's.
+    status_message: str = ""
 
 
 @dataclass(frozen=True)
@@ -412,6 +414,46 @@ _TASK_SUMMARIES_FOR_JOBS_STMT = (
     .group_by(tasks_table.c.job_id, tasks_table.c.state)
 )
 
+# Only a waiting task's message is current: a terminal row keeps whatever it last
+# said, and a PENDING one was never dispatched.
+_WAITING_TASK_STATES = (job_pb2.TASK_STATE_ASSIGNED, job_pb2.TASK_STATE_BUILDING)
+
+# A second statement, not a column on the aggregate above: ``status_message`` is not in
+# ``idx_tasks_job_state (job_id, state)``, so selecting it there costs that query its
+# covering scan — ~2.4x on a 1000-job page, on every dashboard refresh and federation sync.
+_WAITING_STATUS_MESSAGES_STMT = (
+    select(
+        tasks_table.c.job_id,
+        tasks_table.c.status_message,
+        func.count().label("cnt"),
+    )
+    .where(
+        tasks_table.c.job_id.in_(bindparam("job_ids", expanding=True)),
+        tasks_table.c.state.in_(_WAITING_TASK_STATES),
+        tasks_table.c.status_message.is_not(None),
+        tasks_table.c.status_message != "",
+    )
+    .group_by(tasks_table.c.job_id, tasks_table.c.status_message)
+)
+
+
+def _rarest_status_message(tx: Tx, job_ids: list[JobName]) -> dict[JobName, str]:
+    """Return each job's least common backend message across its waiting tasks.
+
+    Rarest wins because the odd one out is the actionable one: seven gated pods and one
+    that cannot pull its image reports the ImagePullBackOff, not the seven siblings
+    saying the queue is full. Ties break on the text, so the answer is stable per tick.
+    """
+    if not job_ids:
+        return {}
+    best: dict[JobName, tuple[int, str]] = {}
+    for row in tx.execute(_WAITING_STATUS_MESSAGES_STMT, {"job_ids": job_ids}).all():
+        candidate = (int(row.cnt), row.status_message)
+        current = best.get(row.job_id)
+        if current is None or candidate < current:
+            best[row.job_id] = candidate
+    return {job_id: message for job_id, (_, message) in best.items()}
+
 
 def task_summaries_for_jobs(
     tx: Tx,
@@ -443,11 +485,20 @@ def task_summaries_for_jobs(
             completed_count=prev.completed_count + (cnt if state in _COMPLETED_TASK_STATES else 0),
             task_state_counts={**prev.task_state_counts, state: cnt},
         )
+    # federation_sync calls this once per job, so asking on a job whose histogram shows
+    # nothing waiting would be a round trip per received job that can only return empty.
+    waiting_ids = [
+        jid
+        for jid, summary in summaries.items()
+        if any(summary.task_state_counts.get(task_state, 0) > 0 for task_state in _WAITING_TASK_STATES)
+    ]
+    messages = _rarest_status_message(tx, waiting_ids)
     return {
         jid: replace(
             summary,
             failure_count=counts.get(jid, AttemptCounts()).failure_count,
             preemption_count=counts.get(jid, AttemptCounts()).preemption_count,
+            status_message=messages.get(jid, ""),
         )
         for jid, summary in summaries.items()
     }

--- a/lib/iris/src/iris/cluster/controller/reconcile/job.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/job.py
@@ -19,7 +19,9 @@ def recompute_state(state: Overlay, job_id: JobName) -> int | None:
 
     Returns the new state (which may equal current). Returns ``None`` when
     the job basis is not in the snapshot (out-of-slice). Records a job-state
-    delta when the state changes.
+    delta when the state changes. The first transition into RUNNING is the job's only
+    ``started_at`` stamp, and the RUNNING branches are checked first, so
+    ``JOB_STATE_BUILDING`` implies ``started_at IS NULL`` — a BUILDING job has no clock.
     """
     basis = state.job_basis(job_id)
     if basis is None:
@@ -78,14 +80,18 @@ def recompute_state(state: Overlay, job_id: JobName) -> int | None:
         # terminal a lone tolerated FAILED still fails the job.) Without this
         # branch the job falls through to the started_at branch and hangs RUNNING.
         new_state = job_pb2.JOB_STATE_FAILED
-    elif (
-        counts.get(job_pb2.TASK_STATE_ASSIGNED, 0) > 0
-        or counts.get(job_pb2.TASK_STATE_BUILDING, 0) > 0
-        or counts.get(job_pb2.TASK_STATE_RUNNING, 0) > 0
-    ):
+    elif counts.get(job_pb2.TASK_STATE_RUNNING, 0) > 0:
         new_state = job_pb2.JOB_STATE_RUNNING
     elif basis.started_at is not None:
+        # A job that has genuinely started stays RUNNING across retries and re-dispatch.
+        # Ordered above BUILDING because ``started_at`` is first-wins (commit.py): demoting
+        # a re-dispatching job would keep its stamp and render the climbing duration that
+        # BUILDING exists to prevent.
         new_state = job_pb2.JOB_STATE_RUNNING
+    elif counts.get(job_pb2.TASK_STATE_ASSIGNED, 0) > 0 or counts.get(job_pb2.TASK_STATE_BUILDING, 0) > 0:
+        # Dispatched, nothing executing, never started. A gang the queue cannot admit sits
+        # here; calling it RUNNING reported a run that never began, clocked from dispatch.
+        new_state = job_pb2.JOB_STATE_BUILDING
     elif total > 0:
         new_state = job_pb2.JOB_STATE_PENDING
     if new_state == current_state:

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -700,14 +700,14 @@ def _clamp_int32(value: int, *, job_id: JobName, field: str) -> int:
     return value
 
 
-def _job_status_counts(
+def _job_status_from_summary(
     summary: TaskJobSummary | None, job_id: JobName, *, pre_sync_task_count: int = 0
 ) -> dict[str, Any]:
-    """Return the clamped int32 counter fields for a ``JobStatus``.
+    """Return the ``JobStatus`` fields derived from a job's task summary.
 
-    Spread into ``JobStatus(...)`` as ``**_job_status_counts(summary, job_id)``.
+    Spread into ``JobStatus(...)`` as ``**_job_status_from_summary(summary, job_id)``.
     A ``None`` summary collapses to all-zero counters (no log noise); a real
-    summary runs each field through ``_clamp_int32`` so 64-bit aggregates
+    summary runs each counter through ``_clamp_int32`` so 64-bit aggregates
     never trip the proto encoder.
 
     ``pre_sync_task_count`` is the requested replica count of a federated job
@@ -727,6 +727,7 @@ def _job_status_counts(
             task_state_friendly(state): _clamp_int32(count, job_id=job_id, field=f"task_state_counts[{state}]")
             for state, count in s.task_state_counts.items()
         },
+        "status_message": s.status_message,
     }
 
 
@@ -1963,7 +1964,7 @@ class ControllerServiceImpl:
             backend_id=job.backend_id or "",
             cluster=job.cluster,
             peer_status=peer_status,
-            **_job_status_counts(
+            **_job_status_from_summary(
                 summary, job.job_id, pre_sync_task_count=job.num_tasks if is_federated(job.cluster) else 0
             ),
         )
@@ -2111,7 +2112,7 @@ class ControllerServiceImpl:
             backend_id=j.backend_id or "",
             cluster=j.cluster,
             peer_status=peer_status,
-            **_job_status_counts(
+            **_job_status_from_summary(
                 task_summary, j.job_id, pre_sync_task_count=j.num_tasks if is_federated(j.cluster) else 0
             ),
         )
@@ -3467,7 +3468,7 @@ class ControllerServiceImpl:
             backend_id=job.backend_id or "",
             cluster=job.cluster,
             resources=resource_spec_from_job_row(job),
-            **_job_status_counts(summaries.get(job.job_id), job.job_id),
+            **_job_status_from_summary(summaries.get(job.job_id), job.job_id),
         )
         if job.started_at_ms:
             status.started_at.CopyFrom(timestamp_to_proto(job.started_at_ms))

--- a/lib/iris/src/iris/cluster/controller/writes.py
+++ b/lib/iris/src/iris/cluster/controller/writes.py
@@ -502,10 +502,11 @@ def record_federation_change(
 
 
 @writes_to(jobs_table)
-def mark_jobs_running(tx: Tx, job_ids: Iterable[JobName], now_ms: int) -> None:
-    """Promote each PENDING job in ``job_ids`` to RUNNING, stamping ``started_at_ms``.
+def mark_jobs_building(tx: Tx, job_ids: Iterable[JobName]) -> None:
+    """Promote each PENDING job in ``job_ids`` to BUILDING. Non-PENDING jobs keep their state.
 
-    Non-PENDING jobs keep their state; ``started_at_ms`` is set only if still NULL (first assignment wins).
+    Dispatch is not a start: ``started_at_ms`` stays NULL until a task reports RUNNING,
+    stamped by ``reconcile.job.recompute_state``.
     """
     for chunk in batched(job_ids, _ID_CHUNK_SIZE):
         tx.execute(
@@ -513,10 +514,9 @@ def mark_jobs_running(tx: Tx, job_ids: Iterable[JobName], now_ms: int) -> None:
             .where(jobs_table.c.job_id.in_(chunk))
             .values(
                 state=case(
-                    (jobs_table.c.state == job_pb2.JOB_STATE_PENDING, job_pb2.JOB_STATE_RUNNING),
+                    (jobs_table.c.state == job_pb2.JOB_STATE_PENDING, job_pb2.JOB_STATE_BUILDING),
                     else_=jobs_table.c.state,
                 ),
-                started_at_ms=func.coalesce(jobs_table.c.started_at_ms, now_ms),
             )
         )
 

--- a/lib/iris/tests/cli/test_job.py
+++ b/lib/iris/tests/cli/test_job.py
@@ -11,10 +11,12 @@ from iris.cli.job import (
     cancel,
     complete,
     describe,
+    list_jobs,
     run,
     wait,
 )
 from iris.client.client import IrisClient
+from iris.client.workload_codec import job_status_from_proto
 from iris.cluster.config import IrisClusterConfig, ScaleGroupConfig, WorkerSettings
 from iris.cluster.constraints import (
     CLUSTER_CONSTRAINT_KEY,
@@ -508,6 +510,28 @@ def test_job_describe_cli_shows_active_backend_status(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert 'Kueue: excluded: resource "memory": 32' in result.output
+
+
+def test_job_list_cli_reports_why_a_building_job_is_waiting(monkeypatch):
+    """A BUILDING job has no pending_reason, so its backend status fills the REASON column."""
+    job = job_status_from_proto(
+        _job_pb2.JobStatus(
+            job_id="/u/gang",
+            state=_job_pb2.JOB_STATE_BUILDING,
+            status_message="SchedulingGated: waiting for Kueue quota",
+        )
+    )
+
+    class FakeClient:
+        def list_jobs(self, **_kwargs):
+            return [job]
+
+    monkeypatch.setattr("iris.cli.job._remote_client", lambda _ctx: FakeClient())
+    result = CliRunner().invoke(list_jobs, [], obj={"controller_url": "http://controller.test"})
+
+    assert result.exit_code == 0, result.output
+    assert "REASON" in result.output
+    assert "SchedulingGated: waiting for Kueue quota" in result.output
 
 
 class _JobActionClusterClient:

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -57,14 +57,14 @@ from iris.testing.controller import (
     query_tasks_with_attempts as _query_tasks_with_attempts,
 )
 from iris.testing.controller_state import ControllerTestState, submit_job_in_tx
-from iris.testing.transitions import WorkerTaskUpdates, apply_task_observations
+from iris.testing.transitions import WorkerTaskUpdates, apply_task_observations, commit_dispatch_updates
 from iris.time_proto import timestamp_to_proto
 from rigging.auth import StaticTokenProvider
 from rigging.credentials import ClientCredentials
 from rigging.server_auth import RequestAuthPolicy
 from rigging.testing import MockVerifier
 from rigging.timing import Timestamp
-from sqlalchemy import func, insert, select
+from sqlalchemy import event, func, insert, select
 from sqlalchemy import update as sa_update
 from starlette.testclient import TestClient
 
@@ -605,6 +605,186 @@ def test_get_job_status_returns_retry_info(client, state, job_request):
     assert job_status["preemptionCount"] == 1
     assert job_status["state"] == "JOB_STATE_RUNNING"
     assert int(job_status["startedAt"]["epochMs"]) == 3000
+
+
+def test_get_job_status_surfaces_the_backend_reason_for_a_building_job(client, state, job_request):
+    """A dispatched-but-unstarted job reads BUILDING, carries the backend's reason, and has no start time.
+
+    The reason is the task's ``status_message`` (here Kueue's admission verdict for a
+    gated pod), lifted onto the job so an operator sees why it is waiting without
+    opening a task.
+    """
+    wid = register_worker(state, "w1", "h1:8080", make_worker_metadata())
+    job_id = submit_job(state, "gated-job", job_request)
+    task_id = job_id.task(0)
+
+    with state._db.transaction() as cur:
+        ops.task.assign(cur, [Assignment(task_id=task_id, worker_id=wid)], health=state._health)
+    # The cluster-backend (direct dispatch) path: only it carries status_message.
+    with state._db.transaction() as cur:
+        commit_dispatch_updates(
+            cur,
+            [
+                TaskUpdate(
+                    task_id=task_id,
+                    attempt_id=0,
+                    new_state=job_pb2.TASK_STATE_BUILDING,
+                    status_message="SchedulingGated: waiting for Kueue quota",
+                )
+            ],
+            now=Timestamp.now(),
+        )
+
+    job_status = rpc_post(client, "GetJobStatus", {"jobId": job_id.to_wire()})["job"]
+
+    assert job_status["state"] == "JOB_STATE_BUILDING"
+    assert job_status["statusMessage"] == "SchedulingGated: waiting for Kueue quota"
+    assert "startedAt" not in job_status
+
+
+def _summaries_counting_message_queries(state, job_ids):
+    """``task_summaries_for_jobs`` plus how many times the backend-message query ran.
+
+    The narrow message statement is the only one grouping on ``status_message``; the
+    per-job histogram groups on ``state``.
+    """
+    seen: list[str] = []
+
+    def _record(_conn, _cursor, statement, _parameters, _context, _executemany):
+        if "GROUP BY tasks.job_id, tasks.status_message" in statement:
+            seen.append(statement)
+
+    engine = state._db.sa_read_engine
+    event.listen(engine, "before_cursor_execute", _record)
+    try:
+        with state._db.read_snapshot() as tx:
+            summaries = reads.task_summaries_for_jobs(tx, list(job_ids))
+    finally:
+        event.remove(engine, "before_cursor_execute", _record)
+    return summaries, len(seen)
+
+
+def test_task_summaries_query_backend_messages_only_for_jobs_with_a_waiting_task(state, job_request):
+    """The message query is skipped when no task could carry one.
+
+    federation_sync calls this once per job, so a query that can only come back empty
+    costs one round trip per received job per sync. An empty result and a skipped query
+    look identical in the returned summary, so count executions instead — and assert
+    the waiting case *does* run it, or a wrong match string would pass both ways.
+    """
+    wid = register_worker(state, "w1", "h1:8080", make_worker_metadata())
+    waiting_id = submit_job(state, "waiting", job_request)
+    running_id = submit_job(state, "running", job_request)
+
+    with state._db.transaction() as cur:
+        ops.task.assign(
+            cur,
+            [Assignment(task_id=jid.task(0), worker_id=wid) for jid in (waiting_id, running_id)],
+            health=state._health,
+        )
+    with state._db.transaction() as cur:
+        commit_dispatch_updates(
+            cur,
+            [
+                TaskUpdate(
+                    task_id=waiting_id.task(0),
+                    attempt_id=0,
+                    new_state=job_pb2.TASK_STATE_BUILDING,
+                    status_message="SchedulingGated: waiting for Kueue quota",
+                ),
+                TaskUpdate(task_id=running_id.task(0), attempt_id=0, new_state=job_pb2.TASK_STATE_RUNNING),
+            ],
+            now=Timestamp.now(),
+        )
+
+    waiting_summaries, waiting_queries = _summaries_counting_message_queries(state, [waiting_id])
+    running_summaries, running_queries = _summaries_counting_message_queries(state, [running_id])
+
+    assert waiting_summaries[waiting_id].status_message == "SchedulingGated: waiting for Kueue quota"
+    assert waiting_queries == 1, "a job with a BUILDING task must be asked about"
+    assert running_summaries[running_id].status_message == ""
+    assert running_queries == 0, "a job with nothing waiting must not run the message query"
+
+
+def test_get_job_status_reports_the_rarest_backend_reason_not_the_loudest(client, state, job_request):
+    """One bad image among seven gated pods is what the operator needs to see.
+
+    The odd message out is the actionable one; the seven siblings only report that the
+    queue is full. A lexicographic pick would return "SchedulingGated" here, since it
+    sorts above "ImagePullBackOff" — the precise misdiagnosis this field exists to
+    prevent.
+    """
+    wid = register_worker(state, "w1", "h1:8080", make_worker_metadata())
+    job_request.replicas = 8
+    job_id = submit_job(state, "gang", job_request)
+    task_ids = [job_id.task(i) for i in range(8)]
+
+    with state._db.transaction() as cur:
+        ops.task.assign(cur, [Assignment(task_id=tid, worker_id=wid) for tid in task_ids], health=state._health)
+    with state._db.transaction() as cur:
+        commit_dispatch_updates(
+            cur,
+            [
+                TaskUpdate(
+                    task_id=tid,
+                    attempt_id=0,
+                    new_state=job_pb2.TASK_STATE_BUILDING,
+                    status_message=(
+                        "ImagePullBackOff: back-off pulling image"
+                        if i == 0
+                        else "SchedulingGated: waiting for Kueue quota"
+                    ),
+                )
+                for i, tid in enumerate(task_ids)
+            ],
+            now=Timestamp.now(),
+        )
+
+    job_status = rpc_post(client, "GetJobStatus", {"jobId": job_id.to_wire()})["job"]
+
+    assert job_status["state"] == "JOB_STATE_BUILDING"
+    assert job_status["statusMessage"] == "ImagePullBackOff: back-off pulling image"
+
+
+def test_get_job_status_ignores_a_status_message_left_on_a_terminal_task(client, state, job_request):
+    """A finished task's last message is stale and must not become the job's.
+
+    The backend clears status_message when a pod starts or ends, but a row that went
+    terminal without a clearing update keeps its old text. Only ASSIGNED/BUILDING tasks
+    are consulted, so the stale row cannot speak for the job.
+    """
+    wid = register_worker(state, "w1", "h1:8080", make_worker_metadata())
+    job_id = submit_job(state, "finished", job_request)
+    task_id = job_id.task(0)
+
+    with state._db.transaction() as cur:
+        ops.task.assign(cur, [Assignment(task_id=task_id, worker_id=wid)], health=state._health)
+    with state._db.transaction() as cur:
+        commit_dispatch_updates(
+            cur,
+            [
+                TaskUpdate(
+                    task_id=task_id,
+                    attempt_id=0,
+                    new_state=job_pb2.TASK_STATE_BUILDING,
+                    status_message="SchedulingGated: waiting for Kueue quota",
+                )
+            ],
+            now=Timestamp.now(),
+        )
+    # status_message=None leaves the column untouched, so the row goes terminal still
+    # carrying the gated text.
+    with state._db.transaction() as cur:
+        commit_dispatch_updates(
+            cur,
+            [TaskUpdate(task_id=task_id, attempt_id=0, new_state=job_pb2.TASK_STATE_SUCCEEDED)],
+            now=Timestamp.now(),
+        )
+
+    job_status = rpc_post(client, "GetJobStatus", {"jobId": job_id.to_wire()})["job"]
+
+    assert job_status["state"] == "JOB_STATE_SUCCEEDED"
+    assert job_status.get("statusMessage", "") == ""
 
 
 def test_get_job_status_returns_original_request(client, state):

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -663,6 +663,93 @@ def test_max_task_failures_tolerance(state):
     assert _query_job(state, job.job_id).state == job_pb2.JOB_STATE_FAILED
 
 
+def test_dispatched_gang_that_never_starts_is_building_with_no_start_time(state):
+    """Tasks handed to a backend but not executing leave the job BUILDING and unstamped.
+
+    Kueue admits a gang all-or-nothing, so an unadmittable gang sits ASSIGNED for as
+    long as the queue is full. Reporting RUNNING with a dispatch-time ``started_at``
+    there showed operators a nine-hour run that had never begun.
+    """
+    worker_id = register_worker(state, "w1", "host:8080", make_worker_metadata())
+    tasks = submit_job(state, "gang", make_job_request("gang", replicas=2))
+    job_id = JobName.root("test-user", "gang")
+
+    with state._db.transaction() as cur:
+        ops.task.assign(
+            cur,
+            [Assignment(task_id=task.task_id, worker_id=worker_id) for task in tasks],
+            health=state._health,
+        )
+
+    for task in tasks:
+        assert _query_task(state, task.task_id).state == job_pb2.TASK_STATE_ASSIGNED
+    job = _query_job(state, job_id)
+    assert job.state == job_pb2.JOB_STATE_BUILDING
+    assert job.started_at_ms is None, "dispatch is not a start"
+
+
+def test_first_running_task_starts_the_job_and_its_clock(state):
+    """The job leaves BUILDING and gets its ``started_at`` when a task reports RUNNING."""
+    worker_id = register_worker(state, "w1", "host:8080", make_worker_metadata())
+    tasks = submit_job(state, "gang", make_job_request("gang", replicas=2))
+    job_id = JobName.root("test-user", "gang")
+
+    with state._db.transaction() as cur:
+        ops.task.assign(
+            cur,
+            [Assignment(task_id=task.task_id, worker_id=worker_id) for task in tasks],
+            health=state._health,
+        )
+    assert _query_job(state, job_id).state == job_pb2.JOB_STATE_BUILDING
+
+    first = _query_task(state, tasks[0].task_id)
+    with state._db.transaction() as cur:
+        apply_task_observations(
+            cur,
+            [
+                WorkerTaskUpdates(
+                    worker_id=worker_id,
+                    updates=[
+                        TaskUpdate(
+                            task_id=first.task_id,
+                            attempt_id=first.current_attempt_id,
+                            new_state=job_pb2.TASK_STATE_RUNNING,
+                        )
+                    ],
+                )
+            ],
+            health=state._health,
+            now=Timestamp.now(),
+        )
+
+    job = _query_job(state, job_id)
+    assert job.state == job_pb2.JOB_STATE_RUNNING
+    assert job.started_at_ms is not None
+
+
+def test_job_cancelled_while_building_goes_terminal_without_a_start_time(state):
+    """A gang killed before it ran is terminal with ``finished_at`` and no ``started_at``."""
+    worker_id = register_worker(state, "w1", "host:8080", make_worker_metadata())
+    tasks = submit_job(state, "gang", make_job_request("gang", replicas=2))
+    job_id = JobName.root("test-user", "gang")
+
+    with state._db.transaction() as cur:
+        ops.task.assign(
+            cur,
+            [Assignment(task_id=task.task_id, worker_id=worker_id) for task in tasks],
+            health=state._health,
+        )
+    assert _query_job(state, job_id).state == job_pb2.JOB_STATE_BUILDING
+
+    with state._db.transaction() as cur:
+        ops.job.cancel(cur, job_id=job_id, reason="never admitted")
+
+    job = _query_job(state, job_id)
+    assert job.state == job_pb2.JOB_STATE_KILLED
+    assert job.started_at_ms is None
+    assert job.finished_at_ms is not None
+
+
 def test_coscheduled_crash_loop_fails_on_cumulative_budget(state):
     """A coscheduled gang crash-looping across rounds fails on the cumulative budget.
 
@@ -3849,11 +3936,13 @@ def _recompute_snapshot(
     task_states: list[int],
     max_task_failures: int,
     failure_counts: list[int] | None = None,
+    started_at: Timestamp | None = Timestamp.from_ms(500),
 ):
     """A RUNNING job snapshot whose tasks carry ``task_states``.
 
-    ``started_at`` is set on the basis so a job that does not otherwise finalize
-    falls through to the RUNNING strand the #5 fix closes. ``job_basis`` rebuilds
+    ``started_at`` defaults to a set stamp so a job that does not otherwise finalize
+    falls through to the RUNNING strand the #5 fix closes; pass ``None`` to model a
+    job that has never had a running task. ``job_basis`` rebuilds
     the task histogram and cumulative failure count from ``all_tasks_by_job``, so
     both live there. ``failure_counts`` defaults to one charged failure per task
     currently in FAILED; pass it explicitly to model failures that have already
@@ -3864,7 +3953,7 @@ def _recompute_snapshot(
     basis = JobStateBasis(
         job_id=job_id,
         state=job_pb2.JOB_STATE_RUNNING,
-        started_at=Timestamp.from_ms(500),
+        started_at=started_at,
         max_task_failures=max_task_failures,
         task_state_counts={},
         total_failures=sum(failure_counts),
@@ -3975,6 +4064,57 @@ def test_recompute_keeps_job_running_within_budget(task_states, failure_counts, 
     new_state = recompute_state(ws, jid)
 
     assert new_state == job_pb2.JOB_STATE_RUNNING
+
+
+@pytest.mark.parametrize(
+    "task_states",
+    [
+        [job_pb2.TASK_STATE_ASSIGNED, job_pb2.TASK_STATE_ASSIGNED],
+        [job_pb2.TASK_STATE_BUILDING, job_pb2.TASK_STATE_BUILDING],
+        [job_pb2.TASK_STATE_SUCCEEDED, job_pb2.TASK_STATE_ASSIGNED],
+    ],
+    ids=["all-assigned", "all-building", "one-done-one-waiting"],
+)
+def test_recompute_reports_a_never_started_job_with_dispatched_tasks_as_building(task_states):
+    """RUNNING needs a task that is actually running; dispatched-but-never-started is BUILDING.
+
+    The basis carries no ``started_at``, which is what distinguishes this from a job
+    that ran and is re-dispatching. The recorded delta must not stamp one either —
+    BUILDING implies no clock.
+    """
+    jid = JobName.from_wire("/u/gated")
+    ws = Overlay(_recompute_snapshot(jid, task_states, max_task_failures=0, started_at=None))
+
+    new_state = recompute_state(ws, jid)
+
+    assert new_state == job_pb2.JOB_STATE_BUILDING
+    assert ws.effects.jobs[jid].state == job_pb2.JOB_STATE_BUILDING
+    assert ws.effects.jobs[jid].started_at is None
+    assert ws.effects.jobs[jid].finished_at is None
+
+
+@pytest.mark.parametrize(
+    "task_states",
+    [
+        [job_pb2.TASK_STATE_ASSIGNED, job_pb2.TASK_STATE_ASSIGNED],
+        [job_pb2.TASK_STATE_BUILDING, job_pb2.TASK_STATE_BUILDING],
+        [job_pb2.TASK_STATE_PENDING, job_pb2.TASK_STATE_PENDING],
+    ],
+    ids=["redispatched", "rebuilding", "requeued"],
+)
+def test_recompute_keeps_a_job_that_already_ran_running_while_it_redispatches(task_states):
+    """A started job does not fall back to BUILDING when its tasks bounce.
+
+    ``started_at`` is first-wins, so a demotion here would pair BUILDING with a stamp
+    from the original run and render as a duration that never stops climbing.
+    """
+    jid = JobName.from_wire("/u/restarted")
+    ws = Overlay(_recompute_snapshot(jid, task_states, max_task_failures=0))
+
+    new_state = recompute_state(ws, jid)
+
+    assert new_state == job_pb2.JOB_STATE_RUNNING
+    assert jid not in ws.effects.jobs, "no state change, so no job row delta"
 
 
 def test_pick_earliest_task_error_reports_first_failed_task():

--- a/scripts/ci/collect_perf_metrics.py
+++ b/scripts/ci/collect_perf_metrics.py
@@ -377,10 +377,14 @@ def compute_stage_wall_seconds(
     Returns ``(stage_wall_seconds, cached_steps)``. Steps in ``EXPECTED_STEPS``
     that don't appear in the tree are reported with ``0.0`` and added to
     ``cached_steps`` — those steps always run unless the artifact already
-    exists, so absence implies a cache hit.
+    exists, so absence implies a cache hit. A step whose job *is* in the tree but
+    never started (dispatched, then killed or failed before any task ran, so
+    ``started_at`` is unset) reports ``0.0`` without being called cached — it did
+    not cache, it did no work.
     """
     parent_depth = _job_depth(parent_id)
     durations: dict[str, float] = {}
+    present_steps: set[str] = set()
 
     for job in jobs:
         job_id = job.get("job_id") or ""
@@ -392,15 +396,16 @@ def compute_stage_wall_seconds(
         for prefix, step in _STEP_PREFIXES.items():
             if not name.startswith(prefix):
                 continue
+            present_steps.add(step)
             start_ms = int((job.get("started_at") or {}).get("epoch_ms") or 0)
             end_ms = int((job.get("finished_at") or {}).get("epoch_ms") or 0)
             if start_ms and end_ms and end_ms > start_ms:
                 durations[step] = durations.get(step, 0.0) + (end_ms - start_ms) / 1000.0
             break
 
-    cached_steps = sorted(s for s in EXPECTED_STEPS if s not in durations)
-    for s in cached_steps:
-        durations[s] = 0.0
+    cached_steps = sorted(s for s in EXPECTED_STEPS if s not in present_steps)
+    for s in EXPECTED_STEPS:
+        durations.setdefault(s, 0.0)
     return durations, cached_steps
 
 


### PR DESCRIPTION
A job flips to `RUNNING` and stamps `started_at` when its tasks are dispatched, not when one starts. A gang the queue cannot admit therefore reports a run in progress with a climbing clock — one that asked for 128 CPUs on 127,960-millicore nodes read `RUNNING` for 24 hours before failing as an execution timeout. It now reads `BUILDING` with no start time and carries the backend's reason for waiting. No proto, schema, or migration change, and nothing terminates.

Two design decisions worth stating. `RUNNING` is checked before `BUILDING`, so a job that genuinely started stays `RUNNING` across retries and re-dispatch; `started_at` is first-wins, so the other order would let a re-dispatching job keep its old stamp and render the same climbing clock. And a job's reason is the least common message across its waiting tasks, because the odd one out is the actionable one — seven gated pods and one that cannot pull its image should report the `ImagePullBackOff`.

- `mark_jobs_running` becomes `mark_jobs_building` and no longer stamps `started_at` at dispatch.
- `recompute_state` requires a running task for `RUNNING`; dispatched-but-never-started is `BUILDING`.
- `JobStatus.status_message` carries the rarest backend message across a job's waiting tasks, read by a separate query so the main summary aggregate keeps its covering index.
- `iris job list` falls back to that message for its REASON column, and the dashboard's Diagnostic columns do the same.
- The dashboard's Running and Pending counts account for `BUILDING`, so they reconcile with Active again.
- `collect_perf_metrics` infers a cache hit from a step's absence rather than from a missing duration.
- The child-job and task duration comparators tie-break on `submittedAt` when a row has no start time.
- `docs/task-states.md` and `README.md` describe the new rule.
