### PR TITLE
Point infra hero graphs at the 535B W&B report

### DIFF
--- a/infra/grafana/src/wandb_source.py
+++ b/infra/grafana/src/wandb_source.py
@@ -23,8 +23,10 @@ from graphql_source import graphql_data
 _GRAPHQL_URL = "https://api.wandb.ai/graphql"
 _ENTITY = "marin-community"
 _PROJECT = "marin_moe"
-_REPORT_VIEW_ID = "VmlldzoxNzM1OTMxMQ=="
-_REPORT_URL = "https://wandb.ai/marin-community/marin_moe/reports/67B-A2B-MoE-on-10T-tokens--VmlldzoxNzM1OTMxMQ"
+_REPORT_VIEW_ID = "VmlldzoxNzc2MDM5Ng=="
+_REPORT_URL = (
+    "https://wandb.ai/marin-community/marin_moe/reports/535B-A23B-18T-Token-Hero-Run-Scaling-Ladder--VmlldzoxNzc2MDM5Ng"
+)
 _TOTAL_TOKENS_KEY = "throughput/total_tokens"
 _SAMPLES = 800
 

--- a/infra/grafana/tests/fixture_bridge.py
+++ b/infra/grafana/tests/fixture_bridge.py
@@ -81,7 +81,7 @@ def _builds() -> list[dict]:
 def _wandb(chart: str) -> list[dict]:
     titles = {"train-loss": "Train cross-entropy loss", "paloma-macro-loss": "Paloma macro loss", "mfu": "MFU (%)"}
     rows = []
-    for run_index, run in enumerate(("67b-a2b-10t", "67b-a2b-resume")):
+    for run_index, run in enumerate(("hero-12d8b6f0-dee637",)):
         for index in range(40):
             tokens = (index + 1) * 250_000_000_000
             if chart == "mfu":
@@ -94,10 +94,10 @@ def _wandb(chart: str) -> list[dict]:
                     "run": run,
                     "tokens": tokens,
                     "value": value,
-                    "report_title": "67B-A2B MoE on 10T tokens",
+                    "report_title": "535B-A23B 18T Token Hero Run + Scaling Ladder",
                     "report_url": (
                         "https://wandb.ai/marin-community/marin_moe/reports/"
-                        "67B-A2B-MoE-on-10T-tokens--VmlldzoxNzM1OTMxMQ"
+                        "535B-A23B-18T-Token-Hero-Run-Scaling-Ladder--VmlldzoxNzc2MDM5Ng"
                     ),
                 }
             )

--- a/infra/grafana/tests/test_sources.py
+++ b/infra/grafana/tests/test_sources.py
@@ -322,7 +322,8 @@ def test_wandb_points_follow_report_runset_and_drop_null_metric_rows():
             "value": 0.42,
             "report_title": "Hero report",
             "report_url": (
-                "https://wandb.ai/marin-community/marin_moe/reports/67B-A2B-MoE-on-10T-tokens--VmlldzoxNzM1OTMxMQ"
+                "https://wandb.ai/marin-community/marin_moe/reports/"
+                "535B-A23B-18T-Token-Hero-Run-Scaling-Ladder--VmlldzoxNzc2MDM5Ng"
             ),
         }
     ]


### PR DESCRIPTION
Point the infra dashboard train-loss, Paloma macro-loss, and MFU panels at the 535B-A23B hero-run report.

The bridge reads the first panel grid, which pins `hero-12d8b6f0-dee637`. The report supplies all three metrics against `throughput/total_tokens`, so the panel query format does not change.
