### PR TITLE
grug: share the ep hero recipe with diagnostics

### DIFF
--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -12,30 +12,34 @@ data-parallel rack uses one 64-device expert mesh.
   and fused RoPE are on.
 - Mesh: 64-way expert parallelism across 16 workers with four GB200 GPUs each. Additional racks use
   the `replica_dcn` axis. Six experts are on each GPU in each rack.
-- Batch: 1024 global sequences. The launcher does not scale the batch with the rack count.
-- Router: top-8 quantile balancing with next-step, stop-gradient expert biases and no auxiliary
-  balancing loss.
+- Batch: The d6144 production run uses 11264 global sequences across 11 racks. A one-rack
+  diagnostic uses 1024 sequences.
+- Router: top-8 quantile balancing uses a global histogram with 10,000 bins. It has next-step,
+  stop-gradient expert biases and no auxiliary balancing loss.
 - MoE backend: `fixed_pooled_wave_all_to_all`. Each sender uses one fixed pool per
   destination and stripes it over three static waves. The receiver runs all six local experts in
   each wave and drops rows above the fixed expert capacity. Expert IDs travel in the activation
-  payload, so the method does not use a metadata collective. The receiver capacity factor is 1.15,
-  and the sender capacity factor is 1.10.
+  payload, so the method does not use a metadata collective. The receiver and sender capacity
+  factors are 1.15.
 - Optimizer: MuonH, with its state offloaded to pinned host memory.
-- Runtime: one JAX process per four-GPU worker, BF16 parameters and compute, GPU command buffers
-  off, `cuda_async`, PGLE off, and collective overlap limit 4.
-- Output: Metrics only by default. `--save-checkpoints` writes checkpoints and resumes from the
-  newest complete checkpoint below `--checkpoint-path`. PR
-  [#8480](https://github.com/marin-community/marin/pull/8480) bounded pinned-host restore memory;
-  its d6144 run restored step 164 and continued training with a 735 GiB fleet peak against a
-  940 GiB request. Drop metrics include the sender and receiver shares of all assignments. The
-  receiver also reports its drop share of assignments that reached it.
+- Runtime: Each GPU has one JAX process. The recipe uses BF16, `cuda_async`, no PGLE, and no GPU
+  command buffers. Inline watch uses collective overlap limit 1. A disabled watch uses limit 4.
+- Resources: Each four-GPU worker requests 120 CPU, 890 GB of RAM, and 1 TB of disk.
 
 The attention, shared-expert, language-model-head, and optimizer states use the combined `data` and
 `expert` axes. The expert axis stays sharded during Newton-Schulz.
 
-## Results
+Bounded diagnostics write metrics only by default. `--save-checkpoints` writes checkpoints below
+`--checkpoint-path` and resumes from the newest complete checkpoint. PR
+[#8480](https://github.com/marin-community/marin/pull/8480) bounded pinned-host restore memory. Its
+d6144 run restored step 164 with a 735 GiB fleet peak against a 940 GiB request.
 
-The current 1.10 sender and 1.15 receiver configuration completed a 20-step, one-rack gate. Median
+## Historical results
+
+These results used earlier capacity or process settings. They do not measure the selected 1.15
+sender and receiver recipe.
+
+The 1.10 sender and 1.15 receiver configuration completed a 20-step, one-rack gate. Median
 throughput over steps 2 through 19 was 250,691 tokens/s, and final throughput was 246,947 tokens/s.
 The final loss was 6.3224. The final total drop rate was 19.33%: 7.14% at the sender and 12.19% at
 the receiver. The receiver dropped 13.12% of assignments that reached it. This short gate validates
@@ -67,7 +71,7 @@ Paloma macro loss, both as trained (with capacity drops) and re-scored dropless
 The drop-free re-eval is the fair comparison to a dropless FSDP run; the training-time drops grow
 with width and are recovered by scoring dropless.
 
-## Sweeps
+## Diagnostic sweeps
 
 Five launcher options move the shape from the hero spec. They keep the hidden dimension, so the
 compute-scaled optimizer values stay constant across a sweep.
@@ -89,7 +93,7 @@ Three quantities set what a sweep can fit on one rack:
 
 The selected E384 model runs at expert width 3072 and receiver capacity factor 1.15.
 
-## Run Controls
+## Diagnostic controls
 
 | option | effect |
 | --- | --- |
@@ -107,12 +111,19 @@ The selected E384 model runs at expert width 3072 and receiver capacity factor 1
 
 ## Launch
 
-### Hero
+### Bounded diagnostics
+
+`launch_diagnostics.py` uses the d6144 model, Harrier 2026.08.18 data, process layout, watch config,
+and TensorStore cache from the production recipe. Its stop step, evaluation, and checkpoint policy
+stay independent from the production run.
+
+The default 25-step diagnostic uses simulated epoching. Set `--schedule-steps 390251` to use the raw
+production mixture. The diagnostic default now matches the production watch and 890 GB RAM request.
 
 Print the plan without a GPU run:
 
 ```bash
-python -m experiments.grug.moe_hero_ep.launch_mfu_test \
+python -m experiments.grug.moe_hero_ep.launch_diagnostics \
   --run-id mhep-pooled-wave \
   --num-steps 200 \
   --version 2026.08.14
@@ -128,7 +139,7 @@ uv run iris --config lib/iris/config/marin.yaml job run --no-wait --enable-extra
   --job-name "${run_id}-coord" \
   -e WANDB_API_KEY "$WANDB_API_KEY" -e WANDB_PROJECT "$WANDB_PROJECT" \
   -e IRIS_PORT_JAX 32575 \
-  -- python -m experiments.grug.moe_hero_ep.launch_mfu_test \
+  -- python -m experiments.grug.moe_hero_ep.launch_diagnostics \
     --run-id "$run_id" --num-steps 200 --version 2026.08.14 --run
 ```
 
@@ -136,6 +147,25 @@ W&B uses the `WANDB_PROJECT` environment variable, or project `marin_moe` when i
 group `moe-hero-ep` and the supplied run ID. The run output includes the durable W&B metrics
 artifact. Give each concurrent gang its own `IRIS_PORT_JAX`: rank 0 binds and registers that port
 for the JAX coordinator, and the default 8476 is shared by every run on the cluster.
+
+Submit a rack-local XProf trace through the Marin Iris controller:
+
+```bash
+run_id="mhep-rack-profile"
+uv run iris --config lib/iris/config/marin.yaml job run --no-wait --enable-extra-resources \
+  --target-cluster cw-us-east-08a --priority interactive \
+  --cpu 2 --memory 8GB --disk 32GB \
+  --job-name "${run_id}-coord" \
+  -e WANDB_API_KEY "$WANDB_API_KEY" -e WANDB_PROJECT "$WANDB_PROJECT" \
+  -e IRIS_PORT_JAX 32576 \
+  -- python -m experiments.grug.moe_hero_ep.launch_diagnostics \
+    --run-id "$run_id" --num-steps 8 --schedule-steps 390251 --batch-size 1024 \
+    --profile-start-step 5 --profile-steps 2 --training-data synthetic \
+    --version dev --run
+```
+
+Batch 1024 keeps the production local batch of 16 sequences per GPU. The trace does not include
+the 11-rack `replica_dcn` collectives or their global histogram reduction.
 
 ### Small-scale hero-shape ablations
 

--- a/experiments/grug/moe_hero_ep/hero_recipe.py
+++ b/experiments/grug/moe_hero_ep/hero_recipe.py
@@ -1,0 +1,115 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared model, fleet, and output definitions for EP hero launchers."""
+
+import dataclasses
+
+import jmp
+from levanter.callbacks.profiler import ProfilerConfig
+from levanter.callbacks.progress_watchdog import ProgressWatchdogConfig
+from levanter.callbacks.watch import WatchConfig
+from levanter.checkpoint import CheckpointerConfig
+from levanter.tracker import TrackerConfig
+from levanter.trainer import TrainerConfig
+from marin.execution.artifact import Artifact
+from marin.execution.lazy import ArtifactStep
+from marin.processing.tokenize.tokenize import TokenizedCache
+
+from experiments.datasets.paloma import paloma_datasets
+from experiments.grug.moe_hero_ep.heuristic import HERO_MODEL
+from experiments.grug.moe_hero_ep.model import QbEstimator
+from experiments.grug.moe_hero_ep.train import (
+    GrugTrainerConfig,
+    MasterParamMode,
+    TrainingDataMode,
+    WatchMode,
+)
+from experiments.marin_tokenizer import marin_tokenizer
+
+DEFAULT_WANDB_PROJECT = "marin_moe"
+HERO_EP_BATCH_SIZE = 1024
+HERO_EP_NODES = 16
+HERO_GPUS_PER_NODE = 4
+HERO_EP_EXPERT_AXIS_SIZE = HERO_EP_NODES * HERO_GPUS_PER_NODE
+HERO_PROCESSES_PER_TASK = HERO_GPUS_PER_NODE
+HERO_NODE_CPU = 120
+HERO_NODE_RAM = "890g"
+HERO_NODE_DISK = "1t"
+HERO_MIXED_PRECISION = "params=bfloat16,compute=bfloat16,output=bfloat16"
+HERO_QB_HIST_BINS = 10_000
+# A two-tray loader benchmark found that 1 GB kept 18.6x throughput headroom. The process cache
+# stayed near 0.923 GiB, while a 125 GB limit let native RSS increase until the cache was full.
+HERO_TENSORSTORE_CACHE_BYTES = 1_000_000_000
+HERO_WATCH_INTERVAL = 10
+HERO_MODEL_CONFIG = dataclasses.replace(
+    HERO_MODEL,
+    qb_estimator=QbEstimator.HIST,
+    qb_hist_bins=HERO_QB_HIST_BINS,
+)
+
+
+class HeroThroughputResult(Artifact):
+    """Metrics artifact for an EP hero run."""
+
+
+def hero_grug_trainer_config(
+    *,
+    replica_axis_size: int,
+    training_data_mode: TrainingDataMode,
+    watch_mode: WatchMode,
+    save_checkpoints: bool,
+) -> GrugTrainerConfig:
+    """Set the Grug options that affect the compiled hero step."""
+    return GrugTrainerConfig(
+        data_seed=None,
+        log_every=1,
+        ema_beta=None,
+        z_loss_weight=1e-4,
+        # Keep the MuonH state on pinned host memory so the pooled buffers have sufficient HBM.
+        offload_opt_state=True,
+        master_param_mode=MasterParamMode.FP32_PINNED_HOST,
+        training_data_mode=training_data_mode,
+        watch_mode=watch_mode,
+        save_checkpoints=save_checkpoints,
+        expert_axis_size=HERO_EP_EXPERT_AXIS_SIZE,
+        replica_axis_size=replica_axis_size,
+        sharding_dump_path=None,
+    )
+
+
+def hero_trainer_config(
+    *,
+    run_id: str,
+    seed: int,
+    train_batch_size: int,
+    num_train_steps: int,
+    profiler: ProfilerConfig,
+    tracker: TrackerConfig,
+    watch: WatchConfig,
+    checkpointer: CheckpointerConfig,
+    progress_watchdog: ProgressWatchdogConfig = ProgressWatchdogConfig(),
+    load_checkpoint_path: str | list[str] | None = None,
+) -> TrainerConfig:
+    """Set the Levanter options that affect the compiled hero step."""
+    return TrainerConfig(
+        id=run_id,
+        seed=seed,
+        train_batch_size=train_batch_size,
+        num_train_steps=num_train_steps,
+        profiler=profiler,
+        mp=jmp.get_policy(HERO_MIXED_PRECISION),
+        tracker=tracker,
+        watch=watch,
+        progress_watchdog=progress_watchdog,
+        use_explicit_mesh_axes=True,
+        require_accelerator=True,
+        allow_nondivisible_batch_size=False,
+        load_checkpoint_path=load_checkpoint_path,
+        checkpointer=checkpointer,
+    )
+
+
+def validation_datasets() -> list[ArtifactStep[TokenizedCache]]:
+    # Weight-zero datasets appear as tagged evaluation sets.
+    return list(paloma_datasets(tokenizer=marin_tokenizer).values())

--- a/experiments/grug/moe_hero_ep/launch_diagnostics.py
+++ b/experiments/grug/moe_hero_ep/launch_diagnostics.py
@@ -1,74 +1,62 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""GB200 launcher for the EP64 MoE hero configuration."""
+"""Bounded GB200 diagnostics for the production EP64 MoE hero recipe."""
 
 import dataclasses
 import os
 from datetime import timedelta
 
 import click
-import jmp
 from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfileOptionsConfig, ProfilerConfig
 from levanter.callbacks.watch import WatchConfig
 from levanter.checkpoint import CheckpointerConfig
 from levanter.tracker.wandb import WandbConfig
-from levanter.trainer import TrainerConfig
-from marin.execution.artifact import Artifact
 from marin.execution.build_context import resolve_version
 from marin.execution.lazy import ArtifactStep, StepContext
 from marin.experiment.cli import build_options
 from marin.experiment.namespacing import user_namespaced_name
-from marin.processing.tokenize.tokenize import TokenizedCache
 from rigging.filesystem.storage_path import prefix_join
 
-from experiments.datasets.paloma import paloma_datasets
-from experiments.grug.moe_hero_ep.harrier_mix_2026_08_17_1 import (
-    HARRIER_MIX_2026_08_17_1_STORE,
-    HARRIER_MIX_2026_08_17_1_TAG,
-    harrier_mix_2026_08_17_1_data_config,
+from experiments.grug.moe_hero_ep.harrier_mix_2026_08_18 import (
+    HARRIER_MIX_2026_08_18_STORE,
+    HARRIER_MIX_2026_08_18_TAG,
+    harrier_mix_2026_08_18_data_config,
 )
-from experiments.grug.moe_hero_ep.heuristic import HERO_MODEL, build_hero_configs
+from experiments.grug.moe_hero_ep.hero_recipe import (
+    DEFAULT_WANDB_PROJECT,
+    HERO_EP_BATCH_SIZE,
+    HERO_EP_EXPERT_AXIS_SIZE,
+    HERO_EP_NODES,
+    HERO_GPUS_PER_NODE,
+    HERO_MODEL_CONFIG,
+    HERO_NODE_CPU,
+    HERO_NODE_DISK,
+    HERO_NODE_RAM,
+    HERO_PROCESSES_PER_TASK,
+    HERO_TENSORSTORE_CACHE_BYTES,
+    HERO_WATCH_INTERVAL,
+    HeroThroughputResult,
+    hero_grug_trainer_config,
+    hero_trainer_config,
+    validation_datasets,
+)
+from experiments.grug.moe_hero_ep.heuristic import build_hero_configs
 from experiments.grug.moe_hero_ep.train import (
     GrugEvalConfig,
     GrugRunConfig,
-    GrugTrainerConfig,
-    MasterParamMode,
     TrainingDataMode,
     WatchMode,
+    _compute_flops,
     run_grug,
 )
-from experiments.marin_tokenizer import marin_tokenizer
 
 DEFAULT_HERO_STEPS = 25
-DEFAULT_WANDB_PROJECT = "marin_moe"
-HERO_EP_BATCH_SIZE = 1024
-HERO_EP_NODES = 16
-HERO_GPUS_PER_NODE = 4
-HERO_EP_EXPERT_AXIS_SIZE = HERO_EP_NODES * HERO_GPUS_PER_NODE
-HERO_PROCESSES_PER_TASK = 1
-HERO_MIXED_PRECISION = "params=bfloat16,compute=bfloat16,output=bfloat16"
-# Keep MuonH state on pinned host memory to leave room for the pooled all-to-all buffers.
-HERO_OFFLOAD_OPT_STATE = True
-HERO_WATCH_INTERVAL = 0
 HERO_CHECKPOINT_INTERVAL = timedelta(minutes=15)
 
 
-# Held-out sets are added at weight 0 so they surface as tagged eval sets.
-def _validation_datasets() -> list[ArtifactStep[TokenizedCache]]:
-    return list(paloma_datasets(tokenizer=marin_tokenizer).values())
-
-
-class HeroThroughputResult(Artifact):
-    """Result of the rack-scale throughput hero run.
-
-    The run mirrors its tracker metrics to the output path. It writes no checkpoint by default.
-    With checkpointing enabled, it resumes from the newest complete checkpoint.
-    """
-
-
-def build_hero_run(
+def build_diagnostic_run(
     *,
     run_id: str,
     dp_racks: int,
@@ -92,7 +80,7 @@ def build_hero_run(
     training_data_mode: TrainingDataMode = TrainingDataMode.MIXTURE,
     version: str | None = None,
 ) -> ArtifactStep[HeroThroughputResult]:
-    """Build the EP64 hero throughput run.
+    """Build a bounded diagnostic run for the production EP64 hero recipe.
 
     The overrides sweep expert count, expert width, routed top-k, and routing capacity from the
     hero spec. They keep the hidden dimension, so the compute-scaled optimizer values stay
@@ -127,10 +115,11 @@ def build_hero_run(
     if schedule_steps is not None and schedule_steps < num_steps:
         raise ValueError(f"schedule_steps={schedule_steps} must be at least num_steps={num_steps}")
     total_schedule_steps = schedule_steps if schedule_steps is not None else num_steps
-    model, optimizer = build_hero_configs(
+    _, optimizer = build_hero_configs(
         num_train_steps=total_schedule_steps,
         batch_size=batch_size,
     )
+    model = HERO_MODEL_CONFIG
     overrides = {
         name: value
         for name, value in (
@@ -163,35 +152,29 @@ def build_hero_run(
     wave_tag = f"expert-waves-{model.num_expert_waves}"
     size_tag = f"e{model.num_experts}-i{model.intermediate_dim}"
     wandb_project = os.environ.get("WANDB_PROJECT") or DEFAULT_WANDB_PROJECT
-    grug_trainer = GrugTrainerConfig(
-        data_seed=None,
-        log_every=1,
-        ema_beta=None,
-        z_loss_weight=1e-4,
-        offload_opt_state=HERO_OFFLOAD_OPT_STATE,
-        master_param_mode=MasterParamMode.FP32_PINNED_HOST,
+    grug_trainer = hero_grug_trainer_config(
+        replica_axis_size=dp_racks,
         training_data_mode=training_data_mode,
         watch_mode=watch_mode,
         save_checkpoints=save_checkpoints,
-        expert_axis_size=HERO_EP_EXPERT_AXIS_SIZE,
-        replica_axis_size=dp_racks,
-        sharding_dump_path=None,
     )
     train_resources = ResourceConfig.with_gpu(
         "GB200",
         count=HERO_GPUS_PER_NODE,
-        cpu=120,
-        ram="850g",
-        disk="1t",
+        cpu=HERO_NODE_CPU,
+        ram=HERO_NODE_RAM,
+        disk=HERO_NODE_DISK,
         replicas=HERO_EP_NODES * dp_racks,
     )
     name = f"grug/{run_id}"
     version = resolve_version(name, version)
-    validation = _validation_datasets() if eval_every > 0 else []
+    validation = validation_datasets() if eval_every > 0 else []
+    flops_per_example, _ = _compute_flops(model_config=model)
+    experiment_flops = flops_per_example * batch_size * total_schedule_steps
 
     def build_config(ctx: StepContext) -> GrugRunConfig:
-        trainer = TrainerConfig(
-            id=run_id,
+        trainer = hero_trainer_config(
+            run_id=run_id,
             seed=seed,
             train_batch_size=batch_size,
             num_train_steps=total_schedule_steps,
@@ -202,9 +185,13 @@ def build_hero_run(
                 # One rank is enough for a step trace, and tracing all 64 multiplies the upload
                 # without adding signal.
                 process_index=0,
-                profile_options=ProfileOptionsConfig(enable_hlo_proto=True),
+                # Host scopes and HLO metadata identify compiled model regions in XProf.
+                profile_options=ProfileOptionsConfig(
+                    host_tracer_level=1,
+                    python_tracer_level=0,
+                    enable_hlo_proto=True,
+                ),
             ),
-            mp=jmp.get_policy(HERO_MIXED_PRECISION),
             tracker=WandbConfig(
                 entity="marin-community",
                 project=wandb_project,
@@ -219,7 +206,7 @@ def build_hero_run(
                     wave_tag,
                     size_tag,
                     "gb200",
-                    HARRIER_MIX_2026_08_17_1_TAG,
+                    HARRIER_MIX_2026_08_18_TAG,
                     "MHEP",
                 ],
                 group="moe-hero-ep",
@@ -227,9 +214,6 @@ def build_hero_run(
                 replicate_path=ctx.output_path,
             ),
             watch=WatchConfig(interval=watch_interval),
-            use_explicit_mesh_axes=True,
-            require_accelerator=True,
-            allow_nondivisible_batch_size=False,
             # Levanter's default base path is pod-local, so a preempted run would have nothing to
             # resume from. `checkpoint_path` overrides this for runs targeting disposable storage.
             checkpointer=CheckpointerConfig(
@@ -242,23 +226,33 @@ def build_hero_run(
                 keep_last_temporary_checkpoints=1,
             ),
         )
-        data = harrier_mix_2026_08_17_1_data_config(
+        data = harrier_mix_2026_08_18_data_config(
             ctx=ctx,
             total_steps=total_schedule_steps,
             batch_size=batch_size,
             max_seq_len=model.max_seq_len,
+            experiment_flops=experiment_flops,
             validation=validation,
         )
         return GrugRunConfig(
             model=model,
             data=data,
             resources=ctx.runtime_arg("train_resources"),
+            tensorstore_cache_bytes=HERO_TENSORSTORE_CACHE_BYTES,
             optimizer=optimizer,
             trainer=dataclasses.replace(grug_trainer, trainer=trainer),
             # Off by default so a throughput run stays a throughput run. Turn it on to make a
             # run scoreable: comparing configs needs held-out loss, not train loss.
             eval=(
-                GrugEvalConfig(steps_per_eval=eval_every, eval_ema=False, compute_bpb=True) if eval_every > 0 else None
+                GrugEvalConfig(
+                    steps_per_eval=eval_every,
+                    eval_batch_size=HERO_EP_EXPERT_AXIS_SIZE * dp_racks,
+                    eval_ema=False,
+                    compute_bpb=True,
+                    dropless_eval=True,
+                )
+                if eval_every > 0
+                else None
             ),
             stop_after_steps=num_steps,
             processes_per_task=HERO_PROCESSES_PER_TASK,
@@ -270,7 +264,7 @@ def build_hero_run(
         artifact_type=HeroThroughputResult,
         run=run_grug,
         build_config=build_config,
-        deps=(HARRIER_MIX_2026_08_17_1_STORE, *validation),
+        deps=(HARRIER_MIX_2026_08_18_STORE, *validation),
         runtime_args={"train_resources": train_resources},
     )
 
@@ -310,24 +304,24 @@ def build_hero_run(
 @click.option(
     "--num-experts",
     type=click.IntRange(min=1),
-    default=HERO_MODEL.num_experts,
+    default=HERO_MODEL_CONFIG.num_experts,
     show_default=True,
     help=(
         f"Override the routed expert count. The count must be divisible by {HERO_EP_EXPERT_AXIS_SIZE}, "
-        f"and the local expert count must support {HERO_MODEL.num_expert_waves} waves."
+        f"and the local expert count must support {HERO_MODEL_CONFIG.num_expert_waves} waves."
     ),
 )
 @click.option(
     "--num-experts-per-token",
     type=click.IntRange(min=1),
-    default=HERO_MODEL.num_experts_per_token,
+    default=HERO_MODEL_CONFIG.num_experts_per_token,
     show_default=True,
     help="Override the routed top-k. Scales both active parameters and the EP dispatch buffers.",
 )
 @click.option(
     "--intermediate-dim",
     type=click.IntRange(min=1),
-    default=HERO_MODEL.intermediate_dim,
+    default=HERO_MODEL_CONFIG.intermediate_dim,
     show_default=True,
     help="Override the routed expert width.",
 )
@@ -407,7 +401,7 @@ def build_hero_run(
 @click.option(
     "--capacity-factor",
     type=click.FloatRange(min=0, min_open=True),
-    default=HERO_MODEL.capacity_factor,
+    default=HERO_MODEL_CONFIG.capacity_factor,
     show_default=True,
     help="Override the pooled receiver capacity factor.",
 )
@@ -434,7 +428,7 @@ def main(
     profile_start_step: int,
     training_data: str,
 ) -> ArtifactStep[HeroThroughputResult]:
-    return build_hero_run(
+    return build_diagnostic_run(
         run_id=run_id,
         dp_racks=dp_racks,
         num_steps=num_steps,

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -26,14 +26,12 @@ import os
 from datetime import timedelta
 
 import click
-import jmp
 from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfilerConfig
 from levanter.callbacks.progress_watchdog import ProgressWatchdogConfig
 from levanter.callbacks.watch import WatchConfig
 from levanter.checkpoint import CheckpointerConfig
 from levanter.tracker.wandb import WandbConfig
-from levanter.trainer import TrainerConfig
 from marin.execution.build_context import resolve_version
 from marin.execution.lazy import ArtifactStep, StepContext
 from marin.experiment.cli import build_options
@@ -51,18 +49,26 @@ from experiments.grug.moe_hero_ep.harrier_mix_2026_08_18 import (
     HARRIER_MIX_2026_08_18_TAG,
     harrier_mix_2026_08_18_data_config,
 )
-from experiments.grug.moe_hero_ep.heuristic import HERO_MODEL, MoeHeuristic, build_hero_configs
-from experiments.grug.moe_hero_ep.launch_mfu_test import (
+from experiments.grug.moe_hero_ep.hero_recipe import (
     DEFAULT_WANDB_PROJECT,
     HERO_EP_BATCH_SIZE,
     HERO_EP_EXPERT_AXIS_SIZE,
     HERO_EP_NODES,
     HERO_GPUS_PER_NODE,
-    HERO_MIXED_PRECISION,
+    HERO_MODEL_CONFIG,
+    HERO_NODE_CPU,
+    HERO_NODE_DISK,
+    HERO_NODE_RAM,
+    HERO_PROCESSES_PER_TASK,
+    HERO_QB_HIST_BINS,
+    HERO_TENSORSTORE_CACHE_BYTES,
+    HERO_WATCH_INTERVAL,
     HeroThroughputResult,
-    _validation_datasets,
+    hero_grug_trainer_config,
+    hero_trainer_config,
+    validation_datasets,
 )
-from experiments.grug.moe_hero_ep.model import QbEstimator
+from experiments.grug.moe_hero_ep.heuristic import MoeHeuristic, build_hero_configs
 from experiments.grug.moe_hero_ep.small_scale_abl_launch import (
     _EP_CAPACITY_FACTOR,
     SEQ_LEN,
@@ -73,16 +79,13 @@ from experiments.grug.moe_hero_ep.small_scale_abl_launch import (
 from experiments.grug.moe_hero_ep.train import (
     GrugEvalConfig,
     GrugRunConfig,
-    GrugTrainerConfig,
-    MasterParamMode,
+    TrainingDataMode,
     WatchMode,
     _compute_flops,
     run_grug,
 )
 from experiments.marin_tokenizer import marin_tokenizer
 
-# Ladder rungs, each pinned to the rack count that holds its batch. d6144 is the hero, reusing
-# HERO_MODEL; the narrower rungs reuse the ablation's `_small_model` at the same hero routing geometry.
 # Deadlines for the progress watchdog. A stalled process exits so the scheduler can replace the
 # gang rather than leaving every rank blocked on it.
 HERO_STEP_TIMEOUT = timedelta(minutes=15)
@@ -92,16 +95,11 @@ HERO_PROCESS_STALL_TIMEOUT = timedelta(hours=1)
 HERO_STARTUP_TIMEOUT = timedelta(seconds=2 * RESTORE_BARRIER_TIMEOUT)
 
 LADDER_RACKS: dict[str, int] = {"d768": 1, "d1024": 2, "d1536": 6, "d2048": 11, "d6144": 11}
-QB_HIST_BINS = 10_000
-# Gradient and parameter norm logs every 10 steps on every rung.
-WATCH_INTERVAL = 10
+# Each rung uses the rack count that holds its batch. d6144 uses the shared hero recipe. Narrower
+# rungs use `_small_model` with the same routing geometry.
 # 791 tokens per active parameter sets the step budget: it lands the d6144 hero at 18T tokens and
 # scales every narrower rung by the same ratio.
 TOKENS_PER_ACTIVE_PARAM = 791
-# The decoded-chunk cache is process-local. A two-tray loader benchmark at the hero's global batch
-# and sequence length found 1 GB retained 18.6x throughput headroom while bounding the cache near
-# 0.923 GiB per process; 125 GB allowed native RSS to grow until the cache filled.
-TENSORSTORE_CACHE_BYTES = 1_000_000_000
 # A crash costs at most this much training time. A hero checkpoint is several TB, thus a shorter
 # interval would spend a large part of the run inside a checkpoint write.
 RESUME_SAVE_INTERVAL = timedelta(hours=1)
@@ -116,7 +114,7 @@ LADDER_MAX_TASK_FAILURES = 1000
 def _ladder_model(size: str):
     """The GrugModelConfig for ``size`` at the hero routing geometry with the QB histogram estimator."""
     if size == "d6144":
-        return dataclasses.replace(HERO_MODEL, qb_estimator=QbEstimator.HIST, qb_hist_bins=QB_HIST_BINS)
+        return HERO_MODEL_CONFIG
     shape = SMALL_SHAPES[size]
     return _small_model(
         shape,
@@ -132,7 +130,7 @@ def _ladder_model(size: str):
         pooled_transport_capacity_factor=_EP_CAPACITY_FACTOR,
         num_expert_waves=3,
         qb_use_histogram=True,
-        qb_hist_bins=QB_HIST_BINS,
+        qb_hist_bins=HERO_QB_HIST_BINS,
     )
 
 
@@ -203,43 +201,35 @@ def build_ladder_run(
 
     # Uniform hero trainer: expert-parallel within each rack, replicated across racks, MuonH state
     # offloaded to FP32 pinned host so the pooled all-to-all buffers keep their HBM.
-    grug_trainer = GrugTrainerConfig(
-        data_seed=None,
-        log_every=1,
-        ema_beta=None,
-        z_loss_weight=1e-4,
-        offload_opt_state=True,
-        master_param_mode=MasterParamMode.FP32_PINNED_HOST,
+    grug_trainer = hero_grug_trainer_config(
+        replica_axis_size=dp_racks,
+        training_data_mode=TrainingDataMode.MIXTURE,
         watch_mode=WatchMode.INLINE,
         save_checkpoints=True,
-        expert_axis_size=HERO_EP_EXPERT_AXIS_SIZE,
-        replica_axis_size=dp_racks,
-        sharding_dump_path=None,
     )
     train_resources = ResourceConfig.with_gpu(
         "GB200",
         count=HERO_GPUS_PER_NODE,
-        cpu=120,
-        ram="890g",
-        disk="1t",
+        cpu=HERO_NODE_CPU,
+        ram=HERO_NODE_RAM,
+        disk=HERO_NODE_DISK,
         replicas=HERO_EP_NODES * dp_racks,
     )
     name = f"grug/{run_id}"
     version = resolve_version(name, version)
-    validation = [*_validation_datasets(), *uncheatable_datasets(tokenizer=marin_tokenizer).values()]
+    validation = [*validation_datasets(), *uncheatable_datasets(tokenizer=marin_tokenizer).values()]
     wandb_project = os.environ.get("WANDB_PROJECT") or DEFAULT_WANDB_PROJECT
 
     def build_config(ctx: StepContext) -> GrugRunConfig:
         permanent_checkpoint_path = prefix_join(ctx.output_path, "checkpoints")
         temporary_checkpoint_path = temporary_checkpoint_base_path(ctx.output_path)
         data_local_checkpoint_path = data_local_temporary_checkpoint_base_path(ctx.output_path)
-        trainer = TrainerConfig(
-            id=run_id,
+        trainer = hero_trainer_config(
+            run_id=run_id,
             seed=0,
             train_batch_size=batch_size,
             num_train_steps=num_steps,
             profiler=ProfilerConfig(enabled=False),
-            mp=jmp.get_policy(HERO_MIXED_PRECISION),
             tracker=WandbConfig(
                 entity="marin-community",
                 project=wandb_project,
@@ -258,15 +248,12 @@ def build_ladder_run(
                 name=run_id,
                 replicate_path=ctx.output_path,
             ),
-            watch=WatchConfig(interval=WATCH_INTERVAL),
+            watch=WatchConfig(interval=HERO_WATCH_INTERVAL),
             progress_watchdog=ProgressWatchdogConfig(
                 step_timeout=HERO_STEP_TIMEOUT,
                 process_timeout=HERO_PROCESS_STALL_TIMEOUT,
                 startup_timeout=HERO_STARTUP_TIMEOUT,
             ),
-            use_explicit_mesh_axes=True,
-            require_accelerator=True,
-            allow_nondivisible_batch_size=False,
             # Existing 02A temporaries remain valid resume candidates for this lineage.
             load_checkpoint_path=[
                 permanent_checkpoint_path,
@@ -298,7 +285,7 @@ def build_ladder_run(
                 validation=validation,
             ),
             resources=ctx.runtime_arg("train_resources"),
-            tensorstore_cache_bytes=TENSORSTORE_CACHE_BYTES,
+            tensorstore_cache_bytes=HERO_TENSORSTORE_CACHE_BYTES,
             optimizer=optimizer,
             trainer=dataclasses.replace(grug_trainer, trainer=trainer),
             eval=GrugEvalConfig(
@@ -312,7 +299,7 @@ def build_ladder_run(
                 eval_at_first_step=size == "d6144",
             ),
             stop_after_steps=num_steps,
-            processes_per_task=HERO_GPUS_PER_NODE,
+            processes_per_task=HERO_PROCESSES_PER_TASK,
             max_retries_failure=LADDER_MAX_RETRIES_FAILURE,
             max_task_failures=LADDER_MAX_TASK_FAILURES,
         )

--- a/experiments/grug/moe_hero_ep/memory_soak.py
+++ b/experiments/grug/moe_hero_ep/memory_soak.py
@@ -41,14 +41,18 @@ from marin.experiment.namespacing import user_namespaced_name
 from rigging.filesystem.cluster_config import marin_temp_bucket
 from rigging.filesystem.storage_path import prefix_join
 
-from experiments.grug.moe_hero_ep.heuristic import HERO_MODEL, MoeHeuristic
-from experiments.grug.moe_hero_ep.launch_mfu_test import (
+from experiments.grug.moe_hero_ep.hero_recipe import (
     DEFAULT_WANDB_PROJECT,
     HERO_GPUS_PER_NODE,
     HERO_MIXED_PRECISION,
+    HERO_MODEL_CONFIG,
+    HERO_NODE_CPU,
+    HERO_NODE_DISK,
+    HERO_NODE_RAM,
+    HERO_QB_HIST_BINS,
     HeroThroughputResult,
 )
-from experiments.grug.moe_hero_ep.model import QbEstimator
+from experiments.grug.moe_hero_ep.heuristic import MoeHeuristic
 from experiments.grug.moe_hero_ep.small_scale_abl_launch import (
     _EP_CAPACITY_FACTOR,
     SMALL_SHAPES,
@@ -90,7 +94,6 @@ CHECKPOINT_TTL_DAYS = 1
 # Falsy `timedelta(0)` disables time-policy saves outright. A microsecond is below even a compiled
 # no-op step, making every call a real temporary save without retaining 100 permanent checkpoints.
 EVERY_STEP = timedelta(microseconds=1)
-QB_HIST_BINS = 10_000
 SOAK_SHAPES = {**SMALL_SHAPES, "d384": SmallShape(384, 4, 3, 1, 1)}
 
 
@@ -148,24 +151,22 @@ def build_memory_soak_run(
         # FA4's packed-segment helper gives equivalent size-one mesh axes distinct explicit
         # shardings. Reference attention avoids that single-device-only mismatch; attention
         # implementation does not participate in checkpoint host staging.
-        attention_implementation="reference" if devices == 1 else HERO_MODEL.attention_implementation,
-        moe_implementation=HERO_MODEL.moe_implementation,
-        expert_chunks=HERO_MODEL.expert_chunks,
+        attention_implementation="reference" if devices == 1 else HERO_MODEL_CONFIG.attention_implementation,
+        moe_implementation=HERO_MODEL_CONFIG.moe_implementation,
+        expert_chunks=HERO_MODEL_CONFIG.expert_chunks,
         seq_len=seq_len,
         num_experts=num_experts,
-        num_experts_per_token=HERO_MODEL.num_experts_per_token,
+        num_experts_per_token=HERO_MODEL_CONFIG.num_experts_per_token,
         intermediate_dim=None,
         latent_dim=None,
-        pooled_transport_capacity_factor=HERO_MODEL.pooled_transport_capacity_factor,
-        num_expert_waves=HERO_MODEL.num_expert_waves,
+        pooled_transport_capacity_factor=HERO_MODEL_CONFIG.pooled_transport_capacity_factor,
+        num_expert_waves=HERO_MODEL_CONFIG.num_expert_waves,
         qb_use_histogram=True,
-        qb_hist_bins=QB_HIST_BINS,
+        qb_hist_bins=HERO_QB_HIST_BINS,
     )
     local_experts = num_experts // expert_axis
     if local_experts % model.num_expert_waves != 0:
         raise ValueError(f"local expert count={local_experts} must divide num_expert_waves={model.num_expert_waves}")
-    model = dataclasses.replace(model, qb_estimator=QbEstimator.HIST, qb_hist_bins=QB_HIST_BINS)
-
     if devices == 1:
         # MuonH's Newton--Schulz contraction expects a nontrivial model axis. Adam keeps the
         # single-device soak on the same training/checkpoint path without introducing a fake axis.
@@ -198,9 +199,9 @@ def build_memory_soak_run(
     train_resources = ResourceConfig.with_gpu(
         "GB200",
         count=gpus_per_task,
-        cpu=120 if gpus_per_task == HERO_GPUS_PER_NODE else 32,
-        ram="890g" if gpus_per_task == HERO_GPUS_PER_NODE else "192g",
-        disk="1t" if gpus_per_task == HERO_GPUS_PER_NODE else "256g",
+        cpu=HERO_NODE_CPU if gpus_per_task == HERO_GPUS_PER_NODE else 32,
+        ram=HERO_NODE_RAM if gpus_per_task == HERO_GPUS_PER_NODE else "192g",
+        disk=HERO_NODE_DISK if gpus_per_task == HERO_GPUS_PER_NODE else "256g",
         replicas=tasks,
     )
     name = f"grug/{run_id}"

--- a/experiments/grug/moe_hero_ep/restore_benchmark.py
+++ b/experiments/grug/moe_hero_ep/restore_benchmark.py
@@ -19,7 +19,6 @@ Dispatch needs an Iris task to submit from, so launch it as a coordinator job:
         -- python -m experiments.grug.moe_hero_ep.restore_benchmark --run-id restore-bench-1
 """
 
-import dataclasses
 import gc
 import logging
 import time
@@ -49,14 +48,19 @@ from rigging.filesystem.cluster_config import marin_temp_bucket
 from rigging.filesystem.storage_path import prefix_join
 
 from experiments.grug.dispatch import dispatch_grug_training_run
-from experiments.grug.moe_hero_ep.heuristic import HERO_MODEL, MoeHeuristic, build_hero_configs
-from experiments.grug.moe_hero_ep.launch_mfu_test import (
+from experiments.grug.moe_hero_ep.hero_recipe import (
     HERO_EP_BATCH_SIZE,
     HERO_EP_EXPERT_AXIS_SIZE,
     HERO_GPUS_PER_NODE,
     HERO_MIXED_PRECISION,
+    HERO_MODEL_CONFIG,
+    HERO_NODE_CPU,
+    HERO_NODE_DISK,
+    HERO_NODE_RAM,
+    HERO_QB_HIST_BINS,
 )
-from experiments.grug.moe_hero_ep.model import GrugModelConfig, QbEstimator
+from experiments.grug.moe_hero_ep.heuristic import MoeHeuristic, build_hero_configs
+from experiments.grug.moe_hero_ep.model import GrugModelConfig
 from experiments.grug.moe_hero_ep.small_scale_abl_launch import SMALL_SHAPES, _small_model
 from experiments.grug.moe_hero_ep.train import (
     MasterParamMode,
@@ -69,7 +73,6 @@ logger = logging.getLogger(__name__)
 
 # The hero's own schedule length, so this pytree matches the one a hero resume restores into.
 HERO_SCHEDULE_STEPS = 390_251
-QB_HIST_BINS = 10_000
 CHECKPOINT_TTL_DAYS = 1
 GIB = 1024**3
 HERO_MODEL_SIZE = "hero"
@@ -240,24 +243,25 @@ def main(
 ) -> None:
     batch_size = HERO_EP_BATCH_SIZE * replica_groups
     if model_size == HERO_MODEL_SIZE:
-        model, optimizer = build_hero_configs(num_train_steps=HERO_SCHEDULE_STEPS, batch_size=batch_size)
+        model = HERO_MODEL_CONFIG
+        _, optimizer = build_hero_configs(num_train_steps=HERO_SCHEDULE_STEPS, batch_size=batch_size)
     else:
         shape = SMALL_SHAPES[model_size]
         model = _small_model(
             shape=shape,
-            capacity_factor=HERO_MODEL.capacity_factor,
-            attention_implementation=HERO_MODEL.attention_implementation,
-            moe_implementation=HERO_MODEL.moe_implementation,
-            expert_chunks=HERO_MODEL.expert_chunks,
-            seq_len=HERO_MODEL.max_seq_len,
-            num_experts=HERO_MODEL.num_experts,
-            num_experts_per_token=HERO_MODEL.num_experts_per_token,
+            capacity_factor=HERO_MODEL_CONFIG.capacity_factor,
+            attention_implementation=HERO_MODEL_CONFIG.attention_implementation,
+            moe_implementation=HERO_MODEL_CONFIG.moe_implementation,
+            expert_chunks=HERO_MODEL_CONFIG.expert_chunks,
+            seq_len=HERO_MODEL_CONFIG.max_seq_len,
+            num_experts=HERO_MODEL_CONFIG.num_experts,
+            num_experts_per_token=HERO_MODEL_CONFIG.num_experts_per_token,
             intermediate_dim=None,
             latent_dim=None,
-            pooled_transport_capacity_factor=HERO_MODEL.pooled_transport_capacity_factor,
-            num_expert_waves=HERO_MODEL.num_expert_waves,
+            pooled_transport_capacity_factor=HERO_MODEL_CONFIG.pooled_transport_capacity_factor,
+            num_expert_waves=HERO_MODEL_CONFIG.num_expert_waves,
             qb_use_histogram=True,
-            qb_hist_bins=QB_HIST_BINS,
+            qb_hist_bins=HERO_QB_HIST_BINS,
         )
         optimizer = MoeHeuristic().build_optimizer_config(
             num_train_steps=HERO_SCHEDULE_STEPS,
@@ -284,7 +288,7 @@ def main(
         checkpoint_path=prefix_join(
             marin_temp_bucket(ttl_days=CHECKPOINT_TTL_DAYS, prefix=f"restore-benchmark/{run_id}"), "checkpoint"
         ),
-        model=dataclasses.replace(model, qb_estimator=QbEstimator.HIST, qb_hist_bins=QB_HIST_BINS),
+        model=model,
         optimizer=optimizer,
         trainer=TrainerConfig(
             id=run_id,
@@ -315,9 +319,9 @@ def main(
         resources=ResourceConfig.with_gpu(
             "GB200",
             count=HERO_GPUS_PER_NODE,
-            cpu=120,
-            ram="890g",
-            disk="1t",
+            cpu=HERO_NODE_CPU,
+            ram=HERO_NODE_RAM,
+            disk=HERO_NODE_DISK,
             replicas=device_count // HERO_GPUS_PER_NODE,
         ),
         processes_per_task=HERO_GPUS_PER_NODE,

--- a/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
+++ b/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
@@ -39,13 +39,13 @@ from experiments.grug.moe_hero_ep.harrier_mix_2026_08_17_1 import (
     HARRIER_MIX_2026_08_17_1_TAG,
     harrier_mix_2026_08_17_1_data_config,
 )
-from experiments.grug.moe_hero_ep.heuristic import MoeHeuristic
-from experiments.grug.moe_hero_ep.launch_mfu_test import (
+from experiments.grug.moe_hero_ep.hero_recipe import (
     DEFAULT_WANDB_PROJECT,
     HERO_EP_NODES,
     HERO_GPUS_PER_NODE,
     HeroThroughputResult,
 )
+from experiments.grug.moe_hero_ep.heuristic import MoeHeuristic
 from experiments.grug.moe_hero_ep.model import GrugModelConfig, QbEstimator
 from experiments.grug.moe_hero_ep.train import GrugEvalConfig, GrugRunConfig, GrugTrainerConfig, run_grug
 from experiments.marin_tokenizer import marin_tokenizer

--- a/tests/test_grug_hero_scaling_ladder.py
+++ b/tests/test_grug_hero_scaling_ladder.py
@@ -6,7 +6,51 @@ import dataclasses
 import pytest
 from marin.execution.lazy import StepContext
 
+from experiments.grug.moe_hero_ep.launch_diagnostics import build_diagnostic_run
 from experiments.grug.moe_hero_ep.launch_scaling_ladder import build_ladder_run
+
+
+def test_diagnostic_run_matches_the_d6144_rack_local_recipe():
+    diagnostic = build_diagnostic_run(
+        run_id="test-diagnostic",
+        dp_racks=1,
+        num_steps=1,
+        schedule_steps=390_251,
+        version="dev",
+    )
+    ladder = build_ladder_run(run_id="test-ladder", size="d6144", version="dev")
+    diagnostic_config = diagnostic.build_config(
+        StepContext.for_fingerprint(runtime_arg_keys=diagnostic.runtime_args, deps=diagnostic.deps)
+    )
+    ladder_config = ladder.build_config(
+        StepContext.for_fingerprint(runtime_arg_keys=ladder.runtime_args, deps=ladder.deps)
+    )
+
+    assert diagnostic_config.model == ladder_config.model
+    assert diagnostic_config.processes_per_task == ladder_config.processes_per_task
+    assert diagnostic_config.tensorstore_cache_bytes == ladder_config.tensorstore_cache_bytes
+    assert diagnostic_config.trainer == dataclasses.replace(
+        ladder_config.trainer,
+        trainer=diagnostic_config.trainer.trainer,
+        replica_axis_size=1,
+        save_checkpoints=False,
+    )
+    assert diagnostic_config.trainer.trainer == dataclasses.replace(
+        ladder_config.trainer.trainer,
+        id=diagnostic_config.trainer.trainer.id,
+        train_batch_size=diagnostic_config.trainer.trainer.train_batch_size,
+        profiler=diagnostic_config.trainer.trainer.profiler,
+        tracker=diagnostic_config.trainer.trainer.tracker,
+        progress_watchdog=diagnostic_config.trainer.trainer.progress_watchdog,
+        checkpointer=diagnostic_config.trainer.trainer.checkpointer,
+        load_checkpoint_path=diagnostic_config.trainer.trainer.load_checkpoint_path,
+    )
+    assert diagnostic_config.data.target_budget is ladder_config.data.target_budget is None
+    assert diagnostic_config.data.experiment_budget is ladder_config.data.experiment_budget is None
+    assert diagnostic_config.data.train_weights == [
+        (step, {name: weight for name, weight in weights.items() if weight > 0})
+        for step, weights in ladder_config.data.train_weights
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -24,12 +24,12 @@ from levanter.callbacks.watch import WatchConfig, compute_watch_stats
 from marin.execution.lazy import StepContext
 
 from experiments.grug.moe_hero_ep import grugmuon_hero, model, train
-from experiments.grug.moe_hero_ep import launch_mfu_test as launch
+from experiments.grug.moe_hero_ep import launch_diagnostics as launch
 from experiments.grug.moe_hero_ep import small_scale_abl_launch as abl
 
 
-def test_hero_run_without_shape_overrides_uses_the_selected_model():
-    step = launch.build_hero_run(run_id="selected-default", dp_racks=1, num_steps=1, version="dev")
+def test_diagnostic_run_without_shape_overrides_uses_the_selected_model():
+    step = launch.build_diagnostic_run(run_id="selected-default", dp_racks=1, num_steps=1, version="dev")
     config = step.build_config(StepContext.for_fingerprint(step.runtime_args, step.deps))
 
     assert (
@@ -43,9 +43,13 @@ def test_hero_run_without_shape_overrides_uses_the_selected_model():
         config.model.pooled_transport_capacity_factor,
         config.model.num_expert_waves,
         config.model.moe_implementation,
+        config.model.qb_estimator,
+        config.model.qb_hist_bins,
         config.trainer.trainer.train_batch_size,
         config.model.max_seq_len,
         config.processes_per_task,
+        config.trainer.trainer.watch.interval,
+        config.tensorstore_cache_bytes,
         config.trainer.trainer.mp.param_dtype,
         config.trainer.trainer.mp.compute_dtype,
         config.trainer.master_param_mode,
@@ -60,9 +64,13 @@ def test_hero_run_without_shape_overrides_uses_the_selected_model():
         1.15,
         3,
         "fixed_pooled_wave_all_to_all",
+        model.QbEstimator.HIST,
+        10_000,
         1024,
         4096,
-        1,
+        4,
+        10,
+        1_000_000_000,
         jnp.bfloat16,
         jnp.bfloat16,
         train.MasterParamMode.FP32_PINNED_HOST,
@@ -74,7 +82,7 @@ def test_full_bank_top_k_is_rejected_before_launch():
     # more entries than there are experts. Without this the job dies in the router, which is after
     # the 16-node gang is allocated.
     with pytest.raises(ValueError, match="must be < num_experts"):
-        launch.build_hero_run(
+        launch.build_diagnostic_run(
             run_id="full-bank",
             dp_racks=1,
             num_steps=1,
@@ -87,7 +95,7 @@ def test_full_bank_top_k_is_rejected_before_launch():
 def test_checkpoint_path_overrides_the_step_output_path():
     """A run that only exercises the checkpoint write sends it to disposable storage."""
     temp_path = "s3://marin-us-east-02a/tmp/ttl=1d/hero-ckpt-smoke"
-    step = launch.build_hero_run(
+    step = launch.build_diagnostic_run(
         run_id="ckpt-elsewhere",
         dp_racks=1,
         num_steps=1,
@@ -101,7 +109,7 @@ def test_checkpoint_path_overrides_the_step_output_path():
 
 
 def test_checkpoint_path_defaults_under_the_step_output_path():
-    step = launch.build_hero_run(run_id="ckpt-default", dp_racks=1, num_steps=1, version="dev")
+    step = launch.build_diagnostic_run(run_id="ckpt-default", dp_racks=1, num_steps=1, version="dev")
     ctx = StepContext.for_fingerprint(step.runtime_args, step.deps)
     config = step.build_config(ctx)
 
@@ -110,7 +118,7 @@ def test_checkpoint_path_defaults_under_the_step_output_path():
 
 def test_checkpoint_interval_must_be_positive():
     with pytest.raises(ValueError, match="checkpoint_interval must be positive"):
-        launch.build_hero_run(
+        launch.build_diagnostic_run(
             run_id="bad-checkpoint-interval",
             dp_racks=1,
             num_steps=1,
@@ -125,7 +133,7 @@ def test_checkpoint_interval_must_be_positive():
 )
 def test_profile_window_must_fall_inside_the_run(profile_steps, profile_start_step):
     with pytest.raises(ValueError, match="profile"):
-        launch.build_hero_run(
+        launch.build_diagnostic_run(
             run_id="bad-profile-window",
             dp_racks=1,
             num_steps=3,
@@ -136,7 +144,7 @@ def test_profile_window_must_fall_inside_the_run(profile_steps, profile_start_st
 
 
 def test_data_parallel_racks_keep_the_global_batch_explicit():
-    step = launch.build_hero_run(run_id="two-racks", dp_racks=2, num_steps=1, version="dev")
+    step = launch.build_diagnostic_run(run_id="two-racks", dp_racks=2, num_steps=1, version="dev")
     config = step.build_config(StepContext.for_fingerprint(step.runtime_args, step.deps))
 
     assert config.trainer.replica_axis_size == 2
@@ -145,7 +153,7 @@ def test_data_parallel_racks_keep_the_global_batch_explicit():
 
 
 def test_schedule_steps_do_not_extend_the_run():
-    step = launch.build_hero_run(
+    step = launch.build_diagnostic_run(
         run_id="schedule-head",
         dp_racks=1,
         num_steps=5,
@@ -183,12 +191,12 @@ def test_expert_bank_override_must_be_divisible_by_the_expert_axis():
     # `moe_mlp` raises on an indivisible bank only once the 16-node gang is already allocated and
     # its workspace is built, so the launcher has to reject it while it is still free to do so.
     with pytest.raises(ValueError, match="must be divisible by 64"):
-        launch.build_hero_run(run_id="bad-bank", dp_racks=1, num_steps=1, num_experts=200, version="dev")
+        launch.build_diagnostic_run(run_id="bad-bank", dp_racks=1, num_steps=1, num_experts=200, version="dev")
 
 
 def test_expert_bank_override_must_support_three_waves():
     with pytest.raises(ValueError, match="local expert count=4 must be divisible by num_expert_waves=3"):
-        launch.build_hero_run(run_id="bad-waves", dp_racks=1, num_steps=1, num_experts=256, version="dev")
+        launch.build_diagnostic_run(run_id="bad-waves", dp_racks=1, num_steps=1, num_experts=256, version="dev")
 
 
 def _runtime_env_config(*, processes_per_task=1, watch_mode=train.WatchMode.INLINE, watch_interval=1):
@@ -443,8 +451,8 @@ def test_dropless_local_transform_swaps_moe_backend_and_shares_weights():
 
 def test_eval_every_adds_the_held_out_suites_as_dependencies():
     # Held-out sets are what make a run scoreable; a throughput-only run should not pay for them.
-    off = launch.build_hero_run(run_id="eval-off", dp_racks=1, num_steps=1, version="dev")
-    on = launch.build_hero_run(run_id="eval-on", dp_racks=1, num_steps=1, eval_every=50, version="dev")
+    off = launch.build_diagnostic_run(run_id="eval-off", dp_racks=1, num_steps=1, version="dev")
+    on = launch.build_diagnostic_run(run_id="eval-on", dp_racks=1, num_steps=1, eval_every=50, version="dev")
     off_config = off.build_config(StepContext.for_fingerprint(off.runtime_args, off.deps))
     on_config = on.build_config(StepContext.for_fingerprint(on.runtime_args, on.deps))
 
@@ -453,6 +461,8 @@ def test_eval_every_adds_the_held_out_suites_as_dependencies():
     assert off_config.eval is None
     assert on_config.eval is not None
     assert on_config.eval.steps_per_eval == 50
+    assert on_config.eval.eval_batch_size == launch.HERO_EP_EXPERT_AXIS_SIZE
+    assert on_config.eval.dropless_eval is True
 
 
 def test_ep_ablation_defaults_match_the_documented_arm_and_scale_per_rack():
@@ -460,7 +470,7 @@ def test_ep_ablation_defaults_match_the_documented_arm_and_scale_per_rack():
     cfg = one.build_config(StepContext.for_fingerprint(one.runtime_args, one.deps))
     m = cfg.model
     # The EP rung is a downsized hero: pooled-wave transport, 384 experts / top-8, hidden/2-wide experts
-    # in a hidden/2 latent, receiver/sender capacity 1.15 with 3 waves, and top-k QB (the hero default).
+    # in a hidden/2 latent, receiver/sender capacity 1.15 with 3 waves, and the selected top-k QB arm.
     assert m.moe_implementation == "fixed_pooled_wave_all_to_all"
     assert (m.num_experts, m.num_experts_per_token) == (384, 8)
     assert m.intermediate_dim == m.hidden_dim // 2


### PR DESCRIPTION
* share the d6144 model, trainer settings, Harrier mix, process topology, cache, and dropless evaluation between production scaling runs and bounded diagnostics
* rename `launch_mfu_test.py` to `launch_diagnostics.py`
  * default to histogram QB, one JAX process per GPU, inline watch, and the 890 GB worker request
  * keep short diagnostics on simulated epoching unless `--schedule-steps 390251` selects the raw production mixture
* document the single-rack XProf launch
  * the trace excludes 11-rack `replica_dcn` collectives and their global histogram reduction
* part of #7279
