### PR TITLE
[levanter] Publish checkpoint phase telemetry

### DIFF
--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -104,7 +104,7 @@ The selected E384 model runs at expert width 3072 and receiver capacity factor 1
 | `--save-checkpoints` | writes periodic and final checkpoints |
 | `--checkpoint-minutes` | sets the wall-clock checkpoint interval |
 | `--checkpoint-path` | places checkpoints at an explicit storage prefix |
-| `--checkpoint-debug` | publishes low-cost checkpoint phase and memory telemetry |
+| `--checkpoint-debug` | publishes checkpoint phase and memory telemetry |
 | `--training-data synthetic` | reuses a deterministic batch without opening TensorStore |
 | `--watch-interval`, `--watch-mode` | select inline or diagnostic norm collection |
 | `--profile-start-step`, `--profile-steps` | select the rank-0 XProf window |

--- a/experiments/grug/moe_hero_ep/README.md
+++ b/experiments/grug/moe_hero_ep/README.md
@@ -104,6 +104,7 @@ The selected E384 model runs at expert width 3072 and receiver capacity factor 1
 | `--save-checkpoints` | writes periodic and final checkpoints |
 | `--checkpoint-minutes` | sets the wall-clock checkpoint interval |
 | `--checkpoint-path` | places checkpoints at an explicit storage prefix |
+| `--checkpoint-debug` | publishes low-cost checkpoint phase and memory telemetry |
 | `--training-data synthetic` | reuses a deterministic batch without opening TensorStore |
 | `--watch-interval`, `--watch-mode` | select inline or diagnostic norm collection |
 | `--profile-start-step`, `--profile-steps` | select the rank-0 XProf window |

--- a/experiments/grug/moe_hero_ep/launch_diagnostics.py
+++ b/experiments/grug/moe_hero_ep/launch_diagnostics.py
@@ -362,7 +362,7 @@ def build_diagnostic_run(
     "--checkpoint-debug/--no-checkpoint-debug",
     default=False,
     show_default=True,
-    help="Publish low-cost checkpoint phase and memory telemetry. Use with --save-checkpoints.",
+    help="Publish checkpoint phase and memory telemetry. Use with --save-checkpoints.",
 )
 @click.option(
     "--eval-every",

--- a/experiments/grug/moe_hero_ep/launch_diagnostics.py
+++ b/experiments/grug/moe_hero_ep/launch_diagnostics.py
@@ -11,7 +11,7 @@ import click
 from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfileOptionsConfig, ProfilerConfig
 from levanter.callbacks.watch import WatchConfig
-from levanter.checkpoint import CheckpointerConfig
+from levanter.checkpoint import CheckpointDebugConfig, CheckpointerConfig
 from levanter.tracker.wandb import WandbConfig
 from marin.execution.build_context import resolve_version
 from marin.execution.lazy import ArtifactStep, StepContext
@@ -73,6 +73,7 @@ def build_diagnostic_run(
     save_checkpoints: bool = False,
     checkpoint_interval: timedelta = HERO_CHECKPOINT_INTERVAL,
     checkpoint_path: str | None = None,
+    checkpoint_debug: CheckpointDebugConfig | None = None,
     watch_interval: int = HERO_WATCH_INTERVAL,
     watch_mode: WatchMode = WatchMode.INLINE,
     profile_steps: int = 0,
@@ -224,6 +225,7 @@ def build_diagnostic_run(
                 append_run_id_to_base_path=False,
                 delete_old_temp_checkpoints=True,
                 keep_last_temporary_checkpoints=1,
+                debug=checkpoint_debug or CheckpointDebugConfig(),
             ),
         )
         data = harrier_mix_2026_08_18_data_config(
@@ -357,6 +359,12 @@ def build_diagnostic_run(
     help="Checkpoint output path, e.g. a marin_temp_bucket() path. Defaults to the step output path.",
 )
 @click.option(
+    "--checkpoint-debug/--no-checkpoint-debug",
+    default=False,
+    show_default=True,
+    help="Publish low-cost checkpoint phase and memory telemetry. Use with --save-checkpoints.",
+)
+@click.option(
     "--eval-every",
     type=click.IntRange(min=0),
     default=0,
@@ -421,6 +429,7 @@ def main(
     save_checkpoints: bool,
     checkpoint_minutes: float,
     checkpoint_path: str | None,
+    checkpoint_debug: bool,
     eval_every: int,
     watch_interval: int,
     watch_mode: str,
@@ -443,6 +452,17 @@ def main(
         save_checkpoints=save_checkpoints,
         checkpoint_interval=timedelta(minutes=checkpoint_minutes),
         checkpoint_path=checkpoint_path,
+        checkpoint_debug=(
+            CheckpointDebugConfig(
+                enabled=True,
+                tracemalloc_frames=None,
+                top_allocations=0,
+                force_gc_before_serialize=False,
+                flush_logs=False,
+            )
+            if checkpoint_debug
+            else None
+        ),
         eval_every=eval_every,
         watch_interval=watch_interval,
         watch_mode=WatchMode(watch_mode),

--- a/lib/levanter/docs/reference/Configuration.md
+++ b/lib/levanter/docs/reference/Configuration.md
@@ -184,7 +184,7 @@ rolls through it.
 
 #### Checkpoint Telemetry
 
-Checkpoint debug mode publishes numeric data from each JAX process to Finelog. Use this low-cost configuration for a long run:
+Checkpoint debug mode publishes numeric data from each JAX process to Finelog. This configuration disables allocation tracing and forced garbage collection:
 
 ```yaml
 checkpointer:

--- a/lib/levanter/docs/reference/Configuration.md
+++ b/lib/levanter/docs/reference/Configuration.md
@@ -182,6 +182,56 @@ rolls through it.
 | `checkpointer.write.cache_pool_bytes`      | Soft limit for each TensorStore write cache.                                            | 1 GiB   |
 | `checkpointer.write.data_copy_concurrency` | Maximum CPU concurrency TensorStore uses to copy and encode checkpoint data.           | 16      |
 
+#### Checkpoint Telemetry
+
+Checkpoint debug mode publishes numeric data from each JAX process to Finelog. Use this low-cost configuration for a long run:
+
+```yaml
+checkpointer:
+  debug:
+    enabled: true
+    tracemalloc_frames: null
+    force_gc_before_serialize: false
+    top_allocations: 0
+    flush_logs: false
+```
+
+This configuration does not start `tracemalloc` or force Python garbage collection. It publishes these gauges:
+
+| Metric | Value |
+|--------|-------|
+| `checkpoint_phase_duration_seconds` | Time in one checkpoint phase. |
+| `checkpoint_total_duration_seconds` | Time from checkpoint start through metadata commit. |
+| `checkpoint_staged_host_bytes` | Peak host bytes staged by one process. |
+| `checkpoint_process_peak_rss_bytes` | Peak resident memory for one process. |
+
+The phase metric uses the `phase` attribute. All metrics use `checkpoint_step`. Finelog also records the run, job, process, node, and cluster fields.
+
+Use a short run that saves at least one checkpoint for a cluster smoke test. Then query the regional Finelog deployment:
+
+```bash
+uv run finelog query <cluster> --format table <<'SQL'
+SELECT to_timestamp_millis(timestamp_ms) AS ts,
+       process_index,
+       name,
+       value,
+       json_get(attributes_json, 'checkpoint_step') AS checkpoint_step,
+       json_get(attributes_json, 'phase') AS phase
+FROM telemetry_v1
+WHERE run_id = '<run-id>'
+  AND timestamp_ms >= CAST(EXTRACT(EPOCH FROM now() - INTERVAL '2 hours') * 1000 AS BIGINT)
+  AND name IN (
+    'checkpoint_phase_duration_seconds',
+    'checkpoint_total_duration_seconds',
+    'checkpoint_staged_host_bytes',
+    'checkpoint_process_peak_rss_bytes'
+  )
+ORDER BY timestamp_ms, process_index, name
+SQL
+```
+
+The checkpoint is complete when each process reports `checkpoint_total_duration_seconds`. Compare the maximum phase time across processes to find the checkpoint straggler.
+
 ### JAX Compilation Cache Configuration
 
 Levanter allows you to configure JAX's persistent compilation cache. This can significantly speed up startup times by caching compiled JAX functions.

--- a/lib/levanter/docs/reference/Configuration.md
+++ b/lib/levanter/docs/reference/Configuration.md
@@ -201,7 +201,7 @@ This configuration does not start `tracemalloc` or force Python garbage collecti
 | Metric | Value |
 |--------|-------|
 | `checkpoint_phase_duration_seconds` | Time in one checkpoint phase. |
-| `checkpoint_total_duration_seconds` | Time from checkpoint start through metadata commit. |
+| `checkpoint_total_duration_seconds` | Time from checkpoint start through metadata commit. Process zero publishes this metric. |
 | `checkpoint_staged_host_bytes` | Peak host bytes staged by one process. |
 | `checkpoint_process_peak_rss_bytes` | Peak resident memory for one process. |
 
@@ -230,7 +230,7 @@ ORDER BY timestamp_ms, process_index, name
 SQL
 ```
 
-The checkpoint is complete when each process reports `checkpoint_total_duration_seconds`. Compare the maximum phase time across processes to find the checkpoint straggler.
+The checkpoint is complete when process zero reports `checkpoint_total_duration_seconds`. Each process reports its local asynchronous commit phase.
 
 ### JAX Compilation Cache Configuration
 

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -877,7 +877,10 @@ def save_checkpoint(
         )
     except Exception:
         if progress_logger is not None:
-            progress_logger.finish("failed")
+            if jax.process_index() == 0:
+                progress_logger.finish("failed")
+            else:
+                progress_logger.finish_local("failed")
         raise
 
     return checkpoint_path

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -873,6 +873,7 @@ def save_checkpoint(
             on_local_commit=on_local_commit,
             on_staged=on_staged,
             debug_checkpointer=checkpoint_debug.enabled,
+            debug_log_flush=flush_debug_output if checkpoint_debug.flush_logs else None,
             write_config=write_config,
         )
     except Exception:

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -47,6 +47,7 @@ from levanter.utils.types import FilterSpec
 logger = logging.getLogger(__name__)
 
 _CHECKPOINT_CURRENT = telemetry.snapshot_attributes("gauge", telemetry.CURRENT_SNAPSHOT)
+_CHECKPOINT_PHASE_DURATION_METRIC = "checkpoint_phase_duration_seconds"
 
 PathLike = Union[str, pathlib.Path]
 
@@ -312,13 +313,20 @@ class _CheckpointProgressLogger:
             previous_phase_elapsed,
             total_elapsed,
         )
-        self._publish("checkpoint_phase_duration_seconds", previous_phase_elapsed, phase=previous_phase)
+        self._publish(_CHECKPOINT_PHASE_DURATION_METRIC, previous_phase_elapsed, phase=previous_phase)
         self._log_memory_state(f"phase_{phase}", include_top_allocations=True)
 
     def publish_staged_host_bytes(self, staged_host_bytes: int) -> None:
         self._publish("checkpoint_staged_host_bytes", staged_host_bytes)
 
-    def finish(self, status: str, *, publish_total: bool = True) -> None:
+    def finish(self, status: str) -> None:
+        elapsed = self._finish_local(status)
+        self._publish("checkpoint_total_duration_seconds", elapsed, status=status)
+
+    def finish_local(self, status: str) -> None:
+        self._finish_local(status)
+
+    def _finish_local(self, status: str) -> float:
         self._stop_event.set()
         if self._thread.is_alive():
             self._thread.join(timeout=1.0)
@@ -326,9 +334,7 @@ class _CheckpointProgressLogger:
         now = time.time()
         elapsed = now - self.started_at
         phase_elapsed = now - self.phase_started_at
-        self._publish("checkpoint_phase_duration_seconds", phase_elapsed, phase=self.phase)
-        if publish_total:
-            self._publish("checkpoint_total_duration_seconds", elapsed, status=status)
+        self._publish(_CHECKPOINT_PHASE_DURATION_METRIC, phase_elapsed, phase=self.phase)
         self._log_memory_state(f"checkpoint_{status}", include_top_allocations=True)
         self._log(
             logging.INFO,
@@ -338,6 +344,7 @@ class _CheckpointProgressLogger:
             self.checkpoint_path,
             elapsed,
         )
+        return elapsed
 
     def _run(self) -> None:
         while not self._stop_event.wait(self.interval):
@@ -850,7 +857,7 @@ def save_checkpoint(
 
     def on_local_commit(status: str) -> None:
         if progress_logger is not None and jax.process_index() != 0:
-            progress_logger.finish(status, publish_total=False)
+            progress_logger.finish_local(status)
 
     try:
         if progress_logger is not None:

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -318,7 +318,7 @@ class _CheckpointProgressLogger:
     def publish_staged_host_bytes(self, staged_host_bytes: int) -> None:
         self._publish("checkpoint_staged_host_bytes", staged_host_bytes)
 
-    def finish(self, status: str) -> None:
+    def finish(self, status: str, *, publish_total: bool = True) -> None:
         self._stop_event.set()
         if self._thread.is_alive():
             self._thread.join(timeout=1.0)
@@ -327,7 +327,8 @@ class _CheckpointProgressLogger:
         elapsed = now - self.started_at
         phase_elapsed = now - self.phase_started_at
         self._publish("checkpoint_phase_duration_seconds", phase_elapsed, phase=self.phase)
-        self._publish("checkpoint_total_duration_seconds", elapsed, status=status)
+        if publish_total:
+            self._publish("checkpoint_total_duration_seconds", elapsed, status=status)
         self._log_memory_state(f"checkpoint_{status}", include_top_allocations=True)
         self._log(
             logging.INFO,
@@ -847,6 +848,10 @@ def save_checkpoint(
             progress_logger.publish_staged_host_bytes(staged_host_bytes)
             progress_logger.set_phase("async_commit_in_flight")
 
+    def on_local_commit(status: str) -> None:
+        if progress_logger is not None and jax.process_index() != 0:
+            progress_logger.finish(status, publish_total=False)
+
     try:
         if progress_logger is not None:
             if checkpoint_debug.force_gc_before_serialize:
@@ -858,6 +863,7 @@ def save_checkpoint(
             tree,
             manager,
             commit_callback=my_callback,
+            on_local_commit=on_local_commit,
             on_staged=on_staged,
             debug_checkpointer=checkpoint_debug.enabled,
             write_config=write_config,

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -33,6 +33,7 @@ from haliax.jax_utils import broadcast_one_to_all, is_in_jit, is_jax_array_like
 from jax.experimental.array_serialization.serialization import GlobalAsyncCheckpointManager
 from jaxtyping import PyTree
 
+from rigging import telemetry
 from rigging.filesystem.storage_path import StoragePath
 
 from levanter._debug_logging import flush_debug_output
@@ -44,6 +45,8 @@ from levanter.tensorstore_serialization import (
 from levanter.utils.types import FilterSpec
 
 logger = logging.getLogger(__name__)
+
+_CHECKPOINT_CURRENT = telemetry.snapshot_attributes("gauge", telemetry.CURRENT_SNAPSHOT)
 
 PathLike = Union[str, pathlib.Path]
 
@@ -218,11 +221,18 @@ class _CheckpointProgressLogger:
         if self._flush_logs:
             flush_debug_output(logger)
 
+    def _publish(self, name: str, value: int | float, **attributes: str) -> None:
+        telemetry.gauge(name).set(
+            float(value),
+            attributes={**_CHECKPOINT_CURRENT, "checkpoint_step": str(self.step), **attributes},
+        )
+
     def _log_memory_state(self, event: str, *, include_top_allocations: bool = False) -> None:
+        rss_bytes = _current_process_rss_bytes()
         state: dict[str, Any] = {
             "event": event,
             "phase": self.phase,
-            "rss": _format_bytes_human_readable(_current_process_rss_bytes()),
+            "rss": _format_bytes_human_readable(rss_bytes),
             "gc_counts": gc.get_count(),
             "gc_garbage_len": len(gc.garbage),
             **_tracemalloc_memory_state(),
@@ -233,6 +243,8 @@ class _CheckpointProgressLogger:
         extra_state = _collect_debug_checkpointer_state()
         if extra_state:
             state["providers"] = extra_state
+        if rss_bytes is not None:
+            self._publish("checkpoint_process_peak_rss_bytes", rss_bytes, event=event, phase=self.phase)
 
         self._log(
             logging.INFO,
@@ -300,14 +312,22 @@ class _CheckpointProgressLogger:
             previous_phase_elapsed,
             total_elapsed,
         )
+        self._publish("checkpoint_phase_duration_seconds", previous_phase_elapsed, phase=previous_phase)
         self._log_memory_state(f"phase_{phase}", include_top_allocations=True)
+
+    def publish_staged_host_bytes(self, staged_host_bytes: int) -> None:
+        self._publish("checkpoint_staged_host_bytes", staged_host_bytes)
 
     def finish(self, status: str) -> None:
         self._stop_event.set()
         if self._thread.is_alive():
             self._thread.join(timeout=1.0)
 
-        elapsed = time.time() - self.started_at
+        now = time.time()
+        elapsed = now - self.started_at
+        phase_elapsed = now - self.phase_started_at
+        self._publish("checkpoint_phase_duration_seconds", phase_elapsed, phase=self.phase)
+        self._publish("checkpoint_total_duration_seconds", elapsed, status=status)
         self._log_memory_state(f"checkpoint_{status}", include_top_allocations=True)
         self._log(
             logging.INFO,
@@ -822,6 +842,11 @@ def save_checkpoint(
 
     tree = equinox.filter(tree, lambda x: is_jax_array_like(x) or isinstance(x, (int, float, bool, complex)))
 
+    def on_staged(staged_host_bytes: int) -> None:
+        if progress_logger is not None:
+            progress_logger.publish_staged_host_bytes(staged_host_bytes)
+            progress_logger.set_phase("async_commit_in_flight")
+
     try:
         if progress_logger is not None:
             if checkpoint_debug.force_gc_before_serialize:
@@ -833,11 +858,10 @@ def save_checkpoint(
             tree,
             manager,
             commit_callback=my_callback,
+            on_staged=on_staged,
             debug_checkpointer=checkpoint_debug.enabled,
             write_config=write_config,
         )
-        if progress_logger is not None:
-            progress_logger.set_phase("async_commit_in_flight")
     except Exception:
         if progress_logger is not None:
             progress_logger.finish("failed")

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -615,6 +615,7 @@ def tree_serialize_leaves_tensorstore(
     manager: Optional[array_ser.GlobalAsyncCheckpointManager] = None,
     *,
     commit_callback: Optional[Callable] = None,
+    on_local_commit: Optional[Callable[[str], None]] = None,
     on_staged: Optional[Callable[[int], None]] = None,
     debug_checkpointer: bool = False,
     write_config: Optional[TensorStoreWriteConfig] = None,
@@ -684,7 +685,16 @@ def tree_serialize_leaves_tensorstore(
         )
         flush_debug_output(logger)
 
-    staged_host_bytes = _serialize_arrays(arrays, tspecs, plans, manager, write_config, commit_callback, on_staged)
+    staged_host_bytes = _serialize_arrays(
+        arrays,
+        tspecs,
+        plans,
+        manager,
+        write_config,
+        commit_callback,
+        on_local_commit,
+        on_staged,
+    )
 
     if debug_checkpointer:
         logger.info("Checkpoint tensorstore serialize handed off async commit for %s", checkpoint_dir)
@@ -703,6 +713,7 @@ def _serialize_arrays(
     manager: array_ser.GlobalAsyncCheckpointManager,
     config: TensorStoreWriteConfig,
     commit_callback: Callable,
+    on_local_commit: Optional[Callable[[str], None]],
     on_staged: Optional[Callable[[int], None]],
 ) -> int:
     """Write every array according to its plan and start the asynchronous commit.
@@ -811,6 +822,29 @@ def _serialize_arrays(
     manager._add_futures(commit_futures)
     if on_staged is not None:
         on_staged(staged_host_bytes)
+    if on_local_commit is not None:
+        remaining = len(commit_futures)
+        callback_lock = threading.Lock()
+        local_status = "local_completed"
+
+        def local_write_finished(future: ts.Future) -> None:
+            nonlocal remaining, local_status
+            try:
+                future.result()
+                failed = False
+            except BaseException:
+                failed = True
+            with callback_lock:
+                if failed:
+                    local_status = "local_failed"
+                remaining -= 1
+                if remaining == 0:
+                    on_local_commit(local_status)
+
+        for future in commit_futures:
+            future.add_done_callback(local_write_finished)
+        if not commit_futures:
+            on_local_commit(local_status)
     manager._start_async_commit(commit_callback)
     return staged_host_bytes
 

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -615,9 +615,10 @@ def tree_serialize_leaves_tensorstore(
     manager: Optional[array_ser.GlobalAsyncCheckpointManager] = None,
     *,
     commit_callback: Optional[Callable] = None,
+    on_staged: Optional[Callable[[int], None]] = None,
     debug_checkpointer: bool = False,
     write_config: Optional[TensorStoreWriteConfig] = None,
-):
+) -> int:
     write_config = write_config or TensorStoreWriteConfig()
 
     if manager is None:
@@ -683,7 +684,7 @@ def tree_serialize_leaves_tensorstore(
         )
         flush_debug_output(logger)
 
-    _serialize_arrays(arrays, tspecs, plans, manager, write_config, commit_callback)
+    staged_host_bytes = _serialize_arrays(arrays, tspecs, plans, manager, write_config, commit_callback, on_staged)
 
     if debug_checkpointer:
         logger.info("Checkpoint tensorstore serialize handed off async commit for %s", checkpoint_dir)
@@ -691,6 +692,8 @@ def tree_serialize_leaves_tensorstore(
 
     if manager_was_none:
         manager.wait_until_finished()
+
+    return staged_host_bytes
 
 
 def _serialize_arrays(
@@ -700,7 +703,8 @@ def _serialize_arrays(
     manager: array_ser.GlobalAsyncCheckpointManager,
     config: TensorStoreWriteConfig,
     commit_callback: Callable,
-) -> None:
+    on_staged: Optional[Callable[[int], None]],
+) -> int:
     """Write every array according to its plan and start the asynchronous commit.
 
     Returns once this process has copied its data out. ``manager`` joins the commits and
@@ -799,12 +803,16 @@ def _serialize_arrays(
         len(commit_futures),
         _STAGED_BYTE_OVERHEAD * gate.peak_bytes / 1024**3,
     )
+    staged_host_bytes = gate.peak_bytes
 
     _trim_host_memory_after_commits(commit_futures)
 
     # Private to AsyncManager. Its own `serialize` calls these.
     manager._add_futures(commit_futures)
+    if on_staged is not None:
+        on_staged(staged_host_bytes)
     manager._start_async_commit(commit_callback)
+    return staged_host_bytes
 
 
 def _sharding_from_leaf(leaf, axis_mapping, mesh) -> Optional[jax.sharding.Sharding]:

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -620,6 +620,7 @@ def tree_serialize_leaves_tensorstore(
     debug_checkpointer: bool = False,
     write_config: Optional[TensorStoreWriteConfig] = None,
 ) -> int:
+    """Serialize a PyTree and return the peak host bytes staged by this process."""
     write_config = write_config or TensorStoreWriteConfig()
 
     if manager is None:
@@ -720,6 +721,9 @@ def _serialize_arrays(
 
     Returns once this process has copied its data out. ``manager`` joins the commits and
     barriers on the other processes.
+
+    Returns:
+        The peak host bytes staged by this process.
     """
     manager.wait_until_finished()
 

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -618,6 +618,7 @@ def tree_serialize_leaves_tensorstore(
     on_local_commit: Optional[Callable[[str], None]] = None,
     on_staged: Optional[Callable[[int], None]] = None,
     debug_checkpointer: bool = False,
+    debug_log_flush: Callable[[logging.Logger], None] | None = flush_debug_output,
     write_config: Optional[TensorStoreWriteConfig] = None,
 ) -> int:
     """Serialize a PyTree and return the peak host bytes staged by this process."""
@@ -652,7 +653,8 @@ def tree_serialize_leaves_tensorstore(
             largest_path or "<none>",
             _format_gib(largest_array_bytes),
         )
-        flush_debug_output(logger)
+        if debug_log_flush is not None:
+            debug_log_flush(logger)
 
     plans = [plan_array_write(path, array, write_config) for path, array in zip(paths, arrays)]
     _log_write_share(paths, arrays, plans, total_array_bytes)
@@ -684,7 +686,8 @@ def tree_serialize_leaves_tensorstore(
             split,
             len(plans),
         )
-        flush_debug_output(logger)
+        if debug_log_flush is not None:
+            debug_log_flush(logger)
 
     staged_host_bytes = _serialize_arrays(
         arrays,
@@ -699,7 +702,8 @@ def tree_serialize_leaves_tensorstore(
 
     if debug_checkpointer:
         logger.info("Checkpoint tensorstore serialize handed off async commit for %s", checkpoint_dir)
-        flush_debug_output(logger)
+        if debug_log_flush is not None:
+            debug_log_flush(logger)
 
     if manager_was_none:
         manager.wait_until_finished()

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -16,6 +16,7 @@ import jax
 import jax.experimental.array_serialization.serialization as array_ser
 import jax.tree_util as jtu
 import levanter.checkpoint as checkpoint_module
+import levanter.tensorstore_serialization as tensorstore_serialization
 import numpy as np
 import optax
 import pytest
@@ -486,6 +487,11 @@ def test_debug_checkpoint_exports_phase_and_staging_telemetry(tmp_path, monkeypa
     telemetry.shutdown(0)
     transport = RecordingTelemetryTransport()
     monkeypatch.setattr(telemetry, "_RequestsTransport", lambda: transport)
+    monkeypatch.setattr(
+        tensorstore_serialization,
+        "flush_debug_output",
+        lambda logger: pytest.fail("flush_logs=False forced TensorStore log output"),
+    )
     telemetry.configure(endpoint="http://finelog/v1/telemetry", service="levanter", attributes={"run_id": "run-42"})
 
     try:

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -18,11 +18,13 @@ import jax.tree_util as jtu
 import numpy as np
 import optax
 import pytest
+from rigging import telemetry
 from chex import assert_trees_all_close, assert_trees_all_equal
 from haliax import Axis
 from jax import ShapeDtypeStruct
 from jax import numpy as jnp
 from rigging.filesystem.storage_path import StoragePath
+from rigging.testing import RecordingTelemetryTransport
 from levanter.testing.helpers import MLP, arrays_only, assert_trees_not_close, use_test_mesh
 
 from levanter.callbacks import StepInfo
@@ -477,6 +479,46 @@ def test_checkpointer_config_propagates_debug_settings():
     assert checkpointer.debug.top_allocations == 5
     assert checkpointer.debug.force_gc_before_serialize is False
     assert checkpointer.debug.flush_logs is False
+
+
+def test_debug_checkpoint_exports_phase_and_staging_telemetry(tmp_path, monkeypatch):
+    telemetry.shutdown(0)
+    transport = RecordingTelemetryTransport()
+    monkeypatch.setattr(telemetry, "_RequestsTransport", lambda: transport)
+    telemetry.configure(endpoint="http://finelog/v1/telemetry", service="levanter", attributes={"run_id": "run-42"})
+
+    try:
+        save_checkpoint(
+            {"weight": np.arange(8, dtype=np.float32)},
+            step=7,
+            checkpoint_path=tmp_path / "checkpoint",
+            debug=CheckpointDebugConfig(
+                enabled=True,
+                tracemalloc_frames=None,
+                force_gc_before_serialize=False,
+                top_allocations=0,
+                flush_logs=False,
+            ),
+        )
+        telemetry.shutdown()
+    finally:
+        telemetry.shutdown(0)
+
+    checkpoint_records = [record for record in transport.records if record["name"].startswith("checkpoint_")]
+    values_by_name = {record["name"]: record["value"] for record in checkpoint_records}
+    assert values_by_name["checkpoint_staged_host_bytes"] == 32
+    assert values_by_name["checkpoint_total_duration_seconds"] >= 0
+
+    phase_records = [record for record in checkpoint_records if record["name"] == "checkpoint_phase_duration_seconds"]
+    assert {record["attributes"]["phase"] for record in phase_records} == {
+        "starting",
+        "filesystem_ready",
+        "tensorstore_serialize",
+        "async_commit_in_flight",
+        "metadata_write",
+    }
+    assert all(record["attributes"]["checkpoint_step"] == "7" for record in checkpoint_records)
+    assert all(record["attributes"]["source_temporality"] == "current_snapshot" for record in checkpoint_records)
 
 
 def test_debug_checkpointer_state_providers_register_and_unregister():

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -15,6 +15,7 @@ import haliax as hax
 import jax
 import jax.experimental.array_serialization.serialization as array_ser
 import jax.tree_util as jtu
+import levanter.checkpoint as checkpoint_module
 import numpy as np
 import optax
 import pytest
@@ -555,6 +556,40 @@ def test_debug_checkpoint_nonprimary_process_finishes_local_telemetry(tmp_path, 
         for record in checkpoint_records
         if record["name"] == "checkpoint_phase_duration_seconds"
     }
+    assert not any(record["name"] == "checkpoint_total_duration_seconds" for record in checkpoint_records)
+
+
+def test_debug_checkpoint_nonprimary_serialization_failure_omits_total_telemetry(tmp_path, monkeypatch):
+    telemetry.shutdown(0)
+    transport = RecordingTelemetryTransport()
+    monkeypatch.setattr(telemetry, "_RequestsTransport", lambda: transport)
+    monkeypatch.setattr(jax, "process_index", lambda: 1)
+
+    def fail_serialization(*args, **kwargs):
+        raise RuntimeError("serialization failed")
+
+    monkeypatch.setattr(checkpoint_module, "tree_serialize_leaves_tensorstore", fail_serialization)
+    telemetry.configure(endpoint="http://finelog/v1/telemetry", service="levanter", attributes={"run_id": "run-42"})
+
+    try:
+        with pytest.raises(RuntimeError, match="serialization failed"):
+            save_checkpoint(
+                {"weight": np.arange(8, dtype=np.float32)},
+                step=7,
+                checkpoint_path=tmp_path / "checkpoint",
+                debug=CheckpointDebugConfig(
+                    enabled=True,
+                    tracemalloc_frames=None,
+                    force_gc_before_serialize=False,
+                    top_allocations=0,
+                    flush_logs=False,
+                ),
+            )
+        telemetry.shutdown()
+    finally:
+        telemetry.shutdown(0)
+
+    checkpoint_records = [record for record in transport.records if record["name"].startswith("checkpoint_")]
     assert not any(record["name"] == "checkpoint_total_duration_seconds" for record in checkpoint_records)
 
 

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -521,6 +521,39 @@ def test_debug_checkpoint_exports_phase_and_staging_telemetry(tmp_path, monkeypa
     assert all(record["attributes"]["source_temporality"] == "current_snapshot" for record in checkpoint_records)
 
 
+def test_debug_checkpoint_nonprimary_process_finishes_local_telemetry(tmp_path, monkeypatch):
+    telemetry.shutdown(0)
+    transport = RecordingTelemetryTransport()
+    monkeypatch.setattr(telemetry, "_RequestsTransport", lambda: transport)
+    monkeypatch.setattr(jax, "process_index", lambda: 1)
+    telemetry.configure(endpoint="http://finelog/v1/telemetry", service="levanter", attributes={"run_id": "run-42"})
+
+    try:
+        save_checkpoint(
+            {"weight": np.arange(8, dtype=np.float32)},
+            step=7,
+            checkpoint_path=tmp_path / "checkpoint",
+            debug=CheckpointDebugConfig(
+                enabled=True,
+                tracemalloc_frames=None,
+                force_gc_before_serialize=False,
+                top_allocations=0,
+                flush_logs=False,
+            ),
+        )
+        telemetry.shutdown()
+    finally:
+        telemetry.shutdown(0)
+
+    checkpoint_records = [record for record in transport.records if record["name"].startswith("checkpoint_")]
+    assert "async_commit_in_flight" in {
+        record["attributes"]["phase"]
+        for record in checkpoint_records
+        if record["name"] == "checkpoint_phase_duration_seconds"
+    }
+    assert not any(record["name"] == "checkpoint_total_duration_seconds" for record in checkpoint_records)
+
+
 def test_debug_checkpointer_state_providers_register_and_unregister():
     provider_name = "unit-test-provider"
     provider = lambda: {"weight_transfer": {"bytes": 123}}

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -507,7 +507,6 @@ def test_debug_checkpoint_exports_phase_and_staging_telemetry(tmp_path, monkeypa
     checkpoint_records = [record for record in transport.records if record["name"].startswith("checkpoint_")]
     values_by_name = {record["name"]: record["value"] for record in checkpoint_records}
     assert values_by_name["checkpoint_staged_host_bytes"] == 32
-    assert values_by_name["checkpoint_total_duration_seconds"] >= 0
 
     phase_records = [record for record in checkpoint_records if record["name"] == "checkpoint_phase_duration_seconds"]
     assert {record["attributes"]["phase"] for record in phase_records} == {
@@ -517,6 +516,11 @@ def test_debug_checkpoint_exports_phase_and_staging_telemetry(tmp_path, monkeypa
         "async_commit_in_flight",
         "metadata_write",
     }
+    total_record = next(
+        record for record in checkpoint_records if record["name"] == "checkpoint_total_duration_seconds"
+    )
+    assert total_record["attributes"]["status"] == "completed"
+    assert total_record["value"] >= max(record["value"] for record in phase_records)
     assert all(record["attributes"]["checkpoint_step"] == "7" for record in checkpoint_records)
     assert all(record["attributes"]["source_temporality"] == "current_snapshot" for record in checkpoint_records)
 


### PR DESCRIPTION
Publish checkpoint phase duration, total duration, staged host bytes, and process peak RSS to Finelog when checkpoint debug mode is enabled. The numeric series make synchronous staging and asynchronous commit time available without parsing task logs.

Each JAX process reports its local phases. Process zero reports total duration after the distributed barrier and metadata commit. Nonprimary progress loggers stop after their local TensorStore commits finish.

Document a configuration that disables `tracemalloc`, forced garbage collection, allocation reports, and forced log output. The stacked hero diagnostic launcher exposes this configuration through `--checkpoint-debug` for a bounded checkpoint smoke test. The reference includes a bounded regional Finelog query.

Three one-rack GB200 runs used the 535B model, synthetic data, batch 64, and two training steps. Normal-step throughput changed from -0.1% to +5.1% across two debug runs. Post-checkpoint throughput decreased by 83.5% and 87.9% against the no-debug control. In the last matched pair, duration increased from 10.17 seconds to 84.02 seconds. These results limit debug mode to bounded diagnostics until its checkpoint-path cost is removed.
