### PR TITLE
[zephyr] Propagate writer failures from close

### DIFF
--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -522,7 +522,12 @@ class ThreadedBatchWriter:
 
     def close(self) -> None:
         """Wait for all pending writes and propagate any error."""
-        self._queue.put(_SENTINEL)
+        while self._thread.is_alive() and self._error is None:
+            try:
+                self._queue.put(_SENTINEL, timeout=1.0)
+                break
+            except queue.Full:
+                continue
         self._thread.join()
         if self._error is not None:
             raise self._error

--- a/lib/zephyr/tests/test_writers.py
+++ b/lib/zephyr/tests/test_writers.py
@@ -4,7 +4,9 @@
 """Tests for writers module."""
 
 import tempfile
+import threading
 import uuid
+from collections.abc import Iterable
 from pathlib import Path
 
 import fsspec
@@ -15,6 +17,7 @@ import pytest
 import vortex
 from pyarrow import fs as pa_fs
 from zephyr.writers import (
+    ThreadedBatchWriter,
     _pyarrow_filesystem,
     _s3_filesystem_kwargs,
     infer_arrow_schema,
@@ -25,6 +28,28 @@ from zephyr.writers import (
 
 # zstandard frame magic number: the first four bytes of any zstd-compressed stream.
 _ZSTD_MAGIC = b"\x28\xb5\x2f\xfd"
+
+
+@pytest.mark.timeout(5)
+def test_threaded_batch_writer_close_propagates_failure_with_full_queue():
+    writer_can_fail = threading.Event()
+    write_error = RuntimeError("background write failed")
+
+    def fail_after_release(_: Iterable) -> None:
+        assert writer_can_fail.wait(timeout=1)
+        raise write_error
+
+    writer = ThreadedBatchWriter(fail_after_release, maxsize=1)
+    writer.submit("queued")
+    writer_can_fail.set()
+
+    with pytest.raises(RuntimeError) as submit_error:
+        writer.submit("overflow")
+    assert submit_error.value is write_error
+
+    with pytest.raises(RuntimeError) as close_error:
+        writer.close()
+    assert close_error.value is write_error
 
 
 def test_write_vortex_file_basic():


### PR DESCRIPTION
ThreadedBatchWriter.close() no longer waits forever for sentinel capacity when the background writer has failed with a full bounded queue. It stops enqueueing once the writer exits, joins the thread, and raises the original write exception.

Before the change, the regression remained blocked in queue.put() until pytest's five-second timeout. The fixed path returns the stored RuntimeError in about one second, after submit() observes the writer failure.
