### PR TITLE
[iris] Preserve ports after failed batch allocation

### DIFF
--- a/lib/iris/src/iris/cluster/worker/port_allocator.py
+++ b/lib/iris/src/iris/cluster/worker/port_allocator.py
@@ -25,11 +25,13 @@ class PortAllocator:
 
     def allocate(self, count: int = 1) -> list[int]:
         with self._lock:
+            unavailable = set(self._allocated)
             ports = []
             for _ in range(count):
-                port = self._find_free_port()
-                self._allocated.add(port)
+                port = self._find_free_port(unavailable)
+                unavailable.add(port)
                 ports.append(port)
+            self._allocated.update(ports)
             return ports
 
     def reserve(self, ports: list[int]) -> None:
@@ -46,9 +48,9 @@ class PortAllocator:
             for port in ports:
                 self._allocated.discard(port)
 
-    def _find_free_port(self) -> int:
+    def _find_free_port(self, unavailable: set[int]) -> int:
         for port in range(self._range[0], self._range[1]):
-            if port in self._allocated:
+            if port in unavailable:
                 continue
             if self._is_port_free(port):
                 return port

--- a/lib/iris/tests/cluster/worker/test_worker.py
+++ b/lib/iris/tests/cluster/worker/test_worker.py
@@ -73,6 +73,13 @@ def test_no_port_reuse_before_release(allocator):
     assert len(set(ports1) & set(ports2)) == 0
 
 
+def test_failed_multi_port_allocation_preserves_capacity(allocator):
+    with pytest.raises(RuntimeError):
+        allocator.allocate(count=101)
+
+    assert len(allocator.allocate()) == 1
+
+
 def test_concurrent_allocations(allocator):
     results = []
 


### PR DESCRIPTION
Keep ports available after a multi-port allocation exceeds the configured range. PortAllocator previously recorded each candidate before the whole request was known to fit, so an oversized request consumed every available port until the worker restarted.

Collect each candidate batch against a temporary unavailable set and update allocator state only after the requested count is complete. Existing successful allocation and exhaustion behavior is unchanged.
