### PR TITLE
[fray] Preserve undiscovered local actor handles

### DIFF
--- a/lib/fray/src/fray/local_backend.py
+++ b/lib/fray/src/fray/local_backend.py
@@ -311,7 +311,7 @@ class LocalActorGroup:
     def __init__(self, handles: list[ActorHandle], jobs: list[LocalJobHandle]):
         self._handles = handles
         self._jobs = jobs
-        self._yielded = False
+        self._delivered_count = 0
 
     @property
     def ready_count(self) -> int:
@@ -322,15 +322,15 @@ class LocalActorGroup:
         """Return ready actor handles. Local actors are ready immediately."""
         if count is None:
             count = len(self._handles)
-        self._yielded = True
-        return self._handles[:count]
+        handles = self._handles[:count]
+        self._delivered_count = max(self._delivered_count, len(handles))
+        return handles
 
     def discover_new(self) -> list[ActorHandle]:
-        """Return handles not yet yielded. After wait_ready, returns empty."""
-        if self._yielded:
-            return []
-        self._yielded = True
-        return self._handles
+        """Return handles not previously delivered by this group."""
+        handles = self._handles[self._delivered_count :]
+        self._delivered_count = len(self._handles)
+        return handles
 
     def is_done(self) -> bool:
         """Local actors run in-process and don't independently fail."""

--- a/lib/fray/tests/test_actor.py
+++ b/lib/fray/tests/test_actor.py
@@ -27,6 +27,14 @@ class Adder:
         return a + b
 
 
+class ActorIndex:
+    def __init__(self):
+        self._index = current_actor().index
+
+    def get(self) -> int:
+        return self._index
+
+
 class _ActorConstructionError(RuntimeError):
     pass
 
@@ -86,6 +94,18 @@ def test_actor_group_wait_ready_partial(client: LocalClient):
     group = client.create_actor_group(Counter, name="counters", count=5)
     handles = group.wait_ready(count=2)
     assert len(handles) == 2
+
+
+def test_actor_group_discover_new_returns_undelivered_handles(client: LocalClient):
+    group = client.create_actor_group(ActorIndex, name="indexed-actors", count=3)
+
+    first = group.wait_ready(count=1)
+    assert [handle.get() for handle in first] == [0]
+    assert [handle.get() for handle in group.wait_ready(count=1)] == [0]
+
+    remaining = group.discover_new()
+    assert [handle.get() for handle in remaining] == [1, 2]
+    assert group.discover_new() == []
 
 
 def test_actor_group_shutdown(client: LocalClient):


### PR DESCRIPTION
`LocalActorGroup.wait_ready(count=1)` previously marked every local actor as yielded. A subsequent `discover_new()` returned zero handles even when the group contained additional ready actors.

Track the largest prefix returned by `wait_ready()`. Repeated waits continue to return the requested prefix, while `discover_new()` returns the remaining handles once.
