### PR TITLE
[grug] Add H100 hero scaling ladder

### DIFF
--- a/experiments/benchmarks/fa4/tile_sweep.py
+++ b/experiments/benchmarks/fa4/tile_sweep.py
@@ -41,6 +41,7 @@ from unittest.mock import patch
 import jax
 import jax.numpy as jnp
 import numpy as np
+from levanter.cutlass_kernel_cache import gpu_compute_capability
 from levanter.grug.attention import AttentionMask, reference_attention
 from levanter.grug.attention import _fa4_cute as fa4_cute
 from levanter.grug.attention import _fa4_cute_kernels as fa4_cute_kernels
@@ -270,7 +271,7 @@ def main() -> None:
     v = jax.random.normal(jax.random.fold_in(key, 2), shape_kv, dtype=jnp.bfloat16)
     segment_ids = _segment_ids(args.batch, args.seq_len, args.documents)
 
-    arch = fa4_cute._gpu_compute_arch()
+    arch = gpu_compute_capability()
     base = flash4_cute_kernel_config(args.head_dim, arch=arch)
     print(f"arch=sm{arch} base_forward_tile={base.forward_tile} base_backward_tile={base.backward_tile}")
     print(f"shape: batch={args.batch} seq={args.seq_len} q_heads={args.q_heads} head_dim={args.head_dim}")

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -1,7 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Hero-shape scaling ladder: one recipe, five widths.
+"""Hero-shape scaling ladders on GB200 and H100.
 
 Every rung trains the *same* EP hero recipe -- 384 routed experts, top-8, hidden/2-wide experts in a
 hidden/2 latent, pooled-wave transport, the Harrier 2026.08.18 two-phase mixture on the Marin
@@ -19,11 +19,23 @@ uniform across the ladder so a rung predicts the d6144 hero. ``d6144`` is the he
 Train batch is 1024 x racks (constant per-rack load); eval batch is 64 x racks (one sequence per
 device). Tokens/steps hold 791 tokens per active parameter (18T at d6144); FLOPs are the levanter
 analytic estimate (forward+backward, including attention and the latent-MoE correction).
+
+The H100 ladder extends the same recipe downward. Its global token batch is the largest power-of-two
+sequence batch no greater than ``training_tokens ** 0.6``. d384 uses EP4 because EP8 underfills the
+devices at this width, d512 uses EP8, and d768 uses two data-parallel EP8 replicas to stay
+comfortably below a 12-hour wall-time target. The hardware mapping changes only the expert/replica
+topology, accelerator kernels, and per-device eval batch:
+
+    size   H100 GPUs  EP per task  global batch  steps  tokens
+    d384       4           4            128       12162   6.4B
+    d512       8           8            256       15721    16B
+    d768      16           8            512       22840    48B
 """
 
 import dataclasses
 import os
 from datetime import timedelta
+from enum import StrEnum
 
 import click
 import jmp
@@ -32,6 +44,7 @@ from levanter.callbacks.profiler import ProfilerConfig
 from levanter.callbacks.progress_watchdog import ProgressWatchdogConfig
 from levanter.callbacks.watch import WatchConfig
 from levanter.checkpoint import CheckpointerConfig
+from levanter.grug.grug_moe import MoeImplementation
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
 from marin.execution.build_context import resolve_version
@@ -92,6 +105,8 @@ HERO_PROCESS_STALL_TIMEOUT = timedelta(hours=1)
 HERO_STARTUP_TIMEOUT = timedelta(seconds=2 * RESTORE_BARRIER_TIMEOUT)
 
 LADDER_RACKS: dict[str, int] = {"d768": 1, "d1024": 2, "d1536": 6, "d2048": 11, "d6144": 11}
+H100_LADDER_NODES: dict[str, int] = {"d384": 1, "d512": 1, "d768": 2}
+H100_LADDER_GPUS_PER_TASK: dict[str, int] = {"d384": 4, "d512": 8, "d768": 8}
 QB_HIST_BINS = 10_000
 # Gradient and parameter norm logs every 10 steps on every rung.
 WATCH_INTERVAL = 10
@@ -111,6 +126,85 @@ RESUME_SAVE_INTERVAL = timedelta(hours=1)
 # The two counters are separate gates and the job fails when either one trips.
 LADDER_MAX_RETRIES_FAILURE = 1000
 LADDER_MAX_TASK_FAILURES = 1000
+# H100 rungs are short diagnostics without the hero's multi-day exposure to routine hardware faults.
+# Keep retries bounded so a deterministic numerical failure cannot turn into a persistent restart loop.
+H100_MAX_RETRIES_FAILURE = 3
+H100_MAX_TASK_FAILURES = 3
+
+
+class LadderTarget(StrEnum):
+    GB200_RACK = "gb200-rack"
+    H100 = "h100"
+
+
+@dataclasses.dataclass(frozen=True)
+class LadderExecution:
+    accelerator: str
+    gpus_per_task: int
+    task_count: int
+    cpu: int
+    ram: str
+    disk: str
+    expert_axis_size: int
+    replica_axis_size: int
+    eval_batch_size: int
+    dropless_eval_moe_implementation: MoeImplementation
+    max_retries_failure: int
+    max_task_failures: int
+    tags: tuple[str, ...]
+
+
+def _ladder_execution(size: str, target: LadderTarget) -> LadderExecution:
+    if target == LadderTarget.GB200_RACK:
+        if size not in LADDER_RACKS:
+            raise ValueError(f"size must be one of {sorted(LADDER_RACKS)} for {target}, got {size!r}")
+        dp_racks = LADDER_RACKS[size]
+        return LadderExecution(
+            accelerator="GB200",
+            gpus_per_task=HERO_GPUS_PER_NODE,
+            task_count=HERO_EP_NODES * dp_racks,
+            cpu=120,
+            ram="890g",
+            disk="1t",
+            expert_axis_size=HERO_EP_EXPERT_AXIS_SIZE,
+            replica_axis_size=dp_racks,
+            eval_batch_size=HERO_EP_EXPERT_AXIS_SIZE * dp_racks,
+            dropless_eval_moe_implementation="sonic_cute",
+            max_retries_failure=LADDER_MAX_RETRIES_FAILURE,
+            max_task_failures=LADDER_MAX_TASK_FAILURES,
+            tags=(f"racks-{dp_racks}", "gb200"),
+        )
+
+    if size not in H100_LADDER_NODES:
+        raise ValueError(f"size must be one of {sorted(H100_LADDER_NODES)} for {target}, got {size!r}")
+    nodes = H100_LADDER_NODES[size]
+    gpus_per_task = H100_LADDER_GPUS_PER_TASK[size]
+    return LadderExecution(
+        accelerator="H100",
+        gpus_per_task=gpus_per_task,
+        task_count=nodes,
+        cpu=32,
+        ram="600g",
+        disk="900g",
+        expert_axis_size=gpus_per_task,
+        replica_axis_size=nodes,
+        eval_batch_size=gpus_per_task * nodes,
+        dropless_eval_moe_implementation="sonic",
+        max_retries_failure=H100_MAX_RETRIES_FAILURE,
+        max_task_failures=H100_MAX_TASK_FAILURES,
+        tags=(f"h100-nodes-{nodes}", "h100", f"ep{gpus_per_task}"),
+    )
+
+
+def _h100_ladder_batch_size(training_tokens: int, global_device_count: int) -> int:
+    """Largest power-of-two sequence batch within the token-budget scaling ceiling."""
+    max_sequences = int(training_tokens**0.6) // SEQ_LEN
+    if max_sequences < global_device_count:
+        raise ValueError(f"token batch ceiling permits {max_sequences} sequences for {global_device_count} devices")
+    batch_size = 1 << (max_sequences.bit_length() - 1)
+    assert batch_size % global_device_count == 0
+    assert batch_size * SEQ_LEN <= training_tokens**0.6
+    return batch_size
 
 
 def _ladder_model(size: str):
@@ -140,35 +234,43 @@ def build_ladder_run(
     *,
     run_id: str,
     size: str,
+    target: LadderTarget = LadderTarget.GB200_RACK,
     num_steps: int | None = None,
+    batch_size: int | None = None,
     checkpoint_every: int | None = None,
     version: str | None = None,
 ) -> ArtifactStep[HeroThroughputResult]:
-    """One scaling-ladder rung at width ``size`` on ``LADDER_RACKS[size]`` GB200 racks.
+    """One scaling-ladder rung at width ``size`` on the selected hardware target.
 
     ``num_steps`` defaults to the steps needed to train ``TOKENS_PER_ACTIVE_PARAM`` tokens per active
-    parameter at the rung's (rack-scaled) batch. Every eval scores the held-out set both as-trained
-    and dropless. The narrow rungs eval every 5% of the run and keep only the forced final
-    checkpoint; the d6144 hero evals every 3000 steps and keeps a permanent checkpoint every 6000.
-    ``checkpoint_every`` overrides that cadence for any rung. A rolling temporary checkpoint every
+    parameter at the rung's batch. ``batch_size`` overrides the hardware target's canonical batch
+    for a one-off comparison. Every eval scores the held-out set both as-trained and dropless. The
+    narrow rungs eval every 5% of the run and keep only the forced final checkpoint; the d6144 hero
+    evals every 3000 steps and keeps a permanent checkpoint every 6000. ``checkpoint_every``
+    overrides that cadence for any rung. A rolling temporary checkpoint every
     ``RESUME_SAVE_INTERVAL`` on region-local storage covers a crash or a preemption, and a rung
     resumes from the newest checkpoint it finds.
     """
     if not run_id.strip():
         raise ValueError("run_id must not be empty")
-    if size not in LADDER_RACKS:
-        raise ValueError(f"size must be one of {sorted(LADDER_RACKS)}, got {size!r}")
-
-    dp_racks = LADDER_RACKS[size]
-    # Weak scaling: batch grows with racks so per-rack token load (and the pooled-wave drop dynamics)
-    # stays constant across rungs. Eval batch is one sequence per device (64 per rack).
-    batch_size = HERO_EP_BATCH_SIZE * dp_racks
-    eval_batch_size = HERO_EP_EXPERT_AXIS_SIZE * dp_racks
+    execution = _ladder_execution(size, target)
+    model = _ladder_model(size)
+    training_tokens = TOKENS_PER_ACTIVE_PARAM * _active_params(model)
+    global_device_count = execution.gpus_per_task * execution.task_count
+    if batch_size is None and target == LadderTarget.H100:
+        batch_size = _h100_ladder_batch_size(
+            training_tokens,
+            global_device_count=global_device_count,
+        )
+    elif batch_size is None:
+        batch_size = HERO_EP_BATCH_SIZE * execution.replica_axis_size
+    elif batch_size <= 0 or batch_size % global_device_count != 0:
+        raise ValueError(f"batch_size must be positive and divisible by {global_device_count}, got {batch_size}")
+    eval_batch_size = execution.eval_batch_size
     global_tokens_per_step = batch_size * SEQ_LEN
 
-    model = _ladder_model(size)
     if num_steps is None:
-        num_steps = max(1, round(TOKENS_PER_ACTIVE_PARAM * _active_params(model) / global_tokens_per_step))
+        num_steps = max(1, round(training_tokens / global_tokens_per_step))
     elif num_steps <= 0:
         raise ValueError(f"num_steps must be positive, got {num_steps}")
     flops_per_example, _ = _compute_flops(model_config=model)
@@ -198,11 +300,11 @@ def build_ladder_run(
                 hidden_dim=model.hidden_dim,
                 seq_len=SEQ_LEN,
             ),
-            use_syrk=True,  # GB200 SM100 symmetric GEMM for MuonH Newton-Schulz
+            use_syrk=True,  # SM90/SM100 symmetric GEMM for MuonH Newton-Schulz
         )
 
-    # Uniform hero trainer: expert-parallel within each rack, replicated across racks, MuonH state
-    # offloaded to FP32 pinned host so the pooled all-to-all buffers keep their HBM.
+    # Uniform hero trainer: expert-parallel within each topology group, replicated across groups,
+    # with MuonH state offloaded to FP32 pinned host so pooled all-to-all buffers retain HBM.
     grug_trainer = GrugTrainerConfig(
         data_seed=None,
         log_every=1,
@@ -212,17 +314,17 @@ def build_ladder_run(
         master_param_mode=MasterParamMode.FP32_PINNED_HOST,
         watch_mode=WatchMode.INLINE,
         save_checkpoints=True,
-        expert_axis_size=HERO_EP_EXPERT_AXIS_SIZE,
-        replica_axis_size=dp_racks,
+        expert_axis_size=execution.expert_axis_size,
+        replica_axis_size=execution.replica_axis_size,
         sharding_dump_path=None,
     )
     train_resources = ResourceConfig.with_gpu(
-        "GB200",
-        count=HERO_GPUS_PER_NODE,
-        cpu=120,
-        ram="890g",
-        disk="1t",
-        replicas=HERO_EP_NODES * dp_racks,
+        execution.accelerator,
+        count=execution.gpus_per_task,
+        cpu=execution.cpu,
+        ram=execution.ram,
+        disk=execution.disk,
+        replicas=execution.task_count,
     )
     name = f"grug/{run_id}"
     version = resolve_version(name, version)
@@ -250,8 +352,7 @@ def build_ladder_run(
                     "ep",
                     "scaling-ladder",
                     f"shape-{size}",
-                    f"racks-{dp_racks}",
-                    "gb200",
+                    *execution.tags,
                     HARRIER_MIX_2026_08_18_TAG,
                 ],
                 group="moe-hero-ep-scaling-ladder",
@@ -307,14 +408,15 @@ def build_ladder_run(
                 eval_ema=False,
                 compute_bpb=True,
                 dropless_eval=True,
+                dropless_eval_moe_implementation=execution.dropless_eval_moe_implementation,
                 # The hero is the run whose full loss curve we report, so give it a baseline point
                 # at the start of the curve.
                 eval_at_first_step=size == "d6144",
             ),
             stop_after_steps=num_steps,
-            processes_per_task=HERO_GPUS_PER_NODE,
-            max_retries_failure=LADDER_MAX_RETRIES_FAILURE,
-            max_task_failures=LADDER_MAX_TASK_FAILURES,
+            processes_per_task=execution.gpus_per_task,
+            max_retries_failure=execution.max_retries_failure,
+            max_task_failures=execution.max_task_failures,
         )
 
     return ArtifactStep(
@@ -330,12 +432,30 @@ def build_ladder_run(
 
 @click.command()
 @click.option("--run-id", required=True, help="Run identifier for artifact and W&B names.")
-@click.option("--size", required=True, type=click.Choice(sorted(LADDER_RACKS)), help="Ladder rung width.")
+@click.option(
+    "--size",
+    required=True,
+    type=click.Choice(sorted(set(LADDER_RACKS) | set(H100_LADDER_NODES))),
+    help="Ladder rung width; availability depends on --target.",
+)
+@click.option(
+    "--target",
+    type=click.Choice([target.value for target in LadderTarget]),
+    default=LadderTarget.GB200_RACK.value,
+    show_default=True,
+    help="Canonical GB200 racks or the H100 EP4/EP8 ladder mapping.",
+)
 @click.option(
     "--num-steps",
     type=click.IntRange(min=1),
     default=None,
     help="Training steps. Default trains 791 tokens per active parameter at the rung's batch.",
+)
+@click.option(
+    "--batch-size",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Global sequence batch override. Default follows the selected hardware target.",
 )
 @click.option(
     "--checkpoint-every",
@@ -347,9 +467,21 @@ def build_ladder_run(
 )
 @build_options
 def main(
-    run_id: str, size: str, num_steps: int | None, checkpoint_every: int | None
+    run_id: str,
+    size: str,
+    target: str,
+    num_steps: int | None,
+    batch_size: int | None,
+    checkpoint_every: int | None,
 ) -> ArtifactStep[HeroThroughputResult]:
-    return build_ladder_run(run_id=run_id, size=size, num_steps=num_steps, checkpoint_every=checkpoint_every)
+    return build_ladder_run(
+        run_id=run_id,
+        size=size,
+        target=LadderTarget(target),
+        num_steps=num_steps,
+        batch_size=batch_size,
+        checkpoint_every=checkpoint_every,
+    )
 
 
 if __name__ == "__main__":

--- a/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_scaling_ladder.py
@@ -3,11 +3,11 @@
 
 """Hero-shape scaling ladders on GB200 and H100.
 
-Every rung trains the *same* EP hero recipe -- 384 routed experts, top-8, hidden/2-wide experts in a
-hidden/2 latent, pooled-wave transport, the Harrier 2026.08.18 two-phase mixture on the Marin
+The GB200 rungs train the same EP hero recipe -- 384 routed experts, top-8, hidden/2-wide experts in
+a hidden/2 latent, pooled-wave transport, the Harrier 2026.08.18 two-phase mixture on the Marin
 tokenizer, offloaded MuonH state on FP32 pinned-host master params, the QB histogram estimator, and
-a dropless held-out eval -- and differs only in width and the rack count it spans. Behaviour is
-uniform across the ladder so a rung predicts the d6144 hero. ``d6144`` is the hero itself.
+a dropless held-out eval. They differ only in width and rack count, so a rung predicts the d6144
+hero. ``d6144`` is the hero itself.
 
     size   racks  batch    steps  eval        checkpoints  tokens  active  total   FLOPs
     d768     1     1024    11420  every 5%    final only     48B     61M    1.6B    5.5e19
@@ -23,8 +23,8 @@ analytic estimate (forward+backward, including attention and the latent-MoE corr
 The H100 ladder extends the same recipe downward. Its global token batch is the largest power-of-two
 sequence batch no greater than ``training_tokens ** 0.6``. d384 uses EP4 because EP8 underfills the
 devices at this width, d512 uses EP8, and d768 uses two data-parallel EP8 replicas to stay
-comfortably below a 12-hour wall-time target. The hardware mapping changes only the expert/replica
-topology, accelerator kernels, and per-device eval batch:
+comfortably below a 12-hour wall-time target. Its execution mapping selects the expert/replica
+topology, accelerator kernels, per-device eval batch, and bounded retry policy:
 
     size   H100 GPUs  EP per task  global batch  steps  tokens
     d384       4           4            128       12162   6.4B
@@ -105,14 +105,14 @@ HERO_PROCESS_STALL_TIMEOUT = timedelta(hours=1)
 HERO_STARTUP_TIMEOUT = timedelta(seconds=2 * RESTORE_BARRIER_TIMEOUT)
 
 LADDER_RACKS: dict[str, int] = {"d768": 1, "d1024": 2, "d1536": 6, "d2048": 11, "d6144": 11}
-H100_LADDER_NODES: dict[str, int] = {"d384": 1, "d512": 1, "d768": 2}
-H100_LADDER_GPUS_PER_TASK: dict[str, int] = {"d384": 4, "d512": 8, "d768": 8}
+H100_LADDER_SIZES = ("d384", "d512", "d768")
 QB_HIST_BINS = 10_000
 # Gradient and parameter norm logs every 10 steps on every rung.
 WATCH_INTERVAL = 10
 # 791 tokens per active parameter sets the step budget: it lands the d6144 hero at 18T tokens and
 # scales every narrower rung by the same ratio.
 TOKENS_PER_ACTIVE_PARAM = 791
+H100_BATCH_TOKEN_EXPONENT = 0.6
 # The decoded-chunk cache is process-local. A two-tray loader benchmark at the hero's global batch
 # and sequence length found 1 GB retained 18.6x throughput headroom while bounding the cache near
 # 0.923 GiB per process; 125 GB allowed native RSS to grow until the cache filled.
@@ -175,10 +175,14 @@ def _ladder_execution(size: str, target: LadderTarget) -> LadderExecution:
             tags=(f"racks-{dp_racks}", "gb200"),
         )
 
-    if size not in H100_LADDER_NODES:
-        raise ValueError(f"size must be one of {sorted(H100_LADDER_NODES)} for {target}, got {size!r}")
-    nodes = H100_LADDER_NODES[size]
-    gpus_per_task = H100_LADDER_GPUS_PER_TASK[size]
+    if size == "d384":
+        nodes, gpus_per_task = 1, 4
+    elif size == "d512":
+        nodes, gpus_per_task = 1, 8
+    elif size == "d768":
+        nodes, gpus_per_task = 2, 8
+    else:
+        raise ValueError(f"size must be one of {list(H100_LADDER_SIZES)} for {target}, got {size!r}")
     return LadderExecution(
         accelerator="H100",
         gpus_per_task=gpus_per_task,
@@ -198,12 +202,13 @@ def _ladder_execution(size: str, target: LadderTarget) -> LadderExecution:
 
 def _h100_ladder_batch_size(training_tokens: int, global_device_count: int) -> int:
     """Largest power-of-two sequence batch within the token-budget scaling ceiling."""
-    max_sequences = int(training_tokens**0.6) // SEQ_LEN
+    token_ceiling = training_tokens**H100_BATCH_TOKEN_EXPONENT
+    max_sequences = int(token_ceiling) // SEQ_LEN
     if max_sequences < global_device_count:
         raise ValueError(f"token batch ceiling permits {max_sequences} sequences for {global_device_count} devices")
     batch_size = 1 << (max_sequences.bit_length() - 1)
     assert batch_size % global_device_count == 0
-    assert batch_size * SEQ_LEN <= training_tokens**0.6
+    assert batch_size * SEQ_LEN <= token_ceiling
     return batch_size
 
 
@@ -435,7 +440,7 @@ def build_ladder_run(
 @click.option(
     "--size",
     required=True,
-    type=click.Choice(sorted(set(LADDER_RACKS) | set(H100_LADDER_NODES))),
+    type=click.Choice(sorted(set(LADDER_RACKS) | set(H100_LADDER_SIZES))),
     help="Ladder rung width; availability depends on --target.",
 )
 @click.option(

--- a/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
+++ b/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
@@ -169,7 +169,7 @@ class SmallShape:
     global_kv_heads: int
 
 
-# Hidden/depth/head split extends the #7856 sweep grid downward: heads = hidden/128, KV split local =
+# Hidden/depth/head split extends the established sweep grid downward: heads = hidden/128, KV split local =
 # heads//4 and global = heads//8 (floored at 1), with depth 4/6/8/12/14/16/22. The step count is
 # derived from the active-param count (see `_active_params`), not carried here.
 SMALL_SHAPES: dict[str, SmallShape] = {

--- a/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
+++ b/experiments/grug/moe_hero_ep/small_scale_abl_launch.py
@@ -1,7 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Small-scale hero-shape ablation: d768 / d1024 / d1280 / d1536 / d2048.
+"""Small-scale hero-shape ablation: d384 / d512 / d768 / d1024 / d1280 / d1536 / d2048.
 
 These runs mirror the EP hero: 384 routed experts, top-8 routing, hidden/2-wide experts in a hidden/2
 latent, two shared experts, and the pooled-wave all-to-all transport at receiver/sender capacity 1.15.
@@ -98,11 +98,9 @@ class Target:
 # These models are small enough to hold a whole rack's worth of experts on one node, so the H100
 # target keeps the all-to-all inside a single NVLink domain instead of crossing InfiniBand.
 #
-# Kernel availability follows the accelerator, in two places. `gpu_fa4_cute` is Blackwell-only: its
-# MMA op accepts sm_100/sm_103/sm_110 and rejects H100's sm_90a outright, and `gpu_fa4_thd` needs
-# fixed-shape THD segment metadata this model does not supply, so Hopper falls back to reference
-# attention. MuonH's `use_syrk` likewise routes the 4D expert-stack Newton-Schulz through QuACK's
-# SM100 symmetric GEMM, so Hopper takes the plain vmapped path instead.
+# These established small-scale H100 targets retain reference attention and the dense MuonH path for
+# comparability. The scaling-ladder launcher separately selects the validated SM90 FA4 and symmetric
+# GEMM kernels on Hopper.
 TARGETS: dict[str, Target] = {
     "gb200-rack": Target("GB200", HERO_GPUS_PER_NODE, HERO_EP_NODES, 120, "850g", "1t", "gpu_fa4_cute", True),
     # 8 nodes, not 1: under pooled-wave the receiver cell pools over all senders and is
@@ -171,10 +169,12 @@ class SmallShape:
     global_kv_heads: int
 
 
-# hidden/depth/head split from the #7856 sweep grid: heads = hidden/128, KV split local = heads//4 and
-# global = heads//8 (floored at 1), depth following the 8/12/14/16/22 progression. The step count is
+# Hidden/depth/head split extends the #7856 sweep grid downward: heads = hidden/128, KV split local =
+# heads//4 and global = heads//8 (floored at 1), with depth 4/6/8/12/14/16/22. The step count is
 # derived from the active-param count (see `_active_params`), not carried here.
 SMALL_SHAPES: dict[str, SmallShape] = {
+    "d384": SmallShape(384, 4, 3, 1, 1),
+    "d512": SmallShape(512, 6, 4, 1, 1),
     "d768": SmallShape(768, 8, 6, 1, 1),
     "d1024": SmallShape(1024, 12, 8, 2, 1),
     "d1280": SmallShape(1280, 14, 10, 2, 1),

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -347,7 +347,7 @@ def _reshard_tree_to_mesh(tree, mesh: Mesh):
     return jax.tree.map(move, tree)
 
 
-def _to_dropless_local(model: Transformer, *, implementation: MoeImplementation = "sonic_cute") -> Transformer:
+def _to_dropless_local(model: Transformer, *, implementation: MoeImplementation) -> Transformer:
     """Swap the scanned block's MoE expert backend to the selected dropless local path.
 
     ``implementation``/``expert_chunks`` are static fields shared across the whole stacked block,

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -37,6 +37,7 @@ from levanter.data.mixture import MixtureDataset, rescale_mixture_schedule_for_b
 from levanter.data.text.datasets import LmDataConfig
 from levanter.data.text.examples import GrugLmExample, grug_lm_example_from_named
 from levanter.eval import TaggedEvaluator, cb_tagged_evaluate, eval_model
+from levanter.grug.grug_moe import MoeImplementation
 from levanter.grug.sharding import compact_grug_mesh
 from levanter.models.lm_model import LmExample
 from levanter.optim.config import AdamConfig, OptimizerConfig
@@ -205,6 +206,9 @@ class GrugEvalConfig:
     # expert-collapsed mesh, logging a separate `eval_dropless` macro loss alongside the
     # as-trained (with-drop) eval. No-op when the mesh has no expert parallelism.
     dropless_eval: bool = False
+    # Local MoE kernel used after collapsing the expert axis. ``sonic`` is the Hopper Triton path;
+    # ``sonic_cute`` is the Blackwell QuACK/CUTLASS path.
+    dropless_eval_moe_implementation: MoeImplementation = "sonic_cute"
     # Run the evals once after the first optimization step, for a baseline at the start of the loss
     # curve. The periodic cadence first fires at `steps_per_eval`, thus it leaves that start bare.
     eval_at_first_step: bool = False
@@ -343,8 +347,8 @@ def _reshard_tree_to_mesh(tree, mesh: Mesh):
     return jax.tree.map(move, tree)
 
 
-def _to_dropless_local(model: Transformer) -> Transformer:
-    """Swap the scanned block's MoE expert backend to the dropless local ``sonic_cute`` path.
+def _to_dropless_local(model: Transformer, *, implementation: MoeImplementation = "sonic_cute") -> Transformer:
+    """Swap the scanned block's MoE expert backend to the selected dropless local path.
 
     ``implementation``/``expert_chunks`` are static fields shared across the whole stacked block,
     so one replacement covers every layer. The forward reads ``self.expert_mlp.implementation``
@@ -352,7 +356,7 @@ def _to_dropless_local(model: Transformer) -> Transformer:
     mesh: the local backend raises when the mesh expert axis is larger than one.
     """
     expert_mlp = model.stacked_blocks.stacked.mlp.expert_mlp
-    dropless = dataclasses.replace(expert_mlp, implementation="sonic_cute", expert_chunks=1)
+    dropless = dataclasses.replace(expert_mlp, implementation=implementation, expert_chunks=1)
     return eqx.tree_at(lambda m: m.stacked_blocks.stacked.mlp.expert_mlp, model, dropless)
 
 
@@ -910,7 +914,10 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                         mesh=dropless_eval_mesh,
                         eval_cfg=eval_cfg,
                         mp=trainer.mp,
-                        model_transform=_to_dropless_local,
+                        model_transform=functools.partial(
+                            _to_dropless_local,
+                            implementation=eval_cfg.dropless_eval_moe_implementation,
+                        ),
                     )
 
         # `trainer.num_train_steps` sizes the schedule; this bounds the run. Progress and the loop

--- a/lib/levanter/src/levanter/cutlass_kernel_cache.py
+++ b/lib/levanter/src/levanter/cutlass_kernel_cache.py
@@ -204,3 +204,18 @@ def _kernel_cache_revision() -> str:
 def _device_architecture() -> str:
     device = jax.local_devices()[0]
     return f"{device.platform}-{getattr(device, 'compute_capability', device.device_kind)}"
+
+
+def gpu_compute_capability() -> int:
+    """Return the CUDA compute capability as an integer such as 90 or 100."""
+    for device in jax.local_devices(backend="gpu"):
+        compute_capability = getattr(device, "compute_capability", None)
+        if callable(compute_capability):
+            compute_capability = compute_capability()
+        if isinstance(compute_capability, tuple) and len(compute_capability) >= 2:
+            return int(compute_capability[0]) * 10 + int(compute_capability[1])
+        if isinstance(compute_capability, str):
+            major, _, minor = compute_capability.partition(".")
+            if major.isdigit() and minor.isdigit():
+                return int(major) * 10 + int(minor)
+    raise RuntimeError("Could not determine CUDA compute capability.")

--- a/lib/levanter/src/levanter/grug/_moe/quack_symmetric_cute.py
+++ b/lib/levanter/src/levanter/grug/_moe/quack_symmetric_cute.py
@@ -1,23 +1,7 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""CuTeDSL->JAX bridge for QuACK's symmetric GEMM (D = X @ X^T, full symmetric via an
-in-kernel mirror), used to accelerate the two symmetric products in the Grug Muon Newton-Schulz.
-
-A thin ``@cute.jit`` launcher over QuACK's architecture-specific kernel wrapped with
-``cutlass.jax.cutlass_call``
-(the same bridge the FA4 attention backend uses, so the kernel runs on XLA's stream and is ordered
-correctly with the surrounding graph). The kernel computes ``A @ B^T`` with a triangular tile
-scheduler that writes each lower tile to D and its mirror to ``D.mT`` (same storage), so D comes out
-fully symmetric with ~half the matmul FLOPs.
-
-Configs match QuACK's own paths: SM90 uses ``mma_tiler (128, 256)`` and SM100 uses ``(256, 256)``;
-both use ``cluster (2, 1, 1)`` and static persistence. The dynamic CLC scheduler (with its GMEM
-tile-count semaphore) raced between clusters and returned intermittent garbage on tiny-magnitude and
-square SM100 inputs; static persistence is deterministic and validated end to end.
-
-Lazy-imported with the GPU-only Grug backend, like the sonic MoE backend.
-"""
+"""QuACK symmetric GEMM for Grug Muon Newton-Schulz on Hopper and Blackwell GPUs."""
 
 from __future__ import annotations
 
@@ -53,6 +37,8 @@ _JAX_TO_CUTE = {
 # loss 11.8 -> 5.94). Do not narrow tile_N without validating on the full set of live NS shapes.
 _SM90_MMA_TILER = (128, 256)
 _SM100_MMA_TILER = (256, 256)
+_HOPPER_ARCH_FAMILY = 9
+_BLACKWELL_ARCH_FAMILIES = (10, 11)
 _DEFAULT_CLUSTER = (2, 1, 1)
 _DEFAULT_SWIZZLE = 8
 
@@ -68,16 +54,16 @@ def _transpose_mn(mD):
 
 def _symmetric_gemm_config(arch: int) -> tuple[int, tuple[int, int]]:
     arch_family = arch // 10
-    if arch_family == 9:
+    if arch_family == _HOPPER_ARCH_FAMILY:
         return arch_family, _SM90_MMA_TILER
-    if arch_family in (10, 11):
+    if arch_family in _BLACKWELL_ARCH_FAMILIES:
         return arch_family, _SM100_MMA_TILER
     raise NotImplementedError(f"QuACK symmetric GEMM does not support CUDA compute capability {arch}.")
 
 
 @cute_launcher_factory
 def _build_launcher(*, arch_family, a_dtype, mma_tiler_mnk, cluster_mnk, mac, max_swizzle):
-    gemm_type = GemmSymmetricSm90 if arch_family == 9 else GemmSymmetricSm100
+    gemm_type = GemmSymmetricSm90 if arch_family == _HOPPER_ARCH_FAMILY else GemmSymmetricSm100
 
     @cute.jit
     def launcher(stream, mA, mB, mD):

--- a/lib/levanter/src/levanter/grug/_moe/quack_symmetric_cute.py
+++ b/lib/levanter/src/levanter/grug/_moe/quack_symmetric_cute.py
@@ -1,23 +1,24 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""CuTeDSL->JAX bridge for QuACK's SM100 symmetric GEMM (D = X @ X^T, full symmetric via
+"""CuTeDSL->JAX bridge for QuACK's symmetric GEMM (D = X @ X^T, full symmetric via an
 in-kernel mirror), used to accelerate the two symmetric products in the Grug Muon Newton-Schulz.
 
-A thin ``@cute.jit`` launcher over ``GemmSymmetricSm100`` wrapped with ``cutlass.jax.cutlass_call``
+A thin ``@cute.jit`` launcher over QuACK's architecture-specific kernel wrapped with
+``cutlass.jax.cutlass_call``
 (the same bridge the FA4 attention backend uses, so the kernel runs on XLA's stream and is ordered
 correctly with the surrounding graph). The kernel computes ``A @ B^T`` with a triangular tile
 scheduler that writes each lower tile to D and its mirror to ``D.mT`` (same storage), so D comes out
 fully symmetric with ~half the matmul FLOPs.
 
-Config matches QuACK's own SM100 path exactly: ``mma_tiler (256, 256)``, ``cluster (2, 1, 1)``, and
-**static** persistence (``use_clc_persistence=False``). The dynamic CLC scheduler (with its GMEM
-tile-count semaphore) races between clusters and returned intermittent garbage on tiny-magnitude and
-square inputs; static persistence is deterministic and bit-exact on all inputs (gram, tiny gram,
-square A@A). Validated ~1.7x vs dense on the symmetric products (GB200, 128 experts).
+Configs match QuACK's own paths: SM90 uses ``mma_tiler (128, 256)`` and SM100 uses ``(256, 256)``;
+both use ``cluster (2, 1, 1)`` and static persistence. The dynamic CLC scheduler (with its GMEM
+tile-count semaphore) raced between clusters and returned intermittent garbage on tiny-magnitude and
+square SM100 inputs; static persistence is deterministic and validated end to end.
 
-Lazy-imported (quack/cutlass-dsl is Blackwell-only), like the sonic MoE backend.
+Lazy-imported with the GPU-only Grug backend, like the sonic MoE backend.
 """
+
 from __future__ import annotations
 
 import jax
@@ -27,9 +28,9 @@ import cutlass
 import cutlass.cute as cute
 import cutlass.jax as cjax
 from cutlass import Float32
-from levanter.cutlass_kernel_cache import cute_launcher_factory, cutlass_call
+from levanter.cutlass_kernel_cache import cute_launcher_factory, cutlass_call, gpu_compute_capability
 from quack.gemm import make_scheduler_args
-from quack.gemm_symmetric import GemmSymmetricMixin, GemmSymmetricSm100
+from quack.gemm_symmetric import GemmSymmetricMixin, GemmSymmetricSm90, GemmSymmetricSm100
 
 try:
     from quack.cute_dsl_utils import get_max_active_clusters
@@ -43,16 +44,17 @@ _JAX_TO_CUTE = {
     jnp.dtype(jnp.float32): cutlass.Float32,
 }
 
-# QuACK's SM100 symmetric config (_symmetric_gemm_config): tile (256, 256), cluster_M 2, static.
+# QuACK's symmetric configs (_symmetric_gemm_config): SM90 uses tile (128, 256), SM100 uses
+# tile (256, 256); both use cluster_M 2 and static persistence.
 # NOTE: (256, 128) benchmarks 1.62x faster on the isolated [96, 2560, 5120] expert gram, but it
 # BREAKS live training (loss stuck at init, run never progresses) -- the NS also orthogonalizes
 # non-expert matrices whose shapes (256, 128) does not handle correctly, and the isolated gram
 # microbench does not cover them. (256, 256) is validated clean end-to-end (30-step GB200 run,
 # loss 11.8 -> 5.94). Do not narrow tile_N without validating on the full set of live NS shapes.
-_DEFAULT_MMA_TILER = (256, 256)
+_SM90_MMA_TILER = (128, 256)
+_SM100_MMA_TILER = (256, 256)
 _DEFAULT_CLUSTER = (2, 1, 1)
 _DEFAULT_SWIZZLE = 8
-_FALLBACK_MAX_ACTIVE_CLUSTERS = 148
 
 
 def _cute_dtype(dt):
@@ -64,13 +66,24 @@ def _transpose_mn(mD):
     return cute.make_tensor(mD.iterator, cute.select(mD.layout, mode=[1, 0, 2]))
 
 
+def _symmetric_gemm_config(arch: int) -> tuple[int, tuple[int, int]]:
+    arch_family = arch // 10
+    if arch_family == 9:
+        return arch_family, _SM90_MMA_TILER
+    if arch_family in (10, 11):
+        return arch_family, _SM100_MMA_TILER
+    raise NotImplementedError(f"QuACK symmetric GEMM does not support CUDA compute capability {arch}.")
+
+
 @cute_launcher_factory
-def _build_launcher(*, a_dtype, mma_tiler_mnk, cluster_mnk, mac, max_swizzle):
+def _build_launcher(*, arch_family, a_dtype, mma_tiler_mnk, cluster_mnk, mac, max_swizzle):
+    gemm_type = GemmSymmetricSm90 if arch_family == 9 else GemmSymmetricSm100
+
     @cute.jit
     def launcher(stream, mA, mB, mD):
         # Static persistence (use_clc_persistence=False): no tile-count semaphore, deterministic
         # tile scheduling. The dynamic CLC path raced and corrupted tiny/square outputs.
-        gemm = GemmSymmetricSm100(_ACC, a_dtype, mma_tiler_mnk, cluster_mnk, use_clc_persistence=False)
+        gemm = gemm_type(_ACC, a_dtype, mma_tiler_mnk, cluster_mnk, use_clc_persistence=False)
         # aux = D.mT (transposed view of the single output): the kernel writes each lower tile to D
         # and its mirror to D.mT, so D is fully symmetric. alpha/beta must be set (D = a*acc + b*C).
         epi_args = GemmSymmetricMixin.EpilogueArguments(
@@ -85,7 +98,7 @@ def _build_launcher(*, a_dtype, mma_tiler_mnk, cluster_mnk, mac, max_swizzle):
 def quack_symmetric_gemm(
     X: jax.Array,
     *,
-    mma_tiler_mnk: tuple[int, int] = _DEFAULT_MMA_TILER,
+    mma_tiler_mnk: tuple[int, int] | None = None,
     cluster_mnk: tuple[int, int, int] = _DEFAULT_CLUSTER,
     max_swizzle: int = _DEFAULT_SWIZZLE,
 ) -> jax.Array:
@@ -95,13 +108,18 @@ def quack_symmetric_gemm(
     The kernel computes ``A @ B^T``, so both operands are ``X``, k-major ([M, K, L], mode (1,2,0)).
     """
     L, M, K = X.shape
+    arch_family, default_mma_tiler = _symmetric_gemm_config(gpu_compute_capability())
+    if mma_tiler_mnk is None:
+        mma_tiler_mnk = default_mma_tiler
     a_dtype = _cute_dtype(X.dtype)
-    try:
-        mac = get_max_active_clusters(cluster_mnk[0] * cluster_mnk[1])
-    except Exception:
-        mac = _FALLBACK_MAX_ACTIVE_CLUSTERS
+    mac = get_max_active_clusters(cluster_mnk[0] * cluster_mnk[1])
     launcher = _build_launcher(
-        a_dtype=a_dtype, mma_tiler_mnk=mma_tiler_mnk, cluster_mnk=cluster_mnk, mac=mac, max_swizzle=max_swizzle
+        arch_family=arch_family,
+        a_dtype=a_dtype,
+        mma_tiler_mnk=mma_tiler_mnk,
+        cluster_mnk=cluster_mnk,
+        mac=mac,
+        max_swizzle=max_swizzle,
     )
     ts = cjax.TensorSpec
     spec = ts(mode=(1, 2, 0), divisibility=(1, 1, 8), static=False)
@@ -114,6 +132,3 @@ def quack_symmetric_gemm(
     )
     (d,) = call(X, X)
     return d
-
-
-__all__ = ["quack_symmetric_gemm"]

--- a/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
+++ b/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
@@ -12,6 +12,7 @@ from jax.sharding import NamedSharding, PartitionSpec as P
 from jax.sharding import get_abstract_mesh, reshard
 from jaxtyping import Array, Bool, Float, Int
 
+from levanter.cutlass_kernel_cache import gpu_compute_capability
 from levanter.grug.attention._core import AttentionMask
 from levanter.grug.attention._fa4_cute_backend import fa4_cute_attention_forward
 from levanter.grug.attention._fa4_cute_config import Flash4CuteKernelConfig, flash4_cute_kernel_config
@@ -280,22 +281,8 @@ def _fa4_cute_attention_forward_sharded(
     return _local_fa4_attention(q, k, v, lower_bounds, valid)
 
 
-def _gpu_compute_arch() -> int:
-    for device in jax.local_devices(backend="gpu"):
-        compute_capability = getattr(device, "compute_capability", None)
-        if callable(compute_capability):
-            compute_capability = compute_capability()
-        if isinstance(compute_capability, tuple) and len(compute_capability) >= 2:
-            return int(compute_capability[0]) * 10 + int(compute_capability[1])
-        if isinstance(compute_capability, str):
-            major, _, minor = compute_capability.partition(".")
-            if major.isdigit() and minor.isdigit():
-                return int(major) * 10 + int(minor)
-    raise RuntimeError("Could not determine CUDA compute capability for FA4/CuTe attention.")
-
-
 def _segmented_kernel_config(head_dim: int):
-    arch = _gpu_compute_arch()
+    arch = gpu_compute_capability()
     kernel_config = flash4_cute_kernel_config(head_dim, arch=arch)
 
     # Upstream flash-attn-4 4.0.0b15 dense SM100 FA4 uses 128x128 tiles in

--- a/lib/levanter/src/levanter/grug/attention/_fa4_thd.py
+++ b/lib/levanter/src/levanter/grug/attention/_fa4_thd.py
@@ -18,9 +18,8 @@ from jax.sharding import PartitionSpec as P
 from jax.sharding import reshard
 from jaxtyping import Array, Bool, Float, Int
 
-from levanter.cutlass_kernel_cache import cute_launcher_factory, cutlass_call
+from levanter.cutlass_kernel_cache import cute_launcher_factory, cutlass_call, gpu_compute_capability
 from levanter.grug.attention._core import AttentionMask
-from levanter.grug.attention._fa4_cute import _gpu_compute_arch
 from levanter.grug.attention._fa4_cute_config import Flash4CuteKernelConfig, flash4_cute_kernel_config
 
 
@@ -59,7 +58,7 @@ def _sm90_backward_kernel_options() -> dict[str, int | bool]:
 @functools.lru_cache(maxsize=1)
 def _import_upstream_fa4_cute() -> _UpstreamFa4CuteModules:
     try:
-        arch = _gpu_compute_arch()
+        arch = gpu_compute_capability()
         arch_family = arch // 10
         cutlass = importlib.import_module("cutlass")
         cute = importlib.import_module("cutlass.cute")
@@ -158,7 +157,7 @@ def _validate_simple_causal_self_attention(
 
 
 def _thd_kernel_config(head_dim: int) -> Flash4CuteKernelConfig:
-    arch = _gpu_compute_arch()
+    arch = gpu_compute_capability()
     arch_family = arch // 10
     if arch_family not in _SUPPORTED_ARCH_FAMILIES:
         raise NotImplementedError(f"gpu_fa4_thd_attention currently supports only SM90/SM100/SM110, got SM{arch}.")

--- a/lib/levanter/tests/grug/test_attention.py
+++ b/lib/levanter/tests/grug/test_attention.py
@@ -153,7 +153,7 @@ def test_gpu_fa4_thd_rejects_nonpositive_sliding_window():
 
 
 def test_gpu_fa4_thd_supports_hopper_kernel_config(monkeypatch):
-    monkeypatch.setattr(fa4_thd, "_gpu_compute_arch", lambda: 90)
+    monkeypatch.setattr(fa4_thd, "gpu_compute_capability", lambda: 90)
 
     config = fa4_thd._thd_kernel_config(128)
 
@@ -243,7 +243,7 @@ def test_real_gpu_fa4_thd_attention_matches_reference_value_and_gradients(slidin
     pytest.importorskip("cutlass")
     pytest.importorskip("cutlass.cute")
     pytest.importorskip("flash_attn.cute.flash_bwd_preprocess")
-    arch_family = fa4_thd._gpu_compute_arch() // 10
+    arch_family = fa4_thd.gpu_compute_capability() // 10
     if arch_family not in fa4_thd._SUPPORTED_ARCH_FAMILIES:
         pytest.skip("gpu_fa4_thd_attention supports only SM90/SM100/SM110.")
     if sliding_window is not None and arch_family == fa4_thd._HOPPER_ARCH_FAMILY:

--- a/tests/test_moe_hero_ep.py
+++ b/tests/test_moe_hero_ep.py
@@ -428,7 +428,7 @@ def test_dropless_local_transform_swaps_moe_backend_and_shares_weights():
     )
     with set_mesh(mesh):
         m = model.Transformer.init(cfg, key=jax.random.key(0))
-    dropless = train._to_dropless_local(m)
+    dropless = train._to_dropless_local(m, implementation="sonic_cute")
 
     original = m.stacked_blocks.stacked.mlp.expert_mlp
     swapped = dropless.stacked_blocks.stacked.mlp.expert_mlp


### PR DESCRIPTION
Add an H100 target to the 791-token-per-active-parameter hero ladder. d384 uses one four-GPU EP4 task with batch 128, d512 uses one eight-GPU EP8 task with batch 256, and d768 uses two eight-GPU EP8 tasks with batch 512. Each batch is the largest power of two within `training_tokens ** 0.6`; the step budget and compute-scaled optimizer are rebuilt from the selected batch.

Hopper runs use SM90 FA4 attention, the Triton Sonic backend for dropless evaluation, and QuACK's SM90 symmetric GEMM for MuonH. Full d384/batch128 and d768/batch512 runs reached 12,161/12,162 and 22,839/22,840 optimizer steps. A d512/batch1024 control reached 3,929/3,930.

The canonical d512/batch256 config reproduces an unresolved numerical failure. Four attempts produced NaN loss at steps 93, 114, 314, and 952 before the first hourly checkpoint. H100 retry budgets stop after three failures to prevent persistent restarts. Investigation is tracked in [Echo incident 240](https://echo.oa.dev/wiki/240).
