### PR TITLE
[grug] Add standalone H100 hero scaling ladder

### DIFF
--- a/experiments/benchmarks/fa4/tile_sweep.py
+++ b/experiments/benchmarks/fa4/tile_sweep.py
@@ -41,6 +41,7 @@ from unittest.mock import patch
 import jax
 import jax.numpy as jnp
 import numpy as np
+from levanter.cutlass_kernel_cache import gpu_compute_capability
 from levanter.grug.attention import AttentionMask, reference_attention
 from levanter.grug.attention import _fa4_cute as fa4_cute
 from levanter.grug.attention import _fa4_cute_kernels as fa4_cute_kernels
@@ -270,7 +271,7 @@ def main() -> None:
     v = jax.random.normal(jax.random.fold_in(key, 2), shape_kv, dtype=jnp.bfloat16)
     segment_ids = _segment_ids(args.batch, args.seq_len, args.documents)
 
-    arch = fa4_cute._gpu_compute_arch()
+    arch = gpu_compute_capability()
     base = flash4_cute_kernel_config(args.head_dim, arch=arch)
     print(f"arch=sm{arch} base_forward_tile={base.forward_tile} base_backward_tile={base.backward_tile}")
     print(f"shape: batch={args.batch} seq={args.seq_len} q_heads={args.q_heads} head_dim={args.head_dim}")

--- a/experiments/grug/moe_hero_ep/launch_h100_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_h100_scaling_ladder.py
@@ -3,12 +3,11 @@
 
 """H100 scaling ladder for the Grug MoE EP hero recipe.
 
-The three rungs keep the existing hero model, data, optimizer, and 791-token-per-active-parameter
+The two rungs keep the existing hero model, data, optimizer, and 791-token-per-active-parameter
 scaling rules while mapping the expert and replica axes onto Hopper nodes. Every rung uses a global
 sequence batch of 1024.
 
     size   H100 GPUs  EP per task  global batch  steps  tokens
-    d384       4           4           1024        1520   6.4B
     d512       8           8           1024        3930    16B
     d768      16           8           1024       11420    48B
 
@@ -68,7 +67,7 @@ from experiments.grug.moe_hero_ep.train import (
 )
 from experiments.marin_tokenizer import marin_tokenizer
 
-H100_LADDER_SIZES = ("d384", "d512", "d768")
+H100_LADDER_SIZES = ("d512", "d768")
 GLOBAL_BATCH_SIZE = 1024
 QB_HIST_BINS = 10_000
 WATCH_INTERVAL = 10
@@ -92,8 +91,6 @@ class H100LadderRung:
 
 
 def _h100_ladder_rung(size: str) -> H100LadderRung:
-    if size == "d384":
-        return H100LadderRung(SmallShape(384, 4, 3, 1, 1), gpus_per_task=4, task_count=1)
     if size == "d512":
         return H100LadderRung(SmallShape(512, 6, 4, 1, 1), gpus_per_task=8, task_count=1)
     if size == "d768":

--- a/experiments/grug/moe_hero_ep/launch_h100_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_h100_scaling_ladder.py
@@ -4,13 +4,13 @@
 """H100 scaling ladder for the Grug MoE EP hero recipe.
 
 The three rungs keep the existing hero model, data, optimizer, and 791-token-per-active-parameter
-scaling rules while mapping the expert and replica axes onto Hopper nodes. The global sequence batch
-is the largest power of two whose token batch does not exceed ``training_tokens ** 0.6``.
+scaling rules while mapping the expert and replica axes onto Hopper nodes. Every rung uses a global
+sequence batch of 1024.
 
     size   H100 GPUs  EP per task  global batch  steps  tokens
-    d384       4           4            128       12162   6.4B
-    d512       8           8            256       15721    16B
-    d768      16           8            512       22840    48B
+    d384       4           4           1024        1520   6.4B
+    d512       8           8           1024        3930    16B
+    d768      16           8           1024       11420    48B
 
 Use ``--batch-size`` for one-off batch comparisons. The step count and compute-scaled optimizer are
 recomputed from the override unless ``--num-steps`` is also set.
@@ -69,7 +69,7 @@ from experiments.grug.moe_hero_ep.train import (
 from experiments.marin_tokenizer import marin_tokenizer
 
 H100_LADDER_SIZES = ("d384", "d512", "d768")
-BATCH_TOKEN_EXPONENT = 0.6
+GLOBAL_BATCH_SIZE = 1024
 QB_HIST_BINS = 10_000
 WATCH_INTERVAL = 10
 RESUME_SAVE_INTERVAL = timedelta(hours=1)
@@ -120,23 +120,12 @@ def _h100_ladder_model(rung: H100LadderRung):
     )
 
 
-def _h100_ladder_batch_size(training_tokens: int, global_device_count: int) -> int:
-    token_ceiling = training_tokens**BATCH_TOKEN_EXPONENT
-    max_sequences = int(token_ceiling) // SEQ_LEN
-    if max_sequences < global_device_count:
-        raise ValueError(f"token batch ceiling permits {max_sequences} sequences for {global_device_count} devices")
-    batch_size = 1 << (max_sequences.bit_length() - 1)
-    assert batch_size % global_device_count == 0
-    assert batch_size * SEQ_LEN <= token_ceiling
-    return batch_size
-
-
 def build_h100_ladder_run(
     *,
     run_id: str,
     size: str,
     num_steps: int | None = None,
-    batch_size: int | None = None,
+    batch_size: int = GLOBAL_BATCH_SIZE,
     checkpoint_every: int | None = None,
     wandb_project: str = DEFAULT_WANDB_PROJECT,
     version: str | None = None,
@@ -157,9 +146,7 @@ def build_h100_ladder_run(
     rung = _h100_ladder_rung(size)
     model = _h100_ladder_model(rung)
     training_tokens = TOKENS_PER_ACTIVE_PARAM * _active_params(model)
-    if batch_size is None:
-        batch_size = _h100_ladder_batch_size(training_tokens, rung.global_device_count)
-    elif batch_size <= 0 or batch_size % rung.global_device_count != 0:
+    if batch_size <= 0 or batch_size % rung.global_device_count != 0:
         raise ValueError(f"batch_size must be positive and divisible by {rung.global_device_count}, got {batch_size}")
 
     global_tokens_per_step = batch_size * SEQ_LEN
@@ -311,8 +298,9 @@ def build_h100_ladder_run(
 @click.option(
     "--batch-size",
     type=click.IntRange(min=1),
-    default=None,
-    help="Global sequence batch override. Default follows the token-budget scaling rule.",
+    default=GLOBAL_BATCH_SIZE,
+    show_default=True,
+    help="Global sequence batch.",
 )
 @click.option(
     "--checkpoint-every",
@@ -332,7 +320,7 @@ def main(
     run_id: str,
     size: str,
     num_steps: int | None,
-    batch_size: int | None,
+    batch_size: int,
     checkpoint_every: int | None,
     wandb_project: str,
 ) -> ArtifactStep[HeroThroughputResult]:

--- a/experiments/grug/moe_hero_ep/launch_h100_scaling_ladder.py
+++ b/experiments/grug/moe_hero_ep/launch_h100_scaling_ladder.py
@@ -1,0 +1,350 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""H100 scaling ladder for the Grug MoE EP hero recipe.
+
+The three rungs keep the existing hero model, data, optimizer, and 791-token-per-active-parameter
+scaling rules while mapping the expert and replica axes onto Hopper nodes. The global sequence batch
+is the largest power of two whose token batch does not exceed ``training_tokens ** 0.6``.
+
+    size   H100 GPUs  EP per task  global batch  steps  tokens
+    d384       4           4            128       12162   6.4B
+    d512       8           8            256       15721    16B
+    d768      16           8            512       22840    48B
+
+Use ``--batch-size`` for one-off batch comparisons. The step count and compute-scaled optimizer are
+recomputed from the override unless ``--num-steps`` is also set.
+"""
+
+import dataclasses
+from datetime import timedelta
+
+import click
+import jmp
+from fray.cluster import ResourceConfig
+from levanter.callbacks.profiler import ProfilerConfig
+from levanter.callbacks.progress_watchdog import ProgressWatchdogConfig
+from levanter.callbacks.watch import WatchConfig
+from levanter.checkpoint import CheckpointerConfig
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
+from marin.execution.build_context import resolve_version
+from marin.execution.lazy import ArtifactStep, StepContext
+from marin.experiment.cli import build_options
+from marin.experiment.namespacing import user_namespaced_name
+from marin.training.training import data_local_temporary_checkpoint_base_path, temporary_checkpoint_base_path
+from rigging.filesystem.storage_path import prefix_join
+
+from experiments.datasets.uncheatable import uncheatable_datasets
+from experiments.grug.checkpointing import RESTORE_BARRIER_TIMEOUT
+from experiments.grug.moe_hero_ep.harrier_mix_2026_08_18 import (
+    HARRIER_MIX_2026_08_18_STORE,
+    HARRIER_MIX_2026_08_18_TAG,
+    harrier_mix_2026_08_18_data_config,
+)
+from experiments.grug.moe_hero_ep.heuristic import MoeHeuristic
+from experiments.grug.moe_hero_ep.launch_mfu_test import (
+    DEFAULT_WANDB_PROJECT,
+    HERO_MIXED_PRECISION,
+    HeroThroughputResult,
+    _validation_datasets,
+)
+from experiments.grug.moe_hero_ep.launch_scaling_ladder import TENSORSTORE_CACHE_BYTES, TOKENS_PER_ACTIVE_PARAM
+from experiments.grug.moe_hero_ep.small_scale_abl_launch import (
+    _EP_CAPACITY_FACTOR,
+    SEQ_LEN,
+    SmallShape,
+    _active_params,
+    _small_model,
+)
+from experiments.grug.moe_hero_ep.train import (
+    GrugEvalConfig,
+    GrugRunConfig,
+    GrugTrainerConfig,
+    MasterParamMode,
+    WatchMode,
+    _compute_flops,
+    run_grug,
+)
+from experiments.marin_tokenizer import marin_tokenizer
+
+H100_LADDER_SIZES = ("d384", "d512", "d768")
+BATCH_TOKEN_EXPONENT = 0.6
+QB_HIST_BINS = 10_000
+WATCH_INTERVAL = 10
+RESUME_SAVE_INTERVAL = timedelta(hours=1)
+STEP_TIMEOUT = timedelta(minutes=15)
+PROCESS_STALL_TIMEOUT = timedelta(hours=1)
+STARTUP_TIMEOUT = timedelta(seconds=2 * RESTORE_BARRIER_TIMEOUT)
+MAX_RETRIES_FAILURE = 3
+MAX_TASK_FAILURES = 3
+
+
+@dataclasses.dataclass(frozen=True)
+class H100LadderRung:
+    shape: SmallShape
+    gpus_per_task: int
+    task_count: int
+
+    @property
+    def global_device_count(self) -> int:
+        return self.gpus_per_task * self.task_count
+
+
+def _h100_ladder_rung(size: str) -> H100LadderRung:
+    if size == "d384":
+        return H100LadderRung(SmallShape(384, 4, 3, 1, 1), gpus_per_task=4, task_count=1)
+    if size == "d512":
+        return H100LadderRung(SmallShape(512, 6, 4, 1, 1), gpus_per_task=8, task_count=1)
+    if size == "d768":
+        return H100LadderRung(SmallShape(768, 8, 6, 1, 1), gpus_per_task=8, task_count=2)
+    raise ValueError(f"size must be one of {list(H100_LADDER_SIZES)}, got {size!r}")
+
+
+def _h100_ladder_model(rung: H100LadderRung):
+    return _small_model(
+        rung.shape,
+        _EP_CAPACITY_FACTOR,
+        attention_implementation="gpu_fa4_cute",
+        moe_implementation="fixed_pooled_wave_all_to_all",
+        expert_chunks=1,
+        seq_len=SEQ_LEN,
+        num_experts=384,
+        num_experts_per_token=8,
+        intermediate_dim=None,
+        latent_dim=None,
+        pooled_transport_capacity_factor=_EP_CAPACITY_FACTOR,
+        num_expert_waves=3,
+        qb_use_histogram=True,
+        qb_hist_bins=QB_HIST_BINS,
+    )
+
+
+def _h100_ladder_batch_size(training_tokens: int, global_device_count: int) -> int:
+    token_ceiling = training_tokens**BATCH_TOKEN_EXPONENT
+    max_sequences = int(token_ceiling) // SEQ_LEN
+    if max_sequences < global_device_count:
+        raise ValueError(f"token batch ceiling permits {max_sequences} sequences for {global_device_count} devices")
+    batch_size = 1 << (max_sequences.bit_length() - 1)
+    assert batch_size % global_device_count == 0
+    assert batch_size * SEQ_LEN <= token_ceiling
+    return batch_size
+
+
+def build_h100_ladder_run(
+    *,
+    run_id: str,
+    size: str,
+    num_steps: int | None = None,
+    batch_size: int | None = None,
+    checkpoint_every: int | None = None,
+    wandb_project: str = DEFAULT_WANDB_PROJECT,
+    version: str | None = None,
+) -> ArtifactStep[HeroThroughputResult]:
+    """Build one H100 scaling-ladder rung.
+
+    The default step budget trains for ``TOKENS_PER_ACTIVE_PARAM`` tokens per active parameter.
+    Narrow-rung evaluation runs every 5% of training. Permanent checkpoints default to the final
+    step, with one rolling hourly checkpoint on region-local temporary storage for recovery.
+    """
+    if not run_id.strip():
+        raise ValueError("run_id must not be empty")
+    if not wandb_project.strip():
+        raise ValueError("wandb_project must not be empty")
+    if checkpoint_every is not None and checkpoint_every <= 0:
+        raise ValueError(f"checkpoint_every must be positive, got {checkpoint_every}")
+
+    rung = _h100_ladder_rung(size)
+    model = _h100_ladder_model(rung)
+    training_tokens = TOKENS_PER_ACTIVE_PARAM * _active_params(model)
+    if batch_size is None:
+        batch_size = _h100_ladder_batch_size(training_tokens, rung.global_device_count)
+    elif batch_size <= 0 or batch_size % rung.global_device_count != 0:
+        raise ValueError(f"batch_size must be positive and divisible by {rung.global_device_count}, got {batch_size}")
+
+    global_tokens_per_step = batch_size * SEQ_LEN
+    if num_steps is None:
+        num_steps = max(1, round(training_tokens / global_tokens_per_step))
+    elif num_steps <= 0:
+        raise ValueError(f"num_steps must be positive, got {num_steps}")
+
+    flops_per_example, _ = _compute_flops(model_config=model)
+    run_flops = flops_per_example * batch_size * num_steps
+    steps_per_eval = max(1, round(num_steps / 20))
+    keep_permanent = None if checkpoint_every is None else [{"every": checkpoint_every}]
+    optimizer = dataclasses.replace(
+        MoeHeuristic().build_optimizer_config(
+            num_train_steps=num_steps,
+            batch_size=batch_size,
+            hidden_dim=model.hidden_dim,
+            seq_len=SEQ_LEN,
+        ),
+        use_syrk=True,
+    )
+    grug_trainer = GrugTrainerConfig(
+        data_seed=None,
+        log_every=1,
+        ema_beta=None,
+        z_loss_weight=1e-4,
+        offload_opt_state=True,
+        master_param_mode=MasterParamMode.FP32_PINNED_HOST,
+        watch_mode=WatchMode.INLINE,
+        save_checkpoints=True,
+        expert_axis_size=rung.gpus_per_task,
+        replica_axis_size=rung.task_count,
+        sharding_dump_path=None,
+    )
+    train_resources = ResourceConfig.with_gpu(
+        "H100",
+        count=rung.gpus_per_task,
+        cpu=32,
+        ram="600g",
+        disk="900g",
+        replicas=rung.task_count,
+    )
+    name = f"grug/{run_id}"
+    version = resolve_version(name, version)
+    validation = [*_validation_datasets(), *uncheatable_datasets(tokenizer=marin_tokenizer).values()]
+
+    def build_config(ctx: StepContext) -> GrugRunConfig:
+        permanent_checkpoint_path = prefix_join(ctx.output_path, "checkpoints")
+        temporary_checkpoint_path = temporary_checkpoint_base_path(ctx.output_path)
+        data_local_checkpoint_path = data_local_temporary_checkpoint_base_path(ctx.output_path)
+        trainer = TrainerConfig(
+            id=run_id,
+            seed=0,
+            train_batch_size=batch_size,
+            num_train_steps=num_steps,
+            profiler=ProfilerConfig(enabled=False),
+            mp=jmp.get_policy(HERO_MIXED_PRECISION),
+            tracker=WandbConfig(
+                entity="marin-community",
+                project=wandb_project,
+                tags=[
+                    "grug",
+                    "moe",
+                    "hero",
+                    "ep",
+                    "scaling-ladder",
+                    "h100",
+                    f"shape-{size}",
+                    f"h100-nodes-{rung.task_count}",
+                    f"ep{rung.gpus_per_task}",
+                    HARRIER_MIX_2026_08_18_TAG,
+                ],
+                group="moe-hero-ep-h100-scaling-ladder",
+                name=run_id,
+                replicate_path=ctx.output_path,
+            ),
+            watch=WatchConfig(interval=WATCH_INTERVAL),
+            progress_watchdog=ProgressWatchdogConfig(
+                step_timeout=STEP_TIMEOUT,
+                process_timeout=PROCESS_STALL_TIMEOUT,
+                startup_timeout=STARTUP_TIMEOUT,
+            ),
+            use_explicit_mesh_axes=True,
+            require_accelerator=True,
+            allow_nondivisible_batch_size=False,
+            load_checkpoint_path=[
+                permanent_checkpoint_path,
+                temporary_checkpoint_path,
+                data_local_checkpoint_path,
+            ],
+            checkpointer=CheckpointerConfig(
+                base_path=permanent_checkpoint_path,
+                temporary_base_path=temporary_checkpoint_path,
+                save_interval=RESUME_SAVE_INTERVAL,
+                keep=keep_permanent,
+                append_run_id_to_base_path=False,
+                delete_old_temp_checkpoints=True,
+                keep_last_temporary_checkpoints=1,
+            ),
+        )
+        return GrugRunConfig(
+            model=model,
+            data=harrier_mix_2026_08_18_data_config(
+                ctx=ctx,
+                total_steps=num_steps,
+                batch_size=batch_size,
+                max_seq_len=model.max_seq_len,
+                experiment_flops=run_flops,
+                validation=validation,
+            ),
+            resources=ctx.runtime_arg("train_resources"),
+            tensorstore_cache_bytes=TENSORSTORE_CACHE_BYTES,
+            optimizer=optimizer,
+            trainer=dataclasses.replace(grug_trainer, trainer=trainer),
+            eval=GrugEvalConfig(
+                steps_per_eval=steps_per_eval,
+                eval_batch_size=rung.global_device_count,
+                eval_ema=False,
+                compute_bpb=True,
+                dropless_eval=True,
+                dropless_eval_moe_implementation="sonic",
+            ),
+            stop_after_steps=num_steps,
+            processes_per_task=rung.gpus_per_task,
+            max_retries_failure=MAX_RETRIES_FAILURE,
+            max_task_failures=MAX_TASK_FAILURES,
+        )
+
+    return ArtifactStep(
+        name=user_namespaced_name(name, version),
+        version=version,
+        artifact_type=HeroThroughputResult,
+        run=run_grug,
+        build_config=build_config,
+        deps=(HARRIER_MIX_2026_08_18_STORE, *validation),
+        runtime_args={"train_resources": train_resources},
+    )
+
+
+@click.command()
+@click.option("--run-id", required=True, help="Run identifier for artifact and W&B names.")
+@click.option("--size", required=True, type=click.Choice(H100_LADDER_SIZES), help="H100 ladder rung width.")
+@click.option(
+    "--num-steps",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Training steps. Default trains 791 tokens per active parameter at the rung's batch.",
+)
+@click.option(
+    "--batch-size",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Global sequence batch override. Default follows the token-budget scaling rule.",
+)
+@click.option(
+    "--checkpoint-every",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Keep a permanent checkpoint every N steps. Default keeps only the final checkpoint.",
+)
+@click.option(
+    "--wandb-project",
+    envvar="WANDB_PROJECT",
+    default=DEFAULT_WANDB_PROJECT,
+    show_default=True,
+    help="W&B project for the run.",
+)
+@build_options
+def main(
+    run_id: str,
+    size: str,
+    num_steps: int | None,
+    batch_size: int | None,
+    checkpoint_every: int | None,
+    wandb_project: str,
+) -> ArtifactStep[HeroThroughputResult]:
+    return build_h100_ladder_run(
+        run_id=run_id,
+        size=size,
+        num_steps=num_steps,
+        batch_size=batch_size,
+        checkpoint_every=checkpoint_every,
+        wandb_project=wandb_project,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/grug/moe_hero_ep/train.py
+++ b/experiments/grug/moe_hero_ep/train.py
@@ -37,6 +37,7 @@ from levanter.data.mixture import MixtureDataset, rescale_mixture_schedule_for_b
 from levanter.data.text.datasets import LmDataConfig
 from levanter.data.text.examples import GrugLmExample, grug_lm_example_from_named
 from levanter.eval import TaggedEvaluator, cb_tagged_evaluate, eval_model
+from levanter.grug.grug_moe import MoeImplementation
 from levanter.grug.sharding import compact_grug_mesh
 from levanter.models.lm_model import LmExample
 from levanter.optim.config import AdamConfig, OptimizerConfig
@@ -87,6 +88,7 @@ _XLA_FLAG_DEFAULTS = (
 )
 XLA_COLLECTIVE_OVERLAP_FLAG = "--xla_gpu_experimental_parallel_collective_overlap_limit"
 DEFAULT_COLLECTIVE_OVERLAP_LIMIT = 4
+DEFAULT_DROPLESS_MOE_IMPLEMENTATION: MoeImplementation = "sonic_cute"
 # Full inline norm watch failed with overlap 4. Overlap 1 completed the selected full-watch gate.
 INLINE_WATCH_COLLECTIVE_OVERLAP_LIMIT = 1
 # TODO(https://github.com/marin-community/marin/issues/5675): Re-enable XLA GPU
@@ -205,6 +207,9 @@ class GrugEvalConfig:
     # expert-collapsed mesh, logging a separate `eval_dropless` macro loss alongside the
     # as-trained (with-drop) eval. No-op when the mesh has no expert parallelism.
     dropless_eval: bool = False
+    # Local MoE kernel used after collapsing the expert axis. ``sonic`` is the Hopper Triton path;
+    # ``sonic_cute`` is the Blackwell QuACK/CUTLASS path.
+    dropless_eval_moe_implementation: MoeImplementation = DEFAULT_DROPLESS_MOE_IMPLEMENTATION
     # Run the evals once after the first optimization step, for a baseline at the start of the loss
     # curve. The periodic cadence first fires at `steps_per_eval`, thus it leaves that start bare.
     eval_at_first_step: bool = False
@@ -343,8 +348,10 @@ def _reshard_tree_to_mesh(tree, mesh: Mesh):
     return jax.tree.map(move, tree)
 
 
-def _to_dropless_local(model: Transformer) -> Transformer:
-    """Swap the scanned block's MoE expert backend to the dropless local ``sonic_cute`` path.
+def _to_dropless_local(
+    model: Transformer, *, implementation: MoeImplementation = DEFAULT_DROPLESS_MOE_IMPLEMENTATION
+) -> Transformer:
+    """Swap the scanned block's MoE expert backend to the selected dropless local path.
 
     ``implementation``/``expert_chunks`` are static fields shared across the whole stacked block,
     so one replacement covers every layer. The forward reads ``self.expert_mlp.implementation``
@@ -352,7 +359,7 @@ def _to_dropless_local(model: Transformer) -> Transformer:
     mesh: the local backend raises when the mesh expert axis is larger than one.
     """
     expert_mlp = model.stacked_blocks.stacked.mlp.expert_mlp
-    dropless = dataclasses.replace(expert_mlp, implementation="sonic_cute", expert_chunks=1)
+    dropless = dataclasses.replace(expert_mlp, implementation=implementation, expert_chunks=1)
     return eqx.tree_at(lambda m: m.stacked_blocks.stacked.mlp.expert_mlp, model, dropless)
 
 
@@ -910,7 +917,10 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                         mesh=dropless_eval_mesh,
                         eval_cfg=eval_cfg,
                         mp=trainer.mp,
-                        model_transform=_to_dropless_local,
+                        model_transform=functools.partial(
+                            _to_dropless_local,
+                            implementation=eval_cfg.dropless_eval_moe_implementation,
+                        ),
                     )
 
         # `trainer.num_train_steps` sizes the schedule; this bounds the run. Progress and the loop

--- a/lib/levanter/src/levanter/cutlass_kernel_cache.py
+++ b/lib/levanter/src/levanter/cutlass_kernel_cache.py
@@ -204,3 +204,18 @@ def _kernel_cache_revision() -> str:
 def _device_architecture() -> str:
     device = jax.local_devices()[0]
     return f"{device.platform}-{getattr(device, 'compute_capability', device.device_kind)}"
+
+
+def gpu_compute_capability() -> int:
+    """Return the CUDA compute capability as an integer such as 90 or 100."""
+    for device in jax.local_devices(backend="gpu"):
+        compute_capability = getattr(device, "compute_capability", None)
+        if callable(compute_capability):
+            compute_capability = compute_capability()
+        if isinstance(compute_capability, tuple) and len(compute_capability) >= 2:
+            return int(compute_capability[0]) * 10 + int(compute_capability[1])
+        if isinstance(compute_capability, str):
+            major, _, minor = compute_capability.partition(".")
+            if major.isdigit() and minor.isdigit():
+                return int(major) * 10 + int(minor)
+    raise RuntimeError("Could not determine CUDA compute capability.")

--- a/lib/levanter/src/levanter/grug/_moe/quack_symmetric_cute.py
+++ b/lib/levanter/src/levanter/grug/_moe/quack_symmetric_cute.py
@@ -1,23 +1,8 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""CuTeDSL->JAX bridge for QuACK's SM100 symmetric GEMM (D = X @ X^T, full symmetric via
-in-kernel mirror), used to accelerate the two symmetric products in the Grug Muon Newton-Schulz.
+"""QuACK symmetric GEMM for Grug Muon Newton-Schulz on Hopper and Blackwell GPUs."""
 
-A thin ``@cute.jit`` launcher over ``GemmSymmetricSm100`` wrapped with ``cutlass.jax.cutlass_call``
-(the same bridge the FA4 attention backend uses, so the kernel runs on XLA's stream and is ordered
-correctly with the surrounding graph). The kernel computes ``A @ B^T`` with a triangular tile
-scheduler that writes each lower tile to D and its mirror to ``D.mT`` (same storage), so D comes out
-fully symmetric with ~half the matmul FLOPs.
-
-Config matches QuACK's own SM100 path exactly: ``mma_tiler (256, 256)``, ``cluster (2, 1, 1)``, and
-**static** persistence (``use_clc_persistence=False``). The dynamic CLC scheduler (with its GMEM
-tile-count semaphore) races between clusters and returned intermittent garbage on tiny-magnitude and
-square inputs; static persistence is deterministic and bit-exact on all inputs (gram, tiny gram,
-square A@A). Validated ~1.7x vs dense on the symmetric products (GB200, 128 experts).
-
-Lazy-imported (quack/cutlass-dsl is Blackwell-only), like the sonic MoE backend.
-"""
 from __future__ import annotations
 
 import jax
@@ -27,9 +12,9 @@ import cutlass
 import cutlass.cute as cute
 import cutlass.jax as cjax
 from cutlass import Float32
-from levanter.cutlass_kernel_cache import cute_launcher_factory, cutlass_call
+from levanter.cutlass_kernel_cache import cute_launcher_factory, cutlass_call, gpu_compute_capability
 from quack.gemm import make_scheduler_args
-from quack.gemm_symmetric import GemmSymmetricMixin, GemmSymmetricSm100
+from quack.gemm_symmetric import GemmSymmetricMixin, GemmSymmetricSm90, GemmSymmetricSm100
 
 try:
     from quack.cute_dsl_utils import get_max_active_clusters
@@ -43,16 +28,19 @@ _JAX_TO_CUTE = {
     jnp.dtype(jnp.float32): cutlass.Float32,
 }
 
-# QuACK's SM100 symmetric config (_symmetric_gemm_config): tile (256, 256), cluster_M 2, static.
+# QuACK's symmetric configs (_symmetric_gemm_config): SM90 uses tile (128, 256), SM100 uses
+# tile (256, 256); both use cluster_M 2 and static persistence.
 # NOTE: (256, 128) benchmarks 1.62x faster on the isolated [96, 2560, 5120] expert gram, but it
 # BREAKS live training (loss stuck at init, run never progresses) -- the NS also orthogonalizes
 # non-expert matrices whose shapes (256, 128) does not handle correctly, and the isolated gram
 # microbench does not cover them. (256, 256) is validated clean end-to-end (30-step GB200 run,
 # loss 11.8 -> 5.94). Do not narrow tile_N without validating on the full set of live NS shapes.
-_DEFAULT_MMA_TILER = (256, 256)
+_SM90_MMA_TILER = (128, 256)
+_SM100_MMA_TILER = (256, 256)
+_HOPPER_ARCH_FAMILY = 9
+_BLACKWELL_ARCH_FAMILIES = (10, 11)
 _DEFAULT_CLUSTER = (2, 1, 1)
 _DEFAULT_SWIZZLE = 8
-_FALLBACK_MAX_ACTIVE_CLUSTERS = 148
 
 
 def _cute_dtype(dt):
@@ -64,13 +52,24 @@ def _transpose_mn(mD):
     return cute.make_tensor(mD.iterator, cute.select(mD.layout, mode=[1, 0, 2]))
 
 
+def _symmetric_gemm_config(arch: int) -> tuple[int, tuple[int, int]]:
+    arch_family = arch // 10
+    if arch_family == _HOPPER_ARCH_FAMILY:
+        return arch_family, _SM90_MMA_TILER
+    if arch_family in _BLACKWELL_ARCH_FAMILIES:
+        return arch_family, _SM100_MMA_TILER
+    raise NotImplementedError(f"QuACK symmetric GEMM does not support CUDA compute capability {arch}.")
+
+
 @cute_launcher_factory
-def _build_launcher(*, a_dtype, mma_tiler_mnk, cluster_mnk, mac, max_swizzle):
+def _build_launcher(*, arch_family, a_dtype, mma_tiler_mnk, cluster_mnk, mac, max_swizzle):
+    gemm_type = GemmSymmetricSm90 if arch_family == _HOPPER_ARCH_FAMILY else GemmSymmetricSm100
+
     @cute.jit
     def launcher(stream, mA, mB, mD):
         # Static persistence (use_clc_persistence=False): no tile-count semaphore, deterministic
         # tile scheduling. The dynamic CLC path raced and corrupted tiny/square outputs.
-        gemm = GemmSymmetricSm100(_ACC, a_dtype, mma_tiler_mnk, cluster_mnk, use_clc_persistence=False)
+        gemm = gemm_type(_ACC, a_dtype, mma_tiler_mnk, cluster_mnk, use_clc_persistence=False)
         # aux = D.mT (transposed view of the single output): the kernel writes each lower tile to D
         # and its mirror to D.mT, so D is fully symmetric. alpha/beta must be set (D = a*acc + b*C).
         epi_args = GemmSymmetricMixin.EpilogueArguments(
@@ -85,7 +84,7 @@ def _build_launcher(*, a_dtype, mma_tiler_mnk, cluster_mnk, mac, max_swizzle):
 def quack_symmetric_gemm(
     X: jax.Array,
     *,
-    mma_tiler_mnk: tuple[int, int] = _DEFAULT_MMA_TILER,
+    mma_tiler_mnk: tuple[int, int] | None = None,
     cluster_mnk: tuple[int, int, int] = _DEFAULT_CLUSTER,
     max_swizzle: int = _DEFAULT_SWIZZLE,
 ) -> jax.Array:
@@ -95,13 +94,18 @@ def quack_symmetric_gemm(
     The kernel computes ``A @ B^T``, so both operands are ``X``, k-major ([M, K, L], mode (1,2,0)).
     """
     L, M, K = X.shape
+    arch_family, default_mma_tiler = _symmetric_gemm_config(gpu_compute_capability())
+    if mma_tiler_mnk is None:
+        mma_tiler_mnk = default_mma_tiler
     a_dtype = _cute_dtype(X.dtype)
-    try:
-        mac = get_max_active_clusters(cluster_mnk[0] * cluster_mnk[1])
-    except Exception:
-        mac = _FALLBACK_MAX_ACTIVE_CLUSTERS
+    mac = get_max_active_clusters(cluster_mnk[0] * cluster_mnk[1])
     launcher = _build_launcher(
-        a_dtype=a_dtype, mma_tiler_mnk=mma_tiler_mnk, cluster_mnk=cluster_mnk, mac=mac, max_swizzle=max_swizzle
+        arch_family=arch_family,
+        a_dtype=a_dtype,
+        mma_tiler_mnk=mma_tiler_mnk,
+        cluster_mnk=cluster_mnk,
+        mac=mac,
+        max_swizzle=max_swizzle,
     )
     ts = cjax.TensorSpec
     spec = ts(mode=(1, 2, 0), divisibility=(1, 1, 8), static=False)
@@ -114,6 +118,3 @@ def quack_symmetric_gemm(
     )
     (d,) = call(X, X)
     return d
-
-
-__all__ = ["quack_symmetric_gemm"]

--- a/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
+++ b/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
@@ -12,6 +12,7 @@ from jax.sharding import NamedSharding, PartitionSpec as P
 from jax.sharding import get_abstract_mesh, reshard
 from jaxtyping import Array, Bool, Float, Int
 
+from levanter.cutlass_kernel_cache import gpu_compute_capability
 from levanter.grug.attention._core import AttentionMask
 from levanter.grug.attention._fa4_cute_backend import fa4_cute_attention_forward
 from levanter.grug.attention._fa4_cute_config import Flash4CuteKernelConfig, flash4_cute_kernel_config
@@ -280,22 +281,8 @@ def _fa4_cute_attention_forward_sharded(
     return _local_fa4_attention(q, k, v, lower_bounds, valid)
 
 
-def _gpu_compute_arch() -> int:
-    for device in jax.local_devices(backend="gpu"):
-        compute_capability = getattr(device, "compute_capability", None)
-        if callable(compute_capability):
-            compute_capability = compute_capability()
-        if isinstance(compute_capability, tuple) and len(compute_capability) >= 2:
-            return int(compute_capability[0]) * 10 + int(compute_capability[1])
-        if isinstance(compute_capability, str):
-            major, _, minor = compute_capability.partition(".")
-            if major.isdigit() and minor.isdigit():
-                return int(major) * 10 + int(minor)
-    raise RuntimeError("Could not determine CUDA compute capability for FA4/CuTe attention.")
-
-
 def _segmented_kernel_config(head_dim: int):
-    arch = _gpu_compute_arch()
+    arch = gpu_compute_capability()
     kernel_config = flash4_cute_kernel_config(head_dim, arch=arch)
 
     # Upstream flash-attn-4 4.0.0b15 dense SM100 FA4 uses 128x128 tiles in

--- a/lib/levanter/src/levanter/grug/attention/_fa4_thd.py
+++ b/lib/levanter/src/levanter/grug/attention/_fa4_thd.py
@@ -18,9 +18,8 @@ from jax.sharding import PartitionSpec as P
 from jax.sharding import reshard
 from jaxtyping import Array, Bool, Float, Int
 
-from levanter.cutlass_kernel_cache import cute_launcher_factory, cutlass_call
+from levanter.cutlass_kernel_cache import cute_launcher_factory, cutlass_call, gpu_compute_capability
 from levanter.grug.attention._core import AttentionMask
-from levanter.grug.attention._fa4_cute import _gpu_compute_arch
 from levanter.grug.attention._fa4_cute_config import Flash4CuteKernelConfig, flash4_cute_kernel_config
 
 
@@ -59,7 +58,7 @@ def _sm90_backward_kernel_options() -> dict[str, int | bool]:
 @functools.lru_cache(maxsize=1)
 def _import_upstream_fa4_cute() -> _UpstreamFa4CuteModules:
     try:
-        arch = _gpu_compute_arch()
+        arch = gpu_compute_capability()
         arch_family = arch // 10
         cutlass = importlib.import_module("cutlass")
         cute = importlib.import_module("cutlass.cute")
@@ -158,7 +157,7 @@ def _validate_simple_causal_self_attention(
 
 
 def _thd_kernel_config(head_dim: int) -> Flash4CuteKernelConfig:
-    arch = _gpu_compute_arch()
+    arch = gpu_compute_capability()
     arch_family = arch // 10
     if arch_family not in _SUPPORTED_ARCH_FAMILIES:
         raise NotImplementedError(f"gpu_fa4_thd_attention currently supports only SM90/SM100/SM110, got SM{arch}.")

--- a/lib/levanter/tests/grug/test_attention.py
+++ b/lib/levanter/tests/grug/test_attention.py
@@ -153,7 +153,7 @@ def test_gpu_fa4_thd_rejects_nonpositive_sliding_window():
 
 
 def test_gpu_fa4_thd_supports_hopper_kernel_config(monkeypatch):
-    monkeypatch.setattr(fa4_thd, "_gpu_compute_arch", lambda: 90)
+    monkeypatch.setattr(fa4_thd, "gpu_compute_capability", lambda: 90)
 
     config = fa4_thd._thd_kernel_config(128)
 
@@ -243,7 +243,7 @@ def test_real_gpu_fa4_thd_attention_matches_reference_value_and_gradients(slidin
     pytest.importorskip("cutlass")
     pytest.importorskip("cutlass.cute")
     pytest.importorskip("flash_attn.cute.flash_bwd_preprocess")
-    arch_family = fa4_thd._gpu_compute_arch() // 10
+    arch_family = fa4_thd.gpu_compute_capability() // 10
     if arch_family not in fa4_thd._SUPPORTED_ARCH_FAMILIES:
         pytest.skip("gpu_fa4_thd_attention supports only SM90/SM100/SM110.")
     if sliding_window is not None and arch_family == fa4_thd._HOPPER_ARCH_FAMILY:


### PR DESCRIPTION
Add a standalone H100 launcher for a 791-token-per-active-parameter hero ladder. The existing GB200 scaling ladder and small-scale ablation launcher remain unchanged. d512 uses one eight-GPU EP8 task, and d768 uses two eight-GPU EP8 tasks. Both rungs use a global batch of 1,024; the step budget and compute-scaled optimizer are rebuilt for that batch.

Hopper runs use SM90 FA4 attention, the Triton Sonic backend for dropless evaluation, and QuACK's SM90 symmetric GEMM for MuonH. Full d512/batch1024 and d768/batch1024 runs reached 3,929/3,930 and 11,419/11,420 optimizer steps.
