### PR TITLE
[grug] Shard expert weights over an auxiliary mesh axis

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -44,6 +44,7 @@ from levanter.grug.grug_moe import (
     MoeImplementation,
     PspecAxis,
     resolve_moe_implementation,
+    validate_expert_weight_hidden_axis,
 )
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import Pembed_vocab, Plm_head, unshard
@@ -554,6 +555,7 @@ class MoEMLP(eqx.Module):
         mesh = get_abstract_mesh()
 
         expert_axis_size = _mesh_axis_size(mesh, "expert")
+        validate_expert_weight_hidden_axis(mesh, cfg.expert_weight_hidden_axis)
         if cfg.num_experts % expert_axis_size != 0:
             raise ValueError(f"num_experts={cfg.num_experts} must be divisible by expert axis size={expert_axis_size}")
 

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -40,7 +40,9 @@ from levanter.grug.grug_moe import (
     MOE_REMAT_SAVE_NAMES,
     MoeActivation,
     MoEExpertMlp,
+    MoEExpertMlpPspecs,
     MoeImplementation,
+    PspecAxis,
     resolve_moe_implementation,
 )
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
@@ -137,6 +139,12 @@ class GrugModelConfig:
     still apply half-RoPE. Set to False to keep RoPE on long layers."""
     attention_implementation: GrugAttentionImplementation | None = None
     moe_implementation: MoeImplementation | None = None
+    expert_weight_hidden_axis: PspecAxis = "data"
+    """Mesh axis used to shard routed-expert hidden dimensions for storage.
+
+    This does not change expert ownership or the EP collective group, which
+    remain on ``expert``.
+    """
     capacity_factor: float = 1.0
     remat_mode: RematMode = "recompute_all"
     """Per-block gradient checkpointing. "recompute_all" reruns the whole block in
@@ -562,6 +570,7 @@ class MoEMLP(eqx.Module):
                 implementation=cfg.moe_implementation,
                 activation=ActivationFunctionEnum.silu,
                 capacity_factor=cfg.capacity_factor,
+                pspecs=MoEExpertMlpPspecs(hidden=cfg.expert_weight_hidden_axis),
             ),
             cfg=cfg,
         )

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -44,7 +44,9 @@ from levanter.grug.grug_moe import (
     MOE_REMAT_SAVE_NAMES,
     MoeActivation,
     MoEExpertMlp,
+    MoEExpertMlpPspecs,
     MoeImplementation,
+    PspecAxis,
     resolve_moe_implementation,
 )
 from levanter.grug.loss import BlockSizes, fused_linear_softmax_cross_entropy_loss
@@ -187,6 +189,12 @@ class GrugModelConfig:
     sconv_sites: tuple[str, ...] = ("k", "attn", "mlp")
     attention_implementation: GrugAttentionImplementation | None = None
     moe_implementation: MoeImplementation | None = None
+    expert_weight_hidden_axis: PspecAxis = "data"
+    """Mesh axis used to shard routed-expert hidden dimensions for storage.
+
+    This does not change expert ownership or the EP collective group, which
+    remain on ``expert``.
+    """
     expert_chunks: int = 1
     pooled_transport_capacity_factor: float | None = None
     num_expert_waves: int = 1
@@ -955,6 +963,7 @@ class MoEMLP(eqx.Module):
                 pooled_transport_capacity_factor=cfg.pooled_transport_capacity_factor,
                 expert_chunks=cfg.expert_chunks,
                 num_expert_waves=cfg.num_expert_waves,
+                pspecs=MoEExpertMlpPspecs(hidden=cfg.expert_weight_hidden_axis),
             ),
             cfg=cfg,
         )

--- a/experiments/grug/moe_hero_ep/model.py
+++ b/experiments/grug/moe_hero_ep/model.py
@@ -48,6 +48,7 @@ from levanter.grug.grug_moe import (
     MoeImplementation,
     PspecAxis,
     resolve_moe_implementation,
+    validate_expert_weight_hidden_axis,
 )
 from levanter.grug.loss import BlockSizes, fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import unshard
@@ -929,6 +930,7 @@ class MoEMLP(eqx.Module):
         mesh = get_abstract_mesh()
 
         expert_axis_size = _mesh_axis_size(mesh, "expert")
+        validate_expert_weight_hidden_axis(mesh, cfg.expert_weight_hidden_axis)
         if cfg.num_experts % expert_axis_size != 0:
             raise ValueError(f"num_experts={cfg.num_experts} must be divisible by expert axis size={expert_axis_size}")
 

--- a/experiments/grug/moe_hero_fsdp/model.py
+++ b/experiments/grug/moe_hero_fsdp/model.py
@@ -43,7 +43,9 @@ from levanter.grug.grug_moe import (
     MOE_REMAT_SAVE_NAMES,
     MoeActivation,
     MoEExpertMlp,
+    MoEExpertMlpPspecs,
     MoeImplementation,
+    PspecAxis,
     resolve_moe_implementation,
 )
 from levanter.grug.loss import BlockSizes, fused_linear_softmax_cross_entropy_loss
@@ -170,6 +172,12 @@ class GrugModelConfig:
     sconv_sites: tuple[str, ...] = ("k", "v", "attn", "mlp")
     attention_implementation: GrugAttentionImplementation | None = None
     moe_implementation: MoeImplementation | None = None
+    expert_weight_hidden_axis: PspecAxis = "data"
+    """Mesh axis used to shard routed-expert hidden dimensions for storage.
+
+    This does not change expert ownership or the EP collective group, which
+    remain on ``expert``.
+    """
     expert_chunks: int = 1
     report_capacity_overflow: bool = False
     remat_mode: RematMode = "recompute_all"
@@ -775,6 +783,7 @@ class MoEMLP(eqx.Module):
                 activation=ActivationFunctionEnum.silu,
                 capacity_factor=cfg.capacity_factor,
                 expert_chunks=cfg.expert_chunks,
+                pspecs=MoEExpertMlpPspecs(hidden=cfg.expert_weight_hidden_axis),
             ),
             cfg=cfg,
         )

--- a/experiments/grug/moe_hero_fsdp/model.py
+++ b/experiments/grug/moe_hero_fsdp/model.py
@@ -47,6 +47,7 @@ from levanter.grug.grug_moe import (
     MoeImplementation,
     PspecAxis,
     resolve_moe_implementation,
+    validate_expert_weight_hidden_axis,
 )
 from levanter.grug.loss import BlockSizes, fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import unshard
@@ -763,6 +764,7 @@ class MoEMLP(eqx.Module):
         mesh = get_abstract_mesh()
 
         expert_axis_size = _mesh_axis_size(mesh, "expert")
+        validate_expert_weight_hidden_axis(mesh, cfg.expert_weight_hidden_axis)
         if cfg.num_experts % expert_axis_size != 0:
             raise ValueError(f"num_experts={cfg.num_experts} must be divisible by expert axis size={expert_axis_size}")
 

--- a/experiments/june_tpu_67b_a2b/moe/model.py
+++ b/experiments/june_tpu_67b_a2b/moe/model.py
@@ -38,7 +38,9 @@ from levanter.grug.grug_moe import (
     MOE_REMAT_SAVE_NAMES,
     MoeActivation,
     MoEExpertMlp,
+    MoEExpertMlpPspecs,
     MoeImplementation,
+    PspecAxis,
     resolve_moe_implementation,
 )
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
@@ -119,6 +121,13 @@ class GrugModelConfig:
     disable_long_rope: bool = False
     attention_implementation: GrugAttentionImplementation | None = None
     moe_implementation: MoeImplementation | None = None
+    expert_weight_hidden_axis: PspecAxis = "data"
+    """Mesh axis used to shard the hidden dimension of routed-expert weights.
+
+    Expert ownership and routing remain on ``expert``. The selected axis only
+    controls persistent weight storage; each EP shard gathers the hidden
+    dimension before applying its local experts.
+    """
     ce_implementation: str | None = None
     """Fused cross-entropy backend selection (levanter fused_cross_entropy_loss). None keeps the
     backend default (GPU: full-logits ``xla`` path). Set ``"batched_xla"`` to use the blocked-vocab
@@ -534,6 +543,7 @@ class MoEMLP(eqx.Module):
                 implementation=cfg.moe_implementation,
                 activation=ActivationFunctionEnum.silu,
                 capacity_factor=_DEFAULT_EP_CAPACITY_FACTOR,
+                pspecs=MoEExpertMlpPspecs(hidden=cfg.expert_weight_hidden_axis),
             ),
             cfg=cfg,
         )

--- a/experiments/june_tpu_67b_a2b/moe/model.py
+++ b/experiments/june_tpu_67b_a2b/moe/model.py
@@ -42,6 +42,7 @@ from levanter.grug.grug_moe import (
     MoeImplementation,
     PspecAxis,
     resolve_moe_implementation,
+    validate_expert_weight_hidden_axis,
 )
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import Pembed_vocab, Plm_head, unshard
@@ -525,6 +526,7 @@ class MoEMLP(eqx.Module):
         mesh = get_abstract_mesh()
 
         expert_axis_size = _mesh_axis_size(mesh, "expert")
+        validate_expert_weight_hidden_axis(mesh, cfg.expert_weight_hidden_axis)
         if cfg.num_experts % expert_axis_size != 0:
             raise ValueError(f"num_experts={cfg.num_experts} must be divisible by expert axis size={expert_axis_size}")
         if not cfg.split_w_gate_up:

--- a/lib/levanter/src/levanter/grug/_moe/common.py
+++ b/lib/levanter/src/levanter/grug/_moe/common.py
@@ -76,7 +76,13 @@ class CapacityOverflow(NamedTuple):
 
 @dataclass(frozen=True)
 class MoEExpertMlpPspecs:
-    """Logical sharding axes for local MoE expert MLP weights."""
+    """Persistent sharding axes for MoE expert MLP weights.
+
+    ``expert`` controls expert ownership. ``hidden`` may name an independent
+    FSDP-style axis (for example ``data`` or ``context``); EP execution gathers
+    that hidden shard within each expert owner without adding the axis to the
+    expert-routing collective group.
+    """
 
     expert: PspecAxis = "expert"
     hidden: PspecAxis = "data"

--- a/lib/levanter/src/levanter/grug/_moe/common.py
+++ b/lib/levanter/src/levanter/grug/_moe/common.py
@@ -97,6 +97,24 @@ class MoEExpertMlpPspecs:
         return P(self.expert, self.intermediate, self.hidden)
 
 
+def validate_expert_weight_hidden_axis(
+    mesh: jax.sharding.AbstractMesh | jax.sharding.Mesh | None, axis: PspecAxis
+) -> None:
+    """Require every configured expert-weight hidden axis to exist on ``mesh``."""
+    if axis is None:
+        return
+    axes = axis if isinstance(axis, tuple) else (axis,)
+    if not axes:
+        raise ValueError("expert_weight_hidden_axis must not be an empty tuple")
+    if mesh is None or mesh.empty:
+        raise ValueError("expert_weight_hidden_axis requires a non-empty mesh")
+    missing = tuple(name for name in axes if name not in mesh.shape)
+    if missing:
+        raise ValueError(
+            f"expert_weight_hidden_axis references missing mesh axes {missing}; available axes are {tuple(mesh.shape)}"
+        )
+
+
 def resolve_moe_implementation(implementation: MoeImplementation | str | None) -> MoeImplementation:
     if implementation is None:
         return "ring"

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -37,6 +37,7 @@ from levanter.grug._moe.common import (
     PspecAxis,
     resolve_moe_implementation,
     split_moe_w13_output,
+    validate_expert_weight_hidden_axis,
 )
 from levanter.grug._moe.ep_common import (
     _clip_receiver_group_sizes as _clip_receiver_group_sizes,
@@ -368,4 +369,5 @@ __all__ = [
     "moe_mlp",
     "resolve_moe_implementation",
     "split_moe_w13_output",
+    "validate_expert_weight_hidden_axis",
 ]

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -545,6 +545,107 @@ def test_moe_expert_mlp_init_uses_logical_weight_pspecs():
     assert mlp.w_down.sharding.spec == P(None, "model", "data")
 
 
+def test_moe_ep_auxiliary_hidden_sharding_matches_dense_value_and_gradients():
+    env = os.environ.copy()
+    env["JAX_PLATFORMS"] = "cpu"
+    env["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+    script = """
+        import jax
+        import jax.numpy as jnp
+        import numpy as np
+        from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
+
+        from levanter.grug.grug_moe import MoEExpertMlp, MoEExpertMlpPspecs, moe_mlp
+
+        assert jax.device_count() == 4
+        mesh = Mesh(
+            np.asarray(jax.devices()).reshape(2, 2),
+            axis_names=("expert", "context"),
+            axis_types=(AxisType.Explicit, AxisType.Explicit),
+        )
+        x = jax.random.normal(jax.random.key(0), (4, 4))
+        selected_experts = jnp.asarray(
+            [[0, 1], [1, 2], [2, 3], [3, 0]],
+            dtype=jnp.int32,
+        )
+        combine_weights = jax.nn.softmax(jax.random.normal(jax.random.key(1), (4, 2)), axis=-1)
+        cotangent = jax.random.normal(jax.random.key(2), (4, 4))
+
+        with jax.set_mesh(mesh):
+            mlp = MoEExpertMlp.init(
+                num_experts=4,
+                hidden_dim=4,
+                intermediate_dim=3,
+                initializer_std=0.02,
+                key=jax.random.key(3),
+                implementation="ring",
+                pspecs=MoEExpertMlpPspecs(expert="expert", hidden="context", intermediate=None),
+            )
+
+        assert mlp.w_gate.sharding.spec == P("expert", "context", None)
+        assert mlp.w_up.sharding.spec == P("expert", "context", None)
+        assert mlp.w_down.sharding.spec == P("expert", None, "context")
+        assert mlp.w_gate.addressable_shards[0].data.shape == (2, 2, 3)
+
+        def dense_output(x, w_gate, w_up, w_down):
+            gate = jnp.einsum("th,tkhi->tki", x, w_gate[selected_experts])
+            up = jnp.einsum("th,tkhi->tki", x, w_up[selected_experts])
+            expert_output = jnp.einsum("tki,tkih->tkh", jax.nn.silu(gate) * up, w_down[selected_experts])
+            return jnp.einsum("tkh,tk->th", expert_output, combine_weights)
+
+        def ep_output(x, w_gate, w_up, w_down):
+            return moe_mlp(
+                x,
+                selected_experts,
+                combine_weights,
+                jnp.concatenate([w_gate, w_up], axis=-1),
+                w_down,
+                activation=jax.nn.silu,
+                implementation="ring",
+                mesh=mesh,
+            )
+
+        weights = (mlp.w_gate, mlp.w_up, mlp.w_down)
+        dense_weights = tuple(jnp.asarray(np.asarray(weight)) for weight in weights)
+        expected = dense_output(x, *dense_weights)
+        expected_gradients = jax.grad(
+            lambda x, *weights: jnp.sum(dense_output(x, *weights) * cotangent),
+            argnums=(0, 1, 2, 3),
+        )(x, *dense_weights)
+
+        token_sharding = NamedSharding(mesh, P("expert", None))
+        x = jax.device_put(x, token_sharding)
+        selected_experts = jax.device_put(selected_experts, token_sharding)
+        combine_weights = jax.device_put(combine_weights, token_sharding)
+        cotangent = jax.device_put(cotangent, token_sharding)
+        with jax.set_mesh(mesh):
+            actual = ep_output(x, *weights)
+            actual_gradients = jax.grad(
+                lambda x, *weights: jnp.sum(ep_output(x, *weights) * cotangent),
+                argnums=(0, 1, 2, 3),
+            )(x, *weights)
+
+        assert actual.sharding.spec == P("expert")
+        np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-5)
+        for actual_gradient, expected_gradient in zip(actual_gradients, expected_gradients, strict=True):
+            np.testing.assert_allclose(
+                np.asarray(actual_gradient),
+                np.asarray(expected_gradient),
+                rtol=1e-5,
+                atol=1e-5,
+            )
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 @pytest.mark.parametrize(
     "implementation",
     ["ring", "ragged_all_to_all", "fixed_all_to_all", "fixed_pooled_wave_all_to_all"],

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -1096,19 +1096,21 @@ def test_moe_mlp_ep_backends_match_dense_value_and_gradients_when_available(impl
     w_up_gate_reference = w_up_gate.astype(jnp.float32)
     w_down_reference = w_down.astype(jnp.float32)
     cotangent_reference = cotangent.astype(jnp.float32)
-    expected = _dense_moe_output(
-        x_reference,
-        selected_experts,
-        combine_weights_reference,
-        w_up_gate_reference,
-        w_down_reference,
-    )
-    expected_gradients = jax.grad(
-        lambda x, w_up_gate, w_down: jnp.sum(
-            _dense_moe_output(x, selected_experts, combine_weights_reference, w_up_gate, w_down) * cotangent_reference
-        ),
-        argnums=(0, 1, 2),
-    )(x_reference, w_up_gate_reference, w_down_reference)
+    with jax.default_matmul_precision("highest"):
+        expected = _dense_moe_output(
+            x_reference,
+            selected_experts,
+            combine_weights_reference,
+            w_up_gate_reference,
+            w_down_reference,
+        )
+        expected_gradients = jax.grad(
+            lambda x, w_up_gate, w_down: jnp.sum(
+                _dense_moe_output(x, selected_experts, combine_weights_reference, w_up_gate, w_down)
+                * cotangent_reference
+            ),
+            argnums=(0, 1, 2),
+        )(x_reference, w_up_gate_reference, w_down_reference)
 
     batch_sharding = NamedSharding(mesh, P(("data", "expert"), None))
     expert_sharding = NamedSharding(mesh, P("expert", None, None))
@@ -1132,7 +1134,7 @@ def test_moe_mlp_ep_backends_match_dense_value_and_gradients_when_available(impl
             capacity_factor=2.0,
         )
 
-    with jax.set_mesh(mesh):
+    with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
         actual, overflow = backend_output(x, w_up_gate, w_down)
         actual_gradients = jax.grad(
             lambda x, w_up_gate, w_down: jnp.sum(backend_output(x, w_up_gate, w_down)[0] * cotangent),

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -24,7 +24,8 @@ import optax
 import pytest
 from fray.cluster import ResourceConfig
 from jax._src import config as jax_config
-from jax.sharding import use_abstract_mesh
+from jax.sharding import AbstractMesh, AxisType, use_abstract_mesh
+from jax.sharding import PartitionSpec as P
 from levanter.checkpoint import CheckpointerConfig
 from levanter.data.dataset import ListAsyncDataset
 from levanter.data.text.datasets import DatasetComponent, DirectDatasetComponent, LmDataConfig
@@ -136,6 +137,34 @@ def _small_model_config(model_config_cls, *, vocab_size: int, seq_len: int):
     field_names = {field.name for field in dataclasses.fields(model_config_cls)}
     kwargs = {k: v for k, v in base_kwargs.items() if k in field_names}
     return model_config_cls(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "experiments.grug.moe.model",
+        "experiments.grug.moe_hero_ep.model",
+        "experiments.grug.moe_hero_fsdp.model",
+        "experiments.june_tpu_67b_a2b.moe.model",
+    ],
+)
+def test_grug_moe_variants_store_expert_hidden_weights_on_configured_axis(module_name: str):
+    model_module = importlib.import_module(module_name)
+    mesh = AbstractMesh(
+        axis_sizes=(1, 1, 2, 1, 2),
+        axis_names=("replica_dcn", "data", "expert", "model", "context"),
+        axis_types=(AxisType.Explicit,) * 5,
+    )
+    cfg = _small_model_config(model_module.GrugModelConfig, vocab_size=128, seq_len=4)
+    cfg = dataclasses.replace(cfg, expert_weight_hidden_axis="context")
+    key = jax.random.PRNGKey(0)
+
+    with _reset_abstract_mesh(), use_abstract_mesh(mesh):
+        mlp = eqx.filter_eval_shape(model_module.MoEMLP.init, cfg, key=key)
+
+    assert mlp.expert_mlp.w_gate.sharding.spec == P("expert", "context", "model")
+    assert mlp.expert_mlp.w_up.sharding.spec == P("expert", "context", "model")
+    assert mlp.expert_mlp.w_down.sharding.spec == P("expert", "model", "context")
 
 
 def test_grug_moe_layer_masks_preserve_thd_segment_metadata():

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -1,11 +1,12 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Contract tests for grug variants under experiments/grug/*.
+"""Contract tests shared by Grug model variants.
 
-These checks are intentionally variant-discovered: if a subdirectory contains
-`model.py` and/or `train.py`, it is expected to satisfy the corresponding
-lowering and training contracts.
+Most checks discover variants under ``experiments/grug/*``: if a subdirectory
+contains ``model.py`` and/or ``train.py``, it must satisfy the corresponding
+lowering and training contracts. Cross-family checks explicitly name compatible
+Grug variants elsewhere in ``experiments``.
 """
 
 import dataclasses

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -168,6 +168,30 @@ def test_grug_moe_variants_store_expert_hidden_weights_on_configured_axis(module
     assert mlp.expert_mlp.w_down.sharding.spec == P("expert", "model", "context")
 
 
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "experiments.grug.moe.model",
+        "experiments.grug.moe_hero_ep.model",
+        "experiments.grug.moe_hero_fsdp.model",
+        "experiments.june_tpu_67b_a2b.moe.model",
+    ],
+)
+def test_grug_moe_variants_reject_missing_expert_weight_hidden_axis(module_name: str):
+    model_module = importlib.import_module(module_name)
+    mesh = AbstractMesh(
+        axis_sizes=(1, 1, 2, 1),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(AxisType.Explicit,) * 4,
+    )
+    cfg = _small_model_config(model_module.GrugModelConfig, vocab_size=128, seq_len=4)
+    cfg = dataclasses.replace(cfg, expert_weight_hidden_axis="context")
+    key = jax.random.PRNGKey(0)
+
+    with _reset_abstract_mesh(), use_abstract_mesh(mesh), pytest.raises(ValueError):
+        eqx.filter_eval_shape(model_module.MoEMLP.init, cfg, key=key)
+
+
 def test_grug_moe_layer_masks_preserve_thd_segment_metadata():
     model_module = importlib.import_module("experiments.grug.moe.model")
     mask = GrugAttentionMask.causal().with_segment_ids(


### PR DESCRIPTION
Allow Grug MoE configs to shard the hidden dimension of routed-expert weights on an auxiliary mesh axis such as `context`. The existing `data`-axis default is unchanged.

Expert ownership and routing collectives remain on `expert`. EP execution gathers each layer's hidden shard within an expert owner. This reduces persistent expert parameter memory by the auxiliary-axis size while adding a per-layer weight gather and transient full local-expert weights.

A four-device test verifies the stored shard layout and matches routed values and gradients against a dense reference within `1e-5`.

Part of #8655
